### PR TITLE
feat(#908): migrate KA config YAML fields from snake_case to camelCase (ADR-030)

### DIFF
--- a/charts/kubernaut/examples/sdk-config.yaml
+++ b/charts/kubernaut/examples/sdk-config.yaml
@@ -17,10 +17,10 @@ llm:
   model: ""          # e.g., "gpt-4o", "vertex_ai/claude-sonnet-4"
   endpoint: ""       # API endpoint (required for Azure, optional for others)
   # GCP Vertex AI specific (required for vertex_ai provider):
-  # vertex_project: ""
-  # vertex_location: ""   # e.g., "us-central1", "europe-west1"
-  max_retries: 3
-  timeout_seconds: 120
+  # vertexProject: ""
+  # vertexLocation: ""   # e.g., "us-central1", "europe-west1"
+  maxRetries: 3
+  timeoutSeconds: 120
   temperature: 0.7
 
 # -- Toolsets (optional)

--- a/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
+++ b/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
@@ -134,20 +134,20 @@ data:
     server:
       address: "0.0.0.0"
       port: 8080
-      health_addr: ":8081"
-      metrics_addr: ":9090"
+      healthAddr: ":8081"
+      metricsAddr: ":9090"
       tls:
         certDir: {{ include "kubernaut.interServiceTLS.certDir" . | quote }}
-    data_storage:
+    dataStorage:
       url: "{{ include "kubernaut.datastorage.url" . }}"
 {{- if include "kubernaut.agent.tlsEnabled" . }}
-    tls:
-      ca_file: "{{ include "kubernaut.agent.tlsCaDir" . }}/{{ include "kubernaut.agent.tlsCaKey" . }}"
+      tls:
+        caFile: "{{ include "kubernaut.agent.tlsCaDir" . }}/{{ include "kubernaut.agent.tlsCaKey" . }}"
 {{- end }}
     audit:
-      flush_interval_seconds: 1.0
-      buffer_size: 10000
-      batch_size: 50
+      flushIntervalSeconds: 1.0
+      bufferSize: 10000
+      batchSize: 50
 {{- if .Values.kubernautAgent.alignmentCheck.enabled }}
     alignmentCheck:
       enabled: true
@@ -165,7 +165,7 @@ data:
         endpoint: {{ .endpoint }}
 {{- end }}
 {{- if .apiKey }}
-        api_key: {{ .apiKey }}
+        apiKey: {{ .apiKey }}
 {{- end }}
 {{- end }}
 {{- end }}
@@ -217,16 +217,16 @@ data:
     llm:
       provider: {{ .Values.kubernautAgent.llm.provider | quote }}
       model: {{ .Values.kubernautAgent.llm.model | quote }}
-      max_retries: 3
-      timeout_seconds: 120
+      maxRetries: 3
+      timeoutSeconds: 120
       temperature: 0.7
 {{- if .Values.kubernautAgent.llm.structuredOutput }}
-      structured_output: true
+      structuredOutput: true
 {{- end }}
 {{- if .Values.kubernautAgent.llm.oauth2.enabled }}
       oauth2:
         enabled: true
-        token_url: {{ .Values.kubernautAgent.llm.oauth2.tokenURL | quote }}
+        tokenURL: {{ .Values.kubernautAgent.llm.oauth2.tokenURL | quote }}
 {{- if .Values.kubernautAgent.llm.oauth2.scopes }}
         scopes:
 {{- range (splitList " " .Values.kubernautAgent.llm.oauth2.scopes) }}

--- a/cmd/kubernautagent/reload_callback_783_test.go
+++ b/cmd/kubernautagent/reload_callback_783_test.go
@@ -49,7 +49,7 @@ func baseCfgYAML() string {
 	return `llm:
   provider: openai
 investigator:
-  max_turns: 15
+  maxTurns: 15
 `
 }
 
@@ -146,9 +146,9 @@ func TestReloadRejectsOAuth2TokenURLChange(t *testing.T) {
   model: gpt-4
   oauth2:
     enabled: true
-    token_url: https://evil.com/token
-    client_id: my-client
-    client_secret: my-secret
+    tokenURL: https://evil.com/token
+    clientID: my-client
+    clientSecret: my-secret
 `)
 	if err == nil {
 		t.Fatal("expected error for OAuth2 token_url change")
@@ -179,9 +179,9 @@ func TestReloadRejectsOAuth2ClientIDChange(t *testing.T) {
   model: gpt-4
   oauth2:
     enabled: true
-    token_url: https://idp.corp.com/token
-    client_id: different-client
-    client_secret: my-secret
+    tokenURL: https://idp.corp.com/token
+    clientID: different-client
+    clientSecret: my-secret
 `)
 	if err == nil {
 		t.Fatal("expected error for OAuth2 client_id change")
@@ -212,9 +212,9 @@ func TestReloadRejectsOAuth2ClientSecretChange(t *testing.T) {
   model: gpt-4
   oauth2:
     enabled: true
-    token_url: https://idp.corp.com/token
-    client_id: my-client
-    client_secret: different-secret
+    tokenURL: https://idp.corp.com/token
+    clientID: my-client
+    clientSecret: different-secret
 `)
 	if err == nil {
 		t.Fatal("expected error for OAuth2 client_secret change")
@@ -245,12 +245,12 @@ func TestReloadAcceptsOAuth2ScopesChange(t *testing.T) {
 	sdkContent := `llm:
   model: gpt-4-turbo
   endpoint: http://localhost:11434
-  api_key: test-key
+  apiKey: test-key
   oauth2:
     enabled: true
-    token_url: https://idp.corp.com/token
-    client_id: my-client
-    client_secret: my-secret
+    tokenURL: https://idp.corp.com/token
+    clientID: my-client
+    clientSecret: my-secret
     scopes:
       - read
       - write
@@ -276,7 +276,7 @@ func TestReloadAcceptsModelChange(t *testing.T) {
 	err := cb(`llm:
   model: gpt-4-turbo
   endpoint: http://localhost:11434
-  api_key: test-key
+  apiKey: test-key
 `)
 	if err != nil {
 		t.Fatalf("model change should succeed, got: %v", err)
@@ -298,7 +298,7 @@ func TestReloadAcceptsEndpointChange(t *testing.T) {
 	err := cb(`llm:
   model: gpt-4
   endpoint: http://new-endpoint:8080
-  api_key: test-key
+  apiKey: test-key
 `)
 	if err != nil {
 		t.Fatalf("endpoint change should succeed, got: %v", err)
@@ -311,7 +311,7 @@ func TestReloadRejectsValidationFailure(t *testing.T) {
   provider: openai
   model: ""
 investigator:
-  max_turns: 15
+  maxTurns: 15
 `), nil
 	})
 	defer restore()
@@ -354,9 +354,9 @@ func TestReloadRejectsTokenURLHTTPScheme(t *testing.T) {
   model: gpt-4
   oauth2:
     enabled: true
-    token_url: http://insecure.com/token
-    client_id: my-client
-    client_secret: my-secret
+    tokenURL: http://insecure.com/token
+    clientID: my-client
+    clientSecret: my-secret
 `)
 	if err == nil {
 		t.Fatal("expected error for http:// token_url scheme")
@@ -373,7 +373,7 @@ func TestReloadRejectsStructuredOutputChange(t *testing.T) {
 	cb := sdkReloadCallback("/tmp/fake.yaml", baseCfg, sc, testLogger())
 
 	err := cb(`llm:
-  structured_output: true
+  structuredOutput: true
 `)
 	if err == nil {
 		t.Fatal("expected error for structured_output change")
@@ -386,7 +386,7 @@ func TestReloadFreshCopyInvariant(t *testing.T) {
   provider: openai
   model: ""
 investigator:
-  max_turns: 15
+  maxTurns: 15
 `), nil
 	})
 	defer restore()

--- a/docs/architecture/decisions/DD-HAPI-004-configmap-hotreload.md
+++ b/docs/architecture/decisions/DD-HAPI-004-configmap-hotreload.md
@@ -92,8 +92,8 @@ data:
       provider: openai
       model: gpt-4
       endpoint: null  # Use default
-      max_retries: 3
-      timeout_seconds: 60
+      maxRetries: 3
+      timeoutSeconds: 60
       max_tokens_per_request: 4096
       temperature: 0.7
 

--- a/docs/operations/configuration/CONFIG_STANDARDS.md
+++ b/docs/operations/configuration/CONFIG_STANDARDS.md
@@ -156,26 +156,26 @@ llm:
   provider: "openai"                # REQUIRED: openai, ollama, azure, vertex, anthropic, bedrock, huggingface, mistral
   endpoint: "https://api.openai.com" # Provider-specific base URL (required for openai, ollama, azure, vertex, mistral; optional for anthropic; unused by bedrock, huggingface)
   model: "gpt-4"                    # Default: "gpt-4"
-  api_key: ""                       # Use env var LLM_API_KEY (required for openai, azure, anthropic, huggingface, mistral; unused by bedrock, vertex, ollama)
-  azure_api_version: ""             # Required when provider=azure (e.g. "2024-02-15-preview")
-  vertex_project: ""                # Required when provider=vertex (GCP project ID)
-  vertex_location: "us-central1"    # Default: "us-central1" (for provider=vertex)
-  bedrock_region: ""                # Optional when provider=bedrock (overrides AWS_REGION env / SDK default credential chain)
+  apiKey: ""                       # Use env var LLM_API_KEY (required for openai, azure, anthropic, huggingface, mistral; unused by bedrock, vertex, ollama)
+  azureApiVersion: ""             # Required when provider=azure (e.g. "2024-02-15-preview")
+  vertexProject: ""                # Required when provider=vertex (GCP project ID)
+  vertexLocation: "us-central1"    # Default: "us-central1" (for provider=vertex)
+  bedrockRegion: ""                # Optional when provider=bedrock (overrides AWS_REGION env / SDK default credential chain)
 
-data_storage:
+dataStorage:
   url: "http://data-storage:8080"   # REQUIRED - no default
 
 investigator:
-  max_turns: 15                     # Default: 15 — max LLM tool-call turns per investigation
+  maxTurns: 15                     # Default: 15 — max LLM tool-call turns per investigation
 
 sanitization:
-  g4_credentials: true              # Default: true — G4 credential scrubbing
-  i1_injection: true                # Default: true — I1 injection stripping
+  injectionPatternsEnabled: true              # Default: true — I1 injection stripping
+  credentialScrubEnabled: true               # Default: true — G4 credential scrubbing
 
 anomaly:
-  max_tool_calls_per_tool: 10       # Default: 10 — I7 per-tool call limit (raised from 5, #860; pagination calls exempt)
-  max_total_tool_calls: 30          # Default: 30 — I7 total tool call limit
-  max_repeated_failures: 3          # Default: 3 — I7 consecutive failure limit
+  maxToolCallsPerTool: 10       # Default: 10 — I7 per-tool call limit (raised from 5, #860; pagination calls exempt)
+  maxTotalToolCalls: 30          # Default: 30 — I7 total tool call limit
+  maxRepeatedFailures: 3          # Default: 3 — I7 consecutive failure limit
 
 summarizer:
   threshold: 8000                   # Default: 8000 chars — above this, tool output is LLM-summarized
@@ -190,11 +190,11 @@ logging:
   level: "info"                     # Default: "info"
   format: "json"                    # Default: "json"
 
-health:
-  listen_addr: ":8081"              # Default: ":8081"
-
-metrics:
-  listen_addr: ":9090"              # Default: ":9090"
+server:
+  address: "0.0.0.0"                # Default: "0.0.0.0"
+  port: 8080                        # Default: 8080
+  healthAddr: ":8081"               # Default: ":8081" — liveness/readiness
+  metricsAddr: ":9090"              # Default: ":9090" — Prometheus scrape
 ```
 
 #### Air-gapped / On-prem LLM Guidance

--- a/docs/tests/684/TEST_PLAN.md
+++ b/docs/tests/684/TEST_PLAN.md
@@ -330,7 +330,7 @@ Format: `{TIER}-{SERVICE}-{BR_NUMBER}-{SEQUENCE}`
 **File**: `test/unit/kubernautagent/config/config_684_test.go`
 
 **Test Steps**:
-1. **Given**: Main config has no vertex_project; SDK YAML has `vertex_project: "my-gcp-project"`
+1. **Given**: Main config has no vertex_project; SDK YAML has `vertexProject: "my-gcp-project"`
 2. **When**: `MergeSDKConfig()` is called
 3. **Then**: `cfg.LLM.VertexProject` equals `"my-gcp-project"`
 
@@ -344,7 +344,7 @@ Format: `{TIER}-{SERVICE}-{BR_NUMBER}-{SEQUENCE}`
 **File**: `test/unit/kubernautagent/config/config_684_test.go`
 
 **Test Steps**:
-1. **Given**: Main config has no vertex_location; SDK YAML has `vertex_location: "europe-west1"`
+1. **Given**: Main config has no vertex_location; SDK YAML has `vertexLocation: "europe-west1"`
 2. **When**: `MergeSDKConfig()` is called
 3. **Then**: `cfg.LLM.VertexLocation` equals `"europe-west1"`
 
@@ -358,7 +358,7 @@ Format: `{TIER}-{SERVICE}-{BR_NUMBER}-{SEQUENCE}`
 **File**: `test/unit/kubernautagent/config/config_684_test.go`
 
 **Test Steps**:
-1. **Given**: Main config has no api_key; SDK YAML has `api_key: "sk-test-from-sdk"`
+1. **Given**: Main config has no api_key; SDK YAML has `apiKey: "sk-test-from-sdk"`
 2. **When**: `MergeSDKConfig()` is called
 3. **Then**: `cfg.LLM.APIKey` equals `"sk-test-from-sdk"`
 

--- a/internal/kubernautagent/config/config.go
+++ b/internal/kubernautagent/config/config.go
@@ -33,7 +33,7 @@ import (
 type Config struct {
 	Logging        LoggingConfig        `yaml:"logging"`
 	LLM            LLMConfig            `yaml:"llm"`
-	DataStorage    DataStorageConfig    `yaml:"data_storage"`
+	DataStorage    DataStorageConfig    `yaml:"dataStorage"`
 	Server         ServerConfig         `yaml:"server"`
 	Session        SessionConfig        `yaml:"session"`
 	Audit          AuditConfig          `yaml:"audit"`
@@ -46,8 +46,6 @@ type Config struct {
 	AlignmentCheck AlignmentCheckConfig `yaml:"alignmentCheck"`
 	Enrichment     EnrichmentConfig     `yaml:"enrichment"`
 
-	// TLSProfile selects the TLS security profile (Old/Intermediate/Modern).
-	// Issue #748: OCP-only — set by kubernaut-operator from the cluster APIServer CR.
 	TLSProfile string `yaml:"tlsProfile,omitempty"`
 }
 
@@ -75,14 +73,14 @@ type LLMConfig struct {
 	Provider         string                       `yaml:"provider"`
 	Endpoint         string                       `yaml:"endpoint"`
 	Model            string                       `yaml:"model"`
-	APIKey           string                       `yaml:"api_key"`
-	AzureAPIVersion  string                       `yaml:"azure_api_version"`
-	VertexProject    string                       `yaml:"vertex_project"`
-	VertexLocation   string                       `yaml:"vertex_location"`
-	BedrockRegion    string                       `yaml:"bedrock_region"`
+	APIKey           string                       `yaml:"apiKey"`
+	AzureAPIVersion  string                       `yaml:"azureApiVersion"`
+	VertexProject    string                       `yaml:"vertexProject"`
+	VertexLocation   string                       `yaml:"vertexLocation"`
+	BedrockRegion    string                       `yaml:"bedrockRegion"`
 	Temperature      float64                      `yaml:"temperature"`
-	MaxRetries       int                          `yaml:"max_retries"`
-	TimeoutSeconds   int                          `yaml:"timeout_seconds"`
+	MaxRetries       int                          `yaml:"maxRetries"`
+	TimeoutSeconds   int                          `yaml:"timeoutSeconds"`
 	StructuredOutput bool                         `yaml:"-"`
 	CustomHeaders    []pkgconfig.HeaderDefinition `yaml:"-"`
 	OAuth2           OAuth2Config                 `yaml:"-"`
@@ -93,23 +91,23 @@ type LLMConfig struct {
 // automatically via the client credentials grant (RFC 6749 s4.4).
 type OAuth2Config struct {
 	Enabled      bool     `yaml:"enabled"`
-	TokenURL     string   `yaml:"token_url"`
-	ClientID     string   `yaml:"client_id"`
-	ClientSecret string   `yaml:"client_secret"`
+	TokenURL     string   `yaml:"tokenURL"`
+	ClientID     string   `yaml:"clientID"`
+	ClientSecret string   `yaml:"clientSecret"`
 	Scopes       []string `yaml:"scopes,omitempty"`
 }
 
 type DataStorageConfig struct {
 	URL         string              `yaml:"url"`
-	SATokenPath string              `yaml:"sa_token_path"`
+	SATokenPath string              `yaml:"saTokenPath"`
 	TLS         sharedtls.TLSConfig `yaml:"tls,omitempty"`
 }
 
 type ServerConfig struct {
 	Address     string              `yaml:"address"`
 	Port        int                 `yaml:"port"`
-	HealthAddr  string              `yaml:"health_addr"`  // Issue #753: Dedicated health probe port (default ":8081")
-	MetricsAddr string              `yaml:"metrics_addr"` // Issue #753: Dedicated metrics port (default ":9090")
+	HealthAddr  string              `yaml:"healthAddr"`  // Issue #753: Dedicated health probe port (default ":8081")
+	MetricsAddr string              `yaml:"metricsAddr"` // Issue #753: Dedicated metrics port (default ":9090")
 	TLS         sharedtls.TLSConfig `yaml:"tls,omitempty"`
 }
 
@@ -120,9 +118,9 @@ type SessionConfig struct {
 type AuditConfig struct {
 	Enabled              bool    `yaml:"enabled"`
 	Endpoint             string  `yaml:"endpoint"`
-	FlushIntervalSeconds float64 `yaml:"flush_interval_seconds"`
-	BufferSize           int     `yaml:"buffer_size"`
-	BatchSize            int     `yaml:"batch_size"`
+	FlushIntervalSeconds float64 `yaml:"flushIntervalSeconds"`
+	BufferSize           int     `yaml:"bufferSize"`
+	BatchSize            int     `yaml:"batchSize"`
 }
 
 type MCPConfig struct {
@@ -136,7 +134,7 @@ type MCPServerEntry struct {
 }
 
 type InvestigatorConfig struct {
-	MaxTurns int `yaml:"max_turns"`
+	MaxTurns int `yaml:"maxTurns"`
 }
 
 type ToolsConfig struct {
@@ -146,13 +144,13 @@ type ToolsConfig struct {
 type PrometheusToolConfig struct {
 	URL       string        `yaml:"url"`
 	Timeout   time.Duration `yaml:"timeout"`
-	SizeLimit int           `yaml:"size_limit"`
-	TLSCaFile string        `yaml:"tls_ca_file"`
+	SizeLimit int           `yaml:"sizeLimit"`
+	TLSCaFile string        `yaml:"tlsCaFile"`
 }
 
 type SanitizationConfig struct {
-	InjectionPatternsEnabled  bool `yaml:"injection_patterns_enabled"`
-	CredentialScrubEnabled    bool `yaml:"credential_scrub_enabled"`
+	InjectionPatternsEnabled  bool `yaml:"injectionPatternsEnabled"`
+	CredentialScrubEnabled    bool `yaml:"credentialScrubEnabled"`
 }
 
 // DefaultMaxToolOutputSize is the default hard character limit for tool output
@@ -161,22 +159,22 @@ const DefaultMaxToolOutputSize = 100000
 
 type SummarizerConfig struct {
 	Threshold         int `yaml:"threshold"`
-	MaxToolOutputSize int `yaml:"max_tool_output_size"`
+	MaxToolOutputSize int `yaml:"maxToolOutputSize"`
 }
 
 // EnrichmentConfig controls retry behavior for K8s owner chain resolution
 // during enrichment. HAPI-aligned defaults (MaxRetries=3, BaseBackoff=1s)
 // ensure rca_incomplete is triggered on definitive enrichment failure.
 type EnrichmentConfig struct {
-	MaxRetries  int           `yaml:"max_retries"`
-	BaseBackoff time.Duration `yaml:"base_backoff"`
+	MaxRetries  int           `yaml:"maxRetries"`
+	BaseBackoff time.Duration `yaml:"baseBackoff"`
 }
 
 type AnomalyConfig struct {
-	MaxToolCallsPerTool int      `yaml:"max_tool_calls_per_tool"`
-	MaxTotalToolCalls   int      `yaml:"max_total_tool_calls"`
-	MaxRepeatedFailures int      `yaml:"max_repeated_failures"`
-	ExemptPrefixes      []string `yaml:"exempt_prefixes"`
+	MaxToolCallsPerTool int      `yaml:"maxToolCallsPerTool"`
+	MaxTotalToolCalls   int      `yaml:"maxTotalToolCalls"`
+	MaxRepeatedFailures int      `yaml:"maxRepeatedFailures"`
+	ExemptPrefixes      []string `yaml:"exemptPrefixes"`
 }
 
 // AlignmentCheckConfig holds settings for the shadow agent alignment checker (#601).
@@ -245,16 +243,16 @@ type SDKConfig struct {
 		Provider         string                       `yaml:"provider"`
 		Model            string                       `yaml:"model"`
 		Endpoint         string                       `yaml:"endpoint"`
-		APIKey           string                       `yaml:"api_key"`
-		AzureAPIVersion  string                       `yaml:"azure_api_version"`
-		VertexProject    string                       `yaml:"vertex_project"`
-		VertexLocation   string                       `yaml:"vertex_location"`
-		BedrockRegion    string                       `yaml:"bedrock_region"`
-		MaxRetries       int                          `yaml:"max_retries"`
-		TimeoutSeconds   int                          `yaml:"timeout_seconds"`
+		APIKey           string                       `yaml:"apiKey"`
+		AzureAPIVersion  string                       `yaml:"azureApiVersion"`
+		VertexProject    string                       `yaml:"vertexProject"`
+		VertexLocation   string                       `yaml:"vertexLocation"`
+		BedrockRegion    string                       `yaml:"bedrockRegion"`
+		MaxRetries       int                          `yaml:"maxRetries"`
+		TimeoutSeconds   int                          `yaml:"timeoutSeconds"`
 		Temperature      float64                      `yaml:"temperature"`
-		StructuredOutput bool                         `yaml:"structured_output"`
-		CustomHeaders    []pkgconfig.HeaderDefinition `yaml:"custom_headers,omitempty"`
+		StructuredOutput bool                         `yaml:"structuredOutput"`
+		CustomHeaders    []pkgconfig.HeaderDefinition `yaml:"customHeaders,omitempty"`
 		OAuth2           OAuth2Config                 `yaml:"oauth2,omitempty"`
 	} `yaml:"llm"`
 }

--- a/pkg/kubernautagent/tools/prometheus/client.go
+++ b/pkg/kubernautagent/tools/prometheus/client.go
@@ -35,9 +35,9 @@ type ClientConfig struct {
 	URL                   string            `yaml:"url"`
 	Headers               map[string]string `yaml:"headers"`
 	Timeout               time.Duration     `yaml:"timeout"`
-	SizeLimit             int               `yaml:"size_limit"`
-	MetadataLimit         int               `yaml:"metadata_limit"`
-	MetadataTimeWindowHrs int               `yaml:"metadata_time_window_hrs"`
+	SizeLimit             int               `yaml:"sizeLimit"`
+	MetadataLimit         int               `yaml:"metadataLimit"`
+	MetadataTimeWindowHrs int               `yaml:"metadataTimeWindowHrs"`
 
 	// Transport overrides the http.Client's RoundTripper. When set, it is used
 	// as the underlying transport for all Prometheus API requests. This enables

--- a/test/infrastructure/kubernautagent.go
+++ b/test/infrastructure/kubernautagent.go
@@ -687,18 +687,18 @@ data:
       provider: "openai"
       model: "mock-model"
       endpoint: "http://mock-llm:8080"
-      api_key: "mock-api-key-for-e2e"
+      apiKey: "mock-api-key-for-e2e"
     server:
       tls:
         certDir: /etc/tls
-    data_storage:
+    dataStorage:
       url: "https://data-storage-service:8080"
     logging:
       level: "debug"
     audit:
-      flush_interval_seconds: 0.1
-      buffer_size: 10000
-      batch_size: 50
+      flushIntervalSeconds: 0.1
+      bufferSize: 10000
+      batchSize: 50
     auth:
       resource_name: "kubernaut-agent"
     alignmentCheck:

--- a/test/integration/aianalysis/hapi-config/config.yaml
+++ b/test/integration/aianalysis/hapi-config/config.yaml
@@ -1,10 +1,10 @@
 logging:
   level: "INFO"
 
-data_storage:
+dataStorage:
   url: "http://host.containers.internal:18095"
 
 audit:
-  flush_interval_seconds: 0.1
-  buffer_size: 10000
-  batch_size: 50
+  flushIntervalSeconds: 0.1
+  bufferSize: 10000
+  batchSize: 50

--- a/test/integration/aianalysis/hapi-config/secrets/llm-credentials.yaml
+++ b/test/integration/aianalysis/hapi-config/secrets/llm-credentials.yaml
@@ -1,3 +1,3 @@
 # LLM Provider Credentials (Integration Tests)
-api_key: "mock-api-key"
+apiKey: "mock-api-key"
 

--- a/test/integration/aianalysis/suite_test.go
+++ b/test/integration/aianalysis/suite_test.go
@@ -539,19 +539,19 @@ var _ = SynchronizedBeforeSuite(NodeTimeout(10*time.Minute), func(specCtx SpecCo
   provider: "openai"
   model: "mock-model"
   endpoint: "%s"
-  api_key: "mock-api-key-for-integration-tests"
-data_storage:
+  apiKey: "mock-api-key-for-integration-tests"
+dataStorage:
   url: "%s"
 logging:
   level: "debug"
 server:
   port: 18120
-  health_addr: ":18121"
-  metrics_addr: ":18122"
+  healthAddr: ":18121"
+  metricsAddr: ":18122"
 audit:
-  flush_interval_seconds: 0.1
-  buffer_size: 10000
-  batch_size: 50
+  flushIntervalSeconds: 0.1
+  bufferSize: 10000
+  batchSize: 50
 auth:
   resource_name: "kubernaut-agent"
 `, llmEndpoint, dsURL)

--- a/test/unit/kubernautagent/config/config_684_test.go
+++ b/test/unit/kubernautagent/config/config_684_test.go
@@ -55,7 +55,7 @@ llm:
 llm:
   provider: "vertex_ai"
   model: "claude-sonnet-4-6"
-  vertex_project: "my-gcp-project"
+  vertexProject: "my-gcp-project"
 `)
 			cfg, err := config.Load(mainYAML)
 			Expect(err).NotTo(HaveOccurred())
@@ -68,7 +68,7 @@ llm:
 llm:
   provider: "vertex_ai"
   model: "claude-sonnet-4-6"
-  vertex_location: "europe-west1"
+  vertexLocation: "europe-west1"
 `)
 			cfg, err := config.Load(mainYAML)
 			Expect(err).NotTo(HaveOccurred())
@@ -81,7 +81,7 @@ llm:
 llm:
   provider: "vertex_ai"
   model: "claude-sonnet-4-6"
-  api_key: "sk-test-from-sdk"
+  apiKey: "sk-test-from-sdk"
 `)
 			cfg, err := config.Load(mainYAML)
 			Expect(err).NotTo(HaveOccurred())
@@ -107,8 +107,8 @@ llm:
 llm:
   provider: "vertex_ai"
   model: "claude-sonnet-4-6"
-  max_retries: 3
-  timeout_seconds: 120
+  maxRetries: 3
+  timeoutSeconds: 120
 `)
 			cfg, err := config.Load(mainYAML)
 			Expect(err).NotTo(HaveOccurred())
@@ -141,7 +141,7 @@ llm:
 llm:
   provider: "bedrock"
   model: "anthropic.claude-3-sonnet"
-  bedrock_region: "eu-west-1"
+  bedrockRegion: "eu-west-1"
 `)
 			mainBedrock := []byte(`
 llm:
@@ -159,7 +159,7 @@ llm:
 llm:
   provider: "azure"
   model: "gpt-4"
-  azure_api_version: "2024-02-15-preview"
+  azureApiVersion: "2024-02-15-preview"
 `)
 			mainAzure := []byte(`
 llm:

--- a/test/unit/kubernautagent/config/config_test.go
+++ b/test/unit/kubernautagent/config/config_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Kubernaut Agent Configuration — #433", func() {
 llm:
   endpoint: "http://localhost:11434/v1"
   model: "llama3"
-  api_key: "test-key"
+  apiKey: "test-key"
 server:
   address: "0.0.0.0"
   port: 8080
@@ -43,7 +43,7 @@ audit:
   enabled: true
   endpoint: "http://datastorage:8080"
 investigator:
-  max_turns: 15
+  maxTurns: 15
 `)
 			cfg, err := config.Load(yaml)
 			Expect(err).NotTo(HaveOccurred())
@@ -110,7 +110,7 @@ llm:
   endpoint: "http://localhost:11434/v1"
   model: "llama3"
 investigator:
-  max_turns: 0
+  maxTurns: 0
 `)
 			cfg, err := config.Load(yaml)
 			if err == nil && cfg != nil {
@@ -126,7 +126,7 @@ llm:
   endpoint: "http://localhost:11434/v1"
   model: "llama3"
 investigator:
-  max_turns: -5
+  maxTurns: -5
 `)
 			cfg, err := config.Load(yaml)
 			if err == nil && cfg != nil {
@@ -161,7 +161,7 @@ llm:
 llm:
   provider: "anthropic"
   model: "claude-sonnet-4-20250514"
-  structured_output: true
+  structuredOutput: true
 `)
 			cfg, err := config.Load(mainYAML)
 			Expect(err).NotTo(HaveOccurred())
@@ -198,7 +198,7 @@ llm:
 llm:
   provider: "openai"
   model: "gpt-4o"
-  custom_headers:
+  customHeaders:
     - name: "X-Custom-Auth"
       value: "Bearer token123"
     - name: "X-Org-Id"
@@ -246,7 +246,7 @@ llm:
   model: "llama3"
 summarizer:
   threshold: 8000
-  max_tool_output_size: 50000
+  maxToolOutputSize: 50000
 `)
 			cfg, err := config.Load(yaml)
 			Expect(err).NotTo(HaveOccurred())
@@ -290,9 +290,9 @@ llm:
   model: "claude-sonnet-4-20250514"
   oauth2:
     enabled: true
-    token_url: "https://keycloak.acme.com/realms/infra/protocol/openid-connect/token"
-    client_id: "kubernaut-agent"
-    client_secret: "s3cret"
+    tokenURL: "https://keycloak.acme.com/realms/infra/protocol/openid-connect/token"
+    clientID: "kubernaut-agent"
+    clientSecret: "s3cret"
     scopes:
       - "openid"
       - "llm-gateway"
@@ -314,7 +314,7 @@ llm:
 llm:
   provider: "anthropic"
   model: "claude-sonnet-4-20250514"
-  structured_output: true
+  structuredOutput: true
 `)
 				cfg, err := config.Load(mainYAML)
 				Expect(err).NotTo(HaveOccurred())
@@ -329,7 +329,7 @@ llm:
 llm:
   provider: "anthropic"
   model: "claude-sonnet-4-20250514"
-  custom_headers:
+  customHeaders:
     - name: "X-Custom-Auth"
       value: "Bearer token123"
     - name: "X-Org-Id"
@@ -354,11 +354,11 @@ llm:
   model: "claude-sonnet-4-20250514"
   oauth2:
     enabled: true
-    token_url: "https://keycloak.acme.com/token"
-    client_id: "ka"
-    client_secret: "secret"
-  structured_output: true
-  custom_headers:
+    tokenURL: "https://keycloak.acme.com/token"
+    clientID: "ka"
+    clientSecret: "secret"
+  structuredOutput: true
+  customHeaders:
     - name: "X-Test"
       value: "should-be-ignored"
 `)
@@ -417,9 +417,9 @@ llm:
   model: "claude-sonnet-4-20250514"
   oauth2:
     enabled: true
-    token_url: "https://keycloak.acme.com/realms/infra/protocol/openid-connect/token"
-    client_id: "kubernaut-agent"
-    client_secret: "s3cret"
+    tokenURL: "https://keycloak.acme.com/realms/infra/protocol/openid-connect/token"
+    clientID: "kubernaut-agent"
+    clientSecret: "s3cret"
     scopes:
       - "openid"
       - "llm-gateway"
@@ -471,8 +471,8 @@ llm:
   model: "claude-sonnet-4-20250514"
   oauth2:
     enabled: true
-    client_id: "kubernaut-agent"
-    client_secret: "s3cret"
+    clientID: "kubernaut-agent"
+    clientSecret: "s3cret"
 `)
 			cfg, err := config.Load(mainYAML)
 			Expect(err).NotTo(HaveOccurred())
@@ -496,8 +496,8 @@ llm:
   model: "claude-sonnet-4-20250514"
   oauth2:
     enabled: true
-    token_url: "https://keycloak.acme.com/token"
-    client_secret: "s3cret"
+    tokenURL: "https://keycloak.acme.com/token"
+    clientSecret: "s3cret"
 `)
 			cfg, err := config.Load(mainYAML)
 			Expect(err).NotTo(HaveOccurred())
@@ -521,8 +521,8 @@ llm:
   model: "claude-sonnet-4-20250514"
   oauth2:
     enabled: true
-    token_url: "https://keycloak.acme.com/token"
-    client_id: "kubernaut-agent"
+    tokenURL: "https://keycloak.acme.com/token"
+    clientID: "kubernaut-agent"
 `)
 			cfg, err := config.Load(mainYAML)
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

- Migrate all 41 kubernaut-agent YAML config fields from `snake_case` to `camelCase` per ADR-030 §167 (MANDATORY naming convention)
- Update Helm templates, examples, integration configs, test literals, and authoritative documentation

## BREAKING CHANGE

All kubernaut-agent configuration YAML fields now require `camelCase` naming. No backward compatibility for `snake_case`. Users must update their config files.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] 57/57 KA config unit tests pass
- [x] KA cmd tests (reload callback) pass
- [x] `helm lint charts/kubernaut` passes
- [ ] CI pipeline (lint, unit tests, integration, E2E)

## References

- Issue: #908
- ADR-030 §167: "camelCase for YAML fields (MANDATORY)"
- Docs issue: jordigilh/kubernaut-docs#131


Made with [Cursor](https://cursor.com)