### PR TITLE
fix(docs): replace stale LiteLLM reference with LangChainGo (#814)

### DIFF
--- a/charts/kubernaut/examples/sdk-config.yaml
+++ b/charts/kubernaut/examples/sdk-config.yaml
@@ -10,8 +10,8 @@
 
 # -- LLM provider configuration (required)
 # Credentials are sourced from the K8s Secret referenced by kubernautAgent.llm.credentialsSecretName
-# Provider names must use the litellm canonical form (e.g., "vertex_ai" not "vertexai").
-# See: https://docs.litellm.ai/docs/providers
+# Provider names must match LangChainGo provider identifiers (e.g., "openai", "azure", "vertex_ai").
+# See: https://tmc.github.io/langchaingo/docs/integrations/llms/
 llm:
   provider: ""       # "openai", "azure", "vertex_ai", "bedrock", etc.
   model: ""          # e.g., "gpt-4o", "vertex_ai/claude-sonnet-4"


### PR DESCRIPTION
## Summary

- Updates `charts/kubernaut/examples/sdk-config.yaml` to replace the stale LiteLLM provider reference with the correct LangChainGo provider list URL
- Since v1.3, the kubernaut-agent uses LangChainGo (not LiteLLM) for LLM provider integration

## Test plan

- [x] YAML syntax valid
- [x] No functional code changes — documentation-only fix

Closes #814


Made with [Cursor](https://cursor.com)