### PR TITLE
feat(753): 3-port standard for GW and KA — dedicated health/metrics ports

### DIFF
--- a/charts/kubernaut/templates/gateway/gateway.yaml
+++ b/charts/kubernaut/templates/gateway/gateway.yaml
@@ -11,6 +11,8 @@ data:
   config.yaml: |
     server:
       listenAddr: ":8080"
+      healthAddr: ":8081"
+      metricsAddr: ":9090"
       maxConcurrentRequests: {{ .Values.gateway.config.server.maxConcurrentRequests | default 100 }}
       readTimeout: {{ .Values.gateway.config.server.readTimeout | default "30s" }}
       writeTimeout: {{ .Values.gateway.config.server.writeTimeout | default "30s" }}
@@ -124,7 +126,7 @@ spec:
         app: gateway
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "8080"
+        prometheus.io/port: "9090"
         prometheus.io/path: "/metrics"
     spec:
       serviceAccountName: gateway
@@ -144,6 +146,12 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+              protocol: TCP
+            - name: health
+              containerPort: 8081
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
               protocol: TCP
           env:
             - name: POD_NAME
@@ -177,16 +185,16 @@ spec:
             {{- end }}
           livenessProbe:
             httpGet:
-              path: /health
-              port: 8080
+              path: /healthz
+              port: 8081
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /ready
-              port: 8080
+              path: /readyz
+              port: 8081
             initialDelaySeconds: 30
             periodSeconds: 5
             timeoutSeconds: 5
@@ -229,3 +237,11 @@ spec:
       protocol: TCP
       port: 8080
       targetPort: 8080
+    - name: health
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+    - name: metrics
+      protocol: TCP
+      port: 9090
+      targetPort: 9090

--- a/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
+++ b/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
@@ -121,6 +121,11 @@ data:
   config.yaml: |
     logging:
       level: "INFO"
+    server:
+      address: "0.0.0.0"
+      port: 8080
+      health_addr: ":8081"
+      metrics_addr: ":9090"
     data_storage:
       url: "{{ include "kubernaut.datastorage.url" . }}"
 {{- if include "kubernaut.agent.tlsEnabled" . }}
@@ -223,7 +228,7 @@ spec:
         app: kubernaut-agent
       annotations:
         prometheus.io/scrape: "true"
-        prometheus.io/port: "8080"
+        prometheus.io/port: "9090"
         prometheus.io/path: "/metrics"
     spec:
       serviceAccountName: kubernaut-agent-sa
@@ -239,7 +244,12 @@ spec:
           securityContext:
             {{- include "kubernaut.containerSecurityContext" .Values.kubernautAgent | nindent 12 }}
           ports:
-            - containerPort: 8080
+            - name: http
+              containerPort: 8080
+            - name: health
+              containerPort: 8081
+            - name: metrics
+              containerPort: 9090
 {{- if or .Values.kubernautAgent.llm.oauth2.enabled (include "kubernaut.interServiceTLS.enabled" .) }}
           env:
 {{- if .Values.kubernautAgent.llm.oauth2.enabled }}
@@ -286,16 +296,16 @@ spec:
             {{- end }}
           livenessProbe:
             httpGet:
-              path: /health
-              port: 8080
+              path: /healthz
+              port: 8081
             initialDelaySeconds: 15
             periodSeconds: 20
             timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /ready
-              port: 8080
+              path: /readyz
+              port: 8081
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
@@ -338,8 +348,15 @@ metadata:
 spec:
   type: {{ .Values.kubernautAgent.service.type }}
   ports:
-    - port: 8080
+    - name: http
+      port: 8080
       targetPort: 8080
+    - name: health
+      port: 8081
+      targetPort: 8081
+    - name: metrics
+      port: 9090
+      targetPort: 9090
   selector:
     app: kubernaut-agent
 {{- if and .Values.kubernautAgent.prometheus.enabled .Values.kubernautAgent.prometheus.ocpMonitoringRbac }}

--- a/cmd/datastorage/main.go
+++ b/cmd/datastorage/main.go
@@ -349,8 +349,9 @@ func main() {
 	metricsMux := http.NewServeMux()
 	metricsMux.Handle("/metrics", promhttp.Handler())
 	metricsServer := &http.Server{
-		Addr:    fmt.Sprintf(":%d", cfg.Server.MetricsPort),
-		Handler: metricsMux,
+		Addr:              fmt.Sprintf(":%d", cfg.Server.MetricsPort),
+		Handler:           metricsMux,
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 
 	metricsErrors := make(chan error, 1)

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -43,6 +43,7 @@ import (
 	sharedaudit "github.com/jordigilh/kubernaut/pkg/audit"
 	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	sharedhealth "github.com/jordigilh/kubernaut/pkg/shared/health"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm/langchaingo"
 	llmtransport "github.com/jordigilh/kubernaut/pkg/kubernautagent/llm/transport"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm/vertexanthropic"
@@ -223,10 +224,8 @@ func main() {
 
 	r := chi.NewRouter()
 
-	r.Get("/health", healthHandler)
-	r.Get("/ready", readyHandler)
+	// Issue #753: /config remains on API port; health, readiness and metrics move to dedicated ports
 	r.Get("/config", configHandler(cfg))
-	r.Handle("/metrics", promhttp.Handler())
 
 	r.Route("/api/v1", func(r chi.Router) {
 		authMw := newAuthMiddleware(cfg, logrLogger)
@@ -265,6 +264,16 @@ func main() {
 		}
 	}
 
+	// Issue #753: Dedicated health and metrics servers (plain HTTP, never TLS)
+	healthServer := sharedhealth.NewHealthServer(cfg.Server.HealthAddr, healthHandler, readyHandler)
+	metricsMux := http.NewServeMux()
+	metricsMux.Handle("/metrics", promhttp.Handler())
+	metricsServer := &http.Server{
+		Addr:              cfg.Server.MetricsAddr,
+		Handler:           metricsMux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
@@ -298,6 +307,20 @@ func main() {
 
 	store.StartCleanupLoop(ctx, cfg.Session.TTL/2)
 
+	// Issue #753: Start dedicated health and metrics servers
+	go func() {
+		slogger.Info("health server listening", "addr", cfg.Server.HealthAddr)
+		if err := healthServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slogger.Error("health server error", "error", err)
+		}
+	}()
+	go func() {
+		slogger.Info("metrics server listening", "addr", cfg.Server.MetricsAddr)
+		if err := metricsServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			slogger.Error("metrics server error", "error", err)
+		}
+	}()
+
 	go func() {
 		slogger.Info("HTTP server listening", "addr", addr)
 		var listenErr error
@@ -318,7 +341,13 @@ func main() {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if shutdownErr := httpServer.Shutdown(shutdownCtx); shutdownErr != nil {
-		fmt.Fprintf(os.Stderr, "shutdown error: %v\n", shutdownErr)
+		fmt.Fprintf(os.Stderr, "API server shutdown error: %v\n", shutdownErr)
+	}
+	if shutdownErr := healthServer.Shutdown(shutdownCtx); shutdownErr != nil {
+		fmt.Fprintf(os.Stderr, "health server shutdown error: %v\n", shutdownErr)
+	}
+	if shutdownErr := metricsServer.Shutdown(shutdownCtx); shutdownErr != nil {
+		fmt.Fprintf(os.Stderr, "metrics server shutdown error: %v\n", shutdownErr)
 	}
 
 	slogger.Info("flushing audit store...")
@@ -327,12 +356,15 @@ func main() {
 
 func healthHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	_, _ = w.Write([]byte(`{"status":"ok"}`))
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"status":    "healthy",
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+	})
 }
 
 func readyHandler(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
-	_, _ = w.Write([]byte(`{"status":"ok"}`))
+	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ready"})
 }
 
 func configHandler(cfg *kaconfig.Config) http.HandlerFunc {

--- a/deploy/data-storage/networkpolicy.yaml
+++ b/deploy/data-storage/networkpolicy.yaml
@@ -19,6 +19,10 @@ spec:
       ports:
         - protocol: TCP
           port: 8080
+    # Allow kubelet health probes (Issue #753: dedicated health port)
+    - ports:
+        - protocol: TCP
+          port: 8081
     # Allow Prometheus scraping
     - from:
         - namespaceSelector:

--- a/internal/kubernautagent/config/config.go
+++ b/internal/kubernautagent/config/config.go
@@ -78,9 +78,11 @@ type DataStorageConfig struct {
 }
 
 type ServerConfig struct {
-	Address string              `yaml:"address"`
-	Port    int                 `yaml:"port"`
-	TLS     sharedtls.TLSConfig `yaml:"tls,omitempty"`
+	Address     string              `yaml:"address"`
+	Port        int                 `yaml:"port"`
+	HealthAddr  string              `yaml:"health_addr"`  // Issue #753: Dedicated health probe port (default ":8081")
+	MetricsAddr string              `yaml:"metrics_addr"` // Issue #753: Dedicated metrics port (default ":9090")
+	TLS         sharedtls.TLSConfig `yaml:"tls,omitempty"`
 }
 
 type SessionConfig struct {
@@ -271,7 +273,7 @@ func DefaultConfig() *Config {
 	return &Config{
 		LLM:          LLMConfig{Provider: "openai"},
 		DataStorage:  DataStorageConfig{SATokenPath: "/var/run/secrets/kubernetes.io/serviceaccount/token"},
-		Server:       ServerConfig{Address: "0.0.0.0", Port: 8080},
+		Server:       ServerConfig{Address: "0.0.0.0", Port: 8080, HealthAddr: ":8081", MetricsAddr: ":9090"},
 		Session:      SessionConfig{TTL: 30 * time.Minute},
 		Investigator: InvestigatorConfig{MaxTurns: 15},
 		Audit:        AuditConfig{Enabled: true},

--- a/pkg/datastorage/server/handlers.go
+++ b/pkg/datastorage/server/handlers.go
@@ -17,6 +17,7 @@ limitations under the License.
 package server
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"runtime/debug"
@@ -93,12 +94,14 @@ func (s *Server) handleReadiness(w http.ResponseWriter, r *http.Request) {
 	_, _ = fmt.Fprint(w, `{"status":"ready"}`)
 }
 
-// handleLiveness handles GET /health/live - liveness probe for Kubernetes
-func (s *Server) handleLiveness(w http.ResponseWriter, r *http.Request) {
-	// Liveness is always true unless the process is completely stuck
-	// Don't check database here - that's the readiness probe's job
+// handleLiveness handles GET /healthz - liveness probe for Kubernetes.
+// Issue #753 H-3: Standardized response across all stateless services.
+func (s *Server) handleLiveness(w http.ResponseWriter, _ *http.Request) {
 	w.WriteHeader(http.StatusOK)
-	_, _ = fmt.Fprint(w, `{"status":"alive"}`)
+	_ = json.NewEncoder(w).Encode(map[string]string{
+		"status":    "healthy",
+		"timestamp": time.Now().UTC().Format(time.RFC3339),
+	})
 }
 
 // Middleware

--- a/pkg/gateway/config/config.go
+++ b/pkg/gateway/config/config.go
@@ -52,6 +52,8 @@ type ServerConfig struct {
 // Single Responsibility: HTTP server behavior
 type ServerSettings struct {
 	ListenAddr            string              `yaml:"listenAddr"`              // Default: ":8080"
+	HealthAddr            string              `yaml:"healthAddr"`              // Default: ":8081" (Issue #753: dedicated health probe port)
+	MetricsAddr           string              `yaml:"metricsAddr"`             // Default: ":9090" (Issue #753: dedicated metrics port)
 	MaxConcurrentRequests int                 `yaml:"maxConcurrentRequests"`   // Default: 100 (0 = unlimited)
 	ReadTimeout           time.Duration       `yaml:"readTimeout"`             // Default: 30s
 	WriteTimeout          time.Duration       `yaml:"writeTimeout"`            // Default: 30s
@@ -238,6 +240,8 @@ func DefaultServerConfig() *ServerConfig {
 	return &ServerConfig{
 		Server: ServerSettings{
 			ListenAddr:            ":8080",
+			HealthAddr:            ":8081",
+			MetricsAddr:           ":9090",
 			MaxConcurrentRequests: 100,
 			ReadTimeout:           30 * time.Second,
 			WriteTimeout:          30 * time.Second,

--- a/pkg/gateway/server.go
+++ b/pkg/gateway/server.go
@@ -41,6 +41,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/shared/auth"                 // BR-GATEWAY-036/037: Shared auth middleware
 	sharedaudit "github.com/jordigilh/kubernaut/pkg/shared/audit"    // BR-AUDIT-005 Gap #7: Standardized error details
 	"github.com/jordigilh/kubernaut/pkg/shared/backoff"              // ADR-052 Addendum 001: Exponential backoff with jitter
+	sharedhealth "github.com/jordigilh/kubernaut/pkg/shared/health"   // Issue #753: Dedicated health server
 	"github.com/jordigilh/kubernaut/pkg/shared/hotreload"             // Issue #756: FileWatcher for cert rotation
 	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"        // Issue #493/#678: Conditional TLS
 
@@ -123,12 +124,14 @@ const (
 // - Structured logging: JSON format with trace IDs
 // - Distributed tracing: OpenTelemetry integration (future)
 type Server struct {
-	// HTTP server
-	httpServer   *http.Server
-	router       chi.Router // Chi router for adapter registration and route grouping
-	certReloader *sharedtls.CertReloader      // Issue #756: nil when TLS disabled
-	certWatcher  *hotreload.FileWatcher        // Issue #756: nil when TLS disabled
-	tlsCertDir   string                        // Issue #756: cert dir for FileWatcher path
+	// HTTP servers (Issue #753: 3-port standard — API :8080, Health :8081, Metrics :9090)
+	httpServer    *http.Server
+	healthServer  *http.Server // Issue #753: dedicated health probe server (/healthz, /readyz)
+	metricsServer *http.Server // Issue #753: dedicated metrics server (/metrics)
+	router        chi.Router   // Chi router for adapter registration and route grouping
+	certReloader  *sharedtls.CertReloader      // Issue #756: nil when TLS disabled
+	certWatcher   *hotreload.FileWatcher        // Issue #756: nil when TLS disabled
+	tlsCertDir    string                        // Issue #756: cert dir for FileWatcher path
 
 	// Configuration
 	config *config.ServerConfig // ADR-030: Service configuration (needed for middleware setup)
@@ -185,8 +188,17 @@ type Server struct {
 	isShuttingDown atomic.Bool
 }
 
-// Configuration types have been moved to pkg/gateway/config/config.go
-// This improves separation of concerns and allows for better testability
+// LivenessHandler returns the liveness probe handler for use with the
+// dedicated health server (Issue #753: port 8081, /healthz).
+func (s *Server) LivenessHandler() http.HandlerFunc {
+	return s.healthHandler
+}
+
+// ReadinessHandler returns the readiness probe handler for use with the
+// dedicated health server (Issue #753: port 8081, /readyz).
+func (s *Server) ReadinessHandler() http.HandlerFunc {
+	return s.readinessHandler
+}
 
 // NewServer creates a new Gateway server with default metrics registry
 //
@@ -328,6 +340,27 @@ func NewServerForTesting(cfg *config.ServerConfig, logger logr.Logger, metricsIn
 		ReadTimeout:       cfg.Server.ReadTimeout,
 		WriteTimeout:      cfg.Server.WriteTimeout,
 		ReadHeaderTimeout: 5 * time.Second, // Issue #673 L-2: Slowloris mitigation (gosec G112)
+	}
+
+	// Issue #753: Dedicated health and metrics servers for testing
+	server.healthServer = sharedhealth.NewHealthServer(
+		cfg.Server.HealthAddr,
+		server.LivenessHandler(),
+		server.ReadinessHandler(),
+	)
+
+	metricsMux := http.NewServeMux()
+	var metricsHandler http.Handler
+	if metricsInstance.Registry() != nil {
+		metricsHandler = promhttp.HandlerFor(metricsInstance.Registry(), promhttp.HandlerOpts{})
+	} else {
+		metricsHandler = promhttp.Handler()
+	}
+	metricsMux.Handle("/metrics", metricsHandler)
+	server.metricsServer = &http.Server{
+		Addr:              cfg.Server.MetricsAddr,
+		Handler:           metricsMux,
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 
 	if cfg.Server.TLS.Enabled() {
@@ -644,6 +677,28 @@ func createServerWithClients(cfg *config.ServerConfig, logger logr.Logger, metri
 		ReadHeaderTimeout: 5 * time.Second, // Issue #673 L-2: Slowloris mitigation (gosec G112)
 	}
 
+	// Issue #753: Dedicated health probe server (plain HTTP, never TLS)
+	server.healthServer = sharedhealth.NewHealthServer(
+		cfg.Server.HealthAddr,
+		server.LivenessHandler(),
+		server.ReadinessHandler(),
+	)
+
+	// Issue #753: Dedicated metrics server (plain HTTP, never TLS)
+	metricsMux := http.NewServeMux()
+	var metricsHandler http.Handler
+	if metricsInstance.Registry() != nil {
+		metricsHandler = promhttp.HandlerFor(metricsInstance.Registry(), promhttp.HandlerOpts{})
+	} else {
+		metricsHandler = promhttp.Handler()
+	}
+	metricsMux.Handle("/metrics", metricsHandler)
+	server.metricsServer = &http.Server{
+		Addr:              cfg.Server.MetricsAddr,
+		Handler:           metricsMux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
 	if cfg.Server.TLS.Enabled() {
 		isTLS, reloader, tlsErr := sharedtls.ConfigureConditionalTLS(server.httpServer, cfg.Server.TLS.CertDir)
 		if tlsErr != nil {
@@ -734,23 +789,8 @@ func (s *Server) setupRoutes() chi.Router {
 	// Records request counts and duration metrics
 	r.Use(middleware.HTTPMetrics(s.metricsInstance))
 
-	// Health endpoints
-	r.Get("/health", s.healthHandler)
-	r.Get("/healthz", s.healthHandler) // Kubernetes-style alias
-	r.Get("/ready", s.readinessHandler)
-
-	// Prometheus metrics
-	// Expose metrics from custom registry (for test isolation)
-	// If metricsInstance is nil, this will use the default registry
-	var metricsHandler http.Handler
-	if s.metricsInstance != nil && s.metricsInstance.Registry() != nil {
-		metricsHandler = promhttp.HandlerFor(s.metricsInstance.Registry(), promhttp.HandlerOpts{})
-	} else {
-		metricsHandler = promhttp.Handler() // Default registry
-	}
-	r.Handle("/metrics", metricsHandler)
-
-	// Note: Adapter routes will be registered dynamically when adapters are registered
+	// Issue #753: Health and metrics routes moved to dedicated servers (:8081, :9090).
+	// API routes are registered dynamically when adapters call RegisterAdapter().
 	// via RegisterAdapter(). Each adapter exposes its own route (e.g. /api/v1/signals/prometheus)
 
 	return r
@@ -1073,7 +1113,10 @@ func (s *Server) sendSuccessResponse(
 //	    }
 //	}()
 func (s *Server) Start(ctx context.Context) error {
-	s.logger.Info("Starting Gateway server", "addr", s.httpServer.Addr)
+	s.logger.Info("Starting Gateway server",
+		"api_addr", s.httpServer.Addr,
+		"health_addr", s.healthServer.Addr,
+		"metrics_addr", s.metricsServer.Addr)
 
 	// Issue #756: Start cert file watcher for hot-reload before accepting connections
 	if s.certReloader != nil {
@@ -1090,6 +1133,20 @@ func (s *Server) Start(ctx context.Context) error {
 		}
 		s.certWatcher = watcher
 	}
+
+	// Issue #753: Start dedicated health and metrics servers (plain HTTP, never TLS)
+	go func() {
+		s.logger.Info("Starting dedicated health server", "addr", s.healthServer.Addr)
+		if err := s.healthServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			s.logger.Error(err, "Health server failed")
+		}
+	}()
+	go func() {
+		s.logger.Info("Starting dedicated metrics server", "addr", s.metricsServer.Addr)
+		if err := s.metricsServer.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			s.logger.Error(err, "Metrics server failed")
+		}
+	}()
 
 	// Issue #493: Conditional TLS — serve HTTPS when TLSConfig is set
 	if s.httpServer.TLSConfig != nil {
@@ -1154,6 +1211,18 @@ func (s *Server) Stop(ctx context.Context) error {
 	if err := s.httpServer.Shutdown(ctx); err != nil {
 		s.logger.Error(err, "Failed to gracefully shutdown HTTP server")
 		return err
+	}
+
+	// Issue #753: Shutdown dedicated health and metrics servers
+	if s.healthServer != nil {
+		if err := s.healthServer.Shutdown(ctx); err != nil {
+			s.logger.Error(err, "Failed to shutdown health server")
+		}
+	}
+	if s.metricsServer != nil {
+		if err := s.metricsServer.Shutdown(ctx); err != nil {
+			s.logger.Error(err, "Failed to shutdown metrics server")
+		}
 	}
 
 	// Issue #756: Stop cert file watcher after HTTP server is down

--- a/pkg/shared/health/server.go
+++ b/pkg/shared/health/server.go
@@ -21,6 +21,7 @@ package health
 
 import (
 	"net/http"
+	"time"
 )
 
 // NewHealthServer creates an http.Server on the given address with /healthz
@@ -34,7 +35,8 @@ func NewHealthServer(addr string, liveness, readiness http.HandlerFunc) *http.Se
 	mux.HandleFunc("/healthz", liveness)
 	mux.HandleFunc("/readyz", readiness)
 	return &http.Server{
-		Addr:    addr,
-		Handler: mux,
+		Addr:              addr,
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
 	}
 }

--- a/scripts/helm-smoke-test.sh
+++ b/scripts/helm-smoke-test.sh
@@ -580,8 +580,9 @@ run_verify_001() {
 
 run_verify_002() {
   assert_port_forward_responds \
-    "kubernaut-agent" 8080 "/health" \
-    "ST-CHART-VERIFY-002: Kubernaut Agent health endpoint"
+    "kubernaut-agent" 8081 "/healthz" \
+    "ST-CHART-VERIFY-002: Kubernaut Agent health endpoint" \
+    "$NAMESPACE" 8081
 }
 
 run_verify_003() {

--- a/test/e2e/aianalysis/01_health_endpoints_test.go
+++ b/test/e2e/aianalysis/01_health_endpoints_test.go
@@ -103,13 +103,12 @@ var _ = Describe("Health Endpoints E2E", Label("e2e", "health"), func() {
 	})
 
 	Context("Dependency health checks", func() {
-		It("should verify HolmesGPT-API is reachable", func() {
-			// HolmesGPT-API health endpoint (NodePort 30088 -> host port 8088)
-			// Use Eventually to wait for service to be ready
+		It("should verify Kubernaut Agent is reachable", func() {
+			// Issue #753: KA health on dedicated port 8081 (NodePort 30188 → host 28088)
 			var resp *http.Response
 			var err error
 			Eventually(func() error {
-				resp, err = httpClient.Get("http://localhost:8088/health")
+				resp, err = httpClient.Get("http://localhost:28088/healthz")
 				return err
 			}, 30*time.Second, 500*time.Millisecond).Should(Succeed())
 			defer func() {

--- a/test/e2e/gateway/03_k8s_api_rate_limit_test.go
+++ b/test/e2e/gateway/03_k8s_api_rate_limit_test.go
@@ -208,7 +208,7 @@ var _ = Describe("Test 3: K8s API Rate Limiting (429 Responses)", Ordered, func(
 		testLogger.Info("")
 		testLogger.Info("Step 2: Verify Gateway is still responsive after burst")
 
-		resp, err := httpClient.Get(gatewayURL + "/health")
+		resp, err := httpClient.Get(gatewayHealthURL + "/healthz")
 		Expect(err).ToNot(HaveOccurred())
 		defer func() { _ = resp.Body.Close() }()
 		Expect(resp.StatusCode).To(Equal(http.StatusOK), "Gateway should still be healthy after burst")

--- a/test/e2e/gateway/04_metrics_endpoint_test.go
+++ b/test/e2e/gateway/04_metrics_endpoint_test.go
@@ -100,7 +100,7 @@ var _ = Describe("Test 04: Metrics Endpoint (BR-GATEWAY-017)", Ordered, func() {
 		// Step 1: Verify /metrics endpoint is accessible
 		testLogger.Info("Step 1: Verify /metrics endpoint is accessible")
 
-		resp, err := httpClient.Get(gatewayURL + "/metrics")
+		resp, err := httpClient.Get(gatewayMetricsURL + "/metrics")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(resp.StatusCode).To(Equal(http.StatusOK), "/metrics should return 200 OK")
 
@@ -176,7 +176,7 @@ var _ = Describe("Test 04: Metrics Endpoint (BR-GATEWAY-017)", Ordered, func() {
 		// Wait for metrics to update using Eventually
 		var metricsOutput2 string
 		Eventually(func() bool {
-			resp2, err := httpClient.Get(gatewayURL + "/metrics")
+			resp2, err := httpClient.Get(gatewayMetricsURL + "/metrics")
 			if err != nil {
 				return false
 			}
@@ -225,7 +225,7 @@ var _ = Describe("Test 04: Metrics Endpoint (BR-GATEWAY-017)", Ordered, func() {
 
 		// Check metrics after invalid request
 		Eventually(func() bool {
-			resp3, err := httpClient.Get(gatewayURL + "/metrics")
+			resp3, err := httpClient.Get(gatewayMetricsURL + "/metrics")
 			if err != nil {
 				return false
 			}

--- a/test/e2e/gateway/07_health_readiness_test.go
+++ b/test/e2e/gateway/07_health_readiness_test.go
@@ -74,10 +74,12 @@ var _ = Describe("Test 07: Health & Readiness Endpoints (BR-GATEWAY-018)", Order
 		testLogger.Info("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 		testLogger.Info("")
 
-		// Step 1: Test /health endpoint
-		testLogger.Info("Step 1: Test /health endpoint")
+		// Issue #753: Health/readiness probes on dedicated port 8081 (/healthz, /readyz)
 
-		resp, err := httpClient.Get(gatewayURL + "/health")
+		// Step 1: Test /healthz endpoint (liveness)
+		testLogger.Info("Step 1: Test /healthz endpoint (liveness)")
+
+		resp, err := httpClient.Get(gatewayHealthURL + "/healthz")
 		Expect(err).ToNot(HaveOccurred())
 
 		healthBody, err := io.ReadAll(resp.Body)
@@ -85,73 +87,38 @@ var _ = Describe("Test 07: Health & Readiness Endpoints (BR-GATEWAY-018)", Order
 		Expect(err).ToNot(HaveOccurred())
 
 		Expect(resp.StatusCode).To(Equal(http.StatusOK),
-			"/health should return 200 OK")
+			"/healthz should return 200 OK")
 
-		testLogger.Info(fmt.Sprintf("  /health: HTTP %d", resp.StatusCode))
+		testLogger.Info(fmt.Sprintf("  /healthz: HTTP %d", resp.StatusCode))
 		testLogger.Info(fmt.Sprintf("  Response: %s", string(healthBody)))
-		testLogger.Info("  ✅ /health endpoint working")
+		testLogger.Info("  ✅ /healthz endpoint working")
 
-		// Step 2: Test /ready endpoint (if available)
+		// Step 2: Test /readyz endpoint (readiness)
 		testLogger.Info("")
-		testLogger.Info("Step 2: Test /ready endpoint")
+		testLogger.Info("Step 2: Test /readyz endpoint (readiness)")
 
-		// Use Eventually() to handle Gateway startup timing (may return 503 initially)
 		var readyResp *http.Response
 		Eventually(func() int {
 			var err error
-			readyResp, err = httpClient.Get(gatewayURL + "/ready")
+			readyResp, err = httpClient.Get(gatewayHealthURL + "/readyz")
 			if err != nil {
 				return 0
 			}
 			defer func() { _ = readyResp.Body.Close() }()
 			return readyResp.StatusCode
-		}, 30*time.Second, 2*time.Second).Should(Or(
+		}, 30*time.Second, 2*time.Second).Should(
 			Equal(http.StatusOK),
-			Equal(http.StatusNotFound), // Some services don't have /ready
-		), "Gateway /ready endpoint should be available")
+			"Gateway /readyz endpoint should be available")
 
-		// Re-fetch for body reading
-		readyResp, err = httpClient.Get(gatewayURL + "/ready")
-		if err == nil {
-			readyBody, _ := io.ReadAll(readyResp.Body)
-			_ = readyResp.Body.Close()
+		readyResp, err = httpClient.Get(gatewayHealthURL + "/readyz")
+		Expect(err).ToNot(HaveOccurred())
+		readyBody, _ := io.ReadAll(readyResp.Body)
+		_ = readyResp.Body.Close()
 
-			// /ready should return 200 when service is ready
-			Expect(readyResp.StatusCode).To(Or(
-				Equal(http.StatusOK),
-				Equal(http.StatusNotFound), // Some services don't have /ready
-			))
-
-			if readyResp.StatusCode == http.StatusOK {
-				testLogger.Info(fmt.Sprintf("  /ready: HTTP %d", readyResp.StatusCode))
-				testLogger.Info(fmt.Sprintf("  Response: %s", string(readyBody)))
-				testLogger.Info("  ✅ /ready endpoint working")
-			} else {
-				testLogger.Info("  /ready endpoint not implemented (optional)")
-			}
-		} else {
-			testLogger.Info("  /ready endpoint not available (optional)")
-		}
-
-		// Step 3: Test /healthz endpoint (alternative naming)
-		testLogger.Info("")
-		testLogger.Info("Step 3: Test /healthz endpoint (K8s convention)")
-
-		healthzResp, err := httpClient.Get(gatewayURL + "/healthz")
-		if err == nil {
-			healthzBody, _ := io.ReadAll(healthzResp.Body)
-			_ = healthzResp.Body.Close()
-
-			if healthzResp.StatusCode == http.StatusOK {
-				testLogger.Info(fmt.Sprintf("  /healthz: HTTP %d", healthzResp.StatusCode))
-				testLogger.Info(fmt.Sprintf("  Response: %s", string(healthzBody)))
-				testLogger.Info("  ✅ /healthz endpoint working")
-			} else {
-				testLogger.Info("  /healthz endpoint not implemented (optional)")
-			}
-		} else {
-			testLogger.Info("  /healthz endpoint not available (optional)")
-		}
+		Expect(readyResp.StatusCode).To(Equal(http.StatusOK))
+		testLogger.Info(fmt.Sprintf("  /readyz: HTTP %d", readyResp.StatusCode))
+		testLogger.Info(fmt.Sprintf("  Response: %s", string(readyBody)))
+		testLogger.Info("  ✅ /readyz endpoint working")
 
 		// Step 4: Test health under load
 		testLogger.Info("")
@@ -185,15 +152,15 @@ var _ = Describe("Test 07: Health & Readiness Endpoints (BR-GATEWAY-018)", Order
 
 		// Verify health endpoint still responds quickly
 		start := time.Now()
-		healthAfterLoad, err := httpClient.Get(gatewayURL + "/health")
+		healthAfterLoad, err := httpClient.Get(gatewayHealthURL + "/healthz")
 		latency := time.Since(start)
 		Expect(err).ToNot(HaveOccurred())
 		_ = healthAfterLoad.Body.Close()
 
 		Expect(healthAfterLoad.StatusCode).To(Equal(http.StatusOK),
-			"/health should return 200 OK after load")
+			"/healthz should return 200 OK after load")
 		Expect(latency).To(BeNumerically("<", 5*time.Second),
-			"/health should respond within 5 seconds")
+			"/healthz should respond within 5 seconds")
 
 		testLogger.Info(fmt.Sprintf("  Health check latency after load: %v", latency))
 		testLogger.Info("  ✅ Health endpoint responsive under load")
@@ -204,7 +171,7 @@ var _ = Describe("Test 07: Health & Readiness Endpoints (BR-GATEWAY-018)", Order
 
 		successCount := 0
 		for i := 0; i < 10; i++ {
-			rapidResp, err := httpClient.Get(gatewayURL + "/health")
+			rapidResp, err := httpClient.Get(gatewayHealthURL + "/healthz")
 			if err == nil && rapidResp.StatusCode == http.StatusOK {
 				successCount++
 				_ = rapidResp.Body.Close()

--- a/test/e2e/gateway/18_cors_enforcement_test.go
+++ b/test/e2e/gateway/18_cors_enforcement_test.go
@@ -80,17 +80,17 @@ var _ = Describe("Test 18: CORS Enforcement (BR-HTTP-015)", Ordered, Label("e2e"
 		testLogger.Info("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 		testLogger.Info("")
 
-		// Step 1: Make cross-origin request to health endpoint
-		testLogger.Info("Step 1: Making cross-origin request to /health endpoint")
+		// Step 1: Make cross-origin request to API endpoint
+		// Issue #753: Health is on a dedicated port without CORS; verify CORS on API router
+		testLogger.Info("Step 1: Making cross-origin request to /api/v1/signals/prometheus endpoint")
 
-		req, err := http.NewRequest("GET", gatewayURL+"/health", nil)
+		req, err := http.NewRequest("GET", gatewayURL+"/api/v1/signals/prometheus", nil)
 		Expect(err).ToNot(HaveOccurred())
 
-		// Simulate browser cross-origin request
 		req.Header.Set("Origin", "https://test-dashboard.kubernaut.io")
 
 		testLogger.Info("Request details",
-			"url", gatewayURL+"/health",
+			"url", gatewayURL+"/api/v1/signals/prometheus",
 			"origin", "https://test-dashboard.kubernaut.io")
 
 		resp, err := httpClient.Do(req)
@@ -167,13 +167,13 @@ var _ = Describe("Test 18: CORS Enforcement (BR-HTTP-015)", Ordered, Label("e2e"
 		testLogger.Info("")
 	})
 
-	It("should include CORS headers on readiness endpoint", func() {
+	It("should not include CORS headers on dedicated health endpoint", func() {
 		testLogger.Info("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
-		testLogger.Info("Test 18.3: Verify CORS on readiness endpoint")
+		testLogger.Info("Test 18.3: Verify health endpoint has no CORS (Issue #753)")
 		testLogger.Info("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 		testLogger.Info("")
 
-		req, err := http.NewRequest("GET", gatewayURL+"/ready", nil)
+		req, err := http.NewRequest("GET", gatewayHealthURL+"/readyz", nil)
 		Expect(err).ToNot(HaveOccurred())
 
 		req.Header.Set("Origin", "https://monitoring.kubernaut.io")
@@ -182,28 +182,12 @@ var _ = Describe("Test 18: CORS Enforcement (BR-HTTP-015)", Ordered, Label("e2e"
 		Expect(err).ToNot(HaveOccurred())
 		defer func() { _ = resp.Body.Close() }()
 
-		// Use Eventually() to handle Gateway startup timing (may return 503 initially)
-		var allowOrigin string
-		Eventually(func() int {
-			var err error
-			resp, err = httpClient.Do(req)
-			if err != nil {
-				return 0
-			}
-			defer func() { _ = resp.Body.Close() }()
-			allowOrigin = resp.Header.Get("Access-Control-Allow-Origin")
-			return resp.StatusCode
-		}, 30*time.Second, 2*time.Second).Should(Equal(http.StatusOK), "Gateway /ready endpoint should be available")
+		allowOrigin := resp.Header.Get("Access-Control-Allow-Origin")
 
-		testLogger.Info("Readiness endpoint CORS",
-			"status", resp.StatusCode,
-			"Access-Control-Allow-Origin", allowOrigin)
+		Expect(allowOrigin).To(BeEmpty(),
+			"Issue #753: Health endpoint on dedicated port should NOT have CORS headers")
 
-		// Readiness should return OK with CORS headers
-		Expect(allowOrigin).ToNot(BeEmpty(),
-			"Readiness endpoint must include CORS headers for monitoring dashboards")
-
-		testLogger.Info("✅ Readiness endpoint includes CORS headers")
+		testLogger.Info("✅ Health endpoint correctly has no CORS headers (Issue #753)")
 		testLogger.Info("")
 	})
 })

--- a/test/e2e/gateway/20_security_headers_test.go
+++ b/test/e2e/gateway/20_security_headers_test.go
@@ -227,7 +227,7 @@ var _ = Describe("Test 20: Security Headers & Observability", Ordered, func() {
 			testLogger.Info("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 
 			testLogger.Info("Step 1: Record initial metrics baseline")
-			metricsResp, err := httpClient.Get(gatewayURL + "/metrics")
+			metricsResp, err := httpClient.Get(gatewayMetricsURL + "/metrics")
 			Expect(err).ToNot(HaveOccurred(), "Metrics endpoint should be accessible")
 			defer func() { _ = metricsResp.Body.Close() }()
 
@@ -268,7 +268,7 @@ var _ = Describe("Test 20: Security Headers & Observability", Ordered, func() {
 			// Use Eventually() to poll for metrics instead of sleep (per TESTING_GUIDELINES.md)
 			var updatedMetricsStr string
 			Eventually(func() bool {
-				metricsResp, err := httpClient.Get(gatewayURL + "/metrics")
+				metricsResp, err := httpClient.Get(gatewayMetricsURL + "/metrics")
 				if err != nil {
 					return false
 				}

--- a/test/e2e/gateway/25_cors_test.go
+++ b/test/e2e/gateway/25_cors_test.go
@@ -73,18 +73,14 @@ var _ = Describe("BR-HTTP-015: Gateway CORS Integration", Label("integration", "
 			corsOpts := kubecors.FromEnvironment()
 			router.Use(kubecors.Handler(corsOpts))
 
-			// Add test endpoints mimicking Gateway
-			router.Get("/health", func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(`{"status":"healthy"}`))
-			})
-			router.Get("/ready", func(w http.ResponseWriter, r *http.Request) {
-				w.WriteHeader(http.StatusOK)
-				_, _ = w.Write([]byte(`{"status":"ready"}`))
-			})
+			// Issue #753: Health/readiness moved to dedicated port; only API routes have CORS
 			router.Post("/api/v1/signals/prometheus", func(w http.ResponseWriter, r *http.Request) {
 				w.WriteHeader(http.StatusCreated)
 				_, _ = w.Write([]byte(`{"status":"created"}`))
+			})
+			router.Get("/api/v1/signals", func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(`{"adapters":["prometheus"]}`))
 			})
 
 			testServer = httptest.NewServer(router)
@@ -108,8 +104,7 @@ var _ = Describe("BR-HTTP-015: Gateway CORS Integration", Label("integration", "
 				Expect(allowOrigin).ToNot(BeEmpty(),
 					"All endpoints should include CORS headers for cross-origin access")
 			},
-			Entry("health endpoint supports CORS", "GET", "/health", http.StatusOK),
-			Entry("readiness endpoint supports CORS", "GET", "/ready", http.StatusOK),
+			Entry("API signals endpoint supports CORS", "GET", "/api/v1/signals", http.StatusOK),
 		)
 
 		It("should handle preflight for webhook endpoint", func() {

--- a/test/e2e/gateway/30_observability_test.go
+++ b/test/e2e/gateway/30_observability_test.go
@@ -55,7 +55,7 @@ var _ = Describe("Observability E2E Tests", func() {
 			// BUSINESS OUTCOME: Operators can scrape Gateway metrics into Prometheus
 			// BUSINESS SCENARIO: Prometheus scrapes /metrics endpoint every 15 seconds
 
-			metricsURL := gatewayURL + "/metrics"
+			metricsURL := gatewayMetricsURL + "/metrics"
 			resp, err := http.Get(metricsURL)
 
 			Expect(err).ToNot(HaveOccurred(), "Metrics endpoint should be accessible")
@@ -79,7 +79,7 @@ var _ = Describe("Observability E2E Tests", func() {
 			// Verify histogram metrics appear after requests
 			// The /metrics request itself should trigger HTTP duration metric
 			Eventually(func() bool {
-				metrics, err := GetPrometheusMetrics(gatewayURL + "/metrics")
+				metrics, err := GetPrometheusMetrics(gatewayMetricsURL + "/metrics")
 				if err != nil {
 					return false
 				}
@@ -105,7 +105,7 @@ var _ = Describe("Observability E2E Tests", func() {
 			// BUSINESS SCENARIO: Operator creates Prometheus alert: rate(gateway_signals_received_total[1m]) > 100
 
 			// Get initial metric value
-			initialMetrics, err := GetPrometheusMetrics(gatewayURL + "/metrics")
+			initialMetrics, err := GetPrometheusMetrics(gatewayMetricsURL + "/metrics")
 			Expect(err).ToNot(HaveOccurred())
 			initialCount := GetMetricSum(initialMetrics, "gateway_signals_received_total")
 
@@ -127,7 +127,7 @@ var _ = Describe("Observability E2E Tests", func() {
 
 			// Wait for metrics to update using Eventually
 			Eventually(func() float64 {
-				metrics, err := GetPrometheusMetrics(gatewayURL + "/metrics")
+				metrics, err := GetPrometheusMetrics(gatewayMetricsURL + "/metrics")
 				if err != nil {
 					return 0
 				}
@@ -192,7 +192,7 @@ var _ = Describe("Observability E2E Tests", func() {
 
 			// Wait for metrics to update using Eventually
 			Eventually(func() float64 {
-				metrics, err := GetPrometheusMetrics(gatewayURL + "/metrics")
+				metrics, err := GetPrometheusMetrics(gatewayMetricsURL + "/metrics")
 				if err != nil {
 					return 0
 				}
@@ -217,7 +217,7 @@ var _ = Describe("Observability E2E Tests", func() {
 			// BUSINESS SCENARIO: SLO requires 99.9% CRD creation success rate
 
 			// Get initial metric value
-			initialMetrics, err := GetPrometheusMetrics(gatewayURL + "/metrics")
+			initialMetrics, err := GetPrometheusMetrics(gatewayMetricsURL + "/metrics")
 			Expect(err).ToNot(HaveOccurred())
 			initialCount := GetMetricSum(initialMetrics, "gateway_crds_created_total")
 
@@ -240,7 +240,7 @@ var _ = Describe("Observability E2E Tests", func() {
 
 			// Wait for metrics to update using Eventually
 			Eventually(func() float64 {
-				metrics, err := GetPrometheusMetrics(gatewayURL + "/metrics")
+				metrics, err := GetPrometheusMetrics(gatewayMetricsURL + "/metrics")
 				if err != nil {
 					return 0
 				}
@@ -293,7 +293,7 @@ var _ = Describe("Observability E2E Tests", func() {
 			var metrics PrometheusMetrics
 			Eventually(func() bool {
 				var err error
-				metrics, err = GetPrometheusMetrics(gatewayURL + "/metrics")
+				metrics, err = GetPrometheusMetrics(gatewayMetricsURL + "/metrics")
 				if err != nil {
 					return false
 				}
@@ -364,7 +364,7 @@ var _ = Describe("Observability E2E Tests", func() {
 			var metrics PrometheusMetrics
 			Eventually(func() bool {
 				var err error
-				metrics, err = GetPrometheusMetrics(gatewayURL + "/metrics")
+				metrics, err = GetPrometheusMetrics(gatewayMetricsURL + "/metrics")
 				if err != nil {
 					GinkgoWriter.Printf("⚠️ Metrics endpoint error: %v\n", err)
 					return false
@@ -401,7 +401,7 @@ var _ = Describe("Observability E2E Tests", func() {
 			}
 
 			// Step 4: Verify histogram structure
-			metrics, err := GetPrometheusMetrics(gatewayURL + "/metrics")
+			metrics, err := GetPrometheusMetrics(gatewayMetricsURL + "/metrics")
 			Expect(err).ToNot(HaveOccurred(), "Should fetch metrics after latency tests")
 
 			// Histograms expose _count, _sum, and _bucket metrics
@@ -437,7 +437,7 @@ var _ = Describe("Observability E2E Tests", func() {
 				"Signal webhook should create CRD")
 
 			// Also query health endpoint
-			healthResp, err := http.Get(gatewayURL + "/health")
+			healthResp, err := http.Get(gatewayHealthURL + "/healthz")
 			Expect(err).ToNot(HaveOccurred(), "Health endpoint should be accessible")
 			Expect(healthResp.StatusCode).To(Equal(http.StatusOK), "Health endpoint should return 200")
 
@@ -445,7 +445,7 @@ var _ = Describe("Observability E2E Tests", func() {
 			var metrics PrometheusMetrics
 			Eventually(func() bool {
 				var err error
-				metrics, err = GetPrometheusMetrics(gatewayURL + "/metrics")
+				metrics, err = GetPrometheusMetrics(gatewayMetricsURL + "/metrics")
 				if err != nil {
 					return false
 				}
@@ -494,16 +494,15 @@ var _ = Describe("Observability E2E Tests", func() {
 	// BR-110: Health Endpoints
 	// ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-	Context("BR-110: Health Endpoints", func() {
-		It("should return healthy status from /health liveness endpoint", func() {
+	Context("BR-110: Health Endpoints (Issue #753: dedicated port)", func() {
+		It("should return healthy status from /healthz liveness endpoint", func() {
 			// BUSINESS OUTCOME: Kubernetes can detect unhealthy Gateway pods
-			// BUSINESS SCENARIO: Kubernetes liveness probe checks /health every 10 seconds
+			// Issue #753: Health probes on dedicated port 8081
 
-			resp, err := http.Get(gatewayURL + "/health")
+			resp, err := http.Get(gatewayHealthURL + "/healthz")
 			Expect(err).ToNot(HaveOccurred(), "Health endpoint should be accessible")
 			Expect(resp.StatusCode).To(Equal(http.StatusOK), "Health endpoint should return 200 OK")
 
-			// Parse response body
 			var healthResp map[string]interface{}
 			err = json.NewDecoder(resp.Body).Decode(&healthResp)
 			_ = resp.Body.Close()
@@ -511,48 +510,22 @@ var _ = Describe("Observability E2E Tests", func() {
 			Expect(err).ToNot(HaveOccurred(), "Health response should be valid JSON")
 			Expect(healthResp["status"]).To(Equal("healthy"), "Status should be 'healthy'")
 			Expect(healthResp["timestamp"]).ToNot(BeNil(), "Timestamp should be present")
-
-			// BUSINESS CAPABILITY VERIFIED:
-			// ✅ Kubernetes can detect Gateway liveness
-			// ✅ Unhealthy pods are restarted automatically
-			// ✅ Health check responds quickly (<100ms)
 		})
 
-		It("should return ready status from /ready readiness endpoint", func() {
+		It("should return ready status from /readyz readiness endpoint", func() {
 			// BUSINESS OUTCOME: Kubernetes can detect when Gateway is ready to serve traffic
-			// BUSINESS SCENARIO: Kubernetes readiness probe checks /ready before routing traffic
+			// Issue #753: Readiness probes on dedicated port 8081
 
-			resp, err := http.Get(gatewayURL + "/ready")
+			resp, err := http.Get(gatewayHealthURL + "/readyz")
 			Expect(err).ToNot(HaveOccurred(), "Readiness endpoint should be accessible")
 			Expect(resp.StatusCode).To(Equal(http.StatusOK), "Readiness endpoint should return 200 OK when ready")
 
-			// Parse response body
 			var readyResp map[string]interface{}
 			err = json.NewDecoder(resp.Body).Decode(&readyResp)
 			_ = resp.Body.Close()
 
 			Expect(err).ToNot(HaveOccurred(), "Readiness response should be valid JSON")
 			Expect(readyResp["status"]).To(Equal("ready"), "Status should be 'ready'")
-
-			// BUSINESS CAPABILITY VERIFIED:
-			// ✅ Kubernetes can detect Gateway readiness
-			// ✅ Traffic only routed to ready pods
-			// ✅ Zero downtime during deployments
-		})
-
-		It("should support /healthz as Kubernetes-style liveness alias", func() {
-			// BUSINESS OUTCOME: Gateway follows Kubernetes health check conventions
-			// BUSINESS SCENARIO: Kubernetes uses /healthz for liveness probe
-
-			resp, err := http.Get(gatewayURL + "/healthz")
-			Expect(err).ToNot(HaveOccurred(), "Healthz endpoint should be accessible")
-			Expect(resp.StatusCode).To(Equal(http.StatusOK), "Healthz endpoint should return 200 OK")
-
-			_ = resp.Body.Close()
-
-			// BUSINESS CAPABILITY VERIFIED:
-			// ✅ Gateway follows Kubernetes conventions
-			// ✅ Standard health check patterns supported
 			// ✅ Compatible with Kubernetes best practices
 		})
 	})

--- a/test/e2e/gateway/37_scope_filtering_test.go
+++ b/test/e2e/gateway/37_scope_filtering_test.go
@@ -382,7 +382,7 @@ var _ = Describe("Test 37: BR-SCOPE-002 Gateway Scope Filtering (E2E)", Ordered,
 
 		By("2. Verify metric is visible on /metrics endpoint")
 		Eventually(func() bool {
-			metricsResp, err := httpClient.Get(gatewayURL + "/metrics")
+			metricsResp, err := httpClient.Get(gatewayMetricsURL + "/metrics")
 			if err != nil {
 				return false
 			}

--- a/test/e2e/gateway/gateway_e2e_suite_test.go
+++ b/test/e2e/gateway/gateway_e2e_suite_test.go
@@ -60,8 +60,10 @@ var (
 	// Cluster configuration (shared across all tests)
 	clusterName      string
 	kubeconfigPath   string
-	gatewayURL       string // Gateway URL for E2E tests (NodePort or port-forward)
-	gatewayNamespace string // Namespace where Gateway is deployed
+	gatewayURL        string // Gateway API URL for E2E tests (NodePort or port-forward)
+	gatewayHealthURL  string // Gateway health URL (Issue #753: dedicated :8081 port)
+	gatewayMetricsURL string // Gateway metrics URL (Issue #753: dedicated :9090 port)
+	gatewayNamespace  string // Namespace where Gateway is deployed
 
 	// Track if any test failed (for cluster cleanup decision)
 	anyTestFailed bool
@@ -121,23 +123,22 @@ var _ = SynchronizedBeforeSuite(NodeTimeout(10*time.Minute),
 		err = infrastructure.SetupGatewayInfrastructureParallel(tempCtx, tempClusterName, tempKubeconfigPath, GinkgoWriter, tempCoverageMode)
 		Expect(err).ToNot(HaveOccurred())
 
-		// Wait for Gateway HTTP endpoint to be ready
-		tempLogger.Info("Waiting for Gateway HTTP endpoint to be ready...")
-		tempURL := "http://127.0.0.1:8080" // Kind extraPortMapping hostPort (maps to NodePort 30080) - Use 127.0.0.1 for CI/CD IPv4 compatibility
+		// Issue #753: Wait for Gateway health endpoint (dedicated port 8081)
+		tempLogger.Info("Waiting for Gateway health endpoint to be ready...")
+		tempHealthURL := "http://127.0.0.1:28080" // Issue #753: dedicated health port (maps to NodePort 30180)
 		httpClient := &http.Client{Timeout: 5 * time.Second}
 
-		// Use Eventually() instead of manual loop (per TESTING_GUIDELINES.md)
 		Eventually(func() int {
-			resp, err := httpClient.Get(tempURL + "/health")
+			resp, err := httpClient.Get(tempHealthURL + "/readyz")
 			if err != nil {
 				return 0
 			}
 			defer func() { _ = resp.Body.Close() }()
 			return resp.StatusCode
 		}, 60*time.Second, 2*time.Second).Should(Equal(http.StatusOK),
-			"Gateway HTTP endpoint should be ready within 60 seconds")
+			"Gateway health endpoint should be ready within 60 seconds")
 
-		tempLogger.Info("✅ Gateway HTTP endpoint ready")
+		tempLogger.Info("✅ Gateway health endpoint ready")
 
 		tempLogger.Info("✅ Cluster created successfully")
 		tempLogger.Info(fmt.Sprintf("  • Kubeconfig: %s", tempKubeconfigPath))
@@ -205,7 +206,9 @@ var _ = SynchronizedBeforeSuite(NodeTimeout(10*time.Minute),
 
 		// Set cluster configuration (shared across all processes)
 		clusterName = "gateway-e2e"
-		gatewayURL = "http://127.0.0.1:8080" // Kind extraPortMapping hostPort (maps to NodePort 30080) - Use 127.0.0.1 for CI/CD IPv4 compatibility
+		gatewayURL = "http://127.0.0.1:8080"         // Kind extraPortMapping hostPort (maps to NodePort 30080)
+		gatewayHealthURL = "http://127.0.0.1:28080"  // Issue #753: dedicated health port (maps to NodePort 30180)
+		gatewayMetricsURL = "http://127.0.0.1:9090"  // Issue #753: dedicated metrics port (maps to NodePort 30090)
 		gatewayNamespace = "kubernaut-system"
 
 		// BR-GATEWAY-036/037: Create suite-level authorized SA for all E2E webhook requests.
@@ -230,7 +233,9 @@ var _ = SynchronizedBeforeSuite(NodeTimeout(10*time.Minute),
 		logger.Info("━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 		logger.Info(fmt.Sprintf("  • Cluster: %s", clusterName))
 		logger.Info(fmt.Sprintf("  • Kubeconfig: %s", kubeconfigPath))
-		logger.Info(fmt.Sprintf("  • Gateway URL: %s", gatewayURL))
+		logger.Info(fmt.Sprintf("  • Gateway API URL: %s", gatewayURL))
+		logger.Info(fmt.Sprintf("  • Gateway Health URL: %s", gatewayHealthURL))
+		logger.Info(fmt.Sprintf("  • Gateway Metrics URL: %s", gatewayMetricsURL))
 		logger.Info(fmt.Sprintf("  • Gateway Namespace: %s", gatewayNamespace))
 		logger.Info("  • K8s Client: Suite-level (1 per process)")
 		logger.Info("  • Auth Token: Suite-level (e2e-gateway-suite-sa)")

--- a/test/e2e/kubernautagent/adversarial_parity_e2e_test.go
+++ b/test/e2e/kubernautagent/adversarial_parity_e2e_test.go
@@ -187,7 +187,7 @@ var _ = Describe("E2E-KA-433-ADV: Adversarial Parity Tests", Label("e2e", "ka", 
 			_, err := sessionClient.Investigate(ctx, req)
 			Expect(err).NotTo(HaveOccurred())
 
-			resp, err := http.Get(kaURL + "/metrics")
+			resp, err := http.Get(kaMetricsURL + "/metrics")
 			Expect(err).NotTo(HaveOccurred())
 			defer func() { _ = resp.Body.Close() }()
 
@@ -205,7 +205,7 @@ var _ = Describe("E2E-KA-433-ADV: Adversarial Parity Tests", Label("e2e", "ka", 
 			_, err := sessionClient.Investigate(ctx, req)
 			Expect(err).NotTo(HaveOccurred())
 
-			resp, err := http.Get(kaURL + "/metrics")
+			resp, err := http.Get(kaMetricsURL + "/metrics")
 			Expect(err).NotTo(HaveOccurred())
 			defer func() { _ = resp.Body.Close() }()
 

--- a/test/e2e/kubernautagent/ka_e2e_test.go
+++ b/test/e2e/kubernautagent/ka_e2e_test.go
@@ -239,22 +239,22 @@ var _ = Describe("E2E-KA-433: Kubernaut Agent API Contract Parity", Label("e2e",
 
 	Context("BR-HAPI-433 (NFR): Non-functional requirements", func() {
 
-		It("E2E-KA-433-006: GET /health returns 200 within 5s of container start", func() {
+		It("E2E-KA-433-006: GET /healthz returns 200 (Issue #753: dedicated health port)", func() {
 			// ========================================
 			// TEST PLAN MAPPING
 			// ========================================
 			// Scenario ID: E2E-KA-433-006
-			// Business Outcome: GET /health returns 200 within 5s of container start
+			// Business Outcome: GET /healthz returns 200 within 5s of container start
 			// BR: BR-HAPI-433 (NFR)
 
-			resp, err := http.Get(kaURL + "/health")
+			resp, err := http.Get(kaHealthURL + "/healthz")
 			Expect(err).NotTo(HaveOccurred())
 			defer func() { _ = resp.Body.Close() }()
 			Expect(resp.StatusCode).To(Equal(http.StatusOK),
 				"health endpoint should return 200")
 		})
 
-		It("E2E-KA-433-007: GET /metrics exposes Prometheus metrics", func() {
+		It("E2E-KA-433-007: GET /metrics exposes Prometheus metrics (Issue #753: dedicated metrics port)", func() {
 			// ========================================
 			// TEST PLAN MAPPING
 			// ========================================
@@ -262,7 +262,7 @@ var _ = Describe("E2E-KA-433: Kubernaut Agent API Contract Parity", Label("e2e",
 			// Business Outcome: GET /metrics exposes Prometheus metrics (go runtime + request counters)
 			// BR: BR-HAPI-433 (NFR)
 
-			resp, err := http.Get(kaURL + "/metrics")
+			resp, err := http.Get(kaMetricsURL + "/metrics")
 			Expect(err).NotTo(HaveOccurred())
 			defer func() { _ = resp.Body.Close() }()
 			Expect(resp.StatusCode).To(Equal(http.StatusOK),

--- a/test/e2e/kubernautagent/suite_test.go
+++ b/test/e2e/kubernautagent/suite_test.go
@@ -59,7 +59,9 @@ var (
 	kubeconfigPath string
 
 	// Same port mapping as KA (DD-TEST-001 v2.9)
-	kaURL          string // http://localhost:8088
+	kaURL          string // http://localhost:8088  (API port)
+	kaHealthURL    string // http://localhost:28088 (Issue #753: dedicated health port)
+	kaMetricsURL   string // http://localhost:9088  (Issue #753: dedicated metrics port)
 	dataStorageURL string // http://localhost:8089
 
 	sharedNamespace string = "kubernaut-agent-e2e"
@@ -102,6 +104,8 @@ var _ = SynchronizedBeforeSuite(
 		Expect(err).ToNot(HaveOccurred())
 
 		kaURL = "http://localhost:8088"
+		kaHealthURL = "http://localhost:28088"
+		kaMetricsURL = "http://localhost:9088"
 		dataStorageURL = "http://localhost:8089"
 
 		logger.Info("⏳ Waiting for Kind NodePort mapping to stabilize...")
@@ -122,9 +126,10 @@ var _ = SynchronizedBeforeSuite(
 			return nil
 		}, 90*time.Second, 2*time.Second).Should(Succeed(), "Data Storage health check should succeed")
 
+		// Issue #753: KA health probes on dedicated port 8081 (NodePort 30188 → host 28088)
 		logger.Info("⏳ Waiting for Kubernaut Agent service to be ready...")
 		Eventually(func() error {
-			resp, err := http.Get(kaURL + "/health")
+			resp, err := http.Get(kaHealthURL + "/readyz")
 			if err != nil {
 				return err
 			}
@@ -172,6 +177,8 @@ var _ = SynchronizedBeforeSuite(
 		logger = kubelog.NewLogger(kubelog.DevelopmentOptions())
 
 		kaURL = "http://localhost:8088"
+		kaHealthURL = "http://localhost:28088"
+		kaMetricsURL = "http://localhost:9088"
 		dataStorageURL = "http://localhost:8089"
 
 		cwd, err := os.Getwd()

--- a/test/infrastructure/gateway_e2e.go
+++ b/test/infrastructure/gateway_e2e.go
@@ -45,7 +45,8 @@ import (
 // Gateway E2E service ports (DD-TEST-001 port allocation strategy)
 const (
 	GatewayE2EHostPort     = 8080  // Gateway API (NodePort 30080 → host port 8080)
-	GatewayE2EMetricsPort  = 9080  // Gateway metrics
+	GatewayE2EHealthPort   = 28080 // Gateway health (NodePort 30180 → host port 28080) -- Issue #753
+	GatewayE2EMetricsPort  = 9090  // Gateway metrics (NodePort 30090 → host port 9090)
 	GatewayDataStoragePort = 30081 // Data Storage NodePort (from shared deployDataStorage)
 	DataStorageE2EHostPort = 18091 // Data Storage host port (NodePort 30081 → host port 18091)
 
@@ -707,29 +708,35 @@ spec:
             - name: http
               containerPort: 8080
               protocol: TCP
+            - name: health
+              containerPort: 8081
+              protocol: TCP
+            - name: metrics
+              containerPort: 9090
+              protocol: TCP
           volumeMounts:
             - name: config
               mountPath: /etc/gateway
               readOnly: true%s
           startupProbe:
             httpGet:
-              path: /health
-              port: 8080
+              path: /healthz
+              port: 8081
             initialDelaySeconds: 5
             periodSeconds: 5
             failureThreshold: 30
           livenessProbe:
             httpGet:
-              path: /health
-              port: 8080
+              path: /healthz
+              port: 8081
             initialDelaySeconds: 10
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /ready
-              port: 8080
+              path: /readyz
+              port: 8081
             initialDelaySeconds: 30
             periodSeconds: 5
             timeoutSeconds: 5
@@ -763,6 +770,16 @@ spec:
       port: 8080
       targetPort: 8080
       nodePort: 30080
+    - name: health
+      protocol: TCP
+      port: 8081
+      targetPort: 8081
+      nodePort: 30180
+    - name: metrics
+      protocol: TCP
+      port: 9090
+      targetPort: 9090
+      nodePort: 30090
 `, coverageSecurityContextYAML, imageName, pullPolicy, coverageEnvYAML, coverageVolumeMountYAML, coverageVolumeYAML)
 }
 
@@ -954,12 +971,10 @@ func DeployGatewayCoverageManifest(kubeconfigPath string, gatewayImageName strin
 	return waitForGatewayHealth(kubeconfigPath, writer, 90*time.Second)
 }
 
-// waitForGatewayHealth waits for the Gateway service to become healthy
-// This is a helper wrapper around WaitForHTTPHealth specifically for Gateway E2E tests
+// waitForGatewayHealth waits for the Gateway service to become healthy.
+// Issue #753: Uses dedicated health port (8081) instead of the API port (8080).
 func waitForGatewayHealth(kubeconfigPath string, writer io.Writer, timeout time.Duration) error {
-	// Gateway health endpoint is available via NodePort on the Kind cluster
-	// Using localhost as the cluster is accessible from the test machine
-	healthURL := fmt.Sprintf("http://localhost:%d/health", GatewayE2EHostPort)
+	healthURL := fmt.Sprintf("http://localhost:%d/readyz", GatewayE2EHealthPort)
 	return WaitForHTTPHealth(healthURL, timeout, writer)
 }
 

--- a/test/infrastructure/kind-aianalysis-config.yaml
+++ b/test/infrastructure/kind-aianalysis-config.yaml
@@ -42,8 +42,14 @@ nodes:
     hostPort: 8184        # Port on host machine (localhost:8184/healthz)
     protocol: TCP
   # Dependency service ports (for E2E health checks)
-  - containerPort: 30088  # HolmesGPT-API NodePort
-    hostPort: 8088        # Port on host machine (localhost:8088/health)
+  - containerPort: 30188  # Kubernaut Agent Health NodePort (Issue #753)
+    hostPort: 28088       # Port on host machine (localhost:28088/healthz)
+    protocol: TCP
+  - containerPort: 30988  # Kubernaut Agent Metrics NodePort (Issue #753)
+    hostPort: 9088        # Port on host machine (localhost:9088/metrics)
+    protocol: TCP
+  - containerPort: 30088  # Kubernaut Agent API NodePort
+    hostPort: 8088        # Port on host machine (localhost:8088)
     protocol: TCP
   - containerPort: 30081  # Data Storage NodePort
     hostPort: 8091        # Port on host machine (localhost:8091/health)

--- a/test/infrastructure/kind-gateway-config.yaml
+++ b/test/infrastructure/kind-gateway-config.yaml
@@ -2,7 +2,8 @@
 # Reference: DD-TEST-001 Port Allocation Strategy
 #
 # Port Allocation (from DD-TEST-001):
-#   Gateway Host Port: 8080 (maps to NodePort 30080)
+#   Gateway API Host Port: 8080 (maps to NodePort 30080)
+#   Gateway Health Host Port: 28080 (maps to NodePort 30180) -- Issue #753
 #   Gateway Metrics Host Port: 9090 (maps to NodePort 30090)
 #   Data Storage Host Port: 18091 (maps to NodePort 30081)
 #
@@ -28,6 +29,9 @@ nodes:
   # Gateway service ports
   - containerPort: 30080  # Gateway NodePort in cluster
     hostPort: 8080        # Port on host machine (localhost:8080)
+    protocol: TCP
+  - containerPort: 30180  # Gateway Health NodePort (Issue #753)
+    hostPort: 28080       # Port on host machine (localhost:28080)
     protocol: TCP
   - containerPort: 30090  # Gateway Metrics NodePort
     hostPort: 9090        # Port on host machine (localhost:9090/metrics)

--- a/test/infrastructure/kind-kubernautagent-config.yaml
+++ b/test/infrastructure/kind-kubernautagent-config.yaml
@@ -12,6 +12,14 @@ nodes:
   - containerPort: 30088
     hostPort: 8088
     protocol: TCP
+  # Kubernaut Agent health - Issue #753
+  - containerPort: 30188
+    hostPort: 28088
+    protocol: TCP
+  # Kubernaut Agent metrics - Issue #753
+  - containerPort: 30988
+    hostPort: 9088
+    protocol: TCP
   # Data Storage - Per DD-TEST-001 v2.5
   - containerPort: 30089
     hostPort: 8089

--- a/test/infrastructure/kubernautagent.go
+++ b/test/infrastructure/kubernautagent.go
@@ -709,7 +709,12 @@ spec:
         image: %s
         imagePullPolicy: %s
         ports:
-        - containerPort: 8080
+        - name: http
+          containerPort: 8080
+        - name: health
+          containerPort: 8081
+        - name: metrics
+          containerPort: 9090
         args:
         - "-config"
         - "/etc/kubernautagent/config.yaml"
@@ -730,14 +735,14 @@ spec:
         %s
         readinessProbe:
           httpGet:
-            path: /ready
-            port: 8080
+            path: /readyz
+            port: 8081
           initialDelaySeconds: 3
           periodSeconds: 5
         livenessProbe:
           httpGet:
-            path: /health
-            port: 8080
+            path: /healthz
+            port: 8081
           initialDelaySeconds: 5
           periodSeconds: 10
       volumes:
@@ -754,9 +759,18 @@ metadata:
 spec:
   type: NodePort
   ports:
-  - port: 8080
+  - name: http
+    port: 8080
     targetPort: 8080
     nodePort: 30088
+  - name: health
+    port: 8081
+    targetPort: 8081
+    nodePort: 30188
+  - name: metrics
+    port: 9090
+    targetPort: 9090
+    nodePort: 30988
   selector:
     app: kubernaut-agent
 `, namespace, namespace, imageTag, imagePullPolicy, covEnv, covMount, covVol, namespace)

--- a/test/integration/aianalysis/suite_test.go
+++ b/test/integration/aianalysis/suite_test.go
@@ -546,6 +546,8 @@ logging:
   level: "debug"
 server:
   port: 18120
+  health_addr: ":18121"
+  metrics_addr: ":18122"
 audit:
   flush_interval_seconds: 0.1
   buffer_size: 10000
@@ -571,7 +573,7 @@ auth:
 			kaSATokenDir:                       "/var/run/secrets/kubernetes.io/serviceaccount:ro",
 		},
 		HealthCheck: &infrastructure.HealthCheckConfig{
-			URL:     "http://127.0.0.1:18120/health",
+			URL:     "http://127.0.0.1:18121/healthz",
 			Timeout: 120 * time.Second,
 		},
 	}
@@ -581,7 +583,7 @@ auth:
 		GinkgoWriter.Printf("   🌐 KA using host network (Linux CI)\n")
 	} else {
 		kaContainerConfig.Network = "aianalysis_test_network"
-		kaContainerConfig.Ports = map[int]int{8080: 18120}
+		kaContainerConfig.Ports = map[int]int{18120: 18120, 18121: 18121}
 		kaContainerConfig.ExtraHosts = []string{
 			"host.containers.internal:host-gateway",
 		}

--- a/test/integration/gateway/auth_integration_test.go
+++ b/test/integration/gateway/auth_integration_test.go
@@ -35,6 +35,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	gwpkg "github.com/jordigilh/kubernaut/pkg/gateway"
 	"github.com/jordigilh/kubernaut/pkg/shared/auth"
 	"github.com/jordigilh/kubernaut/test/infrastructure"
 	"github.com/jordigilh/kubernaut/test/shared/helpers"
@@ -43,7 +44,8 @@ import (
 var _ = Describe("Gateway Authentication & Authorization (BR-GATEWAY-036, BR-GATEWAY-037)", Ordered, func() {
 
 	var (
-		testServer       *httptest.Server
+		testServer        *httptest.Server
+		gatewayServer     *gwpkg.Server
 		authTestNamespace string
 	)
 
@@ -69,7 +71,8 @@ var _ = Describe("Gateway Authentication & Authorization (BR-GATEWAY-036, BR-GAT
 		opts.Authenticator = authenticator
 		opts.Authorizer = authorizer
 
-		gatewayServer, err := StartTestGatewayWithOptions(ctx, testK8sClient, dataStorageURL, opts)
+		var err error
+		gatewayServer, err = StartTestGatewayWithOptions(ctx, testK8sClient, dataStorageURL, opts)
 		Expect(err).ToNot(HaveOccurred(), "Gateway server must start successfully")
 
 		testServer = httptest.NewServer(gatewayServer.Handler())
@@ -124,18 +127,24 @@ var _ = Describe("Gateway Authentication & Authorization (BR-GATEWAY-036, BR-GAT
 				"IT-GW-036-002: Authorized webhook must return 201 Created")
 		})
 
-		It("IT-GW-036-003: Health, readiness, and metrics endpoints bypass auth", func() {
-			endpoints := []string{"/health", "/healthz", "/ready", "/metrics"}
+		It("IT-GW-036-003: Health and readiness endpoints bypass auth (dedicated server)", func() {
+			// Issue #753: health/readiness now on a dedicated server without auth middleware.
+			// Verify the exported handlers respond 200 without authentication.
+			healthMux := http.NewServeMux()
+			healthMux.HandleFunc("/healthz", gatewayServer.LivenessHandler())
+			healthMux.HandleFunc("/readyz", gatewayServer.ReadinessHandler())
+			healthTestServer := httptest.NewServer(healthMux)
+			defer healthTestServer.Close()
 
-			for _, endpoint := range endpoints {
-				resp, err := http.Get(testServer.URL + endpoint)
+			for _, endpoint := range []string{"/healthz", "/readyz"} {
+				resp, err := http.Get(healthTestServer.URL + endpoint)
 				Expect(err).ToNot(HaveOccurred(),
 					fmt.Sprintf("IT-GW-036-003: GET %s should not error", endpoint))
-				defer func() { _ = resp.Body.Close() }()
-				_, _ = io.ReadAll(resp.Body)
+				body, _ := io.ReadAll(resp.Body)
+				_ = resp.Body.Close()
 
 				Expect(resp.StatusCode).To(Equal(http.StatusOK),
-					fmt.Sprintf("IT-GW-036-003: %s must return 200 without authentication", endpoint))
+					fmt.Sprintf("IT-GW-036-003: %s must return 200 without authentication (body: %s)", endpoint, string(body)))
 			}
 		})
 	})


### PR DESCRIPTION
## Summary

Issue #753 Phase 2: Migrate Gateway and Kubernaut Agent to the 3-port standard (API :8080, Health :8081, Metrics :9090), matching the DataStorage pattern established in PR #780.

**Key changes:**
- **Gateway**: Extract `/health`, `/ready`, `/healthz`, `/metrics` from Chi API router into dedicated `http.Server` instances on `:8081` (health) and `:9090` (metrics). Add `HealthAddr`/`MetricsAddr` to config with defaults. Update Helm probes to `/healthz`/:8081 and `/readyz`/:8081. Remove CORS from health endpoints (per adversarial review).
- **Kubernaut Agent**: Same extraction — dedicated health/metrics servers, standardized health responses (`{"status":"healthy","timestamp":"..."}`), updated Helm chart and E2E infrastructure.
- **DataStorage**: Standardize liveness response body to GW format. Add `ReadHeaderTimeout` to shared health server and DS metrics server (gosec G112). Add port 8081 to DS NetworkPolicy.
- **E2E**: Update Kind configs, deployment manifests, port-forward mappings, and all test assertions across GW/KA suites to use dedicated health/metrics ports.

## Motivation

With TLS enabled on the API port (:8080), Kubernetes `httpGet` health probes would fail because they don't support HTTPS. Extracting health probes to a dedicated plain-HTTP port ensures probes work regardless of TLS state, following the pattern already established for DataStorage in PR #780.

## Test plan

- [ ] All GW E2E tests pass with health/metrics on dedicated ports
- [ ] All KA E2E tests pass with health/metrics on dedicated ports
- [ ] GW integration tests unaffected (they use `ProcessSignal()` directly, not HTTP health)
- [ ] Helm smoke tests validate health endpoints on port 8081
- [ ] DS integration/E2E tests still pass (no regression from standardized liveness response)

## Remaining for #753 (next PR)

- C-1/C-2: Helm cert hook restructuring + RBAC scoping
- Phase 2C: KA TLS cert generation
- Phase 2D: E2E HTTPS migration with CA-aware transports
- Phase 2F: ECDSA P-256 switch
- Phase 2G: Smoke test assertions
- Phase 2H: Final `tls.interService.enabled = true` flip


Made with [Cursor](https://cursor.com)