### PR TITLE
fix(#571): Slack notification routing uses wrong type names

### DIFF
--- a/charts/kubernaut/templates/notification/notification.yaml
+++ b/charts/kubernaut/templates/notification/notification.yaml
@@ -103,22 +103,9 @@ data:
 {{ .Values.notification.routing.content | indent 4 }}
 {{- else if .Values.notification.slack.secretName }}
     route:
-      receiver: default-console
-      routes:
-        - match:
-            type: escalation
-          receiver: slack-alerts
-        - match:
-            type: approval_required
-          receiver: slack-alerts
-        - match:
-            type: failed
-          receiver: slack-alerts
+      receiver: slack-and-console
     receivers:
-      - name: default-console
-        consoleConfigs:
-          - enabled: true
-      - name: slack-alerts
+      - name: slack-and-console
         consoleConfigs:
           - enabled: true
         slackConfigs:


### PR DESCRIPTION
## Summary

- **#571** — Fix notification routing mismatch: chart generates routes for non-existent notification types, causing all Slack deliveries to silently fail

## Problem

When Slack is enabled via `notification.slack.secretName`, the auto-generated routing config matched against:
- `type: approval_required` — does not exist (actual: `approval`)
- `type: failed` — does not exist (actual: `manual-review` or `simple`)
- `type: escalation` — exists but not emitted by RO

Missing routes for `approval`, `completion`, `manual-review`, and `simple` meant all notifications fell through to `default-console` (console-only), never reaching Slack.

## Fix

Replace per-type routes with a single default `slack-and-console` receiver that delivers **all** notification types to both console and Slack:

```yaml
# Before (broken)
route:
  receiver: default-console
  routes:
    - match: { type: escalation }
      receiver: slack-alerts
    - match: { type: approval_required }  # wrong name
      receiver: slack-alerts
    - match: { type: failed }             # doesn't exist
      receiver: slack-alerts

# After
route:
  receiver: slack-and-console
receivers:
  - name: slack-and-console
    consoleConfigs:
      - enabled: true
    slackConfigs:
      - channel: "#kubernaut-alerts"
        credentialRef: slack-webhook
```

This is simpler, covers all current types (`approval`, `completion`, `escalation`, `manual-review`, `simple`, `status-update`), and automatically covers any future types without route maintenance.

When Slack is not configured, routing is unchanged (console-only default).

## Test plan

- [x] `helm lint` passes
- [x] `helm template` with `notification.slack.secretName` renders `slack-and-console` as default receiver
- [x] `helm template` without Slack renders `default-console` as default receiver
- [x] No smoke test assertions on routing config content
- [ ] CI: full pipeline

Made with [Cursor](https://cursor.com)