### PR TITLE
feat(auth): JWT/OIDC authentication for MCP interactive endpoint (#1009)

### DIFF
--- a/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
+++ b/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
@@ -242,6 +242,23 @@ data:
       maxConcurrentSessions: {{ .Values.kubernautAgent.interactive.maxConcurrentSessions | default 5 }}
       rateLimitPerUser: {{ .Values.kubernautAgent.interactive.rateLimitPerUser | default 10 }}
       maxAnalyzingTimeout: {{ .Values.kubernautAgent.interactive.maxAnalyzingTimeout | default "45m" | quote }}
+{{- with .Values.kubernautAgent.interactive.jwtProviders }}
+      jwtProviders:
+{{- range . }}
+        - name: {{ .name | quote }}
+          issuer: {{ .issuer | quote }}
+          jwksURL: {{ .jwksURL | quote }}
+          audience: {{ .audience | quote }}
+{{- if .claimMappings }}
+          claimMappings:
+            username: {{ .claimMappings.username | default "preferred_username" | quote }}
+            groups: {{ .claimMappings.groups | default "groups" | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- with .Values.kubernautAgent.interactive.jwtInteractiveGroup }}
+      jwtInteractiveGroup: {{ . | quote }}
+{{- end }}
 {{- end }}
     integrations:
       dataStorage:

--- a/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
+++ b/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
@@ -256,9 +256,6 @@ data:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- with .Values.kubernautAgent.interactive.jwtInteractiveGroup }}
-      jwtInteractiveGroup: {{ . | quote }}
-{{- end }}
 {{- end }}
     integrations:
       dataStorage:

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -778,8 +778,7 @@
                   }
                 }
               }
-            },
-            "jwtInteractiveGroup": { "type": "string", "description": "Kubernetes group name for JWT-authenticated interactive users." }
+            }
           }
         }
       }

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -755,7 +755,31 @@
             "inactivityTimeout": { "type": "string", "default": "10m", "description": "Session timeout after last activity." },
             "maxConcurrentSessions": { "type": "integer", "default": 5, "description": "Maximum concurrent interactive sessions per instance." },
             "rateLimitPerUser": { "type": "integer", "default": 10, "description": "Maximum requests per second per authenticated user." },
-            "maxAnalyzingTimeout": { "type": "string", "default": "45m", "description": "Extended analyzing timeout for RO when an interactive session is active. Prevents RO from timing out a RemediationRequest while an operator is investigating." }
+            "maxAnalyzingTimeout": { "type": "string", "default": "45m", "description": "Extended analyzing timeout for RO when an interactive session is active. Prevents RO from timing out a RemediationRequest while an operator is investigating." },
+            "jwtProviders": {
+              "type": "array",
+              "description": "JWT providers for Pattern B authentication (DD-AUTH-MCP-001 v2.0).",
+              "items": {
+                "type": "object",
+                "required": ["name", "issuer", "jwksURL", "audience"],
+                "additionalProperties": false,
+                "properties": {
+                  "name": { "type": "string", "description": "Human-readable provider name." },
+                  "issuer": { "type": "string", "description": "JWT issuer URL (must match iss claim)." },
+                  "jwksURL": { "type": "string", "description": "JWKS endpoint URL for signature verification." },
+                  "audience": { "type": "string", "description": "Expected audience claim value." },
+                  "claimMappings": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "properties": {
+                      "username": { "type": "string", "default": "preferred_username", "description": "JWT claim for username extraction." },
+                      "groups": { "type": "string", "default": "groups", "description": "JWT claim for groups extraction (supports dot-notation)." }
+                    }
+                  }
+                }
+              }
+            },
+            "jwtInteractiveGroup": { "type": "string", "description": "Kubernetes group name for JWT-authenticated interactive users." }
           }
         }
       }

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -317,6 +317,21 @@ kubernautAgent:
     # -- Extended analyzing timeout for RO when an interactive session is active (Go duration).
     # Prevents RO from timing out a RemediationRequest while an operator is investigating.
     # maxAnalyzingTimeout: "45m"
+    # -- JWT providers for Pattern B authentication (DD-AUTH-MCP-001 v2.0).
+    # When configured, KA validates JWT signatures via JWKS endpoints and extracts
+    # user identity from verified claims. Multiple providers support multi-issuer
+    # architecture (v1.5: Keycloak, v1.6: + SPIRE).
+    # jwtProviders:
+    #   - name: "keycloak"
+    #     issuer: "https://keycloak.example.com/realms/kubernaut"
+    #     jwksURL: "https://keycloak.example.com/realms/kubernaut/protocol/openid-connect/certs"
+    #     audience: "kubernaut-agent"
+    #     claimMappings:
+    #       username: "preferred_username"
+    #       groups: "groups"
+    # -- Kubernetes group name for JWT-authenticated interactive users.
+    # Used in ClusterRoleBinding to grant impersonate permissions.
+    # jwtInteractiveGroup: "kubernaut-interactive-users"
   pdb:
     enabled: false
     # minAvailable: 1

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -329,9 +329,6 @@ kubernautAgent:
     #     claimMappings:
     #       username: "preferred_username"
     #       groups: "groups"
-    # -- Kubernetes group name for JWT-authenticated interactive users.
-    # Used in ClusterRoleBinding to grant impersonate permissions.
-    # jwtInteractiveGroup: "kubernaut-interactive-users"
   pdb:
     enabled: false
     # minAvailable: 1

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -1139,7 +1139,7 @@ func newAuthMiddleware(infra *k8sInfra, interactiveCfg kaconfig.InteractiveConfi
 			}
 		}
 
-		jwtAuth, err := auth.NewJWTAuthenticator(entries)
+		jwtAuth, err := auth.NewJWTAuthenticator(entries, logger.WithName("jwt-auth"))
 		if err != nil {
 			logger.Error(err, "failed to create JWTAuthenticator; Pattern B disabled, Pattern A active")
 		} else {

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -1139,6 +1139,13 @@ func newAuthMiddleware(infra *k8sInfra, interactiveCfg kaconfig.InteractiveConfi
 			}
 		}
 
+		for _, e := range entries {
+			if strings.HasPrefix(e.JWKSURL, "http://") {
+				logger.Info("WARNING: JWKS URL uses plain HTTP — vulnerable to MITM in production; enforce HTTPS via kubernaut-operator admission webhook (kubernaut-operator#46)",
+					"provider", e.Issuer, "jwksURL", e.JWKSURL)
+			}
+		}
+
 		jwtAuth, err := auth.NewJWTAuthenticator(entries, logger.WithName("jwt-auth"))
 		if err != nil {
 			logger.Error(err, "failed to create JWTAuthenticator; Pattern B disabled, Pattern A active")

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -336,6 +336,15 @@ func main() {
 
 	r := chi.NewRouter()
 
+	// authCleanupRef is set inside the chi route-setup closure and deferred here
+	// in the main scope so the JWKS cache goroutines live for the server's lifetime.
+	var authCleanupRef func()
+	defer func() {
+		if authCleanupRef != nil {
+			authCleanupRef()
+		}
+	}()
+
 	const maxRequestBodySize int64 = 1 << 20 // 1 MiB
 
 	apiRateLimiter := kaserver.NewRateLimiter(kaserver.RateLimitConfig{
@@ -361,7 +370,12 @@ func main() {
 		r.Use(kaserver.HTTPMetricsMiddleware(agentMetrics))
 		r.Use(apiRateLimiter.Middleware)
 
-		authMw := newAuthMiddleware(k8sInfra, logger)
+		authMw, authCleanup := newAuthMiddleware(k8sInfra, cfg.Interactive, logger)
+		if authCleanup != nil {
+			// authCleanup is captured and deferred in the outer main() scope below
+			// (not here — this is a chi route-setup closure that returns immediately).
+			authCleanupRef = authCleanup
+		}
 		if authMw != nil {
 			r.Use(authMw.Handler)
 			logger.Info("auth middleware enabled (DD-AUTH-014)",
@@ -1097,23 +1111,56 @@ func (f *dsCatalogFetcher) FetchValidator(ctx context.Context) (*parser.Validato
 }
 
 // newAuthMiddleware creates the DD-AUTH-014 auth middleware using the shared k8sInfra clientset.
-func newAuthMiddleware(infra *k8sInfra, logger logr.Logger) *auth.Middleware {
+// DD-AUTH-MCP-001 v2.0: When JWT providers are configured, wraps K8sAuthenticator
+// in a CompositeAuthenticator for Pattern A + Pattern B coexistence.
+// Returns a cleanup function that stops JWKS background goroutines (nil if no JWT).
+func newAuthMiddleware(infra *k8sInfra, interactiveCfg kaconfig.InteractiveConfig, logger logr.Logger) (*auth.Middleware, func()) {
 	if infra == nil || infra.clientset == nil {
 		logger.Info("K8s infrastructure not available, auth middleware disabled")
-		return nil
+		return nil, nil
 	}
 
-	authenticator := auth.NewK8sAuthenticator(infra.clientset)
+	k8sAuth := auth.NewK8sAuthenticator(infra.clientset)
 	authorizer := auth.NewK8sAuthorizer(infra.clientset)
-
 	namespace := detectNamespace()
 
-	return auth.NewMiddleware(authenticator, authorizer, auth.MiddlewareConfig{
+	var authenticator auth.Authenticator = k8sAuth
+	var cleanup func()
+
+	if interactiveCfg.Enabled && len(interactiveCfg.JWTProviders) > 0 {
+		entries := make([]auth.JWTProviderEntry, len(interactiveCfg.JWTProviders))
+		for i, p := range interactiveCfg.JWTProviders {
+			entries[i] = auth.JWTProviderEntry{
+				Issuer:        p.Issuer,
+				JWKSURL:       p.JWKSURL,
+				Audience:      p.Audience,
+				UsernameClaim: p.ClaimMappings.Username,
+				GroupsClaim:   p.ClaimMappings.Groups,
+			}
+		}
+
+		jwtAuth, err := auth.NewJWTAuthenticator(entries)
+		if err != nil {
+			logger.Error(err, "failed to create JWTAuthenticator; Pattern B disabled, Pattern A active")
+		} else {
+			authenticator = auth.NewCompositeAuthenticator(jwtAuth, k8sAuth)
+			cleanup = func() {
+				jwtAuth.Close()
+				logger.Info("JWTAuthenticator JWKS caches stopped")
+			}
+			logger.Info("CompositeAuthenticator enabled (Pattern A + Pattern B)",
+				"jwtProviders", len(entries),
+			)
+		}
+	}
+
+	mw := auth.NewMiddleware(authenticator, authorizer, auth.MiddlewareConfig{
 		Namespace:    namespace,
 		Resource:     "services",
 		ResourceName: "kubernaut-agent",
 		Verb:         "create",
 	}, logger)
+	return mw, cleanup
 }
 
 // buildMCPHandler constructs the fully-wired MCP interactive handler with all

--- a/docs/architecture/decisions/DD-AUTH-MCP-001-mcp-endpoint-security.md
+++ b/docs/architecture/decisions/DD-AUTH-MCP-001-mcp-endpoint-security.md
@@ -1,8 +1,8 @@
 # DD-AUTH-MCP-001: MCP Endpoint Security and User Impersonation
 
-**Status**: Proposed
+**Status**: Accepted
 **Decision Date**: 2026-04-29
-**Version**: 1.0
+**Version**: 2.0
 **Confidence**: 95%
 **Deciders**: Architecture Team
 **Applies To**: kubernaut-agent, kubernaut-apifrontend
@@ -23,7 +23,8 @@
 
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
-| 1.0 | 2026-04-29 | AI-assisted | Initial design |
+| 1.0 | 2026-04-29 | AI-assisted | Initial design: Pattern B via SA token + Impersonate-* headers |
+| 2.0 | 2026-05-03 | AI-assisted | **BREAKING**: Pattern B rewritten for JWT-based identity delegation. Removed SA-token + Impersonate-header approach. Added multi-issuer architecture (KEP-3331 aligned). Forward-compatible with v1.6 SPIRE. PoC validated. AF team approved. |
 
 ---
 
@@ -37,134 +38,186 @@ Issue #703 introduces interactive mode: human users connect via MCP (Model Conte
 
 ### Problem Statement
 
-How do we authenticate MCP clients, resolve their identity, and execute K8s API calls under the correct user identity -- without introducing OIDC/OAuth2 complexity into KA's binary?
+How do we authenticate MCP clients, resolve their identity, and execute K8s API calls under the correct user identity -- while maintaining a clean security boundary between external OIDC authentication (in apifrontend) and internal K8s operations (in KA)?
 
 ### Constraints
 
 - KA must remain internal-only (ClusterIP service, no ingress)
-- KA must not validate OIDC/OAuth2 tokens (security boundary: external auth belongs in apifrontend)
 - K8s API calls during interactive sessions must respect the user's RBAC
 - The same MCP endpoint must serve both in-cluster K8s clients (direct) and delegated clients (via apifrontend)
 - Audit trail must attribute every action to the correct identity
+- Forward-compatible with v1.6 SPIRE workload identity (#31)
 
 ---
 
 ## Decision Drivers
 
-1. **Security boundary**: OIDC validation + K8s impersonation in the same binary creates unacceptable blast radius
+1. **Security boundary**: External auth isolated from K8s impersonation infrastructure
 2. **Defense-in-depth**: Multiple independent verification layers for identity
-3. **Simplicity**: KA's auth stack remains single-concern (K8s TokenReview + SAR)
-4. **Auditability**: Every impersonated K8s API call must be attributable to a resolved identity
-5. **Backward compatibility**: Autonomous mode (KA SA) must be completely unaffected
+3. **Tamper-proof identity**: Cryptographic signature verification, not unsigned headers
+4. **Auditability**: Every impersonated K8s API call must be attributable to a resolved identity with provider metadata
+5. **Backward compatibility**: Autonomous mode (KA SA) and Pattern A (direct K8s clients) completely unaffected
+6. **Forward compatibility**: Multi-issuer architecture supports SPIRE addition in v1.6 without middleware refactor
 
 ---
 
 ## Alternatives Considered
 
-### Alternative A: Dual-auth in KA (OIDC + K8s) -- REJECTED
+### Alternative A: Dual-auth in KA (full OIDC + K8s) -- REJECTED
 
-**Approach**: KA validates both OIDC tokens (external users) and K8s tokens (internal clients) using issuer-based routing.
+**Approach**: KA validates both OIDC tokens (external users) and K8s tokens (internal clients) using issuer-based routing, with full OIDC configuration (discovery, key rotation, session management).
 
 **Pros**:
 - Single deployment
 - No additional service
 
 **Cons**:
-- OIDC validation library + JWKS key rotation in the same binary that executes impersonation
-- Chain authenticator fallthrough creates non-deterministic routing
+- Full OIDC stack (discovery, key rotation, session management) in the same binary that executes impersonation
 - Blast radius: OIDC vulnerability exposes impersonation infrastructure
+- Complexity: chain authenticator fallthrough creates non-deterministic routing
 
 **Confidence**: 40% (rejected)
 
-### Alternative B: kubernaut-apifrontend as auth gateway -- CHOSEN
+### Alternative B (v1.0): SA token + Impersonate-* headers -- SUPERSEDED
 
-**Approach**: External authentication (OIDC/OAuth2) lives in a separate service (`kubernaut-apifrontend`). KA's MCP endpoint is internal-only with K8s TokenReview + SAR.
+**Approach**: AF authenticates with its own SA token and injects `Impersonate-User`/`Impersonate-Group` headers. KA verifies AF's SA via TokenReview + SAR check for `impersonate` verb.
 
 **Pros**:
-- Clean security boundary: external auth isolated from impersonation
 - KA auth stack unchanged from v1.4
-- Apifrontend can evolve independently (Google ADK, multiple OIDC providers)
-- Defense-in-depth: apifrontend validates external tokens, KA validates impersonation authorization
 
 **Cons**:
-- Additional service to deploy
-- MCP-to-MCP proxy adds latency (~1ms internal)
+- Two tokens (AF SA + user identity in headers) — more complex than necessary
+- Unsigned headers — `Impersonate-*` headers are not cryptographically bound to the authenticated session
+- Contradicts v1.5 header stripping (#896) — middleware strips all `Impersonate-*` headers unconditionally, requiring a "preserved copy" workaround
+- Not forward-compatible with SPIRE workload identity
 
-**Confidence**: 95% (chosen)
+**Confidence**: 60% (superseded by Alternative C)
+
+### Alternative C: JWT-based identity delegation -- CHOSEN (v2.0)
+
+**Approach**: AF forwards the user's original Keycloak JWT to KA. KA performs lightweight JWT signature verification via JWKS (not full OIDC), extracts identity from verified claims, and uses that identity for impersonated K8s API calls.
+
+**Pros**:
+- One token, not two — AF forwards the same JWT it validated
+- Tamper-proof — cryptographic signature verification, not unsigned headers
+- No "preserved copy" workaround — identity comes from verified JWT claims, not stripped headers
+- Forward-compatible — multi-issuer architecture adds SPIRE as a second provider in v1.6 without middleware changes
+- Clean security model — KA trusts cryptographic proof, not network-level trust
+
+**Cons**:
+- KA validates JWT signatures (lightweight JWKS verification, not full OIDC)
+- JWKS endpoint dependency at startup (mitigated: pre-warm with timeout, soft-disable on failure)
+- JWT replay within validity window (mitigated: defense-in-depth layers, v1.6 path: short-lived internal JWTs)
+
+**Confidence**: 95% (chosen — PoC validated, AF team approved)
+
+**Why this differs from Alternative A**: Alternative A was rejected for bringing *full OIDC* into KA (discovery, key rotation, session management). Alternative C only performs *JWT signature verification* via a pre-configured JWKS URL — no discovery, no session management, no token exchange. The blast radius is strictly bounded to signature verification.
 
 ---
 
 ## Decision
 
-### Chosen: Alternative B -- kubernaut-apifrontend as auth gateway
+### Chosen: Alternative C -- JWT-based identity delegation (v2.0)
 
-KA's MCP endpoint is **internal-only** (ClusterIP, K8s TokenReview + SAR). External clients (RHDH Console, CLI via ingress) connect through `kubernaut-apifrontend` (separate repo, Google ADK), which handles OIDC/OAuth2 authentication and proxies to KA using MCP-to-MCP with K8s impersonation headers.
+KA's MCP endpoint is **internal-only** (ClusterIP, K8s TokenReview + SAR for Pattern A clients). External clients connect through `kubernaut-apifrontend`, which handles OIDC/OAuth2 authentication and **forwards the original user JWT** to KA. KA validates the JWT signature via JWKS and extracts identity from verified claims.
 
 ### Architecture
 
 ```mermaid
 flowchart LR
     AA["AA Controller\n(K8s SA token)"]
-    APF["kubernaut-apifrontend\n(Google ADK)\n(OIDC/OAuth2 → K8s)"]
-    KA["KA MCP Server\n(internal)\n(TokenReview + SAR)"]
+    APF["kubernaut-apifrontend\n(Google ADK)\n(OIDC/OAuth2 → JWT forward)"]
+    KA["KA MCP Server\n(internal)\n(CompositeAuthenticator)"]
     K8S["K8s API Server"]
 
-    AA -->|"Bearer: SA token\n(Pattern A)"| KA
-    APF -->|"Bearer: SA token\n+ Impersonate-User/Group\n(Pattern B)"| KA
+    AA -->|"Bearer: SA token\n(Pattern A → K8s TokenReview)"| KA
+    APF -->|"Bearer: user JWT\n(Pattern B → JWKS verify)"| KA
     KA -->|"ImpersonationConfig\n{UserName, Groups}"| K8S
 ```
 
 ### Impersonation Model (Dual-Pattern)
 
-#### Pattern A: Direct In-Cluster Clients
+#### Pattern A: Direct In-Cluster Clients (unchanged from v1.0)
 
 Bearer token = caller's K8s token. KA resolves identity via TokenReview, uses that identity for impersonated K8s calls.
 
 ```
 Client → Authorization: Bearer <caller-token>
-KA     → TokenReview → username + groups
-KA     → rest.ImpersonationConfig{UserName: username, Groups: groups}
+KA     → CompositeAuthenticator → isJWT? No → K8sAuthenticator
+       → TokenReview → username + groups
+       → UserInfo{Username, Groups, ProviderType: "k8s:tokenreview"}
+       → rest.ImpersonationConfig{UserName: username, Groups: groups}
 K8s    → API call as impersonated user
 ```
 
-#### Pattern B: Delegated via apifrontend
+#### Pattern B: Delegated via apifrontend (v2.0 — JWT-based)
 
-Bearer token = apifrontend's SA token + `Impersonate-User`/`Impersonate-Group` headers. KA verifies apifrontend SA has `impersonate` RBAC via SAR, then uses delegated identity.
+Bearer token = user's original Keycloak JWT. KA validates signature via JWKS, extracts identity from verified claims.
 
 ```
-apifrontend → Authorization: Bearer <apifrontend-SA-token>
-              Impersonate-User: user-a@corp
-              Impersonate-Group: system:authenticated, org:team-sre
-KA          → TokenReview(SA-token) → apifrontend-sa
-KA          → SAR(apifrontend-sa, impersonate, users) → allowed
-KA          → rest.ImpersonationConfig{UserName: "user-a@corp", Groups: [...]}
-K8s         → API call as user-a@corp
+apifrontend → Authorization: Bearer <user-keycloak-jwt>
+KA          → CompositeAuthenticator → isJWT? Yes → JWTAuthenticator
+            → Parse JWT (unverified) → extract iss claim
+            → Route to matching JWTProviderConfig by issuer URL
+            → Verify signature against JWKS endpoint
+            → Extract username from configured claim path (e.g., preferred_username)
+            → Extract groups from configured claim path (e.g., groups)
+            → UserInfo{Username, Groups, ProviderType: "jwt:<issuer>"}
+            → SAR check (username has create services/kubernaut-agent)
+            → rest.ImpersonationConfig{UserName, Groups}
+K8s         → API call as user
 ```
 
-### Effective User Extraction
+### CompositeAuthenticator Routing Logic
 
 ```go
-func extractEffectiveUser(ctx context.Context, req *http.Request, preserved http.Header) (*UserInfo, error) {
-    // Pattern B detection: SA token + Impersonate-User header
-    impUser := preserved.Get("Impersonate-User")
-    if impUser != "" {
-        // Verify caller has impersonate RBAC via SAR
-        allowed, err := authorizer.CheckAccessWithGroup(ctx, callerUser,
-            "", "", "users", impUser, "impersonate")
-        if !allowed {
-            return nil, ErrForbiddenImpersonation
-        }
-        groups := preserved.Values("Impersonate-Group")
-        return &UserInfo{Username: impUser, Groups: groups}, nil
+func (c *CompositeAuthenticator) ValidateTokenFull(ctx context.Context, token string) (UserInfo, error) {
+    if !isJWT(token) {
+        return c.k8sAuth.ValidateTokenFull(ctx, token)
     }
-    // Pattern A: identity from TokenReview
-    return &UserInfo{Username: callerUser, Groups: callerGroups}, nil
+
+    userInfo, err := c.jwtAuth.ValidateTokenFull(ctx, token)
+    if err != nil {
+        if errors.Is(err, ErrIssuerNotFound) {
+            // Unknown issuer → fall back to K8s TokenReview
+            return c.k8sAuth.ValidateTokenFull(ctx, token)
+        }
+        // Known issuer, bad token → fail-closed, NO fallback
+        return UserInfo{}, err
+    }
+    return userInfo, nil
 }
 ```
 
-### Header Stripping (Defense-in-Depth)
+**Critical security property**: `ErrIssuerNotFound` (unknown provider → fallback) vs `ErrTokenInvalid` (known provider, bad token → fail-closed). This prevents an attacker from forging a JWT with a known issuer to bypass into the K8s TokenReview path.
 
-Middleware strips ALL `Impersonate-*` headers at entry, before any processing:
+### Multi-Issuer Architecture (KEP-3331 aligned)
+
+KA supports multiple JWT providers via `InteractiveConfig.JWTProviders`:
+
+```yaml
+interactive:
+  enabled: true
+  jwtProviders:
+    - name: "keycloak"
+      issuer: "https://keycloak.example.com/realms/kubernaut"
+      jwksURL: "https://keycloak.example.com/realms/kubernaut/protocol/openid-connect/certs"
+      audience: "kubernaut-agent"
+      claimMappings:
+        username: "preferred_username"
+        groups: "groups"
+    # v1.6: SPIRE provider added here without middleware changes
+    # - name: "spire"
+    #   issuer: "spiffe://cluster.local"
+    #   jwksURL: "https://spire-server:8081/keys"
+    #   audience: "kubernaut-agent"
+```
+
+v1.5 ships with one provider (Keycloak). v1.6 adds SPIRE as a second provider — the CompositeAuthenticator and JWTAuthenticator require zero changes.
+
+### Header Stripping (Defense-in-Depth — unchanged)
+
+Middleware strips ALL `Impersonate-*` headers at entry, before any processing. This is orthogonal to Pattern B's JWT-based identity extraction:
 
 ```go
 r.Header.Del("Impersonate-User")
@@ -177,11 +230,28 @@ for key := range r.Header {
 }
 ```
 
-MCP auth handler reads from a **preserved copy** (captured before stripping) only after SAR verification for Pattern B.
+Pattern B extracts identity from **verified JWT claims**, not from HTTP headers. The header stripping defense layer remains active for both patterns.
+
+### JWKS Pre-warm at Startup
+
+```go
+for _, provider := range cfg.Interactive.JWTProviders {
+    ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+    err := jwtAuth.PreWarm(ctx, provider.Issuer)
+    cancel()
+    if err != nil {
+        logger.Error(err, "JWKS pre-warm failed; Pattern B disabled for this provider",
+            "issuer", provider.Issuer)
+        // Pattern A still works; Pattern B returns 401 for this issuer
+    }
+}
+```
+
+Failure is non-fatal: Pattern A (K8s TokenReview) is unaffected. Pattern B returns 401 with a clear error message. JWKS cache auto-refreshes on subsequent requests.
 
 ### Non-K8s Tool Calls
 
-Prometheus, DataStorage, and log queries use KA SA (no user-level auth available on those systems). This is a known limitation documented below.
+Prometheus, DataStorage, and log queries use KA SA (no user-level auth available on those systems). This is a known limitation documented in Known Limitations.
 
 ### Layered Error Model
 
@@ -213,7 +283,7 @@ Prometheus, DataStorage, and log queries use KA SA (no user-level auth available
 | Helm values | `kubernautAgent.interactive.enabled` |
 | Operator CR | `spec.kubernautAgent.interactive.enabled` |
 | ConfigMap rendered | `interactive.enabled` |
-| MCPConfig | `// Deprecated: v1.4 MCP client config (outbound). Not related to interactive mode.` |
+| JWT providers | `kubernautAgent.interactive.jwtProviders[]` |
 
 ### Metric Definitions
 
@@ -223,6 +293,7 @@ Prometheus, DataStorage, and log queries use KA SA (no user-level auth available
 | `aiagent_mcp_interactive_takeover_total` | Counter | Total takeover events |
 | `aiagent_mcp_interactive_lease_contention_total` | Counter | Lease acquisition failures (contention) |
 | `aiagent_mcp_interactive_command_duration_seconds` | Histogram | Duration of interactive tool calls |
+| `aiagent_mcp_auth_provider_total` | Counter | Authentication attempts by provider type (jwt, k8s) |
 
 ### Data Classification Policy
 
@@ -232,30 +303,37 @@ Prometheus, DataStorage, and log queries use KA SA (no user-level auth available
 | `aiagent.llm.request` | Internal | Configurable prompt verbosity |
 | `aiagent.llm.response` | Internal | Configurable response verbosity |
 | `aiagent.session.*` | Operational | No redaction needed |
+| `aiagent.auth.jwt_validated` | Operational | Log issuer + username, NOT token value |
 
 ---
 
 ## Consequences
 
 ### Positive Consequences
-1. Clean security boundary: KA never touches OIDC tokens
-2. KA auth stack unchanged from v1.4 (zero regression risk for autonomous mode)
-3. Apifrontend can evolve independently (multiple OIDC providers, Google ADK)
-4. Full audit trail with user attribution for every impersonated K8s call
+1. Clean security boundary: KA performs lightweight JWT signature verification, not full OIDC
+2. Tamper-proof identity: Cryptographic signature verification replaces unsigned `Impersonate-*` headers
+3. KA auth stack for Pattern A unchanged from v1.4 (zero regression risk for autonomous mode)
+4. Forward-compatible: multi-issuer architecture supports SPIRE in v1.6 without middleware changes
+5. Full audit trail with user attribution including provider metadata (ProviderType)
+6. Apifrontend integration simplified: JWT pass-through, no token minting required
 
 ### Negative Consequences
-1. Additional service (apifrontend) required for external access
-   - **Mitigation**: Apifrontend is optional. KA operates independently for autonomous remediation. Interactive mode is additive.
-2. Non-K8s tools (Prometheus, DS) use KA SA -- no user-level auth
-   - **Mitigation**: Prometheus has no user-level auth. DS access is internal. Documented as known trust boundary.
+1. KA gains a JWKS dependency at startup
+   - **Mitigation**: Pre-warm with 10s timeout; failure is non-fatal (Pattern A unaffected)
+2. JWT replay within validity window
+   - **Mitigation**: Defense-in-depth (ClusterIP, NetworkPolicy, K8s RBAC scoping, audit trail). v1.6: AF mints short-lived (30s) internal JWTs
+3. Non-K8s tools (Prometheus, DS) use KA SA -- no user-level auth
+   - **Mitigation**: Prometheus has no user-level auth. DS access is internal. Documented as known trust boundary
 
 ### Risks
+
 | Risk | Likelihood | Impact | Mitigation |
 |------|-----------|--------|------------|
-| Apifrontend SA token compromised | Low | High | K8s RBAC of impersonated user constrains access; audit logs capture all impersonation |
-| KA SA token compromised | Low | High | Feature gate disables interactive mode; autonomous mode uses KA SA normally |
-| Impersonation scope unbounded | Medium | Medium | Defense-in-depth: apifrontend CEL validation, NetworkPolicy, K8s audit, KA audit events |
-| Session HA (in-memory store) | Medium | Low | v1.5 single-replica. Cancel+reconstruct from DS audit events. v1.6: kubernaut#892 |
+| JWKS endpoint unavailable at startup | Medium | Low | PreWarm with 10s timeout; Pattern A unaffected; JWKS cache auto-refreshes |
+| JWT replay within validity window | Medium | Medium | Defense-in-depth; v1.6: short-lived internal JWTs |
+| ClusterRoleBinding group misconfiguration | Low | Medium | Helm values documentation; integration test; Helm template test |
+| Breaking Pattern A auth | Low | Critical | CompositeAuthenticator passthrough; existing test regression suite |
+| alg confusion attack (alg:none, HS256) | Low | Critical | RS256-only allowlist; explicit alg validation; PoC test verified |
 
 ---
 
@@ -263,19 +341,21 @@ Prometheus, DataStorage, and log queries use KA SA (no user-level auth available
 
 | Requirement | Status | Notes |
 |-------------|--------|-------|
-| BR-INTERACTIVE-001 | Pending | Interactive sessions via MCP |
-| BR-INTERACTIVE-002 | Pending | User-scoped RBAC via impersonation |
-| BR-INTERACTIVE-003 | Pending | Audit attribution via `acting_user` + `session_id` |
+| BR-INTERACTIVE-001 | Active | Interactive sessions via MCP |
+| BR-INTERACTIVE-002 | Active | User-scoped RBAC via JWT-based impersonation |
+| BR-INTERACTIVE-003 | Active | Audit attribution via `acting_user` + `session_id` + `provider_type` |
 
 ---
 
 ## Validation Strategy
 
-1. CP-2 (SECURITY GATE): 14 penetration scenarios covering header injection, auth bypass, impersonation escalation
-2. Unit tests for `extractEffectiveUser` (Pattern A, B, rejection cases)
-3. Unit tests for `ValidateTokenFull` (groups extraction from TokenReview)
-4. Integration tests for MCP connectivity with valid/invalid tokens
-5. E2E: impersonated K8s API call reaches API server as the impersonated user
+1. TP-1009 test plan: 31 unit tests + 9 integration tests across 5 checkpoints
+2. Unit tests for JWTAuthenticator (JWKS verification, claim extraction, multi-issuer routing)
+3. Unit tests for CompositeAuthenticator (token routing, fail-closed semantics, Pattern A passthrough)
+4. Integration tests for full middleware pipeline with mock JWKS
+5. Security-adversarial tests: alg:none rejection, cross-provider rejection, expired JWT, claim injection
+6. Pattern A regression: existing auth test suite unchanged and passing
+7. Helm template tests: ClusterRoleBinding rendering with JWT group
 
 ---
 
@@ -285,11 +365,13 @@ Prometheus, DataStorage, and log queries use KA SA (no user-level auth available
 2. **Impersonation scope unbounded (H-SEC-1)**: K8s doesn't support `resourceNames` for users/groups impersonation. Defense-in-depth: (1) apifrontend CEL validation, (2) NetworkPolicy, (3) K8s audit logs, (4) KA `EventTypeInteractiveK8sCall` audit events.
 3. **Non-K8s tools use KA SA**: Prometheus and DS queries during interactive mode execute under KA SA, not user identity. These systems lack user-level authentication.
 4. **SAR granularity**: One SAR (`services/kubernaut-agent/create`) for all MCP callers. No per-tool authorization. v1.6 path: per-tool SAR.
-5. **EXT-001 divergence**: PROPOSAL-EXT-001 specified DS session persistence for v1.5. Current plan uses in-memory with cancel+reconstruct model, where the audit trail IS the session state. Rationale: cancel+reconstruct eliminates the need for a separate persistence layer. Acceptable for single-replica v1.5.
+5. **JWT replay**: Forwarded JWT can be replayed within its validity window. Mitigated by defense-in-depth (ClusterIP, NetworkPolicy, K8s RBAC scoping, audit trail). v1.6 path: AF mints short-lived (30s) internal JWTs.
+6. **No `jti` dedup**: No JWT ID tracking for replay detection. Acceptable for v1.5 given internal-only network. v1.6 consideration.
+7. **Claim mapping simplicity**: v1.5 uses dot-notation paths, not CEL expressions. Sufficient for Keycloak. v1.6 may adopt CEL for parity with AF (KEP-3331).
 
 ## Graceful Degradation (M-PROD-2)
 
-Apifrontend is optional. KA operates independently for autonomous remediation. Interactive mode is additive -- apifrontend outage affects only interactive clients, not the autonomous pipeline.
+Apifrontend is optional. KA operates independently for autonomous remediation. Interactive mode is additive -- apifrontend outage affects only interactive clients, not the autonomous pipeline. JWKS pre-warm failure disables Pattern B only; Pattern A continues to function.
 
 ## User Documentation (H-PROD-1)
 
@@ -305,8 +387,32 @@ PR6 (hard requirement) creates `docs/user-guide/interactive-mode.md` covering: h
 - kubernaut-operator#26: KA SA `impersonate` RBAC
 - kubernaut#895: Authenticator `ValidateTokenFull` returning groups
 - kubernaut#896: Impersonation header stripping in middleware
+- kubernaut#1009: Pattern B trust-boundary mechanism
+- kubernaut-apifrontend#2: KEP-3331 multi-provider OIDC
+- kubernaut-apifrontend#3: MCP-to-MCP proxy (JWT forwarding)
+- kubernaut-apifrontend#55: End-to-end authz enforcement
+- kubernaut-apifrontend#31: SPIFFE workload identity binding (v1.6)
+- TP-1009: Test plan (docs/tests/1009/TEST_PLAN.md)
 
 ---
 
-**Document Version**: 1.0
-**Last Updated**: 2026-04-29
+## v1.0 → v2.0 Migration Notes
+
+### What changed
+- **Pattern B mechanism**: SA-token + Impersonate-* headers → JWT-based identity delegation
+- **KA auth responsibility**: Pure K8s TokenReview → CompositeAuthenticator (K8s TokenReview + lightweight JWT JWKS verification)
+- **Identity extraction**: HTTP headers (unsigned) → JWT claims (cryptographically signed)
+- **`extractEffectiveUser` function**: Removed. Identity comes from CompositeAuthenticator, not from preserved header inspection
+
+### What did NOT change
+- **Pattern A**: Completely unchanged. K8s SA tokens validated via TokenReview
+- **Header stripping**: `stripImpersonationHeaders` remains active for defense-in-depth
+- **SAR authorization**: Both patterns go through SAR check
+- **Error model**: RFC 7807 + JSON-RPC error codes unchanged
+- **Feature gates**: Same `interactive.enabled` gate
+- **Metrics, data classification, session management**: Unchanged
+
+---
+
+**Document Version**: 2.0
+**Last Updated**: 2026-05-03

--- a/docs/architecture/decisions/DD-AUTH-MCP-001-mcp-endpoint-security.md
+++ b/docs/architecture/decisions/DD-AUTH-MCP-001-mcp-endpoint-security.md
@@ -234,20 +234,19 @@ Pattern B extracts identity from **verified JWT claims**, not from HTTP headers.
 
 ### JWKS Pre-warm at Startup
 
+`NewJWTAuthenticator` performs a synchronous JWKS fetch with a 15-second timeout for each configured provider during construction:
+
 ```go
-for _, provider := range cfg.Interactive.JWTProviders {
-    ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-    err := jwtAuth.PreWarm(ctx, provider.Issuer)
-    cancel()
-    if err != nil {
-        logger.Error(err, "JWKS pre-warm failed; Pattern B disabled for this provider",
-            "issuer", provider.Issuer)
-        // Pattern A still works; Pattern B returns 401 for this issuer
-    }
+jwtAuth, err := auth.NewJWTAuthenticator(entries, logger)
+if err != nil {
+    logger.Error(err, "failed to create JWTAuthenticator; Pattern B disabled, Pattern A active")
+    // authenticator = k8sAuth (Pattern A only)
+} else {
+    authenticator = auth.NewCompositeAuthenticator(jwtAuth, k8sAuth)
 }
 ```
 
-Failure is non-fatal: Pattern A (K8s TokenReview) is unaffected. Pattern B returns 401 with a clear error message. JWKS cache auto-refreshes on subsequent requests.
+If **any** provider's JWKS endpoint is unreachable at startup, `NewJWTAuthenticator` returns an error and the `CompositeAuthenticator` is not created — Pattern B is disabled **globally**. Pattern A (K8s TokenReview) remains fully operational. For v1.5 with a single OIDC provider (Keycloak), this is equivalent to per-provider disable. Per-provider degradation may be added in v1.6 when SPIRE is introduced as a second provider.
 
 ### Non-K8s Tool Calls
 
@@ -319,7 +318,7 @@ Prometheus, DataStorage, and log queries use KA SA (no user-level auth available
 
 ### Negative Consequences
 1. KA gains a JWKS dependency at startup
-   - **Mitigation**: Pre-warm with 10s timeout; failure is non-fatal (Pattern A unaffected)
+   - **Mitigation**: Pre-warm with 15s timeout; failure disables Pattern B globally but Pattern A is unaffected
 2. JWT replay within validity window
    - **Mitigation**: Defense-in-depth (ClusterIP, NetworkPolicy, K8s RBAC scoping, audit trail). v1.6: AF mints short-lived (30s) internal JWTs
 3. Non-K8s tools (Prometheus, DS) use KA SA -- no user-level auth
@@ -329,7 +328,7 @@ Prometheus, DataStorage, and log queries use KA SA (no user-level auth available
 
 | Risk | Likelihood | Impact | Mitigation |
 |------|-----------|--------|------------|
-| JWKS endpoint unavailable at startup | Medium | Low | PreWarm with 10s timeout; Pattern A unaffected; JWKS cache auto-refreshes |
+| JWKS endpoint unavailable at startup | Medium | Low | Pre-warm with 15s timeout; Pattern B disabled globally; Pattern A unaffected |
 | JWT replay within validity window | Medium | Medium | Defense-in-depth; v1.6: short-lived internal JWTs |
 | ClusterRoleBinding group misconfiguration | Low | Medium | Helm values documentation; integration test; Helm template test |
 | Breaking Pattern A auth | Low | Critical | CompositeAuthenticator passthrough; existing test regression suite |

--- a/docs/tests/1009/TEST_PLAN.md
+++ b/docs/tests/1009/TEST_PLAN.md
@@ -1,0 +1,784 @@
+# Test Plan: Pattern B JWT Trust-Boundary for API Frontend Delegated Impersonation
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+>
+> Based on IEEE 829-2008 (Standard for Software and System Test Documentation) with
+> Kubernaut-specific extensions for TDD phase tracking, business requirement traceability,
+> and per-tier coverage policy.
+
+**Test Plan Identifier**: TP-1009-v1.0
+**Feature**: JWT-based identity delegation from kubernaut-apifrontend to Kubernaut Agent
+**Version**: 1.0
+**Created**: 2026-05-03
+**Author**: AI-assisted
+**Status**: Active
+**Branch**: `development/v1.5`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This test plan provides comprehensive quality assurance for Pattern B JWT trust-boundary
+implementation (#1009). The feature enables `kubernaut-apifrontend` to delegate user identity
+to KA via cryptographically signed JWTs, replacing the previously proposed SA-token +
+Impersonate-header approach. Given the security-critical nature (authentication bypass,
+privilege escalation, impersonation abuse), this plan mandates adversarial test scenarios
+and checkpoints at each TDD boundary.
+
+### 1.2 Objectives
+
+1. **JWT authentication correctness**: JWTAuthenticator validates signatures via JWKS, extracts identity from verified claims, and rejects all invalid tokens
+2. **Composite routing safety**: CompositeAuthenticator routes JWT vs opaque tokens deterministically with fail-closed semantics on known-issuer errors
+3. **Pattern A regression**: Direct in-cluster clients remain completely unaffected by Pattern B introduction
+4. **Identity propagation**: ProviderType metadata flows from authentication through MCP tools to audit logging
+5. **Defense-in-depth**: Multi-layer security (JWKS verification, SAR authorization, ClusterRoleBinding, header stripping) prevents single-point failures
+6. **Forward compatibility**: Multi-issuer architecture supports v1.6 SPIRE addition without middleware changes
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/shared/auth/...` |
+| Integration test pass rate | 100% | `go test ./test/integration/kubernautagent/...` |
+| Unit-testable code coverage | >=80% | `go test -coverprofile` on `pkg/shared/auth/jwt_auth.go`, `composite_auth.go`, `claims.go` |
+| Integration-testable code coverage | >=80% | `go test -coverprofile` on middleware pipeline, main.go wiring |
+| Pattern A regression | 0 regressions | Existing auth tests pass without modification |
+| Security scenarios | 100% pass | All adversarial scenarios pass |
+| Build integrity | 0 errors | `go build ./...` clean after every phase |
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- **BR-INTERACTIVE-001**: Interactive investigation sessions
+- **BR-INTERACTIVE-002**: MCP tool access with user-scoped RBAC
+- **BR-INTERACTIVE-003**: Audit attribution for interactive actions
+- **DD-AUTH-MCP-001 v2.0**: MCP endpoint security (JWT-based Pattern B)
+- **Issue #1009**: Pattern B trust-boundary mechanism for AF delegated impersonation
+- **Issue #896**: Strip Impersonate-* headers in auth middleware
+- **Issue #895**: Authenticator returns user groups for impersonation
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../../.cursor/rules/03-testing-strategy.mdc)
+- [Testing Guidelines](../../development/business-requirements/TESTING_GUIDELINES.md)
+- [Go Coding Standards](../../../.cursor/rules/02-go-coding-standards.mdc)
+- [kubernaut-apifrontend#2](https://github.com/jordigilh/kubernaut-apifrontend/issues/2): KEP-3331 multi-provider OIDC
+- [kubernaut-apifrontend#3](https://github.com/jordigilh/kubernaut-apifrontend/issues/3): MCP-to-MCP proxy
+- [100 Go Mistakes](https://100go.co/) — REFACTOR phase validation checklist
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | JWT signature bypass (alg:none, key confusion) | Critical: impersonation of any user | Low | UT-KA-1009-008, UT-KA-1009-009 | Explicit alg allowlist (RS256 only), reject unsigned tokens |
+| R2 | Cross-path authentication leak (JWT error falls through to K8s TokenReview) | Critical: untrusted token accepted | Medium | UT-KA-1009-016, UT-KA-1009-017 | ErrIssuerNotFound vs ErrTokenInvalid sentinel distinction; fail-closed on known issuer |
+| R3 | Pattern A regression (direct clients broken) | High: production auth failure | Low | UT-KA-1009-018, IT-KA-1009-005 | CompositeAuthenticator passthrough; existing test suite unchanged |
+| R4 | JWKS endpoint unavailable at startup | Medium: Pattern B non-functional | Medium | UT-KA-1009-010, IT-KA-1009-008 | PreWarm with 10s timeout; soft-disable (Pattern A unaffected) |
+| R5 | Dot-notation claim extraction fails on Keycloak nested claims | Medium: user identity lost | Low | UT-KA-1009-003..005 | PoC validated with 11 scenarios; recursive map traversal |
+| R6 | JWT replay within validity window | Medium: unauthorized action replay | Medium | UT-KA-1009-011 | Defense-in-depth (ClusterIP, NetworkPolicy, SAR, audit); v1.6: short-lived internal JWTs |
+| R7 | ClusterRoleBinding group mismatch | Medium: JWT users denied | Low | UT-KA-1009-030, IT-KA-1009-009 | Helm template test validates group rendering |
+| R8 | ProviderType not propagated to audit trail | Low: forensic gap | Low | UT-KA-1009-022, IT-KA-1009-006 | Middleware logs provider metadata |
+| R9 | Concurrent JWKS cache refresh race condition | Low: intermittent auth failures | Low | UT-KA-1009-012 | lestrrat-go/jwx cache is goroutine-safe; integration test under concurrent load |
+
+### 3.1 Risk-to-Test Traceability
+
+- **R1 (Critical)**: Covered by UT-KA-1009-008 (alg:none rejection), UT-KA-1009-009 (wrong key rejection)
+- **R2 (Critical)**: Covered by UT-KA-1009-016 (known issuer bad token → fail-closed), UT-KA-1009-017 (unknown issuer → fallback)
+- **R3 (High)**: Covered by UT-KA-1009-018 (Pattern A passthrough), IT-KA-1009-005 (mixed traffic)
+- **R4-R9**: Mapped in Affected Tests column above
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **JWTAuthenticator** (`pkg/shared/auth/jwt_auth.go`): JWKS-based JWT signature verification, multi-issuer routing, dot-notation claim extraction, error type distinction
+- **CompositeAuthenticator** (`pkg/shared/auth/composite_auth.go`): Token shape routing (JWT vs opaque), fail-closed semantics, ErrIssuerNotFound fallback
+- **JWTProviderConfig** (`internal/kubernautagent/config/config.go`): Configuration types, validation rules, Helm values mapping
+- **ProviderType propagation** (`pkg/shared/auth/interfaces.go`, `internal/kubernautagent/mcp/interfaces.go`): Provider metadata in UserInfo, middleware audit logging
+- **Main.go wiring** (`cmd/kubernautagent/main.go`): CompositeAuthenticator construction, JWKS pre-warm, soft-disable on failure
+- **Claim extraction** (`pkg/shared/auth/claims.go`): Dot-notation path resolution for nested JWT claims
+- **Helm chart** (`charts/kubernaut/templates/kubernaut-agent/`): jwtProviders ConfigMap rendering, conditional ClusterRoleBinding
+
+### 4.2 Features Not to be Tested
+
+- **AF-side JWT forwarding**: Owned by kubernaut-apifrontend repo (kubernaut-apifrontend#3)
+- **Keycloak configuration**: External OIDC provider setup (documented in operator deployment guide)
+- **SPIRE integration**: v1.6 scope (kubernaut-apifrontend#31)
+- **DEX E2E provider**: Implemented — DEX v2.45.1 deployed in Kind cluster for E2E JWT testing
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Mock JWKS server for unit/integration tests | Real OIDC provider adds infrastructure complexity; MockJWKSServer (from PoC) provides deterministic behavior |
+| Separate JWTAuthenticator from CompositeAuthenticator | Single responsibility; testable in isolation; CompositeAuthenticator is pure routing logic |
+| ErrIssuerNotFound as distinct error type | Enables fallback without security leak; distinguishes "unknown provider" from "known provider, bad token" |
+| ProviderType as string not enum | Forward-compatible with unknown future providers (SPIRE, AuthBridge); format: "jwt:<issuer>" or "k8s:tokenreview" |
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+**Authority**: `03-testing-strategy.mdc` — Per-Tier Testable Code Coverage.
+
+- **Unit**: >=80% of unit-testable code (`jwt_auth.go`, `composite_auth.go`, `claims.go`, config types, error types)
+- **Integration**: >=80% of integration-testable code (middleware pipeline with mock JWKS, main.go wiring paths, mixed Pattern A + B traffic)
+- **E2E**: >=80% of E2E-testable code — DEX OIDC provider in Kind cluster validates full JWT/OIDC flow
+
+### 5.2 Two-Tier Minimum
+
+Every acceptance criterion is covered by at least 2 test tiers:
+- **Unit tests**: JWT validation logic, claim extraction, composite routing, error types
+- **Integration tests**: Full middleware pipeline, main.go wiring, mixed traffic patterns
+
+### 5.3 Business Outcome Quality Bar
+
+Tests validate **business outcomes** — "can AF delegate identity to KA securely?" — not just
+code path coverage. Each test scenario answers: "what does the operator/user/system get?"
+
+### 5.4 Pass/Fail Criteria
+
+**PASS** — all of the following must be true:
+
+1. All P0 tests pass (0 failures)
+2. All P1 tests pass or have documented exceptions approved by reviewer
+3. Per-tier code coverage meets >=80% threshold
+4. No regressions in existing test suites (auth middleware, header stripping, K8s auth)
+5. `go build ./...` succeeds with 0 errors
+6. `golangci-lint run --timeout=5m` produces no new errors
+
+**FAIL** — any of the following:
+
+1. Any P0 test fails
+2. Per-tier coverage falls below 80% on any tier
+3. Existing tests that were passing before the change now fail
+4. Any adversarial security test fails
+5. Build errors introduced
+
+### 5.5 Suspension & Resumption Criteria
+
+**Suspend testing when**:
+
+- Build broken — code does not compile; unit tests cannot execute
+- CHECKPOINT audit identifies blocking security issue
+- lestrrat-go/jwx/v3 API incompatibility discovered (mitigate: PoC validated v3.0.13)
+
+**Resume testing when**:
+
+- Build fixed and green
+- CHECKPOINT finding resolved and verified
+- Dependency issue resolved with pinned version
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code (pure logic, no I/O)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `pkg/shared/auth/jwt_auth.go` | `NewJWTAuthenticator`, `ValidateToken`, `ValidateTokenFull`, `resolveIssuer`, `extractIdentity` | ~150 |
+| `pkg/shared/auth/composite_auth.go` | `NewCompositeAuthenticator`, `ValidateToken`, `ValidateTokenFull`, `isJWT`, `routeToken` | ~80 |
+| `pkg/shared/auth/claims.go` | `ExtractClaim`, `ExtractStringClaim`, `ExtractGroupsClaim` | ~73 |
+| `internal/kubernautagent/config/config.go` | `JWTProviderConfig`, `ClaimMappings`, validation rules | ~60 |
+| `pkg/shared/auth/interfaces.go` | `UserInfo` (ProviderType field), error sentinels | ~20 |
+
+### 6.2 Integration-Testable Code (I/O, wiring, cross-component)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `pkg/shared/auth/middleware.go` | `Handler` (composite auth path), audit logging with ProviderType | ~30 (modified lines) |
+| `cmd/kubernautagent/main.go` | `newAuthMiddleware` (CompositeAuthenticator wiring), JWKS pre-warm | ~50 |
+| `internal/kubernautagent/mcp/interfaces.go` | `UserInfo` (ProviderType propagation) | ~10 |
+
+### 6.3 Version Identification
+
+| Item | Version/Commit | Notes |
+|------|----------------|-------|
+| Code under test | `development/v1.5` HEAD | Post-PR #1018 merge |
+| lestrrat-go/jwx/v3 | v3.0.13 | PoC validated |
+| MockJWKSServer | From PoC | `test/shared/auth/mock_jwks_server.go` |
+
+---
+
+## 7. BR Coverage Matrix
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-INTERACTIVE-002 | JWT-bearing requests authenticated via JWKS signature verification | P0 | Unit | UT-KA-1009-001 | Pending |
+| BR-INTERACTIVE-002 | JWT-bearing requests authenticated via JWKS signature verification | P0 | Integration | IT-KA-1009-001 | Pending |
+| BR-INTERACTIVE-002 | User identity extracted from verified JWT claims | P0 | Unit | UT-KA-1009-002..005 | Pending |
+| BR-INTERACTIVE-002 | Unknown JWT issuers fall back to K8s TokenReview | P0 | Unit | UT-KA-1009-017 | Pending |
+| BR-INTERACTIVE-002 | Known issuers with bad tokens fail-closed | P0 | Unit | UT-KA-1009-016 | Pending |
+| BR-INTERACTIVE-001 | Pattern A clients unaffected (no regression on #896) | P0 | Unit | UT-KA-1009-018 | Pending |
+| BR-INTERACTIVE-001 | Pattern A clients unaffected (no regression on #896) | P0 | Integration | IT-KA-1009-005 | Pending |
+| BR-INTERACTIVE-002 | JWT users authorized via K8s SAR against ClusterRoleBinding | P0 | Integration | IT-KA-1009-003 | Pending |
+| BR-INTERACTIVE-003 | ProviderType propagated to audit logging | P1 | Unit | UT-KA-1009-022 | Pending |
+| BR-INTERACTIVE-003 | ProviderType propagated to audit logging | P1 | Integration | IT-KA-1009-006 | Pending |
+
+---
+
+## 8. Test Scenarios
+
+### Test ID Naming Convention
+
+Format: `{TIER}-KA-1009-{SEQUENCE}`
+
+- **TIER**: `UT` (Unit), `IT` (Integration), `E2E` (End-to-End)
+- **KA**: Kubernaut Agent service
+- **1009**: Issue number
+- **SEQUENCE**: Zero-padded 3-digit (001, 002, ...)
+
+### Tier 1: Unit Tests
+
+**Testable code scope**: `pkg/shared/auth/jwt_auth.go`, `composite_auth.go`, `claims.go`, config types — >=80% coverage target
+
+#### Phase 1: Config Types (JWTProviderConfig + ClaimMappings)
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-KA-1009-025` | Valid JWTProviderConfig with all required fields passes validation | Pass |
+| `UT-KA-1009-026` | JWTProviderConfig without issuer URL fails validation with clear error | Pass |
+| `UT-KA-1009-027` | JWTProviderConfig without JWKS URL fails validation with clear error | Pass |
+| `UT-KA-1009-028` | JWTProviderConfig without audience fails validation with clear error | Pass |
+| `UT-KA-1009-029` | ClaimMappings defaults applied when not specified (preferred_username, groups) | Pass |
+| `UT-KA-1009-030` | InteractiveConfig with jwtProviders validates all providers | Pass |
+| `UT-KA-1009-031` | Duplicate issuer URLs across providers rejected | Pass |
+| `UT-KA-1009-034` | JWKS URL exceeding max length (2048) rejected | Pass |
+| `UT-KA-1009-035` | Syntactically invalid JWKS URL rejected via net/url.Parse | Pass |
+| `UT-KA-1009-036` | JWKS URL with unsupported scheme (non-HTTP/HTTPS) rejected | Pass |
+| `UT-KA-1009-037` | JWKS URL with HTTP scheme accepted (dev/test flexibility) | Pass |
+| `UT-KA-1009-038` | Issuer URL exceeding max length (2048) rejected | Pass |
+
+#### Phase 2: JWTAuthenticator
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-KA-1009-001` | Valid JWT from known issuer accepted, correct username+groups extracted | Pending |
+| `UT-KA-1009-002` | Username extracted from dot-notation claim path (e.g., preferred_username) | Pending |
+| `UT-KA-1009-003` | Groups extracted from nested claim path (e.g., realm_access.roles) | Pending |
+| `UT-KA-1009-004` | Groups extracted from double-nested path (resource_access.client.roles) | Pending |
+| `UT-KA-1009-005` | Top-level groups claim extracted correctly | Pending |
+| `UT-KA-1009-006` | Expired JWT rejected with ErrTokenInvalid | Pending |
+| `UT-KA-1009-007` | JWT with wrong audience rejected with ErrTokenInvalid | Pending |
+| `UT-KA-1009-008` | JWT with alg:none rejected (alg confusion attack) | Pending |
+| `UT-KA-1009-009` | JWT signed by unknown key rejected with ErrTokenInvalid | Pending |
+| `UT-KA-1009-010` | JWT from unknown issuer returns ErrIssuerNotFound (not ErrTokenInvalid) | Pending |
+| `UT-KA-1009-011` | JWT with missing username claim rejected with descriptive error | Pending |
+| `UT-KA-1009-012` | Multi-issuer: tokens routed to correct JWKS endpoint by iss claim | Pending |
+| `UT-KA-1009-013` | Multi-issuer: cross-provider rejection (token from issuer-A rejected by issuer-B's JWKS) | Pending |
+| `UT-KA-1009-014` | ProviderType set to "jwt:<issuer>" on successful validation | Pending |
+
+#### Phase 3: CompositeAuthenticator
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-KA-1009-015` | JWT-shaped token (3-dot structure) routed to JWTAuthenticator | Pending |
+| `UT-KA-1009-016` | Known issuer with invalid signature → fail-closed (no fallback to K8s) | Pending |
+| `UT-KA-1009-017` | Unknown issuer → ErrIssuerNotFound → fallback to K8sAuthenticator | Pending |
+| `UT-KA-1009-018` | Opaque token (non-JWT) → direct K8sAuthenticator (Pattern A unchanged) | Pending |
+| `UT-KA-1009-019` | Empty token → error (no fallback, no routing) | Pending |
+| `UT-KA-1009-020` | K8sAuthenticator error after fallback → propagated correctly | Pending |
+| `UT-KA-1009-021` | Malformed JWT (3 dots but not base64) → treated as opaque, fallback to K8s | Pending |
+
+#### Phase 4: ProviderType Propagation
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-KA-1009-022` | UserInfo.ProviderType populated for JWT-authenticated users | Pending |
+| `UT-KA-1009-023` | UserInfo.ProviderType populated for K8s-authenticated users ("k8s:tokenreview") | Pending |
+| `UT-KA-1009-024` | MCP UserInfo bridges ProviderType from shared auth UserInfo | Pending |
+
+### Tier 2: Integration Tests
+
+**Testable code scope**: Middleware pipeline, main.go wiring, mixed traffic — >=80% coverage target
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `IT-KA-1009-001` | Full middleware pipeline accepts valid JWT, injects UserInfo into context | Pending |
+| `IT-KA-1009-002` | Full middleware pipeline rejects expired JWT with 401 | Pending |
+| `IT-KA-1009-003` | JWT-authenticated user passes SAR check against ClusterRoleBinding | Pending |
+| `IT-KA-1009-004` | JWT-authenticated user fails SAR check → 403 Forbidden | Pending |
+| `IT-KA-1009-005` | Mixed traffic: JWT request + K8s SA request both succeed in same middleware instance | Pending |
+| `IT-KA-1009-006` | ProviderType appears in middleware audit log entries | Pending |
+| `IT-KA-1009-007` | Impersonate-* headers stripped before JWT validation (defense-in-depth) | Pending |
+| `IT-KA-1009-008` | JWKS pre-warm failure → Pattern A still works, Pattern B returns 401 | Pending |
+| `IT-KA-1009-009` | Helm-rendered ClusterRoleBinding resolves correct group from values | Pending |
+
+### Tier 3: E2E Tests
+
+**Testable code scope**: Full stack with DEX v2.45.1 OIDC provider in Kind cluster
+
+| ID | Business Outcome Under Test | Phase | Status |
+|----|----------------------------|-------|--------|
+| `E2E-KA-JWT-001` | Real JWT from DEX accepted by KA deployed in Kind → 200 OK | E2E | Implemented |
+| `E2E-KA-JWT-002` | Forged JWT rejected with 401 (fail-closed in real cluster) | E2E | Implemented |
+| `E2E-KA-JWT-003` | Pattern A (SA token) + Pattern B (JWT) coexist in deployed KA | E2E | Implemented |
+| `E2E-KA-JWT-004` | JWT user invokes kubernaut_investigate → session with JWT identity | E2E | Implemented |
+| `E2E-KA-JWT-005` | DEX-issued JWT structure validated end-to-end | E2E | Implemented |
+
+**Infrastructure**: DEX deployed as Phase 5.8 in `SetupKubernautAgentInfrastructure()`, RBAC for DEX user, `jwtProviders` in KA ConfigMap.
+**Location**: `test/e2e/kubernautagent/jwt_e2e_test.go`
+
+---
+
+## 9. Test Cases
+
+### UT-KA-1009-001: Valid JWT accepted with correct identity extraction
+
+**BR**: BR-INTERACTIVE-002
+**Priority**: P0
+**Type**: Unit
+**File**: `test/unit/shared/auth/jwt_auth_test.go`
+
+**Preconditions**:
+- MockJWKSServer running with known RSA key pair
+- JWTAuthenticator configured with one provider pointing to mock server
+
+**Test Steps**:
+1. **Given**: A JWTAuthenticator configured with issuer "https://keycloak.example.com/realms/kubernaut" and audience "kubernaut-agent"
+2. **When**: A valid JWT is issued by MockJWKSServer with sub="user-a@corp", preferred_username="user-a@corp", groups=["kubernaut-interactive-users"]
+3. **Then**: ValidateTokenFull returns UserInfo{Username: "user-a@corp", Groups: ["kubernaut-interactive-users"], ProviderType: "jwt:https://keycloak.example.com/realms/kubernaut"}
+
+**Expected Results**:
+1. No error returned
+2. Username matches preferred_username claim
+3. Groups match groups claim
+4. ProviderType contains "jwt:" prefix + issuer URL
+
+**Acceptance Criteria**:
+- **Behavior**: JWT signature verified against JWKS endpoint
+- **Correctness**: Identity matches JWT claims exactly
+- **Accuracy**: No data loss or transformation errors
+
+### UT-KA-1009-008: alg:none JWT rejected (security-critical)
+
+**BR**: BR-INTERACTIVE-002
+**Priority**: P0 (Security)
+**Type**: Unit
+**File**: `test/unit/shared/auth/jwt_auth_test.go`
+
+**Preconditions**:
+- JWTAuthenticator configured with RS256-only provider
+
+**Test Steps**:
+1. **Given**: A JWTAuthenticator configured for RS256 algorithm
+2. **When**: A JWT with alg:none header is presented (unsigned token)
+3. **Then**: Token is rejected with ErrTokenInvalid
+
+**Expected Results**:
+1. Error returned wrapping ErrTokenInvalid
+2. No identity extracted
+3. No fallback to other auth path
+
+**Acceptance Criteria**:
+- **Behavior**: Algorithm confusion attack blocked
+- **Correctness**: Error is ErrTokenInvalid (fail-closed, not ErrIssuerNotFound)
+
+### UT-KA-1009-016: Known issuer, invalid signature → fail-closed
+
+**BR**: BR-INTERACTIVE-002
+**Priority**: P0 (Security)
+**Type**: Unit
+**File**: `test/unit/shared/auth/composite_auth_test.go`
+
+**Preconditions**:
+- CompositeAuthenticator with JWTAuthenticator + K8sAuthenticator
+- JWT signed with wrong key but correct issuer claim
+
+**Test Steps**:
+1. **Given**: A CompositeAuthenticator with Keycloak issuer configured
+2. **When**: A JWT with correct issuer but signed by a different RSA key is presented
+3. **Then**: Authentication fails with ErrTokenInvalid — NO fallback to K8sAuthenticator
+
+**Expected Results**:
+1. Error wrapping ErrTokenInvalid returned
+2. K8sAuthenticator.ValidateTokenFull is NOT called (zero call count)
+3. Response is 401 Unauthorized
+
+**Acceptance Criteria**:
+- **Behavior**: Fail-closed prevents cross-path security leak
+- **Correctness**: Known issuer errors are terminal, no fallback
+- **Security**: Attacker cannot forge a JWT with known issuer to bypass into K8s TokenReview path
+
+### IT-KA-1009-005: Mixed Pattern A + Pattern B traffic
+
+**BR**: BR-INTERACTIVE-001, BR-INTERACTIVE-002
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/kubernautagent/auth/mixed_traffic_test.go`
+
+**Preconditions**:
+- Full middleware pipeline with CompositeAuthenticator (MockJWKSServer + MockK8sAuthenticator)
+- httptest.Server serving the middleware
+
+**Test Steps**:
+1. **Given**: A middleware pipeline with CompositeAuthenticator configured
+2. **When**: Request 1 sends a valid JWT token (Pattern B), then Request 2 sends a valid K8s SA token (Pattern A)
+3. **Then**: Both requests succeed with correct UserInfo in context
+
+**Expected Results**:
+1. JWT request: UserInfo.ProviderType = "jwt:<issuer>"
+2. K8s request: UserInfo.ProviderType = "k8s:tokenreview"
+3. Both requests pass SAR check
+4. No cross-contamination between auth paths
+
+---
+
+## 10. Environmental Needs
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: MockJWKSServer (JWKS endpoint), MockAuthenticator (K8s fallback), MockAuthorizer (SAR)
+- **Location**: `test/unit/shared/auth/`
+- **External deps mocked**: JWKS HTTP endpoint (httptest), K8s TokenReview, K8s SAR
+
+### 10.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Infrastructure**: httptest for full middleware pipeline, MockJWKSServer for JWKS
+- **Mocks**: MockAuthorizer for SAR (K8s auth not available without cluster)
+- **Location**: `test/integration/kubernautagent/auth/`
+
+### 10.3 E2E Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Infrastructure**: Kind cluster + DEX v2.45.1 OIDC provider (Podman)
+- **OIDC Provider**: DEX with static password user (`e2e-user@kubernaut.test`) and static client (`kubernaut-agent`)
+- **Token Flow**: Resource Owner Password Credentials grant → `id_token` (JWT)
+- **KA Config**: `jwtProviders` pointing to `http://dex:5556/dex` (cluster-internal)
+- **RBAC**: K8s Role/RoleBinding for DEX user (`e2e-user@kubernaut.test`) granting `services/kubernaut-agent` access
+- **Location**: `test/e2e/kubernautagent/jwt_e2e_test.go`
+- **Infrastructure helpers**: `test/infrastructure/dex_e2e.go`
+
+### 10.4 Tools & Versions
+
+| Tool | Minimum Version | Purpose |
+|------|-----------------|---------|
+| Go | 1.25.6 | Build and test |
+| Ginkgo CLI | v2.28+ | Test runner |
+| lestrrat-go/jwx/v3 | v3.0.13 | JWT/JWKS operations |
+| golangci-lint | latest | Lint validation |
+| DEX | v2.45.1 | E2E OIDC provider |
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Blocking Dependencies
+
+| Dependency | Type | Status | Impact if Not Available | Workaround |
+|------------|------|--------|-------------------------|------------|
+| PR #1018 | Code | Merged | InteractiveReadiness, SSAR check | N/A (merged) |
+| lestrrat-go/jwx/v3 | Library | Available (v3.0.13) | JWT operations unavailable | N/A (PoC validated) |
+| MockJWKSServer | Test infra | Available (PoC) | Cannot test JWT validation | N/A (exists) |
+
+### 11.2 Execution Order (TDD Phases with Checkpoints)
+
+#### Phase 0.5: Documentation Updates
+- Update DD-AUTH-MCP-001 to v2.0
+- Update #1009 acceptance criteria
+
+#### Phase 1-RED: Config Types (Failing Tests)
+Write failing tests for `JWTProviderConfig`, `ClaimMappings`, validation rules.
+Tests: UT-KA-1009-025..031
+
+#### Phase 1-GREEN: Config Types (Minimal Implementation)
+Implement `JWTProviderConfig`, `ClaimMappings` structs and validation rules to pass tests.
+
+#### Phase 1-REFACTOR: Config Types (Code Quality)
+**100-Go-Mistakes validation checklist**:
+- [ ] #1: No variable shadowing in validation logic
+- [ ] #2: No unnecessary nesting; happy path aligned left
+- [ ] #5: No interface pollution — concrete types only for config
+- [ ] #8: No `any` usage — all fields have specific types
+- [ ] #11: Functional options pattern used where appropriate
+- [ ] #45: No ignored errors in config validation
+- [ ] #48: Error wrapping with %w for context
+- [ ] #53: No panics in validation — return errors
+
+**Build validation**: `go build ./...`
+
+#### **CHECKPOINT 1: Config Types Audit**
+- [ ] Adversarial: malformed YAML, empty strings, duplicate issuers, excessively long URLs
+- [ ] Security: no secret values (API keys, credentials) in config struct
+- [ ] Completeness: all required fields validated, optional fields have safe defaults
+- [ ] Forward-compat: struct supports adding fields without breaking existing configs
+
+---
+
+#### Phase 2-RED: JWTAuthenticator (Failing Tests)
+Write failing tests for JWKS validation, claim extraction, error types, multi-issuer routing.
+Tests: UT-KA-1009-001..014
+
+#### Phase 2-GREEN: JWTAuthenticator (Minimal Implementation)
+Implement `JWTAuthenticator` with `ValidateToken`, `ValidateTokenFull`, issuer routing, JWKS cache.
+
+#### Phase 2-REFACTOR: JWTAuthenticator (Code Quality)
+**100-Go-Mistakes validation checklist**:
+- [ ] #1: No variable shadowing in token parsing
+- [ ] #2: Happy path left-aligned in ValidateTokenFull
+- [ ] #6: Authenticator interface on consumer side (pkg/shared/auth)
+- [ ] #7: Return concrete `UserInfo`, not interface
+- [ ] #22: Nil vs empty slice distinction for Groups
+- [ ] #27: No unnecessary map iteration — direct key lookup
+- [ ] #45: All errors from jwx library checked
+- [ ] #48: Errors wrapped with descriptive context (%w)
+- [ ] #49: Sentinel errors (ErrTokenInvalid, ErrIssuerNotFound) used correctly
+- [ ] #53: No panics — all error paths return errors
+- [ ] #56: No unbounded goroutines from JWKS cache
+- [ ] #61: No HTTP body leaks in JWKS client
+- [ ] #73: No goroutine leak in JWKS pre-warm
+- [ ] #77: Context propagation for cancellation
+- [ ] #78: No context.Background() misuse — accept context from caller
+- [ ] #83: sync.Once for initialization if needed
+- [ ] #91: No unsafe type assertions — use ok pattern
+
+**Build validation**: `go build ./...`
+
+#### **CHECKPOINT 2: JWT Security Audit**
+- [ ] **Token replay**: Can a valid JWT be replayed? (Accepted risk for v1.5, documented)
+- [ ] **alg confusion**: Can alg:none or HS256 bypass RS256 verification? (Test UT-KA-1009-008)
+- [ ] **Key confusion**: Can a token from issuer-A be verified by issuer-B's JWKS? (Test UT-KA-1009-013)
+- [ ] **Claim injection**: Can a JWT with manipulated claims (extra groups) pass? (Only verified claims used)
+- [ ] **JWKS poisoning**: Can a compromised JWKS endpoint inject keys? (HTTPS-only in prod; TLS CA validation)
+- [ ] **Timing attacks**: Are token comparisons timing-safe? (Not applicable — cryptographic signature verification)
+- [ ] **Empty claims**: What happens when username claim is empty? (Test UT-KA-1009-011)
+- [ ] **Oversized JWT**: What happens with a 1MB JWT? (lestrrat-go/jwx handles; verify no OOM)
+- [ ] **Concurrent access**: Is JWTAuthenticator goroutine-safe? (JWKS cache is; verify struct fields)
+
+---
+
+#### Phase 3-RED: CompositeAuthenticator (Failing Tests)
+Write failing tests for token routing, fail-closed semantics, fallback behavior.
+Tests: UT-KA-1009-015..021
+
+#### Phase 3-GREEN: CompositeAuthenticator (Minimal Implementation)
+Implement `CompositeAuthenticator` with `isJWT()` detection, routing, error handling.
+
+#### Phase 3-REFACTOR: CompositeAuthenticator (Code Quality)
+**100-Go-Mistakes validation checklist**:
+- [ ] #1: No variable shadowing in routing logic
+- [ ] #2: Early returns for non-JWT tokens
+- [ ] #5: No interface pollution — minimal interface (Authenticator)
+- [ ] #45: Error from JWTAuthenticator checked correctly (errors.Is for sentinel)
+- [ ] #48: Error context preserved through routing
+- [ ] #49: Correct use of errors.Is for ErrIssuerNotFound distinction
+- [ ] #53: No panics in routing logic
+- [ ] #77: Context forwarded to both authenticators
+- [ ] #91: No unsafe type assertions
+
+**Build validation**: `go build ./...`
+
+#### **CHECKPOINT 3: Auth Pipeline Security Audit**
+- [ ] **Cross-path leak**: Can a JWT error fall through to K8s TokenReview? (Only ErrIssuerNotFound allows fallback)
+- [ ] **Pattern A regression**: Do existing K8s SA tokens still work? (Test UT-KA-1009-018)
+- [ ] **Race condition**: Is CompositeAuthenticator safe under concurrent requests? (Stateless — yes)
+- [ ] **Error type safety**: Are sentinel errors compared with errors.Is, not == ? (Verify in code)
+- [ ] **Header stripping**: Are Impersonate-* headers still stripped before reaching CompositeAuthenticator? (Existing middleware)
+- [ ] **Token shape detection**: Can `isJWT()` false-positive on K8s tokens? (K8s SA tokens are opaque/base64, not 3-dot JWT)
+- [ ] **Nil safety**: What if JWTAuthenticator is nil? (CompositeAuthenticator requires non-nil at construction)
+
+---
+
+#### Phase 4-RED: ProviderType Propagation (Failing Tests)
+Write failing tests for ProviderType in UserInfo, MCP bridge, middleware audit logging.
+Tests: UT-KA-1009-022..024
+
+#### Phase 4-GREEN: ProviderType Propagation (Minimal Implementation)
+Add ProviderType field to UserInfo (shared + MCP), update K8sAuthenticator, update middleware logging.
+
+#### Phase 4-REFACTOR: ProviderType Propagation (Code Quality)
+**100-Go-Mistakes validation checklist**:
+- [ ] #1: No variable shadowing in middleware handler
+- [ ] #10: No unintended field exposure through type embedding
+- [ ] #22: ProviderType empty string vs zero value handled consistently
+- [ ] #45: All error paths still checked after middleware changes
+
+**Build validation**: `go build ./...`
+
+---
+
+#### Phase 5-RED: Main.go Wiring (Failing Integration Tests)
+Write failing integration tests for CompositeAuthenticator construction, JWKS pre-warm, mixed traffic.
+Tests: IT-KA-1009-001..009
+
+#### Phase 5-GREEN: Main.go Wiring (Minimal Implementation)
+Wire CompositeAuthenticator in `newAuthMiddleware()`, add JWKS pre-warm at startup, handle soft-disable.
+
+#### Phase 5-REFACTOR: Main.go Wiring (Code Quality)
+**100-Go-Mistakes validation checklist**:
+- [ ] #3: No init() misuse — startup logic in explicit functions
+- [ ] #56: JWKS pre-warm goroutine bounded with timeout
+- [ ] #61: HTTP client for JWKS uses response body close
+- [ ] #73: No goroutine leak in pre-warm error path
+- [ ] #77: Context with timeout for JWKS pre-warm
+- [ ] #78: Startup context not leaked to request handlers
+
+**Build validation**: `go build ./...`
+
+#### **CHECKPOINT 4: Full Pipeline Audit**
+- [ ] **Wiring verification**: Every new code path has an integration test from HTTP entry to context injection
+- [ ] **Build**: `go build ./...` passes
+- [ ] **Lint**: `golangci-lint run --timeout=5m` passes
+- [ ] **Existing tests**: All existing auth tests still pass
+- [ ] **Adversarial wiring**: What if config has jwtProviders but interactive.enabled=false? (CompositeAuthenticator not constructed)
+- [ ] **Graceful degradation**: JWKS pre-warm fails → Pattern A works, Pattern B returns 401 with clear error
+- [ ] **Startup timing**: JWKS pre-warm doesn't block server startup beyond 10s timeout
+
+---
+
+#### Phase 6-RED: Helm Chart (Failing Template Tests)
+Write failing Helm template tests for jwtProviders ConfigMap rendering, conditional ClusterRoleBinding.
+Tests: IT-KA-1009-009
+
+#### Phase 6-GREEN: Helm Chart (Minimal Implementation)
+Add jwtProviders to ConfigMap template, conditional ClusterRoleBinding for JWT group.
+
+#### Phase 6-REFACTOR: Helm Chart (Quality)
+- [ ] Template renders valid YAML
+- [ ] ClusterRoleBinding only created when jwtProviders configured
+- [ ] Group name from values.yaml propagated correctly
+- [ ] No hardcoded values — all configurable via values.yaml
+
+#### **CHECKPOINT 5: Final Comprehensive Audit**
+- [ ] **Build**: `go build ./...` clean
+- [ ] **Tests**: All unit + integration tests pass
+- [ ] **Coverage**: >=80% per tier on new code
+- [ ] **Lint**: No new lint errors
+- [ ] **Security review**: All 9 risks from Section 3 have mitigating tests passing
+- [ ] **Pattern A regression**: Full existing auth test suite passes
+- [ ] **Documentation**: DD-AUTH-MCP-001 v2.0 consistent with implementation
+- [ ] **Helm**: Template renders correctly with various values permutations
+- [ ] **Adversarial scenarios**: All CHECKPOINT findings resolved
+- [ ] **100-Go-Mistakes**: All REFACTOR checklists completed
+
+---
+
+## 12. Test Deliverables
+
+| Deliverable | Location | Description |
+|-------------|----------|-------------|
+| This test plan | `docs/tests/1009/TEST_PLAN.md` | Strategy and test design |
+| Unit test suite: JWT auth | `test/unit/shared/auth/jwt_auth_test.go` | JWT validation tests |
+| Unit test suite: Composite auth | `test/unit/shared/auth/composite_auth_test.go` | Routing + fail-closed tests |
+| Unit test suite: Config | `test/unit/kubernautagent/config/jwt_config_test.go` | Config validation tests |
+| Integration test suite | `test/integration/kubernautagent/auth/` | Middleware pipeline tests |
+| Mock JWKS server | `test/shared/auth/mock_jwks_server.go` | Test infrastructure (from PoC) |
+| Coverage report | CI artifact | Per-tier coverage percentages |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests — JWT auth
+go test ./test/unit/shared/auth/... -ginkgo.v -ginkgo.focus="UT-KA-1009"
+
+# Unit tests — Config
+go test ./test/unit/kubernautagent/config/... -ginkgo.v -ginkgo.focus="UT-KA-1009"
+
+# Integration tests
+go test ./test/integration/kubernautagent/auth/... -ginkgo.v -ginkgo.focus="IT-KA-1009"
+
+# Coverage — unit tier
+go test ./test/unit/shared/auth/... -coverprofile=coverage-unit.out \
+  -coverpkg=github.com/jordigilh/kubernaut/pkg/shared/auth/...
+go tool cover -func=coverage-unit.out
+
+# Coverage — integration tier
+go test ./test/integration/kubernautagent/auth/... -coverprofile=coverage-int.out \
+  -coverpkg=github.com/jordigilh/kubernaut/pkg/shared/auth/...,github.com/jordigilh/kubernaut/cmd/kubernautagent/...
+go tool cover -func=coverage-int.out
+
+# Full build validation
+go build ./...
+golangci-lint run --timeout=5m
+```
+
+---
+
+## 14. Wiring Verification (TDD Phase 5)
+
+| Code Path | Entry Point | Exit Point | Wiring IT | Status |
+|-----------|-------------|------------|-----------|--------|
+| JWT token → CompositeAuthenticator → JWTAuthenticator → UserInfo in context | HTTP POST /api/v1/mcp | UserInfo in request context, X-Auth-Request-User header | IT-KA-1009-001 | Pending |
+| Opaque token → CompositeAuthenticator → K8sAuthenticator → UserInfo in context | HTTP POST /api/v1/investigate | UserInfo in request context | IT-KA-1009-005 | Pending |
+| JWT expired → CompositeAuthenticator → 401 response | HTTP POST /api/v1/mcp | 401 JSON response | IT-KA-1009-002 | Pending |
+| JWT valid → SAR denied → 403 response | HTTP POST /api/v1/mcp | 403 JSON response | IT-KA-1009-004 | Pending |
+| JWKS pre-warm failure → soft-disable Pattern B | Server startup | Pattern A works, Pattern B 401 | IT-KA-1009-008 | Pending |
+
+---
+
+## 15. Existing Tests Requiring Updates
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|-------------------|-------------------|-----------------|--------|
+| `test/unit/shared/auth/k8s_auth_test.go` | UserInfo has Username, Groups | No change required | ProviderType is additive (zero value "" is backward compatible) |
+| `test/unit/shared/auth/header_stripping_test.go` | Impersonate-* headers stripped | No change required | Header stripping is unchanged |
+| `pkg/shared/auth/mock_auth.go` | MockAuthenticator returns UserInfo | May need ProviderType in ValidUsersFull entries | Phase 4: ProviderType propagation |
+
+---
+
+## 16. REFACTOR Phase: 100 Go Mistakes Validation Checklist
+
+Applicable mistakes to validate during every REFACTOR phase:
+
+### Code Organization (#1-#16)
+- [ ] #1: No variable shadowing
+- [ ] #2: Unnecessary nesting removed; happy path left-aligned
+- [ ] #5: No interface pollution; abstractions discovered not created
+- [ ] #6: Interfaces on consumer side
+- [ ] #7: Return concrete types, not interfaces
+- [ ] #8: No `any` usage unless justified (JSON marshaling)
+- [ ] #11: Functional options pattern where appropriate
+
+### Data Types (#17-#28)
+- [ ] #21: Slice initialization with known capacity
+- [ ] #22: Nil vs empty slice distinction for Groups
+- [ ] #23: Check slice length, not nil for emptiness
+
+### Error Handling (#45-#53)
+- [ ] #45: No ignored errors
+- [ ] #48: Error wrapping with %w for context
+- [ ] #49: Sentinel errors used correctly with errors.Is
+- [ ] #52: No redundant error wrapping (wrap adds context, not noise)
+- [ ] #53: No panics — all paths return errors
+
+### Concurrency (#55-#73)
+- [ ] #56: No unbounded goroutines
+- [ ] #61: HTTP response bodies always closed
+- [ ] #73: No goroutine leaks (context cancellation, cleanup)
+
+### Standard Library (#74-#91)
+- [ ] #77: Context propagated correctly
+- [ ] #78: No context.Background() misuse in request handlers
+- [ ] #83: sync.Once for one-time initialization
+- [ ] #91: Type assertions use ok pattern
+
+### Testing (#92-#100)
+- [ ] #92: Tests organized by behavior, not by function
+- [ ] #93: No time.Sleep — use Eventually
+- [ ] #95: httptest used for HTTP testing
+- [ ] #97: No hard-coded test ports
+- [ ] #100: No flaky tests
+
+---
+
+## 17. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-05-03 | Initial test plan |

--- a/docs/tests/1009/TEST_PLAN.md
+++ b/docs/tests/1009/TEST_PLAN.md
@@ -80,7 +80,7 @@ and checkpoints at each TDD boundary.
 | R1 | JWT signature bypass (alg:none, key confusion) | Critical: impersonation of any user | Low | UT-KA-1009-008, UT-KA-1009-009 | Explicit alg allowlist (RS256 only), reject unsigned tokens |
 | R2 | Cross-path authentication leak (JWT error falls through to K8s TokenReview) | Critical: untrusted token accepted | Medium | UT-KA-1009-016, UT-KA-1009-017 | ErrIssuerNotFound vs ErrTokenInvalid sentinel distinction; fail-closed on known issuer |
 | R3 | Pattern A regression (direct clients broken) | High: production auth failure | Low | UT-KA-1009-018, IT-KA-1009-005 | CompositeAuthenticator passthrough; existing test suite unchanged |
-| R4 | JWKS endpoint unavailable at startup | Medium: Pattern B non-functional | Medium | UT-KA-1009-010, IT-KA-1009-008 | PreWarm with 10s timeout; soft-disable (Pattern A unaffected) |
+| R4 | JWKS endpoint unavailable at startup | Medium: Pattern B non-functional | Medium | UT-KA-1009-010 | Pre-warm with 15s timeout; global disable (Pattern A unaffected) |
 | R5 | Dot-notation claim extraction fails on Keycloak nested claims | Medium: user identity lost | Low | UT-KA-1009-003..005 | PoC validated with 11 scenarios; recursive map traversal |
 | R6 | JWT replay within validity window | Medium: unauthorized action replay | Medium | UT-KA-1009-011 | Defense-in-depth (ClusterIP, NetworkPolicy, SAR, audit); v1.6: short-lived internal JWTs |
 | R7 | ClusterRoleBinding group mismatch | Medium: JWT users denied | Low | UT-KA-1009-030, IT-KA-1009-009 | Helm template test validates group rendering |
@@ -223,9 +223,9 @@ code path coverage. Each test scenario answers: "what does the operator/user/sys
 | BR-INTERACTIVE-002 | Known issuers with bad tokens fail-closed | P0 | Unit | UT-KA-1009-016 | Pending |
 | BR-INTERACTIVE-001 | Pattern A clients unaffected (no regression on #896) | P0 | Unit | UT-KA-1009-018 | Pending |
 | BR-INTERACTIVE-001 | Pattern A clients unaffected (no regression on #896) | P0 | Integration | IT-KA-1009-005 | Pending |
-| BR-INTERACTIVE-002 | JWT users authorized via K8s SAR against ClusterRoleBinding | P0 | Integration | IT-KA-1009-003 | Pending |
+| BR-INTERACTIVE-002 | JWT users authorized via K8s SAR against ClusterRoleBinding | P0 | Integration | IT-KA-1009-003 | Deferred (v1.6) |
 | BR-INTERACTIVE-003 | ProviderType propagated to audit logging | P1 | Unit | UT-KA-1009-022 | Pending |
-| BR-INTERACTIVE-003 | ProviderType propagated to audit logging | P1 | Integration | IT-KA-1009-006 | Pending |
+| BR-INTERACTIVE-003 | ProviderType propagated to audit logging | P1 | Integration | IT-KA-1009-006 | Deferred (v1.6) |
 
 ---
 
@@ -308,13 +308,13 @@ Format: `{TIER}-KA-1009-{SEQUENCE}`
 |----|----------------------------|-------|
 | `IT-KA-1009-001` | Full middleware pipeline accepts valid JWT, injects UserInfo into context | Pending |
 | `IT-KA-1009-002` | Full middleware pipeline rejects expired JWT with 401 | Pending |
-| `IT-KA-1009-003` | JWT-authenticated user passes SAR check against ClusterRoleBinding | Pending |
+| `IT-KA-1009-003` | JWT-authenticated user passes SAR check against ClusterRoleBinding | Deferred (v1.6 — requires real K8s SAR in IT) |
 | `IT-KA-1009-004` | JWT-authenticated user fails SAR check → 403 Forbidden | Pending |
 | `IT-KA-1009-005` | Mixed traffic: JWT request + K8s SA request both succeed in same middleware instance | Pending |
-| `IT-KA-1009-006` | ProviderType appears in middleware audit log entries | Pending |
+| `IT-KA-1009-006` | ProviderType appears in middleware audit log entries | Deferred (v1.6 — audit integration) |
 | `IT-KA-1009-007` | Impersonate-* headers stripped before JWT validation (defense-in-depth) | Pending |
-| `IT-KA-1009-008` | JWKS pre-warm failure → Pattern A still works, Pattern B returns 401 | Pending |
-| `IT-KA-1009-009` | Helm-rendered ClusterRoleBinding resolves correct group from values | Pending |
+| `IT-KA-1009-008` | JWKS pre-warm failure → Pattern B disabled globally, Pattern A works | Deferred (v1.6 — per-provider degradation) |
+| `IT-KA-1009-009` | Helm-rendered ClusterRoleBinding resolves correct group from values | Deferred (v1.6 — Helm template testing) |
 
 ### Tier 3: E2E Tests
 
@@ -417,7 +417,7 @@ Format: `{TIER}-KA-1009-{SEQUENCE}`
 **BR**: BR-INTERACTIVE-001, BR-INTERACTIVE-002
 **Priority**: P0
 **Type**: Integration
-**File**: `test/integration/kubernautagent/auth/mixed_traffic_test.go`
+**File**: `test/integration/kubernautagent/jwt_middleware_test.go`
 
 **Preconditions**:
 - Full middleware pipeline with CompositeAuthenticator (MockJWKSServer + MockK8sAuthenticator)
@@ -450,7 +450,7 @@ Format: `{TIER}-KA-1009-{SEQUENCE}`
 - **Framework**: Ginkgo/Gomega BDD (mandatory)
 - **Infrastructure**: httptest for full middleware pipeline, MockJWKSServer for JWKS
 - **Mocks**: MockAuthorizer for SAR (K8s auth not available without cluster)
-- **Location**: `test/integration/kubernautagent/auth/`
+- **Location**: `test/integration/kubernautagent/jwt_middleware_test.go`
 
 ### 10.3 E2E Tests
 
@@ -642,7 +642,7 @@ Wire CompositeAuthenticator in `newAuthMiddleware()`, add JWKS pre-warm at start
 
 #### Phase 6-RED: Helm Chart (Failing Template Tests)
 Write failing Helm template tests for jwtProviders ConfigMap rendering, conditional ClusterRoleBinding.
-Tests: IT-KA-1009-009
+Tests: IT-KA-1009-009 (deferred to v1.6)
 
 #### Phase 6-GREEN: Helm Chart (Minimal Implementation)
 Add jwtProviders to ConfigMap template, conditional ClusterRoleBinding for JWT group.
@@ -718,7 +718,7 @@ golangci-lint run --timeout=5m
 | Opaque token → CompositeAuthenticator → K8sAuthenticator → UserInfo in context | HTTP POST /api/v1/investigate | UserInfo in request context | IT-KA-1009-005 | Pending |
 | JWT expired → CompositeAuthenticator → 401 response | HTTP POST /api/v1/mcp | 401 JSON response | IT-KA-1009-002 | Pending |
 | JWT valid → SAR denied → 403 response | HTTP POST /api/v1/mcp | 403 JSON response | IT-KA-1009-004 | Pending |
-| JWKS pre-warm failure → soft-disable Pattern B | Server startup | Pattern A works, Pattern B 401 | IT-KA-1009-008 | Pending |
+| JWKS pre-warm failure → global disable Pattern B | Server startup | Pattern A works, Pattern B disabled | IT-KA-1009-008 | Deferred (v1.6) |
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,8 @@ require (
 	github.com/itchyny/gojq v0.12.19
 	github.com/jackc/pgx/v5 v5.8.0
 	github.com/jmoiron/sqlx v1.4.0
+	github.com/lestrrat-go/httprc/v3 v3.0.4
+	github.com/lestrrat-go/jwx/v3 v3.0.13
 	github.com/lib/pq v1.11.2
 	github.com/modelcontextprotocol/go-sdk v1.5.0
 	github.com/ogen-go/ogen v1.20.1
@@ -150,8 +152,6 @@ require (
 	github.com/lestrrat-go/dsig v1.0.0 // indirect
 	github.com/lestrrat-go/dsig-secp256k1 v1.0.0 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
-	github.com/lestrrat-go/httprc/v3 v3.0.4 // indirect
-	github.com/lestrrat-go/jwx/v3 v3.0.13 // indirect
 	github.com/lestrrat-go/option/v2 v2.0.0 // indirect
 	github.com/mailru/easyjson v0.9.1 // indirect
 	github.com/mattn/go-colorable v0.1.14 // indirect

--- a/internal/kubernautagent/config/config.go
+++ b/internal/kubernautagent/config/config.go
@@ -18,6 +18,7 @@ package config
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -208,12 +209,102 @@ type MCPConfig struct {
 // When Enabled=true, KA exposes an SSE-based MCP endpoint for user-driven
 // investigations. Feature is gated off by default.
 type InteractiveConfig struct {
-	Enabled               bool          `yaml:"enabled"`
-	SessionTTL            time.Duration `yaml:"sessionTTL"`
-	InactivityTimeout     time.Duration `yaml:"inactivityTimeout"`
-	MaxConcurrentSessions int           `yaml:"maxConcurrentSessions"`
-	RateLimitPerUser      int           `yaml:"rateLimitPerUser"`
-	MaxAnalyzingTimeout   time.Duration `yaml:"maxAnalyzingTimeout"`
+	Enabled               bool                `yaml:"enabled"`
+	SessionTTL            time.Duration       `yaml:"sessionTTL"`
+	InactivityTimeout     time.Duration       `yaml:"inactivityTimeout"`
+	MaxConcurrentSessions int                 `yaml:"maxConcurrentSessions"`
+	RateLimitPerUser      int                 `yaml:"rateLimitPerUser"`
+	MaxAnalyzingTimeout   time.Duration       `yaml:"maxAnalyzingTimeout"`
+	JWTProviders          []JWTProviderConfig `yaml:"jwtProviders,omitempty"`
+	JWTInteractiveGroup   string              `yaml:"jwtInteractiveGroup,omitempty"`
+}
+
+// JWTProviderConfig defines a trusted JWT issuer for Pattern B authentication.
+// DD-AUTH-MCP-001 v2.0: KA validates JWT signatures via JWKS and extracts
+// identity from verified claims. Multiple providers support KEP-3331
+// multi-issuer architecture (v1.5: Keycloak, v1.6: + SPIRE).
+type JWTProviderConfig struct {
+	Name          string        `yaml:"name"`
+	Issuer        string        `yaml:"issuer"`
+	JWKSURL       string        `yaml:"jwksURL"`
+	Audience      string        `yaml:"audience"`
+	ClaimMappings ClaimMappings `yaml:"claimMappings,omitempty"`
+}
+
+// ClaimMappings configures which JWT claims map to user identity fields.
+// Supports dot-notation for nested Keycloak claims (e.g., "realm_access.roles").
+type ClaimMappings struct {
+	Username string `yaml:"username"`
+	Groups   string `yaml:"groups"`
+}
+
+const maxURLLength = 2048
+
+// validateJWTProviders checks all configured JWT providers for required fields,
+// validates URL format and length, applies claim mapping defaults, and rejects
+// duplicate issuer URLs.
+//
+// HTTPS enforcement for JWKS URLs is the operator's responsibility
+// (kubernaut-operator#46). KA accepts http:// for dev/test flexibility.
+func (ic *InteractiveConfig) validateJWTProviders() error {
+	if len(ic.JWTProviders) == 0 {
+		return nil
+	}
+
+	seenIssuers := make(map[string]string, len(ic.JWTProviders))
+	for i := range ic.JWTProviders {
+		p := &ic.JWTProviders[i]
+		name := p.Name
+		if name == "" {
+			name = fmt.Sprintf("jwtProviders[%d]", i)
+		}
+
+		if p.Issuer == "" {
+			return fmt.Errorf("interactive.%s: issuer is required", name)
+		}
+		if len(p.Issuer) > maxURLLength {
+			return fmt.Errorf("interactive.%s: issuer exceeds maximum length of %d characters", name, maxURLLength)
+		}
+		if p.JWKSURL == "" {
+			return fmt.Errorf("interactive.%s: jwksURL is required", name)
+		}
+		if len(p.JWKSURL) > maxURLLength {
+			return fmt.Errorf("interactive.%s: jwksURL exceeds maximum length of %d characters", name, maxURLLength)
+		}
+		if err := validateJWKSURL(p.JWKSURL); err != nil {
+			return fmt.Errorf("interactive.%s: %w", name, err)
+		}
+		if p.Audience == "" {
+			return fmt.Errorf("interactive.%s: audience is required", name)
+		}
+
+		if prev, dup := seenIssuers[p.Issuer]; dup {
+			return fmt.Errorf("interactive.jwtProviders: duplicate issuer %q in providers %q and %q", p.Issuer, prev, name)
+		}
+		seenIssuers[p.Issuer] = name
+
+		if p.ClaimMappings.Username == "" {
+			p.ClaimMappings.Username = "preferred_username"
+		}
+		if p.ClaimMappings.Groups == "" {
+			p.ClaimMappings.Groups = "groups"
+		}
+	}
+	return nil
+}
+
+// validateJWKSURL checks that the JWKS URL is syntactically valid and uses
+// an HTTP or HTTPS scheme. HTTPS enforcement in production is delegated to
+// the kubernaut-operator admission webhook (kubernaut-operator#46).
+func validateJWKSURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return fmt.Errorf("invalid jwksURL %q: %w", rawURL, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return fmt.Errorf("invalid jwksURL %q: scheme must be http or https, got %q", rawURL, u.Scheme)
+	}
+	return nil
 }
 
 type MCPServerEntry struct {
@@ -488,6 +579,9 @@ func (c *Config) Validate() error {
 		}
 		if c.Interactive.RateLimitPerUser > 100 {
 			return fmt.Errorf("interactive.rateLimitPerUser must not exceed 100, got %d", c.Interactive.RateLimitPerUser)
+		}
+		if err := c.Interactive.validateJWTProviders(); err != nil {
+			return err
 		}
 	}
 	return nil

--- a/internal/kubernautagent/config/config.go
+++ b/internal/kubernautagent/config/config.go
@@ -215,8 +215,7 @@ type InteractiveConfig struct {
 	MaxConcurrentSessions int                 `yaml:"maxConcurrentSessions"`
 	RateLimitPerUser      int                 `yaml:"rateLimitPerUser"`
 	MaxAnalyzingTimeout   time.Duration       `yaml:"maxAnalyzingTimeout"`
-	JWTProviders          []JWTProviderConfig `yaml:"jwtProviders,omitempty"`
-	JWTInteractiveGroup   string              `yaml:"jwtInteractiveGroup,omitempty"`
+	JWTProviders []JWTProviderConfig `yaml:"jwtProviders,omitempty"`
 }
 
 // JWTProviderConfig defines a trusted JWT issuer for Pattern B authentication.

--- a/internal/kubernautagent/mcp/auth.go
+++ b/internal/kubernautagent/mcp/auth.go
@@ -16,13 +16,14 @@ limitations under the License.
 
 package mcp
 
-// Pattern B (delegated impersonation via apifrontend) is deferred until that
-// component exists. The previous ExtractEffectiveUser implementation was
-// architecturally incompatible with the shared auth middleware which strips
-// Impersonate-* headers before any handler sees them (#896).
+// Pattern B (delegated impersonation via apifrontend) uses JWT-based identity
+// delegation. The apifrontend forwards the user's original Keycloak JWT, and
+// KA's CompositeAuthenticator validates the signature via JWKS and extracts
+// identity from verified claims.
 //
-// When apifrontend ships, Pattern B should use a trust-boundary mechanism
-// (signed JWT, mTLS client cert, or internal-only header set by the gateway)
-// rather than raw Impersonate-* headers from external clients.
+// The previous SA-token + Impersonate-* header approach was superseded because
+// the middleware unconditionally strips Impersonate-* headers (#896), and
+// unsigned headers lack the cryptographic integrity of JWT claims.
 //
-// Reference: DD-AUTH-MCP-001, #895, #896.
+// Implementation: pkg/shared/auth/jwt_auth.go, pkg/shared/auth/composite_auth.go
+// Reference: DD-AUTH-MCP-001 v2.0, #895, #896, #1009.

--- a/internal/kubernautagent/mcp/interfaces.go
+++ b/internal/kubernautagent/mcp/interfaces.go
@@ -51,10 +51,11 @@ type NotificationBus interface {
 }
 
 // UserInfo represents a resolved user identity from TokenReview or impersonation.
-// DD-AUTH-MCP-001: Pattern A (TokenReview) or Pattern B (SAR-verified delegation).
+// DD-AUTH-MCP-001: Pattern A (TokenReview) or Pattern B (JWT delegation).
 type UserInfo struct {
-	Username string
-	Groups   []string
+	Username     string
+	Groups       []string
+	ProviderType string
 }
 
 // InteractiveSession represents an active interactive session state.

--- a/internal/kubernautagent/mcp/server.go
+++ b/internal/kubernautagent/mcp/server.go
@@ -91,7 +91,7 @@ type MCPDeps struct {
 func userFromContext(ctx context.Context) UserInfo {
 	info := sharedauth.GetUserInfoFromContext(ctx)
 	if info.Username != "" {
-		return UserInfo{Username: info.Username, Groups: info.Groups}
+		return UserInfo{Username: info.Username, Groups: info.Groups, ProviderType: info.ProviderType}
 	}
 	username := sharedauth.GetUserFromContext(ctx)
 	return UserInfo{Username: username}

--- a/pkg/shared/auth/claims.go
+++ b/pkg/shared/auth/claims.go
@@ -1,0 +1,72 @@
+package auth
+
+import (
+	"fmt"
+	"strings"
+)
+
+// extractClaim resolves a dot-notation path against a JWT claims map.
+// Supports nested paths like "realm_access.roles" which traverses
+// claims["realm_access"].(map)["roles"].
+//
+// Returns the resolved value or an error if any intermediate key is
+// missing or not a map. The caller is responsible for type-asserting
+// the result (string for username, []interface{} for groups).
+func ExtractClaim(claims map[string]interface{}, path string) (interface{}, error) {
+	parts := strings.Split(path, ".")
+	var current interface{} = claims
+
+	for i, part := range parts {
+		m, ok := current.(map[string]interface{})
+		if !ok {
+			return nil, fmt.Errorf("claim path %q: segment %q is not a map (at index %d)", path, parts[i-1], i-1)
+		}
+		val, exists := m[part]
+		if !exists {
+			return nil, fmt.Errorf("claim path %q: key %q not found", path, part)
+		}
+		current = val
+	}
+
+	return current, nil
+}
+
+// extractStringClaim resolves a dot-notation path and asserts the result is a string.
+func ExtractStringClaim(claims map[string]interface{}, path string) (string, error) {
+	val, err := ExtractClaim(claims, path)
+	if err != nil {
+		return "", err
+	}
+	s, ok := val.(string)
+	if !ok {
+		return "", fmt.Errorf("claim path %q: expected string, got %T", path, val)
+	}
+	return s, nil
+}
+
+// extractGroupsClaim resolves a dot-notation path and asserts the result is a
+// slice of strings. Handles both []interface{} (standard JSON unmarshal) and
+// []string formats.
+func ExtractGroupsClaim(claims map[string]interface{}, path string) ([]string, error) {
+	val, err := ExtractClaim(claims, path)
+	if err != nil {
+		return nil, err
+	}
+
+	switch v := val.(type) {
+	case []interface{}:
+		groups := make([]string, 0, len(v))
+		for i, item := range v {
+			s, ok := item.(string)
+			if !ok {
+				return nil, fmt.Errorf("claim path %q: element %d is %T, expected string", path, i, item)
+			}
+			groups = append(groups, s)
+		}
+		return groups, nil
+	case []string:
+		return v, nil
+	default:
+		return nil, fmt.Errorf("claim path %q: expected array, got %T", path, val)
+	}
+}

--- a/pkg/shared/auth/composite_auth.go
+++ b/pkg/shared/auth/composite_auth.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// CompositeAuthenticator routes tokens to the appropriate authenticator based
+// on token shape: JWT-shaped tokens (3-dot structure) are tried against the
+// JWTAuthenticator first; opaque tokens go directly to K8sAuthenticator.
+//
+// Fail-closed semantics: if a JWT routes to a known issuer but fails signature
+// verification, the error is returned immediately without fallback. Fallback to
+// K8s only occurs when the issuer is unknown (ErrIssuerNotFound) or the token
+// cannot be parsed as a JWT at all.
+//
+// DD-AUTH-MCP-001 v2.0: Pattern A (SA token) and Pattern B (JWT) coexist.
+type CompositeAuthenticator struct {
+	jwtAuth *JWTAuthenticator
+	k8sAuth Authenticator
+}
+
+// NewCompositeAuthenticator creates a CompositeAuthenticator that routes between
+// JWT and K8s authenticators. If jwtAuth is nil, all tokens go to k8sAuth.
+func NewCompositeAuthenticator(jwtAuth *JWTAuthenticator, k8sAuth Authenticator) *CompositeAuthenticator {
+	return &CompositeAuthenticator{
+		jwtAuth: jwtAuth,
+		k8sAuth: k8sAuth,
+	}
+}
+
+// ValidateToken implements Authenticator.ValidateToken.
+func (c *CompositeAuthenticator) ValidateToken(ctx context.Context, token string) (string, error) {
+	info, err := c.ValidateTokenFull(ctx, token)
+	if err != nil {
+		return "", err
+	}
+	return info.Username, nil
+}
+
+// ValidateTokenFull implements Authenticator.ValidateTokenFull with composite routing.
+func (c *CompositeAuthenticator) ValidateTokenFull(ctx context.Context, token string) (UserInfo, error) {
+	if token == "" {
+		return UserInfo{}, fmt.Errorf("%w: empty token", ErrTokenInvalid)
+	}
+
+	if c.jwtAuth != nil && looksLikeJWT(token) {
+		userInfo, err := c.jwtAuth.ValidateTokenFull(ctx, token)
+		if err == nil {
+			return userInfo, nil
+		}
+
+		if errors.Is(err, ErrIssuerNotFound) || errors.Is(err, ErrTokenMalformed) {
+			return c.k8sAuth.ValidateTokenFull(ctx, token)
+		}
+
+		return UserInfo{}, err
+	}
+
+	return c.k8sAuth.ValidateTokenFull(ctx, token)
+}
+
+// looksLikeJWT checks if a token has the 3-part dot-separated structure of a JWT.
+// This is a fast heuristic — actual JWT parsing and validation happens in
+// JWTAuthenticator.
+func looksLikeJWT(token string) bool {
+	return strings.Count(token, ".") == 2
+}
+
+var _ Authenticator = (*CompositeAuthenticator)(nil)

--- a/pkg/shared/auth/interfaces.go
+++ b/pkg/shared/auth/interfaces.go
@@ -26,8 +26,9 @@ var ErrTokenInvalid = errors.New("token not authenticated")
 // Returned by ValidateTokenFull for use cases that need group-based authorization
 // (e.g., impersonation in interactive MCP sessions, #703).
 type UserInfo struct {
-	Username string
-	Groups   []string
+	Username     string
+	Groups       []string
+	ProviderType string
 }
 
 // Authenticator validates tokens and returns user identity.

--- a/pkg/shared/auth/jwt_auth.go
+++ b/pkg/shared/auth/jwt_auth.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/lestrrat-go/httprc/v3"
+	"github.com/lestrrat-go/jwx/v3/jwk"
+	"github.com/lestrrat-go/jwx/v3/jws"
+	"github.com/lestrrat-go/jwx/v3/jwt"
+)
+
+// ErrIssuerNotFound indicates the JWT's issuer claim does not match any
+// configured provider. Distinct from ErrTokenInvalid: the token may be
+// well-formed but KA has no JWKS endpoint registered for this issuer.
+var ErrIssuerNotFound = errors.New("issuer not found in configured providers")
+
+// ErrTokenMalformed indicates the token could not be parsed as a JWT at all.
+// Distinct from ErrTokenInvalid: the token is not a JWT (e.g., opaque or garbage).
+// CompositeAuthenticator uses this to fall back to K8sAuthenticator.
+var ErrTokenMalformed = errors.New("token is not a valid JWT")
+
+// JWTProviderEntry defines a trusted JWT issuer for Pattern B authentication.
+// Maps 1:1 to config.JWTProviderConfig but lives in the auth package to avoid
+// import cycles.
+type JWTProviderEntry struct {
+	Issuer        string
+	JWKSURL       string
+	Audience      string
+	UsernameClaim string
+	GroupsClaim   string
+}
+
+type jwtProvider struct {
+	entry    JWTProviderEntry
+	jwksCache *jwk.Cache
+}
+
+// JWTAuthenticator validates JWTs against configured OIDC providers using JWKS.
+// Implements the Authenticator interface for Pattern B (DD-AUTH-MCP-001 v2.0).
+//
+// Multi-issuer support: tokens are routed to the correct JWKS endpoint by
+// extracting the unverified `iss` claim, then verified against that provider's keys.
+//
+// Call Close() to stop background JWKS refresh goroutines when the authenticator
+// is no longer needed (e.g., during graceful shutdown).
+type JWTAuthenticator struct {
+	providers map[string]*jwtProvider
+	cancel    context.CancelFunc
+}
+
+// jwksPreWarmTimeout is the maximum time to wait for the initial JWKS fetch
+// during construction. Prevents indefinite blocking if the OIDC provider is
+// slow to respond.
+const jwksPreWarmTimeout = 15 * time.Second
+
+// NewJWTAuthenticator creates a JWTAuthenticator from a list of trusted providers.
+// Each provider's JWKS endpoint is configured for automatic background refresh
+// via jwk.Cache. A synchronous pre-warm fetch is performed for each provider
+// to ensure keys are available before the first token validation request.
+// Returns an error if any provider's cache cannot be initialized or pre-warmed.
+func NewJWTAuthenticator(entries []JWTProviderEntry) (*JWTAuthenticator, error) {
+	ctx, cancel := context.WithCancel(context.Background())
+	providers := make(map[string]*jwtProvider, len(entries))
+	for i := range entries {
+		e := entries[i]
+		c, err := jwk.NewCache(ctx, httprc.NewClient())
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("creating JWKS cache for provider %q: %w", e.Issuer, err)
+		}
+		if err := c.Register(ctx, e.JWKSURL); err != nil {
+			cancel()
+			return nil, fmt.Errorf("registering JWKS URL %q for provider %q: %w", e.JWKSURL, e.Issuer, err)
+		}
+
+		warmCtx, warmCancel := context.WithTimeout(ctx, jwksPreWarmTimeout)
+		_, err = c.Lookup(warmCtx, e.JWKSURL)
+		warmCancel()
+		if err != nil {
+			cancel()
+			return nil, fmt.Errorf("JWKS pre-warm failed for provider %q (%s): %w", e.Issuer, e.JWKSURL, err)
+		}
+
+		providers[e.Issuer] = &jwtProvider{
+			entry:     e,
+			jwksCache: c,
+		}
+	}
+	return &JWTAuthenticator{providers: providers, cancel: cancel}, nil
+}
+
+// Close stops all background JWKS refresh goroutines. Safe to call multiple times.
+func (a *JWTAuthenticator) Close() {
+	if a.cancel != nil {
+		a.cancel()
+	}
+}
+
+// ValidateToken implements Authenticator.ValidateToken by delegating to
+// ValidateTokenFull and returning just the username.
+func (a *JWTAuthenticator) ValidateToken(ctx context.Context, token string) (string, error) {
+	info, err := a.ValidateTokenFull(ctx, token)
+	if err != nil {
+		return "", err
+	}
+	return info.Username, nil
+}
+
+// ValidateTokenFull implements Authenticator.ValidateTokenFull.
+// It parses the JWT without verification to extract the issuer, routes to the
+// correct provider's JWKS, verifies signature + standard claims, then extracts
+// username and groups from the configured claim paths.
+func (a *JWTAuthenticator) ValidateTokenFull(ctx context.Context, rawToken string) (UserInfo, error) {
+	issuer, err := extractUnverifiedIssuer(rawToken)
+	if err != nil {
+		return UserInfo{}, fmt.Errorf("%w: %v", ErrTokenMalformed, err)
+	}
+
+	provider, ok := a.providers[issuer]
+	if !ok {
+		return UserInfo{}, fmt.Errorf("%w: %s", ErrIssuerNotFound, issuer)
+	}
+
+	keyset, err := provider.jwksCache.Lookup(ctx, provider.entry.JWKSURL)
+	if err != nil {
+		return UserInfo{}, fmt.Errorf("fetching JWKS for issuer %q: %w", issuer, err)
+	}
+
+	verifiedToken, err := jwt.Parse(
+		[]byte(rawToken),
+		jwt.WithKeySet(keyset, jws.WithInferAlgorithmFromKey(true)),
+		jwt.WithAudience(provider.entry.Audience),
+		jwt.WithValidate(true),
+	)
+	if err != nil {
+		return UserInfo{}, fmt.Errorf("%w: %v", ErrTokenInvalid, err)
+	}
+
+	claims, err := tokenToClaimsMap(verifiedToken)
+	if err != nil {
+		return UserInfo{}, fmt.Errorf("extracting claims: %w", err)
+	}
+
+	username, err := ExtractStringClaim(claims, provider.entry.UsernameClaim)
+	if err != nil {
+		return UserInfo{}, fmt.Errorf("extracting username from claim %q: %w", provider.entry.UsernameClaim, err)
+	}
+
+	groups, err := ExtractGroupsClaim(claims, provider.entry.GroupsClaim)
+	if err != nil {
+		groups = []string{}
+	}
+
+	return UserInfo{
+		Username:     username,
+		Groups:       groups,
+		ProviderType: "jwt:" + issuer,
+	}, nil
+}
+
+// extractUnverifiedIssuer parses the JWT payload without signature verification
+// to extract the `iss` claim for provider routing. This is safe because the
+// actual signature verification happens after routing to the correct JWKS.
+func extractUnverifiedIssuer(rawToken string) (string, error) {
+	token, err := jwt.Parse([]byte(rawToken), jwt.WithVerify(false), jwt.WithValidate(false))
+	if err != nil {
+		return "", fmt.Errorf("parsing JWT header: %w", err)
+	}
+	iss, ok := token.Issuer()
+	if !ok || iss == "" {
+		return "", fmt.Errorf("JWT missing iss claim")
+	}
+	return iss, nil
+}
+
+// tokenToClaimsMap serializes a jwt.Token to a generic map for claim extraction.
+// This allows the claims.go extraction functions to navigate nested structures
+// (e.g., realm_access.roles) uniformly.
+func tokenToClaimsMap(token jwt.Token) (map[string]interface{}, error) {
+	data, err := json.Marshal(token)
+	if err != nil {
+		return nil, err
+	}
+	var claims map[string]interface{}
+	if err := json.Unmarshal(data, &claims); err != nil {
+		return nil, err
+	}
+	return claims, nil
+}
+
+// Compile-time interface compliance check.
+var _ Authenticator = (*JWTAuthenticator)(nil)

--- a/pkg/shared/auth/jwt_auth.go
+++ b/pkg/shared/auth/jwt_auth.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/lestrrat-go/httprc/v3"
 	"github.com/lestrrat-go/jwx/v3/jwk"
 	"github.com/lestrrat-go/jwx/v3/jws"
@@ -66,6 +67,7 @@ type jwtProvider struct {
 type JWTAuthenticator struct {
 	providers map[string]*jwtProvider
 	cancel    context.CancelFunc
+	logger    logr.Logger
 }
 
 // jwksPreWarmTimeout is the maximum time to wait for the initial JWKS fetch
@@ -78,7 +80,7 @@ const jwksPreWarmTimeout = 15 * time.Second
 // via jwk.Cache. A synchronous pre-warm fetch is performed for each provider
 // to ensure keys are available before the first token validation request.
 // Returns an error if any provider's cache cannot be initialized or pre-warmed.
-func NewJWTAuthenticator(entries []JWTProviderEntry) (*JWTAuthenticator, error) {
+func NewJWTAuthenticator(entries []JWTProviderEntry, logger logr.Logger) (*JWTAuthenticator, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	providers := make(map[string]*jwtProvider, len(entries))
 	for i := range entries {
@@ -106,7 +108,7 @@ func NewJWTAuthenticator(entries []JWTProviderEntry) (*JWTAuthenticator, error) 
 			jwksCache: c,
 		}
 	}
-	return &JWTAuthenticator{providers: providers, cancel: cancel}, nil
+	return &JWTAuthenticator{providers: providers, cancel: cancel, logger: logger}, nil
 }
 
 // Close stops all background JWKS refresh goroutines. Safe to call multiple times.
@@ -149,6 +151,7 @@ func (a *JWTAuthenticator) ValidateTokenFull(ctx context.Context, rawToken strin
 	verifiedToken, err := jwt.Parse(
 		[]byte(rawToken),
 		jwt.WithKeySet(keyset, jws.WithInferAlgorithmFromKey(true)),
+		jwt.WithIssuer(provider.entry.Issuer),
 		jwt.WithAudience(provider.entry.Audience),
 		jwt.WithValidate(true),
 	)
@@ -168,6 +171,8 @@ func (a *JWTAuthenticator) ValidateTokenFull(ctx context.Context, rawToken strin
 
 	groups, err := ExtractGroupsClaim(claims, provider.entry.GroupsClaim)
 	if err != nil {
+		a.logger.V(1).Info("groups claim extraction failed; user will have no group memberships",
+			"username", username, "groupsClaim", provider.entry.GroupsClaim, "error", err)
 		groups = []string{}
 	}
 

--- a/pkg/shared/auth/k8s_auth.go
+++ b/pkg/shared/auth/k8s_auth.go
@@ -81,8 +81,9 @@ func (a *K8sAuthenticator) ValidateTokenFull(ctx context.Context, token string) 
 	}
 
 	return UserInfo{
-		Username: result.Status.User.Username,
-		Groups:   groups,
+		Username:     result.Status.User.Username,
+		Groups:       groups,
+		ProviderType: "k8s:tokenreview",
 	}, nil
 }
 

--- a/pkg/shared/auth/middleware.go
+++ b/pkg/shared/auth/middleware.go
@@ -158,6 +158,7 @@ func (m *Middleware) Handler(next http.Handler) http.Handler {
 
 		m.logger.V(2).Info("Token validated",
 			"user", user,
+			"providerType", userInfo.ProviderType,
 			"path", r.URL.Path,
 		)
 

--- a/test/e2e/kubernautagent/jwt_e2e_test.go
+++ b/test/e2e/kubernautagent/jwt_e2e_test.go
@@ -1,0 +1,268 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernautagent
+
+import (
+	"context"
+	"encoding/base64"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/test/infrastructure"
+	testauth "github.com/jordigilh/kubernaut/test/shared/auth"
+)
+
+// E2E JWT/OIDC Tests — #1009 (DD-AUTH-MCP-001 v2.0)
+//
+// Validates the full OIDC flow with DEX as a real identity provider:
+//   - DEX issues JWTs signed by its RSA keys
+//   - KA's CompositeAuthenticator validates JWTs via JWKS endpoint
+//   - SAR check authorizes the OIDC user via Kubernetes RBAC
+//   - Pattern A (SA token) and Pattern B (JWT) coexist on the same endpoint
+//
+// BR: BR-INTERACTIVE-002 (Authentication), BR-INTERACTIVE-010 (Security)
+var _ = Describe("E2E JWT/OIDC — DEX Integration (#1009)", Label("e2e", "ka", "interactive", "jwt", "oidc"), func() {
+
+	var (
+		mcpEndpoint  string
+		tlsTransport http.RoundTripper
+		dexConfig    infrastructure.DexE2EConfig
+	)
+
+	BeforeEach(func() {
+		mcpEndpoint = infrastructure.MCPEndpointForKAE2E()
+		tlsTransport = testauth.NewRetryOn429Transport(http.DefaultTransport)
+		dexConfig = infrastructure.DefaultDexE2EConfig()
+	})
+
+	// ---------------------------------------------------------------
+	// E2E-KA-JWT-001: Valid JWT from DEX accepted by KA MCP endpoint
+	// BR: BR-INTERACTIVE-002
+	// Validates: DEX token issuance → JWKS verification → SAR authz
+	// ---------------------------------------------------------------
+	Describe("E2E-KA-JWT-001: Valid JWT from DEX → MCP endpoint → 200 OK", func() {
+		It("should accept a DEX-issued JWT and allow MCP access", func() {
+			By("Obtaining an OIDC id_token from DEX via password grant")
+			jwtToken, err := infrastructure.GetDexIDToken(dexConfig)
+			Expect(err).NotTo(HaveOccurred(), "DEX should issue an id_token for the E2E user")
+			Expect(jwtToken).NotTo(BeEmpty())
+			GinkgoWriter.Printf("  DEX id_token length: %d chars\n", len(jwtToken))
+
+			By("Decoding JWT claims for diagnostic visibility")
+			parts := strings.SplitN(jwtToken, ".", 3)
+			Expect(parts).To(HaveLen(3), "JWT must have 3 segments")
+			payload, err := base64.RawURLEncoding.DecodeString(parts[1])
+			Expect(err).NotTo(HaveOccurred())
+			GinkgoWriter.Printf("  JWT payload: %s\n", string(payload))
+
+			By("Verifying raw HTTP with JWT returns non-401 (auth pipeline smoke test)")
+			probeReq, err := http.NewRequestWithContext(ctx, "POST", mcpEndpoint, nil)
+			Expect(err).NotTo(HaveOccurred())
+			probeReq.Header.Set("Authorization", "Bearer "+jwtToken)
+			probeReq.Header.Set("Content-Type", "application/json")
+
+			probeClient := &http.Client{Transport: tlsTransport, Timeout: 15 * time.Second}
+			probeResp, err := probeClient.Do(probeReq)
+			Expect(err).NotTo(HaveOccurred(), "raw HTTP probe to MCP endpoint should not fail")
+			probeBody, _ := io.ReadAll(probeResp.Body)
+			_ = probeResp.Body.Close()
+			GinkgoWriter.Printf("  JWT probe: HTTP %d — %s\n", probeResp.StatusCode, string(probeBody))
+			Expect(probeResp.StatusCode).NotTo(Equal(http.StatusUnauthorized),
+				"JWT from DEX should not be rejected as 401 — check issuer/audience/JWKS config")
+			Expect(probeResp.StatusCode).NotTo(Equal(http.StatusForbidden),
+				"JWT user should have RBAC — check DEX user RBAC RoleBinding")
+
+			By("Connecting MCP client with DEX JWT instead of SA token")
+			connectCtx, connectCancel := context.WithTimeout(ctx, 30*time.Second)
+			defer connectCancel()
+			session, err := infrastructure.ConnectMCPClient(connectCtx, infrastructure.MCPClientConfig{
+				Endpoint:     mcpEndpoint,
+				SAToken:      jwtToken,
+				TLSTransport: tlsTransport,
+			})
+			Expect(err).NotTo(HaveOccurred(), "MCP client should connect with DEX JWT")
+			defer session.Close()
+
+			By("Verifying MCP session is alive by listing tools")
+			tools, err := session.ListTools(ctx, nil)
+			Expect(err).NotTo(HaveOccurred(), "ListTools should succeed with JWT auth")
+			Expect(tools.Tools).NotTo(BeEmpty(), "KA should expose MCP tools")
+
+			GinkgoWriter.Printf("  ✅ JWT auth succeeded — %d tools visible\n", len(tools.Tools))
+		})
+	})
+
+	// ---------------------------------------------------------------
+	// E2E-KA-JWT-002: Invalid/forged JWT rejected with 401
+	// BR: BR-INTERACTIVE-010
+	// Validates: CompositeAuthenticator fail-closed for bad JWTs
+	// ---------------------------------------------------------------
+	Describe("E2E-KA-JWT-002: Invalid JWT rejected with 401", func() {
+		It("should reject a forged JWT-shaped token with 401 Unauthorized", func() {
+			By("Crafting a JWT-shaped token not signed by DEX")
+			forgedToken := "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9." +
+				"eyJpc3MiOiJodHRwOi8vZGV4OjU1NTYvZGV4Iiwic3ViIjoiYXR0YWNrZXIiLCJhdWQiOiJrdWJlcm5hdXQtYWdlbnQifQ." +
+				"invalid-signature-data"
+
+			By("Sending HTTP POST to MCP endpoint with forged JWT")
+			req, err := http.NewRequestWithContext(ctx, "POST", mcpEndpoint, nil)
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Authorization", "Bearer "+forgedToken)
+			req.Header.Set("Content-Type", "application/json")
+
+			client := &http.Client{Transport: tlsTransport, Timeout: 10 * time.Second}
+			resp, err := client.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			By("Asserting 401 Unauthorized — fail-closed for known issuer with bad signature")
+			Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized),
+				"forged JWT targeting a known issuer must be rejected as 401")
+		})
+	})
+
+	// ---------------------------------------------------------------
+	// E2E-KA-JWT-003: Pattern A + B coexistence — SA token still works
+	// BR: BR-INTERACTIVE-002
+	// Validates: CompositeAuthenticator does not break SA token path
+	// ---------------------------------------------------------------
+	Describe("E2E-KA-JWT-003: Pattern A + B coexistence — SA token still works alongside JWT", func() {
+		It("should accept SA token (Pattern A) when JWT providers are configured", func() {
+			By("Connecting MCP client with ServiceAccount token (Pattern A)")
+			saToken, err := infrastructure.GetServiceAccountToken(ctx, sharedNamespace, "kubernaut-agent-e2e-sa", kubeconfigPath)
+			Expect(err).NotTo(HaveOccurred())
+
+			connectCtx, connectCancel := context.WithTimeout(ctx, 30*time.Second)
+			defer connectCancel()
+			session, err := infrastructure.ConnectMCPClient(connectCtx, infrastructure.MCPClientConfig{
+				Endpoint:     mcpEndpoint,
+				SAToken:      saToken,
+				TLSTransport: tlsTransport,
+			})
+			Expect(err).NotTo(HaveOccurred(), "MCP client should connect with SA token even when JWT providers are configured")
+			defer session.Close()
+
+			By("Verifying MCP session is alive by listing tools")
+			tools, err := session.ListTools(ctx, nil)
+			Expect(err).NotTo(HaveOccurred(), "ListTools should succeed with SA token auth")
+			Expect(tools.Tools).NotTo(BeEmpty(), "KA should expose MCP tools for SA-authenticated user")
+
+			GinkgoWriter.Printf("  ✅ SA token auth (Pattern A) still works — %d tools visible\n", len(tools.Tools))
+		})
+	})
+
+	// ---------------------------------------------------------------
+	// E2E-KA-JWT-004: JWT user invokes kubernaut_investigate
+	// BR: BR-INTERACTIVE-001, BR-INTERACTIVE-004
+	// Validates: Full interactive flow with JWT identity propagation
+	// ---------------------------------------------------------------
+	Describe("E2E-KA-JWT-004: JWT user invokes kubernaut_investigate tool", func() {
+		It("should allow JWT-authenticated user to start an interactive session", func() {
+			By("Obtaining a DEX JWT")
+			jwtToken, err := infrastructure.GetDexIDToken(dexConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Connecting MCP client with DEX JWT")
+			connectCtx, connectCancel := context.WithTimeout(ctx, 30*time.Second)
+			defer connectCancel()
+			session, err := infrastructure.ConnectMCPClient(connectCtx, infrastructure.MCPClientConfig{
+				Endpoint:     mcpEndpoint,
+				SAToken:      jwtToken,
+				TLSTransport: tlsTransport,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			By("Creating RR fixture for investigate")
+			createTestRemediationRequest(ctx, "rr-jwt-e2e-001")
+
+			By("Calling kubernaut_investigate with start action")
+			result, err := infrastructure.CallInvestigate(ctx, session, map[string]any{
+				"rr_id":  "rr-jwt-e2e-001",
+				"action": "start",
+			})
+			Expect(err).NotTo(HaveOccurred(), "kubernaut_investigate should succeed with JWT auth")
+			Expect(result).NotTo(BeNil())
+
+			text := infrastructure.ExtractToolResultText(result)
+			Expect(text).NotTo(BeEmpty(), "investigate result should contain output")
+			GinkgoWriter.Printf("  ✅ JWT user invoked kubernaut_investigate: %s\n", truncate(text, 200))
+
+			By("Completing the session to release the Lease")
+			_, err = infrastructure.CallInvestigate(ctx, session, map[string]any{
+				"rr_id":  "rr-jwt-e2e-001",
+				"action": "complete",
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	// ---------------------------------------------------------------
+	// E2E-KA-JWT-005: Expired DEX JWT rejected
+	// BR: BR-INTERACTIVE-010
+	// Note: DEX issues JWTs with configurable expiry. We validate the
+	// token was issued recently and check KA rejects stale tokens.
+	// Since we can't easily make DEX issue an already-expired token,
+	// this test validates the auth pipeline handles token format from
+	// a real OIDC provider (complementing the unit-level expiry tests).
+	// ---------------------------------------------------------------
+	Describe("E2E-KA-JWT-005: DEX token format validated end-to-end", func() {
+		It("should successfully decode and validate a DEX-issued JWT structure", func() {
+			By("Obtaining a fresh DEX JWT")
+			jwtToken, err := infrastructure.GetDexIDToken(dexConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the token has JWT structure (3 dot-separated segments)")
+			segments := 0
+			for _, c := range jwtToken {
+				if c == '.' {
+					segments++
+				}
+			}
+			Expect(segments).To(Equal(2), "DEX id_token must be a valid JWT (3 segments)")
+
+			By("Sending a raw HTTP request with the JWT to verify full pipeline")
+			req, err := http.NewRequestWithContext(ctx, "POST", mcpEndpoint, nil)
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Authorization", "Bearer "+jwtToken)
+			req.Header.Set("Content-Type", "application/json")
+
+			client := &http.Client{Transport: tlsTransport, Timeout: 10 * time.Second}
+			resp, err := client.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			body, _ := io.ReadAll(resp.Body)
+			GinkgoWriter.Printf("  DEX JWT → KA response: %d %s\n", resp.StatusCode, string(body))
+
+			Expect(resp.StatusCode).NotTo(Equal(http.StatusUnauthorized),
+				"a valid DEX-issued JWT should not be rejected as unauthorized")
+		})
+	})
+})
+
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "..."
+}

--- a/test/infrastructure/dex_e2e.go
+++ b/test/infrastructure/dex_e2e.go
@@ -1,0 +1,302 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package infrastructure
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// dexImage is the DEX OIDC provider image used for E2E JWT testing.
+// v2.45.1 includes groups/preferred_username support for static passwords.
+const dexImage = "ghcr.io/dexidp/dex:v2.45.1"
+
+// DexE2EConfig holds the DEX E2E user credentials for token acquisition.
+type DexE2EConfig struct {
+	TokenEndpoint string // e.g. http://localhost:5556/dex/token
+	ClientID      string
+	ClientSecret  string
+	Username      string // email for static password user
+	Password      string
+}
+
+// DefaultDexE2EConfig returns the default DEX config matching the static
+// passwords and clients deployed by deployDexInNamespace.
+func DefaultDexE2EConfig() DexE2EConfig {
+	return DexE2EConfig{
+		TokenEndpoint: "http://localhost:5556/dex/token",
+		ClientID:      "kubernaut-agent",
+		ClientSecret:  "e2e-client-secret",
+		Username:      "e2e-user@kubernaut.test",
+		Password:      "e2e-test-password",
+	}
+}
+
+// GetDexIDToken obtains an OIDC id_token from DEX using the Resource Owner
+// Password Credentials grant. The id_token is a JWT signed by DEX's keys.
+func GetDexIDToken(cfg DexE2EConfig) (string, error) {
+	data := url.Values{
+		"grant_type":    {"password"},
+		"scope":         {"openid email groups profile"},
+		"username":      {cfg.Username},
+		"password":      {cfg.Password},
+		"client_id":     {cfg.ClientID},
+		"client_secret": {cfg.ClientSecret},
+	}
+
+	resp, err := http.PostForm(cfg.TokenEndpoint, data)
+	if err != nil {
+		return "", fmt.Errorf("DEX token request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("read DEX token response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("DEX token endpoint returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var tokenResp struct {
+		IDToken string `json:"id_token"`
+	}
+	if err := json.Unmarshal(body, &tokenResp); err != nil {
+		return "", fmt.Errorf("parse DEX token response: %w", err)
+	}
+	if tokenResp.IDToken == "" {
+		return "", fmt.Errorf("DEX token response missing id_token: %s", string(body))
+	}
+
+	return tokenResp.IDToken, nil
+}
+
+// deployDexInNamespace deploys DEX as an OIDC provider in the Kind cluster
+// for E2E JWT/OIDC testing. DEX is configured with:
+//   - Static password user (e2e-user@kubernaut.test)
+//   - Static client (kubernaut-agent)
+//   - Password grant enabled
+//   - In-memory storage (stateless, E2E only)
+//
+// DD-AUTH-MCP-001 v2.0: Validates full OIDC flow with real JWT issuance.
+func deployDexInNamespace(ctx context.Context, namespace, kubeconfigPath string, writer io.Writer) error {
+	// bcrypt hash of "e2e-test-password" at cost 10
+	const passwordHash = "$2a$10$aFeIluCoQjRFg1RqPxXLZeBV4vLXyL0PauEX0ZaAaq/afg2mOYsg."
+
+	manifest := fmt.Sprintf(`---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dex-config
+  namespace: %s
+data:
+  config.yaml: |
+    issuer: http://dex:5556/dex
+    storage:
+      type: memory
+    web:
+      http: 0.0.0.0:5556
+    enablePasswordDB: true
+    oauth2:
+      passwordConnector: local
+      responseTypes: ["code", "token", "id_token"]
+      skipApprovalScreen: true
+    staticPasswords:
+      - email: "e2e-user@kubernaut.test"
+        hash: "%s"
+        username: "e2e-user"
+        userID: "e2e-user-001"
+    staticClients:
+      - id: kubernaut-agent
+        redirectURIs:
+          - 'http://localhost/callback'
+        name: 'Kubernaut Agent E2E'
+        secret: e2e-client-secret
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dex
+  namespace: %s
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dex
+  template:
+    metadata:
+      labels:
+        app: dex
+    spec:
+      containers:
+      - name: dex
+        image: %s
+        command: ["dex", "serve", "/etc/dex/config.yaml"]
+        ports:
+        - name: http
+          containerPort: 5556
+        volumeMounts:
+        - name: config
+          mountPath: /etc/dex
+          readOnly: true
+        readinessProbe:
+          httpGet:
+            path: /dex/healthz
+            port: 5556
+          initialDelaySeconds: 3
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /dex/healthz
+            port: 5556
+          initialDelaySeconds: 5
+          periodSeconds: 10
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "25m"
+          limits:
+            memory: "64Mi"
+            cpu: "100m"
+      volumes:
+      - name: config
+        configMap:
+          name: dex-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex
+  namespace: %s
+spec:
+  type: NodePort
+  ports:
+  - name: http
+    port: 5556
+    targetPort: 5556
+    nodePort: 30556
+  selector:
+    app: dex
+`, namespace, passwordHash, namespace, dexImage, namespace)
+
+	cmd := exec.CommandContext(ctx, "kubectl", "apply", "--kubeconfig", kubeconfigPath, "-f", "-")
+	cmd.Stdin = strings.NewReader(manifest)
+	cmd.Stdout = writer
+	cmd.Stderr = writer
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to deploy DEX: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(writer, "  ✅ DEX OIDC provider deployed")
+
+	_, _ = fmt.Fprintln(writer, "  ⏳ Waiting for DEX pod to be ready...")
+	waitCmd := exec.CommandContext(ctx, "kubectl", "rollout", "status", "deployment/dex",
+		"-n", namespace, "--kubeconfig", kubeconfigPath, "--timeout=120s")
+	waitCmd.Stdout = writer
+	waitCmd.Stderr = writer
+	if err := waitCmd.Run(); err != nil {
+		return fmt.Errorf("DEX deployment rollout failed: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(writer, "  ✅ DEX pod ready")
+	return nil
+}
+
+// waitForDexReady polls the DEX health endpoint via NodePort until it responds
+// or the timeout is reached.
+func waitForDexReady(writer io.Writer) error {
+	_, _ = fmt.Fprintln(writer, "  ⏳ Waiting for DEX OIDC endpoint to be reachable...")
+
+	deadline := time.Now().Add(90 * time.Second)
+	for time.Now().Before(deadline) {
+		resp, err := http.Get("http://localhost:5556/dex/healthz")
+		if err == nil && resp.StatusCode == http.StatusOK {
+			_ = resp.Body.Close()
+			_, _ = fmt.Fprintln(writer, "  ✅ DEX OIDC endpoint reachable")
+			return nil
+		}
+		if resp != nil {
+			_ = resp.Body.Close()
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	return fmt.Errorf("DEX health endpoint not responsive after 90 seconds")
+}
+
+// createDexUserRBAC creates Kubernetes RBAC that allows the DEX-authenticated
+// user (e2e-user@kubernaut.test) to access the Kubernaut Agent API via SAR.
+// This mirrors the SA RBAC but for an OIDC user identity.
+func createDexUserRBAC(ctx context.Context, namespace, kubeconfigPath string, writer io.Writer) error {
+	rbacYAML := fmt.Sprintf(`---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: dex-e2e-user-ka-access
+  namespace: %s
+  labels:
+    app: kubernaut-agent
+    component: e2e-testing
+    authorization: dd-auth-mcp-001-v2
+rules:
+  - apiGroups: [""]
+    resources: ["services"]
+    resourceNames: ["kubernaut-agent"]
+    verbs: ["create", "get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: dex-e2e-user-ka-access
+  namespace: %s
+  labels:
+    app: kubernaut-agent
+    component: e2e-testing
+    authorization: dd-auth-mcp-001-v2
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: dex-e2e-user-ka-access
+subjects:
+  - kind: User
+    name: e2e-user@kubernaut.test
+    apiGroup: rbac.authorization.k8s.io
+`, namespace, namespace)
+
+	cmd := exec.CommandContext(ctx, "kubectl", "apply", "--kubeconfig", kubeconfigPath, "-f", "-")
+	cmd.Stdin = strings.NewReader(rbacYAML)
+	cmd.Stdout = writer
+	cmd.Stderr = writer
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to apply DEX user RBAC: %w", err)
+	}
+	_, _ = fmt.Fprintln(writer, "  ✅ DEX E2E user RBAC created")
+	return nil
+}
+
+// PreloadDexImage pulls the DEX image and loads it into the Kind cluster.
+func PreloadDexImage(clusterName string, writer io.Writer) error {
+	return PreloadExternalImage(dexImage, clusterName, writer)
+}

--- a/test/infrastructure/kind-kubernautagent-config.yaml
+++ b/test/infrastructure/kind-kubernautagent-config.yaml
@@ -36,3 +36,7 @@ nodes:
   - containerPort: 30387
     hostPort: 30387
     protocol: TCP
+  # DEX OIDC Provider - E2E JWT/OIDC testing (#1009)
+  - containerPort: 30556
+    hostPort: 5556
+    protocol: TCP

--- a/test/infrastructure/kubernautagent.go
+++ b/test/infrastructure/kubernautagent.go
@@ -243,6 +243,25 @@ func SetupKubernautAgentInfrastructure(ctx context.Context, clusterName, kubecon
 	}
 
 	// ═══════════════════════════════════════════════════════════════════════
+	// PHASE 5.8: Deploy DEX OIDC Provider for JWT E2E testing (#1009)
+	// Must be ready BEFORE KA starts so JWKS pre-warm succeeds.
+	// DD-AUTH-MCP-001 v2.0: Pattern B validation with real OIDC provider.
+	// ═══════════════════════════════════════════════════════════════════════
+	_, _ = fmt.Fprintln(writer, "\n🔑 PHASE 5.8: Deploying DEX OIDC Provider (#1009)...")
+	if err := PreloadDexImage(clusterName, writer); err != nil {
+		_, _ = fmt.Fprintf(writer, "  ⚠️  Failed to preload DEX image (non-fatal, Kind may pull): %v\n", err)
+	}
+	if err := deployDexInNamespace(ctx, namespace, kubeconfigPath, writer); err != nil {
+		return fmt.Errorf("failed to deploy DEX: %w", err)
+	}
+	if err := waitForDexReady(writer); err != nil {
+		return fmt.Errorf("DEX not ready: %w", err)
+	}
+	if err := createDexUserRBAC(ctx, namespace, kubeconfigPath, writer); err != nil {
+		return fmt.Errorf("failed to create DEX user RBAC: %w", err)
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
 	// PHASE 6: Deploy Kubernaut Agent
 	// ═══════════════════════════════════════════════════════════════════════
 	_, _ = fmt.Fprintln(writer, "\n🤖 PHASE 6: Deploying Kubernaut Agent...")
@@ -761,6 +780,15 @@ data:
       inactivityTimeout: "2m"
       maxConcurrentSessions: 3
       rateLimitPerUser: 20
+      jwtProviders:
+        - name: dex-e2e
+          issuer: "http://dex:5556/dex"
+          jwksURL: "http://dex:5556/dex/keys"
+          audience: "kubernaut-agent"
+          claimMappings:
+            username: "email"
+            groups: "groups"
+      jwtInteractiveGroup: "interactive-users"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/test/infrastructure/kubernautagent.go
+++ b/test/infrastructure/kubernautagent.go
@@ -788,7 +788,6 @@ data:
           claimMappings:
             username: "email"
             groups: "groups"
-      jwtInteractiveGroup: "interactive-users"
 ---
 apiVersion: v1
 kind: ConfigMap

--- a/test/integration/kubernautagent/jwt_middleware_test.go
+++ b/test/integration/kubernautagent/jwt_middleware_test.go
@@ -55,7 +55,7 @@ var _ = Describe("JWT Middleware Pipeline — #1009", func() {
 				UsernameClaim: "preferred_username",
 				GroupsClaim:   "groups",
 			},
-		})
+		}, logr.Discard())
 		Expect(err).NotTo(HaveOccurred())
 
 		mockK8sAuth = &auth.MockAuthenticator{

--- a/test/integration/kubernautagent/jwt_middleware_test.go
+++ b/test/integration/kubernautagent/jwt_middleware_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernautagent_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/shared/auth"
+	testauth "github.com/jordigilh/kubernaut/test/shared/auth"
+)
+
+var _ = Describe("JWT Middleware Pipeline — #1009", func() {
+	var (
+		mockJWKS    *testauth.MockJWKSServer
+		jwtAuth     *auth.JWTAuthenticator
+		mockK8sAuth *auth.MockAuthenticator
+		mockAuthz   *auth.MockAuthorizer
+		composite   *auth.CompositeAuthenticator
+		middleware  *auth.Middleware
+		server      *httptest.Server
+		capturedUser string
+		capturedProviderType string
+	)
+
+	BeforeEach(func() {
+		var err error
+		mockJWKS, err = testauth.NewMockJWKSServer("https://keycloak.example.com/realms/kubernaut")
+		Expect(err).NotTo(HaveOccurred())
+
+		jwtAuth, err = auth.NewJWTAuthenticator([]auth.JWTProviderEntry{
+			{
+				Issuer:        "https://keycloak.example.com/realms/kubernaut",
+				JWKSURL:       mockJWKS.JWKSURL(),
+				Audience:      "kubernaut-agent",
+				UsernameClaim: "preferred_username",
+				GroupsClaim:   "groups",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		mockK8sAuth = &auth.MockAuthenticator{
+			ValidUsers: map[string]string{
+				"sa-token-apifrontend": "system:serviceaccount:kubernaut-system:apifrontend",
+			},
+			ValidUsersFull: map[string]auth.UserInfo{
+				"sa-token-apifrontend": {
+					Username:     "system:serviceaccount:kubernaut-system:apifrontend",
+					Groups:       []string{"system:serviceaccounts"},
+					ProviderType: "k8s:tokenreview",
+				},
+			},
+		}
+
+		mockAuthz = &auth.MockAuthorizer{
+			AllowedUsers: map[string]bool{
+				"user-a@corp":  true,
+				"system:serviceaccount:kubernaut-system:apifrontend": true,
+			},
+		}
+
+		composite = auth.NewCompositeAuthenticator(jwtAuth, mockK8sAuth)
+
+		middleware = auth.NewMiddleware(composite, mockAuthz, auth.MiddlewareConfig{
+			Namespace:    "kubernaut-system",
+			Resource:     "services",
+			ResourceName: "kubernaut-agent",
+			Verb:         "create",
+		}, logr.Discard())
+
+		capturedUser = ""
+		capturedProviderType = ""
+
+		handler := middleware.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			capturedUser = auth.GetUserFromContext(r.Context())
+			info := auth.GetUserInfoFromContext(r.Context())
+			capturedProviderType = info.ProviderType
+			w.WriteHeader(http.StatusOK)
+		}))
+
+		server = httptest.NewServer(handler)
+	})
+
+	AfterEach(func() {
+		if server != nil {
+			server.Close()
+		}
+		if mockJWKS != nil {
+			mockJWKS.Close()
+		}
+	})
+
+	Describe("IT-KA-1009-001: Full middleware pipeline accepts valid JWT", func() {
+		It("should inject correct UserInfo into context for JWT-authenticated user", func() {
+			token, err := mockJWKS.IssueJWT("user-a@corp", []string{"interactive-users"}, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			req, _ := http.NewRequest("POST", server.URL+"/api/v1/investigate", nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			resp, err := http.DefaultClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(capturedUser).To(Equal("user-a@corp"))
+			Expect(capturedProviderType).To(HavePrefix("jwt:"))
+		})
+	})
+
+	Describe("IT-KA-1009-002: Expired JWT rejected with 401", func() {
+		It("should return 401 for expired JWT", func() {
+			token, err := mockJWKS.IssueJWT("user-a@corp", []string{"g1"}, "kubernaut-agent", -1*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			req, _ := http.NewRequest("POST", server.URL+"/api/v1/investigate", nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			resp, err := http.DefaultClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+		})
+	})
+
+	Describe("IT-KA-1009-004: JWT user fails SAR → 403", func() {
+		It("should return 403 when JWT user lacks RBAC permissions", func() {
+			token, err := mockJWKS.IssueJWT("unauthorized-user@corp", []string{"g1"}, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			req, _ := http.NewRequest("POST", server.URL+"/api/v1/investigate", nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			resp, err := http.DefaultClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusForbidden))
+		})
+	})
+
+	Describe("IT-KA-1009-005: Mixed traffic — JWT + K8s SA token both succeed", func() {
+		It("should accept both JWT and SA tokens through the same middleware", func() {
+			jwtToken, err := mockJWKS.IssueJWT("user-a@corp", []string{"interactive-users"}, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			req1, _ := http.NewRequest("POST", server.URL+"/api/v1/investigate", nil)
+			req1.Header.Set("Authorization", "Bearer "+jwtToken)
+			resp1, err := http.DefaultClient.Do(req1)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp1.Body.Close()
+			Expect(resp1.StatusCode).To(Equal(http.StatusOK))
+			Expect(capturedUser).To(Equal("user-a@corp"))
+			Expect(capturedProviderType).To(HavePrefix("jwt:"))
+
+			req2, _ := http.NewRequest("POST", server.URL+"/api/v1/investigate", nil)
+			req2.Header.Set("Authorization", "Bearer sa-token-apifrontend")
+			resp2, err := http.DefaultClient.Do(req2)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp2.Body.Close()
+			Expect(resp2.StatusCode).To(Equal(http.StatusOK))
+			Expect(capturedUser).To(Equal("system:serviceaccount:kubernaut-system:apifrontend"))
+			Expect(capturedProviderType).To(Equal("k8s:tokenreview"))
+		})
+	})
+
+	Describe("IT-KA-1009-007: Impersonation headers stripped before JWT validation", func() {
+		It("should strip Impersonate-* headers from JWT requests", func() {
+			token, err := mockJWKS.IssueJWT("user-a@corp", []string{"interactive-users"}, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			var capturedHeaders http.Header
+			handler := middleware.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedHeaders = r.Header.Clone()
+				w.WriteHeader(http.StatusOK)
+			}))
+			srv := httptest.NewServer(handler)
+			defer srv.Close()
+
+			req, _ := http.NewRequest("POST", srv.URL+"/test", nil)
+			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("Impersonate-User", "admin")
+			req.Header.Set("Impersonate-Group", "cluster-admins")
+			req.Header.Set("Impersonate-Extra-Scopes", "all")
+
+			resp, err := http.DefaultClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			Expect(capturedHeaders.Get("Impersonate-User")).To(BeEmpty())
+			Expect(capturedHeaders.Get("Impersonate-Group")).To(BeEmpty())
+			Expect(capturedHeaders.Get("Impersonate-Extra-Scopes")).To(BeEmpty())
+		})
+	})
+})

--- a/test/shared/auth/mock_jwks_server.go
+++ b/test/shared/auth/mock_jwks_server.go
@@ -1,0 +1,130 @@
+package auth
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwk"
+	"github.com/lestrrat-go/jwx/v3/jwt"
+)
+
+// MockJWKSServer is a test OIDC provider that generates RSA key pairs,
+// serves a JWKS endpoint, and issues signed JWTs. Used for unit and
+// integration testing of JWTAuthenticator without a real OIDC provider.
+type MockJWKSServer struct {
+	PrivateKey *rsa.PrivateKey
+	PublicKey  jwk.Key
+	Issuer     string
+	Server     *httptest.Server
+}
+
+// NewMockJWKSServer creates a mock JWKS server with a fresh RSA key pair.
+// The server serves /.well-known/jwks.json with the public key.
+func NewMockJWKSServer(issuer string) (*MockJWKSServer, error) {
+	privKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return nil, err
+	}
+
+	pubJWK, err := jwk.PublicKeyOf(privKey)
+	if err != nil {
+		return nil, err
+	}
+	if err := pubJWK.Set(jwk.KeyIDKey, "test-key-1"); err != nil {
+		return nil, err
+	}
+	if err := pubJWK.Set(jwk.AlgorithmKey, jwa.RS256()); err != nil {
+		return nil, err
+	}
+	if err := pubJWK.Set(jwk.KeyUsageKey, "sig"); err != nil {
+		return nil, err
+	}
+
+	m := &MockJWKSServer{
+		PrivateKey: privKey,
+		PublicKey:  pubJWK,
+		Issuer:     issuer,
+	}
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("/.well-known/jwks.json", m.handleJWKS)
+	m.Server = httptest.NewServer(mux)
+
+	return m, nil
+}
+
+func (m *MockJWKSServer) handleJWKS(w http.ResponseWriter, _ *http.Request) {
+	set := jwk.NewSet()
+	_ = set.AddKey(m.PublicKey)
+
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(set)
+}
+
+// JWKSURL returns the URL of the JWKS endpoint.
+func (m *MockJWKSServer) JWKSURL() string {
+	return m.Server.URL + "/.well-known/jwks.json"
+}
+
+// IssueJWT creates a signed JWT with the given claims.
+func (m *MockJWKSServer) IssueJWT(sub string, groups []string, aud string, exp time.Duration) (string, error) {
+	claims := map[string]interface{}{
+		"preferred_username": sub,
+		"groups":             groups,
+	}
+	return m.IssueJWTWithClaims(sub, aud, exp, claims)
+}
+
+// IssueJWTWithClaims creates a signed JWT with custom claims merged with standard fields.
+func (m *MockJWKSServer) IssueJWTWithClaims(sub, aud string, exp time.Duration, custom map[string]interface{}) (string, error) {
+	now := time.Now()
+
+	builder := jwt.NewBuilder().
+		Subject(sub).
+		Issuer(m.Issuer).
+		IssuedAt(now).
+		NotBefore(now).
+		Expiration(now.Add(exp))
+
+	if aud != "" {
+		builder = builder.Audience([]string{aud})
+	}
+
+	token, err := builder.Build()
+	if err != nil {
+		return "", err
+	}
+
+	for k, v := range custom {
+		if err := token.Set(k, v); err != nil {
+			return "", err
+		}
+	}
+
+	privJWK, err := jwk.Import(m.PrivateKey)
+	if err != nil {
+		return "", err
+	}
+	if err := privJWK.Set(jwk.KeyIDKey, "test-key-1"); err != nil {
+		return "", err
+	}
+	if err := privJWK.Set(jwk.AlgorithmKey, jwa.RS256()); err != nil {
+		return "", err
+	}
+
+	signed, err := jwt.Sign(token, jwt.WithKey(jwa.RS256(), privJWK))
+	if err != nil {
+		return "", err
+	}
+	return string(signed), nil
+}
+
+// Close shuts down the mock server.
+func (m *MockJWKSServer) Close() {
+	m.Server.Close()
+}

--- a/test/unit/kubernautagent/config/jwt_config_test.go
+++ b/test/unit/kubernautagent/config/jwt_config_test.go
@@ -56,7 +56,6 @@ interactive:
       claimMappings:
         username: "preferred_username"
         groups: "groups"
-  jwtInteractiveGroup: "kubernaut-interactive-users"
 `)
 			cfg, err := config.Load(yaml)
 			Expect(err).NotTo(HaveOccurred())
@@ -71,7 +70,6 @@ interactive:
 			Expect(cfg.Interactive.JWTProviders[0].Audience).To(Equal("kubernaut-agent"))
 			Expect(cfg.Interactive.JWTProviders[0].ClaimMappings.Username).To(Equal("preferred_username"))
 			Expect(cfg.Interactive.JWTProviders[0].ClaimMappings.Groups).To(Equal("groups"))
-			Expect(cfg.Interactive.JWTInteractiveGroup).To(Equal("kubernaut-interactive-users"))
 		})
 	})
 

--- a/test/unit/kubernautagent/config/jwt_config_test.go
+++ b/test/unit/kubernautagent/config/jwt_config_test.go
@@ -1,0 +1,381 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package config_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/config"
+)
+
+var _ = Describe("JWTProviderConfig Validation — #1009", func() {
+
+	validBaseYAML := func(interactiveBlock string) []byte {
+		return []byte(`
+runtime:
+  server:
+    rateLimit:
+      requestsPerSecond: 5
+      burst: 10
+ai:
+  llm:
+    provider: "openai"
+  investigation:
+    maxTurns: 40
+` + interactiveBlock)
+	}
+
+	Describe("UT-KA-1009-025: Valid JWTProviderConfig with all required fields passes validation", func() {
+		It("should pass validation with a complete jwtProviders configuration", func() {
+			yaml := validBaseYAML(`
+interactive:
+  enabled: true
+  sessionTTL: 30m
+  inactivityTimeout: 5m
+  maxConcurrentSessions: 5
+  jwtProviders:
+    - name: "keycloak"
+      issuer: "https://keycloak.example.com/realms/kubernaut"
+      jwksURL: "https://keycloak.example.com/realms/kubernaut/protocol/openid-connect/certs"
+      audience: "kubernaut-agent"
+      claimMappings:
+        username: "preferred_username"
+        groups: "groups"
+  jwtInteractiveGroup: "kubernaut-interactive-users"
+`)
+			cfg, err := config.Load(yaml)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = cfg.Validate()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cfg.Interactive.JWTProviders).To(HaveLen(1))
+			Expect(cfg.Interactive.JWTProviders[0].Name).To(Equal("keycloak"))
+			Expect(cfg.Interactive.JWTProviders[0].Issuer).To(Equal("https://keycloak.example.com/realms/kubernaut"))
+			Expect(cfg.Interactive.JWTProviders[0].JWKSURL).To(Equal("https://keycloak.example.com/realms/kubernaut/protocol/openid-connect/certs"))
+			Expect(cfg.Interactive.JWTProviders[0].Audience).To(Equal("kubernaut-agent"))
+			Expect(cfg.Interactive.JWTProviders[0].ClaimMappings.Username).To(Equal("preferred_username"))
+			Expect(cfg.Interactive.JWTProviders[0].ClaimMappings.Groups).To(Equal("groups"))
+			Expect(cfg.Interactive.JWTInteractiveGroup).To(Equal("kubernaut-interactive-users"))
+		})
+	})
+
+	Describe("UT-KA-1009-026: JWTProviderConfig without issuer URL fails validation", func() {
+		It("should return an error when issuer is empty", func() {
+			yaml := validBaseYAML(`
+interactive:
+  enabled: true
+  sessionTTL: 30m
+  inactivityTimeout: 5m
+  maxConcurrentSessions: 5
+  jwtProviders:
+    - name: "keycloak"
+      jwksURL: "https://keycloak.example.com/realms/kubernaut/protocol/openid-connect/certs"
+      audience: "kubernaut-agent"
+`)
+			cfg, err := config.Load(yaml)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("issuer"))
+		})
+	})
+
+	Describe("UT-KA-1009-027: JWTProviderConfig without JWKS URL fails validation", func() {
+		It("should return an error when jwksURL is empty", func() {
+			yaml := validBaseYAML(`
+interactive:
+  enabled: true
+  sessionTTL: 30m
+  inactivityTimeout: 5m
+  maxConcurrentSessions: 5
+  jwtProviders:
+    - name: "keycloak"
+      issuer: "https://keycloak.example.com/realms/kubernaut"
+      audience: "kubernaut-agent"
+`)
+			cfg, err := config.Load(yaml)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("jwksURL"))
+		})
+	})
+
+	Describe("UT-KA-1009-028: JWTProviderConfig without audience fails validation", func() {
+		It("should return an error when audience is empty", func() {
+			yaml := validBaseYAML(`
+interactive:
+  enabled: true
+  sessionTTL: 30m
+  inactivityTimeout: 5m
+  maxConcurrentSessions: 5
+  jwtProviders:
+    - name: "keycloak"
+      issuer: "https://keycloak.example.com/realms/kubernaut"
+      jwksURL: "https://keycloak.example.com/realms/kubernaut/protocol/openid-connect/certs"
+`)
+			cfg, err := config.Load(yaml)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("audience"))
+		})
+	})
+
+	Describe("UT-KA-1009-029: ClaimMappings defaults applied when not specified", func() {
+		It("should default username to 'preferred_username' and groups to 'groups'", func() {
+			yaml := validBaseYAML(`
+interactive:
+  enabled: true
+  sessionTTL: 30m
+  inactivityTimeout: 5m
+  maxConcurrentSessions: 5
+  jwtProviders:
+    - name: "keycloak"
+      issuer: "https://keycloak.example.com/realms/kubernaut"
+      jwksURL: "https://keycloak.example.com/realms/kubernaut/protocol/openid-connect/certs"
+      audience: "kubernaut-agent"
+`)
+			cfg, err := config.Load(yaml)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = cfg.Validate()
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(cfg.Interactive.JWTProviders[0].ClaimMappings.Username).To(Equal("preferred_username"))
+			Expect(cfg.Interactive.JWTProviders[0].ClaimMappings.Groups).To(Equal("groups"))
+		})
+	})
+
+	Describe("UT-KA-1009-030: InteractiveConfig validates all providers", func() {
+		It("should validate each provider in the jwtProviders list", func() {
+			yaml := validBaseYAML(`
+interactive:
+  enabled: true
+  sessionTTL: 30m
+  inactivityTimeout: 5m
+  maxConcurrentSessions: 5
+  jwtProviders:
+    - name: "valid-provider"
+      issuer: "https://issuer-1.example.com"
+      jwksURL: "https://issuer-1.example.com/.well-known/jwks.json"
+      audience: "kubernaut-agent"
+    - name: "invalid-provider"
+      issuer: ""
+      jwksURL: "https://issuer-2.example.com/.well-known/jwks.json"
+      audience: "kubernaut-agent"
+`)
+			cfg, err := config.Load(yaml)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("issuer"))
+			Expect(err.Error()).To(ContainSubstring("invalid-provider"))
+		})
+	})
+
+	Describe("UT-KA-1009-031: Duplicate issuer URLs across providers rejected", func() {
+		It("should return an error when two providers share the same issuer URL", func() {
+			yaml := validBaseYAML(`
+interactive:
+  enabled: true
+  sessionTTL: 30m
+  inactivityTimeout: 5m
+  maxConcurrentSessions: 5
+  jwtProviders:
+    - name: "provider-1"
+      issuer: "https://keycloak.example.com/realms/kubernaut"
+      jwksURL: "https://keycloak.example.com/realms/kubernaut/protocol/openid-connect/certs"
+      audience: "kubernaut-agent"
+    - name: "provider-2"
+      issuer: "https://keycloak.example.com/realms/kubernaut"
+      jwksURL: "https://keycloak.example.com/realms/kubernaut/protocol/openid-connect/certs"
+      audience: "kubernaut-agent"
+`)
+			cfg, err := config.Load(yaml)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("duplicate"))
+			Expect(err.Error()).To(ContainSubstring("issuer"))
+		})
+	})
+
+	Describe("UT-KA-1009-032: Empty jwtProviders list is valid (Pattern A only)", func() {
+		It("should pass validation when no JWT providers are configured", func() {
+			yaml := validBaseYAML(`
+interactive:
+  enabled: true
+  sessionTTL: 30m
+  inactivityTimeout: 5m
+  maxConcurrentSessions: 5
+`)
+			cfg, err := config.Load(yaml)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = cfg.Validate()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.Interactive.JWTProviders).To(BeEmpty())
+		})
+	})
+
+	Describe("UT-KA-1009-033: jwtProviders ignored when interactive.enabled=false", func() {
+		It("should not validate jwtProviders when interactive mode is disabled", func() {
+			yaml := validBaseYAML(`
+interactive:
+  enabled: false
+  jwtProviders:
+    - name: "invalid"
+      issuer: ""
+`)
+			cfg, err := config.Load(yaml)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = cfg.Validate()
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("UT-KA-1009-034: JWKS URL exceeding max length rejected", func() {
+		It("should return an error when jwksURL exceeds 2048 characters", func() {
+			longPath := ""
+			for i := 0; i < 2100; i++ {
+				longPath += "a"
+			}
+			yaml := validBaseYAML(`
+interactive:
+  enabled: true
+  sessionTTL: 30m
+  inactivityTimeout: 5m
+  maxConcurrentSessions: 5
+  jwtProviders:
+    - name: "keycloak"
+      issuer: "https://keycloak.example.com/realms/kubernaut"
+      jwksURL: "https://keycloak.example.com/` + longPath + `"
+      audience: "kubernaut-agent"
+`)
+			cfg, err := config.Load(yaml)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("exceeds maximum length"))
+		})
+	})
+
+	Describe("UT-KA-1009-035: Syntactically invalid JWKS URL rejected", func() {
+		It("should return an error when jwksURL is not a valid URL", func() {
+			yaml := validBaseYAML(`
+interactive:
+  enabled: true
+  sessionTTL: 30m
+  inactivityTimeout: 5m
+  maxConcurrentSessions: 5
+  jwtProviders:
+    - name: "keycloak"
+      issuer: "https://keycloak.example.com/realms/kubernaut"
+      jwksURL: "://missing-scheme"
+      audience: "kubernaut-agent"
+`)
+			cfg, err := config.Load(yaml)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid jwksURL"))
+		})
+	})
+
+	Describe("UT-KA-1009-036: JWKS URL with unsupported scheme rejected", func() {
+		It("should return an error when jwksURL uses a non-HTTP(S) scheme", func() {
+			yaml := validBaseYAML(`
+interactive:
+  enabled: true
+  sessionTTL: 30m
+  inactivityTimeout: 5m
+  maxConcurrentSessions: 5
+  jwtProviders:
+    - name: "keycloak"
+      issuer: "https://keycloak.example.com/realms/kubernaut"
+      jwksURL: "ftp://keycloak.example.com/certs"
+      audience: "kubernaut-agent"
+`)
+			cfg, err := config.Load(yaml)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("scheme must be"))
+		})
+	})
+
+	Describe("UT-KA-1009-037: JWKS URL with HTTP scheme accepted for dev/test", func() {
+		It("should accept http:// JWKS URLs without error", func() {
+			yaml := validBaseYAML(`
+interactive:
+  enabled: true
+  sessionTTL: 30m
+  inactivityTimeout: 5m
+  maxConcurrentSessions: 5
+  jwtProviders:
+    - name: "dev-keycloak"
+      issuer: "http://localhost:8080/realms/kubernaut"
+      jwksURL: "http://localhost:8080/realms/kubernaut/protocol/openid-connect/certs"
+      audience: "kubernaut-agent"
+`)
+			cfg, err := config.Load(yaml)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = cfg.Validate()
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("UT-KA-1009-038: Issuer URL exceeding max length rejected", func() {
+		It("should return an error when issuer exceeds 2048 characters", func() {
+			longPath := ""
+			for i := 0; i < 2100; i++ {
+				longPath += "a"
+			}
+			yaml := validBaseYAML(`
+interactive:
+  enabled: true
+  sessionTTL: 30m
+  inactivityTimeout: 5m
+  maxConcurrentSessions: 5
+  jwtProviders:
+    - name: "keycloak"
+      issuer: "https://keycloak.example.com/` + longPath + `"
+      jwksURL: "https://keycloak.example.com/realms/kubernaut/protocol/openid-connect/certs"
+      audience: "kubernaut-agent"
+`)
+			cfg, err := config.Load(yaml)
+			Expect(err).NotTo(HaveOccurred())
+
+			err = cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("exceeds maximum length"))
+		})
+	})
+})

--- a/test/unit/shared/auth/claims_extraction_poc_test.go
+++ b/test/unit/shared/auth/claims_extraction_poc_test.go
@@ -1,0 +1,124 @@
+package auth_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/shared/auth"
+)
+
+var _ = Describe("PoC: Dot-notation claim extraction — Keycloak-realistic payloads", func() {
+
+	// Standard Keycloak JWT payload (simplified)
+	keycloakStandard := map[string]interface{}{
+		"sub":                "f:12345-abcde:jsmith",
+		"preferred_username": "jsmith@corp.com",
+		"email":              "jsmith@corp.com",
+		"groups":             []interface{}{"sre-team", "platform-eng", "kubernaut-interactive-users"},
+		"realm_access": map[string]interface{}{
+			"roles": []interface{}{"offline_access", "uma_authorization", "kubernaut-user"},
+		},
+		"resource_access": map[string]interface{}{
+			"kubernaut-agent": map[string]interface{}{
+				"roles": []interface{}{"interactive-user", "investigate"},
+			},
+			"account": map[string]interface{}{
+				"roles": []interface{}{"manage-account", "view-profile"},
+			},
+		},
+		"iss": "https://sso.example.com/realms/kubernaut",
+		"aud": []interface{}{"kubernaut-agent", "account"},
+	}
+
+	Describe("PoC-CLAIMS-001: Top-level string claim", func() {
+		It("should extract preferred_username from top level", func() {
+			val, err := auth.ExtractStringClaim(keycloakStandard, "preferred_username")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(val).To(Equal("jsmith@corp.com"))
+		})
+	})
+
+	Describe("PoC-CLAIMS-002: Top-level array claim (groups)", func() {
+		It("should extract groups as string slice", func() {
+			val, err := auth.ExtractGroupsClaim(keycloakStandard, "groups")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(val).To(ConsistOf("sre-team", "platform-eng", "kubernaut-interactive-users"))
+		})
+	})
+
+	Describe("PoC-CLAIMS-003: Nested claim — realm_access.roles", func() {
+		It("should extract roles from nested realm_access", func() {
+			val, err := auth.ExtractGroupsClaim(keycloakStandard, "realm_access.roles")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(val).To(ConsistOf("offline_access", "uma_authorization", "kubernaut-user"))
+		})
+	})
+
+	Describe("PoC-CLAIMS-004: Double-nested claim — resource_access.kubernaut-agent.roles", func() {
+		It("should extract roles from double-nested resource_access", func() {
+			val, err := auth.ExtractGroupsClaim(keycloakStandard, "resource_access.kubernaut-agent.roles")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(val).To(ConsistOf("interactive-user", "investigate"))
+		})
+	})
+
+	Describe("PoC-CLAIMS-005: Missing intermediate key", func() {
+		It("should return error for missing intermediate map", func() {
+			_, err := auth.ExtractStringClaim(keycloakStandard, "nonexistent.field")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+	})
+
+	Describe("PoC-CLAIMS-006: Key exists but wrong type (string instead of array)", func() {
+		It("should return error when expecting array but got string", func() {
+			_, err := auth.ExtractGroupsClaim(keycloakStandard, "preferred_username")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected array"))
+		})
+	})
+
+	Describe("PoC-CLAIMS-007: Key exists but wrong type (array instead of string)", func() {
+		It("should return error when expecting string but got array", func() {
+			_, err := auth.ExtractStringClaim(keycloakStandard, "groups")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expected string"))
+		})
+	})
+
+	Describe("PoC-CLAIMS-008: Intermediate is not a map", func() {
+		It("should return error when traversing through non-map value", func() {
+			_, err := auth.ExtractStringClaim(keycloakStandard, "preferred_username.nested")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not a map"))
+		})
+	})
+
+	Describe("PoC-CLAIMS-009: Empty claims map", func() {
+		It("should return error for any path on empty claims", func() {
+			_, err := auth.ExtractStringClaim(map[string]interface{}{}, "sub")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not found"))
+		})
+	})
+
+	Describe("PoC-CLAIMS-010: Non-string element in groups array", func() {
+		It("should return error when array contains non-string", func() {
+			claims := map[string]interface{}{
+				"groups": []interface{}{"valid-group", 42, "another-group"},
+			}
+			_, err := auth.ExtractGroupsClaim(claims, "groups")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("element 1"))
+			Expect(err.Error()).To(ContainSubstring("expected string"))
+		})
+	})
+
+	Describe("PoC-CLAIMS-011: sub claim (standard OIDC)", func() {
+		It("should extract sub from top level", func() {
+			val, err := auth.ExtractStringClaim(keycloakStandard, "sub")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(val).To(Equal("f:12345-abcde:jsmith"))
+		})
+	})
+})

--- a/test/unit/shared/auth/composite_auth_test.go
+++ b/test/unit/shared/auth/composite_auth_test.go
@@ -1,0 +1,193 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth_test
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/jordigilh/kubernaut/pkg/shared/auth"
+	testauth "github.com/jordigilh/kubernaut/test/shared/auth"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("CompositeAuthenticator — #1009", func() {
+	var (
+		mockJWKS   *testauth.MockJWKSServer
+		jwtAuth    *auth.JWTAuthenticator
+		mockK8s    *auth.MockAuthenticator
+		composite  *auth.CompositeAuthenticator
+		ctx        context.Context
+	)
+
+	BeforeEach(func() {
+		var err error
+		mockJWKS, err = testauth.NewMockJWKSServer("https://keycloak.example.com/realms/kubernaut")
+		Expect(err).NotTo(HaveOccurred())
+
+		jwtAuth, err = auth.NewJWTAuthenticator([]auth.JWTProviderEntry{
+			{
+				Issuer:        "https://keycloak.example.com/realms/kubernaut",
+				JWKSURL:       mockJWKS.JWKSURL(),
+				Audience:      "kubernaut-agent",
+				UsernameClaim: "preferred_username",
+				GroupsClaim:   "groups",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		mockK8s = &auth.MockAuthenticator{
+			ValidUsers: map[string]string{
+				"sa-token-valid": "system:serviceaccount:kubernaut-system:apifrontend",
+			},
+			ValidUsersFull: map[string]auth.UserInfo{
+				"sa-token-valid": {
+					Username:     "system:serviceaccount:kubernaut-system:apifrontend",
+					Groups:       []string{"system:serviceaccounts"},
+					ProviderType: "k8s:tokenreview",
+				},
+			},
+		}
+
+		composite = auth.NewCompositeAuthenticator(jwtAuth, mockK8s)
+		ctx = context.Background()
+	})
+
+	AfterEach(func() {
+		if mockJWKS != nil {
+			mockJWKS.Close()
+		}
+	})
+
+	Describe("UT-KA-1009-015: JWT-shaped token routed to JWTAuthenticator", func() {
+		It("should route a valid JWT to JWTAuthenticator and return correct identity", func() {
+			token, err := mockJWKS.IssueJWT("user-a@corp", []string{"interactive-users"}, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			userInfo, err := composite.ValidateTokenFull(ctx, token)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(userInfo.Username).To(Equal("user-a@corp"))
+			Expect(userInfo.Groups).To(ConsistOf("interactive-users"))
+			Expect(userInfo.ProviderType).To(HavePrefix("jwt:"))
+			Expect(mockK8s.CallCount).To(Equal(0))
+		})
+	})
+
+	Describe("UT-KA-1009-016: Known issuer with invalid signature → fail-closed", func() {
+		It("should NOT fallback to K8s when JWT has known issuer but invalid signature", func() {
+			otherServer, err := testauth.NewMockJWKSServer("https://keycloak.example.com/realms/kubernaut")
+			Expect(err).NotTo(HaveOccurred())
+			defer otherServer.Close()
+
+			token, err := otherServer.IssueJWT("attacker@corp", []string{"admin"}, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = composite.ValidateTokenFull(ctx, token)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, auth.ErrTokenInvalid)).To(BeTrue())
+			Expect(mockK8s.CallCount).To(Equal(0))
+		})
+	})
+
+	Describe("UT-KA-1009-017: Unknown issuer → fallback to K8sAuthenticator", func() {
+		It("should fallback to K8s when JWT issuer is not in configured providers", func() {
+			unknownServer, err := testauth.NewMockJWKSServer("https://unknown-issuer.example.com")
+			Expect(err).NotTo(HaveOccurred())
+			defer unknownServer.Close()
+
+			token, err := unknownServer.IssueJWT("user-x@corp", []string{"g1"}, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			mockK8s.ValidUsers[token] = "system:serviceaccount:kubernaut-system:unknown-sa"
+			mockK8s.ValidUsersFull[token] = auth.UserInfo{
+				Username:     "system:serviceaccount:kubernaut-system:unknown-sa",
+				Groups:       []string{"system:serviceaccounts"},
+				ProviderType: "k8s:tokenreview",
+			}
+
+			userInfo, err := composite.ValidateTokenFull(ctx, token)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(userInfo.Username).To(Equal("system:serviceaccount:kubernaut-system:unknown-sa"))
+			Expect(userInfo.ProviderType).To(Equal("k8s:tokenreview"))
+			Expect(mockK8s.CallCount).To(Equal(1))
+		})
+	})
+
+	Describe("UT-KA-1009-018: Opaque token → direct K8sAuthenticator", func() {
+		It("should route opaque (non-JWT) tokens directly to K8sAuthenticator", func() {
+			userInfo, err := composite.ValidateTokenFull(ctx, "sa-token-valid")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(userInfo.Username).To(Equal("system:serviceaccount:kubernaut-system:apifrontend"))
+			Expect(userInfo.ProviderType).To(Equal("k8s:tokenreview"))
+			Expect(mockK8s.CallCount).To(Equal(1))
+		})
+	})
+
+	Describe("UT-KA-1009-019: Empty token → error", func() {
+		It("should return an error for empty token without fallback", func() {
+			_, err := composite.ValidateTokenFull(ctx, "")
+			Expect(err).To(HaveOccurred())
+			Expect(mockK8s.CallCount).To(Equal(0))
+		})
+	})
+
+	Describe("UT-KA-1009-020: K8sAuthenticator error after fallback → propagated", func() {
+		It("should propagate K8s auth errors when falling back from unknown issuer", func() {
+			unknownServer, err := testauth.NewMockJWKSServer("https://unknown-issuer.example.com")
+			Expect(err).NotTo(HaveOccurred())
+			defer unknownServer.Close()
+
+			token, err := unknownServer.IssueJWT("user-x@corp", []string{"g1"}, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = composite.ValidateTokenFull(ctx, token)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, auth.ErrTokenInvalid)).To(BeTrue())
+		})
+	})
+
+	Describe("UT-KA-1009-021: Malformed JWT → fallback to K8s", func() {
+		It("should treat a malformed 3-part token as opaque and try K8s", func() {
+			malformedJWT := "not-base64.not-base64.not-base64"
+
+			mockK8s.ValidUsers[malformedJWT] = "system:serviceaccount:kubernaut-system:some-sa"
+			mockK8s.ValidUsersFull[malformedJWT] = auth.UserInfo{
+				Username:     "system:serviceaccount:kubernaut-system:some-sa",
+				Groups:       []string{"system:serviceaccounts"},
+				ProviderType: "k8s:tokenreview",
+			}
+
+			userInfo, err := composite.ValidateTokenFull(ctx, malformedJWT)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(userInfo.Username).To(Equal("system:serviceaccount:kubernaut-system:some-sa"))
+			Expect(mockK8s.CallCount).To(Equal(1))
+		})
+	})
+
+	Describe("ValidateToken convenience wrapper", func() {
+		It("should return username string via ValidateToken", func() {
+			token, err := mockJWKS.IssueJWT("user-a@corp", []string{"g1"}, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			username, err := composite.ValidateToken(ctx, token)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(username).To(Equal("user-a@corp"))
+		})
+	})
+})

--- a/test/unit/shared/auth/composite_auth_test.go
+++ b/test/unit/shared/auth/composite_auth_test.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/jordigilh/kubernaut/pkg/shared/auth"
 	testauth "github.com/jordigilh/kubernaut/test/shared/auth"
 	. "github.com/onsi/ginkgo/v2"
@@ -49,7 +50,7 @@ var _ = Describe("CompositeAuthenticator — #1009", func() {
 				UsernameClaim: "preferred_username",
 				GroupsClaim:   "groups",
 			},
-		})
+		}, logr.Discard())
 		Expect(err).NotTo(HaveOccurred())
 
 		mockK8s = &auth.MockAuthenticator{

--- a/test/unit/shared/auth/jwt_auth_test.go
+++ b/test/unit/shared/auth/jwt_auth_test.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/jordigilh/kubernaut/pkg/shared/auth"
 	testauth "github.com/jordigilh/kubernaut/test/shared/auth"
 	. "github.com/onsi/ginkgo/v2"
@@ -50,7 +51,7 @@ var _ = Describe("JWTAuthenticator — #1009", func() {
 				UsernameClaim: "preferred_username",
 				GroupsClaim:   "groups",
 			},
-		})
+		}, logr.Discard())
 		Expect(err).NotTo(HaveOccurred())
 		ctx = context.Background()
 	})
@@ -98,7 +99,7 @@ var _ = Describe("JWTAuthenticator — #1009", func() {
 					UsernameClaim: "preferred_username",
 					GroupsClaim:   "realm_access.roles",
 				},
-			})
+			}, logr.Discard())
 			Expect(err).NotTo(HaveOccurred())
 
 			token, err := mockServer.IssueJWTWithClaims("user-a", "kubernaut-agent", 5*time.Minute, map[string]interface{}{
@@ -238,7 +239,7 @@ var _ = Describe("JWTAuthenticator — #1009", func() {
 					UsernameClaim: "preferred_username",
 					GroupsClaim:   "groups",
 				},
-			})
+			}, logr.Discard())
 			Expect(err).NotTo(HaveOccurred())
 
 			token1, err := mockServer.IssueJWT("user-from-kc@corp", []string{"g1"}, "kubernaut-agent", 5*time.Minute)
@@ -278,7 +279,7 @@ var _ = Describe("JWTAuthenticator — #1009", func() {
 					UsernameClaim: "preferred_username",
 					GroupsClaim:   "groups",
 				},
-			})
+			}, logr.Discard())
 			Expect(err).NotTo(HaveOccurred())
 
 			// Token signed by issuer-two's key but claiming to be from keycloak

--- a/test/unit/shared/auth/jwt_auth_test.go
+++ b/test/unit/shared/auth/jwt_auth_test.go
@@ -1,0 +1,335 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package auth_test
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jordigilh/kubernaut/pkg/shared/auth"
+	testauth "github.com/jordigilh/kubernaut/test/shared/auth"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("JWTAuthenticator — #1009", func() {
+	var (
+		mockServer *testauth.MockJWKSServer
+		jwtAuth    *auth.JWTAuthenticator
+		ctx        context.Context
+	)
+
+	BeforeEach(func() {
+		var err error
+		mockServer, err = testauth.NewMockJWKSServer("https://keycloak.example.com/realms/kubernaut")
+		Expect(err).NotTo(HaveOccurred())
+
+		jwtAuth, err = auth.NewJWTAuthenticator([]auth.JWTProviderEntry{
+			{
+				Issuer:        "https://keycloak.example.com/realms/kubernaut",
+				JWKSURL:       mockServer.JWKSURL(),
+				Audience:      "kubernaut-agent",
+				UsernameClaim: "preferred_username",
+				GroupsClaim:   "groups",
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		ctx = context.Background()
+	})
+
+	AfterEach(func() {
+		if mockServer != nil {
+			mockServer.Close()
+		}
+	})
+
+	Describe("UT-KA-1009-001: Valid JWT accepted with correct identity extraction", func() {
+		It("should return correct UserInfo from a valid JWT", func() {
+			token, err := mockServer.IssueJWT("user-a@corp", []string{"kubernaut-interactive-users"}, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			userInfo, err := jwtAuth.ValidateTokenFull(ctx, token)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(userInfo.Username).To(Equal("user-a@corp"))
+			Expect(userInfo.Groups).To(ConsistOf("kubernaut-interactive-users"))
+			Expect(userInfo.ProviderType).To(HavePrefix("jwt:"))
+		})
+	})
+
+	Describe("UT-KA-1009-002: Username extracted from preferred_username claim", func() {
+		It("should use the configured username claim path", func() {
+			token, err := mockServer.IssueJWTWithClaims("sub-value", "kubernaut-agent", 5*time.Minute, map[string]interface{}{
+				"preferred_username": "display-name@corp",
+				"groups":             []string{"group-a"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			userInfo, err := jwtAuth.ValidateTokenFull(ctx, token)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(userInfo.Username).To(Equal("display-name@corp"))
+		})
+	})
+
+	Describe("UT-KA-1009-003: Groups extracted from nested claim path", func() {
+		It("should extract groups from a dot-notation path like realm_access.roles", func() {
+			nestedAuth, err := auth.NewJWTAuthenticator([]auth.JWTProviderEntry{
+				{
+					Issuer:        "https://keycloak.example.com/realms/kubernaut",
+					JWKSURL:       mockServer.JWKSURL(),
+					Audience:      "kubernaut-agent",
+					UsernameClaim: "preferred_username",
+					GroupsClaim:   "realm_access.roles",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			token, err := mockServer.IssueJWTWithClaims("user-a", "kubernaut-agent", 5*time.Minute, map[string]interface{}{
+				"preferred_username": "user-a@corp",
+				"realm_access": map[string]interface{}{
+					"roles": []interface{}{"admin", "operator"},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			userInfo, err := nestedAuth.ValidateTokenFull(ctx, token)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(userInfo.Groups).To(ConsistOf("admin", "operator"))
+		})
+	})
+
+	Describe("UT-KA-1009-005: Top-level groups claim extracted", func() {
+		It("should extract groups from a simple top-level claim", func() {
+			token, err := mockServer.IssueJWTWithClaims("user-b", "kubernaut-agent", 5*time.Minute, map[string]interface{}{
+				"preferred_username": "user-b@corp",
+				"groups":             []interface{}{"sre-team", "kubernaut-users"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			userInfo, err := jwtAuth.ValidateTokenFull(ctx, token)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(userInfo.Groups).To(ConsistOf("sre-team", "kubernaut-users"))
+		})
+	})
+
+	Describe("UT-KA-1009-006: Expired JWT rejected", func() {
+		It("should return ErrTokenInvalid for an expired token", func() {
+			token, err := mockServer.IssueJWT("user-a@corp", []string{"group-a"}, "kubernaut-agent", -1*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = jwtAuth.ValidateTokenFull(ctx, token)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, auth.ErrTokenInvalid)).To(BeTrue())
+		})
+	})
+
+	Describe("UT-KA-1009-007: JWT with wrong audience rejected", func() {
+		It("should return ErrTokenInvalid when audience doesn't match", func() {
+			token, err := mockServer.IssueJWT("user-a@corp", []string{"group-a"}, "wrong-audience", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = jwtAuth.ValidateTokenFull(ctx, token)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, auth.ErrTokenInvalid)).To(BeTrue())
+		})
+	})
+
+	Describe("UT-KA-1009-008: JWT with alg:none rejected (alg confusion attack)", func() {
+		It("should reject an unsigned JWT with alg:none", func() {
+			header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
+			payload, err := json.Marshal(map[string]interface{}{
+				"iss":                "https://keycloak.example.com/realms/kubernaut",
+				"sub":               "attacker",
+				"aud":               "kubernaut-agent",
+				"exp":               time.Now().Add(5 * time.Minute).Unix(),
+				"iat":               time.Now().Unix(),
+				"preferred_username": "attacker@corp",
+				"groups":            []string{"admin"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			algNoneToken := fmt.Sprintf("%s.%s.", header, base64.RawURLEncoding.EncodeToString(payload))
+
+			_, err = jwtAuth.ValidateTokenFull(ctx, algNoneToken)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, auth.ErrTokenInvalid)).To(BeTrue(),
+				"alg:none tokens must be rejected as invalid, not accepted")
+		})
+	})
+
+	Describe("UT-KA-1009-009: JWT signed by unknown key rejected", func() {
+		It("should return ErrTokenInvalid when signature doesn't match JWKS", func() {
+			otherServer, err := testauth.NewMockJWKSServer("https://keycloak.example.com/realms/kubernaut")
+			Expect(err).NotTo(HaveOccurred())
+			defer otherServer.Close()
+
+			token, err := otherServer.IssueJWT("user-a@corp", []string{"group-a"}, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = jwtAuth.ValidateTokenFull(ctx, token)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, auth.ErrTokenInvalid)).To(BeTrue())
+		})
+	})
+
+	Describe("UT-KA-1009-010: JWT from unknown issuer returns ErrIssuerNotFound", func() {
+		It("should return ErrIssuerNotFound (not ErrTokenInvalid) for an unknown issuer", func() {
+			unknownServer, err := testauth.NewMockJWKSServer("https://unknown-issuer.example.com")
+			Expect(err).NotTo(HaveOccurred())
+			defer unknownServer.Close()
+
+			token, err := unknownServer.IssueJWT("user-a@corp", []string{"group-a"}, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = jwtAuth.ValidateTokenFull(ctx, token)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, auth.ErrIssuerNotFound)).To(BeTrue())
+			Expect(errors.Is(err, auth.ErrTokenInvalid)).To(BeFalse())
+		})
+	})
+
+	Describe("UT-KA-1009-011: JWT with missing username claim rejected", func() {
+		It("should return an error when the configured username claim is absent", func() {
+			token, err := mockServer.IssueJWTWithClaims("sub-only", "kubernaut-agent", 5*time.Minute, map[string]interface{}{
+				"groups": []string{"group-a"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = jwtAuth.ValidateTokenFull(ctx, token)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("preferred_username"))
+		})
+	})
+
+	Describe("UT-KA-1009-012: Multi-issuer tokens routed correctly", func() {
+		It("should route tokens to the correct JWKS endpoint by issuer claim", func() {
+			secondServer, err := testauth.NewMockJWKSServer("https://issuer-two.example.com")
+			Expect(err).NotTo(HaveOccurred())
+			defer secondServer.Close()
+
+			multiAuth, err := auth.NewJWTAuthenticator([]auth.JWTProviderEntry{
+				{
+					Issuer:        "https://keycloak.example.com/realms/kubernaut",
+					JWKSURL:       mockServer.JWKSURL(),
+					Audience:      "kubernaut-agent",
+					UsernameClaim: "preferred_username",
+					GroupsClaim:   "groups",
+				},
+				{
+					Issuer:        "https://issuer-two.example.com",
+					JWKSURL:       secondServer.JWKSURL(),
+					Audience:      "kubernaut-agent",
+					UsernameClaim: "preferred_username",
+					GroupsClaim:   "groups",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			token1, err := mockServer.IssueJWT("user-from-kc@corp", []string{"g1"}, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			token2, err := secondServer.IssueJWT("user-from-two@corp", []string{"g2"}, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			info1, err := multiAuth.ValidateTokenFull(ctx, token1)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info1.Username).To(Equal("user-from-kc@corp"))
+
+			info2, err := multiAuth.ValidateTokenFull(ctx, token2)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info2.Username).To(Equal("user-from-two@corp"))
+		})
+	})
+
+	Describe("UT-KA-1009-013: Cross-provider rejection", func() {
+		It("should reject a token signed by issuer-A when routed to issuer-B's JWKS", func() {
+			secondServer, err := testauth.NewMockJWKSServer("https://issuer-two.example.com")
+			Expect(err).NotTo(HaveOccurred())
+			defer secondServer.Close()
+
+			multiAuth, err := auth.NewJWTAuthenticator([]auth.JWTProviderEntry{
+				{
+					Issuer:        "https://keycloak.example.com/realms/kubernaut",
+					JWKSURL:       mockServer.JWKSURL(),
+					Audience:      "kubernaut-agent",
+					UsernameClaim: "preferred_username",
+					GroupsClaim:   "groups",
+				},
+				{
+					Issuer:        "https://issuer-two.example.com",
+					JWKSURL:       secondServer.JWKSURL(),
+					Audience:      "kubernaut-agent",
+					UsernameClaim: "preferred_username",
+					GroupsClaim:   "groups",
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// Token signed by issuer-two's key but claiming to be from keycloak
+			tokenFromTwo, err := secondServer.IssueJWTWithClaims("attacker", "kubernaut-agent", 5*time.Minute, map[string]interface{}{
+				"preferred_username": "attacker@corp",
+				"groups":             []string{"admin"},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			// The issuer claim is "https://issuer-two.example.com" so it routes to
+			// issuer-two's JWKS. But if we forge the iss claim to keycloak, it
+			// should fail because the signature won't match keycloak's JWKS.
+			// This test validates correct routing by iss claim.
+			info, err := multiAuth.ValidateTokenFull(ctx, tokenFromTwo)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.Username).To(Equal("attacker@corp"))
+
+			// Now create a token with keycloak issuer but signed by issuer-two's key
+			// (This simulates a cross-provider attack)
+			forgedToken, err := secondServer.IssueJWTWithClaims("attacker", "kubernaut-agent", 5*time.Minute, map[string]interface{}{
+				"preferred_username": "attacker@corp",
+				"groups":             []string{"admin"},
+				"iss":                "https://keycloak.example.com/realms/kubernaut",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = multiAuth.ValidateTokenFull(ctx, forgedToken)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, auth.ErrTokenInvalid)).To(BeTrue())
+		})
+	})
+
+	Describe("UT-KA-1009-014: ProviderType set on successful validation", func() {
+		It("should set ProviderType to jwt:<issuer>", func() {
+			token, err := mockServer.IssueJWT("user-a@corp", []string{"g1"}, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			userInfo, err := jwtAuth.ValidateTokenFull(ctx, token)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(userInfo.ProviderType).To(Equal("jwt:https://keycloak.example.com/realms/kubernaut"))
+		})
+	})
+
+	Describe("UT-KA-1009-ValidateToken: ValidateToken convenience wrapper", func() {
+		It("should return username string from ValidateToken", func() {
+			token, err := mockServer.IssueJWT("user-a@corp", []string{"g1"}, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			username, err := jwtAuth.ValidateToken(ctx, token)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(username).To(Equal("user-a@corp"))
+		})
+	})
+})

--- a/test/unit/shared/auth/jwt_auth_test.go
+++ b/test/unit/shared/auth/jwt_auth_test.go
@@ -27,6 +27,9 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/jordigilh/kubernaut/pkg/shared/auth"
 	testauth "github.com/jordigilh/kubernaut/test/shared/auth"
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwk"
+	"github.com/lestrrat-go/jwx/v3/jwt"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -113,6 +116,39 @@ var _ = Describe("JWTAuthenticator — #1009", func() {
 			userInfo, err := nestedAuth.ValidateTokenFull(ctx, token)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(userInfo.Groups).To(ConsistOf("admin", "operator"))
+		})
+	})
+
+	// QE-9 / UT-KA-1009-004: Full ValidateTokenFull with double-nested Keycloak claims
+	Describe("UT-KA-1009-004: Groups extracted from double-nested claim path via ValidateTokenFull", func() {
+		It("should extract groups from resource_access.<client>.roles end-to-end", func() {
+			doubleNestedAuth, err := auth.NewJWTAuthenticator([]auth.JWTProviderEntry{
+				{
+					Issuer:        "https://keycloak.example.com/realms/kubernaut",
+					JWKSURL:       mockServer.JWKSURL(),
+					Audience:      "kubernaut-agent",
+					UsernameClaim: "preferred_username",
+					GroupsClaim:   "resource_access.kubernaut-agent.roles",
+				},
+			}, logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+			defer doubleNestedAuth.Close()
+
+			token, err := mockServer.IssueJWTWithClaims("user-kc", "kubernaut-agent", 5*time.Minute, map[string]interface{}{
+				"preferred_username": "user-kc@corp",
+				"resource_access": map[string]interface{}{
+					"kubernaut-agent": map[string]interface{}{
+						"roles": []interface{}{"interactive-user", "viewer"},
+					},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			userInfo, err := doubleNestedAuth.ValidateTokenFull(ctx, token)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(userInfo.Username).To(Equal("user-kc@corp"))
+			Expect(userInfo.Groups).To(ConsistOf("interactive-user", "viewer"))
+			Expect(userInfo.ProviderType).To(Equal("jwt:https://keycloak.example.com/realms/kubernaut"))
 		})
 	})
 
@@ -331,6 +367,121 @@ var _ = Describe("JWTAuthenticator — #1009", func() {
 			username, err := jwtAuth.ValidateToken(ctx, token)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(username).To(Equal("user-a@corp"))
+		})
+	})
+
+	// QE-5: JWKS runtime failure — cached keys survive server shutdown (defense-in-depth)
+	Describe("QE-5: JWKS cache resilience after server shutdown", func() {
+		It("should still validate tokens using cached keys after JWKS server goes down", func() {
+			runtimeServer, err := testauth.NewMockJWKSServer("https://runtime-fail.example.com")
+			Expect(err).NotTo(HaveOccurred())
+
+			runtimeAuth, err := auth.NewJWTAuthenticator([]auth.JWTProviderEntry{
+				{
+					Issuer:        "https://runtime-fail.example.com",
+					JWKSURL:       runtimeServer.JWKSURL(),
+					Audience:      "kubernaut-agent",
+					UsernameClaim: "preferred_username",
+					GroupsClaim:   "groups",
+				},
+			}, logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+			defer runtimeAuth.Close()
+
+			token, err := runtimeServer.IssueJWT("user@corp", []string{"g1"}, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			info, err := runtimeAuth.ValidateTokenFull(ctx, token)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.Username).To(Equal("user@corp"))
+
+			runtimeServer.Close()
+
+			// Cached JWKS keys survive — existing tokens still validate
+			info, err = runtimeAuth.ValidateTokenFull(ctx, token)
+			Expect(err).NotTo(HaveOccurred(),
+				"cached JWKS keys should allow validation even after server shutdown")
+			Expect(info.Username).To(Equal("user@corp"))
+		})
+	})
+
+	// QE-6: Concurrent ValidateTokenFull stress test
+	Describe("QE-6: Concurrent token validation (race condition check)", func() {
+		It("should handle concurrent validations without races", func() {
+			const goroutines = 20
+			tokens := make([]string, goroutines)
+			for i := 0; i < goroutines; i++ {
+				t, err := mockServer.IssueJWT(
+					fmt.Sprintf("user-%d@corp", i),
+					[]string{"g1"},
+					"kubernaut-agent",
+					5*time.Minute,
+				)
+				Expect(err).NotTo(HaveOccurred())
+				tokens[i] = t
+			}
+
+			errs := make(chan error, goroutines)
+			for i := 0; i < goroutines; i++ {
+				go func(idx int) {
+					_, err := jwtAuth.ValidateTokenFull(ctx, tokens[idx])
+					errs <- err
+				}(i)
+			}
+
+			for i := 0; i < goroutines; i++ {
+				err := <-errs
+				Expect(err).NotTo(HaveOccurred(), "goroutine %d should succeed", i)
+			}
+		})
+	})
+
+	// QE-7: nbf (not-before) enforcement
+	Describe("QE-7: JWT with future nbf rejected", func() {
+		It("should reject a token whose not-before is in the future", func() {
+			now := time.Now()
+			token, err := mockServer.IssueJWTWithClaims("user@corp", "kubernaut-agent", 5*time.Minute, map[string]interface{}{
+				"preferred_username": "user@corp",
+				"groups":             []string{"g1"},
+				"nbf":               now.Add(1 * time.Hour).Unix(),
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = jwtAuth.ValidateTokenFull(ctx, token)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, auth.ErrTokenInvalid)).To(BeTrue(),
+				"future nbf should be rejected as ErrTokenInvalid")
+		})
+	})
+
+	// QE-8: aud as array (Keycloak multi-audience)
+	Describe("QE-8: JWT with aud as array accepted", func() {
+		It("should accept a token with audience as array containing the expected value", func() {
+			now := time.Now()
+			builder := jwt.NewBuilder().
+				Subject("user@corp").
+				Issuer("https://keycloak.example.com/realms/kubernaut").
+				IssuedAt(now).
+				NotBefore(now).
+				Expiration(now.Add(5 * time.Minute)).
+				Audience([]string{"kubernaut-agent", "another-service"})
+
+			token, err := builder.Build()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(token.Set("preferred_username", "user@corp")).To(Succeed())
+			Expect(token.Set("groups", []string{"g1"})).To(Succeed())
+
+			privJWK, err := jwk.Import(mockServer.PrivateKey)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(privJWK.Set(jwk.KeyIDKey, "test-key-1")).To(Succeed())
+			Expect(privJWK.Set(jwk.AlgorithmKey, jwa.RS256())).To(Succeed())
+
+			signed, err := jwt.Sign(token, jwt.WithKey(jwa.RS256(), privJWK))
+			Expect(err).NotTo(HaveOccurred())
+
+			info, err := jwtAuth.ValidateTokenFull(ctx, string(signed))
+			Expect(err).NotTo(HaveOccurred())
+			Expect(info.Username).To(Equal("user@corp"))
 		})
 	})
 })

--- a/test/unit/shared/auth/jwt_jwks_poc_test.go
+++ b/test/unit/shared/auth/jwt_jwks_poc_test.go
@@ -1,0 +1,302 @@
+package auth_test
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"time"
+
+	"github.com/lestrrat-go/httprc/v3"
+	"github.com/lestrrat-go/jwx/v3/jwa"
+	"github.com/lestrrat-go/jwx/v3/jwk"
+	"github.com/lestrrat-go/jwx/v3/jwt"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	testauth "github.com/jordigilh/kubernaut/test/shared/auth"
+)
+
+// newTestCache creates a jwk.Cache with an httprc.Client suitable for tests.
+func newTestCache(ctx context.Context) (*jwk.Cache, error) {
+	return jwk.NewCache(ctx, httprc.NewClient())
+}
+
+var _ = Describe("PoC: JWKS + JWT validation with lestrrat-go/jwx/v3", func() {
+
+	var (
+		mockServer *testauth.MockJWKSServer
+	)
+
+	BeforeEach(func() {
+		var err error
+		mockServer, err = testauth.NewMockJWKSServer("https://sso.example.com/realms/kubernaut")
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		mockServer.Close()
+	})
+
+	Describe("PoC-JWKS-001: Issue and verify JWT with JWKS endpoint", func() {
+		It("should sign a JWT with mock RSA key and verify via JWKS", func() {
+			tokenStr, err := mockServer.IssueJWT("jsmith@corp.com", []string{"sre-team"}, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tokenStr).NotTo(BeEmpty())
+
+			ctx := context.Background()
+			cache, err := newTestCache(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			err = cache.Register(ctx, mockServer.JWKSURL())
+			Expect(err).NotTo(HaveOccurred())
+
+			keyset, err := cache.Lookup(ctx, mockServer.JWKSURL())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(keyset).NotTo(BeNil())
+
+			verified, err := jwt.Parse([]byte(tokenStr), jwt.WithKeySet(keyset))
+			Expect(err).NotTo(HaveOccurred())
+
+			sub, ok := verified.Subject()
+			Expect(ok).To(BeTrue())
+			Expect(sub).To(Equal("jsmith@corp.com"))
+
+			iss, ok := verified.Issuer()
+			Expect(ok).To(BeTrue())
+			Expect(iss).To(Equal("https://sso.example.com/realms/kubernaut"))
+		})
+	})
+
+	Describe("PoC-JWKS-002: JWT with wrong key is rejected", func() {
+		It("should reject a JWT signed with a different RSA key", func() {
+			wrongKey, err := rsa.GenerateKey(rand.Reader, 2048)
+			Expect(err).NotTo(HaveOccurred())
+
+			wrongJWK, err := jwk.Import(wrongKey)
+			Expect(err).NotTo(HaveOccurred())
+			_ = wrongJWK.Set(jwk.KeyIDKey, "wrong-key")
+			_ = wrongJWK.Set(jwk.AlgorithmKey, jwa.RS256())
+
+			token, err := jwt.NewBuilder().
+				Subject("attacker").
+				Issuer("https://sso.example.com/realms/kubernaut").
+				Expiration(time.Now().Add(5 * time.Minute)).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			signed, err := jwt.Sign(token, jwt.WithKey(jwa.RS256(), wrongJWK))
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx := context.Background()
+			cache, err := newTestCache(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			err = cache.Register(ctx, mockServer.JWKSURL())
+			Expect(err).NotTo(HaveOccurred())
+
+			keyset, err := cache.Lookup(ctx, mockServer.JWKSURL())
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = jwt.Parse(signed, jwt.WithKeySet(keyset))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("PoC-JWKS-003: Expired JWT is rejected", func() {
+		It("should reject a JWT that has expired", func() {
+			tokenStr, err := mockServer.IssueJWT("jsmith@corp.com", []string{"sre-team"}, "kubernaut-agent", -1*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx := context.Background()
+			cache, err := newTestCache(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			err = cache.Register(ctx, mockServer.JWKSURL())
+			Expect(err).NotTo(HaveOccurred())
+
+			keyset, err := cache.Lookup(ctx, mockServer.JWKSURL())
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = jwt.Parse([]byte(tokenStr), jwt.WithKeySet(keyset))
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("PoC-JWKS-004: Audience validation", func() {
+		It("should reject a JWT with wrong audience when audience is validated", func() {
+			tokenStr, err := mockServer.IssueJWT("jsmith@corp.com", []string{"sre-team"}, "wrong-audience", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx := context.Background()
+			cache, err := newTestCache(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			err = cache.Register(ctx, mockServer.JWKSURL())
+			Expect(err).NotTo(HaveOccurred())
+
+			keyset, err := cache.Lookup(ctx, mockServer.JWKSURL())
+			Expect(err).NotTo(HaveOccurred())
+
+			// Signature should pass, then we check audience manually
+			verified, err := jwt.Parse([]byte(tokenStr), jwt.WithKeySet(keyset))
+			Expect(err).NotTo(HaveOccurred())
+
+			aud, ok := verified.Audience()
+			Expect(ok).To(BeTrue())
+			Expect(aud).To(ConsistOf("wrong-audience"))
+			Expect(aud).NotTo(ContainElement("kubernaut-agent"))
+		})
+	})
+
+	Describe("PoC-JWKS-005: Extract custom claims from verified JWT", func() {
+		It("should extract Keycloak-style claims after verification", func() {
+			claims := map[string]interface{}{
+				"preferred_username": "jsmith@corp.com",
+				"groups":             []string{"sre-team", "kubernaut-interactive-users"},
+				"realm_access": map[string]interface{}{
+					"roles": []string{"kubernaut-user", "offline_access"},
+				},
+			}
+			tokenStr, err := mockServer.IssueJWTWithClaims("jsmith@corp.com", "kubernaut-agent", 5*time.Minute, claims)
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx := context.Background()
+			cache, err := newTestCache(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			err = cache.Register(ctx, mockServer.JWKSURL())
+			Expect(err).NotTo(HaveOccurred())
+
+			keyset, err := cache.Lookup(ctx, mockServer.JWKSURL())
+			Expect(err).NotTo(HaveOccurred())
+
+			verified, err := jwt.Parse([]byte(tokenStr), jwt.WithKeySet(keyset))
+			Expect(err).NotTo(HaveOccurred())
+
+			// Extract private claims by marshaling to JSON
+			claimsMap := make(map[string]interface{})
+			data, err := json.Marshal(verified)
+			Expect(err).NotTo(HaveOccurred())
+			err = json.Unmarshal(data, &claimsMap)
+			Expect(err).NotTo(HaveOccurred())
+
+			username, ok := claimsMap["preferred_username"].(string)
+			Expect(ok).To(BeTrue())
+			Expect(username).To(Equal("jsmith@corp.com"))
+
+			realmAccess, ok := claimsMap["realm_access"].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			roles, ok := realmAccess["roles"].([]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(roles).To(ContainElement("kubernaut-user"))
+		})
+	})
+
+	Describe("PoC-JWKS-006: Issuer-based routing simulation", func() {
+		It("should route to correct JWKS based on JWT issuer claim", func() {
+			server1, err := testauth.NewMockJWKSServer("https://issuer-one.example.com")
+			Expect(err).NotTo(HaveOccurred())
+			defer server1.Close()
+
+			server2, err := testauth.NewMockJWKSServer("https://issuer-two.example.com")
+			Expect(err).NotTo(HaveOccurred())
+			defer server2.Close()
+
+			providerMap := map[string]string{
+				"https://issuer-one.example.com": server1.JWKSURL(),
+				"https://issuer-two.example.com": server2.JWKSURL(),
+			}
+
+			token1, err := server1.IssueJWT("user1@one.com", nil, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			token2, err := server2.IssueJWT("user2@two.com", nil, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx := context.Background()
+
+			for _, tc := range []struct {
+				tokenStr    string
+				expectedSub string
+			}{
+				{token1, "user1@one.com"},
+				{token2, "user2@two.com"},
+			} {
+				// Parse without verification to extract issuer
+				unverified, err := jwt.Parse([]byte(tc.tokenStr), jwt.WithVerify(false), jwt.WithValidate(false))
+				Expect(err).NotTo(HaveOccurred())
+
+				iss, ok := unverified.Issuer()
+				Expect(ok).To(BeTrue())
+				jwksURL, found := providerMap[iss]
+				Expect(found).To(BeTrue(), "issuer %q not in provider map", iss)
+
+				// Fetch the correct JWKS
+				cache, err := newTestCache(ctx)
+				Expect(err).NotTo(HaveOccurred())
+				err = cache.Register(ctx, jwksURL)
+				Expect(err).NotTo(HaveOccurred())
+
+				keyset, err := cache.Lookup(ctx, jwksURL)
+				Expect(err).NotTo(HaveOccurred())
+
+				// Verify with correct provider's JWKS
+				verified, err := jwt.Parse([]byte(tc.tokenStr), jwt.WithKeySet(keyset))
+				Expect(err).NotTo(HaveOccurred())
+				sub, ok := verified.Subject()
+				Expect(ok).To(BeTrue())
+				Expect(sub).To(Equal(tc.expectedSub))
+			}
+		})
+	})
+
+	Describe("PoC-JWKS-007: Cross-provider JWT rejection", func() {
+		It("should reject a JWT from issuer-one when verified with issuer-two's JWKS", func() {
+			server1, err := testauth.NewMockJWKSServer("https://issuer-one.example.com")
+			Expect(err).NotTo(HaveOccurred())
+			defer server1.Close()
+
+			server2, err := testauth.NewMockJWKSServer("https://issuer-two.example.com")
+			Expect(err).NotTo(HaveOccurred())
+			defer server2.Close()
+
+			token1, err := server1.IssueJWT("user1@one.com", nil, "kubernaut-agent", 5*time.Minute)
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx := context.Background()
+			cache, err := newTestCache(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			err = cache.Register(ctx, server2.JWKSURL())
+			Expect(err).NotTo(HaveOccurred())
+
+			keyset2, err := cache.Lookup(ctx, server2.JWKSURL())
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = jwt.Parse([]byte(token1), jwt.WithKeySet(keyset2))
+			Expect(err).To(HaveOccurred(), "cross-provider verification must fail")
+		})
+	})
+
+	Describe("PoC-JWKS-008: alg:none rejection", func() {
+		It("should confirm jwx rejects unsigned tokens when verifying with JWKS", func() {
+			token, err := jwt.NewBuilder().
+				Subject("attacker").
+				Issuer("https://sso.example.com/realms/kubernaut").
+				Expiration(time.Now().Add(5 * time.Minute)).
+				Build()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Sign with "none" algorithm
+			unsigned, err := jwt.Sign(token, jwt.WithInsecureNoSignature())
+			Expect(err).NotTo(HaveOccurred())
+
+			ctx := context.Background()
+			cache, err := newTestCache(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			err = cache.Register(ctx, mockServer.JWKSURL())
+			Expect(err).NotTo(HaveOccurred())
+
+			keyset, err := cache.Lookup(ctx, mockServer.JWKSURL())
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = jwt.Parse(unsigned, jwt.WithKeySet(keyset))
+			Expect(err).To(HaveOccurred(), "unsigned (alg:none) tokens must be rejected when verifying with JWKS")
+		})
+	})
+})

--- a/test/unit/shared/auth/k8s_auth_test.go
+++ b/test/unit/shared/auth/k8s_auth_test.go
@@ -116,6 +116,28 @@ var _ = Describe("K8sAuthenticator", func() {
 			Expect(user).To(BeEmpty())
 		})
 	})
+
+	Context("UT-KA-1009-023: ProviderType set on successful K8s authentication", func() {
+		It("should set ProviderType to 'k8s:tokenreview' on ValidateTokenFull", func() {
+			fakeClient.PrependReactor("create", "tokenreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				createAction := action.(k8stesting.CreateAction)
+				review := createAction.GetObject().(*authenticationv1.TokenReview)
+				review.Status = authenticationv1.TokenReviewStatus{
+					Authenticated: true,
+					User: authenticationv1.UserInfo{
+						Username: "system:serviceaccount:kubernaut-system:apifrontend",
+						Groups:   []string{"system:serviceaccounts"},
+					},
+				}
+				return true, review, nil
+			})
+
+			userInfo, err := authenticator.ValidateTokenFull(ctx, "valid-sa-token")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(userInfo.Username).To(Equal("system:serviceaccount:kubernaut-system:apifrontend"))
+			Expect(userInfo.ProviderType).To(Equal("k8s:tokenreview"))
+		})
+	})
 })
 
 var _ = Describe("K8sAuthorizer", func() {


### PR DESCRIPTION
## Summary

- **JWT/OIDC authentication (Pattern B)**: Adds `JWTAuthenticator` with multi-issuer JWKS validation, `alg:none` rejection, JWKS pre-warm with 15s timeout, and graceful shutdown via `Close()`. `CompositeAuthenticator` routes JWT-first with K8s SA token fallback, fail-closed semantics.
- **main.go wiring + Helm**: Wires `CompositeAuthenticator` in kubernaut-agent startup. Fixes critical defer scope bug where `authCleanup` was called inside chi's route-setup closure (causing immediate JWKS context cancellation). Adds Helm chart `jwtProviders` config with schema validation.
- **Comprehensive test coverage**: 22 unit tests (JWT validation, composite routing, claims extraction, config validation), integration tests (full middleware pipeline), and 5 E2E tests with DEX OIDC provider deployed in-cluster (valid JWT, forged JWT rejection, Pattern A+B coexistence, tool invocation, token structure validation).
- **Architecture docs**: Updated DD-AUTH-MCP-001 v2.0 for dual-pattern auth. Added formal #1009 test plan with scenario IDs across all tiers.

Also includes prior commits: #1012 select_workflow internalization, #891 startup SAR self-check, and PR #1018 review feedback fixes.

## Business Requirements

- BR-INTERACTIVE-002: JWT/OIDC authentication for interactive MCP sessions
- BR-SECURITY-001: Token validation security (alg:none, JWKS poisoning)

## Test Plan

- [x] Unit tests: 22 scenarios pass (UT-KA-1009-001 through UT-KA-1009-008, composite, claims, config)
- [x] Integration tests: JWT middleware pipeline with RBAC
- [x] E2E tests: 5/5 pass with DEX OIDC in Kind cluster (E2E-KA-JWT-001 through 005)
- [x] Existing E2E suite: 81/81 pass (no regression)
- [x] Build: `go build ./...` clean
- [ ] Full CI pipeline validation


Made with [Cursor](https://cursor.com)