### PR TITLE
fix(readme): remove roadmap conflict markers and add shadow-agent links

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,9 @@ Kubernaut bridges that gap. It uses an LLM to investigate the actual root cause 
 
 ## Roadmap
 
-<<<<<<< HEAD
-### v1.2 — Operational Resilience and Security Hardening (latest)
-=======
 ### v1.3 — Go Unification and Enterprise Distribution (current)
 
-- **HAPI Go rewrite** — Full reimplementation of the HolmesGPT-API service in Go, eliminating the Python runtime dependency
+- **Kubernaut Agent (KA)** — Ground-up rewrite of the HolmesGPT-API (HAPI) service in Go, designed for security-first operation and agentic investigation flow with layered prompt-injection defenses; architecture enables shadow-agent audit in v1.4 ([#601](https://github.com/jordigilh/kubernaut/issues/601)) and multi-agent consensus investigation in v1.5 ([#648](https://github.com/jordigilh/kubernaut/issues/648)) ([#433](https://github.com/jordigilh/kubernaut/issues/433))
 - **Mock LLM Go rewrite** — DAG-based conversation engine with declarative YAML scenarios and fault injection for resilience testing
 - **Kubernaut Operator** — OLM-packaged operator for OperatorHub distribution on OpenShift
 - **Inter-pod TLS** — Encrypted communication between all internal services
@@ -63,7 +60,7 @@ Track progress on the [v1.3 milestone](https://github.com/jordigilh/kubernaut/mi
 ### v1.4 — Operator Experience and AI Safety (next)
 
 - **OCP Console Plugin** — Operator dashboard and RAR conversational interface integrated into the OpenShift Console
-- **Prompt injection guardrails** — Shadow agent with a dedicated scanning model to protect the agentic pipeline against prompt injection attacks
+- **Prompt injection guardrails** — Shadow agent with a dedicated scanning model to protect the agentic pipeline against prompt injection attacks ([#601](https://github.com/jordigilh/kubernaut/issues/601))
 - **Operator workflow/parameter override** — Allow operators to override workflow selection and parameters during RAR approval
 
 Track progress on the [v1.4 milestone](https://github.com/jordigilh/kubernaut/milestone/5).
@@ -79,7 +76,6 @@ Track progress on the [v1.5 milestone](https://github.com/jordigilh/kubernaut/mi
 - **Fleet-wide remediation** — MCP-based multi-cluster architecture enabling centralized signal ingestion, cross-cluster RCA investigation, and federated workflow execution across Kubernetes fleets
 
 ### v1.2 — Operational Resilience and Security Hardening ([released](https://github.com/jordigilh/kubernaut/releases/tag/v1.2.0))
->>>>>>> origin/main
 
 - **Per-workflow ServiceAccount** — Each remediation workflow runs under its own SA with least-privilege RBAC, replacing the shared default
 - **Short-lived token injection** — Ansible executor uses Kubernetes TokenRequest API with configurable TTL instead of long-lived secrets
@@ -90,24 +86,6 @@ Track progress on the [v1.5 milestone](https://github.com/jordigilh/kubernaut/mi
 
 See [CHANGELOG.md](CHANGELOG.md) for the complete list.
 
-<<<<<<< HEAD
-### v1.3 — Go Unification and Enterprise Distribution (next)
-
-- **Kubernaut Agent (KA)** — Ground-up rewrite of the HolmesGPT-API (HAPI) service in Go,
-  designed for security-first operation and agentic investigation flow with
-  layered prompt-injection defenses; architecture enables shadow-agent audit
-  (v1.4) and multi-agent consensus investigation (v1.5)
-  ([#433](https://github.com/jordigilh/kubernaut/issues/433))
-- **Mock LLM Go rewrite** — DAG-based conversation engine with declarative YAML scenarios and fault injection for resilience testing
-- **Kubernaut Operator** — OLM-packaged operator for OperatorHub distribution on OpenShift and vanilla Kubernetes
-- **Inter-pod TLS** — Encrypted communication between all internal services
-- **Audit event retention** — Automated deletion of expired audit events
-- **Label-based notification routing** — Route notifications to signal and RCA target resource owners
-
-Track progress on the [v1.3 milestone](https://github.com/jordigilh/kubernaut/milestone/4).
-
-=======
->>>>>>> origin/main
 ---
 
 ## Installation


### PR DESCRIPTION
## Summary
- remove unresolved merge conflict markers from `README.md` roadmap section currently visible on `main`
- keep roadmap ordering and milestone links from current `main`
- update the v1.3 KA bullet to include explicit shadow-agent link ([#601](https://github.com/jordigilh/kubernaut/issues/601)) and related roadmap references
- add the same [#601](https://github.com/jordigilh/kubernaut/issues/601) link in the v1.4 prompt-injection guardrails bullet

## Test plan
- [x] verify `README.md` has no `<<<<<<<`, `=======`, or `>>>>>>>` markers
- [x] verify roadmap links render correctly (`#433`, `#601`, `#648`, milestones)
- [x] verify only `README.md` changed

Made with [Cursor](https://cursor.com)