### PR TITLE
fix(hapi): improve Phase 3b prompt to disambiguate remediation target from signal source

### DIFF
--- a/holmesgpt-api/src/extensions/incident/prompt_builder.py
+++ b/holmesgpt-api/src/extensions/incident/prompt_builder.py
@@ -269,7 +269,7 @@ Your previous workflow response had validation errors:
 {errors_list}
 {schema_section}
 **Please correct your response:**
-1. Re-check the workflow ID exists (use get_workflow with the workflow_id)
+1. Re-check the workflow ID exists in the catalog (use get_workflow with the workflow_id)
 2. Verify all required parameters are provided with correct types and values
 
 **Re-submit your JSON response with the corrected workflow selection.**


### PR DESCRIPTION
## Summary

- Clarify Phase 3b `get_resource_context` guidance so the LLM passes the **resource that needs remediation** (e.g., the Deployment using emptyDir) rather than the **resource that reported the signal** (e.g., the Node with DiskPressure). Adds concrete examples (DiskPressure, OOMKilled, NodeNotReady) and a rule of thumb.
- Remove redundant fields (`execution_engine`, `execution_bundle`, `action_type`, `version`) from the `selected_workflow` and `alternative_workflows` JSON examples in the prompt. These are catalog-managed and resolved from `workflow_id` alone — including them wastes tokens and creates hallucination surface.

## Motivation

Observed in the disk-pressure-emptydir demo scenario: the LLM was calling `get_resource_context` with the Node (signal source) instead of the `postgres-emptydir` Deployment (remediation target), causing HAPI to inject `TARGET_RESOURCE_KIND=Node` instead of `TARGET_RESOURCE_KIND=Deployment`.

## Test plan

- [x] Image built and pushed: `quay.io/kubernaut-ai/kubernaut-holmesgpt-api:v1.1.0-rc7-prompt-fix`
- [ ] Manual validation: rerun disk-pressure-emptydir scenario on OCP and verify the LLM passes the Deployment to `get_resource_context`
- [ ] CI passes (prompt-only change, no logic or schema changes)


Made with [Cursor](https://cursor.com)