### PR TITLE
Release v1.3 (Part 2)

### DIFF
--- a/api/aianalysis/v1alpha1/aianalysis_types.go
+++ b/api/aianalysis/v1alpha1/aianalysis_types.go
@@ -564,14 +564,6 @@ type SelectedWorkflow struct {
 	// +optional
 	EngineConfig *apiextensionsv1.JSON `json:"engineConfig,omitempty"`
 
-	// ServiceAccountName is the pre-existing ServiceAccount for the execution
-	// resource (Job, PipelineRun, or Ansible TokenRequest).
-	// DD-WE-005 v2.0: Operators pre-create SAs with appropriate RBAC in the
-	// execution namespace. If absent, K8s assigns the namespace's default SA
-	// (Job/Tekton) or the Ansible executor uses the controller's in-cluster
-	// credentials (#500 fallback).
-	// +optional
-	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 // AlternativeWorkflow contains alternative workflows considered but not selected.

--- a/api/remediationworkflow/v1alpha1/remediationworkflow_types.go
+++ b/api/remediationworkflow/v1alpha1/remediationworkflow_types.go
@@ -24,7 +24,7 @@ import (
 )
 
 // RemediationWorkflowSpec defines the desired state of RemediationWorkflow.
-// Maps to the spec content of a workflow-schema.yaml file per BR-WORKFLOW-004.
+// Declared as a Kubernetes resource; registered via kubectl apply (BR-WORKFLOW-006).
 // Workflow name is derived from the CRD's metadata.name (not duplicated in spec).
 type RemediationWorkflowSpec struct {
 	// Version is the semantic version (e.g., "1.0.0")

--- a/api/workflowexecution/v1alpha1/workflowexecution_types.go
+++ b/api/workflowexecution/v1alpha1/workflowexecution_types.go
@@ -168,14 +168,6 @@ type WorkflowExecutionSpec struct {
 	// +optional
 	Rationale string `json:"rationale,omitempty"`
 
-	// ServiceAccountName is the pre-existing ServiceAccount for the execution
-	// resource (Job, PipelineRun, or Ansible TokenRequest). DD-WE-005 v2.0:
-	// Operators pre-create SAs with appropriate RBAC in the execution namespace.
-	// If absent, K8s assigns the namespace's default SA (Job/Tekton) or the
-	// Ansible executor falls back to the controller's in-cluster credentials.
-	// +optional
-	ServiceAccountName string `json:"serviceAccountName,omitempty"`
-
 	// ExecutionConfig contains minimal execution settings
 	// +optional
 	ExecutionConfig *ExecutionConfig `json:"executionConfig,omitempty"`
@@ -206,7 +198,7 @@ type WorkflowRef struct {
 }
 
 // ExecutionConfig contains minimal execution settings.
-// Issue #501: ServiceAccountName moved to Spec.ServiceAccountName (engine-agnostic).
+// Issue #650: ServiceAccountName resolved at runtime from DS into Status.
 type ExecutionConfig struct {
 	// Timeout for the entire workflow (Tekton PipelineRun timeout)
 	// Default: use global timeout from RemediationRequest or 30m
@@ -326,6 +318,14 @@ type WorkflowExecutionStatus struct {
 	// Values: "tekton", "job", "ansible".
 	// +optional
 	ExecutionEngine string `json:"executionEngine,omitempty"`
+
+	// ServiceAccountName is the pre-existing ServiceAccount resolved from the
+	// DS workflow catalog at runtime by the WE controller (Issue #650).
+	// Set once during Pending phase via ResolveWorkflowCatalogMetadata; immutable
+	// thereafter. If empty, K8s assigns the namespace's default SA (Job/Tekton)
+	// or the Ansible executor falls back to the controller's in-cluster credentials.
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 
 	// Conditions provide detailed status information
 	// +optional

--- a/charts/kubernaut/Chart.yaml
+++ b/charts/kubernaut/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: kubernaut
 description: Kubernaut - Autonomous Kubernetes Remediation Platform
 type: application
-version: 1.1.0-rc6
-appVersion: "1.1.0-rc6"
+version: 1.2.0
+appVersion: "1.2.0"
 home: https://github.com/jordigilh/kubernaut
 sources:
   - https://github.com/jordigilh/kubernaut

--- a/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
@@ -945,15 +945,6 @@ spec:
                   rationale:
                     description: Rationale explaining why this workflow was selected
                     type: string
-                  serviceAccountName:
-                    description: |-
-                      ServiceAccountName is the pre-existing ServiceAccount for the execution
-                      resource (Job, PipelineRun, or Ansible TokenRequest).
-                      DD-WE-005 v2.0: Operators pre-create SAs with appropriate RBAC in the
-                      execution namespace. If absent, K8s assigns the namespace's default SA
-                      (Job/Tekton) or the Ansible executor uses the controller's in-cluster
-                      credentials (#500 fallback).
-                    type: string
                   version:
                     description: Workflow version
                     type: string

--- a/charts/kubernaut/crds/kubernaut.ai_remediationworkflows.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_remediationworkflows.yaml
@@ -62,7 +62,7 @@ spec:
           spec:
             description: |-
               RemediationWorkflowSpec defines the desired state of RemediationWorkflow.
-              Maps to the spec content of a workflow-schema.yaml file per BR-WORKFLOW-004.
+              Declared as a Kubernetes resource; registered via kubectl apply (BR-WORKFLOW-006).
               Workflow name is derived from the CRD's metadata.name (not duplicated in spec).
             properties:
               actionType:

--- a/charts/kubernaut/crds/kubernaut.ai_workflowexecutions.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_workflowexecutions.yaml
@@ -138,14 +138,6 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              serviceAccountName:
-                description: |-
-                  ServiceAccountName is the pre-existing ServiceAccount for the execution
-                  resource (Job, PipelineRun, or Ansible TokenRequest). DD-WE-005 v2.0:
-                  Operators pre-create SAs with appropriate RBAC in the execution namespace.
-                  If absent, K8s assigns the namespace's default SA (Job/Tekton) or the
-                  Ansible executor falls back to the controller's in-cluster credentials.
-                type: string
               targetResource:
                 description: |-
                   TargetResource identifies the K8s resource being remediated
@@ -450,6 +442,14 @@ spec:
                 - Running
                 - Completed
                 - Failed
+                type: string
+              serviceAccountName:
+                description: |-
+                  ServiceAccountName is the pre-existing ServiceAccount resolved from the
+                  DS workflow catalog at runtime by the WE controller (Issue #650).
+                  Set once during Pending phase via ResolveWorkflowCatalogMetadata; immutable
+                  thereafter. If empty, K8s assigns the namespace's default SA (Job/Tekton)
+                  or the Ansible executor falls back to the controller's in-cluster credentials.
                 type: string
               startTime:
                 description: StartTime when execution started

--- a/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
@@ -945,15 +945,6 @@ spec:
                   rationale:
                     description: Rationale explaining why this workflow was selected
                     type: string
-                  serviceAccountName:
-                    description: |-
-                      ServiceAccountName is the pre-existing ServiceAccount for the execution
-                      resource (Job, PipelineRun, or Ansible TokenRequest).
-                      DD-WE-005 v2.0: Operators pre-create SAs with appropriate RBAC in the
-                      execution namespace. If absent, K8s assigns the namespace's default SA
-                      (Job/Tekton) or the Ansible executor uses the controller's in-cluster
-                      credentials (#500 fallback).
-                    type: string
                   version:
                     description: Workflow version
                     type: string

--- a/charts/kubernaut/files/crds/kubernaut.ai_remediationworkflows.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_remediationworkflows.yaml
@@ -62,7 +62,7 @@ spec:
           spec:
             description: |-
               RemediationWorkflowSpec defines the desired state of RemediationWorkflow.
-              Maps to the spec content of a workflow-schema.yaml file per BR-WORKFLOW-004.
+              Declared as a Kubernetes resource; registered via kubectl apply (BR-WORKFLOW-006).
               Workflow name is derived from the CRD's metadata.name (not duplicated in spec).
             properties:
               actionType:

--- a/charts/kubernaut/files/crds/kubernaut.ai_workflowexecutions.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_workflowexecutions.yaml
@@ -138,14 +138,6 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              serviceAccountName:
-                description: |-
-                  ServiceAccountName is the pre-existing ServiceAccount for the execution
-                  resource (Job, PipelineRun, or Ansible TokenRequest). DD-WE-005 v2.0:
-                  Operators pre-create SAs with appropriate RBAC in the execution namespace.
-                  If absent, K8s assigns the namespace's default SA (Job/Tekton) or the
-                  Ansible executor falls back to the controller's in-cluster credentials.
-                type: string
               targetResource:
                 description: |-
                   TargetResource identifies the K8s resource being remediated
@@ -450,6 +442,14 @@ spec:
                 - Running
                 - Completed
                 - Failed
+                type: string
+              serviceAccountName:
+                description: |-
+                  ServiceAccountName is the pre-existing ServiceAccount resolved from the
+                  DS workflow catalog at runtime by the WE controller (Issue #650).
+                  Set once during Pending phase via ResolveWorkflowCatalogMetadata; immutable
+                  thereafter. If empty, K8s assigns the namespace's default SA (Job/Tekton)
+                  or the Ansible executor falls back to the controller's in-cluster credentials.
                 type: string
               startTime:
                 description: StartTime when execution started

--- a/cmd/effectivenessmonitor/main.go
+++ b/cmd/effectivenessmonitor/main.go
@@ -330,10 +330,16 @@ func main() {
 	setupLog.Info("EM audit manager initialized (DD-AUDIT-003, Pattern 2)")
 
 	// ========================================
-	// DS QUERIER INITIALIZATION (DD-EM-002: pre-remediation hash lookup)
+	// DS QUERIER INITIALIZATION (DD-EM-002, DD-API-001: ogen OpenAPI client)
 	// ========================================
-	dsQuerier := emclient.NewDataStorageHTTPQuerierWithTimeout(cfg.DataStorage.URL, cfg.DataStorage.Timeout)
-	setupLog.Info("DataStorage querier initialized for pre-remediation hash lookup (DD-AUTH-005: SA auth)",
+	dsQuerier, err := emclient.NewOgenDataStorageQuerier(cfg.DataStorage.URL, cfg.DataStorage.Timeout)
+	if err != nil {
+		setupLog.Error(err, "Failed to create DataStorage querier",
+			"url", cfg.DataStorage.URL,
+			"timeout", cfg.DataStorage.Timeout)
+		os.Exit(1)
+	}
+	setupLog.Info("DataStorage querier initialized (DD-API-001: ogen, DD-AUTH-005: SA auth)",
 		"url", cfg.DataStorage.URL)
 
 	// ========================================

--- a/config/crd/bases/kubernaut.ai_aianalyses.yaml
+++ b/config/crd/bases/kubernaut.ai_aianalyses.yaml
@@ -945,15 +945,6 @@ spec:
                   rationale:
                     description: Rationale explaining why this workflow was selected
                     type: string
-                  serviceAccountName:
-                    description: |-
-                      ServiceAccountName is the pre-existing ServiceAccount for the execution
-                      resource (Job, PipelineRun, or Ansible TokenRequest).
-                      DD-WE-005 v2.0: Operators pre-create SAs with appropriate RBAC in the
-                      execution namespace. If absent, K8s assigns the namespace's default SA
-                      (Job/Tekton) or the Ansible executor uses the controller's in-cluster
-                      credentials (#500 fallback).
-                    type: string
                   version:
                     description: Workflow version
                     type: string

--- a/config/crd/bases/kubernaut.ai_remediationworkflows.yaml
+++ b/config/crd/bases/kubernaut.ai_remediationworkflows.yaml
@@ -62,7 +62,7 @@ spec:
           spec:
             description: |-
               RemediationWorkflowSpec defines the desired state of RemediationWorkflow.
-              Maps to the spec content of a workflow-schema.yaml file per BR-WORKFLOW-004.
+              Declared as a Kubernetes resource; registered via kubectl apply (BR-WORKFLOW-006).
               Workflow name is derived from the CRD's metadata.name (not duplicated in spec).
             properties:
               actionType:

--- a/config/crd/bases/kubernaut.ai_workflowexecutions.yaml
+++ b/config/crd/bases/kubernaut.ai_workflowexecutions.yaml
@@ -138,14 +138,6 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              serviceAccountName:
-                description: |-
-                  ServiceAccountName is the pre-existing ServiceAccount for the execution
-                  resource (Job, PipelineRun, or Ansible TokenRequest). DD-WE-005 v2.0:
-                  Operators pre-create SAs with appropriate RBAC in the execution namespace.
-                  If absent, K8s assigns the namespace's default SA (Job/Tekton) or the
-                  Ansible executor falls back to the controller's in-cluster credentials.
-                type: string
               targetResource:
                 description: |-
                   TargetResource identifies the K8s resource being remediated
@@ -450,6 +442,14 @@ spec:
                 - Running
                 - Completed
                 - Failed
+                type: string
+              serviceAccountName:
+                description: |-
+                  ServiceAccountName is the pre-existing ServiceAccount resolved from the
+                  DS workflow catalog at runtime by the WE controller (Issue #650).
+                  Set once during Pending phase via ResolveWorkflowCatalogMetadata; immutable
+                  thereafter. If empty, K8s assigns the namespace's default SA (Job/Tekton)
+                  or the Ansible executor falls back to the controller's in-cluster credentials.
                 type: string
               startTime:
                 description: StartTime when execution started

--- a/docker/kubernautagent.Dockerfile
+++ b/docker/kubernautagent.Dockerfile
@@ -19,7 +19,7 @@ ARG TARGETARCH
 ARG GOOS=linux
 ARG GOARCH=${TARGETARCH:-amd64}
 ARG GOFLAGS=""
-ARG APP_VERSION=v1.3.0-dev
+ARG APP_VERSION=v1.2.0
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown
 
@@ -64,7 +64,7 @@ USER 65534
 EXPOSE 8080
 ENTRYPOINT ["/kubernautagent"]
 
-ARG APP_VERSION=v1.3.0-dev
+ARG APP_VERSION=v1.2.0
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown
 LABEL org.opencontainers.image.source="https://github.com/jordigilh/kubernaut" \
@@ -100,7 +100,7 @@ USER 1001
 EXPOSE 8080
 ENTRYPOINT ["/usr/local/bin/kubernautagent"]
 
-ARG APP_VERSION=v1.3.0-dev
+ARG APP_VERSION=v1.2.0
 ARG GIT_COMMIT=unknown
 ARG BUILD_DATE=unknown
 LABEL org.opencontainers.image.source="https://github.com/jordigilh/kubernaut" \

--- a/docs/generated/crds.md
+++ b/docs/generated/crds.md
@@ -667,7 +667,7 @@ _Appears in:_
 
 
 ExecutionConfig contains minimal execution settings.
- ServiceAccountName moved to Spec.ServiceAccountName (engine-agnostic).
+ ServiceAccountName resolved at runtime from DS into Status.
 
 _Appears in:_
 - [WorkflowExecutionSpec](#workflowexecutionspec)
@@ -1634,7 +1634,6 @@ _Appears in:_
 | `rationale`| _string_| Rationale explaining why this workflow was selected|
 | `executionEngine`| _string_| ExecutionEngine specifies the backend engine for workflow execution.<br />Populated from HolmesGPT-API workflow recommendation.<br />When empty, defaults to "tekton" for backwards compatibility.|
 | `engineConfig`| _[JSON](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#json-v1-apiextensions-k8s-io)_| EngineConfig holds engine-specific configuration .<br />For ansible: \{"playbookPath": "...", "jobTemplateName": "...", "inventoryName": "..."\}.|
-| `serviceAccountName`| _string_| ServiceAccountName is the pre-existing ServiceAccount for the execution<br />resource (Job, PipelineRun, or Ansible TokenRequest).<br /> Operators pre-create SAs with appropriate RBAC in the<br />execution namespace. If absent, K8s assigns the namespace's default SA<br />(Job/Tekton) or the Ansible executor uses the controller's in-cluster<br />credentials (#500 fallback).|
 
 
 ### SignalContextInput
@@ -1937,7 +1936,6 @@ _Appears in:_
 | `parameters`| _object (keys:string, values:string)_| Parameters from LLM selection <br />Keys are UPPER_SNAKE_CASE for Tekton PipelineRun params|
 | `confidence`| _float_| Confidence score from LLM (for audit trail)|
 | `rationale`| _string_| Rationale from LLM (for audit trail)|
-| `serviceAccountName`| _string_| ServiceAccountName is the pre-existing ServiceAccount for the execution<br />resource (Job, PipelineRun, or Ansible TokenRequest). <br />Operators pre-create SAs with appropriate RBAC in the execution namespace.<br />If absent, K8s assigns the namespace's default SA (Job/Tekton) or the<br />Ansible executor falls back to the controller's in-cluster credentials.|
 | `executionConfig`| _[ExecutionConfig](#executionconfig)_| ExecutionConfig contains minimal execution settings|
 
 
@@ -1963,6 +1961,7 @@ _Appears in:_
 | `blockClearance`| _[BlockClearanceDetails](#blockclearancedetails)_| BlockClearance tracks the clearing of PreviousExecutionFailed blocks<br />When set, allows new executions despite previous execution failure<br />Preserves audit trail of WHO cleared the block and WHY|
 | `ephemeralCredentialIDs`| _integer array_| EphemeralCredentialIDs stores AWX credential IDs created by the ansible<br />executor for cleanup after execution . Written via the status<br />subresource to avoid violating spec immutability .|
 | `executionEngine`| _string_| ExecutionEngine is the backend engine resolved from the DS workflow catalog<br />at runtime by the WE controller. Set once during Pending phase via<br />WorkflowQuerier.GetWorkflowExecutionEngine; immutable thereafter.<br />Values: "tekton", "job", "ansible".|
+| `serviceAccountName`| _string_| ServiceAccountName is the pre-existing ServiceAccount resolved from the<br />DS workflow catalog at runtime by the WE controller .<br />Set once during Pending phase via ResolveWorkflowCatalogMetadata; immutable<br />thereafter. If empty, K8s assigns the namespace's default SA (Job/Tekton)<br />or the Ansible executor falls back to the controller's in-cluster credentials.|
 | `conditions`| _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#condition-v1-meta) array_| Conditions provide detailed status information|
 
 

--- a/docs/generated/crds.md
+++ b/docs/generated/crds.md
@@ -1494,7 +1494,7 @@ _Appears in:_
 
 
 RemediationWorkflowSpec defines the desired state of RemediationWorkflow.
-Maps to the spec content of a workflow-schema.yaml file per .
+Declared as a Kubernetes resource; registered via kubectl apply .
 Workflow name is derived from the CRD's metadata.name (not duplicated in spec).
 
 _Appears in:_

--- a/docs/requirements/BR-WORKFLOW-006-remediation-workflow-crd.md
+++ b/docs/requirements/BR-WORKFLOW-006-remediation-workflow-crd.md
@@ -66,7 +66,7 @@ Workflow registration in Kubernaut must be Kubernetes-native to support GitOps w
 
 ### Spec Fields
 
-The `.spec` maps to the workflow-schema.yaml content per BR-WORKFLOW-004, structured as a Kubernetes resource. The workflow name is provided by `metadata.name`; the DS-assigned UUID is in `status.workflowId`.
+The `.spec` is the declarative specification of the `RemediationWorkflow` resource. Field names and types originate from BR-WORKFLOW-004. The workflow name is provided by `metadata.name`; the DS-assigned UUID is in `status.workflowId`.
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|

--- a/docs/tests/189/TEST_PLAN.md
+++ b/docs/tests/189/TEST_PLAN.md
@@ -1,0 +1,628 @@
+# Test Plan: Remediation Orchestrator — Distributed Locking for WorkflowExecution Creation
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+>
+> Based on IEEE 829-2008 (Standard for Software and System Test Documentation) with
+> Kubernaut-specific extensions for TDD phase tracking, business requirement traceability,
+> and per-tier coverage policy.
+
+**Test Plan Identifier**: TP-189-v1
+**Feature**: Lease-based distributed lock keyed by `hash(targetResource)` before WorkflowExecution creation to prevent duplicate WFEs when multiple RemediationRequests (different fingerprints) race for the same target
+**Version**: 1.0
+**Created**: 2026-04-09
+**Author**: Kubernaut Engineering
+**Status**: Draft
+**Branch**: `development/v1.3`
+
+---
+
+## 1. Introduction
+
+> **IEEE 829 §3** — Purpose, objectives, and measurable success criteria for the test effort.
+
+### 1.1 Purpose
+
+Issue #189 addresses a race: multiple alerts for the same target produce multiple RemediationRequests with different fingerprints; both can pass `CheckResourceBusy` and `CheckDuplicateInProgress` (fingerprint-scoped), leading to two `WorkflowExecution` objects and a failure at execution level for the second. This plan defines tests that prove a **coordination.k8s.io Lease** lock, acquired before WE creation and released on failure or terminal WE phase, serializes WE creation per target and preserves operator-visible correctness without weakening existing deduplication semantics.
+
+### 1.2 Objectives
+
+1. **Lock acquisition semantics**: `DistributedLockManager` (shared package) acquires a Lease keyed by deterministic `hash(targetResource)` and returns clear errors on contention.
+2. **RO integration**: Remediation Orchestrator reconciler acquires the lock immediately before `weCreator.Create`, releases on creation failure, and releases (or relies on TTL + re-acquire rules) consistent with ADR-052 patterns.
+3. **Concurrency safety**: Parallel reconciles for two RRs targeting the same resource result in **exactly one** WFE (P0 integration outcome).
+4. **Recovery**: After lock holder failure or terminal WE phase, a subsequent RR can acquire the lock and proceed.
+5. **Observability & RBAC**: RO has `create`/`get`/`update`/`delete` on Leases; lock helper remains unit-testable in isolation from the full reconciler.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/remediationorchestrator/... ./test/unit/shared/...` (as lock package lands) |
+| Integration test pass rate | 100% | `go test ./test/integration/remediationorchestrator/...` |
+| Unit-testable code coverage | >=80% | `go test -coverprofile` on lock helper and key derivation |
+| Integration-testable code coverage | >=80% | `go test -coverprofile` on RO reconciler paths using envtest + real Lease API |
+| Backward compatibility | 0 unintended regressions | Existing RO/WE tests pass; new tests document any intentional assertion changes |
+
+---
+
+## 2. References
+
+> **IEEE 829 §2** — Documents that govern or inform this test plan.
+
+### 2.1 Authority (governing documents)
+
+- BR-ORCH-025: WorkflowExecution creation orchestration (scope per BR text)
+- BR-ORCH-031: WorkflowExecution creation orchestration (scope per BR text)
+- ADR-052: Distributed locking pattern (Gateway); reuse for RO via shared `DistributedLockManager`
+- BR-GATEWAY-190: Reference implementation context for `pkg/gateway/processing/distributed_lock.go`
+- Issue #189: RO distributed locking for WE creation
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../../.cursor/rules/03-testing-strategy.mdc)
+- [Test Case Specification Template](../../testing/TEST_CASE_SPECIFICATION_TEMPLATE.md)
+- [Integration/E2E No-Mocks Policy](../../testing/INTEGRATION_E2E_NO_MOCKS_POLICY.md)
+- [Testing Guidelines](../../development/business-requirements/TESTING_GUIDELINES.md)
+
+---
+
+## 3. Risks & Mitigations
+
+> **IEEE 829 §5** — Software risk issues that drive test design.
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | Lock never released (panic path) | Stuck target until Lease TTL | Medium | IT-RO-189-002, UT-RO-189-005 | `defer` release where safe; TTL + explicit release on WE creation failure; IT verifies recovery |
+| R2 | Wrong key derivation (collision or instability) | Incorrect serialization or cross-target blocking | High | UT-RO-189-004 | Deterministic hash tests; documented canonical serialization of `targetResource` |
+| R3 | RBAC / apiReader mis-wiring | Reconciler cannot create Leases; silent skip or error storm | Medium | IT-RO-189-001 | Integration tests with real apiserver; manifest RBAC verification |
+| R4 | Deadlock with existing `CheckResourceBusy` | Ordering conflicts or double-blocking | Low | IT-RO-189-001 | Maintain ordering: existing checks then lock then Create; IT exercises parallel RRs |
+| R5 | Metrics / lease name drift from Gateway | Operational inconsistency | Low | REFACTOR phase | Share `generateLeaseName` with prefix parameter; document ADR-052 reuse |
+
+### 3.1 Risk-to-Test Traceability
+
+- **R1**: IT-RO-189-002 (release on WE creation failure), UT-RO-189-005 (expired lease re-acquire)
+- **R2**: UT-RO-189-004 (deterministic, collision-free keys)
+- **R3**: IT-RO-189-001 (envtest Lease API + RO RBAC effective in test cluster)
+- **R4**: IT-RO-189-001 (parallel reconciles, single WFE)
+
+---
+
+## 4. Scope
+
+> **IEEE 829 §6/§7** — Features to be tested and features not to be tested.
+
+### 4.1 Features to be Tested
+
+- **Shared lock manager** (`pkg/shared/...` after extraction from `pkg/gateway/processing/distributed_lock.go`): acquire, release, lease naming, TTL behavior
+- **RO reconciler** (`internal/controller/remediationorchestrator/reconciler.go`): lock acquire before `weCreator.Create`, defer/release on failure, interaction with terminal WE phase
+- **Routing / blocking context** (`routing/blocking.go`): Existing `CheckDuplicateInProgress`, `CheckResourceBusy` remain; tests prove lock closes the fingerprint race gap
+- **RBAC**: `coordination.k8s.io` Leases — create, get, update, delete for RO ServiceAccount
+
+### 4.2 Features Not to be Tested
+
+- **Gateway-specific lock consumers**: Covered by existing Gateway tests; this plan focuses on RO + shared extraction
+- **Full cluster E2E / multi-replica HA soak**: Deferred; envtest + integration tier validates Kubernetes Lease semantics sufficiently for this change
+- **Altering fingerprint dedup semantics**: Out of scope unless a BR explicitly requires merging duplicate fingerprints
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Extract `DistributedLockManager` to `pkg/shared/` | Single implementation for ADR-052; RO and Gateway both depend on tested abstraction |
+| Key = `hash(targetResource)` | Aligns lock granularity with “one WE pipeline per target” regardless of RR fingerprint |
+| Lease API over ConfigMap locks | Native TTL, coordination primitives, matches existing Gateway pattern |
+| envtest for P0 integration | Real Lease API without full Kind E2E cost |
+
+---
+
+## 5. Approach
+
+> **IEEE 829 §8/§9/§10** — Test strategy, pass/fail criteria, and suspension/resumption.
+
+### 5.1 Coverage Policy
+
+**Authority**: `03-testing-strategy.mdc` — Per-Tier Testable Code Coverage.
+
+- **Unit**: >=80% of **unit-testable** code (lock helper, key derivation, pure lease name logic)
+- **Integration**: >=80% of **integration-testable** code (RO reconciler + apiserver Leases, parallel reconcile)
+- **E2E**: Deferred — integration with envtest provides real coordination API; add E2E only if production incident warrants multi-controller soak
+
+### 5.2 Two-Tier Minimum
+
+- **Unit tests**: Lock behavior, key stability, TTL edge cases
+- **Integration tests**: Parallel reconciles, RBAC, release on failure and terminal phase
+
+### 5.3 Business Outcome Quality Bar
+
+Tests prove the operator gets **at most one in-flight WE creation sequence per target** under concurrent RR admission, and that transient failures **do not permanently block** the target beyond defined TTL/release rules.
+
+### 5.4 Pass/Fail Criteria
+
+**PASS** — all of the following must be true:
+
+1. All P0 tests pass (0 failures), including **IT-RO-189-001**
+2. Per-tier code coverage meets >=80% threshold on lock helper and RO integration surfaces
+3. No regressions in existing remediation orchestrator / workflow execution suites tied to this flow
+4. RBAC manifests allow RO Lease verbs required by integration tests
+
+**FAIL** — any of the following:
+
+1. Any P0 test fails (especially duplicate WFE under parallel reconcile)
+2. Per-tier coverage falls below 80% on the scoped packages
+3. Lock leaks prevent a subsequent RR from proceeding after documented failure/terminal conditions
+
+### 5.5 Suspension & Resumption Criteria
+
+**Suspend testing when**:
+
+- envtest / control-plane binaries unavailable or flaky
+- Shared lock package not extracted (compilation blocks RED/GREEN)
+- RBAC for Leases not merged, blocking realistic integration
+
+**Resume testing when**:
+
+- `go build ./...` succeeds with shared lock + RO wiring
+- RBAC updated and loaded in test harness
+- envtest environment healthy
+
+---
+
+## 6. Test Items
+
+> **IEEE 829 §4** — Software items to be tested, with version identification.
+
+### 6.1 Unit-Testable Code (pure logic, no I/O)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|----------------|
+| `pkg/shared/.../distributed_lock.go` (TBD exact path) | `AcquireLock`, `ReleaseLock`, `generateLeaseName` (shared w/ prefix), key derivation helpers | TBD post-extraction |
+| Key derivation helper(s) | `HashTargetResource` / equivalent | TBD |
+
+### 6.2 Integration-Testable Code (I/O, wiring, cross-component)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|----------------|
+| `internal/controller/remediationorchestrator/reconciler.go` | Reconcile path around `weCreator.Create`, lock acquire/release | ~3627 (file) |
+| `pkg/remediationorchestrator/creator/workflowexecution.go` | WE creation (called under lock) | TBD |
+| RO RBAC manifests | Lease permissions | — |
+
+### 6.3 Version Identification
+
+| Item | Version/Commit | Notes |
+|------|----------------|-------|
+| Code under test | `development/v1.3` HEAD | Feature branch for #189 |
+| Reference pattern | `pkg/gateway/processing/distributed_lock.go` | Pre-extraction source |
+| Kubernetes envtest | envtest-bundled API | coordination.k8s.io/v1 Lease |
+
+---
+
+## 7. BR Coverage Matrix
+
+> Kubernaut-specific. Maps every business requirement to test scenarios across tiers.
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-ORCH-025 | WE creation orchestration | P0 | Unit | UT-RO-189-001, UT-RO-189-002, UT-RO-189-003 | Pending |
+| BR-ORCH-025 | WE creation orchestration | P0 | Integration | IT-RO-189-001, IT-RO-189-002 | Pending |
+| BR-ORCH-031 | WE creation orchestration | P0 | Unit | UT-RO-189-004, UT-RO-189-005 | Pending |
+| BR-ORCH-031 | WE creation orchestration | P1 | Integration | IT-RO-189-003 | Pending |
+| ADR-052 | Distributed lock pattern reuse | P1 | Unit | UT-RO-189-001–003 | Pending |
+| ADR-052 | Distributed lock pattern reuse | P1 | Integration | IT-RO-189-001–003 | Pending |
+
+### Status Legend
+
+- **Pending**: Specification complete, implementation not started
+- **RED**: Failing test written (TDD RED phase)
+- **GREEN**: Minimal implementation passes (TDD GREEN phase)
+- **REFACTOR**: Code cleaned up (TDD REFACTOR phase)
+- **Pass**: Implemented and passing
+
+---
+
+## 8. Test Scenarios
+
+> **IEEE 829 Test Design Specification** — How test cases are organized and grouped.
+
+### Test ID Naming Convention
+
+Format: `{TIER}-{SERVICE}-{ISSUE}-{SEQUENCE}` — Issue **189** used as traceability anchor (aligned with `docs/tests/189/`).
+
+### Tier 1: Unit Tests
+
+**Testable code scope**: Shared `DistributedLockManager`, lease name generation, target hash/key derivation — **>=80%** coverage on extracted unit-testable surface.
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-RO-189-001` | Lock acquired when Lease available; reconciler path can proceed | Pending |
+| `UT-RO-189-002` | Contention surfaces as explicit error; caller can requeue | Pending |
+| `UT-RO-189-003` | Held lock released; Lease deleted or released per implementation contract | Pending |
+| `UT-RO-189-004` | Same target → same key; distinct targets → distinct keys (no accidental sharing) | Pending |
+| `UT-RO-189-005` | Expired / stale Lease allows re-acquisition per Kubernetes semantics | Pending |
+
+### Tier 2: Integration Tests
+
+**Testable code scope**: RO reconciler with fake K8s client **where permitted**, but Lease tests use **envtest** real API per no-mocks policy for integration — **>=80%** on integration-testable RO paths touching locks.
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `IT-RO-189-001` | Two RRs same target, parallel reconciles → **only one** WFE created | Pending |
+| `IT-RO-189-002` | WE creation fails → lock released → next reconcile can acquire | Pending |
+| `IT-RO-189-003` | WE reaches terminal phase (Completed/Failed) → lock semantics allow future work (release or TTL as designed) | Pending |
+
+### Tier 3: E2E Tests (if applicable)
+
+**Testable code scope**: Not required for #189 initial delivery.
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| — | — | N/A |
+
+### Tier Skip Rationale (if any tier is omitted)
+
+- **E2E**: Deferred; **IT-RO-189-001** provides P0 confidence with real Lease API via envtest. Revisit if multi-replica controller production issues arise.
+
+---
+
+## 9. Test Cases
+
+> **IEEE 829 Test Case Specification** — Detailed specification for each test case.
+
+### UT-RO-189-001: AcquireLock happy path
+
+**BR**: BR-ORCH-025
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/shared/distributed_lock_test.go` (or `test/unit/remediationorchestrator/...` if colocated — **prefer package under test**)
+
+**Preconditions**:
+
+- Fake K8s client or envtest setup as required by package test conventions
+- No pre-existing Lease for the derived lock name
+
+**Test Steps**:
+
+1. **Given**: Clean Lease namespace/name for target hash
+2. **When**: `AcquireLock` invoked with valid context and TTL parameters
+3. **Then**: Returns nil error; Lease object exists with expected holder identity / spec fields per ADR-052
+
+**Expected Results**:
+
+1. No error returned
+2. Subsequent `Get` on coordination Lease succeeds
+
+**Acceptance Criteria**:
+
+- **Behavior**: Lock is acquired exactly once for the empty case
+- **Correctness**: Lease metadata matches naming prefix + deterministic key
+- **Accuracy**: No mutation of unrelated Leases
+
+**Dependencies**: UT-RO-189-004 (key derivation stable)
+
+---
+
+### UT-RO-189-002: AcquireLock contention
+
+**BR**: BR-ORCH-025
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/shared/distributed_lock_test.go`
+
+**Preconditions**:
+
+- Lease already held (simulate second holder or non-expired lease record)
+
+**Test Steps**:
+
+1. **Given**: Active Lease for same key held by another identity
+2. **When**: Second `AcquireLock` call runs
+3. **Then**: Returns **contention** error (typed or documented sentinel), no destructive override
+
+**Expected Results**:
+
+1. Error is non-nil and classifiable by caller for requeue/backoff
+2. Existing Lease unchanged
+
+**Acceptance Criteria**:
+
+- **Behavior**: Second acquirer does not create duplicate WFE entry path
+- **Correctness**: Error contract documented in package doc comment
+- **Accuracy**: Holder field remains the first acquirer until released or expired
+
+**Dependencies**: UT-RO-189-001
+
+---
+
+### UT-RO-189-003: ReleaseLock success
+
+**BR**: BR-ORCH-025
+**Priority**: P1
+**Type**: Unit
+**File**: `test/unit/shared/distributed_lock_test.go`
+
+**Preconditions**:
+
+- Lock held by test identity from UT-RO-189-001 setup
+
+**Test Steps**:
+
+1. **Given**: Held lock from happy path
+2. **When**: `ReleaseLock` (or defer hook) executes
+3. **Then**: Lease deleted or transitioned per implementation; `AcquireLock` can succeed again without manual cleanup beyond documented wait/TTL
+
+**Expected Results**:
+
+1. Release completes without error
+2. Follow-up acquire for same target succeeds
+
+**Acceptance Criteria**:
+
+- **Behavior**: Explicit release frees the slot for the same target
+- **Correctness**: No orphaned duplicate lease names for one target
+- **Accuracy**: apiserver state matches expected object count
+
+**Dependencies**: UT-RO-189-001
+
+---
+
+### UT-RO-189-004: Lock key derivation
+
+**BR**: BR-ORCH-031
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/shared/distributed_lock_test.go`
+
+**Preconditions**:
+
+- Canonical serialization of `targetResource` defined in implementation
+
+**Test Steps**:
+
+1. **Given**: Fixed target A and target B (distinct)
+2. **When**: Keys computed for A, A (repeat), and B
+3. **Then**: `key(A)==key(A)`; `key(A)!=key(B)`; stable across process invocations (hash algorithm fixed)
+
+**Expected Results**:
+
+1. Byte-stable or string-stable key equality
+2. Collision probability bounded by hash choice (document SHA or FNV, etc.)
+
+**Acceptance Criteria**:
+
+- **Behavior**: Same logical target always maps to same lock
+- **Correctness**: Different targets do not share a lock in test matrix
+- **Accuracy**: Serialization includes all fields that define “same target” per RO
+
+**Dependencies**: None
+
+---
+
+### UT-RO-189-005: Lock timeout / TTL — re-acquire after expiry
+
+**BR**: BR-ORCH-031
+**Priority**: P1
+**Type**: Unit
+**File**: `test/unit/shared/distributed_lock_test.go`
+
+**Preconditions**:
+
+- Ability to simulate clock or use short TTL with envtest time advancement (choose one in implementation plan)
+
+**Test Steps**:
+
+1. **Given**: Lease with TTL elapsed or `RenewTime` in the past per API rules
+2. **When**: `AcquireLock` runs for same target
+3. **Then**: New holder can acquire (per Kubernetes lease semantics)
+
+**Expected Results**:
+
+1. No permanent deadlock after expiry
+2. Documented interaction with `LeaseSpec` duration fields
+
+**Acceptance Criteria**:
+
+- **Behavior**: Expired lease does not block forever
+- **Correctness**: Matches `coordination.k8s.io` Lease lifecycle
+- **Accuracy**: Test uses real API when in integration; unit uses injected clock if applicable
+
+**Dependencies**: UT-RO-189-001
+
+---
+
+### IT-RO-189-001: Parallel reconciles — single WFE (P0)
+
+**BR**: BR-ORCH-025
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/remediationorchestrator/distributed_lock_we_test.go` (TBD naming)
+
+**Preconditions**:
+
+- envtest control plane running
+- RO reconciler wired with real apiserver client and RBAC for Leases
+- Two `RemediationRequest` objects same target, different fingerprints, both passing existing routing checks
+
+**Test Steps**:
+
+1. **Given**: RR1 and RR2 admitted for same target resource
+2. **When**: Two parallel `Reconcile` invocations (goroutines) race before WE creation completes
+3. **Then**: Exactly **one** `WorkflowExecution` is created for that target; second reconcile observes contention and requeues without creating second WFE
+
+**Expected Results**:
+
+1. WFE count for target = 1 after stabilization window
+2. No execution-level “second WFE” failure mode for this race
+
+**Acceptance Criteria**:
+
+- **Behavior**: Operator sees single WE pipeline for concurrent duplicate-target RRs
+- **Correctness**: List/watch WFE objects confirms singleton
+- **Accuracy**: RR statuses reflect backoff/requeue, not silent drop
+
+**Dependencies**: GREEN phase: shared lock + RO wiring + RBAC
+
+---
+
+### IT-RO-189-002: Lock released on WE creation failure
+
+**BR**: BR-ORCH-025
+**Priority**: P1
+**Type**: Integration
+**File**: `test/integration/remediationorchestrator/distributed_lock_we_test.go`
+
+**Preconditions**:
+
+- Forced `weCreator.Create` error (e.g., invalid WFE template or apiserver 409 injected per harness capability)
+
+**Test Steps**:
+
+1. **Given**: RR eligible for WE creation
+2. **When**: Create fails after lock acquired
+3. **Then**: Lock released (or TTL allows immediate retry per design); subsequent reconcile can acquire
+
+**Expected Results**:
+
+1. No permanent Lease stuck in “held” for successful retry path
+2. Metrics optional: contention counter stable
+
+**Acceptance Criteria**:
+
+- **Behavior**: Target not bricked after transient create failure
+- **Correctness**: Lease object absent or free post-failure
+- **Accuracy**: Logs/events contain identifiable lock release reason
+
+**Dependencies**: IT-RO-189-001
+
+---
+
+### IT-RO-189-003: Lock released on terminal WE phase
+
+**BR**: BR-ORCH-031
+**Priority**: P1
+**Type**: Integration
+**File**: `test/integration/remediationorchestrator/distributed_lock_we_test.go`
+
+**Preconditions**:
+
+- WFE transitions to `Completed` or `Failed` (as defined by API)
+
+**Test Steps**:
+
+1. **Given**: WFE exists and reaches terminal phase while Lease association defined by implementation
+2. **When**: RO observes terminal phase cleanup path
+3. **Then**: Lock is released or not required for next RR per documented rules; new RR can proceed
+
+**Expected Results**:
+
+1. Subsequent RR for same target not blocked incorrectly
+2. Consistent with REFACTOR: contention metrics still valid
+
+**Acceptance Criteria**:
+
+- **Behavior**: Terminal phase does not leave stale lock forever
+- **Correctness**: Matches status phase enum used in production
+- **Accuracy**: Only one release path fires (no double-delete panic)
+
+**Dependencies**: IT-RO-189-001
+
+---
+
+## 10. Environmental Needs
+
+> **IEEE 829 §13** — Hardware, software, tools, and infrastructure required.
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: Kubernetes client fakes acceptable **only** at unit tier for lock unit tests; prefer testing through manager interfaces
+- **Location**: `test/unit/shared/` or co-located with extracted package
+- **Resources**: Default CI runner
+
+### 10.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: **ZERO** mocks of Kubernetes API for Lease semantics — use envtest
+- **Infrastructure**: envtest (apiserver + etcd), RO CRDs/scheme registered as per existing RO integration suite
+- **Location**: `test/integration/remediationorchestrator/`
+- **Resources**: Sufficient CPU for parallel tests; typical CI sizing
+
+### 10.3 E2E Tests (if applicable)
+
+- Not required for initial #189 delivery.
+
+### 10.4 Tools & Versions
+
+| Tool | Minimum Version | Purpose |
+|------|-----------------|---------|
+| Go | Project `go.mod` | Build and test |
+| Ginkgo CLI | v2.x | BDD runner |
+| controller-runtime envtest | Project version | Real Lease API |
+
+---
+
+## 11. Dependencies & Schedule
+
+> **IEEE 829 §12/§16** — Remaining tasks, blocking issues, and execution order.
+
+### 11.1 Blocking Dependencies
+
+| Dependency | Type | Status | Impact if Not Available | Workaround |
+|------------|------|--------|-------------------------|------------|
+| Extraction of `DistributedLockManager` | Code | Open until GREEN | Cannot import shared lock from RO | Temporary duplicate (anti-pattern — avoid) |
+| RO RBAC for Leases | Manifest | Open until GREEN | IT-RO-189-001 fails | None — must land with code |
+| envtest assets | Infra | Existing | Integration blocked | Use existing suite bootstrap |
+
+### 11.2 Execution Order (TDD)
+
+1. **RED**: IT-RO-189-001 — parallel reconcile demonstrates **two WFEs** (current bug) or documents failing assertion; unit tests RED for lock helper
+2. **GREEN**: Extract `DistributedLockManager` to `pkg/shared/`, RO acquire before `weCreator.Create`, `defer` release, wire RBAC + `apiReader` as needed; make IT/UT green
+3. **REFACTOR**: Share `generateLeaseName` with prefix parameter, add contention metrics, document ADR-052 reuse in code/comments
+
+---
+
+## 12. Test Deliverables
+
+> **IEEE 829 §11** — What artifacts this test effort produces.
+
+| Deliverable | Location | Description |
+|-------------|----------|-------------|
+| This test plan | `docs/tests/189/TEST_PLAN.md` | Strategy and traceability |
+| Unit test suite | `test/unit/shared/` (TBD) | Lock manager tests |
+| Integration test suite | `test/integration/remediationorchestrator/` | envtest parallel reconcile |
+| Coverage report | CI artifact | Per-tier >=80% |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests (adjust package path after extraction)
+go test ./test/unit/shared/... -ginkgo.v
+go test ./test/unit/remediationorchestrator/... -ginkgo.v
+
+# Integration tests
+go test ./test/integration/remediationorchestrator/... -ginkgo.v
+
+# Focus by ID
+go test ./test/integration/remediationorchestrator/... -ginkgo.focus="IT-RO-189-001"
+
+# Coverage
+go test ./pkg/shared/... -coverprofile=coverage-shared.out
+go tool cover -func=coverage-shared.out
+```
+
+---
+
+## 14. Existing Tests Requiring Updates (if applicable)
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|-------------------|-------------------|-----------------|--------|
+| TBD during RED | May assume parallel WFE creation possible | Expect single WFE + requeue when second RR races | New locking semantics |
+
+*Populate concrete rows when RED phase identifies exact files.*
+
+---
+
+## 15. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-09 | Initial test plan for Issue #189 |

--- a/docs/tests/235/TEST_PLAN.md
+++ b/docs/tests/235/TEST_PLAN.md
@@ -1,0 +1,508 @@
+# Test Plan: Automated Partition Creation — audit_events & resource_action_traces (#235 + #620)
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+>
+> Based on IEEE 829-2008 (Standard for Software and System Test Documentation) with
+> Kubernaut-specific extensions for TDD phase tracking, business requirement traceability,
+> and per-tier coverage policy.
+
+**Test Plan Identifier**: TP-235-v1.0
+**Feature**: Application-level startup enforcement of PostgreSQL monthly partitions for `audit_events` (by `event_date`) and `resource_action_traces` (by `action_timestamp`), with 3-month lookahead in UTC (Option A)
+**Version**: 1.0
+**Created**: 2026-04-09
+**Author**: AI Assistant
+**Status**: Draft
+**Branch**: `development/v1.3`
+
+---
+
+## 1. Introduction
+
+> **IEEE 829 §3** — Purpose, objectives, and measurable success criteria for the test effort.
+
+### 1.1 Purpose
+
+This test plan validates Issue #235 (with #620 alignment): today static partitions exist through 2028-12 in `pkg/shared/assets/migrations/001_v1_schema.sql`, while `create_monthly_partitions()` only targets `resource_action_traces` (RAT), rolls forward one month, and is never invoked. The human decision is **Option A** — ensure partitions at **application startup**, **3-month lookahead**, **UTC**. Integration test helper `createDynamicPartitions` currently covers only RAT; both tables use `_default` catch-all partitions.
+
+### 1.2 Objectives
+
+1. **Month range calculator**: Given a clock “today” and **N** months lookahead, compute the correct list of partition identities for **both** tables.
+2. **Naming**: Partitions use **`YYYY_MM`** style naming with correct table-specific prefix conventions.
+3. **Idempotency**: Repeated `ensure` calls do not error and do not create duplicate relations.
+4. **Startup behavior**: On service start, missing partitions for **current month + 3 months** exist for **both** `audit_events` and `resource_action_traces`.
+5. **Data path**: Inserts with timestamps falling in newly ensured partitions succeed (boundary validation).
+6. **Catalog verification**: `pg_inherits` shows child partitions attached for **both** parent tables.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/...` (data-storage / partition package paths TBD) |
+| Integration test pass rate | 100% | `go test ./test/integration/...` (data-storage + real Postgres) |
+| Unit-testable code coverage | >=80% | Month calculator, naming, idempotent SQL generation |
+| Integration-testable code coverage | >=80% | Startup hook, DB catalog checks |
+| Regressions | 0 | Existing RAT-only helpers upgraded without breaking callers |
+
+---
+
+## 2. References
+
+> **IEEE 829 §2** — Documents that govern or inform this test plan.
+
+### 2.1 Authority (governing documents)
+
+- BR-AUDIT-029: Automatic partition management for audit storage
+- Issue #235: Automated partition creation for `audit_events` and `resource_action_traces`
+- Issue #620: Related partition / data-storage alignment (coordinated delivery)
+- `pkg/shared/assets/migrations/001_v1_schema.sql`: Static partitions through 2028-12; `create_monthly_partitions()` definition
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../../.cursor/rules/03-testing-strategy.mdc)
+- [Test Case Specification Template](../../testing/TEST_CASE_SPECIFICATION_TEMPLATE.md)
+- [Integration/E2E No-Mocks Policy](../../testing/INTEGRATION_E2E_NO_MOCKS_POLICY.md)
+- [Testing Guidelines](../../development/business-requirements/TESTING_GUIDELINES.md)
+
+---
+
+## 3. Risks & Mitigations
+
+> **IEEE 829 §5** — Software risk issues that drive test design.
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | UTC vs local timezone in partition bounds | Wrong month boundary, data lands in `_default` | Medium | UT-DS-235-001, IT-DS-235-003 | Fix clock to UTC; tests use injected clock |
+| R2 | `IF NOT EXISTS` omitted | Startup flaky or duplicate object errors | Medium | UT-DS-235-003, IT-DS-235-002 | Assert idempotent DDL; integration double-start |
+| R3 | Only RAT ensured, audit_events forgotten | Audit writes fail after static range | High | IT-DS-235-001, IT-DS-235-004 | Explicit both-table IT coverage |
+| R4 | Migration function `create_monthly_partitions` left as dead code | Confusion / dual paths | Low | Documentation + single ensure path in app | REFACTOR: one PartitionManager |
+
+### 3.1 Risk-to-Test Traceability
+
+- **R1**: UT-DS-235-001 uses fixed instants in UTC; IT-DS-235-003 inserts boundary timestamp.
+- **R3**: IT-DS-235-001 and IT-DS-235-004 require both parents.
+- **R2**: UT-DS-235-003 and IT-DS-235-002 exercise double ensure.
+
+---
+
+## 4. Scope
+
+> **IEEE 829 §6/§7** — Features to be tested and features not to be tested.
+
+### 4.1 Features to be Tested
+
+- **Partition month range calculator** (pure logic): Given today + N months, yields partition keys/names for both strategies (`event_date` / `action_timestamp` parents).
+- **DDL ensure loop** at **data-storage** (or shared DB bootstrap) **startup**: `CREATE TABLE ... PARTITION OF ... FOR VALUES FROM ... TO ...` with **IF NOT EXISTS** (or equivalent idempotent pattern).
+- **PostgreSQL catalog**: `pg_inherits` / information_schema checks for children of `audit_events` and `resource_action_traces`.
+- **Insert boundary**: Rows routed to new partitions, not only `_default`.
+
+### 4.2 Features Not to be Tested
+
+- **Dropping** old partitions: Covered by Issue #485 test plan; #235 focuses on **creation**.
+- **Non-Postgres** backends: Out of scope.
+- **Retroactive backfill** of historical partitions beyond lookahead: Out of scope unless BR extends.
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Option A — application startup | No external cron required; deterministic with service lifecycle |
+| 3-month lookahead | Balances DDL churn vs operational safety |
+| UTC | Consistent with partition definitions in migrations |
+| Both tables in one ensure | BR-AUDIT-029; avoids RAT-only gap |
+
+---
+
+## 5. Approach
+
+> **IEEE 829 §8/§9/§10** — Test strategy, pass/fail criteria, and suspension/resumption.
+
+### 5.1 Coverage Policy
+
+**Authority**: `03-testing-strategy.mdc` — Per-Tier Testable Code Coverage.
+
+- **Unit**: >=80% of month calculator, naming, and idempotent ensure planning logic.
+- **Integration**: >=80% of startup wiring against real PostgreSQL (envtest or testcontainer pattern per existing DS tests).
+- **E2E**: Not required for partition DDL; integration with real Postgres is sufficient.
+
+### 5.2 Two-Tier Minimum
+
+Each BR-aligned behavior is covered by **UT** (pure date math / naming) and **IT** (actual catalog + inserts).
+
+### 5.3 Business Outcome Quality Bar
+
+Prove: “Service starts cleanly; both audit and RAT partitions exist for now + 3 months; writes hit correct partitions; reruns are safe.”
+
+### 5.4 Pass/Fail Criteria
+
+**PASS** — all of:
+
+1. All P0 tests pass: IT-DS-235-001, IT-DS-235-002, IT-DS-235-003, IT-DS-235-004, plus unit suite.
+2. Coverage >=80% on new partition manager code.
+3. No duplicate partition relations after double startup.
+
+**FAIL** — any of:
+
+1. Any P0 integration test fails.
+2. Only one table gets partitions in IT-DS-235-004.
+3. Second startup errors or creates duplicate inherit entries.
+
+### 5.5 Suspension & Resumption Criteria
+
+**Suspend**: Postgres unavailable; migration SQL conflict on branch; shared integration suite broken.
+**Resume**: DS integration harness green; migrations applied cleanly.
+
+---
+
+## 6. Test Items
+
+> **IEEE 829 §4** — Software items to be tested, with version identification.
+
+### 6.1 Unit-Testable Code (pure logic, no I/O)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| TBD `pkg/datastorage/.../partition*.go` | Month range calculator, partition name builder | TBD |
+| TBD | `EnsurePartitions` plan builder (SQL statements, idempotent flags) | TBD |
+
+### 6.2 Integration-Testable Code (I/O, wiring, cross-component)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `cmd/data-storage/main.go` (or bootstrap) | Startup hook invoking partition ensure | TBD |
+| TBD | `PartitionManager.Ensure` executing against `sql.DB` | TBD |
+
+### 6.3 Version Identification
+
+| Item | Version/Commit | Notes |
+|------|----------------|-------|
+| Schema | `001_v1_schema.sql` HEAD | Static partitions through 2028-12; `_default` partitions |
+| SQL function | `create_monthly_partitions()` | Pre-change: RAT-only, +1 month, uncalled |
+
+---
+
+## 7. BR Coverage Matrix
+
+> Kubernaut-specific. Maps every business requirement to test scenarios across tiers.
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-AUDIT-029 | Automatic partition management | P0 | Unit | UT-DS-235-001, UT-DS-235-002, UT-DS-235-003 | Pending |
+| BR-AUDIT-029 | Startup ensure both tables | P0 | Integration | IT-DS-235-001 | Pending |
+| BR-AUDIT-029 | Idempotent ensure | P1 | Integration | IT-DS-235-002 | Pending |
+| BR-AUDIT-029 | Insert boundary | P1 | Integration | IT-DS-235-003 | Pending |
+| BR-AUDIT-029 | Catalog inherits both parents | P0 | Integration | IT-DS-235-004 | Pending |
+
+### Status Legend
+
+- **Pending**: Specification complete, implementation not started
+- **RED**: Failing test written (TDD RED phase)
+- **GREEN**: Minimal implementation passes (TDD GREEN phase)
+- **REFACTORED**: Code cleaned up (TDD REFACTOR phase)
+- **Pass**: Implemented and passing
+
+---
+
+## 8. Test Scenarios
+
+> **IEEE 829 Test Design Specification** — How test cases are organized and grouped.
+
+### Test ID Naming Convention
+
+Format: `{TIER}-DS-{ISSUE}-{SEQUENCE}`.
+
+### Tier 1: Unit Tests
+
+**Testable code scope**: Month calculator, `YYYY_MM` naming, table prefix rules, idempotent ensure planning — >=80% coverage.
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-DS-235-001` | Given fixed “today” and N months, partition name list correct for **both** tables | Pending |
+| `UT-DS-235-002` | Naming: `YYYY_MM` format and correct parent/table prefix in generated identifiers | Pending |
+| `UT-DS-235-003` | Idempotency at plan/SQL level: second ensure generates no conflicting operations / safe no-ops | Pending |
+
+### Tier 2: Integration Tests
+
+**Testable code scope**: Data-storage startup wiring, real Postgres, `pg_inherits` — >=80% coverage on integration-testable partition code.
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `IT-DS-235-001` (P0) | Startup ensure creates missing partitions for current + 3 months for **both** tables | Pending |
+| `IT-DS-235-002` | Second startup: no error, no duplicate child relations | Pending |
+| `IT-DS-235-003` | Boundary insert with timestamp in newly created partition succeeds | Pending |
+| `IT-DS-235-004` | `pg_inherits` lists children for **audit_events** and **resource_action_traces** | Pending |
+
+### Tier 3: E2E Tests (if applicable)
+
+Not applicable.
+
+### Tier Skip Rationale (if any tier is omitted)
+
+- **E2E**: Real Postgres in integration tests satisfies storage contract; full Helm deploy deferred.
+
+---
+
+## 9. Test Cases
+
+> **IEEE 829 Test Case Specification** — Detailed specification for each test case.
+
+### UT-DS-235-001: Month range calculator (both tables)
+
+**BR**: BR-AUDIT-029
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/datastorage/...` (TBD path aligned with implementation package)
+
+**Preconditions**:
+- Injected clock interface returns a known UTC instant (e.g., mid-month).
+
+**Test Steps**:
+1. **Given**: Today = T0, lookahead N = 3.
+2. **When**: Calculator returns planned partitions for `audit_events` and `resource_action_traces`.
+3. **Then**: Lists include months M0..M3 (inclusive framing per implementation spec) with correct year/month roll.
+
+**Expected Results**:
+1. Both tables receive the same calendar month sequence (partitioning strategy may differ only in parent name/prefix, not month set).
+
+**Acceptance Criteria**:
+- **Behavior**: Deterministic planning from clock.
+- **Correctness**: Expected month labels match UTC calendar math.
+
+**Dependencies**: None.
+
+---
+
+### UT-DS-235-002: Partition naming
+
+**BR**: BR-AUDIT-029
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/datastorage/...`
+
+**Test Steps**:
+1. **Given**: A calendar month (e.g., 2026-11).
+2. **When**: Name builder runs for each table kind.
+3. **Then**: String matches `YYYY_MM` pattern and includes correct table-specific prefix/suffix per schema conventions.
+
+**Expected Results**:
+1. Regex/table naming rules satisfied; no illegal identifiers.
+
+**Acceptance Criteria**:
+- **Accuracy**: Names align with migration naming for existing partitions.
+
+**Dependencies**: `001_v1_schema.sql` naming audit.
+
+---
+
+### UT-DS-235-003: Idempotency (plan / SQL)
+
+**BR**: BR-AUDIT-029
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/datastorage/...`
+
+**Test Steps**:
+1. **Given**: Planned DDL statements for ensure.
+2. **When**: `Ensure` called twice with same inputs.
+3. **Then**: Second invocation produces only safe no-ops or uses `IF NOT EXISTS` such that executor would not error.
+
+**Expected Results**:
+1. No conflicting `CREATE` without guard; duplicate call flag or empty diff.
+
+**Acceptance Criteria**:
+- **Correctness**: Mathematical idempotence of ensure logic.
+
+**Dependencies**: None.
+
+---
+
+### IT-DS-235-001 (P0): Startup ensure — both tables
+
+**BR**: BR-AUDIT-029
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/datastorage/...` (TBD)
+
+**Preconditions**:
+- Real Postgres (existing suite pattern); database migrated with base schema; optional teardown of future month partitions beyond test window to force creation.
+
+**Test Steps**:
+1. **Given**: Clean DB missing partitions for months in [now, now+3] for one or both parents.
+2. **When**: Run startup ensure (same code path as service boot).
+3. **Then**: Required child partitions exist for **audit_events** and **resource_action_traces**.
+
+**Expected Results**:
+1. Query against `pg_inherits` or catalog helper confirms expected child count/names.
+
+**Acceptance Criteria**:
+- **Behavior**: Both parents extended together.
+
+**Dependencies**: #620 coordination if shared bootstrap changes.
+
+---
+
+### IT-DS-235-002: Idempotency — second startup
+
+**BR**: BR-AUDIT-029
+**Priority**: P1
+**Type**: Integration
+**File**: `test/integration/datastorage/...`
+
+**Test Steps**:
+1. **Given**: DB after successful IT-DS-235-001.
+2. **When**: Startup ensure runs again.
+3. **Then**: No error; no duplicate inheritance entries for same partition name.
+
+**Expected Results**:
+1. Logs structured (optional); SQL errors absent.
+
+**Acceptance Criteria**:
+- **Behavior**: Safe restart.
+
+**Dependencies**: IT-DS-235-001.
+
+---
+
+### IT-DS-235-003: Boundary insert
+
+**BR**: BR-AUDIT-029
+**Priority**: P1
+**Type**: Integration
+**File**: `test/integration/datastorage/...`
+
+**Test Steps**:
+1. **Given**: Partition for target month ensured.
+2. **When**: Insert `audit_events` row with `event_date` / RAT row with `action_timestamp` at boundary instant inside that partition’s range.
+3. **Then**: Insert succeeds; row visible via `SELECT`; not relegated to `_default` (assert partition name via `tableoid` or explain plan if available).
+
+**Expected Results**:
+1. Successful commit; correct routing.
+
+**Acceptance Criteria**:
+- **Data accuracy**: Writes land in child partition.
+
+**Dependencies**: IT-DS-235-001.
+
+---
+
+### IT-DS-235-004: pg_inherits — both tables
+
+**BR**: BR-AUDIT-029
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/datastorage/...`
+
+**Test Steps**:
+1. **Given**: Post-ensure database.
+2. **When**: Query `pg_inherits` joined to `pg_class` for each parent.
+3. **Then**: Non-empty child set for **both** `audit_events` and `resource_action_traces` covering lookahead window.
+
+**Expected Results**:
+1. Each parent lists expected monthly children.
+
+**Acceptance Criteria**:
+- **Correctness**: Catalog matches plan.
+
+**Dependencies**: IT-DS-235-001.
+
+---
+
+## 10. Environmental Needs
+
+> **IEEE 829 §13** — Hardware, software, tools, and infrastructure required.
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: Clock interface only (not external DB)
+- **Location**: `test/unit/datastorage/` (or package under test)
+- **Resources**: Minimal
+
+### 10.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: ZERO mocks for Postgres (per no-mocks policy)
+- **Infrastructure**: Real PostgreSQL — same harness as existing data-storage integration tests
+- **Location**: `test/integration/datastorage/`
+- **Resources**: Docker/Podman or CI-provided Postgres service
+
+### 10.3 E2E Tests (if applicable)
+
+- Not applicable.
+
+### 10.4 Tools & Versions
+
+| Tool | Minimum Version | Purpose |
+|------|-----------------|---------|
+| Go | Project standard | Build and test |
+| Ginkgo CLI | v2.x | BDD runner |
+| PostgreSQL | Schema-compatible with `001_v1_schema.sql` | Partition DDL |
+
+---
+
+## 11. Dependencies & Schedule
+
+> **IEEE 829 §12/§16** — Remaining tasks, blocking issues, and execution order.
+
+### 11.1 Blocking Dependencies
+
+| Dependency | Type | Status | Impact if Not Available | Workaround |
+|------------|------|--------|-------------------------|------------|
+| Issue #620 | Code | Open/Merged TBD | Bootstrap location may shift | Rebase IT paths |
+| Existing `createDynamicPartitions` | Test helper | RAT-only | IT cannot validate audit_events | Extend helper per IT cases |
+
+### 11.2 Execution Order
+
+1. **RED**: Integration tests fail when DB lacks future partitions for **audit_events** (and assert RAT behavior preserved).
+2. **GREEN**: Startup hook; ensure loop for **both** tables; `IF NOT EXISTS` (or equivalent).
+3. **REFACTOR**: Extract `PartitionManager` with clock interface; structured logs.
+
+**TDD sequence**: RED (integration fails without partitions) → GREEN (startup ensure both) → REFACTOR (PartitionManager, clock, logs).
+
+---
+
+## 12. Test Deliverables
+
+> **IEEE 829 §11** — What artifacts this test effort produces.
+
+| Deliverable | Location | Description |
+|-------------|----------|-------------|
+| This test plan | `docs/tests/235/TEST_PLAN.md` | Strategy and test design |
+| Unit tests | `test/unit/datastorage/` (TBD) | Calculator / naming / idempotence |
+| Integration tests | `test/integration/datastorage/` | Startup + catalog + insert |
+| Coverage report | CI artifact | Per-tier coverage |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests (adjust package path when implemented)
+go test ./test/unit/datastorage/... -ginkgo.v
+
+# Integration tests
+go test ./test/integration/datastorage/... -ginkgo.v
+
+# Focus by ID
+go test ./test/integration/datastorage/... -ginkgo.focus="IT-DS-235" -ginkgo.v
+
+# Coverage
+go test ./test/unit/datastorage/... -coverprofile=coverage.out
+go tool cover -func=coverage.out
+```
+
+---
+
+## 14. Existing Tests Requiring Updates (if applicable)
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|-------------------|-------------------|-----------------|--------|
+| Integration helper `createDynamicPartitions` | RAT-only | Ensure **audit_events** + RAT; align with 3-month UTC lookahead | BR-AUDIT-029 |
+| Any startup test assuming static partitions only | No ensure call | Invoke or assert new startup ensure | Option A |
+
+---
+
+## 15. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-09 | Initial test plan for Issues #235 / #620 |

--- a/docs/tests/236/TEST_PLAN.md
+++ b/docs/tests/236/TEST_PLAN.md
@@ -1,0 +1,201 @@
+# Test Plan: EM DataStorageQuerier ogen Migration
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-236-v1
+**Feature**: Migrate EffectivenessMonitor DataStorageQuerier from raw HTTP to ogen OpenAPI client (DD-API-001)
+**Version**: 1.0
+**Created**: 2026-04-09
+**Author**: AI Assistant
+**Status**: Draft
+**Branch**: `development/v1.3_part2`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Validate that the EM DataStorageQuerier migration from hand-written `net/http` to the ogen-generated OpenAPI client preserves identical business behavior while achieving DD-API-001 compliance.
+
+### 1.2 Objectives
+
+1. **Functional parity**: All 3 `DataStorageQuerier` methods (`QueryPreRemediationHash`, `HasWorkflowStarted`, `HasWorkflowCompleted`) produce identical results before and after migration.
+2. **DD-API-001 compliance**: No raw `net/http` calls remain in `ds_querier.go`; all DS communication uses the ogen-generated client.
+3. **DD-AUTH-014 compliance**: ServiceAccount transport is used for authentication, aligned with the established ogen adapter pattern.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/effectivenessmonitor/... -ginkgo.focus="DataStorageQuerier"` |
+| Integration test pass rate | 100% | `go test ./test/integration/effectivenessmonitor/... -ginkgo.focus="G4"` |
+| Backward compatibility | 0 regressions | All existing EM tests pass without modification |
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- DD-API-001: OpenAPI Generated Client MANDATORY
+- DD-AUTH-014: ServiceAccount transport authentication pattern
+- DD-EM-002: Pre-remediation spec hash lookup
+- ADR-EM-001: EffectivenessMonitor assessment scope detection
+- Issue #236: Migrate EffectivenessMonitor DataStorageQuerier to ogen OpenAPI client
+
+### 2.2 Cross-References
+
+- [Testing Guidelines](../../development/business-requirements/TESTING_GUIDELINES.md)
+- Pattern reference: `pkg/audit/openapi_client_adapter.go`
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Mitigation |
+|----|------|--------|-------------|------------|
+| R1 | ogen sum type discriminator requires `event_type` inside `event_data` JSON | Decode error on mock responses | High (verified) | All mock JSON includes discriminator field. Preflight verified exact mapping in `oas_json_gen.go` lines 7896, 7923, 7929. |
+| R2 | `AuditEvent` has 8 required fields; current mocks provide 2 | Decode error `validate.ErrFieldRequired` | High (verified) | Create `testAuditEvent` helper populating all 8 required fields with valid defaults. |
+| R3 | `WorkflowExecutionAuditPayload` has 7 required non-optional fields | Decode error on HasWorkflowStarted/Completed mocks | Medium | Mock helper includes valid defaults for `workflow_id`, `workflow_version`, `target_resource`, `phase`, `container_image`, `execution_name`. |
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **DataStorageQuerier adapter** (`pkg/effectivenessmonitor/client/ds_querier.go`): ogen-backed implementation of 3 query methods
+- **Constructor wiring** (`cmd/effectivenessmonitor/main.go`): New constructor replaces old
+
+### 4.2 Features Not to be Tested
+
+- **ogen-generated client internals** (`pkg/datastorage/ogen-client/`): Generated code, not project-owned
+- **Reconciler logic**: Interface unchanged, reconciler not modified
+- **Audit write path**: Separate adapter, already ogen-compliant
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Keep `DataStorageQuerier` interface unchanged | Zero blast radius on reconciler and all dependent code |
+| Use httptest + real ogen client in tests | Matches established pattern in `openapi_client_adapter_test.go` |
+| Schema-compliant mock JSON | Required by ogen decoder's strict field validation |
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+- **Unit**: Existing 10 UT-EM-DSQ tests adapted to ogen constructor and schema-compliant mocks. No new test scenarios needed (behavior unchanged).
+- **Integration**: Existing IT-EM-573-013/014 adapted to new constructor and compliant mocks.
+- **E2E**: Tier skip — no runtime behavior change; E2E validates controller reconciliation, not DS client internals.
+
+### 5.2 Business Outcome Quality Bar
+
+Tests validate business outcomes: correct hash extraction, correct boolean responses for workflow lifecycle queries, and correct error propagation. Not just "ogen client is called."
+
+### 5.4 Pass/Fail Criteria
+
+**PASS**: All existing UT-EM-DSQ and IT-EM-573 tests pass with identical assertions after migration.
+
+**FAIL**: Any existing test fails, any regression in other EM test suites, or build failure.
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `pkg/effectivenessmonitor/client/ds_querier.go` | `QueryPreRemediationHash`, `HasWorkflowStarted`, `HasWorkflowCompleted`, constructors | ~100 |
+
+### 6.2 Integration-Testable Code
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `cmd/effectivenessmonitor/main.go` | DS querier wiring (lines 332-337) | ~6 |
+
+---
+
+## 7. BR Coverage Matrix
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| DD-API-001 | ogen client mandatory | P0 | Unit | UT-EM-DSQ-001..009, UT-EM-573-009 | Pending |
+| DD-EM-002 | Pre-remediation hash lookup | P0 | Unit | UT-EM-DSQ-001..005 | Pending |
+| ADR-EM-001 §5 | Workflow lifecycle detection | P0 | Unit | UT-EM-DSQ-006..009, UT-EM-573-009 | Pending |
+| ADR-EM-001 §5 | Assessment path differentiation | P0 | Integration | IT-EM-573-013, IT-EM-573-014 | Pending |
+
+---
+
+## 8. Test Scenarios
+
+### Tier 1: Unit Tests
+
+Existing tests adapted (no new scenarios — behavior unchanged):
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| UT-EM-DSQ-001 | Pre-remediation hash retrieved from workflow_created event | Pending |
+| UT-EM-DSQ-002 | Empty string returned when no events found | Pending |
+| UT-EM-DSQ-003 | Empty string returned when event has no hash field | Pending |
+| UT-EM-DSQ-004 | Error propagated on HTTP 500 | Pending |
+| UT-EM-DSQ-005 | Error propagated when DS unreachable | Pending |
+| UT-EM-DSQ-006 | True returned when execution.started event exists | Pending |
+| UT-EM-DSQ-007 | False returned when no execution.started event | Pending |
+| UT-EM-DSQ-008 | Error propagated on HTTP 500 (HasWorkflowStarted) | Pending |
+| UT-EM-DSQ-009 | Error propagated when DS unreachable (HasWorkflowStarted) | Pending |
+| UT-EM-573-009 | HasWorkflowCompleted returns true/false correctly | Pending |
+
+### Tier 2: Integration Tests
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| IT-EM-573-013 | No-execution path detected when no started event | Pending |
+| IT-EM-573-014 | Partial path detected when started but not completed | Pending |
+
+### Tier Skip Rationale
+
+- **E2E**: No runtime behavior change. E2E validates full reconciliation, not DS client library choice.
+
+---
+
+## 9. Environmental Needs
+
+### 9.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Infrastructure**: `httptest.NewServer` serving ogen-compliant JSON
+- **Location**: `test/unit/effectivenessmonitor/ds_querier_test.go`
+
+### 9.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Infrastructure**: `httptest.NewServer` + `envtest` (existing suite)
+- **Location**: `test/integration/effectivenessmonitor/issue573_integration_test.go`
+
+---
+
+## 10. Execution
+
+```bash
+# Unit tests
+go test ./test/unit/effectivenessmonitor/... -ginkgo.focus="DataStorageQuerier" -ginkgo.v
+
+# Integration tests
+go test ./test/integration/effectivenessmonitor/... -ginkgo.focus="G4" -ginkgo.v
+
+# Full EM test suite (regression check)
+go test ./test/unit/effectivenessmonitor/... -count=1
+```
+
+---
+
+## 11. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-09 | Initial test plan. Adapted from existing UT-EM-DSQ and IT-EM-573 test suites for ogen migration. |

--- a/docs/tests/239/TEST_PLAN.md
+++ b/docs/tests/239/TEST_PLAN.md
@@ -1,0 +1,491 @@
+# Test Plan: E2E FullPipeline — Helm chart deployment
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+>
+> Based on IEEE 829-2008 (Standard for Software and System Test Documentation) with
+> Kubernaut-specific extensions for TDD phase tracking, business requirement traceability,
+> and per-tier coverage policy.
+
+**Test Plan Identifier**: TP-239-v1
+**Feature**: Deploy the product stack for FullPipeline E2E via `helm install`/`helm upgrade` (`charts/kubernaut/`) instead of programmatic inline Go manifests, while retaining E2E-only infrastructure for Mock LLM, Prometheus, AlertManager, event-exporter, and mock-slack.
+**Version**: 1.0
+**Created**: 2026-04-09
+**Author**: AI Assistant
+**Status**: Draft
+**Branch**: `development/v1.3_part2` (or branch carrying Issue #239)
+
+---
+
+## 1. Introduction
+
+> **IEEE 829 §3** — Purpose, objectives, and measurable success criteria for the test effort.
+
+### 1.1 Purpose
+
+This test plan defines how Issue #239 will be validated: replacing duplicated inline Kubernetes manifests in `SetupFullPipelineInfrastructure` with the authoritative Helm chart so CI exercises the same deployment path as operators, while test-only components stay on the existing E2E infrastructure path. It also covers optional E2E coverage instrumentation, NodePort accessibility for Gateway and DataStorage, and guarding against CRD and RBAC drift between chart templates and `config/crd/bases`.
+
+### 1.2 Objectives
+
+1. **Chart fidelity**: `helm template` (or equivalent) with `values-e2e.yaml` renders without error and produces the FullPipeline product workload set (PostgreSQL, Valkey, DataStorage, AuthWebhook, Gateway, all controllers, Kubernaut Agent, RBAC, hooks) consistent with today’s E2E expectations.
+2. **Regression safety**: All five existing FullPipeline Ginkgo E2E specs continue to pass **without source changes** to those test files (`01_full_remediation_lifecycle`, `02_approval_lifecycle`, `02_async_hash_deferral`, `03_ka_target_resource` — plus suite/bootstrap as applicable).
+3. **Operational parity**: Install ordering remains correct (PostgreSQL → migrations → DataStorage → seeding → controllers → test infra), with Helm hooks and/or post-install scripting aligned to that sequence.
+4. **Traceability**: Every scenario maps to **BR-E2E-001** and the **E2E-FP-*** scenario identifiers exercised by the FullPipeline suite.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Helm render pass rate | 100% | `helm template kubernaut ./charts/kubernaut -f charts/kubernaut/values-e2e.yaml` (or project-standard wrapper) exits 0 |
+| FullPipeline E2E pass rate | 100% | Ginkgo E2E under `test/e2e/fullpipeline/` with FullPipeline infrastructure enabled |
+| Backward compatibility | 0 regressions | Five existing FullPipeline test files unchanged and green |
+| NodePort accessibility (P1) | Gateway :30080, DataStorage :30081 reachable from test host when overrides applied | HTTP/TCP checks per TP-239-004 |
+| E2E coverage artifacts (P1) | When `E2E_COVERAGE=true`, coverage output present for all six controllers | Files under `GOCOVERDIR` / documented artifact layout |
+| Drift guard (P2) | CI job green | Template diff or policy check for critical RBAC/env consistency (TP-239-006) |
+
+---
+
+## 2. References
+
+> **IEEE 829 §2** — Documents that govern or inform this test plan.
+
+### 2.1 Authority (governing documents)
+
+- **BR-E2E-001**: End-to-end validation of the Kubernaut remediation pipeline (umbrella for FullPipeline E2E).
+- **E2E-FP-***: FullPipeline E2E scenario identifiers referenced by existing `test/e2e/fullpipeline/` specifications.
+- Issue **#239**: E2E FullPipeline — deploy via Helm chart instead of programmatic manifests.
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../../.cursor/rules/03-testing-strategy.mdc)
+- [Test Case Specification Template](../../testing/TEST_CASE_SPECIFICATION_TEMPLATE.md)
+- [Integration/E2E No-Mocks Policy](../../testing/INTEGRATION_E2E_NO_MOCKS_POLICY.md)
+- [Testing Guidelines](../../development/business-requirements/TESTING_GUIDELINES.md)
+- Helm chart: `charts/kubernaut/`
+- E2E infrastructure: `test/infrastructure/fullpipeline_e2e.go`
+- CRD bases: `config/crd/bases/`
+- Chart CRDs: `charts/kubernaut/files/crds/`
+
+---
+
+## 3. Risks & Mitigations
+
+> **IEEE 829 §5** — Software risk issues that drive test design.
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | Ordering dependencies: Postgres before DataStorage before seeding before controllers | Pipeline hangs or flaky E2E; data not ready when tests run | High | TP-239-003 | Use Helm lifecycle hooks and/or documented post-install script; mirror current E2E ordering; add explicit readiness in suite if needed |
+| R2 | Secret/bootstrap differs between chart values and former inline manifests | Auth failures, pods CrashLoop | Medium | TP-239-002, TP-239-003 | `values-e2e.yaml` documents parity with prior secrets; TP-239-002 compares critical env/secret references |
+| R3 | EffectivenessMonitor monitoring URLs: chart defaults may disable Prom/AM; E2E requires in-cluster URLs | EM metrics/alerts tests fail or skip incorrectly | Medium | TP-239-003 | Override in `values-e2e.yaml` to enable URLs required by FullPipeline; assert in TP-239-002 where static |
+| R4 | Coverage: `GOCOVERDIR` + hostPath not present in chart today | No coverage files when `E2E_COVERAGE=true` | High (pre-change) | TP-239-005 | Add optional `e2e.coverage.enabled` (or equivalent) to chart templates for E2E-only volumes/env |
+| R5 | Dual CRD source (`charts/kubernaut/files/crds` vs `config/crd/bases`) | Schema drift, apply failures, false greens | Medium | TP-239-006, TP-239-003 | REFACTOR: single source of truth; P2 drift guard in CI |
+
+### 3.1 Risk-to-Test Traceability
+
+- **R1** → **TP-239-003** (full suite), **TP-239-001** (render sanity).
+- **R2** → **TP-239-002**, **TP-239-003**.
+- **R3** → **TP-239-002** (values/manifest expectations), **TP-239-003** (runtime).
+- **R4** → **TP-239-005**.
+- **R5** → **TP-239-006** (primary), **TP-239-001** (render includes expected CRD install hooks/resources per chosen alignment).
+
+**Coverage gap flag**: If TP-239-006 is deferred, R5 mitigation is incomplete until CRD consolidation lands.
+
+---
+
+## 4. Scope
+
+> **IEEE 829 §6/§7** — Features to be tested and features not to be tested.
+
+### 4.1 Features to be Tested
+
+- **FullPipeline E2E infrastructure** (`test/infrastructure/fullpipeline_e2e.go`): `SetupFullPipelineInfrastructure` (and helpers) refactored to install/upgrade the **product stack** via Helm using `charts/kubernaut/` and `values-e2e.yaml`.
+- **Helm chart** (`charts/kubernaut/`): Renders and deploys PostgreSQL, Valkey, DataStorage, AuthWebhook, Gateway, all controllers, Kubernaut Agent, RBAC, and hooks as modeled by the chart.
+- **E2E values** (`charts/kubernaut/values-e2e.yaml`, new): NodePort overrides (Gateway **30080**, DataStorage **30081**), EM/monitoring overrides as required, and optional `e2e.coverage.enabled` for `GOCOVERDIR` + hostPath volumes.
+- **Test-only infrastructure** (retain programmatic or `kubectl` apply path): Mock LLM, Prometheus, AlertManager, event-exporter, mock-slack — **not** moved into the product chart for this issue.
+- **CI / automation**: Optional drift guard validating rendered manifests for critical RBAC/env consistency (TP-239-006).
+
+### 4.2 Features Not to be Tested
+
+- **cert-manager**, **memory-eater**, and other components explicitly out of scope for the product chart in this issue (unless already part of FullPipeline infra today — document in implementation if touched).
+- **Production** `values.yaml` / airgap profiles: not the primary subject; only **E2E** values file is in scope for TP-239-001/002 unless a shared regression is explicitly added.
+- **Changing assertions** inside the five existing FullPipeline E2E test files: out of scope — they must pass unchanged.
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Incremental strategy: Helm for product stack, E2E infra for test-only | Minimizes chart bloat; keeps Mock LLM and observability mocks out of the shipping chart |
+| Optional `e2e.coverage.enabled` in chart | Coverage is CI/E2E-only; must not affect default operator installs |
+| NodePort overrides in `values-e2e.yaml` | Stable localhost ports **30080** / **30081** for gateway and datastorage per FullPipeline client expectations |
+| Single CRD source (REFACTOR target) | Eliminates R5 drift between `files/crds` and `config/crd/bases` |
+
+---
+
+## 5. Approach
+
+> **IEEE 829 §8/§9/§10** — Test strategy, pass/fail criteria, and suspension/resumption.
+
+### 5.1 Coverage Policy
+
+**Authority**: `03-testing-strategy.mdc` — Per-Tier Testable Code Coverage.
+
+- **Unit**: Where pure logic is extracted (e.g., helpers that diff “expected component set” vs rendered manifests), target **>=80%** of that **unit-testable** subset. Much of this issue is orchestration; **primary** quality signal is regression E2E.
+- **Integration**: Optional tests that run `helm template` in CI or invoke a thin Go wrapper — classify as integration if subprocess/filesystem I/O is used; target **>=80%** of any new **integration-testable** helpers introduced.
+- **E2E**: FullPipeline suite validates the **deployed** stack. Coverage is measured primarily by **TP-239-003** (existing scenarios). Optional **E2E_COVERAGE** path (TP-239-005) validates instrumentation, not necessarily line coverage thresholds for controllers in this plan.
+
+### 5.2 Two-Tier Minimum
+
+- **BR-E2E-001** / **E2E-FP-*** outcomes are covered by **E2E** (Tier 3) plus **at least one** faster tier: **helm render / manifest parity** tests (TP-239-001, TP-239-002) implemented as unit or CI integration checks.
+
+### 5.3 Business Outcome Quality Bar
+
+Tests prove the **operator-visible** outcome: the same cluster capabilities FullPipeline relied on (workloads, services, ports, secrets, monitoring hooks) are present when installed via Helm, and remediation lifecycle behavior remains correct end-to-end.
+
+### 5.4 Pass/Fail Criteria
+
+> **IEEE 829 §9** — When is this test plan considered passed or failed?
+
+**PASS** — all of the following must be true:
+
+1. All **P0** tests pass (TP-239-001, TP-239-002, TP-239-003): 0 failures.
+2. All **P1** tests pass (**TP-239-004**, **TP-239-005**) or have documented exceptions approved by reviewer.
+3. No regressions: five existing FullPipeline E2E files pass **unchanged**.
+4. Helm-based install completes with ordering that satisfies R1 (verified by TP-239-003 and implementation review).
+
+**FAIL** — any of the following:
+
+1. Any **P0** test fails.
+2. Any existing FullPipeline E2E test fails.
+3. **P1** fails without approved exception (team policy).
+4. **P2** (**TP-239-006**) fails **after** it has been promoted from optional to mandatory in the issue/PR acceptance criteria (until then, P2 failure is a quality signal, not automatic FAIL per this plan v1).
+
+### 5.5 Suspension & Resumption Criteria
+
+> **IEEE 829 §10** — When should testing stop? When can it resume?
+
+**Suspend testing when**:
+
+- Kind cluster or CI runner cannot provision Kubernetes or run Helm.
+- `values-e2e.yaml` or chart changes break `helm template` (blocking TP-239-001).
+- Cascading failures: more than one P0 failure shares the same root cause — stop and fix infrastructure first.
+
+**Resume testing when**:
+
+- Cluster/Helm availability restored; `helm template` succeeds.
+- Blocking defect for ordering or secrets fixed and merged.
+- CRD source alignment or drift guard merged if R5 was the blocker.
+
+---
+
+## 6. Test Items
+
+> **IEEE 829 §4** — Software items to be tested, with version identification.
+
+### 6.1 Unit-Testable Code (pure logic, no I/O)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|----------------|
+| New or existing helpers under `test/infrastructure/` or `test/e2e/fullpipeline/` (if added) | Manifest/component set comparison, value validation | TBD (post-implementation) |
+
+*Note: If no pure helpers are extracted, Section 6.1 may remain TBD with coverage rationale in Section 8 (Tier Skip).*
+
+### 6.2 Integration-Testable Code (I/O, wiring, cross-component)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|----------------|
+| `test/infrastructure/fullpipeline_e2e.go` | `SetupFullPipelineInfrastructure`, Helm install/upgrade wiring, ordering | TBD |
+| `charts/kubernaut/templates/**` | Conditional E2E coverage volumes/env | TBD |
+
+### 6.3 Version Identification
+
+| Item | Version/Commit | Notes |
+|------|----------------|-------|
+| Code under test | Branch carrying Issue #239 | Helm 3.x compatible chart |
+| Helm chart | `charts/kubernaut/` Chart.yaml version | Bumped per release process |
+| CRDs | Single source after REFACTOR | Until then: document which path E2E applies |
+
+---
+
+## 7. BR Coverage Matrix
+
+> Kubernaut-specific. Maps every business requirement to test scenarios across tiers.
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-E2E-001 | E2E validation of remediation / FullPipeline behavior | P0 | E2E / Infra | TP-239-003 | Pending |
+| BR-E2E-001 | Chart renders for E2E values | P0 | Unit/CI | TP-239-001 | Pending |
+| BR-E2E-001 | Product component parity vs prior E2E stack | P0 | Unit/CI | TP-239-002 | Pending |
+| BR-E2E-001 | Stable NodePorts for clients | P1 | E2E | TP-239-004 | Pending |
+| BR-E2E-001 | Optional controller coverage in E2E | P1 | E2E | TP-239-005 | Pending |
+| BR-E2E-001 | CI drift guard for chart vs policy | P2 | CI | TP-239-006 | Pending |
+
+**E2E-FP-*** scenarios: Satisfied indirectly by **TP-239-003** (no change to existing scenario IDs in test sources).
+
+### Status Legend
+
+- **Pending**: Specification complete, implementation not started
+- **RED**: Failing test written (TDD RED phase)
+- **GREEN**: Minimal implementation passes (TDD GREEN phase)
+- **REFACTORED**: Code cleaned up (TDD REFACTOR phase)
+- **Pass**: Implemented and passing
+
+---
+
+## 8. Test Scenarios
+
+> **IEEE 829 Test Design Specification** — How test cases are organized and grouped.
+
+### Test ID Naming Convention
+
+This plan uses **TP-239-NNN** for plan-level scenario IDs (aligned with Issue #239). Where tests are implemented in Go with Ginkgo, developers may additionally use **E2E-FP-*** / existing suite labels; **no changes** to existing FullPipeline test file IDs are required by this issue.
+
+### Tier 1: Unit Tests (fast / deterministic)
+
+**Testable code scope**: Pure comparison logic for expected Deployments/Services/labels; optional wrapper around `helm template` output parsing (if kept in-process without cluster).
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| TP-239-001 | Operator can render the chart for E2E without template errors | Pending |
+| TP-239-002 | Rendered product resources match the current FullPipeline **product** component set (Deployments/Services expectations) | Pending |
+
+### Tier 2: Integration Tests
+
+**Testable code scope**: Subprocess or CI job invoking `helm template` / `helm install` against a test cluster fixture (if split from E2E).
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| *(optional)* | Same as TP-239-001/002 when implemented as shell-only CI without Go | Pending |
+
+### Tier 3: E2E Tests
+
+**Testable code scope**: Full Kind (or CI) cluster with FullPipeline infrastructure; five unchanged FullPipeline specs.
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| TP-239-003 | Full remediation lifecycle, approval, async hash, and KA target flows remain green | Pending |
+| TP-239-004 | Gateway reachable on **localhost:30080**, DataStorage on **localhost:30081** with chart overrides | Pending |
+| TP-239-005 | With `E2E_COVERAGE=true`, coverage artifacts produced for **all six** controllers | Pending |
+
+### Tier Skip Rationale (if any tier is omitted)
+
+- **Dedicated Tier 2**: Optional if TP-239-001/002 run only as Ginkgo-in-cluster or Makefile targets; rationale: single CI job may combine Tier 1 (render) and Tier 3 (E2E) for speed, documented in Section 13.
+
+---
+
+## 9. Test Cases
+
+> **IEEE 829 Test Case Specification** — Detailed specification for each test case.
+
+### TP-239-001: Helm template renders with values-e2e.yaml
+
+**BR**: BR-E2E-001  
+**Priority**: P0  
+**Type**: Unit / CI (deterministic)  
+**File**: TBD — e.g. `test/unit/infrastructure/helm_fullpipeline_test.go` or CI script invoked by `Makefile`
+
+**Preconditions**:
+
+- `helm` CLI available; chart path `charts/kubernaut/` present.
+- `values-e2e.yaml` exists (GREEN phase deliverable).
+
+**Test Steps**:
+
+1. **Given**: Clean worktree with chart and `values-e2e.yaml`.
+2. **When**: `helm template` (or project wrapper) runs with E2E values.
+3. **Then**: Exit code 0; no Helm render errors.
+
+**Expected Results**:
+
+1. Command completes successfully.
+2. Output contains expected top-level resources for the product stack (smoke-level assertion optional in same test or TP-239-002).
+
+**Acceptance Criteria**:
+
+- **Behavior**: Chart is valid for E2E consumption.
+- **Correctness**: No template/values coercion errors.
+
+**Dependencies**: None (first P0 gate). **TDD RED**: Add test before `values-e2e.yaml` exists → fails; **GREEN**: add values file + minimal chart hooks as needed.
+
+---
+
+### TP-239-002: Chart product set matches current E2E components
+
+**BR**: BR-E2E-001  
+**Priority**: P0  
+**Type**: Unit / CI  
+**File**: TBD — same package as TP-239-001 or shared helper
+
+**Preconditions**:
+
+- TP-239-001 passes.
+- Canonical list of **product** Deployments/Services (and key differences vs test-only) documented in code or fixture.
+
+**Test Steps**:
+
+1. **Given**: Rendered manifests from `helm template` with `values-e2e.yaml`.
+2. **When**: Parser extracts workload identity (kind, name, key labels).
+3. **Then**: Set equals expected product component set (allowing chart naming conventions if documented).
+
+**Expected Results**:
+
+1. No missing product Deployment/Service.
+2. No unexpected removal vs baseline snapshot (unless issue explicitly documents rename).
+
+**Acceptance Criteria**:
+
+- **Behavior**: Helm delivers the same **product** topology FullPipeline relied on.
+- **Accuracy**: Explicit exclusion of Mock LLM, Prometheus, AlertManager, event-exporter, mock-slack from the **chart** expectation set.
+
+**Dependencies**: TP-239-001. Mitigates **R2**, **R3** (via values assertions where static).
+
+---
+
+### TP-239-003: FullPipeline Ginkgo E2E regression
+
+**BR**: BR-E2E-001 / **E2E-FP-***  
+**Priority**: P0  
+**Type**: E2E  
+**File**: `test/e2e/fullpipeline/01_full_remediation_lifecycle_test.go`, `02_approval_lifecycle_test.go`, `02_async_hash_deferral_test.go`, `03_ka_target_resource_test.go` (**unchanged**), plus suite wiring
+
+**Preconditions**:
+
+- Cluster with FullPipeline infra applied via refactored `SetupFullPipelineInfrastructure`.
+- Test-only components (Mock LLM, Prom, AM, event-exporter, mock-slack) available per existing E2E design.
+
+**Test Steps**:
+
+1. **Given**: E2E environment variables and images as per CI.
+2. **When**: Run FullPipeline Ginkgo suite.
+3. **Then**: All specs pass.
+
+**Expected Results**:
+
+1. Zero failures; same business outcomes as pre-Helm refactor.
+
+**Acceptance Criteria**:
+
+- **Behavior**: End-to-end remediation scenarios unchanged for users/tests.
+- **Correctness**: No edits required to the five existing FullPipeline test files.
+
+**Dependencies**: TP-239-001/002 recommended before full CI dependency; **R1** ordering validated here.
+
+---
+
+### TP-239-004 through TP-239-006 (P1/P2 summary)
+
+| ID | Priority | Summary |
+|----|----------|---------|
+| TP-239-004 | P1 | With NodePort overrides, assert **localhost:30080** (Gateway) and **localhost:30081** (DataStorage) accept connections (or HTTP health) from the test runner. |
+| TP-239-005 | P1 | With `E2E_COVERAGE=true` and chart coverage toggle, assert coverage files for **six** controllers exist post-suite (exact path per implementation). |
+| TP-239-006 | P2 | CI job: drift guard on `helm template` output (RBAC rules, critical env vars, or diff vs golden) — mitigates **R5** and secret/env regressions. |
+
+---
+
+## 10. Environmental Needs
+
+> **IEEE 829 §13** — Hardware, software, tools, and infrastructure required.
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory) if implemented under `test/unit/...`
+- **Mocks**: N/A for pure manifest parsing; external **helm** binary may be invoked (document as test helper)
+- **Location**: TBD under `test/unit/` or `test/infrastructure/`
+- **Resources**: Minimal CPU/memory
+
+### 10.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega if integrated with envtest/cluster; otherwise Makefile/CI
+- **Mocks**: No mocks for Kubernetes — real cluster for full infra tests
+- **Infrastructure**: As today for FullPipeline
+- **Location**: `test/infrastructure/`, CI workflows
+
+### 10.3 E2E Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Infrastructure**: Kind (or project-standard cluster), Docker/Podman, Helm 3.x
+- **Location**: `test/e2e/fullpipeline/`
+- **Resources**: Sufficient disk for images; hostPath for coverage when enabled (**R4**)
+
+### 10.4 Tools & Versions
+
+| Tool | Minimum Version | Purpose |
+|------|-----------------|---------|
+| Go | Per `go.mod` | Build and test |
+| Ginkgo CLI | v2.x | E2E runner |
+| Helm | 3.x | Template and install |
+| Docker/Podman | Project standard | Cluster nodes |
+
+---
+
+## 11. Dependencies & Schedule
+
+> **IEEE 829 §12/§16** — Remaining tasks, blocking issues, and execution order.
+
+### 11.1 Blocking Dependencies
+
+| Dependency | Type | Status | Impact if Not Available | Workaround |
+|------------|------|--------|-------------------------|------------|
+| `values-e2e.yaml` | Config | Open until GREEN | TP-239-001 fails (RED expected) | None — deliver in GREEN |
+| Chart coverage extension | Code | Open until GREEN | TP-239-005 fails | Feature-flag off default installs |
+| CRD single-source (REFACTOR) | Process | May lag | R5 persists | TP-239-006 interim diff |
+
+### 11.2 Execution Order (TDD)
+
+1. **RED**: Add TP-239-001 test asserting `helm template` with `values-e2e.yaml` succeeds (**fails** until file exists).
+2. **GREEN**: Add `charts/kubernaut/values-e2e.yaml`; refactor `SetupFullPipelineInfrastructure` to **helm install/upgrade** product stack; `kubectl` (or existing helpers) for test-only; add `e2e.coverage.enabled` chart support; NodePort overrides **30080**/**30081**.
+3. **REFACTOR**: Remove redundant inline manifest builders; consolidate CRD source; add TP-239-006 drift guard.
+4. **Verification**: TP-239-002 → TP-239-003 → TP-239-004 → TP-239-005 → TP-239-006 (as prioritized).
+
+---
+
+## 12. Test Deliverables
+
+> **IEEE 829 §11** — What artifacts this test effort produces.
+
+| Deliverable | Location | Description |
+|-------------|----------|-------------|
+| This test plan | `docs/tests/239/TEST_PLAN.md` | Strategy and traceability |
+| `values-e2e.yaml` | `charts/kubernaut/values-e2e.yaml` | E2E overrides |
+| Helm template / parity tests | TBD (`test/unit/...` or CI) | TP-239-001, TP-239-002 |
+| Refactored infra | `test/infrastructure/fullpipeline_e2e.go` | Helm + test-only split |
+| Chart template updates | `charts/kubernaut/templates/**` | Optional E2E coverage |
+| Drift guard | CI workflow or script | TP-239-006 |
+| Coverage artifacts | CI artifacts | When TP-239-005 enabled |
+
+---
+
+## 13. Execution
+
+```bash
+# Helm render (P0 smoke)
+helm template kubernaut ./charts/kubernaut -f ./charts/kubernaut/values-e2e.yaml > /tmp/kubernaut-e2e.yaml
+
+# Unit / infra tests (paths TBD after implementation)
+go test ./test/unit/infrastructure/... -ginkgo.v
+
+# FullPipeline E2E (exact target may match Makefile)
+go test ./test/e2e/fullpipeline/... -ginkgo.v
+
+# Example: focus by description (adjust to project conventions)
+go test ./test/e2e/fullpipeline/... -ginkgo.focus="FullPipeline"
+```
+
+---
+
+## 14. Existing Tests Requiring Updates (if applicable)
+
+> When implementation changes behavior that existing tests assert on, document the
+> required updates here to prevent surprises during TDD GREEN phase.
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|--------------------|-------------------|-----------------|--------|
+| **None (target)** | — | — | Issue #239 acceptance: **five** existing FullPipeline E2E files must pass **unchanged**. All changes live in `test/infrastructure/fullpipeline_e2e.go`, chart, values, and **new** TP-239 tests. |
+
+If any existing file must change during implementation, update this table in the same PR with reviewer approval (exception to #239 constraint).
+
+---
+
+## 15. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-09 | Initial test plan for Issue #239 (Helm-based FullPipeline E2E) |

--- a/docs/tests/254/TEST_PLAN.md
+++ b/docs/tests/254/TEST_PLAN.md
@@ -1,0 +1,605 @@
+# Test Plan: Effectiveness Monitor — Reconciler Decomposition (Maintainability)
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+>
+> Based on IEEE 829-2008 (Standard for Software and System Test Documentation) with
+> Kubernaut-specific extensions for TDD phase tracking, business requirement traceability,
+> and per-tier coverage policy.
+
+**Test Plan Identifier**: TP-254-v1
+**Feature**: Pure structural refactor — split `internal/controller/effectivenessmonitor/reconciler.go` (~1868 lines, `Reconcile` ~527 lines) into focused files (<500 lines each) without behavior change
+**Version**: 1.0
+**Created**: 2026-04-09
+**Author**: Kubernaut Engineering
+**Status**: Draft
+**Branch**: `development/v1.3`
+
+---
+
+## 1. Introduction
+
+> **IEEE 829 §3** — Purpose, objectives, and measurable success criteria for the test effort.
+
+### 1.1 Purpose
+
+Issue #254 reduces risk and maintenance cost of the Effectiveness Monitor controller by decomposing an oversized reconciler into cohesive modules while **preserving identical observable behavior**: status fields, `ctrl.Result`, requeue timing, conditions, events, audit emissions, and metrics. This test plan defines **golden snapshots** and **invariant tests** that catch accidental semantic drift during extraction, and establishes **existing suites as the regression gate** (35 unit + 19 integration files unchanged).
+
+### 1.2 Objectives
+
+1. **Zero behavior drift**: Pre-refactor vs post-refactor `Reconcile` outcomes match for representative paths (WFP, Stabilizing, spec drift, partial scope grace).
+2. **Invariant preservation**: Exactly **one** `Status().Update` per happy-path reconcile where that invariant holds today; alert deferral requeue remains capped as today.
+3. **File-size compliance**: Target layout of 12 files, each under 500 lines (excluding generated code).
+4. **Regression gate**: All **35** existing unit test files and **19** integration test files pass **without modification** (pure refactor discipline).
+5. **Coverage policy**: Per-tier >=80%; primary evidence from existing tests; new tests target extracted helpers and golden paths.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/effectivenessmonitor/...` (+ any new UT files) |
+| Integration test pass rate | 100% | `go test ./test/integration/effectivenessmonitor/...` |
+| Unit-testable code coverage | >=80% | `go test -coverprofile` on EM controller packages |
+| Integration-testable code coverage | >=80% | `go test -coverprofile` on integration-testable EM code |
+| Existing test modification count | **0** files changed | `git diff --name-only test/` empty for unplanned edits |
+| Golden snapshot stability | Pass after REFACTOR | UT-EM-254-001–002 byte-stable or knowingly updated once with review |
+
+---
+
+## 2. References
+
+> **IEEE 829 §2** — Documents that govern or inform this test plan.
+
+### 2.1 Authority (governing documents)
+
+- BR-EM-001 through BR-EM-012: Effectiveness Monitor business requirements (scope per BR library)
+- BR-AUDIT-006: Audit event semantics for EM (as applicable to `emitAuditEvent` and related paths)
+- Issue #254: Decompose EM reconciler from ~1.9k lines
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../../.cursor/rules/03-testing-strategy.mdc)
+- [Test Case Specification Template](../../testing/TEST_CASE_SPECIFICATION_TEMPLATE.md)
+- [Integration/E2E No-Mocks Policy](../../testing/INTEGRATION_E2E_NO_MOCKS_POLICY.md)
+- [Testing Guidelines](../../development/business-requirements/TESTING_GUIDELINES.md)
+
+---
+
+## 3. Risks & Mitigations
+
+> **IEEE 829 §5** — Software risk issues that drive test design.
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | Status update ordering change | Flapping conditions, duplicate events, etcd write amplification | High | UT-EM-254-003, regression IT suite | Single orchestrated `reconcile_status.go`; assert one Update on happy path |
+| R2 | Shared local flags diverge (`componentsChanged`, `pendingTransition`, `alertDeferred`, `scope`) | Subtle behavior change across phases | High | UT-EM-254-001–006, all IT | Introduce `reconcileContext` struct in `reconcile_orchestrate.go`; golden tests |
+| R3 | Duplicate `ComputeDerivedTiming` blocks | Inconsistent requeue intervals | Medium | UT-EM-254-004 | REFACTOR consolidates timing; deferral cap tested explicitly |
+| R4 | Event / audit emission order change | Compliance or operator confusion | Medium | UT-EM-254-001–002, BR-AUDIT-006 mapping | Snapshot includes event list ordering where stable |
+| R5 | “Pure refactor” scope creep | New behavior slips in | Medium | Regression gate | Code review + zero existing test file edits policy |
+
+### 3.1 Risk-to-Test Traceability
+
+- **R1**: UT-EM-254-003 + full integration regression
+- **R2**: UT-EM-254-001–006 + `reconcileContext` code review checklist
+- **R3**: UT-EM-254-004
+- **R4**: UT-EM-254-001–002 (events in snapshot), BR-AUDIT-006 row in Section 7
+
+---
+
+## 4. Scope
+
+> **IEEE 829 §6/§7** — Features to be tested and features not to be tested.
+
+### 4.1 Features to be Tested
+
+- **Decomposed EM reconciler** (`internal/controller/effectivenessmonitor/`):
+  1. `reconciler.go` — core type, DI, thin `Reconcile`
+  2. `reconcile_orchestrate.go` — `reconcileContext` + main flow
+  3. `reconcile_validity_phase.go` — WFP / Stabilizing / Assessing transitions
+  4. `reconcile_spec_drift.go` — hash mismatch / `AssessmentReasonSpecDrift`
+  5. `reconcile_components.go` — hash / health / alert / metrics pipeline
+  6. `reconcile_status.go` — atomic `Status().Update` + post-update events
+  7. `assess_components.go` — assessHealth / Hash / Alert / Metrics
+  8. `target_resources.go` — `getTargetSpec`, health status, ConfigMap hashes
+  9. `pod_health.go` — `FilterActivePods`, `ComputePodHealthStats` (**remain exported**)
+  10. `completion.go` — complete/fail assessment, reason mapping
+  11. `events.go` — all `emit*` + `emitAuditEvent`
+  12. `scope.go` — `assessmentScope`, `determineAssessmentScope`, `validateEASpec`
+
+### 4.2 Features Not to be Tested
+
+- **Functional EM feature additions**: No new BR scope beyond decomposition
+- **Cross-controller refactors**: WE, RO, DS out of scope
+- **Performance benchmarking**: Unless regression detected by existing metrics tests
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| 12 files, <500 lines each | Meets readability goals; aligns with single responsibility |
+| `reconcileContext` for shared state | Prevents accidental parameter drift vs many locals |
+| Golden snapshots before GREEN | RED captures baseline; failures during extract signal regression |
+| No edits to existing 35+19 test files | Enforces “pure refactor” contract |
+
+---
+
+## 5. Approach
+
+> **IEEE 829 §8/§9/§10** — Test strategy, pass/fail criteria, and suspension/resumption.
+
+### 5.1 Coverage Policy
+
+**Authority**: `03-testing-strategy.mdc` — Per-Tier Testable Code Coverage.
+
+- **Unit**: >=80% of unit-testable EM controller logic; **existing 35 files** are primary; new golden/helper tests add targeted coverage
+- **Integration**: >=80% of integration-testable EM surfaces; **existing 19 files** unchanged
+- **E2E**: Not expanded for #254; integration + unit provide sufficient safety for internal split
+
+### 5.2 Two-Tier Minimum
+
+- **Unit**: Golden snapshots + invariants (status update count, requeue cap)
+- **Integration**: Full existing suite as regression gate (no mocks policy unchanged)
+
+### 5.3 Business Outcome Quality Bar
+
+Operators and auditors observe **the same** assessment progression, conditions, deferral behavior, and audit trail as before decomposition.
+
+### 5.4 Pass/Fail Criteria
+
+**PASS** — all of the following must be true:
+
+1. UT-EM-254-001 through UT-EM-254-006 pass
+2. **All** existing EM unit + integration tests pass with **zero** test file modifications (except **new** files added for RED)
+3. Per-tier coverage >=80% on scoped packages
+4. No new linter suppressions without justification
+
+**FAIL** — any of the following:
+
+1. Any golden snapshot mismatch without reviewed baseline update
+2. More than one `Status().Update` on happy path where UT-EM-254-003 asserts one
+3. Any pre-existing test file edited to “make refactor pass” (violates pure refactor rule)
+4. Coverage drop below 80% on any tier for EM scope
+
+### 5.5 Suspension & Resumption Criteria
+
+**Suspend testing when**:
+
+- `main` / target branch does not compile
+- Baseline snapshots not captured (RED incomplete)
+- Widespread flaky IT (>3 unrelated flakes in one run)
+
+**Resume testing when**:
+
+- Build green
+- Baseline stored in repo with review
+- Infra stable
+
+---
+
+## 6. Test Items
+
+> **IEEE 829 §4** — Software items to be tested, with version identification.
+
+### 6.1 Unit-Testable Code (pure logic, no I/O)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|----------------|
+| `internal/controller/effectivenessmonitor/reconcile_validity_phase.go` | Phase transition helpers | <500 |
+| `internal/controller/effectivenessmonitor/reconcile_spec_drift.go` | Spec drift detection | <500 |
+| `internal/controller/effectivenessmonitor/assess_components.go` | Assessment helpers | <500 |
+| `internal/controller/effectivenessmonitor/pod_health.go` | `FilterActivePods`, `ComputePodHealthStats` | <500 |
+| `internal/controller/effectivenessmonitor/completion.go` | Completion / fail mapping | <500 |
+| `internal/controller/effectivenessmonitor/scope.go` | Scope validation | <500 |
+
+### 6.2 Integration-Testable Code (I/O, wiring, cross-component)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|----------------|
+| `internal/controller/effectivenessmonitor/reconciler.go` | Thin `Reconcile` entry | <500 |
+| `internal/controller/effectivenessmonitor/reconcile_orchestrate.go` | Main orchestration | <500 |
+| `internal/controller/effectivenessmonitor/reconcile_components.go` | Component pipeline | <500 |
+| `internal/controller/effectivenessmonitor/reconcile_status.go` | Status update + events | <500 |
+| `internal/controller/effectivenessmonitor/target_resources.go` | Target resolution | <500 |
+| `internal/controller/effectivenessmonitor/events.go` | Event emission | <500 |
+
+### 6.3 Version Identification
+
+| Item | Version/Commit | Notes |
+|------|----------------|-------|
+| Code under test | `development/v1.3` HEAD | #254 branch |
+| Pre-refactor baseline | Git tag or commit hash | Record when snapshots taken |
+| Existing tests | 35 UT + 19 IT files | Enumeration in CI job optional |
+
+---
+
+## 7. BR Coverage Matrix
+
+> Kubernaut-specific. Maps business requirements to test scenarios.
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-EM-001–012 | EM assessment lifecycle & components | P0 | Unit | UT-EM-254-001–006 | Pending |
+| BR-EM-001–012 | EM assessment lifecycle & components | P0 | Integration | Regression: 19 IT files | Pending |
+| BR-AUDIT-006 | Audit events | P0 | Unit | UT-EM-254-001–002 (events/audit in snapshot) | Pending |
+| BR-AUDIT-006 | Audit events | P1 | Integration | Regression IT suite | Pending |
+
+### Status Legend
+
+- **Pending**: Specification complete, implementation not started
+- **RED**: Failing test written (TDD RED phase)
+- **GREEN**: Minimal implementation passes (TDD GREEN phase)
+- **REFACTOR**: Code cleaned up (TDD REFACTOR phase)
+- **Pass**: Implemented and passing
+
+---
+
+## 8. Test Scenarios
+
+> **IEEE 829 Test Design Specification** — How test cases are organized and grouped.
+
+### Test ID Naming Convention
+
+Format: `{TIER}-{SERVICE}-{ISSUE}-{SEQUENCE}` — **EM** service, Issue **254**.
+
+### Tier 1: Unit Tests
+
+**Testable code scope**: EM controller packages post-split — >=80% merged with existing coverage.
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-EM-254-001` | Golden snapshot — **WFP** path: status + `Result` + events match baseline | Pending |
+| `UT-EM-254-002` | Golden snapshot — **Stabilizing** path preserved | Pending |
+| `UT-EM-254-003` | **One** `Status().Update` per happy-path reconcile | Pending |
+| `UT-EM-254-004` | Alert deferral requeue — capped timing preserved | Pending |
+| `UT-EM-254-005` | Spec drift early exit — `AssessmentReasonSpecDrift`, same conditions/events | Pending |
+| `UT-EM-254-006` | Partial scope grace — DS partial scope, health+hash done, grace requeue | Pending |
+
+### Tier 2: Integration Tests
+
+**Testable code scope**: **Regression gate** — all 19 existing integration test files.
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `REGRESSION-EM-254-IT` | All existing IT files pass unchanged | Pending |
+
+### Tier 3: E2E Tests (if applicable)
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| — | Not expanded for #254 | N/A |
+
+### Tier Skip Rationale (if any tier is omitted)
+
+- **E2E**: Existing EM E2E (if any) unchanged; decomposition is internal to controller binary.
+
+---
+
+## 9. Test Cases
+
+> **IEEE 829 Test Case Specification** — Detailed specification for each test case.
+
+### UT-EM-254-001: Golden snapshot — WFP path
+
+**BR**: BR-EM-001–012 (representative)
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/effectivenessmonitor/reconciler_golden_wfp_test.go` (new file only)
+
+**Preconditions**:
+
+- Baseline captured **before** file extraction (RED phase) using fixed fixture EA object + fake client setup consistent with existing EM unit patterns
+
+**Test Steps**:
+
+1. **Given**: Seeded `EffectivenessAssessment` (or equivalent CR) and dependencies for **WaitingForPods** / WFP path
+2. **When**: `Reconcile` executes once
+3. **Then**: Serialized snapshot of selected status fields, `ctrl.Result`, and emitted events matches stored golden file
+
+**Expected Results**:
+
+1. Golden file match (or intentional update with PR justification)
+2. No extra unexpected event types
+
+**Acceptance Criteria**:
+
+- **Behavior**: WFP transitions unchanged
+- **Correctness**: Field-level equality for chosen snapshot schema
+- **Accuracy**: Event order stable or normalized per snapshot design doc in test file comment
+
+**Dependencies**: None
+
+---
+
+### UT-EM-254-002: Golden snapshot — Stabilizing path
+
+**BR**: BR-EM-001–012
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/effectivenessmonitor/reconciler_golden_stabilizing_test.go` (new)
+
+**Preconditions**:
+
+- Fixture drives reconciler into **Stabilizing** phase (per current EM semantics)
+
+**Test Steps**:
+
+1. **Given**: Stabilizing fixture
+2. **When**: `Reconcile` runs
+3. **Then**: Snapshot matches baseline
+
+**Expected Results**:
+
+1. Golden match for status + Result + events
+2. Requeue duration consistent with baseline if part of snapshot
+
+**Acceptance Criteria**:
+
+- **Behavior**: Stabilizing logic unchanged post-split
+- **Correctness**: Same conditions and phase fields as baseline
+- **Accuracy**: Metrics hooks (if in snapshot) unchanged
+
+**Dependencies**: UT-EM-254-001 infrastructure (shared helpers)
+
+---
+
+### UT-EM-254-003: Atomic status update count
+
+**BR**: BR-EM-001–012
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/effectivenessmonitor/reconciler_status_invariant_test.go` (new)
+
+**Preconditions**:
+
+- Fake client tracks `Update` calls to `EffectivenessAssessment` status subresource (pattern aligned with existing EM tests)
+
+**Test Steps**:
+
+1. **Given**: Happy-path fixture (no error injection)
+2. **When**: Single `Reconcile`
+3. **Then**: Exactly **one** status update observed
+
+**Expected Results**:
+
+1. `Update` count == 1
+2. Optional: Subresource path matches `Status()` writer
+
+**Acceptance Criteria**:
+
+- **Behavior**: No accidental double patch of status
+- **Correctness**: Matches pre-refactor invariant
+- **Accuracy**: If exception paths exist, separate test documents >1 updates only where pre-existing
+
+**Dependencies**: UT-EM-254-001
+
+---
+
+### UT-EM-254-004: Alert deferral requeue cap
+
+**BR**: BR-EM-001–012
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/effectivenessmonitor/reconciler_alert_deferral_test.go` (new)
+
+**Preconditions**:
+
+- Fixture forces alert deferral branch (`alertDeferred`) with capped backoff
+
+**Test Steps**:
+
+1. **Given**: Deferral scenario
+2. **When**: `Reconcile` returns
+3. **Then**: `Result.RequeueAfter` (or equivalent) equals baseline cap
+
+**Expected Results**:
+
+1. Requeue duration matches golden or explicit constant from pre-refactor commit
+2. No unbounded exponential growth beyond cap
+
+**Acceptance Criteria**:
+
+- **Behavior**: Operator-facing deferral timing unchanged
+- **Correctness**: Exact duration equality vs baseline
+- **Accuracy**: Document clock assumptions (no real sleep)
+
+**Dependencies**: None
+
+---
+
+### UT-EM-254-005: Spec drift early exit
+
+**BR**: BR-EM-001–012
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/effectivenessmonitor/reconciler_spec_drift_test.go` (new)
+
+**Preconditions**:
+
+- Spec hash mismatch vs status / expected hash to trigger `AssessmentReasonSpecDrift`
+
+**Test Steps**:
+
+1. **Given**: Drifted spec vs recorded hash
+2. **When**: `Reconcile` runs
+3. **Then**: Early exit with `AssessmentReasonSpecDrift`; conditions and events match snapshot
+
+**Expected Results**:
+
+1. Reason field matches
+2. No full component pipeline side effects beyond documented early exit
+
+**Acceptance Criteria**:
+
+- **Behavior**: Same early-exit semantics as monolith
+- **Correctness**: Condition types/status/reason stable
+- **Accuracy**: Events include same audit markers if applicable (BR-AUDIT-006)
+
+**Dependencies**: UT-EM-254-001 snapshot harness
+
+---
+
+### UT-EM-254-006: Partial scope grace
+
+**BR**: BR-EM-001–012
+**Priority**: P1
+**Type**: Unit
+**File**: `test/unit/effectivenessmonitor/reconciler_partial_scope_test.go` (new)
+
+**Preconditions**:
+
+- DS **partial scope**: health + hash complete; grace period triggers requeue
+
+**Test Steps**:
+
+1. **Given**: Partial scope fixture with grace timer
+2. **When**: `Reconcile` runs
+3. **Then**: Grace requeue and intermediate status match baseline
+
+**Expected Results**:
+
+1. Same `pendingTransition` / scope-related fields as pre-refactor
+2. Requeue honors grace
+
+**Acceptance Criteria**:
+
+- **Behavior**: No premature completion under partial scope
+- **Correctness**: Same branch as monolith for `scope` locals factored into `reconcileContext`
+- **Accuracy**: Aligns with `scope.go` extraction
+
+**Dependencies**: UT-EM-254-001
+
+---
+
+### REGRESSION-EM-254-IT: All integration tests unchanged
+
+**BR**: BR-EM-001–012, BR-AUDIT-006
+**Priority**: P0
+**Type**: Integration (suite)
+**File**: Existing `test/integration/effectivenessmonitor/**/*.go` (**no edits**)
+
+**Preconditions**:
+
+- CI or local env per existing EM integration docs
+
+**Test Steps**:
+
+1. **Given**: Post-refactor binary
+2. **When**: `go test ./test/integration/effectivenessmonitor/...`
+3. **Then**: All tests pass; **zero** changes to test sources
+
+**Expected Results**:
+
+1. 19 integration files pass unchanged
+2. No new `-ginkgo.skip` or pending specs
+
+**Acceptance Criteria**:
+
+- **Behavior**: External EM behavior unchanged
+- **Correctness**: Full IT suite green
+- **Accuracy**: proves wiring across new files
+
+**Dependencies**: GREEN + REFACTOR complete
+
+---
+
+## 10. Environmental Needs
+
+> **IEEE 829 §13** — Hardware, software, tools, and infrastructure required.
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: External deps only; use existing fake client patterns from EM unit tests
+- **Location**: `test/unit/effectivenessmonitor/` (**new files only** for #254)
+- **Resources**: Standard CI
+
+### 10.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: Per [INTEGRATION_E2E_NO_MOCKS_POLICY.md](../../testing/INTEGRATION_E2E_NO_MOCKS_POLICY.md)
+- **Infrastructure**: Same as current EM integration (envtest / cluster per suite)
+- **Location**: `test/integration/effectivenessmonitor/`
+- **Resources**: Unchanged from baseline
+
+### 10.3 E2E Tests (if applicable)
+
+- Not expanded for #254.
+
+### 10.4 Tools & Versions
+
+| Tool | Minimum Version | Purpose |
+|------|-----------------|---------|
+| Go | Project `go.mod` | Build and test |
+| Ginkgo CLI | v2.x | BDD runner |
+
+---
+
+## 11. Dependencies & Schedule
+
+> **IEEE 829 §12/§16** — Remaining tasks, blocking issues, and execution order.
+
+### 11.1 Blocking Dependencies
+
+| Dependency | Type | Status | Impact if Not Available | Workaround |
+|------------|------|--------|-------------------------|------------|
+| Stable pre-refactor commit | Git | Required for baseline | Cannot diff golden | Tag commit before first extraction |
+| EM fake client patterns | Code | Existing | Slower test authoring | Reuse helpers from current UTs |
+
+### 11.2 Execution Order (TDD)
+
+1. **RED**: Add UT-EM-254-001–006 (**new files only**); capture golden files from monolith reconciler
+2. **GREEN**: Extract files/methods per proposed layout; keep **all** tests green without editing existing 35+19 files
+3. **REFACTOR**: Rename for clarity; remove duplicate `ComputeDerivedTiming` blocks; consolidate; re-run full suite
+
+---
+
+## 12. Test Deliverables
+
+> **IEEE 829 §11** — What artifacts this test effort produces.
+
+| Deliverable | Location | Description |
+|-------------|----------|-------------|
+| This test plan | `docs/tests/254/TEST_PLAN.md` | Strategy |
+| New unit tests | `test/unit/effectivenessmonitor/*_test.go` | Golden + invariant tests |
+| Golden files | `test/unit/effectivenessmonitor/testdata/` (TBD) | Serialized baselines |
+| Decomposed source | `internal/controller/effectivenessmonitor/*.go` | 12 files |
+| Coverage report | CI | >=80% per tier |
+
+---
+
+## 13. Execution
+
+```bash
+# New golden / invariant tests
+go test ./test/unit/effectivenessmonitor/... -ginkgo.v
+
+# Full unit regression (35 files — count may vary; run full package)
+go test ./test/unit/effectivenessmonitor/... -ginkgo.v
+
+# Integration regression (19 files)
+go test ./test/integration/effectivenessmonitor/... -ginkgo.v
+
+# Focus single ID
+go test ./test/unit/effectivenessmonitor/... -ginkgo.focus="UT-EM-254-001"
+
+# Coverage
+go test ./internal/controller/effectivenessmonitor/... -coverprofile=coverage-em.out
+go tool cover -func=coverage-em.out
+```
+
+---
+
+## 14. Existing Tests Requiring Updates (if applicable)
+
+> **Pure refactor rule**: **None** by design. If a test file appears to “need” a change, treat it as a **behavior change** and stop — revert extraction hunk and fix production code.
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|-------------------|-------------------|-----------------|--------|
+| — | — | — | No modifications to existing tests |
+
+---
+
+## 15. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-09 | Initial test plan for Issue #254 |

--- a/docs/tests/485/TEST_PLAN.md
+++ b/docs/tests/485/TEST_PLAN.md
@@ -1,0 +1,594 @@
+# Test Plan: Audit Event Retention Enforcement (#485)
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+>
+> Based on IEEE 829-2008 (Standard for Software and System Test Documentation) with
+> Kubernaut-specific extensions for TDD phase tracking, business requirement traceability,
+> and per-tier coverage policy.
+
+**Test Plan Identifier**: TP-485-v1.0
+**Feature**: Time-based audit event retention with per-event `retention_days` (default 2555 / ~7 years), `legal_hold` exemption, category policies via `audit_retention_policies`, structured logging in `retention_operations`, optional partition drops when enabled by Helm (opt-in, **disabled by default**)
+**Version**: 1.0
+**Created**: 2026-04-09
+**Author**: AI Assistant
+**Status**: Draft
+**Branch**: `development/v1.3`
+
+---
+
+## 1. Introduction
+
+> **IEEE 829 §3** — Purpose, objectives, and measurable success criteria for the test effort.
+
+### 1.1 Purpose
+
+This test plan validates Issue #485: enforcing audit data retention while respecting **legal hold** (`legal_hold=TRUE` blocks deletion via trigger `prevent_legal_hold_deletion`) and policy precedence (`audit_retention_policies` vs per-event values). The `retention_operations` table exists but foreign key relationships (e.g., to `action_histories`) may require schema change without backward-compatible constraint — human decision: **schema may be modified freely** to support retention logging. Efficient partition drops depend on Issues **#235/#620** (automated partition management). Retention worker is **disabled by default** (Helm flag) and **opt-in**.
+
+### 1.2 Objectives
+
+1. **Eligibility**: Rows are eligible for purge when `event_timestamp + retention_days < now` (UTC), absent legal hold and subject to policy merge rules.
+2. **Legal hold**: Time-eligible rows with `legal_hold=true` are **never** deleted.
+3. **Policy merge**: Defaults vs per-category / per-event overrides behave per BR-AUDIT-009.
+4. **Safe default**: With flag **off**, **no** deletes occur (P0).
+5. **Purge correctness**: Synthetic expired rows removed; mixed months delete only eligible subset.
+6. **Partition path**: When all rows in a month partition are expired and none held, **DROP PARTITION** path works.
+7. **Audit trail**: Each run writes structured records to `retention_operations`.
+8. **Scheduling**: Short-interval behavior validated via injected clock/ticker in tests.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/...` (retention package) |
+| Integration test pass rate | 100% | `go test ./test/integration/...` with real Postgres |
+| Unit-testable code coverage | >=80% | Eligibility predicate, policy merge, scheduling math |
+| Integration-testable code coverage | >=80% | Worker, SQL DELETE, partition drop, operation log |
+| Safety | Zero deletes with flag off | IT-DS-485-001 |
+
+---
+
+## 2. References
+
+> **IEEE 829 §2** — Documents that govern or inform this test plan.
+
+### 2.1 Authority (governing documents)
+
+- BR-AUDIT-009: Retention policies for audit data
+- BR-AUDIT-004: Immutability / integrity of audit records (holds, no silent loss)
+- Issue #485: Audit event retention enforcement
+- Issue #235 / #620: Partition creation (enables efficient partition drops)
+- Schema: `retention_days`, `legal_hold`, `audit_retention_policies`, `retention_operations`, trigger `prevent_legal_hold_deletion`
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../../.cursor/rules/03-testing-strategy.mdc)
+- [Test Case Specification Template](../../testing/TEST_CASE_SPECIFICATION_TEMPLATE.md)
+- [Integration/E2E No-Mocks Policy](../../testing/INTEGRATION_E2E_NO_MOCKS_POLICY.md)
+- [Testing Guidelines](../../development/business-requirements/TESTING_GUIDELINES.md)
+
+---
+
+## 3. Risks & Mitigations
+
+> **IEEE 829 §5** — Software risk issues that drive test design.
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | Accidental production purge | Data loss / legal exposure | High | IT-DS-485-001 | Default off; P0 proves no deletes |
+| R2 | Legal hold bypass | Compliance violation | High | IT-DS-485-003 | Integration with trigger + app filter |
+| R3 | Partition DROP too aggressive | Drops month with held rows | High | IT-DS-485-004, IT-DS-485-005 | Pre-check holds; mixed-month row delete |
+| R4 | Clock skew | Wrong eligibility | Medium | UT-DS-485-001, IT-DS-485-007 | Injected clock; UTC |
+| R5 | `retention_operations` FK blocks logging | Worker fails mid-run | Medium | IT-DS-485-006 | Schema change per human decision |
+
+### 3.1 Risk-to-Test Traceability
+
+- **R1**: IT-DS-485-001 (flag off).
+- **R2**: IT-DS-485-003 + trigger interaction.
+- **R3**: IT-DS-485-004 / IT-DS-485-005.
+- **R5**: IT-DS-485-006 asserts successful inserts per run.
+
+---
+
+## 4. Scope
+
+> **IEEE 829 §6/§7** — Features to be tested and features not to be tested.
+
+### 4.1 Features to be Tested
+
+- **Eligibility predicate** (pure): timestamp + retention vs now; legal hold; policy merge.
+- **Configurable worker**: Helm flag gating; ticker/interval; batch DELETE SQL with hold filter.
+- **Partition drop path**: When #235/#620 partitions exist and month fully eligible.
+- **retention_operations**: Structured operation log each run.
+- **Legal hold trigger**: DELETE blocked at DB layer when `legal_hold=TRUE`.
+
+### 4.2 Features Not to be Tested
+
+- **Non-audit tables**: Unless BR explicitly extends scope.
+- **Cross-region replication lag**: Operational concern; not simulated here.
+- **E2E full Helm lifecycle**: Covered by integration + chart values unit tests if present; full cluster E2E optional/deferred.
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Disabled by default | Safety / BR-AUDIT-004 alignment |
+| Schema changes allowed for `retention_operations` | Human decision; unblock logging |
+| Depend on #235/#620 | Partition drop efficiency |
+| Repository + metrics in REFACTOR | Clean boundaries after GREEN |
+
+---
+
+## 5. Approach
+
+> **IEEE 829 §8/§9/§10** — Test strategy, pass/fail criteria, and suspension/resumption.
+
+### 5.1 Coverage Policy
+
+**Authority**: `03-testing-strategy.mdc` — Per-Tier Testable Code Coverage.
+
+- **Unit**: >=80% eligibility, policy merge, schedule helpers.
+- **Integration**: >=80% worker, SQL, partition ops, logging — real Postgres, mock time via injected clock in process.
+
+### 5.2 Two-Tier Minimum
+
+BR-AUDIT-009 and BR-AUDIT-004 covered by **UT** (rules) + **IT** (DB + trigger + worker).
+
+### 5.3 Business Outcome Quality Bar
+
+Validate: “No silent data loss; holds honored; retention runs auditable; opt-in only.”
+
+### 5.4 Pass/Fail Criteria
+
+**PASS** — all of:
+
+1. P0 integration tests pass: IT-DS-485-001, IT-DS-485-002, IT-DS-485-003.
+2. Unit tests UT-DS-485-001–003 pass.
+3. Coverage >=80% on retention modules.
+4. `retention_operations` receives expected rows in IT-DS-485-006.
+
+**FAIL** — any of:
+
+1. Deletes occur with flag off.
+2. Held row deleted or partition dropped while held rows exist.
+3. Eligibility unit tests disagree with SQL filter semantics.
+
+### 5.5 Suspension & Resumption Criteria
+
+**Suspend**: #235 not landed when implementing partition DROP IT; Postgres down; schema migration conflict.
+**Resume**: Partitions available; migrations applied; build green.
+
+---
+
+## 6. Test Items
+
+> **IEEE 829 §4** — Software items to be tested, with version identification.
+
+### 6.1 Unit-Testable Code (pure logic, no I/O)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| TBD `pkg/datastorage/.../retention*.go` | `IsEligibleForPurge`, policy merge | TBD |
+| TBD | Schedule window calculator (with injected clock) | TBD |
+
+### 6.2 Integration-Testable Code (I/O, wiring, cross-component)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| TBD worker | Ticker loop, batch delete, partition drop | TBD |
+| `cmd/data-storage/main.go` (or worker cmd) | Flag wiring, start/stop | TBD |
+
+### 6.3 Version Identification
+
+| Item | Version/Commit | Notes |
+|------|----------------|-------|
+| Schema | Migrations HEAD | `retention_operations` FK may change |
+| Partitions | #235/#620 | Required for IT-DS-485-004 |
+
+---
+
+## 7. BR Coverage Matrix
+
+> Kubernaut-specific. Maps every business requirement to test scenarios across tiers.
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-AUDIT-009 | Retention policies / eligibility | P0 | Unit | UT-DS-485-001, UT-DS-485-002, UT-DS-485-003 | Pending |
+| BR-AUDIT-004 | Integrity / no improper deletion | P0 | Integration | IT-DS-485-001, IT-DS-485-003 | Pending |
+| BR-AUDIT-009 | Expired row removal | P0 | Integration | IT-DS-485-002 | Pending |
+| BR-AUDIT-009 | Partition efficiency | P1 | Integration | IT-DS-485-004 | Pending |
+| BR-AUDIT-004 | Mixed eligibility | P1 | Integration | IT-DS-485-005 | Pending |
+| BR-AUDIT-009 | Retention operations log | P1 | Integration | IT-DS-485-006 | Pending |
+| BR-AUDIT-009 | Scheduled runs | P1 | Integration | IT-DS-485-007 | Pending |
+
+### Status Legend
+
+- **Pending**: Specification complete, implementation not started
+- **RED**: Failing test written (TDD RED phase)
+- **GREEN**: Minimal implementation passes (TDD GREEN phase)
+- **REFACTORED**: Code cleaned up (TDD REFACTOR phase)
+- **Pass**: Implemented and passing
+
+---
+
+## 8. Test Scenarios
+
+> **IEEE 829 Test Design Specification** — How test cases are organized and grouped.
+
+### Test ID Naming Convention
+
+Format: `{TIER}-DS-{ISSUE}-{SEQUENCE}`.
+
+### Tier 1: Unit Tests
+
+**Testable code scope**: Eligibility predicate, legal hold exemption in logic layer, policy precedence — >=80%.
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-DS-485-001` | `event_timestamp + retention_days < now` ⇒ eligible (baseline) | Pending |
+| `UT-DS-485-002` | Time-eligible but `legal_hold=true` ⇒ **not** eligible | Pending |
+| `UT-DS-485-003` | Category policy merge: default vs per-event override precedence | Pending |
+
+### Tier 2: Integration Tests
+
+**Testable code scope**: Worker, SQL, partitions, `retention_operations`, Helm flag — >=80%.
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `IT-DS-485-001` (P0) | Flag off ⇒ **no** deletes | Pending |
+| `IT-DS-485-002` (P0) | Synthetic old event, `legal_hold=false` ⇒ row removed | Pending |
+| `IT-DS-485-003` (P0) | Expired + `legal_hold=true` ⇒ row remains | Pending |
+| `IT-DS-485-004` | Partition drop: month fully expired, no holds ⇒ DROP partition | Pending |
+| `IT-DS-485-005` | Mixed month: DELETE eligible only | Pending |
+| `IT-DS-485-006` | Each run writes structured record to `retention_operations` | Pending |
+| `IT-DS-485-007` | Short interval via injected clock/ticker | Pending |
+
+### Tier 3: E2E Tests (if applicable)
+
+Not required for core retention semantics; integration with Postgres is sufficient.
+
+### Tier Skip Rationale (if any tier is omitted)
+
+- **E2E**: Opt-in Helm flag and worker behavior validated via IT + config unit tests.
+
+---
+
+## 9. Test Cases
+
+> **IEEE 829 Test Case Specification** — Detailed specification for each test case.
+
+### UT-DS-485-001: Eligibility predicate — time expired
+
+**BR**: BR-AUDIT-009
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/datastorage/...`
+
+**Preconditions**:
+- Fixed `now` from clock interface.
+
+**Test Steps**:
+1. **Given**: `event_timestamp` and `retention_days` such that `event_timestamp + retention_days < now`, `legal_hold=false`, default policy.
+2. **When**: Predicate evaluated.
+3. **Then**: Eligible == true.
+
+**Expected Results**:
+1. Matches SQL `WHERE` filter semantics used by worker.
+
+**Acceptance Criteria**:
+- **Correctness**: Aligns with DELETE statement boundary (strict vs non-strict per design).
+
+**Dependencies**: None.
+
+---
+
+### UT-DS-485-002: Legal hold exemption
+
+**BR**: BR-AUDIT-009 / BR-AUDIT-004
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/datastorage/...`
+
+**Test Steps**:
+1. **Given**: Time-eligible row attributes with `legal_hold=true`.
+2. **When**: Predicate evaluated.
+3. **Then**: Eligible == false.
+
+**Expected Results**:
+1. Predicate excludes row even if timestamp old.
+
+**Acceptance Criteria**:
+- **Behavior**: Hold always wins in application layer (defense in depth with DB trigger).
+
+**Dependencies**: None.
+
+---
+
+### UT-DS-485-003: Category policy merge
+
+**BR**: BR-AUDIT-009
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/datastorage/...`
+
+**Test Steps**:
+1. **Given**: `audit_retention_policies` default retention X; per-event or category override Y.
+2. **When**: Effective retention computed.
+3. **Then**: Precedence matches BR (document expected: override wins or default wins — **implement per BR text**).
+
+**Expected Results**:
+1. Table-driven cases for default-only, override-only, conflict.
+
+**Acceptance Criteria**:
+- **Accuracy**: Effective retention matches product rules.
+
+**Dependencies**: BR-AUDIT-009 exact precedence table.
+
+---
+
+### IT-DS-485-001 (P0): Disabled by default
+
+**BR**: BR-AUDIT-004
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/datastorage/...`
+
+**Preconditions**:
+- Config/Helm values: retention worker **disabled**; DB contains synthetic expired rows.
+
+**Test Steps**:
+1. **Given**: Worker started with flag off (or not started).
+2. **When**: Observation window elapses / tick fired in no-op mode.
+3. **Then**: Row counts unchanged; `retention_operations` has no new run rows (or worker never connects).
+
+**Expected Results**:
+1. Zero DELETEs executed.
+
+**Acceptance Criteria**:
+- **Safety**: Opt-in contract honored.
+
+**Dependencies**: Config wiring.
+
+---
+
+### IT-DS-485-002 (P0): Expired row delete
+
+**BR**: BR-AUDIT-009
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/datastorage/...`
+
+**Preconditions**:
+- Flag **on**; synthetic row with old `event_timestamp`, `legal_hold=false`.
+
+**Test Steps**:
+1. **Given**: Row inserted and visible.
+2. **When**: Retention worker runs one cycle with `now` injected forward.
+3. **Then**: Row no longer present; other non-eligible rows remain.
+
+**Expected Results**:
+1. `SELECT` returns 0 for primary key.
+
+**Acceptance Criteria**:
+- **Behavior**: Purge works end-to-end.
+
+**Dependencies**: IT-DS-485-001 inverse (flag on).
+
+---
+
+### IT-DS-485-003 (P0): Legal hold — row remains
+
+**BR**: BR-AUDIT-004
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/datastorage/...`
+
+**Preconditions**:
+- Expired row with `legal_hold=true`; trigger `prevent_legal_hold_deletion` installed.
+
+**Test Steps**:
+1. **Given**: Eligible by time only.
+2. **When**: Worker attempts delete (or direct SQL mirrors worker).
+3. **Then**: Row still exists; DB may raise on direct delete — app must not remove held rows.
+
+**Expected Results**:
+1. Count unchanged; optional assert error on naive DELETE (if test uses direct SQL).
+
+**Acceptance Criteria**:
+- **Integrity**: Hold enforced.
+
+**Dependencies**: Schema trigger.
+
+---
+
+### IT-DS-485-004: Partition drop path
+
+**BR**: BR-AUDIT-009
+**Priority**: P1
+**Type**: Integration
+**File**: `test/integration/datastorage/...`
+
+**Preconditions**:
+- #235/#620 partitions exist; target month partition contains only eligible rows, none held.
+
+**Test Steps**:
+1. **Given**: Month partition ready for drop per implementation rules.
+2. **When**: Retention run executes partition drop branch.
+3. **Then**: Partition detached/dropped; parent remains healthy.
+
+**Expected Results**:
+1. `pg_inherits` / catalog reflects removal.
+
+**Acceptance Criteria**:
+- **Behavior**: Efficient reclaim path works.
+
+**Dependencies**: Issues #235 / #620.
+
+---
+
+### IT-DS-485-005: Mixed month
+
+**BR**: BR-AUDIT-004
+**Priority**: P1
+**Type**: Integration
+**File**: `test/integration/datastorage/...`
+
+**Test Steps**:
+1. **Given**: Same month partition with mix of eligible and held (or ineligible) rows.
+2. **When**: Row-level DELETE phase runs.
+3. **Then**: Only eligible non-held rows removed; partition not dropped if any row remains.
+
+**Expected Results**:
+1. Counts per category match expected.
+
+**Acceptance Criteria**:
+- **Integrity**: No over-deletion.
+
+**Dependencies**: IT-DS-485-002/003 patterns.
+
+---
+
+### IT-DS-485-006: Operation log
+
+**BR**: BR-AUDIT-009
+**Priority**: P1
+**Type**: Integration
+**File**: `test/integration/datastorage/...`
+
+**Test Steps**:
+1. **Given**: Worker enabled.
+2. **When**: One or more retention cycles complete.
+3. **Then**: `retention_operations` contains structured records (counts, window, status, timestamps).
+
+**Expected Results**:
+1. At least one row per run with required columns populated.
+
+**Acceptance Criteria**:
+- **Auditability**: Ops can trace what the worker did.
+
+**Dependencies**: Schema for `retention_operations` finalized.
+
+---
+
+### IT-DS-485-007: Schedule — injected clock/ticker
+
+**BR**: BR-AUDIT-009
+**Priority**: P1
+**Type**: Integration
+**File**: `test/integration/datastorage/...`
+
+**Test Steps**:
+1. **Given**: Short ticker interval or manual tick channel; clock advanced between ticks.
+2. **When**: Multiple cycles executed in test harness.
+3. **Then**: Eligibility changes with mocked time; worker respects interval without waiting wall-clock duration.
+
+**Expected Results**:
+1. Deterministic multi-cycle behavior in <1s wall time.
+
+**Acceptance Criteria**:
+- **Behavior**: Testable scheduling.
+
+**Dependencies**: Injectable `time.Ticker` / clock abstraction.
+
+---
+
+## 10. Environmental Needs
+
+> **IEEE 829 §13** — Hardware, software, tools, and infrastructure required.
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: Clock only
+- **Location**: `test/unit/datastorage/` (TBD)
+- **Resources**: Minimal
+
+### 10.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: ZERO mocks for Postgres; **mock time** via injected clock in application code (not a DB mock)
+- **Infrastructure**: Real PostgreSQL; migrations including triggers and policies
+- **Location**: `test/integration/datastorage/`
+- **Resources**: CI Postgres service
+
+### 10.3 E2E Tests (if applicable)
+
+- Not required for this plan’s core.
+
+### 10.4 Tools & Versions
+
+| Tool | Minimum Version | Purpose |
+|------|-----------------|---------|
+| Go | Project standard | Build and test |
+| Ginkgo CLI | v2.x | BDD runner |
+| PostgreSQL | Compatible with audit schema | DELETE, triggers, PARTITION |
+
+---
+
+## 11. Dependencies & Schedule
+
+> **IEEE 829 §12/§16** — Remaining tasks, blocking issues, and execution order.
+
+### 11.1 Blocking Dependencies
+
+| Dependency | Type | Status | Impact if Not Available | Workaround |
+|------------|------|--------|-------------------------|------------|
+| #235 / #620 | Partitions | Open/Merged | IT-DS-485-004 blocked | Row-only deletes until partitions land |
+| Schema migration | DB | Required | IT-DS-485-006 blocked | Land migration in same PR series |
+
+### 11.2 Execution Order
+
+1. **RED**: Integration tests with real Postgres + mock clock — fail until worker + SQL exist.
+2. **GREEN**: Config flag (default off); worker with ticker; SQL DELETE with hold filter; basic logging.
+3. **REFACTOR**: Repository layer, metrics, transaction boundaries.
+
+**TDD sequence**: RED (IT fails without retention logic) → GREEN (flag, worker, SQL) → REFACTOR (repository, metrics, transactions).
+
+---
+
+## 12. Test Deliverables
+
+> **IEEE 829 §11** — What artifacts this test effort produces.
+
+| Deliverable | Location | Description |
+|-------------|----------|-------------|
+| This test plan | `docs/tests/485/TEST_PLAN.md` | Strategy and test design |
+| Unit tests | `test/unit/datastorage/` | Eligibility + policy merge |
+| Integration tests | `test/integration/datastorage/` | Worker, SQL, partitions, logs |
+| Coverage report | CI artifact | Per-tier coverage |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests
+go test ./test/unit/datastorage/... -ginkgo.v
+
+# Integration tests
+go test ./test/integration/datastorage/... -ginkgo.v
+
+# Focus retention IDs
+go test ./test/integration/datastorage/... -ginkgo.focus="IT-DS-485" -ginkgo.v
+
+# Coverage
+go test ./test/unit/datastorage/... -coverprofile=coverage.out
+go tool cover -func=coverage.out
+```
+
+---
+
+## 14. Existing Tests Requiring Updates (if applicable)
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|-------------------|-------------------|-----------------|--------|
+| Helm `values.yaml` / schema | No retention flag | Add opt-in flag default `false` | IT-DS-485-001 |
+| Migrations | `retention_operations` FK | Adjust per #485 schema decision | IT-DS-485-006 |
+| DS integration suite | No worker | Start worker in tests when flag on | New behavior |
+
+---
+
+## 15. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-09 | Initial test plan for Issue #485 |

--- a/docs/tests/597/TEST_PLAN.md
+++ b/docs/tests/597/TEST_PLAN.md
@@ -1,0 +1,524 @@
+# Test Plan: Route Fanout (Continue Flag) — BR-NOT-068
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+>
+> Based on IEEE 829-2008 (Standard for Software and System Test Documentation) with
+> Kubernaut-specific extensions for TDD phase tracking, business requirement traceability,
+> and per-tier coverage policy.
+
+**Test Plan Identifier**: TP-597-v4
+**Feature**: Implement `continue: true` route fanout in notification routing engine
+**Version**: 4.0
+**Created**: 2026-04-09
+**Author**: AI Assistant
+**Status**: Draft
+**Branch**: `development/v1.3_part2`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This test plan validates the implementation of BR-NOT-068 (Multi-Channel Fanout) in the
+notification routing engine. The `Route.Continue` field exists in the configuration schema
+but is ignored at runtime. This plan ensures that `continue: true` routes fan out to
+multiple receivers, matching Alertmanager semantics, and that the existing single-match
+behavior is preserved when `continue` is false or absent.
+
+### 1.2 Objectives
+
+1. **Fanout correctness**: When `continue: true`, all matching sibling routes are collected and their channels aggregated for delivery
+2. **Backward compatibility**: Existing routing behavior (first-match-wins when `continue` is false) is preserved with zero regressions
+3. **Deduplication**: When the same receiver appears in multiple matching routes, receivers are deduplicated at the `Route.FindReceivers` level (canonical location)
+4. **Controller integration**: The production controller path (`routing_handler.go`) correctly resolves multi-receiver channels and formats the `RoutingResolved` condition
+5. **End-to-end delivery**: Multi-receiver fanout produces actual delivery to all matched channels in a Kind cluster
+6. **Coverage**: >=80% of unit-testable code per tier
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/notification/... -ginkgo.focus="597"` |
+| Integration test pass rate | 100% | `go test ./test/integration/notification/... -ginkgo.focus="597"` |
+| E2E test pass rate | 100% | `go test ./test/e2e/notification/... -ginkgo.focus="597"` |
+| Unit-testable code coverage | >=80% | `go test -coverprofile` on `pkg/notification/routing/config.go` |
+| Backward compatibility | 0 regressions | All existing tests pass without modification |
+| BR-NOT-068 acceptance criteria | See Section 7 | Per BR Coverage Matrix |
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- **BR-NOT-068**: Multi-Channel Fanout — `docs/services/crd-controllers/06-notification/BUSINESS_REQUIREMENTS.md` line 607
+- **BR-NOT-065**: Channel Routing Based on Spec Fields
+- **BR-NOT-066**: Alertmanager-Compatible Configuration Format
+- **BR-NOT-069**: Routing Rule Visibility via Kubernetes Conditions
+- **Issue #597**: `Continue` flag parsed but ignored in `FindReceiver`
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../../.cursor/rules/03-testing-strategy.mdc)
+- [Testing Guidelines](../../development/business-requirements/TESTING_GUIDELINES.md)
+- [Test Case Specification Template](../../testing/TEST_CASE_SPECIFICATION_TEMPLATE.md)
+- Alertmanager routing tree semantics: `Route.Continue` in `github.com/prometheus/alertmanager/dispatch`
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | Breaking existing single-match routing | All notifications route to wrong receiver | Medium | UT-NOT-597-002, UT-NOT-597-006, IT-NOT-597-001 | `FindReceiver` (singular) delegates to `FindReceivers` and takes first element — regression tests validate |
+| R2 | Duplicate channels delivered to orchestrator | Same message delivered twice to same Slack channel | Medium | UT-NOT-597-005 | Deduplication by receiver name inside `Route.FindReceivers` (canonical location) |
+| R3 | `Router.FindReceiver` callers not updated | Controller uses stale single-receiver path | Low | Existing `routing_hotreload_test.go` tests | Backward-compat wrapper preserves `FindReceiver` API |
+| R4 | Condition message (`RoutingResolved`) truncated for many receivers | Operator cannot debug routing | Low | UT-NOT-597-009, IT-NOT-597-001 | Format helper handles multi-receiver display |
+| R5 | Channel aggregation logic in controller incorrect | Channels from some receivers missing | Medium | UT-NOT-597-010, IT-NOT-597-001 | Dedicated unit + integration tests |
+| R6 | `Router.FindReceivers` nil/empty config fallback wrong | Panic or no channels returned | Medium | UT-NOT-597-008 | Explicit nil-handling test |
+| R7 | Fanout route present from initial deployment | Parallel test interference if config mutated at runtime | Low | IT-NOT-597-001, E2E-NOT-597-001 | Fanout routes added to INITIAL suite/E2E configs — no runtime mutation; parallel-safe |
+
+### 3.1 Risk-to-Test Traceability
+
+- **R1** (breaking single-match): Mitigated by UT-NOT-597-002, IT-NOT-597-001 (backward-compat scenario), and all existing tests passing unchanged
+- **R2** (duplicate channels): Mitigated by UT-NOT-597-005 (deduplication test)
+- **R5** (channel aggregation): Mitigated by UT-NOT-597-010 + IT-NOT-597-001 (real controller delivers to all channels)
+- **R7** (parallel safety): Mitigated by adding fanout routes to initial suite configs — no runtime mutation in IT or E2E
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **Route.FindReceivers** (`pkg/notification/routing/config.go`): New method implementing multi-receiver collection with `Continue` flag
+- **Route.FindReceiver** (`pkg/notification/routing/config.go`): Updated to delegate to `FindReceivers` for backward compatibility
+- **Router.FindReceivers** (`pkg/notification/routing/router.go`): Thread-safe multi-receiver resolution with nil-handling and fallback
+- **ResolveChannelsForNotification** (`pkg/notification/routing/resolver.go`): Updated for consistency (test utility, not production path)
+- **resolveChannelsFromRoutingWithDetails** (`internal/controller/notification/routing_handler.go`): Production path updated for multi-receiver channel aggregation and condition formatting
+- **Controller wiring** (integration): Real controller with envtest resolves multi-receiver channels and delivers via orchestrator
+- **End-to-end delivery** (E2E): Pre-deployed ConfigMap with fanout routes + multi-receiver delivery in Kind cluster
+
+### 4.2 Features Not to be Tested
+
+- **DeliverToChannels** (`pkg/notification/delivery/orchestrator.go`): Already supports `[]Channel` — no changes needed
+- **matchesAttributes** (`pkg/notification/routing/config.go`): Matching logic unchanged
+- **ParseConfig / Validate**: Configuration parsing unchanged — `Continue` field already parsed correctly
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Add `FindReceivers` (plural) alongside `FindReceiver` | Backward compatibility — existing callers unchanged; new callers opt in to multi-receiver |
+| Deduplication by receiver name inside `Route.FindReceivers` | Canonical single location for dedup; prevents ambiguity (Audit F6) |
+| Integration test uses pre-loaded fanout routes in suite config | Parallel-safe: no runtime mutation of shared `testRouter`; routes present from suite startup |
+| E2E fanout routes in initial ConfigMap | Parallel-safe: no runtime ConfigMap mutation; routes present from cluster bootstrap |
+
+### 4.4 Production Path vs. Test Utilities
+
+> `ResolveChannelsForNotification` in `resolver.go` is NOT the production controller path.
+> It is only called from `test/unit/notification/routing_integration_test.go`.
+>
+> The **production controller path** is:
+> `notificationrequest_controller.go` → `resolveChannelsFromRoutingWithDetails` (routing_handler.go:70)
+>   → `r.Router.FindReceiver(routingAttrs)` (router.go:128) → `r.config.Route.FindReceiver(attrs)` (config.go:289)
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+**Authority**: `03-testing-strategy.mdc` — Per-Tier Testable Code Coverage.
+
+- **Unit**: >=80% of unit-testable code in `pkg/notification/routing/config.go`
+- **Integration**: >=80% of integration-testable code in `internal/controller/notification/routing_handler.go` (controller wiring + channel aggregation)
+- **E2E**: Full stack validation (ConfigMap → routing → delivery → status)
+
+### 5.2 Three-Tier Coverage
+
+BR-NOT-068 is covered across all three tiers:
+
+- **Unit tests** (new): UT-NOT-597-001..010 — routing logic, Router wrapper, condition formatting
+- **Unit tests** (existing): `routing_hotreload_test.go`, `routing_config_test.go` — backward compat regression guard
+- **Integration test** (new): IT-NOT-597-001 — real controller (envtest) + pre-loaded `continue: true` routing config + multi-channel delivery verification
+- **E2E test** (new): E2E-NOT-597-001 — Kind cluster + ConfigMap deployment + multi-receiver delivery + per-channel status
+
+### 5.3 Business Outcome Quality Bar
+
+Tests validate that operators configuring `continue: true` in their routing YAML get notifications delivered to **all** matching receivers, not just the first — matching documented Alertmanager behavior. Integration and E2E tests validate the actual delivery path, not just routing resolution.
+
+### 5.4 Pass/Fail Criteria
+
+**PASS** — all of the following must be true:
+
+1. All UT-NOT-597-* tests pass (0 failures)
+2. IT-NOT-597-001 passes (0 failures)
+3. E2E-NOT-597-001 passes (0 failures)
+4. All existing tests pass without modification
+5. Unit coverage of `pkg/notification/routing/config.go` >=80%
+
+**FAIL** — any of the following:
+
+1. Any new test fails
+2. Coverage below 80%
+3. Any existing test regresses
+
+### 5.5 Suspension & Resumption Criteria
+
+**Suspend testing when**:
+- Build broken — code does not compile
+- Existing routing tests fail before new code is written
+- Integration infrastructure (PostgreSQL, DataStorage) unavailable
+- Kind cluster provisioning fails
+
+**Resume testing when**:
+- Build fixed and green
+- Infrastructure restored
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code (pure logic, no I/O)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `pkg/notification/routing/config.go` | `FindReceivers` (new), `FindReceiver` (updated) | ~40 new |
+| `pkg/notification/routing/router.go` | `FindReceivers` (new) | ~25 new |
+| `pkg/notification/routing/resolver.go` | `ResolveChannelsForNotification` (updated, test utility) | ~10 changed |
+
+### 6.2 Integration-Testable Code (I/O, wiring, cross-component)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `internal/controller/notification/routing_handler.go` | `resolveChannelsFromRoutingWithDetails` (updated) | ~15 changed |
+
+### 6.3 E2E-Testable Code (full stack)
+
+| Component | What is validated |
+|-----------|-------------------|
+| Routing ConfigMap hot-reload | `continue: true` config deployed and picked up by controller |
+| Multi-receiver channel resolution | Controller resolves channels from all matched receivers |
+| Delivery orchestrator fanout | Notifications delivered to all channels (console + file) |
+| Per-channel delivery status | `NotificationRequest.Status.DeliveryAttempts` has entries for each channel |
+
+### 6.4 Version Identification
+
+| Item | Version/Commit | Notes |
+|------|----------------|-------|
+| Code under test | `development/v1.3_part2` HEAD | Branch |
+| `Route.Continue` field | Already present | YAML/JSON tags correct |
+
+---
+
+## 7. BR Coverage Matrix
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-NOT-068 | Single notification delivered to multiple channels via `continue: true` | P0 | Unit | UT-NOT-597-001 | Pending |
+| BR-NOT-068 | Single notification delivered to multiple channels via `continue: true` | P0 | Integration | IT-NOT-597-001 | Pending |
+| BR-NOT-068 | Single notification delivered to multiple channels via `continue: true` | P0 | E2E | E2E-NOT-597-001 | Pending |
+| BR-NOT-068 | Mixed continue true/false stops at first false | P0 | Unit | UT-NOT-597-003 | Pending |
+| BR-NOT-068 | Per-channel delivery status tracked (partial success) | P1 | Integration | IT-NOT-597-001 | Pending |
+| BR-NOT-068 | Per-channel delivery status tracked (partial success) | P1 | E2E | E2E-NOT-597-001 | Pending |
+| BR-NOT-068 | All channels attempted even if some fail | P1 | Unit | (existing orchestrator tests) | Pass |
+| BR-NOT-065 | First matching route wins when `continue` is false | P0 | Unit | UT-NOT-597-002 | Pending |
+| BR-NOT-065 | Fallback to parent receiver when no children match | P0 | Unit | UT-NOT-597-006 | Pending |
+| BR-NOT-068 | Duplicate receiver deduplication | P1 | Unit | UT-NOT-597-005 | Pending |
+| BR-NOT-068 | Nested routes with `continue` at different levels | P1 | Unit | UT-NOT-597-004 | Pending |
+| BR-NOT-065 | Backward-compat: `FindReceiver` (singular) returns first match | P0 | Unit | UT-NOT-597-007 | Pending |
+| BR-NOT-068 | Router nil/empty config returns console fallback | P0 | Unit | UT-NOT-597-008 | Pending |
+| BR-NOT-069 | Multi-receiver condition message formatted correctly | P1 | Unit | UT-NOT-597-009 | Pending |
+| BR-NOT-069 | Multi-receiver condition message visible on CRD | P1 | Integration | IT-NOT-597-001 | Pending |
+| BR-NOT-068 | Router-level multi-receiver channel aggregation | P0 | Unit | UT-NOT-597-010 | Pending |
+
+---
+
+## 8. Test Scenarios
+
+### Test ID Naming Convention
+
+Format: `{TIER}-NOT-597-{SEQUENCE}`
+- `UT`: Unit, `IT`: Integration, `E2E`: End-to-End
+
+### Tier 1: Unit Tests (10 tests)
+
+**Testable code scope**: `pkg/notification/routing/config.go`, `pkg/notification/routing/router.go` — target >=80% coverage
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-NOT-597-001` | `continue: true` on matching route collects multiple receivers | Pending |
+| `UT-NOT-597-002` | `continue: false` (default) stops at first match — regression guard | Pending |
+| `UT-NOT-597-003` | Mixed `continue: true` and `false` in sibling list — stops at first `false` | Pending |
+| `UT-NOT-597-004` | Nested routes with `continue` at parent and child levels | Pending |
+| `UT-NOT-597-005` | Same receiver matched by two routes — deduplicated in result | Pending |
+| `UT-NOT-597-006` | No children match — falls back to parent receiver | Pending |
+| `UT-NOT-597-007` | `FindReceiver` (singular) returns first receiver from `FindReceivers` | Pending |
+| `UT-NOT-597-008` | `Router.FindReceivers` with nil config returns console fallback | Pending |
+| `UT-NOT-597-009` | Multi-receiver condition message lists all receiver names | Pending |
+| `UT-NOT-597-010` | `Router.FindReceivers` resolves names to `[]*Receiver` and aggregates channels | Pending |
+
+### Tier 2: Integration Test (1 test)
+
+**Testable code scope**: `internal/controller/notification/routing_handler.go` — controller wiring with real envtest
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `IT-NOT-597-001` | Real controller delivers notification to channels from ALL matched receivers when `continue: true` is configured, with correct RoutingResolved condition | Pending |
+
+### Tier 3: E2E Test (1 test)
+
+**Testable code scope**: Full stack in Kind cluster
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `E2E-NOT-597-001` | ConfigMap with `continue: true` deployed to Kind; notification delivered to all matched channels with per-channel delivery status | Pending |
+
+---
+
+## 9. Test Cases
+
+### Unit Tests (UT-NOT-597-001 through 010)
+
+*(Unchanged from v2 — see previous version for full specifications)*
+
+### UT-NOT-597-001 through UT-NOT-597-010
+
+Same as v2 test plan. These test `Route.FindReceivers`, `Route.FindReceiver`, `Router.FindReceivers`, condition message formatting, and channel aggregation at the unit level.
+
+---
+
+### IT-NOT-597-001: Controller multi-receiver fanout delivery
+
+**BR**: BR-NOT-068, BR-NOT-069
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/notification/fanout_routing_test.go` (new)
+
+**Preconditions**:
+- envtest controller running (from `suite_test.go`)
+- Delivery orchestrator with console, file, and log channels registered
+- `testRouter` pre-loaded with fanout routes at suite startup (no runtime mutation)
+  - Route: match `test-channel-set: fanout-test` → `fanout-console` (console), `continue: true`
+  - Route: match `test-channel-set: fanout-test` → `fanout-file` (file)
+
+**Parallel Safety**: No `testRouter.LoadConfig()` calls — fanout routes are added to the
+initial routing config in `suite_test.go`. This ensures parallel test execution (`-procs=4`)
+cannot be impacted by config mutations.
+
+**Test Steps**:
+1. **Given**: Routing config already contains `continue: true` fanout routes from suite setup
+2. **When**: Create a NotificationRequest with `spec.extensions["test-channel-set"] = "fanout-test"`
+3. **Then**:
+   - Notification reaches `Sent` phase
+   - `status.deliveryAttempts` has entries for BOTH console AND file channels
+   - `status.successfulDeliveries >= 2`
+   - RoutingResolved condition message contains both receiver names ("fanout-console", "fanout-file")
+
+**Acceptance Criteria**:
+- **Behavior**: Real controller resolves multi-receiver channels and delivers to all
+- **Correctness**: Delivery attempts recorded for each channel from each matched receiver
+- **Observability**: RoutingResolved condition lists all matched receivers (BR-NOT-069)
+
+**Dependencies**: `suite_test.go` must include fanout routes in initial config
+
+---
+
+### E2E-NOT-597-001: End-to-end multi-receiver fanout in Kind
+
+**BR**: BR-NOT-068
+**Priority**: P0
+**Type**: E2E
+**File**: `test/e2e/notification/10_fanout_routing_test.go` (new)
+
+**Preconditions**:
+- Kind cluster with Notification Controller deployed
+- Routing ConfigMap (`notification-routing-config`) pre-deployed at cluster bootstrap with fanout routes:
+  - Route: match `test-channel-set: e2e-fanout` → `fanout-console` (console), `continue: true`
+  - Route: match `test-channel-set: e2e-fanout` → `fanout-file-log` (file + log)
+
+**Parallel Safety**: No `kubectl apply` of updated ConfigMap — fanout routes are added to the
+initial ConfigMap in `test/infrastructure/notification_e2e.go`. This ensures parallel E2E test
+execution cannot be impacted by ConfigMap mutations.
+
+**Test Steps**:
+1. **Given**: Routing ConfigMap already contains `continue: true` fanout routes from cluster bootstrap
+2. **When**: Create a NotificationRequest with `spec.extensions["test-channel-set"] = "e2e-fanout"`
+3. **Then**:
+   - Notification reaches `Sent` phase within 30s
+   - `status.deliveryAttempts` has entries for console, file, AND log channels (3 total)
+   - `status.successfulDeliveries == 3`
+   - File delivery creates audit file (verifiable via kubectl cp from pod)
+
+**Acceptance Criteria**:
+- **Behavior**: Pre-deployed `continue: true` routing delivers to all matched receivers
+- **Correctness**: Per-channel delivery status tracked (BR-NOT-068 acceptance criterion)
+- **Accuracy**: All 3 channels from 2 receivers delivered successfully
+
+**Dependencies**: `test/infrastructure/notification_e2e.go` must include fanout routes in initial ConfigMap
+
+---
+
+## 10. Environmental Needs
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: None — pure in-memory routing logic
+- **Location**: `test/unit/notification/routing_config_test.go`, `test/unit/notification/routing_hotreload_test.go`
+
+### 10.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: Mock Slack webhook server (from suite)
+- **Infrastructure**: envtest (real K8s API), PostgreSQL, Redis, DataStorage
+- **Location**: `test/integration/notification/fanout_routing_test.go`
+
+### 10.3 E2E Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Infrastructure**: Kind cluster (2 nodes), deployed Notification Controller
+- **Location**: `test/e2e/notification/10_fanout_routing_test.go`
+
+### 10.4 Tools & Versions
+
+| Tool | Minimum Version | Purpose |
+|------|-----------------|---------|
+| Go | 1.23+ | Build and test |
+| Ginkgo CLI | v2.x | Test runner |
+| Kind | v0.20+ | E2E cluster |
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Blocking Dependencies
+
+None. All code to be modified is in-tree with no external dependencies.
+
+### 11.2 Execution Order — TDD Phases
+
+#### Phase 1: TDD RED — Write Failing Tests (all tiers)
+
+Write all 12 test cases:
+- 10 unit tests (UT-NOT-597-001..010)
+- 1 integration test (IT-NOT-597-001) in new file `fanout_routing_test.go`
+- 1 E2E test (E2E-NOT-597-001) in new file `10_fanout_routing_test.go`
+
+Stub `FindReceivers` returning `nil` so tests compile but fail.
+
+**Exit criteria**: All 12 tests compile and FAIL (RED).
+
+#### CHECKPOINT 1: RED Phase Due Diligence
+
+- All 12 tests present and failing for the right reason
+- Zero modifications to existing test code
+- Integration test uses pre-loaded fanout routes in `suite_test.go` initial config (parallel-safe)
+- E2E test uses pre-deployed fanout routes in `notification_e2e.go` initial ConfigMap (parallel-safe)
+- `go build ./...` succeeds
+
+#### Phase 2: TDD GREEN — Minimal Implementation
+
+Implement code to make all 12 tests pass:
+1. `Route.FindReceivers` with dedup (config.go)
+2. `Route.FindReceiver` backward-compat wrapper (config.go)
+3. `Router.FindReceivers` with nil-handling (router.go)
+4. `ResolveChannelsForNotification` update (resolver.go — test utility)
+5. `resolveChannelsFromRoutingWithDetails` update (routing_handler.go — production path)
+
+**Exit criteria**: All 12 new tests pass. All existing tests pass. `go build ./...` succeeds.
+
+#### CHECKPOINT 2: GREEN Phase Due Diligence
+
+- `go test ./test/unit/notification/...` — 0 failures
+- `go test ./test/integration/notification/...` — 0 failures
+- `go build ./...` — clean
+- Backward compat: existing routing tests pass unchanged
+- Coverage >=80% on `pkg/notification/routing/config.go`
+- Dedup confirmed inside `Route.FindReceivers`
+- No anti-patterns (time.Sleep, Skip, interface{})
+
+#### Phase 3: TDD REFACTOR — Code Quality
+
+- Extract dedup helper if needed
+- Doc comments referencing BR-NOT-068, Alertmanager semantics
+- Clean dead code
+- Consistent naming
+
+**Exit criteria**: All tests pass. Code clean and documented.
+
+#### CHECKPOINT 3: REFACTOR Phase Final Validation
+
+- All unit + integration tests green
+- `go build ./...` clean
+- `golangci-lint` clean
+- Coverage >=80%
+- Scope limited to routing package + controller handler + tests
+
+**Note**: E2E tests are validated separately via CI (Kind cluster required).
+
+---
+
+## 12. Test Deliverables
+
+| Deliverable | Location | Description |
+|-------------|----------|-------------|
+| This test plan | `docs/tests/597/TEST_PLAN.md` | Strategy and test design |
+| Unit test suite (routing) | `test/unit/notification/routing_config_test.go` | 8 fanout tests |
+| Unit test suite (router) | `test/unit/notification/routing_hotreload_test.go` | 2 Router fanout tests |
+| Integration test | `test/integration/notification/fanout_routing_test.go` | 1 controller fanout test |
+| E2E test | `test/e2e/notification/10_fanout_routing_test.go` | 1 Kind cluster fanout test |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests
+go test ./test/unit/notification/... -ginkgo.focus="597" -ginkgo.v
+
+# Integration tests (requires infrastructure)
+go test ./test/integration/notification/... -ginkgo.focus="597" -ginkgo.v
+
+# E2E tests (requires Kind cluster)
+go test ./test/e2e/notification/... -ginkgo.focus="597" -ginkgo.v
+
+# Coverage
+go test ./test/unit/notification/... -coverprofile=cov.out -coverpkg=./pkg/notification/routing/...
+go tool cover -func=cov.out
+```
+
+---
+
+## 14. Existing Tests Requiring Updates
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|-------------------|-------------------|-----------------|--------|
+| None | — | — | `FindReceiver` backward compat wrapper ensures all existing callers produce identical results |
+
+---
+
+## 15. Audit Trail
+
+### Adversarial Audit (v2.0)
+
+10 findings identified and addressed. See v2.0 changelog for details.
+
+### Tier Coverage Expansion (v3.0)
+
+Added integration and E2E tests per user request:
+- **IT-NOT-597-001**: Real controller (envtest) with pre-loaded `continue: true` routing config (parallel-safe)
+- **E2E-NOT-597-001**: Kind cluster with pre-deployed fanout ConfigMap and full delivery validation (parallel-safe)
+
+---
+
+## 16. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-09 | Initial test plan (7 unit tests) |
+| 2.0 | 2026-04-09 | Adversarial audit: +3 unit tests, corrected BR matrix, honest tier assessment |
+| 3.0 | 2026-04-09 | Added IT-NOT-597-001 (integration) and E2E-NOT-597-001 (E2E) for full three-tier coverage |
+| 4.0 | 2026-04-09 | Parallel safety: IT/E2E no longer hot-reload shared router/ConfigMap; fanout routes added to initial suite configs instead |

--- a/docs/tests/628/TEST_PLAN.md
+++ b/docs/tests/628/TEST_PLAN.md
@@ -1,0 +1,572 @@
+# Test Plan: Notification — Standardized Status Block (#628)
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+>
+> Based on IEEE 829-2008 (Standard for Software and System Test Documentation) with
+> Kubernaut-specific extensions for TDD phase tracking, business requirement traceability,
+> and per-tier coverage policy.
+
+**Test Plan Identifier**: TP-628-v1.0
+**Feature**: Standardize **Status** label and finite display enum across all notification body types built by the remediation orchestrator
+**Version**: 1.0
+**Created**: 2026-04-09
+**Author**: AI Assistant
+**Status**: Executing
+**Branch**: `development/v1.3`
+
+---
+
+## 1. Introduction
+
+> **IEEE 829 §3** — Purpose, objectives, and measurable success criteria for the test effort.
+
+### 1.1 Purpose
+
+This test plan validates Issue #628: eliminating inconsistent notification body vocabulary (e.g., **Outcome** vs **Result** vs absent status) by introducing a single **Status** line mapped to a finite operator-facing enum, positioned consistently after cluster/remediation prefix and before **Signal**, while preserving deprecated **Outcome** / **Result** for one release. Notification bodies are built in `pkg/remediationorchestrator/creator/notification.go` (not `pkg/notification/`).
+
+### 1.2 Objectives
+
+1. **Completion**: Body includes `**Status**:` with value **Remediated** (or correct mapping from `rr.Status.Outcome`).
+2. **Bulk duplicate**: Body includes `**Status**:` **Duplicate Handled**; legacy `**Result**:` remains present for backward compatibility.
+3. **Manual review / Approval / Self-resolved / Global timeout / Phase timeout**: Each body includes `**Status**:` with **Manual Review Required**, **Pending Approval**, **Self-Resolved**, or **Timed Out** as specified.
+4. **Layout**: For all types that include **Signal**, `index("**Status**:") < index("**Signal**:")`.
+5. **Label collision**: Status value **Timed Out** is distinguishable from any timestamp line that uses a “timed out” phrasing (timestamp line remains semantically distinct from `**Status**:`).
+6. **Deprecation**: Old fields remain for one release with documented deprecation; tests assert both new **Status** and preserved legacy fields where required.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/remediationorchestrator/...` |
+| Integration test pass rate | 100% | N/A (unit-sufficient; see Section 8) |
+| Unit-testable code coverage | >=80% | `go test -coverprofile` on `notification.go` and helpers |
+| Backward compatibility | 0 unintended removals | **Outcome** / **Result** still present per scenario where specified |
+| Regressions | 0 | `notification_creator_test.go`, `notification_body_order_test.go` (#627) updated only as planned |
+
+---
+
+## 2. References
+
+> **IEEE 829 §2** — Documents that govern or inform this test plan.
+
+### 2.1 Authority (governing documents)
+
+- BR-ORCH-045: Completion notification outcome / completion path
+- BR-ORCH-034: Bulk duplicate handling
+- BR-ORCH-036: Manual review notifications
+- BR-ORCH-027 / BR-ORCH-028: Global and phase timeout notifications
+- Issue #628: Notification — Standardize Status Block across all notification types
+- Issue #627: Notification body field ordering (prefix / Signal / ordering prerequisites)
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../../.cursor/rules/03-testing-strategy.mdc)
+- [Test Case Specification Template](../../testing/TEST_CASE_SPECIFICATION_TEMPLATE.md)
+- [Integration/E2E No-Mocks Policy](../../testing/INTEGRATION_E2E_NO_MOCKS_POLICY.md)
+- [Testing Guidelines](../../development/business-requirements/TESTING_GUIDELINES.md)
+
+---
+
+## 3. Risks & Mitigations
+
+> **IEEE 829 §5** — Software risk issues that drive test design.
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | Operators confuse **Status: Timed Out** with a timestamp label also implying timeout | Wrong triage | Medium | UT-NOT-628-006 | Assert distinct line prefixes; document human-readable distinction in implementation comments |
+| R2 | Mapping from internal `Outcome` to display enum drifts | Wrong status shown | Medium | UT-NOT-628-001 | Table-driven mapping tests; single `FormatStatusLine` + mapper |
+| R3 | Removing **Outcome**/**Result** too early breaks downstream parsers | Integration breakage | Low | UT-NOT-628-002 | Keep legacy fields one release; deprecation comments |
+| R4 | **Status** placed after **Signal** | Regresses #627 intent | Low | UT-NOT-628-008 | Explicit index ordering test for all types with Signal |
+
+### 3.1 Risk-to-Test Traceability
+
+- **R1**: UT-NOT-628-006 verifies **Status** line vs timeout timestamp line are distinct.
+- **R2**: UT-NOT-628-001 locks Completion mapping to **Remediated** (or approved mapping table).
+- **R3**: UT-NOT-628-002 asserts **Result** still present alongside **Status**.
+- **R4**: UT-NOT-628-008 covers all notification types that include **Signal**.
+
+### 3.2 Preflight Validation Results (2026-04-09)
+
+**All original risks confirmed manageable. Additional findings:**
+
+| ID | Finding | Resolution |
+|----|---------|------------|
+| R1-PF | Timeout bodies use `**Timed Out**:` as timestamp label. `**Status**: Timed Out` has a structurally different prefix — no collision. | Confirmed safe. UT-NOT-628-006 validates. |
+| R3-PF | UT-RO-627-001 asserts `**Outcome**:` before `**Signal**:`. Inserting `**Status**:` before `**Outcome**:` preserves the Outcome-before-Signal invariant. | No breakage. Update UT-RO-627-001 in REFACTOR to also check `**Status**:`. |
+| R4-PF | Bulk duplicate body has `**Signal**:` before `**Result**:`. Inserting `**Status**:` before `**Signal**:` does not invert any tested ordering. | `**Result**:` stays after `**Signal**:` (legacy position). Only `**Status**:` added before. |
+| G1 | `FormatStatusLine` signature undefined. | **Decision**: `FormatStatusLine(status string) string` → `"**Status**: " + status + "\n\n"`. Builders pass the correct hardcoded enum or `rr.Status.Outcome` for Completion. |
+| G2 | Completion `rr.Status.Outcome` has 4 values (`Remediated`, `NoActionRequired`, `ManualReviewRequired`, `VerificationTimedOut`); plan enum only maps `Remediated`. | **Decision**: Pass `rr.Status.Outcome` directly — values are already human-readable. No translation needed. |
+| I1 | UT-RO-627-001 checks `**Outcome**:` ordering; canonical label now `**Status**:`. | Update in REFACTOR: UT-RO-627-001 adds `**Status**:` check or UT-NOT-628-008 subsumes it. |
+
+**Post-preflight confidence**: 97%
+
+---
+
+## 4. Scope
+
+> **IEEE 829 §6/§7** — Features to be tested and features not to be tested.
+
+### 4.1 Features to be Tested
+
+- **Notification body builders** (`pkg/remediationorchestrator/creator/notification.go`): Completion, Bulk Duplicate, Manual Review, Approval, Self-Resolved, Global Timeout, Phase Timeout — each emits `**Status**:` with the agreed enum value; position relative to **Signal** where applicable.
+- **Shared formatting helpers**: `FormatStatusLine` (or equivalent) and centralized mapping from remediation/request outcomes to display enum.
+- **Backward compatibility**: Deprecated **Outcome** / **Result** fields retained per human decision.
+
+### 4.2 Features Not to be Tested
+
+- **`pkg/notification/` controller delivery**: Out of scope; bodies are authored in RO creator.
+- **SMTP/Teams/slack rendering**: Channel-specific formatting not covered here.
+- **E2E operator inbox**: Deferred; string contract covered at unit level.
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Label **Status** everywhere | Single scan pattern for operators |
+| Finite enum (Remediated \| Pending Approval \| Timed Out \| Manual Review Required \| Self-Resolved \| Duplicate Handled) | Predictable UI/triage; maps from internal states |
+| Position after cluster/remediation prefix + intro line, before **Signal** | Aligns with #627 ordering goals |
+| Keep **Outcome**/**Result** one release | Safe migration for consumers parsing legacy fields |
+| `FormatStatusLine(status string) string` as shared helper | Single format source; no mapping logic inside — caller passes final display value |
+| Completion passes `rr.Status.Outcome` directly (no translation) | Outcome enum values are already human-readable (`Remediated`, etc.) |
+
+### 4.4 Insertion Points (per builder, confirmed by preflight)
+
+| Builder | Insertion Point | Status Value |
+|---------|----------------|--------------|
+| `buildCompletionBody` | After title line, before `**Outcome**:` | `rr.Status.Outcome` (passthrough) |
+| `buildBulkDuplicateBody` | After intro line, before `**Signal**:` | `Duplicate Handled` (fixed) |
+| `buildManualReviewBody` | After header line, before `**Signal**:` | `Manual Review Required` (fixed) |
+| `buildApprovalBody` | After intro line, before `**Signal**:` | `Pending Approval` (fixed) |
+| `buildSelfResolvedBody` | After intro line, before `**Signal**:` | `Self-Resolved` (fixed) |
+| `BuildGlobalTimeoutBody` | After intro paragraph, before `**Signal**:` | `Timed Out` (fixed) |
+| `BuildPhaseTimeoutBody` | After intro paragraph, before `**Signal**:` | `Timed Out` (fixed) |
+
+---
+
+## 5. Approach
+
+> **IEEE 829 §8/§9/§10** — Test strategy, pass/fail criteria, and suspension/resumption.
+
+### 5.1 Coverage Policy
+
+**Authority**: `03-testing-strategy.mdc` — Per-Tier Testable Code Coverage.
+
+- **Unit**: >=80% of **unit-testable** code in notification body builders and status mapping helpers.
+- **Integration**: Notification strings are pure builder output; integration tier not required for #628 (see Section 8).
+- **E2E**: Not in scope for this test plan.
+
+### 5.2 Two-Tier Minimum
+
+BR coverage is met via **unit tests** that assert final body strings; integration with Kubernetes/DS is unchanged. Tier skip rationale documented in Section 8.
+
+### 5.3 Business Outcome Quality Bar
+
+Tests answer: “Does every notification type expose a consistent **Status** line with the correct enum, correct position, and required legacy fields?”
+
+### 5.4 Pass/Fail Criteria
+
+**PASS** — all of the following must be true:
+
+1. All P0 unit tests pass (UT-NOT-628-001 through UT-NOT-628-008).
+2. Per-tier unit coverage >=80% on targeted files.
+3. No regressions in existing remediation orchestrator notification tests except planned assertion updates (Section 14).
+4. Legacy **Outcome**/**Result** fields present where this plan requires them.
+
+**FAIL** — any of the following:
+
+1. Any P0 unit test fails.
+2. Coverage below 80% on notification builder/mapping code.
+3. Unplanned regressions in #627 ordering tests.
+4. **Status** missing on any of the seven scenarios.
+
+### 5.5 Suspension & Resumption Criteria
+
+**Suspend testing when**:
+
+- Issue #627 body-order contract is in flux on the branch without coordinated merge.
+- `notification.go` refactor in progress with non-compiling intermediate commits.
+
+**Resume testing when**:
+
+- #627 expectations stable or Section 14 updates merged.
+- Build green; `go test ./test/unit/remediationorchestrator/...` executable.
+
+---
+
+## 6. Test Items
+
+> **IEEE 829 §4** — Software items to be tested, with version identification.
+
+### 6.1 Unit-Testable Code (pure logic, no I/O)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `pkg/remediationorchestrator/creator/notification.go` | Body builders for Completion, Bulk Duplicate, Manual Review, Approval, Self-Resolved, Global/Phase timeout | TBD |
+| `pkg/remediationorchestrator/creator/notification.go` (or extracted helper) | `FormatStatusLine`, outcome→enum mapping | TBD |
+
+### 6.2 Integration-Testable Code (I/O, wiring, cross-component)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| — | — | Not applicable for #628 body contract |
+
+### 6.3 Version Identification
+
+| Item | Version/Commit | Notes |
+|------|----------------|-------|
+| Code under test | `development/v1.3` HEAD | Post-#627 merge recommended |
+| Dependency: Issue #627 | Merged or branch includes ordering tests | `notification_body_order_test.go` |
+
+---
+
+## 7. BR Coverage Matrix
+
+> Kubernaut-specific. Maps every business requirement to test scenarios across tiers.
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-ORCH-045 | Completion notification reflects remediation outcome | P0 | Unit | UT-NOT-628-001 | Pass |
+| BR-ORCH-034 | Bulk duplicate handled notification | P0 | Unit | UT-NOT-628-002 | Pass |
+| BR-ORCH-036 | Manual review required path | P0 | Unit | UT-NOT-628-003 | Pass |
+| BR-ORCH-027 / BR-ORCH-028 | Timeout notifications (global / phase) | P0 | Unit | UT-NOT-628-006, UT-NOT-628-007 | Pass |
+| BR-ORCH-045 (approval branch) | Pending approval notification | P0 | Unit | UT-NOT-628-004 | Pass |
+| BR-ORCH-045 (self-resolved) | Self-resolved notification | P0 | Unit | UT-NOT-628-005 | Pass |
+| Issue #628 | Consistent **Status** position vs **Signal** | P0 | Unit | UT-NOT-628-008 | Pass |
+
+### Status Legend
+
+- **Pending**: Specification complete, implementation not started
+- **RED**: Failing test written (TDD RED phase)
+- **GREEN**: Minimal implementation passes (TDD GREEN phase)
+- **REFACTORED**: Code cleaned up (TDD REFACTOR phase)
+- **Pass**: Implemented and passing
+
+---
+
+## 8. Test Scenarios
+
+> **IEEE 829 Test Design Specification** — How test cases are organized and grouped.
+
+### Test ID Naming Convention
+
+Format: `{TIER}-{SERVICE}-{ISSUE}-{SEQUENCE}` — **SERVICE** = `NOT` (notification body contract).
+
+### Tier 1: Unit Tests
+
+**Testable code scope**: `pkg/remediationorchestrator/creator/notification.go` and status mapping helpers — >=80% coverage target.
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-NOT-628-001` | Completion body contains `**Status**:` **Remediated** (or correct mapping from `rr.Status.Outcome`) | Pass |
+| `UT-NOT-628-002` | Bulk duplicate: `**Status**:` **Duplicate Handled**; `**Result**:` still present | Pass |
+| `UT-NOT-628-003` | Manual review: `**Status**:` **Manual Review Required** | Pass |
+| `UT-NOT-628-004` | Approval: `**Status**:` **Pending Approval** | Pass |
+| `UT-NOT-628-005` | Self-resolved: `**Status**:` **Self-Resolved** | Pass |
+| `UT-NOT-628-006` | Global timeout: `**Status**:` **Timed Out**; timestamp/timeout wording line distinct from status line | Pass |
+| `UT-NOT-628-007` | Phase timeout: `**Status**:` **Timed Out** | Pass |
+| `UT-NOT-628-008` | Position: `Index("**Status**:") < Index("**Signal**:")` for all types that include **Signal** | Pass |
+
+### Tier 2: Integration Tests
+
+Not applicable — notification strings are validated in unit tests with fake inputs; no external I/O.
+
+### Tier 3: E2E Tests (if applicable)
+
+Not applicable.
+
+### Tier Skip Rationale (if any tier is omitted)
+
+- **Integration / E2E**: Body composition is deterministic string generation; existing pattern in `test/unit/remediationorchestrator/notification_creator_test.go` and #627 order tests.
+
+---
+
+## 9. Test Cases
+
+> **IEEE 829 Test Case Specification** — Detailed specification for each test case.
+
+### UT-NOT-628-001: Completion status line
+
+**BR**: BR-ORCH-045
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/remediationorchestrator/notification_creator_test.go` (or companion file)
+
+**Preconditions**:
+- Test fixtures construct a Completion notification context with representative `rr.Status.Outcome` values.
+
+**Test Steps**:
+1. **Given**: Notification creator builds Completion body for a remediated outcome.
+2. **When**: Body string is produced.
+3. **Then**: Body contains `**Status**:` followed by **Remediated** (or approved mapping from outcome enum).
+
+**Expected Results**:
+1. `**Status**:` appears exactly once as the status discriminator (value matches mapping table).
+2. Legacy **Outcome** field behavior per deprecation policy still satisfied if present.
+
+**Acceptance Criteria**:
+- **Behavior**: Operators see unified **Status** on Completion.
+- **Correctness**: Mapped value matches internal outcome.
+- **Accuracy**: No duplicate conflicting status labels.
+
+**Dependencies**: Issue #627 ordering (Status before Signal).
+
+---
+
+### UT-NOT-628-002: Bulk duplicate status + legacy Result
+
+**BR**: BR-ORCH-034
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/remediationorchestrator/notification_creator_test.go`
+
+**Preconditions**:
+- Fixture for bulk duplicate notification generation.
+
+**Test Steps**:
+1. **Given**: Bulk duplicate scenario inputs.
+2. **When**: Body is built.
+3. **Then**: Body contains `**Status**:` **Duplicate Handled** and still contains `**Result**:` (legacy).
+
+**Expected Results**:
+1. **Status** line present with correct enum.
+2. **Result** line present (backward compat).
+
+**Acceptance Criteria**:
+- **Behavior**: Single **Status** scan path works; parsers using **Result** do not break.
+
+**Dependencies**: None.
+
+---
+
+### UT-NOT-628-003: Manual review status
+
+**BR**: BR-ORCH-036
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/remediationorchestrator/notification_creator_test.go`
+
+**Preconditions**:
+- Manual review notification inputs.
+
+**Test Steps**:
+1. **Given**: Manual review body build.
+2. **When**: String generated.
+3. **Then**: Contains `**Status**:` **Manual Review Required**.
+
+**Expected Results**:
+1. Status value exact match (spacing/punctuation as implemented).
+
+**Acceptance Criteria**:
+- **Behavior**: Operator sees explicit manual review state in standard slot.
+
+**Dependencies**: None.
+
+---
+
+### UT-NOT-628-004: Approval pending status
+
+**BR**: BR-ORCH-045 (approval path)
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/remediationorchestrator/notification_creator_test.go`
+
+**Preconditions**:
+- Approval notification with rationale/prompt as today.
+
+**Test Steps**:
+1. **Given**: Approval body build.
+2. **When**: String generated.
+3. **Then**: Contains `**Status**:` **Pending Approval**.
+
+**Expected Results**:
+1. **Status** present; approval CTA content unchanged except for ordering per #627.
+
+**Acceptance Criteria**:
+- **Behavior**: Pending approval visible via **Status**.
+
+**Dependencies**: Issue #627.
+
+---
+
+### UT-NOT-628-005: Self-resolved status
+
+**BR**: BR-ORCH-045
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/remediationorchestrator/notification_creator_test.go`
+
+**Test Steps**:
+1. **Given**: Self-resolved scenario.
+2. **When**: Body built.
+3. **Then**: `**Status**:` **Self-Resolved**.
+
+**Expected Results**:
+1. Enum exact match.
+
+**Acceptance Criteria**:
+- **Behavior**: Self-resolved distinguishable from Remediated/Duplicate.
+
+**Dependencies**: None.
+
+---
+
+### UT-NOT-628-006: Global timeout status vs timestamp
+
+**BR**: BR-ORCH-027 / BR-ORCH-028
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/remediationorchestrator/notification_creator_test.go`
+
+**Test Steps**:
+1. **Given**: Global timeout body with timeout instant line (however currently labeled).
+2. **When**: Body built.
+3. **Then**: `**Status**:` **Timed Out** exists; timestamp or “timed out at” line is not the same line as `**Status**:` (distinct prefix or structure).
+
+**Expected Results**:
+1. Two distinguishable lines: one is `**Status**:`; the other carries temporal information without replacing **Status**.
+
+**Acceptance Criteria**:
+- **Behavior**: No ambiguity between “when” and “what state”.
+- **Correctness**: Regex/index assertions prove separation.
+
+**Dependencies**: Human decision on timestamp label wording.
+
+---
+
+### UT-NOT-628-007: Phase timeout status
+
+**BR**: BR-ORCH-027 / BR-ORCH-028
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/remediationorchestrator/notification_creator_test.go`
+
+**Test Steps**:
+1. **Given**: Phase timeout scenario.
+2. **When**: Body built.
+3. **Then**: `**Status**:` **Timed Out**.
+
+**Expected Results**:
+1. Same enum as global timeout where appropriate.
+
+**Acceptance Criteria**:
+- **Behavior**: Phase timeout surfaced as timed-out status.
+
+**Dependencies**: None.
+
+---
+
+### UT-NOT-628-008: Status before Signal
+
+**BR**: Issue #628 / BR-ORCH-*
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/remediationorchestrator/notification_body_order_test.go` (extend) or dedicated file
+
+**Test Steps**:
+1. **Given**: Each notification type that includes `**Signal**:`.
+2. **When**: Body built.
+3. **Then**: `strings.Index(body, "**Status**:") < strings.Index(body, "**Signal**:")`.
+
+**Expected Results**:
+1. Ordering holds for every applicable type.
+
+**Acceptance Criteria**:
+- **Behavior**: Consistent scan order for operators.
+
+**Dependencies**: Issue #627.
+
+---
+
+## 10. Environmental Needs
+
+> **IEEE 829 §13** — Hardware, software, tools, and infrastructure required.
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: Fake Kubernetes client only where existing notification tests require it (external dependency mock)
+- **Location**: `test/unit/remediationorchestrator/`
+- **Resources**: None special
+
+### 10.2 Integration Tests
+
+- Not required for this plan.
+
+### 10.3 E2E Tests (if applicable)
+
+- Not required.
+
+### 10.4 Tools & Versions
+
+| Tool | Minimum Version | Purpose |
+|------|-----------------|---------|
+| Go | 1.22+ (project standard) | Build and test |
+| Ginkgo CLI | v2.x | BDD runner |
+
+---
+
+## 11. Dependencies & Schedule
+
+> **IEEE 829 §12/§16** — Remaining tasks, blocking issues, and execution order.
+
+### 11.1 Blocking Dependencies
+
+| Dependency | Type | Status | Impact if Not Available | Workaround |
+|------------|------|--------|-------------------------|------------|
+| Issue #627 | Code / tests | Merged preferred | UT-NOT-628-008 may conflict with ordering assumptions | Coordinate merge or adjust indices in same PR |
+
+### 11.2 Execution Order
+
+1. **RED**: Add failing assertions for `**Status**:` in each builder scenario.
+2. **GREEN**: Implement `FormatStatusLine` + mapping; insert **Status** after prefix, before **Signal**; keep **Outcome**/**Result** with deprecation comments.
+3. **REFACTOR**: Shared helper for status line; deduplicate mapping; update Section 14 tests.
+
+**TDD sequence**: RED (assert Status field in each builder) → GREEN (add FormatStatusLine + mapping) → REFACTOR (shared helper, deprecation comments on old fields).
+
+---
+
+## 12. Test Deliverables
+
+> **IEEE 829 §11** — What artifacts this test effort produces.
+
+| Deliverable | Location | Description |
+|-------------|----------|-------------|
+| This test plan | `docs/tests/628/TEST_PLAN.md` | Strategy and test design |
+| Unit test suite | `test/unit/remediationorchestrator/` | Ginkgo tests for #628 |
+| Coverage report | CI artifact | Unit coverage on notification builder |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests — remediation orchestrator notification suite
+go test ./test/unit/remediationorchestrator/... -ginkgo.v
+
+# Focus by issue / ID prefix
+go test ./test/unit/remediationorchestrator/... -ginkgo.focus="UT-NOT-628" -ginkgo.v
+
+# Coverage
+go test ./test/unit/remediationorchestrator/... -coverprofile=coverage.out
+go tool cover -func=coverage.out
+```
+
+---
+
+## 14. Existing Tests Requiring Updates (if applicable)
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|-------------------|-------------------|-----------------|--------|
+| `notification_creator_test.go` | May assert **Outcome**/**Result** without **Status** | Add `**Status**:` assertions; keep legacy where required | #628 contract |
+| `notification_body_order_test.go` (#627) | **Outcome** before **Signal** | Also assert **Status** before **Signal** (or align with UT-NOT-628-008) | Unified label |
+| `notification_creator_test.go` | Per-type string snapshots | Update expected strings to include **Status** line | New field |
+
+---
+
+## 15. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-09 | Initial test plan for Issue #628 |
+| 1.1 | 2026-04-09 | Preflight validation: confirmed insertion points, resolved G1/G2 gaps, added Section 4.4 |
+| 1.2 | 2026-04-09 | TDD complete: all 8 tests pass (RED→GREEN→REFACTOR). #627 ordering test updated. |

--- a/docs/tests/650/TEST_PLAN.md
+++ b/docs/tests/650/TEST_PLAN.md
@@ -1,0 +1,393 @@
+# Test Plan: SA Propagation Simplification — Resolve at WE Execution Time
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-650-v1
+**Feature**: Remove SA from AA/RO/WFE-spec propagation chain; resolve from DS catalog at WE execution time into WFE status
+**Version**: 1.0
+**Created**: 2026-04-06
+**Author**: AI Assistant
+**Status**: Active
+**Branch**: `development/v1.2`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This test plan validates Issue #650: simplifying ServiceAccountName (SA) propagation
+by removing it from the upstream chain (AIAnalysis SelectedWorkflow, RO creator,
+WorkflowExecution spec) and instead having the WE controller resolve it at runtime
+from the Data Storage catalog into `WorkflowExecution.Status.ServiceAccountName`.
+Additionally, the four individual `WorkflowQuerier` methods that each call
+`GetWorkflowByID` are consolidated into a single `ResolveWorkflowCatalogMetadata`
+method, and the duplicate `BuildPipelineRun`/`PipelineRunName` in the reconciler
+are removed in favor of the executor's canonical implementations.
+
+### 1.2 Objectives
+
+1. **SA resolved from DS at runtime**: WE controller fetches SA from the DS catalog via
+   consolidated `ResolveWorkflowCatalogMetadata` and writes it to `wfe.Status.ServiceAccountName`.
+2. **SA removed from upstream types**: `SelectedWorkflow.ServiceAccountName` (AA type) and
+   `WorkflowExecutionSpec.ServiceAccountName` are deleted; RO creator and response_processor
+   stop propagating SA.
+3. **Executors read from status**: All three executors (Tekton, Job, Ansible) read
+   `wfe.Status.ServiceAccountName` instead of `wfe.Spec.ServiceAccountName`.
+4. **Consolidated DS call**: Single `GetWorkflowByID` call replaces four individual calls;
+   old querier methods removed.
+5. **Deduplication**: Reconciler's `BuildPipelineRun`, `PipelineRunName`, and `ConvertParameters`
+   removed; `HandleAlreadyExists` refactored to accept `resourceName string`.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/workflowexecution/... ./test/unit/remediationorchestrator/... ./test/unit/aianalysis/...` |
+| Integration test pass rate | 100% | `go test ./test/integration/workflowexecution/...` |
+| Unit-testable code coverage | >=80% | `go test -coverprofile` on unit-testable files |
+| Integration-testable code coverage | >=80% | `go test -coverprofile` on integration-testable files |
+| Regressions | 0 | All existing tests pass (beyond planned migration) |
+| No Spec.ServiceAccountName refs | 0 | `rg 'Spec\.ServiceAccountName' --glob '*.go'` returns 0 non-comment hits |
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- DD-WE-005 v2.0: Per-workflow ServiceAccount reference
+- DD-WE-006: WFE queries DS on demand using the workflow ID
+- Issue #650: Simplify SA propagation
+- Issue #518: Runtime engine resolution (established pattern)
+- Issue #501: SA schema migration to spec top-level (predecessor)
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../../.cursor/rules/03-testing-strategy.mdc)
+- [Test Case Specification Template](../../testing/TEST_CASE_SPECIFICATION_TEMPLATE.md)
+- [Integration/E2E No-Mocks Policy](../../testing/INTEGRATION_E2E_NO_MOCKS_POLICY.md)
+- [Testing Guidelines](../../development/business-requirements/TESTING_GUIDELINES.md)
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | DS catalog entry has no SA set | Executor receives empty SA, uses K8s default | Low | UT-WE-650-002 | Empty SA is the intended fallback; tested explicitly |
+| R2 | Status write timing: SA not persisted before exec.Create | Executor reads stale empty SA | Low | UT-WE-650-001 | SA set in-memory before exec.Create (same pattern as ExecutionEngine) |
+| R3 | Existing WFEs in etcd lose spec.serviceAccountName on CRD regen | Silent data loss for in-flight WFEs | Medium | (Operational) | WE controller re-resolves SA from DS; spec field was informational not authoritative |
+| R4 | Ansible executor reads SA in 8+ locations | Missed reference causes fallback regression | Medium | UT-WE-650-005 | Exhaustive grep; all 8 locations mapped in preflight |
+| R5 | HandleAlreadyExists refactor breaks race condition handling | PipelineRun collision not detected | Low | UT-WE-650-011 | Only `pr.Name` was used; resourceName string is equivalent |
+
+### 3.1 Risk-to-Test Traceability
+
+- **R1** (empty SA fallback): UT-WE-650-002 explicitly tests empty OptString from DS
+- **R2** (status timing): UT-WE-650-001 verifies SA in status before exec.Create
+- **R4** (Ansible 8 refs): UT-WE-650-005 covers tokenRequest path with status-sourced SA
+- **R5** (HandleAlreadyExists): UT-WE-650-011 verifies refactored signature works
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **WFE CRD types** (`api/workflowexecution/v1alpha1/workflowexecution_types.go`): SA removed from spec, added to status
+- **AA CRD types** (`api/aianalysis/v1alpha1/aianalysis_types.go`): SA removed from SelectedWorkflow
+- **Consolidated querier** (`pkg/workflowexecution/client/workflow_querier.go`): `ResolveWorkflowCatalogMetadata` returns all metadata from single DS call
+- **WE controller** (`internal/controller/workflowexecution/workflowexecution_controller.go`): Consolidated resolve + SA-to-status write + dedup cleanup
+- **Tekton executor** (`pkg/workflowexecution/executor/tekton.go`): Reads `wfe.Status.ServiceAccountName`
+- **Job executor** (`pkg/workflowexecution/executor/job.go`): Reads `wfe.Status.ServiceAccountName`
+- **Ansible executor** (`pkg/workflowexecution/executor/ansible.go`): All 8 SA references read from status
+- **RO creator** (`pkg/remediationorchestrator/creator/workflowexecution.go`): Stops copying SA to WFE spec
+- **AA response processor** (`pkg/aianalysis/handlers/response_processor.go`): Stops extracting SA from HAPI response
+
+### 4.2 Features Not to be Tested
+
+- **KA internal types** (`InvestigationResult.ServiceAccountName`): Kept for HAPI observability, not part of the propagation chain removal
+- **DS catalog schema**: SA stays in catalog (source of truth)
+- **RemediationWorkflow CRD**: SA stays (source of truth for DS)
+- **E2E tests**: Deferred to CI pipeline; UT + IT provide adequate coverage
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| SA in WFE status, not CreateOptions | Operator visibility via `kubectl get wfe -oyaml`; no executor interface change |
+| Consolidate all 4 querier calls into 1 | Eliminates 3 redundant `GetWorkflowByID` calls per reconcile |
+| Delete reconciler BuildPipelineRun | Exact duplicate of executor's buildPipelineRun; HandleAlreadyExists only needs name |
+| Replace PipelineRunName with ExecutionResourceName | Byte-for-byte identical; executor version is canonical |
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+**Authority**: `03-testing-strategy.mdc` — Per-Tier Testable Code Coverage.
+
+- **Unit**: >=80% of unit-testable code (querier, executor SA reads, RO creator, response_processor)
+- **Integration**: >=80% of integration-testable code (reconciler SA-to-status, consolidated resolve, HandleAlreadyExists)
+- **E2E**: Deferred — existing E2E suite validates full workflow execution; SA source change is transparent
+
+### 5.2 Two-Tier Minimum
+
+Every behavioral change is covered by at least 2 tiers (UT + IT):
+- **Unit tests**: Querier consolidation, executor SA source, RO creator, AA processor
+- **Integration tests**: Reconciler lifecycle with SA in status, HandleAlreadyExists with resourceName
+
+### 5.3 Business Outcome Quality Bar
+
+Tests validate observable behavior: "SA appears in WFE status", "executors use SA from status",
+"no SA in WFE spec", "single DS call per reconcile".
+
+### 5.4 Pass/Fail Criteria
+
+**PASS** — all of:
+1. All P0 tests pass (0 failures)
+2. Per-tier coverage >= 80%
+3. No regressions in existing test suites
+4. `rg 'wfe\.Spec\.ServiceAccountName' --glob '*.go'` returns 0 hits outside comments/docs
+
+**FAIL** — any of:
+1. Any P0 test fails
+2. Per-tier coverage below 80%
+3. Existing tests regress
+4. Any executor still reads `wfe.Spec.ServiceAccountName`
+
+### 5.5 Suspension & Resumption Criteria
+
+**Suspend**: Build broken; CRD regen produces unexpected diff; DS catalog API changes.
+**Resume**: Build green; CRD diff validated; API stable.
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code (pure logic, no I/O)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `pkg/workflowexecution/client/workflow_querier.go` | `ResolveWorkflowCatalogMetadata` | ~60 |
+| `pkg/workflowexecution/executor/tekton.go` | `buildPipelineRun` | ~45 |
+| `pkg/workflowexecution/executor/job.go` | `Create` (PodSpec SA) | ~5 |
+| `pkg/workflowexecution/executor/ansible.go` | `Create`, `injectK8sCredential`, `requestTokenForSA` | ~30 |
+| `pkg/remediationorchestrator/creator/workflowexecution.go` | `Create` | ~5 |
+| `pkg/aianalysis/handlers/response_processor.go` | `processLLMResponse` (3 locations) | ~15 |
+
+### 6.2 Integration-Testable Code (I/O, wiring, cross-component)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `internal/controller/workflowexecution/workflowexecution_controller.go` | `reconcilePending`, `HandleAlreadyExists` | ~80 |
+
+### 6.3 Version Identification
+
+| Item | Version/Commit | Notes |
+|------|----------------|-------|
+| Code under test | `development/v1.2` HEAD | Post-#236, post-authwebhook fix |
+| Dependency: ogen client | Generated | `ogenclient.RemediationWorkflow.ServiceAccountName` is `OptString` |
+
+---
+
+## 7. BR Coverage Matrix
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| DD-WE-005 v2.0 | SA resolved from DS at runtime into WFE status | P0 | Unit | UT-WE-650-001 | Pending |
+| DD-WE-005 v2.0 | Empty SA from DS = K8s default SA fallback | P0 | Unit | UT-WE-650-002 | Pending |
+| DD-WE-006 | Consolidated querier returns all metadata from single DS call | P0 | Unit | UT-WE-650-003 | Pending |
+| DD-WE-006 | Querier handles DS error gracefully | P0 | Unit | UT-WE-650-004 | Pending |
+| DD-WE-005 v2.0 | Ansible executor reads SA from status for TokenRequest | P0 | Unit | UT-WE-650-005 | Pending |
+| DD-WE-005 v2.0 | Tekton executor reads SA from status | P0 | Unit | UT-WE-650-006 | Pending |
+| DD-WE-005 v2.0 | Job executor reads SA from status | P0 | Unit | UT-WE-650-007 | Pending |
+| DD-WE-005 v2.0 | RO creator does not set SA on WFE spec | P0 | Unit | UT-WE-650-008 | Pending |
+| DD-WE-005 v2.0 | AA response processor does not extract SA | P0 | Unit | UT-WE-650-009 | Pending |
+| DD-WE-006 | Consolidated querier extracts dependencies from Content | P1 | Unit | UT-WE-650-010 | Pending |
+| DD-WE-003 | HandleAlreadyExists works with resourceName string | P1 | Unit | UT-WE-650-011 | Pending |
+| DD-WE-005 v2.0 | Reconciler writes SA to status during pending reconcile | P0 | Integration | IT-WE-650-001 | Pending |
+| DD-WE-006 | Integration: single DS call per reconcile | P1 | Integration | IT-WE-650-002 | Pending |
+
+---
+
+## 8. Test Scenarios
+
+### Test ID Naming Convention
+
+Format: `{TIER}-WE-650-{SEQUENCE}`
+
+### Tier 1: Unit Tests
+
+**Testable code scope**: `pkg/workflowexecution/client/`, `pkg/workflowexecution/executor/`,
+`pkg/remediationorchestrator/creator/`, `pkg/aianalysis/handlers/`
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| UT-WE-650-001 | Controller writes resolved SA from DS to `wfe.Status.ServiceAccountName` before exec.Create | Pending |
+| UT-WE-650-002 | When DS catalog has no SA, status SA is empty (K8s default fallback) | Pending |
+| UT-WE-650-003 | `ResolveWorkflowCatalogMetadata` returns engine, bundle, digest, SA, deps, engineConfig from single call | Pending |
+| UT-WE-650-004 | `ResolveWorkflowCatalogMetadata` returns error when DS is unreachable | Pending |
+| UT-WE-650-005 | Ansible executor `requestTokenForSA` uses `wfe.Status.ServiceAccountName` | Pending |
+| UT-WE-650-006 | Tekton `buildPipelineRun` sets `TaskRunTemplate.ServiceAccountName` from `wfe.Status` | Pending |
+| UT-WE-650-007 | Job executor sets `PodSpec.ServiceAccountName` from `wfe.Status` | Pending |
+| UT-WE-650-008 | RO creator builds WFE with no `ServiceAccountName` in spec | Pending |
+| UT-WE-650-009 | AA response processor does not populate `SelectedWorkflow.ServiceAccountName` | Pending |
+| UT-WE-650-010 | Consolidated querier extracts dependencies and engineConfig from Content YAML | Pending |
+| UT-WE-650-011 | `HandleAlreadyExists` accepts `resourceName string` and handles collision correctly | Pending |
+
+### Tier 2: Integration Tests
+
+**Testable code scope**: `internal/controller/workflowexecution/` (envtest with Tekton CRDs)
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| IT-WE-650-001 | Full reconcile: Pending WFE resolves SA from DS, writes to status, creates PipelineRun with correct SA | Pending |
+| IT-WE-650-002 | Reconcile calls DS exactly once (consolidated querier) | Pending |
+
+### Tier Skip Rationale
+
+- **E2E**: Deferred — SA source change is transparent to the E2E flow. The existing E2E suite
+  validates full workflow execution; the behavioral contract (SA applied to execution resource)
+  is unchanged, only the source shifts from spec to status.
+
+---
+
+## 9. Test Cases
+
+### UT-WE-650-001: SA resolved from DS written to WFE status
+
+**BR**: DD-WE-005 v2.0
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/workflowexecution/controller_test.go`
+
+**Preconditions**: Mock querier returns `WorkflowCatalogMetadata` with `ServiceAccountName: "workflow-sa"`.
+
+**Test Steps**:
+1. **Given**: A WFE in Pending phase with `WorkflowRef.WorkflowID` set
+2. **When**: Controller reconciles and calls `ResolveWorkflowCatalogMetadata`
+3. **Then**: `wfe.Status.ServiceAccountName` equals `"workflow-sa"`
+
+### UT-WE-650-003: Consolidated querier returns all metadata
+
+**BR**: DD-WE-006
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/workflowexecution/workflow_querier_test.go`
+
+**Preconditions**: Mock `WorkflowCatalogClient` returns a `RemediationWorkflow` with all fields populated.
+
+**Test Steps**:
+1. **Given**: DS catalog entry with engine=tekton, bundle=ghcr.io/test, SA=workflow-sa, Content with deps
+2. **When**: `ResolveWorkflowCatalogMetadata` is called
+3. **Then**: Returned `WorkflowCatalogMetadata` has all fields populated from the single response
+
+### UT-WE-650-008: RO creator builds WFE without SA
+
+**BR**: DD-WE-005 v2.0
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/remediationorchestrator/workflowexecution_creator_sa_test.go`
+
+**Preconditions**: AIAnalysis with SelectedWorkflow that has no ServiceAccountName field.
+
+**Test Steps**:
+1. **Given**: AA status with selected workflow (no SA field in type)
+2. **When**: RO creator builds WorkflowExecution
+3. **Then**: `wfe.Spec` has no `ServiceAccountName` field (field does not exist in type)
+
+---
+
+## 10. Environmental Needs
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Mocks**: `mockWorkflowCatalogClient` (DS client), `fake.NewClientBuilder()` (K8s)
+- **Location**: `test/unit/workflowexecution/`, `test/unit/remediationorchestrator/`, `test/unit/aianalysis/`
+
+### 10.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Infrastructure**: envtest with Tekton CRDs, PostgreSQL + Redis (shared infra), real DS
+- **Location**: `test/integration/workflowexecution/`
+
+### 10.3 Tools & Versions
+
+| Tool | Minimum Version | Purpose |
+|------|-----------------|---------|
+| Go | 1.23 | Build and test |
+| Ginkgo CLI | v2.x | Test runner |
+| controller-gen | v0.x | CRD generation |
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Blocking Dependencies
+
+| Dependency | Type | Status | Impact if Not Available | Workaround |
+|------------|------|--------|-------------------------|------------|
+| Issue #501 | Code | Merged | SA schema baseline | N/A (already merged) |
+| Issue #518 | Code | Merged | Runtime engine resolution pattern | N/A (already merged) |
+
+### 11.2 Execution Order
+
+1. **Phase 1 RED**: Type changes + new/updated failing tests
+2. **Phase 2 GREEN**: Implement querier, controller SA-to-status, executor updates, CRD regen
+3. **Phase 3 REFACTOR**: Remove old querier methods, dedup BuildPipelineRun/PipelineRunName
+
+---
+
+## 12. Test Deliverables
+
+| Deliverable | Location | Description |
+|-------------|----------|-------------|
+| This test plan | `docs/tests/650/TEST_PLAN.md` | Strategy and test design |
+| Unit test suite | `test/unit/workflowexecution/`, `test/unit/remediationorchestrator/`, `test/unit/aianalysis/` | Ginkgo BDD test files |
+| Integration test suite | `test/integration/workflowexecution/` | Ginkgo BDD test files |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests
+go test ./test/unit/workflowexecution/... -ginkgo.v
+go test ./test/unit/remediationorchestrator/... -ginkgo.v
+go test ./test/unit/aianalysis/... -ginkgo.v
+
+# Integration tests
+go test ./test/integration/workflowexecution/... -ginkgo.v
+
+# Specific test by ID
+go test ./test/unit/workflowexecution/... -ginkgo.focus="UT-WE-650"
+
+# Coverage
+go test ./test/unit/workflowexecution/... -coverprofile=coverage.out
+go tool cover -func=coverage.out
+```
+
+---
+
+## 14. Existing Tests Requiring Updates
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|-------------------|-------------------|-----------------|--------|
+| `executor_sa_test.go` (5 refs) | `wfe.Spec.ServiceAccountName` | Change to `wfe.Status.ServiceAccountName` | SA moved to status |
+| `controller_test.go` (2 refs) | `wfe.Spec.ServiceAccountName` in BuildPipelineRun assertions | Remove/rewrite for status-based SA | BuildPipelineRun deleted |
+| `executor_test.go` (2 refs) | `wfe.Spec.ServiceAccountName` | Change to `wfe.Status.ServiceAccountName` | SA moved to status |
+| `workflowexecution_creator_sa_test.go` (4 refs) | Sets `SelectedWorkflow.ServiceAccountName` | Remove SA from AA type; assert WFE has no spec SA | SA removed from upstream |
+| `reconciler_test.go` (2 refs) | `wfe.Spec.ServiceAccountName` | Change to `wfe.Status.ServiceAccountName` | SA moved to status |
+| `job_lifecycle_integration_test.go` (1 ref) | `wfe.Spec.ServiceAccountName` | Change to `wfe.Status.ServiceAccountName` | SA moved to status |
+| `response_processor_sa_test.go` | Asserts SA extracted from HAPI response | Rewrite: assert SA is NOT extracted | SA extraction removed |
+
+---
+
+## 15. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-06 | Initial test plan |

--- a/docs/tests/658/TEST_PLAN.md
+++ b/docs/tests/658/TEST_PLAN.md
@@ -1,0 +1,550 @@
+# Test Plan: WorkflowQuerier HTTP 500 Error Classification
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+>
+> Based on IEEE 829-2008 (Standard for Software and System Test Documentation) with
+> Kubernaut-specific extensions for TDD phase tracking, business requirement traceability,
+> and per-tier coverage policy.
+
+**Test Plan Identifier**: TP-658-v1
+**Feature**: Correct classification of Data Storage (DS) responses in `OgenWorkflowQuerier` so HTTP 500 is never reported as catalog/workflow "not found"
+**Version**: 1.0
+**Created**: 2026-04-09
+**Author**: AI Assistant
+**Status**: Draft
+**Branch**: `development/v1.3` (or feature branch for #658)
+
+---
+
+## 1. Introduction
+
+> **IEEE 829 §3** — Purpose, objectives, and measurable success criteria for the test effort.
+
+### 1.1 Purpose
+
+This test plan exists to prevent misleading operator and automation behavior when DS returns HTTP 500 for workflow catalog queries. Today, five methods in `OgenWorkflowQuerier` use type assertions that misclassify `*GetWorkflowByIDInternalServerError` as a "not found" style outcome, corrupting error taxonomy used downstream (audit codes, Kubernetes event reasons, and `MarkFailedWithReason` classification). The plan defines unit-level scenarios and TDD phases so fixes are provably correct without relying on integration I/O.
+
+### 1.2 Objectives
+
+1. **Correct 500 handling**: When DS returns ogen type `*GetWorkflowByIDInternalServerError`, every affected querier method returns an error that clearly indicates server/catalog failure, not "workflow not found."
+2. **Preserved 404 semantics**: When DS returns `*GetWorkflowByIDNotFound`, errors continue to indicate that the workflow/catalog entry was not found.
+3. **Unexpected type safety**: Any response type outside the expected 200/404/500 sum-type branches yields an explicit `unexpected response type %T` error.
+4. **Deduplication guard**: If a central helper is introduced in REFACTOR, all five code paths use the same classification logic (single source of truth).
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/workflowexecution/...` (focus on WorkflowQuerier / #658 scenarios) |
+| Integration test pass rate | N/A (skipped) | See Section 8 — Tier Skip Rationale |
+| Unit-testable code coverage | >=80% | `go test -coverprofile` on `pkg/workflowexecution/client/` (querier-focused) |
+| Integration-testable code coverage | N/A | Not in scope for this issue |
+| Backward compatibility | 0 regressions | Existing `workflow_querier_test.go` and related suites pass |
+
+---
+
+## 2. References
+
+> **IEEE 829 §2** — Documents that govern or inform this test plan.
+
+### 2.1 Authority (governing documents)
+
+- DD-WE-006: Catalog query correctness (workflow metadata resolution from DS)
+- DD-API-001: Typed OpenAPI (ogen) client usage for DS communication
+- Issue #658: WorkflowQuerier misleading error classification when DS returns HTTP 500
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../../.cursor/rules/03-testing-strategy.mdc)
+- [Test Case Specification Template](../../testing/TEST_CASE_SPECIFICATION_TEMPLATE.md)
+- [Integration/E2E No-Mocks Policy](../../testing/INTEGRATION_E2E_NO_MOCKS_POLICY.md)
+- [Testing Guidelines](../../development/business-requirements/TESTING_GUIDELINES.md)
+
+---
+
+## 3. Risks & Mitigations
+
+> **IEEE 829 §5** — Software risk issues that drive test design.
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | Downstream components treat "not found" differently from "server error" | Wrong remediation, masked outages, incorrect audit | High | UT-WE-658-001..006 | Assert error strings/wrapping or sentinel semantics consistent with server failure, not `IsNotFound`-style messaging |
+| R2 | Fix only one of five methods | Partial misclassification remains | Medium | UT-WE-658-007 | Table or shared helper test; exercise all entry points |
+| R3 | ogen sum-type extended in future | New branch unhandled | Low | UT-WE-658-008 | Default branch in type switch with `%T` |
+| R4 | Regression on 404 path | Operators see false "server" errors | Medium | UT-WE-658-002 | Explicit 404 scenario remains green |
+
+### 3.1 Risk-to-Test Traceability
+
+- **R1** → UT-WE-658-001, UT-WE-658-003, UT-WE-658-004, UT-WE-658-005, UT-WE-658-006 (500 paths per method family).
+- **R2** → UT-WE-658-007 (central helper / shared classification).
+- **R3** → UT-WE-658-008 (unexpected response type).
+- **R4** → UT-WE-658-002 (404 unchanged).
+
+---
+
+## 4. Scope
+
+> **IEEE 829 §6/§7** — Features to be tested and features not to be tested.
+
+### 4.1 Features to be Tested
+
+- **OgenWorkflowQuerier** (`pkg/workflowexecution/client/workflow_querier.go`): Response handling for `GetWorkflowByID` (or equivalent) ogen union: `*RemediationWorkflow` (200), `*GetWorkflowByIDNotFound` (404), `*GetWorkflowByIDInternalServerError` (500), and default/unexpected types.
+- **Production call sites (behavioral contract)**: Logic consumed by `resolveWorkflowCatalog` (Pending) and `resolveExecutionEngine` / related paths (Running, Terminal, Delete) must receive correctly classified errors (validated indirectly via querier unit tests).
+
+### 4.2 Features Not to be Tested
+
+- **DS HTTP server implementation**: External service; mocked via test doubles returning ogen response types.
+- **Full controller reconcile loops**: Covered under separate integration/E2E plans; this issue is unit-testable classification logic.
+- **ogen-generated client internals** (`pkg/agentclient/` ogen files): Generated code; not modified by this fix.
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Unit-only tier for #658 | Classification is pure mapping from ogen sum type to error; no real network or envtest required |
+| RED uses mock returning `*GetWorkflowByIDInternalServerError` | Matches production ogen types; avoids stringly HTTP stubs |
+| REFACTOR may introduce central helper | Removes five copy-paste type switches; UT-WE-658-007 locks behavior |
+
+---
+
+## 5. Approach
+
+> **IEEE 829 §8/§9/§10** — Test strategy, pass/fail criteria, and suspension/resumption.
+
+### 5.1 Coverage Policy
+
+**Authority**: `03-testing-strategy.mdc` — Per-Tier Testable Code Coverage.
+
+- **Unit**: >=80% of **unit-testable** code in `pkg/workflowexecution/client/` relevant to `workflow_querier.go` (querier methods and any extracted helper).
+- **Integration**: Skipped for this test plan — see Section 8 (Tier Skip Rationale).
+- **E2E**: Not required for sum-type error mapping.
+
+### 5.2 Two-Tier Minimum
+
+Every business requirement is covered by at least two test tiers where applicable. For this issue, **integration tier is explicitly skipped** with documented rationale (Section 8): the behavior under test is unit-testable pure logic with no I/O. **Dual coverage** is achieved via (1) per-method 500 tests and (2) regression 404 + unexpected-type tests, plus optional central-helper assertion.
+
+### 5.3 Business Outcome Quality Bar
+
+Tests validate **operator-observable error semantics**: a DS outage or internal error must not be indistinguishable from "workflow not in catalog." Assertions must reflect business meaning (server/catalog failure vs not found), not merely "an error occurred."
+
+### 5.4 Pass/Fail Criteria
+
+> **IEEE 829 §9** — When is this test plan considered passed or failed?
+
+**PASS** — all of the following must be true:
+
+1. All P0 tests pass (0 failures): UT-WE-658-001 through UT-WE-658-006, UT-WE-658-008
+2. UT-WE-658-007 passes if a central helper exists; if helper is deferred, document exception and ensure R2 mitigated by explicit tests per method
+3. Per-tier unit coverage on querier package meets >=80% threshold
+4. No regressions in existing `test/unit/workflowexecution/workflow_querier_test.go`
+5. No use of `Skip()`, `time.Sleep` for synchronization, or NULL-only assertions (anti-patterns)
+
+**FAIL** — any of the following:
+
+1. Any P0 test fails
+2. Unit coverage falls below 80% on the targeted package scope
+3. Existing workflow querier tests fail without approved assertion updates (Section 14)
+4. HTTP 500 still classified as "not found" in any of the five methods
+
+### 5.5 Suspension & Resumption Criteria
+
+> **IEEE 829 §10** — When should testing stop? When can it resume?
+
+**Suspend testing when**:
+
+- Code does not compile; unit tests cannot execute
+- ogen types for `GetWorkflowByID` responses are renamed or regenerated incompatibly without updating tests
+- More than three unrelated failures appear in the same run (investigate root cause)
+
+**Resume testing when**:
+
+- Build is green
+- ogen regeneration and adapter updates are complete
+- Root cause for cascading failures is fixed
+
+---
+
+## 6. Test Items
+
+> **IEEE 829 §4** — Software items to be tested, with version identification.
+
+### 6.1 Unit-Testable Code (pure logic, no I/O)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|----------------|
+| `pkg/workflowexecution/client/workflow_querier.go` | `ResolveWorkflowCatalogMetadata`, `GetWorkflowExecutionEngine`, `GetWorkflowExecutionBundle`, `GetWorkflowDependencies`, `GetWorkflowEngineConfig`, plus any `classifyGetWorkflowByIDResponse`-style helper | ~291 |
+
+### 6.2 Integration-Testable Code (I/O, wiring, cross-component)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|----------------|
+| — | Not in scope for TP-658 | — |
+
+### 6.3 Version Identification
+
+| Item | Version/Commit | Notes |
+|------|----------------|-------|
+| Code under test | Branch HEAD for #658 | After GREEN/REFACTOR merge target |
+| ogen response types | `*RemediationWorkflow`, `*GetWorkflowByIDNotFound`, `*GetWorkflowByIDInternalServerError` | As generated in `pkg/agentclient/` |
+
+---
+
+## 7. BR Coverage Matrix
+
+> Kubernaut-specific. Maps every business requirement to test scenarios across tiers.
+
+| BR / DD ID | Description | Priority | Tier | Test ID | Status |
+|------------|-------------|----------|------|---------|--------|
+| DD-WE-006 | Catalog query correctness | P0 | Unit | UT-WE-658-001, UT-WE-658-002 | Pending |
+| DD-API-001 | Typed ogen client for DS | P0 | Unit | UT-WE-658-001..006, UT-WE-658-008 | Pending |
+| DD-WE-006 | Engine/bundle/deps/config query correctness | P0 | Unit | UT-WE-658-003..006 | Pending |
+| (Maintainability) | Single classification helper | P1 | Unit | UT-WE-658-007 | Pending |
+
+### Status Legend
+
+- **Pending**: Specification complete, implementation not started
+- **RED**: Failing test written (TDD RED phase)
+- **GREEN**: Minimal implementation passes (TDD GREEN phase)
+- **REFACTORED**: Code cleaned up (TDD REFACTOR phase)
+- **Pass**: Implemented and passing
+
+---
+
+## 8. Test Scenarios
+
+> **IEEE 829 Test Design Specification** — How test cases are organized and grouped.
+
+### Test ID Naming Convention
+
+Format: `{TIER}-{SERVICE}-{ISSUE}-{SEQUENCE}` (issue-scoped plan; aligns with traceability to #658)
+
+- **TIER**: `UT` (Unit)
+- **SERVICE**: `WE` (WorkflowExecution)
+- **ISSUE**: `658`
+- **SEQUENCE**: Zero-padded 3-digit (001, 002, ...)
+
+### Tier 1: Unit Tests
+
+**Testable code scope**: `pkg/workflowexecution/client/workflow_querier.go` — >=80% coverage of querier package (unit-testable subset).
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| UT-WE-658-001 | `ResolveWorkflowCatalogMetadata` + DS 500 → error indicates server/catalog failure, **not** "not found" | Pending |
+| UT-WE-658-002 | `ResolveWorkflowCatalogMetadata` + DS 404 → error correctly indicates not found | Pending |
+| UT-WE-658-003 | `GetWorkflowExecutionEngine` + DS 500 → server error classification | Pending |
+| UT-WE-658-004 | `GetWorkflowExecutionBundle` + DS 500 → server error classification | Pending |
+| UT-WE-658-005 | `GetWorkflowDependencies` + DS 500 → server error classification | Pending |
+| UT-WE-658-006 | `GetWorkflowEngineConfig` + DS 500 → server error classification | Pending |
+| UT-WE-658-007 | Central helper deduplication (if implemented) — all methods use same classification | Pending |
+| UT-WE-658-008 | Unexpected response type → error containing `unexpected response type` and `%T` | Pending |
+
+### Tier 2: Integration Tests
+
+**Testable code scope**: None for this plan.
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| — | — | — |
+
+### Tier 3: E2E Tests (if applicable)
+
+**Testable code scope**: Not applicable.
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| — | — | — |
+
+### Tier Skip Rationale (if any tier is omitted)
+
+- **Integration**: Skipped. Error classification is **unit-testable pure logic**: mock client returns concrete ogen pointer types; no real DS, no envtest, no HTTP integration needed. Blast radius (audit/events) is indirect and covered by controller plans when behavior changes propagate.
+- **E2E**: Skipped. Not required for sum-type mapping correctness.
+
+---
+
+## 9. Test Cases
+
+> **IEEE 829 Test Case Specification** — Detailed specification for each test case.
+
+### UT-WE-658-001: ResolveWorkflowCatalogMetadata — DS 500
+
+**BR / DD**: DD-WE-006, DD-API-001
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/workflowexecution/workflow_querier_test.go`
+
+**Preconditions**:
+
+- Test double implements workflow querier dependency such that `GetWorkflowByID` returns `*GetWorkflowByIDInternalServerError` (or equivalent ogen 500 type).
+
+**Test Steps**:
+
+1. **Given**: Mock returns internal server error response type for catalog ID lookup
+2. **When**: `ResolveWorkflowCatalogMetadata` is invoked
+3. **Then**: Returned error MUST NOT assert or imply "not found" / missing catalog as the primary classification; it MUST indicate server/catalog retrieval failure
+
+**Expected Results**:
+
+1. Error is non-nil
+2. Error message or wrapped cause is consistent with internal/server failure semantics (not not-found wording used for 404 path)
+
+**Acceptance Criteria**:
+
+- **Behavior**: Callers can distinguish outage/server failure from missing workflow
+- **Correctness**: 500 ogen branch is handled explicitly in type switch (or helper)
+- **Accuracy**: No conflation with 404 handling
+
+**Dependencies**: ogen types available in test package; existing test patterns in `workflow_querier_test.go`
+
+---
+
+### UT-WE-658-002: ResolveWorkflowCatalogMetadata — DS 404
+
+**BR / DD**: DD-WE-006
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/workflowexecution/workflow_querier_test.go`
+
+**Preconditions**:
+
+- Mock returns `*GetWorkflowByIDNotFound`
+
+**Test Steps**:
+
+1. **Given**: DS indicates workflow ID not found
+2. **When**: `ResolveWorkflowCatalogMetadata` is invoked
+3. **Then**: Error indicates not found (existing behavior preserved)
+
+**Expected Results**:
+
+1. Error is non-nil
+2. Semantics match pre-fix 404 behavior (regression guard)
+
+**Acceptance Criteria**:
+
+- **Behavior**: Missing catalog entry still reported as not found
+- **Correctness**: 404 branch unchanged aside from shared refactor
+
+**Dependencies**: UT-WE-658-001 (ordering optional; logically independent)
+
+---
+
+### UT-WE-658-003: GetWorkflowExecutionEngine — DS 500
+
+**BR / DD**: DD-WE-006, DD-API-001
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/workflowexecution/workflow_querier_test.go`
+
+**Preconditions**: Mock returns `*GetWorkflowByIDInternalServerError`
+
+**Test Steps**:
+
+1. **Given** / **When** / **Then**: Same pattern as UT-WE-658-001 for `GetWorkflowExecutionEngine`
+
+**Expected Results**: Server error classification; not "not found"
+
+**Acceptance Criteria**: Align with UT-WE-658-001 criteria
+
+**Dependencies**: None
+
+---
+
+### UT-WE-658-004: GetWorkflowExecutionBundle — DS 500
+
+**BR / DD**: DD-WE-006, DD-API-001
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/workflowexecution/workflow_querier_test.go`
+
+**Preconditions**: Mock returns `*GetWorkflowByIDInternalServerError`
+
+**Test Steps**: Invoke `GetWorkflowExecutionBundle`; assert server error classification
+
+**Expected Results**: Non-nil error; not misclassified as not found
+
+**Acceptance Criteria**: Same as UT-WE-658-001
+
+**Dependencies**: None
+
+---
+
+### UT-WE-658-005: GetWorkflowDependencies — DS 500
+
+**BR / DD**: DD-WE-006, DD-API-001
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/workflowexecution/workflow_querier_test.go`
+
+**Preconditions**: Mock returns `*GetWorkflowByIDInternalServerError`
+
+**Test Steps**: Invoke `GetWorkflowDependencies`; assert server error classification
+
+**Expected Results**: Non-nil error; not misclassified as not found
+
+**Acceptance Criteria**: Same as UT-WE-658-001
+
+**Dependencies**: None
+
+---
+
+### UT-WE-658-006: GetWorkflowEngineConfig — DS 500
+
+**BR / DD**: DD-WE-006, DD-API-001
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/workflowexecution/workflow_querier_test.go`
+
+**Preconditions**: Mock returns `*GetWorkflowByIDInternalServerError`
+
+**Test Steps**: Invoke `GetWorkflowEngineConfig`; assert server error classification
+
+**Expected Results**: Non-nil error; not misclassified as not found
+
+**Acceptance Criteria**: Same as UT-WE-658-001
+
+**Dependencies**: None
+
+---
+
+### UT-WE-658-007: Central helper — single classification (REFACTOR)
+
+**BR / DD**: Maintainability / DD-API-001
+**Priority**: P1
+**Type**: Unit
+**File**: `test/unit/workflowexecution/workflow_querier_test.go` (or `_test` in same package if testing unexported helper)
+
+**Preconditions**: REFACTOR introduces shared function (e.g. `classifyGetWorkflowByIDResponse`)
+
+**Test Steps**:
+
+1. **Given**: Helper used by all five methods
+2. **When**: Each public method receives 500 / 404 / success via mock
+3. **Then**: All paths delegate to same classification outcomes
+
+**Expected Results**: No drift between methods; optional direct unit tests on helper if exported or `export_test` pattern used per project conventions
+
+**Acceptance Criteria**: DRY compliance without behavior change
+
+**Dependencies**: GREEN phase complete
+
+---
+
+### UT-WE-658-008: Unexpected response type
+
+**BR / DD**: DD-API-001
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/workflowexecution/workflow_querier_test.go`
+
+**Preconditions**: Mock returns a value that is not 200/404/500 expected types (e.g. wrong concrete type or nil wrapper per test design)
+
+**Test Steps**:
+
+1. **Given**: Unexpected type from client
+2. **When**: Any of the five methods processes the response
+3. **Then**: Error matches pattern `unexpected response type %T` (or project-standard equivalent)
+
+**Expected Results**: Fail-fast, debuggable error
+
+**Acceptance Criteria**: Default branch of type switch is covered
+
+**Dependencies**: None
+
+---
+
+## 10. Environmental Needs
+
+> **IEEE 829 §13** — Hardware, software, tools, and infrastructure required.
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: Mock workflow/DS client interface returning ogen-generated response pointers only (external dependency boundary)
+- **Location**: `test/unit/workflowexecution/workflow_querier_test.go`
+- **Resources**: Standard developer machine
+
+### 10.2 Integration Tests
+
+- **Framework**: N/A (tier skipped)
+- **Mocks**: N/A
+- **Infrastructure**: N/A
+- **Location**: N/A
+
+### 10.3 E2E Tests (if applicable)
+
+- Not applicable.
+
+### 10.4 Tools & Versions
+
+| Tool | Minimum Version | Purpose |
+|------|-----------------|---------|
+| Go | Project `go.mod` | Build and test |
+| Ginkgo CLI | v2.x | BDD test runner |
+
+---
+
+## 11. Dependencies & Schedule
+
+> **IEEE 829 §12/§16** — Remaining tasks, blocking issues, and execution order.
+
+### 11.1 Blocking Dependencies
+
+| Dependency | Type | Status | Impact if Not Available | Workaround |
+|------------|------|--------|-------------------------|------------|
+| ogen types for GetWorkflowByID | Code | Available on branch | Cannot compile RED tests | Regenerate client from OpenAPI |
+| Issue #658 implementation branch | Code | Open | Tests target wrong behavior | Rebase after merge |
+
+### 11.2 Execution Order (TDD)
+
+1. **RED**: Add tests UT-WE-658-001..006, UT-WE-658-008 using mock returning `*GetWorkflowByIDInternalServerError` and unexpected types; confirm failures on current misclassification
+2. **GREEN**: Implement type switch (or helper) distinguishing 200 / 404 / 500 / default
+3. **REFACTOR**: Deduplicate five blocks into central helper; add UT-WE-658-007
+4. **Check**: Coverage >=80% on `pkg/workflowexecution/client` for querier scope; full unit package regression
+
+---
+
+## 12. Test Deliverables
+
+> **IEEE 829 §11** — What artifacts this test effort produces.
+
+| Deliverable | Location | Description |
+|-------------|----------|-------------|
+| This test plan | `docs/tests/658/TEST_PLAN.md` | Strategy and test design |
+| Unit test suite | `test/unit/workflowexecution/workflow_querier_test.go` | Ginkgo BDD additions for #658 |
+| Coverage report | CI artifact / local `coverage.out` | Per-tier coverage for client package |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests — workflow querier suite
+go test ./test/unit/workflowexecution/... -ginkgo.v
+
+# Focus by issue/scenario description (adjust Describe/Context strings to match implementation)
+go test ./test/unit/workflowexecution/... -ginkgo.focus="658" -ginkgo.v
+
+# Coverage (package under test)
+go test ./pkg/workflowexecution/client/... -coverprofile=/tmp/we_client.cover.out
+go tool cover -func=/tmp/we_client.cover.out
+```
+
+---
+
+## 14. Existing Tests Requiring Updates (if applicable)
+
+> When implementation changes behavior that existing tests assert on, document the
+> required updates here to prevent surprises during TDD GREEN phase.
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|-------------------|-------------------|-----------------|--------|
+| `workflow_querier_test.go` (500 paths if any) | May expect generic error or not cover 500 | Assert explicit server-error semantics | Align with new classification |
+| Any test assuming 500 → "not found" | Misaligned | Update to expect server/catalog failure | Correct business semantics |
+
+---
+
+## 15. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-09 | Initial test plan for Issue #658 |

--- a/docs/tests/659/TEST_PLAN.md
+++ b/docs/tests/659/TEST_PLAN.md
@@ -1,0 +1,526 @@
+# Test Plan: WorkflowExecution Controller Validation Observability (SOC2)
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+>
+> Based on IEEE 829-2008 (Standard for Software and System Test Documentation) with
+> Kubernaut-specific extensions for TDD phase tracking, business requirement traceability,
+> and per-tier coverage policy.
+
+**Test Plan Identifier**: TP-659-v1
+**Feature**: Emit `WorkflowValidationFailed` Kubernetes events (and aligned observability) for all validation-class failures in the WorkflowExecution controller, closing gaps vs spec/catalog paths for SOC2-aligned monitoring and incident response
+**Version**: 1.0
+**Created**: 2026-04-09
+**Author**: AI Assistant
+**Status**: Draft
+**Branch**: `development/v1.3` (or feature branch for #659)
+
+---
+
+## 1. Introduction
+
+> **IEEE 829 §3** — Purpose, objectives, and measurable success criteria for the test effort.
+
+### 1.1 Purpose
+
+The WorkflowExecution controller already emits `WorkflowFailed` events and audit records for many failure paths. Validation-class failures (dependency validation, unsupported engine) currently reach operators primarily through generic `WorkflowFailed` via `MarkFailedWithReason`, weakening distinguishability for monitoring, alerting, and SOC2 control evidence (CC7.2 monitoring, CC7.3 incident response, CC8.1 change management). This test plan defines unit and integration scenarios to enforce **human-approved** behavior: add `WorkflowValidationFailed` for all validation-class failures, consistent with spec validation and catalog resolution paths.
+
+### 1.2 Objectives
+
+1. **Event reason uniformity**: Dependency validation failure and unsupported engine failure emit `WorkflowValidationFailed` **before** terminal status updates that use `MarkFailedWithReason`, matching spec/catalog patterns.
+2. **Regression guards**: Catalog resolution failure and spec validation failure continue to emit `WorkflowValidationFailed` (existing behavior locked by tests).
+3. **Running-phase observability**: `reconcileRunning` engine resolution failure emits an appropriate event and log level per product standards (P1).
+4. **Integration fidelity**: Full `reconcilePending` with failing `DependencyValidator` drains fake recorder and asserts `WorkflowValidationFailed` reason string.
+5. **Coverage**: >=80% of controller **validation paths** exercised by this plan’s tiers combined with existing suite.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/workflowexecution/...` (focus on #659 / controller) |
+| Integration test pass rate | 100% | `go test ./test/integration/workflowexecution/...` (IT-WE-659-001) |
+| Unit-testable code coverage | >=80% | `go test -coverprofile` on validation-path logic in controller (shared with existing tests) |
+| Integration-testable code coverage | >=80% | Reconcile paths with fake client + recorder |
+| Backward compatibility | 0 unintended regressions | Existing controller/integration tests updated only where event reason intentionally changes |
+
+---
+
+## 2. References
+
+> **IEEE 829 §2** — Documents that govern or inform this test plan.
+
+### 2.1 Authority (governing documents)
+
+- BR-WE-005: Failure audit trail for workflow execution
+- BR-WE-095: Kubernetes event observability for workflow execution
+- DD-EVENT-001: Event reason naming and emission conventions (validation vs generic failure)
+- SOC2 Trust Services Criteria: CC7.2, CC7.3, CC8.1 (monitoring, incident response, change management)
+- Issue #659: WE Controller observability audit for SOC2 compliance
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../../.cursor/rules/03-testing-strategy.mdc)
+- [Test Case Specification Template](../../testing/TEST_CASE_SPECIFICATION_TEMPLATE.md)
+- [Integration/E2E No-Mocks Policy](../../testing/INTEGRATION_E2E_NO_MOCKS_POLICY.md)
+- [Testing Guidelines](../../development/business-requirements/TESTING_GUIDELINES.md)
+
+---
+
+## 3. Risks & Mitigations
+
+> **IEEE 829 §5** — Software risk issues that drive test design.
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | Duplicate or conflicting events (validation + failed) confuse operators | Alert noise, unclear root cause | Medium | UT-WE-659-001..004, IT-WE-659-001 | Assert event type/reason and ordering; align with spec/catalog single-emission pattern |
+| R2 | Audit code / reason taxonomy drift from K8s event | SOC2 evidence inconsistency | Medium | All P0 tests | Assert recorder reason matches DD-EVENT-001; cross-check audit if tested in suite |
+| R3 | Integration test flakiness from timing | False CI failures | Low | IT-WE-659-001 | No `time.Sleep`; deterministic fake recorder drain |
+| R4 | Missed path (new validation without event) | Gap returns | Medium | Audit matrix + UT-WE-659-001..004 | Table-driven review of controller branches |
+
+### 3.1 Risk-to-Test Traceability
+
+- **R1, R2** → UT-WE-659-001, UT-WE-659-002, UT-WE-659-003, UT-WE-659-004, IT-WE-659-001
+- **R3** → IT-WE-659-001 (explicit anti-pattern: no sleep; sync via reconcile completion)
+- **R4** → Manual audit matrix in Section 4 + P0 regression rows
+
+**Audit matrix (code analysis baseline)**:
+
+| Path | Has Event before MarkFailed? | Event Reason (target) |
+|------|------------------------------|------------------------|
+| Spec validation fail | YES | WorkflowValidationFailed |
+| Catalog resolution fail | YES | WorkflowValidationFailed |
+| Unsupported engine | NO → **fix** | WorkflowValidationFailed |
+| Dependency validation fail | NO → **fix** | WorkflowValidationFailed |
+
+---
+
+## 4. Scope
+
+> **IEEE 829 §6/§7** — Features to be tested and features not to be tested.
+
+### 4.1 Features to be Tested
+
+- **WorkflowExecution reconciler** (`internal/controller/workflowexecution/workflowexecution_controller.go` ~1739 lines): Event emission via `r.Recorder.Event` on validation-class failures; interaction with `MarkFailed` / `MarkFailedWithReason`
+- **Pending reconcile path**: Dependency validator failure → `WorkflowValidationFailed`
+- **Engine selection path**: Unsupported engine → `WorkflowValidationFailed`
+- **Regression paths**: Catalog resolution failure, spec validation failure
+- **Running reconcile** (P1): Engine resolution failure → appropriate event + log level
+
+### 4.2 Features Not to be Tested
+
+- **Unrelated reconciler phases** (e.g. success paths without validation failure): Covered by existing suites unless regression detected
+- **External cloud audit sinks**: Unit/integration use fake recorders; end-to-end export is out of scope
+- **Full SOC2 audit pack**: This plan validates technical observability behavior, not auditor procedures
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Add `WorkflowValidationFailed` before `MarkFailedWithReason` on gap paths | Aligns unsupported engine and dependency validation with spec/catalog human decision |
+| REFACTOR: `emitValidationFailed` helper | Reduces drift; matches existing spec/catalog emission style |
+| IT-WE-659-001 uses envtest/fake recorder pattern | Satisfies integration tier without mocks of business logic |
+
+---
+
+## 5. Approach
+
+> **IEEE 829 §8/§9/§10** — Test strategy, pass/fail criteria, and suspension/resumption.
+
+### 5.1 Coverage Policy
+
+**Authority**: `03-testing-strategy.mdc` — Per-Tier Testable Code Coverage.
+
+- **Unit**: >=80% of **unit-testable** validation-path branches in the controller test harness (existing `controller_test.go` patterns)
+- **Integration**: >=80% of **integration-testable** reconcile wiring with fake Kubernetes client and event recorder
+- **E2E**: Not mandatory for this issue; optional future plan if product requires live cluster event verification
+
+### 5.2 Two-Tier Minimum
+
+BR-WE-005 and BR-WE-095 are covered by **Unit + Integration**: unit tests assert recorder invocations on isolated reconciler setup; integration test asserts full `reconcilePending` with failing `DependencyValidator` and drained events.
+
+### 5.3 Business Outcome Quality Bar
+
+Tests validate **operator-visible signals**: Kubernetes event **reason** and message content suitable for monitoring dashboards and incident triage, not only that `MarkFailed` ran.
+
+### 5.4 Pass/Fail Criteria
+
+> **IEEE 829 §9** — When is this test plan considered passed or failed?
+
+**PASS** — all of the following must be true:
+
+1. All P0 tests pass: UT-WE-659-001, UT-WE-659-002, UT-WE-659-003, UT-WE-659-004, IT-WE-659-001
+2. UT-WE-659-005 (P1) passes or is explicitly waived with reviewer approval
+3. Validation-path coverage >=80% per project measurement approach
+4. No use of `Skip()`, `time.Sleep`, or nil-only assertions
+5. Unsupported engine and dependency validation paths emit `WorkflowValidationFailed` before terminal failure handling
+
+**FAIL** — any of the following:
+
+1. Any P0 test fails
+2. Validation paths still emit only generic `WorkflowFailed` where `WorkflowValidationFailed` is required
+3. Integration test cannot deterministically observe event reason
+4. New duplicate/conflicting events without documented acceptance
+
+### 5.5 Suspension & Resumption Criteria
+
+> **IEEE 829 §10** — When should testing stop? When can it resume?
+
+**Suspend testing when**:
+
+- `envtest` or controller suite infrastructure broken cluster-wide
+- Merge conflict in `workflowexecution_controller.go` blocks consistent event API
+- More than five unrelated failures in workflowexecution test packages
+
+**Resume testing when**:
+
+- Infrastructure restored
+- Controller branch rebased and compiles
+- Root cause for cascading failures fixed
+
+---
+
+## 6. Test Items
+
+> **IEEE 829 §4** — Software items to be tested, with version identification.
+
+### 6.1 Unit-Testable Code (pure logic, no I/O)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|----------------|
+| `internal/controller/workflowexecution/workflowexecution_controller.go` | Validation branches: spec validation, catalog resolution, dependency validation, engine support checks; helpers after REFACTOR (e.g. `emitValidationFailed`) | ~1739 (subset: validation paths) |
+
+### 6.2 Integration-Testable Code (I/O, wiring, cross-component)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|----------------|
+| `internal/controller/workflowexecution/workflowexecution_controller.go` | `reconcilePending` (full path with DependencyValidator) | (subset) |
+| `test/integration/workflowexecution/` | Suite setup, fake recorder, reconciler wiring | Per existing suite |
+
+### 6.3 Version Identification
+
+| Item | Version/Commit | Notes |
+|------|----------------|-------|
+| Code under test | Branch HEAD for #659 | After GREEN/REFACTOR |
+| Related issues | #659 | Observability / SOC2 alignment |
+
+---
+
+## 7. BR Coverage Matrix
+
+> Kubernaut-specific. Maps every business requirement to test scenarios across tiers.
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-WE-005 | Failure audit / status failure alignment | P0 | Unit | UT-WE-659-001, UT-WE-659-002 | Pending |
+| BR-WE-005 | Failure audit / status failure alignment | P0 | Integration | IT-WE-659-001 | Pending |
+| BR-WE-095 | K8s event observability | P0 | Unit | UT-WE-659-001..004 | Pending |
+| BR-WE-095 | K8s event observability | P0 | Integration | IT-WE-659-001 | Pending |
+| BR-WE-095 | Running-phase engine resolution observability | P1 | Unit | UT-WE-659-005 | Pending |
+| DD-EVENT-001 | Event reason conventions | P0 | Unit/IT | UT-WE-659-001..004, IT-WE-659-001 | Pending |
+
+### Status Legend
+
+- **Pending**: Specification complete, implementation not started
+- **RED**: Failing test written (TDD RED phase)
+- **GREEN**: Minimal implementation passes (TDD GREEN phase)
+- **REFACTORED**: Code cleaned up (TDD REFACTOR phase)
+- **Pass**: Implemented and passing
+
+---
+
+## 8. Test Scenarios
+
+> **IEEE 829 Test Design Specification** — How test cases are organized and grouped.
+
+### Test ID Naming Convention
+
+Format: `{TIER}-{SERVICE}-{ISSUE}-{SEQUENCE}`
+
+- **TIER**: `UT` (Unit), `IT` (Integration)
+- **SERVICE**: `WE`
+- **ISSUE**: `659`
+- **SEQUENCE**: Zero-padded 3-digit
+
+### Tier 1: Unit Tests
+
+**Testable code scope**: `workflowexecution_controller.go` validation and running-path observability — >=80% validation-path coverage combined with existing tests.
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| UT-WE-659-001 (P0) | Dependency validation failure → `WorkflowValidationFailed` event emitted | Pending |
+| UT-WE-659-002 (P0) | Unsupported engine → `WorkflowValidationFailed` event emitted | Pending |
+| UT-WE-659-003 (P0) | Catalog resolution failure → `WorkflowValidationFailed` (regression guard) | Pending |
+| UT-WE-659-004 (P0) | Spec validation failure → `WorkflowValidationFailed` (regression guard) | Pending |
+| UT-WE-659-005 (P1) | `reconcileRunning` engine resolution failure → appropriate event + log level | Pending |
+
+### Tier 2: Integration Tests
+
+**Testable code scope**: Full pending reconcile with real controller wiring pattern from `test/integration/workflowexecution/` — >=80% for exercised reconcile path.
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| IT-WE-659-001 (P0) | `reconcilePending` with failing DependencyValidator → drain fake recorder; assert `WorkflowValidationFailed` reason | Pending |
+
+### Tier 3: E2E Tests (if applicable)
+
+**Testable code scope**: Not required for #659 closure.
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| — | Optional future: live cluster event assertion | Deferred |
+
+### Tier Skip Rationale (if any tier is omitted)
+
+- **E2E**: Deferred. Unit + integration provide sufficient evidence for event reason emission; E2E adds cluster cost without unique coverage for this change if integration already drains recorder on real reconciler.
+
+---
+
+## 9. Test Cases
+
+> **IEEE 829 Test Case Specification** — Detailed specification for each test case.
+
+### UT-WE-659-001 (P0): Dependency validation failure → WorkflowValidationFailed
+
+**BR**: BR-WE-005, BR-WE-095
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/workflowexecution/controller_test.go` (or established controller unit test file)
+
+**Preconditions**:
+
+- Reconciler constructed with fake client and **fake event recorder**
+- Dependency validator returns error (or dependency manifest invalid per test setup)
+
+**Test Steps**:
+
+1. **Given**: WorkflowExecution resource triggers pending reconcile path that runs dependency validation
+2. **When**: Reconcile processes validation failure
+3. **Then**: Recorder receives an event with reason `WorkflowValidationFailed` **before** or in conjunction with status update per spec/catalog ordering (must not be only generic `WorkflowFailed` for validation class)
+
+**Expected Results**:
+
+1. Event reason string equals `WorkflowValidationFailed` (exact constant per `DD-EVENT-001`)
+2. `MarkFailedWithReason` may still run; validation event must be present for operators
+
+**Acceptance Criteria**:
+
+- **Behavior**: Monitoring can filter validation failures distinctly
+- **Correctness**: Aligns with audit matrix row "Dependency validation fail"
+- **Accuracy**: Event targets correct object reference (workflow execution)
+
+**Dependencies**: Existing controller unit test harness
+
+**TDD note**: RED expects `WorkflowValidationFailed`; current code may only emit `WorkflowFailed` until GREEN.
+
+---
+
+### UT-WE-659-002 (P0): Unsupported engine → WorkflowValidationFailed
+
+**BR**: BR-WE-005, BR-WE-095
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/workflowexecution/controller_test.go`
+
+**Preconditions**: Workflow spec references engine type controller does not support
+
+**Test Steps**:
+
+1. **Given** / **When**: Reconcile hits unsupported engine branch
+2. **Then**: `WorkflowValidationFailed` recorded
+
+**Expected Results**: Same as UT-WE-659-001 for reason string
+
+**Acceptance Criteria**: Closes audit matrix gap "Unsupported engine"
+
+**Dependencies**: UT-WE-659-001 patterns
+
+---
+
+### UT-WE-659-003 (P0): Catalog resolution failure — regression
+
+**BR**: BR-WE-095
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/workflowexecution/controller_test.go`
+
+**Preconditions**: Catalog resolver returns error (not found or DS error per existing test harness)
+
+**Test Steps**: Trigger catalog resolution failure path; assert `WorkflowValidationFailed`
+
+**Expected Results**: Preserves existing behavior (no regression to generic-only failure)
+
+**Acceptance Criteria**: Audit matrix row "Catalog resolution fail" remains YES
+
+**Dependencies**: None
+
+---
+
+### UT-WE-659-004 (P0): Spec validation failure — regression
+
+**BR**: BR-WE-095
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/workflowexecution/controller_test.go`
+
+**Preconditions**: Invalid spec fields fail validation
+
+**Test Steps**: Reconcile; assert `WorkflowValidationFailed`
+
+**Expected Results**: Existing behavior locked
+
+**Acceptance Criteria**: Audit matrix row "Spec validation fail" remains YES
+
+**Dependencies**: None
+
+---
+
+### UT-WE-659-005 (P1): reconcileRunning engine resolution failure
+
+**BR**: BR-WE-095
+**Priority**: P1
+**Type**: Unit
+**File**: `test/unit/workflowexecution/controller_test.go`
+
+**Preconditions**: Running phase; engine resolution fails (mock or injected error per harness)
+
+**Test Steps**: Reconcile; assert appropriate event reason and log level (per product standard — document exact reason in implementation if not `WorkflowValidationFailed`)
+
+**Expected Results**: Observable signal for operators; logs match severity guidelines
+
+**Acceptance Criteria**: No silent failure; no nil-only assertions
+
+**Dependencies**: Clarify expected reason in GREEN (validation vs execution failure) per code review
+
+---
+
+### IT-WE-659-001 (P0): reconcilePending + DependencyValidator — recorder drain
+
+**BR**: BR-WE-005, BR-WE-095
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/workflowexecution/` (e.g. `reconciler_test.go` or new file aligned with suite conventions)
+
+**Preconditions**:
+
+- envtest/suite setup per existing workflowexecution integration tests
+- Fake recorder attached to manager/controller
+- DependencyValidator wired to fail for test scenario
+
+**Test Steps**:
+
+1. **Given**: WorkflowExecution CR triggers pending reconcile
+2. **When**: Dependency validation fails inside reconcile
+3. **Then**: Drain fake recorder; assert at least one event with reason `WorkflowValidationFailed`
+
+**Expected Results**:
+
+1. Deterministic assertion without `time.Sleep`
+2. Event associated with correct object
+
+**Acceptance Criteria**: SOC2-oriented monitoring can rely on integration-verified path
+
+**Dependencies**: Suite bootstrap from `suite_test.go`
+
+---
+
+## 10. Environmental Needs
+
+> **IEEE 829 §13** — Hardware, software, tools, and infrastructure required.
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: Kubernetes client fakes, fake event recorder (external boundary); **no** mocking of `pkg/` business logic per strategy
+- **Location**: `test/unit/workflowexecution/`
+- **Resources**: Standard developer machine
+
+### 10.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: ZERO mocks of business logic; use envtest/env fake clients per [No-Mocks Policy](../../testing/INTEGRATION_E2E_NO_MOCKS_POLICY.md)
+- **Infrastructure**: Existing workflowexecution integration suite (envtest)
+- **Location**: `test/integration/workflowexecution/`
+- **Resources**: Comparable to existing integration jobs (CPU/memory per CI)
+
+### 10.3 E2E Tests (if applicable)
+
+- Not required for TP-659-v1.
+
+### 10.4 Tools & Versions
+
+| Tool | Minimum Version | Purpose |
+|------|-----------------|---------|
+| Go | Project `go.mod` | Build and test |
+| Ginkgo CLI | v2.x | BDD test runner |
+| envtest | Controller-runtime compatible | Integration reconciler tests |
+
+---
+
+## 11. Dependencies & Schedule
+
+> **IEEE 829 §12/§16** — Remaining tasks, blocking issues, and execution order.
+
+### 11.1 Blocking Dependencies
+
+| Dependency | Type | Status | Impact if Not Available | Workaround |
+|------------|------|--------|-------------------------|------------|
+| Fake recorder API in unit tests | Code | Existing | Cannot assert events | Add helper consistent with suite |
+| Integration suite green | Infra | Required | IT-WE-659-001 blocked | Fix suite before adding case |
+
+### 11.2 Execution Order (TDD)
+
+1. **RED**: UT-WE-659-001, UT-WE-659-002 expect `WorkflowValidationFailed` (currently fail if only `WorkflowFailed`); add IT-WE-659-001 RED if feasible in parallel
+2. **GREEN**: `r.Recorder.Event(..., WorkflowValidationFailed, ...)` before `MarkFailedWithReason` on dependency and unsupported-engine paths
+3. **REFACTOR**: Extract `emitValidationFailed` (or equivalent) aligned with spec/catalog pattern; UT-WE-659-003/004 as regression guards
+4. **Check**: UT-WE-659-005; full `go test` workflowexecution unit + integration packages
+
+---
+
+## 12. Test Deliverables
+
+> **IEEE 829 §11** — What artifacts this test effort produces.
+
+| Deliverable | Location | Description |
+|-------------|----------|-------------|
+| This test plan | `docs/tests/659/TEST_PLAN.md` | Strategy and test design |
+| Unit tests | `test/unit/workflowexecution/controller_test.go` (or sibling) | P0/P1 scenarios |
+| Integration test | `test/integration/workflowexecution/` | IT-WE-659-001 |
+| Coverage / CI | Pipeline artifacts | Validation-path coverage |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests — workflowexecution
+go test ./test/unit/workflowexecution/... -ginkgo.v
+
+# Focus by scenario (adjust to match Describe/Context text)
+go test ./test/unit/workflowexecution/... -ginkgo.focus="659" -ginkgo.v
+
+# Integration tests
+go test ./test/integration/workflowexecution/... -ginkgo.v
+
+# Focus IT-WE-659-001 when named in description
+go test ./test/integration/workflowexecution/... -ginkgo.focus="IT-WE-659" -ginkgo.v
+```
+
+---
+
+## 14. Existing Tests Requiring Updates (if applicable)
+
+> When implementation changes behavior that existing tests assert on, document the
+> required updates here to prevent surprises during TDD GREEN phase.
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|-------------------|-------------------|-----------------|--------|
+| Controller unit tests for unsupported engine / dependency failure | May assert only `WorkflowFailed` or status condition | Add or update to expect `WorkflowValidationFailed` on recorder | Close observability gap #659 |
+| Tests that count total events | Fixed counts | Update counts if new validation event added | Avoid brittle over-count failures |
+| Integration reconciler tests | No validation event assertion | Add IT-WE-659-001 assertions | Tier coverage |
+
+---
+
+## 15. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-09 | Initial test plan for Issue #659 |

--- a/internal/controller/notification/routing_handler.go
+++ b/internal/controller/notification/routing_handler.go
@@ -84,15 +84,21 @@ func (r *NotificationRequestReconciler) resolveChannelsFromRoutingWithDetails(
 	routingAttrs := routing.RoutingAttributesFromSpec(notification)
 	logger.V(1).Info("Routing attributes from spec", "attributes", routingAttrs)
 
-	receiver := r.Router.FindReceiver(routingAttrs)
-	channels := r.receiverToChannels(receiver)
+	receivers := r.Router.FindReceivers(routingAttrs)
+
+	var channels []notificationv1alpha1.Channel
+	var receiverNames []string
+	for _, recv := range receivers {
+		receiverNames = append(receiverNames, recv.Name)
+		channels = append(channels, r.receiverToChannels(recv)...)
+	}
 
 	logger.Info("Resolved channels from routing",
 		"notification", notification.Name,
-		"receiver", receiver.Name,
+		"receivers", receiverNames,
 		"channels", channels)
 
-	isFallback := receiver.Name == "console-fallback" || len(channels) == 0
+	isFallback := len(receivers) == 1 && receivers[0].Name == "default-console-fallback" || len(channels) == 0
 	var routingReason, routingMessage string
 	if isFallback {
 		routingReason = kubernautnotif.ReasonRoutingFallback
@@ -102,8 +108,8 @@ func (r *NotificationRequestReconciler) resolveChannelsFromRoutingWithDetails(
 		routingReason = kubernautnotif.ReasonRoutingRuleMatched
 		attrsPart := r.formatAttributesForCondition(routingAttrs)
 		channelsPart := r.formatChannelsForCondition(channels)
-		routingMessage = fmt.Sprintf("Matched rule '%s' %s → channels: %s",
-			receiver.Name, attrsPart, channelsPart)
+		routingMessage = fmt.Sprintf("Matched rules [%s] %s → channels: %s",
+			strings.Join(receiverNames, ", "), attrsPart, channelsPart)
 	}
 
 	return channels, routingReason, routingMessage

--- a/internal/controller/workflowexecution/workflowexecution_controller.go
+++ b/internal/controller/workflowexecution/workflowexecution_controller.go
@@ -424,6 +424,8 @@ func (r *WorkflowExecutionReconciler) reconcilePending(ctx context.Context, wfe 
 	exec, err := r.ExecutorRegistry.Get(wfe.Status.ExecutionEngine)
 	if err != nil {
 		logger.Error(err, "Unsupported execution engine", "engine", wfe.Status.ExecutionEngine)
+		r.Recorder.Event(wfe, corev1.EventTypeWarning, events.EventReasonWorkflowValidationFailed,
+			fmt.Sprintf("Unsupported execution engine %q: %v", wfe.Status.ExecutionEngine, err))
 		markErr := r.MarkFailedWithReason(ctx, wfe, "UnsupportedEngine", err.Error())
 		return ctrl.Result{}, markErr
 	}
@@ -443,6 +445,8 @@ func (r *WorkflowExecutionReconciler) reconcilePending(ctx context.Context, wfe 
 				if valErr := r.DependencyValidator.ValidateDependencies(ctx, r.ExecutionNamespace, catalogMeta.Dependencies); valErr != nil {
 					logger.Error(valErr, "Workflow dependency validation failed",
 						"workflowID", wfe.Spec.WorkflowRef.WorkflowID)
+					r.Recorder.Event(wfe, corev1.EventTypeWarning, events.EventReasonWorkflowValidationFailed,
+						fmt.Sprintf("Dependency validation failed: %v", valErr))
 					markErr := r.MarkFailedWithReason(ctx, wfe, "ConfigurationError", valErr.Error())
 					return ctrl.Result{}, markErr
 				}

--- a/internal/controller/workflowexecution/workflowexecution_controller.go
+++ b/internal/controller/workflowexecution/workflowexecution_controller.go
@@ -43,8 +43,6 @@ package workflowexecution
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"strings"
 	"time"
@@ -186,40 +184,6 @@ type WorkflowExecutionReconciler struct {
 	// with non-empty data in the execution namespace (defense in depth).
 	// Optional: nil disables execution-time validation.
 	DependencyValidator dsvalidation.DependencyValidator
-}
-
-// resolveDependencies fetches schema-declared dependencies from DS and validates
-// them against the execution namespace. Returns empty CreateOptions when no
-// querier is configured, or when the workflow has no dependencies.
-// Returns a hard error only when validation explicitly fails (missing Secret/ConfigMap).
-// DS fetch failures are treated as non-fatal (graceful degradation).
-func (r *WorkflowExecutionReconciler) resolveDependencies(ctx context.Context, wfe *workflowexecutionv1alpha1.WorkflowExecution) (weexecutor.CreateOptions, error) {
-	opts := weexecutor.CreateOptions{}
-	if r.WorkflowQuerier == nil {
-		return opts, nil
-	}
-
-	logger := log.FromContext(ctx)
-	deps, err := r.WorkflowQuerier.GetWorkflowDependencies(ctx, wfe.Spec.WorkflowRef.WorkflowID)
-	if err != nil {
-		logger.Error(err, "Failed to fetch workflow dependencies from DS (non-fatal, continuing without deps)",
-			"workflowID", wfe.Spec.WorkflowRef.WorkflowID)
-		return opts, nil
-	}
-	if deps == nil {
-		return opts, nil
-	}
-
-	if r.DependencyValidator != nil {
-		if valErr := r.DependencyValidator.ValidateDependencies(ctx, r.ExecutionNamespace, deps); valErr != nil {
-			logger.Error(valErr, "Workflow dependency validation failed",
-				"workflowID", wfe.Spec.WorkflowRef.WorkflowID)
-			return opts, valErr
-		}
-	}
-
-	opts.Dependencies = deps
-	return opts, nil
 }
 
 // ========================================
@@ -364,26 +328,20 @@ func (r *WorkflowExecutionReconciler) reconcilePending(ctx context.Context, wfe 
 		fmt.Sprintf("Workflow spec validated: %s (target: %s)", wfe.Spec.WorkflowRef.WorkflowID, wfe.Spec.TargetResource))
 
 	// ========================================
-	// Step 1.2: Resolve execution engine from DS catalog (Issue #518)
+	// Step 1.2: Resolve all workflow catalog metadata from DS (Issue #650)
+	// Consolidates engine, bundle, SA, deps, engineConfig into single DS call.
 	// ========================================
-	engine, engineErr := r.resolveExecutionEngine(ctx, wfe)
-	if engineErr != nil {
-		logger.Error(engineErr, "Execution engine resolution failed")
+	catalogMeta, catalogErr := r.resolveWorkflowCatalog(ctx, wfe)
+	if catalogErr != nil {
+		logger.Error(catalogErr, "Workflow catalog resolution failed")
 		r.Recorder.Event(wfe, corev1.EventTypeWarning, events.EventReasonWorkflowValidationFailed,
-			fmt.Sprintf("Execution engine resolution failed: %v", engineErr))
-		if markErr := r.MarkFailedWithReason(ctx, wfe, "ConfigurationError", engineErr.Error()); markErr != nil {
+			fmt.Sprintf("Workflow catalog resolution failed: %v", catalogErr))
+		if markErr := r.MarkFailedWithReason(ctx, wfe, "ConfigurationError", catalogErr.Error()); markErr != nil {
 			return ctrl.Result{}, markErr
 		}
 		return ctrl.Result{}, nil
 	}
-	logger.Info("Resolved execution engine from catalog", "engine", engine, "workflowID", wfe.Spec.WorkflowRef.WorkflowID)
-
-	// ========================================
-	// Step 1.3: Resolve execution bundle from DS catalog (defense-in-depth)
-	// ========================================
-	if resolveErr := r.resolveExecutionBundle(ctx, wfe); resolveErr != nil {
-		logger.Error(resolveErr, "Failed to resolve execution bundle from DS (non-fatal)")
-	}
+	logger.Info("Resolved workflow catalog metadata", "engine", wfe.Status.ExecutionEngine, "workflowID", wfe.Spec.WorkflowRef.WorkflowID)
 
 	// ========================================
 	// Step 1.5: Check if cooldown is active for target resource (BR-WE-009)
@@ -476,25 +434,20 @@ func (r *WorkflowExecutionReconciler) reconcilePending(ctx context.Context, wfe 
 		"namespace", r.ExecutionNamespace,
 	)
 
-	// DD-WE-006: Fetch workflow dependencies from DS and validate before execution.
-	createOpts, depErr := r.resolveDependencies(ctx, wfe)
-	if depErr != nil {
-		markErr := r.MarkFailedWithReason(ctx, wfe, "ConfigurationError", depErr.Error())
-		return ctrl.Result{}, markErr
-	}
-
-	// DD-WORKFLOW-017: Resolve engineConfig from DS catalog when not present on the WFE spec.
-	// Execution details like engineConfig come from the workflow catalog entry, not the KA pipeline.
-	if wfe.Spec.WorkflowRef.EngineConfig == nil && wfe.Spec.WorkflowRef.WorkflowID != "" && r.WorkflowQuerier != nil {
-		ecRaw, ecErr := r.WorkflowQuerier.GetWorkflowEngineConfig(ctx, wfe.Spec.WorkflowRef.WorkflowID)
-		if ecErr != nil {
-			logger.Error(ecErr, "Failed to resolve engineConfig from DS (non-fatal)",
-				"workflowID", wfe.Spec.WorkflowRef.WorkflowID)
-		} else if ecRaw != nil {
-			logger.Info("Resolved engineConfig from DS catalog",
-				"workflowID", wfe.Spec.WorkflowRef.WorkflowID,
-				"engine", wfe.Status.ExecutionEngine)
-			wfe.Spec.WorkflowRef.EngineConfig = &apiextensionsv1.JSON{Raw: ecRaw}
+	// DD-WE-006 / Issue #650: Dependencies and engineConfig already resolved
+	// by catalogMeta above. Build CreateOptions from catalog metadata.
+	createOpts := weexecutor.CreateOptions{}
+	if catalogMeta != nil {
+		if catalogMeta.Dependencies != nil {
+			if r.DependencyValidator != nil {
+				if valErr := r.DependencyValidator.ValidateDependencies(ctx, r.ExecutionNamespace, catalogMeta.Dependencies); valErr != nil {
+					logger.Error(valErr, "Workflow dependency validation failed",
+						"workflowID", wfe.Spec.WorkflowRef.WorkflowID)
+					markErr := r.MarkFailedWithReason(ctx, wfe, "ConfigurationError", valErr.Error())
+					return ctrl.Result{}, markErr
+				}
+			}
+			createOpts.Dependencies = catalogMeta.Dependencies
 		}
 	}
 
@@ -503,8 +456,7 @@ func (r *WorkflowExecutionReconciler) reconcilePending(ctx context.Context, wfe 
 		if apierrors.IsAlreadyExists(createErr) {
 			// DD-WE-003 Layer 2: Execution-time collision handling
 			if wfe.Status.ExecutionEngine == "tekton" {
-				pr := r.BuildPipelineRun(wfe)
-				return r.HandleAlreadyExists(ctx, wfe, pr, createErr)
+				return r.HandleAlreadyExists(ctx, wfe, resourceName, createErr)
 			}
 			// Issue #374 / DD-WE-003: Pre-execution cleanup of completed Jobs.
 			// If the existing Job is in a terminal state (Succeeded/Failed), clean it up
@@ -746,7 +698,7 @@ func (r *WorkflowExecutionReconciler) ReconcileTerminal(ctx context.Context, wfe
 		}
 	} else {
 		// Fallback: inline Tekton cleanup when ExecutorRegistry is not configured
-		prName := PipelineRunName(wfe.Spec.TargetResource)
+		prName := weexecutor.ExecutionResourceName(wfe.Spec.TargetResource)
 		var existing tektonv1.PipelineRun
 		if err := r.Get(ctx, client.ObjectKey{Name: prName, Namespace: r.ExecutionNamespace}, &existing); err != nil {
 			if !apierrors.IsNotFound(err) {
@@ -884,7 +836,7 @@ func (r *WorkflowExecutionReconciler) ReconcileDelete(ctx context.Context, wfe *
 		}
 	} else {
 		// Fallback: inline Tekton cleanup when ExecutorRegistry is not configured
-		prName := PipelineRunName(wfe.Spec.TargetResource)
+		prName := weexecutor.ExecutionResourceName(wfe.Spec.TargetResource)
 		pr := &tektonv1.PipelineRun{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      prName,
@@ -1038,16 +990,6 @@ func (r *WorkflowExecutionReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrlBuilder.Complete(r)
 }
 
-// ========================================
-// PipelineRunName generates deterministic name from targetResource
-// DD-WE-003: Lock Persistence via Deterministic Name
-// Format: wfe-<sha256(targetResource)[:16]>
-// ========================================
-func PipelineRunName(targetResource string) string {
-	h := sha256.Sum256([]byte(targetResource))
-	return fmt.Sprintf("wfe-%s", hex.EncodeToString(h[:])[:16])
-}
-
 // sanitizeLabelValue makes a string safe for use as a Kubernetes label value
 // Label values must consist of alphanumeric characters, '-', '_' or '.'
 // and must start and end with an alphanumeric character
@@ -1127,50 +1069,38 @@ func (r *WorkflowExecutionReconciler) handleJobAlreadyExists(
 // DD-WE-003: Layer 2 - Execution-time collision handling (not routing)
 // V1.0: Fails WFE if race condition detected (RO should have prevented this)
 // ========================================
-func (r *WorkflowExecutionReconciler) HandleAlreadyExists(ctx context.Context, wfe *workflowexecutionv1alpha1.WorkflowExecution, pr *tektonv1.PipelineRun, err error) (ctrl.Result, error) {
+func (r *WorkflowExecutionReconciler) HandleAlreadyExists(ctx context.Context, wfe *workflowexecutionv1alpha1.WorkflowExecution, resourceName string, err error) (ctrl.Result, error) {
 	logger := log.FromContext(ctx)
 
-	// PipelineRun already exists - check if it's ours
-	prName := pr.Name
 	existingPR := &tektonv1.PipelineRun{}
 	if getErr := r.Get(ctx, client.ObjectKey{
-		Name:      prName,
+		Name:      resourceName,
 		Namespace: r.ExecutionNamespace,
 	}, existingPR); getErr != nil {
-		logger.Error(getErr, "Failed to get existing PipelineRun", "name", prName)
+		logger.Error(getErr, "Failed to get existing PipelineRun", "name", resourceName)
 		markErr := r.MarkFailedWithReason(ctx, wfe, "RaceConditionError", fmt.Sprintf("PipelineRun already exists but failed to verify ownership: %v", getErr))
 		return ctrl.Result{}, markErr
 	}
 
-	// Check if the existing PipelineRun was created by this WFE
 	if existingPR.Labels != nil &&
 		existingPR.Labels["kubernaut.ai/workflow-execution"] == wfe.Name &&
 		existingPR.Labels["kubernaut.ai/source-namespace"] == wfe.Namespace {
-		// It's ours - we must have lost a race with ourselves (unlikely but safe)
-		// Continue with normal flow
-		logger.Info("PipelineRun already exists and is ours, continuing", "name", prName)
+		logger.Info("PipelineRun already exists and is ours, continuing", "name", resourceName)
 
-		// ========================================
-		// P1: ATOMIC STATUS UPDATE with retry logic
-		// Consolidates phase transition + conditions into single API call
-		// ========================================
 		now := metav1.Now()
 		if err := r.StatusManager.AtomicStatusUpdate(ctx, wfe, func() error {
-			// Set phase (P0: Phase State Machine)
 			if err := r.PhaseManager.TransitionTo(wfe, wephase.Running); err != nil {
 				return fmt.Errorf("failed to transition to Running in HandleAlreadyExists: %w", err)
 			}
 
-			// Set start time and PipelineRun reference
 			wfe.Status.StartTime = &now
 			wfe.Status.ExecutionRef = &corev1.LocalObjectReference{
-				Name: pr.Name,
+				Name: resourceName,
 			}
 
-			// Set ExecutionCreated condition (consistency with main flow)
 			weconditions.SetExecutionCreated(wfe, true,
 				weconditions.ReasonExecutionCreated,
-				fmt.Sprintf("PipelineRun %s already exists (race condition)", prName))
+				fmt.Sprintf("PipelineRun %s already exists (race condition)", resourceName))
 
 			return nil
 		}); err != nil {
@@ -1178,100 +1108,21 @@ func (r *WorkflowExecutionReconciler) HandleAlreadyExists(ctx context.Context, w
 		}
 
 		r.Recorder.Event(wfe, corev1.EventTypeNormal, events.EventReasonPipelineRunCreated,
-			fmt.Sprintf("PipelineRun %s/%s (already exists, ours)", pr.Namespace, pr.Name))
+			fmt.Sprintf("PipelineRun %s/%s (already exists, ours)", r.ExecutionNamespace, resourceName))
 
-		// Requeue to check PipelineRun status
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 
-	// V1.0: Another WFE created this PipelineRun - execution-time race condition
-	// This should be rare (RO handles routing), but handle gracefully
 	logger.Error(err, "Race condition at execution time: PipelineRun created by another WFE",
-		"prName", prName,
+		"prName", resourceName,
 		"existingWFE", existingPR.Labels["kubernaut.ai/workflow-execution"],
 		"targetResource", wfe.Spec.TargetResource,
 	)
 
-	// Note: Using "Unknown" reason as "ExecutionRaceCondition" is not in CRD enum
 	markErr := r.MarkFailedWithReason(ctx, wfe, "Unknown",
 		fmt.Sprintf("Race condition: PipelineRun '%s' already exists for target resource (created by %s). This indicates RO routing may have failed.",
-			prName, existingPR.Labels["kubernaut.ai/workflow-execution"]))
+			resourceName, existingPR.Labels["kubernaut.ai/workflow-execution"]))
 	return ctrl.Result{}, markErr
-}
-
-// ========================================
-// BuildPipelineRun creates a PipelineRun with bundle resolver
-// DD-WE-002: PipelineRuns created in dedicated execution namespace
-// DD-WE-003: Deterministic name for atomic locking
-// ========================================
-func (r *WorkflowExecutionReconciler) BuildPipelineRun(wfe *workflowexecutionv1alpha1.WorkflowExecution) *tektonv1.PipelineRun {
-	// Convert parameters to Tekton format
-	params := r.ConvertParameters(wfe.Spec.Parameters)
-
-	// Add TARGET_RESOURCE parameter (required by all pipelines)
-	params = append(params, tektonv1.Param{
-		Name:  "TARGET_RESOURCE",
-		Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: wfe.Spec.TargetResource},
-	})
-
-	// DD-WE-005 v2.0 / Issue #501: SA at spec top level, engine-agnostic.
-	saName := wfe.Spec.ServiceAccountName
-
-	return &tektonv1.PipelineRun{
-		ObjectMeta: metav1.ObjectMeta{
-			// CRITICAL: Deterministic name = atomic lock (DD-WE-003)
-			Name:      PipelineRunName(wfe.Spec.TargetResource),
-			Namespace: r.ExecutionNamespace, // Always "kubernaut-workflows" (DD-WE-002)
-			Labels: map[string]string{
-				"kubernaut.ai/workflow-execution": wfe.Name,
-				"kubernaut.ai/workflow-id":        wfe.Spec.WorkflowRef.WorkflowID,
-				// Sanitize for label (slashes not allowed, replace with __)
-				"kubernaut.ai/target-resource": sanitizeLabelValue(wfe.Spec.TargetResource),
-				// Source tracking for cross-namespace lookup
-				"kubernaut.ai/source-namespace": wfe.Namespace,
-			},
-			Annotations: map[string]string{
-				// Store original target resource value (with slashes) in annotation
-				"kubernaut.ai/target-resource": wfe.Spec.TargetResource,
-			},
-			// NOTE: No OwnerReference - cross-namespace not supported
-			// Cleanup handled via finalizer in ReconcileDelete()
-		},
-		Spec: tektonv1.PipelineRunSpec{
-			PipelineRef: &tektonv1.PipelineRef{
-				ResolverRef: tektonv1.ResolverRef{
-					Resolver: "bundles",
-					Params: []tektonv1.Param{
-						{Name: "bundle", Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: wfe.Spec.WorkflowRef.ExecutionBundle}},
-						{Name: "name", Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "workflow"}},
-						{Name: "kind", Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: "pipeline"}},
-					},
-				},
-			},
-			Params: params,
-			TaskRunTemplate: tektonv1.PipelineTaskRunTemplate{
-				ServiceAccountName: saName,
-			},
-		},
-	}
-}
-
-// ========================================
-// ConvertParameters converts map[string]string to Tekton params
-// ========================================
-func (r *WorkflowExecutionReconciler) ConvertParameters(params map[string]string) []tektonv1.Param {
-	if len(params) == 0 {
-		return []tektonv1.Param{}
-	}
-
-	tektonParams := make([]tektonv1.Param, 0, len(params))
-	for key, value := range params {
-		tektonParams = append(tektonParams, tektonv1.Param{
-			Name:  key,
-			Value: tektonv1.ParamValue{Type: tektonv1.ParamTypeString, StringVal: value},
-		})
-	}
-	return tektonParams
 }
 
 // ========================================
@@ -1728,6 +1579,66 @@ func (r *WorkflowExecutionReconciler) updateStatus(
 
 // resolveExecutionEngine ensures wfe.Status.ExecutionEngine is populated.
 // On the first call (Pending phase), it queries the DS catalog via WorkflowQuerier.
+// resolveWorkflowCatalog fetches all workflow metadata from the DS catalog in a
+// single GetWorkflowByID call (Issue #650). Consolidates resolveExecutionEngine,
+// resolveExecutionBundle, resolveDependencies, and GetWorkflowEngineConfig.
+// Idempotent: returns nil immediately if the engine is already resolved.
+func (r *WorkflowExecutionReconciler) resolveWorkflowCatalog(ctx context.Context, wfe *workflowexecutionv1alpha1.WorkflowExecution) (*weclient.WorkflowCatalogMetadata, error) {
+	if wfe.Status.ExecutionEngine != "" {
+		return nil, nil
+	}
+
+	if r.WorkflowQuerier == nil {
+		return nil, fmt.Errorf("DataStorage workflow querier not available — cannot resolve workflow catalog for %s", wfe.Spec.WorkflowRef.WorkflowID)
+	}
+
+	workflowID := wfe.Spec.WorkflowRef.WorkflowID
+	if workflowID == "" {
+		return nil, fmt.Errorf("workflowRef.workflowId is empty — cannot resolve workflow catalog")
+	}
+
+	logger := log.FromContext(ctx)
+
+	meta, err := r.WorkflowQuerier.ResolveWorkflowCatalogMetadata(ctx, workflowID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve workflow catalog from DS for workflow %s: %w", workflowID, err)
+	}
+
+	if meta.ExecutionEngine == "" {
+		label := workflowID
+		if meta.WorkflowName != "" {
+			label = fmt.Sprintf("%s - %s", meta.WorkflowName, workflowID)
+		}
+		return nil, fmt.Errorf("no engine defined in remediation workflow %s", label)
+	}
+
+	wfe.Status.ExecutionEngine = meta.ExecutionEngine
+	wfe.Status.ServiceAccountName = meta.ServiceAccountName
+
+	if meta.ExecutionBundle != "" {
+		if wfe.Spec.WorkflowRef.ExecutionBundle != meta.ExecutionBundle {
+			logger.Info("Overriding execution bundle from DS catalog",
+				"specBundle", wfe.Spec.WorkflowRef.ExecutionBundle,
+				"catalogBundle", meta.ExecutionBundle,
+				"workflowID", workflowID,
+			)
+		}
+		wfe.Spec.WorkflowRef.ExecutionBundle = meta.ExecutionBundle
+		if meta.ExecutionBundleDigest != "" {
+			wfe.Spec.WorkflowRef.ExecutionBundleDigest = meta.ExecutionBundleDigest
+		}
+	}
+
+	if wfe.Spec.WorkflowRef.EngineConfig == nil && meta.EngineConfig != nil {
+		logger.Info("Resolved engineConfig from DS catalog",
+			"workflowID", workflowID,
+			"engine", meta.ExecutionEngine)
+		wfe.Spec.WorkflowRef.EngineConfig = &apiextensionsv1.JSON{Raw: meta.EngineConfig}
+	}
+
+	return meta, nil
+}
+
 // On subsequent calls (Running/Terminal/Delete), it returns the already-persisted value.
 // Returns the engine string or an error if resolution fails.
 func (r *WorkflowExecutionReconciler) resolveExecutionEngine(ctx context.Context, wfe *workflowexecutionv1alpha1.WorkflowExecution) (string, error) {
@@ -1759,41 +1670,6 @@ func (r *WorkflowExecutionReconciler) resolveExecutionEngine(ctx context.Context
 
 	wfe.Status.ExecutionEngine = engine
 	return engine, nil
-}
-
-// resolveExecutionBundle overrides wfe.Spec.WorkflowRef.ExecutionBundle with the
-// authoritative value from the DS catalog (defense-in-depth). Non-fatal: if the
-// querier is nil, the workflow ID is empty, or the catalog entry has no bundle,
-// the existing spec value is preserved.
-func (r *WorkflowExecutionReconciler) resolveExecutionBundle(ctx context.Context, wfe *workflowexecutionv1alpha1.WorkflowExecution) error {
-	if r.WorkflowQuerier == nil || wfe.Spec.WorkflowRef.WorkflowID == "" {
-		return nil
-	}
-
-	logger := log.FromContext(ctx)
-
-	bundle, digest, err := r.WorkflowQuerier.GetWorkflowExecutionBundle(ctx, wfe.Spec.WorkflowRef.WorkflowID)
-	if err != nil {
-		return fmt.Errorf("failed to resolve execution bundle from DS for workflow %s: %w", wfe.Spec.WorkflowRef.WorkflowID, err)
-	}
-
-	if bundle == "" {
-		return nil
-	}
-
-	if wfe.Spec.WorkflowRef.ExecutionBundle != bundle {
-		logger.Info("Overriding execution bundle from DS catalog",
-			"specBundle", wfe.Spec.WorkflowRef.ExecutionBundle,
-			"catalogBundle", bundle,
-			"workflowID", wfe.Spec.WorkflowRef.WorkflowID,
-		)
-	}
-	wfe.Spec.WorkflowRef.ExecutionBundle = bundle
-	if digest != "" {
-		wfe.Spec.WorkflowRef.ExecutionBundleDigest = digest
-	}
-
-	return nil
 }
 
 // ========================================

--- a/pkg/aianalysis/handlers/response_processor.go
+++ b/pkg/aianalysis/handlers/response_processor.go
@@ -171,7 +171,6 @@ func (p *ResponseProcessor) ProcessIncidentResponse(ctx context.Context, analysi
 				Confidence:            GetFloat64FromMap(swMap, "confidence"),
 				Rationale:             GetStringFromMap(swMap, "rationale"),
 				ExecutionEngine:       GetStringFromMap(swMap, "execution_engine"),
-				ServiceAccountName:    GetStringFromMap(swMap, "service_account_name"),
 			}
 			// Map parameters if present (map[string]string)
 			if paramsRaw, ok := swMap["parameters"]; ok {
@@ -365,7 +364,6 @@ func (p *ResponseProcessor) handleWorkflowResolutionFailureFromIncident(ctx cont
 				Confidence:         GetFloat64FromMap(swMap, "confidence"),
 				Rationale:          GetStringFromMap(swMap, "rationale"),
 				ExecutionEngine:    GetStringFromMap(swMap, "execution_engine"),
-				ServiceAccountName: GetStringFromMap(swMap, "service_account_name"),
 			}
 		}
 	}
@@ -580,7 +578,6 @@ func (p *ResponseProcessor) handleLowConfidenceFailure(ctx context.Context, anal
 				Confidence:            GetFloat64FromMap(swMap, "confidence"),
 				Rationale:             GetStringFromMap(swMap, "rationale"),
 				ExecutionEngine:       GetStringFromMap(swMap, "execution_engine"),
-				ServiceAccountName:    GetStringFromMap(swMap, "service_account_name"),
 			}
 			// Map parameters if present
 			if paramsRaw, ok := swMap["parameters"]; ok {

--- a/pkg/authwebhook/rw_reconciler.go
+++ b/pkg/authwebhook/rw_reconciler.go
@@ -19,6 +19,7 @@ package authwebhook
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
 	"strings"
 	"time"
@@ -27,6 +28,7 @@ import (
 	atv1alpha1 "github.com/jordigilh/kubernaut/api/actiontype/v1alpha1"
 	rwv1alpha1 "github.com/jordigilh/kubernaut/api/remediationworkflow/v1alpha1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -130,6 +132,8 @@ func (r *RemediationWorkflowReconciler) reconcileDelete(ctx context.Context, log
 
 // refreshActionTypeWorkflowCount queries DS for the authoritative active
 // workflow count and patches the matching ActionType CRD's status.
+// Uses RetryOnConflict to handle races with the webhook's concurrent
+// status update goroutine (fixes E2E-AT-300-003 flake).
 // Best-effort: errors are logged but do not block finalizer removal.
 func (r *RemediationWorkflowReconciler) refreshActionTypeWorkflowCount(ctx context.Context, logger logr.Logger, actionType, namespace string) {
 	if r.ATCounter == nil || actionType == "" {
@@ -142,29 +146,42 @@ func (r *RemediationWorkflowReconciler) refreshActionTypeWorkflowCount(ctx conte
 		return
 	}
 
-	atList := &atv1alpha1.ActionTypeList{}
-	if err := r.List(ctx, atList, client.InNamespace(namespace)); err != nil {
-		logger.Error(err, "Failed to list ActionType CRDs")
+	atKey, err := r.findActionTypeKey(ctx, actionType, namespace)
+	if err != nil {
+		logger.Error(err, "Failed to find ActionType CRD", "actionType", actionType)
+		return
+	}
+	if atKey == nil {
 		return
 	}
 
-	for i := range atList.Items {
-		at := &atList.Items[i]
-		if at.Spec.Name != actionType {
-			continue
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		at := &atv1alpha1.ActionType{}
+		if err := r.Get(ctx, *atKey, at); err != nil {
+			return fmt.Errorf("get ActionType: %w", err)
 		}
 		at.Status.ActiveWorkflowCount = count
-		if err := r.Status().Update(ctx, at); err != nil {
-			if apierrors.IsConflict(err) {
-				logger.V(1).Info("AT status update conflict (will be corrected on next reconcile)", "crd", at.Name)
-			} else {
-				logger.Error(err, "Failed to update AT activeWorkflowCount", "crd", at.Name, "count", count)
-			}
-		} else {
-			logger.Info("ActionType activeWorkflowCount updated", "crd", at.Name, "count", count)
-		}
-		return
+		return r.Status().Update(ctx, at)
+	}); err != nil {
+		logger.Error(err, "Failed to update AT activeWorkflowCount", "actionType", actionType, "count", count)
+	} else {
+		logger.Info("ActionType activeWorkflowCount updated", "actionType", actionType, "count", count)
 	}
+}
+
+// findActionTypeKey locates the ActionType CRD whose spec.name matches actionType.
+func (r *RemediationWorkflowReconciler) findActionTypeKey(ctx context.Context, actionType, namespace string) (*client.ObjectKey, error) {
+	atList := &atv1alpha1.ActionTypeList{}
+	if err := r.List(ctx, atList, client.InNamespace(namespace)); err != nil {
+		return nil, err
+	}
+	for i := range atList.Items {
+		if atList.Items[i].Spec.Name == actionType {
+			key := client.ObjectKeyFromObject(&atList.Items[i])
+			return &key, nil
+		}
+	}
+	return nil, nil
 }
 
 func (r *RemediationWorkflowReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/pkg/effectivenessmonitor/client/ds_querier.go
+++ b/pkg/effectivenessmonitor/client/ds_querier.go
@@ -18,78 +18,92 @@ package client
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/http"
-	"net/url"
 	"time"
 
+	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+	"github.com/jordigilh/kubernaut/pkg/ogenx"
 	"github.com/jordigilh/kubernaut/pkg/shared/auth"
 )
 
-// dataStorageHTTPQuerier implements DataStorageQuerier via HTTP calls to DataStorage.
-type dataStorageHTTPQuerier struct {
-	baseURL    string
-	httpClient *http.Client
+// ========================================
+// DD-API-001: ogen-backed DataStorageQuerier (Issue #236)
+//
+// MIGRATION FROM dataStorageHTTPQuerier:
+//
+//   // OLD (deprecated - violates DD-API-001)
+//   querier := emclient.NewDataStorageHTTPQuerierWithTimeout(url, timeout)
+//
+//   // NEW (DD-API-001 compliant)
+//   querier, err := emclient.NewOgenDataStorageQuerier(url, timeout)
+//
+// Authority: DD-API-001 (OpenAPI Generated Client MANDATORY)
+// ========================================
+
+// ogenDataStorageQuerier implements DataStorageQuerier using the ogen-generated
+// OpenAPI client for type-safe DS queries (DD-API-001).
+type ogenDataStorageQuerier struct {
+	client *ogenclient.Client
 }
 
-// NewDataStorageHTTPQuerier creates a new DS querier with default timeout and
-// ServiceAccount authentication (DD-AUTH-005).
-func NewDataStorageHTTPQuerier(baseURL string) DataStorageQuerier {
-	return NewDataStorageHTTPQuerierWithTransport(baseURL, 10*time.Second, nil)
+// NewOgenDataStorageQuerier creates a DD-API-001 compliant DataStorageQuerier.
+// Production transport uses ServiceAccount token authentication (DD-AUTH-005).
+func NewOgenDataStorageQuerier(baseURL string, timeout time.Duration) (DataStorageQuerier, error) {
+	return NewOgenDataStorageQuerierWithTransport(baseURL, timeout, nil)
 }
 
-// NewDataStorageHTTPQuerierWithTimeout creates a new DS querier with custom timeout
-// and ServiceAccount authentication (DD-AUTH-005).
-func NewDataStorageHTTPQuerierWithTimeout(baseURL string, timeout time.Duration) DataStorageQuerier {
-	return NewDataStorageHTTPQuerierWithTransport(baseURL, timeout, nil)
-}
+// NewOgenDataStorageQuerierWithTransport creates a DataStorageQuerier with custom transport.
+// When transport is nil, ServiceAccount token auth is used (DD-AUTH-005).
+// Integration tests use this to inject mock transports.
+func NewOgenDataStorageQuerierWithTransport(baseURL string, timeout time.Duration, transport http.RoundTripper) (DataStorageQuerier, error) {
+	if baseURL == "" {
+		return nil, fmt.Errorf("baseURL cannot be empty")
+	}
+	if timeout <= 0 {
+		timeout = 10 * time.Second
+	}
 
-// NewDataStorageHTTPQuerierWithTransport creates a DS querier with explicit transport.
-// When transport is nil, ServiceAccount token auth is used automatically
-// (same pattern as audit.NewOpenAPIClientAdapter -- DD-AUTH-005).
-func NewDataStorageHTTPQuerierWithTransport(baseURL string, timeout time.Duration, transport http.RoundTripper) DataStorageQuerier {
 	if transport == nil {
-		transport = auth.NewServiceAccountTransport()
+		baseTransport := &http.Transport{
+			MaxIdleConns:        100,
+			MaxIdleConnsPerHost: 100,
+			IdleConnTimeout:     90 * time.Second,
+		}
+		transport = auth.NewServiceAccountTransportWithBase(baseTransport)
 	}
-	return &dataStorageHTTPQuerier{
-		baseURL: baseURL,
-		httpClient: &http.Client{
-			Timeout:   timeout,
-			Transport: transport,
-		},
+
+	httpClient := &http.Client{
+		Timeout:   timeout,
+		Transport: transport,
 	}
-}
 
-// auditEventsResponse matches the AuditEventsQueryResponse envelope returned by
-// GET /api/v1/audit/events (see api/openapi/data-storage-v1.yaml).
-// Issue #575: EM was decoding the bare array, but DS wraps events in this object.
-type auditEventsResponse struct {
-	Data []auditEvent `json:"data"`
-}
+	client, err := ogenclient.NewClient(baseURL, ogenclient.WithClient(httpClient))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ogen DS client: %w", err)
+	}
 
-// auditEvent carries the subset of fields EM needs from each audit event.
-type auditEvent struct {
-	EventType string         `json:"event_type"`
-	EventData auditEventData `json:"event_data"`
-}
-
-type auditEventData struct {
-	PreRemediationSpecHash string `json:"pre_remediation_spec_hash,omitempty"`
+	return &ogenDataStorageQuerier{client: client}, nil
 }
 
 // QueryPreRemediationHash queries DataStorage for audit events matching the
 // correlation ID and extracts the pre_remediation_spec_hash from the
 // remediation.workflow_created event (DD-EM-002).
-func (q *dataStorageHTTPQuerier) QueryPreRemediationHash(ctx context.Context, correlationID string) (string, error) {
-	events, err := q.queryAuditEvents(ctx, correlationID, "remediation.workflow_created")
+func (q *ogenDataStorageQuerier) QueryPreRemediationHash(ctx context.Context, correlationID string) (string, error) {
+	resp, err := q.client.QueryAuditEvents(ctx, ogenclient.QueryAuditEventsParams{
+		CorrelationID: ogenclient.NewOptString(correlationID),
+		EventType:     ogenclient.NewOptString("remediation.workflow_created"),
+	})
+	err = ogenx.ToError(resp, err)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("DS query failed for correlation_id=%s: %w", correlationID, err)
 	}
 
-	for _, event := range events {
-		if hash := event.EventData.PreRemediationSpecHash; hash != "" {
-			return hash, nil
+	for _, event := range resp.Data {
+		if payload, ok := event.EventData.GetRemediationOrchestratorAuditPayload(); ok {
+			if hash, ok := payload.PreRemediationSpecHash.Get(); ok && hash != "" {
+				return hash, nil
+			}
 		}
 	}
 
@@ -104,13 +118,8 @@ func (q *dataStorageHTTPQuerier) QueryPreRemediationHash(ctx context.Context, co
 // Note: The WE controller emits "workflowexecution.execution.started" (Gap #6,
 // BR-AUDIT-005) when a PipelineRun is created. The ADR references the higher-level
 // "workflowexecution.workflow.started" but that event type is never emitted.
-func (q *dataStorageHTTPQuerier) HasWorkflowStarted(ctx context.Context, correlationID string) (bool, error) {
-	events, err := q.queryAuditEvents(ctx, correlationID, "workflowexecution.execution.started")
-	if err != nil {
-		return false, err
-	}
-
-	return len(events) > 0, nil
+func (q *ogenDataStorageQuerier) HasWorkflowStarted(ctx context.Context, correlationID string) (bool, error) {
+	return q.hasEvent(ctx, correlationID, "workflowexecution.execution.started")
 }
 
 // HasWorkflowCompleted checks if a workflowexecution.workflow.completed event
@@ -119,47 +128,21 @@ func (q *dataStorageHTTPQuerier) HasWorkflowStarted(ctx context.Context, correla
 //
 // Note: Unlike execution.started (#575), the WE controller emits the higher-level
 // "workflowexecution.workflow.completed" event type (see pkg/workflowexecution/audit/manager.go).
-func (q *dataStorageHTTPQuerier) HasWorkflowCompleted(ctx context.Context, correlationID string) (bool, error) {
-	events, err := q.queryAuditEvents(ctx, correlationID, "workflowexecution.workflow.completed")
-	if err != nil {
-		return false, err
-	}
-
-	return len(events) > 0, nil
+func (q *ogenDataStorageQuerier) HasWorkflowCompleted(ctx context.Context, correlationID string) (bool, error) {
+	return q.hasEvent(ctx, correlationID, "workflowexecution.workflow.completed")
 }
 
-// queryAuditEvents calls GET /api/v1/audit/events with the given filters and
-// decodes the paginated envelope response.
-func (q *dataStorageHTTPQuerier) queryAuditEvents(ctx context.Context, correlationID, eventType string) ([]auditEvent, error) {
-	u, err := url.Parse(q.baseURL)
+// hasEvent queries DS for audit events matching correlation ID and event type,
+// returning true if at least one event exists.
+func (q *ogenDataStorageQuerier) hasEvent(ctx context.Context, correlationID, eventType string) (bool, error) {
+	resp, err := q.client.QueryAuditEvents(ctx, ogenclient.QueryAuditEventsParams{
+		CorrelationID: ogenclient.NewOptString(correlationID),
+		EventType:     ogenclient.NewOptString(eventType),
+	})
+	err = ogenx.ToError(resp, err)
 	if err != nil {
-		return nil, fmt.Errorf("invalid DS base URL: %w", err)
-	}
-	u.Path = "/api/v1/audit/events"
-	params := url.Values{}
-	params.Set("correlation_id", correlationID)
-	params.Set("event_type", eventType)
-	u.RawQuery = params.Encode()
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create DS request: %w", err)
+		return false, fmt.Errorf("DS query failed for correlation_id=%s: %w", correlationID, err)
 	}
 
-	resp, err := q.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("DS query failed: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("DS returned HTTP %d for correlation_id=%s", resp.StatusCode, correlationID)
-	}
-
-	var envelope auditEventsResponse
-	if err := json.NewDecoder(resp.Body).Decode(&envelope); err != nil {
-		return nil, fmt.Errorf("failed to decode DS response: %w", err)
-	}
-
-	return envelope.Data, nil
+	return len(resp.Data) > 0, nil
 }

--- a/pkg/notification/routing/config.go
+++ b/pkg/notification/routing/config.go
@@ -284,28 +284,69 @@ func (c *Config) GetReceiver(name string) *Receiver {
 	return c.receiverMap[name]
 }
 
-// FindReceiver finds the matching receiver for the given routing attributes.
-// BR-NOT-065: First matching route wins (ordered evaluation)
-func (r *Route) FindReceiver(attrs map[string]string) string {
+// FindReceivers finds all matching receivers for the given routing attributes,
+// respecting the Continue flag for multi-receiver fanout.
+// BR-NOT-068: Multi-Channel Fanout support
+//
+// Routing follows Alertmanager semantics:
+//   - Routes are evaluated depth-first in declaration order.
+//   - When Continue is false (default), evaluation stops at the first match.
+//   - When Continue is true, evaluation continues to sibling routes.
+//   - Children take over from their parent: if a child route has sub-routes
+//     and those sub-routes match, the sub-route receivers are collected
+//     instead of the child's own Receiver field.
+//   - If no children match, the parent's Receiver is used as fallback.
+//
+// Deduplication by receiver name is performed here (canonical location).
+func (r *Route) FindReceivers(attrs map[string]string) []string {
 	if attrs == nil {
 		attrs = make(map[string]string)
 	}
-
-	// Check child routes first (depth-first)
+	var matched []string
+	seen := make(map[string]bool)
 	for _, childRoute := range r.Routes {
 		if childRoute.matchesAttributes(attrs) {
 			if len(childRoute.Routes) > 0 {
-				result := childRoute.FindReceiver(attrs)
-				if result != "" {
-					return result
+				sub := childRoute.FindReceivers(attrs)
+				if len(sub) > 0 {
+					for _, s := range sub {
+						if !seen[s] {
+							matched = append(matched, s)
+							seen[s] = true
+						}
+					}
+					if !childRoute.Continue {
+						return matched
+					}
+					continue
 				}
 			}
-			if childRoute.Receiver != "" {
-				return childRoute.Receiver
+			if childRoute.Receiver != "" && !seen[childRoute.Receiver] {
+				matched = append(matched, childRoute.Receiver)
+				seen[childRoute.Receiver] = true
+			}
+			if !childRoute.Continue {
+				return matched
 			}
 		}
 	}
+	if len(matched) == 0 && r.Receiver != "" {
+		return []string{r.Receiver}
+	}
+	return matched
+}
 
+// FindReceiver finds the first matching receiver for the given routing attributes.
+// BR-NOT-065: First matching route wins (ordered evaluation)
+//
+// This is a backward-compatible wrapper that delegates to FindReceivers and
+// returns only the first matched receiver. Callers that need multi-receiver
+// fanout should use FindReceivers directly.
+func (r *Route) FindReceiver(attrs map[string]string) string {
+	receivers := r.FindReceivers(attrs)
+	if len(receivers) > 0 {
+		return receivers[0]
+	}
 	return r.Receiver
 }
 

--- a/pkg/notification/routing/resolver.go
+++ b/pkg/notification/routing/resolver.go
@@ -90,13 +90,28 @@ func ResolveChannelsForNotification(config *Config, notification *notificationv1
 
 	attrs := RoutingAttributesFromSpec(notification)
 
-	receiverName := config.Route.FindReceiver(attrs)
-
-	receiver := config.GetReceiver(receiverName)
-	if receiver == nil {
+	receiverNames := config.Route.FindReceivers(attrs)
+	if len(receiverNames) == 0 {
 		return []string{"console"}
 	}
 
-	return receiver.GetChannels()
+	seen := make(map[string]bool)
+	var channels []string
+	for _, name := range receiverNames {
+		receiver := config.GetReceiver(name)
+		if receiver == nil {
+			continue
+		}
+		for _, ch := range receiver.GetChannels() {
+			if !seen[ch] {
+				channels = append(channels, ch)
+				seen[ch] = true
+			}
+		}
+	}
+	if len(channels) == 0 {
+		return []string{"console"}
+	}
+	return channels
 }
 

--- a/pkg/notification/routing/router.go
+++ b/pkg/notification/routing/router.go
@@ -113,6 +113,46 @@ func (r *Router) GetConfig() *Config {
 	return r.config
 }
 
+// FindReceivers finds all matching receivers for the given routing attributes,
+// respecting the Continue flag for multi-receiver fanout (BR-NOT-068).
+// Returns resolved []*Receiver objects (not just names).
+// Falls back to default console receiver when config is nil, no routes match,
+// or resolved receiver names don't exist in the config.
+// Thread-safe: acquires RLock for the duration of the call.
+func (r *Router) FindReceivers(attrs map[string]string) []*Receiver {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	if r.config == nil || r.config.Route == nil {
+		r.logger.V(1).Info("No routing configuration, using default console fallback")
+		return []*Receiver{defaultConsoleReceiver()}
+	}
+
+	names := r.config.Route.FindReceivers(attrs)
+	if len(names) == 0 {
+		r.logger.V(1).Info("No matching routes found, using default console fallback",
+			"attributes", attrs)
+		return []*Receiver{defaultConsoleReceiver()}
+	}
+
+	var receivers []*Receiver
+	for _, name := range names {
+		if recv := r.config.GetReceiver(name); recv != nil {
+			receivers = append(receivers, recv)
+		}
+	}
+	if len(receivers) == 0 {
+		return []*Receiver{defaultConsoleReceiver()}
+	}
+
+	r.logger.V(1).Info("Resolved receivers from routing rules",
+		"attributes", attrs,
+		"receivers", names,
+	)
+
+	return receivers
+}
+
 // FindReceiver finds the matching receiver for the given routing attributes.
 // BR-NOT-065: Attribute-based routing with ordered evaluation
 // Thread-safe read access.

--- a/pkg/remediationorchestrator/creator/notification.go
+++ b/pkg/remediationorchestrator/creator/notification.go
@@ -110,6 +110,13 @@ func FormatRemediationLine(rrName string) string {
 	return fmt.Sprintf("**Remediation**: %s\n\n", rrName)
 }
 
+// FormatStatusLine returns a formatted status line for notification bodies.
+// Issue #628: Single standardized **Status** label across all notification types.
+// Display enum: Remediated | Pending Approval | Timed Out | Manual Review Required | Self-Resolved | Duplicate Handled
+func FormatStatusLine(status string) string {
+	return fmt.Sprintf("**Status**: %s\n\n", status)
+}
+
 // FormatClusterLine returns a formatted cluster identification line for notification bodies.
 // Returns empty string when both name and uuid are empty (graceful degradation).
 func FormatClusterLine(clusterName, clusterUUID string) string {
@@ -262,9 +269,9 @@ func (c *NotificationCreator) buildApprovalBody(rr *remediationv1.RemediationReq
 		workflowLabel = fmt.Sprintf("%s (%s)", ai.Status.SelectedWorkflow.ActionType, ai.Status.SelectedWorkflow.WorkflowID)
 	}
 
-	body := fmt.Sprintf(`Remediation requires approval:
-
-**Signal**: %s
+	body := "Remediation requires approval:\n\n" +
+		FormatStatusLine("Pending Approval") +
+		fmt.Sprintf(`**Signal**: %s
 **Severity**: %s
 
 **Affected Resource**:
@@ -428,9 +435,10 @@ func (c *NotificationCreator) buildCompletionBody(
 		workflowLabel = fmt.Sprintf("%s (%s)", actionType, workflowID)
 	}
 
-	body := fmt.Sprintf(`Remediation Completed Successfully
-
-**Outcome**: %s
+	// Deprecated: **Outcome** retained for one release (Issue #628). Use **Status** for canonical status.
+	body := "Remediation Completed Successfully\n\n" +
+		FormatStatusLine(string(rr.Status.Outcome)) +
+		fmt.Sprintf(`**Outcome**: %s
 
 **Signal**: %s
 **Severity**: %s
@@ -550,9 +558,11 @@ func (c *NotificationCreator) CreateBulkDuplicateNotification(
 
 // buildBulkDuplicateBody builds the bulk duplicate notification body.
 func (c *NotificationCreator) buildBulkDuplicateBody(rr *remediationv1.RemediationRequest) string {
-	return FormatClusterLine(c.clusterName, c.clusterUUID) + FormatRemediationLine(rr.Name) + fmt.Sprintf(`Remediation completed successfully.
-
-**Signal**: %s
+	// Deprecated: **Result** retained for one release (Issue #628). Use **Status** for canonical status.
+	return FormatClusterLine(c.clusterName, c.clusterUUID) + FormatRemediationLine(rr.Name) +
+		"Remediation completed successfully.\n\n" +
+		FormatStatusLine("Duplicate Handled") +
+		fmt.Sprintf(`**Signal**: %s
 **Result**: %s
 
 **Affected Resource**:
@@ -781,9 +791,9 @@ func (c *NotificationCreator) buildManualReviewContext(rr *remediationv1.Remedia
 
 // buildManualReviewBody builds the manual review notification body.
 func (c *NotificationCreator) buildManualReviewBody(rr *remediationv1.RemediationRequest, ctx *ManualReviewContext) string {
-	body := fmt.Sprintf(`⚠️ **Manual Review Required**
-
-**Signal**: %s
+	body := "⚠️ **Manual Review Required**\n\n" +
+		FormatStatusLine("Manual Review Required") +
+		fmt.Sprintf(`**Signal**: %s
 **Severity**: %s
 
 **Affected Resource**:
@@ -937,9 +947,9 @@ func (c *NotificationCreator) buildSelfResolvedBody(
 	rootCause string,
 	target remediationv1.ResourceIdentifier,
 ) string {
-	body := fmt.Sprintf(`Signal was investigated but no remediation was needed.
-
-**Signal**: %s
+	body := "Signal was investigated but no remediation was needed.\n\n" +
+		FormatStatusLine("Self-Resolved") +
+		fmt.Sprintf(`**Signal**: %s
 **Severity**: %s
 
 **Affected Resource**:
@@ -972,9 +982,9 @@ func (c *NotificationCreator) buildSelfResolvedBody(
 func (c *NotificationCreator) BuildGlobalTimeoutBody(
 	signalName, rrName, timeoutPhase, timeoutDuration, startTime, timeoutTime string,
 ) string {
-	body := fmt.Sprintf(`Remediation request has exceeded the global timeout and requires manual intervention.
-
-**Signal**: %s
+	body := "Remediation request has exceeded the global timeout and requires manual intervention.\n\n" +
+		FormatStatusLine("Timed Out") +
+		fmt.Sprintf(`**Signal**: %s
 **Timeout Phase**: %s
 **Timeout Duration**: %s
 **Started**: %s
@@ -991,9 +1001,9 @@ The remediation was in %s phase when it timed out. Please investigate why the re
 func (c *NotificationCreator) BuildPhaseTimeoutBody(
 	signalName, rrName, phase, phaseTimeout, startTime, timeoutTime string,
 ) string {
-	body := fmt.Sprintf(`Remediation phase has exceeded timeout and requires investigation.
-
-**Signal**: %s
+	body := "Remediation phase has exceeded timeout and requires investigation.\n\n" +
+		FormatStatusLine("Timed Out") +
+		fmt.Sprintf(`**Signal**: %s
 **Phase**: %s
 **Phase Timeout**: %s
 **Started**: %s

--- a/pkg/remediationorchestrator/creator/workflowexecution.go
+++ b/pkg/remediationorchestrator/creator/workflowexecution.go
@@ -131,9 +131,8 @@ func (c *WorkflowExecutionCreator) Create(
 			Rationale:  ai.Status.SelectedWorkflow.Rationale,
 			// Issue #518: ExecutionEngine removed from spec — resolved at runtime by
 			// the WE controller from the DS catalog via WorkflowQuerier.
-			// Issue #501: ServiceAccountName is now top-level, engine-agnostic
-			ServiceAccountName: ai.Status.SelectedWorkflow.ServiceAccountName,
-			ExecutionConfig:    c.buildExecutionConfig(rr),
+			// Issue #650: ServiceAccountName is not on WFE spec; resolved at runtime from DS.
+			ExecutionConfig: c.buildExecutionConfig(rr),
 		},
 	}
 
@@ -206,7 +205,7 @@ func resolveTargetResource(rr *remediationv1.RemediationRequest, ai *aianalysisv
 }
 
 // buildExecutionConfig builds ExecutionConfig from RemediationRequest timeouts.
-// Issue #501: ServiceAccountName moved to Spec.ServiceAccountName.
+// Issue #650: Service account is not part of ExecutionConfig or WFE spec.
 func (c *WorkflowExecutionCreator) buildExecutionConfig(rr *remediationv1.RemediationRequest) *workflowexecutionv1.ExecutionConfig {
 	if rr.Status.TimeoutConfig != nil && rr.Status.TimeoutConfig.Executing != nil && rr.Status.TimeoutConfig.Executing.Duration > 0 {
 		return &workflowexecutionv1.ExecutionConfig{

--- a/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
@@ -945,15 +945,6 @@ spec:
                   rationale:
                     description: Rationale explaining why this workflow was selected
                     type: string
-                  serviceAccountName:
-                    description: |-
-                      ServiceAccountName is the pre-existing ServiceAccount for the execution
-                      resource (Job, PipelineRun, or Ansible TokenRequest).
-                      DD-WE-005 v2.0: Operators pre-create SAs with appropriate RBAC in the
-                      execution namespace. If absent, K8s assigns the namespace's default SA
-                      (Job/Tekton) or the Ansible executor uses the controller's in-cluster
-                      credentials (#500 fallback).
-                    type: string
                   version:
                     description: Workflow version
                     type: string

--- a/pkg/shared/assets/crds/kubernaut.ai_notificationrequests.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_notificationrequests.yaml
@@ -264,13 +264,13 @@ spec:
                   Issue #91: promoted from mutable label to immutable spec field
                 type: string
               priority:
-                default: medium
+                default: Medium
                 description: Priority of notification (critical, high, medium, low)
                 enum:
-                - critical
-                - high
-                - medium
-                - low
+                - Critical
+                - High
+                - Medium
+                - Low
                 type: string
               remediationRequestRef:
                 description: |-
@@ -373,12 +373,12 @@ spec:
               type:
                 description: Type of notification (escalation, simple, status-update)
                 enum:
-                - escalation
-                - simple
-                - status-update
-                - approval
-                - manual-review
-                - completion
+                - Escalation
+                - Simple
+                - StatusUpdate
+                - Approval
+                - ManualReview
+                - Completion
                 type: string
             required:
             - body

--- a/pkg/shared/assets/crds/kubernaut.ai_remediationrequests.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_remediationrequests.yaml
@@ -23,45 +23,37 @@ spec:
     - jsonPath: .status.outcome
       name: Outcome
       type: string
+    - jsonPath: .spec.signalName
+      name: Alert
+      type: string
+    - jsonPath: .status.targetDisplay
+      name: RCA Target
+      type: string
+    - jsonPath: .status.workflowDisplayName
+      name: Workflow
+      type: string
+    - jsonPath: .status.confidence
+      name: Confidence
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     - jsonPath: .spec.signalSource
       name: Source
       priority: 1
       type: string
-    - jsonPath: .spec.targetResource.name
-      name: Target
-      priority: 1
-      type: string
     - jsonPath: .spec.targetResource.namespace
-      name: Target NS
+      name: Signal NS
       priority: 1
       type: string
-    - jsonPath: .spec.targetResource.kind
-      name: Target Kind
-      priority: 1
-      type: string
-    - jsonPath: .status.remediationTarget.name
-      name: RCA Target
+    - jsonPath: .status.signalTargetDisplay
+      name: Signal Target
       priority: 1
       type: string
     - jsonPath: .status.remediationTarget.namespace
       name: RCA NS
       priority: 1
       type: string
-    - jsonPath: .status.remediationTarget.kind
-      name: RCA Kind
-      priority: 1
-      type: string
-    - jsonPath: .status.selectedWorkflowRef.workflowId
-      name: Workflow
-      priority: 1
-      type: string
-    - jsonPath: .status.conditions[?(@.type=="Ready")].reason
-      name: Reason
-      priority: 1
-      type: string
-    - jsonPath: .metadata.creationTimestamp
-      name: Age
-      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:
@@ -417,6 +409,11 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              confidence:
+                description: |-
+                  Confidence is the AI analysis confidence score as a display string
+                  (e.g., "0.97"). Populated from AIAnalysis.SelectedWorkflow.Confidence.
+                type: string
               consecutiveFailureCount:
                 description: |-
                   ConsecutiveFailureCount tracks how many times this fingerprint has failed consecutively.
@@ -940,6 +937,11 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
+              signalTargetDisplay:
+                description: |-
+                  SignalTargetDisplay is the Kubernetes-idiomatic Kind/Name of the signal target
+                  (e.g., "Pod/web-frontend-cdbdbc4f8-6kn6j"). Populated from Spec.TargetResource.
+                type: string
               skipMessage:
                 description: |-
                   SkipMessage provides human-readable details about why remediation was skipped
@@ -970,6 +972,11 @@ spec:
               startTime:
                 description: Timestamps
                 format: date-time
+                type: string
+              targetDisplay:
+                description: |-
+                  TargetDisplay is the Kubernetes-idiomatic Kind/Name of the RCA target
+                  (e.g., "Deployment/web-frontend"). Populated when RemediationTarget is set.
                 type: string
               timeoutConfig:
                 description: |-
@@ -1039,6 +1046,11 @@ spec:
                   If exceeded, RR transitions to Completed with Outcome "VerificationTimedOut".
                   Reference: #280 (Verifying phase timeout)
                 format: date-time
+                type: string
+              workflowDisplayName:
+                description: |-
+                  WorkflowDisplayName is the human-readable workflow identifier
+                  (e.g., "GitRevertCommit:git-revert-v2"). Populated from AIAnalysis.SelectedWorkflow.
                 type: string
               workflowExecutionRef:
                 description: ObjectReference contains enough information to let you

--- a/pkg/shared/assets/crds/kubernaut.ai_remediationworkflows.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_remediationworkflows.yaml
@@ -62,7 +62,7 @@ spec:
           spec:
             description: |-
               RemediationWorkflowSpec defines the desired state of RemediationWorkflow.
-              Maps to the spec content of a workflow-schema.yaml file per BR-WORKFLOW-004.
+              Declared as a Kubernetes resource; registered via kubectl apply (BR-WORKFLOW-006).
               Workflow name is derived from the CRD's metadata.name (not duplicated in spec).
             properties:
               actionType:

--- a/pkg/shared/assets/crds/kubernaut.ai_workflowexecutions.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_workflowexecutions.yaml
@@ -138,14 +138,6 @@ spec:
                     type: string
                 type: object
                 x-kubernetes-map-type: atomic
-              serviceAccountName:
-                description: |-
-                  ServiceAccountName is the pre-existing ServiceAccount for the execution
-                  resource (Job, PipelineRun, or Ansible TokenRequest). DD-WE-005 v2.0:
-                  Operators pre-create SAs with appropriate RBAC in the execution namespace.
-                  If absent, K8s assigns the namespace's default SA (Job/Tekton) or the
-                  Ansible executor falls back to the controller's in-cluster credentials.
-                type: string
               targetResource:
                 description: |-
                   TargetResource identifies the K8s resource being remediated
@@ -450,6 +442,14 @@ spec:
                 - Running
                 - Completed
                 - Failed
+                type: string
+              serviceAccountName:
+                description: |-
+                  ServiceAccountName is the pre-existing ServiceAccount resolved from the
+                  DS workflow catalog at runtime by the WE controller (Issue #650).
+                  Set once during Pending phase via ResolveWorkflowCatalogMetadata; immutable
+                  thereafter. If empty, K8s assigns the namespace's default SA (Job/Tekton)
+                  or the Ansible executor falls back to the controller's in-cluster credentials.
                 type: string
               startTime:
                 description: StartTime when execution started

--- a/pkg/workflowexecution/client/workflow_querier.go
+++ b/pkg/workflowexecution/client/workflow_querier.go
@@ -32,8 +32,22 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/shared/auth"
 )
 
+// WorkflowCatalogMetadata holds all workflow metadata resolved from the DS
+// catalog in a single GetWorkflowByID call (Issue #650). Consolidates what was
+// previously 4 separate calls into one round-trip.
+type WorkflowCatalogMetadata struct {
+	ExecutionEngine       string
+	WorkflowName          string
+	ExecutionBundle       string
+	ExecutionBundleDigest string
+	ServiceAccountName    string
+	EngineConfig          json.RawMessage
+	Dependencies          *models.WorkflowDependencies
+}
+
 // WorkflowQuerier retrieves workflow metadata from the Data Storage catalog.
 // DD-WE-006: WFE queries DS on demand using the workflow ID.
+// Issue #650: Consolidated into a single method to avoid redundant DS calls.
 type WorkflowQuerier interface {
 	GetWorkflowDependencies(ctx context.Context, workflowID string) (*models.WorkflowDependencies, error)
 	// GetWorkflowEngineConfig retrieves the engine_config for a workflow from the catalog.
@@ -48,6 +62,10 @@ type WorkflowQuerier interface {
 	// its digest from the DS catalog. Defense-in-depth: the WE controller resolves
 	// the bundle at runtime rather than blindly trusting the WFE spec value.
 	GetWorkflowExecutionBundle(ctx context.Context, workflowID string) (bundle string, digest string, err error)
+	// ResolveWorkflowCatalogMetadata fetches all workflow metadata (engine, bundle,
+	// SA, engineConfig, dependencies) from DS in a single GetWorkflowByID call.
+	// Issue #650: Replaces the 4 individual methods above.
+	ResolveWorkflowCatalogMetadata(ctx context.Context, workflowID string) (*WorkflowCatalogMetadata, error)
 }
 
 // WorkflowCatalogClient is a narrow interface satisfied by the ogen-generated
@@ -220,4 +238,54 @@ func (q *OgenWorkflowQuerier) GetWorkflowExecutionBundle(ctx context.Context, wo
 		digest = wf.ExecutionBundleDigest.Value
 	}
 	return bundle, digest, nil
+}
+
+// ResolveWorkflowCatalogMetadata fetches all workflow metadata from DS in one
+// GetWorkflowByID call (Issue #650).
+func (q *OgenWorkflowQuerier) ResolveWorkflowCatalogMetadata(ctx context.Context, workflowID string) (*WorkflowCatalogMetadata, error) {
+	uid, err := uuid.Parse(workflowID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid workflow ID %q: %w", workflowID, err)
+	}
+
+	res, err := q.client.GetWorkflowByID(ctx, ogenclient.GetWorkflowByIDParams{
+		WorkflowID: uid,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("DS query failed for workflow %s: %w", workflowID, err)
+	}
+
+	wf, ok := res.(*ogenclient.RemediationWorkflow)
+	if !ok {
+		return nil, fmt.Errorf("workflow %s not found in catalog", workflowID)
+	}
+
+	meta := &WorkflowCatalogMetadata{
+		ExecutionEngine: wf.ExecutionEngine,
+		WorkflowName:    wf.WorkflowName,
+	}
+	if wf.ExecutionBundle.IsSet() {
+		meta.ExecutionBundle = wf.ExecutionBundle.Value
+	}
+	if wf.ExecutionBundleDigest.IsSet() {
+		meta.ExecutionBundleDigest = wf.ExecutionBundleDigest.Value
+	}
+	if wf.ServiceAccountName.IsSet() {
+		meta.ServiceAccountName = wf.ServiceAccountName.Value
+	}
+
+	if wf.Content != "" {
+		parser := schema.NewParser()
+		parsed, err := parser.Parse(wf.Content)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse workflow schema for %s: %w", workflowID, err)
+		}
+		meta.Dependencies = parser.ExtractDependencies(parsed)
+		rawMsg := parser.ExtractEngineConfig(parsed)
+		if rawMsg != nil {
+			meta.EngineConfig = *rawMsg
+		}
+	}
+
+	return meta, nil
 }

--- a/pkg/workflowexecution/client/workflow_querier.go
+++ b/pkg/workflowexecution/client/workflow_querier.go
@@ -113,6 +113,23 @@ func NewOgenWorkflowQuerierFromConfig(baseURL string, timeout time.Duration) (*O
 	return &OgenWorkflowQuerier{client: ogenClient}, nil
 }
 
+// classifyGetWorkflowResponse maps the polymorphic ogen response to either the
+// successful workflow object or a properly classified error. This eliminates the
+// misleading "not found" message that was previously returned for all non-200
+// responses including HTTP 500 (Issue #658).
+func classifyGetWorkflowResponse(res ogenclient.GetWorkflowByIDRes, workflowID string) (*ogenclient.RemediationWorkflow, error) {
+	switch r := res.(type) {
+	case *ogenclient.RemediationWorkflow:
+		return r, nil
+	case *ogenclient.GetWorkflowByIDNotFound:
+		return nil, fmt.Errorf("workflow %s not found in catalog", workflowID)
+	case *ogenclient.GetWorkflowByIDInternalServerError:
+		return nil, fmt.Errorf("DS internal server error for workflow %s", workflowID)
+	default:
+		return nil, fmt.Errorf("unexpected DS response type %T for workflow %s", res, workflowID)
+	}
+}
+
 // GetWorkflowDependencies fetches the workflow from DS by ID and extracts
 // schema-declared dependencies from the Content field (raw YAML).
 // Returns nil if the workflow has no dependencies declared.
@@ -129,9 +146,9 @@ func (q *OgenWorkflowQuerier) GetWorkflowDependencies(ctx context.Context, workf
 		return nil, fmt.Errorf("DS query failed for workflow %s: %w", workflowID, err)
 	}
 
-	wf, ok := res.(*ogenclient.RemediationWorkflow)
-	if !ok {
-		return nil, fmt.Errorf("workflow %s not found in catalog", workflowID)
+	wf, err := classifyGetWorkflowResponse(res, workflowID)
+	if err != nil {
+		return nil, err
 	}
 
 	if wf.Content == "" {
@@ -163,9 +180,9 @@ func (q *OgenWorkflowQuerier) GetWorkflowEngineConfig(ctx context.Context, workf
 		return nil, fmt.Errorf("DS query failed for workflow %s: %w", workflowID, err)
 	}
 
-	wf, ok := res.(*ogenclient.RemediationWorkflow)
-	if !ok {
-		return nil, fmt.Errorf("workflow %s not found in catalog", workflowID)
+	wf, err := classifyGetWorkflowResponse(res, workflowID)
+	if err != nil {
+		return nil, err
 	}
 
 	if wf.Content == "" {
@@ -201,9 +218,9 @@ func (q *OgenWorkflowQuerier) GetWorkflowExecutionEngine(ctx context.Context, wo
 		return "", "", fmt.Errorf("DS query failed for workflow %s: %w", workflowID, err)
 	}
 
-	wf, ok := res.(*ogenclient.RemediationWorkflow)
-	if !ok {
-		return "", "", fmt.Errorf("workflow %s not found in catalog", workflowID)
+	wf, err := classifyGetWorkflowResponse(res, workflowID)
+	if err != nil {
+		return "", "", err
 	}
 
 	return wf.ExecutionEngine, wf.WorkflowName, nil
@@ -225,9 +242,9 @@ func (q *OgenWorkflowQuerier) GetWorkflowExecutionBundle(ctx context.Context, wo
 		return "", "", fmt.Errorf("DS query failed for workflow %s: %w", workflowID, err)
 	}
 
-	wf, ok := res.(*ogenclient.RemediationWorkflow)
-	if !ok {
-		return "", "", fmt.Errorf("workflow %s not found in catalog", workflowID)
+	wf, err := classifyGetWorkflowResponse(res, workflowID)
+	if err != nil {
+		return "", "", err
 	}
 
 	var bundle, digest string
@@ -255,9 +272,9 @@ func (q *OgenWorkflowQuerier) ResolveWorkflowCatalogMetadata(ctx context.Context
 		return nil, fmt.Errorf("DS query failed for workflow %s: %w", workflowID, err)
 	}
 
-	wf, ok := res.(*ogenclient.RemediationWorkflow)
-	if !ok {
-		return nil, fmt.Errorf("workflow %s not found in catalog", workflowID)
+	wf, err := classifyGetWorkflowResponse(res, workflowID)
+	if err != nil {
+		return nil, err
 	}
 
 	meta := &WorkflowCatalogMetadata{

--- a/pkg/workflowexecution/executor/ansible.go
+++ b/pkg/workflowexecution/executor/ansible.go
@@ -239,11 +239,11 @@ func (a *AnsibleExecutor) Create(
 	}
 
 	// Issue #501: injectK8sCredential now uses TokenRequest when
-	// Spec.ServiceAccountName is set, falling back to in-cluster creds.
+	// Status.ServiceAccountName is set, falling back to in-cluster creds.
 	var warnings []Warning
 	k8sCredID, k8sWarnings, k8sErr := a.injectK8sCredential(ctx, wfe, namespace)
 	if k8sErr != nil {
-		if wfe.Spec.ServiceAccountName != "" {
+		if wfe.Status.ServiceAccountName != "" {
 			// Hard failure: operator explicitly requested per-workflow credentials.
 			return nil, fmt.Errorf("inject per-workflow K8s credential: %w", k8sErr)
 		}
@@ -505,7 +505,7 @@ func (i k8sCredentialInputs) toMap() map[string]string {
 // When the CA cert is empty (e.g. in dev clusters), the ssl_ca_cert input is
 // omitted so the kubeconfig template falls back to insecure-skip-tls-verify (#552).
 // injectK8sCredential obtains K8s API credentials and creates an ephemeral AWX
-// credential. Issue #501: When wfe.Spec.ServiceAccountName is set, a short-lived
+// credential. Issue #501: When wfe.Status.ServiceAccountName is set, a short-lived
 // token is obtained via the TokenRequest API scoped to that SA. When empty, the
 // controller's own in-cluster credentials are used (backward-compatible fallback
 // from Issue #500).
@@ -517,10 +517,10 @@ func (a *AnsibleExecutor) injectK8sCredential(
 	var creds *InClusterCredentials
 	var warnings []Warning
 
-	if wfe.Spec.ServiceAccountName != "" {
+	if wfe.Status.ServiceAccountName != "" {
 		tokenCreds, tokenWarnings, err := a.requestTokenForSA(ctx, wfe, namespace)
 		if err != nil {
-			return 0, nil, fmt.Errorf("TokenRequest for SA %q in %q: %w", wfe.Spec.ServiceAccountName, namespace, err)
+			return 0, nil, fmt.Errorf("TokenRequest for SA %q in %q: %w", wfe.Status.ServiceAccountName, namespace, err)
 		}
 		creds = tokenCreds
 		warnings = tokenWarnings
@@ -554,7 +554,7 @@ func (a *AnsibleExecutor) injectK8sCredential(
 
 	a.Logger.Info("Created ephemeral K8s credential",
 		"credentialID", credID, "credentialType", typeID, "wfe", wfe.Name,
-		"source", credSourceLabel(wfe.Spec.ServiceAccountName))
+		"source", credSourceLabel(wfe.Status.ServiceAccountName))
 	return credID, warnings, nil
 }
 
@@ -585,14 +585,14 @@ func (a *AnsibleExecutor) requestTokenForSA(
 	}
 
 	tokenResp, err := a.Clientset.CoreV1().ServiceAccounts(namespace).CreateToken(
-		ctx, wfe.Spec.ServiceAccountName, treq, metav1.CreateOptions{},
+		ctx, wfe.Status.ServiceAccountName, treq, metav1.CreateOptions{},
 	)
 	if err != nil {
-		return nil, nil, fmt.Errorf("create token for SA %q: %w", wfe.Spec.ServiceAccountName, err)
+		return nil, nil, fmt.Errorf("create token for SA %q: %w", wfe.Status.ServiceAccountName, err)
 	}
 
 	if tokenResp.Status.Token == "" {
-		return nil, nil, fmt.Errorf("TokenRequest returned empty token for SA %q/%q", namespace, wfe.Spec.ServiceAccountName)
+		return nil, nil, fmt.Errorf("TokenRequest returned empty token for SA %q/%q", namespace, wfe.Status.ServiceAccountName)
 	}
 
 	// TTL validation: compare granted expiration against execution timeout
@@ -602,7 +602,7 @@ func (a *AnsibleExecutor) requestTokenForSA(
 		msg := fmt.Sprintf("granted token TTL %s is shorter than execution timeout %s — playbook may receive 401 errors if it outlives the token",
 			grantedTTL, executionTimeout)
 		a.Logger.Info("WARNING: "+msg,
-			"wfe", wfe.Name, "sa", wfe.Spec.ServiceAccountName,
+			"wfe", wfe.Name, "sa", wfe.Status.ServiceAccountName,
 			"grantedTTL", grantedTTL, "executionTimeout", executionTimeout)
 		warnings = append(warnings, Warning{
 			Type:    workflowexecutionv1alpha1.ConditionTokenTTLInsufficient,

--- a/pkg/workflowexecution/executor/job.go
+++ b/pkg/workflowexecution/executor/job.go
@@ -223,7 +223,7 @@ func (j *JobExecutor) buildJob(wfe *workflowexecutionv1alpha1.WorkflowExecution,
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyNever,
-					ServiceAccountName: wfe.Spec.ServiceAccountName,
+					ServiceAccountName: wfe.Status.ServiceAccountName,
 					Volumes:            volumes,
 					Containers: []corev1.Container{
 						{

--- a/pkg/workflowexecution/executor/tekton.go
+++ b/pkg/workflowexecution/executor/tekton.go
@@ -192,7 +192,7 @@ func (t *TektonExecutor) buildPipelineRun(wfe *workflowexecutionv1alpha1.Workflo
 			Params:     params,
 			Workspaces: workspaces,
 			TaskRunTemplate: tektonv1.PipelineTaskRunTemplate{
-				ServiceAccountName: wfe.Spec.ServiceAccountName,
+				ServiceAccountName: wfe.Status.ServiceAccountName,
 			},
 		},
 	}

--- a/test/e2e/notification/10_fanout_routing_test.go
+++ b/test/e2e/notification/10_fanout_routing_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2025 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package notification
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	notificationv1alpha1 "github.com/jordigilh/kubernaut/api/notification/v1alpha1"
+)
+
+// ========================================
+// E2E Test: Multi-Receiver Fanout Routing (BR-NOT-068, #597)
+// ========================================
+//
+// BUSINESS REQUIREMENT: BR-NOT-068 - Multi-Channel Fanout
+//
+// Test Strategy:
+// 1. Create NotificationRequest matching pre-deployed continue:true routes
+// 2. Validate delivery to channels from ALL matched receivers
+// 3. Verify per-channel delivery status tracking
+//
+// PARALLEL SAFETY: Fanout routes are pre-deployed in the initial routing
+// ConfigMap (test/infrastructure/notification_e2e.go). No ConfigMap mutation
+// occurs at test time.
+// ========================================
+
+var _ = Describe("Fanout Routing E2E (BR-NOT-068, #597)", func() {
+
+	// ========================================
+	// E2E-NOT-597-001: Multi-receiver fanout delivery
+	// ========================================
+	Context("Multi-receiver fanout via continue:true routing", func() {
+
+		It("[E2E-NOT-597-001] should deliver to channels from all matched receivers", FlakeAttempts(3), func() {
+			By("Creating NotificationRequest matching continue:true fanout routes")
+
+			notification := &notificationv1alpha1.NotificationRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "e2e-fanout-routing-597",
+					Namespace: controllerNamespace,
+					Labels: map[string]string{
+						"test-scenario": "fanout-routing",
+						"test-priority": "P0",
+					},
+				},
+				Spec: notificationv1alpha1.NotificationRequestSpec{
+					Type:     notificationv1alpha1.NotificationTypeSimple,
+					Subject:  "E2E-NOT-597-001: Fanout Routing Test",
+					Body:     "Testing multi-receiver fanout via continue:true routing in Kind cluster",
+					Priority: notificationv1alpha1.NotificationPriorityHigh,
+					Extensions: map[string]string{
+						"test-channel-set": "e2e-fanout",
+					},
+				},
+			}
+
+			DeferCleanup(func() {
+				_ = k8sClient.Delete(ctx, notification)
+			})
+
+			err := k8sClient.Create(ctx, notification)
+			Expect(err).ToNot(HaveOccurred(), "Failed to create NotificationRequest")
+
+			By("Waiting for notification to reach Sent phase")
+			Eventually(func() notificationv1alpha1.NotificationPhase {
+				err := k8sClient.Get(ctx, client.ObjectKey{
+					Name:      notification.Name,
+					Namespace: notification.Namespace,
+				}, notification)
+				if err != nil {
+					return ""
+				}
+				return notification.Status.Phase
+			}, 30*time.Second, 500*time.Millisecond).Should(Equal(notificationv1alpha1.NotificationPhaseSent),
+				"All channels from matched receivers should deliver successfully")
+
+			By("Verifying delivery to channels from all matched receivers")
+			err = apiReader.Get(ctx, client.ObjectKey{
+				Name:      notification.Name,
+				Namespace: notification.Namespace,
+			}, notification)
+			Expect(err).ToNot(HaveOccurred())
+
+			// fanout-console (console) + fanout-file-log (file + log) = 3 delivery attempts
+			Expect(notification.Status.SuccessfulDeliveries).To(Equal(3),
+				"Should have 3 successful deliveries (console from fanout-console, file+log from fanout-file-log)")
+			Expect(notification.Status.FailedDeliveries).To(Equal(0),
+				"Should have 0 failed deliveries")
+
+			By("Verifying per-channel delivery attempts (BR-NOT-068)")
+			Expect(notification.Status.DeliveryAttempts).To(HaveLen(3),
+				"Should record 3 delivery attempts (one per channel)")
+
+			channelsSeen := make(map[string]bool)
+			for _, attempt := range notification.Status.DeliveryAttempts {
+				channelsSeen[string(attempt.Channel)] = true
+				Expect(attempt.Status).To(Equal(notificationv1alpha1.DeliveryAttemptStatusSuccess),
+					"All delivery attempts should succeed")
+			}
+
+			Expect(channelsSeen).To(HaveKey("console"),
+				"Console channel from fanout-console receiver should be in delivery attempts")
+			Expect(channelsSeen).To(HaveKey("file"),
+				"File channel from fanout-file-log receiver should be in delivery attempts")
+			Expect(channelsSeen).To(HaveKey("log"),
+				"Log channel from fanout-file-log receiver should be in delivery attempts")
+
+			logger.Info("FANOUT ROUTING SUCCESS: All 3 channels from 2 receivers delivered successfully")
+		})
+	})
+})

--- a/test/infrastructure/notification_e2e.go
+++ b/test/infrastructure/notification_e2e.go
@@ -682,6 +682,13 @@ data:
         - receiver: console-slack-failure
           match:
             test-channel-set: console-slack-failure
+        - receiver: fanout-console
+          match:
+            test-channel-set: e2e-fanout
+          continue: true
+        - receiver: fanout-file-log
+          match:
+            test-channel-set: e2e-fanout
     receivers:
       - name: default-console
         consoleConfigs:
@@ -724,6 +731,14 @@ data:
         slackConfigs:
           - channel: "#test-failure"
             credentialRef: slack-failure
+      - name: fanout-console
+        consoleConfigs:
+          - enabled: true
+      - name: fanout-file-log
+        fileConfigs:
+          - enabled: true
+        logConfigs:
+          - enabled: true
 ---
 apiVersion: v1
 kind: Secret

--- a/test/integration/effectivenessmonitor/issue573_integration_test.go
+++ b/test/integration/effectivenessmonitor/issue573_integration_test.go
@@ -183,7 +183,8 @@ var _ = Describe("Issue #573: ADR-EM-001 Implementation Gaps", func() {
 		newLocalReconciler := func(dsURL string, initObjects ...client.Object) (*controller.Reconciler, client.Client) {
 			localMetrics = emmetrics.NewMetricsWithRegistry(prometheus.NewRegistry())
 			fakeRecorder = record.NewFakeRecorder(20)
-			dsQuerier := emclient.NewDataStorageHTTPQuerier(dsURL)
+			dsQuerier, err := emclient.NewOgenDataStorageQuerier(dsURL, 10*time.Second)
+			Expect(err).ToNot(HaveOccurred())
 
 			s := runtime.NewScheme()
 			Expect(eav1.AddToScheme(s)).To(Succeed())
@@ -213,11 +214,35 @@ var _ = Describe("Issue #573: ADR-EM-001 Implementation Gaps", func() {
 			return r, fc
 		}
 
+		// ogenCompliantEvent builds a schema-compliant AuditEvent JSON map with
+		// all 8 required fields plus event_type discriminator inside event_data.
+		ogenCompliantEvent := func(eventType, correlationID string) map[string]interface{} {
+			return map[string]interface{}{
+				"version":         "1.0",
+				"event_type":      eventType,
+				"event_timestamp": "2026-01-01T00:00:00Z",
+				"event_category":  "workflowexecution",
+				"event_action":    "test_action",
+				"event_outcome":   "success",
+				"correlation_id":  correlationID,
+				"event_data": map[string]interface{}{
+					"event_type":       eventType,
+					"workflow_id":      "test-wf",
+					"workflow_version": "1.0.0",
+					"target_resource":  "default/Deployment/test-app",
+					"phase":            "Running",
+					"container_image":  "test:latest",
+					"execution_name":   "test-exec",
+				},
+			}
+		}
+
 		// mockDSHandler creates an HTTP handler that responds to HasWorkflowStarted
-		// and HasWorkflowCompleted queries based on the provided flags.
+		// and HasWorkflowCompleted queries with ogen-compliant AuditEvent JSON.
 		mockDSHandler := func(started, completed bool) http.HandlerFunc {
 			return func(w http.ResponseWriter, r *http.Request) {
 				eventType := r.URL.Query().Get("event_type")
+				correlationID := r.URL.Query().Get("correlation_id")
 				w.Header().Set("Content-Type", "application/json")
 
 				var events []map[string]interface{}
@@ -225,13 +250,13 @@ var _ = Describe("Issue #573: ADR-EM-001 Implementation Gaps", func() {
 				case "workflowexecution.execution.started":
 					if started {
 						events = []map[string]interface{}{
-							{"event_type": eventType, "correlation_id": r.URL.Query().Get("correlation_id")},
+							ogenCompliantEvent(eventType, correlationID),
 						}
 					}
 				case "workflowexecution.workflow.completed":
 					if completed {
 						events = []map[string]interface{}{
-							{"event_type": eventType, "correlation_id": r.URL.Query().Get("correlation_id")},
+							ogenCompliantEvent(eventType, correlationID),
 						}
 					}
 				}

--- a/test/integration/effectivenessmonitor/issue573_integration_test.go
+++ b/test/integration/effectivenessmonitor/issue573_integration_test.go
@@ -245,19 +245,15 @@ var _ = Describe("Issue #573: ADR-EM-001 Implementation Gaps", func() {
 				correlationID := r.URL.Query().Get("correlation_id")
 				w.Header().Set("Content-Type", "application/json")
 
-				var events []map[string]interface{}
+				events := make([]map[string]interface{}, 0)
 				switch eventType {
 				case "workflowexecution.execution.started":
 					if started {
-						events = []map[string]interface{}{
-							ogenCompliantEvent(eventType, correlationID),
-						}
+						events = append(events, ogenCompliantEvent(eventType, correlationID))
 					}
 				case "workflowexecution.workflow.completed":
 					if completed {
-						events = []map[string]interface{}{
-							ogenCompliantEvent(eventType, correlationID),
-						}
+						events = append(events, ogenCompliantEvent(eventType, correlationID))
 					}
 				}
 				envelope := map[string]interface{}{"data": events}

--- a/test/integration/notification/fanout_routing_test.go
+++ b/test/integration/notification/fanout_routing_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2025 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package notification
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	notificationv1alpha1 "github.com/jordigilh/kubernaut/api/notification/v1alpha1"
+	kubernautnotif "github.com/jordigilh/kubernaut/pkg/notification"
+)
+
+// =============================================================================
+// BR-NOT-068: Multi-Channel Fanout Integration Tests — Issue #597
+// =============================================================================
+//
+// These tests validate that the controller correctly resolves multiple receivers
+// when `continue: true` routes are configured, and delivers to channels from
+// ALL matched receivers.
+//
+// PARALLEL SAFETY: Fanout routes are pre-loaded in the suite routing config
+// (suite_test.go). No runtime mutation of testRouter occurs in these tests.
+// =============================================================================
+
+var _ = Describe("Route Fanout Integration (BR-NOT-068, #597)", func() {
+
+	var uniqueSuffix string
+
+	BeforeEach(func() {
+		uniqueSuffix = fmt.Sprintf("%d", GinkgoRandomSeed())
+	})
+
+	// ========================================
+	// IT-NOT-597-001: Controller multi-receiver fanout delivery
+	// ========================================
+	Context("Multi-receiver fanout via continue:true routing", func() {
+
+		It("[IT-NOT-597-001] should deliver to channels from all matched receivers", func() {
+			By("Creating NotificationRequest matching continue:true fanout routes")
+
+			notifName := fmt.Sprintf("fanout-it-597-%s", uniqueSuffix)
+
+			notif := &notificationv1alpha1.NotificationRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      notifName,
+					Namespace: testNamespace,
+				},
+				Spec: notificationv1alpha1.NotificationRequestSpec{
+					Type:     notificationv1alpha1.NotificationTypeSimple,
+					Subject:  "IT-NOT-597-001: Fanout Routing Test",
+					Body:     "Testing multi-receiver fanout via continue:true routing",
+					Priority: notificationv1alpha1.NotificationPriorityMedium,
+					Extensions: map[string]string{
+						"test-channel-set": "fanout-test",
+					},
+				},
+			}
+
+			err := k8sClient.Create(ctx, notif)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for notification to reach Sent phase")
+			Eventually(func() notificationv1alpha1.NotificationPhase {
+				freshNotif := &notificationv1alpha1.NotificationRequest{}
+				err := k8sManager.GetAPIReader().Get(ctx, types.NamespacedName{
+					Name:      notifName,
+					Namespace: testNamespace,
+				}, freshNotif)
+				if err != nil {
+					return ""
+				}
+				return freshNotif.Status.Phase
+			}, 30*time.Second, 500*time.Millisecond).Should(Equal(notificationv1alpha1.NotificationPhaseSent))
+
+			By("Verifying delivery to channels from BOTH matched receivers")
+			freshNotif := &notificationv1alpha1.NotificationRequest{}
+			err = k8sManager.GetAPIReader().Get(ctx, types.NamespacedName{
+				Name:      notifName,
+				Namespace: testNamespace,
+			}, freshNotif)
+			Expect(err).NotTo(HaveOccurred())
+
+			// fanout-console (console) + fanout-file (file) = 2 delivery attempts
+			Expect(freshNotif.Status.SuccessfulDeliveries).To(BeNumerically(">=", 2),
+				"Should deliver to channels from both matched receivers (console + file)")
+
+			channelsSeen := make(map[string]bool)
+			for _, attempt := range freshNotif.Status.DeliveryAttempts {
+				channelsSeen[string(attempt.Channel)] = true
+			}
+			Expect(channelsSeen).To(HaveKey("console"),
+				"Console channel from fanout-console receiver should be in delivery attempts")
+			Expect(channelsSeen).To(HaveKey("file"),
+				"File channel from fanout-file receiver should be in delivery attempts")
+
+			By("Verifying RoutingResolved condition lists both receiver names (BR-NOT-069)")
+			routingCondition := kubernautnotif.GetRoutingResolved(freshNotif)
+			Expect(routingCondition).ToNot(BeNil(), "RoutingResolved condition should be set")
+			Expect(routingCondition.Status).To(Equal(metav1.ConditionTrue))
+			Expect(routingCondition.Message).To(ContainSubstring("fanout-console"),
+				"Condition message should mention fanout-console receiver")
+			Expect(routingCondition.Message).To(ContainSubstring("fanout-file"),
+				"Condition message should mention fanout-file receiver")
+
+			err = deleteAndWait(ctx, k8sClient, notif, 5*time.Second)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/test/integration/notification/suite_test.go
+++ b/test/integration/notification/suite_test.go
@@ -486,6 +486,13 @@ route:
     - receiver: all-channels
       match:
         test-channel-set: all-channels
+    - receiver: fanout-console
+      match:
+        test-channel-set: fanout-test
+      continue: true
+    - receiver: fanout-file
+      match:
+        test-channel-set: fanout-test
 receivers:
   - name: console-default
     consoleConfigs:
@@ -521,6 +528,12 @@ receivers:
     fileConfigs:
       - enabled: true
     logConfigs:
+      - enabled: true
+  - name: fanout-console
+    consoleConfigs:
+      - enabled: true
+  - name: fanout-file
+    fileConfigs:
       - enabled: true
 `))).To(Succeed())
 	GinkgoWriter.Println("  ✅ Routing configured with test-channel-set routing rules (#261)")

--- a/test/integration/workflowexecution/audit_comprehensive_test.go
+++ b/test/integration/workflowexecution/audit_comprehensive_test.go
@@ -31,7 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	workflowexecutionv1alpha1 "github.com/jordigilh/kubernaut/api/workflowexecution/v1alpha1"
-	workflowexecution "github.com/jordigilh/kubernaut/internal/controller/workflowexecution"
+	weexecutor "github.com/jordigilh/kubernaut/pkg/workflowexecution/executor"
 )
 
 // Comprehensive Audit Trail Integration Tests
@@ -206,7 +206,7 @@ var _ = Describe("Comprehensive Audit Trail Integration Tests", Label("audit", "
 			Expect(k8sClient.Get(ctx, types.NamespacedName{Name: wfe.Name, Namespace: wfe.Namespace}, updated)).To(Succeed())
 
 			// Get the PipelineRun using deterministic name
-			prName := workflowexecution.PipelineRunName(wfe.Spec.TargetResource)
+			prName := weexecutor.ExecutionResourceName(wfe.Spec.TargetResource)
 			var pr tektonv1.PipelineRun
 			Eventually(func() error {
 				return k8sClient.Get(ctx, client.ObjectKey{
@@ -362,7 +362,7 @@ var _ = Describe("Comprehensive Audit Trail Integration Tests", Label("audit", "
 			GinkgoWriter.Println("✅ Step 2: execution.workflow.started audit event emitted")
 
 			By("Step 3: Complete PipelineRun and verify workflow.completed")
-			prName := workflowexecution.PipelineRunName(wfe.Spec.TargetResource)
+			prName := weexecutor.ExecutionResourceName(wfe.Spec.TargetResource)
 			var pr tektonv1.PipelineRun
 			Eventually(func() error {
 				return k8sClient.Get(ctx, client.ObjectKey{Name: prName, Namespace: WorkflowExecutionNS}, &pr)

--- a/test/integration/workflowexecution/conditions_integration_test.go
+++ b/test/integration/workflowexecution/conditions_integration_test.go
@@ -29,8 +29,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	workflowexecutionv1alpha1 "github.com/jordigilh/kubernaut/api/workflowexecution/v1alpha1"
-	workflowexecution "github.com/jordigilh/kubernaut/internal/controller/workflowexecution"
 	weconditions "github.com/jordigilh/kubernaut/pkg/workflowexecution"
+	weexecutor "github.com/jordigilh/kubernaut/pkg/workflowexecution/executor"
 )
 
 // ========================================
@@ -92,7 +92,7 @@ var _ = Describe("Conditions Integration", Label("integration", "conditions"), f
 			// Verify PipelineRun was actually created
 			var pr tektonv1.PipelineRun
 			Eventually(func() error {
-				prName := workflowexecution.PipelineRunName(wfe.Spec.TargetResource)
+				prName := weexecutor.ExecutionResourceName(wfe.Spec.TargetResource)
 				return k8sClient.Get(ctx, client.ObjectKey{
 					Name:      prName,
 					Namespace: WorkflowExecutionNS,
@@ -147,7 +147,7 @@ var _ = Describe("Conditions Integration", Label("integration", "conditions"), f
 
 			// Get the created PipelineRun
 			var pr tektonv1.PipelineRun
-			prName := workflowexecution.PipelineRunName(wfe.Spec.TargetResource)
+			prName := weexecutor.ExecutionResourceName(wfe.Spec.TargetResource)
 			Eventually(func() error {
 				return k8sClient.Get(ctx, client.ObjectKey{
 					Name:      prName,
@@ -211,7 +211,7 @@ var _ = Describe("Conditions Integration", Label("integration", "conditions"), f
 
 			// Get PipelineRun and mark as succeeded
 			var pr tektonv1.PipelineRun
-			prName := workflowexecution.PipelineRunName(wfe.Spec.TargetResource)
+			prName := weexecutor.ExecutionResourceName(wfe.Spec.TargetResource)
 			Eventually(func() error {
 				return k8sClient.Get(ctx, client.ObjectKey{
 					Name:      prName,
@@ -360,7 +360,7 @@ var _ = Describe("Conditions Integration", Label("integration", "conditions"), f
 
 			// 3. Complete the PipelineRun
 			var pr tektonv1.PipelineRun
-			prName := workflowexecution.PipelineRunName(wfe.Spec.TargetResource)
+			prName := weexecutor.ExecutionResourceName(wfe.Spec.TargetResource)
 			Eventually(func() error {
 				return k8sClient.Get(ctx, client.ObjectKey{
 					Name:      prName,

--- a/test/integration/workflowexecution/conflict_test.go
+++ b/test/integration/workflowexecution/conflict_test.go
@@ -26,7 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	workflowexecutionv1alpha1 "github.com/jordigilh/kubernaut/api/workflowexecution/v1alpha1"
-	workflowexecution "github.com/jordigilh/kubernaut/internal/controller/workflowexecution"
+	weexecutor "github.com/jordigilh/kubernaut/pkg/workflowexecution/executor"
 )
 
 // ========================================
@@ -71,7 +71,6 @@ var _ = Describe("WorkflowExecution HandleAlreadyExists - Race Conditions", func
 				return err
 			}, 15*time.Second, 500*time.Millisecond).Should(Succeed())
 
-			Expect(initialPR).ToNot(BeNil())
 			initialPRName := initialPR.Name
 
 			By("Simulating concurrent reconcile attempts (race condition)")
@@ -89,10 +88,8 @@ var _ = Describe("WorkflowExecution HandleAlreadyExists - Race Conditions", func
 
 					// Each goroutine tries to create a PipelineRun with the same deterministic name
 					// This simulates concurrent reconcile loops attempting creation
-					pr := reconciler.BuildPipelineRun(wfe)
-
-					// Attempt creation (should fail with AlreadyExists for all but one)
-					err := k8sClient.Create(ctx, pr)
+					tektonExec := weexecutor.NewTektonExecutor(k8sClient)
+					_, err := tektonExec.Create(ctx, wfe, WorkflowExecutionNS, weexecutor.CreateOptions{})
 					errors[index] = err
 				}(i)
 			}
@@ -136,7 +133,6 @@ var _ = Describe("WorkflowExecution HandleAlreadyExists - Race Conditions", func
 
 			finalWFE, err := getWFE(wfe.Name, wfe.Namespace)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(finalWFE.Status.ExecutionRef).ToNot(BeNil())
 			Expect(finalWFE.Status.ExecutionRef.Name).To(Equal(initialPRName))
 
 			GinkgoWriter.Printf("✅ BR-WE-002: Concurrent reconcile handled gracefully - only 1 PipelineRun created\n")
@@ -152,14 +148,10 @@ var _ = Describe("WorkflowExecution HandleAlreadyExists - Race Conditions", func
 
 			By("Manually creating PipelineRun BEFORE WFE reconciliation")
 			// This simulates external creation (operator, CI/CD, or race with another controller)
-			pr := reconciler.BuildPipelineRun(wfe)
-
-			// Add labels to identify this as "our" PipelineRun
-			pr.Labels["kubernaut.ai/workflow-execution"] = wfe.Name
-			pr.Labels["kubernaut.ai/source-namespace"] = wfe.Namespace
-
-			Expect(k8sClient.Create(ctx, pr)).To(Succeed())
-			externalPRName := pr.Name
+			tektonExec := weexecutor.NewTektonExecutor(k8sClient)
+			createRes, err := tektonExec.Create(ctx, wfe, WorkflowExecutionNS, weexecutor.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			externalPRName := createRes.ResourceName
 
 			By("Now creating the WorkflowExecution (after PipelineRun exists)")
 			Expect(k8sClient.Create(ctx, wfe)).To(Succeed())
@@ -175,14 +167,11 @@ var _ = Describe("WorkflowExecution HandleAlreadyExists - Race Conditions", func
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verifying WFE references the externally-created PipelineRun")
-			Expect(finalWFE.Status.ExecutionRef).ToNot(BeNil())
 			Expect(finalWFE.Status.ExecutionRef.Name).To(Equal(externalPRName),
 				"WFE should reference the pre-existing PipelineRun")
 
 			By("Verifying ExecutionCreated condition is set")
-			Expect(finalWFE.Status.Conditions).ToNot(BeEmpty())
 			createdCondition := findCondition(finalWFE.Status.Conditions, "ExecutionCreated")
-			Expect(createdCondition).ToNot(BeNil())
 			Expect(createdCondition.Status).To(Equal(metav1.ConditionTrue))
 			Expect(createdCondition.Reason).To(Equal("ExecutionCreated"))
 
@@ -206,7 +195,6 @@ var _ = Describe("WorkflowExecution HandleAlreadyExists - Race Conditions", func
 				return err
 			}, 15*time.Second, 500*time.Millisecond).Should(Succeed())
 
-			Expect(pr1).ToNot(BeNil())
 			pr1Name := pr1.Name
 
 			By("Creating second WorkflowExecution for SAME target resource")
@@ -224,7 +212,6 @@ var _ = Describe("WorkflowExecution HandleAlreadyExists - Race Conditions", func
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Verifying failure details indicate race condition")
-			Expect(finalWFE2.Status.FailureDetails).ToNot(BeNil())
 			Expect(finalWFE2.Status.FailureDetails.Reason).To(Equal("Unknown"), // V1.0: Uses "Unknown" for execution race conditions
 				"Failure reason should indicate execution-time issue")
 			Expect(finalWFE2.Status.FailureDetails.Message).To(ContainSubstring("Race condition"),
@@ -253,12 +240,10 @@ var _ = Describe("WorkflowExecution HandleAlreadyExists - Race Conditions", func
 			targetResource := "test-namespace/deployment/deterministic-test"
 
 			wfe1 := createUniqueWFE("deterministic-wfe1", targetResource)
-			pr1 := reconciler.BuildPipelineRun(wfe1)
-			pr1Name := pr1.Name
+			pr1Name := weexecutor.ExecutionResourceName(wfe1.Spec.TargetResource)
 
 			wfe2 := createUniqueWFE("deterministic-wfe2", targetResource)
-			pr2 := reconciler.BuildPipelineRun(wfe2)
-			pr2Name := pr2.Name
+			pr2Name := weexecutor.ExecutionResourceName(wfe2.Spec.TargetResource)
 
 			By("Verifying both WFEs generate identical PipelineRun names")
 			Expect(pr1Name).To(Equal(pr2Name),
@@ -268,10 +253,10 @@ var _ = Describe("WorkflowExecution HandleAlreadyExists - Race Conditions", func
 			Expect(pr1Name).To(HavePrefix("wfe-"),
 				"PipelineRun name should follow wfe-* pattern (WorkflowExecution prefix)")
 
-			By("Verifying name is deterministic via PipelineRunName()")
-			expectedName := workflowexecution.PipelineRunName(targetResource)
+			By("Verifying name is deterministic via ExecutionResourceName()")
+			expectedName := weexecutor.ExecutionResourceName(targetResource)
 			Expect(pr1Name).To(Equal(expectedName),
-				"BuildPipelineRun should use PipelineRunName() for deterministic naming")
+				"ExecutionResourceName should match for same target resource")
 
 			GinkgoWriter.Printf("✅ BR-WE-002: PipelineRun name determinism validated - %s\n", pr1Name)
 		})

--- a/test/integration/workflowexecution/reconciler_test.go
+++ b/test/integration/workflowexecution/reconciler_test.go
@@ -261,18 +261,18 @@ var _ = Describe("WorkflowExecution Controller Reconciliation", func() {
 			Expect(pr.Spec.TaskRunTemplate.ServiceAccountName).To(BeEmpty())
 		})
 
-		// DD-WE-005 v2 / Issue #501: SA at spec top level.
-		It("should use Spec.ServiceAccountName on PipelineRun when set", func() {
-			By("Creating a WorkflowExecution with custom ServiceAccount in spec")
+		// DD-WE-005 v2 / Issue #501: SA resolved to status (Issue #650).
+		It("should use Status.ServiceAccountName on PipelineRun when set", func() {
+			By("Creating a WorkflowExecution with custom ServiceAccount in status")
 			wfe = createUniqueWFE("sa-custom", "default/deployment/sa-custom-test")
-			wfe.Spec.ServiceAccountName = "custom-workflow-sa"
+			wfe.Status.ServiceAccountName = "custom-workflow-sa"
 			Expect(k8sClient.Create(ctx, wfe)).To(Succeed())
 
 			By("Waiting for PipelineRun creation")
 			pr, err := waitForPipelineRunCreation(wfe.Name, wfe.Namespace, 10*time.Second)
 			Expect(err).ToNot(HaveOccurred())
 
-			By("Verifying WFE spec service account is propagated to TaskRunTemplate")
+			By("Verifying WFE status service account is propagated to TaskRunTemplate")
 			Expect(pr.Spec.TaskRunTemplate.ServiceAccountName).To(Equal("custom-workflow-sa"))
 		})
 	})

--- a/test/integration/workflowexecution/reconciler_test.go
+++ b/test/integration/workflowexecution/reconciler_test.go
@@ -261,11 +261,14 @@ var _ = Describe("WorkflowExecution Controller Reconciliation", func() {
 			Expect(pr.Spec.TaskRunTemplate.ServiceAccountName).To(BeEmpty())
 		})
 
-		// DD-WE-005 v2 / Issue #501: SA resolved to status (Issue #650).
+		// DD-WE-005 v2 / Issue #501: SA resolved from DS via querier (Issue #650).
 		It("should use Status.ServiceAccountName on PipelineRun when set", func() {
-			By("Creating a WorkflowExecution with custom ServiceAccount in status")
+			By("Configuring mock querier to return custom SA from Data Storage")
+			testWorkflowQuerier.ServiceAccountName = "custom-workflow-sa"
+			DeferCleanup(func() { testWorkflowQuerier.ServiceAccountName = "" })
+
+			By("Creating a WorkflowExecution")
 			wfe = createUniqueWFE("sa-custom", "default/deployment/sa-custom-test")
-			wfe.Status.ServiceAccountName = "custom-workflow-sa"
 			Expect(k8sClient.Create(ctx, wfe)).To(Succeed())
 
 			By("Waiting for PipelineRun creation")

--- a/test/integration/workflowexecution/suite_test.go
+++ b/test/integration/workflowexecution/suite_test.go
@@ -52,6 +52,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/datastorage/models"
 	dsvalidation "github.com/jordigilh/kubernaut/pkg/datastorage/validation"
 	weaudit "github.com/jordigilh/kubernaut/pkg/workflowexecution/audit"
+	weclient "github.com/jordigilh/kubernaut/pkg/workflowexecution/client"
 	weexecutor "github.com/jordigilh/kubernaut/pkg/workflowexecution/executor"
 	wemetrics "github.com/jordigilh/kubernaut/pkg/workflowexecution/metrics"
 	westatus "github.com/jordigilh/kubernaut/pkg/workflowexecution/status"
@@ -66,10 +67,11 @@ import (
 // When Deps is nil, GetWorkflowDependencies returns nil (no dependencies).
 // Engine defaults to "tekton" via testWorkflowQuerier initialization; createUniqueJobWFE sets "job".
 type configurableWorkflowQuerier struct {
-	Deps         *models.WorkflowDependencies
-	Engine       string
-	Bundle       string
-	BundleDigest string
+	Deps               *models.WorkflowDependencies
+	Engine             string
+	Bundle             string
+	BundleDigest       string
+	ServiceAccountName string
 }
 
 func (q *configurableWorkflowQuerier) GetWorkflowDependencies(_ context.Context, _ string) (*models.WorkflowDependencies, error) {
@@ -86,6 +88,16 @@ func (q *configurableWorkflowQuerier) GetWorkflowExecutionEngine(_ context.Conte
 
 func (q *configurableWorkflowQuerier) GetWorkflowExecutionBundle(_ context.Context, _ string) (string, string, error) {
 	return q.Bundle, q.BundleDigest, nil
+}
+
+func (q *configurableWorkflowQuerier) ResolveWorkflowCatalogMetadata(_ context.Context, _ string) (*weclient.WorkflowCatalogMetadata, error) {
+	return &weclient.WorkflowCatalogMetadata{
+		ExecutionEngine:       q.Engine,
+		ExecutionBundle:       q.Bundle,
+		ExecutionBundleDigest: q.BundleDigest,
+		ServiceAccountName:    q.ServiceAccountName,
+		Dependencies:          q.Deps,
+	}, nil
 }
 
 // WorkflowExecution Integration Test Suite

--- a/test/unit/aianalysis/response_processor_sa_test.go
+++ b/test/unit/aianalysis/response_processor_sa_test.go
@@ -24,18 +24,19 @@ import (
 )
 
 // ========================================
-// RESPONSE PROCESSOR SA MAPPING TESTS (#481)
+// RESPONSE PROCESSOR SA MAPPING TESTS (#481 / #650)
 // ========================================
 // Authority: DD-WE-005 v2.0 (Per-Workflow ServiceAccount Reference)
-// Validates GetStringFromMap correctly extracts service_account_name
-// from KA response maps (same pattern used at 3 mapping sites).
+// Issue #650: service_account_name is no longer extracted into
+// SelectedWorkflow (field removed). GetStringFromMap utility still works,
+// but its result is not consumed for SA.
 // ========================================
 
-var _ = Describe("Response Processor SA Mapping [DD-WE-005] (#481)", func() {
+var _ = Describe("Response Processor SA Mapping [DD-WE-005] (#481/#650)", func() {
 
-	Context("GetStringFromMap for service_account_name", func() {
+	Context("GetStringFromMap utility (still functional)", func() {
 
-		It("UT-AA-481-001: should extract service_account_name from selected_workflow map", func() {
+		It("UT-AA-481-001: GetStringFromMap extracts string values from map", func() {
 			swMap := map[string]interface{}{
 				"workflow_id":          "wf-uuid-123",
 				"execution_bundle":     "quay.io/test:v1@sha256:abc",
@@ -46,7 +47,7 @@ var _ = Describe("Response Processor SA Mapping [DD-WE-005] (#481)", func() {
 			Expect(result).To(Equal("my-workflow-sa"))
 		})
 
-		It("UT-AA-481-002: should return empty string when service_account_name is absent", func() {
+		It("UT-AA-481-002: GetStringFromMap returns empty for absent keys", func() {
 			swMap := map[string]interface{}{
 				"workflow_id":      "wf-uuid-456",
 				"execution_bundle": "quay.io/test:v1@sha256:def",

--- a/test/unit/effectivenessmonitor/ds_querier_test.go
+++ b/test/unit/effectivenessmonitor/ds_querier_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -28,23 +29,49 @@ import (
 	emclient "github.com/jordigilh/kubernaut/pkg/effectivenessmonitor/client"
 )
 
-// dsEnvelope mirrors the AuditEventsQueryResponse returned by DS
-// (see api/openapi/data-storage-v1.yaml, Issue #575).
-type dsEnvelope struct {
-	Data       []map[string]interface{} `json:"data"`
-	Pagination map[string]interface{}   `json:"pagination,omitempty"`
+// testAuditEvent builds a schema-compliant AuditEvent JSON map with all 8 required
+// fields populated. Callers supply the event_type, correlation_id, and an eventData
+// map that is merged into the required event_data structure.
+//
+// Required by ogen's AuditEvent.Decode() bitmask validation (F9).
+func testAuditEvent(eventType, correlationID string, eventData map[string]interface{}) map[string]interface{} {
+	ed := map[string]interface{}{
+		"event_type": eventType,
+	}
+	for k, v := range eventData {
+		ed[k] = v
+	}
+
+	return map[string]interface{}{
+		"version":         "1.0",
+		"event_type":      eventType,
+		"event_timestamp": "2026-01-01T00:00:00Z",
+		"event_category":  categoryForEventType(eventType),
+		"event_action":    "test_action",
+		"event_outcome":   "success",
+		"correlation_id":  correlationID,
+		"event_data":      ed,
+	}
 }
 
-func serveDSEnvelope(w http.ResponseWriter, events []map[string]interface{}) {
+// categoryForEventType derives event_category from the event_type prefix.
+func categoryForEventType(eventType string) string {
+	switch {
+	case len(eventType) > 12 && eventType[:12] == "remediation.":
+		return "orchestration"
+	case len(eventType) > 18 && eventType[:18] == "workflowexecution.":
+		return "workflowexecution"
+	default:
+		return "unknown"
+	}
+}
+
+// serveOgenCompliantResponse writes a schema-compliant AuditEventsQueryResponse
+// JSON envelope that satisfies ogen's strict decoder.
+func serveOgenCompliantResponse(w http.ResponseWriter, events []map[string]interface{}) {
 	w.Header().Set("Content-Type", "application/json")
-	resp := dsEnvelope{
-		Data: events,
-		Pagination: map[string]interface{}{
-			"limit":    100,
-			"offset":   0,
-			"total":    len(events),
-			"has_more": false,
-		},
+	resp := map[string]interface{}{
+		"data": events,
 	}
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
@@ -52,10 +79,10 @@ func serveDSEnvelope(w http.ResponseWriter, events []map[string]interface{}) {
 }
 
 // ========================================
-// DataStorageQuerier Tests (DD-EM-002, Issue #575)
+// DataStorageQuerier Tests (DD-EM-002, DD-API-001, Issue #236)
 //
-// All mock servers return the production-matching envelope:
-//   {"data": [...], "pagination": {...}}
+// All mock servers return ogen-compliant AuditEvent JSON with the 8
+// required fields per F9 and event_type discriminator inside event_data per F4.
 // ========================================
 var _ = Describe("DataStorageQuerier (DD-EM-002)", func() {
 
@@ -81,18 +108,17 @@ var _ = Describe("DataStorageQuerier (DD-EM-002)", func() {
 			expectedHash := "sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				Expect(r.URL.Query().Get("event_type")).To(Equal("remediation.workflow_created"))
-				serveDSEnvelope(w, []map[string]interface{}{
-					{
-						"event_type":     "remediation.workflow_created",
-						"correlation_id": "test-correlation-001",
-						"event_data": map[string]interface{}{
-							"pre_remediation_spec_hash": expectedHash,
-						},
-					},
+				serveOgenCompliantResponse(w, []map[string]interface{}{
+					testAuditEvent("remediation.workflow_created", "test-correlation-001", map[string]interface{}{
+						"rr_name":                   "test-rr",
+						"namespace":                 "test-ns",
+						"pre_remediation_spec_hash": expectedHash,
+					}),
 				})
 			}))
 
-			querier := emclient.NewDataStorageHTTPQuerier(server.URL)
+			querier, err := emclient.NewOgenDataStorageQuerier(server.URL, 10*time.Second)
+			Expect(err).ToNot(HaveOccurred())
 			hash, err := querier.QueryPreRemediationHash(ctx, "test-correlation-001")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hash).To(Equal(expectedHash))
@@ -100,10 +126,11 @@ var _ = Describe("DataStorageQuerier (DD-EM-002)", func() {
 
 		It("UT-EM-DSQ-002: should return empty string when no events found", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				serveDSEnvelope(w, []map[string]interface{}{})
+				serveOgenCompliantResponse(w, []map[string]interface{}{})
 			}))
 
-			querier := emclient.NewDataStorageHTTPQuerier(server.URL)
+			querier, err := emclient.NewOgenDataStorageQuerier(server.URL, 10*time.Second)
+			Expect(err).ToNot(HaveOccurred())
 			hash, err := querier.QueryPreRemediationHash(ctx, "no-events-correlation")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hash).To(BeEmpty())
@@ -111,16 +138,16 @@ var _ = Describe("DataStorageQuerier (DD-EM-002)", func() {
 
 		It("UT-EM-DSQ-003: should return empty string when event has no hash field", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				serveDSEnvelope(w, []map[string]interface{}{
-					{
-						"event_type":     "remediation.workflow_created",
-						"correlation_id": "test-correlation-003",
-						"event_data":     map[string]interface{}{},
-					},
+				serveOgenCompliantResponse(w, []map[string]interface{}{
+					testAuditEvent("remediation.workflow_created", "test-correlation-003", map[string]interface{}{
+						"rr_name":   "test-rr",
+						"namespace": "test-ns",
+					}),
 				})
 			}))
 
-			querier := emclient.NewDataStorageHTTPQuerier(server.URL)
+			querier, err := emclient.NewOgenDataStorageQuerier(server.URL, 10*time.Second)
+			Expect(err).ToNot(HaveOccurred())
 			hash, err := querier.QueryPreRemediationHash(ctx, "test-correlation-003")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(hash).To(BeEmpty())
@@ -131,14 +158,16 @@ var _ = Describe("DataStorageQuerier (DD-EM-002)", func() {
 				http.Error(w, "internal server error", http.StatusInternalServerError)
 			}))
 
-			querier := emclient.NewDataStorageHTTPQuerier(server.URL)
-			_, err := querier.QueryPreRemediationHash(ctx, "test-correlation-004")
+			querier, err := emclient.NewOgenDataStorageQuerier(server.URL, 10*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = querier.QueryPreRemediationHash(ctx, "test-correlation-004")
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("UT-EM-DSQ-005: should return error when DS is unreachable", func() {
-			querier := emclient.NewDataStorageHTTPQuerier("http://localhost:1")
-			_, err := querier.QueryPreRemediationHash(ctx, "test-correlation-005")
+			querier, err := emclient.NewOgenDataStorageQuerier("http://localhost:1", 10*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = querier.QueryPreRemediationHash(ctx, "test-correlation-005")
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -149,15 +178,20 @@ var _ = Describe("DataStorageQuerier (DD-EM-002)", func() {
 		It("UT-EM-DSQ-006: should return true when execution.started event exists", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				Expect(r.URL.Query().Get("event_type")).To(Equal("workflowexecution.execution.started"))
-				serveDSEnvelope(w, []map[string]interface{}{
-					{
-						"event_type":     "workflowexecution.execution.started",
-						"correlation_id": "corr-started",
-					},
+				serveOgenCompliantResponse(w, []map[string]interface{}{
+					testAuditEvent("workflowexecution.execution.started", "corr-started", map[string]interface{}{
+						"workflow_id":      "test-wf",
+						"workflow_version": "1.0.0",
+						"target_resource":  "test-ns/Deployment/test",
+						"phase":            "Running",
+						"container_image":  "test:latest",
+						"execution_name":   "test-exec",
+					}),
 				})
 			}))
 
-			querier := emclient.NewDataStorageHTTPQuerier(server.URL)
+			querier, err := emclient.NewOgenDataStorageQuerier(server.URL, 10*time.Second)
+			Expect(err).ToNot(HaveOccurred())
 			started, err := querier.HasWorkflowStarted(ctx, "corr-started")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(started).To(BeTrue())
@@ -165,10 +199,11 @@ var _ = Describe("DataStorageQuerier (DD-EM-002)", func() {
 
 		It("UT-EM-DSQ-007: should return false when no execution.started event exists", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				serveDSEnvelope(w, []map[string]interface{}{})
+				serveOgenCompliantResponse(w, []map[string]interface{}{})
 			}))
 
-			querier := emclient.NewDataStorageHTTPQuerier(server.URL)
+			querier, err := emclient.NewOgenDataStorageQuerier(server.URL, 10*time.Second)
+			Expect(err).ToNot(HaveOccurred())
 			started, err := querier.HasWorkflowStarted(ctx, "corr-not-started")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(started).To(BeFalse())
@@ -179,14 +214,16 @@ var _ = Describe("DataStorageQuerier (DD-EM-002)", func() {
 				http.Error(w, "internal server error", http.StatusInternalServerError)
 			}))
 
-			querier := emclient.NewDataStorageHTTPQuerier(server.URL)
-			_, err := querier.HasWorkflowStarted(ctx, "corr-error")
+			querier, err := emclient.NewOgenDataStorageQuerier(server.URL, 10*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = querier.HasWorkflowStarted(ctx, "corr-error")
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("UT-EM-DSQ-009: should return error when DS is unreachable", func() {
-			querier := emclient.NewDataStorageHTTPQuerier("http://localhost:1")
-			_, err := querier.HasWorkflowStarted(ctx, "corr-unreachable")
+			querier, err := emclient.NewOgenDataStorageQuerier("http://localhost:1", 10*time.Second)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = querier.HasWorkflowStarted(ctx, "corr-unreachable")
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -196,15 +233,20 @@ var _ = Describe("DataStorageQuerier (DD-EM-002)", func() {
 		It("UT-EM-573-009: should return true when workflow.completed event exists", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				Expect(r.URL.Query().Get("event_type")).To(Equal("workflowexecution.workflow.completed"))
-				serveDSEnvelope(w, []map[string]interface{}{
-					{
-						"event_type":     "workflowexecution.workflow.completed",
-						"correlation_id": "rr-completed",
-					},
+				serveOgenCompliantResponse(w, []map[string]interface{}{
+					testAuditEvent("workflowexecution.workflow.completed", "rr-completed", map[string]interface{}{
+						"workflow_id":      "test-wf",
+						"workflow_version": "1.0.0",
+						"target_resource":  "test-ns/Deployment/test",
+						"phase":            "Completed",
+						"container_image":  "test:latest",
+						"execution_name":   "test-exec",
+					}),
 				})
 			}))
 
-			querier := emclient.NewDataStorageHTTPQuerier(server.URL)
+			querier, err := emclient.NewOgenDataStorageQuerier(server.URL, 10*time.Second)
+			Expect(err).ToNot(HaveOccurred())
 			completed, err := querier.HasWorkflowCompleted(ctx, "rr-completed")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(completed).To(BeTrue(),
@@ -213,10 +255,11 @@ var _ = Describe("DataStorageQuerier (DD-EM-002)", func() {
 
 		It("UT-EM-573-009: should return false when only started event exists", func() {
 			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-				serveDSEnvelope(w, []map[string]interface{}{})
+				serveOgenCompliantResponse(w, []map[string]interface{}{})
 			}))
 
-			querier := emclient.NewDataStorageHTTPQuerier(server.URL)
+			querier, err := emclient.NewOgenDataStorageQuerier(server.URL, 10*time.Second)
+			Expect(err).ToNot(HaveOccurred())
 			completed, err := querier.HasWorkflowCompleted(ctx, "rr-only-started")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(completed).To(BeFalse(),

--- a/test/unit/notification/routing_config_test.go
+++ b/test/unit/notification/routing_config_test.go
@@ -42,8 +42,6 @@ receivers:
 `
 				config, err := routing.ParseConfig([]byte(configYAML))
 				Expect(err).ToNot(HaveOccurred())
-				Expect(config).ToNot(BeNil())
-				Expect(config.Route).ToNot(BeNil())
 				Expect(config.Route.Receiver).To(Equal("default-receiver"))
 				Expect(config.Receivers).To(HaveLen(1))
 				Expect(config.Receivers[0].Name).To(Equal("default-receiver"))
@@ -113,7 +111,7 @@ receivers:
 				config, err := routing.ParseConfig([]byte(configYAML))
 				Expect(err).ToNot(HaveOccurred())
 				receiver := config.GetReceiver("multi-channel")
-				Expect(receiver).ToNot(BeNil())
+				Expect(receiver.Name).To(Equal("multi-channel"))
 				Expect(receiver.SlackConfigs).To(HaveLen(1))
 				Expect(receiver.EmailConfigs).To(HaveLen(1))
 				Expect(receiver.WebhookConfigs).To(HaveLen(1))
@@ -317,7 +315,6 @@ receivers:
 
 		It("should resolve existing receiver by name", func() {
 			receiver := config.GetReceiver("default")
-			Expect(receiver).ToNot(BeNil())
 			Expect(receiver.Name).To(Equal("default"))
 		})
 
@@ -416,8 +413,6 @@ receivers:
 
 		It("should provide sensible defaults when loading from empty ConfigMap", func() {
 			config := routing.DefaultConfig()
-			Expect(config).ToNot(BeNil())
-			Expect(config.Route).ToNot(BeNil())
 			Expect(config.Route.Receiver).To(Equal("console-fallback"))
 			Expect(config.Receivers).To(HaveLen(1))
 			Expect(config.Receivers[0].Name).To(Equal("console-fallback"))
@@ -580,6 +575,304 @@ receivers:
 	// Purpose: Verify investigation-outcome based routing for HolmesGPT-API results
 	// Cross-Team: KA→NOT (2025-12-07)
 	// =============================================================================
+
+	// =============================================================================
+	// BR-NOT-068: Multi-Channel Fanout (Route Continue Flag) — Issue #597
+	// =============================================================================
+
+	Describe("Route Fanout (BR-NOT-068, #597)", func() {
+
+		Context("FindReceivers with continue flag", func() {
+
+			It("[UT-NOT-597-001] should collect all matching receivers when continue is true", func() {
+				configYAML := `
+route:
+  receiver: default
+  routes:
+    - receiver: fanout-A
+      match:
+        team: sre
+      continue: true
+    - receiver: fanout-B
+      match:
+        team: sre
+      continue: true
+    - receiver: fanout-C
+      match:
+        team: sre
+receivers:
+  - name: default
+    consoleConfigs:
+      - enabled: true
+  - name: fanout-A
+    consoleConfigs:
+      - enabled: true
+  - name: fanout-B
+    fileConfigs:
+      - enabled: true
+  - name: fanout-C
+    logConfigs:
+      - enabled: true
+`
+				config, err := routing.ParseConfig([]byte(configYAML))
+				Expect(err).ToNot(HaveOccurred())
+
+				receivers := config.Route.FindReceivers(map[string]string{"team": "sre"})
+				Expect(receivers).To(HaveLen(3))
+				Expect(receivers).To(Equal([]string{"fanout-A", "fanout-B", "fanout-C"}))
+			})
+
+			It("[UT-NOT-597-002] should stop at first match when continue is false (regression)", func() {
+				configYAML := `
+route:
+  receiver: default
+  routes:
+    - receiver: first-match
+      match:
+        team: sre
+    - receiver: second-match
+      match:
+        team: sre
+    - receiver: third-match
+      match:
+        team: sre
+receivers:
+  - name: default
+    consoleConfigs:
+      - enabled: true
+  - name: first-match
+    consoleConfigs:
+      - enabled: true
+  - name: second-match
+    fileConfigs:
+      - enabled: true
+  - name: third-match
+    logConfigs:
+      - enabled: true
+`
+				config, err := routing.ParseConfig([]byte(configYAML))
+				Expect(err).ToNot(HaveOccurred())
+
+				receivers := config.Route.FindReceivers(map[string]string{"team": "sre"})
+				Expect(receivers).To(HaveLen(1))
+				Expect(receivers).To(Equal([]string{"first-match"}))
+			})
+
+			It("[UT-NOT-597-003] should stop at first continue:false after collecting continue:true", func() {
+				configYAML := `
+route:
+  receiver: default
+  routes:
+    - receiver: collected-A
+      match:
+        team: sre
+      continue: true
+    - receiver: collected-B
+      match:
+        team: sre
+    - receiver: skipped-C
+      match:
+        team: sre
+      continue: true
+receivers:
+  - name: default
+    consoleConfigs:
+      - enabled: true
+  - name: collected-A
+    consoleConfigs:
+      - enabled: true
+  - name: collected-B
+    fileConfigs:
+      - enabled: true
+  - name: skipped-C
+    logConfigs:
+      - enabled: true
+`
+				config, err := routing.ParseConfig([]byte(configYAML))
+				Expect(err).ToNot(HaveOccurred())
+
+				receivers := config.Route.FindReceivers(map[string]string{"team": "sre"})
+				Expect(receivers).To(HaveLen(2))
+				Expect(receivers).To(Equal([]string{"collected-A", "collected-B"}))
+			})
+
+			It("[UT-NOT-597-004] should handle nested routes with continue at different levels", func() {
+				// Alertmanager semantic: children take over from parent receiver
+				configYAML := `
+route:
+  receiver: root
+  routes:
+    - receiver: parent-A
+      match:
+        team: sre
+      continue: true
+      routes:
+        - receiver: child-A1
+          match:
+            severity: critical
+    - receiver: parent-B
+      match:
+        team: sre
+receivers:
+  - name: root
+    consoleConfigs:
+      - enabled: true
+  - name: parent-A
+    consoleConfigs:
+      - enabled: true
+  - name: child-A1
+    fileConfigs:
+      - enabled: true
+  - name: parent-B
+    logConfigs:
+      - enabled: true
+`
+				config, err := routing.ParseConfig([]byte(configYAML))
+				Expect(err).ToNot(HaveOccurred())
+
+				// team=sre, severity=critical: child-A1 matches under parent-A (continue), parent-B matches
+				receivers := config.Route.FindReceivers(map[string]string{
+					"team":     "sre",
+					"severity": "critical",
+				})
+				Expect(receivers).To(HaveLen(2))
+				Expect(receivers).To(Equal([]string{"child-A1", "parent-B"}))
+			})
+
+			It("[UT-NOT-597-005] should deduplicate when same receiver appears in multiple routes", func() {
+				configYAML := `
+route:
+  receiver: default
+  routes:
+    - receiver: shared-receiver
+      match:
+        team: sre
+      continue: true
+    - receiver: shared-receiver
+      match:
+        team: sre
+receivers:
+  - name: default
+    consoleConfigs:
+      - enabled: true
+  - name: shared-receiver
+    consoleConfigs:
+      - enabled: true
+`
+				config, err := routing.ParseConfig([]byte(configYAML))
+				Expect(err).ToNot(HaveOccurred())
+
+				receivers := config.Route.FindReceivers(map[string]string{"team": "sre"})
+				Expect(receivers).To(HaveLen(1))
+				Expect(receivers).To(Equal([]string{"shared-receiver"}))
+			})
+
+			It("[UT-NOT-597-006] should fall back to parent receiver when no children match", func() {
+				configYAML := `
+route:
+  receiver: parent-fallback
+  routes:
+    - receiver: child-only
+      match:
+        team: does-not-exist
+receivers:
+  - name: parent-fallback
+    consoleConfigs:
+      - enabled: true
+  - name: child-only
+    fileConfigs:
+      - enabled: true
+`
+				config, err := routing.ParseConfig([]byte(configYAML))
+				Expect(err).ToNot(HaveOccurred())
+
+				receivers := config.Route.FindReceivers(map[string]string{"team": "sre"})
+				Expect(receivers).To(HaveLen(1))
+				Expect(receivers).To(Equal([]string{"parent-fallback"}))
+			})
+		})
+
+		Context("FindReceiver backward compatibility", func() {
+
+			It("[UT-NOT-597-007] should return first matched receiver (backward compat wrapper)", func() {
+				configYAML := `
+route:
+  receiver: default
+  routes:
+    - receiver: fanout-A
+      match:
+        team: sre
+      continue: true
+    - receiver: fanout-B
+      match:
+        team: sre
+receivers:
+  - name: default
+    consoleConfigs:
+      - enabled: true
+  - name: fanout-A
+    consoleConfigs:
+      - enabled: true
+  - name: fanout-B
+    fileConfigs:
+      - enabled: true
+`
+				config, err := routing.ParseConfig([]byte(configYAML))
+				Expect(err).ToNot(HaveOccurred())
+
+				// FindReceiver (singular) should still return first match only
+				receiver := config.Route.FindReceiver(map[string]string{"team": "sre"})
+				Expect(receiver).To(Equal("fanout-A"))
+			})
+		})
+
+		Context("Multi-channel delivery plan from fanout", func() {
+
+			It("[UT-NOT-597-009] should produce a complete multi-channel delivery plan from continue:true routing (BR-NOT-068, BR-NOT-069)", func() {
+				configYAML := `
+route:
+  receiver: default
+  routes:
+    - receiver: console-recv
+      match:
+        team: sre
+      continue: true
+    - receiver: file-recv
+      match:
+        team: sre
+receivers:
+  - name: default
+    consoleConfigs:
+      - enabled: true
+  - name: console-recv
+    consoleConfigs:
+      - enabled: true
+  - name: file-recv
+    fileConfigs:
+      - enabled: true
+`
+				config, err := routing.ParseConfig([]byte(configYAML))
+				Expect(err).ToNot(HaveOccurred())
+
+				receiverNames := config.Route.FindReceivers(map[string]string{"team": "sre"})
+				Expect(receiverNames).To(HaveLen(2),
+					"Fanout should resolve 2 receivers for a single notification")
+
+				// Verify that the resolved receivers produce distinct channels,
+				// confirming the business outcome: one notification → multiple channels
+				var allChannels []string
+				for _, name := range receiverNames {
+					recv := config.GetReceiver(name)
+					Expect(recv.Name).To(Equal(name),
+						"Each resolved name should map to a valid receiver in the config")
+					allChannels = append(allChannels, recv.GetChannels()...)
+				}
+
+				Expect(allChannels).To(ConsistOf("console", "file"),
+					"Fanout should produce delivery to console (from console-recv) and file (from file-recv)")
+			})
+		})
+	})
 
 	Describe("Investigation-Outcome Attribute Routing (BR-HAPI-200)", func() {
 

--- a/test/unit/notification/routing_hotreload_test.go
+++ b/test/unit/notification/routing_hotreload_test.go
@@ -344,6 +344,74 @@ receivers:
 })
 
 // =============================================================================
+// BR-NOT-068: Route Fanout Router-Level Tests — Issue #597
+// =============================================================================
+
+var _ = Describe("Route Fanout Router (BR-NOT-068, #597)", func() {
+
+	Context("Router.FindReceivers nil/empty config handling", func() {
+
+		It("[UT-NOT-597-008] should return console fallback receiver when no routes match unloaded config", func() {
+			router := routing.NewRouter(testLogger)
+
+			receivers := router.FindReceivers(map[string]string{"team": "sre"})
+			Expect(receivers).To(HaveLen(1),
+				"Unmatched attributes should resolve to exactly one fallback receiver")
+			Expect(receivers[0].GetChannels()).To(ContainElement("console"),
+				"Fallback receiver should deliver via console channel (BR-NOT-068 safety)")
+		})
+	})
+
+	Context("Router.FindReceivers name-to-receiver resolution", func() {
+
+		It("[UT-NOT-597-010] should resolve receiver names to Receiver objects and aggregate channels", func() {
+			router := routing.NewRouter(testLogger)
+
+			err := router.LoadConfig([]byte(`
+route:
+  receiver: default
+  routes:
+    - receiver: console-recv
+      match:
+        team: sre
+      continue: true
+    - receiver: file-recv
+      match:
+        team: sre
+receivers:
+  - name: default
+    consoleConfigs:
+      - enabled: true
+  - name: console-recv
+    consoleConfigs:
+      - enabled: true
+  - name: file-recv
+    fileConfigs:
+      - enabled: true
+`))
+			Expect(err).NotTo(HaveOccurred())
+
+			receivers := router.FindReceivers(map[string]string{"team": "sre"})
+			Expect(receivers).To(HaveLen(2))
+
+			// Verify resolved Receiver objects have correct names and channels
+			Expect(receivers[0].Name).To(Equal("console-recv"))
+			Expect(receivers[0].GetChannels()).To(ContainElement("console"))
+
+			Expect(receivers[1].Name).To(Equal("file-recv"))
+			Expect(receivers[1].GetChannels()).To(ContainElement("file"))
+
+			// Verify channel aggregation across receivers
+			var allChannels []string
+			for _, recv := range receivers {
+				allChannels = append(allChannels, recv.GetChannels()...)
+			}
+			Expect(allChannels).To(ContainElements("console", "file"))
+		})
+	})
+})
+
+// =============================================================================
 // Integration Test: Controller ConfigMap Watch
 // =============================================================================
 

--- a/test/unit/remediationorchestrator/notification_body_order_test.go
+++ b/test/unit/remediationorchestrator/notification_body_order_test.go
@@ -49,7 +49,7 @@ var _ = Describe("Issue #627: Notification Body Field Reordering", func() {
 		_ = eav1.AddToScheme(scheme)
 	})
 
-	It("UT-RO-627-001: Completion body has Outcome before Signal", func() {
+	It("UT-RO-627-001: Completion body has Status and Outcome before Signal", func() {
 		cl := fake.NewClientBuilder().WithScheme(scheme).Build()
 		nc := creator.NewNotificationCreator(cl, scheme, rometrics.NewMetricsWithRegistry(prometheus.NewRegistry()))
 
@@ -64,10 +64,14 @@ var _ = Describe("Issue #627: Notification Body Field Reordering", func() {
 		nr := &notificationv1.NotificationRequest{}
 		Expect(cl.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "default"}, nr)).To(Succeed())
 
+		statusIdx := strings.Index(nr.Spec.Body, "**Status**:")
 		outcomeIdx := strings.Index(nr.Spec.Body, "**Outcome**:")
 		signalIdx := strings.Index(nr.Spec.Body, "**Signal**:")
-		Expect(outcomeIdx).To(BeNumerically(">=", 0), "Outcome field must be present")
+		Expect(statusIdx).To(BeNumerically(">=", 0), "#628: Status field must be present")
+		Expect(outcomeIdx).To(BeNumerically(">=", 0), "Outcome field must be present (deprecated, retained one release)")
 		Expect(signalIdx).To(BeNumerically(">=", 0), "Signal field must be present")
+		Expect(statusIdx).To(BeNumerically("<", outcomeIdx),
+			"#628: Status must appear before deprecated Outcome")
 		Expect(outcomeIdx).To(BeNumerically("<", signalIdx),
 			"Outcome must appear before Signal for faster operator triage")
 	})

--- a/test/unit/remediationorchestrator/notification_status_test.go
+++ b/test/unit/remediationorchestrator/notification_status_test.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2025 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package remediationorchestrator
+
+import (
+	"context"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	aianalysisv1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
+	eav1 "github.com/jordigilh/kubernaut/api/effectivenessassessment/v1alpha1"
+	notificationv1 "github.com/jordigilh/kubernaut/api/notification/v1alpha1"
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/remediationorchestrator/creator"
+	rometrics "github.com/jordigilh/kubernaut/pkg/remediationorchestrator/metrics"
+	"github.com/jordigilh/kubernaut/test/shared/helpers"
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var _ = Describe("Issue #628: Notification Status Standardization", func() {
+	var (
+		scheme *runtime.Scheme
+	)
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		Expect(remediationv1.AddToScheme(scheme)).To(Succeed())
+		Expect(notificationv1.AddToScheme(scheme)).To(Succeed())
+		Expect(aianalysisv1.AddToScheme(scheme)).To(Succeed())
+		Expect(eav1.AddToScheme(scheme)).To(Succeed())
+	})
+
+	Context("Per-type Status field presence", func() {
+		It("UT-NOT-628-001: Completion body contains **Status**: with mapped outcome value", func() {
+			cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+			nc := creator.NewNotificationCreator(cl, scheme, rometrics.NewMetricsWithRegistry(prometheus.NewRegistry()))
+
+			rr := helpers.NewRemediationRequest("test-rr-628-001", "default")
+			rr.Status.OverallPhase = "Completed"
+			rr.Status.Outcome = "Remediated"
+			ai := helpers.NewCompletedAIAnalysis("test-ai-628-001", "default")
+
+			name, err := nc.CreateCompletionNotification(context.Background(), rr, ai, "tekton", nil)
+			Expect(err).ToNot(HaveOccurred())
+
+			nr := &notificationv1.NotificationRequest{}
+			Expect(cl.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "default"}, nr)).To(Succeed())
+
+			Expect(nr.Spec.Body).To(ContainSubstring("**Status**: Remediated"),
+				"#628: Completion body must include standardized Status field with mapped outcome")
+			Expect(nr.Spec.Body).To(ContainSubstring("**Outcome**:"),
+				"#628: Legacy Outcome field must remain for backward compatibility (one-release deprecation)")
+		})
+
+		It("UT-NOT-628-002: Bulk duplicate body contains **Status**: Duplicate Handled and legacy **Result**:", func() {
+			cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+			nc := creator.NewNotificationCreator(cl, scheme, rometrics.NewMetricsWithRegistry(prometheus.NewRegistry()))
+
+			rr := helpers.NewRemediationRequest("test-rr-628-002", "default")
+			rr.Status.OverallPhase = "Completed"
+			rr.Status.DuplicateCount = 3
+
+			name, err := nc.CreateBulkDuplicateNotification(context.Background(), rr)
+			Expect(err).ToNot(HaveOccurred())
+
+			nr := &notificationv1.NotificationRequest{}
+			Expect(cl.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "default"}, nr)).To(Succeed())
+
+			Expect(nr.Spec.Body).To(ContainSubstring("**Status**: Duplicate Handled"),
+				"#628: Bulk duplicate body must include standardized Status field")
+			Expect(nr.Spec.Body).To(ContainSubstring("**Result**:"),
+				"#628: Legacy Result field must remain for backward compatibility")
+		})
+
+		It("UT-NOT-628-003: Manual review body contains **Status**: Manual Review Required", func() {
+			cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+			nc := creator.NewNotificationCreator(cl, scheme, rometrics.NewMetricsWithRegistry(prometheus.NewRegistry()))
+
+			rr := helpers.NewRemediationRequest("test-rr-628-003", "default")
+			reviewCtx := &creator.ManualReviewContext{
+				Source:  notificationv1.ReviewSourceAIAnalysis,
+				Reason:  "WorkflowResolutionFailed",
+				Message: "No matching workflow found",
+			}
+
+			name, err := nc.CreateManualReviewNotification(context.Background(), rr, reviewCtx)
+			Expect(err).ToNot(HaveOccurred())
+
+			nr := &notificationv1.NotificationRequest{}
+			Expect(cl.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "default"}, nr)).To(Succeed())
+
+			Expect(nr.Spec.Body).To(ContainSubstring("**Status**: Manual Review Required"),
+				"#628: Manual review body must include standardized Status field")
+		})
+
+		It("UT-NOT-628-004: Approval body contains **Status**: Pending Approval", func() {
+			cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+			nc := creator.NewNotificationCreator(cl, scheme, rometrics.NewMetricsWithRegistry(prometheus.NewRegistry()))
+
+			rr := helpers.NewRemediationRequest("test-rr-628-004", "default")
+			ai := helpers.NewCompletedAIAnalysis("test-ai-628-004", "default")
+
+			name, err := nc.CreateApprovalNotification(context.Background(), rr, ai)
+			Expect(err).ToNot(HaveOccurred())
+
+			nr := &notificationv1.NotificationRequest{}
+			Expect(cl.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "default"}, nr)).To(Succeed())
+
+			Expect(nr.Spec.Body).To(ContainSubstring("**Status**: Pending Approval"),
+				"#628: Approval body must include standardized Status field")
+		})
+
+		It("UT-NOT-628-005: Self-resolved body contains **Status**: Self-Resolved", func() {
+			cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+			nc := creator.NewNotificationCreator(cl, scheme, rometrics.NewMetricsWithRegistry(prometheus.NewRegistry()))
+
+			rr := helpers.NewRemediationRequest("test-rr-628-005", "default")
+			ai := helpers.NewCompletedAIAnalysis("test-ai-628-005", "default")
+
+			name, err := nc.CreateSelfResolvedNotification(context.Background(), rr, ai)
+			Expect(err).ToNot(HaveOccurred())
+
+			nr := &notificationv1.NotificationRequest{}
+			Expect(cl.Get(context.Background(), types.NamespacedName{Name: name, Namespace: "default"}, nr)).To(Succeed())
+
+			Expect(nr.Spec.Body).To(ContainSubstring("**Status**: Self-Resolved"),
+				"#628: Self-resolved body must include standardized Status field")
+		})
+
+		It("UT-NOT-628-006: Global timeout body contains **Status**: Timed Out distinct from timestamp line", func() {
+			cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+			nc := creator.NewNotificationCreator(cl, scheme, rometrics.NewMetricsWithRegistry(prometheus.NewRegistry()))
+
+			body := nc.BuildGlobalTimeoutBody(
+				"HighCPUAlert", "test-rr-628-006", "Executing",
+				"30m", "2026-04-09T10:00:00Z", "2026-04-09T10:30:00Z",
+			)
+
+			Expect(body).To(ContainSubstring("**Status**: Timed Out"),
+				"#628: Global timeout body must include standardized Status field")
+			Expect(body).To(ContainSubstring("**Timed Out**:"),
+				"#628: Legacy timestamp label must remain")
+
+			statusLine := ""
+			timedOutLine := ""
+			for _, line := range strings.Split(body, "\n") {
+				if strings.Contains(line, "**Status**:") {
+					statusLine = line
+				}
+				if strings.Contains(line, "**Timed Out**:") {
+					timedOutLine = line
+				}
+			}
+			Expect(statusLine).ToNot(Equal(timedOutLine),
+				"#628 R1: Status line and timestamp line must be structurally distinct")
+		})
+
+		It("UT-NOT-628-007: Phase timeout body contains **Status**: Timed Out", func() {
+			cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+			nc := creator.NewNotificationCreator(cl, scheme, rometrics.NewMetricsWithRegistry(prometheus.NewRegistry()))
+
+			body := nc.BuildPhaseTimeoutBody(
+				"HighMemAlert", "test-rr-628-007", "AIAnalysis",
+				"15m", "2026-04-09T11:00:00Z", "2026-04-09T11:15:00Z",
+			)
+
+			Expect(body).To(ContainSubstring("**Status**: Timed Out"),
+				"#628: Phase timeout body must include standardized Status field")
+		})
+	})
+
+	Context("Status position ordering", func() {
+		It("UT-NOT-628-008: Status appears before Signal in all notification types that include Signal", func() {
+			cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+			nc := creator.NewNotificationCreator(cl, scheme, rometrics.NewMetricsWithRegistry(prometheus.NewRegistry()))
+
+			type bodyCase struct {
+				label string
+				body  string
+			}
+
+			rr := helpers.NewRemediationRequest("test-rr-628-008", "default")
+			rr.Status.OverallPhase = "Completed"
+			rr.Status.Outcome = "Remediated"
+			rr.Status.DuplicateCount = 2
+			ai := helpers.NewCompletedAIAnalysis("test-ai-628-008", "default")
+
+			completionName, err := nc.CreateCompletionNotification(context.Background(), rr, ai, "tekton", nil)
+			Expect(err).ToNot(HaveOccurred())
+			completionNR := &notificationv1.NotificationRequest{}
+			Expect(cl.Get(context.Background(), types.NamespacedName{Name: completionName, Namespace: "default"}, completionNR)).To(Succeed())
+
+			bulkName, err := nc.CreateBulkDuplicateNotification(context.Background(), rr)
+			Expect(err).ToNot(HaveOccurred())
+			bulkNR := &notificationv1.NotificationRequest{}
+			Expect(cl.Get(context.Background(), types.NamespacedName{Name: bulkName, Namespace: "default"}, bulkNR)).To(Succeed())
+
+			reviewCtx := &creator.ManualReviewContext{
+				Source: notificationv1.ReviewSourceAIAnalysis,
+				Reason: "LowConfidence",
+			}
+			reviewRR := helpers.NewRemediationRequest("test-rr-628-008-review", "default")
+			reviewName, err := nc.CreateManualReviewNotification(context.Background(), reviewRR, reviewCtx)
+			Expect(err).ToNot(HaveOccurred())
+			reviewNR := &notificationv1.NotificationRequest{}
+			Expect(cl.Get(context.Background(), types.NamespacedName{Name: reviewName, Namespace: "default"}, reviewNR)).To(Succeed())
+
+			approvalRR := helpers.NewRemediationRequest("test-rr-628-008-approval", "default")
+			approvalName, err := nc.CreateApprovalNotification(context.Background(), approvalRR, ai)
+			Expect(err).ToNot(HaveOccurred())
+			approvalNR := &notificationv1.NotificationRequest{}
+			Expect(cl.Get(context.Background(), types.NamespacedName{Name: approvalName, Namespace: "default"}, approvalNR)).To(Succeed())
+
+			selfRR := helpers.NewRemediationRequest("test-rr-628-008-self", "default")
+			selfName, err := nc.CreateSelfResolvedNotification(context.Background(), selfRR, ai)
+			Expect(err).ToNot(HaveOccurred())
+			selfNR := &notificationv1.NotificationRequest{}
+			Expect(cl.Get(context.Background(), types.NamespacedName{Name: selfName, Namespace: "default"}, selfNR)).To(Succeed())
+
+			cases := []bodyCase{
+				{label: "Completion", body: completionNR.Spec.Body},
+				{label: "Bulk Duplicate", body: bulkNR.Spec.Body},
+				{label: "Manual Review", body: reviewNR.Spec.Body},
+				{label: "Approval", body: approvalNR.Spec.Body},
+				{label: "Self-Resolved", body: selfNR.Spec.Body},
+				{label: "Global Timeout", body: nc.BuildGlobalTimeoutBody("sig", "rr", "Executing", "30m", "t0", "t1")},
+				{label: "Phase Timeout", body: nc.BuildPhaseTimeoutBody("sig", "rr", "AI", "15m", "t0", "t1")},
+			}
+
+			for _, tc := range cases {
+				statusIdx := strings.Index(tc.body, "**Status**:")
+				signalIdx := strings.Index(tc.body, "**Signal**:")
+				Expect(statusIdx).To(BeNumerically(">=", 0),
+					"%s: **Status**: must be present", tc.label)
+				Expect(signalIdx).To(BeNumerically(">=", 0),
+					"%s: **Signal**: must be present", tc.label)
+				Expect(statusIdx).To(BeNumerically("<", signalIdx),
+					"%s: **Status**: must appear before **Signal**: for consistent operator scan order (#628/#627)", tc.label)
+			}
+		})
+	})
+})

--- a/test/unit/remediationorchestrator/workflowexecution_creator_sa_test.go
+++ b/test/unit/remediationorchestrator/workflowexecution_creator_sa_test.go
@@ -18,6 +18,7 @@ package remediationorchestrator
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -33,14 +34,14 @@ import (
 )
 
 // ========================================
-// RO CREATOR SA PROPAGATION TESTS (#501)
+// RO CREATOR WFE SPEC TESTS (#501 / #650)
 // ========================================
-// Authority: DD-WE-005 v2.0, Issue #501
-// Validates that ServiceAccountName from AIAnalysis.Status.SelectedWorkflow
-// is propagated to WorkflowExecution.Spec.ServiceAccountName (top-level).
+// Authority: DD-WE-005, Issue #501 (ExecutionConfig from RR timeouts),
+// Issue #650 (ServiceAccountName removed from WFE spec and AIAnalysis
+// SelectedWorkflow; SA resolved from DS at runtime in WE controller).
 // ========================================
 
-var _ = Describe("WorkflowExecution Creator SA Propagation [DD-WE-005] (#501)", func() {
+var _ = Describe("WorkflowExecution Creator WFE spec [DD-WE-005] (#501/#650)", func() {
 
 	var scheme *runtime.Scheme
 
@@ -68,8 +69,8 @@ var _ = Describe("WorkflowExecution Creator SA Propagation [DD-WE-005] (#501)", 
 		}
 	}
 
-	buildAI := func(saName string) *aianalysisv1.AIAnalysis {
-		ai := &aianalysisv1.AIAnalysis{
+	buildAI := func() *aianalysisv1.AIAnalysis {
+		return &aianalysisv1.AIAnalysis{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "aa-test",
 				Namespace: "kubernaut-system",
@@ -82,22 +83,24 @@ var _ = Describe("WorkflowExecution Creator SA Propagation [DD-WE-005] (#501)", 
 				},
 			},
 		}
-		if saName != "" {
-			ai.Status.SelectedWorkflow.ServiceAccountName = saName
-		}
-		return ai
 	}
 
-	Context("ServiceAccountName propagation (Issue #501)", func() {
+	Context("WorkflowExecution spec (Issue #650: no SA on spec; #501 timeouts)", func() {
 		var ctx context.Context
 
 		BeforeEach(func() {
 			ctx = context.Background()
 		})
 
-		It("UT-WE-501-010: should set Spec.ServiceAccountName and ExecutionConfig with only Timeout", func() {
+		It("UT-WE-501-010: should set ExecutionConfig.Timeout from RR Status.TimeoutConfig.Executing", func() {
 			rr := buildRR()
-			ai := buildAI("my-workflow-sa")
+			execTimeout := &metav1.Duration{Duration: 45 * time.Minute}
+			rr.Status = remediationv1.RemediationRequestStatus{
+				TimeoutConfig: &remediationv1.TimeoutConfig{
+					Executing: execTimeout,
+				},
+			}
+			ai := buildAI()
 			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rr).Build()
 			wec := creator.NewWorkflowExecutionCreator(k8sClient, scheme, nil)
 
@@ -108,15 +111,15 @@ var _ = Describe("WorkflowExecution Creator SA Propagation [DD-WE-005] (#501)", 
 			created := &workflowexecutionv1.WorkflowExecution{}
 			err = k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: rr.Namespace}, created)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(created.Spec.ServiceAccountName).To(Equal("my-workflow-sa"),
-				"SA should be at Spec top level, not inside ExecutionConfig")
-			Expect(created.Spec.ExecutionConfig).To(BeNil(),
-				"ExecutionConfig should be nil when no timeout is configured")
+			Expect(created.Spec.ExecutionConfig.Timeout.Duration).To(Equal(execTimeout.Duration))
+			Expect(created.Spec.WorkflowRef.WorkflowID).To(Equal("wf-uuid-123"))
+			Expect(created.Spec.WorkflowRef.Version).To(Equal("1.0.0"))
+			Expect(created.Spec.WorkflowRef.ExecutionBundle).To(Equal("quay.io/test:v1@sha256:abc123"))
 		})
 
-		It("UT-RO-481-002: should leave ExecutionConfig nil and SA empty when no SA and no timeout", func() {
+		It("UT-RO-481-002: should leave ExecutionConfig nil when no executing timeout (WFE spec has no SA per #650)", func() {
 			rr := buildRR()
-			ai := buildAI("")
+			ai := buildAI()
 			k8sClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rr).Build()
 			wec := creator.NewWorkflowExecutionCreator(k8sClient, scheme, nil)
 
@@ -126,9 +129,9 @@ var _ = Describe("WorkflowExecution Creator SA Propagation [DD-WE-005] (#501)", 
 			created := &workflowexecutionv1.WorkflowExecution{}
 			err = k8sClient.Get(ctx, client.ObjectKey{Name: name, Namespace: rr.Namespace}, created)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(created.Spec.ServiceAccountName).To(Equal(""),
-				"SA should be empty when no SA specified")
 			Expect(created.Spec.ExecutionConfig).To(BeNil())
+			Expect(created.Spec.WorkflowRef.WorkflowID).To(Equal("wf-uuid-123"))
+			Expect(created.Spec.TargetResource).To(Equal("default/Deployment/nginx"))
 		})
 	})
 })

--- a/test/unit/workflowexecution/ansible_token_request_test.go
+++ b/test/unit/workflowexecution/ansible_token_request_test.go
@@ -67,7 +67,6 @@ var _ = Describe("Ansible TokenRequest Credential Injection [#501]", func() {
 				Namespace: "kubernaut-workflows",
 			},
 			Spec: workflowexecutionv1alpha1.WorkflowExecutionSpec{
-				ServiceAccountName: saName,
 				WorkflowRef: workflowexecutionv1alpha1.WorkflowRef{
 					WorkflowID:      "wf-123",
 					ExecutionBundle: "quay.io/test:v1@sha256:abc123",
@@ -80,7 +79,8 @@ var _ = Describe("Ansible TokenRequest Credential Injection [#501]", func() {
 				},
 			},
 			Status: workflowexecutionv1alpha1.WorkflowExecutionStatus{
-				ExecutionEngine: "ansible",
+				ExecutionEngine:    "ansible",
+				ServiceAccountName: saName,
 			},
 		}
 		if timeout > 0 {

--- a/test/unit/workflowexecution/controller_events_test.go
+++ b/test/unit/workflowexecution/controller_events_test.go
@@ -18,10 +18,13 @@ package workflowexecution
 
 import (
 	"context"
+	"encoding/json"
+	"fmt"
 	"strings"
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
@@ -31,13 +34,19 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	workflowexecutionv1alpha1 "github.com/jordigilh/kubernaut/api/workflowexecution/v1alpha1"
 	"github.com/jordigilh/kubernaut/internal/controller/workflowexecution"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/models"
 	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+	dsvalidation "github.com/jordigilh/kubernaut/pkg/datastorage/validation"
 	"github.com/jordigilh/kubernaut/pkg/shared/events"
 	"github.com/jordigilh/kubernaut/pkg/workflowexecution/audit"
+	weclient "github.com/jordigilh/kubernaut/pkg/workflowexecution/client"
+	weexecutor "github.com/jordigilh/kubernaut/pkg/workflowexecution/executor"
 	"github.com/jordigilh/kubernaut/pkg/workflowexecution/metrics"
 	wephase "github.com/jordigilh/kubernaut/pkg/workflowexecution/phase"
 	"github.com/jordigilh/kubernaut/pkg/workflowexecution/status"
@@ -312,6 +321,266 @@ var _ = Describe("WorkflowExecution Controller K8s Events [DD-EVENT-001]", func(
 		})
 	})
 })
+
+// ========================================
+// Issue #659: WorkflowValidationFailed event observability (SOC2)
+// BR-WE-005, BR-WE-095, DD-EVENT-001
+// ========================================
+var _ = Describe("WorkflowExecution Controller Observability [Issue #659]", func() {
+	var (
+		evtScheme   *runtime.Scheme
+		evtRecorder *record.FakeRecorder
+		evtCtx      context.Context
+	)
+
+	BeforeEach(func() {
+		evtCtx = context.Background()
+		evtScheme = runtime.NewScheme()
+		Expect(workflowexecutionv1alpha1.AddToScheme(evtScheme)).To(Succeed())
+		Expect(tektonv1.AddToScheme(evtScheme)).To(Succeed())
+		Expect(corev1.AddToScheme(evtScheme)).To(Succeed())
+		evtRecorder = record.NewFakeRecorder(20)
+	})
+
+	buildReconciler := func(fakeClient client.Client, querier weclient.WorkflowQuerier, depValidator dsvalidation.DependencyValidator, registry *weexecutor.Registry) *workflowexecution.WorkflowExecutionReconciler {
+		as := &mockAuditStore{events: make([]*ogenclient.AuditEventRequest, 0)}
+		am := audit.NewManager(as, logr.Discard())
+		sm := status.NewManager(fakeClient)
+		tm := metrics.NewMetricsWithRegistry(prometheus.NewRegistry())
+		pm := wephase.NewManager()
+
+		return &workflowexecution.WorkflowExecutionReconciler{
+			Client:              fakeClient,
+			APIReader:           fakeClient,
+			Scheme:              evtScheme,
+			Recorder:            evtRecorder,
+			ExecutionNamespace:  "kubernaut-workflows",
+			AuditStore:          as,
+			Metrics:             tm,
+			StatusManager:       sm,
+			AuditManager:        am,
+			PhaseManager:        pm,
+			WorkflowQuerier:     querier,
+			DependencyValidator: depValidator,
+			ExecutorRegistry:    registry,
+		}
+	}
+
+	buildPendingWFE := func(name string) *workflowexecutionv1alpha1.WorkflowExecution {
+		return &workflowexecutionv1alpha1.WorkflowExecution{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       name,
+				Namespace:  "default",
+				UID:        types.UID("uid-" + name),
+				Finalizers: []string{workflowexecution.FinalizerName},
+			},
+			Spec: workflowexecutionv1alpha1.WorkflowExecutionSpec{
+				TargetResource: "default/deployment/test-app",
+				WorkflowRef: workflowexecutionv1alpha1.WorkflowRef{
+					WorkflowID:      uuid.New().String(),
+					Version:         "v1",
+					ExecutionBundle: "ghcr.io/kubernaut/workflows/restart:v1.0.0",
+				},
+			},
+		}
+	}
+
+	Context("UT-WE-659-001 (P0): Dependency validation failure emits WorkflowValidationFailed", func() {
+		It("should emit WorkflowValidationFailed event when dependency validation fails", func() {
+			wfe := buildPendingWFE("wfe-659-dep-fail")
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(evtScheme).
+				WithObjects(wfe).
+				WithStatusSubresource(wfe).
+				Build()
+
+			querier := &mockCatalogQuerier{
+				meta: &weclient.WorkflowCatalogMetadata{
+					ExecutionEngine: "tekton",
+					WorkflowName:    "cert-renewal",
+					ExecutionBundle: "ghcr.io/test/exec:v1",
+					Dependencies: &models.WorkflowDependencies{
+						Secrets: []models.ResourceDependency{{Name: "missing-secret"}},
+					},
+				},
+			}
+			depValidator := &mockDependencyValidator{err: fmt.Errorf("secret missing-secret not found in namespace kubernaut-workflows")}
+			tektonExec := weexecutor.NewTektonExecutor(fakeClient)
+			registry := weexecutor.NewRegistry()
+			registry.Register(tektonExec.Engine(), tektonExec)
+
+			reconciler := buildReconciler(fakeClient, querier, depValidator, registry)
+			drainFakeRecorderEvents(evtRecorder)
+
+			_, err := reconciler.Reconcile(evtCtx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: wfe.Name, Namespace: wfe.Namespace},
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			evts := drainFakeRecorderEvents(evtRecorder)
+			Expect(hasEventMatch(evts, "Warning", events.EventReasonWorkflowValidationFailed)).
+				To(BeTrue(), "Dependency validation failure must emit WorkflowValidationFailed, got: %v", evts)
+		})
+	})
+
+	Context("UT-WE-659-002 (P0): Unsupported engine emits WorkflowValidationFailed", func() {
+		It("should emit WorkflowValidationFailed event for unsupported engine", func() {
+			wfe := buildPendingWFE("wfe-659-bad-engine")
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(evtScheme).
+				WithObjects(wfe).
+				WithStatusSubresource(wfe).
+				Build()
+
+			querier := &mockCatalogQuerier{
+				meta: &weclient.WorkflowCatalogMetadata{
+					ExecutionEngine: "unsupported-engine-xyz",
+					WorkflowName:    "test-workflow",
+					ExecutionBundle: "ghcr.io/test/exec:v1",
+				},
+			}
+			tektonExec := weexecutor.NewTektonExecutor(fakeClient)
+			registry := weexecutor.NewRegistry()
+			registry.Register(tektonExec.Engine(), tektonExec)
+
+			reconciler := buildReconciler(fakeClient, querier, nil, registry)
+			drainFakeRecorderEvents(evtRecorder)
+
+			_, err := reconciler.Reconcile(evtCtx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: wfe.Name, Namespace: wfe.Namespace},
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			evts := drainFakeRecorderEvents(evtRecorder)
+			Expect(hasEventMatch(evts, "Warning", events.EventReasonWorkflowValidationFailed)).
+				To(BeTrue(), "Unsupported engine must emit WorkflowValidationFailed, got: %v", evts)
+		})
+	})
+
+	Context("UT-WE-659-003 (P0): Catalog resolution failure — regression guard", func() {
+		It("should emit WorkflowValidationFailed event when catalog resolution fails", func() {
+			wfe := buildPendingWFE("wfe-659-catalog-fail")
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(evtScheme).
+				WithObjects(wfe).
+				WithStatusSubresource(wfe).
+				Build()
+
+			querier := &mockCatalogQuerier{
+				err: fmt.Errorf("DS internal server error for workflow"),
+			}
+			registry := weexecutor.NewRegistry()
+
+			reconciler := buildReconciler(fakeClient, querier, nil, registry)
+			drainFakeRecorderEvents(evtRecorder)
+
+			_, err := reconciler.Reconcile(evtCtx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: wfe.Name, Namespace: wfe.Namespace},
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			evts := drainFakeRecorderEvents(evtRecorder)
+			Expect(hasEventMatch(evts, "Warning", events.EventReasonWorkflowValidationFailed)).
+				To(BeTrue(), "Catalog resolution failure must emit WorkflowValidationFailed (regression guard), got: %v", evts)
+		})
+	})
+
+	Context("UT-WE-659-004 (P0): Spec validation failure — regression guard", func() {
+		It("should emit WorkflowValidationFailed event when spec validation fails", func() {
+			wfe := buildPendingWFE("wfe-659-spec-fail")
+			wfe.Spec.WorkflowRef.ExecutionBundle = "" // trigger spec validation failure
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(evtScheme).
+				WithObjects(wfe).
+				WithStatusSubresource(wfe).
+				Build()
+
+			reconciler := buildReconciler(fakeClient, nil, nil, nil)
+			drainFakeRecorderEvents(evtRecorder)
+
+			_, err := reconciler.Reconcile(evtCtx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: wfe.Name, Namespace: wfe.Namespace},
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			evts := drainFakeRecorderEvents(evtRecorder)
+			Expect(hasEventMatch(evts, "Warning", events.EventReasonWorkflowValidationFailed)).
+				To(BeTrue(), "Spec validation failure must emit WorkflowValidationFailed (regression guard), got: %v", evts)
+		})
+	})
+
+	Context("UT-WE-659-005 (P1): reconcileRunning engine resolution failure emits event", func() {
+		It("should emit WorkflowFailed event when engine resolution fails during Running phase", func() {
+			wfe := buildPendingWFE("wfe-659-running-engine-fail")
+			now := metav1.Now()
+			wfe.Status.Phase = workflowexecutionv1alpha1.PhaseRunning
+			wfe.Status.StartTime = &now
+			wfe.Status.ExecutionEngine = "" // force resolution attempt
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(evtScheme).
+				WithObjects(wfe).
+				WithStatusSubresource(wfe).
+				Build()
+
+			reconciler := buildReconciler(fakeClient, nil, nil, nil)
+			drainFakeRecorderEvents(evtRecorder)
+
+			_, err := reconciler.Reconcile(evtCtx, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: wfe.Name, Namespace: wfe.Namespace},
+			})
+			Expect(err).ToNot(HaveOccurred())
+
+			evts := drainFakeRecorderEvents(evtRecorder)
+			Expect(hasEventMatch(evts, "Warning", events.EventReasonWorkflowFailed)).
+				To(BeTrue(), "Running-phase engine resolution failure must emit WorkflowFailed, got: %v", evts)
+		})
+	})
+})
+
+// mockCatalogQuerier implements weclient.WorkflowQuerier for test injection.
+type mockCatalogQuerier struct {
+	meta *weclient.WorkflowCatalogMetadata
+	err  error
+}
+
+func (m *mockCatalogQuerier) GetWorkflowDependencies(_ context.Context, _ string) (*models.WorkflowDependencies, error) {
+	if m.meta != nil {
+		return m.meta.Dependencies, m.err
+	}
+	return nil, m.err
+}
+
+func (m *mockCatalogQuerier) GetWorkflowEngineConfig(_ context.Context, _ string) (json.RawMessage, error) {
+	return nil, m.err
+}
+
+func (m *mockCatalogQuerier) GetWorkflowExecutionEngine(_ context.Context, _ string) (string, string, error) {
+	if m.meta != nil {
+		return m.meta.ExecutionEngine, m.meta.WorkflowName, m.err
+	}
+	return "", "", m.err
+}
+
+func (m *mockCatalogQuerier) GetWorkflowExecutionBundle(_ context.Context, _ string) (string, string, error) {
+	if m.meta != nil {
+		return m.meta.ExecutionBundle, m.meta.ExecutionBundleDigest, m.err
+	}
+	return "", "", m.err
+}
+
+func (m *mockCatalogQuerier) ResolveWorkflowCatalogMetadata(_ context.Context, _ string) (*weclient.WorkflowCatalogMetadata, error) {
+	return m.meta, m.err
+}
+
+// mockDependencyValidator implements dsvalidation.DependencyValidator for testing.
+type mockDependencyValidator struct {
+	err error
+}
+
+func (m *mockDependencyValidator) ValidateDependencies(_ context.Context, _ string, _ *models.WorkflowDependencies) error {
+	return m.err
+}
 
 // Suppress unused import warning
 var _ = time.Second

--- a/test/unit/workflowexecution/controller_test.go
+++ b/test/unit/workflowexecution/controller_test.go
@@ -46,6 +46,7 @@ import (
 	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
 	"github.com/jordigilh/kubernaut/pkg/shared/events"
 	"github.com/jordigilh/kubernaut/pkg/workflowexecution/audit"
+	weexecutor "github.com/jordigilh/kubernaut/pkg/workflowexecution/executor"
 	"github.com/jordigilh/kubernaut/pkg/workflowexecution/metrics"
 	"github.com/jordigilh/kubernaut/pkg/workflowexecution/status"
 )
@@ -125,35 +126,35 @@ var _ = Describe("WorkflowExecution Controller", func() {
 		It("should generate deterministic name from targetResource", func() {
 			// Same input should always produce same output
 			targetResource := "default/deployment/my-app"
-			name1 := workflowexecution.PipelineRunName(targetResource)
-			name2 := workflowexecution.PipelineRunName(targetResource)
+			name1 := weexecutor.ExecutionResourceName(targetResource)
+			name2 := weexecutor.ExecutionResourceName(targetResource)
 			Expect(name1).To(Equal(name2))
 		})
 
 		It("should prefix name with 'wfe-'", func() {
 			targetResource := "default/deployment/my-app"
-			name := workflowexecution.PipelineRunName(targetResource)
+			name := weexecutor.ExecutionResourceName(targetResource)
 			Expect(name).To(HavePrefix("wfe-"))
 		})
 
 		It("should generate valid Kubernetes name (max 63 chars)", func() {
 			// Very long targetResource should still produce valid name
 			targetResource := "very-long-namespace/deployment/very-long-deployment-name-that-exceeds-normal-limits"
-			name := workflowexecution.PipelineRunName(targetResource)
+			name := weexecutor.ExecutionResourceName(targetResource)
 			Expect(len(name)).To(BeNumerically("<=", 63))
 		})
 
 		It("should generate 20-character name (wfe- + 16 hex chars)", func() {
 			targetResource := "default/deployment/my-app"
-			name := workflowexecution.PipelineRunName(targetResource)
+			name := weexecutor.ExecutionResourceName(targetResource)
 			// "wfe-" (4 chars) + 16 hex chars = 20 chars
 			Expect(len(name)).To(Equal(20))
 		})
 
 		It("should generate different names for different targetResources", func() {
-			name1 := workflowexecution.PipelineRunName("ns1/deployment/app1")
-			name2 := workflowexecution.PipelineRunName("ns1/deployment/app2")
-			name3 := workflowexecution.PipelineRunName("ns2/deployment/app1")
+			name1 := weexecutor.ExecutionResourceName("ns1/deployment/app1")
+			name2 := weexecutor.ExecutionResourceName("ns1/deployment/app2")
+			name3 := weexecutor.ExecutionResourceName("ns2/deployment/app1")
 			Expect(name1).ToNot(Equal(name2))
 			Expect(name1).ToNot(Equal(name3))
 			Expect(name2).ToNot(Equal(name3))
@@ -161,7 +162,7 @@ var _ = Describe("WorkflowExecution Controller", func() {
 
 		It("should use only lowercase hex characters", func() {
 			targetResource := "default/deployment/my-app"
-			name := workflowexecution.PipelineRunName(targetResource)
+			name := weexecutor.ExecutionResourceName(targetResource)
 			// Remove "wfe-" prefix and check hex chars
 			hexPart := name[4:]
 			for _, c := range hexPart {
@@ -182,8 +183,8 @@ var _ = Describe("WorkflowExecution Controller", func() {
 		DescribeTable("determinism and uniqueness edge cases",
 			func(targetResource string, description string) {
 				// Test determinism: Same input → same output
-				name1 := workflowexecution.PipelineRunName(targetResource)
-				name2 := workflowexecution.PipelineRunName(targetResource)
+				name1 := weexecutor.ExecutionResourceName(targetResource)
+				name2 := weexecutor.ExecutionResourceName(targetResource)
 				Expect(name1).To(Equal(name2), "Should be deterministic for: %s", description)
 
 				// Test format
@@ -248,7 +249,7 @@ var _ = Describe("WorkflowExecution Controller", func() {
 		It("should handle case when PipelineRun doesn't exist (not AlreadyExists)", func() {
 			// V1.0: HandleAlreadyExists now always tries to get PR to check ownership
 			// This test verifies it handles the case where PR doesn't exist
-			prName := workflowexecution.PipelineRunName(targetResource)
+			prName := weexecutor.ExecutionResourceName(targetResource)
 			wfe := &workflowexecutionv1alpha1.WorkflowExecution{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-wfe", Namespace: "default"},
 				Spec:       workflowexecutionv1alpha1.WorkflowExecutionSpec{TargetResource: targetResource},
@@ -273,16 +274,9 @@ var _ = Describe("WorkflowExecution Controller", func() {
 				AuditManager:       auditManager,
 			}
 
-			pr := &tektonv1.PipelineRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      prName,
-					Namespace: "kubernaut-workflows",
-				},
-			}
-
 			// AlreadyExists error but PR doesn't actually exist (race condition)
 			alreadyExistsErr := apierrors.NewAlreadyExists(tektonv1.Resource("pipelineruns"), prName)
-			result, err := reconciler.HandleAlreadyExists(ctx, wfe, pr, alreadyExistsErr)
+			result, err := reconciler.HandleAlreadyExists(ctx, wfe, prName, alreadyExistsErr)
 			// Should fail to get PR and mark WFE as Failed
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeZero())
@@ -295,7 +289,7 @@ var _ = Describe("WorkflowExecution Controller", func() {
 		})
 
 		It("should update to Running when PipelineRun is ours (race with self)", func() {
-			prName := workflowexecution.PipelineRunName(targetResource)
+			prName := weexecutor.ExecutionResourceName(targetResource)
 			existingPR := &tektonv1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      prName,
@@ -330,16 +324,9 @@ var _ = Describe("WorkflowExecution Controller", func() {
 				AuditManager:       auditManager,
 			}
 
-			pr := &tektonv1.PipelineRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      prName,
-					Namespace: "kubernaut-workflows",
-				},
-			}
-
 			// AlreadyExists error
 			alreadyExistsErr := apierrors.NewAlreadyExists(tektonv1.Resource("pipelineruns"), prName)
-			result, err := reconciler.HandleAlreadyExists(ctx, wfe, pr, alreadyExistsErr)
+			result, err := reconciler.HandleAlreadyExists(ctx, wfe, prName, alreadyExistsErr)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.RequeueAfter).To(Equal(10 * time.Second))
 
@@ -351,7 +338,7 @@ var _ = Describe("WorkflowExecution Controller", func() {
 		})
 
 		It("should mark Failed when PipelineRun belongs to another WFE (execution race)", func() {
-			prName := workflowexecution.PipelineRunName(targetResource)
+			prName := weexecutor.ExecutionResourceName(targetResource)
 			existingPR := &tektonv1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      prName,
@@ -386,16 +373,9 @@ var _ = Describe("WorkflowExecution Controller", func() {
 				AuditManager:       auditManager,
 			}
 
-			pr := &tektonv1.PipelineRun{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      prName,
-					Namespace: "kubernaut-workflows",
-				},
-			}
-
 			// AlreadyExists error
 			alreadyExistsErr := apierrors.NewAlreadyExists(tektonv1.Resource("pipelineruns"), prName)
-			result, err := reconciler.HandleAlreadyExists(ctx, wfe, pr, alreadyExistsErr)
+			result, err := reconciler.HandleAlreadyExists(ctx, wfe, prName, alreadyExistsErr)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.RequeueAfter).To(BeZero())
 
@@ -416,205 +396,6 @@ var _ = Describe("WorkflowExecution Controller", func() {
 	// V1.0: MarkSkipped tests removed - routing moved to RO (DD-RO-002)
 	// WFE no longer has skip logic; RO blocks creation before WFE exists
 	// ========================================
-
-	// ========================================
-	// Day 4: BuildPipelineRun() Tests
-	// TDD RED Phase: Tests written, implementation pending
-	// ========================================
-
-	Describe("BuildPipelineRun", func() {
-		var (
-			wfe        *workflowexecutionv1alpha1.WorkflowExecution
-			reconciler *workflowexecution.WorkflowExecutionReconciler
-		)
-
-		BeforeEach(func() {
-			wfe = &workflowexecutionv1alpha1.WorkflowExecution{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-wfe",
-					Namespace: "payment",
-				},
-				Spec: workflowexecutionv1alpha1.WorkflowExecutionSpec{
-					TargetResource: "payment/deployment/payment-api",
-					WorkflowRef: workflowexecutionv1alpha1.WorkflowRef{
-						WorkflowID:     "restart-deployment",
-						Version:        "1.0.0",
-						ExecutionBundle: "ghcr.io/kubernaut/workflows/restart-deployment:v1.0.0",
-					},
-					Parameters: map[string]string{
-						"NAMESPACE":       "payment",
-						"DEPLOYMENT_NAME": "payment-api",
-					},
-				},
-			}
-
-			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-			reconciler = &workflowexecution.WorkflowExecutionReconciler{
-				Client:             fakeClient,
-				Scheme:             scheme,
-				Recorder:           recorder,
-				ExecutionNamespace: "kubernaut-workflows",
-				CooldownPeriod:     5 * time.Minute,
-			}
-		})
-
-		It("should create PipelineRun with deterministic name", func() {
-			pr := reconciler.BuildPipelineRun(wfe)
-
-			// Name should be deterministic based on targetResource
-			expectedName := workflowexecution.PipelineRunName(wfe.Spec.TargetResource)
-			Expect(pr.Name).To(Equal(expectedName))
-		})
-
-		It("should create PipelineRun in execution namespace", func() {
-			pr := reconciler.BuildPipelineRun(wfe)
-
-			// DD-WE-002: PipelineRuns always in kubernaut-workflows
-			Expect(pr.Namespace).To(Equal("kubernaut-workflows"))
-		})
-
-		It("should set cross-namespace tracking labels", func() {
-			pr := reconciler.BuildPipelineRun(wfe)
-
-			Expect(pr.Labels).To(HaveKeyWithValue("kubernaut.ai/workflow-execution", "test-wfe"))
-			Expect(pr.Labels).To(HaveKeyWithValue("kubernaut.ai/source-namespace", "payment"))
-			Expect(pr.Labels).To(HaveKeyWithValue("kubernaut.ai/workflow-id", "restart-deployment"))
-			// Label value is sanitized (slashes replaced with __)
-			// Original value stored in annotation
-			Expect(pr.Labels).To(HaveKeyWithValue("kubernaut.ai/target-resource", "payment__deployment__payment-api"))
-			// Verify annotation contains original value
-			Expect(pr.Annotations).To(HaveKeyWithValue("kubernaut.ai/target-resource", "payment/deployment/payment-api"))
-		})
-
-		It("should use bundle resolver with correct params", func() {
-			pr := reconciler.BuildPipelineRun(wfe)
-
-			Expect(pr.Spec.PipelineRef).To(Not(BeNil()))
-			Expect(string(pr.Spec.PipelineRef.Resolver)).To(Equal("bundles"))
-
-			// Check bundle param
-			var bundleParam, nameParam, kindParam *tektonv1.Param
-			for i := range pr.Spec.PipelineRef.Params {
-				p := &pr.Spec.PipelineRef.Params[i]
-				switch p.Name {
-				case "bundle":
-					bundleParam = p
-				case "name":
-					nameParam = p
-				case "kind":
-					kindParam = p
-				}
-			}
-
-			Expect(bundleParam).To(And(Not(BeNil()), HaveField("Value.StringVal", Equal("ghcr.io/kubernaut/workflows/restart-deployment:v1.0.0"))))
-			Expect(nameParam).To(And(Not(BeNil()), HaveField("Value.StringVal", Equal("workflow"))))
-			Expect(kindParam).To(And(Not(BeNil()), HaveField("Value.StringVal", Equal("pipeline"))))
-		})
-
-		It("should pass workflow parameters to PipelineRun", func() {
-			pr := reconciler.BuildPipelineRun(wfe)
-
-			// Check params are passed
-			paramMap := make(map[string]string)
-			for _, p := range pr.Spec.Params {
-				paramMap[p.Name] = p.Value.StringVal
-			}
-
-			Expect(paramMap).To(HaveKeyWithValue("NAMESPACE", "payment"))
-			Expect(paramMap).To(HaveKeyWithValue("DEPLOYMENT_NAME", "payment-api"))
-		})
-
-		It("should leave SA empty when WFE has no ExecutionConfig (DD-WE-005 v2.0)", func() {
-			pr := reconciler.BuildPipelineRun(wfe)
-
-			Expect(pr.Spec.TaskRunTemplate.ServiceAccountName).To(BeEmpty(),
-				"DD-WE-005: SA from WFE spec, empty when not set")
-		})
-
-		It("should handle empty parameters", func() {
-			wfe.Spec.Parameters = nil
-			pr := reconciler.BuildPipelineRun(wfe)
-
-			// Even with empty spec parameters, TARGET_RESOURCE is always added
-			Expect(pr.Spec.Params).To(HaveLen(1))
-			Expect(pr.Spec.Params[0].Name).To(Equal("TARGET_RESOURCE"))
-			Expect(pr.Spec.Params[0].Value.StringVal).To(Equal(wfe.Spec.TargetResource))
-		})
-
-		// DD-WE-005 v2.0 / Issue #501: SA at spec top level
-		It("should use SA from WFE Spec.ServiceAccountName", func() {
-			wfe.Spec.ServiceAccountName = "custom-sa"
-
-			pr := reconciler.BuildPipelineRun(wfe)
-
-			Expect(pr.Spec.TaskRunTemplate.ServiceAccountName).To(Equal("custom-sa"))
-		})
-
-		It("should use empty SA when WFE spec has no ExecutionConfig (DD-WE-005 v2.0)", func() {
-			reconcilerNoSA := &workflowexecution.WorkflowExecutionReconciler{
-				Client:             fake.NewClientBuilder().WithScheme(scheme).Build(),
-				Scheme:             scheme,
-				ExecutionNamespace: "kubernaut-workflows",
-			}
-
-			pr := reconcilerNoSA.BuildPipelineRun(wfe)
-
-			Expect(pr.Spec.TaskRunTemplate.ServiceAccountName).To(BeEmpty(),
-				"DD-WE-005: No SA in WFE spec -> K8s assigns namespace default")
-		})
-	})
-
-	// ========================================
-	// Day 4: ConvertParameters() Tests
-	// ========================================
-
-	Describe("ConvertParameters", func() {
-		var reconciler *workflowexecution.WorkflowExecutionReconciler
-
-		BeforeEach(func() {
-			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
-			reconciler = &workflowexecution.WorkflowExecutionReconciler{
-				Client: fakeClient,
-				Scheme: scheme,
-			}
-		})
-
-		It("should convert map to Tekton params", func() {
-			params := map[string]string{
-				"KEY1": "value1",
-				"KEY2": "value2",
-			}
-
-			tektonParams := reconciler.ConvertParameters(params)
-
-			Expect(tektonParams).To(HaveLen(2))
-
-			paramMap := make(map[string]string)
-			for _, p := range tektonParams {
-				paramMap[p.Name] = p.Value.StringVal
-			}
-
-			Expect(paramMap).To(HaveKeyWithValue("KEY1", "value1"))
-			Expect(paramMap).To(HaveKeyWithValue("KEY2", "value2"))
-		})
-
-		It("should return empty slice for nil params", func() {
-			tektonParams := reconciler.ConvertParameters(nil)
-			Expect(tektonParams).To(BeEmpty())
-		})
-
-		It("should return empty slice for empty map", func() {
-			tektonParams := reconciler.ConvertParameters(map[string]string{})
-			Expect(tektonParams).To(BeEmpty())
-		})
-
-		It("should set param type to string", func() {
-			params := map[string]string{"KEY": "value"}
-			tektonParams := reconciler.ConvertParameters(params)
-
-			Expect(tektonParams[0].Value.Type).To(Equal(tektonv1.ParamTypeString))
-		})
-	})
 
 	// ========================================
 	// Day 4: FindWFEForOwnedResource() Tests
@@ -928,7 +709,7 @@ var _ = Describe("WorkflowExecution Controller", func() {
 
 			pr = &tektonv1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      workflowexecution.PipelineRunName(wfe.Spec.TargetResource),
+					Name:      weexecutor.ExecutionResourceName(wfe.Spec.TargetResource),
 					Namespace: "kubernaut-workflows",
 				},
 				Status: tektonv1.PipelineRunStatus{
@@ -1073,7 +854,7 @@ var _ = Describe("WorkflowExecution Controller", func() {
 
 			pr = &tektonv1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      workflowexecution.PipelineRunName(wfe.Spec.TargetResource),
+					Name:      weexecutor.ExecutionResourceName(wfe.Spec.TargetResource),
 					Namespace: "kubernaut-workflows",
 				},
 			}
@@ -2129,7 +1910,7 @@ var _ = Describe("WorkflowExecution Controller", func() {
 				}
 
 			// And: PipelineRun exists with deterministic name and matching ownership label
-			prName := workflowexecution.PipelineRunName(wfe.Spec.TargetResource)
+			prName := weexecutor.ExecutionResourceName(wfe.Spec.TargetResource)
 			pr := &tektonv1.PipelineRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      prName,
@@ -2289,7 +2070,7 @@ var _ = Describe("WorkflowExecution Controller", func() {
 				Expect(fakeClient.Create(ctx, wfe)).To(Succeed())
 
 				// And: PipelineRun exists with deterministic name (NOT ExecutionRef.Name)
-				prName := workflowexecution.PipelineRunName(wfe.Spec.TargetResource)
+				prName := weexecutor.ExecutionResourceName(wfe.Spec.TargetResource)
 				pr := &tektonv1.PipelineRun{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      prName,
@@ -2331,7 +2112,7 @@ var _ = Describe("WorkflowExecution Controller", func() {
 				Expect(fakeClient.Create(ctx, wfe)).To(Succeed())
 
 				// And: PipelineRun exists (created but ref not set yet)
-				prName := workflowexecution.PipelineRunName(wfe.Spec.TargetResource)
+				prName := weexecutor.ExecutionResourceName(wfe.Spec.TargetResource)
 				pr := &tektonv1.PipelineRun{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      prName,
@@ -2442,7 +2223,7 @@ var _ = Describe("WorkflowExecution Controller", func() {
 				Expect(fakeClient.Create(ctx, wfe)).To(Succeed())
 
 				// And: Active PipelineRun exists
-				prName := workflowexecution.PipelineRunName(wfe.Spec.TargetResource)
+				prName := weexecutor.ExecutionResourceName(wfe.Spec.TargetResource)
 				pr := &tektonv1.PipelineRun{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      prName,
@@ -2616,7 +2397,7 @@ var _ = Describe("WorkflowExecution Controller", func() {
 				// And: PipelineRun completed
 				pr := &tektonv1.PipelineRun{
 					ObjectMeta: metav1.ObjectMeta{
-						Name:      workflowexecution.PipelineRunName(wfe.Spec.TargetResource),
+						Name:      weexecutor.ExecutionResourceName(wfe.Spec.TargetResource),
 						Namespace: "kubernaut-workflows",
 					},
 				}
@@ -5135,163 +4916,6 @@ var _ = Describe("WorkflowExecution Controller", func() {
 
 				// Then: Should succeed (operation is just for logging)
 				Expect(err).ToNot(HaveOccurred())
-			})
-		})
-	})
-
-	// ========================================
-	// P3: sanitizeLabelValue - Edge Cases (Unit Test Plan v1.0.0)
-	// Target: 75.0% → 85%+ coverage
-	// Note: Testing indirectly through BuildPipelineRun (sanitizeLabelValue is private)
-	// ========================================
-
-	Describe("P3: Label Sanitization via BuildPipelineRun - Edge Cases", func() {
-		var (
-			fakeClient client.Client
-			reconciler *workflowexecution.WorkflowExecutionReconciler
-		)
-
-		BeforeEach(func() {
-			fakeClient = fake.NewClientBuilder().
-				WithScheme(scheme).
-				Build()
-
-			reconciler = &workflowexecution.WorkflowExecutionReconciler{
-				Client:             fakeClient,
-				Scheme:             scheme,
-				ExecutionNamespace: "kubernaut-workflows",
-			}
-		})
-
-		Context("CTRL-LABEL-01: Forward slash replacement in target-resource label", func() {
-			It("should replace forward slashes with double underscores in PipelineRun labels", func() {
-				// Given: WFE with target resource containing slashes
-				wfe := &workflowexecutionv1alpha1.WorkflowExecution{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-label-slash",
-						Namespace: "default",
-					},
-					Spec: workflowexecutionv1alpha1.WorkflowExecutionSpec{
-						WorkflowRef: workflowexecutionv1alpha1.WorkflowRef{
-							WorkflowID:     "test-workflow",
-							Version:        "v1",
-							ExecutionBundle: "registry.example.com/workflows/test:v1",
-						},
-						TargetResource: "namespace/deployment/app-name",
-					},
-				}
-
-				// When: BuildPipelineRun is called
-				pr := reconciler.BuildPipelineRun(wfe)
-
-				// Then: Label should have slashes replaced
-				Expect(pr.Labels["kubernaut.ai/target-resource"]).To(Equal("namespace__deployment__app-name"))
-			})
-
-			It("should handle multiple consecutive slashes", func() {
-				// Given: WFE with multiple slashes
-				wfe := &workflowexecutionv1alpha1.WorkflowExecution{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-multiple-slash",
-						Namespace: "default",
-					},
-					Spec: workflowexecutionv1alpha1.WorkflowExecutionSpec{
-						WorkflowRef: workflowexecutionv1alpha1.WorkflowRef{
-							WorkflowID:     "test-workflow",
-							Version:        "v1",
-							ExecutionBundle: "registry.example.com/workflows/test:v1",
-						},
-						TargetResource: "path//to///resource",
-					},
-				}
-
-				// When: BuildPipelineRun is called
-				pr := reconciler.BuildPipelineRun(wfe)
-
-				// Then: Each slash should be replaced
-				Expect(pr.Labels["kubernaut.ai/target-resource"]).To(Equal("path____to______resource"))
-			})
-		})
-
-		Context("CTRL-LABEL-02: Truncation at 63 characters", func() {
-			It("should truncate label value at exactly 63 characters", func() {
-				// Given: WFE with very long target resource (>63 chars after sanitization)
-				longResource := strings.Repeat("a", 64)
-				wfe := &workflowexecutionv1alpha1.WorkflowExecution{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-truncate",
-						Namespace: "default",
-					},
-					Spec: workflowexecutionv1alpha1.WorkflowExecutionSpec{
-						WorkflowRef: workflowexecutionv1alpha1.WorkflowRef{
-							WorkflowID:     "test-workflow",
-							Version:        "v1",
-							ExecutionBundle: "registry.example.com/workflows/test:v1",
-						},
-						TargetResource: longResource,
-					},
-				}
-
-				// When: BuildPipelineRun is called
-				pr := reconciler.BuildPipelineRun(wfe)
-
-				// Then: Label should be truncated to 63 characters
-				labelValue := pr.Labels["kubernaut.ai/target-resource"]
-				Expect(len(labelValue)).To(Equal(63))
-				Expect(labelValue).To(Equal(strings.Repeat("a", 63)))
-			})
-
-			It("should not truncate values under 63 characters", func() {
-				// Given: WFE with target resource exactly 63 chars
-				resource63 := strings.Repeat("b", 63)
-				wfe := &workflowexecutionv1alpha1.WorkflowExecution{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-no-truncate",
-						Namespace: "default",
-					},
-					Spec: workflowexecutionv1alpha1.WorkflowExecutionSpec{
-						WorkflowRef: workflowexecutionv1alpha1.WorkflowRef{
-							WorkflowID:     "test-workflow",
-							Version:        "v1",
-							ExecutionBundle: "registry.example.com/workflows/test:v1",
-						},
-						TargetResource: resource63,
-					},
-				}
-
-				// When: BuildPipelineRun is called
-				pr := reconciler.BuildPipelineRun(wfe)
-
-				// Then: Label should remain unchanged
-				labelValue := pr.Labels["kubernaut.ai/target-resource"]
-				Expect(len(labelValue)).To(Equal(63))
-				Expect(labelValue).To(Equal(resource63))
-			})
-		})
-
-		Context("CTRL-LABEL-03: Edge case combinations", func() {
-			It("should handle target resource with only slashes", func() {
-				// Given: WFE with target resource of only slashes
-				wfe := &workflowexecutionv1alpha1.WorkflowExecution{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      "test-only-slashes",
-						Namespace: "default",
-					},
-					Spec: workflowexecutionv1alpha1.WorkflowExecutionSpec{
-						WorkflowRef: workflowexecutionv1alpha1.WorkflowRef{
-							WorkflowID:     "test-workflow",
-							Version:        "v1",
-							ExecutionBundle: "registry.example.com/workflows/test:v1",
-						},
-						TargetResource: "///",
-					},
-				}
-
-				// When: BuildPipelineRun is called
-				pr := reconciler.BuildPipelineRun(wfe)
-
-				// Then: Label should be all underscores
-				Expect(pr.Labels["kubernaut.ai/target-resource"]).To(Equal("______"))
 			})
 		})
 	})

--- a/test/unit/workflowexecution/executor_sa_test.go
+++ b/test/unit/workflowexecution/executor_sa_test.go
@@ -25,13 +25,13 @@ import (
 )
 
 // ========================================
-// PER-WORKFLOW SA SPEC-LEVEL TESTS (#501)
+// PER-WORKFLOW SA STATUS-LEVEL TESTS (#650)
 // ========================================
-// Authority: DD-WE-005 v2.0, Issue #501
-// Issue #501: ServiceAccountName moved from ExecutionConfig to Spec top level.
+// Authority: DD-WE-005 v2.0, Issue #650
+// Issue #650: ServiceAccountName resolved from DS catalog into WFE Status at runtime.
 // ========================================
 
-var _ = Describe("Per-Workflow ServiceAccount Spec Tests [DD-WE-005] (#501)", func() {
+var _ = Describe("Per-Workflow ServiceAccount Status Tests [DD-WE-005] (#650)", func() {
 
 	buildWFE := func(saName string) *workflowexecutionv1alpha1.WorkflowExecution {
 		wfe := &workflowexecutionv1alpha1.WorkflowExecution{
@@ -40,27 +40,29 @@ var _ = Describe("Per-Workflow ServiceAccount Spec Tests [DD-WE-005] (#501)", fu
 				Namespace: "kubernaut-workflows",
 			},
 			Spec: workflowexecutionv1alpha1.WorkflowExecutionSpec{
-				ServiceAccountName: saName,
 				WorkflowRef: workflowexecutionv1alpha1.WorkflowRef{
 					WorkflowID:      "wf-123",
 					ExecutionBundle: "quay.io/test:v1@sha256:abc123",
 				},
 				TargetResource: "default/Deployment/nginx",
 			},
+			Status: workflowexecutionv1alpha1.WorkflowExecutionStatus{
+				ServiceAccountName: saName,
+			},
 		}
 		return wfe
 	}
 
-	Context("Spec.ServiceAccountName (top-level, engine-agnostic)", func() {
+	Context("Status.ServiceAccountName (resolved from DS, engine-agnostic)", func() {
 
-		It("UT-WE-501-001: should read SA directly from Spec.ServiceAccountName", func() {
+		It("UT-WE-501-001: should read SA directly from Status.ServiceAccountName", func() {
 			wfe := buildWFE("custom-sa")
-			Expect(wfe.Spec.ServiceAccountName).To(Equal("custom-sa"))
+			Expect(wfe.Status.ServiceAccountName).To(Equal("custom-sa"))
 		})
 
 		It("UT-WE-501-002: should be empty string when no SA is specified", func() {
 			wfe := buildWFE("")
-			Expect(wfe.Spec.ServiceAccountName).To(Equal(""))
+			Expect(wfe.Status.ServiceAccountName).To(Equal(""))
 		})
 
 		It("UT-WE-501-003: should be independent of ExecutionConfig", func() {
@@ -68,8 +70,8 @@ var _ = Describe("Per-Workflow ServiceAccount Spec Tests [DD-WE-005] (#501)", fu
 			wfe.Spec.ExecutionConfig = &workflowexecutionv1alpha1.ExecutionConfig{
 				Timeout: &metav1.Duration{Duration: 30 * 60e9},
 			}
-			Expect(wfe.Spec.ServiceAccountName).To(Equal("top-level-sa"),
-				"SA should be at spec level, not inside ExecutionConfig")
+			Expect(wfe.Status.ServiceAccountName).To(Equal("top-level-sa"),
+				"SA should be at status level (resolved from DS), not inside ExecutionConfig")
 		})
 	})
 })

--- a/test/unit/workflowexecution/workflow_querier_test.go
+++ b/test/unit/workflowexecution/workflow_querier_test.go
@@ -225,6 +225,114 @@ var _ = Describe("OgenWorkflowQuerier (DD-WE-006)", func() {
 	})
 
 	// ========================================
+	// Issue #658: Error classification — distinguish 404 vs 500 vs unexpected
+	// ========================================
+	Context("Error classification (Issue #658)", func() {
+		It("UT-WE-658-001: ResolveWorkflowCatalogMetadata should classify DS 500 as server error, not 'not found'", func() {
+			mock := &mockWorkflowCatalogClient{
+				response: &ogenclient.GetWorkflowByIDInternalServerError{},
+			}
+			querier := weclient.NewOgenWorkflowQuerier(mock)
+
+			_, err := querier.ResolveWorkflowCatalogMetadata(ctx, uuid.New().String())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).ToNot(ContainSubstring("not found"),
+				"DS 500 must not be misclassified as 'not found'")
+			Expect(err.Error()).To(SatisfyAny(
+				ContainSubstring("server error"),
+				ContainSubstring("internal server error"),
+				ContainSubstring("500"),
+			), "error should indicate a Data Storage server failure")
+		})
+
+		It("UT-WE-658-002: ResolveWorkflowCatalogMetadata should classify DS 404 as 'not found'", func() {
+			mock := &mockWorkflowCatalogClient{
+				response: &ogenclient.GetWorkflowByIDNotFound{},
+			}
+			querier := weclient.NewOgenWorkflowQuerier(mock)
+
+			_, err := querier.ResolveWorkflowCatalogMetadata(ctx, uuid.New().String())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+
+		It("UT-WE-658-003: GetWorkflowExecutionEngine should classify DS 500 as server error", func() {
+			mock := &mockWorkflowCatalogClient{
+				response: &ogenclient.GetWorkflowByIDInternalServerError{},
+			}
+			querier := weclient.NewOgenWorkflowQuerier(mock)
+
+			_, _, err := querier.GetWorkflowExecutionEngine(ctx, uuid.New().String())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).ToNot(ContainSubstring("not found"))
+			Expect(err.Error()).To(SatisfyAny(
+				ContainSubstring("server error"),
+				ContainSubstring("internal server error"),
+				ContainSubstring("500"),
+			))
+		})
+
+		It("UT-WE-658-004: GetWorkflowExecutionBundle should classify DS 500 as server error", func() {
+			mock := &mockWorkflowCatalogClient{
+				response: &ogenclient.GetWorkflowByIDInternalServerError{},
+			}
+			querier := weclient.NewOgenWorkflowQuerier(mock)
+
+			_, _, err := querier.GetWorkflowExecutionBundle(ctx, uuid.New().String())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).ToNot(ContainSubstring("not found"))
+			Expect(err.Error()).To(SatisfyAny(
+				ContainSubstring("server error"),
+				ContainSubstring("internal server error"),
+				ContainSubstring("500"),
+			))
+		})
+
+		It("UT-WE-658-005: GetWorkflowDependencies should classify DS 500 as server error", func() {
+			mock := &mockWorkflowCatalogClient{
+				response: &ogenclient.GetWorkflowByIDInternalServerError{},
+			}
+			querier := weclient.NewOgenWorkflowQuerier(mock)
+
+			_, err := querier.GetWorkflowDependencies(ctx, uuid.New().String())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).ToNot(ContainSubstring("not found"))
+			Expect(err.Error()).To(SatisfyAny(
+				ContainSubstring("server error"),
+				ContainSubstring("internal server error"),
+				ContainSubstring("500"),
+			))
+		})
+
+		It("UT-WE-658-006: GetWorkflowEngineConfig should classify DS 500 as server error", func() {
+			mock := &mockWorkflowCatalogClient{
+				response: &ogenclient.GetWorkflowByIDInternalServerError{},
+			}
+			querier := weclient.NewOgenWorkflowQuerier(mock)
+
+			_, err := querier.GetWorkflowEngineConfig(ctx, uuid.New().String())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).ToNot(ContainSubstring("not found"))
+			Expect(err.Error()).To(SatisfyAny(
+				ContainSubstring("server error"),
+				ContainSubstring("internal server error"),
+				ContainSubstring("500"),
+			))
+		})
+
+		It("UT-WE-658-007: 404 regression guard — type switch still classifies correctly", func() {
+			mock := &mockWorkflowCatalogClient{
+				response: &ogenclient.GetWorkflowByIDNotFound{},
+			}
+			querier := weclient.NewOgenWorkflowQuerier(mock)
+
+			_, err := querier.GetWorkflowDependencies(ctx, uuid.New().String())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+	})
+
+	// ========================================
 	// Issue #650: Consolidated querier — single DS call for all metadata
 	// ========================================
 	Context("ResolveWorkflowCatalogMetadata (Issue #650)", func() {

--- a/test/unit/workflowexecution/workflow_querier_test.go
+++ b/test/unit/workflowexecution/workflow_querier_test.go
@@ -223,4 +223,83 @@ var _ = Describe("OgenWorkflowQuerier (DD-WE-006)", func() {
 			Expect(err.Error()).To(ContainSubstring("DS query failed"))
 		})
 	})
+
+	// ========================================
+	// Issue #650: Consolidated querier — single DS call for all metadata
+	// ========================================
+	Context("ResolveWorkflowCatalogMetadata (Issue #650)", func() {
+		It("UT-WE-650-003: should return all metadata from single DS call", func() {
+			content := buildTestSchema(&models.WorkflowDependencies{
+				Secrets: []models.ResourceDependency{{Name: "my-secret"}},
+			})
+			mock := &mockWorkflowCatalogClient{
+				response: &ogenclient.RemediationWorkflow{
+					ExecutionEngine:       "tekton",
+					WorkflowName:          "cert-renewal",
+					ExecutionBundle:       ogenclient.NewOptString("ghcr.io/test/exec:v1"),
+					ExecutionBundleDigest: ogenclient.NewOptString("sha256:abc123"),
+					ServiceAccountName:    ogenclient.NewOptString("workflow-sa"),
+					Content:               content,
+				},
+			}
+			querier := weclient.NewOgenWorkflowQuerier(mock)
+
+			meta, err := querier.ResolveWorkflowCatalogMetadata(ctx, uuid.New().String())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(meta.ExecutionEngine).To(Equal("tekton"))
+			Expect(meta.WorkflowName).To(Equal("cert-renewal"))
+			Expect(meta.ExecutionBundle).To(Equal("ghcr.io/test/exec:v1"))
+			Expect(meta.ExecutionBundleDigest).To(Equal("sha256:abc123"))
+			Expect(meta.ServiceAccountName).To(Equal("workflow-sa"))
+			Expect(meta.Dependencies.Secrets).To(HaveLen(1))
+			Expect(meta.Dependencies.Secrets[0].Name).To(Equal("my-secret"))
+		})
+
+		It("UT-WE-650-002: should return empty SA when catalog entry has no SA", func() {
+			content := buildTestSchema(nil)
+			mock := &mockWorkflowCatalogClient{
+				response: &ogenclient.RemediationWorkflow{
+					ExecutionEngine: "job",
+					WorkflowName:    "restart-pod",
+					Content:         content,
+				},
+			}
+			querier := weclient.NewOgenWorkflowQuerier(mock)
+
+			meta, err := querier.ResolveWorkflowCatalogMetadata(ctx, uuid.New().String())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(meta.ServiceAccountName).To(BeEmpty())
+			Expect(meta.ExecutionEngine).To(Equal("job"))
+		})
+
+		It("UT-WE-650-004: should return error when DS is unreachable", func() {
+			mock := &mockWorkflowCatalogClient{
+				err: fmt.Errorf("connection refused"),
+			}
+			querier := weclient.NewOgenWorkflowQuerier(mock)
+
+			_, err := querier.ResolveWorkflowCatalogMetadata(ctx, uuid.New().String())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("DS query failed"))
+		})
+
+		It("UT-WE-650-010: should extract dependencies and engineConfig from Content", func() {
+			content := buildTestSchema(&models.WorkflowDependencies{
+				Secrets:    []models.ResourceDependency{{Name: "secret-a"}},
+				ConfigMaps: []models.ResourceDependency{{Name: "config-b"}},
+			})
+			mock := &mockWorkflowCatalogClient{
+				response: &ogenclient.RemediationWorkflow{
+					ExecutionEngine: "tekton",
+					Content:         content,
+				},
+			}
+			querier := weclient.NewOgenWorkflowQuerier(mock)
+
+			meta, err := querier.ResolveWorkflowCatalogMetadata(ctx, uuid.New().String())
+			Expect(err).ToNot(HaveOccurred())
+			Expect(meta.Dependencies.Secrets).To(HaveLen(1))
+			Expect(meta.Dependencies.ConfigMaps).To(HaveLen(1))
+		})
+	})
 })


### PR DESCRIPTION
## Summary

Continues v1.3 milestone work from PR #510 (Part 1), which delivered the Kubernaut Agent Go rewrite, Mock LLM service, LLM auth headers, and numerous bug fixes across all controllers.

Issues closed during triage (already addressed or won't-fix): #433, #508, #509, #532, #578, #237, #617.

This PR delivers **11 issues** from the v1.3 milestone. The remaining 5 L-complexity issues have test plans committed and will be addressed in Part 3.

---

## Completed

| Issue | Title | Commits |
|-------|-------|---------|
| #651 | Remove workflow-schema.yaml wording from RemediationWorkflowSpec CRD description | `0afb9d0` |
| #597 | Fix route fanout Continue flag in notification routing (BR-NOT-068) | `954800c`, `18a53fe` |
| #236 | Migrate EM DataStorageQuerier to ogen OpenAPI client (DD-API-001) | `41c3e7b`, `313a9cb` |
| — | fix(authwebhook): use RetryOnConflict for AT status update in RW finalizer (E2E flake fix) | `6916022` |
| #650 | Simplify SA propagation — resolve serviceAccountName at WE execution time from DS | `6e6f7cd`, `2d30f28`, `62a8321`, `0f3fcfa`, `5b46855` |
| #658 | WorkflowQuerier: classify DS error responses correctly (HTTP 500 vs 404) | `94df495` |
| #659 | WE Controller: emit events for validation-class failures (SOC2 observability) | `3428690` |
| #628 | Standardize **Status** field across all 7 notification body types | `505a3c1` |

---

## Test Plans Committed (Deferred to Part 3)

Test plans for the following issues are committed in `docs/tests/` but execution is deferred to a Part 3 PR to keep this PR at a reviewable size.

| Issue | Title | Complexity | Test Plan |
|-------|-------|------------|-----------|
| #189 | RO: Distributed locking for WE creation (Lease-based) | L | `docs/tests/189/TEST_PLAN.md` |
| #254 | Decompose EM reconciler from 1.9k lines to <500 | L | `docs/tests/254/TEST_PLAN.md` |
| #235 + #620 | Partition automation for audit_events and resource_action_traces | L | `docs/tests/235/TEST_PLAN.md` |
| #485 | Audit event retention enforcement (expired event deletion) | L | `docs/tests/485/TEST_PLAN.md` |
| #239 | E2E FullPipeline: deploy via Helm chart instead of programmatic manifests | L | `docs/tests/239/TEST_PLAN.md` |

---

## Not In Scope (XL — separate PRs)

| Issue | Title | Complexity |
|-------|-------|-----------|
| #416 | Label-based notification routing for signal and RCA target owners | XL |
| #493 | Enable TLS for all inter-pod HTTP communication | XL |
| #264 | Fix documentation-to-code inconsistencies (60+ items) | XL |

---

## Test Plan

- [x] All unit tests pass
- [x] All integration tests pass
- [x] All E2E tests pass
- [x] Helm smoke tests pass