### PR TITLE
fix(#925): strip markdown fences from shadow agent evaluator responses

### DIFF
--- a/internal/kubernautagent/alignment/evaluator.go
+++ b/internal/kubernautagent/alignment/evaluator.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"regexp"
 	"strings"
 	"time"
 
@@ -144,7 +145,8 @@ func (e *Evaluator) EvaluateStep(ctx context.Context, step Step) Observation {
 		}
 
 		var parsed evalResponse
-		if jsonErr := json.Unmarshal([]byte(respContent), &parsed); jsonErr != nil {
+		content := extractJSON(respContent)
+		if jsonErr := json.Unmarshal([]byte(content), &parsed); jsonErr != nil {
 			lastErr = fmt.Errorf("parse evaluator response: %w", jsonErr)
 			continue
 		}
@@ -177,6 +179,20 @@ func (e *Evaluator) EvaluateStep(ctx context.Context, step Step) Observation {
 		Suspicious:  true,
 		Explanation: fmt.Sprintf("evaluator_unavailable (fail-closed): %v", lastErr),
 	}
+}
+
+// markdownFenceRe matches ```json ... ``` or ``` ... ``` blocks, with
+// optional leading/trailing whitespace. Issue #925: some models (e.g. Haiku
+// 4.5) wrap JSON in markdown fences even when JSONMode is requested.
+var markdownFenceRe = regexp.MustCompile("(?s)^\\s*```(?:json)?\\s*\n(.*?)\\s*```\\s*$")
+
+// extractJSON strips markdown code fences if present, returning the inner
+// content. If the input is not fenced, it is returned as-is after trimming.
+func extractJSON(s string) string {
+	if m := markdownFenceRe.FindStringSubmatch(s); len(m) == 2 {
+		return strings.TrimSpace(m[1])
+	}
+	return strings.TrimSpace(s)
 }
 
 const truncationMarker = "…[truncated]…"

--- a/test/unit/kubernautagent/alignment/alignment_test.go
+++ b/test/unit/kubernautagent/alignment/alignment_test.go
@@ -523,6 +523,53 @@ var _ = Describe("Fail-closed behavior — BR-AI-601", func() {
 		})
 	})
 
+	Describe("UT-SA-925-001: EvaluateStep strips markdown fences from JSON response", func() {
+		It("should parse JSON wrapped in ```json fences (Haiku 4.5 format)", func() {
+			resp := llm.ChatResponse{
+				Message: llm.Message{Role: "assistant", Content: "```json\n{\"suspicious\":false,\"explanation\":\"clean\"}\n```"},
+			}
+			client := &mockLLMClient{responses: []llm.ChatResponse{resp}}
+			evaluator := alignment.NewEvaluator(client, alignment.EvaluatorConfig{
+				Timeout: 5 * time.Second, MaxStepTokens: 4000, MaxRetries: 1,
+			}, "")
+			step := alignment.Step{Index: 0, Kind: alignment.StepKindToolResult, Content: "pod restarted"}
+
+			obs := evaluator.EvaluateStep(context.Background(), step)
+			Expect(obs.Suspicious).To(BeFalse(), "should parse JSON from markdown fences")
+			Expect(obs.Explanation).To(Equal("clean"))
+		})
+
+		It("should parse JSON wrapped in bare ``` fences (no language tag)", func() {
+			resp := llm.ChatResponse{
+				Message: llm.Message{Role: "assistant", Content: "```\n{\"suspicious\":true,\"explanation\":\"injected\"}\n```"},
+			}
+			client := &mockLLMClient{responses: []llm.ChatResponse{resp}}
+			evaluator := alignment.NewEvaluator(client, alignment.EvaluatorConfig{
+				Timeout: 5 * time.Second, MaxStepTokens: 4000, MaxRetries: 1,
+			}, "")
+			step := alignment.Step{Index: 0, Kind: alignment.StepKindToolResult, Content: "c"}
+
+			obs := evaluator.EvaluateStep(context.Background(), step)
+			Expect(obs.Suspicious).To(BeTrue())
+			Expect(obs.Explanation).To(Equal("injected"))
+		})
+
+		It("should parse JSON with leading/trailing whitespace around fences", func() {
+			resp := llm.ChatResponse{
+				Message: llm.Message{Role: "assistant", Content: "  \n```json\n{\"suspicious\":false,\"explanation\":\"ok\"}\n```\n  "},
+			}
+			client := &mockLLMClient{responses: []llm.ChatResponse{resp}}
+			evaluator := alignment.NewEvaluator(client, alignment.EvaluatorConfig{
+				Timeout: 5 * time.Second, MaxStepTokens: 4000, MaxRetries: 1,
+			}, "")
+			step := alignment.Step{Index: 0, Kind: alignment.StepKindToolResult, Content: "c"}
+
+			obs := evaluator.EvaluateStep(context.Background(), step)
+			Expect(obs.Suspicious).To(BeFalse())
+			Expect(obs.Explanation).To(Equal("ok"))
+		})
+	})
+
 	Describe("UT-SA-601-FC-003: Observer WaitResult reports incomplete on timeout", func() {
 		It("should return Complete=false and correct Pending count when timeout elapses", func() {
 			slowClient := &slowMockLLMClient{delay: 500 * time.Millisecond}


### PR DESCRIPTION
## Summary

Fixes #925 — Shadow agent alignment check fails to parse Haiku 4.5 responses that wrap JSON in markdown code fences.

Some models (Claude Haiku 4.5 on Vertex AI) return responses like:

````
```json
{"suspicious":false,"explanation":"clean"}
```
````

The evaluator's `json.Unmarshal` fails on the leading backtick, triggering fail-closed semantics that abort the entire investigation.

### Fix

Added `extractJSON()` helper that strips `` ```json ... ``` `` and `` ``` ... ``` `` fences before JSON parsing. Plain JSON (no fences) continues to work unchanged.

**2 files changed** — `internal/kubernautagent/alignment/evaluator.go` + 3 new test specs in `alignment_test.go`.

## Test plan

- [x] 3 new specs: fenced JSON, bare fences, whitespace-padded fences
- [x] Full alignment suite: 56/56 pass (no regression)
- [x] `go build` / `go vet` pass
- [ ] CI


Made with [Cursor](https://cursor.com)