### PR TITLE
fix(test): resolve flaky notification lifecycle integration test

### DIFF
--- a/test/integration/remediationorchestrator/notification_lifecycle_integration_test.go
+++ b/test/integration/remediationorchestrator/notification_lifecycle_integration_test.go
@@ -151,24 +151,21 @@ var _ = Describe("Notification Lifecycle Integration", Label("integration", "not
 				return testRR.Status.NotificationStatus
 			}, timeout, interval).Should(Equal("Cancelled"))
 
-			// CRITICAL: Verify notification cancellation does NOT cause an abnormal phase transition.
-			// The controller may legitimately advance the phase (Pending → Processing) as part of
-			// normal orchestration, but notification cancellation must NOT cause a transition to
-			// Failed or any other error state. We capture the phase AFTER cancellation is confirmed
-			// and verify it remains stable (no further transitions caused by the cancellation).
-			Expect(k8sManager.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(testRR), testRR)).To(Succeed())
-			phaseAfterCancellation := testRR.Status.OverallPhase
+		// CRITICAL: Verify notification cancellation does NOT cause an abnormal phase transition.
+		// The controller may legitimately advance the phase (Pending → Processing → Analyzing)
+		// as part of normal orchestration. BR-ORCH-029 requires that notification cancellation
+		// must NOT cause a transition to Failed or any other error state.
+		Expect(k8sManager.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(testRR), testRR)).To(Succeed())
+		Expect(testRR.Status.OverallPhase).ToNot(Equal(remediationv1.PhaseFailed),
+			"Notification cancellation must not cause phase to transition to Failed")
 
-			// Phase must not be Failed due to notification cancellation
-			Expect(phaseAfterCancellation).ToNot(Equal(remediationv1.PhaseFailed),
-				"Notification cancellation must not cause phase to transition to Failed")
-
-			// Verify phase remains stable (cancellation doesn't trigger further transitions)
-			Consistently(func() remediationv1.RemediationPhase {
-				_ = k8sManager.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(testRR), testRR)
-				return testRR.Status.OverallPhase
-			}, 2*time.Second, 250*time.Millisecond).Should(Equal(phaseAfterCancellation),
-				"Phase should remain stable after notification cancellation")
+		// Sustained verification: phase must never become Failed over the observation window.
+		// Forward progress (Pending → Processing → Analyzing) is expected and healthy.
+		Consistently(func() remediationv1.RemediationPhase {
+			_ = k8sManager.GetAPIReader().Get(ctx, client.ObjectKeyFromObject(testRR), testRR)
+			return testRR.Status.OverallPhase
+		}, 2*time.Second, 250*time.Millisecond).ShouldNot(Equal(remediationv1.PhaseFailed),
+			"Notification cancellation must not cause phase to transition to Failed")
 
 			cond := meta.FindStatusCondition(testRR.Status.Conditions, "NotificationDelivered")
 			Expect(cond).To(HaveField("Status", Equal(metav1.ConditionFalse)))


### PR DESCRIPTION
## Summary

- Fixes flaky `notification_lifecycle_integration_test.go:170` that caused CI failure in [run #1650](https://github.com/jordigilh/kubernaut/actions/runs/25439418861/job/74627266661) (merge of PR #1046)
- Root cause: `Consistently` assertion captured a phase snapshot (`Pending`) then asserted stability, but the controller legitimately advanced the phase to `Processing` between the snapshot and the first poll — a timing-dependent race on CI runners

## Root Cause Analysis

```
T=0ms:   Line 159 reads phase → "Pending" (snapshot captured)
T=+Xms:  Controller reconciles → advances phase to "Processing" (legitimate)
T=+Yms:  Consistently first poll → "Processing" ≠ "Pending" → FAIL
```

The test comments (lines 155-156) explicitly acknowledged this scenario: *"The controller may legitimately advance the phase (Pending → Processing)"* — but the `Equal(phaseAfterCancellation)` assertion didn't account for it.

## Fix

Replace the overly strict `Should(Equal(phaseAfterCancellation))` with `ShouldNot(Equal(PhaseFailed))`, which matches the actual BR-ORCH-029 business contract: **notification cancellation must not cause the remediation to fail**. Forward progress is expected and healthy.

## Test plan

- [x] `go build ./test/integration/remediationorchestrator/...` compiles cleanly
- [ ] CI integration tests pass (no more flake on this assertion)
- [ ] BR-ORCH-029 contract still enforced: cancellation → never `Failed`


Made with [Cursor](https://cursor.com)