### PR TITLE
fix(ka): P1 QE-readiness — GAP-E1/S2/S3/C2/T1 + maxRetries wiring

### DIFF
--- a/cmd/kubernautagent/ds_transport_test.go
+++ b/cmd/kubernautagent/ds_transport_test.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestBuildDSBaseTransport_WithCAFile(t *testing.T) {
+	caPath := generateTestCACert(t, "DS Test CA")
+
+	transport, err := buildDSBaseTransport(caPath)
+	if err != nil {
+		t.Fatalf("expected no error with valid CA file, got: %v", err)
+	}
+	if transport == nil {
+		t.Fatal("expected non-nil transport when caFile is set")
+	}
+	if transport == http.DefaultTransport {
+		t.Fatal("expected custom transport, got http.DefaultTransport")
+	}
+}
+
+func TestBuildDSBaseTransport_EmptyCAFile(t *testing.T) {
+	transport, err := buildDSBaseTransport("")
+	if err != nil {
+		t.Fatalf("expected no error with empty caFile, got: %v", err)
+	}
+	if transport == nil {
+		t.Fatal("expected non-nil transport (default fallback)")
+	}
+}
+
+func TestBuildDSBaseTransport_InvalidCAFile(t *testing.T) {
+	_, err := buildDSBaseTransport("/nonexistent/ca.crt")
+	if err == nil {
+		t.Fatal("expected error with invalid CA file path, got nil")
+	}
+}

--- a/cmd/kubernautagent/llm_builder_tls_test.go
+++ b/cmd/kubernautagent/llm_builder_tls_test.go
@@ -17,46 +17,13 @@ limitations under the License.
 package main
 
 import (
-	"crypto/ecdsa"
-	"crypto/elliptic"
-	"crypto/rand"
-	"crypto/x509"
-	"crypto/x509/pkix"
-	"encoding/pem"
-	"math/big"
-	"os"
-	"path/filepath"
 	"testing"
-	"time"
 
 	kaconfig "github.com/jordigilh/kubernaut/internal/kubernautagent/config"
 )
 
 func TestBuildTransportChain_TLSCaFile(t *testing.T) {
-	caDir := t.TempDir()
-	caPath := filepath.Join(caDir, "ca.crt")
-
-	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
-	if err != nil {
-		t.Fatal(err)
-	}
-	caTemplate := &x509.Certificate{
-		SerialNumber:          big.NewInt(1),
-		Subject:               pkix.Name{CommonName: "Test CA"},
-		NotBefore:             time.Now().Add(-1 * time.Hour),
-		NotAfter:              time.Now().Add(24 * time.Hour),
-		KeyUsage:              x509.KeyUsageCertSign,
-		BasicConstraintsValid: true,
-		IsCA:                  true,
-	}
-	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
-	if err != nil {
-		t.Fatal(err)
-	}
-	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertDER})
-	if err := os.WriteFile(caPath, caPEM, 0644); err != nil {
-		t.Fatal(err)
-	}
+	caPath := generateTestCACert(t, "Test CA")
 
 	cfg := kaconfig.DefaultConfig()
 	cfg.AI.LLM.TLSCaFile = caPath
@@ -86,7 +53,5 @@ func TestBuildTransportChain_InvalidCaFile(t *testing.T) {
 	rt := &kaconfig.LLMRuntimeConfig{}
 
 	transport := buildTransportChain(cfg, rt)
-	// With an invalid CA file, we expect either nil or an error-path behavior.
-	// The current implementation should handle this gracefully.
 	_ = transport
 }

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -47,6 +47,7 @@ import (
 	auth "github.com/jordigilh/kubernaut/pkg/shared/auth"
 	"github.com/jordigilh/kubernaut/pkg/shared/hotreload"
 	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
+	"github.com/jordigilh/kubernaut/pkg/shared/transport"
 
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/alignment"
 	alignprompt "github.com/jordigilh/kubernaut/internal/kubernautagent/alignment/prompt"
@@ -204,7 +205,7 @@ func main() {
 		var shadowClient llm.Client
 		if cfg.AI.AlignmentCheck.LLM == nil {
 			shadowClient = instrumentedLLM
-			logger.Info("shadow agent shares investigation LLM client")
+			logger.Error(nil, "shadow agent shares investigation LLM client — shadow requests will compete with primary investigation; configure ai.alignmentCheck.llm for dedicated shadow model")
 		} else {
 			alignStaticCfg, alignRtCfg := cfg.AI.AlignmentCheck.EffectiveLLM(cfg.AI.LLM, *llmRuntime)
 			alignCfgMerge := *cfg
@@ -531,11 +532,15 @@ func initDSClients(cfg *kaconfig.Config, infra *k8sInfra, logger logr.Logger) *d
 		return nil
 	}
 
-	// Issue #853: Wrapped with RetryTransport for transient failure resilience.
-	dsBase, tlsErr := sharedtls.DefaultBaseTransportWithRetry()
+	dsBase, tlsErr := buildDSBaseTransport(cfg.Integrations.DataStorage.TLS.CAFile)
 	if tlsErr != nil {
-		logger.Error(tlsErr, "failed to create TLS-aware transport for DS client")
+		logger.Error(tlsErr, "failed to create TLS-aware transport for DS client",
+			"ca_file", cfg.Integrations.DataStorage.TLS.CAFile)
 		return nil
+	}
+	if cfg.Integrations.DataStorage.TLS.CAFile != "" {
+		logger.Info("DS client configured with custom TLS CA",
+			"ca_file", cfg.Integrations.DataStorage.TLS.CAFile)
 	}
 
 	var opts []ogenclient.ClientOption
@@ -561,6 +566,21 @@ func initDSClients(cfg *kaconfig.Config, infra *k8sInfra, logger logr.Logger) *d
 		dsAdapter:  enrichment.NewDSAdapter(ogenClient),
 		k8sAdapter: enrichment.NewK8sAdapter(infra.dynClient, infra.mapper),
 	}
+}
+
+// buildDSBaseTransport creates the base HTTP transport for the DataStorage
+// client. When caFile is set, uses a custom TLS transport with the specified CA;
+// otherwise falls back to the shared default transport with retry.
+// Issue #951: Wire DataStorageConfig.TLS.CAFile to DS HTTP client.
+func buildDSBaseTransport(caFile string) (http.RoundTripper, error) {
+	if caFile != "" {
+		tlsTransport, err := sharedtls.NewTLSTransport(caFile)
+		if err != nil {
+			return nil, fmt.Errorf("DS TLS transport: %w", err)
+		}
+		return transport.NewRetryTransport(tlsTransport, transport.DefaultRetryConfig()), nil
+	}
+	return sharedtls.DefaultBaseTransportWithRetry()
 }
 
 // bearerTransport injects a Kubernetes ServiceAccount Bearer token into

--- a/cmd/kubernautagent/testutil_ca_test.go
+++ b/cmd/kubernautagent/testutil_ca_test.go
@@ -1,0 +1,62 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// generateTestCACert creates a self-signed CA certificate PEM file under
+// t.TempDir() and returns its path. The cert is valid for 24 hours.
+func generateTestCACert(t *testing.T, cn string) string {
+	t.Helper()
+	caDir := t.TempDir()
+	caPath := filepath.Join(caDir, "ca.crt")
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: cn},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caCertDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCertDER})
+	if err := os.WriteFile(caPath, caPEM, 0644); err != nil {
+		t.Fatal(err)
+	}
+	return caPath
+}

--- a/internal/kubernautagent/config/config.go
+++ b/internal/kubernautagent/config/config.go
@@ -341,6 +341,9 @@ func (c *Config) Validate() error {
 	if c.AI.Investigation.MaxTurns <= 0 {
 		return fmt.Errorf("ai.investigation.maxTurns must be positive, got %d", c.AI.Investigation.MaxTurns)
 	}
+	if c.AI.Summarizer.MaxToolOutputSize <= 0 {
+		return fmt.Errorf("ai.summarizer.maxToolOutputSize must be positive, got %d", c.AI.Summarizer.MaxToolOutputSize)
+	}
 	if c.AI.LLM.OAuth2.Enabled {
 		if c.AI.LLM.OAuth2.TokenURL == "" {
 			return fmt.Errorf("ai.llm.oauth2.tokenURL is required when oauth2.enabled=true")

--- a/internal/kubernautagent/session/manager.go
+++ b/internal/kubernautagent/session/manager.go
@@ -52,20 +52,27 @@ func (m *Manager) StartInvestigation(_ context.Context, fn InvestigateFunc, meta
 	if metadata != nil {
 		m.store.SetMetadata(id, metadata)
 	}
-	_ = m.store.Update(id, StatusRunning, nil, nil)
+	m.updateSession(id, StatusRunning, nil, nil)
 
 	go func() {
 		bgCtx := context.Background()
 		result, fnErr := fn(bgCtx)
 		if fnErr != nil {
 			m.logger.Error(fnErr, "investigation failed", "session_id", id)
-			_ = m.store.Update(id, StatusFailed, nil, fnErr)
+			m.updateSession(id, StatusFailed, nil, fnErr)
 			return
 		}
-		_ = m.store.Update(id, StatusCompleted, result, nil)
+		m.updateSession(id, StatusCompleted, result, nil)
 	}()
 
 	return id, nil
+}
+
+func (m *Manager) updateSession(id string, status Status, result interface{}, err error) {
+	if updateErr := m.store.Update(id, status, result, err); updateErr != nil {
+		m.logger.Error(updateErr, "failed to update session",
+			"session_id", id, "target_status", string(status))
+	}
 }
 
 // GetSession retrieves the current state of an investigation session.

--- a/pkg/kubernautagent/llm/chat_helpers.go
+++ b/pkg/kubernautagent/llm/chat_helpers.go
@@ -19,26 +19,67 @@ package llm
 import (
 	"context"
 	"time"
+
+	"github.com/jordigilh/kubernaut/pkg/shared/backoff"
 )
 
+var defaultRetryBackoff = backoff.Config{
+	BasePeriod:    500 * time.Millisecond,
+	MaxPeriod:     5 * time.Second,
+	Multiplier:    2.0,
+	JitterPercent: 20,
+}
+
 // ChatWithParams wraps a Client.Chat call, injecting runtime parameters
-// (temperature, timeout) from the hot-reloadable LLM config. The context
-// timeout is cancelled immediately after Chat returns to avoid resource leaks.
+// (temperature, timeout, retries) from the hot-reloadable LLM config.
+// Each attempt gets a fresh context timeout; the timeout is cancelled
+// immediately after Chat returns to avoid resource leaks.
+// Retries use exponential backoff and respect parent context cancellation.
 func ChatWithParams(ctx context.Context, client Client, req ChatRequest, params RuntimeParams) (ChatResponse, error) {
 	temp := params.Temperature
 	req.Options.Temperature = &temp
 
-	chatCtx := ctx
-	var chatCancel context.CancelFunc
-	if params.TimeoutSeconds > 0 {
-		chatCtx, chatCancel = context.WithTimeout(ctx, time.Duration(params.TimeoutSeconds)*time.Second)
+	bo := defaultRetryBackoff
+	if params.RetryBackoff != nil {
+		bo = *params.RetryBackoff
 	}
 
-	resp, err := client.Chat(chatCtx, req)
+	maxAttempts := 1 + params.MaxRetries
+	if maxAttempts < 1 {
+		maxAttempts = 1
+	}
+	var lastErr error
 
-	if chatCancel != nil {
-		chatCancel()
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		chatCtx := ctx
+		var chatCancel context.CancelFunc
+		if params.TimeoutSeconds > 0 {
+			chatCtx, chatCancel = context.WithTimeout(ctx, time.Duration(params.TimeoutSeconds)*time.Second)
+		}
+
+		resp, err := client.Chat(chatCtx, req)
+
+		if chatCancel != nil {
+			chatCancel()
+		}
+
+		if err == nil {
+			return resp, nil
+		}
+
+		lastErr = err
+
+		if attempt < maxAttempts-1 {
+			delay := bo.Calculate(int32(attempt + 1))
+			timer := time.NewTimer(delay)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return ChatResponse{}, ctx.Err()
+			case <-timer.C:
+			}
+		}
 	}
 
-	return resp, err
+	return ChatResponse{}, lastErr
 }

--- a/pkg/kubernautagent/llm/swappable_client.go
+++ b/pkg/kubernautagent/llm/swappable_client.go
@@ -21,6 +21,8 @@ import (
 	"errors"
 	"sync"
 	"time"
+
+	"github.com/jordigilh/kubernaut/pkg/shared/backoff"
 )
 
 const oldClientCloseTimeout = 5 * time.Second
@@ -43,6 +45,10 @@ type RuntimeParams struct {
 	Temperature    float64
 	TimeoutSeconds int
 	MaxRetries     int
+	// RetryBackoff overrides the default backoff config for ChatWithParams retries.
+	// When nil, a sensible default (500ms base, 5s max, 2x multiplier, 20% jitter)
+	// is used. Exposed primarily for testing with fast backoff.
+	RetryBackoff *backoff.Config
 }
 
 type SwappableClient struct {

--- a/test/integration/kubernautagent/investigator/investigator_audit_parity_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_audit_parity_test.go
@@ -19,13 +19,18 @@ package investigator_test
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/alignment"
+	alignprompt "github.com/jordigilh/kubernaut/internal/kubernautagent/alignment/prompt"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/config"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
@@ -45,6 +50,36 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
 )
+
+// shadowMockLLMClient is a thread-safe mock for the shadow evaluator.
+type shadowMockLLMClient struct {
+	mu        sync.Mutex
+	responses []llm.ChatResponse
+	callIdx   int
+	calls     int
+}
+
+func (m *shadowMockLLMClient) Chat(_ context.Context, _ llm.ChatRequest) (llm.ChatResponse, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.calls++
+	if m.callIdx < len(m.responses) {
+		resp := m.responses[m.callIdx]
+		m.callIdx++
+		return resp, nil
+	}
+	return llm.ChatResponse{
+		Message: llm.Message{Role: "assistant", Content: `{"suspicious":false,"explanation":"fallback clean"}`},
+	}, nil
+}
+
+func (m *shadowMockLLMClient) Close() error { return nil }
+
+func (m *shadowMockLLMClient) totalCalls() int {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.calls
+}
 
 type errorLLMClient struct {
 	err error
@@ -363,6 +398,8 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 				audit.EventTypeRCAComplete:       true,
 				audit.EventTypeResponseComplete:  true,
 				audit.EventTypeResponseFailed:    true,
+				audit.EventTypeAlignmentStep:     true,
+				audit.EventTypeAlignmentVerdict:  true,
 			}
 
 			for _, e := range auditStore.events {
@@ -630,6 +667,167 @@ var _ = Describe("KA Audit Parity Integration — TP-433-AUDIT-SOC2", func() {
 			lastEvent := validationEvents[len(validationEvents)-1]
 			Expect(lastEvent.Data["is_valid"]).To(BeFalse(),
 				"final validation event must reflect exhaustion (isValid=false)")
+		})
+	})
+})
+
+var _ = Describe("IT-KA-947: Alignment audit events emitted during investigation — BR-AI-601", func() {
+	var (
+		auditStore *recordingAuditStore
+		builder    *prompt.Builder
+		rp         *parser.ResultParser
+		enricher   *enrichment.Enricher
+		phaseTools katypes.PhaseToolMap
+	)
+
+	BeforeEach(func() {
+		auditStore = &recordingAuditStore{}
+		builder, _ = prompt.NewBuilder()
+		rp = parser.NewResultParser()
+		k8sClient := &fakeK8sClient{
+			ownerChain: []enrichment.OwnerChainEntry{
+				{Kind: "Deployment", Name: "api-server", Namespace: "production"},
+			},
+		}
+		dsClient := &fakeDataStorageClient{
+			history: &enrichment.RemediationHistoryResult{},
+		}
+		enricher = enrichment.NewEnricher(k8sClient, dsClient, auditStore, logr.Discard())
+		phaseTools = investigator.DefaultPhaseToolMap()
+	})
+
+	signal := katypes.SignalContext{
+		Name:          "api-server-abc",
+		Namespace:     "production",
+		Severity:      "critical",
+		Message:       "OOMKilled",
+		ResourceKind:  "Deployment",
+		ResourceName:  "api-server",
+		RemediationID: "rem-it-947",
+	}
+
+	// buildAlignmentWrapper wires up primary + shadow mocks into a full
+	// InvestigatorWrapper, eliminating the per-test setup boilerplate.
+	buildAlignmentWrapper := func(
+		primaryResponses []llm.ChatResponse,
+		shadowResponses []llm.ChatResponse,
+		mode config.AlignmentMode,
+	) (*alignment.InvestigatorWrapper, *shadowMockLLMClient) {
+		primaryMock := &mockLLMClient{responses: primaryResponses}
+		shadowMock := &shadowMockLLMClient{responses: shadowResponses}
+
+		evaluator := alignment.NewEvaluator(shadowMock, alignment.EvaluatorConfig{
+			Timeout: 10 * time.Second, MaxStepTokens: 4000, MaxRetries: 1,
+		}, alignprompt.SystemPrompt())
+
+		llmProxy := alignment.NewLLMProxy(primaryMock)
+		inv := investigator.New(investigator.Config{
+			Client: llmProxy, Builder: builder, ResultParser: rp, Enricher: enricher,
+			AuditStore: auditStore, Logger: logr.Discard(), MaxTurns: 15, PhaseTools: phaseTools,
+		})
+
+		wrapper := alignment.NewInvestigatorWrapper(alignment.InvestigatorWrapperConfig{
+			Inner:          inv,
+			Evaluator:      evaluator,
+			VerdictTimeout: 10 * time.Second,
+			AuditStore:     auditStore,
+			Logger:         logr.Discard(),
+			Mode:           mode,
+		})
+		return wrapper, shadowMock
+	}
+
+	canaryOK := llm.ChatResponse{Message: llm.Message{Role: "assistant", Content: `{"suspicious":true,"explanation":"canary flagged correctly"}`}}
+	clean := llm.ChatResponse{Message: llm.Message{Role: "assistant", Content: `{"suspicious":false,"explanation":"clean"}`}}
+	suspicious := llm.ChatResponse{Message: llm.Message{Role: "assistant", Content: `{"suspicious":true,"explanation":"injection detected in tool result"}`}}
+
+	standardPrimary := []llm.ChatResponse{
+		{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"OOMKilled","confidence":0.9}`}},
+		wfToolResp(`{"workflow_id":"oom-increase-memory","confidence":0.9}`),
+	}
+
+	Describe("IT-KA-947-001: InvestigatorWrapper emits alignment.verdict for a clean investigation", func() {
+		It("should emit EventTypeAlignmentVerdict with flagged=0 when shadow detects no issues", func() {
+			shadowResponses := []llm.ChatResponse{canaryOK, clean, clean, clean, clean, clean}
+			wrapper, shadowMock := buildAlignmentWrapper(standardPrimary, shadowResponses, config.AlignmentModeEnforce)
+
+			result, err := wrapper.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			verdictEvents := filterEvents(auditStore.events, audit.EventTypeAlignmentVerdict)
+			Expect(verdictEvents).NotTo(BeEmpty(), "must emit at least one alignment.verdict event")
+
+			v := verdictEvents[0]
+			Expect(v.Data).To(HaveKey("result"))
+			Expect(v.Data).To(HaveKey("flagged"))
+			Expect(v.Data["flagged"]).To(BeEquivalentTo(0), "clean investigation should have flagged=0")
+
+			Expect(shadowMock.totalCalls()).To(BeNumerically(">=", 3),
+				"shadow evaluator must have been called for canary + at least 2 steps")
+		})
+	})
+
+	Describe("IT-KA-947-002: InvestigatorWrapper emits alignment.step events for suspicious findings", func() {
+		It("should emit EventTypeAlignmentStep with suspicious=true when shadow flags content", func() {
+			shadowResponses := []llm.ChatResponse{canaryOK, suspicious, clean, clean, clean, clean}
+			wrapper, _ := buildAlignmentWrapper(standardPrimary, shadowResponses, config.AlignmentModeEnforce)
+
+			result, err := wrapper.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			stepEvents := filterEvents(auditStore.events, audit.EventTypeAlignmentStep)
+			Expect(stepEvents).NotTo(BeEmpty(), "must emit at least one alignment.step event")
+
+			verdictEvents := filterEvents(auditStore.events, audit.EventTypeAlignmentVerdict)
+			Expect(verdictEvents).NotTo(BeEmpty())
+			v := verdictEvents[0]
+			Expect(v.Data["flagged"]).To(BeNumerically(">=", 1),
+				"at least one step should be flagged as suspicious")
+
+			Expect(result.HumanReviewNeeded).To(BeTrue(),
+				"enforce mode + suspicious findings should escalate to human review")
+		})
+	})
+
+	Describe("IT-KA-947-003: Alignment events carry correct CorrelationID and event_id UUID", func() {
+		It("should set CorrelationID to signal name and event_id to a valid UUID", func() {
+			primary := []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"test","confidence":0.9}`}},
+				wfToolResp(`{"workflow_id":"restart","confidence":0.8}`),
+			}
+			shadowResponses := []llm.ChatResponse{canaryOK, clean, clean, clean}
+			wrapper, _ := buildAlignmentWrapper(primary, shadowResponses, config.AlignmentModeMonitor)
+
+			_, err := wrapper.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+
+			alignmentTypes := map[string]bool{
+				audit.EventTypeAlignmentStep:    true,
+				audit.EventTypeAlignmentVerdict: true,
+			}
+
+			found := 0
+			for _, e := range auditStore.events {
+				if !alignmentTypes[e.EventType] {
+					continue
+				}
+				found++
+				Expect(e.CorrelationID).To(Equal(signal.Name),
+					"alignment event CorrelationID must match signal name")
+
+				rawID, ok := e.Data["event_id"]
+				Expect(ok).To(BeTrue(), "event_id missing on %s event", e.EventType)
+				idStr, ok := rawID.(string)
+				Expect(ok).To(BeTrue(), "event_id should be a string")
+				_, parseErr := uuid.Parse(idStr)
+				Expect(parseErr).NotTo(HaveOccurred(),
+					"event_id must be a valid UUID on %s event: %s", e.EventType, idStr)
+			}
+
+			Expect(found).To(BeNumerically(">=", 1),
+				"at least one alignment event must be present")
 		})
 	})
 })

--- a/test/unit/kubernautagent/config/config_test.go
+++ b/test/unit/kubernautagent/config/config_test.go
@@ -132,6 +132,22 @@ ai:
 			Expect(err.Error()).To(ContainSubstring("ai.investigation.maxTurns"))
 		})
 
+		It("UT-KA-950-001: should reject zero maxToolOutputSize", func() {
+			cfg := config.DefaultConfig()
+			cfg.AI.Summarizer.MaxToolOutputSize = 0
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("maxToolOutputSize"))
+		})
+
+		It("UT-KA-950-002: should reject negative maxToolOutputSize", func() {
+			cfg := config.DefaultConfig()
+			cfg.AI.Summarizer.MaxToolOutputSize = -1
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("maxToolOutputSize"))
+		})
+
 		It("should reject missing LLM model in runtime config", func() {
 			rtYAML := []byte(`
 endpoint: "http://localhost:11434/v1"

--- a/test/unit/kubernautagent/llm/chat_with_params_test.go
+++ b/test/unit/kubernautagent/llm/chat_with_params_test.go
@@ -18,6 +18,7 @@ package llm_test
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -25,7 +26,15 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	"github.com/jordigilh/kubernaut/pkg/shared/backoff"
 )
+
+var fastBackoff = &backoff.Config{
+	BasePeriod:    1 * time.Millisecond,
+	MaxPeriod:     5 * time.Millisecond,
+	Multiplier:    2.0,
+	JitterPercent: 0,
+}
 
 type capturingClient struct {
 	mu          sync.Mutex
@@ -44,6 +53,33 @@ func (c *capturingClient) Chat(ctx context.Context, req llm.ChatRequest) (llm.Ch
 }
 
 func (c *capturingClient) Close() error { return nil }
+
+// countingErrorClient returns errors for the first N calls, then succeeds.
+// Thread-safe for use with retry logic.
+type countingErrorClient struct {
+	mu          sync.Mutex
+	failCount   int
+	totalCalls  int
+	successResp llm.ChatResponse
+}
+
+func (c *countingErrorClient) Chat(_ context.Context, _ llm.ChatRequest) (llm.ChatResponse, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.totalCalls++
+	if c.totalCalls <= c.failCount {
+		return llm.ChatResponse{}, fmt.Errorf("transient error attempt %d", c.totalCalls)
+	}
+	return c.successResp, nil
+}
+
+func (c *countingErrorClient) Close() error { return nil }
+
+func (c *countingErrorClient) calls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.totalCalls
+}
 
 var _ = Describe("ChatWithParams — BUG-1/BUG-3 fixes", func() {
 
@@ -114,6 +150,69 @@ var _ = Describe("ChatWithParams — BUG-1/BUG-3 fixes", func() {
 
 			_, ok := mock.capturedCtx.Deadline()
 			Expect(ok).To(BeFalse(), "context must NOT have a deadline when TimeoutSeconds is 0")
+		})
+	})
+
+	DescribeTable("ChatWithParams retry behavior",
+		func(failCount, maxRetries, expectedCalls int, expectSuccess bool) {
+			mock := &countingErrorClient{
+				failCount:   failCount,
+				successResp: llm.ChatResponse{Message: llm.Message{Role: "assistant", Content: "ok"}},
+			}
+			params := llm.RuntimeParams{
+				Temperature:  0.7,
+				MaxRetries:   maxRetries,
+				RetryBackoff: fastBackoff,
+			}
+			req := llm.ChatRequest{Messages: []llm.Message{{Role: "user", Content: "test"}}}
+
+			resp, err := llm.ChatWithParams(context.Background(), mock, req, params)
+			if expectSuccess {
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.Message.Content).To(Equal("ok"))
+			} else {
+				Expect(err).To(HaveOccurred())
+			}
+			Expect(mock.calls()).To(Equal(expectedCalls))
+		},
+		Entry("UT-KA-967-006: retries twice then succeeds",
+			2, 2, 3, true),
+		Entry("UT-KA-967-007: no retry when MaxRetries=0",
+			5, 0, 1, false),
+		Entry("UT-KA-967-008: succeeds on first attempt, no retry needed",
+			0, 3, 1, true),
+		Entry("UT-KA-967-010: all retries exhausted returns last error",
+			5, 2, 3, false),
+		Entry("UT-KA-967-011: negative MaxRetries treated as zero (1 attempt)",
+			0, -1, 1, true),
+	)
+
+	Describe("UT-KA-967-009: respects parent context cancellation during retry", func() {
+		It("should return context error when parent context is cancelled mid-retry", func() {
+			mock := &countingErrorClient{
+				failCount:   10,
+				successResp: llm.ChatResponse{Message: llm.Message{Role: "assistant", Content: "ok"}},
+			}
+			// Use a backoff slow enough (50ms) that the 100ms context
+			// timeout expires before all 5 retries can complete.
+			slowBackoff := &backoff.Config{
+				BasePeriod: 50 * time.Millisecond, MaxPeriod: 200 * time.Millisecond,
+				Multiplier: 2.0, JitterPercent: 0,
+			}
+			params := llm.RuntimeParams{
+				Temperature:  0.7,
+				MaxRetries:   5,
+				RetryBackoff: slowBackoff,
+			}
+			req := llm.ChatRequest{Messages: []llm.Message{{Role: "user", Content: "test"}}}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+			defer cancel()
+
+			_, err := llm.ChatWithParams(ctx, mock, req, params)
+			Expect(err).To(HaveOccurred())
+			Expect(mock.calls()).To(BeNumerically("<", 6),
+				"should not complete all retries when context is cancelled")
 		})
 	})
 })

--- a/test/unit/kubernautagent/session/manager_error_test.go
+++ b/test/unit/kubernautagent/session/manager_error_test.go
@@ -1,0 +1,71 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr/funcr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+)
+
+var _ = Describe("UT-KA-948: Session manager logs store.Update errors — BR-AUDIT-005", func() {
+
+	Describe("UT-KA-948-001: Manager logs error when session is cleaned up before goroutine completes", func() {
+		It("should log an error when Update fails due to TTL cleanup", func() {
+			var mu sync.Mutex
+			var logLines []string
+			logger := funcr.New(func(prefix, args string) {
+				mu.Lock()
+				defer mu.Unlock()
+				logLines = append(logLines, prefix+" "+args)
+			}, funcr.Options{Verbosity: 10})
+
+			store := session.NewStore(1 * time.Millisecond)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			store.StartCleanupLoop(ctx, 1*time.Millisecond)
+
+			mgr := session.NewManager(store, logger)
+
+			done := make(chan struct{})
+			_, err := mgr.StartInvestigation(context.Background(), func(_ context.Context) (interface{}, error) {
+				time.Sleep(50 * time.Millisecond)
+				close(done)
+				return "result", nil
+			}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(done, 2*time.Second).Should(BeClosed())
+
+			Eventually(func() string {
+				mu.Lock()
+				defer mu.Unlock()
+				return strings.Join(logLines, "\n")
+			}, 2*time.Second, 5*time.Millisecond).Should(
+				ContainSubstring("failed to update session"),
+				"manager must log store.Update errors instead of silently discarding them",
+			)
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Phase 1 (PR2) of the QE-readiness remediation plan, addressing 6 items:

- **GAP-E1**: Log session store `Update` errors instead of silently discarding them; extract `updateSession` helper to centralize logging
- **GAP-S2**: Upgrade shadow-client-sharing log from `Info` to `Error` with actionable guidance for operators
- **GAP-S3**: Add `MaxToolOutputSize > 0` validation in `Config.Validate()`
- **GAP-C2**: Wire `DataStorageConfig.TLS.CAFile` to DS HTTP client via `buildDSBaseTransport` helper
- **GAP-T1**: Add alignment audit integration tests (`IT-KA-947-001/002/003`) verifying verdict, step, and correlation-ID event emission
- **maxRetries**: Implement exponential-backoff retry loop in `ChatWithParams` with injectable `BackoffConfig` for testability

### Refactor & Quality

- DRY: extracted `updateSession`, `generateTestCACert`, `buildAlignmentWrapper` helpers
- Table-driven tests for retry behavior (`DescribeTable` with 6 entries)
- Full audit against [100 Go Mistakes](https://github.com/teivah/100-go-mistakes) — fixed #18 (negative `MaxRetries` guard) and #86 (replaced `time.Sleep` with `Eventually` in concurrent test)

### Business Requirements

- BR-AI-601 (alignment audit events)
- BR-INTEGRATION-400 (data storage TLS)

## Test plan

- [x] Unit tests: `UT-KA-950-001/002` (MaxToolOutputSize validation)
- [x] Unit tests: `UT-KA-967-006` through `UT-KA-967-011` (retry behavior, context cancellation, negative MaxRetries)
- [x] Unit tests: session store error logging (`manager_error_test.go`)
- [x] Unit tests: DS transport TLS wiring (`ds_transport_test.go`)
- [x] Integration tests: `IT-KA-947-001/002/003` (alignment audit parity)
- [x] Pre-commit hooks pass
- [x] `go build ./...` clean
- [x] `go vet ./...` clean


Made with [Cursor](https://cursor.com)