### PR TITLE
fix(release): increase build-image timeout to 90 minutes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
     name: "${{ matrix.service }} (${{ matrix.arch }})"
     needs: prepare
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 90
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Summary

- Increases `build-image` job timeout from 60 to 90 minutes
- The holmesgpt-api arm64 build installs ~170 Python packages under QEMU emulation, which takes ~40 minutes with no output during pip's `Installing collected packages` phase
- The 60-minute timeout was cancelling the job seconds before completion (v1.1.0-rc0 release blocked)

## Evidence

From [run 23119184556](https://github.com/jordigilh/kubernaut/actions/runs/23119184556), attempt 1:
- `21:23:19` — pip starts installing packages (silent phase)
- `22:02:37` — `Successfully installed` printed (39 min later)
- `22:02:52` — timeout cancels the job, 15 seconds too late


Made with [Cursor](https://cursor.com)