### PR TITLE
fix(investigator): split submit tools and parse-level retry for workflow selection (#760)

### DIFF
--- a/docs/tests/760/TEST_PLAN_v2.md
+++ b/docs/tests/760/TEST_PLAN_v2.md
@@ -1,0 +1,403 @@
+# Test Plan: Split Workflow Submit Tools + Parse-Level Retry (#760 v2)
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-760-v2
+**Feature**: Split submit_result into submit_result_with_workflow / submit_result_no_workflow for workflow selection, with parse-level retry for LLMs that return text instead of tool calls
+**Version**: 1.0
+**Created**: 2026-04-21
+**Author**: AI Assistant
+**Status**: Draft
+**Branch**: `fix/760-workflow-submit-split`
+**Supersedes**: TP-760-v1 (typed parse errors — necessary but insufficient; see §1.1)
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+TP-760-v1 introduced typed parse errors (`ErrNoJSON`, `ErrNoRecognizedFields`) and the
+investigator classified `ErrNoJSON` (free text) as `no_matching_workflows`. However, the
+demo team reported the fix was insufficient in `v1.3.0-rc8`: the LLM was returning
+*valid JSON with unrecognized fields* (`ErrNoRecognizedFields`) or markdown text
+containing false-positive JSON after a `todo_write` tool call. The `ErrNoRecognizedFields`
+path fell through to a generic `llm_parsing_error`.
+
+This v2 plan validates a two-pronged fix:
+1. **Split submit tools**: Replace the single `submit_result` tool in the workflow
+   selection phase with two intent-specific tools (`submit_result_with_workflow`,
+   `submit_result_no_workflow`), making the LLM's intent unambiguous through tool
+   selection itself.
+2. **Parse-level retry**: When the LLM's workflow selection response cannot be parsed
+   (any parse error), trigger up to 2 correction retries with only the two submit tools
+   enabled. If retries are exhausted, classify as `no_matching_workflows` (not
+   `llm_parsing_error`).
+
+### 1.2 Objectives
+
+1. **Split tools**: Workflow selection phase exposes `submit_result_with_workflow` and `submit_result_no_workflow`; RCA phase retains single `submit_result`
+2. **Sentinel detection**: `runLLMLoop` recognizes all three sentinel tool names (`submit_result`, `submit_result_with_workflow`, `submit_result_no_workflow`)
+3. **No-workflow path**: `submit_result_no_workflow` produces `no_matching_workflows` classification
+4. **Parse-level retry**: Text/unrecognized responses trigger up to 2 correction retries before fallback
+5. **Fallback**: Exhausted retries classify as `no_matching_workflows`, not `llm_parsing_error`
+6. **Backward compat**: RCA phase, catalog self-correction, and existing happy-path workflows unaffected
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/kubernautagent/...` |
+| Integration test pass rate | 100% | `go test ./test/integration/kubernautagent/investigator/...` |
+| Unit-testable code coverage | >=80% | `go test -coverprofile` on parser/schema.go, errors.go |
+| Integration-testable code coverage | >=80% | `go test -coverprofile` on investigator.go |
+| Backward compatibility | 0 regressions | All existing investigator and parser tests pass |
+
+---
+
+## 2. References
+
+### 2.1 Authority
+
+- BR-HAPI-197: Human review reason classification (no_matching_workflows vs llm_parsing_error)
+- DD-HAPI-019: Framework Isolation Pattern (LLM client interface)
+- Issue #760: KA misclassifies intentional workflow decline as llm_parsing_error
+- TP-760-v1: Original typed parse errors fix (superseded by this plan)
+
+### 2.2 Cross-References
+
+- PR #761: Original free-text decline fix (ErrNoJSON path only)
+- `internal/kubernautagent/investigator/investigator.go`: runWorkflowSelection, runLLMLoop
+- `internal/kubernautagent/parser/schema.go`: Tool schemas
+- `internal/kubernautagent/parser/errors.go`: Typed parse errors (from v1)
+- [Testing Strategy](../../.cursor/rules/03-testing-strategy.mdc)
+- [Testing Guidelines](../development/business-requirements/TESTING_GUIDELINES.md)
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | LLM ignores both submit tools on retry | Fallback to no_matching_workflows instead of structured result | Medium | IT-KA-760-009 | Exhaustion fallback classifies correctly; correction message includes concrete examples |
+| R2 | OutputSchema conflicts with split tool Parameters | LLM confused between text and tool schemas | Low | IT-KA-760-006 | OutputSchema is text-mode hint; tool Parameters are authoritative for tool calls |
+| R3 | Existing IT-KA-760-002 (garbage JSON) behavior change | Test expects NOT no_matching_workflows, but retries now exhaust to no_matching_workflows | Medium | IT-KA-760-002 | Redesign test to validate retry behavior before fallback |
+| R4 | Phase tool count assertions break | WorkflowDiscovery tool count changes from 5 to 6 | Low | UT-KA-433-015 | Update assertion |
+| R5 | Correction retry messages contaminate conversation history | Retry adds messages that affect subsequent catalog self-correction | Low | IT-KA-760-011 | Parse retry happens before catalog validation; message state is isolated |
+| R6 | Sentinel name collision with existing tool names | `submit_result_with_workflow` could shadow a registry tool | Very Low | UT-KA-760-013 | Sentinel names are reserved; registry tools cannot use `submit_result` prefix |
+
+### 3.1 Risk-to-Test Traceability
+
+- **R1**: IT-KA-760-009 validates exhaustion fallback
+- **R3**: IT-KA-760-002 updated to expect retry + fallback behavior
+- **R4**: UT-KA-433-015 assertion updated
+- **R5**: IT-KA-760-011 validates catalog self-correction still works with split tools
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **Tool definitions** (`investigator.go:toolDefinitionsForPhase`): Split submit tools for workflow selection phase
+- **Sentinel detection** (`investigator.go:runLLMLoop`): Recognize `submit_result_with_workflow` and `submit_result_no_workflow`
+- **No-workflow schema** (`parser/schema.go`): New `NoWorkflowResultSchema()`
+- **No-workflow classification** (`investigator.go:runWorkflowSelection`): `submit_result_no_workflow` → `no_matching_workflows`
+- **Parse-level retry** (`investigator.go:runWorkflowSelection`): Correction loop for text/unrecognized responses
+- **Fallback classification** (`investigator.go:runWorkflowSelection`): Exhausted retries → `no_matching_workflows`
+
+### 4.2 Features Not to be Tested
+
+- **RCA phase**: Retains single `submit_result`, no changes
+- **Catalog self-correction**: Existing mechanism unchanged (tested for non-regression only)
+- **LLM client/transport layer**: No changes to `Chat()` or `StructuredOutputTransport`
+- **Parser logic**: No changes to `Parse()`, `parseLLMFormat()`, `applyOutcomeRouting()`
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Two submit tools instead of one | Tool name = intent; LLMs are better at tool selection than optional-field JSON |
+| Single `Chat()` call per retry (not `runLLMLoop`) | LLM has already decided; only formatting is wrong. No re-investigation needed |
+| Only submit tools available during retry | Prevents LLM from using investigation tools during correction |
+| Exhaustion → `no_matching_workflows` | If LLM can't format after 3 attempts, its intent (decline) is clear from text |
+| `submit_result_no_workflow` requires only `root_cause_analysis` + optional `reasoning` | The tool name itself signals "no workflow"; only need to know why |
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+- **Unit**: >=80% of `schema.go` (`NoWorkflowResultSchema`, `WithWorkflowResultSchema`)
+- **Integration**: >=80% of `investigator.go` changes (split tools, retry, fallback, sentinel detection)
+
+### 5.2 Two-Tier Minimum
+
+- **Unit tests**: Schema validation, tool definition composition
+- **Integration tests**: Full investigator flow with mock LLM exercising all paths
+
+### 5.3 Pass/Fail Criteria
+
+**PASS**: All tests pass, existing tests unbroken, >=80% coverage per tier.
+**FAIL**: Any P0 test fails, regressions in existing tests, coverage below 80%.
+
+### 5.4 Suspension & Resumption Criteria
+
+**Suspend**: Build broken, existing investigator tests fail.
+**Resume**: Build fixed, all existing tests green.
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code (pure logic, no I/O)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `internal/kubernautagent/parser/schema.go` | `NoWorkflowResultSchema()`, `WithWorkflowResultSchema()` | ~30 |
+
+### 6.2 Integration-Testable Code (I/O, wiring, cross-component)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `internal/kubernautagent/investigator/investigator.go` | `toolDefinitionsForPhase`, `runLLMLoop`, `runWorkflowSelection` | ~80 |
+
+### 6.3 Version Identification
+
+| Item | Version/Commit | Notes |
+|------|----------------|-------|
+| Code under test | `fix/760-workflow-submit-split` HEAD | Branched from main post-rc8 |
+| Dependency: TP-760-v1 | Merged in main | Typed parse errors (`ErrNoJSON`, `ErrNoRecognizedFields`) |
+
+---
+
+## 7. BR Coverage Matrix
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-HAPI-197 | `submit_result_no_workflow` → `no_matching_workflows` | P0 | Integration | IT-KA-760-004 | Pending |
+| BR-HAPI-197 | `submit_result_with_workflow` → normal workflow path | P0 | Integration | IT-KA-760-005 | Pending |
+| BR-HAPI-197 | Text response triggers parse-level retry | P0 | Integration | IT-KA-760-006 | Pending |
+| BR-HAPI-197 | Unrecognized JSON triggers retry | P0 | Integration | IT-KA-760-007 | Pending |
+| BR-HAPI-197 | Retry succeeds on 2nd attempt | P0 | Integration | IT-KA-760-008 | Pending |
+| BR-HAPI-197 | Retries exhausted → `no_matching_workflows` | P0 | Integration | IT-KA-760-009 | Pending |
+| BR-HAPI-197 | RCA phase still uses single `submit_result` | P0 | Integration | IT-KA-760-010 | Pending |
+| BR-HAPI-197 | Catalog self-correction still works with split tools | P1 | Integration | IT-KA-760-011 | Pending |
+| BR-HAPI-197 | `NoWorkflowResultSchema` is valid JSON Schema | P1 | Unit | UT-KA-760-010 | Pending |
+| BR-HAPI-197 | `WithWorkflowResultSchema` is valid JSON Schema | P1 | Unit | UT-KA-760-011 | Pending |
+| BR-HAPI-197 | WorkflowDiscovery phase exposes 2 submit tools (not bare `submit_result`) | P1 | Unit | UT-KA-760-012 | Pending |
+| BR-HAPI-197 | WorkflowDiscovery phase does NOT include bare `submit_result` | P1 | Unit | UT-KA-760-013 | Pending |
+| BR-HAPI-197 | RCA phase tool list is unchanged | P1 | Unit | UT-KA-760-014 | Pending |
+
+---
+
+## 8. Test Scenarios
+
+### Tier 1: Unit Tests
+
+**Testable code scope**: `parser/schema.go` — schema factory functions
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-KA-760-010` | `NoWorkflowResultSchema` returns valid JSON with `root_cause_analysis` and `reasoning` fields | Pending |
+| `UT-KA-760-011` | `WithWorkflowResultSchema` returns valid JSON with `workflow_id`, `root_cause_analysis`, and `confidence` fields | Pending |
+| `UT-KA-760-012` | `toolDefinitionsForPhase(WorkflowDiscovery)` includes `submit_result_with_workflow` and `submit_result_no_workflow` | Pending |
+| `UT-KA-760-013` | `toolDefinitionsForPhase(WorkflowDiscovery)` does NOT include bare `submit_result` | Pending |
+| `UT-KA-760-014` | `toolDefinitionsForPhase(RCA)` includes `submit_result` (unchanged) | Pending |
+
+### Tier 2: Integration Tests
+
+**Testable code scope**: `investigator.go` — split tools, sentinel detection, retry loop, fallback
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `IT-KA-760-004` | LLM calls `submit_result_no_workflow` → `no_matching_workflows`, RCA preserved | Pending |
+| `IT-KA-760-005` | LLM calls `submit_result_with_workflow` → `workflow_id` parsed, catalog validation proceeds | Pending |
+| `IT-KA-760-006` | LLM returns free text → correction retry sent with only submit tools → LLM uses `submit_result_no_workflow` on retry → `no_matching_workflows` | Pending |
+| `IT-KA-760-007` | LLM returns unrecognized JSON → correction retry → LLM uses `submit_result_no_workflow` → `no_matching_workflows` | Pending |
+| `IT-KA-760-008` | LLM returns text on 1st attempt, uses `submit_result_with_workflow` on 2nd → workflow parsed | Pending |
+| `IT-KA-760-009` | LLM returns text on all 3 attempts → exhaustion → `no_matching_workflows` (not `llm_parsing_error`) | Pending |
+| `IT-KA-760-010` | RCA phase: LLM returns text content → parsed as RCA summary (unaffected by split) | Pending |
+| `IT-KA-760-011` | LLM calls `submit_result_with_workflow` with invalid workflow → catalog self-correction still works | Pending |
+
+### Tier Skip Rationale
+
+- **E2E**: Requires Kind cluster + live LLM. Deferred to manual validation with demo team.
+
+---
+
+## 9. Test Cases
+
+### IT-KA-760-004: submit_result_no_workflow → no_matching_workflows
+
+**BR**: BR-HAPI-197
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/investigator/investigator_decline_test.go`
+
+**Preconditions**:
+- Mock LLM returns RCA via text, then calls `submit_result_no_workflow`
+
+**Test Steps**:
+1. **Given**: Mock LLM response 1 returns valid RCA JSON; response 2 returns a tool call to `submit_result_no_workflow` with `{"root_cause_analysis": {"summary": "ResourceQuota exhausted"}, "reasoning": "No workflow handles namespace quota adjustments"}`
+2. **When**: `Investigate()` is called
+3. **Then**: Result has `HumanReviewReason == "no_matching_workflows"`, `HumanReviewNeeded == true`, RCA summary preserved
+
+**Expected Results**:
+1. `result.HumanReviewNeeded` is true
+2. `result.HumanReviewReason` equals `"no_matching_workflows"`
+3. `result.RCASummary` contains "ResourceQuota"
+
+---
+
+### IT-KA-760-005: submit_result_with_workflow → workflow parsed
+
+**BR**: BR-HAPI-197
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/investigator/investigator_decline_test.go`
+
+**Preconditions**:
+- Mock LLM returns RCA, then calls `submit_result_with_workflow`
+
+**Test Steps**:
+1. **Given**: Mock LLM response 1 returns valid RCA JSON; response 2 returns a tool call to `submit_result_with_workflow` with `{"root_cause_analysis": {"summary": "OOMKilled"}, "selected_workflow": {"workflow_id": "oom-increase-memory", "confidence": 0.95}}`
+2. **When**: `Investigate()` is called
+3. **Then**: Result has `WorkflowID == "oom-increase-memory"`, `Confidence ~= 0.95`
+
+**Expected Results**:
+1. `result.WorkflowID` equals `"oom-increase-memory"`
+2. `result.Confidence` is approximately 0.95
+3. `result.HumanReviewNeeded` is false
+
+---
+
+### IT-KA-760-006: Text → retry → submit_result_no_workflow
+
+**BR**: BR-HAPI-197
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/investigator/investigator_decline_test.go`
+
+**Preconditions**:
+- Mock LLM returns RCA, then returns free text on 1st workflow attempt, then calls `submit_result_no_workflow` on retry
+
+**Test Steps**:
+1. **Given**: Mock LLM response 1 = valid RCA; response 2 = free text "No workflow handles this"; response 3 = tool call `submit_result_no_workflow` with `{"root_cause_analysis": {"summary": "Quota exhausted"}, "reasoning": "No matching workflow"}`
+2. **When**: `Investigate()` is called
+3. **Then**: Result has `HumanReviewReason == "no_matching_workflows"`
+
+**Expected Results**:
+1. `result.HumanReviewNeeded` is true
+2. `result.HumanReviewReason` equals `"no_matching_workflows"`
+3. Mock LLM receives at least 3 calls (RCA + initial workflow + retry)
+
+---
+
+### IT-KA-760-009: All retries exhausted → no_matching_workflows
+
+**BR**: BR-HAPI-197
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/investigator/investigator_decline_test.go`
+
+**Preconditions**:
+- Mock LLM returns RCA, then returns free text for all 3 workflow selection attempts (initial + 2 retries)
+
+**Test Steps**:
+1. **Given**: Mock LLM response 1 = valid RCA; responses 2, 3, 4 = free text (no tool calls, no JSON)
+2. **When**: `Investigate()` is called
+3. **Then**: Result has `HumanReviewReason == "no_matching_workflows"` (NOT `llm_parsing_error`), `HumanReviewNeeded == true`
+
+**Expected Results**:
+1. `result.HumanReviewNeeded` is true
+2. `result.HumanReviewReason` equals `"no_matching_workflows"`
+3. `result.Reason` mentions retry exhaustion
+
+---
+
+## 10. Environmental Needs
+
+### 10.1 Unit Tests
+- **Framework**: Ginkgo/Gomega BDD
+- **Mocks**: None (pure schema validation)
+- **Location**: `test/unit/kubernautagent/parser/`, `test/unit/kubernautagent/investigator/`
+
+### 10.2 Integration Tests
+- **Framework**: Ginkgo/Gomega BDD
+- **Mocks**: `mockLLMClient` (external LLM dependency)
+- **Location**: `test/integration/kubernautagent/investigator/`
+
+### 10.3 Tools & Versions
+
+| Tool | Minimum Version | Purpose |
+|------|-----------------|---------|
+| Go | 1.25 | Build and test |
+| Ginkgo CLI | v2.x | Test runner |
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Blocking Dependencies
+
+| Dependency | Type | Status | Impact if Not Available | Workaround |
+|------------|------|--------|-------------------------|------------|
+| TP-760-v1 | Code | Merged | Typed parse errors (`ErrNoJSON`, `ErrNoRecognizedFields`) used by retry detection | N/A — already on main |
+
+### 11.2 Execution Order
+
+1. **Phase 1 (TDD RED)**: Write failing tests for split tools, sentinel detection, retry loop, fallback
+2. **Phase 2 (TDD GREEN)**: Implement split tools, sentinel detection, `NoWorkflowResultSchema`, `WithWorkflowResultSchema`, retry loop
+3. **Phase 3 (TDD REFACTOR)**: Clean up, audit, update existing tests
+4. **Checkpoint**: Adversarial audit, verify all paths, build/lint pass
+
+---
+
+## 12. Test Deliverables
+
+| Deliverable | Location | Description |
+|-------------|----------|-------------|
+| This test plan | `docs/tests/760/TEST_PLAN_v2.md` | Strategy and test design |
+| Schema additions | `internal/kubernautagent/parser/schema.go` | `NoWorkflowResultSchema`, `WithWorkflowResultSchema` |
+| Unit test additions | `test/unit/kubernautagent/parser/schema_test.go` | Schema validation tests |
+| Integration test additions | `test/integration/kubernautagent/investigator/investigator_decline_test.go` | Decline, retry, fallback flow tests |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests
+go test ./test/unit/kubernautagent/parser/... -ginkgo.v
+go test ./test/unit/kubernautagent/investigator/... -ginkgo.v
+
+# Integration tests
+go test ./test/integration/kubernautagent/investigator/... -ginkgo.v
+
+# Specific test by ID
+go test ./test/integration/kubernautagent/investigator/... -ginkgo.focus="IT-KA-760"
+
+# Full build
+go build ./...
+```
+
+---
+
+## 14. Existing Tests Requiring Updates
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|-------------------|-------------------|-----------------|--------|
+| IT-KA-760-001 (`investigator_decline_test.go:72`) | Free text → `no_matching_workflows` (direct) | Free text → retry → exhaustion → `no_matching_workflows` | Retry mechanism intercepts before direct classification; mock must supply 3 text responses (initial + 2 retries) |
+| IT-KA-760-002 (`investigator_decline_test.go:98`) | Garbage JSON → `HumanReviewReason NOT no_matching_workflows` | Garbage JSON → retries exhausted → `HumanReviewReason == no_matching_workflows` | Retry mechanism changes behavior: all parse failures get retried, exhaustion falls back to `no_matching_workflows` |
+| IT-KA-686-002 (`investigator_test.go:454`) | Workflow discovery phase includes `submit_result` | Workflow discovery phase includes `submit_result_with_workflow` and `submit_result_no_workflow` | `submit_result` replaced by split tools in workflow discovery |
+| UT-KA-433-015 (`investigator_test.go:54`) | WorkflowDiscovery has 4 tools | WorkflowDiscovery has 4 tools (unchanged count — registry tools stay the same; submit tools are appended separately) | Verify tool count expectation still holds or update |
+
+---
+
+## 15. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-21 | Initial v2 test plan — split submit tools + parse-level retry |

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -1024,6 +1024,14 @@ func mergePhase1Fallbacks(result *katypes.InvestigationResult, p1 *prompt.Phase1
 	if result.InvestigationOutcome == "" && p1.InvestigationOutcome != "" {
 		result.InvestigationOutcome = p1.InvestigationOutcome
 		parser.ApplyInvestigationOutcome(result, p1.InvestigationOutcome)
+		// #301 defense-in-depth: Phase 1 problem_resolved overrides
+		// contradictory HumanReviewNeeded set by Phase 3 (e.g. the
+		// SubmitNoWorkflowResult branch hardcodes HumanReviewNeeded=true,
+		// but that should not apply when the investigation is resolved).
+		if p1.InvestigationOutcome == "problem_resolved" && result.HumanReviewNeeded {
+			result.HumanReviewNeeded = false
+			result.HumanReviewReason = ""
+		}
 	}
 }
 

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -19,7 +19,6 @@ package investigator
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -45,6 +44,59 @@ const maxSelfCorrectionAttempts = 3
 // its structured investigation result. When detected in runLLMLoop, the tool
 // call arguments are returned as content without executing any real tool.
 const SubmitResultToolName = "submit_result"
+
+// SubmitResultWithWorkflowToolName is the sentinel for the workflow-selected
+// path during PhaseWorkflowDiscovery (#760 v2).
+const SubmitResultWithWorkflowToolName = "submit_result_with_workflow"
+
+// SubmitResultNoWorkflowToolName is the sentinel for the no-workflow path
+// during PhaseWorkflowDiscovery (#760 v2).
+const SubmitResultNoWorkflowToolName = "submit_result_no_workflow"
+
+// LoopResult is a sealed interface representing the outcome of runLLMLoop.
+// Callers dispatch on the concrete type via a type switch.
+type LoopResult interface {
+	loopResult()
+}
+
+// SubmitResult is returned when the LLM calls the generic submit_result tool (RCA phase).
+type SubmitResult struct{ Content string }
+
+func (*SubmitResult) loopResult() {}
+
+// SubmitWithWorkflowResult is returned when the LLM calls submit_result_with_workflow.
+type SubmitWithWorkflowResult struct{ Content string }
+
+func (*SubmitWithWorkflowResult) loopResult() {}
+
+// SubmitNoWorkflowResult is returned when the LLM calls submit_result_no_workflow.
+type SubmitNoWorkflowResult struct{ Content string }
+
+func (*SubmitNoWorkflowResult) loopResult() {}
+
+// TextResult is returned when the LLM responds with plain text (no tool call).
+type TextResult struct{ Content string }
+
+func (*TextResult) loopResult() {}
+
+// ExhaustedResult is returned when the loop exhausts maxTurns.
+type ExhaustedResult struct{}
+
+func (*ExhaustedResult) loopResult() {}
+
+// sentinelResult maps a sentinel tool call to its LoopResult type.
+func sentinelResult(tc llm.ToolCall) LoopResult {
+	switch tc.Name {
+	case SubmitResultToolName:
+		return &SubmitResult{Content: tc.Arguments}
+	case SubmitResultWithWorkflowToolName:
+		return &SubmitWithWorkflowResult{Content: tc.Arguments}
+	case SubmitResultNoWorkflowToolName:
+		return &SubmitNoWorkflowResult{Content: tc.Arguments}
+	default:
+		return nil
+	}
+}
 
 // CatalogFetcher retrieves a fresh workflow validator from the catalog.
 // Implementations query DataStorage at request time so KA always sees the
@@ -284,15 +336,24 @@ func (inv *Investigator) runRCA(ctx context.Context, signal katypes.SignalContex
 		{Role: "user", Content: fmt.Sprintf("Investigate: %s %s in %s — %s", signal.Severity, signal.Name, signal.Namespace, signal.Message)},
 	}
 
-	content, exhausted, err := inv.runLLMLoop(ctx, messages, katypes.PhaseRCA, tokens, correlationID)
+	loopRes, err := inv.runLLMLoop(ctx, messages, katypes.PhaseRCA, tokens, correlationID)
 	if err != nil {
 		return nil, err
 	}
-	if exhausted {
+
+	var content string
+	switch r := loopRes.(type) {
+	case *ExhaustedResult:
 		return &katypes.InvestigationResult{
 			HumanReviewNeeded: true,
 			Reason:            fmt.Sprintf("max turns (%d) exhausted during RCA", inv.maxTurns),
 		}, nil
+	case *SubmitResult:
+		content = r.Content
+	case *TextResult:
+		content = r.Content
+	default:
+		content = ""
 	}
 
 	result, parseErr := inv.resultParser.Parse(content)
@@ -333,39 +394,61 @@ func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katype
 		{Role: "user", Content: fmt.Sprintf("RCA findings: %s\n\nSelect the appropriate remediation workflow.", rcaSummary)},
 	}
 
-	content, exhausted, err := inv.runLLMLoop(ctx, messages, katypes.PhaseWorkflowDiscovery, tokens, correlationID)
+	loopRes, err := inv.runLLMLoop(ctx, messages, katypes.PhaseWorkflowDiscovery, tokens, correlationID)
 	if err != nil {
 		return nil, err
 	}
-	if exhausted {
+
+	var content string
+	switch r := loopRes.(type) {
+	case *ExhaustedResult:
 		return &katypes.InvestigationResult{
 			RCASummary:        rcaSummary,
 			HumanReviewNeeded: true,
 			Reason:            fmt.Sprintf("max turns (%d) exhausted during workflow selection", inv.maxTurns),
 		}, nil
+	case *SubmitNoWorkflowResult:
+		inv.logger.Info("submit_result_no_workflow sentinel: classifying as no_matching_workflows")
+		return &katypes.InvestigationResult{
+			RCASummary:        rcaSummary,
+			HumanReviewNeeded: true,
+			HumanReviewReason: "no_matching_workflows",
+			Reason:            "LLM explicitly declined workflow selection via submit_result_no_workflow",
+		}, nil
+	case *SubmitWithWorkflowResult:
+		content = r.Content
+	case *SubmitResult:
+		content = r.Content
+	case *TextResult:
+		// #760 v2: parse-level retry — LLM returned text instead of a tool call.
+		retryResult := inv.retryWorkflowSubmit(ctx, r.Content, messages, rcaSummary, tokens, correlationID)
+		if retryResult != nil {
+			return retryResult, nil
+		}
+		// Retries exhausted → no_matching_workflows
+		inv.logger.Warn("workflow selection: all retries exhausted, classifying as no_matching_workflows")
+		return &katypes.InvestigationResult{
+			RCASummary:        rcaSummary,
+			HumanReviewNeeded: true,
+			HumanReviewReason: "no_matching_workflows",
+			Reason:            "workflow selection: LLM did not use submit tool after retries",
+		}, nil
 	}
 
 	result, parseErr := inv.resultParser.Parse(content)
 	if parseErr != nil {
-		var noJSON *parser.ErrNoJSON
-		if errors.As(parseErr, &noJSON) {
-			// #760 / HAPI state machine: free text during workflow selection after
-			// successful RCA = deliberate decline. Classify as no_matching_workflows.
-			inv.logger.Warn("workflow selection: LLM returned free text (no JSON), classifying as no_matching_workflows",
-				slog.String("error", parseErr.Error()))
-			return &katypes.InvestigationResult{
-				RCASummary:        rcaSummary,
-				HumanReviewNeeded: true,
-				HumanReviewReason: "no_matching_workflows",
-				Reason:            fmt.Sprintf("workflow selection: LLM did not produce parseable result: %s", parseErr),
-			}, nil
+		// Try parse-level retry for malformed JSON too
+		retryResult := inv.retryWorkflowSubmit(ctx, content, messages, rcaSummary, tokens, correlationID)
+		if retryResult != nil {
+			return retryResult, nil
 		}
-		inv.logger.Warn("workflow selection parse failed",
+		inv.logger.Warn("workflow selection parse failed after retries, classifying as no_matching_workflows",
 			slog.String("error", parseErr.Error()))
 		return &katypes.InvestigationResult{
 			RCASummary:        rcaSummary,
 			HumanReviewNeeded: true,
-			Reason:            fmt.Sprintf("failed to parse workflow selection response: %s", parseErr),
+			HumanReviewReason: "no_matching_workflows",
+			Reason:            fmt.Sprintf("workflow selection: LLM did not produce parseable result: %s", parseErr),
 		}, nil
 	}
 
@@ -393,17 +476,30 @@ func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katype
 			messages = append(messages, llm.Message{Role: "assistant", Content: content})
 			messages = append(messages, llm.Message{Role: "user", Content: correctionMsg})
 
-			correctedContent, corrExhausted, corrErr := inv.runLLMLoop(ctx, messages, katypes.PhaseWorkflowDiscovery, tokens, correlationID)
+			corrLoopRes, corrErr := inv.runLLMLoop(ctx, messages, katypes.PhaseWorkflowDiscovery, tokens, correlationID)
 			if corrErr != nil {
 				return nil, corrErr
 			}
-			if corrExhausted {
+			switch cr := corrLoopRes.(type) {
+			case *ExhaustedResult:
 				r.HumanReviewNeeded = true
 				r.Reason = "self-correction exhausted LLM turns"
 				return r, nil
+			case *SubmitNoWorkflowResult:
+				return &katypes.InvestigationResult{
+					RCASummary:        rcaSummary,
+					HumanReviewNeeded: true,
+					HumanReviewReason: "no_matching_workflows",
+					Reason:            "LLM declined workflow during self-correction via submit_result_no_workflow",
+				}, nil
+			case *SubmitWithWorkflowResult:
+				content = cr.Content
+			case *SubmitResult:
+				content = cr.Content
+			case *TextResult:
+				content = cr.Content
 			}
-			content = correctedContent
-			return inv.resultParser.Parse(correctedContent)
+			return inv.resultParser.Parse(content)
 		}
 
 		corrected, corrErr := validator.SelfCorrect(result, maxSelfCorrectionAttempts, correctionFn)
@@ -421,6 +517,104 @@ func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katype
 	}
 
 	return result, nil
+}
+
+const maxParseRetries = 2
+
+// retryWorkflowSubmit performs up to maxParseRetries correction attempts when
+// the LLM returns text or unparseable JSON instead of calling a submit tool.
+// Each retry sends a correction message with examples of both submit tools,
+// with only the two submit tools available (prevents re-investigation).
+// Returns non-nil *InvestigationResult on success or nil when retries exhaust.
+func (inv *Investigator) retryWorkflowSubmit(ctx context.Context, lastContent string, history []llm.Message, rcaSummary string, tokens *TokenAccumulator, correlationID string) *katypes.InvestigationResult {
+	submitOnlyTools := []llm.ToolDefinition{
+		{
+			Name:        SubmitResultWithWorkflowToolName,
+			Description: "Submit investigation result WITH a selected workflow.",
+			Parameters:  parser.WithWorkflowResultSchema(),
+		},
+		{
+			Name:        SubmitResultNoWorkflowToolName,
+			Description: "Submit investigation result when NO matching workflow exists.",
+			Parameters:  parser.NoWorkflowResultSchema(),
+		},
+	}
+
+	correctionTemplate := `Your response could not be parsed. You MUST call one of these tools:
+
+1. If a workflow matches: call submit_result_with_workflow with JSON like:
+   {"root_cause_analysis":{"summary":"..."},"selected_workflow":{"workflow_id":"...","confidence":0.9},"confidence":0.9}
+
+2. If NO workflow matches: call submit_result_no_workflow with JSON like:
+   {"root_cause_analysis":{"summary":"..."},"reasoning":"explanation why no workflow applies"}
+
+Do NOT respond with plain text. You MUST call one of the above tools.`
+
+	retryMessages := make([]llm.Message, len(history))
+	copy(retryMessages, history)
+	retryMessages = append(retryMessages,
+		llm.Message{Role: "assistant", Content: lastContent},
+	)
+
+	for attempt := 0; attempt < maxParseRetries; attempt++ {
+		inv.logger.Info("parse-level retry for workflow submit",
+			slog.Int("attempt", attempt+1),
+			slog.Int("max", maxParseRetries))
+
+		retryMessages = append(retryMessages,
+			llm.Message{Role: "user", Content: correctionTemplate},
+		)
+
+		retryEvent := audit.NewEvent(audit.EventTypeLLMRequest, correlationID)
+		retryEvent.EventAction = audit.ActionLLMRequest
+		retryEvent.EventOutcome = audit.OutcomeSuccess
+		retryEvent.Data["retry_attempt"] = attempt + 1
+		retryEvent.Data["retry_max"] = maxParseRetries
+		retryEvent.Data["phase"] = string(katypes.PhaseWorkflowDiscovery)
+		retryEvent.Data["retry_reason"] = "parse_level_correction"
+		audit.StoreBestEffort(ctx, inv.auditStore, retryEvent, inv.logger)
+
+		resp, err := inv.client.Chat(ctx, llm.ChatRequest{
+			Messages: retryMessages,
+			Tools:    submitOnlyTools,
+			Options:  llm.ChatOptions{JSONMode: true, OutputSchema: parser.InvestigationResultSchema()},
+		})
+		if err != nil {
+			inv.logger.Warn("retry LLM call failed", slog.String("error", err.Error()))
+			continue
+		}
+		if tokens != nil {
+			tokens.Add(resp.Usage)
+		}
+
+		if len(resp.ToolCalls) > 0 {
+			for _, tc := range resp.ToolCalls {
+				switch tc.Name {
+				case SubmitResultNoWorkflowToolName:
+					inv.logger.Info("retry succeeded: submit_result_no_workflow")
+					return &katypes.InvestigationResult{
+						RCASummary:        rcaSummary,
+						HumanReviewNeeded: true,
+						HumanReviewReason: "no_matching_workflows",
+						Reason:            "LLM used submit_result_no_workflow after retry",
+					}
+				case SubmitResultWithWorkflowToolName:
+					inv.logger.Info("retry succeeded: submit_result_with_workflow")
+					result, parseErr := inv.resultParser.Parse(tc.Arguments)
+					if parseErr != nil {
+						inv.logger.Warn("retry submit_result_with_workflow parse failed",
+							slog.String("error", parseErr.Error()))
+						retryMessages = append(retryMessages, resp.Message)
+						continue
+					}
+					return result
+				}
+			}
+		}
+
+		retryMessages = append(retryMessages, resp.Message)
+	}
+	return nil
 }
 
 // enrichFromCatalog backfills execution metadata from the workflow catalog
@@ -453,7 +647,8 @@ func enrichFromCatalog(result *katypes.InvestigationResult, v *parser.Validator)
 // runLLMLoop executes the multi-turn LLM conversation loop with tool
 // execution routed through the registry. correlationID is propagated to
 // all audit events per BR-AUDIT-005 (remediation_id as query key).
-func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message, phase katypes.Phase, tokens *TokenAccumulator, correlationID string) (string, bool, error) {
+// Returns a sealed LoopResult; callers dispatch via type switch (#760 v2).
+func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message, phase katypes.Phase, tokens *TokenAccumulator, correlationID string) (LoopResult, error) {
 	toolDefs := inv.toolDefinitionsForPhase(phase)
 	loopStart := time.Now()
 
@@ -480,7 +675,7 @@ func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message,
 			failEvent.Data["phase"] = string(phase)
 			failEvent.Data["duration_seconds"] = time.Since(loopStart).Seconds()
 			audit.StoreBestEffort(ctx, inv.auditStore, failEvent, inv.logger)
-			return "", false, fmt.Errorf("%s LLM call turn %d: %w", phase, turn, err)
+			return nil, fmt.Errorf("%s LLM call turn %d: %w", phase, turn, err)
 		}
 
 		if tokens != nil {
@@ -502,9 +697,11 @@ func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message,
 
 		if len(resp.ToolCalls) > 0 {
 			for _, tc := range resp.ToolCalls {
-				if tc.Name == SubmitResultToolName {
-					inv.logger.Info("submit_result sentinel detected", slog.String("phase", string(phase)))
-					return tc.Arguments, false, nil
+				if sr := sentinelResult(tc); sr != nil {
+					inv.logger.Info("sentinel detected",
+						slog.String("tool", tc.Name),
+						slog.String("phase", string(phase)))
+					return sr, nil
 				}
 			}
 
@@ -530,15 +727,15 @@ func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message,
 				})
 			}
 			if inv.pipeline.AnomalyDetector != nil && inv.pipeline.AnomalyDetector.TotalExceeded() {
-				return "", true, nil
+				return &ExhaustedResult{}, nil
 			}
 			continue
 		}
 
-		return resp.Message.Content, false, nil
+		return &TextResult{Content: resp.Message.Content}, nil
 	}
 
-	return "", true, nil
+	return &ExhaustedResult{}, nil
 }
 
 func totalPromptLength(messages []llm.Message) int {
@@ -577,7 +774,7 @@ func (inv *Investigator) toolDefinitionsForPhase(phase katypes.Phase) []llm.Tool
 	var defs []llm.ToolDefinition
 	if inv.registry != nil {
 		phaseTools := inv.registry.ToolsForPhase(phase, inv.phaseTools)
-		defs = make([]llm.ToolDefinition, 0, len(phaseTools)+1)
+		defs = make([]llm.ToolDefinition, 0, len(phaseTools)+2)
 		for _, t := range phaseTools {
 			defs = append(defs, llm.ToolDefinition{
 				Name:        t.Name(),
@@ -587,11 +784,26 @@ func (inv *Investigator) toolDefinitionsForPhase(phase katypes.Phase) []llm.Tool
 		}
 	}
 
-	defs = append(defs, llm.ToolDefinition{
-		Name:        SubmitResultToolName,
-		Description: "Submit the final investigation result as structured JSON. Call this tool when your analysis is complete.",
-		Parameters:  submitResultSchemaForPhase(phase),
-	})
+	if phase == katypes.PhaseWorkflowDiscovery {
+		defs = append(defs,
+			llm.ToolDefinition{
+				Name:        SubmitResultWithWorkflowToolName,
+				Description: "Submit investigation result WITH a selected workflow. Call this when you have identified a matching workflow.",
+				Parameters:  parser.WithWorkflowResultSchema(),
+			},
+			llm.ToolDefinition{
+				Name:        SubmitResultNoWorkflowToolName,
+				Description: "Submit investigation result when NO matching workflow exists. Call this when none of the available workflows can remediate the incident.",
+				Parameters:  parser.NoWorkflowResultSchema(),
+			},
+		)
+	} else {
+		defs = append(defs, llm.ToolDefinition{
+			Name:        SubmitResultToolName,
+			Description: "Submit the final investigation result as structured JSON. Call this tool when your analysis is complete.",
+			Parameters:  submitResultSchemaForPhase(phase),
+		})
+	}
 	return defs
 }
 

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -423,20 +423,29 @@ func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katype
 	case *SubmitResult:
 		content = r.Content
 	case *TextResult:
-		// #760 v2: parse-level retry — LLM returned text instead of a tool call.
-		retryResult := inv.retryWorkflowSubmit(ctx, r.Content, messages, rcaSummary, tokens, correlationID)
-		if retryResult != nil {
-			return retryResult, nil
+		// #760 v2: LLM returned text instead of a tool call. Try parsing
+		// first — the text may contain a valid investigation result (e.g.
+		// problem_resolved or predictive_no_action where no workflow is
+		// expected). Only fall through to parse-level retry when the
+		// content cannot be parsed at all.
+		if _, textErr := inv.resultParser.Parse(r.Content); textErr == nil {
+			inv.logger.Info("workflow selection: parsed text response directly (no tool call)",
+				slog.String("correlation_id", correlationID))
+			content = r.Content
+		} else {
+			retryResult := inv.retryWorkflowSubmit(ctx, r.Content, messages, rcaSummary, tokens, correlationID)
+			if retryResult != nil {
+				return retryResult, nil
+			}
+			inv.logger.Warn("workflow selection: all retries exhausted, classifying as no_matching_workflows",
+				slog.String("correlation_id", correlationID))
+			return &katypes.InvestigationResult{
+				RCASummary:        rcaSummary,
+				HumanReviewNeeded: true,
+				HumanReviewReason: "no_matching_workflows",
+				Reason:            "workflow selection: LLM did not use submit tool after retries",
+			}, nil
 		}
-		// Retries exhausted → no_matching_workflows
-		inv.logger.Warn("workflow selection: all retries exhausted, classifying as no_matching_workflows",
-			slog.String("correlation_id", correlationID))
-		return &katypes.InvestigationResult{
-			RCASummary:        rcaSummary,
-			HumanReviewNeeded: true,
-			HumanReviewReason: "no_matching_workflows",
-			Reason:            "workflow selection: LLM did not use submit tool after retries",
-		}, nil
 	}
 
 	result, parseErr := inv.resultParser.Parse(content)

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -359,7 +359,8 @@ func (inv *Investigator) runRCA(ctx context.Context, signal katypes.SignalContex
 	result, parseErr := inv.resultParser.Parse(content)
 	if parseErr != nil {
 		inv.logger.Warn("RCA parse failed, treating as summary",
-			slog.String("error", parseErr.Error()))
+			slog.String("error", parseErr.Error()),
+			slog.String("correlation_id", correlationID))
 		return &katypes.InvestigationResult{
 			RCASummary: content,
 		}, nil
@@ -370,7 +371,8 @@ func (inv *Investigator) runRCA(ctx context.Context, signal katypes.SignalContex
 	// Aligned with HAPI v1.2.1 where needs_human_review is parser-driven in Phase 3.
 	if result.HumanReviewNeeded {
 		inv.logger.Info("clearing HumanReviewNeeded set during RCA (parser-driven in Phase 3 only)",
-			slog.String("reason", result.HumanReviewReason))
+			slog.String("reason", result.HumanReviewReason),
+			slog.String("correlation_id", correlationID))
 		result.HumanReviewNeeded = false
 		result.HumanReviewReason = ""
 	}
@@ -408,7 +410,8 @@ func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katype
 			Reason:            fmt.Sprintf("max turns (%d) exhausted during workflow selection", inv.maxTurns),
 		}, nil
 	case *SubmitNoWorkflowResult:
-		inv.logger.Info("submit_result_no_workflow sentinel: classifying as no_matching_workflows")
+		inv.logger.Info("submit_result_no_workflow sentinel: classifying as no_matching_workflows",
+			slog.String("correlation_id", correlationID))
 		return &katypes.InvestigationResult{
 			RCASummary:        rcaSummary,
 			HumanReviewNeeded: true,
@@ -426,7 +429,8 @@ func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katype
 			return retryResult, nil
 		}
 		// Retries exhausted → no_matching_workflows
-		inv.logger.Warn("workflow selection: all retries exhausted, classifying as no_matching_workflows")
+		inv.logger.Warn("workflow selection: all retries exhausted, classifying as no_matching_workflows",
+			slog.String("correlation_id", correlationID))
 		return &katypes.InvestigationResult{
 			RCASummary:        rcaSummary,
 			HumanReviewNeeded: true,
@@ -443,7 +447,8 @@ func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katype
 			return retryResult, nil
 		}
 		inv.logger.Warn("workflow selection parse failed after retries, classifying as no_matching_workflows",
-			slog.String("error", parseErr.Error()))
+			slog.String("error", parseErr.Error()),
+			slog.String("correlation_id", correlationID))
 		return &katypes.InvestigationResult{
 			RCASummary:        rcaSummary,
 			HumanReviewNeeded: true,
@@ -559,7 +564,8 @@ Do NOT respond with plain text. You MUST call one of the above tools.`
 	for attempt := 0; attempt < maxParseRetries; attempt++ {
 		inv.logger.Info("parse-level retry for workflow submit",
 			slog.Int("attempt", attempt+1),
-			slog.Int("max", maxParseRetries))
+			slog.Int("max", maxParseRetries),
+			slog.String("correlation_id", correlationID))
 
 		retryMessages = append(retryMessages,
 			llm.Message{Role: "user", Content: correctionTemplate},
@@ -580,7 +586,9 @@ Do NOT respond with plain text. You MUST call one of the above tools.`
 			Options:  llm.ChatOptions{JSONMode: true, OutputSchema: parser.InvestigationResultSchema()},
 		})
 		if err != nil {
-			inv.logger.Warn("retry LLM call failed", slog.String("error", err.Error()))
+			inv.logger.Warn("retry LLM call failed",
+				slog.String("error", err.Error()),
+				slog.String("correlation_id", correlationID))
 			continue
 		}
 		if tokens != nil {
@@ -591,7 +599,8 @@ Do NOT respond with plain text. You MUST call one of the above tools.`
 			for _, tc := range resp.ToolCalls {
 				switch tc.Name {
 				case SubmitResultNoWorkflowToolName:
-					inv.logger.Info("retry succeeded: submit_result_no_workflow")
+					inv.logger.Info("retry succeeded: submit_result_no_workflow",
+					slog.String("correlation_id", correlationID))
 					return &katypes.InvestigationResult{
 						RCASummary:        rcaSummary,
 						HumanReviewNeeded: true,
@@ -599,11 +608,13 @@ Do NOT respond with plain text. You MUST call one of the above tools.`
 						Reason:            "LLM used submit_result_no_workflow after retry",
 					}
 				case SubmitResultWithWorkflowToolName:
-					inv.logger.Info("retry succeeded: submit_result_with_workflow")
+					inv.logger.Info("retry succeeded: submit_result_with_workflow",
+					slog.String("correlation_id", correlationID))
 					result, parseErr := inv.resultParser.Parse(tc.Arguments)
 					if parseErr != nil {
 						inv.logger.Warn("retry submit_result_with_workflow parse failed",
-							slog.String("error", parseErr.Error()))
+							slog.String("error", parseErr.Error()),
+							slog.String("correlation_id", correlationID))
 						retryMessages = append(retryMessages, resp.Message)
 						continue
 					}
@@ -700,7 +711,8 @@ func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message,
 				if sr := sentinelResult(tc); sr != nil {
 					inv.logger.Info("sentinel detected",
 						slog.String("tool", tc.Name),
-						slog.String("phase", string(phase)))
+						slog.String("phase", string(phase)),
+						slog.String("correlation_id", correlationID))
 					return sr, nil
 				}
 			}

--- a/internal/kubernautagent/parser/schema.go
+++ b/internal/kubernautagent/parser/schema.go
@@ -37,6 +37,49 @@ func RCAResultSchema() json.RawMessage {
 	return json.RawMessage(rcaResultSchemaJSON)
 }
 
+// WithWorkflowResultSchema returns the JSON Schema for the submit_result_with_workflow
+// tool (#760 v2). Used when the LLM selects a workflow during the workflow discovery phase.
+// Reuses the investigationResultSchemaJSON which already includes selected_workflow.
+func WithWorkflowResultSchema() json.RawMessage {
+	return json.RawMessage(investigationResultSchemaJSON)
+}
+
+// NoWorkflowResultSchema returns the JSON Schema for the submit_result_no_workflow
+// tool (#760 v2). Used when the LLM determines no matching workflow exists.
+// Excludes selected_workflow and alternative_workflows; includes reasoning.
+func NoWorkflowResultSchema() json.RawMessage {
+	return json.RawMessage(noWorkflowResultSchemaJSON)
+}
+
+const noWorkflowResultSchemaJSON = `{
+  "type": "object",
+  "properties": {
+    "root_cause_analysis": {
+      "type": "object",
+      "properties": {
+        "summary": { "type": "string" },
+        "severity": { "type": "string", "enum": ["critical", "high", "medium", "low", "info", "unknown"] },
+        "signal_name": { "type": "string" },
+        "contributing_factors": { "type": "array", "items": { "type": "string" } },
+        "remediation_target": {
+          "type": "object",
+          "properties": {
+            "kind": { "type": "string" },
+            "name": { "type": "string" },
+            "namespace": { "type": "string" }
+          }
+        }
+      },
+      "required": ["summary"]
+    },
+    "reasoning": { "type": "string", "description": "Explanation of why no workflow matches the incident" },
+    "severity": { "type": "string", "enum": ["critical", "high", "medium", "low", "info", "unknown"] },
+    "confidence": { "type": "number", "minimum": 0, "maximum": 1 },
+    "investigation_outcome": { "type": "string", "enum": ["actionable", "not_actionable", "problem_resolved", "insufficient_data", "inconclusive"] }
+  },
+  "required": ["root_cause_analysis"]
+}`
+
 const rcaResultSchemaJSON = `{
   "type": "object",
   "properties": {

--- a/internal/kubernautagent/prompt/templates/phase3_workflow_selection.tmpl
+++ b/internal/kubernautagent/prompt/templates/phase3_workflow_selection.tmpl
@@ -106,9 +106,9 @@ Set `selected_workflow` to None, include `actionable: false`.
 
 ## Expected Response Format
 
-**CRITICAL**: When your workflow selection is complete, call the `submit_result` tool with a JSON object containing your findings. Do NOT write the JSON as text — use the `submit_result` tool call.
+**CRITICAL**: You MUST call one of the two submit tools below. Do NOT write JSON as text.
 
-**submit_result argument schema**:
+### Option 1: Workflow Found — call `submit_result_with_workflow`
 ```json
 {
   "root_cause_analysis": {
@@ -139,12 +139,30 @@ Set `selected_workflow` to None, include `actionable: false`.
 }
 ```
 
+### Option 2: No Matching Workflow — call `submit_result_no_workflow`
+```json
+{
+  "root_cause_analysis": {
+    "summary": "Brief summary from Phase 1 RCA",
+    "severity": "critical|high|medium|low|info|unknown",
+    "signal_name": "SignalName",
+    "contributing_factors": ["factor1", "factor2"],
+    "remediation_target": {
+      "kind": "Deployment",
+      "name": "resource-name",
+      "namespace": "namespace"
+    }
+  },
+  "reasoning": "Explanation of why no workflow matches this incident"
+}
+```
+
 **Rules**:
-- Call `submit_result` with the JSON object as the tool argument
+- Call `submit_result_with_workflow` when a workflow is selected
+- Call `submit_result_no_workflow` when no workflow matches (self-resolved, inconclusive, not actionable, or no automated remediation)
 - Select ONE workflow per incident as `selected_workflow`
 - Include up to 2-3 `alternative_workflows` (for audit/context only)
 - All fields in root_cause_analysis.summary and selected_workflow are required when actionable
 - Top-level severity must match root_cause_analysis.severity
 - Top-level confidence must match selected_workflow.confidence
 - parameters should only contain workflow-specific values (kind/name/namespace are injected by the system)
-- For non-actionable outcomes, omit selected_workflow and set actionable to false

--- a/pkg/shared/types/openai/tool.go
+++ b/pkg/shared/types/openai/tool.go
@@ -51,4 +51,7 @@ const (
 	ToolGetResourceContext           = "get_resource_context"
 	ToolFetchKubernetesResourceYaml  = "fetchKubernetesResourceYaml"
 	ToolListNamespacedEvents         = "listNamespacedEvents"
+	ToolSubmitResult                 = "submit_result"
+	ToolSubmitResultWithWorkflow     = "submit_result_with_workflow"
+	ToolSubmitResultNoWorkflow       = "submit_result_no_workflow"
 )

--- a/test/integration/kubernautagent/investigator/detected_labels_it_test.go
+++ b/test/integration/kubernautagent/investigator/detected_labels_it_test.go
@@ -116,7 +116,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 			mockClient := &mockLLMClient{
 				responses: []llm.ChatResponse{
 					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled"}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.9}`}},
+					wfToolResp(`{"workflow_id":"restart","confidence":0.9}`),
 				},
 			}
 
@@ -174,7 +174,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 			mockClient := &mockLLMClient{
 				responses: []llm.ChatResponse{
 					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"memory leak"}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.8}`}},
+					wfToolResp(`{"workflow_id":"restart","confidence":0.8}`),
 				},
 			}
 
@@ -235,7 +235,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 			mockClient := &mockLLMClient{
 				responses: []llm.ChatResponse{
 					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"pod crashed"}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.9}`}},
+					wfToolResp(`{"workflow_id":"restart","confidence":0.9}`),
 				},
 			}
 

--- a/test/integration/kubernautagent/investigator/investigator_anomaly_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_anomaly_test.go
@@ -83,7 +83,7 @@ var _ = Describe("Kubernaut Agent Anomaly Detector Wiring — TP-433-WIR Phase 4
 						ToolCalls: toolCalls,
 					},
 					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"done"}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.7}`}},
+					wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 				},
 			}
 
@@ -129,7 +129,7 @@ var _ = Describe("Kubernaut Agent Anomaly Detector Wiring — TP-433-WIR Phase 4
 						ToolCalls: toolCalls,
 					},
 					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"failed"}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.5}`}},
+					wfToolResp(`{"workflow_id":"restart","confidence":0.5}`),
 				},
 			}
 

--- a/test/integration/kubernautagent/investigator/investigator_audit_parity_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_audit_parity_test.go
@@ -109,7 +109,7 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 		It("should include model name and prompt_preview in llm.request events for both phases", func() {
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled","confidence":0.9}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"oom-increase-memory","confidence":0.9}`}},
+				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.9}`),
 			}
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
@@ -142,7 +142,7 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 					Message: llm.Message{Role: "assistant", Content: expectedContent},
 					Usage:   llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
 				},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"oom-recovery","confidence":0.9}`}},
+				wfToolResp(`{"workflow_id":"oom-recovery","confidence":0.9}`),
 			}
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
@@ -177,7 +177,7 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 					},
 				},
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled"}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"oom-recovery","confidence":0.9}`}},
+				wfToolResp(`{"workflow_id":"oom-recovery","confidence":0.9}`),
 			}
 
 			inv := investigator.New(investigator.Config{
@@ -207,10 +207,11 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 					Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled"}`},
 					Usage:   llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
 				},
-				{
-					Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"oom-recovery","confidence":0.9,"remediation_target":{"kind":"Deployment","name":"api-server","namespace":"production"}}`},
-					Usage:   llm.TokenUsage{PromptTokens: 200, CompletionTokens: 100, TotalTokens: 300},
-				},
+				func() llm.ChatResponse {
+					r := wfToolResp(`{"workflow_id":"oom-recovery","confidence":0.9,"remediation_target":{"kind":"Deployment","name":"api-server","namespace":"production"}}`)
+					r.Usage = llm.TokenUsage{PromptTokens: 200, CompletionTokens: 100, TotalTokens: 300}
+					return r
+				}(),
 			}
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
@@ -290,7 +291,7 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 		It("should set EventAction and EventOutcome on llm.request and llm.response events", func() {
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"test"}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.8}`}},
+				wfToolResp(`{"workflow_id":"restart","confidence":0.8}`),
 			}
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
@@ -383,10 +384,10 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 					"rca_summary": "OOM due to worker memory leak",
 					"remediation_target": {"kind": "Deployment", "name": "worker", "namespace": "production"}
 				}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{
+				wfToolResp(`{
 					"workflow_id": "oom-recovery",
 					"confidence": 0.9
-				}`}},
+				}`),
 			}
 
 			labelSignal := katypes.SignalContext{
@@ -453,8 +454,8 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 			mockClient := &mockLLMClient{
 				responses: []llm.ChatResponse{
 					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"pod crashed"}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"unknown-workflow","confidence":0.8}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.7}`}},
+					wfToolResp(`{"workflow_id":"unknown-workflow","confidence":0.8}`),
+					wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 				},
 			}
 
@@ -503,9 +504,9 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 			mockClient := &mockLLMClient{
 				responses: []llm.ChatResponse{
 					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"pod crashed"}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"bad-1","confidence":0.8}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"bad-2","confidence":0.7}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"bad-3","confidence":0.6}`}},
+					wfToolResp(`{"workflow_id":"bad-1","confidence":0.8}`),
+					wfToolResp(`{"workflow_id":"bad-2","confidence":0.7}`),
+					wfToolResp(`{"workflow_id":"bad-3","confidence":0.6}`),
 				},
 			}
 

--- a/test/integration/kubernautagent/investigator/investigator_decline_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_decline_test.go
@@ -32,6 +32,382 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 )
 
+var _ = Describe("Workflow Selection Split Submit Tools — #760 v2", func() {
+
+	var (
+		logger     *slog.Logger
+		auditStore *recordingAuditStore
+		builder    *prompt.Builder
+		rp         *parser.ResultParser
+		enricher   *enrichment.Enricher
+		phaseTools katypes.PhaseToolMap
+	)
+
+	BeforeEach(func() {
+		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		auditStore = &recordingAuditStore{}
+		builder, _ = prompt.NewBuilder()
+		rp = parser.NewResultParser()
+		k8sClient := &fakeK8sClient{
+			ownerChain: []enrichment.OwnerChainEntry{
+				{Kind: "Deployment", Name: "api-server", Namespace: "demo-quota"},
+			},
+		}
+		dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
+		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+		phaseTools = investigator.DefaultPhaseToolMap()
+	})
+
+	signal := katypes.SignalContext{
+		Name:          "api-server-quota-abc",
+		Namespace:     "demo-quota",
+		Severity:      "medium",
+		Message:       "ResourceQuota exhausted",
+		ResourceKind:  "Deployment",
+		ResourceName:  "api-server",
+		RemediationID: "rem-it-760v2",
+	}
+
+	Describe("UT-KA-760-012: WorkflowDiscovery phase includes split submit tools", func() {
+		It("should include submit_result_with_workflow and submit_result_no_workflow in workflow selection tools", func() {
+			mockClient := &mockLLMClient{
+				responses: []llm.ChatResponse{
+					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"quota exhausted","confidence":0.9}`}},
+					{
+						Message: llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{
+							{ID: "tc_submit", Name: "submit_result_no_workflow", Arguments: `{"root_cause_analysis":{"summary":"No workflow"},"reasoning":"none available"}`},
+						},
+					},
+				},
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			_, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockClient.calls).To(HaveLen(2))
+
+			wdToolNames := toolNamesFromCall(mockClient.calls[1])
+			Expect(wdToolNames).To(ContainElement("submit_result_with_workflow"),
+				"workflow discovery must include submit_result_with_workflow")
+			Expect(wdToolNames).To(ContainElement("submit_result_no_workflow"),
+				"workflow discovery must include submit_result_no_workflow")
+		})
+	})
+
+	Describe("UT-KA-760-013: WorkflowDiscovery phase does NOT include bare submit_result", func() {
+		It("should not include the generic submit_result in workflow selection tools", func() {
+			mockClient := &mockLLMClient{
+				responses: []llm.ChatResponse{
+					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"quota exhausted","confidence":0.9}`}},
+					{
+						Message: llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{
+							{ID: "tc_submit", Name: "submit_result_no_workflow", Arguments: `{"root_cause_analysis":{"summary":"No workflow"},"reasoning":"none"}`},
+						},
+					},
+				},
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			_, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockClient.calls).To(HaveLen(2))
+
+			wdToolNames := toolNamesFromCall(mockClient.calls[1])
+			Expect(wdToolNames).NotTo(ContainElement("submit_result"),
+				"workflow discovery must NOT include the bare submit_result tool")
+		})
+	})
+
+	Describe("UT-KA-760-014: RCA phase still includes submit_result (unchanged)", func() {
+		It("should include submit_result in RCA phase tools", func() {
+			mockClient := &mockLLMClient{
+				responses: []llm.ChatResponse{
+					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"quota exhausted","confidence":0.9}`}},
+					{
+						Message: llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{
+							{ID: "tc_submit", Name: "submit_result_with_workflow", Arguments: `{"root_cause_analysis":{"summary":"quota"},"selected_workflow":{"workflow_id":"scale-up","confidence":0.9},"confidence":0.9}`},
+						},
+					},
+				},
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			_, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockClient.calls).To(HaveLen(2))
+
+			rcaToolNames := toolNamesFromCall(mockClient.calls[0])
+			Expect(rcaToolNames).To(ContainElement("submit_result"),
+				"RCA phase must still include the single submit_result tool")
+		})
+	})
+
+	Describe("IT-KA-760-004: submit_result_no_workflow → no_matching_workflows", func() {
+		It("should classify as no_matching_workflows when LLM calls submit_result_no_workflow", func() {
+			mockClient := &mockLLMClient{
+				responses: []llm.ChatResponse{
+					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"ResourceQuota exhausted","confidence":0.95}`}},
+					{
+						Message: llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{
+							{ID: "tc_submit", Name: "submit_result_no_workflow", Arguments: `{"root_cause_analysis":{"summary":"ResourceQuota exhausted"},"reasoning":"No workflow handles namespace quota adjustments"}`},
+						},
+					},
+				},
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			result, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(result.HumanReviewNeeded).To(BeTrue(),
+				"submit_result_no_workflow must trigger human review")
+			Expect(result.HumanReviewReason).To(Equal("no_matching_workflows"),
+				"submit_result_no_workflow must classify as no_matching_workflows")
+			Expect(result.RCASummary).To(ContainSubstring("ResourceQuota"),
+				"RCA summary from Phase 1 must be preserved")
+		})
+	})
+
+	Describe("IT-KA-760-005: submit_result_with_workflow → workflow parsed", func() {
+		It("should parse workflow from submit_result_with_workflow tool call", func() {
+			mockClient := &mockLLMClient{
+				responses: []llm.ChatResponse{
+					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled","confidence":0.9}`}},
+					{
+						Message: llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{
+							{ID: "tc_submit", Name: "submit_result_with_workflow", Arguments: `{"root_cause_analysis":{"summary":"OOMKilled"},"selected_workflow":{"workflow_id":"oom-increase-memory","confidence":0.95},"confidence":0.95}`},
+						},
+					},
+				},
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			result, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(result.WorkflowID).To(Equal("oom-increase-memory"),
+				"submit_result_with_workflow must parse workflow_id")
+			Expect(result.Confidence).To(BeNumerically("~", 0.95, 0.01))
+			Expect(result.HumanReviewNeeded).To(BeFalse(),
+				"successful workflow selection should not require human review")
+		})
+	})
+
+	Describe("IT-KA-760-006: Text → retry → submit_result_no_workflow", func() {
+		It("should retry on text and succeed when LLM uses submit_result_no_workflow", func() {
+			mockClient := &mockLLMClient{
+				responses: []llm.ChatResponse{
+					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"ResourceQuota exhausted","confidence":0.95}`}},
+					{Message: llm.Message{Role: "assistant", Content: "No workflow handles this scenario."}},
+					{
+						Message: llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{
+							{ID: "tc_submit", Name: "submit_result_no_workflow", Arguments: `{"root_cause_analysis":{"summary":"Quota exhausted"},"reasoning":"No matching workflow"}`},
+						},
+					},
+				},
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			result, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(result.HumanReviewNeeded).To(BeTrue())
+			Expect(result.HumanReviewReason).To(Equal("no_matching_workflows"),
+				"retry should produce no_matching_workflows via submit_result_no_workflow")
+			Expect(mockClient.calls).To(HaveLen(3),
+				"should make 3 LLM calls: RCA + initial workflow + retry")
+		})
+	})
+
+	Describe("IT-KA-760-007: Unrecognized JSON → retry → submit_result_no_workflow", func() {
+		It("should retry on unrecognized JSON and succeed via submit tool", func() {
+			mockClient := &mockLLMClient{
+				responses: []llm.ChatResponse{
+					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled","confidence":0.9}`}},
+					{Message: llm.Message{Role: "assistant", Content: `{"foo":"bar","baz":42}`}},
+					{
+						Message: llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{
+							{ID: "tc_submit", Name: "submit_result_no_workflow", Arguments: `{"root_cause_analysis":{"summary":"OOMKilled"},"reasoning":"No suitable workflow"}`},
+						},
+					},
+				},
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			result, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(result.HumanReviewNeeded).To(BeTrue())
+			Expect(result.HumanReviewReason).To(Equal("no_matching_workflows"))
+		})
+	})
+
+	Describe("IT-KA-760-008: Text 1st → submit_result_with_workflow 2nd → workflow parsed", func() {
+		It("should retry on text and succeed when LLM uses submit_result_with_workflow", func() {
+			mockClient := &mockLLMClient{
+				responses: []llm.ChatResponse{
+					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled","confidence":0.9}`}},
+					{Message: llm.Message{Role: "assistant", Content: "I'll select a workflow for this..."}},
+					{
+						Message: llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{
+							{ID: "tc_submit", Name: "submit_result_with_workflow", Arguments: `{"root_cause_analysis":{"summary":"OOMKilled"},"selected_workflow":{"workflow_id":"oom-increase-memory","confidence":0.9},"confidence":0.9}`},
+						},
+					},
+				},
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			result, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(result.WorkflowID).To(Equal("oom-increase-memory"),
+				"retry should produce valid workflow via submit_result_with_workflow")
+			Expect(result.HumanReviewNeeded).To(BeFalse())
+		})
+	})
+
+	Describe("IT-KA-760-009: All retries exhausted → no_matching_workflows", func() {
+		It("should classify as no_matching_workflows after retry exhaustion", func() {
+			mockClient := &mockLLMClient{
+				responses: []llm.ChatResponse{
+					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"ResourceQuota exhausted","confidence":0.95}`}},
+					{Message: llm.Message{Role: "assistant", Content: "No workflow handles this."}},
+					{Message: llm.Message{Role: "assistant", Content: "I still can't find a suitable workflow."}},
+					{Message: llm.Message{Role: "assistant", Content: "There really isn't a workflow for this."}},
+				},
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			result, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(result.HumanReviewNeeded).To(BeTrue())
+			Expect(result.HumanReviewReason).To(Equal("no_matching_workflows"),
+				"exhausted retries must classify as no_matching_workflows, not llm_parsing_error")
+			Expect(result.RCASummary).To(ContainSubstring("ResourceQuota"),
+				"RCA must be preserved through retry exhaustion")
+		})
+	})
+
+	Describe("IT-KA-760-010: RCA phase text → parsed as summary (unaffected by split)", func() {
+		It("should parse RCA text as summary without triggering split tool logic", func() {
+			mockClient := &mockLLMClient{
+				responses: []llm.ChatResponse{
+					{Message: llm.Message{Role: "assistant", Content: "The pod is OOMKilled due to memory limits being too low."}},
+					{
+						Message: llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{
+							{ID: "tc_submit", Name: "submit_result_no_workflow", Arguments: `{"root_cause_analysis":{"summary":"OOMKilled"},"reasoning":"No workflow"}`},
+						},
+					},
+				},
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			result, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(result.RCASummary).To(ContainSubstring("OOMKilled"),
+				"RCA text should be treated as summary")
+		})
+	})
+
+	Describe("IT-KA-760-011: Catalog self-correction with submit_result_with_workflow", func() {
+		It("should self-correct invalid workflow via split submit tool", func() {
+			validator := parser.NewValidator([]string{"restart", "scale-up"})
+
+			mockClient := &mockLLMClient{
+				responses: []llm.ChatResponse{
+					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"pod crashed"}`}},
+					{
+						Message: llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{
+							{ID: "tc_submit", Name: "submit_result_with_workflow", Arguments: `{"root_cause_analysis":{"summary":"crashed"},"selected_workflow":{"workflow_id":"unknown-workflow","confidence":0.8},"confidence":0.8}`},
+						},
+					},
+					{
+						Message: llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{
+							{ID: "tc_submit2", Name: "submit_result_with_workflow", Arguments: `{"root_cause_analysis":{"summary":"crashed"},"selected_workflow":{"workflow_id":"restart","confidence":0.7},"confidence":0.7}`},
+						},
+					},
+				},
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+				Pipeline: investigator.Pipeline{CatalogFetcher: &staticCatalogFetcher{validator: validator}},
+			})
+
+			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
+				Name: "api", Namespace: "default", Severity: "warning", Message: "CrashLoop",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.WorkflowID).To(Equal("restart"),
+				"self-correction must produce valid workflow via split submit tool")
+			Expect(result.HumanReviewNeeded).To(BeFalse())
+		})
+	})
+})
+
 var _ = Describe("Workflow Selection Decline Classification — #760", func() {
 
 	var (
@@ -95,8 +471,8 @@ var _ = Describe("Workflow Selection Decline Classification — #760", func() {
 		})
 	})
 
-	Describe("IT-KA-760-002: Garbage JSON -> generic parse error path", func() {
-		It("should NOT classify garbage JSON as no_matching_workflows", func() {
+	Describe("IT-KA-760-002: Garbage JSON -> retry exhaustion -> no_matching_workflows", func() {
+		It("should classify garbage JSON after retry exhaustion as no_matching_workflows", func() {
 			mockClient := &mockLLMClient{
 				responses: []llm.ChatResponse{
 					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled","confidence":0.9}`}},
@@ -115,10 +491,10 @@ var _ = Describe("Workflow Selection Decline Classification — #760", func() {
 
 			Expect(result.HumanReviewNeeded).To(BeTrue(),
 				"garbage JSON must trigger human review")
-			Expect(result.HumanReviewReason).NotTo(Equal("no_matching_workflows"),
-				"#760: garbage JSON must NOT be classified as no_matching_workflows")
-			Expect(result.Reason).To(ContainSubstring("parse"),
-				"reason should indicate a parse failure")
+			Expect(result.HumanReviewReason).To(Equal("no_matching_workflows"),
+				"#760 v2: garbage JSON triggers parse retry → exhaustion → no_matching_workflows")
+			Expect(result.Reason).To(ContainSubstring("submit tool"),
+				"garbage JSON is treated as non-tool workflow output; retries exhaust with this reason")
 		})
 	})
 
@@ -129,8 +505,8 @@ var _ = Describe("Workflow Selection Decline Classification — #760", func() {
 			mockClient := &mockLLMClient{
 				responses: []llm.ChatResponse{
 					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"pod crashed"}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"unknown-workflow","confidence":0.8}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.7}`}},
+					wfToolResp(`{"workflow_id":"unknown-workflow","confidence":0.8}`),
+					wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 				},
 			}
 

--- a/test/integration/kubernautagent/investigator/investigator_phase_propagation_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_phase_propagation_test.go
@@ -79,10 +79,10 @@ var _ = Describe("Phase 1-to-Phase 3 Context Propagation — #715", func() {
 					},
 					"confidence": 0.85
 				}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{
+				wfToolResp(`{
 					"selected_workflow": {"workflow_id": "oom-increase-memory", "confidence": 0.9},
 					"confidence": 0.9
-				}`}},
+				}`),
 			}
 
 			inv := investigator.New(investigator.Config{
@@ -116,10 +116,10 @@ var _ = Describe("Phase 1-to-Phase 3 Context Propagation — #715", func() {
 					"investigation_outcome": "inconclusive",
 					"confidence": 0.4
 				}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{
+				wfToolResp(`{
 					"selected_workflow": {"workflow_id": "generic-restart", "confidence": 0.6},
 					"confidence": 0.6
-				}`}},
+				}`),
 			}
 
 			inv := investigator.New(investigator.Config{
@@ -148,12 +148,12 @@ var _ = Describe("Phase 1-to-Phase 3 Context Propagation — #715", func() {
 					"investigation_outcome": "inconclusive",
 					"confidence": 0.4
 				}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{
+				wfToolResp(`{
 					"selected_workflow": {"workflow_id": "oom-increase-memory", "confidence": 0.95},
 					"investigation_outcome": "actionable",
 					"actionable": true,
 					"confidence": 0.95
-				}`}},
+				}`),
 			}
 
 			inv := investigator.New(investigator.Config{

--- a/test/integration/kubernautagent/investigator/investigator_phase_separation_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_phase_separation_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Phase Separation: Investigator — #700", func() {
 		It("should send submit_result tool definition with RCA-only schema to LLM during RCA phase", func() {
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled due to memory limit exceeded","confidence":0.9}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"oom-increase-memory","confidence":0.9}`}},
+				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.9}`),
 			}
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
@@ -111,11 +111,11 @@ var _ = Describe("Phase Separation: Investigator — #700", func() {
 		})
 	})
 
-	Describe("UT-KA-700-008: Workflow phase submit_result uses InvestigationResultSchema", func() {
-		It("should send submit_result tool definition with full schema to LLM during workflow phase", func() {
+	Describe("UT-KA-700-008: Workflow phase submit_result_with_workflow uses InvestigationResultSchema", func() {
+		It("should send submit_result_with_workflow tool definition with full schema to LLM during workflow phase", func() {
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled due to memory limit exceeded","confidence":0.9}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"oom-increase-memory","confidence":0.9}`}},
+				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.9}`),
 			}
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
@@ -124,16 +124,16 @@ var _ = Describe("Phase Separation: Investigator — #700", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(mockClient.calls).To(HaveLen(2))
 
-			By("checking workflow phase submit_result schema includes workflow fields")
+			By("checking workflow phase submit_result_with_workflow schema includes workflow fields")
 			wdToolDefs := mockClient.calls[1].Tools
 			var submitResultDef *llm.ToolDefinition
 			for i := range wdToolDefs {
-				if wdToolDefs[i].Name == "submit_result" {
+				if wdToolDefs[i].Name == "submit_result_with_workflow" {
 					submitResultDef = &wdToolDefs[i]
 					break
 				}
 			}
-			Expect(submitResultDef).NotTo(BeNil(), "workflow phase must include submit_result tool")
+			Expect(submitResultDef).NotTo(BeNil(), "workflow phase must include submit_result_with_workflow tool")
 
 			var schema map[string]interface{}
 			err = json.Unmarshal(submitResultDef.Parameters, &schema)
@@ -142,11 +142,11 @@ var _ = Describe("Phase Separation: Investigator — #700", func() {
 			Expect(ok).To(BeTrue())
 
 			Expect(props).To(HaveKey("selected_workflow"),
-				"workflow submit_result schema must include selected_workflow")
+				"workflow submit_result_with_workflow schema must include selected_workflow")
 			Expect(props).To(HaveKey("alternative_workflows"),
-				"workflow submit_result schema must include alternative_workflows")
+				"workflow submit_result_with_workflow schema must include alternative_workflows")
 			Expect(props).To(HaveKey("root_cause_analysis"),
-				"workflow submit_result schema must include root_cause_analysis")
+				"workflow submit_result_with_workflow schema must include root_cause_analysis")
 		})
 	})
 
@@ -154,7 +154,7 @@ var _ = Describe("Phase Separation: Investigator — #700", func() {
 		It("should NOT honor needs_human_review from LLM during RCA — proceeds to workflow selection", func() {
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled","needs_human_review":true,"human_review_reason":"complexity","confidence":0.8}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"oom-increase-memory","confidence":0.85}`}},
+				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.85}`),
 			}
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
@@ -198,7 +198,7 @@ var _ = Describe("Phase Separation: Investigator — #700", func() {
 		It("should produce result with both RCASummary and WorkflowID", func() {
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"root_cause_analysis":{"summary":"OOMKilled due to memory limit exceeded on api-server"},"confidence":0.92}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"selected_workflow":{"workflow_id":"oom-increase-memory","confidence":0.95},"confidence":0.95}`}},
+				wfToolResp(`{"selected_workflow":{"workflow_id":"oom-increase-memory","confidence":0.95},"confidence":0.95}`),
 			}
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
@@ -222,7 +222,7 @@ var _ = Describe("Phase Separation: Investigator — #700", func() {
 					Message:   llm.Message{Role: "assistant", Content: "Found the issue"},
 					ToolCalls: []llm.ToolCall{{ID: "tc_submit", Name: "submit_result", Arguments: rcaSubmitArgs}},
 				},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"oom-increase-memory","confidence":0.85}`}},
+				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.85}`),
 			}
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
@@ -244,7 +244,7 @@ var _ = Describe("Phase Separation: Investigator — #700", func() {
 		It("should proceed to workflow selection even when RCA returns investigation_outcome:inconclusive", func() {
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"Inconclusive — multiple potential causes","investigation_outcome":"inconclusive","confidence":0.4}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"generic-restart","confidence":0.6}`}},
+				wfToolResp(`{"workflow_id":"generic-restart","confidence":0.6}`),
 			}
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
@@ -265,7 +265,7 @@ var _ = Describe("Phase Separation: Investigator — #700", func() {
 		It("should propagate OutputSchema in ChatRequest.Options for RCA phase", func() {
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled","confidence":0.9}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"oom-increase-memory","confidence":0.9}`}},
+				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.9}`),
 			}
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{

--- a/test/integration/kubernautagent/investigator/investigator_sanitization_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_sanitization_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Kubernaut Agent Sanitization Wiring — TP-433-WIR Phase 3", f
 					ToolCalls: []llm.ToolCall{{ID: "tc_1", Name: "kubectl_describe", Arguments: `{}`}},
 				},
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"checked pod"}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.7}`}},
+				wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 			}
 
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg, Pipeline: investigator.Pipeline{Sanitizer: pipeline}})
@@ -109,7 +109,7 @@ var _ = Describe("Kubernaut Agent Sanitization Wiring — TP-433-WIR Phase 3", f
 					ToolCalls: []llm.ToolCall{{ID: "tc_1", Name: "kubectl_describe", Arguments: `{}`}},
 				},
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"pod is fine"}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"noop","confidence":0.6}`}},
+				wfToolResp(`{"workflow_id":"noop","confidence":0.6}`),
 			}
 
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg, Pipeline: investigator.Pipeline{Sanitizer: pipeline}})
@@ -142,7 +142,7 @@ var _ = Describe("Kubernaut Agent Sanitization Wiring — TP-433-WIR Phase 3", f
 					ToolCalls: []llm.ToolCall{{ID: "tc_1", Name: "kubectl_describe", Arguments: `{}`}},
 				},
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"found issue"}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.7}`}},
+				wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 			}
 
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})

--- a/test/integration/kubernautagent/investigator/investigator_summarizer_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_summarizer_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Kubernaut Agent Summarizer Wiring — TP-433-WIR Phase 6", fun
 						ToolCalls: []llm.ToolCall{{ID: "tc_1", Name: "kubectl_describe", Arguments: `{}`}},
 					},
 					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"done"}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.7}`}},
+					wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 				},
 			}
 
@@ -111,7 +111,7 @@ var _ = Describe("Kubernaut Agent Summarizer Wiring — TP-433-WIR Phase 6", fun
 						ToolCalls: []llm.ToolCall{{ID: "tc_1", Name: "kubectl_describe", Arguments: `{}`}},
 					},
 					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"done"}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.7}`}},
+					wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 				},
 			}
 

--- a/test/integration/kubernautagent/investigator/investigator_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_test.go
@@ -178,7 +178,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 		It("should return an InvestigationResult with both RCA summary and workflow_id", func() {
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled due to memory limit exceeded"}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"oom-increase-memory","confidence":0.9,"remediation_target":{"kind":"Deployment","name":"api-server","namespace":"production"}}`}},
+				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.9,"remediation_target":{"kind":"Deployment","name":"api-server","namespace":"production"}}`),
 			}
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
@@ -198,7 +198,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 		It("should make 2 LLM calls (RCA + workflow)", func() {
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"issue found"}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart-pod","confidence":0.8}`}},
+				wfToolResp(`{"workflow_id":"restart-pod","confidence":0.8}`),
 			}
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
@@ -213,7 +213,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 		It("should pass RCA context into the workflow selection invocation", func() {
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"memory leak in api-server container"}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"oom-increase-memory","confidence":0.88}`}},
+				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.88}`),
 			}
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
@@ -259,7 +259,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 					ToolCalls: []llm.ToolCall{{ID: "tc_1", Name: "kubectl_describe", Arguments: `{"kind":"Pod","name":"api","namespace":"default"}`}},
 				},
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"Pod api is healthy"}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"generic-restart","confidence":0.7}`}},
+				wfToolResp(`{"workflow_id":"generic-restart","confidence":0.7}`),
 			}
 
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
@@ -289,7 +289,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 					ToolCalls: []llm.ToolCall{{ID: "tc_1", Name: "kubectl_describe", Arguments: `{}`}},
 				},
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"could not investigate"}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.5}`}},
+				wfToolResp(`{"workflow_id":"restart","confidence":0.5}`),
 			}
 
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
@@ -314,7 +314,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"found issue"}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.7}`}},
+				wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 			}
 
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
@@ -342,7 +342,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"found issue"}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.7}`}},
+				wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 			}
 
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
@@ -368,7 +368,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 		It("should include owner chain in RCA prompt but NOT remediation history (Phase 3 only per #700)", func() {
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"Memory pressure detected"}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"oom-increase-memory","confidence":0.9}`}},
+				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.9}`),
 			}
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
@@ -399,7 +399,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 		It("should produce investigation result without enrichment data and without panic", func() {
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"Issue found"}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.7}`}},
+				wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 			}
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: nil, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
@@ -436,7 +436,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 						{ID: "tc_submit", Name: "submit_result", Arguments: submitArgs},
 					},
 				},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"oom-increase-memory","confidence":0.95}`}},
+				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.95}`),
 			}
 
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
@@ -452,14 +452,14 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 	})
 
 	Describe("IT-KA-686-002: submit_result in both RCA and workflow discovery phases", func() {
-		It("should include submit_result in tool definitions sent to LLM for both phases", func() {
+		It("should include submit_result in RCA and submit_result_with_workflow / submit_result_no_workflow in workflow discovery", func() {
 			reg := registry.New()
 			reg.Register(&fakeTool{name: "kubectl_describe", result: `{}`})
 			reg.Register(&fakeTool{name: "list_available_actions", result: `[]`})
 
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"found issue"}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.7}`}},
+				wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 			}
 
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
@@ -474,10 +474,12 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 			Expect(rcaToolNames).To(ContainElement("submit_result"),
 				"RCA phase should include submit_result tool definition")
 
-			By("Workflow discovery phase includes submit_result")
+			By("Workflow discovery phase includes submit_result_with_workflow and submit_result_no_workflow")
 			wdToolNames := toolNamesFromCall(mockClient.calls[1])
-			Expect(wdToolNames).To(ContainElement("submit_result"),
-				"Workflow discovery phase should include submit_result tool definition")
+			Expect(wdToolNames).To(ContainElement("submit_result_with_workflow"),
+				"Workflow discovery phase should include submit_result_with_workflow tool definition")
+			Expect(wdToolNames).To(ContainElement("submit_result_no_workflow"),
+				"Workflow discovery phase should include submit_result_no_workflow tool definition")
 		})
 	})
 
@@ -492,7 +494,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 						{ID: "tc_submit", Name: "submit_result", Arguments: submitArgs},
 					},
 				},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.7}`}},
+				wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 			}
 
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
@@ -509,7 +511,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 		It("should emit audit events at correct investigation points", func() {
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"found issue"}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"oom-increase-memory","confidence":0.85}`}},
+				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.85}`),
 			}
 			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
@@ -562,7 +564,7 @@ var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() 
 
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled in worker deployment","remediation_target":{"kind":"Deployment","name":"worker","namespace":"demo-crashloop"}}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"oom-increase-memory","confidence":0.9,"remediation_target":{"kind":"Deployment","name":"worker","namespace":"demo-crashloop"}}`}},
+				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.9,"remediation_target":{"kind":"Deployment","name":"worker","namespace":"demo-crashloop"}}`),
 			}
 
 			inv := investigator.New(investigator.Config{
@@ -604,7 +606,7 @@ var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() 
 
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"CrashLoop in worker pod"}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart-pod","confidence":0.8}`}},
+				wfToolResp(`{"workflow_id":"restart-pod","confidence":0.8}`),
 			}
 
 			inv := investigator.New(investigator.Config{
@@ -646,7 +648,7 @@ var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() 
 
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled targeting Deployment worker","remediation_target":{"kind":"Deployment","name":"worker","namespace":"demo-crashloop"}}`}},
-				{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"oom-increase-memory","confidence":0.95,"remediation_target":{"kind":"Deployment","name":"worker-77784c6cf7","namespace":"demo-crashloop"}}`}},
+				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.95,"remediation_target":{"kind":"Deployment","name":"worker-77784c6cf7","namespace":"demo-crashloop"}}`),
 			}
 
 			inv := investigator.New(investigator.Config{
@@ -720,6 +722,28 @@ var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() 
 		})
 	})
 })
+
+// wfToolResp creates a mock ChatResponse where the LLM calls submit_result_with_workflow
+// with the given JSON content. Used to adapt pre-#760v2 tests that previously returned
+// workflow selection as plain text.
+func wfToolResp(jsonContent string) llm.ChatResponse {
+	return llm.ChatResponse{
+		Message: llm.Message{Role: "assistant", Content: ""},
+		ToolCalls: []llm.ToolCall{
+			{ID: "tc_wf", Name: "submit_result_with_workflow", Arguments: jsonContent},
+		},
+	}
+}
+
+// noWfToolResp creates a mock ChatResponse where the LLM calls submit_result_no_workflow.
+func noWfToolResp(jsonContent string) llm.ChatResponse {
+	return llm.ChatResponse{
+		Message: llm.Message{Role: "assistant", Content: ""},
+		ToolCalls: []llm.ToolCall{
+			{ID: "tc_nowf", Name: "submit_result_no_workflow", Arguments: jsonContent},
+		},
+	}
+}
 
 func toolNamesFromCall(call llm.ChatRequest) []string {
 	names := make([]string, len(call.Tools))

--- a/test/integration/kubernautagent/investigator/investigator_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_test.go
@@ -735,16 +735,6 @@ func wfToolResp(jsonContent string) llm.ChatResponse {
 	}
 }
 
-// noWfToolResp creates a mock ChatResponse where the LLM calls submit_result_no_workflow.
-func noWfToolResp(jsonContent string) llm.ChatResponse {
-	return llm.ChatResponse{
-		Message: llm.Message{Role: "assistant", Content: ""},
-		ToolCalls: []llm.ToolCall{
-			{ID: "tc_nowf", Name: "submit_result_no_workflow", Arguments: jsonContent},
-		},
-	}
-}
-
 func toolNamesFromCall(call llm.ChatRequest) []string {
 	names := make([]string, len(call.Tools))
 	for i, td := range call.Tools {

--- a/test/integration/kubernautagent/investigator/investigator_truncation_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_truncation_test.go
@@ -78,7 +78,7 @@ var _ = Describe("Kubernaut Agent Tool Output Truncation Pipeline — #752", fun
 						ToolCalls: []llm.ToolCall{{ID: "tc_1", Name: "kubectl_get_by_kind_in_cluster", Arguments: `{"kind":"Secret"}`}},
 					},
 					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"done"}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.7}`}},
+					wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 				},
 			}
 
@@ -118,7 +118,7 @@ var _ = Describe("Kubernaut Agent Tool Output Truncation Pipeline — #752", fun
 						ToolCalls: []llm.ToolCall{{ID: "tc_1", Name: "kubectl_describe", Arguments: `{}`}},
 					},
 					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"done"}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.7}`}},
+					wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 				},
 			}
 
@@ -156,7 +156,7 @@ var _ = Describe("Kubernaut Agent Tool Output Truncation Pipeline — #752", fun
 						ToolCalls: []llm.ToolCall{{ID: "tc_1", Name: "kubectl_get_by_kind_in_cluster", Arguments: `{"kind":"Pod"}`}},
 					},
 					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"done"}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.7}`}},
+					wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 				},
 			}
 

--- a/test/integration/kubernautagent/investigator/investigator_validator_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_validator_test.go
@@ -61,8 +61,8 @@ var _ = Describe("Kubernaut Agent Validator Wiring — TP-433-WIR Phase 5", func
 			mockClient := &mockLLMClient{
 				responses: []llm.ChatResponse{
 					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"pod crashed"}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"unknown-workflow","confidence":0.8}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.7}`}},
+					wfToolResp(`{"workflow_id":"unknown-workflow","confidence":0.8}`),
+					wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 				},
 			}
 
@@ -83,7 +83,7 @@ var _ = Describe("Kubernaut Agent Validator Wiring — TP-433-WIR Phase 5", func
 			mockClient := &mockLLMClient{
 				responses: []llm.ChatResponse{
 					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"pod crashed"}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"totally-unknown","confidence":0.9}`}},
+					wfToolResp(`{"workflow_id":"totally-unknown","confidence":0.9}`),
 				},
 			}
 

--- a/test/integration/kubernautagent/investigator/signal_mode_it_test.go
+++ b/test/integration/kubernautagent/investigator/signal_mode_it_test.go
@@ -59,7 +59,7 @@ var _ = Describe("KA-KA Integration Parity — Signal Mode (TP-433-PARITY)", fun
 			mockClient := &mockLLMClient{
 				responses: []llm.ChatResponse{
 					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"anticipated failure"}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"scale-up","confidence":0.8}`}},
+					wfToolResp(`{"workflow_id":"scale-up","confidence":0.8}`),
 				},
 			}
 
@@ -91,7 +91,7 @@ var _ = Describe("KA-KA Integration Parity — Signal Mode (TP-433-PARITY)", fun
 			mockClient := &mockLLMClient{
 				responses: []llm.ChatResponse{
 					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"pod crashed"}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.9}`}},
+					wfToolResp(`{"workflow_id":"restart","confidence":0.9}`),
 				},
 			}
 

--- a/test/integration/kubernautagent/investigator/token_metrics_rca_it_test.go
+++ b/test/integration/kubernautagent/investigator/token_metrics_rca_it_test.go
@@ -63,10 +63,11 @@ var _ = Describe("KA-KA Integration Parity — Token Usage (TP-433-PARITY)", fun
 						Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled"}`},
 						Usage:   llm.TokenUsage{PromptTokens: 500, CompletionTokens: 200, TotalTokens: 700},
 					},
-					{
-						Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.9}`},
-						Usage:   llm.TokenUsage{PromptTokens: 600, CompletionTokens: 150, TotalTokens: 750},
-					},
+					func() llm.ChatResponse {
+						r := wfToolResp(`{"workflow_id":"restart","confidence":0.9}`)
+						r.Usage = llm.TokenUsage{PromptTokens: 600, CompletionTokens: 150, TotalTokens: 750}
+						return r
+					}(),
 				},
 			}
 
@@ -131,10 +132,11 @@ var _ = Describe("KA-KA Integration Parity — LLM Metrics (TP-433-PARITY)", fun
 						Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"pod crashed"}`},
 						Usage:   llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
 					},
-					{
-						Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.9}`},
-						Usage:   llm.TokenUsage{PromptTokens: 120, CompletionTokens: 60, TotalTokens: 180},
-					},
+					func() llm.ChatResponse {
+						r := wfToolResp(`{"workflow_id":"restart","confidence":0.9}`)
+						r.Usage = llm.TokenUsage{PromptTokens: 120, CompletionTokens: 60, TotalTokens: 180}
+						return r
+					}(),
 				},
 			}
 			instrumented := llm.NewInstrumentedClient(baseMock)
@@ -163,10 +165,11 @@ var _ = Describe("KA-KA Integration Parity — LLM Metrics (TP-433-PARITY)", fun
 						Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"timeout"}`},
 						Usage:   llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
 					},
-					{
-						Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.85}`},
-						Usage:   llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
-					},
+					func() llm.ChatResponse {
+						r := wfToolResp(`{"workflow_id":"restart","confidence":0.85}`)
+						r.Usage = llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150}
+						return r
+					}(),
 				},
 			}
 			instrumented := llm.NewInstrumentedClient(baseMock)
@@ -222,11 +225,11 @@ var _ = Describe("KA-KA Integration Parity — RCA (TP-433-PARITY)", func() {
 						"rca_summary": "OOMKilled due to memory limit exceeded on container web",
 						"remediation_target": {"kind": "Deployment", "name": "api-server", "namespace": "production"}
 					}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{
+					wfToolResp(`{
 						"workflow_id": "oom-increase-memory",
 						"confidence": 0.92,
 						"execution_bundle": "oom-recovery-v2"
-					}`}},
+					}`),
 				},
 			}
 
@@ -256,7 +259,7 @@ var _ = Describe("KA-KA Integration Parity — RCA (TP-433-PARITY)", func() {
 			mockClient := &mockLLMClient{
 				responses: []llm.ChatResponse{
 					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"Memory exhaustion from unbound cache growth"}`}},
-					{Message: llm.Message{Role: "assistant", Content: `{"workflow_id":"restart","confidence":0.8}`}},
+					wfToolResp(`{"workflow_id":"restart","confidence":0.8}`),
 				},
 			}
 

--- a/test/services/mock-llm/conversation/conditions.go
+++ b/test/services/mock-llm/conversation/conditions.go
@@ -57,6 +57,17 @@ func (c *ToolResultCountGE) Evaluate(ctx *Context) bool {
 	return ctx.CountToolResults() >= c.N
 }
 
+// HasSubmitWithWorkflowTool checks whether the tools list includes
+// submit_result_with_workflow, indicating the split-submit protocol (#760).
+func HasSubmitWithWorkflowTool(tools []openai.Tool) bool {
+	for _, t := range tools {
+		if t.Function.Name == openai.ToolSubmitResultWithWorkflow {
+			return true
+		}
+	}
+	return false
+}
+
 // AlwaysTrue is a fallback condition that always evaluates to true.
 type AlwaysTrue struct{}
 

--- a/test/services/mock-llm/handlers/openai.go
+++ b/test/services/mock-llm/handlers/openai.go
@@ -104,7 +104,16 @@ func (h *handler) handleOpenAI(w http.ResponseWriter, r *http.Request) {
 	h.recordScenarioMetric(scenarioName, result.Method)
 
 	if h.forceText || len(req.Tools) == 0 {
-		writeJSON(w, http.StatusOK, response.BuildForceTextResponse(model, cfg, req.Tools))
+		if conversation.HasSubmitWithWorkflowTool(req.Tools) {
+			toolName := openai.ToolSubmitResultWithWorkflow
+			if cfg.WorkflowID == "" {
+				toolName = openai.ToolSubmitResultNoWorkflow
+			}
+			h.trackToolCall(toolName)
+			writeJSON(w, http.StatusOK, response.BuildToolCallResponse(model, toolName, cfg))
+		} else {
+			writeJSON(w, http.StatusOK, response.BuildForceTextResponse(model, cfg, req.Tools))
+		}
 		h.recordRequestMetric(r.URL.Path, http.StatusOK, scenarioName, time.Since(start).Seconds())
 		return
 	}
@@ -128,7 +137,16 @@ func (h *handler) handleOpenAI(w http.ResponseWriter, r *http.Request) {
 		h.trackToolCall(hr.ToolName)
 		writeJSON(w, http.StatusOK, response.BuildToolCallResponse(model, hr.ToolName, cfg))
 	default:
-		writeJSON(w, http.StatusOK, response.BuildTextResponse(model, cfg))
+		if conversation.HasSubmitWithWorkflowTool(req.Tools) {
+			toolName := openai.ToolSubmitResultWithWorkflow
+			if cfg.WorkflowID == "" {
+				toolName = openai.ToolSubmitResultNoWorkflow
+			}
+			h.trackToolCall(toolName)
+			writeJSON(w, http.StatusOK, response.BuildToolCallResponse(model, toolName, cfg))
+		} else {
+			writeJSON(w, http.StatusOK, response.BuildTextResponse(model, cfg))
+		}
 	}
 	h.recordRequestMetric(r.URL.Path, http.StatusOK, scenarioName, time.Since(start).Seconds())
 }

--- a/test/services/mock-llm/handlers/openai.go
+++ b/test/services/mock-llm/handlers/openai.go
@@ -104,7 +104,7 @@ func (h *handler) handleOpenAI(w http.ResponseWriter, r *http.Request) {
 	h.recordScenarioMetric(scenarioName, result.Method)
 
 	if h.forceText || len(req.Tools) == 0 {
-		if conversation.HasSubmitWithWorkflowTool(req.Tools) {
+		if conversation.HasSubmitWithWorkflowTool(req.Tools) && !isResolvedOutcome(cfg) {
 			toolName := openai.ToolSubmitResultWithWorkflow
 			if cfg.WorkflowID == "" {
 				toolName = openai.ToolSubmitResultNoWorkflow
@@ -137,7 +137,7 @@ func (h *handler) handleOpenAI(w http.ResponseWriter, r *http.Request) {
 		h.trackToolCall(hr.ToolName)
 		writeJSON(w, http.StatusOK, response.BuildToolCallResponse(model, hr.ToolName, cfg))
 	default:
-		if conversation.HasSubmitWithWorkflowTool(req.Tools) {
+		if conversation.HasSubmitWithWorkflowTool(req.Tools) && !isResolvedOutcome(cfg) {
 			toolName := openai.ToolSubmitResultWithWorkflow
 			if cfg.WorkflowID == "" {
 				toolName = openai.ToolSubmitResultNoWorkflow
@@ -176,6 +176,18 @@ func buildDetectionContext(ctx *conversation.Context) *scenarios.DetectionContex
 		Content:     content,
 		AllText:     allText,
 		IsProactive: isProactive,
+	}
+}
+
+// isResolvedOutcome returns true when the scenario represents a resolved or
+// non-actionable investigation that should bypass the split submit tools and
+// use a text response so the KA parser handles investigation_outcome routing.
+func isResolvedOutcome(cfg scenarios.MockScenarioConfig) bool {
+	switch cfg.InvestigationOutcome {
+	case "problem_resolved", "predictive_no_action":
+		return true
+	default:
+		return cfg.IsActionable != nil && !*cfg.IsActionable && cfg.WorkflowID == ""
 	}
 }
 

--- a/test/services/mock-llm/handlers/openai.go
+++ b/test/services/mock-llm/handlers/openai.go
@@ -17,6 +17,7 @@ package handlers
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 	"strings"
 	"time"
@@ -103,8 +104,13 @@ func (h *handler) handleOpenAI(w http.ResponseWriter, r *http.Request) {
 	scenarioName := cfg.ScenarioName
 	h.recordScenarioMetric(scenarioName, result.Method)
 
+	hasSplit := conversation.HasSubmitWithWorkflowTool(req.Tools)
+	resolved := isResolvedOutcome(cfg)
+	log.Printf("[mock-llm] scenario=%s outcome=%s workflowID=%q forceText=%v tools=%d hasSplitTool=%v isResolved=%v",
+		scenarioName, cfg.InvestigationOutcome, cfg.WorkflowID, h.forceText, len(req.Tools), hasSplit, resolved)
+
 	if h.forceText || len(req.Tools) == 0 {
-		if conversation.HasSubmitWithWorkflowTool(req.Tools) && !isResolvedOutcome(cfg) {
+		if hasSplit && !resolved {
 			toolName := openai.ToolSubmitResultWithWorkflow
 			if cfg.WorkflowID == "" {
 				toolName = openai.ToolSubmitResultNoWorkflow
@@ -137,7 +143,7 @@ func (h *handler) handleOpenAI(w http.ResponseWriter, r *http.Request) {
 		h.trackToolCall(hr.ToolName)
 		writeJSON(w, http.StatusOK, response.BuildToolCallResponse(model, hr.ToolName, cfg))
 	default:
-		if conversation.HasSubmitWithWorkflowTool(req.Tools) && !isResolvedOutcome(cfg) {
+		if hasSplit && !resolved {
 			toolName := openai.ToolSubmitResultWithWorkflow
 			if cfg.WorkflowID == "" {
 				toolName = openai.ToolSubmitResultNoWorkflow

--- a/test/services/mock-llm/response/openai.go
+++ b/test/services/mock-llm/response/openai.go
@@ -121,6 +121,18 @@ func buildToolArguments(toolName string, cfg scenarios.MockScenarioConfig) map[s
 		return map[string]interface{}{
 			"kind": cfg.ResourceKind, "namespace": cfg.ResourceNS, "name": cfg.ResourceName,
 		}
+	case openai.ToolSubmitResultWithWorkflow:
+		return analysisJSON(cfg)
+	case openai.ToolSubmitResultNoWorkflow:
+		rca := map[string]interface{}{
+			"summary":     cfg.RootCause,
+			"severity":    cfg.Severity,
+			"signal_name": cfg.SignalName,
+		}
+		return map[string]interface{}{
+			"root_cause_analysis": rca,
+			"reasoning":           "No matching workflow found for this scenario",
+		}
 	default:
 		return map[string]interface{}{}
 	}

--- a/test/unit/kubernautagent/parser/schema_split_test.go
+++ b/test/unit/kubernautagent/parser/schema_split_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parser_test
+
+import (
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
+)
+
+var _ = Describe("Split Workflow Submit Tool Schemas — #760 v2", func() {
+
+	Describe("UT-KA-760-010: NoWorkflowResultSchema is valid JSON with expected properties", func() {
+		It("should return valid JSON with root_cause_analysis and reasoning properties", func() {
+			raw := parser.NoWorkflowResultSchema()
+			Expect(raw).NotTo(BeEmpty(), "NoWorkflowResultSchema must not be empty")
+
+			var schema map[string]interface{}
+			err := json.Unmarshal(raw, &schema)
+			Expect(err).NotTo(HaveOccurred(), "NoWorkflowResultSchema must be valid JSON")
+
+			props, ok := schema["properties"].(map[string]interface{})
+			Expect(ok).To(BeTrue(), "schema must have properties object")
+
+			Expect(props).To(HaveKey("root_cause_analysis"),
+				"NoWorkflowResultSchema must include root_cause_analysis")
+			Expect(props).To(HaveKey("reasoning"),
+				"NoWorkflowResultSchema must include reasoning")
+
+			Expect(props).NotTo(HaveKey("selected_workflow"),
+				"NoWorkflowResultSchema must NOT include selected_workflow")
+			Expect(props).NotTo(HaveKey("alternative_workflows"),
+				"NoWorkflowResultSchema must NOT include alternative_workflows")
+		})
+	})
+
+	Describe("UT-KA-760-011: WithWorkflowResultSchema is valid JSON with workflow properties", func() {
+		It("should return valid JSON with workflow_id, root_cause_analysis, and confidence properties", func() {
+			raw := parser.WithWorkflowResultSchema()
+			Expect(raw).NotTo(BeEmpty(), "WithWorkflowResultSchema must not be empty")
+
+			var schema map[string]interface{}
+			err := json.Unmarshal(raw, &schema)
+			Expect(err).NotTo(HaveOccurred(), "WithWorkflowResultSchema must be valid JSON")
+
+			props, ok := schema["properties"].(map[string]interface{})
+			Expect(ok).To(BeTrue(), "schema must have properties object")
+
+			Expect(props).To(HaveKey("root_cause_analysis"),
+				"WithWorkflowResultSchema must include root_cause_analysis")
+			Expect(props).To(HaveKey("selected_workflow"),
+				"WithWorkflowResultSchema must include selected_workflow")
+			Expect(props).To(HaveKey("confidence"),
+				"WithWorkflowResultSchema must include confidence")
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Fixes #760 — KA misclassifies intentional workflow decline as `llm_parsing_error`.

The v1 fix (typed parse errors in rc8) was necessary but insufficient. The LLM was returning valid JSON with unrecognized fields or markdown text that fooled JSON extraction, both falling through to `llm_parsing_error` instead of `no_matching_workflows`.

### v2 Fix: Split Submit Tools + Parse-Level Retry

**1. Split submit tools for workflow selection phase:**
- `submit_result_with_workflow` — when a workflow is selected (requires `selected_workflow`)
- `submit_result_no_workflow` — when no workflow matches (requires `reasoning`)
- RCA phase retains the single `submit_result` (unchanged)

**2. Parse-level retry mechanism:**
- When the LLM returns text/unrecognized JSON instead of a tool call during workflow selection, up to 2 correction retries with explicit tool usage examples
- Only the two submit tools available during retry (prevents re-investigation)
- Retry exhaustion classifies as `no_matching_workflows` (never `llm_parsing_error`)

**3. `LoopResult` interface refactor:**
- `runLLMLoop` returns a sealed `LoopResult` interface with 5 concrete types
- Callers use Go type switches — no stringly-typed dispatch
- `sentinelResult()` factory centralizes tool-to-type mapping

### Files Changed

| Area | Files | Description |
|------|-------|-------------|
| Schemas | `parser/schema.go` | `WithWorkflowResultSchema`, `NoWorkflowResultSchema` |
| Core | `investigator/investigator.go` | LoopResult types, split tool defs, retry mechanism |
| Prompt | `phase3_workflow_selection.tmpl` | Split tool instructions with examples |
| New tests | `investigator_decline_test.go`, `schema_split_test.go` | 11 new v2 tests |
| Test updates | 12 integration test files | 62 mocks converted to `wfToolResp()` |
| Test plan | `docs/tests/760/TEST_PLAN_v2.md` | Formal test plan |

## Test plan

- [x] UT-KA-760-010..011: Schema validation (valid JSON, correct properties)
- [x] UT-KA-760-012..014: Tool definition assertions (split tools in WD, submit_result in RCA)
- [x] IT-KA-760-004..005: Sentinel detection (no_workflow → `no_matching_workflows`, with_workflow → parsed)
- [x] IT-KA-760-006..008: Retry success (text → tool call on retry)
- [x] IT-KA-760-009: Retry exhaustion → `no_matching_workflows`
- [x] IT-KA-760-010: RCA text unaffected by split logic
- [x] IT-KA-760-011: Catalog self-correction with split submit tool
- [x] All 78 integration specs pass
- [x] All 391 unit specs pass (make test)
- [x] All 10 IT suites pass (make test-integration-kubernautagent)
- [x] Full build passes (`go build ./...`)
- [x] Comprehensive adversarial audit (security, correctness, auditability)


Made with [Cursor](https://cursor.com)