### PR TITLE
fix(795): handle double-serialized RCA JSON and add RCA parse retry

### DIFF
--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -376,7 +376,13 @@ func (inv *Investigator) runRCA(ctx context.Context, signal katypes.SignalContex
 
 	result, parseErr := inv.resultParser.Parse(content)
 	if parseErr != nil {
-		inv.logger.Warn("RCA parse failed, treating as summary",
+		if retried := inv.retryRCASubmit(ctx, content, messages, tokens, correlationID, client, modelName); retried != nil {
+			result = retried
+			parseErr = nil
+		}
+	}
+	if parseErr != nil {
+		inv.logger.Warn("RCA parse failed after retry, treating as summary",
 			slog.String("error", parseErr.Error()),
 			slog.String("correlation_id", correlationID))
 		return &katypes.InvestigationResult{
@@ -396,6 +402,96 @@ func (inv *Investigator) runRCA(ctx context.Context, signal katypes.SignalContex
 	}
 
 	return result, nil
+}
+
+const maxRCAParseRetries = 1
+
+// retryRCASubmit performs a single correction attempt when the RCA parse fails
+// (e.g. double-serialized JSON that wasn't caught by the unwrap heuristic, or
+// garbage fields). Mirrors retryWorkflowSubmit but scoped to the RCA phase.
+func (inv *Investigator) retryRCASubmit(ctx context.Context, lastContent string, history []llm.Message, tokens *TokenAccumulator, correlationID string, client llm.Client, modelName string) *katypes.InvestigationResult {
+	submitOnlyTools := []llm.ToolDefinition{
+		{
+			Name:        SubmitResultToolName,
+			Description: "Submit root cause analysis result.",
+			Parameters:  parser.RCAResultSchema(),
+		},
+	}
+
+	correctionMsg := `Your response could not be parsed. You MUST call submit_result with a JSON object like:
+{"root_cause_analysis":{"summary":"...","severity":"critical","signal_name":"SignalName","contributing_factors":["factor1"],"remediation_target":{"kind":"Deployment","name":"resource","namespace":"ns"}},"confidence":0.9}
+
+CRITICAL: root_cause_analysis must be a JSON object, NOT a string. Do NOT wrap it in quotes.`
+
+	retryMessages := make([]llm.Message, len(history))
+	copy(retryMessages, history)
+	retryMessages = append(retryMessages,
+		llm.Message{Role: "assistant", Content: lastContent},
+	)
+
+	for attempt := 0; attempt < maxRCAParseRetries; attempt++ {
+		inv.logger.Info("parse-level retry for RCA submit",
+			slog.Int("attempt", attempt+1),
+			slog.Int("max", maxRCAParseRetries),
+			slog.String("correlation_id", correlationID))
+
+		retryMessages = append(retryMessages,
+			llm.Message{Role: "user", Content: correctionMsg},
+		)
+
+		retryEvent := audit.NewEvent(audit.EventTypeLLMRequest, correlationID)
+		retryEvent.EventAction = audit.ActionLLMRequest
+		retryEvent.EventOutcome = audit.OutcomeSuccess
+		retryEvent.Data["model"] = modelName
+		retryEvent.Data["retry_attempt"] = attempt + 1
+		retryEvent.Data["retry_max"] = maxRCAParseRetries
+		retryEvent.Data["phase"] = string(katypes.PhaseRCA)
+		retryEvent.Data["retry_reason"] = "rca_parse_correction"
+		audit.StoreBestEffort(ctx, inv.auditStore, retryEvent, inv.logger)
+
+		resp, err := client.Chat(ctx, llm.ChatRequest{
+			Messages: retryMessages,
+			Tools:    submitOnlyTools,
+			Options:  llm.ChatOptions{JSONMode: true, OutputSchema: parser.RCAResultSchema()},
+		})
+		if err != nil {
+			inv.logger.Warn("RCA retry LLM call failed",
+				slog.String("error", err.Error()),
+				slog.String("correlation_id", correlationID))
+			continue
+		}
+		if tokens != nil {
+			tokens.Add(resp.Usage)
+		}
+
+		for _, tc := range resp.ToolCalls {
+			if tc.Name == SubmitResultToolName {
+				result, parseErr := inv.resultParser.Parse(tc.Arguments)
+				if parseErr != nil {
+					inv.logger.Warn("RCA retry parse still failed",
+						slog.String("error", parseErr.Error()),
+						slog.String("correlation_id", correlationID))
+					retryMessages = append(retryMessages, resp.Message)
+					continue
+				}
+				inv.logger.Info("RCA retry succeeded",
+					slog.String("correlation_id", correlationID))
+				return result
+			}
+		}
+
+		if resp.Message.Content != "" {
+			result, parseErr := inv.resultParser.Parse(resp.Message.Content)
+			if parseErr == nil {
+				inv.logger.Info("RCA retry succeeded from message content",
+					slog.String("correlation_id", correlationID))
+				return result
+			}
+		}
+
+		retryMessages = append(retryMessages, resp.Message)
+	}
+	return nil
 }
 
 func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katypes.SignalContext, rcaSummary string, enrichData *prompt.EnrichmentData, p1Ctx *prompt.Phase1Data, tokens *TokenAccumulator, correlationID string, client llm.Client, modelName string) (*katypes.InvestigationResult, error) {

--- a/internal/kubernautagent/parser/parser.go
+++ b/internal/kubernautagent/parser/parser.go
@@ -232,6 +232,47 @@ type llmWorkflow struct {
 	ExecutionEngine string                 `json:"execution_engine,omitempty"`
 }
 
+// unwrapDoubleSerializedJSON detects when an LLM has double-serialized a
+// structured field (e.g. root_cause_analysis: "{\"summary\":...}" instead of
+// root_cause_analysis: {"summary":...}) and returns corrected JSON. This
+// defends against LLMs that json.Marshal their tool call arguments before
+// embedding them (Issue #795).
+func unwrapDoubleSerializedJSON(rawJSON string) string {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(rawJSON), &raw); err != nil {
+		return rawJSON
+	}
+
+	changed := false
+	for _, key := range []string{"root_cause_analysis", "rootCauseAnalysis", "selected_workflow"} {
+		val, ok := raw[key]
+		if !ok {
+			continue
+		}
+		var s string
+		if json.Unmarshal(val, &s) != nil {
+			continue
+		}
+		s = strings.TrimSpace(s)
+		if len(s) == 0 || s[0] != '{' {
+			continue
+		}
+		if json.Valid([]byte(s)) {
+			raw[key] = json.RawMessage(s)
+			changed = true
+		}
+	}
+
+	if !changed {
+		return rawJSON
+	}
+	fixed, err := json.Marshal(raw)
+	if err != nil {
+		return rawJSON
+	}
+	return string(fixed)
+}
+
 // flatLLMFields captures top-level fields that may appear alongside the flat
 // InvestigationResult format (rca_summary, workflow_id, confidence, etc.).
 type flatLLMFields struct {
@@ -243,8 +284,10 @@ type flatLLMFields struct {
 // parseLLMFormat parses the nested LLM response format and converts
 // it to a flat InvestigationResult.
 func parseLLMFormat(jsonStr string) (*katypes.InvestigationResult, error) {
+	fixed := unwrapDoubleSerializedJSON(jsonStr)
+
 	var resp llmResponse
-	if err := json.Unmarshal([]byte(jsonStr), &resp); err != nil {
+	if err := json.Unmarshal([]byte(fixed), &resp); err != nil {
 		return nil, fmt.Errorf("parsing LLM JSON response: %w", err)
 	}
 

--- a/test/integration/kubernautagent/investigator/investigator_decline_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_decline_test.go
@@ -344,6 +344,7 @@ var _ = Describe("Workflow Selection Split Submit Tools — #760 v2", func() {
 			mockClient := &mockLLMClient{
 				responses: []llm.ChatResponse{
 					{Message: llm.Message{Role: "assistant", Content: "The pod is OOMKilled due to memory limits being too low."}},
+					{Message: llm.Message{Role: "assistant", Content: "still text, retry also fails"}},
 					{
 						Message: llm.Message{Role: "assistant", Content: ""},
 						ToolCalls: []llm.ToolCall{

--- a/test/integration/kubernautagent/investigator/rca_retry_795_it_test.go
+++ b/test/integration/kubernautagent/investigator/rca_retry_795_it_test.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	"context"
+	"log/slog"
+	"os"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	katypes "github.com/jordigilh/kubernaut/internal/kubernautagent/types"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/custom"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/registry"
+)
+
+var _ = Describe("IT-KA-795: RCA parse retry on failure", func() {
+
+	var (
+		logger     *slog.Logger
+		auditStore *recordingAuditStore
+		builder    *prompt.Builder
+		rp         *parser.ResultParser
+		phaseTools katypes.PhaseToolMap
+	)
+
+	BeforeEach(func() {
+		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		auditStore = &recordingAuditStore{}
+		builder, _ = prompt.NewBuilder()
+		rp = parser.NewResultParser()
+		phaseTools = investigator.DefaultPhaseToolMap()
+	})
+
+	Describe("IT-KA-795-R01: RCA parse failure triggers retry, retry succeeds with correct JSON", func() {
+		It("should send a correction message to the LLM when RCA parse fails", func() {
+			capturingDS := &paramCapturingDS{}
+			reg := registry.New()
+			for _, t := range custom.NewAllTools(capturingDS) {
+				reg.Register(t)
+			}
+
+			mockClient := &mockLLMClient{
+				responses: []llm.ChatResponse{
+					// RCA phase: LLM submits garbage JSON via submit_result (parse fails)
+					{
+						Message:   llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{{ID: "tc_rca1", Name: "submit_result", Arguments: `{"foo":"bar","baz":42}`}},
+					},
+					// RCA retry: LLM submits correct JSON via submit_result
+					{
+						Message:   llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{{ID: "tc_rca2", Name: "submit_result", Arguments: `{"root_cause_analysis":{"summary":"OOMKilled due to memory leak","remediation_target":{"kind":"Deployment","name":"api","namespace":"production"}},"confidence":0.9}`}},
+					},
+					// Workflow phase: list_available_actions then submit
+					{
+						Message:   llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{{ID: "tc_wf1", Name: "list_available_actions", Arguments: `{}`}},
+					},
+					wfToolResp(`{"workflow_id":"restart","confidence":0.85}`),
+				},
+			}
+
+			k8sClient := &fakeK8sClient{ownerChain: []enrichment.OwnerChainEntry{
+				{Kind: "ReplicaSet", Name: "api-rs-abc", Namespace: "production"},
+				{Kind: "Deployment", Name: "api", Namespace: "production"},
+			}}
+			dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
+			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools, Registry: reg,
+			})
+
+			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
+				Name: "OOMKilled", Namespace: "production", Severity: "critical",
+				Message: "Pod api-pod OOMKilled", ResourceKind: "Pod", ResourceName: "api-pod",
+				Environment: "production", Priority: "P0",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Without retry: RCA phase consumes 1 mock response, workflow consumes 1 more = 2 total.
+			// With retry: RCA phase consumes 2 (initial + retry), workflow consumes 2 = 4 total.
+			Expect(len(mockClient.calls)).To(BeNumerically(">=", 4),
+				"IT-KA-795-R01: RCA retry must issue at least one extra LLM call (expect >= 4 total calls)")
+
+			// The second call (index 1) should be the retry correction message
+			Expect(allMessageContent(mockClient.calls[1].Messages)).To(ContainSubstring("could not be parsed"),
+				"IT-KA-795-R01: retry correction message must contain parse failure feedback")
+		})
+	})
+
+	Describe("IT-KA-795-R02: RCA parse failure, retry also fails, falls back to summary", func() {
+		It("should send correction message and then fall back to raw content when retry also fails", func() {
+			capturingDS := &paramCapturingDS{}
+			reg := registry.New()
+			for _, t := range custom.NewAllTools(capturingDS) {
+				reg.Register(t)
+			}
+
+			mockClient := &mockLLMClient{
+				responses: []llm.ChatResponse{
+					// RCA phase: garbage JSON
+					{
+						Message:   llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{{ID: "tc_rca1", Name: "submit_result", Arguments: `{"foo":"bar"}`}},
+					},
+					// RCA retry: still garbage (submit_result with unrecognized fields)
+					{
+						Message:   llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{{ID: "tc_rca2", Name: "submit_result", Arguments: `{"invalid":"still wrong"}`}},
+					},
+					// Workflow phase: list_available_actions returns empty, LLM declines
+					{
+						Message:   llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{{ID: "tc_wf1", Name: "list_available_actions", Arguments: `{}`}},
+					},
+					{
+						Message:   llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{{ID: "tc_no", Name: "submit_result_no_workflow", Arguments: `{"root_cause_analysis":{"summary":"fallback"},"reasoning":"no workflows"}`}},
+					},
+				},
+			}
+
+			k8sClient := &fakeK8sClient{ownerChain: []enrichment.OwnerChainEntry{
+				{Kind: "Deployment", Name: "api", Namespace: "production"},
+			}}
+			dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
+			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools, Registry: reg,
+			})
+
+			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
+				Name: "OOMKilled", Namespace: "production", Severity: "critical",
+				Message: "Pod api-pod OOMKilled", ResourceKind: "Pod", ResourceName: "api-pod",
+				Environment: "production", Priority: "P0",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Without retry: 1 RCA call + workflow calls.
+			// With retry: 2 RCA calls (initial + retry) + workflow calls.
+			Expect(len(mockClient.calls)).To(BeNumerically(">=", 4),
+				"IT-KA-795-R02: RCA retry must issue at least one extra LLM call (expect >= 4 total calls)")
+
+			// Verify correction message was sent to the LLM
+			Expect(allMessageContent(mockClient.calls[1].Messages)).To(ContainSubstring("could not be parsed"),
+				"IT-KA-795-R02: retry correction message must contain parse failure feedback")
+		})
+	})
+})

--- a/test/unit/kubernautagent/parser/parser_test.go
+++ b/test/unit/kubernautagent/parser/parser_test.go
@@ -935,4 +935,47 @@ false
 			})
 		})
 	})
+
+	Describe("UT-KA-795: Parser handles double-serialized RCA JSON", func() {
+		var p *parser.ResultParser
+		BeforeEach(func() {
+			p = parser.NewResultParser()
+		})
+
+		Describe("UT-KA-795-P01: root_cause_analysis as escaped JSON string with remediation_target", func() {
+			It("should unwrap the double-serialized string and extract remediation_target", func() {
+				content := `{"root_cause_analysis":"{\"summary\": \"CrashLoopBackOff caused by invalid directive\", \"severity\": \"critical\", \"signal_name\": \"KubePodCrashLooping\", \"contributing_factors\": [\"ConfigMap contains invalid_directive\"], \"remediation_target\": {\"kind\": \"Deployment\", \"name\": \"web-frontend\", \"namespace\": \"demo-gitops\"}}","confidence":0.98}`
+				result, err := p.Parse(content)
+				Expect(err).NotTo(HaveOccurred(),
+					"UT-KA-795-P01: double-serialized root_cause_analysis must not cause parse failure")
+				Expect(result).NotTo(BeNil())
+				Expect(result.RCASummary).To(ContainSubstring("CrashLoopBackOff"),
+					"UT-KA-795-P01: RCA summary must be extracted from unwrapped string")
+				Expect(result.RemediationTarget).To(Equal(katypes.RemediationTarget{
+					Kind: "Deployment", Name: "web-frontend", Namespace: "demo-gitops",
+				}), "UT-KA-795-P01: remediation_target must be extracted from unwrapped string")
+			})
+		})
+
+		Describe("UT-KA-795-P02: rootCauseAnalysis (camelCase) as escaped JSON string", func() {
+			It("should unwrap the camelCase double-serialized string", func() {
+				content := `{"rootCauseAnalysis":"{\"summary\": \"Node disk pressure\", \"remediation_target\": {\"kind\": \"Node\", \"name\": \"worker-1\", \"namespace\": \"\"}}","confidence":0.85}`
+				result, err := p.Parse(content)
+				Expect(err).NotTo(HaveOccurred(),
+					"UT-KA-795-P02: camelCase double-serialized RCA must not cause parse failure")
+				Expect(result).NotTo(BeNil())
+				Expect(result.RCASummary).To(ContainSubstring("disk pressure"))
+				Expect(result.RemediationTarget.Kind).To(Equal("Node"))
+			})
+		})
+
+		Describe("UT-KA-795-P03: root_cause_analysis string that is NOT valid JSON", func() {
+			It("should not false-positive unwrap a plain text string value", func() {
+				content := `{"root_cause_analysis":"This is just a plain text summary, not JSON","confidence":0.7}`
+				_, err := p.Parse(content)
+				Expect(err).To(HaveOccurred(),
+					"UT-KA-795-P03: plain text string in root_cause_analysis must still fail (no false-positive unwrap)")
+			})
+		})
+	})
 })


### PR DESCRIPTION
## Summary

- **Fix A (parser resilience)**: Add `unwrapDoubleSerializedJSON()` to detect and unwrap LLM double-serialized fields (`root_cause_analysis`, `rootCauseAnalysis`, `selected_workflow`) before typed unmarshal. Zero LLM cost, handles the exact failure mode observed in production.
- **Fix B (RCA retry)**: Add `retryRCASubmit()` to `runRCA` — sends a single correction message when RCA parse fails, mirroring the existing `retryWorkflowSubmit` pattern for workflow selection.

## Root Cause

Claude Sonnet 4.6 double-serialized the `root_cause_analysis` field in its `submit_result` tool call:

```json
{"root_cause_analysis":"{\"summary\":\"CrashLoopBackOff...\",\"remediation_target\":{\"kind\":\"Deployment\",...}}"}
```

The string value caused `json.Unmarshal` to fail on `*llmRCA`, triggering `ErrNoRecognizedFields`. This silently dropped `remediation_target`, causing `list_available_actions` to query with `component=pod` instead of `component=deployment` — returning empty results.

See Issue #795 for the full audit trail investigation and the decision rationale for choosing this approach over the previously proposed owner chain promotion (PR #796).

## Test plan

- [x] UT-KA-795-P01: snake_case double-serialized `root_cause_analysis` unwrapped
- [x] UT-KA-795-P02: camelCase double-serialized `rootCauseAnalysis` unwrapped
- [x] UT-KA-795-P03: plain text string NOT false-positive unwrapped
- [x] IT-KA-795-R01: RCA retry sends correction message, retried response parsed
- [x] IT-KA-795-R02: RCA retry exhausts, falls back to summary
- [x] All 88 parser unit tests pass (no regressions)
- [x] All 85 investigator integration tests pass (no regressions)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean

Closes #795
Supersedes #796

Made with [Cursor](https://cursor.com)