### PR TITLE
fix(ka): v1.4 RC must-fix issues (#956, #963, #966, #981)

### DIFF
--- a/cmd/kubernautagent/llm_builder.go
+++ b/cmd/kubernautagent/llm_builder.go
@@ -41,9 +41,16 @@ import (
 func buildLLMClientFromConfig(ctx context.Context, cfg *kaconfig.Config, rt *kaconfig.LLMRuntimeConfig) (llm.Client, error) {
 	switch cfg.AI.LLM.Provider {
 	case "vertex_ai":
+		var vertexOpts []vertexanthropic.Option
+		timeout := 120 * time.Second
+		if rt.TimeoutSeconds > 0 {
+			timeout = time.Duration(rt.TimeoutSeconds) * time.Second
+		}
+		vertexOpts = append(vertexOpts, vertexanthropic.WithHTTPTimeout(timeout))
 		return vertexanthropic.New(ctx,
 			rt.Model, []byte(rt.APIKey),
-			cfg.AI.LLM.VertexProject, cfg.AI.LLM.VertexLocation)
+			cfg.AI.LLM.VertexProject, cfg.AI.LLM.VertexLocation,
+			vertexOpts...)
 	default:
 		return langchaingo.New(cfg.AI.LLM.Provider, rt.Endpoint, rt.Model, rt.APIKey,
 			buildLLMProviderOpts(cfg, rt)...)
@@ -68,15 +75,20 @@ func buildLLMProviderOpts(cfg *kaconfig.Config, rt *kaconfig.LLMRuntimeConfig) [
 
 	const defaultLLMClientTimeout = 120 * time.Second
 
-	if transport := buildTransportChain(cfg, rt); transport != nil {
-		timeout := defaultLLMClientTimeout
-		if rt.TimeoutSeconds > 0 {
-			timeout = time.Duration(rt.TimeoutSeconds) * time.Second
-		}
-		httpClient := &http.Client{Transport: transport, Timeout: timeout}
-		opts = append(opts, langchaingo.WithHTTPClient(httpClient))
+	timeout := defaultLLMClientTimeout
+	if rt.TimeoutSeconds > 0 {
+		timeout = time.Duration(rt.TimeoutSeconds) * time.Second
+	}
+
+	customTransport := buildTransportChain(cfg, rt)
+	httpClient := &http.Client{Timeout: timeout}
+	if customTransport != nil {
+		httpClient.Transport = customTransport
+	}
+	opts = append(opts, langchaingo.WithHTTPClient(httpClient))
+	if customTransport != nil {
 		opts = append(opts, langchaingo.WithCloser(func() error {
-			if t, ok := transport.(interface{ CloseIdleConnections() }); ok {
+			if t, ok := customTransport.(interface{ CloseIdleConnections() }); ok {
 				t.CloseIdleConnections()
 			}
 			return nil

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -25,6 +25,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -343,10 +344,12 @@ func main() {
 		}
 	}
 
+	var shutdownFlag int32
+
 	// Dedicated health server (plain HTTP, never TLS). /config moved here from API port (SEC-4).
 	healthMux := http.NewServeMux()
 	healthMux.HandleFunc("/healthz", healthHandler)
-	healthMux.HandleFunc("/readyz", readyHandler)
+	healthMux.HandleFunc("/readyz", readinessHandler(&shutdownFlag, swappable, ds))
 	healthMux.HandleFunc("/config", configHandler(cfg, swappable))
 	healthMux.Handle("/admin/loglevel", atomicLevel)
 	healthMux.HandleFunc("/openapi.json", kaapi.SpecHandler())
@@ -454,6 +457,7 @@ func main() {
 	}()
 
 	<-ctx.Done()
+	atomic.StoreInt32(&shutdownFlag, 1)
 	logger.Info("shutting down...")
 
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -483,9 +487,47 @@ func healthHandler(w http.ResponseWriter, _ *http.Request) {
 	})
 }
 
-func readyHandler(w http.ResponseWriter, _ *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
-	_ = json.NewEncoder(w).Encode(map[string]string{"status": "ready"})
+// readinessHandler returns an http.HandlerFunc that performs real
+// dependency checks instead of returning a static 200. Checks:
+//   - shutdownFlag: set after SIGTERM/SIGINT received; makes probe fail
+//     so k8s stops routing traffic during graceful shutdown.
+//   - swappable: verifies the LLM client has a non-empty model name
+//     (proxy for "LLM client was successfully initialized").
+//   - ds: if non-nil, verifies the ogen client is initialized (DS is
+//     a soft dependency — nil ds means DS is intentionally unconfigured).
+func readinessHandler(shutdownFlag *int32, swappable *llm.SwappableClient, ds *dsClients) http.HandlerFunc {
+	return func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		if atomic.LoadInt32(shutdownFlag) != 0 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"status": "not_ready",
+				"reason": "shutting_down",
+			})
+			return
+		}
+
+		if swappable.ModelName() == "" {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"status": "not_ready",
+				"reason": "llm_client_not_configured",
+			})
+			return
+		}
+
+		if ds != nil && ds.ogenClient == nil {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]string{
+				"status": "not_ready",
+				"reason": "datastorage_client_unavailable",
+			})
+			return
+		}
+
+		_ = json.NewEncoder(w).Encode(map[string]string{"status": "ready"})
+	}
 }
 
 func configHandler(cfg *kaconfig.Config, swappable *llm.SwappableClient) http.HandlerFunc {
@@ -590,6 +632,10 @@ func initDSClients(cfg *kaconfig.Config, infra *k8sInfra, logger logr.Logger) *d
 		}))
 		logger.Info("DS client auth configured (DD-AUTH-014)", "token_path", cfg.Integrations.DataStorage.SATokenPath)
 	} else {
+		opts = append(opts, ogenclient.WithClient(&http.Client{
+			Transport: dsBase,
+			Timeout:   defaultDSClientTimeout,
+		}))
 		logger.Info("SA token not available for DS client — DS API calls may fail auth",
 			"path", cfg.Integrations.DataStorage.SATokenPath, "error", err)
 	}
@@ -673,12 +719,16 @@ func buildEnricher(cfg *kaconfig.Config, ds *dsClients, infra *k8sInfra, auditSt
 	return e
 }
 
-// buildSanitizationPipeline creates the G4 + I1 sanitization pipeline
-// per DD-HAPI-019-003. Returns nil when both stages are disabled.
+// buildSanitizationPipeline creates the sanitization pipeline with G4 (credential scrub),
+// K8S-SECRET (JSON Secret redaction), and I1 (injection patterns) stages per DD-HAPI-019-003.
+// Returns nil when all stages are disabled.
 func buildSanitizationPipeline(cfg *kaconfig.Config, logger logr.Logger) *sanitization.Pipeline {
 	var stages []sanitization.Stage
 	if cfg.AI.Safety.Sanitization.CredentialScrubEnabled {
 		stages = append(stages, sanitization.NewCredentialSanitizer())
+	}
+	if cfg.AI.Safety.Sanitization.SecretRedactionEnabled {
+		stages = append(stages, sanitization.NewSecretSanitizer())
 	}
 	if cfg.AI.Safety.Sanitization.InjectionPatternsEnabled {
 		stages = append(stages, sanitization.NewInjectionSanitizer(nil))

--- a/internal/kubernautagent/api/openapi.json
+++ b/internal/kubernautagent/api/openapi.json
@@ -412,6 +412,16 @@
                 }
               }
             }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPError"
+                }
+              }
+            }
           }
         }
       }
@@ -472,6 +482,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal server error",
+            "content": {
+              "application/problem+json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPError"
                 }
               }
             }

--- a/internal/kubernautagent/config/config.go
+++ b/internal/kubernautagent/config/config.go
@@ -215,6 +215,7 @@ type PrometheusToolConfig struct {
 type SanitizationConfig struct {
 	InjectionPatternsEnabled bool `yaml:"injectionPatternsEnabled"`
 	CredentialScrubEnabled   bool `yaml:"credentialScrubEnabled"`
+	SecretRedactionEnabled   bool `yaml:"secretRedactionEnabled"`
 }
 
 // DefaultMaxToolOutputSize is the default hard character limit for tool output
@@ -470,10 +471,11 @@ func DefaultConfig() *Config {
 				Canary:         CanaryConfig{ForceEscalation: true},
 			},
 			Safety: SafetyConfig{
-				Sanitization: SanitizationConfig{
-					InjectionPatternsEnabled: true,
-					CredentialScrubEnabled:   true,
-				},
+			Sanitization: SanitizationConfig{
+				InjectionPatternsEnabled: true,
+				CredentialScrubEnabled:   true,
+				SecretRedactionEnabled:   true,
+			},
 				Anomaly: AnomalyConfig{
 					MaxToolCallsPerTool: 10,
 					MaxTotalToolCalls:   30,

--- a/internal/kubernautagent/investigator/investigator_tools.go
+++ b/internal/kubernautagent/investigator/investigator_tools.go
@@ -145,12 +145,14 @@ func (inv *Investigator) executeTool(ctx context.Context, name string, args json
 	if inv.pipeline.Sanitizer != nil {
 		sanitized, sanitizeErr := inv.pipeline.Sanitizer.Run(ctx, result)
 		if sanitizeErr != nil {
-			inv.logger.Error(sanitizeErr, "sanitization failed, returning raw output",
+			inv.logger.Error(sanitizeErr, "sanitization failed, fail-closed for SOC2 compliance",
 				"tool", name,
 			)
-		} else {
-			result = sanitized
+			errResult := toolErrorJSON("sanitization failed: tool output withheld")
+			alignment.SubmitToolStep(ctx, name, errResult)
+			return errResult
 		}
+		result = sanitized
 	}
 
 	if inv.pipeline.Summarizer != nil {

--- a/internal/kubernautagent/server/handler.go
+++ b/internal/kubernautagent/server/handler.go
@@ -144,7 +144,7 @@ func (h *Handler) IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet(
 	sess, err := h.sessions.GetSession(params.SessionID)
 	if err != nil {
 		if errors.Is(err, session.ErrSessionNotFound) {
-			return &agentclient.HTTPError{
+			return &agentclient.IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetNotFound{
 				Type:     "https://kubernaut.ai/problems/not-found",
 				Title:    "Session Not Found",
 				Detail:   fmt.Sprintf("session %s not found", params.SessionID),
@@ -153,7 +153,7 @@ func (h *Handler) IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet(
 			}, nil
 		}
 		h.logger.Error(err, "session lookup failed", "session_id", params.SessionID)
-		return &agentclient.HTTPError{
+		return &agentclient.IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetInternalServerError{
 			Type:     "https://kubernaut.ai/problems/internal-error",
 			Title:    "Internal Server Error",
 			Detail:   "internal server error",
@@ -191,7 +191,13 @@ func (h *Handler) IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResu
 			}, nil
 		}
 		h.logger.Error(err, "session lookup failed", "session_id", params.SessionID)
-		return nil, fmt.Errorf("internal server error")
+		return &agentclient.IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetInternalServerError{
+			Type:     "https://kubernaut.ai/problems/internal-error",
+			Title:    "Internal Server Error",
+			Detail:   "internal server error",
+			Status:   500,
+			Instance: fmt.Sprintf("/api/v1/incident/session/%s/result", params.SessionID),
+		}, nil
 	}
 
 	switch sess.Status {

--- a/pkg/agentclient/client.go
+++ b/pkg/agentclient/client.go
@@ -227,8 +227,10 @@ func (c *KubernautAgentClient) PollSession(ctx context.Context, sessionID string
 	switch v := res.(type) {
 	case *SessionStatus:
 		return v, nil
-	case *HTTPError:
+	case *IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetNotFound:
 		return nil, &APIError{StatusCode: http.StatusNotFound, Message: fmt.Sprintf("session %s not found: %s", sessionID, v.Detail)}
+	case *IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetInternalServerError:
+		return nil, &APIError{StatusCode: http.StatusInternalServerError, Message: fmt.Sprintf("server error: %s", v.Detail)}
 	case *HTTPValidationError:
 		return nil, &APIError{StatusCode: http.StatusUnprocessableEntity, Message: "validation error"}
 	default:
@@ -252,6 +254,8 @@ func (c *KubernautAgentClient) GetSessionResult(ctx context.Context, sessionID s
 		return nil, &APIError{StatusCode: http.StatusNotFound, Message: fmt.Sprintf("session %s not found: %s", sessionID, v.Detail)}
 	case *IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetConflict:
 		return nil, &APIError{StatusCode: http.StatusConflict, Message: fmt.Sprintf("session %s not yet completed: %s", sessionID, v.Detail)}
+	case *IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetInternalServerError:
+		return nil, &APIError{StatusCode: http.StatusInternalServerError, Message: fmt.Sprintf("server error: %s", v.Detail)}
 	case *HTTPValidationError:
 		return nil, &APIError{StatusCode: http.StatusUnprocessableEntity, Message: "validation error"}
 	default:

--- a/pkg/agentclient/oas_cfg_gen.go
+++ b/pkg/agentclient/oas_cfg_gen.go
@@ -4,6 +4,7 @@ package agentclient
 
 import (
 	"net/http"
+	"strings"
 
 	ht "github.com/ogen-go/ogen/http"
 	"github.com/ogen-go/ogen/middleware"
@@ -82,18 +83,8 @@ func (o otelOptionFunc) applyServer(c *serverConfig) {
 
 func newServerConfig(opts ...ServerOption) serverConfig {
 	cfg := serverConfig{
-		NotFound: http.NotFound,
-		MethodNotAllowed: func(w http.ResponseWriter, r *http.Request, allowed string) {
-			status := http.StatusMethodNotAllowed
-			if r.Method == "OPTIONS" {
-				w.Header().Set("Access-Control-Allow-Methods", allowed)
-				w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
-				status = http.StatusNoContent
-			} else {
-				w.Header().Set("Allow", allowed)
-			}
-			w.WriteHeader(status)
-		},
+		NotFound:           http.NotFound,
+		MethodNotAllowed:   nil,
 		ErrorHandler:       ogenerrors.DefaultErrorHandler,
 		Middleware:         nil,
 		MaxMultipartMemory: 32 << 20, // 32 MB
@@ -116,8 +107,44 @@ func (s baseServer) notFound(w http.ResponseWriter, r *http.Request) {
 	s.cfg.NotFound(w, r)
 }
 
-func (s baseServer) notAllowed(w http.ResponseWriter, r *http.Request, allowed string) {
-	s.cfg.MethodNotAllowed(w, r, allowed)
+type notAllowedParams struct {
+	allowedMethods string
+	allowedHeaders map[string]string
+	acceptPost     string
+	acceptPatch    string
+}
+
+func (s baseServer) notAllowed(w http.ResponseWriter, r *http.Request, params notAllowedParams) {
+	h := w.Header()
+	isOptions := r.Method == "OPTIONS"
+	if isOptions {
+		h.Set("Access-Control-Allow-Methods", params.allowedMethods)
+		if params.allowedHeaders != nil {
+			m := r.Header.Get("Access-Control-Request-Method")
+			if m != "" {
+				allowedHeaders, ok := params.allowedHeaders[strings.ToUpper(m)]
+				if ok {
+					h.Set("Access-Control-Allow-Headers", allowedHeaders)
+				}
+			}
+		}
+		if params.acceptPost != "" {
+			h.Set("Accept-Post", params.acceptPost)
+		}
+		if params.acceptPatch != "" {
+			h.Set("Accept-Patch", params.acceptPatch)
+		}
+	}
+	if s.cfg.MethodNotAllowed != nil {
+		s.cfg.MethodNotAllowed(w, r, params.allowedMethods)
+		return
+	}
+	status := http.StatusNoContent
+	if !isOptions {
+		h.Set("Allow", params.allowedMethods)
+		status = http.StatusMethodNotAllowed
+	}
+	w.WriteHeader(status)
 }
 
 func (cfg serverConfig) baseServer() (s baseServer, err error) {

--- a/pkg/agentclient/oas_client_gen.go
+++ b/pkg/agentclient/oas_client_gen.go
@@ -17,7 +17,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -83,10 +83,6 @@ type Client struct {
 	serverURL *url.URL
 	baseClient
 }
-
-var _ Handler = struct {
-	*Client
-}{}
 
 // NewClient initializes new Client defined by OAS.
 func NewClient(serverURL string, opts ...ClientOption) (*Client, error) {
@@ -185,7 +181,8 @@ func (c *Client) sendGetConfigConfigGet(ctx context.Context) (res jx.Raw, err er
 	if err != nil {
 		return res, errors.Wrap(err, "do request")
 	}
-	defer resp.Body.Close()
+	body := resp.Body
+	defer body.Close()
 
 	stage = "DecodeResponse"
 	result, err := decodeGetConfigConfigGetResponse(resp)
@@ -259,7 +256,8 @@ func (c *Client) sendHealthCheckHealthzGet(ctx context.Context) (res jx.Raw, err
 	if err != nil {
 		return res, errors.Wrap(err, "do request")
 	}
-	defer resp.Body.Close()
+	body := resp.Body
+	defer body.Close()
 
 	stage = "DecodeResponse"
 	result, err := decodeHealthCheckHealthzGetResponse(resp)
@@ -341,7 +339,8 @@ func (c *Client) sendIncidentAnalyzeEndpointAPIV1IncidentAnalyzePost(ctx context
 	if err != nil {
 		return res, errors.Wrap(err, "do request")
 	}
-	defer resp.Body.Close()
+	body := resp.Body
+	defer body.Close()
 
 	stage = "DecodeResponse"
 	result, err := decodeIncidentAnalyzeEndpointAPIV1IncidentAnalyzePostResponse(resp)
@@ -433,7 +432,8 @@ func (c *Client) sendIncidentSessionResultEndpointAPIV1IncidentSessionSessionIDR
 	if err != nil {
 		return res, errors.Wrap(err, "do request")
 	}
-	defer resp.Body.Close()
+	body := resp.Body
+	defer body.Close()
 
 	stage = "DecodeResponse"
 	result, err := decodeIncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetResponse(resp)
@@ -524,7 +524,8 @@ func (c *Client) sendIncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDG
 	if err != nil {
 		return res, errors.Wrap(err, "do request")
 	}
-	defer resp.Body.Close()
+	body := resp.Body
+	defer body.Close()
 
 	stage = "DecodeResponse"
 	result, err := decodeIncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetResponse(resp)
@@ -600,7 +601,8 @@ func (c *Client) sendReadinessCheckReadyzGet(ctx context.Context) (res jx.Raw, e
 	if err != nil {
 		return res, errors.Wrap(err, "do request")
 	}
-	defer resp.Body.Close()
+	body := resp.Body
+	defer body.Close()
 
 	stage = "DecodeResponse"
 	result, err := decodeReadinessCheckReadyzGetResponse(resp)

--- a/pkg/agentclient/oas_handlers_gen.go
+++ b/pkg/agentclient/oas_handlers_gen.go
@@ -16,7 +16,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -49,6 +49,8 @@ func (s *Server) handleGetConfigConfigGetRequest(args [0]string, argsEscaped boo
 		semconv.HTTPRequestMethodKey.String("GET"),
 		semconv.HTTPRouteKey.String("/config"),
 	}
+	// Add attributes from config.
+	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), GetConfigConfigGetOperation,
@@ -172,6 +174,8 @@ func (s *Server) handleHealthCheckHealthzGetRequest(args [0]string, argsEscaped 
 		semconv.HTTPRequestMethodKey.String("GET"),
 		semconv.HTTPRouteKey.String("/healthz"),
 	}
+	// Add attributes from config.
+	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), HealthCheckHealthzGetOperation,
@@ -300,6 +304,8 @@ func (s *Server) handleIncidentAnalyzeEndpointAPIV1IncidentAnalyzePostRequest(ar
 		semconv.HTTPRequestMethodKey.String("POST"),
 		semconv.HTTPRouteKey.String("/api/v1/incident/analyze"),
 	}
+	// Add attributes from config.
+	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), IncidentAnalyzeEndpointAPIV1IncidentAnalyzePostOperation,
@@ -441,6 +447,8 @@ func (s *Server) handleIncidentSessionResultEndpointAPIV1IncidentSessionSessionI
 		semconv.HTTPRequestMethodKey.String("GET"),
 		semconv.HTTPRouteKey.String("/api/v1/incident/session/{session_id}/result"),
 	}
+	// Add attributes from config.
+	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetOperation,
@@ -582,6 +590,8 @@ func (s *Server) handleIncidentSessionStatusEndpointAPIV1IncidentSessionSessionI
 		semconv.HTTPRequestMethodKey.String("GET"),
 		semconv.HTTPRouteKey.String("/api/v1/incident/session/{session_id}"),
 	}
+	// Add attributes from config.
+	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetOperation,
@@ -726,6 +736,8 @@ func (s *Server) handleReadinessCheckReadyzGetRequest(args [0]string, argsEscape
 		semconv.HTTPRequestMethodKey.String("GET"),
 		semconv.HTTPRouteKey.String("/readyz"),
 	}
+	// Add attributes from config.
+	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), ReadinessCheckReadyzGetOperation,

--- a/pkg/agentclient/oas_json_gen.go
+++ b/pkg/agentclient/oas_json_gen.go
@@ -3178,6 +3178,44 @@ func (s *IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetConf
 	return s.Decode(d)
 }
 
+// Encode encodes IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetInternalServerError as json.
+func (s *IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetInternalServerError) Encode(e *jx.Encoder) {
+	unwrapped := (*HTTPError)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetInternalServerError from json.
+func (s *IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetInternalServerError) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetInternalServerError to nil")
+	}
+	var unwrapped HTTPError
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetInternalServerError(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetInternalServerError) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetInternalServerError) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
 // Encode encodes IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetNotFound as json.
 func (s *IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetNotFound) Encode(e *jx.Encoder) {
 	unwrapped := (*HTTPError)(s)
@@ -3212,6 +3250,82 @@ func (s *IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetNotF
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetNotFound) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetInternalServerError as json.
+func (s *IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetInternalServerError) Encode(e *jx.Encoder) {
+	unwrapped := (*HTTPError)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetInternalServerError from json.
+func (s *IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetInternalServerError) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetInternalServerError to nil")
+	}
+	var unwrapped HTTPError
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetInternalServerError(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetInternalServerError) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetInternalServerError) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetNotFound as json.
+func (s *IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetNotFound) Encode(e *jx.Encoder) {
+	unwrapped := (*HTTPError)(s)
+
+	unwrapped.Encode(e)
+}
+
+// Decode decodes IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetNotFound from json.
+func (s *IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetNotFound) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetNotFound to nil")
+	}
+	var unwrapped HTTPError
+	if err := func() error {
+		if err := unwrapped.Decode(d); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		return errors.Wrap(err, "alias")
+	}
+	*s = IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetNotFound(unwrapped)
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetNotFound) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetNotFound) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/pkg/agentclient/oas_response_decoders_gen.go
+++ b/pkg/agentclient/oas_response_decoders_gen.go
@@ -600,6 +600,41 @@ func decodeIncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetRe
 		default:
 			return res, validate.InvalidContentType(ct)
 		}
+	case 500:
+		// Code 500.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/problem+json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetInternalServerError
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
 	}
 	return res, validate.UnexpectedStatusCodeWithResponse(resp)
 }
@@ -655,7 +690,7 @@ func decodeIncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetResponse
 			}
 			d := jx.DecodeBytes(buf)
 
-			var response HTTPError
+			var response IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetNotFound
 			if err := func() error {
 				if err := response.Decode(d); err != nil {
 					return err
@@ -715,6 +750,41 @@ func decodeIncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetResponse
 				return nil
 			}(); err != nil {
 				return res, errors.Wrap(err, "validate")
+			}
+			return &response, nil
+		default:
+			return res, validate.InvalidContentType(ct)
+		}
+	case 500:
+		// Code 500.
+		ct, _, err := mime.ParseMediaType(resp.Header.Get("Content-Type"))
+		if err != nil {
+			return res, errors.Wrap(err, "parse media type")
+		}
+		switch {
+		case ct == "application/problem+json":
+			buf, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return res, err
+			}
+			d := jx.DecodeBytes(buf)
+
+			var response IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetInternalServerError
+			if err := func() error {
+				if err := response.Decode(d); err != nil {
+					return err
+				}
+				if err := d.Skip(); err != io.EOF {
+					return errors.New("unexpected trailing data")
+				}
+				return nil
+			}(); err != nil {
+				err = &ogenerrors.DecodeBodyError{
+					ContentType: ct,
+					Body:        buf,
+					Err:         err,
+				}
+				return res, err
 			}
 			return &response, nil
 		default:

--- a/pkg/agentclient/oas_response_encoders_gen.go
+++ b/pkg/agentclient/oas_response_encoders_gen.go
@@ -247,6 +247,19 @@ func encodeIncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetRe
 
 		return nil
 
+	case *IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetInternalServerError:
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
 	default:
 		return errors.Errorf("unexpected response type: %T", response)
 	}
@@ -267,7 +280,7 @@ func encodeIncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetResponse
 
 		return nil
 
-	case *HTTPError:
+	case *IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetNotFound:
 		w.Header().Set("Content-Type", "application/problem+json")
 		w.WriteHeader(404)
 		span.SetStatus(codes.Error, http.StatusText(404))
@@ -284,6 +297,19 @@ func encodeIncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetResponse
 		w.Header().Set("Content-Type", "application/json; charset=utf-8")
 		w.WriteHeader(422)
 		span.SetStatus(codes.Error, http.StatusText(422))
+
+		e := new(jx.Encoder)
+		response.Encode(e)
+		if _, err := e.WriteTo(w); err != nil {
+			return errors.Wrap(err, "write")
+		}
+
+		return nil
+
+	case *IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetInternalServerError:
+		w.Header().Set("Content-Type", "application/problem+json")
+		w.WriteHeader(500)
+		span.SetStatus(codes.Error, http.StatusText(500))
 
 		e := new(jx.Encoder)
 		response.Encode(e)

--- a/pkg/agentclient/oas_router_gen.go
+++ b/pkg/agentclient/oas_router_gen.go
@@ -10,6 +10,12 @@ import (
 	"github.com/ogen-go/ogen/uri"
 )
 
+var (
+	rn4AllowedHeaders = map[string]string{
+		"POST": "Content-Type",
+	}
+)
+
 func (s *Server) cutPrefix(path string) (string, bool) {
 	prefix := s.cfg.Prefix
 	if prefix == "" {
@@ -87,7 +93,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						case "POST":
 							s.handleIncidentAnalyzeEndpointAPIV1IncidentAnalyzePostRequest([0]string{}, elemIsEscaped, w, r)
 						default:
-							s.notAllowed(w, r, "POST")
+							s.notAllowed(w, r, notAllowedParams{
+								allowedMethods: "POST",
+								allowedHeaders: rn4AllowedHeaders,
+								acceptPost:     "application/json",
+								acceptPatch:    "",
+							})
 						}
 
 						return
@@ -117,7 +128,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								args[0],
 							}, elemIsEscaped, w, r)
 						default:
-							s.notAllowed(w, r, "GET")
+							s.notAllowed(w, r, notAllowedParams{
+								allowedMethods: "GET",
+								allowedHeaders: nil,
+								acceptPost:     "",
+								acceptPatch:    "",
+							})
 						}
 
 						return
@@ -139,7 +155,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									args[0],
 								}, elemIsEscaped, w, r)
 							default:
-								s.notAllowed(w, r, "GET")
+								s.notAllowed(w, r, notAllowedParams{
+									allowedMethods: "GET",
+									allowedHeaders: nil,
+									acceptPost:     "",
+									acceptPatch:    "",
+								})
 							}
 
 							return
@@ -163,7 +184,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					case "GET":
 						s.handleGetConfigConfigGetRequest([0]string{}, elemIsEscaped, w, r)
 					default:
-						s.notAllowed(w, r, "GET")
+						s.notAllowed(w, r, notAllowedParams{
+							allowedMethods: "GET",
+							allowedHeaders: nil,
+							acceptPost:     "",
+							acceptPatch:    "",
+						})
 					}
 
 					return
@@ -183,7 +209,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					case "GET":
 						s.handleHealthCheckHealthzGetRequest([0]string{}, elemIsEscaped, w, r)
 					default:
-						s.notAllowed(w, r, "GET")
+						s.notAllowed(w, r, notAllowedParams{
+							allowedMethods: "GET",
+							allowedHeaders: nil,
+							acceptPost:     "",
+							acceptPatch:    "",
+						})
 					}
 
 					return
@@ -203,7 +234,12 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					case "GET":
 						s.handleReadinessCheckReadyzGetRequest([0]string{}, elemIsEscaped, w, r)
 					default:
-						s.notAllowed(w, r, "GET")
+						s.notAllowed(w, r, notAllowedParams{
+							allowedMethods: "GET",
+							allowedHeaders: nil,
+							acceptPost:     "",
+							acceptPatch:    "",
+						})
 					}
 
 					return

--- a/pkg/agentclient/oas_schemas_gen.go
+++ b/pkg/agentclient/oas_schemas_gen.go
@@ -303,8 +303,6 @@ func (s *HTTPError) SetRequestID(val OptNilString) {
 	s.RequestID = val
 }
 
-func (*HTTPError) incidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetRes() {}
-
 // Ref: #/components/schemas/HTTPValidationError
 type HTTPValidationError struct {
 	Detail []ValidationError `json:"detail"`
@@ -1415,9 +1413,24 @@ type IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetConflict
 func (*IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetConflict) incidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetRes() {
 }
 
+type IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetInternalServerError HTTPError
+
+func (*IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetInternalServerError) incidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetRes() {
+}
+
 type IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetNotFound HTTPError
 
 func (*IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetNotFound) incidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetRes() {
+}
+
+type IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetInternalServerError HTTPError
+
+func (*IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetInternalServerError) incidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetRes() {
+}
+
+type IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetNotFound HTTPError
+
+func (*IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetNotFound) incidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetRes() {
 }
 
 // NewOptBool returns new OptBool with value set to v.

--- a/pkg/kubernautagent/llm/vertexanthropic/client.go
+++ b/pkg/kubernautagent/llm/vertexanthropic/client.go
@@ -34,6 +34,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/anthropics/anthropic-sdk-go"
 	"github.com/anthropics/anthropic-sdk-go/option"
@@ -48,12 +49,19 @@ type Option func(*clientOpts)
 
 type clientOpts struct {
 	extraSDKOpts []option.RequestOption
+	httpTimeout  time.Duration
 }
 
 // WithSDKOptions injects additional Anthropic SDK request options (e.g. base URL
 // override for testing). Production code should not need this.
 func WithSDKOptions(opts ...option.RequestOption) Option {
 	return func(o *clientOpts) { o.extraSDKOpts = append(o.extraSDKOpts, opts...) }
+}
+
+// WithHTTPTimeout sets an explicit timeout on the underlying HTTP client used
+// by the Anthropic SDK, preventing unbounded network calls (#956).
+func WithHTTPTimeout(d time.Duration) Option {
+	return func(o *clientOpts) { o.httpTimeout = d }
 }
 
 // Client implements llm.Client for Claude on Vertex AI using the official
@@ -111,6 +119,9 @@ func New(ctx context.Context, model string, credentialsJSON []byte, project, loc
 	}
 
 	sdkOpts := []option.RequestOption{vertexOpt}
+	if o.httpTimeout > 0 {
+		sdkOpts = append(sdkOpts, option.WithRequestTimeout(o.httpTimeout))
+	}
 	sdkOpts = append(sdkOpts, o.extraSDKOpts...)
 	sdk := anthropic.NewClient(sdkOpts...)
 

--- a/pkg/kubernautagent/tools/sanitization/secret.go
+++ b/pkg/kubernautagent/tools/sanitization/secret.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sanitization
+
+import (
+	"context"
+	"encoding/json"
+
+	sharedsanitization "github.com/jordigilh/kubernaut/pkg/shared/sanitization"
+)
+
+// SecretSanitizer redacts Kubernetes Secret data/stringData values from tool
+// output to prevent cleartext credentials from reaching audit storage (SOC2).
+//
+// Unlike the regex-based k8s-secret-data rule in shared/sanitization (which
+// targets YAML-format lines), this stage handles the JSON representation
+// returned by K8s tools via json.Marshal of API objects.
+type SecretSanitizer struct{}
+
+// NewSecretSanitizer creates a K8s Secret sanitizer stage.
+func NewSecretSanitizer() *SecretSanitizer {
+	return &SecretSanitizer{}
+}
+
+// Name implements Stage.
+func (s *SecretSanitizer) Name() string { return "K8S-SECRET" }
+
+// Sanitize implements Stage. Detects JSON blobs containing K8s Secrets
+// and replaces data/stringData values with [REDACTED].
+func (s *SecretSanitizer) Sanitize(_ context.Context, input string) (string, error) {
+	if !json.Valid([]byte(input)) {
+		return input, nil
+	}
+
+	redacted, changed := redactSecretJSON([]byte(input))
+	if changed {
+		return string(redacted), nil
+	}
+	return input, nil
+}
+
+// redactSecretJSON checks if the JSON blob is a K8s Secret (or a list
+// containing Secrets) and redacts data/stringData map values.
+func redactSecretJSON(raw []byte) ([]byte, bool) {
+	var obj map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &obj); err != nil {
+		return raw, false
+	}
+
+	if isSecretKind(obj) {
+		return redactSecretFields(obj)
+	}
+
+	if isList(obj) {
+		return redactSecretList(raw, obj)
+	}
+
+	return raw, false
+}
+
+func isSecretKind(obj map[string]json.RawMessage) bool {
+	kindRaw, ok := obj["kind"]
+	if !ok {
+		return false
+	}
+	var kind string
+	if err := json.Unmarshal(kindRaw, &kind); err != nil {
+		return false
+	}
+	return kind == "Secret"
+}
+
+func isList(obj map[string]json.RawMessage) bool {
+	kindRaw, ok := obj["kind"]
+	if !ok {
+		return false
+	}
+	var kind string
+	if err := json.Unmarshal(kindRaw, &kind); err != nil {
+		return false
+	}
+	return kind == "SecretList" || kind == "List"
+}
+
+func redactSecretFields(obj map[string]json.RawMessage) ([]byte, bool) {
+	changed := false
+	for _, field := range []string{"data", "stringData"} {
+		fieldRaw, ok := obj[field]
+		if !ok {
+			continue
+		}
+		var m map[string]interface{}
+		if err := json.Unmarshal(fieldRaw, &m); err != nil {
+			continue
+		}
+		for k := range m {
+			m[k] = sharedsanitization.RedactedPlaceholder
+		}
+		redacted, err := json.Marshal(m)
+		if err != nil {
+			continue
+		}
+		obj[field] = json.RawMessage(redacted)
+		changed = true
+	}
+	if !changed {
+		return nil, false
+	}
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return nil, false
+	}
+	return out, true
+}
+
+func redactSecretList(raw []byte, obj map[string]json.RawMessage) ([]byte, bool) {
+	itemsRaw, ok := obj["items"]
+	if !ok {
+		return raw, false
+	}
+	var items []json.RawMessage
+	if err := json.Unmarshal(itemsRaw, &items); err != nil {
+		return raw, false
+	}
+	anyChanged := false
+	for i, item := range items {
+		var itemObj map[string]json.RawMessage
+		if err := json.Unmarshal(item, &itemObj); err != nil {
+			continue
+		}
+		if isSecretKind(itemObj) {
+			if redacted, changed := redactSecretFields(itemObj); changed {
+				items[i] = redacted
+				anyChanged = true
+			}
+		}
+	}
+	if !anyChanged {
+		return raw, false
+	}
+	redactedItems, err := json.Marshal(items)
+	if err != nil {
+		return raw, false
+	}
+	obj["items"] = json.RawMessage(redactedItems)
+	out, err := json.Marshal(obj)
+	if err != nil {
+		return raw, false
+	}
+	return out, true
+}

--- a/test/unit/kubernautagent/tools/sanitization/secret_test.go
+++ b/test/unit/kubernautagent/tools/sanitization/secret_test.go
@@ -1,0 +1,152 @@
+package sanitization_test
+
+import (
+	"context"
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/sanitization"
+	sharedsanitization "github.com/jordigilh/kubernaut/pkg/shared/sanitization"
+)
+
+var _ = Describe("Kubernaut Agent K8S-SECRET Sanitizer — #966", func() {
+
+	var (
+		stage sanitization.Stage
+		ctx   context.Context
+	)
+
+	BeforeEach(func() {
+		stage = sanitization.NewSecretSanitizer()
+		ctx = context.Background()
+	})
+
+	Describe("UT-KA-966-001: Redacts JSON Secret data values", func() {
+		It("should redact data map values in a Secret object", func() {
+			secret := map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata":   map[string]interface{}{"name": "db-creds", "namespace": "prod"},
+				"data": map[string]interface{}{
+					"username": "YWRtaW4=",
+					"password": "czNjcjN0",
+				},
+			}
+			input, err := json.Marshal(secret)
+			Expect(err).NotTo(HaveOccurred())
+
+			result, sanitizeErr := stage.Sanitize(ctx, string(input))
+			Expect(sanitizeErr).NotTo(HaveOccurred())
+
+			Expect(result).NotTo(ContainSubstring("YWRtaW4="))
+			Expect(result).NotTo(ContainSubstring("czNjcjN0"))
+			Expect(result).To(ContainSubstring(sharedsanitization.RedactedPlaceholder))
+			Expect(result).To(ContainSubstring("db-creds"))
+		})
+	})
+
+	Describe("UT-KA-966-002: Redacts stringData values", func() {
+		It("should redact stringData map values", func() {
+			secret := map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata":   map[string]interface{}{"name": "tls-cert"},
+				"stringData": map[string]interface{}{
+					"tls.key": "-----BEGIN RSA PRIVATE KEY-----\nfakekey\n-----END RSA PRIVATE KEY-----",
+				},
+			}
+			input, err := json.Marshal(secret)
+			Expect(err).NotTo(HaveOccurred())
+
+			result, sanitizeErr := stage.Sanitize(ctx, string(input))
+			Expect(sanitizeErr).NotTo(HaveOccurred())
+
+			Expect(result).NotTo(ContainSubstring("fakekey"))
+			Expect(result).To(ContainSubstring(sharedsanitization.RedactedPlaceholder))
+		})
+	})
+
+	Describe("UT-KA-966-003: Handles SecretList", func() {
+		It("should redact data in all Secrets within a SecretList", func() {
+			list := map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "SecretList",
+				"items": []interface{}{
+					map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Secret",
+						"metadata":   map[string]interface{}{"name": "secret-1"},
+						"data":       map[string]interface{}{"key1": "dmFsdWUx"},
+					},
+					map[string]interface{}{
+						"apiVersion": "v1",
+						"kind":       "Secret",
+						"metadata":   map[string]interface{}{"name": "secret-2"},
+						"data":       map[string]interface{}{"key2": "dmFsdWUy"},
+					},
+				},
+			}
+			input, err := json.Marshal(list)
+			Expect(err).NotTo(HaveOccurred())
+
+			result, sanitizeErr := stage.Sanitize(ctx, string(input))
+			Expect(sanitizeErr).NotTo(HaveOccurred())
+
+			Expect(result).NotTo(ContainSubstring("dmFsdWUx"))
+			Expect(result).NotTo(ContainSubstring("dmFsdWUy"))
+			Expect(result).To(ContainSubstring("secret-1"))
+			Expect(result).To(ContainSubstring("secret-2"))
+		})
+	})
+
+	Describe("UT-KA-966-004: Preserves non-Secret JSON", func() {
+		It("should not modify ConfigMap JSON", func() {
+			cm := map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata":   map[string]interface{}{"name": "my-config"},
+				"data":       map[string]interface{}{"app.conf": "key=value"},
+			}
+			input, err := json.Marshal(cm)
+			Expect(err).NotTo(HaveOccurred())
+
+			result, sanitizeErr := stage.Sanitize(ctx, string(input))
+			Expect(sanitizeErr).NotTo(HaveOccurred())
+			Expect(result).To(Equal(string(input)))
+		})
+	})
+
+	Describe("UT-KA-966-005: Non-JSON passthrough", func() {
+		It("should pass non-JSON text unchanged", func() {
+			input := "NAME   READY   STATUS    RESTARTS   AGE\nnginx  1/1     Running   0          5m"
+			result, sanitizeErr := stage.Sanitize(ctx, input)
+			Expect(sanitizeErr).NotTo(HaveOccurred())
+			Expect(result).To(Equal(input))
+		})
+	})
+
+	Describe("UT-KA-966-006: Secret without data field", func() {
+		It("should return unchanged when Secret has no data or stringData", func() {
+			secret := map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Secret",
+				"metadata":   map[string]interface{}{"name": "empty-secret"},
+				"type":       "Opaque",
+			}
+			input, err := json.Marshal(secret)
+			Expect(err).NotTo(HaveOccurred())
+
+			result, sanitizeErr := stage.Sanitize(ctx, string(input))
+			Expect(sanitizeErr).NotTo(HaveOccurred())
+			Expect(result).To(Equal(string(input)))
+		})
+	})
+
+	Describe("UT-KA-966-007: Stage name", func() {
+		It("should return K8S-SECRET as the stage name", func() {
+			Expect(stage.Name()).To(Equal("K8S-SECRET"))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Addresses the 4 must-fix issues identified during v1.4 QE readiness triage for the RC milestone.

- **#966 (SOC2)**: New `SecretSanitizer` pipeline stage redacts JSON K8s Secret.data/stringData before audit storage. Sanitization errors now fail closed (output withheld) instead of leaking raw credentials. 7 unit tests.
- **#981 (OPS)**: Readiness probe `/readyz` performs real dependency checks (shutdown flag, LLM model, DataStorage client) instead of returning a static 200.
- **#956 (Security)**: All HTTP clients now have explicit timeouts — LangChain LLM (always creates http.Client), Vertex AI (uses SDK's `WithRequestTimeout` to preserve OAuth2 transport), DS fallback (explicit 30s timeout).
- **#963 (API)**: Session status and result endpoints now define 500 responses in OpenAPI. Ogen regenerated with operation-specific typed errors so handler returns correct HTTP status codes.

## Test plan

- [x] `go build ./...` passes
- [x] All unit tests pass (`go test ./test/unit/...`)
- [x] SecretSanitizer: 7 new tests (single Secret, SecretList, non-Secret, non-JSON, stringData, empty Secret, stage name)
- [x] Session client tests: PollSession/GetSessionResult with new typed errors pass
- [x] Vertex AI timeout uses `WithRequestTimeout` (not `WithHTTPClient`) — preserves OAuth2 transport
- [ ] CI pipeline (build, lint, unit, integration, E2E)


Made with [Cursor](https://cursor.com)