### PR TITLE
fix(#823): QE-readiness hardening for session/streaming implementation

### DIFF
--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -284,7 +284,12 @@ func main() {
 	// Issue #753: /config remains on API port; health, readiness and metrics move to dedicated ports
 	r.Get("/config", configHandler(cfg, swappable))
 
-	apiRateLimiter := kaserver.NewRateLimiter(kaserver.DefaultRateLimitConfig(), agentMetrics.HTTPRateLimitedTotal)
+	apiRateLimiter := kaserver.NewRateLimiter(kaserver.RateLimitConfig{
+		RequestsPerSecond: cfg.Server.RateLimit.RequestsPerSecond,
+		Burst:             cfg.Server.RateLimit.Burst,
+		CleanupInterval:   cfg.Server.RateLimit.CleanupInterval,
+		MaxAge:            cfg.Server.RateLimit.MaxAge,
+	}, agentMetrics.HTTPRateLimitedTotal)
 	defer apiRateLimiter.Stop()
 
 	r.Route("/api/v1", func(r chi.Router) {

--- a/internal/kubernautagent/api/openapi.json
+++ b/internal/kubernautagent/api/openapi.json
@@ -587,7 +587,7 @@
           "Session Control"
         ],
         "summary": "Stream Investigation Events",
-        "description": "Subscribe to live investigation events via Server-Sent Events (SSE).\n\nBusiness Requirement: BR-SESSION-007 (Investigation event observability)\n\nPR2: Returns 501 Not Implemented (stub).\nPR4: Full SSE implementation with turn-level and token-level events.\n\nSSE format: id: {seq}\\nevent: {type}\\ndata: {json}\\n\\n",
+        "description": "Subscribe to live investigation events via Server-Sent Events (SSE).\n\nBusiness Requirement: BR-SESSION-007 (Investigation event observability)\n\nStreams turn-level and token-level events in real time.\nReturns 404 if session not found or already in terminal state (use the snapshot endpoint instead).\n\nSSE format: id: {seq}\\nevent: {type}\\ndata: {json}\\n\\n",
         "operationId": "session_stream_api_v1_incident_session__session_id__stream_get",
         "parameters": [
           {

--- a/internal/kubernautagent/config/config.go
+++ b/internal/kubernautagent/config/config.go
@@ -88,6 +88,15 @@ type ServerConfig struct {
 	HealthAddr  string              `yaml:"health_addr"`  // Issue #753: Dedicated health probe port (default ":8081")
 	MetricsAddr string              `yaml:"metrics_addr"` // Issue #753: Dedicated metrics port (default ":9090")
 	TLS         sharedtls.TLSConfig `yaml:"tls,omitempty"`
+	RateLimit   RateLimitConfig     `yaml:"rate_limit"`
+}
+
+// RateLimitConfig configures per-IP HTTP rate limiting for the agent API.
+type RateLimitConfig struct {
+	RequestsPerSecond float64       `yaml:"requests_per_second"`
+	Burst             int           `yaml:"burst"`
+	CleanupInterval   time.Duration `yaml:"cleanup_interval"`
+	MaxAge            time.Duration `yaml:"max_age"`
 }
 
 type SessionConfig struct {
@@ -306,6 +315,12 @@ func (c *Config) Validate() error {
 	if c.Investigator.MaxTurns <= 0 {
 		return fmt.Errorf("investigator.max_turns must be positive, got %d", c.Investigator.MaxTurns)
 	}
+	if c.Server.RateLimit.RequestsPerSecond <= 0 {
+		return fmt.Errorf("server.rate_limit.requests_per_second must be positive, got %v", c.Server.RateLimit.RequestsPerSecond)
+	}
+	if c.Server.RateLimit.Burst <= 0 {
+		return fmt.Errorf("server.rate_limit.burst must be positive, got %d", c.Server.RateLimit.Burst)
+	}
 	if c.LLM.OAuth2.Enabled {
 		if c.LLM.OAuth2.TokenURL == "" {
 			return fmt.Errorf("llm.oauth2.token_url is required when oauth2.enabled=true")
@@ -346,7 +361,15 @@ func DefaultConfig() *Config {
 	return &Config{
 		LLM:          LLMConfig{Provider: "openai"},
 		DataStorage:  DataStorageConfig{SATokenPath: "/var/run/secrets/kubernetes.io/serviceaccount/token"},
-		Server:       ServerConfig{Address: "0.0.0.0", Port: 8080, HealthAddr: ":8081", MetricsAddr: ":9090"},
+		Server: ServerConfig{
+			Address: "0.0.0.0", Port: 8080, HealthAddr: ":8081", MetricsAddr: ":9090",
+			RateLimit: RateLimitConfig{
+				RequestsPerSecond: 5,
+				Burst:             10,
+				CleanupInterval:   5 * time.Minute,
+				MaxAge:            10 * time.Minute,
+			},
+		},
 		Session:      SessionConfig{TTL: 30 * time.Minute},
 		Investigator: InvestigatorConfig{MaxTurns: 15},
 		Audit:        AuditConfig{Enabled: true},

--- a/internal/kubernautagent/server/ratelimit.go
+++ b/internal/kubernautagent/server/ratelimit.go
@@ -124,6 +124,7 @@ func (rl *RateLimiter) Middleware(next http.Handler) http.Handler {
 			if rl.rateLimitedCounter != nil {
 				rl.rateLimitedCounter.Inc()
 			}
+			w.Header().Set("Retry-After", "1")
 			http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
 			return
 		}

--- a/pkg/agentclient/oas_client_gen.go
+++ b/pkg/agentclient/oas_client_gen.go
@@ -103,8 +103,8 @@ type Invoker interface {
 	//
 	// Subscribe to live investigation events via Server-Sent Events (SSE).
 	// Business Requirement: BR-SESSION-007 (Investigation event observability)
-	// PR2: Returns 501 Not Implemented (stub).
-	// PR4: Full SSE implementation with turn-level and token-level events.
+	// Streams turn-level and token-level events in real time.
+	// Returns 404 if session not found or already in terminal state (use the snapshot endpoint instead).
 	// SSE format: id: {seq}\nevent: {type}\ndata: {json}\n\n.
 	//
 	// GET /api/v1/incident/session/{session_id}/stream
@@ -843,8 +843,8 @@ func (c *Client) sendSessionSnapshotAPIV1IncidentSessionSessionIDSnapshotGet(ctx
 //
 // Subscribe to live investigation events via Server-Sent Events (SSE).
 // Business Requirement: BR-SESSION-007 (Investigation event observability)
-// PR2: Returns 501 Not Implemented (stub).
-// PR4: Full SSE implementation with turn-level and token-level events.
+// Streams turn-level and token-level events in real time.
+// Returns 404 if session not found or already in terminal state (use the snapshot endpoint instead).
 // SSE format: id: {seq}\nevent: {type}\ndata: {json}\n\n.
 //
 // GET /api/v1/incident/session/{session_id}/stream

--- a/pkg/agentclient/oas_handlers_gen.go
+++ b/pkg/agentclient/oas_handlers_gen.go
@@ -1132,8 +1132,8 @@ func (s *Server) handleSessionSnapshotAPIV1IncidentSessionSessionIDSnapshotGetRe
 //
 // Subscribe to live investigation events via Server-Sent Events (SSE).
 // Business Requirement: BR-SESSION-007 (Investigation event observability)
-// PR2: Returns 501 Not Implemented (stub).
-// PR4: Full SSE implementation with turn-level and token-level events.
+// Streams turn-level and token-level events in real time.
+// Returns 404 if session not found or already in terminal state (use the snapshot endpoint instead).
 // SSE format: id: {seq}\nevent: {type}\ndata: {json}\n\n.
 //
 // GET /api/v1/incident/session/{session_id}/stream

--- a/pkg/agentclient/oas_server_gen.go
+++ b/pkg/agentclient/oas_server_gen.go
@@ -85,8 +85,8 @@ type Handler interface {
 	//
 	// Subscribe to live investigation events via Server-Sent Events (SSE).
 	// Business Requirement: BR-SESSION-007 (Investigation event observability)
-	// PR2: Returns 501 Not Implemented (stub).
-	// PR4: Full SSE implementation with turn-level and token-level events.
+	// Streams turn-level and token-level events in real time.
+	// Returns 404 if session not found or already in terminal state (use the snapshot endpoint instead).
 	// SSE format: id: {seq}\nevent: {type}\ndata: {json}\n\n.
 	//
 	// GET /api/v1/incident/session/{session_id}/stream

--- a/pkg/agentclient/oas_unimplemented_gen.go
+++ b/pkg/agentclient/oas_unimplemented_gen.go
@@ -113,8 +113,8 @@ func (UnimplementedHandler) SessionSnapshotAPIV1IncidentSessionSessionIDSnapshot
 //
 // Subscribe to live investigation events via Server-Sent Events (SSE).
 // Business Requirement: BR-SESSION-007 (Investigation event observability)
-// PR2: Returns 501 Not Implemented (stub).
-// PR4: Full SSE implementation with turn-level and token-level events.
+// Streams turn-level and token-level events in real time.
+// Returns 404 if session not found or already in terminal state (use the snapshot endpoint instead).
 // SSE format: id: {seq}\nevent: {type}\ndata: {json}\n\n.
 //
 // GET /api/v1/incident/session/{session_id}/stream

--- a/test/integration/kubernautagent/server/wiring_test.go
+++ b/test/integration/kubernautagent/server/wiring_test.go
@@ -19,11 +19,13 @@ package server_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
@@ -98,15 +100,21 @@ var _ = Describe("Wiring Integration Tests — #823", func() {
 			defer h.Close()
 
 			codes := make([]int, 3)
+			var lastResp *http.Response
 			for i := 0; i < 3; i++ {
 				resp, err := http.Get(h.Server.URL + "/api/v1/incident/session/nonexistent")
 				Expect(err).NotTo(HaveOccurred())
 				codes[i] = resp.StatusCode
+				if i == 2 {
+					lastResp = resp
+				}
 				resp.Body.Close()
 			}
 
 			Expect(codes[2]).To(Equal(http.StatusTooManyRequests),
 				"third request should be rate-limited (429)")
+			Expect(lastResp.Header.Get("Retry-After")).To(Equal("1"),
+				"429 response must include Retry-After header (RFC 6585)")
 		})
 	})
 
@@ -575,6 +583,102 @@ var _ = Describe("Wiring Integration Tests — #823", func() {
 
 			Expect(resp.StatusCode).To(Equal(http.StatusNotFound),
 				"stream on terminal session must return 404 per ErrSessionTerminal mapping")
+		})
+	})
+
+	// ---------------------------------------------------------------
+	// IT-WIRE-16: Concurrent sessions with independent SSE streams
+	// ---------------------------------------------------------------
+	Describe("IT-WIRE-16: Concurrent sessions each deliver independent SSE streams", func() {
+		It("3 parallel investigations each stream events to their own SSE client", func() {
+			h := newTestHarness(withRateLimit(kaserver.RateLimitConfig{
+				RequestsPerSecond: 100,
+				Burst:             100,
+				CleanupInterval:   time.Hour,
+				MaxAge:            time.Hour,
+			}))
+			defer h.Close()
+
+			const numSessions = 3
+			proceeds := make([]chan struct{}, numSessions)
+			ids := make([]string, numSessions)
+
+			for i := 0; i < numSessions; i++ {
+				proceeds[i] = make(chan struct{})
+				idx := i
+				ids[i] = startInvestigationWithFunc(h, func(ctx context.Context) (interface{}, error) {
+					<-proceeds[idx]
+					sink := session.EventSinkFromContext(ctx)
+					if sink != nil {
+						sink <- session.InvestigationEvent{
+							Type:  session.EventTypeReasoningDelta,
+							Turn:  idx,
+							Phase: fmt.Sprintf("session-%d", idx),
+						}
+					}
+					return map[string]string{"rca_summary": fmt.Sprintf("result-%d", idx)}, nil
+				})
+			}
+
+			for _, id := range ids {
+				waitForStatus(h, id, session.StatusRunning)
+			}
+
+			type sseResult struct {
+				body string
+				err  error
+			}
+			results := make([]chan sseResult, numSessions)
+			var wg sync.WaitGroup
+
+			for i := 0; i < numSessions; i++ {
+				results[i] = make(chan sseResult, 1)
+				wg.Add(1)
+				go func(idx int) {
+					defer wg.Done()
+					resp, err := http.Get(h.Server.URL + "/api/v1/incident/session/" + ids[idx] + "/stream")
+					if err != nil {
+						results[idx] <- sseResult{"", err}
+						return
+					}
+					defer resp.Body.Close()
+					data, readErr := io.ReadAll(resp.Body)
+					results[idx] <- sseResult{string(data), readErr}
+				}(i)
+			}
+
+			Eventually(func() int {
+				return len(h.AuditStore.EventsOfType(audit.EventTypeSessionObserved))
+			}, 5*time.Second).Should(BeNumerically(">=", numSessions),
+				"all SSE clients must connect before investigations proceed")
+
+			for _, p := range proceeds {
+				close(p)
+			}
+
+			for i := 0; i < numSessions; i++ {
+				var res sseResult
+				Eventually(func() bool {
+					select {
+					case res = <-results[i]:
+						return true
+					default:
+						return false
+					}
+				}, 10*time.Second).Should(BeTrue(),
+					fmt.Sprintf("SSE stream for session %d should complete", i))
+
+				Expect(res.err).NotTo(HaveOccurred(),
+					fmt.Sprintf("SSE stream %d should not error", i))
+				Expect(res.body).To(ContainSubstring("event: reasoning_delta"),
+					fmt.Sprintf("session %d must receive reasoning_delta event", i))
+				Expect(res.body).To(ContainSubstring(fmt.Sprintf("session-%d", i)),
+					fmt.Sprintf("session %d must receive its own phase identifier", i))
+				Expect(res.body).To(ContainSubstring("event: complete"),
+					fmt.Sprintf("session %d must receive complete event", i))
+			}
+
+			wg.Wait()
 		})
 	})
 })

--- a/test/unit/kubernautagent/config/config_test.go
+++ b/test/unit/kubernautagent/config/config_test.go
@@ -570,5 +570,70 @@ llm:
 			Expect(cfg.Validate()).NotTo(HaveOccurred())
 		})
 	})
+
+	Describe("UT-KA-823-CFG-001: DefaultConfig includes rate limit defaults", func() {
+		It("should set rate limit defaults matching production values", func() {
+			cfg := config.DefaultConfig()
+			Expect(cfg.Server.RateLimit.RequestsPerSecond).To(Equal(5.0))
+			Expect(cfg.Server.RateLimit.Burst).To(Equal(10))
+			Expect(cfg.Server.RateLimit.CleanupInterval).To(Equal(5 * time.Minute))
+			Expect(cfg.Server.RateLimit.MaxAge).To(Equal(10 * time.Minute))
+		})
+	})
+
+	Describe("UT-KA-823-CFG-002: Validate rejects invalid rate limit values", func() {
+		It("should reject zero requests_per_second", func() {
+			yaml := []byte(`
+llm:
+  provider: "openai"
+  model: "gpt-4o"
+server:
+  rate_limit:
+    requests_per_second: 0
+    burst: 10
+`)
+			cfg, err := config.Load(yaml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.Validate()).To(MatchError(ContainSubstring("server.rate_limit.requests_per_second must be positive")))
+		})
+
+		It("should reject zero burst", func() {
+			yaml := []byte(`
+llm:
+  provider: "openai"
+  model: "gpt-4o"
+server:
+  rate_limit:
+    requests_per_second: 5
+    burst: 0
+`)
+			cfg, err := config.Load(yaml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.Validate()).To(MatchError(ContainSubstring("server.rate_limit.burst must be positive")))
+		})
+	})
+
+	Describe("UT-KA-823-CFG-003: Rate limit config parsed from YAML", func() {
+		It("should deserialize custom rate limit values", func() {
+			yaml := []byte(`
+llm:
+  provider: "openai"
+  model: "gpt-4o"
+server:
+  rate_limit:
+    requests_per_second: 20
+    burst: 50
+    cleanup_interval: 10m
+    max_age: 30m
+`)
+			cfg, err := config.Load(yaml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.Server.RateLimit.RequestsPerSecond).To(Equal(20.0))
+			Expect(cfg.Server.RateLimit.Burst).To(Equal(50))
+			Expect(cfg.Server.RateLimit.CleanupInterval).To(Equal(10 * time.Minute))
+			Expect(cfg.Server.RateLimit.MaxAge).To(Equal(30 * time.Minute))
+			Expect(cfg.Validate()).NotTo(HaveOccurred())
+		})
+	})
 })
 

--- a/test/unit/kubernautagent/server/ratelimit_test.go
+++ b/test/unit/kubernautagent/server/ratelimit_test.go
@@ -120,6 +120,39 @@ var _ = Describe("Rate Limiter — #823 Hardening", func() {
 		})
 	})
 
+	Describe("UT-KA-823-RL05: 429 response includes Retry-After header", func() {
+		It("sets Retry-After: 1 on rate-limited responses", func() {
+			cfg := kaserver.RateLimitConfig{
+				RequestsPerSecond: 1,
+				Burst:             1,
+				CleanupInterval:   time.Hour,
+				MaxAge:            time.Hour,
+			}
+			rl := kaserver.NewRateLimiter(cfg, nil)
+			defer rl.Stop()
+
+			handler := rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(http.StatusOK)
+			}))
+
+			req1 := httptest.NewRequest("GET", "/", nil)
+			req1.RemoteAddr = "10.0.0.50:12345"
+			rec1 := httptest.NewRecorder()
+			handler.ServeHTTP(rec1, req1)
+			Expect(rec1.Code).To(Equal(http.StatusOK))
+			Expect(rec1.Header().Get("Retry-After")).To(BeEmpty(),
+				"successful requests must not have Retry-After")
+
+			req2 := httptest.NewRequest("GET", "/", nil)
+			req2.RemoteAddr = "10.0.0.50:12345"
+			rec2 := httptest.NewRecorder()
+			handler.ServeHTTP(rec2, req2)
+			Expect(rec2.Code).To(Equal(http.StatusTooManyRequests))
+			Expect(rec2.Header().Get("Retry-After")).To(Equal("1"),
+				"429 responses must include Retry-After header (RFC 6585)")
+		})
+	})
+
 	Describe("UT-KA-823-RL04: X-Forwarded-For is used for IP extraction", func() {
 		It("limits based on X-Forwarded-For when present", func() {
 			cfg := kaserver.RateLimitConfig{


### PR DESCRIPTION
## Summary

- Remove stale "PR2: stub" / "PR4: Full SSE" references from OpenAPI stream endpoint description; regenerate ogen client (comment-only diff)
- Add `Retry-After: 1` header on 429 rate-limited responses per RFC 6585
- Wire rate limit parameters (`requests_per_second`, `burst`, `cleanup_interval`, `max_age`) to YAML config with validation, replacing hardcoded defaults in main.go
- Add IT-WIRE-16 integration test proving 3 concurrent sessions each deliver independent SSE streams without cross-session interference

## Test Evidence

| Suite | Result |
|-------|--------|
| Unit (server) | 82/82 pass |
| Unit (config) | 61/61 pass |
| Integration (wiring) | 24/24 pass |
| `go build ./...` | clean |
| `go vet ./...` | clean |

## New Tests

| ID | Type | Description |
|----|------|-------------|
| UT-KA-823-RL05 | Unit | Asserts `Retry-After: 1` on 429, absent on 200 |
| UT-KA-823-CFG-001 | Unit | DefaultConfig includes rate limit production defaults |
| UT-KA-823-CFG-002 | Unit | Validate rejects zero requests_per_second / burst |
| UT-KA-823-CFG-003 | Unit | Custom rate limit values parsed from YAML |
| IT-WIRE-02 (extended) | Integration | Now also asserts Retry-After header |
| IT-WIRE-16 | Integration | 3 parallel sessions with independent SSE streams |

## Motivation

Pre-QE hardening pass to close gaps identified in adversarial review:
1. Stale OpenAPI docs would confuse QE reading the spec
2. Missing Retry-After header is a standards compliance gap (RFC 6585)
3. Hardcoded rate limits prevent deployment-time tuning
4. No prior test for concurrent session isolation under load

## Test plan

- [x] All existing tests pass (zero regressions)
- [x] New unit tests follow RED-GREEN-REFACTOR
- [x] Build clean, vet clean, pre-commit hooks pass
- [ ] CI pipeline green (awaiting)

Ref: #823

Made with [Cursor](https://cursor.com)