### PR TITLE
feat(tls): complete TLS certificate rotation support (#756, #758)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1038,7 +1038,7 @@ image-runtime-%: ## Build runtime-only image from pre-built binary (no QEMU need
 	    echo "ERROR: Binary bin/$(BINARY_NAME_$*)-$(IMAGE_ARCH) not found. Run: make cross-build-$* IMAGE_ARCH=$(IMAGE_ARCH)"; exit 1; \
 	fi
 	@echo "  Building runtime image $* [$(IMAGE_ARCH)] (no QEMU)..."
-	@$(CONTAINER_TOOL) build --no-cache \
+	@$(CONTAINER_TOOL) build --no-cache --platform linux/$(IMAGE_ARCH) \
 	    --build-arg BINARY=bin/$(BINARY_NAME_$*)-$(IMAGE_ARCH) \
 	    --build-arg APP_VERSION=$(APP_VERSION) \
 	    --build-arg GIT_COMMIT=$(GIT_COMMIT) \

--- a/cmd/aianalysis/main.go
+++ b/cmd/aianalysis/main.go
@@ -41,6 +41,7 @@ import (
 
 	aianalysisv1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
 	scope "github.com/jordigilh/kubernaut/pkg/shared/scope"
+	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
 	config "github.com/jordigilh/kubernaut/internal/config/aianalysis"
 	"github.com/jordigilh/kubernaut/internal/version"
 	"github.com/jordigilh/kubernaut/internal/controller/aianalysis"
@@ -283,8 +284,21 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Issue #756: Extract signal context for CA file watcher lifecycle
+	ctx = ctrl.SetupSignalHandler()
+
+	// Issue #756: Start CA file watcher for client-side TLS hot-reload
+	caWatcher, caWatchErr := sharedtls.StartCAFileWatcher(ctx, setupLog)
+	if caWatchErr != nil {
+		setupLog.Error(caWatchErr, "Failed to start CA file watcher")
+		os.Exit(1)
+	}
+	if caWatcher != nil {
+		defer caWatcher.Stop()
+	}
+
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}

--- a/cmd/authwebhook/main.go
+++ b/cmd/authwebhook/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/audit"
 	"github.com/jordigilh/kubernaut/pkg/authwebhook"
 	awconfig "github.com/jordigilh/kubernaut/pkg/authwebhook/config"
+	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -267,6 +268,16 @@ func main() {
 		os.Exit(1)
 	}
 	setupLog.Info("Registered health check endpoints", "liveness", "/healthz", "readiness", "/readyz")
+
+	// Issue #756: Start CA file watcher for client-side TLS hot-reload
+	caWatcher, caWatchErr := sharedtls.StartCAFileWatcher(ctx, setupLog)
+	if caWatchErr != nil {
+		setupLog.Error(caWatchErr, "Failed to start CA file watcher")
+		os.Exit(1)
+	}
+	if caWatcher != nil {
+		defer caWatcher.Stop()
+	}
 
 	setupLog.Info("Starting webhook server", "port", cfg.Webhook.Port)
 	if err := mgr.Start(ctx); err != nil {

--- a/cmd/datastorage/main.go
+++ b/cmd/datastorage/main.go
@@ -42,6 +42,7 @@ import (
 	dsvalidation "github.com/jordigilh/kubernaut/pkg/datastorage/validation"
 	kubelog "github.com/jordigilh/kubernaut/pkg/log"
 	"github.com/jordigilh/kubernaut/pkg/shared/auth"
+	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
 )
 
 // ========================================
@@ -342,6 +343,16 @@ func main() {
 			metricsErrors <- err
 		}
 	}()
+
+	// Issue #756: Start CA file watcher for client-side TLS hot-reload
+	caWatcher, caWatchErr := sharedtls.StartCAFileWatcher(ctx, logger)
+	if caWatchErr != nil {
+		logger.Error(caWatchErr, "Failed to start CA file watcher")
+		os.Exit(1)
+	}
+	if caWatcher != nil {
+		defer caWatcher.Stop()
+	}
 
 	// Start API server in goroutine
 	serverErrors := make(chan error, 1)

--- a/cmd/effectivenessmonitor/main.go
+++ b/cmd/effectivenessmonitor/main.go
@@ -49,6 +49,7 @@ import (
 	emmetrics "github.com/jordigilh/kubernaut/pkg/effectivenessmonitor/metrics"
 	"github.com/jordigilh/kubernaut/pkg/effectivenessmonitor/startup"
 	"github.com/jordigilh/kubernaut/pkg/shared/hotreload"
+	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -246,13 +247,14 @@ func main() {
 			time.Sleep(caRetryInterval)
 		}
 
-		caReloader, err := emclient.NewCAReloader(caPEM)
+		// Issue #756: Migrate to shared CAReloader for consistency
+		caReloader, err := sharedtls.NewCAReloader(caPEM)
 		if err != nil {
 			setupLog.Error(err, "Failed to initialize CA reloader", "caFile", cfg.External.TLSCaFile)
 			os.Exit(1)
 		}
 
-		caWatcher, err := hotreload.NewFileWatcher(
+		emCAWatcher, err := hotreload.NewFileWatcher(
 			cfg.External.TLSCaFile,
 			caReloader.ReloadCallback,
 			ctrl.Log.WithName("ca-reloader"),
@@ -261,10 +263,11 @@ func main() {
 			setupLog.Error(err, "Failed to create CA file watcher", "caFile", cfg.External.TLSCaFile)
 			os.Exit(1)
 		}
-		if err := caWatcher.Start(ctx); err != nil {
+		if err := emCAWatcher.Start(ctx); err != nil {
 			setupLog.Error(err, "Failed to start CA file watcher", "caFile", cfg.External.TLSCaFile)
 			os.Exit(1)
 		}
+		defer emCAWatcher.Stop()
 
 		// Wrap CAReloader (RoundTripper) with SA bearer token for OCP monitoring endpoints.
 		saTransport := auth.NewServiceAccountTransportWithBase(caReloader)
@@ -379,6 +382,16 @@ func main() {
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
+	}
+
+	// Issue #756: Start CA file watcher for client-side TLS hot-reload
+	caWatcher, caWatchErr := sharedtls.StartCAFileWatcher(ctx, setupLog)
+	if caWatchErr != nil {
+		setupLog.Error(caWatchErr, "Failed to start CA file watcher")
+		os.Exit(1)
+	}
+	if caWatcher != nil {
+		defer caWatcher.Stop()
 	}
 
 	setupLog.Info("starting manager")

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/gateway/adapters"
 	"github.com/jordigilh/kubernaut/pkg/gateway/config"
 	kubelog "github.com/jordigilh/kubernaut/pkg/log"
+	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -126,6 +127,16 @@ func main() {
 	errChan := make(chan error, 1)
 	serverCtx, serverCancel := context.WithCancel(context.Background())
 	defer serverCancel()
+
+	// Issue #756: Start CA file watcher for client-side TLS hot-reload
+	caWatcher, caWatchErr := sharedtls.StartCAFileWatcher(serverCtx, logger)
+	if caWatchErr != nil {
+		logger.Error(caWatchErr, "Failed to start CA file watcher")
+		os.Exit(1)
+	}
+	if caWatcher != nil {
+		defer caWatcher.Stop()
+	}
 
 	go func() {
 		logger.Info("Gateway server starting", "address", serverCfg.Server.ListenAddr)

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
@@ -46,6 +47,7 @@ import (
 	llmtransport "github.com/jordigilh/kubernaut/pkg/kubernautagent/llm/transport"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm/vertexanthropic"
 	auth "github.com/jordigilh/kubernaut/pkg/shared/auth"
+	"github.com/jordigilh/kubernaut/pkg/shared/hotreload"
 	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
 
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
@@ -248,19 +250,50 @@ func main() {
 	}
 
 	// Issue #493: Conditional TLS for the HTTP server
+	// Issue #756: CertReloader enables hot-reload of server certificates
+	var certReloader *sharedtls.CertReloader
 	if cfg.Server.TLS.Enabled() {
-		isTLS, tlsErr := sharedtls.ConfigureConditionalTLS(httpServer, cfg.Server.TLS.CertDir)
+		isTLS, reloader, tlsErr := sharedtls.ConfigureConditionalTLS(httpServer, cfg.Server.TLS.CertDir)
 		if tlsErr != nil {
 			slogger.Error("Failed to configure TLS", "error", tlsErr)
 			os.Exit(1)
 		}
 		if isTLS {
+			certReloader = reloader
 			slogger.Info("TLS configured for HTTP server", "certDir", cfg.Server.TLS.CertDir)
 		}
 	}
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
+
+	// Issue #756: Wire FileWatcher for server cert hot-reload
+	if certReloader != nil {
+		certWatcher, watchErr := hotreload.NewFileWatcher(
+			filepath.Join(cfg.Server.TLS.CertDir, "tls.crt"),
+			certReloader.ReloadCallback,
+			logr.FromSlogHandler(slogger.Handler()).WithName("cert-reloader"),
+		)
+		if watchErr != nil {
+			slogger.Error("Failed to create cert file watcher", "error", watchErr)
+			os.Exit(1)
+		}
+		if err := certWatcher.Start(ctx); err != nil {
+			slogger.Error("Failed to start cert file watcher", "error", err)
+			os.Exit(1)
+		}
+		defer certWatcher.Stop()
+	}
+
+	// Issue #756: Start CA file watcher for client-side TLS hot-reload
+	caWatcher, caWatchErr := sharedtls.StartCAFileWatcher(ctx, logr.FromSlogHandler(slogger.Handler()))
+	if caWatchErr != nil {
+		slogger.Error("Failed to start CA file watcher", "error", caWatchErr)
+		os.Exit(1)
+	}
+	if caWatcher != nil {
+		defer caWatcher.Stop()
+	}
 
 	store.StartCleanupLoop(ctx, cfg.Session.TTL/2)
 

--- a/cmd/notification/main.go
+++ b/cmd/notification/main.go
@@ -497,6 +497,16 @@ func main() {
 		}()
 	}
 
+	// Issue #756: Start CA file watcher for client-side TLS hot-reload
+	caWatcher, caWatchErr := sharedtls.StartCAFileWatcher(ctx, logger)
+	if caWatchErr != nil {
+		logger.Error(caWatchErr, "Failed to start CA file watcher")
+		os.Exit(1)
+	}
+	if caWatcher != nil {
+		defer caWatcher.Stop()
+	}
+
 	if err := mgr.Start(ctx); err != nil {
 		logger.Error(err, "Problem running manager")
 		os.Exit(1)

--- a/cmd/remediationorchestrator/main.go
+++ b/cmd/remediationorchestrator/main.go
@@ -44,6 +44,7 @@ import (
 	"github.com/jordigilh/kubernaut/internal/version"
 	clusterid "github.com/jordigilh/kubernaut/pkg/shared/cluster"
 	scope "github.com/jordigilh/kubernaut/pkg/shared/scope"
+	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
 	config "github.com/jordigilh/kubernaut/internal/config/remediationorchestrator"
 	controller "github.com/jordigilh/kubernaut/internal/controller/remediationorchestrator"
 	"github.com/jordigilh/kubernaut/pkg/audit"
@@ -380,6 +381,16 @@ func main() {
 
 	// Setup signal handler for graceful shutdown
 	ctx := ctrl.SetupSignalHandler()
+
+	// Issue #756: Start CA file watcher for client-side TLS hot-reload
+	caWatcher, caWatchErr := sharedtls.StartCAFileWatcher(ctx, setupLog)
+	if caWatchErr != nil {
+		setupLog.Error(caWatchErr, "Failed to start CA file watcher")
+		os.Exit(1)
+	}
+	if caWatcher != nil {
+		defer caWatcher.Stop()
+	}
 
 	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")

--- a/cmd/signalprocessing/main.go
+++ b/cmd/signalprocessing/main.go
@@ -62,6 +62,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/signalprocessing/evaluator"
 	spmetrics "github.com/jordigilh/kubernaut/pkg/signalprocessing/metrics"
 	spstatus "github.com/jordigilh/kubernaut/pkg/signalprocessing/status"
+	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
 )
 
 var (
@@ -314,6 +315,16 @@ func main() {
 	if err := mgr.AddReadyzCheck("readyz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up ready check")
 		os.Exit(1)
+	}
+
+	// Issue #756: Start CA file watcher for client-side TLS hot-reload
+	caWatcher, caWatchErr := sharedtls.StartCAFileWatcher(ctx, setupLog)
+	if caWatchErr != nil {
+		setupLog.Error(caWatchErr, "Failed to start CA file watcher")
+		os.Exit(1)
+	}
+	if caWatcher != nil {
+		defer caWatcher.Stop()
 	}
 
 	setupLog.Info("starting manager")

--- a/cmd/workflowexecution/main.go
+++ b/cmd/workflowexecution/main.go
@@ -40,6 +40,7 @@ import (
 	workflowexecutionv1alpha1 "github.com/jordigilh/kubernaut/api/workflowexecution/v1alpha1"
 	"github.com/jordigilh/kubernaut/internal/version"
 	scope "github.com/jordigilh/kubernaut/pkg/shared/scope"
+	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
 	"github.com/jordigilh/kubernaut/internal/controller/workflowexecution"
 	"github.com/jordigilh/kubernaut/pkg/audit"
 	dsvalidation "github.com/jordigilh/kubernaut/pkg/datastorage/validation"
@@ -318,8 +319,21 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Issue #756: Extract signal context for CA file watcher lifecycle
+	ctx := ctrl.SetupSignalHandler()
+
+	// Issue #756: Start CA file watcher for client-side TLS hot-reload
+	caWatcher, caWatchErr := sharedtls.StartCAFileWatcher(ctx, setupLog)
+	if caWatchErr != nil {
+		setupLog.Error(caWatchErr, "Failed to start CA file watcher")
+		os.Exit(1)
+	}
+	if caWatcher != nil {
+		defer caWatcher.Stop()
+	}
+
 	setupLog.Info("starting manager")
-	if err := mgr.Start(ctrl.SetupSignalHandler()); err != nil {
+	if err := mgr.Start(ctx); err != nil {
 		setupLog.Error(err, "problem running manager")
 		os.Exit(1)
 	}

--- a/pkg/datastorage/server/server.go
+++ b/pkg/datastorage/server/server.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sync/atomic"
 	"time"
 
@@ -47,6 +48,7 @@ import (
 	dsmiddleware "github.com/jordigilh/kubernaut/pkg/datastorage/server/middleware"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/validation"
 	"github.com/jordigilh/kubernaut/pkg/shared/auth"
+	"github.com/jordigilh/kubernaut/pkg/shared/hotreload"      // Issue #756: FileWatcher for cert rotation
 	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls" // Issue #493/#678: Conditional TLS
 )
 
@@ -61,6 +63,11 @@ type Server struct {
 	db         *sql.DB
 	logger     logr.Logger
 	httpServer *http.Server
+
+	// Issue #756: TLS cert hot-reload support
+	certReloader *sharedtls.CertReloader      // nil when TLS disabled
+	certWatcher  *hotreload.FileWatcher        // nil when TLS disabled
+	tlsCertDir   string                        // cert dir for FileWatcher path
 
 	// DD-007: Graceful shutdown coordination flag
 	// Thread-safe flag for readiness probe coordination during shutdown
@@ -395,12 +402,14 @@ func NewServer(deps ServerDeps) (*Server, error) {
 	srv.httpServer.Handler = srv.Handler()
 
 	if serverCfg.TLS.Enabled() {
-		isTLS, tlsErr := sharedtls.ConfigureConditionalTLS(srv.httpServer, serverCfg.TLS.CertDir)
+		isTLS, reloader, tlsErr := sharedtls.ConfigureConditionalTLS(srv.httpServer, serverCfg.TLS.CertDir)
 		if tlsErr != nil {
 			_ = db.Close()
 			return nil, fmt.Errorf("failed to configure TLS: %w", tlsErr)
 		}
 		if isTLS {
+			srv.certReloader = reloader
+			srv.tlsCertDir = serverCfg.TLS.CertDir
 			logger.Info("TLS configured for DataStorage server", "certDir", serverCfg.TLS.CertDir)
 		}
 	}
@@ -589,6 +598,22 @@ func (s *Server) Start() error {
 	// Issue #667/M4: Use a server-scoped context instead of context.Background()
 	s.dlqRetryWorker.Start(context.Background())
 
+	// Issue #756: Start cert file watcher for hot-reload before accepting connections
+	if s.certReloader != nil {
+		watcher, err := hotreload.NewFileWatcher(
+			filepath.Join(s.tlsCertDir, "tls.crt"),
+			s.certReloader.ReloadCallback,
+			s.logger.WithName("cert-reloader"),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to create cert file watcher: %w", err)
+		}
+		if err := watcher.Start(context.Background()); err != nil {
+			return fmt.Errorf("failed to start cert file watcher: %w", err)
+		}
+		s.certWatcher = watcher
+	}
+
 	if s.httpServer.TLSConfig != nil {
 		s.logger.Info("TLS enabled, starting HTTPS server")
 		return s.httpServer.ListenAndServeTLS("", "")
@@ -613,6 +638,11 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	// STEP 3: Drain in-flight HTTP connections
 	if err := s.shutdownStep3DrainConnections(ctx); err != nil {
 		return err
+	}
+
+	// Issue #756: Stop cert file watcher after HTTP server is down
+	if s.certWatcher != nil {
+		s.certWatcher.Stop()
 	}
 
 	// STEP 3.5: Stop DLQ retry worker before draining (DD-009 V1.0)

--- a/pkg/effectivenessmonitor/client/ca_reloader.go
+++ b/pkg/effectivenessmonitor/client/ca_reloader.go
@@ -24,6 +24,9 @@ import (
 	"sync"
 )
 
+// Deprecated: Use github.com/jordigilh/kubernaut/pkg/shared/tls.CAReloader instead.
+// This type is retained for backward compatibility with existing EM tests.
+//
 // CAReloader is an http.RoundTripper that supports hot-reloading of
 // the TLS CA certificate pool. When the OCP service-ca operator
 // updates the mounted ConfigMap, the FileWatcher calls ReloadCallback
@@ -34,6 +37,8 @@ import (
 // Issue #484: Resolves the race where EM starts before the service-ca
 // ConfigMap is populated by allowing the cert pool to be replaced at
 // runtime without restarting the pod.
+//
+// Issue #756: Superseded by pkg/shared/tls.CAReloader.
 //
 // Thread safety: all public methods are safe for concurrent use.
 type CAReloader struct {

--- a/pkg/gateway/server.go
+++ b/pkg/gateway/server.go
@@ -24,6 +24,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"path/filepath"
 	"sync/atomic"
 	"time"
 
@@ -40,6 +41,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/shared/auth"                 // BR-GATEWAY-036/037: Shared auth middleware
 	sharedaudit "github.com/jordigilh/kubernaut/pkg/shared/audit"    // BR-AUDIT-005 Gap #7: Standardized error details
 	"github.com/jordigilh/kubernaut/pkg/shared/backoff"              // ADR-052 Addendum 001: Exponential backoff with jitter
+	"github.com/jordigilh/kubernaut/pkg/shared/hotreload"             // Issue #756: FileWatcher for cert rotation
 	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"        // Issue #493/#678: Conditional TLS
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -122,8 +124,11 @@ const (
 // - Distributed tracing: OpenTelemetry integration (future)
 type Server struct {
 	// HTTP server
-	httpServer *http.Server
-	router     chi.Router // Chi router for adapter registration and route grouping
+	httpServer   *http.Server
+	router       chi.Router // Chi router for adapter registration and route grouping
+	certReloader *sharedtls.CertReloader      // Issue #756: nil when TLS disabled
+	certWatcher  *hotreload.FileWatcher        // Issue #756: nil when TLS disabled
+	tlsCertDir   string                        // Issue #756: cert dir for FileWatcher path
 
 	// Configuration
 	config *config.ServerConfig // ADR-030: Service configuration (needed for middleware setup)
@@ -326,11 +331,13 @@ func NewServerForTesting(cfg *config.ServerConfig, logger logr.Logger, metricsIn
 	}
 
 	if cfg.Server.TLS.Enabled() {
-		isTLS, tlsErr := sharedtls.ConfigureConditionalTLS(server.httpServer, cfg.Server.TLS.CertDir)
+		isTLS, reloader, tlsErr := sharedtls.ConfigureConditionalTLS(server.httpServer, cfg.Server.TLS.CertDir)
 		if tlsErr != nil {
 			return nil, fmt.Errorf("failed to configure TLS: %w", tlsErr)
 		}
 		if isTLS {
+			server.certReloader = reloader
+			server.tlsCertDir = cfg.Server.TLS.CertDir
 			server.logger.Info("TLS configured for Gateway server", "certDir", cfg.Server.TLS.CertDir)
 		}
 	}
@@ -638,11 +645,13 @@ func createServerWithClients(cfg *config.ServerConfig, logger logr.Logger, metri
 	}
 
 	if cfg.Server.TLS.Enabled() {
-		isTLS, tlsErr := sharedtls.ConfigureConditionalTLS(server.httpServer, cfg.Server.TLS.CertDir)
+		isTLS, reloader, tlsErr := sharedtls.ConfigureConditionalTLS(server.httpServer, cfg.Server.TLS.CertDir)
 		if tlsErr != nil {
 			return nil, fmt.Errorf("failed to configure TLS: %w", tlsErr)
 		}
 		if isTLS {
+			server.certReloader = reloader
+			server.tlsCertDir = cfg.Server.TLS.CertDir
 			server.logger.Info("TLS configured for Gateway server", "certDir", cfg.Server.TLS.CertDir)
 		}
 	}
@@ -1065,6 +1074,23 @@ func (s *Server) sendSuccessResponse(
 //	}()
 func (s *Server) Start(ctx context.Context) error {
 	s.logger.Info("Starting Gateway server", "addr", s.httpServer.Addr)
+
+	// Issue #756: Start cert file watcher for hot-reload before accepting connections
+	if s.certReloader != nil {
+		watcher, err := hotreload.NewFileWatcher(
+			filepath.Join(s.tlsCertDir, "tls.crt"),
+			s.certReloader.ReloadCallback,
+			s.logger.WithName("cert-reloader"),
+		)
+		if err != nil {
+			return fmt.Errorf("failed to create cert file watcher: %w", err)
+		}
+		if err := watcher.Start(ctx); err != nil {
+			return fmt.Errorf("failed to start cert file watcher: %w", err)
+		}
+		s.certWatcher = watcher
+	}
+
 	// Issue #493: Conditional TLS — serve HTTPS when TLSConfig is set
 	if s.httpServer.TLSConfig != nil {
 		s.logger.Info("TLS enabled, starting HTTPS server")
@@ -1128,6 +1154,11 @@ func (s *Server) Stop(ctx context.Context) error {
 	if err := s.httpServer.Shutdown(ctx); err != nil {
 		s.logger.Error(err, "Failed to gracefully shutdown HTTP server")
 		return err
+	}
+
+	// Issue #756: Stop cert file watcher after HTTP server is down
+	if s.certWatcher != nil {
+		s.certWatcher.Stop()
 	}
 
 	// DD-GATEWAY-012: Redis close REMOVED - Gateway is now Redis-free

--- a/pkg/shared/tls/ca_reloader.go
+++ b/pkg/shared/tls/ca_reloader.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"fmt"
+	"net/http"
+	"os"
+	"sync"
+)
+
+// CAReloader is an http.RoundTripper that supports hot-reloading of the TLS
+// CA certificate pool. When the CA file is rotated (e.g., by the OCP service-ca
+// operator), the FileWatcher calls ReloadCallback which builds a new
+// http.Transport with the fresh cert pool and swaps it atomically.
+//
+// Existing in-flight requests complete on the old transport; new requests
+// use the updated one.
+//
+// Issue #756: Generalized from pkg/effectivenessmonitor/client for all
+// inter-service TLS communication.
+//
+// Thread safety: all public methods are safe for concurrent use.
+type CAReloader struct {
+	mu        sync.RWMutex
+	transport *http.Transport
+	pool      *x509.CertPool
+}
+
+// NewCAReloader creates a CAReloader initialized with the given PEM
+// certificate data. Returns an error if pemData contains no valid PEM
+// certificates or is empty.
+func NewCAReloader(pemData []byte) (*CAReloader, error) {
+	if len(pemData) == 0 {
+		return nil, fmt.Errorf("CA PEM data is empty")
+	}
+	pool, err := buildCertPool(pemData)
+	if err != nil {
+		return nil, err
+	}
+	t := buildCATransport(pool)
+	return &CAReloader{
+		transport: t,
+		pool:      pool,
+	}, nil
+}
+
+// NewCAReloaderFromFile creates a CAReloader by reading PEM data from a file.
+// Error message preserves compatibility with existing test expectations.
+func NewCAReloaderFromFile(path string) (*CAReloader, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read CA certificate %s: %w", path, err)
+	}
+	return NewCAReloader(data)
+}
+
+// ReloadCallback parses newContent as PEM, builds a fresh cert pool, and
+// atomically replaces the underlying http.Transport. If the PEM is invalid,
+// the previous transport is preserved and an error is returned.
+//
+// This function satisfies the hotreload.ReloadCallback signature.
+func (r *CAReloader) ReloadCallback(newContent string) error {
+	if newContent == "" {
+		return fmt.Errorf("CA reload rejected: empty content")
+	}
+	pool, err := buildCertPool([]byte(newContent))
+	if err != nil {
+		return fmt.Errorf("CA reload rejected: %w", err)
+	}
+	t := buildCATransport(pool)
+
+	r.mu.Lock()
+	r.transport = t
+	r.pool = pool
+	r.mu.Unlock()
+	return nil
+}
+
+// RoundTrip implements http.RoundTripper. Each call reads the current
+// transport under a read lock, then delegates. The lock is held only
+// for the pointer copy, not for the network I/O.
+func (r *CAReloader) RoundTrip(req *http.Request) (*http.Response, error) {
+	r.mu.RLock()
+	t := r.transport
+	r.mu.RUnlock()
+	return t.RoundTrip(req)
+}
+
+// GetCertPool returns the currently active certificate pool (snapshot).
+func (r *CAReloader) GetCertPool() *x509.CertPool {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.pool
+}
+
+// CurrentTransport returns the currently active http.Transport (snapshot).
+func (r *CAReloader) CurrentTransport() *http.Transport {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.transport
+}
+
+// buildCertPool creates an x509.CertPool from PEM-encoded certificate data.
+// Appends to system cert pool so both system-trusted and custom CAs are honored.
+func buildCertPool(pemData []byte) (*x509.CertPool, error) {
+	pool, err := x509.SystemCertPool()
+	if err != nil {
+		pool = x509.NewCertPool()
+	}
+	if !pool.AppendCertsFromPEM(pemData) {
+		return nil, fmt.Errorf("no valid PEM certificates found in CA data (%d bytes)", len(pemData))
+	}
+	return pool, nil
+}
+
+// buildCATransport creates an http.Transport configured with the given CA pool.
+func buildCATransport(pool *x509.CertPool) *http.Transport {
+	t := http.DefaultTransport.(*http.Transport).Clone()
+	t.TLSClientConfig = &tls.Config{
+		RootCAs:    pool,
+		MinVersion: tls.VersionTLS12,
+	}
+	return t
+}

--- a/pkg/shared/tls/cert_reloader.go
+++ b/pkg/shared/tls/cert_reloader.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"crypto/tls"
+	"fmt"
+	"sync"
+)
+
+// CertReloader supports hot-reloading of TLS server certificates.
+// It implements the tls.Config.GetCertificate callback pattern, allowing
+// Kubernetes Secret rotation to be picked up without restarting the server.
+// Thread-safe: concurrent GetCertificate calls and ReloadCallback are serialized
+// via RWMutex.
+//
+// Issue #756: TLS certificate rotation for inter-service communication.
+type CertReloader struct {
+	certFile string
+	keyFile  string
+	mu       sync.RWMutex
+	cert     *tls.Certificate
+}
+
+// NewCertReloader creates a CertReloader that loads the initial certificate
+// from disk. Returns error if the initial load fails (fail-fast at startup).
+func NewCertReloader(certFile, keyFile string) (*CertReloader, error) {
+	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load TLS key pair (%s, %s): %w", certFile, keyFile, err)
+	}
+
+	return &CertReloader{
+		certFile: certFile,
+		keyFile:  keyFile,
+		cert:     &cert,
+	}, nil
+}
+
+// GetCertificate returns the current certificate for TLS handshakes.
+// Safe for concurrent use from multiple goroutines (TLS accept loop).
+func (r *CertReloader) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return r.cert, nil
+}
+
+// ReloadCallback re-reads both cert and key files from disk.
+// The content argument is ignored because Kubernetes Secret updates are atomic
+// (symlink swap of the entire directory), so we must re-read both files together
+// rather than using the single-file content provided by FileWatcher.
+//
+// On failure, the previous certificate is preserved (graceful degradation).
+// This function satisfies the hotreload.ReloadCallback signature.
+func (r *CertReloader) ReloadCallback(_ string) error {
+	newCert, err := tls.LoadX509KeyPair(r.certFile, r.keyFile)
+	if err != nil {
+		return fmt.Errorf("cert reload failed (%s, %s): %w", r.certFile, r.keyFile, err)
+	}
+
+	r.mu.Lock()
+	r.cert = &newCert
+	r.mu.Unlock()
+	return nil
+}

--- a/pkg/shared/tls/tls.go
+++ b/pkg/shared/tls/tls.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2025 Jordi Gil.
+Copyright 2026 Jordi Gil.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,13 +19,19 @@ limitations under the License.
 package tls
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
+
+	"github.com/go-logr/logr"
+
+	"github.com/jordigilh/kubernaut/pkg/shared/hotreload"
 )
 
 // TLSConfig holds TLS configuration shared across services.
@@ -55,30 +61,34 @@ func (c TLSConfig) KeyPath() string {
 }
 
 // ConfigureConditionalTLS configures the server for TLS if cert files exist in certDir.
-// Returns (true, nil) if TLS was configured, (false, nil) if no certs found (plain HTTP),
-// or (false, error) if certs exist but are invalid.
-func ConfigureConditionalTLS(server *http.Server, certDir string) (bool, error) {
+// Returns (true, reloader, nil) if TLS was configured with hot-reload support,
+// (false, nil, nil) if no certs found (plain HTTP),
+// or (false, nil, error) if certs exist but are invalid.
+//
+// Issue #756: Returns a CertReloader that can be wired to a FileWatcher for
+// zero-downtime certificate rotation.
+func ConfigureConditionalTLS(server *http.Server, certDir string) (bool, *CertReloader, error) {
 	certFile := filepath.Join(certDir, "tls.crt")
 	keyFile := filepath.Join(certDir, "tls.key")
 
 	if _, err := os.Stat(certFile); os.IsNotExist(err) {
-		return false, nil
+		return false, nil, nil
 	}
 	if _, err := os.Stat(keyFile); os.IsNotExist(err) {
-		return false, nil
+		return false, nil, nil
 	}
 
-	cert, err := tls.LoadX509KeyPair(certFile, keyFile)
+	reloader, err := NewCertReloader(certFile, keyFile)
 	if err != nil {
-		return false, fmt.Errorf("failed to load TLS certificate from %s: %w", certDir, err)
+		return false, nil, fmt.Errorf("failed to load TLS certificate from %s: %w", certDir, err)
 	}
 
 	server.TLSConfig = &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		MinVersion:   tls.VersionTLS12,
+		GetCertificate: reloader.GetCertificate,
+		MinVersion:     tls.VersionTLS12,
 	}
 
-	return true, nil
+	return true, reloader, nil
 }
 
 // LoadCACert loads a PEM-encoded CA certificate from the given file path
@@ -97,11 +107,27 @@ func LoadCACert(caFile string) (*x509.CertPool, error) {
 	return pool, nil
 }
 
-// DefaultBaseTransport returns an http.Transport pre-configured with the CA
-// certificate at $TLS_CA_FILE (if set). Services inject this into their
-// auth-wrapping transports so inter-service HTTPS calls trust the cluster CA.
-// When TLS_CA_FILE is unset or empty, returns a plain Transport.
-func DefaultBaseTransport() (*http.Transport, error) {
+// Singleton CAReloader for process-wide client TLS.
+// Initialized lazily by DefaultBaseTransport via sync.Once.
+var (
+	caReloaderOnce     sync.Once
+	caReloaderInstance *CAReloader
+	caReloaderErr      error
+
+	// mu protects singleton reset (testing only)
+	singletonMu sync.Mutex
+)
+
+// DefaultBaseTransport returns an http.RoundTripper pre-configured with the CA
+// certificate at $TLS_CA_FILE (if set). When TLS_CA_FILE points to a valid CA
+// file, a process-level CAReloader is initialized (once) and returned as the
+// RoundTripper — this enables hot-reload when the CA file is rotated.
+//
+// When TLS_CA_FILE is unset or empty, returns a plain http.Transport.
+//
+// Issue #756: Changed return type from *http.Transport to http.RoundTripper to
+// accommodate CAReloader which implements RoundTripper with hot-reload.
+func DefaultBaseTransport() (http.RoundTripper, error) {
 	caFile := os.Getenv("TLS_CA_FILE")
 	if caFile == "" {
 		return &http.Transport{
@@ -110,7 +136,60 @@ func DefaultBaseTransport() (*http.Transport, error) {
 			IdleConnTimeout:     90 * time.Second,
 		}, nil
 	}
-	return NewTLSTransport(caFile)
+
+	singletonMu.Lock()
+	defer singletonMu.Unlock()
+
+	caReloaderOnce.Do(func() {
+		caReloaderInstance, caReloaderErr = NewCAReloaderFromFile(caFile)
+	})
+	if caReloaderErr != nil {
+		return nil, caReloaderErr
+	}
+	return caReloaderInstance, nil
+}
+
+// ResetDefaultTransportForTesting resets the singleton CAReloader so that
+// tests run with a clean slate. Must only be called from test code.
+func ResetDefaultTransportForTesting() {
+	singletonMu.Lock()
+	defer singletonMu.Unlock()
+	caReloaderOnce = sync.Once{}
+	caReloaderInstance = nil
+	caReloaderErr = nil
+}
+
+// StartCAFileWatcher initializes the CA reloader singleton and starts a
+// FileWatcher on $TLS_CA_FILE. Returns nil watcher if TLS_CA_FILE is unset.
+// The returned watcher must be stopped by the caller (defer watcher.Stop()).
+func StartCAFileWatcher(ctx context.Context, logger logr.Logger) (*hotreload.FileWatcher, error) {
+	caFile := os.Getenv("TLS_CA_FILE")
+	if caFile == "" {
+		return nil, nil
+	}
+
+	rt, err := DefaultBaseTransport()
+	if err != nil {
+		return nil, fmt.Errorf("failed to initialize CA reloader: %w", err)
+	}
+
+	reloader, ok := rt.(*CAReloader)
+	if !ok {
+		return nil, nil
+	}
+
+	watcher, err := hotreload.NewFileWatcher(
+		caFile,
+		reloader.ReloadCallback,
+		logger.WithName("ca-reloader"),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create CA file watcher: %w", err)
+	}
+	if err := watcher.Start(ctx); err != nil {
+		return nil, fmt.Errorf("failed to start CA file watcher: %w", err)
+	}
+	return watcher, nil
 }
 
 // NewTLSTransport creates an http.Transport configured with a custom CA pool

--- a/test/integration/shared/tls/tls_integration_test.go
+++ b/test/integration/shared/tls/tls_integration_test.go
@@ -131,7 +131,7 @@ var _ = Describe("TLS Integration Tests (#493)", func() {
 		})
 
 		server := &http.Server{Handler: mux}
-		isTLS, err := sharedtls.ConfigureConditionalTLS(server, certDir)
+		isTLS, _, err := sharedtls.ConfigureConditionalTLS(server, certDir)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(isTLS).To(BeTrue())
 

--- a/test/unit/aianalysis/agentclient_tls_test.go
+++ b/test/unit/aianalysis/agentclient_tls_test.go
@@ -32,6 +32,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/jordigilh/kubernaut/pkg/agentclient"
+	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
 )
 
 var _ = Describe("BR-INTEGRATION-750: agentclient inter-service TLS trust (#750)", func() {
@@ -42,6 +43,7 @@ var _ = Describe("BR-INTEGRATION-750: agentclient inter-service TLS trust (#750)
 	)
 
 	BeforeEach(func() {
+		sharedtls.ResetDefaultTransportForTesting()
 		origTLSCAFile, hadTLSCAFile = os.LookupEnv("TLS_CA_FILE")
 	})
 
@@ -51,6 +53,7 @@ var _ = Describe("BR-INTEGRATION-750: agentclient inter-service TLS trust (#750)
 		} else {
 			os.Unsetenv("TLS_CA_FILE")
 		}
+		sharedtls.ResetDefaultTransportForTesting()
 	})
 
 	generateSelfSignedCA := func(certFile string) {

--- a/test/unit/authwebhook/ds_client_tls_test.go
+++ b/test/unit/authwebhook/ds_client_tls_test.go
@@ -33,6 +33,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/jordigilh/kubernaut/pkg/authwebhook"
+	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
 )
 
 var _ = Describe("BR-INTEGRATION-750: authwebhook DSClientAdapter inter-service TLS trust (#750)", func() {
@@ -43,6 +44,7 @@ var _ = Describe("BR-INTEGRATION-750: authwebhook DSClientAdapter inter-service 
 	)
 
 	BeforeEach(func() {
+		sharedtls.ResetDefaultTransportForTesting()
 		origTLSCAFile, hadTLSCAFile = os.LookupEnv("TLS_CA_FILE")
 	})
 
@@ -52,6 +54,7 @@ var _ = Describe("BR-INTEGRATION-750: authwebhook DSClientAdapter inter-service 
 		} else {
 			os.Unsetenv("TLS_CA_FILE")
 		}
+		sharedtls.ResetDefaultTransportForTesting()
 	})
 
 	generateSelfSignedCA := func(certFile string) {

--- a/test/unit/shared/tls/ca_reloader_test.go
+++ b/test/unit/shared/tls/ca_reloader_test.go
@@ -70,6 +70,25 @@ var _ = Describe("CAReloader (#756)", func() {
 		return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
 	}
 
+	// subjectFromPEM extracts the raw subject bytes from a PEM-encoded cert
+	// so we can assert our specific CA is present in the pool.
+	subjectFromPEM := func(pemData []byte) []byte {
+		block, _ := pem.Decode(pemData)
+		Expect(block.Type).To(Equal("CERTIFICATE"), "PEM block must be a CERTIFICATE")
+		cert, err := x509.ParseCertificate(block.Bytes)
+		Expect(err).ToNot(HaveOccurred())
+		return cert.RawSubject
+	}
+
+	poolContainsSubject := func(pool *x509.CertPool, subject []byte) bool {
+		for _, s := range pool.Subjects() { //nolint:staticcheck
+			if string(s) == string(subject) {
+				return true
+			}
+		}
+		return false
+	}
+
 	writeCAFile := func(cn string) string {
 		caPath := filepath.Join(certDir, "ca.crt")
 		pemBytes := generateCAPEM(cn)
@@ -84,7 +103,7 @@ var _ = Describe("CAReloader (#756)", func() {
 
 		reloader, err := sharedtls.NewCAReloader(pemBytes)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(reloader.GetCertPool().Subjects()).To(HaveLen(1),
+		Expect(poolContainsSubject(reloader.GetCertPool(), subjectFromPEM(pemBytes))).To(BeTrue(),
 			"reloader must contain the loaded CA certificate")
 	})
 
@@ -109,14 +128,16 @@ var _ = Describe("CAReloader (#756)", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		poolBefore := reloader.GetCertPool()
-		Expect(poolBefore.Subjects()).To(HaveLen(1), "initial pool must have one CA")
+		Expect(poolContainsSubject(poolBefore, subjectFromPEM(pemBytes))).To(BeTrue(),
+			"initial pool must contain the initial CA")
 
 		newPEM := generateCAPEM("rotated-ca")
 		err = reloader.ReloadCallback(string(newPEM))
 		Expect(err).ToNot(HaveOccurred())
 
 		poolAfter := reloader.GetCertPool()
-		Expect(poolAfter.Subjects()).To(HaveLen(1), "reloaded pool must have one CA")
+		Expect(poolContainsSubject(poolAfter, subjectFromPEM(newPEM))).To(BeTrue(),
+			"reloaded pool must contain the rotated CA")
 		Expect(poolAfter).ToNot(BeIdenticalTo(poolBefore),
 			"cert pool must be replaced after reload")
 	})
@@ -188,10 +209,12 @@ var _ = Describe("CAReloader (#756)", func() {
 	// BR-SECURITY-756: Convenience constructor for file-based CA initialization
 	It("UT-TLS-756-017: should load CA from file path", func() {
 		caPath := writeCAFile("file-ca")
-
-		reloader, err := sharedtls.NewCAReloaderFromFile(caPath)
+		pemData, err := os.ReadFile(caPath)
 		Expect(err).ToNot(HaveOccurred())
-		Expect(reloader.GetCertPool().Subjects()).To(HaveLen(1),
+
+		reloader, fileErr := sharedtls.NewCAReloaderFromFile(caPath)
+		Expect(fileErr).ToNot(HaveOccurred())
+		Expect(poolContainsSubject(reloader.GetCertPool(), subjectFromPEM(pemData))).To(BeTrue(),
 			"file-loaded reloader must contain the CA certificate")
 	})
 
@@ -214,7 +237,7 @@ var _ = Describe("CAReloader (#756)", func() {
 		Expect(transport.TLSClientConfig.MinVersion).To(
 			BeNumerically(">=", uint16(0x0303)),
 			"minimum TLS version must be at least TLS 1.2 (0x0303)")
-		Expect(transport.TLSClientConfig.RootCAs.Subjects()).To(HaveLen(1),
+		Expect(poolContainsSubject(transport.TLSClientConfig.RootCAs, subjectFromPEM(pemBytes))).To(BeTrue(),
 			"transport must have the CA in its root CA pool")
 	})
 })

--- a/test/unit/shared/tls/ca_reloader_test.go
+++ b/test/unit/shared/tls/ca_reloader_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
+)
+
+var _ = Describe("CAReloader (#756)", func() {
+
+	var certDir string
+
+	BeforeEach(func() {
+		var err error
+		certDir, err = os.MkdirTemp("", "ca-reloader-test-*")
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		_ = os.RemoveAll(certDir)
+	})
+
+	generateCAPEM := func(cn string) []byte {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		Expect(err).ToNot(HaveOccurred())
+
+		template := &x509.Certificate{
+			SerialNumber:          big.NewInt(time.Now().UnixNano()),
+			Subject:               pkix.Name{CommonName: cn},
+			NotBefore:             time.Now().Add(-1 * time.Hour),
+			NotAfter:              time.Now().Add(24 * time.Hour),
+			IsCA:                  true,
+			BasicConstraintsValid: true,
+			KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		}
+
+		certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+		Expect(err).ToNot(HaveOccurred())
+
+		return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	}
+
+	writeCAFile := func(cn string) string {
+		caPath := filepath.Join(certDir, "ca.crt")
+		pemBytes := generateCAPEM(cn)
+		Expect(os.WriteFile(caPath, pemBytes, 0644)).To(Succeed())
+		return caPath
+	}
+
+	// UT-TLS-756-010: NewCAReloader loads initial CA from PEM data
+	// BR-SECURITY-756: CA certificates must be loaded at startup
+	It("UT-TLS-756-010: should load initial CA from PEM data", func() {
+		pemBytes := generateCAPEM("test-ca")
+
+		reloader, err := sharedtls.NewCAReloader(pemBytes)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(reloader.GetCertPool().Subjects()).To(HaveLen(1),
+			"reloader must contain the loaded CA certificate")
+	})
+
+	// UT-TLS-756-011: RoundTrip delegates to the underlying transport
+	// BR-SECURITY-756: CAReloader must implement http.RoundTripper
+	It("UT-TLS-756-011: should implement http.RoundTripper", func() {
+		pemBytes := generateCAPEM("roundtrip-ca")
+
+		reloader, err := sharedtls.NewCAReloader(pemBytes)
+		Expect(err).ToNot(HaveOccurred())
+
+		var rt http.RoundTripper = reloader
+		_ = rt
+	})
+
+	// UT-TLS-756-012: ReloadCallback swaps transport with new CA
+	// BR-SECURITY-756: Rotated CA must be picked up without restart
+	It("UT-TLS-756-012: should swap transport on ReloadCallback", func() {
+		pemBytes := generateCAPEM("initial-ca")
+
+		reloader, err := sharedtls.NewCAReloader(pemBytes)
+		Expect(err).ToNot(HaveOccurred())
+
+		poolBefore := reloader.GetCertPool()
+		Expect(poolBefore.Subjects()).To(HaveLen(1), "initial pool must have one CA")
+
+		newPEM := generateCAPEM("rotated-ca")
+		err = reloader.ReloadCallback(string(newPEM))
+		Expect(err).ToNot(HaveOccurred())
+
+		poolAfter := reloader.GetCertPool()
+		Expect(poolAfter.Subjects()).To(HaveLen(1), "reloaded pool must have one CA")
+		Expect(poolAfter).ToNot(BeIdenticalTo(poolBefore),
+			"cert pool must be replaced after reload")
+	})
+
+	// UT-TLS-756-013: ReloadCallback preserves previous transport on invalid PEM
+	// BR-SECURITY-756: Graceful degradation on bad CA data
+	It("UT-TLS-756-013: should keep previous transport on invalid PEM", func() {
+		pemBytes := generateCAPEM("good-ca")
+
+		reloader, err := sharedtls.NewCAReloader(pemBytes)
+		Expect(err).ToNot(HaveOccurred())
+
+		poolBefore := reloader.GetCertPool()
+
+		err = reloader.ReloadCallback("not-valid-pem")
+		Expect(err).To(HaveOccurred(), "must return error for invalid PEM")
+
+		poolAfter := reloader.GetCertPool()
+		Expect(poolAfter).To(BeIdenticalTo(poolBefore),
+			"must preserve previous cert pool after failed reload")
+	})
+
+	// UT-TLS-756-014: NewCAReloader fails on invalid PEM data
+	// BR-SECURITY-756: Startup must fail fast on corrupt CA
+	It("UT-TLS-756-014: should fail on invalid PEM data", func() {
+		_, err := sharedtls.NewCAReloader([]byte("garbage"))
+		Expect(err).To(HaveOccurred())
+	})
+
+	// UT-TLS-756-015: NewCAReloader fails on empty PEM data
+	// BR-SECURITY-756: Empty CA data must be rejected
+	It("UT-TLS-756-015: should fail on empty PEM data", func() {
+		_, err := sharedtls.NewCAReloader([]byte{})
+		Expect(err).To(HaveOccurred())
+	})
+
+	// UT-TLS-756-016: Concurrent RoundTrip and ReloadCallback are race-free
+	// BR-SECURITY-756: Must be safe during concurrent requests and rotation
+	It("UT-TLS-756-016: should be safe for concurrent access", func() {
+		pemBytes := generateCAPEM("concurrent-ca")
+
+		reloader, err := sharedtls.NewCAReloader(pemBytes)
+		Expect(err).ToNot(HaveOccurred())
+
+		const goroutines = 50
+		var wg sync.WaitGroup
+		wg.Add(goroutines * 2)
+
+		for i := 0; i < goroutines; i++ {
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+				pool := reloader.GetCertPool()
+				Expect(pool.Subjects()).ToNot(BeEmpty(),
+					"cert pool must always contain at least one CA during concurrent access")
+			}()
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+				newPEM := generateCAPEM("concurrent-reload")
+				_ = reloader.ReloadCallback(string(newPEM))
+			}()
+		}
+
+		wg.Wait()
+	})
+
+	// UT-TLS-756-017: NewCAReloaderFromFile loads CA from file path
+	// BR-SECURITY-756: Convenience constructor for file-based CA initialization
+	It("UT-TLS-756-017: should load CA from file path", func() {
+		caPath := writeCAFile("file-ca")
+
+		reloader, err := sharedtls.NewCAReloaderFromFile(caPath)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(reloader.GetCertPool().Subjects()).To(HaveLen(1),
+			"file-loaded reloader must contain the CA certificate")
+	})
+
+	// UT-TLS-756-018: NewCAReloaderFromFile fails on missing file
+	// BR-SECURITY-756: Startup must fail fast if CA file is missing
+	It("UT-TLS-756-018: should fail on missing CA file", func() {
+		_, err := sharedtls.NewCAReloaderFromFile("/nonexistent/ca.crt")
+		Expect(err).To(HaveOccurred())
+	})
+
+	// UT-TLS-756-019: Transport enforces MinVersion TLS 1.2
+	// BR-SECURITY-756: No TLS downgrade below 1.2
+	It("UT-TLS-756-019: should enforce TLS 1.2 minimum", func() {
+		pemBytes := generateCAPEM("tls-version-ca")
+
+		reloader, err := sharedtls.NewCAReloader(pemBytes)
+		Expect(err).ToNot(HaveOccurred())
+
+		transport := reloader.CurrentTransport()
+		Expect(transport.TLSClientConfig.MinVersion).To(
+			BeNumerically(">=", uint16(0x0303)),
+			"minimum TLS version must be at least TLS 1.2 (0x0303)")
+		Expect(transport.TLSClientConfig.RootCAs.Subjects()).To(HaveLen(1),
+			"transport must have the CA in its root CA pool")
+	})
+})

--- a/test/unit/shared/tls/cert_reloader_test.go
+++ b/test/unit/shared/tls/cert_reloader_test.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tls
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
+)
+
+var _ = Describe("CertReloader (#756)", func() {
+
+	var (
+		certDir  string
+		certPath string
+		keyPath  string
+	)
+
+	BeforeEach(func() {
+		var err error
+		certDir, err = os.MkdirTemp("", "cert-reloader-test-*")
+		Expect(err).ToNot(HaveOccurred())
+		certPath = filepath.Join(certDir, "tls.crt")
+		keyPath = filepath.Join(certDir, "tls.key")
+	})
+
+	AfterEach(func() {
+		_ = os.RemoveAll(certDir)
+	})
+
+	generateCert := func(cn string) (*ecdsa.PrivateKey, []byte) {
+		key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		Expect(err).ToNot(HaveOccurred())
+
+		template := &x509.Certificate{
+			SerialNumber: big.NewInt(time.Now().UnixNano()),
+			Subject:      pkix.Name{CommonName: cn},
+			NotBefore:    time.Now().Add(-1 * time.Hour),
+			NotAfter:     time.Now().Add(24 * time.Hour),
+			KeyUsage:     x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+			IPAddresses:  []net.IP{net.IPv4(127, 0, 0, 1)},
+			DNSNames:     []string{"localhost"},
+		}
+
+		certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+		Expect(err).ToNot(HaveOccurred())
+		return key, certDER
+	}
+
+	writeCertAndKey := func(cn string) {
+		key, certDER := generateCert(cn)
+
+		certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+		Expect(os.WriteFile(certPath, certPEM, 0644)).To(Succeed())
+
+		keyDER, err := x509.MarshalECPrivateKey(key)
+		Expect(err).ToNot(HaveOccurred())
+		keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+		Expect(os.WriteFile(keyPath, keyPEM, 0600)).To(Succeed())
+	}
+
+	// UT-TLS-756-001: NewCertReloader loads initial certificate from disk
+	// BR-SECURITY-756: Server certificates must be loaded at startup
+	It("UT-TLS-756-001: should load initial certificate from disk", func() {
+		writeCertAndKey("initial-cert")
+
+		reloader, err := sharedtls.NewCertReloader(certPath, keyPath)
+		Expect(err).ToNot(HaveOccurred())
+
+		cert, err := reloader.GetCertificate(&tls.ClientHelloInfo{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cert.Certificate).To(HaveLen(1),
+			"newly created reloader must serve exactly one certificate")
+	})
+
+	// UT-TLS-756-002: GetCertificate returns loaded certificate for TLS handshake
+	// BR-SECURITY-756: tls.Config.GetCertificate must serve current cert
+	It("UT-TLS-756-002: should return certificate via GetCertificate", func() {
+		writeCertAndKey("get-cert-test")
+
+		reloader, err := sharedtls.NewCertReloader(certPath, keyPath)
+		Expect(err).ToNot(HaveOccurred())
+
+		cert, err := reloader.GetCertificate(&tls.ClientHelloInfo{})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(cert.Certificate).ToNot(BeEmpty(), "certificate chain must contain at least one cert")
+
+		leaf, err := x509.ParseCertificate(cert.Certificate[0])
+		Expect(err).ToNot(HaveOccurred())
+		Expect(leaf.Subject.CommonName).To(Equal("get-cert-test"))
+	})
+
+	// UT-TLS-756-003: ReloadCallback re-reads both files from disk after rotation
+	// BR-SECURITY-756: Certificate rotation must be picked up without restart
+	It("UT-TLS-756-003: should reload rotated certificate from disk", func() {
+		writeCertAndKey("before-rotation")
+
+		reloader, err := sharedtls.NewCertReloader(certPath, keyPath)
+		Expect(err).ToNot(HaveOccurred())
+
+		cert, err := reloader.GetCertificate(&tls.ClientHelloInfo{})
+		Expect(err).ToNot(HaveOccurred())
+		leaf, err := x509.ParseCertificate(cert.Certificate[0])
+		Expect(err).ToNot(HaveOccurred())
+		Expect(leaf.Subject.CommonName).To(Equal("before-rotation"))
+
+		writeCertAndKey("after-rotation")
+
+		err = reloader.ReloadCallback("ignored-content")
+		Expect(err).ToNot(HaveOccurred())
+
+		cert, err = reloader.GetCertificate(&tls.ClientHelloInfo{})
+		Expect(err).ToNot(HaveOccurred())
+		leaf, err = x509.ParseCertificate(cert.Certificate[0])
+		Expect(err).ToNot(HaveOccurred())
+		Expect(leaf.Subject.CommonName).To(Equal("after-rotation"),
+			"GetCertificate must serve the rotated certificate after ReloadCallback")
+	})
+
+	// UT-TLS-756-004: ReloadCallback preserves previous cert on invalid new cert
+	// BR-SECURITY-756: Graceful degradation -- bad cert must not break TLS
+	It("UT-TLS-756-004: should keep previous cert when reload fails", func() {
+		writeCertAndKey("good-cert")
+
+		reloader, err := sharedtls.NewCertReloader(certPath, keyPath)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(os.WriteFile(certPath, []byte("not-a-cert"), 0644)).To(Succeed())
+		Expect(os.WriteFile(keyPath, []byte("not-a-key"), 0600)).To(Succeed())
+
+		err = reloader.ReloadCallback("ignored")
+		Expect(err).To(HaveOccurred(), "ReloadCallback must return error for invalid cert")
+
+		cert, err := reloader.GetCertificate(&tls.ClientHelloInfo{})
+		Expect(err).ToNot(HaveOccurred())
+		leaf, err := x509.ParseCertificate(cert.Certificate[0])
+		Expect(err).ToNot(HaveOccurred())
+		Expect(leaf.Subject.CommonName).To(Equal("good-cert"),
+			"must preserve previous good certificate after failed reload")
+	})
+
+	// UT-TLS-756-005: NewCertReloader fails on missing cert file
+	// BR-SECURITY-756: Startup must fail fast if certs are missing
+	It("UT-TLS-756-005: should fail on missing cert file", func() {
+		_, err := sharedtls.NewCertReloader("/nonexistent/tls.crt", "/nonexistent/tls.key")
+		Expect(err).To(HaveOccurred())
+	})
+
+	// UT-TLS-756-006: NewCertReloader fails on invalid cert content
+	// BR-SECURITY-756: Startup must fail fast on corrupt certificates
+	It("UT-TLS-756-006: should fail on invalid cert content at startup", func() {
+		Expect(os.WriteFile(certPath, []byte("garbage"), 0644)).To(Succeed())
+		Expect(os.WriteFile(keyPath, []byte("garbage"), 0600)).To(Succeed())
+
+		_, err := sharedtls.NewCertReloader(certPath, keyPath)
+		Expect(err).To(HaveOccurred())
+	})
+
+	// UT-TLS-756-007: Concurrent GetCertificate and ReloadCallback are race-free
+	// BR-SECURITY-756: Must be safe for concurrent TLS handshakes during rotation
+	It("UT-TLS-756-007: should be safe for concurrent access", func() {
+		writeCertAndKey("concurrent-test")
+
+		reloader, err := sharedtls.NewCertReloader(certPath, keyPath)
+		Expect(err).ToNot(HaveOccurred())
+
+		const goroutines = 50
+		var wg sync.WaitGroup
+		wg.Add(goroutines * 2)
+
+		for i := 0; i < goroutines; i++ {
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+				cert, err := reloader.GetCertificate(&tls.ClientHelloInfo{})
+				Expect(err).ToNot(HaveOccurred())
+				Expect(cert.Certificate).ToNot(BeEmpty(),
+					"concurrent GetCertificate must always return a valid certificate chain")
+			}()
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+				_ = reloader.ReloadCallback("ignored")
+			}()
+		}
+
+		wg.Wait()
+	})
+
+	// UT-TLS-756-008: ReloadCallback preserves previous cert when cert file disappears
+	// BR-SECURITY-756: Transient file absence during rotation must not break TLS
+	It("UT-TLS-756-008: should preserve cert when file temporarily disappears", func() {
+		writeCertAndKey("stable-cert")
+
+		reloader, err := sharedtls.NewCertReloader(certPath, keyPath)
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(os.Remove(certPath)).To(Succeed())
+
+		err = reloader.ReloadCallback("ignored")
+		Expect(err).To(HaveOccurred(), "ReloadCallback must error when cert file is missing")
+
+		cert, err := reloader.GetCertificate(&tls.ClientHelloInfo{})
+		Expect(err).ToNot(HaveOccurred())
+		leaf, err := x509.ParseCertificate(cert.Certificate[0])
+		Expect(err).ToNot(HaveOccurred())
+		Expect(leaf.Subject.CommonName).To(Equal("stable-cert"),
+			"must serve previous cert when file disappears")
+	})
+})

--- a/test/unit/shared/tls/tls_test.go
+++ b/test/unit/shared/tls/tls_test.go
@@ -20,6 +20,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
@@ -91,16 +92,19 @@ var _ = Describe("Shared TLS Helper (#493)", func() {
 			generateSelfSignedCert(certPath, keyPath)
 
 			server := &http.Server{Addr: ":0"}
-			isTLS, err := sharedtls.ConfigureConditionalTLS(server, certDir)
+			isTLS, _, err := sharedtls.ConfigureConditionalTLS(server, certDir)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isTLS).To(BeTrue(), "should detect TLS certs and configure TLS")
-			Expect(server.TLSConfig.Certificates).To(HaveLen(1), "TLS config should contain exactly one certificate")
+
+			cert, certErr := server.TLSConfig.GetCertificate(&tls.ClientHelloInfo{})
+			Expect(certErr).ToNot(HaveOccurred())
+			Expect(cert.Certificate).To(HaveLen(1), "TLS cert chain should contain exactly one certificate")
 		})
 
 		// UT-TLS-493-002: ConditionalTLS starts HTTP when cert files don't exist
 		It("UT-TLS-493-002: should start HTTP when cert files don't exist", func() {
 			server := &http.Server{Addr: ":0"}
-			isTLS, err := sharedtls.ConfigureConditionalTLS(server, certDir)
+			isTLS, _, err := sharedtls.ConfigureConditionalTLS(server, certDir)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(isTLS).To(BeFalse(), "no certs, should remain plain HTTP")
 			Expect(server.TLSConfig).To(BeNil(), "TLSConfig must remain nil when no certs exist")
@@ -112,7 +116,7 @@ var _ = Describe("Shared TLS Helper (#493)", func() {
 			Expect(os.WriteFile(keyPath, []byte("not-a-key"), 0600)).To(Succeed())
 
 			server := &http.Server{Addr: ":0"}
-			_, err := sharedtls.ConfigureConditionalTLS(server, certDir)
+			_, _, err := sharedtls.ConfigureConditionalTLS(server, certDir)
 			Expect(err).To(HaveOccurred())
 		})
 	})


### PR DESCRIPTION
## Summary

- **Issue #756**: Implement hot-reload for both server-side TLS certificates (`CertReloader` via `GetCertificate` callback) and client-side CA trust (`CAReloader` as `http.RoundTripper` with atomic transport swap). Wires `FileWatcher` into all 10 services for zero-downtime certificate rotation when Kubernetes Secrets/ConfigMaps are rotated by cert-manager or OCP service-ca.
- **Issue #758**: Add `--platform linux/$(IMAGE_ARCH)` to `image-runtime-%` Makefile target to produce correct multi-arch manifests for arm64 builds.

## Changes

### Core TLS Hot-Reload (#756)
- `pkg/shared/tls/cert_reloader.go` — Server-side: `CertReloader` with `GetCertificate` + `ReloadCallback` (RWMutex, graceful degradation on failure)
- `pkg/shared/tls/ca_reloader.go` — Client-side: `CAReloader` implementing `http.RoundTripper` with atomic transport swap
- `pkg/shared/tls/tls.go` — `ConfigureConditionalTLS` returns `*CertReloader`; `DefaultBaseTransport` returns `http.RoundTripper` backed by singleton `CAReloader`; `StartCAFileWatcher` helper; `ResetDefaultTransportForTesting`

### Server-Side Wiring (#756)
- Gateway, DataStorage, KubernautAgent: store `CertReloader`, start `FileWatcher` on `tls.crt`, stop on shutdown

### Client-Side Wiring (#756)
- All 10 `cmd/` services: call `StartCAFileWatcher` with proper context lifecycle
- `aianalysis`, `workflowexecution`: extract `ctx` from `ctrl.SetupSignalHandler()` for watcher lifecycle
- EM: migrate from `emclient.CAReloader` to `sharedtls.NewCAReloader`; deprecate old type
- Test isolation: `ResetDefaultTransportForTesting()` in authwebhook + aianalysis tests

### Build Fix (#758)
- `Makefile`: add `--platform` flag to runtime image builds

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./test/unit/shared/tls/... -race` — CertReloader + CAReloader contract tests pass
- [x] `go test ./test/integration/shared/tls/... -race` — end-to-end TLS integration passes
- [x] `go test ./test/unit/authwebhook/...` — 162 specs pass (singleton isolation verified)
- [x] `go test ./test/unit/aianalysis/...` — agentclient TLS tests pass
- [x] `go test ./test/unit/effectivenessmonitor/...` — EM tests pass with shared CAReloader
- [x] All test packages compile (`go test ./test/... -run=^$`)
- [x] No lint errors in modified files
- [x] Pre-commit hook passes (no anti-patterns)

Closes #756
Fixes #758

Made with [Cursor](https://cursor.com)