### PR TITLE
fix(release): add kubernautagent to Makefile IMAGE_SERVICES

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -915,7 +915,7 @@ BUILD_DATE  ?= $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 LDFLAGS ?= -ldflags "-X github.com/jordigilh/kubernaut/internal/version.Version=$(APP_VERSION) -X github.com/jordigilh/kubernaut/internal/version.GitCommit=$(GIT_COMMIT) -X github.com/jordigilh/kubernaut/internal/version.BuildDate=$(BUILD_DATE)"
 
 # All Go services with their Dockerfile mappings
-IMAGE_SERVICES := datastorage gateway aianalysis authwebhook notification remediationorchestrator signalprocessing workflowexecution effectivenessmonitor db-migrate
+IMAGE_SERVICES := datastorage gateway aianalysis authwebhook notification remediationorchestrator signalprocessing workflowexecution effectivenessmonitor kubernautagent db-migrate
 IMAGE_DOCKERFILES_datastorage := docker/data-storage.Dockerfile
 IMAGE_DOCKERFILES_gateway := docker/gateway.Dockerfile
 IMAGE_DOCKERFILES_aianalysis := docker/aianalysis.Dockerfile
@@ -925,6 +925,7 @@ IMAGE_DOCKERFILES_remediationorchestrator := docker/remediationorchestrator-cont
 IMAGE_DOCKERFILES_signalprocessing := docker/signalprocessing-controller.Dockerfile
 IMAGE_DOCKERFILES_workflowexecution := docker/workflowexecution-controller.Dockerfile
 IMAGE_DOCKERFILES_effectivenessmonitor := docker/effectivenessmonitor-controller.Dockerfile
+IMAGE_DOCKERFILES_kubernautagent := docker/kubernautagent.Dockerfile
 IMAGE_DOCKERFILES_db-migrate := docker/db-migrate.Dockerfile
 
 # IMAGE_TARGET: Dockerfile --target stage to build. Empty = last stage (development).


### PR DESCRIPTION
## Summary
- Add `kubernautagent` to `IMAGE_SERVICES` in the Makefile
- Add `IMAGE_DOCKERFILES_kubernautagent` mapping to `docker/kubernautagent.Dockerfile`

The v1.3.0-rc1 release build failed because `make image-build-kubernautagent` could not find the service. The CI pipeline has the mapping inline in `ci-pipeline.yml`, but the release workflow delegates to the Makefile which was missing the entry.

Fixes the kubernautagent arm64 build failure in https://github.com/jordigilh/kubernaut/actions/runs/24291233927/job/70928848612

## Test plan
- [x] `make image-build-kubernautagent --dry-run` resolves the correct Dockerfile

Made with [Cursor](https://cursor.com)