### PR TITLE
fix: arm64 cross-build fails for services with multiple Go files in cmd/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1021,7 +1021,7 @@ cross-build-%: ## Cross-compile a Go service binary for target arch (no containe
 	@mkdir -p bin
 	@CGO_ENABLED=0 GOOS=linux GOARCH=$(IMAGE_ARCH) go build -mod=mod \
 	    -ldflags "-s -w -X github.com/jordigilh/kubernaut/internal/version.Version=$(APP_VERSION) -X github.com/jordigilh/kubernaut/internal/version.GitCommit=$(GIT_COMMIT) -X github.com/jordigilh/kubernaut/internal/version.BuildDate=$(BUILD_DATE)" \
-	    -o bin/$(BINARY_NAME_$*)-$(IMAGE_ARCH) ./cmd/$*/main.go
+	    -o bin/$(BINARY_NAME_$*)-$(IMAGE_ARCH) ./cmd/$*/
 
 .PHONY: cross-build-all
 cross-build-all: ## Cross-compile all Go services for target arch


### PR DESCRIPTION
## Summary

- The `cross-build-%` Makefile target passed `./cmd/$*/main.go` (single file) to `go build`, which excludes other `.go` files in the same package directory. This caused arm64 builds to fail with `undefined: sdkReloadCallback` and `undefined: buildLLMClientFromConfig` for `kubernautagent`, which has `llm_builder.go` alongside `main.go`.
- Changed the build target to `./cmd/$*/` (full package), matching the existing `build-%` target behavior.

Fixes the arm64 build failure seen in https://github.com/jordigilh/kubernaut/actions/runs/24808932452/job/72609478543

## Test plan

- [x] Verified `CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build ./cmd/kubernautagent/` succeeds locally
- [ ] CI arm64 build passes for all services


Made with [Cursor](https://cursor.com)