### PR TITLE
fix: resolve KA UT data races and CI errcheck lint violations

### DIFF
--- a/pkg/kubernautagent/llm/vertexanthropic/client.go
+++ b/pkg/kubernautagent/llm/vertexanthropic/client.go
@@ -326,7 +326,9 @@ func (c *Client) StreamChat(ctx context.Context, req llm.ChatRequest, callback f
 	acc := anthropic.Message{}
 	for stream.Next() {
 		event := stream.Current()
-		acc.Accumulate(event)
+		if err := acc.Accumulate(event); err != nil {
+			return llm.ChatResponse{}, fmt.Errorf("vertexanthropic: accumulate error: %w", err)
+		}
 		if delta, ok := extractTextDelta(event); ok && delta != "" {
 			if err := callback(llm.ChatStreamEvent{Delta: delta}); err != nil {
 				return llm.ChatResponse{}, err

--- a/test/integration/gateway/security_integration_test.go
+++ b/test/integration/gateway/security_integration_test.go
@@ -66,9 +66,9 @@ var _ = Describe("Issue #673 C-ADV-2: Generic Processing Error (BR-GATEWAY-182)"
 		Expect(os.Setenv("KUBERNAUT_CONTROLLER_NAMESPACE", "kubernaut-system")).To(Succeed())
 		DeferCleanup(func() {
 			if previousNS != "" {
-				os.Setenv("KUBERNAUT_CONTROLLER_NAMESPACE", previousNS)
+				Expect(os.Setenv("KUBERNAUT_CONTROLLER_NAMESPACE", previousNS)).To(Succeed())
 			} else {
-				os.Unsetenv("KUBERNAUT_CONTROLLER_NAMESPACE")
+				Expect(os.Unsetenv("KUBERNAUT_CONTROLLER_NAMESPACE")).To(Succeed())
 			}
 		})
 

--- a/test/integration/gateway/timeout_integration_test.go
+++ b/test/integration/gateway/timeout_integration_test.go
@@ -63,9 +63,9 @@ var _ = Describe("Issue #673 L-3: K8s API Timeout (BR-GATEWAY-102)", Ordered, fu
 			Expect(os.Setenv("KUBERNAUT_CONTROLLER_NAMESPACE", "kubernaut-system")).To(Succeed())
 			DeferCleanup(func() {
 				if previousNS != "" {
-					os.Setenv("KUBERNAUT_CONTROLLER_NAMESPACE", previousNS)
+					Expect(os.Setenv("KUBERNAUT_CONTROLLER_NAMESPACE", previousNS)).To(Succeed())
 				} else {
-					os.Unsetenv("KUBERNAUT_CONTROLLER_NAMESPACE")
+					Expect(os.Unsetenv("KUBERNAUT_CONTROLLER_NAMESPACE")).To(Succeed())
 				}
 			})
 
@@ -226,9 +226,9 @@ var _ = Describe("Issue #673 L-3: K8s API Timeout (BR-GATEWAY-102)", Ordered, fu
 			Expect(os.Setenv("KUBERNAUT_CONTROLLER_NAMESPACE", "kubernaut-system")).To(Succeed())
 			DeferCleanup(func() {
 				if previousNS != "" {
-					os.Setenv("KUBERNAUT_CONTROLLER_NAMESPACE", previousNS)
+					Expect(os.Setenv("KUBERNAUT_CONTROLLER_NAMESPACE", previousNS)).To(Succeed())
 				} else {
-					os.Unsetenv("KUBERNAUT_CONTROLLER_NAMESPACE")
+					Expect(os.Unsetenv("KUBERNAUT_CONTROLLER_NAMESPACE")).To(Succeed())
 				}
 			})
 

--- a/test/integration/kubernautagent/server/wiring_test.go
+++ b/test/integration/kubernautagent/server/wiring_test.go
@@ -221,7 +221,7 @@ var _ = Describe("Wiring Integration Tests — #823", func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusNotFound),
 				"non-owner should receive 404 for session status")
 
-			h.Manager.CancelInvestigation(id)
+			Expect(h.Manager.CancelInvestigation(id)).To(Succeed())
 		})
 	})
 
@@ -254,7 +254,7 @@ var _ = Describe("Wiring Integration Tests — #823", func() {
 			Expect(denied[0].Data["requesting_user"]).To(Equal("attacker-user"))
 			Expect(denied[0].SessionID).To(Equal(id))
 
-			h.Manager.CancelInvestigation(id)
+			Expect(h.Manager.CancelInvestigation(id)).To(Succeed())
 		})
 	})
 
@@ -288,7 +288,7 @@ var _ = Describe("Wiring Integration Tests — #823", func() {
 			observed := h.AuditStore.EventsOfType(audit.EventTypeSessionObserved)
 			Expect(observed[0].Data["observer_user"]).To(Equal("observer-user"))
 
-			h.Manager.CancelInvestigation(id)
+			Expect(h.Manager.CancelInvestigation(id)).To(Succeed())
 		})
 	})
 
@@ -398,7 +398,7 @@ var _ = Describe("Wiring Integration Tests — #823", func() {
 			Expect(resp.StatusCode).To(Equal(http.StatusConflict),
 				"snapshot of running session should return 409 Conflict")
 
-			h.Manager.CancelInvestigation(id)
+			Expect(h.Manager.CancelInvestigation(id)).To(Succeed())
 		})
 	})
 
@@ -973,7 +973,7 @@ var _ = Describe("Metrics Wiring Integration Tests — BR-KA-OBSERVABILITY-001",
 			Expect(v).To(BeNumerically(">=", 1),
 				"owner_mismatch reason should be recorded when a different user accesses the session")
 
-			h.Manager.CancelInvestigation(id)
+			Expect(h.Manager.CancelInvestigation(id)).To(Succeed())
 		})
 	})
 

--- a/test/unit/kubernautagent/mcp/event_store_test.go
+++ b/test/unit/kubernautagent/mcp/event_store_test.go
@@ -76,9 +76,9 @@ var _ = Describe("DelegatingEventStore + SessionClosedHandler + Janitor — PR4 
 		It("should invoke the release callback with the closed session ID", func() {
 			des := mcpinternal.NewDelegatingEventStore()
 
-			var receivedID string
+			released := make(chan string, 1)
 			handler := mcpinternal.NewSessionClosedHandler(des, func(mcpSessionID string) {
-				receivedID = mcpSessionID
+				released <- mcpSessionID
 			}, slog.Default())
 
 			ctx, cancel := context.WithCancel(context.Background())
@@ -88,7 +88,7 @@ var _ = Describe("DelegatingEventStore + SessionClosedHandler + Janitor — PR4 
 			des.RegisterMCPSession("mcp-sess-003", "interactive-sess-003")
 			_ = des.SessionClosed(context.Background(), "mcp-sess-003")
 
-			Eventually(func() string { return receivedID }).Should(Equal("mcp-sess-003"))
+			Eventually(released).Should(Receive(Equal("mcp-sess-003")))
 		})
 	})
 
@@ -96,15 +96,15 @@ var _ = Describe("DelegatingEventStore + SessionClosedHandler + Janitor — PR4 
 		It("should clean sessions older than TTL", func() {
 			janitor := mcpinternal.NewSessionJanitor(50*time.Millisecond, slog.Default())
 
-			expired := false
+			expiredCh := make(chan string, 1)
 			janitor.Track("stale-sess-001", time.Now().Add(-1*time.Hour), func(sessionID string) {
-				expired = true
+				expiredCh <- sessionID
 			})
 
 			ctx, cancel := context.WithCancel(context.Background())
 			go janitor.Run(ctx)
 
-			Eventually(func() bool { return expired }).Should(BeTrue())
+			Eventually(expiredCh).Should(Receive(Equal("stale-sess-001")))
 			cancel()
 		})
 	})


### PR DESCRIPTION
## Summary
- Fix 2 data races in `event_store_test.go` (UT-KA-SESS-011, UT-KA-SESS-012) that caused the **Unit Tests (kubernautagent)** CI job to fail with exit code 2. Bare variables shared between goroutines replaced with buffered channels, matching the existing pattern in UT-KA-SESS-006.
- Fix 12 errcheck lint violations across 4 files that caused the **Lint (Go Services)** CI job to fail: `wiring_test.go` (5x `CancelInvestigation`), `timeout_integration_test.go` (4x `os.Setenv`/`os.Unsetenv`), `security_integration_test.go` (2x same), `vertexanthropic/client.go` (1x `acc.Accumulate`).

Addresses CI failures in [pipeline run #1532](https://github.com/jordigilh/kubernaut/actions/runs/25216941690) (PR #828).

## Test plan
- [x] `go build ./...` passes
- [x] `make test-unit-kubernautagent` passes (28 suites, 0 failures, 0 data races)
- [x] `golangci-lint run` shows no errcheck violations in the 5 modified files


Made with [Cursor](https://cursor.com)