### PR TITLE
fix: PascalCase AssessmentReason (#749), audit flush config, and inter-service TLS trust (#750)

### DIFF
--- a/api/effectivenessassessment/v1alpha1/effectivenessassessment_types.go
+++ b/api/effectivenessassessment/v1alpha1/effectivenessassessment_types.go
@@ -60,26 +60,30 @@ const (
 )
 
 // AssessmentReason constants describe why an assessment completed with a particular outcome.
+// Issue #749: All values use PascalCase per Kubernetes API conventions.
 const (
 	// AssessmentReasonFull indicates all enabled components were assessed successfully.
-	AssessmentReasonFull = "full"
+	AssessmentReasonFull = "Full"
 	// AssessmentReasonPartial indicates some components were assessed but not all.
-	AssessmentReasonPartial = "partial"
+	AssessmentReasonPartial = "Partial"
 	// AssessmentReasonNoExecution indicates no workflow execution was found for this RR.
-	AssessmentReasonNoExecution = "no_execution"
+	AssessmentReasonNoExecution = "NoExecution"
 	// AssessmentReasonMetricsTimedOut indicates metrics were not available before validity expired.
-	AssessmentReasonMetricsTimedOut = "metrics_timed_out"
+	AssessmentReasonMetricsTimedOut = "MetricsTimedOut"
 	// AssessmentReasonExpired indicates the validity window expired with no data collected.
-	AssessmentReasonExpired = "expired"
+	AssessmentReasonExpired = "Expired"
 	// AssessmentReasonSpecDrift indicates the target resource spec was modified during assessment.
 	// The remediation is considered unsuccessful — DS score = 0.0 (DD-EM-002 v1.1).
-	AssessmentReasonSpecDrift = "spec_drift"
+	AssessmentReasonSpecDrift = "SpecDrift"
 	// AssessmentReasonAlertDecayTimeout indicates the validity window expired while the EM
-	// was actively monitoring alert decay. Unlike "partial" (alert never checked) or
-	// "expired" (no data), this means the EM confirmed the resource was healthy but the
+	// was actively monitoring alert decay. Unlike "Partial" (alert never checked) or
+	// "Expired" (no data), this means the EM confirmed the resource was healthy but the
 	// Prometheus alert persisted beyond validity — likely a genuine re-occurrence.
 	// Reference: Issue #369, BR-EM-012
-	AssessmentReasonAlertDecayTimeout = "alert_decay_timeout"
+	AssessmentReasonAlertDecayTimeout = "AlertDecayTimeout"
+	// AssessmentReasonUnrecoverable indicates the assessment could not be performed
+	// due to an unrecoverable condition (e.g., target not found). Issue #749.
+	AssessmentReasonUnrecoverable = "Unrecoverable"
 )
 
 // EffectivenessAssessmentSpec defines the desired state of an EffectivenessAssessment.
@@ -232,7 +236,7 @@ type EffectivenessAssessmentStatus struct {
 	Components EAComponents `json:"components,omitempty"`
 
 	// AssessmentReason describes why the assessment completed with this outcome.
-	// +kubebuilder:validation:Enum=full;partial;no_execution;metrics_timed_out;expired;spec_drift;alert_decay_timeout
+	// +kubebuilder:validation:Enum=Full;Partial;NoExecution;MetricsTimedOut;Expired;SpecDrift;AlertDecayTimeout;Unrecoverable
 	AssessmentReason string `json:"assessmentReason,omitempty"`
 
 	// CompletedAt is the timestamp when the assessment finished.

--- a/api/openapi/data-storage-v1.yaml
+++ b/api/openapi/data-storage-v1.yaml
@@ -1969,25 +1969,25 @@ components:
           enum:
             - no_data
             - in_progress
-            - full
-            - partial
-            - spec_drift
-            - expired
-            - no_execution
-            - metrics_timed_out
+            - Full
+            - Partial
+            - SpecDrift
+            - Expired
+            - NoExecution
+            - MetricsTimedOut
             - EffectivenessAssessed
           description: |
             Current assessment status:
             - no_data: No component events found
             - in_progress: Some component events present but assessment not completed
-            - full: All components assessed successfully
-            - partial: Some components assessed, others unavailable
-            - spec_drift: Target resource spec changed during assessment (score unreliable, forced to 0.0)
-            - expired: Assessment timed out before completing
-            - no_execution: No workflow execution found for this correlation ID
-            - metrics_timed_out: Prometheus metrics collection timed out
-            - EffectivenessAssessed: Legacy value (equivalent to "full")
-          example: "full"
+            - Full: All components assessed successfully
+            - Partial: Some components assessed, others unavailable
+            - SpecDrift: Target resource spec changed during assessment (score unreliable, forced to 0.0)
+            - Expired: Assessment timed out before completing
+            - NoExecution: No workflow execution found for this correlation ID
+            - MetricsTimedOut: Prometheus metrics collection timed out
+            - EffectivenessAssessed: Legacy value (equivalent to "Full")
+          example: "Full"
         computed_at:
           type: string
           format: date-time
@@ -5682,18 +5682,18 @@ components:
           type: string
           nullable: true
           enum:
-            - full
-            - partial
-            - spec_drift
-            - expired
-            - no_execution
-            - metrics_timed_out
+            - Full
+            - Partial
+            - SpecDrift
+            - Expired
+            - NoExecution
+            - MetricsTimedOut
           description: |
             Reason/status of the effectiveness assessment. Null if assessment
-            not yet completed. When "spec_drift", the effectiveness score is
+            not yet completed. When "SpecDrift", the effectiveness score is
             unreliable (hard-overridden to 0.0) because the target resource
             spec was modified during the assessment window (DD-EM-002 v1.1).
-          example: "full"
+          example: "Full"
         assessedAt:
           type: string
           format: date-time
@@ -5751,17 +5751,17 @@ components:
           type: string
           nullable: true
           enum:
-            - full
-            - partial
-            - spec_drift
-            - expired
-            - no_execution
-            - metrics_timed_out
+            - Full
+            - Partial
+            - SpecDrift
+            - Expired
+            - NoExecution
+            - MetricsTimedOut
           description: |
             Reason/status of the effectiveness assessment (same enum as
-            RemediationHistoryEntry). When "spec_drift", effectiveness score
+            RemediationHistoryEntry). When "SpecDrift", effectiveness score
             is unreliable (DD-EM-002 v1.1).
-          example: "full"
+          example: "Full"
         completedAt:
           type: string
           format: date-time

--- a/charts/kubernaut/crds/kubernaut.ai_effectivenessassessments.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_effectivenessassessments.yaml
@@ -212,13 +212,14 @@ spec:
                 description: AssessmentReason describes why the assessment completed
                   with this outcome.
                 enum:
-                - full
-                - partial
-                - no_execution
-                - metrics_timed_out
-                - expired
-                - spec_drift
-                - alert_decay_timeout
+                - Full
+                - Partial
+                - NoExecution
+                - MetricsTimedOut
+                - Expired
+                - SpecDrift
+                - AlertDecayTimeout
+                - Unrecoverable
                 type: string
               completedAt:
                 description: CompletedAt is the timestamp when the assessment finished.

--- a/charts/kubernaut/files/crds/kubernaut.ai_effectivenessassessments.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_effectivenessassessments.yaml
@@ -212,13 +212,14 @@ spec:
                 description: AssessmentReason describes why the assessment completed
                   with this outcome.
                 enum:
-                - full
-                - partial
-                - no_execution
-                - metrics_timed_out
-                - expired
-                - spec_drift
-                - alert_decay_timeout
+                - Full
+                - Partial
+                - NoExecution
+                - MetricsTimedOut
+                - Expired
+                - SpecDrift
+                - AlertDecayTimeout
+                - Unrecoverable
                 type: string
               completedAt:
                 description: CompletedAt is the timestamp when the assessment finished.

--- a/charts/kubernaut/templates/authwebhook/authwebhook.yaml
+++ b/charts/kubernaut/templates/authwebhook/authwebhook.yaml
@@ -186,6 +186,10 @@ spec:
           env:
             - name: LOG_LEVEL
               value: "debug"
+            {{- if include "kubernaut.interServiceTLS.enabled" . }}
+            - name: TLS_CA_FILE
+              value: {{ include "kubernaut.interServiceTLS.caFile" . | quote }}
+            {{- end }}
           volumeMounts:
             - name: webhook-certs
               mountPath: /tmp/k8s-webhook-server/serving-certs
@@ -193,6 +197,11 @@ spec:
             - name: config
               mountPath: /etc/authwebhook
               readOnly: true
+            {{- if include "kubernaut.interServiceTLS.enabled" . }}
+            - name: tls-ca
+              mountPath: /etc/tls-ca
+              readOnly: true
+            {{- end }}
           resources:
             {{- toYaml .Values.authwebhook.resources | nindent 12 }}
           livenessProbe:
@@ -220,3 +229,9 @@ spec:
         - name: config
           configMap:
             name: authwebhook-config
+        {{- if include "kubernaut.interServiceTLS.enabled" . }}
+        - name: tls-ca
+          configMap:
+            name: inter-service-ca
+            optional: true
+        {{- end }}

--- a/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
+++ b/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
@@ -124,7 +124,7 @@ data:
       ca_file: "{{ include "kubernaut.agent.tlsCaDir" . }}/{{ include "kubernaut.agent.tlsCaKey" . }}"
 {{- end }}
     audit:
-      flush_interval_seconds: 0.1
+      flush_interval_seconds: 1.0
       buffer_size: 10000
       batch_size: 50
 {{- if and .Values.kubernautAgent.prometheus.ocpMonitoringRbac (not (and .Values.kubernautAgent.prometheus.tls .Values.kubernautAgent.prometheus.tls.caConfigMapName)) }}

--- a/config/crd/bases/kubernaut.ai_effectivenessassessments.yaml
+++ b/config/crd/bases/kubernaut.ai_effectivenessassessments.yaml
@@ -212,13 +212,14 @@ spec:
                 description: AssessmentReason describes why the assessment completed
                   with this outcome.
                 enum:
-                - full
-                - partial
-                - no_execution
-                - metrics_timed_out
-                - expired
-                - spec_drift
-                - alert_decay_timeout
+                - Full
+                - Partial
+                - NoExecution
+                - MetricsTimedOut
+                - Expired
+                - SpecDrift
+                - AlertDecayTimeout
+                - Unrecoverable
                 type: string
               completedAt:
                 description: CompletedAt is the timestamp when the assessment finished.

--- a/docs/tests/749/TEST_PLAN.md
+++ b/docs/tests/749/TEST_PLAN.md
@@ -1,0 +1,463 @@
+# Test Plan: EM AssessmentReason PascalCase + Audit Store Fixes
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+>
+> Based on IEEE 829-2008 (Standard for Software and System Test Documentation) with
+> Kubernaut-specific extensions for TDD phase tracking, business requirement traceability,
+> and per-tier coverage policy.
+
+**Test Plan Identifier**: TP-749-v1
+**Feature**: Rename EM AssessmentReason constants to PascalCase and fix audit store TIMER BUG
+**Version**: 1.0
+**Created**: 2026-04-06
+**Author**: AI Assistant
+**Status**: Active
+**Branch**: `fix/749-em-reason-pascalcase-and-audit-flush`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This test plan validates two related changes shipping on a single branch:
+
+**Change A (Issue #749)**: Rename all `AssessmentReason` constants in the
+EffectivenessAssessment CRD from snake_case to PascalCase to comply with
+Kubernetes API conventions (matching the existing `Phase` constants and
+`pkg/shared/events/reasons.go` pattern). This is a big-bang rename across
+the CRD types, CRD schema, OpenAPI spec, ogen-generated client, DS handler
+logic, KA prompt history, Helm charts, and all downstream string literals.
+
+**Change B**: Fix the audit store "TIMER BUG" false alarm by raising the drift
+detection threshold from 2x to 5x, demoting debug-level `Info` logs in
+`StoreAudit` to `V(1)`, and correcting the Helm ConfigMap
+`flush_interval_seconds` from `0.1` to `1.0`.
+
+### 1.2 Objectives
+
+1. **PascalCase enforcement**: All 8 `AssessmentReason` constants (including new `Unrecoverable`) use PascalCase values matching Kubernetes conventions
+2. **Zero orphaned snake_case**: No production or test code references the old snake_case reason values
+3. **Audit store noise reduction**: TIMER BUG Error log only fires at genuine 5x drift; StoreAudit Info logs suppressed at default verbosity
+4. **Helm config correctness**: `flush_interval_seconds` defaults to 1.0 in the chart
+5. **No regressions**: All existing tests pass after string literal updates
+6. **OpenAPI/ogen stability**: Regenerated ogen Go constant names are identical to pre-change names
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/...` |
+| Integration test pass rate | 100% | `go test ./test/integration/...` |
+| Build success | 0 errors | `go build ./...` |
+| Lint compliance | 0 new errors | `golangci-lint run` |
+| Orphaned snake_case | 0 hits | `grep -r '"spec_drift"\|"no_execution"\|"metrics_timed_out"\|"alert_decay_timeout"' --include='*.go'` |
+| Backward compatibility | N/A | v1alpha1 pre-GA, no backward compat required |
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- **BR-EM-749**: EffectivenessAssessment Reason field must use PascalCase per Kubernetes API conventions
+- **Issue #749**: EM Reason field PascalCase enforcement
+- **DD-EM-002 v1.1**: Spec drift assessment design (governs `SpecDrift` reason semantics)
+- **DD-AUDIT-002**: Audit shared library design (governs flush interval and logging)
+- **ADR-EM-001**: Effectiveness Monitor service integration
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../.cursor/rules/03-testing-strategy.mdc)
+- [Test Case Specification Template](../testing/TEST_CASE_SPECIFICATION_TEMPLATE.md)
+- [Testing Guidelines](../development/business-requirements/TESTING_GUIDELINES.md)
+- [Kubernetes Event Reasons](../../pkg/shared/events/reasons.go) — PascalCase convention reference
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | Ogen regeneration changes Go constant names | Build failure across DS client consumers | Low | All DS tests | Preflight verified: ogen normalizes both `spec_drift` and `SpecDrift` to same Go suffix `SpecDrift`. Post-regen `go build` gate. |
+| R2 | Orphaned snake_case string literal in test or production code | Silent test pass with wrong assertion value | Medium | UT-EM-749-001 | Post-GREEN grep sweep + adversarial audit |
+| R3 | DS effectiveness handler uses raw strings instead of constants | Breaks when enum value changes | Medium | UT-DS-749-001 | Replace literals with ogen-generated constants in REFACTOR |
+| R4 | CRD schema enum not updated (CEL validation rejects PascalCase) | EA creation fails at API server | High | Integration tests | `make generate` regenerates from kubebuilder annotations; verify in Helm CRD copy |
+| R5 | Audit store threshold change masks genuine timer bugs | Delayed detection of real Go scheduler issues | Low | UT-AUDIT-749-001/002 | 5x threshold still catches significant drift (>5s for 1s interval) |
+
+### 3.1 Risk-to-Test Traceability
+
+- **R1**: Mitigated by Phase 2 step 7 (`go build ./...` after ogen regen)
+- **R2**: Mitigated by UT-EM-749-001 (regex validation) + post-REFACTOR grep sweep
+- **R3**: Mitigated by UT-DS-749-001 + REFACTOR phase constant replacement
+- **R4**: Mitigated by `make generate` + Helm CRD copy in Phase 2 step 13
+- **R5**: Mitigated by UT-AUDIT-749-001 and UT-AUDIT-749-002
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **EA CRD Types** (`api/effectivenessassessment/v1alpha1/effectivenessassessment_types.go`): PascalCase constant values and kubebuilder enum annotation
+- **EM Completion** (`internal/controller/effectivenessmonitor/completion.go`): `AssessmentReasonUnrecoverable` constant usage
+- **DS Effectiveness Handler** (`pkg/datastorage/server/effectiveness_handler.go`): PascalCase `SpecDrift` short-circuit logic
+- **KA Prompt History** (`internal/kubernautagent/prompt/history.go`): All spec_drift detection functions with PascalCase values
+- **Audit Store** (`pkg/audit/store.go`): Timer drift threshold (5x) and log verbosity demotion
+- **Helm Chart** (`charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml`): `flush_interval_seconds` value
+- **OpenAPI Spec** (`api/openapi/data-storage-v1.yaml`): PascalCase enum values in 3 locations
+- **Ogen Client** (`pkg/datastorage/ogen-client/`): Regenerated with stable Go constant names
+
+### 4.2 Features Not to be Tested
+
+- **CRD version migration**: v1alpha1 is pre-GA; no backward compatibility layer
+- **DataStorage DB schema**: Stores strings; no enum constraint at DB level
+- **External dashboard consumers**: Breaking API change is accepted for pre-GA
+- **E2E cluster deployment**: Deferred to post-merge validation
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Big-bang rename (no dual-value support) | Pre-GA v1alpha1 CRD; no production consumers depend on old values |
+| Add `AssessmentReasonUnrecoverable` constant | `"unrecoverable"` was the only reason using a raw string literal in `completion.go` |
+| 5x timer drift threshold | 2x was too sensitive for Go scheduler jitter on resource-constrained nodes; 5x catches genuine issues while tolerating normal variance |
+| Demote StoreAudit Info logs to V(1) | Debug tracing pollutes production logs; V(1) preserves diagnostic capability when needed |
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+**Authority**: `03-testing-strategy.mdc` — Per-Tier Testable Code Coverage.
+
+- **Unit**: >=80% of unit-testable code (constant definitions, history detection functions, audit store timer logic)
+- **Integration**: Existing integration tests updated with PascalCase values; no new integration tests needed (same behavior, different string values)
+- **E2E**: Deferred — requires Kind cluster with updated CRD; validated post-merge
+
+### 5.2 Two-Tier Minimum
+
+Every business requirement is covered by at least 2 test tiers:
+- **Unit tests**: Validate constant values, detection logic, threshold behavior
+- **Integration tests**: Validate end-to-end EM lifecycle with PascalCase reasons (existing tests updated)
+
+### 5.3 Business Outcome Quality Bar
+
+Tests validate that:
+- Operators see PascalCase values in `kubectl get ea` output (Reason column)
+- DS API returns PascalCase assessment reasons in remediation history
+- Audit store does not emit false-alarm Error logs under normal scheduling jitter
+- KA prompt history correctly identifies spec drift patterns with PascalCase values
+
+### 5.4 Pass/Fail Criteria
+
+**PASS** — all of the following must be true:
+
+1. All P0 tests pass (0 failures)
+2. All P1 tests pass or have documented exceptions
+3. `go build ./...` succeeds after ogen regeneration
+4. Zero orphaned snake_case reason values in `*.go` files
+5. No regressions in existing test suites
+
+**FAIL** — any of the following:
+
+1. Any P0 test fails
+2. Ogen regeneration changes Go constant names
+3. Existing tests that were passing before the change now fail (regression)
+
+### 5.5 Suspension & Resumption Criteria
+
+**Suspend testing when**:
+- Ogen regeneration produces different Go constant names (R1 materialized)
+- `make generate` fails (controller-gen issue)
+- Build broken after constant rename (cascade failure)
+
+**Resume testing when**:
+- Root cause identified and alternative approach approved
+- Build restored to green
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code (pure logic, no I/O)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `api/effectivenessassessment/v1alpha1/effectivenessassessment_types.go` | Constants block | ~25 |
+| `internal/kubernautagent/prompt/history.go` | `FormatTier1Entry`, `FormatTier2Summary`, `DetectDecliningEffectiveness`, `DetectCompletedButRecurring`, `AllZeroEffectiveness`, `DetectSpecDriftCausalChains`, `BuildRemediationHistorySection` | ~300 |
+| `pkg/audit/store.go` | `backgroundWriter` (timer tick case), `StoreAudit` | ~80 |
+| `pkg/datastorage/server/effectiveness_handler.go` | `BuildEffectivenessResponse` | ~30 |
+
+### 6.2 Integration-Testable Code (I/O, wiring, cross-component)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `internal/controller/effectivenessmonitor/completion.go` | `completeAssessment`, `failAssessment`, `determineAssessmentReason` | ~100 |
+| `internal/controller/remediationorchestrator/effectiveness_tracking.go` | `trackEffectivenessStatus` | ~80 |
+
+### 6.3 Version Identification
+
+| Item | Version/Commit | Notes |
+|------|----------------|-------|
+| Code under test | `fix/749-em-reason-pascalcase-and-audit-flush` HEAD | Branch from main |
+| ogen | v1.18.0 | Pinned in `gen.go` |
+
+---
+
+## 7. BR Coverage Matrix
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-EM-749 | AssessmentReason constants use PascalCase | P0 | Unit | UT-EM-749-001 | Pending |
+| BR-EM-749 | Unrecoverable reason uses constant | P0 | Unit | UT-EM-749-002 | Pending |
+| BR-EM-749 | KA history: FormatTier1Entry recognizes PascalCase SpecDrift | P0 | Unit | UT-KA-749-001 | Pending |
+| BR-EM-749 | KA history: DetectDecliningEffectiveness skips SpecDrift | P1 | Unit | UT-KA-749-002 | Pending |
+| BR-EM-749 | KA history: DetectCompletedButRecurring skips SpecDrift | P1 | Unit | UT-KA-749-003 | Pending |
+| BR-EM-749 | KA history: AllZeroEffectiveness skips SpecDrift | P1 | Unit | UT-KA-749-004 | Pending |
+| BR-EM-749 | KA history: DetectSpecDriftCausalChains matches SpecDrift | P1 | Unit | UT-KA-749-005 | Pending |
+| BR-EM-749 | KA history: BuildRemediationHistorySection HasSpecDrift | P1 | Unit | UT-KA-749-006 | Pending |
+| BR-EM-749 | DS: BuildEffectivenessResponse short-circuits SpecDrift to 0.0 | P0 | Unit | UT-DS-749-001 | Pending |
+| BR-AUDIT-749 | Timer drift at 3x does NOT emit Error log | P0 | Unit | UT-AUDIT-749-001 | Pending |
+| BR-AUDIT-749 | Timer drift at 6x DOES emit Error log | P0 | Unit | UT-AUDIT-749-002 | Pending |
+| BR-AUDIT-749 | StoreAudit suppresses Info logs at V(0) | P1 | Unit | UT-AUDIT-749-003 | Pending |
+
+---
+
+## 8. Test Scenarios
+
+### Test ID Naming Convention
+
+Format: `{TIER}-{SERVICE}-{BR_NUMBER}-{SEQUENCE}`
+
+- **TIER**: `UT` (Unit), `IT` (Integration), `E2E` (End-to-End)
+- **SERVICE**: EM (EffectivenessMonitor), KA (KubernautAgent), DS (DataStorage), AUDIT (Audit)
+- **BR_NUMBER**: 749
+- **SEQUENCE**: Zero-padded 3-digit (001, 002, ...)
+
+### Tier 1: Unit Tests
+
+**Testable code scope**: EA types constants, KA history functions, audit store timer logic, DS effectiveness handler
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-EM-749-001` | All AssessmentReason constants are PascalCase (no underscores) | Pending |
+| `UT-EM-749-002` | AssessmentReasonUnrecoverable constant exists and equals "Unrecoverable" | Pending |
+| `UT-KA-749-001` | FormatTier1Entry renders "INCONCLUSIVE (spec drift)" for PascalCase SpecDrift | Pending |
+| `UT-KA-749-002` | DetectDecliningEffectiveness skips SpecDrift entries (not counted in score trends) | Pending |
+| `UT-KA-749-003` | DetectCompletedButRecurring skips SpecDrift entries (not counted as recurring) | Pending |
+| `UT-KA-749-004` | AllZeroEffectiveness skips SpecDrift entries (not counted as zero-effectiveness) | Pending |
+| `UT-KA-749-005` | DetectSpecDriftCausalChains matches SpecDrift assessment reason | Pending |
+| `UT-KA-749-006` | BuildRemediationHistorySection sets HasSpecDrift=true for PascalCase SpecDrift | Pending |
+| `UT-DS-749-001` | BuildEffectivenessResponse short-circuits to score 0.0 for PascalCase SpecDrift | Pending |
+| `UT-AUDIT-749-001` | Timer drift at 3x expected interval does NOT emit Error log (threshold is 5x) | Pending |
+| `UT-AUDIT-749-002` | Timer drift at 6x expected interval DOES emit Error log | Pending |
+| `UT-AUDIT-749-003` | StoreAudit does not emit Info-level logs at default verbosity V(0) | Pending |
+
+### Tier 2: Integration Tests
+
+**Testable code scope**: Existing EM integration tests updated with PascalCase values
+
+No new integration tests are needed. Existing tests that use `eav1.AssessmentReasonSpecDrift` constants will automatically pick up the new PascalCase values. Tests using string literals will be updated in the GREEN phase.
+
+### Tier Skip Rationale
+
+- **E2E**: Deferred to post-merge. Requires Kind cluster with updated CRD installed. The unit and integration tiers provide sufficient coverage for a string-value rename.
+
+---
+
+## 9. Test Cases
+
+### UT-EM-749-001: All AssessmentReason constants are PascalCase
+
+**BR**: BR-EM-749
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/effectivenessmonitor/ea_types_test.go`
+
+**Preconditions**:
+- `eav1` package importable
+
+**Test Steps**:
+1. **Given**: The set of all AssessmentReason constants (`Full`, `Partial`, `NoExecution`, `MetricsTimedOut`, `Expired`, `SpecDrift`, `AlertDecayTimeout`, `Unrecoverable`)
+2. **When**: Each constant value is checked against the regex `^[A-Z][a-zA-Z]+$`
+3. **Then**: All values match PascalCase pattern (no underscores, starts with uppercase)
+
+**Expected Results**:
+1. All 8 constants match PascalCase regex
+2. No constant contains an underscore character
+
+### UT-EM-749-002: AssessmentReasonUnrecoverable constant exists
+
+**BR**: BR-EM-749
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/effectivenessmonitor/ea_types_test.go`
+
+**Preconditions**:
+- `eav1` package importable
+
+**Test Steps**:
+1. **Given**: The `eav1.AssessmentReasonUnrecoverable` constant
+2. **When**: Its value is inspected
+3. **Then**: It equals `"Unrecoverable"`
+
+### UT-KA-749-001: FormatTier1Entry recognizes PascalCase SpecDrift
+
+**BR**: BR-EM-749
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/prompt/history_test.go`
+
+**Test Steps**:
+1. **Given**: A Tier1Entry with `AssessmentReason: "SpecDrift"`
+2. **When**: `FormatTier1Entry` is called
+3. **Then**: Output contains "INCONCLUSIVE (spec drift)"
+
+### UT-DS-749-001: BuildEffectivenessResponse short-circuits SpecDrift
+
+**BR**: BR-EM-749
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/datastorage/effectiveness_score_test.go`
+
+**Test Steps**:
+1. **Given**: EM events with `reason: "SpecDrift"` in assessment.completed event data
+2. **When**: `BuildEffectivenessResponse` is called
+3. **Then**: `AssessmentStatus == "SpecDrift"` and `Score == 0.0`
+
+### UT-AUDIT-749-001: Timer drift at 3x does NOT emit Error
+
+**BR**: BR-AUDIT-749
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/audit/store_timer_test.go`
+
+**Test Steps**:
+1. **Given**: A BufferedAuditStore with FlushInterval=100ms
+2. **When**: Timer tick fires with actual interval = 300ms (3x expected)
+3. **Then**: No Error-level log is emitted (below 5x threshold)
+
+### UT-AUDIT-749-002: Timer drift at 6x DOES emit Error
+
+**BR**: BR-AUDIT-749
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/audit/store_timer_test.go`
+
+**Test Steps**:
+1. **Given**: A BufferedAuditStore with FlushInterval=100ms
+2. **When**: Timer tick fires with actual interval = 600ms (6x expected)
+3. **Then**: Error-level log containing "TIMER BUG" is emitted
+
+### UT-AUDIT-749-003: StoreAudit suppresses Info at V(0)
+
+**BR**: BR-AUDIT-749
+**Priority**: P1
+**Type**: Unit
+**File**: `test/unit/audit/store_timer_test.go`
+
+**Test Steps**:
+1. **Given**: A BufferedAuditStore with a logger at verbosity V(0)
+2. **When**: `StoreAudit` is called with a valid event
+3. **Then**: No Info-level log messages are emitted (all demoted to V(1))
+
+---
+
+## 10. Environmental Needs
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: None for EA types / KA history tests; mock DataStorageClient for audit store tests
+- **Location**: `test/unit/effectivenessmonitor/`, `test/unit/kubernautagent/prompt/`, `test/unit/audit/`, `test/unit/datastorage/`
+
+### 10.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: ZERO mocks (No-Mocks Policy)
+- **Infrastructure**: envtest (API server + etcd) for EM lifecycle tests
+- **Location**: `test/integration/effectivenessmonitor/`
+
+### 10.3 Tools & Versions
+
+| Tool | Minimum Version | Purpose |
+|------|-----------------|---------|
+| Go | 1.25.7 | Build and test |
+| Ginkgo CLI | v2.x | Test runner |
+| controller-gen | v0.19.0 | CRD generation |
+| ogen | v1.18.0 | OpenAPI client generation |
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Blocking Dependencies
+
+| Dependency | Type | Status | Impact if Not Available | Workaround |
+|------------|------|--------|-------------------------|------------|
+| None | — | — | — | — |
+
+### 11.2 Execution Order
+
+1. **Phase 1 (TDD RED)**: Write 12 failing unit tests
+2. **Phase 2 (TDD GREEN)**: Rename constants, regenerate CRD/ogen, update all downstream, fix audit store
+3. **Checkpoint 1**: Adversarial + security audit
+4. **Phase 3 (TDD REFACTOR)**: Replace string literals with constant references, grep sweep
+5. **Final Checkpoint**: Build, lint, full test pass, confidence assessment
+
+---
+
+## 12. Test Deliverables
+
+| Deliverable | Location | Description |
+|-------------|----------|-------------|
+| This test plan | `docs/tests/749/TEST_PLAN.md` | Strategy and test design |
+| EA types unit tests | `test/unit/effectivenessmonitor/ea_types_test.go` | PascalCase constant validation |
+| KA history unit tests | `test/unit/kubernautagent/prompt/history_test.go` | SpecDrift detection with PascalCase |
+| Audit store unit tests | `test/unit/audit/store_timer_test.go` | Timer threshold and log verbosity |
+| DS effectiveness tests | `test/unit/datastorage/effectiveness_score_test.go` | SpecDrift short-circuit with PascalCase |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests (all services)
+go test ./test/unit/... -ginkgo.v
+
+# Specific 749 tests
+go test ./test/unit/effectivenessmonitor/... -ginkgo.focus="UT-EM-749"
+go test ./test/unit/kubernautagent/prompt/... -ginkgo.focus="UT-KA-749"
+go test ./test/unit/audit/... -ginkgo.focus="UT-AUDIT-749"
+go test ./test/unit/datastorage/... -ginkgo.focus="UT-DS-749"
+
+# Build verification
+go build ./...
+
+# Orphan check
+grep -r '"spec_drift"\|"no_execution"\|"metrics_timed_out"\|"alert_decay_timeout"' --include='*.go' .
+```
+
+---
+
+## 14. Existing Tests Requiring Updates (if applicable)
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|-------------------|-------------------|-----------------|--------|
+| `test/unit/kubernautagent/prompt/history_test.go` (7 places) | `AssessmentReason: "spec_drift"` | Change to `"SpecDrift"` | Constant value renamed |
+| `test/unit/datastorage/effectiveness_score_test.go` (9 places) | `"spec_drift"` in event data and assertions | Change to `"SpecDrift"` | Constant value renamed |
+| `test/unit/datastorage/remediation_history_logic_test.go` (4 places) | `"spec_drift"` in event data and assertions | Change to `"SpecDrift"` | Constant value renamed |
+| `test/unit/effectivenessmonitor/failed_phase_test.go` (2 places) | `"unrecoverable"` in assertions | Change to `"Unrecoverable"` | Constant value renamed |
+| `test/integration/datastorage/remediation_history_integration_test.go` (4 places) | `"spec_drift"` in event data and assertions | Change to `"SpecDrift"` | Constant value renamed |
+| `test/e2e/datastorage/25_remediation_history_api_test.go` (4 places) | `"spec_drift"` in event data and assertions | Change to `"SpecDrift"` | Constant value renamed |
+| ~12 additional test files | Various snake_case reason values | Change to PascalCase equivalents | Constant values renamed |
+
+---
+
+## 15. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-06 | Initial test plan |

--- a/docs/tests/750/TEST_PLAN.md
+++ b/docs/tests/750/TEST_PLAN.md
@@ -1,0 +1,357 @@
+# Test Plan: Fix Inter-Service TLS Client Trust Gaps
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+>
+> Based on IEEE 829-2008 (Standard for Software and System Test Documentation) with
+> Kubernaut-specific extensions for TDD phase tracking, business requirement traceability,
+> and per-tier coverage policy.
+
+**Test Plan Identifier**: TP-750-v1
+**Feature**: Fix inter-service TLS client trust gaps in agentclient and authwebhook
+**Version**: 1.0
+**Created**: 2026-04-06
+**Author**: AI Assistant
+**Status**: Active
+**Branch**: `fix/749-em-reason-pascalcase-and-audit-flush`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This test plan validates that all inter-service HTTP clients in `agentclient` and
+`authwebhook` correctly wire `sharedtls.DefaultBaseTransport()` so that the cluster CA
+from `TLS_CA_FILE` is trusted on outbound HTTPS calls. It also validates that the
+AuthWebhook Helm template mounts the `inter-service-ca` ConfigMap and sets `TLS_CA_FILE`
+when `tls.interService.enabled=true`.
+
+### 1.2 Objectives
+
+1. **TLS trust wiring**: Both `NewKubernautAgentClient` and `NewDSClientAdapter` use `sharedtls.DefaultBaseTransport()` as base transport
+2. **Error propagation**: Invalid `TLS_CA_FILE` values cause constructors to return errors instead of silently proceeding with a broken transport
+3. **Regression safety**: With `TLS_CA_FILE` unset, constructors continue to work as before (plain HTTP)
+4. **Helm parity**: AuthWebhook deployment template matches the TLS mount pattern used by all other controllers
+5. **Dead code removal**: `NewInterServiceClient` (zero callers) is removed in REFACTOR phase
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/...` |
+| Unit-testable code coverage | >=80% | `go test -coverprofile` on affected files |
+| Backward compatibility | 0 regressions | Existing tests pass without modification |
+| Helm template correctness | Manual | `helm template --set tls.interService.enabled=true` |
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- Issue #750: Fix inter-service TLS client trust gaps in agentclient and authwebhook
+- Issue #493: TLS for inter-pod HTTP communication (introduced shared TLS infra)
+- Issue #678: Wire Gateway/DataStorage inter-service TLS
+- DD-AUTH-006: ServiceAccount authentication
+- DD-HAPI-003: Mandatory OpenAPI Client Usage
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../.cursor/rules/03-testing-strategy.mdc)
+- [Testing Guidelines](../development/business-requirements/TESTING_GUIDELINES.md)
+- Existing TLS tests: `test/unit/shared/tls/tls_test.go`
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | `DefaultBaseTransport()` changes connection pool params in authwebhook | Increased idle connections (10→100) | Low | UT-AW-750-002 | Accepted: consistency with all other services; authwebhook is not a high-concurrency service |
+| R2 | Existing agentclient tests break from new error path | Test failures | Low | UT-AC-750-003 | `TLS_CA_FILE` unset → `DefaultBaseTransport()` returns plain transport (identical behavior) |
+| R3 | Helm template syntax error breaks deployment | Deployment failure | Low | Manual helm template | Copy exact pattern from 6 existing controllers |
+| R4 | `NewDSClientAdapterFromClient` still uses `http.DefaultClient` | Test-only gap | Very Low | N/A | Test-only code; TLS responsibility is on caller who created ogen client |
+
+### 3.1 Risk-to-Test Traceability
+
+- **R1**: UT-AW-750-002 validates constructor succeeds with valid CA
+- **R2**: UT-AC-750-003 validates constructor succeeds without `TLS_CA_FILE`
+- **R3**: Manual `helm template` validation after Helm change
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **`pkg/agentclient/client.go`** (`NewKubernautAgentClient`): Validates TLS transport wiring for AI Analysis → KA outbound calls
+- **`pkg/authwebhook/ds_client.go`** (`NewDSClientAdapter`): Validates TLS transport wiring for AuthWebhook → DataStorage outbound calls
+- **`charts/kubernaut/templates/authwebhook/authwebhook.yaml`**: Validates Helm template includes CA mount when inter-service TLS enabled
+
+### 4.2 Features Not to be Tested
+
+- **`NewDSClientAdapterFromClient`**: Test-only wrapper; TLS responsibility belongs to caller who creates the ogen client
+- **`audit.NewOpenAPIClientAdapter`**: Already correctly uses `DefaultBaseTransport()` (verified during due diligence)
+- **Other controllers' TLS wiring**: Already correct (aianalysis, notification, workflowexecution, RO, SP, gateway)
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Test via `TLS_CA_FILE` env var injection | Constructors are opaque (return wrapped clients); env var is the observable contract. Invalid path → error proves the constructor reads it. |
+| Option A: use `DefaultBaseTransport()` as-is | Consistency with all other services; connection pool param difference is negligible |
+| Remove `NewInterServiceClient` in REFACTOR | Zero callers confirmed; dead code per issue #750 |
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+- **Unit**: >=80% of unit-testable code in `NewKubernautAgentClient` and `NewDSClientAdapter`
+- **Integration**: Not applicable — TLS wiring is a constructor concern, not an I/O integration boundary
+- **E2E**: Deferred — requires full Kind cluster with `tls.interService.enabled=true`
+
+### 5.2 Two-Tier Minimum
+
+Unit tests provide the primary coverage. The Helm template change is validated manually
+via `helm template`. E2E is deferred because it requires a Kind cluster with inter-service
+TLS enabled, which is out of scope for this bug fix.
+
+### 5.3 Pass/Fail Criteria
+
+**PASS** — all of the following must be true:
+
+1. All P0 tests pass (0 failures)
+2. Existing agentclient and authwebhook tests pass without modification
+3. `helm template` with `tls.interService.enabled=true` shows `TLS_CA_FILE`, `tls-ca` volume mount, and `inter-service-ca` ConfigMap in authwebhook deployment
+4. `go build ./...` succeeds
+
+**FAIL** — any of the following:
+
+1. Any P0 test fails
+2. Existing tests regress
+3. Helm template missing required TLS artifacts
+
+### 5.4 Suspension & Resumption Criteria
+
+**Suspend**: Build broken or `DefaultBaseTransport()` API changes
+**Resume**: Build fixed
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code (pure logic, no I/O)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `pkg/agentclient/client.go` | `NewKubernautAgentClient` | ~15 |
+| `pkg/authwebhook/ds_client.go` | `NewDSClientAdapter` | ~30 |
+| `pkg/shared/tls/tls.go` | `NewInterServiceClient` (removal) | ~10 |
+
+### 6.2 Helm Template (manual validation)
+
+| File | Change | Lines (approx) |
+|------|--------|-----------------|
+| `charts/kubernaut/templates/authwebhook/authwebhook.yaml` | Add TLS env/volume/mount | ~15 |
+
+---
+
+## 7. BR Coverage Matrix
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-INTEGRATION-750 | agentclient trusts cluster CA via TLS_CA_FILE | P0 | Unit | UT-AC-750-001 | Pending |
+| BR-INTEGRATION-750 | agentclient TLS trust with valid CA | P0 | Unit | UT-AC-750-002 | Pending |
+| BR-INTEGRATION-750 | agentclient regression guard (no TLS_CA_FILE) | P0 | Unit | UT-AC-750-003 | Pending |
+| BR-INTEGRATION-750 | authwebhook DS client trusts cluster CA via TLS_CA_FILE | P0 | Unit | UT-AW-750-001 | Pending |
+| BR-INTEGRATION-750 | authwebhook DS client TLS trust with valid CA | P0 | Unit | UT-AW-750-002 | Pending |
+| BR-INTEGRATION-750 | authwebhook DS client regression guard (no TLS_CA_FILE) | P0 | Unit | UT-AW-750-003 | Pending |
+
+---
+
+## 8. Test Scenarios
+
+### Test ID Naming Convention
+
+- **UT-AC-750-NNN**: Unit tests for agentclient TLS (#750)
+- **UT-AW-750-NNN**: Unit tests for authwebhook DS client TLS (#750)
+
+### Tier 1: Unit Tests
+
+**Testable code scope**: `NewKubernautAgentClient`, `NewDSClientAdapter` — >=80% coverage target
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-AC-750-001` | agentclient constructor fails fast when TLS_CA_FILE points to invalid path | Pending |
+| `UT-AC-750-002` | agentclient constructor succeeds with valid CA cert in TLS_CA_FILE | Pending |
+| `UT-AC-750-003` | agentclient constructor succeeds when TLS_CA_FILE is unset (regression guard) | Pending |
+| `UT-AW-750-001` | authwebhook DS client constructor fails fast when TLS_CA_FILE points to invalid path | Pending |
+| `UT-AW-750-002` | authwebhook DS client constructor succeeds with valid CA cert in TLS_CA_FILE | Pending |
+| `UT-AW-750-003` | authwebhook DS client constructor succeeds when TLS_CA_FILE is unset (regression guard) | Pending |
+
+### Tier Skip Rationale
+
+- **Integration**: TLS wiring is a constructor concern tested at unit level via env var injection. No cross-component I/O boundary to test.
+- **E2E**: Requires Kind cluster with `tls.interService.enabled=true`. Deferred to a dedicated TLS E2E test effort.
+
+---
+
+## 9. Test Cases
+
+### UT-AC-750-001: agentclient fails on invalid TLS_CA_FILE
+
+**BR**: BR-INTEGRATION-750
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/aianalysis/agentclient_tls_test.go`
+
+**Test Steps**:
+1. **Given**: `TLS_CA_FILE` env var set to `/nonexistent/ca.crt`
+2. **When**: `NewKubernautAgentClient(Config{BaseURL: "https://localhost:9999"})` is called
+3. **Then**: Constructor returns a non-nil error containing "failed to read CA certificate"
+
+**Acceptance Criteria**:
+- **Behavior**: Constructor propagates `DefaultBaseTransport()` error
+- **Correctness**: Error is returned, no nil-pointer client
+- **Security**: Misconfigured TLS is a hard failure, not a silent fallback
+
+### UT-AC-750-002: agentclient succeeds with valid TLS_CA_FILE
+
+**BR**: BR-INTEGRATION-750
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/aianalysis/agentclient_tls_test.go`
+
+**Test Steps**:
+1. **Given**: Self-signed CA cert written to temp file, `TLS_CA_FILE` set to that path
+2. **When**: `NewKubernautAgentClient(Config{BaseURL: "https://localhost:9999"})` is called
+3. **Then**: Constructor returns a non-nil client and nil error
+
+### UT-AC-750-003: agentclient succeeds without TLS_CA_FILE (regression)
+
+**BR**: BR-INTEGRATION-750
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/aianalysis/agentclient_tls_test.go`
+
+**Test Steps**:
+1. **Given**: `TLS_CA_FILE` env var is unset
+2. **When**: `NewKubernautAgentClient(Config{BaseURL: "http://localhost:9999"})` is called
+3. **Then**: Constructor returns a non-nil client and nil error
+
+### UT-AW-750-001: authwebhook DS client fails on invalid TLS_CA_FILE
+
+**BR**: BR-INTEGRATION-750
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/authwebhook/ds_client_tls_test.go`
+
+**Test Steps**:
+1. **Given**: `TLS_CA_FILE` env var set to `/nonexistent/ca.crt`
+2. **When**: `NewDSClientAdapter("https://localhost:9999", 5s, logger)` is called
+3. **Then**: Constructor returns a non-nil error containing "failed to read CA certificate"
+
+### UT-AW-750-002: authwebhook DS client succeeds with valid TLS_CA_FILE
+
+**BR**: BR-INTEGRATION-750
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/authwebhook/ds_client_tls_test.go`
+
+**Test Steps**:
+1. **Given**: Self-signed CA cert written to temp file, `TLS_CA_FILE` set to that path
+2. **When**: `NewDSClientAdapter("https://localhost:9999", 5s, logger)` is called
+3. **Then**: Constructor returns a non-nil adapter and nil error
+
+### UT-AW-750-003: authwebhook DS client succeeds without TLS_CA_FILE (regression)
+
+**BR**: BR-INTEGRATION-750
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/authwebhook/ds_client_tls_test.go`
+
+**Test Steps**:
+1. **Given**: `TLS_CA_FILE` env var is unset
+2. **When**: `NewDSClientAdapter("http://localhost:9999", 5s, logger)` is called
+3. **Then**: Constructor returns a non-nil adapter and nil error
+
+---
+
+## 10. Environmental Needs
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: None — tests use env var injection and temp cert files
+- **Location**: `test/unit/aianalysis/`, `test/unit/authwebhook/`
+- **Resources**: Minimal (temp file I/O only)
+
+### 10.2 Tools & Versions
+
+| Tool | Minimum Version | Purpose |
+|------|-----------------|---------|
+| Go | 1.22 | Build and test |
+| Ginkgo CLI | v2.x | Test runner |
+| Helm | 3.x | Template validation (manual) |
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Blocking Dependencies
+
+None. All required infrastructure (`pkg/shared/tls`, Helm helpers) already exists.
+
+### 11.2 Execution Order
+
+1. **Phase 1 — TDD RED**: Write failing tests (UT-AC-750-001 through UT-AW-750-003)
+2. **Phase 2 — TDD GREEN**: Fix `agentclient/client.go`, `authwebhook/ds_client.go`, and Helm template
+3. **Phase 3 — TDD REFACTOR**: Remove `NewInterServiceClient` dead code, final audit
+4. **Checkpoint**: Build, lint, full test pass, confidence assessment
+
+---
+
+## 12. Test Deliverables
+
+| Deliverable | Location | Description |
+|-------------|----------|-------------|
+| This test plan | `docs/tests/750/TEST_PLAN.md` | Strategy and test design |
+| agentclient TLS tests | `test/unit/aianalysis/agentclient_tls_test.go` | 3 Ginkgo BDD tests |
+| authwebhook DS client TLS tests | `test/unit/authwebhook/ds_client_tls_test.go` | 3 Ginkgo BDD tests |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests — agentclient TLS
+go test ./test/unit/aianalysis/... -ginkgo.v -ginkgo.focus="750"
+
+# Unit tests — authwebhook DS client TLS
+go test ./test/unit/authwebhook/... -ginkgo.v -ginkgo.focus="750"
+
+# All unit tests (regression check)
+go test ./test/unit/... -ginkgo.v
+
+# Helm template validation (manual)
+helm template kubernaut charts/kubernaut \
+  --set tls.interService.enabled=true \
+  | grep -A5 "TLS_CA_FILE"
+```
+
+---
+
+## 14. Existing Tests Requiring Updates
+
+None. Existing tests do not set `TLS_CA_FILE` and will continue to work with
+`DefaultBaseTransport()` returning a plain transport (identical to `http.DefaultTransport`).
+
+---
+
+## 15. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-06 | Initial test plan |

--- a/internal/controller/effectivenessmonitor/completion.go
+++ b/internal/controller/effectivenessmonitor/completion.go
@@ -63,7 +63,7 @@ func (r *Reconciler) failAssessment(ctx context.Context, ea *eav1.EffectivenessA
 	now := metav1.Now()
 	ea.Status.Phase = eav1.PhaseFailed
 	ea.Status.CompletedAt = &now
-	ea.Status.AssessmentReason = "unrecoverable"
+	ea.Status.AssessmentReason = eav1.AssessmentReasonUnrecoverable
 	ea.Status.Message = fmt.Sprintf("Assessment failed: %s", reason)
 
 	conditions.SetCondition(ea, conditions.ConditionAssessmentComplete, metav1.ConditionFalse, "ValidationFailed", ea.Status.Message)

--- a/internal/kubernautagent/prompt/history.go
+++ b/internal/kubernautagent/prompt/history.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"text/template"
 
+	eav1 "github.com/jordigilh/kubernaut/api/effectivenessassessment/v1alpha1"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
 )
 
@@ -128,7 +129,7 @@ func BuildRemediationHistorySection(result *enrichment.RemediationHistoryResult,
 
 	hasSpecDrift := false
 	for _, e := range allEntries {
-		if e.AssessmentReason == "spec_drift" {
+		if e.AssessmentReason == eav1.AssessmentReasonSpecDrift {
 			hasSpecDrift = true
 			break
 		}
@@ -171,7 +172,7 @@ func FormatTier1Entry(entry enrichment.Tier1Entry, causalChains map[string]strin
 		fmt.Sprintf("  Workflow: %s | Outcome: %s | Signal: %s", workflow, outcome, signal),
 	}
 
-	if entry.AssessmentReason == "spec_drift" {
+	if entry.AssessmentReason == eav1.AssessmentReasonSpecDrift {
 		if causalChains != nil {
 			if followupUID, ok := causalChains[entry.RemediationUID]; ok {
 				lines = append(lines, fmt.Sprintf(
@@ -231,7 +232,7 @@ func FormatTier2Summary(entry enrichment.Tier2Summary) string {
 	outcome := withDefault(entry.Outcome, "unknown")
 
 	var scoreText string
-	if entry.AssessmentReason == "spec_drift" {
+	if entry.AssessmentReason == eav1.AssessmentReasonSpecDrift {
 		scoreText = "INCONCLUSIVE (spec drift)"
 	} else if entry.EffectivenessScore != nil {
 		level := EffectivenessLevel(entry.EffectivenessScore)
@@ -312,7 +313,7 @@ func FormatMetricDeltas(md *enrichment.MetricDeltas) string {
 func DetectDecliningEffectiveness(chain []enrichment.Tier1Entry) []string {
 	actionScores := make(map[string][]float64)
 	for _, e := range chain {
-		if e.AssessmentReason == "spec_drift" {
+		if e.AssessmentReason == eav1.AssessmentReasonSpecDrift {
 			continue
 		}
 		if e.ActionType != "" && e.EffectivenessScore != nil {
@@ -348,7 +349,7 @@ func DetectCompletedButRecurring(entries []HistoryEntry, threshold int) []Recurr
 	counts := make(map[key]int)
 
 	for _, e := range entries {
-		if e.AssessmentReason == "spec_drift" {
+		if e.AssessmentReason == eav1.AssessmentReasonSpecDrift {
 			continue
 		}
 		if !completedOutcomes[e.Outcome] {
@@ -379,7 +380,7 @@ func AllZeroEffectiveness(entries []HistoryEntry, actionType, signalType string)
 
 	matched := false
 	for _, e := range entries {
-		if e.AssessmentReason == "spec_drift" {
+		if e.AssessmentReason == eav1.AssessmentReasonSpecDrift {
 			continue
 		}
 		if !completedOutcomes[e.Outcome] {
@@ -412,7 +413,7 @@ func DetectSpecDriftCausalChains(chain []enrichment.Tier1Entry) map[string]strin
 
 	causalMap := make(map[string]string)
 	for _, e := range chain {
-		if e.AssessmentReason != "spec_drift" {
+		if e.AssessmentReason != eav1.AssessmentReasonSpecDrift {
 			continue
 		}
 		if e.RemediationUID == "" || e.PostRemediationSpecHash == "" {

--- a/pkg/agentclient/client.go
+++ b/pkg/agentclient/client.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/jordigilh/kubernaut/pkg/shared/auth"
+	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
 )
 
 // ========================================
@@ -80,9 +81,13 @@ func defaultTimeout(cfg Config) time.Duration {
 //
 // For integration tests with custom authentication, use NewHolmesGPTClientWithTransport.
 func NewKubernautAgentClient(cfg Config) (*KubernautAgentClient, error) {
-	// DD-AUTH-006: Use ServiceAccount authentication for production/E2E
-	// OAuth-proxy validates this token and injects X-Auth-Request-User header
-	transport := auth.NewServiceAccountTransportWithBase(http.DefaultTransport)
+	// Issue #750: Use DefaultBaseTransport so TLS_CA_FILE is honoured for
+	// inter-service HTTPS when tls.interService.enabled=true.
+	baseTransport, err := sharedtls.DefaultBaseTransport()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create TLS-aware base transport: %w", err)
+	}
+	transport := auth.NewServiceAccountTransportWithBase(baseTransport)
 
 	return newClientWithHTTP(cfg, &http.Client{
 		Timeout:   defaultTimeout(cfg),

--- a/pkg/audit/openapi_spec_data.yaml
+++ b/pkg/audit/openapi_spec_data.yaml
@@ -1969,25 +1969,25 @@ components:
           enum:
             - no_data
             - in_progress
-            - full
-            - partial
-            - spec_drift
-            - expired
-            - no_execution
-            - metrics_timed_out
+            - Full
+            - Partial
+            - SpecDrift
+            - Expired
+            - NoExecution
+            - MetricsTimedOut
             - EffectivenessAssessed
           description: |
             Current assessment status:
             - no_data: No component events found
             - in_progress: Some component events present but assessment not completed
-            - full: All components assessed successfully
-            - partial: Some components assessed, others unavailable
-            - spec_drift: Target resource spec changed during assessment (score unreliable, forced to 0.0)
-            - expired: Assessment timed out before completing
-            - no_execution: No workflow execution found for this correlation ID
-            - metrics_timed_out: Prometheus metrics collection timed out
-            - EffectivenessAssessed: Legacy value (equivalent to "full")
-          example: "full"
+            - Full: All components assessed successfully
+            - Partial: Some components assessed, others unavailable
+            - SpecDrift: Target resource spec changed during assessment (score unreliable, forced to 0.0)
+            - Expired: Assessment timed out before completing
+            - NoExecution: No workflow execution found for this correlation ID
+            - MetricsTimedOut: Prometheus metrics collection timed out
+            - EffectivenessAssessed: Legacy value (equivalent to "Full")
+          example: "Full"
         computed_at:
           type: string
           format: date-time
@@ -5682,18 +5682,18 @@ components:
           type: string
           nullable: true
           enum:
-            - full
-            - partial
-            - spec_drift
-            - expired
-            - no_execution
-            - metrics_timed_out
+            - Full
+            - Partial
+            - SpecDrift
+            - Expired
+            - NoExecution
+            - MetricsTimedOut
           description: |
             Reason/status of the effectiveness assessment. Null if assessment
-            not yet completed. When "spec_drift", the effectiveness score is
+            not yet completed. When "SpecDrift", the effectiveness score is
             unreliable (hard-overridden to 0.0) because the target resource
             spec was modified during the assessment window (DD-EM-002 v1.1).
-          example: "full"
+          example: "Full"
         assessedAt:
           type: string
           format: date-time
@@ -5751,17 +5751,17 @@ components:
           type: string
           nullable: true
           enum:
-            - full
-            - partial
-            - spec_drift
-            - expired
-            - no_execution
-            - metrics_timed_out
+            - Full
+            - Partial
+            - SpecDrift
+            - Expired
+            - NoExecution
+            - MetricsTimedOut
           description: |
             Reason/status of the effectiveness assessment (same enum as
-            RemediationHistoryEntry). When "spec_drift", effectiveness score
+            RemediationHistoryEntry). When "SpecDrift", effectiveness score
             is unreliable (DD-EM-002 v1.1).
-          example: "full"
+          example: "Full"
         completedAt:
           type: string
           format: date-time

--- a/pkg/audit/store.go
+++ b/pkg/audit/store.go
@@ -183,8 +183,7 @@ func NewBufferedStore(client DataStorageClient, config Config, serviceName strin
 // - The event fails validation (missing required fields)
 // - The buffer is full (event is dropped, but service continues)
 func (s *BufferedAuditStore) StoreAudit(ctx context.Context, event *ogenclient.AuditEventRequest) error {
-	// DEBUG: Log entry to StoreAudit (E2E debugging - Dec 28, 2025)
-	s.logger.Info("🔍 StoreAudit called",
+	s.logger.V(1).Info("StoreAudit called",
 		"event_type", event.EventType,
 		"event_action", event.EventAction,
 		"correlation_id", event.CorrelationID,
@@ -214,8 +213,7 @@ func (s *BufferedAuditStore) StoreAudit(ctx context.Context, event *ogenclient.A
 		return nil // Silently drop event during graceful shutdown
 	}
 
-	// DEBUG: Validation passed
-	s.logger.Info("✅ Validation passed, attempting to buffer event",
+	s.logger.V(1).Info("Validation passed, attempting to buffer event",
 		"event_type", event.EventType,
 		"buffer_size_before", len(s.buffer))
 
@@ -224,8 +222,7 @@ func (s *BufferedAuditStore) StoreAudit(ctx context.Context, event *ogenclient.A
 		// ✅ Event buffered successfully
 		newCount := atomic.AddInt64(&s.bufferedCount, 1)
 
-		// DEBUG: Event successfully added to buffer
-		s.logger.Info("✅ Event buffered successfully",
+		s.logger.V(1).Info("Event buffered successfully",
 			"event_type", event.EventType,
 			"correlation_id", event.CorrelationID,
 			"buffer_size_after", len(s.buffer),
@@ -446,8 +443,8 @@ func (s *BufferedAuditStore) backgroundWriter() {
 				"drift", drift,
 				"tick_time", tickTime.Format(time.RFC3339Nano))
 
-			// Warn if tick drift exceeds 2x expected interval (potential bug)
-			if timeSinceLastFlush > expectedInterval*2 {
+			// Warn if tick drift exceeds 5x expected interval (genuine scheduling issue)
+			if timeSinceLastFlush > expectedInterval*5 {
 				s.logger.Error(nil, "🚨 TIMER BUG DETECTED: Tick interval significantly exceeded expected",
 					"expected_interval", expectedInterval,
 					"actual_interval", timeSinceLastFlush,

--- a/pkg/authwebhook/ds_client.go
+++ b/pkg/authwebhook/ds_client.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/jordigilh/kubernaut/pkg/shared/auth"
+	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
 	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
 )
 
@@ -58,10 +59,11 @@ func NewDSClientAdapter(baseURL string, timeout time.Duration, logger logr.Logge
 		timeout = 5 * time.Second
 	}
 
-	baseTransport := &http.Transport{
-		MaxIdleConns:        10,
-		MaxIdleConnsPerHost: 10,
-		IdleConnTimeout:     30 * time.Second,
+	// Issue #750: Use DefaultBaseTransport so TLS_CA_FILE is honoured for
+	// inter-service HTTPS when tls.interService.enabled=true.
+	baseTransport, err := sharedtls.DefaultBaseTransport()
+	if err != nil {
+		return nil, fmt.Errorf("failed to create TLS-aware base transport: %w", err)
 	}
 	transport := auth.NewServiceAccountTransportWithBase(baseTransport)
 

--- a/pkg/datastorage/ogen-client/oas_schemas_gen.go
+++ b/pkg/datastorage/ogen-client/oas_schemas_gen.go
@@ -8411,13 +8411,13 @@ type EffectivenessScoreResponse struct {
 	// Current assessment status:
 	// - no_data: No component events found
 	// - in_progress: Some component events present but assessment not completed
-	// - full: All components assessed successfully
-	// - partial: Some components assessed, others unavailable
-	// - spec_drift: Target resource spec changed during assessment (score unreliable, forced to 0.0)
-	// - expired: Assessment timed out before completing
-	// - no_execution: No workflow execution found for this correlation ID
-	// - metrics_timed_out: Prometheus metrics collection timed out
-	// - EffectivenessAssessed: Legacy value (equivalent to "full").
+	// - Full: All components assessed successfully
+	// - Partial: Some components assessed, others unavailable
+	// - SpecDrift: Target resource spec changed during assessment (score unreliable, forced to 0.0)
+	// - Expired: Assessment timed out before completing
+	// - NoExecution: No workflow execution found for this correlation ID
+	// - MetricsTimedOut: Prometheus metrics collection timed out
+	// - EffectivenessAssessed: Legacy value (equivalent to "Full").
 	AssessmentStatus EffectivenessScoreResponseAssessmentStatus `json:"assessment_status"`
 	// Timestamp when this score was computed.
 	ComputedAt time.Time `json:"computed_at"`
@@ -8488,24 +8488,24 @@ func (*EffectivenessScoreResponse) getEffectivenessScoreRes() {}
 // Current assessment status:
 // - no_data: No component events found
 // - in_progress: Some component events present but assessment not completed
-// - full: All components assessed successfully
-// - partial: Some components assessed, others unavailable
-// - spec_drift: Target resource spec changed during assessment (score unreliable, forced to 0.0)
-// - expired: Assessment timed out before completing
-// - no_execution: No workflow execution found for this correlation ID
-// - metrics_timed_out: Prometheus metrics collection timed out
-// - EffectivenessAssessed: Legacy value (equivalent to "full").
+// - Full: All components assessed successfully
+// - Partial: Some components assessed, others unavailable
+// - SpecDrift: Target resource spec changed during assessment (score unreliable, forced to 0.0)
+// - Expired: Assessment timed out before completing
+// - NoExecution: No workflow execution found for this correlation ID
+// - MetricsTimedOut: Prometheus metrics collection timed out
+// - EffectivenessAssessed: Legacy value (equivalent to "Full").
 type EffectivenessScoreResponseAssessmentStatus string
 
 const (
 	EffectivenessScoreResponseAssessmentStatusNoData                EffectivenessScoreResponseAssessmentStatus = "no_data"
 	EffectivenessScoreResponseAssessmentStatusInProgress            EffectivenessScoreResponseAssessmentStatus = "in_progress"
-	EffectivenessScoreResponseAssessmentStatusFull                  EffectivenessScoreResponseAssessmentStatus = "full"
-	EffectivenessScoreResponseAssessmentStatusPartial               EffectivenessScoreResponseAssessmentStatus = "partial"
-	EffectivenessScoreResponseAssessmentStatusSpecDrift             EffectivenessScoreResponseAssessmentStatus = "spec_drift"
-	EffectivenessScoreResponseAssessmentStatusExpired               EffectivenessScoreResponseAssessmentStatus = "expired"
-	EffectivenessScoreResponseAssessmentStatusNoExecution           EffectivenessScoreResponseAssessmentStatus = "no_execution"
-	EffectivenessScoreResponseAssessmentStatusMetricsTimedOut       EffectivenessScoreResponseAssessmentStatus = "metrics_timed_out"
+	EffectivenessScoreResponseAssessmentStatusFull                  EffectivenessScoreResponseAssessmentStatus = "Full"
+	EffectivenessScoreResponseAssessmentStatusPartial               EffectivenessScoreResponseAssessmentStatus = "Partial"
+	EffectivenessScoreResponseAssessmentStatusSpecDrift             EffectivenessScoreResponseAssessmentStatus = "SpecDrift"
+	EffectivenessScoreResponseAssessmentStatusExpired               EffectivenessScoreResponseAssessmentStatus = "Expired"
+	EffectivenessScoreResponseAssessmentStatusNoExecution           EffectivenessScoreResponseAssessmentStatus = "NoExecution"
+	EffectivenessScoreResponseAssessmentStatusMetricsTimedOut       EffectivenessScoreResponseAssessmentStatus = "MetricsTimedOut"
 	EffectivenessScoreResponseAssessmentStatusEffectivenessAssessed EffectivenessScoreResponseAssessmentStatus = "EffectivenessAssessed"
 )
 
@@ -17633,7 +17633,7 @@ type RemediationHistoryEntry struct {
 	// When the remediation was completed.
 	CompletedAt time.Time `json:"completedAt"`
 	// Reason/status of the effectiveness assessment. Null if assessment
-	// not yet completed. When "spec_drift", the effectiveness score is
+	// not yet completed. When "SpecDrift", the effectiveness score is
 	// unreliable (hard-overridden to 0.0) because the target resource
 	// spec was modified during the assessment window (DD-EM-002 v1.1).
 	AssessmentReason OptNilRemediationHistoryEntryAssessmentReason `json:"assessmentReason"`
@@ -17802,18 +17802,18 @@ func (s *RemediationHistoryEntry) SetAssessedAt(val OptDateTime) {
 }
 
 // Reason/status of the effectiveness assessment. Null if assessment
-// not yet completed. When "spec_drift", the effectiveness score is
+// not yet completed. When "SpecDrift", the effectiveness score is
 // unreliable (hard-overridden to 0.0) because the target resource
 // spec was modified during the assessment window (DD-EM-002 v1.1).
 type RemediationHistoryEntryAssessmentReason string
 
 const (
-	RemediationHistoryEntryAssessmentReasonFull            RemediationHistoryEntryAssessmentReason = "full"
-	RemediationHistoryEntryAssessmentReasonPartial         RemediationHistoryEntryAssessmentReason = "partial"
-	RemediationHistoryEntryAssessmentReasonSpecDrift       RemediationHistoryEntryAssessmentReason = "spec_drift"
-	RemediationHistoryEntryAssessmentReasonExpired         RemediationHistoryEntryAssessmentReason = "expired"
-	RemediationHistoryEntryAssessmentReasonNoExecution     RemediationHistoryEntryAssessmentReason = "no_execution"
-	RemediationHistoryEntryAssessmentReasonMetricsTimedOut RemediationHistoryEntryAssessmentReason = "metrics_timed_out"
+	RemediationHistoryEntryAssessmentReasonFull            RemediationHistoryEntryAssessmentReason = "Full"
+	RemediationHistoryEntryAssessmentReasonPartial         RemediationHistoryEntryAssessmentReason = "Partial"
+	RemediationHistoryEntryAssessmentReasonSpecDrift       RemediationHistoryEntryAssessmentReason = "SpecDrift"
+	RemediationHistoryEntryAssessmentReasonExpired         RemediationHistoryEntryAssessmentReason = "Expired"
+	RemediationHistoryEntryAssessmentReasonNoExecution     RemediationHistoryEntryAssessmentReason = "NoExecution"
+	RemediationHistoryEntryAssessmentReasonMetricsTimedOut RemediationHistoryEntryAssessmentReason = "MetricsTimedOut"
 )
 
 // AllValues returns all RemediationHistoryEntryAssessmentReason values.
@@ -17945,7 +17945,7 @@ type RemediationHistorySummary struct {
 	// Result of three-way hash comparison against currentSpecHash.
 	HashMatch OptRemediationHistorySummaryHashMatch `json:"hashMatch"`
 	// Reason/status of the effectiveness assessment (same enum as
-	// RemediationHistoryEntry). When "spec_drift", effectiveness score
+	// RemediationHistoryEntry). When "SpecDrift", effectiveness score
 	// is unreliable (DD-EM-002 v1.1).
 	AssessmentReason OptNilRemediationHistorySummaryAssessmentReason `json:"assessmentReason"`
 	// When the remediation was completed.
@@ -18043,17 +18043,17 @@ func (s *RemediationHistorySummary) SetCompletedAt(val time.Time) {
 }
 
 // Reason/status of the effectiveness assessment (same enum as
-// RemediationHistoryEntry). When "spec_drift", effectiveness score
+// RemediationHistoryEntry). When "SpecDrift", effectiveness score
 // is unreliable (DD-EM-002 v1.1).
 type RemediationHistorySummaryAssessmentReason string
 
 const (
-	RemediationHistorySummaryAssessmentReasonFull            RemediationHistorySummaryAssessmentReason = "full"
-	RemediationHistorySummaryAssessmentReasonPartial         RemediationHistorySummaryAssessmentReason = "partial"
-	RemediationHistorySummaryAssessmentReasonSpecDrift       RemediationHistorySummaryAssessmentReason = "spec_drift"
-	RemediationHistorySummaryAssessmentReasonExpired         RemediationHistorySummaryAssessmentReason = "expired"
-	RemediationHistorySummaryAssessmentReasonNoExecution     RemediationHistorySummaryAssessmentReason = "no_execution"
-	RemediationHistorySummaryAssessmentReasonMetricsTimedOut RemediationHistorySummaryAssessmentReason = "metrics_timed_out"
+	RemediationHistorySummaryAssessmentReasonFull            RemediationHistorySummaryAssessmentReason = "Full"
+	RemediationHistorySummaryAssessmentReasonPartial         RemediationHistorySummaryAssessmentReason = "Partial"
+	RemediationHistorySummaryAssessmentReasonSpecDrift       RemediationHistorySummaryAssessmentReason = "SpecDrift"
+	RemediationHistorySummaryAssessmentReasonExpired         RemediationHistorySummaryAssessmentReason = "Expired"
+	RemediationHistorySummaryAssessmentReasonNoExecution     RemediationHistorySummaryAssessmentReason = "NoExecution"
+	RemediationHistorySummaryAssessmentReasonMetricsTimedOut RemediationHistorySummaryAssessmentReason = "MetricsTimedOut"
 )
 
 // AllValues returns all RemediationHistorySummaryAssessmentReason values.

--- a/pkg/datastorage/ogen-client/oas_validators_gen.go
+++ b/pkg/datastorage/ogen-client/oas_validators_gen.go
@@ -2390,17 +2390,17 @@ func (s EffectivenessScoreResponseAssessmentStatus) Validate() error {
 		return nil
 	case "in_progress":
 		return nil
-	case "full":
+	case "Full":
 		return nil
-	case "partial":
+	case "Partial":
 		return nil
-	case "spec_drift":
+	case "SpecDrift":
 		return nil
-	case "expired":
+	case "Expired":
 		return nil
-	case "no_execution":
+	case "NoExecution":
 		return nil
-	case "metrics_timed_out":
+	case "MetricsTimedOut":
 		return nil
 	case "EffectivenessAssessed":
 		return nil
@@ -4499,17 +4499,17 @@ func (s *RemediationHistoryEntry) Validate() error {
 
 func (s RemediationHistoryEntryAssessmentReason) Validate() error {
 	switch s {
-	case "full":
+	case "Full":
 		return nil
-	case "partial":
+	case "Partial":
 		return nil
-	case "spec_drift":
+	case "SpecDrift":
 		return nil
-	case "expired":
+	case "Expired":
 		return nil
-	case "no_execution":
+	case "NoExecution":
 		return nil
-	case "metrics_timed_out":
+	case "MetricsTimedOut":
 		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)
@@ -4607,17 +4607,17 @@ func (s *RemediationHistorySummary) Validate() error {
 
 func (s RemediationHistorySummaryAssessmentReason) Validate() error {
 	switch s {
-	case "full":
+	case "Full":
 		return nil
-	case "partial":
+	case "Partial":
 		return nil
-	case "spec_drift":
+	case "SpecDrift":
 		return nil
-	case "expired":
+	case "Expired":
 		return nil
-	case "no_execution":
+	case "NoExecution":
 		return nil
-	case "metrics_timed_out":
+	case "MetricsTimedOut":
 		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)

--- a/pkg/datastorage/server/effectiveness_handler.go
+++ b/pkg/datastorage/server/effectiveness_handler.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	eav1 "github.com/jordigilh/kubernaut/api/effectivenessassessment/v1alpha1"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/validation"
 )
 
@@ -191,11 +192,11 @@ func BuildEffectivenessResponse(correlationID string, events []*EffectivenessEve
 
 		case "effectiveness.assessment.completed":
 			if reason, ok := eventData["reason"].(string); ok {
-				// DD-EM-002 v1.1: spec_drift is terminal and takes priority over
+				// DD-EM-002 v1.1: SpecDrift is terminal and takes priority over
 				// all other reasons. When multiple completed events exist (e.g.,
-				// "full" followed by "spec_drift" after EA re-assessment), spec_drift
+				// "Full" followed by "SpecDrift" after EA re-assessment), SpecDrift
 				// must not be overwritten by an earlier reason that sorts later.
-				if resp.AssessmentStatus != "spec_drift" {
+				if resp.AssessmentStatus != eav1.AssessmentReasonSpecDrift {
 					resp.AssessmentStatus = reason
 				}
 			}
@@ -205,7 +206,7 @@ func BuildEffectivenessResponse(correlationID string, events []*EffectivenessEve
 	// DD-EM-002 v1.1: Spec drift means remediation was unsuccessful.
 	// Short-circuit to score 0.0 — component scores are unreliable because
 	// the target resource spec was modified (likely by another remediation).
-	if resp.AssessmentStatus == "spec_drift" {
+	if resp.AssessmentStatus == eav1.AssessmentReasonSpecDrift {
 		score := 0.0
 		resp.Score = &score
 		return resp

--- a/pkg/datastorage/server/middleware/openapi_spec_data.yaml
+++ b/pkg/datastorage/server/middleware/openapi_spec_data.yaml
@@ -1969,25 +1969,25 @@ components:
           enum:
             - no_data
             - in_progress
-            - full
-            - partial
-            - spec_drift
-            - expired
-            - no_execution
-            - metrics_timed_out
+            - Full
+            - Partial
+            - SpecDrift
+            - Expired
+            - NoExecution
+            - MetricsTimedOut
             - EffectivenessAssessed
           description: |
             Current assessment status:
             - no_data: No component events found
             - in_progress: Some component events present but assessment not completed
-            - full: All components assessed successfully
-            - partial: Some components assessed, others unavailable
-            - spec_drift: Target resource spec changed during assessment (score unreliable, forced to 0.0)
-            - expired: Assessment timed out before completing
-            - no_execution: No workflow execution found for this correlation ID
-            - metrics_timed_out: Prometheus metrics collection timed out
-            - EffectivenessAssessed: Legacy value (equivalent to "full")
-          example: "full"
+            - Full: All components assessed successfully
+            - Partial: Some components assessed, others unavailable
+            - SpecDrift: Target resource spec changed during assessment (score unreliable, forced to 0.0)
+            - Expired: Assessment timed out before completing
+            - NoExecution: No workflow execution found for this correlation ID
+            - MetricsTimedOut: Prometheus metrics collection timed out
+            - EffectivenessAssessed: Legacy value (equivalent to "Full")
+          example: "Full"
         computed_at:
           type: string
           format: date-time
@@ -5682,18 +5682,18 @@ components:
           type: string
           nullable: true
           enum:
-            - full
-            - partial
-            - spec_drift
-            - expired
-            - no_execution
-            - metrics_timed_out
+            - Full
+            - Partial
+            - SpecDrift
+            - Expired
+            - NoExecution
+            - MetricsTimedOut
           description: |
             Reason/status of the effectiveness assessment. Null if assessment
-            not yet completed. When "spec_drift", the effectiveness score is
+            not yet completed. When "SpecDrift", the effectiveness score is
             unreliable (hard-overridden to 0.0) because the target resource
             spec was modified during the assessment window (DD-EM-002 v1.1).
-          example: "full"
+          example: "Full"
         assessedAt:
           type: string
           format: date-time
@@ -5751,17 +5751,17 @@ components:
           type: string
           nullable: true
           enum:
-            - full
-            - partial
-            - spec_drift
-            - expired
-            - no_execution
-            - metrics_timed_out
+            - Full
+            - Partial
+            - SpecDrift
+            - Expired
+            - NoExecution
+            - MetricsTimedOut
           description: |
             Reason/status of the effectiveness assessment (same enum as
-            RemediationHistoryEntry). When "spec_drift", effectiveness score
+            RemediationHistoryEntry). When "SpecDrift", effectiveness score
             is unreliable (DD-EM-002 v1.1).
-          example: "full"
+          example: "Full"
         completedAt:
           type: string
           format: date-time

--- a/pkg/shared/assets/crds/kubernaut.ai_effectivenessassessments.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_effectivenessassessments.yaml
@@ -212,13 +212,14 @@ spec:
                 description: AssessmentReason describes why the assessment completed
                   with this outcome.
                 enum:
-                - full
-                - partial
-                - no_execution
-                - metrics_timed_out
-                - expired
-                - spec_drift
-                - alert_decay_timeout
+                - Full
+                - Partial
+                - NoExecution
+                - MetricsTimedOut
+                - Expired
+                - SpecDrift
+                - AlertDecayTimeout
+                - Unrecoverable
                 type: string
               completedAt:
                 description: CompletedAt is the timestamp when the assessment finished.

--- a/pkg/shared/tls/tls.go
+++ b/pkg/shared/tls/tls.go
@@ -113,19 +113,6 @@ func DefaultBaseTransport() (*http.Transport, error) {
 	return NewTLSTransport(caFile)
 }
 
-// NewInterServiceClient creates an http.Client with optional CA trust for
-// inter-service HTTPS calls. When caFile is empty, returns a plain client.
-func NewInterServiceClient(caFile string, timeout time.Duration) (*http.Client, error) {
-	if caFile == "" {
-		return &http.Client{Timeout: timeout}, nil
-	}
-	transport, err := NewTLSTransport(caFile)
-	if err != nil {
-		return nil, err
-	}
-	return &http.Client{Transport: transport, Timeout: timeout}, nil
-}
-
 // NewTLSTransport creates an http.Transport configured with a custom CA pool
 // for verifying server certificates on outbound HTTPS calls.
 func NewTLSTransport(caFile string) (*http.Transport, error) {

--- a/test/e2e/datastorage/25_remediation_history_api_test.go
+++ b/test/e2e/datastorage/25_remediation_history_api_test.go
@@ -192,7 +192,7 @@ var _ = Describe("BR-HAPI-016: Remediation History API E2E Tests (DD-HAPI-016 v1
 		now := time.Now().UTC()
 		cid := fmt.Sprintf("corr-e2e-full-%s", testID)
 		insertROEvent(cid, targetResource, currentSpecHash, "ScaleUp", now.Add(-2*time.Hour))
-		insertEMEvents(cid, "full", 0.85, currentSpecHash, "sha256:e2e_post_"+testID, now.Add(-2*time.Hour))
+		insertEMEvents(cid, "Full", 0.85, currentSpecHash, "sha256:e2e_post_"+testID, now.Add(-2*time.Hour))
 
 		// Act: query via HTTP API
 		status, body := queryRemediationHistory(map[string]string{
@@ -213,7 +213,7 @@ var _ = Describe("BR-HAPI-016: Remediation History API E2E Tests (DD-HAPI-016 v1
 
 		entry := chain[0].(map[string]interface{})
 		Expect(entry).To(HaveKey("assessmentReason"))
-		Expect(entry["assessmentReason"]).To(Equal("full"))
+		Expect(entry["assessmentReason"]).To(Equal("Full"))
 		Expect(entry).To(HaveKey("effectivenessScore"))
 		score := entry["effectivenessScore"].(float64)
 		Expect(score).To(BeNumerically(">", 0.0))
@@ -226,7 +226,7 @@ var _ = Describe("BR-HAPI-016: Remediation History API E2E Tests (DD-HAPI-016 v1
 		now := time.Now().UTC()
 		cid := fmt.Sprintf("corr-e2e-drift-%s", testID)
 		insertROEvent(cid, targetResource, currentSpecHash, "ScaleUp", now.Add(-2*time.Hour))
-		insertEMEvents(cid, "spec_drift", 0.0, currentSpecHash, "sha256:e2e_drift_"+testID, now.Add(-2*time.Hour))
+		insertEMEvents(cid, "SpecDrift", 0.0, currentSpecHash, "sha256:e2e_drift_"+testID, now.Add(-2*time.Hour))
 
 		// Act
 		status, body := queryRemediationHistory(map[string]string{
@@ -244,7 +244,7 @@ var _ = Describe("BR-HAPI-016: Remediation History API E2E Tests (DD-HAPI-016 v1
 		Expect(chain).To(HaveLen(1))
 
 		entry := chain[0].(map[string]interface{})
-		Expect(entry["assessmentReason"]).To(Equal("spec_drift"),
+		Expect(entry["assessmentReason"]).To(Equal("SpecDrift"),
 			"spec_drift reason must survive the full service pipeline")
 		Expect(entry["effectivenessScore"]).To(BeNumerically("==", 0.0),
 			"spec_drift score must be 0.0 (unreliable)")
@@ -281,13 +281,13 @@ var _ = Describe("BR-HAPI-016: Remediation History API E2E Tests (DD-HAPI-016 v1
 		cid3 := fmt.Sprintf("corr-e2e-mixed3-%s", testID)
 
 		insertROEvent(cid1, targetResource, currentSpecHash, "ScaleUp", now.Add(-3*time.Hour))
-		insertEMEvents(cid1, "full", 0.85, currentSpecHash, "sha256:p1_"+testID, now.Add(-3*time.Hour))
+		insertEMEvents(cid1, "Full", 0.85, currentSpecHash, "sha256:p1_"+testID, now.Add(-3*time.Hour))
 
 		insertROEvent(cid2, targetResource, currentSpecHash, "RestartPod", now.Add(-2*time.Hour))
-		insertEMEvents(cid2, "spec_drift", 0.0, currentSpecHash, "sha256:p2_"+testID, now.Add(-2*time.Hour))
+		insertEMEvents(cid2, "SpecDrift", 0.0, currentSpecHash, "sha256:p2_"+testID, now.Add(-2*time.Hour))
 
 		insertROEvent(cid3, targetResource, currentSpecHash, "ScaleDown", now.Add(-1*time.Hour))
-		insertEMEvents(cid3, "partial", 0.65, currentSpecHash, "sha256:p3_"+testID, now.Add(-1*time.Hour))
+		insertEMEvents(cid3, "Partial", 0.65, currentSpecHash, "sha256:p3_"+testID, now.Add(-1*time.Hour))
 
 		// Act
 		status, body := queryRemediationHistory(map[string]string{
@@ -312,7 +312,7 @@ var _ = Describe("BR-HAPI-016: Remediation History API E2E Tests (DD-HAPI-016 v1
 				reasons[i] = r.(string)
 			}
 		}
-		Expect(reasons).To(Equal([]string{"full", "spec_drift", "partial"}),
+		Expect(reasons).To(Equal([]string{"Full", "SpecDrift", "Partial"}),
 			"Assessment reasons should be in ascending timestamp order (oldest first, per OpenAPI spec)")
 	})
 

--- a/test/e2e/effectivenessmonitor/lifecycle_e2e_test.go
+++ b/test/e2e/effectivenessmonitor/lifecycle_e2e_test.go
@@ -148,7 +148,7 @@ var _ = Describe("EffectivenessMonitor Lifecycle E2E Tests", Label("e2e"), func(
 		Expect(ea.Status.ValidityDeadline).NotTo(BeNil())
 		Expect(ea.Status.PrometheusCheckAfter).NotTo(BeNil())
 		Expect(ea.Status.AlertManagerCheckAfter).NotTo(BeNil())
-		Expect(ea.Status.Message).To(Equal("Assessment completed: full"))
+		Expect(ea.Status.Message).To(Equal("Assessment completed: Full"))
 
 		// E2E-EA-163-002: Conditions validation (Ready, AssessmentComplete, SpecIntegrity)
 		Expect(ea.Status.Conditions).To(ContainElements(

--- a/test/e2e/effectivenessmonitor/operational_e2e_test.go
+++ b/test/e2e/effectivenessmonitor/operational_e2e_test.go
@@ -69,11 +69,11 @@ var _ = Describe("EffectivenessMonitor Operational E2E Tests", Label("e2e"), fun
 			ea := waitForEAPhase(name, eav1.PhaseCompleted)
 
 			Expect(ea.Status.AssessmentReason).To(Equal(eav1.AssessmentReasonExpired),
-				"EA should have assessment reason 'expired'")
+				"EA should have assessment reason 'Expired'")
 
 			// E2E-EA-163-003: Controller NEVER sets PhaseFailed for expired - stays Completed
 			Expect(ea.Status.Phase).To(Equal("Completed"))
-			Expect(ea.Status.Message).To(Equal("Assessment completed: expired"))
+			Expect(ea.Status.Message).To(Equal("Assessment completed: Expired"))
 
 			By("Verifying no component assessments were performed")
 			Expect(ea.Status.Components.HealthAssessed).To(BeFalse(),

--- a/test/e2e/effectivenessmonitor/spec_drift_e2e_test.go
+++ b/test/e2e/effectivenessmonitor/spec_drift_e2e_test.go
@@ -182,7 +182,7 @@ var _ = Describe("Spec Drift Guard E2E Tests (DD-EM-002 v1.1)", Label("e2e"), fu
 					continue
 				}
 				payload, ok := evt.EventData.GetEffectivenessAssessmentAuditPayload()
-				if ok && payload.Reason.IsSet() && payload.Reason.Value == "spec_drift" {
+				if ok && payload.Reason.IsSet() && payload.Reason.Value == "SpecDrift" {
 					hasSpecDriftEvent = true
 					break
 				}

--- a/test/integration/datastorage/remediation_history_integration_test.go
+++ b/test/integration/datastorage/remediation_history_integration_test.go
@@ -231,7 +231,7 @@ var _ = Describe("BR-HAPI-016: Remediation History Integration Tests (DD-HAPI-01
 				fmt.Sprintf("corr-em-3-%s", testID),
 			}
 			for i, cid := range cids {
-				insertEMEvents(cid, "full", 0.85, "sha256:pre"+fmt.Sprintf("%d", i), "sha256:post"+fmt.Sprintf("%d", i), now.Add(time.Duration(-3+i)*time.Hour))
+				insertEMEvents(cid, "Full", 0.85, "sha256:pre"+fmt.Sprintf("%d", i), "sha256:post"+fmt.Sprintf("%d", i), now.Add(time.Duration(-3+i)*time.Hour))
 			}
 
 			// Act
@@ -278,7 +278,7 @@ var _ = Describe("BR-HAPI-016: Remediation History Integration Tests (DD-HAPI-01
 			// and available to the correlation engine after passing through the adapter.
 			now := time.Now().UTC()
 			cid := fmt.Sprintf("corr-adapter-%s", testID)
-			insertEMEvents(cid, "full", 0.85, "sha256:pre_a", "sha256:post_a", now.Add(-1*time.Hour))
+			insertEMEvents(cid, "Full", 0.85, "sha256:pre_a", "sha256:post_a", now.Add(-1*time.Hour))
 
 			adapter := server.NewRemediationHistoryRepoAdapter(rhRepo)
 
@@ -361,7 +361,7 @@ var _ = Describe("BR-HAPI-016: Remediation History Integration Tests (DD-HAPI-01
 			now := time.Now().UTC()
 			cid := fmt.Sprintf("corr-full-%s", testID)
 			insertROEvent(cid, targetResource, currentSpecHash, "ScaleUp", now.Add(-2*time.Hour))
-			insertEMEvents(cid, "full", 0.85, currentSpecHash, "sha256:post_full_"+testID, now.Add(-2*time.Hour))
+			insertEMEvents(cid, "Full", 0.85, currentSpecHash, "sha256:post_full_"+testID, now.Add(-2*time.Hour))
 
 			// Act: direct business logic pipeline (no HTTP)
 			entries, _ := queryAndCorrelate(targetResource, currentSpecHash, now.Add(-24*time.Hour))
@@ -370,7 +370,7 @@ var _ = Describe("BR-HAPI-016: Remediation History Integration Tests (DD-HAPI-01
 			Expect(entries).To(HaveLen(1), "Should have 1 Tier 1 entry")
 			entry := entries[0]
 			Expect(entry.AssessmentReason.Set).To(BeTrue(), "assessmentReason must be set")
-			Expect(string(entry.AssessmentReason.Value)).To(Equal("full"))
+			Expect(string(entry.AssessmentReason.Value)).To(Equal("Full"))
 			Expect(entry.EffectivenessScore.Set).To(BeTrue(), "effectivenessScore must be set")
 			Expect(entry.EffectivenessScore.Value).To(BeNumerically(">", 0.0),
 				"Full assessment should have a positive weighted score")
@@ -382,7 +382,7 @@ var _ = Describe("BR-HAPI-016: Remediation History Integration Tests (DD-HAPI-01
 			now := time.Now().UTC()
 			cid := fmt.Sprintf("corr-drift-%s", testID)
 			insertROEvent(cid, targetResource, currentSpecHash, "ScaleUp", now.Add(-2*time.Hour))
-			insertEMEvents(cid, "spec_drift", 0.0, currentSpecHash, "sha256:post_drift_"+testID, now.Add(-2*time.Hour))
+			insertEMEvents(cid, "SpecDrift", 0.0, currentSpecHash, "sha256:post_drift_"+testID, now.Add(-2*time.Hour))
 
 			// Act
 			entries, _ := queryAndCorrelate(targetResource, currentSpecHash, now.Add(-24*time.Hour))
@@ -391,7 +391,7 @@ var _ = Describe("BR-HAPI-016: Remediation History Integration Tests (DD-HAPI-01
 			Expect(entries).To(HaveLen(1))
 			entry := entries[0]
 			Expect(entry.AssessmentReason.Set).To(BeTrue())
-			Expect(string(entry.AssessmentReason.Value)).To(Equal("spec_drift"))
+			Expect(string(entry.AssessmentReason.Value)).To(Equal("SpecDrift"))
 			Expect(entry.EffectivenessScore.Set).To(BeTrue())
 			Expect(entry.EffectivenessScore.Value).To(BeNumerically("==", 0.0),
 				"spec_drift assessment should have score 0.0 (unreliable, not failure)")
@@ -403,7 +403,7 @@ var _ = Describe("BR-HAPI-016: Remediation History Integration Tests (DD-HAPI-01
 			regressionHash := currentSpecHash // Same hash means config reverted
 			cid := fmt.Sprintf("corr-regr-%s", testID)
 			insertROEvent(cid, targetResource, regressionHash, "ScaleUp", now.Add(-2*time.Hour))
-			insertEMEvents(cid, "full", 0.7, regressionHash, "sha256:post_regr_"+testID, now.Add(-2*time.Hour))
+			insertEMEvents(cid, "Full", 0.7, regressionHash, "sha256:post_regr_"+testID, now.Add(-2*time.Hour))
 
 			// Act
 			entries, regressionDetected := queryAndCorrelate(targetResource, currentSpecHash, now.Add(-24*time.Hour))
@@ -432,7 +432,7 @@ var _ = Describe("BR-HAPI-016: Remediation History Integration Tests (DD-HAPI-01
 			insertAuditEvent("effectiveness.hash.computed", "effectiveness", cid,
 				map[string]interface{}{"pre_remediation_spec_hash": "sha256:pre", "post_remediation_spec_hash": "sha256:post"}, ts)
 			insertAuditEvent("effectiveness.assessment.completed", "effectiveness", cid,
-				map[string]interface{}{"reason": "spec_drift"}, ts)
+				map[string]interface{}{"reason": "SpecDrift"}, ts)
 
 			// Query 10 times and verify event ordering is identical every time
 			var referenceOrder []string

--- a/test/integration/datastorage/remediation_history_query_fix_integration_test.go
+++ b/test/integration/datastorage/remediation_history_query_fix_integration_test.go
@@ -126,7 +126,7 @@ var _ = Describe("Issue #616: QueryROEventsBySpecHash Post-Hash Matching", Label
 		)
 		insertEMHashEvent(correlationID, preHash, postHash, ts.Add(4*time.Minute))
 		insertAuditEvent("effectiveness.assessment.completed", "effectiveness", correlationID,
-			map[string]interface{}{"reason": "full", "score": 0.85},
+			map[string]interface{}{"reason": "Full", "score": 0.85},
 			ts.Add(5*time.Minute),
 		)
 	}

--- a/test/integration/effectivenessmonitor/alert_decay_integration_test.go
+++ b/test/integration/effectivenessmonitor/alert_decay_integration_test.go
@@ -152,7 +152,7 @@ var _ = Describe("Alert Decay Detection Integration (Issue #369, BR-EM-012)", fu
 		Expect(fetchedEA.Status.Components.AlertScore).To(HaveValue(Equal(1.0)),
 			"AlertScore should be 1.0 (confirmed resolved)")
 		Expect(fetchedEA.Status.AssessmentReason).To(Equal(eav1.AssessmentReasonFull),
-			"Reason should be 'full' (all components assessed)")
+			"Reason should be 'Full' (all components assessed)")
 		Expect(fetchedEA.Status.Components.AlertDecayRetries).To(BeNumerically(">", 0),
 			"AlertDecayRetries should be preserved for operator observability")
 
@@ -287,7 +287,7 @@ var _ = Describe("Alert Decay Detection Integration (Issue #369, BR-EM-012)", fu
 		Expect(fetchedEA.Status.Components.AlertScore).To(HaveValue(Equal(0.0)),
 			"AlertScore should be 0.0 (alert firing, remediation failed)")
 		Expect(fetchedEA.Status.AssessmentReason).To(Equal(eav1.AssessmentReasonFull),
-			"AssessmentReason should be 'full' (all components assessed, not alert_decay_timeout)")
+			"AssessmentReason should be 'Full' (all components assessed, not alert_decay_timeout)")
 		Expect(fetchedEA.Status.Components.AlertDecayRetries).To(Equal(int32(1)),
 			"AlertDecayRetries should be 1 (one decay pass before metrics gate killed hypothesis)")
 

--- a/test/integration/effectivenessmonitor/dual_target_routing_integration_test.go
+++ b/test/integration/effectivenessmonitor/dual_target_routing_integration_test.go
@@ -234,7 +234,7 @@ var _ = Describe("Dual-Target Routing (Issue #188, DD-EM-003)", func() {
 				Equal(fetchedEA.Status.Components.PostRemediationSpecHash),
 				"DD-EM-003: current hash should match post-remediation hash (no drift)")
 		}
-		Expect(fetchedEA.Status.AssessmentReason).NotTo(Equal("spec_drift"),
+		Expect(fetchedEA.Status.AssessmentReason).NotTo(Equal("SpecDrift"),
 			"DD-EM-003: no spec drift should be detected when RemediationTarget is stable")
 	})
 

--- a/test/integration/effectivenessmonitor/hash_deferral_integration_test.go
+++ b/test/integration/effectivenessmonitor/hash_deferral_integration_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Hash Compute Deferral Integration (DD-EM-004, BR-EM-010)", fun
 		Expect(fetchedEA.Status.Components.AlertAssessed).To(BeTrue(),
 			"Alert component must still be assessed after deferred hash")
 		Expect(fetchedEA.Status.AssessmentReason).To(
-			BeElementOf("full", "partial", "metrics_timed_out"),
+			BeElementOf("Full", "Partial", "MetricsTimedOut"),
 			"Assessment must complete with a definitive reason despite hash deferral")
 
 		GinkgoWriter.Printf("Assessment completed: hash=%s, reason=%s\n",
@@ -150,7 +150,7 @@ var _ = Describe("Hash Compute Deferral Integration (DD-EM-004, BR-EM-010)", fun
 			"Hash must use canonical sha256: format")
 		Expect(fetchedEA.Status.Components.PostRemediationSpecHash).To(HaveLen(71))
 		Expect(fetchedEA.Status.AssessmentReason).To(
-			BeElementOf("full", "partial", "metrics_timed_out"),
+			BeElementOf("Full", "Partial", "MetricsTimedOut"),
 			"Assessment must complete normally for sync targets")
 	})
 
@@ -210,7 +210,7 @@ var _ = Describe("Hash Compute Deferral Integration (DD-EM-004, BR-EM-010)", fun
 		Expect(fetchedEA.Status.Components.AlertAssessed).To(BeTrue(),
 			"All components must be assessed when deferral window already elapsed")
 		Expect(fetchedEA.Status.AssessmentReason).To(
-			BeElementOf("full", "partial", "metrics_timed_out"),
+			BeElementOf("Full", "Partial", "MetricsTimedOut"),
 			"Assessment must complete with a definitive reason")
 	})
 })

--- a/test/integration/effectivenessmonitor/hash_integration_test.go
+++ b/test/integration/effectivenessmonitor/hash_integration_test.go
@@ -173,7 +173,7 @@ var _ = Describe("Spec Hash Integration (BR-EM-004)", func() {
 
 		// Business outcome 5: Assessment completed with a definitive reason.
 		Expect(fetchedEA.Status.AssessmentReason).To(
-			BeElementOf("full", "partial", "metrics_timed_out"),
+			BeElementOf("Full", "Partial", "MetricsTimedOut"),
 			"Assessment must complete with a definitive reason, not hang or fail")
 	})
 
@@ -226,7 +226,7 @@ var _ = Describe("Spec Hash Integration (BR-EM-004)", func() {
 
 		// Business outcome 4: Assessment completes with a definitive reason.
 		Expect(fetchedEA.Status.AssessmentReason).To(
-			BeElementOf("full", "partial", "metrics_timed_out"),
+			BeElementOf("Full", "Partial", "MetricsTimedOut"),
 			"Assessment must complete definitively, not fail due to missing pre-hash")
 
 		// Confirm the EA spec didn't fabricate a pre-hash

--- a/test/integration/effectivenessmonitor/issue573_integration_test.go
+++ b/test/integration/effectivenessmonitor/issue573_integration_test.go
@@ -305,7 +305,7 @@ var _ = Describe("Issue #573: ADR-EM-001 Implementation Gaps", func() {
 
 			Expect(fetchedEA.Status.Phase).To(Equal(eav1.PhaseCompleted),
 				"IT-EM-573-013: phase should be Completed")
-			Expect(fetchedEA.Status.AssessmentReason).To(Equal("partial"),
+			Expect(fetchedEA.Status.AssessmentReason).To(Equal("Partial"),
 				"IT-EM-573-013: reason should be partial")
 			Expect(fetchedEA.Status.Components.HealthAssessed).To(BeTrue(),
 				"IT-EM-573-013: health should be assessed")
@@ -363,7 +363,7 @@ var _ = Describe("Issue #573: ADR-EM-001 Implementation Gaps", func() {
 			// full path reaches allComponentsDone at Step 8.
 			Expect(fetchedEA.Status.Phase).To(Equal(eav1.PhaseCompleted),
 				"IT-EM-573-014: phase should be Completed")
-			Expect(fetchedEA.Status.AssessmentReason).NotTo(Equal("partial"),
+			Expect(fetchedEA.Status.AssessmentReason).NotTo(Equal("Partial"),
 				"IT-EM-573-014: reason should NOT be partial (full assessment path)")
 			Expect(fetchedEA.Status.Components.HealthAssessed).To(BeTrue(),
 				"IT-EM-573-014: health should be assessed")

--- a/test/integration/kubernautagent/enrichment/enrichment_real_ds_test.go
+++ b/test/integration/kubernautagent/enrichment/enrichment_real_ds_test.go
@@ -140,9 +140,9 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 
 			By("Seeding 2 RO events + EM events in PostgreSQL")
 			insertROEvent(corrID1, target, "sha256:pre1", "IncreaseMemory", now)
-			insertEMEvents(corrID1, "full", 0.85, "sha256:pre1", "sha256:post1", now)
+			insertEMEvents(corrID1, "Full", 0.85, "sha256:pre1", "sha256:post1", now)
 			insertROEvent(corrID2, target, "sha256:pre1", "RestartPod", now.Add(30*time.Minute))
-			insertEMEvents(corrID2, "full", 0.90, "sha256:pre1", "sha256:post2", now.Add(30*time.Minute))
+			insertEMEvents(corrID2, "Full", 0.90, "sha256:pre1", "sha256:post2", now.Add(30*time.Minute))
 
 			By("Calling enricher with real infrastructure")
 			result, err := enricher.Enrich(testCtx, "Pod", "web-pod-1", "it-enrichment", "sha256:pre1", "incident-enr001-"+testID)
@@ -170,7 +170,7 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 			Expect(recent.Outcome).To(Equal("success"))
 			Expect(recent.HashMatch).To(Equal("preRemediation"))
 			Expect(recent.PreRemediationSpecHash).To(Equal("sha256:pre1"))
-			Expect(recent.AssessmentReason).To(Equal("full"))
+			Expect(recent.AssessmentReason).To(Equal("Full"))
 
 			older := result.RemediationHistory.Tier1[1]
 			Expect(older.RemediationUID).To(Equal(corrID1))
@@ -236,7 +236,7 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 
 			By("Seeding remediation history")
 			insertROEvent(corrID, target, "sha256:pre3", "IncreaseMemory", now)
-			insertEMEvents(corrID, "full", 0.88, "sha256:pre3", "sha256:post3", now)
+			insertEMEvents(corrID, "Full", 0.88, "sha256:pre3", "sha256:post3", now)
 
 			By("Calling enricher (triggers audit event)")
 			_, err := enricher.Enrich(testCtx, "Pod", "web-pod-1", "it-enrichment", "sha256:pre3", incidentID)
@@ -318,7 +318,7 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 
 			By("Seeding remediation history for StatefulSet")
 			insertROEvent(corrID, target, "sha256:pre5", "RestartPod", now)
-			insertEMEvents(corrID, "full", 0.92, "sha256:pre5", "sha256:post5", now)
+			insertEMEvents(corrID, "Full", 0.92, "sha256:pre5", "sha256:post5", now)
 
 			By("Building enricher with broken K8s + real DS + real audit store")
 			brokenK8s := &errorK8sClient{err: errors.New("K8s API unavailable")}
@@ -484,7 +484,7 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 				}, now.Add(4*time.Minute))
 
 			insertAuditEvent("effectiveness.assessment.completed", "effectiveness", corrID,
-				map[string]interface{}{"reason": "full", "score": 0.855},
+				map[string]interface{}{"reason": "Full", "score": 0.855},
 				now.Add(5*time.Minute))
 
 			By("Calling enricher")
@@ -528,7 +528,7 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 
 			By("Seeding RO event with preHash=sha256:old9")
 			insertROEvent(corrID, target, "sha256:old9", "RestartPod", now)
-			insertEMEvents(corrID, "full", 0.90, "sha256:old9", "sha256:current9", now)
+			insertEMEvents(corrID, "Full", 0.90, "sha256:old9", "sha256:current9", now)
 
 			By("Calling enricher with currentSpecHash=sha256:old9 (matches preHash → regression)")
 			result1, err := enricher.Enrich(testCtx, "Pod", "web-pod-1", "it-enrichment", "sha256:old9", "incident-enr009a-"+testID)

--- a/test/unit/aianalysis/agentclient_tls_test.go
+++ b/test/unit/aianalysis/agentclient_tls_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aianalysis
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/agentclient"
+)
+
+var _ = Describe("BR-INTEGRATION-750: agentclient inter-service TLS trust (#750)", func() {
+
+	var (
+		origTLSCAFile string
+		hadTLSCAFile  bool
+	)
+
+	BeforeEach(func() {
+		origTLSCAFile, hadTLSCAFile = os.LookupEnv("TLS_CA_FILE")
+	})
+
+	AfterEach(func() {
+		if hadTLSCAFile {
+			os.Setenv("TLS_CA_FILE", origTLSCAFile)
+		} else {
+			os.Unsetenv("TLS_CA_FILE")
+		}
+	})
+
+	generateSelfSignedCA := func(certFile string) {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		Expect(err).ToNot(HaveOccurred())
+
+		template := &x509.Certificate{
+			SerialNumber:          big.NewInt(1),
+			Subject:               pkix.Name{CommonName: "test-ca"},
+			NotBefore:             time.Now().Add(-1 * time.Hour),
+			NotAfter:              time.Now().Add(24 * time.Hour),
+			IsCA:                  true,
+			BasicConstraintsValid: true,
+			KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		}
+
+		certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+		Expect(err).ToNot(HaveOccurred())
+
+		certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+		Expect(os.WriteFile(certFile, certPEM, 0644)).To(Succeed())
+	}
+
+	// UT-AC-750-001: Constructor must fail when TLS_CA_FILE points to a nonexistent path.
+	// This proves the constructor reads the env var (http.DefaultTransport would ignore it).
+	It("UT-AC-750-001: returns error when TLS_CA_FILE points to invalid path", func() {
+		os.Setenv("TLS_CA_FILE", "/nonexistent/ca.crt")
+
+		client, err := agentclient.NewKubernautAgentClient(agentclient.Config{
+			BaseURL: "https://localhost:9999",
+		})
+		Expect(err).To(HaveOccurred(), "constructor must propagate DefaultBaseTransport error")
+		Expect(err.Error()).To(ContainSubstring("failed to read CA certificate"),
+			"error should originate from TLS CA loading")
+		Expect(client).To(BeNil())
+	})
+
+	// UT-AC-750-002: Constructor must succeed when TLS_CA_FILE points to a valid CA cert.
+	It("UT-AC-750-002: succeeds when TLS_CA_FILE points to valid CA cert", func() {
+		tmpDir, err := os.MkdirTemp("", "tls-test-750-*")
+		Expect(err).ToNot(HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+
+		caFile := filepath.Join(tmpDir, "ca.crt")
+		generateSelfSignedCA(caFile)
+		os.Setenv("TLS_CA_FILE", caFile)
+
+		client, err := agentclient.NewKubernautAgentClient(agentclient.Config{
+			BaseURL: "https://localhost:9999",
+		})
+		Expect(err).ToNot(HaveOccurred(), "constructor must succeed with valid CA cert")
+		Expect(client).NotTo(BeNil(), "client must be returned when TLS_CA_FILE is valid")
+	})
+
+	// UT-AC-750-003: Constructor must continue to work when TLS_CA_FILE is unset (regression guard).
+	It("UT-AC-750-003: succeeds when TLS_CA_FILE is unset (regression guard)", func() {
+		os.Unsetenv("TLS_CA_FILE")
+
+		client, err := agentclient.NewKubernautAgentClient(agentclient.Config{
+			BaseURL: "http://localhost:9999",
+		})
+		Expect(err).ToNot(HaveOccurred(), "constructor must work without TLS_CA_FILE (plain HTTP)")
+		Expect(client).NotTo(BeNil(), "client must be returned when TLS_CA_FILE is unset")
+	})
+})

--- a/test/unit/audit/store_test.go
+++ b/test/unit/audit/store_test.go
@@ -145,6 +145,92 @@ func (m *MockDataStorageClient) Reset() {
 	m.failUntilCall = 0
 }
 
+// errorCaptureSink captures Error-level log messages for test assertions.
+type errorCaptureSink struct {
+	mu     sync.Mutex
+	errors []string
+}
+
+func (s *errorCaptureSink) Init(logr.RuntimeInfo)                    {}
+func (s *errorCaptureSink) Enabled(int) bool                         { return true }
+func (s *errorCaptureSink) Info(level int, msg string, _ ...interface{}) {}
+func (s *errorCaptureSink) Error(_ error, msg string, _ ...interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.errors = append(s.errors, msg)
+}
+func (s *errorCaptureSink) WithValues(...interface{}) logr.LogSink { return s }
+func (s *errorCaptureSink) WithName(string) logr.LogSink          { return s }
+
+func (s *errorCaptureSink) hasErrorContaining(substr string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, msg := range s.errors {
+		if containsSubstring(msg, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *errorCaptureSink) errorCountContaining(substr string) int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	count := 0
+	for _, msg := range s.errors {
+		if containsSubstring(msg, substr) {
+			count++
+		}
+	}
+	return count
+}
+
+// infoCaptureSink captures Info-level log messages with their verbosity level.
+type infoCaptureSink struct {
+	mu      sync.Mutex
+	entries []infoEntry
+}
+
+type infoEntry struct {
+	level int
+	msg   string
+}
+
+func (s *infoCaptureSink) Init(logr.RuntimeInfo)                          {}
+func (s *infoCaptureSink) Enabled(int) bool                               { return true }
+func (s *infoCaptureSink) Error(_ error, _ string, _ ...interface{})      {}
+func (s *infoCaptureSink) WithValues(...interface{}) logr.LogSink         { return s }
+func (s *infoCaptureSink) WithName(string) logr.LogSink                  { return s }
+func (s *infoCaptureSink) Info(level int, msg string, _ ...interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.entries = append(s.entries, infoEntry{level: level, msg: msg})
+}
+
+func (s *infoCaptureSink) hasInfoAtLevel(level int, substr string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, e := range s.entries {
+		if e.level == level && containsSubstring(e.msg, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsSubstring(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || findSubstring(s, substr))
+}
+
+func findSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
 // Helper function to create a test event
 // DD-AUDIT-002 V2.0: Uses OpenAPI types and helper functions
 func createTestEvent() *ogenclient.AuditEventRequest {
@@ -537,6 +623,120 @@ var _ = Describe("BufferedAuditStore", func() {
 				ContainSubstring("dropped"),
 				ContainSubstring("timeout"), // Close() may timeout if retries are still in-flight
 			))
+		})
+	})
+
+	// ========================================
+	// Issue #749: Timer drift threshold and log verbosity (BR-AUDIT-749)
+	// ========================================
+	Describe("Timer Drift Threshold (Issue #749)", func() {
+
+		// UT-AUDIT-749-001: 3x drift should NOT trigger Error log (threshold is 5x)
+		It("UT-AUDIT-749-001: timer drift at 3x does NOT emit Error log", func() {
+			config := audit.Config{
+				BufferSize:    100,
+				BatchSize:     10,
+				FlushInterval: 100 * time.Millisecond,
+				MaxRetries:    3,
+			}
+
+			logSink := &errorCaptureSink{}
+			testLogger := logr.New(logSink)
+
+			var err error
+			store, err = audit.NewBufferedStore(mockClient, config, "test-service", testLogger)
+			Expect(err).ToNot(HaveOccurred())
+
+			// Store one event so the timer-based flush has something to process
+			event := createTestEvent()
+			Expect(store.StoreAudit(ctx, event)).To(Succeed())
+
+			// Wait for several flush intervals to allow timer ticks to accumulate
+			// At 100ms interval, 3x drift means ~300ms between ticks (normal jitter)
+			time.Sleep(500 * time.Millisecond)
+
+			// Close cleanly to drain
+			Expect(store.Close()).To(Succeed())
+			store = nil
+
+			// No Error-level log about "TIMER BUG" should appear for normal jitter
+			Expect(logSink.hasErrorContaining("TIMER BUG")).To(BeFalse(),
+				"3x drift (normal jitter) must NOT trigger TIMER BUG Error — threshold should be 5x")
+		})
+
+		// UT-AUDIT-749-002: 6x drift SHOULD trigger Error log
+		// This is harder to test deterministically since we can't control Go scheduler.
+		// We validate the threshold constant indirectly: the threshold value in the code
+		// must be >2x (old value) and <=5x (new value). Since we can't inject fake time
+		// into backgroundWriter, we test the behavioral contract: a store with a very short
+		// FlushInterval on a loaded system won't fire the Error for normal jitter.
+		// The actual 6x test requires inspecting the threshold constant.
+		It("UT-AUDIT-749-002: timer drift threshold is 5x (not 2x)", func() {
+			// This test validates the code review finding: the threshold should be 5x.
+			// We can't deterministically trigger 6x drift in a unit test, but we can
+			// verify that with a 10ms FlushInterval (where 2x=20ms is easily exceeded
+			// by Go scheduler), the old 2x threshold would fire constantly but
+			// the new 5x threshold (50ms) should rarely fire.
+			config := audit.Config{
+				BufferSize:    100,
+				BatchSize:     10,
+				FlushInterval: 10 * time.Millisecond,
+				MaxRetries:    3,
+			}
+
+			logSink := &errorCaptureSink{}
+			testLogger := logr.New(logSink)
+
+			var err error
+			store, err = audit.NewBufferedStore(mockClient, config, "test-service", testLogger)
+			Expect(err).ToNot(HaveOccurred())
+
+			event := createTestEvent()
+			Expect(store.StoreAudit(ctx, event)).To(Succeed())
+
+			// With 10ms interval and 2x threshold (20ms), Error would fire on almost every tick.
+			// With 5x threshold (50ms), it should fire much less frequently.
+			time.Sleep(200 * time.Millisecond)
+
+			Expect(store.Close()).To(Succeed())
+			store = nil
+
+			errorCount := logSink.errorCountContaining("TIMER BUG")
+			// With 5x threshold at 10ms interval, we expect far fewer errors than tick count (~20 ticks)
+			// Old 2x threshold would fire on nearly every tick
+			Expect(errorCount).To(BeNumerically("<", 10),
+				"5x threshold should fire much less than the ~20 ticks that occurred")
+		})
+	})
+
+	Describe("StoreAudit Log Verbosity (Issue #749)", func() {
+
+		// UT-AUDIT-749-003: StoreAudit should NOT emit Info logs at V(0)
+		It("UT-AUDIT-749-003: StoreAudit does not emit Info-level logs at default verbosity", func() {
+			config := audit.Config{
+				BufferSize:    100,
+				BatchSize:     10,
+				FlushInterval: 10 * time.Second,
+				MaxRetries:    3,
+			}
+
+			logSink := &infoCaptureSink{}
+			testLogger := logr.New(logSink)
+
+			var err error
+			store, err = audit.NewBufferedStore(mockClient, config, "test-service", testLogger)
+			Expect(err).ToNot(HaveOccurred())
+
+			event := createTestEvent()
+			Expect(store.StoreAudit(ctx, event)).To(Succeed())
+
+			// At V(0) (production default), no Info logs from StoreAudit should appear
+			Expect(logSink.hasInfoAtLevel(0, "StoreAudit called")).To(BeFalse(),
+				"StoreAudit called log must be V(1), not Info")
+			Expect(logSink.hasInfoAtLevel(0, "Validation passed")).To(BeFalse(),
+				"Validation passed log must be V(1), not Info")
+			Expect(logSink.hasInfoAtLevel(0, "Event buffered successfully")).To(BeFalse(),
+				"Event buffered successfully log must be V(1), not Info")
 		})
 	})
 

--- a/test/unit/authwebhook/ds_client_tls_test.go
+++ b/test/unit/authwebhook/ds_client_tls_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authwebhook
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/authwebhook"
+)
+
+var _ = Describe("BR-INTEGRATION-750: authwebhook DSClientAdapter inter-service TLS trust (#750)", func() {
+
+	var (
+		origTLSCAFile string
+		hadTLSCAFile  bool
+	)
+
+	BeforeEach(func() {
+		origTLSCAFile, hadTLSCAFile = os.LookupEnv("TLS_CA_FILE")
+	})
+
+	AfterEach(func() {
+		if hadTLSCAFile {
+			os.Setenv("TLS_CA_FILE", origTLSCAFile)
+		} else {
+			os.Unsetenv("TLS_CA_FILE")
+		}
+	})
+
+	generateSelfSignedCA := func(certFile string) {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		Expect(err).ToNot(HaveOccurred())
+
+		template := &x509.Certificate{
+			SerialNumber:          big.NewInt(1),
+			Subject:               pkix.Name{CommonName: "test-ca"},
+			NotBefore:             time.Now().Add(-1 * time.Hour),
+			NotAfter:              time.Now().Add(24 * time.Hour),
+			IsCA:                  true,
+			BasicConstraintsValid: true,
+			KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		}
+
+		certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+		Expect(err).ToNot(HaveOccurred())
+
+		certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+		Expect(os.WriteFile(certFile, certPEM, 0644)).To(Succeed())
+	}
+
+	// UT-AW-750-001: Constructor must fail when TLS_CA_FILE points to a nonexistent path.
+	// This proves the constructor reads the env var (plain http.Transport would ignore it).
+	It("UT-AW-750-001: returns error when TLS_CA_FILE points to invalid path", func() {
+		os.Setenv("TLS_CA_FILE", "/nonexistent/ca.crt")
+
+		adapter, err := authwebhook.NewDSClientAdapter(
+			"https://localhost:9999", 5*time.Second, logr.Discard(),
+		)
+		Expect(err).To(HaveOccurred(), "constructor must propagate DefaultBaseTransport error")
+		Expect(err.Error()).To(ContainSubstring("failed to read CA certificate"),
+			"error should originate from TLS CA loading")
+		Expect(adapter).To(BeNil())
+	})
+
+	// UT-AW-750-002: Constructor must succeed when TLS_CA_FILE points to a valid CA cert.
+	It("UT-AW-750-002: succeeds when TLS_CA_FILE points to valid CA cert", func() {
+		tmpDir, err := os.MkdirTemp("", "tls-test-750-*")
+		Expect(err).ToNot(HaveOccurred())
+		defer os.RemoveAll(tmpDir)
+
+		caFile := filepath.Join(tmpDir, "ca.crt")
+		generateSelfSignedCA(caFile)
+		os.Setenv("TLS_CA_FILE", caFile)
+
+		adapter, err := authwebhook.NewDSClientAdapter(
+			"https://localhost:9999", 5*time.Second, logr.Discard(),
+		)
+		Expect(err).ToNot(HaveOccurred(), "constructor must succeed with valid CA cert")
+		Expect(adapter).NotTo(BeNil(), "adapter must be returned when TLS_CA_FILE is valid")
+	})
+
+	// UT-AW-750-003: Constructor must continue to work when TLS_CA_FILE is unset (regression guard).
+	It("UT-AW-750-003: succeeds when TLS_CA_FILE is unset (regression guard)", func() {
+		os.Unsetenv("TLS_CA_FILE")
+
+		adapter, err := authwebhook.NewDSClientAdapter(
+			"http://localhost:9999", 5*time.Second, logr.Discard(),
+		)
+		Expect(err).ToNot(HaveOccurred(), "constructor must work without TLS_CA_FILE (plain HTTP)")
+		Expect(adapter).NotTo(BeNil(), "adapter must be returned when TLS_CA_FILE is unset")
+	})
+})

--- a/test/unit/datastorage/effectiveness_score_test.go
+++ b/test/unit/datastorage/effectiveness_score_test.go
@@ -198,7 +198,7 @@ var _ = Describe("Effectiveness Score Computation (DD-017 v2.1)", func() {
 				{
 					EventData: map[string]interface{}{
 						"event_type": "effectiveness.assessment.completed",
-						"reason":     "full",
+						"reason":     "Full",
 					},
 				},
 			}
@@ -207,7 +207,7 @@ var _ = Describe("Effectiveness Score Computation (DD-017 v2.1)", func() {
 
 			Expect(resp.CorrelationID).To(Equal("rr-test-001"))
 			Expect(resp.Score).To(HaveValue(BeNumerically("~", 0.95, 0.001)))
-			Expect(resp.AssessmentStatus).To(Equal("full"))
+			Expect(resp.AssessmentStatus).To(Equal("Full"))
 			Expect(resp.Components.HealthAssessed).To(BeTrue())
 			Expect(resp.Components.AlertAssessed).To(BeTrue())
 			Expect(resp.Components.MetricsAssessed).To(BeTrue())
@@ -299,14 +299,14 @@ var _ = Describe("Effectiveness Score Computation (DD-017 v2.1)", func() {
 				{
 					EventData: map[string]interface{}{
 						"event_type": "effectiveness.assessment.completed",
-						"reason":     "spec_drift",
+						"reason":     "SpecDrift",
 					},
 				},
 			}
 
 			resp := server.BuildEffectivenessResponse("rr-drift-001", events)
 
-			Expect(resp.AssessmentStatus).To(Equal("spec_drift"))
+			Expect(resp.AssessmentStatus).To(Equal("SpecDrift"))
 			Expect(resp.Score).To(HaveValue(Equal(0.0)),
 				"spec_drift should short-circuit to score 0.0 regardless of component scores")
 		})
@@ -338,14 +338,14 @@ var _ = Describe("Effectiveness Score Computation (DD-017 v2.1)", func() {
 				{
 					EventData: map[string]interface{}{
 						"event_type": "effectiveness.assessment.completed",
-						"reason":     "spec_drift",
+						"reason":     "SpecDrift",
 					},
 				},
 			}
 
 			resp := server.BuildEffectivenessResponse("rr-drift-002", events)
 
-			Expect(resp.AssessmentStatus).To(Equal("spec_drift"))
+			Expect(resp.AssessmentStatus).To(Equal("SpecDrift"))
 			Expect(resp.Score).To(HaveValue(Equal(0.0)),
 				"spec_drift overrides all component scores to 0.0")
 		})
@@ -365,20 +365,20 @@ var _ = Describe("Effectiveness Score Computation (DD-017 v2.1)", func() {
 				{
 					EventData: map[string]interface{}{
 						"event_type": "effectiveness.assessment.completed",
-						"reason":     "full",
+						"reason":     "Full",
 					},
 				},
 				{
 					EventData: map[string]interface{}{
 						"event_type": "effectiveness.assessment.completed",
-						"reason":     "spec_drift",
+						"reason":     "SpecDrift",
 					},
 				},
 			}
 
 			resp := server.BuildEffectivenessResponse("rr-order-001", events)
 
-			Expect(resp.AssessmentStatus).To(Equal("spec_drift"),
+			Expect(resp.AssessmentStatus).To(Equal("SpecDrift"),
 				"DD-EM-002 v1.1: spec_drift must take priority over full")
 			Expect(resp.Score).To(HaveValue(Equal(0.0)),
 				"spec_drift short-circuits to score 0.0")
@@ -392,23 +392,49 @@ var _ = Describe("Effectiveness Score Computation (DD-017 v2.1)", func() {
 				{
 					EventData: map[string]interface{}{
 						"event_type": "effectiveness.assessment.completed",
-						"reason":     "spec_drift",
+						"reason":     "SpecDrift",
 					},
 				},
 				{
 					EventData: map[string]interface{}{
 						"event_type": "effectiveness.assessment.completed",
-						"reason":     "full",
+						"reason":     "Full",
 					},
 				},
 			}
 
 			resp := server.BuildEffectivenessResponse("rr-order-002", events)
 
-			Expect(resp.AssessmentStatus).To(Equal("spec_drift"),
+			Expect(resp.AssessmentStatus).To(Equal("SpecDrift"),
 				"DD-EM-002 v1.1: spec_drift must not be overwritten by later full event")
 			Expect(resp.Score).To(HaveValue(Equal(0.0)),
 				"spec_drift short-circuits to score 0.0")
+		})
+
+		// UT-DS-749-001: PascalCase SpecDrift short-circuits to 0.0 (BR-EM-749)
+		It("UT-DS-749-001: BuildEffectivenessResponse short-circuits PascalCase SpecDrift to 0.0", func() {
+			events := []*server.EffectivenessEvent{
+				{
+					EventData: map[string]interface{}{
+						"event_type": "effectiveness.health.assessed",
+						"assessed":   true,
+						"score":      1.0,
+					},
+				},
+				{
+					EventData: map[string]interface{}{
+						"event_type": "effectiveness.assessment.completed",
+						"reason":     "SpecDrift",
+					},
+				},
+			}
+
+			resp := server.BuildEffectivenessResponse("rr-pascal-drift-001", events)
+
+			Expect(resp.AssessmentStatus).To(Equal("SpecDrift"),
+				"BR-EM-749: PascalCase SpecDrift must be recognized")
+			Expect(resp.Score).To(HaveValue(Equal(0.0)),
+				"BR-EM-749: PascalCase SpecDrift must short-circuit to 0.0")
 		})
 
 		// UT-DS-EFF-015: Non-drift assessment still computes normally
@@ -424,14 +450,14 @@ var _ = Describe("Effectiveness Score Computation (DD-017 v2.1)", func() {
 				{
 					EventData: map[string]interface{}{
 						"event_type": "effectiveness.assessment.completed",
-						"reason":     "full",
+						"reason":     "Full",
 					},
 				},
 			}
 
 			resp := server.BuildEffectivenessResponse("rr-normal-001", events)
 
-			Expect(resp.AssessmentStatus).To(Equal("full"))
+			Expect(resp.AssessmentStatus).To(Equal("Full"))
 			Expect(resp.Score).To(HaveValue(BeNumerically(">", 0.0)),
 				"non-drift assessment should compute a positive score from components")
 		})

--- a/test/unit/datastorage/remediation_history_handler_test.go
+++ b/test/unit/datastorage/remediation_history_handler_test.go
@@ -209,7 +209,7 @@ var _ = Describe("Remediation History Handler (DD-HAPI-016 v1.4)", func() {
 						{
 							EventData: map[string]interface{}{
 								"event_type": "effectiveness.assessment.completed",
-								"reason":     "full",
+								"reason":     "Full",
 							},
 						},
 					},

--- a/test/unit/datastorage/remediation_history_logic_test.go
+++ b/test/unit/datastorage/remediation_history_logic_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Remediation History Correlation Logic (DD-HAPI-016 v1.1)", fun
 			{
 				EventData: map[string]interface{}{
 					"event_type": "effectiveness.assessment.completed",
-					"reason":     "full",
+					"reason":     "Full",
 				},
 			},
 		}
@@ -416,7 +416,7 @@ var _ = Describe("Remediation History Correlation Logic (DD-HAPI-016 v1.1)", fun
 				{
 					EventData: map[string]interface{}{
 						"event_type": "effectiveness.assessment.completed",
-						"reason":     "spec_drift",
+						"reason":     "SpecDrift",
 					},
 				},
 			}
@@ -439,7 +439,7 @@ var _ = Describe("Remediation History Correlation Logic (DD-HAPI-016 v1.1)", fun
 
 				// assessmentReason must be propagated
 				Expect(entry.AssessmentReason.Set).To(BeTrue())
-				Expect(string(entry.AssessmentReason.Value)).To(Equal("spec_drift"))
+				Expect(string(entry.AssessmentReason.Value)).To(Equal("SpecDrift"))
 
 				// score is 0.0 (spec_drift short-circuit in BuildEffectivenessResponse)
 				Expect(entry.EffectivenessScore.Set).To(BeTrue())
@@ -461,7 +461,7 @@ var _ = Describe("Remediation History Correlation Logic (DD-HAPI-016 v1.1)", fun
 
 				// assessmentReason must be "full"
 				Expect(entry.AssessmentReason.Set).To(BeTrue())
-				Expect(string(entry.AssessmentReason.Value)).To(Equal("full"))
+				Expect(string(entry.AssessmentReason.Value)).To(Equal("Full"))
 
 				// score is normal (not 0.0)
 				Expect(entry.EffectivenessScore.Set).To(BeTrue())
@@ -498,7 +498,7 @@ var _ = Describe("Remediation History Correlation Logic (DD-HAPI-016 v1.1)", fun
 				s := summaries[0]
 
 				Expect(s.AssessmentReason.Set).To(BeTrue())
-				Expect(string(s.AssessmentReason.Value)).To(Equal("spec_drift"))
+				Expect(string(s.AssessmentReason.Value)).To(Equal("SpecDrift"))
 
 				// score is 0.0
 				Expect(s.EffectivenessScore.Set).To(BeTrue())
@@ -519,7 +519,7 @@ var _ = Describe("Remediation History Correlation Logic (DD-HAPI-016 v1.1)", fun
 				s := summaries[0]
 
 				Expect(s.AssessmentReason.Set).To(BeTrue())
-				Expect(string(s.AssessmentReason.Value)).To(Equal("full"))
+				Expect(string(s.AssessmentReason.Value)).To(Equal("Full"))
 			})
 		})
 	})

--- a/test/unit/effectivenessmonitor/audit_test.go
+++ b/test/unit/effectivenessmonitor/audit_test.go
@@ -57,8 +57,7 @@ var _ = Describe("Audit Event Builder (BR-AUDIT-006)", func() {
 			Expect(event.CorrelationID).To(Equal("rr-test-001"))
 			Expect(event.AssessmentName).To(Equal("ea-test-001"))
 			Expect(event.Namespace).To(Equal("default"))
-			Expect(event.Score).ToNot(BeNil())
-			Expect(*event.Score).To(Equal(1.0))
+			Expect(event.Score).To(HaveValue(Equal(1.0)))
 			Expect(event.TotalReplicas).To(Equal(int32(3)))
 			Expect(event.ReadyReplicas).To(Equal(int32(3)))
 			Expect(event.RestartsSinceRemediation).To(Equal(int32(0)))
@@ -89,8 +88,7 @@ var _ = Describe("Audit Event Builder (BR-AUDIT-006)", func() {
 			Expect(event.CorrelationID).To(Equal("rr-test-001"))
 			Expect(event.PostRemediationSpecHash).To(Equal("sha256:aaa111"))
 			Expect(event.PreRemediationSpecHash).To(Equal("sha256:aaa111"))
-			Expect(event.Match).ToNot(BeNil())
-			Expect(*event.Match).To(BeTrue())
+			Expect(event.Match).To(HaveValue(BeTrue()))
 		})
 
 		It("should build hash audit event with match=false when hashes differ", func() {
@@ -136,8 +134,7 @@ var _ = Describe("Audit Event Builder (BR-AUDIT-006)", func() {
 
 			event := builder.BuildAlertEvent(data, &score, "HighLatency", true)
 
-			Expect(event.Score).ToNot(BeNil())
-			Expect(*event.Score).To(Equal(1.0))
+			Expect(event.Score).To(HaveValue(Equal(1.0)))
 			Expect(event.SignalName).To(Equal("HighLatency"))
 			Expect(event.AlertResolved).To(BeTrue())
 		})
@@ -242,9 +239,9 @@ var _ = Describe("Audit Event Builder (BR-AUDIT-006)", func() {
 				{Component: types.ComponentAlert, Assessed: true, Score: &alertScore},
 			}
 
-			event := builder.BuildCompletedEvent(data, components, "full", "Assessment completed successfully")
+			event := builder.BuildCompletedEvent(data, components, "Full", "Assessment completed successfully")
 
-			Expect(event.Reason).To(Equal("full"))
+			Expect(event.Reason).To(Equal("Full"))
 			Expect(event.Message).To(Equal("Assessment completed successfully"))
 			Expect(event.Components).To(HaveLen(2))
 		})
@@ -257,18 +254,18 @@ var _ = Describe("Audit Event Builder (BR-AUDIT-006)", func() {
 				{Component: types.ComponentMetrics, Assessed: false, Score: nil},
 			}
 
-			event := builder.BuildCompletedEvent(data, components, "partial", "Metrics timed out")
+			event := builder.BuildCompletedEvent(data, components, "Partial", "Metrics timed out")
 
-			Expect(event.Reason).To(Equal("partial"))
+			Expect(event.Reason).To(Equal("Partial"))
 			Expect(event.Components).To(HaveLen(2))
 		})
 
 		It("should build completed audit event for expired assessment", func() {
 			data := baseEventData()
 
-			event := builder.BuildCompletedEvent(data, nil, "expired", "Validity window expired")
+			event := builder.BuildCompletedEvent(data, nil, "Expired", "Validity window expired")
 
-			Expect(event.Reason).To(Equal("expired"))
+			Expect(event.Reason).To(Equal("Expired"))
 			Expect(event.Components).To(BeNil())
 		})
 	})

--- a/test/unit/effectivenessmonitor/conditions_test.go
+++ b/test/unit/effectivenessmonitor/conditions_test.go
@@ -214,7 +214,7 @@ var _ = Describe("EA Conditions Infrastructure (DD-CRD-002)", func() {
 	// UT-EM-COND-011: AssessmentReasonSpecDrift constant exists
 	// ========================================
 	It("UT-EM-COND-011: should define AssessmentReasonSpecDrift in EA types", func() {
-		Expect(eav1.AssessmentReasonSpecDrift).To(Equal("spec_drift"))
+		Expect(eav1.AssessmentReasonSpecDrift).To(Equal("SpecDrift"))
 	})
 
 	// ========================================

--- a/test/unit/effectivenessmonitor/controller_metrics_test.go
+++ b/test/unit/effectivenessmonitor/controller_metrics_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Controller Metrics (BR-EM-009, DD-METRICS-001)", func() {
 
 			Expect(func() {
 				m.RecordComponentAssessment("health", "success", nil)
-				m.RecordAssessmentCompleted("full")
+				m.RecordAssessmentCompleted("Full")
 				m.RecordExternalCallError("test", "op", "err")
 				m.RecordValidityExpiration()
 			}).ToNot(Panic(), "all metric collectors should accept observations without panic")
@@ -108,7 +108,7 @@ var _ = Describe("Controller Metrics (BR-EM-009, DD-METRICS-001)", func() {
 
 		It("RecordAssessmentCompleted should not panic", func() {
 			Expect(func() {
-				m.RecordAssessmentCompleted("full")
+				m.RecordAssessmentCompleted("Full")
 			}).ToNot(Panic())
 		})
 

--- a/test/unit/effectivenessmonitor/ea_types_test.go
+++ b/test/unit/effectivenessmonitor/ea_types_test.go
@@ -51,11 +51,34 @@ var _ = Describe("EffectivenessAssessment CRD Types (ADR-EM-001)", func() {
 	Describe("AssessmentReason Constants", func() {
 
 		It("should define all five assessment reasons", func() {
-			Expect(eav1.AssessmentReasonFull).To(Equal("full"))
-			Expect(eav1.AssessmentReasonPartial).To(Equal("partial"))
-			Expect(eav1.AssessmentReasonNoExecution).To(Equal("no_execution"))
-			Expect(eav1.AssessmentReasonMetricsTimedOut).To(Equal("metrics_timed_out"))
-			Expect(eav1.AssessmentReasonExpired).To(Equal("expired"))
+			Expect(eav1.AssessmentReasonFull).To(Equal("Full"))
+			Expect(eav1.AssessmentReasonPartial).To(Equal("Partial"))
+			Expect(eav1.AssessmentReasonNoExecution).To(Equal("NoExecution"))
+			Expect(eav1.AssessmentReasonMetricsTimedOut).To(Equal("MetricsTimedOut"))
+			Expect(eav1.AssessmentReasonExpired).To(Equal("Expired"))
+		})
+
+		// UT-EM-749-001: All AssessmentReason constants are PascalCase (BR-EM-749)
+		It("UT-EM-749-001: all AssessmentReason constants must be PascalCase", func() {
+			reasons := []string{
+				eav1.AssessmentReasonFull,
+				eav1.AssessmentReasonPartial,
+				eav1.AssessmentReasonNoExecution,
+				eav1.AssessmentReasonMetricsTimedOut,
+				eav1.AssessmentReasonExpired,
+				eav1.AssessmentReasonSpecDrift,
+				eav1.AssessmentReasonAlertDecayTimeout,
+			}
+
+			for _, reason := range reasons {
+				Expect(reason).To(MatchRegexp(`^[A-Z][a-zA-Z]+$`),
+					"AssessmentReason %q must be PascalCase (no underscores, starts with uppercase)", reason)
+			}
+		})
+
+		// UT-EM-749-002: Unrecoverable reason must be a PascalCase constant (BR-EM-749)
+		It("UT-EM-749-002: unrecoverable reason must become PascalCase Unrecoverable", func() {
+			Expect(eav1.AssessmentReasonUnrecoverable).To(Equal("Unrecoverable"))
 		})
 	})
 

--- a/test/unit/effectivenessmonitor/failed_phase_test.go
+++ b/test/unit/effectivenessmonitor/failed_phase_test.go
@@ -99,8 +99,8 @@ var _ = Describe("EM Failed Phase (#573, ADR-EM-001 section 11)", func() {
 
 			Expect(updatedEA.Status.Phase).To(Equal(eav1.PhaseFailed),
 				"UT-EM-573-001: EA with empty correlationID should transition to Failed")
-			Expect(updatedEA.Status.AssessmentReason).To(Equal("unrecoverable"),
-				"UT-EM-573-001: reason should be 'unrecoverable'")
+			Expect(updatedEA.Status.AssessmentReason).To(Equal("Unrecoverable"),
+				"UT-EM-573-001: reason should be 'Unrecoverable'")
 			Expect(updatedEA.Status.Message).To(ContainSubstring("correlationID"),
 				"UT-EM-573-001: message should mention correlationID")
 		})
@@ -140,8 +140,8 @@ var _ = Describe("EM Failed Phase (#573, ADR-EM-001 section 11)", func() {
 				"UT-EM-573-002: completedAt should be set")
 			Expect(updatedEA.Status.CompletedAt.Time).To(BeTemporally(">=", beforeReconcile),
 				"UT-EM-573-002: completedAt should be after reconcile started")
-			Expect(updatedEA.Status.AssessmentReason).To(Equal("unrecoverable"),
-				"UT-EM-573-002: assessmentReason should be 'unrecoverable'")
+			Expect(updatedEA.Status.AssessmentReason).To(Equal("Unrecoverable"),
+				"UT-EM-573-002: assessmentReason should be 'Unrecoverable'")
 			Expect(updatedEA.Status.Message).To(ContainSubstring("correlationID is required"),
 				"UT-EM-573-002: message should describe the validation failure")
 		})

--- a/test/unit/effectivenessmonitor/reconciler_partial_scope_test.go
+++ b/test/unit/effectivenessmonitor/reconciler_partial_scope_test.go
@@ -194,7 +194,7 @@ var _ = Describe("Partial Scope Grace (UT-EM-254-006, #254)", func() {
 		Expect(fetched.Status.Phase).To(Equal(eav1.PhaseCompleted),
 			"Phase must be Completed after grace expires")
 		Expect(fetched.Status.AssessmentReason).To(Equal(eav1.AssessmentReasonPartial),
-			"AssessmentReason must be 'partial'")
+			"AssessmentReason must be 'Partial'")
 		Expect(fetched.Status.CompletedAt).NotTo(BeNil(),
 			"CompletedAt must be set")
 	})

--- a/test/unit/effectivenessmonitor/reconciler_spec_drift_test.go
+++ b/test/unit/effectivenessmonitor/reconciler_spec_drift_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Spec Drift Early Exit (UT-EM-254-005, #254)", func() {
 		Expect(fetched.Status.Phase).To(Equal(eav1.PhaseCompleted),
 			"Phase must be Completed after spec drift")
 		Expect(fetched.Status.AssessmentReason).To(Equal(eav1.AssessmentReasonSpecDrift),
-			"AssessmentReason must be spec_drift")
+			"AssessmentReason must be SpecDrift")
 		Expect(fetched.Status.CompletedAt).NotTo(BeNil(),
 			"CompletedAt must be set")
 

--- a/test/unit/kubernautagent/enrichment/ds_adapter_test.go
+++ b/test/unit/kubernautagent/enrichment/ds_adapter_test.go
@@ -106,7 +106,7 @@ var _ = Describe("DataStorage Adapter — TP-433-WIR Phase 1a", func() {
 			Expect(t1.HashMatch).To(Equal("preRemediation"))
 			Expect(t1.PreRemediationSpecHash).To(Equal("sha256:aaa"))
 			Expect(t1.PostRemediationSpecHash).To(Equal("sha256:bbb"))
-			Expect(t1.AssessmentReason).To(Equal("full"))
+			Expect(t1.AssessmentReason).To(Equal("Full"))
 			Expect(t1.HealthChecks).NotTo(BeNil())
 			Expect(*t1.HealthChecks.PodRunning).To(BeTrue())
 			Expect(*t1.HealthChecks.ReadinessPass).To(BeTrue())

--- a/test/unit/kubernautagent/prompt/history_test.go
+++ b/test/unit/kubernautagent/prompt/history_test.go
@@ -129,7 +129,7 @@ var _ = Describe("Remediation History Prompt Builder — KA Parity (#433)", func
 				RemediationUID:   "wf-drift-001",
 				ActionType:       "restart_pod",
 				Outcome:          "Success",
-				AssessmentReason: "spec_drift",
+				AssessmentReason: "SpecDrift",
 				CompletedAt:      time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC),
 			}
 			result := prompt.FormatTier1Entry(entry, nil)
@@ -143,7 +143,7 @@ var _ = Describe("Remediation History Prompt Builder — KA Parity (#433)", func
 				RemediationUID:          "wf-drift-001",
 				ActionType:              "restart_pod",
 				Outcome:                 "Success",
-				AssessmentReason:        "spec_drift",
+				AssessmentReason:        "SpecDrift",
 				PostRemediationSpecHash: "sha256:aaa",
 				CompletedAt:             time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC),
 			}
@@ -176,7 +176,7 @@ var _ = Describe("Remediation History Prompt Builder — KA Parity (#433)", func
 				RemediationUID:   "wf-drift-old",
 				ActionType:       "scale_up",
 				Outcome:          "Success",
-				AssessmentReason: "spec_drift",
+				AssessmentReason: "SpecDrift",
 				CompletedAt:      time.Date(2026, 1, 10, 8, 0, 0, 0, time.UTC),
 			}
 			result := prompt.FormatTier2Summary(s)
@@ -206,7 +206,7 @@ var _ = Describe("Remediation History Prompt Builder — KA Parity (#433)", func
 		It("should exclude spec_drift entries from declining detection", func() {
 			chain := []enrichment.Tier1Entry{
 				{ActionType: "restart_pod", EffectivenessScore: floatPtr(0.8)},
-				{ActionType: "restart_pod", EffectivenessScore: floatPtr(0.0), AssessmentReason: "spec_drift"},
+				{ActionType: "restart_pod", EffectivenessScore: floatPtr(0.0), AssessmentReason: "SpecDrift"},
 				{ActionType: "restart_pod", EffectivenessScore: floatPtr(0.9)},
 			}
 			Expect(prompt.DetectDecliningEffectiveness(chain)).To(BeEmpty())
@@ -229,7 +229,7 @@ var _ = Describe("Remediation History Prompt Builder — KA Parity (#433)", func
 		It("should not count spec_drift entries", func() {
 			entries := []prompt.HistoryEntry{
 				{ActionType: "restart_pod", SignalType: "OOMKilled", Outcome: "Success"},
-				{ActionType: "restart_pod", SignalType: "OOMKilled", Outcome: "Success", AssessmentReason: "spec_drift"},
+				{ActionType: "restart_pod", SignalType: "OOMKilled", Outcome: "Success", AssessmentReason: "SpecDrift"},
 			}
 			recurring := prompt.DetectCompletedButRecurring(entries, 2)
 			Expect(recurring).To(BeEmpty())
@@ -266,7 +266,7 @@ var _ = Describe("Remediation History Prompt Builder — KA Parity (#433)", func
 			chain := []enrichment.Tier1Entry{
 				{
 					RemediationUID:          "wf-drift-001",
-					AssessmentReason:        "spec_drift",
+					AssessmentReason:        "SpecDrift",
 					PostRemediationSpecHash: "sha256:aaa",
 				},
 				{
@@ -381,7 +381,7 @@ var _ = Describe("Remediation History Prompt Builder — KA Parity (#433)", func
 			result := &enrichment.RemediationHistoryResult{
 				TargetResource: "default/Pod/web",
 				Tier1: []enrichment.Tier1Entry{
-					{RemediationUID: "wf-drift", AssessmentReason: "spec_drift", ActionType: "restart", Outcome: "Success", CompletedAt: time.Now()},
+					{RemediationUID: "wf-drift", AssessmentReason: "SpecDrift", ActionType: "restart", Outcome: "Success", CompletedAt: time.Now()},
 				},
 				Tier1Window: "24h",
 			}
@@ -454,6 +454,93 @@ var _ = Describe("Remediation History Prompt Builder — KA Parity (#433)", func
 				{ActionType: "scale_up", SignalType: "HighLatency", Outcome: "Inconclusive", EffectivenessScore: floatPtr(0.0), SignalResolved: boolPtr(false)},
 			}
 			Expect(prompt.AllZeroEffectiveness(entries, "scale_up", "HighLatency")).To(BeTrue())
+		})
+	})
+
+	// ========================================
+	// Issue #749: PascalCase AssessmentReason (BR-EM-749)
+	// ========================================
+
+	Describe("UT-KA-749-001: FormatTier1Entry recognizes PascalCase SpecDrift", func() {
+		It("should render INCONCLUSIVE (spec drift) for SpecDrift reason", func() {
+			entry := enrichment.Tier1Entry{
+				RemediationUID:   "wf-drift-001",
+				AssessmentReason: "SpecDrift",
+				ActionType:       "restart_pod",
+				Outcome:          "Success",
+				CompletedAt:      time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC),
+			}
+			output := prompt.FormatTier1Entry(entry, nil)
+			Expect(output).To(ContainSubstring("INCONCLUSIVE (spec drift)"))
+		})
+	})
+
+	Describe("UT-KA-749-002: DetectDecliningEffectiveness skips SpecDrift", func() {
+		It("should not count SpecDrift entries in declining effectiveness detection", func() {
+			chain := []enrichment.Tier1Entry{
+				{ActionType: "restart_pod", EffectivenessScore: floatPtr(0.8)},
+				{ActionType: "restart_pod", EffectivenessScore: floatPtr(0.0), AssessmentReason: "SpecDrift"},
+				{ActionType: "restart_pod", EffectivenessScore: floatPtr(0.9)},
+			}
+			declining := prompt.DetectDecliningEffectiveness(chain)
+			Expect(declining).To(BeEmpty(), "SpecDrift entries must be excluded from declining detection")
+		})
+	})
+
+	Describe("UT-KA-749-003: DetectCompletedButRecurring skips SpecDrift", func() {
+		It("should not count SpecDrift entries as recurring", func() {
+			entries := []prompt.HistoryEntry{
+				{ActionType: "restart_pod", SignalType: "OOMKilled", Outcome: "Success"},
+				{ActionType: "restart_pod", SignalType: "OOMKilled", Outcome: "Success", AssessmentReason: "SpecDrift"},
+			}
+			recurring := prompt.DetectCompletedButRecurring(entries, 2)
+			Expect(recurring).To(BeEmpty(), "SpecDrift entries must be excluded from recurring detection")
+		})
+	})
+
+	Describe("UT-KA-749-004: AllZeroEffectiveness skips SpecDrift", func() {
+		It("should not count SpecDrift entries in zero-effectiveness check", func() {
+			entries := []prompt.HistoryEntry{
+				{ActionType: "restart_pod", SignalType: "OOMKilled", Outcome: "Success", EffectivenessScore: floatPtr(0.0), SignalResolved: boolPtr(false)},
+				{ActionType: "restart_pod", SignalType: "OOMKilled", Outcome: "Success", EffectivenessScore: floatPtr(0.0), AssessmentReason: "SpecDrift"},
+			}
+			result := prompt.AllZeroEffectiveness(entries, "restart_pod", "OOMKilled")
+			Expect(result).To(BeTrue(), "SpecDrift entries must be excluded; remaining entry has zero effectiveness")
+		})
+	})
+
+	Describe("UT-KA-749-005: DetectSpecDriftCausalChains matches SpecDrift", func() {
+		It("should detect causal chain with PascalCase SpecDrift", func() {
+			chain := []enrichment.Tier1Entry{
+				{
+					RemediationUID:          "wf-drift-001",
+					AssessmentReason:        "SpecDrift",
+					PostRemediationSpecHash: "sha256:aaa",
+				},
+				{
+					RemediationUID:          "wf-followup-001",
+					PreRemediationSpecHash:  "sha256:aaa",
+					PostRemediationSpecHash: "sha256:bbb",
+				},
+			}
+			causalChains := prompt.DetectSpecDriftCausalChains(chain)
+			Expect(causalChains).To(HaveKey("wf-drift-001"))
+			Expect(causalChains["wf-drift-001"]).To(Equal("wf-followup-001"))
+		})
+	})
+
+	Describe("UT-KA-749-006: BuildRemediationHistorySection HasSpecDrift for PascalCase", func() {
+		It("should set HasSpecDrift=true for PascalCase SpecDrift entries", func() {
+			result := &enrichment.RemediationHistoryResult{
+				TargetResource: "default/Pod/web",
+				Tier1: []enrichment.Tier1Entry{
+					{RemediationUID: "wf-drift", AssessmentReason: "SpecDrift", ActionType: "restart", Outcome: "Success", CompletedAt: time.Now()},
+				},
+				Tier1Window: "24h",
+			}
+			output := prompt.BuildRemediationHistorySection(result, 2)
+			Expect(output).To(ContainSubstring("Note on spec drift entries"),
+				"PascalCase SpecDrift must trigger the spec drift note in the rendered section")
 		})
 	})
 })

--- a/test/unit/notification/notification_context_test.go
+++ b/test/unit/notification/notification_context_test.go
@@ -332,14 +332,14 @@ var _ = Describe("Issue #453 Phase B: Metadata Decomposition", func() {
 				Verification: &notificationv1.VerificationContext{
 					Assessed: true,
 					Outcome:  "inconclusive",
-					Reason:   "spec_drift",
+					Reason:   "SpecDrift",
 					Summary:  "Verification inconclusive: the resource spec was modified by an external entity after remediation.",
 				},
 			}
 			result := ctx.FlattenToMap()
 			Expect(result).To(HaveKeyWithValue("verificationAssessed", "true"))
 			Expect(result).To(HaveKeyWithValue("verificationOutcome", "inconclusive"))
-			Expect(result).To(HaveKeyWithValue("verificationReason", "spec_drift"))
+			Expect(result).To(HaveKeyWithValue("verificationReason", "SpecDrift"))
 		})
 	})
 

--- a/test/unit/remediationorchestrator/controller/effectiveness_tracking_test.go
+++ b/test/unit/remediationorchestrator/controller/effectiveness_tracking_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Effectiveness Assessment Tracking (ADR-EM-001, GAP-RO-2)", fun
 		Expect(cond).ToNot(BeNil(), "EffectivenessAssessed condition should be set")
 		Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 		Expect(cond.Reason).To(Equal("AssessmentCompleted"))
-		Expect(cond.Message).To(ContainSubstring("full"))
+		Expect(cond.Message).To(ContainSubstring("Full"))
 	})
 
 	// ========================================
@@ -285,7 +285,7 @@ var _ = Describe("Effectiveness Assessment Tracking (ADR-EM-001, GAP-RO-2)", fun
 		Expect(fakeClient.Get(ctx, types.NamespacedName{Name: rrName, Namespace: namespace}, fetchedRR)).To(Succeed())
 
 		cond := meta.FindStatusCondition(fetchedRR.Status.Conditions, "EffectivenessAssessed")
-		Expect(cond).ToNot(BeNil())
+		Expect(cond).NotTo(BeNil(), "EffectivenessAssessed condition must exist to verify idempotency")
 		Expect(cond.Message).To(Equal("Already set"), "Condition should not be overwritten")
 	})
 
@@ -337,6 +337,6 @@ var _ = Describe("Effectiveness Assessment Tracking (ADR-EM-001, GAP-RO-2)", fun
 			"Expired is still a completed assessment (Status=True)")
 		Expect(cond.Reason).To(Equal("AssessmentExpired"),
 			"ADR-EM-001: expired EAs must use Reason=AssessmentExpired, not AssessmentCompleted")
-		Expect(cond.Message).To(ContainSubstring("expired"))
+		Expect(cond.Message).To(ContainSubstring("Expired"))
 	})
 })

--- a/test/unit/remediationorchestrator/controller/notification_retry_test.go
+++ b/test/unit/remediationorchestrator/controller/notification_retry_test.go
@@ -646,7 +646,7 @@ var _ = Describe("Completion Notification Verification Context (#318)", func() {
 
 		Expect(nr.Spec.Context.Verification.Assessed).To(BeTrue())
 		Expect(nr.Spec.Context.Verification.Outcome).To(Equal("passed"))
-		Expect(nr.Spec.Context.Verification.Reason).To(Equal("full"))
+		Expect(nr.Spec.Context.Verification.Reason).To(Equal("Full"))
 	})
 
 	// ========================================

--- a/test/unit/remediationorchestrator/controller/verifying_phase_test.go
+++ b/test/unit/remediationorchestrator/controller/verifying_phase_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Verifying Phase Transition (#280)", func() {
 			Status: eav1.EffectivenessAssessmentStatus{
 				Phase:            eav1.PhaseCompleted,
 				AssessmentReason: eav1.AssessmentReasonFull,
-				Message:          "Assessment completed: full",
+				Message:          "Assessment completed: Full",
 			},
 		}
 

--- a/test/unit/remediationorchestrator/notification_creator_test.go
+++ b/test/unit/remediationorchestrator/notification_creator_test.go
@@ -1663,7 +1663,7 @@ var _ = Describe("NotificationCreator", func() {
 
 				Expect(nr.Spec.Context.Verification.Assessed).To(BeTrue())
 				Expect(nr.Spec.Context.Verification.Outcome).To(Equal("inconclusive"))
-				Expect(nr.Spec.Context.Verification.Reason).To(Equal("spec_drift"))
+				Expect(nr.Spec.Context.Verification.Reason).To(Equal("SpecDrift"))
 				Expect(nr.Spec.Context.Verification.Summary).To(ContainSubstring("modified by an external entity"))
 			})
 		})

--- a/test/unit/remediationorchestrator/verification_summary_test.go
+++ b/test/unit/remediationorchestrator/verification_summary_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Verification Summary Builder (#318)", func() {
 			Expect(summary).To(ContainSubstring("Verification passed"))
 			Expect(vCtx.Assessed).To(BeTrue())
 			Expect(vCtx.Outcome).To(Equal("passed"))
-			Expect(vCtx.Reason).To(Equal("full"))
+			Expect(vCtx.Reason).To(Equal("Full"))
 		})
 	})
 
@@ -76,7 +76,7 @@ var _ = Describe("Verification Summary Builder (#318)", func() {
 			Expect(summary).To(ContainSubstring("modified by an external entity"))
 			Expect(vCtx.Assessed).To(BeTrue())
 			Expect(vCtx.Outcome).To(Equal("inconclusive"))
-			Expect(vCtx.Reason).To(Equal("spec_drift"))
+			Expect(vCtx.Reason).To(Equal("SpecDrift"))
 
 			bullets := creator.BuildComponentBullets(ea)
 			Expect(bullets).To(ContainSubstring("Resource integrity: spec modified externally after remediation"))
@@ -120,7 +120,7 @@ var _ = Describe("Verification Summary Builder (#318)", func() {
 			summary, vCtx := creator.BuildVerificationSummary(ea, nil)
 			Expect(summary).To(ContainSubstring("related alerts persisted beyond the assessment window"))
 			Expect(vCtx.Outcome).To(Equal("inconclusive"))
-			Expect(vCtx.Reason).To(Equal("alert_decay_timeout"))
+			Expect(vCtx.Reason).To(Equal("AlertDecayTimeout"))
 		})
 	})
 
@@ -135,7 +135,7 @@ var _ = Describe("Verification Summary Builder (#318)", func() {
 			summary, vCtx := creator.BuildVerificationSummary(ea, nil)
 			Expect(summary).To(ContainSubstring("metrics were not available"))
 			Expect(vCtx.Outcome).To(Equal("partial"))
-			Expect(vCtx.Reason).To(Equal("metrics_timed_out"))
+			Expect(vCtx.Reason).To(Equal("MetricsTimedOut"))
 		})
 	})
 
@@ -150,7 +150,7 @@ var _ = Describe("Verification Summary Builder (#318)", func() {
 			summary, vCtx := creator.BuildVerificationSummary(ea, nil)
 			Expect(summary).To(ContainSubstring("assessment window expired"))
 			Expect(vCtx.Outcome).To(Equal("unavailable"))
-			Expect(vCtx.Reason).To(Equal("expired"))
+			Expect(vCtx.Reason).To(Equal("Expired"))
 		})
 	})
 
@@ -165,7 +165,7 @@ var _ = Describe("Verification Summary Builder (#318)", func() {
 			summary, vCtx := creator.BuildVerificationSummary(ea, nil)
 			Expect(summary).To(ContainSubstring("no workflow execution was found"))
 			Expect(vCtx.Outcome).To(Equal("unavailable"))
-			Expect(vCtx.Reason).To(Equal("no_execution"))
+			Expect(vCtx.Reason).To(Equal("NoExecution"))
 		})
 	})
 
@@ -487,7 +487,7 @@ var _ = Describe("Verification Summary Builder (#318)", func() {
 			Expect(summary).To(ContainSubstring("Related alerts: still firing"))
 			Expect(summary).To(ContainSubstring("Metrics: partial improvement (score: 0.50)"))
 			Expect(vCtx.Outcome).To(Equal("completed"))
-			Expect(vCtx.Reason).To(Equal("full"))
+			Expect(vCtx.Reason).To(Equal("Full"))
 			Expect(vCtx.Summary).To(ContainSubstring("all checks were performed"))
 			Expect(vCtx.Summary).NotTo(ContainSubstring("Verification passed"))
 		})
@@ -546,7 +546,7 @@ var _ = Describe("Verification Summary Builder (#318)", func() {
 			Expect(summary).To(ContainSubstring("Metrics: no improvement detected"))
 			Expect(summary).NotTo(ContainSubstring("Pod health"))
 			Expect(vCtx.Outcome).To(Equal("completed"))
-			Expect(vCtx.Reason).To(Equal("full"))
+			Expect(vCtx.Reason).To(Equal("Full"))
 		})
 	})
 


### PR DESCRIPTION
## Summary

- **#749**: Rename all `AssessmentReason` constants from snake_case to PascalCase (Kubernetes API convention). Updates CRD types, OpenAPI spec, ogen client, and 113 string literals across 29 test files.
- **Audit flush**: Raise TIMER BUG drift threshold from 2x to 5x and demote noisy `Info` logs to `V(1)`. Fix Helm ConfigMap `flush_interval_seconds` from 0.1s to 1.0s.
- **#750**: Wire `sharedtls.DefaultBaseTransport()` in `agentclient` (F-1) and `authwebhook` DSClientAdapter (F-2). Add `TLS_CA_FILE` env, `tls-ca` volume mount, and `inter-service-ca` ConfigMap to AuthWebhook Helm template (F-3). Remove dead `NewInterServiceClient` function.

## Changes

### Issue #749 — EM AssessmentReason PascalCase
- `api/effectivenessassessment/v1alpha1/effectivenessassessment_types.go`: Rename 7 constants + add `AssessmentReasonUnrecoverable`
- `internal/controller/effectivenessmonitor/completion.go`: Use constant instead of hardcoded string
- `internal/kubernautagent/prompt/history.go`: Replace `"spec_drift"` with `eav1.AssessmentReasonSpecDrift`
- `pkg/datastorage/server/effectiveness_handler.go`: Replace `"spec_drift"` with constant
- `api/openapi/data-storage-v1.yaml`: Update 3 enum blocks to PascalCase
- `config/crd/bases/kubernaut.ai_effectivenessassessments.yaml`: Regenerated via `make manifests`
- `pkg/datastorage/ogen-client/`: Regenerated via `make generate-datastorage-client`
- 29 test files: Update 113 string literal assertions

### Audit flush config
- `pkg/audit/store.go`: Raise drift threshold 2x→5x, demote 3 logs to `V(1)`
- `charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml`: Fix `flush_interval_seconds` 0.1→1.0

### Issue #750 — Inter-service TLS client trust
- `pkg/agentclient/client.go`: Replace `http.DefaultTransport` with `sharedtls.DefaultBaseTransport()`
- `pkg/authwebhook/ds_client.go`: Replace plain `http.Transport{}` with `sharedtls.DefaultBaseTransport()`
- `charts/kubernaut/templates/authwebhook/authwebhook.yaml`: Add TLS_CA_FILE env, tls-ca volume mount, inter-service-ca ConfigMap
- `pkg/shared/tls/tls.go`: Remove unused `NewInterServiceClient`
- 6 new unit tests (UT-AC-750-001..003, UT-AW-750-001..003)

## Test plan

- [x] `docs/tests/749/TEST_PLAN.md` — IEEE 829 test plan for #749
- [x] `docs/tests/750/TEST_PLAN.md` — IEEE 829 test plan for #750
- [x] All new unit tests pass
- [x] Full regression: `test/unit/aianalysis`, `test/unit/authwebhook`, `test/unit/shared/tls` — all green
- [x] `go build ./...` clean
- [x] Helm template validated with `tls.interService.enabled=true` and default

Closes #749
Closes #750

Made with [Cursor](https://cursor.com)