### PR TITLE
docs(chart): rewrite README as concise operational reference

### DIFF
--- a/charts/kubernaut/README.md
+++ b/charts/kubernaut/README.md
@@ -2,29 +2,10 @@
 
 Kubernaut is an autonomous Kubernetes remediation platform that detects incidents via Prometheus AlertManager and Kubernetes events, performs AI-powered root cause analysis, and executes automated remediation workflows with human-in-the-loop approval gates.
 
-## Architecture
-
-Kubernaut consists of 9 microservices, each deployed as a Kubernetes Deployment:
-
-- **Gateway**: Ingests signals from AlertManager and Kubernetes events
-- **SignalProcessing**: Correlates and deduplicates signals
-- **AIAnalysis**: AI-powered root cause analysis via HolmesGPT
-- **RemediationOrchestrator**: Routes analysis results to appropriate workflows
-- **WorkflowExecution**: Executes remediation via K8s Jobs, Tekton, or Ansible
-- **EffectivenessMonitor**: Validates remediation effectiveness
-- **Notification**: Delivers notifications to Slack and console
-- **AuthWebhook**: Kubernetes admission webhooks for SOC2 attribution
-- **DataStorage**: Audit trail persistence with PostgreSQL and Redis
-
-Supporting infrastructure:
-
-- **Event Exporter**: Forwards Kubernetes Warning events to the Gateway
-- **PostgreSQL**: Audit trail and workflow state persistence
-- **Redis**: Dead letter queue for failed events
+> **Full documentation**: [jordigilh.github.io/kubernaut-docs](https://jordigilh.github.io/kubernaut-docs/)
 
 ## Prerequisites
 
-<!-- --8<-- [start:prerequisites] -->
 | Requirement | Version | Notes |
 |---|---|---|
 | Kubernetes | 1.32+ | selectableFields GA required |
@@ -38,204 +19,34 @@ Supporting infrastructure:
 - Tekton Pipelines (optional)
 - Ansible Automation Platform (AAP) / AWX (optional)
 
-**External monitoring** (recommended):
-
-- [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) provides:
-  - Alert-based signal ingestion (AlertManager sends alerts to Gateway)
-  - Metrics enrichment for effectiveness assessments (Prometheus queries)
-  - Alert resolution checks (AlertManager API)
-  - Metrics scraping for all Kubernaut services (all pods expose `/metrics`)
+**External monitoring** (recommended): [kube-prometheus-stack](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack) for alert-based signal ingestion and metrics enrichment.
 
 If Prometheus and AlertManager are not deployed, set `effectivenessmonitor.external.prometheusEnabled=false` and `effectivenessmonitor.external.alertManagerEnabled=false`.
-<!-- --8<-- [end:prerequisites] -->
 
-## Infrastructure Setup
-
-Complete these steps before installing the Kubernaut chart.
-
-<!-- --8<-- [start:infrastructure-setup] -->
-### Storage
-
-PostgreSQL and Redis each require a PersistentVolumeClaim for data persistence:
-
-| Component | PVC Name | Default Size | Values |
-|---|---|---|---|
-| PostgreSQL | `postgresql-data` | `10Gi` | `postgresql.storage.size`, `postgresql.storage.storageClassName` |
-| Redis | `redis-data` | `512Mi` | `redis.storage.size`, `redis.storage.storageClassName` |
-
-Both PVCs are annotated with `helm.sh/resource-policy: keep` so data survives `helm uninstall`.
-
-If the cluster has no default StorageClass, set `storageClassName` explicitly:
-
-```yaml
-postgresql:
-  storage:
-    size: 50Gi
-    storageClassName: gp3-encrypted
-redis:
-  storage:
-    storageClassName: gp3-encrypted
-```
-
-To skip in-chart databases entirely and use external instances, set `postgresql.enabled=false` and/or `redis.enabled=false` and configure `externalPostgresql` / `externalRedis` values.
-
-### Prometheus and AlertManager
-
-Kubernaut integrates with Prometheus and AlertManager at two levels:
-
-**1. EffectivenessMonitor queries** -- EM queries Prometheus for metric-based assessment enrichment and AlertManager for alert resolution checks. The expected service endpoints (configurable):
-
-| Service | Default URL | Override |
-|---|---|---|
-| Prometheus | `http://kube-prometheus-stack-prometheus.monitoring.svc:9090` | `effectivenessmonitor.external.prometheusUrl` |
-| AlertManager | `http://kube-prometheus-stack-alertmanager.monitoring.svc:9093` | `effectivenessmonitor.external.alertManagerUrl` |
-
-**2. AlertManager sends alerts to Gateway** -- AlertManager must be configured with a webhook receiver pointing to the Kubernaut Gateway. Add this to your AlertManager configuration:
-
-```yaml
-receivers:
-  - name: kubernaut
-    webhook_configs:
-      - url: "http://gateway.kubernaut-system.svc:9090/api/v1/signals/alertmanager"
-        send_resolved: true
-
-route:
-  routes:
-    - receiver: kubernaut
-      matchers:
-        - alertname!=""
-      continue: true
-```
-
-For kube-prometheus-stack, configure this via Helm values:
-
-```yaml
-# kube-prometheus-stack values
-alertmanager:
-  config:
-    receivers:
-      - name: kubernaut
-        webhook_configs:
-          - url: "http://gateway.kubernaut-system.svc:9090/api/v1/signals/alertmanager"
-            send_resolved: true
-    route:
-      routes:
-        - receiver: kubernaut
-          matchers:
-            - alertname!=""
-          continue: true
-```
-
-**3. Gateway RBAC for AlertManager** -- The Gateway requires AlertManager's ServiceAccount to be authorized as a signal source. Configure `gateway.auth.signalSources` in your Kubernaut values:
-
-```yaml
-gateway:
-  auth:
-    signalSources:
-      - name: alertmanager
-        serviceAccount: alertmanager-kube-prometheus-stack-alertmanager
-        namespace: monitoring
-```
-<!-- --8<-- [end:infrastructure-setup] -->
-
-## Pre-Installation
-
-<!-- --8<-- [start:pre-installation] -->
-### 1. Install CRDs
-
-Kubernaut uses 9 Custom Resource Definitions. Apply them before installing the chart:
+## Quick Start
 
 ```bash
+# 1. Install CRDs
 kubectl apply --server-side --force-conflicts -f charts/kubernaut/crds/
-```
 
-Helm installs CRDs on first install but does **not** upgrade them on `helm upgrade`. Always apply CRDs manually before upgrading to a new chart version.
-
-### 2. Create the Namespace
-
-```bash
+# 2. Create namespace and secrets
 kubectl create namespace kubernaut-system
-```
-
-### 3. Provision Secrets
-
-Create the required secrets in the namespace before installing. The chart references these by name.
-
-**PostgreSQL credentials** (required):
-
-```bash
 kubectl create secret generic kubernaut-pg-credentials \
   --from-literal=POSTGRES_USER=slm_user \
   --from-literal=POSTGRES_PASSWORD=<password> \
   --from-literal=POSTGRES_DB=action_history \
   -n kubernaut-system
-```
-
-| Chart Value | Secret Name | Required Keys |
-|---|---|---|
-| `postgresql.auth.existingSecret` | Your secret name | `POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_DB` |
-
-**DataStorage DB config** (required):
-
-```bash
 kubectl create secret generic kubernaut-ds-credentials \
   --from-literal=db-secrets.yaml=$'username: slm_user\npassword: <password>' \
   -n kubernaut-system
-```
-
-| Chart Value | Secret Name | Required Keys |
-|---|---|---|
-| `datastorage.dbExistingSecret` | Your secret name | `db-secrets.yaml` (YAML with `username` and `password`) |
-
-**Redis credentials** (required):
-
-```bash
 kubectl create secret generic kubernaut-redis-credentials \
   --from-literal=redis-secrets.yaml=$'password: <password>' \
   -n kubernaut-system
-```
-
-| Chart Value | Secret Name | Required Keys |
-|---|---|---|
-| `redis.existingSecret` | Your secret name | `redis-secrets.yaml` (YAML with `password`) |
-
-**LLM credentials** (required for AI analysis):
-
-```bash
 kubectl create secret generic kubernaut-llm-credentials \
   --from-literal=OPENAI_API_KEY=sk-... \
   -n kubernaut-system
-```
 
-| Chart Value | Secret Name | Required Keys |
-|---|---|---|
-| `holmesgptApi.llm.credentialsSecretName` | Your secret name (default: `llm-credentials`) | Provider-specific (e.g., `OPENAI_API_KEY`, `AZURE_API_KEY`, `GOOGLE_APPLICATION_CREDENTIALS`) |
-
-HAPI starts without this secret (`optional: true`) but all LLM calls will fail until it is created.
-
-**Notification credentials** (optional, only for Slack delivery):
-
-```bash
-kubectl create secret generic kubernaut-slack-credentials \
-  --from-literal=webhook-url=https://hooks.slack.com/services/T.../B.../... \
-  -n kubernaut-system
-```
-
-| Chart Value | Secret Name | Required Keys |
-|---|---|---|
-| `notification.credentials[].secretName` | Your secret name | `webhook-url` (or custom key via `secretKey`) |
-
-Only required when `notification.slack.enabled=true`. When Slack is disabled (default), no notification secret is needed.
-<!-- --8<-- [end:pre-installation] -->
-
-## Installation
-
-<!-- --8<-- [start:installation] -->
-### Production
-
-With namespace and secrets already provisioned:
-
-```bash
+# 3. Install
 helm install kubernaut charts/kubernaut/ \
   --namespace kubernaut-system \
   --set postgresql.auth.existingSecret=kubernaut-pg-credentials \
@@ -247,67 +58,54 @@ helm install kubernaut charts/kubernaut/ \
   --set gateway.auth.signalSources[0].name=alertmanager \
   --set gateway.auth.signalSources[0].serviceAccount=alertmanager-kube-prometheus-stack-alertmanager \
   --set gateway.auth.signalSources[0].namespace=monitoring
-```
 
-### From OCI Registry
-
-```bash
-helm install kubernaut oci://ghcr.io/jordigilh/kubernaut/charts/kubernaut \
-  --version 1.0.0 \
-  --namespace kubernaut-system \
-  -f my-values.yaml
-```
-
-### Development Quick Start
-
-For local development without external monitoring or pre-created secrets:
-
-```bash
-helm install kubernaut charts/kubernaut/ \
-  --namespace kubernaut-system --create-namespace \
-  --set postgresql.auth.password=devpass \
-  --set redis.password=redispass \
-  --set effectivenessmonitor.external.prometheusEnabled=false \
-  --set effectivenessmonitor.external.alertManagerEnabled=false
-```
-
-### Post-Install Verification
-
-```bash
-# All 13 pods should be 1/1 Running
+# 4. Verify
 kubectl get pods -n kubernaut-system
-
-# Verify LLM connectivity
-kubectl port-forward -n kubernaut-system svc/holmesgpt-api 8080:8080
-curl -s http://localhost:8080/health | jq '.'
-
-# Verify workflow catalog
-kubectl port-forward -n kubernaut-system svc/data-storage-service 8080:8080
-curl -s http://localhost:8080/api/v1/workflows | jq '.'
-```
-<!-- --8<-- [end:installation] -->
-
-## Post-Installation
-
-<!-- --8<-- [start:post-installation] -->
-### Action Types
-
-Kubernaut ships with 24 ActionType definitions in `deploy/action-types/` that define the remediation catalog (e.g., `delete-pod`, `restart-deployment`, `scale-replicas`). Load them per your operational workflow:
-
-```bash
-kubectl apply -f deploy/action-types/ -n kubernaut-system
 ```
 
-### Remediation Workflows
+See the [Installation Guide](https://jordigilh.github.io/kubernaut-docs/getting-started/installation/) for the full walkthrough including secret provisioning, AlertManager integration, and post-install steps.
 
-Create RemediationWorkflow CRs to define end-to-end remediation flows that reference ActionTypes. See the project documentation for workflow authoring guidelines.
-<!-- --8<-- [end:post-installation] -->
+## AlertManager Integration
+
+Configure AlertManager to send webhooks to the Gateway with bearer token authentication:
+
+```yaml
+receivers:
+  - name: kubernaut
+    webhook_configs:
+      - url: "http://gateway-service.kubernaut-system.svc.cluster.local:8080/api/v1/signals/prometheus"
+        send_resolved: true
+        http_config:
+          bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+route:
+  routes:
+    - receiver: kubernaut
+      matchers:
+        - alertname!=""
+      continue: true
+```
+
+Then register AlertManager's ServiceAccount as an authorized signal source:
+
+```yaml
+# kubernaut values.yaml
+gateway:
+  auth:
+    signalSources:
+      - name: alertmanager
+        serviceAccount: alertmanager-kube-prometheus-stack-alertmanager
+        namespace: monitoring
+```
+
+> **Important**: Without `http_config.bearer_token_file`, the Gateway rejects requests with `401 Unauthorized`. Without the `signalSources` entry, SAR denies access with `403 Forbidden`.
+
+See [Signal Source Authentication](https://jordigilh.github.io/kubernaut-docs/architecture/security-rbac/#signal-ingestion) for the full TokenReview + SAR flow and RBAC details.
 
 ## Configuration Reference
 
 All values are validated against `values.schema.json`. Run `helm lint` to check your overrides before installing.
 
-<!-- --8<-- [start:helm-values] -->
 ### Global Settings
 
 | Parameter | Description | Default |
@@ -357,19 +155,6 @@ All values are validated against `values.schema.json`. Run `helm lint` to check 
 | `notification.slack.enabled` | Enable Slack delivery channel | `false` |
 | `notification.slack.channel` | Default Slack channel | `#kubernaut-alerts` |
 | `notification.credentials` | Projected volume sources from K8s Secrets | `[]` |
-
-When `slack.enabled` is `true`, add credentials entries pointing to your pre-existing secrets:
-
-```yaml
-notification:
-  slack:
-    enabled: true
-    channel: "#kubernaut-alerts"
-  credentials:
-    - name: slack-webhook
-      secretName: kubernaut-slack-credentials
-      secretKey: webhook-url
-```
 
 ### Controllers (Common Parameters)
 
@@ -471,6 +256,8 @@ Set `redis.enabled=false` and configure these values to use a pre-existing Redis
 | `tls.certManager.issuerRef.kind` | Issuer kind | `ClusterIssuer` |
 | `tls.certManager.issuerRef.group` | Issuer API group | `cert-manager.io` |
 
+See [TLS and Certificate Management](https://jordigilh.github.io/kubernaut-docs/user-guide/configuration/#tls-and-certificate-management) for hook vs cert-manager mode details.
+
 ### Hooks
 
 | Parameter | Description | Default |
@@ -486,215 +273,9 @@ Set `redis.enabled=false` and configure these values to use a pre-existing Redis
 | `networkPolicies.enabled` | Create NetworkPolicy resources | `false` |
 
 When enabled, NetworkPolicies restrict ingress/egress traffic for gateway, datastorage, and authwebhook. DNS egress (port 53) is always allowed.
-<!-- --8<-- [end:helm-values] -->
-
-## Security Hardening
-
-### Pod Security (Platform-Agnostic)
-
-The chart ships **without hardcoded `runAsUser` or `fsGroup` values** so it deploys
-on both vanilla Kubernetes (Kind, EKS, GKE, AKS) and OpenShift without modification.
-
-**Tier 1 -- Kubernaut microservices** (gateway, datastorage, aianalysis, authwebhook,
-notification, remediationorchestrator, signalprocessing, workflowexecution,
-effectivenessmonitor, holmesgptApi, eventExporter) and `bitnami/kubectl` hook jobs:
-
-| Field | Default |
-|-------|---------|
-| `runAsNonRoot` | `true` |
-| `seccompProfile.type` | `RuntimeDefault` |
-| `runAsUser` / `fsGroup` | **Not set** -- image USER directive (non-root) is used on vanilla K8s; OCP SCC assigns from namespace range |
-
-All kubernaut images declare `USER nobody` (UID 65534) in their Dockerfiles,
-so `runAsNonRoot: true` alone is sufficient for admission validation.
-
-**Tier 2 -- Infrastructure** (postgresql, redis, migration hook job):
-
-| Field | Default |
-|-------|---------|
-| `seccompProfile.type` | `RuntimeDefault` |
-| `runAsNonRoot` / `runAsUser` / `fsGroup` | **Not set** |
-
-Third-party images (`postgres:16-alpine`, `redis:7-alpine`) start as root and
-switch to an application user internally via gosu/su-exec. On OpenShift the SCC
-assigns a non-root UID and the entrypoints detect this automatically.
-
-**Container-level** (`securityContext`) for all components:
-- `allowPrivilegeEscalation: false`
-- `readOnlyRootFilesystem: true` (where supported)
-- `capabilities.drop: ["ALL"]`
-
-Override per-component via `<component>.podSecurityContext` and `<component>.containerSecurityContext`.
-For example, on a namespace with PodSecurity `restricted` enforcement where
-postgres needs an explicit non-root UID:
-
-```yaml
-postgresql:
-  podSecurityContext:
-    runAsUser: 999
-    fsGroup: 999
-    runAsNonRoot: true
-```
-
-### Service Accounts
-
-PostgreSQL and Redis run with dedicated ServiceAccounts that have `automountServiceAccountToken: false`, preventing unnecessary API token mounting.
-
-## High Availability
-
-### Replicas
-
-All components default to 1 replica. Scale for production:
-
-```yaml
-gateway:
-  replicas: 3
-datastorage:
-  replicas: 2
-```
-
-### Pod Disruption Budgets
-
-Enable PDBs for critical components:
-
-```yaml
-gateway:
-  pdb:
-    enabled: true
-    minAvailable: 1
-datastorage:
-  pdb:
-    enabled: true
-    maxUnavailable: 1
-```
-
-### Affinity and Topology Spread
-
-Spread pods across nodes or zones:
-
-```yaml
-gateway:
-  affinity:
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-        - weight: 100
-          podAffinityTerm:
-            labelSelector:
-              matchExpressions:
-                - key: app
-                  operator: In
-                  values: ["gateway"]
-            topologyKey: kubernetes.io/hostname
-  topologySpreadConstraints:
-    - maxSkew: 1
-      topologyKey: topology.kubernetes.io/zone
-      whenUnsatisfiable: DoNotSchedule
-      labelSelector:
-        matchLabels:
-          app: gateway
-```
-
-### Scheduling
-
-Per-component `nodeSelector` and `tolerations` override global settings:
-
-```yaml
-gateway:
-  nodeSelector:
-    node-type: kubernaut
-  tolerations:
-    - key: "dedicated"
-      operator: "Equal"
-      value: "kubernaut"
-      effect: "NoSchedule"
-```
-
-## TLS Certificate Management
-
-<!-- --8<-- [start:tls-management] -->
-The chart supports two modes for managing TLS certificates used by the admission webhooks, controlled by `tls.mode`:
-
-### Hook Mode (`tls.mode: hook`) -- Default
-
-Self-signed certificates are generated and managed by Helm hooks. No external dependencies required. Suitable for development, testing, and CI environments.
-
-**How it works:**
-
-1. **Pre-install/pre-upgrade** (`tls-cert-gen`): Generates a self-signed CA and server certificate, stored as the `authwebhook-tls` Secret and `authwebhook-ca` ConfigMap.
-2. **Post-install/post-upgrade** (`tls-cabundle-patch`): Patches the `caBundle` field on the webhook configurations.
-3. **Post-delete** (`tls-cleanup`): Removes the `authwebhook-tls` Secret and `authwebhook-ca` ConfigMap.
-
-**Automatic renewal**: On `helm upgrade`, if the certificate expires within 30 days, it is automatically regenerated.
-
-**Recovery**: If the `authwebhook-ca` ConfigMap is accidentally deleted while `authwebhook-tls` still exists, delete the `authwebhook-tls` Secret and run `helm upgrade` to regenerate both:
-
-```bash
-kubectl delete secret authwebhook-tls -n kubernaut-system
-helm upgrade kubernaut kubernaut/kubernaut -n kubernaut-system -f my-values.yaml
-```
-
-> **Note**: `helm template` output will not show `caBundle` on webhook configurations. This is expected -- the hook injects it at runtime after the webhook resources are created.
-
-### cert-manager Mode (`tls.mode: cert-manager`) -- Production
-
-Certificates are managed by [cert-manager](https://cert-manager.io/). Recommended for production environments. cert-manager handles issuance, renewal, and `caBundle` injection automatically.
-
-**Prerequisites:**
-
-1. Install cert-manager (v1.12+):
-
-```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/latest/download/cert-manager.yaml
-kubectl wait --for=condition=Available deployment --all -n cert-manager --timeout=120s
-```
-
-2. Create an Issuer or ClusterIssuer. For development with cert-manager, a self-signed issuer works:
-
-```yaml
-apiVersion: cert-manager.io/v1
-kind: ClusterIssuer
-metadata:
-  name: selfsigned-issuer
-spec:
-  selfSigned: {}
-```
-
-For production, use your organization's CA or an ACME issuer (e.g., Let's Encrypt).
-
-3. Install the chart with cert-manager mode:
-
-```bash
-helm install kubernaut kubernaut/kubernaut \
-  --namespace kubernaut-system \
-  --set tls.mode=cert-manager \
-  --set tls.certManager.issuerRef.name=selfsigned-issuer \
-  -f my-values.yaml
-```
-
-The chart creates a `Certificate` resource (`authwebhook-cert`) that provisions the `authwebhook-tls` Secret. cert-manager's `cainjector` automatically writes the `caBundle` into the webhook configurations via the `cert-manager.io/inject-ca-from` annotation.
-
-**No TLS hook jobs** are created in this mode -- cert-manager handles the full lifecycle including renewal.
-<!-- --8<-- [end:tls-management] -->
-
-## CRD Management
-
-Kubernaut installs 9 Custom Resource Definitions in the `crds/` directory:
-
-- `ActionType`, `RemediationWorkflow`, `RemediationRequest`
-- `AIAnalysis`, `WorkflowExecution`, `EffectivenessAssessment`
-- `NotificationRequest`, `RemediationApprovalRequest`, `SignalProcessing`
-
-Helm does **not** update CRDs automatically on `helm upgrade`. To upgrade CRDs:
-
-```bash
-kubectl apply --server-side --force-conflicts -f charts/kubernaut/crds/
-```
-
-Run this **before** `helm upgrade` when CRD schemas have changed between versions.
 
 ## Upgrading
 
-<!-- --8<-- [start:upgrading] -->
 ```bash
 # 1. Update CRDs if schema changed
 kubectl apply --server-side --force-conflicts -f charts/kubernaut/crds/
@@ -704,43 +285,13 @@ helm upgrade kubernaut kubernaut/kubernaut \
   -n kubernaut-system -f my-values.yaml
 ```
 
-Key upgrade behaviors:
-
-- **TLS certificates** (`tls.mode: hook`): Renewed automatically if expiring within 30 days. In `cert-manager` mode, cert-manager handles renewal.
-- **Database migrations** run automatically via the post-upgrade hook.
-- **PVCs** are not modified (immutable for bound claims).
-- **ConfigMaps and Secrets** are updated to reflect new values.
-<!-- --8<-- [end:upgrading] -->
-
 ## Uninstalling
 
-<!-- --8<-- [start:uninstalling] -->
 ```bash
 helm uninstall kubernaut -n kubernaut-system
 ```
 
-### What is retained after uninstall
-
-| Resource | Behavior | Manual cleanup |
-|---|---|---|
-| PostgreSQL PVC (`postgresql-data`) | **Retained** (`resource-policy: keep`) | `kubectl delete pvc postgresql-data -n kubernaut-system` |
-| Redis PVC (`redis-data`) | **Retained** (`resource-policy: keep`) | `kubectl delete pvc redis-data -n kubernaut-system` |
-| CRDs (9 definitions) | **Retained** (standard Helm behavior) | `kubectl delete -f charts/kubernaut/crds/` |
-| CR instances | **Retained** until CRDs are deleted | Deleted when parent CRD is deleted |
-| TLS Secret and CA ConfigMap | **Deleted** by post-delete hook (`hook` mode) or by cert-manager (`cert-manager` mode) | -- |
-| Cluster-scoped RBAC | **Deleted** by Helm | -- |
-| `kubernaut-workflows` namespace | **Deleted** by Helm | May get stuck if it contains active Jobs; see below |
-
-If the `kubernaut-workflows` namespace gets stuck in `Terminating` state:
-
-```bash
-kubectl get all -n kubernaut-workflows
-kubectl delete jobs --all -n kubernaut-workflows
-```
-
 ### Full cleanup
-
-To remove everything including persistent data:
 
 ```bash
 helm uninstall kubernaut -n kubernaut-system
@@ -748,15 +299,19 @@ kubectl delete pvc postgresql-data redis-data -n kubernaut-system
 kubectl delete -f charts/kubernaut/crds/
 kubectl delete namespace kubernaut-system
 ```
-<!-- --8<-- [end:uninstalling] -->
 
 ## Known Limitations
 
-<!-- --8<-- [start:known-limitations] -->
-- **Single installation per cluster**: Cluster-scoped resources (ClusterRoles, ClusterRoleBindings, WebhookConfigurations) use static names. Installing multiple releases in different namespaces will cause conflicts.
-- **Init container timeouts**: The `wait-for-postgres` init containers in DataStorage and the migration Job have no timeout. If PostgreSQL is unavailable, these containers will block indefinitely.
-- **Event Exporter probes**: The event-exporter container does not expose health endpoints, so no liveness or readiness probes are configured.
-<!-- --8<-- [end:known-limitations] -->
+- **Single installation per cluster**: Cluster-scoped resources (ClusterRoles, ClusterRoleBindings, WebhookConfigurations) use static names.
+- **Init container timeouts**: `wait-for-postgres` init containers have no timeout.
+- **Event Exporter probes**: No liveness or readiness probes (no health endpoint).
+
+## Documentation
+
+- [Installation Guide](https://jordigilh.github.io/kubernaut-docs/getting-started/installation/) -- Full walkthrough
+- [Configuration Reference](https://jordigilh.github.io/kubernaut-docs/user-guide/configuration/) -- All settings and tuning
+- [Security & RBAC](https://jordigilh.github.io/kubernaut-docs/architecture/security-rbac/) -- RBAC model and signal source authentication
+- [Architecture](https://jordigilh.github.io/kubernaut-docs/architecture/overview/) -- System design
 
 ## License
 


### PR DESCRIPTION
## Summary

- Rewrites the chart README as a concise quick-start guide with Helm values, removing detailed explanations that now live in the docs site
- **Fixes #337**: Corrects the wrong AlertManager webhook URL (`gateway.kubernaut-system.svc:9090/api/v1/signals/alertmanager` → `gateway-service.kubernaut-system.svc.cluster.local:8080/api/v1/signals/prometheus`), adds missing `http_config.bearer_token_file`, and fixes the API path
- Removes all `pymdownx.snippets` markers since the docs site no longer embeds from this file
- Adds links to the docs site for: installation guide, RBAC reference, configuration reference, TLS management

The docs site (`kubernaut-docs`) is now the source of truth for all detailed documentation. The chart README focuses on what a Helm user needs to install and configure the chart.

## Test plan

- [x] `helm lint charts/kubernaut/` passes
- [ ] Verify docs site renders correctly at https://jordigilh.github.io/kubernaut-docs/
- [ ] Verify chart README renders correctly on GitHub

Closes #336


Made with [Cursor](https://cursor.com)