### PR TITLE
feat(audit): add apifrontend event category and 11 payload schemas (#1021)

### DIFF
--- a/api/openapi/data-storage-v1.yaml
+++ b/api/openapi/data-storage-v1.yaml
@@ -2365,7 +2365,7 @@ components:
           type: string
           minLength: 1
           maxLength: 50
-          enum: [gateway, notification, analysis, aiagent, signalprocessing, workflow, workflowexecution, orchestration, approval, effectiveness, actiontype]
+          enum: [gateway, notification, analysis, aiagent, signalprocessing, workflow, workflowexecution, orchestration, approval, effectiveness, actiontype, apifrontend]
           description: |
             Domain-level event category (ADR-034 v1.8, Issue #306).
             Per convention: event_category identifies the business domain of the event.
@@ -2382,6 +2382,7 @@ components:
             - approval: Remediation approval request decision events
             - effectiveness: Effectiveness assessment and monitoring events
             - actiontype: ActionType taxonomy lifecycle events (Issue #300)
+            - apifrontend: API Frontend service — triage, session, delegation, and user decision events (Issue #1021)
           example: gateway
         event_action:
           type: string
@@ -2487,6 +2488,17 @@ components:
             - $ref: '#/components/schemas/ActionTypeCatalogReenabledPayload'
             - $ref: '#/components/schemas/ActionTypeCatalogDisableDeniedPayload'
             - $ref: '#/components/schemas/ActionTypeWebhookAuditPayload'
+            - $ref: '#/components/schemas/ApifrontendTriageStartedPayload'
+            - $ref: '#/components/schemas/ApifrontendTriageCompletedPayload'
+            - $ref: '#/components/schemas/ApifrontendRRCreatedPayload'
+            - $ref: '#/components/schemas/ApifrontendRRDeduplicatedPayload'
+            - $ref: '#/components/schemas/ApifrontendSessionCreatedPayload'
+            - $ref: '#/components/schemas/ApifrontendSessionCompletedPayload'
+            - $ref: '#/components/schemas/ApifrontendKADelegatedPayload'
+            - $ref: '#/components/schemas/ApifrontendKAResultReceivedPayload'
+            - $ref: '#/components/schemas/ApifrontendUserDecisionPayload'
+            - $ref: '#/components/schemas/ApifrontendAuthAccessDeniedPayload'
+            - $ref: '#/components/schemas/ApifrontendToolExecutedPayload'
           discriminator:
             propertyName: event_type
             mapping:
@@ -2589,6 +2601,17 @@ components:
               'actiontype.denied.create': '#/components/schemas/ActionTypeWebhookAuditPayload'
               'actiontype.denied.update': '#/components/schemas/ActionTypeWebhookAuditPayload'
               'actiontype.denied.delete': '#/components/schemas/ActionTypeWebhookAuditPayload'
+              'apifrontend.triage.started': '#/components/schemas/ApifrontendTriageStartedPayload'
+              'apifrontend.triage.completed': '#/components/schemas/ApifrontendTriageCompletedPayload'
+              'apifrontend.rr.created': '#/components/schemas/ApifrontendRRCreatedPayload'
+              'apifrontend.rr.deduplicated': '#/components/schemas/ApifrontendRRDeduplicatedPayload'
+              'apifrontend.session.created': '#/components/schemas/ApifrontendSessionCreatedPayload'
+              'apifrontend.session.completed': '#/components/schemas/ApifrontendSessionCompletedPayload'
+              'apifrontend.ka.delegated': '#/components/schemas/ApifrontendKADelegatedPayload'
+              'apifrontend.ka.result_received': '#/components/schemas/ApifrontendKAResultReceivedPayload'
+              'apifrontend.user.decision': '#/components/schemas/ApifrontendUserDecisionPayload'
+              'apifrontend.auth.access_denied': '#/components/schemas/ApifrontendAuthAccessDeniedPayload'
+              'apifrontend.tool.executed': '#/components/schemas/ApifrontendToolExecutedPayload'
           # Removed x-go-type override to use proper oneOf discriminator
           # Let oapi-codegen generate appropriate union type from oneOf schemas
 
@@ -6572,4 +6595,328 @@ components:
           type: string
         denial_operation:
           type: string
+
+    # ── Apifrontend Audit Payloads (Issue #1021) ──────────────────────────
+
+    ApifrontendTriageStartedPayload:
+      type: object
+      required: [event_type, session_id, persona]
+      description: Triage started event payload (apifrontend.triage.started) — user NL query received, triage LLM invocation begins (SOC2 CC7.2, Issue #1021)
+      properties:
+        event_type:
+          type: string
+          enum: ['apifrontend.triage.started']
+          description: Event type for discriminator (matches parent event_type)
+        session_id:
+          type: string
+          description: InvestigationSession CRD name
+        persona:
+          type: string
+          enum: [sre, orchestrator, cicd, dashboard, audit, approver]
+          description: Detected/assigned persona from JWT role
+        model_name:
+          type: string
+          description: LLM model identifier used for triage
+        query_length:
+          type: integer
+          description: Length of user query in characters (not the query itself, for privacy)
+
+    ApifrontendTriageCompletedPayload:
+      type: object
+      required: [event_type, session_id, triage_outcome, triage_duration_ms]
+      description: Triage completed event payload (apifrontend.triage.completed) — triage finished with outcome (SOC2 CC7.2, Issue #1021)
+      properties:
+        event_type:
+          type: string
+          enum: ['apifrontend.triage.completed']
+          description: Event type for discriminator (matches parent event_type)
+        session_id:
+          type: string
+          description: InvestigationSession CRD name
+        triage_outcome:
+          type: string
+          enum: [rr_created, no_issue_found, escalated, error]
+          description: Result of triage phase
+        triage_duration_ms:
+          type: integer
+          description: Wall-clock time for triage phase
+        tokens_input:
+          type: integer
+          description: Input tokens consumed during triage
+        tokens_output:
+          type: integer
+          description: Output tokens generated during triage
+        tools_called:
+          type: array
+          items:
+            type: string
+          description: Tools invoked during triage (names only)
+        tools_call_count:
+          type: integer
+          description: Total number of tool invocations
+
+    ApifrontendRRCreatedPayload:
+      type: object
+      required: [event_type, session_id, rr_name, rr_namespace, target_kind, target_name, fingerprint]
+      description: RemediationRequest created event payload (apifrontend.rr.created) — AF created an RR (SOC2 CC7.2, Issue #1021)
+      properties:
+        event_type:
+          type: string
+          enum: ['apifrontend.rr.created']
+          description: Event type for discriminator (matches parent event_type)
+        session_id:
+          type: string
+          description: InvestigationSession CRD name
+        rr_name:
+          type: string
+          description: RemediationRequest CRD name
+        rr_namespace:
+          type: string
+          description: K8s namespace of the RR
+        target_kind:
+          type: string
+          description: Target resource kind (Deployment, StatefulSet, etc.)
+        target_name:
+          type: string
+          description: Target resource name
+        fingerprint:
+          type: string
+          description: Dedup fingerprint hash
+        signal_source:
+          type: string
+          description: How the signal was received (nl_query, alert_forward, etc.)
+
+    ApifrontendRRDeduplicatedPayload:
+      type: object
+      required: [event_type, session_id, fingerprint, existing_rr_name]
+      description: RR deduplicated event payload (apifrontend.rr.deduplicated) — RR creation skipped due to fingerprint match (SOC2 CC7.2, Issue #1021)
+      properties:
+        event_type:
+          type: string
+          enum: ['apifrontend.rr.deduplicated']
+          description: Event type for discriminator (matches parent event_type)
+        session_id:
+          type: string
+          description: InvestigationSession CRD name
+        fingerprint:
+          type: string
+          description: The matching fingerprint hash
+        existing_rr_name:
+          type: string
+          description: Name of the existing RR that matched
+        existing_rr_namespace:
+          type: string
+          description: K8s namespace of the existing RR
+        lease_holder:
+          type: string
+          description: Identity of the Lease holder (for debugging)
+
+    ApifrontendSessionCreatedPayload:
+      type: object
+      required: [event_type, session_id, a2a_task_id, join_mode, user_identity]
+      description: Session created event payload (apifrontend.session.created) — InvestigationSession CRD created (SOC2 CC7.2, Issue #1021)
+      properties:
+        event_type:
+          type: string
+          enum: ['apifrontend.session.created']
+          description: Event type for discriminator (matches parent event_type)
+        session_id:
+          type: string
+          description: InvestigationSession CRD name
+        a2a_task_id:
+          type: string
+          description: A2A task ID for client reconnection
+        rr_ref:
+          type: string
+          description: Reference to associated RemediationRequest (name)
+        join_mode:
+          type: string
+          enum: [start, takeover]
+          description: Whether user initiated or joined running investigation
+        user_identity:
+          type: string
+          description: Username from JWT (sub claim)
+        user_groups:
+          type: array
+          items:
+            type: string
+          description: User's group memberships from JWT
+
+    ApifrontendSessionCompletedPayload:
+      type: object
+      required: [event_type, session_id, terminal_phase, total_duration_ms]
+      description: Session completed event payload (apifrontend.session.completed) — session reached terminal state (SOC2 CC7.2, Issue #1021)
+      properties:
+        event_type:
+          type: string
+          enum: ['apifrontend.session.completed']
+          description: Event type for discriminator (matches parent event_type)
+        session_id:
+          type: string
+          description: InvestigationSession CRD name
+        terminal_phase:
+          type: string
+          enum: [Completed, Cancelled, Failed]
+          description: Terminal state of the session
+        total_duration_ms:
+          type: integer
+          description: Total session wall-clock time
+        total_tokens_input:
+          type: integer
+          description: Total input tokens across all LLM calls
+        total_tokens_output:
+          type: integer
+          description: Total output tokens across all LLM calls
+        total_tool_calls:
+          type: integer
+          description: Total number of tool invocations
+        polls_count:
+          type: integer
+          description: Number of poll_investigation calls during this session
+        user_decision:
+          type: string
+          enum: [accept, reject, investigate_more, cancel, none]
+          description: Final user decision (if session reached decision phase)
+
+    ApifrontendKADelegatedPayload:
+      type: object
+      required: [event_type, session_id, ka_correlation_id, delegation_type]
+      description: KA delegation event payload (apifrontend.ka.delegated) — investigation delegated to Kubernaut Agent (SOC2 CC7.2, Issue #1021)
+      properties:
+        event_type:
+          type: string
+          enum: ['apifrontend.ka.delegated']
+          description: Event type for discriminator (matches parent event_type)
+        session_id:
+          type: string
+          description: InvestigationSession CRD name
+        ka_correlation_id:
+          type: string
+          description: Correlation ID returned by KA's /analyze endpoint
+        delegation_type:
+          type: string
+          enum: [autonomous, interactive]
+          description: Whether delegated via REST (autonomous) or MCP (interactive)
+        rr_name:
+          type: string
+          description: Associated RemediationRequest name
+        rr_namespace:
+          type: string
+          description: Associated RemediationRequest namespace
+
+    ApifrontendKAResultReceivedPayload:
+      type: object
+      required: [event_type, session_id, ka_correlation_id, result_type]
+      description: KA result received event payload (apifrontend.ka.result_received) — RCA result received from KA (SOC2 CC7.2, Issue #1021)
+      properties:
+        event_type:
+          type: string
+          enum: ['apifrontend.ka.result_received']
+          description: Event type for discriminator (matches parent event_type)
+        session_id:
+          type: string
+          description: InvestigationSession CRD name
+        ka_correlation_id:
+          type: string
+          description: Correlation ID linking to the delegation event
+        result_type:
+          type: string
+          enum: [rca_complete, rca_failed, timeout, cancelled]
+          description: Type of result received from KA
+        investigation_duration_ms:
+          type: integer
+          description: Time from delegation to result receipt
+        confidence:
+          type: number
+          format: float
+          description: RCA confidence score (0.0-1.0, if available)
+        workflow_candidates_count:
+          type: integer
+          description: Number of workflow candidates identified by KA
+
+    ApifrontendUserDecisionPayload:
+      type: object
+      required: [event_type, session_id, decision]
+      description: User decision event payload (apifrontend.user.decision) — user acted on RCA/options (SOC2 CC7.2, Issue #1021)
+      properties:
+        event_type:
+          type: string
+          enum: ['apifrontend.user.decision']
+          description: Event type for discriminator (matches parent event_type)
+        session_id:
+          type: string
+          description: InvestigationSession CRD name
+        decision:
+          type: string
+          enum: [accept, reject, investigate_more, cancel]
+          description: User's decision on the RCA/options
+        workflow_id:
+          type: string
+          description: Selected workflow identifier (if decision is 'accept')
+        time_to_decision_ms:
+          type: integer
+          description: Time from RCA presentation (input-required) to user response
+        rr_name:
+          type: string
+          description: Associated RemediationRequest name
+
+    ApifrontendAuthAccessDeniedPayload:
+      type: object
+      required: [event_type, tool_name, user_role, required_roles, endpoint]
+      description: Auth access denied event payload (apifrontend.auth.access_denied) — tool invocation denied by RBAC (SOC2 CC6.1, Issue #1021)
+      properties:
+        event_type:
+          type: string
+          enum: ['apifrontend.auth.access_denied']
+          description: Event type for discriminator (matches parent event_type)
+        session_id:
+          type: string
+          description: Session ID if available (may be empty for pre-session auth failures)
+        tool_name:
+          type: string
+          description: MCP tool that was denied
+        user_role:
+          type: string
+          description: User's actual role from JWT
+        required_roles:
+          type: array
+          items:
+            type: string
+          description: Roles that would grant access to this tool
+        endpoint:
+          type: string
+          enum: [a2a, mcp]
+          description: Which protocol endpoint the request came through
+        reason:
+          type: string
+          description: Denial reason (rbac_policy, token_expired, invalid_scope, etc.)
+
+    ApifrontendToolExecutedPayload:
+      type: object
+      required: [event_type, session_id, tool_name, execution_duration_ms, tool_outcome]
+      description: Tool executed event payload (apifrontend.tool.executed) — MCP tool executed with outcome (SOC2 CC7.2, Issue #1021)
+      properties:
+        event_type:
+          type: string
+          enum: ['apifrontend.tool.executed']
+          description: Event type for discriminator (matches parent event_type)
+        session_id:
+          type: string
+          description: InvestigationSession CRD name
+        tool_name:
+          type: string
+          description: Name of the executed MCP tool
+        execution_duration_ms:
+          type: integer
+          description: Tool execution wall-clock time
+        tool_outcome:
+          type: string
+          enum: [success, failure, timeout, denied]
+          description: Outcome of tool execution
+        error_code:
+          type: string
+          description: Error classification (if failure)
+        target_resource:
+          type: string
+          description: Resource the tool operated on (if applicable)
 

--- a/pkg/datastorage/ogen-client/oas_json_gen.go
+++ b/pkg/datastorage/ogen-client/oas_json_gen.go
@@ -7927,6 +7927,3016 @@ func (s *ActionTypeWorkflowCountResponse) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
+func (s *ApifrontendAuthAccessDeniedPayload) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *ApifrontendAuthAccessDeniedPayload) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("event_type")
+		s.EventType.Encode(e)
+	}
+	{
+		if s.SessionID.Set {
+			e.FieldStart("session_id")
+			s.SessionID.Encode(e)
+		}
+	}
+	{
+		e.FieldStart("tool_name")
+		e.Str(s.ToolName)
+	}
+	{
+		e.FieldStart("user_role")
+		e.Str(s.UserRole)
+	}
+	{
+		e.FieldStart("required_roles")
+		e.ArrStart()
+		for _, elem := range s.RequiredRoles {
+			e.Str(elem)
+		}
+		e.ArrEnd()
+	}
+	{
+		e.FieldStart("endpoint")
+		s.Endpoint.Encode(e)
+	}
+	{
+		if s.Reason.Set {
+			e.FieldStart("reason")
+			s.Reason.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfApifrontendAuthAccessDeniedPayload = [7]string{
+	0: "event_type",
+	1: "session_id",
+	2: "tool_name",
+	3: "user_role",
+	4: "required_roles",
+	5: "endpoint",
+	6: "reason",
+}
+
+// Decode decodes ApifrontendAuthAccessDeniedPayload from json.
+func (s *ApifrontendAuthAccessDeniedPayload) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendAuthAccessDeniedPayload to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "event_type":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.EventType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "session_id":
+			if err := func() error {
+				s.SessionID.Reset()
+				if err := s.SessionID.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"session_id\"")
+			}
+		case "tool_name":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Str()
+				s.ToolName = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"tool_name\"")
+			}
+		case "user_role":
+			requiredBitSet[0] |= 1 << 3
+			if err := func() error {
+				v, err := d.Str()
+				s.UserRole = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"user_role\"")
+			}
+		case "required_roles":
+			requiredBitSet[0] |= 1 << 4
+			if err := func() error {
+				s.RequiredRoles = make([]string, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem string
+					v, err := d.Str()
+					elem = string(v)
+					if err != nil {
+						return err
+					}
+					s.RequiredRoles = append(s.RequiredRoles, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"required_roles\"")
+			}
+		case "endpoint":
+			requiredBitSet[0] |= 1 << 5
+			if err := func() error {
+				if err := s.Endpoint.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"endpoint\"")
+			}
+		case "reason":
+			if err := func() error {
+				s.Reason.Reset()
+				if err := s.Reason.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"reason\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode ApifrontendAuthAccessDeniedPayload")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00111101,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfApifrontendAuthAccessDeniedPayload) {
+					name = jsonFieldsNameOfApifrontendAuthAccessDeniedPayload[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *ApifrontendAuthAccessDeniedPayload) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendAuthAccessDeniedPayload) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendAuthAccessDeniedPayloadEndpoint as json.
+func (s ApifrontendAuthAccessDeniedPayloadEndpoint) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendAuthAccessDeniedPayloadEndpoint from json.
+func (s *ApifrontendAuthAccessDeniedPayloadEndpoint) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendAuthAccessDeniedPayloadEndpoint to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendAuthAccessDeniedPayloadEndpoint(v) {
+	case ApifrontendAuthAccessDeniedPayloadEndpointA2a:
+		*s = ApifrontendAuthAccessDeniedPayloadEndpointA2a
+	case ApifrontendAuthAccessDeniedPayloadEndpointMcp:
+		*s = ApifrontendAuthAccessDeniedPayloadEndpointMcp
+	default:
+		*s = ApifrontendAuthAccessDeniedPayloadEndpoint(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendAuthAccessDeniedPayloadEndpoint) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendAuthAccessDeniedPayloadEndpoint) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendAuthAccessDeniedPayloadEventType as json.
+func (s ApifrontendAuthAccessDeniedPayloadEventType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendAuthAccessDeniedPayloadEventType from json.
+func (s *ApifrontendAuthAccessDeniedPayloadEventType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendAuthAccessDeniedPayloadEventType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendAuthAccessDeniedPayloadEventType(v) {
+	case ApifrontendAuthAccessDeniedPayloadEventTypeApifrontendAuthAccessDenied:
+		*s = ApifrontendAuthAccessDeniedPayloadEventTypeApifrontendAuthAccessDenied
+	default:
+		*s = ApifrontendAuthAccessDeniedPayloadEventType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendAuthAccessDeniedPayloadEventType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendAuthAccessDeniedPayloadEventType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *ApifrontendKADelegatedPayload) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *ApifrontendKADelegatedPayload) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("event_type")
+		s.EventType.Encode(e)
+	}
+	{
+		e.FieldStart("session_id")
+		e.Str(s.SessionID)
+	}
+	{
+		e.FieldStart("ka_correlation_id")
+		e.Str(s.KaCorrelationID)
+	}
+	{
+		e.FieldStart("delegation_type")
+		s.DelegationType.Encode(e)
+	}
+	{
+		if s.RrName.Set {
+			e.FieldStart("rr_name")
+			s.RrName.Encode(e)
+		}
+	}
+	{
+		if s.RrNamespace.Set {
+			e.FieldStart("rr_namespace")
+			s.RrNamespace.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfApifrontendKADelegatedPayload = [6]string{
+	0: "event_type",
+	1: "session_id",
+	2: "ka_correlation_id",
+	3: "delegation_type",
+	4: "rr_name",
+	5: "rr_namespace",
+}
+
+// Decode decodes ApifrontendKADelegatedPayload from json.
+func (s *ApifrontendKADelegatedPayload) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendKADelegatedPayload to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "event_type":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.EventType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "session_id":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.SessionID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"session_id\"")
+			}
+		case "ka_correlation_id":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Str()
+				s.KaCorrelationID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"ka_correlation_id\"")
+			}
+		case "delegation_type":
+			requiredBitSet[0] |= 1 << 3
+			if err := func() error {
+				if err := s.DelegationType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"delegation_type\"")
+			}
+		case "rr_name":
+			if err := func() error {
+				s.RrName.Reset()
+				if err := s.RrName.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"rr_name\"")
+			}
+		case "rr_namespace":
+			if err := func() error {
+				s.RrNamespace.Reset()
+				if err := s.RrNamespace.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"rr_namespace\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode ApifrontendKADelegatedPayload")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00001111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfApifrontendKADelegatedPayload) {
+					name = jsonFieldsNameOfApifrontendKADelegatedPayload[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *ApifrontendKADelegatedPayload) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendKADelegatedPayload) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendKADelegatedPayloadDelegationType as json.
+func (s ApifrontendKADelegatedPayloadDelegationType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendKADelegatedPayloadDelegationType from json.
+func (s *ApifrontendKADelegatedPayloadDelegationType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendKADelegatedPayloadDelegationType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendKADelegatedPayloadDelegationType(v) {
+	case ApifrontendKADelegatedPayloadDelegationTypeAutonomous:
+		*s = ApifrontendKADelegatedPayloadDelegationTypeAutonomous
+	case ApifrontendKADelegatedPayloadDelegationTypeInteractive:
+		*s = ApifrontendKADelegatedPayloadDelegationTypeInteractive
+	default:
+		*s = ApifrontendKADelegatedPayloadDelegationType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendKADelegatedPayloadDelegationType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendKADelegatedPayloadDelegationType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendKADelegatedPayloadEventType as json.
+func (s ApifrontendKADelegatedPayloadEventType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendKADelegatedPayloadEventType from json.
+func (s *ApifrontendKADelegatedPayloadEventType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendKADelegatedPayloadEventType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendKADelegatedPayloadEventType(v) {
+	case ApifrontendKADelegatedPayloadEventTypeApifrontendKaDelegated:
+		*s = ApifrontendKADelegatedPayloadEventTypeApifrontendKaDelegated
+	default:
+		*s = ApifrontendKADelegatedPayloadEventType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendKADelegatedPayloadEventType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendKADelegatedPayloadEventType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *ApifrontendKAResultReceivedPayload) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *ApifrontendKAResultReceivedPayload) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("event_type")
+		s.EventType.Encode(e)
+	}
+	{
+		e.FieldStart("session_id")
+		e.Str(s.SessionID)
+	}
+	{
+		e.FieldStart("ka_correlation_id")
+		e.Str(s.KaCorrelationID)
+	}
+	{
+		e.FieldStart("result_type")
+		s.ResultType.Encode(e)
+	}
+	{
+		if s.InvestigationDurationMs.Set {
+			e.FieldStart("investigation_duration_ms")
+			s.InvestigationDurationMs.Encode(e)
+		}
+	}
+	{
+		if s.Confidence.Set {
+			e.FieldStart("confidence")
+			s.Confidence.Encode(e)
+		}
+	}
+	{
+		if s.WorkflowCandidatesCount.Set {
+			e.FieldStart("workflow_candidates_count")
+			s.WorkflowCandidatesCount.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfApifrontendKAResultReceivedPayload = [7]string{
+	0: "event_type",
+	1: "session_id",
+	2: "ka_correlation_id",
+	3: "result_type",
+	4: "investigation_duration_ms",
+	5: "confidence",
+	6: "workflow_candidates_count",
+}
+
+// Decode decodes ApifrontendKAResultReceivedPayload from json.
+func (s *ApifrontendKAResultReceivedPayload) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendKAResultReceivedPayload to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "event_type":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.EventType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "session_id":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.SessionID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"session_id\"")
+			}
+		case "ka_correlation_id":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Str()
+				s.KaCorrelationID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"ka_correlation_id\"")
+			}
+		case "result_type":
+			requiredBitSet[0] |= 1 << 3
+			if err := func() error {
+				if err := s.ResultType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"result_type\"")
+			}
+		case "investigation_duration_ms":
+			if err := func() error {
+				s.InvestigationDurationMs.Reset()
+				if err := s.InvestigationDurationMs.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"investigation_duration_ms\"")
+			}
+		case "confidence":
+			if err := func() error {
+				s.Confidence.Reset()
+				if err := s.Confidence.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"confidence\"")
+			}
+		case "workflow_candidates_count":
+			if err := func() error {
+				s.WorkflowCandidatesCount.Reset()
+				if err := s.WorkflowCandidatesCount.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"workflow_candidates_count\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode ApifrontendKAResultReceivedPayload")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00001111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfApifrontendKAResultReceivedPayload) {
+					name = jsonFieldsNameOfApifrontendKAResultReceivedPayload[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *ApifrontendKAResultReceivedPayload) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendKAResultReceivedPayload) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendKAResultReceivedPayloadEventType as json.
+func (s ApifrontendKAResultReceivedPayloadEventType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendKAResultReceivedPayloadEventType from json.
+func (s *ApifrontendKAResultReceivedPayloadEventType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendKAResultReceivedPayloadEventType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendKAResultReceivedPayloadEventType(v) {
+	case ApifrontendKAResultReceivedPayloadEventTypeApifrontendKaResultReceived:
+		*s = ApifrontendKAResultReceivedPayloadEventTypeApifrontendKaResultReceived
+	default:
+		*s = ApifrontendKAResultReceivedPayloadEventType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendKAResultReceivedPayloadEventType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendKAResultReceivedPayloadEventType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendKAResultReceivedPayloadResultType as json.
+func (s ApifrontendKAResultReceivedPayloadResultType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendKAResultReceivedPayloadResultType from json.
+func (s *ApifrontendKAResultReceivedPayloadResultType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendKAResultReceivedPayloadResultType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendKAResultReceivedPayloadResultType(v) {
+	case ApifrontendKAResultReceivedPayloadResultTypeRcaComplete:
+		*s = ApifrontendKAResultReceivedPayloadResultTypeRcaComplete
+	case ApifrontendKAResultReceivedPayloadResultTypeRcaFailed:
+		*s = ApifrontendKAResultReceivedPayloadResultTypeRcaFailed
+	case ApifrontendKAResultReceivedPayloadResultTypeTimeout:
+		*s = ApifrontendKAResultReceivedPayloadResultTypeTimeout
+	case ApifrontendKAResultReceivedPayloadResultTypeCancelled:
+		*s = ApifrontendKAResultReceivedPayloadResultTypeCancelled
+	default:
+		*s = ApifrontendKAResultReceivedPayloadResultType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendKAResultReceivedPayloadResultType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendKAResultReceivedPayloadResultType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *ApifrontendRRCreatedPayload) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *ApifrontendRRCreatedPayload) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("event_type")
+		s.EventType.Encode(e)
+	}
+	{
+		e.FieldStart("session_id")
+		e.Str(s.SessionID)
+	}
+	{
+		e.FieldStart("rr_name")
+		e.Str(s.RrName)
+	}
+	{
+		e.FieldStart("rr_namespace")
+		e.Str(s.RrNamespace)
+	}
+	{
+		e.FieldStart("target_kind")
+		e.Str(s.TargetKind)
+	}
+	{
+		e.FieldStart("target_name")
+		e.Str(s.TargetName)
+	}
+	{
+		e.FieldStart("fingerprint")
+		e.Str(s.Fingerprint)
+	}
+	{
+		if s.SignalSource.Set {
+			e.FieldStart("signal_source")
+			s.SignalSource.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfApifrontendRRCreatedPayload = [8]string{
+	0: "event_type",
+	1: "session_id",
+	2: "rr_name",
+	3: "rr_namespace",
+	4: "target_kind",
+	5: "target_name",
+	6: "fingerprint",
+	7: "signal_source",
+}
+
+// Decode decodes ApifrontendRRCreatedPayload from json.
+func (s *ApifrontendRRCreatedPayload) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendRRCreatedPayload to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "event_type":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.EventType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "session_id":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.SessionID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"session_id\"")
+			}
+		case "rr_name":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Str()
+				s.RrName = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"rr_name\"")
+			}
+		case "rr_namespace":
+			requiredBitSet[0] |= 1 << 3
+			if err := func() error {
+				v, err := d.Str()
+				s.RrNamespace = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"rr_namespace\"")
+			}
+		case "target_kind":
+			requiredBitSet[0] |= 1 << 4
+			if err := func() error {
+				v, err := d.Str()
+				s.TargetKind = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"target_kind\"")
+			}
+		case "target_name":
+			requiredBitSet[0] |= 1 << 5
+			if err := func() error {
+				v, err := d.Str()
+				s.TargetName = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"target_name\"")
+			}
+		case "fingerprint":
+			requiredBitSet[0] |= 1 << 6
+			if err := func() error {
+				v, err := d.Str()
+				s.Fingerprint = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"fingerprint\"")
+			}
+		case "signal_source":
+			if err := func() error {
+				s.SignalSource.Reset()
+				if err := s.SignalSource.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"signal_source\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode ApifrontendRRCreatedPayload")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b01111111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfApifrontendRRCreatedPayload) {
+					name = jsonFieldsNameOfApifrontendRRCreatedPayload[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *ApifrontendRRCreatedPayload) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendRRCreatedPayload) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendRRCreatedPayloadEventType as json.
+func (s ApifrontendRRCreatedPayloadEventType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendRRCreatedPayloadEventType from json.
+func (s *ApifrontendRRCreatedPayloadEventType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendRRCreatedPayloadEventType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendRRCreatedPayloadEventType(v) {
+	case ApifrontendRRCreatedPayloadEventTypeApifrontendRrCreated:
+		*s = ApifrontendRRCreatedPayloadEventTypeApifrontendRrCreated
+	default:
+		*s = ApifrontendRRCreatedPayloadEventType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendRRCreatedPayloadEventType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendRRCreatedPayloadEventType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *ApifrontendRRDeduplicatedPayload) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *ApifrontendRRDeduplicatedPayload) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("event_type")
+		s.EventType.Encode(e)
+	}
+	{
+		e.FieldStart("session_id")
+		e.Str(s.SessionID)
+	}
+	{
+		e.FieldStart("fingerprint")
+		e.Str(s.Fingerprint)
+	}
+	{
+		e.FieldStart("existing_rr_name")
+		e.Str(s.ExistingRrName)
+	}
+	{
+		if s.ExistingRrNamespace.Set {
+			e.FieldStart("existing_rr_namespace")
+			s.ExistingRrNamespace.Encode(e)
+		}
+	}
+	{
+		if s.LeaseHolder.Set {
+			e.FieldStart("lease_holder")
+			s.LeaseHolder.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfApifrontendRRDeduplicatedPayload = [6]string{
+	0: "event_type",
+	1: "session_id",
+	2: "fingerprint",
+	3: "existing_rr_name",
+	4: "existing_rr_namespace",
+	5: "lease_holder",
+}
+
+// Decode decodes ApifrontendRRDeduplicatedPayload from json.
+func (s *ApifrontendRRDeduplicatedPayload) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendRRDeduplicatedPayload to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "event_type":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.EventType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "session_id":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.SessionID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"session_id\"")
+			}
+		case "fingerprint":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Str()
+				s.Fingerprint = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"fingerprint\"")
+			}
+		case "existing_rr_name":
+			requiredBitSet[0] |= 1 << 3
+			if err := func() error {
+				v, err := d.Str()
+				s.ExistingRrName = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"existing_rr_name\"")
+			}
+		case "existing_rr_namespace":
+			if err := func() error {
+				s.ExistingRrNamespace.Reset()
+				if err := s.ExistingRrNamespace.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"existing_rr_namespace\"")
+			}
+		case "lease_holder":
+			if err := func() error {
+				s.LeaseHolder.Reset()
+				if err := s.LeaseHolder.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"lease_holder\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode ApifrontendRRDeduplicatedPayload")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00001111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfApifrontendRRDeduplicatedPayload) {
+					name = jsonFieldsNameOfApifrontendRRDeduplicatedPayload[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *ApifrontendRRDeduplicatedPayload) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendRRDeduplicatedPayload) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendRRDeduplicatedPayloadEventType as json.
+func (s ApifrontendRRDeduplicatedPayloadEventType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendRRDeduplicatedPayloadEventType from json.
+func (s *ApifrontendRRDeduplicatedPayloadEventType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendRRDeduplicatedPayloadEventType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendRRDeduplicatedPayloadEventType(v) {
+	case ApifrontendRRDeduplicatedPayloadEventTypeApifrontendRrDeduplicated:
+		*s = ApifrontendRRDeduplicatedPayloadEventTypeApifrontendRrDeduplicated
+	default:
+		*s = ApifrontendRRDeduplicatedPayloadEventType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendRRDeduplicatedPayloadEventType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendRRDeduplicatedPayloadEventType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *ApifrontendSessionCompletedPayload) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *ApifrontendSessionCompletedPayload) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("event_type")
+		s.EventType.Encode(e)
+	}
+	{
+		e.FieldStart("session_id")
+		e.Str(s.SessionID)
+	}
+	{
+		e.FieldStart("terminal_phase")
+		s.TerminalPhase.Encode(e)
+	}
+	{
+		e.FieldStart("total_duration_ms")
+		e.Int(s.TotalDurationMs)
+	}
+	{
+		if s.TotalTokensInput.Set {
+			e.FieldStart("total_tokens_input")
+			s.TotalTokensInput.Encode(e)
+		}
+	}
+	{
+		if s.TotalTokensOutput.Set {
+			e.FieldStart("total_tokens_output")
+			s.TotalTokensOutput.Encode(e)
+		}
+	}
+	{
+		if s.TotalToolCalls.Set {
+			e.FieldStart("total_tool_calls")
+			s.TotalToolCalls.Encode(e)
+		}
+	}
+	{
+		if s.PollsCount.Set {
+			e.FieldStart("polls_count")
+			s.PollsCount.Encode(e)
+		}
+	}
+	{
+		if s.UserDecision.Set {
+			e.FieldStart("user_decision")
+			s.UserDecision.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfApifrontendSessionCompletedPayload = [9]string{
+	0: "event_type",
+	1: "session_id",
+	2: "terminal_phase",
+	3: "total_duration_ms",
+	4: "total_tokens_input",
+	5: "total_tokens_output",
+	6: "total_tool_calls",
+	7: "polls_count",
+	8: "user_decision",
+}
+
+// Decode decodes ApifrontendSessionCompletedPayload from json.
+func (s *ApifrontendSessionCompletedPayload) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendSessionCompletedPayload to nil")
+	}
+	var requiredBitSet [2]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "event_type":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.EventType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "session_id":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.SessionID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"session_id\"")
+			}
+		case "terminal_phase":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				if err := s.TerminalPhase.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"terminal_phase\"")
+			}
+		case "total_duration_ms":
+			requiredBitSet[0] |= 1 << 3
+			if err := func() error {
+				v, err := d.Int()
+				s.TotalDurationMs = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"total_duration_ms\"")
+			}
+		case "total_tokens_input":
+			if err := func() error {
+				s.TotalTokensInput.Reset()
+				if err := s.TotalTokensInput.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"total_tokens_input\"")
+			}
+		case "total_tokens_output":
+			if err := func() error {
+				s.TotalTokensOutput.Reset()
+				if err := s.TotalTokensOutput.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"total_tokens_output\"")
+			}
+		case "total_tool_calls":
+			if err := func() error {
+				s.TotalToolCalls.Reset()
+				if err := s.TotalToolCalls.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"total_tool_calls\"")
+			}
+		case "polls_count":
+			if err := func() error {
+				s.PollsCount.Reset()
+				if err := s.PollsCount.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"polls_count\"")
+			}
+		case "user_decision":
+			if err := func() error {
+				s.UserDecision.Reset()
+				if err := s.UserDecision.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"user_decision\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode ApifrontendSessionCompletedPayload")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [2]uint8{
+		0b00001111,
+		0b00000000,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfApifrontendSessionCompletedPayload) {
+					name = jsonFieldsNameOfApifrontendSessionCompletedPayload[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *ApifrontendSessionCompletedPayload) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendSessionCompletedPayload) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendSessionCompletedPayloadEventType as json.
+func (s ApifrontendSessionCompletedPayloadEventType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendSessionCompletedPayloadEventType from json.
+func (s *ApifrontendSessionCompletedPayloadEventType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendSessionCompletedPayloadEventType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendSessionCompletedPayloadEventType(v) {
+	case ApifrontendSessionCompletedPayloadEventTypeApifrontendSessionCompleted:
+		*s = ApifrontendSessionCompletedPayloadEventTypeApifrontendSessionCompleted
+	default:
+		*s = ApifrontendSessionCompletedPayloadEventType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendSessionCompletedPayloadEventType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendSessionCompletedPayloadEventType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendSessionCompletedPayloadTerminalPhase as json.
+func (s ApifrontendSessionCompletedPayloadTerminalPhase) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendSessionCompletedPayloadTerminalPhase from json.
+func (s *ApifrontendSessionCompletedPayloadTerminalPhase) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendSessionCompletedPayloadTerminalPhase to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendSessionCompletedPayloadTerminalPhase(v) {
+	case ApifrontendSessionCompletedPayloadTerminalPhaseCompleted:
+		*s = ApifrontendSessionCompletedPayloadTerminalPhaseCompleted
+	case ApifrontendSessionCompletedPayloadTerminalPhaseCancelled:
+		*s = ApifrontendSessionCompletedPayloadTerminalPhaseCancelled
+	case ApifrontendSessionCompletedPayloadTerminalPhaseFailed:
+		*s = ApifrontendSessionCompletedPayloadTerminalPhaseFailed
+	default:
+		*s = ApifrontendSessionCompletedPayloadTerminalPhase(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendSessionCompletedPayloadTerminalPhase) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendSessionCompletedPayloadTerminalPhase) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendSessionCompletedPayloadUserDecision as json.
+func (s ApifrontendSessionCompletedPayloadUserDecision) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendSessionCompletedPayloadUserDecision from json.
+func (s *ApifrontendSessionCompletedPayloadUserDecision) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendSessionCompletedPayloadUserDecision to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendSessionCompletedPayloadUserDecision(v) {
+	case ApifrontendSessionCompletedPayloadUserDecisionAccept:
+		*s = ApifrontendSessionCompletedPayloadUserDecisionAccept
+	case ApifrontendSessionCompletedPayloadUserDecisionReject:
+		*s = ApifrontendSessionCompletedPayloadUserDecisionReject
+	case ApifrontendSessionCompletedPayloadUserDecisionInvestigateMore:
+		*s = ApifrontendSessionCompletedPayloadUserDecisionInvestigateMore
+	case ApifrontendSessionCompletedPayloadUserDecisionCancel:
+		*s = ApifrontendSessionCompletedPayloadUserDecisionCancel
+	case ApifrontendSessionCompletedPayloadUserDecisionNone:
+		*s = ApifrontendSessionCompletedPayloadUserDecisionNone
+	default:
+		*s = ApifrontendSessionCompletedPayloadUserDecision(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendSessionCompletedPayloadUserDecision) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendSessionCompletedPayloadUserDecision) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *ApifrontendSessionCreatedPayload) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *ApifrontendSessionCreatedPayload) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("event_type")
+		s.EventType.Encode(e)
+	}
+	{
+		e.FieldStart("session_id")
+		e.Str(s.SessionID)
+	}
+	{
+		e.FieldStart("a2a_task_id")
+		e.Str(s.A2aTaskID)
+	}
+	{
+		if s.RrRef.Set {
+			e.FieldStart("rr_ref")
+			s.RrRef.Encode(e)
+		}
+	}
+	{
+		e.FieldStart("join_mode")
+		s.JoinMode.Encode(e)
+	}
+	{
+		e.FieldStart("user_identity")
+		e.Str(s.UserIdentity)
+	}
+	{
+		if s.UserGroups != nil {
+			e.FieldStart("user_groups")
+			e.ArrStart()
+			for _, elem := range s.UserGroups {
+				e.Str(elem)
+			}
+			e.ArrEnd()
+		}
+	}
+}
+
+var jsonFieldsNameOfApifrontendSessionCreatedPayload = [7]string{
+	0: "event_type",
+	1: "session_id",
+	2: "a2a_task_id",
+	3: "rr_ref",
+	4: "join_mode",
+	5: "user_identity",
+	6: "user_groups",
+}
+
+// Decode decodes ApifrontendSessionCreatedPayload from json.
+func (s *ApifrontendSessionCreatedPayload) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendSessionCreatedPayload to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "event_type":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.EventType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "session_id":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.SessionID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"session_id\"")
+			}
+		case "a2a_task_id":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Str()
+				s.A2aTaskID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"a2a_task_id\"")
+			}
+		case "rr_ref":
+			if err := func() error {
+				s.RrRef.Reset()
+				if err := s.RrRef.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"rr_ref\"")
+			}
+		case "join_mode":
+			requiredBitSet[0] |= 1 << 4
+			if err := func() error {
+				if err := s.JoinMode.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"join_mode\"")
+			}
+		case "user_identity":
+			requiredBitSet[0] |= 1 << 5
+			if err := func() error {
+				v, err := d.Str()
+				s.UserIdentity = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"user_identity\"")
+			}
+		case "user_groups":
+			if err := func() error {
+				s.UserGroups = make([]string, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem string
+					v, err := d.Str()
+					elem = string(v)
+					if err != nil {
+						return err
+					}
+					s.UserGroups = append(s.UserGroups, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"user_groups\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode ApifrontendSessionCreatedPayload")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00110111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfApifrontendSessionCreatedPayload) {
+					name = jsonFieldsNameOfApifrontendSessionCreatedPayload[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *ApifrontendSessionCreatedPayload) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendSessionCreatedPayload) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendSessionCreatedPayloadEventType as json.
+func (s ApifrontendSessionCreatedPayloadEventType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendSessionCreatedPayloadEventType from json.
+func (s *ApifrontendSessionCreatedPayloadEventType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendSessionCreatedPayloadEventType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendSessionCreatedPayloadEventType(v) {
+	case ApifrontendSessionCreatedPayloadEventTypeApifrontendSessionCreated:
+		*s = ApifrontendSessionCreatedPayloadEventTypeApifrontendSessionCreated
+	default:
+		*s = ApifrontendSessionCreatedPayloadEventType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendSessionCreatedPayloadEventType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendSessionCreatedPayloadEventType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendSessionCreatedPayloadJoinMode as json.
+func (s ApifrontendSessionCreatedPayloadJoinMode) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendSessionCreatedPayloadJoinMode from json.
+func (s *ApifrontendSessionCreatedPayloadJoinMode) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendSessionCreatedPayloadJoinMode to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendSessionCreatedPayloadJoinMode(v) {
+	case ApifrontendSessionCreatedPayloadJoinModeStart:
+		*s = ApifrontendSessionCreatedPayloadJoinModeStart
+	case ApifrontendSessionCreatedPayloadJoinModeTakeover:
+		*s = ApifrontendSessionCreatedPayloadJoinModeTakeover
+	default:
+		*s = ApifrontendSessionCreatedPayloadJoinMode(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendSessionCreatedPayloadJoinMode) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendSessionCreatedPayloadJoinMode) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *ApifrontendToolExecutedPayload) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *ApifrontendToolExecutedPayload) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("event_type")
+		s.EventType.Encode(e)
+	}
+	{
+		e.FieldStart("session_id")
+		e.Str(s.SessionID)
+	}
+	{
+		e.FieldStart("tool_name")
+		e.Str(s.ToolName)
+	}
+	{
+		e.FieldStart("execution_duration_ms")
+		e.Int(s.ExecutionDurationMs)
+	}
+	{
+		e.FieldStart("tool_outcome")
+		s.ToolOutcome.Encode(e)
+	}
+	{
+		if s.ErrorCode.Set {
+			e.FieldStart("error_code")
+			s.ErrorCode.Encode(e)
+		}
+	}
+	{
+		if s.TargetResource.Set {
+			e.FieldStart("target_resource")
+			s.TargetResource.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfApifrontendToolExecutedPayload = [7]string{
+	0: "event_type",
+	1: "session_id",
+	2: "tool_name",
+	3: "execution_duration_ms",
+	4: "tool_outcome",
+	5: "error_code",
+	6: "target_resource",
+}
+
+// Decode decodes ApifrontendToolExecutedPayload from json.
+func (s *ApifrontendToolExecutedPayload) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendToolExecutedPayload to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "event_type":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.EventType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "session_id":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.SessionID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"session_id\"")
+			}
+		case "tool_name":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Str()
+				s.ToolName = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"tool_name\"")
+			}
+		case "execution_duration_ms":
+			requiredBitSet[0] |= 1 << 3
+			if err := func() error {
+				v, err := d.Int()
+				s.ExecutionDurationMs = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"execution_duration_ms\"")
+			}
+		case "tool_outcome":
+			requiredBitSet[0] |= 1 << 4
+			if err := func() error {
+				if err := s.ToolOutcome.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"tool_outcome\"")
+			}
+		case "error_code":
+			if err := func() error {
+				s.ErrorCode.Reset()
+				if err := s.ErrorCode.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"error_code\"")
+			}
+		case "target_resource":
+			if err := func() error {
+				s.TargetResource.Reset()
+				if err := s.TargetResource.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"target_resource\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode ApifrontendToolExecutedPayload")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00011111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfApifrontendToolExecutedPayload) {
+					name = jsonFieldsNameOfApifrontendToolExecutedPayload[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *ApifrontendToolExecutedPayload) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendToolExecutedPayload) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendToolExecutedPayloadEventType as json.
+func (s ApifrontendToolExecutedPayloadEventType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendToolExecutedPayloadEventType from json.
+func (s *ApifrontendToolExecutedPayloadEventType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendToolExecutedPayloadEventType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendToolExecutedPayloadEventType(v) {
+	case ApifrontendToolExecutedPayloadEventTypeApifrontendToolExecuted:
+		*s = ApifrontendToolExecutedPayloadEventTypeApifrontendToolExecuted
+	default:
+		*s = ApifrontendToolExecutedPayloadEventType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendToolExecutedPayloadEventType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendToolExecutedPayloadEventType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendToolExecutedPayloadToolOutcome as json.
+func (s ApifrontendToolExecutedPayloadToolOutcome) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendToolExecutedPayloadToolOutcome from json.
+func (s *ApifrontendToolExecutedPayloadToolOutcome) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendToolExecutedPayloadToolOutcome to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendToolExecutedPayloadToolOutcome(v) {
+	case ApifrontendToolExecutedPayloadToolOutcomeSuccess:
+		*s = ApifrontendToolExecutedPayloadToolOutcomeSuccess
+	case ApifrontendToolExecutedPayloadToolOutcomeFailure:
+		*s = ApifrontendToolExecutedPayloadToolOutcomeFailure
+	case ApifrontendToolExecutedPayloadToolOutcomeTimeout:
+		*s = ApifrontendToolExecutedPayloadToolOutcomeTimeout
+	case ApifrontendToolExecutedPayloadToolOutcomeDenied:
+		*s = ApifrontendToolExecutedPayloadToolOutcomeDenied
+	default:
+		*s = ApifrontendToolExecutedPayloadToolOutcome(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendToolExecutedPayloadToolOutcome) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendToolExecutedPayloadToolOutcome) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *ApifrontendTriageCompletedPayload) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *ApifrontendTriageCompletedPayload) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("event_type")
+		s.EventType.Encode(e)
+	}
+	{
+		e.FieldStart("session_id")
+		e.Str(s.SessionID)
+	}
+	{
+		e.FieldStart("triage_outcome")
+		s.TriageOutcome.Encode(e)
+	}
+	{
+		e.FieldStart("triage_duration_ms")
+		e.Int(s.TriageDurationMs)
+	}
+	{
+		if s.TokensInput.Set {
+			e.FieldStart("tokens_input")
+			s.TokensInput.Encode(e)
+		}
+	}
+	{
+		if s.TokensOutput.Set {
+			e.FieldStart("tokens_output")
+			s.TokensOutput.Encode(e)
+		}
+	}
+	{
+		if s.ToolsCalled != nil {
+			e.FieldStart("tools_called")
+			e.ArrStart()
+			for _, elem := range s.ToolsCalled {
+				e.Str(elem)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.ToolsCallCount.Set {
+			e.FieldStart("tools_call_count")
+			s.ToolsCallCount.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfApifrontendTriageCompletedPayload = [8]string{
+	0: "event_type",
+	1: "session_id",
+	2: "triage_outcome",
+	3: "triage_duration_ms",
+	4: "tokens_input",
+	5: "tokens_output",
+	6: "tools_called",
+	7: "tools_call_count",
+}
+
+// Decode decodes ApifrontendTriageCompletedPayload from json.
+func (s *ApifrontendTriageCompletedPayload) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendTriageCompletedPayload to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "event_type":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.EventType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "session_id":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.SessionID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"session_id\"")
+			}
+		case "triage_outcome":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				if err := s.TriageOutcome.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"triage_outcome\"")
+			}
+		case "triage_duration_ms":
+			requiredBitSet[0] |= 1 << 3
+			if err := func() error {
+				v, err := d.Int()
+				s.TriageDurationMs = int(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"triage_duration_ms\"")
+			}
+		case "tokens_input":
+			if err := func() error {
+				s.TokensInput.Reset()
+				if err := s.TokensInput.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"tokens_input\"")
+			}
+		case "tokens_output":
+			if err := func() error {
+				s.TokensOutput.Reset()
+				if err := s.TokensOutput.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"tokens_output\"")
+			}
+		case "tools_called":
+			if err := func() error {
+				s.ToolsCalled = make([]string, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem string
+					v, err := d.Str()
+					elem = string(v)
+					if err != nil {
+						return err
+					}
+					s.ToolsCalled = append(s.ToolsCalled, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"tools_called\"")
+			}
+		case "tools_call_count":
+			if err := func() error {
+				s.ToolsCallCount.Reset()
+				if err := s.ToolsCallCount.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"tools_call_count\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode ApifrontendTriageCompletedPayload")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00001111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfApifrontendTriageCompletedPayload) {
+					name = jsonFieldsNameOfApifrontendTriageCompletedPayload[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *ApifrontendTriageCompletedPayload) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendTriageCompletedPayload) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendTriageCompletedPayloadEventType as json.
+func (s ApifrontendTriageCompletedPayloadEventType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendTriageCompletedPayloadEventType from json.
+func (s *ApifrontendTriageCompletedPayloadEventType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendTriageCompletedPayloadEventType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendTriageCompletedPayloadEventType(v) {
+	case ApifrontendTriageCompletedPayloadEventTypeApifrontendTriageCompleted:
+		*s = ApifrontendTriageCompletedPayloadEventTypeApifrontendTriageCompleted
+	default:
+		*s = ApifrontendTriageCompletedPayloadEventType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendTriageCompletedPayloadEventType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendTriageCompletedPayloadEventType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendTriageCompletedPayloadTriageOutcome as json.
+func (s ApifrontendTriageCompletedPayloadTriageOutcome) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendTriageCompletedPayloadTriageOutcome from json.
+func (s *ApifrontendTriageCompletedPayloadTriageOutcome) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendTriageCompletedPayloadTriageOutcome to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendTriageCompletedPayloadTriageOutcome(v) {
+	case ApifrontendTriageCompletedPayloadTriageOutcomeRrCreated:
+		*s = ApifrontendTriageCompletedPayloadTriageOutcomeRrCreated
+	case ApifrontendTriageCompletedPayloadTriageOutcomeNoIssueFound:
+		*s = ApifrontendTriageCompletedPayloadTriageOutcomeNoIssueFound
+	case ApifrontendTriageCompletedPayloadTriageOutcomeEscalated:
+		*s = ApifrontendTriageCompletedPayloadTriageOutcomeEscalated
+	case ApifrontendTriageCompletedPayloadTriageOutcomeError:
+		*s = ApifrontendTriageCompletedPayloadTriageOutcomeError
+	default:
+		*s = ApifrontendTriageCompletedPayloadTriageOutcome(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendTriageCompletedPayloadTriageOutcome) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendTriageCompletedPayloadTriageOutcome) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *ApifrontendTriageStartedPayload) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *ApifrontendTriageStartedPayload) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("event_type")
+		s.EventType.Encode(e)
+	}
+	{
+		e.FieldStart("session_id")
+		e.Str(s.SessionID)
+	}
+	{
+		e.FieldStart("persona")
+		s.Persona.Encode(e)
+	}
+	{
+		if s.ModelName.Set {
+			e.FieldStart("model_name")
+			s.ModelName.Encode(e)
+		}
+	}
+	{
+		if s.QueryLength.Set {
+			e.FieldStart("query_length")
+			s.QueryLength.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfApifrontendTriageStartedPayload = [5]string{
+	0: "event_type",
+	1: "session_id",
+	2: "persona",
+	3: "model_name",
+	4: "query_length",
+}
+
+// Decode decodes ApifrontendTriageStartedPayload from json.
+func (s *ApifrontendTriageStartedPayload) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendTriageStartedPayload to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "event_type":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.EventType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "session_id":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.SessionID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"session_id\"")
+			}
+		case "persona":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				if err := s.Persona.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"persona\"")
+			}
+		case "model_name":
+			if err := func() error {
+				s.ModelName.Reset()
+				if err := s.ModelName.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"model_name\"")
+			}
+		case "query_length":
+			if err := func() error {
+				s.QueryLength.Reset()
+				if err := s.QueryLength.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"query_length\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode ApifrontendTriageStartedPayload")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfApifrontendTriageStartedPayload) {
+					name = jsonFieldsNameOfApifrontendTriageStartedPayload[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *ApifrontendTriageStartedPayload) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendTriageStartedPayload) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendTriageStartedPayloadEventType as json.
+func (s ApifrontendTriageStartedPayloadEventType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendTriageStartedPayloadEventType from json.
+func (s *ApifrontendTriageStartedPayloadEventType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendTriageStartedPayloadEventType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendTriageStartedPayloadEventType(v) {
+	case ApifrontendTriageStartedPayloadEventTypeApifrontendTriageStarted:
+		*s = ApifrontendTriageStartedPayloadEventTypeApifrontendTriageStarted
+	default:
+		*s = ApifrontendTriageStartedPayloadEventType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendTriageStartedPayloadEventType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendTriageStartedPayloadEventType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendTriageStartedPayloadPersona as json.
+func (s ApifrontendTriageStartedPayloadPersona) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendTriageStartedPayloadPersona from json.
+func (s *ApifrontendTriageStartedPayloadPersona) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendTriageStartedPayloadPersona to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendTriageStartedPayloadPersona(v) {
+	case ApifrontendTriageStartedPayloadPersonaSre:
+		*s = ApifrontendTriageStartedPayloadPersonaSre
+	case ApifrontendTriageStartedPayloadPersonaOrchestrator:
+		*s = ApifrontendTriageStartedPayloadPersonaOrchestrator
+	case ApifrontendTriageStartedPayloadPersonaCicd:
+		*s = ApifrontendTriageStartedPayloadPersonaCicd
+	case ApifrontendTriageStartedPayloadPersonaDashboard:
+		*s = ApifrontendTriageStartedPayloadPersonaDashboard
+	case ApifrontendTriageStartedPayloadPersonaAudit:
+		*s = ApifrontendTriageStartedPayloadPersonaAudit
+	case ApifrontendTriageStartedPayloadPersonaApprover:
+		*s = ApifrontendTriageStartedPayloadPersonaApprover
+	default:
+		*s = ApifrontendTriageStartedPayloadPersona(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendTriageStartedPayloadPersona) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendTriageStartedPayloadPersona) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *ApifrontendUserDecisionPayload) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *ApifrontendUserDecisionPayload) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("event_type")
+		s.EventType.Encode(e)
+	}
+	{
+		e.FieldStart("session_id")
+		e.Str(s.SessionID)
+	}
+	{
+		e.FieldStart("decision")
+		s.Decision.Encode(e)
+	}
+	{
+		if s.WorkflowID.Set {
+			e.FieldStart("workflow_id")
+			s.WorkflowID.Encode(e)
+		}
+	}
+	{
+		if s.TimeToDecisionMs.Set {
+			e.FieldStart("time_to_decision_ms")
+			s.TimeToDecisionMs.Encode(e)
+		}
+	}
+	{
+		if s.RrName.Set {
+			e.FieldStart("rr_name")
+			s.RrName.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfApifrontendUserDecisionPayload = [6]string{
+	0: "event_type",
+	1: "session_id",
+	2: "decision",
+	3: "workflow_id",
+	4: "time_to_decision_ms",
+	5: "rr_name",
+}
+
+// Decode decodes ApifrontendUserDecisionPayload from json.
+func (s *ApifrontendUserDecisionPayload) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendUserDecisionPayload to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "event_type":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.EventType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "session_id":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.SessionID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"session_id\"")
+			}
+		case "decision":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				if err := s.Decision.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"decision\"")
+			}
+		case "workflow_id":
+			if err := func() error {
+				s.WorkflowID.Reset()
+				if err := s.WorkflowID.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"workflow_id\"")
+			}
+		case "time_to_decision_ms":
+			if err := func() error {
+				s.TimeToDecisionMs.Reset()
+				if err := s.TimeToDecisionMs.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"time_to_decision_ms\"")
+			}
+		case "rr_name":
+			if err := func() error {
+				s.RrName.Reset()
+				if err := s.RrName.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"rr_name\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode ApifrontendUserDecisionPayload")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfApifrontendUserDecisionPayload) {
+					name = jsonFieldsNameOfApifrontendUserDecisionPayload[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *ApifrontendUserDecisionPayload) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendUserDecisionPayload) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendUserDecisionPayloadDecision as json.
+func (s ApifrontendUserDecisionPayloadDecision) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendUserDecisionPayloadDecision from json.
+func (s *ApifrontendUserDecisionPayloadDecision) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendUserDecisionPayloadDecision to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendUserDecisionPayloadDecision(v) {
+	case ApifrontendUserDecisionPayloadDecisionAccept:
+		*s = ApifrontendUserDecisionPayloadDecisionAccept
+	case ApifrontendUserDecisionPayloadDecisionReject:
+		*s = ApifrontendUserDecisionPayloadDecisionReject
+	case ApifrontendUserDecisionPayloadDecisionInvestigateMore:
+		*s = ApifrontendUserDecisionPayloadDecisionInvestigateMore
+	case ApifrontendUserDecisionPayloadDecisionCancel:
+		*s = ApifrontendUserDecisionPayloadDecisionCancel
+	default:
+		*s = ApifrontendUserDecisionPayloadDecision(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendUserDecisionPayloadDecision) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendUserDecisionPayloadDecision) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendUserDecisionPayloadEventType as json.
+func (s ApifrontendUserDecisionPayloadEventType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes ApifrontendUserDecisionPayloadEventType from json.
+func (s *ApifrontendUserDecisionPayloadEventType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode ApifrontendUserDecisionPayloadEventType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch ApifrontendUserDecisionPayloadEventType(v) {
+	case ApifrontendUserDecisionPayloadEventTypeApifrontendUserDecision:
+		*s = ApifrontendUserDecisionPayloadEventTypeApifrontendUserDecision
+	default:
+		*s = ApifrontendUserDecisionPayloadEventType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s ApifrontendUserDecisionPayloadEventType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *ApifrontendUserDecisionPayloadEventType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
 func (s *AsyncAcceptanceResponse) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -8475,6 +11485,8 @@ func (s *AuditEventEventCategory) Decode(d *jx.Decoder) error {
 		*s = AuditEventEventCategoryEffectiveness
 	case AuditEventEventCategoryActiontype:
 		*s = AuditEventEventCategoryActiontype
+	case AuditEventEventCategoryApifrontend:
+		*s = AuditEventEventCategoryApifrontend
 	default:
 		*s = AuditEventEventCategory(v)
 	}
@@ -10937,6 +13949,400 @@ func (s AuditEventEventData) encodeFields(e *jx.Encoder) {
 				}
 			}
 		}
+	case ApifrontendTriageStartedPayloadAuditEventEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.triage.started")
+		{
+			s := s.ApifrontendTriageStartedPayload
+			{
+				e.FieldStart("session_id")
+				e.Str(s.SessionID)
+			}
+			{
+				e.FieldStart("persona")
+				s.Persona.Encode(e)
+			}
+			{
+				if s.ModelName.Set {
+					e.FieldStart("model_name")
+					s.ModelName.Encode(e)
+				}
+			}
+			{
+				if s.QueryLength.Set {
+					e.FieldStart("query_length")
+					s.QueryLength.Encode(e)
+				}
+			}
+		}
+	case ApifrontendTriageCompletedPayloadAuditEventEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.triage.completed")
+		{
+			s := s.ApifrontendTriageCompletedPayload
+			{
+				e.FieldStart("session_id")
+				e.Str(s.SessionID)
+			}
+			{
+				e.FieldStart("triage_outcome")
+				s.TriageOutcome.Encode(e)
+			}
+			{
+				e.FieldStart("triage_duration_ms")
+				e.Int(s.TriageDurationMs)
+			}
+			{
+				if s.TokensInput.Set {
+					e.FieldStart("tokens_input")
+					s.TokensInput.Encode(e)
+				}
+			}
+			{
+				if s.TokensOutput.Set {
+					e.FieldStart("tokens_output")
+					s.TokensOutput.Encode(e)
+				}
+			}
+			{
+				if s.ToolsCalled != nil {
+					e.FieldStart("tools_called")
+					e.ArrStart()
+					for _, elem := range s.ToolsCalled {
+						e.Str(elem)
+					}
+					e.ArrEnd()
+				}
+			}
+			{
+				if s.ToolsCallCount.Set {
+					e.FieldStart("tools_call_count")
+					s.ToolsCallCount.Encode(e)
+				}
+			}
+		}
+	case ApifrontendRRCreatedPayloadAuditEventEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.rr.created")
+		{
+			s := s.ApifrontendRRCreatedPayload
+			{
+				e.FieldStart("session_id")
+				e.Str(s.SessionID)
+			}
+			{
+				e.FieldStart("rr_name")
+				e.Str(s.RrName)
+			}
+			{
+				e.FieldStart("rr_namespace")
+				e.Str(s.RrNamespace)
+			}
+			{
+				e.FieldStart("target_kind")
+				e.Str(s.TargetKind)
+			}
+			{
+				e.FieldStart("target_name")
+				e.Str(s.TargetName)
+			}
+			{
+				e.FieldStart("fingerprint")
+				e.Str(s.Fingerprint)
+			}
+			{
+				if s.SignalSource.Set {
+					e.FieldStart("signal_source")
+					s.SignalSource.Encode(e)
+				}
+			}
+		}
+	case ApifrontendRRDeduplicatedPayloadAuditEventEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.rr.deduplicated")
+		{
+			s := s.ApifrontendRRDeduplicatedPayload
+			{
+				e.FieldStart("session_id")
+				e.Str(s.SessionID)
+			}
+			{
+				e.FieldStart("fingerprint")
+				e.Str(s.Fingerprint)
+			}
+			{
+				e.FieldStart("existing_rr_name")
+				e.Str(s.ExistingRrName)
+			}
+			{
+				if s.ExistingRrNamespace.Set {
+					e.FieldStart("existing_rr_namespace")
+					s.ExistingRrNamespace.Encode(e)
+				}
+			}
+			{
+				if s.LeaseHolder.Set {
+					e.FieldStart("lease_holder")
+					s.LeaseHolder.Encode(e)
+				}
+			}
+		}
+	case ApifrontendSessionCreatedPayloadAuditEventEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.session.created")
+		{
+			s := s.ApifrontendSessionCreatedPayload
+			{
+				e.FieldStart("session_id")
+				e.Str(s.SessionID)
+			}
+			{
+				e.FieldStart("a2a_task_id")
+				e.Str(s.A2aTaskID)
+			}
+			{
+				if s.RrRef.Set {
+					e.FieldStart("rr_ref")
+					s.RrRef.Encode(e)
+				}
+			}
+			{
+				e.FieldStart("join_mode")
+				s.JoinMode.Encode(e)
+			}
+			{
+				e.FieldStart("user_identity")
+				e.Str(s.UserIdentity)
+			}
+			{
+				if s.UserGroups != nil {
+					e.FieldStart("user_groups")
+					e.ArrStart()
+					for _, elem := range s.UserGroups {
+						e.Str(elem)
+					}
+					e.ArrEnd()
+				}
+			}
+		}
+	case ApifrontendSessionCompletedPayloadAuditEventEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.session.completed")
+		{
+			s := s.ApifrontendSessionCompletedPayload
+			{
+				e.FieldStart("session_id")
+				e.Str(s.SessionID)
+			}
+			{
+				e.FieldStart("terminal_phase")
+				s.TerminalPhase.Encode(e)
+			}
+			{
+				e.FieldStart("total_duration_ms")
+				e.Int(s.TotalDurationMs)
+			}
+			{
+				if s.TotalTokensInput.Set {
+					e.FieldStart("total_tokens_input")
+					s.TotalTokensInput.Encode(e)
+				}
+			}
+			{
+				if s.TotalTokensOutput.Set {
+					e.FieldStart("total_tokens_output")
+					s.TotalTokensOutput.Encode(e)
+				}
+			}
+			{
+				if s.TotalToolCalls.Set {
+					e.FieldStart("total_tool_calls")
+					s.TotalToolCalls.Encode(e)
+				}
+			}
+			{
+				if s.PollsCount.Set {
+					e.FieldStart("polls_count")
+					s.PollsCount.Encode(e)
+				}
+			}
+			{
+				if s.UserDecision.Set {
+					e.FieldStart("user_decision")
+					s.UserDecision.Encode(e)
+				}
+			}
+		}
+	case ApifrontendKADelegatedPayloadAuditEventEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.ka.delegated")
+		{
+			s := s.ApifrontendKADelegatedPayload
+			{
+				e.FieldStart("session_id")
+				e.Str(s.SessionID)
+			}
+			{
+				e.FieldStart("ka_correlation_id")
+				e.Str(s.KaCorrelationID)
+			}
+			{
+				e.FieldStart("delegation_type")
+				s.DelegationType.Encode(e)
+			}
+			{
+				if s.RrName.Set {
+					e.FieldStart("rr_name")
+					s.RrName.Encode(e)
+				}
+			}
+			{
+				if s.RrNamespace.Set {
+					e.FieldStart("rr_namespace")
+					s.RrNamespace.Encode(e)
+				}
+			}
+		}
+	case ApifrontendKAResultReceivedPayloadAuditEventEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.ka.result_received")
+		{
+			s := s.ApifrontendKAResultReceivedPayload
+			{
+				e.FieldStart("session_id")
+				e.Str(s.SessionID)
+			}
+			{
+				e.FieldStart("ka_correlation_id")
+				e.Str(s.KaCorrelationID)
+			}
+			{
+				e.FieldStart("result_type")
+				s.ResultType.Encode(e)
+			}
+			{
+				if s.InvestigationDurationMs.Set {
+					e.FieldStart("investigation_duration_ms")
+					s.InvestigationDurationMs.Encode(e)
+				}
+			}
+			{
+				if s.Confidence.Set {
+					e.FieldStart("confidence")
+					s.Confidence.Encode(e)
+				}
+			}
+			{
+				if s.WorkflowCandidatesCount.Set {
+					e.FieldStart("workflow_candidates_count")
+					s.WorkflowCandidatesCount.Encode(e)
+				}
+			}
+		}
+	case ApifrontendUserDecisionPayloadAuditEventEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.user.decision")
+		{
+			s := s.ApifrontendUserDecisionPayload
+			{
+				e.FieldStart("session_id")
+				e.Str(s.SessionID)
+			}
+			{
+				e.FieldStart("decision")
+				s.Decision.Encode(e)
+			}
+			{
+				if s.WorkflowID.Set {
+					e.FieldStart("workflow_id")
+					s.WorkflowID.Encode(e)
+				}
+			}
+			{
+				if s.TimeToDecisionMs.Set {
+					e.FieldStart("time_to_decision_ms")
+					s.TimeToDecisionMs.Encode(e)
+				}
+			}
+			{
+				if s.RrName.Set {
+					e.FieldStart("rr_name")
+					s.RrName.Encode(e)
+				}
+			}
+		}
+	case ApifrontendAuthAccessDeniedPayloadAuditEventEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.auth.access_denied")
+		{
+			s := s.ApifrontendAuthAccessDeniedPayload
+			{
+				if s.SessionID.Set {
+					e.FieldStart("session_id")
+					s.SessionID.Encode(e)
+				}
+			}
+			{
+				e.FieldStart("tool_name")
+				e.Str(s.ToolName)
+			}
+			{
+				e.FieldStart("user_role")
+				e.Str(s.UserRole)
+			}
+			{
+				e.FieldStart("required_roles")
+				e.ArrStart()
+				for _, elem := range s.RequiredRoles {
+					e.Str(elem)
+				}
+				e.ArrEnd()
+			}
+			{
+				e.FieldStart("endpoint")
+				s.Endpoint.Encode(e)
+			}
+			{
+				if s.Reason.Set {
+					e.FieldStart("reason")
+					s.Reason.Encode(e)
+				}
+			}
+		}
+	case ApifrontendToolExecutedPayloadAuditEventEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.tool.executed")
+		{
+			s := s.ApifrontendToolExecutedPayload
+			{
+				e.FieldStart("session_id")
+				e.Str(s.SessionID)
+			}
+			{
+				e.FieldStart("tool_name")
+				e.Str(s.ToolName)
+			}
+			{
+				e.FieldStart("execution_duration_ms")
+				e.Int(s.ExecutionDurationMs)
+			}
+			{
+				e.FieldStart("tool_outcome")
+				s.ToolOutcome.Encode(e)
+			}
+			{
+				if s.ErrorCode.Set {
+					e.FieldStart("error_code")
+					s.ErrorCode.Encode(e)
+				}
+			}
+			{
+				if s.TargetResource.Set {
+					e.FieldStart("target_resource")
+					s.TargetResource.Encode(e)
+				}
+			}
+		}
 	}
 }
 
@@ -11263,6 +14669,39 @@ func (s *AuditEventEventData) Decode(d *jx.Decoder) error {
 				case "actiontype.denied.update":
 					s.Type = AuditEventEventDataActiontypeDeniedUpdateAuditEventEventData
 					found = true
+				case "apifrontend.triage.started":
+					s.Type = ApifrontendTriageStartedPayloadAuditEventEventData
+					found = true
+				case "apifrontend.triage.completed":
+					s.Type = ApifrontendTriageCompletedPayloadAuditEventEventData
+					found = true
+				case "apifrontend.rr.created":
+					s.Type = ApifrontendRRCreatedPayloadAuditEventEventData
+					found = true
+				case "apifrontend.rr.deduplicated":
+					s.Type = ApifrontendRRDeduplicatedPayloadAuditEventEventData
+					found = true
+				case "apifrontend.session.created":
+					s.Type = ApifrontendSessionCreatedPayloadAuditEventEventData
+					found = true
+				case "apifrontend.session.completed":
+					s.Type = ApifrontendSessionCompletedPayloadAuditEventEventData
+					found = true
+				case "apifrontend.ka.delegated":
+					s.Type = ApifrontendKADelegatedPayloadAuditEventEventData
+					found = true
+				case "apifrontend.ka.result_received":
+					s.Type = ApifrontendKAResultReceivedPayloadAuditEventEventData
+					found = true
+				case "apifrontend.user.decision":
+					s.Type = ApifrontendUserDecisionPayloadAuditEventEventData
+					found = true
+				case "apifrontend.auth.access_denied":
+					s.Type = ApifrontendAuthAccessDeniedPayloadAuditEventEventData
+					found = true
+				case "apifrontend.tool.executed":
+					s.Type = ApifrontendToolExecutedPayloadAuditEventEventData
+					found = true
 				default:
 					return errors.Errorf("unknown type %s", typ)
 				}
@@ -11483,6 +14922,50 @@ func (s *AuditEventEventData) Decode(d *jx.Decoder) error {
 		}
 	case AuditEventEventDataActiontypeAdmittedCreateAuditEventEventData, AuditEventEventDataActiontypeAdmittedDeleteAuditEventEventData, AuditEventEventDataActiontypeAdmittedUpdateAuditEventEventData, AuditEventEventDataActiontypeDeniedCreateAuditEventEventData, AuditEventEventDataActiontypeDeniedDeleteAuditEventEventData, AuditEventEventDataActiontypeDeniedUpdateAuditEventEventData:
 		if err := s.ActionTypeWebhookAuditPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendTriageStartedPayloadAuditEventEventData:
+		if err := s.ApifrontendTriageStartedPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendTriageCompletedPayloadAuditEventEventData:
+		if err := s.ApifrontendTriageCompletedPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendRRCreatedPayloadAuditEventEventData:
+		if err := s.ApifrontendRRCreatedPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendRRDeduplicatedPayloadAuditEventEventData:
+		if err := s.ApifrontendRRDeduplicatedPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendSessionCreatedPayloadAuditEventEventData:
+		if err := s.ApifrontendSessionCreatedPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendSessionCompletedPayloadAuditEventEventData:
+		if err := s.ApifrontendSessionCompletedPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendKADelegatedPayloadAuditEventEventData:
+		if err := s.ApifrontendKADelegatedPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendKAResultReceivedPayloadAuditEventEventData:
+		if err := s.ApifrontendKAResultReceivedPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendUserDecisionPayloadAuditEventEventData:
+		if err := s.ApifrontendUserDecisionPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendAuthAccessDeniedPayloadAuditEventEventData:
+		if err := s.ApifrontendAuthAccessDeniedPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendToolExecutedPayloadAuditEventEventData:
+		if err := s.ApifrontendToolExecutedPayload.Decode(d); err != nil {
 			return err
 		}
 	default:
@@ -11948,6 +15431,8 @@ func (s *AuditEventRequestEventCategory) Decode(d *jx.Decoder) error {
 		*s = AuditEventRequestEventCategoryEffectiveness
 	case AuditEventRequestEventCategoryActiontype:
 		*s = AuditEventRequestEventCategoryActiontype
+	case AuditEventRequestEventCategoryApifrontend:
+		*s = AuditEventRequestEventCategoryApifrontend
 	default:
 		*s = AuditEventRequestEventCategory(v)
 	}
@@ -14410,6 +17895,400 @@ func (s AuditEventRequestEventData) encodeFields(e *jx.Encoder) {
 				}
 			}
 		}
+	case ApifrontendTriageStartedPayloadAuditEventRequestEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.triage.started")
+		{
+			s := s.ApifrontendTriageStartedPayload
+			{
+				e.FieldStart("session_id")
+				e.Str(s.SessionID)
+			}
+			{
+				e.FieldStart("persona")
+				s.Persona.Encode(e)
+			}
+			{
+				if s.ModelName.Set {
+					e.FieldStart("model_name")
+					s.ModelName.Encode(e)
+				}
+			}
+			{
+				if s.QueryLength.Set {
+					e.FieldStart("query_length")
+					s.QueryLength.Encode(e)
+				}
+			}
+		}
+	case ApifrontendTriageCompletedPayloadAuditEventRequestEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.triage.completed")
+		{
+			s := s.ApifrontendTriageCompletedPayload
+			{
+				e.FieldStart("session_id")
+				e.Str(s.SessionID)
+			}
+			{
+				e.FieldStart("triage_outcome")
+				s.TriageOutcome.Encode(e)
+			}
+			{
+				e.FieldStart("triage_duration_ms")
+				e.Int(s.TriageDurationMs)
+			}
+			{
+				if s.TokensInput.Set {
+					e.FieldStart("tokens_input")
+					s.TokensInput.Encode(e)
+				}
+			}
+			{
+				if s.TokensOutput.Set {
+					e.FieldStart("tokens_output")
+					s.TokensOutput.Encode(e)
+				}
+			}
+			{
+				if s.ToolsCalled != nil {
+					e.FieldStart("tools_called")
+					e.ArrStart()
+					for _, elem := range s.ToolsCalled {
+						e.Str(elem)
+					}
+					e.ArrEnd()
+				}
+			}
+			{
+				if s.ToolsCallCount.Set {
+					e.FieldStart("tools_call_count")
+					s.ToolsCallCount.Encode(e)
+				}
+			}
+		}
+	case ApifrontendRRCreatedPayloadAuditEventRequestEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.rr.created")
+		{
+			s := s.ApifrontendRRCreatedPayload
+			{
+				e.FieldStart("session_id")
+				e.Str(s.SessionID)
+			}
+			{
+				e.FieldStart("rr_name")
+				e.Str(s.RrName)
+			}
+			{
+				e.FieldStart("rr_namespace")
+				e.Str(s.RrNamespace)
+			}
+			{
+				e.FieldStart("target_kind")
+				e.Str(s.TargetKind)
+			}
+			{
+				e.FieldStart("target_name")
+				e.Str(s.TargetName)
+			}
+			{
+				e.FieldStart("fingerprint")
+				e.Str(s.Fingerprint)
+			}
+			{
+				if s.SignalSource.Set {
+					e.FieldStart("signal_source")
+					s.SignalSource.Encode(e)
+				}
+			}
+		}
+	case ApifrontendRRDeduplicatedPayloadAuditEventRequestEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.rr.deduplicated")
+		{
+			s := s.ApifrontendRRDeduplicatedPayload
+			{
+				e.FieldStart("session_id")
+				e.Str(s.SessionID)
+			}
+			{
+				e.FieldStart("fingerprint")
+				e.Str(s.Fingerprint)
+			}
+			{
+				e.FieldStart("existing_rr_name")
+				e.Str(s.ExistingRrName)
+			}
+			{
+				if s.ExistingRrNamespace.Set {
+					e.FieldStart("existing_rr_namespace")
+					s.ExistingRrNamespace.Encode(e)
+				}
+			}
+			{
+				if s.LeaseHolder.Set {
+					e.FieldStart("lease_holder")
+					s.LeaseHolder.Encode(e)
+				}
+			}
+		}
+	case ApifrontendSessionCreatedPayloadAuditEventRequestEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.session.created")
+		{
+			s := s.ApifrontendSessionCreatedPayload
+			{
+				e.FieldStart("session_id")
+				e.Str(s.SessionID)
+			}
+			{
+				e.FieldStart("a2a_task_id")
+				e.Str(s.A2aTaskID)
+			}
+			{
+				if s.RrRef.Set {
+					e.FieldStart("rr_ref")
+					s.RrRef.Encode(e)
+				}
+			}
+			{
+				e.FieldStart("join_mode")
+				s.JoinMode.Encode(e)
+			}
+			{
+				e.FieldStart("user_identity")
+				e.Str(s.UserIdentity)
+			}
+			{
+				if s.UserGroups != nil {
+					e.FieldStart("user_groups")
+					e.ArrStart()
+					for _, elem := range s.UserGroups {
+						e.Str(elem)
+					}
+					e.ArrEnd()
+				}
+			}
+		}
+	case ApifrontendSessionCompletedPayloadAuditEventRequestEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.session.completed")
+		{
+			s := s.ApifrontendSessionCompletedPayload
+			{
+				e.FieldStart("session_id")
+				e.Str(s.SessionID)
+			}
+			{
+				e.FieldStart("terminal_phase")
+				s.TerminalPhase.Encode(e)
+			}
+			{
+				e.FieldStart("total_duration_ms")
+				e.Int(s.TotalDurationMs)
+			}
+			{
+				if s.TotalTokensInput.Set {
+					e.FieldStart("total_tokens_input")
+					s.TotalTokensInput.Encode(e)
+				}
+			}
+			{
+				if s.TotalTokensOutput.Set {
+					e.FieldStart("total_tokens_output")
+					s.TotalTokensOutput.Encode(e)
+				}
+			}
+			{
+				if s.TotalToolCalls.Set {
+					e.FieldStart("total_tool_calls")
+					s.TotalToolCalls.Encode(e)
+				}
+			}
+			{
+				if s.PollsCount.Set {
+					e.FieldStart("polls_count")
+					s.PollsCount.Encode(e)
+				}
+			}
+			{
+				if s.UserDecision.Set {
+					e.FieldStart("user_decision")
+					s.UserDecision.Encode(e)
+				}
+			}
+		}
+	case ApifrontendKADelegatedPayloadAuditEventRequestEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.ka.delegated")
+		{
+			s := s.ApifrontendKADelegatedPayload
+			{
+				e.FieldStart("session_id")
+				e.Str(s.SessionID)
+			}
+			{
+				e.FieldStart("ka_correlation_id")
+				e.Str(s.KaCorrelationID)
+			}
+			{
+				e.FieldStart("delegation_type")
+				s.DelegationType.Encode(e)
+			}
+			{
+				if s.RrName.Set {
+					e.FieldStart("rr_name")
+					s.RrName.Encode(e)
+				}
+			}
+			{
+				if s.RrNamespace.Set {
+					e.FieldStart("rr_namespace")
+					s.RrNamespace.Encode(e)
+				}
+			}
+		}
+	case ApifrontendKAResultReceivedPayloadAuditEventRequestEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.ka.result_received")
+		{
+			s := s.ApifrontendKAResultReceivedPayload
+			{
+				e.FieldStart("session_id")
+				e.Str(s.SessionID)
+			}
+			{
+				e.FieldStart("ka_correlation_id")
+				e.Str(s.KaCorrelationID)
+			}
+			{
+				e.FieldStart("result_type")
+				s.ResultType.Encode(e)
+			}
+			{
+				if s.InvestigationDurationMs.Set {
+					e.FieldStart("investigation_duration_ms")
+					s.InvestigationDurationMs.Encode(e)
+				}
+			}
+			{
+				if s.Confidence.Set {
+					e.FieldStart("confidence")
+					s.Confidence.Encode(e)
+				}
+			}
+			{
+				if s.WorkflowCandidatesCount.Set {
+					e.FieldStart("workflow_candidates_count")
+					s.WorkflowCandidatesCount.Encode(e)
+				}
+			}
+		}
+	case ApifrontendUserDecisionPayloadAuditEventRequestEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.user.decision")
+		{
+			s := s.ApifrontendUserDecisionPayload
+			{
+				e.FieldStart("session_id")
+				e.Str(s.SessionID)
+			}
+			{
+				e.FieldStart("decision")
+				s.Decision.Encode(e)
+			}
+			{
+				if s.WorkflowID.Set {
+					e.FieldStart("workflow_id")
+					s.WorkflowID.Encode(e)
+				}
+			}
+			{
+				if s.TimeToDecisionMs.Set {
+					e.FieldStart("time_to_decision_ms")
+					s.TimeToDecisionMs.Encode(e)
+				}
+			}
+			{
+				if s.RrName.Set {
+					e.FieldStart("rr_name")
+					s.RrName.Encode(e)
+				}
+			}
+		}
+	case ApifrontendAuthAccessDeniedPayloadAuditEventRequestEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.auth.access_denied")
+		{
+			s := s.ApifrontendAuthAccessDeniedPayload
+			{
+				if s.SessionID.Set {
+					e.FieldStart("session_id")
+					s.SessionID.Encode(e)
+				}
+			}
+			{
+				e.FieldStart("tool_name")
+				e.Str(s.ToolName)
+			}
+			{
+				e.FieldStart("user_role")
+				e.Str(s.UserRole)
+			}
+			{
+				e.FieldStart("required_roles")
+				e.ArrStart()
+				for _, elem := range s.RequiredRoles {
+					e.Str(elem)
+				}
+				e.ArrEnd()
+			}
+			{
+				e.FieldStart("endpoint")
+				s.Endpoint.Encode(e)
+			}
+			{
+				if s.Reason.Set {
+					e.FieldStart("reason")
+					s.Reason.Encode(e)
+				}
+			}
+		}
+	case ApifrontendToolExecutedPayloadAuditEventRequestEventData:
+		e.FieldStart("event_type")
+		e.Str("apifrontend.tool.executed")
+		{
+			s := s.ApifrontendToolExecutedPayload
+			{
+				e.FieldStart("session_id")
+				e.Str(s.SessionID)
+			}
+			{
+				e.FieldStart("tool_name")
+				e.Str(s.ToolName)
+			}
+			{
+				e.FieldStart("execution_duration_ms")
+				e.Int(s.ExecutionDurationMs)
+			}
+			{
+				e.FieldStart("tool_outcome")
+				s.ToolOutcome.Encode(e)
+			}
+			{
+				if s.ErrorCode.Set {
+					e.FieldStart("error_code")
+					s.ErrorCode.Encode(e)
+				}
+			}
+			{
+				if s.TargetResource.Set {
+					e.FieldStart("target_resource")
+					s.TargetResource.Encode(e)
+				}
+			}
+		}
 	}
 }
 
@@ -14736,6 +18615,39 @@ func (s *AuditEventRequestEventData) Decode(d *jx.Decoder) error {
 				case "actiontype.denied.update":
 					s.Type = AuditEventRequestEventDataActiontypeDeniedUpdateAuditEventRequestEventData
 					found = true
+				case "apifrontend.triage.started":
+					s.Type = ApifrontendTriageStartedPayloadAuditEventRequestEventData
+					found = true
+				case "apifrontend.triage.completed":
+					s.Type = ApifrontendTriageCompletedPayloadAuditEventRequestEventData
+					found = true
+				case "apifrontend.rr.created":
+					s.Type = ApifrontendRRCreatedPayloadAuditEventRequestEventData
+					found = true
+				case "apifrontend.rr.deduplicated":
+					s.Type = ApifrontendRRDeduplicatedPayloadAuditEventRequestEventData
+					found = true
+				case "apifrontend.session.created":
+					s.Type = ApifrontendSessionCreatedPayloadAuditEventRequestEventData
+					found = true
+				case "apifrontend.session.completed":
+					s.Type = ApifrontendSessionCompletedPayloadAuditEventRequestEventData
+					found = true
+				case "apifrontend.ka.delegated":
+					s.Type = ApifrontendKADelegatedPayloadAuditEventRequestEventData
+					found = true
+				case "apifrontend.ka.result_received":
+					s.Type = ApifrontendKAResultReceivedPayloadAuditEventRequestEventData
+					found = true
+				case "apifrontend.user.decision":
+					s.Type = ApifrontendUserDecisionPayloadAuditEventRequestEventData
+					found = true
+				case "apifrontend.auth.access_denied":
+					s.Type = ApifrontendAuthAccessDeniedPayloadAuditEventRequestEventData
+					found = true
+				case "apifrontend.tool.executed":
+					s.Type = ApifrontendToolExecutedPayloadAuditEventRequestEventData
+					found = true
 				default:
 					return errors.Errorf("unknown type %s", typ)
 				}
@@ -14956,6 +18868,50 @@ func (s *AuditEventRequestEventData) Decode(d *jx.Decoder) error {
 		}
 	case AuditEventRequestEventDataActiontypeAdmittedCreateAuditEventRequestEventData, AuditEventRequestEventDataActiontypeAdmittedDeleteAuditEventRequestEventData, AuditEventRequestEventDataActiontypeAdmittedUpdateAuditEventRequestEventData, AuditEventRequestEventDataActiontypeDeniedCreateAuditEventRequestEventData, AuditEventRequestEventDataActiontypeDeniedDeleteAuditEventRequestEventData, AuditEventRequestEventDataActiontypeDeniedUpdateAuditEventRequestEventData:
 		if err := s.ActionTypeWebhookAuditPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendTriageStartedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendTriageStartedPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendTriageCompletedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendTriageCompletedPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendRRCreatedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendRRCreatedPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendRRDeduplicatedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendRRDeduplicatedPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendSessionCreatedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendSessionCreatedPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendSessionCompletedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendSessionCompletedPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendKADelegatedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendKADelegatedPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendKAResultReceivedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendKAResultReceivedPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendUserDecisionPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendUserDecisionPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendAuthAccessDeniedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendAuthAccessDeniedPayload.Decode(d); err != nil {
+			return err
+		}
+	case ApifrontendToolExecutedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendToolExecutedPayload.Decode(d); err != nil {
 			return err
 		}
 	default:
@@ -26338,6 +30294,39 @@ func (s OptActionTypeDescription) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *OptActionTypeDescription) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes ApifrontendSessionCompletedPayloadUserDecision as json.
+func (o OptApifrontendSessionCompletedPayloadUserDecision) Encode(e *jx.Encoder) {
+	if !o.Set {
+		return
+	}
+	e.Str(string(o.Value))
+}
+
+// Decode decodes ApifrontendSessionCompletedPayloadUserDecision from json.
+func (o *OptApifrontendSessionCompletedPayloadUserDecision) Decode(d *jx.Decoder) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptApifrontendSessionCompletedPayloadUserDecision to nil")
+	}
+	o.Set = true
+	if err := o.Value.Decode(d); err != nil {
+		return err
+	}
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptApifrontendSessionCompletedPayloadUserDecision) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptApifrontendSessionCompletedPayloadUserDecision) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/pkg/datastorage/ogen-client/oas_schemas_gen.go
+++ b/pkg/datastorage/ogen-client/oas_schemas_gen.go
@@ -3749,6 +3749,1903 @@ func (s *ActionTypeWorkflowCountResponse) SetCount(val int) {
 	s.Count = val
 }
 
+// Auth access denied event payload (apifrontend.auth.access_denied) — tool invocation denied by
+// RBAC (SOC2 CC6.1, Issue.
+// Ref: #/components/schemas/ApifrontendAuthAccessDeniedPayload
+type ApifrontendAuthAccessDeniedPayload struct {
+	// Event type for discriminator (matches parent event_type).
+	EventType ApifrontendAuthAccessDeniedPayloadEventType `json:"event_type"`
+	// Session ID if available (may be empty for pre-session auth failures).
+	SessionID OptString `json:"session_id"`
+	// MCP tool that was denied.
+	ToolName string `json:"tool_name"`
+	// User's actual role from JWT.
+	UserRole string `json:"user_role"`
+	// Roles that would grant access to this tool.
+	RequiredRoles []string `json:"required_roles"`
+	// Which protocol endpoint the request came through.
+	Endpoint ApifrontendAuthAccessDeniedPayloadEndpoint `json:"endpoint"`
+	// Denial reason (rbac_policy, token_expired, invalid_scope, etc.).
+	Reason OptString `json:"reason"`
+}
+
+// GetEventType returns the value of EventType.
+func (s *ApifrontendAuthAccessDeniedPayload) GetEventType() ApifrontendAuthAccessDeniedPayloadEventType {
+	return s.EventType
+}
+
+// GetSessionID returns the value of SessionID.
+func (s *ApifrontendAuthAccessDeniedPayload) GetSessionID() OptString {
+	return s.SessionID
+}
+
+// GetToolName returns the value of ToolName.
+func (s *ApifrontendAuthAccessDeniedPayload) GetToolName() string {
+	return s.ToolName
+}
+
+// GetUserRole returns the value of UserRole.
+func (s *ApifrontendAuthAccessDeniedPayload) GetUserRole() string {
+	return s.UserRole
+}
+
+// GetRequiredRoles returns the value of RequiredRoles.
+func (s *ApifrontendAuthAccessDeniedPayload) GetRequiredRoles() []string {
+	return s.RequiredRoles
+}
+
+// GetEndpoint returns the value of Endpoint.
+func (s *ApifrontendAuthAccessDeniedPayload) GetEndpoint() ApifrontendAuthAccessDeniedPayloadEndpoint {
+	return s.Endpoint
+}
+
+// GetReason returns the value of Reason.
+func (s *ApifrontendAuthAccessDeniedPayload) GetReason() OptString {
+	return s.Reason
+}
+
+// SetEventType sets the value of EventType.
+func (s *ApifrontendAuthAccessDeniedPayload) SetEventType(val ApifrontendAuthAccessDeniedPayloadEventType) {
+	s.EventType = val
+}
+
+// SetSessionID sets the value of SessionID.
+func (s *ApifrontendAuthAccessDeniedPayload) SetSessionID(val OptString) {
+	s.SessionID = val
+}
+
+// SetToolName sets the value of ToolName.
+func (s *ApifrontendAuthAccessDeniedPayload) SetToolName(val string) {
+	s.ToolName = val
+}
+
+// SetUserRole sets the value of UserRole.
+func (s *ApifrontendAuthAccessDeniedPayload) SetUserRole(val string) {
+	s.UserRole = val
+}
+
+// SetRequiredRoles sets the value of RequiredRoles.
+func (s *ApifrontendAuthAccessDeniedPayload) SetRequiredRoles(val []string) {
+	s.RequiredRoles = val
+}
+
+// SetEndpoint sets the value of Endpoint.
+func (s *ApifrontendAuthAccessDeniedPayload) SetEndpoint(val ApifrontendAuthAccessDeniedPayloadEndpoint) {
+	s.Endpoint = val
+}
+
+// SetReason sets the value of Reason.
+func (s *ApifrontendAuthAccessDeniedPayload) SetReason(val OptString) {
+	s.Reason = val
+}
+
+// Which protocol endpoint the request came through.
+type ApifrontendAuthAccessDeniedPayloadEndpoint string
+
+const (
+	ApifrontendAuthAccessDeniedPayloadEndpointA2a ApifrontendAuthAccessDeniedPayloadEndpoint = "a2a"
+	ApifrontendAuthAccessDeniedPayloadEndpointMcp ApifrontendAuthAccessDeniedPayloadEndpoint = "mcp"
+)
+
+// AllValues returns all ApifrontendAuthAccessDeniedPayloadEndpoint values.
+func (ApifrontendAuthAccessDeniedPayloadEndpoint) AllValues() []ApifrontendAuthAccessDeniedPayloadEndpoint {
+	return []ApifrontendAuthAccessDeniedPayloadEndpoint{
+		ApifrontendAuthAccessDeniedPayloadEndpointA2a,
+		ApifrontendAuthAccessDeniedPayloadEndpointMcp,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendAuthAccessDeniedPayloadEndpoint) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendAuthAccessDeniedPayloadEndpointA2a:
+		return []byte(s), nil
+	case ApifrontendAuthAccessDeniedPayloadEndpointMcp:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendAuthAccessDeniedPayloadEndpoint) UnmarshalText(data []byte) error {
+	switch ApifrontendAuthAccessDeniedPayloadEndpoint(data) {
+	case ApifrontendAuthAccessDeniedPayloadEndpointA2a:
+		*s = ApifrontendAuthAccessDeniedPayloadEndpointA2a
+		return nil
+	case ApifrontendAuthAccessDeniedPayloadEndpointMcp:
+		*s = ApifrontendAuthAccessDeniedPayloadEndpointMcp
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Event type for discriminator (matches parent event_type).
+type ApifrontendAuthAccessDeniedPayloadEventType string
+
+const (
+	ApifrontendAuthAccessDeniedPayloadEventTypeApifrontendAuthAccessDenied ApifrontendAuthAccessDeniedPayloadEventType = "apifrontend.auth.access_denied"
+)
+
+// AllValues returns all ApifrontendAuthAccessDeniedPayloadEventType values.
+func (ApifrontendAuthAccessDeniedPayloadEventType) AllValues() []ApifrontendAuthAccessDeniedPayloadEventType {
+	return []ApifrontendAuthAccessDeniedPayloadEventType{
+		ApifrontendAuthAccessDeniedPayloadEventTypeApifrontendAuthAccessDenied,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendAuthAccessDeniedPayloadEventType) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendAuthAccessDeniedPayloadEventTypeApifrontendAuthAccessDenied:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendAuthAccessDeniedPayloadEventType) UnmarshalText(data []byte) error {
+	switch ApifrontendAuthAccessDeniedPayloadEventType(data) {
+	case ApifrontendAuthAccessDeniedPayloadEventTypeApifrontendAuthAccessDenied:
+		*s = ApifrontendAuthAccessDeniedPayloadEventTypeApifrontendAuthAccessDenied
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// KA delegation event payload (apifrontend.ka.delegated) — investigation delegated to Kubernaut
+// Agent (SOC2 CC7.2, Issue.
+// Ref: #/components/schemas/ApifrontendKADelegatedPayload
+type ApifrontendKADelegatedPayload struct {
+	// Event type for discriminator (matches parent event_type).
+	EventType ApifrontendKADelegatedPayloadEventType `json:"event_type"`
+	// InvestigationSession CRD name.
+	SessionID string `json:"session_id"`
+	// Correlation ID returned by KA's /analyze endpoint.
+	KaCorrelationID string `json:"ka_correlation_id"`
+	// Whether delegated via REST (autonomous) or MCP (interactive).
+	DelegationType ApifrontendKADelegatedPayloadDelegationType `json:"delegation_type"`
+	// Associated RemediationRequest name.
+	RrName OptString `json:"rr_name"`
+	// Associated RemediationRequest namespace.
+	RrNamespace OptString `json:"rr_namespace"`
+}
+
+// GetEventType returns the value of EventType.
+func (s *ApifrontendKADelegatedPayload) GetEventType() ApifrontendKADelegatedPayloadEventType {
+	return s.EventType
+}
+
+// GetSessionID returns the value of SessionID.
+func (s *ApifrontendKADelegatedPayload) GetSessionID() string {
+	return s.SessionID
+}
+
+// GetKaCorrelationID returns the value of KaCorrelationID.
+func (s *ApifrontendKADelegatedPayload) GetKaCorrelationID() string {
+	return s.KaCorrelationID
+}
+
+// GetDelegationType returns the value of DelegationType.
+func (s *ApifrontendKADelegatedPayload) GetDelegationType() ApifrontendKADelegatedPayloadDelegationType {
+	return s.DelegationType
+}
+
+// GetRrName returns the value of RrName.
+func (s *ApifrontendKADelegatedPayload) GetRrName() OptString {
+	return s.RrName
+}
+
+// GetRrNamespace returns the value of RrNamespace.
+func (s *ApifrontendKADelegatedPayload) GetRrNamespace() OptString {
+	return s.RrNamespace
+}
+
+// SetEventType sets the value of EventType.
+func (s *ApifrontendKADelegatedPayload) SetEventType(val ApifrontendKADelegatedPayloadEventType) {
+	s.EventType = val
+}
+
+// SetSessionID sets the value of SessionID.
+func (s *ApifrontendKADelegatedPayload) SetSessionID(val string) {
+	s.SessionID = val
+}
+
+// SetKaCorrelationID sets the value of KaCorrelationID.
+func (s *ApifrontendKADelegatedPayload) SetKaCorrelationID(val string) {
+	s.KaCorrelationID = val
+}
+
+// SetDelegationType sets the value of DelegationType.
+func (s *ApifrontendKADelegatedPayload) SetDelegationType(val ApifrontendKADelegatedPayloadDelegationType) {
+	s.DelegationType = val
+}
+
+// SetRrName sets the value of RrName.
+func (s *ApifrontendKADelegatedPayload) SetRrName(val OptString) {
+	s.RrName = val
+}
+
+// SetRrNamespace sets the value of RrNamespace.
+func (s *ApifrontendKADelegatedPayload) SetRrNamespace(val OptString) {
+	s.RrNamespace = val
+}
+
+// Whether delegated via REST (autonomous) or MCP (interactive).
+type ApifrontendKADelegatedPayloadDelegationType string
+
+const (
+	ApifrontendKADelegatedPayloadDelegationTypeAutonomous  ApifrontendKADelegatedPayloadDelegationType = "autonomous"
+	ApifrontendKADelegatedPayloadDelegationTypeInteractive ApifrontendKADelegatedPayloadDelegationType = "interactive"
+)
+
+// AllValues returns all ApifrontendKADelegatedPayloadDelegationType values.
+func (ApifrontendKADelegatedPayloadDelegationType) AllValues() []ApifrontendKADelegatedPayloadDelegationType {
+	return []ApifrontendKADelegatedPayloadDelegationType{
+		ApifrontendKADelegatedPayloadDelegationTypeAutonomous,
+		ApifrontendKADelegatedPayloadDelegationTypeInteractive,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendKADelegatedPayloadDelegationType) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendKADelegatedPayloadDelegationTypeAutonomous:
+		return []byte(s), nil
+	case ApifrontendKADelegatedPayloadDelegationTypeInteractive:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendKADelegatedPayloadDelegationType) UnmarshalText(data []byte) error {
+	switch ApifrontendKADelegatedPayloadDelegationType(data) {
+	case ApifrontendKADelegatedPayloadDelegationTypeAutonomous:
+		*s = ApifrontendKADelegatedPayloadDelegationTypeAutonomous
+		return nil
+	case ApifrontendKADelegatedPayloadDelegationTypeInteractive:
+		*s = ApifrontendKADelegatedPayloadDelegationTypeInteractive
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Event type for discriminator (matches parent event_type).
+type ApifrontendKADelegatedPayloadEventType string
+
+const (
+	ApifrontendKADelegatedPayloadEventTypeApifrontendKaDelegated ApifrontendKADelegatedPayloadEventType = "apifrontend.ka.delegated"
+)
+
+// AllValues returns all ApifrontendKADelegatedPayloadEventType values.
+func (ApifrontendKADelegatedPayloadEventType) AllValues() []ApifrontendKADelegatedPayloadEventType {
+	return []ApifrontendKADelegatedPayloadEventType{
+		ApifrontendKADelegatedPayloadEventTypeApifrontendKaDelegated,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendKADelegatedPayloadEventType) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendKADelegatedPayloadEventTypeApifrontendKaDelegated:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendKADelegatedPayloadEventType) UnmarshalText(data []byte) error {
+	switch ApifrontendKADelegatedPayloadEventType(data) {
+	case ApifrontendKADelegatedPayloadEventTypeApifrontendKaDelegated:
+		*s = ApifrontendKADelegatedPayloadEventTypeApifrontendKaDelegated
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// KA result received event payload (apifrontend.ka.result_received) — RCA result received from KA
+// (SOC2 CC7.2, Issue.
+// Ref: #/components/schemas/ApifrontendKAResultReceivedPayload
+type ApifrontendKAResultReceivedPayload struct {
+	// Event type for discriminator (matches parent event_type).
+	EventType ApifrontendKAResultReceivedPayloadEventType `json:"event_type"`
+	// InvestigationSession CRD name.
+	SessionID string `json:"session_id"`
+	// Correlation ID linking to the delegation event.
+	KaCorrelationID string `json:"ka_correlation_id"`
+	// Type of result received from KA.
+	ResultType ApifrontendKAResultReceivedPayloadResultType `json:"result_type"`
+	// Time from delegation to result receipt.
+	InvestigationDurationMs OptInt `json:"investigation_duration_ms"`
+	// RCA confidence score (0.0-1.0, if available).
+	Confidence OptFloat32 `json:"confidence"`
+	// Number of workflow candidates identified by KA.
+	WorkflowCandidatesCount OptInt `json:"workflow_candidates_count"`
+}
+
+// GetEventType returns the value of EventType.
+func (s *ApifrontendKAResultReceivedPayload) GetEventType() ApifrontendKAResultReceivedPayloadEventType {
+	return s.EventType
+}
+
+// GetSessionID returns the value of SessionID.
+func (s *ApifrontendKAResultReceivedPayload) GetSessionID() string {
+	return s.SessionID
+}
+
+// GetKaCorrelationID returns the value of KaCorrelationID.
+func (s *ApifrontendKAResultReceivedPayload) GetKaCorrelationID() string {
+	return s.KaCorrelationID
+}
+
+// GetResultType returns the value of ResultType.
+func (s *ApifrontendKAResultReceivedPayload) GetResultType() ApifrontendKAResultReceivedPayloadResultType {
+	return s.ResultType
+}
+
+// GetInvestigationDurationMs returns the value of InvestigationDurationMs.
+func (s *ApifrontendKAResultReceivedPayload) GetInvestigationDurationMs() OptInt {
+	return s.InvestigationDurationMs
+}
+
+// GetConfidence returns the value of Confidence.
+func (s *ApifrontendKAResultReceivedPayload) GetConfidence() OptFloat32 {
+	return s.Confidence
+}
+
+// GetWorkflowCandidatesCount returns the value of WorkflowCandidatesCount.
+func (s *ApifrontendKAResultReceivedPayload) GetWorkflowCandidatesCount() OptInt {
+	return s.WorkflowCandidatesCount
+}
+
+// SetEventType sets the value of EventType.
+func (s *ApifrontendKAResultReceivedPayload) SetEventType(val ApifrontendKAResultReceivedPayloadEventType) {
+	s.EventType = val
+}
+
+// SetSessionID sets the value of SessionID.
+func (s *ApifrontendKAResultReceivedPayload) SetSessionID(val string) {
+	s.SessionID = val
+}
+
+// SetKaCorrelationID sets the value of KaCorrelationID.
+func (s *ApifrontendKAResultReceivedPayload) SetKaCorrelationID(val string) {
+	s.KaCorrelationID = val
+}
+
+// SetResultType sets the value of ResultType.
+func (s *ApifrontendKAResultReceivedPayload) SetResultType(val ApifrontendKAResultReceivedPayloadResultType) {
+	s.ResultType = val
+}
+
+// SetInvestigationDurationMs sets the value of InvestigationDurationMs.
+func (s *ApifrontendKAResultReceivedPayload) SetInvestigationDurationMs(val OptInt) {
+	s.InvestigationDurationMs = val
+}
+
+// SetConfidence sets the value of Confidence.
+func (s *ApifrontendKAResultReceivedPayload) SetConfidence(val OptFloat32) {
+	s.Confidence = val
+}
+
+// SetWorkflowCandidatesCount sets the value of WorkflowCandidatesCount.
+func (s *ApifrontendKAResultReceivedPayload) SetWorkflowCandidatesCount(val OptInt) {
+	s.WorkflowCandidatesCount = val
+}
+
+// Event type for discriminator (matches parent event_type).
+type ApifrontendKAResultReceivedPayloadEventType string
+
+const (
+	ApifrontendKAResultReceivedPayloadEventTypeApifrontendKaResultReceived ApifrontendKAResultReceivedPayloadEventType = "apifrontend.ka.result_received"
+)
+
+// AllValues returns all ApifrontendKAResultReceivedPayloadEventType values.
+func (ApifrontendKAResultReceivedPayloadEventType) AllValues() []ApifrontendKAResultReceivedPayloadEventType {
+	return []ApifrontendKAResultReceivedPayloadEventType{
+		ApifrontendKAResultReceivedPayloadEventTypeApifrontendKaResultReceived,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendKAResultReceivedPayloadEventType) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendKAResultReceivedPayloadEventTypeApifrontendKaResultReceived:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendKAResultReceivedPayloadEventType) UnmarshalText(data []byte) error {
+	switch ApifrontendKAResultReceivedPayloadEventType(data) {
+	case ApifrontendKAResultReceivedPayloadEventTypeApifrontendKaResultReceived:
+		*s = ApifrontendKAResultReceivedPayloadEventTypeApifrontendKaResultReceived
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Type of result received from KA.
+type ApifrontendKAResultReceivedPayloadResultType string
+
+const (
+	ApifrontendKAResultReceivedPayloadResultTypeRcaComplete ApifrontendKAResultReceivedPayloadResultType = "rca_complete"
+	ApifrontendKAResultReceivedPayloadResultTypeRcaFailed   ApifrontendKAResultReceivedPayloadResultType = "rca_failed"
+	ApifrontendKAResultReceivedPayloadResultTypeTimeout     ApifrontendKAResultReceivedPayloadResultType = "timeout"
+	ApifrontendKAResultReceivedPayloadResultTypeCancelled   ApifrontendKAResultReceivedPayloadResultType = "cancelled"
+)
+
+// AllValues returns all ApifrontendKAResultReceivedPayloadResultType values.
+func (ApifrontendKAResultReceivedPayloadResultType) AllValues() []ApifrontendKAResultReceivedPayloadResultType {
+	return []ApifrontendKAResultReceivedPayloadResultType{
+		ApifrontendKAResultReceivedPayloadResultTypeRcaComplete,
+		ApifrontendKAResultReceivedPayloadResultTypeRcaFailed,
+		ApifrontendKAResultReceivedPayloadResultTypeTimeout,
+		ApifrontendKAResultReceivedPayloadResultTypeCancelled,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendKAResultReceivedPayloadResultType) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendKAResultReceivedPayloadResultTypeRcaComplete:
+		return []byte(s), nil
+	case ApifrontendKAResultReceivedPayloadResultTypeRcaFailed:
+		return []byte(s), nil
+	case ApifrontendKAResultReceivedPayloadResultTypeTimeout:
+		return []byte(s), nil
+	case ApifrontendKAResultReceivedPayloadResultTypeCancelled:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendKAResultReceivedPayloadResultType) UnmarshalText(data []byte) error {
+	switch ApifrontendKAResultReceivedPayloadResultType(data) {
+	case ApifrontendKAResultReceivedPayloadResultTypeRcaComplete:
+		*s = ApifrontendKAResultReceivedPayloadResultTypeRcaComplete
+		return nil
+	case ApifrontendKAResultReceivedPayloadResultTypeRcaFailed:
+		*s = ApifrontendKAResultReceivedPayloadResultTypeRcaFailed
+		return nil
+	case ApifrontendKAResultReceivedPayloadResultTypeTimeout:
+		*s = ApifrontendKAResultReceivedPayloadResultTypeTimeout
+		return nil
+	case ApifrontendKAResultReceivedPayloadResultTypeCancelled:
+		*s = ApifrontendKAResultReceivedPayloadResultTypeCancelled
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// RemediationRequest created event payload (apifrontend.rr.created) — AF created an RR (SOC2 CC7.2,
+//
+//	Issue.
+//
+// Ref: #/components/schemas/ApifrontendRRCreatedPayload
+type ApifrontendRRCreatedPayload struct {
+	// Event type for discriminator (matches parent event_type).
+	EventType ApifrontendRRCreatedPayloadEventType `json:"event_type"`
+	// InvestigationSession CRD name.
+	SessionID string `json:"session_id"`
+	// RemediationRequest CRD name.
+	RrName string `json:"rr_name"`
+	// K8s namespace of the RR.
+	RrNamespace string `json:"rr_namespace"`
+	// Target resource kind (Deployment, StatefulSet, etc.).
+	TargetKind string `json:"target_kind"`
+	// Target resource name.
+	TargetName string `json:"target_name"`
+	// Dedup fingerprint hash.
+	Fingerprint string `json:"fingerprint"`
+	// How the signal was received (nl_query, alert_forward, etc.).
+	SignalSource OptString `json:"signal_source"`
+}
+
+// GetEventType returns the value of EventType.
+func (s *ApifrontendRRCreatedPayload) GetEventType() ApifrontendRRCreatedPayloadEventType {
+	return s.EventType
+}
+
+// GetSessionID returns the value of SessionID.
+func (s *ApifrontendRRCreatedPayload) GetSessionID() string {
+	return s.SessionID
+}
+
+// GetRrName returns the value of RrName.
+func (s *ApifrontendRRCreatedPayload) GetRrName() string {
+	return s.RrName
+}
+
+// GetRrNamespace returns the value of RrNamespace.
+func (s *ApifrontendRRCreatedPayload) GetRrNamespace() string {
+	return s.RrNamespace
+}
+
+// GetTargetKind returns the value of TargetKind.
+func (s *ApifrontendRRCreatedPayload) GetTargetKind() string {
+	return s.TargetKind
+}
+
+// GetTargetName returns the value of TargetName.
+func (s *ApifrontendRRCreatedPayload) GetTargetName() string {
+	return s.TargetName
+}
+
+// GetFingerprint returns the value of Fingerprint.
+func (s *ApifrontendRRCreatedPayload) GetFingerprint() string {
+	return s.Fingerprint
+}
+
+// GetSignalSource returns the value of SignalSource.
+func (s *ApifrontendRRCreatedPayload) GetSignalSource() OptString {
+	return s.SignalSource
+}
+
+// SetEventType sets the value of EventType.
+func (s *ApifrontendRRCreatedPayload) SetEventType(val ApifrontendRRCreatedPayloadEventType) {
+	s.EventType = val
+}
+
+// SetSessionID sets the value of SessionID.
+func (s *ApifrontendRRCreatedPayload) SetSessionID(val string) {
+	s.SessionID = val
+}
+
+// SetRrName sets the value of RrName.
+func (s *ApifrontendRRCreatedPayload) SetRrName(val string) {
+	s.RrName = val
+}
+
+// SetRrNamespace sets the value of RrNamespace.
+func (s *ApifrontendRRCreatedPayload) SetRrNamespace(val string) {
+	s.RrNamespace = val
+}
+
+// SetTargetKind sets the value of TargetKind.
+func (s *ApifrontendRRCreatedPayload) SetTargetKind(val string) {
+	s.TargetKind = val
+}
+
+// SetTargetName sets the value of TargetName.
+func (s *ApifrontendRRCreatedPayload) SetTargetName(val string) {
+	s.TargetName = val
+}
+
+// SetFingerprint sets the value of Fingerprint.
+func (s *ApifrontendRRCreatedPayload) SetFingerprint(val string) {
+	s.Fingerprint = val
+}
+
+// SetSignalSource sets the value of SignalSource.
+func (s *ApifrontendRRCreatedPayload) SetSignalSource(val OptString) {
+	s.SignalSource = val
+}
+
+// Event type for discriminator (matches parent event_type).
+type ApifrontendRRCreatedPayloadEventType string
+
+const (
+	ApifrontendRRCreatedPayloadEventTypeApifrontendRrCreated ApifrontendRRCreatedPayloadEventType = "apifrontend.rr.created"
+)
+
+// AllValues returns all ApifrontendRRCreatedPayloadEventType values.
+func (ApifrontendRRCreatedPayloadEventType) AllValues() []ApifrontendRRCreatedPayloadEventType {
+	return []ApifrontendRRCreatedPayloadEventType{
+		ApifrontendRRCreatedPayloadEventTypeApifrontendRrCreated,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendRRCreatedPayloadEventType) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendRRCreatedPayloadEventTypeApifrontendRrCreated:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendRRCreatedPayloadEventType) UnmarshalText(data []byte) error {
+	switch ApifrontendRRCreatedPayloadEventType(data) {
+	case ApifrontendRRCreatedPayloadEventTypeApifrontendRrCreated:
+		*s = ApifrontendRRCreatedPayloadEventTypeApifrontendRrCreated
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// RR deduplicated event payload (apifrontend.rr.deduplicated) — RR creation skipped due to
+// fingerprint match (SOC2 CC7.2, Issue.
+// Ref: #/components/schemas/ApifrontendRRDeduplicatedPayload
+type ApifrontendRRDeduplicatedPayload struct {
+	// Event type for discriminator (matches parent event_type).
+	EventType ApifrontendRRDeduplicatedPayloadEventType `json:"event_type"`
+	// InvestigationSession CRD name.
+	SessionID string `json:"session_id"`
+	// The matching fingerprint hash.
+	Fingerprint string `json:"fingerprint"`
+	// Name of the existing RR that matched.
+	ExistingRrName string `json:"existing_rr_name"`
+	// K8s namespace of the existing RR.
+	ExistingRrNamespace OptString `json:"existing_rr_namespace"`
+	// Identity of the Lease holder (for debugging).
+	LeaseHolder OptString `json:"lease_holder"`
+}
+
+// GetEventType returns the value of EventType.
+func (s *ApifrontendRRDeduplicatedPayload) GetEventType() ApifrontendRRDeduplicatedPayloadEventType {
+	return s.EventType
+}
+
+// GetSessionID returns the value of SessionID.
+func (s *ApifrontendRRDeduplicatedPayload) GetSessionID() string {
+	return s.SessionID
+}
+
+// GetFingerprint returns the value of Fingerprint.
+func (s *ApifrontendRRDeduplicatedPayload) GetFingerprint() string {
+	return s.Fingerprint
+}
+
+// GetExistingRrName returns the value of ExistingRrName.
+func (s *ApifrontendRRDeduplicatedPayload) GetExistingRrName() string {
+	return s.ExistingRrName
+}
+
+// GetExistingRrNamespace returns the value of ExistingRrNamespace.
+func (s *ApifrontendRRDeduplicatedPayload) GetExistingRrNamespace() OptString {
+	return s.ExistingRrNamespace
+}
+
+// GetLeaseHolder returns the value of LeaseHolder.
+func (s *ApifrontendRRDeduplicatedPayload) GetLeaseHolder() OptString {
+	return s.LeaseHolder
+}
+
+// SetEventType sets the value of EventType.
+func (s *ApifrontendRRDeduplicatedPayload) SetEventType(val ApifrontendRRDeduplicatedPayloadEventType) {
+	s.EventType = val
+}
+
+// SetSessionID sets the value of SessionID.
+func (s *ApifrontendRRDeduplicatedPayload) SetSessionID(val string) {
+	s.SessionID = val
+}
+
+// SetFingerprint sets the value of Fingerprint.
+func (s *ApifrontendRRDeduplicatedPayload) SetFingerprint(val string) {
+	s.Fingerprint = val
+}
+
+// SetExistingRrName sets the value of ExistingRrName.
+func (s *ApifrontendRRDeduplicatedPayload) SetExistingRrName(val string) {
+	s.ExistingRrName = val
+}
+
+// SetExistingRrNamespace sets the value of ExistingRrNamespace.
+func (s *ApifrontendRRDeduplicatedPayload) SetExistingRrNamespace(val OptString) {
+	s.ExistingRrNamespace = val
+}
+
+// SetLeaseHolder sets the value of LeaseHolder.
+func (s *ApifrontendRRDeduplicatedPayload) SetLeaseHolder(val OptString) {
+	s.LeaseHolder = val
+}
+
+// Event type for discriminator (matches parent event_type).
+type ApifrontendRRDeduplicatedPayloadEventType string
+
+const (
+	ApifrontendRRDeduplicatedPayloadEventTypeApifrontendRrDeduplicated ApifrontendRRDeduplicatedPayloadEventType = "apifrontend.rr.deduplicated"
+)
+
+// AllValues returns all ApifrontendRRDeduplicatedPayloadEventType values.
+func (ApifrontendRRDeduplicatedPayloadEventType) AllValues() []ApifrontendRRDeduplicatedPayloadEventType {
+	return []ApifrontendRRDeduplicatedPayloadEventType{
+		ApifrontendRRDeduplicatedPayloadEventTypeApifrontendRrDeduplicated,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendRRDeduplicatedPayloadEventType) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendRRDeduplicatedPayloadEventTypeApifrontendRrDeduplicated:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendRRDeduplicatedPayloadEventType) UnmarshalText(data []byte) error {
+	switch ApifrontendRRDeduplicatedPayloadEventType(data) {
+	case ApifrontendRRDeduplicatedPayloadEventTypeApifrontendRrDeduplicated:
+		*s = ApifrontendRRDeduplicatedPayloadEventTypeApifrontendRrDeduplicated
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Session completed event payload (apifrontend.session.completed) — session reached terminal state
+// (SOC2 CC7.2, Issue.
+// Ref: #/components/schemas/ApifrontendSessionCompletedPayload
+type ApifrontendSessionCompletedPayload struct {
+	// Event type for discriminator (matches parent event_type).
+	EventType ApifrontendSessionCompletedPayloadEventType `json:"event_type"`
+	// InvestigationSession CRD name.
+	SessionID string `json:"session_id"`
+	// Terminal state of the session.
+	TerminalPhase ApifrontendSessionCompletedPayloadTerminalPhase `json:"terminal_phase"`
+	// Total session wall-clock time.
+	TotalDurationMs int `json:"total_duration_ms"`
+	// Total input tokens across all LLM calls.
+	TotalTokensInput OptInt `json:"total_tokens_input"`
+	// Total output tokens across all LLM calls.
+	TotalTokensOutput OptInt `json:"total_tokens_output"`
+	// Total number of tool invocations.
+	TotalToolCalls OptInt `json:"total_tool_calls"`
+	// Number of poll_investigation calls during this session.
+	PollsCount OptInt `json:"polls_count"`
+	// Final user decision (if session reached decision phase).
+	UserDecision OptApifrontendSessionCompletedPayloadUserDecision `json:"user_decision"`
+}
+
+// GetEventType returns the value of EventType.
+func (s *ApifrontendSessionCompletedPayload) GetEventType() ApifrontendSessionCompletedPayloadEventType {
+	return s.EventType
+}
+
+// GetSessionID returns the value of SessionID.
+func (s *ApifrontendSessionCompletedPayload) GetSessionID() string {
+	return s.SessionID
+}
+
+// GetTerminalPhase returns the value of TerminalPhase.
+func (s *ApifrontendSessionCompletedPayload) GetTerminalPhase() ApifrontendSessionCompletedPayloadTerminalPhase {
+	return s.TerminalPhase
+}
+
+// GetTotalDurationMs returns the value of TotalDurationMs.
+func (s *ApifrontendSessionCompletedPayload) GetTotalDurationMs() int {
+	return s.TotalDurationMs
+}
+
+// GetTotalTokensInput returns the value of TotalTokensInput.
+func (s *ApifrontendSessionCompletedPayload) GetTotalTokensInput() OptInt {
+	return s.TotalTokensInput
+}
+
+// GetTotalTokensOutput returns the value of TotalTokensOutput.
+func (s *ApifrontendSessionCompletedPayload) GetTotalTokensOutput() OptInt {
+	return s.TotalTokensOutput
+}
+
+// GetTotalToolCalls returns the value of TotalToolCalls.
+func (s *ApifrontendSessionCompletedPayload) GetTotalToolCalls() OptInt {
+	return s.TotalToolCalls
+}
+
+// GetPollsCount returns the value of PollsCount.
+func (s *ApifrontendSessionCompletedPayload) GetPollsCount() OptInt {
+	return s.PollsCount
+}
+
+// GetUserDecision returns the value of UserDecision.
+func (s *ApifrontendSessionCompletedPayload) GetUserDecision() OptApifrontendSessionCompletedPayloadUserDecision {
+	return s.UserDecision
+}
+
+// SetEventType sets the value of EventType.
+func (s *ApifrontendSessionCompletedPayload) SetEventType(val ApifrontendSessionCompletedPayloadEventType) {
+	s.EventType = val
+}
+
+// SetSessionID sets the value of SessionID.
+func (s *ApifrontendSessionCompletedPayload) SetSessionID(val string) {
+	s.SessionID = val
+}
+
+// SetTerminalPhase sets the value of TerminalPhase.
+func (s *ApifrontendSessionCompletedPayload) SetTerminalPhase(val ApifrontendSessionCompletedPayloadTerminalPhase) {
+	s.TerminalPhase = val
+}
+
+// SetTotalDurationMs sets the value of TotalDurationMs.
+func (s *ApifrontendSessionCompletedPayload) SetTotalDurationMs(val int) {
+	s.TotalDurationMs = val
+}
+
+// SetTotalTokensInput sets the value of TotalTokensInput.
+func (s *ApifrontendSessionCompletedPayload) SetTotalTokensInput(val OptInt) {
+	s.TotalTokensInput = val
+}
+
+// SetTotalTokensOutput sets the value of TotalTokensOutput.
+func (s *ApifrontendSessionCompletedPayload) SetTotalTokensOutput(val OptInt) {
+	s.TotalTokensOutput = val
+}
+
+// SetTotalToolCalls sets the value of TotalToolCalls.
+func (s *ApifrontendSessionCompletedPayload) SetTotalToolCalls(val OptInt) {
+	s.TotalToolCalls = val
+}
+
+// SetPollsCount sets the value of PollsCount.
+func (s *ApifrontendSessionCompletedPayload) SetPollsCount(val OptInt) {
+	s.PollsCount = val
+}
+
+// SetUserDecision sets the value of UserDecision.
+func (s *ApifrontendSessionCompletedPayload) SetUserDecision(val OptApifrontendSessionCompletedPayloadUserDecision) {
+	s.UserDecision = val
+}
+
+// Event type for discriminator (matches parent event_type).
+type ApifrontendSessionCompletedPayloadEventType string
+
+const (
+	ApifrontendSessionCompletedPayloadEventTypeApifrontendSessionCompleted ApifrontendSessionCompletedPayloadEventType = "apifrontend.session.completed"
+)
+
+// AllValues returns all ApifrontendSessionCompletedPayloadEventType values.
+func (ApifrontendSessionCompletedPayloadEventType) AllValues() []ApifrontendSessionCompletedPayloadEventType {
+	return []ApifrontendSessionCompletedPayloadEventType{
+		ApifrontendSessionCompletedPayloadEventTypeApifrontendSessionCompleted,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendSessionCompletedPayloadEventType) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendSessionCompletedPayloadEventTypeApifrontendSessionCompleted:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendSessionCompletedPayloadEventType) UnmarshalText(data []byte) error {
+	switch ApifrontendSessionCompletedPayloadEventType(data) {
+	case ApifrontendSessionCompletedPayloadEventTypeApifrontendSessionCompleted:
+		*s = ApifrontendSessionCompletedPayloadEventTypeApifrontendSessionCompleted
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Terminal state of the session.
+type ApifrontendSessionCompletedPayloadTerminalPhase string
+
+const (
+	ApifrontendSessionCompletedPayloadTerminalPhaseCompleted ApifrontendSessionCompletedPayloadTerminalPhase = "Completed"
+	ApifrontendSessionCompletedPayloadTerminalPhaseCancelled ApifrontendSessionCompletedPayloadTerminalPhase = "Cancelled"
+	ApifrontendSessionCompletedPayloadTerminalPhaseFailed    ApifrontendSessionCompletedPayloadTerminalPhase = "Failed"
+)
+
+// AllValues returns all ApifrontendSessionCompletedPayloadTerminalPhase values.
+func (ApifrontendSessionCompletedPayloadTerminalPhase) AllValues() []ApifrontendSessionCompletedPayloadTerminalPhase {
+	return []ApifrontendSessionCompletedPayloadTerminalPhase{
+		ApifrontendSessionCompletedPayloadTerminalPhaseCompleted,
+		ApifrontendSessionCompletedPayloadTerminalPhaseCancelled,
+		ApifrontendSessionCompletedPayloadTerminalPhaseFailed,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendSessionCompletedPayloadTerminalPhase) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendSessionCompletedPayloadTerminalPhaseCompleted:
+		return []byte(s), nil
+	case ApifrontendSessionCompletedPayloadTerminalPhaseCancelled:
+		return []byte(s), nil
+	case ApifrontendSessionCompletedPayloadTerminalPhaseFailed:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendSessionCompletedPayloadTerminalPhase) UnmarshalText(data []byte) error {
+	switch ApifrontendSessionCompletedPayloadTerminalPhase(data) {
+	case ApifrontendSessionCompletedPayloadTerminalPhaseCompleted:
+		*s = ApifrontendSessionCompletedPayloadTerminalPhaseCompleted
+		return nil
+	case ApifrontendSessionCompletedPayloadTerminalPhaseCancelled:
+		*s = ApifrontendSessionCompletedPayloadTerminalPhaseCancelled
+		return nil
+	case ApifrontendSessionCompletedPayloadTerminalPhaseFailed:
+		*s = ApifrontendSessionCompletedPayloadTerminalPhaseFailed
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Final user decision (if session reached decision phase).
+type ApifrontendSessionCompletedPayloadUserDecision string
+
+const (
+	ApifrontendSessionCompletedPayloadUserDecisionAccept          ApifrontendSessionCompletedPayloadUserDecision = "accept"
+	ApifrontendSessionCompletedPayloadUserDecisionReject          ApifrontendSessionCompletedPayloadUserDecision = "reject"
+	ApifrontendSessionCompletedPayloadUserDecisionInvestigateMore ApifrontendSessionCompletedPayloadUserDecision = "investigate_more"
+	ApifrontendSessionCompletedPayloadUserDecisionCancel          ApifrontendSessionCompletedPayloadUserDecision = "cancel"
+	ApifrontendSessionCompletedPayloadUserDecisionNone            ApifrontendSessionCompletedPayloadUserDecision = "none"
+)
+
+// AllValues returns all ApifrontendSessionCompletedPayloadUserDecision values.
+func (ApifrontendSessionCompletedPayloadUserDecision) AllValues() []ApifrontendSessionCompletedPayloadUserDecision {
+	return []ApifrontendSessionCompletedPayloadUserDecision{
+		ApifrontendSessionCompletedPayloadUserDecisionAccept,
+		ApifrontendSessionCompletedPayloadUserDecisionReject,
+		ApifrontendSessionCompletedPayloadUserDecisionInvestigateMore,
+		ApifrontendSessionCompletedPayloadUserDecisionCancel,
+		ApifrontendSessionCompletedPayloadUserDecisionNone,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendSessionCompletedPayloadUserDecision) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendSessionCompletedPayloadUserDecisionAccept:
+		return []byte(s), nil
+	case ApifrontendSessionCompletedPayloadUserDecisionReject:
+		return []byte(s), nil
+	case ApifrontendSessionCompletedPayloadUserDecisionInvestigateMore:
+		return []byte(s), nil
+	case ApifrontendSessionCompletedPayloadUserDecisionCancel:
+		return []byte(s), nil
+	case ApifrontendSessionCompletedPayloadUserDecisionNone:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendSessionCompletedPayloadUserDecision) UnmarshalText(data []byte) error {
+	switch ApifrontendSessionCompletedPayloadUserDecision(data) {
+	case ApifrontendSessionCompletedPayloadUserDecisionAccept:
+		*s = ApifrontendSessionCompletedPayloadUserDecisionAccept
+		return nil
+	case ApifrontendSessionCompletedPayloadUserDecisionReject:
+		*s = ApifrontendSessionCompletedPayloadUserDecisionReject
+		return nil
+	case ApifrontendSessionCompletedPayloadUserDecisionInvestigateMore:
+		*s = ApifrontendSessionCompletedPayloadUserDecisionInvestigateMore
+		return nil
+	case ApifrontendSessionCompletedPayloadUserDecisionCancel:
+		*s = ApifrontendSessionCompletedPayloadUserDecisionCancel
+		return nil
+	case ApifrontendSessionCompletedPayloadUserDecisionNone:
+		*s = ApifrontendSessionCompletedPayloadUserDecisionNone
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Session created event payload (apifrontend.session.created) — InvestigationSession CRD created
+// (SOC2 CC7.2, Issue.
+// Ref: #/components/schemas/ApifrontendSessionCreatedPayload
+type ApifrontendSessionCreatedPayload struct {
+	// Event type for discriminator (matches parent event_type).
+	EventType ApifrontendSessionCreatedPayloadEventType `json:"event_type"`
+	// InvestigationSession CRD name.
+	SessionID string `json:"session_id"`
+	// A2A task ID for client reconnection.
+	A2aTaskID string `json:"a2a_task_id"`
+	// Reference to associated RemediationRequest (name).
+	RrRef OptString `json:"rr_ref"`
+	// Whether user initiated or joined running investigation.
+	JoinMode ApifrontendSessionCreatedPayloadJoinMode `json:"join_mode"`
+	// Username from JWT (sub claim).
+	UserIdentity string `json:"user_identity"`
+	// User's group memberships from JWT.
+	UserGroups []string `json:"user_groups"`
+}
+
+// GetEventType returns the value of EventType.
+func (s *ApifrontendSessionCreatedPayload) GetEventType() ApifrontendSessionCreatedPayloadEventType {
+	return s.EventType
+}
+
+// GetSessionID returns the value of SessionID.
+func (s *ApifrontendSessionCreatedPayload) GetSessionID() string {
+	return s.SessionID
+}
+
+// GetA2aTaskID returns the value of A2aTaskID.
+func (s *ApifrontendSessionCreatedPayload) GetA2aTaskID() string {
+	return s.A2aTaskID
+}
+
+// GetRrRef returns the value of RrRef.
+func (s *ApifrontendSessionCreatedPayload) GetRrRef() OptString {
+	return s.RrRef
+}
+
+// GetJoinMode returns the value of JoinMode.
+func (s *ApifrontendSessionCreatedPayload) GetJoinMode() ApifrontendSessionCreatedPayloadJoinMode {
+	return s.JoinMode
+}
+
+// GetUserIdentity returns the value of UserIdentity.
+func (s *ApifrontendSessionCreatedPayload) GetUserIdentity() string {
+	return s.UserIdentity
+}
+
+// GetUserGroups returns the value of UserGroups.
+func (s *ApifrontendSessionCreatedPayload) GetUserGroups() []string {
+	return s.UserGroups
+}
+
+// SetEventType sets the value of EventType.
+func (s *ApifrontendSessionCreatedPayload) SetEventType(val ApifrontendSessionCreatedPayloadEventType) {
+	s.EventType = val
+}
+
+// SetSessionID sets the value of SessionID.
+func (s *ApifrontendSessionCreatedPayload) SetSessionID(val string) {
+	s.SessionID = val
+}
+
+// SetA2aTaskID sets the value of A2aTaskID.
+func (s *ApifrontendSessionCreatedPayload) SetA2aTaskID(val string) {
+	s.A2aTaskID = val
+}
+
+// SetRrRef sets the value of RrRef.
+func (s *ApifrontendSessionCreatedPayload) SetRrRef(val OptString) {
+	s.RrRef = val
+}
+
+// SetJoinMode sets the value of JoinMode.
+func (s *ApifrontendSessionCreatedPayload) SetJoinMode(val ApifrontendSessionCreatedPayloadJoinMode) {
+	s.JoinMode = val
+}
+
+// SetUserIdentity sets the value of UserIdentity.
+func (s *ApifrontendSessionCreatedPayload) SetUserIdentity(val string) {
+	s.UserIdentity = val
+}
+
+// SetUserGroups sets the value of UserGroups.
+func (s *ApifrontendSessionCreatedPayload) SetUserGroups(val []string) {
+	s.UserGroups = val
+}
+
+// Event type for discriminator (matches parent event_type).
+type ApifrontendSessionCreatedPayloadEventType string
+
+const (
+	ApifrontendSessionCreatedPayloadEventTypeApifrontendSessionCreated ApifrontendSessionCreatedPayloadEventType = "apifrontend.session.created"
+)
+
+// AllValues returns all ApifrontendSessionCreatedPayloadEventType values.
+func (ApifrontendSessionCreatedPayloadEventType) AllValues() []ApifrontendSessionCreatedPayloadEventType {
+	return []ApifrontendSessionCreatedPayloadEventType{
+		ApifrontendSessionCreatedPayloadEventTypeApifrontendSessionCreated,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendSessionCreatedPayloadEventType) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendSessionCreatedPayloadEventTypeApifrontendSessionCreated:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendSessionCreatedPayloadEventType) UnmarshalText(data []byte) error {
+	switch ApifrontendSessionCreatedPayloadEventType(data) {
+	case ApifrontendSessionCreatedPayloadEventTypeApifrontendSessionCreated:
+		*s = ApifrontendSessionCreatedPayloadEventTypeApifrontendSessionCreated
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Whether user initiated or joined running investigation.
+type ApifrontendSessionCreatedPayloadJoinMode string
+
+const (
+	ApifrontendSessionCreatedPayloadJoinModeStart    ApifrontendSessionCreatedPayloadJoinMode = "start"
+	ApifrontendSessionCreatedPayloadJoinModeTakeover ApifrontendSessionCreatedPayloadJoinMode = "takeover"
+)
+
+// AllValues returns all ApifrontendSessionCreatedPayloadJoinMode values.
+func (ApifrontendSessionCreatedPayloadJoinMode) AllValues() []ApifrontendSessionCreatedPayloadJoinMode {
+	return []ApifrontendSessionCreatedPayloadJoinMode{
+		ApifrontendSessionCreatedPayloadJoinModeStart,
+		ApifrontendSessionCreatedPayloadJoinModeTakeover,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendSessionCreatedPayloadJoinMode) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendSessionCreatedPayloadJoinModeStart:
+		return []byte(s), nil
+	case ApifrontendSessionCreatedPayloadJoinModeTakeover:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendSessionCreatedPayloadJoinMode) UnmarshalText(data []byte) error {
+	switch ApifrontendSessionCreatedPayloadJoinMode(data) {
+	case ApifrontendSessionCreatedPayloadJoinModeStart:
+		*s = ApifrontendSessionCreatedPayloadJoinModeStart
+		return nil
+	case ApifrontendSessionCreatedPayloadJoinModeTakeover:
+		*s = ApifrontendSessionCreatedPayloadJoinModeTakeover
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Tool executed event payload (apifrontend.tool.executed) — MCP tool executed with outcome (SOC2
+// CC7.2, Issue.
+// Ref: #/components/schemas/ApifrontendToolExecutedPayload
+type ApifrontendToolExecutedPayload struct {
+	// Event type for discriminator (matches parent event_type).
+	EventType ApifrontendToolExecutedPayloadEventType `json:"event_type"`
+	// InvestigationSession CRD name.
+	SessionID string `json:"session_id"`
+	// Name of the executed MCP tool.
+	ToolName string `json:"tool_name"`
+	// Tool execution wall-clock time.
+	ExecutionDurationMs int `json:"execution_duration_ms"`
+	// Outcome of tool execution.
+	ToolOutcome ApifrontendToolExecutedPayloadToolOutcome `json:"tool_outcome"`
+	// Error classification (if failure).
+	ErrorCode OptString `json:"error_code"`
+	// Resource the tool operated on (if applicable).
+	TargetResource OptString `json:"target_resource"`
+}
+
+// GetEventType returns the value of EventType.
+func (s *ApifrontendToolExecutedPayload) GetEventType() ApifrontendToolExecutedPayloadEventType {
+	return s.EventType
+}
+
+// GetSessionID returns the value of SessionID.
+func (s *ApifrontendToolExecutedPayload) GetSessionID() string {
+	return s.SessionID
+}
+
+// GetToolName returns the value of ToolName.
+func (s *ApifrontendToolExecutedPayload) GetToolName() string {
+	return s.ToolName
+}
+
+// GetExecutionDurationMs returns the value of ExecutionDurationMs.
+func (s *ApifrontendToolExecutedPayload) GetExecutionDurationMs() int {
+	return s.ExecutionDurationMs
+}
+
+// GetToolOutcome returns the value of ToolOutcome.
+func (s *ApifrontendToolExecutedPayload) GetToolOutcome() ApifrontendToolExecutedPayloadToolOutcome {
+	return s.ToolOutcome
+}
+
+// GetErrorCode returns the value of ErrorCode.
+func (s *ApifrontendToolExecutedPayload) GetErrorCode() OptString {
+	return s.ErrorCode
+}
+
+// GetTargetResource returns the value of TargetResource.
+func (s *ApifrontendToolExecutedPayload) GetTargetResource() OptString {
+	return s.TargetResource
+}
+
+// SetEventType sets the value of EventType.
+func (s *ApifrontendToolExecutedPayload) SetEventType(val ApifrontendToolExecutedPayloadEventType) {
+	s.EventType = val
+}
+
+// SetSessionID sets the value of SessionID.
+func (s *ApifrontendToolExecutedPayload) SetSessionID(val string) {
+	s.SessionID = val
+}
+
+// SetToolName sets the value of ToolName.
+func (s *ApifrontendToolExecutedPayload) SetToolName(val string) {
+	s.ToolName = val
+}
+
+// SetExecutionDurationMs sets the value of ExecutionDurationMs.
+func (s *ApifrontendToolExecutedPayload) SetExecutionDurationMs(val int) {
+	s.ExecutionDurationMs = val
+}
+
+// SetToolOutcome sets the value of ToolOutcome.
+func (s *ApifrontendToolExecutedPayload) SetToolOutcome(val ApifrontendToolExecutedPayloadToolOutcome) {
+	s.ToolOutcome = val
+}
+
+// SetErrorCode sets the value of ErrorCode.
+func (s *ApifrontendToolExecutedPayload) SetErrorCode(val OptString) {
+	s.ErrorCode = val
+}
+
+// SetTargetResource sets the value of TargetResource.
+func (s *ApifrontendToolExecutedPayload) SetTargetResource(val OptString) {
+	s.TargetResource = val
+}
+
+// Event type for discriminator (matches parent event_type).
+type ApifrontendToolExecutedPayloadEventType string
+
+const (
+	ApifrontendToolExecutedPayloadEventTypeApifrontendToolExecuted ApifrontendToolExecutedPayloadEventType = "apifrontend.tool.executed"
+)
+
+// AllValues returns all ApifrontendToolExecutedPayloadEventType values.
+func (ApifrontendToolExecutedPayloadEventType) AllValues() []ApifrontendToolExecutedPayloadEventType {
+	return []ApifrontendToolExecutedPayloadEventType{
+		ApifrontendToolExecutedPayloadEventTypeApifrontendToolExecuted,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendToolExecutedPayloadEventType) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendToolExecutedPayloadEventTypeApifrontendToolExecuted:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendToolExecutedPayloadEventType) UnmarshalText(data []byte) error {
+	switch ApifrontendToolExecutedPayloadEventType(data) {
+	case ApifrontendToolExecutedPayloadEventTypeApifrontendToolExecuted:
+		*s = ApifrontendToolExecutedPayloadEventTypeApifrontendToolExecuted
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Outcome of tool execution.
+type ApifrontendToolExecutedPayloadToolOutcome string
+
+const (
+	ApifrontendToolExecutedPayloadToolOutcomeSuccess ApifrontendToolExecutedPayloadToolOutcome = "success"
+	ApifrontendToolExecutedPayloadToolOutcomeFailure ApifrontendToolExecutedPayloadToolOutcome = "failure"
+	ApifrontendToolExecutedPayloadToolOutcomeTimeout ApifrontendToolExecutedPayloadToolOutcome = "timeout"
+	ApifrontendToolExecutedPayloadToolOutcomeDenied  ApifrontendToolExecutedPayloadToolOutcome = "denied"
+)
+
+// AllValues returns all ApifrontendToolExecutedPayloadToolOutcome values.
+func (ApifrontendToolExecutedPayloadToolOutcome) AllValues() []ApifrontendToolExecutedPayloadToolOutcome {
+	return []ApifrontendToolExecutedPayloadToolOutcome{
+		ApifrontendToolExecutedPayloadToolOutcomeSuccess,
+		ApifrontendToolExecutedPayloadToolOutcomeFailure,
+		ApifrontendToolExecutedPayloadToolOutcomeTimeout,
+		ApifrontendToolExecutedPayloadToolOutcomeDenied,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendToolExecutedPayloadToolOutcome) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendToolExecutedPayloadToolOutcomeSuccess:
+		return []byte(s), nil
+	case ApifrontendToolExecutedPayloadToolOutcomeFailure:
+		return []byte(s), nil
+	case ApifrontendToolExecutedPayloadToolOutcomeTimeout:
+		return []byte(s), nil
+	case ApifrontendToolExecutedPayloadToolOutcomeDenied:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendToolExecutedPayloadToolOutcome) UnmarshalText(data []byte) error {
+	switch ApifrontendToolExecutedPayloadToolOutcome(data) {
+	case ApifrontendToolExecutedPayloadToolOutcomeSuccess:
+		*s = ApifrontendToolExecutedPayloadToolOutcomeSuccess
+		return nil
+	case ApifrontendToolExecutedPayloadToolOutcomeFailure:
+		*s = ApifrontendToolExecutedPayloadToolOutcomeFailure
+		return nil
+	case ApifrontendToolExecutedPayloadToolOutcomeTimeout:
+		*s = ApifrontendToolExecutedPayloadToolOutcomeTimeout
+		return nil
+	case ApifrontendToolExecutedPayloadToolOutcomeDenied:
+		*s = ApifrontendToolExecutedPayloadToolOutcomeDenied
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Triage completed event payload (apifrontend.triage.completed) — triage finished with outcome
+// (SOC2 CC7.2, Issue.
+// Ref: #/components/schemas/ApifrontendTriageCompletedPayload
+type ApifrontendTriageCompletedPayload struct {
+	// Event type for discriminator (matches parent event_type).
+	EventType ApifrontendTriageCompletedPayloadEventType `json:"event_type"`
+	// InvestigationSession CRD name.
+	SessionID string `json:"session_id"`
+	// Result of triage phase.
+	TriageOutcome ApifrontendTriageCompletedPayloadTriageOutcome `json:"triage_outcome"`
+	// Wall-clock time for triage phase.
+	TriageDurationMs int `json:"triage_duration_ms"`
+	// Input tokens consumed during triage.
+	TokensInput OptInt `json:"tokens_input"`
+	// Output tokens generated during triage.
+	TokensOutput OptInt `json:"tokens_output"`
+	// Tools invoked during triage (names only).
+	ToolsCalled []string `json:"tools_called"`
+	// Total number of tool invocations.
+	ToolsCallCount OptInt `json:"tools_call_count"`
+}
+
+// GetEventType returns the value of EventType.
+func (s *ApifrontendTriageCompletedPayload) GetEventType() ApifrontendTriageCompletedPayloadEventType {
+	return s.EventType
+}
+
+// GetSessionID returns the value of SessionID.
+func (s *ApifrontendTriageCompletedPayload) GetSessionID() string {
+	return s.SessionID
+}
+
+// GetTriageOutcome returns the value of TriageOutcome.
+func (s *ApifrontendTriageCompletedPayload) GetTriageOutcome() ApifrontendTriageCompletedPayloadTriageOutcome {
+	return s.TriageOutcome
+}
+
+// GetTriageDurationMs returns the value of TriageDurationMs.
+func (s *ApifrontendTriageCompletedPayload) GetTriageDurationMs() int {
+	return s.TriageDurationMs
+}
+
+// GetTokensInput returns the value of TokensInput.
+func (s *ApifrontendTriageCompletedPayload) GetTokensInput() OptInt {
+	return s.TokensInput
+}
+
+// GetTokensOutput returns the value of TokensOutput.
+func (s *ApifrontendTriageCompletedPayload) GetTokensOutput() OptInt {
+	return s.TokensOutput
+}
+
+// GetToolsCalled returns the value of ToolsCalled.
+func (s *ApifrontendTriageCompletedPayload) GetToolsCalled() []string {
+	return s.ToolsCalled
+}
+
+// GetToolsCallCount returns the value of ToolsCallCount.
+func (s *ApifrontendTriageCompletedPayload) GetToolsCallCount() OptInt {
+	return s.ToolsCallCount
+}
+
+// SetEventType sets the value of EventType.
+func (s *ApifrontendTriageCompletedPayload) SetEventType(val ApifrontendTriageCompletedPayloadEventType) {
+	s.EventType = val
+}
+
+// SetSessionID sets the value of SessionID.
+func (s *ApifrontendTriageCompletedPayload) SetSessionID(val string) {
+	s.SessionID = val
+}
+
+// SetTriageOutcome sets the value of TriageOutcome.
+func (s *ApifrontendTriageCompletedPayload) SetTriageOutcome(val ApifrontendTriageCompletedPayloadTriageOutcome) {
+	s.TriageOutcome = val
+}
+
+// SetTriageDurationMs sets the value of TriageDurationMs.
+func (s *ApifrontendTriageCompletedPayload) SetTriageDurationMs(val int) {
+	s.TriageDurationMs = val
+}
+
+// SetTokensInput sets the value of TokensInput.
+func (s *ApifrontendTriageCompletedPayload) SetTokensInput(val OptInt) {
+	s.TokensInput = val
+}
+
+// SetTokensOutput sets the value of TokensOutput.
+func (s *ApifrontendTriageCompletedPayload) SetTokensOutput(val OptInt) {
+	s.TokensOutput = val
+}
+
+// SetToolsCalled sets the value of ToolsCalled.
+func (s *ApifrontendTriageCompletedPayload) SetToolsCalled(val []string) {
+	s.ToolsCalled = val
+}
+
+// SetToolsCallCount sets the value of ToolsCallCount.
+func (s *ApifrontendTriageCompletedPayload) SetToolsCallCount(val OptInt) {
+	s.ToolsCallCount = val
+}
+
+// Event type for discriminator (matches parent event_type).
+type ApifrontendTriageCompletedPayloadEventType string
+
+const (
+	ApifrontendTriageCompletedPayloadEventTypeApifrontendTriageCompleted ApifrontendTriageCompletedPayloadEventType = "apifrontend.triage.completed"
+)
+
+// AllValues returns all ApifrontendTriageCompletedPayloadEventType values.
+func (ApifrontendTriageCompletedPayloadEventType) AllValues() []ApifrontendTriageCompletedPayloadEventType {
+	return []ApifrontendTriageCompletedPayloadEventType{
+		ApifrontendTriageCompletedPayloadEventTypeApifrontendTriageCompleted,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendTriageCompletedPayloadEventType) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendTriageCompletedPayloadEventTypeApifrontendTriageCompleted:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendTriageCompletedPayloadEventType) UnmarshalText(data []byte) error {
+	switch ApifrontendTriageCompletedPayloadEventType(data) {
+	case ApifrontendTriageCompletedPayloadEventTypeApifrontendTriageCompleted:
+		*s = ApifrontendTriageCompletedPayloadEventTypeApifrontendTriageCompleted
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Result of triage phase.
+type ApifrontendTriageCompletedPayloadTriageOutcome string
+
+const (
+	ApifrontendTriageCompletedPayloadTriageOutcomeRrCreated    ApifrontendTriageCompletedPayloadTriageOutcome = "rr_created"
+	ApifrontendTriageCompletedPayloadTriageOutcomeNoIssueFound ApifrontendTriageCompletedPayloadTriageOutcome = "no_issue_found"
+	ApifrontendTriageCompletedPayloadTriageOutcomeEscalated    ApifrontendTriageCompletedPayloadTriageOutcome = "escalated"
+	ApifrontendTriageCompletedPayloadTriageOutcomeError        ApifrontendTriageCompletedPayloadTriageOutcome = "error"
+)
+
+// AllValues returns all ApifrontendTriageCompletedPayloadTriageOutcome values.
+func (ApifrontendTriageCompletedPayloadTriageOutcome) AllValues() []ApifrontendTriageCompletedPayloadTriageOutcome {
+	return []ApifrontendTriageCompletedPayloadTriageOutcome{
+		ApifrontendTriageCompletedPayloadTriageOutcomeRrCreated,
+		ApifrontendTriageCompletedPayloadTriageOutcomeNoIssueFound,
+		ApifrontendTriageCompletedPayloadTriageOutcomeEscalated,
+		ApifrontendTriageCompletedPayloadTriageOutcomeError,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendTriageCompletedPayloadTriageOutcome) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendTriageCompletedPayloadTriageOutcomeRrCreated:
+		return []byte(s), nil
+	case ApifrontendTriageCompletedPayloadTriageOutcomeNoIssueFound:
+		return []byte(s), nil
+	case ApifrontendTriageCompletedPayloadTriageOutcomeEscalated:
+		return []byte(s), nil
+	case ApifrontendTriageCompletedPayloadTriageOutcomeError:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendTriageCompletedPayloadTriageOutcome) UnmarshalText(data []byte) error {
+	switch ApifrontendTriageCompletedPayloadTriageOutcome(data) {
+	case ApifrontendTriageCompletedPayloadTriageOutcomeRrCreated:
+		*s = ApifrontendTriageCompletedPayloadTriageOutcomeRrCreated
+		return nil
+	case ApifrontendTriageCompletedPayloadTriageOutcomeNoIssueFound:
+		*s = ApifrontendTriageCompletedPayloadTriageOutcomeNoIssueFound
+		return nil
+	case ApifrontendTriageCompletedPayloadTriageOutcomeEscalated:
+		*s = ApifrontendTriageCompletedPayloadTriageOutcomeEscalated
+		return nil
+	case ApifrontendTriageCompletedPayloadTriageOutcomeError:
+		*s = ApifrontendTriageCompletedPayloadTriageOutcomeError
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Triage started event payload (apifrontend.triage.started) — user NL query received, triage LLM
+// invocation begins (SOC2 CC7.2, Issue.
+// Ref: #/components/schemas/ApifrontendTriageStartedPayload
+type ApifrontendTriageStartedPayload struct {
+	// Event type for discriminator (matches parent event_type).
+	EventType ApifrontendTriageStartedPayloadEventType `json:"event_type"`
+	// InvestigationSession CRD name.
+	SessionID string `json:"session_id"`
+	// Detected/assigned persona from JWT role.
+	Persona ApifrontendTriageStartedPayloadPersona `json:"persona"`
+	// LLM model identifier used for triage.
+	ModelName OptString `json:"model_name"`
+	// Length of user query in characters (not the query itself, for privacy).
+	QueryLength OptInt `json:"query_length"`
+}
+
+// GetEventType returns the value of EventType.
+func (s *ApifrontendTriageStartedPayload) GetEventType() ApifrontendTriageStartedPayloadEventType {
+	return s.EventType
+}
+
+// GetSessionID returns the value of SessionID.
+func (s *ApifrontendTriageStartedPayload) GetSessionID() string {
+	return s.SessionID
+}
+
+// GetPersona returns the value of Persona.
+func (s *ApifrontendTriageStartedPayload) GetPersona() ApifrontendTriageStartedPayloadPersona {
+	return s.Persona
+}
+
+// GetModelName returns the value of ModelName.
+func (s *ApifrontendTriageStartedPayload) GetModelName() OptString {
+	return s.ModelName
+}
+
+// GetQueryLength returns the value of QueryLength.
+func (s *ApifrontendTriageStartedPayload) GetQueryLength() OptInt {
+	return s.QueryLength
+}
+
+// SetEventType sets the value of EventType.
+func (s *ApifrontendTriageStartedPayload) SetEventType(val ApifrontendTriageStartedPayloadEventType) {
+	s.EventType = val
+}
+
+// SetSessionID sets the value of SessionID.
+func (s *ApifrontendTriageStartedPayload) SetSessionID(val string) {
+	s.SessionID = val
+}
+
+// SetPersona sets the value of Persona.
+func (s *ApifrontendTriageStartedPayload) SetPersona(val ApifrontendTriageStartedPayloadPersona) {
+	s.Persona = val
+}
+
+// SetModelName sets the value of ModelName.
+func (s *ApifrontendTriageStartedPayload) SetModelName(val OptString) {
+	s.ModelName = val
+}
+
+// SetQueryLength sets the value of QueryLength.
+func (s *ApifrontendTriageStartedPayload) SetQueryLength(val OptInt) {
+	s.QueryLength = val
+}
+
+// Event type for discriminator (matches parent event_type).
+type ApifrontendTriageStartedPayloadEventType string
+
+const (
+	ApifrontendTriageStartedPayloadEventTypeApifrontendTriageStarted ApifrontendTriageStartedPayloadEventType = "apifrontend.triage.started"
+)
+
+// AllValues returns all ApifrontendTriageStartedPayloadEventType values.
+func (ApifrontendTriageStartedPayloadEventType) AllValues() []ApifrontendTriageStartedPayloadEventType {
+	return []ApifrontendTriageStartedPayloadEventType{
+		ApifrontendTriageStartedPayloadEventTypeApifrontendTriageStarted,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendTriageStartedPayloadEventType) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendTriageStartedPayloadEventTypeApifrontendTriageStarted:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendTriageStartedPayloadEventType) UnmarshalText(data []byte) error {
+	switch ApifrontendTriageStartedPayloadEventType(data) {
+	case ApifrontendTriageStartedPayloadEventTypeApifrontendTriageStarted:
+		*s = ApifrontendTriageStartedPayloadEventTypeApifrontendTriageStarted
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Detected/assigned persona from JWT role.
+type ApifrontendTriageStartedPayloadPersona string
+
+const (
+	ApifrontendTriageStartedPayloadPersonaSre          ApifrontendTriageStartedPayloadPersona = "sre"
+	ApifrontendTriageStartedPayloadPersonaOrchestrator ApifrontendTriageStartedPayloadPersona = "orchestrator"
+	ApifrontendTriageStartedPayloadPersonaCicd         ApifrontendTriageStartedPayloadPersona = "cicd"
+	ApifrontendTriageStartedPayloadPersonaDashboard    ApifrontendTriageStartedPayloadPersona = "dashboard"
+	ApifrontendTriageStartedPayloadPersonaAudit        ApifrontendTriageStartedPayloadPersona = "audit"
+	ApifrontendTriageStartedPayloadPersonaApprover     ApifrontendTriageStartedPayloadPersona = "approver"
+)
+
+// AllValues returns all ApifrontendTriageStartedPayloadPersona values.
+func (ApifrontendTriageStartedPayloadPersona) AllValues() []ApifrontendTriageStartedPayloadPersona {
+	return []ApifrontendTriageStartedPayloadPersona{
+		ApifrontendTriageStartedPayloadPersonaSre,
+		ApifrontendTriageStartedPayloadPersonaOrchestrator,
+		ApifrontendTriageStartedPayloadPersonaCicd,
+		ApifrontendTriageStartedPayloadPersonaDashboard,
+		ApifrontendTriageStartedPayloadPersonaAudit,
+		ApifrontendTriageStartedPayloadPersonaApprover,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendTriageStartedPayloadPersona) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendTriageStartedPayloadPersonaSre:
+		return []byte(s), nil
+	case ApifrontendTriageStartedPayloadPersonaOrchestrator:
+		return []byte(s), nil
+	case ApifrontendTriageStartedPayloadPersonaCicd:
+		return []byte(s), nil
+	case ApifrontendTriageStartedPayloadPersonaDashboard:
+		return []byte(s), nil
+	case ApifrontendTriageStartedPayloadPersonaAudit:
+		return []byte(s), nil
+	case ApifrontendTriageStartedPayloadPersonaApprover:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendTriageStartedPayloadPersona) UnmarshalText(data []byte) error {
+	switch ApifrontendTriageStartedPayloadPersona(data) {
+	case ApifrontendTriageStartedPayloadPersonaSre:
+		*s = ApifrontendTriageStartedPayloadPersonaSre
+		return nil
+	case ApifrontendTriageStartedPayloadPersonaOrchestrator:
+		*s = ApifrontendTriageStartedPayloadPersonaOrchestrator
+		return nil
+	case ApifrontendTriageStartedPayloadPersonaCicd:
+		*s = ApifrontendTriageStartedPayloadPersonaCicd
+		return nil
+	case ApifrontendTriageStartedPayloadPersonaDashboard:
+		*s = ApifrontendTriageStartedPayloadPersonaDashboard
+		return nil
+	case ApifrontendTriageStartedPayloadPersonaAudit:
+		*s = ApifrontendTriageStartedPayloadPersonaAudit
+		return nil
+	case ApifrontendTriageStartedPayloadPersonaApprover:
+		*s = ApifrontendTriageStartedPayloadPersonaApprover
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// User decision event payload (apifrontend.user.decision) — user acted on RCA/options (SOC2 CC7.2,
+// Issue.
+// Ref: #/components/schemas/ApifrontendUserDecisionPayload
+type ApifrontendUserDecisionPayload struct {
+	// Event type for discriminator (matches parent event_type).
+	EventType ApifrontendUserDecisionPayloadEventType `json:"event_type"`
+	// InvestigationSession CRD name.
+	SessionID string `json:"session_id"`
+	// User's decision on the RCA/options.
+	Decision ApifrontendUserDecisionPayloadDecision `json:"decision"`
+	// Selected workflow identifier (if decision is 'accept').
+	WorkflowID OptString `json:"workflow_id"`
+	// Time from RCA presentation (input-required) to user response.
+	TimeToDecisionMs OptInt `json:"time_to_decision_ms"`
+	// Associated RemediationRequest name.
+	RrName OptString `json:"rr_name"`
+}
+
+// GetEventType returns the value of EventType.
+func (s *ApifrontendUserDecisionPayload) GetEventType() ApifrontendUserDecisionPayloadEventType {
+	return s.EventType
+}
+
+// GetSessionID returns the value of SessionID.
+func (s *ApifrontendUserDecisionPayload) GetSessionID() string {
+	return s.SessionID
+}
+
+// GetDecision returns the value of Decision.
+func (s *ApifrontendUserDecisionPayload) GetDecision() ApifrontendUserDecisionPayloadDecision {
+	return s.Decision
+}
+
+// GetWorkflowID returns the value of WorkflowID.
+func (s *ApifrontendUserDecisionPayload) GetWorkflowID() OptString {
+	return s.WorkflowID
+}
+
+// GetTimeToDecisionMs returns the value of TimeToDecisionMs.
+func (s *ApifrontendUserDecisionPayload) GetTimeToDecisionMs() OptInt {
+	return s.TimeToDecisionMs
+}
+
+// GetRrName returns the value of RrName.
+func (s *ApifrontendUserDecisionPayload) GetRrName() OptString {
+	return s.RrName
+}
+
+// SetEventType sets the value of EventType.
+func (s *ApifrontendUserDecisionPayload) SetEventType(val ApifrontendUserDecisionPayloadEventType) {
+	s.EventType = val
+}
+
+// SetSessionID sets the value of SessionID.
+func (s *ApifrontendUserDecisionPayload) SetSessionID(val string) {
+	s.SessionID = val
+}
+
+// SetDecision sets the value of Decision.
+func (s *ApifrontendUserDecisionPayload) SetDecision(val ApifrontendUserDecisionPayloadDecision) {
+	s.Decision = val
+}
+
+// SetWorkflowID sets the value of WorkflowID.
+func (s *ApifrontendUserDecisionPayload) SetWorkflowID(val OptString) {
+	s.WorkflowID = val
+}
+
+// SetTimeToDecisionMs sets the value of TimeToDecisionMs.
+func (s *ApifrontendUserDecisionPayload) SetTimeToDecisionMs(val OptInt) {
+	s.TimeToDecisionMs = val
+}
+
+// SetRrName sets the value of RrName.
+func (s *ApifrontendUserDecisionPayload) SetRrName(val OptString) {
+	s.RrName = val
+}
+
+// User's decision on the RCA/options.
+type ApifrontendUserDecisionPayloadDecision string
+
+const (
+	ApifrontendUserDecisionPayloadDecisionAccept          ApifrontendUserDecisionPayloadDecision = "accept"
+	ApifrontendUserDecisionPayloadDecisionReject          ApifrontendUserDecisionPayloadDecision = "reject"
+	ApifrontendUserDecisionPayloadDecisionInvestigateMore ApifrontendUserDecisionPayloadDecision = "investigate_more"
+	ApifrontendUserDecisionPayloadDecisionCancel          ApifrontendUserDecisionPayloadDecision = "cancel"
+)
+
+// AllValues returns all ApifrontendUserDecisionPayloadDecision values.
+func (ApifrontendUserDecisionPayloadDecision) AllValues() []ApifrontendUserDecisionPayloadDecision {
+	return []ApifrontendUserDecisionPayloadDecision{
+		ApifrontendUserDecisionPayloadDecisionAccept,
+		ApifrontendUserDecisionPayloadDecisionReject,
+		ApifrontendUserDecisionPayloadDecisionInvestigateMore,
+		ApifrontendUserDecisionPayloadDecisionCancel,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendUserDecisionPayloadDecision) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendUserDecisionPayloadDecisionAccept:
+		return []byte(s), nil
+	case ApifrontendUserDecisionPayloadDecisionReject:
+		return []byte(s), nil
+	case ApifrontendUserDecisionPayloadDecisionInvestigateMore:
+		return []byte(s), nil
+	case ApifrontendUserDecisionPayloadDecisionCancel:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendUserDecisionPayloadDecision) UnmarshalText(data []byte) error {
+	switch ApifrontendUserDecisionPayloadDecision(data) {
+	case ApifrontendUserDecisionPayloadDecisionAccept:
+		*s = ApifrontendUserDecisionPayloadDecisionAccept
+		return nil
+	case ApifrontendUserDecisionPayloadDecisionReject:
+		*s = ApifrontendUserDecisionPayloadDecisionReject
+		return nil
+	case ApifrontendUserDecisionPayloadDecisionInvestigateMore:
+		*s = ApifrontendUserDecisionPayloadDecisionInvestigateMore
+		return nil
+	case ApifrontendUserDecisionPayloadDecisionCancel:
+		*s = ApifrontendUserDecisionPayloadDecisionCancel
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Event type for discriminator (matches parent event_type).
+type ApifrontendUserDecisionPayloadEventType string
+
+const (
+	ApifrontendUserDecisionPayloadEventTypeApifrontendUserDecision ApifrontendUserDecisionPayloadEventType = "apifrontend.user.decision"
+)
+
+// AllValues returns all ApifrontendUserDecisionPayloadEventType values.
+func (ApifrontendUserDecisionPayloadEventType) AllValues() []ApifrontendUserDecisionPayloadEventType {
+	return []ApifrontendUserDecisionPayloadEventType{
+		ApifrontendUserDecisionPayloadEventTypeApifrontendUserDecision,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s ApifrontendUserDecisionPayloadEventType) MarshalText() ([]byte, error) {
+	switch s {
+	case ApifrontendUserDecisionPayloadEventTypeApifrontendUserDecision:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *ApifrontendUserDecisionPayloadEventType) UnmarshalText(data []byte) error {
+	switch ApifrontendUserDecisionPayloadEventType(data) {
+	case ApifrontendUserDecisionPayloadEventTypeApifrontendUserDecision:
+		*s = ApifrontendUserDecisionPayloadEventTypeApifrontendUserDecision
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
 // Response when audit event is queued for async processing (202 Accepted).
 // Ref: #/components/schemas/AsyncAcceptanceResponse
 type AsyncAcceptanceResponse struct {
@@ -3803,7 +5700,9 @@ type AuditEvent struct {
 	// - orchestration: Remediation orchestration lifecycle events
 	// - approval: Remediation approval request decision events
 	// - effectiveness: Effectiveness assessment and monitoring events
-	// - actiontype: ActionType taxonomy lifecycle events (Issue #300).
+	// - actiontype: ActionType taxonomy lifecycle events (Issue #300)
+	// - apifrontend: API Frontend service — triage, session, delegation, and user decision events
+	// (Issue #1021).
 	EventCategory AuditEventEventCategory `json:"event_category"`
 	// Action performed (ADR-034).
 	EventAction string `json:"event_action"`
@@ -4034,7 +5933,9 @@ func (s *AuditEvent) SetEventDate(val OptNilDate) {
 // - orchestration: Remediation orchestration lifecycle events
 // - approval: Remediation approval request decision events
 // - effectiveness: Effectiveness assessment and monitoring events
-// - actiontype: ActionType taxonomy lifecycle events (Issue #300).
+// - actiontype: ActionType taxonomy lifecycle events (Issue #300)
+// - apifrontend: API Frontend service — triage, session, delegation, and user decision events
+// (Issue #1021).
 type AuditEventEventCategory string
 
 const (
@@ -4049,6 +5950,7 @@ const (
 	AuditEventEventCategoryApproval          AuditEventEventCategory = "approval"
 	AuditEventEventCategoryEffectiveness     AuditEventEventCategory = "effectiveness"
 	AuditEventEventCategoryActiontype        AuditEventEventCategory = "actiontype"
+	AuditEventEventCategoryApifrontend       AuditEventEventCategory = "apifrontend"
 )
 
 // AllValues returns all AuditEventEventCategory values.
@@ -4065,6 +5967,7 @@ func (AuditEventEventCategory) AllValues() []AuditEventEventCategory {
 		AuditEventEventCategoryApproval,
 		AuditEventEventCategoryEffectiveness,
 		AuditEventEventCategoryActiontype,
+		AuditEventEventCategoryApifrontend,
 	}
 }
 
@@ -4092,6 +5995,8 @@ func (s AuditEventEventCategory) MarshalText() ([]byte, error) {
 	case AuditEventEventCategoryEffectiveness:
 		return []byte(s), nil
 	case AuditEventEventCategoryActiontype:
+		return []byte(s), nil
+	case AuditEventEventCategoryApifrontend:
 		return []byte(s), nil
 	default:
 		return nil, errors.Errorf("invalid value: %q", s)
@@ -4133,6 +6038,9 @@ func (s *AuditEventEventCategory) UnmarshalText(data []byte) error {
 		return nil
 	case AuditEventEventCategoryActiontype:
 		*s = AuditEventEventCategoryActiontype
+		return nil
+	case AuditEventEventCategoryApifrontend:
+		*s = AuditEventEventCategoryApifrontend
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)
@@ -4198,6 +6106,17 @@ type AuditEventEventData struct {
 	ActionTypeCatalogReenabledPayload      ActionTypeCatalogReenabledPayload
 	ActionTypeCatalogDisableDeniedPayload  ActionTypeCatalogDisableDeniedPayload
 	ActionTypeWebhookAuditPayload          ActionTypeWebhookAuditPayload
+	ApifrontendTriageStartedPayload        ApifrontendTriageStartedPayload
+	ApifrontendTriageCompletedPayload      ApifrontendTriageCompletedPayload
+	ApifrontendRRCreatedPayload            ApifrontendRRCreatedPayload
+	ApifrontendRRDeduplicatedPayload       ApifrontendRRDeduplicatedPayload
+	ApifrontendSessionCreatedPayload       ApifrontendSessionCreatedPayload
+	ApifrontendSessionCompletedPayload     ApifrontendSessionCompletedPayload
+	ApifrontendKADelegatedPayload          ApifrontendKADelegatedPayload
+	ApifrontendKAResultReceivedPayload     ApifrontendKAResultReceivedPayload
+	ApifrontendUserDecisionPayload         ApifrontendUserDecisionPayload
+	ApifrontendAuthAccessDeniedPayload     ApifrontendAuthAccessDeniedPayload
+	ApifrontendToolExecutedPayload         ApifrontendToolExecutedPayload
 }
 
 // AuditEventEventDataType is oneOf type of AuditEventEventData.
@@ -4305,6 +6224,17 @@ const (
 	AuditEventEventDataActiontypeDeniedCreateAuditEventEventData                     AuditEventEventDataType = "actiontype.denied.create"
 	AuditEventEventDataActiontypeDeniedDeleteAuditEventEventData                     AuditEventEventDataType = "actiontype.denied.delete"
 	AuditEventEventDataActiontypeDeniedUpdateAuditEventEventData                     AuditEventEventDataType = "actiontype.denied.update"
+	ApifrontendTriageStartedPayloadAuditEventEventData                               AuditEventEventDataType = "apifrontend.triage.started"
+	ApifrontendTriageCompletedPayloadAuditEventEventData                             AuditEventEventDataType = "apifrontend.triage.completed"
+	ApifrontendRRCreatedPayloadAuditEventEventData                                   AuditEventEventDataType = "apifrontend.rr.created"
+	ApifrontendRRDeduplicatedPayloadAuditEventEventData                              AuditEventEventDataType = "apifrontend.rr.deduplicated"
+	ApifrontendSessionCreatedPayloadAuditEventEventData                              AuditEventEventDataType = "apifrontend.session.created"
+	ApifrontendSessionCompletedPayloadAuditEventEventData                            AuditEventEventDataType = "apifrontend.session.completed"
+	ApifrontendKADelegatedPayloadAuditEventEventData                                 AuditEventEventDataType = "apifrontend.ka.delegated"
+	ApifrontendKAResultReceivedPayloadAuditEventEventData                            AuditEventEventDataType = "apifrontend.ka.result_received"
+	ApifrontendUserDecisionPayloadAuditEventEventData                                AuditEventEventDataType = "apifrontend.user.decision"
+	ApifrontendAuthAccessDeniedPayloadAuditEventEventData                            AuditEventEventDataType = "apifrontend.auth.access_denied"
+	ApifrontendToolExecutedPayloadAuditEventEventData                                AuditEventEventDataType = "apifrontend.tool.executed"
 )
 
 // IsGatewayAuditPayload reports whether AuditEventEventData is GatewayAuditPayload.
@@ -4620,6 +6550,61 @@ func (s AuditEventEventData) IsActionTypeWebhookAuditPayload() bool {
 	default:
 		return false
 	}
+}
+
+// IsApifrontendTriageStartedPayload reports whether AuditEventEventData is ApifrontendTriageStartedPayload.
+func (s AuditEventEventData) IsApifrontendTriageStartedPayload() bool {
+	return s.Type == ApifrontendTriageStartedPayloadAuditEventEventData
+}
+
+// IsApifrontendTriageCompletedPayload reports whether AuditEventEventData is ApifrontendTriageCompletedPayload.
+func (s AuditEventEventData) IsApifrontendTriageCompletedPayload() bool {
+	return s.Type == ApifrontendTriageCompletedPayloadAuditEventEventData
+}
+
+// IsApifrontendRRCreatedPayload reports whether AuditEventEventData is ApifrontendRRCreatedPayload.
+func (s AuditEventEventData) IsApifrontendRRCreatedPayload() bool {
+	return s.Type == ApifrontendRRCreatedPayloadAuditEventEventData
+}
+
+// IsApifrontendRRDeduplicatedPayload reports whether AuditEventEventData is ApifrontendRRDeduplicatedPayload.
+func (s AuditEventEventData) IsApifrontendRRDeduplicatedPayload() bool {
+	return s.Type == ApifrontendRRDeduplicatedPayloadAuditEventEventData
+}
+
+// IsApifrontendSessionCreatedPayload reports whether AuditEventEventData is ApifrontendSessionCreatedPayload.
+func (s AuditEventEventData) IsApifrontendSessionCreatedPayload() bool {
+	return s.Type == ApifrontendSessionCreatedPayloadAuditEventEventData
+}
+
+// IsApifrontendSessionCompletedPayload reports whether AuditEventEventData is ApifrontendSessionCompletedPayload.
+func (s AuditEventEventData) IsApifrontendSessionCompletedPayload() bool {
+	return s.Type == ApifrontendSessionCompletedPayloadAuditEventEventData
+}
+
+// IsApifrontendKADelegatedPayload reports whether AuditEventEventData is ApifrontendKADelegatedPayload.
+func (s AuditEventEventData) IsApifrontendKADelegatedPayload() bool {
+	return s.Type == ApifrontendKADelegatedPayloadAuditEventEventData
+}
+
+// IsApifrontendKAResultReceivedPayload reports whether AuditEventEventData is ApifrontendKAResultReceivedPayload.
+func (s AuditEventEventData) IsApifrontendKAResultReceivedPayload() bool {
+	return s.Type == ApifrontendKAResultReceivedPayloadAuditEventEventData
+}
+
+// IsApifrontendUserDecisionPayload reports whether AuditEventEventData is ApifrontendUserDecisionPayload.
+func (s AuditEventEventData) IsApifrontendUserDecisionPayload() bool {
+	return s.Type == ApifrontendUserDecisionPayloadAuditEventEventData
+}
+
+// IsApifrontendAuthAccessDeniedPayload reports whether AuditEventEventData is ApifrontendAuthAccessDeniedPayload.
+func (s AuditEventEventData) IsApifrontendAuthAccessDeniedPayload() bool {
+	return s.Type == ApifrontendAuthAccessDeniedPayloadAuditEventEventData
+}
+
+// IsApifrontendToolExecutedPayload reports whether AuditEventEventData is ApifrontendToolExecutedPayload.
+func (s AuditEventEventData) IsApifrontendToolExecutedPayload() bool {
+	return s.Type == ApifrontendToolExecutedPayloadAuditEventEventData
 }
 
 // SetGatewayAuditPayload sets AuditEventEventData to GatewayAuditPayload.
@@ -6094,6 +8079,237 @@ func NewAuditEventEventDataActiontypeDeniedUpdateAuditEventEventData(v ActionTyp
 	return s
 }
 
+// SetApifrontendTriageStartedPayload sets AuditEventEventData to ApifrontendTriageStartedPayload.
+func (s *AuditEventEventData) SetApifrontendTriageStartedPayload(v ApifrontendTriageStartedPayload) {
+	s.Type = ApifrontendTriageStartedPayloadAuditEventEventData
+	s.ApifrontendTriageStartedPayload = v
+}
+
+// GetApifrontendTriageStartedPayload returns ApifrontendTriageStartedPayload and true boolean if AuditEventEventData is ApifrontendTriageStartedPayload.
+func (s AuditEventEventData) GetApifrontendTriageStartedPayload() (v ApifrontendTriageStartedPayload, ok bool) {
+	if !s.IsApifrontendTriageStartedPayload() {
+		return v, false
+	}
+	return s.ApifrontendTriageStartedPayload, true
+}
+
+// NewApifrontendTriageStartedPayloadAuditEventEventData returns new AuditEventEventData from ApifrontendTriageStartedPayload.
+func NewApifrontendTriageStartedPayloadAuditEventEventData(v ApifrontendTriageStartedPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetApifrontendTriageStartedPayload(v)
+	return s
+}
+
+// SetApifrontendTriageCompletedPayload sets AuditEventEventData to ApifrontendTriageCompletedPayload.
+func (s *AuditEventEventData) SetApifrontendTriageCompletedPayload(v ApifrontendTriageCompletedPayload) {
+	s.Type = ApifrontendTriageCompletedPayloadAuditEventEventData
+	s.ApifrontendTriageCompletedPayload = v
+}
+
+// GetApifrontendTriageCompletedPayload returns ApifrontendTriageCompletedPayload and true boolean if AuditEventEventData is ApifrontendTriageCompletedPayload.
+func (s AuditEventEventData) GetApifrontendTriageCompletedPayload() (v ApifrontendTriageCompletedPayload, ok bool) {
+	if !s.IsApifrontendTriageCompletedPayload() {
+		return v, false
+	}
+	return s.ApifrontendTriageCompletedPayload, true
+}
+
+// NewApifrontendTriageCompletedPayloadAuditEventEventData returns new AuditEventEventData from ApifrontendTriageCompletedPayload.
+func NewApifrontendTriageCompletedPayloadAuditEventEventData(v ApifrontendTriageCompletedPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetApifrontendTriageCompletedPayload(v)
+	return s
+}
+
+// SetApifrontendRRCreatedPayload sets AuditEventEventData to ApifrontendRRCreatedPayload.
+func (s *AuditEventEventData) SetApifrontendRRCreatedPayload(v ApifrontendRRCreatedPayload) {
+	s.Type = ApifrontendRRCreatedPayloadAuditEventEventData
+	s.ApifrontendRRCreatedPayload = v
+}
+
+// GetApifrontendRRCreatedPayload returns ApifrontendRRCreatedPayload and true boolean if AuditEventEventData is ApifrontendRRCreatedPayload.
+func (s AuditEventEventData) GetApifrontendRRCreatedPayload() (v ApifrontendRRCreatedPayload, ok bool) {
+	if !s.IsApifrontendRRCreatedPayload() {
+		return v, false
+	}
+	return s.ApifrontendRRCreatedPayload, true
+}
+
+// NewApifrontendRRCreatedPayloadAuditEventEventData returns new AuditEventEventData from ApifrontendRRCreatedPayload.
+func NewApifrontendRRCreatedPayloadAuditEventEventData(v ApifrontendRRCreatedPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetApifrontendRRCreatedPayload(v)
+	return s
+}
+
+// SetApifrontendRRDeduplicatedPayload sets AuditEventEventData to ApifrontendRRDeduplicatedPayload.
+func (s *AuditEventEventData) SetApifrontendRRDeduplicatedPayload(v ApifrontendRRDeduplicatedPayload) {
+	s.Type = ApifrontendRRDeduplicatedPayloadAuditEventEventData
+	s.ApifrontendRRDeduplicatedPayload = v
+}
+
+// GetApifrontendRRDeduplicatedPayload returns ApifrontendRRDeduplicatedPayload and true boolean if AuditEventEventData is ApifrontendRRDeduplicatedPayload.
+func (s AuditEventEventData) GetApifrontendRRDeduplicatedPayload() (v ApifrontendRRDeduplicatedPayload, ok bool) {
+	if !s.IsApifrontendRRDeduplicatedPayload() {
+		return v, false
+	}
+	return s.ApifrontendRRDeduplicatedPayload, true
+}
+
+// NewApifrontendRRDeduplicatedPayloadAuditEventEventData returns new AuditEventEventData from ApifrontendRRDeduplicatedPayload.
+func NewApifrontendRRDeduplicatedPayloadAuditEventEventData(v ApifrontendRRDeduplicatedPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetApifrontendRRDeduplicatedPayload(v)
+	return s
+}
+
+// SetApifrontendSessionCreatedPayload sets AuditEventEventData to ApifrontendSessionCreatedPayload.
+func (s *AuditEventEventData) SetApifrontendSessionCreatedPayload(v ApifrontendSessionCreatedPayload) {
+	s.Type = ApifrontendSessionCreatedPayloadAuditEventEventData
+	s.ApifrontendSessionCreatedPayload = v
+}
+
+// GetApifrontendSessionCreatedPayload returns ApifrontendSessionCreatedPayload and true boolean if AuditEventEventData is ApifrontendSessionCreatedPayload.
+func (s AuditEventEventData) GetApifrontendSessionCreatedPayload() (v ApifrontendSessionCreatedPayload, ok bool) {
+	if !s.IsApifrontendSessionCreatedPayload() {
+		return v, false
+	}
+	return s.ApifrontendSessionCreatedPayload, true
+}
+
+// NewApifrontendSessionCreatedPayloadAuditEventEventData returns new AuditEventEventData from ApifrontendSessionCreatedPayload.
+func NewApifrontendSessionCreatedPayloadAuditEventEventData(v ApifrontendSessionCreatedPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetApifrontendSessionCreatedPayload(v)
+	return s
+}
+
+// SetApifrontendSessionCompletedPayload sets AuditEventEventData to ApifrontendSessionCompletedPayload.
+func (s *AuditEventEventData) SetApifrontendSessionCompletedPayload(v ApifrontendSessionCompletedPayload) {
+	s.Type = ApifrontendSessionCompletedPayloadAuditEventEventData
+	s.ApifrontendSessionCompletedPayload = v
+}
+
+// GetApifrontendSessionCompletedPayload returns ApifrontendSessionCompletedPayload and true boolean if AuditEventEventData is ApifrontendSessionCompletedPayload.
+func (s AuditEventEventData) GetApifrontendSessionCompletedPayload() (v ApifrontendSessionCompletedPayload, ok bool) {
+	if !s.IsApifrontendSessionCompletedPayload() {
+		return v, false
+	}
+	return s.ApifrontendSessionCompletedPayload, true
+}
+
+// NewApifrontendSessionCompletedPayloadAuditEventEventData returns new AuditEventEventData from ApifrontendSessionCompletedPayload.
+func NewApifrontendSessionCompletedPayloadAuditEventEventData(v ApifrontendSessionCompletedPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetApifrontendSessionCompletedPayload(v)
+	return s
+}
+
+// SetApifrontendKADelegatedPayload sets AuditEventEventData to ApifrontendKADelegatedPayload.
+func (s *AuditEventEventData) SetApifrontendKADelegatedPayload(v ApifrontendKADelegatedPayload) {
+	s.Type = ApifrontendKADelegatedPayloadAuditEventEventData
+	s.ApifrontendKADelegatedPayload = v
+}
+
+// GetApifrontendKADelegatedPayload returns ApifrontendKADelegatedPayload and true boolean if AuditEventEventData is ApifrontendKADelegatedPayload.
+func (s AuditEventEventData) GetApifrontendKADelegatedPayload() (v ApifrontendKADelegatedPayload, ok bool) {
+	if !s.IsApifrontendKADelegatedPayload() {
+		return v, false
+	}
+	return s.ApifrontendKADelegatedPayload, true
+}
+
+// NewApifrontendKADelegatedPayloadAuditEventEventData returns new AuditEventEventData from ApifrontendKADelegatedPayload.
+func NewApifrontendKADelegatedPayloadAuditEventEventData(v ApifrontendKADelegatedPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetApifrontendKADelegatedPayload(v)
+	return s
+}
+
+// SetApifrontendKAResultReceivedPayload sets AuditEventEventData to ApifrontendKAResultReceivedPayload.
+func (s *AuditEventEventData) SetApifrontendKAResultReceivedPayload(v ApifrontendKAResultReceivedPayload) {
+	s.Type = ApifrontendKAResultReceivedPayloadAuditEventEventData
+	s.ApifrontendKAResultReceivedPayload = v
+}
+
+// GetApifrontendKAResultReceivedPayload returns ApifrontendKAResultReceivedPayload and true boolean if AuditEventEventData is ApifrontendKAResultReceivedPayload.
+func (s AuditEventEventData) GetApifrontendKAResultReceivedPayload() (v ApifrontendKAResultReceivedPayload, ok bool) {
+	if !s.IsApifrontendKAResultReceivedPayload() {
+		return v, false
+	}
+	return s.ApifrontendKAResultReceivedPayload, true
+}
+
+// NewApifrontendKAResultReceivedPayloadAuditEventEventData returns new AuditEventEventData from ApifrontendKAResultReceivedPayload.
+func NewApifrontendKAResultReceivedPayloadAuditEventEventData(v ApifrontendKAResultReceivedPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetApifrontendKAResultReceivedPayload(v)
+	return s
+}
+
+// SetApifrontendUserDecisionPayload sets AuditEventEventData to ApifrontendUserDecisionPayload.
+func (s *AuditEventEventData) SetApifrontendUserDecisionPayload(v ApifrontendUserDecisionPayload) {
+	s.Type = ApifrontendUserDecisionPayloadAuditEventEventData
+	s.ApifrontendUserDecisionPayload = v
+}
+
+// GetApifrontendUserDecisionPayload returns ApifrontendUserDecisionPayload and true boolean if AuditEventEventData is ApifrontendUserDecisionPayload.
+func (s AuditEventEventData) GetApifrontendUserDecisionPayload() (v ApifrontendUserDecisionPayload, ok bool) {
+	if !s.IsApifrontendUserDecisionPayload() {
+		return v, false
+	}
+	return s.ApifrontendUserDecisionPayload, true
+}
+
+// NewApifrontendUserDecisionPayloadAuditEventEventData returns new AuditEventEventData from ApifrontendUserDecisionPayload.
+func NewApifrontendUserDecisionPayloadAuditEventEventData(v ApifrontendUserDecisionPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetApifrontendUserDecisionPayload(v)
+	return s
+}
+
+// SetApifrontendAuthAccessDeniedPayload sets AuditEventEventData to ApifrontendAuthAccessDeniedPayload.
+func (s *AuditEventEventData) SetApifrontendAuthAccessDeniedPayload(v ApifrontendAuthAccessDeniedPayload) {
+	s.Type = ApifrontendAuthAccessDeniedPayloadAuditEventEventData
+	s.ApifrontendAuthAccessDeniedPayload = v
+}
+
+// GetApifrontendAuthAccessDeniedPayload returns ApifrontendAuthAccessDeniedPayload and true boolean if AuditEventEventData is ApifrontendAuthAccessDeniedPayload.
+func (s AuditEventEventData) GetApifrontendAuthAccessDeniedPayload() (v ApifrontendAuthAccessDeniedPayload, ok bool) {
+	if !s.IsApifrontendAuthAccessDeniedPayload() {
+		return v, false
+	}
+	return s.ApifrontendAuthAccessDeniedPayload, true
+}
+
+// NewApifrontendAuthAccessDeniedPayloadAuditEventEventData returns new AuditEventEventData from ApifrontendAuthAccessDeniedPayload.
+func NewApifrontendAuthAccessDeniedPayloadAuditEventEventData(v ApifrontendAuthAccessDeniedPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetApifrontendAuthAccessDeniedPayload(v)
+	return s
+}
+
+// SetApifrontendToolExecutedPayload sets AuditEventEventData to ApifrontendToolExecutedPayload.
+func (s *AuditEventEventData) SetApifrontendToolExecutedPayload(v ApifrontendToolExecutedPayload) {
+	s.Type = ApifrontendToolExecutedPayloadAuditEventEventData
+	s.ApifrontendToolExecutedPayload = v
+}
+
+// GetApifrontendToolExecutedPayload returns ApifrontendToolExecutedPayload and true boolean if AuditEventEventData is ApifrontendToolExecutedPayload.
+func (s AuditEventEventData) GetApifrontendToolExecutedPayload() (v ApifrontendToolExecutedPayload, ok bool) {
+	if !s.IsApifrontendToolExecutedPayload() {
+		return v, false
+	}
+	return s.ApifrontendToolExecutedPayload, true
+}
+
+// NewApifrontendToolExecutedPayloadAuditEventEventData returns new AuditEventEventData from ApifrontendToolExecutedPayload.
+func NewApifrontendToolExecutedPayloadAuditEventEventData(v ApifrontendToolExecutedPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetApifrontendToolExecutedPayload(v)
+	return s
+}
+
 // Result of the event.
 type AuditEventEventOutcome string
 
@@ -6165,7 +8381,9 @@ type AuditEventRequest struct {
 	// - orchestration: Remediation orchestration lifecycle events
 	// - approval: Remediation approval request decision events
 	// - effectiveness: Effectiveness assessment and monitoring events
-	// - actiontype: ActionType taxonomy lifecycle events (Issue #300).
+	// - actiontype: ActionType taxonomy lifecycle events (Issue #300)
+	// - apifrontend: API Frontend service — triage, session, delegation, and user decision events
+	// (Issue #1021).
 	EventCategory AuditEventRequestEventCategory `json:"event_category"`
 	// Action performed (ADR-034).
 	EventAction string `json:"event_action"`
@@ -6373,7 +8591,9 @@ func (s *AuditEventRequest) SetEventData(val AuditEventRequestEventData) {
 // - orchestration: Remediation orchestration lifecycle events
 // - approval: Remediation approval request decision events
 // - effectiveness: Effectiveness assessment and monitoring events
-// - actiontype: ActionType taxonomy lifecycle events (Issue #300).
+// - actiontype: ActionType taxonomy lifecycle events (Issue #300)
+// - apifrontend: API Frontend service — triage, session, delegation, and user decision events
+// (Issue #1021).
 type AuditEventRequestEventCategory string
 
 const (
@@ -6388,6 +8608,7 @@ const (
 	AuditEventRequestEventCategoryApproval          AuditEventRequestEventCategory = "approval"
 	AuditEventRequestEventCategoryEffectiveness     AuditEventRequestEventCategory = "effectiveness"
 	AuditEventRequestEventCategoryActiontype        AuditEventRequestEventCategory = "actiontype"
+	AuditEventRequestEventCategoryApifrontend       AuditEventRequestEventCategory = "apifrontend"
 )
 
 // AllValues returns all AuditEventRequestEventCategory values.
@@ -6404,6 +8625,7 @@ func (AuditEventRequestEventCategory) AllValues() []AuditEventRequestEventCatego
 		AuditEventRequestEventCategoryApproval,
 		AuditEventRequestEventCategoryEffectiveness,
 		AuditEventRequestEventCategoryActiontype,
+		AuditEventRequestEventCategoryApifrontend,
 	}
 }
 
@@ -6431,6 +8653,8 @@ func (s AuditEventRequestEventCategory) MarshalText() ([]byte, error) {
 	case AuditEventRequestEventCategoryEffectiveness:
 		return []byte(s), nil
 	case AuditEventRequestEventCategoryActiontype:
+		return []byte(s), nil
+	case AuditEventRequestEventCategoryApifrontend:
 		return []byte(s), nil
 	default:
 		return nil, errors.Errorf("invalid value: %q", s)
@@ -6472,6 +8696,9 @@ func (s *AuditEventRequestEventCategory) UnmarshalText(data []byte) error {
 		return nil
 	case AuditEventRequestEventCategoryActiontype:
 		*s = AuditEventRequestEventCategoryActiontype
+		return nil
+	case AuditEventRequestEventCategoryApifrontend:
+		*s = AuditEventRequestEventCategoryApifrontend
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)
@@ -6537,6 +8764,17 @@ type AuditEventRequestEventData struct {
 	ActionTypeCatalogReenabledPayload      ActionTypeCatalogReenabledPayload
 	ActionTypeCatalogDisableDeniedPayload  ActionTypeCatalogDisableDeniedPayload
 	ActionTypeWebhookAuditPayload          ActionTypeWebhookAuditPayload
+	ApifrontendTriageStartedPayload        ApifrontendTriageStartedPayload
+	ApifrontendTriageCompletedPayload      ApifrontendTriageCompletedPayload
+	ApifrontendRRCreatedPayload            ApifrontendRRCreatedPayload
+	ApifrontendRRDeduplicatedPayload       ApifrontendRRDeduplicatedPayload
+	ApifrontendSessionCreatedPayload       ApifrontendSessionCreatedPayload
+	ApifrontendSessionCompletedPayload     ApifrontendSessionCompletedPayload
+	ApifrontendKADelegatedPayload          ApifrontendKADelegatedPayload
+	ApifrontendKAResultReceivedPayload     ApifrontendKAResultReceivedPayload
+	ApifrontendUserDecisionPayload         ApifrontendUserDecisionPayload
+	ApifrontendAuthAccessDeniedPayload     ApifrontendAuthAccessDeniedPayload
+	ApifrontendToolExecutedPayload         ApifrontendToolExecutedPayload
 }
 
 // AuditEventRequestEventDataType is oneOf type of AuditEventRequestEventData.
@@ -6644,6 +8882,17 @@ const (
 	AuditEventRequestEventDataActiontypeDeniedCreateAuditEventRequestEventData                     AuditEventRequestEventDataType = "actiontype.denied.create"
 	AuditEventRequestEventDataActiontypeDeniedDeleteAuditEventRequestEventData                     AuditEventRequestEventDataType = "actiontype.denied.delete"
 	AuditEventRequestEventDataActiontypeDeniedUpdateAuditEventRequestEventData                     AuditEventRequestEventDataType = "actiontype.denied.update"
+	ApifrontendTriageStartedPayloadAuditEventRequestEventData                                      AuditEventRequestEventDataType = "apifrontend.triage.started"
+	ApifrontendTriageCompletedPayloadAuditEventRequestEventData                                    AuditEventRequestEventDataType = "apifrontend.triage.completed"
+	ApifrontendRRCreatedPayloadAuditEventRequestEventData                                          AuditEventRequestEventDataType = "apifrontend.rr.created"
+	ApifrontendRRDeduplicatedPayloadAuditEventRequestEventData                                     AuditEventRequestEventDataType = "apifrontend.rr.deduplicated"
+	ApifrontendSessionCreatedPayloadAuditEventRequestEventData                                     AuditEventRequestEventDataType = "apifrontend.session.created"
+	ApifrontendSessionCompletedPayloadAuditEventRequestEventData                                   AuditEventRequestEventDataType = "apifrontend.session.completed"
+	ApifrontendKADelegatedPayloadAuditEventRequestEventData                                        AuditEventRequestEventDataType = "apifrontend.ka.delegated"
+	ApifrontendKAResultReceivedPayloadAuditEventRequestEventData                                   AuditEventRequestEventDataType = "apifrontend.ka.result_received"
+	ApifrontendUserDecisionPayloadAuditEventRequestEventData                                       AuditEventRequestEventDataType = "apifrontend.user.decision"
+	ApifrontendAuthAccessDeniedPayloadAuditEventRequestEventData                                   AuditEventRequestEventDataType = "apifrontend.auth.access_denied"
+	ApifrontendToolExecutedPayloadAuditEventRequestEventData                                       AuditEventRequestEventDataType = "apifrontend.tool.executed"
 )
 
 // IsGatewayAuditPayload reports whether AuditEventRequestEventData is GatewayAuditPayload.
@@ -6959,6 +9208,61 @@ func (s AuditEventRequestEventData) IsActionTypeWebhookAuditPayload() bool {
 	default:
 		return false
 	}
+}
+
+// IsApifrontendTriageStartedPayload reports whether AuditEventRequestEventData is ApifrontendTriageStartedPayload.
+func (s AuditEventRequestEventData) IsApifrontendTriageStartedPayload() bool {
+	return s.Type == ApifrontendTriageStartedPayloadAuditEventRequestEventData
+}
+
+// IsApifrontendTriageCompletedPayload reports whether AuditEventRequestEventData is ApifrontendTriageCompletedPayload.
+func (s AuditEventRequestEventData) IsApifrontendTriageCompletedPayload() bool {
+	return s.Type == ApifrontendTriageCompletedPayloadAuditEventRequestEventData
+}
+
+// IsApifrontendRRCreatedPayload reports whether AuditEventRequestEventData is ApifrontendRRCreatedPayload.
+func (s AuditEventRequestEventData) IsApifrontendRRCreatedPayload() bool {
+	return s.Type == ApifrontendRRCreatedPayloadAuditEventRequestEventData
+}
+
+// IsApifrontendRRDeduplicatedPayload reports whether AuditEventRequestEventData is ApifrontendRRDeduplicatedPayload.
+func (s AuditEventRequestEventData) IsApifrontendRRDeduplicatedPayload() bool {
+	return s.Type == ApifrontendRRDeduplicatedPayloadAuditEventRequestEventData
+}
+
+// IsApifrontendSessionCreatedPayload reports whether AuditEventRequestEventData is ApifrontendSessionCreatedPayload.
+func (s AuditEventRequestEventData) IsApifrontendSessionCreatedPayload() bool {
+	return s.Type == ApifrontendSessionCreatedPayloadAuditEventRequestEventData
+}
+
+// IsApifrontendSessionCompletedPayload reports whether AuditEventRequestEventData is ApifrontendSessionCompletedPayload.
+func (s AuditEventRequestEventData) IsApifrontendSessionCompletedPayload() bool {
+	return s.Type == ApifrontendSessionCompletedPayloadAuditEventRequestEventData
+}
+
+// IsApifrontendKADelegatedPayload reports whether AuditEventRequestEventData is ApifrontendKADelegatedPayload.
+func (s AuditEventRequestEventData) IsApifrontendKADelegatedPayload() bool {
+	return s.Type == ApifrontendKADelegatedPayloadAuditEventRequestEventData
+}
+
+// IsApifrontendKAResultReceivedPayload reports whether AuditEventRequestEventData is ApifrontendKAResultReceivedPayload.
+func (s AuditEventRequestEventData) IsApifrontendKAResultReceivedPayload() bool {
+	return s.Type == ApifrontendKAResultReceivedPayloadAuditEventRequestEventData
+}
+
+// IsApifrontendUserDecisionPayload reports whether AuditEventRequestEventData is ApifrontendUserDecisionPayload.
+func (s AuditEventRequestEventData) IsApifrontendUserDecisionPayload() bool {
+	return s.Type == ApifrontendUserDecisionPayloadAuditEventRequestEventData
+}
+
+// IsApifrontendAuthAccessDeniedPayload reports whether AuditEventRequestEventData is ApifrontendAuthAccessDeniedPayload.
+func (s AuditEventRequestEventData) IsApifrontendAuthAccessDeniedPayload() bool {
+	return s.Type == ApifrontendAuthAccessDeniedPayloadAuditEventRequestEventData
+}
+
+// IsApifrontendToolExecutedPayload reports whether AuditEventRequestEventData is ApifrontendToolExecutedPayload.
+func (s AuditEventRequestEventData) IsApifrontendToolExecutedPayload() bool {
+	return s.Type == ApifrontendToolExecutedPayloadAuditEventRequestEventData
 }
 
 // SetGatewayAuditPayload sets AuditEventRequestEventData to GatewayAuditPayload.
@@ -8430,6 +10734,237 @@ func NewAuditEventRequestEventDataActiontypeDeniedDeleteAuditEventRequestEventDa
 func NewAuditEventRequestEventDataActiontypeDeniedUpdateAuditEventRequestEventData(v ActionTypeWebhookAuditPayload) AuditEventRequestEventData {
 	var s AuditEventRequestEventData
 	s.SetActionTypeWebhookAuditPayload(AuditEventRequestEventDataActiontypeDeniedUpdateAuditEventRequestEventData, v)
+	return s
+}
+
+// SetApifrontendTriageStartedPayload sets AuditEventRequestEventData to ApifrontendTriageStartedPayload.
+func (s *AuditEventRequestEventData) SetApifrontendTriageStartedPayload(v ApifrontendTriageStartedPayload) {
+	s.Type = ApifrontendTriageStartedPayloadAuditEventRequestEventData
+	s.ApifrontendTriageStartedPayload = v
+}
+
+// GetApifrontendTriageStartedPayload returns ApifrontendTriageStartedPayload and true boolean if AuditEventRequestEventData is ApifrontendTriageStartedPayload.
+func (s AuditEventRequestEventData) GetApifrontendTriageStartedPayload() (v ApifrontendTriageStartedPayload, ok bool) {
+	if !s.IsApifrontendTriageStartedPayload() {
+		return v, false
+	}
+	return s.ApifrontendTriageStartedPayload, true
+}
+
+// NewApifrontendTriageStartedPayloadAuditEventRequestEventData returns new AuditEventRequestEventData from ApifrontendTriageStartedPayload.
+func NewApifrontendTriageStartedPayloadAuditEventRequestEventData(v ApifrontendTriageStartedPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetApifrontendTriageStartedPayload(v)
+	return s
+}
+
+// SetApifrontendTriageCompletedPayload sets AuditEventRequestEventData to ApifrontendTriageCompletedPayload.
+func (s *AuditEventRequestEventData) SetApifrontendTriageCompletedPayload(v ApifrontendTriageCompletedPayload) {
+	s.Type = ApifrontendTriageCompletedPayloadAuditEventRequestEventData
+	s.ApifrontendTriageCompletedPayload = v
+}
+
+// GetApifrontendTriageCompletedPayload returns ApifrontendTriageCompletedPayload and true boolean if AuditEventRequestEventData is ApifrontendTriageCompletedPayload.
+func (s AuditEventRequestEventData) GetApifrontendTriageCompletedPayload() (v ApifrontendTriageCompletedPayload, ok bool) {
+	if !s.IsApifrontendTriageCompletedPayload() {
+		return v, false
+	}
+	return s.ApifrontendTriageCompletedPayload, true
+}
+
+// NewApifrontendTriageCompletedPayloadAuditEventRequestEventData returns new AuditEventRequestEventData from ApifrontendTriageCompletedPayload.
+func NewApifrontendTriageCompletedPayloadAuditEventRequestEventData(v ApifrontendTriageCompletedPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetApifrontendTriageCompletedPayload(v)
+	return s
+}
+
+// SetApifrontendRRCreatedPayload sets AuditEventRequestEventData to ApifrontendRRCreatedPayload.
+func (s *AuditEventRequestEventData) SetApifrontendRRCreatedPayload(v ApifrontendRRCreatedPayload) {
+	s.Type = ApifrontendRRCreatedPayloadAuditEventRequestEventData
+	s.ApifrontendRRCreatedPayload = v
+}
+
+// GetApifrontendRRCreatedPayload returns ApifrontendRRCreatedPayload and true boolean if AuditEventRequestEventData is ApifrontendRRCreatedPayload.
+func (s AuditEventRequestEventData) GetApifrontendRRCreatedPayload() (v ApifrontendRRCreatedPayload, ok bool) {
+	if !s.IsApifrontendRRCreatedPayload() {
+		return v, false
+	}
+	return s.ApifrontendRRCreatedPayload, true
+}
+
+// NewApifrontendRRCreatedPayloadAuditEventRequestEventData returns new AuditEventRequestEventData from ApifrontendRRCreatedPayload.
+func NewApifrontendRRCreatedPayloadAuditEventRequestEventData(v ApifrontendRRCreatedPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetApifrontendRRCreatedPayload(v)
+	return s
+}
+
+// SetApifrontendRRDeduplicatedPayload sets AuditEventRequestEventData to ApifrontendRRDeduplicatedPayload.
+func (s *AuditEventRequestEventData) SetApifrontendRRDeduplicatedPayload(v ApifrontendRRDeduplicatedPayload) {
+	s.Type = ApifrontendRRDeduplicatedPayloadAuditEventRequestEventData
+	s.ApifrontendRRDeduplicatedPayload = v
+}
+
+// GetApifrontendRRDeduplicatedPayload returns ApifrontendRRDeduplicatedPayload and true boolean if AuditEventRequestEventData is ApifrontendRRDeduplicatedPayload.
+func (s AuditEventRequestEventData) GetApifrontendRRDeduplicatedPayload() (v ApifrontendRRDeduplicatedPayload, ok bool) {
+	if !s.IsApifrontendRRDeduplicatedPayload() {
+		return v, false
+	}
+	return s.ApifrontendRRDeduplicatedPayload, true
+}
+
+// NewApifrontendRRDeduplicatedPayloadAuditEventRequestEventData returns new AuditEventRequestEventData from ApifrontendRRDeduplicatedPayload.
+func NewApifrontendRRDeduplicatedPayloadAuditEventRequestEventData(v ApifrontendRRDeduplicatedPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetApifrontendRRDeduplicatedPayload(v)
+	return s
+}
+
+// SetApifrontendSessionCreatedPayload sets AuditEventRequestEventData to ApifrontendSessionCreatedPayload.
+func (s *AuditEventRequestEventData) SetApifrontendSessionCreatedPayload(v ApifrontendSessionCreatedPayload) {
+	s.Type = ApifrontendSessionCreatedPayloadAuditEventRequestEventData
+	s.ApifrontendSessionCreatedPayload = v
+}
+
+// GetApifrontendSessionCreatedPayload returns ApifrontendSessionCreatedPayload and true boolean if AuditEventRequestEventData is ApifrontendSessionCreatedPayload.
+func (s AuditEventRequestEventData) GetApifrontendSessionCreatedPayload() (v ApifrontendSessionCreatedPayload, ok bool) {
+	if !s.IsApifrontendSessionCreatedPayload() {
+		return v, false
+	}
+	return s.ApifrontendSessionCreatedPayload, true
+}
+
+// NewApifrontendSessionCreatedPayloadAuditEventRequestEventData returns new AuditEventRequestEventData from ApifrontendSessionCreatedPayload.
+func NewApifrontendSessionCreatedPayloadAuditEventRequestEventData(v ApifrontendSessionCreatedPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetApifrontendSessionCreatedPayload(v)
+	return s
+}
+
+// SetApifrontendSessionCompletedPayload sets AuditEventRequestEventData to ApifrontendSessionCompletedPayload.
+func (s *AuditEventRequestEventData) SetApifrontendSessionCompletedPayload(v ApifrontendSessionCompletedPayload) {
+	s.Type = ApifrontendSessionCompletedPayloadAuditEventRequestEventData
+	s.ApifrontendSessionCompletedPayload = v
+}
+
+// GetApifrontendSessionCompletedPayload returns ApifrontendSessionCompletedPayload and true boolean if AuditEventRequestEventData is ApifrontendSessionCompletedPayload.
+func (s AuditEventRequestEventData) GetApifrontendSessionCompletedPayload() (v ApifrontendSessionCompletedPayload, ok bool) {
+	if !s.IsApifrontendSessionCompletedPayload() {
+		return v, false
+	}
+	return s.ApifrontendSessionCompletedPayload, true
+}
+
+// NewApifrontendSessionCompletedPayloadAuditEventRequestEventData returns new AuditEventRequestEventData from ApifrontendSessionCompletedPayload.
+func NewApifrontendSessionCompletedPayloadAuditEventRequestEventData(v ApifrontendSessionCompletedPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetApifrontendSessionCompletedPayload(v)
+	return s
+}
+
+// SetApifrontendKADelegatedPayload sets AuditEventRequestEventData to ApifrontendKADelegatedPayload.
+func (s *AuditEventRequestEventData) SetApifrontendKADelegatedPayload(v ApifrontendKADelegatedPayload) {
+	s.Type = ApifrontendKADelegatedPayloadAuditEventRequestEventData
+	s.ApifrontendKADelegatedPayload = v
+}
+
+// GetApifrontendKADelegatedPayload returns ApifrontendKADelegatedPayload and true boolean if AuditEventRequestEventData is ApifrontendKADelegatedPayload.
+func (s AuditEventRequestEventData) GetApifrontendKADelegatedPayload() (v ApifrontendKADelegatedPayload, ok bool) {
+	if !s.IsApifrontendKADelegatedPayload() {
+		return v, false
+	}
+	return s.ApifrontendKADelegatedPayload, true
+}
+
+// NewApifrontendKADelegatedPayloadAuditEventRequestEventData returns new AuditEventRequestEventData from ApifrontendKADelegatedPayload.
+func NewApifrontendKADelegatedPayloadAuditEventRequestEventData(v ApifrontendKADelegatedPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetApifrontendKADelegatedPayload(v)
+	return s
+}
+
+// SetApifrontendKAResultReceivedPayload sets AuditEventRequestEventData to ApifrontendKAResultReceivedPayload.
+func (s *AuditEventRequestEventData) SetApifrontendKAResultReceivedPayload(v ApifrontendKAResultReceivedPayload) {
+	s.Type = ApifrontendKAResultReceivedPayloadAuditEventRequestEventData
+	s.ApifrontendKAResultReceivedPayload = v
+}
+
+// GetApifrontendKAResultReceivedPayload returns ApifrontendKAResultReceivedPayload and true boolean if AuditEventRequestEventData is ApifrontendKAResultReceivedPayload.
+func (s AuditEventRequestEventData) GetApifrontendKAResultReceivedPayload() (v ApifrontendKAResultReceivedPayload, ok bool) {
+	if !s.IsApifrontendKAResultReceivedPayload() {
+		return v, false
+	}
+	return s.ApifrontendKAResultReceivedPayload, true
+}
+
+// NewApifrontendKAResultReceivedPayloadAuditEventRequestEventData returns new AuditEventRequestEventData from ApifrontendKAResultReceivedPayload.
+func NewApifrontendKAResultReceivedPayloadAuditEventRequestEventData(v ApifrontendKAResultReceivedPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetApifrontendKAResultReceivedPayload(v)
+	return s
+}
+
+// SetApifrontendUserDecisionPayload sets AuditEventRequestEventData to ApifrontendUserDecisionPayload.
+func (s *AuditEventRequestEventData) SetApifrontendUserDecisionPayload(v ApifrontendUserDecisionPayload) {
+	s.Type = ApifrontendUserDecisionPayloadAuditEventRequestEventData
+	s.ApifrontendUserDecisionPayload = v
+}
+
+// GetApifrontendUserDecisionPayload returns ApifrontendUserDecisionPayload and true boolean if AuditEventRequestEventData is ApifrontendUserDecisionPayload.
+func (s AuditEventRequestEventData) GetApifrontendUserDecisionPayload() (v ApifrontendUserDecisionPayload, ok bool) {
+	if !s.IsApifrontendUserDecisionPayload() {
+		return v, false
+	}
+	return s.ApifrontendUserDecisionPayload, true
+}
+
+// NewApifrontendUserDecisionPayloadAuditEventRequestEventData returns new AuditEventRequestEventData from ApifrontendUserDecisionPayload.
+func NewApifrontendUserDecisionPayloadAuditEventRequestEventData(v ApifrontendUserDecisionPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetApifrontendUserDecisionPayload(v)
+	return s
+}
+
+// SetApifrontendAuthAccessDeniedPayload sets AuditEventRequestEventData to ApifrontendAuthAccessDeniedPayload.
+func (s *AuditEventRequestEventData) SetApifrontendAuthAccessDeniedPayload(v ApifrontendAuthAccessDeniedPayload) {
+	s.Type = ApifrontendAuthAccessDeniedPayloadAuditEventRequestEventData
+	s.ApifrontendAuthAccessDeniedPayload = v
+}
+
+// GetApifrontendAuthAccessDeniedPayload returns ApifrontendAuthAccessDeniedPayload and true boolean if AuditEventRequestEventData is ApifrontendAuthAccessDeniedPayload.
+func (s AuditEventRequestEventData) GetApifrontendAuthAccessDeniedPayload() (v ApifrontendAuthAccessDeniedPayload, ok bool) {
+	if !s.IsApifrontendAuthAccessDeniedPayload() {
+		return v, false
+	}
+	return s.ApifrontendAuthAccessDeniedPayload, true
+}
+
+// NewApifrontendAuthAccessDeniedPayloadAuditEventRequestEventData returns new AuditEventRequestEventData from ApifrontendAuthAccessDeniedPayload.
+func NewApifrontendAuthAccessDeniedPayloadAuditEventRequestEventData(v ApifrontendAuthAccessDeniedPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetApifrontendAuthAccessDeniedPayload(v)
+	return s
+}
+
+// SetApifrontendToolExecutedPayload sets AuditEventRequestEventData to ApifrontendToolExecutedPayload.
+func (s *AuditEventRequestEventData) SetApifrontendToolExecutedPayload(v ApifrontendToolExecutedPayload) {
+	s.Type = ApifrontendToolExecutedPayloadAuditEventRequestEventData
+	s.ApifrontendToolExecutedPayload = v
+}
+
+// GetApifrontendToolExecutedPayload returns ApifrontendToolExecutedPayload and true boolean if AuditEventRequestEventData is ApifrontendToolExecutedPayload.
+func (s AuditEventRequestEventData) GetApifrontendToolExecutedPayload() (v ApifrontendToolExecutedPayload, ok bool) {
+	if !s.IsApifrontendToolExecutedPayload() {
+		return v, false
+	}
+	return s.ApifrontendToolExecutedPayload, true
+}
+
+// NewApifrontendToolExecutedPayloadAuditEventRequestEventData returns new AuditEventRequestEventData from ApifrontendToolExecutedPayload.
+func NewApifrontendToolExecutedPayloadAuditEventRequestEventData(v ApifrontendToolExecutedPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetApifrontendToolExecutedPayload(v)
 	return s
 }
 
@@ -14763,6 +17298,52 @@ func (o OptActionTypeDescription) Get() (v ActionTypeDescription, ok bool) {
 
 // Or returns value if set, or given parameter if does not.
 func (o OptActionTypeDescription) Or(d ActionTypeDescription) ActionTypeDescription {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
+
+// NewOptApifrontendSessionCompletedPayloadUserDecision returns new OptApifrontendSessionCompletedPayloadUserDecision with value set to v.
+func NewOptApifrontendSessionCompletedPayloadUserDecision(v ApifrontendSessionCompletedPayloadUserDecision) OptApifrontendSessionCompletedPayloadUserDecision {
+	return OptApifrontendSessionCompletedPayloadUserDecision{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptApifrontendSessionCompletedPayloadUserDecision is optional ApifrontendSessionCompletedPayloadUserDecision.
+type OptApifrontendSessionCompletedPayloadUserDecision struct {
+	Value ApifrontendSessionCompletedPayloadUserDecision
+	Set   bool
+}
+
+// IsSet returns true if OptApifrontendSessionCompletedPayloadUserDecision was set.
+func (o OptApifrontendSessionCompletedPayloadUserDecision) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptApifrontendSessionCompletedPayloadUserDecision) Reset() {
+	var v ApifrontendSessionCompletedPayloadUserDecision
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptApifrontendSessionCompletedPayloadUserDecision) SetTo(v ApifrontendSessionCompletedPayloadUserDecision) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptApifrontendSessionCompletedPayloadUserDecision) Get() (v ApifrontendSessionCompletedPayloadUserDecision, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptApifrontendSessionCompletedPayloadUserDecision) Or(d ApifrontendSessionCompletedPayloadUserDecision) ApifrontendSessionCompletedPayloadUserDecision {
 	if v, ok := o.Get(); ok {
 		return v
 	}

--- a/pkg/datastorage/ogen-client/oas_validators_gen.go
+++ b/pkg/datastorage/ogen-client/oas_validators_gen.go
@@ -1519,6 +1519,646 @@ func (s ActionTypeWebhookAuditPayloadEventType) Validate() error {
 	}
 }
 
+func (s *ApifrontendAuthAccessDeniedPayload) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.EventType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "event_type",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if s.RequiredRoles == nil {
+			return errors.New("nil is invalid value")
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "required_roles",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := s.Endpoint.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "endpoint",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s ApifrontendAuthAccessDeniedPayloadEndpoint) Validate() error {
+	switch s {
+	case "a2a":
+		return nil
+	case "mcp":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s ApifrontendAuthAccessDeniedPayloadEventType) Validate() error {
+	switch s {
+	case "apifrontend.auth.access_denied":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s *ApifrontendKADelegatedPayload) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.EventType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "event_type",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := s.DelegationType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "delegation_type",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s ApifrontendKADelegatedPayloadDelegationType) Validate() error {
+	switch s {
+	case "autonomous":
+		return nil
+	case "interactive":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s ApifrontendKADelegatedPayloadEventType) Validate() error {
+	switch s {
+	case "apifrontend.ka.delegated":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s *ApifrontendKAResultReceivedPayload) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.EventType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "event_type",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := s.ResultType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "result_type",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.Confidence.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "confidence",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s ApifrontendKAResultReceivedPayloadEventType) Validate() error {
+	switch s {
+	case "apifrontend.ka.result_received":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s ApifrontendKAResultReceivedPayloadResultType) Validate() error {
+	switch s {
+	case "rca_complete":
+		return nil
+	case "rca_failed":
+		return nil
+	case "timeout":
+		return nil
+	case "cancelled":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s *ApifrontendRRCreatedPayload) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.EventType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "event_type",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s ApifrontendRRCreatedPayloadEventType) Validate() error {
+	switch s {
+	case "apifrontend.rr.created":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s *ApifrontendRRDeduplicatedPayload) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.EventType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "event_type",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s ApifrontendRRDeduplicatedPayloadEventType) Validate() error {
+	switch s {
+	case "apifrontend.rr.deduplicated":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s *ApifrontendSessionCompletedPayload) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.EventType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "event_type",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := s.TerminalPhase.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "terminal_phase",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.UserDecision.Get(); ok {
+			if err := func() error {
+				if err := value.Validate(); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "user_decision",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s ApifrontendSessionCompletedPayloadEventType) Validate() error {
+	switch s {
+	case "apifrontend.session.completed":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s ApifrontendSessionCompletedPayloadTerminalPhase) Validate() error {
+	switch s {
+	case "Completed":
+		return nil
+	case "Cancelled":
+		return nil
+	case "Failed":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s ApifrontendSessionCompletedPayloadUserDecision) Validate() error {
+	switch s {
+	case "accept":
+		return nil
+	case "reject":
+		return nil
+	case "investigate_more":
+		return nil
+	case "cancel":
+		return nil
+	case "none":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s *ApifrontendSessionCreatedPayload) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.EventType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "event_type",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := s.JoinMode.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "join_mode",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s ApifrontendSessionCreatedPayloadEventType) Validate() error {
+	switch s {
+	case "apifrontend.session.created":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s ApifrontendSessionCreatedPayloadJoinMode) Validate() error {
+	switch s {
+	case "start":
+		return nil
+	case "takeover":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s *ApifrontendToolExecutedPayload) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.EventType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "event_type",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := s.ToolOutcome.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "tool_outcome",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s ApifrontendToolExecutedPayloadEventType) Validate() error {
+	switch s {
+	case "apifrontend.tool.executed":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s ApifrontendToolExecutedPayloadToolOutcome) Validate() error {
+	switch s {
+	case "success":
+		return nil
+	case "failure":
+		return nil
+	case "timeout":
+		return nil
+	case "denied":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s *ApifrontendTriageCompletedPayload) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.EventType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "event_type",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := s.TriageOutcome.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "triage_outcome",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s ApifrontendTriageCompletedPayloadEventType) Validate() error {
+	switch s {
+	case "apifrontend.triage.completed":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s ApifrontendTriageCompletedPayloadTriageOutcome) Validate() error {
+	switch s {
+	case "rr_created":
+		return nil
+	case "no_issue_found":
+		return nil
+	case "escalated":
+		return nil
+	case "error":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s *ApifrontendTriageStartedPayload) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.EventType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "event_type",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := s.Persona.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "persona",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s ApifrontendTriageStartedPayloadEventType) Validate() error {
+	switch s {
+	case "apifrontend.triage.started":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s ApifrontendTriageStartedPayloadPersona) Validate() error {
+	switch s {
+	case "sre":
+		return nil
+	case "orchestrator":
+		return nil
+	case "cicd":
+		return nil
+	case "dashboard":
+		return nil
+	case "audit":
+		return nil
+	case "approver":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s *ApifrontendUserDecisionPayload) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.EventType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "event_type",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := s.Decision.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "decision",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s ApifrontendUserDecisionPayloadDecision) Validate() error {
+	switch s {
+	case "accept":
+		return nil
+	case "reject":
+		return nil
+	case "investigate_more":
+		return nil
+	case "cancel":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s ApifrontendUserDecisionPayloadEventType) Validate() error {
+	switch s {
+	case "apifrontend.user.decision":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
 func (s *AuditEvent) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -1679,6 +2319,8 @@ func (s AuditEventEventCategory) Validate() error {
 	case "effectiveness":
 		return nil
 	case "actiontype":
+		return nil
+	case "apifrontend":
 		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)
@@ -1920,6 +2562,61 @@ func (s AuditEventEventData) Validate() error {
 			return err
 		}
 		return nil
+	case ApifrontendTriageStartedPayloadAuditEventEventData:
+		if err := s.ApifrontendTriageStartedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendTriageCompletedPayloadAuditEventEventData:
+		if err := s.ApifrontendTriageCompletedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendRRCreatedPayloadAuditEventEventData:
+		if err := s.ApifrontendRRCreatedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendRRDeduplicatedPayloadAuditEventEventData:
+		if err := s.ApifrontendRRDeduplicatedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendSessionCreatedPayloadAuditEventEventData:
+		if err := s.ApifrontendSessionCreatedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendSessionCompletedPayloadAuditEventEventData:
+		if err := s.ApifrontendSessionCompletedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendKADelegatedPayloadAuditEventEventData:
+		if err := s.ApifrontendKADelegatedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendKAResultReceivedPayloadAuditEventEventData:
+		if err := s.ApifrontendKAResultReceivedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendUserDecisionPayloadAuditEventEventData:
+		if err := s.ApifrontendUserDecisionPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendAuthAccessDeniedPayloadAuditEventEventData:
+		if err := s.ApifrontendAuthAccessDeniedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendToolExecutedPayloadAuditEventEventData:
+		if err := s.ApifrontendToolExecutedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -2098,6 +2795,8 @@ func (s AuditEventRequestEventCategory) Validate() error {
 	case "effectiveness":
 		return nil
 	case "actiontype":
+		return nil
+	case "apifrontend":
 		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)
@@ -2336,6 +3035,61 @@ func (s AuditEventRequestEventData) Validate() error {
 		return nil
 	case AuditEventRequestEventDataActiontypeAdmittedCreateAuditEventRequestEventData, AuditEventRequestEventDataActiontypeAdmittedDeleteAuditEventRequestEventData, AuditEventRequestEventDataActiontypeAdmittedUpdateAuditEventRequestEventData, AuditEventRequestEventDataActiontypeDeniedCreateAuditEventRequestEventData, AuditEventRequestEventDataActiontypeDeniedDeleteAuditEventRequestEventData, AuditEventRequestEventDataActiontypeDeniedUpdateAuditEventRequestEventData:
 		if err := s.ActionTypeWebhookAuditPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendTriageStartedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendTriageStartedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendTriageCompletedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendTriageCompletedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendRRCreatedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendRRCreatedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendRRDeduplicatedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendRRDeduplicatedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendSessionCreatedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendSessionCreatedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendSessionCompletedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendSessionCompletedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendKADelegatedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendKADelegatedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendKAResultReceivedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendKAResultReceivedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendUserDecisionPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendUserDecisionPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendAuthAccessDeniedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendAuthAccessDeniedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case ApifrontendToolExecutedPayloadAuditEventRequestEventData:
+		if err := s.ApifrontendToolExecutedPayload.Validate(); err != nil {
 			return err
 		}
 		return nil


### PR DESCRIPTION
## Summary

- Adds `apifrontend` to the `event_category` enum in the DataStorage OpenAPI spec
- Defines 11 typed payload schemas for AF audit events with discriminator mappings
- Regenerates the ogen client (`pkg/datastorage/ogen-client/`)

This unblocks the AF team to emit SOC2-compliant audit traces using the `BufferedAuditStore` + ogen client pattern (DD-AUDIT-002).

## Event Types Added

| Event Type | Action | Payload Schema |
|------------|--------|----------------|
| `apifrontend.triage.started` | `triage_started` | `ApifrontendTriageStartedPayload` |
| `apifrontend.triage.completed` | `triage_completed` | `ApifrontendTriageCompletedPayload` |
| `apifrontend.rr.created` | `rr_created` | `ApifrontendRRCreatedPayload` |
| `apifrontend.rr.deduplicated` | `rr_deduplicated` | `ApifrontendRRDeduplicatedPayload` |
| `apifrontend.session.created` | `session_created` | `ApifrontendSessionCreatedPayload` |
| `apifrontend.session.completed` | `session_completed` | `ApifrontendSessionCompletedPayload` |
| `apifrontend.ka.delegated` | `ka_delegated` | `ApifrontendKADelegatedPayload` |
| `apifrontend.ka.result_received` | `ka_result_received` | `ApifrontendKAResultReceivedPayload` |
| `apifrontend.user.decision` | `user_decision` | `ApifrontendUserDecisionPayload` |
| `apifrontend.auth.access_denied` | `access_denied` | `ApifrontendAuthAccessDeniedPayload` |
| `apifrontend.tool.executed` | `tool_executed` | `ApifrontendToolExecutedPayload` |

## Cross-references

- Closes #1021
- AF tracking: jordigilh/kubernaut-apifrontend#34
- Design authority: DD-AUDIT-002, DD-AUDIT-003

## Test plan

- [x] ogen client regenerates without errors
- [x] `go build ./...` passes cleanly
- [x] Pre-commit anti-pattern checks pass (0 violations)
- [x] New `AuditEventRequestEventCategoryApifrontend` constant exists in generated code
- [x] All 11 `Apifrontend*Payload` types generated with correct fields

Made with [Cursor](https://cursor.com)