### PR TITLE
feat(audit): session lifecycle audit trail for SOC2 compliance (#823)

### DIFF
--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -264,7 +264,7 @@ func main() {
 	}
 
 	store := session.NewStore(cfg.Session.TTL)
-	mgr := session.NewManager(store, slogger)
+	mgr := session.NewManager(store, slogger, auditStore)
 
 	handler := kaserver.NewHandler(mgr, investigationRunner, slogger)
 

--- a/docs/architecture/decisions/DD-AUDIT-003-service-audit-trace-requirements.md
+++ b/docs/architecture/decisions/DD-AUDIT-003-service-audit-trace-requirements.md
@@ -2,10 +2,21 @@
 
 **Status**: ✅ **APPROVED** (Production Standard)
 **Date**: November 8, 2025
-**Last Reviewed**: March 25, 2026
-**Version**: 1.8
+**Last Reviewed**: April 24, 2026
+**Version**: 1.9
 **Confidence**: 95%
 **Authority Level**: SYSTEM-WIDE - Defines audit requirements for all 12 services
+
+**Recent Changes** (v1.9 - April 24, 2026):
+- **Kubernaut Agent (KA)**: Added 4 session lifecycle audit events per Issue #823 (PR 1.5):
+  - `aiagent.session.started` — Investigation session started (StatusRunning)
+  - `aiagent.session.cancelled` — Investigation session cancelled by operator
+  - `aiagent.session.completed` — Investigation session completed successfully
+  - `aiagent.session.failed` — Investigation session failed with error
+- **Authority**: BR-AUDIT-005 v2.0 (SOC2 CC8.1), Issue #823
+- **Implementation**: `internal/kubernautagent/session/manager.go` (Manager-level emission via `StoreBestEffort`)
+- **Expected Volume**: +200 events/day (session lifecycle tracking: 1 started + 1 terminal per investigation)
+- **Note**: Typed OpenAPI payloads deferred to follow-up DataStorage schema update; events use untyped `event_data` JSONB fallback
 
 **Recent Changes** (v1.8 - March 25, 2026):
 - **HolmesGPT API Service**: Added 2 Phase 2 enrichment audit events per Issue #533:
@@ -942,6 +953,10 @@ In v1.3 (issue [#433](https://github.com/jordigilh/kubernaut/issues/433), Kubern
 | `aiagent.response.failed` | `response_failed` | `failure` |
 | `aiagent.enrichment.completed` | `enrichment` | `success` |
 | `aiagent.enrichment.failed` | `enrichment` | `failure` |
+| `aiagent.session.started` | `session_started` | `success` |
+| `aiagent.session.cancelled` | `session_cancelled` | `success` |
+| `aiagent.session.completed` | `session_completed` | `success` |
+| `aiagent.session.failed` | `session_failed` | `failure` |
 | `aiagent.conversation.turn` | `conversation_turn` | `success` |
 
 **Granularity**: `aiagent.llm.tool_call` is emitted **once per tool call**. `aiagent.workflow.validation_attempt` is emitted per validation attempt and includes `workflow_id` and `is_final_attempt` where applicable. `aiagent.conversation.turn` is emitted once per user message in the conversational RAR API (see [DD-CONV-001](./DD-CONV-001-conversation-tool-call-architecture.md)).

--- a/docs/tests/823/TEST_PLAN.md
+++ b/docs/tests/823/TEST_PLAN.md
@@ -1,0 +1,782 @@
+# Test Plan: Session Store Cancellation Infrastructure (#823)
+
+> **Template**: IEEE 829-2008 + Kubernaut Hybrid v2.0
+
+**Test Plan Identifier**: TP-823-v1.0
+**Feature**: Session cancellation infrastructure — terminal state guards, context-driven cancellation, and event channel scaffolding for live investigation streaming.
+**Version**: 1.0
+**Created**: 2026-04-24
+**Author**: AI Assistant
+**Status**: Active — All Checkpoints Passed
+**Branch**: `feature/pr1-session-cancel-infra`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This test plan validates the cancellation infrastructure added to the Kubernaut Agent session store and manager as the first PR in the v1.5 streaming and cancellation feature set (#822). The changes introduce terminal state immutability, operator-initiated cancellation, and event channel scaffolding that subsequent PRs will use for live investigation streaming.
+
+The test plan provides behavioral assurance that:
+- Investigations reaching a terminal state (completed, cancelled, failed) are immutable
+- Operators can cancel active investigations, stopping the running LLM analysis
+- Event channels are scaffolded for future observer delivery without breaking the existing autonomous flow
+- All changes are backward-compatible with the existing v1.4 session lifecycle
+
+### 1.2 Objectives
+
+1. **Terminal state immutability**: Completed, cancelled, and failed investigations reject all subsequent state changes
+2. **Cancellation effectiveness**: Cancelling an active investigation propagates to the background goroutine and stops analysis
+3. **Error semantics**: Cancelling or subscribing to nonexistent or already-terminal investigations returns clear, typed errors
+4. **Observation scaffolding**: Event channels are created and closed with correct lifecycle, ready for PR 4
+5. **Zero regression**: All 14 existing session tests (10 UT + 4 IT) pass without modification
+6. **Per-tier coverage**: >=80% on both unit-testable and integration-testable session code
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test -race ./test/unit/kubernautagent/session/...` |
+| Integration test pass rate | 100% | `go test -race ./test/integration/kubernautagent/session/...` |
+| Unit-testable code coverage | >=80% | `go test -coverprofile` on store.go + types.go |
+| Integration-testable code coverage | >=80% | `go test -coverprofile` on manager.go |
+| Backward compatibility | 0 regressions | All 14 existing tests pass without modification |
+| Data races | 0 | `go test -race` on both tiers |
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- BR-SESSION-001: Investigation cancellation and terminal state immutability (working definition — see Section 2.3)
+- BR-SESSION-002: Session state query accuracy (working definition — see Section 2.3)
+- BR-SESSION-003: Live event observation for active investigations (working definition — see Section 2.3)
+- BR-SESSION-007: Runtime-agnostic event types for SSE contract stability (working definition — see Section 2.3)
+- Issue [#823](https://github.com/jordigilh/kubernaut/issues/823): Session Store Cancellation Infrastructure
+- Issue [#822](https://github.com/jordigilh/kubernaut/issues/822): v1.5 Streaming and Cancellation (parent)
+- PROPOSAL-EXT-003: Goose Runtime Evaluation
+
+### 2.2 Cross-References
+
+- [TP-433-v1.0](../433/TEST_PLAN.md) — Kubernaut Agent session management (parent test plan)
+- [Testing Strategy](../../../.cursor/rules/03-testing-strategy.mdc)
+- [Testing Guidelines](../../development/business-requirements/TESTING_GUIDELINES.md)
+
+### 2.3 Business Requirements — Working Definitions
+
+These BRs do not yet have formal `BUSINESS_REQUIREMENTS.md` definitions in the session domain. The following working definitions are authoritative for this test plan and will be superseded by formal definitions when created.
+
+| BR ID | Working Definition | Source |
+|-------|-------------------|--------|
+| BR-SESSION-001 | An operator can cancel an autonomous investigation in progress. The cancellation is final: once cancelled, the investigation state is immutable and cannot be overwritten by any concurrent process. This immutability extends to all terminal states (completed, failed, cancelled). | Inline in `manager_test.go`, `store_test.go` |
+| BR-SESSION-002 | The session store accurately reflects the current state of every investigation. Querying a cancelled, completed, or failed investigation returns the correct terminal state. | Derived from BR-SESSION-001 state integrity guarantee; formalized here. |
+| BR-SESSION-003 | Observers can subscribe to live events from an active investigation and are notified when the investigation concludes. | Inline in `manager_test.go` |
+| BR-SESSION-007 | Investigation event types are runtime-agnostic, providing a stable SSE contract across runtime migrations (current LangChainGo to future Goose ACP). See PROPOSAL-EXT-003. | `types.go` comment |
+
+**Action item**: Create `docs/services/kubernautagent/session/BUSINESS_REQUIREMENTS.md` with formal definitions after PR 1 merges.
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | Cancel + goroutine race on status: concurrent cancel endpoint and investigation goroutine both attempt to write status | Corrupted session state or data race | High | UT-KA-823-001..004, IT-KA-823-001, IT-KA-823-004 | Terminal state guard under lock + `-race` flag on all tests |
+| R2 | Cleanup TTL deletes a running session: housekeeping fires while investigation is active | Active investigation loses its session, goroutine orphaned | Medium | UT-KA-823-006 | `Cleanup()` skips `StatusRunning` sessions |
+| R3 | Event channel backpressure blocks `runLLMLoop` in future PRs | Investigation stalls if channel is full (PR 4+ risk) | Low | IT-KA-823-005 | Buffered channel (64 events) with documented capacity. Non-blocking send deferred to PR 4. |
+| R4 | Cancel/eventChan exposed via clone() | Caller obtains internal control references and interferes with investigation | Medium | UT-KA-823-007 | Fields unexported; `clone()` excludes them |
+| R5 | Double-cancel panics: calling cancel() on already-cancelled context | Runtime panic crashes KA | Medium | IT-KA-823-003 | Terminal state guard checks status before calling cancel() |
+| R6 | Manager accesses Store internal map directly (bypassing Store API) | Tight coupling makes future refactoring fragile | Low | IT-KA-823-001 | Documented in code; lock discipline verified at CHECKPOINT 3 |
+
+### 3.1 Risk-to-Test Traceability
+
+| Risk | Mitigating Tests |
+|------|-----------------|
+| R1 | UT-KA-823-001, UT-KA-823-002, UT-KA-823-003, UT-KA-823-004, IT-KA-823-001, IT-KA-823-004 |
+| R2 | UT-KA-823-006 |
+| R3 | IT-KA-823-005 |
+| R4 | UT-KA-823-007 |
+| R5 | IT-KA-823-003 |
+| R6 | IT-KA-823-001 (verifies cancel propagates through Manager -> Store -> goroutine chain) |
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **Session state integrity** (`internal/kubernautagent/session/store.go`): Terminal state immutability guards on `Update()`, `StatusCancelled` constant, `Cleanup()` protection for running sessions, isolation of internal control fields from callers
+- **Investigation lifecycle** (`internal/kubernautagent/session/manager.go`): Context-driven cancellation via `CancelInvestigation()`, event channel scaffolding via `Subscribe()`, goroutine cleanup on investigation exit
+- **Event type definitions** (`internal/kubernautagent/session/types.go`): Runtime-agnostic event type constants and `InvestigationEvent` struct
+
+### 4.2 Features Not to be Tested
+
+- **HTTP endpoint for cancel** (`POST /api/v1/incident/session/{id}/cancel`): Deferred to PR 2
+- **SSE streaming endpoint** (`GET /api/v1/incident/session/{id}/stream`): Deferred to PR 3-5
+- **Event emission during LLM loop**: Deferred to PR 4
+- **Authorization/authentication**: Deferred to PR 2 (KA endpoint auth)
+- **Goose runtime integration**: Out of scope; event types designed for compatibility but no Goose code in this PR
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| `context.WithCancel` on `context.Background()` for investigation goroutine | The investigation must outlive the HTTP request. Cancel is explicit via `CancelInvestigation()`, not via request context. |
+| Buffered event channel (64 events) | Provides headroom for bursty LLM output without blocking. Non-blocking send deferred to PR 4. |
+| Unexported `cancel`/`eventChan` on Session | These are internal control mechanisms. Exposing them would allow callers to bypass the Manager API. |
+| `ErrSessionTerminal` sentinel error | Typed error allows callers to distinguish "session exists but is terminal" from "session not found" without string matching. |
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+**Authority**: `03-testing-strategy.mdc` — Per-Tier Testable Code Coverage.
+
+- **Unit**: >=80% of unit-testable code (`store.go` pure logic: `isTerminal()`, `Update()` guard, `Cleanup()` skip, `clone()` isolation)
+- **Integration**: >=80% of integration-testable code (`manager.go`: `StartInvestigation` with cancel context, `CancelInvestigation`, `Subscribe`, `closeEventChan`, goroutine lifecycle)
+- **E2E**: Not applicable for this PR (no HTTP endpoints added)
+
+### 5.2 Two-Tier Minimum
+
+Every BR is covered by at least 2 tiers:
+
+| BR | Unit Coverage | Integration Coverage |
+|----|--------------|---------------------|
+| BR-SESSION-001 | UT-KA-823-001..004, UT-KA-823-006, UT-KA-823-007 | IT-KA-823-001..004 |
+| BR-SESSION-002 | UT-KA-823-005 | IT-KA-823-001 (state verified after cancel) |
+| BR-SESSION-003 | — | IT-KA-823-005, IT-KA-823-006, IT-KA-823-007 |
+| BR-SESSION-007 | Compile-time (type constants) | IT-KA-823-005 (event type in channel) |
+
+**Note on BR-SESSION-003**: No unit test tier because event delivery is inherently cross-component (Manager + Store + goroutine). This is documented as a tier skip.
+
+### 5.3 Business Outcome Quality Bar
+
+Tests validate **business outcomes** — what the operator/observer gets — not implementation mechanics. Every test description answers "what does the operator/system experience?" not "what function is called?"
+
+### 5.4 Pass/Fail Criteria
+
+**PASS** — all of the following:
+
+1. All P0 tests pass (0 failures)
+2. All P1 tests pass
+3. Per-tier code coverage >= 80%
+4. Zero regressions in existing 14 session tests
+5. Zero data races under `-race`
+
+**FAIL** — any of the following:
+
+1. Any P0 test fails
+2. Per-tier coverage below 80%
+3. Any existing test regresses
+4. Any data race detected
+
+### 5.5 Suspension & Resumption Criteria
+
+**Suspend testing when**:
+
+- Code does not compile (`go build ./...` fails)
+- Existing session tests fail before new tests are written (baseline broken)
+- Design question requires user input (escalate)
+
+**Resume testing when**:
+
+- Build restored
+- Baseline tests passing
+- Design question resolved
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code (pure logic, no I/O)
+
+| File | Behaviors | Lines (approx) |
+|------|-----------|-----------------|
+| `internal/kubernautagent/session/store.go` | `isTerminal()`, terminal guard in `Update()`, `StatusCancelled`, `Cleanup()` skip for running, `clone()` isolation of unexported fields | ~156 (will grow ~30 lines) |
+| `internal/kubernautagent/session/types.go` | `InvestigationEvent` struct, event type constants | ~30 (new file) |
+
+### 6.2 Integration-Testable Code (I/O, goroutine lifecycle, cross-component)
+
+| File | Behaviors | Lines (approx) |
+|------|-----------|-----------------|
+| `internal/kubernautagent/session/manager.go` | `StartInvestigation` with `context.WithCancel`, `CancelInvestigation`, `Subscribe`, `closeEventChan`, goroutine cleanup | ~73 (will grow ~60 lines) |
+
+### 6.3 Version Identification
+
+| Item | Version/Commit | Notes |
+|------|----------------|-------|
+| Code under test | `development/v1.5` HEAD | Branch: `feature/pr1-session-cancel-infra` |
+| Parent issue | #822 | v1.5 Streaming and Cancellation |
+
+---
+
+## 7. BR Coverage Matrix
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-SESSION-001 | Terminal state immutability | P0 | Unit | UT-KA-823-001 | Pass |
+| BR-SESSION-001 | Terminal state immutability | P0 | Unit | UT-KA-823-002 | Pass |
+| BR-SESSION-001 | Terminal state immutability | P0 | Unit | UT-KA-823-003 | Pass |
+| BR-SESSION-001 | Cancellation transition | P0 | Unit | UT-KA-823-004 | Pass |
+| BR-SESSION-001 | Housekeeping safety | P1 | Unit | UT-KA-823-006 | Pass |
+| BR-SESSION-001 | Session isolation | P1 | Unit | UT-KA-823-007 | Pass |
+| BR-SESSION-001 | Cancel stops analysis | P0 | Integration | IT-KA-823-001 | Pass |
+| BR-SESSION-001 | Cancel nonexistent | P0 | Integration | IT-KA-823-002 | Pass |
+| BR-SESSION-001 | Cancel terminal | P0 | Integration | IT-KA-823-003 | Pass |
+| BR-SESSION-001 | Post-cancel integrity | P0 | Integration | IT-KA-823-004 | Pass |
+| BR-SESSION-002 | State query accuracy | P0 | Unit | UT-KA-823-005 | Pass |
+| BR-SESSION-003 | Live event delivery | P0 | Integration | IT-KA-823-005 | Pass |
+| BR-SESSION-003 | Subscription consistency | P1 | Integration | IT-KA-823-006 | Pass |
+| BR-SESSION-003 | End-of-investigation notification | P0 | Integration | IT-KA-823-007 | Pass |
+| BR-SESSION-003 | Subscribe error for unknown investigation | P1 | Integration | IT-KA-823-008 | Pass |
+| BR-SESSION-003 | Subscribe error for concluded investigation | P1 | Integration | IT-KA-823-009 | Pass |
+
+### Status Legend
+
+- **Pending**: Specification complete, implementation not started
+- **RED**: Failing test written (TDD RED phase)
+- **GREEN**: Minimal implementation passes (TDD GREEN phase)
+- **REFACTORED**: Code cleaned up (TDD REFACTOR phase)
+- **Pass**: Implemented and passing
+
+---
+
+## 8. Test Scenarios
+
+### Test ID Naming Convention
+
+Format: `{TIER}-{SERVICE}-{ISSUE}-{SEQUENCE}`
+
+- **TIER**: `UT` (Unit), `IT` (Integration)
+- **SERVICE**: `KA` (Kubernaut Agent)
+- **ISSUE**: `823`
+- **SEQUENCE**: Zero-padded 3-digit (001, 002, ...)
+
+### Tier 1: Unit Tests
+
+**Testable code scope**: `internal/kubernautagent/session/store.go`, `internal/kubernautagent/session/types.go` — >=80% coverage target
+
+| ID | Business Acceptance Criterion | Phase |
+|----|------------------------------|-------|
+| UT-KA-823-001 | A completed investigation is immutable — no subsequent status change is accepted | Pass |
+| UT-KA-823-002 | A cancelled investigation is immutable — no subsequent status change is accepted | Pass |
+| UT-KA-823-003 | A failed investigation is immutable — no subsequent status change is accepted | Pass |
+| UT-KA-823-004 | An active investigation can be cancelled by an operator | Pass |
+| UT-KA-823-005 | Querying a cancelled investigation accurately reports the cancelled state | Pass |
+| UT-KA-823-006 | Active investigations are never removed by housekeeping regardless of age | Pass |
+| UT-KA-823-007 | Session metadata returned to callers cannot be used to interfere with active investigations | Pass |
+
+### Tier 2: Integration Tests
+
+**Testable code scope**: `internal/kubernautagent/session/manager.go` — >=80% coverage target
+
+| ID | Business Acceptance Criterion | Phase |
+|----|------------------------------|-------|
+| IT-KA-823-001 | Cancelling an investigation stops the running LLM analysis | Pass |
+| IT-KA-823-002 | Cancelling a nonexistent investigation returns a clear not-found error | Pass |
+| IT-KA-823-003 | Cancelling an already-completed investigation returns a clear terminal-state error | Pass |
+| IT-KA-823-004 | After cancellation, the investigation cannot retroactively report failure | Pass |
+| IT-KA-823-005 | An observer can receive live events from an active investigation | Pass |
+| IT-KA-823-006 | Multiple subscriptions to the same investigation share a single event stream | Pass |
+| IT-KA-823-007 | Observers are notified when an investigation concludes | Pass |
+| IT-KA-823-008 | Subscribing to a nonexistent investigation returns a clear error | Pass |
+| IT-KA-823-009 | Subscribing to a concluded investigation returns a clear error | Pass |
+
+### Tier 3: E2E Tests
+
+Not applicable for this PR. No HTTP endpoints are added.
+
+### Tier Skip Rationale
+
+- **E2E**: No HTTP endpoints or external service interactions in this PR. Cancel/Subscribe are internal APIs consumed by future PR 2-3 HTTP handlers.
+- **BR-SESSION-003 Unit tier**: Event delivery is inherently cross-component (Manager creates channel, goroutine closes it, caller reads from it). Pure unit testing would require mocking the Manager, violating the no-mocks integration policy. Integration tier provides adequate coverage.
+
+---
+
+## 9. Test Cases
+
+### UT-KA-823-001: Completed investigation is immutable
+
+**BR**: BR-SESSION-001
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/session/store_test.go`
+
+**Preconditions**:
+- Session store created with standard TTL
+- Session created and updated to `StatusCompleted`
+
+**Test Steps**:
+1. **Given**: A session in `StatusCompleted`
+2. **When**: An attempt is made to change the status to `StatusRunning`
+3. **Then**: The update is rejected with `ErrSessionTerminal`
+
+**Expected Results**:
+1. `Update()` returns `ErrSessionTerminal`
+2. Session status remains `StatusCompleted` on subsequent `Get()`
+
+**Acceptance Criteria**:
+- **Behavior**: Completed investigations cannot change state
+- **Correctness**: Error is the sentinel `ErrSessionTerminal`, not a generic error
+
+---
+
+### UT-KA-823-002: Cancelled investigation is immutable
+
+**BR**: BR-SESSION-001
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/session/store_test.go`
+
+**Preconditions**:
+- Session store created with standard TTL
+- Session created and updated to `StatusCancelled`
+
+**Test Steps**:
+1. **Given**: A session in `StatusCancelled`
+2. **When**: An attempt is made to change the status to `StatusFailed`
+3. **Then**: The update is rejected with `ErrSessionTerminal`
+
+**Expected Results**:
+1. `Update()` returns `ErrSessionTerminal`
+2. Session status remains `StatusCancelled` on subsequent `Get()`
+
+**Acceptance Criteria**:
+- **Behavior**: Cancelled investigations cannot change state
+- **Correctness**: Error is the sentinel `ErrSessionTerminal`
+
+---
+
+### UT-KA-823-003: Failed investigation is immutable
+
+**BR**: BR-SESSION-001
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/session/store_test.go`
+
+**Preconditions**:
+- Session store created with standard TTL
+- Session created and updated to `StatusFailed`
+
+**Test Steps**:
+1. **Given**: A session in `StatusFailed`
+2. **When**: An attempt is made to change the status to `StatusCompleted`
+3. **Then**: The update is rejected with `ErrSessionTerminal`
+
+**Expected Results**:
+1. `Update()` returns `ErrSessionTerminal`
+2. Session status remains `StatusFailed` on subsequent `Get()`
+
+**Acceptance Criteria**:
+- **Behavior**: Failed investigations cannot change state
+- **Correctness**: Error is the sentinel `ErrSessionTerminal`
+
+---
+
+### UT-KA-823-004: Active investigation can be cancelled
+
+**BR**: BR-SESSION-001
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/session/store_test.go`
+
+**Preconditions**:
+- Session store created with standard TTL
+- Session created and updated to `StatusRunning`
+
+**Test Steps**:
+1. **Given**: A session in `StatusRunning`
+2. **When**: The status is changed to `StatusCancelled`
+3. **Then**: The update succeeds
+
+**Expected Results**:
+1. `Update()` returns nil
+2. Session status is `StatusCancelled` on subsequent `Get()`
+
+**Acceptance Criteria**:
+- **Behavior**: Running investigations accept cancellation
+- **Correctness**: Status transitions cleanly
+
+---
+
+### UT-KA-823-005: Querying a cancelled investigation reports the cancelled state
+
+**BR**: BR-SESSION-002
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/session/store_test.go`
+
+**Preconditions**:
+- Session store created with standard TTL
+- Session created, set to Running, then updated to Cancelled
+
+**Test Steps**:
+1. **Given**: A session that has been cancelled
+2. **When**: The session is retrieved by ID
+3. **Then**: The returned session has `StatusCancelled`
+
+**Expected Results**:
+1. `Get()` returns a session with `Status == StatusCancelled`
+2. No error
+
+**Acceptance Criteria**:
+- **Behavior**: State query reflects actual state
+- **Accuracy**: Status field is `StatusCancelled`, not any other value
+
+---
+
+### UT-KA-823-006: Active investigations are never removed by housekeeping
+
+**BR**: BR-SESSION-001
+**Priority**: P1
+**Type**: Unit
+**File**: `test/unit/kubernautagent/session/store_test.go`
+
+**Preconditions**:
+- Session store created with very short TTL (1ms)
+- Session created and updated to `StatusRunning`
+- Sufficient time elapsed for TTL to expire
+
+**Test Steps**:
+1. **Given**: A running session whose TTL has expired
+2. **When**: `Cleanup()` executes
+3. **Then**: The running session is not removed
+
+**Expected Results**:
+1. `Cleanup()` returns 0 (no sessions removed)
+2. `Get()` still returns the running session
+
+**Acceptance Criteria**:
+- **Behavior**: Housekeeping never disrupts active investigations
+- **Correctness**: Only non-running, expired sessions are cleaned up
+
+---
+
+### UT-KA-823-007: Session metadata cannot be used to interfere with active investigations
+
+**BR**: BR-SESSION-001
+**Priority**: P1
+**Type**: Unit
+**File**: `test/unit/kubernautagent/session/store_test.go`
+
+**Preconditions**:
+- Session store created
+- Session created with a cancel function and event channel installed (via Manager path)
+
+**Test Steps**:
+1. **Given**: A running session with internal control fields set
+2. **When**: The session is retrieved via `Get()`
+3. **Then**: The returned copy has nil/zero-valued cancel and event channel fields
+
+**Expected Results**:
+1. Returned session's unexported fields are zero-valued
+2. Modifying the returned session has no effect on the stored session
+
+**Acceptance Criteria**:
+- **Behavior**: Internal control references are not exposed to callers
+- **Correctness**: `clone()` produces an isolated copy
+
+**Dependencies**: Requires access to unexported fields (test in same package or reflection-based assertion)
+
+---
+
+### IT-KA-823-001: Cancelling an investigation stops the running LLM analysis
+
+**BR**: BR-SESSION-001
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/session/manager_test.go`
+
+**Preconditions**:
+- Manager created with default store and logger
+- Investigation started with a long-running function that respects context cancellation
+
+**Test Steps**:
+1. **Given**: A running investigation whose function blocks on `ctx.Done()`
+2. **When**: `CancelInvestigation(id)` is called
+3. **Then**: The investigation function's context is cancelled, and the session transitions to `StatusCancelled`
+
+**Expected Results**:
+1. `CancelInvestigation()` returns nil
+2. Investigation function receives context cancellation (verified by `Eventually`)
+3. Session status becomes `StatusCancelled`
+
+**Acceptance Criteria**:
+- **Behavior**: Cancel propagates to the running analysis
+- **Correctness**: Session reaches `StatusCancelled` deterministically
+
+---
+
+### IT-KA-823-002: Cancelling a nonexistent investigation returns a clear error
+
+**BR**: BR-SESSION-001
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/session/manager_test.go`
+
+**Preconditions**:
+- Manager created with empty store
+
+**Test Steps**:
+1. **Given**: No investigation exists with the given ID
+2. **When**: `CancelInvestigation("nonexistent-id")` is called
+3. **Then**: The call returns `ErrSessionNotFound`
+
+**Expected Results**:
+1. Error matches `ErrSessionNotFound` sentinel
+
+**Acceptance Criteria**:
+- **Behavior**: Clear, typed error for unknown investigation
+- **Correctness**: No panic, no state corruption
+
+---
+
+### IT-KA-823-003: Cancelling an already-completed investigation returns a clear error
+
+**BR**: BR-SESSION-001
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/session/manager_test.go`
+
+**Preconditions**:
+- Manager created
+- Investigation started and completed successfully
+
+**Test Steps**:
+1. **Given**: An investigation that has already completed
+2. **When**: `CancelInvestigation(id)` is called
+3. **Then**: The call returns `ErrSessionTerminal`
+
+**Expected Results**:
+1. Error matches `ErrSessionTerminal` sentinel
+2. Session status remains `StatusCompleted`
+
+**Acceptance Criteria**:
+- **Behavior**: Terminal investigations cannot be cancelled (R5 mitigation)
+- **Correctness**: No panic from double cancel or post-terminal cancel
+
+---
+
+### IT-KA-823-004: After cancellation, the investigation cannot retroactively report failure
+
+**BR**: BR-SESSION-001
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/session/manager_test.go`
+
+**Preconditions**:
+- Manager created
+- Investigation started with a function that returns an error after detecting context cancellation
+
+**Test Steps**:
+1. **Given**: A running investigation
+2. **When**: `CancelInvestigation(id)` is called, and the investigation function subsequently returns an error
+3. **Then**: The session status is `StatusCancelled`, not `StatusFailed`
+
+**Expected Results**:
+1. Session status is `StatusCancelled`
+2. The goroutine's attempt to set `StatusFailed` is rejected by the terminal guard
+
+**Acceptance Criteria**:
+- **Behavior**: Cancellation takes precedence over the analysis outcome
+- **Correctness**: Terminal state guard prevents race (R1 mitigation)
+
+---
+
+### IT-KA-823-005: An observer can receive live events from an active investigation
+
+**BR**: BR-SESSION-003
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/session/manager_test.go`
+
+**Preconditions**:
+- Manager created
+- Investigation started
+
+**Test Steps**:
+1. **Given**: A running investigation
+2. **When**: `Subscribe(id)` is called
+3. **Then**: A readable event channel is returned
+
+**Expected Results**:
+1. `Subscribe()` returns a non-nil channel and no error
+2. The channel is open (not closed)
+
+**Acceptance Criteria**:
+- **Behavior**: Observers can subscribe to active investigations
+- **Correctness**: Channel is usable for reading events
+
+---
+
+### IT-KA-823-006: Multiple subscriptions share a single event stream
+
+**BR**: BR-SESSION-003
+**Priority**: P1
+**Type**: Integration
+**File**: `test/integration/kubernautagent/session/manager_test.go`
+
+**Preconditions**:
+- Manager created
+- Investigation started
+
+**Test Steps**:
+1. **Given**: A running investigation
+2. **When**: `Subscribe(id)` is called twice
+3. **Then**: Both calls return the same channel
+
+**Expected Results**:
+1. Channel reference from first call == channel reference from second call
+
+**Acceptance Criteria**:
+- **Behavior**: Single event stream per investigation (no fan-out duplication)
+- **Correctness**: Channel identity is stable
+
+---
+
+### IT-KA-823-007: Observers are notified when an investigation concludes
+
+**BR**: BR-SESSION-003
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/session/manager_test.go`
+
+**Preconditions**:
+- Manager created
+- Investigation started with a function that completes quickly
+- Observer subscribed to the investigation
+
+**Test Steps**:
+1. **Given**: An observer subscribed to an active investigation
+2. **When**: The investigation completes (function returns)
+3. **Then**: The event channel is closed
+
+**Expected Results**:
+1. Reading from the channel eventually returns the zero value (channel closed)
+
+**Acceptance Criteria**:
+- **Behavior**: Observers know when the investigation ends
+- **Correctness**: Channel is closed exactly once, no panic from double-close
+
+---
+
+### IT-KA-823-008: Subscribing to a nonexistent investigation returns a clear error
+
+**BR**: BR-SESSION-003
+**Priority**: P1
+**Type**: Integration
+**File**: `test/integration/kubernautagent/session/manager_test.go`
+
+**Preconditions**:
+- Manager created with empty store
+
+**Test Steps**:
+1. **Given**: No investigation exists with the given ID
+2. **When**: `Subscribe("nonexistent-id")` is called
+3. **Then**: The call returns nil channel and `ErrSessionNotFound`
+
+**Expected Results**:
+1. Channel is nil
+2. Error matches `ErrSessionNotFound` sentinel
+
+**Acceptance Criteria**:
+- **Behavior**: Clear, typed error for unknown investigation
+- **Correctness**: No panic, no dangling channel
+
+---
+
+## 10. Environmental Needs
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: None
+- **Location**: `test/unit/kubernautagent/session/`
+- **Resources**: Standard (no external dependencies)
+
+### 10.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: ZERO mocks
+- **Infrastructure**: None (in-process Manager + Store, no external services)
+- **Location**: `test/integration/kubernautagent/session/`
+- **Resources**: Standard (goroutine-based, no containers)
+
+### 10.3 Tools & Versions
+
+| Tool | Minimum Version | Purpose |
+|------|-----------------|---------|
+| Go | 1.22+ | Build and test |
+| Ginkgo CLI | v2.x | Test runner |
+| `go test -race` | Built-in | Data race detection |
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Blocking Dependencies
+
+None. This PR has zero external dependencies.
+
+### 11.2 Execution Order
+
+1. **Phase 1 (RED)**: Write all 14 failing tests with minimal stubs
+2. **Phase 2 (GREEN)**: Implement minimal code to pass all 14 tests
+3. **Phase 3 (REFACTOR)**: Improve code quality without changing behavior
+
+---
+
+## 12. Test Deliverables
+
+| Deliverable | Location | Description |
+|-------------|----------|-------------|
+| This test plan | `docs/tests/823/TEST_PLAN.md` | Strategy and test design |
+| Unit test suite | `test/unit/kubernautagent/session/store_test.go` | 7 new Ginkgo specs added to existing file |
+| Integration test suite | `test/integration/kubernautagent/session/manager_test.go` | 7 new Ginkgo specs added to existing file |
+| Coverage report | CI artifact | Per-tier coverage percentages |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests
+go test -race -v ./test/unit/kubernautagent/session/...
+
+# Integration tests
+go test -race -v ./test/integration/kubernautagent/session/...
+
+# Specific test by ID
+go test -race -v ./test/unit/kubernautagent/session/... -ginkgo.focus="UT-KA-823"
+
+# Coverage (unit)
+go test -coverprofile=cover-ut.out ./test/unit/kubernautagent/session/...
+go tool cover -func=cover-ut.out
+
+# Coverage (integration)
+go test -coverprofile=cover-it.out ./test/integration/kubernautagent/session/...
+go tool cover -func=cover-it.out
+```
+
+---
+
+## 14. Existing Tests Requiring Updates
+
+None. All 14 existing session tests (10 UT + 4 IT) must pass without modification. The terminal state guard in `Update()` does not affect existing tests because:
+- Existing tests never attempt to update a terminal-state session
+- `Cleanup()` behavior change (skip running) adds protection but doesn't break existing TTL tests (they test expired non-running sessions)
+
+---
+
+## 15. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-24 | Initial test plan (14 scenarios: 7 UT + 7 IT) |
+| 1.1 | 2026-04-24 | Added IT-KA-823-008 (subscribe nonexistent) from CHECKPOINT 1 gap analysis |
+| 1.2 | 2026-04-24 | Added IT-KA-823-009 (subscribe after conclusion) from CHECKPOINT 3 rework loop |
+| 1.3 | 2026-04-24 | All 16 scenarios passing. Coverage: 97.2% merged, ~99% UT on store.go, ~96% IT on manager.go |

--- a/docs/tests/823/TP-823-AUDIT.md
+++ b/docs/tests/823/TP-823-AUDIT.md
@@ -1,0 +1,507 @@
+# Test Plan: Session Lifecycle Audit Trail for SOC2 Compliance
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+>
+> Based on IEEE 829-2008 (Standard for Software and System Test Documentation) with
+> Kubernaut-specific extensions for TDD phase tracking, business requirement traceability,
+> and per-tier coverage policy.
+
+**Test Plan Identifier**: TP-823-AUDIT-v1.0
+**Feature**: Session lifecycle audit trail — emit SOC2-compliant audit events for session started/cancelled/completed/failed
+**Version**: 1.0
+**Created**: 2026-04-24
+**Author**: AI Assistant + Jordi Gil
+**Status**: Active
+**Branch**: `feature/pr1.5-session-audit-trail`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+PR 1 (#823) added session cancellation infrastructure but emitted zero audit events for
+session lifecycle transitions. This violates SOC2 CC8.1 (operator attribution) and
+BR-AUDIT-005 v2.0 (100% RR reconstruction from audit traces). This test plan covers
+the addition of 4 `aiagent.session.*` audit event types to the session Manager, ensuring
+every investigation lifecycle transition is audited fire-and-forget per ADR-038.
+
+### 1.2 Objectives
+
+1. **Audit completeness**: Every session lifecycle transition (started, cancelled, completed, failed) emits exactly one audit event
+2. **SOC2 traceability**: Audit events carry `remediation_id` as CorrelationID, `session_id`, and `initiated_by` for operator attribution
+3. **Fire-and-forget resilience**: Audit store failures never abort investigations (ADR-038)
+4. **Nil safety**: A nil AuditStore in NewManager defaults to NopAuditStore without panic
+5. **Zero regression**: All existing v1.4 and PR1 tests pass without modification (other than NewManager signature update)
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/kubernautagent/session/...` |
+| Integration test pass rate | 100% | `go test ./test/integration/kubernautagent/session/...` |
+| Unit-testable code coverage (emitter.go) | >=80% | `go test -coverprofile -coverpkg=.../audit` |
+| Integration-testable code coverage (manager.go) | >=80% | `go test -coverprofile -coverpkg=.../session` |
+| Backward compatibility | 0 regressions | All existing tests pass with NewManager signature update |
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- **BR-AUDIT-005 v2.0**: SOC2 CC8.1 — all session lifecycle events must be audited for RR reconstruction
+- **ADR-038**: Async Buffered Audit Ingestion — fire-and-forget semantics, audit failures never block business logic
+- **DD-AUDIT-003 v1.8**: Service Audit Trace Requirements — authoritative event registry for all Kubernaut services
+- **Issue #823**: Session Store Cancellation Infrastructure (parent issue)
+- **TP-823-v1.0**: Companion test plan for PR1 cancellation infrastructure
+
+### 2.2 Business Requirements — Working Definitions
+
+| BR ID | Definition |
+|-------|-----------|
+| BR-AUDIT-005 v2.0 | Every business-critical state transition MUST be auditable for 100% RR CRD reconstruction |
+| BR-SESSION-001 | A session MUST be uniquely identifiable (session_id as UUID) |
+| BR-SESSION-003 | Lifecycle transitions (pending→running→terminal) MUST be traceable |
+| SOC2 CC8.1 | Operator attribution: who started, who cancelled, when, with what correlation |
+
+### 2.3 Cross-References
+
+- [Testing Strategy](../../.cursor/rules/03-testing-strategy.mdc)
+- [Testing Guidelines](../development/business-requirements/TESTING_GUIDELINES.md)
+- [DD-AUDIT-003](../../architecture/decisions/DD-AUDIT-003-service-audit-trace-requirements.md)
+- [ADR-038](../../architecture/decisions/ADR-038-async-buffered-audit-ingestion.md)
+- [PR1 Test Plan](TEST_PLAN.md)
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | Nil AuditStore causes panic in Manager | Investigation crashes, availability loss | Medium | IT-KA-823-A07 | NopAuditStore guard in NewManager constructor |
+| R2 | Phantom audit events for rejected state transitions | SOC2 reconstructs non-existent sessions | Medium | IT-KA-823-A05 | Emit audit AFTER successful state transition |
+| R3 | Missing CorrelationID prevents RR reconstruction | SOC2 audit gap | High | IT-KA-823-A06 | Use `remediation_id` from session metadata as CorrelationID |
+| R4 | Audit emission blocks investigation goroutine | Performance degradation under audit backpressure | Medium | IT-KA-823-A08 | Fire-and-forget via `StoreBestEffort` (ADR-038) |
+| R5 | Existing tests break from NewManager signature change | False CI failures, regression | High | Checkpoint 0 | Update all 8 callsites; existing tests pass `nil` (guarded by R1 mitigation) |
+| R6 | Data race on AuditStore access from background goroutine | Undefined behavior | Low | Checkpoint 3 (race detector) | `StoreBestEffort` uses AuditStore interface which is goroutine-safe by contract |
+| R7 | CancelInvestigation lacks actor identity (no ctx parameter) | Incomplete SOC2 CC8.1 attribution for cancel events | Low | N/A (deferred) | Deferred to PR 2 when cancel HTTP endpoint is wired; PR 1.5 uses ActorID="kubernaut-agent" |
+
+### 3.1 Risk-to-Test Traceability
+
+- **R1** → IT-KA-823-A07 (nil AuditStore guard)
+- **R2** → IT-KA-823-A05 (no phantom audit after cancel)
+- **R3** → IT-KA-823-A06 (correlation fields present)
+- **R4** → IT-KA-823-A08 (audit error is fire-and-forget)
+- **R5** → Checkpoint 0 (build + existing test regression)
+- **R6** → Checkpoint 3 (race detector)
+- **R7** → Documented deferral; no test (cancel endpoint not yet wired)
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **Audit event constants** (`internal/kubernautagent/audit/emitter.go`): 4 new `aiagent.session.*` event types and 4 action constants registered in `AllEventTypes`
+- **Manager audit emission** (`internal/kubernautagent/session/manager.go`): AuditStore injection, audit event emission at all 4 lifecycle transitions
+- **Nil AuditStore guard**: NewManager defaults nil to NopAuditStore
+- **Fire-and-forget semantics**: StoreBestEffort wrapping for all audit calls
+- **Handler metadata enrichment** (`internal/kubernautagent/server/handler.go`): `remediation_id` added to metadata, user identity extraction from context
+
+### 4.2 Features Not to be Tested
+
+- **DataStorage OpenAPI typed payloads**: Deferred to follow-up issue (new `AIAgentSessionPayload` schema needed in DS OpenAPI spec). `buildEventData` returns untyped fallback.
+- **CancelInvestigation actor plumbing**: Deferred to PR 2 when the cancel HTTP endpoint is wired. Current CancelInvestigation has no context parameter.
+- **Conversation/SSE audit emission**: Out of scope (different audit category, covered by existing `aiagent.conversation.turn` events)
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Emit audit at Manager level, not Store level | Manager owns lifecycle semantics; Store is a dumb data structure |
+| Use `StoreBestEffort` for all audit calls | ADR-038 fire-and-forget; audit failures never block investigations |
+| Actor for goroutine events = "kubernaut-agent" | Background goroutine outlives HTTP request; `initiated_by` in event data provides human traceability |
+| `buildEventData` returns `(empty, false)` for session events | No typed OpenAPI payload exists yet; DS persists raw event_data as JSONB |
+| `CancelInvestigation` keeps `(id string)` signature | No cancel endpoint wired yet; adding ctx would create dead parameter |
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+**Authority**: `03-testing-strategy.mdc` — Per-Tier Testable Code Coverage.
+
+- **Unit**: >=80% of unit-testable code (`internal/kubernautagent/audit/emitter.go` — constant registration)
+- **Integration**: >=80% of integration-testable code (`internal/kubernautagent/session/manager.go` — audit emission paths)
+
+### 5.2 Two-Tier Minimum
+
+Every business requirement is covered by at least 2 test tiers:
+- **Unit tests**: Validate audit event type constants, action strings, and registry completeness
+- **Integration tests**: Validate Manager emits correct audit events at lifecycle transitions with correct metadata
+
+### 5.3 Business Outcome Quality Bar
+
+Tests validate **business outcomes** — "does the SOC2 auditor see the right events with the right correlation data?" — not just "does the function call succeed?"
+
+### 5.4 Pass/Fail Criteria
+
+**PASS** — all of the following must be true:
+
+1. All P0 tests pass (0 failures)
+2. Per-tier code coverage meets >=80% threshold
+3. No regressions in existing test suites (PR1 #823 tests, v1.4 #433 tests)
+4. Race detector reports no new races in session package
+5. DD-AUDIT-003 updated to v1.9 with 4 new session event types
+
+**FAIL** — any of the following:
+
+1. Any P0 test fails
+2. Per-tier coverage falls below 80%
+3. Existing tests regress
+4. Race detected in audit emission path
+
+### 5.5 Suspension & Resumption Criteria
+
+**Suspend testing when**:
+- Build broken — code does not compile
+- Circular import — audit package cannot be imported from session
+- Pre-existing race failures obscure new races
+
+**Resume testing when**:
+- Build restored
+- Import path resolved
+- Pre-existing races documented and excluded
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code (pure logic, no I/O)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `internal/kubernautagent/audit/emitter.go` | Event type constants, Action constants, `AllEventTypes` slice | ~15 new lines |
+
+### 6.2 Integration-Testable Code (I/O, wiring, cross-component)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `internal/kubernautagent/session/manager.go` | `NewManager`, `StartInvestigation`, `CancelInvestigation`, goroutine completion/failure | ~40 new/changed lines |
+| `internal/kubernautagent/server/handler.go` | `IncidentAnalyzeEndpointAPIV1IncidentAnalyzePost` (metadata enrichment) | ~5 changed lines |
+| `cmd/kubernautagent/main.go` | `NewManager` callsite wiring | ~2 changed lines |
+
+### 6.3 Version Identification
+
+| Item | Version/Commit | Notes |
+|------|----------------|-------|
+| Code under test | `feature/pr1.5-session-audit-trail` HEAD | Branched from `feature/pr1-session-cancel-infra` |
+| Dependency: PR1 cancellation infra | `fd15319b6` | Must be present (parent commit) |
+
+---
+
+## 7. BR Coverage Matrix
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-AUDIT-005 v2.0 | Session started emits audit | P0 | Integration | IT-KA-823-A01 | Pending |
+| BR-AUDIT-005 v2.0 | Session completed emits audit | P0 | Integration | IT-KA-823-A02 | Pending |
+| BR-AUDIT-005 v2.0 | Session failed emits audit | P0 | Integration | IT-KA-823-A03 | Pending |
+| BR-AUDIT-005 v2.0 | Session cancelled emits audit | P0 | Integration | IT-KA-823-A04 | Pending |
+| BR-AUDIT-005 v2.0 | No phantom audit after cancel | P0 | Integration | IT-KA-823-A05 | Pending |
+| SOC2 CC8.1 | Correlation fields present (remediation_id, session_id, initiated_by) | P0 | Integration | IT-KA-823-A06 | Pending |
+| ADR-038 | Nil AuditStore guard (NopAuditStore default) | P0 | Integration | IT-KA-823-A07 | Pending |
+| ADR-038 | Fire-and-forget on audit error | P0 | Integration | IT-KA-823-A08 | Pending |
+| BR-AUDIT-005 v2.0 | Event types registered in AllEventTypes | P0 | Unit | UT-KA-823-A01 | Pending |
+| BR-AUDIT-005 v2.0 | Action constants map to event types | P0 | Unit | UT-KA-823-A02 | Pending |
+| BR-AUDIT-005 v2.0 | buildEventData returns untyped for session events | P1 | Unit | UT-KA-823-A03 | Pending |
+
+---
+
+## 8. Test Scenarios
+
+### Test ID Naming Convention
+
+Format: `{TIER}-KA-823-A{SEQUENCE}` (A prefix distinguishes audit scenarios from PR1 cancellation scenarios)
+
+### Tier 1: Unit Tests
+
+**Testable code scope**: `internal/kubernautagent/audit/emitter.go` — constant definitions and `AllEventTypes` registry.
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| UT-KA-823-A01 | SOC2 auditors can discover all 4 session event types via the AllEventTypes registry | Pending |
+| UT-KA-823-A02 | Each session lifecycle transition has a dedicated action constant for structured querying | Pending |
+| UT-KA-823-A03 | buildEventData gracefully falls through for session events (no panic, returns false) | Pending |
+
+### Tier 2: Integration Tests
+
+**Testable code scope**: `internal/kubernautagent/session/manager.go` — audit emission at lifecycle transitions.
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| IT-KA-823-A01 | When StartInvestigation is called, a `session.started` audit event is emitted with session_id and remediation_id | Pending |
+| IT-KA-823-A02 | When an investigation completes successfully, a `session.completed` audit event is emitted | Pending |
+| IT-KA-823-A03 | When an investigation fails, a `session.failed` audit event is emitted with the error message | Pending |
+| IT-KA-823-A04 | When CancelInvestigation is called, a `session.cancelled` audit event is emitted | Pending |
+| IT-KA-823-A05 | A cancelled investigation does NOT emit a session.completed or session.failed event (no phantom audit) | Pending |
+| IT-KA-823-A06 | All audit events carry remediation_id as CorrelationID, session_id and initiated_by in event data, and EventCategory="aiagent" | Pending |
+| IT-KA-823-A07 | NewManager with nil AuditStore defaults to NopAuditStore; StartInvestigation succeeds without panic | Pending |
+| IT-KA-823-A08 | When AuditStore.StoreAudit returns an error, the investigation continues and completes successfully (fire-and-forget) | Pending |
+
+### Tier Skip Rationale
+
+- **E2E**: Not applicable for PR 1.5 — session audit emission is infrastructure-level; E2E coverage deferred to full v1.5 streaming integration.
+
+---
+
+## 9. Test Cases
+
+### UT-KA-823-A01: Session event types registered in AllEventTypes
+
+**BR**: BR-AUDIT-005 v2.0
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/audit/emitter_test.go`
+
+**Test Steps**:
+1. **Given**: The 4 session event type constants are defined
+2. **When**: AllEventTypes is inspected
+3. **Then**: Each of `aiagent.session.started`, `aiagent.session.cancelled`, `aiagent.session.completed`, `aiagent.session.failed` appears exactly once
+
+**Acceptance Criteria**:
+- All 4 session event types are in AllEventTypes
+- No duplicates in AllEventTypes
+
+### UT-KA-823-A02: Session action constants exist
+
+**BR**: BR-AUDIT-005 v2.0
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/audit/emitter_test.go`
+
+**Test Steps**:
+1. **Given**: Action constants for session lifecycle transitions
+2. **When**: Constants are referenced
+3. **Then**: `ActionSessionStarted`, `ActionSessionCancelled`, `ActionSessionCompleted`, `ActionSessionFailed` are non-empty strings
+
+### UT-KA-823-A03: buildEventData returns untyped for session events
+
+**BR**: BR-AUDIT-005 v2.0
+**Priority**: P1
+**Type**: Unit
+**File**: `test/unit/kubernautagent/audit/ds_store_test.go`
+
+**Test Steps**:
+1. **Given**: An AuditEvent with EventType = `aiagent.session.started`
+2. **When**: `buildEventData` is called
+3. **Then**: Returns `(empty, false)` — no typed payload, graceful fallback
+
+### IT-KA-823-A01: StartInvestigation emits session.started audit event
+
+**BR**: BR-AUDIT-005 v2.0
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/session/manager_audit_test.go`
+
+**Preconditions**:
+- Manager created with spy AuditStore
+- Metadata includes `remediation_id`
+
+**Test Steps**:
+1. **Given**: A Manager with a spy AuditStore
+2. **When**: `StartInvestigation` is called with metadata `{"remediation_id": "rr-123"}`
+3. **Then**: Spy contains exactly 1 event with EventType=`aiagent.session.started`, CorrelationID=`rr-123`, Data["session_id"] is non-empty
+
+### IT-KA-823-A02: Successful investigation emits session.completed
+
+**BR**: BR-AUDIT-005 v2.0
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/session/manager_audit_test.go`
+
+**Preconditions**:
+- Manager with spy AuditStore
+- Investigation function returns success
+
+**Test Steps**:
+1. **Given**: An investigation that returns `("result", nil)`
+2. **When**: The goroutine completes
+3. **Then**: Spy contains a `session.completed` event with `EventOutcome="success"`
+
+### IT-KA-823-A03: Failed investigation emits session.failed
+
+**BR**: BR-AUDIT-005 v2.0
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/session/manager_audit_test.go`
+
+**Preconditions**:
+- Manager with spy AuditStore
+- Investigation function returns error
+
+**Test Steps**:
+1. **Given**: An investigation that returns `(nil, errors.New("timeout"))`
+2. **When**: The goroutine completes
+3. **Then**: Spy contains a `session.failed` event with `EventOutcome="failure"` and Data["error"]="timeout"
+
+### IT-KA-823-A04: CancelInvestigation emits session.cancelled
+
+**BR**: BR-AUDIT-005 v2.0
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/session/manager_audit_test.go`
+
+**Preconditions**:
+- Manager with spy AuditStore
+- Session is in StatusRunning
+
+**Test Steps**:
+1. **Given**: A running investigation
+2. **When**: `CancelInvestigation(id)` is called
+3. **Then**: Spy contains a `session.cancelled` event with `EventOutcome="success"` and matching session_id
+
+### IT-KA-823-A05: Cancelled session does not emit phantom completed/failed
+
+**BR**: BR-AUDIT-005 v2.0
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/session/manager_audit_test.go`
+
+**Preconditions**:
+- Manager with spy AuditStore
+- Session started, then cancelled before goroutine finishes
+
+**Test Steps**:
+1. **Given**: A running investigation blocked on a channel
+2. **When**: `CancelInvestigation` is called, then the goroutine is released
+3. **Then**: Spy contains `session.started` and `session.cancelled` events only; NO `session.completed` or `session.failed`
+
+### IT-KA-823-A06: Audit events carry SOC2 correlation fields
+
+**BR**: SOC2 CC8.1
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/session/manager_audit_test.go`
+
+**Test Steps**:
+1. **Given**: Manager with spy, metadata=`{"remediation_id": "rr-456", "incident_id": "inc-789"}`
+2. **When**: Investigation completes
+3. **Then**: All emitted events have `CorrelationID="rr-456"`, `Data["session_id"]` matches the returned session ID, `EventCategory="aiagent"`
+
+### IT-KA-823-A07: Nil AuditStore defaults to NopAuditStore
+
+**BR**: ADR-038
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/session/manager_audit_test.go`
+
+**Test Steps**:
+1. **Given**: `NewManager(store, logger, nil)` is called
+2. **When**: `StartInvestigation` runs and investigation completes
+3. **Then**: No panic; session reaches StatusCompleted normally
+
+### IT-KA-823-A08: Audit store error does not abort investigation
+
+**BR**: ADR-038
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/session/manager_audit_test.go`
+
+**Preconditions**:
+- Manager with a failing AuditStore (always returns error)
+
+**Test Steps**:
+1. **Given**: AuditStore that returns `errors.New("ds unavailable")`
+2. **When**: Investigation completes successfully
+3. **Then**: Session status is StatusCompleted (not StatusFailed); audit failure logged but investigation not aborted
+
+---
+
+## 10. Environmental Needs
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Mocks**: None — testing constants and pure functions
+- **Location**: `test/unit/kubernautagent/audit/`
+
+### 10.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Mocks**: `spyAuditStore` (implements `audit.AuditStore` interface, records events) — this is a test double for the AuditStore dependency, not a mock of the system under test
+- **Infrastructure**: No external infra needed (in-process Manager + Store)
+- **Location**: `test/integration/kubernautagent/session/`
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Blocking Dependencies
+
+| Dependency | Type | Status | Impact if Not Available | Workaround |
+|------------|------|--------|-------------------------|------------|
+| PR1 cancellation infra (fd15319b6) | Code | Merged to feature branch | All tests blocked | N/A — parent commit |
+
+### 11.2 Execution Order (TDD Phases)
+
+1. **CHECKPOINT 0**: Clean-state verification (build, existing tests, git)
+2. **Phase 1 (RED)**: Write all failing tests (UT-KA-823-A01..A03, IT-KA-823-A01..A08) with minimal stubs
+3. **CHECKPOINT 1A**: Test plan quality gate
+4. **CHECKPOINT 2A**: RED quality gate — verify tests fail for the right reasons
+5. **Phase 2 (GREEN)**: Implement minimal code to pass all tests
+6. **CHECKPOINT 3A**: GREEN quality gate — race detector, regression, adversarial audit
+7. **Phase 3 (REFACTOR)**: GoDoc, logging, documentation (DD-AUDIT-003 v1.9)
+8. **CHECKPOINT 4A**: Final gate — coverage, full audit, commit
+
+---
+
+## 12. Test Deliverables
+
+| Deliverable | Location | Description |
+|-------------|----------|-------------|
+| This test plan | `docs/tests/823/TP-823-AUDIT.md` | Strategy and test design |
+| Unit test suite | `test/unit/kubernautagent/audit/emitter_test.go` | Ginkgo BDD audit constant tests |
+| Integration test suite | `test/integration/kubernautagent/session/manager_audit_test.go` | Ginkgo BDD audit emission tests |
+| DD-AUDIT-003 v1.9 | `docs/architecture/decisions/DD-AUDIT-003-service-audit-trace-requirements.md` | Updated event registry |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests (audit constants)
+go test ./test/unit/kubernautagent/audit/... -ginkgo.v
+
+# Integration tests (manager audit emission)
+go test ./test/integration/kubernautagent/session/... -ginkgo.v
+
+# Focus on audit scenarios only
+go test ./test/integration/kubernautagent/session/... -ginkgo.focus="Audit"
+
+# Coverage (manager.go)
+go test ./test/integration/kubernautagent/session/... -coverprofile=cover.out -coverpkg=github.com/jordigilh/kubernaut/internal/kubernautagent/session
+go tool cover -func=cover.out
+```
+
+---
+
+## 14. Existing Tests Requiring Updates
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|-------------------|-------------------|-----------------|--------|
+| `test/integration/kubernautagent/session/manager_test.go` (all) | `session.NewManager(store, slog.Default())` | `session.NewManager(store, slog.Default(), audit.NopAuditStore{})` | NewManager signature gains `auditStore` parameter |
+| `test/unit/kubernautagent/session/metadata_test.go` (3 sites) | `session.NewManager(store, slog.Default())` | `session.NewManager(store, slog.Default(), nil)` | Nil is safe (F1 guard); minimal change to unrelated tests |
+| `test/unit/kubernautagent/server/adversarial_http_test.go` | `session.NewManager(store, logger)` | `session.NewManager(store, logger, nil)` | Same |
+| `test/unit/kubernautagent/server/response_mapper_test.go` | `session.NewManager(store, logger)` | `session.NewManager(store, logger, nil)` | Same |
+| `cmd/kubernautagent/main.go:267` | `session.NewManager(store, slogger)` | `session.NewManager(store, slogger, auditStore)` | Production wiring |
+
+---
+
+## 15. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-24 | Initial test plan for session lifecycle audit trail |

--- a/internal/kubernautagent/audit/emitter.go
+++ b/internal/kubernautagent/audit/emitter.go
@@ -38,6 +38,11 @@ const (
 	EventTypeEnrichmentFailed    = "aiagent.enrichment.failed"
 	EventTypeAlignmentStep       = "aiagent.alignment.step"
 	EventTypeAlignmentVerdict    = "aiagent.alignment.verdict"
+
+	EventTypeSessionStarted   = "aiagent.session.started"
+	EventTypeSessionCancelled = "aiagent.session.cancelled"
+	EventTypeSessionCompleted = "aiagent.session.completed"
+	EventTypeSessionFailed    = "aiagent.session.failed"
 )
 
 const (
@@ -49,6 +54,11 @@ const (
 	ActionResponseFailed    = "response_failed"
 	ActionAlignmentEvaluate = "alignment_evaluate"
 	ActionAlignmentVerdict  = "alignment_verdict"
+
+	ActionSessionStarted   = "session_started"
+	ActionSessionCancelled = "session_cancelled"
+	ActionSessionCompleted = "session_completed"
+	ActionSessionFailed    = "session_failed"
 )
 
 const (
@@ -70,6 +80,10 @@ var AllEventTypes = []string{
 	EventTypeEnrichmentFailed,
 	EventTypeAlignmentStep,
 	EventTypeAlignmentVerdict,
+	EventTypeSessionStarted,
+	EventTypeSessionCancelled,
+	EventTypeSessionCompleted,
+	EventTypeSessionFailed,
 }
 
 // AuditEvent represents an audit event to be stored.

--- a/internal/kubernautagent/server/handler.go
+++ b/internal/kubernautagent/server/handler.go
@@ -105,7 +105,8 @@ func (h *Handler) IncidentAnalyzeEndpointAPIV1IncidentAnalyzePost(
 	)
 
 	metadata := map[string]string{
-		"incident_id": req.IncidentID,
+		"incident_id":    req.IncidentID,
+		"remediation_id": req.RemediationID,
 	}
 	sessionID, err := h.sessions.StartInvestigation(ctx, func(bgCtx context.Context) (interface{}, error) {
 		return h.investigator.Investigate(bgCtx, signal)

--- a/internal/kubernautagent/session/manager.go
+++ b/internal/kubernautagent/session/manager.go
@@ -19,6 +19,8 @@ package session
 import (
 	"context"
 	"log/slog"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
 )
 
 // InvestigateFunc is the function signature for running an investigation.
@@ -27,13 +29,18 @@ type InvestigateFunc func(ctx context.Context) (interface{}, error)
 // Manager orchestrates investigation sessions, running each in a
 // background goroutine and tracking progress via the Store.
 type Manager struct {
-	store  *Store
-	logger *slog.Logger
+	store      *Store
+	logger     *slog.Logger
+	auditStore audit.AuditStore
 }
 
 // NewManager creates a session manager backed by the given store.
-func NewManager(store *Store, logger *slog.Logger) *Manager {
-	return &Manager{store: store, logger: logger}
+// If auditStore is nil, a NopAuditStore is used (no audit events emitted).
+func NewManager(store *Store, logger *slog.Logger, auditStore audit.AuditStore) *Manager {
+	if auditStore == nil {
+		auditStore = audit.NopAuditStore{}
+	}
+	return &Manager{store: store, logger: logger, auditStore: auditStore}
 }
 
 // eventChannelBuffer is the capacity of the per-session event channel.
@@ -49,7 +56,11 @@ const eventChannelBuffer = 64
 // The goroutine uses a cancellable child of context.Background() to ensure
 // the investigation outlives the originating HTTP request while remaining
 // cancellable via CancelInvestigation.
-func (m *Manager) StartInvestigation(_ context.Context, fn InvestigateFunc, metadata map[string]string) (string, error) {
+//
+// Audit: emits aiagent.session.started after the session transitions to
+// StatusRunning, and aiagent.session.completed or aiagent.session.failed
+// when the goroutine finishes. Audit errors are fire-and-forget (ADR-038).
+func (m *Manager) StartInvestigation(ctx context.Context, fn InvestigateFunc, metadata map[string]string) (string, error) {
 	id, err := m.store.Create()
 	if err != nil {
 		return "", err
@@ -68,6 +79,9 @@ func (m *Manager) StartInvestigation(_ context.Context, fn InvestigateFunc, meta
 
 	_ = m.store.Update(id, StatusRunning, nil, nil)
 
+	correlationID := metadata["remediation_id"]
+	m.emitSessionEvent(ctx, audit.EventTypeSessionStarted, audit.ActionSessionStarted, audit.OutcomeSuccess, id, correlationID, nil)
+
 	go func() {
 		defer m.closeEventChan(id)
 		result, fnErr := fn(bgCtx)
@@ -80,10 +94,19 @@ func (m *Manager) StartInvestigation(_ context.Context, fn InvestigateFunc, meta
 					slog.String("session_id", id),
 					slog.String("attempted_status", string(StatusFailed)),
 					slog.String("reason", updateErr.Error()))
+			} else {
+				m.emitSessionEvent(context.Background(), audit.EventTypeSessionFailed, audit.ActionSessionFailed, audit.OutcomeFailure, id, correlationID, fnErr)
 			}
 			return
 		}
-		_ = m.store.Update(id, StatusCompleted, result, nil)
+		if updateErr := m.store.Update(id, StatusCompleted, result, nil); updateErr != nil {
+			m.logger.Info("post-investigation status update rejected",
+				slog.String("session_id", id),
+				slog.String("attempted_status", string(StatusCompleted)),
+				slog.String("reason", updateErr.Error()))
+		} else {
+			m.emitSessionEvent(context.Background(), audit.EventTypeSessionCompleted, audit.ActionSessionCompleted, audit.OutcomeSuccess, id, correlationID, nil)
+		}
 	}()
 
 	return id, nil
@@ -93,21 +116,28 @@ func (m *Manager) StartInvestigation(_ context.Context, fn InvestigateFunc, meta
 // and transitioning its status to StatusCancelled. Returns ErrSessionNotFound
 // if the session does not exist, or ErrSessionTerminal if it has already
 // reached a terminal state.
+//
+// Audit: emits aiagent.session.cancelled after the status transition succeeds.
 func (m *Manager) CancelInvestigation(id string) error {
 	m.store.mu.Lock()
-	defer m.store.mu.Unlock()
 
 	sess, ok := m.store.sessions[id]
 	if !ok {
+		m.store.mu.Unlock()
 		return ErrSessionNotFound
 	}
 	if isTerminal(sess.Status) {
+		m.store.mu.Unlock()
 		return ErrSessionTerminal
 	}
 	if sess.cancel != nil {
 		sess.cancel()
 	}
 	sess.Status = StatusCancelled
+	correlationID := sess.Metadata["remediation_id"]
+	m.store.mu.Unlock()
+
+	m.emitSessionEvent(context.Background(), audit.EventTypeSessionCancelled, audit.ActionSessionCancelled, audit.OutcomeSuccess, id, correlationID, nil)
 	return nil
 }
 
@@ -149,4 +179,17 @@ func (m *Manager) closeEventChan(id string) {
 // GetSession retrieves the current state of an investigation session.
 func (m *Manager) GetSession(id string) (*Session, error) {
 	return m.store.Get(id)
+}
+
+// emitSessionEvent builds and stores an audit event for a session lifecycle
+// transition. Errors are fire-and-forget per ADR-038.
+func (m *Manager) emitSessionEvent(ctx context.Context, eventType, action, outcome, sessionID, correlationID string, fnErr error) {
+	event := audit.NewEvent(eventType, correlationID)
+	event.EventAction = action
+	event.EventOutcome = outcome
+	event.Data["session_id"] = sessionID
+	if fnErr != nil {
+		event.Data["error"] = fnErr.Error()
+	}
+	audit.StoreBestEffort(ctx, m.auditStore, event, m.logger)
 }

--- a/internal/kubernautagent/session/manager.go
+++ b/internal/kubernautagent/session/manager.go
@@ -36,13 +36,19 @@ func NewManager(store *Store, logger *slog.Logger) *Manager {
 	return &Manager{store: store, logger: logger}
 }
 
+// eventChannelBuffer is the capacity of the per-session event channel.
+// 64 provides headroom for bursty LLM output (reasoning deltas + tool calls)
+// without blocking the investigation goroutine. Non-blocking send semantics
+// are deferred to PR 4 when events are actively written.
+const eventChannelBuffer = 64
+
 // StartInvestigation creates a new session and launches the investigation
 // function in a background goroutine. Returns the session ID immediately.
 // metadata is stored on the session for later retrieval (e.g., incident_id).
 //
-// The goroutine uses context.Background() to ensure the investigation outlives
-// the originating HTTP request. The incoming ctx is NOT propagated because the
-// request context is cancelled as soon as the 202 response is sent.
+// The goroutine uses a cancellable child of context.Background() to ensure
+// the investigation outlives the originating HTTP request while remaining
+// cancellable via CancelInvestigation.
 func (m *Manager) StartInvestigation(_ context.Context, fn InvestigateFunc, metadata map[string]string) (string, error) {
 	id, err := m.store.Create()
 	if err != nil {
@@ -51,20 +57,93 @@ func (m *Manager) StartInvestigation(_ context.Context, fn InvestigateFunc, meta
 	if metadata != nil {
 		m.store.SetMetadata(id, metadata)
 	}
+
+	bgCtx, cancelFn := context.WithCancel(context.Background())
+
+	m.store.mu.Lock()
+	sess := m.store.sessions[id]
+	sess.cancel = cancelFn
+	sess.eventChan = make(chan InvestigationEvent, eventChannelBuffer)
+	m.store.mu.Unlock()
+
 	_ = m.store.Update(id, StatusRunning, nil, nil)
 
 	go func() {
-		bgCtx := context.Background()
+		defer m.closeEventChan(id)
 		result, fnErr := fn(bgCtx)
 		if fnErr != nil {
-			m.logger.Error("investigation failed", slog.String("session_id", id), slog.String("error", fnErr.Error()))
-			_ = m.store.Update(id, StatusFailed, nil, fnErr)
+			m.logger.Error("investigation failed",
+				slog.String("session_id", id),
+				slog.String("error", fnErr.Error()))
+			if updateErr := m.store.Update(id, StatusFailed, nil, fnErr); updateErr != nil {
+				m.logger.Info("post-investigation status update rejected",
+					slog.String("session_id", id),
+					slog.String("attempted_status", string(StatusFailed)),
+					slog.String("reason", updateErr.Error()))
+			}
 			return
 		}
 		_ = m.store.Update(id, StatusCompleted, result, nil)
 	}()
 
 	return id, nil
+}
+
+// CancelInvestigation stops a running investigation by cancelling its context
+// and transitioning its status to StatusCancelled. Returns ErrSessionNotFound
+// if the session does not exist, or ErrSessionTerminal if it has already
+// reached a terminal state.
+func (m *Manager) CancelInvestigation(id string) error {
+	m.store.mu.Lock()
+	defer m.store.mu.Unlock()
+
+	sess, ok := m.store.sessions[id]
+	if !ok {
+		return ErrSessionNotFound
+	}
+	if isTerminal(sess.Status) {
+		return ErrSessionTerminal
+	}
+	if sess.cancel != nil {
+		sess.cancel()
+	}
+	sess.Status = StatusCancelled
+	return nil
+}
+
+// Subscribe returns a read-only channel that delivers investigation events
+// for the given session. The channel is closed when the investigation ends.
+// Returns ErrSessionNotFound if the session does not exist, or
+// ErrSessionTerminal if the investigation has already concluded.
+func (m *Manager) Subscribe(id string) (<-chan InvestigationEvent, error) {
+	m.store.mu.RLock()
+	defer m.store.mu.RUnlock()
+
+	sess, ok := m.store.sessions[id]
+	if !ok {
+		return nil, ErrSessionNotFound
+	}
+	if sess.eventChan == nil {
+		return nil, ErrSessionTerminal
+	}
+	return sess.eventChan, nil
+}
+
+// closeEventChan closes the event channel for a session and sets it to nil,
+// signaling to observers that the investigation has concluded. The nil-check
+// guard prevents double-close panics.
+func (m *Manager) closeEventChan(id string) {
+	m.store.mu.Lock()
+	defer m.store.mu.Unlock()
+
+	sess, ok := m.store.sessions[id]
+	if !ok {
+		return
+	}
+	if sess.eventChan != nil {
+		close(sess.eventChan)
+		sess.eventChan = nil
+	}
 }
 
 // GetSession retrieves the current state of an investigation session.

--- a/internal/kubernautagent/session/store.go
+++ b/internal/kubernautagent/session/store.go
@@ -33,6 +33,8 @@ const (
 	StatusRunning   Status = "running"
 	StatusCompleted Status = "completed"
 	StatusFailed    Status = "failed"
+	// StatusCancelled indicates an operator explicitly cancelled the investigation.
+	StatusCancelled Status = "cancelled"
 )
 
 // Session holds the state of a single investigation session.
@@ -43,10 +45,19 @@ type Session struct {
 	Error     error
 	CreatedAt time.Time
 	Metadata  map[string]string
+
+	// cancel and eventChan are manager-managed internal fields.
+	// They are NOT part of the public copy surface (clone excludes them).
+	cancel    context.CancelFunc
+	eventChan chan InvestigationEvent
 }
 
 // ErrSessionNotFound is returned when a session ID does not exist in the store.
 var ErrSessionNotFound = errors.New("session not found")
+
+// ErrSessionTerminal is returned when an operation is attempted on a session
+// that has already reached a terminal state (completed, cancelled, or failed).
+var ErrSessionTerminal = errors.New("session is in terminal state")
 
 // Store provides thread-safe session storage with TTL-based cleanup.
 type Store struct {
@@ -89,8 +100,13 @@ func (s *Store) Get(id string) (*Session, error) {
 	return sess.clone(), nil
 }
 
+// clone returns an isolated copy of the session. Internal control fields
+// (cancel, eventChan) are excluded to prevent callers from interfering
+// with active investigations.
 func (s *Session) clone() *Session {
 	cp := *s
+	cp.cancel = nil
+	cp.eventChan = nil
 	if s.Metadata != nil {
 		cp.Metadata = make(map[string]string, len(s.Metadata))
 		for k, v := range s.Metadata {
@@ -98,6 +114,12 @@ func (s *Session) clone() *Session {
 		}
 	}
 	return &cp
+}
+
+// isTerminal reports whether the given status represents a final state
+// that cannot be changed.
+func isTerminal(st Status) bool {
+	return st == StatusCompleted || st == StatusFailed || st == StatusCancelled
 }
 
 // SetMetadata stores request-level metadata on an existing session.
@@ -109,13 +131,17 @@ func (s *Store) SetMetadata(id string, metadata map[string]string) {
 	}
 }
 
-// Update modifies an existing session.
+// Update modifies an existing session. Returns ErrSessionTerminal if the
+// session has already reached a terminal state (completed, cancelled, failed).
 func (s *Store) Update(id string, status Status, result interface{}, err error) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	sess, ok := s.sessions[id]
 	if !ok {
 		return ErrSessionNotFound
+	}
+	if isTerminal(sess.Status) {
+		return ErrSessionTerminal
 	}
 	sess.Status = status
 	sess.Result = result
@@ -140,6 +166,7 @@ func (s *Store) StartCleanupLoop(ctx context.Context, interval time.Duration) {
 }
 
 // Cleanup removes sessions older than the configured TTL.
+// Running sessions are never removed regardless of age.
 // Returns the number of sessions removed.
 func (s *Store) Cleanup() int {
 	cutoff := time.Now().Add(-s.ttl)
@@ -147,6 +174,9 @@ func (s *Store) Cleanup() int {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	for id, sess := range s.sessions {
+		if sess.Status == StatusRunning {
+			continue
+		}
 		if sess.CreatedAt.Before(cutoff) {
 			delete(s.sessions, id)
 			removed++

--- a/internal/kubernautagent/session/types.go
+++ b/internal/kubernautagent/session/types.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session
+
+// InvestigationEvent represents a discrete event emitted during an
+// investigation session. Event types are runtime-agnostic to provide a
+// stable SSE contract across runtime migrations (LangChainGo -> Goose ACP).
+//
+// Goose ACP mapping (future):
+//   - EventTypeReasoningDelta -> acp.StreamEvent with kind="reasoning"
+//   - EventTypeToolCall       -> acp.StreamEvent with kind="tool_use"
+//   - EventTypeToolResult     -> acp.StreamEvent with kind="tool_result"
+//   - EventTypeError          -> acp.StreamEvent with kind="error"
+//   - EventTypeComplete       -> acp.StreamEvent with kind="end"
+type InvestigationEvent struct {
+	Type    string      `json:"type"`
+	Payload interface{} `json:"payload,omitempty"`
+}
+
+// Event type constants for investigation lifecycle events.
+// These are wire-format values sent over SSE to observers.
+const (
+	EventTypeReasoningDelta = "reasoning_delta"
+	EventTypeToolCall       = "tool_call"
+	EventTypeToolResult     = "tool_result"
+	EventTypeError          = "error"
+	EventTypeComplete       = "complete"
+)

--- a/test/integration/kubernautagent/session/manager_audit_test.go
+++ b/test/integration/kubernautagent/session/manager_audit_test.go
@@ -1,0 +1,305 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session_test
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+)
+
+type spyAuditStore struct {
+	mu     sync.Mutex
+	events []*audit.AuditEvent
+}
+
+func (s *spyAuditStore) StoreAudit(_ context.Context, event *audit.AuditEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, event)
+	return nil
+}
+
+func (s *spyAuditStore) getEvents() []*audit.AuditEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make([]*audit.AuditEvent, len(s.events))
+	copy(cp, s.events)
+	return cp
+}
+
+func (s *spyAuditStore) eventsOfType(eventType string) []*audit.AuditEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var result []*audit.AuditEvent
+	for _, e := range s.events {
+		if e.EventType == eventType {
+			result = append(result, e)
+		}
+	}
+	return result
+}
+
+type failingAuditStore struct {
+	mu     sync.Mutex
+	calls  int
+}
+
+func (f *failingAuditStore) StoreAudit(_ context.Context, _ *audit.AuditEvent) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls++
+	return errors.New("ds unavailable")
+}
+
+func (f *failingAuditStore) callCount() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.calls
+}
+
+var _ = Describe("Kubernaut Agent Session Audit Trail — #823 PR 1.5", func() {
+
+	var (
+		store *session.Store
+		spy   *spyAuditStore
+		mgr   *session.Manager
+	)
+
+	BeforeEach(func() {
+		store = session.NewStore(5 * time.Minute)
+		spy = &spyAuditStore{}
+		mgr = session.NewManager(store, slog.Default(), spy)
+	})
+
+	Describe("IT-KA-823-A01: StartInvestigation emits session.started audit event", func() {
+		It("should emit a session.started event with session_id and remediation_id", func() {
+			metadata := map[string]string{
+				"remediation_id": "rr-123",
+				"incident_id":    "inc-456",
+			}
+			id, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				return "result", nil
+			}, metadata)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(id).NotTo(BeEmpty())
+
+			Eventually(func() []*audit.AuditEvent {
+				return spy.eventsOfType(audit.EventTypeSessionStarted)
+			}, 2*time.Second, 10*time.Millisecond).Should(HaveLen(1))
+
+			started := spy.eventsOfType(audit.EventTypeSessionStarted)[0]
+			Expect(started.CorrelationID).To(Equal("rr-123"))
+			Expect(started.Data).To(HaveKeyWithValue("session_id", id))
+			Expect(started.EventAction).To(Equal(audit.ActionSessionStarted))
+			Expect(started.EventCategory).To(Equal(audit.EventCategory))
+		})
+	})
+
+	Describe("IT-KA-823-A02: Successful investigation emits session.completed", func() {
+		It("should emit a session.completed event with outcome=success", func() {
+			metadata := map[string]string{"remediation_id": "rr-complete"}
+			_, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				return "done", nil
+			}, metadata)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() []*audit.AuditEvent {
+				return spy.eventsOfType(audit.EventTypeSessionCompleted)
+			}, 2*time.Second, 10*time.Millisecond).Should(HaveLen(1))
+
+			completed := spy.eventsOfType(audit.EventTypeSessionCompleted)[0]
+			Expect(completed.CorrelationID).To(Equal("rr-complete"))
+			Expect(completed.EventOutcome).To(Equal(audit.OutcomeSuccess))
+			Expect(completed.EventAction).To(Equal(audit.ActionSessionCompleted))
+		})
+	})
+
+	Describe("IT-KA-823-A03: Failed investigation emits session.failed", func() {
+		It("should emit a session.failed event with outcome=failure and error detail", func() {
+			metadata := map[string]string{"remediation_id": "rr-fail"}
+			_, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				return nil, errors.New("llm timeout")
+			}, metadata)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() []*audit.AuditEvent {
+				return spy.eventsOfType(audit.EventTypeSessionFailed)
+			}, 2*time.Second, 10*time.Millisecond).Should(HaveLen(1))
+
+			failed := spy.eventsOfType(audit.EventTypeSessionFailed)[0]
+			Expect(failed.CorrelationID).To(Equal("rr-fail"))
+			Expect(failed.EventOutcome).To(Equal(audit.OutcomeFailure))
+			Expect(failed.EventAction).To(Equal(audit.ActionSessionFailed))
+			Expect(failed.Data).To(HaveKeyWithValue("error", "llm timeout"))
+		})
+	})
+
+	Describe("IT-KA-823-A04: CancelInvestigation emits session.cancelled", func() {
+		It("should emit a session.cancelled event when a running investigation is cancelled", func() {
+			metadata := map[string]string{"remediation_id": "rr-cancel"}
+			proceed := make(chan struct{})
+			id, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				<-proceed
+				return nil, ctx.Err()
+			}, metadata)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				sess, _ := mgr.GetSession(id)
+				if sess == nil {
+					return ""
+				}
+				return sess.Status
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(session.StatusRunning))
+
+			Expect(mgr.CancelInvestigation(id)).To(Succeed())
+			close(proceed)
+
+			Eventually(func() []*audit.AuditEvent {
+				return spy.eventsOfType(audit.EventTypeSessionCancelled)
+			}, 2*time.Second, 10*time.Millisecond).Should(HaveLen(1))
+
+			cancelled := spy.eventsOfType(audit.EventTypeSessionCancelled)[0]
+			Expect(cancelled.CorrelationID).To(Equal("rr-cancel"))
+			Expect(cancelled.EventOutcome).To(Equal(audit.OutcomeSuccess))
+			Expect(cancelled.EventAction).To(Equal(audit.ActionSessionCancelled))
+			Expect(cancelled.Data).To(HaveKeyWithValue("session_id", id))
+		})
+	})
+
+	Describe("IT-KA-823-A05: Cancelled session does not emit phantom completed/failed", func() {
+		It("should only emit started and cancelled, not completed or failed", func() {
+			metadata := map[string]string{"remediation_id": "rr-phantom"}
+			proceed := make(chan struct{})
+			id, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				<-proceed
+				return nil, ctx.Err()
+			}, metadata)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				sess, _ := mgr.GetSession(id)
+				if sess == nil {
+					return ""
+				}
+				return sess.Status
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(session.StatusRunning))
+
+			Expect(mgr.CancelInvestigation(id)).To(Succeed())
+			close(proceed)
+
+			// Wait for goroutine to finish
+			Eventually(func() bool {
+				_, subErr := mgr.Subscribe(id)
+				return errors.Is(subErr, session.ErrSessionTerminal)
+			}, 2*time.Second, 10*time.Millisecond).Should(BeTrue())
+
+			// Allow any pending audit events to be emitted
+			time.Sleep(50 * time.Millisecond)
+
+			events := spy.getEvents()
+			for _, e := range events {
+				Expect(e.EventType).NotTo(Equal(audit.EventTypeSessionCompleted),
+					"cancelled session should not emit session.completed")
+				Expect(e.EventType).NotTo(Equal(audit.EventTypeSessionFailed),
+					"cancelled session should not emit session.failed")
+			}
+
+			Expect(spy.eventsOfType(audit.EventTypeSessionStarted)).To(HaveLen(1))
+			Expect(spy.eventsOfType(audit.EventTypeSessionCancelled)).To(HaveLen(1))
+		})
+	})
+
+	Describe("IT-KA-823-A06: Audit events carry SOC2 correlation fields", func() {
+		It("should include remediation_id as CorrelationID and session_id in event data", func() {
+			metadata := map[string]string{
+				"remediation_id": "rr-soc2-456",
+				"incident_id":    "inc-soc2-789",
+			}
+			id, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				return "soc2-ok", nil
+			}, metadata)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() []*audit.AuditEvent {
+				return spy.eventsOfType(audit.EventTypeSessionCompleted)
+			}, 2*time.Second, 10*time.Millisecond).Should(HaveLen(1))
+
+			for _, event := range spy.getEvents() {
+				Expect(event.CorrelationID).To(Equal("rr-soc2-456"),
+					"all events should have remediation_id as CorrelationID, got type: %s", event.EventType)
+				Expect(event.Data).To(HaveKeyWithValue("session_id", id),
+					"all events should carry session_id in data, got type: %s", event.EventType)
+				Expect(event.EventCategory).To(Equal(audit.EventCategory),
+					"all events should have EventCategory=aiagent, got type: %s", event.EventType)
+			}
+		})
+	})
+
+	Describe("IT-KA-823-A07: Nil AuditStore defaults to NopAuditStore", func() {
+		It("should not panic when AuditStore is nil", func() {
+			nilStore := session.NewStore(5 * time.Minute)
+			nilMgr := session.NewManager(nilStore, slog.Default(), nil)
+
+			id, err := nilMgr.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				return "safe", nil
+			}, map[string]string{"remediation_id": "rr-nil"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(id).NotTo(BeEmpty())
+
+			Eventually(func() session.Status {
+				sess, _ := nilMgr.GetSession(id)
+				if sess == nil {
+					return ""
+				}
+				return sess.Status
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(session.StatusCompleted))
+		})
+	})
+
+	Describe("IT-KA-823-A08: Audit store error does not abort investigation", func() {
+		It("should complete the investigation even when audit store fails", func() {
+			failStore := &failingAuditStore{}
+			failMgr := session.NewManager(session.NewStore(5*time.Minute), slog.Default(), failStore)
+
+			id, err := failMgr.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				return "resilient", nil
+			}, map[string]string{"remediation_id": "rr-fail-audit"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				sess, _ := failMgr.GetSession(id)
+				if sess == nil {
+					return ""
+				}
+				return sess.Status
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(session.StatusCompleted))
+
+			Expect(failStore.callCount()).To(BeNumerically(">", 0),
+				"audit store should have been called at least once")
+		})
+	})
+})

--- a/test/integration/kubernautagent/session/manager_test.go
+++ b/test/integration/kubernautagent/session/manager_test.go
@@ -115,3 +115,237 @@ var _ = Describe("Kubernaut Agent Session Manager — #433", func() {
 		})
 	})
 })
+
+var _ = Describe("Session Cancellation Infrastructure — #823", func() {
+
+	var (
+		store   *session.Store
+		manager *session.Manager
+	)
+
+	BeforeEach(func() {
+		store = session.NewStore(5 * time.Minute)
+		manager = session.NewManager(store, slog.Default())
+	})
+
+	Describe("IT-KA-823-001: Cancelling an investigation stops the running LLM analysis", func() {
+		It("should propagate cancellation and transition to cancelled", func() {
+			cancelled := make(chan struct{})
+
+			id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				<-ctx.Done()
+				close(cancelled)
+				return nil, ctx.Err()
+			}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				sess, _ := manager.GetSession(id)
+				if sess == nil {
+					return ""
+				}
+				return sess.Status
+			}, 1*time.Second, 10*time.Millisecond).Should(Equal(session.StatusRunning))
+
+			err = manager.CancelInvestigation(id)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(cancelled, 2*time.Second).Should(BeClosed(),
+				"investigation function should receive context cancellation")
+
+			Eventually(func() session.Status {
+				sess, _ := manager.GetSession(id)
+				if sess == nil {
+					return ""
+				}
+				return sess.Status
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(session.StatusCancelled))
+		})
+	})
+
+	Describe("IT-KA-823-002: Cancelling a nonexistent investigation returns a clear error", func() {
+		It("should return ErrSessionNotFound for unknown session ID", func() {
+			err := manager.CancelInvestigation("nonexistent-id")
+			Expect(err).To(MatchError(session.ErrSessionNotFound))
+		})
+	})
+
+	Describe("IT-KA-823-003: Cancelling an already-completed investigation returns a clear error", func() {
+		It("should return ErrSessionTerminal for a completed session", func() {
+			id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				return "result", nil
+			}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				sess, _ := manager.GetSession(id)
+				if sess == nil {
+					return ""
+				}
+				return sess.Status
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(session.StatusCompleted))
+
+			err = manager.CancelInvestigation(id)
+			Expect(err).To(MatchError(session.ErrSessionTerminal))
+		})
+	})
+
+	Describe("IT-KA-823-004: After cancellation, the investigation cannot retroactively report failure", func() {
+		It("should keep StatusCancelled even when goroutine returns an error", func() {
+			started := make(chan struct{})
+
+			id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				close(started)
+				<-ctx.Done()
+				return nil, errors.New("investigation aborted")
+			}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(started, 1*time.Second).Should(BeClosed())
+			Eventually(func() session.Status {
+				sess, _ := manager.GetSession(id)
+				if sess == nil {
+					return ""
+				}
+				return sess.Status
+			}, 1*time.Second, 10*time.Millisecond).Should(Equal(session.StatusRunning))
+
+			err = manager.CancelInvestigation(id)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				sess, _ := manager.GetSession(id)
+				if sess == nil {
+					return ""
+				}
+				return sess.Status
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(session.StatusCancelled))
+
+			Consistently(func() session.Status {
+				sess, _ := manager.GetSession(id)
+				if sess == nil {
+					return ""
+				}
+				return sess.Status
+			}, 200*time.Millisecond, 20*time.Millisecond).Should(Equal(session.StatusCancelled),
+				"status must remain cancelled, not transition to failed")
+		})
+	})
+
+	Describe("IT-KA-823-005: An observer can receive live events from an active investigation", func() {
+		It("should return a readable event channel for a running investigation", func() {
+			id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				sess, _ := manager.GetSession(id)
+				if sess == nil {
+					return ""
+				}
+				return sess.Status
+			}, 1*time.Second, 10*time.Millisecond).Should(Equal(session.StatusRunning))
+
+			ch, err := manager.Subscribe(id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ch).NotTo(BeNil(), "event channel must be non-nil for a running investigation")
+
+			Expect(manager.CancelInvestigation(id)).To(Succeed())
+		})
+	})
+
+	Describe("IT-KA-823-006: Multiple subscriptions share a single event stream", func() {
+		It("should return the same channel on repeated subscribe calls", func() {
+			id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				sess, _ := manager.GetSession(id)
+				if sess == nil {
+					return ""
+				}
+				return sess.Status
+			}, 1*time.Second, 10*time.Millisecond).Should(Equal(session.StatusRunning))
+
+			ch1, err := manager.Subscribe(id)
+			Expect(err).NotTo(HaveOccurred())
+			ch2, err := manager.Subscribe(id)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(ch1).To(BeIdenticalTo(ch2),
+				"repeated subscriptions must return the same channel")
+
+			Expect(manager.CancelInvestigation(id)).To(Succeed())
+		})
+	})
+
+	Describe("IT-KA-823-007: Observers are notified when an investigation concludes", func() {
+		It("should close the event channel when the investigation function returns", func() {
+			proceed := make(chan struct{})
+
+			id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				<-proceed
+				return "done", nil
+			}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				sess, _ := manager.GetSession(id)
+				if sess == nil {
+					return ""
+				}
+				return sess.Status
+			}, 1*time.Second, 10*time.Millisecond).Should(Equal(session.StatusRunning))
+
+			ch, err := manager.Subscribe(id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ch).NotTo(BeNil())
+
+			close(proceed)
+
+			Eventually(func() bool {
+				select {
+				case _, ok := <-ch:
+					return !ok
+				default:
+					return false
+				}
+			}, 2*time.Second, 10*time.Millisecond).Should(BeTrue(),
+				"event channel should be closed when investigation completes")
+		})
+	})
+
+	Describe("IT-KA-823-008: Subscribing to a nonexistent investigation returns a clear error", func() {
+		It("should return ErrSessionNotFound for unknown session ID", func() {
+			ch, err := manager.Subscribe("nonexistent-id")
+			Expect(err).To(MatchError(session.ErrSessionNotFound))
+			Expect(ch).To(BeNil())
+		})
+	})
+
+	Describe("IT-KA-823-009: Subscribing to a concluded investigation returns a clear error", func() {
+		It("should return ErrSessionTerminal after the investigation has completed", func() {
+			id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				return "result", nil
+			}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				sess, _ := manager.GetSession(id)
+				if sess == nil {
+					return ""
+				}
+				return sess.Status
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(session.StatusCompleted))
+
+			ch, err := manager.Subscribe(id)
+			Expect(err).To(MatchError(session.ErrSessionTerminal))
+			Expect(ch).To(BeNil())
+		})
+	})
+})

--- a/test/integration/kubernautagent/session/manager_test.go
+++ b/test/integration/kubernautagent/session/manager_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
 )
 
@@ -37,7 +38,7 @@ var _ = Describe("Kubernaut Agent Session Manager — #433", func() {
 
 	BeforeEach(func() {
 		store = session.NewStore(5 * time.Minute)
-		manager = session.NewManager(store, slog.Default())
+		manager = session.NewManager(store, slog.Default(), audit.NopAuditStore{})
 	})
 
 	Describe("IT-KA-433-001: Session manager starts background investigation", func() {
@@ -125,7 +126,7 @@ var _ = Describe("Session Cancellation Infrastructure — #823", func() {
 
 	BeforeEach(func() {
 		store = session.NewStore(5 * time.Minute)
-		manager = session.NewManager(store, slog.Default())
+		manager = session.NewManager(store, slog.Default(), audit.NopAuditStore{})
 	})
 
 	Describe("IT-KA-823-001: Cancelling an investigation stops the running LLM analysis", func() {

--- a/test/unit/kubernautagent/audit/emitter_test.go
+++ b/test/unit/kubernautagent/audit/emitter_test.go
@@ -65,9 +65,61 @@ var _ = Describe("Kubernaut Agent Audit Emitter — #433", func() {
 			Entry("aiagent.alignment.verdict", audit.EventTypeAlignmentVerdict),
 		)
 
-		It("should define exactly 11 event types", func() {
-			Expect(audit.AllEventTypes).To(HaveLen(11))
+		It("should define exactly 15 event types", func() {
+			Expect(audit.AllEventTypes).To(HaveLen(15))
 		})
+	})
+
+	Describe("UT-KA-823-A01: Session event types registered in AllEventTypes", func() {
+		It("should include all 4 session lifecycle event types", func() {
+			sessionTypes := []string{
+				audit.EventTypeSessionStarted,
+				audit.EventTypeSessionCancelled,
+				audit.EventTypeSessionCompleted,
+				audit.EventTypeSessionFailed,
+			}
+			for _, et := range sessionTypes {
+				Expect(audit.AllEventTypes).To(ContainElement(et),
+					"AllEventTypes should contain %s", et)
+			}
+		})
+
+		It("should have no duplicates in AllEventTypes", func() {
+			seen := make(map[string]bool)
+			for _, et := range audit.AllEventTypes {
+				Expect(seen[et]).To(BeFalse(), "duplicate event type: %s", et)
+				seen[et] = true
+			}
+		})
+	})
+
+	Describe("UT-KA-823-A02: Session action constants are non-empty", func() {
+		DescribeTable("should have non-empty action for each session lifecycle transition",
+			func(action string) {
+				Expect(action).NotTo(BeEmpty())
+			},
+			Entry("started", audit.ActionSessionStarted),
+			Entry("cancelled", audit.ActionSessionCancelled),
+			Entry("completed", audit.ActionSessionCompleted),
+			Entry("failed", audit.ActionSessionFailed),
+		)
+	})
+
+	Describe("UT-KA-823-A03: NewEvent produces correct fields for session events", func() {
+		DescribeTable("should create correct audit event for session event types",
+			func(eventType string) {
+				event := audit.NewEvent(eventType, "rr-audit-test")
+				Expect(event).NotTo(BeNil())
+				Expect(event.EventType).To(Equal(eventType))
+				Expect(event.EventCategory).To(Equal(audit.EventCategory))
+				Expect(event.CorrelationID).To(Equal("rr-audit-test"))
+				Expect(event.Data).To(HaveKey("event_id"))
+			},
+			Entry("session.started", audit.EventTypeSessionStarted),
+			Entry("session.cancelled", audit.EventTypeSessionCancelled),
+			Entry("session.completed", audit.EventTypeSessionCompleted),
+			Entry("session.failed", audit.EventTypeSessionFailed),
+		)
 	})
 
 	Describe("UT-KA-433-013: Audit best-effort helper does not propagate errors", func() {

--- a/test/unit/kubernautagent/server/adversarial_http_test.go
+++ b/test/unit/kubernautagent/server/adversarial_http_test.go
@@ -44,7 +44,7 @@ var _ = Describe("TP-433-ADV P6: HTTP Contract — GAP-004/015/016/018", func() 
 	BeforeEach(func() {
 		store = session.NewStore(5 * time.Minute)
 		logger = slog.Default()
-		manager = session.NewManager(store, logger)
+		manager = session.NewManager(store, logger, nil)
 		handler = server.NewHandler(manager, nil, logger)
 	})
 

--- a/test/unit/kubernautagent/server/response_mapper_test.go
+++ b/test/unit/kubernautagent/server/response_mapper_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Response Mapper — #433", func() {
 	BeforeEach(func() {
 		store = session.NewStore(5 * time.Minute)
 		logger = slog.Default()
-		manager = session.NewManager(store, logger)
+		manager = session.NewManager(store, logger, nil)
 		handler = server.NewHandler(manager, nil, logger)
 	})
 

--- a/test/unit/kubernautagent/session/metadata_test.go
+++ b/test/unit/kubernautagent/session/metadata_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Session Metadata — #433", func() {
 	Describe("UT-KA-433-METADATA-001: StartInvestigation propagates metadata to session", func() {
 		It("should store metadata on the session and make it retrievable", func() {
 			store := session.NewStore(5 * time.Minute)
-			manager := session.NewManager(store, slog.Default())
+			manager := session.NewManager(store, slog.Default(), nil)
 
 			metadata := map[string]string{
 				"incident_id": "e2e-ka-001-oom",
@@ -55,7 +55,7 @@ var _ = Describe("Session Metadata — #433", func() {
 	Describe("UT-KA-433-METADATA-002: Metadata persists after investigation completes", func() {
 		It("should retain metadata on a completed session", func() {
 			store := session.NewStore(5 * time.Minute)
-			manager := session.NewManager(store, slog.Default())
+			manager := session.NewManager(store, slog.Default(), nil)
 
 			metadata := map[string]string{
 				"incident_id": "e2e-ka-002-crash",
@@ -84,7 +84,7 @@ var _ = Describe("Session Metadata — #433", func() {
 	Describe("UT-KA-433-METADATA-003: Nil metadata does not cause issues", func() {
 		It("should handle nil metadata gracefully", func() {
 			store := session.NewStore(5 * time.Minute)
-			manager := session.NewManager(store, slog.Default())
+			manager := session.NewManager(store, slog.Default(), nil)
 
 			id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
 				return "result", nil

--- a/test/unit/kubernautagent/session/store_test.go
+++ b/test/unit/kubernautagent/session/store_test.go
@@ -18,6 +18,7 @@ package session_test
 
 import (
 	"context"
+	"reflect"
 	"sync"
 	"time"
 
@@ -142,6 +143,129 @@ var _ = Describe("Kubernaut Agent Session Store — #433", func() {
 			}
 
 			wg.Wait()
+		})
+	})
+})
+
+var _ = Describe("Session Cancellation Infrastructure — #823", func() {
+
+	Describe("UT-KA-823-001: A completed investigation is immutable", func() {
+		It("should reject status changes on a completed investigation", func() {
+			store := session.NewStore(30 * time.Minute)
+			id, err := store.Create()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(store.Update(id, session.StatusRunning, nil, nil)).To(Succeed())
+			Expect(store.Update(id, session.StatusCompleted, "done", nil)).To(Succeed())
+
+			err = store.Update(id, session.StatusRunning, nil, nil)
+			Expect(err).To(MatchError(session.ErrSessionTerminal))
+
+			sess, err := store.Get(id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sess.Status).To(Equal(session.StatusCompleted))
+		})
+	})
+
+	Describe("UT-KA-823-002: A cancelled investigation is immutable", func() {
+		It("should reject status changes on a cancelled investigation", func() {
+			store := session.NewStore(30 * time.Minute)
+			id, err := store.Create()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(store.Update(id, session.StatusRunning, nil, nil)).To(Succeed())
+			Expect(store.Update(id, session.StatusCancelled, nil, nil)).To(Succeed())
+
+			err = store.Update(id, session.StatusFailed, nil, nil)
+			Expect(err).To(MatchError(session.ErrSessionTerminal))
+
+			sess, err := store.Get(id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sess.Status).To(Equal(session.StatusCancelled))
+		})
+	})
+
+	Describe("UT-KA-823-003: A failed investigation is immutable", func() {
+		It("should reject status changes on a failed investigation", func() {
+			store := session.NewStore(30 * time.Minute)
+			id, err := store.Create()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(store.Update(id, session.StatusRunning, nil, nil)).To(Succeed())
+			Expect(store.Update(id, session.StatusFailed, nil, nil)).To(Succeed())
+
+			err = store.Update(id, session.StatusCompleted, "late-result", nil)
+			Expect(err).To(MatchError(session.ErrSessionTerminal))
+
+			sess, err := store.Get(id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sess.Status).To(Equal(session.StatusFailed))
+		})
+	})
+
+	Describe("UT-KA-823-004: An active investigation can be cancelled by an operator", func() {
+		It("should accept cancellation of a running investigation", func() {
+			store := session.NewStore(30 * time.Minute)
+			id, err := store.Create()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(store.Update(id, session.StatusRunning, nil, nil)).To(Succeed())
+
+			err = store.Update(id, session.StatusCancelled, nil, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			sess, err := store.Get(id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sess.Status).To(Equal(session.StatusCancelled))
+		})
+	})
+
+	Describe("UT-KA-823-005: Querying a cancelled investigation reports the cancelled state", func() {
+		It("should return StatusCancelled for a cancelled investigation", func() {
+			store := session.NewStore(30 * time.Minute)
+			id, err := store.Create()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(store.Update(id, session.StatusRunning, nil, nil)).To(Succeed())
+			Expect(store.Update(id, session.StatusCancelled, nil, nil)).To(Succeed())
+
+			sess, err := store.Get(id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sess.Status).To(Equal(session.StatusCancelled))
+		})
+	})
+
+	Describe("UT-KA-823-006: Active investigations are never removed by housekeeping", func() {
+		It("should skip running sessions during cleanup even if TTL expired", func() {
+			store := session.NewStore(1 * time.Millisecond)
+			id, err := store.Create()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(store.Update(id, session.StatusRunning, nil, nil)).To(Succeed())
+
+			time.Sleep(5 * time.Millisecond)
+
+			removed := store.Cleanup()
+			Expect(removed).To(Equal(0))
+
+			sess, err := store.Get(id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sess.Status).To(Equal(session.StatusRunning))
+		})
+	})
+
+	Describe("UT-KA-823-007: Session metadata cannot interfere with active investigations", func() {
+		It("should not expose internal control fields in the returned session copy", func() {
+			store := session.NewStore(30 * time.Minute)
+			id, err := store.Create()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(store.Update(id, session.StatusRunning, nil, nil)).To(Succeed())
+
+			sess, err := store.Get(id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sess).NotTo(BeNil())
+
+			v := reflect.ValueOf(*sess)
+			cancelField := v.FieldByName("cancel")
+			eventChanField := v.FieldByName("eventChan")
+			Expect(cancelField.IsValid()).To(BeTrue(), "cancel field must exist on Session struct")
+			Expect(eventChanField.IsValid()).To(BeTrue(), "eventChan field must exist on Session struct")
+			Expect(cancelField.IsNil()).To(BeTrue(), "cancel must be nil on cloned session")
+			Expect(eventChanField.IsNil()).To(BeTrue(), "eventChan must be nil on cloned session")
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- Emit `aiagent.session.{started,cancelled,completed,failed}` audit events at every investigation lifecycle transition for SOC2 CC8.1 compliance
- Inject `AuditStore` into `session.NewManager` with nil-safe guard (defaults to `NopAuditStore`)
- Fire-and-forget semantics per ADR-038: audit failures are logged but never abort investigations
- Update DD-AUDIT-003 to v1.9 with 4 new session event types in the authoritative registry

## Changes

**Production code (4 files):**
- `internal/kubernautagent/audit/emitter.go` — 4 event types + 4 action constants
- `internal/kubernautagent/session/manager.go` — AuditStore injection, `emitSessionEvent` helper
- `internal/kubernautagent/server/handler.go` — `remediation_id` in session metadata
- `cmd/kubernautagent/main.go` — wire `auditStore` into `NewManager`

**Tests (2 new + 4 updated):**
- `test/integration/kubernautagent/session/manager_audit_test.go` — 8 new IT scenarios
- `test/unit/kubernautagent/audit/emitter_test.go` — 3 new UT scenarios
- 4 existing test files updated for `NewManager` signature change

**Documentation:**
- `docs/architecture/decisions/DD-AUDIT-003-service-audit-trace-requirements.md` — v1.9
- `docs/tests/823/TP-823-AUDIT.md` — formal IEEE 829 test plan

## Coverage

| Tier | Package | Coverage |
|------|---------|----------|
| Integration | session | 81.5% |
| Unit | audit | 89.4% |

## Test plan

- [x] All 21 integration tests pass (13 existing + 8 new)
- [x] All 65 unit tests pass (including 3 new audit constant tests)
- [x] Race detector clean on all 4 affected test suites
- [x] Zero regressions in PR1 and v1.4 test suites
- [x] Coverage >= 80% on both tiers
- [x] DD-AUDIT-003 v1.9 updated with event registry

## Dependencies

- Depends on PR1 (`feature/pr1-session-cancel-infra`, commit `fd15319b6`) being merged first


Made with [Cursor](https://cursor.com)