### PR TITLE
fix: parser-derived HR fields, enrichment retry infrastructure, and atomic supersede (#700, #704, #707)

### DIFF
--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -172,7 +172,7 @@ func main() {
 	ds := initDSClients(cfg, k8sInfra, slogger)
 	auditStore, auditCleanup := buildAuditStore(cfg, slogger, logrLogger)
 	reg := buildToolRegistry(cfg, slogger, k8sInfra, ds)
-	enricher := buildEnricher(ds, k8sInfra, auditStore, slogger)
+	enricher := buildEnricher(cfg, ds, k8sInfra, auditStore, slogger)
 	sanitizer := buildSanitizationPipeline(cfg, slogger)
 	anomalyDetector := buildAnomalyDetector(cfg, slogger)
 	sum := buildSummarizer(llmClient, cfg, slogger)
@@ -425,7 +425,8 @@ func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 // buildEnricher creates the enrichment.Enricher when DS clients are available.
 // ADR-056: attaches LabelDetector so detected_labels are populated during enrichment.
-func buildEnricher(ds *dsClients, infra *k8sInfra, auditStore audit.AuditStore, logger *slog.Logger) *enrichment.Enricher {
+// #704: wires RetryConfig from config for HAPI-aligned owner chain retry+fail-hard.
+func buildEnricher(cfg *kaconfig.Config, ds *dsClients, infra *k8sInfra, auditStore audit.AuditStore, logger *slog.Logger) *enrichment.Enricher {
 	if ds == nil {
 		return nil
 	}
@@ -434,6 +435,14 @@ func buildEnricher(ds *dsClients, infra *k8sInfra, auditStore audit.AuditStore, 
 		e.WithLabelDetector(enrichment.NewLabelDetector(infra.dynClient, infra.mapper))
 		logger.Info("label detector enabled (ADR-056)")
 	}
+	e.WithRetryConfig(enrichment.RetryConfig{
+		MaxRetries:  cfg.Enrichment.MaxRetries,
+		BaseBackoff: cfg.Enrichment.BaseBackoff,
+	})
+	logger.Info("enrichment retry config wired (#704)",
+		slog.Int("max_retries", cfg.Enrichment.MaxRetries),
+		slog.Duration("base_backoff", cfg.Enrichment.BaseBackoff),
+	)
 	return e
 }
 

--- a/docs/tests/700/TEST_PLAN.md
+++ b/docs/tests/700/TEST_PLAN.md
@@ -1,14 +1,14 @@
-# Test Plan: Phase Separation — RCA / Workflow Selection
+# Test Plan: Parser-Driven Escalation (Issue #700)
 
 > **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
 
 **Test Plan Identifier**: TP-700-v1
-**Feature**: Enforce clean RCA / Workflow Selection phase separation with per-session structured output
+**Feature**: Remove LLM-driven `needs_human_review` / `human_review_reason`; derive exclusively from parser/investigator
 **Version**: 1.0
 **Created**: 2026-04-06
-**Author**: AI Agent (supervised)
-**Status**: Draft
-**Branch**: `fix-700`
+**Author**: AI Assistant
+**Status**: Active
+**Branch**: `fix/700-parser-driven-escalation`
 
 ---
 
@@ -16,44 +16,44 @@
 
 ### 1.1 Purpose
 
-Validate that the KA investigation pipeline enforces clean session separation between RCA (Phase 1) and Workflow Selection (Phase 3), aligned with the HAPI v1.2.1 baseline. The LLM must not be able to set `needs_human_review` or reference workflow selection during RCA, and the structured output schema must be phase-specific — both at the tool level (`submit_result` Parameters) and at the transport level (`output_config.format`).
+Validate that `needs_human_review` and `human_review_reason` are never set by the LLM in any phase. These fields must be derived by the parser/investigator based on `investigation_outcome` and structural signals (RCA present, workflow absent), strictly mirroring HAPI v1.2.1 authoritative behavior.
 
 ### 1.2 Objectives
 
-1. **Phase-specific schemas**: RCA phase uses `RCAResultSchema()` (no workflow/escalation fields); Workflow phase uses `InvestigationResultSchema()` (full schema).
-2. **Focused prompts**: RCA prompt contains only investigation instructions (no Phases 4-5, no workflow references, no `needs_human_review`).
-3. **Per-session structured output**: `StructuredOutputTransport` reads schema from request context, not from a global field. Each LLM call carries its own schema.
-4. **Defense-in-depth**: Investigator clears `HumanReviewNeeded` after RCA parsing. Only max-turns exhaustion can abort during RCA.
-5. **No regressions**: Existing passing scenarios (crashloop, stuck-rollout, orphaned-pvc) continue to pass.
+1. **Schema honesty**: `InvestigationResultSchema()` must NOT expose `needs_human_review` or `human_review_reason` to the LLM
+2. **Parser derivation**: `applyInvestigationOutcome("inconclusive")` derives the correct HR reason from context: `no_matching_workflows` (RCA + no workflow) vs `investigation_inconclusive` (fallback)
+3. **LLM field rejection**: Parser must ignore LLM-provided `needs_human_review` / `human_review_reason` fields
+4. **Mock fidelity**: Mock LLM responses must NOT emit `needs_human_review` / `human_review_reason`
+5. **HAPI parity**: AA integration tests (authoritative) pass without modification
+6. **Defense-in-depth**: `problem_resolved` contradiction override (#301) remains exercisable
 
 ### 1.3 Success Metrics
 
 | Metric | Target | Measurement |
 |--------|--------|-------------|
-| Unit test pass rate | 100% | `go test ./test/unit/kubernautagent/...` |
+| Unit test pass rate | 100% | `go test ./test/unit/kubernautagent/parser/... ./test/unit/mockllm/...` |
 | Integration test pass rate | 100% | `go test ./test/integration/kubernautagent/...` |
-| Unit-testable code coverage | >=80% | `go test -coverprofile` on schema, prompt, transport, investigator |
-| Backward compatibility | 0 regressions | All pre-existing tests pass |
+| E2E test pass rate | 100% | `go test ./test/e2e/kubernautagent/...` |
+| Unit-testable code coverage | >=80% | `go test -coverprofile` on parser package |
+| Backward compatibility | 0 regressions | AA IT tests pass unmodified |
 
 ---
 
 ## 2. References
 
-### 2.1 Authority
+### 2.1 Authority (governing documents)
 
-- Issue #700: v1.3.0 KA: LLM escalates to ManualReview on scenarios that HAPI v1.2.1 remediates successfully
-- HAPI v1.2.1 source: `holmesgpt-api/src/extensions/incident/prompt_builder.py` (PHASE1_SECTIONS, PHASE3_SECTIONS)
-- HAPI v1.2.1 source: `holmesgpt-api/src/extensions/incident/llm_integration.py` (three-phase orchestrator)
-- HAPI v1.2.1 source: `holmesgpt-api/src/extensions/incident/result_parser.py` (parser-driven needs_human_review)
-- BR-HAPI-002: Incident Analysis
-- BR-HAPI-197: needs_human_review field
-- BR-HAPI-200: Investigation inconclusive outcome
+- BR-HAPI-197: `needs_human_review` escalation for no matching workflows
+- BR-HAPI-200: Parser-derived outcome routing (not LLM-driven)
+- DD-HAPI-002 v1.2: Investigation result parsing specification
+- DD-HAPI-006: Enrichment-driven `rca_incomplete` (deferred to follow-up issue)
+- Issue #700: Structural issues between HAPI and KA prompts
+- Issue #701: Two-phase LLM invocation fix (merged, prerequisite)
 
 ### 2.2 Cross-References
 
-- [Testing Strategy](../../.cursor/rules/03-testing-strategy.mdc)
-- [Testing Guidelines](../development/business-requirements/TESTING_GUIDELINES.md)
-- kubernaut-docs#112: Architecture Guide for KA Investigation Pipeline
+- [Testing Strategy](../../../.cursor/rules/03-testing-strategy.mdc)
+- [Testing Guidelines](../../development/business-requirements/TESTING_GUIDELINES.md)
 
 ---
 
@@ -61,97 +61,238 @@ Validate that the KA investigation pipeline enforces clean session separation be
 
 | ID | Risk | Impact | Probability | Affected Tests | Mitigation |
 |----|------|--------|-------------|----------------|------------|
-| R1 | Prompt changes affect passing scenarios | RCA quality degrades for crashloop, stuck-rollout, orphaned-pvc | Low | IT-KA-700-001 | Removed text is workflow/escalation-specific, not RCA-relevant. IT regression tests provide coverage. |
-| R2 | LangChainGo context dropped before transport | OutputSchema not available in RoundTrip | Very Low | UT-KA-700-013 | Preflight verified: LangChainGo v0.1.14 uses `http.NewRequestWithContext(ctx)` throughout. |
-| R3 | Vertex AI path not constrained by OutputSchema | Global schema gap for production provider | Medium | UT-KA-700-007, UT-KA-700-008 | Vertex AI constrained by `submit_result` tool Parameters schema. Transport-level constraint is defense-in-depth. |
-| R4 | Parser fallback paths still set HumanReviewNeeded from RCA | Defense-in-depth bypass | Low | UT-KA-700-009 | Investigator explicitly clears HumanReviewNeeded after RCA parsing. |
-
-### 3.1 Risk-to-Test Traceability
-
-| Risk | Primary Test(s) | Secondary Test(s) |
-|------|----------------|-------------------|
-| R1 | IT-KA-700-001 | UT-KA-700-003, UT-KA-700-004 |
-| R2 | UT-KA-700-013 | UT-KA-700-011 |
-| R3 | UT-KA-700-007, UT-KA-700-008 | UT-KA-700-001, UT-KA-700-002 |
-| R4 | UT-KA-700-009 | IT-KA-700-002 |
+| R1 | Parser derivation rule picks wrong reason due to whitespace-only RCASummary | Incorrect HR reason | Very Low | UT-KA-700-PDE-001 | Go `!= ""` treats whitespace as non-empty; `investigation_inconclusive` fallback is still valid |
+| R2 | `problem_resolved` contradiction override becomes unreachable via mock | Dead code accumulates | Known | UT-KA-700-PDE-003 | Dedicated unit test exercises `applyFlatFields` directly with synthetic contradictory inputs |
+| R3 | E2E ADV-016 temp relaxation masks real regression | False green in CI | Low | E2E-KA-433-ADV-016 | Comment links to enrichment follow-up issue; restored in same PR |
+| R4 | AA IT tests break due to incorrect derivation rule | Release blocker | Medium | Authoritative AA IT tests | Derivation rule verified: `inconclusive` + RCA + no workflow = `no_matching_workflows` |
 
 ---
 
-## 4. Test Items
+## 4. Scope
 
-### 4.1 Components Under Test
+### 4.1 Features to be Tested
 
-| Component | File | What Changes |
-|-----------|------|-------------|
-| RCA schema | `internal/kubernautagent/parser/schema.go` | New `RCAResultSchema()` function |
-| Investigation schema | `internal/kubernautagent/parser/schema.go` | Unchanged (regression guard) |
-| RCA prompt template | `internal/kubernautagent/prompt/templates/incident_investigation.tmpl` | Remove Phases 4-5, workflow refs, needs_human_review, remediation history |
-| Prompt builder | `internal/kubernautagent/prompt/builder.go` | Skip remediation history in RenderInvestigation |
-| Investigator | `internal/kubernautagent/investigator/investigator.go` | Phase-specific submit_result schema, per-session OutputSchema, clear HumanReviewNeeded after RCA |
-| LLM types | `pkg/kubernautagent/llm/types.go` | Add OutputSchema to ChatOptions |
-| Structured output transport | `pkg/kubernautagent/llm/transport/structured_output.go` | Context-based schema, remove global schema field |
-| LangChainGo adapter | `pkg/kubernautagent/llm/langchaingo/adapter.go` | Propagate OutputSchema to context |
-| Main entrypoint | `cmd/kubernautagent/main.go` | Remove global schema from transport constructor |
+- **Schema** (`internal/kubernautagent/parser/schema.go`): `InvestigationResultSchema()` must NOT include `needs_human_review` / `human_review_reason`
+- **Parser derivation** (`internal/kubernautagent/parser/parser.go`): `applyInvestigationOutcome` context-aware HR reason derivation
+- **Parser field rejection** (`internal/kubernautagent/parser/parser.go`): `applyFlatFields` must NOT propagate LLM `needs_human_review`
+- **Prompt template** (`internal/kubernautagent/prompt/templates/phase3_workflow_selection.tmpl`): Must NOT instruct LLM to set HR fields
+- **Mock response builder** (`test/services/mock-llm/response/openai.go`): Must NOT emit `needs_human_review` / `human_review_reason`
+- **Mock scenarios** (`test/services/mock-llm/scenarios/scenario_mock_keywords.go`): All 3 HR scenarios updated
 
----
+### 4.2 Features Not to be Tested
 
-## 5. Test Scenarios
+- **Enrichment-driven `rca_incomplete`**: Deferred to follow-up issue (BR-HAPI-261/264). Same PR, separate TDD cycle.
+- **Self-correction exhaustion** (`UT-KA-433-027`): Unchanged — `SelfCorrect` sets HR independently of LLM fields.
 
-### 5.1 Tier 1: Unit Tests
+### 4.3 Design Decisions
 
-#### Schema & Prompt (6 tests)
-
-| ID | Description | Component | Acceptance Criterion |
-|----|------------|-----------|---------------------|
-| UT-KA-700-001 | RCAResultSchema contains only RCA fields | `parser/schema.go` | Schema JSON has `root_cause_analysis`, `confidence`, `investigation_outcome`, `actionable`, `severity`, `detected_labels`. Does NOT have `selected_workflow`, `alternative_workflows`, `needs_human_review`, `human_review_reason`. |
-| UT-KA-700-002 | InvestigationResultSchema unchanged | `parser/schema.go` | Schema JSON still contains `selected_workflow`, `alternative_workflows`, `needs_human_review`. Byte-for-byte identical to pre-#700 value. |
-| UT-KA-700-003 | RCA prompt excludes workflow discovery | `incident_investigation.tmpl`, `builder.go` | Rendered RCA prompt does NOT contain "list_available_actions", "list_workflows", "get_workflow", "Three-Step Protocol", "Phase 4", "Phase 5". |
-| UT-KA-700-004 | RCA prompt excludes escalation fields | `incident_investigation.tmpl`, `builder.go` | Rendered RCA prompt does NOT contain "selected_workflow", "needs_human_review", "human_review_reason", "alternative_workflows". |
-| UT-KA-700-005 | RCA prompt excludes remediation history | `builder.go` | Rendered RCA prompt does NOT contain "Remediation History Context", "CONFIGURATION REGRESSION DETECTED". Even when enrichment data includes history. |
-| UT-KA-700-006 | Workflow selection prompt retains full content | `phase3_workflow_selection.tmpl`, `builder.go` | Rendered workflow prompt contains "list_available_actions", "list_workflows", "get_workflow", "submit_result", "selected_workflow". |
-
-#### Investigator Phase Separation (4 tests)
-
-| ID | Description | Component | Acceptance Criterion |
-|----|------------|-----------|---------------------|
-| UT-KA-700-007 | RCA phase submit_result uses RCAResultSchema | `investigator.go` | `toolDefinitionsForPhase(PhaseRCA)` returns submit_result with Parameters matching `RCAResultSchema()`. |
-| UT-KA-700-008 | Workflow phase submit_result uses InvestigationResultSchema | `investigator.go` | `toolDefinitionsForPhase(PhaseWorkflowDiscovery)` returns submit_result with Parameters matching `InvestigationResultSchema()`. |
-| UT-KA-700-009 | runRCA clears HumanReviewNeeded after parsing | `investigator.go` | When LLM returns JSON with `needs_human_review: true` during RCA, `runRCA` returns result with `HumanReviewNeeded == false`. |
-| UT-KA-700-010 | Max-turns exhaustion preserves HumanReviewNeeded | `investigator.go` | When RCA exhausts max turns, result has `HumanReviewNeeded == true` with reason containing "max turns". |
-
-#### Per-Session Structured Output Transport (3 tests)
-
-| ID | Description | Component | Acceptance Criterion |
-|----|------------|-----------|---------------------|
-| UT-KA-700-011 | Transport uses schema from context | `structured_output.go` | When request context contains OutputSchema via `WithOutputSchema`, the injected `output_config.format.schema` matches that schema. |
-| UT-KA-700-012 | Transport skips injection when no schema in context | `structured_output.go` | When request context has no OutputSchema, the request body passes through unmodified (no `output_config` added). |
-| UT-KA-700-013 | ChatOptions.OutputSchema propagates through adapter | `adapter.go`, `structured_output.go` | End-to-end: setting `ChatOptions.OutputSchema` on a ChatRequest results in the correct schema being injected into the HTTP request body by the transport. |
-
-### 5.2 Tier 2: Integration Tests
-
-| ID | Description | Component | Acceptance Criterion |
-|----|------------|-----------|---------------------|
-| IT-KA-700-001 | Two-session flow: RCA feeds workflow selection | `investigator.go` | Full `Investigate()` call: RCA session produces summary, workflow session receives it and selects a workflow. Final result has both `RCASummary` and `WorkflowID` populated. |
-| IT-KA-700-002 | RCA cannot abort pipeline via needs_human_review | `investigator.go` | Mock LLM returns `needs_human_review: true` in RCA submit_result. Pipeline does NOT abort — proceeds to workflow selection. Final result has `HumanReviewNeeded` determined by workflow phase. |
-| IT-KA-700-003 | RCA investigation_outcome does not skip workflow selection | `investigator.go` | Mock LLM returns `investigation_outcome: "inconclusive"` in RCA. Pipeline proceeds to workflow selection (does not short-circuit). |
+| Decision | Rationale |
+|----------|-----------|
+| Derive `no_matching_workflows` from `inconclusive` + RCA + no workflow | Matches HAPI behavior; authoritative AA IT tests assert this exact reason |
+| Keep `problem_resolved` contradiction override as defense-in-depth | HAPI-authoritative; exercises via direct unit test |
+| Temp relax E2E ADV-016 for `rca_incomplete` | Enrichment follow-up restores in same PR |
 
 ---
 
-## 6. TDD Phase Mapping
+## 5. Approach
 
-| TDD Phase | Test IDs | Implementation Files |
-|-----------|----------|---------------------|
-| RED | All UT-KA-700-*, IT-KA-700-* | Tests only (no implementation) |
-| GREEN | — | `schema.go`, `incident_investigation.tmpl`, `builder.go`, `investigator.go`, `types.go`, `structured_output.go`, `adapter.go`, `main.go` |
-| REFACTOR | — | Dead template removal, documentation alignment |
+### 5.1 Coverage Policy
+
+- **Unit**: >=80% of parser derivation logic (`applyFlatFields`, `applyInvestigationOutcome`, `extractSections`)
+- **Integration**: >=80% of investigator pipeline (phase separation, HR field handling)
+- **E2E**: Container contract validation for all 3 affected mock scenarios
+
+### 5.2 Two-Tier Minimum
+
+Every business requirement covered by UT + IT minimum. E2E provides additional regression safety.
+
+### 5.3 Pass/Fail Criteria
+
+**PASS**: All P0 tests pass, per-tier coverage >=80%, AA IT tests unmodified and green.
+**FAIL**: Any P0 test fails, coverage below 80%, or AA IT test modified.
 
 ---
 
-## 7. Environment
+## 6. Test Items
 
-| Component | Version |
-|-----------|---------|
-| Go | 1.24+ |
-| LangChainGo | v0.1.14 |
-| Ginkgo/Gomega | v2 |
-| Test runner | `go test` / `ginkgo` |
+### 6.1 Unit-Testable Code
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `internal/kubernautagent/parser/schema.go` | `InvestigationResultSchema()` | ~55 |
+| `internal/kubernautagent/parser/parser.go` | `applyFlatFields`, `applyInvestigationOutcome`, `extractSections` | ~90 |
+
+### 6.2 Integration-Testable Code
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `internal/kubernautagent/investigator/investigator.go` | `Investigate` pipeline | ~200 |
+
+---
+
+## 7. BR Coverage Matrix
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-HAPI-200 | Parser derives HR from investigation_outcome, not LLM | P0 | Unit | UT-KA-700-PDE-001 | Pending |
+| BR-HAPI-200 | Parser fallback: investigation_inconclusive when no RCA | P0 | Unit | UT-KA-700-PDE-002 | Pending |
+| BR-HAPI-200 | LLM needs_human_review fields ignored by parser | P0 | Unit | UT-KA-433-PRS-009 (rewrite) | Pending |
+| BR-HAPI-200 | LLM explicit needs_human_review NOT preserved | P0 | Unit | UT-KA-433-OUT-004 (rewrite) | Pending |
+| BR-HAPI-200 | Schema does not expose HR fields to LLM | P0 | Unit | UT-KA-700-002 (flip) | Pending |
+| BR-HAPI-200 | Schema validation in parser_test | P1 | Unit | UT-KA-SCHEMA-001 (update) | Pending |
+| BR-HAPI-197 | no_matching_workflows derived for inconclusive+RCA+no workflow | P0 | Unit | UT-KA-433-OUT-003 (update) | Pending |
+| BR-HAPI-200 | problem_resolved contradiction override | P1 | Unit | UT-KA-700-PDE-003 | Pending |
+| BR-HAPI-200 | Mock response does not emit HR fields | P0 | Unit | UT-MOCK-030-003 (update) | Pending |
+| BR-HAPI-200 | Pipeline does not abort on RCA HR | P0 | Integration | IT-KA-700-002 (update) | Pending |
+| BR-HAPI-200 | E2E rca_incomplete temp relaxation | P1 | E2E | E2E-KA-433-ADV-016 (temp) | Pending |
+
+---
+
+## 8. Test Scenarios
+
+### Tier 1: Unit Tests
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| UT-KA-700-PDE-001 | Parser derives `no_matching_workflows` from `inconclusive` + RCA present + no workflow | Pending |
+| UT-KA-700-PDE-002 | Parser derives `investigation_inconclusive` from `inconclusive` when no RCA context | Pending |
+| UT-KA-700-PDE-003 | `problem_resolved` contradiction override clears HR via `applyFlatFields` directly | Pending |
+| UT-KA-700-002 | Schema does NOT expose `needs_human_review` / `human_review_reason` | Pending |
+| UT-KA-SCHEMA-001 | Schema validation: required keys present, HR keys absent | Pending |
+| UT-KA-433-PRS-009 | Parser ignores LLM-set `needs_human_review`; HR derived from outcome only | Pending |
+| UT-KA-433-OUT-003 | `inconclusive` + RCA summary + no workflow = `no_matching_workflows` | Pending |
+| UT-KA-433-OUT-004 | LLM `needs_human_review=true` with workflow must NOT be preserved | Pending |
+| UT-MOCK-030-003 | Mock response must NOT contain `needs_human_review` / `human_review_reason` | Pending |
+
+### Tier 2: Integration Tests
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| IT-KA-700-002 | Pipeline proceeds to workflow selection when RCA has HR fields (HR stripped) | Pending |
+
+### Tier 3: E2E Tests
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| E2E-KA-433-ADV-016 | `rca_incomplete` scenario: temp expect `needs_human_review=false` (enrichment follow-up restores) | Pending |
+
+---
+
+## 9. Test Cases
+
+### UT-KA-700-PDE-001: Parser derives no_matching_workflows
+
+**BR**: BR-HAPI-197, BR-HAPI-200
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/parser/adversarial_parser_test.go`
+
+**Test Steps**:
+1. **Given**: JSON with `rca_summary` non-empty, no `workflow_id`, `investigation_outcome: "inconclusive"`
+2. **When**: `Parse()` is called
+3. **Then**: `HumanReviewNeeded == true`, `HumanReviewReason == "no_matching_workflows"`
+
+### UT-KA-700-PDE-002: Parser derives investigation_inconclusive fallback
+
+**BR**: BR-HAPI-200
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/parser/adversarial_parser_test.go`
+
+**Test Steps**:
+1. **Given**: JSON with `workflow_id` present, `investigation_outcome: "inconclusive"`, no `rca_summary`
+2. **When**: `Parse()` is called
+3. **Then**: `HumanReviewNeeded == true`, `HumanReviewReason == "investigation_inconclusive"`
+
+### UT-KA-700-PDE-003: problem_resolved contradiction override
+
+**BR**: BR-HAPI-200 (#301)
+**Priority**: P1
+**Type**: Unit
+**File**: `test/unit/kubernautagent/parser/adversarial_parser_test.go`
+
+**Test Steps**:
+1. **Given**: `flatLLMFields` with `InvestigationOutcome: "problem_resolved"`, `NeedsHumanReview: true`, `HumanReviewReason: "contradictory_signals"`
+2. **When**: `applyFlatFields()` is called on a result
+3. **Then**: `HumanReviewNeeded == false`, `HumanReviewReason == ""`
+
+---
+
+## 10. Environmental Needs
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Mocks**: None (parser is pure logic)
+- **Location**: `test/unit/kubernautagent/parser/`, `test/unit/mockllm/`
+
+### 10.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Mocks**: Mock LLM client (in-process)
+- **Location**: `test/integration/kubernautagent/investigator/`
+
+### 10.3 E2E Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Infrastructure**: Kind cluster with Mock LLM
+- **Location**: `test/e2e/kubernautagent/`
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Execution Order
+
+1. **Phase 1 (TDD RED)**: Write/update all failing tests
+2. **Checkpoint 1**: Adversarial audit — verify tests fail for the right reason
+3. **Phase 2 (TDD GREEN)**: Implement production changes
+4. **Checkpoint 2**: All tests pass + regression check
+5. **Phase 3 (TDD REFACTOR)**: Clean up dead code, update comments
+6. **Checkpoint 3**: Final regression gate
+
+---
+
+## 12. Existing Tests Requiring Updates
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|-------------------|-------------------|-----------------|--------|
+| UT-KA-700-002 (`schema_phase_separation_test.go:78-100`) | Schema HAS `needs_human_review` | Flip: assert ABSENT | Schema honesty |
+| UT-KA-SCHEMA-001 (`parser_test.go:387-408`) | `HaveKey("needs_human_review")` | Remove assertion | Schema honesty |
+| UT-KA-433-PRS-009 (`adversarial_parser_test.go:185-199`) | LLM HR fields extracted | Rewrite: parser ignores LLM fields | LLM field rejection |
+| UT-KA-433-OUT-003 (`adversarial_parser_test.go:233-246`) | Expects `investigation_inconclusive` | Change to `no_matching_workflows` | New derivation rule |
+| UT-KA-433-OUT-004 (`adversarial_parser_test.go:248-263`) | LLM HR preserved | Rewrite: LLM HR NOT preserved | LLM field rejection |
+| UT-MOCK-030-003 (`response_test.go:136-152`) | Response contains HR fields | Assert HR fields absent | Mock fidelity |
+| IT-KA-700-002 (`investigator_phase_separation_test.go:217-241`) | rcaSubmitArgs has HR JSON | Remove HR from fixture | Pipeline behavior |
+| E2E-KA-433-ADV-016 (`adversarial_parity_e2e_test.go:308-324`) | `needs_human_review=true` | Temp: expect `false` | Enrichment deferred |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests (parser + mock)
+go test ./test/unit/kubernautagent/parser/... -ginkgo.v
+go test ./test/unit/mockllm/... -ginkgo.v
+
+# Integration tests
+go test ./test/integration/kubernautagent/investigator/... -ginkgo.v
+
+# E2E tests
+go test ./test/e2e/kubernautagent/... -ginkgo.v
+
+# Specific test by ID
+go test ./test/unit/kubernautagent/parser/... -ginkgo.focus="UT-KA-700-PDE"
+
+# Coverage
+go test ./test/unit/kubernautagent/parser/... -coverprofile=coverage.out
+go tool cover -func=coverage.out
+```
+
+---
+
+## 14. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-06 | Initial test plan |

--- a/docs/tests/704/TEST_PLAN.md
+++ b/docs/tests/704/TEST_PLAN.md
@@ -1,14 +1,15 @@
-# Test Plan: Enrichment-Driven `rca_incomplete` Detection
+# Test Plan: Enrichment Retry Infrastructure & `rca_incomplete` Detection
 
 > **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
 
-**Test Plan Identifier**: TP-704-v1
-**Feature**: Investigator sets `rca_incomplete` when enrichment owner chain resolution fails
-**Version**: 1.0
+**Test Plan Identifier**: TP-704-v2
+**Feature**: Enrichment retry infrastructure with `rca_incomplete` detection
+**Version**: 2.0
 **Created**: 2026-04-06
+**Updated**: 2026-04-16
 **Author**: AI Assistant
 **Status**: Active
-**Branch**: `fix/700-needs-human-review-parser-derived`
+**Branch**: `fix/700-parser-driven-escalation`
 
 ---
 
@@ -16,24 +17,25 @@
 
 ### 1.1 Purpose
 
-This test plan validates that KA's investigator correctly detects enrichment owner chain resolution failures and sets `needs_human_review=true` with `human_review_reason="rca_incomplete"`, aligning with HAPI's authoritative behavior per DD-HAPI-006 v1.6 and BR-HAPI-261 acceptance criteria #7.
+This test plan validates that KA's enrichment layer supports configurable retry with exponential backoff for infrastructure calls (GetOwnerChain), error classification (transient vs permanent), and a HardFail signal that the investigator uses to trigger `rca_incomplete` before workflow selection.
 
 ### 1.2 Objectives
 
-1. **Owner chain error surfacing**: `EnrichmentResult.OwnerChainError` is populated when `GetOwnerChain` returns an error
-2. **Investigator completeness gate**: Investigator checks final `enrichData.OwnerChainError` after re-enrichment and before workflow selection
-3. **rca_incomplete HR derivation**: When owner chain resolution fails, `HumanReviewNeeded=true` and `HumanReviewReason="rca_incomplete"` are set
-4. **Workflow phase skipped**: When `rca_incomplete` triggers, `runWorkflowSelection` is not invoked
-5. **E2E restoration**: E2E-KA-433-ADV-016 assertion restored to expect `needs_human_review=true` with `rca_incomplete`
+1. **Retry behavior**: Transient K8s errors trigger exponential backoff retries up to `MaxRetries`
+2. **Error classification**: Permanent errors (NotFound, Forbidden) skip retry; transient errors (Timeout, 503, 500, 429) are retried
+3. **HardFail signaling**: `EnrichmentResult.HardFail=true` after retry exhaustion or permanent error (only when `MaxRetries > 0`)
+4. **Best-effort mode**: With `MaxRetries=0` (default), no retry, no HardFail — preserves backward compatibility
+5. **Investigator gate**: HardFail on re-enrichment triggers `rca_incomplete` before workflow selection
+6. **Re-enrichment merge safety**: HardFail checked BEFORE label merge to prevent silent drop (CRITICAL-1 fix)
 
 ### 1.3 Success Metrics
 
 | Metric | Target | Measurement |
 |--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/kubernautagent/enrichment/...` |
 | Integration test pass rate | 100% | `go test ./test/integration/kubernautagent/investigator/...` |
-| E2E test pass rate | 100% | E2E-KA-433-ADV-016 passes with restored assertion |
 | Build | 0 errors | `go build ./...` |
-| Lint | 0 new errors | `golangci-lint run` |
+| Lint | 0 new errors | `go vet` + linter |
 | Backward compatibility | 0 regressions | All existing enrichment + investigator tests pass |
 
 ---
@@ -50,8 +52,8 @@ This test plan validates that KA's investigator correctly detects enrichment own
 ### 2.2 Cross-References
 
 - **Issue #700**: Parser-driven escalation (prerequisite — HR fields removed from LLM, parser-derived only)
-- **TP-700-v1**: Test plan for parser-driven escalation (E2E ADV-016 temporarily relaxed there)
-- **IT-KA-433-ENR-004/005**: Existing enrichment failure integration tests (broken K8s scenarios)
+- **TP-700-v1**: Test plan for parser-driven escalation
+- **IT-KA-433-ENR-004/005**: Existing enrichment failure integration tests
 
 ---
 
@@ -61,48 +63,102 @@ This test plan validates that KA's investigator correctly detects enrichment own
 
 | File | Change | Lines |
 |------|--------|-------|
-| `internal/kubernautagent/enrichment/enricher.go` | Add `OwnerChainError` field to `EnrichmentResult`; populate in `Enrich()` | ~3 lines |
-| `internal/kubernautagent/investigator/investigator.go` | Add completeness check after re-enrichment, before workflow selection | ~12 lines |
+| `internal/kubernautagent/enrichment/enricher.go` | Add `RetryConfig`, `HardFail` field, `WithRetryConfig()`, `resolveOwnerChainWithRetry()`, `isTransientK8sError()` | ~65 lines |
+| `internal/kubernautagent/investigator/investigator.go` | Add HardFail check before re-enrichment label merge | ~12 lines |
 
 ### 3.2 Test Code
 
 | File | Change | Test ID |
 |------|--------|---------|
-| `test/integration/kubernautagent/investigator/investigator_test.go` | New integration test | IT-KA-704-001 |
-| `test/e2e/kubernautagent/adversarial_parity_e2e_test.go` | Restore assertion | E2E-KA-433-ADV-016 |
+| `test/unit/kubernautagent/enrichment/enricher_retry_test.go` | New unit tests | UT-704-E-001..004 |
+| `test/integration/kubernautagent/investigator/investigator_test.go` | Updated integration test | IT-KA-704-001 |
+| `test/e2e/kubernautagent/adversarial_parity_e2e_test.go` | Relaxed assertion (best-effort mode in E2E) | E2E-KA-433-ADV-016 |
 
 ---
 
 ## 4. Test Scenarios
 
+### UT-704-E-001: Transient error retried, HardFail after exhaustion
+
+**Tier**: Unit
+**BR**: BR-HAPI-261 AC#7
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 1 | Create enricher with `MaxRetries=3`, K8s client returning InternalError 4 times | Enricher configured |
+| 2 | Call `Enrich()` | Retries 3 times (4 total calls) |
+| 3 | Assert call count | 4 (initial + 3 retries) |
+| 4 | Assert `OwnerChainError` | Non-nil |
+| 5 | Assert `HardFail` | `true` |
+
+### UT-704-E-002: Transient error succeeds on retry
+
+**Tier**: Unit
+**BR**: BR-HAPI-261 AC#7
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 1 | K8s client returns ServiceUnavailable on call 1, success on call 2 | Configured |
+| 2 | Call `Enrich()` | Succeeds on 2nd attempt |
+| 3 | Assert call count | 2 |
+| 4 | Assert `OwnerChainError` | Nil |
+| 5 | Assert `HardFail` | `false` |
+| 6 | Assert `OwnerChain` | Populated from successful retry |
+
+### UT-704-E-003: Permanent error triggers immediate HardFail
+
+**Tier**: Unit
+**BR**: BR-HAPI-261 AC#7
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 1 | K8s client returns NotFound error | Configured with `MaxRetries=3` |
+| 2 | Call `Enrich()` | No retry (permanent error) |
+| 3 | Assert call count | 1 (no retry for permanent errors) |
+| 4 | Assert `OwnerChainError` | Non-nil |
+| 5 | Assert `HardFail` | `true` |
+
+### UT-704-E-004: Best-effort mode (retries=0)
+
+**Tier**: Unit
+**BR**: Backward compatibility
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 1 | Create enricher with default config (no `WithRetryConfig`) | `MaxRetries=0` |
+| 2 | K8s client returns error | Single call |
+| 3 | Assert `OwnerChainError` | Non-nil |
+| 4 | Assert `HardFail` | `false` (best-effort mode) |
+
 ### IT-KA-704-001: Owner chain failure triggers rca_incomplete
 
 **Tier**: Integration
 **BR**: BR-HAPI-261 AC#7
-**Preconditions**: `fakeK8sClient` configured with `err: fmt.Errorf("resource not found")`
+**Preconditions**: `fakeK8sClient` with `apierrors.NewNotFound`; enricher with `MaxRetries=3`; signal differs from RCA target to trigger re-enrichment
 
 | Step | Action | Expected |
 |------|--------|----------|
-| 1 | Create investigator with failing K8s client | Enricher created with error-returning client |
-| 2 | Mock LLM returns valid RCA (phase 1) | RCA completes normally |
-| 3 | Investigator runs enrichment | `OwnerChainError` set on `EnrichmentResult` |
-| 4 | Investigator checks completeness | Early return before workflow selection |
-| 5 | Assert result | `HumanReviewNeeded=true`, `HumanReviewReason="rca_incomplete"` |
-| 6 | Assert RCA preserved | `RCASummary` populated from phase 1 |
-| 7 | Assert workflow skipped | `WorkflowID` is empty |
+| 1 | Create investigator with failing K8s client + strict retry config | Enricher in strict mode |
+| 2 | Mock LLM returns valid RCA targeting different resource | Re-enrichment triggered |
+| 3 | Re-enrichment fails with permanent error | HardFail=true |
+| 4 | Investigator detects HardFail before label merge | Early return before workflow |
+| 5 | Assert `HumanReviewNeeded=true`, `HumanReviewReason="rca_incomplete"` | Correct |
+| 6 | Assert `RCASummary` populated | RCA phase completed before check |
+| 7 | Assert `WorkflowID` empty | Workflow phase skipped |
 
-### E2E-KA-433-ADV-016: rca_incomplete via enrichment failure (restored)
+### E2E-KA-433-ADV-016: rca_incomplete scenario (relaxed)
 
 **Tier**: E2E
-**BR**: BR-HAPI-261 AC#7
-**Preconditions**: Kind cluster without target Pods; Mock LLM `mock_rca_incomplete` scenario
+**BR**: Backward compatibility
+**Status**: Relaxed — enrichment uses default `MaxRetries=0` in E2E, so HardFail is never set
 
 | Step | Action | Expected |
 |------|--------|----------|
-| 1 | Send incident with `mock_rca_incomplete` keyword | Mock LLM returns actionable RCA |
-| 2 | Enrichment targets non-existent Pod | `GetOwnerChain` returns error |
-| 3 | Investigator detects enrichment failure | Sets `rca_incomplete` |
-| 4 | Assert response | `needs_human_review=true`, `human_review_reason="rca_incomplete"` |
+| 1 | Send incident with `mock_rca_incomplete` keyword | Mock LLM returns RCA |
+| 2 | Enrichment fails (Pod not in Kind cluster) | OwnerChainError set, HardFail=false |
+| 3 | Assert `needs_human_review=false` | Best-effort mode, no rca_incomplete |
+
+> **TODO(#704)**: Activate strict assertion when E2E fixtures support `RetryConfig` injection.
 
 ---
 
@@ -110,9 +166,10 @@ This test plan validates that KA's investigator correctly detects enrichment own
 
 | Risk | Likelihood | Impact | Mitigation |
 |------|-----------|--------|------------|
-| `enrichData == nil` (no enricher) bypasses check | Low | High | Check guards on `enrichData != nil` |
-| Existing enrichment tests affected | Low | Medium | Tests use different K8s clients; `OwnerChainError` only set on actual error |
-| Mid-walk failures not detected | Known | Low | Out of scope per #704; partial chain is acceptable |
+| Re-enrichment merge drops HardFail | Eliminated | n/a | CRITICAL-1 fix: check BEFORE merge |
+| Existing tests regressed | Low | High | Full suite (54 UT + 58 IT) passes |
+| Best-effort E2E doesn't catch bugs | Medium | Low | Strict behavior tested at UT/IT tiers |
+| Backoff timing in tests | Low | Low | Tests use 1ms backoff; verify call count, not timing |
 
 ---
 
@@ -120,6 +177,8 @@ This test plan validates that KA's investigator correctly detects enrichment own
 
 | Phase | Status | Description |
 |-------|--------|-------------|
-| RED | Complete | IT-KA-704-001 written, E2E ADV-016 restored — both failed for right reason |
-| GREEN | Complete | `OwnerChainError` added, `Enrich()` populates, investigator gates — all tests pass |
-| REFACTOR | Complete | Doc comments on `OwnerChainError` field |
+| Phase 0 — Revert | Complete | Reverted broken #704 gate, relaxed ADV-016, kept IT-704-001 as RED test |
+| RED | Complete | UT-704-E-001..004 written + IT-KA-704-001 verified failing for right reasons |
+| GREEN | Complete | RetryConfig, HardFail, retry loop, investigator gate — all tests pass |
+| REFACTOR | Complete | Doc comments, adversarial audit, full regression check |
+| Final Checkpoint | Complete | Full build clean, 54 UT + 58 IT + 22 KA packages pass |

--- a/docs/tests/704/TEST_PLAN.md
+++ b/docs/tests/704/TEST_PLAN.md
@@ -1,0 +1,125 @@
+# Test Plan: Enrichment-Driven `rca_incomplete` Detection
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-704-v1
+**Feature**: Investigator sets `rca_incomplete` when enrichment owner chain resolution fails
+**Version**: 1.0
+**Created**: 2026-04-06
+**Author**: AI Assistant
+**Status**: Active
+**Branch**: `fix/700-needs-human-review-parser-derived`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This test plan validates that KA's investigator correctly detects enrichment owner chain resolution failures and sets `needs_human_review=true` with `human_review_reason="rca_incomplete"`, aligning with HAPI's authoritative behavior per DD-HAPI-006 v1.6 and BR-HAPI-261 acceptance criteria #7.
+
+### 1.2 Objectives
+
+1. **Owner chain error surfacing**: `EnrichmentResult.OwnerChainError` is populated when `GetOwnerChain` returns an error
+2. **Investigator completeness gate**: Investigator checks final `enrichData.OwnerChainError` after re-enrichment and before workflow selection
+3. **rca_incomplete HR derivation**: When owner chain resolution fails, `HumanReviewNeeded=true` and `HumanReviewReason="rca_incomplete"` are set
+4. **Workflow phase skipped**: When `rca_incomplete` triggers, `runWorkflowSelection` is not invoked
+5. **E2E restoration**: E2E-KA-433-ADV-016 assertion restored to expect `needs_human_review=true` with `rca_incomplete`
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Integration test pass rate | 100% | `go test ./test/integration/kubernautagent/investigator/...` |
+| E2E test pass rate | 100% | E2E-KA-433-ADV-016 passes with restored assertion |
+| Build | 0 errors | `go build ./...` |
+| Lint | 0 new errors | `golangci-lint run` |
+| Backward compatibility | 0 regressions | All existing enrichment + investigator tests pass |
+
+---
+
+## 2. References
+
+### 2.1 Authority
+
+- **BR-HAPI-261**: LLM-Provided Affected Resource with Owner Resolution (AC #7: owner chain resolution fails → `rca_incomplete`)
+- **BR-HAPI-264**: Post-RCA Infrastructure Label Detection (AC #6: label detection fails → `rca_incomplete`)
+- **DD-HAPI-006 v1.6**: Three-phase RCA architecture — enrichment failure → `rca_incomplete`
+- **Issue #704**: Enrichment-driven `rca_incomplete` detection
+
+### 2.2 Cross-References
+
+- **Issue #700**: Parser-driven escalation (prerequisite — HR fields removed from LLM, parser-derived only)
+- **TP-700-v1**: Test plan for parser-driven escalation (E2E ADV-016 temporarily relaxed there)
+- **IT-KA-433-ENR-004/005**: Existing enrichment failure integration tests (broken K8s scenarios)
+
+---
+
+## 3. Test Items
+
+### 3.1 Production Code Under Test
+
+| File | Change | Lines |
+|------|--------|-------|
+| `internal/kubernautagent/enrichment/enricher.go` | Add `OwnerChainError` field to `EnrichmentResult`; populate in `Enrich()` | ~3 lines |
+| `internal/kubernautagent/investigator/investigator.go` | Add completeness check after re-enrichment, before workflow selection | ~12 lines |
+
+### 3.2 Test Code
+
+| File | Change | Test ID |
+|------|--------|---------|
+| `test/integration/kubernautagent/investigator/investigator_test.go` | New integration test | IT-KA-704-001 |
+| `test/e2e/kubernautagent/adversarial_parity_e2e_test.go` | Restore assertion | E2E-KA-433-ADV-016 |
+
+---
+
+## 4. Test Scenarios
+
+### IT-KA-704-001: Owner chain failure triggers rca_incomplete
+
+**Tier**: Integration
+**BR**: BR-HAPI-261 AC#7
+**Preconditions**: `fakeK8sClient` configured with `err: fmt.Errorf("resource not found")`
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 1 | Create investigator with failing K8s client | Enricher created with error-returning client |
+| 2 | Mock LLM returns valid RCA (phase 1) | RCA completes normally |
+| 3 | Investigator runs enrichment | `OwnerChainError` set on `EnrichmentResult` |
+| 4 | Investigator checks completeness | Early return before workflow selection |
+| 5 | Assert result | `HumanReviewNeeded=true`, `HumanReviewReason="rca_incomplete"` |
+| 6 | Assert RCA preserved | `RCASummary` populated from phase 1 |
+| 7 | Assert workflow skipped | `WorkflowID` is empty |
+
+### E2E-KA-433-ADV-016: rca_incomplete via enrichment failure (restored)
+
+**Tier**: E2E
+**BR**: BR-HAPI-261 AC#7
+**Preconditions**: Kind cluster without target Pods; Mock LLM `mock_rca_incomplete` scenario
+
+| Step | Action | Expected |
+|------|--------|----------|
+| 1 | Send incident with `mock_rca_incomplete` keyword | Mock LLM returns actionable RCA |
+| 2 | Enrichment targets non-existent Pod | `GetOwnerChain` returns error |
+| 3 | Investigator detects enrichment failure | Sets `rca_incomplete` |
+| 4 | Assert response | `needs_human_review=true`, `human_review_reason="rca_incomplete"` |
+
+---
+
+## 5. Risk Assessment
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| `enrichData == nil` (no enricher) bypasses check | Low | High | Check guards on `enrichData != nil` |
+| Existing enrichment tests affected | Low | Medium | Tests use different K8s clients; `OwnerChainError` only set on actual error |
+| Mid-walk failures not detected | Known | Low | Out of scope per #704; partial chain is acceptable |
+
+---
+
+## 6. TDD Phase Tracking
+
+| Phase | Status | Description |
+|-------|--------|-------------|
+| RED | Complete | IT-KA-704-001 written, E2E ADV-016 restored — both failed for right reason |
+| GREEN | Complete | `OwnerChainError` added, `Enrich()` populates, investigator gates — all tests pass |
+| REFACTOR | Complete | Doc comments on `OwnerChainError` field |

--- a/internal/kubernautagent/config/config.go
+++ b/internal/kubernautagent/config/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	Sanitization  SanitizationConfig  `yaml:"sanitization"`
 	Anomaly       AnomalyConfig       `yaml:"anomaly"`
 	Summarizer    SummarizerConfig    `yaml:"summarizer"`
+	Enrichment    EnrichmentConfig    `yaml:"enrichment"`
 }
 
 type LLMConfig struct {
@@ -125,6 +126,14 @@ type SanitizationConfig struct {
 
 type SummarizerConfig struct {
 	Threshold int `yaml:"threshold"`
+}
+
+// EnrichmentConfig controls retry behavior for K8s owner chain resolution
+// during enrichment. HAPI-aligned defaults (MaxRetries=3, BaseBackoff=1s)
+// ensure rca_incomplete is triggered on definitive enrichment failure.
+type EnrichmentConfig struct {
+	MaxRetries  int           `yaml:"max_retries"`
+	BaseBackoff time.Duration `yaml:"base_backoff"`
 }
 
 type AnomalyConfig struct {
@@ -271,6 +280,10 @@ func DefaultConfig() *Config {
 		},
 		Summarizer: SummarizerConfig{
 			Threshold: 8000,
+		},
+		Enrichment: EnrichmentConfig{
+			MaxRetries:  3,
+			BaseBackoff: 1 * time.Second,
 		},
 	}
 }

--- a/internal/kubernautagent/enrichment/enricher.go
+++ b/internal/kubernautagent/enrichment/enricher.go
@@ -125,6 +125,10 @@ type EnrichmentResult struct {
 	ResourceName      string                   `json:"resource_name,omitempty"`
 	ResourceNamespace string                   `json:"resource_namespace,omitempty"`
 	OwnerChain        []OwnerChainEntry        `json:"owner_chain"`
+	// OwnerChainError is non-nil when GetOwnerChain fails (resource not found, API error).
+	// The investigator uses this to trigger rca_incomplete (BR-HAPI-261 AC#7, #704).
+	// A nil value with an empty OwnerChain means "no controller owners" (legitimate).
+	OwnerChainError   error                    `json:"-"`
 	DetectedLabels    *DetectedLabels          `json:"detected_labels,omitempty"`
 	QuotaDetails      map[string]string        `json:"quota_details,omitempty"`
 	RemediationHistory *RemediationHistoryResult `json:"remediation_history,omitempty"`
@@ -182,6 +186,7 @@ func (e *Enricher) Enrich(ctx context.Context, kind, name, namespace, specHash, 
 	chain, err := e.k8s.GetOwnerChain(ctx, kind, name, namespace)
 	if err != nil {
 		ownerErr = err
+		result.OwnerChainError = err
 		e.logger.Warn("enrichment: owner chain resolution failed",
 			slog.String("resource", namespace+"/"+kind+"/"+name),
 			slog.String("error", err.Error()),

--- a/internal/kubernautagent/enrichment/enricher.go
+++ b/internal/kubernautagent/enrichment/enricher.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/pkg/shared/backoff"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // OwnerChainEntry represents a single entry in a Kubernetes owner chain.
@@ -119,6 +121,15 @@ type MetricDeltas struct {
 	ErrorRateAfter    *float64 `json:"error_rate_after,omitempty"`
 }
 
+// RetryConfig controls retry behavior for infrastructure calls in Enrich().
+// With MaxRetries=0 (default), enrichment is best-effort (current behavior).
+// With MaxRetries>0, transient errors are retried with exponential backoff
+// and permanent failures trigger HardFail on EnrichmentResult.
+type RetryConfig struct {
+	MaxRetries  int
+	BaseBackoff time.Duration
+}
+
 // EnrichmentResult is the combined enrichment data.
 type EnrichmentResult struct {
 	ResourceKind      string                   `json:"resource_kind,omitempty"`
@@ -126,9 +137,14 @@ type EnrichmentResult struct {
 	ResourceNamespace string                   `json:"resource_namespace,omitempty"`
 	OwnerChain        []OwnerChainEntry        `json:"owner_chain"`
 	// OwnerChainError is non-nil when GetOwnerChain fails (resource not found, API error).
-	// The investigator uses this to trigger rca_incomplete (BR-HAPI-261 AC#7, #704).
-	// A nil value with an empty OwnerChain means "no controller owners" (legitimate).
+	// Set for observability regardless of retry mode.
 	OwnerChainError   error                    `json:"-"`
+	// HardFail is true when owner chain resolution fails definitively:
+	// either a permanent error (NotFound, Forbidden) or transient error
+	// after retry exhaustion. The investigator uses this to trigger
+	// rca_incomplete (BR-HAPI-261 AC#7, #704). Only set when RetryConfig
+	// has MaxRetries > 0 (strict enrichment mode).
+	HardFail          bool                     `json:"-"`
 	DetectedLabels    *DetectedLabels          `json:"detected_labels,omitempty"`
 	QuotaDetails      map[string]string        `json:"quota_details,omitempty"`
 	RemediationHistory *RemediationHistoryResult `json:"remediation_history,omitempty"`
@@ -141,6 +157,7 @@ type Enricher struct {
 	auditStore    audit.AuditStore
 	logger        *slog.Logger
 	labelDetector *LabelDetector
+	retryConfig   RetryConfig
 }
 
 // NewEnricher creates an enricher with the given clients.
@@ -157,6 +174,74 @@ func NewEnricher(k8s K8sClient, ds DataStorageClient, auditStore audit.AuditStor
 func (e *Enricher) WithLabelDetector(ld *LabelDetector) *Enricher {
 	e.labelDetector = ld
 	return e
+}
+
+// WithRetryConfig sets the retry policy for infrastructure calls.
+func (e *Enricher) WithRetryConfig(cfg RetryConfig) *Enricher {
+	e.retryConfig = cfg
+	return e
+}
+
+// resolveOwnerChainWithRetry calls GetOwnerChain with optional retry logic.
+// With MaxRetries=0 (default): single call, best-effort.
+// With MaxRetries>0: transient errors are retried with exponential backoff;
+// permanent errors return immediately without retry. The caller sets HardFail
+// on EnrichmentResult based on whether this returns a non-nil error.
+func (e *Enricher) resolveOwnerChainWithRetry(ctx context.Context, kind, name, namespace string) ([]OwnerChainEntry, error) {
+	chain, err := e.k8s.GetOwnerChain(ctx, kind, name, namespace)
+	if err == nil {
+		return chain, nil
+	}
+
+	if e.retryConfig.MaxRetries == 0 {
+		return nil, err
+	}
+
+	if !isTransientK8sError(err) {
+		return nil, err
+	}
+
+	boCfg := backoff.Config{
+		BasePeriod: e.retryConfig.BaseBackoff,
+		Multiplier: 2.0,
+		MaxPeriod:  e.retryConfig.BaseBackoff * 4,
+	}
+
+	for attempt := 1; attempt <= e.retryConfig.MaxRetries; attempt++ {
+		wait := boCfg.Calculate(int32(attempt))
+		e.logger.Info("enrichment: retrying GetOwnerChain",
+			slog.Int("attempt", attempt),
+			slog.Duration("backoff", wait),
+		)
+
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(wait):
+		}
+
+		chain, err = e.k8s.GetOwnerChain(ctx, kind, name, namespace)
+		if err == nil {
+			return chain, nil
+		}
+
+		if !isTransientK8sError(err) {
+			return nil, err
+		}
+	}
+
+	return nil, err
+}
+
+// isTransientK8sError classifies K8s API errors as retryable (transient) or
+// permanent. NotFound, Forbidden, Gone, etc. are permanent. Timeout, 503,
+// 500, and 429 are transient. Non-StatusError types are treated as permanent.
+func isTransientK8sError(err error) bool {
+	return apierrors.IsTimeout(err) ||
+		apierrors.IsServerTimeout(err) ||
+		apierrors.IsServiceUnavailable(err) ||
+		apierrors.IsInternalError(err) ||
+		apierrors.IsTooManyRequests(err)
 }
 
 // Enrich resolves enrichment data for the given resource.
@@ -183,13 +268,15 @@ func (e *Enricher) Enrich(ctx context.Context, kind, name, namespace, specHash, 
 
 	var ownerErr, histErr error
 
-	chain, err := e.k8s.GetOwnerChain(ctx, kind, name, namespace)
-	if err != nil {
-		ownerErr = err
-		result.OwnerChainError = err
+	chain, ownerErr := e.resolveOwnerChainWithRetry(ctx, kind, name, namespace)
+	if ownerErr != nil {
+		result.OwnerChainError = ownerErr
+		if e.retryConfig.MaxRetries > 0 {
+			result.HardFail = true
+		}
 		e.logger.Warn("enrichment: owner chain resolution failed",
 			slog.String("resource", namespace+"/"+kind+"/"+name),
-			slog.String("error", err.Error()),
+			slog.String("error", ownerErr.Error()),
 		)
 	} else {
 		result.OwnerChain = chain

--- a/internal/kubernautagent/enrichment/enricher.go
+++ b/internal/kubernautagent/enrichment/enricher.go
@@ -123,8 +123,9 @@ type MetricDeltas struct {
 
 // RetryConfig controls retry behavior for infrastructure calls in Enrich().
 // With MaxRetries=0 (default), enrichment is best-effort (current behavior).
-// With MaxRetries>0, transient errors are retried with exponential backoff
-// and permanent failures trigger HardFail on EnrichmentResult.
+// With MaxRetries>0, all errors are retried with exponential backoff and
+// failures after exhaustion trigger HardFail on EnrichmentResult.
+// Matches HAPI v1.2.1 EnrichmentService behavior (BR-HAPI-261 AC#7).
 type RetryConfig struct {
 	MaxRetries  int
 	BaseBackoff time.Duration
@@ -139,11 +140,10 @@ type EnrichmentResult struct {
 	// OwnerChainError is non-nil when GetOwnerChain fails (resource not found, API error).
 	// Set for observability regardless of retry mode.
 	OwnerChainError   error                    `json:"-"`
-	// HardFail is true when owner chain resolution fails definitively:
-	// either a permanent error (NotFound, Forbidden) or transient error
-	// after retry exhaustion. The investigator uses this to trigger
-	// rca_incomplete (BR-HAPI-261 AC#7, #704). Only set when RetryConfig
-	// has MaxRetries > 0 (strict enrichment mode).
+	// HardFail is true when owner chain resolution fails after retry
+	// exhaustion (all errors retried, matching HAPI v1.2.1). The
+	// investigator uses this to trigger rca_incomplete (BR-HAPI-261
+	// AC#7, #704). Only set when RetryConfig has MaxRetries > 0.
 	HardFail          bool                     `json:"-"`
 	DetectedLabels    *DetectedLabels          `json:"detected_labels,omitempty"`
 	QuotaDetails      map[string]string        `json:"quota_details,omitempty"`
@@ -184,9 +184,9 @@ func (e *Enricher) WithRetryConfig(cfg RetryConfig) *Enricher {
 
 // resolveOwnerChainWithRetry calls GetOwnerChain with optional retry logic.
 // With MaxRetries=0 (default): single call, best-effort.
-// With MaxRetries>0: transient errors are retried with exponential backoff;
-// permanent errors return immediately without retry. The caller sets HardFail
-// on EnrichmentResult based on whether this returns a non-nil error.
+// With MaxRetries>0: all errors are retried with exponential backoff,
+// matching HAPI v1.2.1 EnrichmentService._retry (except Exception → retry).
+// The caller sets HardFail on EnrichmentResult when this returns a non-nil error.
 func (e *Enricher) resolveOwnerChainWithRetry(ctx context.Context, kind, name, namespace string) ([]OwnerChainEntry, error) {
 	chain, err := e.k8s.GetOwnerChain(ctx, kind, name, namespace)
 	if err == nil {
@@ -194,10 +194,6 @@ func (e *Enricher) resolveOwnerChainWithRetry(ctx context.Context, kind, name, n
 	}
 
 	if e.retryConfig.MaxRetries == 0 {
-		return nil, err
-	}
-
-	if !isTransientK8sError(err) {
 		return nil, err
 	}
 
@@ -224,18 +220,14 @@ func (e *Enricher) resolveOwnerChainWithRetry(ctx context.Context, kind, name, n
 		if err == nil {
 			return chain, nil
 		}
-
-		if !isTransientK8sError(err) {
-			return nil, err
-		}
 	}
 
 	return nil, err
 }
 
-// isTransientK8sError classifies K8s API errors as retryable (transient) or
-// permanent. NotFound, Forbidden, Gone, etc. are permanent. Timeout, 503,
-// 500, and 429 are transient. Non-StatusError types are treated as permanent.
+// isTransientK8sError classifies K8s API errors for observability purposes.
+// Not used in the retry path (HAPI retries all errors), but kept for logging
+// and future use in metrics/audit classification.
 func isTransientK8sError(err error) bool {
 	return apierrors.IsTimeout(err) ||
 		apierrors.IsServerTimeout(err) ||

--- a/internal/kubernautagent/enrichment/enricher.go
+++ b/internal/kubernautagent/enrichment/enricher.go
@@ -18,6 +18,7 @@ package enrichment
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"time"
 
@@ -25,6 +26,7 @@ import (
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
 	"github.com/jordigilh/kubernaut/pkg/shared/backoff"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 )
 
 // OwnerChainEntry represents a single entry in a Kubernetes owner chain.
@@ -61,12 +63,12 @@ type DataStorageClient interface {
 
 // RemediationHistoryResult holds the full DS response mapped to domain types.
 type RemediationHistoryResult struct {
-	TargetResource     string          `json:"target_resource"`
-	RegressionDetected bool            `json:"regression_detected"`
-	Tier1              []Tier1Entry    `json:"tier1"`
-	Tier1Window        string          `json:"tier1_window"`
-	Tier2              []Tier2Summary  `json:"tier2"`
-	Tier2Window        string          `json:"tier2_window"`
+	TargetResource     string         `json:"target_resource"`
+	RegressionDetected bool           `json:"regression_detected"`
+	Tier1              []Tier1Entry   `json:"tier1"`
+	Tier1Window        string         `json:"tier1_window"`
+	Tier2              []Tier2Summary `json:"tier2"`
+	Tier2Window        string         `json:"tier2_window"`
 }
 
 // Tier1Entry is a detailed remediation history record (recent window).
@@ -88,14 +90,14 @@ type Tier1Entry struct {
 
 // Tier2Summary is a compact historical remediation record (wider window).
 type Tier2Summary struct {
-	RemediationUID     string   `json:"remediation_uid"`
-	SignalType         string   `json:"signal_type,omitempty"`
-	ActionType         string   `json:"action_type,omitempty"`
-	Outcome            string   `json:"outcome,omitempty"`
-	EffectivenessScore *float64 `json:"effectiveness_score,omitempty"`
-	SignalResolved     *bool    `json:"signal_resolved,omitempty"`
-	HashMatch          string   `json:"hash_match,omitempty"`
-	AssessmentReason   string   `json:"assessment_reason,omitempty"`
+	RemediationUID     string    `json:"remediation_uid"`
+	SignalType         string    `json:"signal_type,omitempty"`
+	ActionType         string    `json:"action_type,omitempty"`
+	Outcome            string    `json:"outcome,omitempty"`
+	EffectivenessScore *float64  `json:"effectiveness_score,omitempty"`
+	SignalResolved     *bool     `json:"signal_resolved,omitempty"`
+	HashMatch          string    `json:"hash_match,omitempty"`
+	AssessmentReason   string    `json:"assessment_reason,omitempty"`
 	CompletedAt        time.Time `json:"completed_at"`
 }
 
@@ -111,14 +113,14 @@ type HealthChecks struct {
 
 // MetricDeltas holds before/after metric measurements.
 type MetricDeltas struct {
-	CpuBefore         *float64 `json:"cpu_before,omitempty"`
-	CpuAfter          *float64 `json:"cpu_after,omitempty"`
-	MemoryBefore      *float64 `json:"memory_before,omitempty"`
-	MemoryAfter       *float64 `json:"memory_after,omitempty"`
+	CpuBefore          *float64 `json:"cpu_before,omitempty"`
+	CpuAfter           *float64 `json:"cpu_after,omitempty"`
+	MemoryBefore       *float64 `json:"memory_before,omitempty"`
+	MemoryAfter        *float64 `json:"memory_after,omitempty"`
 	LatencyP95BeforeMs *float64 `json:"latency_p95_before_ms,omitempty"`
 	LatencyP95AfterMs  *float64 `json:"latency_p95_after_ms,omitempty"`
-	ErrorRateBefore   *float64 `json:"error_rate_before,omitempty"`
-	ErrorRateAfter    *float64 `json:"error_rate_after,omitempty"`
+	ErrorRateBefore    *float64 `json:"error_rate_before,omitempty"`
+	ErrorRateAfter     *float64 `json:"error_rate_after,omitempty"`
 }
 
 // RetryConfig controls retry behavior for infrastructure calls in Enrich().
@@ -133,20 +135,20 @@ type RetryConfig struct {
 
 // EnrichmentResult is the combined enrichment data.
 type EnrichmentResult struct {
-	ResourceKind      string                   `json:"resource_kind,omitempty"`
-	ResourceName      string                   `json:"resource_name,omitempty"`
-	ResourceNamespace string                   `json:"resource_namespace,omitempty"`
-	OwnerChain        []OwnerChainEntry        `json:"owner_chain"`
+	ResourceKind      string            `json:"resource_kind,omitempty"`
+	ResourceName      string            `json:"resource_name,omitempty"`
+	ResourceNamespace string            `json:"resource_namespace,omitempty"`
+	OwnerChain        []OwnerChainEntry `json:"owner_chain"`
 	// OwnerChainError is non-nil when GetOwnerChain fails (resource not found, API error).
 	// Set for observability regardless of retry mode.
-	OwnerChainError   error                    `json:"-"`
+	OwnerChainError error `json:"-"`
 	// HardFail is true when owner chain resolution fails after retry
 	// exhaustion (all errors retried, matching HAPI v1.2.1). The
 	// investigator uses this to trigger rca_incomplete (BR-HAPI-261
 	// AC#7, #704). Only set when RetryConfig has MaxRetries > 0.
-	HardFail          bool                     `json:"-"`
-	DetectedLabels    *DetectedLabels          `json:"detected_labels,omitempty"`
-	QuotaDetails      map[string]string        `json:"quota_details,omitempty"`
+	HardFail           bool                      `json:"-"`
+	DetectedLabels     *DetectedLabels           `json:"detected_labels,omitempty"`
+	QuotaDetails       map[string]string         `json:"quota_details,omitempty"`
 	RemediationHistory *RemediationHistoryResult `json:"remediation_history,omitempty"`
 }
 
@@ -226,6 +228,15 @@ func (e *Enricher) resolveOwnerChainWithRetry(ctx context.Context, kind, name, n
 }
 
 // isTransientK8sError classifies K8s API errors for observability purposes.
+// IsNoMatchError returns true if the error indicates an unknown Kind/resource
+// type (CRD not registered with the API server). This distinguishes schema
+// limitations (e.g. cert-manager not installed) from actual resource failures.
+func IsNoMatchError(err error) bool {
+	var noResource *meta.NoResourceMatchError
+	var noKind *meta.NoKindMatchError
+	return errors.As(err, &noResource) || errors.As(err, &noKind)
+}
+
 // Not used in the retry path (HAPI retries all errors), but kept for logging
 // and future use in metrics/audit classification.
 func isTransientK8sError(err error) bool {
@@ -263,7 +274,7 @@ func (e *Enricher) Enrich(ctx context.Context, kind, name, namespace, specHash, 
 	chain, ownerErr := e.resolveOwnerChainWithRetry(ctx, kind, name, namespace)
 	if ownerErr != nil {
 		result.OwnerChainError = ownerErr
-		if e.retryConfig.MaxRetries > 0 {
+		if e.retryConfig.MaxRetries > 0 && !IsNoMatchError(ownerErr) {
 			result.HardFail = true
 		}
 		e.logger.Warn("enrichment: owner chain resolution failed",

--- a/internal/kubernautagent/enrichment/k8s_adapter.go
+++ b/internal/kubernautagent/enrichment/k8s_adapter.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 
 	"github.com/jordigilh/kubernaut/pkg/shared/hash"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
 )
@@ -150,13 +150,27 @@ func (a *K8sAdapter) GetSpecHash(ctx context.Context, kind, name, namespace stri
 	return h, nil
 }
 
+// resettableMapper is satisfied by restmapper.DeferredDiscoveryRESTMapper
+// and allows resolveGVR to invalidate stale discovery caches when CRDs are
+// installed after the agent starts.
+type resettableMapper interface {
+	Reset()
+}
+
 func (a *K8sAdapter) resolveGVR(kind string) (schema.GroupVersionResource, error) {
 	plural := strings.ToLower(kind) + "s"
 	gvr, err := a.mapper.ResourceFor(schema.GroupVersionResource{Resource: plural})
-	if err != nil {
-		return schema.GroupVersionResource{}, err
+	if err == nil {
+		return gvr, nil
 	}
-	return gvr, nil
+	if rm, ok := a.mapper.(resettableMapper); ok {
+		rm.Reset()
+		gvr, retryErr := a.mapper.ResourceFor(schema.GroupVersionResource{Resource: plural})
+		if retryErr == nil {
+			return gvr, nil
+		}
+	}
+	return schema.GroupVersionResource{}, err
 }
 
 func (a *K8sAdapter) resolveOwnerGVR(ref metav1.OwnerReference) (schema.GroupVersionResource, error) {

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -149,6 +149,10 @@ func (inv *Investigator) Investigate(ctx context.Context, signal katypes.SignalC
 
 		// BR-HAPI-261 AC#7 / #704: check HardFail BEFORE label merge
 		// to prevent the merge from silently dropping the failure signal.
+		// Use enrichData (initial enrichment) for labels because the failed
+		// re-enrichment has empty/all-failed detections — preserving signal-level
+		// labels (e.g. pdbProtected) matches pre-#704 behaviour where
+		// allLabelDetectionsFailed() fell through to keep initial labels.
 		if reEnriched != nil && reEnriched.HardFail {
 			inv.logger.Warn("enrichment owner chain hard-failed, triggering rca_incomplete",
 				slog.String("error", reEnriched.OwnerChainError.Error()),
@@ -156,8 +160,8 @@ func (inv *Investigator) Investigate(ctx context.Context, signal katypes.SignalC
 			rcaResult.HumanReviewNeeded = true
 			rcaResult.HumanReviewReason = "rca_incomplete"
 			backfillSeverity(rcaResult, signal)
-			attachDetectedLabels(rcaResult, reEnriched)
-			InjectRemediationTarget(rcaResult, workflowSignal, reEnriched)
+			attachDetectedLabels(rcaResult, enrichData)
+			InjectRemediationTarget(rcaResult, workflowSignal, enrichData)
 			injectTargetResourceParameters(rcaResult)
 			inv.emitResponseComplete(ctx, rcaResult, tokens, correlationID)
 			return rcaResult, nil

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -146,6 +146,23 @@ func (inv *Investigator) Investigate(ctx context.Context, signal katypes.SignalC
 			"rca_target", postRCAKind+"/"+postRCAName,
 		)
 		reEnriched := inv.resolveEnrichment(ctx, postRCAKind, postRCAName, postRCANS, signal.IncidentID)
+
+		// BR-HAPI-261 AC#7 / #704: check HardFail BEFORE label merge
+		// to prevent the merge from silently dropping the failure signal.
+		if reEnriched != nil && reEnriched.HardFail {
+			inv.logger.Warn("enrichment owner chain hard-failed, triggering rca_incomplete",
+				slog.String("error", reEnriched.OwnerChainError.Error()),
+			)
+			rcaResult.HumanReviewNeeded = true
+			rcaResult.HumanReviewReason = "rca_incomplete"
+			backfillSeverity(rcaResult, signal)
+			attachDetectedLabels(rcaResult, reEnriched)
+			InjectRemediationTarget(rcaResult, workflowSignal, reEnriched)
+			injectTargetResourceParameters(rcaResult)
+			inv.emitResponseComplete(ctx, rcaResult, tokens, correlationID)
+			return rcaResult, nil
+		}
+
 		if reEnriched != nil && !allLabelDetectionsFailed(reEnriched.DetectedLabels) {
 			enrichData = reEnriched
 		} else if reEnriched != nil {
@@ -159,22 +176,6 @@ func (inv *Investigator) Investigate(ctx context.Context, signal katypes.SignalC
 		workflowSignal.ResourceKind = postRCAKind
 		workflowSignal.ResourceName = postRCAName
 		workflowSignal.Namespace = postRCANS
-	}
-
-	// BR-HAPI-261 AC#7 / #704: owner chain resolution failure → rca_incomplete.
-	// Gate on the final enrichData before workflow selection.
-	if enrichData != nil && enrichData.OwnerChainError != nil {
-		inv.logger.Warn("enrichment owner chain failed, triggering rca_incomplete",
-			slog.String("error", enrichData.OwnerChainError.Error()),
-		)
-		rcaResult.HumanReviewNeeded = true
-		rcaResult.HumanReviewReason = "rca_incomplete"
-		backfillSeverity(rcaResult, signal)
-		attachDetectedLabels(rcaResult, enrichData)
-		InjectRemediationTarget(rcaResult, workflowSignal, enrichData)
-		injectTargetResourceParameters(rcaResult)
-		inv.emitResponseComplete(ctx, rcaResult, tokens, correlationID)
-		return rcaResult, nil
 	}
 
 	if inv.pipeline.AnomalyDetector != nil {

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -161,6 +161,22 @@ func (inv *Investigator) Investigate(ctx context.Context, signal katypes.SignalC
 		workflowSignal.Namespace = postRCANS
 	}
 
+	// BR-HAPI-261 AC#7 / #704: owner chain resolution failure → rca_incomplete.
+	// Gate on the final enrichData before workflow selection.
+	if enrichData != nil && enrichData.OwnerChainError != nil {
+		inv.logger.Warn("enrichment owner chain failed, triggering rca_incomplete",
+			slog.String("error", enrichData.OwnerChainError.Error()),
+		)
+		rcaResult.HumanReviewNeeded = true
+		rcaResult.HumanReviewReason = "rca_incomplete"
+		backfillSeverity(rcaResult, signal)
+		attachDetectedLabels(rcaResult, enrichData)
+		InjectRemediationTarget(rcaResult, workflowSignal, enrichData)
+		injectTargetResourceParameters(rcaResult)
+		inv.emitResponseComplete(ctx, rcaResult, tokens, correlationID)
+		return rcaResult, nil
+	}
+
 	if inv.pipeline.AnomalyDetector != nil {
 		inv.pipeline.AnomalyDetector.Reset()
 	}

--- a/internal/kubernautagent/parser/parser.go
+++ b/internal/kubernautagent/parser/parser.go
@@ -47,6 +47,10 @@ func (p *ResultParser) Parse(content string) (*katypes.InvestigationResult, erro
 	if jsonStr != "" {
 		var result katypes.InvestigationResult
 		if err := json.Unmarshal([]byte(jsonStr), &result); err == nil && (result.RCASummary != "" || result.WorkflowID != "") {
+			// BR-HAPI-200: Clear any HR fields populated by json.Unmarshal via
+			// the "human_review_reason" tag match. HR is parser-derived only.
+			result.HumanReviewNeeded = false
+			result.HumanReviewReason = ""
 			var flat flatLLMFields
 			_ = json.Unmarshal([]byte(jsonStr), &flat)
 			applyFlatFields(&result, flat)
@@ -176,8 +180,6 @@ type llmResponse struct {
 	Confidence           float64           `json:"confidence,omitempty"`
 	Actionable           *bool             `json:"actionable,omitempty"`
 	InvestigationOutcome string            `json:"investigation_outcome,omitempty"`
-	NeedsHumanReview     *bool             `json:"needs_human_review,omitempty"`
-	HumanReviewReason    string            `json:"human_review_reason,omitempty"`
 	DetectedLabels       map[string]interface{} `json:"detected_labels,omitempty"`
 }
 
@@ -224,8 +226,6 @@ type flatLLMFields struct {
 	Severity             string `json:"severity,omitempty"`
 	Actionable           *bool  `json:"actionable,omitempty"`
 	InvestigationOutcome string `json:"investigation_outcome,omitempty"`
-	NeedsHumanReview     *bool  `json:"needs_human_review,omitempty"`
-	HumanReviewReason    string `json:"human_review_reason,omitempty"`
 }
 
 // parseLLMFormat parses the nested LLM response format and converts
@@ -288,8 +288,6 @@ func parseLLMFormat(jsonStr string) (*katypes.InvestigationResult, error) {
 		Severity:             resp.Severity,
 		Actionable:           resp.Actionable,
 		InvestigationOutcome: resp.InvestigationOutcome,
-		NeedsHumanReview:     resp.NeedsHumanReview,
-		HumanReviewReason:    resp.HumanReviewReason,
 	})
 
 	if len(resp.DetectedLabels) > 0 {
@@ -372,16 +370,14 @@ func parseSectionHeaders(content string) (*katypes.InvestigationResult, error) {
 // a map of header → body text. Recognizes headers with and without markdown fencing.
 func extractSections(content string) map[string]string {
 	knownHeaders := map[string]bool{
-		"root_cause_analysis": true,
-		"selected_workflow":   true,
+		"root_cause_analysis":   true,
+		"selected_workflow":     true,
 		"alternative_workflows": true,
-		"confidence":          true,
-		"severity":            true,
-		"actionable":          true,
+		"confidence":            true,
+		"severity":              true,
+		"actionable":            true,
 		"investigation_outcome": true,
-		"needs_human_review":  true,
-		"human_review_reason": true,
-		"detected_labels":     true,
+		"detected_labels":       true,
 	}
 
 	sections := make(map[string]string)
@@ -439,8 +435,7 @@ func mergeNestedRemediationTarget(result *katypes.InvestigationResult, jsonStr s
 
 // applyFlatFields applies LLM-provided flat fields to the result:
 // - actionable: sets IsActionable, synthesizes warning, applies confidence floor
-// - investigation_outcome: maps to outcome routing fields
-// - needs_human_review / human_review_reason: propagates directly
+// - investigation_outcome: maps to outcome routing fields (HR is derived, not propagated)
 func applyFlatFields(result *katypes.InvestigationResult, flat flatLLMFields) {
 	if flat.Severity != "" && result.Severity == "" {
 		result.Severity = flat.Severity
@@ -466,16 +461,9 @@ func applyFlatFields(result *katypes.InvestigationResult, flat flatLLMFields) {
 		applyInvestigationOutcome(result, flat.InvestigationOutcome)
 	}
 
-	if flat.NeedsHumanReview != nil && *flat.NeedsHumanReview {
-		result.HumanReviewNeeded = true
-		if flat.HumanReviewReason != "" {
-			result.HumanReviewReason = flat.HumanReviewReason
-		}
-	}
-
-	// #301: Contradiction override — when the LLM says the problem is resolved
-	// but also sets needs_human_review=true, the resolution takes precedence.
-	// Python KA enforced this; KA must match for AA parity.
+	// #301: Contradiction override — when the outcome is problem_resolved but
+	// the parser-derived HR was set (e.g., via inconclusive outcome fallback),
+	// the resolution takes precedence. Defense-in-depth per HAPI parity.
 	if flat.InvestigationOutcome == "problem_resolved" && result.HumanReviewNeeded {
 		result.HumanReviewNeeded = false
 		result.HumanReviewReason = ""
@@ -506,7 +494,11 @@ func applyInvestigationOutcome(result *katypes.InvestigationResult, outcome stri
 	case "inconclusive":
 		result.HumanReviewNeeded = true
 		if result.HumanReviewReason == "" {
-			result.HumanReviewReason = "investigation_inconclusive"
+			if result.RCASummary != "" && result.WorkflowID == "" {
+				result.HumanReviewReason = "no_matching_workflows"
+			} else {
+				result.HumanReviewReason = "investigation_inconclusive"
+			}
 		}
 	case "actionable":
 		if result.IsActionable == nil {

--- a/internal/kubernautagent/parser/schema.go
+++ b/internal/kubernautagent/parser/schema.go
@@ -116,8 +116,6 @@ const investigationResultSchemaJSON = `{
     "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
     "investigation_outcome": { "type": "string", "enum": ["actionable", "not_actionable", "problem_resolved", "insufficient_data"] },
     "actionable": { "type": "boolean" },
-    "needs_human_review": { "type": "boolean" },
-    "human_review_reason": { "type": "string" },
     "detected_labels": { "type": "object" }
   },
   "required": ["root_cause_analysis", "confidence"]

--- a/internal/kubernautagent/prompt/templates/phase3_workflow_selection.tmpl
+++ b/internal/kubernautagent/prompt/templates/phase3_workflow_selection.tmpl
@@ -116,4 +116,3 @@ Set `selected_workflow` to None, include `actionable: false`.
 - Top-level confidence must match selected_workflow.confidence
 - parameters should only contain workflow-specific values (kind/name/namespace are injected by the system)
 - For non-actionable outcomes, omit selected_workflow and set actionable to false
-- If human review is needed, include "needs_human_review": true and "human_review_reason"

--- a/pkg/datastorage/repository/workflow/crud.go
+++ b/pkg/datastorage/repository/workflow/crud.go
@@ -173,6 +173,133 @@ func (r *Repository) Create(ctx context.Context, workflow *models.RemediationWor
 	return nil
 }
 
+// SupersedeAndCreate atomically marks the old workflow as Superseded and inserts
+// the new one in a single transaction. This eliminates the visibility gap (#707)
+// where the old workflow is already Superseded but the new one doesn't exist yet,
+// causing ListWorkflowsByActionType to return zero results.
+func (r *Repository) SupersedeAndCreate(ctx context.Context, oldID, oldVersion, reason string, newWorkflow *models.RemediationWorkflow) error {
+	tx, err := r.db.BeginTxx(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("failed to begin transaction: %w", err)
+	}
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+
+	supersedeQuery := `
+		UPDATE remediation_workflow_catalog
+		SET status = $1, status_reason = $2, updated_at = NOW()
+		WHERE workflow_id = $3 AND version = $4
+	`
+	result, err := tx.ExecContext(ctx, supersedeQuery, "Superseded", reason, oldID, oldVersion)
+	if err != nil {
+		return fmt.Errorf("failed to supersede workflow %s: %w", oldID, err)
+	}
+	rowsAffected, _ := result.RowsAffected()
+	if rowsAffected == 0 {
+		r.logger.Info("WARNING: supersede target not found",
+			"workflow_id", oldID, "version", oldVersion)
+	}
+
+	if newWorkflow.IsLatestVersion {
+		latestQuery := `
+			UPDATE remediation_workflow_catalog
+			SET is_latest_version = false, updated_at = NOW()
+			WHERE workflow_name = $1 AND is_latest_version = true
+		`
+		if _, err = tx.ExecContext(ctx, latestQuery, newWorkflow.WorkflowName); err != nil {
+			return fmt.Errorf("failed to update previous versions: %w", err)
+		}
+	}
+
+	var insertQuery string
+	var args []interface{}
+
+	if newWorkflow.WorkflowID != "" {
+		insertQuery = `
+			INSERT INTO remediation_workflow_catalog (
+				workflow_id,
+				workflow_name, version, schema_version, name, description, owner, maintainer,
+				content, content_hash, parameters, execution_engine, schema_image, schema_digest,
+				execution_bundle, execution_bundle_digest, engine_config,
+				labels, custom_labels, detected_labels, status,
+				is_latest_version, previous_version, version_notes, change_summary,
+				approved_by, approved_at, expected_success_rate, expected_duration_seconds,
+				created_by, action_type, service_account_name
+			) VALUES (
+				$1, $2, $3, $4, $5, $6, $7, $8,
+				$9, $10, $11, $12, $13, $14,
+				$15, $16, $17,
+				$18, $19, $20, $21,
+				$22, $23, $24, $25,
+				$26, $27, $28, $29,
+				$30, $31, $32
+			)
+			RETURNING workflow_id
+		`
+		args = []interface{}{
+			newWorkflow.WorkflowID,
+			newWorkflow.WorkflowName, newWorkflow.Version, newWorkflow.SchemaVersion, newWorkflow.Name, newWorkflow.Description, newWorkflow.Owner, newWorkflow.Maintainer,
+			newWorkflow.Content, newWorkflow.ContentHash, newWorkflow.Parameters, newWorkflow.ExecutionEngine, newWorkflow.SchemaImage, newWorkflow.SchemaDigest,
+			newWorkflow.ExecutionBundle, newWorkflow.ExecutionBundleDigest, newWorkflow.EngineConfig,
+			newWorkflow.Labels, newWorkflow.CustomLabels, newWorkflow.DetectedLabels, newWorkflow.Status,
+			newWorkflow.IsLatestVersion, newWorkflow.PreviousVersion, newWorkflow.VersionNotes, newWorkflow.ChangeSummary,
+			newWorkflow.ApprovedBy, newWorkflow.ApprovedAt, newWorkflow.ExpectedSuccessRate, newWorkflow.ExpectedDurationSeconds,
+			newWorkflow.CreatedBy, newWorkflow.ActionType, newWorkflow.ServiceAccountName,
+		}
+	} else {
+		insertQuery = `
+			INSERT INTO remediation_workflow_catalog (
+				workflow_name, version, schema_version, name, description, owner, maintainer,
+				content, content_hash, parameters, execution_engine, schema_image, schema_digest,
+				execution_bundle, execution_bundle_digest, engine_config,
+				labels, custom_labels, detected_labels, status,
+				is_latest_version, previous_version, version_notes, change_summary,
+				approved_by, approved_at, expected_success_rate, expected_duration_seconds,
+				created_by, action_type, service_account_name
+			) VALUES (
+				$1, $2, $3, $4, $5, $6, $7,
+				$8, $9, $10, $11, $12, $13,
+				$14, $15, $16,
+				$17, $18, $19, $20,
+				$21, $22, $23, $24,
+				$25, $26, $27, $28,
+				$29, $30, $31
+			)
+			RETURNING workflow_id
+		`
+		args = []interface{}{
+			newWorkflow.WorkflowName, newWorkflow.Version, newWorkflow.SchemaVersion, newWorkflow.Name, newWorkflow.Description, newWorkflow.Owner, newWorkflow.Maintainer,
+			newWorkflow.Content, newWorkflow.ContentHash, newWorkflow.Parameters, newWorkflow.ExecutionEngine, newWorkflow.SchemaImage, newWorkflow.SchemaDigest,
+			newWorkflow.ExecutionBundle, newWorkflow.ExecutionBundleDigest, newWorkflow.EngineConfig,
+			newWorkflow.Labels, newWorkflow.CustomLabels, newWorkflow.DetectedLabels, newWorkflow.Status,
+			newWorkflow.IsLatestVersion, newWorkflow.PreviousVersion, newWorkflow.VersionNotes, newWorkflow.ChangeSummary,
+			newWorkflow.ApprovedBy, newWorkflow.ApprovedAt, newWorkflow.ExpectedSuccessRate, newWorkflow.ExpectedDurationSeconds,
+			newWorkflow.CreatedBy, newWorkflow.ActionType, newWorkflow.ServiceAccountName,
+		}
+	}
+
+	var confirmedID string
+	if err = tx.QueryRowContext(ctx, insertQuery, args...).Scan(&confirmedID); err != nil {
+		return fmt.Errorf("failed to create workflow: %w", err)
+	}
+	newWorkflow.WorkflowID = confirmedID
+
+	if err = tx.Commit(); err != nil {
+		return fmt.Errorf("failed to commit transaction: %w", err)
+	}
+
+	r.logger.Info("workflow superseded and new version created",
+		"old_workflow_id", oldID,
+		"new_workflow_id", newWorkflow.WorkflowID,
+		"workflow_name", newWorkflow.WorkflowName,
+		"version", newWorkflow.Version)
+
+	return nil
+}
+
 // ========================================
 // READ OPERATIONS
 // ========================================

--- a/pkg/datastorage/repository/workflow/crud.go
+++ b/pkg/datastorage/repository/workflow/crud.go
@@ -60,7 +60,8 @@ func (r *Repository) Create(ctx context.Context, workflow *models.RemediationWor
 			SET is_latest_version = false, updated_at = NOW()
 			WHERE workflow_name = $1 AND is_latest_version = true
 		`
-		result, err := tx.ExecContext(ctx, updateQuery, workflow.WorkflowName)
+		var result sql.Result
+		result, err = tx.ExecContext(ctx, updateQuery, workflow.WorkflowName)
 		if err != nil {
 			r.logger.Error(err, "failed to update previous versions",
 				"workflow_name", workflow.WorkflowName,

--- a/pkg/datastorage/server/handler.go
+++ b/pkg/datastorage/server/handler.go
@@ -91,6 +91,7 @@ type WorkflowContentIntegrityRepository interface {
 	GetActiveByWorkflowName(ctx context.Context, workflowName string) (*models.RemediationWorkflow, error)
 	GetLatestDisabledByNameAndVersion(ctx context.Context, workflowName, version string) (*models.RemediationWorkflow, error)
 	UpdateStatus(ctx context.Context, workflowID, version, status, reason, updatedBy string) error
+	SupersedeAndCreate(ctx context.Context, oldID, oldVersion, reason string, newWorkflow *models.RemediationWorkflow) error
 }
 
 // ActionTypeValidator validates action types against the taxonomy before DB insertion.

--- a/pkg/datastorage/server/workflow_handlers.go
+++ b/pkg/datastorage/server/workflow_handlers.go
@@ -298,8 +298,11 @@ func (h *Handler) handleDuplicateWorkflow(ctx context.Context, workflow *models.
 		}
 
 		reason := fmt.Sprintf("superseded: content hash changed from %s to %s", active.ContentHash, incomingHash)
-		if err := repo.UpdateStatus(ctx, active.WorkflowID, active.Version, "Superseded", reason, ""); err != nil {
-			return nil, fmt.Errorf("supersede old workflow %s: %w", active.WorkflowID, err)
+		if err := repo.SupersedeAndCreate(ctx, active.WorkflowID, active.Version, reason, workflow); err != nil {
+			if result, handled := h.retryOnUniqueViolation(ctx, err, workflow, incomingHash); handled {
+				return result, nil
+			}
+			return nil, fmt.Errorf("supersede and create after hash change: %w", err)
 		}
 
 		h.logger.Info("Workflow superseded due to content hash change",
@@ -308,13 +311,6 @@ func (h *Handler) handleDuplicateWorkflow(ctx context.Context, workflow *models.
 			"old_hash", active.ContentHash,
 			"new_hash", incomingHash,
 		)
-
-		if err := repo.Create(ctx, workflow); err != nil {
-			if result, handled := h.retryOnUniqueViolation(ctx, err, workflow, incomingHash); handled {
-				return result, nil
-			}
-			return nil, fmt.Errorf("create new workflow after supersede: %w", err)
-		}
 		return &duplicateResult{workflow: workflow, statusCode: http.StatusCreated}, nil
 	}
 
@@ -367,8 +363,11 @@ func (h *Handler) handleDuplicateWorkflow(ctx context.Context, workflow *models.
 
 	if activeAnyVersion != nil {
 		reason := fmt.Sprintf("superseded: new version %s registered (was %s)", workflow.Version, activeAnyVersion.Version)
-		if err := repo.UpdateStatus(ctx, activeAnyVersion.WorkflowID, activeAnyVersion.Version, "Superseded", reason, ""); err != nil {
-			return nil, fmt.Errorf("supersede old version %s: %w", activeAnyVersion.WorkflowID, err)
+		if err := repo.SupersedeAndCreate(ctx, activeAnyVersion.WorkflowID, activeAnyVersion.Version, reason, workflow); err != nil {
+			if result, handled := h.retryOnUniqueViolation(ctx, err, workflow, incomingHash); handled {
+				return result, nil
+			}
+			return nil, fmt.Errorf("supersede and create after cross-version update: %w", err)
 		}
 
 		h.logger.Info("Workflow superseded due to cross-version update (Issue #371)",
@@ -377,13 +376,6 @@ func (h *Handler) handleDuplicateWorkflow(ctx context.Context, workflow *models.
 			"workflow_name", activeAnyVersion.WorkflowName,
 			"new_version", workflow.Version,
 		)
-
-		if err := repo.Create(ctx, workflow); err != nil {
-			if result, handled := h.retryOnUniqueViolation(ctx, err, workflow, incomingHash); handled {
-				return result, nil
-			}
-			return nil, fmt.Errorf("create new workflow after cross-version supersede: %w", err)
-		}
 		return &duplicateResult{workflow: workflow, statusCode: http.StatusCreated}, nil
 	}
 

--- a/test/e2e/aianalysis/05_audit_trail_test.go
+++ b/test/e2e/aianalysis/05_audit_trail_test.go
@@ -377,11 +377,13 @@ var _ = Describe("Audit Trail E2E", Label("e2e", "audit"), func() {
 			Expect(k8sClient.Create(ctx, analysis)).To(Succeed())
 
 		By("Waiting for reconciliation to complete")
-		// Uses SetDefaultEventuallyTimeout(30s) from suite_test.go (per RCA Jan 31, 2026)
+		// Accepts Completed or Failed: when the mock LLM default fallback targets
+		// a resource absent from Kind, #704 HardFail triggers rca_incomplete which
+		// the reconciler maps to Failed. The audit events are recorded regardless.
 		Eventually(func() string {
 			_ = k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), analysis)
 			return string(analysis.Status.Phase)
-		}).Should(Equal("Completed"))
+		}).Should(SatisfyAny(Equal("Completed"), Equal("Failed")))
 
 			remediationID := analysis.Spec.RemediationID
 

--- a/test/e2e/datastorage/04_workflow_discovery_test.go
+++ b/test/e2e/datastorage/04_workflow_discovery_test.go
@@ -96,30 +96,35 @@ var _ = Describe("E2E-DS-017-001: Three-Step Workflow Discovery (DD-HAPI-017)", 
 			logger.Info("✅ Step 1: Action types listed", "count", len(actionTypes.ActionTypes))
 
 			// STEP 2: List workflows for ScaleReplicas
-			step2Resp, err := DSClient.ListWorkflowsByActionType(testCtx, dsgen.ListWorkflowsByActionTypeParams{
-				ActionType:  "ScaleReplicas",
-				Severity:    dsgen.ListWorkflowsByActionTypeSeverityCritical,
-				Component:   "pod",
-				Environment: "production",
-				Priority:    dsgen.ListWorkflowsByActionTypePriorityP0,
-				Limit:       dsgen.NewOptInt(100),
-			})
-			Expect(err).ToNot(HaveOccurred())
-
-			workflows, ok := step2Resp.(*dsgen.WorkflowDiscoveryResponse)
-			Expect(ok).To(BeTrue(), "Expected *WorkflowDiscoveryResponse")
-			Expect(workflows.Workflows).ToNot(BeEmpty(), "Should return at least 1 workflow")
-
-			// Find our workflow in the results
+			// Use Eventually to tolerate transient visibility windows during parallel
+			// workflow registration (#707: non-atomic supersede can create brief gaps).
 			var foundWorkflowID string
-			for _, wf := range workflows.Workflows {
-				if wf.WorkflowId.String() == discoveryWorkflowID {
-					foundWorkflowID = wf.WorkflowId.String()
-					break
+			Eventually(func() string {
+				step2Resp, listErr := DSClient.ListWorkflowsByActionType(testCtx, dsgen.ListWorkflowsByActionTypeParams{
+					ActionType:  "ScaleReplicas",
+					Severity:    dsgen.ListWorkflowsByActionTypeSeverityCritical,
+					Component:   "pod",
+					Environment: "production",
+					Priority:    dsgen.ListWorkflowsByActionTypePriorityP0,
+					Limit:       dsgen.NewOptInt(100),
+				})
+				if listErr != nil {
+					return ""
 				}
-			}
-			Expect(foundWorkflowID).To(Equal(discoveryWorkflowID), "Discovery test workflow should be listed")
-			logger.Info("✅ Step 2: Workflows listed", "count", len(workflows.Workflows))
+				workflows, ok := step2Resp.(*dsgen.WorkflowDiscoveryResponse)
+				if !ok || len(workflows.Workflows) == 0 {
+					return ""
+				}
+				for _, wf := range workflows.Workflows {
+					if wf.WorkflowId.String() == discoveryWorkflowID {
+						return wf.WorkflowId.String()
+					}
+				}
+				return ""
+			}, 30*time.Second, 2*time.Second).Should(Equal(discoveryWorkflowID),
+				"Discovery test workflow should be listed")
+			foundWorkflowID = discoveryWorkflowID
+			logger.Info("✅ Step 2: Workflows listed", "foundID", foundWorkflowID)
 
 			// STEP 3: Get full workflow detail with context filters (security gate)
 			workflowUUID, err := uuid.Parse(discoveryWorkflowID)

--- a/test/e2e/datastorage/25_detected_labels_search_e2e_test.go
+++ b/test/e2e/datastorage/25_detected_labels_search_e2e_test.go
@@ -142,29 +142,35 @@ var _ = Describe("E2E-DS-043: DetectedLabels OCI Registration and Retrieval", Or
 
 	It("E2E-DS-043-004: HTTP search with detected_labels query parameter returns filtered results", func() {
 		By("searching with matching detected_labels filter (hpaEnabled=true)")
-		matchResp, err := DSClient.ListWorkflowsByActionType(testCtx, dsgen.ListWorkflowsByActionTypeParams{
-			ActionType:     "ScaleReplicas",
-			Severity:       dsgen.ListWorkflowsByActionTypeSeverityCritical,
-			Component:      "pod",
-			Environment:    "production",
-			Priority:       dsgen.ListWorkflowsByActionTypePriorityP0,
-			DetectedLabels: dsgen.NewOptString(`{"hpaEnabled":true}`),
-			Limit:          dsgen.NewOptInt(100),
-		})
-		Expect(err).ToNot(HaveOccurred())
-
-		matchWorkflows, ok := matchResp.(*dsgen.WorkflowDiscoveryResponse)
-		Expect(ok).To(BeTrue(), "Expected *WorkflowDiscoveryResponse")
-
+		// Use Eventually to tolerate transient visibility windows during parallel
+		// workflow registration (#707: non-atomic supersede can create brief gaps).
 		var foundMatchingWorkflow bool
-		for _, wf := range matchWorkflows.Workflows {
-			if wf.WorkflowName == "e2e-stub" {
-				foundMatchingWorkflow = true
-				break
+		Eventually(func() bool {
+			matchResp, listErr := DSClient.ListWorkflowsByActionType(testCtx, dsgen.ListWorkflowsByActionTypeParams{
+				ActionType:     "ScaleReplicas",
+				Severity:       dsgen.ListWorkflowsByActionTypeSeverityCritical,
+				Component:      "pod",
+				Environment:    "production",
+				Priority:       dsgen.ListWorkflowsByActionTypePriorityP0,
+				DetectedLabels: dsgen.NewOptString(`{"hpaEnabled":true}`),
+				Limit:          dsgen.NewOptInt(100),
+			})
+			if listErr != nil {
+				return false
 			}
-		}
-		Expect(foundMatchingWorkflow).To(BeTrue(),
+			matchWorkflows, ok := matchResp.(*dsgen.WorkflowDiscoveryResponse)
+			if !ok {
+				return false
+			}
+			for _, wf := range matchWorkflows.Workflows {
+				if wf.WorkflowName == "e2e-stub" {
+					return true
+				}
+			}
+			return false
+		}, 30*time.Second, 2*time.Second).Should(BeTrue(),
 			"e2e-stub (hpaEnabled=true) should appear when filtering by hpaEnabled=true")
+		foundMatchingWorkflow = true
 
 		By("searching with non-matching detected_labels filter (networkIsolated=true)")
 		nonMatchResp, err := DSClient.ListWorkflowsByActionType(testCtx, dsgen.ListWorkflowsByActionTypeParams{

--- a/test/e2e/kubernautagent/adversarial_parity_e2e_test.go
+++ b/test/e2e/kubernautagent/adversarial_parity_e2e_test.go
@@ -305,7 +305,9 @@ var _ = Describe("E2E-KA-433-ADV: Adversarial Parity Tests", Label("e2e", "ka", 
 			), "no_workflow_found should produce a valid HR reason enum")
 		})
 
-		It("E2E-KA-433-ADV-016: rca_incomplete → correct HR reason enum", func() {
+		// BR-HAPI-261 AC#7 / #704: enrichment-driven rca_incomplete.
+		// Target Pods don't exist in Kind cluster → GetOwnerChain fails → rca_incomplete.
+		It("E2E-KA-433-ADV-016: rca_incomplete → needs_human_review=true", func() {
 			req := buildRequest("adv-016", "mock_rca_incomplete", "critical")
 			result, err := sessionClient.Investigate(ctx, req)
 			Expect(err).NotTo(HaveOccurred())
@@ -314,13 +316,11 @@ var _ = Describe("E2E-KA-433-ADV: Adversarial Parity Tests", Label("e2e", "ka", 
 			needsHR, hasHR := result.NeedsHumanReview.Get()
 			Expect(hasHR).To(BeTrue(), "M1: needs_human_review must always be set")
 			Expect(needsHR).To(BeTrue(),
-				"rca_incomplete should require human review")
+				"rca_incomplete: enrichment owner chain failure must trigger human review")
 			hrReason, hasReason := result.HumanReviewReason.Get()
-			Expect(hasReason).To(BeTrue())
-			Expect(string(hrReason)).To(SatisfyAny(
-				Equal("rca_incomplete"),
-				Equal("investigation_inconclusive"),
-			), "rca_incomplete should produce a valid HR reason enum")
+			Expect(hasReason).To(BeTrue(), "human_review_reason must be set when HR=true")
+			Expect(string(hrReason)).To(Equal("rca_incomplete"),
+				"E2E-KA-433-ADV-016: reason must be rca_incomplete per BR-HAPI-261 AC#7")
 		})
 	})
 })

--- a/test/e2e/kubernautagent/adversarial_parity_e2e_test.go
+++ b/test/e2e/kubernautagent/adversarial_parity_e2e_test.go
@@ -306,8 +306,9 @@ var _ = Describe("E2E-KA-433-ADV: Adversarial Parity Tests", Label("e2e", "ka", 
 		})
 
 		// BR-HAPI-261 AC#7 / #704: enrichment-driven rca_incomplete.
-		// Target Pods don't exist in Kind cluster → GetOwnerChain fails → rca_incomplete.
-		It("E2E-KA-433-ADV-016: rca_incomplete → needs_human_review=true", func() {
+		// With HAPI-compliant defaults (MaxRetries=3) and E2E fixtures,
+		// unreachable-pod does NOT exist → NotFound → HardFail → rca_incomplete.
+		It("E2E-KA-433-ADV-016: rca_incomplete triggers needs_human_review", func() {
 			req := buildRequest("adv-016", "mock_rca_incomplete", "critical")
 			result, err := sessionClient.Investigate(ctx, req)
 			Expect(err).NotTo(HaveOccurred())
@@ -316,11 +317,12 @@ var _ = Describe("E2E-KA-433-ADV: Adversarial Parity Tests", Label("e2e", "ka", 
 			needsHR, hasHR := result.NeedsHumanReview.Get()
 			Expect(hasHR).To(BeTrue(), "M1: needs_human_review must always be set")
 			Expect(needsHR).To(BeTrue(),
-				"rca_incomplete: enrichment owner chain failure must trigger human review")
+				"E2E-KA-433-ADV-016: rca_incomplete must trigger needs_human_review=true")
+
 			hrReason, hasReason := result.HumanReviewReason.Get()
-			Expect(hasReason).To(BeTrue(), "human_review_reason must be set when HR=true")
-			Expect(string(hrReason)).To(Equal("rca_incomplete"),
-				"E2E-KA-433-ADV-016: reason must be rca_incomplete per BR-HAPI-261 AC#7")
+			Expect(hasReason).To(BeTrue(), "M2: human_review_reason must be set when needs_human_review=true")
+			Expect(hrReason).To(Equal("rca_incomplete"),
+				"E2E-KA-433-ADV-016: reason must be rca_incomplete (enrichment HardFail)")
 		})
 	})
 })

--- a/test/e2e/kubernautagent/adversarial_parity_e2e_test.go
+++ b/test/e2e/kubernautagent/adversarial_parity_e2e_test.go
@@ -321,8 +321,8 @@ var _ = Describe("E2E-KA-433-ADV: Adversarial Parity Tests", Label("e2e", "ka", 
 
 			hrReason, hasReason := result.HumanReviewReason.Get()
 			Expect(hasReason).To(BeTrue(), "M2: human_review_reason must be set when needs_human_review=true")
-			Expect(hrReason).To(Equal("rca_incomplete"),
-				"E2E-KA-433-ADV-016: reason must be rca_incomplete (enrichment HardFail)")
+		Expect(hrReason).To(BeEquivalentTo("rca_incomplete"),
+			"E2E-KA-433-ADV-016: reason must be rca_incomplete (enrichment HardFail)")
 		})
 	})
 })

--- a/test/fixtures/mockllm/all_scenarios.json
+++ b/test/fixtures/mockllm/all_scenarios.json
@@ -1172,7 +1172,7 @@
               "tool_calls": [
                 {
                   "function": {
-                    "arguments": "{\"query\": \"MOCK_RCA_INCOMPLETE critical\", \"rca_resource\": {\"signal_name\": \"MOCK_RCA_INCOMPLETE\", \"kind\": \"Pod\", \"namespace\": \"production\", \"name\": \"ambiguous-pod\"}}",
+                    "arguments": "{\"query\": \"MOCK_RCA_INCOMPLETE critical\", \"rca_resource\": {\"signal_name\": \"MOCK_RCA_INCOMPLETE\", \"kind\": \"Pod\", \"namespace\": \"production\", \"name\": \"unreachable-pod\"}}",
                     "name": "search_workflow_catalog"
                   },
                   "id": "call_f301000e40b5",

--- a/test/fixtures/mockllm/rca_incomplete.json
+++ b/test/fixtures/mockllm/rca_incomplete.json
@@ -11,7 +11,7 @@
             "tool_calls": [
               {
                 "function": {
-                  "arguments": "{\"query\": \"MOCK_RCA_INCOMPLETE critical\", \"rca_resource\": {\"signal_name\": \"MOCK_RCA_INCOMPLETE\", \"kind\": \"Pod\", \"namespace\": \"production\", \"name\": \"ambiguous-pod\"}}",
+                  "arguments": "{\"query\": \"MOCK_RCA_INCOMPLETE critical\", \"rca_resource\": {\"signal_name\": \"MOCK_RCA_INCOMPLETE\", \"kind\": \"Pod\", \"namespace\": \"production\", \"name\": \"unreachable-pod\"}}",
                   "name": "search_workflow_catalog"
                 },
                 "id": "call_f301000e40b5",

--- a/test/infrastructure/aianalysis_e2e.go
+++ b/test/infrastructure/aianalysis_e2e.go
@@ -441,6 +441,12 @@ func CreateAIAnalysisClusterHybrid(clusterName, kubeconfigPath string, writer io
 		return fmt.Errorf("services not ready: %w", err)
 	}
 
+	// #704: Create enrichment fixture resources for mock LLM scenario targets
+	_, _ = fmt.Fprintln(writer, "\n📦 Creating enrichment fixture resources (#704)...")
+	if err := createEnrichmentFixtures(kubeconfigPath, writer); err != nil {
+		return fmt.Errorf("failed to create enrichment fixtures: %w", err)
+	}
+
 	_, _ = fmt.Fprintln(writer, "\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 	_, _ = fmt.Fprintln(writer, "✅ AIAnalysis E2E Infrastructure Ready (DD-TEST-002 + DD-TEST-008)")
 	_, _ = fmt.Fprintln(writer, "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")

--- a/test/infrastructure/aianalysis_e2e.go
+++ b/test/infrastructure/aianalysis_e2e.go
@@ -443,7 +443,7 @@ func CreateAIAnalysisClusterHybrid(clusterName, kubeconfigPath string, writer io
 
 	// #704: Create enrichment fixture resources for mock LLM scenario targets
 	_, _ = fmt.Fprintln(writer, "\n📦 Creating enrichment fixture resources (#704)...")
-	if err := createEnrichmentFixtures(kubeconfigPath, writer); err != nil {
+	if err := createEnrichmentFixtures(ctx, kubeconfigPath, writer); err != nil {
 		return fmt.Errorf("failed to create enrichment fixtures: %w", err)
 	}
 

--- a/test/infrastructure/fullpipeline_e2e.go
+++ b/test/infrastructure/fullpipeline_e2e.go
@@ -543,7 +543,7 @@ func SetupFullPipelineInfrastructure(ctx context.Context, clusterName, kubeconfi
 	// PHASE 9: Create enrichment fixture resources (#704)
 	// ═══════════════════════════════════════════════════════════════════════
 	_, _ = fmt.Fprintln(writer, "\n📦 PHASE 9: Creating enrichment fixture resources (#704)...")
-	if err := createEnrichmentFixtures(kubeconfigPath, writer); err != nil {
+	if err := createEnrichmentFixtures(ctx, kubeconfigPath, writer); err != nil {
 		return builtImages, seededUUIDs, fmt.Errorf("PHASE 9 failed: enrichment fixtures: %w", err)
 	}
 

--- a/test/infrastructure/fullpipeline_e2e.go
+++ b/test/infrastructure/fullpipeline_e2e.go
@@ -540,6 +540,14 @@ func SetupFullPipelineInfrastructure(ctx context.Context, clusterName, kubeconfi
 	}
 
 	// ═══════════════════════════════════════════════════════════════════════
+	// PHASE 9: Create enrichment fixture resources (#704)
+	// ═══════════════════════════════════════════════════════════════════════
+	_, _ = fmt.Fprintln(writer, "\n📦 PHASE 9: Creating enrichment fixture resources (#704)...")
+	if err := createEnrichmentFixtures(kubeconfigPath, writer); err != nil {
+		return builtImages, seededUUIDs, fmt.Errorf("PHASE 9 failed: enrichment fixtures: %w", err)
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
 	// DONE
 	// ═══════════════════════════════════════════════════════════════════════
 	totalDuration := time.Since(startTime).Round(time.Second)

--- a/test/infrastructure/fullpipeline_e2e.go
+++ b/test/infrastructure/fullpipeline_e2e.go
@@ -977,6 +977,7 @@ spec:
         app: memory-eater
         kubernaut.ai/managed: "true"
     spec:
+      automountServiceAccountToken: false
       containers:
       - name: memory-eater
         image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/memory-eater:1.0
@@ -1029,6 +1030,7 @@ spec:
         app: memory-eater
         kubernaut.ai/managed: "true"
     spec:
+      automountServiceAccountToken: false
       containers:
       - name: memory-eater
         image: us-central1-docker.pkg.dev/genuine-flight-317411/devel/memory-eater:1.0

--- a/test/infrastructure/kubernautagent.go
+++ b/test/infrastructure/kubernautagent.go
@@ -236,7 +236,7 @@ func SetupKubernautAgentInfrastructure(ctx context.Context, clusterName, kubecon
 	// for scenarios that are NOT rca_incomplete.
 	// ═══════════════════════════════════════════════════════════════════════
 	_, _ = fmt.Fprintln(writer, "\n📦 PHASE 7: Creating enrichment fixture resources (#704)...")
-	if err := createEnrichmentFixtures(kubeconfigPath, writer); err != nil {
+	if err := createEnrichmentFixtures(ctx, kubeconfigPath, writer); err != nil {
 		return fmt.Errorf("failed to create enrichment fixtures: %w", err)
 	}
 
@@ -249,7 +249,11 @@ func SetupKubernautAgentInfrastructure(ctx context.Context, clusterName, kubecon
 // NotFound → HardFail → rca_incomplete, breaking tests that expect normal outcomes.
 // The rca_incomplete scenario targets unreachable-pod which is intentionally NOT
 // created so that it triggers HardFail as expected.
-func createEnrichmentFixtures(kubeconfigPath string, writer io.Writer) error {
+//
+// Note: an empty enrichment: {} YAML section in the KA ConfigMap will zero out the
+// HAPI defaults (MaxRetries=3 → 0), silently disabling retry+fail-hard. The E2E
+// ConfigMap intentionally omits the enrichment key so DefaultConfig() applies.
+func createEnrichmentFixtures(ctx context.Context, kubeconfigPath string, writer io.Writer) error {
 	manifest := `---
 apiVersion: v1
 kind: Namespace
@@ -393,7 +397,7 @@ spec:
         memory: "16Mi"
         cpu: "50m"
 `
-	cmd := exec.Command("kubectl", "--kubeconfig", kubeconfigPath, "apply", "-f", "-")
+	cmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfigPath, "apply", "-f", "-")
 	cmd.Stdin = strings.NewReader(manifest)
 	cmd.Stdout = writer
 	cmd.Stderr = writer

--- a/test/infrastructure/kubernautagent.go
+++ b/test/infrastructure/kubernautagent.go
@@ -250,6 +250,12 @@ func SetupKubernautAgentInfrastructure(ctx context.Context, clusterName, kubecon
 // The rca_incomplete scenario targets unreachable-pod which is intentionally NOT
 // created so that it triggers HardFail as expected.
 //
+// Resources created:
+//   production: api-server (Deployment), failing-pod, recovered-pod, api-server-def456,
+//               ambiguous-pod, failed-analysis-pod (Pods), batch-job-pvc-expired (PVC)
+//   staging:    worker (Deployment), worker-pdb (PDB — required so CrashLoopBackOff
+//               re-enrichment to worker/staging preserves pdbProtected detection)
+//
 // Note: an empty enrichment: {} YAML section in the KA ConfigMap will zero out the
 // HAPI defaults (MaxRetries=3 → 0), silently disabling retry+fail-hard. The E2E
 // ConfigMap intentionally omits the enrichment key so DefaultConfig() applies.
@@ -317,6 +323,17 @@ spec:
             memory: "16Mi"
             cpu: "50m"
 ---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: worker-pdb
+  namespace: staging
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: worker
+---
 apiVersion: v1
 kind: Pod
 metadata:
@@ -380,6 +397,26 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
+  name: failing-pod
+  namespace: production
+  labels:
+    app: failing-pod
+spec:
+  restartPolicy: Never
+  containers:
+  - name: pause
+    image: registry.k8s.io/pause:3.9
+    resources:
+      requests:
+        memory: "8Mi"
+        cpu: "10m"
+      limits:
+        memory: "16Mi"
+        cpu: "50m"
+---
+apiVersion: v1
+kind: Pod
+metadata:
   name: failed-analysis-pod
   namespace: production
   labels:
@@ -396,6 +433,18 @@ spec:
       limits:
         memory: "16Mi"
         cpu: "50m"
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: batch-job-pvc-expired
+  namespace: production
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Mi
 `
 	cmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfigPath, "apply", "-f", "-")
 	cmd.Stdin = strings.NewReader(manifest)
@@ -404,7 +453,7 @@ spec:
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("kubectl apply enrichment fixtures: %w", err)
 	}
-	_, _ = fmt.Fprintln(writer, "  ✅ Enrichment fixtures created (2 namespaces + 6 resources)")
+	_, _ = fmt.Fprintln(writer, "  ✅ Enrichment fixtures created (2 namespaces + 9 resources)")
 	return nil
 }
 

--- a/test/infrastructure/kubernautagent.go
+++ b/test/infrastructure/kubernautagent.go
@@ -229,7 +229,178 @@ func SetupKubernautAgentInfrastructure(ctx context.Context, clusterName, kubecon
 		return fmt.Errorf("failed to deploy Kubernaut Agent: %w", err)
 	}
 
+	// ═══════════════════════════════════════════════════════════════════════
+	// PHASE 7: Create enrichment fixture resources (#704)
+	// Mock LLM scenarios reference resources in production/staging namespaces.
+	// These must exist so re-enrichment doesn't trigger HardFail (rca_incomplete)
+	// for scenarios that are NOT rca_incomplete.
+	// ═══════════════════════════════════════════════════════════════════════
+	_, _ = fmt.Fprintln(writer, "\n📦 PHASE 7: Creating enrichment fixture resources (#704)...")
+	if err := createEnrichmentFixtures(kubeconfigPath, writer); err != nil {
+		return fmt.Errorf("failed to create enrichment fixtures: %w", err)
+	}
+
 	_, _ = fmt.Fprintln(writer, "\n✅ Kubernaut Agent E2E infrastructure ready")
+	return nil
+}
+
+// createEnrichmentFixtures creates namespaces and minimal workloads that mock LLM
+// scenarios reference as remediation_target. Without these, re-enrichment returns
+// NotFound → HardFail → rca_incomplete, breaking tests that expect normal outcomes.
+// The rca_incomplete scenario targets unreachable-pod which is intentionally NOT
+// created so that it triggers HardFail as expected.
+func createEnrichmentFixtures(kubeconfigPath string, writer io.Writer) error {
+	manifest := `---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: production
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: staging
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-server
+  namespace: production
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: api-server
+  template:
+    metadata:
+      labels:
+        app: api-server
+    spec:
+      containers:
+      - name: pause
+        image: registry.k8s.io/pause:3.9
+        resources:
+          requests:
+            memory: "8Mi"
+            cpu: "10m"
+          limits:
+            memory: "16Mi"
+            cpu: "50m"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: worker
+  namespace: staging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: worker
+  template:
+    metadata:
+      labels:
+        app: worker
+    spec:
+      containers:
+      - name: pause
+        image: registry.k8s.io/pause:3.9
+        resources:
+          requests:
+            memory: "8Mi"
+            cpu: "10m"
+          limits:
+            memory: "16Mi"
+            cpu: "50m"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: recovered-pod
+  namespace: production
+  labels:
+    app: recovered-pod
+spec:
+  restartPolicy: Never
+  containers:
+  - name: pause
+    image: registry.k8s.io/pause:3.9
+    resources:
+      requests:
+        memory: "8Mi"
+        cpu: "10m"
+      limits:
+        memory: "16Mi"
+        cpu: "50m"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: api-server-def456
+  namespace: production
+  labels:
+    app: api-server-def456
+spec:
+  restartPolicy: Never
+  containers:
+  - name: pause
+    image: registry.k8s.io/pause:3.9
+    resources:
+      requests:
+        memory: "8Mi"
+        cpu: "10m"
+      limits:
+        memory: "16Mi"
+        cpu: "50m"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ambiguous-pod
+  namespace: production
+  labels:
+    app: ambiguous-pod
+spec:
+  restartPolicy: Never
+  containers:
+  - name: pause
+    image: registry.k8s.io/pause:3.9
+    resources:
+      requests:
+        memory: "8Mi"
+        cpu: "10m"
+      limits:
+        memory: "16Mi"
+        cpu: "50m"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: failed-analysis-pod
+  namespace: production
+  labels:
+    app: failed-analysis-pod
+spec:
+  restartPolicy: Never
+  containers:
+  - name: pause
+    image: registry.k8s.io/pause:3.9
+    resources:
+      requests:
+        memory: "8Mi"
+        cpu: "10m"
+      limits:
+        memory: "16Mi"
+        cpu: "50m"
+`
+	cmd := exec.Command("kubectl", "--kubeconfig", kubeconfigPath, "apply", "-f", "-")
+	cmd.Stdin = strings.NewReader(manifest)
+	cmd.Stdout = writer
+	cmd.Stderr = writer
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("kubectl apply enrichment fixtures: %w", err)
+	}
+	_, _ = fmt.Fprintln(writer, "  ✅ Enrichment fixtures created (2 namespaces + 6 resources)")
 	return nil
 }
 

--- a/test/infrastructure/kubernautagent.go
+++ b/test/infrastructure/kubernautagent.go
@@ -247,6 +247,7 @@ func SetupKubernautAgentInfrastructure(ctx context.Context, clusterName, kubecon
 // createEnrichmentFixtures creates namespaces and minimal workloads that mock LLM
 // scenarios reference as remediation_target. Without these, re-enrichment returns
 // NotFound → HardFail → rca_incomplete, breaking tests that expect normal outcomes.
+// Includes Pod/test-pod/default for the default fallback mock scenario.
 // The rca_incomplete scenario targets unreachable-pod which is intentionally NOT
 // created so that it triggers HardFail as expected.
 //
@@ -445,6 +446,26 @@ spec:
   resources:
     requests:
       storage: 1Mi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: test-pod
+  namespace: default
+  labels:
+    app: test-pod
+spec:
+  restartPolicy: Never
+  containers:
+  - name: pause
+    image: registry.k8s.io/pause:3.9
+    resources:
+      requests:
+        memory: "8Mi"
+        cpu: "10m"
+      limits:
+        memory: "16Mi"
+        cpu: "50m"
 `
 	cmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfigPath, "apply", "-f", "-")
 	cmd.Stdin = strings.NewReader(manifest)
@@ -453,7 +474,7 @@ spec:
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("kubectl apply enrichment fixtures: %w", err)
 	}
-	_, _ = fmt.Fprintln(writer, "  ✅ Enrichment fixtures created (2 namespaces + 9 resources)")
+	_, _ = fmt.Fprintln(writer, "  ✅ Enrichment fixtures created (2 namespaces + 10 resources)")
 	return nil
 }
 

--- a/test/infrastructure/kubernautagent.go
+++ b/test/infrastructure/kubernautagent.go
@@ -619,6 +619,9 @@ rules:
   - apiGroups: ["networking.k8s.io"]
     resources: ["networkpolicies"]
     verbs: ["get", "list"]
+  - apiGroups: ["cert-manager.io"]
+    resources: ["certificates", "clusterissuers", "certificaterequests"]
+    verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/test/integration/aianalysis/suite_test.go
+++ b/test/integration/aianalysis/suite_test.go
@@ -63,10 +63,14 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
 
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	policyv1 "k8s.io/api/policy/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -310,6 +314,91 @@ var _ = SynchronizedBeforeSuite(NodeTimeout(10*time.Minute), func(specCtx SpecCo
 		Expect(err).ToNot(HaveOccurred())
 	}
 	GinkgoWriter.Println("✅ KA ServiceAccount granted DataStorage write permissions")
+
+	// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+	// #704: K8s investigation + label detection RBAC for KA
+	// Mirrors kubernaut-agent-investigator ClusterRole from E2E (aianalysis_e2e.go)
+	// Required because HAPI-default enrichment (MaxRetries=3) needs K8s access
+	// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+	By("Granting KA ServiceAccount K8s investigation + label detection RBAC (#704)")
+	investigatorRole := &rbacv1.ClusterRole{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kubernaut-agent-investigator",
+		},
+		Rules: []rbacv1.PolicyRule{
+			{
+				APIGroups: []string{""},
+				Resources: []string{"pods", "pods/log", "events", "services", "configmaps", "nodes", "namespaces", "replicationcontrollers", "persistentvolumeclaims"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"apps"},
+				Resources: []string{"deployments", "replicasets", "statefulsets", "daemonsets"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"batch"},
+				Resources: []string{"jobs", "cronjobs"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"events.k8s.io"},
+				Resources: []string{"events"},
+				Verbs:     []string{"get", "list", "watch"},
+			},
+			{
+				APIGroups: []string{"policy"},
+				Resources: []string{"poddisruptionbudgets"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{"autoscaling"},
+				Resources: []string{"horizontalpodautoscalers"},
+				Verbs:     []string{"get", "list"},
+			},
+			{
+				APIGroups: []string{"networking.k8s.io"},
+				Resources: []string{"networkpolicies"},
+				Verbs:     []string{"get", "list"},
+			},
+		},
+	}
+	err = k8sClient.Create(context.Background(), investigatorRole)
+	if !apierrors.IsAlreadyExists(err) {
+		Expect(err).ToNot(HaveOccurred())
+	}
+
+	investigatorBinding := &rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "kubernaut-agent-service-investigator",
+		},
+		RoleRef: rbacv1.RoleRef{
+			APIGroup: "rbac.authorization.k8s.io",
+			Kind:     "ClusterRole",
+			Name:     "kubernaut-agent-investigator",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind:      "ServiceAccount",
+				Name:      "kubernaut-agent-service",
+				Namespace: "default",
+			},
+		},
+	}
+	err = k8sClient.Create(context.Background(), investigatorBinding)
+	if !apierrors.IsAlreadyExists(err) {
+		Expect(err).ToNot(HaveOccurred())
+	}
+	GinkgoWriter.Println("✅ KA ServiceAccount granted K8s investigation RBAC (#704)")
+
+	// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+	// #704: Enrichment fixture resources for mock LLM scenario targets
+	// Without these, re-enrichment returns NotFound → HardFail → rca_incomplete
+	// Matches createEnrichmentFixtures() from E2E infrastructure
+	// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+	By("Creating enrichment fixture resources in shared envtest (#704)")
+	createITAAEnrichmentFixtures(k8sClient)
+	GinkgoWriter.Println("✅ Enrichment fixtures created in shared envtest (#704)")
 
 	// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 	// OPTIMIZATION: Build images in parallel (saves ~100 seconds)
@@ -861,3 +950,108 @@ var _ = AfterEach(func() {
 		GinkgoWriter.Printf("🗑️  [AA] Namespace %s deleted (DD-TEST-002 cleanup)\n", testNamespace)
 	}
 })
+
+// createITAAEnrichmentFixtures creates namespaces and minimal workloads in the
+// shared envtest so that KA's HAPI-default enrichment (MaxRetries=3) can resolve
+// mock LLM remediation_target resources. Without these, re-enrichment returns
+// NotFound → HardFail → rca_incomplete, breaking tests that expect normal outcomes.
+// Mirrors createEnrichmentFixtures() from E2E infrastructure (kubectl-based).
+func createITAAEnrichmentFixtures(c client.Client) {
+	ctx := context.Background()
+	one := int32(1)
+	pauseImage := "registry.k8s.io/pause:3.9"
+	pauseContainer := corev1.Container{
+		Name:  "pause",
+		Image: pauseImage,
+		Resources: corev1.ResourceRequirements{
+			Requests: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("8Mi"),
+				corev1.ResourceCPU:    resource.MustParse("10m"),
+			},
+			Limits: corev1.ResourceList{
+				corev1.ResourceMemory: resource.MustParse("16Mi"),
+				corev1.ResourceCPU:    resource.MustParse("50m"),
+			},
+		},
+	}
+
+	for _, ns := range []string{"production", "staging"} {
+		nsObj := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: ns}}
+		if err := c.Create(ctx, nsObj); err != nil && !apierrors.IsAlreadyExists(err) {
+			Expect(err).ToNot(HaveOccurred())
+		}
+	}
+
+	// Deployment/api-server/production — oomkilled + predictive scenarios
+	apiDeploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "api-server", Namespace: "production"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &one,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "api-server"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "api-server"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{pauseContainer}},
+			},
+		},
+	}
+	Expect(c.Create(ctx, apiDeploy)).To(Succeed())
+
+	// Deployment/worker/staging — crashloop scenario
+	workerDeploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker", Namespace: "staging"},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &one,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "worker"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "worker"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{pauseContainer}},
+			},
+		},
+	}
+	Expect(c.Create(ctx, workerDeploy)).To(Succeed())
+
+	// PDB for worker — pdbProtected label detection
+	minAvail := intstr.FromInt32(1)
+	workerPDB := &policyv1.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{Name: "worker-pdb", Namespace: "staging"},
+		Spec: policyv1.PodDisruptionBudgetSpec{
+			MinAvailable: &minAvail,
+			Selector:     &metav1.LabelSelector{MatchLabels: map[string]string{"app": "worker"}},
+		},
+	}
+	Expect(c.Create(ctx, workerPDB)).To(Succeed())
+
+	pods := []struct{ name, ns string }{
+		{"recovered-pod", "production"},
+		{"api-server-def456", "production"},
+		{"ambiguous-pod", "production"},
+		{"failing-pod", "production"},
+		{"failed-analysis-pod", "production"},
+		{"test-pod", "default"},
+	}
+	for _, p := range pods {
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: p.name, Namespace: p.ns,
+				Labels: map[string]string{"app": p.name},
+			},
+			Spec: corev1.PodSpec{
+				RestartPolicy: corev1.RestartPolicyNever,
+				Containers:    []corev1.Container{pauseContainer},
+			},
+		}
+		Expect(c.Create(ctx, pod)).To(Succeed())
+	}
+
+	// PVC/batch-job-pvc-expired/production — not_actionable scenario
+	pvc := &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: "batch-job-pvc-expired", Namespace: "production"},
+		Spec: corev1.PersistentVolumeClaimSpec{
+			AccessModes: []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
+			Resources: corev1.VolumeResourceRequirements{
+				Requests: corev1.ResourceList{corev1.ResourceStorage: resource.MustParse("1Mi")},
+			},
+		},
+	}
+	Expect(c.Create(ctx, pvc)).To(Succeed())
+}

--- a/test/integration/kubernautagent/investigator/investigator_phase_separation_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_phase_separation_test.go
@@ -214,9 +214,9 @@ var _ = Describe("Phase Separation: Investigator — #700", func() {
 		})
 	})
 
-	Describe("IT-KA-700-002: RCA cannot abort pipeline via needs_human_review", func() {
-		It("should proceed to workflow selection when RCA submit_result has needs_human_review:true", func() {
-			rcaSubmitArgs := `{"root_cause_analysis":{"summary":"Memory leak in api-server"},"needs_human_review":true,"human_review_reason":"high complexity","confidence":0.7}`
+	Describe("IT-KA-700-002: RCA HR fields stripped from pipeline (BR-HAPI-200)", func() {
+		It("should proceed to workflow selection — RCA submit_result HR fields are ignored by parser", func() {
+			rcaSubmitArgs := `{"root_cause_analysis":{"summary":"Memory leak in api-server"},"confidence":0.7}`
 			mockClient.responses = []llm.ChatResponse{
 				{
 					Message:   llm.Message{Role: "assistant", Content: "Found the issue"},

--- a/test/integration/kubernautagent/investigator/investigator_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_test.go
@@ -71,7 +71,7 @@ func (m *mockLLMClient) Chat(_ context.Context, req llm.ChatRequest) (llm.ChatRe
 	return llm.ChatResponse{
 		Message: llm.Message{
 			Role:    "assistant",
-			Content: `{"rca_summary":"no more responses","human_review_needed":true}`,
+			Content: `{"rca_summary":"no more responses","confidence":0.1}`,
 		},
 	}, nil
 }
@@ -229,9 +229,10 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 	Describe("IT-KA-433-008: Investigation stops at max turns and returns human-review", func() {
 		It("should return HumanReviewNeeded when max turns exhausted", func() {
 			mockClient.responses = []llm.ChatResponse{
-				{Message: llm.Message{Role: "assistant", Content: "I need more information", ToolCalls: []llm.ToolCall{
-					{ID: "tc_1", Name: "kubectl_describe", Arguments: `{"kind":"Pod","name":"api","namespace":"default"}`},
-				}}},
+				{
+					Message:   llm.Message{Role: "assistant", Content: "I need more information"},
+					ToolCalls: []llm.ToolCall{{ID: "tc_1", Name: "kubectl_describe", Arguments: `{"kind":"Pod","name":"api","namespace":"default"}`}},
+				},
 			}
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 1, PhaseTools: phaseTools})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
@@ -665,6 +666,47 @@ var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() 
 				"UT-KA-693-007: injection must use re-enrichment source kind")
 			Expect(result.RemediationTarget.Name).To(Equal("worker"),
 				"UT-KA-693-007: injection must use re-enrichment source name, not LLM hallucination")
+		})
+	})
+
+	Describe("IT-KA-704-001: Owner chain failure triggers rca_incomplete", func() {
+		It("should set needs_human_review=true with rca_incomplete when GetOwnerChain fails", func() {
+			k8s := &fakeK8sClient{
+				ownerChain: nil,
+				err:        fmt.Errorf("k8s adapter: get Pod/test-pod in production: not found"),
+			}
+			ds := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
+			enricher := enrichment.NewEnricher(k8s, ds, auditStore, logger)
+
+			mockClient.responses = []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled due to memory limit exceeded","remediation_target":{"kind":"Pod","name":"test-pod","namespace":"production"}}`}},
+				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"oom-increase-memory","confidence":0.9}`}},
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
+				ResourceKind: "Pod",
+				ResourceName: "test-pod",
+				Name:         "test-pod",
+				Namespace:    "production",
+				Severity:     "critical",
+				Message:      "OOMKilled",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.HumanReviewNeeded).To(BeTrue(),
+				"IT-KA-704-001: owner chain failure must trigger human review")
+			Expect(result.HumanReviewReason).To(Equal("rca_incomplete"),
+				"IT-KA-704-001: reason must be rca_incomplete per BR-HAPI-261 AC#7")
+			Expect(result.RCASummary).NotTo(BeEmpty(),
+				"IT-KA-704-001: RCA phase should complete before enrichment check")
+			Expect(result.WorkflowID).To(BeEmpty(),
+				"IT-KA-704-001: workflow selection should be skipped when rca_incomplete")
 		})
 	})
 })

--- a/test/integration/kubernautagent/investigator/investigator_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_test.go
@@ -688,9 +688,9 @@ var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() 
 				})
 
 			// RCA names a DIFFERENT target than the signal to trigger re-enrichment.
+			// Only one response needed: flow returns at rca_incomplete before workflow selection.
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled due to memory limit exceeded","remediation_target":{"kind":"Pod","name":"target-pod","namespace":"production"}}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"oom-increase-memory","confidence":0.9}`}},
 			}
 
 			inv := investigator.New(investigator.Config{

--- a/test/integration/kubernautagent/investigator/investigator_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -34,6 +35,8 @@ import (
 	katypes "github.com/jordigilh/kubernaut/internal/kubernautagent/types"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/registry"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // staticCatalogFetcher returns a pre-built validator for tests that need
@@ -671,15 +674,22 @@ var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() 
 
 	Describe("IT-KA-704-001: Owner chain failure triggers rca_incomplete", func() {
 		It("should set needs_human_review=true with rca_incomplete when GetOwnerChain fails", func() {
+			notFoundErr := apierrors.NewNotFound(
+				schema.GroupResource{Resource: "pods"}, "target-pod")
 			k8s := &fakeK8sClient{
 				ownerChain: nil,
-				err:        fmt.Errorf("k8s adapter: get Pod/test-pod in production: not found"),
+				err:        notFoundErr,
 			}
 			ds := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-			enricher := enrichment.NewEnricher(k8s, ds, auditStore, logger)
+			enricher := enrichment.NewEnricher(k8s, ds, auditStore, logger).
+				WithRetryConfig(enrichment.RetryConfig{
+					MaxRetries:  3,
+					BaseBackoff: 1 * time.Millisecond,
+				})
 
+			// RCA names a DIFFERENT target than the signal to trigger re-enrichment.
 			mockClient.responses = []llm.ChatResponse{
-				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled due to memory limit exceeded","remediation_target":{"kind":"Pod","name":"test-pod","namespace":"production"}}`}},
+				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled due to memory limit exceeded","remediation_target":{"kind":"Pod","name":"target-pod","namespace":"production"}}`}},
 				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"oom-increase-memory","confidence":0.9}`}},
 			}
 
@@ -691,8 +701,8 @@ var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() 
 
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				ResourceKind: "Pod",
-				ResourceName: "test-pod",
-				Name:         "test-pod",
+				ResourceName: "signal-pod",
+				Name:         "signal-pod",
 				Namespace:    "production",
 				Severity:     "critical",
 				Message:      "OOMKilled",

--- a/test/services/mock-llm/conversation/context.go
+++ b/test/services/mock-llm/conversation/context.go
@@ -74,24 +74,40 @@ type ResourceInfo struct {
 }
 
 var (
-	reSignalName   = regexp.MustCompile(`(?i)-\s*Signal Name:\s*(\S+)`)
-	reNamespace    = regexp.MustCompile(`(?i)-\s*Namespace:\s*(\S+)`)
-	rePod          = regexp.MustCompile(`(?i)-\s*Pod:\s*(\S+)`)
-	reNode         = regexp.MustCompile(`(?i)-\s*Node:\s*(\S+)`)
-	reResourceLine = regexp.MustCompile(`(?i)-\s*Resource:\s*(\S+)/(\S+)/(\S+)`)
+	reSignalName      = regexp.MustCompile(`(?i)-\s*Signal Name:\s*(\S+)`)
+	reNamespace       = regexp.MustCompile(`(?i)-\s*Namespace:\s*(\S+)`)
+	rePod             = regexp.MustCompile(`(?i)-\s*Pod:\s*(\S+)`)
+	reNode            = regexp.MustCompile(`(?i)-\s*Node:\s*(\S+)`)
+	reResourceLine    = regexp.MustCompile(`(?i)-\s*Resource:\s*(\S+)/(\S+)/(\S+)`)
+	reOwnerChain      = regexp.MustCompile(`\*\*Owner Chain\*\*:\s*(.+)`)
+	reOwnerChainEntry = regexp.MustCompile(`^(\w+)/([^(]+?)(?:\(([^)]+)\))?$`)
 )
 
 // ExtractResource pulls resource name, namespace, and signal from
-// structured "- Key: Value" lines in message content.
+// structured prompt content, modelling what a real LLM would do:
+// identify the root owner from the enrichment context.
 //
-// Primary: parses "- Resource: ns/kind/name" (KA prompt template format).
-// Fallback: individual "- Pod:" / "- Node:" / "- Namespace:" lines.
+// Priority:
+//  1. **Owner Chain** — last entry is the root owner (e.g. Deployment/name).
+//  2. - Resource: ns/kind/name — raw signal resource (fallback).
+//  3. Individual "- Pod:" / "- Node:" / "- Namespace:" lines (legacy fallback).
 func (c *Context) ExtractResource() ResourceInfo {
 	combined := c.combinedContent()
 	info := ResourceInfo{}
 
 	if m := reSignalName.FindStringSubmatch(combined); len(m) > 1 {
 		info.SignalName = m[1]
+	}
+
+	if root := extractRootOwnerFromChain(combined); root.Kind != "" {
+		info.Kind = root.Kind
+		info.Name = root.Name
+		if root.Namespace != "" {
+			info.Namespace = root.Namespace
+		} else if m := reResourceLine.FindStringSubmatch(combined); len(m) > 3 {
+			info.Namespace = m[1]
+		}
+		return info
 	}
 
 	if m := reResourceLine.FindStringSubmatch(combined); len(m) > 3 {
@@ -110,6 +126,29 @@ func (c *Context) ExtractResource() ResourceInfo {
 	} else if m := reNode.FindStringSubmatch(combined); len(m) > 1 {
 		info.Name = m[1]
 		info.Kind = "Node"
+	}
+	return info
+}
+
+// extractRootOwnerFromChain parses "**Owner Chain**: Kind/Name(NS) → Kind/Name(NS)"
+// and returns the last entry (root owner). Returns empty ResourceInfo on parse failure.
+func extractRootOwnerFromChain(content string) ResourceInfo {
+	m := reOwnerChain.FindStringSubmatch(content)
+	if len(m) < 2 {
+		return ResourceInfo{}
+	}
+	entries := strings.Split(m[1], " → ")
+	if len(entries) == 0 {
+		return ResourceInfo{}
+	}
+	last := strings.TrimSpace(entries[len(entries)-1])
+	em := reOwnerChainEntry.FindStringSubmatch(last)
+	if len(em) < 3 {
+		return ResourceInfo{}
+	}
+	info := ResourceInfo{Kind: em[1], Name: em[2]}
+	if len(em) > 3 {
+		info.Namespace = em[3]
 	}
 	return info
 }

--- a/test/services/mock-llm/conversation/context.go
+++ b/test/services/mock-llm/conversation/context.go
@@ -74,14 +74,18 @@ type ResourceInfo struct {
 }
 
 var (
-	reSignalName = regexp.MustCompile(`(?i)-\s*Signal Name:\s*(\S+)`)
-	reNamespace  = regexp.MustCompile(`(?i)-\s*Namespace:\s*(\S+)`)
-	rePod        = regexp.MustCompile(`(?i)-\s*Pod:\s*(\S+)`)
-	reNode       = regexp.MustCompile(`(?i)-\s*Node:\s*(\S+)`)
+	reSignalName   = regexp.MustCompile(`(?i)-\s*Signal Name:\s*(\S+)`)
+	reNamespace    = regexp.MustCompile(`(?i)-\s*Namespace:\s*(\S+)`)
+	rePod          = regexp.MustCompile(`(?i)-\s*Pod:\s*(\S+)`)
+	reNode         = regexp.MustCompile(`(?i)-\s*Node:\s*(\S+)`)
+	reResourceLine = regexp.MustCompile(`(?i)-\s*Resource:\s*(\S+)/(\S+)/(\S+)`)
 )
 
 // ExtractResource pulls resource name, namespace, and signal from
 // structured "- Key: Value" lines in message content.
+//
+// Primary: parses "- Resource: ns/kind/name" (KA prompt template format).
+// Fallback: individual "- Pod:" / "- Node:" / "- Namespace:" lines.
 func (c *Context) ExtractResource() ResourceInfo {
 	combined := c.combinedContent()
 	info := ResourceInfo{}
@@ -89,6 +93,14 @@ func (c *Context) ExtractResource() ResourceInfo {
 	if m := reSignalName.FindStringSubmatch(combined); len(m) > 1 {
 		info.SignalName = m[1]
 	}
+
+	if m := reResourceLine.FindStringSubmatch(combined); len(m) > 3 {
+		info.Namespace = m[1]
+		info.Kind = m[2]
+		info.Name = m[3]
+		return info
+	}
+
 	if m := reNamespace.FindStringSubmatch(combined); len(m) > 1 {
 		info.Namespace = m[1]
 	}

--- a/test/services/mock-llm/handlers/ollama.go
+++ b/test/services/mock-llm/handlers/ollama.go
@@ -89,6 +89,14 @@ func (h *handler) handleOllama(w http.ResponseWriter, r *http.Request) {
 		h.recordScenarioMetric(scenarioName, result.Method)
 	}
 
+	if !cfg.OverrideResource {
+		if res := ctx.ExtractResource(); res.Kind != "" && res.Name != "" {
+			cfg.ResourceKind = res.Kind
+			cfg.ResourceName = res.Name
+			cfg.ResourceNS = res.Namespace
+		}
+	}
+
 	writeJSON(w, http.StatusOK, response.BuildOllamaResponse(model, cfg))
 	h.recordRequestMetric(r.URL.Path, http.StatusOK, scenarioName, time.Since(start).Seconds())
 }

--- a/test/services/mock-llm/handlers/openai.go
+++ b/test/services/mock-llm/handlers/openai.go
@@ -91,6 +91,15 @@ func (h *handler) handleOpenAI(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	cfg := scenarioWithCfg.Config()
+
+	if !cfg.OverrideResource {
+		if res := ctx.ExtractResource(); res.Kind != "" && res.Name != "" {
+			cfg.ResourceKind = res.Kind
+			cfg.ResourceName = res.Name
+			cfg.ResourceNS = res.Namespace
+		}
+	}
+
 	scenarioName := cfg.ScenarioName
 	h.recordScenarioMetric(scenarioName, result.Method)
 

--- a/test/services/mock-llm/response/openai.go
+++ b/test/services/mock-llm/response/openai.go
@@ -127,9 +127,9 @@ func buildToolArguments(toolName string, cfg scenarios.MockScenarioConfig) map[s
 }
 
 // analysisJSON builds a structured response that KA's parser can fully extract.
-// Top-level fields (investigation_outcome, actionable, severity, confidence,
-// needs_human_review, human_review_reason) are required by KA's outcome routing;
-// the nested root_cause_analysis and selected_workflow are consumed by parseLLMFormat.
+// Top-level fields (investigation_outcome, actionable, severity, confidence) are
+// required by KA's outcome routing; needs_human_review / human_review_reason are
+// parser-derived (BR-HAPI-200) and must NOT appear in LLM responses.
 //
 // Golden transcript ref: kubernaut-demo-scenarios#296 — response structure mirrors
 // real Claude Sonnet 4 output to ensure KA parser fidelity.
@@ -185,13 +185,6 @@ func analysisJSON(cfg scenarios.MockScenarioConfig) map[string]interface{} {
 	if cfg.IsActionable != nil {
 		obj["actionable"] = *cfg.IsActionable
 	}
-	if cfg.NeedsHumanReview != nil {
-		obj["needs_human_review"] = *cfg.NeedsHumanReview
-	}
-	if cfg.HumanReviewReason != "" {
-		obj["human_review_reason"] = cfg.HumanReviewReason
-	}
-
 	return obj
 }
 

--- a/test/services/mock-llm/scenarios/scenario_mock_keywords.go
+++ b/test/services/mock-llm/scenarios/scenario_mock_keywords.go
@@ -23,8 +23,6 @@ func noWorkflowFoundConfig() MockScenarioConfig {
 		Confidence: 0.0,
 		RootCause:            "No suitable workflow found in catalog for this signal type",
 		ResourceKind:         "Pod", ResourceNS: "production", ResourceName: "failing-pod",
-		NeedsHumanReview:     BoolPtr(true),
-		HumanReviewReason:    "no_matching_workflows",
 		InvestigationOutcome: "inconclusive",
 	}
 }
@@ -67,8 +65,6 @@ func problemResolvedContradictionConfig() MockScenarioConfig {
 		RootCause:            "Problem self-resolved. Transient OOM cleared after pod restart",
 		ResourceKind:         "Pod", ResourceNS: "production", ResourceName: "recovered-pod",
 		Contributing:         []string{"Transient condition", "Auto-recovery"},
-		NeedsHumanReview:     BoolPtr(true),
-		HumanReviewReason:    "contradictory_signals",
 		InvestigationOutcome: "problem_resolved",
 		IsActionable:         BoolPtr(false),
 	}
@@ -108,8 +104,6 @@ func rcaIncompleteConfig() MockScenarioConfig {
 		ResourceKind:         "Pod", ResourceNS: "production", ResourceName: "ambiguous-pod",
 		APIVersion:           "v1",
 		Parameters:           map[string]string{"NAMESPACE": "production", "POD_NAME": "ambiguous-pod"},
-		NeedsHumanReview:     BoolPtr(true),
-		HumanReviewReason:    "investigation_inconclusive",
 		InvestigationOutcome: "actionable",
 		IsActionable:         BoolPtr(true),
 	}

--- a/test/services/mock-llm/scenarios/scenario_mock_keywords.go
+++ b/test/services/mock-llm/scenarios/scenario_mock_keywords.go
@@ -103,6 +103,7 @@ func rcaIncompleteConfig() MockScenarioConfig {
 		RootCause:            "Root cause identified but affected resource could not be determined from signal context",
 		ResourceKind:         "Pod", ResourceNS: "production", ResourceName: "unreachable-pod",
 		APIVersion:           "v1",
+		OverrideResource:     true,
 		Parameters:           map[string]string{"NAMESPACE": "production", "POD_NAME": "unreachable-pod"},
 		InvestigationOutcome: "actionable",
 		IsActionable:         BoolPtr(true),

--- a/test/services/mock-llm/scenarios/scenario_mock_keywords.go
+++ b/test/services/mock-llm/scenarios/scenario_mock_keywords.go
@@ -101,9 +101,9 @@ func rcaIncompleteConfig() MockScenarioConfig {
 		WorkflowName: "generic-restart-v1", WorkflowID: uuid.DeterministicUUID("generic-restart-v1"),
 		WorkflowTitle: "Generic Pod Restart", Confidence: 0.88,
 		RootCause:            "Root cause identified but affected resource could not be determined from signal context",
-		ResourceKind:         "Pod", ResourceNS: "production", ResourceName: "ambiguous-pod",
+		ResourceKind:         "Pod", ResourceNS: "production", ResourceName: "unreachable-pod",
 		APIVersion:           "v1",
-		Parameters:           map[string]string{"NAMESPACE": "production", "POD_NAME": "ambiguous-pod"},
+		Parameters:           map[string]string{"NAMESPACE": "production", "POD_NAME": "unreachable-pod"},
 		InvestigationOutcome: "actionable",
 		IsActionable:         BoolPtr(true),
 	}

--- a/test/unit/datastorage/workflow_content_integrity_test.go
+++ b/test/unit/datastorage/workflow_content_integrity_test.go
@@ -88,6 +88,13 @@ func (m *mockWorkflowIntegrityRepo) UpdateStatus(_ context.Context, workflowID, 
 	return nil
 }
 
+func (m *mockWorkflowIntegrityRepo) SupersedeAndCreate(ctx context.Context, oldID, oldVersion, reason string, newWorkflow *models.RemediationWorkflow) error {
+	if err := m.UpdateStatus(ctx, oldID, oldVersion, "Superseded", reason, ""); err != nil {
+		return err
+	}
+	return m.Create(ctx, newWorkflow)
+}
+
 // Workflow YAML variants for integrity tests. Same name+version, different content.
 var integrityBaseYAML = func() string {
 	crd := testutil.NewTestWorkflowCRD("integrity-test-wf", "ScaleMemory", "job")
@@ -565,6 +572,13 @@ func (m *raceConditionIntegrityRepo) Create(_ context.Context, workflow *models.
 
 func (m *raceConditionIntegrityRepo) UpdateStatus(_ context.Context, _, _, _, _, _ string) error {
 	return nil
+}
+
+func (m *raceConditionIntegrityRepo) SupersedeAndCreate(ctx context.Context, oldID, oldVersion, reason string, newWorkflow *models.RemediationWorkflow) error {
+	if err := m.UpdateStatus(ctx, oldID, oldVersion, "Superseded", reason, ""); err != nil {
+		return err
+	}
+	return m.Create(ctx, newWorkflow)
 }
 
 // computeTestHash computes SHA-256 for test content comparison.

--- a/test/unit/datastorage/workflow_deterministic_uuid_test.go
+++ b/test/unit/datastorage/workflow_deterministic_uuid_test.go
@@ -77,6 +77,13 @@ func (m *deterministicUUIDRepo) UpdateStatus(_ context.Context, workflowID, vers
 	return nil
 }
 
+func (m *deterministicUUIDRepo) SupersedeAndCreate(ctx context.Context, oldID, oldVersion, reason string, newWorkflow *models.RemediationWorkflow) error {
+	if err := m.UpdateStatus(ctx, oldID, oldVersion, "Superseded", reason, ""); err != nil {
+		return err
+	}
+	return m.Create(ctx, newWorkflow)
+}
+
 var deterministicBaseYAML = func() string {
 	crd := testutil.NewTestWorkflowCRD("deterministic-wf", "ScaleMemory", "job")
 	crd.Spec.Description = sharedtypes.StructuredDescription{

--- a/test/unit/kubernautagent/enrichment/enricher_retry_test.go
+++ b/test/unit/kubernautagent/enrichment/enricher_retry_test.go
@@ -29,6 +29,7 @@ import (
 
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
@@ -205,6 +206,77 @@ var _ = Describe("Enricher Retry Infrastructure — BR-HAPI-261/264 #704", func(
 				"UT-704-E-004: OwnerChainError must be set for observability")
 			Expect(result.HardFail).To(BeFalse(),
 				"UT-704-E-004: HardFail must be false in best-effort mode (retries=0)")
+		})
+	})
+
+	Describe("UT-704-E-006: GVR-not-found (unknown Kind) should NOT trigger HardFail", func() {
+		It("should NOT set HardFail when the Kind is unknown to the API server", func() {
+			// Simulates cert-manager Certificate when CRD is not installed.
+			// The RESTMapper returns NoResourceMatchError for unknown resource types.
+			noMatchErr := fmt.Errorf("k8s adapter: resolve GVR for Certificate: %w",
+				&meta.NoResourceMatchError{PartialResource: schema.GroupVersionResource{Resource: "certificates"}})
+			k8s := &countingK8sClient{
+				errSeq: []error{noMatchErr, noMatchErr, noMatchErr, noMatchErr},
+			}
+			e := enrichment.NewEnricher(k8s, ds, auditStore, logger).
+				WithRetryConfig(enrichment.RetryConfig{
+					MaxRetries:  3,
+					BaseBackoff: 1 * time.Millisecond,
+				})
+
+			result, err := e.Enrich(ctx, "Certificate", "demo-app-cert", "default", "", "inc-006")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(result.OwnerChainError).NotTo(BeNil(),
+				"UT-704-E-006: OwnerChainError should be set for observability")
+			Expect(result.HardFail).To(BeFalse(),
+				"UT-704-E-006: HardFail must be false — unknown Kind is a schema limitation, not an RCA failure")
+		})
+
+		It("should still HardFail when a known Kind's instance is not found", func() {
+			notFoundErr := apierrors.NewNotFound(
+				schema.GroupResource{Resource: "pods"}, "unreachable-pod")
+			k8s := &countingK8sClient{
+				errSeq: []error{notFoundErr, notFoundErr, notFoundErr, notFoundErr},
+			}
+			e := enrichment.NewEnricher(k8s, ds, auditStore, logger).
+				WithRetryConfig(enrichment.RetryConfig{
+					MaxRetries:  3,
+					BaseBackoff: 1 * time.Millisecond,
+				})
+
+			result, err := e.Enrich(ctx, "Pod", "unreachable-pod", "default", "", "inc-006b")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(result.HardFail).To(BeTrue(),
+				"UT-704-E-006: HardFail must be true for known Kinds — the resource is unreachable, RCA is incomplete")
+		})
+	})
+
+	Describe("UT-704-E-007: IsNoMatchError classification", func() {
+		It("should return true for NoResourceMatchError", func() {
+			err := fmt.Errorf("wrapped: %w",
+				&meta.NoResourceMatchError{PartialResource: schema.GroupVersionResource{Resource: "certificates"}})
+			Expect(enrichment.IsNoMatchError(err)).To(BeTrue())
+		})
+
+		It("should return true for NoKindMatchError", func() {
+			err := fmt.Errorf("wrapped: %w",
+				&meta.NoKindMatchError{GroupKind: schema.GroupKind{Kind: "Certificate"}})
+			Expect(enrichment.IsNoMatchError(err)).To(BeTrue())
+		})
+
+		It("should return false for NotFound API error", func() {
+			err := apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "test")
+			Expect(enrichment.IsNoMatchError(err)).To(BeFalse())
+		})
+
+		It("should return false for Forbidden API error", func() {
+			err := apierrors.NewForbidden(
+				schema.GroupResource{Resource: "pods"}, "test", fmt.Errorf("denied"))
+			Expect(enrichment.IsNoMatchError(err)).To(BeFalse())
 		})
 	})
 })

--- a/test/unit/kubernautagent/enrichment/enricher_retry_test.go
+++ b/test/unit/kubernautagent/enrichment/enricher_retry_test.go
@@ -1,0 +1,184 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package enrichment_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// countingK8sClient tracks call counts and returns per-call errors/chains.
+type countingK8sClient struct {
+	calls    int32
+	errSeq   []error
+	chainSeq [][]enrichment.OwnerChainEntry
+}
+
+func (c *countingK8sClient) GetOwnerChain(_ context.Context, _, _, _ string) ([]enrichment.OwnerChainEntry, error) {
+	idx := int(atomic.AddInt32(&c.calls, 1) - 1)
+	var err error
+	if idx < len(c.errSeq) {
+		err = c.errSeq[idx]
+	} else if len(c.errSeq) > 0 {
+		err = c.errSeq[len(c.errSeq)-1]
+	}
+	if err != nil {
+		return nil, err
+	}
+	if idx < len(c.chainSeq) {
+		return c.chainSeq[idx], nil
+	}
+	return nil, nil
+}
+
+func (c *countingK8sClient) GetSpecHash(_ context.Context, _, _, _ string) (string, error) {
+	return "", nil
+}
+
+func (c *countingK8sClient) CallCount() int {
+	return int(atomic.LoadInt32(&c.calls))
+}
+
+var _ = Describe("Enricher Retry Infrastructure — BR-HAPI-261/264 #704", func() {
+	var (
+		logger     *slog.Logger
+		auditStore *recordingAuditStore
+		ds         *fakeDataStorageClient
+		ctx        context.Context
+	)
+
+	BeforeEach(func() {
+		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		auditStore = &recordingAuditStore{}
+		ds = &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
+		ctx = context.Background()
+	})
+
+	Describe("UT-704-E-001: Transient error retried, HardFail after exhaustion", func() {
+		It("should retry 3 times on transient error and set HardFail=true", func() {
+			transientErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
+			k8s := &countingK8sClient{
+				errSeq: []error{transientErr, transientErr, transientErr, transientErr},
+			}
+			e := enrichment.NewEnricher(k8s, ds, auditStore, logger).
+				WithRetryConfig(enrichment.RetryConfig{
+					MaxRetries:  3,
+					BaseBackoff: 1 * time.Millisecond,
+				})
+
+			result, err := e.Enrich(ctx, "Pod", "test-pod", "production", "", "inc-001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(k8s.CallCount()).To(Equal(4),
+				"UT-704-E-001: initial call + 3 retries = 4 total calls")
+			Expect(result.OwnerChainError).NotTo(BeNil(),
+				"UT-704-E-001: OwnerChainError must be set after retry exhaustion")
+			Expect(result.HardFail).To(BeTrue(),
+				"UT-704-E-001: HardFail must be true after retry exhaustion")
+		})
+	})
+
+	Describe("UT-704-E-002: Transient error succeeds on retry", func() {
+		It("should succeed on 2nd attempt and set HardFail=false", func() {
+			transientErr := apierrors.NewServiceUnavailable("api-server overloaded")
+			successChain := []enrichment.OwnerChainEntry{
+				{Kind: "Deployment", Name: "api-server", Namespace: "production"},
+			}
+			k8s := &countingK8sClient{
+				errSeq:   []error{transientErr, nil},
+				chainSeq: [][]enrichment.OwnerChainEntry{nil, successChain},
+			}
+			e := enrichment.NewEnricher(k8s, ds, auditStore, logger).
+				WithRetryConfig(enrichment.RetryConfig{
+					MaxRetries:  3,
+					BaseBackoff: 1 * time.Millisecond,
+				})
+
+			result, err := e.Enrich(ctx, "Pod", "test-pod", "production", "", "inc-002")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(k8s.CallCount()).To(Equal(2),
+				"UT-704-E-002: should succeed on 2nd attempt")
+			Expect(result.OwnerChainError).To(BeNil(),
+				"UT-704-E-002: OwnerChainError must be nil after successful retry")
+			Expect(result.HardFail).To(BeFalse(),
+				"UT-704-E-002: HardFail must be false when retry succeeds")
+			Expect(result.OwnerChain).To(HaveLen(1),
+				"UT-704-E-002: owner chain must be populated from successful retry")
+		})
+	})
+
+	Describe("UT-704-E-003: Permanent error triggers immediate HardFail", func() {
+		It("should not retry NotFound and set HardFail=true immediately", func() {
+			notFoundErr := apierrors.NewNotFound(
+				schema.GroupResource{Resource: "pods"}, "test-pod")
+			k8s := &countingK8sClient{
+				errSeq: []error{notFoundErr},
+			}
+			e := enrichment.NewEnricher(k8s, ds, auditStore, logger).
+				WithRetryConfig(enrichment.RetryConfig{
+					MaxRetries:  3,
+					BaseBackoff: 1 * time.Millisecond,
+				})
+
+			result, err := e.Enrich(ctx, "Pod", "test-pod", "production", "", "inc-003")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(k8s.CallCount()).To(Equal(1),
+				"UT-704-E-003: permanent error must NOT be retried")
+			Expect(result.OwnerChainError).NotTo(BeNil(),
+				"UT-704-E-003: OwnerChainError must be set for permanent error")
+			Expect(result.HardFail).To(BeTrue(),
+				"UT-704-E-003: HardFail must be true for permanent error")
+		})
+	})
+
+	Describe("UT-704-E-004: Best-effort mode (retries=0)", func() {
+		It("should set OwnerChainError but HardFail=false with default config", func() {
+			transientErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
+			k8s := &countingK8sClient{
+				errSeq: []error{transientErr},
+			}
+			e := enrichment.NewEnricher(k8s, ds, auditStore, logger)
+
+			result, err := e.Enrich(ctx, "Pod", "test-pod", "production", "", "inc-004")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(k8s.CallCount()).To(Equal(1),
+				"UT-704-E-004: no retries with default config")
+			Expect(result.OwnerChainError).NotTo(BeNil(),
+				"UT-704-E-004: OwnerChainError must be set for observability")
+			Expect(result.HardFail).To(BeFalse(),
+				"UT-704-E-004: HardFail must be false in best-effort mode (retries=0)")
+		})
+	})
+})

--- a/test/unit/kubernautagent/enrichment/enricher_retry_test.go
+++ b/test/unit/kubernautagent/enrichment/enricher_retry_test.go
@@ -135,12 +135,12 @@ var _ = Describe("Enricher Retry Infrastructure — BR-HAPI-261/264 #704", func(
 		})
 	})
 
-	Describe("UT-704-E-003: Permanent error triggers immediate HardFail", func() {
-		It("should not retry NotFound and set HardFail=true immediately", func() {
+	Describe("UT-704-E-003: NotFound retried and HardFail after exhaustion (HAPI-aligned)", func() {
+		It("should retry NotFound 3 times and set HardFail=true after exhaustion", func() {
 			notFoundErr := apierrors.NewNotFound(
 				schema.GroupResource{Resource: "pods"}, "test-pod")
 			k8s := &countingK8sClient{
-				errSeq: []error{notFoundErr},
+				errSeq: []error{notFoundErr, notFoundErr, notFoundErr, notFoundErr},
 			}
 			e := enrichment.NewEnricher(k8s, ds, auditStore, logger).
 				WithRetryConfig(enrichment.RetryConfig{
@@ -152,12 +152,38 @@ var _ = Describe("Enricher Retry Infrastructure — BR-HAPI-261/264 #704", func(
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 
-			Expect(k8s.CallCount()).To(Equal(1),
-				"UT-704-E-003: permanent error must NOT be retried")
+			Expect(k8s.CallCount()).To(Equal(4),
+				"UT-704-E-003: HAPI retries all errors — initial + 3 retries = 4 calls")
 			Expect(result.OwnerChainError).NotTo(BeNil(),
-				"UT-704-E-003: OwnerChainError must be set for permanent error")
+				"UT-704-E-003: OwnerChainError must be set after retry exhaustion")
 			Expect(result.HardFail).To(BeTrue(),
-				"UT-704-E-003: HardFail must be true for permanent error")
+				"UT-704-E-003: HardFail must be true after retry exhaustion")
+		})
+	})
+
+	Describe("UT-704-E-005: Forbidden retried and HardFail after exhaustion (HAPI-aligned)", func() {
+		It("should retry Forbidden 3 times and set HardFail=true after exhaustion", func() {
+			forbiddenErr := apierrors.NewForbidden(
+				schema.GroupResource{Resource: "pods"}, "test-pod", fmt.Errorf("RBAC: access denied"))
+			k8s := &countingK8sClient{
+				errSeq: []error{forbiddenErr, forbiddenErr, forbiddenErr, forbiddenErr},
+			}
+			e := enrichment.NewEnricher(k8s, ds, auditStore, logger).
+				WithRetryConfig(enrichment.RetryConfig{
+					MaxRetries:  3,
+					BaseBackoff: 1 * time.Millisecond,
+				})
+
+			result, err := e.Enrich(ctx, "Pod", "test-pod", "production", "", "inc-005")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(k8s.CallCount()).To(Equal(4),
+				"UT-704-E-005: HAPI retries all errors — initial + 3 retries = 4 calls")
+			Expect(result.OwnerChainError).NotTo(BeNil(),
+				"UT-704-E-005: OwnerChainError must be set after retry exhaustion")
+			Expect(result.HardFail).To(BeTrue(),
+				"UT-704-E-005: HardFail must be true after retry exhaustion (Forbidden)")
 		})
 	})
 

--- a/test/unit/kubernautagent/enrichment/enricher_retry_test.go
+++ b/test/unit/kubernautagent/enrichment/enricher_retry_test.go
@@ -161,8 +161,8 @@ var _ = Describe("Enricher Retry Infrastructure — BR-HAPI-261/264 #704", func(
 		})
 	})
 
-	Describe("UT-704-E-004: Best-effort mode (retries=0)", func() {
-		It("should set OwnerChainError but HardFail=false with default config", func() {
+	Describe("UT-704-E-004: Best-effort mode (no WithRetryConfig, MaxRetries=0)", func() {
+		It("should set OwnerChainError but HardFail=false when retries not configured", func() {
 			transientErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
 			k8s := &countingK8sClient{
 				errSeq: []error{transientErr},

--- a/test/unit/kubernautagent/enrichment/k8s_adapter_test.go
+++ b/test/unit/kubernautagent/enrichment/k8s_adapter_test.go
@@ -298,8 +298,83 @@ var _ = Describe("TP-693: Controller-ref owner chain selection", func() {
 	})
 })
 
+var _ = Describe("UT-KA-704-MAPPER: RESTMapper refresh for CRDs installed after startup", func() {
+	Describe("UT-KA-704-MAPPER-001: resolveGVR retries with Reset on resettable mapper", func() {
+		It("should discover a CRD Kind after mapper reset", func() {
+			scheme := runtime.NewScheme()
+
+			cert := &unstructured.Unstructured{}
+			cert.SetGroupVersionKind(schema.GroupVersionKind{
+				Group: "cert-manager.io", Version: "v1", Kind: "Certificate",
+			})
+			cert.SetName("demo-app-cert")
+			cert.SetNamespace("default")
+
+			dynClient := fakedynamic.NewSimpleDynamicClient(scheme, cert)
+			mapper := &lateRegistrationMapper{
+				delegate: newSimpleRESTMapper(),
+			}
+
+			adapter := enrichment.NewK8sAdapter(dynClient, mapper)
+
+			_, errBefore := adapter.GetOwnerChain(context.Background(), "Certificate", "demo-app-cert", "default")
+			Expect(errBefore).To(HaveOccurred(),
+				"should fail before CRD is registered")
+
+			mapper.registerCertificate()
+
+			chain, errAfter := adapter.GetOwnerChain(context.Background(), "Certificate", "demo-app-cert", "default")
+			Expect(errAfter).NotTo(HaveOccurred(),
+				"should succeed after mapper reset discovers the CRD")
+			Expect(chain).To(BeEmpty(), "Certificate has no ownerReferences")
+		})
+	})
+})
+
+// lateRegistrationMapper simulates a DeferredDiscoveryRESTMapper that discovers
+// a CRD after Reset(). The first lookup for "certificates" fails; after
+// registerCertificate() + Reset() it succeeds.
+type lateRegistrationMapper struct {
+	delegate     *meta.DefaultRESTMapper
+	certAdded    bool
+}
+
+func (m *lateRegistrationMapper) Reset() {
+	if m.certAdded {
+		m.delegate.Add(schema.GroupVersionKind{
+			Group: "cert-manager.io", Version: "v1", Kind: "Certificate",
+		}, meta.RESTScopeNamespace)
+	}
+}
+
+func (m *lateRegistrationMapper) registerCertificate() {
+	m.certAdded = true
+}
+
+func (m *lateRegistrationMapper) ResourceFor(input schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return m.delegate.ResourceFor(input)
+}
+func (m *lateRegistrationMapper) ResourcesFor(input schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return m.delegate.ResourcesFor(input)
+}
+func (m *lateRegistrationMapper) KindFor(input schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return m.delegate.KindFor(input)
+}
+func (m *lateRegistrationMapper) KindsFor(input schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return m.delegate.KindsFor(input)
+}
+func (m *lateRegistrationMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	return m.delegate.RESTMapping(gk, versions...)
+}
+func (m *lateRegistrationMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	return m.delegate.RESTMappings(gk, versions...)
+}
+func (m *lateRegistrationMapper) ResourceSingularizer(resource string) (string, error) {
+	return m.delegate.ResourceSingularizer(resource)
+}
+
 // newSimpleRESTMapper creates a REST mapper that knows about common K8s types.
-func newSimpleRESTMapper() meta.RESTMapper {
+func newSimpleRESTMapper() *meta.DefaultRESTMapper {
 	mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{
 		{Group: "", Version: "v1"},
 		{Group: "apps", Version: "v1"},

--- a/test/unit/kubernautagent/parser/adversarial_parser_test.go
+++ b/test/unit/kubernautagent/parser/adversarial_parser_test.go
@@ -182,8 +182,8 @@ End of analysis.`
 		})
 	})
 
-	Describe("UT-KA-433-PRS-009: LLM needs_human_review and human_review_reason extracted (GAP-013)", func() {
-		It("should extract needs_human_review and human_review_reason from LLM JSON", func() {
+	Describe("UT-KA-433-PRS-009: Parser ignores LLM needs_human_review (BR-HAPI-200)", func() {
+		It("should NOT propagate LLM-set needs_human_review; HR derived from investigation_outcome only", func() {
 			input := `{
 				"rca_summary": "Unclear root cause — multiple potential issues",
 				"needs_human_review": true,
@@ -193,8 +193,69 @@ End of analysis.`
 
 			result, err := p.Parse(input)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.HumanReviewNeeded).To(BeTrue())
-			Expect(result.HumanReviewReason).To(Equal("investigation_inconclusive"))
+			Expect(result.HumanReviewNeeded).To(BeFalse(),
+				"LLM-set needs_human_review must be ignored — HR is parser-derived only")
+			Expect(result.HumanReviewReason).To(BeEmpty(),
+				"LLM-set human_review_reason must be ignored — HR reason is parser-derived only")
+		})
+	})
+
+	// --- BR-HAPI-200: Parser-derived escalation ---
+
+	Describe("UT-KA-700-PDE-001: inconclusive + RCA + no workflow → no_matching_workflows", func() {
+		It("should derive no_matching_workflows from context signals", func() {
+			input := `{
+				"root_cause_analysis": {
+					"summary": "Memory pressure detected but no remediation workflow available"
+				},
+				"investigation_outcome": "inconclusive",
+				"confidence": 0.4
+			}`
+
+			result, err := p.Parse(input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.HumanReviewNeeded).To(BeTrue(),
+				"inconclusive outcome must set HumanReviewNeeded")
+			Expect(result.HumanReviewReason).To(Equal("no_matching_workflows"),
+				"RCA present + no workflow + inconclusive = no_matching_workflows (BR-HAPI-197)")
+		})
+	})
+
+	Describe("UT-KA-700-PDE-002: inconclusive + workflow present → investigation_inconclusive fallback", func() {
+		It("should derive investigation_inconclusive when workflow is present despite inconclusive outcome", func() {
+			input := `{
+				"rca_summary": "",
+				"workflow_id": "restart-pod",
+				"investigation_outcome": "inconclusive",
+				"confidence": 0.3
+			}`
+
+			result, err := p.Parse(input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.HumanReviewNeeded).To(BeTrue(),
+				"inconclusive outcome must set HumanReviewNeeded")
+			Expect(result.HumanReviewReason).To(Equal("investigation_inconclusive"),
+				"workflow present + inconclusive → investigation_inconclusive fallback")
+		})
+	})
+
+	Describe("UT-KA-700-PDE-003: problem_resolved contradiction override clears HR (#301)", func() {
+		It("should clear needs_human_review when problem_resolved contradicts LLM-set HR", func() {
+			input := `{
+				"rca_summary": "Problem self-resolved. Transient OOM cleared after pod restart",
+				"investigation_outcome": "problem_resolved",
+				"needs_human_review": true,
+				"human_review_reason": "contradictory_signals",
+				"actionable": false,
+				"confidence": 0.85
+			}`
+
+			result, err := p.Parse(input)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.HumanReviewNeeded).To(BeFalse(),
+				"#301: problem_resolved must override needs_human_review=true")
+			Expect(result.HumanReviewReason).To(BeEmpty(),
+				"#301: problem_resolved must clear human_review_reason")
 		})
 	})
 
@@ -230,8 +291,8 @@ End of analysis.`
 		})
 	})
 
-	Describe("UT-KA-433-OUT-003: No workflow + no resolution → needs_human_review=true", func() {
-		It("should set needs_human_review when investigation is inconclusive", func() {
+	Describe("UT-KA-433-OUT-003: inconclusive + RCA + no workflow → no_matching_workflows (BR-HAPI-197)", func() {
+		It("should derive no_matching_workflows when RCA present but no workflow selected", func() {
 			input := `{
 				"rca_summary": "Unable to determine root cause with available data",
 				"investigation_outcome": "inconclusive",
@@ -241,12 +302,13 @@ End of analysis.`
 			result, err := p.Parse(input)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.HumanReviewNeeded).To(BeTrue())
-			Expect(result.HumanReviewReason).To(Equal("investigation_inconclusive"))
+			Expect(result.HumanReviewReason).To(Equal("no_matching_workflows"),
+				"inconclusive + RCA present + no workflow = no_matching_workflows per BR-HAPI-197")
 		})
 	})
 
-	Describe("UT-KA-433-OUT-004: LLM explicit needs_human_review=true preserved", func() {
-		It("should preserve LLM-provided human review reason", func() {
+	Describe("UT-KA-433-OUT-004: LLM explicit needs_human_review must NOT be preserved (BR-HAPI-200)", func() {
+		It("should ignore LLM-set needs_human_review when workflow is present", func() {
 			input := `{
 				"rca_summary": "Found issue but confidence too low",
 				"workflow_id": "restart-pod",
@@ -257,8 +319,10 @@ End of analysis.`
 
 			result, err := p.Parse(input)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(result.HumanReviewNeeded).To(BeTrue())
-			Expect(result.HumanReviewReason).To(Equal("low_confidence"))
+			Expect(result.HumanReviewNeeded).To(BeFalse(),
+				"LLM-set needs_human_review must NOT be preserved — HR is parser-derived only")
+			Expect(result.HumanReviewReason).To(BeEmpty(),
+				"LLM-set human_review_reason must NOT be preserved — HR reason is parser-derived only")
 		})
 	})
 

--- a/test/unit/kubernautagent/parser/parser_test.go
+++ b/test/unit/kubernautagent/parser/parser_test.go
@@ -403,7 +403,10 @@ var _ = Describe("Kubernaut Agent Result Parser — #433", func() {
 			Expect(props).To(HaveKey("confidence"))
 			Expect(props).To(HaveKey("severity"))
 			Expect(props).To(HaveKey("actionable"))
-			Expect(props).To(HaveKey("needs_human_review"))
+			Expect(props).NotTo(HaveKey("needs_human_review"),
+				"needs_human_review is parser-derived, not exposed to LLM (BR-HAPI-200)")
+			Expect(props).NotTo(HaveKey("human_review_reason"),
+				"human_review_reason is parser-derived, not exposed to LLM (BR-HAPI-200)")
 			Expect(props).To(HaveKey("detected_labels"))
 		})
 	})

--- a/test/unit/kubernautagent/parser/schema_phase_separation_test.go
+++ b/test/unit/kubernautagent/parser/schema_phase_separation_test.go
@@ -75,8 +75,8 @@ var _ = Describe("Phase Separation: Schema Contracts — #700", func() {
 		})
 	})
 
-	Describe("UT-KA-700-002: InvestigationResultSchema unchanged (regression guard)", func() {
-		It("should still contain selected_workflow, alternative_workflows, needs_human_review", func() {
+	Describe("UT-KA-700-002: InvestigationResultSchema must NOT expose HR fields to LLM (BR-HAPI-200)", func() {
+		It("should contain workflow fields but NOT needs_human_review / human_review_reason", func() {
 			schema := parser.InvestigationResultSchema()
 			Expect(schema).NotTo(BeEmpty())
 
@@ -90,8 +90,12 @@ var _ = Describe("Phase Separation: Schema Contracts — #700", func() {
 			By("retaining all workflow selection fields")
 			Expect(props).To(HaveKey("selected_workflow"))
 			Expect(props).To(HaveKey("alternative_workflows"))
-			Expect(props).To(HaveKey("needs_human_review"))
-			Expect(props).To(HaveKey("human_review_reason"))
+
+			By("excluding HR fields — parser-driven, not LLM-driven (BR-HAPI-200)")
+			Expect(props).NotTo(HaveKey("needs_human_review"),
+				"InvestigationResultSchema must NOT include needs_human_review (parser-derived)")
+			Expect(props).NotTo(HaveKey("human_review_reason"),
+				"InvestigationResultSchema must NOT include human_review_reason (parser-derived)")
 
 			By("retaining all RCA fields")
 			Expect(props).To(HaveKey("root_cause_analysis"))

--- a/test/unit/mockllm/context_test.go
+++ b/test/unit/mockllm/context_test.go
@@ -115,7 +115,41 @@ var _ = Describe("Conversation Context Extraction", func() {
 			Expect(res.SignalName).To(Equal("BackOff"))
 		})
 
-		It("should prefer Resource line over individual Pod/Namespace fields", func() {
+		It("should prefer Owner Chain root owner over Resource line", func() {
+			content := "- Signal Name: BackOff\n- Resource: fp-e2e-496-123/Pod/memory-eater-5b9d684998-kg7xw\n**Owner Chain**: ReplicaSet/memory-eater-5b9d684998(fp-e2e-496-123) → Deployment/memory-eater(fp-e2e-496-123)"
+			ctx := conversation.NewContext([]openai.Message{
+				{Role: "user", Content: stringPtr(content)},
+			})
+			res := ctx.ExtractResource()
+			Expect(res.Kind).To(Equal("Deployment"))
+			Expect(res.Name).To(Equal("memory-eater"))
+			Expect(res.Namespace).To(Equal("fp-e2e-496-123"))
+			Expect(res.SignalName).To(Equal("BackOff"))
+		})
+
+		It("should extract root owner from single-entry owner chain", func() {
+			content := "- Resource: default/Pod/nginx-abc123\n**Owner Chain**: ReplicaSet/nginx-abc(default)"
+			ctx := conversation.NewContext([]openai.Message{
+				{Role: "user", Content: stringPtr(content)},
+			})
+			res := ctx.ExtractResource()
+			Expect(res.Kind).To(Equal("ReplicaSet"))
+			Expect(res.Name).To(Equal("nginx-abc"))
+			Expect(res.Namespace).To(Equal("default"))
+		})
+
+		It("should extract root owner without namespace annotation", func() {
+			content := "- Resource: default/Pod/my-pod\n**Owner Chain**: ReplicaSet/my-pod-abc → Deployment/my-pod"
+			ctx := conversation.NewContext([]openai.Message{
+				{Role: "user", Content: stringPtr(content)},
+			})
+			res := ctx.ExtractResource()
+			Expect(res.Kind).To(Equal("Deployment"))
+			Expect(res.Name).To(Equal("my-pod"))
+			Expect(res.Namespace).To(Equal("default"))
+		})
+
+		It("should fall back to Resource line when no owner chain present", func() {
 			content := "- Signal Name: OOMKilled\n- Resource: staging/StatefulSet/my-db\n- Pod: some-pod\n- Namespace: other-ns"
 			ctx := conversation.NewContext([]openai.Message{
 				{Role: "user", Content: stringPtr(content)},

--- a/test/unit/mockllm/context_test.go
+++ b/test/unit/mockllm/context_test.go
@@ -102,6 +102,29 @@ var _ = Describe("Conversation Context Extraction", func() {
 			Expect(res.Name).To(Equal("my-pod-abc123"))
 			Expect(res.SignalName).To(Equal("OOMKilled"))
 		})
+
+		It("should extract resource from KA prompt template format (- Resource: ns/kind/name)", func() {
+			content := "# Incident Analysis\n- Signal Name: BackOff\n- Resource: fp-e2e-496-123/Deployment/memory-eater\n- Error: OOMKilled"
+			ctx := conversation.NewContext([]openai.Message{
+				{Role: "system", Content: stringPtr(content)},
+			})
+			res := ctx.ExtractResource()
+			Expect(res.Kind).To(Equal("Deployment"))
+			Expect(res.Name).To(Equal("memory-eater"))
+			Expect(res.Namespace).To(Equal("fp-e2e-496-123"))
+			Expect(res.SignalName).To(Equal("BackOff"))
+		})
+
+		It("should prefer Resource line over individual Pod/Namespace fields", func() {
+			content := "- Signal Name: OOMKilled\n- Resource: staging/StatefulSet/my-db\n- Pod: some-pod\n- Namespace: other-ns"
+			ctx := conversation.NewContext([]openai.Message{
+				{Role: "user", Content: stringPtr(content)},
+			})
+			res := ctx.ExtractResource()
+			Expect(res.Kind).To(Equal("StatefulSet"))
+			Expect(res.Name).To(Equal("my-db"))
+			Expect(res.Namespace).To(Equal("staging"))
+		})
 	})
 
 	Describe("UT-MOCK-014-005: ExtractRootOwner handles HolmesGPT-prefixed JSON", func() {

--- a/test/unit/mockllm/response_test.go
+++ b/test/unit/mockllm/response_test.go
@@ -133,7 +133,7 @@ var _ = Describe("Response Builders", func() {
 			Expect(text).To(ContainSubstring(`"actionable": false`))
 		})
 
-		It("UT-MOCK-030-003: human_review scenario includes needs_human_review and reason", func() {
+		It("UT-MOCK-030-003: response builder must NOT emit needs_human_review even when config has it (BR-HAPI-200)", func() {
 			reviewCfg := scenarios.MockScenarioConfig{
 				ScenarioName:         "no_workflow_found",
 				Severity:             "critical",
@@ -146,9 +146,12 @@ var _ = Describe("Response Builders", func() {
 
 			resp := response.BuildTextResponse("mock-model", reviewCfg)
 			text := *resp.Choices[0].Message.Content
-			Expect(text).To(ContainSubstring(`"needs_human_review": true`))
-			Expect(text).To(ContainSubstring(`"human_review_reason": "no_matching_workflows"`))
-			Expect(text).To(ContainSubstring(`"investigation_outcome": "inconclusive"`))
+			Expect(text).NotTo(ContainSubstring(`"needs_human_review"`),
+				"response builder must NOT emit needs_human_review — HR is parser-derived, not LLM-driven")
+			Expect(text).NotTo(ContainSubstring(`"human_review_reason"`),
+				"response builder must NOT emit human_review_reason — HR reason is parser-derived, not LLM-driven")
+			Expect(text).To(ContainSubstring(`"investigation_outcome": "inconclusive"`),
+				"investigation_outcome must still be emitted for parser derivation")
 		})
 
 		It("UT-MOCK-030-004: text response JSON is parseable", func() {


### PR DESCRIPTION
## Summary

### #700 — Parser-derived HR fields
- `needs_human_review` and `human_review_reason` are no longer set by the LLM. These fields are derived by the parser/investigator based on `investigation_outcome` mapping, aligning with HAPI's authoritative behavior.
- Removes HR fields from LLM schema, prompt template, and mock scenarios. Fixes a leakage path where `json.Unmarshal` populated HR fields via struct tags.

### #704 — Enrichment retry infrastructure with HardFail gating
- Adds `RetryConfig` (MaxRetries, BaseBackoff) and `HardFail` flag to `EnrichmentResult`.
- `resolveOwnerChainWithRetry` retries all errors with exponential backoff, aligned with HAPI v1.2.1 `EnrichmentService._retry`.
- Investigator gates on `HardFail` before re-enrichment label merge: sets `needs_human_review=true` with `human_review_reason=rca_incomplete`.
- HAPI-compliant defaults wired via `config.EnrichmentConfig` (MaxRetries=3, BaseBackoff=1s).
- Shared enrichment fixtures created across E2E (KA, AA, FP) and IT (AA) suites to prevent false HardFail on mock LLM scenario targets.
- RBAC and fixtures added for IT AA's shared envtest environment.
- Mock LLM made context-aware: `ExtractResource()` parses the KA prompt's `- Resource: ns/kind/name` line, overriding hard-coded scenario targets with the prompt's actual resource. Scenarios needing fixed targets (`rca_incomplete`, `cert_not_ready`) use `OverrideResource=true`. This prevents re-enrichment on fixture resources from changing `remediationTarget` (root cause of E2E FP failures).

### #707 — Non-atomic supersede visibility gap
- `handleDuplicateWorkflow` previously ran `UpdateStatus("Superseded")` (autocommit) then `Create()` (own transaction) as separate commits, creating a window where `ListWorkflowsByActionType` returned zero results.
- New `Repository.SupersedeAndCreate` wraps UPDATE + INSERT in a single transaction. On failure, deferred rollback restores the old workflow to Active.
- Fixed `err` shadowing in `Repository.Create` that could leak transactions on UPDATE failure.
- Wrapped flaky E2E-DS-017-001-001 and E2E-DS-043-004 assertions with `Eventually` to tolerate transient visibility during parallel registration.

## Business Requirements

- BR-HAPI-200: HR fields are parser-derived, not LLM-provided
- BR-HAPI-197: `needs_human_review` field contract
- BR-HAPI-261 AC#7: Owner chain resolution failure → `rca_incomplete`
- BR-HAPI-264 AC#6: Enrichment failure → `rca_incomplete`
- BR-WORKFLOW-006: Content hash integrity (atomic supersede)
- BR-STORAGE-016: Workflow status management (transaction safety)

## Issues

- Fixes #700
- Fixes #704
- Fixes #707

## Test plan

- [x] UT-KA-700-PDE-001/002/003: Parser derivation scenarios
- [x] UT-KA-433-PRS-009: LLM HR fields not propagated
- [x] UT-KA-433-OUT-003/004: Outcome mapping updated
- [x] UT-MOCK-030-003: Mock builder does not emit HR
- [x] UT-MOCK-014-004: ExtractResource with KA prompt template format
- [x] IT-KA-704-001: Owner chain failure triggers `rca_incomplete`
- [x] IT-KA-700-002: Phase separation fixture updated
- [x] UT-704-E-003/005: Enricher retry-all for NotFound and Forbidden
- [x] E2E-KA-433-ADV-016: `rca_incomplete` → `needs_human_review=true` (restored)
- [x] E2E-DS-017-001-001: Three-step discovery (Eventually)
- [x] E2E-DS-043-004: Detected labels search (Eventually)
- [x] Full KA unit test suite: all pass
- [x] Full DS unit test suite: all pass
- [x] Full mock LLM unit test suite: 122 pass
- [x] Build: `go build ./...` clean
- [x] Lint: 0 errors