### PR TITLE
fix(e2e): use Eventually for gateway_ metrics prefix check

### DIFF
--- a/test/e2e/gateway/04_metrics_endpoint_test.go
+++ b/test/e2e/gateway/04_metrics_endpoint_test.go
@@ -116,18 +116,31 @@ var _ = Describe("Test 04: Metrics Endpoint (BR-GATEWAY-017)", Ordered, func() {
 		testLogger.Info("")
 		testLogger.Info("Step 2: Verify key metrics are present")
 
-		// Check for expected Prometheus metrics
-		expectedMetrics := []string{
-			"gateway_", // Gateway-specific metrics prefix
-			"go_",      // Go runtime metrics
-			"process_", // Process metrics
-		}
-
-		for _, metric := range expectedMetrics {
+		// Go runtime and process metrics are registered eagerly — assert immediately.
+		for _, metric := range []string{"go_", "process_"} {
 			Expect(metricsOutput).To(ContainSubstring(metric),
 				fmt.Sprintf("Metrics should contain %s prefix", metric))
 			testLogger.Info(fmt.Sprintf("  ✅ Found %s metrics", metric))
 		}
+
+		// Gateway-specific metrics may only appear after the first request is
+		// processed or after lazy Prometheus collectors finish registration.
+		// Poll with Eventually to avoid a race against metric initialisation.
+		Eventually(func() string {
+			r, err := httpClient.Get(gatewayMetricsURL + "/metrics")
+			if err != nil {
+				return ""
+			}
+			b, err := io.ReadAll(r.Body)
+			_ = r.Body.Close()
+			if err != nil {
+				return ""
+			}
+			return string(b)
+		}, 30*time.Second, 1*time.Second).Should(
+			ContainSubstring("gateway_"),
+			"Metrics should contain gateway_ prefix (may require first request to register)")
+		testLogger.Info("  ✅ Found gateway_ metrics")
 
 		// Step 3: Send an alert and verify metrics update
 		testLogger.Info("")


### PR DESCRIPTION
## Summary

- Fixes flaky E2E gateway Test 04 (BR-GATEWAY-017) that intermittently fails because `gateway_*` Prometheus metrics are not yet registered when the test eagerly scrapes `/metrics`
- Splits the metrics prefix assertion into immediate checks (`go_`, `process_`) and an `Eventually`-polled check (`gateway_`) with a 30s timeout to tolerate lazy metric registration

## Root Cause

The `gateway_*` metrics may only appear after the gateway processes its first request or after lazy Prometheus collector initialisation completes. The previous code asserted all three prefixes in a single `/metrics` scrape taken immediately after setup, creating a race condition.

## Evidence

- CI run [#1365](https://github.com/jordigilh/kubernaut/actions/runs/24841440160/job/72717257719): 103/104 passed, sole failure at `04_metrics_endpoint_test.go:127` — `/metrics` returned 8206 bytes of `go_gc_*` and `process_*` metrics but no `gateway_*` prefix
- PR branch CI and all prior merge commits passed — confirms this is a timing-dependent flake, not a code regression

## Test plan

- [ ] E2E gateway CI passes consistently (this PR)
- [ ] No regressions in other gateway E2E tests (104 specs)

Made with [Cursor](https://cursor.com)