### PR TITLE
fix(#752): prevent LLM context window overflow from oversized tool outputs

### DIFF
--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -199,10 +199,11 @@ func main() {
 		Registry:     reg,
 		ModelName:    cfg.LLM.Model,
 		Pipeline: investigator.Pipeline{
-			Sanitizer:       sanitizer,
-			AnomalyDetector: anomalyDetector,
-			CatalogFetcher:  catalogFetcher,
-			Summarizer:      sum,
+			Sanitizer:         sanitizer,
+			AnomalyDetector:   anomalyDetector,
+			CatalogFetcher:    catalogFetcher,
+			Summarizer:        sum,
+			MaxToolOutputSize: cfg.Summarizer.MaxToolOutputSize,
 		},
 	})
 
@@ -588,10 +589,18 @@ func buildAuditStore(cfg *kaconfig.Config, slogger *slog.Logger, logrLog logr.Lo
 }
 
 // buildSummarizer creates a tool output summarizer when the threshold is positive.
+// When MaxToolOutputSize is configured, it enables pre-truncation to prevent
+// the summarizer's own LLM call from exceeding context window limits (#752).
 func buildSummarizer(llmClient llm.Client, cfg *kaconfig.Config, logger *slog.Logger) *summarizer.Summarizer {
 	if cfg.Summarizer.Threshold <= 0 {
 		logger.Info("summarizer disabled (threshold <= 0)")
 		return nil
+	}
+	if cfg.Summarizer.MaxToolOutputSize > 0 {
+		logger.Info("summarizer enabled with pre-truncation",
+			"threshold", cfg.Summarizer.Threshold,
+			"max_tool_output_size", cfg.Summarizer.MaxToolOutputSize)
+		return summarizer.NewWithMaxInput(llmClient, cfg.Summarizer.Threshold, cfg.Summarizer.MaxToolOutputSize)
 	}
 	logger.Info("summarizer enabled", "threshold", cfg.Summarizer.Threshold)
 	return summarizer.New(llmClient, cfg.Summarizer.Threshold)

--- a/docs/tests/752/TEST_PLAN.md
+++ b/docs/tests/752/TEST_PLAN.md
@@ -1,0 +1,442 @@
+# Test Plan: Tool Output Truncation Safety Net — Context Window Overflow Prevention
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+>
+> Based on IEEE 829-2008 (Standard for Software and System Test Documentation) with
+> Kubernaut-specific extensions for TDD phase tracking, business requirement traceability,
+> and per-tier coverage policy.
+
+**Test Plan Identifier**: TP-752-v1
+**Feature**: Prevent LLM context window overflow from oversized tool outputs
+**Version**: 1.0
+**Created**: 2026-04-06
+**Author**: AI Assistant
+**Status**: Draft
+**Branch**: `fix/752-kubectl-context-window-overflow`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Issue #752 reports that `kubectl_get_by_kind_in_cluster` returned 3.4 MB of Secret data, overwhelming both the summarizer's secondary LLM call and the main investigation LLM's context window. This test plan validates three mitigations: (1) a hard truncation safety net in the investigator pipeline, (2) pre-truncation of oversized input before the summarizer's LLM call, and (3) a new targeted tool `kubectl_get_by_name_in_cluster` that lets the LLM fetch a single resource across namespaces without listing everything.
+
+### 1.2 Objectives
+
+1. **Hard truncation safety net**: Tool outputs exceeding `MaxToolOutputSize` (default 100,000 chars) are truncated with a guidance hint before entering the LLM conversation
+2. **Summarizer pre-truncation**: Inputs to the summarizer's secondary LLM call are pre-truncated so the summarizer can produce useful summaries instead of failing
+3. **Targeted lookup tool**: `kubectl_get_by_name_in_cluster` returns a single resource by name across all namespaces, eliminating the need to list all resources of a kind
+4. **Zero regressions**: Existing summarizer, investigator, and K8s tool tests continue to pass
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/kubernautagent/...` |
+| Integration test pass rate | 100% | `go test ./test/integration/kubernautagent/...` |
+| Unit-testable code coverage | >=80% | `go test -coverprofile` on unit-testable files |
+| Backward compatibility | 0 regressions | Existing tests pass without modification |
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- BR-SAFETY-752: Tool output must not exceed LLM context window capacity
+- Issue #752: `kubectl_get_by_kind_in_cluster` returned 3.4 MB, overwhelming summarizer and LLM
+- DD-HAPI-019-002: llm_summarize transformer design
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../.cursor/rules/03-testing-strategy.mdc)
+- [Testing Guidelines](../development/business-requirements/TESTING_GUIDELINES.md)
+- Existing summarizer tests: `test/unit/kubernautagent/tools/summarizer/summarizer_test.go`
+- Existing K8s tools tests: `test/unit/kubernautagent/tools/k8s/kind_resolution_test.go`
+- Prometheus `TruncateWithHint` pattern: `pkg/kubernautagent/tools/prometheus/tools.go`
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | Truncation removes critical diagnostic data | LLM misses root cause | Medium | UT-KA-752-001,002 | Truncation message guides LLM to use targeted tools; hint includes char count |
+| R2 | Summarizer pre-truncation produces poor summaries | Degraded investigation quality | Low | UT-KA-752-003,004 | Pre-truncated input still 100K chars — ample for summary extraction |
+| R3 | New tool `kubectl_get_by_name_in_cluster` returns empty for nonexistent resource | LLM confusion | Low | UT-KA-752-007,008 | Returns clear "not found" error matching existing tool patterns |
+| R4 | MaxToolOutputSize config not loaded from YAML | Default silently used | Low | UT-KA-752-010 | Config test validates YAML parsing and default application |
+| R5 | Summarizer failure + truncation double-truncates | Data loss | Low | IT-KA-752-001 | Truncation in executeTool is a final safety net, applied once after summarizer |
+
+### 3.1 Risk-to-Test Traceability
+
+- **R1** (critical data loss): UT-KA-752-001 verifies truncation message includes guidance; UT-KA-752-002 verifies below-limit output passes through unchanged
+- **R2** (poor summaries): UT-KA-752-003 verifies summarizer pre-truncates before LLM call; UT-KA-752-004 verifies summarizer still works for moderate-size inputs
+- **R3** (empty results): UT-KA-752-007 verifies single-match return; UT-KA-752-008 verifies not-found behavior
+- **R5** (double truncation): IT-KA-752-001 verifies end-to-end pipeline with oversized tool output
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **Summarizer pre-truncation** (`pkg/kubernautagent/tools/summarizer/summarizer.go`): `MaybeSummarize` pre-truncates input exceeding `maxInputSize` before secondary LLM call
+- **Hard truncation safety net** (`internal/kubernautagent/investigator/investigator.go`): `executeTool` truncates final result exceeding `MaxToolOutputSize`
+- **New tool** (`pkg/kubernautagent/tools/k8s/tools.go`): `kubectl_get_by_name_in_cluster` fetches a single resource by name across all namespaces
+- **Configuration** (`internal/kubernautagent/config/config.go`): `MaxToolOutputSize` field in `SummarizerConfig`
+
+### 4.2 Features Not to be Tested
+
+- **Blocklist of high-volume kinds** (Mitigation 4): Deferred per user decision
+- **E2E tests**: No Kind cluster changes needed; truncation is internal pipeline behavior
+- **Audit store changes**: No audit schema changes
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Hard cap at 100,000 chars (default) | ~25K tokens, well within any production LLM context window |
+| Truncation hint guides LLM to targeted tools | Prevents repeated oversized fetches; follows Prometheus `TruncateWithHint` pattern |
+| Pre-truncation in summarizer uses same limit | Ensures summarizer LLM call stays within context window |
+| New tool reuses `ResourceResolver.List` + name filter | Avoids adding new interface methods; consistent with `kubectl_find_resource` pattern |
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+- **Unit**: >=80% of unit-testable code (summarizer truncation, K8s tool, config parsing)
+- **Integration**: >=80% of integration-testable code (investigator pipeline with truncation)
+- **E2E**: Not applicable (internal pipeline behavior, no external API changes)
+
+### 5.2 Two-Tier Minimum
+
+Every business requirement is covered by at least 2 test tiers:
+- **Unit tests**: Validate truncation logic, summarizer pre-truncation, new tool behavior, config parsing
+- **Integration tests**: Validate end-to-end investigator pipeline with oversized tool outputs
+
+### 5.3 Business Outcome Quality Bar
+
+Tests validate business outcomes:
+- "Operator sees investigation complete (not hang/crash) even when a tool returns multi-MB output"
+- "LLM receives actionable truncation guidance instead of raw overflow"
+- "LLM can fetch a specific resource by name without listing all resources of that kind"
+
+### 5.4 Pass/Fail Criteria
+
+**PASS** — all of the following must be true:
+1. All P0 tests pass (0 failures)
+2. All P1 tests pass
+3. Per-tier code coverage meets >=80% threshold
+4. No regressions in existing test suites
+5. `go build ./...` succeeds with zero errors
+
+**FAIL** — any of the following:
+1. Any P0 test fails
+2. Per-tier coverage falls below 80% on any tier
+3. Existing tests regress
+
+### 5.5 Suspension & Resumption Criteria
+
+**Suspend testing when**:
+- Build broken: Code does not compile
+- Summarizer LLM mock interface changes upstream
+
+**Resume testing when**:
+- Build fixed and green on CI
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code (pure logic, no I/O)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `pkg/kubernautagent/tools/summarizer/summarizer.go` | `MaybeSummarize` (pre-truncation) | ~30 |
+| `pkg/kubernautagent/tools/k8s/tools.go` | `newGetByNameInCluster`, `Execute` | ~30 |
+| `internal/kubernautagent/config/config.go` | `SummarizerConfig.MaxToolOutputSize`, `DefaultConfig` | ~10 |
+
+### 6.2 Integration-Testable Code (I/O, wiring, cross-component)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `internal/kubernautagent/investigator/investigator.go` | `executeTool` (hard truncation safety net) | ~20 |
+
+### 6.3 Version Identification
+
+| Item | Version/Commit | Notes |
+|------|----------------|-------|
+| Code under test | `fix/752-kubectl-context-window-overflow` HEAD | Branch |
+
+---
+
+## 7. BR Coverage Matrix
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-SAFETY-752 | Hard truncation prevents context overflow | P0 | Unit | UT-KA-752-001 | Pending |
+| BR-SAFETY-752 | Below-limit output passes through unchanged | P0 | Unit | UT-KA-752-002 | Pending |
+| BR-SAFETY-752 | Summarizer pre-truncates before LLM call | P0 | Unit | UT-KA-752-003 | Pending |
+| BR-SAFETY-752 | Summarizer works normally for moderate inputs | P0 | Unit | UT-KA-752-004 | Pending |
+| BR-SAFETY-752 | Truncation hint includes output size and guidance | P1 | Unit | UT-KA-752-005 | Pending |
+| BR-SAFETY-752 | Summarizer pre-truncation note included in prompt | P1 | Unit | UT-KA-752-006 | Pending |
+| BR-SAFETY-752 | New tool returns single resource by name across namespaces | P0 | Unit | UT-KA-752-007 | Pending |
+| BR-SAFETY-752 | New tool returns error for nonexistent resource | P0 | Unit | UT-KA-752-008 | Pending |
+| BR-SAFETY-752 | New tool registered in AllToolNames and phase map | P0 | Unit | UT-KA-752-009 | Pending |
+| BR-SAFETY-752 | MaxToolOutputSize parsed from YAML config | P1 | Unit | UT-KA-752-010 | Pending |
+| BR-SAFETY-752 | MaxToolOutputSize default applied when absent | P1 | Unit | UT-KA-752-011 | Pending |
+| BR-SAFETY-752 | Pipeline truncation with oversized tool output end-to-end | P0 | Integration | IT-KA-752-001 | Pending |
+| BR-SAFETY-752 | Pipeline passes through normal-size tool output end-to-end | P0 | Integration | IT-KA-752-002 | Pending |
+| BR-SAFETY-752 | Summarizer failure + hard truncation fallback | P0 | Integration | IT-KA-752-003 | Pending |
+
+---
+
+## 8. Test Scenarios
+
+### Test ID Naming Convention
+
+Format: `{TIER}-KA-752-{SEQUENCE}`
+- **TIER**: `UT` (Unit), `IT` (Integration)
+- **KA**: Kubernaut Agent
+- **752**: Issue number
+
+### Tier 1: Unit Tests
+
+**Testable code scope**: `pkg/kubernautagent/tools/summarizer/`, `pkg/kubernautagent/tools/k8s/`, `internal/kubernautagent/config/`
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-KA-752-001` | Tool output exceeding MaxToolOutputSize is truncated with guidance hint | Pending |
+| `UT-KA-752-002` | Tool output at or below MaxToolOutputSize passes through unchanged | Pending |
+| `UT-KA-752-003` | Summarizer pre-truncates input exceeding MaxToolOutputSize before LLM call | Pending |
+| `UT-KA-752-004` | Summarizer works normally for inputs between threshold and MaxToolOutputSize | Pending |
+| `UT-KA-752-005` | Truncation hint includes original output size and tool name | Pending |
+| `UT-KA-752-006` | Summarizer pre-truncation note mentions truncation in prompt | Pending |
+| `UT-KA-752-007` | `kubectl_get_by_name_in_cluster` returns single matching resource | Pending |
+| `UT-KA-752-008` | `kubectl_get_by_name_in_cluster` returns error when resource not found | Pending |
+| `UT-KA-752-009` | New tool registered in AllToolNames and available in RCA phase | Pending |
+| `UT-KA-752-010` | MaxToolOutputSize parsed correctly from YAML configuration | Pending |
+| `UT-KA-752-011` | MaxToolOutputSize defaults to 100000 when not specified in config | Pending |
+
+### Tier 2: Integration Tests
+
+**Testable code scope**: `internal/kubernautagent/investigator/`
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `IT-KA-752-001` | Investigator pipeline truncates oversized tool output before LLM receives it | Pending |
+| `IT-KA-752-002` | Investigator pipeline passes normal-size tool output unchanged | Pending |
+| `IT-KA-752-003` | When summarizer fails, hard truncation safety net still protects context window | Pending |
+
+### Tier Skip Rationale
+
+- **E2E**: Truncation is internal pipeline behavior with no external API surface changes. Integration tests with real pipeline wiring provide sufficient coverage.
+
+---
+
+## 9. Test Cases
+
+### UT-KA-752-001: Hard truncation applied to oversized output
+
+**BR**: BR-SAFETY-752
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/tools/summarizer/truncation_test.go`
+
+**Preconditions**:
+- `TruncateToolOutput` function available with configurable limit
+
+**Test Steps**:
+1. **Given**: A tool output string of 200,000 characters and a limit of 100,000
+2. **When**: `TruncateToolOutput` is called
+3. **Then**: Result is <= 100,000 chars + hint suffix length; result ends with truncation guidance
+
+**Expected Results**:
+1. Output truncated to limit
+2. Truncation hint appended with tool name and original size
+
+### UT-KA-752-002: Below-limit output passes through unchanged
+
+**BR**: BR-SAFETY-752
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/tools/summarizer/truncation_test.go`
+
+**Preconditions**:
+- `TruncateToolOutput` function available
+
+**Test Steps**:
+1. **Given**: A tool output string of 500 characters and a limit of 100,000
+2. **When**: `TruncateToolOutput` is called
+3. **Then**: Result is identical to input
+
+### UT-KA-752-003: Summarizer pre-truncates before LLM call
+
+**BR**: BR-SAFETY-752
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/tools/summarizer/summarizer_test.go`
+
+**Preconditions**:
+- Summarizer created with threshold=100 and maxInputSize=500
+- Fake LLM client records calls
+
+**Test Steps**:
+1. **Given**: Tool output of 1000 characters (exceeds both threshold and maxInputSize)
+2. **When**: `MaybeSummarize` is called
+3. **Then**: The LLM receives a prompt whose tool output portion is <= 500 characters
+
+### UT-KA-752-004: Summarizer works for moderate inputs
+
+**BR**: BR-SAFETY-752
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/tools/summarizer/summarizer_test.go`
+
+**Preconditions**:
+- Summarizer with threshold=100 and maxInputSize=5000
+
+**Test Steps**:
+1. **Given**: Tool output of 300 characters (exceeds threshold but below maxInputSize)
+2. **When**: `MaybeSummarize` is called
+3. **Then**: Full output is sent to LLM (no pre-truncation)
+
+### UT-KA-752-007: New tool returns single matching resource
+
+**BR**: BR-SAFETY-752
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/tools/k8s/kind_resolution_test.go`
+
+**Preconditions**:
+- Fake K8s cluster with 3 Pods in different namespaces; one named "api-server"
+
+**Test Steps**:
+1. **Given**: Registry with `kubectl_get_by_name_in_cluster` tool registered
+2. **When**: Execute with `{"kind":"Pod","name":"api-server"}`
+3. **Then**: Returns JSON for exactly one Pod named "api-server"
+
+### UT-KA-752-008: New tool returns error for nonexistent resource
+
+**BR**: BR-SAFETY-752
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/tools/k8s/kind_resolution_test.go`
+
+**Preconditions**:
+- Fake K8s cluster with no Pod named "nonexistent"
+
+**Test Steps**:
+1. **Given**: Registry with `kubectl_get_by_name_in_cluster` tool registered
+2. **When**: Execute with `{"kind":"Pod","name":"nonexistent"}`
+3. **Then**: Returns error or empty result indicating resource not found
+
+### IT-KA-752-001: Pipeline truncation with oversized tool output
+
+**BR**: BR-SAFETY-752
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/investigator/investigator_truncation_test.go`
+
+**Preconditions**:
+- Investigator with real pipeline (summarizer + truncation), fake tool returning 200K chars
+
+**Test Steps**:
+1. **Given**: Investigator configured with MaxToolOutputSize=1000
+2. **When**: Tool returns 200,000 character output
+3. **Then**: The tool result message in the LLM conversation is <= 1000 chars + hint
+
+---
+
+## 10. Environmental Needs
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: Fake LLM client (existing `fakeLLM` pattern), fake K8s dynamic client
+- **Location**: `test/unit/kubernautagent/tools/summarizer/`, `test/unit/kubernautagent/tools/k8s/`
+
+### 10.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: ZERO mocks — uses real Investigator with fake K8s client and fake LLM
+- **Location**: `test/integration/kubernautagent/investigator/`
+
+### 10.4 Tools & Versions
+
+| Tool | Minimum Version | Purpose |
+|------|-----------------|---------|
+| Go | 1.23 | Build and test |
+| Ginkgo CLI | v2.x | Test runner |
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Blocking Dependencies
+
+| Dependency | Type | Status | Impact if Not Available | Workaround |
+|------------|------|--------|-------------------------|------------|
+| None | — | — | — | — |
+
+### 11.2 Execution Order
+
+1. **Phase 1 (TDD RED)**: Write failing tests for truncation, summarizer pre-truncation, new tool, config
+2. **Phase 2 (TDD GREEN)**: Implement minimal code to pass all tests
+3. **Phase 3 (Checkpoint 1)**: Comprehensive adversarial and security audit
+4. **Phase 4 (TDD REFACTOR)**: Extract constants, improve hints, ensure consistency
+5. **Phase 5 (Final Checkpoint)**: Build, lint, full test pass
+
+---
+
+## 12. Test Deliverables
+
+| Deliverable | Location | Description |
+|-------------|----------|-------------|
+| This test plan | `docs/tests/752/TEST_PLAN.md` | Strategy and test design |
+| Truncation unit tests | `test/unit/kubernautagent/tools/summarizer/truncation_test.go` | Truncation logic tests |
+| Summarizer pre-truncation tests | `test/unit/kubernautagent/tools/summarizer/summarizer_test.go` | Extended summarizer tests |
+| New K8s tool unit tests | `test/unit/kubernautagent/tools/k8s/kind_resolution_test.go` | `kubectl_get_by_name_in_cluster` tests |
+| Config unit tests | `test/unit/kubernautagent/config/config_test.go` | MaxToolOutputSize config tests |
+| Integration tests | `test/integration/kubernautagent/investigator/investigator_truncation_test.go` | Pipeline truncation tests |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests
+go test ./test/unit/kubernautagent/tools/summarizer/... -ginkgo.v
+go test ./test/unit/kubernautagent/tools/k8s/... -ginkgo.v
+go test ./test/unit/kubernautagent/config/... -ginkgo.v
+
+# Integration tests
+go test ./test/integration/kubernautagent/investigator/... -ginkgo.v
+
+# Specific test by ID
+go test ./test/unit/kubernautagent/tools/summarizer/... -ginkgo.focus="UT-KA-752"
+go test ./test/unit/kubernautagent/tools/k8s/... -ginkgo.focus="UT-KA-752"
+
+# Coverage
+go test ./test/unit/kubernautagent/tools/summarizer/... -coverprofile=coverage.out
+go tool cover -func=coverage.out
+```
+
+---
+
+## 14. Existing Tests Requiring Updates
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|-------------------|-------------------|-----------------|--------|
+| None | — | — | All changes are additive; existing tests unaffected |
+
+---
+
+## 15. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-06 | Initial test plan |

--- a/internal/kubernautagent/config/config.go
+++ b/internal/kubernautagent/config/config.go
@@ -124,8 +124,13 @@ type SanitizationConfig struct {
 	CredentialScrubEnabled    bool `yaml:"credential_scrub_enabled"`
 }
 
+// DefaultMaxToolOutputSize is the default hard character limit for tool output
+// before it enters the LLM context window. ~25K tokens for most models.
+const DefaultMaxToolOutputSize = 100000
+
 type SummarizerConfig struct {
-	Threshold int `yaml:"threshold"`
+	Threshold         int `yaml:"threshold"`
+	MaxToolOutputSize int `yaml:"max_tool_output_size"`
 }
 
 // EnrichmentConfig controls retry behavior for K8s owner chain resolution
@@ -279,7 +284,8 @@ func DefaultConfig() *Config {
 			CredentialScrubEnabled:   true,
 		},
 		Summarizer: SummarizerConfig{
-			Threshold: 8000,
+			Threshold:         8000,
+			MaxToolOutputSize: DefaultMaxToolOutputSize,
 		},
 		Enrichment: EnrichmentConfig{
 			MaxRetries:  3,

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -52,10 +52,11 @@ type CatalogFetcher interface {
 // Investigator applies inside executeTool and runWorkflowSelection.
 // All fields may be nil; nil fields are skipped.
 type Pipeline struct {
-	Sanitizer       *sanitization.Pipeline
-	AnomalyDetector *AnomalyDetector
-	CatalogFetcher  CatalogFetcher
-	Summarizer      *summarizer.Summarizer
+	Sanitizer         *sanitization.Pipeline
+	AnomalyDetector   *AnomalyDetector
+	CatalogFetcher    CatalogFetcher
+	Summarizer        *summarizer.Summarizer
+	MaxToolOutputSize int
 }
 
 // Config holds all dependencies for constructing an Investigator.
@@ -625,6 +626,10 @@ func (inv *Investigator) executeTool(ctx context.Context, name string, args json
 		} else {
 			result = summarized
 		}
+	}
+
+	if inv.pipeline.MaxToolOutputSize > 0 {
+		result = summarizer.TruncateToolOutput(result, name, inv.pipeline.MaxToolOutputSize)
 	}
 
 	return result

--- a/internal/kubernautagent/investigator/types.go
+++ b/internal/kubernautagent/investigator/types.go
@@ -35,7 +35,8 @@ var resourceContextTools = []string{
 func DefaultPhaseToolMap() katypes.PhaseToolMap {
 	todo := investigation.ToolName
 
-	rca := make([]string, 0, len(k8s.AllToolNames)+len(k8s.MetricsToolNames)+1+len(prometheus.AllToolNames)+len(resourceContextTools)+1)
+	rcaCap := len(k8s.AllToolNames) + len(k8s.MetricsToolNames) + 1 + len(prometheus.AllToolNames) + len(resourceContextTools) + 1
+	rca := make([]string, 0, rcaCap)
 	rca = append(rca, k8s.AllToolNames...)
 	rca = append(rca, k8s.MetricsToolNames...)
 	rca = append(rca, logs.ToolName)

--- a/pkg/kubernautagent/tools/k8s/tools.go
+++ b/pkg/kubernautagent/tools/k8s/tools.go
@@ -34,6 +34,7 @@ import (
 var AllToolNames = []string{
 	"kubectl_describe",
 	"kubectl_get_by_name",
+	"kubectl_get_by_name_in_cluster",
 	"kubectl_get_by_kind_in_namespace",
 	"kubectl_get_by_kind_in_cluster",
 	"kubectl_find_resource",
@@ -60,6 +61,7 @@ func NewAllTools(client kubernetes.Interface, resolver ResourceResolver) []tools
 	result := []tools.Tool{
 		newDescribe(resolver),
 		newGetByName(resolver),
+		newGetByNameInCluster(resolver),
 		newGetByKindInNamespace(resolver),
 		newGetByKindInCluster(resolver),
 		newFindResource(resolver),
@@ -96,13 +98,14 @@ type logArgs struct {
 }
 
 var (
-	objParams         = json.RawMessage(`{"type":"object","properties":{"kind":{"type":"string"},"name":{"type":"string"},"namespace":{"type":"string"}},"required":["kind","name","namespace"]}`)
-	listParams        = json.RawMessage(`{"type":"object","properties":{"kind":{"type":"string"},"namespace":{"type":"string"}},"required":["kind","namespace"]}`)
-	clusterListParams = json.RawMessage(`{"type":"object","properties":{"kind":{"type":"string"}},"required":["kind"]}`)
-	findParams        = json.RawMessage(`{"type":"object","properties":{"kind":{"type":"string"},"keyword":{"type":"string","description":"Substring to match in resource name, namespace, or labels"}},"required":["kind","keyword"]}`)
-	nsOnlyParams      = json.RawMessage(`{"type":"object","properties":{"namespace":{"type":"string"}},"required":["namespace"]}`)
-	noParams          = json.RawMessage(`{"type":"object","properties":{}}`)
-	logParams         = json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"},"namespace":{"type":"string"},"container":{"type":"string"},"tailLines":{"type":"integer"},"limitBytes":{"type":"integer"},"pattern":{"type":"string"}},"required":["name","namespace"]}`)
+	objParams             = json.RawMessage(`{"type":"object","properties":{"kind":{"type":"string"},"name":{"type":"string"},"namespace":{"type":"string"}},"required":["kind","name","namespace"]}`)
+	clusterObjParams      = json.RawMessage(`{"type":"object","properties":{"kind":{"type":"string","description":"Kubernetes resource kind"},"name":{"type":"string","description":"Exact resource name to find across all namespaces"}},"required":["kind","name"]}`)
+	listParams            = json.RawMessage(`{"type":"object","properties":{"kind":{"type":"string"},"namespace":{"type":"string"}},"required":["kind","namespace"]}`)
+	clusterListParams     = json.RawMessage(`{"type":"object","properties":{"kind":{"type":"string"}},"required":["kind"]}`)
+	findParams            = json.RawMessage(`{"type":"object","properties":{"kind":{"type":"string"},"keyword":{"type":"string","description":"Substring to match in resource name, namespace, or labels"}},"required":["kind","keyword"]}`)
+	nsOnlyParams          = json.RawMessage(`{"type":"object","properties":{"namespace":{"type":"string"}},"required":["namespace"]}`)
+	noParams              = json.RawMessage(`{"type":"object","properties":{}}`)
+	logParams             = json.RawMessage(`{"type":"object","properties":{"name":{"type":"string"},"namespace":{"type":"string"},"container":{"type":"string"},"tailLines":{"type":"integer"},"limitBytes":{"type":"integer"},"pattern":{"type":"string"}},"required":["name","namespace"]}`)
 )
 
 // resourceTool is a shared base for tools that fetch K8s resources.
@@ -170,6 +173,62 @@ func newGetByKindInCluster(resolver ResourceResolver) *resourceTool {
 			return resolver.List(ctx, a.Kind, "")
 		},
 	}
+}
+
+// --- get by name in cluster tool (#752) ---
+
+type getByNameInClusterTool struct {
+	resolver ResourceResolver
+}
+
+func newGetByNameInCluster(resolver ResourceResolver) *getByNameInClusterTool {
+	return &getByNameInClusterTool{resolver: resolver}
+}
+
+func (t *getByNameInClusterTool) Name() string               { return "kubectl_get_by_name_in_cluster" }
+func (t *getByNameInClusterTool) Description() string {
+	return "Get a single Kubernetes resource by exact name across all namespaces (avoids listing all resources of a kind)"
+}
+func (t *getByNameInClusterTool) Parameters() json.RawMessage { return clusterObjParams }
+
+func (t *getByNameInClusterTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
+	var a struct {
+		Kind string `json:"kind"`
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal(args, &a); err != nil {
+		return "", fmt.Errorf("parsing args: %w", err)
+	}
+
+	resources, err := t.resolver.List(ctx, a.Kind, "")
+	if err != nil {
+		return "", err
+	}
+
+	data, _ := json.Marshal(resources)
+
+	var listObj struct {
+		Items []json.RawMessage `json:"items"`
+	}
+	if err := json.Unmarshal(data, &listObj); err != nil || listObj.Items == nil {
+		return "", fmt.Errorf("resource %q named %q not found in cluster", a.Kind, a.Name)
+	}
+
+	for _, item := range listObj.Items {
+		var meta struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+		}
+		if err := json.Unmarshal(item, &meta); err != nil {
+			continue
+		}
+		if meta.Metadata.Name == a.Name {
+			return string(item), nil
+		}
+	}
+
+	return "", fmt.Errorf("resource %q named %q not found in cluster", a.Kind, a.Name)
 }
 
 // --- find resource tool ---

--- a/pkg/kubernautagent/tools/summarizer/summarizer.go
+++ b/pkg/kubernautagent/tools/summarizer/summarizer.go
@@ -28,11 +28,13 @@ import (
 // Summarizer uses a secondary LLM call to shorten tool output that exceeds
 // a configurable threshold. Per DD-HAPI-019-002: llm_summarize transformer.
 type Summarizer struct {
-	llmClient llm.Client
-	threshold int
+	llmClient    llm.Client
+	threshold    int
+	maxInputSize int
 }
 
 // New creates a summarizer with the given LLM client and threshold.
+// maxInputSize defaults to 0 (no pre-truncation).
 func New(client llm.Client, threshold int) *Summarizer {
 	return &Summarizer{
 		llmClient: client,
@@ -40,18 +42,46 @@ func New(client llm.Client, threshold int) *Summarizer {
 	}
 }
 
+// NewWithMaxInput creates a summarizer that pre-truncates inputs exceeding
+// maxInputSize before sending them to the secondary LLM call. This prevents
+// the summarizer's own LLM from hitting context window limits (#752).
+func NewWithMaxInput(client llm.Client, threshold, maxInputSize int) *Summarizer {
+	return &Summarizer{
+		llmClient:    client,
+		threshold:    threshold,
+		maxInputSize: maxInputSize,
+	}
+}
+
 // MaybeSummarize returns the input unchanged if it is at or below the threshold.
 // If the input exceeds the threshold, it makes a secondary LLM call to produce
 // a shorter summary preserving key details for incident investigation.
+// When maxInputSize > 0 and the result exceeds it, the input is pre-truncated
+// before being sent to the LLM to prevent the summarizer itself from overflowing.
 func (s *Summarizer) MaybeSummarize(ctx context.Context, toolName string, result string) (string, error) {
 	if len(result) <= s.threshold {
 		return result, nil
 	}
 
-	prompt := fmt.Sprintf(
-		"Summarize the following %s output, preserving key details for incident investigation:\n\n%s",
-		toolName, result,
-	)
+	input := result
+	preTruncated := false
+	if s.maxInputSize > 0 && len(input) > s.maxInputSize {
+		input = input[:s.maxInputSize]
+		preTruncated = true
+	}
+
+	var prompt string
+	if preTruncated {
+		prompt = fmt.Sprintf(
+			"Summarize the following %s output [PRE-TRUNCATED from %d to %d chars], preserving key details for incident investigation:\n\n%s",
+			toolName, len(result), s.maxInputSize, input,
+		)
+	} else {
+		prompt = fmt.Sprintf(
+			"Summarize the following %s output, preserving key details for incident investigation:\n\n%s",
+			toolName, input,
+		)
+	}
 
 	resp, err := s.llmClient.Chat(ctx, llm.ChatRequest{
 		Messages: []llm.Message{
@@ -66,6 +96,20 @@ func (s *Summarizer) MaybeSummarize(ctx context.Context, toolName string, result
 	}
 
 	return resp.Message.Content, nil
+}
+
+// TruncateToolOutput applies a hard character limit to tool output, appending
+// a guidance hint when truncation occurs. This is the final safety net
+// preventing oversized output from entering the LLM context window (#752).
+func TruncateToolOutput(output, toolName string, limit int) string {
+	if len(output) <= limit {
+		return output
+	}
+	hint := fmt.Sprintf(
+		"\n... [TRUNCATED] %s output was %d chars (limit: %d). Use kubectl_get_by_name or kubectl_get_by_name_in_cluster to fetch specific resources instead of listing all.",
+		toolName, len(output), limit,
+	)
+	return output[:limit] + hint
 }
 
 // Wrap returns a tool that delegates to inner but applies MaybeSummarize

--- a/test/integration/kubernautagent/investigator/investigator_truncation_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_truncation_test.go
@@ -1,0 +1,187 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	katypes "github.com/jordigilh/kubernaut/internal/kubernautagent/types"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/registry"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/summarizer"
+)
+
+type alwaysFailLLM struct{}
+
+func (f *alwaysFailLLM) Chat(_ context.Context, _ llm.ChatRequest) (llm.ChatResponse, error) {
+	return llm.ChatResponse{}, errors.New("simulated context window overflow")
+}
+
+var _ = Describe("Kubernaut Agent Tool Output Truncation Pipeline — #752", func() {
+
+	var (
+		logger     *slog.Logger
+		auditStore *recordingAuditStore
+		builder    *prompt.Builder
+		rp         *parser.ResultParser
+		enricher   *enrichment.Enricher
+		phaseTools katypes.PhaseToolMap
+	)
+
+	BeforeEach(func() {
+		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		auditStore = &recordingAuditStore{}
+		builder, _ = prompt.NewBuilder()
+		rp = parser.NewResultParser()
+		k8sClient := &fakeK8sClient{ownerChain: []enrichment.OwnerChainEntry{}}
+		dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
+		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+		phaseTools = investigator.DefaultPhaseToolMap()
+	})
+
+	Describe("IT-KA-752-001: Pipeline truncates oversized tool output before LLM receives it", func() {
+		It("should truncate tool output exceeding MaxToolOutputSize", func() {
+			oversizedOutput := strings.Repeat("x", 200000)
+			reg := registry.New()
+			reg.Register(&fakeTool{name: "kubectl_get_by_kind_in_cluster", result: oversizedOutput})
+
+			investigationLLM := &mockLLMClient{
+				responses: []llm.ChatResponse{
+					{
+						Message:   llm.Message{Role: "assistant", Content: "investigating"},
+						ToolCalls: []llm.ToolCall{{ID: "tc_1", Name: "kubectl_get_by_kind_in_cluster", Arguments: `{"kind":"Secret"}`}},
+					},
+					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"done"}`}},
+					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.7}`}},
+				},
+			}
+
+			maxOutput := 1000
+			inv := investigator.New(investigator.Config{
+				Client: investigationLLM, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools, Registry: reg,
+				Pipeline: investigator.Pipeline{MaxToolOutputSize: maxOutput},
+			})
+			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
+				Name: "api", Namespace: "default", Severity: "warning", Message: "CrashLoop",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(investigationLLM.calls).To(HaveLen(3))
+			secondCall := investigationLLM.calls[1]
+			toolMsg := secondCall.Messages[len(secondCall.Messages)-1]
+			Expect(toolMsg.Role).To(Equal("tool"))
+			Expect(len(toolMsg.Content)).To(BeNumerically("<=", maxOutput+300),
+				fmt.Sprintf("tool output should be truncated to ~%d chars, got %d", maxOutput, len(toolMsg.Content)))
+			Expect(toolMsg.Content).To(ContainSubstring("[TRUNCATED]"),
+				"truncated output should contain truncation marker")
+		})
+	})
+
+	Describe("IT-KA-752-002: Pipeline passes normal-size tool output unchanged", func() {
+		It("should not truncate output below MaxToolOutputSize", func() {
+			normalOutput := strings.Repeat("y", 500)
+			reg := registry.New()
+			reg.Register(&fakeTool{name: "kubectl_describe", result: normalOutput})
+
+			investigationLLM := &mockLLMClient{
+				responses: []llm.ChatResponse{
+					{
+						Message:   llm.Message{Role: "assistant", Content: "checking"},
+						ToolCalls: []llm.ToolCall{{ID: "tc_1", Name: "kubectl_describe", Arguments: `{}`}},
+					},
+					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"done"}`}},
+					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.7}`}},
+				},
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: investigationLLM, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools, Registry: reg,
+				Pipeline: investigator.Pipeline{MaxToolOutputSize: 100000},
+			})
+			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
+				Name: "api", Namespace: "default", Severity: "warning", Message: "CrashLoop",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(investigationLLM.calls).To(HaveLen(3))
+			secondCall := investigationLLM.calls[1]
+			toolMsg := secondCall.Messages[len(secondCall.Messages)-1]
+			Expect(toolMsg.Content).To(Equal(normalOutput),
+				"normal-size output should pass through unchanged")
+		})
+	})
+
+	Describe("IT-KA-752-003: Summarizer failure + hard truncation fallback", func() {
+		It("should truncate when summarizer fails and output exceeds MaxToolOutputSize", func() {
+			oversizedOutput := strings.Repeat("z", 50000)
+			reg := registry.New()
+			reg.Register(&fakeTool{name: "kubectl_get_by_kind_in_cluster", result: oversizedOutput})
+
+			sum := summarizer.New(&alwaysFailLLM{}, 100)
+
+			investigationLLM := &mockLLMClient{
+				responses: []llm.ChatResponse{
+					{
+						Message:   llm.Message{Role: "assistant", Content: "investigating"},
+						ToolCalls: []llm.ToolCall{{ID: "tc_1", Name: "kubectl_get_by_kind_in_cluster", Arguments: `{"kind":"Pod"}`}},
+					},
+					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"done"}`}},
+					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.7}`}},
+				},
+			}
+
+			maxOutput := 2000
+			inv := investigator.New(investigator.Config{
+				Client: investigationLLM, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools, Registry: reg,
+				Pipeline: investigator.Pipeline{
+					Summarizer:        sum,
+					MaxToolOutputSize: maxOutput,
+				},
+			})
+			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
+				Name: "api", Namespace: "default", Severity: "warning", Message: "CrashLoop",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(investigationLLM.calls).To(HaveLen(3))
+			secondCall := investigationLLM.calls[1]
+			toolMsg := secondCall.Messages[len(secondCall.Messages)-1]
+			Expect(len(toolMsg.Content)).To(BeNumerically("<=", maxOutput+300),
+				"tool output should be truncated by safety net after summarizer failure")
+			Expect(toolMsg.Content).To(ContainSubstring("[TRUNCATED]"),
+				"should contain truncation marker")
+		})
+	})
+})

--- a/test/integration/kubernautagent/security/phase_scoping_test.go
+++ b/test/integration/kubernautagent/security/phase_scoping_test.go
@@ -128,9 +128,9 @@ var _ = Describe("Kubernaut Agent I4 Phase Scoping Integration — #433", func()
 			}
 		})
 
-		It("should enforce that RCA has 33 tools, WorkflowDiscovery has 4, Validation has 1", func() {
+		It("should enforce that RCA has 34 tools, WorkflowDiscovery has 4, Validation has 1", func() {
 			rcaTools := reg.ToolsForPhase(katypes.PhaseRCA, ptm)
-			Expect(rcaTools).To(HaveLen(33), "RCA should have 19 K8s + 2 metrics + 1 fetch_pod_logs + 8 Prometheus + 2 resource context + 1 TodoWrite = 33 tools")
+			Expect(rcaTools).To(HaveLen(34), "RCA should have 20 K8s + 2 metrics + 1 fetch_pod_logs + 8 Prometheus + 2 resource context + 1 TodoWrite = 34 tools")
 
 			wdTools := reg.ToolsForPhase(katypes.PhaseWorkflowDiscovery, ptm)
 			Expect(wdTools).To(HaveLen(4), "WorkflowDiscovery should have 3 workflow + 1 TodoWrite = 4 tools")

--- a/test/unit/kubernautagent/config/config_test.go
+++ b/test/unit/kubernautagent/config/config_test.go
@@ -238,6 +238,30 @@ llm:
 		})
 	})
 
+	Describe("UT-KA-752-010: MaxToolOutputSize parsed from YAML configuration", func() {
+		It("should parse max_tool_output_size from summarizer config", func() {
+			yaml := []byte(`
+llm:
+  endpoint: "http://localhost:11434/v1"
+  model: "llama3"
+summarizer:
+  threshold: 8000
+  max_tool_output_size: 50000
+`)
+			cfg, err := config.Load(yaml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.Summarizer.MaxToolOutputSize).To(Equal(50000))
+		})
+	})
+
+	Describe("UT-KA-752-011: MaxToolOutputSize default applied when absent", func() {
+		It("should default MaxToolOutputSize to DefaultMaxToolOutputSize when not specified", func() {
+			cfg := config.DefaultConfig()
+			Expect(cfg.Summarizer.MaxToolOutputSize).To(Equal(config.DefaultMaxToolOutputSize),
+				"default MaxToolOutputSize should match DefaultMaxToolOutputSize constant")
+		})
+	})
+
 	Describe("UT-KA-433W-011: DefaultConfig applies anomaly thresholds", func() {
 		It("should set MaxToolCallsPerTool=5, MaxTotalToolCalls=30, MaxRepeatedFailures=3", func() {
 			cfg := config.DefaultConfig()

--- a/test/unit/kubernautagent/investigator/investigator_test.go
+++ b/test/unit/kubernautagent/investigator/investigator_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Kubernaut Agent Investigator — #433", func() {
 			ptm := investigator.DefaultPhaseToolMap()
 			Expect(ptm).NotTo(BeNil(), "DefaultPhaseToolMap should not return nil")
 			rcaTools := ptm[katypes.PhaseRCA]
-			Expect(rcaTools).To(HaveLen(33), "RCA phase should have 19 K8s + 2 metrics + 1 fetch_pod_logs + 8 Prometheus + 2 resource context + 1 todo_write")
+			Expect(rcaTools).To(HaveLen(34), "RCA phase should have 20 K8s + 2 metrics + 1 fetch_pod_logs + 8 Prometheus + 2 resource context + 1 todo_write")
 			Expect(rcaTools).To(ContainElement("kubectl_describe"))
 			Expect(rcaTools).To(ContainElement("kubectl_logs"))
 			Expect(rcaTools).To(ContainElement("execute_prometheus_instant_query"))
@@ -39,6 +39,7 @@ var _ = Describe("Kubernaut Agent Investigator — #433", func() {
 			Expect(rcaTools).To(ContainElement("get_namespaced_resource_context"))
 			Expect(rcaTools).To(ContainElement("get_cluster_resource_context"))
 			Expect(rcaTools).To(ContainElement("todo_write"))
+			Expect(rcaTools).To(ContainElement("kubectl_get_by_name_in_cluster"))
 			Expect(rcaTools).To(ContainElement("kubectl_get_by_kind_in_cluster"))
 			Expect(rcaTools).To(ContainElement("kubectl_find_resource"))
 			Expect(rcaTools).To(ContainElement("kubectl_get_yaml"))

--- a/test/unit/kubernautagent/tools/k8s/kind_resolution_test.go
+++ b/test/unit/kubernautagent/tools/k8s/kind_resolution_test.go
@@ -670,4 +670,56 @@ var _ = Describe("Kubernaut Agent K8s Kind Resolution — #433 Phase 2", func() 
 			Expect(result).To(Equal("[]"))
 		})
 	})
+
+	// --- #752: kubectl_get_by_name_in_cluster tool ---
+
+	Describe("UT-KA-752-007: kubectl_get_by_name_in_cluster returns single matching resource", func() {
+		It("should return a single Pod by name across all namespaces", func() {
+			tool := findToolByName(reg, "kubectl_get_by_name_in_cluster")
+			Expect(tool).NotTo(BeNil(), "kubectl_get_by_name_in_cluster must be registered")
+
+			result, err := tool.Execute(context.Background(),
+				json.RawMessage(`{"kind":"Pod","name":"api-pod"}`))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(ContainSubstring("api-pod"),
+				"should return the matching Pod")
+		})
+	})
+
+	Describe("UT-KA-752-008: kubectl_get_by_name_in_cluster returns not-found for nonexistent resource", func() {
+		It("should return an error or empty result when resource does not exist", func() {
+			tool := findToolByName(reg, "kubectl_get_by_name_in_cluster")
+			Expect(tool).NotTo(BeNil(), "kubectl_get_by_name_in_cluster must be registered")
+
+			result, err := tool.Execute(context.Background(),
+				json.RawMessage(`{"kind":"Pod","name":"nonexistent-pod-xyz"}`))
+			if err != nil {
+				Expect(err.Error()).To(ContainSubstring("not found"),
+					"error should indicate resource not found")
+			} else {
+				Expect(result).To(ContainSubstring("not found"),
+					"result should indicate resource not found")
+			}
+		})
+	})
+
+	Describe("UT-KA-752-009: kubectl_get_by_name_in_cluster registered in AllToolNames", func() {
+		It("should be included in AllToolNames", func() {
+			found := false
+			for _, name := range k8s.AllToolNames {
+				if name == "kubectl_get_by_name_in_cluster" {
+					found = true
+					break
+				}
+			}
+			Expect(found).To(BeTrue(),
+				"kubectl_get_by_name_in_cluster must be in AllToolNames")
+		})
+
+		It("should be discoverable via the registry", func() {
+			tool := findToolByName(reg, "kubectl_get_by_name_in_cluster")
+			Expect(tool).NotTo(BeNil(),
+				"tool must be registered in the registry")
+		})
+	})
 })

--- a/test/unit/kubernautagent/tools/registry/registry_test.go
+++ b/test/unit/kubernautagent/tools/registry/registry_test.go
@@ -40,11 +40,11 @@ var _ k8s.ResourceResolver = (*nopResolver)(nil)
 var _ = Describe("Kubernaut Agent Tool Registry — #433", func() {
 
 	Describe("UT-KA-433-029: Baseline K8s tools satisfy Tool interface", func() {
-		It("should create 19 baseline tools implementing the Tool interface", func() {
+		It("should create 20 baseline tools implementing the Tool interface", func() {
 			client := fake.NewSimpleClientset()
 			allTools := k8s.NewAllTools(client, &nopResolver{})
 			Expect(allTools).NotTo(BeNil(), "NewAllTools should not return nil")
-			Expect(allTools).To(HaveLen(19), "should create exactly 19 baseline K8s tools")
+			Expect(allTools).To(HaveLen(20), "should create exactly 20 baseline K8s tools")
 
 			for _, t := range allTools {
 				Expect(t.Name()).NotTo(BeEmpty(), "tool Name() should not be empty")
@@ -92,7 +92,7 @@ var _ = Describe("Kubernaut Agent Tool Registry — #433", func() {
 			}
 
 			all := reg.All()
-			Expect(all).To(HaveLen(19), "registry should contain 19 tools")
+			Expect(all).To(HaveLen(20), "registry should contain 20 tools")
 
 			for _, expected := range k8s.AllToolNames {
 				tool, err := reg.Get(expected)
@@ -135,10 +135,10 @@ var _ = Describe("Kubernaut Agent Tool Registry — #433", func() {
 	})
 
 	Describe("UT-KA-433-630: Full tool registry count matches production wiring", func() {
-		It("should register exactly 36 tools matching main.go wiring", func() {
+		It("should register exactly 37 tools matching main.go wiring", func() {
 			expectedTotal := len(k8s.AllToolNames) + len(k8s.MetricsToolNames) + 8 + 5 + 1 + 1
-			Expect(expectedTotal).To(Equal(36),
-				"K8s baseline (19) + K8s metrics (2) + Prometheus (8) + Custom (5) + TodoWrite (1) + FetchPodLogs (1)")
+			Expect(expectedTotal).To(Equal(37),
+				"K8s baseline (20) + K8s metrics (2) + Prometheus (8) + Custom (5) + TodoWrite (1) + FetchPodLogs (1)")
 		})
 	})
 })

--- a/test/unit/kubernautagent/tools/summarizer/summarizer_test.go
+++ b/test/unit/kubernautagent/tools/summarizer/summarizer_test.go
@@ -124,4 +124,55 @@ var _ = Describe("Kubernaut Agent Summarizer Unit — #433", func() {
 			Expect(wrapped.Parameters()).To(Equal(inner.Parameters()))
 		})
 	})
+
+	Describe("UT-KA-752-003: Summarizer pre-truncates before LLM call", func() {
+		It("should pre-truncate input exceeding maxInputSize before sending to LLM", func() {
+			fake := &fakeLLM{response: "summarized"}
+			maxInput := 500
+			s := summarizer.NewWithMaxInput(fake, 100, maxInput)
+
+			longOutput := strings.Repeat("d", 1000)
+			result, err := s.MaybeSummarize(context.Background(), "kubectl_get_by_kind_in_cluster", longOutput)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("summarized"))
+
+			Expect(fake.calls).To(HaveLen(1))
+			prompt := fake.calls[0].Messages[0].Content
+			Expect(len(prompt)).To(BeNumerically("<=", maxInput+200),
+				"LLM prompt should not exceed maxInputSize plus format overhead")
+		})
+	})
+
+	Describe("UT-KA-752-004: Summarizer works for moderate inputs", func() {
+		It("should send full output when between threshold and maxInputSize", func() {
+			fake := &fakeLLM{response: "moderate summary"}
+			s := summarizer.NewWithMaxInput(fake, 100, 5000)
+
+			moderateOutput := strings.Repeat("m", 300)
+			result, err := s.MaybeSummarize(context.Background(), "kubectl_logs", moderateOutput)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(Equal("moderate summary"))
+
+			Expect(fake.calls).To(HaveLen(1))
+			prompt := fake.calls[0].Messages[0].Content
+			Expect(prompt).To(ContainSubstring(moderateOutput),
+				"full output should be in prompt when below maxInputSize")
+		})
+	})
+
+	Describe("UT-KA-752-006: Pre-truncation note in prompt", func() {
+		It("should include truncation note in LLM prompt when input was pre-truncated", func() {
+			fake := &fakeLLM{response: "summary with note"}
+			s := summarizer.NewWithMaxInput(fake, 100, 400)
+
+			longOutput := strings.Repeat("n", 800)
+			_, err := s.MaybeSummarize(context.Background(), "kubectl_get_by_kind_in_cluster", longOutput)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fake.calls).To(HaveLen(1))
+			prompt := fake.calls[0].Messages[0].Content
+			Expect(prompt).To(ContainSubstring("PRE-TRUNCATED"),
+				"prompt should indicate pre-truncation occurred")
+		})
+	})
 })

--- a/test/unit/kubernautagent/tools/summarizer/truncation_test.go
+++ b/test/unit/kubernautagent/tools/summarizer/truncation_test.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package summarizer_test
+
+import (
+	"fmt"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/summarizer"
+)
+
+var _ = Describe("Kubernaut Agent Tool Output Truncation — #752", func() {
+
+	Describe("UT-KA-752-001: Hard truncation applied to oversized output", func() {
+		It("should truncate output exceeding the limit and append guidance hint", func() {
+			limit := 1000
+			toolName := "kubectl_get_by_kind_in_cluster"
+			longOutput := strings.Repeat("x", 2000)
+
+			result := summarizer.TruncateToolOutput(longOutput, toolName, limit)
+
+			Expect(len(result)).To(BeNumerically("<=", limit+300),
+				"truncated result should not vastly exceed limit (hint overhead)")
+			Expect(result).To(ContainSubstring("[TRUNCATED]"),
+				"should contain truncation marker")
+			Expect(result).To(ContainSubstring(toolName),
+				"hint should reference the tool name")
+			Expect(result).To(ContainSubstring("2000"),
+				"hint should mention original output size")
+		})
+	})
+
+	Describe("UT-KA-752-002: Below-limit output passes through unchanged", func() {
+		It("should return input unchanged when at or below limit", func() {
+			limit := 100000
+			shortOutput := "metric_value=42"
+
+			result := summarizer.TruncateToolOutput(shortOutput, "kubectl_describe", limit)
+
+			Expect(result).To(Equal(shortOutput),
+				"should pass through unchanged")
+		})
+
+		It("should return input unchanged when exactly at limit", func() {
+			limit := 500
+			exactOutput := strings.Repeat("a", 500)
+
+			result := summarizer.TruncateToolOutput(exactOutput, "kubectl_describe", limit)
+
+			Expect(result).To(Equal(exactOutput),
+				"should pass through unchanged when exactly at limit")
+		})
+	})
+
+	Describe("UT-KA-752-005: Truncation hint includes output size and guidance", func() {
+		It("should include original character count and tool-specific guidance", func() {
+			limit := 500
+			toolName := "kubectl_get_by_kind_in_cluster"
+			longOutput := strings.Repeat("z", 5000)
+
+			result := summarizer.TruncateToolOutput(longOutput, toolName, limit)
+
+			Expect(result).To(ContainSubstring(fmt.Sprintf("%d", 5000)),
+				"hint should include original output length")
+			Expect(result).To(ContainSubstring("kubectl_get_by_name"),
+				"hint should suggest using targeted tool for cluster-wide listings")
+		})
+
+		It("should include generic guidance for non-listing tools", func() {
+			limit := 500
+			toolName := "kubectl_logs"
+			longOutput := strings.Repeat("log", 1000)
+
+			result := summarizer.TruncateToolOutput(longOutput, toolName, limit)
+
+			Expect(result).To(ContainSubstring("[TRUNCATED]"),
+				"should contain truncation marker")
+			Expect(result).To(ContainSubstring(fmt.Sprintf("%d", 3000)),
+				"hint should include original output length")
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- **Hard truncation safety net**: Tool outputs exceeding configurable `MaxToolOutputSize` (default 100K chars) are truncated with guidance hint before entering the LLM conversation context, preventing context window overflow
- **Summarizer pre-truncation**: Inputs to the secondary summarizer LLM are pre-truncated to prevent the summarizer itself from failing on oversized inputs
- **New `kubectl_get_by_name_in_cluster` tool**: Fetches a single resource by exact name across all namespaces, eliminating the need to list all resources of a kind (the primary trigger for the 3.4MB Secret dump reported in #752)

## Problem

`kubectl_get_by_kind_in_cluster` returned 3.4 MB of Secret data, which:
1. Overwhelmed the summarizer's secondary LLM call (it embedded the full output in its prompt)
2. On summarizer failure, the raw 3.4 MB output was injected into the main LLM's conversation context
3. Caused the primary LLM to hit its context window limit

## Changes

| File | Change |
|------|--------|
| `pkg/kubernautagent/tools/summarizer/summarizer.go` | `TruncateToolOutput()` + `NewWithMaxInput()` with pre-truncation |
| `internal/kubernautagent/investigator/investigator.go` | Hard truncation in `executeTool()` via `Pipeline.MaxToolOutputSize` |
| `internal/kubernautagent/config/config.go` | `MaxToolOutputSize` field + `DefaultMaxToolOutputSize` constant |
| `pkg/kubernautagent/tools/k8s/tools.go` | New `kubectl_get_by_name_in_cluster` tool |
| `cmd/kubernautagent/main.go` | Config wiring for pre-truncation and pipeline limit |

## Test plan

- [x] 11 unit test scenarios (UT-KA-752-001..011)
- [x] 3 integration test scenarios (IT-KA-752-001..003)
- [x] Full KA unit suite (22 packages) — zero regressions
- [x] Full investigator integration suite — zero regressions
- [x] `go build ./...` passes
- [x] Pre-commit hooks pass on all 4 commits
- [x] Test plan: `docs/tests/752/TEST_PLAN.md`

Closes #752

Made with [Cursor](https://cursor.com)