### PR TITLE
fix: v1.5 wiring audit — E2E URL corrections + integration test gap coverage

### DIFF
--- a/test/e2e/kubernautagent/observability_e2e_test.go
+++ b/test/e2e/kubernautagent/observability_e2e_test.go
@@ -76,7 +76,7 @@ var _ = Describe("E2E-KA-OBS: Observability / Prometheus Metrics (BR-KA-OBSERVAB
 
 			By("Hitting a non-existent session to trigger authz_denied metric")
 			req, err := http.NewRequestWithContext(ctx, "GET",
-				kaURL+"/api/v1/incident/session/non-existent-obs-001/status", nil)
+				kaURL+"/api/v1/incident/session/non-existent-obs-001", nil)
 			Expect(err).NotTo(HaveOccurred())
 			resp, err := authHTTPClient.Do(req)
 			Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/kubernautagent/session_v15_e2e_test.go
+++ b/test/e2e/kubernautagent/session_v15_e2e_test.go
@@ -286,7 +286,7 @@ var _ = Describe("E2E-KA-V15: v1.5 Streaming and Cancellation", Label("e2e", "ka
 
 			By("User B attempts to read session status — expects 404 (authz denial)")
 			statusReq, err := http.NewRequestWithContext(ctx, "GET",
-				fmt.Sprintf("%s/api/v1/incident/session/%s/status", kaURL, sessionID), nil)
+				fmt.Sprintf("%s/api/v1/incident/session/%s", kaURL, sessionID), nil)
 			Expect(err).ToNot(HaveOccurred())
 			statusResp, err := authHTTPClientB.Do(statusReq)
 			Expect(err).ToNot(HaveOccurred())

--- a/test/integration/kubernautagent/server/wiring_test.go
+++ b/test/integration/kubernautagent/server/wiring_test.go
@@ -531,6 +531,52 @@ var _ = Describe("Wiring Integration Tests — #823", func() {
 				"stream must still terminate with complete event after error")
 		})
 	})
+
+	// ---------------------------------------------------------------
+	// IT-WIRE-14: POST /cancel on terminal session returns 409
+	// ---------------------------------------------------------------
+	Describe("IT-WIRE-14: Cancel on completed session returns 409 (ErrSessionTerminal)", func() {
+		It("POST /cancel returns 409 after investigation completes", func() {
+			h := newTestHarness()
+			defer h.Close()
+
+			id := startInvestigationWithFunc(h, func(_ context.Context) (interface{}, error) {
+				return &katypes.InvestigationResult{RCASummary: "done"}, nil
+			})
+			waitForStatus(h, id, session.StatusCompleted)
+
+			resp, err := http.Post(
+				h.Server.URL+"/api/v1/incident/session/"+id+"/cancel",
+				"application/json", nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusConflict),
+				"cancel on terminal session must return 409 per ErrSessionTerminal mapping")
+		})
+	})
+
+	// ---------------------------------------------------------------
+	// IT-WIRE-15: GET /stream on terminal session returns 404
+	// ---------------------------------------------------------------
+	Describe("IT-WIRE-15: Stream on completed session returns 404 (ErrSessionTerminal)", func() {
+		It("GET /stream returns 404 after investigation completes", func() {
+			h := newTestHarness()
+			defer h.Close()
+
+			id := startInvestigationWithFunc(h, func(_ context.Context) (interface{}, error) {
+				return &katypes.InvestigationResult{RCASummary: "done"}, nil
+			})
+			waitForStatus(h, id, session.StatusCompleted)
+
+			resp, err := http.Get(h.Server.URL + "/api/v1/incident/session/" + id + "/stream")
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound),
+				"stream on terminal session must return 404 per ErrSessionTerminal mapping")
+		})
+	})
 })
 
 // --- Helpers ---
@@ -798,6 +844,33 @@ var _ = Describe("Metrics Wiring Integration Tests — BR-KA-OBSERVABILITY-001",
 			})
 			Expect(v).To(BeNumerically(">=", 1))
 		})
+
+		It("records authz_denied_total with owner_mismatch reason on cross-user access", func() {
+			h := newMetricsTestHarness(&blockingInvestigator{}, "user-b")
+			defer h.Close()
+
+			ctx := context.WithValue(context.Background(), auth.UserContextKey, "user-a")
+			id, err := h.Manager.StartInvestigation(ctx, func(ctx context.Context) (interface{}, error) {
+				<-ctx.Done()
+				return &katypes.InvestigationResult{RCASummary: "cancelled"}, nil
+			}, map[string]string{"remediation_id": "rr-obs-004b"})
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, err := http.Get(h.Server.URL + "/api/v1/incident/session/" + id)
+			Expect(err).NotTo(HaveOccurred())
+			resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound),
+				"cross-user access should return 404")
+
+			v := gatherCounterFromReg(h.Registry, kametrics.MetricNameAuthzDeniedTotal, map[string]string{
+				"reason": "owner_mismatch",
+			})
+			Expect(v).To(BeNumerically(">=", 1),
+				"owner_mismatch reason should be recorded when a different user accesses the session")
+
+			h.Manager.CancelInvestigation(id)
+		})
 	})
 
 	Describe("IT-KA-OBS-005: Rate limiter increments counter when request rejected", func() {
@@ -820,6 +893,38 @@ var _ = Describe("Metrics Wiring Integration Tests — BR-KA-OBSERVABILITY-001",
 			if resp2.StatusCode == http.StatusTooManyRequests {
 				Expect(v).To(BeNumerically(">=", 1))
 			}
+		})
+	})
+
+	Describe("IT-KA-OBS-006: InstrumentedAuditStore increments audit_events_emitted_total", func() {
+		It("records metric after session lifecycle generates audit events", func() {
+			reg := prometheus.NewRegistry()
+			m := kametrics.NewMetricsWithRegistry(reg)
+
+			instrumentedStore := audit.NewInstrumentedAuditStore(
+				audit.NopAuditStore{}, m.RecordAuditEventEmitted,
+			)
+
+			store := session.NewStore(5 * time.Minute)
+			mgr := session.NewManager(store, slog.Default(), instrumentedStore, m)
+
+			id, err := mgr.StartInvestigation(context.Background(),
+				func(_ context.Context) (interface{}, error) {
+					return &katypes.InvestigationResult{RCASummary: "done"}, nil
+				}, map[string]string{"remediation_id": "rr-obs-006"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() string {
+				s, _ := mgr.GetSession(id)
+				if s == nil {
+					return ""
+				}
+				return string(s.Status)
+			}, 5*time.Second).Should(Equal(string(session.StatusCompleted)))
+
+			v := gatherCounterFromReg(reg, kametrics.MetricNameAuditEventsEmittedTotal, nil)
+			Expect(v).To(BeNumerically(">=", 1),
+				"audit_events_emitted_total should increment from session lifecycle audit events")
 		})
 	})
 })

--- a/test/unit/kubernautagent/alignment/alignment_test.go
+++ b/test/unit/kubernautagent/alignment/alignment_test.go
@@ -51,7 +51,10 @@ func (s *stubTool) Parameters() json.RawMessage                                 
 func (s *stubTool) Execute(_ context.Context, _ json.RawMessage) (string, error) { return "", nil }
 
 // mockLLMClient implements llm.Client for testing.
+// A mutex guards shared mutable state because Observer.SubmitAsync
+// calls EvaluateStep (and therefore Chat) from concurrent goroutines.
 type mockLLMClient struct {
+	mu        sync.Mutex
 	responses []llm.ChatResponse
 	errs      []error
 	call      int
@@ -64,6 +67,10 @@ func (m *mockLLMClient) Chat(_ context.Context, req llm.ChatRequest) (llm.ChatRe
 	for _, msg := range req.Messages {
 		b.WriteString(msg.Content)
 	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
 	m.capturedRequestContents = append(m.capturedRequestContents, b.String())
 
 	if m.call < len(m.errs) && m.errs[m.call] != nil {
@@ -90,7 +97,11 @@ func (m *mockLLMClient) StreamChat(ctx context.Context, req llm.ChatRequest, cb 
 
 func (m *mockLLMClient) Close() error { return nil }
 
-func (m *mockLLMClient) chatCalls() int { return m.call }
+func (m *mockLLMClient) chatCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.call
+}
 
 // slowMockLLMClient adds a delay before responding, used to test timeout behavior.
 type slowMockLLMClient struct {


### PR DESCRIPTION
## Summary

Addresses findings from the v1.5 wiring verification audit conducted across all 10 PRs under #822.

- **FINDING-1 (CRITICAL)**: E2E tests for cross-user authz (`E2E-KA-AUTHZ-001`) and observability (`E2E-KA-OBS-001` authz trigger) were hitting `/api/v1/incident/session/{id}/status`, which is **not a valid ogen route**. Tests were getting 404 from the router, not from the business handler — meaning authz and metric assertions were vacuously passing. Fixed by removing the `/status` suffix to match the actual OpenAPI spec.
- **FINDING-2 (LOW)**: Added `IT-WIRE-14` — `POST /cancel` on a completed session returns `409 Conflict`.
- **FINDING-3 (LOW)**: Extended `IT-KA-OBS-004` — cross-user access increments `authz_denied_total` with `reason=owner_mismatch`.
- **FINDING-4 (MEDIUM)**: Added `IT-KA-OBS-006` — `InstrumentedAuditStore` wired through session Manager increments `audit_events_emitted_total` after a full session lifecycle.
- **FINDING-5 (LOW)**: Added `IT-WIRE-15` — `GET /stream` on a completed session returns `404 Not Found`.

All 23 server integration tests pass (0 failures). E2E suite previously validated at 100% pass rate.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./test/e2e/kubernautagent/... ./test/integration/kubernautagent/server/...` — clean
- [x] Integration tests: 23/23 pass (`go test ./test/integration/kubernautagent/server/...`)
- [ ] E2E tests: run `make test-e2e-kubernautagent` in Kind cluster to confirm URL fix exercises real authz logic

Closes wiring audit findings for #822.

Made with [Cursor](https://cursor.com)