### PR TITLE
feat(#908): restructure KA config into 3 concern domains

### DIFF
--- a/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
+++ b/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
@@ -129,50 +129,55 @@ metadata:
     {{- include "kubernaut.labels" . | nindent 4 }}
 data:
   config.yaml: |
-    logging:
-      level: "INFO"
-    server:
-      address: "0.0.0.0"
-      port: 8080
-      healthAddr: ":8081"
-      metricsAddr: ":9090"
-      tls:
-        certDir: {{ include "kubernaut.interServiceTLS.certDir" . | quote }}
-    dataStorage:
-      url: "{{ include "kubernaut.datastorage.url" . }}"
-{{- if include "kubernaut.agent.tlsEnabled" . }}
-      tls:
-        caFile: "{{ include "kubernaut.agent.tlsCaDir" . }}/{{ include "kubernaut.agent.tlsCaKey" . }}"
-{{- end }}
-    audit:
-      flushIntervalSeconds: 1.0
-      bufferSize: 10000
-      batchSize: 50
+    runtime:
+      logging:
+        level: "INFO"
+      server:
+        address: "0.0.0.0"
+        port: 8080
+        healthAddr: ":8081"
+        metricsAddr: ":9090"
+        tls:
+          certDir: {{ include "kubernaut.interServiceTLS.certDir" . | quote }}
+      audit:
+        flushIntervalSeconds: 1.0
+        bufferSize: 10000
+        batchSize: 50
+    ai:
+      investigation:
+        maxTurns: 40
 {{- if .Values.kubernautAgent.alignmentCheck.enabled }}
-    alignmentCheck:
-      enabled: true
-      timeout: {{ .Values.kubernautAgent.alignmentCheck.timeout | default "10s" }}
-      maxStepTokens: {{ .Values.kubernautAgent.alignmentCheck.maxStepTokens | default 500 }}
+      alignmentCheck:
+        enabled: true
+        timeout: {{ .Values.kubernautAgent.alignmentCheck.timeout | default "10s" }}
+        maxStepTokens: {{ .Values.kubernautAgent.alignmentCheck.maxStepTokens | default 500 }}
 {{- with .Values.kubernautAgent.alignmentCheck.llm }}
-      llm:
+        llm:
 {{- if .provider }}
-        provider: {{ .provider }}
+          provider: {{ .provider }}
 {{- end }}
 {{- if .model }}
-        model: {{ .model }}
+          model: {{ .model }}
 {{- end }}
 {{- if .endpoint }}
-        endpoint: {{ .endpoint }}
+          endpoint: {{ .endpoint }}
 {{- end }}
 {{- if .apiKey }}
-        apiKey: {{ .apiKey }}
+          apiKey: {{ .apiKey }}
 {{- end }}
 {{- end }}
+{{- end }}
+    integrations:
+      dataStorage:
+        url: "{{ include "kubernaut.datastorage.url" . }}"
+{{- if include "kubernaut.agent.tlsEnabled" . }}
+        tls:
+          caFile: "{{ include "kubernaut.agent.tlsCaDir" . }}/{{ include "kubernaut.agent.tlsCaKey" . }}"
 {{- end }}
 {{- if include "kubernaut.monitoring.prometheus.enabled" . }}
-    tools:
-      prometheus:
-        url: {{ include "kubernaut.monitoring.prometheus.url" . | quote }}
+      tools:
+        prometheus:
+          url: {{ include "kubernaut.monitoring.prometheus.url" . | quote }}
 {{- end }}
 {{/* DEPRECATED v1.4 (Issue #848): OCP service-ca inject-cabundle ConfigMap.
      Will be removed in v1.5 — use the Kubernaut Operator for OCP. */}}

--- a/cmd/kubernautagent/llm_builder.go
+++ b/cmd/kubernautagent/llm_builder.go
@@ -35,13 +35,13 @@ import (
 // This is a pure function used both at startup and by the SDK hot-reload
 // callback. It does not mutate cfg.
 func buildLLMClientFromConfig(ctx context.Context, cfg *kaconfig.Config) (llm.Client, error) {
-	switch cfg.LLM.Provider {
+	switch cfg.AI.LLM.Provider {
 	case "vertex_ai":
 		return vertexanthropic.New(ctx,
-			cfg.LLM.Model, []byte(cfg.LLM.APIKey),
-			cfg.LLM.VertexProject, cfg.LLM.VertexLocation)
+			cfg.AI.LLM.Model, []byte(cfg.AI.LLM.APIKey),
+			cfg.AI.LLM.VertexProject, cfg.AI.LLM.VertexLocation)
 	default:
-		return langchaingo.New(cfg.LLM.Provider, cfg.LLM.Endpoint, cfg.LLM.Model, cfg.LLM.APIKey,
+		return langchaingo.New(cfg.AI.LLM.Provider, cfg.AI.LLM.Endpoint, cfg.AI.LLM.Model, cfg.AI.LLM.APIKey,
 			buildLLMProviderOpts(cfg)...)
 	}
 }
@@ -50,17 +50,17 @@ func buildLLMClientFromConfig(ctx context.Context, cfg *kaconfig.Config) (llm.Cl
 // config. Extracted from buildLLMProviderOptions for reuse.
 func buildLLMProviderOpts(cfg *kaconfig.Config) []langchaingo.Option {
 	var opts []langchaingo.Option
-	if cfg.LLM.AzureAPIVersion != "" {
-		opts = append(opts, langchaingo.WithAzureAPIVersion(cfg.LLM.AzureAPIVersion))
+	if cfg.AI.LLM.AzureAPIVersion != "" {
+		opts = append(opts, langchaingo.WithAzureAPIVersion(cfg.AI.LLM.AzureAPIVersion))
 	}
-	if cfg.LLM.VertexProject != "" {
-		opts = append(opts, langchaingo.WithVertexProject(cfg.LLM.VertexProject))
+	if cfg.AI.LLM.VertexProject != "" {
+		opts = append(opts, langchaingo.WithVertexProject(cfg.AI.LLM.VertexProject))
 	}
-	if cfg.LLM.VertexLocation != "" {
-		opts = append(opts, langchaingo.WithVertexLocation(cfg.LLM.VertexLocation))
+	if cfg.AI.LLM.VertexLocation != "" {
+		opts = append(opts, langchaingo.WithVertexLocation(cfg.AI.LLM.VertexLocation))
 	}
-	if cfg.LLM.BedrockRegion != "" {
-		opts = append(opts, langchaingo.WithBedrockRegion(cfg.LLM.BedrockRegion))
+	if cfg.AI.LLM.BedrockRegion != "" {
+		opts = append(opts, langchaingo.WithBedrockRegion(cfg.AI.LLM.BedrockRegion))
 	}
 
 	if rt := buildTransportChainFromConfig(cfg); rt != nil {
@@ -81,15 +81,15 @@ func buildTransportChainFromConfig(cfg *kaconfig.Config) http.RoundTripper {
 	var base http.RoundTripper = http.DefaultTransport
 	needsCustom := false
 
-	if cfg.LLM.OAuth2.Enabled {
-		base = llmtransport.NewOAuth2ClientCredentialsTransport(cfg.LLM.OAuth2, base)
+	if cfg.AI.LLM.OAuth2.Enabled {
+		base = llmtransport.NewOAuth2ClientCredentialsTransport(cfg.AI.LLM.OAuth2, base)
 		needsCustom = true
 	}
-	if len(cfg.LLM.CustomHeaders) > 0 {
-		base = llmtransport.NewAuthHeadersTransport(cfg.LLM.CustomHeaders, base)
+	if len(cfg.AI.LLM.CustomHeaders) > 0 {
+		base = llmtransport.NewAuthHeadersTransport(cfg.AI.LLM.CustomHeaders, base)
 		needsCustom = true
 	}
-	if cfg.LLM.StructuredOutput {
+	if cfg.AI.LLM.StructuredOutput {
 		base = llmtransport.NewStructuredOutputTransport(nil, base)
 		needsCustom = true
 	}
@@ -159,7 +159,7 @@ func sdkReloadCallback(
 			return fmt.Errorf("reload: building LLM client: %w", err)
 		}
 
-		if err := swappable.Swap(newClient, freshCfg.LLM.Model); err != nil {
+		if err := swappable.Swap(newClient, freshCfg.AI.LLM.Model); err != nil {
 			logger.Error("sdk_config_reload failed: swap error",
 				"event", "sdk_config_reload", "status", "error", "reason", "swap_failed", "error", err)
 			return fmt.Errorf("reload: swapping client: %w", err)
@@ -169,9 +169,9 @@ func sdkReloadCallback(
 			"event", "sdk_config_reload",
 			"status", "success",
 			"old_model", oldModel,
-			"new_model", freshCfg.LLM.Model,
-			"old_endpoint", cur.LLM.Endpoint,
-			"new_endpoint", freshCfg.LLM.Endpoint,
+			"new_model", freshCfg.AI.LLM.Model,
+			"old_endpoint", cur.AI.LLM.Endpoint,
+			"new_endpoint", freshCfg.AI.LLM.Endpoint,
 		)
 		return nil
 	}
@@ -193,23 +193,23 @@ var readFile = os.ReadFile
 // validateReloadSafety checks that the new config does not violate hot-reload
 // safety constraints.
 func validateReloadSafety(current, proposed *kaconfig.Config) error {
-	if current.LLM.Provider != proposed.LLM.Provider {
+	if current.AI.LLM.Provider != proposed.AI.LLM.Provider {
 		return fmt.Errorf("SDK config reload rejected: provider change from %q to %q requires pod restart",
-			current.LLM.Provider, proposed.LLM.Provider)
+			current.AI.LLM.Provider, proposed.AI.LLM.Provider)
 	}
 
-	if current.LLM.StructuredOutput != proposed.LLM.StructuredOutput {
+	if current.AI.LLM.StructuredOutput != proposed.AI.LLM.StructuredOutput {
 		return fmt.Errorf("SDK config reload rejected: structured_output change requires pod restart")
 	}
 
-	if err := validateOAuth2Safety(current.LLM.OAuth2, proposed.LLM.OAuth2); err != nil {
+	if err := validateOAuth2Safety(current.AI.LLM.OAuth2, proposed.AI.LLM.OAuth2); err != nil {
 		return err
 	}
 
-	if proposed.LLM.OAuth2.Enabled && proposed.LLM.OAuth2.TokenURL != "" {
-		if !strings.HasPrefix(strings.ToLower(proposed.LLM.OAuth2.TokenURL), "https://") {
+	if proposed.AI.LLM.OAuth2.Enabled && proposed.AI.LLM.OAuth2.TokenURL != "" {
+		if !strings.HasPrefix(strings.ToLower(proposed.AI.LLM.OAuth2.TokenURL), "https://") {
 			return fmt.Errorf("SDK config reload rejected: oauth2.token_url must use https:// scheme, got %q",
-				proposed.LLM.OAuth2.TokenURL)
+				proposed.AI.LLM.OAuth2.TokenURL)
 		}
 	}
 

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -101,11 +101,11 @@ func main() {
 	}
 
 	// Re-create logger with configured level (#875).
-	slogHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: cfg.Logging.SlogLevel()})
+	slogHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: cfg.Runtime.Logging.SlogLevel()})
 	slogger = slog.New(slogHandler)
 	logrLogger := logr.FromSlogHandler(slogHandler)
 
-	slogger.Info("log level configured", "level", cfg.Logging.Level)
+	slogger.Info("log level configured", "level", cfg.Runtime.Logging.Level)
 
 	if sdkData, sdkErr := os.ReadFile(sdkConfigPath); sdkErr == nil {
 		if mergeErr := cfg.MergeSDKConfig(sdkData); mergeErr != nil {
@@ -118,25 +118,25 @@ func main() {
 		slogger.Info("SDK config not found, using main config only", "path", sdkConfigPath)
 	}
 
-	if cfg.LLM.APIKey == "" {
+	if cfg.AI.LLM.APIKey == "" {
 		const credDir = "/etc/kubernaut-agent/credentials" // pre-commit:allow-sensitive (mount path)
-		cfg.LLM.APIKey = credentials.ResolveCredentialsFile(cfg.LLM.Provider, credDir, slogger)
+		cfg.AI.LLM.APIKey = credentials.ResolveCredentialsFile(cfg.AI.LLM.Provider, credDir, slogger)
 	}
 
-	switch cfg.LLM.Provider {
+	switch cfg.AI.LLM.Provider {
 	case "vertex", "vertex_ai":
-		if cfg.LLM.APIKey == "" {
+		if cfg.AI.LLM.APIKey == "" {
 			slogger.Warn("GCP provider configured without credentials — requests will use ambient ADC if available",
-				"provider", cfg.LLM.Provider)
+				"provider", cfg.AI.LLM.Provider)
 		}
 	}
 
-	if cfg.LLM.OAuth2.Enabled {
+	if cfg.AI.LLM.OAuth2.Enabled {
 		if v := os.Getenv("OAUTH2_CLIENT_ID"); v != "" {
-			cfg.LLM.OAuth2.ClientID = v
+			cfg.AI.LLM.OAuth2.ClientID = v
 		}
 		if v := os.Getenv("OAUTH2_CLIENT_SECRET"); v != "" {
-			cfg.LLM.OAuth2.ClientSecret = v
+			cfg.AI.LLM.OAuth2.ClientSecret = v
 		}
 	}
 
@@ -146,25 +146,25 @@ func main() {
 	}
 
 	if addr == "" {
-		addr = fmt.Sprintf("%s:%d", cfg.Server.Address, cfg.Server.Port)
+		addr = fmt.Sprintf("%s:%d", cfg.Runtime.Server.Address, cfg.Runtime.Server.Port)
 	}
 
 	slogger.Info("starting Kubernaut Agent", "addr", addr, "config", configPath)
 
 	llmClient, err := buildLLMClientFromConfig(context.Background(), cfg)
 	if err != nil {
-		slogger.Error("failed to create LLM client", "provider", cfg.LLM.Provider, "error", err)
+		slogger.Error("failed to create LLM client", "provider", cfg.AI.LLM.Provider, "error", err)
 		os.Exit(1)
 	}
 
-	swappable, err := llm.NewSwappableClient(llmClient, cfg.LLM.Model)
+	swappable, err := llm.NewSwappableClient(llmClient, cfg.AI.LLM.Model)
 	if err != nil {
 		slogger.Error("failed to create swappable LLM client", "error", err)
 		os.Exit(1)
 	}
 
 	var promptOpts []prompt.BuilderOption
-	if cfg.LLM.StructuredOutput {
+	if cfg.AI.LLM.StructuredOutput {
 		promptOpts = append(promptOpts, prompt.WithStructuredOutput(true))
 	}
 	promptBuilder, err := prompt.NewBuilder(promptOpts...)
@@ -199,15 +199,15 @@ func main() {
 	var effectiveReg registry.ToolRegistry = reg
 	var alignEvaluator *alignment.Evaluator
 
-	if cfg.AlignmentCheck.Enabled {
+	if cfg.AI.AlignmentCheck.Enabled {
 		var shadowClient llm.Client
-		if cfg.AlignmentCheck.LLM == nil {
+		if cfg.AI.AlignmentCheck.LLM == nil {
 			shadowClient = instrumentedLLM
 			slogger.Info("shadow agent shares investigation LLM client")
 		} else {
-			alignLLMCfg := cfg.AlignmentCheck.EffectiveLLM(cfg.LLM)
+			alignLLMCfg := cfg.AI.AlignmentCheck.EffectiveLLM(cfg.AI.LLM)
 			alignCfgMerge := *cfg
-			alignCfgMerge.LLM = alignLLMCfg
+			alignCfgMerge.AI.LLM = alignLLMCfg
 			raw, alignErr := langchaingo.New(
 				alignLLMCfg.Provider, alignLLMCfg.Endpoint, alignLLMCfg.Model, alignLLMCfg.APIKey,
 				buildLLMProviderOpts(&alignCfgMerge)...)
@@ -221,8 +221,8 @@ func main() {
 		}
 		if shadowClient != nil {
 			alignEvaluator = alignment.NewEvaluator(shadowClient, alignment.EvaluatorConfig{
-				Timeout:       cfg.AlignmentCheck.Timeout,
-				MaxStepTokens: cfg.AlignmentCheck.MaxStepTokens,
+				Timeout:       cfg.AI.AlignmentCheck.Timeout,
+				MaxStepTokens: cfg.AI.AlignmentCheck.MaxStepTokens,
 				MaxRetries:    1,
 			}, alignprompt.SystemPrompt())
 			effectiveLLM = alignment.NewLLMProxy(instrumentedLLM)
@@ -243,10 +243,10 @@ func main() {
 		Enricher:      enricher,
 		AuditStore:    auditStore,
 		Logger:        slogger,
-		MaxTurns:      cfg.Investigator.MaxTurns,
+		MaxTurns:      cfg.AI.Investigation.MaxTurns,
 		PhaseTools:    phaseTools,
 		Registry:      effectiveReg,
-		ModelName:     cfg.LLM.Model,
+		ModelName:     cfg.AI.LLM.Model,
 		Swappable:     swappable,
 		ScopeResolver: scopeResolver,
 		Pipeline: investigator.Pipeline{
@@ -254,7 +254,7 @@ func main() {
 			AnomalyDetector:   anomalyDetector,
 			CatalogFetcher:    catalogFetcher,
 			Summarizer:        sum,
-			MaxToolOutputSize: cfg.Summarizer.MaxToolOutputSize,
+			MaxToolOutputSize: cfg.AI.Summarizer.MaxToolOutputSize,
 		},
 	})
 
@@ -269,7 +269,7 @@ func main() {
 		})
 	}
 
-	store := session.NewStore(cfg.Session.TTL)
+	store := session.NewStore(cfg.Runtime.Session.TTL)
 	mgr := session.NewManager(store, slogger)
 
 	handler := kaserver.NewHandler(mgr, investigationRunner, slogger)
@@ -310,24 +310,24 @@ func main() {
 	// Issue #493: Conditional TLS for the HTTP server
 	// Issue #756: CertReloader enables hot-reload of server certificates
 	var certReloader *sharedtls.CertReloader
-	if cfg.Server.TLS.Enabled() {
-		isTLS, reloader, tlsErr := sharedtls.ConfigureConditionalTLS(httpServer, cfg.Server.TLS.CertDir)
+	if cfg.Runtime.Server.TLS.Enabled() {
+		isTLS, reloader, tlsErr := sharedtls.ConfigureConditionalTLS(httpServer, cfg.Runtime.Server.TLS.CertDir)
 		if tlsErr != nil {
 			slogger.Error("Failed to configure TLS", "error", tlsErr)
 			os.Exit(1)
 		}
 		if isTLS {
 			certReloader = reloader
-			slogger.Info("TLS configured for HTTP server", "certDir", cfg.Server.TLS.CertDir)
+			slogger.Info("TLS configured for HTTP server", "certDir", cfg.Runtime.Server.TLS.CertDir)
 		}
 	}
 
 	// Issue #753: Dedicated health and metrics servers (plain HTTP, never TLS)
-	healthServer := sharedhealth.NewHealthServer(cfg.Server.HealthAddr, healthHandler, readyHandler)
+	healthServer := sharedhealth.NewHealthServer(cfg.Runtime.Server.HealthAddr, healthHandler, readyHandler)
 	metricsMux := http.NewServeMux()
 	metricsMux.Handle("/metrics", promhttp.Handler())
 	metricsServer := &http.Server{
-		Addr:              cfg.Server.MetricsAddr,
+		Addr:              cfg.Runtime.Server.MetricsAddr,
 		Handler:           metricsMux,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
@@ -338,7 +338,7 @@ func main() {
 	// Issue #756: Wire FileWatcher for server cert hot-reload
 	if certReloader != nil {
 		certWatcher, watchErr := hotreload.NewFileWatcher(
-			filepath.Join(cfg.Server.TLS.CertDir, "tls.crt"),
+			filepath.Join(cfg.Runtime.Server.TLS.CertDir, "tls.crt"),
 			certReloader.ReloadCallback,
 			logr.FromSlogHandler(slogger.Handler()).WithName("cert-reloader"),
 		)
@@ -372,10 +372,10 @@ func main() {
 	}
 
 	// Issue #748: Load OCP TLS security profile from config before any TLS setup
-	if err := sharedtls.SetDefaultSecurityProfileFromConfig(cfg.TLSProfile); err != nil {
+	if err := sharedtls.SetDefaultSecurityProfileFromConfig(cfg.Runtime.Server.TLSProfile); err != nil {
 		slogger.Error("Invalid TLS security profile in config, using default TLS 1.2", "error", err)
-	} else if cfg.TLSProfile != "" {
-		slogger.Info("TLS security profile active", "profile", cfg.TLSProfile)
+	} else if cfg.Runtime.Server.TLSProfile != "" {
+		slogger.Info("TLS security profile active", "profile", cfg.Runtime.Server.TLSProfile)
 	}
 
 	// Issue #756: Start CA file watcher for client-side TLS hot-reload
@@ -388,17 +388,17 @@ func main() {
 		defer caWatcher.Stop()
 	}
 
-	store.StartCleanupLoop(ctx, cfg.Session.TTL/2)
+	store.StartCleanupLoop(ctx, cfg.Runtime.Session.TTL/2)
 
 	// Issue #753: Start dedicated health and metrics servers
 	go func() {
-		slogger.Info("health server listening", "addr", cfg.Server.HealthAddr)
+		slogger.Info("health server listening", "addr", cfg.Runtime.Server.HealthAddr)
 		if err := healthServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			slogger.Error("health server error", "error", err)
 		}
 	}()
 	go func() {
-		slogger.Info("metrics server listening", "addr", cfg.Server.MetricsAddr)
+		slogger.Info("metrics server listening", "addr", cfg.Runtime.Server.MetricsAddr)
 		if err := metricsServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			slogger.Error("metrics server error", "error", err)
 		}
@@ -452,7 +452,7 @@ func readyHandler(w http.ResponseWriter, _ *http.Request) {
 
 func configHandler(cfg *kaconfig.Config, swappable *llm.SwappableClient) http.HandlerFunc {
 	return func(w http.ResponseWriter, _ *http.Request) {
-		model := cfg.LLM.Model
+		model := cfg.AI.LLM.Model
 		if swappable != nil {
 			model = swappable.ModelName()
 		}
@@ -460,7 +460,7 @@ func configHandler(cfg *kaconfig.Config, swappable *llm.SwappableClient) http.Ha
 			"service":     "kubernaut-agent",
 			"version":     "v1.3",
 			"llm_model":   model,
-			"session_ttl": cfg.Session.TTL.String(),
+			"session_ttl": cfg.Runtime.Session.TTL.String(),
 		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(sanitized)
@@ -524,7 +524,7 @@ type dsClients struct {
 // client is configured with a Bearer token transport so that all DS API calls
 // (including ListWorkflows for the workflow validator) pass authentication.
 func initDSClients(cfg *kaconfig.Config, infra *k8sInfra, logger *slog.Logger) *dsClients {
-	if cfg.DataStorage.URL == "" {
+	if cfg.Integrations.DataStorage.URL == "" {
 		logger.Info("DataStorage URL not configured, DS adapters disabled")
 		return nil
 	}
@@ -541,23 +541,23 @@ func initDSClients(cfg *kaconfig.Config, infra *k8sInfra, logger *slog.Logger) *
 	}
 
 	var opts []ogenclient.ClientOption
-	if tokenData, err := os.ReadFile(cfg.DataStorage.SATokenPath); err == nil && len(tokenData) > 0 {
+	if tokenData, err := os.ReadFile(cfg.Integrations.DataStorage.SATokenPath); err == nil && len(tokenData) > 0 {
 		token := string(tokenData)
 		opts = append(opts, ogenclient.WithClient(&http.Client{
 			Transport: &bearerTransport{base: dsBase, token: token},
 		}))
-		logger.Info("DS client auth configured (DD-AUTH-014)", "token_path", cfg.DataStorage.SATokenPath)
+		logger.Info("DS client auth configured (DD-AUTH-014)", "token_path", cfg.Integrations.DataStorage.SATokenPath)
 	} else {
 		logger.Warn("SA token not available for DS client — DS API calls may fail auth",
-			"path", cfg.DataStorage.SATokenPath, "error", err)
+			"path", cfg.Integrations.DataStorage.SATokenPath, "error", err)
 	}
 
-	ogenClient, err := ogenclient.NewClient(cfg.DataStorage.URL, opts...)
+	ogenClient, err := ogenclient.NewClient(cfg.Integrations.DataStorage.URL, opts...)
 	if err != nil {
-		logger.Error("failed to create DataStorage ogen client", "url", cfg.DataStorage.URL, "error", err)
+		logger.Error("failed to create DataStorage ogen client", "url", cfg.Integrations.DataStorage.URL, "error", err)
 		return nil
 	}
-	logger.Info("DataStorage clients initialized", "url", cfg.DataStorage.URL)
+	logger.Info("DataStorage clients initialized", "url", cfg.Integrations.DataStorage.URL)
 	return &dsClients{
 		ogenClient: ogenClient,
 		dsAdapter:  enrichment.NewDSAdapter(ogenClient),
@@ -591,12 +591,12 @@ func buildEnricher(cfg *kaconfig.Config, ds *dsClients, infra *k8sInfra, auditSt
 		logger.Info("label detector enabled (ADR-056)")
 	}
 	e.WithRetryConfig(enrichment.RetryConfig{
-		MaxRetries:  cfg.Enrichment.MaxRetries,
-		BaseBackoff: cfg.Enrichment.BaseBackoff,
+		MaxRetries:  cfg.AI.Enrichment.MaxRetries,
+		BaseBackoff: cfg.AI.Enrichment.BaseBackoff,
 	})
 	logger.Info("enrichment retry config wired (#704)",
-		slog.Int("max_retries", cfg.Enrichment.MaxRetries),
-		slog.Duration("base_backoff", cfg.Enrichment.BaseBackoff),
+		slog.Int("max_retries", cfg.AI.Enrichment.MaxRetries),
+		slog.Duration("base_backoff", cfg.AI.Enrichment.BaseBackoff),
 	)
 	return e
 }
@@ -605,10 +605,10 @@ func buildEnricher(cfg *kaconfig.Config, ds *dsClients, infra *k8sInfra, auditSt
 // per DD-HAPI-019-003. Returns nil when both stages are disabled.
 func buildSanitizationPipeline(cfg *kaconfig.Config, logger *slog.Logger) *sanitization.Pipeline {
 	var stages []sanitization.Stage
-	if cfg.Sanitization.CredentialScrubEnabled {
+	if cfg.AI.Safety.Sanitization.CredentialScrubEnabled {
 		stages = append(stages, sanitization.NewCredentialSanitizer())
 	}
-	if cfg.Sanitization.InjectionPatternsEnabled {
+	if cfg.AI.Safety.Sanitization.InjectionPatternsEnabled {
 		stages = append(stages, sanitization.NewInjectionSanitizer(nil))
 	}
 	if len(stages) == 0 {
@@ -626,7 +626,7 @@ func buildSanitizationPipeline(cfg *kaconfig.Config, logger *slog.Logger) *sanit
 // to guarantee identical authentication behavior.
 func buildAuditStore(cfg *kaconfig.Config, slogger *slog.Logger, logrLog logr.Logger) (audit.AuditStore, func()) {
 	nop := func() {}
-	if !cfg.Audit.Enabled || cfg.DataStorage.URL == "" {
+	if !cfg.Runtime.Audit.Enabled || cfg.Integrations.DataStorage.URL == "" {
 		slogger.Info("audit store disabled (nop)")
 		return audit.NopAuditStore{}, nop
 	}
@@ -640,17 +640,17 @@ func buildAuditStore(cfg *kaconfig.Config, slogger *slog.Logger, logrLog logr.Lo
 	}
 
 	var transport http.RoundTripper
-	if tokenData, err := os.ReadFile(cfg.DataStorage.SATokenPath); err == nil && len(tokenData) > 0 {
+	if tokenData, err := os.ReadFile(cfg.Integrations.DataStorage.SATokenPath); err == nil && len(tokenData) > 0 {
 		transport = &bearerTransport{base: auditBase, token: string(tokenData)}
 		slogger.Info("audit store auth configured (same SA token as DS client)",
-			"token_path", cfg.DataStorage.SATokenPath)
+			"token_path", cfg.Integrations.DataStorage.SATokenPath)
 	} else {
 		slogger.Warn("SA token not available for audit store — batch writes may fail auth",
-			"path", cfg.DataStorage.SATokenPath, "error", err)
+			"path", cfg.Integrations.DataStorage.SATokenPath, "error", err)
 	}
 
 	dsClient, err := sharedaudit.NewOpenAPIClientAdapterWithTransport(
-		cfg.DataStorage.URL, 5*time.Second, transport,
+		cfg.Integrations.DataStorage.URL, 5*time.Second, transport,
 	)
 	if err != nil {
 		slogger.Error("failed to create DS audit client, falling back to nop", "error", err)
@@ -658,15 +658,15 @@ func buildAuditStore(cfg *kaconfig.Config, slogger *slog.Logger, logrLog logr.Lo
 	}
 
 	var storeOpts []audit.BufferedDSAuditStoreOption
-	if cfg.Audit.FlushIntervalSeconds > 0 {
+	if cfg.Runtime.Audit.FlushIntervalSeconds > 0 {
 		storeOpts = append(storeOpts, audit.WithFlushInterval(
-			time.Duration(cfg.Audit.FlushIntervalSeconds*float64(time.Second))))
+			time.Duration(cfg.Runtime.Audit.FlushIntervalSeconds*float64(time.Second))))
 	}
-	if cfg.Audit.BufferSize > 0 {
-		storeOpts = append(storeOpts, audit.WithBufferSize(cfg.Audit.BufferSize))
+	if cfg.Runtime.Audit.BufferSize > 0 {
+		storeOpts = append(storeOpts, audit.WithBufferSize(cfg.Runtime.Audit.BufferSize))
 	}
-	if cfg.Audit.BatchSize > 0 {
-		storeOpts = append(storeOpts, audit.WithBatchSize(cfg.Audit.BatchSize))
+	if cfg.Runtime.Audit.BatchSize > 0 {
+		storeOpts = append(storeOpts, audit.WithBatchSize(cfg.Runtime.Audit.BatchSize))
 	}
 
 	store, err := audit.NewBufferedDSAuditStore(dsClient, logrLog, storeOpts...)
@@ -675,7 +675,7 @@ func buildAuditStore(cfg *kaconfig.Config, slogger *slog.Logger, logrLog logr.Lo
 		return audit.NopAuditStore{}, nop
 	}
 	slogger.Info("audit store enabled (buffered, DD-AUDIT-002 aligned)",
-		"ds_url", cfg.DataStorage.URL)
+		"ds_url", cfg.Integrations.DataStorage.URL)
 	return store, func() {
 		if closeErr := store.Close(); closeErr != nil {
 			slogger.Error("audit store close error", "error", closeErr)
@@ -687,27 +687,27 @@ func buildAuditStore(cfg *kaconfig.Config, slogger *slog.Logger, logrLog logr.Lo
 // When MaxToolOutputSize is configured, it enables pre-truncation to prevent
 // the summarizer's own LLM call from exceeding context window limits (#752).
 func buildSummarizer(llmClient llm.Client, cfg *kaconfig.Config, logger *slog.Logger) *summarizer.Summarizer {
-	if cfg.Summarizer.Threshold <= 0 {
+	if cfg.AI.Summarizer.Threshold <= 0 {
 		logger.Info("summarizer disabled (threshold <= 0)")
 		return nil
 	}
-	if cfg.Summarizer.MaxToolOutputSize > 0 {
+	if cfg.AI.Summarizer.MaxToolOutputSize > 0 {
 		logger.Info("summarizer enabled with pre-truncation",
-			"threshold", cfg.Summarizer.Threshold,
-			"max_tool_output_size", cfg.Summarizer.MaxToolOutputSize)
-		return summarizer.NewWithMaxInput(llmClient, cfg.Summarizer.Threshold, cfg.Summarizer.MaxToolOutputSize)
+			"threshold", cfg.AI.Summarizer.Threshold,
+			"max_tool_output_size", cfg.AI.Summarizer.MaxToolOutputSize)
+		return summarizer.NewWithMaxInput(llmClient, cfg.AI.Summarizer.Threshold, cfg.AI.Summarizer.MaxToolOutputSize)
 	}
-	logger.Info("summarizer enabled", "threshold", cfg.Summarizer.Threshold)
-	return summarizer.New(llmClient, cfg.Summarizer.Threshold)
+	logger.Info("summarizer enabled", "threshold", cfg.AI.Summarizer.Threshold)
+	return summarizer.New(llmClient, cfg.AI.Summarizer.Threshold)
 }
 
 // buildAnomalyDetector creates the I7 anomaly detector from config thresholds.
 func buildAnomalyDetector(cfg *kaconfig.Config, logger *slog.Logger) *investigator.AnomalyDetector {
 	ac := investigator.AnomalyConfig{
-		MaxToolCallsPerTool: cfg.Anomaly.MaxToolCallsPerTool,
-		MaxTotalToolCalls:   cfg.Anomaly.MaxTotalToolCalls,
-		MaxRepeatedFailures: cfg.Anomaly.MaxRepeatedFailures,
-		ExemptPrefixes:      cfg.Anomaly.ExemptPrefixes,
+		MaxToolCallsPerTool: cfg.AI.Safety.Anomaly.MaxToolCallsPerTool,
+		MaxTotalToolCalls:   cfg.AI.Safety.Anomaly.MaxTotalToolCalls,
+		MaxRepeatedFailures: cfg.AI.Safety.Anomaly.MaxRepeatedFailures,
+		ExemptPrefixes:      cfg.AI.Safety.Anomaly.ExemptPrefixes,
 	}
 	logger.Info("anomaly detector enabled",
 		"maxToolCallsPerTool", ac.MaxToolCallsPerTool,
@@ -726,19 +726,19 @@ func buildToolRegistry(cfg *kaconfig.Config, logger *slog.Logger, infra *k8sInfr
 		registerK8sTools(reg, infra, logger)
 	}
 
-	if cfg.Tools.Prometheus.URL != "" {
+	if cfg.Integrations.Tools.Prometheus.URL != "" {
 		promCfg := promtools.ClientConfig{
-			URL:       cfg.Tools.Prometheus.URL,
-			Timeout:   cfg.Tools.Prometheus.Timeout,
-			SizeLimit: cfg.Tools.Prometheus.SizeLimit,
+			URL:       cfg.Integrations.Tools.Prometheus.URL,
+			Timeout:   cfg.Integrations.Tools.Prometheus.Timeout,
+			SizeLimit: cfg.Integrations.Tools.Prometheus.SizeLimit,
 		}
-		if cfg.Tools.Prometheus.TLSCaFile != "" {
-			promBase, promTLSErr := sharedtls.NewTLSTransport(cfg.Tools.Prometheus.TLSCaFile)
+		if cfg.Integrations.Tools.Prometheus.TLSCaFile != "" {
+			promBase, promTLSErr := sharedtls.NewTLSTransport(cfg.Integrations.Tools.Prometheus.TLSCaFile)
 			if promTLSErr != nil {
-				logger.Error("failed to create Prometheus TLS transport", "error", promTLSErr, "ca_file", cfg.Tools.Prometheus.TLSCaFile)
+				logger.Error("failed to create Prometheus TLS transport", "error", promTLSErr, "ca_file", cfg.Integrations.Tools.Prometheus.TLSCaFile)
 			} else {
 				promCfg.Transport = auth.NewServiceAccountTransportWithBase(promBase)
-				logger.Info("Prometheus client configured with TLS + SA bearer auth", "ca_file", cfg.Tools.Prometheus.TLSCaFile)
+				logger.Info("Prometheus client configured with TLS + SA bearer auth", "ca_file", cfg.Integrations.Tools.Prometheus.TLSCaFile)
 			}
 		}
 		promClient, promErr := promtools.NewClient(promCfg)

--- a/cmd/kubernautagent/reload_callback_783_test.go
+++ b/cmd/kubernautagent/reload_callback_783_test.go
@@ -35,10 +35,10 @@ func testLogger() *slog.Logger {
 // fills the gaps.
 func baseCfg() *kaconfig.Config {
 	cfg := kaconfig.DefaultConfig()
-	cfg.LLM.Provider = "openai"
-	cfg.LLM.Model = "gpt-4"
-	cfg.LLM.Endpoint = "http://localhost:11434"
-	cfg.LLM.APIKey = "test-key"
+	cfg.AI.LLM.Provider = "openai"
+	cfg.AI.LLM.Model = "gpt-4"
+	cfg.AI.LLM.Endpoint = "http://localhost:11434"
+	cfg.AI.LLM.APIKey = "test-key"
 	return cfg
 }
 
@@ -46,10 +46,11 @@ func baseCfg() *kaconfig.Config {
 // In production, the main config file does NOT contain LLM fields --
 // those come exclusively from the SDK config via MergeSDKConfig.
 func baseCfgYAML() string {
-	return `llm:
-  provider: openai
-investigator:
-  maxTurns: 15
+	return `ai:
+  llm:
+    provider: openai
+  investigation:
+    maxTurns: 40
 `
 }
 
@@ -125,7 +126,7 @@ func TestReloadRejectsProviderChange(t *testing.T) {
 func TestReloadRejectsOAuth2TokenURLChange(t *testing.T) {
 	currentCfg := func() *kaconfig.Config {
 		c := baseCfg()
-		c.LLM.OAuth2 = kaconfig.OAuth2Config{
+		c.AI.LLM.OAuth2 = kaconfig.OAuth2Config{
 			Enabled:      true,
 			TokenURL:     "https://idp.corp.com/token",
 			ClientID:     "my-client",
@@ -158,7 +159,7 @@ func TestReloadRejectsOAuth2TokenURLChange(t *testing.T) {
 func TestReloadRejectsOAuth2ClientIDChange(t *testing.T) {
 	currentCfg := func() *kaconfig.Config {
 		c := baseCfg()
-		c.LLM.OAuth2 = kaconfig.OAuth2Config{
+		c.AI.LLM.OAuth2 = kaconfig.OAuth2Config{
 			Enabled:      true,
 			TokenURL:     "https://idp.corp.com/token",
 			ClientID:     "my-client",
@@ -191,7 +192,7 @@ func TestReloadRejectsOAuth2ClientIDChange(t *testing.T) {
 func TestReloadRejectsOAuth2ClientSecretChange(t *testing.T) {
 	currentCfg := func() *kaconfig.Config {
 		c := baseCfg()
-		c.LLM.OAuth2 = kaconfig.OAuth2Config{
+		c.AI.LLM.OAuth2 = kaconfig.OAuth2Config{
 			Enabled:      true,
 			TokenURL:     "https://idp.corp.com/token",
 			ClientID:     "my-client",
@@ -224,7 +225,7 @@ func TestReloadRejectsOAuth2ClientSecretChange(t *testing.T) {
 func TestReloadAcceptsOAuth2ScopesChange(t *testing.T) {
 	currentCfg := func() *kaconfig.Config {
 		c := baseCfg()
-		c.LLM.OAuth2 = kaconfig.OAuth2Config{
+		c.AI.LLM.OAuth2 = kaconfig.OAuth2Config{
 			Enabled:      true,
 			TokenURL:     "https://idp.corp.com/token",
 			ClientID:     "my-client",
@@ -307,11 +308,12 @@ func TestReloadAcceptsEndpointChange(t *testing.T) {
 
 func TestReloadRejectsValidationFailure(t *testing.T) {
 	restore := withReadFile(func(string) ([]byte, error) {
-		return []byte(`llm:
-  provider: openai
-  model: ""
-investigator:
-  maxTurns: 15
+		return []byte(`ai:
+  llm:
+    provider: openai
+    model: ""
+  investigation:
+    maxTurns: 40
 `), nil
 	})
 	defer restore()
@@ -333,7 +335,7 @@ investigator:
 func TestReloadRejectsTokenURLHTTPScheme(t *testing.T) {
 	currentCfg := func() *kaconfig.Config {
 		c := baseCfg()
-		c.LLM.OAuth2 = kaconfig.OAuth2Config{
+		c.AI.LLM.OAuth2 = kaconfig.OAuth2Config{
 			Enabled:      true,
 			TokenURL:     "http://insecure.com/token",
 			ClientID:     "my-client",
@@ -382,17 +384,18 @@ func TestReloadRejectsStructuredOutputChange(t *testing.T) {
 
 func TestReloadFreshCopyInvariant(t *testing.T) {
 	restore := withReadFile(func(string) ([]byte, error) {
-		return []byte(`llm:
-  provider: openai
-  model: ""
-investigator:
-  maxTurns: 15
+		return []byte(`ai:
+  llm:
+    provider: openai
+    model: ""
+  investigation:
+    maxTurns: 40
 `), nil
 	})
 	defer restore()
 
 	origCfg := baseCfg()
-	origModel := origCfg.LLM.Model
+	origModel := origCfg.AI.LLM.Model
 
 	sc := setupSwappable(t)
 	cb := sdkReloadCallback("/tmp/fake.yaml", func() *kaconfig.Config { return origCfg }, sc, testLogger())
@@ -402,7 +405,7 @@ investigator:
   model: ""
 `)
 
-	if origCfg.LLM.Model != origModel {
-		t.Fatalf("live config must not be mutated on failed reload; model was %q, now %q", origModel, origCfg.LLM.Model)
+	if origCfg.AI.LLM.Model != origModel {
+		t.Fatalf("live config must not be mutated on failed reload; model was %q, now %q", origModel, origCfg.AI.LLM.Model)
 	}
 }

--- a/docs/architecture/decisions/ADR-KA-001-shadow-agent-alignment-check.md
+++ b/docs/architecture/decisions/ADR-KA-001-shadow-agent-alignment-check.md
@@ -122,18 +122,19 @@ kubernautAgent:
 ### Service Configuration (YAML)
 
 ```yaml
-alignmentCheck:
-  enabled: true
-  timeout: 10s
-  maxStepTokens: 500
-  llm:
-    provider: "openai"
-    model: "gpt-4o-mini"
+ai:
+  alignmentCheck:
+    enabled: true
+    timeout: 10s
+    maxStepTokens: 500
+    llm:
+      provider: "openai"
+      model: "gpt-4o-mini"
 ```
 
 ### Validation Rules
 
-When `alignmentCheck.enabled=true`:
+When `ai.alignmentCheck.enabled=true`:
 - `timeout` must be positive
 - `maxStepTokens` must be positive
 - If `llm` is set, `model` must be non-empty and `endpoint` is required for non-managed providers (bedrock, huggingface, anthropic, openai are managed)

--- a/docs/operations/configuration/CONFIG_STANDARDS.md
+++ b/docs/operations/configuration/CONFIG_STANDARDS.md
@@ -152,49 +152,46 @@ metrics:
 > The Python HolmesGPT SDK dependency has been eliminated.
 
 ```yaml
-llm:
-  provider: "openai"                # REQUIRED: openai, ollama, azure, vertex, anthropic, bedrock, huggingface, mistral
-  endpoint: "https://api.openai.com" # Provider-specific base URL (required for openai, ollama, azure, vertex, mistral; optional for anthropic; unused by bedrock, huggingface)
-  model: "gpt-4"                    # Default: "gpt-4"
-  apiKey: ""                       # Use env var LLM_API_KEY (required for openai, azure, anthropic, huggingface, mistral; unused by bedrock, vertex, ollama)
-  azureApiVersion: ""             # Required when provider=azure (e.g. "2024-02-15-preview")
-  vertexProject: ""                # Required when provider=vertex (GCP project ID)
-  vertexLocation: "us-central1"    # Default: "us-central1" (for provider=vertex)
-  bedrockRegion: ""                # Optional when provider=bedrock (overrides AWS_REGION env / SDK default credential chain)
+runtime:
+  logging:
+    level: "info"                     # Default: "info"
+    format: "json"                    # Default: "json"
+  server:
+    address: "0.0.0.0"                # Default: "0.0.0.0"
+    port: 8080                        # Default: 8080
+    healthAddr: ":8081"               # Default: ":8081" — liveness/readiness
+    metricsAddr: ":9090"              # Default: ":9090" — Prometheus scrape
+  session:
+    ttl: 10m                          # Default: 10m — async session expiry
+  audit:
+    enabled: true                     # Default: true — sends audit events to DataStorage
 
-dataStorage:
-  url: "http://data-storage:8080"   # REQUIRED - no default
+ai:
+  llm:
+    provider: "openai"                # REQUIRED: openai, ollama, azure, vertex, anthropic, bedrock, huggingface, mistral
+    endpoint: "https://api.openai.com" # Provider-specific base URL (required for openai, ollama, azure, vertex, mistral; optional for anthropic; unused by bedrock, huggingface)
+    model: "gpt-4"                    # Default: "gpt-4"
+    apiKey: ""                       # Use env var LLM_API_KEY (required for openai, azure, anthropic, huggingface, mistral; unused by bedrock, vertex, ollama)
+    azureApiVersion: ""             # Required when provider=azure (e.g. "2024-02-15-preview")
+    vertexProject: ""                # Required when provider=vertex (GCP project ID)
+    vertexLocation: "us-central1"    # Default: "us-central1" (for provider=vertex)
+    bedrockRegion: ""                # Optional when provider=bedrock (overrides AWS_REGION env / SDK default credential chain)
+  investigation:
+    maxTurns: 40                     # Default: 40 — max LLM tool-call turns per investigation
+  safety:
+    sanitization:
+      injectionPatternsEnabled: true              # Default: true — I1 injection stripping
+      credentialScrubEnabled: true               # Default: true — G4 credential scrubbing
+    anomaly:
+      maxToolCallsPerTool: 10       # Default: 10 — I7 per-tool call limit (raised from 5, #860; pagination calls exempt)
+      maxTotalToolCalls: 30          # Default: 30 — I7 total tool call limit
+      maxRepeatedFailures: 3          # Default: 3 — I7 consecutive failure limit
+  summarizer:
+    threshold: 8000                   # Default: 8000 chars — above this, tool output is LLM-summarized
 
-investigator:
-  maxTurns: 15                     # Default: 15 — max LLM tool-call turns per investigation
-
-sanitization:
-  injectionPatternsEnabled: true              # Default: true — I1 injection stripping
-  credentialScrubEnabled: true               # Default: true — G4 credential scrubbing
-
-anomaly:
-  maxToolCallsPerTool: 10       # Default: 10 — I7 per-tool call limit (raised from 5, #860; pagination calls exempt)
-  maxTotalToolCalls: 30          # Default: 30 — I7 total tool call limit
-  maxRepeatedFailures: 3          # Default: 3 — I7 consecutive failure limit
-
-summarizer:
-  threshold: 8000                   # Default: 8000 chars — above this, tool output is LLM-summarized
-
-audit:
-  enabled: true                     # Default: true — sends audit events to DataStorage
-
-session:
-  ttl: 10m                          # Default: 10m — async session expiry
-
-logging:
-  level: "info"                     # Default: "info"
-  format: "json"                    # Default: "json"
-
-server:
-  address: "0.0.0.0"                # Default: "0.0.0.0"
-  port: 8080                        # Default: 8080
-  healthAddr: ":8081"               # Default: ":8081" — liveness/readiness
-  metricsAddr: ":9090"              # Default: ":9090" — Prometheus scrape
+integrations:
+  dataStorage:
+    url: "http://data-storage:8080"   # REQUIRED - no default
 ```
 
 #### Air-gapped / On-prem LLM Guidance

--- a/internal/kubernautagent/config/config.go
+++ b/internal/kubernautagent/config/config.go
@@ -27,26 +27,42 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// Config holds all Kubernaut Agent configuration.
-// Nested sub-configs support forward-compatibility with Phases 2-6
-// without breaking Phase 1 tests.
+// Config holds all Kubernaut Agent configuration organized into 3 concern domains.
 type Config struct {
-	Logging        LoggingConfig        `yaml:"logging"`
-	LLM            LLMConfig            `yaml:"llm"`
-	DataStorage    DataStorageConfig    `yaml:"dataStorage"`
-	Server         ServerConfig         `yaml:"server"`
-	Session        SessionConfig        `yaml:"session"`
-	Audit          AuditConfig          `yaml:"audit"`
-	MCP            MCPConfig            `yaml:"mcp"`
-	Investigator   InvestigatorConfig   `yaml:"investigator"`
-	Tools          ToolsConfig          `yaml:"tools"`
-	Sanitization   SanitizationConfig   `yaml:"sanitization"`
-	Anomaly        AnomalyConfig        `yaml:"anomaly"`
-	Summarizer     SummarizerConfig     `yaml:"summarizer"`
-	AlignmentCheck AlignmentCheckConfig `yaml:"alignmentCheck"`
-	Enrichment     EnrichmentConfig     `yaml:"enrichment"`
+	Runtime      RuntimeConfig      `yaml:"runtime"`
+	AI           AIConfig           `yaml:"ai"`
+	Integrations IntegrationsConfig `yaml:"integrations"`
+}
 
-	TLSProfile string `yaml:"tlsProfile,omitempty"`
+// RuntimeConfig holds operational infrastructure settings.
+type RuntimeConfig struct {
+	Logging LoggingConfig `yaml:"logging"`
+	Server  ServerConfig  `yaml:"server"`
+	Session SessionConfig `yaml:"session"`
+	Audit   AuditConfig   `yaml:"audit"`
+}
+
+// AIConfig holds LLM, investigation behavior, and safety guardrails.
+type AIConfig struct {
+	LLM            LLMConfig            `yaml:"llm"`
+	Investigation  InvestigationConfig  `yaml:"investigation"`
+	Summarizer     SummarizerConfig     `yaml:"summarizer"`
+	Enrichment     EnrichmentConfig     `yaml:"enrichment"`
+	AlignmentCheck AlignmentCheckConfig `yaml:"alignmentCheck"`
+	Safety         SafetyConfig         `yaml:"safety"`
+}
+
+// SafetyConfig holds guardrails that constrain AI behavior.
+type SafetyConfig struct {
+	Sanitization SanitizationConfig `yaml:"sanitization"`
+	Anomaly      AnomalyConfig      `yaml:"anomaly"`
+}
+
+// IntegrationsConfig holds external service connection settings.
+type IntegrationsConfig struct {
+	DataStorage DataStorageConfig `yaml:"dataStorage"`
+	Tools       ToolsConfig       `yaml:"tools"`
+	MCP         MCPConfig         `yaml:"mcp"`
 }
 
 // LoggingConfig holds log-level configuration (#875).
@@ -104,11 +120,12 @@ type DataStorageConfig struct {
 }
 
 type ServerConfig struct {
-	Address     string              `yaml:"address"`
-	Port        int                 `yaml:"port"`
-	HealthAddr  string              `yaml:"healthAddr"`  // Issue #753: Dedicated health probe port (default ":8081")
-	MetricsAddr string              `yaml:"metricsAddr"` // Issue #753: Dedicated metrics port (default ":9090")
-	TLS         sharedtls.TLSConfig `yaml:"tls,omitempty"`
+	Address    string              `yaml:"address"`
+	Port       int                 `yaml:"port"`
+	HealthAddr string              `yaml:"healthAddr"`
+	MetricsAddr string             `yaml:"metricsAddr"`
+	TLS        sharedtls.TLSConfig `yaml:"tls,omitempty"`
+	TLSProfile string              `yaml:"tlsProfile,omitempty"`
 }
 
 type SessionConfig struct {
@@ -133,7 +150,7 @@ type MCPServerEntry struct {
 	Transport string `yaml:"transport"`
 }
 
-type InvestigatorConfig struct {
+type InvestigationConfig struct {
 	MaxTurns int `yaml:"maxTurns"`
 }
 
@@ -149,8 +166,8 @@ type PrometheusToolConfig struct {
 }
 
 type SanitizationConfig struct {
-	InjectionPatternsEnabled  bool `yaml:"injectionPatternsEnabled"`
-	CredentialScrubEnabled    bool `yaml:"credentialScrubEnabled"`
+	InjectionPatternsEnabled bool `yaml:"injectionPatternsEnabled"`
+	CredentialScrubEnabled   bool `yaml:"credentialScrubEnabled"`
 }
 
 // DefaultMaxToolOutputSize is the default hard character limit for tool output
@@ -260,108 +277,103 @@ type SDKConfig struct {
 // MergeSDKConfig loads an SDK config file and merges LLM fields into
 // the main config. Gap-fill semantics: the main config value is kept
 // when non-zero; the SDK value fills the gap only when the main value
-// is the zero value. Gap-fill fields: provider (special: also replaces
-// the default "openai"), model, endpoint, api_key, vertex_project,
-// vertex_location, bedrock_region, azure_api_version, temperature,
-// max_retries, timeout_seconds. Override fields (SDK always wins):
-// structured_output, custom_headers, oauth2.
+// is the zero value.
 func (c *Config) MergeSDKConfig(data []byte) error {
 	var sdk SDKConfig
 	if err := yaml.Unmarshal(data, &sdk); err != nil {
 		return fmt.Errorf("parsing SDK config: %w", err)
 	}
-	if c.LLM.Provider == "" || c.LLM.Provider == DefaultConfig().LLM.Provider {
+	if c.AI.LLM.Provider == "" || c.AI.LLM.Provider == DefaultConfig().AI.LLM.Provider {
 		if sdk.LLM.Provider != "" {
-			c.LLM.Provider = sdk.LLM.Provider
+			c.AI.LLM.Provider = sdk.LLM.Provider
 		}
 	}
-	if c.LLM.Model == "" && sdk.LLM.Model != "" {
-		c.LLM.Model = sdk.LLM.Model
+	if c.AI.LLM.Model == "" && sdk.LLM.Model != "" {
+		c.AI.LLM.Model = sdk.LLM.Model
 	}
-	if c.LLM.Endpoint == "" && sdk.LLM.Endpoint != "" {
-		c.LLM.Endpoint = sdk.LLM.Endpoint
+	if c.AI.LLM.Endpoint == "" && sdk.LLM.Endpoint != "" {
+		c.AI.LLM.Endpoint = sdk.LLM.Endpoint
 	}
-	if c.LLM.APIKey == "" && sdk.LLM.APIKey != "" {
-		c.LLM.APIKey = sdk.LLM.APIKey
+	if c.AI.LLM.APIKey == "" && sdk.LLM.APIKey != "" {
+		c.AI.LLM.APIKey = sdk.LLM.APIKey
 	}
-	if c.LLM.VertexProject == "" && sdk.LLM.VertexProject != "" {
-		c.LLM.VertexProject = sdk.LLM.VertexProject
+	if c.AI.LLM.VertexProject == "" && sdk.LLM.VertexProject != "" {
+		c.AI.LLM.VertexProject = sdk.LLM.VertexProject
 	}
-	if c.LLM.VertexLocation == "" && sdk.LLM.VertexLocation != "" {
-		c.LLM.VertexLocation = sdk.LLM.VertexLocation
+	if c.AI.LLM.VertexLocation == "" && sdk.LLM.VertexLocation != "" {
+		c.AI.LLM.VertexLocation = sdk.LLM.VertexLocation
 	}
-	if c.LLM.BedrockRegion == "" && sdk.LLM.BedrockRegion != "" {
-		c.LLM.BedrockRegion = sdk.LLM.BedrockRegion
+	if c.AI.LLM.BedrockRegion == "" && sdk.LLM.BedrockRegion != "" {
+		c.AI.LLM.BedrockRegion = sdk.LLM.BedrockRegion
 	}
-	if c.LLM.AzureAPIVersion == "" && sdk.LLM.AzureAPIVersion != "" {
-		c.LLM.AzureAPIVersion = sdk.LLM.AzureAPIVersion
+	if c.AI.LLM.AzureAPIVersion == "" && sdk.LLM.AzureAPIVersion != "" {
+		c.AI.LLM.AzureAPIVersion = sdk.LLM.AzureAPIVersion
 	}
-	if c.LLM.Temperature == 0 && sdk.LLM.Temperature != 0 {
-		c.LLM.Temperature = sdk.LLM.Temperature
+	if c.AI.LLM.Temperature == 0 && sdk.LLM.Temperature != 0 {
+		c.AI.LLM.Temperature = sdk.LLM.Temperature
 	}
-	if c.LLM.MaxRetries == 0 && sdk.LLM.MaxRetries != 0 {
-		c.LLM.MaxRetries = sdk.LLM.MaxRetries
+	if c.AI.LLM.MaxRetries == 0 && sdk.LLM.MaxRetries != 0 {
+		c.AI.LLM.MaxRetries = sdk.LLM.MaxRetries
 	}
-	if c.LLM.TimeoutSeconds == 0 && sdk.LLM.TimeoutSeconds != 0 {
-		c.LLM.TimeoutSeconds = sdk.LLM.TimeoutSeconds
+	if c.AI.LLM.TimeoutSeconds == 0 && sdk.LLM.TimeoutSeconds != 0 {
+		c.AI.LLM.TimeoutSeconds = sdk.LLM.TimeoutSeconds
 	}
-	c.LLM.StructuredOutput = sdk.LLM.StructuredOutput
-	c.LLM.CustomHeaders = sdk.LLM.CustomHeaders
-	c.LLM.OAuth2 = sdk.LLM.OAuth2
+	c.AI.LLM.StructuredOutput = sdk.LLM.StructuredOutput
+	c.AI.LLM.CustomHeaders = sdk.LLM.CustomHeaders
+	c.AI.LLM.OAuth2 = sdk.LLM.OAuth2
 	return nil
 }
 
 // Validate checks required fields and value constraints.
 func (c *Config) Validate() error {
-	if c.Logging.Level != "" {
+	if c.Runtime.Logging.Level != "" {
 		validLevels := map[string]bool{"DEBUG": true, "INFO": true, "WARN": true, "ERROR": true}
-		if !validLevels[strings.ToUpper(c.Logging.Level)] {
-			return fmt.Errorf("invalid log level: %s (must be DEBUG, INFO, WARN, or ERROR)", c.Logging.Level)
+		if !validLevels[strings.ToUpper(c.Runtime.Logging.Level)] {
+			return fmt.Errorf("invalid log level: %s (must be DEBUG, INFO, WARN, or ERROR)", c.Runtime.Logging.Level)
 		}
 	}
-	switch c.LLM.Provider {
+	switch c.AI.LLM.Provider {
 	case "bedrock", "huggingface", "anthropic", "openai", "vertex", "vertex_ai":
-		// endpoint is optional: LangChainGo uses default endpoints or project/location for these providers
 	default:
-		if c.LLM.Endpoint == "" {
-			return fmt.Errorf("llm.endpoint is required for provider %q", c.LLM.Provider)
+		if c.AI.LLM.Endpoint == "" {
+			return fmt.Errorf("ai.llm.endpoint is required for provider %q", c.AI.LLM.Provider)
 		}
 	}
-	if c.LLM.Model == "" {
-		return fmt.Errorf("llm.model is required")
+	if c.AI.LLM.Model == "" {
+		return fmt.Errorf("ai.llm.model is required")
 	}
-	if c.Investigator.MaxTurns <= 0 {
-		return fmt.Errorf("investigator.max_turns must be positive, got %d", c.Investigator.MaxTurns)
+	if c.AI.Investigation.MaxTurns <= 0 {
+		return fmt.Errorf("ai.investigation.maxTurns must be positive, got %d", c.AI.Investigation.MaxTurns)
 	}
-	if c.LLM.OAuth2.Enabled {
-		if c.LLM.OAuth2.TokenURL == "" {
-			return fmt.Errorf("llm.oauth2.token_url is required when oauth2.enabled=true")
+	if c.AI.LLM.OAuth2.Enabled {
+		if c.AI.LLM.OAuth2.TokenURL == "" {
+			return fmt.Errorf("ai.llm.oauth2.tokenURL is required when oauth2.enabled=true")
 		}
-		if c.LLM.OAuth2.ClientID == "" {
-			return fmt.Errorf("llm.oauth2.client_id is required when oauth2.enabled=true")
+		if c.AI.LLM.OAuth2.ClientID == "" {
+			return fmt.Errorf("ai.llm.oauth2.clientID is required when oauth2.enabled=true")
 		}
-		if c.LLM.OAuth2.ClientSecret == "" {
-			return fmt.Errorf("llm.oauth2.client_secret is required when oauth2.enabled=true")
+		if c.AI.LLM.OAuth2.ClientSecret == "" {
+			return fmt.Errorf("ai.llm.oauth2.clientSecret is required when oauth2.enabled=true")
 		}
 	}
-	if c.AlignmentCheck.Enabled {
-		if c.AlignmentCheck.Timeout <= 0 {
-			return fmt.Errorf("alignmentCheck.timeout must be positive when enabled, got %v", c.AlignmentCheck.Timeout)
+	if c.AI.AlignmentCheck.Enabled {
+		if c.AI.AlignmentCheck.Timeout <= 0 {
+			return fmt.Errorf("ai.alignmentCheck.timeout must be positive when enabled, got %v", c.AI.AlignmentCheck.Timeout)
 		}
-		if c.AlignmentCheck.MaxStepTokens <= 0 {
-			return fmt.Errorf("alignmentCheck.maxStepTokens must be positive when enabled, got %d", c.AlignmentCheck.MaxStepTokens)
+		if c.AI.AlignmentCheck.MaxStepTokens <= 0 {
+			return fmt.Errorf("ai.alignmentCheck.maxStepTokens must be positive when enabled, got %d", c.AI.AlignmentCheck.MaxStepTokens)
 		}
-		if c.AlignmentCheck.LLM != nil {
-			merged := c.AlignmentCheck.EffectiveLLM(c.LLM)
+		if c.AI.AlignmentCheck.LLM != nil {
+			merged := c.AI.AlignmentCheck.EffectiveLLM(c.AI.LLM)
 			switch merged.Provider {
 			case "bedrock", "huggingface", "anthropic", "openai":
 			default:
 				if merged.Endpoint == "" {
-					return fmt.Errorf("alignmentCheck.llm.endpoint is required for provider %q", merged.Provider)
+					return fmt.Errorf("ai.alignmentCheck.llm.endpoint is required for provider %q", merged.Provider)
 				}
 			}
 			if merged.Model == "" {
-				return fmt.Errorf("alignmentCheck.llm.model is required when alignmentCheck.llm is set")
+				return fmt.Errorf("ai.alignmentCheck.llm.model is required when alignmentCheck.llm is set")
 			}
 		}
 	}
@@ -371,35 +383,43 @@ func (c *Config) Validate() error {
 // DefaultConfig returns a Config with production defaults applied.
 func DefaultConfig() *Config {
 	return &Config{
-		Logging:      LoggingConfig{Level: "INFO"},
-		LLM:          LLMConfig{Provider: "openai"},
-		DataStorage:  DataStorageConfig{SATokenPath: "/var/run/secrets/kubernetes.io/serviceaccount/token"},
-		Server:       ServerConfig{Address: "0.0.0.0", Port: 8080, HealthAddr: ":8081", MetricsAddr: ":9090"},
-		Session:      SessionConfig{TTL: 30 * time.Minute},
-		Investigator: InvestigatorConfig{MaxTurns: 15},
-		Audit:        AuditConfig{Enabled: true},
-		Anomaly: AnomalyConfig{
-			MaxToolCallsPerTool: 10,
-			MaxTotalToolCalls:   30,
-			MaxRepeatedFailures: 3,
-			ExemptPrefixes:      []string{"todo_"},
+		Runtime: RuntimeConfig{
+			Logging: LoggingConfig{Level: "INFO"},
+			Server:  ServerConfig{Address: "0.0.0.0", Port: 8080, HealthAddr: ":8081", MetricsAddr: ":9090"},
+			Session: SessionConfig{TTL: 30 * time.Minute},
+			Audit:   AuditConfig{Enabled: true},
 		},
-		Sanitization: SanitizationConfig{
-			InjectionPatternsEnabled: true,
-			CredentialScrubEnabled:   true,
+		AI: AIConfig{
+			LLM:           LLMConfig{Provider: "openai"},
+			Investigation: InvestigationConfig{MaxTurns: 40},
+			Summarizer: SummarizerConfig{
+				Threshold:         8000,
+				MaxToolOutputSize: DefaultMaxToolOutputSize,
+			},
+			Enrichment: EnrichmentConfig{
+				MaxRetries:  3,
+				BaseBackoff: 1 * time.Second,
+			},
+			AlignmentCheck: AlignmentCheckConfig{
+				Enabled:       false,
+				Timeout:       10 * time.Second,
+				MaxStepTokens: 500,
+			},
+			Safety: SafetyConfig{
+				Sanitization: SanitizationConfig{
+					InjectionPatternsEnabled: true,
+					CredentialScrubEnabled:   true,
+				},
+				Anomaly: AnomalyConfig{
+					MaxToolCallsPerTool: 10,
+					MaxTotalToolCalls:   30,
+					MaxRepeatedFailures: 3,
+					ExemptPrefixes:      []string{"todo_"},
+				},
+			},
 		},
-		Summarizer: SummarizerConfig{
-			Threshold:         8000,
-			MaxToolOutputSize: DefaultMaxToolOutputSize,
-		},
-		AlignmentCheck: AlignmentCheckConfig{
-			Enabled:       false,
-			Timeout:       10 * time.Second,
-			MaxStepTokens: 500,
-		},
-		Enrichment: EnrichmentConfig{
-			MaxRetries:  3,
-			BaseBackoff: 1 * time.Second,
+		Integrations: IntegrationsConfig{
+			DataStorage: DataStorageConfig{SATokenPath: "/var/run/secrets/kubernetes.io/serviceaccount/token"},
 		},
 	}
 }

--- a/test/infrastructure/kubernautagent.go
+++ b/test/infrastructure/kubernautagent.go
@@ -683,33 +683,34 @@ metadata:
   namespace: %s
 data:
   config.yaml: |
-    llm:
-      provider: "openai"
-      model: "mock-model"
-      endpoint: "http://mock-llm:8080"
-      apiKey: "mock-api-key-for-e2e"
-    server:
-      tls:
-        certDir: /etc/tls
-    dataStorage:
-      url: "https://data-storage-service:8080"
-    logging:
-      level: "debug"
-    audit:
-      flushIntervalSeconds: 0.1
-      bufferSize: 10000
-      batchSize: 50
-    auth:
-      resource_name: "kubernaut-agent"
-    alignmentCheck:
-      enabled: true
-      timeout: "10s"
-      maxStepTokens: 500
+    runtime:
+      logging:
+        level: "debug"
+      server:
+        tls:
+          certDir: /etc/tls
+      audit:
+        flushIntervalSeconds: 0.1
+        bufferSize: 10000
+        batchSize: 50
+    ai:
       llm:
         provider: "openai"
-        model: "shadow-eval"
-        endpoint: "http://mock-llm-shadow:8080"
-        api_key: "mock-shadow-key"
+        model: "mock-model"
+        endpoint: "http://mock-llm:8080"
+        apiKey: "mock-api-key-for-e2e"
+      alignmentCheck:
+        enabled: true
+        timeout: "10s"
+        maxStepTokens: 500
+        llm:
+          provider: "openai"
+          model: "shadow-eval"
+          endpoint: "http://mock-llm-shadow:8080"
+          apiKey: "mock-shadow-key"
+    integrations:
+      dataStorage:
+        url: "https://data-storage-service:8080"
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/test/integration/aianalysis/hapi-config/config.yaml
+++ b/test/integration/aianalysis/hapi-config/config.yaml
@@ -1,10 +1,10 @@
-logging:
-  level: "INFO"
-
-dataStorage:
-  url: "http://host.containers.internal:18095"
-
-audit:
-  flushIntervalSeconds: 0.1
-  bufferSize: 10000
-  batchSize: 50
+runtime:
+  logging:
+    level: "INFO"
+  audit:
+    flushIntervalSeconds: 0.1
+    bufferSize: 10000
+    batchSize: 50
+integrations:
+  dataStorage:
+    url: "http://host.containers.internal:18095"

--- a/test/integration/aianalysis/suite_test.go
+++ b/test/integration/aianalysis/suite_test.go
@@ -535,25 +535,26 @@ var _ = SynchronizedBeforeSuite(NodeTimeout(10*time.Minute), func(specCtx SpecCo
 		dsURL = "http://host.containers.internal:18095"
 	}
 
-	kaConfigContent := fmt.Sprintf(`llm:
-  provider: "openai"
-  model: "mock-model"
-  endpoint: "%s"
-  apiKey: "mock-api-key-for-integration-tests"
-dataStorage:
-  url: "%s"
-logging:
-  level: "debug"
-server:
-  port: 18120
-  healthAddr: ":18121"
-  metricsAddr: ":18122"
-audit:
-  flushIntervalSeconds: 0.1
-  bufferSize: 10000
-  batchSize: 50
-auth:
-  resource_name: "kubernaut-agent"
+	kaConfigContent := fmt.Sprintf(`runtime:
+  logging:
+    level: "debug"
+  server:
+    port: 18120
+    healthAddr: ":18121"
+    metricsAddr: ":18122"
+  audit:
+    flushIntervalSeconds: 0.1
+    bufferSize: 10000
+    batchSize: 50
+ai:
+  llm:
+    provider: "openai"
+    model: "mock-model"
+    endpoint: "%s"
+    apiKey: "mock-api-key-for-integration-tests"
+integrations:
+  dataStorage:
+    url: "%s"
 `, llmEndpoint, dsURL)
 	kaConfigPath := filepath.Join(kaConfigDir, "config.yaml")
 	err = os.WriteFile(kaConfigPath, []byte(kaConfigContent), 0644)

--- a/test/unit/kubernautagent/alignment/alignment_test.go
+++ b/test/unit/kubernautagent/alignment/alignment_test.go
@@ -823,10 +823,10 @@ var _ = Describe("Correctness fixes — BR-AI-601", func() {
 	Describe("UT-SA-601-CX-004: Config verdictTimeout must be positive when enabled", func() {
 		It("should reject AlignmentCheck with Timeout <= 0 when enabled", func() {
 			cfg := config.DefaultConfig()
-			cfg.LLM.Model = "test-model"
-			cfg.AlignmentCheck.Enabled = true
-			cfg.AlignmentCheck.Timeout = 0
-			cfg.AlignmentCheck.MaxStepTokens = 500
+			cfg.AI.LLM.Model = "test-model"
+			cfg.AI.AlignmentCheck.Enabled = true
+			cfg.AI.AlignmentCheck.Timeout = 0
+			cfg.AI.AlignmentCheck.MaxStepTokens = 500
 
 			err := cfg.Validate()
 			Expect(err).To(HaveOccurred())

--- a/test/unit/kubernautagent/config/config_684_test.go
+++ b/test/unit/kubernautagent/config/config_684_test.go
@@ -31,9 +31,10 @@ var _ = Describe("Vertex AI + Claude Regression — #684", func() {
 
 		BeforeEach(func() {
 			mainYAML = []byte(`
-llm:
-  provider: "vertex_ai"
-  model: "claude-sonnet-4-6"
+ai:
+  llm:
+    provider: "vertex_ai"
+    model: "claude-sonnet-4-6"
 `)
 		})
 
@@ -47,7 +48,7 @@ llm:
 			cfg, err := config.Load(mainYAML)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
-			Expect(cfg.LLM.Endpoint).To(Equal("https://europe-west1-aiplatform.googleapis.com")) // pre-commit:allow-sensitive (test fixture)
+			Expect(cfg.AI.LLM.Endpoint).To(Equal("https://europe-west1-aiplatform.googleapis.com")) // pre-commit:allow-sensitive (test fixture)
 		})
 
 		It("UT-KA-684-002: merges vertex_project from SDK config when main has none", func() {
@@ -60,7 +61,7 @@ llm:
 			cfg, err := config.Load(mainYAML)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
-			Expect(cfg.LLM.VertexProject).To(Equal("my-gcp-project"))
+			Expect(cfg.AI.LLM.VertexProject).To(Equal("my-gcp-project"))
 		})
 
 		It("UT-KA-684-003: merges vertex_location from SDK config when main has none", func() {
@@ -73,7 +74,7 @@ llm:
 			cfg, err := config.Load(mainYAML)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
-			Expect(cfg.LLM.VertexLocation).To(Equal("europe-west1"))
+			Expect(cfg.AI.LLM.VertexLocation).To(Equal("europe-west1"))
 		})
 
 		It("UT-KA-684-004: merges api_key from SDK config when main has none", func() {
@@ -86,7 +87,7 @@ llm:
 			cfg, err := config.Load(mainYAML)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
-			Expect(cfg.LLM.APIKey).To(Equal("sk-test-from-sdk"))
+			Expect(cfg.AI.LLM.APIKey).To(Equal("sk-test-from-sdk"))
 		})
 
 		It("UT-KA-684-005: merges temperature from SDK config", func() {
@@ -99,7 +100,7 @@ llm:
 			cfg, err := config.Load(mainYAML)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
-			Expect(cfg.LLM.Temperature).To(BeNumerically("~", 0.7, 0.001))
+			Expect(cfg.AI.LLM.Temperature).To(BeNumerically("~", 0.7, 0.001))
 		})
 
 		It("UT-KA-684-006: merges max_retries and timeout_seconds from SDK config", func() {
@@ -113,16 +114,17 @@ llm:
 			cfg, err := config.Load(mainYAML)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
-			Expect(cfg.LLM.MaxRetries).To(Equal(3))
-			Expect(cfg.LLM.TimeoutSeconds).To(Equal(120))
+			Expect(cfg.AI.LLM.MaxRetries).To(Equal(3))
+			Expect(cfg.AI.LLM.TimeoutSeconds).To(Equal(120))
 		})
 
 		It("UT-KA-684-007: main config endpoint takes precedence over SDK (gap-fill)", func() {
 			mainWithEndpoint := []byte(`
-llm:
-  provider: "vertex_ai"
-  model: "claude-sonnet-4-6"
-  endpoint: "http://main-endpoint"
+ai:
+  llm:
+    provider: "vertex_ai"
+    model: "claude-sonnet-4-6"
+    endpoint: "http://main-endpoint"
 `)
 			sdkYAML := []byte(`
 llm:
@@ -133,7 +135,7 @@ llm:
 			cfg, err := config.Load(mainWithEndpoint)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
-			Expect(cfg.LLM.Endpoint).To(Equal("http://main-endpoint"))
+			Expect(cfg.AI.LLM.Endpoint).To(Equal("http://main-endpoint"))
 		})
 
 		It("UT-KA-684-008: merges bedrock_region from SDK config when main has none", func() {
@@ -144,14 +146,15 @@ llm:
   bedrockRegion: "eu-west-1"
 `)
 			mainBedrock := []byte(`
-llm:
-  provider: "bedrock"
-  model: "anthropic.claude-3-sonnet"
+ai:
+  llm:
+    provider: "bedrock"
+    model: "anthropic.claude-3-sonnet"
 `)
 			cfg, err := config.Load(mainBedrock)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
-			Expect(cfg.LLM.BedrockRegion).To(Equal("eu-west-1"))
+			Expect(cfg.AI.LLM.BedrockRegion).To(Equal("eu-west-1"))
 		})
 
 		It("UT-KA-684-009: merges azure_api_version from SDK config when main has none", func() {
@@ -162,21 +165,23 @@ llm:
   azureApiVersion: "2024-02-15-preview"
 `)
 			mainAzure := []byte(`
-llm:
-  provider: "azure"
-  model: "gpt-4"
-  endpoint: "https://my-resource.openai.azure.com" # pre-commit:allow-sensitive (test fixture)
+ai:
+  llm:
+    provider: "azure"
+    model: "gpt-4"
+    endpoint: "https://my-resource.openai.azure.com" # pre-commit:allow-sensitive (test fixture)
 `)
 			cfg, err := config.Load(mainAzure)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
-			Expect(cfg.LLM.AzureAPIVersion).To(Equal("2024-02-15-preview"))
+			Expect(cfg.AI.LLM.AzureAPIVersion).To(Equal("2024-02-15-preview"))
 		})
 
 		It("UT-KA-684-010: existing provider/model gap-fill semantics unchanged", func() {
 			minimalMain := []byte(`
-llm:
-  endpoint: "http://localhost:11434/v1"
+ai:
+  llm:
+    endpoint: "http://localhost:11434/v1"
 `)
 			sdkYAML := []byte(`
 llm:
@@ -186,9 +191,9 @@ llm:
 			cfg, err := config.Load(minimalMain)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
-			Expect(cfg.LLM.Provider).To(Equal("anthropic"))
-			Expect(cfg.LLM.Model).To(Equal("claude-sonnet-4-20250514"))
-			Expect(cfg.LLM.Endpoint).To(Equal("http://localhost:11434/v1"),
+			Expect(cfg.AI.LLM.Provider).To(Equal("anthropic"))
+			Expect(cfg.AI.LLM.Model).To(Equal("claude-sonnet-4-20250514"))
+			Expect(cfg.AI.LLM.Endpoint).To(Equal("http://localhost:11434/v1"),
 				"main config endpoint must not be overwritten")
 		})
 	})
@@ -197,9 +202,10 @@ llm:
 	Describe("Bug 2: Validate() endpoint exemptions", func() {
 		It("UT-KA-684-103: accepts vertex_ai provider with no endpoint", func() {
 			yaml := []byte(`
-llm:
-  provider: "vertex_ai"
-  model: "claude-sonnet-4-6"
+ai:
+  llm:
+    provider: "vertex_ai"
+    model: "claude-sonnet-4-6"
 `)
 			cfg, err := config.Load(yaml)
 			Expect(err).NotTo(HaveOccurred())
@@ -208,9 +214,10 @@ llm:
 
 		It("UT-KA-684-103b: accepts vertex provider with no endpoint", func() {
 			yaml := []byte(`
-llm:
-  provider: "vertex"
-  model: "gemini-1.5-pro"
+ai:
+  llm:
+    provider: "vertex"
+    model: "gemini-1.5-pro"
 `)
 			cfg, err := config.Load(yaml)
 			Expect(err).NotTo(HaveOccurred())
@@ -219,9 +226,10 @@ llm:
 
 		It("UT-KA-684-104: still rejects mistral provider with no endpoint", func() {
 			yaml := []byte(`
-llm:
-  provider: "mistral"
-  model: "mistral-large"
+ai:
+  llm:
+    provider: "mistral"
+    model: "mistral-large"
 `)
 			cfg, err := config.Load(yaml)
 			Expect(err).NotTo(HaveOccurred())

--- a/test/unit/kubernautagent/config/config_test.go
+++ b/test/unit/kubernautagent/config/config_test.go
@@ -30,60 +30,64 @@ var _ = Describe("Kubernaut Agent Configuration — #433", func() {
 	Describe("UT-KA-433-001: Kubernaut Agent loads valid YAML configuration", func() {
 		It("should parse all required fields from valid YAML", func() {
 			yaml := []byte(`
-llm:
-  endpoint: "http://localhost:11434/v1"
-  model: "llama3"
-  apiKey: "test-key"
-server:
-  address: "0.0.0.0"
-  port: 8080
-session:
-  ttl: 30m
-audit:
-  enabled: true
-  endpoint: "http://datastorage:8080"
-investigator:
-  maxTurns: 15
+ai:
+  llm:
+    endpoint: "http://localhost:11434/v1"
+    model: "llama3"
+    apiKey: "test-key"
+  investigation:
+    maxTurns: 15
+runtime:
+  server:
+    address: "0.0.0.0"
+    port: 8080
+  session:
+    ttl: 30m
+  audit:
+    enabled: true
+    endpoint: "http://datastorage:8080"
 `)
 			cfg, err := config.Load(yaml)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg).NotTo(BeNil())
-			Expect(cfg.LLM.Endpoint).To(Equal("http://localhost:11434/v1"))
-			Expect(cfg.LLM.Model).To(Equal("llama3"))
-			Expect(cfg.LLM.APIKey).To(Equal("test-key"))
-			Expect(cfg.Server.Port).To(Equal(8080))
-			Expect(cfg.Session.TTL).To(Equal(30 * time.Minute))
-			Expect(cfg.Audit.Enabled).To(BeTrue())
-			Expect(cfg.Investigator.MaxTurns).To(Equal(15))
+			Expect(cfg.AI.LLM.Endpoint).To(Equal("http://localhost:11434/v1"))
+			Expect(cfg.AI.LLM.Model).To(Equal("llama3"))
+			Expect(cfg.AI.LLM.APIKey).To(Equal("test-key"))
+			Expect(cfg.Runtime.Server.Port).To(Equal(8080))
+			Expect(cfg.Runtime.Session.TTL).To(Equal(30 * time.Minute))
+			Expect(cfg.Runtime.Audit.Enabled).To(BeTrue())
+			Expect(cfg.AI.Investigation.MaxTurns).To(Equal(15))
 		})
 	})
 
 	Describe("UT-KA-433-002: Kubernaut Agent applies correct defaults", func() {
 		It("should fill defaults when optional fields are omitted", func() {
 			yaml := []byte(`
-llm:
-  endpoint: "http://localhost:11434/v1"
-  model: "llama3"
+ai:
+  llm:
+    endpoint: "http://localhost:11434/v1"
+    model: "llama3"
 `)
 			cfg, err := config.Load(yaml)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg).NotTo(BeNil())
 
-			Expect(cfg.Server.Port).To(Equal(8080), "default port should be 8080")
-			Expect(cfg.Session.TTL).To(Equal(30*time.Minute), "default TTL should be 30m")
-			Expect(cfg.Investigator.MaxTurns).To(Equal(15), "default max turns should be 15")
-			Expect(cfg.Anomaly.MaxToolCallsPerTool).To(Equal(10), "UT-KA-860-006: default per-tool limit raised to 10 per #860")
-			Expect(cfg.Anomaly.MaxTotalToolCalls).To(Equal(30), "default total tool calls should be 30")
-			Expect(cfg.Anomaly.MaxRepeatedFailures).To(Equal(3), "default repeated failures should be 3")
+			Expect(cfg.Runtime.Server.Port).To(Equal(8080), "default port should be 8080")
+			Expect(cfg.Runtime.Session.TTL).To(Equal(30*time.Minute), "default TTL should be 30m")
+			Expect(cfg.AI.Investigation.MaxTurns).To(Equal(40), "default max turns should be 40")
+			Expect(cfg.AI.Safety.Anomaly.MaxToolCallsPerTool).To(Equal(10), "UT-KA-860-006: default per-tool limit raised to 10 per #860")
+			Expect(cfg.AI.Safety.Anomaly.MaxTotalToolCalls).To(Equal(30), "default total tool calls should be 30")
+			Expect(cfg.AI.Safety.Anomaly.MaxRepeatedFailures).To(Equal(3), "default repeated failures should be 3")
 		})
 	})
 
 	Describe("UT-KA-433-003: Kubernaut Agent rejects invalid config at startup", func() {
 		It("should reject missing LLM endpoint for non-exempt providers", func() {
 			yaml := []byte(`
-llm:
-  provider: "mistral"
-  model: "mistral-large"
+ai:
+  llm:
+    provider: "mistral"
+    model: "mistral-large"
 `)
 			cfg, err := config.Load(yaml)
 			if err == nil && cfg != nil {
@@ -95,9 +99,10 @@ llm:
 
 		It("should accept empty LLM endpoint for openai (LangChainGo uses default)", func() {
 			yaml := []byte(`
-llm:
-  provider: "openai"
-  model: "gpt-4o"
+ai:
+  llm:
+    provider: "openai"
+    model: "gpt-4o"
 `)
 			cfg, err := config.Load(yaml)
 			Expect(err).NotTo(HaveOccurred())
@@ -106,56 +111,60 @@ llm:
 
 		It("should reject invalid max-turns (zero)", func() {
 			yaml := []byte(`
-llm:
-  endpoint: "http://localhost:11434/v1"
-  model: "llama3"
-investigator:
-  maxTurns: 0
+ai:
+  llm:
+    endpoint: "http://localhost:11434/v1"
+    model: "llama3"
+  investigation:
+    maxTurns: 0
 `)
 			cfg, err := config.Load(yaml)
 			if err == nil && cfg != nil {
 				err = cfg.Validate()
 			}
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("max_turns"))
+			Expect(err.Error()).To(ContainSubstring("ai.investigation.maxTurns"))
 		})
 
 		It("should reject negative max-turns", func() {
 			yaml := []byte(`
-llm:
-  endpoint: "http://localhost:11434/v1"
-  model: "llama3"
-investigator:
-  maxTurns: -5
+ai:
+  llm:
+    endpoint: "http://localhost:11434/v1"
+    model: "llama3"
+  investigation:
+    maxTurns: -5
 `)
 			cfg, err := config.Load(yaml)
 			if err == nil && cfg != nil {
 				err = cfg.Validate()
 			}
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("max_turns"))
+			Expect(err.Error()).To(ContainSubstring("ai.investigation.maxTurns"))
 		})
 
 		It("should reject missing LLM model", func() {
 			yaml := []byte(`
-llm:
-  endpoint: "http://localhost:11434/v1"
+ai:
+  llm:
+    endpoint: "http://localhost:11434/v1"
 `)
 			cfg, err := config.Load(yaml)
 			if err == nil && cfg != nil {
 				err = cfg.Validate()
 			}
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("llm.model"))
+			Expect(err.Error()).To(ContainSubstring("ai.llm.model"))
 		})
 	})
 
 	Describe("UT-KA-SO-CFG-001: structured_output flag sourced from SDK config", func() {
 		It("should parse structured_output=true from SDK YAML via MergeSDKConfig", func() {
 			mainYAML := []byte(`
-llm:
-  provider: "anthropic"
-  model: "claude-sonnet-4-20250514"
+ai:
+  llm:
+    provider: "anthropic"
+    model: "claude-sonnet-4-20250514"
 `)
 			sdkYAML := []byte(`
 llm:
@@ -166,14 +175,15 @@ llm:
 			cfg, err := config.Load(mainYAML)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
-			Expect(cfg.LLM.StructuredOutput).To(BeTrue())
+			Expect(cfg.AI.LLM.StructuredOutput).To(BeTrue())
 		})
 
 		It("should default structured_output to false when omitted from SDK config", func() {
 			mainYAML := []byte(`
-llm:
-  provider: "openai"
-  model: "gpt-4o"
+ai:
+  llm:
+    provider: "openai"
+    model: "gpt-4o"
 `)
 			sdkYAML := []byte(`
 llm:
@@ -183,16 +193,17 @@ llm:
 			cfg, err := config.Load(mainYAML)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
-			Expect(cfg.LLM.StructuredOutput).To(BeFalse())
+			Expect(cfg.AI.LLM.StructuredOutput).To(BeFalse())
 		})
 	})
 
 	Describe("UT-KA-SO-CFG-002: custom_headers sourced from SDK config", func() {
 		It("should parse custom_headers from SDK YAML via MergeSDKConfig", func() {
 			mainYAML := []byte(`
-llm:
-  provider: "openai"
-  model: "gpt-4o"
+ai:
+  llm:
+    provider: "openai"
+    model: "gpt-4o"
 `)
 			sdkYAML := []byte(`
 llm:
@@ -207,17 +218,18 @@ llm:
 			cfg, err := config.Load(mainYAML)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
-			Expect(cfg.LLM.CustomHeaders).To(HaveLen(2))
-			Expect(cfg.LLM.CustomHeaders[0].Name).To(Equal("X-Custom-Auth"))
-			Expect(cfg.LLM.CustomHeaders[0].Value).To(Equal("Bearer token123"))
-			Expect(cfg.LLM.CustomHeaders[1].Name).To(Equal("X-Org-Id"))
+			Expect(cfg.AI.LLM.CustomHeaders).To(HaveLen(2))
+			Expect(cfg.AI.LLM.CustomHeaders[0].Name).To(Equal("X-Custom-Auth"))
+			Expect(cfg.AI.LLM.CustomHeaders[0].Value).To(Equal("Bearer token123"))
+			Expect(cfg.AI.LLM.CustomHeaders[1].Name).To(Equal("X-Org-Id"))
 		})
 
 		It("should default custom_headers to nil when omitted from SDK config", func() {
 			mainYAML := []byte(`
-llm:
-  provider: "openai"
-  model: "gpt-4o"
+ai:
+  llm:
+    provider: "openai"
+    model: "gpt-4o"
 `)
 			sdkYAML := []byte(`
 llm:
@@ -227,37 +239,38 @@ llm:
 			cfg, err := config.Load(mainYAML)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
-			Expect(cfg.LLM.CustomHeaders).To(BeEmpty())
+			Expect(cfg.AI.LLM.CustomHeaders).To(BeEmpty())
 		})
 	})
 
 	Describe("UT-KA-433W-010: DefaultConfig applies summarizer threshold", func() {
 		It("should set Summarizer.Threshold to 8000", func() {
 			cfg := config.DefaultConfig()
-			Expect(cfg.Summarizer.Threshold).To(Equal(8000))
+			Expect(cfg.AI.Summarizer.Threshold).To(Equal(8000))
 		})
 	})
 
 	Describe("UT-KA-752-010: MaxToolOutputSize parsed from YAML configuration", func() {
 		It("should parse max_tool_output_size from summarizer config", func() {
 			yaml := []byte(`
-llm:
-  endpoint: "http://localhost:11434/v1"
-  model: "llama3"
-summarizer:
-  threshold: 8000
-  maxToolOutputSize: 50000
+ai:
+  llm:
+    endpoint: "http://localhost:11434/v1"
+    model: "llama3"
+  summarizer:
+    threshold: 8000
+    maxToolOutputSize: 50000
 `)
 			cfg, err := config.Load(yaml)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(cfg.Summarizer.MaxToolOutputSize).To(Equal(50000))
+			Expect(cfg.AI.Summarizer.MaxToolOutputSize).To(Equal(50000))
 		})
 	})
 
 	Describe("UT-KA-752-011: MaxToolOutputSize default applied when absent", func() {
 		It("should default MaxToolOutputSize to DefaultMaxToolOutputSize when not specified", func() {
 			cfg := config.DefaultConfig()
-			Expect(cfg.Summarizer.MaxToolOutputSize).To(Equal(config.DefaultMaxToolOutputSize),
+			Expect(cfg.AI.Summarizer.MaxToolOutputSize).To(Equal(config.DefaultMaxToolOutputSize),
 				"default MaxToolOutputSize should match DefaultMaxToolOutputSize constant")
 		})
 	})
@@ -265,9 +278,9 @@ summarizer:
 	Describe("UT-KA-433W-011: DefaultConfig applies anomaly thresholds", func() {
 		It("should set MaxToolCallsPerTool=10, MaxTotalToolCalls=30, MaxRepeatedFailures=3 (#860)", func() {
 			cfg := config.DefaultConfig()
-			Expect(cfg.Anomaly.MaxToolCallsPerTool).To(Equal(10))
-			Expect(cfg.Anomaly.MaxTotalToolCalls).To(Equal(30))
-			Expect(cfg.Anomaly.MaxRepeatedFailures).To(Equal(3))
+			Expect(cfg.AI.Safety.Anomaly.MaxToolCallsPerTool).To(Equal(10))
+			Expect(cfg.AI.Safety.Anomaly.MaxTotalToolCalls).To(Equal(30))
+			Expect(cfg.AI.Safety.Anomaly.MaxRepeatedFailures).To(Equal(3))
 		})
 	})
 
@@ -276,9 +289,10 @@ summarizer:
 
 		BeforeEach(func() {
 			mainYAML = []byte(`
-llm:
-  provider: "anthropic"
-  model: "claude-sonnet-4-20250514"
+ai:
+  llm:
+    provider: "anthropic"
+    model: "claude-sonnet-4-20250514"
 `)
 		})
 
@@ -300,11 +314,11 @@ llm:
 				cfg, err := config.Load(mainYAML)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
-				Expect(cfg.LLM.OAuth2.Enabled).To(BeTrue())
-				Expect(cfg.LLM.OAuth2.TokenURL).To(Equal("https://keycloak.acme.com/realms/infra/protocol/openid-connect/token"))
-				Expect(cfg.LLM.OAuth2.ClientID).To(Equal("kubernaut-agent"))
-				Expect(cfg.LLM.OAuth2.ClientSecret).To(Equal("s3cret"))
-				Expect(cfg.LLM.OAuth2.Scopes).To(Equal([]string{"openid", "llm-gateway"}))
+				Expect(cfg.AI.LLM.OAuth2.Enabled).To(BeTrue())
+				Expect(cfg.AI.LLM.OAuth2.TokenURL).To(Equal("https://keycloak.acme.com/realms/infra/protocol/openid-connect/token"))
+				Expect(cfg.AI.LLM.OAuth2.ClientID).To(Equal("kubernaut-agent"))
+				Expect(cfg.AI.LLM.OAuth2.ClientSecret).To(Equal("s3cret"))
+				Expect(cfg.AI.LLM.OAuth2.Scopes).To(Equal([]string{"openid", "llm-gateway"}))
 			})
 		})
 
@@ -319,7 +333,7 @@ llm:
 				cfg, err := config.Load(mainYAML)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
-				Expect(cfg.LLM.StructuredOutput).To(BeTrue())
+				Expect(cfg.AI.LLM.StructuredOutput).To(BeTrue())
 			})
 		})
 
@@ -338,47 +352,49 @@ llm:
 				cfg, err := config.Load(mainYAML)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
-				Expect(cfg.LLM.CustomHeaders).To(HaveLen(2))
-				Expect(cfg.LLM.CustomHeaders[0].Name).To(Equal("X-Custom-Auth"))
-				Expect(cfg.LLM.CustomHeaders[0].Value).To(Equal("Bearer token123"))
-				Expect(cfg.LLM.CustomHeaders[1].Name).To(Equal("X-Org-Id"))
-				Expect(cfg.LLM.CustomHeaders[1].Value).To(Equal("org-42"))
+				Expect(cfg.AI.LLM.CustomHeaders).To(HaveLen(2))
+				Expect(cfg.AI.LLM.CustomHeaders[0].Name).To(Equal("X-Custom-Auth"))
+				Expect(cfg.AI.LLM.CustomHeaders[0].Value).To(Equal("Bearer token123"))
+				Expect(cfg.AI.LLM.CustomHeaders[1].Name).To(Equal("X-Org-Id"))
+				Expect(cfg.AI.LLM.CustomHeaders[1].Value).To(Equal("org-42"))
 			})
 		})
 
 		Describe("UT-KA-CFG-SDK-004: Main config YAML with llm.oauth2 is ignored by config.Load()", func() {
 			It("should NOT parse oauth2 from main config YAML", func() {
 				mainWithOAuth := []byte(`
-llm:
-  provider: "anthropic"
-  model: "claude-sonnet-4-20250514"
-  oauth2:
-    enabled: true
-    tokenURL: "https://keycloak.acme.com/token"
-    clientID: "ka"
-    clientSecret: "secret"
-  structuredOutput: true
-  customHeaders:
-    - name: "X-Test"
-      value: "should-be-ignored"
+ai:
+  llm:
+    provider: "anthropic"
+    model: "claude-sonnet-4-20250514"
+    oauth2:
+      enabled: true
+      tokenURL: "https://keycloak.acme.com/token"
+      clientID: "ka"
+      clientSecret: "secret"
+    structuredOutput: true
+    customHeaders:
+      - name: "X-Test"
+        value: "should-be-ignored"
 `)
 				cfg, err := config.Load(mainWithOAuth)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(cfg.LLM.OAuth2.Enabled).To(BeFalse(), "oauth2 must not be parsed from main config")
-				Expect(cfg.LLM.OAuth2.TokenURL).To(BeEmpty())
-				Expect(cfg.LLM.OAuth2.ClientID).To(BeEmpty())
-				Expect(cfg.LLM.OAuth2.ClientSecret).To(BeEmpty())
-				Expect(cfg.LLM.OAuth2.Scopes).To(BeNil())
-				Expect(cfg.LLM.StructuredOutput).To(BeFalse(), "structured_output must not be parsed from main config")
-				Expect(cfg.LLM.CustomHeaders).To(BeEmpty(), "custom_headers must not be parsed from main config")
+				Expect(cfg.AI.LLM.OAuth2.Enabled).To(BeFalse(), "oauth2 must not be parsed from main config")
+				Expect(cfg.AI.LLM.OAuth2.TokenURL).To(BeEmpty())
+				Expect(cfg.AI.LLM.OAuth2.ClientID).To(BeEmpty())
+				Expect(cfg.AI.LLM.OAuth2.ClientSecret).To(BeEmpty())
+				Expect(cfg.AI.LLM.OAuth2.Scopes).To(BeNil())
+				Expect(cfg.AI.LLM.StructuredOutput).To(BeFalse(), "structured_output must not be parsed from main config")
+				Expect(cfg.AI.LLM.CustomHeaders).To(BeEmpty(), "custom_headers must not be parsed from main config")
 			})
 		})
 
 		Describe("UT-KA-CFG-SDK-005: Provider/model merge still works (regression)", func() {
 			It("should merge provider and model from SDK when main uses defaults", func() {
 				minimalMain := []byte(`
-llm:
-  endpoint: "http://localhost:11434/v1"
+ai:
+  llm:
+    endpoint: "http://localhost:11434/v1"
 `)
 				sdkYAML := []byte(`
 llm:
@@ -388,8 +404,8 @@ llm:
 				cfg, err := config.Load(minimalMain)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
-				Expect(cfg.LLM.Provider).To(Equal("anthropic"))
-				Expect(cfg.LLM.Model).To(Equal("claude-sonnet-4-20250514"))
+				Expect(cfg.AI.LLM.Provider).To(Equal("anthropic"))
+				Expect(cfg.AI.LLM.Model).To(Equal("claude-sonnet-4-20250514"))
 			})
 		})
 
@@ -407,9 +423,10 @@ llm:
 	Describe("UT-KA-417-020: OAuth2Config sourced from SDK config", func() {
 		It("should parse all OAuth2 fields from SDK YAML via MergeSDKConfig", func() {
 			mainYAML := []byte(`
-llm:
-  provider: "anthropic"
-  model: "claude-sonnet-4-20250514"
+ai:
+  llm:
+    provider: "anthropic"
+    model: "claude-sonnet-4-20250514"
 `)
 			sdkYAML := []byte(`
 llm:
@@ -427,20 +444,21 @@ llm:
 			cfg, err := config.Load(mainYAML)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
-			Expect(cfg.LLM.OAuth2.Enabled).To(BeTrue())
-			Expect(cfg.LLM.OAuth2.TokenURL).To(Equal("https://keycloak.acme.com/realms/infra/protocol/openid-connect/token"))
-			Expect(cfg.LLM.OAuth2.ClientID).To(Equal("kubernaut-agent"))
-			Expect(cfg.LLM.OAuth2.ClientSecret).To(Equal("s3cret"))
-			Expect(cfg.LLM.OAuth2.Scopes).To(Equal([]string{"openid", "llm-gateway"}))
+			Expect(cfg.AI.LLM.OAuth2.Enabled).To(BeTrue())
+			Expect(cfg.AI.LLM.OAuth2.TokenURL).To(Equal("https://keycloak.acme.com/realms/infra/protocol/openid-connect/token"))
+			Expect(cfg.AI.LLM.OAuth2.ClientID).To(Equal("kubernaut-agent"))
+			Expect(cfg.AI.LLM.OAuth2.ClientSecret).To(Equal("s3cret"))
+			Expect(cfg.AI.LLM.OAuth2.Scopes).To(Equal([]string{"openid", "llm-gateway"}))
 		})
 	})
 
 	Describe("UT-KA-417-021: OAuth2Config defaults to disabled when omitted from SDK", func() {
 		It("should have OAuth2 disabled with empty fields after SDK merge", func() {
 			mainYAML := []byte(`
-llm:
-  provider: "openai"
-  model: "gpt-4o"
+ai:
+  llm:
+    provider: "openai"
+    model: "gpt-4o"
 `)
 			sdkYAML := []byte(`
 llm:
@@ -450,20 +468,21 @@ llm:
 			cfg, err := config.Load(mainYAML)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
-			Expect(cfg.LLM.OAuth2.Enabled).To(BeFalse())
-			Expect(cfg.LLM.OAuth2.TokenURL).To(BeEmpty())
-			Expect(cfg.LLM.OAuth2.ClientID).To(BeEmpty())
-			Expect(cfg.LLM.OAuth2.ClientSecret).To(BeEmpty())
-			Expect(cfg.LLM.OAuth2.Scopes).To(BeNil())
+			Expect(cfg.AI.LLM.OAuth2.Enabled).To(BeFalse())
+			Expect(cfg.AI.LLM.OAuth2.TokenURL).To(BeEmpty())
+			Expect(cfg.AI.LLM.OAuth2.ClientID).To(BeEmpty())
+			Expect(cfg.AI.LLM.OAuth2.ClientSecret).To(BeEmpty())
+			Expect(cfg.AI.LLM.OAuth2.Scopes).To(BeNil())
 		})
 	})
 
 	Describe("UT-KA-417-022: Validate rejects missing token_url when oauth2 enabled", func() {
 		It("should return error identifying missing token_url", func() {
 			mainYAML := []byte(`
-llm:
-  provider: "anthropic"
-  model: "claude-sonnet-4-20250514"
+ai:
+  llm:
+    provider: "anthropic"
+    model: "claude-sonnet-4-20250514"
 `)
 			sdkYAML := []byte(`
 llm:
@@ -479,16 +498,17 @@ llm:
 			Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
 			err = cfg.Validate()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("token_url"))
+			Expect(err.Error()).To(ContainSubstring("tokenURL"))
 		})
 	})
 
 	Describe("UT-KA-417-023: Validate rejects missing client_id when oauth2 enabled", func() {
 		It("should return error identifying missing client_id", func() {
 			mainYAML := []byte(`
-llm:
-  provider: "anthropic"
-  model: "claude-sonnet-4-20250514"
+ai:
+  llm:
+    provider: "anthropic"
+    model: "claude-sonnet-4-20250514"
 `)
 			sdkYAML := []byte(`
 llm:
@@ -504,16 +524,17 @@ llm:
 			Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
 			err = cfg.Validate()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("client_id"))
+			Expect(err.Error()).To(ContainSubstring("clientID"))
 		})
 	})
 
 	Describe("UT-KA-417-024: Validate rejects missing client_secret when oauth2 enabled", func() {
 		It("should return error identifying missing client_secret", func() {
 			mainYAML := []byte(`
-llm:
-  provider: "anthropic"
-  model: "claude-sonnet-4-20250514"
+ai:
+  llm:
+    provider: "anthropic"
+    model: "claude-sonnet-4-20250514"
 `)
 			sdkYAML := []byte(`
 llm:
@@ -529,16 +550,17 @@ llm:
 			Expect(cfg.MergeSDKConfig(sdkYAML)).To(Succeed())
 			err = cfg.Validate()
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("client_secret"))
+			Expect(err.Error()).To(ContainSubstring("clientSecret"))
 		})
 	})
 
 	Describe("UT-KA-417-025: Validate accepts oauth2 disabled with empty fields", func() {
 		It("should not require OAuth2 fields when disabled in SDK config", func() {
 			mainYAML := []byte(`
-llm:
-  provider: "anthropic"
-  model: "claude-sonnet-4-20250514"
+ai:
+  llm:
+    provider: "anthropic"
+    model: "claude-sonnet-4-20250514"
 `)
 			sdkYAML := []byte(`
 llm:
@@ -555,9 +577,10 @@ llm:
 
 		It("should not require OAuth2 fields when section omitted from SDK config", func() {
 			mainYAML := []byte(`
-llm:
-  provider: "anthropic"
-  model: "claude-sonnet-4-20250514"
+ai:
+  llm:
+    provider: "anthropic"
+    model: "claude-sonnet-4-20250514"
 `)
 			sdkYAML := []byte(`
 llm:
@@ -571,4 +594,3 @@ llm:
 		})
 	})
 })
-

--- a/test/unit/kubernautagent/config/logging_test.go
+++ b/test/unit/kubernautagent/config/logging_test.go
@@ -30,33 +30,37 @@ var _ = Describe("Kubernaut Agent Logging Configuration — #875", func() {
 	Describe("UT-KA-875-001: DefaultConfig sets logging level to INFO", func() {
 		It("should default Logging.Level to INFO", func() {
 			cfg := config.DefaultConfig()
-			Expect(cfg.Logging.Level).To(Equal("INFO"))
+			Expect(cfg.Runtime.Logging.Level).To(Equal("INFO"))
 		})
 	})
 
 	Describe("UT-KA-875-002: Logging level parsed from YAML config", func() {
 		It("should parse logging.level from YAML", func() {
 			yamlData := []byte(`
-llm:
-  provider: "openai"
-  model: "gpt-4o"
-logging:
-  level: "DEBUG"
+ai:
+  llm:
+    provider: "openai"
+    model: "gpt-4o"
+runtime:
+  logging:
+    level: "DEBUG"
 `)
 			cfg, err := config.Load(yamlData)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(cfg.Logging.Level).To(Equal("DEBUG"))
+			Expect(cfg.Runtime.Logging.Level).To(Equal("DEBUG"))
 		})
 	})
 
 	Describe("UT-KA-875-003: Validate rejects invalid log level", func() {
 		It("should reject an unrecognized log level", func() {
 			yamlData := []byte(`
-llm:
-  provider: "openai"
-  model: "gpt-4o"
-logging:
-  level: "VERBOSE"
+ai:
+  llm:
+    provider: "openai"
+    model: "gpt-4o"
+runtime:
+  logging:
+    level: "VERBOSE"
 `)
 			cfg, err := config.Load(yamlData)
 			Expect(err).NotTo(HaveOccurred())
@@ -70,11 +74,13 @@ logging:
 		DescribeTable("valid log levels",
 			func(level string) {
 				yamlData := []byte(`
-llm:
-  provider: "openai"
-  model: "gpt-4o"
-logging:
-  level: "` + level + `"
+ai:
+  llm:
+    provider: "openai"
+    model: "gpt-4o"
+runtime:
+  logging:
+    level: "` + level + `"
 `)
 				cfg, err := config.Load(yamlData)
 				Expect(err).NotTo(HaveOccurred())
@@ -91,15 +97,17 @@ logging:
 		DescribeTable("level mapping",
 			func(level string, expected slog.Level) {
 				yamlData := []byte(`
-llm:
-  provider: "openai"
-  model: "gpt-4o"
-logging:
-  level: "` + level + `"
+ai:
+  llm:
+    provider: "openai"
+    model: "gpt-4o"
+runtime:
+  logging:
+    level: "` + level + `"
 `)
 				cfg, err := config.Load(yamlData)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(cfg.Logging.SlogLevel()).To(Equal(expected))
+				Expect(cfg.Runtime.Logging.SlogLevel()).To(Equal(expected))
 			},
 			Entry("DEBUG -> slog.LevelDebug", "DEBUG", slog.LevelDebug),
 			Entry("INFO -> slog.LevelInfo", "INFO", slog.LevelInfo),
@@ -111,7 +119,7 @@ logging:
 	Describe("UT-KA-875-006: SlogLevel defaults to INFO for empty level", func() {
 		It("should return slog.LevelInfo when level is empty", func() {
 			cfg := config.DefaultConfig()
-			Expect(cfg.Logging.SlogLevel()).To(Equal(slog.LevelInfo))
+			Expect(cfg.Runtime.Logging.SlogLevel()).To(Equal(slog.LevelInfo))
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- Reorganizes Kubernaut Agent configuration from flat top-level fields into 3 concern-based domains: `runtime` (operational), `ai` (LLM/investigation/safety), and `integrations` (external services)
- Renames `InvestigatorConfig` → `InvestigationConfig` (YAML key: `investigator` → `investigation`)
- Increases default `maxTurns` from 15 to 40
- Moves `TLSProfile` into `ServerConfig` (runtime.server.tlsProfile)

## Breaking Changes

The main config YAML structure changes from flat:
```yaml
llm:
  provider: "openai"
server:
  port: 8080
investigator:
  maxTurns: 15
```

To nested 3-domain:
```yaml
ai:
  llm:
    provider: "openai"
  investigation:
    maxTurns: 40
runtime:
  server:
    port: 8080
integrations:
  dataStorage:
    url: "http://..."
```

## Test plan

- [x] All 69 config unit tests pass
- [x] All 13 reload callback tests pass
- [x] All 53 alignment unit tests pass
- [x] `go build ./...` clean
- [x] `go vet` clean
- [x] Pre-commit hooks pass

Depends on: #909 (camelCase migration)
Part of: #908 (KA config restructuring sequence — PR2/5)


Made with [Cursor](https://cursor.com)