### PR TITLE
fix(enrichment): exempt NotFound from HardFail for deleted resources (#1039)

### DIFF
--- a/docs/tests/1039/TEST_PLAN.md
+++ b/docs/tests/1039/TEST_PLAN.md
@@ -1,0 +1,348 @@
+# Test Plan: Soften Enrichment for Deleted Resources
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-1039-v1
+**Feature**: Exempt K8s NotFound errors from enrichment HardFail so deleted-resource scenarios proceed to workflow discovery
+**Version**: 1.0
+**Created**: 2026-05-05
+**Author**: AI Agent (supervised)
+**Status**: Approved
+**Branch**: `fix/1039`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Validate that the enrichment pipeline treats K8s `NotFound` errors as non-fatal, allowing investigations targeting deleted resources to proceed to workflow selection instead of aborting with `rca_incomplete`. Confirmed by production audit trace on OCP cluster: `ClusterServiceVersion/etcdoperator.v0.9.4` was deleted mid-investigation, causing enrichment HardFail and pipeline abort despite the LLM producing a valid RCA.
+
+### 1.2 Objectives
+
+1. **NotFound exemption**: `IsNotFoundError` correctly detects wrapped K8s NotFound errors and `HardFail` is not set for them
+2. **Retry skip**: `resolveOwnerChainWithRetry` does not retry when the initial error is NotFound
+3. **Audit trail**: `EnrichmentResult.TargetResourceDeleted` is set to `true` when the resource is deleted, and a warning is surfaced in the investigation response
+4. **Regression safety**: Existing `rca_incomplete` behavior is preserved for genuine API errors (timeout, internal server error)
+5. **E2E validation**: Full pipeline proceeds to workflow selection in a Kind cluster when the remediation target does not exist
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/kubernautagent/enrichment/... --race` |
+| Integration test pass rate | 100% | `go test ./test/integration/kubernautagent/...` |
+| E2E test pass rate | 100% | `make test-e2e-kubernautagent` |
+| Unit-testable code coverage | >=80% | `go test -coverprofile` on enricher.go, errors.go |
+| Backward compatibility | 0 regressions | Existing tests pass (IT-KA-704-001 updated) |
+
+---
+
+## 2. References
+
+### 2.1 Authority
+
+- Issue #1039: Agent: add existence validation gate for RCA remediation target
+- BR-HAPI-261 AC#7: Enrichment hard-failure triggers rca_incomplete
+- Production incident: `OperatorCSVFailed` on `etcdoperator.v0.9.4` in `demo-operator` (OCP audit 2026-05-06)
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../.cursor/rules/03-testing-strategy.mdc)
+- [Testing Guidelines](../development/business-requirements/TESTING_GUIDELINES.md)
+- Issue #704: Original HardFail implementation
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | `IsNotFoundError` false positive on non-NotFound StatusError | Genuine API errors silently bypass HardFail | Low | UT-KA-1039-007 | `errors.As` with `StatusReasonNotFound` check; explicit false-positive test |
+| R2 | Existing E2E-KA-433-ADV-016 breaks (expects rca_incomplete for NotFound) | E2E regression | High | E2E-KA-1039-001 | Replace with inverted assertions |
+| R3 | IT-KA-704-001 breaks (uses NotFound to test rca_incomplete) | Integration regression | High | IT-KA-704-001 | Change error type to InternalError |
+| R4 | Mock LLM multi-turn fails after pipeline continuation | E2E test flake | Low | E2E-KA-1039-001 | Preflight verified: ThreeStepDAG returns workflow |
+| R5 | Label detection on deleted resource causes nil panic | Runtime crash | Low | UT-KA-1039-001 | Preflight verified: DetectLabels fails gracefully |
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **IsNotFoundError helper** (`internal/kubernautagent/enrichment/errors.go`): Robust detection of wrapped K8s NotFound errors
+- **HardFail exemption** (`internal/kubernautagent/enrichment/enricher.go`): NotFound excluded from HardFail alongside NoMatchError
+- **TargetResourceDeleted field** (`internal/kubernautagent/enrichment/enricher.go`): New boolean on EnrichmentResult
+- **Retry skip** (`internal/kubernautagent/enrichment/enricher.go`): NotFound exits retry loop immediately
+- **Warning surface** (`internal/kubernautagent/investigator/investigator.go`): TargetResourceDeleted produces a warning in InvestigationResult
+- **E2E pipeline** (`test/e2e/kubernautagent/`): Full investigation with deleted resource proceeds to workflow selection
+
+### 4.2 Features Not to be Tested
+
+- **Workflow catalog matching for deleted resources**: Catalog query uses signal/RCA fields, not enrichment — separate concern
+- **Spec hash calculation**: Empty spec hash for deleted resources is correct and handled by existing code
+- **DataStorage bad request on empty spec_hash**: Secondary failure, non-blocking, separate issue
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Use `errors.As` with `*apierrors.StatusError` instead of `apierrors.IsNotFound` | Handles wrapped errors from `K8sAdapter.GetOwnerChain` which uses `fmt.Errorf("k8s adapter: ... %w")` |
+| Add `TargetResourceDeleted` to `EnrichmentResult` not API schema | Internal field for audit/observability; surfaced via existing `Warnings` array |
+| Update IT-KA-704-001 error type rather than delete it | Preserves rca_incomplete regression coverage for genuine API errors |
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+- **Unit**: >=80% of `enricher.go` changes + `errors.go` (new)
+- **Integration**: >=80% of enrichment I/O paths (envtest)
+- **E2E**: 2 scenarios validating full pipeline behavior in Kind cluster
+
+### 5.2 Pass/Fail Criteria
+
+**PASS**: All 11 tests pass, existing suites show 0 regressions, per-tier coverage >=80%
+
+**FAIL**: Any P0 test fails, existing IT-KA-704-001 or E2E suites regress
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `internal/kubernautagent/enrichment/errors.go` (new) | `IsNotFoundError` | ~15 |
+| `internal/kubernautagent/enrichment/enricher.go` | `Enrich` (HardFail condition), `resolveOwnerChainWithRetry` (early exit) | ~10 changed |
+
+### 6.2 Integration-Testable Code
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `internal/kubernautagent/enrichment/enricher.go` | `Enrich` with real K8s adapter (envtest) | ~50 |
+| `internal/kubernautagent/investigator/investigator.go` | `Investigate` warning injection | ~5 changed |
+
+---
+
+## 7. BR Coverage Matrix
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-HAPI-261 | NotFound exempt from HardFail | P0 | Unit | UT-KA-1039-001 | Pending |
+| BR-HAPI-261 | TargetResourceDeleted set on NotFound | P0 | Unit | UT-KA-1039-002 | Pending |
+| BR-HAPI-261 | NotFound skips retries | P0 | Unit | UT-KA-1039-003 | Pending |
+| BR-HAPI-261 | Other errors still HardFail | P0 | Unit | UT-KA-1039-004 | Pending |
+| BR-HAPI-261 | NoMatchError still exempt | P1 | Unit | UT-KA-1039-005 | Pending |
+| BR-HAPI-261 | IsNotFoundError detects wrapped error | P0 | Unit | UT-KA-1039-006 | Pending |
+| BR-HAPI-261 | IsNotFoundError rejects non-NotFound | P0 | Unit | UT-KA-1039-007 | Pending |
+| BR-HAPI-261 | Enrichment pipeline continues on NotFound | P0 | Integration | IT-KA-1039-001 | Pending |
+| BR-HAPI-261 | Deleted resource proceeds to workflow selection | P0 | E2E | E2E-KA-1039-001 | Pending |
+| BR-HAPI-261 | Deleted resource warning in response | P1 | E2E | E2E-KA-1039-002 | Pending |
+
+---
+
+## 8. Test Scenarios
+
+### Tier 1: Unit Tests
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| UT-KA-1039-001 | NotFound error -> HardFail=false, pipeline does not abort | Pending |
+| UT-KA-1039-002 | NotFound error -> TargetResourceDeleted=true for audit trail | Pending |
+| UT-KA-1039-003 | NotFound error -> no retries attempted (single call only) | Pending |
+| UT-KA-1039-004 | InternalError -> HardFail=true, existing behavior preserved | Pending |
+| UT-KA-1039-005 | NoMatchError -> HardFail=false, existing behavior preserved | Pending |
+| UT-KA-1039-006 | IsNotFoundError detects NotFound wrapped by K8sAdapter | Pending |
+| UT-KA-1039-007 | IsNotFoundError returns false for InternalError, Forbidden | Pending |
+
+### Tier 2: Integration Tests
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| IT-KA-1039-001 | Enrichment with deleted resource (envtest) completes with TargetResourceDeleted=true | Pending |
+
+### Tier 3: E2E Tests
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| E2E-KA-1039-001 | Deleted resource investigation proceeds to workflow selection (full pipeline) | Pending |
+| E2E-KA-1039-002 | Deleted resource warning surfaced in investigation response | Pending |
+
+---
+
+## 9. Test Cases
+
+### UT-KA-1039-001: NotFound does not trigger HardFail
+
+**BR**: BR-HAPI-261
+**Priority**: P0
+**File**: `test/unit/kubernautagent/enrichment/enricher_not_found_test.go`
+
+**Test Steps**:
+1. **Given**: fakeK8sClient returns `apierrors.NewNotFound(schema.GroupResource{Resource: "pods"}, "deleted-pod")`; enricher configured with MaxRetries=3
+2. **When**: `Enrich(ctx, "Pod", "deleted-pod", "production", "", "inc-001")` is called
+3. **Then**: `result.HardFail` is `false`; `result.OwnerChainError` is not nil
+
+### UT-KA-1039-002: NotFound sets TargetResourceDeleted
+
+**BR**: BR-HAPI-261
+**Priority**: P0
+**File**: `test/unit/kubernautagent/enrichment/enricher_not_found_test.go`
+
+**Test Steps**:
+1. **Given**: fakeK8sClient returns NotFound error; enricher with MaxRetries=3
+2. **When**: `Enrich` is called
+3. **Then**: `result.TargetResourceDeleted` is `true`
+
+### UT-KA-1039-003: NotFound skips retries
+
+**BR**: BR-HAPI-261
+**Priority**: P0
+**File**: `test/unit/kubernautagent/enrichment/enricher_not_found_test.go`
+
+**Test Steps**:
+1. **Given**: countingK8sClient returns NotFound on every call; enricher with MaxRetries=3
+2. **When**: `Enrich` is called
+3. **Then**: `k8s.CallCount()` is `1` (no retries)
+
+### UT-KA-1039-004: Non-NotFound errors still HardFail
+
+**BR**: BR-HAPI-261
+**Priority**: P0
+**File**: `test/unit/kubernautagent/enrichment/enricher_not_found_test.go`
+
+**Test Steps**:
+1. **Given**: fakeK8sClient returns `apierrors.NewInternalError(fmt.Errorf("etcd timeout"))`; enricher with MaxRetries=3
+2. **When**: `Enrich` is called
+3. **Then**: `result.HardFail` is `true`; `result.TargetResourceDeleted` is `false`
+
+### UT-KA-1039-005: NoMatchError still exempt from HardFail
+
+**BR**: BR-HAPI-261
+**Priority**: P1
+**File**: `test/unit/kubernautagent/enrichment/enricher_not_found_test.go`
+
+**Test Steps**:
+1. **Given**: fakeK8sClient returns `meta.NoResourceMatchError`; enricher with MaxRetries=3
+2. **When**: `Enrich` is called
+3. **Then**: `result.HardFail` is `false`; `result.TargetResourceDeleted` is `false`
+
+### UT-KA-1039-006: IsNotFoundError detects wrapped NotFound
+
+**BR**: BR-HAPI-261
+**Priority**: P0
+**File**: `test/unit/kubernautagent/enrichment/enricher_not_found_test.go`
+
+**Test Steps**:
+1. **Given**: `fmt.Errorf("k8s adapter: get Pod/deleted-pod in production: %w", apierrors.NewNotFound(...))`
+2. **When**: `IsNotFoundError(err)` is called
+3. **Then**: returns `true`
+
+### UT-KA-1039-007: IsNotFoundError rejects non-NotFound
+
+**BR**: BR-HAPI-261
+**Priority**: P0
+**File**: `test/unit/kubernautagent/enrichment/enricher_not_found_test.go`
+
+**Test Steps**:
+1. **Given**: `apierrors.NewForbidden(...)`, `apierrors.NewInternalError(...)`, `fmt.Errorf("generic error")`
+2. **When**: `IsNotFoundError(err)` is called for each
+3. **Then**: returns `false` for all
+
+### IT-KA-1039-001: Enrichment pipeline continues on deleted resource
+
+**BR**: BR-HAPI-261
+**Priority**: P0
+**File**: `test/integration/kubernautagent/enrichment/enrichment_real_ds_test.go`
+
+**Test Steps**:
+1. **Given**: envtest cluster with enrichment fixtures; target resource `nonexistent-deploy` does NOT exist
+2. **When**: `enricher.Enrich(ctx, "Deployment", "nonexistent-deploy", "it-enrichment", "", "it-1039")` is called
+3. **Then**: `result.TargetResourceDeleted` is `true`; `result.HardFail` is `false`; `result.OwnerChain` is empty
+
+### E2E-KA-1039-001: Deleted resource proceeds to workflow selection
+
+**BR**: BR-HAPI-261
+**Priority**: P0
+**File**: `test/e2e/kubernautagent/adversarial_parity_e2e_test.go`
+
+**Test Steps**:
+1. **Given**: Kind cluster with mock LLM; `unreachable-pod` does NOT exist in `production` namespace
+2. **When**: `sessionClient.Investigate(ctx, buildRequest("1039-001", "mock_rca_incomplete", "critical"))`
+3. **Then**: Investigation succeeds; `NeedsHumanReview` is NOT true for `rca_incomplete`; `SelectedWorkflow.Set` is true with `workflow_id`; `Confidence` >= 0.5
+
+### E2E-KA-1039-002: Deleted resource warning in response
+
+**BR**: BR-HAPI-261
+**Priority**: P1
+**File**: `test/e2e/kubernautagent/adversarial_parity_e2e_test.go`
+
+**Test Steps**:
+1. **Given**: Same as E2E-KA-1039-001
+2. **When**: Investigation completes
+3. **Then**: `Warnings` contains at least one entry with "deleted" substring
+
+---
+
+## 10. Environmental Needs
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Mocks**: `fakeK8sClient`, `fakeDataStorageClient`, `countingK8sClient`, `recordingAuditStore` (existing test helpers)
+- **Location**: `test/unit/kubernautagent/enrichment/`
+
+### 10.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Infrastructure**: envtest + real DataStorage (PostgreSQL, Redis)
+- **Location**: `test/integration/kubernautagent/enrichment/`
+
+### 10.3 E2E Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Infrastructure**: Kind cluster, mock LLM, DataStorage, seeded workflow catalog
+- **Location**: `test/e2e/kubernautagent/`
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Execution Order
+
+1. **Phase 1 (TDD RED)**: Write all failing tests (unit + integration + E2E + IT-KA-704-001 update)
+2. **Phase 2 (TDD GREEN)**: Implement `IsNotFoundError`, HardFail exemption, `TargetResourceDeleted`, retry skip, warning surface
+3. **Phase 3 (TDD REFACTOR)**: 100-go-mistakes review, 9-category checkpoint audit
+
+---
+
+## 12. Existing Tests Requiring Updates
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|-------------------|-------------------|-----------------|--------|
+| E2E-KA-433-ADV-016 (`adversarial_parity_e2e_test.go:311`) | `NeedsHumanReview=true`, `HumanReviewReason="rca_incomplete"` | Replace with E2E-KA-1039-001: `NeedsHumanReview` not rca_incomplete, `SelectedWorkflow.Set=true` | NotFound no longer triggers HardFail |
+| IT-KA-704-001 (`investigator_test.go:738`) | `apierrors.NewNotFound(...)` -> `rca_incomplete` | Change error to `apierrors.NewInternalError(...)` | NotFound is now exempt; test needs non-exempt error to verify rca_incomplete |
+
+---
+
+## 13. Due Diligence Findings
+
+| ID | Finding | Severity | Resolution |
+|----|---------|----------|------------|
+| DD-1 | Production error wraps NotFound via `fmt.Errorf("k8s adapter: get %s/%s in %s: %w")` | P0 | `errors.As` with `*apierrors.StatusError` handles wrapping; UT-KA-1039-006 validates |
+| DD-2 | `GetSpecHash` also fails for deleted resources (empty spec_hash) | Info | Acceptable: empty spec hash → no remediation history match. Not a regression. |
+| DD-3 | `ds adapter: bad request` on empty spec_hash | Info | Secondary failure in DataStorage adapter, non-blocking. Separate issue. |
+| DD-4 | `allLabelDetectionsFailed` gracefully handles deleted resource enrichment | Info | Preflight verified: all categories marked failed → initial enrichment preserved |
+| DD-5 | IT-KA-704-001 uses NotFound to test rca_incomplete | P0 | Must update error type to InternalError to preserve rca_incomplete coverage |
+| DD-6 | Mock LLM `rcaIncompleteConfig` has WorkflowID set, multi-turn works after HardFail removal | Info | Preflight verified: ThreeStepDAG returns `submit_result_with_workflow` |
+
+---
+
+## 14. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-05-05 | Initial test plan with E2E scenarios, production trace validation |

--- a/internal/kubernautagent/enrichment/enricher.go
+++ b/internal/kubernautagent/enrichment/enricher.go
@@ -160,10 +160,14 @@ type EnrichmentResult struct {
 	// exhaustion (all errors retried, matching HAPI v1.2.1). The
 	// investigator uses this to trigger rca_incomplete (BR-HAPI-261
 	// AC#7, #704). Only set when RetryConfig has MaxRetries > 0.
-	HardFail           bool                          `json:"-"`
-	DetectedLabels     *DetectedLabels               `json:"detected_labels,omitempty"`
-	QuotaDetails       map[string]QuotaResourceUsage `json:"quota_details,omitempty"`
-	RemediationHistory *RemediationHistoryResult     `json:"remediation_history,omitempty"`
+	// Issue #1039: NotFound errors are exempt (deleted resources).
+	HardFail bool `json:"-"`
+	// TargetResourceDeleted is true when the remediation target no longer
+	// exists in the cluster (K8s NotFound). Issue #1039.
+	TargetResourceDeleted bool                          `json:"-"`
+	DetectedLabels        *DetectedLabels               `json:"detected_labels,omitempty"`
+	QuotaDetails          map[string]QuotaResourceUsage `json:"quota_details,omitempty"`
+	RemediationHistory    *RemediationHistoryResult     `json:"remediation_history,omitempty"`
 }
 
 // Enricher resolves owner chain, labels, and remediation history.
@@ -209,7 +213,7 @@ func (e *Enricher) resolveOwnerChainWithRetry(ctx context.Context, kind, name, n
 		return chain, nil
 	}
 
-	if e.retryConfig.MaxRetries == 0 {
+	if e.retryConfig.MaxRetries == 0 || IsNotFoundError(err) || IsNoMatchError(err) {
 		return nil, err
 	}
 
@@ -288,11 +292,14 @@ func (e *Enricher) Enrich(ctx context.Context, kind, name, namespace, apiVersion
 	chain, ownerErr := e.resolveOwnerChainWithRetry(ctx, kind, name, namespace, apiVersion)
 	if ownerErr != nil {
 		result.OwnerChainError = ownerErr
-		if e.retryConfig.MaxRetries > 0 && !IsNoMatchError(ownerErr) {
+		if IsNotFoundError(ownerErr) {
+			result.TargetResourceDeleted = true
+		} else if e.retryConfig.MaxRetries > 0 && !IsNoMatchError(ownerErr) {
 			result.HardFail = true
 		}
 		e.logger.Error(ownerErr, "enrichment: owner chain resolution failed",
 			"resource", namespace+"/"+kind+"/"+name,
+			"target_resource_deleted", result.TargetResourceDeleted,
 		)
 	} else {
 		result.OwnerChain = chain

--- a/internal/kubernautagent/enrichment/errors.go
+++ b/internal/kubernautagent/enrichment/errors.go
@@ -1,0 +1,38 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package enrichment
+
+import (
+	"errors"
+
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// IsNotFoundError returns true when err (or any error in its chain) is a
+// Kubernetes NotFound status error. Uses errors.As to handle wrapping by
+// K8sAdapter (fmt.Errorf("k8s adapter: get %s/%s in %s: %w", ...)).
+func IsNotFoundError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var statusErr *apierrors.StatusError
+	if errors.As(err, &statusErr) {
+		return statusErr.Status().Reason == metav1.StatusReasonNotFound
+	}
+	return false
+}

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -29,11 +29,11 @@ import (
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
-	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/registry"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/sanitization"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/summarizer"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 )
 
 const maxSelfCorrectionAttempts = 3
@@ -259,6 +259,12 @@ func (inv *Investigator) Investigate(ctx context.Context, signal katypes.SignalC
 			injectTargetResourceParameters(rcaResult)
 			inv.emitResponseComplete(ctx, rcaResult, tokens, correlationID)
 			return rcaResult, nil
+		}
+
+		if reEnriched != nil && reEnriched.TargetResourceDeleted {
+			rcaResult.Warnings = append(rcaResult.Warnings,
+				fmt.Sprintf("target resource %s/%s in %s was deleted; enrichment data is sparse",
+					postRCAKind, postRCAName, postRCANS))
 		}
 
 		if reEnriched != nil && !allLabelDetectionsFailed(reEnriched.DetectedLabels) {
@@ -916,6 +922,3 @@ func (inv *Investigator) runLLMLoop(ctx context.Context, messages []llm.Message,
 
 	return &ExhaustedResult{Reason: "max turns exhausted"}, nil
 }
-
-
-

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -263,8 +263,7 @@ func (inv *Investigator) Investigate(ctx context.Context, signal katypes.SignalC
 
 		if reEnriched != nil && reEnriched.TargetResourceDeleted {
 			rcaResult.Warnings = append(rcaResult.Warnings,
-				fmt.Sprintf("target resource %s/%s in %s was deleted; enrichment data is sparse",
-					postRCAKind, postRCAName, postRCANS))
+				deletedResourceWarning(postRCAKind, postRCAName, postRCANS))
 		}
 
 		if reEnriched != nil && !allLabelDetectionsFailed(reEnriched.DetectedLabels) {
@@ -282,8 +281,7 @@ func (inv *Investigator) Investigate(ctx context.Context, signal katypes.SignalC
 		workflowSignal.Namespace = postRCANS
 	} else if enrichData != nil && enrichData.TargetResourceDeleted {
 		rcaResult.Warnings = append(rcaResult.Warnings,
-			fmt.Sprintf("target resource %s/%s in %s was deleted; enrichment data is sparse",
-				signalKind, signalName, signalNS))
+			deletedResourceWarning(signalKind, signalName, signalNS))
 	}
 
 	inv.pipeline.AnomalyDetector.Reset()
@@ -313,6 +311,10 @@ func (inv *Investigator) Investigate(ctx context.Context, signal katypes.SignalC
 	injectTargetResourceParameters(workflowResult)
 	inv.emitResponseComplete(ctx, workflowResult, tokens, correlationID)
 	return workflowResult, nil
+}
+
+func deletedResourceWarning(kind, name, ns string) string {
+	return fmt.Sprintf("target resource %s/%s in %s was deleted; enrichment data is sparse", kind, name, ns)
 }
 
 // backfillSeverity ensures InvestigationResult.Severity is never empty.

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -301,6 +301,9 @@ func (inv *Investigator) Investigate(ctx context.Context, signal katypes.SignalC
 	if workflowResult.SignalName == "" && rcaResult.SignalName != "" {
 		workflowResult.SignalName = rcaResult.SignalName
 	}
+	if len(rcaResult.Warnings) > 0 {
+		workflowResult.Warnings = append(rcaResult.Warnings, workflowResult.Warnings...)
+	}
 
 	MergePhase1Fallbacks(workflowResult, p1Ctx)
 

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -280,6 +280,10 @@ func (inv *Investigator) Investigate(ctx context.Context, signal katypes.SignalC
 		workflowSignal.ResourceKind = postRCAKind
 		workflowSignal.ResourceName = postRCAName
 		workflowSignal.Namespace = postRCANS
+	} else if enrichData != nil && enrichData.TargetResourceDeleted {
+		rcaResult.Warnings = append(rcaResult.Warnings,
+			fmt.Sprintf("target resource %s/%s in %s was deleted; enrichment data is sparse",
+				signalKind, signalName, signalNS))
 	}
 
 	inv.pipeline.AnomalyDetector.Reset()

--- a/test/e2e/kubernautagent/adversarial_parity_e2e_test.go
+++ b/test/e2e/kubernautagent/adversarial_parity_e2e_test.go
@@ -305,24 +305,65 @@ var _ = Describe("E2E-KA-433-ADV: Adversarial Parity Tests", Label("e2e", "ka", 
 			), "no_workflow_found should produce a valid HR reason enum")
 		})
 
-		// BR-HAPI-261 AC#7 / #704: enrichment-driven rca_incomplete.
-		// With HAPI-compliant defaults (MaxRetries=3) and E2E fixtures,
-		// unreachable-pod does NOT exist → NotFound → HardFail → rca_incomplete.
-		It("E2E-KA-433-ADV-016: rca_incomplete triggers needs_human_review", func() {
-			req := buildRequest("adv-016", "mock_rca_incomplete", "critical")
+		// Issue #1039: Deleted resource proceeds to workflow selection.
+		// unreachable-pod does NOT exist → NotFound → enrichment softened
+		// (no HardFail) → pipeline continues to workflow selection →
+		// mock LLM returns generic-restart-v1 workflow.
+		// Replaces E2E-KA-433-ADV-016 which asserted rca_incomplete.
+		It("E2E-KA-1039-001: deleted resource proceeds to workflow selection", func() {
+			req := buildRequest("1039-001", "mock_rca_incomplete", "critical")
 			result, err := sessionClient.Investigate(ctx, req)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 
+			// Pipeline must NOT abort with rca_incomplete.
 			needsHR, hasHR := result.NeedsHumanReview.Get()
-			Expect(hasHR).To(BeTrue(), "M1: needs_human_review must always be set")
-			Expect(needsHR).To(BeTrue(),
-				"E2E-KA-433-ADV-016: rca_incomplete must trigger needs_human_review=true")
+			if hasHR && needsHR {
+				hrReason, hasReason := result.HumanReviewReason.Get()
+				if hasReason {
+					Expect(string(hrReason)).NotTo(Equal("rca_incomplete"),
+						"E2E-KA-1039-001: deleted resource must NOT trigger rca_incomplete")
+				}
+			}
 
-			hrReason, hasReason := result.HumanReviewReason.Get()
-			Expect(hasReason).To(BeTrue(), "M2: human_review_reason must be set when needs_human_review=true")
-		Expect(hrReason).To(BeEquivalentTo("rca_incomplete"),
-			"E2E-KA-433-ADV-016: reason must be rca_incomplete (enrichment HardFail)")
+			// Workflow selection must have run and produced a result.
+			sw, hasSW := result.SelectedWorkflow.Get()
+			Expect(hasSW).To(BeTrue(),
+				"E2E-KA-1039-001: selected_workflow must be present (pipeline continued)")
+			Expect(sw).To(HaveKey("workflow_id"),
+				"E2E-KA-1039-001: selected_workflow must contain workflow_id")
+
+			Expect(result.Confidence).To(BeNumerically(">=", 0.5),
+				"E2E-KA-1039-001: confidence must reflect LLM assessment (mock returns 0.88)")
+			Expect(result.Analysis).NotTo(BeEmpty(),
+				"E2E-KA-1039-001: analysis must be present (RCA phase completed)")
+		})
+
+		// Issue #1039: Deleted resource warning surfaced in response.
+		// Verifies observability: when enrichment detects a deleted target,
+		// a warning is added to the investigation response.
+		It("E2E-KA-1039-002: deleted resource warning in response", func() {
+			req := buildRequest("1039-002", "mock_rca_incomplete", "critical")
+			result, err := sessionClient.Investigate(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			hasDeletedWarning := false
+			for _, w := range result.Warnings {
+				if strings.Contains(w, "deleted") {
+					hasDeletedWarning = true
+					break
+				}
+			}
+			Expect(hasDeletedWarning).To(BeTrue(),
+				"E2E-KA-1039-002: warnings must contain a 'deleted' resource notice")
+
+			// Investigation must still succeed despite the warning.
+			sw, hasSW := result.SelectedWorkflow.Get()
+			Expect(hasSW).To(BeTrue(),
+				"E2E-KA-1039-002: investigation must succeed with workflow selected")
+			Expect(sw).To(HaveKey("workflow_id"),
+				"E2E-KA-1039-002: selected_workflow must contain workflow_id")
 		})
 	})
 })

--- a/test/integration/kubernautagent/investigator/investigator_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_test.go
@@ -36,7 +36,6 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/registry"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // staticCatalogFetcher returns a pre-built validator for tests that need
@@ -732,11 +731,13 @@ var _ = Describe("TP-693: Workflow signal override after re-enrichment", func() 
 
 	Describe("IT-KA-704-001: Owner chain failure triggers rca_incomplete", func() {
 		It("should set needs_human_review=true with rca_incomplete when GetOwnerChain fails", func() {
-			notFoundErr := apierrors.NewNotFound(
-				schema.GroupResource{Resource: "deployments"}, "target-deploy")
+			// Issue #1039: NotFound is now exempt from HardFail (deleted resources
+			// proceed to workflow selection). Use InternalError to test rca_incomplete
+			// for genuine API failures that still trigger HardFail.
+			apiErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
 			k8s := &fakeK8sClient{
 				ownerChain: nil,
-				err:        notFoundErr,
+				err:        apiErr,
 			}
 			ds := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
 			enricher := enrichment.NewEnricher(k8s, ds, auditStore, invLogger).

--- a/test/unit/kubernautagent/enrichment/enricher_not_found_test.go
+++ b/test/unit/kubernautagent/enrichment/enricher_not_found_test.go
@@ -1,0 +1,204 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package enrichment_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var _ = Describe("Enricher NotFound Handling — Issue #1039", func() {
+	var (
+		logger     = logr.Discard()
+		auditStore *recordingAuditStore
+		ds         *fakeDataStorageClient
+		ctx        context.Context
+	)
+
+	BeforeEach(func() {
+		auditStore = &recordingAuditStore{}
+		ds = &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
+		ctx = context.Background()
+	})
+
+	retryConfig := enrichment.RetryConfig{
+		MaxRetries:  3,
+		BaseBackoff: 1 * time.Millisecond,
+	}
+
+	Describe("UT-KA-1039-001: NotFound does not trigger HardFail", func() {
+		It("should set HardFail=false when GetOwnerChain returns NotFound", func() {
+			notFoundErr := apierrors.NewNotFound(
+				schema.GroupResource{Resource: "pods"}, "deleted-pod")
+			k8s := &fakeK8sClient{err: notFoundErr}
+
+			e := enrichment.NewEnricher(k8s, ds, auditStore, logger).
+				WithRetryConfig(retryConfig)
+
+			result, err := e.Enrich(ctx, "Pod", "deleted-pod", "production", "", "inc-1039-001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(result.HardFail).To(BeFalse(),
+				"UT-KA-1039-001: NotFound must NOT trigger HardFail")
+			Expect(result.OwnerChainError).NotTo(BeNil(),
+				"UT-KA-1039-001: OwnerChainError must still be recorded for observability")
+		})
+	})
+
+	Describe("UT-KA-1039-002: NotFound sets TargetResourceDeleted", func() {
+		It("should set TargetResourceDeleted=true when resource is not found", func() {
+			notFoundErr := apierrors.NewNotFound(
+				schema.GroupResource{Resource: "clusterserviceversions"}, "etcdoperator.v0.9.4")
+			k8s := &fakeK8sClient{err: notFoundErr}
+
+			e := enrichment.NewEnricher(k8s, ds, auditStore, logger).
+				WithRetryConfig(retryConfig)
+
+			result, err := e.Enrich(ctx, "ClusterServiceVersion", "etcdoperator.v0.9.4", "demo-operator", "", "inc-1039-002")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(result.TargetResourceDeleted).To(BeTrue(),
+				"UT-KA-1039-002: TargetResourceDeleted must be true when resource is NotFound")
+		})
+	})
+
+	Describe("UT-KA-1039-003: NotFound skips retries", func() {
+		It("should make exactly 1 call (no retries) when error is NotFound", func() {
+			notFoundErr := apierrors.NewNotFound(
+				schema.GroupResource{Resource: "deployments"}, "deleted-deploy")
+			k8s := &countingK8sClient{
+				errSeq: []error{notFoundErr, notFoundErr, notFoundErr, notFoundErr},
+			}
+
+			e := enrichment.NewEnricher(k8s, ds, auditStore, logger).
+				WithRetryConfig(retryConfig)
+
+			result, err := e.Enrich(ctx, "Deployment", "deleted-deploy", "production", "", "inc-1039-003")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(k8s.CallCount()).To(Equal(1),
+				"UT-KA-1039-003: NotFound must skip retries — only 1 call expected")
+		})
+	})
+
+	Describe("UT-KA-1039-004: Non-NotFound errors still trigger HardFail", func() {
+		It("should set HardFail=true for InternalError (existing behavior)", func() {
+			internalErr := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
+			k8s := &countingK8sClient{
+				errSeq: []error{internalErr, internalErr, internalErr, internalErr},
+			}
+
+			e := enrichment.NewEnricher(k8s, ds, auditStore, logger).
+				WithRetryConfig(retryConfig)
+
+			result, err := e.Enrich(ctx, "Pod", "failing-pod", "production", "", "inc-1039-004")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(result.HardFail).To(BeTrue(),
+				"UT-KA-1039-004: InternalError must still trigger HardFail")
+			Expect(result.TargetResourceDeleted).To(BeFalse(),
+				"UT-KA-1039-004: TargetResourceDeleted must be false for non-NotFound errors")
+		})
+	})
+
+	Describe("UT-KA-1039-005: NoMatchError still exempt from HardFail", func() {
+		It("should set HardFail=false for NoMatchError (existing behavior preserved)", func() {
+			noMatchErr := &meta.NoResourceMatchError{
+				PartialResource: schema.GroupVersionResource{
+					Group: "custom.example.com", Version: "v1", Resource: "widgets",
+				},
+			}
+			k8s := &fakeK8sClient{err: noMatchErr}
+
+			e := enrichment.NewEnricher(k8s, ds, auditStore, logger).
+				WithRetryConfig(retryConfig)
+
+			result, err := e.Enrich(ctx, "Widget", "test-widget", "default", "", "inc-1039-005")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(result.HardFail).To(BeFalse(),
+				"UT-KA-1039-005: NoMatchError must NOT trigger HardFail (existing behavior)")
+			Expect(result.TargetResourceDeleted).To(BeFalse(),
+				"UT-KA-1039-005: TargetResourceDeleted must be false for NoMatchError")
+		})
+	})
+
+	Describe("UT-KA-1039-006: IsNotFoundError detects wrapped NotFound", func() {
+		It("should return true for NotFound wrapped by K8sAdapter", func() {
+			inner := apierrors.NewNotFound(
+				schema.GroupResource{Resource: "clusterserviceversions"}, "etcdoperator.v0.9.4")
+			wrapped := fmt.Errorf("k8s adapter: get ClusterServiceVersion/etcdoperator.v0.9.4 in demo-operator: %w", inner)
+
+			Expect(enrichment.IsNotFoundError(wrapped)).To(BeTrue(),
+				"UT-KA-1039-006: must detect NotFound through fmt.Errorf wrapping")
+		})
+
+		It("should return true for bare NotFound (unwrapped)", func() {
+			bare := apierrors.NewNotFound(
+				schema.GroupResource{Resource: "pods"}, "deleted-pod")
+
+			Expect(enrichment.IsNotFoundError(bare)).To(BeTrue(),
+				"UT-KA-1039-006: must detect bare NotFound")
+		})
+	})
+
+	Describe("UT-KA-1039-007: IsNotFoundError rejects non-NotFound errors", func() {
+		It("should return false for Forbidden error", func() {
+			forbidden := apierrors.NewForbidden(
+				schema.GroupResource{Resource: "secrets"}, "my-secret",
+				fmt.Errorf("RBAC denied"))
+
+			Expect(enrichment.IsNotFoundError(forbidden)).To(BeFalse(),
+				"UT-KA-1039-007: Forbidden must not be detected as NotFound")
+		})
+
+		It("should return false for InternalError", func() {
+			internal := apierrors.NewInternalError(fmt.Errorf("etcd timeout"))
+
+			Expect(enrichment.IsNotFoundError(internal)).To(BeFalse(),
+				"UT-KA-1039-007: InternalError must not be detected as NotFound")
+		})
+
+		It("should return false for generic (non-API) error", func() {
+			generic := fmt.Errorf("network unreachable")
+
+			Expect(enrichment.IsNotFoundError(generic)).To(BeFalse(),
+				"UT-KA-1039-007: generic error must not be detected as NotFound")
+		})
+
+		It("should return false for nil error", func() {
+			Expect(enrichment.IsNotFoundError(nil)).To(BeFalse(),
+				"UT-KA-1039-007: nil must not be detected as NotFound")
+		})
+	})
+})

--- a/test/unit/kubernautagent/enrichment/enricher_not_found_test.go
+++ b/test/unit/kubernautagent/enrichment/enricher_not_found_test.go
@@ -60,7 +60,7 @@ var _ = Describe("Enricher NotFound Handling — Issue #1039", func() {
 			e := enrichment.NewEnricher(k8s, ds, auditStore, logger).
 				WithRetryConfig(retryConfig)
 
-			result, err := e.Enrich(ctx, "Pod", "deleted-pod", "production", "", "inc-1039-001")
+			result, err := e.Enrich(ctx, "Pod", "deleted-pod", "production", "", "", "inc-1039-001")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 
@@ -80,7 +80,7 @@ var _ = Describe("Enricher NotFound Handling — Issue #1039", func() {
 			e := enrichment.NewEnricher(k8s, ds, auditStore, logger).
 				WithRetryConfig(retryConfig)
 
-			result, err := e.Enrich(ctx, "ClusterServiceVersion", "etcdoperator.v0.9.4", "demo-operator", "", "inc-1039-002")
+			result, err := e.Enrich(ctx, "ClusterServiceVersion", "etcdoperator.v0.9.4", "demo-operator", "", "", "inc-1039-002")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 
@@ -100,7 +100,7 @@ var _ = Describe("Enricher NotFound Handling — Issue #1039", func() {
 			e := enrichment.NewEnricher(k8s, ds, auditStore, logger).
 				WithRetryConfig(retryConfig)
 
-			result, err := e.Enrich(ctx, "Deployment", "deleted-deploy", "production", "", "inc-1039-003")
+			result, err := e.Enrich(ctx, "Deployment", "deleted-deploy", "production", "", "", "inc-1039-003")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 
@@ -119,7 +119,7 @@ var _ = Describe("Enricher NotFound Handling — Issue #1039", func() {
 			e := enrichment.NewEnricher(k8s, ds, auditStore, logger).
 				WithRetryConfig(retryConfig)
 
-			result, err := e.Enrich(ctx, "Pod", "failing-pod", "production", "", "inc-1039-004")
+			result, err := e.Enrich(ctx, "Pod", "failing-pod", "production", "", "", "inc-1039-004")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 
@@ -142,7 +142,7 @@ var _ = Describe("Enricher NotFound Handling — Issue #1039", func() {
 			e := enrichment.NewEnricher(k8s, ds, auditStore, logger).
 				WithRetryConfig(retryConfig)
 
-			result, err := e.Enrich(ctx, "Widget", "test-widget", "default", "", "inc-1039-005")
+			result, err := e.Enrich(ctx, "Widget", "test-widget", "default", "", "", "inc-1039-005")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 

--- a/test/unit/kubernautagent/enrichment/enricher_retry_test.go
+++ b/test/unit/kubernautagent/enrichment/enricher_retry_test.go
@@ -135,8 +135,8 @@ var _ = Describe("Enricher Retry Infrastructure — BR-HAPI-261/264 #704", func(
 		})
 	})
 
-	Describe("UT-704-E-003: NotFound retried and HardFail after exhaustion (HAPI-aligned)", func() {
-		It("should retry NotFound 3 times and set HardFail=true after exhaustion", func() {
+	Describe("UT-704-E-003: NotFound skips retries and does not HardFail (#1039)", func() {
+		It("should make 1 call (no retries) and set HardFail=false for NotFound", func() {
 			notFoundErr := apierrors.NewNotFound(
 				schema.GroupResource{Resource: "pods"}, "test-pod")
 			k8s := &countingK8sClient{
@@ -152,12 +152,14 @@ var _ = Describe("Enricher Retry Infrastructure — BR-HAPI-261/264 #704", func(
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 
-			Expect(k8s.CallCount()).To(Equal(4),
-				"UT-704-E-003: HAPI retries all errors — initial + 3 retries = 4 calls")
+			Expect(k8s.CallCount()).To(Equal(1),
+				"UT-704-E-003: NotFound skips retries — only 1 call (#1039)")
 			Expect(result.OwnerChainError).NotTo(BeNil(),
-				"UT-704-E-003: OwnerChainError must be set after retry exhaustion")
-			Expect(result.HardFail).To(BeTrue(),
-				"UT-704-E-003: HardFail must be true after retry exhaustion")
+				"UT-704-E-003: OwnerChainError must be set for observability")
+			Expect(result.HardFail).To(BeFalse(),
+				"UT-704-E-003: HardFail must be false for NotFound — deleted resource proceeds (#1039)")
+			Expect(result.TargetResourceDeleted).To(BeTrue(),
+				"UT-704-E-003: TargetResourceDeleted must be true (#1039)")
 		})
 	})
 
@@ -233,7 +235,7 @@ var _ = Describe("Enricher Retry Infrastructure — BR-HAPI-261/264 #704", func(
 				"UT-704-E-006: HardFail must be false — unknown Kind is a schema limitation, not an RCA failure")
 		})
 
-		It("should still HardFail when a known Kind's instance is not found", func() {
+		It("should NOT HardFail when a known Kind's instance is not found (#1039)", func() {
 			notFoundErr := apierrors.NewNotFound(
 				schema.GroupResource{Resource: "pods"}, "unreachable-pod")
 			k8s := &countingK8sClient{
@@ -249,8 +251,10 @@ var _ = Describe("Enricher Retry Infrastructure — BR-HAPI-261/264 #704", func(
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 
-			Expect(result.HardFail).To(BeTrue(),
-				"UT-704-E-006: HardFail must be true for known Kinds — the resource is unreachable, RCA is incomplete")
+			Expect(result.HardFail).To(BeFalse(),
+				"UT-704-E-006: HardFail must be false for NotFound — deleted resource proceeds (#1039)")
+			Expect(result.TargetResourceDeleted).To(BeTrue(),
+				"UT-704-E-006: TargetResourceDeleted must be true (#1039)")
 		})
 	})
 


### PR DESCRIPTION
## Summary

- Exempt K8s `NotFound` errors from enrichment `HardFail` so deleted-resource investigations proceed to workflow selection instead of aborting with `rca_incomplete`
- Add `IsNotFoundError` helper using `errors.As` for robust wrapped-error detection
- Surface `TargetResourceDeleted` as a warning in the investigation response for observability
- Replace E2E-KA-433-ADV-016 with two new E2E scenarios validating the softened behavior

### Production validation
Confirmed via OCP audit traces that `ClusterServiceVersion/etcdoperator.v0.9.4` deletion caused `rca_incomplete` despite valid RCA — this PR fixes that exact scenario.

### Files changed
| File | Change |
|------|--------|
| `internal/kubernautagent/enrichment/errors.go` (new) | `IsNotFoundError` helper |
| `internal/kubernautagent/enrichment/enricher.go` | HardFail exemption, `TargetResourceDeleted`, retry skip |
| `internal/kubernautagent/investigator/investigator.go` | Surface `TargetResourceDeleted` as warning |
| `test/unit/.../enricher_not_found_test.go` (new) | 7 unit tests (UT-KA-1039-001 through 007) |
| `test/unit/.../enricher_retry_test.go` | Update UT-704-E-003/006 for new behavior |
| `test/integration/.../investigator_test.go` | Update IT-KA-704-001 error type |
| `test/e2e/.../adversarial_parity_e2e_test.go` | Replace ADV-016 with E2E-KA-1039-001/002 |
| `docs/tests/1039/TEST_PLAN.md` (new) | IEEE 829 test plan |

## Test plan

- [x] 107/107 enrichment unit tests pass (`--race`)
- [x] Investigator unit tests pass (no regression)
- [x] Build and vet pass for all internal packages
- [x] Pre-commit anti-pattern hooks pass
- [ ] CI: integration tests (IT-KA-704-001 with InternalError)
- [ ] CI: E2E tests in Kind cluster (E2E-KA-1039-001, E2E-KA-1039-002)

Closes #1039

Made with [Cursor](https://cursor.com)