### PR TITLE
fix(#914): add image pull retry with exponential backoff to test infrastructure

### DIFF
--- a/test/infrastructure/datastorage.go
+++ b/test/infrastructure/datastorage.go
@@ -1716,6 +1716,12 @@ func startPostgreSQL(infra *DataStorageInfrastructure, cfg *DataStorageConfig, w
 	_ = exec.Command("podman", "stop", infra.PostgresContainer).Run()
 	_ = exec.Command("podman", "rm", infra.PostgresContainer).Run()
 
+	// Pull image with retry to handle transient registry failures (#914)
+	const postgresImage = "docker.io/library/postgres:16-alpine"
+	if err := PullImageWithRetry(postgresImage, 3, writer); err != nil {
+		return fmt.Errorf("failed to pull PostgreSQL image: %w", err)
+	}
+
 	// Start PostgreSQL
 	cmd := exec.Command("podman", "run", "-d",
 		"--name", infra.PostgresContainer,
@@ -1723,7 +1729,7 @@ func startPostgreSQL(infra *DataStorageInfrastructure, cfg *DataStorageConfig, w
 		"-e", fmt.Sprintf("POSTGRES_DB=%s", cfg.DBName),
 		"-e", fmt.Sprintf("POSTGRES_USER=%s", cfg.DBUser),
 		"-e", fmt.Sprintf("POSTGRES_PASSWORD=%s", cfg.DBPassword),
-		"docker.io/library/postgres:16-alpine")
+		postgresImage)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -1749,11 +1755,17 @@ func startRedis(infra *DataStorageInfrastructure, cfg *DataStorageConfig, writer
 	_ = exec.Command("podman", "stop", infra.RedisContainer).Run()
 	_ = exec.Command("podman", "rm", infra.RedisContainer).Run()
 
+	// Pull image with retry to handle transient registry failures (#914)
+	const redisImage = "quay.io/jordigilh/redis:7-alpine"
+	if err := PullImageWithRetry(redisImage, 3, writer); err != nil {
+		return fmt.Errorf("failed to pull Redis image: %w", err)
+	}
+
 	// Start Redis
 	cmd := exec.Command("podman", "run", "-d",
 		"--name", infra.RedisContainer,
 		"-p", fmt.Sprintf("%s:6379", cfg.RedisPort),
-		"quay.io/jordigilh/redis:7-alpine")
+		redisImage)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/test/infrastructure/datastorage_bootstrap.go
+++ b/test/infrastructure/datastorage_bootstrap.go
@@ -509,9 +509,39 @@ func createDSBootstrapNetwork(infra *DSBootstrapInfra, writer io.Writer) error {
 	return cmd.Run()
 }
 
+// PullImageWithRetry pulls a container image with exponential backoff.
+// This prevents transient registry failures (e.g., Docker Hub 504) from failing the entire test suite.
+func PullImageWithRetry(image string, maxRetries int, writer io.Writer) error {
+	var lastErr error
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		cmd := exec.Command("podman", "pull", image)
+		cmd.Stdout = writer
+		cmd.Stderr = writer
+		if err := cmd.Run(); err != nil {
+			lastErr = err
+			if attempt < maxRetries {
+				backoff := time.Duration(1<<uint(attempt)) * time.Second // 2s, 4s, 8s...
+				_, _ = fmt.Fprintf(writer, "   ⚠️  Image pull failed (attempt %d/%d), retrying in %v: %v\n", attempt, maxRetries, backoff, err)
+				time.Sleep(backoff)
+			}
+			continue
+		}
+		if attempt > 1 {
+			_, _ = fmt.Fprintf(writer, "   ✅ Image pull succeeded on attempt %d/%d\n", attempt, maxRetries)
+		}
+		return nil
+	}
+	return fmt.Errorf("image pull failed after %d attempts: %w", maxRetries, lastErr)
+}
+
 // startDSBootstrapPostgreSQL starts the PostgreSQL container
 func startDSBootstrapPostgreSQL(infra *DSBootstrapInfra, writer io.Writer) error {
 	cfg := infra.Config
+
+	const postgresImage = "docker.io/library/postgres:16-alpine"
+	if err := PullImageWithRetry(postgresImage, 3, writer); err != nil {
+		return fmt.Errorf("failed to pull PostgreSQL image: %w", err)
+	}
 
 	cmd := exec.Command("podman", "run", "-d",
 		"--name", infra.PostgresContainer,
@@ -520,7 +550,7 @@ func startDSBootstrapPostgreSQL(infra *DSBootstrapInfra, writer io.Writer) error
 		"-e", fmt.Sprintf("POSTGRES_USER=%s", defaultPostgresUser),
 		"-e", fmt.Sprintf("POSTGRES_PASSWORD=%s", defaultPostgresPassword),
 		"-e", fmt.Sprintf("POSTGRES_DB=%s", defaultPostgresDB),
-		"docker.io/library/postgres:16-alpine",
+		postgresImage,
 	)
 	cmd.Stdout = writer
 	cmd.Stderr = writer
@@ -553,11 +583,16 @@ func runDSBootstrapMigrations(infra *DSBootstrapInfra, projectRoot string, write
 func startDSBootstrapRedis(infra *DSBootstrapInfra, writer io.Writer) error {
 	cfg := infra.Config
 
+	const redisImage = "redis:7-alpine"
+	if err := PullImageWithRetry(redisImage, 3, writer); err != nil {
+		return fmt.Errorf("failed to pull Redis image: %w", err)
+	}
+
 	cmd := exec.Command("podman", "run", "-d",
 		"--name", infra.RedisContainer,
 		"--network", infra.Network,
 		"-p", fmt.Sprintf("%d:6379", cfg.RedisPort),
-		"redis:7-alpine",
+		redisImage,
 	)
 	cmd.Stdout = writer
 	cmd.Stderr = writer

--- a/test/infrastructure/notification_integration.go
+++ b/test/infrastructure/notification_integration.go
@@ -196,6 +196,10 @@ func StartNotificationIntegrationInfrastructure(writer io.Writer) error {
 	// ============================================================================
 	_, _ = fmt.Fprintf(writer, "🔄 Running database migrations...\n")
 	projectRoot := getProjectRoot()
+	const migrationsImage = "docker.io/library/postgres:16-alpine"
+	if err := PullImageWithRetry(migrationsImage, 3, writer); err != nil {
+		return fmt.Errorf("failed to pull migrations image: %w", err)
+	}
 	migrationsCmd := exec.Command("podman", "run", "--rm",
 		"-e", "PGHOST=host.containers.internal", // Use host.containers.internal for port-mapped PostgreSQL
 		"-e", fmt.Sprintf("PGPORT=%d", NTIntegrationPostgresPort),
@@ -203,7 +207,7 @@ func StartNotificationIntegrationInfrastructure(writer io.Writer) error {
 		"-e", fmt.Sprintf("PGPASSWORD=%s", NTIntegrationDBPassword),
 		"-e", fmt.Sprintf("PGDATABASE=%s", NTIntegrationDBName),
 		"-v", filepath.Join(projectRoot, "migrations")+":/migrations:ro",
-		"docker.io/library/postgres:16-alpine",
+		migrationsImage,
 		"sh", "-c",
 		`set -e
 echo "Applying migrations (Up sections only)..."

--- a/test/infrastructure/shared_integration_utils.go
+++ b/test/infrastructure/shared_integration_utils.go
@@ -135,6 +135,11 @@ type PostgreSQLConfig struct {
 //	    return err
 //	}
 func StartPostgreSQL(cfg PostgreSQLConfig, writer io.Writer) error {
+	const postgresImage = "docker.io/library/postgres:16-alpine"
+	if err := PullImageWithRetry(postgresImage, 3, writer); err != nil {
+		return fmt.Errorf("failed to pull PostgreSQL image: %w", err)
+	}
+
 	// Build podman run command
 	args := []string{"run", "-d",
 		"--name", cfg.ContainerName,
@@ -149,7 +154,7 @@ func StartPostgreSQL(cfg PostgreSQLConfig, writer io.Writer) error {
 		args = append(args, "--network", cfg.Network)
 	}
 
-	args = append(args, "docker.io/library/postgres:16-alpine")
+	args = append(args, postgresImage)
 
 	// Add max_connections if specified
 	if cfg.MaxConnections > 0 {
@@ -262,6 +267,11 @@ type RedisConfig struct {
 //	    return err
 //	}
 func StartRedis(cfg RedisConfig, writer io.Writer) error {
+	const redisImage = "redis:7-alpine"
+	if err := PullImageWithRetry(redisImage, 3, writer); err != nil {
+		return fmt.Errorf("failed to pull Redis image: %w", err)
+	}
+
 	args := []string{"run", "-d",
 		"--name", cfg.ContainerName,
 		"-p", fmt.Sprintf("%d:6379", cfg.Port),
@@ -272,7 +282,7 @@ func StartRedis(cfg RedisConfig, writer io.Writer) error {
 		args = append(args, "--network", cfg.Network)
 	}
 
-	args = append(args, "redis:7-alpine")
+	args = append(args, redisImage)
 
 	cmd := exec.Command("podman", args...)
 	cmd.Stdout = writer

--- a/test/infrastructure/workflowexecution_integration_infra.go
+++ b/test/infrastructure/workflowexecution_integration_infra.go
@@ -274,6 +274,10 @@ func runWEMigrations(projectRoot string, writer io.Writer) error {
 	`
 
 	// Use host.containers.internal for macOS compatibility (Podman VM can reach host)
+	const migrationsImage = "docker.io/library/postgres:16-alpine"
+	if err := PullImageWithRetry(migrationsImage, 3, writer); err != nil {
+		return fmt.Errorf("failed to pull migrations image: %w", err)
+	}
 	cmd := exec.Command("podman", "run", "--rm",
 		"--name", WEIntegrationMigrationsContainer,
 		"-v", fmt.Sprintf("%s:/migrations:ro", migrationsDir),
@@ -282,7 +286,7 @@ func runWEMigrations(projectRoot string, writer io.Writer) error {
 		"-e", "PGUSER="+WEIntegrationDBUser,
 		"-e", "PGPASSWORD="+WEIntegrationDBPassword,
 		"-e", "PGDATABASE="+WEIntegrationDBName,
-		"docker.io/library/postgres:16-alpine",
+		migrationsImage,
 		"bash", "-c", migrationScript,
 	)
 	cmd.Stdout = writer

--- a/test/integration/datastorage/suite_test.go
+++ b/test/integration/datastorage/suite_test.go
@@ -577,6 +577,8 @@ func startPostgreSQL() {
 	// Use --network=datastorage-test for container-to-container communication
 	// Increase max_connections for parallel test execution (default is 100)
 	GinkgoWriter.Println("🔧 Starting fresh PostgreSQL container...")
+	const postgresImage = "docker.io/library/postgres:16-alpine"
+	Expect(infrastructure.PullImageWithRetry(postgresImage, 3, GinkgoWriter)).To(Succeed())
 	cmd := exec.Command("podman", "run", "-d",
 		"--name", postgresContainer,
 		"--network", "datastorage-test",
@@ -584,7 +586,7 @@ func startPostgreSQL() {
 		"-e", "POSTGRES_DB=action_history",
 		"-e", "POSTGRES_USER=slm_user",
 		"-e", "POSTGRES_PASSWORD=test_password",
-		"docker.io/library/postgres:16-alpine",
+		postgresImage,
 		"-c", "max_connections=200")
 
 	output, err := cmd.CombinedOutput()
@@ -640,11 +642,13 @@ func startRedis() {
 	_ = exec.Command("podman", "rm", redisContainer).Run()
 	// Start Redis
 	// Use --network=datastorage-test for container-to-container communication
+	const redisImage = "quay.io/jordigilh/redis:7-alpine"
+	Expect(infrastructure.PullImageWithRetry(redisImage, 3, GinkgoWriter)).To(Succeed())
 	cmd := exec.Command("podman", "run", "-d",
 		"--name", redisContainer,
 		"--network", "datastorage-test",
 		"-p", "16379:6379", // DD-TEST-001
-		"quay.io/jordigilh/redis:7-alpine")
+		redisImage)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {


### PR DESCRIPTION
## Summary

- Add `PullImageWithRetry()` helper in `test/infrastructure/datastorage_bootstrap.go` that separates image pull from container start and retries with exponential backoff (3 attempts: 2s, 4s, 8s delays)
- Wire retry into all `podman run` callsites that pull external registry images (PostgreSQL from Docker Hub, Redis from Quay)
- Retry logging provides triage visibility in CI logs

## Motivation

Integration tests fail intermittently when Docker Hub/Quay returns transient 504 Gateway Timeout during image pull. Since `podman run` combines pull + start in a single operation with no retry, a single transient failure cascades into a full test suite failure (as seen in PR #911 CI run).

Separating pull from run and adding retry to the pull step keeps the retry scoped to the flaky operation (network I/O) without needing to clean up half-started containers.

## Files Changed

- `test/infrastructure/datastorage_bootstrap.go` — `PullImageWithRetry()` helper + PostgreSQL/Redis
- `test/infrastructure/datastorage.go` — PostgreSQL/Redis start functions
- `test/infrastructure/shared_integration_utils.go` — `StartPostgreSQL()`, `StartRedis()`
- `test/infrastructure/notification_integration.go` — migrations container
- `test/infrastructure/workflowexecution_integration_infra.go` — migrations container
- `test/integration/datastorage/suite_test.go` — PostgreSQL/Redis start

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] Pre-commit hooks pass
- [ ] CI pipeline validates no regressions

Closes #914


Made with [Cursor](https://cursor.com)