### PR TITLE
fix(#935): adopt logr logging standard for Kubernaut Agent (DD-005)

### DIFF
--- a/cmd/kubernautagent/llm_builder.go
+++ b/cmd/kubernautagent/llm_builder.go
@@ -19,9 +19,10 @@ package main
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"strings"
+
+	"github.com/go-logr/logr"
 
 	kaconfig "github.com/jordigilh/kubernaut/internal/kubernautagent/config"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
@@ -115,40 +116,40 @@ func buildTransportChain(cfg *kaconfig.Config, rt *kaconfig.LLMRuntimeConfig) ht
 func llmRuntimeReloadCallback(
 	staticCfg *kaconfig.Config,
 	swappable *llm.SwappableClient,
-	logger *slog.Logger,
+	logger logr.Logger,
 ) func(newContent string) error {
 	return func(newContent string) error {
 		oldModel := swappable.ModelName()
 
 		if strings.TrimSpace(newContent) == "" {
-			logger.Warn("llm_runtime_reload rejected: empty content",
+			logger.Info("llm_runtime_reload rejected: empty content",
 				"event", "llm_runtime_reload", "status", "rejected", "reason", "empty_content")
 			return fmt.Errorf("llm runtime reload rejected: empty or whitespace-only content")
 		}
 
 		rt, err := kaconfig.LoadLLMRuntime([]byte(newContent))
 		if err != nil {
-			logger.Error("llm_runtime_reload failed: parse error",
-				"event", "llm_runtime_reload", "status", "error", "error", err)
+			logger.Error(err, "llm_runtime_reload failed: parse error",
+				"event", "llm_runtime_reload", "status", "error")
 			return fmt.Errorf("reload: parsing llm runtime config: %w", err)
 		}
 
 		if err := rt.Validate(staticCfg.AI.LLM.Provider); err != nil {
-			logger.Warn("llm_runtime_reload rejected: validation failed",
+			logger.Info("llm_runtime_reload rejected: validation failed",
 				"event", "llm_runtime_reload", "status", "rejected", "error", err)
 			return fmt.Errorf("reload: validation failed: %w", err)
 		}
 
 		newClient, err := buildLLMClientFromConfig(context.Background(), staticCfg, rt)
 		if err != nil {
-			logger.Error("llm_runtime_reload failed: client build error",
-				"event", "llm_runtime_reload", "status", "error", "error", err)
+			logger.Error(err, "llm_runtime_reload failed: client build error",
+				"event", "llm_runtime_reload", "status", "error")
 			return fmt.Errorf("reload: building LLM client: %w", err)
 		}
 
 		if err := swappable.Swap(newClient, rt.Model); err != nil {
-			logger.Error("llm_runtime_reload failed: swap error",
-				"event", "llm_runtime_reload", "status", "error", "error", err)
+			logger.Error(err, "llm_runtime_reload failed: swap error",
+				"event", "llm_runtime_reload", "status", "error")
 			return fmt.Errorf("reload: swapping client: %w", err)
 		}
 

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
@@ -68,6 +67,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/registry"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/sanitization"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/summarizer"
+	kubelog "github.com/jordigilh/kubernaut/pkg/log"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/rest"
 	metricsclient "k8s.io/metrics/pkg/client/clientset/versioned"
@@ -85,66 +85,64 @@ func main() {
 	flag.Parse()
 
 	// Bootstrap logger at INFO for startup; replaced after config is loaded (#875).
-	bootHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelInfo})
-	slogger := slog.New(bootHandler)
+	logger := kubelog.NewLogger(kubelog.Options{Level: 0, ServiceName: "kubernaut-agent"})
 
 	cfgData, err := os.ReadFile(configPath)
 	if err != nil {
-		slogger.Error("failed to read config", "path", configPath, "error", err)
+		logger.Error(err, "failed to read config", "path", configPath)
 		os.Exit(1)
 	}
 	cfg, err := kaconfig.Load(cfgData)
 	if err != nil {
-		slogger.Error("failed to parse config", "error", err)
+		logger.Error(err, "failed to parse config")
 		os.Exit(1)
 	}
 
-	// Re-create logger with configured level (#875).
-	slogHandler := slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: cfg.Runtime.Logging.SlogLevel()})
-	slogger = slog.New(slogHandler)
-	logrLogger := logr.FromSlogHandler(slogHandler)
+	atomicLevel := cfg.Runtime.Logging.NewAtomicLevel()
+	logger = kubelog.NewLoggerWithAtomicLevel(kubelog.Options{ServiceName: "kubernaut-agent"}, atomicLevel)
+	defer kubelog.Sync(logger)
 
-	slogger.Info("log level configured", "level", cfg.Runtime.Logging.Level)
+	logger.Info("log level configured", "level", cfg.Runtime.Logging.Level)
 
 	llmRtData, err := os.ReadFile(llmRuntimePath)
 	if err != nil {
-		slogger.Error("failed to read llm runtime config", "path", llmRuntimePath, "error", err)
+		logger.Error(err, "failed to read llm runtime config", "path", llmRuntimePath)
 		os.Exit(1)
 	}
 	llmRuntime, err := kaconfig.LoadLLMRuntime(llmRtData)
 	if err != nil {
-		slogger.Error("failed to parse llm runtime config", "error", err)
+		logger.Error(err, "failed to parse llm runtime config")
 		os.Exit(1)
 	}
 
 	if llmRuntime.APIKey == "" {
 		const credDir = "/etc/kubernaut-agent/credentials" // pre-commit:allow-sensitive (mount path)
-		llmRuntime.APIKey = credentials.ResolveCredentialsFile(cfg.AI.LLM.Provider, credDir, slogger)
+		llmRuntime.APIKey = credentials.ResolveCredentialsFile(cfg.AI.LLM.Provider, credDir, logger)
 	}
 
 	switch cfg.AI.LLM.Provider {
 	case "vertex", "vertex_ai":
 		if llmRuntime.APIKey == "" {
-			slogger.Warn("GCP provider configured without credentials — requests will use ambient ADC if available",
+			logger.Info("GCP provider configured without credentials — requests will use ambient ADC if available",
 				"provider", cfg.AI.LLM.Provider)
 		}
 	}
 
 	if cfg.AI.LLM.OAuth2.Enabled {
 		if err := cfg.AI.LLM.OAuth2.ResolveOAuth2Credentials(); err != nil {
-			slogger.Error("failed to resolve OAuth2 credentials from mounted Secret", "error", err)
+			logger.Error(err, "failed to resolve OAuth2 credentials from mounted Secret")
 			os.Exit(1)
 		}
-		slogger.Info("OAuth2 credentials resolved from mounted Secret",
+		logger.Info("OAuth2 credentials resolved from mounted Secret",
 			"credentialsDir", cfg.AI.LLM.OAuth2.CredentialsDir)
 	}
 
 	if err := cfg.Validate(); err != nil {
-		slogger.Error("invalid configuration", "error", err)
+		logger.Error(err, "invalid configuration")
 		os.Exit(1)
 	}
 	if err := llmRuntime.Validate(cfg.AI.LLM.Provider); err != nil {
-		slogger.Error("invalid llm runtime configuration", "error", err)
+		logger.Error(err, "invalid llm runtime configuration")
 		os.Exit(1)
 	}
 
@@ -152,46 +150,46 @@ func main() {
 		addr = fmt.Sprintf("%s:%d", cfg.Runtime.Server.Address, cfg.Runtime.Server.Port)
 	}
 
-	slogger.Info("starting Kubernaut Agent", "addr", addr, "config", configPath)
+	logger.Info("starting Kubernaut Agent", "addr", addr, "config", configPath)
 
 	llmClient, err := buildLLMClientFromConfig(context.Background(), cfg, llmRuntime)
 	if err != nil {
-		slogger.Error("failed to create LLM client", "provider", cfg.AI.LLM.Provider, "error", err)
+		logger.Error(err, "failed to create LLM client", "provider", cfg.AI.LLM.Provider)
 		os.Exit(1)
 	}
 
 	swappable, err := llm.NewSwappableClient(llmClient, llmRuntime.Model)
 	if err != nil {
-		slogger.Error("failed to create swappable LLM client", "error", err)
+		logger.Error(err, "failed to create swappable LLM client")
 		os.Exit(1)
 	}
 
 	promptBuilder, err := prompt.NewBuilder()
 	if err != nil {
-		slogger.Error("failed to create prompt builder", "error", err)
+		logger.Error(err, "failed to create prompt builder")
 		os.Exit(1)
 	}
 
-	resultParser := parser.NewResultParser(logrLogger.WithName("parser"))
+	resultParser := parser.NewResultParser(logger.WithName("parser"))
 	phaseTools := investigator.DefaultPhaseToolMap()
 
-	k8sInfra := initK8sInfra(slogger)
-	ds := initDSClients(cfg, k8sInfra, slogger)
-	auditStore, auditCleanup := buildAuditStore(cfg, slogger, logrLogger)
-	reg := buildToolRegistry(cfg, slogger, k8sInfra, ds)
-	enricher := buildEnricher(cfg, ds, k8sInfra, auditStore, slogger)
-	sanitizer := buildSanitizationPipeline(cfg, slogger)
-	anomalyDetector := buildAnomalyDetector(cfg, slogger)
-	sum := buildSummarizer(swappable, cfg, slogger)
+	k8sInfra := initK8sInfra(logger)
+	ds := initDSClients(cfg, k8sInfra, logger)
+	auditStore, auditCleanup := buildAuditStore(cfg, logger)
+	reg := buildToolRegistry(cfg, logger, k8sInfra, ds)
+	enricher := buildEnricher(cfg, ds, k8sInfra, auditStore, logger)
+	sanitizer := buildSanitizationPipeline(cfg, logger)
+	anomalyDetector := buildAnomalyDetector(cfg, logger)
+	sum := buildSummarizer(swappable, cfg, logger)
 
 	instrumentedLLM := llm.NewInstrumentedClient(swappable)
 
 	var catalogFetcher investigator.CatalogFetcher
 	if ds != nil {
-		catalogFetcher = newDSCatalogFetcher(ds, slogger)
-		slogger.Info("workflow catalog fetcher enabled (per-request, DD-HAPI-002)")
+		catalogFetcher = newDSCatalogFetcher(ds, logger)
+		logger.Info("workflow catalog fetcher enabled (per-request, DD-HAPI-002)")
 	} else {
-		slogger.Info("workflow catalog fetcher disabled (no DataStorage — dev mode)")
+		logger.Info("workflow catalog fetcher disabled (no DataStorage — dev mode)")
 	}
 
 	var effectiveLLM llm.Client = instrumentedLLM
@@ -202,18 +200,18 @@ func main() {
 		var shadowClient llm.Client
 		if cfg.AI.AlignmentCheck.LLM == nil {
 			shadowClient = instrumentedLLM
-			slogger.Info("shadow agent shares investigation LLM client")
+			logger.Info("shadow agent shares investigation LLM client")
 		} else {
 			alignStaticCfg, alignRtCfg := cfg.AI.AlignmentCheck.EffectiveLLM(cfg.AI.LLM, *llmRuntime)
 			alignCfgMerge := *cfg
 			alignCfgMerge.AI.LLM = alignStaticCfg
 			raw, alignErr := buildLLMClientFromConfig(context.Background(), &alignCfgMerge, &alignRtCfg)
 			if alignErr != nil {
-				slogger.Error("alignment check LLM client failed (fail-closed): alignment is enabled but shadow client unavailable", "error", alignErr)
+				logger.Error(alignErr, "alignment check LLM client failed (fail-closed): alignment is enabled but shadow client unavailable")
 				os.Exit(1)
 			} else {
 				shadowClient = llm.NewInstrumentedClient(raw)
-				slogger.Info("shadow agent using dedicated LLM client", "model", alignRtCfg.Model)
+				logger.Info("shadow agent using dedicated LLM client", "model", alignRtCfg.Model)
 			}
 		}
 		if shadowClient != nil {
@@ -221,10 +219,10 @@ func main() {
 				Timeout:       cfg.AI.AlignmentCheck.Timeout,
 				MaxStepTokens: cfg.AI.AlignmentCheck.MaxStepTokens,
 				MaxRetries:    cfg.AI.AlignmentCheck.MaxRetries,
-			}, alignprompt.SystemPrompt(), alignment.WithLogger(slogger))
+			}, alignprompt.SystemPrompt(), alignment.WithLogger(logger))
 			effectiveLLM = alignment.NewLLMProxy(instrumentedLLM)
 			effectiveReg = alignment.NewToolProxy(reg)
-			slogger.Info("shadow agent alignment check enabled")
+			logger.Info("shadow agent alignment check enabled")
 		}
 	}
 
@@ -239,7 +237,7 @@ func main() {
 		ResultParser:  resultParser,
 		Enricher:      enricher,
 		AuditStore:    auditStore,
-		Logger:        slogger,
+		Logger:        logger,
 		MaxTurns:      cfg.AI.Investigation.MaxTurns,
 		PhaseTools:    phaseTools,
 		Registry:      effectiveReg,
@@ -262,20 +260,20 @@ func main() {
 			Evaluator:             alignEvaluator,
 			VerdictTimeout:        cfg.AI.AlignmentCheck.VerdictTimeout,
 			AuditStore:            auditStore,
-			Logger:                slogger,
+			Logger:                logger,
 			Mode:                  cfg.AI.AlignmentCheck.Mode,
 			CanaryForceEscalation: cfg.AI.AlignmentCheck.Canary.ForceEscalation,
 		})
 	}
 
 	store := session.NewStore(cfg.Runtime.Session.TTL)
-	mgr := session.NewManager(store, slogger)
+	mgr := session.NewManager(store, logger)
 
-	handler := kaserver.NewHandler(mgr, investigationRunner, slogger)
+	handler := kaserver.NewHandler(mgr, investigationRunner, logger)
 
 	ogenSrv, err := agentclient.NewServer(handler)
 	if err != nil {
-		slogger.Error("failed to create ogen server", "error", err)
+		logger.Error(err, "failed to create ogen server")
 		os.Exit(1)
 	}
 
@@ -285,16 +283,16 @@ func main() {
 	r.Get("/config", configHandler(cfg, swappable))
 
 	r.Route("/api/v1", func(r chi.Router) {
-		authMw := newAuthMiddleware(k8sInfra, logrLogger)
+		authMw := newAuthMiddleware(k8sInfra, logger)
 		if authMw != nil {
 			r.Use(authMw.Handler)
-			slogger.Info("auth middleware enabled (DD-AUTH-014)",
+			logger.Info("auth middleware enabled (DD-AUTH-014)",
 				"resource", "services",
 				"resourceName", "kubernaut-agent",
 				"verb", "create",
 			)
 		} else {
-			slogger.Info("auth middleware DISABLED (no in-cluster K8s config)")
+			logger.Info("auth middleware DISABLED (no in-cluster K8s config)")
 		}
 
 		r.Handle("/*", ogenSrv)
@@ -312,12 +310,12 @@ func main() {
 	if cfg.Runtime.Server.TLS.Enabled() {
 		isTLS, reloader, tlsErr := sharedtls.ConfigureConditionalTLS(httpServer, cfg.Runtime.Server.TLS.CertDir)
 		if tlsErr != nil {
-			slogger.Error("Failed to configure TLS", "error", tlsErr)
+			logger.Error(tlsErr, "Failed to configure TLS")
 			os.Exit(1)
 		}
 		if isTLS {
 			certReloader = reloader
-			slogger.Info("TLS configured for HTTP server", "certDir", cfg.Runtime.Server.TLS.CertDir)
+			logger.Info("TLS configured for HTTP server", "certDir", cfg.Runtime.Server.TLS.CertDir)
 		}
 	}
 
@@ -339,48 +337,48 @@ func main() {
 		certWatcher, watchErr := hotreload.NewFileWatcher(
 			filepath.Join(cfg.Runtime.Server.TLS.CertDir, "tls.crt"),
 			certReloader.ReloadCallback,
-			logr.FromSlogHandler(slogger.Handler()).WithName("cert-reloader"),
+			logger.WithName("cert-reloader"),
 		)
 		if watchErr != nil {
-			slogger.Error("Failed to create cert file watcher", "error", watchErr)
+			logger.Error(watchErr, "Failed to create cert file watcher")
 			os.Exit(1)
 		}
 		if err := certWatcher.Start(ctx); err != nil {
-			slogger.Error("Failed to start cert file watcher", "error", err)
+			logger.Error(err, "Failed to start cert file watcher")
 			os.Exit(1)
 		}
 		defer certWatcher.Stop()
 	}
 
 	// Issue #916: Wire FileWatcher for LLM runtime config hot-reload
-	rtCallback := llmRuntimeReloadCallback(cfg, swappable, slogger)
+	rtCallback := llmRuntimeReloadCallback(cfg, swappable, logger)
 	rtWatcher, rtWatchErr := hotreload.NewFileWatcher(
 		llmRuntimePath,
 		rtCallback,
-		logr.FromSlogHandler(slogger.Handler()).WithName("llm-runtime-reloader"),
+		logger.WithName("llm-runtime-reloader"),
 	)
 	if rtWatchErr != nil {
-		slogger.Warn("llm runtime file watcher not started", "error", rtWatchErr)
+		logger.Info("llm runtime file watcher not started", "error", rtWatchErr)
 	} else {
 		if err := rtWatcher.Start(ctx); err != nil {
-			slogger.Warn("llm runtime file watcher failed to start", "error", err)
+			logger.Info("llm runtime file watcher failed to start", "error", err)
 		} else {
 			defer rtWatcher.Stop()
-			slogger.Info("llm runtime hot-reload enabled (#916)", "path", llmRuntimePath)
+			logger.Info("llm runtime hot-reload enabled (#916)", "path", llmRuntimePath)
 		}
 	}
 
 	// Issue #748: Load OCP TLS security profile from config before any TLS setup
 	if err := sharedtls.SetDefaultSecurityProfileFromConfig(cfg.Runtime.Server.TLSProfile); err != nil {
-		slogger.Error("Invalid TLS security profile in config, using default TLS 1.2", "error", err)
+		logger.Error(err, "Invalid TLS security profile in config, using default TLS 1.2")
 	} else if cfg.Runtime.Server.TLSProfile != "" {
-		slogger.Info("TLS security profile active", "profile", cfg.Runtime.Server.TLSProfile)
+		logger.Info("TLS security profile active", "profile", cfg.Runtime.Server.TLSProfile)
 	}
 
 	// Issue #756: Start CA file watcher for client-side TLS hot-reload
-	caWatcher, caWatchErr := sharedtls.StartCAFileWatcher(ctx, logr.FromSlogHandler(slogger.Handler()))
+	caWatcher, caWatchErr := sharedtls.StartCAFileWatcher(ctx, logger)
 	if caWatchErr != nil {
-		slogger.Error("Failed to start CA file watcher", "error", caWatchErr)
+		logger.Error(caWatchErr, "Failed to start CA file watcher")
 		os.Exit(1)
 	}
 	if caWatcher != nil {
@@ -391,20 +389,20 @@ func main() {
 
 	// Issue #753: Start dedicated health and metrics servers
 	go func() {
-		slogger.Info("health server listening", "addr", cfg.Runtime.Server.HealthAddr)
+		logger.Info("health server listening", "addr", cfg.Runtime.Server.HealthAddr)
 		if err := healthServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			slogger.Error("health server error", "error", err)
+			logger.Error(err, "health server error")
 		}
 	}()
 	go func() {
-		slogger.Info("metrics server listening", "addr", cfg.Runtime.Server.MetricsAddr)
+		logger.Info("metrics server listening", "addr", cfg.Runtime.Server.MetricsAddr)
 		if err := metricsServer.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			slogger.Error("metrics server error", "error", err)
+			logger.Error(err, "metrics server error")
 		}
 	}()
 
 	go func() {
-		slogger.Info("HTTP server listening", "addr", addr)
+		logger.Info("HTTP server listening", "addr", addr)
 		var listenErr error
 		if httpServer.TLSConfig != nil {
 			listenErr = httpServer.ListenAndServeTLS("", "")
@@ -412,13 +410,13 @@ func main() {
 			listenErr = httpServer.ListenAndServe()
 		}
 		if listenErr != nil && listenErr != http.ErrServerClosed {
-			slogger.Error("HTTP server error", "error", listenErr)
+			logger.Error(listenErr, "HTTP server error")
 			os.Exit(1)
 		}
 	}()
 
 	<-ctx.Done()
-	slogger.Info("shutting down...")
+	logger.Info("shutting down...")
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -432,7 +430,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "metrics server shutdown error: %v\n", shutdownErr)
 	}
 
-	slogger.Info("flushing audit store...")
+	logger.Info("flushing audit store...")
 	auditCleanup()
 }
 
@@ -483,20 +481,20 @@ type k8sInfra struct {
 
 // initK8sInfra creates the shared Kubernetes clients. Returns nil when
 // running outside a cluster (e.g. local development).
-func initK8sInfra(logger *slog.Logger) *k8sInfra {
+func initK8sInfra(logger logr.Logger) *k8sInfra {
 	kubeConfig, err := ctrl.GetConfig()
 	if err != nil {
-		logger.Warn("K8s config not available, K8s tools and enricher disabled", "error", err)
+		logger.Info("K8s config not available, K8s tools and enricher disabled", "error", err)
 		return nil
 	}
 	k8sClient, err := kubernetes.NewForConfig(kubeConfig)
 	if err != nil {
-		logger.Error("failed to create K8s clientset", "error", err)
+		logger.Error(err, "failed to create K8s clientset")
 		return nil
 	}
 	dynClient, err := dynamic.NewForConfig(kubeConfig)
 	if err != nil {
-		logger.Error("failed to create dynamic client", "error", err)
+		logger.Error(err, "failed to create dynamic client")
 		return nil
 	}
 	cachedDisc := memory.NewMemCacheClient(k8sClient.Discovery())
@@ -519,20 +517,20 @@ type dsClients struct {
 // or default /var/run/secrets/kubernetes.io/serviceaccount/token), the ogen
 // client is configured with a Bearer token transport so that all DS API calls
 // (including ListWorkflows for the workflow validator) pass authentication.
-func initDSClients(cfg *kaconfig.Config, infra *k8sInfra, logger *slog.Logger) *dsClients {
+func initDSClients(cfg *kaconfig.Config, infra *k8sInfra, logger logr.Logger) *dsClients {
 	if cfg.Integrations.DataStorage.URL == "" {
 		logger.Info("DataStorage URL not configured, DS adapters disabled")
 		return nil
 	}
 	if infra == nil {
-		logger.Warn("K8s infrastructure unavailable, DS adapters disabled")
+		logger.Info("K8s infrastructure unavailable, DS adapters disabled")
 		return nil
 	}
 
 	// Issue #853: Wrapped with RetryTransport for transient failure resilience.
 	dsBase, tlsErr := sharedtls.DefaultBaseTransportWithRetry()
 	if tlsErr != nil {
-		logger.Error("failed to create TLS-aware transport for DS client", "error", tlsErr)
+		logger.Error(tlsErr, "failed to create TLS-aware transport for DS client")
 		return nil
 	}
 
@@ -544,13 +542,13 @@ func initDSClients(cfg *kaconfig.Config, infra *k8sInfra, logger *slog.Logger) *
 		}))
 		logger.Info("DS client auth configured (DD-AUTH-014)", "token_path", cfg.Integrations.DataStorage.SATokenPath)
 	} else {
-		logger.Warn("SA token not available for DS client — DS API calls may fail auth",
+		logger.Info("SA token not available for DS client — DS API calls may fail auth",
 			"path", cfg.Integrations.DataStorage.SATokenPath, "error", err)
 	}
 
 	ogenClient, err := ogenclient.NewClient(cfg.Integrations.DataStorage.URL, opts...)
 	if err != nil {
-		logger.Error("failed to create DataStorage ogen client", "url", cfg.Integrations.DataStorage.URL, "error", err)
+		logger.Error(err, "failed to create DataStorage ogen client", "url", cfg.Integrations.DataStorage.URL)
 		return nil
 	}
 	logger.Info("DataStorage clients initialized", "url", cfg.Integrations.DataStorage.URL)
@@ -577,13 +575,13 @@ func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 // buildEnricher creates the enrichment.Enricher when DS clients are available.
 // ADR-056: attaches LabelDetector so detected_labels are populated during enrichment.
 // #704: wires RetryConfig from config for HAPI-aligned owner chain retry+fail-hard.
-func buildEnricher(cfg *kaconfig.Config, ds *dsClients, infra *k8sInfra, auditStore audit.AuditStore, logger *slog.Logger) *enrichment.Enricher {
+func buildEnricher(cfg *kaconfig.Config, ds *dsClients, infra *k8sInfra, auditStore audit.AuditStore, logger logr.Logger) *enrichment.Enricher {
 	if ds == nil {
 		return nil
 	}
 	e := enrichment.NewEnricher(ds.k8sAdapter, ds.dsAdapter, auditStore, logger)
 	if infra != nil && infra.dynClient != nil {
-		e.WithLabelDetector(enrichment.NewLabelDetector(infra.dynClient, infra.mapper))
+		e.WithLabelDetector(enrichment.NewLabelDetector(infra.dynClient, infra.mapper, logger.WithName("label-detector")))
 		logger.Info("label detector enabled (ADR-056)")
 	}
 	e.WithRetryConfig(enrichment.RetryConfig{
@@ -591,15 +589,15 @@ func buildEnricher(cfg *kaconfig.Config, ds *dsClients, infra *k8sInfra, auditSt
 		BaseBackoff: cfg.AI.Enrichment.BaseBackoff,
 	})
 	logger.Info("enrichment retry config wired (#704)",
-		slog.Int("max_retries", cfg.AI.Enrichment.MaxRetries),
-		slog.Duration("base_backoff", cfg.AI.Enrichment.BaseBackoff),
+		"max_retries", cfg.AI.Enrichment.MaxRetries,
+		"base_backoff", cfg.AI.Enrichment.BaseBackoff,
 	)
 	return e
 }
 
 // buildSanitizationPipeline creates the G4 + I1 sanitization pipeline
 // per DD-HAPI-019-003. Returns nil when both stages are disabled.
-func buildSanitizationPipeline(cfg *kaconfig.Config, logger *slog.Logger) *sanitization.Pipeline {
+func buildSanitizationPipeline(cfg *kaconfig.Config, logger logr.Logger) *sanitization.Pipeline {
 	var stages []sanitization.Stage
 	if cfg.AI.Safety.Sanitization.CredentialScrubEnabled {
 		stages = append(stages, sanitization.NewCredentialSanitizer())
@@ -620,10 +618,10 @@ func buildSanitizationPipeline(cfg *kaconfig.Config, logger *slog.Logger) *sanit
 // Uses the same OpenAPIClientAdapter + BufferedAuditStore stack as every other
 // platform service. Auth transport is shared with initDSClients (same SA token)
 // to guarantee identical authentication behavior.
-func buildAuditStore(cfg *kaconfig.Config, slogger *slog.Logger, logrLog logr.Logger) (audit.AuditStore, func()) {
+func buildAuditStore(cfg *kaconfig.Config, logger logr.Logger) (audit.AuditStore, func()) {
 	nop := func() {}
 	if !cfg.Runtime.Audit.Enabled || cfg.Integrations.DataStorage.URL == "" {
-		slogger.Info("audit store disabled (nop)")
+		logger.Info("audit store disabled (nop)")
 		return audit.NopAuditStore{}, nop
 	}
 
@@ -631,17 +629,17 @@ func buildAuditStore(cfg *kaconfig.Config, slogger *slog.Logger, logrLog logr.Lo
 	// configured path and inject as Bearer header on every request.
 	auditBase, tlsErr := sharedtls.DefaultBaseTransport()
 	if tlsErr != nil {
-		slogger.Error("failed to create TLS-aware transport for audit store", "error", tlsErr)
+		logger.Error(tlsErr, "failed to create TLS-aware transport for audit store")
 		return audit.NopAuditStore{}, nop
 	}
 
 	var transport http.RoundTripper
 	if tokenData, err := os.ReadFile(cfg.Integrations.DataStorage.SATokenPath); err == nil && len(tokenData) > 0 {
 		transport = &bearerTransport{base: auditBase, token: string(tokenData)}
-		slogger.Info("audit store auth configured (same SA token as DS client)",
+		logger.Info("audit store auth configured (same SA token as DS client)",
 			"token_path", cfg.Integrations.DataStorage.SATokenPath)
 	} else {
-		slogger.Warn("SA token not available for audit store — batch writes may fail auth",
+		logger.Info("SA token not available for audit store — batch writes may fail auth",
 			"path", cfg.Integrations.DataStorage.SATokenPath, "error", err)
 	}
 
@@ -649,7 +647,7 @@ func buildAuditStore(cfg *kaconfig.Config, slogger *slog.Logger, logrLog logr.Lo
 		cfg.Integrations.DataStorage.URL, 5*time.Second, transport,
 	)
 	if err != nil {
-		slogger.Error("failed to create DS audit client, falling back to nop", "error", err)
+		logger.Error(err, "failed to create DS audit client, falling back to nop")
 		return audit.NopAuditStore{}, nop
 	}
 
@@ -665,16 +663,16 @@ func buildAuditStore(cfg *kaconfig.Config, slogger *slog.Logger, logrLog logr.Lo
 		storeOpts = append(storeOpts, audit.WithBatchSize(cfg.Runtime.Audit.BatchSize))
 	}
 
-	store, err := audit.NewBufferedDSAuditStore(dsClient, logrLog, storeOpts...)
+	store, err := audit.NewBufferedDSAuditStore(dsClient, logger, storeOpts...)
 	if err != nil {
-		slogger.Error("failed to create buffered audit store, falling back to nop", "error", err)
+		logger.Error(err, "failed to create buffered audit store, falling back to nop")
 		return audit.NopAuditStore{}, nop
 	}
-	slogger.Info("audit store enabled (buffered, DD-AUDIT-002 aligned)",
+	logger.Info("audit store enabled (buffered, DD-AUDIT-002 aligned)",
 		"ds_url", cfg.Integrations.DataStorage.URL)
 	return store, func() {
 		if closeErr := store.Close(); closeErr != nil {
-			slogger.Error("audit store close error", "error", closeErr)
+			logger.Error(closeErr, "audit store close error")
 		}
 	}
 }
@@ -682,7 +680,7 @@ func buildAuditStore(cfg *kaconfig.Config, slogger *slog.Logger, logrLog logr.Lo
 // buildSummarizer creates a tool output summarizer when the threshold is positive.
 // When MaxToolOutputSize is configured, it enables pre-truncation to prevent
 // the summarizer's own LLM call from exceeding context window limits (#752).
-func buildSummarizer(llmClient llm.Client, cfg *kaconfig.Config, logger *slog.Logger) *summarizer.Summarizer {
+func buildSummarizer(llmClient llm.Client, cfg *kaconfig.Config, logger logr.Logger) *summarizer.Summarizer {
 	if cfg.AI.Summarizer.Threshold <= 0 {
 		logger.Info("summarizer disabled (threshold <= 0)")
 		return nil
@@ -698,7 +696,7 @@ func buildSummarizer(llmClient llm.Client, cfg *kaconfig.Config, logger *slog.Lo
 }
 
 // buildAnomalyDetector creates the I7 anomaly detector from config thresholds.
-func buildAnomalyDetector(cfg *kaconfig.Config, logger *slog.Logger) *investigator.AnomalyDetector {
+func buildAnomalyDetector(cfg *kaconfig.Config, logger logr.Logger) *investigator.AnomalyDetector {
 	ac := investigator.AnomalyConfig{
 		MaxToolCallsPerTool: cfg.AI.Safety.Anomaly.MaxToolCallsPerTool,
 		MaxTotalToolCalls:   cfg.AI.Safety.Anomaly.MaxTotalToolCalls,
@@ -715,7 +713,7 @@ func buildAnomalyDetector(cfg *kaconfig.Config, logger *slog.Logger) *investigat
 }
 
 // buildToolRegistry creates and populates the tool registry with all available tool sets.
-func buildToolRegistry(cfg *kaconfig.Config, logger *slog.Logger, infra *k8sInfra, ds *dsClients) *registry.Registry {
+func buildToolRegistry(cfg *kaconfig.Config, logger logr.Logger, infra *k8sInfra, ds *dsClients) *registry.Registry {
 	reg := registry.New()
 
 	if infra != nil {
@@ -731,7 +729,7 @@ func buildToolRegistry(cfg *kaconfig.Config, logger *slog.Logger, infra *k8sInfr
 		if cfg.Integrations.Tools.Prometheus.TLSCaFile != "" {
 			promBase, promTLSErr := sharedtls.NewTLSTransport(cfg.Integrations.Tools.Prometheus.TLSCaFile)
 			if promTLSErr != nil {
-				logger.Error("failed to create Prometheus TLS transport", "error", promTLSErr, "ca_file", cfg.Integrations.Tools.Prometheus.TLSCaFile)
+				logger.Error(promTLSErr, "failed to create Prometheus TLS transport", "ca_file", cfg.Integrations.Tools.Prometheus.TLSCaFile)
 			} else {
 				promCfg.Transport = auth.NewServiceAccountTransportWithBase(promBase)
 				logger.Info("Prometheus client configured with TLS + SA bearer auth", "ca_file", cfg.Integrations.Tools.Prometheus.TLSCaFile)
@@ -739,7 +737,7 @@ func buildToolRegistry(cfg *kaconfig.Config, logger *slog.Logger, infra *k8sInfr
 		}
 		promClient, promErr := promtools.NewClient(promCfg)
 		if promErr != nil {
-			logger.Error("failed to create Prometheus client", "error", promErr)
+			logger.Error(promErr, "failed to create Prometheus client")
 		} else {
 			for _, t := range promtools.NewAllTools(promClient) {
 				reg.Register(t)
@@ -749,7 +747,7 @@ func buildToolRegistry(cfg *kaconfig.Config, logger *slog.Logger, infra *k8sInfr
 	}
 
 	if ds != nil {
-		custom.RegisterAll(reg, ds.ogenClient, ds.dsAdapter, ds.k8sAdapter)
+		custom.RegisterAll(reg, ds.ogenClient, ds.dsAdapter, ds.k8sAdapter, logger)
 		logger.Info("registered custom tools", "count", len(custom.AllToolNames))
 	}
 
@@ -760,10 +758,10 @@ func buildToolRegistry(cfg *kaconfig.Config, logger *slog.Logger, infra *k8sInfr
 	return reg
 }
 
-func registerK8sTools(reg *registry.Registry, infra *k8sInfra, logger *slog.Logger) {
+func registerK8sTools(reg *registry.Registry, infra *k8sInfra, logger logr.Logger) {
 	kindIndex, err := k8stools.BuildKindIndex(infra.clientset.Discovery())
 	if err != nil {
-		logger.Warn("failed to build kind index, using empty index", "error", err)
+		logger.Info("failed to build kind index, using empty index", "error", err)
 		kindIndex = make(map[string]schema.GroupKind)
 	}
 	resolver := k8stools.NewDynamicResolver(infra.dynClient, infra.mapper, kindIndex)
@@ -778,7 +776,7 @@ func registerK8sTools(reg *registry.Registry, infra *k8sInfra, logger *slog.Logg
 
 	mc, mcErr := metricsclient.NewForConfig(infra.kubeConfig)
 	if mcErr != nil {
-		logger.Error("failed to create metrics client, metrics tools will not be registered", "error", mcErr)
+		logger.Error(mcErr, "failed to create metrics client, metrics tools will not be registered")
 	} else {
 		for _, t := range k8stools.NewMetricsTools(k8stools.NewMetricsClient(mc)) {
 			reg.Register(t)
@@ -796,10 +794,10 @@ func registerK8sTools(reg *registry.Registry, infra *k8sInfra, logger *slog.Logg
 // without needing a restart when workflows are added/removed.
 type dsCatalogFetcher struct {
 	ds     *dsClients
-	logger *slog.Logger
+	logger logr.Logger
 }
 
-func newDSCatalogFetcher(ds *dsClients, logger *slog.Logger) *dsCatalogFetcher {
+func newDSCatalogFetcher(ds *dsClients, logger logr.Logger) *dsCatalogFetcher {
 	return &dsCatalogFetcher{ds: ds, logger: logger}
 }
 
@@ -873,4 +871,3 @@ func newAuthMiddleware(infra *k8sInfra, logger logr.Logger) *auth.Middleware {
 		Verb:         "create",
 	}, logger)
 }
-

--- a/cmd/kubernautagent/reload_callback_783_test.go
+++ b/cmd/kubernautagent/reload_callback_783_test.go
@@ -18,16 +18,15 @@ package main
 
 import (
 	"context"
-	"log/slog"
-	"os"
 	"testing"
 
+	"github.com/go-logr/logr"
 	kaconfig "github.com/jordigilh/kubernaut/internal/kubernautagent/config"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 )
 
-func testLogger() *slog.Logger {
-	return slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: slog.LevelError}))
+func testReloadLogger() logr.Logger {
+	return logr.Discard()
 }
 
 func staticCfg() *kaconfig.Config {
@@ -56,7 +55,7 @@ func (s *stubLLMClient) Close() error { return nil }
 
 func TestReloadRejectsEmptyContent(t *testing.T) {
 	sc := setupSwappable(t)
-	cb := llmRuntimeReloadCallback(staticCfg(), sc, testLogger())
+	cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger())
 
 	err := cb("")
 	if err == nil {
@@ -69,7 +68,7 @@ func TestReloadRejectsEmptyContent(t *testing.T) {
 
 func TestReloadRejectsWhitespaceContent(t *testing.T) {
 	sc := setupSwappable(t)
-	cb := llmRuntimeReloadCallback(staticCfg(), sc, testLogger())
+	cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger())
 
 	err := cb("   \n  \t  ")
 	if err == nil {
@@ -79,7 +78,7 @@ func TestReloadRejectsWhitespaceContent(t *testing.T) {
 
 func TestReloadAcceptsModelChange(t *testing.T) {
 	sc := setupSwappable(t)
-	cb := llmRuntimeReloadCallback(staticCfg(), sc, testLogger())
+	cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger())
 
 	err := cb(`model: gpt-4-turbo
 endpoint: http://localhost:11434
@@ -95,7 +94,7 @@ apiKey: test-key
 
 func TestReloadAcceptsEndpointChange(t *testing.T) {
 	sc := setupSwappable(t)
-	cb := llmRuntimeReloadCallback(staticCfg(), sc, testLogger())
+	cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger())
 
 	err := cb(`model: gpt-4
 endpoint: http://new-endpoint:8080
@@ -108,7 +107,7 @@ apiKey: test-key
 
 func TestReloadRejectsValidationFailure(t *testing.T) {
 	sc := setupSwappable(t)
-	cb := llmRuntimeReloadCallback(staticCfg(), sc, testLogger())
+	cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger())
 
 	err := cb(`model: ""
 endpoint: http://localhost:11434
@@ -124,7 +123,7 @@ apiKey: test-key
 
 func TestReloadAcceptsTemperatureChange(t *testing.T) {
 	sc := setupSwappable(t)
-	cb := llmRuntimeReloadCallback(staticCfg(), sc, testLogger())
+	cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger())
 
 	err := cb(`model: gpt-4
 endpoint: http://localhost:11434

--- a/docs/architecture/LOGGING_STANDARD.md
+++ b/docs/architecture/LOGGING_STANDARD.md
@@ -1,7 +1,7 @@
 # Logging Standard - Kubernaut Services
 
 **Version**: v2.0
-**Last Updated**: April 27, 2026
+**Last Updated**: April 26, 2026
 **Status**: APPROVED & STANDARDIZED
 **Scope**: All 10 Services
 **Standard**: `go.uber.org/zap` via `pkg/log` (logr.Logger interface)
@@ -27,7 +27,7 @@
 | Library | Files | Status | Action |
 |---------|-------|--------|--------|
 | **go.uber.org/zap** | 496+ files (99.8%) | STANDARD | APPROVED |
-| **log/slog** | ~47 files (kubernaut-agent) | Legacy | Migration to zap planned |
+| **log/slog** | 0 files | Removed | Migrated to logr/zap (Issue #935) |
 
 ### Unified Strategy (v2.0)
 
@@ -56,8 +56,6 @@ Key methods:
 - `ZapLevel()` -- converts to `zapcore.Level`
 - `NewAtomicLevel()` -- creates a `zap.AtomicLevel` for runtime mutation
 - `Validate()` -- rejects unrecognised level strings
-- `SlogLevel()` -- bridge for services still using `log/slog` (kubernaut-agent)
-
 ### Hot-Reload Helper: `ParseAndSetLevel()`
 
 ```go
@@ -129,12 +127,12 @@ Same pattern as CRD controllers, but uses `zap.New(zap.Level(atomicLevel))` dire
 
 ---
 
-## Kubernaut Agent (Temporary: slog)
+## Kubernaut Agent
 
-The kubernaut-agent currently uses `log/slog` instead of zap. Its `LoggingConfig`
-has been migrated to the shared `internal/config.LoggingConfig` type, which provides
-a `SlogLevel()` bridge method. A follow-up issue will migrate the agent to
-`pkg/log` (zap-backed `logr.Logger`) to eliminate this special case.
+The kubernaut-agent uses `pkg/log` (zap-backed `logr.Logger`), the same standard
+as Gateway, Notification, and DataStorage. It bootstraps with
+`kubelog.NewLoggerWithAtomicLevel()` and supports config-driven hot-reload via
+`zap.AtomicLevel`. The `SlogLevel()` bridge method has been removed (Issue #935).
 
 ---
 
@@ -392,7 +390,7 @@ logger.Info("Signal processed",
 | **Gateway** | pkg/log (kubelog) | `internal/config` | FileWatcher | Done (Issue #877) |
 | **Notification** | pkg/log (kubelog) | `internal/config` | FileWatcher | Done (Issue #878) |
 | **DataStorage** | pkg/log (kubelog) | `internal/config` | FileWatcher | Done (Issue #875) |
-| **Kubernaut Agent** | log/slog (temporary) | `internal/config` | Planned | Config aligned; full slog->zap migration TBD |
+| **Kubernaut Agent** | pkg/log (kubelog) | `internal/config` | FileWatcher | Done (Issue #935) |
 
 ---
 
@@ -441,12 +439,12 @@ logger.Info("Signal processed",
 4. `zap.AtomicLevel` is thread-safe and zero-allocation
 
 **Migration**:
-- 9/10 services fully migrated to config-file-only log level with hot-reload
-- kubernaut-agent: config aligned to shared type; full slog->zap migration in follow-up PR
+- All 10 services fully migrated to config-file-only log level with hot-reload
+- kubernaut-agent: migrated from slog to logr/zap in Issue #935
 
 ---
 
 **Document Status**: Complete & Approved
 **Standard**: `go.uber.org/zap` via config file
-**Last Updated**: April 27, 2026
+**Last Updated**: April 26, 2026
 **Version**: 2.0

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"fmt"
-	"log/slog"
 	"strings"
 
 	"go.uber.org/zap"
@@ -62,22 +61,6 @@ func (l LoggingConfig) ZapLevel() zapcore.Level {
 // The returned AtomicLevel can be mutated at runtime for hot-reload.
 func (l LoggingConfig) NewAtomicLevel() zap.AtomicLevel {
 	return zap.NewAtomicLevelAt(l.ZapLevel())
-}
-
-// SlogLevel converts the configured level string to an slog.Level.
-// Bridge method for services still using log/slog (e.g., kubernaut-agent).
-// Will be removed when all services migrate to zap-backed logr.Logger.
-func (l LoggingConfig) SlogLevel() slog.Level {
-	switch strings.ToUpper(l.Level) {
-	case "DEBUG":
-		return slog.LevelDebug
-	case "WARN":
-		return slog.LevelWarn
-	case "ERROR":
-		return slog.LevelError
-	default:
-		return slog.LevelInfo
-	}
 }
 
 // ParseAndSetLevel parses a level string and applies it to the given

--- a/internal/kubernautagent/alignment/evaluator.go
+++ b/internal/kubernautagent/alignment/evaluator.go
@@ -20,11 +20,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/security/boundary"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 )
@@ -41,7 +41,7 @@ type Evaluator struct {
 	client llm.Client
 	config EvaluatorConfig
 	prompt string
-	logger *slog.Logger
+	logger logr.Logger
 }
 
 type evalResponse struct {
@@ -51,10 +51,10 @@ type evalResponse struct {
 
 // NewEvaluator creates an Evaluator with the given shadow LLM client, config,
 // and system prompt. The prompt is immutable after construction.
-// The optional logger enables per-step DEBUG-level logging for operator
-// troubleshooting. Pass nil to disable step-level logging.
+// Without optional WithLogger, per-step diagnostics are discarded; attach a Logger
+// (e.g. zapr-backed) for operator troubleshooting (step detail at verbosity V(1)).
 func NewEvaluator(client llm.Client, cfg EvaluatorConfig, prompt string, opts ...EvaluatorOption) *Evaluator {
-	e := &Evaluator{client: client, config: cfg, prompt: prompt}
+	e := &Evaluator{client: client, config: cfg, prompt: prompt, logger: logr.Discard()}
 	for _, o := range opts {
 		o(e)
 	}
@@ -64,8 +64,8 @@ func NewEvaluator(client llm.Client, cfg EvaluatorConfig, prompt string, opts ..
 // EvaluatorOption configures optional Evaluator behavior.
 type EvaluatorOption func(*Evaluator)
 
-// WithLogger attaches a structured logger for per-step DEBUG output.
-func WithLogger(l *slog.Logger) EvaluatorOption {
+// WithLogger attaches a structured logger for per-step diagnostic output at V(1).
+func WithLogger(l logr.Logger) EvaluatorOption {
 	return func(e *Evaluator) { e.logger = l }
 }
 
@@ -158,15 +158,15 @@ func (e *Evaluator) EvaluateStep(ctx context.Context, step Step) Observation {
 				Explanation: "evaluator_unavailable (fail-closed): shadow LLM response missing 'suspicious' field",
 			}
 			e.debugLog("step evaluated: missing suspicious field",
-				slog.Int("step_index", step.Index), slog.String("kind", string(step.Kind)),
-				slog.Bool("suspicious", true))
+				"step_index", step.Index, "kind", string(step.Kind),
+				"suspicious", true)
 			return obs
 		}
 
 		e.debugLog("step evaluated",
-			slog.Int("step_index", step.Index), slog.String("kind", string(step.Kind)),
-			slog.String("tool", step.Tool), slog.Bool("suspicious", *parsed.Suspicious),
-			slog.Int("attempt", attempt+1))
+			"step_index", step.Index, "kind", string(step.Kind),
+			"tool", step.Tool, "suspicious", *parsed.Suspicious,
+			"attempt", attempt+1)
 		return Observation{
 			Step:        step,
 			Suspicious:  *parsed.Suspicious,
@@ -215,10 +215,8 @@ func TruncateHeadTail(s string, max int) string {
 	return truncateHeadTail(s, max)
 }
 
-func (e *Evaluator) debugLog(msg string, attrs ...any) {
-	if e.logger != nil {
-		e.logger.Debug(msg, attrs...)
-	}
+func (e *Evaluator) debugLog(msg string, kvs ...any) {
+	e.logger.V(1).Info(msg, kvs...)
 }
 
 // hasDuplicateSuspiciousKey performs a raw-byte pre-scan for duplicate

--- a/internal/kubernautagent/alignment/investigator_wrapper.go
+++ b/internal/kubernautagent/alignment/investigator_wrapper.go
@@ -19,9 +19,9 @@ package alignment
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/config"
 	kaserver "github.com/jordigilh/kubernaut/internal/kubernautagent/server"
@@ -36,7 +36,7 @@ type InvestigatorWrapper struct {
 	evaluator             *Evaluator
 	verdictTimeout        time.Duration
 	auditStore            audit.AuditStore
-	logger                *slog.Logger
+	logger                logr.Logger
 	mode                  config.AlignmentMode
 	canaryForceEscalation bool
 }
@@ -49,7 +49,7 @@ type InvestigatorWrapperConfig struct {
 	Evaluator             *Evaluator
 	VerdictTimeout        time.Duration
 	AuditStore            audit.AuditStore
-	Logger                *slog.Logger
+	Logger                logr.Logger
 	Mode                  config.AlignmentMode
 	CanaryForceEscalation bool
 }
@@ -64,8 +64,9 @@ func NewInvestigatorWrapper(cfg InvestigatorWrapperConfig) *InvestigatorWrapper 
 		panic("alignment.NewInvestigatorWrapper: Evaluator must not be nil")
 	}
 	logger := cfg.Logger
-	if logger == nil {
-		logger = slog.Default()
+	var zero logr.Logger
+	if logger == zero {
+		logger = logr.Discard()
 	}
 	mode := cfg.Mode
 	if mode == "" {
@@ -105,10 +106,10 @@ func (w *InvestigatorWrapper) Investigate(ctx context.Context, signal katypes.Si
 	canary := RunCanary(ctx, w.evaluator)
 	canaryDegraded := !canary.Passed
 	if canaryDegraded {
-		w.logger.Warn("shadow agent canary failed: shadow model did not flag known-malicious content",
-			slog.String("signal", signal.Name),
-			slog.String("namespace", signal.Namespace),
-			slog.String("explanation", canary.Explanation),
+		w.logger.Info("shadow agent canary failed: shadow model did not flag known-malicious content",
+			"signal", signal.Name,
+			"namespace", signal.Namespace,
+			"explanation", canary.Explanation,
 		)
 	}
 
@@ -151,11 +152,11 @@ func (w *InvestigatorWrapper) Investigate(ctx context.Context, signal katypes.Si
 			result.Warnings = append(result.Warnings,
 				"Shadow agent canary integrity check failed: shadow model may be compromised — forcing human review")
 		}
-		w.logger.Warn("canary degradation",
-			slog.String("signal", signal.Name),
-			slog.String("namespace", signal.Namespace),
-			slog.Bool("escalated", escalateCanary),
-			slog.String("mode", string(w.mode)),
+		w.logger.Info("canary degradation",
+			"signal", signal.Name,
+			"namespace", signal.Namespace,
+			"escalated", escalateCanary,
+			"mode", string(w.mode),
 		)
 	}
 
@@ -166,22 +167,22 @@ func (w *InvestigatorWrapper) Investigate(ctx context.Context, signal katypes.Si
 			result.Warnings = append(result.Warnings,
 				fmt.Sprintf("Shadow agent alignment check flagged suspicious content: %s", verdict.Summary))
 		}
-		w.logger.Warn("shadow agent flagged suspicious content",
-			slog.String("signal", signal.Name),
-			slog.String("namespace", signal.Namespace),
-			slog.Int("flagged", verdict.Flagged),
-			slog.Int("total", verdict.Total),
-			slog.Int("pending", verdict.Pending),
-			slog.Bool("timed_out", verdict.TimedOut),
-			slog.String("summary", verdict.Summary),
-			slog.Bool("escalated", escalateVerdict),
-			slog.String("mode", string(w.mode)),
+		w.logger.Info("shadow agent flagged suspicious content",
+			"signal", signal.Name,
+			"namespace", signal.Namespace,
+			"flagged", verdict.Flagged,
+			"total", verdict.Total,
+			"pending", verdict.Pending,
+			"timed_out", verdict.TimedOut,
+			"summary", verdict.Summary,
+			"escalated", escalateVerdict,
+			"mode", string(w.mode),
 		)
 	} else if !canaryDegraded {
 		w.logger.Info("shadow agent alignment check passed",
-			slog.String("signal", signal.Name),
-			slog.String("namespace", signal.Namespace),
-			slog.Int("total", verdict.Total),
+			"signal", signal.Name,
+			"namespace", signal.Namespace,
+			"total", verdict.Total,
 		)
 	}
 

--- a/internal/kubernautagent/audit/emitter.go
+++ b/internal/kubernautagent/audit/emitter.go
@@ -18,8 +18,8 @@ package audit
 
 import (
 	"context"
-	"log/slog"
 
+	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 )
 
@@ -41,11 +41,11 @@ const (
 )
 
 const (
-	ActionLLMRequest     = "llm_request"
-	ActionLLMResponse    = "llm_response"
-	ActionToolExecution  = "tool_execution"
-	ActionValidation     = "validation"
-	ActionResponseSent   = "response_sent"
+	ActionLLMRequest        = "llm_request"
+	ActionLLMResponse       = "llm_response"
+	ActionToolExecution     = "tool_execution"
+	ActionValidation        = "validation"
+	ActionResponseSent      = "response_sent"
 	ActionResponseFailed    = "response_failed"
 	ActionAlignmentEvaluate = "alignment_evaluate"
 	ActionAlignmentVerdict  = "alignment_verdict"
@@ -101,11 +101,8 @@ func NewEvent(eventType string, correlationID string) *AuditEvent {
 }
 
 // StoreBestEffort stores an audit event without propagating errors (fire-and-forget).
-func StoreBestEffort(ctx context.Context, store AuditStore, event *AuditEvent, logger *slog.Logger) {
+func StoreBestEffort(ctx context.Context, store AuditStore, event *AuditEvent, logger logr.Logger) {
 	if err := store.StoreAudit(ctx, event); err != nil {
-		logger.Warn("audit store failure (best-effort)",
-			slog.String("event_type", event.EventType),
-			slog.String("error", err.Error()),
-		)
+		logger.Error(err, "audit store failure (best-effort)", "event_type", event.EventType)
 	}
 }

--- a/internal/kubernautagent/credentials/resolver.go
+++ b/internal/kubernautagent/credentials/resolver.go
@@ -17,10 +17,11 @@ limitations under the License.
 package credentials
 
 import (
-	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/go-logr/logr"
 )
 
 var providerKeyFiles = map[string]string{
@@ -42,7 +43,7 @@ var providerKeyFiles = map[string]string{
 // actual credentials JSON or a file path pointing to the real credentials (#686).
 // When the content looks like a path rather than JSON, the function follows
 // the indirection and reads the target file.
-func ResolveCredentialsFile(provider, credDir string, logger *slog.Logger) string {
+func ResolveCredentialsFile(provider, credDir string, logger logr.Logger) string {
 	if keyFile, ok := providerKeyFiles[provider]; ok {
 		path := filepath.Join(credDir, keyFile)
 		if data, err := os.ReadFile(path); err == nil {
@@ -91,7 +92,7 @@ const maxCredentialFileSize = 1 << 20 // 1 MB (F-05)
 //   - F-10: relative paths are rejected
 //   - Gap 5: content is trimmed before the JSON-object check
 //   - Gap 6: returns empty string on failure (not the original content)
-func ResolveGCPCredentialIndirection(provider, content, credDir string, logger *slog.Logger) string {
+func ResolveGCPCredentialIndirection(provider, content, credDir string, logger logr.Logger) string {
 	switch provider {
 	case "vertex", "vertex_ai":
 	default:
@@ -113,7 +114,7 @@ func ResolveGCPCredentialIndirection(provider, content, credDir string, logger *
 	// F-10: reject relative paths — they make no sense in a container context
 	// and are ambiguous about the working directory.
 	if !filepath.IsAbs(target) {
-		logger.Warn("GCP credentials indirection rejected: path is not absolute",
+		logger.Info("GCP credentials indirection rejected: path is not absolute",
 			"path", target)
 		return ""
 	}
@@ -122,7 +123,7 @@ func ResolveGCPCredentialIndirection(provider, content, credDir string, logger *
 	cleaned := filepath.Clean(target)
 	if !strings.HasPrefix(cleaned, filepath.Clean(credDir)+string(filepath.Separator)) &&
 		cleaned != filepath.Clean(credDir) {
-		logger.Warn("GCP credentials indirection rejected: path escapes credential directory",
+		logger.Info("GCP credentials indirection rejected: path escapes credential directory",
 			"path", target, "credDir", credDir)
 		return ""
 	}
@@ -130,26 +131,26 @@ func ResolveGCPCredentialIndirection(provider, content, credDir string, logger *
 	// F-05: enforce file size limit before reading.
 	info, err := os.Stat(cleaned)
 	if err != nil {
-		logger.Warn("GCP credentials indirection target is unreadable",
-			"path", cleaned, "error", err)
+		logger.Error(err, "GCP credentials indirection target is unreadable",
+			"path", cleaned)
 		return "" // Gap 6: return empty, not the original content
 	}
 	if info.Size() > maxCredentialFileSize {
-		logger.Warn("GCP credentials indirection target exceeds size limit",
+		logger.Info("GCP credentials indirection target exceeds size limit",
 			"path", cleaned, "size", info.Size(), "limit", maxCredentialFileSize)
 		return ""
 	}
 
 	data, err := os.ReadFile(cleaned)
 	if err != nil {
-		logger.Warn("GCP credentials indirection target read failed",
-			"path", cleaned, "error", err)
+		logger.Error(err, "GCP credentials indirection target read failed",
+			"path", cleaned)
 		return ""
 	}
 
 	resolved := strings.TrimSpace(string(data))
 	if resolved == "" {
-		logger.Warn("GCP credentials indirection target is empty", "path", cleaned)
+		logger.Info("GCP credentials indirection target is empty", "path", cleaned)
 		return ""
 	}
 

--- a/internal/kubernautagent/enrichment/enricher.go
+++ b/internal/kubernautagent/enrichment/enricher.go
@@ -19,9 +19,9 @@ package enrichment
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
 	"github.com/jordigilh/kubernaut/pkg/shared/backoff"
@@ -154,10 +154,10 @@ type EnrichmentResult struct {
 	// exhaustion (all errors retried, matching HAPI v1.2.1). The
 	// investigator uses this to trigger rca_incomplete (BR-HAPI-261
 	// AC#7, #704). Only set when RetryConfig has MaxRetries > 0.
-	HardFail           bool                      `json:"-"`
-	DetectedLabels     *DetectedLabels              `json:"detected_labels,omitempty"`
+	HardFail           bool                          `json:"-"`
+	DetectedLabels     *DetectedLabels               `json:"detected_labels,omitempty"`
 	QuotaDetails       map[string]QuotaResourceUsage `json:"quota_details,omitempty"`
-	RemediationHistory *RemediationHistoryResult `json:"remediation_history,omitempty"`
+	RemediationHistory *RemediationHistoryResult     `json:"remediation_history,omitempty"`
 }
 
 // Enricher resolves owner chain, labels, and remediation history.
@@ -165,13 +165,13 @@ type Enricher struct {
 	k8s           K8sClient
 	ds            DataStorageClient
 	auditStore    audit.AuditStore
-	logger        *slog.Logger
+	logger        logr.Logger
 	labelDetector *LabelDetector
 	retryConfig   RetryConfig
 }
 
 // NewEnricher creates an enricher with the given clients.
-func NewEnricher(k8s K8sClient, ds DataStorageClient, auditStore audit.AuditStore, logger *slog.Logger) *Enricher {
+func NewEnricher(k8s K8sClient, ds DataStorageClient, auditStore audit.AuditStore, logger logr.Logger) *Enricher {
 	return &Enricher{
 		k8s:        k8s,
 		ds:         ds,
@@ -216,8 +216,8 @@ func (e *Enricher) resolveOwnerChainWithRetry(ctx context.Context, kind, name, n
 	for attempt := 1; attempt <= e.retryConfig.MaxRetries; attempt++ {
 		wait := boCfg.Calculate(int32(attempt))
 		e.logger.Info("enrichment: retrying GetOwnerChain",
-			slog.Int("attempt", attempt),
-			slog.Duration("backoff", wait),
+			"attempt", attempt,
+			"backoff", wait,
 		)
 
 		select {
@@ -268,9 +268,8 @@ func (e *Enricher) Enrich(ctx context.Context, kind, name, namespace, specHash, 
 	if specHash == "" {
 		computed, err := e.k8s.GetSpecHash(ctx, kind, name, namespace)
 		if err != nil {
-			e.logger.Warn("enrichment: specHash auto-computation failed, proceeding with empty",
-				slog.String("resource", namespace+"/"+kind+"/"+name),
-				slog.String("error", err.Error()),
+			e.logger.Error(err, "enrichment: specHash auto-computation failed, proceeding with empty",
+				"resource", namespace+"/"+kind+"/"+name,
 			)
 		} else {
 			specHash = computed
@@ -285,9 +284,8 @@ func (e *Enricher) Enrich(ctx context.Context, kind, name, namespace, specHash, 
 		if e.retryConfig.MaxRetries > 0 && !IsNoMatchError(ownerErr) {
 			result.HardFail = true
 		}
-		e.logger.Warn("enrichment: owner chain resolution failed",
-			slog.String("resource", namespace+"/"+kind+"/"+name),
-			slog.String("error", ownerErr.Error()),
+		e.logger.Error(ownerErr, "enrichment: owner chain resolution failed",
+			"resource", namespace+"/"+kind+"/"+name,
 		)
 	} else {
 		result.OwnerChain = chain
@@ -296,9 +294,8 @@ func (e *Enricher) Enrich(ctx context.Context, kind, name, namespace, specHash, 
 	if e.labelDetector != nil {
 		labels, quotaDetails, labelErr := e.labelDetector.DetectLabels(ctx, kind, name, namespace, result.OwnerChain)
 		if labelErr != nil {
-			e.logger.Warn("enrichment: label detection failed",
-				slog.String("resource", namespace+"/"+kind+"/"+name),
-				slog.String("error", labelErr.Error()),
+			e.logger.Error(labelErr, "enrichment: label detection failed",
+				"resource", namespace+"/"+kind+"/"+name,
 			)
 		}
 		if labels != nil {
@@ -312,9 +309,8 @@ func (e *Enricher) Enrich(ctx context.Context, kind, name, namespace, specHash, 
 	histResult, err := e.ds.GetRemediationHistory(ctx, kind, name, namespace, specHash)
 	if err != nil {
 		histErr = err
-		e.logger.Warn("enrichment: remediation history fetch failed",
-			slog.String("resource", namespace+"/"+name),
-			slog.String("error", err.Error()),
+		e.logger.Error(err, "enrichment: remediation history fetch failed",
+			"resource", namespace+"/"+name,
 		)
 	} else {
 		result.RemediationHistory = histResult

--- a/internal/kubernautagent/enrichment/label_detector.go
+++ b/internal/kubernautagent/enrichment/label_detector.go
@@ -19,8 +19,9 @@ package enrichment
 import (
 	"context"
 	"fmt"
-	"log/slog"
 	"strings"
+
+	"github.com/go-logr/logr"
 
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -46,12 +47,13 @@ var (
 type LabelDetector struct {
 	dynClient dynamic.Interface
 	mapper    meta.RESTMapper
+	logger    logr.Logger
 }
 
 // NewLabelDetector creates a LabelDetector backed by the given dynamic K8s client
 // and REST mapper. The mapper resolves any Kubernetes kind to its GVR (#679).
-func NewLabelDetector(dynClient dynamic.Interface, mapper meta.RESTMapper) *LabelDetector {
-	return &LabelDetector{dynClient: dynClient, mapper: mapper}
+func NewLabelDetector(dynClient dynamic.Interface, mapper meta.RESTMapper, logger logr.Logger) *LabelDetector {
+	return &LabelDetector{dynClient: dynClient, mapper: mapper, logger: logger}
 }
 
 // DetectLabels detects infrastructure characteristics for the given resource,
@@ -72,7 +74,7 @@ func (d *LabelDetector) DetectLabels(ctx context.Context, kind, name, namespace 
 
 	rootObj, err := d.fetchResource(ctx, rootKind, rootName, rootNS)
 	if err != nil {
-		slog.Warn("label detection: root owner fetch failed", "kind", rootKind, "name", rootName, "error", err)
+		d.logger.Error(err, "label detection: root owner fetch failed", "kind", rootKind, "name", rootName)
 		result.FailedDetections = append([]string(nil), AllDetectionCategories...)
 		return result, nil, nil
 	}
@@ -97,7 +99,7 @@ func (d *LabelDetector) DetectLabels(ctx context.Context, kind, name, namespace 
 		result.FailedDetections = failed
 	}
 
-	slog.Debug("label detection complete",
+	d.logger.V(1).Info("label detection complete",
 		"root", rootKind+"/"+rootName,
 		"namespace", rootNS,
 		"gitOpsManaged", result.GitOpsManaged,
@@ -153,7 +155,7 @@ func (d *LabelDetector) resolveMapping(kind string) (*meta.RESTMapping, error) {
 func (d *LabelDetector) fetchNamespace(ctx context.Context, namespace string) *unstructured.Unstructured {
 	obj, err := d.dynClient.Resource(namespaceGVR).Get(ctx, namespace, metav1.GetOptions{})
 	if err != nil {
-		slog.Warn("label detection: namespace fetch failed (best-effort skip)", "namespace", namespace, "error", err)
+		d.logger.Error(err, "label detection: namespace fetch failed (best-effort skip)", "namespace", namespace)
 		return nil
 	}
 	return obj
@@ -227,21 +229,21 @@ func detectGitOps(rootObj *unstructured.Unstructured, podTemplateAnnotations map
 
 	// DD-HAPI-018 priorities 1-10 then legacy 11-13
 	checks := []gitOpsCheck{
-		{podTemplateAnnotations, "argocd.argoproj.io/tracking-id", "argocd"},  // P1
-		{podTemplateLabels, "argocd.argoproj.io/instance", "argocd"},          // P2
-		{rootAnnotations, "argocd.argoproj.io/tracking-id", "argocd"},         // P3
-		{rootLabels, "fluxcd.io/sync-gc-mark", "flux"},                        // P4
-		{rootAnnotations, "argocd.argoproj.io/instance", "argocd"},            // P5 (annotation)
-		{rootLabels, "argocd.argoproj.io/instance", "argocd"},                 // P5 (label)
-		{nsLabels, "argocd.argoproj.io/instance", "argocd"},                   // P6
-		{nsAnnotations, "argocd.argoproj.io/tracking-id", "argocd"},           // P7
-		{nsAnnotations, "fluxcd.io/sync-gc-mark", "flux"},                     // P8
-		{nsAnnotations, "argocd.argoproj.io/managed", "argocd"},               // P9
-		{nsAnnotations, "fluxcd.io/sync-status", "flux"},                      // P10
+		{podTemplateAnnotations, "argocd.argoproj.io/tracking-id", "argocd"}, // P1
+		{podTemplateLabels, "argocd.argoproj.io/instance", "argocd"},         // P2
+		{rootAnnotations, "argocd.argoproj.io/tracking-id", "argocd"},        // P3
+		{rootLabels, "fluxcd.io/sync-gc-mark", "flux"},                       // P4
+		{rootAnnotations, "argocd.argoproj.io/instance", "argocd"},           // P5 (annotation)
+		{rootLabels, "argocd.argoproj.io/instance", "argocd"},                // P5 (label)
+		{nsLabels, "argocd.argoproj.io/instance", "argocd"},                  // P6
+		{nsAnnotations, "argocd.argoproj.io/tracking-id", "argocd"},          // P7
+		{nsAnnotations, "fluxcd.io/sync-gc-mark", "flux"},                    // P8
+		{nsAnnotations, "argocd.argoproj.io/managed", "argocd"},              // P9
+		{nsAnnotations, "fluxcd.io/sync-status", "flux"},                     // P10
 		// Legacy fallbacks (backward compatibility, not in DD-HAPI-018)
-		{rootAnnotations, "argocd.argoproj.io/managed-by", "argocd"},          // L11
-		{rootAnnotations, "fluxcd.io/sync-checksum", "flux"},                  // L12
-		{rootAnnotations, "kustomize.toolkit.fluxcd.io/name", "flux"},         // L13
+		{rootAnnotations, "argocd.argoproj.io/managed-by", "argocd"},  // L11
+		{rootAnnotations, "fluxcd.io/sync-checksum", "flux"},          // L12
+		{rootAnnotations, "kustomize.toolkit.fluxcd.io/name", "flux"}, // L13
 	}
 
 	for _, c := range checks {
@@ -326,7 +328,7 @@ func (d *LabelDetector) detectHPA(ctx context.Context, ownerChain []OwnerChainEn
 
 	list, err := d.dynClient.Resource(hpaGVR).Namespace(rootNS).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		slog.Warn("label detection: HPA list failed", "namespace", rootNS, "error", err)
+		d.logger.Error(err, "label detection: HPA list failed", "namespace", rootNS)
 		*failed = append(*failed, "hpaEnabled")
 		return
 	}
@@ -366,7 +368,7 @@ func (d *LabelDetector) detectPDB(ctx context.Context, rootObj *unstructured.Uns
 	}
 	list, err := d.dynClient.Resource(pdbGVR).Namespace(rootNS).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		slog.Warn("label detection: PDB list failed", "namespace", rootNS, "error", err)
+		d.logger.Error(err, "label detection: PDB list failed", "namespace", rootNS)
 		*failed = append(*failed, "pdbProtected")
 		return
 	}
@@ -421,7 +423,7 @@ func (d *LabelDetector) detectNetworkPolicy(ctx context.Context, namespace strin
 	}
 	list, err := d.dynClient.Resource(networkPolicyGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		slog.Warn("label detection: NetworkPolicy list failed", "namespace", namespace, "error", err)
+		d.logger.Error(err, "label detection: NetworkPolicy list failed", "namespace", namespace)
 		*failed = append(*failed, "networkIsolated")
 		return
 	}
@@ -437,7 +439,7 @@ func (d *LabelDetector) detectResourceQuota(ctx context.Context, namespace strin
 	}
 	list, err := d.dynClient.Resource(resourceQuotaGVR).Namespace(namespace).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		slog.Warn("label detection: ResourceQuota list failed", "namespace", namespace, "error", err)
+		d.logger.Error(err, "label detection: ResourceQuota list failed", "namespace", namespace)
 		*failed = append(*failed, "resourceQuotaConstrained")
 		return nil
 	}

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -20,10 +20,10 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
@@ -132,7 +132,7 @@ type Config struct {
 	ResultParser  *parser.ResultParser
 	Enricher      *enrichment.Enricher
 	AuditStore    audit.AuditStore
-	Logger        *slog.Logger
+	Logger        logr.Logger
 	MaxTurns      int
 	PhaseTools    katypes.PhaseToolMap
 	Registry      registry.ToolRegistry
@@ -151,7 +151,7 @@ type Investigator struct {
 	resultParser  *parser.ResultParser
 	enricher      *enrichment.Enricher
 	auditStore    audit.AuditStore
-	logger        *slog.Logger
+	logger        logr.Logger
 	maxTurns      int
 	phaseTools    katypes.PhaseToolMap
 	registry      registry.ToolRegistry
@@ -159,6 +159,10 @@ type Investigator struct {
 	modelName     string
 	scopeResolver ScopeResolver
 	swappable     *llm.SwappableClient
+}
+
+func (inv *Investigator) auditLog() logr.Logger {
+	return inv.logger
 }
 
 // New creates an Investigator from the given configuration.
@@ -246,9 +250,7 @@ func (inv *Investigator) Investigate(ctx context.Context, signal katypes.SignalC
 		// labels (e.g. pdbProtected) matches pre-#704 behaviour where
 		// allLabelDetectionsFailed() fell through to keep initial labels.
 		if reEnriched != nil && reEnriched.HardFail {
-			inv.logger.Warn("enrichment owner chain hard-failed, triggering rca_incomplete",
-				slog.String("error", reEnriched.OwnerChainError.Error()),
-			)
+			inv.logger.Error(reEnriched.OwnerChainError, "enrichment owner chain hard-failed, triggering rca_incomplete")
 			rcaResult.HumanReviewNeeded = true
 			rcaResult.HumanReviewReason = "rca_incomplete"
 			backfillSeverity(rcaResult, signal)
@@ -262,10 +264,10 @@ func (inv *Investigator) Investigate(ctx context.Context, signal katypes.SignalC
 		if reEnriched != nil && !allLabelDetectionsFailed(reEnriched.DetectedLabels) {
 			enrichData = reEnriched
 		} else if reEnriched != nil {
-			inv.logger.Warn("re-enrichment labels all failed (RCA target not found), preserving signal-target labels",
+			inv.logger.Info("re-enrichment labels all failed (RCA target not found), preserving signal-target labels",
 				"rca_target", postRCAKind+"/"+postRCAName)
 		} else {
-			inv.logger.Warn("re-enrichment returned nil, retaining pre-RCA enrichment data")
+			inv.logger.Info("re-enrichment returned nil, retaining pre-RCA enrichment data")
 		}
 		promptEnrichment = toPromptEnrichment(enrichData)
 
@@ -342,7 +344,7 @@ func (inv *Investigator) resolveEnrichment(ctx context.Context, kind, name, name
 	}
 	result, err := inv.enricher.Enrich(ctx, kind, name, namespace, "", incidentID)
 	if err != nil {
-		inv.logger.Warn("enrichment failed", slog.String("error", err.Error()))
+		inv.logger.Error(err, "enrichment failed")
 		return nil
 	}
 	return result
@@ -387,9 +389,9 @@ func (inv *Investigator) runRCA(ctx context.Context, signal katypes.SignalContex
 		}
 	}
 	if parseErr != nil {
-		inv.logger.Warn("RCA parse failed after retry, treating as summary",
-			slog.String("error", parseErr.Error()),
-			slog.String("correlation_id", correlationID))
+		inv.logger.Info("RCA parse failed after retry, treating as summary",
+			"error", parseErr.Error(),
+			"correlation_id", correlationID)
 		return &katypes.InvestigationResult{
 			RCASummary: content,
 		}, nil
@@ -406,8 +408,8 @@ func (inv *Investigator) runRCA(ctx context.Context, signal katypes.SignalContex
 	// Aligned with HAPI v1.2.1 where needs_human_review is parser-driven in Phase 3.
 	if result.HumanReviewNeeded {
 		inv.logger.Info("clearing HumanReviewNeeded set during RCA (parser-driven in Phase 3 only)",
-			slog.String("reason", result.HumanReviewReason),
-			slog.String("correlation_id", correlationID))
+			"reason", result.HumanReviewReason,
+			"correlation_id", correlationID)
 		result.HumanReviewNeeded = false
 		result.HumanReviewReason = ""
 	}
@@ -442,9 +444,9 @@ CRITICAL: root_cause_analysis must be a JSON object, NOT a string. Do NOT wrap i
 
 	for attempt := 0; attempt < maxRCAParseRetries; attempt++ {
 		inv.logger.Info("parse-level retry for RCA submit",
-			slog.Int("attempt", attempt+1),
-			slog.Int("max", maxRCAParseRetries),
-			slog.String("correlation_id", correlationID))
+			"attempt", attempt+1,
+			"max", maxRCAParseRetries,
+			"correlation_id", correlationID)
 
 		retryMessages = append(retryMessages,
 			llm.Message{Role: "user", Content: correctionMsg},
@@ -458,7 +460,7 @@ CRITICAL: root_cause_analysis must be a JSON object, NOT a string. Do NOT wrap i
 		retryEvent.Data["retry_max"] = maxRCAParseRetries
 		retryEvent.Data["phase"] = string(katypes.PhaseRCA)
 		retryEvent.Data["retry_reason"] = "rca_parse_correction"
-		audit.StoreBestEffort(ctx, inv.auditStore, retryEvent, inv.logger)
+		audit.StoreBestEffort(ctx, inv.auditStore, retryEvent, inv.auditLog())
 
 		resp, err := client.Chat(ctx, llm.ChatRequest{
 			Messages: retryMessages,
@@ -466,9 +468,8 @@ CRITICAL: root_cause_analysis must be a JSON object, NOT a string. Do NOT wrap i
 			Options:  llm.ChatOptions{JSONMode: true, OutputSchema: parser.RCAResultSchema()},
 		})
 		if err != nil {
-			inv.logger.Warn("RCA retry LLM call failed",
-				slog.String("error", err.Error()),
-				slog.String("correlation_id", correlationID))
+			inv.logger.Error(err, "RCA retry LLM call failed",
+				"correlation_id", correlationID)
 			continue
 		}
 		if tokens != nil {
@@ -479,14 +480,13 @@ CRITICAL: root_cause_analysis must be a JSON object, NOT a string. Do NOT wrap i
 			if tc.Name == SubmitResultToolName {
 				result, parseErr := inv.resultParser.Parse(tc.Arguments)
 				if parseErr != nil {
-					inv.logger.Warn("RCA retry parse still failed",
-						slog.String("error", parseErr.Error()),
-						slog.String("correlation_id", correlationID))
+					inv.logger.Error(parseErr, "RCA retry parse still failed",
+						"correlation_id", correlationID)
 					retryMessages = append(retryMessages, resp.Message)
 					continue
 				}
 				inv.logger.Info("RCA retry succeeded",
-					slog.String("correlation_id", correlationID))
+					"correlation_id", correlationID)
 				return result
 			}
 		}
@@ -495,7 +495,7 @@ CRITICAL: root_cause_analysis must be a JSON object, NOT a string. Do NOT wrap i
 			result, parseErr := inv.resultParser.Parse(resp.Message.Content)
 			if parseErr == nil {
 				inv.logger.Info("RCA retry succeeded from message content",
-					slog.String("correlation_id", correlationID))
+					"correlation_id", correlationID)
 				return result
 			}
 		}
@@ -530,9 +530,9 @@ func (inv *Investigator) sameKindValidationGate(
 	}
 
 	inv.logger.Info("same-kind validation gate triggered: remediation_target.kind matches signal resource_kind",
-		slog.String("target_kind", result.RemediationTarget.Kind),
-		slog.String("signal_resource_kind", signal.ResourceKind),
-		slog.String("correlation_id", correlationID))
+		"target_kind", result.RemediationTarget.Kind,
+		"signal_resource_kind", signal.ResourceKind,
+		"correlation_id", correlationID)
 
 	gateEvent := audit.NewEvent(audit.EventTypeLLMRequest, correlationID)
 	gateEvent.EventAction = "same_kind_validation_gate"
@@ -540,7 +540,7 @@ func (inv *Investigator) sameKindValidationGate(
 	gateEvent.Data["signal_resource_kind"] = signal.ResourceKind
 	gateEvent.Data["target_kind"] = result.RemediationTarget.Kind
 	gateEvent.Data["target_name"] = result.RemediationTarget.Name
-	audit.StoreBestEffort(ctx, inv.auditStore, gateEvent, inv.logger)
+	audit.StoreBestEffort(ctx, inv.auditStore, gateEvent, inv.auditLog())
 
 	correctionMsg := fmt.Sprintf(
 		`Your remediation_target.kind is "%s", which is the same resource kind as the input signal. `+
@@ -574,9 +574,8 @@ func (inv *Investigator) sameKindValidationGate(
 		Options:  llm.ChatOptions{JSONMode: true, OutputSchema: parser.RCAResultSchema()},
 	})
 	if err != nil {
-		inv.logger.Warn("same-kind validation gate retry failed, keeping original result",
-			slog.String("error", err.Error()),
-			slog.String("correlation_id", correlationID))
+		inv.logger.Error(err, "same-kind validation gate retry failed, keeping original result",
+			"correlation_id", correlationID)
 		return result
 	}
 	if tokens != nil {
@@ -594,30 +593,29 @@ func (inv *Investigator) sameKindValidationGate(
 		retryContent = resp.Message.Content
 	}
 	if retryContent == "" {
-		inv.logger.Warn("same-kind validation gate: no content in retry response, keeping original",
-			slog.String("correlation_id", correlationID))
+		inv.logger.Info("same-kind validation gate: no content in retry response, keeping original",
+			"correlation_id", correlationID)
 		return result
 	}
 
 	retryResult, parseErr := inv.resultParser.Parse(retryContent)
 	if parseErr != nil {
-		inv.logger.Warn("same-kind validation gate: retry parse failed, keeping original",
-			slog.String("error", parseErr.Error()),
-			slog.String("correlation_id", correlationID))
+		inv.logger.Error(parseErr, "same-kind validation gate: retry parse failed, keeping original",
+			"correlation_id", correlationID)
 		return result
 	}
 
 	if retryResult.RemediationTarget.Kind == "" && result.RemediationTarget.Kind != "" {
-		inv.logger.Warn("same-kind validation gate: retry lost remediation_target, keeping original",
-			slog.String("original_target", result.RemediationTarget.Kind+"/"+result.RemediationTarget.Name),
-			slog.String("correlation_id", correlationID))
+		inv.logger.Info("same-kind validation gate: retry lost remediation_target, keeping original",
+			"original_target", result.RemediationTarget.Kind+"/"+result.RemediationTarget.Name,
+			"correlation_id", correlationID)
 		return result
 	}
 
 	inv.logger.Info("same-kind validation gate: accepted retry result",
-		slog.String("original_target", result.RemediationTarget.Kind+"/"+result.RemediationTarget.Name),
-		slog.String("retry_target", retryResult.RemediationTarget.Kind+"/"+retryResult.RemediationTarget.Name),
-		slog.String("correlation_id", correlationID))
+		"original_target", result.RemediationTarget.Kind+"/"+result.RemediationTarget.Name,
+		"retry_target", retryResult.RemediationTarget.Kind+"/"+retryResult.RemediationTarget.Name,
+		"correlation_id", correlationID)
 	return retryResult
 }
 
@@ -657,7 +655,7 @@ func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katype
 		}, nil
 	case *SubmitNoWorkflowResult:
 		inv.logger.Info("submit_result_no_workflow sentinel: classifying as no_matching_workflows",
-			slog.String("correlation_id", correlationID))
+			"correlation_id", correlationID)
 		return &katypes.InvestigationResult{
 			RCASummary:        rcaSummary,
 			HumanReviewNeeded: true,
@@ -676,15 +674,15 @@ func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katype
 		// content cannot be parsed at all.
 		if _, textErr := inv.resultParser.Parse(r.Content); textErr == nil {
 			inv.logger.Info("workflow selection: parsed text response directly (no tool call)",
-				slog.String("correlation_id", correlationID))
+				"correlation_id", correlationID)
 			content = r.Content
 		} else {
 			retryResult := inv.retryWorkflowSubmit(ctx, r.Content, messages, rcaSummary, tokens, correlationID, client, modelName)
 			if retryResult != nil {
 				return retryResult, nil
 			}
-			inv.logger.Warn("workflow selection: all retries exhausted, classifying as no_matching_workflows",
-				slog.String("correlation_id", correlationID))
+			inv.logger.Info("workflow selection: all retries exhausted, classifying as no_matching_workflows",
+				"correlation_id", correlationID)
 			return &katypes.InvestigationResult{
 				RCASummary:        rcaSummary,
 				HumanReviewNeeded: true,
@@ -700,9 +698,8 @@ func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katype
 		if retryResult != nil {
 			return retryResult, nil
 		}
-		inv.logger.Warn("workflow selection parse failed after retries, classifying as no_matching_workflows",
-			slog.String("error", parseErr.Error()),
-			slog.String("correlation_id", correlationID))
+		inv.logger.Error(parseErr, "workflow selection parse failed after retries, classifying as no_matching_workflows",
+			"correlation_id", correlationID)
 		return &katypes.InvestigationResult{
 			RCASummary:        rcaSummary,
 			HumanReviewNeeded: true,
@@ -714,8 +711,7 @@ func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katype
 	if inv.pipeline.CatalogFetcher != nil {
 		validator, fetchErr := inv.pipeline.CatalogFetcher.FetchValidator(ctx)
 		if fetchErr != nil {
-			inv.logger.Warn("workflow catalog unavailable, requiring human review",
-				slog.String("error", fetchErr.Error()))
+			inv.logger.Error(fetchErr, "workflow catalog unavailable, requiring human review")
 			result.HumanReviewNeeded = true
 			result.HumanReviewReason = "catalog_unavailable"
 			result.Reason = fmt.Sprintf("workflow catalog unavailable: %s", fetchErr)
@@ -817,9 +813,9 @@ Do NOT respond with plain text. You MUST call one of the above tools.`
 
 	for attempt := 0; attempt < maxParseRetries; attempt++ {
 		inv.logger.Info("parse-level retry for workflow submit",
-			slog.Int("attempt", attempt+1),
-			slog.Int("max", maxParseRetries),
-			slog.String("correlation_id", correlationID))
+			"attempt", attempt+1,
+			"max", maxParseRetries,
+			"correlation_id", correlationID)
 
 		retryMessages = append(retryMessages,
 			llm.Message{Role: "user", Content: correctionTemplate},
@@ -833,7 +829,7 @@ Do NOT respond with plain text. You MUST call one of the above tools.`
 		retryEvent.Data["retry_max"] = maxParseRetries
 		retryEvent.Data["phase"] = string(katypes.PhaseWorkflowDiscovery)
 		retryEvent.Data["retry_reason"] = "parse_level_correction"
-		audit.StoreBestEffort(ctx, inv.auditStore, retryEvent, inv.logger)
+		audit.StoreBestEffort(ctx, inv.auditStore, retryEvent, inv.auditLog())
 
 		resp, err := client.Chat(ctx, llm.ChatRequest{
 			Messages: retryMessages,
@@ -841,9 +837,8 @@ Do NOT respond with plain text. You MUST call one of the above tools.`
 			Options:  llm.ChatOptions{JSONMode: true, OutputSchema: parser.InvestigationResultSchema()},
 		})
 		if err != nil {
-			inv.logger.Warn("retry LLM call failed",
-				slog.String("error", err.Error()),
-				slog.String("correlation_id", correlationID))
+			inv.logger.Error(err, "retry LLM call failed",
+				"correlation_id", correlationID)
 			continue
 		}
 		if tokens != nil {
@@ -855,7 +850,7 @@ Do NOT respond with plain text. You MUST call one of the above tools.`
 				switch tc.Name {
 				case SubmitResultNoWorkflowToolName:
 					inv.logger.Info("retry succeeded: submit_result_no_workflow",
-					slog.String("correlation_id", correlationID))
+						"correlation_id", correlationID)
 					return &katypes.InvestigationResult{
 						RCASummary:        rcaSummary,
 						HumanReviewNeeded: true,
@@ -864,12 +859,11 @@ Do NOT respond with plain text. You MUST call one of the above tools.`
 					}
 				case SubmitResultWithWorkflowToolName:
 					inv.logger.Info("retry succeeded: submit_result_with_workflow",
-					slog.String("correlation_id", correlationID))
+						"correlation_id", correlationID)
 					result, parseErr := inv.resultParser.Parse(tc.Arguments)
 					if parseErr != nil {
-						inv.logger.Warn("retry submit_result_with_workflow parse failed",
-							slog.String("error", parseErr.Error()),
-							slog.String("correlation_id", correlationID))
+						inv.logger.Error(parseErr, "retry submit_result_with_workflow parse failed",
+							"correlation_id", correlationID)
 						retryMessages = append(retryMessages, resp.Message)
 						continue
 					}
@@ -929,7 +923,7 @@ func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message,
 		reqEvent.Data["prompt_preview"] = lastUserMessage(messages, 500)
 		reqEvent.Data["toolsets_enabled"] = toolNames(toolDefs)
 		reqEvent.Data["messages"] = messagesToAuditFormat(messages)
-		audit.StoreBestEffort(ctx, inv.auditStore, reqEvent, inv.logger)
+		audit.StoreBestEffort(ctx, inv.auditStore, reqEvent, inv.auditLog())
 
 		resp, err := client.Chat(ctx, llm.ChatRequest{
 			Messages: messages,
@@ -943,7 +937,7 @@ func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message,
 			failEvent.Data["error_message"] = err.Error()
 			failEvent.Data["phase"] = string(phase)
 			failEvent.Data["duration_seconds"] = time.Since(loopStart).Seconds()
-			audit.StoreBestEffort(ctx, inv.auditStore, failEvent, inv.logger)
+			audit.StoreBestEffort(ctx, inv.auditStore, failEvent, inv.auditLog())
 			return nil, fmt.Errorf("%s LLM call turn %d: %w", phase, turn, err)
 		}
 
@@ -964,15 +958,15 @@ func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message,
 		respEvent.Data["analysis_content"] = resp.Message.Content
 		respEvent.Data["tool_call_count"] = len(resp.ToolCalls)
 		respEvent.Data["finish_reason"] = resp.FinishReason
-		audit.StoreBestEffort(ctx, inv.auditStore, respEvent, inv.logger)
+		audit.StoreBestEffort(ctx, inv.auditStore, respEvent, inv.auditLog())
 
 		if len(resp.ToolCalls) > 0 {
 			for _, tc := range resp.ToolCalls {
 				if sr := sentinelResult(tc); sr != nil {
 					inv.logger.Info("sentinel detected",
-						slog.String("tool", tc.Name),
-						slog.String("phase", string(phase)),
-						slog.String("correlation_id", correlationID))
+						"tool", tc.Name,
+						"phase", string(phase),
+						"correlation_id", correlationID)
 					return sr, nil
 				}
 			}
@@ -989,7 +983,7 @@ func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message,
 				tcEvent.Data["tool_arguments"] = tc.Arguments
 				tcEvent.Data["tool_result"] = toolResult
 				tcEvent.Data["tool_result_preview"] = truncatePreview(toolResult, 500)
-				audit.StoreBestEffort(ctx, inv.auditStore, tcEvent, inv.logger)
+				audit.StoreBestEffort(ctx, inv.auditStore, tcEvent, inv.auditLog())
 
 				messages = append(messages, llm.Message{
 					Role:       "tool",
@@ -998,19 +992,19 @@ func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message,
 					ToolName:   tc.Name,
 				})
 			}
-		if inv.pipeline.AnomalyDetector.TotalExceeded() {
-			return &ExhaustedResult{Reason: "tool budget exhausted"}, nil
-		}
+			if inv.pipeline.AnomalyDetector.TotalExceeded() {
+				return &ExhaustedResult{Reason: "tool budget exhausted"}, nil
+			}
 			continue
 		}
 
 		if resp.FinishReason == llm.FinishReasonLength && !truncationRetried {
 			truncationRetried = true
 			maxTokens = escalateMaxTokens(resp.Usage.CompletionTokens)
-			inv.logger.Warn("LLM response truncated, retrying with escalated MaxTokens",
-				slog.String("phase", string(phase)),
-				slog.Int("escalated_max_tokens", maxTokens),
-				slog.String("correlation_id", correlationID))
+			inv.logger.Info("LLM response truncated, retrying with escalated MaxTokens",
+				"phase", string(phase),
+				"escalated_max_tokens", maxTokens,
+				"correlation_id", correlationID)
 
 			truncEvent := audit.NewEvent(audit.EventTypeLLMResponse, correlationID)
 			truncEvent.EventAction = "truncation_detected"
@@ -1018,7 +1012,7 @@ func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message,
 			truncEvent.Data["finish_reason"] = resp.FinishReason
 			truncEvent.Data["escalated_max_tokens"] = maxTokens
 			truncEvent.Data["truncated_content_length"] = len(resp.Message.Content)
-			audit.StoreBestEffort(ctx, inv.auditStore, truncEvent, inv.logger)
+			audit.StoreBestEffort(ctx, inv.auditStore, truncEvent, inv.auditLog())
 
 			messages = append(messages, resp.Message)
 			messages = append(messages, llm.Message{
@@ -1151,18 +1145,17 @@ func (inv *Investigator) executeTool(ctx context.Context, name string, args json
 	}
 
 	if ar := inv.pipeline.AnomalyDetector.CheckToolCall(name, args); !ar.Allowed {
-		inv.logger.Warn("anomaly detector rejected tool call",
-			slog.String("tool", name),
-			slog.String("reason", ar.Reason),
+		inv.logger.Info("anomaly detector rejected tool call",
+			"tool", name,
+			"reason", ar.Reason,
 		)
 		return toolErrorJSON(ar.Reason)
 	}
 
 	result, err := inv.registry.Execute(ctx, name, args)
 	if err != nil {
-		inv.logger.Warn("tool execution failed",
-			slog.String("tool", name),
-			slog.String("error", err.Error()),
+		inv.logger.Error(err, "tool execution failed",
+			"tool", name,
 		)
 		if ar := inv.pipeline.AnomalyDetector.RecordFailure(name, args); !ar.Allowed {
 			return toolErrorJSON(ar.Reason)
@@ -1173,9 +1166,8 @@ func (inv *Investigator) executeTool(ctx context.Context, name string, args json
 	if inv.pipeline.Sanitizer != nil {
 		sanitized, sanitizeErr := inv.pipeline.Sanitizer.Run(ctx, result)
 		if sanitizeErr != nil {
-			inv.logger.Warn("sanitization failed, returning raw output",
-				slog.String("tool", name),
-				slog.String("error", sanitizeErr.Error()),
+			inv.logger.Error(sanitizeErr, "sanitization failed, returning raw output",
+				"tool", name,
 			)
 		} else {
 			result = sanitized
@@ -1185,9 +1177,8 @@ func (inv *Investigator) executeTool(ctx context.Context, name string, args json
 	if inv.pipeline.Summarizer != nil {
 		summarized, sumErr := inv.pipeline.Summarizer.MaybeSummarize(ctx, name, result)
 		if sumErr != nil {
-			inv.logger.Warn("summarization failed, returning unsummarized output",
-				slog.String("tool", name),
-				slog.String("error", sumErr.Error()),
+			inv.logger.Error(sumErr, "summarization failed, returning unsummarized output",
+				"tool", name,
 			)
 		} else {
 			result = summarized
@@ -1211,7 +1202,7 @@ func (inv *Investigator) emitResponseComplete(ctx context.Context, result *katyp
 	if b, err := json.Marshal(ResultToAuditJSON(result)); err == nil {
 		completeEvent.Data["response_data"] = string(b)
 	}
-	audit.StoreBestEffort(ctx, inv.auditStore, completeEvent, inv.logger)
+	audit.StoreBestEffort(ctx, inv.auditStore, completeEvent, inv.auditLog())
 }
 
 func (inv *Investigator) emitRCAComplete(ctx context.Context, result *katypes.InvestigationResult, tokens *TokenAccumulator, correlationID string) {
@@ -1224,7 +1215,7 @@ func (inv *Investigator) emitRCAComplete(ctx context.Context, result *katypes.In
 	if b, err := json.Marshal(ResultToAuditJSON(result)); err == nil {
 		ev.Data["response_data"] = string(b)
 	}
-	audit.StoreBestEffort(ctx, inv.auditStore, ev, inv.logger)
+	audit.StoreBestEffort(ctx, inv.auditStore, ev, inv.auditLog())
 }
 
 func ResultToAuditJSON(r *katypes.InvestigationResult) map[string]interface{} {
@@ -1331,7 +1322,7 @@ func (inv *Investigator) emitValidationEvent(ctx context.Context, attempt, maxAt
 	valEvent.Data["errors"] = errors
 	valEvent.Data["workflow_id"] = workflowID
 	valEvent.Data["is_final_attempt"] = attempt == maxAttempts
-	audit.StoreBestEffort(ctx, inv.auditStore, valEvent, inv.logger)
+	audit.StoreBestEffort(ctx, inv.auditStore, valEvent, inv.auditLog())
 }
 
 func toolErrorJSON(msg string) string {
@@ -1641,8 +1632,8 @@ func (inv *Investigator) normalizeNamespace(kind, namespace string) string {
 	}
 	isCluster, err := inv.scopeResolver.IsClusterScoped(kind)
 	if err != nil {
-		inv.logger.Warn("ScopeResolver error, preserving namespace",
-			"kind", kind, "error", err)
+		inv.logger.Error(err, "ScopeResolver error, preserving namespace",
+			"kind", kind)
 		return namespace
 	}
 	if isCluster {

--- a/internal/kubernautagent/server/handler.go
+++ b/internal/kubernautagent/server/handler.go
@@ -21,11 +21,11 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"strings"
 	"time"
 
 	"github.com/go-faster/jx"
+	"github.com/go-logr/logr"
 
 	"github.com/jordigilh/kubernaut/pkg/agentclient"
 
@@ -47,13 +47,13 @@ type Handler struct {
 
 	sessions     *session.Manager
 	investigator InvestigationRunner
-	logger       *slog.Logger
+	logger       logr.Logger
 }
 
 var _ agentclient.Handler = (*Handler)(nil)
 
 // NewHandler creates a Kubernaut Agent ogen handler.
-func NewHandler(sessions *session.Manager, inv InvestigationRunner, logger *slog.Logger) *Handler {
+func NewHandler(sessions *session.Manager, inv InvestigationRunner, logger logr.Logger) *Handler {
 	return &Handler{
 		sessions:     sessions,
 		investigator: inv,
@@ -87,7 +87,7 @@ func (h *Handler) IncidentAnalyzeEndpointAPIV1IncidentAnalyzePost(
 	}
 
 	if h.investigator == nil {
-		h.logger.Error("investigator not configured")
+		h.logger.Error(nil, "investigator not configured")
 		return &agentclient.IncidentAnalyzeEndpointAPIV1IncidentAnalyzePostInternalServerErrorApplicationProblemJSON{
 			Type:     "https://kubernaut.ai/problems/internal-error",
 			Title:    "Internal Server Error",
@@ -111,7 +111,7 @@ func (h *Handler) IncidentAnalyzeEndpointAPIV1IncidentAnalyzePost(
 		return h.investigator.Investigate(bgCtx, signal)
 	}, metadata)
 	if err != nil {
-		h.logger.Error("failed to start investigation", "error", err)
+		h.logger.Error(err, "failed to start investigation")
 		return &agentclient.IncidentAnalyzeEndpointAPIV1IncidentAnalyzePostInternalServerErrorApplicationProblemJSON{
 			Type:     "https://kubernaut.ai/problems/internal-error",
 			Title:    "Internal Server Error",
@@ -142,7 +142,7 @@ func (h *Handler) IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet(
 				Instance: fmt.Sprintf("/api/v1/incident/session/%s", params.SessionID),
 			}, nil
 		}
-		h.logger.Error("session lookup failed", "session_id", params.SessionID, "error", err)
+		h.logger.Error(err, "session lookup failed", "session_id", params.SessionID)
 		return nil, fmt.Errorf("session lookup: %w", err)
 	}
 
@@ -172,7 +172,7 @@ func (h *Handler) IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResu
 				Instance: fmt.Sprintf("/api/v1/incident/session/%s/result", params.SessionID),
 			}, nil
 		}
-		h.logger.Error("session lookup failed", "session_id", params.SessionID, "error", err)
+		h.logger.Error(err, "session lookup failed", "session_id", params.SessionID)
 		return nil, fmt.Errorf("session lookup: %w", err)
 	}
 
@@ -188,7 +188,7 @@ func (h *Handler) IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResu
 
 	result, ok := sess.Result.(*katypes.InvestigationResult)
 	if !ok {
-		h.logger.Error("unexpected result type in session", "session_id", sess.ID)
+		h.logger.Error(nil, "unexpected result type in session", "session_id", sess.ID)
 		return &agentclient.IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetConflict{
 			Type:     "https://kubernaut.ai/problems/session-not-completed",
 			Title:    "Session Not Completed",
@@ -203,7 +203,7 @@ func (h *Handler) IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResu
 		incidentID = sess.Metadata["incident_id"]
 	}
 
-	resp := mapInvestigationResultToResponse(result, incidentID)
+	resp := mapInvestigationResultToResponse(h.logger, result, incidentID)
 	return resp, nil
 }
 
@@ -276,7 +276,7 @@ func mapSessionStatusToAPI(s session.Status) string {
 	}
 }
 
-func mapInvestigationResultToResponse(r *katypes.InvestigationResult, incidentID string) *agentclient.IncidentResponse {
+func mapInvestigationResultToResponse(log logr.Logger, r *katypes.InvestigationResult, incidentID string) *agentclient.IncidentResponse {
 	resp := &agentclient.IncidentResponse{
 		IncidentID: incidentID,
 		Analysis:   r.RCASummary,
@@ -323,7 +323,7 @@ func mapInvestigationResultToResponse(r *katypes.InvestigationResult, incidentID
 		}
 		mapped, isDefault := mapHumanReviewReason(reason)
 		if isDefault && reason != "" {
-			slog.Warn("unrecognized human review reason, falling back to investigation_inconclusive",
+			log.Info("unrecognized human review reason, falling back to investigation_inconclusive",
 				"original_reason", reason)
 		}
 		resp.HumanReviewReason.SetTo(mapped)

--- a/internal/kubernautagent/session/manager.go
+++ b/internal/kubernautagent/session/manager.go
@@ -18,7 +18,8 @@ package session
 
 import (
 	"context"
-	"log/slog"
+
+	"github.com/go-logr/logr"
 )
 
 // InvestigateFunc is the function signature for running an investigation.
@@ -28,11 +29,11 @@ type InvestigateFunc func(ctx context.Context) (interface{}, error)
 // background goroutine and tracking progress via the Store.
 type Manager struct {
 	store  *Store
-	logger *slog.Logger
+	logger logr.Logger
 }
 
 // NewManager creates a session manager backed by the given store.
-func NewManager(store *Store, logger *slog.Logger) *Manager {
+func NewManager(store *Store, logger logr.Logger) *Manager {
 	return &Manager{store: store, logger: logger}
 }
 
@@ -57,7 +58,7 @@ func (m *Manager) StartInvestigation(_ context.Context, fn InvestigateFunc, meta
 		bgCtx := context.Background()
 		result, fnErr := fn(bgCtx)
 		if fnErr != nil {
-			m.logger.Error("investigation failed", slog.String("session_id", id), slog.String("error", fnErr.Error()))
+			m.logger.Error(fnErr, "investigation failed", "session_id", id)
 			_ = m.store.Update(id, StatusFailed, nil, fnErr)
 			return
 		}

--- a/pkg/kubernautagent/llm/client.go
+++ b/pkg/kubernautagent/llm/client.go
@@ -17,8 +17,9 @@ limitations under the License.
 package llm
 
 import (
-	"log/slog"
 	"net/http"
+
+	"github.com/go-logr/logr"
 
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/config"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm/transport"
@@ -37,7 +38,7 @@ func NewLLMClient(baseURL string, headers []config.HeaderDefinition) (*http.Clie
 // NewLLMClientWithLogger creates an http.Client with custom authentication headers
 // and structured logging. Header injection events are logged with sensitive values
 // redacted per DD-HAPI-019-003 (G4: Credential Scrubbing).
-func NewLLMClientWithLogger(baseURL string, headers []config.HeaderDefinition, logger *slog.Logger) (*http.Client, error) {
+func NewLLMClientWithLogger(baseURL string, headers []config.HeaderDefinition, logger logr.Logger) (*http.Client, error) {
 	rt := transport.NewAuthHeadersTransportWithLogger(headers, http.DefaultTransport, logger)
 	return &http.Client{Transport: rt}, nil
 }

--- a/pkg/kubernautagent/llm/transport/auth_headers.go
+++ b/pkg/kubernautagent/llm/transport/auth_headers.go
@@ -18,8 +18,9 @@ package transport
 
 import (
 	"fmt"
-	"log/slog"
 	"net/http"
+
+	"github.com/go-logr/logr"
 
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/config"
 )
@@ -33,18 +34,18 @@ import (
 type AuthHeadersTransport struct {
 	base    http.RoundTripper
 	headers []config.HeaderDefinition
-	logger  *slog.Logger
+	logger  logr.Logger
 }
 
 // NewAuthHeadersTransport wraps a base transport, injecting the given
 // headers into every outbound request. If base is nil, http.DefaultTransport is used.
 func NewAuthHeadersTransport(headers []config.HeaderDefinition, base http.RoundTripper) *AuthHeadersTransport {
-	return NewAuthHeadersTransportWithLogger(headers, base, nil)
+	return NewAuthHeadersTransportWithLogger(headers, base, logr.Discard())
 }
 
 // NewAuthHeadersTransportWithLogger wraps a base transport with structured logging.
 // Header values are redacted in log output per DD-HAPI-019-003 (G4).
-func NewAuthHeadersTransportWithLogger(headers []config.HeaderDefinition, base http.RoundTripper, logger *slog.Logger) *AuthHeadersTransport {
+func NewAuthHeadersTransportWithLogger(headers []config.HeaderDefinition, base http.RoundTripper, logger logr.Logger) *AuthHeadersTransport {
 	if base == nil {
 		base = http.DefaultTransport
 	}
@@ -69,12 +70,10 @@ func (t *AuthHeadersTransport) RoundTrip(req *http.Request) (*http.Response, err
 		}
 		reqClone.Header.Set(h.Name, val)
 
-		if t.logger != nil {
-			t.logger.Debug("injected auth header",
-				"header", h.Name,
-				"value", RedactHeaderValue(val, IsSensitiveSource(h)),
-			)
-		}
+		t.logger.V(1).Info("injected auth header",
+			"header", h.Name,
+			"value", RedactHeaderValue(val, IsSensitiveSource(h)),
+		)
 	}
 
 	return t.base.RoundTrip(reqClone)

--- a/pkg/kubernautagent/tools/custom/resource_context.go
+++ b/pkg/kubernautagent/tools/custom/resource_context.go
@@ -20,7 +20,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
+
+	"github.com/go-logr/logr"
 
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools"
@@ -52,32 +53,30 @@ type rootOwnerResponse struct {
 }
 
 type namespacedResponse struct {
-	RootOwner          rootOwnerResponse              `json:"root_owner"`
+	RootOwner          rootOwnerResponse                    `json:"root_owner"`
 	RemediationHistory *enrichment.RemediationHistoryResult `json:"remediation_history"`
 }
 
 type clusterResponse struct {
-	RootOwner          rootOwnerResponse              `json:"root_owner"`
+	RootOwner          rootOwnerResponse                    `json:"root_owner"`
 	RemediationHistory *enrichment.RemediationHistoryResult `json:"remediation_history"`
 }
 
-func computeSpecHash(ctx context.Context, k8s enrichment.K8sClient, kind, name, namespace, toolName string) string {
+func computeSpecHash(ctx context.Context, logger logr.Logger, k8s enrichment.K8sClient, kind, name, namespace, toolName string) string {
 	computed, err := k8s.GetSpecHash(ctx, kind, name, namespace)
 	if err != nil {
-		slog.Warn(toolName+": specHash computation failed, proceeding with empty",
-			slog.String("kind", kind), slog.String("name", name),
-			slog.String("namespace", namespace), slog.String("error", err.Error()))
+		logger.Info(toolName+": specHash computation failed, proceeding with empty",
+			"kind", kind, "name", name, "namespace", namespace, "error", err)
 		return ""
 	}
 	return computed
 }
 
-func fetchRemediationHistory(ctx context.Context, ds enrichment.DataStorageClient, kind, name, namespace, specHash, toolName string) *enrichment.RemediationHistoryResult {
+func fetchRemediationHistory(ctx context.Context, logger logr.Logger, ds enrichment.DataStorageClient, kind, name, namespace, specHash, toolName string) *enrichment.RemediationHistoryResult {
 	result, err := ds.GetRemediationHistory(ctx, kind, name, namespace, specHash)
 	if err != nil {
-		slog.Warn(toolName+": remediation history fetch failed",
-			slog.String("kind", kind), slog.String("name", name),
-			slog.String("namespace", namespace), slog.String("error", err.Error()))
+		logger.Info(toolName+": remediation history fetch failed",
+			"kind", kind, "name", name, "namespace", namespace, "error", err)
 	}
 	if result == nil {
 		result = &enrichment.RemediationHistoryResult{}
@@ -88,18 +87,23 @@ func fetchRemediationHistory(ctx context.Context, ds enrichment.DataStorageClien
 // --- get_namespaced_resource_context ---
 
 type namespacedResourceContextTool struct {
-	ds  enrichment.DataStorageClient
-	k8s enrichment.K8sClient
+	ds     enrichment.DataStorageClient
+	k8s    enrichment.K8sClient
+	logger logr.Logger
 }
 
 // NewNamespacedResourceContextTool creates a get_namespaced_resource_context tool.
-func NewNamespacedResourceContextTool(ds enrichment.DataStorageClient, k8s enrichment.K8sClient) tools.Tool {
-	return &namespacedResourceContextTool{ds: ds, k8s: k8s}
+func NewNamespacedResourceContextTool(ds enrichment.DataStorageClient, k8s enrichment.K8sClient, logger logr.Logger) tools.Tool {
+	return &namespacedResourceContextTool{ds: ds, k8s: k8s, logger: logger.WithName("get_namespaced_resource_context")}
 }
 
-func (t *namespacedResourceContextTool) Name() string               { return "get_namespaced_resource_context" }
-func (t *namespacedResourceContextTool) Description() string         { return "Get resource context including owner chain root, remediation history, and detected infrastructure for a namespaced resource" }
-func (t *namespacedResourceContextTool) Parameters() json.RawMessage { return namespacedResourceContextSchema }
+func (t *namespacedResourceContextTool) Name() string { return "get_namespaced_resource_context" }
+func (t *namespacedResourceContextTool) Description() string {
+	return "Get resource context including owner chain root, remediation history, and detected infrastructure for a namespaced resource"
+}
+func (t *namespacedResourceContextTool) Parameters() json.RawMessage {
+	return namespacedResourceContextSchema
+}
 
 func (t *namespacedResourceContextTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var params struct {
@@ -113,9 +117,8 @@ func (t *namespacedResourceContextTool) Execute(ctx context.Context, args json.R
 
 	chain, chainErr := t.k8s.GetOwnerChain(ctx, params.Kind, params.Name, params.Namespace)
 	if chainErr != nil {
-		slog.Warn("get_namespaced_resource_context: owner chain resolution failed",
-			slog.String("kind", params.Kind), slog.String("name", params.Name),
-			slog.String("namespace", params.Namespace), slog.String("error", chainErr.Error()))
+		t.logger.Info("get_namespaced_resource_context: owner chain resolution failed",
+			"kind", params.Kind, "name", params.Name, "namespace", params.Namespace, "error", chainErr)
 	}
 
 	rootOwner := rootOwnerResponse{
@@ -132,8 +135,8 @@ func (t *namespacedResourceContextTool) Execute(ctx context.Context, args json.R
 		}
 	}
 
-	specHash := computeSpecHash(ctx, t.k8s, rootOwner.Kind, rootOwner.Name, rootOwner.Namespace, "get_namespaced_resource_context")
-	histResult := fetchRemediationHistory(ctx, t.ds, rootOwner.Kind, rootOwner.Name, rootOwner.Namespace, specHash, "get_namespaced_resource_context")
+	specHash := computeSpecHash(ctx, t.logger, t.k8s, rootOwner.Kind, rootOwner.Name, rootOwner.Namespace, "get_namespaced_resource_context")
+	histResult := fetchRemediationHistory(ctx, t.logger, t.ds, rootOwner.Kind, rootOwner.Name, rootOwner.Namespace, specHash, "get_namespaced_resource_context")
 
 	resp := namespacedResponse{
 		RootOwner:          rootOwner,
@@ -149,18 +152,23 @@ func (t *namespacedResourceContextTool) Execute(ctx context.Context, args json.R
 // --- get_cluster_resource_context ---
 
 type clusterResourceContextTool struct {
-	ds  enrichment.DataStorageClient
-	k8s enrichment.K8sClient
+	ds     enrichment.DataStorageClient
+	k8s    enrichment.K8sClient
+	logger logr.Logger
 }
 
 // NewClusterResourceContextTool creates a get_cluster_resource_context tool.
-func NewClusterResourceContextTool(ds enrichment.DataStorageClient, k8s enrichment.K8sClient) tools.Tool {
-	return &clusterResourceContextTool{ds: ds, k8s: k8s}
+func NewClusterResourceContextTool(ds enrichment.DataStorageClient, k8s enrichment.K8sClient, logger logr.Logger) tools.Tool {
+	return &clusterResourceContextTool{ds: ds, k8s: k8s, logger: logger.WithName("get_cluster_resource_context")}
 }
 
-func (t *clusterResourceContextTool) Name() string               { return "get_cluster_resource_context" }
-func (t *clusterResourceContextTool) Description() string         { return "Get resource context including remediation history for a cluster-scoped resource" }
-func (t *clusterResourceContextTool) Parameters() json.RawMessage { return clusterResourceContextSchema }
+func (t *clusterResourceContextTool) Name() string { return "get_cluster_resource_context" }
+func (t *clusterResourceContextTool) Description() string {
+	return "Get resource context including remediation history for a cluster-scoped resource"
+}
+func (t *clusterResourceContextTool) Parameters() json.RawMessage {
+	return clusterResourceContextSchema
+}
 
 func (t *clusterResourceContextTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
 	var params struct {
@@ -171,8 +179,8 @@ func (t *clusterResourceContextTool) Execute(ctx context.Context, args json.RawM
 		return "", fmt.Errorf("parsing args: %w", err)
 	}
 
-	specHash := computeSpecHash(ctx, t.k8s, params.Kind, params.Name, "", "get_cluster_resource_context")
-	histResult := fetchRemediationHistory(ctx, t.ds, params.Kind, params.Name, "", specHash, "get_cluster_resource_context")
+	specHash := computeSpecHash(ctx, t.logger, t.k8s, params.Kind, params.Name, "", "get_cluster_resource_context")
+	histResult := fetchRemediationHistory(ctx, t.logger, t.ds, params.Kind, params.Name, "", specHash, "get_cluster_resource_context")
 
 	resp := clusterResponse{
 		RootOwner: rootOwnerResponse{

--- a/pkg/kubernautagent/tools/custom/tools.go
+++ b/pkg/kubernautagent/tools/custom/tools.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
 	katypes "github.com/jordigilh/kubernaut/internal/kubernautagent/types"
@@ -98,12 +99,12 @@ func NewAllTools(ds WorkflowDiscoveryClient) []tools.Tool {
 // RegisterAll registers all 5 custom tools (3 DS workflow tools + 2 resource context tools)
 // into the given registry. Pass nil for any dependency to create tools that will fail at
 // execution time rather than registration time.
-func RegisterAll(reg *registry.Registry, dsOgenClient WorkflowDiscoveryClient, dsClient enrichment.DataStorageClient, k8sClient enrichment.K8sClient) {
+func RegisterAll(reg *registry.Registry, dsOgenClient WorkflowDiscoveryClient, dsClient enrichment.DataStorageClient, k8sClient enrichment.K8sClient, logger logr.Logger) {
 	for _, t := range NewAllTools(dsOgenClient) {
 		reg.Register(t)
 	}
-	reg.Register(NewNamespacedResourceContextTool(dsClient, k8sClient))
-	reg.Register(NewClusterResourceContextTool(dsClient, k8sClient))
+	reg.Register(NewNamespacedResourceContextTool(dsClient, k8sClient, logger))
+	reg.Register(NewClusterResourceContextTool(dsClient, k8sClient, logger))
 }
 
 // signalFromContext extracts the SignalContext from ctx. Workflow discovery
@@ -121,8 +122,10 @@ func signalFromContext(ctx context.Context, toolName string) (katypes.SignalCont
 
 type listActionsTool struct{ ds WorkflowDiscoveryClient }
 
-func (t *listActionsTool) Name() string               { return "list_available_actions" }
-func (t *listActionsTool) Description() string         { return "List available remediation action types from DataStorage" }
+func (t *listActionsTool) Name() string { return "list_available_actions" }
+func (t *listActionsTool) Description() string {
+	return "List available remediation action types from DataStorage"
+}
 func (t *listActionsTool) Parameters() json.RawMessage { return listAvailableActionsSchema }
 
 func (t *listActionsTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
@@ -162,8 +165,10 @@ func (t *listActionsTool) Execute(ctx context.Context, args json.RawMessage) (st
 
 type listWorkflowsTool struct{ ds WorkflowDiscoveryClient }
 
-func (t *listWorkflowsTool) Name() string               { return "list_workflows" }
-func (t *listWorkflowsTool) Description() string         { return "Search for workflows by action type in DataStorage" }
+func (t *listWorkflowsTool) Name() string { return "list_workflows" }
+func (t *listWorkflowsTool) Description() string {
+	return "Search for workflows by action type in DataStorage"
+}
 func (t *listWorkflowsTool) Parameters() json.RawMessage { return listWorkflowsSchemaJSON }
 
 func (t *listWorkflowsTool) Execute(ctx context.Context, args json.RawMessage) (string, error) {
@@ -207,7 +212,7 @@ func (t *listWorkflowsTool) Execute(ctx context.Context, args json.RawMessage) (
 
 type getWorkflowTool struct{ ds WorkflowDiscoveryClient }
 
-func (t *getWorkflowTool) Name() string               { return "get_workflow" }
+func (t *getWorkflowTool) Name() string                { return "get_workflow" }
 func (t *getWorkflowTool) Description() string         { return "Get a specific workflow definition by ID" }
 func (t *getWorkflowTool) Parameters() json.RawMessage { return getWorkflowSchemaJSON }
 

--- a/pkg/kubernautagent/tools/mcp/stub.go
+++ b/pkg/kubernautagent/tools/mcp/stub.go
@@ -18,24 +18,25 @@ package mcp
 
 import (
 	"context"
-	"log/slog"
+
+	"github.com/go-logr/logr"
 )
 
-// StubProvider is the v1.3 MCP tool provider that logs a warning and
+// StubProvider is the v1.3 MCP tool provider that logs an info message and
 // returns an empty tool list. Config parsing and registry wiring are
 // tested; real SSE/stdio transport deferred to v1.5.
 type StubProvider struct {
-	logger *slog.Logger
+	logger logr.Logger
 }
 
 // NewStubProvider creates a stub MCP provider.
-func NewStubProvider(logger *slog.Logger) *StubProvider {
+func NewStubProvider(logger logr.Logger) *StubProvider {
 	return &StubProvider{logger: logger}
 }
 
-// DiscoverTools returns an empty tool list and logs a warning.
+// DiscoverTools returns an empty tool list and logs at info level.
 func (p *StubProvider) DiscoverTools(_ context.Context) ([]Tool, error) {
-	p.logger.Warn("MCP tool discovery is stubbed in v1.3; returning empty tool list")
+	p.logger.Info("MCP tool discovery is stubbed in v1.3; returning empty tool list")
 	return []Tool{}, nil
 }
 

--- a/test/integration/kubernautagent/auth_headers_test.go
+++ b/test/integration/kubernautagent/auth_headers_test.go
@@ -18,13 +18,15 @@ package kubernautagent_test
 
 import (
 	"bytes"
-	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 
+	"github.com/go-logr/zapr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/config"
 	llmclient "github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
@@ -152,7 +154,11 @@ var _ = Describe("Auth Headers Integration — #417", func() {
 			defer server.Close()
 
 			var logBuf bytes.Buffer
-			logger := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+			encCfg := zap.NewProductionEncoderConfig()
+			ws := zapcore.AddSync(&logBuf)
+			core := zapcore.NewCore(zapcore.NewJSONEncoder(encCfg), ws, zapcore.DebugLevel)
+			zl := zap.New(core)
+			logger := zapr.NewLogger(zl)
 
 			hdefs := []config.HeaderDefinition{
 				{Name: "Authorization", SecretKeyRef: "KA_IT_SCRUB_SECRET"},

--- a/test/integration/kubernautagent/enrichment/enrichment_real_ds_test.go
+++ b/test/integration/kubernautagent/enrichment/enrichment_real_ds_test.go
@@ -29,9 +29,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
-	"os"
 	"time"
+
+	"github.com/go-logr/logr"
 
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
@@ -275,7 +275,7 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 			brokenK8s := &errorK8sClient{err: errors.New("envtest unreachable")}
 			brokenDS := &errorDSClient{err: errors.New("DS endpoint unreachable")}
 			brokenEnricher := enrichment.NewEnricher(brokenK8s, brokenDS, auditStore,
-				slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+				logr.Discard())
 
 			By("Calling broken enricher")
 			result, err := brokenEnricher.Enrich(testCtx, "Pod", "broken-pod-"+testID, "it-enrichment", "", incidentID)
@@ -324,7 +324,7 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 			brokenK8s := &errorK8sClient{err: errors.New("K8s API unavailable")}
 			dsAdapter := enrichment.NewDSAdapter(ogenClient)
 			partialEnricher := enrichment.NewEnricher(brokenK8s, dsAdapter, auditStore,
-				slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+				logr.Discard())
 
 			By("Calling enricher")
 			result, err := partialEnricher.Enrich(testCtx, "StatefulSet", "redis-"+testID, "it-enrichment", "sha256:pre5", incidentID)
@@ -395,7 +395,7 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 			By("Building enricher with real K8s + broken DS + real audit store")
 			brokenDS := &errorDSClient{err: errors.New("DS connection refused")}
 			partialEnricher := enrichment.NewEnricher(k8sAdapter, brokenDS, auditStore,
-				slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+				logr.Discard())
 
 			By("Calling enricher")
 			result, err := partialEnricher.Enrich(testCtx, "Pod", "web-pod-1", "it-enrichment", "sha256:test7", incidentID)

--- a/test/integration/kubernautagent/enrichment/suite_test.go
+++ b/test/integration/kubernautagent/enrichment/suite_test.go
@@ -20,14 +20,13 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"log/slog"
-	"os"
 	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/go-logr/logr"
 	_ "github.com/jackc/pgx/v5/stdlib"
 
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
@@ -64,7 +63,7 @@ var (
 	seedDB      *sql.DB
 	enricher    *enrichment.Enricher
 	auditStore  *audit.DSAuditStore
-	suiteLogger *slog.Logger
+	suiteLogger logr.Logger
 	k8sAdapter  enrichment.K8sClient
 )
 
@@ -120,8 +119,7 @@ var _ = SynchronizedBeforeSuite(
 		dsToken := lines[0]
 		kubeconfigPath := lines[1]
 
-		suiteLogger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelDebug}))
-
+		suiteLogger = logr.Discard()
 		dsURL := fmt.Sprintf("http://127.0.0.1:%d", enrDataStoragePort)
 		dsClients := integration.NewAuthenticatedDataStorageClients(dsURL, dsToken, 10*time.Second)
 		ogenClient = dsClients.OpenAPIClient
@@ -233,15 +231,15 @@ func createK8sFixtures(dynClient dynamic.Interface) {
 			"metadata": map[string]interface{}{
 				"name":      "web-rs-abc",
 				"namespace": "it-enrichment",
-			"ownerReferences": []interface{}{
-				map[string]interface{}{
-					"apiVersion": "apps/v1",
-					"kind":       "Deployment",
-					"name":       "web-deploy",
-					"uid":        deployUID,
-					"controller": true,
+				"ownerReferences": []interface{}{
+					map[string]interface{}{
+						"apiVersion": "apps/v1",
+						"kind":       "Deployment",
+						"name":       "web-deploy",
+						"uid":        deployUID,
+						"controller": true,
+					},
 				},
-			},
 			},
 			"spec": map[string]interface{}{
 				"replicas": int64(1),
@@ -276,15 +274,15 @@ func createK8sFixtures(dynClient dynamic.Interface) {
 			"metadata": map[string]interface{}{
 				"name":      "web-pod-1",
 				"namespace": "it-enrichment",
-			"ownerReferences": []interface{}{
-				map[string]interface{}{
-					"apiVersion": "apps/v1",
-					"kind":       "ReplicaSet",
-					"name":       "web-rs-abc",
-					"uid":        rsUID,
-					"controller": true,
+				"ownerReferences": []interface{}{
+					map[string]interface{}{
+						"apiVersion": "apps/v1",
+						"kind":       "ReplicaSet",
+						"name":       "web-rs-abc",
+						"uid":        rsUID,
+						"controller": true,
+					},
 				},
-			},
 			},
 			"spec": map[string]interface{}{
 				"containers": []interface{}{

--- a/test/integration/kubernautagent/investigator/detected_labels_it_test.go
+++ b/test/integration/kubernautagent/investigator/detected_labels_it_test.go
@@ -18,8 +18,8 @@ package investigator_test
 
 import (
 	"context"
-	"log/slog"
-	"os"
+
+	"github.com/go-logr/logr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -73,7 +73,7 @@ func newItTestMapper() meta.RESTMapper {
 var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)", func() {
 
 	var (
-		logger     *slog.Logger
+		invLogger  logr.Logger
 		auditStore *recordingAuditStore
 		builder    *prompt.Builder
 		rp         *parser.ResultParser
@@ -81,7 +81,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		invLogger = logr.Discard()
 		auditStore = &recordingAuditStore{}
 		builder, _ = prompt.NewBuilder()
 		rp = parser.NewResultParser()
@@ -113,7 +113,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy, hpa)
-			ld := enrichment.NewLabelDetector(dynClient, newItTestMapper())
+			ld := enrichment.NewLabelDetector(dynClient, newItTestMapper(), invLogger)
 
 			k8sClient := &fakeK8sClient{
 				ownerChain: []enrichment.OwnerChainEntry{
@@ -121,7 +121,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 				},
 			}
 			dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger).WithLabelDetector(ld)
+			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger).WithLabelDetector(ld)
 
 			mockClient := &mockLLMClient{
 				responses: []llm.ChatResponse{
@@ -132,7 +132,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
@@ -171,7 +171,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			ld := enrichment.NewLabelDetector(dynClient, newItTestMapper())
+			ld := enrichment.NewLabelDetector(dynClient, newItTestMapper(), invLogger)
 
 			k8sClient := &fakeK8sClient{
 				ownerChain: []enrichment.OwnerChainEntry{
@@ -179,7 +179,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 				},
 			}
 			dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger).WithLabelDetector(ld)
+			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger).WithLabelDetector(ld)
 
 			mockClient := &mockLLMClient{
 				responses: []llm.ChatResponse{
@@ -190,7 +190,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
@@ -231,7 +231,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			ld := enrichment.NewLabelDetector(dynClient, newItTestMapper())
+			ld := enrichment.NewLabelDetector(dynClient, newItTestMapper(), invLogger)
 
 			k8sClient := &fakeK8sClient{
 				ownerChain: []enrichment.OwnerChainEntry{
@@ -239,7 +239,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 				},
 			}
 			dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger).WithLabelDetector(ld)
+			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger).WithLabelDetector(ld)
 
 			mockClient := &mockLLMClient{
 				responses: []llm.ChatResponse{
@@ -250,7 +250,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
@@ -294,7 +294,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			ld := enrichment.NewLabelDetector(dynClient, newItTestMapper())
+			ld := enrichment.NewLabelDetector(dynClient, newItTestMapper(), invLogger)
 
 			k8sClient := &fakeK8sClient{
 				ownerChain: []enrichment.OwnerChainEntry{
@@ -302,7 +302,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 				},
 			}
 			dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger).WithLabelDetector(ld)
+			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger).WithLabelDetector(ld)
 
 			mockClient := &mockLLMClient{
 				responses: []llm.ChatResponse{
@@ -313,7 +313,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
@@ -355,7 +355,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			ld := enrichment.NewLabelDetector(dynClient, newItTestMapper())
+			ld := enrichment.NewLabelDetector(dynClient, newItTestMapper(), invLogger)
 
 			k8sClient := &fakeK8sClient{
 				ownerChain: []enrichment.OwnerChainEntry{
@@ -363,7 +363,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 				},
 			}
 			dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger).WithLabelDetector(ld)
+			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger).WithLabelDetector(ld)
 
 			mockClient := &mockLLMClient{
 				responses: []llm.ChatResponse{
@@ -374,7 +374,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
@@ -419,7 +419,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy, quota)
-			ld := enrichment.NewLabelDetector(dynClient, newItTestMapper())
+			ld := enrichment.NewLabelDetector(dynClient, newItTestMapper(), invLogger)
 
 			k8sClient := &fakeK8sClient{
 				ownerChain: []enrichment.OwnerChainEntry{
@@ -427,7 +427,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 				},
 			}
 			dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger).WithLabelDetector(ld)
+			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger).WithLabelDetector(ld)
 
 			result, err := enricher.Enrich(context.Background(), "Pod", "web-app-xyz", "constrained", "", "inc-1")
 			Expect(err).NotTo(HaveOccurred())

--- a/test/integration/kubernautagent/investigator/investigator_anomaly_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_anomaly_test.go
@@ -19,9 +19,9 @@ package investigator_test
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 	"strings"
+
+	"github.com/go-logr/logr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -42,7 +42,7 @@ func containsSubstring(s, substr string) bool {
 var _ = Describe("Kubernaut Agent Anomaly Detector Wiring — TP-433-WIR Phase 4", func() {
 
 	var (
-		logger     *slog.Logger
+		invLogger  logr.Logger
 		auditStore *recordingAuditStore
 		builder    *prompt.Builder
 		rp         *parser.ResultParser
@@ -51,13 +51,13 @@ var _ = Describe("Kubernaut Agent Anomaly Detector Wiring — TP-433-WIR Phase 4
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		invLogger = logr.Discard()
 		auditStore = &recordingAuditStore{}
 		builder, _ = prompt.NewBuilder()
 		rp = parser.NewResultParser()
 		k8sClient := &fakeK8sClient{ownerChain: []enrichment.OwnerChainEntry{}}
 		dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 		phaseTools = investigator.DefaultPhaseToolMap()
 	})
 
@@ -87,7 +87,7 @@ var _ = Describe("Kubernaut Agent Anomaly Detector Wiring — TP-433-WIR Phase 4
 				},
 			}
 
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg, Pipeline: investigator.Pipeline{AnomalyDetector: detector}})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg, Pipeline: investigator.Pipeline{AnomalyDetector: detector}})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api", Namespace: "default", Severity: "warning", Message: "CrashLoop",
 			})
@@ -133,7 +133,7 @@ var _ = Describe("Kubernaut Agent Anomaly Detector Wiring — TP-433-WIR Phase 4
 				},
 			}
 
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg, Pipeline: investigator.Pipeline{AnomalyDetector: detector}})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg, Pipeline: investigator.Pipeline{AnomalyDetector: detector}})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api", Namespace: "default", Severity: "critical", Message: "OOMKilled",
 			})
@@ -183,7 +183,7 @@ var _ = Describe("Kubernaut Agent Anomaly Detector Wiring — TP-433-WIR Phase 4
 				},
 			}
 
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg, Pipeline: investigator.Pipeline{AnomalyDetector: detector}})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg, Pipeline: investigator.Pipeline{AnomalyDetector: detector}})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api", Namespace: "default", Severity: "warning", Message: "DiskPressure",
 			})
@@ -217,7 +217,7 @@ var _ = Describe("Kubernaut Agent Anomaly Detector Wiring — TP-433-WIR Phase 4
 				})
 			}
 
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg, Pipeline: investigator.Pipeline{AnomalyDetector: detector}})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg, Pipeline: investigator.Pipeline{AnomalyDetector: detector}})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api", Namespace: "default", Severity: "critical", Message: "OOMKilled",
 			})

--- a/test/integration/kubernautagent/investigator/investigator_audit_parity_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_audit_parity_test.go
@@ -19,9 +19,8 @@ package investigator_test
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 
+	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -60,7 +59,7 @@ func (e *errorLLMClient) Close() error { return nil }
 var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 
 	var (
-		logger     *slog.Logger
+		invLogger  logr.Logger
 		auditStore *recordingAuditStore
 		mockClient *mockLLMClient
 		builder    *prompt.Builder
@@ -70,7 +69,7 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		invLogger = logr.Discard()
 		auditStore = &recordingAuditStore{}
 		mockClient = &mockLLMClient{}
 		builder, _ = prompt.NewBuilder()
@@ -83,7 +82,7 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 		dsClient := &fakeDataStorageClient{
 			history: &enrichment.RemediationHistoryResult{},
 		}
-		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 		phaseTools = investigator.DefaultPhaseToolMap()
 	})
 
@@ -98,12 +97,12 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 	}
 
 	signal := katypes.SignalContext{
-		Name:         "api-server-abc",
-		Namespace:    "production",
-		Severity:     "critical",
-		Message:      "OOMKilled",
-		ResourceKind: "Deployment",
-		ResourceName: "api-server",
+		Name:          "api-server-abc",
+		Namespace:     "production",
+		Severity:      "critical",
+		Message:       "OOMKilled",
+		ResourceKind:  "Deployment",
+		ResourceName:  "api-server",
 		RemediationID: "rem-it-audit-parity",
 	}
 
@@ -115,7 +114,7 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 			}
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 				ModelName: "claude-sonnet-4-20250514",
 			})
 
@@ -148,7 +147,7 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 			}
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
 			_, err := inv.Investigate(context.Background(), signal)
@@ -184,7 +183,7 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 				Registry: reg,
 			})
 
@@ -217,7 +216,7 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 			}
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
 			_, err := inv.Investigate(context.Background(), signal)
@@ -263,7 +262,7 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 			}
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
 			_, err := inv.Investigate(context.Background(), signal)
@@ -305,7 +304,7 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 			}
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
 			result, err := inv.Investigate(context.Background(), signal)
@@ -327,7 +326,7 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 			failingClient := &errorLLMClient{err: fmt.Errorf("LLM timeout after 30s")}
 			inv := investigator.New(investigator.Config{
 				Client: failingClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
 			_, err := inv.Investigate(context.Background(), signal)
@@ -350,7 +349,7 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 			}
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
 			_, err := inv.Investigate(context.Background(), signal)
@@ -388,7 +387,7 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 			}
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
 			_, err := inv.Investigate(context.Background(), signal)
@@ -456,7 +455,7 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 			testMapper.Add(schema.GroupVersionKind{Group: "policy", Version: "v1", Kind: "PodDisruptionBudget"}, meta.RESTScopeNamespace)
 			testMapper.Add(schema.GroupVersionKind{Group: "networking.k8s.io", Version: "v1", Kind: "NetworkPolicy"}, meta.RESTScopeNamespace)
 			testMapper.Add(schema.GroupVersionKind{Group: "", Version: "v1", Kind: "ResourceQuota"}, meta.RESTScopeNamespace)
-			ld := enrichment.NewLabelDetector(dynClient, testMapper)
+			ld := enrichment.NewLabelDetector(dynClient, testMapper, invLogger)
 
 			k8sClientForLabels := &resourceAwareK8sClient{
 				chains: map[string][]enrichment.OwnerChainEntry{
@@ -468,7 +467,7 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 				k8sClientForLabels,
 				&fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}},
 				auditStore,
-				logger,
+				invLogger,
 			).WithLabelDetector(ld)
 
 			labelMockClient := &mockLLMClient{}
@@ -499,7 +498,7 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 				ResultParser: rp,
 				Enricher:     labelEnricher,
 				AuditStore:   auditStore,
-				Logger:       logger,
+				Logger:       invLogger,
 				MaxTurns:     15,
 				PhaseTools:   phaseTools,
 			})
@@ -533,13 +532,13 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 
 	Describe("IT-KA-433-AP-004: Investigation emits validation_attempt per self-correction attempt", func() {
 		It("should emit one failure validation_attempt then one success when correction succeeds", func() {
-			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+			itInvLog := logr.Discard()
 			auditStore := &recordingAuditStore{}
 			builder, _ := prompt.NewBuilder()
 			rp := parser.NewResultParser()
 			k8sClient := &fakeK8sClient{ownerChain: []enrichment.OwnerChainEntry{}}
 			dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, itInvLog)
 			phaseTools := investigator.DefaultPhaseToolMap()
 
 			validator := parser.NewValidator([]string{"restart", "scale-up"})
@@ -554,7 +553,7 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: itInvLog,
 				MaxTurns: 15, PhaseTools: phaseTools,
 				Pipeline: investigator.Pipeline{
 					CatalogFetcher:  &staticCatalogFetcher{validator: validator},
@@ -586,13 +585,13 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 		})
 
 		It("should emit isValid=false on final event when validation is exhausted", func() {
-			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+			itInvLog := logr.Discard()
 			auditStore := &recordingAuditStore{}
 			builder, _ := prompt.NewBuilder()
 			rp := parser.NewResultParser()
 			k8sClient := &fakeK8sClient{ownerChain: []enrichment.OwnerChainEntry{}}
 			dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, itInvLog)
 			phaseTools := investigator.DefaultPhaseToolMap()
 
 			validator := parser.NewValidator([]string{"restart", "scale-up"})
@@ -608,7 +607,7 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: itInvLog,
 				MaxTurns: 15, PhaseTools: phaseTools,
 				Pipeline: investigator.Pipeline{
 					CatalogFetcher:  &staticCatalogFetcher{validator: validator},

--- a/test/integration/kubernautagent/investigator/investigator_decline_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_decline_test.go
@@ -18,8 +18,8 @@ package investigator_test
 
 import (
 	"context"
-	"log/slog"
-	"os"
+
+	"github.com/go-logr/logr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,7 +35,7 @@ import (
 var _ = Describe("Workflow Selection Split Submit Tools — #760 v2", func() {
 
 	var (
-		logger     *slog.Logger
+		invLogger  logr.Logger
 		auditStore *recordingAuditStore
 		builder    *prompt.Builder
 		rp         *parser.ResultParser
@@ -44,7 +44,7 @@ var _ = Describe("Workflow Selection Split Submit Tools — #760 v2", func() {
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		invLogger = logr.Discard()
 		auditStore = &recordingAuditStore{}
 		builder, _ = prompt.NewBuilder()
 		rp = parser.NewResultParser()
@@ -54,7 +54,7 @@ var _ = Describe("Workflow Selection Split Submit Tools — #760 v2", func() {
 			},
 		}
 		dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 		phaseTools = investigator.DefaultPhaseToolMap()
 	})
 
@@ -84,7 +84,7 @@ var _ = Describe("Workflow Selection Split Submit Tools — #760 v2", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
 			_, err := inv.Investigate(context.Background(), signal)
@@ -115,7 +115,7 @@ var _ = Describe("Workflow Selection Split Submit Tools — #760 v2", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
 			_, err := inv.Investigate(context.Background(), signal)
@@ -144,7 +144,7 @@ var _ = Describe("Workflow Selection Split Submit Tools — #760 v2", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
 			_, err := inv.Investigate(context.Background(), signal)
@@ -173,7 +173,7 @@ var _ = Describe("Workflow Selection Split Submit Tools — #760 v2", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
 			result, err := inv.Investigate(context.Background(), signal)
@@ -205,7 +205,7 @@ var _ = Describe("Workflow Selection Split Submit Tools — #760 v2", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
 			result, err := inv.Investigate(context.Background(), signal)
@@ -237,7 +237,7 @@ var _ = Describe("Workflow Selection Split Submit Tools — #760 v2", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
 			result, err := inv.Investigate(context.Background(), signal)
@@ -269,7 +269,7 @@ var _ = Describe("Workflow Selection Split Submit Tools — #760 v2", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
 			result, err := inv.Investigate(context.Background(), signal)
@@ -298,7 +298,7 @@ var _ = Describe("Workflow Selection Split Submit Tools — #760 v2", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
 			result, err := inv.Investigate(context.Background(), signal)
@@ -324,7 +324,7 @@ var _ = Describe("Workflow Selection Split Submit Tools — #760 v2", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
 			result, err := inv.Investigate(context.Background(), signal)
@@ -356,7 +356,7 @@ var _ = Describe("Workflow Selection Split Submit Tools — #760 v2", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
 			result, err := inv.Investigate(context.Background(), signal)
@@ -392,7 +392,7 @@ var _ = Describe("Workflow Selection Split Submit Tools — #760 v2", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 				Pipeline: investigator.Pipeline{
 					CatalogFetcher:  &staticCatalogFetcher{validator: validator},
@@ -415,7 +415,7 @@ var _ = Describe("Workflow Selection Split Submit Tools — #760 v2", func() {
 var _ = Describe("Workflow Selection Decline Classification — #760", func() {
 
 	var (
-		logger     *slog.Logger
+		invLogger  logr.Logger
 		auditStore *recordingAuditStore
 		builder    *prompt.Builder
 		rp         *parser.ResultParser
@@ -424,7 +424,7 @@ var _ = Describe("Workflow Selection Decline Classification — #760", func() {
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		invLogger = logr.Discard()
 		auditStore = &recordingAuditStore{}
 		builder, _ = prompt.NewBuilder()
 		rp = parser.NewResultParser()
@@ -434,7 +434,7 @@ var _ = Describe("Workflow Selection Decline Classification — #760", func() {
 			},
 		}
 		dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 		phaseTools = investigator.DefaultPhaseToolMap()
 	})
 
@@ -459,7 +459,7 @@ var _ = Describe("Workflow Selection Decline Classification — #760", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
 			result, err := inv.Investigate(context.Background(), signal)
@@ -486,7 +486,7 @@ var _ = Describe("Workflow Selection Decline Classification — #760", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
-				AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
 			result, err := inv.Investigate(context.Background(), signal)
@@ -516,7 +516,7 @@ var _ = Describe("Workflow Selection Decline Classification — #760", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 				Pipeline: investigator.Pipeline{
 					CatalogFetcher:  &staticCatalogFetcher{validator: validator},

--- a/test/integration/kubernautagent/investigator/investigator_phase_propagation_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_phase_propagation_test.go
@@ -18,8 +18,8 @@ package investigator_test
 
 import (
 	"context"
-	"log/slog"
-	"os"
+
+	"github.com/go-logr/logr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,7 +35,7 @@ import (
 var _ = Describe("Phase 1-to-Phase 3 Context Propagation — #715", func() {
 
 	var (
-		logger     *slog.Logger
+		invLogger  logr.Logger
 		auditStore *recordingAuditStore
 		mockClient *mockLLMClient
 		builder    *prompt.Builder
@@ -45,7 +45,7 @@ var _ = Describe("Phase 1-to-Phase 3 Context Propagation — #715", func() {
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		invLogger = logr.Discard()
 		auditStore = &recordingAuditStore{}
 		mockClient = &mockLLMClient{}
 		builder, _ = prompt.NewBuilder()
@@ -63,7 +63,7 @@ var _ = Describe("Phase 1-to-Phase 3 Context Propagation — #715", func() {
 				},
 			},
 		}
-		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 		phaseTools = investigator.DefaultPhaseToolMap()
 	})
 
@@ -87,7 +87,7 @@ var _ = Describe("Phase 1-to-Phase 3 Context Propagation — #715", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
@@ -124,7 +124,7 @@ var _ = Describe("Phase 1-to-Phase 3 Context Propagation — #715", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
@@ -158,7 +158,7 @@ var _ = Describe("Phase 1-to-Phase 3 Context Propagation — #715", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 			})
 

--- a/test/integration/kubernautagent/investigator/investigator_phase_separation_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_phase_separation_test.go
@@ -19,8 +19,8 @@ package investigator_test
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
-	"os"
+
+	"github.com/go-logr/logr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -36,7 +36,7 @@ import (
 var _ = Describe("Phase Separation: Investigator — #700", func() {
 
 	var (
-		logger     *slog.Logger
+		invLogger  logr.Logger
 		auditStore *recordingAuditStore
 		mockClient *mockLLMClient
 		builder    *prompt.Builder
@@ -46,7 +46,7 @@ var _ = Describe("Phase Separation: Investigator — #700", func() {
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		invLogger = logr.Discard()
 		auditStore = &recordingAuditStore{}
 		mockClient = &mockLLMClient{}
 		builder, _ = prompt.NewBuilder()
@@ -64,7 +64,7 @@ var _ = Describe("Phase Separation: Investigator — #700", func() {
 				},
 			},
 		}
-		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 		phaseTools = investigator.DefaultPhaseToolMap()
 	})
 
@@ -74,7 +74,7 @@ var _ = Describe("Phase Separation: Investigator — #700", func() {
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled due to memory limit exceeded","confidence":0.9}`}},
 				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.9}`),
 			}
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api-server-abc", Namespace: "production", Severity: "critical", Message: "OOMKilled",
 			})
@@ -117,7 +117,7 @@ var _ = Describe("Phase Separation: Investigator — #700", func() {
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled due to memory limit exceeded","confidence":0.9}`}},
 				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.9}`),
 			}
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api-server-abc", Namespace: "production", Severity: "critical", Message: "OOMKilled",
 			})
@@ -156,7 +156,7 @@ var _ = Describe("Phase Separation: Investigator — #700", func() {
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled","needs_human_review":true,"human_review_reason":"complexity","confidence":0.8}`}},
 				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.85}`),
 			}
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api-server-abc", Namespace: "production", Severity: "critical", Message: "OOMKilled",
 			})
@@ -181,7 +181,7 @@ var _ = Describe("Phase Separation: Investigator — #700", func() {
 					},
 				},
 			}
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 1, PhaseTools: phaseTools})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 1, PhaseTools: phaseTools})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api", Namespace: "default", Severity: "critical", Message: "OOMKilled",
 			})
@@ -200,7 +200,7 @@ var _ = Describe("Phase Separation: Investigator — #700", func() {
 				{Message: llm.Message{Role: "assistant", Content: `{"root_cause_analysis":{"summary":"OOMKilled due to memory limit exceeded on api-server"},"confidence":0.92}`}},
 				wfToolResp(`{"selected_workflow":{"workflow_id":"oom-increase-memory","confidence":0.95},"confidence":0.95}`),
 			}
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api-server-abc", Namespace: "production", Severity: "critical", Message: "OOMKilled",
 			})
@@ -224,7 +224,7 @@ var _ = Describe("Phase Separation: Investigator — #700", func() {
 				},
 				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.85}`),
 			}
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api-server-abc", Namespace: "production", Severity: "critical", Message: "OOMKilled",
 			})
@@ -246,7 +246,7 @@ var _ = Describe("Phase Separation: Investigator — #700", func() {
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"Inconclusive — multiple potential causes","investigation_outcome":"inconclusive","confidence":0.4}`}},
 				wfToolResp(`{"workflow_id":"generic-restart","confidence":0.6}`),
 			}
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api-server-abc", Namespace: "production", Severity: "warning", Message: "High memory usage",
 			})
@@ -267,7 +267,7 @@ var _ = Describe("Phase Separation: Investigator — #700", func() {
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled","confidence":0.9}`}},
 				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.9}`),
 			}
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api-server-abc", Namespace: "production", Severity: "critical", Message: "OOMKilled",
 			})

--- a/test/integration/kubernautagent/investigator/investigator_sanitization_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_sanitization_test.go
@@ -18,8 +18,8 @@ package investigator_test
 
 import (
 	"context"
-	"log/slog"
-	"os"
+
+	"github.com/go-logr/logr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -37,7 +37,7 @@ import (
 var _ = Describe("Kubernaut Agent Sanitization Wiring — TP-433-WIR Phase 3", func() {
 
 	var (
-		logger     *slog.Logger
+		invLogger  logr.Logger
 		auditStore *recordingAuditStore
 		mockClient *mockLLMClient
 		builder    *prompt.Builder
@@ -48,14 +48,14 @@ var _ = Describe("Kubernaut Agent Sanitization Wiring — TP-433-WIR Phase 3", f
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		invLogger = logr.Discard()
 		auditStore = &recordingAuditStore{}
 		mockClient = &mockLLMClient{}
 		builder, _ = prompt.NewBuilder()
 		rp = parser.NewResultParser()
 		k8sClient := &fakeK8sClient{ownerChain: []enrichment.OwnerChainEntry{}}
 		dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 		phaseTools = investigator.DefaultPhaseToolMap()
 
 		pipeline = sanitization.NewPipeline(
@@ -78,7 +78,7 @@ var _ = Describe("Kubernaut Agent Sanitization Wiring — TP-433-WIR Phase 3", f
 				wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 			}
 
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg, Pipeline: investigator.Pipeline{Sanitizer: pipeline, AnomalyDetector: investigator.NewAnomalyDetector(investigator.DefaultAnomalyConfig(), nil)}})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg, Pipeline: investigator.Pipeline{Sanitizer: pipeline, AnomalyDetector: investigator.NewAnomalyDetector(investigator.DefaultAnomalyConfig(), nil)}})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api", Namespace: "default", Severity: "warning", Message: "CrashLoop",
 			})
@@ -112,7 +112,7 @@ var _ = Describe("Kubernaut Agent Sanitization Wiring — TP-433-WIR Phase 3", f
 				wfToolResp(`{"workflow_id":"noop","confidence":0.6}`),
 			}
 
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg, Pipeline: investigator.Pipeline{Sanitizer: pipeline, AnomalyDetector: investigator.NewAnomalyDetector(investigator.DefaultAnomalyConfig(), nil)}})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg, Pipeline: investigator.Pipeline{Sanitizer: pipeline, AnomalyDetector: investigator.NewAnomalyDetector(investigator.DefaultAnomalyConfig(), nil)}})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api", Namespace: "default", Severity: "warning", Message: "CrashLoop",
 			})
@@ -145,7 +145,7 @@ var _ = Describe("Kubernaut Agent Sanitization Wiring — TP-433-WIR Phase 3", f
 				wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 			}
 
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api", Namespace: "default", Severity: "warning", Message: "CrashLoop",
 			})

--- a/test/integration/kubernautagent/investigator/investigator_summarizer_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_summarizer_test.go
@@ -18,9 +18,9 @@ package investigator_test
 
 import (
 	"context"
-	"log/slog"
-	"os"
 	"strings"
+
+	"github.com/go-logr/logr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -38,7 +38,7 @@ import (
 var _ = Describe("Kubernaut Agent Summarizer Wiring — TP-433-WIR Phase 6", func() {
 
 	var (
-		logger     *slog.Logger
+		invLogger  logr.Logger
 		auditStore *recordingAuditStore
 		builder    *prompt.Builder
 		rp         *parser.ResultParser
@@ -47,13 +47,13 @@ var _ = Describe("Kubernaut Agent Summarizer Wiring — TP-433-WIR Phase 6", fun
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		invLogger = logr.Discard()
 		auditStore = &recordingAuditStore{}
 		builder, _ = prompt.NewBuilder()
 		rp = parser.NewResultParser()
 		k8sClient := &fakeK8sClient{ownerChain: []enrichment.OwnerChainEntry{}}
 		dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 		phaseTools = investigator.DefaultPhaseToolMap()
 	})
 
@@ -81,7 +81,7 @@ var _ = Describe("Kubernaut Agent Summarizer Wiring — TP-433-WIR Phase 6", fun
 				},
 			}
 
-			inv := investigator.New(investigator.Config{Client: investigationLLM, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg, Pipeline: investigator.Pipeline{Summarizer: sum, AnomalyDetector: investigator.NewAnomalyDetector(investigator.DefaultAnomalyConfig(), nil)}})
+			inv := investigator.New(investigator.Config{Client: investigationLLM, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg, Pipeline: investigator.Pipeline{Summarizer: sum, AnomalyDetector: investigator.NewAnomalyDetector(investigator.DefaultAnomalyConfig(), nil)}})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api", Namespace: "default", Severity: "warning", Message: "CrashLoop",
 			})
@@ -115,7 +115,7 @@ var _ = Describe("Kubernaut Agent Summarizer Wiring — TP-433-WIR Phase 6", fun
 				},
 			}
 
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api", Namespace: "default", Severity: "warning", Message: "CrashLoop",
 			})

--- a/test/integration/kubernautagent/investigator/investigator_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_test.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"log/slog"
-	"os"
 	"time"
+
+	"github.com/go-logr/logr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -126,10 +126,12 @@ type fakeTool struct {
 	err    error
 }
 
-func (f *fakeTool) Name() string                                                         { return f.name }
-func (f *fakeTool) Description() string                                                  { return "fake " + f.name }
-func (f *fakeTool) Parameters() json.RawMessage                                          { return nil }
-func (f *fakeTool) Execute(_ context.Context, _ json.RawMessage) (string, error) { return f.result, f.err }
+func (f *fakeTool) Name() string                { return f.name }
+func (f *fakeTool) Description() string         { return "fake " + f.name }
+func (f *fakeTool) Parameters() json.RawMessage { return nil }
+func (f *fakeTool) Execute(_ context.Context, _ json.RawMessage) (string, error) {
+	return f.result, f.err
+}
 
 func filterEvents(events []*audit.AuditEvent, eventType string) []*audit.AuditEvent {
 	var filtered []*audit.AuditEvent
@@ -144,7 +146,7 @@ func filterEvents(events []*audit.AuditEvent, eventType string) []*audit.AuditEv
 var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 
 	var (
-		logger     *slog.Logger
+		invLogger  logr.Logger
 		auditStore *recordingAuditStore
 		mockClient *mockLLMClient
 		builder    *prompt.Builder
@@ -154,7 +156,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		invLogger = logr.Discard()
 		auditStore = &recordingAuditStore{}
 		mockClient = &mockLLMClient{}
 		builder, _ = prompt.NewBuilder()
@@ -172,7 +174,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 				},
 			},
 		}
-		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 		phaseTools = investigator.DefaultPhaseToolMap()
 	})
 
@@ -182,7 +184,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled due to memory limit exceeded"}`}},
 				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.9,"remediation_target":{"kind":"Deployment","name":"api-server","namespace":"production"}}`),
 			}
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name:      "api-server-abc",
 				Namespace: "production",
@@ -202,7 +204,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"issue found"}`}},
 				wfToolResp(`{"workflow_id":"restart-pod","confidence":0.8}`),
 			}
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "pod-abc", Namespace: "default", Severity: "warning", Message: "CrashLoopBackOff",
 			})
@@ -217,7 +219,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"memory leak in api-server container"}`}},
 				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.88}`),
 			}
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api-server-abc", Namespace: "production", Severity: "critical", Message: "OOMKilled",
 			})
@@ -239,7 +241,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 					ToolCalls: []llm.ToolCall{{ID: "tc_1", Name: "kubectl_describe", Arguments: `{"kind":"Pod","name":"api","namespace":"default"}`}},
 				},
 			}
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 1, PhaseTools: phaseTools})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 1, PhaseTools: phaseTools})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api", Namespace: "default", Severity: "critical", Message: "OOMKilled",
 			})
@@ -264,7 +266,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 				wfToolResp(`{"workflow_id":"generic-restart","confidence":0.7}`),
 			}
 
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api", Namespace: "default", Severity: "warning", Message: "CrashLoop",
 			})
@@ -294,7 +296,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 				wfToolResp(`{"workflow_id":"restart","confidence":0.5}`),
 			}
 
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api", Namespace: "default", Severity: "critical", Message: "OOMKilled",
 			})
@@ -319,7 +321,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 				wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 			}
 
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api", Namespace: "default", Severity: "warning", Message: "CrashLoop",
 			})
@@ -347,7 +349,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 				wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 			}
 
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api", Namespace: "default", Severity: "warning", Message: "CrashLoop",
 			})
@@ -372,7 +374,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"Memory pressure detected"}`}},
 				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.9}`),
 			}
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name:      "api-server-abc",
 				Namespace: "production",
@@ -405,7 +407,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"Issue found"}`}},
 				wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 			}
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: nil, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: nil, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "test-pod", Namespace: "default", Severity: "warning", Message: "CrashLoop",
 			})
@@ -443,7 +445,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.95}`),
 			}
 
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api-server", Namespace: "production", Severity: "critical", Message: "OOMKilled",
 			})
@@ -466,7 +468,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 				wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 			}
 
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools, Registry: reg})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api", Namespace: "default", Severity: "warning", Message: "CrashLoop",
 			})
@@ -501,7 +503,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 				wfToolResp(`{"workflow_id":"restart","confidence":0.7}`),
 			}
 
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api", Namespace: "default", Severity: "warning", Message: "CrashLoop",
 			})
@@ -517,7 +519,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"found issue"}`}},
 				wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.85}`),
 			}
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api-server", Namespace: "production", Severity: "critical", Message: "OOMKilled",
 			})
@@ -535,7 +537,7 @@ var _ = Describe("Kubernaut Agent Investigator Integration — #433", func() {
 var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() {
 
 	var (
-		logger     *slog.Logger
+		invLogger  logr.Logger
 		auditStore *recordingAuditStore
 		mockClient *mockLLMClient
 		builder    *prompt.Builder
@@ -544,7 +546,7 @@ var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() 
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		invLogger = logr.Discard()
 		auditStore = &recordingAuditStore{}
 		mockClient = &mockLLMClient{}
 		builder, _ = prompt.NewBuilder()
@@ -564,7 +566,7 @@ var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() 
 				},
 			}
 			ds := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-			enricher := enrichment.NewEnricher(k8s, ds, auditStore, logger)
+			enricher := enrichment.NewEnricher(k8s, ds, auditStore, invLogger)
 
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled in worker deployment","remediation_target":{"kind":"Deployment","name":"worker","namespace":"demo-crashloop"}}`}},
@@ -573,7 +575,7 @@ var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() 
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
@@ -606,7 +608,7 @@ var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() 
 				},
 			}
 			ds := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-			enricher := enrichment.NewEnricher(k8s, ds, auditStore, logger)
+			enricher := enrichment.NewEnricher(k8s, ds, auditStore, invLogger)
 
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"CrashLoop in worker pod"}`}},
@@ -615,7 +617,7 @@ var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() 
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
@@ -648,7 +650,7 @@ var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() 
 				},
 			}
 			ds := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-			enricher := enrichment.NewEnricher(k8s, ds, auditStore, logger)
+			enricher := enrichment.NewEnricher(k8s, ds, auditStore, invLogger)
 
 			mockClient.responses = []llm.ChatResponse{
 				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled targeting Deployment worker","remediation_target":{"kind":"Deployment","name":"worker","namespace":"demo-crashloop"}}`}},
@@ -657,7 +659,7 @@ var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() 
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
@@ -685,7 +687,7 @@ var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() 
 			// Approach D defensive check must preserve the original Node target.
 			k8s := &fakeK8sClient{ownerChain: nil, err: nil}
 			ds := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-			localEnricher := enrichment.NewEnricher(k8s, ds, auditStore, logger)
+			localEnricher := enrichment.NewEnricher(k8s, ds, auditStore, invLogger)
 
 			mockClient.responses = []llm.ChatResponse{
 				// Phase 1 RCA: same kind as signal (Node == Node) → gate triggers
@@ -705,7 +707,7 @@ var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() 
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: localEnricher, AuditStore: auditStore, Logger: logger,
+				Enricher: localEnricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
@@ -737,7 +739,7 @@ var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() 
 				err:        notFoundErr,
 			}
 			ds := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-			enricher := enrichment.NewEnricher(k8s, ds, auditStore, logger).
+			enricher := enrichment.NewEnricher(k8s, ds, auditStore, invLogger).
 				WithRetryConfig(enrichment.RetryConfig{
 					MaxRetries:  3,
 					BaseBackoff: 1 * time.Millisecond,
@@ -753,7 +755,7 @@ var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() 
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 			})
 

--- a/test/integration/kubernautagent/investigator/investigator_truncation_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_truncation_test.go
@@ -20,9 +20,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
-	"os"
 	"strings"
+
+	"github.com/go-logr/logr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -48,7 +48,7 @@ func (f *alwaysFailLLM) Close() error { return nil }
 var _ = Describe("Kubernaut Agent Tool Output Truncation Pipeline — #752", func() {
 
 	var (
-		logger     *slog.Logger
+		invLogger  logr.Logger
 		auditStore *recordingAuditStore
 		builder    *prompt.Builder
 		rp         *parser.ResultParser
@@ -57,13 +57,13 @@ var _ = Describe("Kubernaut Agent Tool Output Truncation Pipeline — #752", fun
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		invLogger = logr.Discard()
 		auditStore = &recordingAuditStore{}
 		builder, _ = prompt.NewBuilder()
 		rp = parser.NewResultParser()
 		k8sClient := &fakeK8sClient{ownerChain: []enrichment.OwnerChainEntry{}}
 		dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 		phaseTools = investigator.DefaultPhaseToolMap()
 	})
 
@@ -87,11 +87,11 @@ var _ = Describe("Kubernaut Agent Tool Output Truncation Pipeline — #752", fun
 			maxOutput := 1000
 			inv := investigator.New(investigator.Config{
 				Client: investigationLLM, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools, Registry: reg,
 				Pipeline: investigator.Pipeline{
 					MaxToolOutputSize: maxOutput,
-					AnomalyDetector:  investigator.NewAnomalyDetector(investigator.DefaultAnomalyConfig(), nil),
+					AnomalyDetector:   investigator.NewAnomalyDetector(investigator.DefaultAnomalyConfig(), nil),
 				},
 			})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
@@ -129,11 +129,11 @@ var _ = Describe("Kubernaut Agent Tool Output Truncation Pipeline — #752", fun
 
 			inv := investigator.New(investigator.Config{
 				Client: investigationLLM, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools, Registry: reg,
 				Pipeline: investigator.Pipeline{
 					MaxToolOutputSize: 100000,
-					AnomalyDetector:  investigator.NewAnomalyDetector(investigator.DefaultAnomalyConfig(), nil),
+					AnomalyDetector:   investigator.NewAnomalyDetector(investigator.DefaultAnomalyConfig(), nil),
 				},
 			})
 			_, err := inv.Investigate(context.Background(), katypes.SignalContext{
@@ -171,7 +171,7 @@ var _ = Describe("Kubernaut Agent Tool Output Truncation Pipeline — #752", fun
 			maxOutput := 2000
 			inv := investigator.New(investigator.Config{
 				Client: investigationLLM, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools, Registry: reg,
 				Pipeline: investigator.Pipeline{
 					Summarizer:        sum,

--- a/test/integration/kubernautagent/investigator/investigator_validator_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_validator_test.go
@@ -18,8 +18,8 @@ package investigator_test
 
 import (
 	"context"
-	"log/slog"
-	"os"
+
+	"github.com/go-logr/logr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,7 +35,7 @@ import (
 var _ = Describe("Kubernaut Agent Validator Wiring — TP-433-WIR Phase 5", func() {
 
 	var (
-		logger     *slog.Logger
+		invLogger  logr.Logger
 		auditStore *recordingAuditStore
 		builder    *prompt.Builder
 		rp         *parser.ResultParser
@@ -44,13 +44,13 @@ var _ = Describe("Kubernaut Agent Validator Wiring — TP-433-WIR Phase 5", func
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		invLogger = logr.Discard()
 		auditStore = &recordingAuditStore{}
 		builder, _ = prompt.NewBuilder()
 		rp = parser.NewResultParser()
 		k8sClient := &fakeK8sClient{ownerChain: []enrichment.OwnerChainEntry{}}
 		dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 		phaseTools = investigator.DefaultPhaseToolMap()
 	})
 
@@ -66,7 +66,7 @@ var _ = Describe("Kubernaut Agent Validator Wiring — TP-433-WIR Phase 5", func
 				},
 			}
 
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools, Pipeline: investigator.Pipeline{CatalogFetcher: &staticCatalogFetcher{validator: validator}, AnomalyDetector: investigator.NewAnomalyDetector(investigator.DefaultAnomalyConfig(), nil)}})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools, Pipeline: investigator.Pipeline{CatalogFetcher: &staticCatalogFetcher{validator: validator}, AnomalyDetector: investigator.NewAnomalyDetector(investigator.DefaultAnomalyConfig(), nil)}})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api", Namespace: "default", Severity: "warning", Message: "CrashLoop",
 			})
@@ -87,7 +87,7 @@ var _ = Describe("Kubernaut Agent Validator Wiring — TP-433-WIR Phase 5", func
 				},
 			}
 
-			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: logger, MaxTurns: 15, PhaseTools: phaseTools})
+			inv := investigator.New(investigator.Config{Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher, AuditStore: auditStore, Logger: invLogger, MaxTurns: 15, PhaseTools: phaseTools})
 			result, err := inv.Investigate(context.Background(), katypes.SignalContext{
 				Name: "api", Namespace: "default", Severity: "warning", Message: "CrashLoop",
 			})

--- a/test/integration/kubernautagent/investigator/investigator_wiring_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_wiring_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package investigator_test
 
 import (
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -29,7 +30,7 @@ var _ = Describe("Kubernaut Agent Registry Wiring — TP-433-WIR Phase 2", func(
 	Describe("IT-KA-433W-007: Registry with DS URL includes all 5 custom tools", func() {
 		It("should register all 5 custom tool names when DataStorage is configured", func() {
 			reg := registry.New()
-			custom.RegisterAll(reg, nil, nil, nil)
+			custom.RegisterAll(reg, nil, nil, nil, logr.Discard())
 
 			allTools := reg.All()
 			toolNames := make([]string, len(allTools))

--- a/test/integration/kubernautagent/investigator/rca_retry_795_it_test.go
+++ b/test/integration/kubernautagent/investigator/rca_retry_795_it_test.go
@@ -18,8 +18,8 @@ package investigator_test
 
 import (
 	"context"
-	"log/slog"
-	"os"
+
+	"github.com/go-logr/logr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -37,7 +37,7 @@ import (
 var _ = Describe("IT-KA-795: RCA parse retry on failure", func() {
 
 	var (
-		logger     *slog.Logger
+		invLogger  logr.Logger
 		auditStore *recordingAuditStore
 		builder    *prompt.Builder
 		rp         *parser.ResultParser
@@ -45,7 +45,7 @@ var _ = Describe("IT-KA-795: RCA parse retry on failure", func() {
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		invLogger = logr.Discard()
 		auditStore = &recordingAuditStore{}
 		builder, _ = prompt.NewBuilder()
 		rp = parser.NewResultParser()
@@ -86,11 +86,11 @@ var _ = Describe("IT-KA-795: RCA parse retry on failure", func() {
 				{Kind: "Deployment", Name: "api", Namespace: "production"},
 			}}
 			dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools, Registry: reg,
 			})
 
@@ -148,11 +148,11 @@ var _ = Describe("IT-KA-795: RCA parse retry on failure", func() {
 				{Kind: "Deployment", Name: "api", Namespace: "production"},
 			}}
 			dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools, Registry: reg,
 			})
 
@@ -208,11 +208,11 @@ var _ = Describe("IT-KA-795: RCA parse retry on failure", func() {
 				{Kind: "Deployment", Name: "web-frontend", Namespace: "demo-gitops"},
 			}}
 			dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools, Registry: reg,
 			})
 
@@ -220,7 +220,7 @@ var _ = Describe("IT-KA-795: RCA parse retry on failure", func() {
 				Name: "KubePodCrashLooping", Namespace: "demo-gitops", Severity: "critical",
 				Message: "Pod web-frontend-c8dc85956-jn2b8 CrashLoopBackOff", ResourceKind: "Pod",
 				ResourceName: "web-frontend-c8dc85956-jn2b8",
-				Environment: "staging", Priority: "P1",
+				Environment:  "staging", Priority: "P1",
 			})
 			Expect(err).NotTo(HaveOccurred())
 
@@ -272,11 +272,11 @@ var _ = Describe("IT-KA-795: RCA parse retry on failure", func() {
 				{Kind: "Deployment", Name: "api", Namespace: "production"},
 			}}
 			dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools, Registry: reg,
 			})
 

--- a/test/integration/kubernautagent/investigator/signal_context_779_it_test.go
+++ b/test/integration/kubernautagent/investigator/signal_context_779_it_test.go
@@ -18,9 +18,8 @@ package investigator_test
 
 import (
 	"context"
-	"log/slog"
-	"os"
 
+	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -74,7 +73,7 @@ func (p *paramCapturingDS) GetWorkflowByID(_ context.Context, _ ogenclient.GetWo
 var _ = Describe("IT-KA-779: Signal context propagation through investigator to DS tool params", func() {
 
 	var (
-		logger     *slog.Logger
+		invLogger  logr.Logger
 		auditStore *recordingAuditStore
 		builder    *prompt.Builder
 		rp         *parser.ResultParser
@@ -82,7 +81,7 @@ var _ = Describe("IT-KA-779: Signal context propagation through investigator to 
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		invLogger = logr.Discard()
 		auditStore = &recordingAuditStore{}
 		builder, _ = prompt.NewBuilder()
 		rp = parser.NewResultParser()
@@ -112,11 +111,11 @@ var _ = Describe("IT-KA-779: Signal context propagation through investigator to 
 
 			k8sClient := &fakeK8sClient{ownerChain: []enrichment.OwnerChainEntry{}}
 			dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools, Registry: reg,
 			})
 
@@ -166,11 +165,11 @@ var _ = Describe("IT-KA-779: Signal context propagation through investigator to 
 
 			k8sClient := &fakeK8sClient{ownerChain: []enrichment.OwnerChainEntry{}}
 			dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools, Registry: reg,
 			})
 

--- a/test/integration/kubernautagent/investigator/signal_mode_it_test.go
+++ b/test/integration/kubernautagent/investigator/signal_mode_it_test.go
@@ -18,8 +18,8 @@ package investigator_test
 
 import (
 	"context"
-	"log/slog"
-	"os"
+
+	"github.com/go-logr/logr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -35,7 +35,7 @@ import (
 var _ = Describe("KA-KA Integration Parity — Signal Mode (TP-433-PARITY)", func() {
 
 	var (
-		logger     *slog.Logger
+		invLogger  logr.Logger
 		auditStore *recordingAuditStore
 		builder    *prompt.Builder
 		rp         *parser.ResultParser
@@ -44,13 +44,13 @@ var _ = Describe("KA-KA Integration Parity — Signal Mode (TP-433-PARITY)", fun
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		invLogger = logr.Discard()
 		auditStore = &recordingAuditStore{}
 		builder, _ = prompt.NewBuilder()
 		rp = parser.NewResultParser()
 		k8sClient := &fakeK8sClient{ownerChain: []enrichment.OwnerChainEntry{}}
 		dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 		phaseTools = investigator.DefaultPhaseToolMap()
 	})
 
@@ -65,7 +65,7 @@ var _ = Describe("KA-KA Integration Parity — Signal Mode (TP-433-PARITY)", fun
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
@@ -97,7 +97,7 @@ var _ = Describe("KA-KA Integration Parity — Signal Mode (TP-433-PARITY)", fun
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 			})
 

--- a/test/integration/kubernautagent/investigator/token_metrics_rca_it_test.go
+++ b/test/integration/kubernautagent/investigator/token_metrics_rca_it_test.go
@@ -18,8 +18,8 @@ package investigator_test
 
 import (
 	"context"
-	"log/slog"
-	"os"
+
+	"github.com/go-logr/logr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -36,7 +36,7 @@ import (
 var _ = Describe("KA-KA Integration Parity — Token Usage (TP-433-PARITY)", func() {
 
 	var (
-		logger     *slog.Logger
+		invLogger  logr.Logger
 		auditStore *recordingAuditStore
 		builder    *prompt.Builder
 		rp         *parser.ResultParser
@@ -45,13 +45,13 @@ var _ = Describe("KA-KA Integration Parity — Token Usage (TP-433-PARITY)", fun
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		invLogger = logr.Discard()
 		auditStore = &recordingAuditStore{}
 		builder, _ = prompt.NewBuilder()
 		rp = parser.NewResultParser()
 		k8sClient := &fakeK8sClient{ownerChain: []enrichment.OwnerChainEntry{}}
 		dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 		phaseTools = investigator.DefaultPhaseToolMap()
 	})
 
@@ -73,7 +73,7 @@ var _ = Describe("KA-KA Integration Parity — Token Usage (TP-433-PARITY)", fun
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
@@ -105,7 +105,7 @@ var _ = Describe("KA-KA Integration Parity — Token Usage (TP-433-PARITY)", fun
 var _ = Describe("KA-KA Integration Parity — LLM Metrics (TP-433-PARITY)", func() {
 
 	var (
-		logger     *slog.Logger
+		invLogger  logr.Logger
 		auditStore *recordingAuditStore
 		builder    *prompt.Builder
 		rp         *parser.ResultParser
@@ -114,13 +114,13 @@ var _ = Describe("KA-KA Integration Parity — LLM Metrics (TP-433-PARITY)", fun
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		invLogger = logr.Discard()
 		auditStore = &recordingAuditStore{}
 		builder, _ = prompt.NewBuilder()
 		rp = parser.NewResultParser()
 		k8sClient := &fakeK8sClient{ownerChain: []enrichment.OwnerChainEntry{}}
 		dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 		phaseTools = investigator.DefaultPhaseToolMap()
 	})
 
@@ -143,7 +143,7 @@ var _ = Describe("KA-KA Integration Parity — LLM Metrics (TP-433-PARITY)", fun
 
 			inv := investigator.New(investigator.Config{
 				Client: instrumented, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
@@ -176,7 +176,7 @@ var _ = Describe("KA-KA Integration Parity — LLM Metrics (TP-433-PARITY)", fun
 
 			inv := investigator.New(investigator.Config{
 				Client: instrumented, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
@@ -194,7 +194,7 @@ var _ = Describe("KA-KA Integration Parity — LLM Metrics (TP-433-PARITY)", fun
 var _ = Describe("KA-KA Integration Parity — RCA (TP-433-PARITY)", func() {
 
 	var (
-		logger     *slog.Logger
+		invLogger  logr.Logger
 		auditStore *recordingAuditStore
 		builder    *prompt.Builder
 		rp         *parser.ResultParser
@@ -203,7 +203,7 @@ var _ = Describe("KA-KA Integration Parity — RCA (TP-433-PARITY)", func() {
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+		invLogger = logr.Discard()
 		auditStore = &recordingAuditStore{}
 		builder, _ = prompt.NewBuilder()
 		rp = parser.NewResultParser()
@@ -213,7 +213,7 @@ var _ = Describe("KA-KA Integration Parity — RCA (TP-433-PARITY)", func() {
 			},
 		}
 		dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
-		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, logger)
+		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger)
 		phaseTools = investigator.DefaultPhaseToolMap()
 	})
 
@@ -235,7 +235,7 @@ var _ = Describe("KA-KA Integration Parity — RCA (TP-433-PARITY)", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 			})
 
@@ -265,7 +265,7 @@ var _ = Describe("KA-KA Integration Parity — RCA (TP-433-PARITY)", func() {
 
 			inv := investigator.New(investigator.Config{
 				Client: mockClient, Builder: builder, ResultParser: rp,
-				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				Enricher: enricher, AuditStore: auditStore, Logger: invLogger,
 				MaxTurns: 15, PhaseTools: phaseTools,
 			})
 

--- a/test/integration/kubernautagent/session/manager_test.go
+++ b/test/integration/kubernautagent/session/manager_test.go
@@ -19,12 +19,12 @@ package session_test
 import (
 	"context"
 	"errors"
-	"log/slog"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/go-logr/logr"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
 )
 
@@ -37,7 +37,7 @@ var _ = Describe("Kubernaut Agent Session Manager — #433", func() {
 
 	BeforeEach(func() {
 		store = session.NewStore(5 * time.Minute)
-		manager = session.NewManager(store, slog.Default())
+		manager = session.NewManager(store, logr.Discard())
 	})
 
 	Describe("IT-KA-433-001: Session manager starts background investigation", func() {

--- a/test/unit/config/logging_test.go
+++ b/test/unit/config/logging_test.go
@@ -17,8 +17,6 @@ limitations under the License.
 package config_test
 
 import (
-	"log/slog"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"go.uber.org/zap"
@@ -92,22 +90,6 @@ var _ = Describe("Shared LoggingConfig — BR-PLATFORM-875", func() {
 			Entry("TRACE", "TRACE"),
 			Entry("FATAL", "FATAL"),
 			Entry("warning", "warning"),
-		)
-	})
-
-	Describe("UT-CFG-875-006: SlogLevel maps correctly (bridge for KA)", func() {
-		DescribeTable("slog level mapping",
-			func(level string, expected slog.Level) {
-				cfg := config.LoggingConfig{Level: level}
-				Expect(cfg.SlogLevel()).To(Equal(expected))
-			},
-			Entry("DEBUG -> slog.LevelDebug", "DEBUG", slog.LevelDebug),
-			Entry("INFO -> slog.LevelInfo", "INFO", slog.LevelInfo),
-			Entry("WARN -> slog.LevelWarn", "WARN", slog.LevelWarn),
-			Entry("ERROR -> slog.LevelError", "ERROR", slog.LevelError),
-			Entry("debug (lowercase) -> slog.LevelDebug", "debug", slog.LevelDebug),
-			Entry("empty string -> slog.LevelInfo", "", slog.LevelInfo),
-			Entry("unknown -> slog.LevelInfo", "TRACE", slog.LevelInfo),
 		)
 	})
 

--- a/test/unit/kubernautagent/alignment/alignment_test.go
+++ b/test/unit/kubernautagent/alignment/alignment_test.go
@@ -21,10 +21,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log/slog"
 	"strings"
 	"time"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -442,7 +442,7 @@ var _ = Describe("Shadow Agent alignment — BR-AI-601", func() {
 				Inner:          inner,
 				Evaluator:      evaluator,
 				VerdictTimeout: 5 * time.Second,
-				Logger:         slog.Default(),
+				Logger:         logr.Discard(),
 			})
 			sig := katypes.SignalContext{Name: "s", Namespace: "ns", Severity: "high", Message: "m"}
 
@@ -654,7 +654,7 @@ var _ = Describe("Fail-closed behavior — BR-AI-601", func() {
 				Inner:          innerRunner,
 				Evaluator:      evaluator,
 				VerdictTimeout: 50 * time.Millisecond,
-				Logger:         slog.Default(),
+				Logger:         logr.Discard(),
 			})
 
 			res, err := wrapper.Investigate(context.Background(), katypes.SignalContext{Name: "s", Namespace: "ns"})
@@ -687,7 +687,7 @@ var _ = Describe("Fail-closed behavior — BR-AI-601", func() {
 				Inner:          innerRunner,
 				Evaluator:      evaluator,
 				VerdictTimeout: 5 * time.Second,
-				Logger:         slog.Default(),
+				Logger:         logr.Discard(),
 			})
 
 			res, err := wrapper.Investigate(context.Background(), katypes.SignalContext{Name: "s", Namespace: "ns"})
@@ -834,7 +834,7 @@ var _ = Describe("Correctness fixes — BR-AI-601", func() {
 				alignment.NewInvestigatorWrapper(alignment.InvestigatorWrapperConfig{
 					Inner:     nil,
 					Evaluator: &alignment.Evaluator{},
-					Logger:    slog.Default(),
+					Logger:    logr.Discard(),
 				})
 			}).To(Panic(), "nil Inner must cause panic at construction time")
 		})
@@ -844,7 +844,7 @@ var _ = Describe("Correctness fixes — BR-AI-601", func() {
 				alignment.NewInvestigatorWrapper(alignment.InvestigatorWrapperConfig{
 					Inner:     &mockInvestigationRunner{},
 					Evaluator: nil,
-					Logger:    slog.Default(),
+					Logger:    logr.Discard(),
 				})
 			}).To(Panic(), "nil Evaluator must cause panic at construction time")
 		})
@@ -922,7 +922,7 @@ var _ = Describe("AlignmentCheck mode and config — PROD-1/PROD-2", func() {
 				Inner:          inner,
 				Evaluator:      evaluator,
 				VerdictTimeout: 5 * time.Second,
-				Logger:         slog.Default(),
+				Logger:         logr.Discard(),
 				Mode:           config.AlignmentModeMonitor,
 			})
 
@@ -948,11 +948,11 @@ var _ = Describe("AlignmentCheck mode and config — PROD-1/PROD-2", func() {
 				Timeout: 5 * time.Second, MaxRetries: 1,
 			}, "")
 			wrapper := alignment.NewInvestigatorWrapper(alignment.InvestigatorWrapperConfig{
-				Inner:              inner,
-				Evaluator:          evaluator,
-				VerdictTimeout:     5 * time.Second,
-				Logger:             slog.Default(),
-				Mode:               config.AlignmentModeMonitor,
+				Inner:                 inner,
+				Evaluator:             evaluator,
+				VerdictTimeout:        5 * time.Second,
+				Logger:                logr.Discard(),
+				Mode:                  config.AlignmentModeMonitor,
 				CanaryForceEscalation: true,
 			})
 
@@ -978,11 +978,11 @@ var _ = Describe("AlignmentCheck mode and config — PROD-1/PROD-2", func() {
 				Timeout: 5 * time.Second, MaxRetries: 1,
 			}, "")
 			wrapper := alignment.NewInvestigatorWrapper(alignment.InvestigatorWrapperConfig{
-				Inner:              inner,
-				Evaluator:          evaluator,
-				VerdictTimeout:     5 * time.Second,
-				Logger:             slog.Default(),
-				Mode:               config.AlignmentModeMonitor,
+				Inner:                 inner,
+				Evaluator:             evaluator,
+				VerdictTimeout:        5 * time.Second,
+				Logger:                logr.Discard(),
+				Mode:                  config.AlignmentModeMonitor,
 				CanaryForceEscalation: false,
 			})
 
@@ -1107,7 +1107,7 @@ var _ = Describe("Signal input alignment — BR-AI-601", func() {
 				Inner:          innerRunner,
 				Evaluator:      evaluator,
 				VerdictTimeout: 5 * time.Second,
-				Logger:         slog.Default(),
+				Logger:         logr.Discard(),
 			})
 
 			sig := katypes.SignalContext{
@@ -1144,7 +1144,7 @@ var _ = Describe("Signal input alignment — BR-AI-601", func() {
 				Inner:          inner,
 				Evaluator:      evaluator,
 				VerdictTimeout: 5 * time.Second,
-				Logger:         slog.Default(),
+				Logger:         logr.Discard(),
 			})
 
 			sig := katypes.SignalContext{
@@ -1177,7 +1177,7 @@ var _ = Describe("Signal input alignment — BR-AI-601", func() {
 				Inner:          inner,
 				Evaluator:      evaluator,
 				VerdictTimeout: 5 * time.Second,
-				Logger:         slog.Default(),
+				Logger:         logr.Discard(),
 			})
 
 			sig := katypes.SignalContext{}
@@ -1285,7 +1285,7 @@ var _ = Describe("Explanation sanitization — SEC-2", func() {
 				Inner:          inner,
 				Evaluator:      evaluator,
 				VerdictTimeout: 5 * time.Second,
-				Logger:         slog.Default(),
+				Logger:         logr.Discard(),
 			})
 
 			sig := katypes.SignalContext{Name: "s", Namespace: "ns", Severity: "high", Message: "m"}
@@ -1431,7 +1431,7 @@ var _ = Describe("Canary integrity mechanism — SEC-3", func() {
 				Inner:          inner,
 				Evaluator:      evaluator,
 				VerdictTimeout: 5 * time.Second,
-				Logger:         slog.Default(),
+				Logger:         logr.Discard(),
 			})
 
 			sig := katypes.SignalContext{Name: "s", Namespace: "ns", Severity: "high", Message: "m"}
@@ -1462,7 +1462,7 @@ var _ = Describe("Canary integrity mechanism — SEC-3", func() {
 				Inner:          inner,
 				Evaluator:      evaluator,
 				VerdictTimeout: 5 * time.Second,
-				Logger:         slog.Default(),
+				Logger:         logr.Discard(),
 			})
 
 			sig := katypes.SignalContext{Name: "s", Namespace: "ns", Severity: "high", Message: "m"}
@@ -1489,7 +1489,7 @@ var _ = Describe("Canary integrity mechanism — SEC-3", func() {
 				Inner:          inner,
 				Evaluator:      evaluator,
 				VerdictTimeout: 5 * time.Second,
-				Logger:         slog.Default(),
+				Logger:         logr.Discard(),
 			})
 
 			sig := katypes.SignalContext{Name: "s", Namespace: "ns"}

--- a/test/unit/kubernautagent/audit/emitter_test.go
+++ b/test/unit/kubernautagent/audit/emitter_test.go
@@ -19,9 +19,8 @@ package audit_test
 import (
 	"context"
 	"errors"
-	"log/slog"
-	"os"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -83,10 +82,9 @@ var _ = Describe("Kubernaut Agent Audit Emitter — #433", func() {
 				EventCategory: audit.EventCategory,
 				CorrelationID: "corr-456",
 			}
-			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
 			Expect(func() {
-				audit.StoreBestEffort(context.Background(), store, event, logger)
+				audit.StoreBestEffort(context.Background(), store, event, logr.Discard())
 			}).NotTo(Panic())
 		})
 
@@ -97,9 +95,8 @@ var _ = Describe("Kubernaut Agent Audit Emitter — #433", func() {
 				EventCategory: audit.EventCategory,
 				CorrelationID: "corr-789",
 			}
-			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 
-			audit.StoreBestEffort(context.Background(), store, event, logger)
+			audit.StoreBestEffort(context.Background(), store, event, logr.Discard())
 			Expect(store.events).To(HaveLen(1))
 			Expect(store.events[0].CorrelationID).To(Equal("corr-789"))
 		})

--- a/test/unit/kubernautagent/config/logging_test.go
+++ b/test/unit/kubernautagent/config/logging_test.go
@@ -17,10 +17,9 @@ limitations under the License.
 package config_test
 
 import (
-	"log/slog"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"go.uber.org/zap/zapcore"
 
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/config"
 )
@@ -93,9 +92,9 @@ runtime:
 		)
 	})
 
-	Describe("UT-KA-875-005: SlogLevel returns correct slog.Level", func() {
+	Describe("UT-KA-875-005: ZapLevel returns correct zapcore.Level", func() {
 		DescribeTable("level mapping",
-			func(level string, expected slog.Level) {
+			func(level string, expected zapcore.Level) {
 				yamlData := []byte(`
 ai:
   llm:
@@ -107,19 +106,19 @@ runtime:
 `)
 				cfg, err := config.Load(yamlData)
 				Expect(err).NotTo(HaveOccurred())
-				Expect(cfg.Runtime.Logging.SlogLevel()).To(Equal(expected))
+				Expect(cfg.Runtime.Logging.ZapLevel()).To(Equal(expected))
 			},
-			Entry("DEBUG -> slog.LevelDebug", "DEBUG", slog.LevelDebug),
-			Entry("INFO -> slog.LevelInfo", "INFO", slog.LevelInfo),
-			Entry("WARN -> slog.LevelWarn", "WARN", slog.LevelWarn),
-			Entry("ERROR -> slog.LevelError", "ERROR", slog.LevelError),
+			Entry("DEBUG -> DebugLevel", "DEBUG", zapcore.DebugLevel),
+			Entry("INFO -> InfoLevel", "INFO", zapcore.InfoLevel),
+			Entry("WARN -> WarnLevel", "WARN", zapcore.WarnLevel),
+			Entry("ERROR -> ErrorLevel", "ERROR", zapcore.ErrorLevel),
 		)
 	})
 
-	Describe("UT-KA-875-006: SlogLevel defaults to INFO for empty level", func() {
-		It("should return slog.LevelInfo when level is empty", func() {
+	Describe("UT-KA-875-006: ZapLevel defaults to INFO for empty level", func() {
+		It("should return InfoLevel when level is empty", func() {
 			cfg := config.DefaultConfig()
-			Expect(cfg.Runtime.Logging.SlogLevel()).To(Equal(slog.LevelInfo))
+			Expect(cfg.Runtime.Logging.ZapLevel()).To(Equal(zapcore.InfoLevel))
 		})
 	})
 })

--- a/test/unit/kubernautagent/credentials/resolver_test.go
+++ b/test/unit/kubernautagent/credentials/resolver_test.go
@@ -17,11 +17,11 @@ limitations under the License.
 package credentials_test
 
 import (
-	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -32,7 +32,7 @@ var _ = Describe("ResolveGCPCredentialIndirection — #686", func() {
 
 	var (
 		credDir string
-		logger  *slog.Logger
+		logger  = logr.Discard()
 	)
 
 	BeforeEach(func() {
@@ -40,8 +40,6 @@ var _ = Describe("ResolveGCPCredentialIndirection — #686", func() {
 		credDir, err = os.MkdirTemp("", "cred-resolver-test-*")
 		Expect(err).NotTo(HaveOccurred())
 		DeferCleanup(func() { os.RemoveAll(credDir) })
-
-		logger = slog.New(slog.NewTextHandler(GinkgoWriter, &slog.HandlerOptions{Level: slog.LevelDebug}))
 	})
 
 	// -- Passthrough scenarios --

--- a/test/unit/kubernautagent/enrichment/context_cancel_779_test.go
+++ b/test/unit/kubernautagent/enrichment/context_cancel_779_test.go
@@ -19,6 +19,7 @@ package enrichment_test
 import (
 	"context"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -37,7 +38,7 @@ var _ = Describe("UT-KA-779-CC: Context cancellation behavior", func() {
 		It("should return a context error or fail gracefully", func() {
 			scheme := newFullScheme()
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()
@@ -65,7 +66,7 @@ var _ = Describe("UT-KA-779-CC: Context cancellation behavior", func() {
 		It("should complete without panicking when called with cancelled context", func() {
 			scheme := runtime.NewScheme()
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()

--- a/test/unit/kubernautagent/enrichment/detected_labels_679_test.go
+++ b/test/unit/kubernautagent/enrichment/detected_labels_679_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/go-logr/logr"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -85,7 +86,7 @@ var _ = Describe("LabelDetector Non-Workload Root Owners — Issue #679", func()
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, cm)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			labels, _, err := detector.DetectLabels(ctx, "ConfigMap", "worker-config", "demo-crashloop-helm", nil)
 			Expect(err).NotTo(HaveOccurred())
@@ -110,7 +111,7 @@ var _ = Describe("LabelDetector Non-Workload Root Owners — Issue #679", func()
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, secret)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			labels, _, err := detector.DetectLabels(ctx, "Secret", "tls-cert", "production", nil)
 			Expect(err).NotTo(HaveOccurred())
@@ -132,7 +133,7 @@ var _ = Describe("LabelDetector Non-Workload Root Owners — Issue #679", func()
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, svc)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			labels, _, err := detector.DetectLabels(ctx, "Service", "api-gateway", "default", nil)
 			Expect(err).NotTo(HaveOccurred())
@@ -157,7 +158,7 @@ var _ = Describe("LabelDetector Non-Workload Root Owners — Issue #679", func()
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, node)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			labels, _, err := detector.DetectLabels(ctx, "Node", "worker-1", "", nil)
 			Expect(err).NotTo(HaveOccurred())
@@ -183,7 +184,7 @@ var _ = Describe("LabelDetector Non-Workload Root Owners — Issue #679", func()
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "web-app", Namespace: "default"},
@@ -211,7 +212,7 @@ var _ = Describe("LabelDetector Non-Workload Root Owners — Issue #679", func()
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "web-deploy", Namespace: "default"},
@@ -240,7 +241,7 @@ var _ = Describe("LabelDetector Non-Workload Root Owners — Issue #679", func()
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "web-deploy", Namespace: "default"},
@@ -272,7 +273,7 @@ var _ = Describe("LabelDetector Non-Workload Root Owners — Issue #679", func()
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, cm)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			labels, _, err := detector.DetectLabels(ctx, "ConfigMap", "worker-config", "demo-crashloop-helm", nil)
 			Expect(err).NotTo(HaveOccurred())
@@ -286,7 +287,7 @@ var _ = Describe("LabelDetector Non-Workload Root Owners — Issue #679", func()
 		It("should return error when mapper is nil", func() {
 			scheme := newFullScheme()
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme)
-			detector := enrichment.NewLabelDetector(dynClient, nil)
+			detector := enrichment.NewLabelDetector(dynClient, nil, logr.Discard())
 
 			labels, _, err := detector.DetectLabels(ctx, "ConfigMap", "some-cm", "default", nil)
 			Expect(err).NotTo(HaveOccurred(), "DetectLabels should not error — it logs warnings")

--- a/test/unit/kubernautagent/enrichment/detected_labels_776_test.go
+++ b/test/unit/kubernautagent/enrichment/detected_labels_776_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/go-logr/logr"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -58,7 +59,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "api-server", Namespace: "production"},
@@ -92,7 +93,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "web-app", Namespace: "staging"},
@@ -125,7 +126,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy, ns)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "web-app", Namespace: "argocd-managed-ns"},
@@ -156,7 +157,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "web-app", Namespace: "production"},
@@ -193,7 +194,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "mixed-app", Namespace: "production"},
@@ -230,7 +231,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "mixed-app", Namespace: "production"},
@@ -266,7 +267,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy, ns)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "mixed-app", Namespace: "mixed-ns"},
@@ -309,7 +310,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "rich-app", Namespace: "production"},
@@ -342,7 +343,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy, ns)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "plain-app", Namespace: "argocd-ns"},
@@ -375,7 +376,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy, ns)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "plain-app", Namespace: "flux-ns"},
@@ -402,7 +403,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, node)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			labels, _, err := detector.DetectLabels(ctx, "Node", "worker-1", "", nil)
 			Expect(err).NotTo(HaveOccurred())
@@ -436,7 +437,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "meshed-app", Namespace: "production"},
@@ -469,7 +470,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "linkerd-app", Namespace: "production"},
@@ -496,7 +497,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "legacy-istio", Namespace: "production"},
@@ -523,7 +524,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "legacy-linkerd", Namespace: "production"},
@@ -563,7 +564,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy, hpa)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "api-server", Namespace: "production"},
@@ -599,7 +600,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy, hpa)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Pod", Name: "api-pod-xyz", Namespace: "production"},
@@ -637,7 +638,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, ss, hpa)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "StatefulSet", Name: "db-cluster", Namespace: "production"},
@@ -665,7 +666,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, ss)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Pod", Name: "db-pod-0", Namespace: "production"},
@@ -690,7 +691,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, ss)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Pod", Name: "db-pod-0", Namespace: "production"},
@@ -736,7 +737,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy, quota)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "web-app", Namespace: "constrained-ns"},
@@ -797,7 +798,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy, quota1, quota2)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "web-app", Namespace: "multi-quota-ns"},
@@ -829,7 +830,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy, quota)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "web-app", Namespace: "empty-status-ns"},
@@ -853,7 +854,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			ownerChain := []enrichment.OwnerChainEntry{
 				{Kind: "Deployment", Name: "web-app", Namespace: "no-quota-ns"},
@@ -876,7 +877,7 @@ var _ = Describe("DD-HAPI-018 Parity — Issue #776", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, node)
-			detector := enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector := enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 
 			labels, quotaDetails, err := detector.DetectLabels(ctx, "Node", "worker-node", "", nil)
 			Expect(err).NotTo(HaveOccurred())

--- a/test/unit/kubernautagent/enrichment/detected_labels_test.go
+++ b/test/unit/kubernautagent/enrichment/detected_labels_test.go
@@ -22,6 +22,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/go-logr/logr"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -67,7 +68,7 @@ var _ = Describe("Detected Labels Detection — TP-433-PARITY (#433)", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			detector = enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector = enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 			ctx = context.Background()
 
 			ownerChain := []enrichment.OwnerChainEntry{
@@ -108,7 +109,7 @@ var _ = Describe("Detected Labels Detection — TP-433-PARITY (#433)", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy, hpa)
-			detector = enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector = enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 			ctx = context.Background()
 
 			ownerChain := []enrichment.OwnerChainEntry{
@@ -155,7 +156,7 @@ var _ = Describe("Detected Labels Detection — TP-433-PARITY (#433)", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy, pdb)
-			detector = enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector = enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 			ctx = context.Background()
 
 			ownerChain := []enrichment.OwnerChainEntry{
@@ -185,7 +186,7 @@ var _ = Describe("Detected Labels Detection — TP-433-PARITY (#433)", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			detector = enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector = enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 			ctx = context.Background()
 
 			ownerChain := []enrichment.OwnerChainEntry{
@@ -261,7 +262,7 @@ var _ = Describe("Detected Labels Detection — TP-433-PARITY (#433)", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy, hpa, pdb, netpol, quota)
-			detector = enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector = enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 			ctx = context.Background()
 
 			ownerChain := []enrichment.OwnerChainEntry{
@@ -296,7 +297,7 @@ var _ = Describe("Detected Labels Detection — TP-433-PARITY (#433)", func() {
 			}
 
 			dynClient := dynamicfake.NewSimpleDynamicClient(scheme, deploy)
-			detector = enrichment.NewLabelDetector(dynClient, newTestMapper())
+			detector = enrichment.NewLabelDetector(dynClient, newTestMapper(), logr.Discard())
 			ctx = context.Background()
 
 			ownerChain := []enrichment.OwnerChainEntry{

--- a/test/unit/kubernautagent/enrichment/ds_adapter_test.go
+++ b/test/unit/kubernautagent/enrichment/ds_adapter_test.go
@@ -75,8 +75,8 @@ var _ = Describe("DataStorage Adapter — TP-433-WIR Phase 1a", func() {
 							{
 								RemediationUID:     "wf-old-001",
 								Outcome:            ogenclient.NewOptString("Failed"),
-								SignalType:          ogenclient.NewOptString("HighCPU"),
-								ActionType:          ogenclient.NewOptNilString("restart_pod"),
+								SignalType:         ogenclient.NewOptString("HighCPU"),
+								ActionType:         ogenclient.NewOptNilString("restart_pod"),
 								EffectivenessScore: ogenclient.OptNilFloat64{Value: 0.2, Set: true},
 								CompletedAt:        time.Date(2026, 1, 15, 8, 0, 0, 0, time.UTC),
 							},

--- a/test/unit/kubernautagent/enrichment/enricher_retry_test.go
+++ b/test/unit/kubernautagent/enrichment/enricher_retry_test.go
@@ -19,13 +19,13 @@ package enrichment_test
 import (
 	"context"
 	"fmt"
-	"log/slog"
-	"os"
 	"sync/atomic"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
 
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -67,14 +67,13 @@ func (c *countingK8sClient) CallCount() int {
 
 var _ = Describe("Enricher Retry Infrastructure — BR-HAPI-261/264 #704", func() {
 	var (
-		logger     *slog.Logger
+		logger     = logr.Discard()
 		auditStore *recordingAuditStore
 		ds         *fakeDataStorageClient
 		ctx        context.Context
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 		auditStore = &recordingAuditStore{}
 		ds = &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
 		ctx = context.Background()

--- a/test/unit/kubernautagent/enrichment/enrichment_test.go
+++ b/test/unit/kubernautagent/enrichment/enrichment_test.go
@@ -20,13 +20,12 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"log/slog"
-	"os"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/go-logr/logr"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
 )
@@ -211,12 +210,11 @@ var _ = Describe("Kubernaut Agent Enrichment — #433", func() {
 var _ = Describe("Kubernaut Agent Enricher Coordination — #433 (reclassified from IT)", func() {
 
 	var (
-		logger     *slog.Logger
+		logger     = logr.Discard()
 		auditStore *recordingAuditStore
 	)
 
 	BeforeEach(func() {
-		logger = slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
 		auditStore = &recordingAuditStore{}
 	})
 

--- a/test/unit/kubernautagent/enrichment/k8s_adapter_test.go
+++ b/test/unit/kubernautagent/enrichment/k8s_adapter_test.go
@@ -335,8 +335,8 @@ var _ = Describe("UT-KA-704-MAPPER: RESTMapper refresh for CRDs installed after 
 // a CRD after Reset(). The first lookup for "certificates" fails; after
 // registerCertificate() + Reset() it succeeds.
 type lateRegistrationMapper struct {
-	delegate     *meta.DefaultRESTMapper
-	certAdded    bool
+	delegate  *meta.DefaultRESTMapper
+	certAdded bool
 }
 
 func (m *lateRegistrationMapper) Reset() {

--- a/test/unit/kubernautagent/enrichment/resource_context_test.go
+++ b/test/unit/kubernautagent/enrichment/resource_context_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -50,7 +51,7 @@ var _ = Describe("Kubernaut Agent Resource Context — #433 (reclassified from I
 			}
 
 			reg := registry.New()
-			reg.Register(custom.NewNamespacedResourceContextTool(ds, k8s))
+			reg.Register(custom.NewNamespacedResourceContextTool(ds, k8s, logr.Discard()))
 
 			result, err := reg.Execute(context.Background(), "get_namespaced_resource_context",
 				json.RawMessage(`{"kind":"Pod","name":"api-server-abc-xyz","namespace":"production"}`))
@@ -83,7 +84,7 @@ var _ = Describe("Kubernaut Agent Resource Context — #433 (reclassified from I
 			ds := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
 
 			reg := registry.New()
-			reg.Register(custom.NewNamespacedResourceContextTool(ds, k8s))
+			reg.Register(custom.NewNamespacedResourceContextTool(ds, k8s, logr.Discard()))
 
 			result, err := reg.Execute(context.Background(), "get_namespaced_resource_context",
 				json.RawMessage(`{"kind":"StatefulSet","name":"redis-ss","namespace":"default"}`))
@@ -111,7 +112,7 @@ var _ = Describe("Kubernaut Agent Resource Context — #433 (reclassified from I
 			}
 
 			reg := registry.New()
-			reg.Register(custom.NewClusterResourceContextTool(ds, k8s))
+			reg.Register(custom.NewClusterResourceContextTool(ds, k8s, logr.Discard()))
 
 			result, err := reg.Execute(context.Background(), "get_cluster_resource_context",
 				json.RawMessage(`{"kind":"Node","name":"worker-1"}`))

--- a/test/unit/kubernautagent/enrichment/scope_aware_test.go
+++ b/test/unit/kubernautagent/enrichment/scope_aware_test.go
@@ -22,6 +22,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/go-logr/logr"
+
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -154,16 +156,16 @@ var _ = Describe("TP-762: Scope-Aware LabelDetector (#762)", func() {
 
 			dynClient := fakedynamic.NewSimpleDynamicClientWithCustomListKinds(scheme,
 				map[schema.GroupVersionResource]string{
-					{Group: "", Version: "v1", Resource: "nodes"}:                                          "NodeList",
-					{Group: "autoscaling", Version: "v2", Resource: "horizontalpodautoscalers"}:             "HorizontalPodAutoscalerList",
-					{Group: "policy", Version: "v1", Resource: "poddisruptionbudgets"}:                     "PodDisruptionBudgetList",
-					{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}:                "NetworkPolicyList",
-					{Group: "", Version: "v1", Resource: "resourcequotas"}:                                  "ResourceQuotaList",
+					{Group: "", Version: "v1", Resource: "nodes"}:                               "NodeList",
+					{Group: "autoscaling", Version: "v2", Resource: "horizontalpodautoscalers"}: "HorizontalPodAutoscalerList",
+					{Group: "policy", Version: "v1", Resource: "poddisruptionbudgets"}:          "PodDisruptionBudgetList",
+					{Group: "networking.k8s.io", Version: "v1", Resource: "networkpolicies"}:    "NetworkPolicyList",
+					{Group: "", Version: "v1", Resource: "resourcequotas"}:                      "ResourceQuotaList",
 				}, node)
 			mapper := newSimpleRESTMapper()
 			addLabelDetectorKinds(mapper)
 
-			ld := enrichment.NewLabelDetector(dynClient, mapper)
+			ld := enrichment.NewLabelDetector(dynClient, mapper, logr.Discard())
 			labels, _, err := ld.DetectLabels(context.Background(), "Node", "worker-1", "kube-system", nil)
 			Expect(err).NotTo(HaveOccurred(),
 				"UT-KA-762-005: LabelDetector must fetch Node using cluster-scoped client")
@@ -183,7 +185,7 @@ var _ = Describe("TP-762: Scope-Aware LabelDetector (#762)", func() {
 			mapper := newSimpleRESTMapper()
 			addLabelDetectorKinds(mapper)
 
-			ld := enrichment.NewLabelDetector(dynClient, mapper)
+			ld := enrichment.NewLabelDetector(dynClient, mapper, logr.Discard())
 			labels, _, err := ld.DetectLabels(context.Background(), "Node", "worker-1", "", nil)
 			Expect(err).NotTo(HaveOccurred(),
 				"UT-KA-762-006: should not error when namespace is empty")

--- a/test/unit/kubernautagent/investigator/audit_completeness_test.go
+++ b/test/unit/kubernautagent/investigator/audit_completeness_test.go
@@ -19,9 +19,10 @@ package investigator_test
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
 	"strings"
 	"sync"
+
+	"github.com/go-logr/logr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -129,7 +130,7 @@ var _ = Describe("Phase 0: Audit Completeness — #592", func() {
 				Builder:      builder,
 				ResultParser: parser.NewResultParser(),
 				AuditStore:   capStore,
-				Logger:       slog.Default(),
+				Logger:       logr.Discard(),
 				MaxTurns:     5,
 				ModelName:    "test-model",
 			})
@@ -181,7 +182,7 @@ var _ = Describe("Phase 0: Audit Completeness — #592", func() {
 				Builder:      builder,
 				ResultParser: parser.NewResultParser(),
 				AuditStore:   capStore,
-				Logger:       slog.Default(),
+				Logger:       logr.Discard(),
 				MaxTurns:     5,
 				ModelName:    "test-model",
 			})
@@ -247,7 +248,7 @@ var _ = Describe("Phase 0: Audit Completeness — #592", func() {
 				Builder:      builder,
 				ResultParser: parser.NewResultParser(),
 				AuditStore:   capStore,
-				Logger:       slog.Default(),
+				Logger:       logr.Discard(),
 				MaxTurns:     5,
 				ModelName:    "test-model",
 			})
@@ -313,7 +314,7 @@ var _ = Describe("Phase 0: Audit Completeness — #592", func() {
 				Builder:      builder,
 				ResultParser: parser.NewResultParser(),
 				AuditStore:   capStore,
-				Logger:       slog.Default(),
+				Logger:       logr.Discard(),
 				MaxTurns:     5,
 				ModelName:    "test-model",
 			})

--- a/test/unit/kubernautagent/investigator/wiring_test.go
+++ b/test/unit/kubernautagent/investigator/wiring_test.go
@@ -19,7 +19,8 @@ package investigator_test
 import (
 	"context"
 	"fmt"
-	"log/slog"
+
+	"github.com/go-logr/logr"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -80,7 +81,7 @@ var _ = Describe("TP-433-ADV P1: Critical Wiring — GAP-006/GAP-007", func() {
 
 			cfg := investigator.Config{
 				Client: instrumented,
-				Logger: slog.Default(),
+				Logger: logr.Discard(),
 			}
 			inv := investigator.New(cfg)
 			Expect(inv).NotTo(BeNil(),

--- a/test/unit/kubernautagent/server/adversarial_http_test.go
+++ b/test/unit/kubernautagent/server/adversarial_http_test.go
@@ -19,12 +19,12 @@ package server_test
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/go-logr/logr"
 	"github.com/jordigilh/kubernaut/pkg/agentclient"
 
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/server"
@@ -38,14 +38,12 @@ var _ = Describe("TP-433-ADV P6: HTTP Contract — GAP-004/015/016/018", func() 
 		store   *session.Store
 		manager *session.Manager
 		handler *server.Handler
-		logger  *slog.Logger
 	)
 
 	BeforeEach(func() {
 		store = session.NewStore(5 * time.Minute)
-		logger = slog.Default()
-		manager = session.NewManager(store, logger)
-		handler = server.NewHandler(manager, nil, logger)
+		manager = session.NewManager(store, logr.Discard())
+		handler = server.NewHandler(manager, nil, logr.Discard())
 	})
 
 	Describe("UT-KA-433-HTTP-001: Error response has RFC 7807 fields (GAP-004)", func() {

--- a/test/unit/kubernautagent/server/response_mapper_test.go
+++ b/test/unit/kubernautagent/server/response_mapper_test.go
@@ -18,12 +18,12 @@ package server_test
 
 import (
 	"context"
-	"log/slog"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/go-logr/logr"
 	"github.com/jordigilh/kubernaut/pkg/agentclient"
 
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/server"
@@ -37,14 +37,12 @@ var _ = Describe("Response Mapper — #433", func() {
 		store   *session.Store
 		manager *session.Manager
 		handler *server.Handler
-		logger  *slog.Logger
 	)
 
 	BeforeEach(func() {
 		store = session.NewStore(5 * time.Minute)
-		logger = slog.Default()
-		manager = session.NewManager(store, logger)
-		handler = server.NewHandler(manager, nil, logger)
+		manager = session.NewManager(store, logr.Discard())
+		handler = server.NewHandler(manager, nil, logr.Discard())
 	})
 
 	Describe("UT-KA-433-MAPPER-001: IncidentID is populated from session metadata", func() {

--- a/test/unit/kubernautagent/session/metadata_test.go
+++ b/test/unit/kubernautagent/session/metadata_test.go
@@ -18,12 +18,12 @@ package session_test
 
 import (
 	"context"
-	"log/slog"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/go-logr/logr"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
 )
 
@@ -32,7 +32,7 @@ var _ = Describe("Session Metadata — #433", func() {
 	Describe("UT-KA-433-METADATA-001: StartInvestigation propagates metadata to session", func() {
 		It("should store metadata on the session and make it retrievable", func() {
 			store := session.NewStore(5 * time.Minute)
-			manager := session.NewManager(store, slog.Default())
+			manager := session.NewManager(store, logr.Discard())
 
 			metadata := map[string]string{
 				"incident_id": "e2e-ka-001-oom",
@@ -55,7 +55,7 @@ var _ = Describe("Session Metadata — #433", func() {
 	Describe("UT-KA-433-METADATA-002: Metadata persists after investigation completes", func() {
 		It("should retain metadata on a completed session", func() {
 			store := session.NewStore(5 * time.Minute)
-			manager := session.NewManager(store, slog.Default())
+			manager := session.NewManager(store, logr.Discard())
 
 			metadata := map[string]string{
 				"incident_id": "e2e-ka-002-crash",
@@ -84,7 +84,7 @@ var _ = Describe("Session Metadata — #433", func() {
 	Describe("UT-KA-433-METADATA-003: Nil metadata does not cause issues", func() {
 		It("should handle nil metadata gracefully", func() {
 			store := session.NewStore(5 * time.Minute)
-			manager := session.NewManager(store, slog.Default())
+			manager := session.NewManager(store, logr.Discard())
 
 			id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (interface{}, error) {
 				return "result", nil

--- a/test/unit/kubernautagent/tools/custom/resource_context_test.go
+++ b/test/unit/kubernautagent/tools/custom/resource_context_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"errors"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -75,7 +76,7 @@ var _ = Describe("Kubernaut Agent Resource Context Tools — #433", func() {
 			}}
 			ds := &fakeDS{history: &enrichment.RemediationHistoryResult{}}
 
-			tool := custom.NewNamespacedResourceContextTool(ds, k8s)
+			tool := custom.NewNamespacedResourceContextTool(ds, k8s, logr.Discard())
 			result, err := tool.Execute(context.Background(),
 				json.RawMessage(`{"kind":"Pod","name":"api-server-abc-xyz","namespace":"production"}`))
 			Expect(err).NotTo(HaveOccurred())
@@ -94,7 +95,7 @@ var _ = Describe("Kubernaut Agent Resource Context Tools — #433", func() {
 			k8s := &fakeK8s{chain: nil}
 			ds := &fakeDS{history: &enrichment.RemediationHistoryResult{}}
 
-			tool := custom.NewNamespacedResourceContextTool(ds, k8s)
+			tool := custom.NewNamespacedResourceContextTool(ds, k8s, logr.Discard())
 			result, err := tool.Execute(context.Background(),
 				json.RawMessage(`{"kind":"Pod","name":"orphan-pod","namespace":"default"}`))
 			Expect(err).NotTo(HaveOccurred())
@@ -120,7 +121,7 @@ var _ = Describe("Kubernaut Agent Resource Context Tools — #433", func() {
 				},
 			}}
 
-			tool := custom.NewNamespacedResourceContextTool(ds, k8s)
+			tool := custom.NewNamespacedResourceContextTool(ds, k8s, logr.Discard())
 			result, err := tool.Execute(context.Background(),
 				json.RawMessage(`{"kind":"Pod","name":"web","namespace":"prod"}`))
 			Expect(err).NotTo(HaveOccurred())
@@ -139,7 +140,7 @@ var _ = Describe("Kubernaut Agent Resource Context Tools — #433", func() {
 			k8s := &fakeK8s{chain: nil}
 			ds := &fakeDS{history: nil}
 
-			tool := custom.NewNamespacedResourceContextTool(ds, k8s)
+			tool := custom.NewNamespacedResourceContextTool(ds, k8s, logr.Discard())
 			result, err := tool.Execute(context.Background(),
 				json.RawMessage(`{"kind":"Pod","name":"web","namespace":"default"}`))
 			Expect(err).NotTo(HaveOccurred())
@@ -154,7 +155,7 @@ var _ = Describe("Kubernaut Agent Resource Context Tools — #433", func() {
 		It("should return a non-nil parameter schema with required kind/name/namespace", func() {
 			k8s := &fakeK8s{}
 			ds := &fakeDS{}
-			tool := custom.NewNamespacedResourceContextTool(ds, k8s)
+			tool := custom.NewNamespacedResourceContextTool(ds, k8s, logr.Discard())
 
 			Expect(tool.Name()).To(Equal("get_namespaced_resource_context"))
 			Expect(tool.Description()).NotTo(BeEmpty())
@@ -179,7 +180,7 @@ var _ = Describe("Kubernaut Agent Resource Context Tools — #433", func() {
 			k8s := &fakeK8s{}
 			ds := &fakeDS{history: &enrichment.RemediationHistoryResult{}}
 
-			tool := custom.NewClusterResourceContextTool(ds, k8s)
+			tool := custom.NewClusterResourceContextTool(ds, k8s, logr.Discard())
 			result, err := tool.Execute(context.Background(),
 				json.RawMessage(`{"kind":"Node","name":"worker-1"}`))
 			Expect(err).NotTo(HaveOccurred())
@@ -204,7 +205,7 @@ var _ = Describe("Kubernaut Agent Resource Context Tools — #433", func() {
 				},
 			}}
 
-			tool := custom.NewClusterResourceContextTool(ds, k8s)
+			tool := custom.NewClusterResourceContextTool(ds, k8s, logr.Discard())
 			result, err := tool.Execute(context.Background(),
 				json.RawMessage(`{"kind":"Node","name":"worker-1"}`))
 			Expect(err).NotTo(HaveOccurred())
@@ -224,7 +225,7 @@ var _ = Describe("Kubernaut Agent Resource Context Tools — #433", func() {
 		It("should return a non-nil parameter schema with required kind/name", func() {
 			k8s := &fakeK8s{}
 			ds := &fakeDS{}
-			tool := custom.NewClusterResourceContextTool(ds, k8s)
+			tool := custom.NewClusterResourceContextTool(ds, k8s, logr.Discard())
 
 			Expect(tool.Name()).To(Equal("get_cluster_resource_context"))
 			Expect(tool.Description()).NotTo(BeEmpty())
@@ -249,7 +250,7 @@ var _ = Describe("Kubernaut Agent Resource Context Tools — #433", func() {
 			k8s := &fakeK8s{}
 			ds := &fakeDS{history: nil}
 
-			tool := custom.NewClusterResourceContextTool(ds, k8s)
+			tool := custom.NewClusterResourceContextTool(ds, k8s, logr.Discard())
 			result, err := tool.Execute(context.Background(),
 				json.RawMessage(`{"kind":"Namespace","name":"kube-system"}`))
 			Expect(err).NotTo(HaveOccurred())
@@ -280,7 +281,7 @@ var _ = Describe("Kubernaut Agent Resource Context Tools — #433", func() {
 			}
 			ds := &fakeDS{history: &enrichment.RemediationHistoryResult{}}
 
-			tool := custom.NewNamespacedResourceContextTool(ds, k8s)
+			tool := custom.NewNamespacedResourceContextTool(ds, k8s, logr.Discard())
 			_, err := tool.Execute(context.Background(),
 				json.RawMessage(`{"kind":"Pod","name":"api-server-abc-xyz","namespace":"production"}`))
 			Expect(err).NotTo(HaveOccurred())
@@ -300,7 +301,7 @@ var _ = Describe("Kubernaut Agent Resource Context Tools — #433", func() {
 			}
 			ds := &fakeDS{history: &enrichment.RemediationHistoryResult{}}
 
-			tool := custom.NewNamespacedResourceContextTool(ds, k8s)
+			tool := custom.NewNamespacedResourceContextTool(ds, k8s, logr.Discard())
 			_, err := tool.Execute(context.Background(),
 				json.RawMessage(`{"kind":"Pod","name":"orphan-pod","namespace":"default"}`))
 			Expect(err).NotTo(HaveOccurred())
@@ -320,7 +321,7 @@ var _ = Describe("Kubernaut Agent Resource Context Tools — #433", func() {
 			}
 			ds := &fakeDS{history: &enrichment.RemediationHistoryResult{}}
 
-			tool := custom.NewNamespacedResourceContextTool(ds, k8s)
+			tool := custom.NewNamespacedResourceContextTool(ds, k8s, logr.Discard())
 			result, err := tool.Execute(context.Background(),
 				json.RawMessage(`{"kind":"CustomResource","name":"my-cr","namespace":"test"}`))
 			Expect(err).NotTo(HaveOccurred())
@@ -334,7 +335,7 @@ var _ = Describe("Kubernaut Agent Resource Context Tools — #433", func() {
 			k8s := &fakeK8s{specHash: "node-hash-abc"}
 			ds := &fakeDS{history: &enrichment.RemediationHistoryResult{}}
 
-			tool := custom.NewClusterResourceContextTool(ds, k8s)
+			tool := custom.NewClusterResourceContextTool(ds, k8s, logr.Discard())
 			_, err := tool.Execute(context.Background(),
 				json.RawMessage(`{"kind":"Node","name":"worker-1"}`))
 			Expect(err).NotTo(HaveOccurred())
@@ -351,7 +352,7 @@ var _ = Describe("Kubernaut Agent Resource Context Tools — #433", func() {
 			k8s := &fakeK8s{specHashErr: errors.New("node not found")}
 			ds := &fakeDS{history: &enrichment.RemediationHistoryResult{}}
 
-			tool := custom.NewClusterResourceContextTool(ds, k8s)
+			tool := custom.NewClusterResourceContextTool(ds, k8s, logr.Discard())
 			result, err := tool.Execute(context.Background(),
 				json.RawMessage(`{"kind":"Node","name":"missing-node"}`))
 			Expect(err).NotTo(HaveOccurred())

--- a/test/unit/kubernautagent/tools/mcp/mcp_test.go
+++ b/test/unit/kubernautagent/tools/mcp/mcp_test.go
@@ -19,9 +19,8 @@ package mcp_test
 import (
 	"context"
 	"encoding/json"
-	"log/slog"
-	"os"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -47,8 +46,8 @@ var _ = Describe("MCP Skeleton — #433, Option C", func() {
 	})
 
 	Describe("UT-KA-433-011: MCP stub provider returns empty tool list", func() {
-		It("should return an empty slice and log a warning", func() {
-			logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+		It("should return an empty slice and log at info level", func() {
+			logger := logr.Discard()
 			provider := mcp.NewStubProvider(logger)
 
 			tools, err := provider.DiscoverTools(context.Background())


### PR DESCRIPTION
## Summary

- Migrates all Kubernaut Agent code from `log/slog` to `github.com/go-logr/logr` (backed by zap via zapr), aligning KA with the authoritative logging standard DD-005
- Removes the `SlogLevel()` bridge method from `internal/config/logging.go` — no longer needed
- Updates `LOGGING_STANDARD.md` to reflect all 10 services are now fully migrated

## Changes

**Production code (19 files):**
- `cmd/kubernautagent/main.go`: bootstrap via `kubelog.NewLoggerWithAtomicLevel`, single `logr.Logger` replaces dual `slogger`/`logrLogger` variables
- `internal/kubernautagent/{alignment,audit,credentials,enrichment,investigator,server,session}`: `*slog.Logger` → `logr.Logger` in all structs, constructors, and method calls
- `pkg/kubernautagent/{llm,tools}`: slog → logr for transport auth headers, LLM client, MCP stub, and custom resource context tools
- `internal/config/logging.go`: removed `SlogLevel()` bridge and `log/slog` import

**Test code (~41 files):**
- Replaced `logr.FromSlogHandler(slog.New(...))` bridge pattern with `logr.Discard()`
- Updated constructor calls for new `logr.Logger` parameter signatures

**Documentation (1 file):**
- `LOGGING_STANDARD.md`: KA row updated to `pkg/log (kubelog)` with status `Done (Issue #935)`, 10/10 services migrated

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] All 86 unit test packages pass (`go test ./test/unit/... -count=1`)
- [ ] CI: unit tests
- [ ] CI: integration tests
- [ ] CI: E2E tests

Closes #935


Made with [Cursor](https://cursor.com)