### PR TITLE
fix(e2e): use UUID for test namespace to prevent deletion race flake

### DIFF
--- a/test/e2e/kubernautagent/detected_labels_e2e_test.go
+++ b/test/e2e/kubernautagent/detected_labels_e2e_test.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -68,7 +69,7 @@ var _ = Describe("E2E-KA ADR-056 DetectedLabels", Label("e2e", "ka", "adr-056", 
 		Expect(err).NotTo(HaveOccurred(), "Failed to create K8s clientset")
 
 		// Create unique test namespace
-		testNS = fmt.Sprintf("adr056-e2e-%d", time.Now().UnixNano()%100000)
+		testNS = fmt.Sprintf("adr056-e2e-%s", uuid.New().String()[:8])
 		deployName = "test-app"
 
 		ns := &corev1.Namespace{


### PR DESCRIPTION
## Summary

- Replace time-based namespace suffix (`UnixNano%100000`) with UUID in `detected_labels_e2e_test.go` to eliminate namespace collision flakes

## Root cause

The E2E test `E2E-KA-056-003` intermittently fails with `object is being deleted: namespaces "adr056-e2e-NNNNN" already exists` when the previous test's namespace finalizer hasn't completed before the next test tries to create a namespace with the same generated name. The modulus-based suffix (`%100000`) has high collision probability across fast sequential test runs.

## Fix

Use `uuid.New().String()[:8]` for namespace naming, consistent with other E2E test suites across the project.

## Test plan

- [x] `go build ./test/e2e/kubernautagent/...` compiles
- [ ] CI: E2E kubernautagent suite passes without namespace flake


Made with [Cursor](https://cursor.com)