### PR TITLE
fix: harden component SQL filter and eliminate flaky test races

### DIFF
--- a/pkg/datastorage/repository/workflow/crud.go
+++ b/pkg/datastorage/repository/workflow/crud.go
@@ -535,10 +535,13 @@ func (r *Repository) List(ctx context.Context, filters *models.WorkflowSearchFil
 		if filters.Component != "" {
 			// DD-WORKFLOW-016 v2.1: Case-insensitive + wildcard "*"
 			// Issue #790: component is now a JSONB array (like severity/environment).
-			// Must use LOWER() matching to align with discovery path (discovery.go).
-			builder.WhereRaw(fmt.Sprintf(
-				"(EXISTS (SELECT 1 FROM jsonb_array_elements_text(labels->'component') elem WHERE LOWER(elem) = LOWER($%d)) OR labels->'component' ? '*')",
-				builder.CurrentArgIndex()), filters.Component)
+			// Guard with jsonb_typeof to handle legacy scalar values that would crash
+			// jsonb_array_elements_text (ERROR: cannot extract elements from a scalar).
+			idx := builder.CurrentArgIndex()
+			builder.WhereRaw(fmt.Sprintf(`(CASE WHEN jsonb_typeof(labels->'component') = 'array'
+				THEN EXISTS (SELECT 1 FROM jsonb_array_elements_text(labels->'component') elem WHERE LOWER(elem) = LOWER($%d)) OR labels->'component' ? '*'
+				ELSE LOWER(labels->>'component') = LOWER($%d) OR labels->>'component' = '*'
+			END)`, idx, idx), filters.Component)
 		}
 		// DD-WORKFLOW-001 v2.5: environment is JSONB array, use ? operator; supports "*" wildcard per OpenAPI spec
 		if filters.Environment != "" {

--- a/pkg/datastorage/repository/workflow/discovery.go
+++ b/pkg/datastorage/repository/workflow/discovery.go
@@ -286,10 +286,14 @@ func buildContextFilterSQL(filters *models.WorkflowDiscoveryFilters) (string, []
 	if filters.Component != "" {
 		// DD-WORKFLOW-016 v2.1: Case-insensitive component matching.
 		// Issue #790: component is now a JSONB array (like severity/environment).
+		// Guard with jsonb_typeof to handle legacy scalar values that would crash
+		// jsonb_array_elements_text (ERROR: cannot extract elements from a scalar).
 		// Kubernetes resource Kind is PascalCase (e.g., "Deployment"),
 		// but OCI workflow labels store lowercase (e.g., "deployment").
-		conditions = append(conditions, fmt.Sprintf(
-			"(EXISTS (SELECT 1 FROM jsonb_array_elements_text(labels->'component') elem WHERE LOWER(elem) = LOWER($%d)) OR labels->'component' ? '*')", argIdx))
+		conditions = append(conditions, fmt.Sprintf(`(CASE WHEN jsonb_typeof(labels->'component') = 'array'
+			THEN EXISTS (SELECT 1 FROM jsonb_array_elements_text(labels->'component') elem WHERE LOWER(elem) = LOWER($%d)) OR labels->'component' ? '*'
+			ELSE LOWER(labels->>'component') = LOWER($%d) OR labels->>'component' = '*'
+		END)`, argIdx, argIdx))
 		args = append(args, filters.Component)
 		argIdx++
 	}

--- a/pkg/datastorage/repository/workflow/discovery_filter_test.go
+++ b/pkg/datastorage/repository/workflow/discovery_filter_test.go
@@ -183,18 +183,24 @@ func TestBuildContextFilterSQL_DetectedLabels_ServiceMesh(t *testing.T) {
 
 func TestBuildContextFilterSQL_Issue464_ComponentWildcard(t *testing.T) {
 	// UT-DS-464-001: When component filter is "Pod", the SQL must include
-	// a wildcard fallback so workflows with component='*' are matched.
+	// a jsonb_typeof guard (handles legacy scalar values) and wildcard fallback.
 	filters := &models.WorkflowDiscoveryFilters{
 		Component: "Pod",
 	}
 
 	sql, args := buildContextFilterSQL(filters)
 
+	if !strings.Contains(sql, "jsonb_typeof(labels->'component')") {
+		t.Errorf("UT-DS-464-001: expected jsonb_typeof guard for component, got: %s", sql)
+	}
 	if !strings.Contains(sql, "labels->'component' ? '*'") {
 		t.Errorf("UT-DS-464-001: expected component wildcard fallback (labels->'component' ? '*'), got: %s", sql)
 	}
 	if !strings.Contains(sql, "jsonb_array_elements_text(labels->'component')") {
-		t.Errorf("UT-DS-464-001: expected array-based component matching, got: %s", sql)
+		t.Errorf("UT-DS-464-001: expected array-based component matching in THEN branch, got: %s", sql)
+	}
+	if !strings.Contains(sql, "labels->>'component'") {
+		t.Errorf("UT-DS-464-001: expected scalar fallback in ELSE branch, got: %s", sql)
 	}
 	if len(args) != 1 || args[0] != "Pod" {
 		t.Errorf("UT-DS-464-001: expected args=[Pod], got: %v", args)
@@ -396,13 +402,22 @@ func TestBuildContextFilterSQL_Issue595_CombinedCaseInsensitive(t *testing.T) {
 	if !strings.Contains(sql, "jsonb_array_elements_text(labels->'environment')") {
 		t.Errorf("UT-DS-595-004: expected case-insensitive environment pattern, got: %s", sql)
 	}
-	if !strings.Contains(sql, "jsonb_array_elements_text(labels->'component')") {
-		t.Errorf("UT-DS-595-004: expected array-based component matching, got: %s", sql)
+	if !strings.Contains(sql, "jsonb_typeof(labels->'component')") {
+		t.Errorf("UT-DS-595-004: expected jsonb_typeof guard for component, got: %s", sql)
 	}
-	thenIdx := strings.Index(sql, "THEN")
-	elseIdx := strings.Index(sql, "ELSE")
-	if thenIdx != -1 && elseIdx != -1 {
-		arrayBranch := sql[thenIdx:elseIdx]
+	if !strings.Contains(sql, "jsonb_array_elements_text(labels->'component')") {
+		t.Errorf("UT-DS-595-004: expected array-based component matching in THEN branch, got: %s", sql)
+	}
+	// Find the priority-specific CASE block (second jsonb_typeof in the SQL)
+	priorityTypeofIdx := strings.Index(sql, "jsonb_typeof(labels->'priority')")
+	if priorityTypeofIdx == -1 {
+		t.Fatalf("UT-DS-595-004: expected jsonb_typeof guard for priority, got: %s", sql)
+	}
+	prioritySQL := sql[priorityTypeofIdx:]
+	priorityThenIdx := strings.Index(prioritySQL, "THEN")
+	priorityElseIdx := strings.Index(prioritySQL, "ELSE")
+	if priorityThenIdx != -1 && priorityElseIdx != -1 {
+		arrayBranch := prioritySQL[priorityThenIdx:priorityElseIdx]
 		if !strings.Contains(arrayBranch, "jsonb_array_elements_text(labels->'priority')") {
 			t.Errorf("UT-DS-595-004: priority array branch must use jsonb_array_elements_text, got: %s", arrayBranch)
 		}

--- a/test/e2e/authwebhook/04_workflow_update_propagation_test.go
+++ b/test/e2e/authwebhook/04_workflow_update_propagation_test.go
@@ -27,6 +27,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/types"
+	k8sretry "k8s.io/client-go/util/retry"
 
 	rwv1alpha1 "github.com/jordigilh/kubernaut/api/remediationworkflow/v1alpha1"
 	auditclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
@@ -76,12 +77,15 @@ var _ = Describe("E2E: RemediationWorkflow UPDATE Propagation (#773)", Serial, L
 		Expect(initialWorkflowID).ToNot(BeEmpty(), "Initial workflowId should be set")
 
 		By("Updating CRD: bump version to 1.1.0 and change description")
-		current := &rwv1alpha1.RemediationWorkflow{}
-		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crdName, Namespace: sharedNamespace}, current)).To(Succeed())
-		current.Spec.Version = "1.1.0"
-		current.Spec.Description.WhenNotToUse = "Updated for version bump test"
-		Expect(k8sClient.Update(ctx, current)).To(Succeed(),
-			"Version bump UPDATE should be Allowed by webhook")
+		Expect(k8sretry.RetryOnConflict(k8sretry.DefaultRetry, func() error {
+			current := &rwv1alpha1.RemediationWorkflow{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: crdName, Namespace: sharedNamespace}, current); err != nil {
+				return err
+			}
+			current.Spec.Version = "1.1.0"
+			current.Spec.Description.WhenNotToUse = "Updated for version bump test"
+			return k8sClient.Update(ctx, current)
+		})).To(Succeed(), "Version bump UPDATE should be Allowed by webhook")
 
 		By("Waiting for new workflowId (content hash changes -> new deterministic UUID)")
 		var newWorkflowID string
@@ -148,11 +152,14 @@ var _ = Describe("E2E: RemediationWorkflow UPDATE Propagation (#773)", Serial, L
 			"Initial workflowId should be a UUID (36 chars)")
 
 		By("Updating CRD: change description WITHOUT bumping version")
-		current := &rwv1alpha1.RemediationWorkflow{}
-		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crdName, Namespace: sharedNamespace}, current)).To(Succeed())
-		current.Spec.Description.WhenNotToUse = "Changed content without version bump"
-
-		err := k8sClient.Update(ctx, current)
+		err := k8sretry.RetryOnConflict(k8sretry.DefaultRetry, func() error {
+			current := &rwv1alpha1.RemediationWorkflow{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: crdName, Namespace: sharedNamespace}, current); err != nil {
+				return err
+			}
+			current.Spec.Description.WhenNotToUse = "Changed content without version bump"
+			return k8sClient.Update(ctx, current)
+		})
 		Expect(err).To(HaveOccurred(),
 			"Same-version content change should be DENIED by webhook")
 		Expect(err.Error()).To(ContainSubstring("denied"),
@@ -185,10 +192,13 @@ var _ = Describe("E2E: RemediationWorkflow UPDATE Propagation (#773)", Serial, L
 			"Initial workflowId should be a UUID (36 chars)")
 
 		By("Re-applying the CRD with identical spec (no changes)")
-		current := &rwv1alpha1.RemediationWorkflow{}
-		Expect(k8sClient.Get(ctx, types.NamespacedName{Name: crdName, Namespace: sharedNamespace}, current)).To(Succeed())
-		Expect(k8sClient.Update(ctx, current)).To(Succeed(),
-			"Idempotent re-apply should be Allowed")
+		Expect(k8sretry.RetryOnConflict(k8sretry.DefaultRetry, func() error {
+			current := &rwv1alpha1.RemediationWorkflow{}
+			if err := k8sClient.Get(ctx, types.NamespacedName{Name: crdName, Namespace: sharedNamespace}, current); err != nil {
+				return err
+			}
+			return k8sClient.Update(ctx, current)
+		})).To(Succeed(), "Idempotent re-apply should be Allowed")
 
 		By("Verifying workflowId is unchanged (no supersession)")
 		Consistently(func() string {

--- a/test/integration/datastorage/workflow_repository_integration_test.go
+++ b/test/integration/datastorage/workflow_repository_integration_test.go
@@ -613,19 +613,14 @@ var _ = Describe("Workflow Catalog Repository Integration Tests", func() {
 				createWorkflowWithLabels("sev-wc", []string{"*"}, "pod", []string{"production"}, "P1")
 
 				workflows, totalCount, err := workflowRepo.List(ctx, &models.WorkflowSearchFilters{
-					Severity: "high",
+					WorkflowName: fmt.Sprintf("wf-repo-%s-sev-wc", testID),
+					Severity:     "high",
 				}, 100, 0)
 
 				Expect(err).ToNot(HaveOccurred())
-				Expect(totalCount).To(BeNumerically(">=", 1), "IT-DS-522-010: severity wildcard must match specific query value")
-				found := false
-				for _, wf := range workflows {
-					if wf.WorkflowName == fmt.Sprintf("wf-repo-%s-sev-wc", testID) {
-						found = true
-						break
-					}
-				}
-				Expect(found).To(BeTrue(), "IT-DS-522-010: wildcard-severity workflow must appear in results")
+				Expect(totalCount).To(Equal(1), "IT-DS-522-010: severity wildcard must match specific query value")
+				Expect(workflows).To(HaveLen(1))
+				Expect(workflows[0].WorkflowName).To(Equal(fmt.Sprintf("wf-repo-%s-sev-wc", testID)))
 			})
 		})
 
@@ -634,19 +629,14 @@ var _ = Describe("Workflow Catalog Repository Integration Tests", func() {
 				createWorkflowWithLabels("comp-wc", []string{"critical"}, "*", []string{"production"}, "P1")
 
 				workflows, totalCount, err := workflowRepo.List(ctx, &models.WorkflowSearchFilters{
-					Component: "Node",
+					WorkflowName: fmt.Sprintf("wf-repo-%s-comp-wc", testID),
+					Component:    "Node",
 				}, 100, 0)
 
 				Expect(err).ToNot(HaveOccurred())
-				Expect(totalCount).To(BeNumerically(">=", 1), "IT-DS-522-011: component wildcard must match specific query value")
-				found := false
-				for _, wf := range workflows {
-					if wf.WorkflowName == fmt.Sprintf("wf-repo-%s-comp-wc", testID) {
-						found = true
-						break
-					}
-				}
-				Expect(found).To(BeTrue(), "IT-DS-522-011: wildcard-component workflow must appear in results")
+				Expect(totalCount).To(Equal(1), "IT-DS-522-011: component wildcard must match specific query value")
+				Expect(workflows).To(HaveLen(1))
+				Expect(workflows[0].WorkflowName).To(Equal(fmt.Sprintf("wf-repo-%s-comp-wc", testID)))
 			})
 		})
 
@@ -655,19 +645,14 @@ var _ = Describe("Workflow Catalog Repository Integration Tests", func() {
 				createWorkflowWithLabels("pri-wc", []string{"critical"}, "pod", []string{"production"}, "*")
 
 				workflows, totalCount, err := workflowRepo.List(ctx, &models.WorkflowSearchFilters{
-					Priority: "P3",
+					WorkflowName: fmt.Sprintf("wf-repo-%s-pri-wc", testID),
+					Priority:     "P3",
 				}, 100, 0)
 
 				Expect(err).ToNot(HaveOccurred())
-				Expect(totalCount).To(BeNumerically(">=", 1), "IT-DS-522-012: priority wildcard must match specific query value")
-				found := false
-				for _, wf := range workflows {
-					if wf.WorkflowName == fmt.Sprintf("wf-repo-%s-pri-wc", testID) {
-						found = true
-						break
-					}
-				}
-				Expect(found).To(BeTrue(), "IT-DS-522-012: wildcard-priority workflow must appear in results")
+				Expect(totalCount).To(Equal(1), "IT-DS-522-012: priority wildcard must match specific query value")
+				Expect(workflows).To(HaveLen(1))
+				Expect(workflows[0].WorkflowName).To(Equal(fmt.Sprintf("wf-repo-%s-pri-wc", testID)))
 			})
 		})
 
@@ -676,22 +661,17 @@ var _ = Describe("Workflow Catalog Repository Integration Tests", func() {
 				createWorkflowWithLabels("all-wc", []string{"critical", "high"}, "*", []string{"*"}, "*")
 
 				workflows, totalCount, err := workflowRepo.List(ctx, &models.WorkflowSearchFilters{
-					Severity:    "high",
-					Component:   "Node",
-					Environment: "unknown",
-					Priority:    "P3",
+					WorkflowName: fmt.Sprintf("wf-repo-%s-all-wc", testID),
+					Severity:     "high",
+					Component:    "Node",
+					Environment:  "unknown",
+					Priority:     "P3",
 				}, 100, 0)
 
 				Expect(err).ToNot(HaveOccurred())
-				Expect(totalCount).To(BeNumerically(">=", 1), "IT-DS-522-013: all-wildcard workflow must match any specific query values")
-				found := false
-				for _, wf := range workflows {
-					if wf.WorkflowName == fmt.Sprintf("wf-repo-%s-all-wc", testID) {
-						found = true
-						break
-					}
-				}
-				Expect(found).To(BeTrue(), "IT-DS-522-013: all-wildcard workflow must appear in results")
+				Expect(totalCount).To(Equal(1), "IT-DS-522-013: all-wildcard workflow must match any specific query values")
+				Expect(workflows).To(HaveLen(1))
+				Expect(workflows[0].WorkflowName).To(Equal(fmt.Sprintf("wf-repo-%s-all-wc", testID)))
 			})
 		})
 
@@ -700,18 +680,13 @@ var _ = Describe("Workflow Catalog Repository Integration Tests", func() {
 				createWorkflowWithLabels("comp-ci", []string{"critical"}, "deployment", []string{"production"}, "P1")
 
 				workflows, _, err := workflowRepo.List(ctx, &models.WorkflowSearchFilters{
-					Component: "Deployment",
+					WorkflowName: fmt.Sprintf("wf-repo-%s-comp-ci", testID),
+					Component:    "Deployment",
 				}, 100, 0)
 
 				Expect(err).ToNot(HaveOccurred())
-				found := false
-				for _, wf := range workflows {
-					if wf.WorkflowName == fmt.Sprintf("wf-repo-%s-comp-ci", testID) {
-						found = true
-						break
-					}
-				}
-				Expect(found).To(BeTrue(), "IT-DS-522-014: case-insensitive component match must work in catalog list")
+				Expect(workflows).To(HaveLen(1), "IT-DS-522-014: case-insensitive component match must work in catalog list")
+				Expect(workflows[0].WorkflowName).To(Equal(fmt.Sprintf("wf-repo-%s-comp-ci", testID)))
 			})
 		})
 	})


### PR DESCRIPTION
## Summary

- Add `jsonb_typeof` guard to `component` SQL filter in `crud.go` (List) and `discovery.go` (buildContextFilterSQL), matching the existing `priority` pattern. Prevents `ERROR: cannot extract elements from a scalar (SQLSTATE 22023)` when legacy scalar component values exist in the shared DB during parallel Ginkgo runs.
- Scope wildcard integration tests IT-DS-522-010 through IT-DS-522-014 with `WorkflowName` filter to prevent cross-process interference. Tighten assertions from `>=1` to exact `Equal(1)`.
- Wrap all three CRD Update calls in E2E-AW-773-001, 002, 003 (`04_workflow_update_propagation_test.go`) with `k8sretry.RetryOnConflict` to handle 409 Conflict races when the reconciler updates `.status` between Get and Update.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] All 33 unit tests in `pkg/datastorage/repository/workflow/` pass
- [x] Integration tests compile cleanly
- [x] E2E authwebhook tests compile cleanly
- [ ] CI pipeline passes (Integration datastorage + E2E authwebhook)


Made with [Cursor](https://cursor.com)