### PR TITLE
feat: LLM resilience hardening — array unwrap, type coercion, truncation detection

### DIFF
--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -163,7 +163,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	resultParser := parser.NewResultParser()
+	resultParser := parser.NewResultParser(logrLogger.WithName("parser"))
 	phaseTools := investigator.DefaultPhaseToolMap()
 
 	k8sInfra := initK8sInfra(slogger)

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -790,6 +790,8 @@ func enrichFromCatalog(result *katypes.InvestigationResult, v *parser.Validator)
 func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message, phase katypes.Phase, tokens *TokenAccumulator, correlationID string, client llm.Client, modelName string) (LoopResult, error) {
 	toolDefs := inv.toolDefinitionsForPhase(phase)
 	loopStart := time.Now()
+	truncationRetried := false
+	maxTokens := 0
 
 	for turn := 0; turn < inv.maxTurns; turn++ {
 		reqEvent := audit.NewEvent(audit.EventTypeLLMRequest, correlationID)
@@ -804,7 +806,7 @@ func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message,
 		resp, err := client.Chat(ctx, llm.ChatRequest{
 			Messages: messages,
 			Tools:    toolDefs,
-			Options:  llm.ChatOptions{JSONMode: true, OutputSchema: submitResultSchemaForPhase(phase)},
+			Options:  llm.ChatOptions{JSONMode: true, OutputSchema: submitResultSchemaForPhase(phase), MaxTokens: maxTokens},
 		})
 		if err != nil {
 			failEvent := audit.NewEvent(audit.EventTypeResponseFailed, correlationID)
@@ -832,6 +834,7 @@ func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message,
 		respEvent.Data["analysis_preview"] = truncatePreview(resp.Message.Content, 500)
 		respEvent.Data["analysis_full"] = resp.Message.Content
 		respEvent.Data["tool_call_count"] = len(resp.ToolCalls)
+		respEvent.Data["finish_reason"] = resp.FinishReason
 		audit.StoreBestEffort(ctx, inv.auditStore, respEvent, inv.logger)
 
 		if len(resp.ToolCalls) > 0 {
@@ -872,10 +875,48 @@ func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message,
 			continue
 		}
 
+		if resp.FinishReason == llm.FinishReasonLength && !truncationRetried {
+			truncationRetried = true
+			maxTokens = escalateMaxTokens(resp.Usage.CompletionTokens)
+			inv.logger.Warn("LLM response truncated, retrying with escalated MaxTokens",
+				slog.String("phase", string(phase)),
+				slog.Int("escalated_max_tokens", maxTokens),
+				slog.String("correlation_id", correlationID))
+
+			truncEvent := audit.NewEvent(audit.EventTypeLLMResponse, correlationID)
+			truncEvent.EventAction = "truncation_detected"
+			truncEvent.EventOutcome = audit.OutcomeFailure
+			truncEvent.Data["finish_reason"] = resp.FinishReason
+			truncEvent.Data["escalated_max_tokens"] = maxTokens
+			truncEvent.Data["truncated_content_length"] = len(resp.Message.Content)
+			audit.StoreBestEffort(ctx, inv.auditStore, truncEvent, inv.logger)
+
+			messages = append(messages, resp.Message)
+			messages = append(messages, llm.Message{
+				Role:    "user",
+				Content: "Your previous response was truncated (output token limit reached). Please provide your complete response. Use the submit_result tool to deliver your structured result.",
+			})
+			continue
+		}
+
 		return &TextResult{Content: resp.Message.Content}, nil
 	}
 
 	return &ExhaustedResult{Reason: "max turns exhausted"}, nil
+}
+
+// escalateMaxTokens computes a higher MaxTokens value for truncation recovery.
+// If the truncated response used N completion tokens, we request 2x. Falls back
+// to a default of 8192 if the usage data is unavailable.
+func escalateMaxTokens(completionTokens int) int {
+	if completionTokens > 0 {
+		escalated := completionTokens * 2
+		if escalated > 16384 {
+			return 16384
+		}
+		return escalated
+	}
+	return 8192
 }
 
 func totalPromptLength(messages []llm.Message) int {

--- a/internal/kubernautagent/parser/parser.go
+++ b/internal/kubernautagent/parser/parser.go
@@ -20,6 +20,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"strconv"
 	"strings"
 
 	katypes "github.com/jordigilh/kubernaut/internal/kubernautagent/types"
@@ -46,17 +47,18 @@ func (p *ResultParser) Parse(content string) (*katypes.InvestigationResult, erro
 
 	jsonStr := extractJSON(content)
 	if jsonStr != "" {
+		coerced := coerceKnownFields(jsonStr)
 		var result katypes.InvestigationResult
-		if err := json.Unmarshal([]byte(jsonStr), &result); err == nil && (result.RCASummary != "" || result.WorkflowID != "") {
+		if err := json.Unmarshal([]byte(coerced), &result); err == nil && (result.RCASummary != "" || result.WorkflowID != "") {
 			// BR-HAPI-200: Clear any HR fields populated by json.Unmarshal via
 			// the "human_review_reason" tag match. HR is parser-derived only.
 			result.HumanReviewNeeded = false
 			result.HumanReviewReason = ""
 			var flat flatLLMFields
-			_ = json.Unmarshal([]byte(jsonStr), &flat)
+			_ = json.Unmarshal([]byte(coerced), &flat)
 			applyFlatFields(&result, flat)
-			mergeNestedRemediationTarget(&result, jsonStr)
-			mergeNestedInvestigationAnalysis(&result, jsonStr)
+			mergeNestedRemediationTarget(&result, coerced)
+			mergeNestedInvestigationAnalysis(&result, coerced)
 			applyOutcomeRouting(&result)
 			return &result, nil
 		}
@@ -105,7 +107,28 @@ func extractJSON(content string) string {
 	if len(trimmed) > 0 && trimmed[0] == '{' {
 		return trimmed
 	}
+	if len(trimmed) > 0 && trimmed[0] == '[' {
+		return unwrapSingleElementArray(trimmed)
+	}
 	return extractBalancedJSON(content)
+}
+
+// unwrapSingleElementArray handles LLMs that wrap their response in a JSON
+// array (e.g. `[{"rca_summary":...}]`). Single-element arrays are unwrapped
+// to the inner object; multi-element arrays are rejected as ambiguous.
+func unwrapSingleElementArray(s string) string {
+	var arr []json.RawMessage
+	if err := json.Unmarshal([]byte(s), &arr); err != nil {
+		return ""
+	}
+	if len(arr) != 1 {
+		return ""
+	}
+	elem := strings.TrimSpace(string(arr[0]))
+	if len(elem) > 0 && elem[0] == '{' {
+		return elem
+	}
+	return ""
 }
 
 // extractBalancedJSON finds the first complete JSON object in content
@@ -280,6 +303,84 @@ func unwrapDoubleSerializedJSON(rawJSON string) string {
 	return string(fixed)
 }
 
+// coerceKnownFields fixes type drift from LLMs that return numeric or boolean
+// fields as quoted strings (e.g. "confidence":"0.92" or "actionable":"false").
+// It operates on raw JSON bytes, unquoting known fields before typed unmarshal.
+func coerceKnownFields(rawJSON string) string {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal([]byte(rawJSON), &raw); err != nil {
+		return rawJSON
+	}
+
+	changed := false
+	for _, key := range []string{"confidence"} {
+		val, ok := raw[key]
+		if !ok {
+			continue
+		}
+		var s string
+		if json.Unmarshal(val, &s) != nil {
+			continue
+		}
+		s = strings.TrimSpace(s)
+		if _, err := strconv.ParseFloat(s, 64); err == nil {
+			raw[key] = json.RawMessage(s)
+		} else {
+			delete(raw, key)
+		}
+		changed = true
+	}
+	for _, key := range []string{"actionable"} {
+		val, ok := raw[key]
+		if !ok {
+			continue
+		}
+		var s string
+		if json.Unmarshal(val, &s) != nil {
+			continue
+		}
+		s = strings.TrimSpace(s)
+		if s == "true" || s == "false" {
+			raw[key] = json.RawMessage(s)
+		} else {
+			delete(raw, key)
+		}
+		changed = true
+	}
+
+	if nested, ok := raw["selected_workflow"]; ok {
+		var wf map[string]json.RawMessage
+		if json.Unmarshal(nested, &wf) == nil {
+			wfChanged := false
+			if confVal, ok := wf["confidence"]; ok {
+				var s string
+				if json.Unmarshal(confVal, &s) == nil {
+					s = strings.TrimSpace(s)
+					if _, err := strconv.ParseFloat(s, 64); err == nil {
+						wf["confidence"] = json.RawMessage(s)
+						wfChanged = true
+					}
+				}
+			}
+			if wfChanged {
+				if fixed, err := json.Marshal(wf); err == nil {
+					raw["selected_workflow"] = json.RawMessage(fixed)
+					changed = true
+				}
+			}
+		}
+	}
+
+	if !changed {
+		return rawJSON
+	}
+	fixed, err := json.Marshal(raw)
+	if err != nil {
+		return rawJSON
+	}
+	return string(fixed)
+}
+
 // flatLLMFields captures top-level fields that may appear alongside the flat
 // InvestigationResult format (rca_summary, workflow_id, confidence, etc.).
 type flatLLMFields struct {
@@ -292,6 +393,7 @@ type flatLLMFields struct {
 // it to a flat InvestigationResult.
 func parseLLMFormat(jsonStr string) (*katypes.InvestigationResult, error) {
 	fixed := unwrapDoubleSerializedJSON(jsonStr)
+	fixed = coerceKnownFields(fixed)
 
 	var resp llmResponse
 	if err := json.Unmarshal([]byte(fixed), &resp); err != nil {

--- a/internal/kubernautagent/parser/parser.go
+++ b/internal/kubernautagent/parser/parser.go
@@ -19,19 +19,28 @@ package parser
 import (
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"strconv"
 	"strings"
+
+	"github.com/go-logr/logr"
 
 	katypes "github.com/jordigilh/kubernaut/internal/kubernautagent/types"
 )
 
 // ResultParser extracts and validates InvestigationResult from LLM JSON output.
-type ResultParser struct{}
+type ResultParser struct {
+	logger logr.Logger
+}
 
-// NewResultParser creates a new result parser.
-func NewResultParser() *ResultParser {
-	return &ResultParser{}
+// NewResultParser creates a new result parser. An optional logr.Logger enables
+// debug-level diagnostics per DD-005 v2.0. If omitted, a discarding logger is
+// used so callers are not forced to supply one.
+func NewResultParser(logger ...logr.Logger) *ResultParser {
+	l := logr.Discard()
+	if len(logger) > 0 {
+		l = logger[0]
+	}
+	return &ResultParser{logger: l}
 }
 
 // Parse extracts InvestigationResult from raw LLM content.
@@ -63,13 +72,13 @@ func (p *ResultParser) Parse(content string) (*katypes.InvestigationResult, erro
 			return &result, nil
 		}
 
-		if parsed, err := parseLLMFormat(jsonStr); err == nil {
+		if parsed, err := parseLLMFormat(jsonStr, p.logger); err == nil {
 			applyOutcomeRouting(parsed)
 			return parsed, nil
 		}
 	}
 
-	if parsed, err := parseSectionHeaders(content); err == nil {
+	if parsed, err := parseSectionHeaders(content, p.logger); err == nil {
 		applyOutcomeRouting(parsed)
 		return parsed, nil
 	}
@@ -261,7 +270,7 @@ type llmWorkflow struct {
 // root_cause_analysis: {"summary":...}) and returns corrected JSON. This
 // defends against LLMs that json.Marshal their tool call arguments before
 // embedding them (Issue #795).
-func unwrapDoubleSerializedJSON(rawJSON string) string {
+func unwrapDoubleSerializedJSON(rawJSON string, logger logr.Logger) string {
 	var raw map[string]json.RawMessage
 	if err := json.Unmarshal([]byte(rawJSON), &raw); err != nil {
 		return rawJSON
@@ -283,10 +292,10 @@ func unwrapDoubleSerializedJSON(rawJSON string) string {
 		}
 		if t := extractBalancedJSON(s); t != "" && json.Valid([]byte(t)) {
 			if len(t) != len(s) {
-				slog.Debug("unwrapDoubleSerializedJSON: stripped trailing content",
-					slog.String("key", key),
-					slog.Int("original_len", len(s)),
-					slog.Int("extracted_len", len(t)))
+				logger.V(1).Info("unwrapDoubleSerializedJSON: stripped trailing content",
+					"key", key,
+					"original_len", len(s),
+					"extracted_len", len(t))
 			}
 			raw[key] = json.RawMessage(t)
 			changed = true
@@ -391,8 +400,8 @@ type flatLLMFields struct {
 
 // parseLLMFormat parses the nested LLM response format and converts
 // it to a flat InvestigationResult.
-func parseLLMFormat(jsonStr string) (*katypes.InvestigationResult, error) {
-	fixed := unwrapDoubleSerializedJSON(jsonStr)
+func parseLLMFormat(jsonStr string, logger logr.Logger) (*katypes.InvestigationResult, error) {
+	fixed := unwrapDoubleSerializedJSON(jsonStr, logger)
 	fixed = coerceKnownFields(fixed)
 
 	var resp llmResponse
@@ -495,7 +504,7 @@ func parseLLMFormat(jsonStr string) (*katypes.InvestigationResult, error) {
 //
 // This function extracts each section's content, assembles an llmResponse,
 // and maps it to InvestigationResult via parseLLMFormat.
-func parseSectionHeaders(content string) (*katypes.InvestigationResult, error) {
+func parseSectionHeaders(content string, logger logr.Logger) (*katypes.InvestigationResult, error) {
 	sections := extractSections(content)
 	if len(sections) == 0 {
 		return nil, fmt.Errorf("no section headers found")
@@ -542,7 +551,7 @@ func parseSectionHeaders(content string) (*katypes.InvestigationResult, error) {
 		return nil, fmt.Errorf("assembling section headers: %w", err)
 	}
 
-	return parseLLMFormat(string(compositeJSON))
+	return parseLLMFormat(string(compositeJSON), logger)
 }
 
 // extractSections splits content on lines matching "# <header_name>" and returns

--- a/pkg/kubernautagent/llm/langchaingo/adapter.go
+++ b/pkg/kubernautagent/llm/langchaingo/adapter.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	awsconfig "github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/bedrockruntime"
@@ -300,6 +301,8 @@ func fromContentResponse(cr *llms.ContentResponse) llm.ChatResponse {
 		})
 	}
 
+	resp.FinishReason = normalizeStopReason(choice.StopReason)
+
 	if gi := choice.GenerationInfo; gi != nil {
 		if pt, ok := gi["PromptTokens"].(int); ok {
 			resp.Usage.PromptTokens = pt
@@ -313,6 +316,27 @@ func fromContentResponse(cr *llms.ContentResponse) llm.ChatResponse {
 	}
 
 	return resp
+}
+
+// normalizeStopReason maps provider-specific stop reasons to our canonical
+// FinishReason constants. LangChainGo exposes the raw provider value as a
+// string, so we normalize across OpenAI ("stop"/"length"/"tool_calls"),
+// Anthropic ("end_turn"/"max_tokens"/"tool_use"), and Gemini
+// ("FinishReasonStop"/"FinishReasonMaxTokens").
+func normalizeStopReason(raw string) string {
+	switch strings.ToLower(raw) {
+	case "stop", "end_turn", "stop_sequence", "finishreasonstop":
+		return llm.FinishReasonStop
+	case "length", "max_tokens", "finishreasonmaxtokens":
+		return llm.FinishReasonLength
+	case "tool_calls", "tool_use":
+		return llm.FinishReasonToolCalls
+	default:
+		if raw != "" {
+			return raw
+		}
+		return llm.FinishReasonStop
+	}
 }
 
 // Close releases resources held by the adapter. For providers with gRPC

--- a/pkg/kubernautagent/llm/types.go
+++ b/pkg/kubernautagent/llm/types.go
@@ -40,11 +40,20 @@ type ChatRequest struct {
 	Options  ChatOptions      `json:"options,omitempty"`
 }
 
+// FinishReason constants normalized across all LLM providers. Adapters must
+// map provider-specific stop reasons to one of these values.
+const (
+	FinishReasonStop      = "stop"
+	FinishReasonLength    = "length"
+	FinishReasonToolCalls = "tool_calls"
+)
+
 // ChatResponse contains the LLM's reply and any tool call requests.
 type ChatResponse struct {
-	Message   Message    `json:"message"`
-	ToolCalls []ToolCall `json:"tool_calls,omitempty"`
-	Usage     TokenUsage `json:"usage,omitempty"`
+	Message      Message    `json:"message"`
+	ToolCalls    []ToolCall `json:"tool_calls,omitempty"`
+	Usage        TokenUsage `json:"usage,omitempty"`
+	FinishReason string     `json:"finish_reason,omitempty"`
 }
 
 // Message represents a single conversation message.

--- a/pkg/kubernautagent/llm/vertexanthropic/client.go
+++ b/pkg/kubernautagent/llm/vertexanthropic/client.go
@@ -232,6 +232,7 @@ func (c *Client) mapResponse(msg *anthropic.Message) llm.ChatResponse {
 			CompletionTokens: int(msg.Usage.OutputTokens),
 			TotalTokens:      int(msg.Usage.InputTokens + msg.Usage.OutputTokens),
 		},
+		FinishReason: normalizeAnthropicStopReason(string(msg.StopReason)),
 	}
 
 	var textParts []string
@@ -252,6 +253,24 @@ func (c *Client) mapResponse(msg *anthropic.Message) llm.ChatResponse {
 	resp.Message.ToolCalls = resp.ToolCalls
 
 	return resp
+}
+
+// normalizeAnthropicStopReason maps Anthropic's stop_reason values to our
+// canonical FinishReason constants.
+func normalizeAnthropicStopReason(raw string) string {
+	switch raw {
+	case "end_turn", "stop_sequence":
+		return llm.FinishReasonStop
+	case "max_tokens":
+		return llm.FinishReasonLength
+	case "tool_use":
+		return llm.FinishReasonToolCalls
+	default:
+		if raw != "" {
+			return raw
+		}
+		return llm.FinishReasonStop
+	}
 }
 
 // allowedCredentialTypes lists the GCP credential types that Kubernaut accepts.

--- a/test/integration/kubernautagent/investigator/rca_retry_795_it_test.go
+++ b/test/integration/kubernautagent/investigator/rca_retry_795_it_test.go
@@ -238,4 +238,65 @@ var _ = Describe("IT-KA-795: RCA parse retry on failure", func() {
 				"IT-KA-795-R03: workflow must be selected after successful retry")
 		})
 	})
+
+	Describe("IT-KA-800-TR-01: Truncation detection triggers retry with escalated MaxTokens", func() {
+		It("should detect FinishReason 'length' and retry instead of returning truncated text", func() {
+			capturingDS := &paramCapturingDS{}
+			reg := registry.New()
+			for _, t := range custom.NewAllTools(capturingDS) {
+				reg.Register(t)
+			}
+
+			mockClient := &mockLLMClient{
+				responses: []llm.ChatResponse{
+					// RCA phase: truncated text response (FinishReason = "length")
+					{
+						Message:      llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled due to`},
+						FinishReason: llm.FinishReasonLength,
+					},
+					// RCA retry: successful submit_result after truncation recovery
+					{
+						Message:   llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{{ID: "tc_rca2", Name: "submit_result", Arguments: `{"root_cause_analysis":{"summary":"OOMKilled due to memory leak","remediation_target":{"kind":"Deployment","name":"api","namespace":"production"}},"confidence":0.9}`}},
+					},
+					// Workflow phase
+					{
+						Message:   llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{{ID: "tc_wf1", Name: "list_available_actions", Arguments: `{}`}},
+					},
+					wfToolResp(`{"workflow_id":"restart","confidence":0.85}`),
+				},
+			}
+
+			k8sClient := &fakeK8sClient{ownerChain: []enrichment.OwnerChainEntry{
+				{Kind: "Deployment", Name: "api", Namespace: "production"},
+			}}
+			dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
+			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools, Registry: reg,
+			})
+
+			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
+				Name: "OOMKilled", Namespace: "production", Severity: "critical",
+				Message: "Pod api-pod OOMKilled", ResourceKind: "Pod", ResourceName: "api-pod",
+				Environment: "production", Priority: "P0",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.RCASummary).To(ContainSubstring("OOMKilled"))
+
+			// Truncation recovery must have caused at least one extra LLM call
+			Expect(len(mockClient.calls)).To(BeNumerically(">=", 4),
+				"IT-KA-800-TR-01: truncation detection must cause a retry (>= 4 calls)")
+
+			// Second call should have increased MaxTokens
+			secondCall := mockClient.calls[1]
+			Expect(secondCall.Options.MaxTokens).To(BeNumerically(">", 0),
+				"IT-KA-800-TR-01: retry after truncation must escalate MaxTokens")
+		})
+	})
 })

--- a/test/unit/kubernautagent/llm/langchaingo_adapter_test.go
+++ b/test/unit/kubernautagent/llm/langchaingo_adapter_test.go
@@ -541,4 +541,70 @@ var _ = Describe("LangChainGo Adapter — #433", func() {
 			Expect(err).To(HaveOccurred())
 		})
 	})
+
+	Describe("LLM Resilience P1: FinishReason propagation", func() {
+		It("UT-KA-800-FR-01: should propagate FinishReason 'stop' from OpenAI", func() {
+			content := "Analysis complete"
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				resp := openaitypes.ChatCompletionResponse{
+					ID:      "chatcmpl-fr01",
+					Object:  openaitypes.ObjectChatCompletion,
+					Created: openaitypes.FixedCreatedTime,
+					Model:   "mock-model",
+					Choices: []openaitypes.Choice{
+						{
+							Index:        0,
+							Message:      openaitypes.Message{Role: "assistant", Content: &content},
+							FinishReason: "stop",
+						},
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(resp)
+			}))
+			defer server.Close()
+
+			adapter, err := langchaingo.New("openai", server.URL, "mock-model", "sk-test")
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, err := adapter.Chat(context.Background(), llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "test"}},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.FinishReason).To(Equal(llm.FinishReasonStop),
+				"UT-KA-800-FR-01: FinishReason must be propagated as 'stop'")
+		})
+
+		It("UT-KA-800-FR-02: should propagate FinishReason 'length' (truncation) from OpenAI", func() {
+			content := `{"rca_summary":"trunca`
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				resp := openaitypes.ChatCompletionResponse{
+					ID:      "chatcmpl-fr02",
+					Object:  openaitypes.ObjectChatCompletion,
+					Created: openaitypes.FixedCreatedTime,
+					Model:   "mock-model",
+					Choices: []openaitypes.Choice{
+						{
+							Index:        0,
+							Message:      openaitypes.Message{Role: "assistant", Content: &content},
+							FinishReason: "length",
+						},
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(resp)
+			}))
+			defer server.Close()
+
+			adapter, err := langchaingo.New("openai", server.URL, "mock-model", "sk-test")
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, err := adapter.Chat(context.Background(), llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "test"}},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.FinishReason).To(Equal(llm.FinishReasonLength),
+				"UT-KA-800-FR-02: FinishReason must be propagated as 'length' for truncation")
+		})
+	})
 })

--- a/test/unit/kubernautagent/parser/parser_test.go
+++ b/test/unit/kubernautagent/parser/parser_test.go
@@ -1046,4 +1046,68 @@ false
 			})
 		})
 	})
+
+	Describe("LLM Resilience Hardening: Array/Type/Truncation defenses", func() {
+
+		Describe("UT-KA-800-ARR-01: Single-element array wrapping is unwrapped", func() {
+			It("should extract the object from a single-element array", func() {
+				p := parser.NewResultParser()
+				content := `[{"rca_summary":"OOMKilled due to memory leak","workflow_id":"oom-increase-memory","confidence":0.9}]`
+				result, err := p.Parse(content)
+				Expect(err).NotTo(HaveOccurred(),
+					"UT-KA-800-ARR-01: single-element array must be unwrapped to extract the inner object")
+				Expect(result).NotTo(BeNil())
+				Expect(result.RCASummary).To(ContainSubstring("OOMKilled"))
+				Expect(result.WorkflowID).To(Equal("oom-increase-memory"))
+			})
+		})
+
+		Describe("UT-KA-800-ARR-02: Multi-element array is not unwrapped", func() {
+			It("should return error for a multi-element array (ambiguous)", func() {
+				p := parser.NewResultParser()
+				content := `[{"rca_summary":"cause A"},{"rca_summary":"cause B"}]`
+				_, err := p.Parse(content)
+				Expect(err).To(HaveOccurred(),
+					"UT-KA-800-ARR-02: multi-element array must not be unwrapped (ambiguous)")
+			})
+		})
+
+		Describe("UT-KA-800-TC-01: String-typed confidence is coerced to float", func() {
+			It("should parse confidence when LLM returns it as a quoted string", func() {
+				p := parser.NewResultParser()
+				content := `{"root_cause_analysis":{"summary":"OOM","remediation_target":{"kind":"Deployment","name":"api","namespace":"prod"}},"selected_workflow":{"workflow_id":"oom-fix","confidence":"0.92","rationale":"increase memory"},"confidence":"0.92"}`
+				result, err := p.Parse(content)
+				Expect(err).NotTo(HaveOccurred(),
+					"UT-KA-800-TC-01: string confidence '0.92' must be coerced to float64")
+				Expect(result).NotTo(BeNil())
+				Expect(result.Confidence).To(BeNumerically("~", 0.92, 0.001))
+			})
+		})
+
+		Describe("UT-KA-800-TC-02: String-typed actionable boolean is coerced", func() {
+			It("should parse actionable when LLM returns it as a quoted string", func() {
+				p := parser.NewResultParser()
+				content := `{"root_cause_analysis":{"summary":"resolved itself","remediation_target":{"kind":"Deployment","name":"api","namespace":"prod"}},"confidence":0.85,"actionable":"false","investigation_outcome":"problem_resolved"}`
+				result, err := p.Parse(content)
+				Expect(err).NotTo(HaveOccurred(),
+					"UT-KA-800-TC-02: string actionable 'false' must be coerced to bool")
+				Expect(result).NotTo(BeNil())
+				Expect(result.IsActionable).NotTo(BeNil())
+				Expect(*result.IsActionable).To(BeFalse())
+			})
+		})
+
+		Describe("UT-KA-800-TC-03: Non-numeric string confidence is rejected", func() {
+			It("should not crash on garbage string confidence", func() {
+				p := parser.NewResultParser()
+				content := `{"rca_summary":"OOM","workflow_id":"oom-fix","confidence":"high"}`
+				result, err := p.Parse(content)
+				Expect(err).NotTo(HaveOccurred(),
+					"UT-KA-800-TC-03: garbage confidence must not crash parser")
+				Expect(result).NotTo(BeNil())
+				Expect(result.Confidence).To(BeNumerically("==", 0),
+					"UT-KA-800-TC-03: non-numeric confidence should default to 0")
+			})
+		})
+	})
 })


### PR DESCRIPTION
## Summary

Hardens the Kubernaut Agent parser and investigator loop against three classes of LLM output defects identified during Issue #795 follow-up audits and SME review:

- **P3: Array Unwrapping** — LLMs occasionally wrap responses in a JSON array (`[{...}]`). Single-element arrays are now unwrapped; multi-element arrays are rejected as ambiguous.
- **P2: Type Coercion** — LLMs sometimes return numeric/boolean fields as quoted strings (`"confidence":"0.92"`, `"actionable":"false"`). A pre-processor now unquotes valid values before typed unmarshal, and removes non-coercible strings to prevent parse errors.
- **P1: Truncation Detection** — Adds `FinishReason` to `ChatResponse` with normalized constants across all providers (OpenAI, Anthropic, Gemini, Bedrock). When `runLLMLoop` detects `finish_reason: "length"`, it retries once with 2x MaxTokens and a continuation prompt instead of silently returning truncated output.

## Changes

### Parser (`internal/kubernautagent/parser/parser.go`)
- `unwrapSingleElementArray()` — extracts inner object from `[{...}]`, rejects `[{...},{...}]`
- `coerceKnownFields()` — unquotes string-typed `confidence` (float) and `actionable` (bool) at top-level and inside `selected_workflow`
- Applied `coerceKnownFields` in both flat and nested parse paths

### LLM Types (`pkg/kubernautagent/llm/types.go`)
- `FinishReason` field on `ChatResponse`
- Constants: `FinishReasonStop`, `FinishReasonLength`, `FinishReasonToolCalls`

### Adapters
- **LangChainGo** (`adapter.go`): `normalizeStopReason()` maps OpenAI/Anthropic/Gemini/Bedrock values to canonical constants
- **VertexAnthropic** (`client.go`): `normalizeAnthropicStopReason()` maps Anthropic SDK values

### Investigator (`internal/kubernautagent/investigator/investigator.go`)
- Truncation detection in `runLLMLoop`: when `FinishReason == "length"`, appends continuation message and retries with `escalateMaxTokens()` (2x completion tokens, capped at 16384)
- One-shot retry (no infinite loop risk)
- Audit event for truncation detection

## Test Plan

| ID | Type | What it verifies |
|---|---|---|
| UT-KA-800-ARR-01 | Unit | Single-element array `[{...}]` unwrapped successfully |
| UT-KA-800-ARR-02 | Unit | Multi-element array rejected as ambiguous |
| UT-KA-800-TC-01 | Unit | String confidence `"0.92"` coerced to float64 |
| UT-KA-800-TC-02 | Unit | String actionable `"false"` coerced to bool |
| UT-KA-800-TC-03 | Unit | Non-numeric confidence `"high"` removed (defaults to 0) |
| UT-KA-800-FR-01 | Unit | Adapter propagates `FinishReason: "stop"` |
| UT-KA-800-FR-02 | Unit | Adapter propagates `FinishReason: "length"` |
| IT-KA-800-TR-01 | Integration | Truncation triggers retry with escalated MaxTokens |

All existing parser (93), LLM (53), and investigator (86) tests pass with zero regressions.

## Related

- Issue #795 (LLM output resilience)
- Issue #800 (multi-provider golden transcripts — deferred)
- BR-AI-795


Made with [Cursor](https://cursor.com)