### PR TITLE
fix(795): handle trailing-brace double-serialization and reject partial RCA

### DIFF
--- a/internal/kubernautagent/parser/parser.go
+++ b/internal/kubernautagent/parser/parser.go
@@ -19,6 +19,7 @@ package parser
 import (
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strings"
 
 	katypes "github.com/jordigilh/kubernaut/internal/kubernautagent/types"
@@ -257,8 +258,14 @@ func unwrapDoubleSerializedJSON(rawJSON string) string {
 		if len(s) == 0 || s[0] != '{' {
 			continue
 		}
-		if json.Valid([]byte(s)) {
-			raw[key] = json.RawMessage(s)
+		if t := extractBalancedJSON(s); t != "" && json.Valid([]byte(t)) {
+			if len(t) != len(s) {
+				slog.Debug("unwrapDoubleSerializedJSON: stripped trailing content",
+					slog.String("key", key),
+					slog.Int("original_len", len(s)),
+					slog.Int("extracted_len", len(t)))
+			}
+			raw[key] = json.RawMessage(t)
 			changed = true
 		}
 	}
@@ -357,6 +364,14 @@ func parseLLMFormat(jsonStr string) (*katypes.InvestigationResult, error) {
 	// as a minimum to reject truly garbage JSON (e.g., {"foo": "bar"}).
 	hasContent := result.RCASummary != "" || result.WorkflowID != "" || resp.Confidence > 0
 	if !hasContent {
+		return nil, &ErrNoRecognizedFields{}
+	}
+
+	// #795 Fix D: Confidence alone without summary or workflow is a partial parse
+	// caused by json.Unmarshal silently skipping type-mismatched fields or the inner
+	// RCA object missing the required "summary" field. Reject so the investigator's
+	// retryRCASubmit can request the missing data. See #795 preflight audit.
+	if resp.Confidence > 0 && result.RCASummary == "" && result.WorkflowID == "" {
 		return nil, &ErrNoRecognizedFields{}
 	}
 

--- a/test/integration/kubernautagent/investigator/rca_retry_795_it_test.go
+++ b/test/integration/kubernautagent/investigator/rca_retry_795_it_test.go
@@ -173,4 +173,69 @@ var _ = Describe("IT-KA-795: RCA parse retry on failure", func() {
 				"IT-KA-795-R02: retry correction message must contain parse failure feedback")
 		})
 	})
+
+	Describe("IT-KA-795-R03: Trailing brace + no-summary triggers retry, retry succeeds with proper JSON", func() {
+		It("should recover when first response is double-serialized with trailing brace and no summary", func() {
+			capturingDS := &paramCapturingDS{}
+			reg := registry.New()
+			for _, t := range custom.NewAllTools(capturingDS) {
+				reg.Register(t)
+			}
+
+			mockClient := &mockLLMClient{
+				responses: []llm.ChatResponse{
+					// RCA phase: double-serialized RCA with trailing brace, NO summary
+					{
+						Message:   llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{{ID: "tc_rca1", Name: "submit_result", Arguments: `{"rootCauseAnalysis":"{\"severity\":\"medium\",\"remediation_target\":{\"kind\":\"Deployment\",\"name\":\"web-frontend\",\"namespace\":\"demo-gitops\"}}}","confidence":0.98}`}},
+					},
+					// RCA retry: LLM now submits correct JSON with summary
+					{
+						Message:   llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{{ID: "tc_rca2", Name: "submit_result", Arguments: `{"root_cause_analysis":{"summary":"CrashLoopBackOff caused by invalid ConfigMap directive","severity":"critical","remediation_target":{"kind":"Deployment","name":"web-frontend","namespace":"demo-gitops"}},"confidence":0.95}`}},
+					},
+					// Workflow phase: list_available_actions then submit
+					{
+						Message:   llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{{ID: "tc_wf1", Name: "list_available_actions", Arguments: `{}`}},
+					},
+					wfToolResp(`{"workflow_id":"git-revert-v2","confidence":0.9}`),
+				},
+			}
+
+			k8sClient := &fakeK8sClient{ownerChain: []enrichment.OwnerChainEntry{
+				{Kind: "ReplicaSet", Name: "web-frontend-rs", Namespace: "demo-gitops"},
+				{Kind: "Deployment", Name: "web-frontend", Namespace: "demo-gitops"},
+			}}
+			dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
+			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools, Registry: reg,
+			})
+
+			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
+				Name: "KubePodCrashLooping", Namespace: "demo-gitops", Severity: "critical",
+				Message: "Pod web-frontend-c8dc85956-jn2b8 CrashLoopBackOff", ResourceKind: "Pod",
+				ResourceName: "web-frontend-c8dc85956-jn2b8",
+				Environment: "staging", Priority: "P1",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// With retry: RCA phase consumes 2 (initial fails Fix D + retry), workflow consumes 2 = 4 total
+			Expect(len(mockClient.calls)).To(BeNumerically(">=", 4),
+				"IT-KA-795-R03: trailing-brace no-summary must trigger retry (expect >= 4 LLM calls)")
+
+			// The retry must have sent a correction message
+			Expect(allMessageContent(mockClient.calls[1].Messages)).To(ContainSubstring("could not be parsed"),
+				"IT-KA-795-R03: retry correction message must be sent after Fix D rejection")
+
+			// The final result should have the workflow from the retry path
+			Expect(result).NotTo(BeNil())
+			Expect(result.WorkflowID).To(Equal("git-revert-v2"),
+				"IT-KA-795-R03: workflow must be selected after successful retry")
+		})
+	})
 })

--- a/test/unit/kubernautagent/parser/parser_test.go
+++ b/test/unit/kubernautagent/parser/parser_test.go
@@ -899,8 +899,12 @@ false
 			})
 		})
 
-		Describe("UT-KA-746-008: Golden transcript — exact #746 audit JSON", func() {
-			It("should classify exact #746 audit response as no_matching_workflows", func() {
+		Describe("UT-KA-746-008: Golden transcript — exact #746 audit JSON (no summary)", func() {
+			// Updated for #795 Fix D: the prompt template requires root_cause_analysis.summary
+			// to always be present. A response with confidence but no summary and no workflow
+			// is incomplete and must return an error so the investigator's retryRCASubmit
+			// can request the missing field. See #795 preflight audit for justification.
+			It("should return parse error for no-summary RCA (triggers retry in investigator)", func() {
 				p := parser.NewResultParser()
 				content := `{
 					"needsHumanReview": true,
@@ -922,16 +926,9 @@ false
 						]
 					}
 				}`
-				result, err := p.Parse(content)
-				Expect(err).NotTo(HaveOccurred(),
-					"#746: Golden transcript must parse successfully, not return llm_parsing_error")
-				Expect(result).NotTo(BeNil())
-				Expect(result.Confidence).To(BeNumerically("~", 0.98, 0.01),
-					"#746: confidence must be preserved from LLM response")
-				Expect(result.HumanReviewNeeded).To(BeTrue(),
-					"#746: No workflow selected must trigger HumanReviewNeeded")
-				Expect(result.HumanReviewReason).To(Equal("no_matching_workflows"),
-					"#746: Must be classified as no_matching_workflows, not llm_parsing_error")
+				_, err := p.Parse(content)
+				Expect(err).To(HaveOccurred(),
+					"#746/#795: confidence-only with no RCA summary and no workflow must return error to trigger retry")
 			})
 		})
 	})
@@ -975,6 +972,77 @@ false
 				_, err := p.Parse(content)
 				Expect(err).To(HaveOccurred(),
 					"UT-KA-795-P03: plain text string in root_cause_analysis must still fail (no false-positive unwrap)")
+			})
+		})
+
+		Describe("UT-KA-795-P04: trailing brace in double-serialized root_cause_analysis", func() {
+			It("should unwrap via balanced extraction despite the trailing brace", func() {
+				content := `{"root_cause_analysis":"{\"summary\":\"CrashLoopBackOff caused by invalid directive\",\"severity\":\"critical\",\"remediation_target\":{\"kind\":\"Deployment\",\"name\":\"web-frontend\",\"namespace\":\"demo-gitops\"}}}","confidence":0.98}`
+				result, err := p.Parse(content)
+				Expect(err).NotTo(HaveOccurred(),
+					"UT-KA-795-P04: trailing brace must be stripped by balanced extraction")
+				Expect(result).NotTo(BeNil())
+				Expect(result.RCASummary).To(ContainSubstring("CrashLoopBackOff"),
+					"UT-KA-795-P04: summary must be extracted from unwrapped string")
+				Expect(result.RemediationTarget).To(Equal(katypes.RemediationTarget{
+					Kind: "Deployment", Name: "web-frontend", Namespace: "demo-gitops",
+				}), "UT-KA-795-P04: remediation_target must survive trailing-brace recovery")
+			})
+		})
+
+		Describe("UT-KA-795-P05: confidence > 0 with no-summary inner object after unwrap returns error", func() {
+			It("should return parse error when unwrapped RCA has no summary field", func() {
+				content := `{"rootCauseAnalysis":"{\"severity\":\"medium\",\"remediation_target\":{\"kind\":\"Deployment\",\"name\":\"web-frontend\",\"namespace\":\"demo-gitops\"}}}","confidence":0.98}`
+				_, err := p.Parse(content)
+				Expect(err).To(HaveOccurred(),
+					"UT-KA-795-P05: confidence-only with no RCA summary after unwrap must return error to trigger retry")
+			})
+		})
+
+		Describe("UT-KA-795-P06: valid RCA object with summary and confidence succeeds", func() {
+			It("should parse successfully when RCA has summary field (non-regression)", func() {
+				content := `{"root_cause_analysis":{"summary":"OOMKilled due to memory leak","severity":"critical","remediation_target":{"kind":"Deployment","name":"api","namespace":"production"}},"confidence":0.92}`
+				result, err := p.Parse(content)
+				Expect(err).NotTo(HaveOccurred(),
+					"UT-KA-795-P06: valid RCA with summary must not be rejected by Fix D guard")
+				Expect(result).NotTo(BeNil())
+				Expect(result.RCASummary).To(ContainSubstring("OOMKilled"))
+				Expect(result.Confidence).To(BeNumerically("~", 0.92, 0.01))
+			})
+		})
+
+		Describe("UT-KA-795-P07: triple-serialized JSON is rejected at s[0] guard", func() {
+			It("should not attempt to unwrap a triple-serialized string", func() {
+				content := `{"root_cause_analysis":"\"{\\\"summary\\\": \\\"triple\\\"}\"","confidence":0.8}`
+				_, err := p.Parse(content)
+				Expect(err).To(HaveOccurred(),
+					"UT-KA-795-P07: triple-serialized string starts with '\"' not '{', must not be unwrapped")
+			})
+		})
+
+		Describe("UT-KA-795-P08: trailing brace with summary succeeds without retry (Fix C primary value)", func() {
+			It("should unwrap and parse successfully on first attempt when summary is present", func() {
+				content := `{"root_cause_analysis":"{\"summary\":\"ResourceQuota exceeded\",\"severity\":\"medium\",\"remediation_target\":{\"kind\":\"Deployment\",\"name\":\"api-server\",\"namespace\":\"demo-quota\"}}}","confidence":0.95}`
+				result, err := p.Parse(content)
+				Expect(err).NotTo(HaveOccurred(),
+					"UT-KA-795-P08: trailing brace with valid summary must succeed on first parse (no retry needed)")
+				Expect(result).NotTo(BeNil())
+				Expect(result.RCASummary).To(ContainSubstring("ResourceQuota exceeded"))
+				Expect(result.RemediationTarget.Kind).To(Equal("Deployment"))
+				Expect(result.RemediationTarget.Name).To(Equal("api-server"))
+				Expect(result.Confidence).To(BeNumerically("~", 0.95, 0.01))
+			})
+		})
+
+		Describe("UT-KA-795-P09: selected_workflow trailing brace is unwrapped", func() {
+			It("should unwrap a double-serialized selected_workflow with trailing brace", func() {
+				content := `{"root_cause_analysis":{"summary":"OOM due to memory leak","remediation_target":{"kind":"Deployment","name":"api","namespace":"prod"}},"selected_workflow":"{\"workflow_id\":\"oom-increase-memory\",\"confidence\":0.9}}","confidence":0.9}`
+				result, err := p.Parse(content)
+				Expect(err).NotTo(HaveOccurred(),
+					"UT-KA-795-P09: double-serialized selected_workflow with trailing brace must be unwrapped")
+				Expect(result).NotTo(BeNil())
+				Expect(result.WorkflowID).To(Equal("oom-increase-memory"),
+					"UT-KA-795-P09: workflow_id must be extracted from unwrapped selected_workflow")
 			})
 		})
 	})


### PR DESCRIPTION
## Summary

Follow-up to PR #797 addressing the remaining regression where the LLM's double-serialized `root_cause_analysis` contained a **trailing `}`** that `json.Valid` rejected, preventing unwrap and causing `list_available_actions` to return empty.

- **Fix C**: Replace `json.Valid([]byte(s))` with `extractBalancedJSON(s)` + `json.Valid([]byte(t))` in `unwrapDoubleSerializedJSON`. This strips trailing garbage via balanced brace extraction before validating, recovering otherwise-valid inner JSON. Adds DEBUG-level logging when content is stripped (SME rec #3).
- **Fix D**: Add RCA summary guard in `parseLLMFormat` — reject responses where `confidence > 0` but both `RCASummary` and `WorkflowID` are empty. This prevents silently propagating a partial result that causes the investigator to skip retry and proceed with no remediation target.
- **UT-KA-746-008 updated**: Now expects parse error for no-summary RCA (prompt contract requires `summary`; regression justified in #795 preflight audit comment).

## Test Plan

| Test ID | Type | Description | Status |
|---------|------|-------------|--------|
| UT-KA-795-P04 | Unit | Trailing `}` in double-serialized RCA is unwrapped and parsed | ✅ |
| UT-KA-795-P05 | Unit | Confidence > 0 with no-summary inner object → returns error | ✅ |
| UT-KA-795-P06 | Unit | Valid RCA object + confidence + summary → succeeds (non-regression) | ✅ |
| UT-KA-795-P07 | Unit | Triple-serialized JSON rejected at `s[0]` guard (SME rec #1) | ✅ |
| UT-KA-795-P08 | Unit | Trailing brace WITH summary succeeds first attempt (Fix C primary value, SME rec #2) | ✅ |
| UT-KA-795-P09 | Unit | `selected_workflow` trailing brace unwrapped (SME rec #5) | ✅ |
| UT-KA-746-008 | Unit | Updated: no-summary golden transcript → parse error (SME rec #4 documented) | ✅ |
| IT-KA-795-R03 | Integration | Trailing brace + no-summary triggers retry, retry succeeds | ✅ |

Full suite: 94/94 parser unit tests, 86/86 investigator integration tests.

## Preflight Audit

See [#795 comment](https://github.com/jordigilh/kubernaut/issues/795#issuecomment-4304365269) for comprehensive blast radius analysis and [SME review](https://github.com/jordigilh/kubernaut/issues/795#issuecomment-4304401262) confirming the approach.

## Related

- Closes #795
- Follow-up to #797
- Enhancement deferred to #798 (context-aware retry message)


Made with [Cursor](https://cursor.com)