### PR TITLE
fix(ka): P0 QE-readiness audit — alignment audit, synthetic events, shadow sanitization, config wiring

### DIFF
--- a/api/openapi/data-storage-v1.yaml
+++ b/api/openapi/data-storage-v1.yaml
@@ -2465,6 +2465,8 @@ components:
             - $ref: '#/components/schemas/LLMResponsePayload'
             - $ref: '#/components/schemas/LLMToolCallPayload'
             - $ref: '#/components/schemas/WorkflowValidationPayload'
+            - $ref: '#/components/schemas/AlignmentStepPayload'
+            - $ref: '#/components/schemas/AlignmentVerdictPayload'
             - $ref: '#/components/schemas/RemediationRequestWebhookAuditPayload'
             - $ref: '#/components/schemas/RemediationWorkflowWebhookAuditPayload'
             - $ref: '#/components/schemas/EffectivenessAssessmentAuditPayload'
@@ -2545,6 +2547,8 @@ components:
               'aiagent.llm.response': '#/components/schemas/LLMResponsePayload'
               'aiagent.llm.tool_call': '#/components/schemas/LLMToolCallPayload'
               'aiagent.workflow.validation_attempt': '#/components/schemas/WorkflowValidationPayload'
+              'aiagent.alignment.step': '#/components/schemas/AlignmentStepPayload'
+              'aiagent.alignment.verdict': '#/components/schemas/AlignmentVerdictPayload'
               'effectiveness.health.assessed': '#/components/schemas/EffectivenessAssessmentAuditPayload'
               'effectiveness.hash.computed': '#/components/schemas/EffectivenessAssessmentAuditPayload'
               'effectiveness.alert.assessed': '#/components/schemas/EffectivenessAssessmentAuditPayload'
@@ -5592,6 +5596,66 @@ components:
           type: boolean
           default: false
           description: Whether this is the final validation attempt
+
+    AlignmentStepPayload:
+      type: object
+      required: [event_type, event_id, incident_id, step_index, step_kind]
+      description: Shadow agent alignment check step payload (aiagent.alignment.step). Emitted for each step flagged as suspicious during shadow evaluation.
+      properties:
+        event_type:
+          type: string
+          enum: ['aiagent.alignment.step']
+          description: Event type for discriminator (matches parent event_type)
+        event_id:
+          type: string
+          description: Unique event identifier
+        incident_id:
+          type: string
+          description: Incident correlation ID (signal name)
+        step_index:
+          type: integer
+          minimum: 0
+          description: Index of the suspicious step in the investigation trace
+        step_kind:
+          type: string
+          description: Kind of step (e.g., tool_result, llm_reasoning)
+        tool:
+          type: string
+          description: Tool name used in the step (empty for non-tool steps)
+        explanation:
+          type: string
+          description: Sanitized explanation of why the step was flagged
+
+    AlignmentVerdictPayload:
+      type: object
+      required: [event_type, event_id, incident_id, result, flagged, total]
+      description: Shadow agent alignment verdict payload (aiagent.alignment.verdict). Emitted once per investigation after full shadow evaluation completes.
+      properties:
+        event_type:
+          type: string
+          enum: ['aiagent.alignment.verdict']
+          description: Event type for discriminator (matches parent event_type)
+        event_id:
+          type: string
+          description: Unique event identifier
+        incident_id:
+          type: string
+          description: Incident correlation ID (signal name)
+        result:
+          type: string
+          enum: ['aligned', 'suspicious']
+          description: Overall alignment verdict
+        summary:
+          type: string
+          description: Free-text summary of the shadow evaluation
+        flagged:
+          type: integer
+          minimum: 0
+          description: Number of steps flagged as suspicious
+        total:
+          type: integer
+          minimum: 0
+          description: Total number of steps evaluated
 
     # ─── Remediation History Context (DD-HAPI-016) ───
 

--- a/cmd/kubernautagent/llm_builder.go
+++ b/cmd/kubernautagent/llm_builder.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/go-logr/logr"
 
@@ -64,7 +65,11 @@ func buildLLMProviderOpts(cfg *kaconfig.Config, rt *kaconfig.LLMRuntimeConfig) [
 	}
 
 	if transport := buildTransportChain(cfg, rt); transport != nil {
-		opts = append(opts, langchaingo.WithHTTPClient(&http.Client{Transport: transport}))
+		httpClient := &http.Client{Transport: transport}
+		if rt.TimeoutSeconds > 0 {
+			httpClient.Timeout = time.Duration(rt.TimeoutSeconds) * time.Second
+		}
+		opts = append(opts, langchaingo.WithHTTPClient(httpClient))
 		opts = append(opts, langchaingo.WithCloser(func() error {
 			if t, ok := transport.(interface{ CloseIdleConnections() }); ok {
 				t.CloseIdleConnections()
@@ -147,7 +152,11 @@ func llmRuntimeReloadCallback(
 			return fmt.Errorf("reload: building LLM client: %w", err)
 		}
 
-		if err := swappable.Swap(newClient, rt.Model); err != nil {
+		if err := swappable.Swap(newClient, rt.Model, llm.RuntimeParams{
+			Temperature:    rt.Temperature,
+			TimeoutSeconds: rt.TimeoutSeconds,
+			MaxRetries:     rt.MaxRetries,
+		}); err != nil {
 			logger.Error(err, "llm_runtime_reload failed: swap error",
 				"event", "llm_runtime_reload", "status", "error")
 			return fmt.Errorf("reload: swapping client: %w", err)

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -158,7 +158,11 @@ func main() {
 		os.Exit(1)
 	}
 
-	swappable, err := llm.NewSwappableClient(llmClient, llmRuntime.Model)
+	swappable, err := llm.NewSwappableClient(llmClient, llmRuntime.Model, llm.RuntimeParams{
+		Temperature:    llmRuntime.Temperature,
+		TimeoutSeconds: llmRuntime.TimeoutSeconds,
+		MaxRetries:     llmRuntime.MaxRetries,
+	})
 	if err != nil {
 		logger.Error(err, "failed to create swappable LLM client")
 		os.Exit(1)

--- a/internal/kubernautagent/alignment/toolproxy.go
+++ b/internal/kubernautagent/alignment/toolproxy.go
@@ -40,29 +40,28 @@ func NewToolProxy(inner registry.ToolRegistry) *ToolProxy {
 	return &ToolProxy{inner: inner}
 }
 
-// Execute delegates to the inner registry, then submits the result (or error)
-// for alignment evaluation via the context-scoped Observer.
-// Error content is also submitted: injection can occur in error paths.
+// Execute delegates to the inner registry. Shadow observation is handled
+// post-pipeline by the investigator (SubmitToolStep) so the shadow agent
+// evaluates the same sanitized, truncated output that the primary LLM sees.
 func (p *ToolProxy) Execute(ctx context.Context, name string, args json.RawMessage) (string, error) {
-	result, err := p.inner.Execute(ctx, name, args)
+	return p.inner.Execute(ctx, name, args)
+}
 
-	if obs := ObserverFromContext(ctx); obs != nil {
-		content := result
-		if err != nil {
-			content = err.Error()
-		}
-		if content != "" {
-			step := Step{
-				Index:   obs.NextStepIndex(),
-				Kind:    StepKindToolResult,
-				Tool:    name,
-				Content: content,
-			}
-			obs.SubmitAsync(ctx, step)
-		}
+// SubmitToolStep sends a post-pipeline tool result to the shadow agent for
+// alignment evaluation. Called by the investigator after sanitize/summarize/
+// truncate so the shadow evaluates the same content the primary LLM sees.
+func SubmitToolStep(ctx context.Context, name, content string) {
+	obs := ObserverFromContext(ctx)
+	if obs == nil || content == "" {
+		return
 	}
-
-	return result, err
+	step := Step{
+		Index:   obs.NextStepIndex(),
+		Kind:    StepKindToolResult,
+		Tool:    name,
+		Content: content,
+	}
+	obs.SubmitAsync(ctx, step)
 }
 
 // ToolsForPhase delegates directly to the inner registry.

--- a/internal/kubernautagent/audit/ds_store.go
+++ b/internal/kubernautagent/audit/ds_store.go
@@ -219,6 +219,36 @@ func buildEventData(event *AuditEvent) (ogenclient.AuditEventRequestEventData, b
 		}
 		return ogenclient.NewAIAgentResponseFailedPayloadAuditEventRequestEventData(payload), true
 
+	case EventTypeAlignmentStep:
+		payload := ogenclient.AlignmentStepPayload{
+			EventType:  ogenclient.AlignmentStepPayloadEventTypeAiagentAlignmentStep,
+			EventID:    dataString(event.Data, "event_id"),
+			IncidentID: event.CorrelationID,
+			StepIndex:  dataInt(event.Data, "step_index"),
+			StepKind:   dataString(event.Data, "step_kind"),
+		}
+		if tool := dataString(event.Data, "tool"); tool != "" {
+			payload.Tool.SetTo(tool)
+		}
+		if explanation := dataString(event.Data, "explanation"); explanation != "" {
+			payload.Explanation.SetTo(explanation)
+		}
+		return ogenclient.NewAlignmentStepPayloadAuditEventRequestEventData(payload), true
+
+	case EventTypeAlignmentVerdict:
+		payload := ogenclient.AlignmentVerdictPayload{
+			EventType:  ogenclient.AlignmentVerdictPayloadEventTypeAiagentAlignmentVerdict,
+			EventID:    dataString(event.Data, "event_id"),
+			IncidentID: event.CorrelationID,
+			Result:     ogenclient.AlignmentVerdictPayloadResult(dataString(event.Data, "result")),
+			Flagged:    dataInt(event.Data, "flagged"),
+			Total:      dataInt(event.Data, "total"),
+		}
+		if summary := dataString(event.Data, "summary"); summary != "" {
+			payload.Summary.SetTo(summary)
+		}
+		return ogenclient.NewAlignmentVerdictPayloadAuditEventRequestEventData(payload), true
+
 	default:
 		return ogenclient.AuditEventRequestEventData{}, false
 	}

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/alignment"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
@@ -196,14 +197,16 @@ func New(cfg Config) *Investigator {
 func (inv *Investigator) Investigate(ctx context.Context, signal katypes.SignalContext) (*katypes.InvestigationResult, error) {
 	inv.pipeline.AnomalyDetector.Reset()
 
-	// #783: Pin client and model name for the duration of this investigation.
-	// Subsequent hot-reload swaps do not affect an in-flight investigation.
+	// #783: Pin client, model name, and runtime params for the duration of
+	// this investigation. Subsequent hot-reload swaps do not affect in-flight work.
 	client := inv.client
 	modelName := inv.modelName
+	var runtimeParams llm.RuntimeParams
 	if inv.swappable != nil {
 		pinned := inv.swappable.Snapshot()
 		client = llm.NewInstrumentedClient(pinned)
 		modelName = inv.swappable.ModelName()
+		runtimeParams = inv.swappable.RuntimeParameters()
 	}
 
 	correlationID := signal.RemediationID
@@ -215,7 +218,7 @@ func (inv *Investigator) Investigate(ctx context.Context, signal katypes.SignalC
 	promptEnrichment := toPromptEnrichment(enrichData)
 	tokens := &TokenAccumulator{}
 
-	rcaResult, err := inv.runRCA(ctx, signal, promptEnrichment, tokens, correlationID, client, modelName)
+	rcaResult, err := inv.runRCA(ctx, signal, promptEnrichment, tokens, correlationID, client, modelName, runtimeParams)
 	if err != nil {
 		return nil, fmt.Errorf("RCA invocation: %w", err)
 	}
@@ -280,7 +283,7 @@ func (inv *Investigator) Investigate(ctx context.Context, signal katypes.SignalC
 
 	p1Ctx := BuildPhase1Context(rcaResult)
 
-	workflowResult, err := inv.runWorkflowSelection(ctx, workflowSignal, rcaResult.RCASummary, promptEnrichment, p1Ctx, tokens, correlationID, client, modelName)
+	workflowResult, err := inv.runWorkflowSelection(ctx, workflowSignal, rcaResult.RCASummary, promptEnrichment, p1Ctx, tokens, correlationID, client, modelName, runtimeParams)
 	if err != nil {
 		return nil, fmt.Errorf("workflow selection invocation: %w", err)
 	}
@@ -350,7 +353,7 @@ func (inv *Investigator) resolveEnrichment(ctx context.Context, kind, name, name
 	return result
 }
 
-func (inv *Investigator) runRCA(ctx context.Context, signal katypes.SignalContext, enrichData *prompt.EnrichmentData, tokens *TokenAccumulator, correlationID string, client llm.Client, modelName string) (*katypes.InvestigationResult, error) {
+func (inv *Investigator) runRCA(ctx context.Context, signal katypes.SignalContext, enrichData *prompt.EnrichmentData, tokens *TokenAccumulator, correlationID string, client llm.Client, modelName string, runtimeParams llm.RuntimeParams) (*katypes.InvestigationResult, error) {
 	systemPrompt, err := inv.builder.RenderInvestigation(signalToPrompt(signal))
 	if err != nil {
 		return nil, fmt.Errorf("rendering investigation prompt: %w", err)
@@ -361,7 +364,7 @@ func (inv *Investigator) runRCA(ctx context.Context, signal katypes.SignalContex
 		{Role: "user", Content: fmt.Sprintf("Investigate: %s %s in %s — %s", signal.Severity, signal.Name, signal.Namespace, signal.Message)},
 	}
 
-	loopRes, err := inv.runLLMLoop(ctx, messages, katypes.PhaseRCA, tokens, correlationID, client, modelName)
+	loopRes, err := inv.runLLMLoop(ctx, messages, katypes.PhaseRCA, tokens, correlationID, client, modelName, runtimeParams)
 	if err != nil {
 		return nil, err
 	}
@@ -456,6 +459,8 @@ CRITICAL: root_cause_analysis must be a JSON object, NOT a string. Do NOT wrap i
 		retryEvent.EventAction = audit.ActionLLMRequest
 		retryEvent.EventOutcome = audit.OutcomeSuccess
 		retryEvent.Data["model"] = modelName
+		retryEvent.Data["prompt_length"] = totalPromptLength(retryMessages)
+		retryEvent.Data["prompt_preview"] = lastUserMessage(retryMessages, 500)
 		retryEvent.Data["retry_attempt"] = attempt + 1
 		retryEvent.Data["retry_max"] = maxRCAParseRetries
 		retryEvent.Data["phase"] = string(katypes.PhaseRCA)
@@ -537,6 +542,9 @@ func (inv *Investigator) sameKindValidationGate(
 	gateEvent := audit.NewEvent(audit.EventTypeLLMRequest, correlationID)
 	gateEvent.EventAction = "same_kind_validation_gate"
 	gateEvent.EventOutcome = audit.OutcomeSuccess
+	gateEvent.Data["model"] = modelName
+	gateEvent.Data["prompt_length"] = 0
+	gateEvent.Data["prompt_preview"] = ""
 	gateEvent.Data["signal_resource_kind"] = signal.ResourceKind
 	gateEvent.Data["target_kind"] = result.RemediationTarget.Kind
 	gateEvent.Data["target_name"] = result.RemediationTarget.Name
@@ -619,7 +627,7 @@ func (inv *Investigator) sameKindValidationGate(
 	return retryResult
 }
 
-func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katypes.SignalContext, rcaSummary string, enrichData *prompt.EnrichmentData, p1Ctx *prompt.Phase1Data, tokens *TokenAccumulator, correlationID string, client llm.Client, modelName string) (*katypes.InvestigationResult, error) {
+func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katypes.SignalContext, rcaSummary string, enrichData *prompt.EnrichmentData, p1Ctx *prompt.Phase1Data, tokens *TokenAccumulator, correlationID string, client llm.Client, modelName string, runtimeParams llm.RuntimeParams) (*katypes.InvestigationResult, error) {
 	// Attach signal context so workflow discovery tools (list_available_actions,
 	// list_workflows) can extract severity/component/environment/priority from
 	// ctx instead of using hardcoded values. Fix for #779.
@@ -640,7 +648,7 @@ func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katype
 		{Role: "user", Content: fmt.Sprintf("RCA findings: %s\n\nSelect the appropriate remediation workflow.", rcaSummary)},
 	}
 
-	loopRes, err := inv.runLLMLoop(ctx, messages, katypes.PhaseWorkflowDiscovery, tokens, correlationID, client, modelName)
+	loopRes, err := inv.runLLMLoop(ctx, messages, katypes.PhaseWorkflowDiscovery, tokens, correlationID, client, modelName, runtimeParams)
 	if err != nil {
 		return nil, err
 	}
@@ -731,7 +739,7 @@ func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katype
 			messages = append(messages, llm.Message{Role: "assistant", Content: content})
 			messages = append(messages, llm.Message{Role: "user", Content: correctionMsg})
 
-			corrLoopRes, corrErr := inv.runLLMLoop(ctx, messages, katypes.PhaseWorkflowDiscovery, tokens, correlationID, client, modelName)
+			corrLoopRes, corrErr := inv.runLLMLoop(ctx, messages, katypes.PhaseWorkflowDiscovery, tokens, correlationID, client, modelName, runtimeParams)
 			if corrErr != nil {
 				return nil, corrErr
 			}
@@ -928,6 +936,9 @@ func CheckWorkflowTargetAlignment(ctx context.Context, result *katypes.Investiga
 	} else {
 		ev.EventOutcome = audit.OutcomeFailure
 	}
+	ev.Data["model"] = ""
+	ev.Data["prompt_length"] = 0
+	ev.Data["prompt_preview"] = ""
 	ev.Data["workflow_id"] = result.WorkflowID
 	ev.Data["target_kind"] = result.RemediationTarget.Kind
 	ev.Data["workflow_components"] = meta.Component
@@ -945,7 +956,7 @@ func CheckWorkflowTargetAlignment(ctx context.Context, result *katypes.Investiga
 // execution routed through the registry. correlationID is propagated to
 // all audit events per BR-AUDIT-005 (remediation_id as query key).
 // Returns a sealed LoopResult; callers dispatch via type switch (#760 v2).
-func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message, phase katypes.Phase, tokens *TokenAccumulator, correlationID string, client llm.Client, modelName string) (LoopResult, error) {
+func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message, phase katypes.Phase, tokens *TokenAccumulator, correlationID string, client llm.Client, modelName string, runtimeParams llm.RuntimeParams) (LoopResult, error) {
 	toolDefs := inv.toolDefinitionsForPhase(phase)
 	loopStart := time.Now()
 	truncationRetried := false
@@ -962,10 +973,17 @@ func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message,
 		reqEvent.Data["messages"] = messagesToAuditFormat(messages)
 		audit.StoreBestEffort(ctx, inv.auditStore, reqEvent, inv.auditLog())
 
-		resp, err := client.Chat(ctx, llm.ChatRequest{
+		chatCtx := ctx
+		if runtimeParams.TimeoutSeconds > 0 {
+			var cancel context.CancelFunc
+			chatCtx, cancel = context.WithTimeout(ctx, time.Duration(runtimeParams.TimeoutSeconds)*time.Second)
+			defer cancel()
+		}
+
+		resp, err := client.Chat(chatCtx, llm.ChatRequest{
 			Messages: messages,
 			Tools:    toolDefs,
-			Options:  llm.ChatOptions{JSONMode: true, OutputSchema: submitResultSchemaForPhase(phase), MaxTokens: maxTokens},
+			Options:  llm.ChatOptions{Temperature: runtimeParams.Temperature, JSONMode: true, OutputSchema: submitResultSchemaForPhase(phase), MaxTokens: maxTokens},
 		})
 		if err != nil {
 			failEvent := audit.NewEvent(audit.EventTypeResponseFailed, correlationID)
@@ -1046,6 +1064,9 @@ func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message,
 			truncEvent := audit.NewEvent(audit.EventTypeLLMResponse, correlationID)
 			truncEvent.EventAction = "truncation_detected"
 			truncEvent.EventOutcome = audit.OutcomeFailure
+			truncEvent.Data["has_analysis"] = resp.Message.Content != ""
+			truncEvent.Data["analysis_length"] = len(resp.Message.Content)
+			truncEvent.Data["analysis_preview"] = truncatePreview(resp.Message.Content, 500)
 			truncEvent.Data["finish_reason"] = resp.FinishReason
 			truncEvent.Data["escalated_max_tokens"] = maxTokens
 			truncEvent.Data["truncated_content_length"] = len(resp.Message.Content)
@@ -1195,9 +1216,13 @@ func (inv *Investigator) executeTool(ctx context.Context, name string, args json
 			"tool", name,
 		)
 		if ar := inv.pipeline.AnomalyDetector.RecordFailure(name, args); !ar.Allowed {
-			return toolErrorJSON(ar.Reason)
+			errResult := toolErrorJSON(ar.Reason)
+			alignment.SubmitToolStep(ctx, name, errResult)
+			return errResult
 		}
-		return toolErrorJSON(err.Error())
+		errResult := toolErrorJSON(err.Error())
+		alignment.SubmitToolStep(ctx, name, errResult)
+		return errResult
 	}
 
 	if inv.pipeline.Sanitizer != nil {
@@ -1225,6 +1250,8 @@ func (inv *Investigator) executeTool(ctx context.Context, name string, args json
 	if inv.pipeline.MaxToolOutputSize > 0 {
 		result = summarizer.TruncateToolOutput(result, name, inv.pipeline.MaxToolOutputSize)
 	}
+
+	alignment.SubmitToolStep(ctx, name, result)
 
 	return result
 }

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -386,7 +386,7 @@ func (inv *Investigator) runRCA(ctx context.Context, signal katypes.SignalContex
 
 	result, parseErr := inv.resultParser.Parse(content)
 	if parseErr != nil {
-		if retried := inv.retryRCASubmit(ctx, content, messages, tokens, correlationID, client, modelName); retried != nil {
+		if retried := inv.retryRCASubmit(ctx, content, messages, tokens, correlationID, client, modelName, runtimeParams); retried != nil {
 			result = retried
 			parseErr = nil
 		}
@@ -404,7 +404,7 @@ func (inv *Investigator) runRCA(ctx context.Context, signal katypes.SignalContex
 	// remediation_target.kind matches the signal's resource_kind, the LLM may
 	// be targeting the symptom reporter instead of the actual root cause.
 	// Inject a single correction message and re-run. Max 1 retry.
-	result = inv.sameKindValidationGate(ctx, result, signal, messages, tokens, correlationID, client, modelName)
+	result = inv.sameKindValidationGate(ctx, result, signal, messages, tokens, correlationID, client, modelName, runtimeParams)
 
 	// Defense-in-depth: RCA phase must never abort the pipeline via
 	// needs_human_review. Only max-turns exhaustion (above) is a valid RCA abort.
@@ -425,7 +425,7 @@ const maxRCAParseRetries = 1
 // retryRCASubmit performs a single correction attempt when the RCA parse fails
 // (e.g. double-serialized JSON that wasn't caught by the unwrap heuristic, or
 // garbage fields). Mirrors retryWorkflowSubmit but scoped to the RCA phase.
-func (inv *Investigator) retryRCASubmit(ctx context.Context, lastContent string, history []llm.Message, tokens *TokenAccumulator, correlationID string, client llm.Client, modelName string) *katypes.InvestigationResult {
+func (inv *Investigator) retryRCASubmit(ctx context.Context, lastContent string, history []llm.Message, tokens *TokenAccumulator, correlationID string, client llm.Client, modelName string, runtimeParams llm.RuntimeParams) *katypes.InvestigationResult {
 	submitOnlyTools := []llm.ToolDefinition{
 		{
 			Name:        SubmitResultToolName,
@@ -467,11 +467,11 @@ CRITICAL: root_cause_analysis must be a JSON object, NOT a string. Do NOT wrap i
 		retryEvent.Data["retry_reason"] = "rca_parse_correction"
 		audit.StoreBestEffort(ctx, inv.auditStore, retryEvent, inv.auditLog())
 
-		resp, err := client.Chat(ctx, llm.ChatRequest{
+		resp, err := llm.ChatWithParams(ctx, client, llm.ChatRequest{
 			Messages: retryMessages,
 			Tools:    submitOnlyTools,
 			Options:  llm.ChatOptions{JSONMode: true, OutputSchema: parser.RCAResultSchema()},
-		})
+		}, runtimeParams)
 		if err != nil {
 			inv.logger.Error(err, "RCA retry LLM call failed",
 				"correlation_id", correlationID)
@@ -526,6 +526,7 @@ func (inv *Investigator) sameKindValidationGate(
 	correlationID string,
 	client llm.Client,
 	modelName string,
+	runtimeParams llm.RuntimeParams,
 ) *katypes.InvestigationResult {
 	if signal.ResourceKind == "" || result.RemediationTarget.Kind == "" {
 		return result
@@ -576,11 +577,11 @@ func (inv *Investigator) sameKindValidationGate(
 		llm.Message{Role: "user", Content: correctionMsg},
 	)
 
-	resp, err := client.Chat(ctx, llm.ChatRequest{
+	resp, err := llm.ChatWithParams(ctx, client, llm.ChatRequest{
 		Messages: retryMessages,
 		Tools:    submitOnlyTools,
 		Options:  llm.ChatOptions{JSONMode: true, OutputSchema: parser.RCAResultSchema()},
-	})
+	}, runtimeParams)
 	if err != nil {
 		inv.logger.Error(err, "same-kind validation gate retry failed, keeping original result",
 			"correlation_id", correlationID)
@@ -685,7 +686,7 @@ func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katype
 				"correlation_id", correlationID)
 			content = r.Content
 		} else {
-			retryResult := inv.retryWorkflowSubmit(ctx, r.Content, messages, rcaSummary, tokens, correlationID, client, modelName)
+			retryResult := inv.retryWorkflowSubmit(ctx, r.Content, messages, rcaSummary, tokens, correlationID, client, modelName, runtimeParams)
 			if retryResult != nil {
 				return retryResult, nil
 			}
@@ -702,7 +703,7 @@ func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katype
 
 	result, parseErr := inv.resultParser.Parse(content)
 	if parseErr != nil {
-		retryResult := inv.retryWorkflowSubmit(ctx, content, messages, rcaSummary, tokens, correlationID, client, modelName)
+		retryResult := inv.retryWorkflowSubmit(ctx, content, messages, rcaSummary, tokens, correlationID, client, modelName, runtimeParams)
 		if retryResult != nil {
 			return retryResult, nil
 		}
@@ -790,7 +791,7 @@ const maxParseRetries = 2
 // Each retry sends a correction message with examples of both submit tools,
 // with only the two submit tools available (prevents re-investigation).
 // Returns non-nil *InvestigationResult on success or nil when retries exhaust.
-func (inv *Investigator) retryWorkflowSubmit(ctx context.Context, lastContent string, history []llm.Message, rcaSummary string, tokens *TokenAccumulator, correlationID string, client llm.Client, modelName string) *katypes.InvestigationResult {
+func (inv *Investigator) retryWorkflowSubmit(ctx context.Context, lastContent string, history []llm.Message, rcaSummary string, tokens *TokenAccumulator, correlationID string, client llm.Client, modelName string, runtimeParams llm.RuntimeParams) *katypes.InvestigationResult {
 	submitOnlyTools := []llm.ToolDefinition{
 		{
 			Name:        SubmitResultWithWorkflowToolName,
@@ -834,17 +835,19 @@ Do NOT respond with plain text. You MUST call one of the above tools.`
 		retryEvent.EventAction = audit.ActionLLMRequest
 		retryEvent.EventOutcome = audit.OutcomeSuccess
 		retryEvent.Data["model"] = modelName
+		retryEvent.Data["prompt_length"] = totalPromptLength(retryMessages)
+		retryEvent.Data["prompt_preview"] = lastUserMessage(retryMessages, 500)
 		retryEvent.Data["retry_attempt"] = attempt + 1
 		retryEvent.Data["retry_max"] = maxParseRetries
 		retryEvent.Data["phase"] = string(katypes.PhaseWorkflowDiscovery)
 		retryEvent.Data["retry_reason"] = "parse_level_correction"
 		audit.StoreBestEffort(ctx, inv.auditStore, retryEvent, inv.auditLog())
 
-		resp, err := client.Chat(ctx, llm.ChatRequest{
+		resp, err := llm.ChatWithParams(ctx, client, llm.ChatRequest{
 			Messages: retryMessages,
 			Tools:    submitOnlyTools,
 			Options:  llm.ChatOptions{JSONMode: true, OutputSchema: parser.InvestigationResultSchema()},
-		})
+		}, runtimeParams)
 		if err != nil {
 			inv.logger.Error(err, "retry LLM call failed",
 				"correlation_id", correlationID)
@@ -973,18 +976,11 @@ func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message,
 		reqEvent.Data["messages"] = messagesToAuditFormat(messages)
 		audit.StoreBestEffort(ctx, inv.auditStore, reqEvent, inv.auditLog())
 
-		chatCtx := ctx
-		if runtimeParams.TimeoutSeconds > 0 {
-			var cancel context.CancelFunc
-			chatCtx, cancel = context.WithTimeout(ctx, time.Duration(runtimeParams.TimeoutSeconds)*time.Second)
-			defer cancel()
-		}
-
-		resp, err := client.Chat(chatCtx, llm.ChatRequest{
+		resp, err := llm.ChatWithParams(ctx, client, llm.ChatRequest{
 			Messages: messages,
 			Tools:    toolDefs,
-			Options:  llm.ChatOptions{Temperature: runtimeParams.Temperature, JSONMode: true, OutputSchema: submitResultSchemaForPhase(phase), MaxTokens: maxTokens},
-		})
+			Options:  llm.ChatOptions{JSONMode: true, OutputSchema: submitResultSchemaForPhase(phase), MaxTokens: maxTokens},
+		}, runtimeParams)
 		if err != nil {
 			failEvent := audit.NewEvent(audit.EventTypeResponseFailed, correlationID)
 			failEvent.EventAction = audit.ActionResponseFailed

--- a/pkg/datastorage/ogen-client/oas_json_gen.go
+++ b/pkg/datastorage/ogen-client/oas_json_gen.go
@@ -5377,6 +5377,512 @@ func (s *ActionTypeWorkflowCountResponse) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
+func (s *AlignmentStepPayload) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *AlignmentStepPayload) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("event_type")
+		s.EventType.Encode(e)
+	}
+	{
+		e.FieldStart("event_id")
+		e.Str(s.EventID)
+	}
+	{
+		e.FieldStart("incident_id")
+		e.Str(s.IncidentID)
+	}
+	{
+		e.FieldStart("step_index")
+		e.Int(s.StepIndex)
+	}
+	{
+		e.FieldStart("step_kind")
+		e.Str(s.StepKind)
+	}
+	{
+		if s.Tool.Set {
+			e.FieldStart("tool")
+			s.Tool.Encode(e)
+		}
+	}
+	{
+		if s.Explanation.Set {
+			e.FieldStart("explanation")
+			s.Explanation.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfAlignmentStepPayload = [7]string{
+	0: "event_type",
+	1: "event_id",
+	2: "incident_id",
+	3: "step_index",
+	4: "step_kind",
+	5: "tool",
+	6: "explanation",
+}
+
+// Decode decodes AlignmentStepPayload from json.
+func (s *AlignmentStepPayload) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AlignmentStepPayload to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "event_type":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.EventType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "event_id":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.EventID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_id\"")
+			}
+		case "incident_id":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Str()
+				s.IncidentID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"incident_id\"")
+			}
+		case "step_index":
+			requiredBitSet[0] |= 1 << 3
+			if err := func() error {
+				v, err := d.Int()
+				s.StepIndex = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"step_index\"")
+			}
+		case "step_kind":
+			requiredBitSet[0] |= 1 << 4
+			if err := func() error {
+				v, err := d.Str()
+				s.StepKind = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"step_kind\"")
+			}
+		case "tool":
+			if err := func() error {
+				s.Tool.Reset()
+				if err := s.Tool.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"tool\"")
+			}
+		case "explanation":
+			if err := func() error {
+				s.Explanation.Reset()
+				if err := s.Explanation.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"explanation\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode AlignmentStepPayload")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00011111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfAlignmentStepPayload) {
+					name = jsonFieldsNameOfAlignmentStepPayload[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *AlignmentStepPayload) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AlignmentStepPayload) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes AlignmentStepPayloadEventType as json.
+func (s AlignmentStepPayloadEventType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes AlignmentStepPayloadEventType from json.
+func (s *AlignmentStepPayloadEventType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AlignmentStepPayloadEventType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch AlignmentStepPayloadEventType(v) {
+	case AlignmentStepPayloadEventTypeAiagentAlignmentStep:
+		*s = AlignmentStepPayloadEventTypeAiagentAlignmentStep
+	default:
+		*s = AlignmentStepPayloadEventType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s AlignmentStepPayloadEventType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AlignmentStepPayloadEventType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *AlignmentVerdictPayload) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *AlignmentVerdictPayload) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("event_type")
+		s.EventType.Encode(e)
+	}
+	{
+		e.FieldStart("event_id")
+		e.Str(s.EventID)
+	}
+	{
+		e.FieldStart("incident_id")
+		e.Str(s.IncidentID)
+	}
+	{
+		e.FieldStart("result")
+		s.Result.Encode(e)
+	}
+	{
+		if s.Summary.Set {
+			e.FieldStart("summary")
+			s.Summary.Encode(e)
+		}
+	}
+	{
+		e.FieldStart("flagged")
+		e.Int(s.Flagged)
+	}
+	{
+		e.FieldStart("total")
+		e.Int(s.Total)
+	}
+}
+
+var jsonFieldsNameOfAlignmentVerdictPayload = [7]string{
+	0: "event_type",
+	1: "event_id",
+	2: "incident_id",
+	3: "result",
+	4: "summary",
+	5: "flagged",
+	6: "total",
+}
+
+// Decode decodes AlignmentVerdictPayload from json.
+func (s *AlignmentVerdictPayload) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AlignmentVerdictPayload to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "event_type":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.EventType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "event_id":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.EventID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_id\"")
+			}
+		case "incident_id":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Str()
+				s.IncidentID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"incident_id\"")
+			}
+		case "result":
+			requiredBitSet[0] |= 1 << 3
+			if err := func() error {
+				if err := s.Result.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"result\"")
+			}
+		case "summary":
+			if err := func() error {
+				s.Summary.Reset()
+				if err := s.Summary.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"summary\"")
+			}
+		case "flagged":
+			requiredBitSet[0] |= 1 << 5
+			if err := func() error {
+				v, err := d.Int()
+				s.Flagged = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"flagged\"")
+			}
+		case "total":
+			requiredBitSet[0] |= 1 << 6
+			if err := func() error {
+				v, err := d.Int()
+				s.Total = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"total\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode AlignmentVerdictPayload")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b01101111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfAlignmentVerdictPayload) {
+					name = jsonFieldsNameOfAlignmentVerdictPayload[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *AlignmentVerdictPayload) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AlignmentVerdictPayload) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes AlignmentVerdictPayloadEventType as json.
+func (s AlignmentVerdictPayloadEventType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes AlignmentVerdictPayloadEventType from json.
+func (s *AlignmentVerdictPayloadEventType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AlignmentVerdictPayloadEventType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch AlignmentVerdictPayloadEventType(v) {
+	case AlignmentVerdictPayloadEventTypeAiagentAlignmentVerdict:
+		*s = AlignmentVerdictPayloadEventTypeAiagentAlignmentVerdict
+	default:
+		*s = AlignmentVerdictPayloadEventType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s AlignmentVerdictPayloadEventType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AlignmentVerdictPayloadEventType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes AlignmentVerdictPayloadResult as json.
+func (s AlignmentVerdictPayloadResult) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes AlignmentVerdictPayloadResult from json.
+func (s *AlignmentVerdictPayloadResult) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AlignmentVerdictPayloadResult to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch AlignmentVerdictPayloadResult(v) {
+	case AlignmentVerdictPayloadResultAligned:
+		*s = AlignmentVerdictPayloadResultAligned
+	case AlignmentVerdictPayloadResultSuspicious:
+		*s = AlignmentVerdictPayloadResultSuspicious
+	default:
+		*s = AlignmentVerdictPayloadResult(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s AlignmentVerdictPayloadResult) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AlignmentVerdictPayloadResult) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
 func (s *AsyncAcceptanceResponse) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -7614,6 +8120,72 @@ func (s AuditEventEventData) encodeFields(e *jx.Encoder) {
 				}
 			}
 		}
+	case AlignmentStepPayloadAuditEventEventData:
+		e.FieldStart("event_type")
+		e.Str("aiagent.alignment.step")
+		{
+			s := s.AlignmentStepPayload
+			{
+				e.FieldStart("event_id")
+				e.Str(s.EventID)
+			}
+			{
+				e.FieldStart("incident_id")
+				e.Str(s.IncidentID)
+			}
+			{
+				e.FieldStart("step_index")
+				e.Int(s.StepIndex)
+			}
+			{
+				e.FieldStart("step_kind")
+				e.Str(s.StepKind)
+			}
+			{
+				if s.Tool.Set {
+					e.FieldStart("tool")
+					s.Tool.Encode(e)
+				}
+			}
+			{
+				if s.Explanation.Set {
+					e.FieldStart("explanation")
+					s.Explanation.Encode(e)
+				}
+			}
+		}
+	case AlignmentVerdictPayloadAuditEventEventData:
+		e.FieldStart("event_type")
+		e.Str("aiagent.alignment.verdict")
+		{
+			s := s.AlignmentVerdictPayload
+			{
+				e.FieldStart("event_id")
+				e.Str(s.EventID)
+			}
+			{
+				e.FieldStart("incident_id")
+				e.Str(s.IncidentID)
+			}
+			{
+				e.FieldStart("result")
+				s.Result.Encode(e)
+			}
+			{
+				if s.Summary.Set {
+					e.FieldStart("summary")
+					s.Summary.Encode(e)
+				}
+			}
+			{
+				e.FieldStart("flagged")
+				e.Int(s.Flagged)
+			}
+			{
+				e.FieldStart("total")
+				e.Int(s.Total)
+			}
+		}
 	case RemediationRequestWebhookAuditPayloadAuditEventEventData:
 		e.FieldStart("event_type")
 		e.Str("webhook.remediationrequest.timeout_modified")
@@ -8299,6 +8871,12 @@ func (s *AuditEventEventData) Decode(d *jx.Decoder) error {
 				case "aiagent.workflow.validation_attempt":
 					s.Type = WorkflowValidationPayloadAuditEventEventData
 					found = true
+				case "aiagent.alignment.step":
+					s.Type = AlignmentStepPayloadAuditEventEventData
+					found = true
+				case "aiagent.alignment.verdict":
+					s.Type = AlignmentVerdictPayloadAuditEventEventData
+					found = true
 				case "webhook.remediationrequest.timeout_modified":
 					s.Type = RemediationRequestWebhookAuditPayloadAuditEventEventData
 					found = true
@@ -8500,6 +9078,14 @@ func (s *AuditEventEventData) Decode(d *jx.Decoder) error {
 		}
 	case WorkflowValidationPayloadAuditEventEventData:
 		if err := s.WorkflowValidationPayload.Decode(d); err != nil {
+			return err
+		}
+	case AlignmentStepPayloadAuditEventEventData:
+		if err := s.AlignmentStepPayload.Decode(d); err != nil {
+			return err
+		}
+	case AlignmentVerdictPayloadAuditEventEventData:
+		if err := s.AlignmentVerdictPayload.Decode(d); err != nil {
 			return err
 		}
 	case RemediationRequestWebhookAuditPayloadAuditEventEventData:
@@ -10690,6 +11276,72 @@ func (s AuditEventRequestEventData) encodeFields(e *jx.Encoder) {
 				}
 			}
 		}
+	case AlignmentStepPayloadAuditEventRequestEventData:
+		e.FieldStart("event_type")
+		e.Str("aiagent.alignment.step")
+		{
+			s := s.AlignmentStepPayload
+			{
+				e.FieldStart("event_id")
+				e.Str(s.EventID)
+			}
+			{
+				e.FieldStart("incident_id")
+				e.Str(s.IncidentID)
+			}
+			{
+				e.FieldStart("step_index")
+				e.Int(s.StepIndex)
+			}
+			{
+				e.FieldStart("step_kind")
+				e.Str(s.StepKind)
+			}
+			{
+				if s.Tool.Set {
+					e.FieldStart("tool")
+					s.Tool.Encode(e)
+				}
+			}
+			{
+				if s.Explanation.Set {
+					e.FieldStart("explanation")
+					s.Explanation.Encode(e)
+				}
+			}
+		}
+	case AlignmentVerdictPayloadAuditEventRequestEventData:
+		e.FieldStart("event_type")
+		e.Str("aiagent.alignment.verdict")
+		{
+			s := s.AlignmentVerdictPayload
+			{
+				e.FieldStart("event_id")
+				e.Str(s.EventID)
+			}
+			{
+				e.FieldStart("incident_id")
+				e.Str(s.IncidentID)
+			}
+			{
+				e.FieldStart("result")
+				s.Result.Encode(e)
+			}
+			{
+				if s.Summary.Set {
+					e.FieldStart("summary")
+					s.Summary.Encode(e)
+				}
+			}
+			{
+				e.FieldStart("flagged")
+				e.Int(s.Flagged)
+			}
+			{
+				e.FieldStart("total")
+				e.Int(s.Total)
+			}
+		}
 	case RemediationRequestWebhookAuditPayloadAuditEventRequestEventData:
 		e.FieldStart("event_type")
 		e.Str("webhook.remediationrequest.timeout_modified")
@@ -11375,6 +12027,12 @@ func (s *AuditEventRequestEventData) Decode(d *jx.Decoder) error {
 				case "aiagent.workflow.validation_attempt":
 					s.Type = WorkflowValidationPayloadAuditEventRequestEventData
 					found = true
+				case "aiagent.alignment.step":
+					s.Type = AlignmentStepPayloadAuditEventRequestEventData
+					found = true
+				case "aiagent.alignment.verdict":
+					s.Type = AlignmentVerdictPayloadAuditEventRequestEventData
+					found = true
 				case "webhook.remediationrequest.timeout_modified":
 					s.Type = RemediationRequestWebhookAuditPayloadAuditEventRequestEventData
 					found = true
@@ -11576,6 +12234,14 @@ func (s *AuditEventRequestEventData) Decode(d *jx.Decoder) error {
 		}
 	case WorkflowValidationPayloadAuditEventRequestEventData:
 		if err := s.WorkflowValidationPayload.Decode(d); err != nil {
+			return err
+		}
+	case AlignmentStepPayloadAuditEventRequestEventData:
+		if err := s.AlignmentStepPayload.Decode(d); err != nil {
+			return err
+		}
+	case AlignmentVerdictPayloadAuditEventRequestEventData:
+		if err := s.AlignmentVerdictPayload.Decode(d); err != nil {
 			return err
 		}
 	case RemediationRequestWebhookAuditPayloadAuditEventRequestEventData:

--- a/pkg/datastorage/ogen-client/oas_schemas_gen.go
+++ b/pkg/datastorage/ogen-client/oas_schemas_gen.go
@@ -2469,6 +2469,298 @@ func (s *ActionTypeWorkflowCountResponse) SetCount(val int) {
 	s.Count = val
 }
 
+// Shadow agent alignment check step payload (aiagent.alignment.step). Emitted for each step flagged
+// as suspicious during shadow evaluation.
+// Ref: #/components/schemas/AlignmentStepPayload
+type AlignmentStepPayload struct {
+	// Event type for discriminator (matches parent event_type).
+	EventType AlignmentStepPayloadEventType `json:"event_type"`
+	// Unique event identifier.
+	EventID string `json:"event_id"`
+	// Incident correlation ID (signal name).
+	IncidentID string `json:"incident_id"`
+	// Index of the suspicious step in the investigation trace.
+	StepIndex int `json:"step_index"`
+	// Kind of step (e.g., tool_result, llm_reasoning).
+	StepKind string `json:"step_kind"`
+	// Tool name used in the step (empty for non-tool steps).
+	Tool OptString `json:"tool"`
+	// Sanitized explanation of why the step was flagged.
+	Explanation OptString `json:"explanation"`
+}
+
+// GetEventType returns the value of EventType.
+func (s *AlignmentStepPayload) GetEventType() AlignmentStepPayloadEventType {
+	return s.EventType
+}
+
+// GetEventID returns the value of EventID.
+func (s *AlignmentStepPayload) GetEventID() string {
+	return s.EventID
+}
+
+// GetIncidentID returns the value of IncidentID.
+func (s *AlignmentStepPayload) GetIncidentID() string {
+	return s.IncidentID
+}
+
+// GetStepIndex returns the value of StepIndex.
+func (s *AlignmentStepPayload) GetStepIndex() int {
+	return s.StepIndex
+}
+
+// GetStepKind returns the value of StepKind.
+func (s *AlignmentStepPayload) GetStepKind() string {
+	return s.StepKind
+}
+
+// GetTool returns the value of Tool.
+func (s *AlignmentStepPayload) GetTool() OptString {
+	return s.Tool
+}
+
+// GetExplanation returns the value of Explanation.
+func (s *AlignmentStepPayload) GetExplanation() OptString {
+	return s.Explanation
+}
+
+// SetEventType sets the value of EventType.
+func (s *AlignmentStepPayload) SetEventType(val AlignmentStepPayloadEventType) {
+	s.EventType = val
+}
+
+// SetEventID sets the value of EventID.
+func (s *AlignmentStepPayload) SetEventID(val string) {
+	s.EventID = val
+}
+
+// SetIncidentID sets the value of IncidentID.
+func (s *AlignmentStepPayload) SetIncidentID(val string) {
+	s.IncidentID = val
+}
+
+// SetStepIndex sets the value of StepIndex.
+func (s *AlignmentStepPayload) SetStepIndex(val int) {
+	s.StepIndex = val
+}
+
+// SetStepKind sets the value of StepKind.
+func (s *AlignmentStepPayload) SetStepKind(val string) {
+	s.StepKind = val
+}
+
+// SetTool sets the value of Tool.
+func (s *AlignmentStepPayload) SetTool(val OptString) {
+	s.Tool = val
+}
+
+// SetExplanation sets the value of Explanation.
+func (s *AlignmentStepPayload) SetExplanation(val OptString) {
+	s.Explanation = val
+}
+
+// Event type for discriminator (matches parent event_type).
+type AlignmentStepPayloadEventType string
+
+const (
+	AlignmentStepPayloadEventTypeAiagentAlignmentStep AlignmentStepPayloadEventType = "aiagent.alignment.step"
+)
+
+// AllValues returns all AlignmentStepPayloadEventType values.
+func (AlignmentStepPayloadEventType) AllValues() []AlignmentStepPayloadEventType {
+	return []AlignmentStepPayloadEventType{
+		AlignmentStepPayloadEventTypeAiagentAlignmentStep,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s AlignmentStepPayloadEventType) MarshalText() ([]byte, error) {
+	switch s {
+	case AlignmentStepPayloadEventTypeAiagentAlignmentStep:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *AlignmentStepPayloadEventType) UnmarshalText(data []byte) error {
+	switch AlignmentStepPayloadEventType(data) {
+	case AlignmentStepPayloadEventTypeAiagentAlignmentStep:
+		*s = AlignmentStepPayloadEventTypeAiagentAlignmentStep
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Shadow agent alignment verdict payload (aiagent.alignment.verdict). Emitted once per investigation
+// after full shadow evaluation completes.
+// Ref: #/components/schemas/AlignmentVerdictPayload
+type AlignmentVerdictPayload struct {
+	// Event type for discriminator (matches parent event_type).
+	EventType AlignmentVerdictPayloadEventType `json:"event_type"`
+	// Unique event identifier.
+	EventID string `json:"event_id"`
+	// Incident correlation ID (signal name).
+	IncidentID string `json:"incident_id"`
+	// Overall alignment verdict.
+	Result AlignmentVerdictPayloadResult `json:"result"`
+	// Free-text summary of the shadow evaluation.
+	Summary OptString `json:"summary"`
+	// Number of steps flagged as suspicious.
+	Flagged int `json:"flagged"`
+	// Total number of steps evaluated.
+	Total int `json:"total"`
+}
+
+// GetEventType returns the value of EventType.
+func (s *AlignmentVerdictPayload) GetEventType() AlignmentVerdictPayloadEventType {
+	return s.EventType
+}
+
+// GetEventID returns the value of EventID.
+func (s *AlignmentVerdictPayload) GetEventID() string {
+	return s.EventID
+}
+
+// GetIncidentID returns the value of IncidentID.
+func (s *AlignmentVerdictPayload) GetIncidentID() string {
+	return s.IncidentID
+}
+
+// GetResult returns the value of Result.
+func (s *AlignmentVerdictPayload) GetResult() AlignmentVerdictPayloadResult {
+	return s.Result
+}
+
+// GetSummary returns the value of Summary.
+func (s *AlignmentVerdictPayload) GetSummary() OptString {
+	return s.Summary
+}
+
+// GetFlagged returns the value of Flagged.
+func (s *AlignmentVerdictPayload) GetFlagged() int {
+	return s.Flagged
+}
+
+// GetTotal returns the value of Total.
+func (s *AlignmentVerdictPayload) GetTotal() int {
+	return s.Total
+}
+
+// SetEventType sets the value of EventType.
+func (s *AlignmentVerdictPayload) SetEventType(val AlignmentVerdictPayloadEventType) {
+	s.EventType = val
+}
+
+// SetEventID sets the value of EventID.
+func (s *AlignmentVerdictPayload) SetEventID(val string) {
+	s.EventID = val
+}
+
+// SetIncidentID sets the value of IncidentID.
+func (s *AlignmentVerdictPayload) SetIncidentID(val string) {
+	s.IncidentID = val
+}
+
+// SetResult sets the value of Result.
+func (s *AlignmentVerdictPayload) SetResult(val AlignmentVerdictPayloadResult) {
+	s.Result = val
+}
+
+// SetSummary sets the value of Summary.
+func (s *AlignmentVerdictPayload) SetSummary(val OptString) {
+	s.Summary = val
+}
+
+// SetFlagged sets the value of Flagged.
+func (s *AlignmentVerdictPayload) SetFlagged(val int) {
+	s.Flagged = val
+}
+
+// SetTotal sets the value of Total.
+func (s *AlignmentVerdictPayload) SetTotal(val int) {
+	s.Total = val
+}
+
+// Event type for discriminator (matches parent event_type).
+type AlignmentVerdictPayloadEventType string
+
+const (
+	AlignmentVerdictPayloadEventTypeAiagentAlignmentVerdict AlignmentVerdictPayloadEventType = "aiagent.alignment.verdict"
+)
+
+// AllValues returns all AlignmentVerdictPayloadEventType values.
+func (AlignmentVerdictPayloadEventType) AllValues() []AlignmentVerdictPayloadEventType {
+	return []AlignmentVerdictPayloadEventType{
+		AlignmentVerdictPayloadEventTypeAiagentAlignmentVerdict,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s AlignmentVerdictPayloadEventType) MarshalText() ([]byte, error) {
+	switch s {
+	case AlignmentVerdictPayloadEventTypeAiagentAlignmentVerdict:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *AlignmentVerdictPayloadEventType) UnmarshalText(data []byte) error {
+	switch AlignmentVerdictPayloadEventType(data) {
+	case AlignmentVerdictPayloadEventTypeAiagentAlignmentVerdict:
+		*s = AlignmentVerdictPayloadEventTypeAiagentAlignmentVerdict
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Overall alignment verdict.
+type AlignmentVerdictPayloadResult string
+
+const (
+	AlignmentVerdictPayloadResultAligned    AlignmentVerdictPayloadResult = "aligned"
+	AlignmentVerdictPayloadResultSuspicious AlignmentVerdictPayloadResult = "suspicious"
+)
+
+// AllValues returns all AlignmentVerdictPayloadResult values.
+func (AlignmentVerdictPayloadResult) AllValues() []AlignmentVerdictPayloadResult {
+	return []AlignmentVerdictPayloadResult{
+		AlignmentVerdictPayloadResultAligned,
+		AlignmentVerdictPayloadResultSuspicious,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s AlignmentVerdictPayloadResult) MarshalText() ([]byte, error) {
+	switch s {
+	case AlignmentVerdictPayloadResultAligned:
+		return []byte(s), nil
+	case AlignmentVerdictPayloadResultSuspicious:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *AlignmentVerdictPayloadResult) UnmarshalText(data []byte) error {
+	switch AlignmentVerdictPayloadResult(data) {
+	case AlignmentVerdictPayloadResultAligned:
+		*s = AlignmentVerdictPayloadResultAligned
+		return nil
+	case AlignmentVerdictPayloadResultSuspicious:
+		*s = AlignmentVerdictPayloadResultSuspicious
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
 // Response when audit event is queued for async processing (202 Accepted).
 // Ref: #/components/schemas/AsyncAcceptanceResponse
 type AsyncAcceptanceResponse struct {
@@ -2896,6 +3188,8 @@ type AuditEventEventData struct {
 	LLMResponsePayload                     LLMResponsePayload
 	LLMToolCallPayload                     LLMToolCallPayload
 	WorkflowValidationPayload              WorkflowValidationPayload
+	AlignmentStepPayload                   AlignmentStepPayload
+	AlignmentVerdictPayload                AlignmentVerdictPayload
 	RemediationRequestWebhookAuditPayload  RemediationRequestWebhookAuditPayload
 	RemediationWorkflowWebhookAuditPayload RemediationWorkflowWebhookAuditPayload
 	EffectivenessAssessmentAuditPayload    EffectivenessAssessmentAuditPayload
@@ -2976,6 +3270,8 @@ const (
 	LLMResponsePayloadAuditEventEventData                                            AuditEventEventDataType = "aiagent.llm.response"
 	LLMToolCallPayloadAuditEventEventData                                            AuditEventEventDataType = "aiagent.llm.tool_call"
 	WorkflowValidationPayloadAuditEventEventData                                     AuditEventEventDataType = "aiagent.workflow.validation_attempt"
+	AlignmentStepPayloadAuditEventEventData                                          AuditEventEventDataType = "aiagent.alignment.step"
+	AlignmentVerdictPayloadAuditEventEventData                                       AuditEventEventDataType = "aiagent.alignment.verdict"
 	RemediationRequestWebhookAuditPayloadAuditEventEventData                         AuditEventEventDataType = "webhook.remediationrequest.timeout_modified"
 	AuditEventEventDataRemediationworkflowAdmittedCreateAuditEventEventData          AuditEventEventDataType = "remediationworkflow.admitted.create"
 	AuditEventEventDataRemediationworkflowAdmittedDeleteAuditEventEventData          AuditEventEventDataType = "remediationworkflow.admitted.delete"
@@ -3189,6 +3485,16 @@ func (s AuditEventEventData) IsLLMToolCallPayload() bool {
 // IsWorkflowValidationPayload reports whether AuditEventEventData is WorkflowValidationPayload.
 func (s AuditEventEventData) IsWorkflowValidationPayload() bool {
 	return s.Type == WorkflowValidationPayloadAuditEventEventData
+}
+
+// IsAlignmentStepPayload reports whether AuditEventEventData is AlignmentStepPayload.
+func (s AuditEventEventData) IsAlignmentStepPayload() bool {
+	return s.Type == AlignmentStepPayloadAuditEventEventData
+}
+
+// IsAlignmentVerdictPayload reports whether AuditEventEventData is AlignmentVerdictPayload.
+func (s AuditEventEventData) IsAlignmentVerdictPayload() bool {
+	return s.Type == AlignmentVerdictPayloadAuditEventEventData
 }
 
 // IsRemediationRequestWebhookAuditPayload reports whether AuditEventEventData is RemediationRequestWebhookAuditPayload.
@@ -4151,6 +4457,48 @@ func NewWorkflowValidationPayloadAuditEventEventData(v WorkflowValidationPayload
 	return s
 }
 
+// SetAlignmentStepPayload sets AuditEventEventData to AlignmentStepPayload.
+func (s *AuditEventEventData) SetAlignmentStepPayload(v AlignmentStepPayload) {
+	s.Type = AlignmentStepPayloadAuditEventEventData
+	s.AlignmentStepPayload = v
+}
+
+// GetAlignmentStepPayload returns AlignmentStepPayload and true boolean if AuditEventEventData is AlignmentStepPayload.
+func (s AuditEventEventData) GetAlignmentStepPayload() (v AlignmentStepPayload, ok bool) {
+	if !s.IsAlignmentStepPayload() {
+		return v, false
+	}
+	return s.AlignmentStepPayload, true
+}
+
+// NewAlignmentStepPayloadAuditEventEventData returns new AuditEventEventData from AlignmentStepPayload.
+func NewAlignmentStepPayloadAuditEventEventData(v AlignmentStepPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetAlignmentStepPayload(v)
+	return s
+}
+
+// SetAlignmentVerdictPayload sets AuditEventEventData to AlignmentVerdictPayload.
+func (s *AuditEventEventData) SetAlignmentVerdictPayload(v AlignmentVerdictPayload) {
+	s.Type = AlignmentVerdictPayloadAuditEventEventData
+	s.AlignmentVerdictPayload = v
+}
+
+// GetAlignmentVerdictPayload returns AlignmentVerdictPayload and true boolean if AuditEventEventData is AlignmentVerdictPayload.
+func (s AuditEventEventData) GetAlignmentVerdictPayload() (v AlignmentVerdictPayload, ok bool) {
+	if !s.IsAlignmentVerdictPayload() {
+		return v, false
+	}
+	return s.AlignmentVerdictPayload, true
+}
+
+// NewAlignmentVerdictPayloadAuditEventEventData returns new AuditEventEventData from AlignmentVerdictPayload.
+func NewAlignmentVerdictPayloadAuditEventEventData(v AlignmentVerdictPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetAlignmentVerdictPayload(v)
+	return s
+}
+
 // SetRemediationRequestWebhookAuditPayload sets AuditEventEventData to RemediationRequestWebhookAuditPayload.
 func (s *AuditEventEventData) SetRemediationRequestWebhookAuditPayload(v RemediationRequestWebhookAuditPayload) {
 	s.Type = RemediationRequestWebhookAuditPayloadAuditEventEventData
@@ -4871,6 +5219,8 @@ type AuditEventRequestEventData struct {
 	LLMResponsePayload                     LLMResponsePayload
 	LLMToolCallPayload                     LLMToolCallPayload
 	WorkflowValidationPayload              WorkflowValidationPayload
+	AlignmentStepPayload                   AlignmentStepPayload
+	AlignmentVerdictPayload                AlignmentVerdictPayload
 	RemediationRequestWebhookAuditPayload  RemediationRequestWebhookAuditPayload
 	RemediationWorkflowWebhookAuditPayload RemediationWorkflowWebhookAuditPayload
 	EffectivenessAssessmentAuditPayload    EffectivenessAssessmentAuditPayload
@@ -4951,6 +5301,8 @@ const (
 	LLMResponsePayloadAuditEventRequestEventData                                                   AuditEventRequestEventDataType = "aiagent.llm.response"
 	LLMToolCallPayloadAuditEventRequestEventData                                                   AuditEventRequestEventDataType = "aiagent.llm.tool_call"
 	WorkflowValidationPayloadAuditEventRequestEventData                                            AuditEventRequestEventDataType = "aiagent.workflow.validation_attempt"
+	AlignmentStepPayloadAuditEventRequestEventData                                                 AuditEventRequestEventDataType = "aiagent.alignment.step"
+	AlignmentVerdictPayloadAuditEventRequestEventData                                              AuditEventRequestEventDataType = "aiagent.alignment.verdict"
 	RemediationRequestWebhookAuditPayloadAuditEventRequestEventData                                AuditEventRequestEventDataType = "webhook.remediationrequest.timeout_modified"
 	AuditEventRequestEventDataRemediationworkflowAdmittedCreateAuditEventRequestEventData          AuditEventRequestEventDataType = "remediationworkflow.admitted.create"
 	AuditEventRequestEventDataRemediationworkflowAdmittedDeleteAuditEventRequestEventData          AuditEventRequestEventDataType = "remediationworkflow.admitted.delete"
@@ -5164,6 +5516,16 @@ func (s AuditEventRequestEventData) IsLLMToolCallPayload() bool {
 // IsWorkflowValidationPayload reports whether AuditEventRequestEventData is WorkflowValidationPayload.
 func (s AuditEventRequestEventData) IsWorkflowValidationPayload() bool {
 	return s.Type == WorkflowValidationPayloadAuditEventRequestEventData
+}
+
+// IsAlignmentStepPayload reports whether AuditEventRequestEventData is AlignmentStepPayload.
+func (s AuditEventRequestEventData) IsAlignmentStepPayload() bool {
+	return s.Type == AlignmentStepPayloadAuditEventRequestEventData
+}
+
+// IsAlignmentVerdictPayload reports whether AuditEventRequestEventData is AlignmentVerdictPayload.
+func (s AuditEventRequestEventData) IsAlignmentVerdictPayload() bool {
+	return s.Type == AlignmentVerdictPayloadAuditEventRequestEventData
 }
 
 // IsRemediationRequestWebhookAuditPayload reports whether AuditEventRequestEventData is RemediationRequestWebhookAuditPayload.
@@ -6123,6 +6485,48 @@ func (s AuditEventRequestEventData) GetWorkflowValidationPayload() (v WorkflowVa
 func NewWorkflowValidationPayloadAuditEventRequestEventData(v WorkflowValidationPayload) AuditEventRequestEventData {
 	var s AuditEventRequestEventData
 	s.SetWorkflowValidationPayload(v)
+	return s
+}
+
+// SetAlignmentStepPayload sets AuditEventRequestEventData to AlignmentStepPayload.
+func (s *AuditEventRequestEventData) SetAlignmentStepPayload(v AlignmentStepPayload) {
+	s.Type = AlignmentStepPayloadAuditEventRequestEventData
+	s.AlignmentStepPayload = v
+}
+
+// GetAlignmentStepPayload returns AlignmentStepPayload and true boolean if AuditEventRequestEventData is AlignmentStepPayload.
+func (s AuditEventRequestEventData) GetAlignmentStepPayload() (v AlignmentStepPayload, ok bool) {
+	if !s.IsAlignmentStepPayload() {
+		return v, false
+	}
+	return s.AlignmentStepPayload, true
+}
+
+// NewAlignmentStepPayloadAuditEventRequestEventData returns new AuditEventRequestEventData from AlignmentStepPayload.
+func NewAlignmentStepPayloadAuditEventRequestEventData(v AlignmentStepPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetAlignmentStepPayload(v)
+	return s
+}
+
+// SetAlignmentVerdictPayload sets AuditEventRequestEventData to AlignmentVerdictPayload.
+func (s *AuditEventRequestEventData) SetAlignmentVerdictPayload(v AlignmentVerdictPayload) {
+	s.Type = AlignmentVerdictPayloadAuditEventRequestEventData
+	s.AlignmentVerdictPayload = v
+}
+
+// GetAlignmentVerdictPayload returns AlignmentVerdictPayload and true boolean if AuditEventRequestEventData is AlignmentVerdictPayload.
+func (s AuditEventRequestEventData) GetAlignmentVerdictPayload() (v AlignmentVerdictPayload, ok bool) {
+	if !s.IsAlignmentVerdictPayload() {
+		return v, false
+	}
+	return s.AlignmentVerdictPayload, true
+}
+
+// NewAlignmentVerdictPayloadAuditEventRequestEventData returns new AuditEventRequestEventData from AlignmentVerdictPayload.
+func NewAlignmentVerdictPayloadAuditEventRequestEventData(v AlignmentVerdictPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetAlignmentVerdictPayload(v)
 	return s
 }
 

--- a/pkg/datastorage/ogen-client/oas_validators_gen.go
+++ b/pkg/datastorage/ogen-client/oas_validators_gen.go
@@ -935,6 +935,155 @@ func (s ActionTypeWebhookAuditPayloadEventType) Validate() error {
 	}
 }
 
+func (s *AlignmentStepPayload) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.EventType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "event_type",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := (validate.Int{
+			MinSet:        true,
+			Min:           0,
+			MaxSet:        false,
+			Max:           0,
+			MinExclusive:  false,
+			MaxExclusive:  false,
+			MultipleOfSet: false,
+			MultipleOf:    0,
+			Pattern:       nil,
+		}).Validate(int64(s.StepIndex)); err != nil {
+			return errors.Wrap(err, "int")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "step_index",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s AlignmentStepPayloadEventType) Validate() error {
+	switch s {
+	case "aiagent.alignment.step":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s *AlignmentVerdictPayload) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.EventType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "event_type",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := s.Result.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "result",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := (validate.Int{
+			MinSet:        true,
+			Min:           0,
+			MaxSet:        false,
+			Max:           0,
+			MinExclusive:  false,
+			MaxExclusive:  false,
+			MultipleOfSet: false,
+			MultipleOf:    0,
+			Pattern:       nil,
+		}).Validate(int64(s.Flagged)); err != nil {
+			return errors.Wrap(err, "int")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "flagged",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := (validate.Int{
+			MinSet:        true,
+			Min:           0,
+			MaxSet:        false,
+			Max:           0,
+			MinExclusive:  false,
+			MaxExclusive:  false,
+			MultipleOfSet: false,
+			MultipleOf:    0,
+			Pattern:       nil,
+		}).Validate(int64(s.Total)); err != nil {
+			return errors.Wrap(err, "int")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "total",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s AlignmentVerdictPayloadEventType) Validate() error {
+	switch s {
+	case "aiagent.alignment.verdict":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s AlignmentVerdictPayloadResult) Validate() error {
+	switch s {
+	case "aligned":
+		return nil
+	case "suspicious":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
 func (s *AuditEvent) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -1223,6 +1372,16 @@ func (s AuditEventEventData) Validate() error {
 		return nil
 	case WorkflowValidationPayloadAuditEventEventData:
 		if err := s.WorkflowValidationPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case AlignmentStepPayloadAuditEventEventData:
+		if err := s.AlignmentStepPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case AlignmentVerdictPayloadAuditEventEventData:
+		if err := s.AlignmentVerdictPayload.Validate(); err != nil {
 			return err
 		}
 		return nil
@@ -1577,6 +1736,16 @@ func (s AuditEventRequestEventData) Validate() error {
 		return nil
 	case WorkflowValidationPayloadAuditEventRequestEventData:
 		if err := s.WorkflowValidationPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case AlignmentStepPayloadAuditEventRequestEventData:
+		if err := s.AlignmentStepPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case AlignmentVerdictPayloadAuditEventRequestEventData:
+		if err := s.AlignmentVerdictPayload.Validate(); err != nil {
 			return err
 		}
 		return nil

--- a/pkg/kubernautagent/llm/chat_helpers.go
+++ b/pkg/kubernautagent/llm/chat_helpers.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llm
+
+import (
+	"context"
+	"time"
+)
+
+// ChatWithParams wraps a Client.Chat call, injecting runtime parameters
+// (temperature, timeout) from the hot-reloadable LLM config. The context
+// timeout is cancelled immediately after Chat returns to avoid resource leaks.
+func ChatWithParams(ctx context.Context, client Client, req ChatRequest, params RuntimeParams) (ChatResponse, error) {
+	temp := params.Temperature
+	req.Options.Temperature = &temp
+
+	chatCtx := ctx
+	var chatCancel context.CancelFunc
+	if params.TimeoutSeconds > 0 {
+		chatCtx, chatCancel = context.WithTimeout(ctx, time.Duration(params.TimeoutSeconds)*time.Second)
+	}
+
+	resp, err := client.Chat(chatCtx, req)
+
+	if chatCancel != nil {
+		chatCancel()
+	}
+
+	return resp, err
+}

--- a/pkg/kubernautagent/llm/langchaingo/adapter.go
+++ b/pkg/kubernautagent/llm/langchaingo/adapter.go
@@ -280,8 +280,8 @@ func buildCallOptions(req llm.ChatRequest) []llms.CallOption {
 		}
 		opts = append(opts, llms.WithTools(tools))
 	}
-	if req.Options.Temperature > 0 {
-		opts = append(opts, llms.WithTemperature(req.Options.Temperature))
+	if req.Options.Temperature != nil {
+		opts = append(opts, llms.WithTemperature(*req.Options.Temperature))
 	}
 	if req.Options.MaxTokens > 0 {
 		opts = append(opts, llms.WithMaxTokens(req.Options.MaxTokens))

--- a/pkg/kubernautagent/llm/swappable_client.go
+++ b/pkg/kubernautagent/llm/swappable_client.go
@@ -36,18 +36,32 @@ const oldClientCloseTimeout = 5 * time.Second
 //     so it never blocks callers.
 //   - Snapshot returns a bare llm.Client pinned at the current moment;
 //     subsequent Swap calls do not affect outstanding snapshots.
+// RuntimeParams holds LLM runtime parameters that can be hot-reloaded
+// alongside the client. Investigator reads these at the start of each
+// investigation to pin values for the duration.
+type RuntimeParams struct {
+	Temperature    float64
+	TimeoutSeconds int
+	MaxRetries     int
+}
+
 type SwappableClient struct {
-	mu        sync.RWMutex
-	inner     Client
-	modelName string
+	mu            sync.RWMutex
+	inner         Client
+	modelName     string
+	runtimeParams RuntimeParams
 }
 
 // NewSwappableClient creates a SwappableClient wrapping the given initial client.
-func NewSwappableClient(initial Client, modelName string) (*SwappableClient, error) {
+func NewSwappableClient(initial Client, modelName string, params ...RuntimeParams) (*SwappableClient, error) {
 	if initial == nil {
 		return nil, errors.New("llm: SwappableClient requires non-nil initial client")
 	}
-	return &SwappableClient{inner: initial, modelName: modelName}, nil
+	sc := &SwappableClient{inner: initial, modelName: modelName}
+	if len(params) > 0 {
+		sc.runtimeParams = params[0]
+	}
+	return sc, nil
 }
 
 // Chat delegates to the inner client. The inner reference is copied under
@@ -68,9 +82,10 @@ func (sc *SwappableClient) Close() error {
 	return c.Close()
 }
 
-// Swap atomically replaces the inner client and model name. The old client's
-// Close is called in a background goroutine with a timeout to avoid blocking.
-func (sc *SwappableClient) Swap(newClient Client, newModelName string) error {
+// Swap atomically replaces the inner client, model name, and runtime params.
+// The old client's Close is called in a background goroutine with a timeout
+// so it never blocks callers.
+func (sc *SwappableClient) Swap(newClient Client, newModelName string, params ...RuntimeParams) error {
 	if newClient == nil {
 		return errors.New("llm: cannot swap to nil client")
 	}
@@ -78,6 +93,9 @@ func (sc *SwappableClient) Swap(newClient Client, newModelName string) error {
 	old := sc.inner
 	sc.inner = newClient
 	sc.modelName = newModelName
+	if len(params) > 0 {
+		sc.runtimeParams = params[0]
+	}
 	sc.mu.Unlock()
 
 	go closeWithTimeout(old, oldClientCloseTimeout)
@@ -100,6 +118,14 @@ func (sc *SwappableClient) ModelName() string {
 	name := sc.modelName
 	sc.mu.RUnlock()
 	return name
+}
+
+// RuntimeParameters returns the current runtime parameters for the LLM.
+func (sc *SwappableClient) RuntimeParameters() RuntimeParams {
+	sc.mu.RLock()
+	p := sc.runtimeParams
+	sc.mu.RUnlock()
+	return p
 }
 
 func closeWithTimeout(c Client, timeout time.Duration) {

--- a/pkg/kubernautagent/llm/types.go
+++ b/pkg/kubernautagent/llm/types.go
@@ -88,7 +88,7 @@ type TokenUsage struct {
 
 // ChatOptions holds optional parameters for the LLM call.
 type ChatOptions struct {
-	Temperature  float64         `json:"temperature,omitempty"`
+	Temperature  *float64        `json:"temperature,omitempty"`
 	MaxTokens    int             `json:"max_tokens,omitempty"`
 	JSONMode     bool            `json:"json_mode,omitempty"`
 	OutputSchema json.RawMessage `json:"output_schema,omitempty"`

--- a/pkg/kubernautagent/llm/vertexanthropic/client.go
+++ b/pkg/kubernautagent/llm/vertexanthropic/client.go
@@ -139,8 +139,8 @@ func (c *Client) buildParams(req llm.ChatRequest) anthropic.MessageNewParams {
 	if req.Options.MaxTokens > 0 {
 		params.MaxTokens = int64(req.Options.MaxTokens)
 	}
-	if req.Options.Temperature > 0 {
-		params.Temperature = anthropic.Float(req.Options.Temperature)
+	if req.Options.Temperature != nil {
+		params.Temperature = anthropic.Float(*req.Options.Temperature)
 	}
 
 	var pendingToolResults []anthropic.ContentBlockParamUnion

--- a/pkg/kubernautagent/tools/summarizer/summarizer.go
+++ b/pkg/kubernautagent/tools/summarizer/summarizer.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools"
+	"k8s.io/utils/ptr"
 )
 
 // Summarizer uses a secondary LLM call to shorten tool output that exceeds
@@ -88,7 +89,7 @@ func (s *Summarizer) MaybeSummarize(ctx context.Context, toolName string, result
 			{Role: "user", Content: prompt},
 		},
 		Options: llm.ChatOptions{
-			Temperature: 0.0,
+			Temperature: ptr.To(0.0),
 		},
 	})
 	if err != nil {

--- a/test/integration/kubernautagent/llm/adapter_httptest_684_test.go
+++ b/test/integration/kubernautagent/llm/adapter_httptest_684_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Vertex AI + Claude httptest round-trips — #684", func() {
 		},
 		Options: llm.ChatOptions{
 			MaxTokens:   200,
-			Temperature: 0.0,
+			Temperature: func() *float64 { v := 0.0; return &v }(),
 		},
 	}
 

--- a/test/integration/kubernautagent/llm/adapter_httptest_test.go
+++ b/test/integration/kubernautagent/llm/adapter_httptest_test.go
@@ -43,7 +43,7 @@ var _ = Describe("LLM Adapter httptest round-trips — #433", func() {
 		},
 		Options: llm.ChatOptions{
 			MaxTokens:   100,
-			Temperature: 0.0,
+			Temperature: func() *float64 { v := 0.0; return &v }(),
 		},
 	}
 

--- a/test/unit/kubernautagent/alignment/alignment_test.go
+++ b/test/unit/kubernautagent/alignment/alignment_test.go
@@ -399,8 +399,8 @@ var _ = Describe("Shadow Agent alignment — BR-AI-601", func() {
 		})
 	})
 
-	Describe("UT-SA-601-012: ToolProxy.Execute delegates and observes via context", func() {
-		It("should call inner Execute and submit the tool step to the context observer", func() {
+	Describe("UT-SA-601-012: ToolProxy.Execute delegates and SubmitToolStep observes via context", func() {
+		It("should call inner Execute and submit the tool step to the context observer via SubmitToolStep", func() {
 			inner := &mockToolRegistry{executeResult: `{"ok":true}`}
 			shadowClient := &mockLLMClient{responses: []llm.ChatResponse{cleanResponse()}}
 			evaluator := alignment.NewEvaluator(shadowClient, alignment.EvaluatorConfig{
@@ -415,6 +415,8 @@ var _ = Describe("Shadow Agent alignment — BR-AI-601", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(inner.executeCalls).To(Equal(1), "must delegate to inner registry")
 			Expect(out).To(Equal(`{"ok":true}`))
+
+			alignment.SubmitToolStep(ctx, "get_pods", out)
 
 			wr := observer.WaitForCompletion(5 * time.Second)
 			Expect(wr.Observations).To(HaveLen(1), "one observation for the tool result")
@@ -862,7 +864,7 @@ var _ = Describe("Correctness fixes — BR-AI-601", func() {
 		})
 	})
 
-	Describe("UT-SA-601-CX-003: ToolProxy sends error content to shadow", func() {
+	Describe("UT-SA-601-CX-003: SubmitToolStep sends error content to shadow", func() {
 		It("should submit error content to shadow when Execute fails", func() {
 			toolErr := errors.New("connection refused")
 			inner := &mockToolRegistry{executeErr: toolErr}
@@ -876,6 +878,8 @@ var _ = Describe("Correctness fixes — BR-AI-601", func() {
 
 			_, err := proxy.Execute(ctx, "get_pods", json.RawMessage(`{}`))
 			Expect(err).To(HaveOccurred())
+
+			alignment.SubmitToolStep(ctx, "get_pods", err.Error())
 
 			wr := observer.WaitForCompletion(5 * time.Second)
 			Expect(wr.Observations).To(HaveLen(1), "error content must be submitted to shadow")

--- a/test/unit/kubernautagent/audit/ds_store_audit_parity_test.go
+++ b/test/unit/kubernautagent/audit/ds_store_audit_parity_test.go
@@ -835,4 +835,36 @@ var _ = Describe("KA Audit Parity — TP-433-AUDIT-SOC2", func() {
 			Expect(payload.ResponseData.Warnings).To(BeEmpty())
 		})
 	})
+
+	// --- BUG-5: Workflow retry event completeness ---
+
+	Describe("UT-KA-967-005: LLM retry events must include prompt_length and prompt_preview", func() {
+		It("should have prompt_length and prompt_preview on workflow retry audit event", func() {
+			event := audit.NewEvent(audit.EventTypeLLMRequest, "corr-retry-wf")
+			event.EventAction = audit.ActionLLMRequest
+			event.EventOutcome = audit.OutcomeSuccess
+
+			event.Data["model"] = "test-model"
+			event.Data["retry_attempt"] = 1
+			event.Data["retry_max"] = 3
+			event.Data["phase"] = "workflow_discovery"
+			event.Data["retry_reason"] = "parse_level_correction"
+			event.Data["prompt_length"] = 1500
+			event.Data["prompt_preview"] = "Please correct the JSON output..."
+
+			recorder := &fakeOgenClient{}
+			store := audit.NewDSAuditStore(recorder)
+			err := store.StoreAudit(context.Background(), event)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(recorder.calls).To(HaveLen(1))
+
+			payload, ok := recorder.calls[0].EventData.GetLLMRequestPayload()
+			Expect(ok).To(BeTrue(), "must map to LLMRequestPayload")
+			Expect(payload.Model).To(Equal("test-model"))
+			Expect(payload.PromptLength).To(Equal(1500),
+				"prompt_length must be populated for retry audit events (BUG-5)")
+			Expect(payload.PromptPreview).To(Equal("Please correct the JSON output..."),
+				"prompt_preview must be populated for retry audit events (BUG-5)")
+		})
+	})
 })

--- a/test/unit/kubernautagent/audit/ds_store_audit_parity_test.go
+++ b/test/unit/kubernautagent/audit/ds_store_audit_parity_test.go
@@ -290,6 +290,82 @@ var _ = Describe("KA Audit Parity — TP-433-AUDIT-SOC2", func() {
 		})
 	})
 
+	// --- Phase 4b: Alignment Events (#942) ---
+
+	Describe("UT-KA-942-001: buildEventData maps AlignmentStepPayload (#942)", func() {
+		It("should populate step_index, step_kind, tool, explanation for suspicious step", func() {
+			recorder := &fakeOgenClient{}
+			store := audit.NewDSAuditStore(recorder)
+
+			event := audit.NewEvent(audit.EventTypeAlignmentStep, "corr-align-step")
+			event.Data["step_index"] = 3
+			event.Data["step_kind"] = "tool_result"
+			event.Data["tool"] = "kubectl_get"
+			event.Data["explanation"] = "step attempts to read secrets outside scope"
+
+			err := store.StoreAudit(context.Background(), event)
+			Expect(err).NotTo(HaveOccurred())
+
+			req := recorder.calls[0]
+			Expect(req.EventData.Type).To(Equal(ogenclient.AlignmentStepPayloadAuditEventRequestEventData))
+
+			payload, ok := req.EventData.GetAlignmentStepPayload()
+			Expect(ok).To(BeTrue())
+			Expect(payload.StepIndex).To(Equal(3))
+			Expect(payload.StepKind).To(Equal("tool_result"))
+			Expect(payload.Tool.Value).To(Equal("kubectl_get"))
+			Expect(payload.Explanation.Value).To(ContainSubstring("secrets outside scope"))
+		})
+	})
+
+	Describe("UT-KA-942-002: buildEventData maps AlignmentVerdictPayload (#942)", func() {
+		It("should populate result, summary, flagged, total for suspicious verdict", func() {
+			recorder := &fakeOgenClient{}
+			store := audit.NewDSAuditStore(recorder)
+
+			event := audit.NewEvent(audit.EventTypeAlignmentVerdict, "corr-align-verdict")
+			event.Data["result"] = "suspicious"
+			event.Data["summary"] = "2 steps flagged as suspicious out of 15 total"
+			event.Data["flagged"] = 2
+			event.Data["total"] = 15
+
+			err := store.StoreAudit(context.Background(), event)
+			Expect(err).NotTo(HaveOccurred())
+
+			req := recorder.calls[0]
+			Expect(req.EventData.Type).To(Equal(ogenclient.AlignmentVerdictPayloadAuditEventRequestEventData))
+
+			payload, ok := req.EventData.GetAlignmentVerdictPayload()
+			Expect(ok).To(BeTrue())
+			Expect(string(payload.Result)).To(Equal("suspicious"))
+			Expect(payload.Summary.Value).To(ContainSubstring("2 steps flagged"))
+			Expect(payload.Flagged).To(Equal(2))
+			Expect(payload.Total).To(Equal(15))
+		})
+	})
+
+	Describe("UT-KA-942-003: alignment verdict with aligned result (#942)", func() {
+		It("should map aligned result correctly", func() {
+			recorder := &fakeOgenClient{}
+			store := audit.NewDSAuditStore(recorder)
+
+			event := audit.NewEvent(audit.EventTypeAlignmentVerdict, "corr-align-ok")
+			event.Data["result"] = "aligned"
+			event.Data["summary"] = "all steps aligned"
+			event.Data["flagged"] = 0
+			event.Data["total"] = 10
+
+			err := store.StoreAudit(context.Background(), event)
+			Expect(err).NotTo(HaveOccurred())
+
+			payload, ok := recorder.calls[0].EventData.GetAlignmentVerdictPayload()
+			Expect(ok).To(BeTrue())
+			Expect(string(payload.Result)).To(Equal("aligned"))
+			Expect(payload.Flagged).To(Equal(0))
+			Expect(payload.Total).To(Equal(10))
+		})
+	})
+
 	// --- Phase 5: Response Failed ---
 
 	Describe("UT-KA-433-AP-011: buildEventData maps AIAgentResponseFailedPayload", func() {

--- a/test/unit/kubernautagent/llm/chat_with_params_test.go
+++ b/test/unit/kubernautagent/llm/chat_with_params_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llm_test
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+)
+
+type capturingClient struct {
+	mu          sync.Mutex
+	capturedCtx context.Context
+	capturedReq llm.ChatRequest
+	resp        llm.ChatResponse
+	err         error
+}
+
+func (c *capturingClient) Chat(ctx context.Context, req llm.ChatRequest) (llm.ChatResponse, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.capturedCtx = ctx
+	c.capturedReq = req
+	return c.resp, c.err
+}
+
+func (c *capturingClient) Close() error { return nil }
+
+var _ = Describe("ChatWithParams — BUG-1/BUG-3 fixes", func() {
+
+	Describe("UT-KA-967-002: applies context timeout when TimeoutSeconds > 0", func() {
+		It("should set a deadline on the context passed to Chat", func() {
+			mock := &capturingClient{resp: llm.ChatResponse{
+				Message: llm.Message{Role: "assistant", Content: "ok"},
+			}}
+
+			params := llm.RuntimeParams{
+				Temperature:    0.7,
+				TimeoutSeconds: 5,
+			}
+			req := llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "test"}},
+			}
+
+			_, err := llm.ChatWithParams(context.Background(), mock, req, params)
+			Expect(err).NotTo(HaveOccurred())
+
+			deadline, ok := mock.capturedCtx.Deadline()
+			Expect(ok).To(BeTrue(), "context must have a deadline when TimeoutSeconds > 0")
+			Expect(deadline).To(BeTemporally("~", time.Now().Add(5*time.Second), 2*time.Second))
+		})
+	})
+
+	Describe("UT-KA-967-003: injects temperature via pointer", func() {
+		It("should set Temperature on the ChatRequest passed to Chat", func() {
+			mock := &capturingClient{resp: llm.ChatResponse{
+				Message: llm.Message{Role: "assistant", Content: "ok"},
+			}}
+
+			params := llm.RuntimeParams{
+				Temperature: 0.7,
+			}
+			req := llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "test"}},
+				Options:  llm.ChatOptions{JSONMode: true},
+			}
+
+			_, err := llm.ChatWithParams(context.Background(), mock, req, params)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mock.capturedReq.Options.Temperature).NotTo(BeNil(),
+				"Temperature must be set by ChatWithParams")
+			Expect(*mock.capturedReq.Options.Temperature).To(BeNumerically("~", 0.7, 0.001))
+			Expect(mock.capturedReq.Options.JSONMode).To(BeTrue(),
+				"other options must be preserved")
+		})
+	})
+
+	Describe("UT-KA-967-004: no timeout when TimeoutSeconds is 0", func() {
+		It("should not wrap context with timeout", func() {
+			mock := &capturingClient{resp: llm.ChatResponse{
+				Message: llm.Message{Role: "assistant", Content: "ok"},
+			}}
+
+			params := llm.RuntimeParams{
+				Temperature:    0.5,
+				TimeoutSeconds: 0,
+			}
+			req := llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "test"}},
+			}
+
+			_, err := llm.ChatWithParams(context.Background(), mock, req, params)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, ok := mock.capturedCtx.Deadline()
+			Expect(ok).To(BeFalse(), "context must NOT have a deadline when TimeoutSeconds is 0")
+		})
+	})
+})

--- a/test/unit/kubernautagent/llm/langchaingo_adapter_test.go
+++ b/test/unit/kubernautagent/llm/langchaingo_adapter_test.go
@@ -372,6 +372,68 @@ var _ = Describe("LangChainGo Adapter — #433", func() {
 		})
 	})
 
+	Describe("UT-KA-967-001: Temperature=0 must reach the LLM backend", func() {
+		var (
+			server       *httptest.Server
+			adapter      llm.Client
+			receivedBody []byte
+		)
+
+		BeforeEach(func() {
+			content := "deterministic output"
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var reqBody json.RawMessage
+				Expect(json.NewDecoder(r.Body).Decode(&reqBody)).To(Succeed())
+				receivedBody = reqBody
+
+				resp := openaitypes.ChatCompletionResponse{
+					ID:      "chatcmpl-temp0",
+					Object:  openaitypes.ObjectChatCompletion,
+					Created: openaitypes.FixedCreatedTime,
+					Model:   "mock-model",
+					Choices: []openaitypes.Choice{
+						{
+							Index:        0,
+							Message:      openaitypes.Message{Role: "assistant", Content: &content},
+							FinishReason: "stop",
+						},
+					},
+					Usage: openaitypes.Usage{PromptTokens: 10, CompletionTokens: 5, TotalTokens: 15},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				Expect(json.NewEncoder(w).Encode(resp)).To(Succeed())
+			}))
+
+			var err error
+			adapter, err = langchaingo.New("openai", server.URL, "mock-model", "sk-test")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			server.Close()
+		})
+
+		It("should include temperature=0 in the request when explicitly set — BR-HAPI-199", func() {
+			zero := 0.0
+			req := llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "deterministic query"}},
+				Options:  llm.ChatOptions{Temperature: &zero},
+			}
+
+			_, err := adapter.Chat(context.Background(), req)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(receivedBody).NotTo(BeEmpty())
+			var sent map[string]interface{}
+			Expect(json.Unmarshal(receivedBody, &sent)).To(Succeed())
+			Expect(sent).To(HaveKey("temperature"),
+				"temperature=0 must be sent to the LLM, not silently dropped")
+			Expect(sent["temperature"]).To(BeNumerically("==", 0),
+				"temperature value must be exactly 0 for deterministic/greedy decoding")
+		})
+
+	})
+
 	Describe("UT-KA-433-051: Anthropic adapter Chat() via mock HTTP server", func() {
 		var (
 			server  *httptest.Server

--- a/test/unit/kubernautagent/llm/types_test.go
+++ b/test/unit/kubernautagent/llm/types_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 )
 
+func floatPtr(v float64) *float64 { return &v }
+
 var _ = Describe("LLM Types — #433", func() {
 
 	Describe("UT-KA-433-004: ChatRequest/ChatResponse round-trip serialization", func() {
@@ -45,11 +47,11 @@ var _ = Describe("LLM Types — #433", func() {
 						Parameters:  json.RawMessage(`{"type":"object","properties":{"kind":{"type":"string"}}}`),
 					},
 				},
-				Options: llm.ChatOptions{
-					Temperature: 0.1,
-					MaxTokens:   4096,
-					JSONMode:    true,
-				},
+			Options: llm.ChatOptions{
+				Temperature: floatPtr(0.1),
+				MaxTokens:   4096,
+				JSONMode:    true,
+			},
 			}
 
 			data, err := json.Marshal(original)
@@ -66,7 +68,8 @@ var _ = Describe("LLM Types — #433", func() {
 			Expect(restored.Messages[3].ToolCallID).To(Equal("tc_1"))
 			Expect(restored.Tools).To(HaveLen(1))
 			Expect(restored.Tools[0].Name).To(Equal("kubectl_describe"))
-			Expect(restored.Options.Temperature).To(BeNumerically("~", 0.1, 0.001))
+			Expect(restored.Options.Temperature).NotTo(BeNil())
+			Expect(*restored.Options.Temperature).To(BeNumerically("~", 0.1, 0.001))
 			Expect(restored.Options.MaxTokens).To(Equal(4096))
 			Expect(restored.Options.JSONMode).To(BeTrue())
 

--- a/test/unit/kubernautagent/llm/vertexanthropic/client_test.go
+++ b/test/unit/kubernautagent/llm/vertexanthropic/client_test.go
@@ -42,6 +42,8 @@ import (
 // generateFakeServiceAccountJSON builds a GCP service account credential blob
 // with a real RSA-2048 key so that the SDK's JWT-signing transport works in
 // tests. The key is generated fresh each run and never leaves the process.
+func floatPtr(v float64) *float64 { return &v }
+
 func generateFakeServiceAccountJSON() []byte {
 	return generateFakeServiceAccountJSONWithTokenURL("https://oauth2.googleapis.com/token")
 }
@@ -422,7 +424,7 @@ var _ = Describe("vertexanthropic.Client — #684 #686", func() {
 
 			_, err := client.Chat(context.Background(), llm.ChatRequest{
 				Messages: []llm.Message{{Role: "user", Content: "hello"}},
-				Options:  llm.ChatOptions{Temperature: 0.7},
+				Options:  llm.ChatOptions{Temperature: floatPtr(0.7)},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(receivedBody).To(HaveKeyWithValue("temperature", BeNumerically("~", 0.7, 0.01)))


### PR DESCRIPTION
## Summary

Addresses all P0 findings from the KA QE-readiness audit, ensuring alignment audit events persist correctly, synthetic LLM events conform to the OpenAPI contract, the shadow agent evaluates sanitized content, and LLM runtime config fields are actually wired.

- **GAP-A1** (#942): Add `AlignmentStepPayload` and `AlignmentVerdictPayload` schemas to `data-storage-v1.yaml` with discriminator mappings. Regenerate ogen client. Add `buildEventData` mapping cases so alignment events are no longer dropped with `event_data: null`. 3 new unit tests.
- **GAP-A2** (#944): Populate required OpenAPI fields (`model`, `prompt_length`, `prompt_preview`, `has_analysis`, `analysis_length`, `analysis_preview`) on all 4 synthetic LLM audit event sites (RCA retry, same-kind gate, workflow alignment gate, truncation detection).
- **GAP-S1** (#945): Move shadow tool-result submission from `ToolProxy` (pre-pipeline) to `investigator.executeTool` (post-pipeline). Shadow agent now evaluates the same sanitized, truncated output as the primary LLM. Error paths also forwarded.
- **GAP-C1** (#946): Wire `temperature`, `timeoutSeconds`, `maxRetries` from `LLMRuntimeConfig` to LLM client and Chat calls. Temperature passed via `ChatOptions`, timeout as both HTTP client and context deadline, runtime params stored in `SwappableClient` and propagated on hot-reload.

## Test plan

- [x] 64/64 audit unit tests pass (including 3 new alignment tests: UT-KA-942-001 through 003)
- [x] `go build ./...` clean
- [x] `go vet` clean
- [x] Pre-commit hooks pass (anti-pattern detection, CRD-OpenAPI enum drift)
- [ ] CI: unit tests
- [ ] CI: integration tests (KA)
- [ ] CI: E2E tests (KA)

Closes #942, #944, #945, #946

Made with [Cursor](https://cursor.com)