### PR TITLE
fix: propagate apiVersion through remediation target pipeline (#1040)

### DIFF
--- a/api/aianalysis/v1alpha1/aianalysis_types.go
+++ b/api/aianalysis/v1alpha1/aianalysis_types.go
@@ -205,6 +205,11 @@ type TargetResource struct {
 	// Resource namespace. Empty for cluster-scoped resources (e.g., Node, PersistentVolume).
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
+	// APIVersion disambiguates the resource's API group when the Kind exists in
+	// multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+	// Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+	// +optional
+	APIVersion string `json:"apiVersion,omitempty"`
 }
 
 // ========================================
@@ -529,6 +534,11 @@ type RemediationTarget struct {
 	// Namespace is the resource namespace. Empty for cluster-scoped resources (e.g., Node, PersistentVolume).
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
+	// APIVersion disambiguates the resource's API group when the Kind exists in
+	// multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+	// Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+	// +optional
+	APIVersion string `json:"apiVersion,omitempty"`
 }
 
 // SelectedWorkflow contains the AI-selected workflow for execution

--- a/api/effectivenessassessment/v1alpha1/effectivenessassessment_types.go
+++ b/api/effectivenessassessment/v1alpha1/effectivenessassessment_types.go
@@ -160,6 +160,11 @@ type TargetResource struct {
 	// Empty for cluster-scoped resources (e.g., Node, PersistentVolume).
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
+	// APIVersion disambiguates the resource's API group when the Kind exists in
+	// multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+	// Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+	// +optional
+	APIVersion string `json:"apiVersion,omitempty"`
 }
 
 // EAConfig contains assessment configuration set by the RO at creation time.

--- a/api/remediation/v1alpha1/remediationrequest_types.go
+++ b/api/remediation/v1alpha1/remediationrequest_types.go
@@ -388,6 +388,12 @@ type ResourceIdentifier struct {
 	// Namespace of the Kubernetes resource (empty for cluster-scoped resources like Node)
 	// +optional
 	Namespace string `json:"namespace,omitempty"`
+
+	// APIVersion disambiguates the resource's API group when the Kind exists in
+	// multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+	// Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+	// +optional
+	APIVersion string `json:"apiVersion,omitempty"`
 }
 
 // String returns the resource identifier in the format used by WorkflowExecution.

--- a/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
@@ -186,6 +186,11 @@ spec:
                                     {Namespace: \"prod\", Kind: \"Deployment\", Name:
                                     \"api\"}"
                                   properties:
+                                    api_version:
+                                      description: |-
+                                        APIVersion of the owner resource from OwnerReference (e.g. "apps/v1").
+                                        Issue #1040.
+                                      type: string
                                     kind:
                                       description: Kind of the owner resource (e.g.,
                                         ReplicaSet, Deployment, StatefulSet, DaemonSet)
@@ -279,6 +284,12 @@ spec:
                       targetResource:
                         description: Target resource identification
                         properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion disambiguates the resource's API group when the Kind exists in
+                              multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                              Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                            type: string
                           kind:
                             description: Resource kind (e.g., Pod, Deployment, StatefulSet)
                             type: string
@@ -870,6 +881,12 @@ spec:
                       the Pod that generated the signal. The WFE creator should prefer this over the RR's
                       TargetResource when available to ensure the correct resource is patched.
                     properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion disambiguates the resource's API group when the Kind exists in
+                          multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                          Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                        type: string
                       kind:
                         description: Kind is the Kubernetes resource kind (e.g., "Deployment",
                           "StatefulSet", "DaemonSet")

--- a/charts/kubernaut/crds/kubernaut.ai_effectivenessassessments.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_effectivenessassessments.yaml
@@ -138,6 +138,12 @@ spec:
                   Source: AA.Status.RootCauseAnalysis.RemediationTarget (from HAPI RCA resolution).
                   Used by: spec hash computation, drift detection (DD-EM-003).
                 properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion disambiguates the resource's API group when the Kind exists in
+                      multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                      Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                    type: string
                   kind:
                     description: Kind is the Kubernetes resource kind (e.g., "Deployment",
                       "StatefulSet").
@@ -167,6 +173,12 @@ spec:
                   Source: RR.Spec.TargetResource (from Gateway alert extraction).
                   Used by: health assessment, alert resolution, metrics queries (DD-EM-003).
                 properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion disambiguates the resource's API group when the Kind exists in
+                      multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                      Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                    type: string
                   kind:
                     description: Kind is the Kubernetes resource kind (e.g., "Deployment",
                       "StatefulSet").

--- a/charts/kubernaut/crds/kubernaut.ai_remediationrequests.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_remediationrequests.yaml
@@ -181,6 +181,12 @@ spec:
                   Used by SignalProcessing for context enrichment and RO for workflow routing.
                   For Kubernetes signals, this contains Kind, Name, Namespace of the affected resource.
                 properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion disambiguates the resource's API group when the Kind exists in
+                      multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                      Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                    type: string
                   kind:
                     description: Kind of the Kubernetes resource (e.g., "Pod", "Deployment",
                       "Node", "StatefulSet")
@@ -854,6 +860,12 @@ spec:
                   May differ from Spec.TargetResource (e.g., Deployment vs Pod).
                   Reference: BR-HAPI-191, Issue #387
                 properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion disambiguates the resource's API group when the Kind exists in
+                      multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                      Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                    type: string
                   kind:
                     description: Kind of the Kubernetes resource (e.g., "Pod", "Deployment",
                       "Node", "StatefulSet")

--- a/charts/kubernaut/crds/kubernaut.ai_signalprocessings.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_signalprocessings.yaml
@@ -393,6 +393,11 @@ spec:
                         Kind: \"ReplicaSet\", Name: \"api-7d8f9c6b5\"}\n\t[1]: {Namespace:
                         \"prod\", Kind: \"Deployment\", Name: \"api\"}"
                       properties:
+                        api_version:
+                          description: |-
+                            APIVersion of the owner resource from OwnerReference (e.g. "apps/v1").
+                            Issue #1040.
+                          type: string
                         kind:
                           description: Kind of the owner resource (e.g., ReplicaSet,
                             Deployment, StatefulSet, DaemonSet)

--- a/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
@@ -186,6 +186,11 @@ spec:
                                     {Namespace: \"prod\", Kind: \"Deployment\", Name:
                                     \"api\"}"
                                   properties:
+                                    api_version:
+                                      description: |-
+                                        APIVersion of the owner resource from OwnerReference (e.g. "apps/v1").
+                                        Issue #1040.
+                                      type: string
                                     kind:
                                       description: Kind of the owner resource (e.g.,
                                         ReplicaSet, Deployment, StatefulSet, DaemonSet)
@@ -279,6 +284,12 @@ spec:
                       targetResource:
                         description: Target resource identification
                         properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion disambiguates the resource's API group when the Kind exists in
+                              multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                              Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                            type: string
                           kind:
                             description: Resource kind (e.g., Pod, Deployment, StatefulSet)
                             type: string
@@ -870,6 +881,12 @@ spec:
                       the Pod that generated the signal. The WFE creator should prefer this over the RR's
                       TargetResource when available to ensure the correct resource is patched.
                     properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion disambiguates the resource's API group when the Kind exists in
+                          multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                          Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                        type: string
                       kind:
                         description: Kind is the Kubernetes resource kind (e.g., "Deployment",
                           "StatefulSet", "DaemonSet")

--- a/charts/kubernaut/files/crds/kubernaut.ai_effectivenessassessments.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_effectivenessassessments.yaml
@@ -138,6 +138,12 @@ spec:
                   Source: AA.Status.RootCauseAnalysis.RemediationTarget (from HAPI RCA resolution).
                   Used by: spec hash computation, drift detection (DD-EM-003).
                 properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion disambiguates the resource's API group when the Kind exists in
+                      multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                      Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                    type: string
                   kind:
                     description: Kind is the Kubernetes resource kind (e.g., "Deployment",
                       "StatefulSet").
@@ -167,6 +173,12 @@ spec:
                   Source: RR.Spec.TargetResource (from Gateway alert extraction).
                   Used by: health assessment, alert resolution, metrics queries (DD-EM-003).
                 properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion disambiguates the resource's API group when the Kind exists in
+                      multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                      Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                    type: string
                   kind:
                     description: Kind is the Kubernetes resource kind (e.g., "Deployment",
                       "StatefulSet").

--- a/charts/kubernaut/files/crds/kubernaut.ai_remediationrequests.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_remediationrequests.yaml
@@ -181,6 +181,12 @@ spec:
                   Used by SignalProcessing for context enrichment and RO for workflow routing.
                   For Kubernetes signals, this contains Kind, Name, Namespace of the affected resource.
                 properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion disambiguates the resource's API group when the Kind exists in
+                      multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                      Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                    type: string
                   kind:
                     description: Kind of the Kubernetes resource (e.g., "Pod", "Deployment",
                       "Node", "StatefulSet")
@@ -854,6 +860,12 @@ spec:
                   May differ from Spec.TargetResource (e.g., Deployment vs Pod).
                   Reference: BR-HAPI-191, Issue #387
                 properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion disambiguates the resource's API group when the Kind exists in
+                      multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                      Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                    type: string
                   kind:
                     description: Kind of the Kubernetes resource (e.g., "Pod", "Deployment",
                       "Node", "StatefulSet")

--- a/charts/kubernaut/files/crds/kubernaut.ai_signalprocessings.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_signalprocessings.yaml
@@ -393,6 +393,11 @@ spec:
                         Kind: \"ReplicaSet\", Name: \"api-7d8f9c6b5\"}\n\t[1]: {Namespace:
                         \"prod\", Kind: \"Deployment\", Name: \"api\"}"
                       properties:
+                        api_version:
+                          description: |-
+                            APIVersion of the owner resource from OwnerReference (e.g. "apps/v1").
+                            Issue #1040.
+                          type: string
                         kind:
                           description: Kind of the owner resource (e.g., ReplicaSet,
                             Deployment, StatefulSet, DaemonSet)

--- a/config/crd/bases/kubernaut.ai_aianalyses.yaml
+++ b/config/crd/bases/kubernaut.ai_aianalyses.yaml
@@ -186,6 +186,11 @@ spec:
                                     {Namespace: \"prod\", Kind: \"Deployment\", Name:
                                     \"api\"}"
                                   properties:
+                                    api_version:
+                                      description: |-
+                                        APIVersion of the owner resource from OwnerReference (e.g. "apps/v1").
+                                        Issue #1040.
+                                      type: string
                                     kind:
                                       description: Kind of the owner resource (e.g.,
                                         ReplicaSet, Deployment, StatefulSet, DaemonSet)
@@ -279,6 +284,12 @@ spec:
                       targetResource:
                         description: Target resource identification
                         properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion disambiguates the resource's API group when the Kind exists in
+                              multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                              Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                            type: string
                           kind:
                             description: Resource kind (e.g., Pod, Deployment, StatefulSet)
                             type: string
@@ -870,6 +881,12 @@ spec:
                       the Pod that generated the signal. The WFE creator should prefer this over the RR's
                       TargetResource when available to ensure the correct resource is patched.
                     properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion disambiguates the resource's API group when the Kind exists in
+                          multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                          Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                        type: string
                       kind:
                         description: Kind is the Kubernetes resource kind (e.g., "Deployment",
                           "StatefulSet", "DaemonSet")

--- a/config/crd/bases/kubernaut.ai_effectivenessassessments.yaml
+++ b/config/crd/bases/kubernaut.ai_effectivenessassessments.yaml
@@ -138,6 +138,12 @@ spec:
                   Source: AA.Status.RootCauseAnalysis.RemediationTarget (from HAPI RCA resolution).
                   Used by: spec hash computation, drift detection (DD-EM-003).
                 properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion disambiguates the resource's API group when the Kind exists in
+                      multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                      Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                    type: string
                   kind:
                     description: Kind is the Kubernetes resource kind (e.g., "Deployment",
                       "StatefulSet").
@@ -167,6 +173,12 @@ spec:
                   Source: RR.Spec.TargetResource (from Gateway alert extraction).
                   Used by: health assessment, alert resolution, metrics queries (DD-EM-003).
                 properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion disambiguates the resource's API group when the Kind exists in
+                      multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                      Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                    type: string
                   kind:
                     description: Kind is the Kubernetes resource kind (e.g., "Deployment",
                       "StatefulSet").

--- a/config/crd/bases/kubernaut.ai_remediationrequests.yaml
+++ b/config/crd/bases/kubernaut.ai_remediationrequests.yaml
@@ -181,6 +181,12 @@ spec:
                   Used by SignalProcessing for context enrichment and RO for workflow routing.
                   For Kubernetes signals, this contains Kind, Name, Namespace of the affected resource.
                 properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion disambiguates the resource's API group when the Kind exists in
+                      multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                      Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                    type: string
                   kind:
                     description: Kind of the Kubernetes resource (e.g., "Pod", "Deployment",
                       "Node", "StatefulSet")
@@ -854,6 +860,12 @@ spec:
                   May differ from Spec.TargetResource (e.g., Deployment vs Pod).
                   Reference: BR-HAPI-191, Issue #387
                 properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion disambiguates the resource's API group when the Kind exists in
+                      multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                      Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                    type: string
                   kind:
                     description: Kind of the Kubernetes resource (e.g., "Pod", "Deployment",
                       "Node", "StatefulSet")

--- a/config/crd/bases/kubernaut.ai_signalprocessings.yaml
+++ b/config/crd/bases/kubernaut.ai_signalprocessings.yaml
@@ -393,6 +393,11 @@ spec:
                         Kind: \"ReplicaSet\", Name: \"api-7d8f9c6b5\"}\n\t[1]: {Namespace:
                         \"prod\", Kind: \"Deployment\", Name: \"api\"}"
                       properties:
+                        api_version:
+                          description: |-
+                            APIVersion of the owner resource from OwnerReference (e.g. "apps/v1").
+                            Issue #1040.
+                          type: string
                         kind:
                           description: Kind of the owner resource (e.g., ReplicaSet,
                             Deployment, StatefulSet, DaemonSet)

--- a/docs/generated/crds.md
+++ b/docs/generated/crds.md
@@ -1363,6 +1363,7 @@ _Appears in:_
 | `kind`| _string_| Kind is the Kubernetes resource kind (e.g., "Deployment", "StatefulSet", "DaemonSet")|
 | `name`| _string_| Name is the resource name|
 | `namespace`| _string_| Namespace is the resource namespace. Empty for cluster-scoped resources (e.g., Node, PersistentVolume).|
+| `apiVersion`| _string_| APIVersion disambiguates the resource's API group when the Kind exists in<br />multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).<br />Format: "group/version" (e.g. "route.openshift.io/v1"). .|
 
 
 ## RemediationWorkflow
@@ -1828,6 +1829,7 @@ _Appears in:_
 | `kind`| _string_| Kind is the Kubernetes resource kind (e.g., "Deployment", "StatefulSet").|
 | `name`| _string_| Name is the resource name.|
 | `namespace`| _string_| Namespace is the resource namespace.<br />Empty for cluster-scoped resources (e.g., Node, PersistentVolume).|
+| `apiVersion`| _string_| APIVersion disambiguates the resource's API group when the Kind exists in<br />multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).<br />Format: "group/version" (e.g. "route.openshift.io/v1"). .|
 
 
 ### TimeoutConfig

--- a/docs/tests/1040/TEST_PLAN.md
+++ b/docs/tests/1040/TEST_PLAN.md
@@ -1,0 +1,235 @@
+# Test Plan: Propagate apiVersion Through Remediation Target Pipeline
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-1040-v1
+**Feature**: Propagate `apiVersion` from LLM remediation target through the pipeline to EA resource fetching, resolving ambiguous kind resolution on OCP with Knative
+**Version**: 1.0
+**Created**: 2026-05-05
+**Author**: AI Agent (supervised)
+**Status**: Approved
+**Branch**: `fix/1040`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Validate that the `api_version` field is correctly parsed from LLM responses, propagated through all target resource types (AIAnalysis, RR, EA CRDs), and used by the EA controller for unambiguous GVR resolution. Confirms backwards compatibility when `api_version` is absent.
+
+### 1.2 Objectives
+
+1. **Parser extraction**: `api_version` from LLM JSON is captured in `RemediationTarget`
+2. **Type propagation**: `APIVersion` flows through AIAnalysis → RR → EA without loss
+3. **GVR resolution**: EA uses `apiVersion` directly instead of `ResolveGVKForKind` when present
+4. **Enrichment disambiguation**: `K8sAdapter` uses `apiVersion` for initial resource resolution
+5. **Owner chain capture**: `OwnerChainEntry` retains `APIVersion` from `OwnerReference`
+6. **InjectRemediationTarget**: `APIVersion` is preserved through target injection logic
+7. **Backwards compatibility**: Absent `api_version` falls back to existing kind-only resolution
+8. **Validation**: Invalid `apiVersion` from LLM is rejected with warning, falls back gracefully
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test --race` on affected packages |
+| Integration test pass rate | 100% | `go test` on integration packages |
+| Backward compatibility | 0 regressions | All existing tests pass |
+| CRD generation | Clean | `make generate && make manifests` succeeds |
+
+---
+
+## 2. References
+
+### 2.1 Authority
+
+- Issue #1040: EffectivenessMonitor: ambiguous Route kind resolution on OCP with Knative
+- Issue #1029: Gateway Dynamic Owner Resolution for OpenShift CRDs (related pattern)
+- Production incident: `route-misconfiguration` scenario on OCP with Knative installed
+
+### 2.2 Cross-References
+
+- [Testing Guidelines](../development/business-requirements/TESTING_GUIDELINES.md)
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | K8sClient interface change breaks all fakes | Build failure in tests | High | All enrichment/investigator tests | Update all fakes to accept `apiVersion` parameter |
+| R2 | LLM hallucinates wrong apiVersion | Wrong resource fetched by EA | Medium | UT-KA-1040-008 | Validate against REST mapper; fall back on failure |
+| R3 | CRD schema change not regenerated | Runtime field ignored | Low | Build check | `make generate && make manifests` in GREEN phase |
+| R4 | InjectRemediationTarget loses apiVersion during override | EA receives empty apiVersion | Medium | UT-KA-1040-005/006 | Explicit propagation logic with tests |
+| R5 | Backwards incompatibility for absent apiVersion | Existing investigations break | Low | UT-KA-1040-007 | All code paths have `""` fallback |
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **Parser** (`internal/kubernautagent/parser/`): `api_version` extraction from LLM JSON
+- **Type propagation** (`pkg/kubernautagent/types/`, `api/*/v1alpha1/`): `APIVersion` field on all target types
+- **ResolveGVKWithAPIVersion** (`pkg/shared/k8s/gvk.go`): New helper for apiVersion-aware GVR resolution
+- **InjectRemediationTarget** (`internal/kubernautagent/investigator/`): APIVersion propagation through injection
+- **EA consumer** (`internal/controller/effectivenessmonitor/`): apiVersion-aware resource fetching
+- **K8sAdapter** (`internal/kubernautagent/enrichment/`): apiVersion-aware initial resolution and owner chain capture
+- **Serialization** (`pkg/aianalysis/handlers/`): `api_version` deserialization from RCA map
+- **RO propagation** (`internal/controller/remediationorchestrator/`): APIVersion in WFE/EA creation
+
+### 4.2 Features Not to be Tested
+
+- **Signal context apiVersion**: Gateway-to-agent path; separate issue scope
+- **Route CRD E2E in Kind**: Requires Knative + OCP CRDs; deferred to OCP-specific test suite
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+- **Unit**: >=80% of changed logic (parser, helper, injection, resolution)
+- **Integration**: >=80% of I/O paths (EA resource fetch, enrichment)
+
+### 5.2 Pass/Fail Criteria
+
+**PASS**: All tests pass, `make generate && make manifests` clean, 0 regressions
+**FAIL**: Any P0 test fails, CRD regeneration fails, existing tests regress
+
+---
+
+## 7. BR Coverage Matrix
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-EA-1040 | Parser extracts api_version from LLM JSON | P0 | Unit | UT-KA-1040-001 | Pending |
+| BR-EA-1040 | Parser handles missing api_version (backwards compat) | P0 | Unit | UT-KA-1040-002 | Pending |
+| BR-EA-1040 | ResolveGVKWithAPIVersion uses apiVersion when present | P0 | Unit | UT-KA-1040-003 | Pending |
+| BR-EA-1040 | ResolveGVKWithAPIVersion falls back when apiVersion empty | P0 | Unit | UT-KA-1040-004 | Pending |
+| BR-EA-1040 | InjectRemediationTarget preserves apiVersion (same kind) | P0 | Unit | UT-KA-1040-005 | Pending |
+| BR-EA-1040 | InjectRemediationTarget preserves apiVersion (cross-type) | P0 | Unit | UT-KA-1040-006 | Pending |
+| BR-EA-1040 | InjectRemediationTarget with empty apiVersion (compat) | P0 | Unit | UT-KA-1040-007 | Pending |
+| BR-EA-1040 | ResolveGVKWithAPIVersion rejects invalid apiVersion | P1 | Unit | UT-KA-1040-008 | Pending |
+| BR-EA-1040 | OwnerChainEntry captures APIVersion from OwnerReference | P0 | Unit | UT-KA-1040-009 | Pending |
+| BR-EA-1040 | K8sAdapter uses apiVersion for initial resolution | P0 | Unit | UT-KA-1040-010 | Pending |
+| BR-EA-1040 | ExtractRootCauseAnalysis reads api_version | P0 | Unit | UT-KA-1040-011 | Pending |
+| BR-EA-1040 | EA getTargetFunctionalState uses apiVersion | P0 | Integration | IT-KA-1040-001 | Pending |
+| BR-EA-1040 | Mock LLM emits api_version in remediation_target | P1 | Unit | UT-KA-1040-012 | Pending |
+| BR-EA-1040 | injectTargetResourceParameters includes API_VERSION | P1 | Unit | UT-KA-1040-013 | Pending |
+
+---
+
+## 8. Test Scenarios
+
+### Tier 1: Unit Tests
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| UT-KA-1040-001 | LLM JSON with api_version is parsed into RemediationTarget.APIVersion | Pending |
+| UT-KA-1040-002 | LLM JSON without api_version preserves empty APIVersion (backwards compat) | Pending |
+| UT-KA-1040-003 | ResolveGVKWithAPIVersion("Route", "route.openshift.io/v1") returns correct GVK | Pending |
+| UT-KA-1040-004 | ResolveGVKWithAPIVersion("Deployment", "") falls back to static table | Pending |
+| UT-KA-1040-005 | InjectRemediationTarget preserves LLM apiVersion when kind matches root | Pending |
+| UT-KA-1040-006 | InjectRemediationTarget preserves LLM apiVersion for cross-type target | Pending |
+| UT-KA-1040-007 | InjectRemediationTarget with empty apiVersion works (backwards compat) | Pending |
+| UT-KA-1040-008 | ResolveGVKWithAPIVersion rejects malformed apiVersion gracefully | Pending |
+| UT-KA-1040-009 | K8sAdapter.GetOwnerChain captures APIVersion in OwnerChainEntry | Pending |
+| UT-KA-1040-010 | K8sAdapter uses apiVersion parameter for initial resolveMapping | Pending |
+| UT-KA-1040-011 | ExtractRootCauseAnalysis captures api_version from RCA JSON map | Pending |
+| UT-KA-1040-012 | Mock LLM analysisJSON includes api_version when config has APIVersion | Pending |
+| UT-KA-1040-013 | injectTargetResourceParameters includes TARGET_RESOURCE_API_VERSION | Pending |
+
+---
+
+## 9. Test Cases
+
+### UT-KA-1040-001: Parser extracts api_version
+
+**Priority**: P0
+**File**: `test/unit/kubernautagent/parser/parser_apiversion_test.go`
+
+**Test Steps**:
+1. **Given**: JSON string `{"root_cause_analysis":{"summary":"...","remediation_target":{"kind":"Route","name":"storefront","namespace":"demo-route","api_version":"route.openshift.io/v1"}}}`
+2. **When**: `Parse(jsonStr, logger)` is called
+3. **Then**: `result.RemediationTarget.APIVersion` equals `"route.openshift.io/v1"`
+
+### UT-KA-1040-003: ResolveGVKWithAPIVersion with apiVersion
+
+**Priority**: P0
+**File**: `test/unit/shared/k8s/gvk_apiversion_test.go`
+
+**Test Steps**:
+1. **Given**: REST mapper with `route.openshift.io/v1/Route` registered
+2. **When**: `ResolveGVKWithAPIVersion(mapper, "Route", "route.openshift.io/v1")`
+3. **Then**: Returns GVK `{Group: "route.openshift.io", Version: "v1", Kind: "Route"}`
+
+### UT-KA-1040-005: InjectRemediationTarget preserves apiVersion (same kind)
+
+**Priority**: P0
+**File**: `test/unit/kubernautagent/investigator/investigator_phases_apiversion_test.go`
+
+**Test Steps**:
+1. **Given**: LLM result with `RemediationTarget{Kind: "Route", Name: "storefront", Namespace: "demo-route", APIVersion: "route.openshift.io/v1"}`; enrichment with empty owner chain but `ResourceKind: "Route"`
+2. **When**: `InjectRemediationTarget(result, signal, enrichData)`
+3. **Then**: `result.RemediationTarget.APIVersion` equals `"route.openshift.io/v1"` (preserved because kind matches)
+
+---
+
+## 10. Environmental Needs
+
+### 10.1 Unit Tests
+- **Framework**: Ginkgo/Gomega BDD
+- **Mocks**: `fakeK8sClient` with updated interface, `fake.NewSimpleClientset` for REST mapper tests
+- **Location**: `test/unit/kubernautagent/`, `test/unit/shared/k8s/`
+
+### 10.2 Integration Tests
+- **Framework**: Ginkgo/Gomega BDD
+- **Infrastructure**: envtest for REST mapper with real CRDs
+- **Location**: `test/integration/`
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Execution Order
+
+1. **Phase 1 (TDD RED)**: Write failing tests for parser, GVK helper, InjectRemediationTarget, EA resolution
+2. **Phase 2 (TDD GREEN L1-3)**: LLM schema + prompt + parser + internal types + CRD types + make generate/manifests
+3. **Phase 3 (TDD GREEN L4-7)**: Serialization, RO propagation, InjectRemediationTarget, EA consumer
+4. **Phase 4 (TDD GREEN L8-10)**: Enrichment, validation helper, mock LLM
+5. **Phase 5 (TDD REFACTOR)**: 100-go-mistakes review, 9-category checkpoint audit
+
+---
+
+## 12. Existing Tests Requiring Updates
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|-------------------|-------------------|-----------------|--------|
+| `enrichment_test.go` fakeK8sClient | `GetOwnerChain(_, _, _, _)` | Add `apiVersion` parameter | K8sClient interface change |
+| `enricher_retry_test.go` countingK8sClient | `GetOwnerChain(_, _, _, _)` | Add `apiVersion` parameter | K8sClient interface change |
+| `enricher_not_found_test.go` fakeK8sClient | `GetOwnerChain(_, _, _, _)` | Add `apiVersion` parameter | K8sClient interface change |
+| `investigator_test.go` fakeK8sClient | `GetOwnerChain(_, _, _, _)` | Add `apiVersion` parameter | K8sClient interface change |
+| `resource_context_test.go` | May use K8sClient mock | Add `apiVersion` parameter | K8sClient interface change |
+
+---
+
+## 13. Due Diligence Findings
+
+| ID | Finding | Severity | Resolution |
+|----|---------|----------|------------|
+| DD-1 | K8sClient interface change breaks 4 fake implementations + ~15 test call sites | P0 | Update all fakes; add `_` parameter for apiVersion |
+| DD-2 | `resolveMapping(kind)` uses heuristic plural — ambiguous for multi-group kinds | P0 | New `resolveMappingWithAPIVersion` path when apiVersion non-empty |
+| DD-3 | `OwnerReference.APIVersion` is already parsed in `resolveOwnerMapping` but discarded | P0 | Capture in `OwnerChainEntry.APIVersion` |
+| DD-4 | `resource_context.go` tool calls `GetOwnerChain`/`GetSpecHash` without apiVersion context | Info | Pass `""` — tool works on arbitrary resources from LLM tool calls |
+| DD-5 | Mock LLM `MockScenarioConfig.APIVersion` field exists but unused in JSON builders | P1 | Wire into `analysisJSON` when non-empty |
+| DD-6 | CRD regeneration required after type changes | P0 | `make generate && make manifests` in GREEN phase |
+
+---
+
+## 14. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-05-05 | Initial test plan |

--- a/internal/controller/effectivenessmonitor/target_resources.go
+++ b/internal/controller/effectivenessmonitor/target_resources.go
@@ -143,6 +143,11 @@ func (r *Reconciler) getTargetFunctionalState(ctx context.Context, target eav1.T
 	}
 
 	gvk, err := k8sutil.ResolveGVKWithAPIVersion(r.restMapper, target.Kind, target.APIVersion) // #1040
+	if err != nil && target.APIVersion != "" {
+		logger.Info("apiVersion-based GVK resolution failed, falling back to kind-only resolution",
+			"kind", target.Kind, "apiVersion", target.APIVersion, "error", err)
+		gvk, err = k8sutil.ResolveGVKForKind(r.restMapper, target.Kind)
+	}
 	if err != nil {
 		logger.Error(err, "Failed to resolve GVK for target resource kind",
 			"kind", target.Kind, "apiVersion", target.APIVersion)

--- a/internal/controller/effectivenessmonitor/target_resources.go
+++ b/internal/controller/effectivenessmonitor/target_resources.go
@@ -142,10 +142,10 @@ func (r *Reconciler) getTargetFunctionalState(ctx context.Context, target eav1.T
 		return fallback, fallback, ""
 	}
 
-	gvk, err := k8sutil.ResolveGVKForKind(r.restMapper, target.Kind)
+	gvk, err := k8sutil.ResolveGVKWithAPIVersion(r.restMapper, target.Kind, target.APIVersion) // #1040
 	if err != nil {
 		logger.Error(err, "Failed to resolve GVK for target resource kind",
-			"kind", target.Kind)
+			"kind", target.Kind, "apiVersion", target.APIVersion)
 		return map[string]interface{}{}, map[string]interface{}{}, ""
 	}
 

--- a/internal/controller/remediationorchestrator/reconciler.go
+++ b/internal/controller/remediationorchestrator/reconciler.go
@@ -3112,9 +3112,10 @@ func resolveDualTargets(
 	ai *aianalysisv1.AIAnalysis,
 ) *creator.DualTarget {
 	signal := eav1.TargetResource{
-		Kind:      rr.Spec.TargetResource.Kind,
-		Name:      rr.Spec.TargetResource.Name,
-		Namespace: rr.Spec.TargetResource.Namespace,
+		Kind:       rr.Spec.TargetResource.Kind,
+		Name:       rr.Spec.TargetResource.Name,
+		Namespace:  rr.Spec.TargetResource.Namespace,
+		APIVersion: rr.Spec.TargetResource.APIVersion, // #1040
 	}
 
 	remediation := signal
@@ -3122,9 +3123,10 @@ func resolveDualTargets(
 		ar := ai.Status.RootCauseAnalysis.RemediationTarget
 		if ar.Kind != "" && ar.Name != "" {
 			remediation = eav1.TargetResource{
-				Kind:      ar.Kind,
-				Name:      ar.Name,
-				Namespace: ar.Namespace,
+				Kind:       ar.Kind,
+				Name:       ar.Name,
+				Namespace:  ar.Namespace,
+				APIVersion: ar.APIVersion, // #1040
 			}
 		}
 	}

--- a/internal/controller/remediationorchestrator/wfe_creation_helper.go
+++ b/internal/controller/remediationorchestrator/wfe_creation_helper.go
@@ -101,9 +101,10 @@ func CreateWFEAndTransition(
 		if ai.Status.RootCauseAnalysis != nil && ai.Status.RootCauseAnalysis.RemediationTarget != nil {
 			ar := ai.Status.RootCauseAnalysis.RemediationTarget
 			rr.Status.RemediationTarget = &remediationv1.ResourceIdentifier{
-				Kind:      ar.Kind,
-				Name:      ar.Name,
-				Namespace: ar.Namespace,
+				Kind:       ar.Kind,
+				Name:       ar.Name,
+				Namespace:  ar.Namespace,
+				APIVersion: ar.APIVersion, // #1040
 			}
 			rr.Status.TargetDisplay = remediationrequest.FormatResourceDisplay(ar.Kind, ar.Name)
 		}

--- a/internal/kubernautagent/enrichment/enricher.go
+++ b/internal/kubernautagent/enrichment/enricher.go
@@ -34,6 +34,10 @@ type OwnerChainEntry struct {
 	Kind      string `json:"kind"`
 	Name      string `json:"name"`
 	Namespace string `json:"namespace,omitempty"`
+	// APIVersion captures the owner's API group/version from OwnerReference.
+	// Format: "group/version" (e.g. "apps/v1") or "version" for core (e.g. "v1").
+	// Issue #1040.
+	APIVersion string `json:"api_version,omitempty"`
 }
 
 // DetectedLabels holds the structured label detection results matching KA's LabelDetector output.
@@ -59,9 +63,11 @@ type QuotaResourceUsage struct {
 }
 
 // K8sClient abstracts Kubernetes API access for enrichment.
+// Issue #1040: apiVersion parameter disambiguates multi-group kinds (e.g. Route).
+// Pass "" when unknown — preserves existing heuristic-based resolution.
 type K8sClient interface {
-	GetOwnerChain(ctx context.Context, kind, name, namespace string) ([]OwnerChainEntry, error)
-	GetSpecHash(ctx context.Context, kind, name, namespace string) (string, error)
+	GetOwnerChain(ctx context.Context, kind, name, namespace, apiVersion string) ([]OwnerChainEntry, error)
+	GetSpecHash(ctx context.Context, kind, name, namespace, apiVersion string) (string, error)
 }
 
 // DataStorageClient abstracts DataStorage API access for enrichment.
@@ -197,8 +203,8 @@ func (e *Enricher) WithRetryConfig(cfg RetryConfig) *Enricher {
 // With MaxRetries>0: all errors are retried with exponential backoff,
 // matching HAPI v1.2.1 EnrichmentService._retry (except Exception → retry).
 // The caller sets HardFail on EnrichmentResult when this returns a non-nil error.
-func (e *Enricher) resolveOwnerChainWithRetry(ctx context.Context, kind, name, namespace string) ([]OwnerChainEntry, error) {
-	chain, err := e.k8s.GetOwnerChain(ctx, kind, name, namespace)
+func (e *Enricher) resolveOwnerChainWithRetry(ctx context.Context, kind, name, namespace, apiVersion string) ([]OwnerChainEntry, error) {
+	chain, err := e.k8s.GetOwnerChain(ctx, kind, name, namespace, apiVersion)
 	if err == nil {
 		return chain, nil
 	}
@@ -226,7 +232,7 @@ func (e *Enricher) resolveOwnerChainWithRetry(ctx context.Context, kind, name, n
 		case <-time.After(wait):
 		}
 
-		chain, err = e.k8s.GetOwnerChain(ctx, kind, name, namespace)
+		chain, err = e.k8s.GetOwnerChain(ctx, kind, name, namespace, apiVersion)
 		if err == nil {
 			return chain, nil
 		}
@@ -258,7 +264,8 @@ func isTransientK8sError(err error) bool {
 // Enrich resolves enrichment data for the given resource.
 // Implements partial failure: each sub-call is best-effort.
 // If specHash is empty, auto-computes it via K8sClient.GetSpecHash.
-func (e *Enricher) Enrich(ctx context.Context, kind, name, namespace, specHash, incidentID string) (*EnrichmentResult, error) {
+// apiVersion disambiguates multi-group kinds (e.g. Route). Pass "" when unknown. Issue #1040.
+func (e *Enricher) Enrich(ctx context.Context, kind, name, namespace, apiVersion, specHash, incidentID string) (*EnrichmentResult, error) {
 	result := &EnrichmentResult{
 		ResourceKind:      kind,
 		ResourceName:      name,
@@ -266,7 +273,7 @@ func (e *Enricher) Enrich(ctx context.Context, kind, name, namespace, specHash, 
 	}
 
 	if specHash == "" {
-		computed, err := e.k8s.GetSpecHash(ctx, kind, name, namespace)
+		computed, err := e.k8s.GetSpecHash(ctx, kind, name, namespace, apiVersion)
 		if err != nil {
 			e.logger.Error(err, "enrichment: specHash auto-computation failed, proceeding with empty",
 				"resource", namespace+"/"+kind+"/"+name,
@@ -278,7 +285,7 @@ func (e *Enricher) Enrich(ctx context.Context, kind, name, namespace, specHash, 
 
 	var ownerErr, histErr error
 
-	chain, ownerErr := e.resolveOwnerChainWithRetry(ctx, kind, name, namespace)
+	chain, ownerErr := e.resolveOwnerChainWithRetry(ctx, kind, name, namespace, apiVersion)
 	if ownerErr != nil {
 		result.OwnerChainError = ownerErr
 		if e.retryConfig.MaxRetries > 0 && !IsNoMatchError(ownerErr) {

--- a/internal/kubernautagent/enrichment/k8s_adapter.go
+++ b/internal/kubernautagent/enrichment/k8s_adapter.go
@@ -50,8 +50,8 @@ func NewK8sAdapter(dynClient dynamic.Interface, mapper meta.RESTMapper) *K8sAdap
 //
 // Scope-aware (#762): uses RESTMapping.Scope to determine cluster vs namespaced
 // API calls, rather than relying on the namespace parameter being empty.
-func (a *K8sAdapter) GetOwnerChain(ctx context.Context, kind, name, namespace string) ([]OwnerChainEntry, error) {
-	mapping, err := a.resolveMapping(kind)
+func (a *K8sAdapter) GetOwnerChain(ctx context.Context, kind, name, namespace, apiVersion string) ([]OwnerChainEntry, error) {
+	mapping, err := a.resolveMappingWithAPIVersion(kind, apiVersion)
 	if err != nil {
 		return nil, fmt.Errorf("k8s adapter: resolve GVR for %s: %w", kind, err)
 	}
@@ -95,9 +95,10 @@ func (a *K8sAdapter) GetOwnerChain(ctx context.Context, kind, name, namespace st
 		}
 
 		chain = append(chain, OwnerChainEntry{
-			Kind:      ownerRef.Kind,
-			Name:      ownerRef.Name,
-			Namespace: ownerNS,
+			Kind:       ownerRef.Kind,
+			Name:       ownerRef.Name,
+			Namespace:  ownerNS,
+			APIVersion: ownerRef.APIVersion, // #1040: capture from OwnerReference
 		})
 
 		ownerClient := a.scopedClient(ownerMapping, namespace)
@@ -116,8 +117,8 @@ func (a *K8sAdapter) GetOwnerChain(ctx context.Context, kind, name, namespace st
 // not just .spec. The method name is retained for interface compatibility.
 //
 // Scope-aware (#762): uses RESTMapping.Scope for cluster vs namespaced dispatch.
-func (a *K8sAdapter) GetSpecHash(ctx context.Context, kind, name, namespace string) (string, error) {
-	mapping, err := a.resolveMapping(kind)
+func (a *K8sAdapter) GetSpecHash(ctx context.Context, kind, name, namespace, apiVersion string) (string, error) {
+	mapping, err := a.resolveMappingWithAPIVersion(kind, apiVersion)
 	if err != nil {
 		return "", fmt.Errorf("k8s adapter: resolve GVR for spec hash of %s: %w", kind, err)
 	}
@@ -141,6 +142,30 @@ func (a *K8sAdapter) GetSpecHash(ctx context.Context, kind, name, namespace stri
 // installed after the agent starts.
 type resettableMapper interface {
 	Reset()
+}
+
+// resolveMappingWithAPIVersion resolves a RESTMapping using an explicit apiVersion
+// when provided, bypassing the heuristic plural-guess path. Falls back to
+// resolveMapping when apiVersion is empty. Issue #1040.
+func (a *K8sAdapter) resolveMappingWithAPIVersion(kind, apiVersion string) (*meta.RESTMapping, error) {
+	if apiVersion != "" {
+		gv, err := schema.ParseGroupVersion(apiVersion)
+		if err != nil {
+			return nil, fmt.Errorf("parse API version %q: %w", apiVersion, err)
+		}
+		mapping, err := a.mapper.RESTMapping(schema.GroupKind{Group: gv.Group, Kind: kind}, gv.Version)
+		if err != nil {
+			if rm, ok := a.mapper.(resettableMapper); ok {
+				rm.Reset()
+				mapping, err = a.mapper.RESTMapping(schema.GroupKind{Group: gv.Group, Kind: kind}, gv.Version)
+			}
+			if err != nil {
+				return nil, fmt.Errorf("resolve mapping for %s in apiVersion %q: %w", kind, apiVersion, err)
+			}
+		}
+		return mapping, nil
+	}
+	return a.resolveMapping(kind)
 }
 
 // resolveMapping returns the full RESTMapping for a Kind, including GVR and Scope.

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -342,7 +342,7 @@ func (inv *Investigator) resolveEnrichment(ctx context.Context, kind, name, name
 	if inv.enricher == nil {
 		return nil
 	}
-	result, err := inv.enricher.Enrich(ctx, kind, name, namespace, "", incidentID)
+	result, err := inv.enricher.Enrich(ctx, kind, name, namespace, "", "", incidentID)
 	if err != nil {
 		inv.logger.Error(err, "enrichment failed")
 		return nil

--- a/internal/kubernautagent/investigator/investigator_phases.go
+++ b/internal/kubernautagent/investigator/investigator_phases.go
@@ -24,9 +24,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
-	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 )
 
 // BuildPhase1Context extracts structured assessment fields from the Phase 1
@@ -233,11 +233,18 @@ func InjectRemediationTarget(result *katypes.InvestigationResult, signal katypes
 	}
 
 	llmKind := result.RemediationTarget.Kind
+	llmAPIVersion := result.RemediationTarget.APIVersion
 	if llmKind == "" || llmKind == rootKind {
+		// Same kind as root: preserve LLM's apiVersion (same kind = same API group). #1040
+		apiVersion := llmAPIVersion
+		if apiVersion == "" && enrichData != nil && len(enrichData.OwnerChain) > 0 {
+			apiVersion = enrichData.OwnerChain[len(enrichData.OwnerChain)-1].APIVersion
+		}
 		result.RemediationTarget = katypes.RemediationTarget{
-			Kind:      rootKind,
-			Name:      rootName,
-			Namespace: rootNS,
+			Kind:       rootKind,
+			Name:       rootName,
+			Namespace:  rootNS,
+			APIVersion: apiVersion,
 		}
 		return
 	}
@@ -248,10 +255,16 @@ func InjectRemediationTarget(result *katypes.InvestigationResult, signal katypes
 	// the LLM's target when its kind is genuinely cross-type (not in
 	// the owner chain at all, e.g. Node vs Deployment).
 	if enrichData != nil && isKindInOwnerChain(llmKind, signal.ResourceKind, enrichData.OwnerChain) {
+		// Use root owner's APIVersion from the chain if available. #1040
+		rootAPIVersion := ""
+		if len(enrichData.OwnerChain) > 0 {
+			rootAPIVersion = enrichData.OwnerChain[len(enrichData.OwnerChain)-1].APIVersion
+		}
 		result.RemediationTarget = katypes.RemediationTarget{
-			Kind:      rootKind,
-			Name:      rootName,
-			Namespace: rootNS,
+			Kind:       rootKind,
+			Name:       rootName,
+			Namespace:  rootNS,
+			APIVersion: rootAPIVersion,
 		}
 		return
 	}
@@ -279,6 +292,9 @@ func injectTargetResourceParameters(result *katypes.InvestigationResult) {
 	result.Parameters["TARGET_RESOURCE_NAME"] = result.RemediationTarget.Name
 	result.Parameters["TARGET_RESOURCE_KIND"] = result.RemediationTarget.Kind
 	result.Parameters["TARGET_RESOURCE_NAMESPACE"] = result.RemediationTarget.Namespace
+	if result.RemediationTarget.APIVersion != "" {
+		result.Parameters["TARGET_RESOURCE_API_VERSION"] = result.RemediationTarget.APIVersion
+	}
 }
 
 func allLabelDetectionsFailed(labels *enrichment.DetectedLabels) bool {

--- a/internal/kubernautagent/parser/parser.go
+++ b/internal/kubernautagent/parser/parser.go
@@ -209,13 +209,13 @@ const confidenceFloor = 0.8
 type llmResponse struct {
 	RCA                  *llmRCA                `json:"root_cause_analysis"`
 	RCAAlt               *llmRCA                `json:"rootCauseAnalysis,omitempty"`
-	Workflow             *llmWorkflow            `json:"selected_workflow"`
-	AlternativeWorkflows []llmAlternative        `json:"alternative_workflows,omitempty"`
-	Severity             string                  `json:"severity,omitempty"`
-	Confidence           float64                 `json:"confidence,omitempty"`
-	Actionable           *bool                   `json:"actionable,omitempty"`
-	InvestigationOutcome string                  `json:"investigation_outcome,omitempty"`
-	DetectedLabels       map[string]interface{}  `json:"detected_labels,omitempty"`
+	Workflow             *llmWorkflow           `json:"selected_workflow"`
+	AlternativeWorkflows []llmAlternative       `json:"alternative_workflows,omitempty"`
+	Severity             string                 `json:"severity,omitempty"`
+	Confidence           float64                `json:"confidence,omitempty"`
+	Actionable           *bool                  `json:"actionable,omitempty"`
+	InvestigationOutcome string                 `json:"investigation_outcome,omitempty"`
+	DetectedLabels       map[string]interface{} `json:"detected_labels,omitempty"`
 }
 
 // resolvedRCA returns the RCA from either snake_case or camelCase key.
@@ -253,9 +253,10 @@ func (r *llmRCA) resolvedTarget() *llmRemTarget {
 }
 
 type llmRemTarget struct {
-	Kind      string `json:"kind"`
-	Name      string `json:"name"`
-	Namespace string `json:"namespace"`
+	Kind       string `json:"kind"`
+	Name       string `json:"name"`
+	Namespace  string `json:"namespace"`
+	APIVersion string `json:"api_version,omitempty"`
 }
 
 type llmWorkflow struct {
@@ -423,9 +424,10 @@ func parseLLMFormat(jsonStr string, logger logr.Logger) (*katypes.InvestigationR
 		result.DueDiligence = rca.DueDiligence
 		if t := rca.resolvedTarget(); t != nil {
 			result.RemediationTarget = katypes.RemediationTarget{
-				Kind:      t.Kind,
-				Name:      t.Name,
-				Namespace: t.Namespace,
+				Kind:       t.Kind,
+				Name:       t.Name,
+				Namespace:  t.Namespace,
+				APIVersion: t.APIVersion,
 			}
 		}
 	}
@@ -622,9 +624,10 @@ func mergeNestedRemediationTarget(result *katypes.InvestigationResult, jsonStr s
 	}
 	if t := rca.resolvedTarget(); t != nil {
 		result.RemediationTarget = katypes.RemediationTarget{
-			Kind:      t.Kind,
-			Name:      t.Name,
-			Namespace: t.Namespace,
+			Kind:       t.Kind,
+			Name:       t.Name,
+			Namespace:  t.Namespace,
+			APIVersion: t.APIVersion,
 		}
 	}
 }

--- a/internal/kubernautagent/parser/parser.go
+++ b/internal/kubernautagent/parser/parser.go
@@ -423,6 +423,10 @@ func parseLLMFormat(jsonStr string, logger logr.Logger) (*katypes.InvestigationR
 		result.CausalChain = rca.CausalChain
 		result.DueDiligence = rca.DueDiligence
 		if t := rca.resolvedTarget(); t != nil {
+			if t.APIVersion == "" && t.Kind != "" {
+				logger.Info("LLM omitted required api_version for remediation_target, resolution will use heuristic fallback",
+					"kind", t.Kind, "name", t.Name, "namespace", t.Namespace)
+			}
 			result.RemediationTarget = katypes.RemediationTarget{
 				Kind:       t.Kind,
 				Name:       t.Name,

--- a/internal/kubernautagent/parser/schema.go
+++ b/internal/kubernautagent/parser/schema.go
@@ -66,7 +66,8 @@ const noWorkflowResultSchemaJSON = `{
           "properties": {
             "kind": { "type": "string" },
             "name": { "type": "string" },
-            "namespace": { "type": "string" }
+            "namespace": { "type": "string" },
+            "api_version": { "type": "string", "description": "Optional API group/version (e.g. route.openshift.io/v1) to disambiguate when multiple API groups register the same Kind." }
           }
         }
       },
@@ -95,7 +96,8 @@ const rcaResultSchemaJSON = `{
           "properties": {
             "kind": { "type": "string" },
             "name": { "type": "string" },
-            "namespace": { "type": "string" }
+            "namespace": { "type": "string" },
+            "api_version": { "type": "string", "description": "Optional API group/version (e.g. route.openshift.io/v1) to disambiguate when multiple API groups register the same Kind." }
           }
         },
         "investigation_analysis": { "type": "string", "description": "Concise narrative summary of the investigation findings and reasoning (< 500 words). This field is consumed by the Phase 3 workflow selection LLM to provide investigation context." },
@@ -147,7 +149,8 @@ const investigationResultSchemaJSON = `{
           "properties": {
             "kind": { "type": "string" },
             "name": { "type": "string" },
-            "namespace": { "type": "string" }
+            "namespace": { "type": "string" },
+            "api_version": { "type": "string", "description": "Optional API group/version (e.g. route.openshift.io/v1) to disambiguate when multiple API groups register the same Kind." }
           }
         }
       },

--- a/internal/kubernautagent/parser/schema.go
+++ b/internal/kubernautagent/parser/schema.go
@@ -67,8 +67,9 @@ const noWorkflowResultSchemaJSON = `{
             "kind": { "type": "string" },
             "name": { "type": "string" },
             "namespace": { "type": "string" },
-            "api_version": { "type": "string", "description": "Optional API group/version (e.g. route.openshift.io/v1) to disambiguate when multiple API groups register the same Kind." }
-          }
+            "api_version": { "type": "string", "description": "API group/version (e.g. route.openshift.io/v1, apps/v1). Required to disambiguate the target resource's API group." }
+          },
+          "required": ["kind", "name", "namespace", "api_version"]
         }
       },
       "required": ["summary"]
@@ -97,8 +98,9 @@ const rcaResultSchemaJSON = `{
             "kind": { "type": "string" },
             "name": { "type": "string" },
             "namespace": { "type": "string" },
-            "api_version": { "type": "string", "description": "Optional API group/version (e.g. route.openshift.io/v1) to disambiguate when multiple API groups register the same Kind." }
-          }
+            "api_version": { "type": "string", "description": "API group/version (e.g. route.openshift.io/v1, apps/v1). Required to disambiguate the target resource's API group." }
+          },
+          "required": ["kind", "name", "namespace", "api_version"]
         },
         "investigation_analysis": { "type": "string", "description": "Concise narrative summary of the investigation findings and reasoning (< 500 words). This field is consumed by the Phase 3 workflow selection LLM to provide investigation context." },
         "causal_chain": {
@@ -150,8 +152,9 @@ const investigationResultSchemaJSON = `{
             "kind": { "type": "string" },
             "name": { "type": "string" },
             "namespace": { "type": "string" },
-            "api_version": { "type": "string", "description": "Optional API group/version (e.g. route.openshift.io/v1) to disambiguate when multiple API groups register the same Kind." }
-          }
+            "api_version": { "type": "string", "description": "API group/version (e.g. route.openshift.io/v1, apps/v1). Required to disambiguate the target resource's API group." }
+          },
+          "required": ["kind", "name", "namespace", "api_version"]
         }
       },
       "required": ["summary"]

--- a/internal/kubernautagent/prompt/templates/incident_investigation.tmpl
+++ b/internal/kubernautagent/prompt/templates/incident_investigation.tmpl
@@ -220,7 +220,7 @@ Before calling `submit_result`, perform a comprehensive adversarial self-review 
       "kind": "Deployment",
       "name": "resource-name",
       "namespace": "namespace",
-      "api_version": "apps/v1"
+      "api_version": "apps/v1"  // REQUIRED: always provide the API group/version
     },
     "investigation_analysis": "Concise narrative of investigation findings and reasoning",
     "causal_chain": [
@@ -250,6 +250,7 @@ Before calling `submit_result`, perform a comprehensive adversarial self-review 
 **Rules**:
 - Call `submit_result` with the JSON object as the tool argument
 - root_cause_analysis.summary is always required
+- remediation_target.api_version is REQUIRED: you MUST always provide the API group/version (e.g. "apps/v1", "v1", "route.openshift.io/v1"). Every Kubernetes resource has an apiVersion — use the one you observed during investigation or your knowledge of the Kubernetes API.
 - Top-level severity must match root_cause_analysis.severity
 - confidence indicates your certainty in the root cause analysis (0.0–1.0)
 - For non-actionable outcomes, set actionable to false

--- a/internal/kubernautagent/prompt/templates/incident_investigation.tmpl
+++ b/internal/kubernautagent/prompt/templates/incident_investigation.tmpl
@@ -219,7 +219,8 @@ Before calling `submit_result`, perform a comprehensive adversarial self-review 
     "remediation_target": {
       "kind": "Deployment",
       "name": "resource-name",
-      "namespace": "namespace"
+      "namespace": "namespace",
+      "api_version": "apps/v1"
     },
     "investigation_analysis": "Concise narrative of investigation findings and reasoning",
     "causal_chain": [

--- a/internal/kubernautagent/tools/custom/resource_context.go
+++ b/internal/kubernautagent/tools/custom/resource_context.go
@@ -63,7 +63,7 @@ type clusterResponse struct {
 }
 
 func computeSpecHash(ctx context.Context, logger logr.Logger, k8s enrichment.K8sClient, kind, name, namespace, toolName string) string {
-	computed, err := k8s.GetSpecHash(ctx, kind, name, namespace)
+	computed, err := k8s.GetSpecHash(ctx, kind, name, namespace, "")
 	if err != nil {
 		logger.Info(toolName+": specHash computation failed, proceeding with empty",
 			"kind", kind, "name", name, "namespace", namespace, "error", err)
@@ -115,7 +115,7 @@ func (t *namespacedResourceContextTool) Execute(ctx context.Context, args json.R
 		return "", fmt.Errorf("parsing args: %w", err)
 	}
 
-	chain, chainErr := t.k8s.GetOwnerChain(ctx, params.Kind, params.Name, params.Namespace)
+	chain, chainErr := t.k8s.GetOwnerChain(ctx, params.Kind, params.Name, params.Namespace, "")
 	if chainErr != nil {
 		t.logger.Info("get_namespaced_resource_context: owner chain resolution failed",
 			"kind", params.Kind, "name", params.Name, "namespace", params.Namespace, "error", chainErr)

--- a/pkg/agentclient/oas_cfg_gen.go
+++ b/pkg/agentclient/oas_cfg_gen.go
@@ -4,7 +4,6 @@ package agentclient
 
 import (
 	"net/http"
-	"strings"
 
 	ht "github.com/ogen-go/ogen/http"
 	"github.com/ogen-go/ogen/middleware"
@@ -83,8 +82,18 @@ func (o otelOptionFunc) applyServer(c *serverConfig) {
 
 func newServerConfig(opts ...ServerOption) serverConfig {
 	cfg := serverConfig{
-		NotFound:           http.NotFound,
-		MethodNotAllowed:   nil,
+		NotFound: http.NotFound,
+		MethodNotAllowed: func(w http.ResponseWriter, r *http.Request, allowed string) {
+			status := http.StatusMethodNotAllowed
+			if r.Method == "OPTIONS" {
+				w.Header().Set("Access-Control-Allow-Methods", allowed)
+				w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+				status = http.StatusNoContent
+			} else {
+				w.Header().Set("Allow", allowed)
+			}
+			w.WriteHeader(status)
+		},
 		ErrorHandler:       ogenerrors.DefaultErrorHandler,
 		Middleware:         nil,
 		MaxMultipartMemory: 32 << 20, // 32 MB
@@ -107,44 +116,8 @@ func (s baseServer) notFound(w http.ResponseWriter, r *http.Request) {
 	s.cfg.NotFound(w, r)
 }
 
-type notAllowedParams struct {
-	allowedMethods string
-	allowedHeaders map[string]string
-	acceptPost     string
-	acceptPatch    string
-}
-
-func (s baseServer) notAllowed(w http.ResponseWriter, r *http.Request, params notAllowedParams) {
-	h := w.Header()
-	isOptions := r.Method == "OPTIONS"
-	if isOptions {
-		h.Set("Access-Control-Allow-Methods", params.allowedMethods)
-		if params.allowedHeaders != nil {
-			m := r.Header.Get("Access-Control-Request-Method")
-			if m != "" {
-				allowedHeaders, ok := params.allowedHeaders[strings.ToUpper(m)]
-				if ok {
-					h.Set("Access-Control-Allow-Headers", allowedHeaders)
-				}
-			}
-		}
-		if params.acceptPost != "" {
-			h.Set("Accept-Post", params.acceptPost)
-		}
-		if params.acceptPatch != "" {
-			h.Set("Accept-Patch", params.acceptPatch)
-		}
-	}
-	if s.cfg.MethodNotAllowed != nil {
-		s.cfg.MethodNotAllowed(w, r, params.allowedMethods)
-		return
-	}
-	status := http.StatusNoContent
-	if !isOptions {
-		h.Set("Allow", params.allowedMethods)
-		status = http.StatusMethodNotAllowed
-	}
-	w.WriteHeader(status)
+func (s baseServer) notAllowed(w http.ResponseWriter, r *http.Request, allowed string) {
+	s.cfg.MethodNotAllowed(w, r, allowed)
 }
 
 func (cfg serverConfig) baseServer() (s baseServer, err error) {

--- a/pkg/agentclient/oas_client_gen.go
+++ b/pkg/agentclient/oas_client_gen.go
@@ -17,7 +17,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
-	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -83,6 +83,10 @@ type Client struct {
 	serverURL *url.URL
 	baseClient
 }
+
+var _ Handler = struct {
+	*Client
+}{}
 
 // NewClient initializes new Client defined by OAS.
 func NewClient(serverURL string, opts ...ClientOption) (*Client, error) {
@@ -181,8 +185,7 @@ func (c *Client) sendGetConfigConfigGet(ctx context.Context) (res jx.Raw, err er
 	if err != nil {
 		return res, errors.Wrap(err, "do request")
 	}
-	body := resp.Body
-	defer body.Close()
+	defer resp.Body.Close()
 
 	stage = "DecodeResponse"
 	result, err := decodeGetConfigConfigGetResponse(resp)
@@ -256,8 +259,7 @@ func (c *Client) sendHealthCheckHealthzGet(ctx context.Context) (res jx.Raw, err
 	if err != nil {
 		return res, errors.Wrap(err, "do request")
 	}
-	body := resp.Body
-	defer body.Close()
+	defer resp.Body.Close()
 
 	stage = "DecodeResponse"
 	result, err := decodeHealthCheckHealthzGetResponse(resp)
@@ -339,8 +341,7 @@ func (c *Client) sendIncidentAnalyzeEndpointAPIV1IncidentAnalyzePost(ctx context
 	if err != nil {
 		return res, errors.Wrap(err, "do request")
 	}
-	body := resp.Body
-	defer body.Close()
+	defer resp.Body.Close()
 
 	stage = "DecodeResponse"
 	result, err := decodeIncidentAnalyzeEndpointAPIV1IncidentAnalyzePostResponse(resp)
@@ -432,8 +433,7 @@ func (c *Client) sendIncidentSessionResultEndpointAPIV1IncidentSessionSessionIDR
 	if err != nil {
 		return res, errors.Wrap(err, "do request")
 	}
-	body := resp.Body
-	defer body.Close()
+	defer resp.Body.Close()
 
 	stage = "DecodeResponse"
 	result, err := decodeIncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetResponse(resp)
@@ -524,8 +524,7 @@ func (c *Client) sendIncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDG
 	if err != nil {
 		return res, errors.Wrap(err, "do request")
 	}
-	body := resp.Body
-	defer body.Close()
+	defer resp.Body.Close()
 
 	stage = "DecodeResponse"
 	result, err := decodeIncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetResponse(resp)
@@ -601,8 +600,7 @@ func (c *Client) sendReadinessCheckReadyzGet(ctx context.Context) (res jx.Raw, e
 	if err != nil {
 		return res, errors.Wrap(err, "do request")
 	}
-	body := resp.Body
-	defer body.Close()
+	defer resp.Body.Close()
 
 	stage = "DecodeResponse"
 	result, err := decodeReadinessCheckReadyzGetResponse(resp)

--- a/pkg/agentclient/oas_handlers_gen.go
+++ b/pkg/agentclient/oas_handlers_gen.go
@@ -16,7 +16,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
-	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
 	"go.opentelemetry.io/otel/trace"
 )
 
@@ -49,8 +49,6 @@ func (s *Server) handleGetConfigConfigGetRequest(args [0]string, argsEscaped boo
 		semconv.HTTPRequestMethodKey.String("GET"),
 		semconv.HTTPRouteKey.String("/config"),
 	}
-	// Add attributes from config.
-	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), GetConfigConfigGetOperation,
@@ -174,8 +172,6 @@ func (s *Server) handleHealthCheckHealthzGetRequest(args [0]string, argsEscaped 
 		semconv.HTTPRequestMethodKey.String("GET"),
 		semconv.HTTPRouteKey.String("/healthz"),
 	}
-	// Add attributes from config.
-	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), HealthCheckHealthzGetOperation,
@@ -304,8 +300,6 @@ func (s *Server) handleIncidentAnalyzeEndpointAPIV1IncidentAnalyzePostRequest(ar
 		semconv.HTTPRequestMethodKey.String("POST"),
 		semconv.HTTPRouteKey.String("/api/v1/incident/analyze"),
 	}
-	// Add attributes from config.
-	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), IncidentAnalyzeEndpointAPIV1IncidentAnalyzePostOperation,
@@ -447,8 +441,6 @@ func (s *Server) handleIncidentSessionResultEndpointAPIV1IncidentSessionSessionI
 		semconv.HTTPRequestMethodKey.String("GET"),
 		semconv.HTTPRouteKey.String("/api/v1/incident/session/{session_id}/result"),
 	}
-	// Add attributes from config.
-	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetOperation,
@@ -590,8 +582,6 @@ func (s *Server) handleIncidentSessionStatusEndpointAPIV1IncidentSessionSessionI
 		semconv.HTTPRequestMethodKey.String("GET"),
 		semconv.HTTPRouteKey.String("/api/v1/incident/session/{session_id}"),
 	}
-	// Add attributes from config.
-	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetOperation,
@@ -736,8 +726,6 @@ func (s *Server) handleReadinessCheckReadyzGetRequest(args [0]string, argsEscape
 		semconv.HTTPRequestMethodKey.String("GET"),
 		semconv.HTTPRouteKey.String("/readyz"),
 	}
-	// Add attributes from config.
-	otelAttrs = append(otelAttrs, s.cfg.Attributes...)
 
 	// Start a span for this request.
 	ctx, span := s.cfg.Tracer.Start(r.Context(), ReadinessCheckReadyzGetOperation,

--- a/pkg/agentclient/oas_router_gen.go
+++ b/pkg/agentclient/oas_router_gen.go
@@ -10,12 +10,6 @@ import (
 	"github.com/ogen-go/ogen/uri"
 )
 
-var (
-	rn4AllowedHeaders = map[string]string{
-		"POST": "Content-Type",
-	}
-)
-
 func (s *Server) cutPrefix(path string) (string, bool) {
 	prefix := s.cfg.Prefix
 	if prefix == "" {
@@ -93,12 +87,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 						case "POST":
 							s.handleIncidentAnalyzeEndpointAPIV1IncidentAnalyzePostRequest([0]string{}, elemIsEscaped, w, r)
 						default:
-							s.notAllowed(w, r, notAllowedParams{
-								allowedMethods: "POST",
-								allowedHeaders: rn4AllowedHeaders,
-								acceptPost:     "application/json",
-								acceptPatch:    "",
-							})
+							s.notAllowed(w, r, "POST")
 						}
 
 						return
@@ -128,12 +117,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 								args[0],
 							}, elemIsEscaped, w, r)
 						default:
-							s.notAllowed(w, r, notAllowedParams{
-								allowedMethods: "GET",
-								allowedHeaders: nil,
-								acceptPost:     "",
-								acceptPatch:    "",
-							})
+							s.notAllowed(w, r, "GET")
 						}
 
 						return
@@ -155,12 +139,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 									args[0],
 								}, elemIsEscaped, w, r)
 							default:
-								s.notAllowed(w, r, notAllowedParams{
-									allowedMethods: "GET",
-									allowedHeaders: nil,
-									acceptPost:     "",
-									acceptPatch:    "",
-								})
+								s.notAllowed(w, r, "GET")
 							}
 
 							return
@@ -184,12 +163,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					case "GET":
 						s.handleGetConfigConfigGetRequest([0]string{}, elemIsEscaped, w, r)
 					default:
-						s.notAllowed(w, r, notAllowedParams{
-							allowedMethods: "GET",
-							allowedHeaders: nil,
-							acceptPost:     "",
-							acceptPatch:    "",
-						})
+						s.notAllowed(w, r, "GET")
 					}
 
 					return
@@ -209,12 +183,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					case "GET":
 						s.handleHealthCheckHealthzGetRequest([0]string{}, elemIsEscaped, w, r)
 					default:
-						s.notAllowed(w, r, notAllowedParams{
-							allowedMethods: "GET",
-							allowedHeaders: nil,
-							acceptPost:     "",
-							acceptPatch:    "",
-						})
+						s.notAllowed(w, r, "GET")
 					}
 
 					return
@@ -234,12 +203,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 					case "GET":
 						s.handleReadinessCheckReadyzGetRequest([0]string{}, elemIsEscaped, w, r)
 					default:
-						s.notAllowed(w, r, notAllowedParams{
-							allowedMethods: "GET",
-							allowedHeaders: nil,
-							acceptPost:     "",
-							acceptPatch:    "",
-						})
+						s.notAllowed(w, r, "GET")
 					}
 
 					return

--- a/pkg/aianalysis/handlers/response_processor.go
+++ b/pkg/aianalysis/handlers/response_processor.go
@@ -840,11 +840,13 @@ func ExtractRootCauseAnalysis(rcaData interface{}) *aianalysisv1.RootCauseAnalys
 			kind, _ := arMap["kind"].(string)
 			name, _ := arMap["name"].(string)
 			ns, _ := arMap["namespace"].(string)
+			apiVersion, _ := arMap["api_version"].(string) // #1040
 			if kind != "" && name != "" {
 				rca.RemediationTarget = &aianalysisv1.RemediationTarget{
-					Kind:      kind,
-					Name:      name,
-					Namespace: ns,
+					Kind:       kind,
+					Name:       name,
+					Namespace:  ns,
+					APIVersion: apiVersion,
 				}
 			}
 		}

--- a/pkg/audit/openapi_spec_data.yaml
+++ b/pkg/audit/openapi_spec_data.yaml
@@ -3995,6 +3995,10 @@ components:
           type: string
           description: Version of the workflow being executed
           example: "v1.0.0"
+        workflow_name:
+          type: string
+          description: Human-readable name of the selected workflow from the DataStorage catalog. Optional; present only when the catalog provides a name.
+          example: "fix-security-context-job"
         target_resource:
           type: string
           description: Kubernetes resource being acted upon (format depends on scope)

--- a/pkg/datastorage/server/middleware/openapi_spec_data.yaml
+++ b/pkg/datastorage/server/middleware/openapi_spec_data.yaml
@@ -3995,6 +3995,10 @@ components:
           type: string
           description: Version of the workflow being executed
           example: "v1.0.0"
+        workflow_name:
+          type: string
+          description: Human-readable name of the selected workflow from the DataStorage catalog. Optional; present only when the catalog provides a name.
+          example: "fix-security-context-job"
         target_resource:
           type: string
           description: Kubernetes resource being acted upon (format depends on scope)

--- a/pkg/kubernautagent/types/types.go
+++ b/pkg/kubernautagent/types/types.go
@@ -124,6 +124,11 @@ type RemediationTarget struct {
 	Kind      string `json:"kind"`
 	Name      string `json:"name"`
 	Namespace string `json:"namespace"`
+	// APIVersion disambiguates the resource's API group when the Kind exists
+	// in multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+	// Format: "group/version" (e.g. "route.openshift.io/v1") or "version" for core (e.g. "v1").
+	// Issue #1040.
+	APIVersion string `json:"api_version,omitempty"`
 }
 
 // SignalContext holds the input signal data for an investigation.

--- a/pkg/remediationorchestrator/creator/aianalysis.go
+++ b/pkg/remediationorchestrator/creator/aianalysis.go
@@ -181,9 +181,10 @@ func (c *AIAnalysisCreator) buildSignalContext(
 		Environment:      environment,
 		BusinessPriority: priority,
 		TargetResource: aianalysisv1.TargetResource{
-			Kind:      rr.Spec.TargetResource.Kind,
-			Name:      rr.Spec.TargetResource.Name,
-			Namespace: rr.Spec.TargetResource.Namespace,
+			Kind:       rr.Spec.TargetResource.Kind,
+			Name:       rr.Spec.TargetResource.Name,
+			Namespace:  rr.Spec.TargetResource.Namespace,
+			APIVersion: rr.Spec.TargetResource.APIVersion, // #1040
 		},
 		// EnrichmentResults from SignalProcessing status (BR-ORCH-025)
 		EnrichmentResults: c.buildEnrichmentResults(sp),

--- a/pkg/remediationorchestrator/creator/effectivenessassessment.go
+++ b/pkg/remediationorchestrator/creator/effectivenessassessment.go
@@ -134,9 +134,10 @@ func (c *EffectivenessAssessmentCreator) CreateEffectivenessAssessment(
 
 	// DD-EM-003: Resolve signal and remediation targets.
 	signalTarget := eav1.TargetResource{
-		Kind:      rr.Spec.TargetResource.Kind,
-		Name:      rr.Spec.TargetResource.Name,
-		Namespace: rr.Spec.TargetResource.Namespace,
+		Kind:       rr.Spec.TargetResource.Kind,
+		Name:       rr.Spec.TargetResource.Name,
+		Namespace:  rr.Spec.TargetResource.Namespace,
+		APIVersion: rr.Spec.TargetResource.APIVersion, // #1040
 	}
 	remediationTarget := signalTarget
 	if dualTarget != nil {

--- a/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
@@ -186,6 +186,11 @@ spec:
                                     {Namespace: \"prod\", Kind: \"Deployment\", Name:
                                     \"api\"}"
                                   properties:
+                                    api_version:
+                                      description: |-
+                                        APIVersion of the owner resource from OwnerReference (e.g. "apps/v1").
+                                        Issue #1040.
+                                      type: string
                                     kind:
                                       description: Kind of the owner resource (e.g.,
                                         ReplicaSet, Deployment, StatefulSet, DaemonSet)
@@ -279,6 +284,12 @@ spec:
                       targetResource:
                         description: Target resource identification
                         properties:
+                          apiVersion:
+                            description: |-
+                              APIVersion disambiguates the resource's API group when the Kind exists in
+                              multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                              Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                            type: string
                           kind:
                             description: Resource kind (e.g., Pod, Deployment, StatefulSet)
                             type: string
@@ -870,6 +881,12 @@ spec:
                       the Pod that generated the signal. The WFE creator should prefer this over the RR's
                       TargetResource when available to ensure the correct resource is patched.
                     properties:
+                      apiVersion:
+                        description: |-
+                          APIVersion disambiguates the resource's API group when the Kind exists in
+                          multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                          Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                        type: string
                       kind:
                         description: Kind is the Kubernetes resource kind (e.g., "Deployment",
                           "StatefulSet", "DaemonSet")

--- a/pkg/shared/assets/crds/kubernaut.ai_effectivenessassessments.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_effectivenessassessments.yaml
@@ -138,6 +138,12 @@ spec:
                   Source: AA.Status.RootCauseAnalysis.RemediationTarget (from HAPI RCA resolution).
                   Used by: spec hash computation, drift detection (DD-EM-003).
                 properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion disambiguates the resource's API group when the Kind exists in
+                      multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                      Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                    type: string
                   kind:
                     description: Kind is the Kubernetes resource kind (e.g., "Deployment",
                       "StatefulSet").
@@ -167,6 +173,12 @@ spec:
                   Source: RR.Spec.TargetResource (from Gateway alert extraction).
                   Used by: health assessment, alert resolution, metrics queries (DD-EM-003).
                 properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion disambiguates the resource's API group when the Kind exists in
+                      multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                      Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                    type: string
                   kind:
                     description: Kind is the Kubernetes resource kind (e.g., "Deployment",
                       "StatefulSet").

--- a/pkg/shared/assets/crds/kubernaut.ai_remediationrequests.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_remediationrequests.yaml
@@ -181,6 +181,12 @@ spec:
                   Used by SignalProcessing for context enrichment and RO for workflow routing.
                   For Kubernetes signals, this contains Kind, Name, Namespace of the affected resource.
                 properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion disambiguates the resource's API group when the Kind exists in
+                      multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                      Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                    type: string
                   kind:
                     description: Kind of the Kubernetes resource (e.g., "Pod", "Deployment",
                       "Node", "StatefulSet")
@@ -854,6 +860,12 @@ spec:
                   May differ from Spec.TargetResource (e.g., Deployment vs Pod).
                   Reference: BR-HAPI-191, Issue #387
                 properties:
+                  apiVersion:
+                    description: |-
+                      APIVersion disambiguates the resource's API group when the Kind exists in
+                      multiple groups (e.g. Route in route.openshift.io vs serving.knative.dev).
+                      Format: "group/version" (e.g. "route.openshift.io/v1"). Issue #1040.
+                    type: string
                   kind:
                     description: Kind of the Kubernetes resource (e.g., "Pod", "Deployment",
                       "Node", "StatefulSet")

--- a/pkg/shared/assets/crds/kubernaut.ai_signalprocessings.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_signalprocessings.yaml
@@ -393,6 +393,11 @@ spec:
                         Kind: \"ReplicaSet\", Name: \"api-7d8f9c6b5\"}\n\t[1]: {Namespace:
                         \"prod\", Kind: \"Deployment\", Name: \"api\"}"
                       properties:
+                        api_version:
+                          description: |-
+                            APIVersion of the owner resource from OwnerReference (e.g. "apps/v1").
+                            Issue #1040.
+                          type: string
                         kind:
                           description: Kind of the owner resource (e.g., ReplicaSet,
                             Deployment, StatefulSet, DaemonSet)

--- a/pkg/shared/k8s/gvk.go
+++ b/pkg/shared/k8s/gvk.go
@@ -67,3 +67,23 @@ func ResolveGVKForKind(mapper meta.RESTMapper, kind string) (schema.GroupVersion
 
 	return schema.GroupVersionKind{}, fmt.Errorf("cannot resolve GVK for kind %q", kind)
 }
+
+// ResolveGVKWithAPIVersion resolves a Kind to its GVK using an explicit apiVersion
+// when provided (e.g. "route.openshift.io/v1"), bypassing the static table and
+// plural-guess heuristic. When apiVersion is empty, falls back to ResolveGVKForKind.
+// Issue #1040: this eliminates ambiguity when multiple API groups register the
+// same Kind (e.g. Route in route.openshift.io vs serving.knative.dev).
+func ResolveGVKWithAPIVersion(mapper meta.RESTMapper, kind, apiVersion string) (schema.GroupVersionKind, error) {
+	if apiVersion != "" {
+		gv, err := schema.ParseGroupVersion(apiVersion)
+		if err != nil {
+			return schema.GroupVersionKind{}, fmt.Errorf("invalid apiVersion %q: %w", apiVersion, err)
+		}
+		mapping, err := mapper.RESTMapping(schema.GroupKind{Group: gv.Group, Kind: kind}, gv.Version)
+		if err != nil {
+			return schema.GroupVersionKind{}, fmt.Errorf("kind %q not found in apiVersion %q: %w", kind, apiVersion, err)
+		}
+		return mapping.GroupVersionKind, nil
+	}
+	return ResolveGVKForKind(mapper, kind)
+}

--- a/pkg/shared/types/enrichment.go
+++ b/pkg/shared/types/enrichment.go
@@ -107,6 +107,9 @@ type OwnerChainEntry struct {
 	Kind string `json:"kind"`
 	// Name of the owner resource
 	Name string `json:"name"`
+	// APIVersion of the owner resource from OwnerReference (e.g. "apps/v1").
+	// Issue #1040.
+	APIVersion string `json:"api_version,omitempty"`
 }
 
 // ========================================

--- a/test/integration/kubernautagent/enrichment/enrichment_real_ds_test.go
+++ b/test/integration/kubernautagent/enrichment/enrichment_real_ds_test.go
@@ -145,7 +145,7 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 			insertEMEvents(corrID2, "Full", 0.90, "sha256:pre1", "sha256:post2", now.Add(30*time.Minute))
 
 			By("Calling enricher with real infrastructure")
-			result, err := enricher.Enrich(testCtx, "Pod", "web-pod-1", "it-enrichment", "sha256:pre1", "incident-enr001-"+testID)
+			result, err := enricher.Enrich(testCtx, "Pod", "web-pod-1", "it-enrichment", "", "sha256:pre1", "incident-enr001-"+testID)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Asserting owner chain from real K8s (envtest)")
@@ -190,7 +190,7 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 			incidentID := "incident-enr002-" + testID
 
 			By("Calling enricher with empty specHash for known K8s resource")
-			result, err := enricher.Enrich(testCtx, "Pod", "web-pod-1", "it-enrichment", "", incidentID)
+			result, err := enricher.Enrich(testCtx, "Pod", "web-pod-1", "it-enrichment", "", "", incidentID)
 			Expect(err).ToNot(HaveOccurred(),
 				"enricher should handle specHash auto-computation gracefully")
 
@@ -239,7 +239,7 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 			insertEMEvents(corrID, "Full", 0.88, "sha256:pre3", "sha256:post3", now)
 
 			By("Calling enricher (triggers audit event)")
-			_, err := enricher.Enrich(testCtx, "Pod", "web-pod-1", "it-enrichment", "sha256:pre3", incidentID)
+			_, err := enricher.Enrich(testCtx, "Pod", "web-pod-1", "it-enrichment", "", "sha256:pre3", incidentID)
 			Expect(err).ToNot(HaveOccurred())
 
 			By("Querying audit_events table for enrichment.completed event")
@@ -278,7 +278,7 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 				logr.Discard())
 
 			By("Calling broken enricher")
-			result, err := brokenEnricher.Enrich(testCtx, "Pod", "broken-pod-"+testID, "it-enrichment", "", incidentID)
+			result, err := brokenEnricher.Enrich(testCtx, "Pod", "broken-pod-"+testID, "it-enrichment", "", "", incidentID)
 			Expect(err).ToNot(HaveOccurred(), "enricher handles failure gracefully")
 			Expect(result.OwnerChain).To(BeEmpty(), "K8s failed so owner chain should be empty")
 			Expect(result.RemediationHistory).To(BeNil(), "DS failed so history should be nil")
@@ -327,7 +327,7 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 				logr.Discard())
 
 			By("Calling enricher")
-			result, err := partialEnricher.Enrich(testCtx, "StatefulSet", "redis-"+testID, "it-enrichment", "sha256:pre5", incidentID)
+			result, err := partialEnricher.Enrich(testCtx, "StatefulSet", "redis-"+testID, "it-enrichment", "", "sha256:pre5", incidentID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.OwnerChain).To(BeEmpty(), "K8s failed so owner chain should be empty")
 			Expect(result.RemediationHistory.Tier1).To(HaveLen(1), "DS succeeded so history should have 1 Tier1 entry")
@@ -361,7 +361,7 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 			ghostName := "ghost-" + testID
 
 			By("Calling enricher for a target with no seeded data")
-			result, err := enricher.Enrich(testCtx, "Deployment", ghostName, "it-enrichment", "sha256:none", incidentID)
+			result, err := enricher.Enrich(testCtx, "Deployment", ghostName, "it-enrichment", "", "sha256:none", incidentID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.RemediationHistory.Tier1).To(BeEmpty(), "no seeded data means empty Tier1 history")
 
@@ -398,7 +398,7 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 				logr.Discard())
 
 			By("Calling enricher")
-			result, err := partialEnricher.Enrich(testCtx, "Pod", "web-pod-1", "it-enrichment", "sha256:test7", incidentID)
+			result, err := partialEnricher.Enrich(testCtx, "Pod", "web-pod-1", "it-enrichment", "", "sha256:test7", incidentID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.OwnerChain).To(HaveLen(2),
 				"K8s succeeded so owner chain should be populated")
@@ -488,7 +488,7 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 				now.Add(5*time.Minute))
 
 			By("Calling enricher")
-			result, err := enricher.Enrich(testCtx, "Pod", "web-pod-1", "it-enrichment", "sha256:pre8", "incident-enr008-"+testID)
+			result, err := enricher.Enrich(testCtx, "Pod", "web-pod-1", "it-enrichment", "", "sha256:pre8", "incident-enr008-"+testID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.RemediationHistory.Tier1).To(HaveLen(1))
 
@@ -531,7 +531,7 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 			insertEMEvents(corrID, "Full", 0.90, "sha256:old9", "sha256:current9", now)
 
 			By("Calling enricher with currentSpecHash=sha256:old9 (matches preHash → regression)")
-			result1, err := enricher.Enrich(testCtx, "Pod", "web-pod-1", "it-enrichment", "sha256:old9", "incident-enr009a-"+testID)
+			result1, err := enricher.Enrich(testCtx, "Pod", "web-pod-1", "it-enrichment", "", "sha256:old9", "incident-enr009a-"+testID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result1.RemediationHistory.Tier1).To(HaveLen(1))
 			Expect(result1.RemediationHistory.RegressionDetected).To(BeTrue(),
@@ -539,7 +539,7 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 			Expect(result1.RemediationHistory.Tier1[0].HashMatch).To(Equal("preRemediation"))
 
 			By("Calling enricher with currentSpecHash=sha256:novel (matches nothing → no results, no regression)")
-			result2, err := enricher.Enrich(testCtx, "Pod", "web-pod-1", "it-enrichment", "sha256:novel", "incident-enr009b-"+testID)
+			result2, err := enricher.Enrich(testCtx, "Pod", "web-pod-1", "it-enrichment", "", "sha256:novel", "incident-enr009b-"+testID)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result2.RemediationHistory.Tier1).To(BeEmpty(),
 				"no RO events match sha256:novel as preHash")
@@ -554,11 +554,11 @@ type errorK8sClient struct {
 	err error
 }
 
-func (e *errorK8sClient) GetOwnerChain(_ context.Context, _, _, _ string) ([]enrichment.OwnerChainEntry, error) {
+func (e *errorK8sClient) GetOwnerChain(_ context.Context, _, _, _, _ string) ([]enrichment.OwnerChainEntry, error) {
 	return nil, e.err
 }
 
-func (e *errorK8sClient) GetSpecHash(_ context.Context, _, _, _ string) (string, error) {
+func (e *errorK8sClient) GetSpecHash(_ context.Context, _, _, _, _ string) (string, error) {
 	return "", e.err
 }
 

--- a/test/integration/kubernautagent/investigator/detected_labels_it_test.go
+++ b/test/integration/kubernautagent/investigator/detected_labels_it_test.go
@@ -429,7 +429,7 @@ var _ = Describe("KA-KA Integration Parity — Detected Labels (TP-433-PARITY)",
 			dsClient := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
 			enricher := enrichment.NewEnricher(k8sClient, dsClient, auditStore, invLogger).WithLabelDetector(ld)
 
-			result, err := enricher.Enrich(context.Background(), "Pod", "web-app-xyz", "constrained", "", "inc-1")
+			result, err := enricher.Enrich(context.Background(), "Pod", "web-app-xyz", "constrained", "", "", "inc-1")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 			Expect(result.DetectedLabels).NotTo(BeNil())

--- a/test/integration/kubernautagent/investigator/investigator_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_test.go
@@ -86,11 +86,11 @@ type fakeK8sClient struct {
 	err        error
 }
 
-func (f *fakeK8sClient) GetOwnerChain(_ context.Context, _, _, _ string) ([]enrichment.OwnerChainEntry, error) {
+func (f *fakeK8sClient) GetOwnerChain(_ context.Context, _, _, _, _ string) ([]enrichment.OwnerChainEntry, error) {
 	return f.ownerChain, f.err
 }
 
-func (f *fakeK8sClient) GetSpecHash(_ context.Context, _, _, _ string) (string, error) {
+func (f *fakeK8sClient) GetSpecHash(_ context.Context, _, _, _, _ string) (string, error) {
 	return "", nil
 }
 
@@ -100,14 +100,14 @@ type resourceAwareK8sClient struct {
 	chains map[string][]enrichment.OwnerChainEntry
 }
 
-func (r *resourceAwareK8sClient) GetOwnerChain(_ context.Context, _, name, _ string) ([]enrichment.OwnerChainEntry, error) {
+func (r *resourceAwareK8sClient) GetOwnerChain(_ context.Context, _, name, _, _ string) ([]enrichment.OwnerChainEntry, error) {
 	if chain, ok := r.chains[name]; ok {
 		return chain, nil
 	}
 	return nil, nil
 }
 
-func (r *resourceAwareK8sClient) GetSpecHash(_ context.Context, _, _, _ string) (string, error) {
+func (r *resourceAwareK8sClient) GetSpecHash(_ context.Context, _, _, _, _ string) (string, error) {
 	return "", nil
 }
 

--- a/test/services/mock-llm/response/openai.go
+++ b/test/services/mock-llm/response/openai.go
@@ -201,11 +201,15 @@ func analysisJSON(cfg scenarios.MockScenarioConfig) map[string]interface{} {
 		"contributing_factors": contributingSlice(cfg),
 	}
 	if cfg.ResourceKind != "" {
-		rca["remediation_target"] = map[string]string{
+		rt := map[string]string{
 			"kind":      cfg.ResourceKind,
 			"name":      cfg.ResourceName,
 			"namespace": cfg.ResourceNS,
 		}
+		if cfg.APIVersion != "" {
+			rt["api_version"] = cfg.APIVersion // #1040
+		}
+		rca["remediation_target"] = rt
 	}
 
 	obj := map[string]interface{}{

--- a/test/unit/kubernautagent/enrichment/enricher_retry_test.go
+++ b/test/unit/kubernautagent/enrichment/enricher_retry_test.go
@@ -40,7 +40,7 @@ type countingK8sClient struct {
 	chainSeq [][]enrichment.OwnerChainEntry
 }
 
-func (c *countingK8sClient) GetOwnerChain(_ context.Context, _, _, _ string) ([]enrichment.OwnerChainEntry, error) {
+func (c *countingK8sClient) GetOwnerChain(_ context.Context, _, _, _, _ string) ([]enrichment.OwnerChainEntry, error) {
 	idx := int(atomic.AddInt32(&c.calls, 1) - 1)
 	var err error
 	if idx < len(c.errSeq) {
@@ -57,7 +57,7 @@ func (c *countingK8sClient) GetOwnerChain(_ context.Context, _, _, _ string) ([]
 	return nil, nil
 }
 
-func (c *countingK8sClient) GetSpecHash(_ context.Context, _, _, _ string) (string, error) {
+func (c *countingK8sClient) GetSpecHash(_ context.Context, _, _, _, _ string) (string, error) {
 	return "", nil
 }
 
@@ -91,7 +91,7 @@ var _ = Describe("Enricher Retry Infrastructure — BR-HAPI-261/264 #704", func(
 					BaseBackoff: 1 * time.Millisecond,
 				})
 
-			result, err := e.Enrich(ctx, "Pod", "test-pod", "production", "", "inc-001")
+			result, err := e.Enrich(ctx, "Pod", "test-pod", "production", "", "", "inc-001")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 
@@ -120,7 +120,7 @@ var _ = Describe("Enricher Retry Infrastructure — BR-HAPI-261/264 #704", func(
 					BaseBackoff: 1 * time.Millisecond,
 				})
 
-			result, err := e.Enrich(ctx, "Pod", "test-pod", "production", "", "inc-002")
+			result, err := e.Enrich(ctx, "Pod", "test-pod", "production", "", "", "inc-002")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 
@@ -148,7 +148,7 @@ var _ = Describe("Enricher Retry Infrastructure — BR-HAPI-261/264 #704", func(
 					BaseBackoff: 1 * time.Millisecond,
 				})
 
-			result, err := e.Enrich(ctx, "Pod", "test-pod", "production", "", "inc-003")
+			result, err := e.Enrich(ctx, "Pod", "test-pod", "production", "", "", "inc-003")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 
@@ -174,7 +174,7 @@ var _ = Describe("Enricher Retry Infrastructure — BR-HAPI-261/264 #704", func(
 					BaseBackoff: 1 * time.Millisecond,
 				})
 
-			result, err := e.Enrich(ctx, "Pod", "test-pod", "production", "", "inc-005")
+			result, err := e.Enrich(ctx, "Pod", "test-pod", "production", "", "", "inc-005")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 
@@ -195,7 +195,7 @@ var _ = Describe("Enricher Retry Infrastructure — BR-HAPI-261/264 #704", func(
 			}
 			e := enrichment.NewEnricher(k8s, ds, auditStore, logger)
 
-			result, err := e.Enrich(ctx, "Pod", "test-pod", "production", "", "inc-004")
+			result, err := e.Enrich(ctx, "Pod", "test-pod", "production", "", "", "inc-004")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 
@@ -223,7 +223,7 @@ var _ = Describe("Enricher Retry Infrastructure — BR-HAPI-261/264 #704", func(
 					BaseBackoff: 1 * time.Millisecond,
 				})
 
-			result, err := e.Enrich(ctx, "Certificate", "demo-app-cert", "default", "", "inc-006")
+			result, err := e.Enrich(ctx, "Certificate", "demo-app-cert", "default", "", "", "inc-006")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 
@@ -245,7 +245,7 @@ var _ = Describe("Enricher Retry Infrastructure — BR-HAPI-261/264 #704", func(
 					BaseBackoff: 1 * time.Millisecond,
 				})
 
-			result, err := e.Enrich(ctx, "Pod", "unreachable-pod", "default", "", "inc-006b")
+			result, err := e.Enrich(ctx, "Pod", "unreachable-pod", "default", "", "", "inc-006b")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 

--- a/test/unit/kubernautagent/enrichment/enrichment_test.go
+++ b/test/unit/kubernautagent/enrichment/enrichment_test.go
@@ -199,7 +199,7 @@ var _ = Describe("Kubernaut Agent Enrichment — #433", func() {
 	Describe("UT-KA-433-134: K8sClient.GetOwnerChain returns []OwnerChainEntry", func() {
 		It("should compile with []OwnerChainEntry return type", func() {
 			var client enrichment.K8sClient = &fakeK8s{}
-			chain, err := client.GetOwnerChain(nil, "Pod", "web-abc", "default")
+			chain, err := client.GetOwnerChain(nil, "Pod", "web-abc", "default", "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(chain).To(HaveLen(1))
 			Expect(chain[0].Kind).To(Equal("Deployment"))
@@ -231,7 +231,7 @@ var _ = Describe("Kubernaut Agent Enricher Coordination — #433 (reclassified f
 				history: &enrichment.RemediationHistoryResult{},
 			}
 			e := enrichment.NewEnricher(k8s, ds, auditStore, logger)
-			result, err := e.Enrich(context.Background(), "Pod", "api-server-abc-xyz", "production", "", "")
+			result, err := e.Enrich(context.Background(), "Pod", "api-server-abc-xyz", "production", "", "", "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil(), "Enrich should return a result")
 			Expect(result.OwnerChain).To(HaveLen(3))
@@ -253,7 +253,7 @@ var _ = Describe("Kubernaut Agent Enricher Coordination — #433 (reclassified f
 				},
 			}
 			e := enrichment.NewEnricher(k8s, ds, auditStore, logger)
-			result, err := e.Enrich(context.Background(), "Pod", "api-server-abc", "production", "", "")
+			result, err := e.Enrich(context.Background(), "Pod", "api-server-abc", "production", "", "", "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 			Expect(result.RemediationHistory).NotTo(BeNil())
@@ -273,7 +273,7 @@ var _ = Describe("Kubernaut Agent Enricher Coordination — #433 (reclassified f
 				},
 			}
 			e := enrichment.NewEnricher(k8s, ds, auditStore, logger)
-			result, err := e.Enrich(context.Background(), "Pod", "api-server-abc", "production", "", "")
+			result, err := e.Enrich(context.Background(), "Pod", "api-server-abc", "production", "", "", "")
 			Expect(err).NotTo(HaveOccurred(), "partial failure should not return error")
 			Expect(result).NotTo(BeNil())
 			Expect(result.OwnerChain).To(BeEmpty(), "owner chain should be empty on failure")
@@ -292,7 +292,7 @@ var _ = Describe("Kubernaut Agent Enricher Coordination — #433 (reclassified f
 				history: &enrichment.RemediationHistoryResult{},
 			}
 			e := enrichment.NewEnricher(k8s, ds, auditStore, logger)
-			_, err := e.Enrich(context.Background(), "Deployment", "api-server", "default", "", "")
+			_, err := e.Enrich(context.Background(), "Deployment", "api-server", "default", "", "", "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ds.capturedSpecHash).To(Equal("sha256:auto-computed-hash"),
 				"enricher should auto-compute specHash when empty and forward to DS")
@@ -307,7 +307,7 @@ var _ = Describe("Kubernaut Agent Enricher Coordination — #433 (reclassified f
 				history: &enrichment.RemediationHistoryResult{},
 			}
 			e := enrichment.NewEnricher(k8s, ds, auditStore, logger)
-			_, err := e.Enrich(context.Background(), "Deployment", "api-server", "default", "sha256:caller-provided", "")
+			_, err := e.Enrich(context.Background(), "Deployment", "api-server", "default", "", "sha256:caller-provided", "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ds.capturedSpecHash).To(Equal("sha256:caller-provided"),
 				"enricher should not override caller-provided specHash")
@@ -322,7 +322,7 @@ var _ = Describe("Kubernaut Agent Enricher Coordination — #433 (reclassified f
 				history: &enrichment.RemediationHistoryResult{},
 			}
 			e := enrichment.NewEnricher(k8s, ds, auditStore, logger)
-			result, err := e.Enrich(context.Background(), "Deployment", "api-server", "default", "", "")
+			result, err := e.Enrich(context.Background(), "Deployment", "api-server", "default", "", "", "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 			Expect(ds.capturedSpecHash).To(BeEmpty(),
@@ -335,7 +335,7 @@ var _ = Describe("Kubernaut Agent Enricher Coordination — #433 (reclassified f
 			k8s := &fakeK8sClient{ownerChain: []enrichment.OwnerChainEntry{}}
 			ds := &fakeDataStorageClient{history: &enrichment.RemediationHistoryResult{}}
 			e := enrichment.NewEnricher(k8s, ds, auditStore, logger)
-			result, err := e.Enrich(context.Background(), "Deployment", "worker", "demo-crashloop", "", "inc-1")
+			result, err := e.Enrich(context.Background(), "Deployment", "worker", "demo-crashloop", "", "", "inc-1")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 			Expect(result.ResourceKind).To(Equal("Deployment"),
@@ -359,7 +359,7 @@ var _ = Describe("Kubernaut Agent Enricher Coordination — #433 (reclassified f
 				},
 			}}
 			e := enrichment.NewEnricher(k8s, ds, auditStore, logger)
-			_, err := e.Enrich(context.Background(), "Pod", "api-server-abc", "production", "", "test-incident-001")
+			_, err := e.Enrich(context.Background(), "Pod", "api-server-abc", "production", "", "", "test-incident-001")
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(auditStore.events).To(HaveLen(1))
@@ -381,7 +381,7 @@ var _ = Describe("Kubernaut Agent Enricher Coordination — #433 (reclassified f
 			k8s := &fakeK8sClient{err: errors.New("K8s down")}
 			ds := &fakeDataStorageClient{err: errors.New("DS down")}
 			e := enrichment.NewEnricher(k8s, ds, auditStore, logger)
-			_, err := e.Enrich(context.Background(), "Pod", "api-server-abc", "production", "", "test-incident-002")
+			_, err := e.Enrich(context.Background(), "Pod", "api-server-abc", "production", "", "", "test-incident-002")
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(auditStore.events).To(HaveLen(1))
@@ -412,11 +412,11 @@ func (f *fakeDS) GetRemediationHistory(_ context.Context, _, _, _, _ string) (*e
 // fakeK8s satisfies the updated K8sClient interface for compile-time verification.
 type fakeK8s struct{}
 
-func (f *fakeK8s) GetOwnerChain(_ context.Context, _, _, _ string) ([]enrichment.OwnerChainEntry, error) {
+func (f *fakeK8s) GetOwnerChain(_ context.Context, _, _, _, _ string) ([]enrichment.OwnerChainEntry, error) {
 	return []enrichment.OwnerChainEntry{{Kind: "Deployment", Name: "api-server", Namespace: "default"}}, nil
 }
 
-func (f *fakeK8s) GetSpecHash(_ context.Context, _, _, _ string) (string, error) {
+func (f *fakeK8s) GetSpecHash(_ context.Context, _, _, _, _ string) (string, error) {
 	return "", nil
 }
 
@@ -438,11 +438,11 @@ type fakeK8sClient struct {
 	err         error
 }
 
-func (f *fakeK8sClient) GetOwnerChain(_ context.Context, _, _, _ string) ([]enrichment.OwnerChainEntry, error) {
+func (f *fakeK8sClient) GetOwnerChain(_ context.Context, _, _, _, _ string) ([]enrichment.OwnerChainEntry, error) {
 	return f.ownerChain, f.err
 }
 
-func (f *fakeK8sClient) GetSpecHash(_ context.Context, _, _, _ string) (string, error) {
+func (f *fakeK8sClient) GetSpecHash(_ context.Context, _, _, _, _ string) (string, error) {
 	return f.specHash, f.specHashErr
 }
 

--- a/test/unit/kubernautagent/enrichment/k8s_adapter_test.go
+++ b/test/unit/kubernautagent/enrichment/k8s_adapter_test.go
@@ -57,7 +57,7 @@ var _ = Describe("K8s Owner-Chain Adapter — TP-433-WIR Phase 1b", func() {
 			mapper := newSimpleRESTMapper()
 
 			adapter := enrichment.NewK8sAdapter(dynClient, mapper)
-			chain, err := adapter.GetOwnerChain(context.Background(), "Pod", "web-abc123", "default")
+			chain, err := adapter.GetOwnerChain(context.Background(), "Pod", "web-abc123", "default", "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(chain).To(HaveLen(1))
 			Expect(chain[0].Kind).To(Equal("ReplicaSet"))
@@ -95,7 +95,7 @@ var _ = Describe("K8s Owner-Chain Adapter — TP-433-WIR Phase 1b", func() {
 			mapper := newSimpleRESTMapper()
 
 			adapter := enrichment.NewK8sAdapter(dynClient, mapper)
-			chain, err := adapter.GetOwnerChain(context.Background(), "Pod", "web-abc123", "default")
+			chain, err := adapter.GetOwnerChain(context.Background(), "Pod", "web-abc123", "default", "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(chain).To(HaveLen(2))
 			Expect(chain[0].Kind).To(Equal("ReplicaSet"))
@@ -118,7 +118,7 @@ var _ = Describe("K8s Owner-Chain Adapter — TP-433-WIR Phase 1b", func() {
 			mapper := newSimpleRESTMapper()
 
 			adapter := enrichment.NewK8sAdapter(dynClient, mapper)
-			chain, err := adapter.GetOwnerChain(context.Background(), "Pod", "standalone-pod", "default")
+			chain, err := adapter.GetOwnerChain(context.Background(), "Pod", "standalone-pod", "default", "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(chain).NotTo(BeNil())
 			Expect(chain).To(BeEmpty())
@@ -156,7 +156,7 @@ var _ = Describe("K8s Owner-Chain Adapter — TP-433-WIR Phase 1b", func() {
 			mapper := newSimpleRESTMapper()
 
 			adapter := enrichment.NewK8sAdapter(dynClient, mapper)
-			chain, err := adapter.GetOwnerChain(context.Background(), "Pod", "deep-pod", "default")
+			chain, err := adapter.GetOwnerChain(context.Background(), "Pod", "deep-pod", "default", "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(len(chain)).To(BeNumerically("<=", 10))
 		})
@@ -191,7 +191,7 @@ var _ = Describe("K8s Owner-Chain Adapter — TP-433-WIR Phase 1b", func() {
 			mapper := newSimpleRESTMapper()
 
 			adapter := enrichment.NewK8sAdapter(dynClient, mapper)
-			chain, err := adapter.GetOwnerChain(context.Background(), "Pod", "web-pod-1", "production")
+			chain, err := adapter.GetOwnerChain(context.Background(), "Pod", "web-pod-1", "production", "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(chain).To(HaveLen(2))
 			Expect(chain[0].Kind).To(Equal("ReplicaSet"))
@@ -215,7 +215,7 @@ var _ = Describe("K8s Owner-Chain Adapter — TP-433-WIR Phase 1b", func() {
 			mapper := newSimpleRESTMapper()
 
 			adapter := enrichment.NewK8sAdapter(dynClient, mapper)
-			chain, err := adapter.GetOwnerChain(context.Background(), "Node", "worker-1", "")
+			chain, err := adapter.GetOwnerChain(context.Background(), "Node", "worker-1", "", "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(chain).To(BeEmpty())
 		})
@@ -259,7 +259,7 @@ var _ = Describe("TP-693: Controller-ref owner chain selection", func() {
 			mapper := newSimpleRESTMapper()
 
 			adapter := enrichment.NewK8sAdapter(dynClient, mapper)
-			chain, err := adapter.GetOwnerChain(context.Background(), "Pod", "test-pod", "default")
+			chain, err := adapter.GetOwnerChain(context.Background(), "Pod", "test-pod", "default", "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(chain).To(HaveLen(2),
 				"UT-KA-693-008: should follow controller RS → Deployment")
@@ -290,7 +290,7 @@ var _ = Describe("TP-693: Controller-ref owner chain selection", func() {
 			mapper := newSimpleRESTMapper()
 
 			adapter := enrichment.NewK8sAdapter(dynClient, mapper)
-			chain, err := adapter.GetOwnerChain(context.Background(), "Pod", "orphan-pod", "default")
+			chain, err := adapter.GetOwnerChain(context.Background(), "Pod", "orphan-pod", "default", "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(chain).To(BeEmpty(),
 				"UT-KA-693-009: no controller:true → empty chain (aligned with SP/GW)")
@@ -317,13 +317,13 @@ var _ = Describe("UT-KA-704-MAPPER: RESTMapper refresh for CRDs installed after 
 
 			adapter := enrichment.NewK8sAdapter(dynClient, mapper)
 
-			_, errBefore := adapter.GetOwnerChain(context.Background(), "Certificate", "demo-app-cert", "default")
+			_, errBefore := adapter.GetOwnerChain(context.Background(), "Certificate", "demo-app-cert", "default", "")
 			Expect(errBefore).To(HaveOccurred(),
 				"should fail before CRD is registered")
 
 			mapper.registerCertificate()
 
-			chain, errAfter := adapter.GetOwnerChain(context.Background(), "Certificate", "demo-app-cert", "default")
+			chain, errAfter := adapter.GetOwnerChain(context.Background(), "Certificate", "demo-app-cert", "default", "")
 			Expect(errAfter).NotTo(HaveOccurred(),
 				"should succeed after mapper reset discovers the CRD")
 			Expect(chain).To(BeEmpty(), "Certificate has no ownerReferences")

--- a/test/unit/kubernautagent/enrichment/scope_aware_test.go
+++ b/test/unit/kubernautagent/enrichment/scope_aware_test.go
@@ -51,7 +51,7 @@ var _ = Describe("TP-762: Scope-Aware K8sAdapter (#762)", func() {
 			mapper := newSimpleRESTMapper()
 
 			adapter := enrichment.NewK8sAdapter(dynClient, mapper)
-			chain, err := adapter.GetOwnerChain(context.Background(), "Node", "worker-1", "kube-system")
+			chain, err := adapter.GetOwnerChain(context.Background(), "Node", "worker-1", "kube-system", "")
 			Expect(err).NotTo(HaveOccurred(),
 				"UT-KA-762-001: GetOwnerChain must use cluster-scoped client for Node, ignoring namespace")
 			Expect(chain).To(BeEmpty())
@@ -87,7 +87,7 @@ var _ = Describe("TP-762: Scope-Aware K8sAdapter (#762)", func() {
 			mapper := newSimpleRESTMapper()
 
 			adapter := enrichment.NewK8sAdapter(dynClient, mapper)
-			chain, err := adapter.GetOwnerChain(context.Background(), "Pod", "web-abc123", "production")
+			chain, err := adapter.GetOwnerChain(context.Background(), "Pod", "web-abc123", "production", "")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(chain).To(HaveLen(2),
 				"UT-KA-762-002: namespaced chain should resolve normally")
@@ -110,7 +110,7 @@ var _ = Describe("TP-762: Scope-Aware K8sAdapter (#762)", func() {
 			mapper := newSimpleRESTMapper()
 
 			adapter := enrichment.NewK8sAdapter(dynClient, mapper)
-			hash, err := adapter.GetSpecHash(context.Background(), "Node", "worker-1", "kube-system")
+			hash, err := adapter.GetSpecHash(context.Background(), "Node", "worker-1", "kube-system", "")
 			Expect(err).NotTo(HaveOccurred(),
 				"UT-KA-762-003: GetSpecHash must use cluster-scoped client for Node, ignoring namespace")
 			Expect(hash).NotTo(BeEmpty(), "Node has a .spec, so hash should be non-empty")
@@ -133,7 +133,7 @@ var _ = Describe("TP-762: Scope-Aware K8sAdapter (#762)", func() {
 			mapper := newSimpleRESTMapper()
 
 			adapter := enrichment.NewK8sAdapter(dynClient, mapper)
-			hash, err := adapter.GetSpecHash(context.Background(), "Deployment", "api-server", "default")
+			hash, err := adapter.GetSpecHash(context.Background(), "Deployment", "api-server", "default", "")
 			Expect(err).NotTo(HaveOccurred(),
 				"UT-KA-762-004: namespaced GetSpecHash should work for Deployment")
 			Expect(hash).NotTo(BeEmpty())

--- a/test/unit/kubernautagent/investigator/inject_target_apiversion_test.go
+++ b/test/unit/kubernautagent/investigator/inject_target_apiversion_test.go
@@ -1,0 +1,127 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+var _ = Describe("InjectRemediationTarget apiVersion propagation — Issue #1040", func() {
+
+	Describe("UT-KA-1040-005: Preserves LLM apiVersion when kind matches root", func() {
+		It("should keep apiVersion when LLM kind equals root owner kind", func() {
+			signal := katypes.SignalContext{
+				ResourceKind: "Route",
+				ResourceName: "storefront",
+				Namespace:    "demo-route",
+			}
+			enrichData := &enrichment.EnrichmentResult{
+				ResourceKind:      "Route",
+				ResourceName:      "storefront",
+				ResourceNamespace: "demo-route",
+				OwnerChain:        []enrichment.OwnerChainEntry{},
+			}
+			result := &katypes.InvestigationResult{
+				RemediationTarget: katypes.RemediationTarget{
+					Kind:       "Route",
+					Name:       "storefront",
+					Namespace:  "demo-route",
+					APIVersion: "route.openshift.io/v1",
+				},
+			}
+
+			investigator.InjectRemediationTarget(result, signal, enrichData)
+
+			Expect(result.RemediationTarget.Kind).To(Equal("Route"))
+			Expect(result.RemediationTarget.Name).To(Equal("storefront"))
+			Expect(result.RemediationTarget.APIVersion).To(Equal("route.openshift.io/v1"),
+				"UT-KA-1040-005: apiVersion must be preserved when LLM kind matches root")
+		})
+	})
+
+	Describe("UT-KA-1040-006: Preserves LLM apiVersion for cross-type target", func() {
+		It("should keep LLM apiVersion when target kind is not in owner chain", func() {
+			signal := katypes.SignalContext{
+				ResourceKind: "Pod",
+				ResourceName: "worker-abc123",
+				Namespace:    "production",
+			}
+			enrichData := &enrichment.EnrichmentResult{
+				ResourceKind:      "Deployment",
+				ResourceName:      "worker",
+				ResourceNamespace: "production",
+				OwnerChain: []enrichment.OwnerChainEntry{
+					{Kind: "ReplicaSet", Name: "worker-abc", Namespace: "production"},
+					{Kind: "Deployment", Name: "worker", Namespace: "production"},
+				},
+			}
+			result := &katypes.InvestigationResult{
+				RemediationTarget: katypes.RemediationTarget{
+					Kind:       "Route",
+					Name:       "storefront",
+					Namespace:  "demo-route",
+					APIVersion: "route.openshift.io/v1",
+				},
+			}
+
+			investigator.InjectRemediationTarget(result, signal, enrichData)
+
+			Expect(result.RemediationTarget.Kind).To(Equal("Route"),
+				"UT-KA-1040-006: cross-type target kind must be preserved")
+			Expect(result.RemediationTarget.APIVersion).To(Equal("route.openshift.io/v1"),
+				"UT-KA-1040-006: cross-type target apiVersion must be preserved")
+		})
+	})
+
+	Describe("UT-KA-1040-007: Empty apiVersion works (backwards compat)", func() {
+		It("should produce valid result with empty apiVersion", func() {
+			signal := katypes.SignalContext{
+				ResourceKind: "Pod",
+				ResourceName: "worker-abc123",
+				Namespace:    "production",
+			}
+			enrichData := &enrichment.EnrichmentResult{
+				ResourceKind:      "Deployment",
+				ResourceName:      "worker",
+				ResourceNamespace: "production",
+				OwnerChain: []enrichment.OwnerChainEntry{
+					{Kind: "ReplicaSet", Name: "worker-abc", Namespace: "production"},
+					{Kind: "Deployment", Name: "worker", Namespace: "production"},
+				},
+			}
+			result := &katypes.InvestigationResult{
+				RemediationTarget: katypes.RemediationTarget{
+					Kind:      "Deployment",
+					Name:      "worker-wrong",
+					Namespace: "production",
+				},
+			}
+
+			investigator.InjectRemediationTarget(result, signal, enrichData)
+
+			Expect(result.RemediationTarget.Kind).To(Equal("Deployment"))
+			Expect(result.RemediationTarget.Name).To(Equal("worker"))
+			Expect(result.RemediationTarget.APIVersion).To(BeEmpty(),
+				"UT-KA-1040-007: empty apiVersion must remain empty for backwards compat")
+		})
+	})
+})

--- a/test/unit/kubernautagent/parser/parser_apiversion_test.go
+++ b/test/unit/kubernautagent/parser/parser_apiversion_test.go
@@ -78,8 +78,8 @@ var _ = Describe("Parser apiVersion Extraction — Issue #1040", func() {
 		})
 	})
 
-	Describe("UT-KA-1040-002: Parser handles missing api_version (backwards compat)", func() {
-		It("should leave APIVersion empty when not present in LLM JSON", func() {
+	Describe("UT-KA-1040-002: Parser handles missing api_version gracefully (defense-in-depth)", func() {
+		It("should leave APIVersion empty when LLM omits it despite being required", func() {
 			jsonStr := `{
 				"root_cause_analysis": {
 					"summary": "OOMKilled due to memory limit",
@@ -98,7 +98,7 @@ var _ = Describe("Parser apiVersion Extraction — Issue #1040", func() {
 
 			Expect(result.RemediationTarget.Kind).To(Equal("Deployment"))
 			Expect(result.RemediationTarget.APIVersion).To(BeEmpty(),
-				"UT-KA-1040-002: APIVersion must be empty when not provided by LLM")
+				"UT-KA-1040-002: APIVersion must be empty when LLM omits it — heuristic fallback applies")
 		})
 	})
 })

--- a/test/unit/kubernautagent/parser/parser_apiversion_test.go
+++ b/test/unit/kubernautagent/parser/parser_apiversion_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package parser_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
+)
+
+var _ = Describe("Parser apiVersion Extraction — Issue #1040", func() {
+	var rp *parser.ResultParser
+
+	BeforeEach(func() {
+		rp = parser.NewResultParser()
+	})
+
+	Describe("UT-KA-1040-001: Parser extracts api_version from LLM JSON", func() {
+		It("should capture api_version in RemediationTarget when present in nested RCA", func() {
+			jsonStr := `{
+				"root_cause_analysis": {
+					"summary": "Route misconfigured due to wrong backend service",
+					"severity": "high",
+					"remediation_target": {
+						"kind": "Route",
+						"name": "storefront",
+						"namespace": "demo-route",
+						"api_version": "route.openshift.io/v1"
+					}
+				},
+				"confidence": 0.92
+			}`
+
+			result, err := rp.Parse(jsonStr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(result.RemediationTarget.Kind).To(Equal("Route"))
+			Expect(result.RemediationTarget.Name).To(Equal("storefront"))
+			Expect(result.RemediationTarget.Namespace).To(Equal("demo-route"))
+			Expect(result.RemediationTarget.APIVersion).To(Equal("route.openshift.io/v1"),
+				"UT-KA-1040-001: api_version must be captured from LLM JSON")
+		})
+
+		It("should capture api_version from flat remediation_target path", func() {
+			jsonStr := `{
+				"rca_summary": "Route misconfigured",
+				"remediation_target": {
+					"kind": "Route",
+					"name": "storefront",
+					"namespace": "demo-route",
+					"api_version": "route.openshift.io/v1"
+				},
+				"confidence": 0.92
+			}`
+
+			result, err := rp.Parse(jsonStr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(result.RemediationTarget.APIVersion).To(Equal("route.openshift.io/v1"),
+				"UT-KA-1040-001: api_version must be captured from flat path")
+		})
+	})
+
+	Describe("UT-KA-1040-002: Parser handles missing api_version (backwards compat)", func() {
+		It("should leave APIVersion empty when not present in LLM JSON", func() {
+			jsonStr := `{
+				"root_cause_analysis": {
+					"summary": "OOMKilled due to memory limit",
+					"remediation_target": {
+						"kind": "Deployment",
+						"name": "api-server",
+						"namespace": "production"
+					}
+				},
+				"confidence": 0.85
+			}`
+
+			result, err := rp.Parse(jsonStr)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+
+			Expect(result.RemediationTarget.Kind).To(Equal("Deployment"))
+			Expect(result.RemediationTarget.APIVersion).To(BeEmpty(),
+				"UT-KA-1040-002: APIVersion must be empty when not provided by LLM")
+		})
+	})
+})

--- a/test/unit/kubernautagent/tools/custom/resource_context_test.go
+++ b/test/unit/kubernautagent/tools/custom/resource_context_test.go
@@ -41,11 +41,11 @@ type fakeK8s struct {
 	capturedSpecHashNamespace string
 }
 
-func (f *fakeK8s) GetOwnerChain(_ context.Context, _, _, _ string) ([]enrichment.OwnerChainEntry, error) {
+func (f *fakeK8s) GetOwnerChain(_ context.Context, _, _, _, _ string) ([]enrichment.OwnerChainEntry, error) {
 	return f.chain, f.err
 }
 
-func (f *fakeK8s) GetSpecHash(_ context.Context, kind, name, namespace string) (string, error) {
+func (f *fakeK8s) GetSpecHash(_ context.Context, kind, name, namespace, _ string) (string, error) {
 	f.capturedSpecHashKind = kind
 	f.capturedSpecHashName = name
 	f.capturedSpecHashNamespace = namespace

--- a/test/unit/shared/k8s/gvk_apiversion_test.go
+++ b/test/unit/shared/k8s/gvk_apiversion_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	k8sutil "github.com/jordigilh/kubernaut/pkg/shared/k8s"
+)
+
+// apiVersionMapper implements meta.RESTMapper with RESTMapping support
+// for testing ResolveGVKWithAPIVersion.
+type apiVersionMapper struct {
+	mappings map[schema.GroupKind]*meta.RESTMapping
+}
+
+func (m *apiVersionMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return nil, &meta.NoResourceMatchError{PartialResource: resource}
+}
+
+func (m *apiVersionMapper) KindFor(schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	panic("not implemented")
+}
+func (m *apiVersionMapper) ResourceFor(schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	panic("not implemented")
+}
+func (m *apiVersionMapper) ResourcesFor(schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	panic("not implemented")
+}
+func (m *apiVersionMapper) RESTMapping(gk schema.GroupKind, versions ...string) (*meta.RESTMapping, error) {
+	if mapping, ok := m.mappings[gk]; ok {
+		return mapping, nil
+	}
+	return nil, &meta.NoResourceMatchError{PartialResource: schema.GroupVersionResource{
+		Group: gk.Group, Resource: gk.Kind,
+	}}
+}
+func (m *apiVersionMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	panic("not implemented")
+}
+func (m *apiVersionMapper) ResourceSingularizer(resource string) (string, error) {
+	panic("not implemented")
+}
+
+var _ = Describe("ResolveGVKWithAPIVersion — Issue #1040", func() {
+	var mapper *apiVersionMapper
+
+	BeforeEach(func() {
+		mapper = &apiVersionMapper{
+			mappings: map[schema.GroupKind]*meta.RESTMapping{
+				{Group: "route.openshift.io", Kind: "Route"}: {
+					Resource: schema.GroupVersionResource{
+						Group: "route.openshift.io", Version: "v1", Resource: "routes",
+					},
+					GroupVersionKind: schema.GroupVersionKind{
+						Group: "route.openshift.io", Version: "v1", Kind: "Route",
+					},
+				},
+				{Group: "apps", Kind: "Deployment"}: {
+					Resource: schema.GroupVersionResource{
+						Group: "apps", Version: "v1", Resource: "deployments",
+					},
+					GroupVersionKind: schema.GroupVersionKind{
+						Group: "apps", Version: "v1", Kind: "Deployment",
+					},
+				},
+			},
+		}
+	})
+
+	Describe("UT-KA-1040-003: Uses apiVersion when present", func() {
+		It("should resolve Route to route.openshift.io/v1 when apiVersion is provided", func() {
+			gvk, err := k8sutil.ResolveGVKWithAPIVersion(mapper, "Route", "route.openshift.io/v1")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(gvk.Group).To(Equal("route.openshift.io"),
+				"UT-KA-1040-003: must resolve to route.openshift.io group")
+			Expect(gvk.Version).To(Equal("v1"))
+			Expect(gvk.Kind).To(Equal("Route"))
+		})
+	})
+
+	Describe("UT-KA-1040-004: Falls back when apiVersion empty", func() {
+		It("should fall back to ResolveGVKForKind for well-known kinds", func() {
+			gvk, err := k8sutil.ResolveGVKWithAPIVersion(mapper, "Deployment", "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(gvk.Group).To(Equal("apps"),
+				"UT-KA-1040-004: must fall back to static table for Deployment")
+			Expect(gvk.Kind).To(Equal("Deployment"))
+		})
+	})
+
+	Describe("UT-KA-1040-008: Rejects invalid apiVersion", func() {
+		It("should return error for malformed apiVersion", func() {
+			_, err := k8sutil.ResolveGVKWithAPIVersion(mapper, "Route", "///invalid")
+			Expect(err).To(HaveOccurred(),
+				"UT-KA-1040-008: malformed apiVersion must produce an error")
+		})
+
+		It("should return error when kind not found in given apiVersion", func() {
+			_, err := k8sutil.ResolveGVKWithAPIVersion(mapper, "Widget", "custom.io/v1")
+			Expect(err).To(HaveOccurred(),
+				"UT-KA-1040-008: unknown kind+apiVersion combination must error")
+		})
+	})
+})

--- a/test/unit/shared/k8s/gvk_apiversion_test.go
+++ b/test/unit/shared/k8s/gvk_apiversion_test.go
@@ -119,4 +119,17 @@ var _ = Describe("ResolveGVKWithAPIVersion — Issue #1040", func() {
 				"UT-KA-1040-008: unknown kind+apiVersion combination must error")
 		})
 	})
+
+	Describe("UT-KA-1040-009: EA fallback pattern — invalid apiVersion falls back to kind-only", func() {
+		It("should resolve via ResolveGVKForKind when apiVersion-based resolution fails", func() {
+			wrongAPIVersion := "wrong.group.io/v1"
+			_, err := k8sutil.ResolveGVKWithAPIVersion(mapper, "Deployment", wrongAPIVersion)
+			Expect(err).To(HaveOccurred(), "apiVersion-based resolution must fail for wrong group")
+
+			gvk, err := k8sutil.ResolveGVKForKind(mapper, "Deployment")
+			Expect(err).NotTo(HaveOccurred(), "kind-only fallback must succeed for well-known kind")
+			Expect(gvk.Group).To(Equal("apps"))
+			Expect(gvk.Kind).To(Equal("Deployment"))
+		})
+	})
 })


### PR DESCRIPTION
## Summary

- Adds optional `apiVersion` field to the remediation target at every pipeline layer (LLM schema → parser → internal types → CRD types → RO → EA) so the EffectivenessMonitor can resolve ambiguous Kubernetes kinds (e.g. `Route` in `route.openshift.io` vs `serving.knative.dev`) using an explicit API group instead of `ResolveGVKForKind`'s first-match heuristic.
- Introduces `ResolveGVKWithAPIVersion` helper that uses `RESTMapping` directly when `apiVersion` is provided, falling back to the existing static table + REST mapper for backwards compatibility.
- Updates `K8sClient` interface, `K8sAdapter`, and `OwnerChainEntry` to capture and propagate `apiVersion` from `OwnerReference` through the enrichment pipeline.

## Changes

| Layer | Files | Change |
|-------|-------|--------|
| **LLM Schema** | `parser/schema.go`, `prompt/templates/incident_investigation.tmpl` | Add `api_version` to JSON schema and prompt example |
| **Parser** | `parser/parser.go` | `llmRemTarget.APIVersion`, propagation in `parseLLMFormat` and `mergeNestedRemediationTarget` |
| **Internal Types** | `pkg/kubernautagent/types/types.go` | `RemediationTarget.APIVersion` |
| **CRD Types** | `api/{aianalysis,remediation,effectivenessassessment}/v1alpha1/*_types.go` | Add `APIVersion` to `RemediationTarget`, `ResourceIdentifier`, `TargetResource` |
| **Serialization** | `pkg/aianalysis/handlers/response_processor.go` | Read `api_version` from RCA map |
| **RO Propagation** | `reconciler.go`, `wfe_creation_helper.go`, EA/AIAnalysis creators | Copy `APIVersion` through pipeline |
| **InjectRemediationTarget** | `investigator_phases.go` | Preserve LLM `apiVersion` through injection; add `TARGET_RESOURCE_API_VERSION` parameter |
| **EA Consumer** | `target_resources.go` | Use `ResolveGVKWithAPIVersion` |
| **Enrichment** | `enricher.go`, `k8s_adapter.go` | `OwnerChainEntry.APIVersion`, `K8sClient` interface updated, `resolveMappingWithAPIVersion` |
| **Validation** | `pkg/shared/k8s/gvk.go` | New `ResolveGVKWithAPIVersion` helper |
| **Mock LLM** | `test/services/mock-llm/response/openai.go` | Wire `APIVersion` into `analysisJSON` |

## Test plan

- [IEEE 829 Test Plan](docs/tests/1040/TEST_PLAN.md)
- 10 new unit tests (UT-KA-1040-001 through -008 plus backwards compat)
- All existing tests updated for `K8sClient` interface change (34 `Enrich` call sites, 15 adapter calls, 14 fake method signatures)
- `go test -race` passes on all affected packages
- `make generate && make manifests` clean

## Closes

Fixes #1040

Made with [Cursor](https://cursor.com)