### PR TITLE
feat(observability): add failure-path metrics to interactive takeover + runbook enhancements (#1026)

### DIFF
--- a/charts/kubernaut/templates/kubernaut-agent/prometheusrule.yaml
+++ b/charts/kubernaut/templates/kubernaut-agent/prometheusrule.yaml
@@ -45,7 +45,7 @@ spec:
           annotations:
             summary: "Interactive MCP command p99 latency exceeds SLO"
             description: "Tool {{ "{{" }} $labels.tool {{ "}}" }} p99 latency is {{ "{{" }} $value | humanize {{ "}}" }}s (SLO: {{ .Values.monitoring.prometheusRule.thresholds.commandDurationP99Max }}s)."
-            runbook_url: "https://github.com/jordigilh/kubernaut/blob/main/docs/operations/runbooks/interactive-mode-runbook.md#7-prometheus-dashboard-queries"
+            runbook_url: "https://github.com/jordigilh/kubernaut/blob/main/docs/operations/runbooks/interactive-mode-runbook.md#9-command-latency-high"
 
         - alert: KubernautTakeoverRateHigh
           expr: rate(aiagent_mcp_interactive_takeover_total[5m]) > {{ .Values.monitoring.prometheusRule.thresholds.takeoverRateMax }}

--- a/docs/operations/runbooks/interactive-mode-runbook.md
+++ b/docs/operations/runbooks/interactive-mode-runbook.md
@@ -91,6 +91,7 @@ kubectl get lease kubernaut-interactive-<rr_id> -n kubernaut-system -o yaml
 **Symptoms**:
 - Users invoke `kubernaut_investigate` with `action: takeover` but get errors
 - Logs show `transition autonomous session to user-driving` failures
+- The `aiagent_mcp_interactive_takeover_total` counter increments with failure outcomes
 
 **Diagnosis**:
 ```bash
@@ -102,6 +103,11 @@ kubectl logs -n kubernaut-system deploy/kubernaut-agent | grep "TransitionToUser
 
 # Verify the RR is in a takeover-eligible state (not terminal)
 kubectl get remediationrequests <rr_name> -n kubernaut-system -o yaml | grep phase
+
+# Check failure breakdown by outcome label
+```
+```promql
+sum by (outcome) (rate(aiagent_mcp_interactive_takeover_total{outcome=~".*_failed|takeover_race_lost"}[5m]))
 ```
 
 **Resolution**:
@@ -109,11 +115,26 @@ kubectl get remediationrequests <rr_name> -n kubernaut-system -o yaml | grep pha
    expected in race conditions — the interactive session proceeds normally (Lease is already acquired)
 2. **No autonomous session found**: The RR may not have an active investigation. The user should
    use `action: start` instead of `action: takeover`
-3. **Lease acquisition failure during takeover**: Another interactive user beat this one. Wait and retry.
+3. **`takeover_race_lost`**: Another interactive user acquired the Lease first. Wait and retry.
+4. **`takeover_failed`**: Generic failure — check logs for `TransitionToUserDriving` errors
+   or K8s API connectivity issues.
+5. **`start_failed`**: Session start failed due to Lease contention, max sessions reached,
+   or infrastructure errors.
+
+**Outcome Labels Reference**:
+
+| Outcome | Meaning |
+|---|---|
+| `start_success` | `action: start` — Lease acquired, session started |
+| `start_failed` | `action: start` — Lease held, max sessions, or infrastructure error |
+| `takeover_success` | `action: takeover` — Lease acquired, autonomous session transitioned |
+| `takeover_race_lost` | `action: takeover` — another user holds the Lease |
+| `takeover_failed` | `action: takeover` — generic error (transition failure, K8s API) |
 
 **Prevention**:
 - Educate operators: takeover is for transferring control from autonomous to human-driven
 - Monitor `aiagent_mcp_interactive_takeover_total` by outcome label
+- If `takeover_race_lost` is frequent, multiple operators are competing for the same RR
 
 ---
 
@@ -289,6 +310,56 @@ container_memory_working_set_bytes{container="kubernaut-agent", namespace="kuber
 | `ErrCodeUnauthorized` | 401 | Authentication failed (invalid token, expired JWT) | Re-authenticate; check JWT provider configuration |
 | `ErrCodeForbidden` | 403 | User lacks RBAC for the requested K8s operation | Expected security behavior; user needs appropriate RBAC |
 | `ErrCodeMaxSessions` | 503 | Agent has reached `maxConcurrentSessions` capacity | Wait for a session to complete; scale replicas if persistent |
+
+---
+
+## 9. Command Latency High
+
+**Symptoms**:
+- The `KubernautInteractiveCommandLatencyHigh` alert fires
+- `histogram_quantile(0.99, ...)` of `aiagent_mcp_interactive_command_duration_seconds` exceeds SLO
+- Users report slow response times from `kubernaut_investigate` tool calls
+
+**Diagnosis**:
+```bash
+# Check which tool/action combination is slow
+kubectl logs -n kubernaut-system deploy/kubernaut-agent | grep "interactive turn" | tail -20
+
+# Check LLM response times
+kubectl logs -n kubernaut-system deploy/kubernaut-agent | grep "RunInteractiveTurn" | tail -20
+
+# Check if Lease acquisition is slow (K8s API latency)
+kubectl logs -n kubernaut-system deploy/kubernaut-agent | grep "Takeover" | tail -20
+
+# Check pod resource pressure
+kubectl top pod -n kubernaut-system -l app=kubernaut-agent
+```
+```promql
+# p99 latency by tool and action
+histogram_quantile(0.99, sum by (le, tool, action) (rate(aiagent_mcp_interactive_command_duration_seconds_bucket[5m])))
+
+# p50 for comparison (is p99 an outlier or systemic?)
+histogram_quantile(0.50, sum by (le, tool, action) (rate(aiagent_mcp_interactive_command_duration_seconds_bucket[5m])))
+
+# Check if sessions are concurrently saturated
+aiagent_mcp_interactive_sessions_active
+```
+
+**Resolution**:
+1. **LLM latency**: If `RunInteractiveTurn` dominates the duration, the bottleneck is the LLM
+   provider. Check provider health, rate limits, and token counts in logs.
+2. **Lease acquisition latency**: If `Takeover` calls are slow, the K8s API server may be under
+   pressure. Check etcd latency and API server request queue.
+3. **Context reconstruction**: If `Reconstruct` is slow, the audit/history query is the bottleneck.
+   Check DataStorage query performance.
+4. **Pod resource pressure**: CPU throttling or memory pressure. Check `kubectl top pod` and
+   consider increasing resource requests/limits.
+
+**Prevention**:
+- Set appropriate SLOs via `monitoring.prometheusRule.thresholds.commandDurationP99Max` (default: 30s)
+- Monitor LLM provider latency independently
+- Use `go tool pprof` against the agent's debug endpoint for CPU/memory profiling
+- Scale replicas if sessions are consistently near `maxConcurrentSessions`
 
 ---
 

--- a/internal/kubernautagent/mcp/tools/investigate.go
+++ b/internal/kubernautagent/mcp/tools/investigate.go
@@ -239,6 +239,7 @@ func (t *InvestigateTool) handleStart(ctx context.Context, input InvestigateInpu
 		if errors.Is(err, mcpinternal.ErrLeaseHeld) {
 			if t.metrics != nil {
 				t.metrics.RecordInteractiveLeaseContention()
+				t.metrics.RecordInteractiveTakeover("start_failed")
 			}
 			driver, _ := t.sessions.GetDriver(input.RRID)
 			driverName := "unknown"
@@ -248,7 +249,13 @@ func (t *InvestigateTool) handleStart(ctx context.Context, input InvestigateInpu
 			return InvestigateOutput{}, ErrCodeSessionActive.WithDetail("driver", driverName)
 		}
 		if errors.Is(err, mcpinternal.ErrMaxSessionsReached) {
+			if t.metrics != nil {
+				t.metrics.RecordInteractiveTakeover("start_failed")
+			}
 			return InvestigateOutput{}, &MCPError{Code: "max_sessions", Message: "Maximum concurrent sessions reached"}
+		}
+		if t.metrics != nil {
+			t.metrics.RecordInteractiveTakeover("start_failed")
 		}
 		return InvestigateOutput{}, fmt.Errorf("start session: %w", err)
 	}
@@ -281,6 +288,7 @@ func (t *InvestigateTool) handleTakeover(ctx context.Context, input InvestigateI
 		if errors.Is(err, mcpinternal.ErrLeaseHeld) {
 			if t.metrics != nil {
 				t.metrics.RecordInteractiveLeaseContention()
+				t.metrics.RecordInteractiveTakeover("takeover_race_lost")
 			}
 			driver, _ := t.sessions.GetDriver(input.RRID)
 			driverName := "unknown"
@@ -288,6 +296,9 @@ func (t *InvestigateTool) handleTakeover(ctx context.Context, input InvestigateI
 				driverName = driver.ActingUser.Username
 			}
 			return InvestigateOutput{}, ErrCodeSessionActive.WithDetail("driver", driverName)
+		}
+		if t.metrics != nil {
+			t.metrics.RecordInteractiveTakeover("takeover_failed")
 		}
 		return InvestigateOutput{}, fmt.Errorf("takeover session: %w", err)
 	}
@@ -302,6 +313,9 @@ func (t *InvestigateTool) handleTakeover(ctx context.Context, input InvestigateI
 		if found {
 			if err := t.autoMgr.TransitionToUserDriving(autoSessionID, user.Username, user.Groups); err != nil {
 				if !errors.Is(err, session.ErrSessionTerminal) {
+					if t.metrics != nil {
+						t.metrics.RecordInteractiveTakeover("takeover_failed")
+					}
 					return InvestigateOutput{}, fmt.Errorf("transition autonomous session to user-driving: %w", err)
 				}
 				// ErrSessionTerminal after lease acquired: autonomous already finished,

--- a/test/unit/kubernautagent/mcp/tools/takeover_test.go
+++ b/test/unit/kubernautagent/mcp/tools/takeover_test.go
@@ -441,6 +441,26 @@ var _ = Describe("kubernaut_investigate — Dynamic Takeover (PR4, BR-INTERACTIV
 		})
 	})
 
+	Describe("UT-KA-1026-006: handleStart emits start_failed on ErrMaxSessionsReached", func() {
+		It("should emit RecordInteractiveTakeover(start_failed) on max sessions", func() {
+			metrics := &recordingToolMetrics{}
+			sessMgr.takeoverErr = mcpinternal.ErrMaxSessionsReached
+			toolWithMetrics := tools.NewInvestigateTool(sessMgr, runner, recon,
+				tools.WithAutonomousManager(autoMgr),
+				tools.WithToolMetrics(metrics),
+			)
+
+			input := tools.InvestigateInput{RRID: "rr-001", Action: tools.ActionStart}
+			_, err := toolWithMetrics.Handle(ctx, input, testUser)
+			Expect(err).To(HaveOccurred())
+
+			var mcpErr *tools.MCPError
+			Expect(errors.As(err, &mcpErr)).To(BeTrue())
+			Expect(mcpErr.Code).To(Equal("max_sessions"))
+			Expect(metrics.takeoverOutcomes).To(ContainElement("start_failed"))
+		})
+	})
+
 	Describe("UT-KA-1026-003: handleTakeover emits takeover_race_lost when Lease held", func() {
 		It("should emit RecordInteractiveTakeover(takeover_race_lost) on ErrLeaseHeld", func() {
 			metrics := &recordingToolMetrics{}

--- a/test/unit/kubernautagent/mcp/tools/takeover_test.go
+++ b/test/unit/kubernautagent/mcp/tools/takeover_test.go
@@ -122,6 +122,46 @@ func (m *takeoverSessMgr) IsDriverActive(_ string) bool {
 
 func (m *takeoverSessMgr) TouchActivity(_ string) {}
 
+// recordingToolMetrics captures metric calls for assertion.
+type recordingToolMetrics struct {
+	takeoverOutcomes   []string
+	sessionStarted     int
+	sessionEnded       int
+	leaseContentions   int
+	commandDurations   []float64
+	mu                 sync.Mutex
+}
+
+func (m *recordingToolMetrics) RecordInteractiveSessionStarted() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sessionStarted++
+}
+
+func (m *recordingToolMetrics) RecordInteractiveSessionEnded() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.sessionEnded++
+}
+
+func (m *recordingToolMetrics) RecordInteractiveCommandDuration(_, _ string, d float64) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.commandDurations = append(m.commandDurations, d)
+}
+
+func (m *recordingToolMetrics) RecordInteractiveTakeover(outcome string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.takeoverOutcomes = append(m.takeoverOutcomes, outcome)
+}
+
+func (m *recordingToolMetrics) RecordInteractiveLeaseContention() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.leaseContentions++
+}
+
 // takeoverRunner mocks tools.InvestigatorRunner for takeover tests.
 type takeoverRunner struct {
 	response string
@@ -361,6 +401,96 @@ var _ = Describe("kubernaut_investigate — Dynamic Takeover (PR4, BR-INTERACTIV
 			Expect(mcpErr.Code).To(Equal("session_active"))
 			Expect(mcpErr.Message).NotTo(BeEmpty())
 			Expect(mcpErr.Details["driver"]).To(Equal("alice@example.com"))
+		})
+	})
+
+	// --- #1026: Failure-path metric emissions (BR-MONITORING-003) ---
+
+	Describe("UT-KA-1026-001: handleStart emits start_failed when Lease held", func() {
+		It("should emit RecordInteractiveTakeover(start_failed) on ErrLeaseHeld", func() {
+			metrics := &recordingToolMetrics{}
+			sessMgr.takeoverErr = mcpinternal.ErrLeaseHeld
+			toolWithMetrics := tools.NewInvestigateTool(sessMgr, runner, recon,
+				tools.WithAutonomousManager(autoMgr),
+				tools.WithToolMetrics(metrics),
+			)
+
+			input := tools.InvestigateInput{RRID: "rr-001", Action: tools.ActionStart}
+			_, err := toolWithMetrics.Handle(ctx, input, testUser)
+			Expect(err).To(HaveOccurred())
+
+			Expect(metrics.takeoverOutcomes).To(ContainElement("start_failed"))
+			Expect(metrics.leaseContentions).To(Equal(1))
+		})
+	})
+
+	Describe("UT-KA-1026-002: handleStart emits start_failed on generic Takeover error", func() {
+		It("should emit RecordInteractiveTakeover(start_failed) on generic session error", func() {
+			metrics := &recordingToolMetrics{}
+			sessMgr.takeoverErr = errors.New("k8s API unavailable")
+			toolWithMetrics := tools.NewInvestigateTool(sessMgr, runner, recon,
+				tools.WithAutonomousManager(autoMgr),
+				tools.WithToolMetrics(metrics),
+			)
+
+			input := tools.InvestigateInput{RRID: "rr-001", Action: tools.ActionStart}
+			_, err := toolWithMetrics.Handle(ctx, input, testUser)
+			Expect(err).To(HaveOccurred())
+
+			Expect(metrics.takeoverOutcomes).To(ContainElement("start_failed"))
+		})
+	})
+
+	Describe("UT-KA-1026-003: handleTakeover emits takeover_race_lost when Lease held", func() {
+		It("should emit RecordInteractiveTakeover(takeover_race_lost) on ErrLeaseHeld", func() {
+			metrics := &recordingToolMetrics{}
+			sessMgr.takeoverErr = mcpinternal.ErrLeaseHeld
+			toolWithMetrics := tools.NewInvestigateTool(sessMgr, runner, recon,
+				tools.WithAutonomousManager(autoMgr),
+				tools.WithToolMetrics(metrics),
+			)
+
+			input := tools.InvestigateInput{RRID: "rr-001", Action: tools.ActionTakeover}
+			_, err := toolWithMetrics.Handle(ctx, input, testUser)
+			Expect(err).To(HaveOccurred())
+
+			Expect(metrics.takeoverOutcomes).To(ContainElement("takeover_race_lost"))
+			Expect(metrics.leaseContentions).To(Equal(1))
+		})
+	})
+
+	Describe("UT-KA-1026-004: handleTakeover emits takeover_failed on generic Takeover error", func() {
+		It("should emit RecordInteractiveTakeover(takeover_failed) on generic session error", func() {
+			metrics := &recordingToolMetrics{}
+			sessMgr.takeoverErr = errors.New("k8s API unavailable")
+			toolWithMetrics := tools.NewInvestigateTool(sessMgr, runner, recon,
+				tools.WithAutonomousManager(autoMgr),
+				tools.WithToolMetrics(metrics),
+			)
+
+			input := tools.InvestigateInput{RRID: "rr-001", Action: tools.ActionTakeover}
+			_, err := toolWithMetrics.Handle(ctx, input, testUser)
+			Expect(err).To(HaveOccurred())
+
+			Expect(metrics.takeoverOutcomes).To(ContainElement("takeover_failed"))
+		})
+	})
+
+	Describe("UT-KA-1026-005: handleTakeover emits takeover_failed when TransitionToUserDriving fails (non-terminal)", func() {
+		It("should emit RecordInteractiveTakeover(takeover_failed) when transition fails", func() {
+			metrics := &recordingToolMetrics{}
+			autoMgr.transitionErr = errors.New("context manager unavailable")
+			toolWithMetrics := tools.NewInvestigateTool(sessMgr, runner, recon,
+				tools.WithAutonomousManager(autoMgr),
+				tools.WithToolMetrics(metrics),
+			)
+
+			input := tools.InvestigateInput{RRID: "rr-001", Action: tools.ActionTakeover}
+			_, err := toolWithMetrics.Handle(ctx, input, testUser)
+			Expect(err).To(HaveOccurred())
+
+			Expect(metrics.takeoverOutcomes).To(ContainElement("takeover_failed"))
+			Expect(metrics.sessionStarted).To(Equal(0), "session should not be counted as started on failure")
 		})
 	})
 


### PR DESCRIPTION
## Summary

Adds failure-path observability to the interactive takeover flow and completes runbook coverage for command latency alerting.

- **Code**: 5 new `RecordInteractiveTakeover` emissions on error paths in `handleStart` and `handleTakeover`, giving operators visibility into `start_failed`, `takeover_race_lost`, and `takeover_failed` outcomes
- **Runbook Section 3**: Updated with outcome label reference table, PromQL for failure breakdown, and resolution steps per outcome
- **Runbook Section 9**: New "Command Latency High" troubleshooting section (symptoms, diagnosis, resolution, prevention)
- **Helm**: Fixed `KubernautInteractiveCommandLatencyHigh` `runbook_url` to point to new Section 9

## Changes

| File | Change |
|------|--------|
| `internal/kubernautagent/mcp/tools/investigate.go` | 5 new `RecordInteractiveTakeover` calls on error paths |
| `test/unit/kubernautagent/mcp/tools/takeover_test.go` | `recordingToolMetrics` mock + 5 new tests (UT-KA-1026-001..005) |
| `docs/operations/runbooks/interactive-mode-runbook.md` | Updated Section 3, new Section 9 |
| `charts/kubernaut/templates/kubernaut-agent/prometheusrule.yaml` | Fixed `runbook_url` for command latency alert |

## Outcome Labels

| Outcome | Meaning |
|---------|---------|
| `start_success` | `action: start` — Lease acquired, session started (existing) |
| `start_failed` | `action: start` — Lease held, max sessions, or infra error (new) |
| `takeover_success` | `action: takeover` — Lease acquired, autonomous transitioned (existing) |
| `takeover_race_lost` | `action: takeover` — another user holds the Lease (new) |
| `takeover_failed` | `action: takeover` — generic error or transition failure (new) |

## Validation

- `go build ./...` — passes
- `golangci-lint run --enable gosec cmd/... pkg/... internal/...` — 0 issues
- `go test ./test/unit/kubernautagent/mcp/tools/` — 44/44 pass (5 new + 39 existing)
- `helm unittest charts/kubernaut/ -f 'tests/prometheusrule_test.yaml'` — 7/7 pass
- `helm template --set monitoring.prometheusRule.enabled=true` — all `runbook_url` point to valid sections

## Test plan

- [x] UT-KA-1026-001: `handleStart` emits `start_failed` on `ErrLeaseHeld`
- [x] UT-KA-1026-002: `handleStart` emits `start_failed` on generic error
- [x] UT-KA-1026-003: `handleTakeover` emits `takeover_race_lost` on `ErrLeaseHeld`
- [x] UT-KA-1026-004: `handleTakeover` emits `takeover_failed` on generic error
- [x] UT-KA-1026-005: `handleTakeover` emits `takeover_failed` on `TransitionToUserDriving` non-terminal error

Closes #1026

Made with [Cursor](https://cursor.com)