### PR TITLE
fix(ro): resolve workflow display name from DataStorage instead of CRD (#643)

### DIFF
--- a/cmd/remediationorchestrator/main.go
+++ b/cmd/remediationorchestrator/main.go
@@ -306,6 +306,15 @@ func main() {
 		routingEngine, // DD-RO-002: Routing engine built from YAML config
 		eaCreator,     // ADR-EM-001: EA creation on terminal phases
 	)
+	// Issue #643 v2: Wire DS-backed workflow display resolver.
+	dsWorkflowAdapter, err := routing.NewDSWorkflowAdapterFromConfig(cfg.DataStorage.URL, cfg.DataStorage.Timeout)
+	if err != nil {
+		setupLog.Error(err, "Failed to create DataStorage workflow adapter",
+			"url", cfg.DataStorage.URL)
+		os.Exit(1)
+	}
+	roReconciler.SetWorkflowResolver(dsWorkflowAdapter)
+
 	// DD-EM-002: Set REST mapper for pre-remediation hash Kind resolution
 	roReconciler.SetRESTMapper(mgr.GetRESTMapper())
 	// DD-EM-004 v2.0, Issue #253: Wire config-driven async propagation delays

--- a/internal/controller/remediationorchestrator/reconciler.go
+++ b/internal/controller/remediationorchestrator/reconciler.go
@@ -52,7 +52,6 @@ import (
 	eav1 "github.com/jordigilh/kubernaut/api/effectivenessassessment/v1alpha1"
 	notificationv1 "github.com/jordigilh/kubernaut/api/notification/v1alpha1"
 	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
-	remediationworkflowv1 "github.com/jordigilh/kubernaut/api/remediationworkflow/v1alpha1"
 	signalprocessingv1 "github.com/jordigilh/kubernaut/api/signalprocessing/v1alpha1"
 	workflowexecutionv1 "github.com/jordigilh/kubernaut/api/workflowexecution/v1alpha1"
 	"github.com/jordigilh/kubernaut/pkg/audit"
@@ -126,6 +125,11 @@ type Reconciler struct {
 	// Used by createEffectivenessAssessmentIfNeeded to compute HashComputeDelay
 	// from gitOpsSyncDelay/operatorReconcileDelay instead of stabilization window.
 	asyncPropagation roconfig.AsyncPropagationConfig
+
+	// Issue #643 v2: DS-backed workflow display resolver.
+	// Resolves workflow UUID → human-readable WorkflowName + ActionType from DataStorage.
+	// nil = graceful degradation (UUID shown as-is in printer columns).
+	workflowResolver routing.WorkflowDisplayResolver
 
 	// BR-ORCH-025: Distributed lock manager for WFE creation safety.
 	// Prevents duplicate WFEs when concurrent reconciles target the same resource.
@@ -272,6 +276,13 @@ func NewReconciler(c client.Client, apiReader client.Reader, s *runtime.Scheme, 
 	r.weHandler = handler.NewWorkflowExecutionHandler(c, s, m, r.transitionToFailed, r.transitionToVerifying)
 
 	return r
+}
+
+// SetWorkflowResolver wires the DS-backed workflow display resolver.
+// Must be called after NewReconciler in production (cmd/remediationorchestrator/main.go).
+// nil is safe — resolveWorkflowDisplay falls back to the raw UUID.
+func (r *Reconciler) SetWorkflowResolver(resolver routing.WorkflowDisplayResolver) {
+	r.workflowResolver = resolver
 }
 
 // SetDSClient wires the DataStorage history querier into the routing engine.
@@ -1130,13 +1141,11 @@ func (r *Reconciler) handleAnalyzingPhase(ctx context.Context, rr *remediationv1
 		// BR-ORCH-044: Track child CRD creation
 		r.Metrics.ChildCRDCreationsTotal.WithLabelValues("WorkflowExecution", rr.Namespace).Inc()
 
-		// Issue #643: Resolve workflow UUID outside the retry callback — the name
-		// is immutable between retries and the API call should not repeat on conflicts.
+		// Issue #643 v2: Resolve workflow UUID to human-readable name via DS.
 		var workflowDisplayName, confidence string
 		if ai.Status.SelectedWorkflow != nil {
-			workflowName := r.resolveWorkflowName(ctx, ai.Status.SelectedWorkflow.WorkflowID)
-			workflowDisplayName = remediationrequest.FormatWorkflowDisplay(
-				ai.Status.SelectedWorkflow.ActionType, workflowName)
+			actionType, workflowName := r.resolveWorkflowDisplay(ctx, ai.Status.SelectedWorkflow.WorkflowID)
+			workflowDisplayName = remediationrequest.FormatWorkflowDisplay(actionType, workflowName)
 			confidence = remediationrequest.FormatConfidence(ai.Status.SelectedWorkflow.Confidence)
 		}
 
@@ -1380,12 +1389,11 @@ func (r *Reconciler) handleAwaitingApprovalPhase(ctx context.Context, rr *remedi
 		// BR-ORCH-044: Track child CRD creation
 		r.Metrics.ChildCRDCreationsTotal.WithLabelValues("WorkflowExecution", rr.Namespace).Inc()
 
-		// Issue #643: Resolve workflow UUID outside the retry callback.
+		// Issue #643 v2: Resolve workflow UUID to human-readable name via DS.
 		var workflowDisplayName2, confidence2 string
 		if ai.Status.SelectedWorkflow != nil {
-			workflowName := r.resolveWorkflowName(ctx, ai.Status.SelectedWorkflow.WorkflowID)
-			workflowDisplayName2 = remediationrequest.FormatWorkflowDisplay(
-				ai.Status.SelectedWorkflow.ActionType, workflowName)
+			actionType, workflowName := r.resolveWorkflowDisplay(ctx, ai.Status.SelectedWorkflow.WorkflowID)
+			workflowDisplayName2 = remediationrequest.FormatWorkflowDisplay(actionType, workflowName)
 			confidence2 = remediationrequest.FormatConfidence(ai.Status.SelectedWorkflow.Confidence)
 		}
 
@@ -2935,25 +2943,18 @@ func (r *Reconciler) emitTimeoutAudit(ctx context.Context, rr *remediationv1.Rem
 	}
 }
 
-// resolveWorkflowName resolves a workflow UUID to its CRD metadata.name by
-// listing RemediationWorkflow CRDs. Returns the UUID unchanged if no match is
-// found (graceful degradation — the display is still usable, just not ideal).
-// Issue #643: workflowDisplayName should show the human-readable CRD name.
-// Uses apiReader (direct API call) instead of r.client (cached) because
-// RemediationWorkflow is not in the controller's watch list — a cached List
-// would trigger an on-demand informer sync that blocks the reconcile loop.
-func (r *Reconciler) resolveWorkflowName(ctx context.Context, workflowID string) string {
-	var rwList remediationworkflowv1.RemediationWorkflowList
-	if err := r.apiReader.List(ctx, &rwList); err != nil {
-		log.FromContext(ctx).V(1).Info("Failed to list RemediationWorkflows for display name resolution", "error", err)
-		return workflowID
-	}
-	for i := range rwList.Items {
-		if rwList.Items[i].Status.WorkflowID == workflowID {
-			return rwList.Items[i].Name
+// resolveWorkflowDisplay resolves a workflow UUID to human-readable display
+// fields (WorkflowName + ActionType) by querying DataStorage.
+// Returns (actionType, workflowName) for use with FormatWorkflowDisplay.
+// Falls back to ("", workflowID) if the resolver is nil or DS lookup fails.
+// Issue #643 v2: Replaced CRD-based resolution with authoritative DS lookup.
+func (r *Reconciler) resolveWorkflowDisplay(ctx context.Context, workflowID string) (string, string) {
+	if r.workflowResolver != nil {
+		if info := r.workflowResolver.ResolveWorkflowDisplay(ctx, workflowID); info != nil {
+			return info.ActionType, info.WorkflowName
 		}
 	}
-	return workflowID
+	return "", workflowID
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/remediationorchestrator/routing/ds_workflow_adapter.go
+++ b/pkg/remediationorchestrator/routing/ds_workflow_adapter.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routing
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/google/uuid"
+	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+	"github.com/jordigilh/kubernaut/pkg/shared/auth"
+	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
+)
+
+// WorkflowDisplayInfo holds the resolved human-readable workflow metadata
+// needed for the RR printer column display.
+type WorkflowDisplayInfo struct {
+	WorkflowName string
+	ActionType   string
+}
+
+// WorkflowCatalogClient is a narrow interface for resolving workflow metadata
+// from DataStorage. Satisfied by *ogenclient.Client.
+type WorkflowCatalogClient interface {
+	GetWorkflowByID(
+		ctx context.Context,
+		params ogenclient.GetWorkflowByIDParams,
+	) (ogenclient.GetWorkflowByIDRes, error)
+}
+
+// WorkflowDisplayResolver resolves a workflow UUID to human-readable display
+// metadata (WorkflowName + ActionType) by querying DataStorage.
+// Returns nil on any failure (graceful degradation — caller falls back to UUID).
+type WorkflowDisplayResolver interface {
+	ResolveWorkflowDisplay(ctx context.Context, workflowID string) *WorkflowDisplayInfo
+}
+
+// DSWorkflowAdapter adapts the ogen-generated DataStorage client to the
+// WorkflowDisplayResolver interface used by the RO reconciler.
+type DSWorkflowAdapter struct {
+	client WorkflowCatalogClient
+}
+
+var _ WorkflowDisplayResolver = (*DSWorkflowAdapter)(nil)
+
+// NewDSWorkflowAdapter creates a new adapter wrapping the given DS client.
+func NewDSWorkflowAdapter(client WorkflowCatalogClient) *DSWorkflowAdapter {
+	if client == nil {
+		panic("DSWorkflowAdapter: client must not be nil")
+	}
+	return &DSWorkflowAdapter{client: client}
+}
+
+// NewDSWorkflowAdapterFromConfig creates a DSWorkflowAdapter with a standalone
+// ogen client configured from the DataStorage URL and timeout.
+// Follows the same pattern as NewDSHistoryAdapterFromConfig.
+func NewDSWorkflowAdapterFromConfig(baseURL string, timeout time.Duration) (*DSWorkflowAdapter, error) {
+	if baseURL == "" {
+		return nil, fmt.Errorf("DataStorage base URL cannot be empty")
+	}
+	if timeout <= 0 {
+		timeout = 5 * time.Second
+	}
+
+	baseTransport, err := sharedtls.DefaultBaseTransport()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create base transport: %w", err)
+	}
+	transport := auth.NewServiceAccountTransportWithBase(baseTransport)
+
+	ogenClient, err := ogenclient.NewClient(baseURL, ogenclient.WithClient(&http.Client{
+		Timeout:   timeout,
+		Transport: transport,
+	}))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create ogen client for DS workflow catalog: %w", err)
+	}
+
+	return &DSWorkflowAdapter{client: ogenClient}, nil
+}
+
+// ResolveWorkflowDisplay queries DataStorage for the workflow matching the
+// given UUID and returns its WorkflowName + ActionType.
+// Returns nil if the UUID is invalid, the workflow is not found, or DS is unreachable.
+func (a *DSWorkflowAdapter) ResolveWorkflowDisplay(ctx context.Context, workflowID string) *WorkflowDisplayInfo {
+	uid, err := uuid.Parse(workflowID)
+	if err != nil {
+		return nil
+	}
+
+	res, err := a.client.GetWorkflowByID(ctx, ogenclient.GetWorkflowByIDParams{
+		WorkflowID: uid,
+	})
+	if err != nil {
+		return nil
+	}
+
+	wf, ok := res.(*ogenclient.RemediationWorkflow)
+	if !ok {
+		return nil
+	}
+
+	return &WorkflowDisplayInfo{
+		WorkflowName: wf.WorkflowName,
+		ActionType:   wf.ActionType,
+	}
+}

--- a/test/unit/remediationorchestrator/controller/test_helpers.go
+++ b/test/unit/remediationorchestrator/controller/test_helpers.go
@@ -86,6 +86,18 @@ func (m *MockRoutingEngine) CalculateExponentialBackoff(consecutiveFailures int3
 	return time.Duration(consecutiveFailures) * time.Minute
 }
 
+// MockWorkflowResolver implements routing.WorkflowDisplayResolver for unit tests.
+type MockWorkflowResolver struct {
+	Responses map[string]*routing.WorkflowDisplayInfo
+}
+
+func (m *MockWorkflowResolver) ResolveWorkflowDisplay(_ context.Context, workflowID string) *routing.WorkflowDisplayInfo {
+	if m == nil || m.Responses == nil {
+		return nil
+	}
+	return m.Responses[workflowID]
+}
+
 // ptr is a helper to get pointer to bool
 func ptr(b bool) *bool {
 	return &b

--- a/test/unit/remediationorchestrator/controller/workflow_name_resolution_test.go
+++ b/test/unit/remediationorchestrator/controller/workflow_name_resolution_test.go
@@ -21,7 +21,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -29,35 +28,25 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
-	remediationworkflowv1 "github.com/jordigilh/kubernaut/api/remediationworkflow/v1alpha1"
 	prodcontroller "github.com/jordigilh/kubernaut/internal/controller/remediationorchestrator"
 	rometrics "github.com/jordigilh/kubernaut/pkg/remediationorchestrator/metrics"
+	"github.com/jordigilh/kubernaut/pkg/remediationorchestrator/routing"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
-// Issue #643 regression: resolveWorkflowName must resolve UUID → CRD name.
-// The root cause was a missing remediationworkflowv1.AddToScheme(scheme) in
-// cmd/remediationorchestrator/main.go, which caused client.List to silently
-// return empty results and fall back to the UUID.
-var _ = Describe("Issue #643: Workflow Name Resolution", func() {
+// Issue #643 v2: WorkflowDisplayName must be resolved from DataStorage,
+// not from RemediationWorkflow CRD status. DS is the authoritative source
+// and remains available even when the CRD is deleted.
+var _ = Describe("Issue #643 v2: Workflow Name Resolution via DataStorage", func() {
 	const (
-		workflowUUID    = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
-		workflowCRDName = "crashloop-rollback-v1"
+		workflowUUID = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+		workflowName = "crashloop-rollback-v1"
+		actionType   = "RestartPod"
 	)
 
-	It("UT-RO-643-001: should resolve workflow UUID to CRD name when RemediationWorkflow exists", func() {
+	It("UT-RO-643-001: should resolve workflow UUID to ActionType:WorkflowName from DS", func() {
 		ctx := context.Background()
 		scheme := setupScheme()
-
-		rw := &remediationworkflowv1.RemediationWorkflow{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      workflowCRDName,
-				Namespace: "default",
-			},
-			Status: remediationworkflowv1.RemediationWorkflowStatus{
-				WorkflowID: workflowUUID,
-			},
-		}
 
 		rr := newRemediationRequestWithChildRefs(
 			"test-rr-643", "default", remediationv1.PhaseAnalyzing,
@@ -67,7 +56,7 @@ var _ = Describe("Issue #643: Workflow Name Resolution", func() {
 
 		fakeClient := fake.NewClientBuilder().
 			WithScheme(scheme).
-			WithObjects(rr, ai, sp, rw).
+			WithObjects(rr, ai, sp).
 			WithStatusSubresource(&remediationv1.RemediationRequest{}).
 			Build()
 
@@ -77,6 +66,15 @@ var _ = Describe("Issue #643: Workflow Name Resolution", func() {
 			nil, recorder,
 			rometrics.NewMetricsWithRegistry(prometheus.NewRegistry()),
 			prodcontroller.TimeoutConfig{}, &MockRoutingEngine{})
+
+		reconciler.SetWorkflowResolver(&MockWorkflowResolver{
+			Responses: map[string]*routing.WorkflowDisplayInfo{
+				workflowUUID: {
+					WorkflowName: workflowName,
+					ActionType:   actionType,
+				},
+			},
+		})
 
 		_, err := reconciler.Reconcile(ctx, ctrl.Request{
 			NamespacedName: types.NamespacedName{Name: "test-rr-643", Namespace: "default"},
@@ -88,14 +86,14 @@ var _ = Describe("Issue #643: Workflow Name Resolution", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		Expect(updatedRR.Status.WorkflowDisplayName).To(
-			ContainSubstring(workflowCRDName),
-			"WorkflowDisplayName should contain the CRD name, not the UUID")
+			Equal(actionType+":"+workflowName),
+			"WorkflowDisplayName should be ActionType:WorkflowName from DS")
 		Expect(updatedRR.Status.WorkflowDisplayName).NotTo(
 			ContainSubstring(workflowUUID),
 			"WorkflowDisplayName should NOT contain the raw UUID")
 	})
 
-	It("UT-RO-643-002: should fall back to UUID when no matching RemediationWorkflow exists", func() {
+	It("UT-RO-643-002: should fall back to UUID when DS returns no match", func() {
 		ctx := context.Background()
 		scheme := setupScheme()
 
@@ -118,6 +116,10 @@ var _ = Describe("Issue #643: Workflow Name Resolution", func() {
 			rometrics.NewMetricsWithRegistry(prometheus.NewRegistry()),
 			prodcontroller.TimeoutConfig{}, &MockRoutingEngine{})
 
+		reconciler.SetWorkflowResolver(&MockWorkflowResolver{
+			Responses: map[string]*routing.WorkflowDisplayInfo{},
+		})
+
 		_, err := reconciler.Reconcile(ctx, ctrl.Request{
 			NamespacedName: types.NamespacedName{Name: "test-rr-643b", Namespace: "default"},
 		})
@@ -129,14 +131,44 @@ var _ = Describe("Issue #643: Workflow Name Resolution", func() {
 
 		Expect(updatedRR.Status.WorkflowDisplayName).To(
 			ContainSubstring(workflowUUID),
-			"WorkflowDisplayName should fall back to UUID when no CRD match exists")
+			"WorkflowDisplayName should fall back to UUID when DS has no match")
 	})
 
-	It("UT-RO-643-003: scheme must include RemediationWorkflow types", func() {
+	It("UT-RO-643-003: should fall back to UUID when resolver is nil (graceful degradation)", func() {
+		ctx := context.Background()
 		scheme := setupScheme()
-		gvk := remediationworkflowv1.GroupVersion.WithKind("RemediationWorkflow")
-		recognized := scheme.Recognizes(gvk)
-		Expect(recognized).To(BeTrue(),
-			"Test scheme must recognize RemediationWorkflow GVK — mirrors cmd/remediationorchestrator/main.go init()")
+
+		rr := newRemediationRequestWithChildRefs(
+			"test-rr-643c", "default", remediationv1.PhaseAnalyzing,
+			"sp-test-rr-643c", "ai-test-rr-643c", "")
+		ai := newAIAnalysisCompleted("ai-test-rr-643c", "default", "test-rr-643c", 0.95, workflowUUID)
+		sp := newSignalProcessingCompleted("sp-test-rr-643c", "default", "test-rr-643c")
+
+		fakeClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithObjects(rr, ai, sp).
+			WithStatusSubresource(&remediationv1.RemediationRequest{}).
+			Build()
+
+		recorder := record.NewFakeRecorder(20)
+		reconciler := prodcontroller.NewReconciler(
+			fakeClient, fakeClient, scheme,
+			nil, recorder,
+			rometrics.NewMetricsWithRegistry(prometheus.NewRegistry()),
+			prodcontroller.TimeoutConfig{}, &MockRoutingEngine{})
+		// Do NOT call SetWorkflowResolver — resolver stays nil
+
+		_, err := reconciler.Reconcile(ctx, ctrl.Request{
+			NamespacedName: types.NamespacedName{Name: "test-rr-643c", Namespace: "default"},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		var updatedRR remediationv1.RemediationRequest
+		err = fakeClient.Get(ctx, client.ObjectKey{Name: "test-rr-643c", Namespace: "default"}, &updatedRR)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(updatedRR.Status.WorkflowDisplayName).To(
+			ContainSubstring(workflowUUID),
+			"WorkflowDisplayName should fall back to UUID when resolver is nil")
 	})
 })

--- a/test/unit/remediationorchestrator/routing/ds_workflow_adapter_test.go
+++ b/test/unit/remediationorchestrator/routing/ds_workflow_adapter_test.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package routing
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+	prodrouting "github.com/jordigilh/kubernaut/pkg/remediationorchestrator/routing"
+)
+
+// mockWorkflowCatalogClient implements routing.WorkflowCatalogClient for testing.
+type mockWorkflowCatalogClient struct {
+	workflows map[uuid.UUID]*ogenclient.RemediationWorkflow
+	err       error
+}
+
+func (m *mockWorkflowCatalogClient) GetWorkflowByID(
+	ctx context.Context,
+	params ogenclient.GetWorkflowByIDParams,
+) (ogenclient.GetWorkflowByIDRes, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	wf, ok := m.workflows[params.WorkflowID]
+	if !ok {
+		return &ogenclient.GetWorkflowByIDNotFound{}, nil
+	}
+	return wf, nil
+}
+
+var _ = Describe("DSWorkflowAdapter", func() {
+	const (
+		workflowUUID = "deb76100-421f-5623-bb1f-58827e5c93ae"
+		workflowName = "restart-crashloop-v2"
+		actionType   = "RestartPod"
+	)
+
+	It("UT-RO-WF-001: should resolve UUID to WorkflowName and ActionType from DS", func() {
+		uid := uuid.MustParse(workflowUUID)
+		mock := &mockWorkflowCatalogClient{
+			workflows: map[uuid.UUID]*ogenclient.RemediationWorkflow{
+				uid: {
+					WorkflowName: workflowName,
+					ActionType:   actionType,
+					WorkflowId:   ogenclient.OptUUID{Value: uid, Set: true},
+				},
+			},
+		}
+
+		adapter := prodrouting.NewDSWorkflowAdapter(mock)
+		info := adapter.ResolveWorkflowDisplay(context.Background(), workflowUUID)
+
+		Expect(info).NotTo(BeNil())
+		Expect(info.WorkflowName).To(Equal(workflowName))
+		Expect(info.ActionType).To(Equal(actionType))
+	})
+
+	It("UT-RO-WF-002: should return nil when workflow not found in DS", func() {
+		mock := &mockWorkflowCatalogClient{
+			workflows: map[uuid.UUID]*ogenclient.RemediationWorkflow{},
+		}
+
+		adapter := prodrouting.NewDSWorkflowAdapter(mock)
+		info := adapter.ResolveWorkflowDisplay(context.Background(), workflowUUID)
+
+		Expect(info).To(BeNil())
+	})
+
+	It("UT-RO-WF-003: should return nil when DS is unreachable", func() {
+		mock := &mockWorkflowCatalogClient{
+			err: fmt.Errorf("connection refused"),
+		}
+
+		adapter := prodrouting.NewDSWorkflowAdapter(mock)
+		info := adapter.ResolveWorkflowDisplay(context.Background(), workflowUUID)
+
+		Expect(info).To(BeNil())
+	})
+
+	It("UT-RO-WF-004: should return nil for invalid UUID string", func() {
+		mock := &mockWorkflowCatalogClient{
+			workflows: map[uuid.UUID]*ogenclient.RemediationWorkflow{},
+		}
+
+		adapter := prodrouting.NewDSWorkflowAdapter(mock)
+		info := adapter.ResolveWorkflowDisplay(context.Background(), "not-a-uuid")
+
+		Expect(info).To(BeNil())
+	})
+
+	It("UT-RO-WF-005: should return nil for empty workflow ID", func() {
+		mock := &mockWorkflowCatalogClient{
+			workflows: map[uuid.UUID]*ogenclient.RemediationWorkflow{},
+		}
+
+		adapter := prodrouting.NewDSWorkflowAdapter(mock)
+		info := adapter.ResolveWorkflowDisplay(context.Background(), "")
+
+		Expect(info).To(BeNil())
+	})
+})


### PR DESCRIPTION
## Summary

- **Replaces CRD-based workflow name resolution with a direct DataStorage lookup** via `GetWorkflowByID(uuid)`, which returns both `WorkflowName` and `ActionType` — the authoritative source that persists even when the RemediationWorkflow CRD is deleted.
- **Fixes the WORKFLOW printer column** in `kubectl get rr` showing a bare UUID (e.g., `deb76100-421f-5623-bb1f-58827e5c93ae`) instead of a human-readable name (e.g., `RestartPod:restart-crashloop-v2`).
- **Root cause was twofold**: (1) `resolveWorkflowName` relied on `RemediationWorkflow` CRD `status.workflowId` which depends on the auth webhook having populated it — fragile in practice; (2) `ActionType` was never included by the KA in the `selected_workflow` response, so `FormatWorkflowDisplay` always fell through to the bare UUID.

## Changes

| File | What |
|------|------|
| `pkg/remediationorchestrator/routing/ds_workflow_adapter.go` | New `WorkflowDisplayResolver` interface + `DSWorkflowAdapter` (follows `DSHistoryAdapter` pattern) |
| `internal/controller/remediationorchestrator/reconciler.go` | `resolveWorkflowName` → `resolveWorkflowDisplay` (DS-backed); removed dead `remediationworkflowv1` import |
| `cmd/remediationorchestrator/main.go` | Wire `DSWorkflowAdapterFromConfig` using existing `cfg.DataStorage.URL`/`Timeout` |
| `test/unit/.../ds_workflow_adapter_test.go` | 5 adapter unit tests (happy path, not found, DS down, invalid UUID, empty UUID) |
| `test/unit/.../workflow_name_resolution_test.go` | 3 updated #643 tests using `MockWorkflowResolver` |
| `test/unit/.../test_helpers.go` | Added `MockWorkflowResolver` |

## Test plan

- [x] 5 DS adapter unit tests pass (UT-RO-WF-001 through 005)
- [x] 3 updated #643 resolution tests pass (UT-RO-643-001 through 003)
- [x] Full RO unit test suite (9 sub-suites, 0 failures)
- [x] `go build ./...` clean
- [x] `go vet` clean
- [ ] Demo team retest: `oc get rr` WORKFLOW column shows `ActionType:WorkflowName`

Ref: #643

Made with [Cursor](https://cursor.com)