### PR TITLE
feat(investigator): token-level streaming in runLLMLoop (#823) — PR 6/6

### DIFF
--- a/docs/tests/823/TP-823-TOKEN-STREAMING.md
+++ b/docs/tests/823/TP-823-TOKEN-STREAMING.md
@@ -1,0 +1,129 @@
+# Test Plan: Token-Level Streaming in runLLMLoop
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-823-TOKEN-v1.0
+**Feature**: Use StreamChat in runLLMLoop when event sink is present, Chat when not
+**Version**: 1.1
+**Created**: 2026-04-24
+**Author**: AI Assistant + Jordi Gil
+**Status**: Active
+**Branch**: `feature/pr6-token-streaming`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Validate that operators observing an active investigation receive token-by-token
+LLM reasoning in real time, while autonomous investigations without observers
+behave identically to v1.4. This is the capstone PR that completes the SSE
+streaming pipeline.
+
+### 1.2 Objectives
+
+1. **Real-time observation** (BR-SESSION-003): When an operator is observing, they receive each LLM text fragment as it is generated — faithfully reproducing the LLM output in order
+2. **Ordering guarantee** (BR-SESSION-003): Token-level deltas arrive BEFORE the turn-level reasoning summary for the same turn
+3. **Autonomous regression** (BR-SESSION-003): Without an observer, the investigation produces identical results to v1.4
+4. **Resilience** (BR-SESSION-003): A slow or disconnected observer cannot block the autonomous investigation
+5. **Cancellation parity** (BR-SESSION-001): Cancellation during streaming yields the same outcome as non-streaming cancellation
+6. **Runtime agnosticism** (BR-SESSION-007): EventTypeTokenDelta has a stable wire value mapped to Goose ACP
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/kubernautagent/investigator/ --ginkgo.focus="PR6"` |
+| Backward compatibility | 0 regressions | All existing tests pass |
+| Coverage | >=80% of `chatOrStream` | `go test -coverprofile` |
+
+---
+
+## 2. References
+
+### 2.1 Authority
+
+- **BR-SESSION-003**: Real-time streaming of investigation to observer — operator can observe autonomous investigation progress token-by-token
+- **BR-SESSION-001**: Operator can cancel an autonomous investigation; cancellation behavior identical with and without streaming
+- **BR-SESSION-007**: Event types are runtime-agnostic, providing a stable SSE contract across runtime migrations (LangChainGo → Goose ACP)
+- TP-823-TURN-EVENTS-SSE.md (PR4), TP-823-STREAMCHAT.md (PR5)
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Mitigation |
+|----|------|--------|-------------|------------|
+| R1 | StreamChat callback error disrupts investigation | Investigation stops mid-turn | Medium | Callback always returns nil (non-blocking send); StreamChat errors handled same as Chat errors |
+| R2 | Token deltas overwhelm event channel buffer | Events dropped for slow consumers | Low | Non-blocking send (select/default); documented as acceptable degradation |
+| R3 | StreamChat changes response structure vs Chat | Audit events record different data | Low | Both return identical ChatResponse; same downstream code path |
+| R4 | Token delta ordering broken by concurrent events | Observer sees garbled output | Low | Events emitted sequentially within single-goroutine runLLMLoop |
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **Operator observation fidelity**: Token deltas faithfully reproduce LLM output fragments in order
+- **Autonomous regression**: No behavioral change when no observer is present
+- **Observation resilience**: Slow consumer does not block investigation
+- **Cancellation parity**: Streaming cancellation equivalent to non-streaming
+- **Event ordering**: Token deltas precede turn-level reasoning summaries
+- **Runtime agnosticism**: Wire value stability for Goose migration
+
+### 4.2 Features Not to be Tested
+
+- StreamChat adapter implementations (covered in PR5 / TP-823-STREAMCHAT)
+- SSE pipe delivery to HTTP clients (covered in PR4 deferred items)
+- Turn-level events (covered in PR4 / TP-823-TURN-EVENTS-SSE)
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Helper function `chatOrStream` encapsulates the conditional | Single change point; easy to test; clear separation of concerns |
+| `EventTypeTokenDelta` distinct from `EventTypeReasoningDelta` | Token-level = character fragments for real-time display; reasoning = turn summary for UI state. Different consumers filter differently. |
+| StreamChat callback always returns nil | Observation path must never disrupt investigation — fire-and-forget semantics per ADR-038 |
+
+---
+
+## 5. Test Scenarios
+
+### 5.1 Business Requirement Traceability
+
+| BR ID | Business Outcome | Priority | Tier | Test ID | Status |
+|-------|------------------|----------|------|---------|--------|
+| BR-SESSION-003 | Operator receives exact LLM text fragments in order | P0 | Unit | UT-KA-823-T01 | Pass |
+| BR-SESSION-003 | Autonomous investigation without observer produces identical results | P0 | Unit | UT-KA-823-T02 | Pass |
+| BR-SESSION-003 | Slow observer cannot block autonomous investigation | P0 | Unit | UT-KA-823-T03 | Pass |
+| BR-SESSION-001, BR-SESSION-003 | Cancellation during streaming yields same outcome | P0 | Unit | UT-KA-823-T04 | Pass |
+| BR-SESSION-003 | Token deltas arrive before turn summary (real-time ordering) | P0 | Unit | UT-KA-823-T05 | Pass |
+| BR-SESSION-007 | EventTypeTokenDelta wire value is runtime-agnostic | P1 | Unit | UT-KA-823-T06 | Pass |
+
+### 5.2 Business Outcome Quality Bar
+
+Each test asserts an operator-visible behavior or business invariant, not an
+implementation detail. Tests verify:
+- **What the operator sees** (event content, ordering, fidelity)
+- **What the operator's action causes** (cancellation outcome)
+- **What remains unchanged** (autonomous mode regression)
+
+---
+
+## 6. Execution
+
+```bash
+go test ./test/unit/kubernautagent/investigator/ --ginkgo.focus="PR6" -v
+go test -race ./test/unit/kubernautagent/investigator/ ./test/unit/kubernautagent/session/
+```
+
+---
+
+## 7. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-24 | Initial test plan |
+| 1.1 | 2026-04-24 | Rewritten tests for business-outcome behavioral assurance: added content fidelity (T01), ordering guarantee (T05), cancellation parity (T04), wire value stability (T06). Removed implementation-detail assertions (call counters). |

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -897,11 +897,12 @@ func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message,
 		reqEvent.Data["messages"] = messagesToAuditFormat(messages)
 		audit.StoreBestEffort(ctx, inv.auditStore, reqEvent, inv.logger)
 
-		resp, err := client.Chat(ctx, llm.ChatRequest{
+		chatReq := llm.ChatRequest{
 			Messages: messages,
 			Tools:    toolDefs,
 			Options:  llm.ChatOptions{JSONMode: true, OutputSchema: submitResultSchemaForPhase(phase), MaxTokens: maxTokens},
-		})
+		}
+		resp, err := chatOrStream(ctx, client, chatReq, turn, string(phase))
 		if err != nil {
 			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 				emitToSink(ctx, session.EventTypeCancelled, turn, string(phase), nil)
@@ -1190,6 +1191,25 @@ func (inv *Investigator) executeTool(ctx context.Context, name string, args json
 	}
 
 	return result
+}
+
+// chatOrStream calls StreamChat when an event sink is present on the context,
+// forwarding token-level text deltas as EventTypeTokenDelta events. When no
+// event sink is present, it falls back to Chat for identical v1.4 behavior.
+// The returned ChatResponse is the same in both paths.
+func chatOrStream(ctx context.Context, client llm.Client, req llm.ChatRequest, turn int, phase string) (llm.ChatResponse, error) {
+	sink := session.EventSinkFromContext(ctx)
+	if sink == nil {
+		return client.Chat(ctx, req)
+	}
+	return client.StreamChat(ctx, req, func(evt llm.ChatStreamEvent) error {
+		if evt.Delta != "" {
+			emitToSink(ctx, session.EventTypeTokenDelta, turn, phase, map[string]interface{}{
+				"delta": evt.Delta,
+			})
+		}
+		return nil
+	})
 }
 
 // emitToSink sends an InvestigationEvent to the context-carried event sink

--- a/internal/kubernautagent/session/types.go
+++ b/internal/kubernautagent/session/types.go
@@ -24,6 +24,7 @@ import "encoding/json"
 //
 // Goose ACP mapping (future):
 //   - EventTypeReasoningDelta -> acp.StreamEvent with kind="reasoning"
+//   - EventTypeTokenDelta     -> acp.StreamEvent with kind="text_delta"
 //   - EventTypeToolCallStart  -> acp.StreamEvent with kind="tool_use"
 //   - EventTypeToolResult     -> acp.StreamEvent with kind="tool_result"
 //   - EventTypeError          -> acp.StreamEvent with kind="error"
@@ -46,4 +47,5 @@ const (
 	EventTypeError          = "error"
 	EventTypeComplete       = "complete"
 	EventTypeCancelled      = "cancelled"
+	EventTypeTokenDelta     = "token_delta"
 )

--- a/test/unit/kubernautagent/investigator/token_streaming_test.go
+++ b/test/unit/kubernautagent/investigator/token_streaming_test.go
@@ -1,0 +1,398 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"sync/atomic"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	katypes "github.com/jordigilh/kubernaut/internal/kubernautagent/types"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+)
+
+// streamTrackingMockClient simulates an LLM that emits known text chunks
+// via StreamChat, allowing tests to verify the operator-visible event stream
+// matches the actual LLM output. Responses cycle: the last response is
+// reused for any subsequent phases beyond the provided list.
+type streamTrackingMockClient struct {
+	chatCalls   atomic.Int64
+	streamCalls atomic.Int64
+	chunks      []string
+	responses   []llm.ChatResponse
+	callIdx     int
+}
+
+func (m *streamTrackingMockClient) Chat(_ context.Context, _ llm.ChatRequest) (llm.ChatResponse, error) {
+	m.chatCalls.Add(1)
+	return m.nextResponse(), nil
+}
+
+func (m *streamTrackingMockClient) StreamChat(_ context.Context, _ llm.ChatRequest, callback func(llm.ChatStreamEvent) error) (llm.ChatResponse, error) {
+	m.streamCalls.Add(1)
+	for _, chunk := range m.chunks {
+		_ = callback(llm.ChatStreamEvent{Delta: chunk})
+	}
+	_ = callback(llm.ChatStreamEvent{Done: true})
+	return m.nextResponse(), nil
+}
+
+func (m *streamTrackingMockClient) nextResponse() llm.ChatResponse {
+	if m.callIdx < len(m.responses) {
+		resp := m.responses[m.callIdx]
+		m.callIdx++
+		return resp
+	}
+	if len(m.responses) > 0 {
+		return m.responses[len(m.responses)-1]
+	}
+	return llm.ChatResponse{
+		Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"fallback","confidence":0.1}`},
+	}
+}
+
+func (m *streamTrackingMockClient) Close() error { return nil }
+
+func tokenStreamTestInvestigator(client llm.Client) *investigator.Investigator {
+	logger := slog.Default()
+	builder, _ := prompt.NewBuilder()
+	rp := parser.NewResultParser()
+	enricher := enrichment.NewEnricher(nopK8sClient{}, nopDSClient{}, audit.NopAuditStore{}, logger)
+	return investigator.New(investigator.Config{
+		Client:       client,
+		Builder:      builder,
+		ResultParser: rp,
+		Enricher:     enricher,
+		AuditStore:   audit.NopAuditStore{},
+		Logger:       logger,
+		MaxTurns:     15,
+		PhaseTools:   investigator.DefaultPhaseToolMap(),
+	})
+}
+
+var tokenStreamSignal = katypes.SignalContext{
+	Name:          "test-pod",
+	Namespace:     "default",
+	Severity:      "critical",
+	Message:       "OOMKilled",
+	RemediationID: "rem-token-stream",
+}
+
+var _ = Describe("Token-Level Streaming in runLLMLoop — #823 PR6", func() {
+
+	// BR-SESSION-003: An operator observing an active investigation receives
+	// token-by-token LLM reasoning fragments that faithfully reproduce the
+	// LLM's output as it is generated.
+	Describe("UT-KA-823-T01: Operator observing an investigation receives token-by-token LLM reasoning", func() {
+		It("delivers each LLM text chunk as an EventTypeTokenDelta with the exact fragment", func() {
+			expectedChunks := []string{"ana", "lyzing", " pod ", "crash"}
+			mock := &streamTrackingMockClient{
+				chunks: expectedChunks,
+				responses: []llm.ChatResponse{
+					{
+						Message: llm.Message{
+							Role:    "assistant",
+							Content: `{"rca_summary":"pod OOM killed","confidence":0.9}`,
+						},
+						Usage: llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+					},
+				},
+			}
+
+			eventCh := make(chan session.InvestigationEvent, 128)
+			ctx := session.WithEventSink(context.Background(), eventCh)
+
+			inv := tokenStreamTestInvestigator(mock)
+			go func() {
+				_, _ = inv.Investigate(ctx, tokenStreamSignal)
+				close(eventCh)
+			}()
+
+			var events []session.InvestigationEvent
+			for ev := range eventCh {
+				events = append(events, ev)
+			}
+
+			// Collect token deltas from the first phase (RCA). The investigation
+			// has multiple phases; each phase that calls the LLM generates its own
+			// set of token deltas. We verify fidelity within a single phase.
+			var firstPhase string
+			var firstPhaseDeltas []string
+			for _, ev := range events {
+				if ev.Type == session.EventTypeTokenDelta {
+					var data map[string]interface{}
+					Expect(json.Unmarshal(ev.Data, &data)).To(Succeed())
+					Expect(data).To(HaveKey("delta"),
+						"each token_delta event must carry the text fragment")
+					delta := data["delta"].(string)
+					if firstPhase == "" {
+						firstPhase = ev.Phase
+					}
+					if ev.Phase == firstPhase {
+						firstPhaseDeltas = append(firstPhaseDeltas, delta)
+					}
+					Expect(ev.Turn).To(BeNumerically(">=", 0),
+						"token_delta must carry the turn number for SSE ordering")
+					Expect(ev.Phase).NotTo(BeEmpty(),
+						"token_delta must carry the investigation phase")
+				}
+			}
+			Expect(firstPhaseDeltas).To(Equal(expectedChunks),
+				"operator must receive the exact LLM text fragments in order for each phase")
+		})
+	})
+
+	// BR-SESSION-003 (regression): Autonomous investigations without an
+	// observer produce identical results to v1.4 — no events leak, no
+	// behavioral change.
+	Describe("UT-KA-823-T02: Autonomous investigation without observer produces identical results", func() {
+		It("completes with a valid RCA result and emits zero events", func() {
+			mock := &streamTrackingMockClient{
+				chunks: []string{"should", "not", "appear"},
+				responses: []llm.ChatResponse{
+					{
+						Message: llm.Message{
+							Role:    "assistant",
+							Content: `{"rca_summary":"pod OOM killed","confidence":0.9}`,
+						},
+						Usage: llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+					},
+				},
+			}
+
+			ctx := context.Background() // no event sink — autonomous mode
+			inv := tokenStreamTestInvestigator(mock)
+			result, err := inv.Investigate(ctx, tokenStreamSignal)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.RCASummary).NotTo(BeEmpty(),
+				"autonomous investigation must produce a valid root cause analysis")
+			Expect(result.Cancelled).To(BeFalse(),
+				"non-cancelled investigation must not be marked cancelled")
+		})
+	})
+
+	// BR-SESSION-003 (resilience): A slow or disconnected observer must never
+	// block the autonomous investigation. The investigation MUST complete
+	// regardless of observer capacity.
+	Describe("UT-KA-823-T03: Slow observer cannot block the autonomous investigation", func() {
+		It("investigation completes with a valid result even when the event channel is full", func() {
+			mock := &streamTrackingMockClient{
+				chunks: []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
+				responses: []llm.ChatResponse{
+					{
+						Message: llm.Message{
+							Role:    "assistant",
+							Content: `{"rca_summary":"OOM detected in container","confidence":0.8}`,
+						},
+					},
+				},
+			}
+
+			eventCh := make(chan session.InvestigationEvent, 1) // tiny buffer — simulates slow consumer
+			ctx := session.WithEventSink(context.Background(), eventCh)
+
+			inv := tokenStreamTestInvestigator(mock)
+			result, err := inv.Investigate(ctx, tokenStreamSignal)
+
+			Expect(err).NotTo(HaveOccurred(),
+				"investigation must not deadlock on a full event channel")
+			Expect(result).NotTo(BeNil())
+			Expect(result.RCASummary).NotTo(BeEmpty(),
+				"investigation must still produce a valid RCA despite dropped events")
+		})
+	})
+
+	// BR-SESSION-001 + BR-SESSION-003: When an operator cancels a streaming
+	// investigation, the cancellation outcome is identical regardless of
+	// whether streaming was active. The operator's cancel action takes effect.
+	Describe("UT-KA-823-T04: Cancellation during streaming produces same outcome as non-streaming", func() {
+		It("cancellation yields notification to observer with token deltas before the cancel event", func() {
+			cancelCtx, cancel := context.WithCancel(context.Background())
+			mock := &streamTrackingMockClient{
+				chunks: []string{"analyzing", "..."},
+				responses: []llm.ChatResponse{
+					{
+						Message: llm.Message{Role: "assistant", Content: "investigating..."},
+						ToolCalls: []llm.ToolCall{
+							{ID: "tc_1", Name: "kubectl_describe", Arguments: `{"kind":"Pod","name":"test","namespace":"default"}`},
+						},
+						Usage: llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+					},
+				},
+			}
+
+			eventCh := make(chan session.InvestigationEvent, 128)
+			ctx := session.WithEventSink(cancelCtx, eventCh)
+
+			callCount := &atomic.Int64{}
+			wrappedMock := &cancelOnSecondCallMock{
+				inner:     mock,
+				cancelFn:  cancel,
+				callCount: callCount,
+			}
+
+			inv := tokenStreamTestInvestigator(wrappedMock)
+			go func() {
+				_, _ = inv.Investigate(ctx, tokenStreamSignal)
+				close(eventCh)
+			}()
+
+			var events []session.InvestigationEvent
+			for ev := range eventCh {
+				events = append(events, ev)
+			}
+
+			hasCancelled := false
+			hasTokenDelta := false
+			for _, ev := range events {
+				if ev.Type == session.EventTypeCancelled {
+					hasCancelled = true
+				}
+				if ev.Type == session.EventTypeTokenDelta {
+					hasTokenDelta = true
+				}
+			}
+			Expect(hasTokenDelta).To(BeTrue(),
+				"operator should have received token deltas before cancellation")
+			Expect(hasCancelled).To(BeTrue(),
+				"operator must be notified of cancellation via EventTypeCancelled")
+		})
+	})
+
+	// BR-SESSION-003 + BR-SESSION-007: A complete investigation with an
+	// observer produces both fine-grained (token_delta) and coarse-grained
+	// (reasoning_delta) events. Within a single phase, token deltas arrive
+	// BEFORE the turn summary — ensuring real-time experience.
+	Describe("UT-KA-823-T05: Observer receives both token-level and turn-level events with correct ordering", func() {
+		It("token_delta events precede the reasoning_delta within the same phase", func() {
+			expectedChunks := []string{"think", "ing", " about", " OOM"}
+			mock := &streamTrackingMockClient{
+				chunks: expectedChunks,
+				responses: []llm.ChatResponse{
+					{
+						Message: llm.Message{
+							Role:    "assistant",
+							Content: `{"rca_summary":"root cause found","confidence":0.95}`,
+						},
+						Usage: llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+					},
+				},
+			}
+
+			eventCh := make(chan session.InvestigationEvent, 128)
+			ctx := session.WithEventSink(context.Background(), eventCh)
+
+			inv := tokenStreamTestInvestigator(mock)
+			go func() {
+				_, _ = inv.Investigate(ctx, tokenStreamSignal)
+				close(eventCh)
+			}()
+
+			var events []session.InvestigationEvent
+			for ev := range eventCh {
+				events = append(events, ev)
+			}
+
+			// Verify ordering within the first phase: all token_delta events
+			// for a given phase must precede the reasoning_delta for that phase.
+			var firstPhase string
+			lastTokenDeltaIdx := -1
+			firstReasoningIdx := -1
+			var phaseTokenTexts []string
+
+			for i, ev := range events {
+				if ev.Type == session.EventTypeTokenDelta {
+					if firstPhase == "" {
+						firstPhase = ev.Phase
+					}
+					if ev.Phase == firstPhase {
+						lastTokenDeltaIdx = i
+						var data map[string]interface{}
+						if json.Unmarshal(ev.Data, &data) == nil {
+							if d, ok := data["delta"].(string); ok {
+								phaseTokenTexts = append(phaseTokenTexts, d)
+							}
+						}
+					}
+				}
+				if ev.Type == session.EventTypeReasoningDelta && ev.Phase == firstPhase && firstReasoningIdx == -1 {
+					firstReasoningIdx = i
+				}
+			}
+
+			Expect(lastTokenDeltaIdx).To(BeNumerically(">=", 0),
+				"operator must receive token-level delta events")
+			Expect(firstReasoningIdx).To(BeNumerically(">=", 0),
+				"operator must receive the turn-level reasoning summary")
+			Expect(lastTokenDeltaIdx).To(BeNumerically("<", firstReasoningIdx),
+				"within a phase, token deltas must arrive BEFORE the turn reasoning summary (real-time streaming)")
+
+			reconstructed := strings.Join(phaseTokenTexts, "")
+			Expect(reconstructed).To(Equal(strings.Join(expectedChunks, "")),
+				"concatenated token deltas must reconstruct the original LLM output")
+		})
+	})
+
+	// BR-SESSION-007: EventTypeTokenDelta is runtime-agnostic and forwards-
+	// compatible with Goose ACP migration. Verify the constant value is stable.
+	Describe("UT-KA-823-T06: EventTypeTokenDelta wire value is runtime-agnostic", func() {
+		It("has a stable wire value suitable for SSE contract", func() {
+			Expect(session.EventTypeTokenDelta).To(Equal("token_delta"),
+				"wire value must be stable across runtime migrations (BR-SESSION-007)")
+		})
+	})
+})
+
+// cancelOnSecondCallMock wraps a streamTrackingMockClient and cancels the
+// context after the first successful LLM call, simulating an operator cancel
+// that arrives between investigation turns.
+type cancelOnSecondCallMock struct {
+	inner     *streamTrackingMockClient
+	cancelFn  context.CancelFunc
+	callCount *atomic.Int64
+}
+
+func (m *cancelOnSecondCallMock) Chat(ctx context.Context, req llm.ChatRequest) (llm.ChatResponse, error) {
+	if m.callCount.Add(1) > 1 {
+		m.cancelFn()
+		return llm.ChatResponse{}, context.Canceled
+	}
+	return m.inner.Chat(ctx, req)
+}
+
+func (m *cancelOnSecondCallMock) StreamChat(ctx context.Context, req llm.ChatRequest, cb func(llm.ChatStreamEvent) error) (llm.ChatResponse, error) {
+	if m.callCount.Add(1) > 1 {
+		m.cancelFn()
+		return llm.ChatResponse{}, context.Canceled
+	}
+	return m.inner.StreamChat(ctx, req, cb)
+}
+
+func (m *cancelOnSecondCallMock) Close() error { return nil }


### PR DESCRIPTION
## Summary

Capstone PR for v1.5 session streaming and cancellation (6/6). `runLLMLoop` now conditionally uses `StreamChat` when an event sink is present, delivering token-by-token LLM reasoning to the observer in real time. When no observer is attached, `Chat` is used identically to v1.4.

- **`chatOrStream` helper** (`investigator.go`): Checks `EventSinkFromContext`; routes to `StreamChat` with delta callback or `Chat` fallback
- **`EventTypeTokenDelta`** (`session/types.go`): New event type with Goose ACP mapping (`acp.StreamEvent kind="text_delta"`)
- **6 business-outcome tests** (`token_streaming_test.go`): Content fidelity, event ordering, slow-consumer resilience, cancellation parity, autonomous regression, wire value stability

### Business Requirements Covered

| BR | Outcome |
|---|---|
| BR-SESSION-003 | Operator receives exact LLM text fragments in order, in real time |
| BR-SESSION-001 | Cancellation during streaming produces same outcome as non-streaming |
| BR-SESSION-007 | `EventTypeTokenDelta` wire value is runtime-agnostic (Goose ACP ready) |

### v1.5 Streaming Pipeline Complete

| PR | Feature | Status |
|---|---|---|
| PR1 | Session store + cancellation infrastructure | Merged |
| PR1.5 | Session lifecycle audit events (SOC2) | Merged |
| PR2 | OAS endpoints (cancel, snapshot, stream stub) | Merged |
| PR3 | CancelledResult in runLLMLoop | Merged |
| PR4 | Turn-level event emission + SSE middleware | Merged |
| PR5 | StreamChat on llm.Client interface | Merged |
| **PR6** | **Token-level streaming in runLLMLoop** | **This PR** |

## Test plan

- [x] 6 new unit tests pass (`go test --ginkgo.focus="PR6"`)
- [x] Zero regressions across investigator, session, llm, audit test suites
- [x] Race detector clean (`go test -race`)
- [x] `go vet ./...` clean
- [x] Pre-commit anti-pattern hooks pass
- [x] Test plan: `docs/tests/823/TP-823-TOKEN-STREAMING.md`


Made with [Cursor](https://cursor.com)