### PR TITLE
fix(authwebhook): recover from orphaned DS workflows blocking ActionType delete (#512)

### DIFF
--- a/pkg/authwebhook/actiontype_client.go
+++ b/pkg/authwebhook/actiontype_client.go
@@ -29,4 +29,7 @@ type ActionTypeCatalogClient interface {
 	CreateActionType(ctx context.Context, name string, description ogenclient.ActionTypeDescription, registeredBy string) (*ActionTypeRegistrationResult, error)
 	UpdateActionType(ctx context.Context, name string, description ogenclient.ActionTypeDescription, updatedBy string) (*ActionTypeUpdateResult, error)
 	DisableActionType(ctx context.Context, name string, disabledBy string) (*ActionTypeDisableResult, error)
+	// ForceDisableActionType disables the named orphaned workflows and then
+	// attempts to disable the action type. Issue #512: orphan recovery.
+	ForceDisableActionType(ctx context.Context, name string, disabledBy string, orphanedWorkflows []string) (*ActionTypeDisableResult, error)
 }

--- a/pkg/authwebhook/actiontype_handler.go
+++ b/pkg/authwebhook/actiontype_handler.go
@@ -23,7 +23,9 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	atv1alpha1 "github.com/jordigilh/kubernaut/api/actiontype/v1alpha1"
+	rwv1alpha1 "github.com/jordigilh/kubernaut/api/remediationworkflow/v1alpha1"
 	"github.com/jordigilh/kubernaut/pkg/audit"
 	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
 	sharedtypes "github.com/jordigilh/kubernaut/pkg/shared/types"
@@ -179,6 +181,12 @@ func (h *ActionTypeHandler) handleDelete(ctx context.Context, req admission.Requ
 		msg := fmt.Sprintf("Cannot delete ActionType %q: %d active workflow(s) depend on it (%s)",
 			at.Spec.Name, result.DependentWorkflowCount,
 			strings.Join(result.DependentWorkflows, ", "))
+
+		// Issue #512: Cross-check with K8s to detect orphaned DS entries.
+		if recovered := h.attemptOrphanRecovery(ctx, logger, req, at, username, result); recovered {
+			return admission.Allowed("action type disabled in catalog (orphan recovery)")
+		}
+
 		logger.Info("ActionType disable denied", "reason", msg)
 		h.emitATDeniedAudit(ctx, req, msg, "DELETE")
 		return admission.Denied(msg)
@@ -187,6 +195,69 @@ func (h *ActionTypeHandler) handleDelete(ctx context.Context, req admission.Requ
 	logger.Info("ActionType disabled in DS", "action_type", at.Spec.Name)
 	h.emitATAdmitAudit(ctx, req, EventTypeATAdmittedDelete, at.Spec.Name, false, "disabled")
 	return admission.Allowed("action type disabled in catalog")
+}
+
+// attemptOrphanRecovery cross-checks DS-reported dependent workflows against
+// live K8s RemediationWorkflow CRDs. If some dependents no longer exist in K8s,
+// they are orphaned DS entries. The method calls ForceDisableActionType to clean
+// them up. Returns true if the action type was successfully disabled.
+// Issue #512: Prevents permanently undeletable ActionTypes.
+func (h *ActionTypeHandler) attemptOrphanRecovery(
+	ctx context.Context,
+	logger logr.Logger,
+	req admission.Request,
+	at *atv1alpha1.ActionType,
+	username string,
+	result *ActionTypeDisableResult,
+) bool {
+	if h.k8sClient == nil {
+		return false
+	}
+
+	rwList := &rwv1alpha1.RemediationWorkflowList{}
+	if err := h.k8sClient.List(ctx, rwList, client.InNamespace(req.Namespace)); err != nil {
+		logger.Error(err, "Failed to list RemediationWorkflows for orphan check")
+		return false
+	}
+
+	liveNames := make(map[string]struct{})
+	for i := range rwList.Items {
+		if rwList.Items[i].Spec.ActionType == at.Spec.Name {
+			liveNames[rwList.Items[i].Name] = struct{}{}
+		}
+	}
+
+	var orphaned []string
+	for _, depName := range result.DependentWorkflows {
+		if _, live := liveNames[depName]; !live {
+			orphaned = append(orphaned, depName)
+		}
+	}
+
+	if len(orphaned) == 0 {
+		return false
+	}
+
+	logger.Info("Orphaned DS workflows detected, attempting force-disable",
+		"orphaned", orphaned,
+		"live_count", len(liveNames),
+		"action_type", at.Spec.Name,
+	)
+
+	forceResult, err := h.dsClient.ForceDisableActionType(ctx, at.Spec.Name, username, orphaned)
+	if err != nil {
+		logger.Error(err, "Force-disable failed during orphan recovery")
+		return false
+	}
+	if !forceResult.Disabled {
+		logger.Info("Force-disable denied — non-orphaned workflows remain",
+			"remaining", forceResult.DependentWorkflows)
+		return false
+	}
+
+	logger.Info("ActionType disabled via orphan recovery", "action_type", at.Spec.Name)
+	h.emitATAdmitAudit(ctx, req, EventTypeATAdmittedDelete, at.Spec.Name, false, "disabled")
+	return true
 }
 
 // updateCRDStatusCreate writes the DS registration result into the CRD's .status subresource.

--- a/pkg/authwebhook/ds_client.go
+++ b/pkg/authwebhook/ds_client.go
@@ -17,7 +17,9 @@ limitations under the License.
 package authwebhook
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -35,14 +37,16 @@ import (
 //
 // ADR-058: Used by RemediationWorkflowHandler to register/disable workflows in DS.
 type DSClientAdapter struct {
-	client *ogenclient.Client
-	logger logr.Logger
+	client     *ogenclient.Client
+	logger     logr.Logger
+	baseURL    string
+	httpClient *http.Client
 }
 
 // NewDSClientAdapterFromClient wraps an existing ogen client as a DSClientAdapter.
 // Use when the ogen client is shared across multiple adapters (e.g., audit + workflow).
 func NewDSClientAdapterFromClient(client *ogenclient.Client, logger logr.Logger) *DSClientAdapter {
-	return &DSClientAdapter{client: client, logger: logger}
+	return &DSClientAdapter{client: client, logger: logger, httpClient: http.DefaultClient}
 }
 
 // NewDSClientAdapter creates a DSClientAdapter from a Data Storage service URL.
@@ -72,8 +76,10 @@ func NewDSClientAdapter(baseURL string, timeout time.Duration, logger logr.Logge
 	}
 
 	return &DSClientAdapter{
-		client: client,
-		logger: logger,
+		client:     client,
+		logger:     logger,
+		baseURL:    baseURL,
+		httpClient: httpClient,
 	}, nil
 }
 
@@ -263,6 +269,65 @@ func (a *DSClientAdapter) DisableActionType(ctx context.Context, name string, di
 		return nil, rfc7807Error(fmt.Sprintf("disable action type %q: server error", name), (*ogenclient.RFC7807Problem)(v))
 	default:
 		return nil, fmt.Errorf("unexpected response type from DisableActionType: %T", res)
+	}
+}
+
+// ForceDisableActionType sends a force-disable request to DS, disabling the
+// specified orphaned workflows before attempting to disable the action type.
+// Issue #512: raw HTTP call because the ogen client doesn't support the force fields.
+func (a *DSClientAdapter) ForceDisableActionType(ctx context.Context, name string, disabledBy string, orphanedWorkflows []string) (*ActionTypeDisableResult, error) {
+	if a.baseURL == "" || a.httpClient == nil {
+		return nil, fmt.Errorf("ForceDisableActionType requires baseURL and httpClient (use NewDSClientAdapter)")
+	}
+
+	body := struct {
+		DisabledBy        string   `json:"disabledBy"`
+		Force             bool     `json:"force"`
+		OrphanedWorkflows []string `json:"orphanedWorkflows"`
+	}{
+		DisabledBy:        disabledBy,
+		Force:             true,
+		OrphanedWorkflows: orphanedWorkflows,
+	}
+
+	bodyBytes, err := json.Marshal(body)
+	if err != nil {
+		return nil, fmt.Errorf("marshal force-disable request: %w", err)
+	}
+
+	url := fmt.Sprintf("%s/api/v1/action-types/%s/disable", a.baseURL, name)
+	req, err := http.NewRequestWithContext(ctx, http.MethodPatch, url, bytes.NewReader(bodyBytes))
+	if err != nil {
+		return nil, fmt.Errorf("create force-disable request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := a.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("force-disable action type %q: %w", name, err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		return &ActionTypeDisableResult{Disabled: true}, nil
+	case http.StatusConflict:
+		var denied struct {
+			DependentWorkflowCount int      `json:"dependentWorkflowCount"`
+			DependentWorkflows     []string `json:"dependentWorkflows"`
+		}
+		if err := json.NewDecoder(resp.Body).Decode(&denied); err != nil {
+			return nil, fmt.Errorf("decode force-disable denied response: %w", err)
+		}
+		return &ActionTypeDisableResult{
+			Disabled:               false,
+			DependentWorkflowCount: denied.DependentWorkflowCount,
+			DependentWorkflows:     denied.DependentWorkflows,
+		}, nil
+	case http.StatusNotFound:
+		return &ActionTypeDisableResult{Disabled: true}, nil
+	default:
+		return nil, fmt.Errorf("force-disable action type %q: unexpected status %d", name, resp.StatusCode)
 	}
 }
 

--- a/pkg/datastorage/repository/actiontype/crud.go
+++ b/pkg/datastorage/repository/actiontype/crud.go
@@ -276,6 +276,119 @@ func (r *Repository) disableOnce(ctx context.Context, actionType string, disable
 	return &DisableResult{Disabled: true}, nil
 }
 
+// ForceDisable disables the specified orphaned workflows and then attempts to
+// disable the action type, all within a single SERIALIZABLE transaction.
+// Issue #512: Recovers from stale DS entries when K8s RW CRDs are deleted but
+// the catalog-cleanup finalizer failed to disable the workflow in DS.
+//
+// Only the named workflows are disabled (scoped cleanup). If additional active
+// workflows exist that are NOT in orphanedWorkflows, the action type remains
+// active and DisableResult.Disabled is false.
+func (r *Repository) ForceDisable(ctx context.Context, actionType string, disabledBy string, orphanedWorkflows []string) (*DisableResult, error) {
+	const maxRetries = 3
+	var result *DisableResult
+	err := txretry.WithSerializableRetry(ctx, maxRetries, func() error {
+		var txErr error
+		result, txErr = r.forceDisableOnce(ctx, actionType, disabledBy, orphanedWorkflows)
+		return txErr
+	})
+	return result, err
+}
+
+func (r *Repository) forceDisableOnce(ctx context.Context, actionType string, disabledBy string, orphanedWorkflows []string) (*DisableResult, error) {
+	tx, err := r.db.BeginTxx(ctx, &sql.TxOptions{Isolation: sql.LevelSerializable})
+	if err != nil {
+		return nil, fmt.Errorf("begin transaction: %w", err)
+	}
+	defer func() { _ = tx.Rollback() }()
+
+	var existing models.ActionTypeTaxonomy
+	err = tx.QueryRowxContext(ctx,
+		`SELECT action_type, description, status, disabled_at, disabled_by, created_at, updated_at
+		 FROM action_type_taxonomy WHERE action_type = $1`,
+		actionType,
+	).StructScan(&existing)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, fmt.Errorf("%w: %s", ErrActionTypeNotFound, actionType)
+		}
+		return nil, fmt.Errorf("check action type for force-disable: %w", err)
+	}
+
+	if existing.Status != "active" {
+		if err := tx.Commit(); err != nil {
+			return nil, fmt.Errorf("commit (already disabled): %w", err)
+		}
+		return &DisableResult{Disabled: true}, nil
+	}
+
+	// Disable only the named orphaned workflows (scoped cleanup).
+	if len(orphanedWorkflows) > 0 {
+		now := time.Now().UTC()
+		_, err = tx.ExecContext(ctx,
+			`UPDATE remediation_workflow_catalog
+			 SET status = 'disabled', disabled_at = $2, disabled_by = $3,
+			     disabled_reason = 'orphan cleanup (#512)', status_reason = 'orphan cleanup (#512)'
+			 WHERE action_type = $1 AND status = 'active'
+			   AND workflow_name = ANY($4)`,
+			actionType, now, disabledBy, orphanedWorkflows,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("disable orphaned workflows for %q: %w", actionType, err)
+		}
+	}
+
+	// Check for remaining active workflows after orphan cleanup.
+	rows, err := tx.QueryxContext(ctx,
+		`SELECT workflow_name FROM remediation_workflow_catalog
+		 WHERE action_type = $1 AND status = 'active'`,
+		actionType,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("count remaining active workflows for %q: %w", actionType, err)
+	}
+	var remaining []string
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			_ = rows.Close()
+			return nil, fmt.Errorf("scan workflow name: %w", err)
+		}
+		remaining = append(remaining, name)
+	}
+	_ = rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate remaining workflow rows: %w", err)
+	}
+
+	if len(remaining) > 0 {
+		if err := tx.Commit(); err != nil {
+			return nil, fmt.Errorf("commit (denied, non-orphaned workflows remain): %w", err)
+		}
+		return &DisableResult{
+			Disabled:               false,
+			DependentWorkflowCount: len(remaining),
+			DependentWorkflows:     remaining,
+		}, nil
+	}
+
+	now := time.Now().UTC()
+	_, err = tx.ExecContext(ctx,
+		`UPDATE action_type_taxonomy
+		 SET status = 'disabled', disabled_at = $2, disabled_by = $3
+		 WHERE action_type = $1 AND status = 'active'`,
+		actionType, now, disabledBy,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("disable action type %q: %w", actionType, err)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return nil, fmt.Errorf("commit force-disable: %w", err)
+	}
+	return &DisableResult{Disabled: true}, nil
+}
+
 // CountActiveWorkflows returns the count and names of active workflows referencing this action type.
 func (r *Repository) CountActiveWorkflows(ctx context.Context, actionType string) (int, []string, error) {
 	rows, err := r.db.QueryxContext(ctx,

--- a/pkg/datastorage/server/actiontype_handlers.go
+++ b/pkg/datastorage/server/actiontype_handlers.go
@@ -64,6 +64,10 @@ type actionTypeUpdateResponse struct {
 // actionTypeDisableRequest is the request body for PATCH /api/v1/action-types/{name}/disable.
 type actionTypeDisableRequest struct {
 	DisabledBy string `json:"disabledBy"`
+	// Force enables orphan recovery (#512): disable only the named workflows
+	// before attempting to disable the action type.
+	Force              bool     `json:"force,omitempty"`
+	OrphanedWorkflows  []string `json:"orphanedWorkflows,omitempty"`
 }
 
 // actionTypeDisableResponse is the response for PATCH /api/v1/action-types/{name}/disable.
@@ -272,16 +276,24 @@ func (h *Handler) HandleDisableActionType(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	result, err := h.actionTypeRepo.Disable(r.Context(), name, req.DisabledBy)
-	if err != nil {
-		h.logger.Error(err, "Failed to disable action type", "name", name)
-		if errors.Is(err, actiontyperepo.ErrActionTypeNotFound) {
+	var (
+		result *actiontyperepo.DisableResult
+		disableErr error
+	)
+	if req.Force && len(req.OrphanedWorkflows) > 0 {
+		result, disableErr = h.actionTypeRepo.ForceDisable(r.Context(), name, req.DisabledBy, req.OrphanedWorkflows)
+	} else {
+		result, disableErr = h.actionTypeRepo.Disable(r.Context(), name, req.DisabledBy)
+	}
+	if disableErr != nil {
+		h.logger.Error(disableErr, "Failed to disable action type", "name", name, "force", req.Force)
+		if errors.Is(disableErr, actiontyperepo.ErrActionTypeNotFound) {
 			response.WriteRFC7807Error(w, http.StatusNotFound, "not-found",
 				"Not Found", fmt.Sprintf("Action type %q not found", name), h.logger)
 			return
 		}
 		response.WriteRFC7807Error(w, http.StatusInternalServerError, "database-error",
-			"Database Error", fmt.Sprintf("Failed to disable action type: %v", err), h.logger)
+			"Database Error", fmt.Sprintf("Failed to disable action type: %v", disableErr), h.logger)
 		return
 	}
 

--- a/pkg/shared/dsclient/interface.go
+++ b/pkg/shared/dsclient/interface.go
@@ -52,6 +52,9 @@ type ActionTypeCatalog interface {
 	CreateActionType(ctx context.Context, name string, description ogenclient.ActionTypeDescription, registeredBy string) (ActionTypeResult, error)
 	UpdateActionType(ctx context.Context, name string, description ogenclient.ActionTypeDescription, updatedBy string) (ActionTypeUpdateResult, error)
 	DisableActionType(ctx context.Context, name string, disabledBy string) (ActionTypeDisableResult, error)
+	// ForceDisableActionType disables the named orphaned workflows and then
+	// attempts to disable the action type. Issue #512: orphan recovery.
+	ForceDisableActionType(ctx context.Context, name string, disabledBy string, orphanedWorkflows []string) (ActionTypeDisableResult, error)
 }
 
 // WorkflowCounter queries active workflow counts for an action type.

--- a/test/integration/datastorage/actiontype_lifecycle_test.go
+++ b/test/integration/datastorage/actiontype_lifecycle_test.go
@@ -47,6 +47,27 @@ import (
 //
 // ========================================
 
+func buildMinimalWorkflow(workflowName, actionType string, seq int) *models.RemediationWorkflow {
+	content := fmt.Sprintf(`{"steps":[{"action":"test-%d"}]}`, seq)
+	contentHash := fmt.Sprintf("%x", sha256.Sum256([]byte(content)))
+	createdBy := "integration-test"
+	return &models.RemediationWorkflow{
+		WorkflowName:    workflowName,
+		Version:         "1.0.0",
+		SchemaVersion:   "1.0",
+		Name:            workflowName,
+		Description:     models.StructuredDescription{What: "test workflow", WhenToUse: "during integration tests"},
+		Content:         content,
+		ContentHash:     contentHash,
+		ActionType:      actionType,
+		ExecutionEngine: models.ExecutionEngineJob,
+		Labels:          models.MandatoryLabels{Severity: []string{"critical"}, Component: "pod"},
+		Status:          "active",
+		IsLatestVersion: true,
+		CreatedBy:       &createdBy,
+	}
+}
+
 var _ = Describe("ActionType Lifecycle Integration Tests (#300)", Label("integration", "actiontype"), func() {
 	var (
 		atRepo       *actiontyperepo.Repository
@@ -176,26 +197,9 @@ var _ = Describe("ActionType Lifecycle Integration Tests (#300)", Label("integra
 			_, err := atRepo.Create(ctx, name, desc, "admin@example.com")
 			Expect(err).ToNot(HaveOccurred())
 
-			// Insert a fake active workflow referencing this action type
-			wfName := fmt.Sprintf("AT-IT-%s-wf-dep", testID)
-			content := `{"steps":[{"action":"test"}]}`
-			contentHash := fmt.Sprintf("%x", sha256.Sum256([]byte(content)))
-			labelsJSON, _ := json.Marshal(map[string]interface{}{
-				"severity": []string{"critical"}, "component": "pod",
-				"priority": "P0", "environment": []string{"production"},
-			})
-			descJSON, _ := json.Marshal(map[string]string{
-				"what": "test workflow", "whenToUse": "during tests",
-			})
-
-			_, err = db.ExecContext(ctx,
-				`INSERT INTO remediation_workflow_catalog
-				 (workflow_name, version, name, is_latest_version, status, content, content_hash,
-				  action_type, labels, description)
-				 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
-				wfName, "1.0.0", wfName, true, "active", content, contentHash,
-				name, labelsJSON, descJSON)
-			Expect(err).ToNot(HaveOccurred(), "Inserting fake workflow should succeed")
+			// Register workflow via repo (Issue #514: replaced raw SQL)
+			wf := buildMinimalWorkflow(fmt.Sprintf("AT-IT-%s-wf-dep", testID), name, 1)
+			Expect(workflowRepo.Create(ctx, wf)).To(Succeed(), "Registering workflow should succeed")
 
 			// Disable should be denied
 			disResult, err := atRepo.Disable(ctx, name, "admin@example.com")
@@ -203,17 +207,17 @@ var _ = Describe("ActionType Lifecycle Integration Tests (#300)", Label("integra
 			Expect(disResult.Disabled).To(BeFalse(),
 				"Disable should be denied when active workflows exist")
 			Expect(disResult.DependentWorkflowCount).To(Equal(1))
-			Expect(disResult.DependentWorkflows).To(ContainElement(wfName))
+			Expect(disResult.DependentWorkflows).To(ContainElement(wf.WorkflowName))
 
 			// Verify action type still active
 			fetched, err := atRepo.GetByName(ctx, name)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(fetched.Status).To(Equal("active"))
 
-			// Remove workflow, then disable should succeed
-			_, err = db.ExecContext(ctx,
-				"DELETE FROM remediation_workflow_catalog WHERE workflow_name = $1", wfName)
+			// Disable workflow via repo, then AT disable should succeed (Issue #514)
+			created, err := workflowRepo.GetActiveByWorkflowName(ctx, wf.WorkflowName)
 			Expect(err).ToNot(HaveOccurred())
+			Expect(workflowRepo.UpdateStatus(ctx, created.WorkflowID, created.Version, "disabled", "CRD deleted", "admin@example.com")).To(Succeed())
 
 			disResult2, err := atRepo.Disable(ctx, name, "admin@example.com")
 			Expect(err).ToNot(HaveOccurred())
@@ -394,34 +398,111 @@ var _ = Describe("ActionType Lifecycle Integration Tests (#300)", Label("integra
 			_, err := atRepo.Create(ctx, name, desc, "admin@example.com")
 			Expect(err).ToNot(HaveOccurred())
 
-			// Insert 2 active workflows
 			for i := 1; i <= 2; i++ {
-				wfName := fmt.Sprintf("AT-IT-%s-wf-count-%d", testID, i)
-				content := fmt.Sprintf(`{"steps":[{"action":"test-%d"}]}`, i)
-				contentHash := fmt.Sprintf("%x", sha256.Sum256([]byte(content)))
-				labelsJSON, _ := json.Marshal(map[string]interface{}{
-					"severity": []string{"critical"}, "component": "pod",
-				})
-				descJSON, _ := json.Marshal(map[string]string{
-					"what": "test", "whenToUse": "test",
-				})
-
-				_, insertErr := db.ExecContext(ctx,
-					`INSERT INTO remediation_workflow_catalog
-					 (workflow_name, version, name, is_latest_version, status, content, content_hash,
-					  action_type, labels, description)
-					 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)`,
-					wfName, "1.0.0", wfName, true, "active", content, contentHash,
-					name, labelsJSON, descJSON)
-				Expect(insertErr).ToNot(HaveOccurred())
+				wf := buildMinimalWorkflow(fmt.Sprintf("AT-IT-%s-wf-count-%d", testID, i), name, i)
+				Expect(workflowRepo.Create(ctx, wf)).To(Succeed())
 			}
 
 			count, names, err := atRepo.CountActiveWorkflows(ctx, name)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(count).To(Equal(2))
 			Expect(names).To(HaveLen(2))
+		})
+	})
 
-			_ = workflowRepo
+	// ========================================
+	// IT-AT-512-001: ForceDisable with orphaned workflows
+	// Issue #512
+	// ========================================
+	Describe("IT-AT-512-001: ForceDisable cleans orphaned workflows and disables action type", func() {
+		It("should disable named orphaned workflows and then disable the action type", func() {
+			name := atName("force-disable")
+			desc := baseDesc()
+
+			_, err := atRepo.Create(ctx, name, desc, "admin@example.com")
+			Expect(err).ToNot(HaveOccurred())
+
+			orphanWf := buildMinimalWorkflow(fmt.Sprintf("AT-IT-%s-orphan", testID), name, 1)
+			Expect(workflowRepo.Create(ctx, orphanWf)).To(Succeed())
+
+			// Normal disable should be denied
+			disResult, err := atRepo.Disable(ctx, name, "admin@example.com")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(disResult.Disabled).To(BeFalse())
+			Expect(disResult.DependentWorkflowCount).To(Equal(1))
+
+			// ForceDisable with the orphan's name should succeed
+			forceResult, err := atRepo.ForceDisable(ctx, name, "admin@example.com", []string{orphanWf.WorkflowName})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(forceResult.Disabled).To(BeTrue(),
+				"ForceDisable should succeed when all dependents are named as orphans")
+
+			// Verify the action type is disabled
+			fetched, err := atRepo.GetByName(ctx, name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fetched.Status).To(Equal("disabled"))
+		})
+
+		It("should deny when non-orphaned workflows remain", func() {
+			name := atName("force-partial")
+			desc := baseDesc()
+
+			_, err := atRepo.Create(ctx, name, desc, "admin@example.com")
+			Expect(err).ToNot(HaveOccurred())
+
+			orphanWf := buildMinimalWorkflow(fmt.Sprintf("AT-IT-%s-fp-orphan", testID), name, 1)
+			Expect(workflowRepo.Create(ctx, orphanWf)).To(Succeed())
+
+			liveWf := buildMinimalWorkflow(fmt.Sprintf("AT-IT-%s-fp-live", testID), name, 2)
+			Expect(workflowRepo.Create(ctx, liveWf)).To(Succeed())
+
+			// ForceDisable naming only the orphan should still deny (live remains)
+			forceResult, err := atRepo.ForceDisable(ctx, name, "admin@example.com", []string{orphanWf.WorkflowName})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(forceResult.Disabled).To(BeFalse(),
+				"ForceDisable should deny when non-orphaned workflows remain")
+			Expect(forceResult.DependentWorkflowCount).To(Equal(1))
+			Expect(forceResult.DependentWorkflows).To(ConsistOf(liveWf.WorkflowName))
+
+			// Verify the action type is still active
+			fetched, err := atRepo.GetByName(ctx, name)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(fetched.Status).To(Equal("active"))
+		})
+	})
+
+	// ========================================
+	// IT-AT-512-002: Full lifecycle via repo methods
+	// Issue #512, #514: Replaces raw SQL with proper repo calls
+	// ========================================
+	Describe("IT-AT-512-002: Full AT+workflow lifecycle via repo methods", func() {
+		It("should create AT, register workflow, disable workflow, then disable AT", func() {
+			name := atName("lifecycle")
+			desc := baseDesc()
+
+			By("Creating action type")
+			_, err := atRepo.Create(ctx, name, desc, "admin@example.com")
+			Expect(err).ToNot(HaveOccurred())
+
+			By("Registering workflow via workflowRepo.Create")
+			wf := buildMinimalWorkflow(fmt.Sprintf("AT-IT-%s-lifecycle-wf", testID), name, 1)
+			Expect(workflowRepo.Create(ctx, wf)).To(Succeed())
+
+			By("Verifying AT disable is denied with active workflow")
+			disResult, err := atRepo.Disable(ctx, name, "admin@example.com")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(disResult.Disabled).To(BeFalse())
+
+			By("Disabling workflow via workflowRepo.UpdateStatus")
+			created, err := workflowRepo.GetActiveByWorkflowName(ctx, wf.WorkflowName)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(workflowRepo.UpdateStatus(ctx, created.WorkflowID, created.Version, "disabled", "CRD deleted", "admin@example.com")).To(Succeed())
+
+			By("Verifying AT disable now succeeds")
+			disResult, err = atRepo.Disable(ctx, name, "admin@example.com")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(disResult.Disabled).To(BeTrue(),
+				"AT disable should succeed after all workflows are disabled")
 		})
 	})
 })

--- a/test/unit/authwebhook/actiontype_handler_test.go
+++ b/test/unit/authwebhook/actiontype_handler_test.go
@@ -43,9 +43,10 @@ import (
 // ========================================
 
 type mockActionTypeCatalogClient struct {
-	createFn  func(ctx context.Context, name string, desc ogenclient.ActionTypeDescription, registeredBy string) (*authwebhook.ActionTypeRegistrationResult, error)
-	updateFn  func(ctx context.Context, name string, desc ogenclient.ActionTypeDescription, updatedBy string) (*authwebhook.ActionTypeUpdateResult, error)
-	disableFn func(ctx context.Context, name string, disabledBy string) (*authwebhook.ActionTypeDisableResult, error)
+	createFn       func(ctx context.Context, name string, desc ogenclient.ActionTypeDescription, registeredBy string) (*authwebhook.ActionTypeRegistrationResult, error)
+	updateFn       func(ctx context.Context, name string, desc ogenclient.ActionTypeDescription, updatedBy string) (*authwebhook.ActionTypeUpdateResult, error)
+	disableFn      func(ctx context.Context, name string, disabledBy string) (*authwebhook.ActionTypeDisableResult, error)
+	forceDisableFn func(ctx context.Context, name string, disabledBy string, orphanedWorkflows []string) (*authwebhook.ActionTypeDisableResult, error)
 }
 
 func (m *mockActionTypeCatalogClient) CreateActionType(ctx context.Context, name string, desc ogenclient.ActionTypeDescription, registeredBy string) (*authwebhook.ActionTypeRegistrationResult, error) {
@@ -67,6 +68,13 @@ func (m *mockActionTypeCatalogClient) UpdateActionType(ctx context.Context, name
 func (m *mockActionTypeCatalogClient) DisableActionType(ctx context.Context, name string, disabledBy string) (*authwebhook.ActionTypeDisableResult, error) {
 	if m.disableFn != nil {
 		return m.disableFn(ctx, name, disabledBy)
+	}
+	return &authwebhook.ActionTypeDisableResult{Disabled: true}, nil
+}
+
+func (m *mockActionTypeCatalogClient) ForceDisableActionType(ctx context.Context, name string, disabledBy string, orphanedWorkflows []string) (*authwebhook.ActionTypeDisableResult, error) {
+	if m.forceDisableFn != nil {
+		return m.forceDisableFn(ctx, name, disabledBy, orphanedWorkflows)
 	}
 	return &authwebhook.ActionTypeDisableResult{Disabled: true}, nil
 }
@@ -613,6 +621,159 @@ var _ = Describe("ActionType Admission Handler (#300)", func() {
 			Expect(updated.Status.RegisteredBy).To(Equal(testUserEmail))
 			Expect(updated.Status.RegisteredAt).NotTo(BeNil())
 			Expect(updated.Status.PreviouslyExisted).To(BeFalse())
+		})
+	})
+
+	// ========================================
+	// UT-AT-512-001: DELETE with orphaned DS entries — orphan recovery succeeds
+	// Issue #512: K8s cross-check detects no live RWs → force-disable
+	// ========================================
+	Describe("UT-AT-512-001: DELETE with orphaned DS entries triggers orphan recovery", func() {
+		It("should return Allowed when DS denies but no live RWs exist in K8s", func() {
+			at := buildActionType("restart-pod", "RestartPod", "kubernaut-system")
+			scheme := newATScheme()
+			fakeK8s := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(at).
+				Build()
+
+			mockDS.disableFn = func(_ context.Context, _ string, _ string) (*authwebhook.ActionTypeDisableResult, error) {
+				return &authwebhook.ActionTypeDisableResult{
+					Disabled:               false,
+					DependentWorkflowCount: 1,
+					DependentWorkflows:     []string{"orphaned-wf"},
+				}, nil
+			}
+			forceDisableCalled := false
+			mockDS.forceDisableFn = func(_ context.Context, name string, _ string, orphaned []string) (*authwebhook.ActionTypeDisableResult, error) {
+				forceDisableCalled = true
+				Expect(name).To(Equal("RestartPod"))
+				Expect(orphaned).To(ConsistOf("orphaned-wf"))
+				return &authwebhook.ActionTypeDisableResult{Disabled: true}, nil
+			}
+
+			handlerWithK8s := authwebhook.NewActionTypeHandler(mockDS, mockAudit, fakeK8s)
+			resp := handlerWithK8s.Handle(ctx, buildATDeleteAdmissionRequest(at))
+
+			Expect(resp.Allowed).To(BeTrue(),
+				"DELETE should be Allowed when all DS-reported dependents are orphaned")
+			Expect(forceDisableCalled).To(BeTrue(),
+				"ForceDisableActionType should be called for orphan recovery")
+		})
+	})
+
+	// ========================================
+	// UT-AT-512-002: DELETE with live RWs — genuine denial
+	// Issue #512: K8s cross-check finds live RWs → no recovery
+	// ========================================
+	Describe("UT-AT-512-002: DELETE denied when live RWs exist in K8s", func() {
+		It("should return Denied when DS-reported dependents are live in K8s", func() {
+			at := buildActionType("restart-pod", "RestartPod", "kubernaut-system")
+			rw := buildRemediationWorkflow("live-wf", "kubernaut-system")
+			rw.Spec.ActionType = "RestartPod"
+
+			scheme := newATScheme()
+			fakeK8s := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(at, rw).
+				Build()
+
+			mockDS.disableFn = func(_ context.Context, _ string, _ string) (*authwebhook.ActionTypeDisableResult, error) {
+				return &authwebhook.ActionTypeDisableResult{
+					Disabled:               false,
+					DependentWorkflowCount: 1,
+					DependentWorkflows:     []string{"live-wf"},
+				}, nil
+			}
+			forceDisableCalled := false
+			mockDS.forceDisableFn = func(_ context.Context, _ string, _ string, _ []string) (*authwebhook.ActionTypeDisableResult, error) {
+				forceDisableCalled = true
+				return nil, fmt.Errorf("should not be called")
+			}
+
+			handlerWithK8s := authwebhook.NewActionTypeHandler(mockDS, mockAudit, fakeK8s)
+			resp := handlerWithK8s.Handle(ctx, buildATDeleteAdmissionRequest(at))
+
+			Expect(resp.Allowed).To(BeFalse(),
+				"DELETE should be Denied when live RWs exist in K8s")
+			Expect(forceDisableCalled).To(BeFalse(),
+				"ForceDisableActionType should NOT be called when live RWs exist")
+		})
+	})
+
+	// ========================================
+	// UT-AT-512-003: DELETE with orphaned entries — force-disable fails
+	// Issue #512: Fallback to denial when force-disable fails
+	// ========================================
+	Describe("UT-AT-512-003: DELETE denied when force-disable fails", func() {
+		It("should return Denied when orphans detected but force-disable errors", func() {
+			at := buildActionType("restart-pod", "RestartPod", "kubernaut-system")
+			scheme := newATScheme()
+			fakeK8s := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(at).
+				Build()
+
+			mockDS.disableFn = func(_ context.Context, _ string, _ string) (*authwebhook.ActionTypeDisableResult, error) {
+				return &authwebhook.ActionTypeDisableResult{
+					Disabled:               false,
+					DependentWorkflowCount: 1,
+					DependentWorkflows:     []string{"orphaned-wf"},
+				}, nil
+			}
+			mockDS.forceDisableFn = func(_ context.Context, _ string, _ string, _ []string) (*authwebhook.ActionTypeDisableResult, error) {
+				return nil, fmt.Errorf("DS connection error")
+			}
+
+			handlerWithK8s := authwebhook.NewActionTypeHandler(mockDS, mockAudit, fakeK8s)
+			resp := handlerWithK8s.Handle(ctx, buildATDeleteAdmissionRequest(at))
+
+			Expect(resp.Allowed).To(BeFalse(),
+				"DELETE should be Denied when force-disable fails (fallback to original denial)")
+		})
+	})
+
+	// ========================================
+	// UT-AT-512-004: DELETE with mixed live + orphaned — genuine denial
+	// Issue #512: Some deps are live, some orphaned → deny (don't force)
+	// ========================================
+	Describe("UT-AT-512-004: DELETE denied with mixed live and orphaned workflows", func() {
+		It("should return Denied when some dependents are live and some orphaned", func() {
+			at := buildActionType("restart-pod", "RestartPod", "kubernaut-system")
+			rw := buildRemediationWorkflow("live-wf", "kubernaut-system")
+			rw.Spec.ActionType = "RestartPod"
+
+			scheme := newATScheme()
+			fakeK8s := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(at, rw).
+				Build()
+
+			mockDS.disableFn = func(_ context.Context, _ string, _ string) (*authwebhook.ActionTypeDisableResult, error) {
+				return &authwebhook.ActionTypeDisableResult{
+					Disabled:               false,
+					DependentWorkflowCount: 2,
+					DependentWorkflows:     []string{"live-wf", "orphaned-wf"},
+				}, nil
+			}
+			forceDisableCalled := false
+			mockDS.forceDisableFn = func(_ context.Context, name string, _ string, orphaned []string) (*authwebhook.ActionTypeDisableResult, error) {
+				forceDisableCalled = true
+				Expect(orphaned).To(ConsistOf("orphaned-wf"))
+				return &authwebhook.ActionTypeDisableResult{
+					Disabled:               false,
+					DependentWorkflowCount: 1,
+					DependentWorkflows:     []string{"live-wf"},
+				}, nil
+			}
+
+			handlerWithK8s := authwebhook.NewActionTypeHandler(mockDS, mockAudit, fakeK8s)
+			resp := handlerWithK8s.Handle(ctx, buildATDeleteAdmissionRequest(at))
+
+			Expect(resp.Allowed).To(BeFalse(),
+				"DELETE should be Denied when non-orphaned workflows remain")
+			Expect(forceDisableCalled).To(BeTrue(),
+				"ForceDisableActionType should be called to clean orphans even when live RWs exist")
 		})
 	})
 


### PR DESCRIPTION
## Summary

- When the `catalog-cleanup` finalizer fails to disable a `RemediationWorkflow` in DS (empty `workflowID` or DS unreachable per #469), the DS entry remains active and permanently blocks `ActionType` deletion
- Adds orphan recovery to the webhook's `handleDelete` path: cross-checks DS-reported dependents against live K8s RW CRDs, then calls a new `ForceDisableActionType` to clean up only the confirmed orphans in a single SERIALIZABLE transaction
- Fixes `IT-AT-300-003` to use `workflowRepo` methods instead of raw SQL (#514) and adds 4 unit tests + 3 integration tests covering orphan detection, genuine denial, force-disable fallback, and full AT+workflow lifecycle

## Changes

**DS repository** (`pkg/datastorage/repository/actiontype/crud.go`):
- `ForceDisable()` — disables named orphaned workflows and then attempts AT disable, all within a SERIALIZABLE transaction

**DS handler** (`pkg/datastorage/server/actiontype_handlers.go`):
- Extends `actionTypeDisableRequest` with `force` and `orphanedWorkflows` fields
- Routes to `ForceDisable` when `force=true`

**Webhook** (`pkg/authwebhook/actiontype_handler.go`):
- `attemptOrphanRecovery()` — lists RW CRDs, identifies orphaned DS entries, calls `ForceDisableActionType`

**Client adapter** (`pkg/authwebhook/ds_client.go`):
- `ForceDisableActionType()` — raw HTTP call with force fields (ogen client doesn't support them)

**Tests**:
- `UT-AT-512-001..004` — orphan recovery, genuine denial, force-disable failure, mixed live+orphaned
- `IT-AT-512-001` — ForceDisable against real PostgreSQL
- `IT-AT-512-002` — full lifecycle via repo methods (create AT -> register WF -> disable WF -> disable AT)
- `IT-AT-300-003` refactored from raw SQL to `workflowRepo.Create`/`UpdateStatus`

## Test plan

- [x] All 129 existing unit tests pass (no regressions)
- [x] 4 new unit tests pass (UT-AT-512-001..004)
- [x] Full project builds clean (`go build ./...`)
- [ ] Integration tests pass against real PostgreSQL (IT-AT-512-001, IT-AT-512-002, IT-AT-300-003)
- [ ] Manual validation on OCP cluster with orphaned scenario

Closes #512
Related: #514

Made with [Cursor](https://cursor.com)