### PR TITLE
fix(ci): resolve CI failures and wire HARM-004 RR existence check

### DIFF
--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -32,13 +32,16 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/restmapper"
 	ctrl "sigs.k8s.io/controller-runtime"
 
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
 	"github.com/jordigilh/kubernaut/pkg/agentclient"
 	sharedaudit "github.com/jordigilh/kubernaut/pkg/audit"
 	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
@@ -969,12 +972,18 @@ func buildMCPHandler(
 	
 
 	// SEC-07: Build controller-runtime client with MCP-specific timeouts.
+	// Scheme includes remediationv1 for RR existence validation (HARM-004)
+	// and future NL signal intake (#714).
+	mcpScheme := k8sruntime.NewScheme()
+	_ = clientgoscheme.AddToScheme(mcpScheme)
+	_ = remediationv1.AddToScheme(mcpScheme)
+
 	mcpRestConfig := *infra.kubeConfig
 	mcpRestConfig.Timeout = 10 * time.Second
 	mcpRestConfig.QPS = 20
 	mcpRestConfig.Burst = 40
 
-	ctrlCli, err := ctrlclient.New(&mcpRestConfig, ctrlclient.Options{})
+	ctrlCli, err := ctrlclient.New(&mcpRestConfig, ctrlclient.Options{Scheme: mcpScheme})
 	if err != nil {
 		logger.Error(err, "MCP interactive mode: failed to create controller-runtime client")
 		return nil
@@ -1077,12 +1086,16 @@ func buildMCPHandler(
 	// UX-01/02: Session notifier delivers timeout warnings to MCP clients.
 	sessionNotifier := mcpkg.NewSessionNotifier()
 
+	// HARM-004: Validate RR existence before creating interactive Leases.
+	rrChecker := mcptools.NewK8sRRExistenceChecker(ctrlCli, namespace)
+
 	// Build the InvestigateTool with optional dependencies.
 	investigateOpts := []mcptools.InvestigateOption{
 		mcptools.WithToolMetrics(agentMetrics),
 		mcptools.WithRateLimiter(sessionRateLimiter),
 		mcptools.WithTimeoutTracker(timeoutMgr),
 		mcptools.WithNotifyFunc(sessionNotifier.Notify),
+		mcptools.WithRRExistenceChecker(rrChecker),
 	}
 	if autoMgr != nil {
 		investigateOpts = append(investigateOpts, mcptools.WithAutonomousManager(autoMgr))

--- a/internal/kubernautagent/mcp/tools/errors.go
+++ b/internal/kubernautagent/mcp/tools/errors.go
@@ -74,4 +74,8 @@ var (
 		Code:    "session_expired",
 		Message: "Session has expired due to TTL or inactivity. Start a new session.",
 	}
+	ErrCodeRRNotFound = &MCPError{
+		Code:    "rr_not_found",
+		Message: "RemediationRequest not found",
+	}
 )

--- a/internal/kubernautagent/mcp/tools/investigate.go
+++ b/internal/kubernautagent/mcp/tools/investigate.go
@@ -49,6 +49,13 @@ type AutonomousSessionManager interface {
 	CancelInvestigation(id string) error
 }
 
+// RRExistenceChecker validates that a RemediationRequest exists before
+// creating a Lease. Prevents orphaned Lease resources for non-existent RRs
+// (HARM-004). Implemented by a thin K8s client wrapper at wiring time.
+type RRExistenceChecker interface {
+	RemediationRequestExists(ctx context.Context, rrID string) (bool, error)
+}
+
 // MessageRateLimiter enforces per-session rate limits on tool messages.
 // Implemented by *mcp.SessionRateLimiter.
 type MessageRateLimiter interface {
@@ -70,6 +77,7 @@ type InvestigateTool struct {
 	runner         InvestigatorRunner
 	recon          mcpinternal.ContextReconstructor
 	autoMgr        AutonomousSessionManager
+	rrChecker      RRExistenceChecker
 	metrics        ToolMetrics
 	rateLimiter    MessageRateLimiter
 	timeoutTracker TimeoutTracker
@@ -113,6 +121,16 @@ func WithTimeoutTracker(tt TimeoutTracker) InvestigateOption {
 	return func(t *InvestigateTool) {
 		if tt != nil {
 			t.timeoutTracker = tt
+		}
+	}
+}
+
+// WithRRExistenceChecker enables pre-Lease validation that the target
+// RemediationRequest exists (HARM-004: prevents orphaned Lease resources).
+func WithRRExistenceChecker(checker RRExistenceChecker) InvestigateOption {
+	return func(t *InvestigateTool) {
+		if checker != nil {
+			t.rrChecker = checker
 		}
 	}
 }
@@ -182,6 +200,16 @@ func (t *InvestigateTool) dispatch(ctx context.Context, input InvestigateInput, 
 }
 
 func (t *InvestigateTool) handleStart(ctx context.Context, input InvestigateInput, user mcpinternal.UserInfo) (InvestigateOutput, error) {
+	if t.rrChecker != nil {
+		exists, err := t.rrChecker.RemediationRequestExists(ctx, input.RRID)
+		if err != nil {
+			return InvestigateOutput{}, fmt.Errorf("validate remediation request: %w", err)
+		}
+		if !exists {
+			return InvestigateOutput{}, ErrCodeRRNotFound.WithDetail("rr_id", input.RRID)
+		}
+	}
+
 	sess, err := t.sessions.Takeover(ctx, input.RRID, user)
 	if err != nil {
 		if errors.Is(err, mcpinternal.ErrLeaseHeld) {

--- a/internal/kubernautagent/mcp/tools/rr_checker.go
+++ b/internal/kubernautagent/mcp/tools/rr_checker.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"context"
+
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// K8sRRExistenceChecker implements RRExistenceChecker by querying the K8s API
+// for a RemediationRequest CRD by name. Follows the same pattern as
+// pkg/gateway/k8s.Client.GetRemediationRequest (BR-GATEWAY-190).
+//
+// HARM-004: Prevents orphaned Lease creation for non-existent RRs.
+type K8sRRExistenceChecker struct {
+	client    client.Client
+	namespace string
+}
+
+// NewK8sRRExistenceChecker creates a checker backed by a controller-runtime client.
+func NewK8sRRExistenceChecker(c client.Client, namespace string) *K8sRRExistenceChecker {
+	return &K8sRRExistenceChecker{client: c, namespace: namespace}
+}
+
+func (c *K8sRRExistenceChecker) RemediationRequestExists(ctx context.Context, rrID string) (bool, error) {
+	var rr remediationv1.RemediationRequest
+	err := c.client.Get(ctx, client.ObjectKey{Namespace: c.namespace, Name: rrID}, &rr)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+var _ RRExistenceChecker = (*K8sRRExistenceChecker)(nil)

--- a/test/e2e/fullpipeline/04_interactive_regression_test.go
+++ b/test/e2e/fullpipeline/04_interactive_regression_test.go
@@ -44,10 +44,11 @@ import (
 // Context: Full pipeline E2E with all services deployed.
 var _ = Describe("CP-5 HARM-001: Autonomous regression — no interactive artifacts", Label("e2e", "fullpipeline", "interactive", "harm"), Ordered, func() {
 
-	var (
-		testNamespace string
-		testCtx       = ctx
-	)
+	var testNamespace string
+
+	BeforeAll(func() {
+		Expect(ctx).NotTo(BeNil(), "suite ctx must be initialized before tests run")
+	})
 
 	AfterAll(func() {
 		if testNamespace != "" {
@@ -70,7 +71,7 @@ var _ = Describe("CP-5 HARM-001: Autonomous regression — no interactive artifa
 		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
 
 		By("Step 2: Deploying memory-eater pod (triggers OOMKill → Gateway → pipeline)")
-		err := infrastructure.DeployMemoryEater(testCtx, testNamespace, kubeconfigPath, GinkgoWriter)
+		err := infrastructure.DeployMemoryEater(ctx, testNamespace, kubeconfigPath, GinkgoWriter)
 		Expect(err).ToNot(HaveOccurred(), "Failed to deploy memory-eater")
 
 		By("Step 2b: Waiting for OOMKill event...")

--- a/test/e2e/kubernautagent/interactive_flow_e2e_test.go
+++ b/test/e2e/kubernautagent/interactive_flow_e2e_test.go
@@ -27,9 +27,10 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/jordigilh/kubernaut/test/infrastructure"
+	testauth "github.com/jordigilh/kubernaut/test/shared/auth"
 )
 
-var _ = Describe("CP-5 INT: Interactive Flow Lifecycle Tests", Label("e2e", "ka", "interactive", "int"), Ordered, func() {
+var _ = Describe("CP-5 INT: Interactive Flow Lifecycle Tests", Label("e2e", "ka", "interactive", "int"), func() {
 
 	var (
 		mcpEndpoint  string
@@ -37,9 +38,9 @@ var _ = Describe("CP-5 INT: Interactive Flow Lifecycle Tests", Label("e2e", "ka"
 		saToken      string
 	)
 
-	BeforeAll(func() {
+	BeforeEach(func() {
 		mcpEndpoint = infrastructure.MCPEndpointForKAE2E()
-		tlsTransport = http.DefaultTransport
+		tlsTransport = testauth.NewRetryOn429Transport(http.DefaultTransport)
 
 		var err error
 		saToken, err = infrastructure.GetServiceAccountToken(ctx, sharedNamespace, "kubernaut-agent-e2e-sa", kubeconfigPath)

--- a/test/e2e/kubernautagent/interactive_harm_e2e_test.go
+++ b/test/e2e/kubernautagent/interactive_harm_e2e_test.go
@@ -31,18 +31,19 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/jordigilh/kubernaut/test/infrastructure"
+	testauth "github.com/jordigilh/kubernaut/test/shared/auth"
 )
 
-var _ = Describe("CP-5 HARM: Holistic Adversarial Regression & Misuse Scenarios", Label("e2e", "ka", "interactive", "harm"), Ordered, func() {
+var _ = Describe("CP-5 HARM: Holistic Adversarial Regression & Misuse Scenarios", Label("e2e", "ka", "interactive", "harm"), func() {
 
 	var (
 		mcpEndpoint  string
 		tlsTransport http.RoundTripper
 	)
 
-	BeforeAll(func() {
+	BeforeEach(func() {
 		mcpEndpoint = infrastructure.MCPEndpointForKAE2E()
-		tlsTransport = http.DefaultTransport
+		tlsTransport = testauth.NewRetryOn429Transport(http.DefaultTransport)
 	})
 
 	// ---------------------------------------------------------------

--- a/test/e2e/kubernautagent/interactive_ux_e2e_test.go
+++ b/test/e2e/kubernautagent/interactive_ux_e2e_test.go
@@ -26,9 +26,10 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/jordigilh/kubernaut/test/infrastructure"
+	testauth "github.com/jordigilh/kubernaut/test/shared/auth"
 )
 
-var _ = Describe("CP-5 UX: User Experience & Operational Tests", Label("e2e", "ka", "interactive", "ux"), Ordered, func() {
+var _ = Describe("CP-5 UX: User Experience & Operational Tests", Label("e2e", "ka", "interactive", "ux"), func() {
 
 	var (
 		mcpEndpoint  string
@@ -36,9 +37,9 @@ var _ = Describe("CP-5 UX: User Experience & Operational Tests", Label("e2e", "k
 		saToken      string
 	)
 
-	BeforeAll(func() {
+	BeforeEach(func() {
 		mcpEndpoint = infrastructure.MCPEndpointForKAE2E()
-		tlsTransport = http.DefaultTransport
+		tlsTransport = testauth.NewRetryOn429Transport(http.DefaultTransport)
 
 		var err error
 		saToken, err = infrastructure.GetServiceAccountToken(ctx, sharedNamespace, "kubernaut-agent-e2e-sa", kubeconfigPath)

--- a/test/integration/kubernautagent/mcp/suite_test.go
+++ b/test/integration/kubernautagent/mcp/suite_test.go
@@ -32,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
@@ -146,6 +147,18 @@ var _ = SynchronizedBeforeSuite(
 		return []byte(payload)
 	},
 	func(data []byte) {
+		lines := strings.SplitN(string(data), "\n", 2)
+
+		// Reconstruct rest.Config from the kubeconfig file written by process 1.
+		// In parallel Ginkgo execution, sharedK8sConfig is only set in the primary
+		// process; secondary processes must load it from the persisted kubeconfig.
+		if sharedK8sConfig == nil && len(lines) == 2 {
+			kubeconfigPath := lines[1]
+			cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+			Expect(err).ToNot(HaveOccurred(), "secondary process should load rest.Config from kubeconfig")
+			sharedK8sConfig = cfg
+		}
+
 		if sharedK8sClient == nil {
 			scheme := runtime.NewScheme()
 			Expect(coordinationv1.AddToScheme(scheme)).To(Succeed())
@@ -157,7 +170,6 @@ var _ = SynchronizedBeforeSuite(
 		}
 
 		// Build authenticated DS client for this Ginkgo process
-		lines := strings.SplitN(string(data), "\n", 2)
 		if len(lines) == 2 {
 			dsToken := lines[0]
 			dsURL := fmt.Sprintf("http://127.0.0.1:%d", mcpDataStoragePort)

--- a/test/integration/remediationorchestrator/interactive_timeout_integration_test.go
+++ b/test/integration/remediationorchestrator/interactive_timeout_integration_test.go
@@ -45,6 +45,7 @@ import (
 
 	aianalysisv1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
 	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
+	sharedtypes "github.com/jordigilh/kubernaut/pkg/shared/types"
 	"github.com/jordigilh/kubernaut/test/shared/helpers"
 )
 
@@ -63,7 +64,18 @@ var _ = Describe("DD-INTERACTIVE-002: Interactive Timeout Extension (Integration
 			ai := &aianalysisv1.AIAnalysis{
 				ObjectMeta: metav1.ObjectMeta{Name: aiName, Namespace: ns},
 				Spec: aianalysisv1.AIAnalysisSpec{
+					RemediationRequestRef: corev1.ObjectReference{Name: rrName, Namespace: ns},
+					RemediationID:         "it-703-001",
 					AnalysisRequest: aianalysisv1.AnalysisRequest{
+						SignalContext: aianalysisv1.SignalContextInput{
+							Fingerprint:      "a1b2c3d4e5f6",
+							Severity:         "medium",
+							SignalName:       "TestSignal",
+							Environment:      "test",
+							BusinessPriority: "P2",
+							TargetResource:   aianalysisv1.TargetResource{Kind: "Pod", Name: "test-pod", Namespace: ns},
+							EnrichmentResults: sharedtypes.EnrichmentResults{},
+						},
 						AnalysisTypes: []aianalysisv1.AnalysisType{aianalysisv1.AnalysisTypeInvestigation},
 					},
 				},
@@ -120,7 +132,18 @@ var _ = Describe("DD-INTERACTIVE-002: Interactive Timeout Extension (Integration
 			ai := &aianalysisv1.AIAnalysis{
 				ObjectMeta: metav1.ObjectMeta{Name: aiName, Namespace: ns},
 				Spec: aianalysisv1.AIAnalysisSpec{
+					RemediationRequestRef: corev1.ObjectReference{Name: rrName, Namespace: ns},
+					RemediationID:         "it-703-002",
 					AnalysisRequest: aianalysisv1.AnalysisRequest{
+						SignalContext: aianalysisv1.SignalContextInput{
+							Fingerprint:      "a1b2c3d4e5f6",
+							Severity:         "medium",
+							SignalName:       "TestSignal",
+							Environment:      "test",
+							BusinessPriority: "P2",
+							TargetResource:   aianalysisv1.TargetResource{Kind: "Pod", Name: "test-pod", Namespace: ns},
+							EnrichmentResults: sharedtypes.EnrichmentResults{},
+						},
 						AnalysisTypes: []aianalysisv1.AnalysisType{aianalysisv1.AnalysisTypeInvestigation},
 					},
 				},

--- a/test/shared/helpers/remediation.go
+++ b/test/shared/helpers/remediation.go
@@ -109,6 +109,8 @@ func NewRemediationRequest(name, namespace string, opts ...RemediationRequestOpt
 				Name:      targetName,
 				Namespace: targetNamespace,
 			},
+			FiringTime:   metav1.Now(),
+			ReceivedTime: metav1.Now(),
 		},
 	}
 


### PR DESCRIPTION
## Summary

- Fix 6 CI failures from `development/v1.5` [GHA run #25237975214](https://github.com/jordigilh/kubernaut/actions/runs/25237975214)
- Wire HARM-004 production fix: validate RemediationRequest existence before creating interactive session Leases, preventing orphaned Lease resources for non-existent RRs
- Register `remediationv1alpha1` scheme on MCP controller-runtime client, forward-looking for #714 (NL signal intake)

## Changes

### CI Fixes (Integration)

| Job | Root Cause | Fix |
|-----|-----------|-----|
| Integration (kubernautagent) | `nil rest.Config` in secondary Ginkgo processes | Reconstruct config from kubeconfig via `clientcmd.BuildConfigFromFlags` |
| Integration (remediationorchestrator) | Missing required CRD fields in AIAnalysis/RR fixtures | Add `RemediationRequestRef`, `RemediationID`, `SignalContextInput`, `FiringTime`, `ReceivedTime` |

### CI Fixes (E2E)

| Job | Root Cause | Fix |
|-----|-----------|-----|
| E2E (fullpipeline) HARM-001 | Nil context panic — `testCtx = ctx` at package init | Replace with `BeforeAll` guard, use suite `ctx` directly |
| E2E (kubernautagent) UX-002 | `429 Too Many Requests` from `UserRateLimiter` | Remove `Ordered`, wrap `tlsTransport` with `RetryOn429Transport` |
| E2E (kubernautagent) HARM-004 | Lease created for non-existent RR (production bug) | See HARM-004 section below |

### HARM-004: RR Existence Validation (Production Fix)

**Problem**: `handleStart` blindly calls `Takeover()` which creates a K8s Lease even when the `rr_id` references a non-existent RemediationRequest. Adversarial users can exhaust `maxSessions` with fake RR IDs.

**Fix** (follows Gateway `GetRemediationRequest` pattern from `pkg/gateway/k8s/client.go`):
1. `RRExistenceChecker` interface + `handleStart` guard in `investigate.go`
2. `K8sRRExistenceChecker` concrete impl — `client.Get()` with `IsNotFound` handling
3. `remediationv1alpha1` scheme registered on MCP `ctrlCli` (also enables #714)
4. Always-on wiring in `cmd/kubernautagent/main.go` via `WithRRExistenceChecker`

### Files Changed

- `cmd/kubernautagent/main.go` — scheme registration + checker wiring
- `internal/kubernautagent/mcp/tools/investigate.go` — interface + guard
- `internal/kubernautagent/mcp/tools/rr_checker.go` — concrete checker (new)
- `internal/kubernautagent/mcp/tools/errors.go` — `ErrCodeRRNotFound`
- `test/e2e/fullpipeline/04_interactive_regression_test.go` — nil ctx fix
- `test/e2e/kubernautagent/interactive_{flow,harm,ux}_e2e_test.go` — Ordered removal + RetryOn429
- `test/integration/kubernautagent/mcp/suite_test.go` — secondary process rest.Config
- `test/integration/remediationorchestrator/interactive_timeout_integration_test.go` — CRD fields
- `test/shared/helpers/remediation.go` — FiringTime + ReceivedTime

## Test plan

- [ ] CI passes: Integration (kubernautagent) — nil rest.Config resolved
- [ ] CI passes: Integration (remediationorchestrator) — CRD validation resolved
- [ ] CI passes: E2E (fullpipeline) — HARM-001 nil context resolved
- [ ] CI passes: E2E (kubernautagent) — UX-002 rate limit resolved
- [ ] CI passes: E2E (kubernautagent) — HARM-004 no Lease for ghost RR
- [ ] Full build: `go build ./...` clean


Made with [Cursor](https://cursor.com)