### PR TITLE
feat(ro): config hot-reload via FileWatcher (#835) [backport v1.4]

### DIFF
--- a/cmd/remediationorchestrator/main.go
+++ b/cmd/remediationorchestrator/main.go
@@ -43,6 +43,7 @@ import (
 	workflowexecutionv1 "github.com/jordigilh/kubernaut/api/workflowexecution/v1alpha1"
 	"github.com/jordigilh/kubernaut/internal/version"
 	clusterid "github.com/jordigilh/kubernaut/pkg/shared/cluster"
+	"github.com/jordigilh/kubernaut/pkg/shared/hotreload"
 	scope "github.com/jordigilh/kubernaut/pkg/shared/scope"
 	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
 	config "github.com/jordigilh/kubernaut/internal/config/remediationorchestrator"
@@ -355,6 +356,24 @@ func main() {
 		setupLog.Info("Dry-run mode enabled: pipeline stops after AI analysis",
 			"holdPeriod", cfg.DryRunHoldPeriod)
 	}
+
+	// #835, DD-INFRA-001: Start config file watcher for hot-reload.
+	// Only enabled when a config file is explicitly provided (not defaults).
+	if configPath != "" {
+		reloadCallback := controller.NewReloadCallback(roReconciler, setupLog)
+		configWatcher, watchErr := hotreload.NewFileWatcher(configPath, reloadCallback, setupLog)
+		if watchErr != nil {
+			setupLog.Error(watchErr, "Failed to create config file watcher, hot-reload disabled")
+		} else {
+			if startErr := configWatcher.Start(context.Background()); startErr != nil {
+				setupLog.Error(startErr, "Failed to start config file watcher, hot-reload disabled")
+			} else {
+				defer configWatcher.Stop()
+				setupLog.Info("Config hot-reload enabled (DD-INFRA-001)", "watchPath", configPath)
+			}
+		}
+	}
+
 	if err = roReconciler.SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RemediationOrchestrator")
 		os.Exit(1)

--- a/internal/controller/remediationorchestrator/reconciler.go
+++ b/internal/controller/remediationorchestrator/reconciler.go
@@ -32,6 +32,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync"
 	"time"
 
 
@@ -134,6 +135,10 @@ type Reconciler struct {
 	// Prevents duplicate WFEs when concurrent reconciles target the same resource.
 	// nil = locking disabled (single-replica deployments).
 	lockManager *locking.DistributedLockManager
+
+	// #835: Guards hot-reloadable config fields. Setters acquire write lock,
+	// getters acquire read lock. Per DD-INFRA-001 thread-safety requirement.
+	configMu sync.RWMutex
 
 	// #265: CRD retention TTL — how long terminal RRs persist before cleanup.
 	// Default: 24h. Configurable via SetRetentionPeriod or YAML config.
@@ -348,7 +353,7 @@ func NewReconciler(c client.Client, apiReader client.Reader, s *runtime.Scheme, 
 				return nil
 			})
 		},
-		IsDryRun:      func() bool { return r.dryRun },
+		IsDryRun:      r.isDryRun,
 		WFECallbacks:  wfeCallbacks,
 	}))
 	r.phaseRegistry.MustRegister(NewAwaitingApprovalHandler(c, m, AwaitingApprovalCallbacks{
@@ -461,10 +466,21 @@ func (r *Reconciler) SetWorkflowResolver(resolver routing.WorkflowDisplayResolve
 
 // SetRetentionPeriod configures how long terminal RemediationRequest CRDs persist
 // before automatic cleanup. Default: 24h. Issue #265.
+// Thread-safe: acquires configMu write lock (#835, DD-INFRA-001).
 func (r *Reconciler) SetRetentionPeriod(d time.Duration) {
 	if d > 0 {
+		r.configMu.Lock()
 		r.retentionPeriod = d
+		r.configMu.Unlock()
 	}
+}
+
+// getRetentionPeriod returns the current retention TTL for terminal RRs.
+// Thread-safe: acquires configMu read lock (#835).
+func (r *Reconciler) getRetentionPeriod() time.Duration {
+	r.configMu.RLock()
+	defer r.configMu.RUnlock()
+	return r.retentionPeriod
 }
 
 // SetDSClient wires the DataStorage history querier into the routing engine.
@@ -482,9 +498,28 @@ func (r *Reconciler) SetDSClient(dsClient routing.RemediationHistoryQuerier) {
 // When enabled, the pipeline stops after AI analysis without creating WFE or EA.
 // holdPeriod controls how long the Gateway suppresses re-triggering for the same fingerprint.
 // #712, #736: Called from cmd/remediationorchestrator/main.go.
+// Thread-safe: acquires configMu write lock (#835, DD-INFRA-001).
 func (r *Reconciler) SetDryRun(enabled bool, holdPeriod time.Duration) {
+	r.configMu.Lock()
 	r.dryRun = enabled
 	r.dryRunHoldPeriod = holdPeriod
+	r.configMu.Unlock()
+}
+
+// isDryRun returns whether dry-run mode is enabled.
+// Thread-safe: acquires configMu read lock (#835).
+func (r *Reconciler) isDryRun() bool {
+	r.configMu.RLock()
+	defer r.configMu.RUnlock()
+	return r.dryRun
+}
+
+// getDryRunHoldPeriod returns the current dry-run suppression window.
+// Thread-safe: acquires configMu read lock (#835).
+func (r *Reconciler) getDryRunHoldPeriod() time.Duration {
+	r.configMu.RLock()
+	defer r.configMu.RUnlock()
+	return r.dryRunHoldPeriod
 }
 
 // ========================================
@@ -795,9 +830,10 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		}
 
 		// Stamp expiry on first terminal reconcile (non-blocking — housekeeping continues)
-		retentionRequeue := r.retentionPeriod
+		retention := r.getRetentionPeriod()
+		retentionRequeue := retention
 		if rr.Status.RetentionExpiryTime == nil {
-			expiry := metav1.NewTime(time.Now().Add(r.retentionPeriod))
+			expiry := metav1.NewTime(time.Now().Add(retention))
 			if err := helpers.UpdateRemediationRequestStatus(ctx, r.client, rr, func(rr *remediationv1.RemediationRequest) error {
 				rr.Status.RetentionExpiryTime = &expiry
 				return nil
@@ -977,7 +1013,7 @@ func (r *Reconciler) transitionToCompletedWithoutVerification(ctx context.Contex
 		rr.Status.ObservedGeneration = rr.Generation
 
 		// Set NextAllowedExecution for GW suppression, only if later than existing value
-		dryRunNAE := metav1.NewTime(now.Add(r.dryRunHoldPeriod))
+		dryRunNAE := metav1.NewTime(now.Add(r.getDryRunHoldPeriod()))
 		if rr.Status.NextAllowedExecution == nil || dryRunNAE.After(rr.Status.NextAllowedExecution.Time) {
 			rr.Status.NextAllowedExecution = &dryRunNAE
 		}
@@ -1766,7 +1802,8 @@ func (r *Reconciler) createEffectivenessAssessmentIfNeeded(ctx context.Context, 
 		isCRD = true
 	}
 
-	propagationDelay := r.asyncPropagation.ComputePropagationDelay(isGitOpsManaged, isCRD)
+	asyncCfg := r.getAsyncPropagation()
+	propagationDelay := asyncCfg.ComputePropagationDelay(isGitOpsManaged, isCRD)
 	if propagationDelay > 0 {
 		hashComputeDelay = &metav1.Duration{Duration: propagationDelay}
 		logger.Info("Async-managed target detected, setting hash check delay",
@@ -1780,11 +1817,11 @@ func (r *Reconciler) createEffectivenessAssessmentIfNeeded(ctx context.Context, 
 	// Proactive alerts (e.g. predict_linear) need extra time to resolve.
 	var alertCheckDelay *metav1.Duration
 	if ai != nil && ai.Spec.AnalysisRequest.SignalContext.SignalMode == "proactive" {
-		if r.asyncPropagation.ProactiveAlertDelay > 0 {
-			alertCheckDelay = &metav1.Duration{Duration: r.asyncPropagation.ProactiveAlertDelay}
+		if asyncCfg.ProactiveAlertDelay > 0 {
+			alertCheckDelay = &metav1.Duration{Duration: asyncCfg.ProactiveAlertDelay}
 			logger.Info("Proactive signal detected, setting alert check delay",
 				"signalMode", ai.Spec.AnalysisRequest.SignalContext.SignalMode,
-				"alertCheckDelay", r.asyncPropagation.ProactiveAlertDelay)
+				"alertCheckDelay", asyncCfg.ProactiveAlertDelay)
 		}
 	}
 
@@ -1955,11 +1992,12 @@ func (r *Reconciler) emitEACreatedAudit(ctx context.Context, rr *remediationv1.R
 	if alertCheckDelay != nil {
 		data.AlertCheckDelay = alertCheckDelay.Duration
 	}
+	auditAsyncCfg := r.getAsyncPropagation()
 	if isGitOpsManaged {
-		data.GitOpsSyncDelay = r.asyncPropagation.GitOpsSyncDelay
+		data.GitOpsSyncDelay = auditAsyncCfg.GitOpsSyncDelay
 	}
 	if isCRD {
-		data.OperatorReconcileDelay = r.asyncPropagation.OperatorReconcileDelay
+		data.OperatorReconcileDelay = auditAsyncCfg.OperatorReconcileDelay
 	}
 
 	event, err := r.auditManager.BuildEACreatedEvent(rr.Name, rr.Namespace, rr.Name, data)
@@ -3009,8 +3047,39 @@ func (r *Reconciler) SetRESTMapper(mapper meta.RESTMapper) {
 
 // SetAsyncPropagation configures propagation delays for async-managed targets.
 // DD-EM-004 v2.0, Issue #253: Called from cmd/remediationorchestrator/main.go.
+// Thread-safe: acquires configMu write lock (#835, DD-INFRA-001).
 func (r *Reconciler) SetAsyncPropagation(cfg roconfig.AsyncPropagationConfig) {
+	r.configMu.Lock()
 	r.asyncPropagation = cfg
+	r.configMu.Unlock()
+}
+
+// getAsyncPropagation returns the current async propagation config.
+// Thread-safe: acquires configMu read lock (#835).
+func (r *Reconciler) getAsyncPropagation() roconfig.AsyncPropagationConfig {
+	r.configMu.RLock()
+	defer r.configMu.RUnlock()
+	return r.asyncPropagation
+}
+
+// IsDryRunExported exposes isDryRun for unit testing hot-reload thread safety (#835).
+func (r *Reconciler) IsDryRunExported() bool {
+	return r.isDryRun()
+}
+
+// GetDryRunHoldPeriodExported exposes getDryRunHoldPeriod for unit testing (#835).
+func (r *Reconciler) GetDryRunHoldPeriodExported() time.Duration {
+	return r.getDryRunHoldPeriod()
+}
+
+// GetRetentionPeriodExported exposes getRetentionPeriod for unit testing (#835).
+func (r *Reconciler) GetRetentionPeriodExported() time.Duration {
+	return r.getRetentionPeriod()
+}
+
+// GetAsyncPropagationExported exposes getAsyncPropagation for unit testing (#835).
+func (r *Reconciler) GetAsyncPropagationExported() roconfig.AsyncPropagationConfig {
+	return r.getAsyncPropagation()
 }
 
 // SetNotifySelfResolved enables or disables the self-resolved status-update notification.

--- a/internal/controller/remediationorchestrator/reload_callback.go
+++ b/internal/controller/remediationorchestrator/reload_callback.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"gopkg.in/yaml.v3"
+
+	roconfig "github.com/jordigilh/kubernaut/internal/config/remediationorchestrator"
+	"github.com/jordigilh/kubernaut/pkg/shared/hotreload"
+)
+
+// NewReloadCallback creates a hotreload.ReloadCallback that applies validated
+// configuration changes to the reconciler's hot-reloadable fields.
+//
+// Per DD-INFRA-001: Graceful degradation — returns error on invalid config
+// (watcher keeps previous), logs before/after for audit trail.
+//
+// Hot-reloadable fields (#835):
+//   - dryRun, dryRunHoldPeriod (#712, #736)
+//   - retentionPeriod (#265)
+//   - asyncPropagation (#253, DD-EM-004)
+func NewReloadCallback(reconciler *Reconciler, logger logr.Logger) hotreload.ReloadCallback {
+	return func(newContent string) error {
+		cfg := roconfig.DefaultConfig()
+
+		if err := yaml.Unmarshal([]byte(newContent), cfg); err != nil {
+			return fmt.Errorf("failed to parse config YAML: %w", err)
+		}
+
+		if err := cfg.Validate(); err != nil {
+			return fmt.Errorf("invalid configuration: %w", err)
+		}
+
+		prevDryRun := reconciler.IsDryRunExported()
+		prevHoldPeriod := reconciler.GetDryRunHoldPeriodExported()
+		prevRetention := reconciler.GetRetentionPeriodExported()
+		prevAsync := reconciler.GetAsyncPropagationExported()
+
+		reconciler.SetDryRun(cfg.DryRun, cfg.DryRunHoldPeriod)
+		reconciler.SetRetentionPeriod(cfg.Retention.Period)
+		reconciler.SetAsyncPropagation(cfg.AsyncPropagation)
+
+		logger.Info("Configuration hot-reloaded successfully",
+			"dryRun", fmt.Sprintf("%v → %v", prevDryRun, cfg.DryRun),
+			"dryRunHoldPeriod", fmt.Sprintf("%v → %v", prevHoldPeriod, cfg.DryRunHoldPeriod),
+			"retentionPeriod", fmt.Sprintf("%v → %v", prevRetention, cfg.Retention.Period),
+			"asyncPropagation.gitOpsSyncDelay", fmt.Sprintf("%v → %v", prevAsync.GitOpsSyncDelay, cfg.AsyncPropagation.GitOpsSyncDelay),
+			"asyncPropagation.operatorReconcileDelay", fmt.Sprintf("%v → %v", prevAsync.OperatorReconcileDelay, cfg.AsyncPropagation.OperatorReconcileDelay),
+			"asyncPropagation.proactiveAlertDelay", fmt.Sprintf("%v → %v", prevAsync.ProactiveAlertDelay, cfg.AsyncPropagation.ProactiveAlertDelay),
+		)
+
+		return nil
+	}
+}

--- a/test/integration/shared/hotreload/ro_hotreload_integration_test.go
+++ b/test/integration/shared/hotreload/ro_hotreload_integration_test.go
@@ -1,0 +1,296 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hotreload
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
+	controller "github.com/jordigilh/kubernaut/internal/controller/remediationorchestrator"
+	rometrics "github.com/jordigilh/kubernaut/pkg/remediationorchestrator/metrics"
+	"github.com/jordigilh/kubernaut/pkg/shared/hotreload"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+)
+
+func setupScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = clientgoscheme.AddToScheme(s)
+	_ = remediationv1.AddToScheme(s)
+	return s
+}
+
+var _ = Describe("RO Config Hot-Reload via FileWatcher (IT-RO-835)", func() {
+	var (
+		reconciler *controller.Reconciler
+		tmpDir     string
+		configPath string
+	)
+
+	BeforeEach(func() {
+		scheme := setupScheme()
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		reconciler = controller.NewReconciler(
+			fakeClient,
+			fakeClient,
+			scheme,
+			nil,
+			nil,
+			rometrics.NewMetricsWithRegistry(prometheus.NewRegistry()),
+			controller.TimeoutConfig{
+				Global:           1 * time.Hour,
+				Processing:       5 * time.Minute,
+				Analyzing:        10 * time.Minute,
+				Executing:        30 * time.Minute,
+				AwaitingApproval: 15 * time.Minute,
+				Verifying:        30 * time.Minute,
+			},
+			nil, // routing engine (not needed for config reload)
+			nil, // eaCreator
+		)
+		reconciler.SetRetentionPeriod(24 * time.Hour)
+		reconciler.SetDryRun(false, 1*time.Hour)
+
+		var err error
+		tmpDir, err = os.MkdirTemp("", "ro-hotreload-*")
+		Expect(err).NotTo(HaveOccurred())
+
+		configPath = filepath.Join(tmpDir, "config.yaml")
+	})
+
+	AfterEach(func() {
+		os.RemoveAll(tmpDir)
+	})
+
+	It("IT-RO-835-01: file modification triggers config update via FileWatcher", func() {
+		initialConfig := `
+controller:
+  metricsAddr: ":9090"
+  healthProbeAddr: ":8081"
+timeouts:
+  global: 1h
+  processing: 5m
+  analyzing: 10m
+  executing: 30m
+  awaitingApproval: 15m
+  verifying: 30m
+effectivenessAssessment:
+  stabilizationWindow: 5m
+asyncPropagation:
+  gitOpsSyncDelay: 3m
+  operatorReconcileDelay: 1m
+  proactiveAlertDelay: 5m
+retention:
+  period: 24h
+dryRun: false
+routing:
+  consecutiveFailureThreshold: 3
+  consecutiveFailureCooldown: 1h
+  recentlyRemediatedCooldown: 5m
+  exponentialBackoffBase: 1m
+  exponentialBackoffMax: 10m
+  exponentialBackoffMaxExponent: 4
+  scopeBackoffBase: 5s
+  scopeBackoffMax: 5m
+  ineffectiveChainThreshold: 3
+  recurrenceCountThreshold: 5
+  ineffectiveTimeWindow: 4h
+datastorage:
+  url: "http://localhost:8080"
+  timeout: 30s
+  buffer:
+    bufferSize: 1000
+    batchSize: 100
+    flushInterval: 5s
+    maxRetries: 3
+`
+		err := os.WriteFile(configPath, []byte(initialConfig), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		callback := controller.NewReloadCallback(reconciler, ctrl.Log.WithName("test"))
+		watcher, err := hotreload.NewFileWatcher(configPath, callback, ctrl.Log.WithName("test"))
+		Expect(err).NotTo(HaveOccurred())
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		err = watcher.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		defer watcher.Stop()
+
+		Expect(reconciler.IsDryRunExported()).To(BeFalse())
+		Expect(reconciler.GetRetentionPeriodExported()).To(Equal(24 * time.Hour))
+
+		updatedConfig := `
+controller:
+  metricsAddr: ":9090"
+  healthProbeAddr: ":8081"
+timeouts:
+  global: 1h
+  processing: 5m
+  analyzing: 10m
+  executing: 30m
+  awaitingApproval: 15m
+  verifying: 30m
+effectivenessAssessment:
+  stabilizationWindow: 5m
+asyncPropagation:
+  gitOpsSyncDelay: 7m
+  operatorReconcileDelay: 3m
+  proactiveAlertDelay: 10m
+retention:
+  period: 72h
+dryRun: true
+dryRunHoldPeriod: 4h
+routing:
+  consecutiveFailureThreshold: 3
+  consecutiveFailureCooldown: 1h
+  recentlyRemediatedCooldown: 5m
+  exponentialBackoffBase: 1m
+  exponentialBackoffMax: 10m
+  exponentialBackoffMaxExponent: 4
+  scopeBackoffBase: 5s
+  scopeBackoffMax: 5m
+  ineffectiveChainThreshold: 3
+  recurrenceCountThreshold: 5
+  ineffectiveTimeWindow: 4h
+datastorage:
+  url: "http://localhost:8080"
+  timeout: 30s
+  buffer:
+    bufferSize: 1000
+    batchSize: 100
+    flushInterval: 5s
+    maxRetries: 3
+`
+		err = os.WriteFile(configPath, []byte(updatedConfig), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(func() bool {
+			return reconciler.IsDryRunExported()
+		}, 3*time.Second, 100*time.Millisecond).Should(BeTrue(),
+			"dryRun should be enabled after config file modification")
+
+		Eventually(func() time.Duration {
+			return reconciler.GetRetentionPeriodExported()
+		}, 3*time.Second, 100*time.Millisecond).Should(Equal(72 * time.Hour),
+			"retentionPeriod should update to 72h")
+
+		Eventually(func() time.Duration {
+			return reconciler.GetDryRunHoldPeriodExported()
+		}, 3*time.Second, 100*time.Millisecond).Should(Equal(4 * time.Hour),
+			"dryRunHoldPeriod should update to 4h")
+
+		asyncCfg := reconciler.GetAsyncPropagationExported()
+		Expect(asyncCfg.GitOpsSyncDelay).To(Equal(7 * time.Minute))
+		Expect(asyncCfg.OperatorReconcileDelay).To(Equal(3 * time.Minute))
+		Expect(asyncCfg.ProactiveAlertDelay).To(Equal(10 * time.Minute))
+	})
+
+	It("IT-RO-835-02: invalid config file modification is rejected (graceful degradation)", func() {
+		validConfig := `
+controller:
+  metricsAddr: ":9090"
+  healthProbeAddr: ":8081"
+timeouts:
+  global: 1h
+  processing: 5m
+  analyzing: 10m
+  executing: 30m
+  awaitingApproval: 15m
+  verifying: 30m
+effectivenessAssessment:
+  stabilizationWindow: 5m
+asyncPropagation:
+  gitOpsSyncDelay: 3m
+  operatorReconcileDelay: 1m
+  proactiveAlertDelay: 5m
+retention:
+  period: 24h
+routing:
+  consecutiveFailureThreshold: 3
+  consecutiveFailureCooldown: 1h
+  recentlyRemediatedCooldown: 5m
+  exponentialBackoffBase: 1m
+  exponentialBackoffMax: 10m
+  exponentialBackoffMaxExponent: 4
+  scopeBackoffBase: 5s
+  scopeBackoffMax: 5m
+  ineffectiveChainThreshold: 3
+  recurrenceCountThreshold: 5
+  ineffectiveTimeWindow: 4h
+datastorage:
+  url: "http://localhost:8080"
+  timeout: 30s
+  buffer:
+    bufferSize: 1000
+    batchSize: 100
+    flushInterval: 5s
+    maxRetries: 3
+`
+		err := os.WriteFile(configPath, []byte(validConfig), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		callback := controller.NewReloadCallback(reconciler, ctrl.Log.WithName("test"))
+		watcher, err := hotreload.NewFileWatcher(configPath, callback, ctrl.Log.WithName("test"))
+		Expect(err).NotTo(HaveOccurred())
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		err = watcher.Start(ctx)
+		Expect(err).NotTo(HaveOccurred())
+		defer watcher.Stop()
+
+		Expect(reconciler.GetRetentionPeriodExported()).To(Equal(24 * time.Hour))
+
+		invalidConfig := `
+controller:
+  metricsAddr: ":9090"
+  healthProbeAddr: ":8081"
+timeouts:
+  global: 0s
+  processing: 5m
+  analyzing: 10m
+  executing: 30m
+  awaitingApproval: 15m
+  verifying: 30m
+retention:
+  period: 1h
+`
+		err = os.WriteFile(configPath, []byte(invalidConfig), 0644)
+		Expect(err).NotTo(HaveOccurred())
+
+		// ✅ APPROVED EXCEPTION: intentional wait for fsnotify debounce (200ms) + processing
+		time.Sleep(500 * time.Millisecond)
+
+		Expect(reconciler.GetRetentionPeriodExported()).To(Equal(24 * time.Hour),
+			"retention should remain unchanged after invalid config rejected")
+
+		Expect(watcher.GetErrorCount()).To(BeNumerically(">=", int64(1)),
+			"watcher should record at least one error for rejected config")
+	})
+})

--- a/test/integration/shared/hotreload/suite_test.go
+++ b/test/integration/shared/hotreload/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package hotreload
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestHotReloadIntegration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "RO Config Hot-Reload Integration Suite (#835, DD-INFRA-001)")
+}

--- a/test/unit/remediationorchestrator/controller/hotreload_test.go
+++ b/test/unit/remediationorchestrator/controller/hotreload_test.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	roconfig "github.com/jordigilh/kubernaut/internal/config/remediationorchestrator"
+	controller "github.com/jordigilh/kubernaut/internal/controller/remediationorchestrator"
+	rometrics "github.com/jordigilh/kubernaut/pkg/remediationorchestrator/metrics"
+)
+
+var _ = Describe("RO Config Hot-Reload (#835, DD-INFRA-001)", func() {
+
+	var reconciler *controller.Reconciler
+
+	BeforeEach(func() {
+		scheme := setupScheme()
+		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+		reconciler = controller.NewReconciler(
+			fakeClient,
+			fakeClient,
+			scheme,
+			nil, // audit store
+			nil, // recorder
+			rometrics.NewMetricsWithRegistry(prometheus.NewRegistry()),
+			controller.TimeoutConfig{
+				Global:           1 * time.Hour,
+				Processing:       5 * time.Minute,
+				Analyzing:        10 * time.Minute,
+				Executing:        30 * time.Minute,
+				AwaitingApproval: 15 * time.Minute,
+				Verifying:        30 * time.Minute,
+			},
+			&MockRoutingEngine{},
+			nil, // eaCreator
+		)
+	})
+
+	Context("Thread-safety (UT-RO-835-TS)", func() {
+		// BR-ORCH-835: Concurrent reads and writes to hot-reloadable config fields
+		// must not race. Validates sync.RWMutex protection per DD-INFRA-001.
+
+		It("UT-RO-835-TS01: concurrent SetDryRun and isDryRun do not race", func() {
+			reconciler.SetDryRun(false, 1*time.Hour)
+
+			var wg sync.WaitGroup
+			const goroutines = 50
+
+			for i := 0; i < goroutines; i++ {
+				wg.Add(2)
+				go func() {
+					defer wg.Done()
+					reconciler.SetDryRun(true, 2*time.Hour)
+				}()
+				go func() {
+					defer wg.Done()
+					_ = reconciler.IsDryRunExported()
+				}()
+			}
+
+			wg.Wait()
+		})
+
+		It("UT-RO-835-TS02: concurrent SetRetentionPeriod and getRetentionPeriod do not race", func() {
+			reconciler.SetRetentionPeriod(24 * time.Hour)
+
+			var wg sync.WaitGroup
+			const goroutines = 50
+
+			for i := 0; i < goroutines; i++ {
+				wg.Add(2)
+				go func() {
+					defer wg.Done()
+					reconciler.SetRetentionPeriod(48 * time.Hour)
+				}()
+				go func() {
+					defer wg.Done()
+					_ = reconciler.GetRetentionPeriodExported()
+				}()
+			}
+
+			wg.Wait()
+		})
+
+		It("UT-RO-835-TS03: concurrent SetAsyncPropagation and getAsyncPropagation do not race", func() {
+			reconciler.SetAsyncPropagation(roconfig.AsyncPropagationConfig{
+				GitOpsSyncDelay: 3 * time.Minute,
+			})
+
+			var wg sync.WaitGroup
+			const goroutines = 50
+
+			for i := 0; i < goroutines; i++ {
+				wg.Add(2)
+				go func() {
+					defer wg.Done()
+					reconciler.SetAsyncPropagation(roconfig.AsyncPropagationConfig{
+						GitOpsSyncDelay:        5 * time.Minute,
+						OperatorReconcileDelay: 2 * time.Minute,
+					})
+				}()
+				go func() {
+					defer wg.Done()
+					_ = reconciler.GetAsyncPropagationExported()
+				}()
+			}
+
+			wg.Wait()
+		})
+	})
+
+	Context("ReloadCallback validation (UT-RO-835-CB)", func() {
+		// BR-ORCH-835: ReloadCallback must reject invalid config (graceful degradation)
+		// and apply valid config atomically.
+
+		It("UT-RO-835-CB01: rejects invalid YAML and preserves previous config", func() {
+			reconciler.SetDryRun(true, 2*time.Hour)
+			reconciler.SetRetentionPeriod(48 * time.Hour)
+			reconciler.SetAsyncPropagation(roconfig.AsyncPropagationConfig{
+				GitOpsSyncDelay: 5 * time.Minute,
+			})
+
+			callback := controller.NewReloadCallback(reconciler, ctrl.Log.WithName("test"))
+
+			err := callback("this is not valid YAML: [[[")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("parse"))
+
+			Expect(reconciler.IsDryRunExported()).To(BeTrue())
+			Expect(reconciler.GetRetentionPeriodExported()).To(Equal(48 * time.Hour))
+			Expect(reconciler.GetAsyncPropagationExported().GitOpsSyncDelay).To(Equal(5 * time.Minute))
+		})
+
+		It("UT-RO-835-CB02: rejects config that fails Validate() and preserves previous", func() {
+			reconciler.SetRetentionPeriod(24 * time.Hour)
+
+			callback := controller.NewReloadCallback(reconciler, ctrl.Log.WithName("test"))
+
+			invalidYAML := `
+timeouts:
+  global: 0s
+  processing: 5m
+  analyzing: 10m
+  executing: 30m
+  awaitingApproval: 15m
+  verifying: 30m
+`
+			err := callback(invalidYAML)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid configuration"))
+
+			Expect(reconciler.GetRetentionPeriodExported()).To(Equal(24 * time.Hour))
+		})
+
+		It("UT-RO-835-CB03: applies valid config and updates all hot-reloadable fields", func() {
+			reconciler.SetDryRun(false, 1*time.Hour)
+			reconciler.SetRetentionPeriod(24 * time.Hour)
+			reconciler.SetAsyncPropagation(roconfig.AsyncPropagationConfig{
+				GitOpsSyncDelay:        3 * time.Minute,
+				OperatorReconcileDelay: 1 * time.Minute,
+				ProactiveAlertDelay:    5 * time.Minute,
+			})
+
+			callback := controller.NewReloadCallback(reconciler, ctrl.Log.WithName("test"))
+
+			validYAML := `
+controller:
+  metricsAddr: ":9090"
+  healthProbeAddr: ":8081"
+timeouts:
+  global: 1h
+  processing: 5m
+  analyzing: 10m
+  executing: 30m
+  awaitingApproval: 15m
+  verifying: 30m
+effectivenessAssessment:
+  stabilizationWindow: 5m
+asyncPropagation:
+  gitOpsSyncDelay: 7m
+  operatorReconcileDelay: 3m
+  proactiveAlertDelay: 10m
+retention:
+  period: 72h
+dryRun: true
+dryRunHoldPeriod: 4h
+routing:
+  consecutiveFailureThreshold: 3
+  consecutiveFailureCooldown: 1h
+  recentlyRemediatedCooldown: 5m
+  exponentialBackoffBase: 1m
+  exponentialBackoffMax: 10m
+  exponentialBackoffMaxExponent: 4
+  scopeBackoffBase: 5s
+  scopeBackoffMax: 5m
+  ineffectiveChainThreshold: 3
+  recurrenceCountThreshold: 5
+  ineffectiveTimeWindow: 4h
+datastorage:
+  url: "http://localhost:8080"
+  timeout: 30s
+  buffer:
+    bufferSize: 1000
+    batchSize: 100
+    flushInterval: 5s
+    maxRetries: 3
+`
+			err := callback(validYAML)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(reconciler.IsDryRunExported()).To(BeTrue())
+			Expect(reconciler.GetDryRunHoldPeriodExported()).To(Equal(4 * time.Hour))
+			Expect(reconciler.GetRetentionPeriodExported()).To(Equal(72 * time.Hour))
+			asyncCfg := reconciler.GetAsyncPropagationExported()
+			Expect(asyncCfg.GitOpsSyncDelay).To(Equal(7 * time.Minute))
+			Expect(asyncCfg.OperatorReconcileDelay).To(Equal(3 * time.Minute))
+			Expect(asyncCfg.ProactiveAlertDelay).To(Equal(10 * time.Minute))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Cherry-pick of #887 (`development/v1.5` → `main`) for v1.4.0-rc inclusion.

- Add `sync.RWMutex` to protect hot-reloadable config fields (`dryRun`, `dryRunHoldPeriod`, `retentionPeriod`, `asyncPropagation`) with thread-safe getters/setters
- Implement `NewReloadCallback` that parses YAML, validates, logs before/after values, and atomically updates the reconciler (graceful degradation on invalid config per DD-INFRA-001)
- Wire `hotreload.FileWatcher` in `cmd/remediationorchestrator/main.go` — starts when `--config` is provided, gracefully degrades on failure

## Test plan

- [x] 6 unit tests (UT-RO-835-TS01..03, CB01..03) — thread-safety with `-race`, callback validation
- [x] 2 integration tests (IT-RO-835-01..02) — file modification triggers update, invalid config rejected
- [x] All existing RO tests pass with `-race`
- [x] `go build ./...` clean on `main`
- [x] Clean cherry-pick (no conflicts)

## Cross-references

- Closes #835
- Forward port: #887 (development/v1.5)
- Operator dependency: jordigilh/kubernaut-operator#24 (v1.4 milestone)
- Authority: DD-INFRA-001 (ConfigMap Hot-Reload Pattern)


Made with [Cursor](https://cursor.com)