### PR TITLE
perf: eliminate QEMU from arm64 release builds via host cross-compilation

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -16,6 +16,8 @@ WARP.md
 
 # Build artifacts
 bin/
+!bin/*-arm64
+!bin/*-amd64
 *.exe
 *.test
 *.prof

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,21 +139,21 @@ jobs:
           podman push "${IMAGE}"
 
   # ========================================
-  # STAGE 1b: BUILD & PUSH arm64 IMAGES
-  # 12 parallel jobs: one per service, arm64 only.
-  # Runs in parallel with Stage 1a. Does NOT block smoke tests.
+  # STAGE 1b: BUILD & PUSH arm64 IMAGES (Go services)
+  # 10 parallel jobs: one per Go service, arm64 via host-native cross-compile.
+  # No QEMU needed — CGO_ENABLED=0 GOARCH=arm64 runs natively on amd64.
+  # Runtime images use FROM scratch with pre-built binary.
   #
   # Strategy:
-  #   - Go services: CGO_ENABLED=0 cross-compile via GOARCH (native speed)
-  #     inside ubi10/go-toolset pulled for target platform (QEMU for arm64)
-  #   - Python/Bash: Full QEMU emulation for arm64 (slower, acceptable for releases)
+  #   - Host cross-compile: go build with GOARCH=arm64 (native speed, ~25s)
+  #   - Runtime image: scratch + certs from amd64 ubi-minimal (no QEMU, ~5s)
   # ========================================
 
   build-arm64:
     name: "${{ matrix.service }} (arm64)"
     needs: prepare
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -168,6 +168,81 @@ jobs:
           - datastorage
           - effectivenessmonitor
           - kubernautagent
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          submodules: true
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+          cache: true
+
+      - name: Generate code
+        run: |
+          export PATH="${{ github.workspace }}/bin:$PATH"
+          make generate
+
+      - name: Cross-compile binary (native, no QEMU)
+        env:
+          IMAGE_ARCH: arm64
+          APP_VERSION: ${{ needs.prepare.outputs.version }}
+          GIT_COMMIT: ${{ github.sha }}
+          BUILD_DATE: ${{ needs.prepare.outputs.build_date }}
+        run: |
+          echo "Cross-compiling ${{ matrix.service }} for arm64 (native)..."
+          START=$(date +%s)
+          make cross-build-${{ matrix.service }}
+          END=$(date +%s)
+          echo "Binary built in $(($END - $START))s"
+          ls -lh bin/*-arm64
+
+      - name: Login to Quay.io
+        run: |
+          podman login -u "${{ secrets.QUAY_ROBOT_USERNAME }}" \
+                       -p "${{ secrets.QUAY_ROBOT_TOKEN }}" \
+                       quay.io
+
+      - name: Build runtime image (no QEMU)
+        env:
+          IMAGE_TAG: ${{ needs.prepare.outputs.version }}
+          IMAGE_ARCH: arm64
+          CONTAINER_TOOL: podman
+          APP_VERSION: ${{ needs.prepare.outputs.version }}
+          GIT_COMMIT: ${{ github.sha }}
+          BUILD_DATE: ${{ needs.prepare.outputs.build_date }}
+        run: |
+          echo "Building runtime image ${{ matrix.service }} (arm64, no QEMU)..."
+          START=$(date +%s)
+          make image-runtime-${{ matrix.service }}
+          END=$(date +%s)
+          echo "Image built in $(($END - $START))s"
+
+      - name: Push image
+        env:
+          IMAGE_TAG: ${{ needs.prepare.outputs.version }}
+        run: |
+          IMAGE="${IMAGE_REGISTRY}/${{ matrix.service }}:${IMAGE_TAG}-arm64"
+          echo "Pushing ${IMAGE}..."
+          podman push "${IMAGE}"
+
+  # ========================================
+  # STAGE 1c: BUILD & PUSH arm64 IMAGES (non-Go services)
+  # must-gather (Bash) and db-migrate (downloads goose binary) still need QEMU
+  # for package installation in their respective base images.
+  # ========================================
+
+  build-arm64-qemu:
+    name: "${{ matrix.service }} (arm64, QEMU)"
+    needs: prepare
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
           - must-gather
           - db-migrate
     steps:
@@ -213,8 +288,30 @@ jobs:
           GIT_COMMIT: ${{ github.sha }}
           BUILD_DATE: ${{ needs.prepare.outputs.build_date }}
         run: |
-          echo "Building ${{ matrix.service }} for arm64..."
+          echo "::group::arm64 QEMU build for ${{ matrix.service }}"
+          echo "Building ${{ matrix.service }} for arm64 (QEMU emulated)..."
+          echo "Start: $(date -u '+%H:%M:%S UTC')"
+
+          # Background heartbeat: prints elapsed time every 60s
+          (
+            LOOP_START=$SECONDS
+            while true; do
+              sleep 60
+              ELAPSED=$(( (SECONDS - LOOP_START) / 60 ))
+              BUILD_PID=$(pgrep -f "podman build" || echo "none")
+              QEMU_PROCS=$(pgrep -c qemu-aarch64 2>/dev/null || echo "0")
+              echo "[heartbeat +${ELAPSED}m] podman_pid=${BUILD_PID} qemu_procs=${QEMU_PROCS}"
+            done
+          ) &
+          HEARTBEAT_PID=$!
+
           make image-build-${{ matrix.service }}
+          BUILD_EXIT=$?
+
+          kill $HEARTBEAT_PID 2>/dev/null || true
+          echo "Finished: $(date -u '+%H:%M:%S UTC') (exit: $BUILD_EXIT)"
+          echo "::endgroup::"
+          exit $BUILD_EXIT
 
       - name: Push image
         env:
@@ -347,7 +444,7 @@ jobs:
 
   create-manifests:
     name: Create Multi-Arch Manifests
-    needs: [prepare, build-amd64, build-arm64]
+    needs: [prepare, build-amd64, build-arm64, build-arm64-qemu]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
@@ -397,7 +494,7 @@ jobs:
 
   helm-publish:
     name: Publish Helm Chart
-    needs: [prepare, build-amd64, build-arm64]
+    needs: [prepare, build-amd64, build-arm64, build-arm64-qemu]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/Makefile
+++ b/Makefile
@@ -979,6 +979,72 @@ image-manifest: ## Create and push multi-arch manifests (run after both arches a
 	@echo ""
 	@echo "✅ All manifests pushed as $(IMAGE_REGISTRY):$(IMAGE_TAG)."
 
+# ========================================
+# Cross-compilation targets (no QEMU, no container)
+# Used by release.yml arm64 jobs for native cross-compile.
+# Produces bin/<binary>-<arch> (e.g., bin/data-storage-arm64)
+# ========================================
+
+# Service-to-binary-name mapping (matches Dockerfile -o flags)
+BINARY_NAME_datastorage := data-storage
+BINARY_NAME_gateway := gateway
+BINARY_NAME_aianalysis := aianalysis-controller
+BINARY_NAME_authwebhook := authwebhook
+BINARY_NAME_notification := manager
+BINARY_NAME_remediationorchestrator := remediationorchestrator-controller
+BINARY_NAME_signalprocessing := signalprocessing-controller
+BINARY_NAME_workflowexecution := workflowexecution
+BINARY_NAME_effectivenessmonitor := effectivenessmonitor-controller
+BINARY_NAME_kubernautagent := kubernautagent
+
+# Go services that support host-native cross-compilation (excludes db-migrate, must-gather)
+CROSS_SERVICES := datastorage gateway aianalysis authwebhook notification remediationorchestrator signalprocessing workflowexecution effectivenessmonitor kubernautagent
+
+# Runtime Dockerfile mapping (production scratch images for pre-built binaries)
+RUNTIME_DOCKERFILES_datastorage := docker/data-storage.runtime.Dockerfile
+RUNTIME_DOCKERFILES_gateway := docker/gateway.runtime.Dockerfile
+RUNTIME_DOCKERFILES_aianalysis := docker/aianalysis.runtime.Dockerfile
+RUNTIME_DOCKERFILES_authwebhook := docker/authwebhook.runtime.Dockerfile
+RUNTIME_DOCKERFILES_notification := docker/notification-controller.runtime.Dockerfile
+RUNTIME_DOCKERFILES_remediationorchestrator := docker/remediationorchestrator-controller.runtime.Dockerfile
+RUNTIME_DOCKERFILES_signalprocessing := docker/signalprocessing-controller.runtime.Dockerfile
+RUNTIME_DOCKERFILES_workflowexecution := docker/workflowexecution-controller.runtime.Dockerfile
+RUNTIME_DOCKERFILES_effectivenessmonitor := docker/effectivenessmonitor-controller.runtime.Dockerfile
+RUNTIME_DOCKERFILES_kubernautagent := docker/kubernautagent.runtime.Dockerfile
+
+.PHONY: cross-build-%
+cross-build-%: ## Cross-compile a Go service binary for target arch (no container, no QEMU)
+	@if [ -z "$(BINARY_NAME_$*)" ]; then \
+	    echo "ERROR: Unknown cross-compile service '$*'. Available: $(CROSS_SERVICES)"; exit 1; \
+	fi
+	@echo "  Cross-compiling $* -> bin/$(BINARY_NAME_$*)-$(IMAGE_ARCH)..."
+	@mkdir -p bin
+	@CGO_ENABLED=0 GOOS=linux GOARCH=$(IMAGE_ARCH) go build -mod=mod \
+	    -ldflags "-s -w -X github.com/jordigilh/kubernaut/internal/version.Version=$(APP_VERSION) -X github.com/jordigilh/kubernaut/internal/version.GitCommit=$(GIT_COMMIT) -X github.com/jordigilh/kubernaut/internal/version.BuildDate=$(BUILD_DATE)" \
+	    -o bin/$(BINARY_NAME_$*)-$(IMAGE_ARCH) ./cmd/$*/main.go
+
+.PHONY: cross-build-all
+cross-build-all: ## Cross-compile all Go services for target arch
+	@echo "🔨 Cross-compiling all Go services for $(IMAGE_ARCH)..."
+	@$(foreach svc,$(CROSS_SERVICES),$(MAKE) cross-build-$(svc);)
+	@echo "✅ All binaries built in bin/*-$(IMAGE_ARCH)"
+
+.PHONY: image-runtime-%
+image-runtime-%: ## Build runtime-only image from pre-built binary (no QEMU needed)
+	@if [ -z "$(RUNTIME_DOCKERFILES_$*)" ]; then \
+	    echo "ERROR: Unknown runtime service '$*'. Available: $(CROSS_SERVICES)"; exit 1; \
+	fi
+	@if [ ! -f "bin/$(BINARY_NAME_$*)-$(IMAGE_ARCH)" ]; then \
+	    echo "ERROR: Binary bin/$(BINARY_NAME_$*)-$(IMAGE_ARCH) not found. Run: make cross-build-$* IMAGE_ARCH=$(IMAGE_ARCH)"; exit 1; \
+	fi
+	@echo "  Building runtime image $* [$(IMAGE_ARCH)] (no QEMU)..."
+	@$(CONTAINER_TOOL) build --no-cache \
+	    --build-arg BINARY=bin/$(BINARY_NAME_$*)-$(IMAGE_ARCH) \
+	    --build-arg APP_VERSION=$(APP_VERSION) \
+	    --build-arg GIT_COMMIT=$(GIT_COMMIT) \
+	    --build-arg BUILD_DATE=$(BUILD_DATE) \
+	    -t $(IMAGE_REGISTRY)/$*:$(IMAGE_TAG)-$(IMAGE_ARCH) -f $(RUNTIME_DOCKERFILES_$*) .
+
 # Per-service image targets (e.g., make image-build-aianalysis IMAGE_TAG=demo-v1.0)
 .PHONY: image-build-%
 image-build-%: ## Build a single service image (specified arch via IMAGE_ARCH)

--- a/docker/aianalysis.runtime.Dockerfile
+++ b/docker/aianalysis.runtime.Dockerfile
@@ -1,0 +1,30 @@
+# AIAnalysis Controller - Runtime-Only Dockerfile (no QEMU)
+#
+# Prerequisites: make cross-build-aianalysis IMAGE_ARCH=arm64
+# Usage: make image-runtime-aianalysis IMAGE_ARCH=arm64
+
+ARG BINARY=bin/aianalysis-controller-arm64
+
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi10/ubi-minimal:latest AS certs
+RUN microdnf install -y ca-certificates tzdata && microdnf clean all
+
+FROM scratch
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt
+COPY --from=certs /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=certs /etc/passwd /etc/passwd
+ARG BINARY
+COPY ${BINARY} /aianalysis-controller
+USER 65534
+EXPOSE 8080 9090
+ENTRYPOINT ["/aianalysis-controller"]
+CMD []
+
+ARG APP_VERSION=unknown
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+LABEL org.opencontainers.image.source="https://github.com/jordigilh/kubernaut" \
+	org.opencontainers.image.version="${APP_VERSION}" \
+	org.opencontainers.image.revision="${GIT_COMMIT}" \
+	org.opencontainers.image.created="${BUILD_DATE}" \
+	org.opencontainers.image.title="kubernaut-aianalysis-controller" \
+	org.opencontainers.image.vendor="Kubernaut"

--- a/docker/authwebhook.runtime.Dockerfile
+++ b/docker/authwebhook.runtime.Dockerfile
@@ -1,0 +1,30 @@
+# AuthWebhook Service - Runtime-Only Dockerfile (no QEMU)
+#
+# Prerequisites: make cross-build-authwebhook IMAGE_ARCH=arm64
+# Usage: make image-runtime-authwebhook IMAGE_ARCH=arm64
+
+ARG BINARY=bin/authwebhook-arm64
+
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi10/ubi-minimal:latest AS certs
+RUN microdnf install -y ca-certificates tzdata && microdnf clean all
+
+FROM scratch
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt
+COPY --from=certs /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=certs /etc/passwd /etc/passwd
+ARG BINARY
+COPY ${BINARY} /authwebhook
+USER 65534
+EXPOSE 8080 9090
+ENTRYPOINT ["/authwebhook"]
+CMD []
+
+ARG APP_VERSION=unknown
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+LABEL org.opencontainers.image.source="https://github.com/jordigilh/kubernaut" \
+	org.opencontainers.image.version="${APP_VERSION}" \
+	org.opencontainers.image.revision="${GIT_COMMIT}" \
+	org.opencontainers.image.created="${BUILD_DATE}" \
+	org.opencontainers.image.title="kubernaut-authwebhook" \
+	org.opencontainers.image.vendor="Kubernaut"

--- a/docker/data-storage.runtime.Dockerfile
+++ b/docker/data-storage.runtime.Dockerfile
@@ -1,0 +1,35 @@
+# Data Storage Service - Runtime-Only Dockerfile (no QEMU)
+#
+# Used by release.yml arm64 builds: binary is cross-compiled on the host,
+# then packaged into this scratch image without QEMU emulation.
+#
+# Prerequisites: make cross-build-datastorage IMAGE_ARCH=arm64
+# Usage: make image-runtime-datastorage IMAGE_ARCH=arm64
+
+ARG BINARY=bin/data-storage-arm64
+
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi10/ubi-minimal:latest AS certs
+RUN microdnf install -y ca-certificates tzdata && microdnf clean all
+
+FROM scratch
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt
+COPY --from=certs /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=certs /etc/passwd /etc/passwd
+ARG BINARY
+COPY ${BINARY} /data-storage
+COPY api/openapi/data-storage-v1.yaml /usr/local/share/kubernaut/api/openapi/data-storage-v1.yaml
+USER 65534
+EXPOSE 8080 9090
+ENTRYPOINT ["/data-storage"]
+CMD []
+
+ARG APP_VERSION=unknown
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+LABEL org.opencontainers.image.source="https://github.com/jordigilh/kubernaut" \
+	org.opencontainers.image.version="${APP_VERSION}" \
+	org.opencontainers.image.revision="${GIT_COMMIT}" \
+	org.opencontainers.image.created="${BUILD_DATE}" \
+	org.opencontainers.image.title="kubernaut-data-storage" \
+	org.opencontainers.image.description="Persistent storage service for remediation audit trails with PostgreSQL dual-write support." \
+	org.opencontainers.image.vendor="Kubernaut"

--- a/docker/effectivenessmonitor-controller.runtime.Dockerfile
+++ b/docker/effectivenessmonitor-controller.runtime.Dockerfile
@@ -1,0 +1,30 @@
+# Effectiveness Monitor Controller - Runtime-Only Dockerfile (no QEMU)
+#
+# Prerequisites: make cross-build-effectivenessmonitor IMAGE_ARCH=arm64
+# Usage: make image-runtime-effectivenessmonitor IMAGE_ARCH=arm64
+
+ARG BINARY=bin/effectivenessmonitor-controller-arm64
+
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi10/ubi-minimal:latest AS certs
+RUN microdnf install -y ca-certificates tzdata && microdnf clean all
+
+FROM scratch
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt
+COPY --from=certs /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=certs /etc/passwd /etc/passwd
+ARG BINARY
+COPY ${BINARY} /effectivenessmonitor-controller
+USER 65534
+EXPOSE 8080 9090
+ENTRYPOINT ["/effectivenessmonitor-controller"]
+CMD []
+
+ARG APP_VERSION=unknown
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+LABEL org.opencontainers.image.source="https://github.com/jordigilh/kubernaut" \
+	org.opencontainers.image.version="${APP_VERSION}" \
+	org.opencontainers.image.revision="${GIT_COMMIT}" \
+	org.opencontainers.image.created="${BUILD_DATE}" \
+	org.opencontainers.image.title="kubernaut-effectivenessmonitor-controller" \
+	org.opencontainers.image.vendor="Kubernaut"

--- a/docker/gateway.runtime.Dockerfile
+++ b/docker/gateway.runtime.Dockerfile
@@ -1,0 +1,30 @@
+# Gateway Service - Runtime-Only Dockerfile (no QEMU)
+#
+# Prerequisites: make cross-build-gateway IMAGE_ARCH=arm64
+# Usage: make image-runtime-gateway IMAGE_ARCH=arm64
+
+ARG BINARY=bin/gateway-arm64
+
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi10/ubi-minimal:latest AS certs
+RUN microdnf install -y ca-certificates tzdata && microdnf clean all
+
+FROM scratch
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt
+COPY --from=certs /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=certs /etc/passwd /etc/passwd
+ARG BINARY
+COPY ${BINARY} /gateway
+USER 65534
+EXPOSE 8080 9090
+ENTRYPOINT ["/gateway"]
+CMD []
+
+ARG APP_VERSION=unknown
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+LABEL org.opencontainers.image.source="https://github.com/jordigilh/kubernaut" \
+	org.opencontainers.image.version="${APP_VERSION}" \
+	org.opencontainers.image.revision="${GIT_COMMIT}" \
+	org.opencontainers.image.created="${BUILD_DATE}" \
+	org.opencontainers.image.title="kubernaut-gateway" \
+	org.opencontainers.image.vendor="Kubernaut"

--- a/docker/kubernautagent.runtime.Dockerfile
+++ b/docker/kubernautagent.runtime.Dockerfile
@@ -1,0 +1,30 @@
+# Kubernaut Agent - Runtime-Only Dockerfile (no QEMU)
+#
+# Prerequisites: make cross-build-kubernautagent IMAGE_ARCH=arm64
+# Usage: make image-runtime-kubernautagent IMAGE_ARCH=arm64
+
+ARG BINARY=bin/kubernautagent-arm64
+
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi10/ubi-minimal:latest AS certs
+RUN microdnf install -y ca-certificates tzdata && microdnf clean all
+
+FROM scratch
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt
+COPY --from=certs /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=certs /etc/passwd /etc/passwd
+ARG BINARY
+COPY ${BINARY} /kubernautagent
+USER 65534
+EXPOSE 8080 9090
+ENTRYPOINT ["/kubernautagent"]
+CMD []
+
+ARG APP_VERSION=unknown
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+LABEL org.opencontainers.image.source="https://github.com/jordigilh/kubernaut" \
+	org.opencontainers.image.version="${APP_VERSION}" \
+	org.opencontainers.image.revision="${GIT_COMMIT}" \
+	org.opencontainers.image.created="${BUILD_DATE}" \
+	org.opencontainers.image.title="kubernaut-agent" \
+	org.opencontainers.image.vendor="Kubernaut"

--- a/docker/notification-controller.runtime.Dockerfile
+++ b/docker/notification-controller.runtime.Dockerfile
@@ -1,0 +1,30 @@
+# Notification Controller - Runtime-Only Dockerfile (no QEMU)
+#
+# Prerequisites: make cross-build-notification IMAGE_ARCH=arm64
+# Usage: make image-runtime-notification IMAGE_ARCH=arm64
+
+ARG BINARY=bin/manager-arm64
+
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi10/ubi-minimal:latest AS certs
+RUN microdnf install -y ca-certificates tzdata && microdnf clean all
+
+FROM scratch
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt
+COPY --from=certs /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=certs /etc/passwd /etc/passwd
+ARG BINARY
+COPY ${BINARY} /manager
+USER 65534
+EXPOSE 8080 9090
+ENTRYPOINT ["/manager"]
+CMD []
+
+ARG APP_VERSION=unknown
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+LABEL org.opencontainers.image.source="https://github.com/jordigilh/kubernaut" \
+	org.opencontainers.image.version="${APP_VERSION}" \
+	org.opencontainers.image.revision="${GIT_COMMIT}" \
+	org.opencontainers.image.created="${BUILD_DATE}" \
+	org.opencontainers.image.title="kubernaut-notification-controller" \
+	org.opencontainers.image.vendor="Kubernaut"

--- a/docker/remediationorchestrator-controller.runtime.Dockerfile
+++ b/docker/remediationorchestrator-controller.runtime.Dockerfile
@@ -1,0 +1,30 @@
+# Remediation Orchestrator Controller - Runtime-Only Dockerfile (no QEMU)
+#
+# Prerequisites: make cross-build-remediationorchestrator IMAGE_ARCH=arm64
+# Usage: make image-runtime-remediationorchestrator IMAGE_ARCH=arm64
+
+ARG BINARY=bin/remediationorchestrator-controller-arm64
+
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi10/ubi-minimal:latest AS certs
+RUN microdnf install -y ca-certificates tzdata && microdnf clean all
+
+FROM scratch
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt
+COPY --from=certs /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=certs /etc/passwd /etc/passwd
+ARG BINARY
+COPY ${BINARY} /remediationorchestrator-controller
+USER 65534
+EXPOSE 8080 9090
+ENTRYPOINT ["/remediationorchestrator-controller"]
+CMD []
+
+ARG APP_VERSION=unknown
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+LABEL org.opencontainers.image.source="https://github.com/jordigilh/kubernaut" \
+	org.opencontainers.image.version="${APP_VERSION}" \
+	org.opencontainers.image.revision="${GIT_COMMIT}" \
+	org.opencontainers.image.created="${BUILD_DATE}" \
+	org.opencontainers.image.title="kubernaut-remediationorchestrator-controller" \
+	org.opencontainers.image.vendor="Kubernaut"

--- a/docker/signalprocessing-controller.runtime.Dockerfile
+++ b/docker/signalprocessing-controller.runtime.Dockerfile
@@ -1,0 +1,30 @@
+# Signal Processing Controller - Runtime-Only Dockerfile (no QEMU)
+#
+# Prerequisites: make cross-build-signalprocessing IMAGE_ARCH=arm64
+# Usage: make image-runtime-signalprocessing IMAGE_ARCH=arm64
+
+ARG BINARY=bin/signalprocessing-controller-arm64
+
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi10/ubi-minimal:latest AS certs
+RUN microdnf install -y ca-certificates tzdata && microdnf clean all
+
+FROM scratch
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt
+COPY --from=certs /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=certs /etc/passwd /etc/passwd
+ARG BINARY
+COPY ${BINARY} /signalprocessing-controller
+USER 65534
+EXPOSE 8080 9090
+ENTRYPOINT ["/signalprocessing-controller"]
+CMD []
+
+ARG APP_VERSION=unknown
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+LABEL org.opencontainers.image.source="https://github.com/jordigilh/kubernaut" \
+	org.opencontainers.image.version="${APP_VERSION}" \
+	org.opencontainers.image.revision="${GIT_COMMIT}" \
+	org.opencontainers.image.created="${BUILD_DATE}" \
+	org.opencontainers.image.title="kubernaut-signalprocessing-controller" \
+	org.opencontainers.image.vendor="Kubernaut"

--- a/docker/workflowexecution-controller.runtime.Dockerfile
+++ b/docker/workflowexecution-controller.runtime.Dockerfile
@@ -1,0 +1,30 @@
+# Workflow Execution Controller - Runtime-Only Dockerfile (no QEMU)
+#
+# Prerequisites: make cross-build-workflowexecution IMAGE_ARCH=arm64
+# Usage: make image-runtime-workflowexecution IMAGE_ARCH=arm64
+
+ARG BINARY=bin/workflowexecution-arm64
+
+FROM --platform=linux/amd64 registry.access.redhat.com/ubi10/ubi-minimal:latest AS certs
+RUN microdnf install -y ca-certificates tzdata && microdnf clean all
+
+FROM scratch
+COPY --from=certs /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem /etc/ssl/certs/ca-certificates.crt
+COPY --from=certs /usr/share/zoneinfo /usr/share/zoneinfo
+COPY --from=certs /etc/passwd /etc/passwd
+ARG BINARY
+COPY ${BINARY} /workflowexecution
+USER 65534
+EXPOSE 8080 9090
+ENTRYPOINT ["/workflowexecution"]
+CMD []
+
+ARG APP_VERSION=unknown
+ARG GIT_COMMIT=unknown
+ARG BUILD_DATE=unknown
+LABEL org.opencontainers.image.source="https://github.com/jordigilh/kubernaut" \
+	org.opencontainers.image.version="${APP_VERSION}" \
+	org.opencontainers.image.revision="${GIT_COMMIT}" \
+	org.opencontainers.image.created="${BUILD_DATE}" \
+	org.opencontainers.image.title="kubernaut-workflowexecution" \
+	org.opencontainers.image.vendor="Kubernaut"

--- a/test/e2e/fullpipeline/01_full_remediation_lifecycle_test.go
+++ b/test/e2e/fullpipeline/01_full_remediation_lifecycle_test.go
@@ -796,7 +796,30 @@ var _ = Describe("Full Remediation Lifecycle [BR-E2E-001]", func() {
 		Expect(apiReader.Get(ctx, client.ObjectKey{Name: weName, Namespace: namespace}, weObj)).To(Succeed())
 		allFailures = append(allFailures, crdvalidators.ValidateWEStatus(weObj)...)
 
-		// NT: re-fetch completion notification
+		// NT: wait for completion notification to reach terminal phase before validation.
+		Eventually(func() bool {
+			nrList := &notificationv1.NotificationRequestList{}
+			if err := apiReader.List(ctx, nrList, client.InNamespace(namespace)); err != nil {
+				return false
+			}
+			for i := range nrList.Items {
+				nr := &nrList.Items[i]
+				if nr.Spec.RemediationRequestRef != nil &&
+					nr.Spec.RemediationRequestRef.Name == remediationRequest.Name &&
+					nr.Spec.Type == notificationv1.NotificationTypeCompletion {
+					switch nr.Status.Phase {
+					case notificationv1.NotificationPhaseSent,
+						notificationv1.NotificationPhasePartiallySent,
+						notificationv1.NotificationPhaseFailed:
+						return true
+					}
+					return false
+				}
+			}
+			return false
+		}, 2*time.Minute, interval).Should(BeTrue(),
+			"Completion NotificationRequest should reach terminal phase (Sent, PartiallySent, or Failed)")
+
 		nrList := &notificationv1.NotificationRequestList{}
 		Expect(apiReader.List(ctx, nrList, client.InNamespace(namespace))).To(Succeed())
 		for i := range nrList.Items {
@@ -1336,7 +1359,30 @@ var _ = Describe("Full Remediation Lifecycle [BR-E2E-001]", func() {
 		Expect(apiReader.Get(ctx, client.ObjectKey{Name: weName, Namespace: namespace}, amWE)).To(Succeed())
 		allFailures = append(allFailures, crdvalidators.ValidateWEStatus(amWE)...)
 
-		// NT: fetch completion notification
+		// NT: wait for completion notification to reach terminal phase before validation.
+		Eventually(func() bool {
+			amNRList := &notificationv1.NotificationRequestList{}
+			if err := apiReader.List(ctx, amNRList, client.InNamespace(namespace)); err != nil {
+				return false
+			}
+			for i := range amNRList.Items {
+				nr := &amNRList.Items[i]
+				if nr.Spec.RemediationRequestRef != nil &&
+					nr.Spec.RemediationRequestRef.Name == remediationRequest.Name &&
+					nr.Spec.Type == notificationv1.NotificationTypeCompletion {
+					switch nr.Status.Phase {
+					case notificationv1.NotificationPhaseSent,
+						notificationv1.NotificationPhasePartiallySent,
+						notificationv1.NotificationPhaseFailed:
+						return true
+					}
+					return false
+				}
+			}
+			return false
+		}, 2*time.Minute, interval).Should(BeTrue(),
+			"Completion NotificationRequest should reach terminal phase (Sent, PartiallySent, or Failed)")
+
 		amNRList := &notificationv1.NotificationRequestList{}
 		Expect(apiReader.List(ctx, amNRList, client.InNamespace(namespace))).To(Succeed())
 		for i := range amNRList.Items {

--- a/test/e2e/fullpipeline/02_approval_lifecycle_test.go
+++ b/test/e2e/fullpipeline/02_approval_lifecycle_test.go
@@ -430,7 +430,30 @@ var _ = Describe("Approval Lifecycle [BR-ORCH-026]", func() {
 		Expect(apiReader.Get(ctx, client.ObjectKey{Name: weName, Namespace: namespace}, weObj)).To(Succeed())
 		allFailures = append(allFailures, crdvalidators.ValidateWEStatus(weObj)...)
 
-		// NT: validate both approval and completion notifications
+		// NT: wait for all pipeline notifications to reach terminal phase before validation.
+		// The completion NR may still be in "Sending" if the delivery loop hasn't finished.
+		Eventually(func() bool {
+			nrList := &notificationv1.NotificationRequestList{}
+			if err := apiReader.List(ctx, nrList, client.InNamespace(namespace)); err != nil {
+				return false
+			}
+			for i := range nrList.Items {
+				nr := &nrList.Items[i]
+				if nr.Spec.RemediationRequestRef != nil &&
+					nr.Spec.RemediationRequestRef.Name == remediationRequest.Name {
+					switch nr.Status.Phase {
+					case notificationv1.NotificationPhaseSent,
+						notificationv1.NotificationPhasePartiallySent,
+						notificationv1.NotificationPhaseFailed:
+					default:
+						return false
+					}
+				}
+			}
+			return true
+		}, 2*time.Minute, interval).Should(BeTrue(),
+			"All NotificationRequests should reach terminal phase (Sent, PartiallySent, or Failed)")
+
 		nrList := &notificationv1.NotificationRequestList{}
 		Expect(apiReader.List(ctx, nrList, client.InNamespace(namespace))).To(Succeed())
 		for i := range nrList.Items {


### PR DESCRIPTION
## Summary

- Eliminates QEMU user-mode emulation from 10/12 arm64 release builds by using Go's native cross-compilation (`CGO_ENABLED=0 GOARCH=arm64`)
- Reduces arm64 build time from **60+ minutes** (frequently appearing hung) to **~30 seconds** per service
- Adds heartbeat watchdog to the remaining 2 QEMU-dependent builds (must-gather, db-migrate) for stuck-vs-working observability

## Changes

- **Makefile**: New `cross-build-%` and `image-runtime-%` targets for host-native cross-compile + scratch runtime image
- **10 runtime Dockerfiles**: `docker/<service>.runtime.Dockerfile` — sources CA certs/tzdata from amd64 ubi-minimal, `FROM scratch` final stage with pre-built binary
- **release.yml**: Split `build-arm64` into two jobs:
  - `build-arm64`: 10 Go services via cross-compile (no QEMU, ~30s each)
  - `build-arm64-qemu`: must-gather + db-migrate (still need QEMU for package manager)
- **.dockerignore**: Allow `bin/*-arm64` and `bin/*-amd64` through for runtime Dockerfile COPY

## Validation

- All 10 Go services cross-compiled to arm64 on helios08 (x86_64): **10/10 pass, 0 failures**
- DataStorage end-to-end (cross-compile + runtime image build): **29 seconds** vs. 60+ min with QEMU
- Full `make cross-build-all IMAGE_ARCH=amd64` passes locally (arm64 Mac -> amd64)
- `make image-runtime-datastorage` produces correct scratch image locally

## Test Plan

- [x] `make cross-build-all IMAGE_ARCH=amd64` passes (local arm64 -> amd64)
- [x] `make image-runtime-datastorage IMAGE_ARCH=amd64` builds successfully
- [x] All 10 services cross-compile on helios08 (amd64 -> arm64)
- [ ] Release workflow triggered by tag produces correct arm64 images (verified on next RC)

Made with [Cursor](https://cursor.com)