### PR TITLE
fix(#922): shadow agent fails with vertex_ai provider

### DIFF
--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -43,7 +43,6 @@ import (
 	sharedaudit "github.com/jordigilh/kubernaut/pkg/audit"
 	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
-	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm/langchaingo"
 	sharedhealth "github.com/jordigilh/kubernaut/pkg/shared/health"
 
 	auth "github.com/jordigilh/kubernaut/pkg/shared/auth"
@@ -208,9 +207,7 @@ func main() {
 			alignStaticCfg, alignRtCfg := cfg.AI.AlignmentCheck.EffectiveLLM(cfg.AI.LLM, *llmRuntime)
 			alignCfgMerge := *cfg
 			alignCfgMerge.AI.LLM = alignStaticCfg
-			raw, alignErr := langchaingo.New(
-				alignStaticCfg.Provider, alignRtCfg.Endpoint, alignRtCfg.Model, alignRtCfg.APIKey,
-				buildLLMProviderOpts(&alignCfgMerge, &alignRtCfg)...)
+			raw, alignErr := buildLLMClientFromConfig(context.Background(), &alignCfgMerge, &alignRtCfg)
 			if alignErr != nil {
 				slogger.Error("alignment check LLM client failed (fail-closed): alignment is enabled but shadow client unavailable", "error", alignErr)
 				os.Exit(1)


### PR DESCRIPTION
## Summary

Fixes #922 — shadow agent (alignment check) fails with `unsupported LLM provider: "vertex_ai"` when using a dedicated shadow LLM config.

The shadow agent called `langchaingo.New()` directly, bypassing the `vertex_ai` routing in `buildLLMClientFromConfig()`. Now it uses the same provider dispatch as the main investigation client.

**1 file changed, 1 line added, 4 lines removed** — `cmd/kubernautagent/main.go`.

## Test plan

- [x] `go build ./cmd/kubernautagent/...` passes
- [x] `go vet ./cmd/kubernautagent/...` passes
- [x] KA unit tests: 9/9 pass
- [ ] CI


Made with [Cursor](https://cursor.com)