### PR TITLE
fix(audit): always set tool_result on LLMToolCallPayload (#929)

### DIFF
--- a/internal/kubernautagent/audit/ds_store.go
+++ b/internal/kubernautagent/audit/ds_store.go
@@ -146,9 +146,7 @@ func buildEventData(event *AuditEvent) (ogenclient.AuditEventRequestEventData, b
 		if args := dataString(event.Data, "tool_arguments"); args != "" {
 			payload.ToolArguments.SetTo(toJxRawMap(args))
 		}
-		if result := dataString(event.Data, "tool_result"); result != "" {
-			payload.ToolResult = toJxRaw(result)
-		}
+		payload.ToolResult = toJxRaw(dataString(event.Data, "tool_result"))
 		if preview := dataString(event.Data, "tool_result_preview"); preview != "" {
 			payload.ToolResultPreview.SetTo(truncate(preview, previewMaxLen))
 		}

--- a/test/unit/kubernautagent/audit/ds_store_audit_parity_test.go
+++ b/test/unit/kubernautagent/audit/ds_store_audit_parity_test.go
@@ -268,6 +268,28 @@ var _ = Describe("KA Audit Parity — TP-433-AUDIT-SOC2", func() {
 		})
 	})
 
+	Describe("UT-KA-929-001: tool_result is required even when tool returns empty string (#929)", func() {
+		It("should include tool_result in payload when tool_result is empty", func() {
+			recorder := &fakeOgenClient{}
+			store := audit.NewDSAuditStore(recorder)
+
+			event := audit.NewEvent(audit.EventTypeLLMToolCall, "corr-929")
+			event.Data["tool_call_index"] = 1
+			event.Data["tool_name"] = "kubectl_logs"
+			event.Data["tool_arguments"] = `{"name":"log-collector"}`
+			event.Data["tool_result"] = ""
+			event.Data["tool_result_preview"] = ""
+
+			err := store.StoreAudit(context.Background(), event)
+			Expect(err).NotTo(HaveOccurred())
+
+			payload, ok := recorder.calls[0].EventData.GetLLMToolCallPayload()
+			Expect(ok).To(BeTrue())
+			Expect(payload.ToolResult).NotTo(BeNil(), "tool_result must be present (required by OpenAPI schema)")
+			Expect(payload.ToolResult).NotTo(BeEmpty(), "tool_result must not be empty jx.Raw")
+		})
+	})
+
 	// --- Phase 5: Response Failed ---
 
 	Describe("UT-KA-433-AP-011: buildEventData maps AIAgentResponseFailedPayload", func() {


### PR DESCRIPTION
## Summary

- **Fixes #929**: `aiagent.llm.tool_call` audit events were emitted without the `tool_result` field when a tool returned an empty string, causing OpenAPI validation failures in Data Storage.
- **Root cause**: Conditional `if result != ""` guard in `ds_store.go` prevented the required field from being set.
- **Fix**: Remove the guard so `tool_result` is unconditionally populated, satisfying the OpenAPI schema's `required` constraint.
- **Regression test**: `UT-KA-929-001` asserts `tool_result` is present even with empty tool output.

## Test plan

- [x] RED: New test `UT-KA-929-001` fails before fix (tool_result is nil)
- [x] GREEN: Test passes after removing the if-guard
- [x] Full audit test suite (61/61) passes
- [x] `go build ./...` clean
- [x] `go vet` clean


Made with [Cursor](https://cursor.com)