### PR TITLE
docs: add aiagent.response.failed to audit event catalog

### DIFF
--- a/docs/architecture/decisions/ADR-034-unified-audit-table-design.md
+++ b/docs/architecture/decisions/ADR-034-unified-audit-table-design.md
@@ -2,7 +2,7 @@
 
 **Date**: 2025-11-08
 **Status**: ✅ Approved
-**Version**: 1.9
+**Version**: 2.0
 **Last Updated**: 2026-03-04
 **Deciders**: Architecture Team
 **Consulted**: Gateway, Data Storage, Context API, AI Analysis, Notification, Signal Processing, Remediation Orchestrator, Authentication Webhook, HolmesGPT API teams
@@ -22,6 +22,7 @@
 | **v1.6** | 2026-01-31 | **BREAKING**: Fixed event_category collision between AIAnalysis and HolmesGPT API. Added new `aiagent` category for HolmesGPT API Service (AI Agent Provider with autonomous tool-calling). Clarified `analysis` category is exclusively for AIAnalysis controller (remediation workflow orchestration). **Rationale**: Two distinct services were incorrectly sharing `"analysis"` category, violating ADR-034 v1.2 service-level naming rule. HolmesGPT is architecturally an autonomous AI agent (per HolmesGPT documentation), not an analysis controller. New name is implementation-agnostic (supports future agent replacements). **Impact**: (1) Historical queries filtering by `event_category='analysis'` will now miss HAPI events (must use `'aiagent'`). (2) **KNOWN ISSUE**: AIAnalysis INT tests will temporarily fail - they query with `event_category='analysis'` expecting to find HAPI events (`holmesgpt.response.complete`). **Migration Path**: Fix HAPI INT tests first (Priority 1), then update AIAnalysis INT tests to query `event_category='aiagent'` for HAPI events (Priority 2). Estimated 20-30 test updates across `test/integration/aianalysis/`. | Architecture Team |
 | **v1.9** | 2026-03-04 | Added RemediationWorkflow webhook event types under `webhook` category: `remediationworkflow.admitted.create`, `remediationworkflow.admitted.delete`, `remediationworkflow.admitted.denied`. CRD-based workflow registration via AuthWebhook (ADR-058, BR-WORKFLOW-006). Cross-references DD-WEBHOOK-003. Expected volume: +10-50 events/day. | Architecture Team |
 | **v1.8** | 2026-02-05 | **BREAKING**: Renamed all AI Agent (HAPI) audit event types to follow `{service}.{domain}.{action}` convention: `llm_request` → `aiagent.llm.request`, `llm_response` → `aiagent.llm.response`, `llm_tool_call` → `aiagent.llm.tool_call`, `workflow_validation_attempt` → `aiagent.workflow.validation_attempt`, `holmesgpt.response.complete` → `aiagent.response.complete`. Also renamed `HolmesGPTResponsePayload` schema to `AIAgentResponsePayload`. **Rationale**: HAPI event types were the only ones not following the dotted naming convention, causing inconsistency and confusion. **Impact**: All consumers querying by old event_type strings must update. OpenAPI spec, Go (ogen) client, Python client, and all tests updated. | Architecture Team |
+| **v2.0** | 2026-03-04 | Added `aiagent.response.failed` event type to `aiagent` category for failure audit trail. New `AIAgentResponseFailedPayload` schema captures `error_message`, `phase`, and `duration_seconds`. SOC2 CC8.1 compliance: failed investigations now have a complete audit trail. Cross-references: #442, PR #443, DD-AUDIT-005 (hybrid provider audit). | Architecture Team |
 | **v1.7** | 2026-02-03 | Added RemediationOrchestrator approval decision audit events (`orchestration` category) to complete two-event audit trail pattern for RemediationApprovalRequest decisions. New event types: `orchestrator.approval.approved`, `orchestrator.approval.rejected`, `orchestrator.approval.expired`. **Rationale**: SOC 2 CC8.1 compliance requires complete audit trail showing both authenticated user (from AuthWebhook `webhook` category) AND business context (from RO controller `orchestration` category). Two-event pattern ensures tamper-proof WHO attribution (webhook intercepts CRD update) and complete forensic context (RO controller provides correlation_id, workflow details, confidence scores). **Integration**: Events share `correlation_id` (parent RR name) for cross-service querying. RO controller uses `Status.DecidedBy` field populated by AuthWebhook to attribute approval to authenticated operator. **Implementation**: Uses AuditRecorded condition for secure, controller-managed idempotency (not annotations). Cross-references: BR-AUDIT-006 (RAR Audit Trail), DD-WEBHOOK-003 (Webhook Audit Pattern), DD-AUDIT-006 (RAR Implementation), ADR-040 (RAR Architecture). | Architecture Team |
 
 ---
@@ -142,7 +143,7 @@ CREATE TABLE audit_events (
 | `gateway` | Gateway Service | Signal ingestion and CRD creation | `gateway.signal.received`, `gateway.crd.created`, `gateway.signal.deduplicated` |
 | `notification` | Notification Service | Alert notification delivery | `notification.message.sent`, `notification.delivery.failed`, `notification.message.acknowledged` |
 | `analysis` | AI Analysis Controller | Remediation workflow orchestration (NOT HolmesGPT API - see `aiagent`) | `aianalysis.investigation.started`, `aianalysis.recommendation.generated`, `aianalysis.analysis.completed`, `aianalysis.phase.transition` |
-| `aiagent` | AI Agent Provider (HolmesGPT API) | Autonomous AI agent with tool-calling for investigations, recovery, and effectiveness analysis | `aiagent.llm.request`, `aiagent.llm.response`, `aiagent.llm.tool_call`, `aiagent.workflow.validation_attempt`, `aiagent.response.complete` |
+| `aiagent` | AI Agent Provider (HolmesGPT API) | Autonomous AI agent with tool-calling for investigations, recovery, and effectiveness analysis | `aiagent.llm.request`, `aiagent.llm.response`, `aiagent.llm.tool_call`, `aiagent.workflow.validation_attempt`, `aiagent.response.complete`, `aiagent.response.failed` |
 | `signalprocessing` | Signal Processing Service | Signal enrichment and classification | `signalprocessing.enrichment.completed`, `signalprocessing.classification.decision`, `signalprocessing.phase.transition` |
 | `workflow` | Workflow Catalog Service | Workflow search and selection | `workflow.catalog.search_completed` (DD-WORKFLOW-014) |
 | `workflowexecution` | WorkflowExecution Controller | Tekton workflow orchestration and execution | `workflowexecution.workflow.started`, `workflowexecution.selection.completed`, `workflowexecution.execution.started`, `workflowexecution.workflow.completed`, `workflowexecution.workflow.failed` (BR-AUDIT-005 Gap #5, #6) |
@@ -754,4 +755,13 @@ This ADR establishes the following subdocument as authoritative for specific imp
 **Approved By**: Architecture Team
 **Date**: 2025-11-08
 **Implementation Target**: Post-current-branch (Day 21 for Data Storage, Day 22 for Gateway)
+
+---
+
+## Changelog
+
+| Date | Change | Reference |
+|------|--------|-----------|
+| 2025-11-08 | Initial ADR approved | Architecture Team |
+| 2026-03-04 | Added `aiagent.response.failed` to `aiagent` event category | #442, PR #443 |
 

--- a/docs/architecture/decisions/DD-AUDIT-005-hybrid-provider-data-capture.md
+++ b/docs/architecture/decisions/DD-AUDIT-005-hybrid-provider-data-capture.md
@@ -30,7 +30,8 @@ For SOC2 Type II compliance and RemediationRequest (RR) reconstruction, we need 
 
 | Service | Event Type | Purpose | Content |
 |---------|-----------|---------|---------|
-| **HolmesAPI** | `aiagent.response.complete` | Provider perspective | Full `IncidentResponse` structure |
+| **HolmesAPI** | `aiagent.response.complete` | Provider perspective (success) | Full `IncidentResponse` structure |
+| **HolmesAPI** | `aiagent.response.failed` | Provider perspective (failure) | Error message, failure phase, duration (#442, SOC2 CC8.1) |
 | **AI Analysis** | `aianalysis.analysis.completed` | Consumer perspective | `provider_response_summary` + business context |
 
 ---
@@ -62,6 +63,12 @@ For SOC2 Type II compliance and RemediationRequest (RR) reconstruction, we need 
 SELECT event_data->'response_data'
 FROM audit_events
 WHERE event_type = 'aiagent.response.complete'
+  AND correlation_id = 'req-2025-01-05-abc123';
+
+-- Provider failure details (#442: SOC2 CC8.1 - failed investigations must have audit trail)
+SELECT event_data->>'error_message', event_data->>'phase', event_data->>'duration_seconds'
+FROM audit_events
+WHERE event_type = 'aiagent.response.failed'
   AND correlation_id = 'req-2025-01-05-abc123';
 
 -- Business context (complementary)
@@ -156,6 +163,39 @@ def create_hapi_response_complete_event(
     )
 ```
 
+**File**: `holmesgpt-api/src/audit/events.py` (failure path, added in #442)
+
+```python
+def create_aiagent_response_failed_event(
+    incident_id: str,
+    remediation_id: Optional[str],
+    error_message: str,
+    phase: str,
+    duration_seconds: Optional[float] = None,
+) -> AuditEventRequest:
+    """
+    Create audit event for a failed HAPI investigation.
+
+    SOC2 CC8.1: Failed investigations MUST have an audit trail.
+    DD-AUDIT-005: Provider perspective failure audit.
+    """
+    event_data_model = HAPIResponseFailedEventData(
+        event_type="aiagent.response.failed",
+        event_id=str(uuid.uuid4()),
+        incident_id=incident_id,
+        error_message=error_message,
+        phase=phase,
+        duration_seconds=duration_seconds,
+    )
+    return _create_adr034_event(
+        event_type="aiagent.response.failed",
+        operation="response_failed",
+        outcome="failure",
+        correlation_id=remediation_id or "unknown",
+        event_data=event_data_model,
+    )
+```
+
 **File**: `holmesgpt-api/src/extensions/incident/endpoint.py`
 
 ```python
@@ -173,6 +213,8 @@ async def incident_analyze_endpoint(request: IncidentRequest) -> IncidentRespons
 
     return result
 ```
+
+The endpoint also wraps `analyze_incident` in a `try/except` to emit `aiagent.response.failed` on exception, capturing `error_message`, `phase`, and `duration_seconds` before re-raising (#442).
 
 **Effort**: ~15 minutes
 
@@ -376,6 +418,15 @@ If storage cost becomes a concern in the future, we can:
 3. **Sample audit events** for non-production environments
 
 **Note**: These are FUTURE optimizations. Current cost is negligible.
+
+---
+
+## Changelog
+
+| Date | Change | Reference |
+|------|--------|-----------|
+| 2026-01-05 | Initial document (hybrid approach for provider/consumer audit) | BR-AUDIT-005 v2.0 |
+| 2026-03-04 | Added `aiagent.response.failed` event for failure audit trail (SOC2 CC8.1) | #442, PR #443 |
 
 ---
 


### PR DESCRIPTION
## Summary

- Updates **DD-AUDIT-005** (Hybrid Provider Data Capture) to document the `aiagent.response.failed` event: event distribution table, failure factory code example, SQL query pattern, and changelog entry.
- Updates **ADR-034** (Unified Audit Table Design) to add `aiagent.response.failed` to the `aiagent` event category table and version history (v2.0).

Documentation follow-up to PR #443 which implemented the failure audit event.

## Test plan

- [x] Verify DD-AUDIT-005 event distribution table lists both success and failure events
- [x] Verify ADR-034 aiagent category includes `aiagent.response.failed`
- [x] Verify version history entries are consistent with merged implementation


Made with [Cursor](https://cursor.com)