### PR TITLE
fix(#875): make kubernaut-agent log level configurable via config file

### DIFF
--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -85,9 +85,9 @@ func main() {
 	flag.StringVar(&addr, "addr", "", "HTTP listen address (overrides config server.port)")
 	flag.Parse()
 
-	slogHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
-	slogger := slog.New(slogHandler)
-	logrLogger := logr.FromSlogHandler(slogHandler)
+	// Bootstrap logger at INFO for startup; replaced after config is loaded (#875).
+	bootHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
+	slogger := slog.New(bootHandler)
 
 	cfgData, err := os.ReadFile(configPath)
 	if err != nil {
@@ -99,6 +99,13 @@ func main() {
 		slogger.Error("failed to parse config", "error", err)
 		os.Exit(1)
 	}
+
+	// Re-create logger with configured level (#875).
+	slogHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: cfg.Logging.SlogLevel()})
+	slogger = slog.New(slogHandler)
+	logrLogger := logr.FromSlogHandler(slogHandler)
+
+	slogger.Info("log level configured", "level", cfg.Logging.Level)
 
 	if sdkData, sdkErr := os.ReadFile(sdkConfigPath); sdkErr == nil {
 		if mergeErr := cfg.MergeSDKConfig(sdkData); mergeErr != nil {

--- a/internal/kubernautagent/config/config.go
+++ b/internal/kubernautagent/config/config.go
@@ -18,6 +18,8 @@ package config
 
 import (
 	"fmt"
+	"log/slog"
+	"strings"
 	"time"
 
 	pkgconfig "github.com/jordigilh/kubernaut/pkg/kubernautagent/config"
@@ -29,6 +31,7 @@ import (
 // Nested sub-configs support forward-compatibility with Phases 2-6
 // without breaking Phase 1 tests.
 type Config struct {
+	Logging        LoggingConfig        `yaml:"logging"`
 	LLM            LLMConfig            `yaml:"llm"`
 	DataStorage    DataStorageConfig    `yaml:"data_storage"`
 	Server         ServerConfig         `yaml:"server"`
@@ -46,6 +49,26 @@ type Config struct {
 	// TLSProfile selects the TLS security profile (Old/Intermediate/Modern).
 	// Issue #748: OCP-only — set by kubernaut-operator from the cluster APIServer CR.
 	TLSProfile string `yaml:"tlsProfile,omitempty"`
+}
+
+// LoggingConfig holds log-level configuration (#875).
+type LoggingConfig struct {
+	Level string `yaml:"level"` // DEBUG, INFO, WARN, ERROR
+}
+
+// SlogLevel converts the configured level string to an slog.Level.
+// Defaults to slog.LevelInfo for empty or unrecognised values.
+func (l LoggingConfig) SlogLevel() slog.Level {
+	switch strings.ToUpper(l.Level) {
+	case "DEBUG":
+		return slog.LevelDebug
+	case "WARN":
+		return slog.LevelWarn
+	case "ERROR":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
 }
 
 type LLMConfig struct {
@@ -292,6 +315,12 @@ func (c *Config) MergeSDKConfig(data []byte) error {
 
 // Validate checks required fields and value constraints.
 func (c *Config) Validate() error {
+	if c.Logging.Level != "" {
+		validLevels := map[string]bool{"DEBUG": true, "INFO": true, "WARN": true, "ERROR": true}
+		if !validLevels[strings.ToUpper(c.Logging.Level)] {
+			return fmt.Errorf("invalid log level: %s (must be DEBUG, INFO, WARN, or ERROR)", c.Logging.Level)
+		}
+	}
 	switch c.LLM.Provider {
 	case "bedrock", "huggingface", "anthropic", "openai", "vertex", "vertex_ai":
 		// endpoint is optional: LangChainGo uses default endpoints or project/location for these providers
@@ -344,6 +373,7 @@ func (c *Config) Validate() error {
 // DefaultConfig returns a Config with production defaults applied.
 func DefaultConfig() *Config {
 	return &Config{
+		Logging:      LoggingConfig{Level: "INFO"},
 		LLM:          LLMConfig{Provider: "openai"},
 		DataStorage:  DataStorageConfig{SATokenPath: "/var/run/secrets/kubernetes.io/serviceaccount/token"},
 		Server:       ServerConfig{Address: "0.0.0.0", Port: 8080, HealthAddr: ":8081", MetricsAddr: ":9090"},

--- a/test/unit/kubernautagent/config/logging_test.go
+++ b/test/unit/kubernautagent/config/logging_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config_test
+
+import (
+	"log/slog"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/config"
+)
+
+var _ = Describe("Kubernaut Agent Logging Configuration — #875", func() {
+
+	Describe("UT-KA-875-001: DefaultConfig sets logging level to INFO", func() {
+		It("should default Logging.Level to INFO", func() {
+			cfg := config.DefaultConfig()
+			Expect(cfg.Logging.Level).To(Equal("INFO"))
+		})
+	})
+
+	Describe("UT-KA-875-002: Logging level parsed from YAML config", func() {
+		It("should parse logging.level from YAML", func() {
+			yamlData := []byte(`
+llm:
+  provider: "openai"
+  model: "gpt-4o"
+logging:
+  level: "DEBUG"
+`)
+			cfg, err := config.Load(yamlData)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.Logging.Level).To(Equal("DEBUG"))
+		})
+	})
+
+	Describe("UT-KA-875-003: Validate rejects invalid log level", func() {
+		It("should reject an unrecognized log level", func() {
+			yamlData := []byte(`
+llm:
+  provider: "openai"
+  model: "gpt-4o"
+logging:
+  level: "VERBOSE"
+`)
+			cfg, err := config.Load(yamlData)
+			Expect(err).NotTo(HaveOccurred())
+			err = cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("log level"))
+		})
+	})
+
+	Describe("UT-KA-875-004: Validate accepts all valid log levels", func() {
+		DescribeTable("valid log levels",
+			func(level string) {
+				yamlData := []byte(`
+llm:
+  provider: "openai"
+  model: "gpt-4o"
+logging:
+  level: "` + level + `"
+`)
+				cfg, err := config.Load(yamlData)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg.Validate()).To(Succeed())
+			},
+			Entry("DEBUG", "DEBUG"),
+			Entry("INFO", "INFO"),
+			Entry("WARN", "WARN"),
+			Entry("ERROR", "ERROR"),
+		)
+	})
+
+	Describe("UT-KA-875-005: SlogLevel returns correct slog.Level", func() {
+		DescribeTable("level mapping",
+			func(level string, expected slog.Level) {
+				yamlData := []byte(`
+llm:
+  provider: "openai"
+  model: "gpt-4o"
+logging:
+  level: "` + level + `"
+`)
+				cfg, err := config.Load(yamlData)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(cfg.Logging.SlogLevel()).To(Equal(expected))
+			},
+			Entry("DEBUG -> slog.LevelDebug", "DEBUG", slog.LevelDebug),
+			Entry("INFO -> slog.LevelInfo", "INFO", slog.LevelInfo),
+			Entry("WARN -> slog.LevelWarn", "WARN", slog.LevelWarn),
+			Entry("ERROR -> slog.LevelError", "ERROR", slog.LevelError),
+		)
+	})
+
+	Describe("UT-KA-875-006: SlogLevel defaults to INFO for empty level", func() {
+		It("should return slog.LevelInfo when level is empty", func() {
+			cfg := config.DefaultConfig()
+			Expect(cfg.Logging.SlogLevel()).To(Equal(slog.LevelInfo))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

The KA binary hardcoded `slog.LevelInfo`, so the `logging.level` key already rendered by the Helm chart ConfigMap was silently ignored.

### Changes

- **Config** (`internal/kubernautagent/config/config.go`):
  - Added `LoggingConfig` struct with `Level` field and `SlogLevel()` helper
  - Default `INFO` in `DefaultConfig()`
  - Validation in `Validate()` — accepts DEBUG, INFO, WARN, ERROR

- **Main** (`cmd/kubernautagent/main.go`):
  - Two-phase logger: bootstrap at INFO for startup errors, then reconfigured with `cfg.Logging.SlogLevel()` after config load

- **Tests** (`test/unit/kubernautagent/config/logging_test.go`):
  - 6 specs (TDD): default level, YAML parsing, validation rejection, valid level table, SlogLevel mapping table, empty-level default

### Related

- Closes #875
- Sibling issues from log-level audit: #876 (authwebhook), #877 (gateway), #878 (notification)

## Test plan

- [x] Unit tests pass (69/69 specs, 0 failures)
- [x] `go build ./cmd/kubernautagent/...` succeeds
- [x] No lint errors
- [ ] CI passes

Made with [Cursor](https://cursor.com)