### PR TITLE
feat(703): add InteractiveSessionInfo to AIAnalysis CRD status

### DIFF
--- a/api/aianalysis/v1alpha1/aianalysis_types.go
+++ b/api/aianalysis/v1alpha1/aianalysis_types.go
@@ -442,6 +442,16 @@ type AIAnalysisStatus struct {
 	InvestigationSession *InvestigationSession `json:"investigationSession,omitempty"`
 
 	// ========================================
+	// INTERACTIVE SESSION (DD-INTERACTIVE-002)
+	// Tracks the dynamic takeover session for MCP interactive mode (#703)
+	// ========================================
+	// InteractiveSession tracks who is currently driving the investigation.
+	// Populated when a user takes over via MCP; nil during autonomous mode.
+	// DD-INTERACTIVE-002: Every RR is takeover-capable; this is observability-only.
+	// +optional
+	InteractiveSession *InteractiveSessionInfo `json:"interactiveSession,omitempty"`
+
+	// ========================================
 	// POST-RCA CONTEXT (ADR-056)
 	// Runtime-computed cluster characteristics from HAPI
 	// ========================================
@@ -493,6 +503,27 @@ type InvestigationSession struct {
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	PollCount int32 `json:"pollCount,omitempty"`
+}
+
+// InteractiveSessionInfo tracks the dynamic takeover session for MCP interactive mode.
+// DD-INTERACTIVE-002: Observability-only status field showing who is driving the investigation.
+// BR-INTERACTIVE-007: Operators can see the current driver via kubectl.
+type InteractiveSessionInfo struct {
+	// SessionID is the KA-assigned interactive session identifier
+	// +optional
+	SessionID string `json:"sessionId,omitempty"`
+	// MCPSessionID is the go-sdk MCP session identifier
+	// +optional
+	MCPSessionID string `json:"mcpSessionId,omitempty"`
+	// ActingUser is the resolved identity currently driving the investigation
+	// +optional
+	ActingUser string `json:"actingUser,omitempty"`
+	// StartedAt is when the user took over
+	// +optional
+	StartedAt *metav1.Time `json:"startedAt,omitempty"`
+	// CompletedAt is when the user disconnected (KA resumed autonomous)
+	// +optional
+	CompletedAt *metav1.Time `json:"completedAt,omitempty"`
 }
 
 // RootCauseAnalysis contains detailed RCA results

--- a/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
@@ -634,6 +634,37 @@ spec:
                 - investigation_inconclusive
                 - rca_incomplete
                 type: string
+              interactiveSession:
+                description: |-
+                  ========================================
+                  INTERACTIVE SESSION (DD-INTERACTIVE-002)
+                  Tracks the dynamic takeover session for MCP interactive mode (#703)
+                  ========================================
+                  InteractiveSession tracks who is currently driving the investigation.
+                  Populated when a user takes over via MCP; nil during autonomous mode.
+                  DD-INTERACTIVE-002: Every RR is takeover-capable; this is observability-only.
+                properties:
+                  actingUser:
+                    description: ActingUser is the resolved identity currently driving
+                      the investigation
+                    type: string
+                  completedAt:
+                    description: CompletedAt is when the user disconnected (KA resumed
+                      autonomous)
+                    format: date-time
+                    type: string
+                  mcpSessionId:
+                    description: MCPSessionID is the go-sdk MCP session identifier
+                    type: string
+                  sessionId:
+                    description: SessionID is the KA-assigned interactive session
+                      identifier
+                    type: string
+                  startedAt:
+                    description: StartedAt is when the user took over
+                    format: date-time
+                    type: string
+                type: object
               investigationId:
                 description: |-
                   ========================================

--- a/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
@@ -634,6 +634,37 @@ spec:
                 - investigation_inconclusive
                 - rca_incomplete
                 type: string
+              interactiveSession:
+                description: |-
+                  ========================================
+                  INTERACTIVE SESSION (DD-INTERACTIVE-002)
+                  Tracks the dynamic takeover session for MCP interactive mode (#703)
+                  ========================================
+                  InteractiveSession tracks who is currently driving the investigation.
+                  Populated when a user takes over via MCP; nil during autonomous mode.
+                  DD-INTERACTIVE-002: Every RR is takeover-capable; this is observability-only.
+                properties:
+                  actingUser:
+                    description: ActingUser is the resolved identity currently driving
+                      the investigation
+                    type: string
+                  completedAt:
+                    description: CompletedAt is when the user disconnected (KA resumed
+                      autonomous)
+                    format: date-time
+                    type: string
+                  mcpSessionId:
+                    description: MCPSessionID is the go-sdk MCP session identifier
+                    type: string
+                  sessionId:
+                    description: SessionID is the KA-assigned interactive session
+                      identifier
+                    type: string
+                  startedAt:
+                    description: StartedAt is when the user took over
+                    format: date-time
+                    type: string
+                type: object
               investigationId:
                 description: |-
                   ========================================

--- a/config/crd/bases/kubernaut.ai_aianalyses.yaml
+++ b/config/crd/bases/kubernaut.ai_aianalyses.yaml
@@ -634,6 +634,37 @@ spec:
                 - investigation_inconclusive
                 - rca_incomplete
                 type: string
+              interactiveSession:
+                description: |-
+                  ========================================
+                  INTERACTIVE SESSION (DD-INTERACTIVE-002)
+                  Tracks the dynamic takeover session for MCP interactive mode (#703)
+                  ========================================
+                  InteractiveSession tracks who is currently driving the investigation.
+                  Populated when a user takes over via MCP; nil during autonomous mode.
+                  DD-INTERACTIVE-002: Every RR is takeover-capable; this is observability-only.
+                properties:
+                  actingUser:
+                    description: ActingUser is the resolved identity currently driving
+                      the investigation
+                    type: string
+                  completedAt:
+                    description: CompletedAt is when the user disconnected (KA resumed
+                      autonomous)
+                    format: date-time
+                    type: string
+                  mcpSessionId:
+                    description: MCPSessionID is the go-sdk MCP session identifier
+                    type: string
+                  sessionId:
+                    description: SessionID is the KA-assigned interactive session
+                      identifier
+                    type: string
+                  startedAt:
+                    description: StartedAt is when the user took over
+                    format: date-time
+                    type: string
+                type: object
               investigationId:
                 description: |-
                   ========================================

--- a/docs/generated/crds.md
+++ b/docs/generated/crds.md
@@ -103,6 +103,7 @@ _Appears in:_
 | `totalAnalysisTime`| _integer_| TotalAnalysisTime is the total duration of the analysis in seconds|
 | `consecutiveFailures`| _integer_| ConsecutiveFailures tracks retry attempts for exponential backoff<br /> Reset to 0 on success, increment on transient failure<br />Used with for retry logic with jitter|
 | `investigationSession`| _[InvestigationSession](#investigationsession)_| Tracks the async submit/poll session with HAPI<br />InvestigationSession tracks the async HAPI session for submit/poll pattern|
+| `interactiveSession`| _[InteractiveSessionInfo](#interactivesessioninfo)_| Tracks the dynamic takeover session for MCP interactive mode <br />InteractiveSession tracks who is currently driving the investigation.<br />Populated when a user takes over via MCP; nil during autonomous mode.<br /> Every RR is takeover-capable; this is observability-only.|
 | `postRCAContext`| _[PostRCAContext](#postrcacontext)_| Runtime-computed cluster characteristics from HAPI<br />PostRCAContext holds data computed by HAPI after RCA (e.g., DetectedLabels).<br />Immutable once set — use CEL validation on the PostRCAContext type.|
 | `conditions`| _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#condition-v1-meta) array_| Conditions|
 
@@ -757,6 +758,25 @@ _Validation:_
 | `WorkflowExecution`||
 | `Blocked`||
 | `Deduplicated`| FailurePhaseDeduplicated indicates an RR that inherited a failure from a<br />deduplicated WorkflowExecution collision . Excluded from<br />consecutive failure counting per .|
+
+
+### InteractiveSessionInfo
+
+
+InteractiveSessionInfo tracks the dynamic takeover session for MCP interactive mode.
+ Observability-only status field showing who is driving the investigation.
+ Operators can see the current driver via kubectl.
+
+_Appears in:_
+- [AIAnalysisStatus](#aianalysisstatus)
+
+| Field| Type| Description|
+| ---| ---| ---|
+| `sessionId`| _string_| SessionID is the KA-assigned interactive session identifier|
+| `mcpSessionId`| _string_| MCPSessionID is the go-sdk MCP session identifier|
+| `actingUser`| _string_| ActingUser is the resolved identity currently driving the investigation|
+| `startedAt`| _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#time-v1-meta)_| StartedAt is when the user took over|
+| `completedAt`| _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#time-v1-meta)_| CompletedAt is when the user disconnected (KA resumed autonomous)|
 
 
 ### InvestigationSession

--- a/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
@@ -634,6 +634,37 @@ spec:
                 - investigation_inconclusive
                 - rca_incomplete
                 type: string
+              interactiveSession:
+                description: |-
+                  ========================================
+                  INTERACTIVE SESSION (DD-INTERACTIVE-002)
+                  Tracks the dynamic takeover session for MCP interactive mode (#703)
+                  ========================================
+                  InteractiveSession tracks who is currently driving the investigation.
+                  Populated when a user takes over via MCP; nil during autonomous mode.
+                  DD-INTERACTIVE-002: Every RR is takeover-capable; this is observability-only.
+                properties:
+                  actingUser:
+                    description: ActingUser is the resolved identity currently driving
+                      the investigation
+                    type: string
+                  completedAt:
+                    description: CompletedAt is when the user disconnected (KA resumed
+                      autonomous)
+                    format: date-time
+                    type: string
+                  mcpSessionId:
+                    description: MCPSessionID is the go-sdk MCP session identifier
+                    type: string
+                  sessionId:
+                    description: SessionID is the KA-assigned interactive session
+                      identifier
+                    type: string
+                  startedAt:
+                    description: StartedAt is when the user took over
+                    format: date-time
+                    type: string
+                type: object
               investigationId:
                 description: |-
                   ========================================


### PR DESCRIPTION
## Summary

- Adds `InteractiveSessionInfo` struct to `AIAnalysisStatus` for observability of MCP interactive mode dynamic takeover sessions
- Regenerated CRD manifests (Helm chart, config/crd, embedded assets) and reference documentation

## Details

The new status field tracks:
- `sessionId`: KA-assigned interactive session identifier
- `mcpSessionId`: go-sdk MCP session identifier
- `actingUser`: resolved identity currently driving the investigation
- `startedAt` / `completedAt`: takeover lifecycle timestamps

This is **observability-only** - populated when a user takes over via MCP, nil during autonomous mode. Operators can see the current driver via `kubectl get aianalysis -o yaml`.

## Test plan

- [x] `go build ./...` passes
- [x] CRD manifests regenerated (`make manifests`)
- [x] CRD docs regenerated (`make generate-crd-docs`)
- [x] Enum drift check: 0 violations (pre-existing warnings from #838 unrelated)

## Traceability

| Item | Reference |
|------|-----------|
| Issue | #703 |
| Design | DD-INTERACTIVE-002 |
| BR | BR-INTERACTIVE-007 |


Made with [Cursor](https://cursor.com)