### PR TITLE
fix: CRD-to-OpenAPI enum drift detection for v1.3.1 (Issue #838)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -199,6 +199,36 @@ if [ -n "$STAGED_TYPES" ]; then
 fi
 
 # ========================================
+# CHECK 6: CRD-to-OpenAPI Enum Drift Detection (Issue #838)
+# ========================================
+echo ""
+echo "🔍 Checking for CRD-to-OpenAPI enum drift..."
+
+STAGED_ENUM_SOURCES=$(git diff --cached --name-only --diff-filter=ACM | \
+    grep -E '(api/openapi/.*\.yaml|api/.*_types\.go)$' || true)
+
+if [ -n "$STAGED_ENUM_SOURCES" ]; then
+    # Regenerate CRDs from Go types to catch any uncommitted drift
+    if command -v make &>/dev/null && [ -f Makefile ]; then
+        make manifests >/dev/null 2>&1 || true
+    fi
+
+    # Compare CRD enums against OpenAPI spec
+    if command -v go &>/dev/null; then
+        if ! go run ./scripts/validation/check-openapi-crd-enum-drift/... . 2>/dev/null; then
+            echo "❌ VIOLATION: CRD-to-OpenAPI enum drift detected"
+            echo "   CRD enums contain values missing from the OpenAPI spec."
+            echo "   The ogen-generated client will reject these at runtime (Issue #838)."
+            echo ""
+            echo "   To fix: add missing values to api/openapi/data-storage-v1.yaml"
+            echo "   Then run: make generate-datastorage-client"
+            echo ""
+            VIOLATIONS=$((VIOLATIONS + 1))
+        fi
+    fi
+fi
+
+# ========================================
 # RESULT
 # ========================================
 echo ""

--- a/Makefile
+++ b/Makefile
@@ -845,7 +845,7 @@ endef
 ##@ Cursor Rule Compliance
 
 .PHONY: lint-rules
-lint-rules: lint-test-patterns lint-business-integration lint-tdd-compliance lint-naming-convention ## Run all cursor rule compliance checks
+lint-rules: lint-test-patterns lint-business-integration lint-tdd-compliance lint-naming-convention lint-openapi-crd-drift ## Run all cursor rule compliance checks
 
 .PHONY: lint-naming-convention
 lint-naming-convention: ## Check for legacy holmesgpt-api references (#691)
@@ -872,6 +872,11 @@ lint-business-integration: ## Check business code integration in main applicatio
 lint-tdd-compliance: ## Check TDD compliance (BDD framework, BR references)
 	@echo "🔍 Checking TDD compliance..."
 	@./scripts/validation/check-tdd-compliance.sh
+
+.PHONY: lint-openapi-crd-drift
+lint-openapi-crd-drift: manifests ## Check CRD-to-OpenAPI enum alignment (Issue #838)
+	@echo "🔍 Checking CRD-to-OpenAPI enum drift..."
+	@go run ./scripts/validation/check-openapi-crd-enum-drift/...
 
 ##@ Image Build & Push
 

--- a/scripts/validation/check-openapi-crd-enum-drift/main.go
+++ b/scripts/validation/check-openapi-crd-enum-drift/main.go
@@ -1,0 +1,398 @@
+// check-openapi-crd-enum-drift compares enum values in CRD schemas (generated
+// from Go types via controller-gen) against the DataStorage OpenAPI spec. It
+// uses a declarative mapping file to pair CRD fields with their OpenAPI
+// counterparts and exits non-zero when the CRD contains values that the OpenAPI
+// spec (and therefore the ogen-generated client) would reject at runtime.
+//
+// Usage:
+//
+//	go run ./scripts/validation/check-openapi-crd-enum-drift [repo-root]
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+type Mapping struct {
+	CRD           string `yaml:"crd"`
+	CRDPath       string `yaml:"crd_path"`
+	OpenAPISchema string `yaml:"openapi_schema"`
+	OpenAPIField  string `yaml:"openapi_field"`
+	SubsetOK      bool   `yaml:"subset_ok,omitempty"`
+	Note          string `yaml:"note,omitempty"`
+}
+
+type MappingFile struct {
+	Mappings []Mapping `yaml:"mappings"`
+}
+
+func main() {
+	repoRoot := "."
+	if len(os.Args) > 1 {
+		repoRoot = os.Args[1]
+	}
+
+	crdDir := filepath.Join(repoRoot, "config", "crd", "bases")
+	openapiPath := filepath.Join(repoRoot, "api", "openapi", "data-storage-v1.yaml")
+	mappingPath := filepath.Join(repoRoot, "scripts", "validation", "openapi-crd-enum-mappings.yaml")
+
+	crdEnums, err := extractAllCRDEnums(crdDir)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR extracting CRD enums: %v\n", err)
+		os.Exit(2)
+	}
+
+	openapiEnums, err := extractOpenAPIEnums(openapiPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR extracting OpenAPI enums: %v\n", err)
+		os.Exit(2)
+	}
+
+	mappings, err := loadMappings(mappingPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR loading mapping file: %v\n", err)
+		os.Exit(2)
+	}
+
+	violations := 0
+	warnings := 0
+
+	for _, m := range mappings.Mappings {
+		crdKey := m.CRD + ":" + m.CRDPath
+		oaKey := m.OpenAPISchema + "." + m.OpenAPIField
+
+		crdVals, crdOK := crdEnums[crdKey]
+		oaVals, oaOK := openapiEnums[oaKey]
+
+		if !crdOK {
+			fmt.Printf("  WARN: CRD enum not found: %s\n", crdKey)
+			warnings++
+			continue
+		}
+		if !oaOK {
+			fmt.Printf("  WARN: OpenAPI enum not found: %s\n", oaKey)
+			warnings++
+			continue
+		}
+
+		crdOnly := setDiff(crdVals, oaVals)
+		oaOnly := setDiff(oaVals, crdVals)
+
+		if len(crdOnly) == 0 && len(oaOnly) == 0 {
+			fmt.Printf("  OK: %s <-> %s\n", crdKey, oaKey)
+			continue
+		}
+
+		if len(crdOnly) > 0 {
+			if m.SubsetOK {
+				fmt.Printf("  WARN [subset_ok]: %s -> %s: CRD has %v not in OpenAPI\n", crdKey, oaKey, crdOnly)
+				warnings++
+			} else {
+				fmt.Printf("  FAIL: %s -> %s: CRD has %v not in OpenAPI (ogen will reject)\n", crdKey, oaKey, crdOnly)
+				violations++
+			}
+		}
+
+		if len(oaOnly) > 0 {
+			fmt.Printf("  WARN: %s -> %s: OpenAPI has %v not in CRD\n", crdKey, oaKey, oaOnly)
+			warnings++
+		}
+
+		if m.Note != "" {
+			fmt.Printf("         Note: %s\n", m.Note)
+		}
+	}
+
+	// Check for unmapped CRD enums (potential blind spots)
+	mappedCRDKeys := make(map[string]bool)
+	for _, m := range mappings.Mappings {
+		mappedCRDKeys[m.CRD+":"+m.CRDPath] = true
+	}
+	unmapped := 0
+	for k := range crdEnums {
+		// Skip generic Kubernetes condition status enums
+		if strings.HasSuffix(k, "conditions[].status") {
+			continue
+		}
+		if !mappedCRDKeys[k] {
+			unmapped++
+			if unmapped == 1 {
+				fmt.Println("\n  Unmapped CRD enums (consider adding mappings):")
+			}
+			fmt.Printf("    - %s: %v\n", k, crdEnums[k])
+		}
+	}
+
+	fmt.Printf("\n=== Summary: %d violation(s), %d warning(s), %d unmapped ===\n", violations, warnings, unmapped)
+	if violations > 0 {
+		fmt.Println("\nFAILED: CRD enum values missing from OpenAPI spec will cause ogen client rejection at runtime.")
+		fmt.Println("Fix: Add missing values to api/openapi/data-storage-v1.yaml, then run 'make generate-datastorage-client'.")
+		os.Exit(1)
+	}
+}
+
+// extractAllCRDEnums parses all CRD YAMLs and returns enum values keyed by
+// "filename:json.path".
+func extractAllCRDEnums(dir string) (map[string][]string, error) {
+	result := make(map[string][]string)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("reading CRD directory %s: %w", dir, err)
+	}
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".yaml") {
+			continue
+		}
+
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", e.Name(), err)
+		}
+
+		var doc map[string]interface{}
+		if err := yaml.Unmarshal(data, &doc); err != nil {
+			return nil, fmt.Errorf("parsing %s: %w", e.Name(), err)
+		}
+
+		versions, ok := navigateSlice(doc, "spec", "versions")
+		if !ok {
+			continue
+		}
+
+		for _, v := range versions {
+			vMap, ok := v.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			schema, ok := navigateMap(vMap, "schema", "openAPIV3Schema", "properties")
+			if !ok {
+				continue
+			}
+			propsMap, ok := schema.(map[string]interface{})
+			if !ok {
+				continue
+			}
+			for topKey, topVal := range propsMap {
+				if topKey != "spec" && topKey != "status" {
+					continue
+				}
+				topObj, ok := topVal.(map[string]interface{})
+				if !ok {
+					continue
+				}
+				if props, exists := topObj["properties"]; exists {
+					walkCRDProperties(props, topKey, e.Name(), result)
+				}
+			}
+		}
+	}
+
+	return result, nil
+}
+
+// walkCRDProperties recursively extracts enum arrays from a CRD properties tree,
+// handling direct enum, allOf-wrapped enum, nested properties, and array items.
+func walkCRDProperties(node interface{}, path string, filename string, result map[string][]string) {
+	propsMap, ok := node.(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	for fieldName, fieldVal := range propsMap {
+		fieldMap, ok := fieldVal.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		currentPath := path + "." + fieldName
+
+		collectEnum(fieldMap, filename, currentPath, result)
+
+		if subProps, exists := fieldMap["properties"]; exists {
+			walkCRDProperties(subProps, currentPath, filename, result)
+		}
+
+		if items, exists := fieldMap["items"]; exists {
+			if itemsMap, ok := items.(map[string]interface{}); ok {
+				collectEnum(itemsMap, filename, currentPath+"[]", result)
+				if itemProps, exists := itemsMap["properties"]; exists {
+					walkCRDProperties(itemProps, currentPath+"[]", filename, result)
+				}
+			}
+		}
+	}
+}
+
+// collectEnum extracts enum values from a field map, handling both direct enum
+// and allOf-wrapped enum patterns (controller-gen emits allOf for shared types).
+func collectEnum(fieldMap map[string]interface{}, filename, path string, result map[string][]string) {
+	if enumVal, exists := fieldMap["enum"]; exists {
+		if vals := toStringSlice(enumVal); vals != nil {
+			result[filename+":"+path] = vals
+			return
+		}
+	}
+
+	if allOf, exists := fieldMap["allOf"]; exists {
+		if allOfSlice, ok := allOf.([]interface{}); ok {
+			for _, item := range allOfSlice {
+				if itemMap, ok := item.(map[string]interface{}); ok {
+					if enumVal, exists := itemMap["enum"]; exists {
+						if vals := toStringSlice(enumVal); vals != nil {
+							result[filename+":"+path] = vals
+							return
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// extractOpenAPIEnums parses an OpenAPI 3.x spec and returns enum values keyed
+// by "SchemaName.fieldName" for component schemas and "param:path:method.name"
+// for query/path parameters.
+func extractOpenAPIEnums(path string) (map[string][]string, error) {
+	result := make(map[string][]string)
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", path, err)
+	}
+
+	var doc map[string]interface{}
+	if err := yaml.Unmarshal(data, &doc); err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+
+	schemas, ok := navigateMap(doc, "components", "schemas")
+	if !ok {
+		return nil, fmt.Errorf("components.schemas not found")
+	}
+	schemasMap, ok := schemas.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("components.schemas is not a map")
+	}
+
+	for schemaName, schemaVal := range schemasMap {
+		schemaMap, ok := schemaVal.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if props, exists := schemaMap["properties"]; exists {
+			walkOpenAPIProperties(props, schemaName, result)
+		}
+	}
+
+	return result, nil
+}
+
+func walkOpenAPIProperties(node interface{}, prefix string, result map[string][]string) {
+	propsMap, ok := node.(map[string]interface{})
+	if !ok {
+		return
+	}
+
+	for fieldName, fieldVal := range propsMap {
+		fieldMap, ok := fieldVal.(map[string]interface{})
+		if !ok {
+			continue
+		}
+
+		key := prefix + "." + fieldName
+
+		if enumVal, exists := fieldMap["enum"]; exists {
+			if vals := toStringSlice(enumVal); vals != nil {
+				result[key] = vals
+			}
+		}
+
+		if subProps, exists := fieldMap["properties"]; exists {
+			walkOpenAPIProperties(subProps, key, result)
+		}
+
+		if items, exists := fieldMap["items"]; exists {
+			if itemsMap, ok := items.(map[string]interface{}); ok {
+				if itemProps, exists := itemsMap["properties"]; exists {
+					walkOpenAPIProperties(itemProps, key+"[]", result)
+				}
+				if enumVal, exists := itemsMap["enum"]; exists {
+					if vals := toStringSlice(enumVal); vals != nil {
+						result[key+"[]"] = vals
+					}
+				}
+			}
+		}
+	}
+}
+
+func loadMappings(path string) (*MappingFile, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var mf MappingFile
+	if err := yaml.Unmarshal(data, &mf); err != nil {
+		return nil, err
+	}
+	return &mf, nil
+}
+
+func navigateMap(m interface{}, keys ...string) (interface{}, bool) {
+	current := m
+	for _, k := range keys {
+		cm, ok := current.(map[string]interface{})
+		if !ok {
+			return nil, false
+		}
+		current = cm[k]
+		if current == nil {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+func navigateSlice(m interface{}, keys ...string) ([]interface{}, bool) {
+	val, ok := navigateMap(m, keys...)
+	if !ok {
+		return nil, false
+	}
+	sl, ok := val.([]interface{})
+	return sl, ok
+}
+
+func toStringSlice(v interface{}) []string {
+	sl, ok := v.([]interface{})
+	if !ok {
+		return nil
+	}
+	vals := make([]string, 0, len(sl))
+	for _, item := range sl {
+		vals = append(vals, fmt.Sprintf("%v", item))
+	}
+	sort.Strings(vals)
+	return vals
+}
+
+func setDiff(a, b []string) []string {
+	bSet := make(map[string]bool, len(b))
+	for _, v := range b {
+		bSet[v] = true
+	}
+	var diff []string
+	for _, v := range a {
+		if !bSet[v] {
+			diff = append(diff, v)
+		}
+	}
+	return diff
+}

--- a/scripts/validation/openapi-crd-enum-mappings.yaml
+++ b/scripts/validation/openapi-crd-enum-mappings.yaml
@@ -1,0 +1,158 @@
+# CRD-to-OpenAPI enum correspondence mappings.
+#
+# Used by check-openapi-crd-enum-drift to detect values present in CRDs
+# (source of truth for K8s resources) but missing from the OpenAPI spec
+# (source of truth for the DataStorage REST API / ogen client).
+#
+# Fields:
+#   crd            - CRD YAML filename in config/crd/bases/
+#   crd_path       - dot-separated path to the enum field (spec.x.y or status.x.y)
+#   openapi_schema - schema name under components.schemas in data-storage-v1.yaml
+#   openapi_field  - property name within the schema
+#   subset_ok      - if true, CRD superset is a warning not a failure (intentional)
+#   note           - context for reviewers
+#
+# When adding a new CRD enum, add a mapping here or the pre-commit hook will
+# flag it as unmapped.
+
+mappings:
+  # ===========================================================================
+  # CRITICAL: Missing values cause ogen response validation rejection (#838)
+  # ===========================================================================
+
+  - crd: kubernaut.ai_remediationworkflows.yaml
+    crd_path: spec.execution.engine
+    openapi_schema: WorkflowDiscoveryEntry
+    openapi_field: executionEngine
+    note: "Issue #838 - must include ansible"
+
+  - crd: kubernaut.ai_remediationworkflows.yaml
+    crd_path: spec.execution.engine
+    openapi_schema: WorkflowSearchResult
+    openapi_field: executionEngine
+    note: "Reference: already aligned"
+
+  - crd: kubernaut.ai_aianalyses.yaml
+    crd_path: status.phase
+    openapi_schema: AIAnalysisAuditPayload
+    openapi_field: phase
+    note: "Audit gap #2 - must include Investigating"
+
+  - crd: kubernaut.ai_remediationworkflows.yaml
+    crd_path: status.catalogStatus
+    openapi_schema: RemediationWorkflow
+    openapi_field: status
+    note: "Audit gap #3 - CRD has Invalid, Pending not in OpenAPI"
+
+  - crd: kubernaut.ai_effectivenessassessments.yaml
+    crd_path: status.assessmentReason
+    openapi_schema: RemediationHistoryEntry
+    openapi_field: assessmentReason
+    note: "Audit gap #4 - missing AlertDecayTimeout, Unrecoverable"
+
+  - crd: kubernaut.ai_effectivenessassessments.yaml
+    crd_path: status.assessmentReason
+    openapi_schema: RemediationHistorySummary
+    openapi_field: assessmentReason
+    note: "Audit gap #4 - summary variant"
+
+  # ===========================================================================
+  # HIGH: Important alignment checks
+  # ===========================================================================
+
+  - crd: kubernaut.ai_aianalyses.yaml
+    crd_path: status.selectedWorkflow.executionEngine
+    openapi_schema: WorkflowDiscoveryEntry
+    openapi_field: executionEngine
+    note: "AI analysis stores selected engine; must match discovery values"
+
+  - crd: kubernaut.ai_workflowexecutions.yaml
+    crd_path: status.phase
+    openapi_schema: WorkflowExecutionAuditPayload
+    openapi_field: phase
+
+  - crd: kubernaut.ai_workflowexecutions.yaml
+    crd_path: status.failureDetails.reason
+    openapi_schema: WorkflowExecutionAuditPayload
+    openapi_field: failure_reason
+
+  - crd: kubernaut.ai_notificationrequests.yaml
+    crd_path: spec.type
+    openapi_schema: NotificationAuditPayload
+    openapi_field: notification_type
+
+  - crd: kubernaut.ai_notificationrequests.yaml
+    crd_path: spec.priority
+    openapi_schema: NotificationAuditPayload
+    openapi_field: priority
+
+  - crd: kubernaut.ai_signalprocessings.yaml
+    crd_path: status.phase
+    openapi_schema: SignalProcessingAuditPayload
+    openapi_field: phase
+
+  - crd: kubernaut.ai_signalprocessings.yaml
+    crd_path: status.severity
+    openapi_schema: SignalProcessingAuditPayload
+    openapi_field: severity
+
+  - crd: kubernaut.ai_signalprocessings.yaml
+    crd_path: status.signalMode
+    openapi_schema: SignalProcessingAuditPayload
+    openapi_field: signal_mode
+
+  - crd: kubernaut.ai_aianalyses.yaml
+    crd_path: status.humanReviewReason
+    openapi_schema: IncidentResponseData
+    openapi_field: humanReviewReason
+
+  - crd: kubernaut.ai_aianalyses.yaml
+    crd_path: status.postRCAContext.detectedLabels.failedDetections[]
+    openapi_schema: DetectedLabels
+    openapi_field: failedDetections[]
+
+  # ===========================================================================
+  # MEDIUM: Intentional subsets (subset_ok: true)
+  # ===========================================================================
+
+  - crd: kubernaut.ai_notificationrequests.yaml
+    crd_path: status.phase
+    openapi_schema: NotificationAuditPayload
+    openapi_field: final_status
+    subset_ok: true
+    note: "Intentional: audit omits Retrying, PartiallySent; adds Cancelled"
+
+  - crd: kubernaut.ai_remediationrequests.yaml
+    crd_path: status.overallPhase
+    openapi_schema: RemediationOrchestratorAuditPayload
+    openapi_field: failure_phase
+    subset_ok: true
+    note: "Intentional: audit only reports AIAnalysis, Approval, SP, WE as failure phases"
+
+  - crd: kubernaut.ai_signalprocessings.yaml
+    crd_path: status.environmentClassification.environment
+    openapi_schema: SignalProcessingAuditPayload
+    openapi_field: environment
+    subset_ok: true
+    note: "Intentional: audit uses lowercase, omits Test/Unknown"
+
+  - crd: kubernaut.ai_signalprocessings.yaml
+    crd_path: status.severity
+    openapi_schema: SignalProcessingAuditPayload
+    openapi_field: priority
+    subset_ok: true
+    note: "Different concepts: CRD severity vs OpenAPI derived priority"
+
+  - crd: kubernaut.ai_remediationworkflows.yaml
+    crd_path: status.catalogStatus
+    openapi_schema: WorkflowCatalogCreatedPayload
+    openapi_field: status
+    subset_ok: true
+    note: "Audit gap #5 - creation event only captures Active/Disabled/Archived"
+
+  - crd: kubernaut.ai_remediationapprovalrequests.yaml
+    crd_path: status.decision
+    openapi_schema: RemediationApprovalAuditPayload
+    openapi_field: decision
+    subset_ok: true
+    note: "Audit only reports Approved/Rejected, CRD also has empty and Expired"


### PR DESCRIPTION
## Summary

Cherry-pick of the CRD-to-OpenAPI enum drift checker onto the v1.3.0 release line for tagging as v1.3.1.

- Go-based pre-commit checker comparing CRD enum values against the DataStorage OpenAPI spec
- Declarative YAML mapping file (22 correspondences) for CRD-to-OpenAPI enum pairs
- Pre-commit CHECK 6 and `make lint-openapi-crd-drift` CI target
- Detects 7 enum drift violations on v1.3 (all audit gaps from Issue #838 triage)

**Release**: After merge, tag as `v1.3.1` on the merge commit.

Refs #838

## Test plan

- [x] Clean cherry-pick from `feature/openapi-crd-drift-checker` (ad6cfed5f)
- [x] `go build` passes on v1.3 codebase
- [x] Checker detects all known violations on v1.3

Made with [Cursor](https://cursor.com)