### PR TITLE
cherry-pick(#860): exempt pagination from per-tool budget (v1.3.2 → main)

### DIFF
--- a/docs/architecture/decisions/DD-HAPI-019-go-rewrite-design/DD-HAPI-019-003-security-architecture.md
+++ b/docs/architecture/decisions/DD-HAPI-019-go-rewrite-design/DD-HAPI-019-003-security-architecture.md
@@ -222,7 +222,7 @@ Phase transitions are controlled by the investigator loop based on conversation 
 
 ```go
 type AnomalyDetector struct {
-    maxToolCallsPerTool int           // default: 5
+    maxToolCallsPerTool int           // default: 10 (raised from 5 per #860 for pagination)
     maxTotalToolCalls   int           // default: 30
     maxRepeatedFailures int           // default: 3
     suspiciousPatterns  []*regexp.Regexp
@@ -236,7 +236,7 @@ func (d *AnomalyDetector) RecordFailure(name string, args json.RawMessage) (Anom
 
 | Anomaly | Default Threshold | Response |
 |---|---|---|
-| Per-tool call limit exceeded | 5 calls per tool | Abort, flag human review |
+| Per-tool call limit exceeded | 10 calls per tool (pagination-exempt, #860) | Abort, flag human review |
 | Total tool calls exceeded | 30 calls per investigation | Abort, flag human review |
 | Repeated identical failures | 3 same-args failures | Abort, flag human review |
 | Suspicious argument patterns | Regex match | Log warning, optionally reject |

--- a/docs/architecture/decisions/DD-WORKFLOW-016-action-type-workflow-indexing.md
+++ b/docs/architecture/decisions/DD-WORKFLOW-016-action-type-workflow-indexing.md
@@ -898,7 +898,7 @@ To:
 ### Security Considerations
 
 - **Tampered cursors**: LLM may craft arbitrary cursor values. `DecodeCursor` validates and clamps (offset >= 0, 0 < limit <= 100). DS `ParsePagination` provides a second layer of clamping.
-- **DoS via large offsets**: Capped by anomaly detector's `MaxToolCallsPerTool` (default 5), limiting practical max offset to 50 items. Catalog data is small (10 action types, ~10s of workflows per type).
+- **DoS via large offsets**: Capped by anomaly detector's `MaxTotalToolCalls` (default 30). Pagination calls (`list_workflows`, `list_available_actions` with a `cursor` argument) are exempt from the per-tool budget (`MaxToolCallsPerTool`, default 10) but still count against the total budget (#860). Catalog data is small (10 action types, ~10s of workflows per type).
 - **Cursor opacity**: Base64 is encoding, not encryption. Cursor contents are not secret — the trust boundary is server-side validation, not encoding.
 
 ---

--- a/docs/operations/configuration/CONFIG_STANDARDS.md
+++ b/docs/operations/configuration/CONFIG_STANDARDS.md
@@ -173,7 +173,7 @@ sanitization:
   i1_injection: true                # Default: true — I1 injection stripping
 
 anomaly:
-  max_tool_calls_per_tool: 5        # Default: 5 — I7 per-tool call limit
+  max_tool_calls_per_tool: 10       # Default: 10 — I7 per-tool call limit (raised from 5, #860; pagination calls exempt)
   max_total_tool_calls: 30          # Default: 30 — I7 total tool call limit
   max_repeated_failures: 3          # Default: 3 — I7 consecutive failure limit
 

--- a/docs/tests/688/TEST_PLAN.md
+++ b/docs/tests/688/TEST_PLAN.md
@@ -113,7 +113,7 @@ pagination without exposing raw numeric offsets or total counts.
 
 - **DataStorage server-side pagination** (`pkg/datastorage/server/workflow_handlers.go`): Already covered by existing DS tests. ParsePagination clamping is assumed correct.
 - **Ogen client/server codegen** (`pkg/datastorage/ogen-client/`): Generated code, tested upstream.
-- **Anomaly detector tool call limits** (`internal/kubernautagent/investigator/anomaly.go`): Unchanged; pagination adds tool calls within existing limits.
+- **Anomaly detector tool call limits** (`internal/kubernautagent/investigator/anomaly.go`): Updated by #860 — pagination calls (`list_workflows`, `list_available_actions` with `cursor`) are exempt from per-tool budget but still count toward `MaxTotalToolCalls` (30). `MaxToolCallsPerTool` raised from 5 to 10.
 - **Golden transcript replay**: Will need separate update if transcripts include pagination; deferred to post-merge validation.
 
 ### 4.3 Design Decisions

--- a/docs/tests/860/TEST_PLAN.md
+++ b/docs/tests/860/TEST_PLAN.md
@@ -1,0 +1,372 @@
+# Test Plan: Pagination Exemption from Per-Tool Call Budget (#860)
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-860-v1.0
+**Feature**: Exempt cursor-based pagination calls from the per-tool anomaly budget; raise `MaxToolCallsPerTool` default from 5 to 10
+**Version**: 1.0
+**Created**: 2026-04-26
+**Author**: AI Agent (Cursor)
+**Status**: Draft
+**Branch**: `release/v1.3.2`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Validates that the anomaly detector correctly exempts pagination calls (identified by tool name + non-empty `cursor` argument) from the per-tool call counter while still enforcing the `MaxTotalToolCalls` safety net. Also validates the raised `MaxToolCallsPerTool` default (5 -> 10) and updated prompt guidance.
+
+### 1.2 Objectives
+
+1. **Pagination exemption correctness**: Pagination calls to `list_workflows` and `list_available_actions` do not increment per-tool counters
+2. **Safety net preservation**: Pagination calls still count toward `MaxTotalToolCalls=30`
+3. **Fail-closed security**: Malformed, empty, or nil args are treated as non-pagination (counted normally)
+4. **Default alignment**: Both `DefaultAnomalyConfig()` and `config.DefaultConfig().Anomaly` reflect `MaxToolCallsPerTool=10`
+5. **Integration correctness**: Full `executeTool` path allows pagination-heavy workflows without false rejection
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/kubernautagent/investigator/... --ginkgo.focus="860"` |
+| Integration test pass rate | 100% | `go test ./test/integration/kubernautagent/investigator/... --ginkgo.focus="860"` |
+| Unit-testable code coverage | >=80% | `go test -coverprofile` on `anomaly.go` |
+| Backward compatibility | 0 regressions | Existing anomaly tests pass after limit update |
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- [DD-HAPI-019-003](../../architecture/decisions/DD-HAPI-019-go-rewrite-design/DD-HAPI-019-003-security-architecture.md): I7 Behavioral Anomaly Detection — canonical spec for per-tool/total limits
+- [DD-WORKFLOW-016](../../architecture/decisions/DD-WORKFLOW-016-action-type-workflow-indexing.md): Workflow discovery pagination security considerations
+- [BR-HAPI-433-004](../../requirements/BR-HAPI-433-go-language-migration/BR-HAPI-433-004-security-requirements.md): I7 configurable per-tool invocation cap
+- Issue #860: `list_workflows` per-tool call limit too restrictive for paginated catalogs
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../../.cursor/rules/03-testing-strategy.mdc)
+- [Testing Guidelines](../../development/business-requirements/TESTING_GUIDELINES.md)
+- [TP-433-WIR](../433/TP-433-WIR-v1.0.md): Original anomaly detector test plan (I7)
+- [TP-688](../688/TEST_PLAN.md): Workflow pagination test plan (scope note update needed)
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | Malformed JSON in `isPaginationCall` causes panic | Investigation crash | Low | UT-KA-860-004 | Fail-closed: `json.Unmarshal` error returns false |
+| R2 | Pagination exemption bypasses `MaxTotalToolCalls` | Unbounded LLM tool usage | Medium | UT-KA-860-003 | Pagination increments `totalCallCount`; only per-tool count exempt |
+| R3 | LLM crafts fake cursor to exploit exemption | Per-tool limit evasion for non-paginated tools | Low | UT-KA-860-004 | Tool-name-aware: only `list_workflows` and `list_available_actions` qualify |
+| R4 | Raising limit to 10 doubles DoS surface | More tool calls per investigation | Low | UT-KA-860-002 | `MaxTotalToolCalls=30` bounds total; catalog data is small (DD-WORKFLOW-016) |
+| R5 | Default drift between `anomaly.go` and `config.go` | Config mismatch in production | Medium | UT-KA-860-005, UT-KA-860-006 | Both defaults tested independently |
+
+### 3.1 Risk-to-Test Traceability
+
+- **R1 (panic)**: UT-KA-860-004 tests malformed JSON, nil args, empty args
+- **R2 (total bypass)**: UT-KA-860-003 verifies pagination calls hit `MaxTotalToolCalls`
+- **R3 (fake cursor)**: UT-KA-860-004 tests non-paginated tool with cursor (should still count)
+- **R4 (DoS surface)**: UT-KA-860-002 verifies enforcement at new limit=10
+- **R5 (config drift)**: UT-KA-860-005 + UT-KA-860-006 independently assert both defaults
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **`isPaginationCall`** (`internal/kubernautagent/investigator/anomaly.go`): New function — determines whether a tool call is a pagination continuation based on tool name (`list_workflows`, `list_available_actions`) and non-empty `cursor` argument
+- **`CheckToolCall` update** (`internal/kubernautagent/investigator/anomaly.go`): Pagination calls skip `toolCallCounts[name]++` but still increment `totalCallCount`
+- **`DefaultAnomalyConfig()`** (`internal/kubernautagent/investigator/anomaly.go`): `MaxToolCallsPerTool` changed from 5 to 10
+- **`DefaultConfig().Anomaly`** (`internal/kubernautagent/config/config.go`): `MaxToolCallsPerTool` changed from 5 to 10
+- **`executeTool` integration path** (`internal/kubernautagent/investigator/investigator.go`): Validates pagination-heavy tool call sequences pass through without false rejection
+
+### 4.2 Features Not to be Tested
+
+- **Prompt template changes** (`phase3_workflow_selection.tmpl`): Text-only change; validated by manual review, not programmatic assertion
+- **DataStorage pagination server-side**: Covered by TP-688
+- **Cursor encoding/validation**: Covered by DD-WORKFLOW-016 / DS tests
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Tool-name-aware `isPaginationCall` | Only `list_workflows` and `list_available_actions` have cursor pagination (DD-WORKFLOW-016). Prevents LLM exploiting cursor field on arbitrary tools. |
+| Pagination still counts toward `MaxTotalToolCalls` | Defense-in-depth: prevents unbounded pagination loops. 30-call total is the safety net. |
+| No separate `MaxPaginationCalls` cap | Catalog data is small (~10 action types, ~10s workflows per type). `MaxTotalToolCalls=30` provides sufficient bound. |
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+- **Unit**: >=80% of `isPaginationCall` and `CheckToolCall` pagination paths in `anomaly.go`
+- **Integration**: >=80% of `executeTool` pagination flow in `investigator.go`
+- **E2E**: Deferred — anomaly detector is tested at unit + integration tiers
+
+### 5.2 Two-Tier Minimum
+
+Every behavior is covered by at least unit + integration:
+- Unit: Tests `isPaginationCall` logic and `CheckToolCall` branching in isolation
+- Integration: Tests full `executeTool` path with mock LLM producing pagination sequences
+
+### 5.3 Pass/Fail Criteria
+
+**PASS** — all of:
+1. All 7 unit tests and 1 integration test pass
+2. >=80% statement coverage on `isPaginationCall` and `CheckToolCall` pagination branch
+3. All existing anomaly tests pass after limit update (0 regressions)
+4. `go build ./...` and `go vet ./...` clean
+
+**FAIL** — any of:
+1. Any test fails
+2. Coverage below 80% on changed code
+3. Existing tests regress
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code (pure logic, no I/O)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `internal/kubernautagent/investigator/anomaly.go` | `isPaginationCall`, `CheckToolCall` (pagination branch) | ~15 new |
+| `internal/kubernautagent/investigator/anomaly.go` | `DefaultAnomalyConfig()` | 1 line change |
+| `internal/kubernautagent/config/config.go` | `DefaultConfig()` | 1 line change |
+
+### 6.2 Integration-Testable Code (I/O, wiring, cross-component)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `internal/kubernautagent/investigator/investigator.go` | `executeTool` (anomaly check path) | ~5 (existing, behavior change) |
+
+---
+
+## 7. BR Coverage Matrix
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-HAPI-433-004 (I7) | Pagination calls exempt from per-tool budget | P0 | Unit | UT-KA-860-001 | Pending |
+| BR-HAPI-433-004 (I7) | Non-pagination calls enforced at limit=10 | P0 | Unit | UT-KA-860-002 | Pending |
+| BR-HAPI-433-004 (I7) | Pagination calls count toward total budget | P0 | Unit | UT-KA-860-003 | Pending |
+| BR-HAPI-433-004 (I7) | Malformed/edge-case args fail-closed | P0 | Unit | UT-KA-860-004 | Pending |
+| BR-HAPI-433-004 (I7) | DefaultAnomalyConfig reflects limit=10 | P1 | Unit | UT-KA-860-005 | Pending |
+| BR-HAPI-433-004 (I7) | DefaultConfig().Anomaly reflects limit=10 | P1 | Unit | UT-KA-860-006 | Pending |
+| BR-HAPI-433-004 (I7) | Full executeTool allows pagination-heavy sequence | P0 | Integration | IT-KA-860-001 | Pending |
+
+---
+
+## 8. Test Scenarios
+
+### Tier 1: Unit Tests
+
+**Testable code scope**: `internal/kubernautagent/investigator/anomaly.go` — `isPaginationCall`, `CheckToolCall` pagination path, `DefaultAnomalyConfig()`; `internal/kubernautagent/config/config.go` — `DefaultConfig().Anomaly`
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| UT-KA-860-001 | Pagination call (list_workflows with cursor) does NOT increment per-tool count; allows >limit calls | Pending |
+| UT-KA-860-002 | Non-pagination call increments per-tool count and rejects at limit=10 (11th call rejected) | Pending |
+| UT-KA-860-003 | Pagination calls still count toward MaxTotalToolCalls=30 (safety net enforced) | Pending |
+| UT-KA-860-004 | isPaginationCall edge cases: nil args, empty args, malformed JSON, empty cursor, non-paginated tool with cursor — all return false (fail-closed) | Pending |
+| UT-KA-860-005 | DefaultAnomalyConfig().MaxToolCallsPerTool == 10 | Pending |
+| UT-KA-860-006 | config.DefaultConfig().Anomaly.MaxToolCallsPerTool == 10 | Pending |
+
+### Tier 2: Integration Tests
+
+**Testable code scope**: `internal/kubernautagent/investigator/investigator.go` — `executeTool` with `AnomalyDetector` wired
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| IT-KA-860-001 | Full executeTool path allows 12 list_workflows calls (5 new + 7 pagination) without per-tool rejection | Pending |
+
+### Tier Skip Rationale
+
+- **E2E**: Anomaly detector is fully exercised at unit + integration tiers. E2E would require Kind cluster + mock LLM scenario for pagination, which is disproportionate cost for this change.
+
+---
+
+## 9. Test Cases
+
+### UT-KA-860-001: Pagination call does not increment per-tool count
+
+**BR**: BR-HAPI-433-004 (I7)
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/investigator/anomaly_test.go`
+
+**Test Steps**:
+1. **Given**: AnomalyDetector with MaxToolCallsPerTool=3, MaxTotalToolCalls=100
+2. **When**: Call CheckToolCall("list_workflows", `{"action_type":"cordon","cursor":"abc123"}`) 10 times
+3. **Then**: All 10 calls return Allowed=true (cursor calls don't count toward per-tool limit)
+
+### UT-KA-860-002: Non-pagination call enforced at raised limit
+
+**BR**: BR-HAPI-433-004 (I7)
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/investigator/anomaly_test.go`
+
+**Test Steps**:
+1. **Given**: AnomalyDetector with MaxToolCallsPerTool=10, MaxTotalToolCalls=100
+2. **When**: Call CheckToolCall("kubectl_describe", `{}`) 11 times
+3. **Then**: First 10 return Allowed=true; 11th returns Allowed=false with "per-tool call limit exceeded"
+
+### UT-KA-860-003: Pagination calls count toward total budget
+
+**BR**: BR-HAPI-433-004 (I7)
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/investigator/anomaly_test.go`
+
+**Test Steps**:
+1. **Given**: AnomalyDetector with MaxToolCallsPerTool=100, MaxTotalToolCalls=5
+2. **When**: Call CheckToolCall("list_workflows", `{"action_type":"cordon","cursor":"abc"}`) 6 times
+3. **Then**: First 5 return Allowed=true; 6th returns Allowed=false with "total tool call limit exceeded"
+
+### UT-KA-860-004: isPaginationCall edge cases (fail-closed)
+
+**BR**: BR-HAPI-433-004 (I7)
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/kubernautagent/investigator/anomaly_test.go`
+
+**Test Steps** (table-driven):
+
+| Sub-case | Tool name | Args | Expected isPagination | Rationale |
+|----------|-----------|------|-----------------------|-----------|
+| nil args | list_workflows | nil | false | Fail-closed on nil |
+| empty args | list_workflows | `{}` | false | No cursor field |
+| malformed JSON | list_workflows | `{bad` | false | Fail-closed on parse error |
+| empty cursor | list_workflows | `{"cursor":""}` | false | Empty cursor = initial call |
+| non-paginated tool with cursor | kubectl_describe | `{"cursor":"abc"}` | false | Tool not in allow-list |
+| list_available_actions with cursor | list_available_actions | `{"cursor":"abc"}` | true | Both paginated tools covered |
+| list_workflows with cursor | list_workflows | `{"cursor":"abc"}` | true | Primary paginated tool |
+
+### UT-KA-860-005: DefaultAnomalyConfig reflects limit=10
+
+**BR**: BR-HAPI-433-004 (I7)
+**Priority**: P1
+**Type**: Unit
+**File**: `test/unit/kubernautagent/investigator/anomaly_test.go`
+
+**Test Steps**:
+1. **Given**: Call `DefaultAnomalyConfig()`
+2. **Then**: `MaxToolCallsPerTool == 10`, `MaxTotalToolCalls == 30`, `MaxRepeatedFailures == 3`
+
+### UT-KA-860-006: DefaultConfig().Anomaly reflects limit=10
+
+**BR**: BR-HAPI-433-004 (I7)
+**Priority**: P1
+**Type**: Unit
+**File**: `test/unit/kubernautagent/config/config_test.go`
+
+**Test Steps**:
+1. **Given**: Call `config.DefaultConfig()`
+2. **Then**: `cfg.Anomaly.MaxToolCallsPerTool == 10`
+
+### IT-KA-860-001: executeTool allows pagination-heavy sequence
+
+**BR**: BR-HAPI-433-004 (I7)
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/investigator/investigator_anomaly_test.go`
+
+**Test Steps**:
+1. **Given**: Investigator with AnomalyDetector (MaxToolCallsPerTool=10, MaxTotalToolCalls=100), mock LLM that issues 12 list_workflows tool calls (5 initial + 7 with cursor)
+2. **When**: Investigate is called
+3. **Then**: No tool call is rejected with "per-tool call limit exceeded"; investigation completes normally
+
+---
+
+## 10. Environmental Needs
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Mocks**: None (AnomalyDetector is pure logic)
+- **Location**: `test/unit/kubernautagent/investigator/`
+
+### 10.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Mocks**: Mock LLM client (existing `mockLLMClient` pattern), fake tool registry
+- **Location**: `test/integration/kubernautagent/investigator/`
+
+### 10.3 Tools & Versions
+
+| Tool | Minimum Version | Purpose |
+|------|-----------------|---------|
+| Go | 1.25 | Build and test |
+| Ginkgo CLI | v2.x | Test runner |
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Blocking Dependencies
+
+| Dependency | Type | Status | Impact if Not Available | Workaround |
+|------------|------|--------|-------------------------|------------|
+| Cherry-picked #852/#853 | Code | Merged to release/v1.3.2 | None — independent code paths | N/A |
+| Cherry-picked B+D fix | Code | Merged to release/v1.3.2 | None — independent code paths | N/A |
+
+### 11.2 Execution Order
+
+1. **TDD RED**: Write UT-KA-860-001..006 + IT-KA-860-001 (all fail)
+2. **TDD GREEN**: Implement `isPaginationCall`, update `CheckToolCall`, change defaults, update prompt
+3. **TDD REFACTOR**: Coverage check, 100-go-mistakes audit, anti-pattern check
+
+---
+
+## 12. Test Deliverables
+
+| Deliverable | Location | Description |
+|-------------|----------|-------------|
+| This test plan | `docs/tests/860/TEST_PLAN.md` | Strategy and test design |
+| Unit test suite | `test/unit/kubernautagent/investigator/anomaly_test.go` | 6 new Ginkgo specs |
+| Config unit test update | `test/unit/kubernautagent/config/config_test.go` | 1 updated spec |
+| Integration test suite | `test/integration/kubernautagent/investigator/investigator_anomaly_test.go` | 1 new Ginkgo spec |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests (focused)
+go test ./test/unit/kubernautagent/investigator/... --ginkgo.focus="860"
+
+# Config unit tests
+go test ./test/unit/kubernautagent/config/... --ginkgo.focus="860"
+
+# Integration tests (focused)
+go test ./test/integration/kubernautagent/investigator/... --ginkgo.focus="860"
+
+# Coverage
+go test ./test/unit/kubernautagent/investigator/... -coverprofile=coverage.out -coverpkg=github.com/jordigilh/kubernaut/internal/kubernautagent/investigator
+go tool cover -func=coverage.out | grep -E "isPaginationCall|CheckToolCall"
+```
+
+---
+
+## 14. Existing Tests Requiring Updates
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|-------------------|-------------------|-----------------|--------|
+| `anomaly_test.go:323` `DefaultAnomalyConfig()` | `Expect(cfg.MaxToolCallsPerTool).To(Equal(5))` | Change to `Equal(10)` | Default raised to 10 |
+| `config_test.go:75` `DefaultConfig()` | `Expect(cfg.Anomaly.MaxToolCallsPerTool).To(Equal(5))` | Change to `Equal(10)` | Default raised to 10 |
+| `config_test.go:266-268` `MaxToolCallsPerTool=5` | Title + assertion reference 5 | Update to 10 | Default raised to 10 |
+| `investigator_anomaly_test.go:64-71` `IT-KA-433W-012` | `MaxToolCallsPerTool: 5`, "6th call", 6 tool calls | Change to `MaxToolCallsPerTool: 10`, "11th call", 11 tool calls | Production default alignment |
+
+---
+
+## 15. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-04-26 | Initial test plan |

--- a/internal/kubernautagent/config/config.go
+++ b/internal/kubernautagent/config/config.go
@@ -377,7 +377,7 @@ func DefaultConfig() *Config {
 		Investigator: InvestigatorConfig{MaxTurns: 15},
 		Audit:        AuditConfig{Enabled: true},
 		Anomaly: AnomalyConfig{
-			MaxToolCallsPerTool: 5,
+			MaxToolCallsPerTool: 10,
 			MaxTotalToolCalls:   30,
 			MaxRepeatedFailures: 3,
 			ExemptPrefixes:      []string{"todo_"},

--- a/internal/kubernautagent/investigator/anomaly.go
+++ b/internal/kubernautagent/investigator/anomaly.go
@@ -33,11 +33,13 @@ type AnomalyConfig struct {
 }
 
 // DefaultAnomalyConfig returns production defaults per DD-HAPI-019-003.
+// MaxToolCallsPerTool raised from 5 to 10 per #860 to accommodate
+// workflow discovery pagination (DD-WORKFLOW-016).
 // ExemptPrefixes includes "todo_" per #770: internal planning tools should
 // not consume the investigation tool budget.
 func DefaultAnomalyConfig() AnomalyConfig {
 	return AnomalyConfig{
-		MaxToolCallsPerTool: 5,
+		MaxToolCallsPerTool: 10,
 		MaxTotalToolCalls:   30,
 		MaxRepeatedFailures: 3,
 		ExemptPrefixes:      []string{"todo_"},
@@ -74,6 +76,8 @@ func NewAnomalyDetector(config AnomalyConfig, suspiciousPatterns []*regexp.Regex
 // Returns Allowed=false if the call should be rejected.
 // Tools matching ExemptPrefixes are checked for suspicious arguments but
 // do not count against total or per-tool budgets (#770).
+// Pagination calls (cursor-bearing calls to list_workflows / list_available_actions)
+// count toward MaxTotalToolCalls but are exempt from per-tool counting (#860).
 func (d *AnomalyDetector) CheckToolCall(name string, args json.RawMessage) AnomalyResult {
 	if r := d.checkSuspiciousArgs(name, args); !r.Allowed {
 		return r
@@ -91,6 +95,10 @@ func (d *AnomalyDetector) CheckToolCall(name string, args json.RawMessage) Anoma
 		}
 	}
 
+	if isPaginationCall(name, args) {
+		return AnomalyResult{Allowed: true}
+	}
+
 	d.toolCallCounts[name]++
 	if d.toolCallCounts[name] > d.config.MaxToolCallsPerTool {
 		return AnomalyResult{
@@ -100,6 +108,26 @@ func (d *AnomalyDetector) CheckToolCall(name string, args json.RawMessage) Anoma
 	}
 
 	return AnomalyResult{Allowed: true}
+}
+
+// isPaginationCall returns true when the call is a cursor-based pagination
+// continuation for a known paginated tool. Only list_workflows and
+// list_available_actions qualify (DD-WORKFLOW-016). Returns false (fail-closed)
+// on malformed input, missing cursor, or unrecognized tool names.
+func isPaginationCall(name string, args json.RawMessage) bool {
+	if name != "list_workflows" && name != "list_available_actions" {
+		return false
+	}
+	if len(args) == 0 {
+		return false
+	}
+	var parsed struct {
+		Cursor string `json:"cursor"`
+	}
+	if err := json.Unmarshal(args, &parsed); err != nil {
+		return false
+	}
+	return parsed.Cursor != ""
 }
 
 // isExempt returns true if the tool name matches any configured exempt prefix.

--- a/internal/kubernautagent/prompt/templates/phase3_workflow_selection.tmpl
+++ b/internal/kubernautagent/prompt/templates/phase3_workflow_selection.tmpl
@@ -57,14 +57,17 @@ enrichment context provided.
 **Step 1**: Call `list_available_actions` to discover available remediation action types.
 Review all returned action types and their descriptions. Choose the action type that
 best matches the RCA findings.
+DO NOT GUESS action types. You MUST call `list_available_actions` first to see what is available.
+If the response includes `pagination.hasNext`, call the tool again with `page: "next"` and `cursor` set to the `nextCursor` value to review ALL action types before selecting one.
 
 **Action Type Selection Rules** (apply BEFORE calling Step 2):
 - If `cluster_context` shows `gitOpsManaged=true`, MUST prefer git-based action types.
 - If the RCA reveals an error rate spike correlating with a recent deployment revision change, prefer ProactiveRollback.
 - Cross-reference each action type's `when_to_use` and `when_not_to_use` guidance against the RCA findings.
 
-**Step 2**: Call `list_workflows` with `action_type` set to your chosen action type.
-**CRITICAL**: If the response includes `pagination.hasNext`, call the tool again with `page: "next"` and `cursor` set to the `nextCursor` value to review ALL workflows.
+**Step 2**: Call `list_workflows` with `action_type` set to your chosen action type from Step 1.
+DO NOT GUESS workflow IDs. You MUST call `list_workflows` to see what is available.
+**CRITICAL**: If the response includes `pagination.hasNext`, call the tool again with `page: "next"` and `cursor` set to the `nextCursor` value to review ALL workflows before selecting one.
 
 **Step 3**: Call `get_workflow` with the `workflow_id` of your selected workflow to retrieve its full parameter schema.
 

--- a/test/integration/kubernautagent/investigator/investigator_anomaly_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_anomaly_test.go
@@ -61,17 +61,17 @@ var _ = Describe("Kubernaut Agent Anomaly Detector Wiring — TP-433-WIR Phase 4
 		phaseTools = investigator.DefaultPhaseToolMap()
 	})
 
-	Describe("IT-KA-433W-012: executeTool rejects 6th call to same tool (per-tool limit)", func() {
-		It("should return error JSON on 6th call when MaxToolCallsPerTool=5", func() {
+	Describe("IT-KA-433W-012: executeTool rejects 11th call to same tool (per-tool limit=10, #860)", func() {
+		It("should return error JSON on 11th call when MaxToolCallsPerTool=10", func() {
 			reg := registry.New()
 			reg.Register(&fakeTool{name: "kubectl_describe", result: `{"status":"ok"}`})
 
 			detector := investigator.NewAnomalyDetector(
-				investigator.AnomalyConfig{MaxToolCallsPerTool: 5, MaxTotalToolCalls: 100, MaxRepeatedFailures: 10},
+				investigator.AnomalyConfig{MaxToolCallsPerTool: 10, MaxTotalToolCalls: 100, MaxRepeatedFailures: 10},
 				nil,
 			)
 
-			toolCalls := make([]llm.ToolCall, 6)
+			toolCalls := make([]llm.ToolCall, 11)
 			for i := range toolCalls {
 				toolCalls[i] = llm.ToolCall{ID: fmt.Sprintf("tc_%d", i+1), Name: "kubectl_describe", Arguments: `{}`}
 			}
@@ -103,7 +103,7 @@ var _ = Describe("Kubernaut Agent Anomaly Detector Wiring — TP-433-WIR Phase 4
 				}
 			}
 			Expect(foundRejection).To(BeTrue(),
-				"6th tool call should be rejected with per-tool limit error")
+				"11th tool call should be rejected with per-tool limit error")
 		})
 	})
 
@@ -150,6 +150,52 @@ var _ = Describe("Kubernaut Agent Anomaly Detector Wiring — TP-433-WIR Phase 4
 			}
 			Expect(foundRejection).To(BeTrue(),
 				"3rd identical failure should trigger repeated-failure anomaly")
+		})
+	})
+
+	Describe("IT-KA-860-001: executeTool allows pagination-heavy list_workflows sequence (#860, BR-HAPI-433-004 I7)", func() {
+		It("should allow 12 list_workflows calls (5 initial + 7 pagination) without per-tool rejection", func() {
+			reg := registry.New()
+			reg.Register(&fakeTool{name: "list_workflows", result: `{"workflows":[{"id":"drain-node"}],"pagination":{"hasNext":true,"nextCursor":"abc"}}`})
+
+			detector := investigator.NewAnomalyDetector(
+				investigator.AnomalyConfig{MaxToolCallsPerTool: 10, MaxTotalToolCalls: 100, MaxRepeatedFailures: 100},
+				nil,
+			)
+
+			toolCalls := make([]llm.ToolCall, 12)
+			for i := range toolCalls {
+				args := `{"action_type":"cordon"}`
+				if i >= 5 {
+					args = fmt.Sprintf(`{"action_type":"cordon","cursor":"page_%d"}`, i-4)
+				}
+				toolCalls[i] = llm.ToolCall{ID: fmt.Sprintf("tc_%d", i+1), Name: "list_workflows", Arguments: args}
+			}
+
+			mockClient := &mockLLMClient{
+				responses: []llm.ChatResponse{
+					{
+						Message:   llm.Message{Role: "assistant", Content: "listing workflows"},
+						ToolCalls: toolCalls,
+					},
+					{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"needs drain","confidence":0.9}`}},
+					wfToolResp(`{"workflow_id":"drain-node","confidence":0.9}`),
+				},
+			}
+
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg, Pipeline: investigator.Pipeline{AnomalyDetector: detector}})
+			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
+				Name: "api", Namespace: "default", Severity: "warning", Message: "DiskPressure",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			secondCall := mockClient.calls[1]
+			for _, msg := range secondCall.Messages {
+				if msg.Role == "tool" {
+					Expect(msg.Content).NotTo(ContainSubstring("per-tool call limit exceeded"),
+						"IT-KA-860-001: no list_workflows call should be rejected — pagination calls are exempt from per-tool budget")
+				}
+			}
 		})
 	})
 

--- a/test/unit/kubernautagent/config/config_test.go
+++ b/test/unit/kubernautagent/config/config_test.go
@@ -72,7 +72,7 @@ llm:
 			Expect(cfg.Server.Port).To(Equal(8080), "default port should be 8080")
 			Expect(cfg.Session.TTL).To(Equal(30*time.Minute), "default TTL should be 30m")
 			Expect(cfg.Investigator.MaxTurns).To(Equal(15), "default max turns should be 15")
-			Expect(cfg.Anomaly.MaxToolCallsPerTool).To(Equal(5), "default per-tool limit should be 5")
+			Expect(cfg.Anomaly.MaxToolCallsPerTool).To(Equal(10), "UT-KA-860-006: default per-tool limit raised to 10 per #860")
 			Expect(cfg.Anomaly.MaxTotalToolCalls).To(Equal(30), "default total tool calls should be 30")
 			Expect(cfg.Anomaly.MaxRepeatedFailures).To(Equal(3), "default repeated failures should be 3")
 		})
@@ -263,9 +263,9 @@ summarizer:
 	})
 
 	Describe("UT-KA-433W-011: DefaultConfig applies anomaly thresholds", func() {
-		It("should set MaxToolCallsPerTool=5, MaxTotalToolCalls=30, MaxRepeatedFailures=3", func() {
+		It("should set MaxToolCallsPerTool=10, MaxTotalToolCalls=30, MaxRepeatedFailures=3 (#860)", func() {
 			cfg := config.DefaultConfig()
-			Expect(cfg.Anomaly.MaxToolCallsPerTool).To(Equal(5))
+			Expect(cfg.Anomaly.MaxToolCallsPerTool).To(Equal(10))
 			Expect(cfg.Anomaly.MaxTotalToolCalls).To(Equal(30))
 			Expect(cfg.Anomaly.MaxRepeatedFailures).To(Equal(3))
 		})

--- a/test/unit/kubernautagent/investigator/anomaly_test.go
+++ b/test/unit/kubernautagent/investigator/anomaly_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
 )
 
+// DescribeTable and Entry are dot-imported from ginkgo/v2 above.
+
 var _ = Describe("Kubernaut Agent I7 Anomaly Detection — #433", func() {
 
 	Describe("UT-KA-433-054: Per-tool call limit triggers abort", func() {
@@ -318,11 +320,103 @@ var _ = Describe("Kubernaut Agent I7 Anomaly Detection — #433", func() {
 			Expect(result.Allowed).To(BeFalse(), "custom per-tool limit of 2 should apply")
 		})
 
-		It("should use default config values when DefaultAnomalyConfig is used", func() {
+		It("UT-KA-860-005: DefaultAnomalyConfig reflects MaxToolCallsPerTool=10 (BR-HAPI-433-004 I7)", func() {
 			cfg := investigator.DefaultAnomalyConfig()
-			Expect(cfg.MaxToolCallsPerTool).To(Equal(5))
+			Expect(cfg.MaxToolCallsPerTool).To(Equal(10),
+				"UT-KA-860-005: default per-tool limit raised to 10 per #860")
 			Expect(cfg.MaxTotalToolCalls).To(Equal(30))
 			Expect(cfg.MaxRepeatedFailures).To(Equal(3))
+		})
+	})
+
+	Describe("Pagination Exemption from Per-Tool Budget (#860, BR-HAPI-433-004 I7)", func() {
+
+		It("UT-KA-860-001: pagination call (list_workflows with cursor) does NOT increment per-tool count", func() {
+			cfg := investigator.AnomalyConfig{
+				MaxToolCallsPerTool: 3,
+				MaxTotalToolCalls:   100,
+				MaxRepeatedFailures: 100,
+			}
+			detector := investigator.NewAnomalyDetector(cfg, nil)
+
+			paginationArgs := json.RawMessage(`{"action_type":"cordon","cursor":"eyJvZmZzZXQiOjEwfQ=="}`)
+			for i := 0; i < 10; i++ {
+				result := detector.CheckToolCall("list_workflows", paginationArgs)
+				Expect(result.Allowed).To(BeTrue(),
+					"UT-KA-860-001: pagination call %d should be allowed (cursor exempt from per-tool count)", i+1)
+			}
+		})
+
+		It("UT-KA-860-002: non-pagination call increments per-tool count and rejects at limit=10", func() {
+			cfg := investigator.AnomalyConfig{
+				MaxToolCallsPerTool: 10,
+				MaxTotalToolCalls:   100,
+				MaxRepeatedFailures: 100,
+			}
+			detector := investigator.NewAnomalyDetector(cfg, nil)
+
+			for i := 0; i < 10; i++ {
+				result := detector.CheckToolCall("kubectl_describe", json.RawMessage(`{}`))
+				Expect(result.Allowed).To(BeTrue(), "call %d should be allowed", i+1)
+			}
+			result := detector.CheckToolCall("kubectl_describe", json.RawMessage(`{}`))
+			Expect(result.Allowed).To(BeFalse(),
+				"UT-KA-860-002: 11th non-pagination call should be rejected at limit=10")
+			Expect(result.Reason).To(ContainSubstring("per-tool call limit exceeded"))
+		})
+
+		It("UT-KA-860-003: pagination calls still count toward MaxTotalToolCalls (safety net)", func() {
+			cfg := investigator.AnomalyConfig{
+				MaxToolCallsPerTool: 100,
+				MaxTotalToolCalls:   5,
+				MaxRepeatedFailures: 100,
+			}
+			detector := investigator.NewAnomalyDetector(cfg, nil)
+
+			paginationArgs := json.RawMessage(`{"action_type":"cordon","cursor":"abc123"}`)
+			for i := 0; i < 5; i++ {
+				result := detector.CheckToolCall("list_workflows", paginationArgs)
+				Expect(result.Allowed).To(BeTrue(),
+					"UT-KA-860-003: pagination call %d within total budget should be allowed", i+1)
+			}
+			result := detector.CheckToolCall("list_workflows", paginationArgs)
+			Expect(result.Allowed).To(BeFalse(),
+				"UT-KA-860-003: 6th pagination call should hit MaxTotalToolCalls=5 safety net")
+			Expect(result.Reason).To(ContainSubstring("total tool call limit exceeded"))
+		})
+
+		Describe("UT-KA-860-004: isPaginationCall edge cases (fail-closed)", func() {
+			var detector *investigator.AnomalyDetector
+
+			BeforeEach(func() {
+				cfg := investigator.AnomalyConfig{
+					MaxToolCallsPerTool: 1,
+					MaxTotalToolCalls:   100,
+					MaxRepeatedFailures: 100,
+				}
+				detector = investigator.NewAnomalyDetector(cfg, nil)
+			})
+
+			DescribeTable("should treat non-pagination calls as counted (fail-closed)",
+				func(toolName string, args json.RawMessage, shouldBePagination bool) {
+					detector.CheckToolCall(toolName, args)
+					result := detector.CheckToolCall(toolName, args)
+					if shouldBePagination {
+						Expect(result.Allowed).To(BeTrue(),
+							"pagination call should NOT count against per-tool limit")
+					} else {
+						Expect(result.Allowed).To(BeFalse(),
+							"non-pagination call should count and reject at limit=1")
+					}
+				},
+				Entry("nil args", "list_workflows", json.RawMessage(nil), false),
+				Entry("empty args", "list_workflows", json.RawMessage(`{}`), false),
+				Entry("malformed JSON", "list_workflows", json.RawMessage(`{bad`), false),
+				Entry("empty cursor", "list_workflows", json.RawMessage(`{"cursor":""}`), false),
+				Entry("non-paginated tool with cursor", "kubectl_describe", json.RawMessage(`{"cursor":"abc"}`), false),
+				Entry("list_available_actions with cursor", "list_available_actions", json.RawMessage(`{"cursor":"abc"}`), true),
+				Entry("list_workflows with cursor", "list_workflows", json.RawMessage(`{"action_type":"cordon","cursor":"abc"}`), true),
+			)
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Cherry-picks the #860 pagination exemption fix from `release/v1.3.2` to `main` (v1.4.0-rc1).

- `isPaginationCall` exempts cursor-bearing `list_workflows`/`list_available_actions` from per-tool anomaly budget
- `MaxToolCallsPerTool` raised from 5 to 10
- Phase 3 prompt reinforced with "DO NOT GUESS" and pagination exhaustion
- Authoritative docs updated: DD-WORKFLOW-016, DD-HAPI-019-003, CONFIG_STANDARDS, TP-688
- New test plan TP-860 with 6 unit + 1 integration test

Source commit: `c5a7203ab` from `release/v1.3.2`

## Test plan
- [x] Build: `go build ./...` — clean on main
- [x] Unit tests (860 focus): all pass
- [x] Integration tests (860 + 433W-012): all pass
- [ ] CI validation on PR


Made with [Cursor](https://cursor.com)