### PR TITLE
feat(authz): add object-level session authorization with ownership tracking (#823)

### DIFF
--- a/docs/architecture/decisions/DD-AUDIT-003-service-audit-trace-requirements.md
+++ b/docs/architecture/decisions/DD-AUDIT-003-service-audit-trace-requirements.md
@@ -962,7 +962,7 @@ In v1.3 (issue [#433](https://github.com/jordigilh/kubernaut/issues/433), Kubern
 | `aiagent.session.observed` | `session_observed` | `success` |
 | `aiagent.conversation.turn` | `conversation_turn` | `success` |
 
-**Granularity**: `aiagent.llm.tool_call` is emitted **once per tool call**. `aiagent.workflow.validation_attempt` is emitted per validation attempt and includes `workflow_id` and `is_final_attempt` where applicable. `aiagent.conversation.turn` is emitted once per user message in the conversational RAR API (see [DD-CONV-001](./DD-CONV-001-conversation-tool-call-architecture.md)).
+**Granularity**: `aiagent.llm.tool_call` is emitted **once per tool call**. `aiagent.workflow.validation_attempt` is emitted per validation attempt and includes `workflow_id` and `is_final_attempt` where applicable. `aiagent.conversation.turn` is emitted once per user message in the conversational RAR API (see [DD-CONV-001](./DD-CONV-001-conversation-tool-call-architecture.md)). `aiagent.session.observed` includes `observer_user` (the authenticated identity of the subscribing user, extracted from `auth.UserContextKey` in the request context) for SOC2 CC8.1 operator attribution.
 
 **Reference**: [TP-433-AUDIT-SOC2](../../tests/433/TP-433-AUDIT-SOC2.md).
 

--- a/docs/architecture/decisions/DD-AUDIT-003-service-audit-trace-requirements.md
+++ b/docs/architecture/decisions/DD-AUDIT-003-service-audit-trace-requirements.md
@@ -960,9 +960,10 @@ In v1.3 (issue [#433](https://github.com/jordigilh/kubernaut/issues/433), Kubern
 | `aiagent.session.failed` | `session_failed` | `failure` |
 | `aiagent.investigation.cancelled` | `investigation_cancelled` | `failure` |
 | `aiagent.session.observed` | `session_observed` | `success` |
+| `aiagent.session.access_denied` | `session_access_denied` | `failure` |
 | `aiagent.conversation.turn` | `conversation_turn` | `success` |
 
-**Granularity**: `aiagent.llm.tool_call` is emitted **once per tool call**. `aiagent.workflow.validation_attempt` is emitted per validation attempt and includes `workflow_id` and `is_final_attempt` where applicable. `aiagent.conversation.turn` is emitted once per user message in the conversational RAR API (see [DD-CONV-001](./DD-CONV-001-conversation-tool-call-architecture.md)). `aiagent.session.observed` includes `observer_user` (the authenticated identity of the subscribing user, extracted from `auth.UserContextKey` in the request context) for SOC2 CC8.1 operator attribution.
+**Granularity**: `aiagent.llm.tool_call` is emitted **once per tool call**. `aiagent.workflow.validation_attempt` is emitted per validation attempt and includes `workflow_id` and `is_final_attempt` where applicable. `aiagent.conversation.turn` is emitted once per user message in the conversational RAR API (see [DD-CONV-001](./DD-CONV-001-conversation-tool-call-architecture.md)). `aiagent.session.observed` includes `observer_user` (the authenticated identity of the subscribing user, extracted from `auth.UserContextKey` in the request context) for SOC2 CC8.1 operator attribution. `aiagent.session.access_denied` is emitted when an authenticated user attempts to access a session they do not own; includes `requesting_user`, `session_id`, and `endpoint` for SOC2 CC8.1 failed-access audit trail.
 
 **Reference**: [TP-433-AUDIT-SOC2](../../tests/433/TP-433-AUDIT-SOC2.md).
 

--- a/docs/tests/823/TP-823-SSE-DELIVERY.md
+++ b/docs/tests/823/TP-823-SSE-DELIVERY.md
@@ -1,0 +1,109 @@
+# Test Plan: SSE Delivery Path (PR7)
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-823-SSE-DELIVERY-v1.0
+**Feature**: Wire SSE stream handler, lazy event sink, panic recovery, event completeness
+**Version**: 1.0
+**Created**: 2026-04-24
+**Author**: AI Assistant + Jordi Gil
+**Status**: Draft
+**Branch**: `feature/pr7-sse-delivery`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Close the critical delivery gap: the v1.5 streaming pipeline (PRs 1-6) built
+infrastructure but never connected it to HTTP. This PR wires the SSE stream
+handler, makes the event sink lazy (restoring v1.4 autonomous behavior), adds
+panic recovery in the investigation goroutine, and emits missing lifecycle events.
+
+### 1.2 Objectives
+
+1. **SSE delivery** (GAP-1/2/3): Operators can GET `/api/v1/incident/session/{id}/stream` and receive SSE frames with investigation events
+2. **Lazy event sink** (GAP-4): Autonomous investigations without observers use `Chat` (v1.4 parity); sink attached only on `Subscribe`
+3. **Panic recovery** (COR-1): Investigation goroutine recovers from panics, transitions session to `StatusFailed`
+4. **Event completeness** (GAP-5/6): `EventTypeComplete` emitted at end; `EventTypeSessionObserved` emitted on subscribe
+5. **Regression**: All existing tests pass unchanged
+
+---
+
+## 2. References
+
+### 2.1 Authority
+
+- BR-SESSION-003: Real-time streaming of investigation to observer
+- BR-SESSION-005: All session control actions are audited
+- BR-SESSION-007: Runtime-agnostic event types
+- SOC2 CC8.1: Operator attribution for observation
+- Gap audit: v1.5_gap_remediation_5a29c0a8.plan.md
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Mitigation |
+|----|------|--------|------------|
+| R1 | `io.Pipe` blocks if consumer disconnects | Investigation goroutine blocked | Write to pipe in separate goroutine; close pipe on context cancel |
+| R2 | Lazy sink changes Subscribe semantics | Existing integration tests break | Subscribe triggers sink attachment atomically |
+| R3 | Panic recovery masks bugs | Errors hidden | Log at Error level with stack trace; transition to StatusFailed |
+| R4 | ogen encoder sets Content-Type but not proxy headers | Buffered by nginx/envoy | SSEHeadersMiddleware mounted on stream route |
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **SSE stream handler** (`handler.go`): `SessionStream...Get` using `io.Pipe` + `Manager.Subscribe`
+- **Lazy event sink** (`manager.go`): Sink attached only on first `Subscribe`, not on `StartInvestigation`
+- **Panic recovery** (`manager.go`): `recover()` in investigation goroutine
+- **EventTypeComplete emission** (`investigator.go`): At investigation end
+- **EventTypeSessionObserved emission** (`manager.go`): On `Subscribe`
+
+### 4.2 Features Not to be Tested
+
+- StreamChat adapters (PR5)
+- Token-level streaming in runLLMLoop (PR6)
+- Cancel/snapshot handlers (PR2)
+- DataStorage typed payloads (PR8)
+
+---
+
+## 5. Test Scenarios
+
+### 5.1 Business Requirement Traceability
+
+| BR ID | Business Outcome | Priority | Tier | Test ID | Status |
+|-------|------------------|----------|------|---------|--------|
+| BR-SESSION-003 | SSE stream delivers investigation events to HTTP client | P0 | Unit | UT-KA-823-D01 | Pending |
+| BR-SESSION-003 | Stream ends when investigation completes (pipe closed) | P0 | Unit | UT-KA-823-D02 | Pending |
+| BR-SESSION-003 | Stream for unknown session returns 404 | P0 | Unit | UT-KA-823-D03 | Pending |
+| BR-SESSION-003 | Stream for terminal session returns 409 | P0 | Unit | UT-KA-823-D04 | Pending |
+| BR-SESSION-003 | Lazy sink: autonomous investigation uses Chat (no sink) | P0 | Unit | UT-KA-823-D05 | Pending |
+| BR-SESSION-003 | Lazy sink: Subscribe triggers sink attachment, events flow | P0 | Integration | IT-KA-823-D01 | Pending |
+| COR-1 | Panic in investigation: session transitions to Failed, goroutine exits | P0 | Unit | UT-KA-823-D06 | Pending |
+| BR-SESSION-007 | EventTypeComplete emitted when investigation ends | P1 | Unit | UT-KA-823-D07 | Pending |
+| BR-SESSION-005 | EventTypeSessionObserved emitted on Subscribe | P1 | Unit | UT-KA-823-D08 | Pending |
+| BR-SESSION-003 | Client disconnect closes pipe without blocking investigation | P0 | Integration | IT-KA-823-D02 | Pending |
+
+---
+
+## 6. Execution
+
+```bash
+go test ./test/unit/kubernautagent/server/ --ginkgo.focus="PR7" -v
+go test ./test/unit/kubernautagent/session/ --ginkgo.focus="PR7" -v
+go test -race ./test/unit/kubernautagent/... ./test/integration/kubernautagent/session/
+```
+
+---
+
+## 7. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-24 | Initial test plan |

--- a/internal/kubernautagent/audit/emitter.go
+++ b/internal/kubernautagent/audit/emitter.go
@@ -57,6 +57,11 @@ const (
 	// active investigation's SSE stream (BR-SESSION-005). Records who is
 	// observing which investigation for SOC2 CC8.1 audit trail.
 	EventTypeSessionObserved = "aiagent.session.observed"
+
+	// EventTypeSessionAccessDenied is emitted when an authenticated user
+	// attempts to access a session they do not own. Records the requesting
+	// user, target session, and endpoint for SOC2 CC8.1 failed-access audit.
+	EventTypeSessionAccessDenied = "aiagent.session.access_denied"
 )
 
 const (
@@ -76,6 +81,7 @@ const (
 
 	ActionInvestigationCancelled = "investigation_cancelled"
 	ActionSessionObserved       = "session_observed"
+	ActionSessionAccessDenied   = "session_access_denied"
 )
 
 const (
@@ -103,6 +109,7 @@ var AllEventTypes = []string{
 	EventTypeSessionFailed,
 	EventTypeInvestigationCancelled,
 	EventTypeSessionObserved,
+	EventTypeSessionAccessDenied,
 }
 
 // AuditEvent represents an audit event to be stored.

--- a/internal/kubernautagent/server/handler.go
+++ b/internal/kubernautagent/server/handler.go
@@ -134,7 +134,8 @@ func (h *Handler) IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet(
 	ctx context.Context,
 	params agentclient.IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetParams,
 ) (agentclient.IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetRes, error) {
-	sess, err := h.getAuthorizedSession(ctx, params.SessionID)
+	endpoint := fmt.Sprintf("/api/v1/incident/session/%s", params.SessionID)
+	sess, err := h.getAuthorizedSession(ctx, params.SessionID, endpoint)
 	if err != nil {
 		if errors.Is(err, session.ErrSessionNotFound) {
 			return &agentclient.HTTPError{
@@ -142,7 +143,7 @@ func (h *Handler) IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet(
 				Title:    "Session Not Found",
 				Detail:   fmt.Sprintf("session %s not found", params.SessionID),
 				Status:   404,
-				Instance: fmt.Sprintf("/api/v1/incident/session/%s", params.SessionID),
+				Instance: endpoint,
 			}, nil
 		}
 		h.logger.Error("session lookup failed", "session_id", params.SessionID, "error", err)
@@ -164,7 +165,8 @@ func (h *Handler) IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResu
 	ctx context.Context,
 	params agentclient.IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetParams,
 ) (agentclient.IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetRes, error) {
-	sess, err := h.getAuthorizedSession(ctx, params.SessionID)
+	endpoint := fmt.Sprintf("/api/v1/incident/session/%s/result", params.SessionID)
+	sess, err := h.getAuthorizedSession(ctx, params.SessionID, endpoint)
 	if err != nil {
 		if errors.Is(err, session.ErrSessionNotFound) {
 			return &agentclient.IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetNotFound{
@@ -172,7 +174,7 @@ func (h *Handler) IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResu
 				Title:    "Session Not Found",
 				Detail:   fmt.Sprintf("session %s not found", params.SessionID),
 				Status:   404,
-				Instance: fmt.Sprintf("/api/v1/incident/session/%s/result", params.SessionID),
+				Instance: endpoint,
 			}, nil
 		}
 		h.logger.Error("session lookup failed", "session_id", params.SessionID, "error", err)
@@ -215,14 +217,15 @@ func (h *Handler) CancelSessionAPIV1IncidentSessionSessionIDCancelPost(
 	ctx context.Context,
 	params agentclient.CancelSessionAPIV1IncidentSessionSessionIDCancelPostParams,
 ) (agentclient.CancelSessionAPIV1IncidentSessionSessionIDCancelPostRes, error) {
-	if _, authzErr := h.getAuthorizedSession(ctx, params.SessionID); authzErr != nil {
+	endpoint := fmt.Sprintf("/api/v1/incident/session/%s/cancel", params.SessionID)
+	if _, authzErr := h.getAuthorizedSession(ctx, params.SessionID, endpoint); authzErr != nil {
 		if errors.Is(authzErr, session.ErrSessionNotFound) {
 			return &agentclient.CancelSessionAPIV1IncidentSessionSessionIDCancelPostNotFound{
 				Type:     "https://kubernaut.ai/problems/not-found",
 				Title:    "Session Not Found",
 				Detail:   fmt.Sprintf("session %s not found", params.SessionID),
 				Status:   404,
-				Instance: fmt.Sprintf("/api/v1/incident/session/%s/cancel", params.SessionID),
+				Instance: endpoint,
 			}, nil
 		}
 		return nil, fmt.Errorf("session authz: %w", authzErr)
@@ -262,7 +265,8 @@ func (h *Handler) SessionSnapshotAPIV1IncidentSessionSessionIDSnapshotGet(
 	ctx context.Context,
 	params agentclient.SessionSnapshotAPIV1IncidentSessionSessionIDSnapshotGetParams,
 ) (agentclient.SessionSnapshotAPIV1IncidentSessionSessionIDSnapshotGetRes, error) {
-	sess, err := h.getAuthorizedSession(ctx, params.SessionID)
+	endpoint := fmt.Sprintf("/api/v1/incident/session/%s/snapshot", params.SessionID)
+	sess, err := h.getAuthorizedSession(ctx, params.SessionID, endpoint)
 	if err != nil {
 		if errors.Is(err, session.ErrSessionNotFound) {
 			return &agentclient.SessionSnapshotAPIV1IncidentSessionSessionIDSnapshotGetNotFound{
@@ -270,7 +274,7 @@ func (h *Handler) SessionSnapshotAPIV1IncidentSessionSessionIDSnapshotGet(
 				Title:    "Session Not Found",
 				Detail:   fmt.Sprintf("session %s not found", params.SessionID),
 				Status:   404,
-				Instance: fmt.Sprintf("/api/v1/incident/session/%s/snapshot", params.SessionID),
+				Instance: endpoint,
 			}, nil
 		}
 		h.logger.Error("snapshot lookup failed", "session_id", params.SessionID, "error", err)
@@ -367,14 +371,15 @@ func (h *Handler) SessionStreamAPIV1IncidentSessionSessionIDStreamGet(
 	ctx context.Context,
 	params agentclient.SessionStreamAPIV1IncidentSessionSessionIDStreamGetParams,
 ) (agentclient.SessionStreamAPIV1IncidentSessionSessionIDStreamGetRes, error) {
-	if _, authzErr := h.getAuthorizedSession(ctx, params.SessionID); authzErr != nil {
+	endpoint := fmt.Sprintf("/api/v1/incident/session/%s/stream", params.SessionID)
+	if _, authzErr := h.getAuthorizedSession(ctx, params.SessionID, endpoint); authzErr != nil {
 		if errors.Is(authzErr, session.ErrSessionNotFound) {
 			return &agentclient.HTTPError{
 				Type:     "https://kubernaut.ai/problems/not-found",
 				Title:    "Session Not Found",
 				Detail:   fmt.Sprintf("session %s not found", params.SessionID),
 				Status:   404,
-				Instance: fmt.Sprintf("/api/v1/incident/session/%s/stream", params.SessionID),
+				Instance: endpoint,
 			}, nil
 		}
 		h.logger.Error("stream authz failed", "session_id", params.SessionID, "error", authzErr)
@@ -434,7 +439,9 @@ func (h *Handler) SessionStreamAPIV1IncidentSessionSessionIDStreamGet(
 // is the session owner. Returns the session if authorized, or nil with
 // ErrSessionNotFound if the session doesn't exist or the user is not the owner.
 // When auth middleware is disabled (user is empty), ownership checks are skipped.
-func (h *Handler) getAuthorizedSession(ctx context.Context, sessionID string) (*session.Session, error) {
+// Denied access attempts are recorded via aiagent.session.access_denied for
+// SOC2 CC8.1 failed-access audit trail.
+func (h *Handler) getAuthorizedSession(ctx context.Context, sessionID, endpoint string) (*session.Session, error) {
 	sess, err := h.sessions.GetSession(sessionID)
 	if err != nil {
 		return nil, err
@@ -447,6 +454,7 @@ func (h *Handler) getAuthorizedSession(ctx context.Context, sessionID string) (*
 
 	owner := sess.Metadata["created_by"]
 	if owner != "" && owner != requestUser {
+		h.sessions.EmitAccessDenied(ctx, sessionID, endpoint, requestUser)
 		return nil, session.ErrSessionNotFound
 	}
 

--- a/internal/kubernautagent/server/handler.go
+++ b/internal/kubernautagent/server/handler.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
 	katypes "github.com/jordigilh/kubernaut/internal/kubernautagent/types"
+	"github.com/jordigilh/kubernaut/pkg/shared/auth"
 )
 
 // InvestigationRunner abstracts the investigation entry point so that
@@ -130,10 +131,10 @@ func (h *Handler) IncidentAnalyzeEndpointAPIV1IncidentAnalyzePost(
 
 // IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet implements GET /api/v1/incident/session/{session_id}.
 func (h *Handler) IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet(
-	_ context.Context,
+	ctx context.Context,
 	params agentclient.IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetParams,
 ) (agentclient.IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetRes, error) {
-	sess, err := h.sessions.GetSession(params.SessionID)
+	sess, err := h.getAuthorizedSession(ctx, params.SessionID)
 	if err != nil {
 		if errors.Is(err, session.ErrSessionNotFound) {
 			return &agentclient.HTTPError{
@@ -160,10 +161,10 @@ func (h *Handler) IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet(
 // IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGet implements
 // GET /api/v1/incident/session/{session_id}/result.
 func (h *Handler) IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGet(
-	_ context.Context,
+	ctx context.Context,
 	params agentclient.IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetParams,
 ) (agentclient.IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetRes, error) {
-	sess, err := h.sessions.GetSession(params.SessionID)
+	sess, err := h.getAuthorizedSession(ctx, params.SessionID)
 	if err != nil {
 		if errors.Is(err, session.ErrSessionNotFound) {
 			return &agentclient.IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetNotFound{
@@ -211,9 +212,21 @@ func (h *Handler) IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResu
 
 // CancelSessionAPIV1IncidentSessionSessionIDCancelPost implements POST /api/v1/incident/session/{session_id}/cancel.
 func (h *Handler) CancelSessionAPIV1IncidentSessionSessionIDCancelPost(
-	_ context.Context,
+	ctx context.Context,
 	params agentclient.CancelSessionAPIV1IncidentSessionSessionIDCancelPostParams,
 ) (agentclient.CancelSessionAPIV1IncidentSessionSessionIDCancelPostRes, error) {
+	if _, authzErr := h.getAuthorizedSession(ctx, params.SessionID); authzErr != nil {
+		if errors.Is(authzErr, session.ErrSessionNotFound) {
+			return &agentclient.CancelSessionAPIV1IncidentSessionSessionIDCancelPostNotFound{
+				Type:     "https://kubernaut.ai/problems/not-found",
+				Title:    "Session Not Found",
+				Detail:   fmt.Sprintf("session %s not found", params.SessionID),
+				Status:   404,
+				Instance: fmt.Sprintf("/api/v1/incident/session/%s/cancel", params.SessionID),
+			}, nil
+		}
+		return nil, fmt.Errorf("session authz: %w", authzErr)
+	}
 	err := h.sessions.CancelInvestigation(params.SessionID)
 	if err != nil {
 		if errors.Is(err, session.ErrSessionNotFound) {
@@ -246,10 +259,10 @@ func (h *Handler) CancelSessionAPIV1IncidentSessionSessionIDCancelPost(
 
 // SessionSnapshotAPIV1IncidentSessionSessionIDSnapshotGet implements GET /api/v1/incident/session/{session_id}/snapshot.
 func (h *Handler) SessionSnapshotAPIV1IncidentSessionSessionIDSnapshotGet(
-	_ context.Context,
+	ctx context.Context,
 	params agentclient.SessionSnapshotAPIV1IncidentSessionSessionIDSnapshotGetParams,
 ) (agentclient.SessionSnapshotAPIV1IncidentSessionSessionIDSnapshotGetRes, error) {
-	sess, err := h.sessions.GetSession(params.SessionID)
+	sess, err := h.getAuthorizedSession(ctx, params.SessionID)
 	if err != nil {
 		if errors.Is(err, session.ErrSessionNotFound) {
 			return &agentclient.SessionSnapshotAPIV1IncidentSessionSessionIDSnapshotGetNotFound{
@@ -354,7 +367,21 @@ func (h *Handler) SessionStreamAPIV1IncidentSessionSessionIDStreamGet(
 	ctx context.Context,
 	params agentclient.SessionStreamAPIV1IncidentSessionSessionIDStreamGetParams,
 ) (agentclient.SessionStreamAPIV1IncidentSessionSessionIDStreamGetRes, error) {
-	ch, err := h.sessions.Subscribe(params.SessionID)
+	if _, authzErr := h.getAuthorizedSession(ctx, params.SessionID); authzErr != nil {
+		if errors.Is(authzErr, session.ErrSessionNotFound) {
+			return &agentclient.HTTPError{
+				Type:     "https://kubernaut.ai/problems/not-found",
+				Title:    "Session Not Found",
+				Detail:   fmt.Sprintf("session %s not found", params.SessionID),
+				Status:   404,
+				Instance: fmt.Sprintf("/api/v1/incident/session/%s/stream", params.SessionID),
+			}, nil
+		}
+		h.logger.Error("stream authz failed", "session_id", params.SessionID, "error", authzErr)
+		return nil, fmt.Errorf("stream authz: %w", authzErr)
+	}
+
+	ch, err := h.sessions.Subscribe(ctx, params.SessionID)
 	if err != nil {
 		if errors.Is(err, session.ErrSessionNotFound) {
 			return &agentclient.HTTPError{
@@ -401,6 +428,29 @@ func (h *Handler) SessionStreamAPIV1IncidentSessionSessionIDStreamGet(
 	}()
 
 	return &agentclient.SessionStreamAPIV1IncidentSessionSessionIDStreamGetOK{Data: pr}, nil
+}
+
+// getAuthorizedSession retrieves a session and checks that the requesting user
+// is the session owner. Returns the session if authorized, or nil with
+// ErrSessionNotFound if the session doesn't exist or the user is not the owner.
+// When auth middleware is disabled (user is empty), ownership checks are skipped.
+func (h *Handler) getAuthorizedSession(ctx context.Context, sessionID string) (*session.Session, error) {
+	sess, err := h.sessions.GetSession(sessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	requestUser := auth.GetUserFromContext(ctx)
+	if requestUser == "" {
+		return sess, nil
+	}
+
+	owner := sess.Metadata["created_by"]
+	if owner != "" && owner != requestUser {
+		return nil, session.ErrSessionNotFound
+	}
+
+	return sess, nil
 }
 
 func mapSessionStatusToAPI(s session.Status) string {

--- a/internal/kubernautagent/server/handler.go
+++ b/internal/kubernautagent/server/handler.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"strings"
 	"time"
@@ -340,6 +341,66 @@ func MapIncidentRequestToSignal(req *agentclient.IncidentRequest) katypes.Signal
 		sc.LastSeen = v
 	}
 	return sc
+}
+
+// SessionStreamAPIV1IncidentSessionSessionIDStreamGet implements
+// GET /api/v1/incident/session/{session_id}/stream.
+// Returns an SSE event stream via io.Pipe. The ogen encoder copies from the
+// pipe reader while a goroutine writes SSE-framed events from the session's
+// event channel into the pipe writer. The pipe is closed when the channel
+// closes (investigation ends) or the request context is cancelled (client
+// disconnect).
+func (h *Handler) SessionStreamAPIV1IncidentSessionSessionIDStreamGet(
+	ctx context.Context,
+	params agentclient.SessionStreamAPIV1IncidentSessionSessionIDStreamGetParams,
+) (agentclient.SessionStreamAPIV1IncidentSessionSessionIDStreamGetRes, error) {
+	ch, err := h.sessions.Subscribe(params.SessionID)
+	if err != nil {
+		if errors.Is(err, session.ErrSessionNotFound) {
+			return &agentclient.HTTPError{
+				Type:     "https://kubernaut.ai/problems/not-found",
+				Title:    "Session Not Found",
+				Detail:   fmt.Sprintf("session %s not found", params.SessionID),
+				Status:   404,
+				Instance: fmt.Sprintf("/api/v1/incident/session/%s/stream", params.SessionID),
+			}, nil
+		}
+		if errors.Is(err, session.ErrSessionTerminal) {
+			return &agentclient.HTTPError{
+				Type:     "https://kubernaut.ai/problems/session-terminal",
+				Title:    "Session Terminal",
+				Detail:   fmt.Sprintf("session %s has already concluded; use the snapshot endpoint", params.SessionID),
+				Status:   404,
+				Instance: fmt.Sprintf("/api/v1/incident/session/%s/stream", params.SessionID),
+			}, nil
+		}
+		h.logger.Error("subscribe failed", "session_id", params.SessionID, "error", err)
+		return nil, fmt.Errorf("subscribe: %w", err)
+	}
+
+	pr, pw := io.Pipe()
+	go func() {
+		defer pw.Close()
+		seq := 1
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case ev, ok := <-ch:
+				if !ok {
+					return
+				}
+				data, _ := json.Marshal(ev)
+				frame := fmt.Sprintf("id: %d\nevent: %s\ndata: %s\n\n", seq, ev.Type, string(data))
+				if _, writeErr := pw.Write([]byte(frame)); writeErr != nil {
+					return
+				}
+				seq++
+			}
+		}
+	}()
+
+	return &agentclient.SessionStreamAPIV1IncidentSessionSessionIDStreamGetOK{Data: pr}, nil
 }
 
 func mapSessionStatusToAPI(s session.Status) string {

--- a/internal/kubernautagent/session/event_sink.go
+++ b/internal/kubernautagent/session/event_sink.go
@@ -16,20 +16,56 @@ limitations under the License.
 
 package session
 
-import "context"
+import (
+	"context"
+	"sync"
+)
 
 type eventSinkKey struct{}
 
-// WithEventSink returns a derived context carrying the given event channel.
-// The investigator retrieves it via EventSinkFromContext to emit turn-level
-// events without importing the session package directly.
+// LazySink holds a channel reference that can be set after the context is
+// created. This allows Subscribe to attach the event sink lazily while the
+// investigation goroutine's context is already in flight.
+type LazySink struct {
+	mu sync.RWMutex
+	ch chan<- InvestigationEvent
+}
+
+// Set assigns the channel. Safe for concurrent use.
+func (ls *LazySink) Set(ch chan<- InvestigationEvent) {
+	ls.mu.Lock()
+	ls.ch = ch
+	ls.mu.Unlock()
+}
+
+// Get returns the channel, or nil if not yet set.
+func (ls *LazySink) Get() chan<- InvestigationEvent {
+	ls.mu.RLock()
+	defer ls.mu.RUnlock()
+	return ls.ch
+}
+
+// WithLazySink returns a derived context carrying a LazySink.
+// The investigator retrieves the current channel via EventSinkFromContext.
+func WithLazySink(ctx context.Context, ls *LazySink) context.Context {
+	return context.WithValue(ctx, eventSinkKey{}, ls)
+}
+
+// WithEventSink returns a derived context carrying a pre-set event channel.
+// Retained for backward compatibility with tests that set the sink eagerly.
 func WithEventSink(ctx context.Context, ch chan<- InvestigationEvent) context.Context {
-	return context.WithValue(ctx, eventSinkKey{}, ch)
+	ls := &LazySink{}
+	ls.Set(ch)
+	return context.WithValue(ctx, eventSinkKey{}, ls)
 }
 
 // EventSinkFromContext retrieves the event sink channel from ctx, or nil if
-// none was attached. Callers must nil-check before sending.
+// none was attached (or the lazy sink has not been activated yet).
+// Callers must nil-check before sending.
 func EventSinkFromContext(ctx context.Context) chan<- InvestigationEvent {
-	ch, _ := ctx.Value(eventSinkKey{}).(chan<- InvestigationEvent)
-	return ch
+	ls, ok := ctx.Value(eventSinkKey{}).(*LazySink)
+	if !ok || ls == nil {
+		return nil
+	}
+	return ls.Get()
 }

--- a/internal/kubernautagent/session/manager.go
+++ b/internal/kubernautagent/session/manager.go
@@ -207,14 +207,11 @@ func (m *Manager) Subscribe(ctx context.Context, id string) (<-chan Investigatio
 	correlationID := sess.Metadata["remediation_id"]
 	m.store.mu.Unlock()
 
-	event := audit.NewEvent(audit.EventTypeSessionObserved, correlationID)
-	event.EventAction = audit.ActionSessionObserved
-	event.EventOutcome = audit.OutcomeSuccess
-	event.Data["session_id"] = id
+	var extra []string
 	if user := auth.GetUserFromContext(ctx); user != "" {
-		event.Data["observer_user"] = user
+		extra = append(extra, "observer_user", user)
 	}
-	audit.StoreBestEffort(ctx, m.auditStore, event, m.logger)
+	m.emitSessionEvent(ctx, audit.EventTypeSessionObserved, audit.ActionSessionObserved, audit.OutcomeSuccess, id, correlationID, nil, extra...)
 
 	return ch, nil
 }
@@ -287,15 +284,31 @@ func (m *Manager) emitCompleteEvent(id string) {
 	}
 }
 
+// EmitAccessDenied records a failed session access attempt for SOC2 CC8.1
+// failed-access audit trail. Fire-and-forget per ADR-038.
+func (m *Manager) EmitAccessDenied(ctx context.Context, sessionID, endpoint, requestingUser string) {
+	event := audit.NewEvent(audit.EventTypeSessionAccessDenied, "")
+	event.EventAction = audit.ActionSessionAccessDenied
+	event.EventOutcome = audit.OutcomeFailure
+	event.Data["session_id"] = sessionID
+	event.Data["endpoint"] = endpoint
+	event.Data["requesting_user"] = requestingUser
+	audit.StoreBestEffort(ctx, m.auditStore, event, m.logger)
+}
+
 // emitSessionEvent builds and stores an audit event for a session lifecycle
-// transition. Errors are fire-and-forget per ADR-038.
-func (m *Manager) emitSessionEvent(ctx context.Context, eventType, action, outcome, sessionID, correlationID string, fnErr error) {
+// transition. Optional extraData key-value pairs are merged into the event
+// data. Errors are fire-and-forget per ADR-038.
+func (m *Manager) emitSessionEvent(ctx context.Context, eventType, action, outcome, sessionID, correlationID string, fnErr error, extraData ...string) {
 	event := audit.NewEvent(eventType, correlationID)
 	event.EventAction = action
 	event.EventOutcome = outcome
 	event.Data["session_id"] = sessionID
 	if fnErr != nil {
 		event.Data["error"] = fnErr.Error()
+	}
+	for i := 0; i+1 < len(extraData); i += 2 {
+		event.Data[extraData[i]] = extraData[i+1]
 	}
 	audit.StoreBestEffort(ctx, m.auditStore, event, m.logger)
 }

--- a/internal/kubernautagent/session/manager.go
+++ b/internal/kubernautagent/session/manager.go
@@ -22,6 +22,7 @@ import (
 	"log/slog"
 
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/pkg/shared/auth"
 )
 
 // InvestigateFunc is the function signature for running an investigation.
@@ -54,6 +55,9 @@ const eventChannelBuffer = 64
 // StartInvestigation creates a new session and launches the investigation
 // function in a background goroutine. Returns the session ID immediately.
 // metadata is stored on the session for later retrieval (e.g., incident_id).
+// If the context carries an authenticated user (auth.UserContextKey), the
+// user identity is stored as "created_by" in session metadata for
+// object-level authorization checks.
 //
 // The goroutine uses a cancellable child of context.Background() to ensure
 // the investigation outlives the originating HTTP request while remaining
@@ -74,9 +78,13 @@ func (m *Manager) StartInvestigation(ctx context.Context, fn InvestigateFunc, me
 	if err != nil {
 		return "", err
 	}
-	if metadata != nil {
-		m.store.SetMetadata(id, metadata)
+	if metadata == nil {
+		metadata = make(map[string]string)
 	}
+	if user := auth.GetUserFromContext(ctx); user != "" {
+		metadata["created_by"] = user
+	}
+	m.store.SetMetadata(id, metadata)
 
 	bgCtx, cancelFn := context.WithCancel(context.Background())
 
@@ -168,11 +176,13 @@ func (m *Manager) CancelInvestigation(id string) error {
 // an event sink, preserving v1.4 Chat behavior. The channel is closed when
 // the investigation ends.
 //
+// The context carries the authenticated user identity (via auth.UserContextKey)
+// which is recorded in the aiagent.session.observed audit event for SOC2 CC8.1
+// operator attribution.
+//
 // Returns ErrSessionNotFound if the session does not exist, or
 // ErrSessionTerminal if the investigation has already concluded.
-//
-// Audit: emits aiagent.session.observed for SOC2 CC8.1 attribution.
-func (m *Manager) Subscribe(id string) (<-chan InvestigationEvent, error) {
+func (m *Manager) Subscribe(ctx context.Context, id string) (<-chan InvestigationEvent, error) {
 	m.store.mu.Lock()
 
 	sess, ok := m.store.sessions[id]
@@ -197,7 +207,14 @@ func (m *Manager) Subscribe(id string) (<-chan InvestigationEvent, error) {
 	correlationID := sess.Metadata["remediation_id"]
 	m.store.mu.Unlock()
 
-	m.emitSessionEvent(context.Background(), audit.EventTypeSessionObserved, audit.ActionSessionObserved, audit.OutcomeSuccess, id, correlationID, nil)
+	event := audit.NewEvent(audit.EventTypeSessionObserved, correlationID)
+	event.EventAction = audit.ActionSessionObserved
+	event.EventOutcome = audit.OutcomeSuccess
+	event.Data["session_id"] = id
+	if user := auth.GetUserFromContext(ctx); user != "" {
+		event.Data["observer_user"] = user
+	}
+	audit.StoreBestEffort(ctx, m.auditStore, event, m.logger)
 
 	return ch, nil
 }

--- a/internal/kubernautagent/session/manager.go
+++ b/internal/kubernautagent/session/manager.go
@@ -18,6 +18,7 @@ package session
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
@@ -45,8 +46,9 @@ func NewManager(store *Store, logger *slog.Logger, auditStore audit.AuditStore) 
 
 // eventChannelBuffer is the capacity of the per-session event channel.
 // 64 provides headroom for bursty LLM output (reasoning deltas + tool calls)
-// without blocking the investigation goroutine. Non-blocking send semantics
-// are deferred to PR 4 when events are actively written.
+// without blocking the investigation goroutine. The investigator uses
+// non-blocking send semantics (select/default) so a slow SSE consumer
+// cannot stall the investigation loop.
 const eventChannelBuffer = 64
 
 // StartInvestigation creates a new session and launches the investigation
@@ -56,6 +58,13 @@ const eventChannelBuffer = 64
 // The goroutine uses a cancellable child of context.Background() to ensure
 // the investigation outlives the originating HTTP request while remaining
 // cancellable via CancelInvestigation.
+//
+// A LazySink is placed on the context but starts with a nil channel.
+// EventSinkFromContext returns nil until Subscribe activates the sink,
+// ensuring autonomous investigations (no observer) use Chat (v1.4 parity).
+//
+// The goroutine includes recover() to catch panics in the investigation
+// function, transitioning the session to StatusFailed instead of crashing.
 //
 // Audit: emits aiagent.session.started after the session transitions to
 // StatusRunning, and aiagent.session.completed or aiagent.session.failed
@@ -71,13 +80,13 @@ func (m *Manager) StartInvestigation(ctx context.Context, fn InvestigateFunc, me
 
 	bgCtx, cancelFn := context.WithCancel(context.Background())
 
-	eventCh := make(chan InvestigationEvent, eventChannelBuffer)
-	bgCtx = WithEventSink(bgCtx, eventCh)
+	ls := &LazySink{}
+	bgCtx = WithLazySink(bgCtx, ls)
 
 	m.store.mu.Lock()
 	sess := m.store.sessions[id]
 	sess.cancel = cancelFn
-	sess.eventChan = eventCh
+	sess.lazySink = ls
 	m.store.mu.Unlock()
 
 	_ = m.store.Update(id, StatusRunning, nil, nil)
@@ -87,7 +96,10 @@ func (m *Manager) StartInvestigation(ctx context.Context, fn InvestigateFunc, me
 
 	go func() {
 		defer m.closeEventChan(id)
+		defer m.recoverPanic(id, correlationID)
+
 		result, fnErr := fn(bgCtx)
+		m.emitCompleteEvent(id)
 		if fnErr != nil {
 			m.logger.Error("investigation failed",
 				slog.String("session_id", id),
@@ -151,21 +163,43 @@ func (m *Manager) CancelInvestigation(id string) error {
 }
 
 // Subscribe returns a read-only channel that delivers investigation events
-// for the given session. The channel is closed when the investigation ends.
+// for the given session. The event sink is lazily created on the first
+// Subscribe call so that autonomous investigations (no observer) run without
+// an event sink, preserving v1.4 Chat behavior. The channel is closed when
+// the investigation ends.
+//
 // Returns ErrSessionNotFound if the session does not exist, or
 // ErrSessionTerminal if the investigation has already concluded.
+//
+// Audit: emits aiagent.session.observed for SOC2 CC8.1 attribution.
 func (m *Manager) Subscribe(id string) (<-chan InvestigationEvent, error) {
-	m.store.mu.RLock()
-	defer m.store.mu.RUnlock()
+	m.store.mu.Lock()
 
 	sess, ok := m.store.sessions[id]
 	if !ok {
+		m.store.mu.Unlock()
 		return nil, ErrSessionNotFound
 	}
-	if sess.eventChan == nil {
+	if IsTerminal(sess.Status) && sess.eventChan == nil {
+		m.store.mu.Unlock()
 		return nil, ErrSessionTerminal
 	}
-	return sess.eventChan, nil
+
+	if sess.eventChan == nil {
+		ch := make(chan InvestigationEvent, eventChannelBuffer)
+		sess.eventChan = ch
+		if sess.lazySink != nil {
+			sess.lazySink.Set(ch)
+		}
+	}
+
+	ch := sess.eventChan
+	correlationID := sess.Metadata["remediation_id"]
+	m.store.mu.Unlock()
+
+	m.emitSessionEvent(context.Background(), audit.EventTypeSessionObserved, audit.ActionSessionObserved, audit.OutcomeSuccess, id, correlationID, nil)
+
+	return ch, nil
 }
 
 // closeEventChan closes the event channel for a session and sets it to nil,
@@ -196,6 +230,44 @@ func (m *Manager) GetSession(id string) (*Session, error) {
 // partial investigation state for snapshot retrieval (BR-SESSION-002).
 func (m *Manager) storePartialResult(id string, result interface{}) {
 	m.store.SetResult(id, result)
+}
+
+// recoverPanic catches panics in the investigation goroutine, transitions the
+// session to StatusFailed, and logs with stack context. This prevents a
+// panicking LLM tool or parser from crashing the entire KA process.
+func (m *Manager) recoverPanic(id, correlationID string) {
+	r := recover()
+	if r == nil {
+		return
+	}
+	m.logger.Error("investigation panic recovered",
+		slog.String("session_id", id),
+		slog.Any("panic", r),
+	)
+	_ = m.store.Update(id, StatusFailed, nil, fmt.Errorf("panic: %v", r))
+	m.emitSessionEvent(context.Background(), audit.EventTypeSessionFailed, audit.ActionSessionFailed, audit.OutcomeFailure, id, correlationID, fmt.Errorf("panic: %v", r))
+}
+
+// emitCompleteEvent sends an EventTypeComplete to the event sink (if active)
+// to signal the SSE consumer that the investigation has finished.
+func (m *Manager) emitCompleteEvent(id string) {
+	m.store.mu.RLock()
+	sess, ok := m.store.sessions[id]
+	m.store.mu.RUnlock()
+	if !ok {
+		return
+	}
+	if sess.lazySink == nil {
+		return
+	}
+	ch := sess.lazySink.Get()
+	if ch == nil {
+		return
+	}
+	select {
+	case ch <- InvestigationEvent{Type: EventTypeComplete}:
+	default:
+	}
 }
 
 // emitSessionEvent builds and stores an audit event for a session lifecycle

--- a/internal/kubernautagent/session/store.go
+++ b/internal/kubernautagent/session/store.go
@@ -46,10 +46,11 @@ type Session struct {
 	CreatedAt time.Time
 	Metadata  map[string]string
 
-	// cancel and eventChan are manager-managed internal fields.
+	// cancel, eventChan, and lazySink are manager-managed internal fields.
 	// They are NOT part of the public copy surface (clone excludes them).
 	cancel    context.CancelFunc
 	eventChan chan InvestigationEvent
+	lazySink  *LazySink
 }
 
 // ErrSessionNotFound is returned when a session ID does not exist in the store.
@@ -107,6 +108,7 @@ func (s *Session) clone() *Session {
 	cp := *s
 	cp.cancel = nil
 	cp.eventChan = nil
+	cp.lazySink = nil
 	if s.Metadata != nil {
 		cp.Metadata = make(map[string]string, len(s.Metadata))
 		for k, v := range s.Metadata {

--- a/test/integration/kubernautagent/session/manager_audit_test.go
+++ b/test/integration/kubernautagent/session/manager_audit_test.go
@@ -213,7 +213,7 @@ var _ = Describe("Kubernaut Agent Session Audit Trail — #823 PR 1.5", func() {
 
 			// Wait for goroutine to finish
 			Eventually(func() bool {
-				_, subErr := mgr.Subscribe(id)
+				_, subErr := mgr.Subscribe(context.Background(), id)
 				return errors.Is(subErr, session.ErrSessionTerminal)
 			}, 2*time.Second, 10*time.Millisecond).Should(BeTrue())
 

--- a/test/integration/kubernautagent/session/manager_cancel_test.go
+++ b/test/integration/kubernautagent/session/manager_cancel_test.go
@@ -105,7 +105,7 @@ var _ = Describe("Kubernaut Agent Session Manager Cancellation — #823 PR3", fu
 
 			<-proceed
 
-			ch, subErr := manager.Subscribe(id)
+			ch, subErr := manager.Subscribe(context.Background(), id)
 			Expect(subErr).NotTo(HaveOccurred())
 			Expect(ch).NotTo(BeNil())
 

--- a/test/integration/kubernautagent/session/manager_sse_delivery_test.go
+++ b/test/integration/kubernautagent/session/manager_sse_delivery_test.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session_test
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+)
+
+var _ = Describe("SSE Delivery Integration — #823 PR7", func() {
+
+	Describe("IT-KA-823-D01: Subscribe triggers event sink — events flow to subscriber", func() {
+		It("events emitted after Subscribe are received by subscriber", func() {
+			store := session.NewStore(30 * time.Minute)
+			mgr := session.NewManager(store, slog.Default(), audit.NopAuditStore{})
+
+			subscribed := make(chan struct{})
+			proceed := make(chan struct{})
+
+			id, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				<-subscribed
+				sink := session.EventSinkFromContext(ctx)
+				if sink != nil {
+					sink <- session.InvestigationEvent{
+						Type:  session.EventTypeReasoningDelta,
+						Turn:  0,
+						Phase: "rca",
+					}
+					sink <- session.InvestigationEvent{
+						Type:  session.EventTypeToolCallStart,
+						Turn:  0,
+						Phase: "rca",
+					}
+				}
+				<-proceed
+				return map[string]string{"rca_summary": "delivered"}, nil
+			}, map[string]string{"remediation_id": "rr-sse-delivery"})
+			Expect(err).NotTo(HaveOccurred())
+
+			ch, subErr := mgr.Subscribe(id)
+			Expect(subErr).NotTo(HaveOccurred())
+			close(subscribed)
+
+			var events []session.InvestigationEvent
+			Eventually(func() int {
+				for {
+					select {
+					case ev, ok := <-ch:
+						if !ok {
+							return len(events)
+						}
+						events = append(events, ev)
+					default:
+						return len(events)
+					}
+				}
+			}, 5*time.Second).Should(BeNumerically(">=", 2),
+				"subscriber should receive events emitted after Subscribe triggers the sink")
+
+			close(proceed)
+		})
+	})
+
+	Describe("IT-KA-823-D02: Client disconnect does not block investigation", func() {
+		It("investigation completes even if subscriber stops reading", func() {
+			store := session.NewStore(30 * time.Minute)
+			mgr := session.NewManager(store, slog.Default(), audit.NopAuditStore{})
+
+			subscribed := make(chan struct{})
+
+			id, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				<-subscribed
+				sink := session.EventSinkFromContext(ctx)
+				if sink != nil {
+					for i := 0; i < 200; i++ {
+						select {
+						case sink <- session.InvestigationEvent{
+							Type:  session.EventTypeReasoningDelta,
+							Turn:  i,
+							Phase: "rca",
+						}:
+						default:
+						}
+					}
+				}
+				return map[string]string{"rca_summary": "completed despite slow consumer"}, nil
+			}, map[string]string{"remediation_id": "rr-disconnect"})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, subErr := mgr.Subscribe(id)
+			Expect(subErr).NotTo(HaveOccurred())
+			close(subscribed)
+
+			Eventually(func() session.Status {
+				sess, _ := mgr.GetSession(id)
+				if sess == nil {
+					return session.StatusPending
+				}
+				return sess.Status
+			}, 10*time.Second).Should(Equal(session.StatusCompleted),
+				"investigation must complete even when subscriber is slow/disconnected")
+		})
+	})
+})

--- a/test/integration/kubernautagent/session/manager_sse_delivery_test.go
+++ b/test/integration/kubernautagent/session/manager_sse_delivery_test.go
@@ -58,7 +58,7 @@ var _ = Describe("SSE Delivery Integration — #823 PR7", func() {
 			}, map[string]string{"remediation_id": "rr-sse-delivery"})
 			Expect(err).NotTo(HaveOccurred())
 
-			ch, subErr := mgr.Subscribe(id)
+			ch, subErr := mgr.Subscribe(context.Background(), id)
 			Expect(subErr).NotTo(HaveOccurred())
 			close(subscribed)
 
@@ -108,7 +108,7 @@ var _ = Describe("SSE Delivery Integration — #823 PR7", func() {
 			}, map[string]string{"remediation_id": "rr-disconnect"})
 			Expect(err).NotTo(HaveOccurred())
 
-			_, subErr := mgr.Subscribe(id)
+			_, subErr := mgr.Subscribe(context.Background(), id)
 			Expect(subErr).NotTo(HaveOccurred())
 			close(subscribed)
 

--- a/test/integration/kubernautagent/session/manager_stream_test.go
+++ b/test/integration/kubernautagent/session/manager_stream_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Session Manager Stream Integration — #823 PR4", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(id).NotTo(BeEmpty())
 
-			_, subErr := mgr.Subscribe(id)
+			_, subErr := mgr.Subscribe(context.Background(), id)
 			Expect(subErr).NotTo(HaveOccurred())
 			close(subscribed)
 
@@ -69,7 +69,7 @@ var _ = Describe("Session Manager Stream Integration — #823 PR4", func() {
 			}, map[string]string{"remediation_id": "rr-stream-close"})
 			Expect(err).NotTo(HaveOccurred())
 
-			ch, subErr := mgr.Subscribe(id)
+			ch, subErr := mgr.Subscribe(context.Background(), id)
 			Expect(subErr).NotTo(HaveOccurred())
 			Expect(ch).NotTo(BeNil())
 
@@ -105,7 +105,7 @@ var _ = Describe("Session Manager Stream Integration — #823 PR4", func() {
 			}, map[string]string{"remediation_id": "rr-flow-test"})
 			Expect(err).NotTo(HaveOccurred())
 
-			ch, subErr := mgr.Subscribe(id)
+			ch, subErr := mgr.Subscribe(context.Background(), id)
 			Expect(subErr).NotTo(HaveOccurred())
 
 			var events []session.InvestigationEvent

--- a/test/integration/kubernautagent/session/manager_stream_test.go
+++ b/test/integration/kubernautagent/session/manager_stream_test.go
@@ -30,28 +30,30 @@ import (
 
 var _ = Describe("Session Manager Stream Integration — #823 PR4", func() {
 
-	Describe("IT-KA-823-S04: Event sink wired in StartInvestigation context", func() {
-		It("investigation function receives event sink via context", func() {
+	Describe("IT-KA-823-S04: Lazy event sink activated by Subscribe", func() {
+		It("investigation function receives non-nil event sink after Subscribe", func() {
 			store := session.NewStore(30 * time.Minute)
 			mgr := session.NewManager(store, slog.Default(), audit.NopAuditStore{})
 
+			subscribed := make(chan struct{})
 			sinkReceived := make(chan bool, 1)
 
 			id, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				<-subscribed
 				sink := session.EventSinkFromContext(ctx)
-				if sink != nil {
-					sinkReceived <- true
-				} else {
-					sinkReceived <- false
-				}
+				sinkReceived <- (sink != nil)
 				return map[string]string{"rca_summary": "test"}, nil
 			}, map[string]string{"remediation_id": "rr-stream-test"})
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(id).NotTo(BeEmpty())
 
+			_, subErr := mgr.Subscribe(id)
+			Expect(subErr).NotTo(HaveOccurred())
+			close(subscribed)
+
 			Eventually(sinkReceived, 5*time.Second).Should(Receive(BeTrue()),
-				"investigation function must receive a non-nil event sink via context")
+				"investigation function must receive a non-nil event sink after Subscribe activates the lazy sink")
 		})
 	})
 

--- a/test/integration/kubernautagent/session/manager_test.go
+++ b/test/integration/kubernautagent/session/manager_test.go
@@ -249,7 +249,7 @@ var _ = Describe("Session Cancellation Infrastructure — #823", func() {
 				return sess.Status
 			}, 1*time.Second, 10*time.Millisecond).Should(Equal(session.StatusRunning))
 
-			ch, err := manager.Subscribe(id)
+			ch, err := manager.Subscribe(context.Background(), id)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ch).NotTo(BeNil(), "event channel must be non-nil for a running investigation")
 
@@ -273,9 +273,9 @@ var _ = Describe("Session Cancellation Infrastructure — #823", func() {
 				return sess.Status
 			}, 1*time.Second, 10*time.Millisecond).Should(Equal(session.StatusRunning))
 
-			ch1, err := manager.Subscribe(id)
+			ch1, err := manager.Subscribe(context.Background(), id)
 			Expect(err).NotTo(HaveOccurred())
-			ch2, err := manager.Subscribe(id)
+			ch2, err := manager.Subscribe(context.Background(), id)
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(ch1).To(BeIdenticalTo(ch2),
@@ -303,7 +303,7 @@ var _ = Describe("Session Cancellation Infrastructure — #823", func() {
 				return sess.Status
 			}, 1*time.Second, 10*time.Millisecond).Should(Equal(session.StatusRunning))
 
-			ch, err := manager.Subscribe(id)
+			ch, err := manager.Subscribe(context.Background(), id)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ch).NotTo(BeNil())
 
@@ -323,7 +323,7 @@ var _ = Describe("Session Cancellation Infrastructure — #823", func() {
 
 	Describe("IT-KA-823-008: Subscribing to a nonexistent investigation returns a clear error", func() {
 		It("should return ErrSessionNotFound for unknown session ID", func() {
-			ch, err := manager.Subscribe("nonexistent-id")
+			ch, err := manager.Subscribe(context.Background(), "nonexistent-id")
 			Expect(err).To(MatchError(session.ErrSessionNotFound))
 			Expect(ch).To(BeNil())
 		})
@@ -344,7 +344,7 @@ var _ = Describe("Session Cancellation Infrastructure — #823", func() {
 				return sess.Status
 			}, 2*time.Second, 10*time.Millisecond).Should(Equal(session.StatusCompleted))
 
-			ch, err := manager.Subscribe(id)
+			ch, err := manager.Subscribe(context.Background(), id)
 			Expect(err).To(MatchError(session.ErrSessionTerminal))
 			Expect(ch).To(BeNil())
 		})

--- a/test/unit/kubernautagent/audit/emitter_test.go
+++ b/test/unit/kubernautagent/audit/emitter_test.go
@@ -65,8 +65,8 @@ var _ = Describe("Kubernaut Agent Audit Emitter — #433", func() {
 			Entry("aiagent.alignment.verdict", audit.EventTypeAlignmentVerdict),
 		)
 
-		It("should define exactly 17 event types", func() {
-			Expect(audit.AllEventTypes).To(HaveLen(17))
+		It("should define exactly 18 event types", func() {
+			Expect(audit.AllEventTypes).To(HaveLen(18))
 		})
 	})
 

--- a/test/unit/kubernautagent/server/cancel_snapshot_test.go
+++ b/test/unit/kubernautagent/server/cancel_snapshot_test.go
@@ -246,16 +246,18 @@ var _ = Describe("TP-823-OAS: Cancel, Snapshot, Stream Endpoints (#823 PR2)", fu
 		})
 	})
 
-	// --- Stream Stub ---
+	// --- Stream Endpoint ---
 
-	Describe("UT-KA-823-OAS-008: Stream endpoint returns 501 Not Implemented", func() {
-		It("should return ErrNotImplemented since SSE is deferred to PR4", func() {
+	Describe("UT-KA-823-OAS-008: Stream endpoint returns 404 for unknown session", func() {
+		It("should return HTTPError with status 404 for nonexistent session", func() {
 			params := agentclient.SessionStreamAPIV1IncidentSessionSessionIDStreamGetParams{
 				SessionID: "any-session",
 			}
-			_, err := handler.SessionStreamAPIV1IncidentSessionSessionIDStreamGet(context.Background(), params)
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("not implemented"))
+			resp, err := handler.SessionStreamAPIV1IncidentSessionSessionIDStreamGet(context.Background(), params)
+			Expect(err).NotTo(HaveOccurred())
+			httpErr, ok := resp.(*agentclient.HTTPError)
+			Expect(ok).To(BeTrue(), "response should be HTTPError for not-found session")
+			Expect(httpErr.Status).To(Equal(404))
 		})
 	})
 })

--- a/test/unit/kubernautagent/server/session_authz_test.go
+++ b/test/unit/kubernautagent/server/session_authz_test.go
@@ -201,6 +201,46 @@ var _ = Describe("Session Object-Level Authorization — #823 PR7.5", func() {
 		})
 	})
 
+	Describe("UT-KA-823-A10: Denied access emits audit event", func() {
+		It("emits aiagent.session.access_denied when non-owner attempts access", func() {
+			recorder := &syncAuditRecorder{}
+			authzStore := session.NewStore(30 * time.Minute)
+			authzMgr := session.NewManager(authzStore, slog.Default(), recorder)
+			authzH := server.NewHandler(authzMgr, nil, slog.Default())
+
+			proceed := make(chan struct{})
+			id, err := authzMgr.StartInvestigation(userCtx("user-a"), func(ctx context.Context) (interface{}, error) {
+				<-proceed
+				return nil, nil
+			}, map[string]string{"remediation_id": "rr-denied-audit"})
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() { close(proceed) })
+
+			resp, err := authzH.IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet(
+				userCtx("user-b"),
+				agentclient.IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetParams{SessionID: id},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			httpErr, ok := resp.(*agentclient.HTTPError)
+			Expect(ok).To(BeTrue())
+			Expect(httpErr.Status).To(Equal(404))
+
+			Eventually(func() bool {
+				for _, evt := range recorder.Events() {
+					if evt.EventType == audit.EventTypeSessionAccessDenied {
+						user, _ := evt.Data["requesting_user"].(string)
+						sid, _ := evt.Data["session_id"].(string)
+						ep, _ := evt.Data["endpoint"].(string)
+						return user == "user-b" && sid == id && ep != ""
+					}
+				}
+				return false
+			}, 5*time.Second).Should(BeTrue(),
+				"access_denied audit event must include requesting_user, session_id, and endpoint")
+		})
+	})
+
 	Describe("UT-KA-823-A09: session.observed includes observer identity", func() {
 		It("audit event includes the subscribing user extracted from context", func() {
 			recorder := &syncAuditRecorder{}

--- a/test/unit/kubernautagent/server/session_authz_test.go
+++ b/test/unit/kubernautagent/server/session_authz_test.go
@@ -1,0 +1,255 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server_test
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/server"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	katypes "github.com/jordigilh/kubernaut/internal/kubernautagent/types"
+	"github.com/jordigilh/kubernaut/pkg/agentclient"
+	"github.com/jordigilh/kubernaut/pkg/shared/auth"
+)
+
+func userCtx(user string) context.Context {
+	return context.WithValue(context.Background(), auth.UserContextKey, user)
+}
+
+var _ = Describe("Session Object-Level Authorization — #823 PR7.5", func() {
+
+	var (
+		store *session.Store
+		mgr   *session.Manager
+		h     *server.Handler
+	)
+
+	BeforeEach(func() {
+		store = session.NewStore(30 * time.Minute)
+		mgr = session.NewManager(store, slog.Default(), audit.NopAuditStore{})
+		h = server.NewHandler(mgr, &stubInvestigator{
+			fn: func(ctx context.Context, _ katypes.SignalContext) (*katypes.InvestigationResult, error) {
+				<-ctx.Done()
+				return &katypes.InvestigationResult{RCASummary: "cancelled"}, nil
+			},
+		}, slog.Default())
+	})
+
+	createSessionAs := func(user string) string {
+		ctx := userCtx(user)
+		proceed := make(chan struct{})
+		id, err := mgr.StartInvestigation(ctx, func(bgCtx context.Context) (interface{}, error) {
+			<-proceed
+			return &katypes.InvestigationResult{RCASummary: "done"}, nil
+		}, map[string]string{"remediation_id": "rr-authz-test"})
+		Expect(err).NotTo(HaveOccurred())
+		DeferCleanup(func() { close(proceed) })
+		return id
+	}
+
+	Describe("UT-KA-823-A01: Session created_by stored in metadata", func() {
+		It("session metadata contains the creating user identity", func() {
+			id := createSessionAs("system:serviceaccount:kubernaut:operator-a")
+
+			sess, err := mgr.GetSession(id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sess.Metadata).To(HaveKeyWithValue("created_by", "system:serviceaccount:kubernaut:operator-a"))
+		})
+	})
+
+	Describe("UT-KA-823-A02: Owner can access their session status", func() {
+		It("returns 200 when owner queries session status", func() {
+			id := createSessionAs("user-a")
+
+			resp, err := h.IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet(
+				userCtx("user-a"),
+				agentclient.IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetParams{SessionID: id},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, ok := resp.(*agentclient.IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetOKApplicationJSON)
+			Expect(ok).To(BeTrue(), "owner should receive 200 OK for session status")
+		})
+	})
+
+	Describe("UT-KA-823-A03: Non-owner gets 404 on session status", func() {
+		It("returns 404 when non-owner queries session status", func() {
+			id := createSessionAs("user-a")
+
+			resp, err := h.IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet(
+				userCtx("user-b"),
+				agentclient.IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetParams{SessionID: id},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			httpErr, ok := resp.(*agentclient.HTTPError)
+			Expect(ok).To(BeTrue(), "non-owner should receive HTTPError (404)")
+			Expect(httpErr.Status).To(Equal(404))
+		})
+	})
+
+	Describe("UT-KA-823-A04: Non-owner gets 404 on cancel", func() {
+		It("returns 404 when non-owner tries to cancel session", func() {
+			id := createSessionAs("user-a")
+
+			resp, err := h.CancelSessionAPIV1IncidentSessionSessionIDCancelPost(
+				userCtx("user-b"),
+				agentclient.CancelSessionAPIV1IncidentSessionSessionIDCancelPostParams{SessionID: id},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, ok := resp.(*agentclient.CancelSessionAPIV1IncidentSessionSessionIDCancelPostNotFound)
+			Expect(ok).To(BeTrue(), "non-owner should receive 404 on cancel")
+		})
+	})
+
+	Describe("UT-KA-823-A05: Non-owner gets 404 on snapshot", func() {
+		It("returns 404 when non-owner tries to read snapshot", func() {
+			id := createSessionAs("user-a")
+
+			resp, err := h.SessionSnapshotAPIV1IncidentSessionSessionIDSnapshotGet(
+				userCtx("user-b"),
+				agentclient.SessionSnapshotAPIV1IncidentSessionSessionIDSnapshotGetParams{SessionID: id},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			httpErr, ok := resp.(*agentclient.SessionSnapshotAPIV1IncidentSessionSessionIDSnapshotGetNotFound)
+			Expect(ok).To(BeTrue(), "non-owner should receive 404 on snapshot")
+			Expect(httpErr.Status).To(Equal(404))
+		})
+	})
+
+	Describe("UT-KA-823-A06: Non-owner gets 404 on stream", func() {
+		It("returns 404 when non-owner tries to subscribe to stream", func() {
+			id := createSessionAs("user-a")
+
+			resp, err := h.SessionStreamAPIV1IncidentSessionSessionIDStreamGet(
+				userCtx("user-b"),
+				agentclient.SessionStreamAPIV1IncidentSessionSessionIDStreamGetParams{SessionID: id},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			httpErr, ok := resp.(*agentclient.HTTPError)
+			Expect(ok).To(BeTrue(), "non-owner should receive HTTPError (404) on stream")
+			Expect(httpErr.Status).To(Equal(404))
+		})
+	})
+
+	Describe("UT-KA-823-A07: Non-owner gets 404 on result", func() {
+		It("returns 404 when non-owner tries to read result", func() {
+			completedStore := session.NewStore(30 * time.Minute)
+			completedMgr := session.NewManager(completedStore, slog.Default(), audit.NopAuditStore{})
+			completedH := server.NewHandler(completedMgr, nil, slog.Default())
+
+			id, sErr := completedMgr.StartInvestigation(userCtx("user-a"), func(ctx context.Context) (interface{}, error) {
+				return &katypes.InvestigationResult{RCASummary: "done", Confidence: 0.9}, nil
+			}, map[string]string{"remediation_id": "rr-authz-result"})
+			Expect(sErr).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				sess, _ := completedMgr.GetSession(id)
+				if sess == nil {
+					return session.StatusPending
+				}
+				return sess.Status
+			}, 5*time.Second).Should(Equal(session.StatusCompleted))
+
+			resp, err := completedH.IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGet(
+				userCtx("user-b"),
+				agentclient.IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetParams{SessionID: id},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, ok := resp.(*agentclient.IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetNotFound)
+			Expect(ok).To(BeTrue(), "non-owner should receive 404 on result")
+		})
+	})
+
+	Describe("UT-KA-823-A08: Empty user (no auth) bypasses authz", func() {
+		It("allows access when auth middleware is disabled (no user in context)", func() {
+			id := createSessionAs("")
+
+			resp, err := h.IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet(
+				context.Background(),
+				agentclient.IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetParams{SessionID: id},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, ok := resp.(*agentclient.IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetOKApplicationJSON)
+			Expect(ok).To(BeTrue(), "unauthenticated context should still access sessions (dev mode)")
+		})
+	})
+
+	Describe("UT-KA-823-A09: session.observed includes observer identity", func() {
+		It("audit event includes the subscribing user extracted from context", func() {
+			recorder := &syncAuditRecorder{}
+			authzStore := session.NewStore(30 * time.Minute)
+			authzMgr := session.NewManager(authzStore, slog.Default(), recorder)
+
+			proceed := make(chan struct{})
+			id, err := authzMgr.StartInvestigation(userCtx("user-a"), func(ctx context.Context) (interface{}, error) {
+				<-proceed
+				return nil, nil
+			}, map[string]string{"remediation_id": "rr-observer-audit"})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, subErr := authzMgr.Subscribe(userCtx("user-a"), id)
+			Expect(subErr).NotTo(HaveOccurred())
+
+			close(proceed)
+
+			Eventually(func() bool {
+				for _, evt := range recorder.Events() {
+					if evt.EventType == audit.EventTypeSessionObserved {
+						if observer, ok := evt.Data["observer_user"].(string); ok {
+							return observer == "user-a"
+						}
+					}
+				}
+				return false
+			}, 5*time.Second).Should(BeTrue(),
+				"session.observed audit event must include observer_user identity")
+		})
+	})
+})
+
+type syncAuditRecorder struct {
+	mu     sync.Mutex
+	events []*audit.AuditEvent
+}
+
+func (r *syncAuditRecorder) StoreAudit(_ context.Context, event *audit.AuditEvent) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, event)
+	return nil
+}
+
+func (r *syncAuditRecorder) Events() []*audit.AuditEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := make([]*audit.AuditEvent, len(r.events))
+	copy(cp, r.events)
+	return cp
+}

--- a/test/unit/kubernautagent/server/stream_handler_test.go
+++ b/test/unit/kubernautagent/server/stream_handler_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/server"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	katypes "github.com/jordigilh/kubernaut/internal/kubernautagent/types"
+	"github.com/jordigilh/kubernaut/pkg/agentclient"
+)
+
+type stubInvestigator struct {
+	fn func(ctx context.Context, signal katypes.SignalContext) (*katypes.InvestigationResult, error)
+}
+
+func (s *stubInvestigator) Investigate(ctx context.Context, signal katypes.SignalContext) (*katypes.InvestigationResult, error) {
+	return s.fn(ctx, signal)
+}
+
+var _ = Describe("SSE Stream Handler — #823 PR7", func() {
+
+	var (
+		store *session.Store
+		mgr   *session.Manager
+		h     *server.Handler
+	)
+
+	BeforeEach(func() {
+		store = session.NewStore(30 * time.Minute)
+		mgr = session.NewManager(store, slog.Default(), audit.NopAuditStore{})
+		h = server.NewHandler(mgr, &stubInvestigator{
+			fn: func(ctx context.Context, _ katypes.SignalContext) (*katypes.InvestigationResult, error) {
+				<-ctx.Done()
+				return &katypes.InvestigationResult{RCASummary: "cancelled"}, nil
+			},
+		}, slog.Default())
+	})
+
+	Describe("UT-KA-823-D01: SSE stream delivers investigation events to HTTP client", func() {
+		It("returns SSE-framed events via io.Reader", func() {
+			proceed := make(chan struct{})
+			id, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				sink := session.EventSinkFromContext(ctx)
+				if sink != nil {
+					sink <- session.InvestigationEvent{
+						Type:  session.EventTypeReasoningDelta,
+						Turn:  0,
+						Phase: "rca",
+						Data:  json.RawMessage(`{"content_preview":"test"}`),
+					}
+				}
+				<-proceed
+				return map[string]string{"rca_summary": "test"}, nil
+			}, map[string]string{"remediation_id": "rr-sse-test"})
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, handlerErr := h.SessionStreamAPIV1IncidentSessionSessionIDStreamGet(
+				context.Background(),
+				agentclient.SessionStreamAPIV1IncidentSessionSessionIDStreamGetParams{SessionID: id},
+			)
+			Expect(handlerErr).NotTo(HaveOccurred())
+
+			okResp, ok := resp.(*agentclient.SessionStreamAPIV1IncidentSessionSessionIDStreamGetOK)
+			Expect(ok).To(BeTrue(), "response should be OK type with SSE data")
+			Expect(okResp.Data).NotTo(BeNil())
+
+			close(proceed)
+			data, readErr := io.ReadAll(okResp.Data)
+			Expect(readErr).NotTo(HaveOccurred())
+			Expect(string(data)).To(ContainSubstring("event: reasoning_delta"))
+			Expect(string(data)).To(ContainSubstring("data: "))
+		})
+	})
+
+	Describe("UT-KA-823-D02: Stream ends when investigation completes", func() {
+		It("returns 404 for a session that has already completed", func() {
+			id, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				return map[string]string{"rca_summary": "done"}, nil
+			}, map[string]string{"remediation_id": "rr-sse-eof"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				sess, _ := mgr.GetSession(id)
+				if sess == nil {
+					return session.StatusPending
+				}
+				return sess.Status
+			}, 5*time.Second).Should(Equal(session.StatusCompleted))
+
+			resp, handlerErr := h.SessionStreamAPIV1IncidentSessionSessionIDStreamGet(
+				context.Background(),
+				agentclient.SessionStreamAPIV1IncidentSessionSessionIDStreamGetParams{SessionID: id},
+			)
+			Expect(handlerErr).NotTo(HaveOccurred())
+
+			httpErr, ok := resp.(*agentclient.HTTPError)
+			Expect(ok).To(BeTrue(), "already-completed session should return 404 (terminal)")
+			Expect(httpErr.Status).To(Equal(404))
+		})
+	})
+
+	Describe("UT-KA-823-D03: Stream for unknown session returns 404", func() {
+		It("returns HTTPError for nonexistent session", func() {
+			resp, handlerErr := h.SessionStreamAPIV1IncidentSessionSessionIDStreamGet(
+				context.Background(),
+				agentclient.SessionStreamAPIV1IncidentSessionSessionIDStreamGetParams{SessionID: "nonexistent-id"},
+			)
+			Expect(handlerErr).NotTo(HaveOccurred())
+
+			httpErr, ok := resp.(*agentclient.HTTPError)
+			Expect(ok).To(BeTrue(), "response should be HTTPError for not-found")
+			Expect(httpErr.Status).To(Equal(404))
+			Expect(httpErr.Detail).To(ContainSubstring("not found"))
+		})
+	})
+
+	Describe("UT-KA-823-D04: Stream for terminal session returns 404", func() {
+		It("returns HTTPError for completed session with no active stream", func() {
+			id, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				return map[string]string{"rca_summary": "done"}, nil
+			}, map[string]string{"remediation_id": "rr-terminal"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				sess, _ := mgr.GetSession(id)
+				if sess == nil {
+					return session.StatusPending
+				}
+				return sess.Status
+			}, 5*time.Second).Should(Equal(session.StatusCompleted))
+
+			resp, handlerErr := h.SessionStreamAPIV1IncidentSessionSessionIDStreamGet(
+				context.Background(),
+				agentclient.SessionStreamAPIV1IncidentSessionSessionIDStreamGetParams{SessionID: id},
+			)
+			Expect(handlerErr).NotTo(HaveOccurred())
+
+			httpErr, ok := resp.(*agentclient.HTTPError)
+			Expect(ok).To(BeTrue(), "response should be HTTPError for terminal session")
+			Expect(httpErr.Status).To(Equal(404))
+		})
+	})
+})

--- a/test/unit/kubernautagent/session/lazy_sink_test.go
+++ b/test/unit/kubernautagent/session/lazy_sink_test.go
@@ -82,7 +82,7 @@ var _ = Describe("Lazy Event Sink — #823 PR7", func() {
 			}, map[string]string{"remediation_id": "rr-complete-evt"})
 			Expect(err).NotTo(HaveOccurred())
 
-			ch, subErr := mgr.Subscribe(id)
+			ch, subErr := mgr.Subscribe(context.Background(), id)
 			Expect(subErr).NotTo(HaveOccurred())
 			Expect(ch).NotTo(BeNil())
 
@@ -121,7 +121,7 @@ var _ = Describe("Lazy Event Sink — #823 PR7", func() {
 			}, map[string]string{"remediation_id": "rr-observed"})
 			Expect(err).NotTo(HaveOccurred())
 
-			_, subErr := mgr.Subscribe(id)
+			_, subErr := mgr.Subscribe(context.Background(), id)
 			Expect(subErr).NotTo(HaveOccurred())
 
 			close(proceed)

--- a/test/unit/kubernautagent/session/lazy_sink_test.go
+++ b/test/unit/kubernautagent/session/lazy_sink_test.go
@@ -1,0 +1,160 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session_test
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+)
+
+var _ = Describe("Lazy Event Sink — #823 PR7", func() {
+
+	Describe("UT-KA-823-D05: Autonomous investigation receives no event sink", func() {
+		It("EventSinkFromContext returns nil when no Subscribe has been called", func() {
+			store := session.NewStore(30 * time.Minute)
+			mgr := session.NewManager(store, slog.Default(), audit.NopAuditStore{})
+
+			sinkResult := make(chan bool, 1)
+			_, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				sink := session.EventSinkFromContext(ctx)
+				sinkResult <- (sink == nil)
+				return map[string]string{"rca_summary": "autonomous"}, nil
+			}, map[string]string{"remediation_id": "rr-lazy-test"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(sinkResult, 5*time.Second).Should(Receive(BeTrue()),
+				"autonomous investigation (no Subscribe) must receive nil event sink")
+		})
+	})
+
+	Describe("UT-KA-823-D06: Panic in investigation goroutine transitions session to Failed", func() {
+		It("session reaches StatusFailed and goroutine does not crash the process", func() {
+			store := session.NewStore(30 * time.Minute)
+			mgr := session.NewManager(store, slog.Default(), audit.NopAuditStore{})
+
+			id, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				panic("simulated investigation panic")
+			}, map[string]string{"remediation_id": "rr-panic-test"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				sess, _ := mgr.GetSession(id)
+				if sess == nil {
+					return session.StatusPending
+				}
+				return sess.Status
+			}, 5*time.Second).Should(Equal(session.StatusFailed),
+				"panic in investigation should transition session to Failed")
+		})
+	})
+
+	Describe("UT-KA-823-D07: EventTypeComplete emitted at investigation end", func() {
+		It("subscriber receives a complete event before channel closure", func() {
+			store := session.NewStore(30 * time.Minute)
+			mgr := session.NewManager(store, slog.Default(), audit.NopAuditStore{})
+
+			proceed := make(chan struct{})
+			id, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				<-proceed
+				return map[string]string{"rca_summary": "done"}, nil
+			}, map[string]string{"remediation_id": "rr-complete-evt"})
+			Expect(err).NotTo(HaveOccurred())
+
+			ch, subErr := mgr.Subscribe(id)
+			Expect(subErr).NotTo(HaveOccurred())
+			Expect(ch).NotTo(BeNil())
+
+			close(proceed)
+
+			var sawComplete bool
+			Eventually(func() bool {
+				for {
+					select {
+					case ev, ok := <-ch:
+						if !ok {
+							return sawComplete
+						}
+						if ev.Type == session.EventTypeComplete {
+							sawComplete = true
+						}
+					default:
+						return sawComplete
+					}
+				}
+			}, 5*time.Second).Should(BeTrue(),
+				"subscriber must receive EventTypeComplete before channel closure")
+		})
+	})
+
+	Describe("UT-KA-823-D08: EventTypeSessionObserved emitted on Subscribe", func() {
+		It("audit store receives session.observed event when Subscribe is called", func() {
+			store := session.NewStore(30 * time.Minute)
+			recorder := &auditRecorder{}
+			mgr := session.NewManager(store, slog.Default(), recorder)
+
+			proceed := make(chan struct{})
+			id, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
+				<-proceed
+				return nil, nil
+			}, map[string]string{"remediation_id": "rr-observed"})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, subErr := mgr.Subscribe(id)
+			Expect(subErr).NotTo(HaveOccurred())
+
+			close(proceed)
+
+			Eventually(func() bool {
+				for _, evt := range recorder.Events() {
+					if evt.EventType == audit.EventTypeSessionObserved {
+						return true
+					}
+				}
+				return false
+			}, 5*time.Second).Should(BeTrue(),
+				"Subscribe must emit aiagent.session.observed audit event")
+		})
+	})
+})
+
+type auditRecorder struct {
+	mu     sync.Mutex
+	events []*audit.AuditEvent
+}
+
+func (r *auditRecorder) StoreAudit(_ context.Context, event *audit.AuditEvent) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.events = append(r.events, event)
+	return nil
+}
+
+func (r *auditRecorder) Events() []*audit.AuditEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	cp := make([]*audit.AuditEvent, len(r.events))
+	copy(cp, r.events)
+	return cp
+}


### PR DESCRIPTION
## Summary

- Store authenticated user identity as `created_by` in session metadata during `StartInvestigation`, extracted from `auth.UserContextKey` in the request context
- Add `getAuthorizedSession` helper to `handler.go` that checks session ownership before granting access; returns 404 (not 403) for unauthorized access to prevent information leakage
- Guard all 6 session endpoints (status, result, cancel, snapshot, stream) with ownership checks
- Refactor `Subscribe` to accept `context.Context` (idiomatic Go) instead of an explicit observer string parameter; observer identity is extracted from context for the `aiagent.session.observed` audit event (SOC2 CC8.1)
- Auth bypass preserved for dev mode (empty user = no ownership enforcement)
- Updated DD-AUDIT-003 to document `observer_user` attribute on `aiagent.session.observed`

## Test plan

- [x] UT-KA-823-A01: Session `created_by` stored in metadata
- [x] UT-KA-823-A02: Owner can access their session status (200)
- [x] UT-KA-823-A03: Non-owner gets 404 on session status
- [x] UT-KA-823-A04: Non-owner gets 404 on cancel
- [x] UT-KA-823-A05: Non-owner gets 404 on snapshot
- [x] UT-KA-823-A06: Non-owner gets 404 on stream
- [x] UT-KA-823-A07: Non-owner gets 404 on result
- [x] UT-KA-823-A08: Empty user (no auth) bypasses authz
- [x] UT-KA-823-A09: `session.observed` includes observer identity
- [x] All existing session unit/integration tests pass (no regression)
- [x] Race detector clean on all affected test suites


Made with [Cursor](https://cursor.com)