### PR TITLE
fix: cluster-scoped enrichment, fingerprint unification, namespace validation & dedup (#762, #763, #764, #765)

### DIFF
--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -190,16 +190,17 @@ func main() {
 	}
 
 	inv := investigator.New(investigator.Config{
-		Client:       instrumentedLLM,
-		Builder:      promptBuilder,
-		ResultParser: resultParser,
-		Enricher:     enricher,
-		AuditStore:   auditStore,
-		Logger:       slogger,
-		MaxTurns:     cfg.Investigator.MaxTurns,
-		PhaseTools:   phaseTools,
-		Registry:     reg,
-		ModelName:    cfg.LLM.Model,
+		Client:        instrumentedLLM,
+		Builder:       promptBuilder,
+		ResultParser:  resultParser,
+		Enricher:      enricher,
+		AuditStore:    auditStore,
+		Logger:        slogger,
+		MaxTurns:      cfg.Investigator.MaxTurns,
+		PhaseTools:    phaseTools,
+		Registry:      reg,
+		ModelName:     cfg.LLM.Model,
+		ScopeResolver: investigator.NewMapperScopeResolver(k8sInfra.mapper),
 		Pipeline: investigator.Pipeline{
 			Sanitizer:         sanitizer,
 			AnomalyDetector:   anomalyDetector,

--- a/docs/architecture/decisions/DD-EM-002-canonical-spec-hash.md
+++ b/docs/architecture/decisions/DD-EM-002-canonical-spec-hash.md
@@ -10,6 +10,7 @@
 | 1.1 | 2026-02-14 | Architecture Team | Added Spec Drift Guard: re-hash on each reconcile, spec_drift reason, DS score=0.0 short-circuit |
 | 1.2 | 2026-02-24 | Architecture Team | **Issue #188 (DD-EM-003)**: Updated RO consumer description to reference `resolveDualTargets` (renamed from `resolveEffectivenessTarget`). Hash is now explicitly computed from the `RemediationTarget` (the AI-resolved resource), not the single `TargetResource`. |
 | 1.3 | 2026-03-04 | Architecture Team | **Issue #396**: ConfigMap-aware composite hashing. Spec hash now incorporates referenced ConfigMap `.data` and `.binaryData` content. Added `ExtractConfigMapRefs`, `ConfigMapDataHash`, `CompositeSpecHash` utilities. Sentinel value for absent/forbidden ConfigMaps. RBAC update for configmaps. |
+| 2.0 | 2026-04-06 | Architecture Team | **Issue #765**: Resource Fingerprint Generalization. Algorithm now hashes all functional state (not just `.spec`), enabling fingerprinting for ConfigMaps, ClusterRoles, Nodes, etc. `CanonicalResourceFingerprint` replaces `CanonicalSpecHash`. `CompositeResourceFingerprint` replaces `CompositeSpecHash`. No backwards compatibility (clean cut). Secrets excluded from cascading (Vault-managed, rotational). |
 
 ---
 

--- a/docs/tests/762/TEST_PLAN.md
+++ b/docs/tests/762/TEST_PLAN.md
@@ -1,0 +1,357 @@
+# Test Plan: Cluster-Scoped Enrichment + Resource Fingerprint Unification
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-762-v1
+**Feature**: Scope-aware enrichment pipeline, resource fingerprint generalization, namespace validation, enrichment deduplication
+**Version**: 1.0
+**Created**: 2026-04-06
+**Author**: AI Assistant
+**Status**: Active
+**Branch**: `fix/762-cluster-scoped-enrichment`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This test plan validates the combined fix for Issues #762, #763, #764, and #765. The enrichment pipeline incorrectly assumes all Kubernetes resources are namespace-scoped, causing API failures for cluster-scoped resources (Node, ClusterRole) that result in `rca_incomplete`. Additionally, the hash algorithm is limited to `.spec` fields, the investigator lacks namespace validation for cluster-scoped kinds, and enrichment is called redundantly.
+
+### 1.2 Objectives
+
+1. **Scope awareness (#762)**: K8sAdapter and LabelDetector use `RESTMapping.Scope` to correctly dispatch cluster-scoped vs namespaced API calls.
+2. **DS empty namespace (#762)**: DataStorage handler accepts empty `targetNamespace` for cluster-scoped resources and the adapter surfaces 400 errors.
+3. **Resource fingerprint (#765)**: `CanonicalResourceFingerprint` hashes all functional state (not just `.spec`), enabling fingerprinting for ConfigMap, ClusterRole, etc.
+4. **Namespace validation (#763)**: Investigator forces `namespace=""` for cluster-scoped kinds before enrichment.
+5. **Enrichment dedup (#764)**: Identical pre-RCA and post-RCA targets reuse cached enrichment results.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/...` |
+| Integration test pass rate | 100% | `go test ./test/integration/...` |
+| Unit-testable code coverage | >=80% | `go test -coverprofile` on unit-testable files |
+| Integration-testable code coverage | >=80% | `go test -coverprofile` on integration-testable files |
+| Backward compatibility | 0 regressions | Existing tests pass (hash values change — clean cut) |
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- BR-HAPI-261: Enrichment pipeline for incident investigation
+- DD-EM-002: Canonical spec hash for pre/post remediation comparison
+- Issue #762: Enrichment pipeline fails for cluster-scoped resources
+- Issue #763: Namespace injection validation
+- Issue #764: Enrichment deduplication
+- Issue #765: Hash algorithm unification / resource fingerprint generalization
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../../.cursor/rules/03-testing-strategy.mdc)
+- [Testing Guidelines](../../development/business-requirements/TESTING_GUIDELINES.md)
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | RESTMapper returns wrong scope for CRD kinds | Cluster-scoped CRD treated as namespaced | Low | UT-KA-762-001..004 | resettableMapper retry already included |
+| R2 | Hash value change breaks DS history lookup | No historical context for existing remediations | Medium | UT-HASH-765-001..008 | Clean cut accepted by user; no backwards compat |
+| R3 | InjectRemediationTarget namespace fallback wrong for cluster-scoped | Remediation target has wrong namespace in CRD | Medium | UT-KA-762-010 | Explicit cluster-scope namespace clearing |
+| R4 | DS 400 error surfaced breaks existing callers | Enrichment logs errors where it previously swallowed them silently | Low | UT-KA-762-008 | Enricher already handles sub-call errors gracefully |
+| R5 | Dedup cache returns stale data if enrichment is non-deterministic | Stale enrichment in workflow selection | Low | UT-KA-764-001..003 | Cache is per-call; investigation is single-request |
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **K8sAdapter** (`internal/kubernautagent/enrichment/k8s_adapter.go`): Scope-aware `GetOwnerChain`, `GetSpecHash`, `resolveMapping`
+- **LabelDetector** (`internal/kubernautagent/enrichment/label_detector.go`): Scope-aware `fetchResource`, skip namespace-scoped lists for cluster roots
+- **DS handler** (`pkg/datastorage/server/remediation_history_handler.go`): Accept empty namespace
+- **DS adapter** (`internal/kubernautagent/enrichment/ds_adapter.go`): Surface 400 errors
+- **InjectRemediationTarget** (`internal/kubernautagent/investigator/investigator.go`): Cluster-scope namespace fix
+- **CanonicalResourceFingerprint** (`pkg/shared/hash/canonical.go`): Functional state hashing
+- **CompositeResourceFingerprint** (`pkg/shared/hash/configmap.go`): Renamed composite hash
+- **CapturePreRemediationHash** (`internal/controller/remediationorchestrator/reconciler.go`): Uses fingerprint
+- **getTargetFunctionalState** (`internal/controller/effectivenessmonitor/target_resources.go`): Returns functional state + spec
+- **ScopeResolver** (`internal/kubernautagent/investigator/investigator.go`): Namespace forcing
+- **Enrichment cache** (`internal/kubernautagent/investigator/investigator.go`): Per-call dedup
+
+### 4.2 Features Not to be Tested
+
+- **Secret cascading**: Explicitly excluded per user directive (Vault-managed, rotational)
+- **SignalProcessing owner chain**: Uses static `isClusterScoped` map; separate concern
+- **E2E tests**: Deferred; unit + integration provide >=80% coverage
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Delete `CanonicalSpecHash` (no deprecation) | Clean cut; no backwards compatibility per user directive |
+| Dedup cache as local variable, not struct field | Thread safety: `Investigate()` runs concurrently on shared `Investigator` |
+| `ExtractConfigMapRefs` still operates on `.spec` | Needs pod template structure which lives under `.spec`; independent from fingerprint |
+| No Secret cascading in fingerprint | Secrets are Vault-managed, rotational, not functional configuration state |
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+- **Unit**: >=80% of unit-testable code (hash functions, scope helpers, adapter logic, investigator enrichment paths)
+- **Integration**: >=80% of integration-testable code (DS handler, enrichment wiring, RO/EM hash capture)
+- **E2E**: Deferred (container contract validated by unit + integration)
+
+### 5.2 Two-Tier Minimum
+
+Every business requirement is covered by at least 2 test tiers (UT + IT).
+
+### 5.3 Pass/Fail Criteria
+
+**PASS**: All P0 tests pass, per-tier coverage >=80%, no regressions in existing test suites.
+**FAIL**: Any P0 test fails, coverage below 80%, or existing tests regress.
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `pkg/shared/hash/canonical.go` | `CanonicalResourceFingerprint`, `normalizeValue` | ~50 |
+| `pkg/shared/hash/configmap.go` | `CompositeResourceFingerprint`, `ExtractConfigMapRefs` | ~225 |
+| `internal/kubernautagent/enrichment/k8s_adapter.go` | `resolveMapping`, `GetOwnerChain`, `GetSpecHash` | ~187 |
+| `internal/kubernautagent/enrichment/label_detector.go` | `fetchResource`, `resolveMapping`, `detectHPA/PDB/NP/RQ` | ~322 |
+| `internal/kubernautagent/enrichment/ds_adapter.go` | `GetRemediationHistory` | ~237 |
+| `internal/kubernautagent/investigator/investigator.go` | `InjectRemediationTarget`, `ResolveEnrichmentTarget`, `Investigate` | ~959 |
+
+### 6.2 Integration-Testable Code
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `pkg/datastorage/server/remediation_history_handler.go` | `HandleGetRemediationHistoryContext` | ~259 |
+| `internal/controller/remediationorchestrator/reconciler.go` | `CapturePreRemediationHash`, `resolveConfigMapHashes` | ~125 |
+| `internal/controller/effectivenessmonitor/target_resources.go` | `getTargetFunctionalState`, `resolveConfigMapHashes` | ~257 |
+
+---
+
+## 7. BR Coverage Matrix
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-HAPI-261 | Enrichment for cluster-scoped resources | P0 | Unit | UT-KA-762-001..006 | Pending |
+| BR-HAPI-261 | Enrichment for cluster-scoped resources | P0 | Integration | IT-KA-762-001..003 | Pending |
+| BR-HAPI-261 | DS accepts empty namespace | P0 | Unit | UT-KA-762-007..009 | Pending |
+| BR-HAPI-261 | InjectRemediationTarget cluster fix | P0 | Unit | UT-KA-762-010..011 | Pending |
+| BR-EM-004 | Resource fingerprint unification | P0 | Unit | UT-HASH-765-001..008 | Pending |
+| BR-EM-004 | RO/EM fingerprint consumers | P0 | Unit | UT-HASH-765-009..012 | Pending |
+| BR-HAPI-261 | Namespace injection validation | P1 | Unit | UT-KA-763-001..004 | Pending |
+| BR-HAPI-261 | Enrichment deduplication | P1 | Unit | UT-KA-764-001..003 | Pending |
+
+---
+
+## 8. Test Scenarios
+
+### Tier 1: Unit Tests
+
+#### Phase 1 — Core Scope Fix (#762)
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-KA-762-001` | K8sAdapter.GetOwnerChain uses cluster-scoped client for Node kind (no namespace) | Pending |
+| `UT-KA-762-002` | K8sAdapter.GetOwnerChain uses namespaced client for Deployment kind | Pending |
+| `UT-KA-762-003` | K8sAdapter.GetSpecHash uses cluster-scoped client for Node kind | Pending |
+| `UT-KA-762-004` | K8sAdapter.GetSpecHash uses namespaced client for Deployment kind | Pending |
+| `UT-KA-762-005` | LabelDetector.fetchResource uses scope-aware client dispatch | Pending |
+| `UT-KA-762-006` | LabelDetector skips HPA/PDB/NP/RQ list when rootNS is empty (cluster-scoped root) | Pending |
+| `UT-KA-762-007` | DS handler accepts empty targetNamespace and returns 200 | Pending |
+| `UT-KA-762-008` | DS adapter returns error on 400 Bad Request (not empty result) | Pending |
+| `UT-KA-762-009` | DS handler still rejects empty targetKind with 400 | Pending |
+| `UT-KA-762-010` | InjectRemediationTarget sets namespace="" for cluster-scoped enrichment | Pending |
+| `UT-KA-762-011` | InjectRemediationTarget preserves namespace for namespaced enrichment (no regression) | Pending |
+
+#### Phase 2 — Resource Fingerprint (#765)
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-HASH-765-001` | CanonicalResourceFingerprint strips metadata/status/apiVersion/kind | Pending |
+| `UT-HASH-765-002` | CanonicalResourceFingerprint produces stable hash for Deployment object | Pending |
+| `UT-HASH-765-003` | CanonicalResourceFingerprint captures ConfigMap .data/.binaryData | Pending |
+| `UT-HASH-765-004` | CanonicalResourceFingerprint captures ClusterRole .rules | Pending |
+| `UT-HASH-765-005` | CanonicalResourceFingerprint is idempotent (1000 iterations) | Pending |
+| `UT-HASH-765-006` | CanonicalResourceFingerprint map-order and slice-order independent | Pending |
+| `UT-HASH-765-007` | CompositeResourceFingerprint identity when no ConfigMap hashes | Pending |
+| `UT-HASH-765-008` | CompositeResourceFingerprint includes ConfigMap content in digest | Pending |
+| `UT-HASH-765-009` | CapturePreRemediationHash uses CanonicalResourceFingerprint | Pending |
+| `UT-HASH-765-010` | EM getTargetFunctionalState returns functional state + spec separately | Pending |
+| `UT-HASH-765-011` | EM handleSpecDrift uses CanonicalResourceFingerprint | Pending |
+| `UT-HASH-765-012` | K8sAdapter.GetSpecHash uses CanonicalResourceFingerprint | Pending |
+
+#### Phase 3 — Namespace Validation (#763)
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-KA-763-001` | ScopeResolver.IsClusterScoped returns true for Node | Pending |
+| `UT-KA-763-002` | ScopeResolver.IsClusterScoped returns false for Deployment | Pending |
+| `UT-KA-763-003` | Investigate forces namespace="" for cluster-scoped signal kind | Pending |
+| `UT-KA-763-004` | Investigate preserves namespace for namespaced signal kind | Pending |
+
+#### Phase 4 — Enrichment Deduplication (#764)
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-KA-764-001` | Enrichment called once when pre/post RCA targets identical | Pending |
+| `UT-KA-764-002` | Enrichment called twice when post-RCA target differs from signal | Pending |
+| `UT-KA-764-003` | Cache is per-call (not shared across concurrent investigations) | Pending |
+
+### Tier 2: Integration Tests
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `IT-KA-762-001` | Full enrichment pipeline succeeds for Node (cluster-scoped, real mapper) | Pending |
+| `IT-KA-762-002` | Full enrichment pipeline succeeds for Deployment (namespaced, real mapper) | Pending |
+| `IT-KA-762-003` | DS handler integration: empty namespace query returns valid response | Pending |
+
+### Tier Skip Rationale
+
+- **E2E**: Deferred. The scope fix is in pure Go library code testable at UT+IT level. E2E would require Kind cluster with Node resources, which adds infrastructure cost without proportional coverage gain.
+
+---
+
+## 9. Test Cases
+
+### UT-KA-762-001: K8sAdapter cluster-scoped GetOwnerChain
+
+**BR**: BR-HAPI-261
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/enrichment/k8s_adapter_test.go`
+
+**Test Steps**:
+1. **Given**: A fake dynamic client with a Node resource at cluster scope; a fake RESTMapper that maps Node to `RESTScopeRoot`
+2. **When**: `GetOwnerChain(ctx, "Node", "worker-1", "kube-system")` is called (namespace passed but should be ignored)
+3. **Then**: The adapter uses the cluster-scoped client (no `.Namespace()` call), successfully retrieves the Node
+
+### UT-HASH-765-001: CanonicalResourceFingerprint strips non-functional keys
+
+**BR**: BR-EM-004
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/shared/hash/canonical_test.go`
+
+**Test Steps**:
+1. **Given**: A full K8s object map with `apiVersion`, `kind`, `metadata`, `status`, and `spec` keys
+2. **When**: `CanonicalResourceFingerprint(obj)` is called
+3. **Then**: Hash is computed from `{spec: ...}` only (metadata/status/apiVersion/kind stripped). Adding/changing metadata does not change hash. Removing spec does change hash.
+
+### UT-KA-763-003: Investigate forces namespace for cluster-scoped
+
+**BR**: BR-HAPI-261
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/investigator/investigator_test.go`
+
+**Test Steps**:
+1. **Given**: A signal with `ResourceKind=Node`, `Namespace=kube-system`; ScopeResolver returns `IsClusterScoped=true` for Node
+2. **When**: `Investigate()` is called
+3. **Then**: The enricher receives `namespace=""` (not "kube-system")
+
+### UT-KA-764-001: Enrichment dedup cache hit
+
+**BR**: BR-HAPI-261
+**Priority**: P1
+**Type**: Unit
+**File**: `test/unit/kubernautagent/investigator/investigator_test.go`
+
+**Test Steps**:
+1. **Given**: A signal where pre-RCA and post-RCA resolve to the same (kind, name, namespace)
+2. **When**: `Investigate()` completes
+3. **Then**: `Enricher.Enrich()` is called exactly once
+
+---
+
+## 10. Environmental Needs
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Mocks**: Fake dynamic client (`fake.NewSimpleDynamicClient`), fake RESTMapper, mock LLM client, mock DS client
+- **Location**: `test/unit/kubernautagent/enrichment/`, `test/unit/shared/hash/`, `test/unit/kubernautagent/investigator/`
+
+### 10.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Mocks**: ZERO mocks. Real DS handler via httptest, real RESTMapper via envtest or discovery
+- **Location**: `test/integration/kubernautagent/enrichment/`, `test/integration/datastorage/`
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Execution Order
+
+1. **Phase 1**: Core scope fix tests (UT-KA-762-*), then implementation
+2. **Phase 2**: Fingerprint tests (UT-HASH-765-*), then implementation, then existing test updates
+3. **Phase 3**: Namespace validation tests (UT-KA-763-*), then implementation
+4. **Phase 4**: Dedup tests (UT-KA-764-*), then implementation
+
+---
+
+## 12. Test Deliverables
+
+| Deliverable | Location | Description |
+|-------------|----------|-------------|
+| This test plan | `docs/tests/762/TEST_PLAN.md` | Strategy and test design |
+| Unit test suite (Phase 1) | `test/unit/kubernautagent/enrichment/` | Scope-aware adapter/detector tests |
+| Unit test suite (Phase 2) | `test/unit/shared/hash/` | Fingerprint tests |
+| Unit test suite (Phase 3+4) | `test/unit/kubernautagent/investigator/` | ScopeResolver + dedup tests |
+| Integration test suite | `test/integration/kubernautagent/enrichment/` | Full enrichment pipeline tests |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests (all phases)
+go test ./test/unit/kubernautagent/enrichment/... -ginkgo.v
+go test ./test/unit/shared/hash/... -ginkgo.v
+go test ./test/unit/kubernautagent/investigator/... -ginkgo.v
+
+# Integration tests
+go test ./test/integration/kubernautagent/enrichment/... -ginkgo.v
+
+# Specific test by ID
+go test ./test/unit/kubernautagent/enrichment/... -ginkgo.focus="UT-KA-762"
+
+# Coverage
+go test ./test/unit/kubernautagent/enrichment/... -coverprofile=coverage.out
+go tool cover -func=coverage.out
+```
+
+---
+
+## 14. Existing Tests Requiring Updates
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|-------------------|-------------------|-----------------|--------|
+| `test/unit/shared/hash/canonical_test.go` | Tests `CanonicalSpecHash` with bare spec maps | Rewrite for `CanonicalResourceFingerprint` with full objects | Function deleted in #765 |
+| `test/unit/shared/hash/configmap_test.go` | Tests `CompositeSpecHash` | Rename to `CompositeResourceFingerprint` | Function renamed in #765 |
+| `test/unit/remediationorchestrator/pre_remediation_hash_test.go` | Asserts specific hash values from `CapturePreRemediationHash` | Update expected hash values | Algorithm change (functional state vs .spec only) |
+| `test/unit/effectivenessmonitor/hash_test.go` | Tests `(*computer).Compute` with spec-only input | Update input shape and expected hashes | Algorithm change |
+| `test/unit/effectivenessmonitor/reconciler_spec_drift_test.go` | Tests `handleSpecDrift` assertions | Update expected hashes | Algorithm change |
+
+---
+
+## 15. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-06 | Initial test plan covering all 4 issues |

--- a/internal/controller/effectivenessmonitor/assess_components.go
+++ b/internal/controller/effectivenessmonitor/assess_components.go
@@ -59,15 +59,13 @@ func (r *Reconciler) assessHealth(ctx context.Context, ea *eav1.EffectivenessAss
 	return healthAssessResult{Component: result, Status: status}
 }
 
-// assessHash computes the spec hash of the target resource and compares
-// with the pre-remediation hash (BR-EM-004, DD-EM-002).
+// assessHash computes the resource fingerprint and compares
+// with the pre-remediation hash (BR-EM-004, DD-EM-002 v2.0, #765).
 func (r *Reconciler) assessHash(ctx context.Context, ea *eav1.EffectivenessAssessment) hash.ComputeResult {
 	logger := log.FromContext(ctx)
 
-	// Step 1: Fetch target spec from K8s API (DD-EM-003: hash uses RemediationTarget)
-	spec, postHashDegradedReason := r.getTargetSpec(ctx, ea.Spec.RemediationTarget)
+	functionalState, spec, postHashDegradedReason := r.getTargetFunctionalState(ctx, ea.Spec.RemediationTarget)
 
-	// Issue #546: Set EA condition based on spec fetch result
 	if postHashDegradedReason != "" {
 		conditions.SetCondition(ea, conditions.ConditionPostHashCaptured,
 			metav1.ConditionFalse, conditions.ReasonPostHashCaptureFailed, postHashDegradedReason)
@@ -78,21 +76,16 @@ func (r *Reconciler) assessHash(ctx context.Context, ea *eav1.EffectivenessAsses
 			metav1.ConditionTrue, conditions.ReasonPostHashCaptured, "Post-remediation spec hash captured")
 	}
 
-	// Step 2: Read pre-remediation hash from EA spec (set by RO via RR status).
-	// Falls back to DataStorage query for backward compatibility with EAs created
-	// before the RO started populating PreRemediationSpecHash.
 	preHash := ea.Spec.PreRemediationSpecHash
 	if preHash == "" {
 		logger.V(1).Info("PreRemediationSpecHash not in EA spec, falling back to DataStorage query")
 		preHash = r.queryPreRemediationHash(ctx, ea.Spec.CorrelationID)
 	}
 
-	// Step 3: Resolve ConfigMap content hashes (#396, BR-EM-004)
 	configMapHashes := r.resolveConfigMapHashes(ctx, spec, ea.Spec.RemediationTarget)
 
-	// Step 4: Compute post-hash (composite when ConfigMaps present) and compare with pre-hash
 	result := r.hashComputer.Compute(hash.SpecHashInput{
-		Spec:            spec,
+		FunctionalState: functionalState,
 		PreHash:         preHash,
 		ConfigMapHashes: configMapHashes,
 	})

--- a/internal/controller/effectivenessmonitor/reconcile_spec_drift.go
+++ b/internal/controller/effectivenessmonitor/reconcile_spec_drift.go
@@ -46,23 +46,23 @@ func (r *Reconciler) handleSpecDrift(ctx context.Context, rctx *reconcileContext
 
 	logger := log.FromContext(ctx)
 
-	currentSpec, _ := r.getTargetSpec(ctx, ea.Spec.RemediationTarget)
-	specHash, specHashErr := canonicalhash.CanonicalSpecHash(currentSpec)
-	if specHashErr != nil {
-		logger.Error(specHashErr, "Failed to compute current spec hash for drift check")
+	functionalState, spec, _ := r.getTargetFunctionalState(ctx, ea.Spec.RemediationTarget)
+	fingerprint, fpErr := canonicalhash.CanonicalResourceFingerprint(functionalState)
+	if fpErr != nil {
+		logger.Error(fpErr, "Failed to compute current resource fingerprint for drift check")
 		return ctrl.Result{}, false, nil
 	}
 
-	driftConfigMapHashes := r.resolveConfigMapHashes(ctx, currentSpec, ea.Spec.RemediationTarget)
+	driftConfigMapHashes := r.resolveConfigMapHashes(ctx, spec, ea.Spec.RemediationTarget)
 	if len(driftConfigMapHashes) > 0 {
 		logger.V(2).Info("Drift guard resolved ConfigMap hashes",
 			"configMapCount", len(driftConfigMapHashes),
 			"correlationID", ea.Spec.CorrelationID)
 	}
 
-	currentHash, compositeErr := canonicalhash.CompositeSpecHash(specHash, driftConfigMapHashes)
+	currentHash, compositeErr := canonicalhash.CompositeResourceFingerprint(fingerprint, driftConfigMapHashes)
 	if compositeErr != nil {
-		logger.Error(compositeErr, "Failed to compute composite hash for drift check")
+		logger.Error(compositeErr, "Failed to compute composite fingerprint for drift check")
 		return ctrl.Result{}, false, nil
 	}
 

--- a/internal/controller/effectivenessmonitor/target_resources.go
+++ b/internal/controller/effectivenessmonitor/target_resources.go
@@ -119,32 +119,34 @@ func (r *Reconciler) listActivePodNames(ctx context.Context, target eav1.TargetR
 	return names
 }
 
-// getTargetSpec retrieves a target resource's .spec as an unstructured map from the K8s API.
-// Uses the REST mapper to resolve the Kind to a GVR, then fetches via unstructured client.
+// getTargetFunctionalState fetches the target resource and returns both:
+//   - functionalState: full obj.Object (for CanonicalResourceFingerprint)
+//   - spec: obj.Object["spec"] (for ExtractConfigMapRefs which needs pod template structure)
 //
-// Returns (spec, degradedReason) where:
-//   - (specMap, "") on success
-//   - (emptyMap, "") when not applicable: NotFound, no .spec, unknown GVK, nil RESTMapper
-//   - (emptyMap, "reason") when degraded: Forbidden, transient API errors (Issue #546)
+// Returns (functionalState, spec, degradedReason) where:
+//   - (obj, specMap, "") on success
+//   - (emptyMap, emptyMap, "") when not applicable: NotFound, unknown GVK, nil RESTMapper
+//   - (emptyMap, emptyMap, "reason") when degraded: Forbidden, transient API errors (Issue #546)
 //
-// DD-EM-003: Caller decides which target to pass (RemediationTarget for hash, etc.).
-func (r *Reconciler) getTargetSpec(ctx context.Context, target eav1.TargetResource) (map[string]interface{}, string) {
+// DD-EM-002 v2.0 (#765): Returns full object for resource fingerprint.
+func (r *Reconciler) getTargetFunctionalState(ctx context.Context, target eav1.TargetResource) (map[string]interface{}, map[string]interface{}, string) {
 	logger := log.FromContext(ctx)
 
 	if r.restMapper == nil {
 		logger.V(1).Info("RESTMapper not configured, falling back to metadata spec")
-		return map[string]interface{}{
+		fallback := map[string]interface{}{
 			"kind":      target.Kind,
 			"name":      target.Name,
 			"namespace": target.Namespace,
-		}, ""
+		}
+		return fallback, fallback, ""
 	}
 
 	gvk, err := k8sutil.ResolveGVKForKind(r.restMapper, target.Kind)
 	if err != nil {
 		logger.Error(err, "Failed to resolve GVK for target resource kind",
 			"kind", target.Kind)
-		return map[string]interface{}{}, ""
+		return map[string]interface{}{}, map[string]interface{}{}, ""
 	}
 
 	obj := &unstructured.Unstructured{}
@@ -158,24 +160,28 @@ func (r *Reconciler) getTargetSpec(ctx context.Context, target eav1.TargetResour
 			logger.Info("Target resource not found, computing hash from empty spec",
 				"kind", target.Kind,
 				"name", target.Name)
-			return map[string]interface{}{}, ""
+			return map[string]interface{}{}, map[string]interface{}{}, ""
 		}
 		logger.Error(err, "Failed to fetch target resource")
-		return map[string]interface{}{}, fmt.Sprintf("failed to fetch target resource %s/%s: %v", target.Kind, target.Name, err)
+		return map[string]interface{}{}, map[string]interface{}{}, fmt.Sprintf("failed to fetch target resource %s/%s: %v", target.Kind, target.Name, err)
 	}
 
-	spec, found, err := unstructured.NestedMap(obj.Object, "spec")
-	if err != nil || !found {
-		logger.V(1).Info("Target resource has no .spec field",
-			"kind", target.Kind,
-			"name", target.Name)
-		return map[string]interface{}{}, ""
+	spec, _, _ := unstructured.NestedMap(obj.Object, "spec")
+	if spec == nil {
+		spec = map[string]interface{}{}
 	}
 
-	logger.V(2).Info("Target spec retrieved",
+	logger.V(2).Info("Target functional state retrieved",
 		"kind", target.Kind,
 		"name", target.Name)
-	return spec, ""
+	return obj.Object, spec, ""
+}
+
+// getTargetSpec is a backward-compatible wrapper that returns only the spec map.
+// Used by callers that don't need the full functional state.
+func (r *Reconciler) getTargetSpec(ctx context.Context, target eav1.TargetResource) (map[string]interface{}, string) {
+	_, spec, degradedReason := r.getTargetFunctionalState(ctx, target)
+	return spec, degradedReason
 }
 
 // queryPreRemediationHash queries DataStorage for the pre-remediation spec hash

--- a/internal/controller/remediationorchestrator/reconciler.go
+++ b/internal/controller/remediationorchestrator/reconciler.go
@@ -1038,7 +1038,7 @@ func (r *Reconciler) handleAnalyzingPhase(ctx context.Context, rr *remediationv1
 			remTarget.Kind, remTarget.Name, remTarget.Namespace,
 		)
 		if hashErr != nil {
-			// Hard errors (NestedMap/CanonicalSpecHash) are terminal
+			// Hard errors (CanonicalResourceFingerprint) are terminal
 			logger.Error(hashErr, "Failed to capture pre-remediation hash (terminal)")
 			if updateErr := helpers.UpdateRemediationRequestStatus(ctx, r.client, rr, func(rr *remediationv1.RemediationRequest) error {
 				rr.Status.OverallPhase = remediationv1.PhaseFailed
@@ -3616,14 +3616,14 @@ func formatRemediationTargetString(ai *aianalysisv1.AIAnalysis) string {
 	return ar.Kind + "/" + ar.Name
 }
 
-// CapturePreRemediationHash fetches the target resource via an uncached reader,
-// extracts its .spec, and computes the canonical SHA-256 hash (DD-EM-002).
+// CapturePreRemediationHash fetches the target resource via an uncached reader
+// and computes the canonical resource fingerprint (DD-EM-002 v2.0, #765).
 //
 // Returns (hash, degradedReason, err) where:
 //   - ("sha256:...", "", nil) on success
-//   - ("", "", nil) when legitimately no hash: NotFound, no .spec, unknown GVK
+//   - ("", "", nil) when legitimately no hash: NotFound, unknown GVK
 //   - ("", "reason", nil) when degraded: Forbidden, transient API errors (Issue #545 defense-in-depth)
-//   - ("", "", err) on hard errors: NestedMap or CanonicalSpecHash failures
+//   - ("", "", err) on hard errors: fingerprint computation failures
 //
 // This is exported for testability from the test package.
 func CapturePreRemediationHash(
@@ -3636,7 +3636,6 @@ func CapturePreRemediationHash(
 ) (string, string, error) {
 	logger := log.FromContext(ctx)
 
-	// Resolve Kind to GVK via REST mapper
 	gvk, err := k8sutil.ResolveGVKForKind(restMapper, targetKind)
 	if err != nil {
 		logger.V(1).Info("Cannot resolve GVK for kind, skipping pre-remediation hash",
@@ -3644,7 +3643,6 @@ func CapturePreRemediationHash(
 		return "", "", nil
 	}
 
-	// Fetch the resource using unstructured client
 	obj := &unstructured.Unstructured{}
 	obj.SetGroupVersionKind(gvk)
 	key := client.ObjectKey{Name: targetName, Namespace: targetNamespace}
@@ -3654,43 +3652,29 @@ func CapturePreRemediationHash(
 				"kind", targetKind, "name", targetName, "namespace", targetNamespace)
 			return "", "", nil
 		}
-		// Issue #545: Soft-fail on access errors (Forbidden, transient API errors).
-		// The EA will be degraded but the remediation pipeline continues.
 		reason := fmt.Sprintf("failed to fetch target resource %s/%s: %v", targetKind, targetName, err)
 		logger.Info("Pre-remediation hash capture degraded (soft-fail)",
 			"kind", targetKind, "name", targetName, "namespace", targetNamespace, "reason", reason)
 		return "", reason, nil
 	}
 
-	// Extract .spec from unstructured
-	spec, found, err := unstructured.NestedMap(obj.Object, "spec")
+	fingerprint, err := canonicalhash.CanonicalResourceFingerprint(obj.Object)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to extract .spec from %s/%s: %w", targetKind, targetName, err)
-	}
-	if !found || spec == nil {
-		logger.V(1).Info("Target resource has no .spec, skipping pre-remediation hash",
-			"kind", targetKind, "name", targetName)
-		return "", "", nil
+		return "", "", fmt.Errorf("failed to compute resource fingerprint for %s/%s: %w", targetKind, targetName, err)
 	}
 
-	// Compute canonical spec hash
-	specHash, err := canonicalhash.CanonicalSpecHash(spec)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to compute canonical hash for %s/%s: %w", targetKind, targetName, err)
-	}
-
-	// Resolve ConfigMap references and compute composite hash (#396, BR-EM-004)
+	spec, _, _ := unstructured.NestedMap(obj.Object, "spec")
 	configMapHashes := resolveConfigMapHashes(ctx, reader, spec, targetKind, targetNamespace)
 
-	compositeHash, err := canonicalhash.CompositeSpecHash(specHash, configMapHashes)
+	compositeHash, err := canonicalhash.CompositeResourceFingerprint(fingerprint, configMapHashes)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to compute composite hash for %s/%s: %w", targetKind, targetName, err)
+		return "", "", fmt.Errorf("failed to compute composite fingerprint for %s/%s: %w", targetKind, targetName, err)
 	}
 
 	if len(configMapHashes) > 0 {
-		logger.V(1).Info("Pre-remediation composite hash computed",
+		logger.V(1).Info("Pre-remediation composite fingerprint computed",
 			"kind", targetKind, "name", targetName,
-			"specHash", specHash, "configMapCount", len(configMapHashes),
+			"fingerprint", fingerprint, "configMapCount", len(configMapHashes),
 			"compositeHash", compositeHash)
 	}
 

--- a/internal/kubernautagent/enrichment/ds_adapter.go
+++ b/internal/kubernautagent/enrichment/ds_adapter.go
@@ -61,7 +61,7 @@ func (a *DSAdapter) GetRemediationHistory(ctx context.Context, kind, name, names
 	}
 
 	if _, isBadRequest := res.(*ogenclient.GetRemediationHistoryContextBadRequest); isBadRequest {
-		return &RemediationHistoryResult{}, nil
+		return nil, fmt.Errorf("ds adapter: bad request for %s/%s/%s (spec_hash=%s)", namespace, kind, name, specHash)
 	}
 
 	historyCtx, ok := res.(*ogenclient.RemediationHistoryContext)

--- a/internal/kubernautagent/enrichment/k8s_adapter.go
+++ b/internal/kubernautagent/enrichment/k8s_adapter.go
@@ -47,18 +47,16 @@ func NewK8sAdapter(dynClient dynamic.Interface, mapper meta.RESTMapper) *K8sAdap
 // At each level, only the controller ownerReference (Controller: true) is followed,
 // aligning with Gateway and SignalProcessing behavior (see #696).
 // Returns the chain from the immediate owner to the root owner, excluding the starting resource.
+//
+// Scope-aware (#762): uses RESTMapping.Scope to determine cluster vs namespaced
+// API calls, rather than relying on the namespace parameter being empty.
 func (a *K8sAdapter) GetOwnerChain(ctx context.Context, kind, name, namespace string) ([]OwnerChainEntry, error) {
-	gvr, err := a.resolveGVR(kind)
+	mapping, err := a.resolveMapping(kind)
 	if err != nil {
 		return nil, fmt.Errorf("k8s adapter: resolve GVR for %s: %w", kind, err)
 	}
 
-	var resourceClient dynamic.ResourceInterface
-	if namespace != "" {
-		resourceClient = a.dynClient.Resource(gvr).Namespace(namespace)
-	} else {
-		resourceClient = a.dynClient.Resource(gvr)
-	}
+	resourceClient := a.scopedClient(mapping, namespace)
 
 	obj, err := resourceClient.Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
@@ -85,24 +83,24 @@ func (a *K8sAdapter) GetOwnerChain(ctx context.Context, kind, name, namespace st
 			break
 		}
 		ownerRef := *controllerRef
-		chain = append(chain, OwnerChainEntry{
-			Kind:      ownerRef.Kind,
-			Name:      ownerRef.Name,
-			Namespace: namespace,
-		})
 
-		ownerGVR, err := a.resolveOwnerGVR(ownerRef)
+		ownerMapping, err := a.resolveOwnerMapping(ownerRef)
 		if err != nil {
 			break
 		}
 
-		var ownerClient dynamic.ResourceInterface
-		if namespace != "" {
-			ownerClient = a.dynClient.Resource(ownerGVR).Namespace(namespace)
-		} else {
-			ownerClient = a.dynClient.Resource(ownerGVR)
+		ownerNS := namespace
+		if ownerMapping.Scope.Name() != meta.RESTScopeNameNamespace {
+			ownerNS = ""
 		}
 
+		chain = append(chain, OwnerChainEntry{
+			Kind:      ownerRef.Kind,
+			Name:      ownerRef.Name,
+			Namespace: ownerNS,
+		})
+
+		ownerClient := a.scopedClient(ownerMapping, namespace)
 		ownerObj, err := ownerClient.Get(ctx, ownerRef.Name, metav1.GetOptions{})
 		if err != nil {
 			break
@@ -113,39 +111,27 @@ func (a *K8sAdapter) GetOwnerChain(ctx context.Context, kind, name, namespace st
 	return chain, nil
 }
 
-// GetSpecHash fetches the resource and computes a canonical SHA-256 hash of its .spec field.
-// Returns an empty string (not an error) when the resource has no .spec (e.g. ConfigMaps, Nodes).
+// GetSpecHash fetches the resource and computes a canonical resource fingerprint.
+// Uses CanonicalResourceFingerprint (#765) which hashes all functional state,
+// not just .spec. The method name is retained for interface compatibility.
+//
+// Scope-aware (#762): uses RESTMapping.Scope for cluster vs namespaced dispatch.
 func (a *K8sAdapter) GetSpecHash(ctx context.Context, kind, name, namespace string) (string, error) {
-	gvr, err := a.resolveGVR(kind)
+	mapping, err := a.resolveMapping(kind)
 	if err != nil {
 		return "", fmt.Errorf("k8s adapter: resolve GVR for spec hash of %s: %w", kind, err)
 	}
 
-	var resourceClient dynamic.ResourceInterface
-	if namespace != "" {
-		resourceClient = a.dynClient.Resource(gvr).Namespace(namespace)
-	} else {
-		resourceClient = a.dynClient.Resource(gvr)
-	}
+	resourceClient := a.scopedClient(mapping, namespace)
 
 	obj, err := resourceClient.Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		return "", fmt.Errorf("k8s adapter: get %s/%s in %s for spec hash: %w", kind, name, namespace, err)
 	}
 
-	spec, ok := obj.Object["spec"]
-	if !ok {
-		return "", nil
-	}
-
-	specMap, ok := spec.(map[string]interface{})
-	if !ok {
-		return "", nil
-	}
-
-	h, err := hash.CanonicalSpecHash(specMap)
+	h, err := hash.CanonicalResourceFingerprint(obj.Object)
 	if err != nil {
-		return "", fmt.Errorf("k8s adapter: compute spec hash for %s/%s in %s: %w", kind, name, namespace, err)
+		return "", fmt.Errorf("k8s adapter: compute resource fingerprint for %s/%s in %s: %w", kind, name, namespace, err)
 	}
 	return h, nil
 }
@@ -157,30 +143,41 @@ type resettableMapper interface {
 	Reset()
 }
 
-func (a *K8sAdapter) resolveGVR(kind string) (schema.GroupVersionResource, error) {
+// resolveMapping returns the full RESTMapping for a Kind, including GVR and Scope.
+// Includes resettableMapper retry for CRDs installed after startup.
+func (a *K8sAdapter) resolveMapping(kind string) (*meta.RESTMapping, error) {
 	plural := strings.ToLower(kind) + "s"
 	gvr, err := a.mapper.ResourceFor(schema.GroupVersionResource{Resource: plural})
-	if err == nil {
-		return gvr, nil
-	}
-	if rm, ok := a.mapper.(resettableMapper); ok {
-		rm.Reset()
-		gvr, retryErr := a.mapper.ResourceFor(schema.GroupVersionResource{Resource: plural})
-		if retryErr == nil {
-			return gvr, nil
+	if err != nil {
+		if rm, ok := a.mapper.(resettableMapper); ok {
+			rm.Reset()
+			gvr, err = a.mapper.ResourceFor(schema.GroupVersionResource{Resource: plural})
+		}
+		if err != nil {
+			return nil, err
 		}
 	}
-	return schema.GroupVersionResource{}, err
+	gvk, err := a.mapper.KindFor(gvr)
+	if err != nil {
+		return nil, fmt.Errorf("resolve kind for %s: %w", gvr, err)
+	}
+	return a.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 }
 
-func (a *K8sAdapter) resolveOwnerGVR(ref metav1.OwnerReference) (schema.GroupVersionResource, error) {
+// resolveOwnerMapping resolves a full RESTMapping from an ownerReference.
+func (a *K8sAdapter) resolveOwnerMapping(ref metav1.OwnerReference) (*meta.RESTMapping, error) {
 	gv, err := schema.ParseGroupVersion(ref.APIVersion)
 	if err != nil {
-		return schema.GroupVersionResource{}, fmt.Errorf("parse API version %q: %w", ref.APIVersion, err)
+		return nil, fmt.Errorf("parse API version %q: %w", ref.APIVersion, err)
 	}
-	mapping, err := a.mapper.RESTMapping(schema.GroupKind{Group: gv.Group, Kind: ref.Kind}, gv.Version)
-	if err != nil {
-		return schema.GroupVersionResource{}, err
+	return a.mapper.RESTMapping(schema.GroupKind{Group: gv.Group, Kind: ref.Kind}, gv.Version)
+}
+
+// scopedClient returns a namespaced or cluster-scoped dynamic client based on
+// the RESTMapping's Scope, matching the pattern in resolver.go (#762).
+func (a *K8sAdapter) scopedClient(mapping *meta.RESTMapping, namespace string) dynamic.ResourceInterface {
+	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+		return a.dynClient.Resource(mapping.Resource).Namespace(namespace)
 	}
-	return mapping.Resource, nil
+	return a.dynClient.Resource(mapping.Resource)
 }

--- a/internal/kubernautagent/enrichment/label_detector.go
+++ b/internal/kubernautagent/enrichment/label_detector.go
@@ -91,30 +91,36 @@ func (d *LabelDetector) DetectLabels(ctx context.Context, kind, name, namespace 
 	return result, nil
 }
 
+// fetchResource retrieves a resource using scope-aware client dispatch (#762).
 func (d *LabelDetector) fetchResource(ctx context.Context, kind, name, namespace string) (*unstructured.Unstructured, error) {
-	gvr, err := d.resolveGVR(kind)
+	mapping, err := d.resolveMapping(kind)
 	if err != nil {
 		return nil, fmt.Errorf("cannot resolve GVR for kind %q: %w", kind, err)
 	}
 	var client dynamic.ResourceInterface
-	if namespace != "" {
-		client = d.dynClient.Resource(gvr).Namespace(namespace)
+	if mapping.Scope.Name() == meta.RESTScopeNameNamespace {
+		client = d.dynClient.Resource(mapping.Resource).Namespace(namespace)
 	} else {
-		client = d.dynClient.Resource(gvr)
+		client = d.dynClient.Resource(mapping.Resource)
 	}
 	return client.Get(ctx, name, metav1.GetOptions{})
 }
 
-func (d *LabelDetector) resolveGVR(kind string) (schema.GroupVersionResource, error) {
+// resolveMapping returns the full RESTMapping for a Kind, including Scope.
+func (d *LabelDetector) resolveMapping(kind string) (*meta.RESTMapping, error) {
 	if d.mapper == nil {
-		return schema.GroupVersionResource{}, fmt.Errorf("REST mapper is required for GVR resolution of kind %q", kind)
+		return nil, fmt.Errorf("REST mapper is required for GVR resolution of kind %q", kind)
 	}
 	plural := strings.ToLower(kind) + "s"
 	gvr, err := d.mapper.ResourceFor(schema.GroupVersionResource{Resource: plural})
 	if err != nil {
-		return schema.GroupVersionResource{}, err
+		return nil, err
 	}
-	return gvr, nil
+	gvk, err := d.mapper.KindFor(gvr)
+	if err != nil {
+		return nil, fmt.Errorf("resolve kind for %s: %w", gvr, err)
+	}
+	return d.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 }
 
 func detectGitOps(obj *unstructured.Unstructured, result *DetectedLabels) {
@@ -185,6 +191,10 @@ func detectServiceMesh(obj *unstructured.Unstructured, result *DetectedLabels) {
 }
 
 func (d *LabelDetector) detectHPA(ctx context.Context, rootKind, rootName, rootNS string, result *DetectedLabels, failed *[]string) {
+	if rootNS == "" {
+		*failed = append(*failed, "hpaEnabled")
+		return
+	}
 	list, err := d.dynClient.Resource(hpaGVR).Namespace(rootNS).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		slog.Warn("label detection: HPA list failed", "namespace", rootNS, "error", err)
@@ -215,9 +225,10 @@ func extractScaleTargetRef(hpa *unstructured.Unstructured) (string, string) {
 }
 
 func (d *LabelDetector) detectPDB(ctx context.Context, rootObj *unstructured.Unstructured, rootNS string, result *DetectedLabels, failed *[]string) {
-	// PDB selectors match pod labels, not the controller's own metadata.labels.
-	// For Deployments/StatefulSets/DaemonSets/ReplicaSets, extract the pod
-	// template labels from spec.template.metadata.labels.
+	if rootNS == "" {
+		*failed = append(*failed, "pdbProtected")
+		return
+	}
 	podLabels := extractPodTemplateLabels(rootObj)
 	rootLabels := rootObj.GetLabels()
 
@@ -301,6 +312,10 @@ func labelsSubset(subset, superset map[string]string) bool {
 }
 
 func (d *LabelDetector) detectNetworkPolicy(ctx context.Context, namespace string, result *DetectedLabels, failed *[]string) {
+	if namespace == "" {
+		*failed = append(*failed, "networkIsolated")
+		return
+	}
 	list, err := d.dynClient.Resource(networkPolicyGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		slog.Warn("label detection: NetworkPolicy list failed", "namespace", namespace, "error", err)
@@ -311,6 +326,10 @@ func (d *LabelDetector) detectNetworkPolicy(ctx context.Context, namespace strin
 }
 
 func (d *LabelDetector) detectResourceQuota(ctx context.Context, namespace string, result *DetectedLabels, failed *[]string) {
+	if namespace == "" {
+		*failed = append(*failed, "resourceQuotaConstrained")
+		return
+	}
 	list, err := d.dynClient.Resource(resourceQuotaGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		slog.Warn("label detection: ResourceQuota list failed", "namespace", namespace, "error", err)

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -22,7 +22,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
@@ -64,35 +68,42 @@ type Pipeline struct {
 // Using a struct instead of positional parameters makes the constructor
 // stable and self-documenting. Optional fields (Registry, Pipeline)
 // default to their zero values when omitted.
+// ScopeResolver determines whether a Kubernetes kind is cluster-scoped (#763).
+type ScopeResolver interface {
+	IsClusterScoped(kind string) (bool, error)
+}
+
 type Config struct {
-	Client       llm.Client
-	Builder      *prompt.Builder
-	ResultParser *parser.ResultParser
-	Enricher     *enrichment.Enricher
-	AuditStore   audit.AuditStore
-	Logger       *slog.Logger
-	MaxTurns     int
-	PhaseTools   katypes.PhaseToolMap
-	Registry     *registry.Registry
-	Pipeline     Pipeline
-	ModelName    string
+	Client        llm.Client
+	Builder       *prompt.Builder
+	ResultParser  *parser.ResultParser
+	Enricher      *enrichment.Enricher
+	AuditStore    audit.AuditStore
+	Logger        *slog.Logger
+	MaxTurns      int
+	PhaseTools    katypes.PhaseToolMap
+	Registry      *registry.Registry
+	Pipeline      Pipeline
+	ModelName     string
+	ScopeResolver ScopeResolver
 }
 
 // Investigator orchestrates the two-invocation architecture:
 // Invocation 1 (RCA): system prompt + tool calls -> RCA summary
 // Invocation 2 (Workflow Selection): new session with RCA context -> workflow choice
 type Investigator struct {
-	client       llm.Client
-	builder      *prompt.Builder
-	resultParser *parser.ResultParser
-	enricher     *enrichment.Enricher
-	auditStore   audit.AuditStore
-	logger       *slog.Logger
-	maxTurns     int
-	phaseTools   katypes.PhaseToolMap
-	registry     *registry.Registry
-	pipeline     Pipeline
-	modelName    string
+	client        llm.Client
+	builder       *prompt.Builder
+	resultParser  *parser.ResultParser
+	enricher      *enrichment.Enricher
+	auditStore    audit.AuditStore
+	logger        *slog.Logger
+	maxTurns      int
+	phaseTools    katypes.PhaseToolMap
+	registry      *registry.Registry
+	pipeline      Pipeline
+	modelName     string
+	scopeResolver ScopeResolver
 }
 
 // New creates an Investigator from the given configuration.
@@ -100,17 +111,18 @@ type Investigator struct {
 // Config.Pipeline fields default to nil (their features are skipped).
 func New(cfg Config) *Investigator {
 	return &Investigator{
-		client:       cfg.Client,
-		builder:      cfg.Builder,
-		resultParser: cfg.ResultParser,
-		enricher:     cfg.Enricher,
-		auditStore:   cfg.AuditStore,
-		logger:       cfg.Logger,
-		maxTurns:     cfg.MaxTurns,
-		phaseTools:   cfg.PhaseTools,
-		registry:     cfg.Registry,
-		pipeline:     cfg.Pipeline,
-		modelName:    cfg.ModelName,
+		client:        cfg.Client,
+		builder:       cfg.Builder,
+		resultParser:  cfg.ResultParser,
+		enricher:      cfg.Enricher,
+		auditStore:    cfg.AuditStore,
+		logger:        cfg.Logger,
+		maxTurns:      cfg.MaxTurns,
+		phaseTools:    cfg.PhaseTools,
+		registry:      cfg.Registry,
+		pipeline:      cfg.Pipeline,
+		modelName:     cfg.ModelName,
+		scopeResolver: cfg.ScopeResolver,
 	}
 }
 
@@ -119,8 +131,11 @@ func New(cfg Config) *Investigator {
 // so that DataStorage queries by remediation_id return the full investigation trail.
 func (inv *Investigator) Investigate(ctx context.Context, signal katypes.SignalContext) (*katypes.InvestigationResult, error) {
 	correlationID := signal.RemediationID
+	enrichmentCache := make(map[string]*enrichment.EnrichmentResult)
+
 	signalKind, signalName, signalNS := ResolveEnrichmentTarget(signal, nil)
-	enrichData := inv.resolveEnrichment(ctx, signalKind, signalName, signalNS, signal.IncidentID)
+	signalNS = inv.normalizeNamespace(signalKind, signalNS)
+	enrichData := inv.resolveEnrichmentCached(ctx, enrichmentCache, signalKind, signalName, signalNS, signal.IncidentID)
 	promptEnrichment := toPromptEnrichment(enrichData)
 	tokens := &TokenAccumulator{}
 
@@ -142,12 +157,13 @@ func (inv *Investigator) Investigate(ctx context.Context, signal katypes.SignalC
 	// H3-fix: retain pre-RCA enrichment if re-enrichment fails.
 	workflowSignal := signal
 	postRCAKind, postRCAName, postRCANS := ResolveEnrichmentTarget(signal, rcaResult)
+	postRCANS = inv.normalizeNamespace(postRCAKind, postRCANS)
 	if postRCAKind != signalKind || postRCAName != signalName || postRCANS != signalNS {
 		inv.logger.Info("re-enriching with RCA remediation target",
 			"signal", signalKind+"/"+signalName,
 			"rca_target", postRCAKind+"/"+postRCAName,
 		)
-		reEnriched := inv.resolveEnrichment(ctx, postRCAKind, postRCAName, postRCANS, signal.IncidentID)
+		reEnriched := inv.resolveEnrichmentCached(ctx, enrichmentCache, postRCAKind, postRCAName, postRCANS, signal.IncidentID)
 
 		// BR-HAPI-261 AC#7 / #704: check HardFail BEFORE label merge
 		// to prevent the merge from silently dropping the failure signal.
@@ -908,15 +924,11 @@ func InjectRemediationTarget(result *katypes.InvestigationResult, signal katypes
 		root := enrichData.OwnerChain[len(enrichData.OwnerChain)-1]
 		rootKind = root.Kind
 		rootName = root.Name
-		if root.Namespace != "" {
-			rootNS = root.Namespace
-		}
+		rootNS = root.Namespace
 	} else if enrichData != nil && enrichData.ResourceKind != "" {
 		rootKind = enrichData.ResourceKind
 		rootName = enrichData.ResourceName
-		if enrichData.ResourceNamespace != "" {
-			rootNS = enrichData.ResourceNamespace
-		}
+		rootNS = enrichData.ResourceNamespace
 	}
 
 	llmKind := result.RemediationTarget.Kind
@@ -955,4 +967,69 @@ func allLabelDetectionsFailed(labels *enrichment.DetectedLabels) bool {
 		return false
 	}
 	return len(labels.FailedDetections) >= len(enrichment.AllDetectionCategories)
+}
+
+// EnrichmentCacheKey returns the dedup cache key for a (kind, name, namespace) tuple (#764).
+func EnrichmentCacheKey(kind, name, namespace string) string {
+	return kind + "/" + name + "/" + namespace
+}
+
+// resolveEnrichmentCached wraps resolveEnrichment with a per-call cache (#764).
+// If the same (kind, name, namespace) was already enriched in this investigation,
+// returns the cached result without making another API call.
+func (inv *Investigator) resolveEnrichmentCached(ctx context.Context, cache map[string]*enrichment.EnrichmentResult, kind, name, namespace, incidentID string) *enrichment.EnrichmentResult {
+	key := EnrichmentCacheKey(kind, name, namespace)
+	if cached, ok := cache[key]; ok {
+		inv.logger.Info("enrichment cache hit, reusing cached result",
+			"kind", kind, "name", name, "namespace", namespace)
+		return cached
+	}
+	result := inv.resolveEnrichment(ctx, kind, name, namespace, incidentID)
+	cache[key] = result
+	return result
+}
+
+// normalizeNamespace forces namespace="" for cluster-scoped resources (#763).
+// If no ScopeResolver is configured, returns the namespace unchanged.
+func (inv *Investigator) normalizeNamespace(kind, namespace string) string {
+	if inv.scopeResolver == nil {
+		return namespace
+	}
+	isCluster, err := inv.scopeResolver.IsClusterScoped(kind)
+	if err != nil {
+		inv.logger.Warn("ScopeResolver error, preserving namespace",
+			"kind", kind, "error", err)
+		return namespace
+	}
+	if isCluster {
+		return ""
+	}
+	return namespace
+}
+
+// mapperScopeResolver implements ScopeResolver using a RESTMapper.
+type mapperScopeResolver struct {
+	mapper meta.RESTMapper
+}
+
+// NewMapperScopeResolver creates a ScopeResolver backed by a RESTMapper.
+func NewMapperScopeResolver(mapper meta.RESTMapper) ScopeResolver {
+	return &mapperScopeResolver{mapper: mapper}
+}
+
+func (r *mapperScopeResolver) IsClusterScoped(kind string) (bool, error) {
+	plural := strings.ToLower(kind) + "s"
+	gvr, err := r.mapper.ResourceFor(schema.GroupVersionResource{Resource: plural})
+	if err != nil {
+		return false, err
+	}
+	gvk, err := r.mapper.KindFor(gvr)
+	if err != nil {
+		return false, err
+	}
+	mapping, err := r.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return false, err
+	}
+	return mapping.Scope.Name() != meta.RESTScopeNameNamespace, nil
 }

--- a/pkg/datastorage/server/remediation_history_handler.go
+++ b/pkg/datastorage/server/remediation_history_handler.go
@@ -78,12 +78,7 @@ func (h *Handler) HandleGetRemediationHistoryContext(w http.ResponseWriter, r *h
 			"targetName query parameter is required", h.logger)
 		return
 	}
-	if targetNamespace == "" {
-		response.WriteRFC7807Error(w, http.StatusBadRequest,
-			"missing-parameter", "Missing Required Parameter",
-			"targetNamespace query parameter is required", h.logger)
-		return
-	}
+	// targetNamespace may be empty for cluster-scoped resources (#762)
 	if currentSpecHash == "" {
 		response.WriteRFC7807Error(w, http.StatusBadRequest,
 			"missing-parameter", "Missing Required Parameter",
@@ -123,8 +118,13 @@ func (h *Handler) HandleGetRemediationHistoryContext(w http.ResponseWriter, r *h
 		return
 	}
 
-	// Build target resource string: "{namespace}/{kind}/{name}"
-	targetResource := fmt.Sprintf("%s/%s/%s", targetNamespace, targetKind, targetName)
+	// Build target resource string: "{namespace}/{kind}/{name}" or "{kind}/{name}" for cluster-scoped (#762)
+	var targetResource string
+	if targetNamespace != "" {
+		targetResource = fmt.Sprintf("%s/%s/%s", targetNamespace, targetKind, targetName)
+	} else {
+		targetResource = fmt.Sprintf("%s/%s", targetKind, targetName)
+	}
 	now := time.Now()
 	ctx := r.Context()
 

--- a/pkg/effectivenessmonitor/hash/hash.go
+++ b/pkg/effectivenessmonitor/hash/hash.go
@@ -22,7 +22,7 @@ limitations under the License.
 // - BR-EM-004: Spec hash comparison to detect configuration drift
 //
 // Hash Algorithm (DD-EM-002):
-//   - Uses pkg/shared/hash.CanonicalSpecHash for cross-service consistency
+//   - Uses pkg/shared/hash.CanonicalResourceFingerprint for cross-service consistency
 //   - Both the RO (pre-remediation) and EM (post-remediation) use the same algorithm
 //   - Deterministic, map-order independent, slice-order independent
 //   - Returns "sha256:<lowercase-hex>" format
@@ -58,11 +58,14 @@ type ComputeResult struct {
 	Component types.ComponentResult
 }
 
-// SpecHashInput contains the data needed to compute a spec hash.
+// SpecHashInput contains the data needed to compute a resource fingerprint.
 type SpecHashInput struct {
-	// Spec is the target resource's .spec as an unstructured map.
-	// Obtained from the K8s API via unstructured client.
+	// Spec is the target resource's full obj.Object (for CanonicalResourceFingerprint).
+	// When FunctionalState is non-nil, it takes precedence over Spec.
 	Spec map[string]interface{}
+	// FunctionalState is the full K8s object (obj.Object) for CanonicalResourceFingerprint (#765).
+	// When set, the Computer uses CanonicalResourceFingerprint on the full object.
+	FunctionalState map[string]interface{}
 	// PreHash is the pre-remediation spec hash from the DS audit trail.
 	// Format: "sha256:<hex>". Empty string if not available.
 	// When provided, the Computer will compare pre and post hashes.
@@ -70,8 +73,8 @@ type SpecHashInput struct {
 	// ConfigMapHashes is a map of ConfigMap name -> content hash ("sha256:<hex>").
 	// Pre-computed by the caller using pkg/shared/hash.ConfigMapDataHash.
 	// When non-empty, the Computer produces a composite hash that incorporates
-	// both the spec hash and the ConfigMap content hashes (#396, BR-EM-004).
-	// When nil or empty, the Computer falls back to spec-only hash.
+	// both the fingerprint and the ConfigMap content hashes (#396, BR-EM-004).
+	// When nil or empty, the Computer falls back to fingerprint-only hash.
 	ConfigMapHashes map[string]string
 }
 
@@ -91,37 +94,45 @@ func NewComputer() Computer {
 	return &computer{}
 }
 
-// Compute calculates the canonical SHA-256 hash of the given spec map using
-// the DD-EM-002 canonical hash algorithm (pkg/shared/hash.CanonicalSpecHash).
+// Compute calculates the canonical resource fingerprint using the DD-EM-002 v2.0 algorithm (#765).
+//
+// If FunctionalState is provided, uses CanonicalResourceFingerprint on the full object.
+// Otherwise falls back to hashing Spec directly for backward compatibility.
 //
 // If PreHash is provided in the input, it compares the two hashes and sets
 // the Match field in the result.
 func (c *computer) Compute(input SpecHashInput) ComputeResult {
-	spec := input.Spec
-	if spec == nil {
-		spec = map[string]interface{}{}
-	}
+	var fingerprint string
+	var err error
 
-	specHash, err := canonicalhash.CanonicalSpecHash(spec)
+	if input.FunctionalState != nil {
+		fingerprint, err = canonicalhash.CanonicalResourceFingerprint(input.FunctionalState)
+	} else {
+		spec := input.Spec
+		if spec == nil {
+			spec = map[string]interface{}{}
+		}
+		fingerprint, err = canonicalhash.CanonicalResourceFingerprint(spec)
+	}
 	if err != nil {
 		return ComputeResult{
 			Component: types.ComponentResult{
 				Component: types.ComponentHash,
 				Assessed:  false,
 				Error:     fmt.Errorf("canonical hash computation failed: %w", err),
-				Details:   "failed to compute canonical spec hash: " + err.Error(),
+				Details:   "failed to compute resource fingerprint: " + err.Error(),
 			},
 		}
 	}
 
-	postHash, err := canonicalhash.CompositeSpecHash(specHash, input.ConfigMapHashes)
+	postHash, err := canonicalhash.CompositeResourceFingerprint(fingerprint, input.ConfigMapHashes)
 	if err != nil {
 		return ComputeResult{
 			Component: types.ComponentResult{
 				Component: types.ComponentHash,
 				Assessed:  false,
 				Error:     fmt.Errorf("composite hash computation failed: %w", err),
-				Details:   "failed to compute composite spec hash: " + err.Error(),
+				Details:   "failed to compute composite fingerprint: " + err.Error(),
 			},
 		}
 	}

--- a/pkg/shared/hash/canonical.go
+++ b/pkg/shared/hash/canonical.go
@@ -1,8 +1,8 @@
 // Package hash provides a canonical hashing utility for Kubernetes resource specs.
 //
 // DD-EM-002: Both the Remediation Orchestrator and Effectiveness Monitor use
-// CanonicalSpecHash to compute deterministic, order-independent SHA-256 hashes
-// of resource .spec fields. This enables cross-process pre/post remediation
+// CanonicalResourceFingerprint to compute deterministic, order-independent SHA-256 hashes
+// of resource functional state. This enables cross-process pre/post remediation
 // comparison without being affected by Go's non-deterministic map iteration
 // or Kubernetes API server slice reordering.
 //
@@ -21,25 +21,47 @@ import (
 	"sort"
 )
 
-// CanonicalSpecHash computes a deterministic SHA-256 hash of a Kubernetes
-// resource spec (DD-EM-002). The algorithm recursively normalizes the input:
+// strippedKeys are the top-level keys excluded from the resource fingerprint.
+// These are non-functional metadata managed by Kubernetes, not the resource's
+// intended state.
+var strippedKeys = map[string]bool{
+	"apiVersion": true,
+	"kind":       true,
+	"metadata":   true,
+	"status":     true,
+}
+
+// CanonicalResourceFingerprint computes a deterministic SHA-256 hash of a
+// Kubernetes resource's functional state (DD-EM-002 v2.0, #765).
 //
-//   - Maps: keys sorted alphabetically, values normalized recursively
-//   - Slices: elements sorted by their canonical JSON representation
-//   - Scalars: passed through unchanged
+// It strips non-functional top-level keys (apiVersion, kind, metadata, status)
+// and hashes the remaining map. For a Deployment this is {spec: {...}}, for a
+// ConfigMap it's {data: {...}, binaryData: {...}}, for a ClusterRole it's
+// {rules: [...], aggregationRule: {...}}.
 //
-// A nil spec is treated as an empty map. The returned string is in the format
-// "sha256:<64-lowercase-hex>" (71 characters total).
-func CanonicalSpecHash(spec map[string]interface{}) (string, error) {
-	if spec == nil {
-		spec = map[string]interface{}{}
+// Normalization guarantees:
+//   - Map-order independent
+//   - Slice-order independent
+//   - Idempotent
+//   - Format: "sha256:<64-lowercase-hex>" (71 characters)
+func CanonicalResourceFingerprint(obj map[string]interface{}) (string, error) {
+	if obj == nil {
+		obj = map[string]interface{}{}
 	}
 
-	normalized := normalizeValue(spec)
+	functional := make(map[string]interface{}, len(obj))
+	for k, v := range obj {
+		if strippedKeys[k] {
+			continue
+		}
+		functional[k] = v
+	}
+
+	normalized := normalizeValue(functional)
 
 	data, err := json.Marshal(normalized)
 	if err != nil {
-		return "", fmt.Errorf("failed to marshal normalized spec: %w", err)
+		return "", fmt.Errorf("failed to marshal normalized resource fingerprint: %w", err)
 	}
 
 	h := sha256.Sum256(data)

--- a/pkg/shared/hash/configmap.go
+++ b/pkg/shared/hash/configmap.go
@@ -199,9 +199,23 @@ func ConfigMapDataHash(data map[string]string, binaryData map[string][]byte) (st
 //
 // Identity: if configMapHashes is nil or empty, returns specHash unchanged.
 // This preserves backward compatibility for resources with no ConfigMap refs.
+//
+// Deprecated: Use CompositeResourceFingerprint for new code (#765).
 func CompositeSpecHash(specHash string, configMapHashes map[string]string) (string, error) {
+	return CompositeResourceFingerprint(specHash, configMapHashes)
+}
+
+// CompositeResourceFingerprint combines a resource fingerprint with per-ConfigMap
+// content hashes into a single composite digest (#765, DD-EM-002 v2.0).
+//
+// ConfigMap names are sorted before concatenation to ensure order independence.
+// Identity: if configMapHashes is nil or empty, returns fingerprint unchanged.
+//
+// Note: Secrets are excluded from cascading per project policy (Vault-managed,
+// rotational, not functional configuration state).
+func CompositeResourceFingerprint(fingerprint string, configMapHashes map[string]string) (string, error) {
 	if len(configMapHashes) == 0 {
-		return specHash, nil
+		return fingerprint, nil
 	}
 
 	names := make([]string, 0, len(configMapHashes))
@@ -211,7 +225,7 @@ func CompositeSpecHash(specHash string, configMapHashes map[string]string) (stri
 	sort.Strings(names)
 
 	var b strings.Builder
-	b.WriteString(specHash)
+	b.WriteString(fingerprint)
 	for _, name := range names {
 		b.WriteString("\n")
 		b.WriteString(name)

--- a/test/integration/effectivenessmonitor/hash_integration_test.go
+++ b/test/integration/effectivenessmonitor/hash_integration_test.go
@@ -286,7 +286,7 @@ var _ = Describe("Spec Hash Integration (BR-EM-004)", func() {
 		ns := createTestNamespace("em-183-001")
 		defer deleteTestNamespace(ns)
 
-		emptyMapHash, err := canonicalhash.CanonicalSpecHash(map[string]interface{}{})
+		emptyMapHash, err := canonicalhash.CanonicalResourceFingerprint(map[string]interface{}{})
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Creating a Deployment as the HPA scale target")

--- a/test/unit/datastorage/remediation_history_handler_test.go
+++ b/test/unit/datastorage/remediation_history_handler_test.go
@@ -103,14 +103,13 @@ var _ = Describe("Remediation History Handler (DD-HAPI-016 v1.4)", func() {
 			Expect(rec.Header().Get("Content-Type")).To(Equal("application/problem+json"))
 		})
 
-		It("UT-RH-HANDLER-003: should return 400 when targetNamespace is missing", func() {
+		It("UT-RH-HANDLER-003: should return 200 when targetNamespace is absent (cluster-scoped resources)", func() {
 			req := httptest.NewRequest("GET",
 				"/api/v1/remediation-history/context?targetKind=Deployment&targetName=nginx&currentSpecHash=sha256:abc",
 				nil)
 			handler.HandleGetRemediationHistoryContext(rec, req)
 
-			Expect(rec.Code).To(Equal(http.StatusBadRequest))
-			Expect(rec.Header().Get("Content-Type")).To(Equal("application/problem+json"))
+			Expect(rec.Code).To(Equal(http.StatusOK))
 		})
 
 		It("UT-RH-HANDLER-004: should return 400 when currentSpecHash is missing", func() {

--- a/test/unit/effectivenessmonitor/hash_test.go
+++ b/test/unit/effectivenessmonitor/hash_test.go
@@ -33,7 +33,7 @@ import (
 //   - ComputeResult.Hash is canonical "sha256:<hex>" format
 //   - ComputeResult.PreHash stores the pre-remediation hash
 //   - ComputeResult.Match is *bool: true/false/nil
-//   - Deterministic output using pkg/shared/hash.CanonicalSpecHash
+//   - Deterministic output using pkg/shared/hash.CanonicalResourceFingerprint
 // ========================================
 var _ = Describe("Spec Hash Computer (DD-EM-002)", func() {
 
@@ -224,7 +224,7 @@ var _ = Describe("Spec Hash Computer (DD-EM-002)", func() {
 			Expect(result.PreHash).To(BeEmpty())
 		})
 
-		It("UT-EM-SH-009: should be consistent with pkg/shared/hash.CanonicalSpecHash", func() {
+		It("UT-EM-SH-009: should be consistent with pkg/shared/hash.CanonicalResourceFingerprint", func() {
 			spec := map[string]interface{}{
 				"replicas": float64(2),
 				"selector": map[string]interface{}{
@@ -234,7 +234,7 @@ var _ = Describe("Spec Hash Computer (DD-EM-002)", func() {
 
 			result := computer.Compute(hash.SpecHashInput{Spec: spec})
 
-			// The hash from the EM Computer should use CanonicalSpecHash internally
+			// The hash from the EM Computer should use CanonicalResourceFingerprint internally
 			// and produce the sha256: prefixed format
 			Expect(result.Hash).To(HavePrefix("sha256:"))
 			Expect(result.Hash).To(HaveLen(71))

--- a/test/unit/kubernautagent/enrichment/detected_labels_679_test.go
+++ b/test/unit/kubernautagent/enrichment/detected_labels_679_test.go
@@ -143,7 +143,7 @@ var _ = Describe("LabelDetector Non-Workload Root Owners — Issue #679", func()
 	})
 
 	Describe("UT-KA-679-004: Node root owner (cluster-scoped)", func() {
-		It("should detect serviceMesh annotation with zero failedDetections", func() {
+		It("should detect serviceMesh annotation; namespace-scoped detections fail for cluster root (#762)", func() {
 			scheme := newFullScheme()
 
 			node := &corev1.Node{
@@ -162,7 +162,8 @@ var _ = Describe("LabelDetector Non-Workload Root Owners — Issue #679", func()
 			Expect(err).NotTo(HaveOccurred())
 			Expect(labels).NotTo(BeNil())
 			Expect(labels.ServiceMesh).To(Equal("istio"), "Node with Istio inject annotation should be detected")
-			Expect(labels.FailedDetections).To(BeEmpty(), "no detections should fail for Node")
+			Expect(labels.FailedDetections).To(ContainElements("hpaEnabled", "pdbProtected", "networkIsolated", "resourceQuotaConstrained"),
+				"#762: namespace-scoped detections must be marked failed for cluster-scoped root with empty namespace")
 		})
 	})
 

--- a/test/unit/kubernautagent/enrichment/ds_adapter_test.go
+++ b/test/unit/kubernautagent/enrichment/ds_adapter_test.go
@@ -233,18 +233,17 @@ var _ = Describe("DataStorage Adapter — TP-433-WIR Phase 1a", func() {
 		})
 	})
 
-	Describe("UT-KA-433W-013: DS adapter returns empty results on BadRequest (e.g. empty specHash)", func() {
-		It("should return empty result (not error) when DS responds with 400", func() {
+	Describe("UT-KA-433W-013: DS adapter returns error on BadRequest (#762)", func() {
+		It("should return error when DS responds with 400 (not silently swallow)", func() {
 			client := &stubDSClient{
 				response: &ogenclient.GetRemediationHistoryContextBadRequest{},
 			}
 
 			adapter := enrichment.NewDSAdapter(client)
 			result, err := adapter.GetRemediationHistory(context.Background(), "Deployment", "api-server", "default", "")
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result).NotTo(BeNil())
-			Expect(result.Tier1).To(BeNil())
-			Expect(result.Tier2).To(BeNil())
+			Expect(err).To(HaveOccurred(), "#762: 400 responses must surface as errors")
+			Expect(err.Error()).To(ContainSubstring("bad request"))
+			Expect(result).To(BeNil())
 		})
 	})
 

--- a/test/unit/kubernautagent/enrichment/scope_aware_test.go
+++ b/test/unit/kubernautagent/enrichment/scope_aware_test.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package enrichment_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	fakedynamic "k8s.io/client-go/dynamic/fake"
+	"k8s.io/utils/ptr"
+
+	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+)
+
+var _ = Describe("TP-762: Scope-Aware K8sAdapter (#762)", func() {
+
+	Describe("UT-KA-762-001: GetOwnerChain uses cluster-scoped client for Node", func() {
+		It("should succeed for a Node even when a non-empty namespace is passed", func() {
+			scheme := runtime.NewScheme()
+
+			node := &unstructured.Unstructured{}
+			node.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"})
+			node.SetName("worker-1")
+
+			dynClient := fakedynamic.NewSimpleDynamicClient(scheme, node)
+			mapper := newSimpleRESTMapper()
+
+			adapter := enrichment.NewK8sAdapter(dynClient, mapper)
+			chain, err := adapter.GetOwnerChain(context.Background(), "Node", "worker-1", "kube-system")
+			Expect(err).NotTo(HaveOccurred(),
+				"UT-KA-762-001: GetOwnerChain must use cluster-scoped client for Node, ignoring namespace")
+			Expect(chain).To(BeEmpty())
+		})
+	})
+
+	Describe("UT-KA-762-002: GetOwnerChain uses namespaced client for Deployment", func() {
+		It("should use namespaced client and resolve owner chain correctly", func() {
+			scheme := runtime.NewScheme()
+
+			pod := &unstructured.Unstructured{}
+			pod.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Pod"})
+			pod.SetName("web-abc123")
+			pod.SetNamespace("production")
+			pod.SetOwnerReferences([]metav1.OwnerReference{
+				{APIVersion: "apps/v1", Kind: "ReplicaSet", Name: "web-rs", UID: "uid-rs", Controller: ptr.To(true)},
+			})
+
+			rs := &unstructured.Unstructured{}
+			rs.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSet"})
+			rs.SetName("web-rs")
+			rs.SetNamespace("production")
+			rs.SetOwnerReferences([]metav1.OwnerReference{
+				{APIVersion: "apps/v1", Kind: "Deployment", Name: "web", UID: "uid-d", Controller: ptr.To(true)},
+			})
+
+			deploy := &unstructured.Unstructured{}
+			deploy.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
+			deploy.SetName("web")
+			deploy.SetNamespace("production")
+
+			dynClient := fakedynamic.NewSimpleDynamicClient(scheme, pod, rs, deploy)
+			mapper := newSimpleRESTMapper()
+
+			adapter := enrichment.NewK8sAdapter(dynClient, mapper)
+			chain, err := adapter.GetOwnerChain(context.Background(), "Pod", "web-abc123", "production")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(chain).To(HaveLen(2),
+				"UT-KA-762-002: namespaced chain should resolve normally")
+			Expect(chain[1].Kind).To(Equal("Deployment"))
+		})
+	})
+
+	Describe("UT-KA-762-003: GetSpecHash uses cluster-scoped client for Node", func() {
+		It("should compute spec hash for a cluster-scoped Node even with non-empty namespace", func() {
+			scheme := runtime.NewScheme()
+
+			node := &unstructured.Unstructured{}
+			node.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"})
+			node.SetName("worker-1")
+			node.Object["spec"] = map[string]interface{}{
+				"providerID": "aws:///us-east-1a/i-1234567890",
+			}
+
+			dynClient := fakedynamic.NewSimpleDynamicClient(scheme, node)
+			mapper := newSimpleRESTMapper()
+
+			adapter := enrichment.NewK8sAdapter(dynClient, mapper)
+			hash, err := adapter.GetSpecHash(context.Background(), "Node", "worker-1", "kube-system")
+			Expect(err).NotTo(HaveOccurred(),
+				"UT-KA-762-003: GetSpecHash must use cluster-scoped client for Node, ignoring namespace")
+			Expect(hash).NotTo(BeEmpty(), "Node has a .spec, so hash should be non-empty")
+		})
+	})
+
+	Describe("UT-KA-762-004: GetSpecHash uses namespaced client for Deployment", func() {
+		It("should compute spec hash for a namespaced Deployment", func() {
+			scheme := runtime.NewScheme()
+
+			deploy := &unstructured.Unstructured{}
+			deploy.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"})
+			deploy.SetName("api-server")
+			deploy.SetNamespace("default")
+			deploy.Object["spec"] = map[string]interface{}{
+				"replicas": int64(3),
+			}
+
+			dynClient := fakedynamic.NewSimpleDynamicClient(scheme, deploy)
+			mapper := newSimpleRESTMapper()
+
+			adapter := enrichment.NewK8sAdapter(dynClient, mapper)
+			hash, err := adapter.GetSpecHash(context.Background(), "Deployment", "api-server", "default")
+			Expect(err).NotTo(HaveOccurred(),
+				"UT-KA-762-004: namespaced GetSpecHash should work for Deployment")
+			Expect(hash).NotTo(BeEmpty())
+		})
+	})
+})
+
+var _ = Describe("TP-762: Scope-Aware LabelDetector (#762)", func() {
+
+	Describe("UT-KA-762-005: LabelDetector uses scope-aware client for Node", func() {
+		It("should fetch cluster-scoped Node via LabelDetector.DetectLabels without error", func() {
+			scheme := runtime.NewScheme()
+
+			node := &unstructured.Unstructured{}
+			node.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"})
+			node.SetName("worker-1")
+			node.SetAnnotations(map[string]string{
+				"node.kubernetes.io/instance-type": "m5.xlarge",
+			})
+
+			dynClient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(scheme,
+				map[schema.GroupVersionResource]string{
+					{Group: "", Version: "v1", Resource: "nodes"}:                                          "NodeList",
+					{Group: "autoscaling", Version: "v2", Resource: "horizontalpodautoscalers"}:             "HorizontalPodAutoscalerList",
+					{Group: "policy", Version: "v1", Resource: "poddisruptionbudgets"}:                     "PodDisruptionBudgetList",
+					{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}:                "NetworkPolicyList",
+					{Group: "", Version: "v1", Resource: "resourcequotas"}:                                  "ResourceQuotaList",
+				}, node)
+			mapper := newSimpleRESTMapper()
+			addLabelDetectorKinds(mapper)
+
+			ld := enrichment.NewLabelDetector(dynClient, mapper)
+			labels, err := ld.DetectLabels(context.Background(), "Node", "worker-1", "kube-system", nil)
+			Expect(err).NotTo(HaveOccurred(),
+				"UT-KA-762-005: LabelDetector must fetch Node using cluster-scoped client")
+			Expect(labels).NotTo(BeNil())
+		})
+	})
+
+	Describe("UT-KA-762-006: LabelDetector skips namespace-scoped lists for cluster-scoped root", func() {
+		It("should mark HPA/PDB/NP/RQ as failed detections when rootNS is empty", func() {
+			scheme := runtime.NewScheme()
+
+			node := &unstructured.Unstructured{}
+			node.SetGroupVersionKind(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"})
+			node.SetName("worker-1")
+
+			dynClient := fakedynamic.NewSimpleDynamicClient(scheme, node)
+			mapper := newSimpleRESTMapper()
+			addLabelDetectorKinds(mapper)
+
+			ld := enrichment.NewLabelDetector(dynClient, mapper)
+			labels, err := ld.DetectLabels(context.Background(), "Node", "worker-1", "", nil)
+			Expect(err).NotTo(HaveOccurred(),
+				"UT-KA-762-006: should not error when namespace is empty")
+			Expect(labels).NotTo(BeNil())
+			Expect(labels.FailedDetections).To(ContainElements("hpaEnabled", "pdbProtected", "networkIsolated", "resourceQuotaConstrained"),
+				"UT-KA-762-006: namespace-scoped detections should be marked failed for cluster-scoped root")
+		})
+	})
+})
+
+var _ = Describe("TP-762: DS Adapter 400 Error Surfacing (#762)", func() {
+
+	Describe("UT-KA-762-008: DS adapter returns error on 400 Bad Request", func() {
+		It("should return an error instead of silently swallowing 400 responses", func() {
+			client := &stubDSClient{
+				response: &ogenclient.GetRemediationHistoryContextBadRequest{},
+			}
+
+			adapter := enrichment.NewDSAdapter(client)
+			result, err := adapter.GetRemediationHistory(context.Background(), "Deployment", "api-server", "default", "")
+			Expect(err).To(HaveOccurred(),
+				"UT-KA-762-008: DS adapter must return error on 400, not silently swallow")
+			Expect(err.Error()).To(ContainSubstring("bad request"))
+			Expect(result).To(BeNil())
+		})
+	})
+})
+
+func addLabelDetectorKinds(mapper *meta.DefaultRESTMapper) {
+	mapper.Add(schema.GroupVersionKind{Group: "autoscaling", Version: "v2", Kind: "HorizontalPodAutoscaler"}, meta.RESTScopeNamespace)
+	mapper.Add(schema.GroupVersionKind{Group: "policy", Version: "v1", Kind: "PodDisruptionBudget"}, meta.RESTScopeNamespace)
+	mapper.Add(schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"}, meta.RESTScopeNamespace)
+	mapper.Add(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ResourceQuota"}, meta.RESTScopeNamespace)
+}

--- a/test/unit/kubernautagent/investigator/enrichment_cache_test.go
+++ b/test/unit/kubernautagent/investigator/enrichment_cache_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+)
+
+var _ = Describe("TP-764: Enrichment deduplication (#764)", func() {
+
+	Describe("UT-KA-764-001: EnrichmentCacheKey produces unique keys", func() {
+		It("should produce distinct keys for different targets", func() {
+			key1 := investigator.EnrichmentCacheKey("Deployment", "web", "production")
+			key2 := investigator.EnrichmentCacheKey("Deployment", "web", "staging")
+			key3 := investigator.EnrichmentCacheKey("StatefulSet", "web", "production")
+
+			Expect(key1).NotTo(Equal(key2), "different namespace -> different key")
+			Expect(key1).NotTo(Equal(key3), "different kind -> different key")
+		})
+	})
+
+	Describe("UT-KA-764-002: EnrichmentCacheKey produces same key for identical targets", func() {
+		It("should produce the same key for same (kind, name, namespace)", func() {
+			key1 := investigator.EnrichmentCacheKey("Node", "worker-1", "")
+			key2 := investigator.EnrichmentCacheKey("Node", "worker-1", "")
+
+			Expect(key1).To(Equal(key2), "same target -> same key")
+		})
+	})
+})

--- a/test/unit/kubernautagent/investigator/inject_target_cluster_test.go
+++ b/test/unit/kubernautagent/investigator/inject_target_cluster_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	katypes "github.com/jordigilh/kubernaut/internal/kubernautagent/types"
+)
+
+var _ = Describe("TP-762: InjectRemediationTarget cluster-scoped fix", func() {
+
+	Describe("UT-KA-762-010: InjectRemediationTarget sets namespace=\"\" for cluster-scoped enrichment", func() {
+		It("should override signal namespace with empty string for cluster-scoped resource", func() {
+			signal := katypes.SignalContext{
+				ResourceKind: "Node",
+				ResourceName: "worker-1",
+				Namespace:    "kube-system",
+			}
+			enrichData := &enrichment.EnrichmentResult{
+				ResourceKind:      "Node",
+				ResourceName:      "worker-1",
+				ResourceNamespace: "",
+				OwnerChain:        []enrichment.OwnerChainEntry{},
+			}
+			result := &katypes.InvestigationResult{
+				RemediationTarget: katypes.RemediationTarget{},
+			}
+
+			investigator.InjectRemediationTarget(result, signal, enrichData)
+
+			Expect(result.RemediationTarget.Kind).To(Equal("Node"),
+				"UT-KA-762-010: kind should be Node")
+			Expect(result.RemediationTarget.Name).To(Equal("worker-1"),
+				"UT-KA-762-010: name should be worker-1")
+			Expect(result.RemediationTarget.Namespace).To(BeEmpty(),
+				"UT-KA-762-010: namespace must be empty for cluster-scoped resource, not signal's kube-system")
+		})
+	})
+
+	Describe("UT-KA-762-011: InjectRemediationTarget preserves namespace for namespaced enrichment", func() {
+		It("should keep the enrichment namespace for namespaced resources", func() {
+			signal := katypes.SignalContext{
+				ResourceKind: "Pod",
+				ResourceName: "web-abc",
+				Namespace:    "production",
+			}
+			enrichData := &enrichment.EnrichmentResult{
+				ResourceKind:      "Deployment",
+				ResourceName:      "web",
+				ResourceNamespace: "production",
+				OwnerChain:        []enrichment.OwnerChainEntry{},
+			}
+			result := &katypes.InvestigationResult{
+				RemediationTarget: katypes.RemediationTarget{},
+			}
+
+			investigator.InjectRemediationTarget(result, signal, enrichData)
+
+			Expect(result.RemediationTarget.Kind).To(Equal("Deployment"))
+			Expect(result.RemediationTarget.Name).To(Equal("web"))
+			Expect(result.RemediationTarget.Namespace).To(Equal("production"),
+				"UT-KA-762-011: namespace must be preserved for namespaced resources")
+		})
+	})
+})

--- a/test/unit/kubernautagent/investigator/scope_resolver_test.go
+++ b/test/unit/kubernautagent/investigator/scope_resolver_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+)
+
+var _ = Describe("TP-763: ScopeResolver and namespace forcing", func() {
+
+	Describe("UT-KA-763-001: ScopeResolver.IsClusterScoped returns true for Node", func() {
+		It("should return true for a cluster-scoped kind", func() {
+			mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{
+				{Group: "", Version: "v1"},
+			})
+			mapper.Add(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "Node"}, meta.RESTScopeRoot)
+
+			resolver := investigator.NewMapperScopeResolver(mapper)
+			isCluster, err := resolver.IsClusterScoped("Node")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isCluster).To(BeTrue(), "UT-KA-763-001: Node must be cluster-scoped")
+		})
+	})
+
+	Describe("UT-KA-763-002: ScopeResolver.IsClusterScoped returns false for Deployment", func() {
+		It("should return false for a namespaced kind", func() {
+			mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{
+				{Group: "apps", Version: "v1"},
+			})
+			mapper.Add(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}, meta.RESTScopeNamespace)
+
+			resolver := investigator.NewMapperScopeResolver(mapper)
+			isCluster, err := resolver.IsClusterScoped("Deployment")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(isCluster).To(BeFalse(), "UT-KA-763-002: Deployment must be namespaced")
+		})
+	})
+})

--- a/test/unit/remediationorchestrator/pre_remediation_hash_test.go
+++ b/test/unit/remediationorchestrator/pre_remediation_hash_test.go
@@ -145,7 +145,8 @@ var _ = Describe("CapturePreRemediationHash (DD-EM-002)", func() {
 		)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(degradedReason).To(BeEmpty(), "No .spec is legitimate, not degraded")
-		Expect(hash).To(BeEmpty(), "Resource without .spec should return empty hash")
+		Expect(hash).NotTo(BeEmpty(), "#765: ConfigMap functional state (.data) produces valid fingerprint")
+		Expect(hash).To(HavePrefix("sha256:"))
 	})
 
 	// UT-RO-545-001: Forbidden error yields empty hash (degraded soft-fail)
@@ -215,7 +216,7 @@ var _ = Describe("CapturePreRemediationHash (DD-EM-002)", func() {
 // CapturePreRemediationHash with ConfigMaps (#396, BR-EM-004)
 //
 // Tests that CapturePreRemediationHash includes ConfigMap content in the
-// composite hash via resolveConfigMapHashes + CompositeSpecHash.
+// composite hash via resolveConfigMapHashes + CompositeResourceFingerprint.
 // ========================================
 var _ = Describe("CapturePreRemediationHash with ConfigMaps (#396)", func() {
 

--- a/test/unit/shared/hash/canonical_test.go
+++ b/test/unit/shared/hash/canonical_test.go
@@ -25,9 +25,9 @@ import (
 )
 
 // ========================================
-// Canonical Spec Hash Tests (DD-EM-002)
+// Canonical Resource Fingerprint Tests (DD-EM-002 v2.0, #765)
 //
-// Contract: CanonicalSpecHash(spec map[string]interface{}) -> (string, error)
+// Contract: CanonicalResourceFingerprint(obj map[string]interface{}) -> (string, error)
 //
 // Guarantees from DD-EM-002:
 //   - Idempotent: same content always produces same hash
@@ -36,10 +36,11 @@ import (
 //   - SHA-256 strength
 //   - Human-readable hex format: "sha256:<64-char-hex>" (71 chars total)
 //   - Cross-process portable
+//   - Strips apiVersion, kind, metadata, status from input before hashing
 //
 // Test IDs from DD-EM-002 Testing Requirements table.
 // ========================================
-var _ = Describe("CanonicalSpecHash (DD-EM-002)", func() {
+var _ = Describe("CanonicalResourceFingerprint (DD-EM-002 v2.0)", func() {
 
 	// UT-HASH-001: Map key order independence
 	It("UT-HASH-001: should produce identical hash regardless of map key iteration order", func() {
@@ -77,8 +78,8 @@ var _ = Describe("CanonicalSpecHash (DD-EM-002)", func() {
 			"replicas": float64(3),
 		}
 
-		hashA, errA := hash.CanonicalSpecHash(specA)
-		hashB, errB := hash.CanonicalSpecHash(specB)
+		hashA, errA := hash.CanonicalResourceFingerprint(specA)
+		hashB, errB := hash.CanonicalResourceFingerprint(specB)
 
 		Expect(errA).ToNot(HaveOccurred())
 		Expect(errB).ToNot(HaveOccurred())
@@ -94,8 +95,8 @@ var _ = Describe("CanonicalSpecHash (DD-EM-002)", func() {
 			"items": []interface{}{"charlie", "alpha", "bravo"},
 		}
 
-		hashA, errA := hash.CanonicalSpecHash(specA)
-		hashB, errB := hash.CanonicalSpecHash(specB)
+		hashA, errA := hash.CanonicalResourceFingerprint(specA)
+		hashB, errB := hash.CanonicalResourceFingerprint(specB)
 
 		Expect(errA).ToNot(HaveOccurred())
 		Expect(errB).ToNot(HaveOccurred())
@@ -125,8 +126,8 @@ var _ = Describe("CanonicalSpecHash (DD-EM-002)", func() {
 			},
 		}
 
-		hashA, errA := hash.CanonicalSpecHash(specA)
-		hashB, errB := hash.CanonicalSpecHash(specB)
+		hashA, errA := hash.CanonicalResourceFingerprint(specA)
+		hashB, errB := hash.CanonicalResourceFingerprint(specB)
 
 		Expect(errA).ToNot(HaveOccurred())
 		Expect(errB).ToNot(HaveOccurred())
@@ -168,7 +169,7 @@ var _ = Describe("CanonicalSpecHash (DD-EM-002)", func() {
 			},
 		}
 
-		h, err := hash.CanonicalSpecHash(spec)
+		h, err := hash.CanonicalResourceFingerprint(spec)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(h).To(HavePrefix("sha256:"), "Hash must have sha256: prefix")
 		Expect(h).To(HaveLen(71), "sha256: (7) + 64 hex chars = 71")
@@ -189,8 +190,8 @@ var _ = Describe("CanonicalSpecHash (DD-EM-002)", func() {
 			},
 		}
 
-		hashA, errA := hash.CanonicalSpecHash(specA)
-		hashB, errB := hash.CanonicalSpecHash(specB)
+		hashA, errA := hash.CanonicalResourceFingerprint(specA)
+		hashB, errB := hash.CanonicalResourceFingerprint(specB)
 
 		Expect(errA).ToNot(HaveOccurred())
 		Expect(errB).ToNot(HaveOccurred())
@@ -200,12 +201,12 @@ var _ = Describe("CanonicalSpecHash (DD-EM-002)", func() {
 	// UT-HASH-006: Empty spec, nil spec, empty map
 	It("UT-HASH-006: should handle edge cases gracefully", func() {
 		// Empty map
-		h1, err1 := hash.CanonicalSpecHash(map[string]interface{}{})
+		h1, err1 := hash.CanonicalResourceFingerprint(map[string]interface{}{})
 		Expect(err1).ToNot(HaveOccurred())
 		Expect(h1).To(HavePrefix("sha256:"))
 
 		// Nil map
-		h2, err2 := hash.CanonicalSpecHash(nil)
+		h2, err2 := hash.CanonicalResourceFingerprint(nil)
 		Expect(err2).ToNot(HaveOccurred())
 		Expect(h2).To(HavePrefix("sha256:"))
 
@@ -222,8 +223,8 @@ var _ = Describe("CanonicalSpecHash (DD-EM-002)", func() {
 			"ratio":    float64(0.75),
 		}
 
-		h1, err1 := hash.CanonicalSpecHash(spec)
-		h2, err2 := hash.CanonicalSpecHash(spec)
+		h1, err1 := hash.CanonicalResourceFingerprint(spec)
+		h2, err2 := hash.CanonicalResourceFingerprint(spec)
 
 		Expect(err1).ToNot(HaveOccurred())
 		Expect(err2).ToNot(HaveOccurred())
@@ -238,7 +239,7 @@ var _ = Describe("CanonicalSpecHash (DD-EM-002)", func() {
 			"emoji":       "🚀",
 		}
 
-		h, err := hash.CanonicalSpecHash(spec)
+		h, err := hash.CanonicalResourceFingerprint(spec)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(h).To(HavePrefix("sha256:"))
 		Expect(h).To(HaveLen(71))
@@ -263,7 +264,7 @@ var _ = Describe("CanonicalSpecHash (DD-EM-002)", func() {
 			"containers": containers,
 		}
 
-		h, err := hash.CanonicalSpecHash(spec)
+		h, err := hash.CanonicalResourceFingerprint(spec)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(h).To(HavePrefix("sha256:"))
 		Expect(h).To(HaveLen(71))
@@ -278,11 +279,11 @@ var _ = Describe("CanonicalSpecHash (DD-EM-002)", func() {
 			},
 		}
 
-		first, err := hash.CanonicalSpecHash(spec)
+		first, err := hash.CanonicalResourceFingerprint(spec)
 		Expect(err).ToNot(HaveOccurred())
 
 		for i := 0; i < 999; i++ {
-			h, err := hash.CanonicalSpecHash(spec)
+			h, err := hash.CanonicalResourceFingerprint(spec)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(h).To(Equal(first), "Iteration %d produced different hash", i+1)
 		}
@@ -313,8 +314,8 @@ var _ = Describe("CanonicalSpecHash (DD-EM-002)", func() {
 			},
 		}
 
-		hashA, errA := hash.CanonicalSpecHash(specA)
-		hashB, errB := hash.CanonicalSpecHash(specB)
+		hashA, errA := hash.CanonicalResourceFingerprint(specA)
+		hashB, errB := hash.CanonicalResourceFingerprint(specB)
 
 		Expect(errA).ToNot(HaveOccurred())
 		Expect(errB).ToNot(HaveOccurred())
@@ -342,8 +343,8 @@ var _ = Describe("CanonicalSpecHash (DD-EM-002)", func() {
 			},
 		}
 
-		hashA, errA := hash.CanonicalSpecHash(specA)
-		hashB, errB := hash.CanonicalSpecHash(specB)
+		hashA, errA := hash.CanonicalResourceFingerprint(specA)
+		hashB, errB := hash.CanonicalResourceFingerprint(specB)
 
 		Expect(errA).ToNot(HaveOccurred())
 		Expect(errB).ToNot(HaveOccurred())
@@ -355,8 +356,8 @@ var _ = Describe("CanonicalSpecHash (DD-EM-002)", func() {
 		specA := map[string]interface{}{"replicas": float64(1)}
 		specB := map[string]interface{}{"replicas": float64(2)}
 
-		hashA, errA := hash.CanonicalSpecHash(specA)
-		hashB, errB := hash.CanonicalSpecHash(specB)
+		hashA, errA := hash.CanonicalResourceFingerprint(specA)
+		hashB, errB := hash.CanonicalResourceFingerprint(specB)
 
 		Expect(errA).ToNot(HaveOccurred())
 		Expect(errB).ToNot(HaveOccurred())
@@ -367,7 +368,7 @@ var _ = Describe("CanonicalSpecHash (DD-EM-002)", func() {
 	It("should return hash in sha256:<64-hex> format (71 chars total)", func() {
 		spec := map[string]interface{}{"key": "value"}
 
-		h, err := hash.CanonicalSpecHash(spec)
+		h, err := hash.CanonicalResourceFingerprint(spec)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(h).To(HavePrefix("sha256:"))
 		Expect(h).To(HaveLen(71))

--- a/test/unit/shared/hash/configmap_test.go
+++ b/test/unit/shared/hash/configmap_test.go
@@ -471,13 +471,13 @@ var _ = Describe("CompositeSpecHash (#396)", func() {
 
 	BeforeEach(func() {
 		var err error
-		specHash, err = hash.CanonicalSpecHash(map[string]interface{}{
+		specHash, err = hash.CanonicalResourceFingerprint(map[string]interface{}{
 			"replicas": float64(3),
 		})
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("UT-SH-396-017: should equal CanonicalSpecHash when no ConfigMaps (backward compat)", func() {
+	It("UT-SH-396-017: should equal CanonicalResourceFingerprint when no ConfigMaps (identity)", func() {
 		composite, err := hash.CompositeSpecHash(specHash, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(composite).To(Equal(specHash),

--- a/test/unit/shared/hash/fingerprint_test.go
+++ b/test/unit/shared/hash/fingerprint_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hash_test
+
+import (
+	hash "github.com/jordigilh/kubernaut/pkg/shared/hash"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CanonicalResourceFingerprint (#765)", func() {
+
+	It("UT-HASH-765-001: should strip metadata/status/apiVersion/kind from hash input", func() {
+		objWithMeta := map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata": map[string]interface{}{
+				"name":      "web",
+				"namespace": "default",
+				"uid":       "abc-123",
+			},
+			"status": map[string]interface{}{
+				"readyReplicas": float64(3),
+			},
+			"spec": map[string]interface{}{
+				"replicas": float64(3),
+			},
+		}
+
+		objWithoutMeta := map[string]interface{}{
+			"spec": map[string]interface{}{
+				"replicas": float64(3),
+			},
+		}
+
+		h1, err1 := hash.CanonicalResourceFingerprint(objWithMeta)
+		h2, err2 := hash.CanonicalResourceFingerprint(objWithoutMeta)
+
+		Expect(err1).NotTo(HaveOccurred())
+		Expect(err2).NotTo(HaveOccurred())
+		Expect(h1).To(Equal(h2), "metadata/status/apiVersion/kind must be stripped before hashing")
+	})
+
+	It("UT-HASH-765-002: should produce stable hash for Deployment object", func() {
+		obj := map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "web", "namespace": "default"},
+			"spec": map[string]interface{}{
+				"replicas": float64(3),
+				"selector": map[string]interface{}{
+					"matchLabels": map[string]interface{}{"app": "web"},
+				},
+			},
+		}
+
+		h, err := hash.CanonicalResourceFingerprint(obj)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(h).To(HavePrefix("sha256:"))
+		Expect(h).To(HaveLen(71))
+	})
+
+	It("UT-HASH-765-003: should capture ConfigMap .data/.binaryData in fingerprint", func() {
+		cmObj := map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]interface{}{"name": "app-config", "namespace": "default"},
+			"data": map[string]interface{}{
+				"config.yaml": "server:\n  port: 8080",
+			},
+		}
+
+		h, err := hash.CanonicalResourceFingerprint(cmObj)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(h).NotTo(BeEmpty())
+
+		cmObjChanged := map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]interface{}{"name": "app-config", "namespace": "default"},
+			"data": map[string]interface{}{
+				"config.yaml": "server:\n  port: 9090",
+			},
+		}
+
+		hChanged, errChanged := hash.CanonicalResourceFingerprint(cmObjChanged)
+		Expect(errChanged).NotTo(HaveOccurred())
+		Expect(hChanged).NotTo(Equal(h), "different ConfigMap data must produce different fingerprint")
+	})
+
+	It("UT-HASH-765-004: should capture ClusterRole .rules in fingerprint", func() {
+		crObj := map[string]interface{}{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRole",
+			"metadata":   map[string]interface{}{"name": "admin"},
+			"rules": []interface{}{
+				map[string]interface{}{
+					"apiGroups": []interface{}{""},
+					"resources": []interface{}{"pods"},
+					"verbs":     []interface{}{"get", "list", "watch"},
+				},
+			},
+		}
+
+		h, err := hash.CanonicalResourceFingerprint(crObj)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(h).NotTo(BeEmpty())
+
+		crObjDifferent := map[string]interface{}{
+			"apiVersion": "rbac.authorization.k8s.io/v1",
+			"kind":       "ClusterRole",
+			"metadata":   map[string]interface{}{"name": "admin"},
+			"rules": []interface{}{
+				map[string]interface{}{
+					"apiGroups": []interface{}{""},
+					"resources": []interface{}{"pods"},
+					"verbs":     []interface{}{"get", "list", "watch", "delete"},
+				},
+			},
+		}
+
+		hDiff, errDiff := hash.CanonicalResourceFingerprint(crObjDifferent)
+		Expect(errDiff).NotTo(HaveOccurred())
+		Expect(hDiff).NotTo(Equal(h), "different ClusterRole rules must produce different fingerprint")
+	})
+
+	It("UT-HASH-765-005: should be idempotent (1000 iterations)", func() {
+		obj := map[string]interface{}{
+			"apiVersion": "apps/v1",
+			"kind":       "Deployment",
+			"metadata":   map[string]interface{}{"name": "test"},
+			"spec": map[string]interface{}{
+				"replicas": float64(2),
+			},
+		}
+
+		first, err := hash.CanonicalResourceFingerprint(obj)
+		Expect(err).NotTo(HaveOccurred())
+
+		for i := 0; i < 999; i++ {
+			h, e := hash.CanonicalResourceFingerprint(obj)
+			Expect(e).NotTo(HaveOccurred())
+			Expect(h).To(Equal(first), "iteration %d produced different hash", i+1)
+		}
+	})
+
+	It("UT-HASH-765-006: should be map-order and slice-order independent", func() {
+		objA := map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata":   map[string]interface{}{"name": "a"},
+			"data": map[string]interface{}{
+				"b": "2",
+				"a": "1",
+			},
+		}
+
+		objB := map[string]interface{}{
+			"kind":       "ConfigMap",
+			"apiVersion": "v1",
+			"metadata":   map[string]interface{}{"name": "a"},
+			"data": map[string]interface{}{
+				"a": "1",
+				"b": "2",
+			},
+		}
+
+		hA, errA := hash.CanonicalResourceFingerprint(objA)
+		hB, errB := hash.CanonicalResourceFingerprint(objB)
+
+		Expect(errA).NotTo(HaveOccurred())
+		Expect(errB).NotTo(HaveOccurred())
+		Expect(hA).To(Equal(hB))
+	})
+})
+
+var _ = Describe("CompositeResourceFingerprint (#765)", func() {
+
+	It("UT-HASH-765-007: should return fingerprint unchanged when no ConfigMap hashes", func() {
+		fingerprint := "sha256:abc123def456789012345678901234567890123456789012345678901234"
+
+		composite, err := hash.CompositeResourceFingerprint(fingerprint, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(composite).To(Equal(fingerprint))
+	})
+
+	It("UT-HASH-765-008: should include ConfigMap content in composite digest", func() {
+		fingerprint := "sha256:abc123def456789012345678901234567890123456789012345678901234"
+		cmHashes := map[string]string{
+			"app-config": "sha256:111111111111111111111111111111111111111111111111111111111111",
+		}
+
+		composite, err := hash.CompositeResourceFingerprint(fingerprint, cmHashes)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(composite).NotTo(Equal(fingerprint), "ConfigMap hash must change the composite")
+		Expect(composite).To(HavePrefix("sha256:"))
+		Expect(composite).To(HaveLen(71))
+	})
+})


### PR DESCRIPTION
## Summary

Combined fix for four interconnected issues affecting cluster-scoped resource handling:

- **#762 — Enrichment pipeline fails for cluster-scoped resources (Node)**: K8sAdapter and LabelDetector used `if namespace != ""` instead of RESTMapper scope resolution, causing lookup failures and `rca_incomplete` for Node/PV/ClusterRole. DataStorage handler rejected empty `targetNamespace` with 400.
- **#765 — Hash algorithm unification**: `CanonicalSpecHash` only hashed `.spec`, missing `ConfigMap.data`, `ClusterRole.rules`, etc. Replaced with `CanonicalResourceFingerprint` that hashes the full functional state (strips `apiVersion`, `kind`, `metadata`, `status`). `CompositeSpecHash` renamed to `CompositeResourceFingerprint`; Secrets excluded per SEC-1 policy. DD-EM-002 updated to v2.0.
- **#763 — Namespace injection validation**: Investigator could inject signal namespace into cluster-scoped resources. Added `ScopeResolver` interface using `RESTMapper` to force `namespace=""` for cluster-scoped kinds.
- **#764 — Enrichment deduplication**: Duplicate enrichment calls for the same resource. Added per-call in-memory cache (`resolveEnrichmentCached`) keyed by `kind/name/namespace`.

### Key changes

- `resolveMapping()` + `scopedClient()` helpers in K8sAdapter and LabelDetector for scope-aware K8s API dispatch
- `CanonicalResourceFingerprint()` replaces deleted `CanonicalSpecHash()`; all 6 production callers updated (RO, EM, KA enrichment)
- `ScopeResolver` interface wired via `NewMapperScopeResolver` in `cmd/kubernautagent/main.go`
- DS handler accepts empty `targetNamespace`; DS adapter surfaces 400 errors instead of swallowing

## Test plan

- [x] New unit tests: `scope_aware_test.go`, `inject_target_cluster_test.go`, `fingerprint_test.go`, `scope_resolver_test.go`, `enrichment_cache_test.go`
- [x] Updated existing tests: `detected_labels_679_test.go`, `ds_adapter_test.go`, `canonical_test.go`, `configmap_test.go`, `hash_test.go`, `pre_remediation_hash_test.go`, `hash_integration_test.go`
- [x] All unit tests pass across shared/hash, enrichment, investigator, EM, RO packages
- [x] `go build ./...` clean
- [x] Full test plan: `docs/tests/762/TEST_PLAN.md`

Closes #762
Closes #763
Closes #764
Closes #765


Made with [Cursor](https://cursor.com)