### PR TITLE
feat(mcp): PR6a — Helm wiring, production tool registration, and metrics (#703)

### DIFF
--- a/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
+++ b/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
@@ -83,6 +83,10 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "create", "update", "delete"]
+  # ── Interactive Impersonation (#703, DD-AUTH-MCP-001) ──────────────────
+  - apiGroups: [""]
+    resources: ["users", "groups", "serviceaccounts"]
+    verbs: ["impersonate"]
   {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -164,6 +168,14 @@ data:
         api_key: {{ .apiKey }}
 {{- end }}
 {{- end }}
+{{- end }}
+{{- if .Values.kubernautAgent.interactive.enabled }}
+    interactive:
+      enabled: true
+      session_ttl: {{ .Values.kubernautAgent.interactive.sessionTTL | default "30m" | quote }}
+      inactivity_timeout: {{ .Values.kubernautAgent.interactive.inactivityTimeout | default "10m" | quote }}
+      max_concurrent_sessions: {{ .Values.kubernautAgent.interactive.maxConcurrentSessions | default 5 }}
+      rate_limit_per_user: {{ .Values.kubernautAgent.interactive.rateLimitPerUser | default 10 }}
 {{- end }}
 {{- if include "kubernaut.monitoring.prometheus.enabled" . }}
     tools:

--- a/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
+++ b/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
@@ -84,6 +84,11 @@ rules:
     resources: ["leases"]
     verbs: ["get", "create", "update", "delete"]
   # ── Interactive Impersonation (#703, DD-AUTH-MCP-001) ──────────────────
+  # ACCEPTED RISK (SEC-06): Cluster-wide impersonate without resourceNames.
+  # Mitigation: Only granted when interactive.enabled=true; application-level
+  # identity validation in LeaseSessionManager.Takeover rejects empty usernames;
+  # per-user rate limiting bounds abuse surface. Future: scope via resourceNames
+  # if identity set is bounded.
   - apiGroups: [""]
     resources: ["users", "groups", "serviceaccounts"]
     verbs: ["impersonate"]

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -720,6 +720,18 @@
               }
             }
           }
+        },
+        "interactive": {
+          "type": "object",
+          "description": "MCP interactive mode (#703): enables human-in-the-loop investigation sessions.",
+          "additionalProperties": false,
+          "properties": {
+            "enabled": { "type": "boolean", "default": false, "description": "Enable MCP interactive mode endpoint and Lease-based session management." },
+            "sessionTTL": { "type": "string", "default": "30m", "description": "Maximum duration for an interactive session before auto-release." },
+            "inactivityTimeout": { "type": "string", "default": "10m", "description": "Session timeout after last activity." },
+            "maxConcurrentSessions": { "type": "integer", "default": 5, "description": "Maximum concurrent interactive sessions per instance." },
+            "rateLimitPerUser": { "type": "integer", "default": 10, "description": "Maximum requests per second per authenticated user." }
+          }
         }
       }
     },

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -58,6 +58,8 @@ import (
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
 	mcpkg "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+	mcpadapters "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/adapters"
+	mcptools "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
 	kametrics "github.com/jordigilh/kubernaut/internal/kubernautagent/metrics"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
@@ -71,9 +73,11 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/registry"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/sanitization"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/summarizer"
+	wfclient "github.com/jordigilh/kubernaut/pkg/workflowexecution/client"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/rest"
 	metricsclient "k8s.io/metrics/pkg/client/clientset/versioned"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func main() {
@@ -310,12 +314,14 @@ func main() {
 		}
 
 		if cfg.Interactive.Enabled {
-			mcpHandler, _ := mcpkg.BootstrapMCP(mcpkg.MCPDeps{
-				AuthMiddleware: authMw.Handler,
-			})
-			r.Handle("/mcp", kaserver.SSEHeadersMiddleware(mcpHandler))
-			r.Handle("/mcp/*", kaserver.SSEHeadersMiddleware(mcpHandler))
-			slogger.Info("MCP interactive route mounted", "path", "/api/v1/mcp")
+			mcpHandler := buildMCPHandler(cfg, k8sInfra, ds, inv, enricher, mgr, authMw, slogger)
+			if mcpHandler != nil {
+				r.Handle("/mcp", kaserver.SSEHeadersMiddleware(mcpHandler))
+				r.Handle("/mcp/*", kaserver.SSEHeadersMiddleware(mcpHandler))
+				slogger.Info("MCP interactive route mounted", "path", "/api/v1/mcp")
+			} else {
+				slogger.Error("MCP interactive mode enabled but prerequisites missing (K8s or DS unavailable)")
+			}
 		}
 
 		r.Handle("/*", kaserver.SSEHeadersMiddleware(ogenSrv))
@@ -904,5 +910,101 @@ func newAuthMiddleware(infra *k8sInfra, logger logr.Logger) *auth.Middleware {
 		ResourceName: "kubernaut-agent",
 		Verb:         "create",
 	}, logger)
+}
+
+// buildMCPHandler constructs the fully-wired MCP interactive handler with all
+// tools registered. Returns nil if prerequisites are missing (K8s infra or DS).
+// PR6a: Production wiring for MCP interactive mode (BR-INTERACTIVE-001..008).
+func buildMCPHandler(
+	cfg *kaconfig.Config,
+	infra *k8sInfra,
+	ds *dsClients,
+	inv *investigator.Investigator,
+	enricher *enrichment.Enricher,
+	autoMgr *session.Manager,
+	authMw *auth.Middleware,
+	logger *slog.Logger,
+) http.Handler {
+	if infra == nil || infra.kubeConfig == nil {
+		logger.Error("MCP interactive mode requires K8s infrastructure")
+		return nil
+	}
+	if authMw == nil {
+		logger.Error("MCP interactive mode requires auth middleware (DD-AUTH-MCP-001)")
+		return nil
+	}
+
+	// Build controller-runtime client for LeaseSessionManager.
+	ctrlCli, err := ctrlclient.New(infra.kubeConfig, ctrlclient.Options{})
+	if err != nil {
+		logger.Error("failed to create controller-runtime client for MCP sessions", "error", err)
+		return nil
+	}
+
+	namespace := detectNamespace()
+
+	// Session management via K8s Leases (single-driver guarantee).
+	leaseMgr := mcpkg.NewLeaseSessionManager(ctrlCli, namespace, logger)
+
+	// Context reconstruction from DS audit events (best-effort).
+	var recon mcpkg.ContextReconstructor
+	if ds != nil {
+		recon = mcpkg.NewDSContextReconstructor(ds.ogenClient, 10*time.Second, logger)
+	} else {
+		recon = &noopReconstructor{}
+		logger.Warn("DS unavailable — context reconstruction disabled for MCP interactive")
+	}
+
+	// Build the InvestigatorRunner adapter.
+	investigatorRunner := mcpadapters.NewInvestigatorRunnerAdapter(inv)
+
+	// Build the InvestigateTool with the autonomous session manager for takeover.
+	investigateTool := mcptools.NewInvestigateTool(leaseMgr, investigatorRunner, recon, autoMgr)
+
+	// Build the EnrichTool (enricher can be nil in dev mode).
+	var enrichTool *mcptools.EnrichTool
+	if enricher != nil {
+		enrichTool = mcptools.NewEnrichTool(enricher, leaseMgr)
+	}
+
+	// Build the WorkflowCatalog adapter and SelectWorkflowTool.
+	var selectWfTool *mcptools.SelectWorkflowTool
+	if ds != nil {
+		wfQuerier := wfclient.NewOgenWorkflowQuerier(ds.ogenClient)
+		catalogAdapter := mcpadapters.NewWorkflowCatalogAdapter(wfQuerier)
+		selectWfTool = mcptools.NewSelectWorkflowTool(catalogAdapter, leaseMgr)
+	}
+
+	// Register tools with the MCP SDK server.
+	toolDeps := mcpkg.ToolDeps{}
+	if investigateTool != nil {
+		toolDeps.Investigate = mcptools.InvestigateRegistration(investigateTool)
+	}
+	if enrichTool != nil {
+		toolDeps.Enrich = mcptools.EnrichRegistration(enrichTool)
+	}
+	if selectWfTool != nil {
+		toolDeps.SelectWorkflow = mcptools.SelectWorkflowRegistration(selectWfTool)
+	}
+
+	mcpHandler, _ := mcpkg.BootstrapMCP(mcpkg.MCPDeps{
+		AuthMiddleware: authMw.Handler,
+		Tools:          toolDeps,
+	})
+
+	logger.Info("MCP interactive tools registered",
+		"investigate", investigateTool != nil,
+		"enrich", enrichTool != nil,
+		"select_workflow", selectWfTool != nil,
+	)
+
+	return mcpHandler
+}
+
+// noopReconstructor is a no-op ContextReconstructor used when DS is unavailable.
+type noopReconstructor struct{}
+
+func (n *noopReconstructor) Reconstruct(_ context.Context, _ string, _ string) ([]mcpkg.ConversationTurn, error) {
+	return nil, nil
 }
 

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -314,13 +315,26 @@ func main() {
 		}
 
 		if cfg.Interactive.Enabled {
-			mcpHandler := buildMCPHandler(cfg, k8sInfra, ds, inv, enricher, mgr, authMw, slogger)
+			mcpHandler := buildMCPHandler(cfg, k8sInfra, ds, inv, enricher, mgr, authMw, agentMetrics, slogger)
 			if mcpHandler != nil {
-				r.Handle("/mcp", kaserver.SSEHeadersMiddleware(mcpHandler))
-				r.Handle("/mcp/*", kaserver.SSEHeadersMiddleware(mcpHandler))
-				slogger.Info("MCP interactive route mounted", "path", "/api/v1/mcp")
+				// SEC-02: Per-user rate limiting for MCP interactive endpoint.
+				userRL := kaserver.NewUserRateLimiter(
+					kaserver.DefaultUserRateLimitConfig(cfg.Interactive.RateLimitPerUser),
+					agentMetrics.HTTPRateLimitedTotal,
+				)
+				defer userRL.Stop()
+
+				r.Route("/mcp", func(mcpRouter chi.Router) {
+					mcpRouter.Use(userRL.Middleware)
+					mcpRouter.Handle("/", kaserver.SSEHeadersMiddleware(mcpHandler))
+					mcpRouter.Handle("/*", kaserver.SSEHeadersMiddleware(mcpHandler))
+				})
+				slogger.Info("MCP interactive route mounted",
+					"path", "/api/v1/mcp",
+					"rate_limit_per_user", cfg.Interactive.RateLimitPerUser,
+				)
 			} else {
-				slogger.Error("MCP interactive mode enabled but prerequisites missing (K8s or DS unavailable)")
+				slogger.Error("MCP interactive mode enabled but handler construction failed (check preceding errors)")
 			}
 		}
 
@@ -505,7 +519,7 @@ func configHandler(cfg *kaconfig.Config, swappable *llm.SwappableClient) http.Ha
 func detectNamespace() string {
 	data, err := os.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace")
 	if err == nil && len(data) > 0 {
-		return string(data)
+		return strings.TrimSpace(string(data))
 	}
 	return "kubernaut-system"
 }
@@ -923,28 +937,44 @@ func buildMCPHandler(
 	enricher *enrichment.Enricher,
 	autoMgr *session.Manager,
 	authMw *auth.Middleware,
+	agentMetrics *kametrics.Metrics,
 	logger *slog.Logger,
 ) http.Handler {
 	if infra == nil || infra.kubeConfig == nil {
-		logger.Error("MCP interactive mode requires K8s infrastructure")
+		logger.Error("MCP interactive mode: K8s infrastructure unavailable")
 		return nil
 	}
 	if authMw == nil {
-		logger.Error("MCP interactive mode requires auth middleware (DD-AUTH-MCP-001)")
+		logger.Error("MCP interactive mode: auth middleware unavailable (DD-AUTH-MCP-001)")
+		return nil
+	}
+	// SEC-05: Investigator is required for the core investigate tool.
+	if inv == nil {
+		logger.Error("MCP interactive mode: investigator unavailable")
 		return nil
 	}
 
-	// Build controller-runtime client for LeaseSessionManager.
-	ctrlCli, err := ctrlclient.New(infra.kubeConfig, ctrlclient.Options{})
+	// SEC-07: Build controller-runtime client with MCP-specific timeouts.
+	mcpRestConfig := *infra.kubeConfig
+	mcpRestConfig.Timeout = 10 * time.Second
+	mcpRestConfig.QPS = 20
+	mcpRestConfig.Burst = 40
+
+	ctrlCli, err := ctrlclient.New(&mcpRestConfig, ctrlclient.Options{})
 	if err != nil {
-		logger.Error("failed to create controller-runtime client for MCP sessions", "error", err)
+		logger.Error("MCP interactive mode: failed to create controller-runtime client", "error", err)
 		return nil
 	}
 
 	namespace := detectNamespace()
 
 	// Session management via K8s Leases (single-driver guarantee).
-	leaseMgr := mcpkg.NewLeaseSessionManager(ctrlCli, namespace, logger)
+	leaseOpts := []mcpkg.LeaseOption{
+		mcpkg.WithSessionTTL(cfg.Interactive.SessionTTL),
+		mcpkg.WithInactivityTimeout(cfg.Interactive.InactivityTimeout),
+		mcpkg.WithMaxConcurrentSessions(cfg.Interactive.MaxConcurrentSessions),
+	}
+	leaseMgr := mcpkg.NewLeaseSessionManager(ctrlCli, namespace, logger, leaseOpts...)
 
 	// Context reconstruction from DS audit events (best-effort).
 	var recon mcpkg.ContextReconstructor
@@ -952,14 +982,20 @@ func buildMCPHandler(
 		recon = mcpkg.NewDSContextReconstructor(ds.ogenClient, 10*time.Second, logger)
 	} else {
 		recon = &noopReconstructor{}
-		logger.Warn("DS unavailable — context reconstruction disabled for MCP interactive")
+		logger.Warn("MCP interactive mode: DS unavailable — context reconstruction disabled")
 	}
 
 	// Build the InvestigatorRunner adapter.
 	investigatorRunner := mcpadapters.NewInvestigatorRunnerAdapter(inv)
 
-	// Build the InvestigateTool with the autonomous session manager for takeover.
-	investigateTool := mcptools.NewInvestigateTool(leaseMgr, investigatorRunner, recon, autoMgr)
+	// Build the InvestigateTool with optional dependencies.
+	investigateOpts := []mcptools.InvestigateOption{
+		mcptools.WithToolMetrics(agentMetrics),
+	}
+	if autoMgr != nil {
+		investigateOpts = append(investigateOpts, mcptools.WithAutonomousManager(autoMgr))
+	}
+	investigateTool := mcptools.NewInvestigateTool(leaseMgr, investigatorRunner, recon, investigateOpts...)
 
 	// Build the EnrichTool (enricher can be nil in dev mode).
 	var enrichTool *mcptools.EnrichTool
@@ -977,9 +1013,7 @@ func buildMCPHandler(
 
 	// Register tools with the MCP SDK server.
 	toolDeps := mcpkg.ToolDeps{}
-	if investigateTool != nil {
-		toolDeps.Investigate = mcptools.InvestigateRegistration(investigateTool)
-	}
+	toolDeps.Investigate = mcptools.InvestigateRegistration(investigateTool)
 	if enrichTool != nil {
 		toolDeps.Enrich = mcptools.EnrichRegistration(enrichTool)
 	}
@@ -993,7 +1027,7 @@ func buildMCPHandler(
 	})
 
 	logger.Info("MCP interactive tools registered",
-		"investigate", investigateTool != nil,
+		"investigate", true,
 		"enrich", enrichTool != nil,
 		"select_workflow", selectWfTool != nil,
 	)

--- a/internal/kubernautagent/config/config.go
+++ b/internal/kubernautagent/config/config.go
@@ -126,6 +126,7 @@ type InteractiveConfig struct {
 	SessionTTL            time.Duration `yaml:"session_ttl"`
 	InactivityTimeout     time.Duration `yaml:"inactivity_timeout"`
 	MaxConcurrentSessions int           `yaml:"max_concurrent_sessions"`
+	RateLimitPerUser      int           `yaml:"rate_limit_per_user"`
 	MaxAnalyzingTimeout   time.Duration `yaml:"max_analyzing_timeout"`
 }
 
@@ -385,6 +386,12 @@ func (c *Config) Validate() error {
 		}
 		if c.Interactive.MaxConcurrentSessions > 100 {
 			return fmt.Errorf("interactive.max_concurrent_sessions must not exceed 100, got %d", c.Interactive.MaxConcurrentSessions)
+		}
+		if c.Interactive.RateLimitPerUser <= 0 {
+			c.Interactive.RateLimitPerUser = 10
+		}
+		if c.Interactive.RateLimitPerUser > 100 {
+			return fmt.Errorf("interactive.rate_limit_per_user must not exceed 100, got %d", c.Interactive.RateLimitPerUser)
 		}
 	}
 	return nil

--- a/internal/kubernautagent/mcp/adapters/adapters.go
+++ b/internal/kubernautagent/mcp/adapters/adapters.go
@@ -55,11 +55,11 @@ func (a *InvestigatorRunnerAdapter) RunInteractiveTurn(ctx context.Context, mess
 		return "", fmt.Errorf("interactive turn: %w", err)
 	}
 
-	return extractContent(result)
+	return ExtractContent(result)
 }
 
-// extractContent maps the sealed investigator.LoopResult to a plain string.
-func extractContent(result investigator.LoopResult) (string, error) {
+// ExtractContent maps the sealed investigator.LoopResult to a plain string.
+func ExtractContent(result investigator.LoopResult) (string, error) {
 	switch r := result.(type) {
 	case *investigator.TextResult:
 		return r.Content, nil

--- a/internal/kubernautagent/mcp/adapters/adapters.go
+++ b/internal/kubernautagent/mcp/adapters/adapters.go
@@ -1,0 +1,112 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package adapters bridges MCP tool interfaces to production implementations,
+// breaking the import cycle between mcp and tools packages.
+package adapters
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	wfclient "github.com/jordigilh/kubernaut/pkg/workflowexecution/client"
+)
+
+// InvestigatorRunnerAdapter bridges the MCP tools.InvestigatorRunner interface
+// to the real investigator.Investigator.RunInteractiveTurn method.
+//
+// Type conversions:
+//   - tools.LLMMessage{Role, Content} → llm.Message{Role, Content}
+//   - investigator.LoopResult (sealed) → string via type switch
+type InvestigatorRunnerAdapter struct {
+	inv *investigator.Investigator
+}
+
+// NewInvestigatorRunnerAdapter creates an adapter wrapping a real Investigator.
+func NewInvestigatorRunnerAdapter(inv *investigator.Investigator) *InvestigatorRunnerAdapter {
+	return &InvestigatorRunnerAdapter{inv: inv}
+}
+
+// RunInteractiveTurn implements tools.InvestigatorRunner.
+func (a *InvestigatorRunnerAdapter) RunInteractiveTurn(ctx context.Context, messages []tools.LLMMessage, correlationID string) (string, error) {
+	llmMessages := make([]llm.Message, len(messages))
+	for i, m := range messages {
+		llmMessages[i] = llm.Message{Role: m.Role, Content: m.Content}
+	}
+
+	result, err := a.inv.RunInteractiveTurn(ctx, llmMessages, correlationID)
+	if err != nil {
+		return "", fmt.Errorf("interactive turn: %w", err)
+	}
+
+	return extractContent(result)
+}
+
+// extractContent maps the sealed investigator.LoopResult to a plain string.
+func extractContent(result investigator.LoopResult) (string, error) {
+	switch r := result.(type) {
+	case *investigator.TextResult:
+		return r.Content, nil
+	case *investigator.SubmitResult:
+		return r.Content, nil
+	case *investigator.SubmitWithWorkflowResult:
+		return r.Content, nil
+	case *investigator.SubmitNoWorkflowResult:
+		return r.Content, nil
+	case *investigator.ExhaustedResult:
+		return "", fmt.Errorf("investigation exhausted: %s", r.Reason)
+	case *investigator.CancelledResult:
+		return "", fmt.Errorf("investigation cancelled at turn %d", r.Turn)
+	default:
+		return "", fmt.Errorf("unexpected loop result type: %T", result)
+	}
+}
+
+// Compile-time interface compliance check.
+var _ tools.InvestigatorRunner = (*InvestigatorRunnerAdapter)(nil)
+
+// WorkflowCatalogAdapter bridges the MCP tools.WorkflowCatalog interface
+// to the real wfclient.WorkflowQuerier.ResolveWorkflowCatalogMetadata method.
+type WorkflowCatalogAdapter struct {
+	querier wfclient.WorkflowQuerier
+}
+
+// NewWorkflowCatalogAdapter creates an adapter wrapping a real WorkflowQuerier.
+func NewWorkflowCatalogAdapter(querier wfclient.WorkflowQuerier) *WorkflowCatalogAdapter {
+	return &WorkflowCatalogAdapter{querier: querier}
+}
+
+// GetWorkflowByID implements tools.WorkflowCatalog.
+func (a *WorkflowCatalogAdapter) GetWorkflowByID(ctx context.Context, workflowID string) (*tools.CatalogWorkflow, error) {
+	meta, err := a.querier.ResolveWorkflowCatalogMetadata(ctx, workflowID)
+	if err != nil {
+		return nil, fmt.Errorf("workflow catalog lookup: %w", err)
+	}
+
+	return &tools.CatalogWorkflow{
+		WorkflowID:         workflowID,
+		WorkflowName:       meta.WorkflowName,
+		ExecutionEngine:    meta.ExecutionEngine,
+		ExecutionBundle:    meta.ExecutionBundle,
+		ServiceAccountName: meta.ServiceAccountName,
+	}, nil
+}
+
+// Compile-time interface compliance check.
+var _ tools.WorkflowCatalog = (*WorkflowCatalogAdapter)(nil)

--- a/internal/kubernautagent/mcp/interfaces.go
+++ b/internal/kubernautagent/mcp/interfaces.go
@@ -87,6 +87,10 @@ type SessionManager interface {
 
 	// IsDriverActive returns true if a user is currently driving the given RR.
 	IsDriverActive(rrID string) bool
+
+	// TouchActivity updates the last activity timestamp for a session (SEC-04).
+	// Called by tool handlers on each interaction to reset the inactivity timer.
+	TouchActivity(rrID string)
 }
 
 // ConversationTurn represents a single LLM turn reconstructed from DS audit events.

--- a/internal/kubernautagent/mcp/server.go
+++ b/internal/kubernautagent/mcp/server.go
@@ -17,9 +17,11 @@ limitations under the License.
 package mcp
 
 import (
+	"context"
 	"net/http"
 	"sync/atomic"
 
+	sharedauth "github.com/jordigilh/kubernaut/pkg/shared/auth"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -32,7 +34,7 @@ type MCPServer struct {
 
 // NewMCPServer creates a new MCP server instance configured for Kubernaut Agent
 // interactive mode. The server starts with zero tools; tools are registered
-// dynamically when sessions are established.
+// via RegisterTools before the handler is created.
 func NewMCPServer() *MCPServer {
 	impl := &mcpsdk.Implementation{
 		Name:    "kubernaut-agent-interactive",
@@ -52,7 +54,7 @@ func (s *MCPServer) Implementation() *mcpsdk.Implementation {
 	return s.impl
 }
 
-// ToolCount returns the number of registered tools.
+// ToolCount returns the number of tools registered with the MCP SDK server.
 func (s *MCPServer) ToolCount() int {
 	return int(s.toolCount.Load())
 }
@@ -60,6 +62,86 @@ func (s *MCPServer) ToolCount() int {
 // Server returns the underlying go-sdk MCP server for handler construction.
 func (s *MCPServer) Server() *mcpsdk.Server {
 	return s.server
+}
+
+// ToolRegistration is a function that registers a tool with the MCP SDK server.
+// Each tool package provides its own registration function that calls mcp.AddTool
+// with the correct generic type parameters, avoiding import cycles.
+type ToolRegistration func(server *mcpsdk.Server, userFromCtx func(context.Context) UserInfo)
+
+// ToolDeps holds optional tool registration functions.
+// nil fields are skipped during registration.
+type ToolDeps struct {
+	Investigate    ToolRegistration
+	Enrich         ToolRegistration
+	SelectWorkflow ToolRegistration
+}
+
+// MCPDeps holds the dependencies needed to bootstrap the MCP server.
+type MCPDeps struct {
+	AuthMiddleware func(http.Handler) http.Handler
+	Tools          ToolDeps
+}
+
+// userFromContext extracts the authenticated user identity from the request
+// context (set by auth middleware via sharedauth.UserContextKey).
+func userFromContext(ctx context.Context) UserInfo {
+	username := sharedauth.GetUserFromContext(ctx)
+	return UserInfo{Username: username}
+}
+
+// registerTools invokes each non-nil ToolRegistration, which calls mcp.AddTool
+// on the SDK server with the correct generic type parameters.
+func (s *MCPServer) registerTools(deps ToolDeps) {
+	userFn := userFromContext
+
+	if deps.Investigate != nil {
+		deps.Investigate(s.server, userFn)
+		s.toolCount.Add(1)
+	}
+	if deps.Enrich != nil {
+		deps.Enrich(s.server, userFn)
+		s.toolCount.Add(1)
+	}
+	if deps.SelectWorkflow != nil {
+		deps.SelectWorkflow(s.server, userFn)
+		s.toolCount.Add(1)
+	}
+}
+
+// BootstrapMCP creates a fully configured MCP handler with tools registered
+// via the MCP SDK's AddTool. Returns the handler and the MCPServer for
+// lifecycle management.
+//
+// Panics if AuthMiddleware is nil — the MCP endpoint must never be exposed
+// without authentication (defense-in-depth, DD-AUTH-MCP-001).
+func BootstrapMCP(deps MCPDeps) (http.Handler, *MCPServer) {
+	if deps.AuthMiddleware == nil {
+		panic("MCP interactive mode enabled but auth middleware is nil — refusing to start without authentication")
+	}
+
+	srv := NewMCPServer()
+	srv.registerTools(deps.Tools)
+
+	mcpHandler := mcpsdk.NewStreamableHTTPHandler(func(_ *http.Request) *mcpsdk.Server {
+		return srv.Server()
+	}, nil)
+
+	handler := deps.AuthMiddleware(mcpHandler)
+	return handler, srv
+}
+
+// BootstrapMCPNoAuth creates a configured MCP handler without auth middleware.
+// Used ONLY by integration tests that provide their own auth context.
+func BootstrapMCPNoAuth(toolDeps ToolDeps) (http.Handler, *MCPServer) {
+	srv := NewMCPServer()
+	srv.registerTools(toolDeps)
+
+	mcpHandler := mcpsdk.NewStreamableHTTPHandler(func(_ *http.Request) *mcpsdk.Server {
+		return srv.Server()
+	}, nil)
+
+	return mcpHandler, srv
 }
 
 // NewMCPHandler creates an http.Handler for the MCP server endpoint.
@@ -81,66 +163,4 @@ func NewMCPHandler(authMiddleware func(http.Handler) http.Handler, enabled bool)
 	}, nil)
 
 	return authMiddleware(handler)
-}
-
-// ToolDeps holds optional tool instances for registration.
-// nil fields are skipped during registration.
-type ToolDeps struct {
-	Investigate    ToolHandler
-	Enrich         ToolHandler
-	SelectWorkflow ToolHandler
-}
-
-// MCPDeps holds the dependencies needed to bootstrap the MCP server.
-type MCPDeps struct {
-	AuthMiddleware func(http.Handler) http.Handler
-	Tools          ToolDeps
-}
-
-// BootstrapMCP creates a fully configured MCP handler with tools registered
-// from deps.Tools. Returns the handler and the MCPServer for lifecycle management.
-func BootstrapMCP(deps MCPDeps) (http.Handler, *MCPServer) {
-	srv := NewMCPServer()
-
-	if deps.Tools.Investigate != nil {
-		srv.toolCount.Add(1)
-	}
-	if deps.Tools.Enrich != nil {
-		srv.toolCount.Add(1)
-	}
-	if deps.Tools.SelectWorkflow != nil {
-		srv.toolCount.Add(1)
-	}
-
-	mcpHandler := mcpsdk.NewStreamableHTTPHandler(func(_ *http.Request) *mcpsdk.Server {
-		return srv.Server()
-	}, nil)
-
-	var handler http.Handler = mcpHandler
-	if deps.AuthMiddleware != nil {
-		handler = deps.AuthMiddleware(mcpHandler)
-	}
-
-	return handler, srv
-}
-
-// ToolHandler defines the contract for MCP tool handlers that can be registered
-// with BootstrapMCPWithTool.
-type ToolHandler interface{}
-
-// BootstrapMCPWithTool creates a configured MCP handler with a pre-built tool
-// registered. Used by integration tests that need to wire their own tool dependencies.
-func BootstrapMCPWithTool(deps MCPDeps, _ ToolHandler) (http.Handler, *MCPServer) {
-	srv := NewMCPServer()
-
-	mcpHandler := mcpsdk.NewStreamableHTTPHandler(func(_ *http.Request) *mcpsdk.Server {
-		return srv.Server()
-	}, nil)
-
-	var handler http.Handler = mcpHandler
-	if deps.AuthMiddleware != nil {
-		handler = deps.AuthMiddleware(mcpHandler)
-	}
-
-	return handler, srv
 }

--- a/internal/kubernautagent/mcp/session_manager.go
+++ b/internal/kubernautagent/mcp/session_manager.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -37,6 +38,15 @@ var (
 
 	// ErrSessionNotFound indicates no session exists with the given ID.
 	ErrSessionNotFound = errors.New("session not found")
+
+	// ErrEmptyUsername rejects sessions with no authenticated identity (SEC-01).
+	ErrEmptyUsername = errors.New("username must not be empty")
+
+	// ErrMaxSessionsReached rejects new sessions when capacity is exhausted (SEC-03).
+	ErrMaxSessionsReached = errors.New("maximum concurrent sessions reached")
+
+	// ErrSessionExpired indicates the session TTL has been exceeded (SEC-04).
+	ErrSessionExpired = errors.New("session expired")
 )
 
 const (
@@ -54,18 +64,22 @@ var DefaultSessionTTL = 30 * time.Minute
 // LeaseSessionManager implements SessionManager with K8s coordination/v1 Lease
 // for single-driver guarantee (BR-INTERACTIVE-002).
 type LeaseSessionManager struct {
-	client     client.Client
-	namespace  string
-	sessionTTL time.Duration
-	sessions   sync.Map // sessionID -> *sessionEntry
-	rrIndex    sync.Map // rrID -> sessionID
-	logger     *slog.Logger
+	client            client.Client
+	namespace         string
+	sessionTTL        time.Duration
+	inactivityTimeout time.Duration
+	maxSessions       int
+	sessions          sync.Map // sessionID -> *sessionEntry
+	rrIndex           sync.Map // rrID -> sessionID
+	activeCount       atomic.Int32
+	logger            *slog.Logger
 }
 
 type sessionEntry struct {
-	session    *InteractiveSession
-	rrID       string
-	signalMeta map[string]string
+	session      *InteractiveSession
+	rrID         string
+	signalMeta   map[string]string
+	lastActivity atomic.Value // stores time.Time
 }
 
 // LeaseOption configures optional parameters for LeaseSessionManager.
@@ -75,6 +89,20 @@ type LeaseOption func(*LeaseSessionManager)
 func WithSessionTTL(ttl time.Duration) LeaseOption {
 	return func(m *LeaseSessionManager) {
 		m.sessionTTL = ttl
+	}
+}
+
+// WithInactivityTimeout sets the per-session inactivity timeout (SEC-04).
+func WithInactivityTimeout(timeout time.Duration) LeaseOption {
+	return func(m *LeaseSessionManager) {
+		m.inactivityTimeout = timeout
+	}
+}
+
+// WithMaxConcurrentSessions sets the session capacity limit (SEC-03).
+func WithMaxConcurrentSessions(max int) LeaseOption {
+	return func(m *LeaseSessionManager) {
+		m.maxSessions = max
 	}
 }
 
@@ -120,7 +148,23 @@ func (m *LeaseSessionManager) GetSignalMetadata(sessionID string) map[string]str
 }
 
 func (m *LeaseSessionManager) Takeover(ctx context.Context, rrID string, user UserInfo) (*InteractiveSession, error) {
-	if _, ok := m.rrIndex.Load(rrID); ok {
+	// SEC-01: Reject anonymous/empty identity.
+	if user.Username == "" {
+		return nil, ErrEmptyUsername
+	}
+
+	// SEC-03: Enforce max concurrent sessions.
+	if m.maxSessions > 0 && int(m.activeCount.Load()) >= m.maxSessions {
+		return nil, ErrMaxSessionsReached
+	}
+
+	// UX-03: Check local index first and provide holder context in error.
+	if existingSessionID, ok := m.rrIndex.Load(rrID); ok {
+		if raw, found := m.sessions.Load(existingSessionID); found {
+			entry := raw.(*sessionEntry)
+			return nil, fmt.Errorf("%w: held by %q since %s",
+				ErrLeaseHeld, entry.session.ActingUser.Username, entry.session.StartedAt.Format(time.RFC3339))
+		}
 		return nil, ErrLeaseHeld
 	}
 
@@ -158,8 +202,10 @@ func (m *LeaseSessionManager) Takeover(ctx context.Context, rrID string, user Us
 	}
 
 	entry := &sessionEntry{session: session, rrID: rrID}
+	entry.lastActivity.Store(time.Now())
 	m.sessions.Store(sessionID, entry)
 	m.rrIndex.Store(rrID, sessionID)
+	m.activeCount.Add(1)
 
 	m.logger.Info("interactive session started",
 		slog.String("session_id", sessionID),
@@ -194,6 +240,7 @@ func (m *LeaseSessionManager) Release(sessionID string, reason string) error {
 
 	m.sessions.Delete(sessionID)
 	m.rrIndex.Delete(entry.rrID)
+	m.activeCount.Add(-1)
 
 	m.logger.Info("interactive session released",
 		slog.String("session_id", sessionID),
@@ -215,7 +262,46 @@ func (m *LeaseSessionManager) GetDriver(rrID string) (*InteractiveSession, error
 	if !ok {
 		return nil, nil
 	}
-	return raw.(*sessionEntry).session, nil
+	entry := raw.(*sessionEntry)
+
+	// SEC-04: Check session TTL expiry.
+	if m.sessionTTL > 0 && time.Since(entry.session.StartedAt) > m.sessionTTL {
+		m.logger.Warn("session TTL expired, auto-releasing",
+			slog.String("session_id", sessionID),
+			slog.String("rr_id", rrID))
+		_ = m.Release(sessionID, "ttl_expired")
+		return nil, ErrSessionExpired
+	}
+
+	// SEC-04: Check inactivity timeout.
+	if m.inactivityTimeout > 0 {
+		if lastAct, ok := entry.lastActivity.Load().(time.Time); ok {
+			if time.Since(lastAct) > m.inactivityTimeout {
+				m.logger.Warn("session inactivity timeout, auto-releasing",
+					slog.String("session_id", sessionID),
+					slog.String("rr_id", rrID))
+				_ = m.Release(sessionID, "inactivity_timeout")
+				return nil, ErrSessionExpired
+			}
+		}
+	}
+
+	return entry.session, nil
+}
+
+// TouchActivity updates the last activity timestamp for a session (SEC-04).
+// Called by tool handlers on each interaction to reset the inactivity timer.
+func (m *LeaseSessionManager) TouchActivity(rrID string) {
+	raw, ok := m.rrIndex.Load(rrID)
+	if !ok {
+		return
+	}
+	sessionID := raw.(string)
+	raw, ok = m.sessions.Load(sessionID)
+	if !ok {
+		return
+	}
+	raw.(*sessionEntry).lastActivity.Store(time.Now())
 }
 
 func (m *LeaseSessionManager) IsDriverActive(rrID string) bool {

--- a/internal/kubernautagent/mcp/tools/errors.go
+++ b/internal/kubernautagent/mcp/tools/errors.go
@@ -70,4 +70,8 @@ var (
 		Code:    "rate_limited",
 		Message: "Too many requests. Please slow down.",
 	}
+	ErrCodeSessionExpired = &MCPError{
+		Code:    "session_expired",
+		Message: "Session has expired due to TTL or inactivity. Start a new session.",
+	}
 )

--- a/internal/kubernautagent/mcp/tools/investigate.go
+++ b/internal/kubernautagent/mcp/tools/investigate.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"time"
 
 	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
@@ -50,23 +51,45 @@ type AutonomousSessionManager interface {
 // InvestigateTool handles the kubernaut_investigate MCP tool actions:
 // start, message, complete, cancel, takeover. BR-INTERACTIVE-001, BR-INTERACTIVE-004.
 type InvestigateTool struct {
-	sessions  mcpinternal.SessionManager
-	runner    InvestigatorRunner
-	recon     mcpinternal.ContextReconstructor
-	autoMgr   AutonomousSessionManager
-	sessionMu sync.Map // rrID -> *sync.Mutex (per-session serialization)
+	sessions     mcpinternal.SessionManager
+	runner       InvestigatorRunner
+	recon        mcpinternal.ContextReconstructor
+	autoMgr      AutonomousSessionManager
+	metrics      ToolMetrics
+	sessionMu    sync.Map // rrID -> *sync.Mutex (per-session serialization)
+	reconHistory sync.Map // rrID -> []LLMMessage (reconstructed context for LLM)
+}
+
+// InvestigateOption configures optional dependencies for InvestigateTool.
+type InvestigateOption func(*InvestigateTool)
+
+// WithAutonomousManager enables autonomous session takeover.
+func WithAutonomousManager(mgr AutonomousSessionManager) InvestigateOption {
+	return func(t *InvestigateTool) {
+		if mgr != nil {
+			t.autoMgr = mgr
+		}
+	}
+}
+
+// WithToolMetrics enables metrics recording on tool operations (PROD-01).
+func WithToolMetrics(m ToolMetrics) InvestigateOption {
+	return func(t *InvestigateTool) {
+		if m != nil {
+			t.metrics = m
+		}
+	}
 }
 
 // NewInvestigateTool creates the tool handler with its dependencies.
-// autoMgr may be nil if dynamic takeover is not enabled (PR3 compatibility).
-func NewInvestigateTool(sessions mcpinternal.SessionManager, runner InvestigatorRunner, recon mcpinternal.ContextReconstructor, autoMgr ...AutonomousSessionManager) *InvestigateTool {
+func NewInvestigateTool(sessions mcpinternal.SessionManager, runner InvestigatorRunner, recon mcpinternal.ContextReconstructor, opts ...InvestigateOption) *InvestigateTool {
 	t := &InvestigateTool{
 		sessions: sessions,
 		runner:   runner,
 		recon:    recon,
 	}
-	if len(autoMgr) > 0 && autoMgr[0] != nil {
-		t.autoMgr = autoMgr[0]
+	for _, opt := range opts {
+		opt(t)
 	}
 	return t
 }
@@ -83,6 +106,18 @@ func (t *InvestigateTool) Handle(ctx context.Context, input InvestigateInput, us
 		return InvestigateOutput{}, err
 	}
 
+	start := time.Now()
+	output, err := t.dispatch(ctx, input, user)
+
+	// PROD-01: Record command duration for all actions.
+	if t.metrics != nil {
+		t.metrics.RecordInteractiveCommandDuration("kubernaut_investigate", input.Action, time.Since(start).Seconds())
+	}
+
+	return output, err
+}
+
+func (t *InvestigateTool) dispatch(ctx context.Context, input InvestigateInput, user mcpinternal.UserInfo) (InvestigateOutput, error) {
 	switch input.Action {
 	case ActionStart:
 		return t.handleStart(ctx, input, user)
@@ -104,10 +139,18 @@ func (t *InvestigateTool) Handle(ctx context.Context, input InvestigateInput, us
 func (t *InvestigateTool) handleStart(ctx context.Context, input InvestigateInput, user mcpinternal.UserInfo) (InvestigateOutput, error) {
 	sess, err := t.sessions.Takeover(ctx, input.RRID, user)
 	if err != nil {
+		if errors.Is(err, mcpinternal.ErrLeaseHeld) && t.metrics != nil {
+			t.metrics.RecordInteractiveLeaseContention()
+		}
 		return InvestigateOutput{}, err
 	}
 
-	_, _ = t.recon.Reconstruct(ctx, input.RRID, sess.SessionID)
+	if t.metrics != nil {
+		t.metrics.RecordInteractiveSessionStarted()
+		t.metrics.RecordInteractiveTakeover("start_success")
+	}
+
+	t.storeReconstructedContext(ctx, input.RRID, sess.SessionID)
 
 	return InvestigateOutput{
 		SessionID: sess.SessionID,
@@ -135,6 +178,9 @@ func (t *InvestigateTool) handleTakeover(ctx context.Context, input InvestigateI
 	sess, err := t.sessions.Takeover(ctx, input.RRID, user)
 	if err != nil {
 		if errors.Is(err, mcpinternal.ErrLeaseHeld) {
+			if t.metrics != nil {
+				t.metrics.RecordInteractiveLeaseContention()
+			}
 			driver, _ := t.sessions.GetDriver(input.RRID)
 			driverName := "unknown"
 			if driver != nil {
@@ -145,8 +191,13 @@ func (t *InvestigateTool) handleTakeover(ctx context.Context, input InvestigateI
 		return InvestigateOutput{}, fmt.Errorf("takeover session: %w", err)
 	}
 
-	turns, _ := t.recon.Reconstruct(ctx, input.RRID, sess.SessionID)
-	contextSummary := fmt.Sprintf("%d prior turns reconstructed", len(turns))
+	if t.metrics != nil {
+		t.metrics.RecordInteractiveSessionStarted()
+		t.metrics.RecordInteractiveTakeover("takeover_success")
+	}
+
+	reconCount := t.storeReconstructedContext(ctx, input.RRID, sess.SessionID)
+	contextSummary := fmt.Sprintf("%d prior turns reconstructed", reconCount)
 
 	return InvestigateOutput{
 		SessionID: sess.SessionID,
@@ -165,7 +216,13 @@ func (t *InvestigateTool) handleMessage(ctx context.Context, input InvestigateIn
 	}
 
 	sess, err := t.sessions.GetDriver(input.RRID)
-	if err != nil || sess == nil {
+	if err != nil {
+		if errors.Is(err, mcpinternal.ErrSessionExpired) {
+			return InvestigateOutput{}, ErrCodeSessionExpired
+		}
+		return InvestigateOutput{}, ErrCodeNotDriving
+	}
+	if sess == nil {
 		return InvestigateOutput{}, ErrCodeNotDriving
 	}
 
@@ -173,7 +230,11 @@ func (t *InvestigateTool) handleMessage(ctx context.Context, input InvestigateIn
 		return InvestigateOutput{}, ErrCodeSessionActive.WithDetail("driver", sess.ActingUser.Username)
 	}
 
-	messages := []LLMMessage{{Role: "user", Content: input.Message}}
+	// SEC-04: Touch activity to reset inactivity timer.
+	t.sessions.TouchActivity(input.RRID)
+
+	// PROD-02: Prepend reconstructed context turns so the LLM has full history.
+	messages := t.buildMessagesWithContext(input.RRID, input.Message)
 
 	response, err := t.runner.RunInteractiveTurn(ctx, messages, input.RRID)
 	if err != nil {
@@ -204,7 +265,12 @@ func (t *InvestigateTool) handleComplete(input InvestigateInput) (InvestigateOut
 		return InvestigateOutput{}, fmt.Errorf("release session: %w", err)
 	}
 
+	if t.metrics != nil {
+		t.metrics.RecordInteractiveSessionEnded()
+	}
+
 	t.sessionMu.Delete(input.RRID)
+	t.reconHistory.Delete(input.RRID)
 
 	return InvestigateOutput{
 		SessionID: sess.SessionID,
@@ -256,10 +322,42 @@ func (t *InvestigateTool) handleCancel(input InvestigateInput) (InvestigateOutpu
 		return InvestigateOutput{}, fmt.Errorf("release session: %w", err)
 	}
 
+	if t.metrics != nil {
+		t.metrics.RecordInteractiveSessionEnded()
+	}
+
 	t.sessionMu.Delete(input.RRID)
+	t.reconHistory.Delete(input.RRID)
 
 	return InvestigateOutput{
 		SessionID: sess.SessionID,
 		Status:    "cancelled",
 	}, nil
+}
+
+// storeReconstructedContext queries the reconstructor and caches prior turns
+// for the session's lifetime. Returns the number of turns stored.
+func (t *InvestigateTool) storeReconstructedContext(ctx context.Context, rrID, sessionID string) int {
+	turns, _ := t.recon.Reconstruct(ctx, rrID, sessionID)
+	if len(turns) == 0 {
+		return 0
+	}
+
+	history := make([]LLMMessage, len(turns))
+	for i, turn := range turns {
+		history[i] = LLMMessage{Role: turn.Role, Content: turn.Content}
+	}
+	t.reconHistory.Store(rrID, history)
+	return len(history)
+}
+
+// buildMessagesWithContext prepends any cached reconstruction history to the
+// current user message, giving the LLM full prior context (PROD-02).
+func (t *InvestigateTool) buildMessagesWithContext(rrID, userMessage string) []LLMMessage {
+	var messages []LLMMessage
+	if raw, ok := t.reconHistory.Load(rrID); ok {
+		messages = append(messages, raw.([]LLMMessage)...)
+	}
+	messages = append(messages, LLMMessage{Role: "user", Content: userMessage})
+	return messages
 }

--- a/internal/kubernautagent/mcp/tools/metrics.go
+++ b/internal/kubernautagent/mcp/tools/metrics.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+// ToolMetrics abstracts the metrics recording methods needed by MCP tool handlers.
+// Implemented by *metrics.Metrics to avoid a direct import dependency.
+type ToolMetrics interface {
+	RecordInteractiveSessionStarted()
+	RecordInteractiveSessionEnded()
+	RecordInteractiveCommandDuration(tool, action string, durationSeconds float64)
+	RecordInteractiveTakeover(outcome string)
+	RecordInteractiveLeaseContention()
+}

--- a/internal/kubernautagent/mcp/tools/registration.go
+++ b/internal/kubernautagent/mcp/tools/registration.go
@@ -1,0 +1,69 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"context"
+
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// InvestigateRegistration returns a ToolRegistration that registers the
+// kubernaut_investigate tool with the MCP SDK server.
+func InvestigateRegistration(tool *InvestigateTool) mcpinternal.ToolRegistration {
+	return func(server *mcpsdk.Server, userFromCtx func(context.Context) mcpinternal.UserInfo) {
+		mcpsdk.AddTool(server, &mcpsdk.Tool{
+			Name:        "kubernaut_investigate",
+			Description: "Investigate a remediation request interactively. Actions: start, takeover, message, complete, cancel, status.",
+		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, input InvestigateInput) (*mcpsdk.CallToolResult, InvestigateOutput, error) {
+			user := userFromCtx(ctx)
+			output, err := tool.Handle(ctx, input, user)
+			return nil, output, err
+		})
+	}
+}
+
+// EnrichRegistration returns a ToolRegistration that registers the
+// kubernaut_enrich tool with the MCP SDK server.
+func EnrichRegistration(tool *EnrichTool) mcpinternal.ToolRegistration {
+	return func(server *mcpsdk.Server, userFromCtx func(context.Context) mcpinternal.UserInfo) {
+		mcpsdk.AddTool(server, &mcpsdk.Tool{
+			Name:        "kubernaut_enrich",
+			Description: "Enrich a resource with K8s owner chain, labels, and remediation history during an interactive investigation.",
+		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, input EnrichInput) (*mcpsdk.CallToolResult, EnrichOutput, error) {
+			user := userFromCtx(ctx)
+			output, err := tool.Handle(ctx, input, user)
+			return nil, output, err
+		})
+	}
+}
+
+// SelectWorkflowRegistration returns a ToolRegistration that registers the
+// kubernaut_select_workflow tool with the MCP SDK server.
+func SelectWorkflowRegistration(tool *SelectWorkflowTool) mcpinternal.ToolRegistration {
+	return func(server *mcpsdk.Server, userFromCtx func(context.Context) mcpinternal.UserInfo) {
+		mcpsdk.AddTool(server, &mcpsdk.Tool{
+			Name:        "kubernaut_select_workflow",
+			Description: "Select a remediation workflow from the catalog during an interactive investigation.",
+		}, func(ctx context.Context, req *mcpsdk.CallToolRequest, input SelectWorkflowInput) (*mcpsdk.CallToolResult, SelectWorkflowOutput, error) {
+			user := userFromCtx(ctx)
+			output, err := tool.Handle(ctx, input, user)
+			return nil, output, err
+		})
+	}
+}

--- a/internal/kubernautagent/metrics/metrics.go
+++ b/internal/kubernautagent/metrics/metrics.go
@@ -38,6 +38,12 @@ const (
 	MetricNameHTTPRequestsInFlight       = "aiagent_http_requests_in_flight"
 	MetricNameAuthzDeniedTotal           = "aiagent_authz_denied_total"
 	MetricNameAuditEventsEmittedTotal    = "aiagent_audit_events_emitted_total"
+
+	// Interactive mode metrics (PR6a, BR-INTERACTIVE-001..008)
+	MetricNameInteractiveSessionsActive       = "kubernaut_interactive_sessions_active"
+	MetricNameInteractiveCommandDuration      = "kubernaut_interactive_command_duration_seconds"
+	MetricNameInteractiveTakeoverTotal        = "kubernaut_interactive_takeover_total"
+	MetricNameInteractiveLeaseContentionTotal = "kubernaut_interactive_lease_contention_total"
 )
 
 // maxSignalNameLen bounds the signal_name label to prevent Prometheus TSDB
@@ -56,6 +62,12 @@ type Metrics struct {
 	HTTPRequestsInFlight        prometheus.Gauge
 	AuthzDeniedTotal            *prometheus.CounterVec
 	AuditEventsEmittedTotal     *prometheus.CounterVec
+
+	// Interactive mode metrics (PR6a)
+	InteractiveSessionsActive       prometheus.Gauge
+	InteractiveCommandDuration      *prometheus.HistogramVec
+	InteractiveTakeoverTotal        *prometheus.CounterVec
+	InteractiveLeaseContentionTotal prometheus.Counter
 }
 
 var (
@@ -142,6 +154,33 @@ func newMetrics(registry prometheus.Registerer) *Metrics {
 			},
 			[]string{"event_type"},
 		),
+		InteractiveSessionsActive: prometheus.NewGauge(
+			prometheus.GaugeOpts{
+				Name: MetricNameInteractiveSessionsActive,
+				Help: "Number of currently active MCP interactive sessions",
+			},
+		),
+		InteractiveCommandDuration: prometheus.NewHistogramVec(
+			prometheus.HistogramOpts{
+				Name:    MetricNameInteractiveCommandDuration,
+				Help:    "MCP tool call duration in seconds by tool name and action",
+				Buckets: []float64{0.1, 0.5, 1, 2, 5, 10, 30, 60},
+			},
+			[]string{"tool", "action"},
+		),
+		InteractiveTakeoverTotal: prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: MetricNameInteractiveTakeoverTotal,
+				Help: "Total interactive takeover operations by outcome",
+			},
+			[]string{"outcome"},
+		),
+		InteractiveLeaseContentionTotal: prometheus.NewCounter(
+			prometheus.CounterOpts{
+				Name: MetricNameInteractiveLeaseContentionTotal,
+				Help: "Total Lease contention events (another driver holds the Lease)",
+			},
+		),
 	}
 
 	registry.MustRegister(
@@ -154,6 +193,10 @@ func newMetrics(registry prometheus.Registerer) *Metrics {
 		m.HTTPRequestsInFlight,
 		m.AuthzDeniedTotal,
 		m.AuditEventsEmittedTotal,
+		m.InteractiveSessionsActive,
+		m.InteractiveCommandDuration,
+		m.InteractiveTakeoverTotal,
+		m.InteractiveLeaseContentionTotal,
 	)
 
 	return m
@@ -205,4 +248,44 @@ func (m *Metrics) RecordAuditEventEmitted(eventType string) {
 		return
 	}
 	m.AuditEventsEmittedTotal.WithLabelValues(eventType).Inc()
+}
+
+// RecordInteractiveSessionStarted increments the active interactive sessions gauge.
+func (m *Metrics) RecordInteractiveSessionStarted() {
+	if m == nil {
+		return
+	}
+	m.InteractiveSessionsActive.Inc()
+}
+
+// RecordInteractiveSessionEnded decrements the active interactive sessions gauge.
+func (m *Metrics) RecordInteractiveSessionEnded() {
+	if m == nil {
+		return
+	}
+	m.InteractiveSessionsActive.Dec()
+}
+
+// RecordInteractiveCommandDuration observes the duration of an MCP tool call.
+func (m *Metrics) RecordInteractiveCommandDuration(tool, action string, durationSeconds float64) {
+	if m == nil {
+		return
+	}
+	m.InteractiveCommandDuration.WithLabelValues(tool, action).Observe(durationSeconds)
+}
+
+// RecordInteractiveTakeover increments the takeover counter by outcome.
+func (m *Metrics) RecordInteractiveTakeover(outcome string) {
+	if m == nil {
+		return
+	}
+	m.InteractiveTakeoverTotal.WithLabelValues(outcome).Inc()
+}
+
+// RecordInteractiveLeaseContention increments the Lease contention counter.
+func (m *Metrics) RecordInteractiveLeaseContention() {
+	if m == nil {
+		return
+	}
+	m.InteractiveLeaseContentionTotal.Inc()
 }

--- a/internal/kubernautagent/metrics/metrics.go
+++ b/internal/kubernautagent/metrics/metrics.go
@@ -39,11 +39,11 @@ const (
 	MetricNameAuthzDeniedTotal           = "aiagent_authz_denied_total"
 	MetricNameAuditEventsEmittedTotal    = "aiagent_audit_events_emitted_total"
 
-	// Interactive mode metrics (PR6a, BR-INTERACTIVE-001..008)
-	MetricNameInteractiveSessionsActive       = "kubernaut_interactive_sessions_active"
-	MetricNameInteractiveCommandDuration      = "kubernaut_interactive_command_duration_seconds"
-	MetricNameInteractiveTakeoverTotal        = "kubernaut_interactive_takeover_total"
-	MetricNameInteractiveLeaseContentionTotal = "kubernaut_interactive_lease_contention_total"
+	// Interactive MCP mode metrics (PR6a, BR-INTERACTIVE-001..008)
+	MetricNameInteractiveSessionsActive       = "aiagent_mcp_interactive_sessions_active"
+	MetricNameInteractiveCommandDuration      = "aiagent_mcp_interactive_command_duration_seconds"
+	MetricNameInteractiveTakeoverTotal        = "aiagent_mcp_interactive_takeover_total"
+	MetricNameInteractiveLeaseContentionTotal = "aiagent_mcp_interactive_lease_contention_total"
 )
 
 // maxSignalNameLen bounds the signal_name label to prevent Prometheus TSDB

--- a/internal/kubernautagent/server/user_ratelimit.go
+++ b/internal/kubernautagent/server/user_ratelimit.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	sharedauth "github.com/jordigilh/kubernaut/pkg/shared/auth"
+	"golang.org/x/time/rate"
+)
+
+// UserRateLimitConfig configures per-user token-bucket rate limiting (SEC-02).
+type UserRateLimitConfig struct {
+	RequestsPerSecond float64
+	Burst             int
+	CleanupInterval   time.Duration
+	MaxAge            time.Duration
+}
+
+// DefaultUserRateLimitConfig returns sensible defaults for MCP interactive.
+func DefaultUserRateLimitConfig(rps int) UserRateLimitConfig {
+	if rps <= 0 {
+		rps = 10
+	}
+	return UserRateLimitConfig{
+		RequestsPerSecond: float64(rps),
+		Burst:             rps * 2,
+		CleanupInterval:   5 * time.Minute,
+		MaxAge:            10 * time.Minute,
+	}
+}
+
+type userLimiter struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+// UserRateLimiter tracks per-authenticated-user token-bucket limiters.
+// Keyed by the username extracted from request context (set by auth middleware).
+type UserRateLimiter struct {
+	mu       sync.Mutex
+	limiters map[string]*userLimiter
+	cfg      UserRateLimitConfig
+	stopOnce sync.Once
+	stopCh   chan struct{}
+	counter  prometheus.Counter
+}
+
+// NewUserRateLimiter creates a per-user rate limiter and starts background cleanup.
+func NewUserRateLimiter(cfg UserRateLimitConfig, counter prometheus.Counter) *UserRateLimiter {
+	rl := &UserRateLimiter{
+		limiters: make(map[string]*userLimiter),
+		cfg:      cfg,
+		stopCh:   make(chan struct{}),
+		counter:  counter,
+	}
+	go rl.cleanup()
+	return rl
+}
+
+// Stop halts the background cleanup goroutine.
+func (rl *UserRateLimiter) Stop() {
+	rl.stopOnce.Do(func() { close(rl.stopCh) })
+}
+
+func (rl *UserRateLimiter) getLimiter(username string) *rate.Limiter {
+	rl.mu.Lock()
+	defer rl.mu.Unlock()
+
+	entry, ok := rl.limiters[username]
+	if !ok {
+		entry = &userLimiter{
+			limiter: rate.NewLimiter(rate.Limit(rl.cfg.RequestsPerSecond), rl.cfg.Burst),
+		}
+		rl.limiters[username] = entry
+	}
+	entry.lastSeen = time.Now()
+	return entry.limiter
+}
+
+func (rl *UserRateLimiter) cleanup() {
+	ticker := time.NewTicker(rl.cfg.CleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-rl.stopCh:
+			return
+		case <-ticker.C:
+			rl.mu.Lock()
+			cutoff := time.Now().Add(-rl.cfg.MaxAge)
+			for user, entry := range rl.limiters {
+				if entry.lastSeen.Before(cutoff) {
+					delete(rl.limiters, user)
+				}
+			}
+			rl.mu.Unlock()
+		}
+	}
+}
+
+// Middleware returns an http.Handler middleware that rate-limits by authenticated user.
+// Requests without an authenticated user identity are rejected with 401.
+func (rl *UserRateLimiter) Middleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		username := sharedauth.GetUserFromContext(r.Context())
+		if username == "" {
+			http.Error(w, "authentication required", http.StatusUnauthorized)
+			return
+		}
+
+		if !rl.getLimiter(username).Allow() {
+			if rl.counter != nil {
+				rl.counter.Inc()
+			}
+			w.Header().Set("Retry-After", "1")
+			http.Error(w, http.StatusText(http.StatusTooManyRequests), http.StatusTooManyRequests)
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}

--- a/scripts/helm-smoke-test.sh
+++ b/scripts/helm-smoke-test.sh
@@ -1528,6 +1528,74 @@ for d in docs:
     tap_not_ok "UT-MON-463-013: helm lint with monitoring" \
       "helm lint failed with monitoring values"
   fi
+
+  echo "# --- Template Tests: MCP Interactive Mode (#703 PR6a) ---"
+
+  local interactive_out
+
+  # HELM-01: interactive.enabled=true emits interactive: block in ConfigMap
+  interactive_out=$(helm template test "$CHART_PATH" "$tpl_flag" "$tpl_path" \
+    $(template_common_args) $(template_llm_args) $(policy_flags) \
+    --set kubernautAgent.interactive.enabled=true 2>&1)
+  if echo "$interactive_out" | grep -q "interactive:" && \
+     echo "$interactive_out" | grep -q "enabled: true"; then
+    tap_ok "HELM-01: interactive.enabled=true emits interactive: block in ConfigMap"
+  else
+    tap_not_ok "HELM-01: interactive ConfigMap block" \
+      "interactive: block not found when interactive.enabled=true"
+  fi
+
+  # HELM-02: interactive.enabled=true adds Lease RBAC
+  if echo "$interactive_out" | grep -q "coordination.k8s.io" && \
+     echo "$interactive_out" | grep -q "leases"; then
+    tap_ok "HELM-02: interactive.enabled=true adds coordination.k8s.io/leases RBAC"
+  else
+    tap_not_ok "HELM-02: Lease RBAC" \
+      "coordination.k8s.io/leases RBAC not found when interactive enabled"
+  fi
+
+  # HELM-03: interactive.enabled=true adds impersonate RBAC
+  if echo "$interactive_out" | grep -q "impersonate"; then
+    tap_ok "HELM-03: interactive.enabled=true adds impersonate verb RBAC"
+  else
+    tap_not_ok "HELM-03: impersonate RBAC" \
+      "impersonate verb not found when interactive enabled"
+  fi
+
+  # HELM-04: interactive.enabled=false omits interactive: block and RBAC
+  local interactive_off
+  interactive_off=$(helm template test "$CHART_PATH" "$tpl_flag" "$tpl_path" \
+    $(template_common_args) $(template_llm_args) $(policy_flags) 2>&1)
+  if ! echo "$interactive_off" | grep -q "interactive:" && \
+     ! echo "$interactive_off" | grep -q "impersonate"; then
+    tap_ok "HELM-04: interactive disabled omits interactive: block and impersonate RBAC"
+  else
+    tap_not_ok "HELM-04: interactive disabled should omit" \
+      "interactive: or impersonate found when interactive.enabled is false/unset"
+  fi
+
+  # HELM-05: custom sessionTTL and maxConcurrentSessions rendered
+  interactive_out=$(helm template test "$CHART_PATH" "$tpl_flag" "$tpl_path" \
+    $(template_common_args) $(template_llm_args) $(policy_flags) \
+    --set kubernautAgent.interactive.enabled=true \
+    --set kubernautAgent.interactive.sessionTTL=15m \
+    --set kubernautAgent.interactive.maxConcurrentSessions=10 2>&1)
+  if echo "$interactive_out" | grep -q '15m' && \
+     echo "$interactive_out" | grep -q "max_concurrent_sessions: 10"; then
+    tap_ok "HELM-05: custom sessionTTL and maxConcurrentSessions rendered in ConfigMap"
+  else
+    tap_not_ok "HELM-05: custom interactive values" \
+      "Custom sessionTTL or maxConcurrentSessions not rendered"
+  fi
+
+  # HELM-LINT: helm lint passes with interactive enabled
+  if helm lint "$CHART_PATH" $(template_common_args) $(template_llm_args) $(policy_flags) \
+    --set kubernautAgent.interactive.enabled=true >/dev/null 2>&1; then
+    tap_ok "HELM-LINT-INTERACTIVE: helm lint passes with interactive.enabled=true"
+  else
+    tap_not_ok "HELM-LINT-INTERACTIVE: helm lint with interactive" \
+      "helm lint failed with kubernautAgent.interactive.enabled=true"
+  fi
 }
 
 # ---------------------------------------------------------------------------

--- a/test/infrastructure/kubernautagent.go
+++ b/test/infrastructure/kubernautagent.go
@@ -636,6 +636,14 @@ rules:
   - apiGroups: ["metrics.k8s.io"]
     resources: ["pods", "nodes"]
     verbs: ["get", "list"]
+  # Interactive mode: Lease-based session management (#703)
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "create", "update", "delete"]
+  # Interactive mode: user impersonation (DD-AUTH-MCP-001)
+  - apiGroups: [""]
+    resources: ["users", "groups", "serviceaccounts"]
+    verbs: ["impersonate"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -710,6 +718,12 @@ data:
         model: "shadow-eval"
         endpoint: "http://mock-llm-shadow:8080"
         api_key: "mock-shadow-key"
+    interactive:
+      enabled: true
+      session_ttl: "5m"
+      inactivity_timeout: "2m"
+      max_concurrent_sessions: 3
+      rate_limit_per_user: 20
 ---
 apiVersion: apps/v1
 kind: Deployment

--- a/test/integration/kubernautagent/mcp/golden_path_test.go
+++ b/test/integration/kubernautagent/mcp/golden_path_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Golden Path Lifecycle — IT-KA-GOLDEN-001", func() {
 		fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 		sessMgr := mcpinternal.NewLeaseSessionManagerConcrete(fakeClient, "kubernaut", logger)
-		tool = mcptools.NewInvestigateTool(sessMgr, runner, recon, autoMgr)
+		tool = mcptools.NewInvestigateTool(sessMgr, runner, recon, mcptools.WithAutonomousManager(autoMgr))
 	})
 
 	Describe("IT-KA-GOLDEN-001: Full lifecycle: status → takeover → message → status → complete", func() {

--- a/test/integration/kubernautagent/mcp/takeover_test.go
+++ b/test/integration/kubernautagent/mcp/takeover_test.go
@@ -222,9 +222,12 @@ var _ = Describe("MCP Dynamic Takeover Integration — PR4 BR-INTERACTIVE-004", 
 			Expect(err).NotTo(HaveOccurred())
 
 			// Build a real MCP server with the tool registered
-			handler, _ := mcpinternal.BootstrapMCPWithTool(mcpinternal.MCPDeps{
+			handler, _ := mcpinternal.BootstrapMCP(mcpinternal.MCPDeps{
 				AuthMiddleware: fakeAuthMiddleware("alice@example.com"),
-			}, tool)
+				Tools: mcpinternal.ToolDeps{
+					Investigate: tools.InvestigateRegistration(tool),
+				},
+			})
 
 			r := chi.NewRouter()
 			r.Handle("/api/v1/mcp", kaserver.SSEHeadersMiddleware(handler))

--- a/test/integration/kubernautagent/mcp/takeover_test.go
+++ b/test/integration/kubernautagent/mcp/takeover_test.go
@@ -113,6 +113,8 @@ func (m *mockLeaseSessionManager) IsDriverActive(rrID string) bool {
 	return ok
 }
 
+func (m *mockLeaseSessionManager) TouchActivity(_ string) {}
+
 // mockReconIT mocks ContextReconstructor for integration tests.
 type mockReconIT struct{}
 
@@ -167,7 +169,7 @@ var _ = Describe("MCP Dynamic Takeover Integration — PR4 BR-INTERACTIVE-004", 
 			leaseMgr := newMockLeaseSessionManager()
 			runner := &delayedMockRunner{delay: 10 * time.Millisecond, response: "interactive response"}
 			recon := &mockReconIT{}
-			tool := tools.NewInvestigateTool(leaseMgr, runner, recon, autoMgr)
+			tool := tools.NewInvestigateTool(leaseMgr, runner, recon, tools.WithAutonomousManager(autoMgr))
 
 			user := mcpinternal.UserInfo{Username: "sre-operator@example.com"}
 			input := tools.InvestigateInput{
@@ -210,7 +212,7 @@ var _ = Describe("MCP Dynamic Takeover Integration — PR4 BR-INTERACTIVE-004", 
 			}, map[string]string{"remediation_id": "rr-concurrent-001"})
 			Expect(err).NotTo(HaveOccurred())
 
-			tool := tools.NewInvestigateTool(leaseMgr, runner, recon, autoMgr)
+			tool := tools.NewInvestigateTool(leaseMgr, runner, recon, tools.WithAutonomousManager(autoMgr))
 			user := mcpinternal.UserInfo{Username: "alice@example.com"}
 
 			// Perform takeover first

--- a/test/integration/kubernautagent/mcp/tools_call_http_test.go
+++ b/test/integration/kubernautagent/mcp/tools_call_http_test.go
@@ -18,6 +18,7 @@ package mcp_test
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 
@@ -86,6 +87,8 @@ func (m *stubSessionManager) IsDriverActive(rrID string) bool {
 	_, ok := m.sessions[rrID]
 	return ok
 }
+
+func (m *stubSessionManager) TouchActivity(_ string) {}
 
 // stubInvestigatorRunner implements tools.InvestigatorRunner for integration testing.
 type stubInvestigatorRunner struct{}
@@ -186,8 +189,14 @@ var _ = Describe("MCP tools/call over HTTP — PR6a", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.IsError).To(BeFalse(), "tool call should not return error")
 
-			// The structured output contains session_id and status.
+			// QE-02: Decode and verify structured output fields.
 			Expect(result.StructuredContent).NotTo(BeNil())
+			raw, jsonErr := json.Marshal(result.StructuredContent)
+			Expect(jsonErr).NotTo(HaveOccurred())
+			var output map[string]interface{}
+			Expect(json.Unmarshal(raw, &output)).To(Succeed())
+			Expect(output["session_id"]).To(Equal("sess-rr-test-001"))
+			Expect(output["status"]).To(Equal("started"))
 		})
 	})
 
@@ -228,6 +237,26 @@ var _ = Describe("MCP tools/call over HTTP — PR6a", func() {
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.IsError).To(BeFalse())
+
+			// QE-02: Verify the LLM response content is present.
+			Expect(result.StructuredContent).NotTo(BeNil())
+			raw, jsonErr := json.Marshal(result.StructuredContent)
+			Expect(jsonErr).NotTo(HaveOccurred())
+			var output map[string]interface{}
+			Expect(json.Unmarshal(raw, &output)).To(Succeed())
+			Expect(output["status"]).To(Equal("message_received"))
+			Expect(output["response"]).To(Equal("mock LLM response"))
+			Expect(output["session_id"]).To(Equal("sess-rr-test-002"))
+		})
+	})
+
+	Describe("IT-KA-PR6A-TOOLS-004: unauthenticated request returns 401", func() {
+		It("should reject requests without Authorization header", func() {
+			// QE-03: Send request without auth header to verify middleware rejects.
+			resp, err := http.Get(ts.URL + "/mcp")
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
 		})
 	})
 })

--- a/test/integration/kubernautagent/mcp/tools_call_http_test.go
+++ b/test/integration/kubernautagent/mcp/tools_call_http_test.go
@@ -1,0 +1,251 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/go-chi/chi/v5"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+	sharedauth "github.com/jordigilh/kubernaut/pkg/shared/auth"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// fakeAuthMiddlewareWithContext injects the user into the request context
+// via sharedauth.UserContextKey, which the MCP tool handlers use.
+func fakeAuthMiddlewareWithContext(user string) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") == "" {
+				http.Error(w, "Unauthorized", http.StatusUnauthorized)
+				return
+			}
+			ctx := context.WithValue(r.Context(), sharedauth.UserContextKey, user)
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}
+
+// stubSessionManager implements mcp.SessionManager for integration testing.
+type stubSessionManager struct {
+	sessions map[string]*mcpinternal.InteractiveSession
+}
+
+func newStubSessionManager() *stubSessionManager {
+	return &stubSessionManager{sessions: make(map[string]*mcpinternal.InteractiveSession)}
+}
+
+func (m *stubSessionManager) Takeover(_ context.Context, rrID string, user mcpinternal.UserInfo) (*mcpinternal.InteractiveSession, error) {
+	sess := &mcpinternal.InteractiveSession{
+		SessionID:     "sess-" + rrID,
+		CorrelationID: rrID,
+		ActingUser:    user,
+	}
+	m.sessions[rrID] = sess
+	return sess, nil
+}
+
+func (m *stubSessionManager) Release(sessionID string, _ string) error {
+	for k, v := range m.sessions {
+		if v.SessionID == sessionID {
+			delete(m.sessions, k)
+			return nil
+		}
+	}
+	return mcpinternal.ErrSessionNotFound
+}
+
+func (m *stubSessionManager) GetDriver(rrID string) (*mcpinternal.InteractiveSession, error) {
+	if s, ok := m.sessions[rrID]; ok {
+		return s, nil
+	}
+	return nil, nil
+}
+
+func (m *stubSessionManager) IsDriverActive(rrID string) bool {
+	_, ok := m.sessions[rrID]
+	return ok
+}
+
+// stubInvestigatorRunner implements tools.InvestigatorRunner for integration testing.
+type stubInvestigatorRunner struct{}
+
+func (s *stubInvestigatorRunner) RunInteractiveTurn(_ context.Context, _ []tools.LLMMessage, _ string) (string, error) {
+	return "mock LLM response", nil
+}
+
+// stubReconstructor implements mcp.ContextReconstructor for integration testing.
+type stubReconstructor struct{}
+
+func (s *stubReconstructor) Reconstruct(_ context.Context, _ string, _ string) ([]mcpinternal.ConversationTurn, error) {
+	return nil, nil
+}
+
+var _ = Describe("MCP tools/call over HTTP — PR6a", func() {
+
+	var (
+		ts      *httptest.Server
+		cleanup func()
+	)
+
+	BeforeEach(func() {
+		sessMgr := newStubSessionManager()
+		runner := &stubInvestigatorRunner{}
+		recon := &stubReconstructor{}
+
+		investigateTool := tools.NewInvestigateTool(sessMgr, runner, recon)
+
+		toolDeps := mcpinternal.ToolDeps{
+			Investigate: tools.InvestigateRegistration(investigateTool),
+		}
+
+		handler, _ := mcpinternal.BootstrapMCP(mcpinternal.MCPDeps{
+			AuthMiddleware: fakeAuthMiddlewareWithContext("alice@example.com"),
+			Tools:          toolDeps,
+		})
+
+		r := chi.NewRouter()
+		r.Handle("/mcp", handler)
+		r.Handle("/mcp/*", handler)
+		ts = httptest.NewServer(r)
+		cleanup = func() { ts.Close() }
+	})
+
+	AfterEach(func() {
+		cleanup()
+	})
+
+	Describe("IT-KA-PR6A-TOOLS-001: tools/list returns registered tools via SDK client", func() {
+		It("should list kubernaut_investigate via the MCP protocol", func() {
+			ctx := context.Background()
+			client := mcpsdk.NewClient(&mcpsdk.Implementation{
+				Name:    "it-client",
+				Version: "0.0.1",
+			}, nil)
+
+			transport := &mcpsdk.StreamableClientTransport{
+				Endpoint:   ts.URL + "/mcp",
+				HTTPClient: authedHTTPClient("alice@example.com"),
+			}
+			session, err := client.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = session.Close() }()
+
+			var toolNames []string
+			for tool, err := range session.Tools(ctx, nil) {
+				Expect(err).NotTo(HaveOccurred())
+				toolNames = append(toolNames, tool.Name)
+			}
+			Expect(toolNames).To(ContainElement("kubernaut_investigate"))
+		})
+	})
+
+	Describe("IT-KA-PR6A-TOOLS-002: tools/call invokes investigate start action", func() {
+		It("should return session_id and status=started", func() {
+			ctx := context.Background()
+			client := mcpsdk.NewClient(&mcpsdk.Implementation{
+				Name:    "it-client",
+				Version: "0.0.1",
+			}, nil)
+
+			transport := &mcpsdk.StreamableClientTransport{
+				Endpoint:   ts.URL + "/mcp",
+				HTTPClient: authedHTTPClient("alice@example.com"),
+			}
+			session, err := client.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = session.Close() }()
+
+			result, err := session.CallTool(ctx, &mcpsdk.CallToolParams{
+				Name: "kubernaut_investigate",
+				Arguments: map[string]any{
+					"rr_id":  "rr-test-001",
+					"action": "start",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IsError).To(BeFalse(), "tool call should not return error")
+
+			// The structured output contains session_id and status.
+			Expect(result.StructuredContent).NotTo(BeNil())
+		})
+	})
+
+	Describe("IT-KA-PR6A-TOOLS-003: tools/call message action returns LLM response", func() {
+		It("should return the mock LLM response for message action", func() {
+			ctx := context.Background()
+			client := mcpsdk.NewClient(&mcpsdk.Implementation{
+				Name:    "it-client",
+				Version: "0.0.1",
+			}, nil)
+
+			transport := &mcpsdk.StreamableClientTransport{
+				Endpoint:   ts.URL + "/mcp",
+				HTTPClient: authedHTTPClient("alice@example.com"),
+			}
+			session, err := client.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = session.Close() }()
+
+			// Start first to acquire the session.
+			_, err = session.CallTool(ctx, &mcpsdk.CallToolParams{
+				Name: "kubernaut_investigate",
+				Arguments: map[string]any{
+					"rr_id":  "rr-test-002",
+					"action": "start",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Send a message.
+			result, err := session.CallTool(ctx, &mcpsdk.CallToolParams{
+				Name: "kubernaut_investigate",
+				Arguments: map[string]any{
+					"rr_id":   "rr-test-002",
+					"action":  "message",
+					"message": "What caused this pod crash?",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IsError).To(BeFalse())
+		})
+	})
+})
+
+// authedHTTPClient returns an *http.Client that always includes the Authorization header.
+func authedHTTPClient(user string) *http.Client {
+	return &http.Client{
+		Transport: &authedTransport{user: user, base: http.DefaultTransport},
+	}
+}
+
+type authedTransport struct {
+	user string
+	base http.RoundTripper
+}
+
+func (t *authedTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set("Authorization", "Bearer token-for-"+t.user)
+	return t.base.RoundTrip(req)
+}

--- a/test/unit/kubernautagent/mcp/adapters/adapters_test.go
+++ b/test/unit/kubernautagent/mcp/adapters/adapters_test.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapters_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/adapters"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/models"
+	wfclient "github.com/jordigilh/kubernaut/pkg/workflowexecution/client"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// mockWorkflowQuerier is a test double for wfclient.WorkflowQuerier.
+type mockWorkflowQuerier struct {
+	meta *wfclient.WorkflowCatalogMetadata
+	err  error
+}
+
+func (m *mockWorkflowQuerier) ResolveWorkflowCatalogMetadata(_ context.Context, _ string) (*wfclient.WorkflowCatalogMetadata, error) {
+	return m.meta, m.err
+}
+
+func (m *mockWorkflowQuerier) GetWorkflowDependencies(_ context.Context, _ string) (*models.WorkflowDependencies, error) {
+	return nil, nil
+}
+
+func (m *mockWorkflowQuerier) GetWorkflowEngineConfig(_ context.Context, _ string) (json.RawMessage, error) {
+	return nil, nil
+}
+
+func (m *mockWorkflowQuerier) GetWorkflowExecutionEngine(_ context.Context, _ string) (string, string, error) {
+	return "", "", nil
+}
+
+func (m *mockWorkflowQuerier) GetWorkflowExecutionBundle(_ context.Context, _ string) (string, string, error) {
+	return "", "", nil
+}
+
+func (m *mockWorkflowQuerier) GetWorkflowSchemaMetadata(_ context.Context, _ string) (*wfclient.SchemaMetadata, error) {
+	return nil, nil
+}
+
+var _ = Describe("WorkflowCatalogAdapter — PR6a", func() {
+
+	Describe("UT-KA-PR6A-ADAPT-001: maps DS metadata to CatalogWorkflow", func() {
+		It("should map all fields correctly", func() {
+			querier := &mockWorkflowQuerier{
+				meta: &wfclient.WorkflowCatalogMetadata{
+					WorkflowName:       "restart-pod",
+					ExecutionEngine:    "tekton",
+					ExecutionBundle:    "ghcr.io/kubernaut/restart-pod:v1",
+					ServiceAccountName: "remediation-sa",
+				},
+			}
+
+			adapter := adapters.NewWorkflowCatalogAdapter(querier)
+			result, err := adapter.GetWorkflowByID(context.Background(), "wf-123")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.WorkflowID).To(Equal("wf-123"))
+			Expect(result.WorkflowName).To(Equal("restart-pod"))
+			Expect(result.ExecutionEngine).To(Equal("tekton"))
+			Expect(result.ExecutionBundle).To(Equal("ghcr.io/kubernaut/restart-pod:v1"))
+			Expect(result.ServiceAccountName).To(Equal("remediation-sa"))
+		})
+	})
+
+	Describe("UT-KA-PR6A-ADAPT-002: propagates DS errors", func() {
+		It("should wrap and return the error", func() {
+			querier := &mockWorkflowQuerier{err: fmt.Errorf("DS unavailable")}
+
+			adapter := adapters.NewWorkflowCatalogAdapter(querier)
+			_, err := adapter.GetWorkflowByID(context.Background(), "wf-bad")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("DS unavailable"))
+		})
+	})
+
+	Describe("UT-KA-PR6A-ADAPT-003: compile-time interface check", func() {
+		It("should satisfy tools.WorkflowCatalog", func() {
+			var _ tools.WorkflowCatalog = &adapters.WorkflowCatalogAdapter{}
+		})
+	})
+})

--- a/test/unit/kubernautagent/mcp/adapters/adapters_test.go
+++ b/test/unit/kubernautagent/mcp/adapters/adapters_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/adapters"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/models"
@@ -99,4 +100,40 @@ var _ = Describe("WorkflowCatalogAdapter — PR6a", func() {
 			var _ tools.WorkflowCatalog = &adapters.WorkflowCatalogAdapter{}
 		})
 	})
+})
+
+var _ = Describe("ExtractContent — QE-01", func() {
+
+	DescribeTable("maps LoopResult variants to string",
+		func(result investigator.LoopResult, expectedContent string, expectErr bool) {
+			content, err := adapters.ExtractContent(result)
+			if expectErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(content).To(Equal(expectedContent))
+			}
+		},
+		Entry("UT-KA-QE01-001: TextResult",
+			&investigator.TextResult{Content: "analysis in progress"},
+			"analysis in progress", false),
+		Entry("UT-KA-QE01-002: SubmitResult",
+			&investigator.SubmitResult{Content: "root cause: OOM"},
+			"root cause: OOM", false),
+		Entry("UT-KA-QE01-003: SubmitWithWorkflowResult",
+			&investigator.SubmitWithWorkflowResult{Content: "execute restart-pod"},
+			"execute restart-pod", false),
+		Entry("UT-KA-QE01-004: SubmitNoWorkflowResult",
+			&investigator.SubmitNoWorkflowResult{Content: "no remediation needed"},
+			"no remediation needed", false),
+		Entry("UT-KA-QE01-005: ExhaustedResult returns error",
+			&investigator.ExhaustedResult{Reason: "max turns reached"},
+			"", true),
+		Entry("UT-KA-QE01-006: CancelledResult returns error",
+			&investigator.CancelledResult{Turn: 3},
+			"", true),
+		Entry("UT-KA-QE01-007: nil result returns error",
+			nil,
+			"", true),
+	)
 })

--- a/test/unit/kubernautagent/mcp/adapters/suite_test.go
+++ b/test/unit/kubernautagent/mcp/adapters/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapters_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestMCPAdaptersUnit(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Kubernaut Agent MCP Adapters Unit Suite")
+}

--- a/test/unit/kubernautagent/mcp/session_manager_test.go
+++ b/test/unit/kubernautagent/mcp/session_manager_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"log/slog"
 	"os"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -142,6 +143,105 @@ var _ = Describe("LeaseSessionManager — #703 BR-INTERACTIVE-002", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(mgr.IsDriverActive("rr-007")).To(BeTrue())
+		})
+	})
+
+	Describe("UT-KA-SEC01-001: Takeover rejects empty username", func() {
+		It("should return ErrEmptyUsername for anonymous identity", func() {
+			user := mcpinternal.UserInfo{Username: "", Groups: nil}
+			_, err := mgr.Takeover(ctx, "rr-sec01", user)
+			Expect(err).To(MatchError(mcpinternal.ErrEmptyUsername))
+		})
+	})
+
+	Describe("UT-KA-SEC03-001: Takeover enforces maxConcurrentSessions", func() {
+		It("should reject when max sessions reached", func() {
+			mgrLimited := mcpinternal.NewLeaseSessionManager(k8sClient, namespace, logger,
+				mcpinternal.WithMaxConcurrentSessions(2),
+			)
+
+			user := mcpinternal.UserInfo{Username: "alice@example.com"}
+			_, err := mgrLimited.Takeover(ctx, "rr-max-1", user)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = mgrLimited.Takeover(ctx, "rr-max-2", user)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = mgrLimited.Takeover(ctx, "rr-max-3", user)
+			Expect(err).To(MatchError(mcpinternal.ErrMaxSessionsReached))
+		})
+
+		It("should allow new sessions after release", func() {
+			mgrLimited := mcpinternal.NewLeaseSessionManager(k8sClient, namespace, logger,
+				mcpinternal.WithMaxConcurrentSessions(1),
+			)
+
+			user := mcpinternal.UserInfo{Username: "bob@example.com"}
+			sess, err := mgrLimited.Takeover(ctx, "rr-max-release-1", user)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mgrLimited.Release(sess.SessionID, "complete")).To(Succeed())
+
+			_, err = mgrLimited.Takeover(ctx, "rr-max-release-2", user)
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("UT-KA-SEC04-001: GetDriver auto-releases expired sessions (TTL)", func() {
+		It("should return ErrSessionExpired when session TTL has elapsed", func() {
+			mgrShortTTL := mcpinternal.NewLeaseSessionManagerConcrete(k8sClient, namespace, logger,
+				mcpinternal.WithSessionTTL(1*time.Millisecond),
+			)
+
+			user := mcpinternal.UserInfo{Username: "alice@example.com"}
+			_, err := mgrShortTTL.Takeover(ctx, "rr-ttl-001", user)
+			Expect(err).NotTo(HaveOccurred())
+
+			time.Sleep(5 * time.Millisecond)
+
+			sess, err := mgrShortTTL.GetDriver("rr-ttl-001")
+			Expect(err).To(MatchError(mcpinternal.ErrSessionExpired))
+			Expect(sess).To(BeNil())
+
+			Expect(mgrShortTTL.IsDriverActive("rr-ttl-001")).To(BeFalse())
+		})
+	})
+
+	Describe("UT-KA-SEC04-002: GetDriver auto-releases inactive sessions", func() {
+		It("should return ErrSessionExpired when inactivity timeout exceeded", func() {
+			mgrShortInactivity := mcpinternal.NewLeaseSessionManagerConcrete(k8sClient, namespace, logger,
+				mcpinternal.WithSessionTTL(1*time.Hour),
+				mcpinternal.WithInactivityTimeout(1*time.Millisecond),
+			)
+
+			user := mcpinternal.UserInfo{Username: "bob@example.com"}
+			_, err := mgrShortInactivity.Takeover(ctx, "rr-inact-001", user)
+			Expect(err).NotTo(HaveOccurred())
+
+			time.Sleep(5 * time.Millisecond)
+
+			sess, err := mgrShortInactivity.GetDriver("rr-inact-001")
+			Expect(err).To(MatchError(mcpinternal.ErrSessionExpired))
+			Expect(sess).To(BeNil())
+		})
+
+		It("should NOT expire when TouchActivity resets the timer", func() {
+			mgrShortInactivity := mcpinternal.NewLeaseSessionManagerConcrete(k8sClient, namespace, logger,
+				mcpinternal.WithSessionTTL(1*time.Hour),
+				mcpinternal.WithInactivityTimeout(50*time.Millisecond),
+			)
+
+			user := mcpinternal.UserInfo{Username: "charlie@example.com"}
+			_, err := mgrShortInactivity.Takeover(ctx, "rr-inact-002", user)
+			Expect(err).NotTo(HaveOccurred())
+
+			time.Sleep(30 * time.Millisecond)
+			mgrShortInactivity.TouchActivity("rr-inact-002")
+
+			time.Sleep(30 * time.Millisecond)
+			sess, err := mgrShortInactivity.GetDriver("rr-inact-002")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sess).NotTo(BeNil())
 		})
 	})
 })

--- a/test/unit/kubernautagent/mcp/tool_registration_test.go
+++ b/test/unit/kubernautagent/mcp/tool_registration_test.go
@@ -17,58 +17,107 @@ limitations under the License.
 package mcp_test
 
 import (
+	"context"
 	"net/http"
-
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
+	"net/http/httptest"
 
 	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
 	mcptools "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("MCP Tool Registration — PR5 Slice E", func() {
+// stubInvestigate returns a minimal InvestigateTool for registration tests.
+func stubInvestigate() *mcptools.InvestigateTool {
+	return mcptools.NewInvestigateTool(nil, nil, nil)
+}
 
-	Describe("UT-KA-PR5-E01: BootstrapMCP registers all three MCP tools", func() {
-		It("should register investigate, enrich, and select_workflow tools", func() {
+// stubEnrich returns a minimal EnrichTool for registration tests.
+func stubEnrich() *mcptools.EnrichTool {
+	return mcptools.NewEnrichTool(nil, nil)
+}
+
+// stubSelectWorkflow returns a minimal SelectWorkflowTool for registration tests.
+func stubSelectWorkflow() *mcptools.SelectWorkflowTool {
+	return mcptools.NewSelectWorkflowTool(nil, nil)
+}
+
+var _ = Describe("MCP Tool Registration — PR6a", func() {
+
+	Describe("UT-KA-PR6A-001: BootstrapMCP registers all three tools with the MCP SDK", func() {
+		It("should expose 3 tools via the SDK tools/list protocol", func() {
 			deps := mcpinternal.MCPDeps{
 				AuthMiddleware: func(next http.Handler) http.Handler { return next },
 				Tools: mcpinternal.ToolDeps{
-					Investigate:    &mcptools.InvestigateTool{},
-					Enrich:         &mcptools.EnrichTool{},
-					SelectWorkflow: &mcptools.SelectWorkflowTool{},
+					Investigate:    mcptools.InvestigateRegistration(stubInvestigate()),
+					Enrich:         mcptools.EnrichRegistration(stubEnrich()),
+					SelectWorkflow: mcptools.SelectWorkflowRegistration(stubSelectWorkflow()),
 				},
 			}
 
 			handler, srv := mcpinternal.BootstrapMCP(deps)
 			Expect(handler).NotTo(BeNil())
-			Expect(srv.ToolCount()).To(Equal(3),
-				"all three tools (investigate, enrich, select_workflow) must be registered")
+			Expect(srv.ToolCount()).To(Equal(3))
+
+			ts := httptest.NewServer(handler)
+			defer ts.Close()
+
+			ctx := context.Background()
+			client := mcpsdk.NewClient(&mcpsdk.Implementation{
+				Name:    "test-client",
+				Version: "0.0.1",
+			}, nil)
+
+			transport := &mcpsdk.StreamableClientTransport{Endpoint: ts.URL}
+			session, err := client.Connect(ctx, transport, nil)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = session.Close() }()
+
+			var toolNames []string
+			for tool, err := range session.Tools(ctx, nil) {
+				Expect(err).NotTo(HaveOccurred())
+				toolNames = append(toolNames, tool.Name)
+			}
+
+			Expect(toolNames).To(ConsistOf(
+				"kubernaut_investigate",
+				"kubernaut_enrich",
+				"kubernaut_select_workflow",
+			))
 		})
 	})
 
-	Describe("UT-KA-PR5-E02: BootstrapMCP with nil tools registers zero tools", func() {
+	Describe("UT-KA-PR6A-002: BootstrapMCP with nil tools registers zero", func() {
 		It("should register zero tools when no tool deps provided", func() {
 			deps := mcpinternal.MCPDeps{
 				AuthMiddleware: func(next http.Handler) http.Handler { return next },
 			}
 
 			_, srv := mcpinternal.BootstrapMCP(deps)
-			Expect(srv.ToolCount()).To(Equal(0),
-				"no tools should be registered when ToolDeps is zero-value")
+			Expect(srv.ToolCount()).To(Equal(0))
 		})
 	})
 
-	Describe("UT-KA-PR5-E03: BootstrapMCP with partial tools registers only provided tools", func() {
-		It("should register only the investigate tool when others are nil", func() {
+	Describe("UT-KA-PR6A-003: BootstrapMCP with partial tools registers only provided", func() {
+		It("should register only investigate when others are nil", func() {
 			deps := mcpinternal.MCPDeps{
 				AuthMiddleware: func(next http.Handler) http.Handler { return next },
 				Tools: mcpinternal.ToolDeps{
-					Investigate: &mcptools.InvestigateTool{},
+					Investigate: mcptools.InvestigateRegistration(stubInvestigate()),
 				},
 			}
 
 			_, srv := mcpinternal.BootstrapMCP(deps)
 			Expect(srv.ToolCount()).To(Equal(1))
+		})
+	})
+
+	Describe("UT-KA-PR6A-004: BootstrapMCP panics without auth middleware", func() {
+		It("should panic when AuthMiddleware is nil", func() {
+			Expect(func() {
+				mcpinternal.BootstrapMCP(mcpinternal.MCPDeps{})
+			}).To(Panic())
 		})
 	})
 })

--- a/test/unit/kubernautagent/mcp/tools/investigate_test.go
+++ b/test/unit/kubernautagent/mcp/tools/investigate_test.go
@@ -56,6 +56,8 @@ func (m *mockSessionManager) IsDriverActive(_ string) bool {
 	return m.isActive
 }
 
+func (m *mockSessionManager) TouchActivity(_ string) {}
+
 type mockInvestigatorRunner struct {
 	response string
 	err      error

--- a/test/unit/kubernautagent/mcp/tools/status_test.go
+++ b/test/unit/kubernautagent/mcp/tools/status_test.go
@@ -44,6 +44,8 @@ func (m *statusSessionMgr) IsDriverActive(_ string) bool {
 	return m.driverSession != nil
 }
 
+func (m *statusSessionMgr) TouchActivity(_ string) {}
+
 type statusAutoMgr struct {
 	found bool
 }
@@ -57,7 +59,7 @@ var _ = Describe("action=status — PR4 PROD-01 BR-INTERACTIVE-002", func() {
 		It("should return autonomous mode with no driver info", func() {
 			sessMgr := &statusSessionMgr{driverSession: nil}
 			autoMgr := &statusAutoMgr{found: true}
-			tool := mcptools.NewInvestigateTool(sessMgr, nil, nil, autoMgr)
+			tool := mcptools.NewInvestigateTool(sessMgr, nil, nil, mcptools.WithAutonomousManager(autoMgr))
 
 			input := mcptools.InvestigateInput{
 				RRID:   "rr-status-001",
@@ -85,7 +87,7 @@ var _ = Describe("action=status — PR4 PROD-01 BR-INTERACTIVE-002", func() {
 				},
 			}
 			autoMgr := &statusAutoMgr{found: true}
-			tool := mcptools.NewInvestigateTool(sessMgr, nil, nil, autoMgr)
+			tool := mcptools.NewInvestigateTool(sessMgr, nil, nil, mcptools.WithAutonomousManager(autoMgr))
 
 			input := mcptools.InvestigateInput{
 				RRID:   "rr-status-002",
@@ -106,7 +108,7 @@ var _ = Describe("action=status — PR4 PROD-01 BR-INTERACTIVE-002", func() {
 		It("should return not_found mode when autonomous session doesn't exist and no driver", func() {
 			sessMgr := &statusSessionMgr{driverSession: nil}
 			autoMgr := &statusAutoMgr{found: false}
-			tool := mcptools.NewInvestigateTool(sessMgr, nil, nil, autoMgr)
+			tool := mcptools.NewInvestigateTool(sessMgr, nil, nil, mcptools.WithAutonomousManager(autoMgr))
 
 			input := mcptools.InvestigateInput{
 				RRID:   "rr-status-003",

--- a/test/unit/kubernautagent/mcp/tools/takeover_test.go
+++ b/test/unit/kubernautagent/mcp/tools/takeover_test.go
@@ -79,6 +79,8 @@ func (m *takeoverSessMgr) IsDriverActive(_ string) bool {
 	return m.driverActive
 }
 
+func (m *takeoverSessMgr) TouchActivity(_ string) {}
+
 // takeoverRunner mocks tools.InvestigatorRunner for takeover tests.
 type takeoverRunner struct {
 	response string
@@ -141,7 +143,7 @@ var _ = Describe("kubernaut_investigate — Dynamic Takeover (PR4, BR-INTERACTIV
 		}
 		runner = &takeoverRunner{response: "LLM response here"}
 		recon = &takeoverRecon{}
-		tool = tools.NewInvestigateTool(sessMgr, runner, recon, autoMgr)
+		tool = tools.NewInvestigateTool(sessMgr, runner, recon, tools.WithAutonomousManager(autoMgr))
 		ctx = context.Background()
 	})
 

--- a/test/unit/kubernautagent/server/user_ratelimit_test.go
+++ b/test/unit/kubernautagent/server/user_ratelimit_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kaserver "github.com/jordigilh/kubernaut/internal/kubernautagent/server"
+	sharedauth "github.com/jordigilh/kubernaut/pkg/shared/auth"
+)
+
+var _ = Describe("UserRateLimiter — SEC-02", func() {
+
+	var (
+		rl      *kaserver.UserRateLimiter
+		handler http.Handler
+	)
+
+	BeforeEach(func() {
+		cfg := kaserver.UserRateLimitConfig{
+			RequestsPerSecond: 2,
+			Burst:             2,
+			CleanupInterval:   5 * 60 * 1e9,
+			MaxAge:            10 * 60 * 1e9,
+		}
+		rl = kaserver.NewUserRateLimiter(cfg, nil)
+
+		handler = rl.Middleware(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+	})
+
+	AfterEach(func() {
+		rl.Stop()
+	})
+
+	Describe("UT-KA-SEC02-001: rejects unauthenticated requests with 401", func() {
+		It("should return 401 when no user in context", func() {
+			req := httptest.NewRequest(http.MethodGet, "/mcp", nil)
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			Expect(rec.Code).To(Equal(http.StatusUnauthorized))
+		})
+	})
+
+	Describe("UT-KA-SEC02-002: allows requests within rate limit", func() {
+		It("should return 200 for authenticated requests within burst", func() {
+			req := authedRequest("alice@example.com")
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			Expect(rec.Code).To(Equal(http.StatusOK))
+		})
+	})
+
+	Describe("UT-KA-SEC02-003: rejects requests exceeding per-user limit", func() {
+		It("should return 429 after burst is exhausted", func() {
+			for i := 0; i < 2; i++ {
+				req := authedRequest("bob@example.com")
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+				Expect(rec.Code).To(Equal(http.StatusOK))
+			}
+
+			req := authedRequest("bob@example.com")
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			Expect(rec.Code).To(Equal(http.StatusTooManyRequests))
+			Expect(rec.Header().Get("Retry-After")).To(Equal("1"))
+		})
+	})
+
+	Describe("UT-KA-SEC02-004: rate limits are per-user (isolation)", func() {
+		It("should not affect one user when another is rate limited", func() {
+			for i := 0; i < 3; i++ {
+				req := authedRequest("heavy-user@example.com")
+				rec := httptest.NewRecorder()
+				handler.ServeHTTP(rec, req)
+			}
+
+			req := authedRequest("fresh-user@example.com")
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+			Expect(rec.Code).To(Equal(http.StatusOK))
+		})
+	})
+})
+
+func authedRequest(username string) *http.Request {
+	req := httptest.NewRequest(http.MethodPost, "/mcp", nil)
+	ctx := context.WithValue(req.Context(), sharedauth.UserContextKey, username)
+	return req.WithContext(ctx)
+}


### PR DESCRIPTION
## Summary

This PR completes the **PR6a** slice of the CP-5 Release Gate for #703 (MCP Interactive Mode). It addresses all critical findings from the wiring verification audit:

- **Fix BootstrapMCP** to actually register tools with the MCP SDK server via `mcp.AddTool()` (previously only incremented a counter — tools were invisible to clients)
- **Wire production tools** in `cmd/kubernautagent/main.go` with real `InvestigatorRunnerAdapter`, `WorkflowCatalogAdapter`, `LeaseSessionManager`, and `DSContextReconstructor`
- **Add Helm chart** interactive config block, impersonate RBAC, and JSON schema validation
- **Add Prometheus metrics** for interactive sessions (active gauge, command duration, takeover count, lease contention)
- **Add integration tests** proving the full `tools/call` chain over HTTP works end-to-end via the official MCP SDK client

### Key Changes

| Area | What |
|------|------|
| `internal/kubernautagent/mcp/server.go` | `ToolRegistration` function type, `registerTools`, `BootstrapMCPNoAuth`, panic guard |
| `internal/kubernautagent/mcp/tools/registration.go` | `InvestigateRegistration`, `EnrichRegistration`, `SelectWorkflowRegistration` |
| `internal/kubernautagent/mcp/adapters/adapters.go` | `InvestigatorRunnerAdapter`, `WorkflowCatalogAdapter` |
| `cmd/kubernautagent/main.go` | `buildMCPHandler()` with full dependency wiring |
| `charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml` | Conditional `interactive:` ConfigMap block + impersonate RBAC |
| `charts/kubernaut/values.schema.json` | `kubernautAgent.interactive` schema object |
| `scripts/helm-smoke-test.sh` | HELM-01..05 template tests |
| `internal/kubernautagent/metrics/metrics.go` | 4 new interactive Prometheus metrics |
| `test/infrastructure/kubernautagent.go` | E2E ConfigMap + Lease/impersonate RBAC |

## Test plan

- [x] Unit tests: BootstrapMCP registers tools via SDK `tools/list` (UT-KA-PR6A-001..004)
- [x] Unit tests: WorkflowCatalogAdapter maps DS metadata correctly (UT-KA-PR6A-ADAPT-001..003)
- [x] Integration tests: `tools/call` over HTTP returns session + LLM response (IT-KA-PR6A-TOOLS-001..003)
- [x] Helm smoke tests: interactive ConfigMap, RBAC, schema validation (HELM-01..05)
- [x] Full project `go build ./...` clean
- [x] All 105 MCP unit tests + 11 integration tests pass with zero regressions


Made with [Cursor](https://cursor.com)