### PR TITLE
fix(ci): resolve namespace collisions, E2E RR fixtures, and fullpipeline timeout

### DIFF
--- a/test/e2e/fullpipeline/04_interactive_regression_test.go
+++ b/test/e2e/fullpipeline/04_interactive_regression_test.go
@@ -116,7 +116,7 @@ var _ = Describe("CP-5 HARM-001: Autonomous regression — no interactive artifa
 				}
 			}
 			return false
-		}, 3*time.Minute, 2*time.Second).Should(BeTrue(), "Gateway should create RR for OOMKill")
+		}, timeout, interval).Should(BeTrue(), "Gateway should create RR for OOMKill")
 
 		By("Step 4: Waiting for AIAnalysis to reach Completed phase (autonomous)")
 		var aaName string

--- a/test/e2e/kubernautagent/interactive_flow_e2e_test.go
+++ b/test/e2e/kubernautagent/interactive_flow_e2e_test.go
@@ -55,6 +55,7 @@ var _ = Describe("CP-5 INT: Interactive Flow Lifecycle Tests", Label("e2e", "ka"
 	Describe("E2E-KA-INT-001: Complete interactive lifecycle", func() {
 		It("should execute full interactive lifecycle: start → message → complete [E2E-KA-INT-001]", func() {
 			rrID := fmt.Sprintf("rr-int001-%d", time.Now().Unix())
+			createTestRemediationRequest(ctx, rrID)
 
 			By("Step 1: Connecting MCP client")
 			session, err := infrastructure.ConnectMCPClient(ctx, infrastructure.MCPClientConfig{
@@ -133,6 +134,7 @@ var _ = Describe("CP-5 INT: Interactive Flow Lifecycle Tests", Label("e2e", "ka"
 			Expect(err).NotTo(HaveOccurred())
 
 			rrID := fmt.Sprintf("rr-int004-%d", time.Now().Unix())
+			createTestRemediationRequest(ctx, rrID)
 
 			By("Step 2: Connecting and starting session with limited SA")
 			session, err := infrastructure.ConnectMCPClient(ctx, infrastructure.MCPClientConfig{
@@ -187,6 +189,7 @@ var _ = Describe("CP-5 INT: Interactive Flow Lifecycle Tests", Label("e2e", "ka"
 			defer fullSession.Close()
 
 			fullRRID := fmt.Sprintf("rr-int004-full-%d", time.Now().Unix())
+			createTestRemediationRequest(ctx, fullRRID)
 			_, err = infrastructure.CallInvestigate(ctx, fullSession, map[string]any{
 				"rr_id":  fullRRID,
 				"action": "start",
@@ -218,6 +221,7 @@ var _ = Describe("CP-5 INT: Interactive Flow Lifecycle Tests", Label("e2e", "ka"
 	Describe("E2E-KA-INT-005: Audit trail complete in DS after full flow", func() {
 		It("should record complete audit trail in DataStorage [E2E-KA-INT-005]", func() {
 			rrID := fmt.Sprintf("rr-int005-%d", time.Now().Unix())
+			createTestRemediationRequest(ctx, rrID)
 
 			By("Step 1: Executing interactive flow")
 			session, err := infrastructure.ConnectMCPClient(ctx, infrastructure.MCPClientConfig{
@@ -285,6 +289,7 @@ var _ = Describe("CP-5 INT: Interactive Flow Lifecycle Tests", Label("e2e", "ka"
 	Describe("E2E-KA-INT-007: Multi-step interactive investigation with enrichment", func() {
 		It("should support multi-step Q&A, enrichment, and workflow selection [E2E-KA-INT-007]", func() {
 			rrID := fmt.Sprintf("rr-int007-%d", time.Now().Unix())
+			createTestRemediationRequest(ctx, rrID)
 
 			By("Step 1: Connecting and starting session")
 			session, err := infrastructure.ConnectMCPClient(ctx, infrastructure.MCPClientConfig{

--- a/test/e2e/kubernautagent/interactive_harm_e2e_test.go
+++ b/test/e2e/kubernautagent/interactive_harm_e2e_test.go
@@ -208,6 +208,7 @@ var _ = Describe("CP-5 HARM: Holistic Adversarial Regression & Misuse Scenarios"
 			Expect(err).NotTo(HaveOccurred(), "User-B SA should be created")
 
 			rrID := "rr-harm006-concurrent"
+			createTestRemediationRequest(ctx, rrID)
 
 			By("User-A connects and starts interactive session (acquires Lease)")
 			sessionA, err := infrastructure.ConnectMCPClient(ctx, infrastructure.MCPClientConfig{

--- a/test/e2e/kubernautagent/interactive_helpers_test.go
+++ b/test/e2e/kubernautagent/interactive_helpers_test.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernautagent
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
+)
+
+// createTestRemediationRequest provisions a minimal RemediationRequest CRD in the
+// Kind cluster so that the RRExistenceChecker (HARM-004) allows the session to start.
+// The RR is created with the bare minimum fields required by the CRD validation schema.
+func createTestRemediationRequest(testCtx context.Context, rrID string) {
+	GinkgoHelper()
+
+	scheme := k8sruntime.NewScheme()
+	Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+	Expect(remediationv1.AddToScheme(scheme)).To(Succeed())
+
+	cfg, err := clientcmd.BuildConfigFromFlags("", kubeconfigPath)
+	Expect(err).NotTo(HaveOccurred(), "build kubeconfig for RR creation")
+
+	cli, err := ctrlclient.New(cfg, ctrlclient.Options{Scheme: scheme})
+	Expect(err).NotTo(HaveOccurred(), "create controller-runtime client for RR creation")
+
+	rr := &remediationv1.RemediationRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rrID,
+			Namespace: sharedNamespace,
+		},
+		Spec: remediationv1.RemediationRequestSpec{
+			SignalFingerprint: "e2e-test-fingerprint-" + rrID,
+			SignalName:        "E2ETestSignal",
+			Severity:          "warning",
+			SignalType:        "alert",
+			SignalSource:      "e2e-test",
+			TargetType:        "kubernetes",
+			TargetResource: remediationv1.ResourceIdentifier{
+				Kind:      "Pod",
+				Name:      "e2e-test-pod",
+				Namespace: sharedNamespace,
+			},
+			FiringTime:   metav1.Now(),
+			ReceivedTime: metav1.Now(),
+		},
+	}
+
+	Expect(cli.Create(testCtx, rr)).To(Succeed(),
+		"should create RemediationRequest %s for E2E test", rrID)
+	GinkgoWriter.Printf("  📋 Created RR fixture: %s/%s\n", sharedNamespace, rrID)
+}

--- a/test/e2e/kubernautagent/interactive_ux_e2e_test.go
+++ b/test/e2e/kubernautagent/interactive_ux_e2e_test.go
@@ -54,6 +54,7 @@ var _ = Describe("CP-5 UX: User Experience & Operational Tests", Label("e2e", "k
 	Describe("E2E-KA-UX-001: Time-remaining visible during session", func() {
 		It("should show remaining session time via status query [E2E-KA-UX-001]", func() {
 			rrID := fmt.Sprintf("rr-ux001-%d", time.Now().Unix())
+			createTestRemediationRequest(ctx, rrID)
 
 			By("Step 1: Starting interactive session")
 			session, err := infrastructure.ConnectMCPClient(ctx, infrastructure.MCPClientConfig{
@@ -109,6 +110,7 @@ var _ = Describe("CP-5 UX: User Experience & Operational Tests", Label("e2e", "k
 	Describe("E2E-KA-UX-002: Inactivity timer resets on activity", func() {
 		It("should keep session alive when tool calls reset inactivity timer [E2E-KA-UX-002]", func() {
 			rrID := fmt.Sprintf("rr-ux002-%d", time.Now().Unix())
+			createTestRemediationRequest(ctx, rrID)
 
 			By("Step 1: Starting interactive session")
 			session, err := infrastructure.ConnectMCPClient(ctx, infrastructure.MCPClientConfig{
@@ -166,6 +168,7 @@ var _ = Describe("CP-5 UX: User Experience & Operational Tests", Label("e2e", "k
 	Describe("E2E-KA-UX-003: Rejection includes holder info", func() {
 		It("should include holder identity in rejection error [E2E-KA-UX-003]", func() {
 			rrID := fmt.Sprintf("rr-ux003-%d", time.Now().Unix())
+			createTestRemediationRequest(ctx, rrID)
 
 			By("Step 1: User-A takes over (holds Lease)")
 			tokenA, err := infrastructure.CreateInteractiveE2ESA(ctx, sharedNamespace, "ux003-user-a", kubeconfigPath, GinkgoWriter)
@@ -238,6 +241,7 @@ var _ = Describe("CP-5 UX: User Experience & Operational Tests", Label("e2e", "k
 	Describe("E2E-KA-UX-004: Prometheus metrics for interactive sessions", func() {
 		It("should emit session metrics on /metrics endpoint [E2E-KA-UX-004]", func() {
 			rrID := fmt.Sprintf("rr-ux004-%d", time.Now().Unix())
+			createTestRemediationRequest(ctx, rrID)
 
 			By("Step 1: Getting baseline metrics")
 			baselineMetrics := scrapeKAMetrics()

--- a/test/integration/kubernautagent/mcp/helpers_test.go
+++ b/test/integration/kubernautagent/mcp/helpers_test.go
@@ -20,12 +20,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-
-	"github.com/go-logr/logr"
 	"net/http"
 	"net/http/httptest"
 	"sync"
 	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
 
 	"github.com/go-chi/chi/v5"
 	. "github.com/onsi/ginkgo/v2"
@@ -243,15 +244,11 @@ func resetMockLLMTracker() {
 // Namespace helpers for test isolation
 // ---------------------------------------------------------------------------
 
-var nsCounter uint64
-var nsCounterMu sync.Mutex
-
 func uniqueNamespace(prefix string) string {
-	nsCounterMu.Lock()
-	nsCounter++
-	n := nsCounter
-	nsCounterMu.Unlock()
-	return fmt.Sprintf("mcp-it-%s-%d", prefix, n)
+	return fmt.Sprintf("mcp-it-%s-%d-%s",
+		prefix,
+		GinkgoParallelProcess(),
+		uuid.New().String()[:8])
 }
 
 func createNamespace(ctx context.Context, k8sClient client.Client, name string) {


### PR DESCRIPTION
## Summary

- **Integration test namespace collisions**: Replaced process-local counter in `uniqueNamespace()` with UUID-based naming (`{prefix}-{process}-{uuid[:8]}`) to prevent collisions across parallel Ginkgo workers.
- **E2E test RR fixtures**: Added `createTestRemediationRequest()` helper that provisions minimal `RemediationRequest` CRDs before each interactive session `start` call, satisfying the new `RRExistenceChecker` (HARM-004).
- **Fullpipeline timeout**: Aligned Step 3 `Eventually` block with suite-wide `timeout`/`interval` constants (10m/500ms) instead of the aggressive 3m/2s that caused CI timeouts.

## Test plan

- [ ] CI `Integration (kubernautagent)` job passes — no more `"already exists"` namespace errors
- [ ] CI `E2E (kubernautagent)` job passes — all interactive tests find their RR CRDs
- [ ] CI `E2E (fullpipeline)` job passes — HARM-001 no longer times out at 180s


Made with [Cursor](https://cursor.com)