### PR TITLE
Fix SA Token Refresh and Audit 401 Handling (#1055, #1056)

### DIFF
--- a/cmd/effectivenessmonitor/main.go
+++ b/cmd/effectivenessmonitor/main.go
@@ -274,7 +274,7 @@ func main() {
 		defer emCAWatcher.Stop()
 
 		// Wrap CAReloader (RoundTripper) with SA bearer token for OCP monitoring endpoints.
-		saTransport := auth.NewServiceAccountTransportWithBase(caReloader)
+		saTransport := auth.NewAuthTransport(auth.NewDefaultTokenSource(), caReloader)
 		externalHTTPClient = &http.Client{
 			Transport: saTransport,
 			Timeout:   cfg.External.ConnectionTimeout,

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -629,6 +629,11 @@ func initDSClients(cfg *kaconfig.Config, infra *k8sInfra, logger logr.Logger) *d
 	authTransport := auth.NewServiceAccountTransportWithPath(
 		cfg.Integrations.DataStorage.SATokenPath, dsBase)
 
+	if _, err := os.Stat(cfg.Integrations.DataStorage.SATokenPath); err != nil {
+		logger.Info("WARNING: SA token file not found at startup, DS API calls will fail auth until file appears",
+			"token_path", cfg.Integrations.DataStorage.SATokenPath, "error", err)
+	}
+
 	var opts []ogenclient.ClientOption
 	opts = append(opts, ogenclient.WithClient(&http.Client{
 		Transport: authTransport,
@@ -747,6 +752,11 @@ func buildAuditStore(cfg *kaconfig.Config, logger logr.Logger) (audit.AuditStore
 
 	auditAuthTransport := auth.NewServiceAccountTransportWithPath(
 		cfg.Integrations.DataStorage.SATokenPath, auditBase)
+
+	if _, err := os.Stat(cfg.Integrations.DataStorage.SATokenPath); err != nil {
+		logger.Info("WARNING: SA token file not found at startup, audit batch writes will fail auth until file appears",
+			"token_path", cfg.Integrations.DataStorage.SATokenPath, "error", err)
+	}
 	logger.Info("audit store auth configured (AuthTransport with token refresh)",
 		"token_path", cfg.Integrations.DataStorage.SATokenPath)
 

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -632,6 +632,9 @@ func initDSClients(cfg *kaconfig.Config, infra *k8sInfra, logger logr.Logger) *d
 	if _, err := os.Stat(cfg.Integrations.DataStorage.SATokenPath); err != nil {
 		logger.Info("WARNING: SA token file not found at startup, DS API calls will fail auth until file appears",
 			"token_path", cfg.Integrations.DataStorage.SATokenPath, "error", err)
+	} else {
+		logger.Info("DS client auth configured (AuthTransport with token refresh)",
+			"token_path", cfg.Integrations.DataStorage.SATokenPath)
 	}
 
 	var opts []ogenclient.ClientOption
@@ -639,8 +642,6 @@ func initDSClients(cfg *kaconfig.Config, infra *k8sInfra, logger logr.Logger) *d
 		Transport: authTransport,
 		Timeout:   defaultDSClientTimeout,
 	}))
-	logger.Info("DS client auth configured (AuthTransport with token refresh)",
-		"token_path", cfg.Integrations.DataStorage.SATokenPath)
 
 	ogenClient, err := ogenclient.NewClient(cfg.Integrations.DataStorage.URL, opts...)
 	if err != nil {
@@ -750,15 +751,21 @@ func buildAuditStore(cfg *kaconfig.Config, logger logr.Logger) (audit.AuditStore
 		return audit.NopAuditStore{}, nop
 	}
 
+	// PROD-R3-1: This creates a second AuthTransport with its own independent token cache.
+	// The DS ogen client (initDSClients) and audit store each have separate 5-min TTL caches.
+	// After token rotation, each invalidates independently on its own first 401. Audit writes
+	// may lag up to 5 min behind DS client recovery. Acceptable for v1; a shared cache is a
+	// future improvement.
 	auditAuthTransport := auth.NewServiceAccountTransportWithPath(
 		cfg.Integrations.DataStorage.SATokenPath, auditBase)
 
 	if _, err := os.Stat(cfg.Integrations.DataStorage.SATokenPath); err != nil {
 		logger.Info("WARNING: SA token file not found at startup, audit batch writes will fail auth until file appears",
 			"token_path", cfg.Integrations.DataStorage.SATokenPath, "error", err)
+	} else {
+		logger.Info("audit store auth configured (AuthTransport with token refresh)",
+			"token_path", cfg.Integrations.DataStorage.SATokenPath)
 	}
-	logger.Info("audit store auth configured (AuthTransport with token refresh)",
-		"token_path", cfg.Integrations.DataStorage.SATokenPath)
 
 	dsClient, err := sharedaudit.NewOpenAPIClientAdapterWithTransport(
 		cfg.Integrations.DataStorage.URL, 5*time.Second, auditAuthTransport,

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -623,22 +623,19 @@ func initDSClients(cfg *kaconfig.Config, infra *k8sInfra, logger logr.Logger) *d
 
 	const defaultDSClientTimeout = 30 * time.Second
 
+	// #1055: Use AuthTransport with configurable token path instead of static bearerTransport.
+	// AuthTransport re-reads the SA token from disk every 5 minutes (or immediately after
+	// a 401 response), so the agent survives kubelet token rotation.
+	authTransport := auth.NewServiceAccountTransportWithPath(
+		cfg.Integrations.DataStorage.SATokenPath, dsBase)
+
 	var opts []ogenclient.ClientOption
-	if tokenData, err := os.ReadFile(cfg.Integrations.DataStorage.SATokenPath); err == nil && len(tokenData) > 0 {
-		token := string(tokenData)
-		opts = append(opts, ogenclient.WithClient(&http.Client{
-			Transport: &bearerTransport{base: dsBase, token: token},
-			Timeout:   defaultDSClientTimeout,
-		}))
-		logger.Info("DS client auth configured (DD-AUTH-014)", "token_path", cfg.Integrations.DataStorage.SATokenPath)
-	} else {
-		opts = append(opts, ogenclient.WithClient(&http.Client{
-			Transport: dsBase,
-			Timeout:   defaultDSClientTimeout,
-		}))
-		logger.Info("SA token not available for DS client — DS API calls may fail auth",
-			"path", cfg.Integrations.DataStorage.SATokenPath, "error", err)
-	}
+	opts = append(opts, ogenclient.WithClient(&http.Client{
+		Transport: authTransport,
+		Timeout:   defaultDSClientTimeout,
+	}))
+	logger.Info("DS client auth configured (AuthTransport with token refresh)",
+		"token_path", cfg.Integrations.DataStorage.SATokenPath)
 
 	ogenClient, err := ogenclient.NewClient(cfg.Integrations.DataStorage.URL, opts...)
 	if err != nil {
@@ -681,19 +678,6 @@ func buildDSBaseTransport(caFile string, cbCfg kaconfig.CircuitBreakerCfg) (http
 		FailureThreshold: cbCfg.FailureThreshold,
 		FailureRatio:     cbCfg.FailureRatio,
 	}), nil
-}
-
-// bearerTransport injects a Kubernetes ServiceAccount Bearer token into
-// every outbound HTTP request (DD-AUTH-014).
-type bearerTransport struct {
-	base  http.RoundTripper
-	token string
-}
-
-func (t *bearerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	r := req.Clone(req.Context())
-	r.Header.Set("Authorization", "Bearer "+t.token)
-	return t.base.RoundTrip(r)
 }
 
 // buildEnricher creates the enrichment.Enricher when DS clients are available.
@@ -753,26 +737,21 @@ func buildAuditStore(cfg *kaconfig.Config, logger logr.Logger) (audit.AuditStore
 		return audit.NopAuditStore{}, nop
 	}
 
-	// Use the same auth transport as initDSClients: read SA token from the
-	// configured path and inject as Bearer header on every request.
+	// #1055: Use AuthTransport for audit store (same pattern as initDSClients).
+	// AuthTransport handles token refresh automatically via 5-minute cache + 401 invalidation.
 	auditBase, tlsErr := sharedtls.DefaultBaseTransport()
 	if tlsErr != nil {
 		logger.Error(tlsErr, "failed to create TLS-aware transport for audit store")
 		return audit.NopAuditStore{}, nop
 	}
 
-	var transport http.RoundTripper
-	if tokenData, err := os.ReadFile(cfg.Integrations.DataStorage.SATokenPath); err == nil && len(tokenData) > 0 {
-		transport = &bearerTransport{base: auditBase, token: string(tokenData)}
-		logger.Info("audit store auth configured (same SA token as DS client)",
-			"token_path", cfg.Integrations.DataStorage.SATokenPath)
-	} else {
-		logger.Info("SA token not available for audit store — batch writes may fail auth",
-			"path", cfg.Integrations.DataStorage.SATokenPath, "error", err)
-	}
+	auditAuthTransport := auth.NewServiceAccountTransportWithPath(
+		cfg.Integrations.DataStorage.SATokenPath, auditBase)
+	logger.Info("audit store auth configured (AuthTransport with token refresh)",
+		"token_path", cfg.Integrations.DataStorage.SATokenPath)
 
 	dsClient, err := sharedaudit.NewOpenAPIClientAdapterWithTransport(
-		cfg.Integrations.DataStorage.URL, 5*time.Second, transport,
+		cfg.Integrations.DataStorage.URL, 5*time.Second, auditAuthTransport,
 	)
 	if err != nil {
 		logger.Error(err, "failed to create DS audit client, falling back to nop")

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -180,8 +180,21 @@ func main() {
 	phaseTools := investigator.DefaultPhaseToolMap()
 
 	k8sInfra := initK8sInfra(logger)
-	ds := initDSClients(cfg, k8sInfra, logger)
-	auditStore, auditCleanup := buildAuditStore(cfg, logger)
+
+	// #1055: Create a single shared TokenSource for all DS-bound HTTP clients.
+	// Both the ogen DS client and the audit store share this cache, so a 401 on
+	// either side immediately invalidates the token for both.
+	dsTokenSource := auth.NewTokenSource(cfg.Integrations.DataStorage.SATokenPath)
+	if _, err := os.Stat(cfg.Integrations.DataStorage.SATokenPath); err != nil {
+		logger.Info("WARNING: SA token file not found at startup, DS/audit API calls will fail auth until file appears",
+			"token_path", cfg.Integrations.DataStorage.SATokenPath, "error", err)
+	} else {
+		logger.Info("SA token source configured (shared cache with token refresh)",
+			"token_path", cfg.Integrations.DataStorage.SATokenPath)
+	}
+
+	ds := initDSClients(cfg, k8sInfra, dsTokenSource, logger)
+	auditStore, auditCleanup := buildAuditStore(cfg, dsTokenSource, logger)
 	reg := buildToolRegistry(cfg, logger, k8sInfra, ds)
 	enricher := buildEnricher(cfg, ds, k8sInfra, auditStore, logger)
 	sanitizer := buildSanitizationPipeline(cfg, logger)
@@ -600,7 +613,7 @@ type dsClients struct {
 // or default /var/run/secrets/kubernetes.io/serviceaccount/token), the ogen
 // client is configured with a Bearer token transport so that all DS API calls
 // (including ListWorkflows for the workflow validator) pass authentication.
-func initDSClients(cfg *kaconfig.Config, infra *k8sInfra, logger logr.Logger) *dsClients {
+func initDSClients(cfg *kaconfig.Config, infra *k8sInfra, dsTokenSource *auth.TokenSource, logger logr.Logger) *dsClients {
 	if cfg.Integrations.DataStorage.URL == "" {
 		logger.Info("DataStorage URL not configured, DS adapters disabled")
 		return nil
@@ -623,23 +636,9 @@ func initDSClients(cfg *kaconfig.Config, infra *k8sInfra, logger logr.Logger) *d
 
 	const defaultDSClientTimeout = 30 * time.Second
 
-	// #1055: Use AuthTransport with configurable token path instead of static bearerTransport.
-	// AuthTransport re-reads the SA token from disk every 5 minutes (or immediately after
-	// a 401 response), so the agent survives kubelet token rotation.
-	authTransport := auth.NewServiceAccountTransportWithPath(
-		cfg.Integrations.DataStorage.SATokenPath, dsBase)
-
-	if _, err := os.Stat(cfg.Integrations.DataStorage.SATokenPath); err != nil {
-		logger.Info("WARNING: SA token file not found at startup, DS API calls will fail auth until file appears",
-			"token_path", cfg.Integrations.DataStorage.SATokenPath, "error", err)
-	} else {
-		logger.Info("DS client auth configured (AuthTransport with token refresh)",
-			"token_path", cfg.Integrations.DataStorage.SATokenPath)
-	}
-
 	var opts []ogenclient.ClientOption
 	opts = append(opts, ogenclient.WithClient(&http.Client{
-		Transport: authTransport,
+		Transport: auth.NewAuthTransport(dsTokenSource, dsBase),
 		Timeout:   defaultDSClientTimeout,
 	}))
 
@@ -736,39 +735,21 @@ func buildSanitizationPipeline(cfg *kaconfig.Config, logger logr.Logger) *saniti
 // Uses the same OpenAPIClientAdapter + BufferedAuditStore stack as every other
 // platform service. Auth transport is shared with initDSClients (same SA token)
 // to guarantee identical authentication behavior.
-func buildAuditStore(cfg *kaconfig.Config, logger logr.Logger) (audit.AuditStore, func()) {
+func buildAuditStore(cfg *kaconfig.Config, dsTokenSource *auth.TokenSource, logger logr.Logger) (audit.AuditStore, func()) {
 	nop := func() {}
 	if !cfg.Runtime.Audit.Enabled || cfg.Integrations.DataStorage.URL == "" {
 		logger.Info("audit store disabled (nop)")
 		return audit.NopAuditStore{}, nop
 	}
 
-	// #1055: Use AuthTransport for audit store (same pattern as initDSClients).
-	// AuthTransport handles token refresh automatically via 5-minute cache + 401 invalidation.
 	auditBase, tlsErr := sharedtls.DefaultBaseTransport()
 	if tlsErr != nil {
 		logger.Error(tlsErr, "failed to create TLS-aware transport for audit store")
 		return audit.NopAuditStore{}, nop
 	}
 
-	// PROD-R3-1: This creates a second AuthTransport with its own independent token cache.
-	// The DS ogen client (initDSClients) and audit store each have separate 5-min TTL caches.
-	// After token rotation, each invalidates independently on its own first 401. Audit writes
-	// may lag up to 5 min behind DS client recovery. Acceptable for v1; a shared cache is a
-	// future improvement.
-	auditAuthTransport := auth.NewServiceAccountTransportWithPath(
-		cfg.Integrations.DataStorage.SATokenPath, auditBase)
-
-	if _, err := os.Stat(cfg.Integrations.DataStorage.SATokenPath); err != nil {
-		logger.Info("WARNING: SA token file not found at startup, audit batch writes will fail auth until file appears",
-			"token_path", cfg.Integrations.DataStorage.SATokenPath, "error", err)
-	} else {
-		logger.Info("audit store auth configured (AuthTransport with token refresh)",
-			"token_path", cfg.Integrations.DataStorage.SATokenPath)
-	}
-
 	dsClient, err := sharedaudit.NewOpenAPIClientAdapterWithTransport(
-		cfg.Integrations.DataStorage.URL, 5*time.Second, auditAuthTransport,
+		cfg.Integrations.DataStorage.URL, 5*time.Second, auth.NewAuthTransport(dsTokenSource, auditBase),
 	)
 	if err != nil {
 		logger.Error(err, "failed to create DS audit client, falling back to nop")
@@ -855,7 +836,7 @@ func buildToolRegistry(cfg *kaconfig.Config, logger logr.Logger, infra *k8sInfra
 			if promTLSErr != nil {
 				logger.Error(promTLSErr, "failed to create Prometheus TLS transport", "ca_file", cfg.Integrations.Tools.Prometheus.TLSCaFile)
 			} else {
-				promCfg.Transport = auth.NewServiceAccountTransportWithBase(promBase)
+				promCfg.Transport = auth.NewAuthTransport(auth.NewDefaultTokenSource(), promBase)
 				logger.Info("Prometheus client configured with TLS + SA bearer auth", "ca_file", cfg.Integrations.Tools.Prometheus.TLSCaFile)
 			}
 		}

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -185,6 +185,7 @@ func main() {
 	// Both the ogen DS client and the audit store share this cache, so a 401 on
 	// either side immediately invalidates the token for both.
 	dsTokenSource := auth.NewTokenSource(cfg.Integrations.DataStorage.SATokenPath)
+	dsTokenSource.SetLogger(logger.WithName("ds-token-source"))
 	if _, err := os.Stat(cfg.Integrations.DataStorage.SATokenPath); err != nil {
 		logger.Info("WARNING: SA token file not found at startup, DS/audit API calls will fail auth until file appears",
 			"token_path", cfg.Integrations.DataStorage.SATokenPath, "error", err)

--- a/cmd/notification/main.go
+++ b/cmd/notification/main.go
@@ -420,7 +420,7 @@ func main() {
 		cfg.DataStorage.URL,
 		ogenclient.WithClient(&http.Client{
 			Timeout:   cfg.DataStorage.Timeout,
-			Transport: auth.NewServiceAccountTransportWithBase(dsBaseTransport),
+			Transport: auth.NewAuthTransport(auth.NewDefaultTokenSource(), dsBaseTransport),
 		}),
 	)
 	if err != nil {

--- a/docs/tests/1055-1056/TEST_PLAN.md
+++ b/docs/tests/1055-1056/TEST_PLAN.md
@@ -123,7 +123,7 @@ immediately dropped with a misleading "invalid data" log message. The fix reclas
 
 | Phase | Description | Tests | Checkpoint |
 |-------|-------------|-------|------------|
-| RED | Write failing tests for all new behavior | UT-AT-1055-001..005, UT-AE-1056-001..009, UT-AS-1056-001..002 | CHECKPOINT 1 |
+| RED | Write failing tests for all new behavior | UT-AT-1055-001..008, UT-AE-1056-001..009, UT-AS-1056-001..003 | CHECKPOINT 1 |
 | GREEN | Minimal implementation to pass all tests | Production code changes | CHECKPOINT 2 |
 | REFACTOR | 100 Go Mistakes audit, code cleanup, lint | N/A (quality pass) | CHECKPOINT 3 |
 
@@ -142,6 +142,9 @@ immediately dropped with a misleading "invalid data" log message. The fix reclas
 | UT-AT-1055-003 | Token re-read after invalidation picks up new content | Write "token-v1" to file, get 401, write "token-v2", next request | Second request uses "token-v2" | #1055 |
 | UT-AT-1055-004 | Non-401 responses do not invalidate cache | RoundTrip returns 200, 500 | Cache remains valid (no file re-read) | #1055 |
 | UT-AT-1055-005 | Concurrent RoundTrip under 401 storm | 10+ goroutines, all getting 401, with -race | No data races, no panics | #1055 |
+| UT-AT-1055-006 | Nil base transport defaults to http.DefaultTransport | `NewServiceAccountTransportWithPath(path, nil)` | Request succeeds with Bearer header | #1055 |
+| UT-AT-1055-007 | Empty token path degrades gracefully | `NewServiceAccountTransportWithPath("", base)` | Request proceeds without auth header | #1055 |
+| UT-AT-1055-008 | Token file deleted mid-operation | File exists → cached → deleted → 401 invalidation | Next request proceeds without auth header | #1055 |
 
 ### 6.2 Audit Error Tests (Tier 1 — Unit)
 
@@ -167,6 +170,7 @@ immediately dropped with a misleading "invalid data" log message. The fix reclas
 |---------|-------------|-------|----------|-----|
 | UT-AS-1056-001 | 401 error retries and succeeds on 2nd attempt | Mock returns HTTPError{401} once, then succeeds | `AttemptCount() >= 2`, `BatchCount() == 1` | #1056 |
 | UT-AS-1056-002 | Auth error logging contains diagnostic context | Mock returns HTTPError{401}; capture error logs | Log contains "auth" or "token" context | #1056 |
+| UT-AS-1056-003 | Persistent 401 exhausts all retries | Mock returns HTTPError{401} for all attempts | Batch dropped, "Dropping"/"max retries" log emitted | #1056 |
 
 ---
 
@@ -174,7 +178,7 @@ immediately dropped with a misleading "invalid data" log message. The fix reclas
 
 ### 7.1 Pass Criteria
 
-- All 16 test cases pass
+- All 21 test cases pass
 - `go build ./...` succeeds with zero errors
 - `go test -race ./test/unit/shared/auth/...` reports zero races
 - `golangci-lint run --timeout=5m` introduces zero new errors

--- a/docs/tests/1055-1056/TEST_PLAN.md
+++ b/docs/tests/1055-1056/TEST_PLAN.md
@@ -1,0 +1,223 @@
+# Test Plan: SA Token Refresh and Audit 401 Handling
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+>
+> Based on IEEE 829-2008 (Standard for Software and System Test Documentation) with
+> Kubernaut-specific extensions for TDD phase tracking, business requirement traceability,
+> and per-tier coverage policy.
+
+**Test Plan Identifier**: TP-1055-1056-v1
+**Feature**: Fix SA token cached forever (#1055) and audit batches silently dropped on 401 (#1056)
+**Version**: 1.0
+**Created**: 2026-05-06
+**Author**: AI Assistant
+**Status**: Active
+**Branch**: `fix/1055-1056-sa-token-refresh-audit-401`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This test plan validates two coupled bug fixes shipping on a single branch:
+
+**Bug A (Issue #1055)**: `bearerTransport` in `cmd/kubernautagent/main.go` reads the
+ServiceAccount token once at startup via `os.ReadFile` and stores it as a static string.
+After ~1 hour when kubelet rotates the projected token, all DataStorage and audit calls
+fail with 401 Unauthorized. The fix replaces `bearerTransport` with the existing
+`AuthTransport` pattern (5-minute TTL cache + 401 cache invalidation).
+
+**Bug B (Issue #1056)**: `pkg/audit/errors.go` treats ALL 4xx HTTP errors as non-retryable
+("invalid data"), including 401/403 (authentication/authorization). Audit batches are
+immediately dropped with a misleading "invalid data" log message. The fix reclassifies
+401/403 as retryable auth errors and adds distinct logging.
+
+### 1.2 Objectives
+
+1. **Token refresh**: `AuthTransport` re-reads the SA token from disk when the 5-minute cache expires or when a 401 response invalidates the cache
+2. **401 retry**: Audit store retries on 401/403 errors instead of silently dropping batches
+3. **Observability**: Auth errors produce distinct log messages differentiating them from data errors (400/422)
+4. **Pattern convergence**: KA uses the same `AuthTransport` as all other services (eliminates one-off `bearerTransport`)
+5. **No regressions**: All existing tests pass; `bearerTransport` removal does not affect integration test types
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/shared/auth/... ./test/unit/audit/...` |
+| Build success | 0 errors | `go build ./...` |
+| Lint compliance | 0 new errors | `golangci-lint run --timeout=5m` |
+| `bearerTransport` in production | 0 references | `grep -r 'bearerTransport' cmd/ pkg/ --include='*.go'` |
+| Race detector | 0 races | `go test -race ./test/unit/shared/auth/...` |
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- **Issue #1055**: kubernaut-agent: SA token cached in memory, expires after 1h causing silent 401 failures
+- **Issue #1056**: kubernaut-agent: audit event batches silently dropped on non-retryable 401 errors
+- **DD-AUTH-005**: DataStorage Client Authentication Pattern
+- **DD-AUDIT-002**: Audit Shared Library Design
+- **ADR-032**: No Audit Loss
+
+### 2.2 Cross-References
+
+- [Testing Guidelines](../../development/business-requirements/TESTING_GUIDELINES.md)
+- [Testing Strategy](../../../.cursor/rules/03-testing-strategy.mdc)
+- [Go Coding Standards](../../../.cursor/rules/02-go-coding-standards.mdc)
+- [100 Go Mistakes](https://100go.co) — TDD REFACTOR validation reference
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | 401 invalidation under concurrent storm causes excessive file reads | Performance degradation | Low | UT-AT-1055-005 | Benign: multiple goroutines re-read ~1KB file; cache re-populates on next read. Validated under -race. |
+| R2 | `NewOpenAPIClientAdapterWithTransport` double-wraps auth | Double Bearer header | Low | UT-AT-1055-001 | Preflight verified: adapter skips wrapping when transport is non-nil. |
+| R3 | Integration test `bearerTransport` type breaks | Test compilation failure | None | N/A | Integration tests define their own independent `bearerTransport` type in a separate package. |
+| R4 | `os` import becomes unused after removing `os.ReadFile` calls | Build failure | None | N/A | 23+ other `os.*` usages remain in main.go. |
+| R5 | Existing 401/403 `IsRetryable=false` assertions in errors_test.go | Test flips needed | Certain | UT-AE-1056-001/002 | Intentional: flip assertions from `BeFalse` to `BeTrue` in RED phase. |
+
+### 3.1 Risk-to-Test Traceability
+
+- **R1**: Mitigated by UT-AT-1055-005 (10+ goroutine race test)
+- **R2**: Preflight code review of `NewOpenAPIClientAdapterWithTransport` nil-check logic
+- **R5**: Mitigated by UT-AE-1056-001/002 (explicit assertion flips)
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **AuthTransport custom path constructor** (`pkg/shared/auth/transport.go`): `NewServiceAccountTransportWithPath` reads from configurable path
+- **401 cache invalidation** (`pkg/shared/auth/transport.go`): `RoundTrip` zeroes cache time on 401 response
+- **Auth error classification** (`pkg/audit/errors.go`): `IsAuthError()` for 401/403; `IsRetryable()` returns true for auth errors
+- **Audit store retry on auth errors** (`pkg/audit/store.go`): `writeBatchWithRetry` retries 401/403 instead of dropping
+- **Auth error logging** (`pkg/audit/store.go`): Distinct log message for auth vs data errors
+- **bearerTransport removal** (`cmd/kubernautagent/main.go`): Replaced by `AuthTransport` in `initDSClients` and `buildAuditStore`
+
+### 4.2 Features Not to be Tested
+
+- **Integration test `bearerTransport`**: Independent type in `test/integration/datastorage/`, unaffected
+- **E2E token rotation**: Requires Kind cluster with projected SA volumes; deferred to post-merge
+- **Prometheus metrics for auth retry**: Follow-up item (SRE-M1), not blocking
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+**Authority**: TESTING_GUIDELINES.md — Per-Tier Testable Code Coverage (>=80% per tier).
+
+- **Unit**: >=80% of unit-testable code (transport constructors, cache logic, error classification, retry paths)
+- **Integration**: Existing integration tests unaffected (different `bearerTransport` type)
+- **E2E**: Deferred — requires Kind cluster with token rotation; validated post-merge
+
+### 5.2 TDD Phases
+
+| Phase | Description | Tests | Checkpoint |
+|-------|-------------|-------|------------|
+| RED | Write failing tests for all new behavior | UT-AT-1055-001..005, UT-AE-1056-001..009, UT-AS-1056-001..002 | CHECKPOINT 1 |
+| GREEN | Minimal implementation to pass all tests | Production code changes | CHECKPOINT 2 |
+| REFACTOR | 100 Go Mistakes audit, code cleanup, lint | N/A (quality pass) | CHECKPOINT 3 |
+
+---
+
+## 6. Test Design Specification
+
+### 6.1 AuthTransport Tests (Tier 1 — Unit)
+
+**Test file**: `test/unit/shared/auth/transport_test.go`
+
+| Test ID | Description | Input | Expected | BR |
+|---------|-------------|-------|----------|-----|
+| UT-AT-1055-001 | Custom path constructor reads from specified path | Token file at temp path; `NewServiceAccountTransportWithPath(tempPath, base)` | `Authorization: Bearer <token>` header injected | #1055 |
+| UT-AT-1055-002 | 401 response invalidates token cache | RoundTrip returns 401; next call checks cache | Next getServiceAccountToken re-reads from disk | #1055 |
+| UT-AT-1055-003 | Token re-read after invalidation picks up new content | Write "token-v1" to file, get 401, write "token-v2", next request | Second request uses "token-v2" | #1055 |
+| UT-AT-1055-004 | Non-401 responses do not invalidate cache | RoundTrip returns 200, 500 | Cache remains valid (no file re-read) | #1055 |
+| UT-AT-1055-005 | Concurrent RoundTrip under 401 storm | 10+ goroutines, all getting 401, with -race | No data races, no panics | #1055 |
+
+### 6.2 Audit Error Tests (Tier 1 — Unit)
+
+**Test file**: `test/unit/audit/errors_test.go`
+
+| Test ID | Description | Input | Expected | BR |
+|---------|-------------|-------|----------|-----|
+| UT-AE-1056-001 | 401 is retryable | `HTTPError{401}` | `IsRetryable() == true` | #1056 |
+| UT-AE-1056-002 | 403 is retryable | `HTTPError{403}` | `IsRetryable() == true` | #1056 |
+| UT-AE-1056-003 | 400 is NOT retryable | `HTTPError{400}` | `IsRetryable() == false` | #1056 |
+| UT-AE-1056-004 | 422 is NOT retryable | `HTTPError{422}` | `IsRetryable() == false` | #1056 |
+| UT-AE-1056-005 | IsAuthError(401) | `HTTPError{401}` | `IsAuthError() == true` | #1056 |
+| UT-AE-1056-006 | IsAuthError(403) | `HTTPError{403}` | `IsAuthError() == true` | #1056 |
+| UT-AE-1056-007 | IsAuthError(400) | `HTTPError{400}` | `IsAuthError() == false` | #1056 |
+| UT-AE-1056-008 | IsAuthError(500) | `HTTPError{500}` | `IsAuthError() == false` | #1056 |
+| UT-AE-1056-009 | Package-level IsAuthError with wrapped 401 | `fmt.Errorf("ctx: %w", HTTPError{401})` | `IsAuthError() == true` | #1056 |
+
+### 6.3 Audit Store Retry Tests (Tier 1 — Unit)
+
+**Test file**: `test/unit/audit/store_test.go`
+
+| Test ID | Description | Input | Expected | BR |
+|---------|-------------|-------|----------|-----|
+| UT-AS-1056-001 | 401 error retries and succeeds on 2nd attempt | Mock returns HTTPError{401} once, then succeeds | `AttemptCount() >= 2`, `BatchCount() == 1` | #1056 |
+| UT-AS-1056-002 | Auth error logging contains diagnostic context | Mock returns HTTPError{401}; capture error logs | Log contains "auth" or "token" context | #1056 |
+
+---
+
+## 7. Pass/Fail Criteria
+
+### 7.1 Pass Criteria
+
+- All 16 test cases pass
+- `go build ./...` succeeds with zero errors
+- `go test -race ./test/unit/shared/auth/...` reports zero races
+- `golangci-lint run --timeout=5m` introduces zero new errors
+- `grep -r 'bearerTransport' cmd/ pkg/ --include='*.go'` returns zero hits
+
+### 7.2 Fail Criteria
+
+- Any test case fails
+- Build errors in any package
+- Race detector reports data races
+- New lint errors introduced
+
+### 7.3 Suspension Criteria
+
+- If `AuthTransport` changes break other services' tests, suspend and investigate shared component impact
+
+---
+
+## 8. Checkpoint Audit Categories
+
+At each checkpoint (1, 2, 3), audit all 9 categories before advancing:
+
+1. **Observability wiring**: No new metrics defined. Existing `audit_events_dropped_total` covered by store_test.go.
+2. **Adversarial inputs**: Empty path, path traversal, Unicode path for transport; boundary status codes (0, -1, 399, 600) for errors.
+3. **Resource bounds**: `tokenCache` is a single string, not a growing structure. N/A.
+4. **Concurrency**: UT-AT-1055-005 covers 10+ goroutine race test under -race.
+5. **Nil/zero edge cases**: Nil base transport, zero tokenCacheTime, zero StatusCode.
+6. **Error-path observability**: Auth error log includes status_code, attempt, batch_size.
+7. **Cross-phase integration**: Phase 2D wires AuthTransport into initDSClients/buildAuditStore.
+8. **Spec compliance**: http.RoundTripper contract (no request mutation, no body consumption). RFC 6750 Bearer.
+9. **API surface hygiene**: `invalidateTokenCache` unexported. `IsAuthError` mirrors existing `Is4xxError` pattern.
+
+---
+
+## 9. Deliverables
+
+| Deliverable | Location |
+|-------------|----------|
+| Test plan | `docs/tests/1055-1056/TEST_PLAN.md` |
+| AuthTransport tests | `test/unit/shared/auth/transport_test.go` |
+| Audit error tests | `test/unit/audit/errors_test.go` |
+| Audit store tests | `test/unit/audit/store_test.go` |
+| AuthTransport implementation | `pkg/shared/auth/transport.go` |
+| Audit error implementation | `pkg/audit/errors.go` |
+| Audit store logging | `pkg/audit/store.go` |
+| bearerTransport removal | `cmd/kubernautagent/main.go` |

--- a/docs/tests/1055-1056/TEST_PLAN.md
+++ b/docs/tests/1055-1056/TEST_PLAN.md
@@ -123,7 +123,7 @@ immediately dropped with a misleading "invalid data" log message. The fix reclas
 
 | Phase | Description | Tests | Checkpoint |
 |-------|-------------|-------|------------|
-| RED | Write failing tests for all new behavior | UT-AT-1055-001..008, UT-AE-1056-001..009, UT-AS-1056-001..003 | CHECKPOINT 1 |
+| RED | Write failing tests for all new behavior | UT-AT-1055-001..009, UT-AE-1056-001..009, UT-AS-1056-001..003 | CHECKPOINT 1 |
 | GREEN | Minimal implementation to pass all tests | Production code changes | CHECKPOINT 2 |
 | REFACTOR | 100 Go Mistakes audit, code cleanup, lint | N/A (quality pass) | CHECKPOINT 3 |
 
@@ -137,14 +137,15 @@ immediately dropped with a misleading "invalid data" log message. The fix reclas
 
 | Test ID | Description | Input | Expected | BR |
 |---------|-------------|-------|----------|-----|
-| UT-AT-1055-001 | Custom path constructor reads from specified path | Token file at temp path; `NewServiceAccountTransportWithPath(tempPath, base)` | `Authorization: Bearer <token>` header injected | #1055 |
-| UT-AT-1055-002 | 401 response invalidates token cache | RoundTrip returns 401; next call checks cache | Next getServiceAccountToken re-reads from disk | #1055 |
+| UT-AT-1055-001 | Custom path constructor reads from specified path | Token file at temp path; `NewTokenSource(tempPath)` + `NewAuthTransport(ts, base)` | `Authorization: Bearer <token>` header injected | #1055 |
+| UT-AT-1055-002 | 401 response invalidates token cache | RoundTrip returns 401; next call checks cache | Next Token() re-reads from disk | #1055 |
 | UT-AT-1055-003 | Token re-read after invalidation picks up new content | Write "token-v1" to file, get 401, write "token-v2", next request | Second request uses "token-v2" | #1055 |
 | UT-AT-1055-004 | Non-401 responses do not invalidate cache | RoundTrip returns 200, 500 | Cache remains valid (no file re-read) | #1055 |
 | UT-AT-1055-005 | Concurrent RoundTrip under 401 storm | 10+ goroutines, all getting 401, with -race | No data races, no panics | #1055 |
-| UT-AT-1055-006 | Nil base transport defaults to http.DefaultTransport | `NewServiceAccountTransportWithPath(path, nil)` | Request succeeds with Bearer header | #1055 |
-| UT-AT-1055-007 | Empty token path degrades gracefully | `NewServiceAccountTransportWithPath("", base)` | Request proceeds without auth header | #1055 |
+| UT-AT-1055-006 | Nil base transport defaults to http.DefaultTransport | `NewAuthTransport(ts, nil)` | Request succeeds with Bearer header | #1055 |
+| UT-AT-1055-007 | Empty token path degrades gracefully | `NewTokenSource("")` + `NewAuthTransport(ts, base)` | Request proceeds without auth header | #1055 |
 | UT-AT-1055-008 | Token file deleted mid-operation | File exists → cached → deleted → 401 invalidation | Next request proceeds without auth header | #1055 |
+| UT-AT-1055-009 | Shared TokenSource: 401 on transport A invalidates cache for transport B | Two transports share one TokenSource; A gets 401 | B picks up fresh token on next request | #1055 |
 
 ### 6.2 Audit Error Tests (Tier 1 — Unit)
 
@@ -178,7 +179,7 @@ immediately dropped with a misleading "invalid data" log message. The fix reclas
 
 ### 7.1 Pass Criteria
 
-- All 21 test cases pass
+- All 22 test cases pass
 - `go build ./...` succeeds with zero errors
 - `go test -race ./test/unit/shared/auth/...` reports zero races
 - `golangci-lint run --timeout=5m` introduces zero new errors

--- a/docs/tests/1055-1056/TEST_PLAN.md
+++ b/docs/tests/1055-1056/TEST_PLAN.md
@@ -179,7 +179,7 @@ immediately dropped with a misleading "invalid data" log message. The fix reclas
 
 ### 7.1 Pass Criteria
 
-- All 22 test cases pass
+- All 21 test cases pass
 - `go build ./...` succeeds with zero errors
 - `go test -race ./test/unit/shared/auth/...` reports zero races
 - `golangci-lint run --timeout=5m` introduces zero new errors

--- a/pkg/agentclient/client.go
+++ b/pkg/agentclient/client.go
@@ -86,7 +86,7 @@ func NewKubernautAgentClient(cfg Config) (*KubernautAgentClient, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create TLS-aware base transport: %w", err)
 	}
-	transport := auth.NewServiceAccountTransportWithBase(baseTransport)
+	transport := auth.NewAuthTransport(auth.NewDefaultTokenSource(), baseTransport)
 
 	return newClientWithHTTP(cfg, &http.Client{
 		Timeout:   defaultTimeout(cfg),

--- a/pkg/audit/errors.go
+++ b/pkg/audit/errors.go
@@ -59,10 +59,22 @@ func (e *HTTPError) Error() string {
 	return fmt.Sprintf("Data Storage Service returned status %d: %s", e.StatusCode, e.Message)
 }
 
-// IsRetryable returns true for 5xx errors (server errors)
-// 4xx errors (client errors) are NOT retryable - they indicate invalid data
+// IsRetryable returns true for errors that may succeed on retry:
+// - 401/403 auth errors: transient when using file-based SA token rotation (#1056)
+// - 5xx server errors: transient infrastructure failures
+// Other 4xx errors (400, 422) are NOT retryable — they indicate invalid request data.
 func (e *HTTPError) IsRetryable() bool {
+	if e.IsAuthError() {
+		return true
+	}
 	return e.StatusCode >= 500 && e.StatusCode < 600
+}
+
+// IsAuthError returns true for authentication/authorization errors (401, 403).
+// These are classified separately from data errors (400, 422) because auth errors
+// are transient when services use file-based SA token rotation (#1056).
+func (e *HTTPError) IsAuthError() bool {
+	return e.StatusCode == 401 || e.StatusCode == 403
 }
 
 // Is4xxError returns true for client errors (400-499)
@@ -167,6 +179,19 @@ func Is5xxError(err error) bool {
 	var httpErr *HTTPError
 	if errors.As(err, &httpErr) {
 		return httpErr.Is5xxError()
+	}
+	return false
+}
+
+// IsAuthError checks if an error is an authentication/authorization HTTP error (401/403).
+// Supports wrapped errors via errors.As (#1056).
+func IsAuthError(err error) bool {
+	if err == nil {
+		return false
+	}
+	var httpErr *HTTPError
+	if errors.As(err, &httpErr) {
+		return httpErr.IsAuthError()
 	}
 	return false
 }

--- a/pkg/audit/errors.go
+++ b/pkg/audit/errors.go
@@ -73,6 +73,12 @@ func (e *HTTPError) IsRetryable() bool {
 // IsAuthError returns true for authentication/authorization errors (401, 403).
 // These are classified separately from data errors (400, 422) because auth errors
 // are transient when services use file-based SA token rotation (#1056).
+//
+// Note on 401 vs 403 retry semantics:
+// - 401: AuthTransport invalidates the token cache → next retry re-reads from disk → self-heals.
+// - 403: AuthTransport does NOT invalidate the cache (refresh won't fix a permissions issue).
+//   Retries for 403 rely on RBAC propagation delays resolving between attempts. If the 403
+//   persists, the batch is dropped after MaxRetries like any other exhausted-retries path.
 func (e *HTTPError) IsAuthError() bool {
 	return e.StatusCode == 401 || e.StatusCode == 403
 }

--- a/pkg/audit/openapi_client_adapter.go
+++ b/pkg/audit/openapi_client_adapter.go
@@ -147,9 +147,9 @@ func NewOpenAPIClientAdapterWithTransport(baseURL string, timeout time.Duration,
 	// ========================================
 	if transport == nil {
 		// Production: Use ServiceAccount transport (default).
-		// Issue #678: DefaultBaseTransport picks up TLS_CA_FILE env var
-		// to trust the cluster CA for inter-service HTTPS.
-		baseTransport, err := sharedtls.DefaultBaseTransport()
+		// Issue #678: TLS_CA_FILE honoured for inter-service HTTPS.
+		// Issue #853: Wrapped with RetryTransport for transient failure resilience.
+		baseTransport, err := sharedtls.DefaultBaseTransportWithRetry()
 		if err != nil {
 			return nil, fmt.Errorf("failed to create base transport: %w", err)
 		}

--- a/pkg/audit/openapi_client_adapter.go
+++ b/pkg/audit/openapi_client_adapter.go
@@ -153,7 +153,7 @@ func NewOpenAPIClientAdapterWithTransport(baseURL string, timeout time.Duration,
 		if err != nil {
 			return nil, fmt.Errorf("failed to create base transport: %w", err)
 		}
-		transport = auth.NewServiceAccountTransportWithBase(baseTransport)
+		transport = auth.NewAuthTransport(auth.NewDefaultTokenSource(), baseTransport)
 	}
 
 	// Create HTTP client with auth transport (ServiceAccount or mock)

--- a/pkg/audit/store.go
+++ b/pkg/audit/store.go
@@ -549,8 +549,9 @@ func (s *BufferedAuditStore) writeBatchWithRetry(batch []*ogenclient.AuditEventR
 		if err != nil {
 			// #1056: Distinguish auth errors from data errors for observability
 			if IsAuthError(err) {
-				s.logger.Error(err, "Auth error writing audit batch (token may be expired, will retry)",
+				s.logger.Error(err, "Auth error writing audit batch (token expired or insufficient permissions, will retry)",
 					"attempt", attempt,
+					"max_retries", s.config.MaxRetries,
 					"batch_size", len(batch),
 				)
 			} else {

--- a/pkg/audit/store.go
+++ b/pkg/audit/store.go
@@ -547,19 +547,27 @@ func (s *BufferedAuditStore) writeBatchWithRetry(batch []*ogenclient.AuditEventR
 		cancel()
 
 		if err != nil {
-			s.logger.Error(err, "Failed to write audit batch",
-				"attempt", attempt,
-				"batch_size", len(batch),
-			)
+			// #1056: Distinguish auth errors from data errors for observability
+			if IsAuthError(err) {
+				s.logger.Error(err, "Auth error writing audit batch (token may be expired, will retry)",
+					"attempt", attempt,
+					"batch_size", len(batch),
+				)
+			} else {
+				s.logger.Error(err, "Failed to write audit batch",
+					"attempt", attempt,
+					"batch_size", len(batch),
+				)
+			}
 
-			// GAP-10/GAP-11: Check if error is retryable
-			// 4xx errors are NOT retryable (invalid data)
+			// GAP-10/GAP-11/#1056: Check if error is retryable
+			// 401/403 auth errors ARE retryable (token refresh will fix)
 			// 5xx and network errors ARE retryable
+			// Other 4xx errors (400, 422) are NOT retryable (invalid request data)
 			if !IsRetryable(err) {
-				// Non-retryable error (4xx) - don't retry, log as invalid
 				atomic.AddInt64(&s.failedBatchCount, 1)
 
-				s.logger.Error(nil, "Dropping audit batch due to non-retryable error (invalid data)",
+				s.logger.Error(nil, "Dropping audit batch due to non-retryable client error (invalid request data)",
 					"batch_size", len(batch),
 					"is_4xx_error", Is4xxError(err),
 				)

--- a/pkg/authwebhook/ds_client.go
+++ b/pkg/authwebhook/ds_client.go
@@ -65,7 +65,7 @@ func NewDSClientAdapter(baseURL string, timeout time.Duration, logger logr.Logge
 	if err != nil {
 		return nil, fmt.Errorf("failed to create TLS-aware base transport: %w", err)
 	}
-	transport := auth.NewServiceAccountTransportWithBase(baseTransport)
+	transport := auth.NewAuthTransport(auth.NewDefaultTokenSource(), baseTransport)
 
 	httpClient := &http.Client{
 		Timeout:   timeout,

--- a/pkg/effectivenessmonitor/client/ds_querier.go
+++ b/pkg/effectivenessmonitor/client/ds_querier.go
@@ -71,7 +71,7 @@ func NewOgenDataStorageQuerierWithTransport(baseURL string, timeout time.Duratio
 		if err != nil {
 			return nil, fmt.Errorf("failed to create base transport: %w", err)
 		}
-		transport = auth.NewServiceAccountTransportWithBase(baseTransport)
+		transport = auth.NewAuthTransport(auth.NewDefaultTokenSource(), baseTransport)
 	}
 
 	httpClient := &http.Client{

--- a/pkg/effectivenessmonitor/client/tls.go
+++ b/pkg/effectivenessmonitor/client/tls.go
@@ -49,7 +49,7 @@ func BuildCertPool(pemData []byte) (*x509.CertPool, error) {
 // service-serving signer).
 //
 // The returned client has TLS configured but no bearer token injection.
-// Callers can wrap client.Transport with auth.NewServiceAccountTransportWithBase
+// Callers can wrap client.Transport with auth.NewAuthTransport(auth.NewDefaultTokenSource(), base)
 // to add SA token authentication.
 func NewHTTPClientWithCA(caFile string, timeout time.Duration) (*http.Client, error) {
 	caCert, err := os.ReadFile(caFile)

--- a/pkg/kubernautagent/tools/prometheus/client.go
+++ b/pkg/kubernautagent/tools/prometheus/client.go
@@ -41,7 +41,7 @@ type ClientConfig struct {
 
 	// Transport overrides the http.Client's RoundTripper. When set, it is used
 	// as the underlying transport for all Prometheus API requests. This enables
-	// SA bearer token injection on OCP (via auth.NewServiceAccountTransportWithBase)
+	// SA bearer token injection on OCP (via auth.NewAuthTransport)
 	// and custom TLS trust (via sharedtls). When nil, http.DefaultTransport is used.
 	Transport http.RoundTripper `yaml:"-"`
 }

--- a/pkg/remediationorchestrator/routing/ds_history_adapter.go
+++ b/pkg/remediationorchestrator/routing/ds_history_adapter.go
@@ -70,7 +70,7 @@ func NewDSHistoryAdapterFromConfig(baseURL string, timeout time.Duration) (*DSHi
 	if err != nil {
 		return nil, fmt.Errorf("failed to create base transport: %w", err)
 	}
-	transport := auth.NewServiceAccountTransportWithBase(baseTransport)
+	transport := auth.NewAuthTransport(auth.NewDefaultTokenSource(), baseTransport)
 
 	ogenClient, err := ogenclient.NewClient(baseURL, ogenclient.WithClient(&http.Client{
 		Timeout:   timeout,

--- a/pkg/remediationorchestrator/routing/ds_workflow_adapter.go
+++ b/pkg/remediationorchestrator/routing/ds_workflow_adapter.go
@@ -83,7 +83,7 @@ func NewDSWorkflowAdapterFromConfig(baseURL string, timeout time.Duration) (*DSW
 	if err != nil {
 		return nil, fmt.Errorf("failed to create base transport: %w", err)
 	}
-	transport := auth.NewServiceAccountTransportWithBase(baseTransport)
+	transport := auth.NewAuthTransport(auth.NewDefaultTokenSource(), baseTransport)
 
 	ogenClient, err := ogenclient.NewClient(baseURL, ogenclient.WithClient(&http.Client{
 		Timeout:   timeout,

--- a/pkg/shared/auth/transport.go
+++ b/pkg/shared/auth/transport.go
@@ -22,6 +22,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/go-logr/logr"
 )
 
 // ========================================
@@ -96,12 +98,22 @@ type TokenSource struct {
 	// Writes use atomic.AddInt64 (under tokenCacheMutex for cache consistency).
 	// Reads use atomic.LoadInt64 (no mutex needed — atomics are self-synchronizing).
 	tokenInvalidationCount int64
+
+	logger         logr.Logger
+	lastReadFailed bool
 }
 
 // NewTokenSource creates a TokenSource that reads SA tokens from the given path.
 // Use NewDefaultTokenSource for the standard Kubernetes projected volume path.
 func NewTokenSource(path string) *TokenSource {
-	return &TokenSource{tokenPath: path}
+	return &TokenSource{tokenPath: path, logger: logr.Discard()}
+}
+
+// SetLogger configures a logger for token lifecycle events (cache invalidation,
+// file read failures, recovery). By default, TokenSource uses logr.Discard().
+// Callers in cmd/ can wire a real logger for SRE observability.
+func (ts *TokenSource) SetLogger(l logr.Logger) {
+	ts.logger = l
 }
 
 // NewDefaultTokenSource creates a TokenSource for the standard Kubernetes
@@ -131,7 +143,16 @@ func (ts *TokenSource) Token() string {
 
 	tokenBytes, err := os.ReadFile(ts.tokenPath)
 	if err != nil {
+		ts.lastReadFailed = true
+		ts.logger.V(1).Info("token file read failed, requests will proceed without auth",
+			"path", ts.tokenPath, "error", err)
 		return ""
+	}
+
+	if ts.lastReadFailed {
+		ts.logger.Info("token file recovered, auth resumed",
+			"path", ts.tokenPath)
+		ts.lastReadFailed = false
 	}
 
 	ts.tokenCache = string(tokenBytes)
@@ -147,7 +168,9 @@ func (ts *TokenSource) Invalidate() {
 	ts.tokenCacheMutex.Lock()
 	defer ts.tokenCacheMutex.Unlock()
 	ts.tokenCacheTime = time.Time{}
-	atomic.AddInt64(&ts.tokenInvalidationCount, 1)
+	count := atomic.AddInt64(&ts.tokenInvalidationCount, 1)
+	ts.logger.V(1).Info("token cache invalidated due to 401 response",
+		"path", ts.tokenPath, "invalidation_count", count)
 }
 
 // InvalidationCount returns the number of times the cache was invalidated

--- a/pkg/shared/auth/transport.go
+++ b/pkg/shared/auth/transport.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -89,6 +90,10 @@ type AuthTransport struct {
 	tokenCache      string
 	tokenCacheTime  time.Time
 	tokenCacheMutex sync.RWMutex
+
+	// Observability: counts how many times the cache was invalidated due to 401.
+	// Exposed via TokenInvalidationCount() for metrics/testing (SRE-M1).
+	tokenInvalidationCount int64
 }
 
 // NewServiceAccountTransport creates a transport that reads tokens from the ServiceAccount filesystem.
@@ -161,9 +166,14 @@ func (t *AuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 	resp, err := t.base.RoundTrip(reqClone)
 	if err == nil && resp.StatusCode == http.StatusUnauthorized {
-		// #1055: Invalidate cached token on 401 so the next request re-reads
-		// from disk. This handles kubelet SA token rotation where the file
-		// has been updated but our cache still holds the stale token.
+		// #1055: Only 401 triggers cache invalidation, NOT 403. Rationale:
+		// - 401 (Unauthorized) = credential expired/invalid → re-reading the
+		//   rotated token from disk will fix it.
+		// - 403 (Forbidden) = valid credential but insufficient permissions →
+		//   re-reading the same token won't help; the issue is RBAC, not expiry.
+		// The audit layer (pkg/audit/errors.go) retries both 401 and 403 because
+		// RBAC propagation delays can cause transient 403s, but the transport
+		// only refreshes credentials on 401.
 		t.invalidateTokenCache()
 	}
 	return resp, err
@@ -227,4 +237,11 @@ func (t *AuthTransport) invalidateTokenCache() {
 	t.tokenCacheMutex.Lock()
 	defer t.tokenCacheMutex.Unlock()
 	t.tokenCacheTime = time.Time{}
+	atomic.AddInt64(&t.tokenInvalidationCount, 1)
+}
+
+// TokenInvalidationCount returns the number of times the token cache was
+// invalidated due to a 401 response. Useful for Prometheus metrics and testing.
+func (t *AuthTransport) TokenInvalidationCount() int64 {
+	return atomic.LoadInt64(&t.tokenInvalidationCount)
 }

--- a/pkg/shared/auth/transport.go
+++ b/pkg/shared/auth/transport.go
@@ -63,15 +63,18 @@ import (
 // AuthTransport is an http.RoundTripper that handles authentication for DataStorage API calls.
 //
 // Behavior:
-// - Reads token from /var/run/secrets/kubernetes.io/serviceaccount/token
+// - Reads token from a configurable filesystem path (default: /var/run/secrets/kubernetes.io/serviceaccount/token)
 // - Used by: ALL services in production, E2E, and integration (with mounted tokens)
 // - Injects: Authorization: Bearer <token>
 // - Caching: 5-minute cache to avoid filesystem reads on every request
+// - 401 cache invalidation: When downstream returns 401 Unauthorized, the token
+//   cache is immediately invalidated so the next request re-reads from disk.
+//   This handles kubelet SA token rotation (#1055).
 // - Graceful degradation: If token file missing, request proceeds without auth
 //
 // Thread Safety:
-// - RoundTrip() is thread-safe (clones request, no shared state mutation)
-// - Token caching uses sync.RWMutex for concurrent access
+// - RoundTrip() is thread-safe (clones request, cache uses sync.RWMutex)
+// - invalidateTokenCache() is safe for concurrent use
 //
 // DD-AUTH-005: This transport enables all 7 Go services to authenticate with
 // DataStorage without modifying the OpenAPI-generated client code.
@@ -119,6 +122,22 @@ func NewServiceAccountTransportWithBase(base http.RoundTripper) *AuthTransport {
 	}
 }
 
+// NewServiceAccountTransportWithPath creates a ServiceAccount transport that reads tokens
+// from a custom filesystem path. Used by kubernaut-agent where the SA token path is
+// configurable via config.DataStorageConfig.SATokenPath (#1055).
+//
+// The transport caches the token for 5 minutes and invalidates the cache on 401 responses,
+// enabling automatic recovery when kubelet rotates the projected SA token.
+func NewServiceAccountTransportWithPath(tokenPath string, base http.RoundTripper) *AuthTransport {
+	if base == nil {
+		base = http.DefaultTransport
+	}
+	return &AuthTransport{
+		base:      base,
+		tokenPath: tokenPath,
+	}
+}
+
 // RoundTrip implements http.RoundTripper.
 // Injects authentication headers based on the transport mode before forwarding the request.
 //
@@ -140,7 +159,14 @@ func (t *AuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	// This allows services to start before ServiceAccount token is mounted
 	// Also allows local development without Kubernetes
 
-	return t.base.RoundTrip(reqClone)
+	resp, err := t.base.RoundTrip(reqClone)
+	if err == nil && resp.StatusCode == http.StatusUnauthorized {
+		// #1055: Invalidate cached token on 401 so the next request re-reads
+		// from disk. This handles kubelet SA token rotation where the file
+		// has been updated but our cache still holds the stale token.
+		t.invalidateTokenCache()
+	}
+	return resp, err
 }
 
 // getServiceAccountToken retrieves the ServiceAccount token with 5-minute caching.
@@ -189,4 +215,16 @@ func (t *AuthTransport) getServiceAccountToken() string {
 	t.tokenCache = string(tokenBytes)
 	t.tokenCacheTime = time.Now()
 	return t.tokenCache
+}
+
+// invalidateTokenCache zeroes the cache timestamp so the next call to
+// getServiceAccountToken takes the slow path and re-reads from disk.
+// Called when a downstream service returns 401 Unauthorized (#1055).
+//
+// Thread Safety: Uses exclusive Lock (not RLock). Safe to call concurrently
+// from multiple goroutines — redundant invalidations are benign.
+func (t *AuthTransport) invalidateTokenCache() {
+	t.tokenCacheMutex.Lock()
+	defer t.tokenCacheMutex.Unlock()
+	t.tokenCacheTime = time.Time{}
 }

--- a/pkg/shared/auth/transport.go
+++ b/pkg/shared/auth/transport.go
@@ -93,6 +93,8 @@ type AuthTransport struct {
 
 	// Observability: counts how many times the cache was invalidated due to 401.
 	// Exposed via TokenInvalidationCount() for metrics/testing (SRE-M1).
+	// Writes use atomic.AddInt64 (under tokenCacheMutex for cache consistency).
+	// Reads use atomic.LoadInt64 (no mutex needed — atomics are self-synchronizing).
 	tokenInvalidationCount int64
 }
 

--- a/pkg/shared/auth/transport.go
+++ b/pkg/shared/auth/transport.go
@@ -44,9 +44,17 @@ import (
 //
 // Production/E2E (ServiceAccount token from filesystem):
 //
-//	transport := auth.NewServiceAccountTransport()
+//	ts := auth.NewDefaultTokenSource()
+//	transport := auth.NewAuthTransport(ts, http.DefaultTransport)
 //	httpClient := &http.Client{Transport: transport}
 //	dsClient := datastorage.NewClientWithResponses(url, datastorage.WithHTTPClient(httpClient))
+//
+// Shared cache (kubernaut-agent: DS client + audit store share one cache):
+//
+//	ts := auth.NewTokenSource(cfg.SATokenPath)
+//	dsTransport := auth.NewAuthTransport(ts, dsBase)
+//	auditTransport := auth.NewAuthTransport(ts, auditBase)
+//	// A 401 on either transport invalidates the cache for both.
 //
 // Integration Tests (Mock user header, no oauth-proxy):
 //
@@ -55,27 +63,111 @@ import (
 //	httpClient := &http.Client{Transport: transport}
 //	dsClient := datastorage.NewClientWithResponses(url, datastorage.WithHTTPClient(httpClient))
 //
-// E2E Tests: Use SAME ServiceAccount transport as production (run tests in pods with mounted tokens)
+// E2E Tests: Use SAME transport as production (run tests in pods with mounted tokens)
 //
 // Authority: DD-AUTH-005 (Authoritative client authentication pattern)
 // Related: DD-AUTH-004 (OAuth-proxy sidecar), DD-HAPI-003 (OpenAPI client mandatory)
 // ========================================
 
-// AuthTransport is an http.RoundTripper that handles authentication for DataStorage API calls.
+const (
+	defaultTokenPath = "/var/run/secrets/kubernetes.io/serviceaccount/token"
+	tokenCacheTTL    = 5 * time.Minute
+)
+
+// TokenSource owns the SA token file path and a thread-safe in-memory cache.
+// Multiple AuthTransport instances can share a single TokenSource so that a
+// 401-triggered cache invalidation on one transport immediately benefits all
+// others reading from the same projected volume.
+//
+// Cache strategy:
+//  1. Check cache with read lock (fast path for cache hits)
+//  2. If cache miss or expired, acquire write lock
+//  3. Double-check after acquiring write lock (avoid thundering herd)
+//  4. Read token from filesystem
+//  5. Update cache
+//
+// Thread Safety: All methods are safe for concurrent use.
+type TokenSource struct {
+	tokenPath       string
+	tokenCache      string
+	tokenCacheTime  time.Time
+	tokenCacheMutex sync.RWMutex
+
+	// Writes use atomic.AddInt64 (under tokenCacheMutex for cache consistency).
+	// Reads use atomic.LoadInt64 (no mutex needed — atomics are self-synchronizing).
+	tokenInvalidationCount int64
+}
+
+// NewTokenSource creates a TokenSource that reads SA tokens from the given path.
+// Use NewDefaultTokenSource for the standard Kubernetes projected volume path.
+func NewTokenSource(path string) *TokenSource {
+	return &TokenSource{tokenPath: path}
+}
+
+// NewDefaultTokenSource creates a TokenSource for the standard Kubernetes
+// projected volume at /var/run/secrets/kubernetes.io/serviceaccount/token.
+func NewDefaultTokenSource() *TokenSource {
+	return NewTokenSource(defaultTokenPath)
+}
+
+// Token returns the cached SA token, re-reading from disk when the cache has
+// expired (5-minute TTL) or been invalidated.
+func (ts *TokenSource) Token() string {
+	ts.tokenCacheMutex.RLock()
+	if time.Since(ts.tokenCacheTime) < tokenCacheTTL && ts.tokenCache != "" {
+		cached := ts.tokenCache
+		ts.tokenCacheMutex.RUnlock()
+		return cached
+	}
+	ts.tokenCacheMutex.RUnlock()
+
+	ts.tokenCacheMutex.Lock()
+	defer ts.tokenCacheMutex.Unlock()
+
+	// Double-check after acquiring write lock (another goroutine may have refreshed)
+	if time.Since(ts.tokenCacheTime) < tokenCacheTTL && ts.tokenCache != "" {
+		return ts.tokenCache
+	}
+
+	tokenBytes, err := os.ReadFile(ts.tokenPath)
+	if err != nil {
+		return ""
+	}
+
+	ts.tokenCache = string(tokenBytes)
+	ts.tokenCacheTime = time.Now()
+	return ts.tokenCache
+}
+
+// Invalidate zeroes the cache timestamp so the next Token() call re-reads from
+// disk. Called by AuthTransport when a downstream 401 indicates credential expiry.
+//
+// Safe to call concurrently — redundant invalidations are benign.
+func (ts *TokenSource) Invalidate() {
+	ts.tokenCacheMutex.Lock()
+	defer ts.tokenCacheMutex.Unlock()
+	ts.tokenCacheTime = time.Time{}
+	atomic.AddInt64(&ts.tokenInvalidationCount, 1)
+}
+
+// InvalidationCount returns the number of times the cache was invalidated
+// due to a 401 response. Useful for Prometheus metrics and testing.
+func (ts *TokenSource) InvalidationCount() int64 {
+	return atomic.LoadInt64(&ts.tokenInvalidationCount)
+}
+
+// AuthTransport is an http.RoundTripper that injects a Bearer token from a
+// shared TokenSource into every outgoing request.
 //
 // Behavior:
-// - Reads token from a configurable filesystem path (default: /var/run/secrets/kubernetes.io/serviceaccount/token)
-// - Used by: ALL services in production, E2E, and integration (with mounted tokens)
-// - Injects: Authorization: Bearer <token>
-// - Caching: 5-minute cache to avoid filesystem reads on every request
-// - 401 cache invalidation: When downstream returns 401 Unauthorized, the token
-//   cache is immediately invalidated so the next request re-reads from disk.
-//   This handles kubelet SA token rotation (#1055).
-// - Graceful degradation: If token file missing, request proceeds without auth
+//   - Reads token via TokenSource (5-minute cache + 401 invalidation)
+//   - Injects: Authorization: Bearer <token>
+//   - 401 cache invalidation: When downstream returns 401 Unauthorized, the
+//     TokenSource cache is immediately invalidated so the next request (from
+//     this or any other transport sharing the same TokenSource) re-reads from disk.
+//   - Graceful degradation: If token file missing, request proceeds without auth
 //
-// Thread Safety:
-// - RoundTrip() is thread-safe (clones request, cache uses sync.RWMutex)
-// - invalidateTokenCache() is safe for concurrent use
+// Thread Safety: RoundTrip() is thread-safe (clones request, TokenSource uses sync.RWMutex).
 //
 // DD-AUTH-005: This transport enables all 7 Go services to authenticate with
 // DataStorage without modifying the OpenAPI-generated client code.
@@ -83,88 +175,36 @@ import (
 // ZERO TEST LOGIC: This production code contains no test-specific modes.
 // For integration tests (mock user headers), use internal/mocks.NewMockUserTransport().
 type AuthTransport struct {
-	base      http.RoundTripper
-	tokenPath string
-
-	// Token caching
-	tokenCache      string
-	tokenCacheTime  time.Time
-	tokenCacheMutex sync.RWMutex
-
-	// Observability: counts how many times the cache was invalidated due to 401.
-	// Exposed via TokenInvalidationCount() for metrics/testing (SRE-M1).
-	// Writes use atomic.AddInt64 (under tokenCacheMutex for cache consistency).
-	// Reads use atomic.LoadInt64 (no mutex needed — atomics are self-synchronizing).
-	tokenInvalidationCount int64
+	base        http.RoundTripper
+	tokenSource *TokenSource
 }
 
-// NewServiceAccountTransport creates a transport that reads tokens from the ServiceAccount filesystem.
-// Used by services in E2E/Production environments.
-//
-// Token Path: /var/run/secrets/kubernetes.io/serviceaccount/token
-// Caching: 5-minute cache to reduce filesystem reads
-// Injects: Authorization: Bearer <token>
-//
-// Usage:
-//
-//	transport := auth.NewServiceAccountTransport()
-//	httpClient := &http.Client{Transport: transport}
-//	dsClient := datastorage.NewClientWithResponses(url, datastorage.WithHTTPClient(httpClient))
-//
-// DD-AUTH-005: This is the PRIMARY transport for production and E2E services.
-// All 7 Go services use this via audit.NewOpenAPIClientAdapter().
-func NewServiceAccountTransport() *AuthTransport {
-	return NewServiceAccountTransportWithBase(http.DefaultTransport)
-}
-
-// NewServiceAccountTransportWithBase creates a ServiceAccount transport with custom base transport.
-// Useful for testing or custom transport configuration (e.g., custom timeouts, TLS).
-func NewServiceAccountTransportWithBase(base http.RoundTripper) *AuthTransport {
+// NewAuthTransport creates an AuthTransport that reads tokens from the given
+// TokenSource and delegates HTTP calls to the given base RoundTripper.
+// If base is nil, http.DefaultTransport is used.
+func NewAuthTransport(ts *TokenSource, base http.RoundTripper) *AuthTransport {
 	if base == nil {
 		base = http.DefaultTransport
 	}
 	return &AuthTransport{
-		base:      base,
-		tokenPath: "/var/run/secrets/kubernetes.io/serviceaccount/token",
-	}
-}
-
-// NewServiceAccountTransportWithPath creates a ServiceAccount transport that reads tokens
-// from a custom filesystem path. Used by kubernaut-agent where the SA token path is
-// configurable via config.DataStorageConfig.SATokenPath (#1055).
-//
-// The transport caches the token for 5 minutes and invalidates the cache on 401 responses,
-// enabling automatic recovery when kubelet rotates the projected SA token.
-func NewServiceAccountTransportWithPath(tokenPath string, base http.RoundTripper) *AuthTransport {
-	if base == nil {
-		base = http.DefaultTransport
-	}
-	return &AuthTransport{
-		base:      base,
-		tokenPath: tokenPath,
+		base:        base,
+		tokenSource: ts,
 	}
 }
 
 // RoundTrip implements http.RoundTripper.
-// Injects authentication headers based on the transport mode before forwarding the request.
+// Injects the Bearer token from the shared TokenSource before forwarding.
 //
 // Thread Safety: Safe for concurrent use (clones request to avoid mutation).
 //
-// DD-AUTH-005: This method is called automatically by the http.Client for every request.
-// Services using the OpenAPI-generated client don't need to know about authentication.
+// DD-AUTH-005: Called automatically by http.Client for every request.
 func (t *AuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	// Clone request to avoid mutating original
-	// CRITICAL: http.RoundTripper must NOT modify the original request
 	reqClone := req.Clone(req.Context())
 
-	// Read token from filesystem (with 5-minute caching)
-	token := t.getServiceAccountToken()
+	token := t.tokenSource.Token()
 	if token != "" {
 		reqClone.Header.Set("Authorization", "Bearer "+token)
 	}
-	// Note: If token file doesn't exist, request proceeds without auth
-	// This allows services to start before ServiceAccount token is mounted
-	// Also allows local development without Kubernetes
 
 	resp, err := t.base.RoundTrip(reqClone)
 	if err == nil && resp.StatusCode == http.StatusUnauthorized {
@@ -176,74 +216,13 @@ func (t *AuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		// The audit layer (pkg/audit/errors.go) retries both 401 and 403 because
 		// RBAC propagation delays can cause transient 403s, but the transport
 		// only refreshes credentials on 401.
-		t.invalidateTokenCache()
+		t.tokenSource.Invalidate()
 	}
 	return resp, err
 }
 
-// getServiceAccountToken retrieves the ServiceAccount token with 5-minute caching.
-// Reduces filesystem reads from every request to once per 5 minutes.
-//
-// Thread Safety: Uses sync.RWMutex for concurrent access.
-//
-// Cache Strategy:
-// 1. Check cache with read lock (fast path for cache hits)
-// 2. If cache miss or expired, acquire write lock
-// 3. Double-check cache after acquiring write lock (avoid race)
-// 4. Read token from filesystem
-// 5. Update cache
-//
-// DD-AUTH-005: 5-minute cache balances performance (reduced filesystem I/O)
-// with security (token rotation every 5 minutes).
-func (t *AuthTransport) getServiceAccountToken() string {
-	// Fast path: Check cache with read lock
-	t.tokenCacheMutex.RLock()
-	if time.Since(t.tokenCacheTime) < 5*time.Minute && t.tokenCache != "" {
-		cached := t.tokenCache
-		t.tokenCacheMutex.RUnlock()
-		return cached
-	}
-	t.tokenCacheMutex.RUnlock()
-
-	// Slow path: Cache miss or expired - read from filesystem with write lock
-	t.tokenCacheMutex.Lock()
-	defer t.tokenCacheMutex.Unlock()
-
-	// Double-check after acquiring write lock (another goroutine may have updated cache)
-	if time.Since(t.tokenCacheTime) < 5*time.Minute && t.tokenCache != "" {
-		return t.tokenCache
-	}
-
-	// Read token from filesystem
-	tokenBytes, err := os.ReadFile(t.tokenPath)
-	if err != nil {
-		// Token file doesn't exist or read error
-		// Common during local development or before ServiceAccount is mounted
-		// Return empty string - request proceeds without auth header
-		return ""
-	}
-
-	// Update cache
-	t.tokenCache = string(tokenBytes)
-	t.tokenCacheTime = time.Now()
-	return t.tokenCache
-}
-
-// invalidateTokenCache zeroes the cache timestamp so the next call to
-// getServiceAccountToken takes the slow path and re-reads from disk.
-// Called when a downstream service returns 401 Unauthorized (#1055).
-//
-// Thread Safety: Uses exclusive Lock (not RLock). Safe to call concurrently
-// from multiple goroutines — redundant invalidations are benign.
-func (t *AuthTransport) invalidateTokenCache() {
-	t.tokenCacheMutex.Lock()
-	defer t.tokenCacheMutex.Unlock()
-	t.tokenCacheTime = time.Time{}
-	atomic.AddInt64(&t.tokenInvalidationCount, 1)
-}
-
-// TokenInvalidationCount returns the number of times the token cache was
-// invalidated due to a 401 response. Useful for Prometheus metrics and testing.
+// TokenInvalidationCount delegates to the underlying TokenSource for backward
+// compatibility with tests that assert on the transport directly.
 func (t *AuthTransport) TokenInvalidationCount() int64 {
-	return atomic.LoadInt64(&t.tokenInvalidationCount)
+	return t.tokenSource.InvalidationCount()
 }

--- a/pkg/workflowexecution/client/workflow_querier.go
+++ b/pkg/workflowexecution/client/workflow_querier.go
@@ -125,7 +125,7 @@ func NewOgenWorkflowQuerierFromConfig(baseURL string, timeout time.Duration) (*O
 	if err != nil {
 		return nil, fmt.Errorf("failed to create base transport: %w", err)
 	}
-	transport := auth.NewServiceAccountTransportWithBase(baseTransport)
+	transport := auth.NewAuthTransport(auth.NewDefaultTokenSource(), baseTransport)
 
 	ogenClient, err := ogenclient.NewClient(baseURL, ogenclient.WithClient(&http.Client{
 		Timeout:   timeout,

--- a/test/integration/effectivenessmonitor/tls_integration_test.go
+++ b/test/integration/effectivenessmonitor/tls_integration_test.go
@@ -132,9 +132,9 @@ var _ = Describe("TLS Integration (Issue #452, BR-EM-002, BR-EM-003)", Label("tl
 
 		// Wrap the TLS transport with a bearer token injector to verify that
 		// layered transports (TLS base + auth wrapper) deliver the token header
-		// over HTTPS. In production, auth.NewServiceAccountTransportWithBase
-		// provides this; here we use a test double because AuthTransport.tokenPath
-		// is unexported and reads from the SA filesystem.
+		// over HTTPS. In production, auth.NewAuthTransport(auth.NewDefaultTokenSource(), base)
+		// provides this; here we use a test double because TokenSource reads from
+		// the SA filesystem.
 		httpClient.Transport = &tokenInjectTransport{
 			base:  httpClient.Transport,
 			token: "test-bearer-token-452",

--- a/test/unit/audit/errors_test.go
+++ b/test/unit/audit/errors_test.go
@@ -55,18 +55,22 @@ var _ = Describe("Audit Error Types (GAP-11)", func() {
 			Expect(err.Is5xxError()).To(BeFalse())
 		})
 
-		It("should NOT be retryable for 401 Unauthorized", func() {
+		// UT-AE-1056-001: 401 is retryable (auth errors are transient when using file-based token rotation)
+		It("UT-AE-1056-001: should be retryable for 401 Unauthorized", func() {
 			err := audit.NewHTTPError(401, "Unauthorized")
 
-			Expect(err.IsRetryable()).To(BeFalse())
+			Expect(err.IsRetryable()).To(BeTrue(), "401 auth errors should be retryable (#1056)")
 			Expect(err.Is4xxError()).To(BeTrue())
+			Expect(err.IsAuthError()).To(BeTrue())
 		})
 
-		It("should NOT be retryable for 403 Forbidden", func() {
+		// UT-AE-1056-002: 403 is retryable (auth errors are transient when using file-based token rotation)
+		It("UT-AE-1056-002: should be retryable for 403 Forbidden", func() {
 			err := audit.NewHTTPError(403, "Forbidden")
 
-			Expect(err.IsRetryable()).To(BeFalse())
+			Expect(err.IsRetryable()).To(BeTrue(), "403 auth errors should be retryable (#1056)")
 			Expect(err.Is4xxError()).To(BeTrue())
+			Expect(err.IsAuthError()).To(BeTrue())
 		})
 
 		It("should NOT be retryable for 404 Not Found", func() {
@@ -266,6 +270,70 @@ var _ = Describe("Audit Error Types (GAP-11)", func() {
 			wrappedErr := fmt.Errorf("server error: %w", innerErr)
 
 			Expect(audit.Is5xxError(wrappedErr)).To(BeTrue())
+		})
+	})
+
+	Context("IsAuthError (#1056)", func() {
+		// UT-AE-1056-005: IsAuthError returns true for 401
+		It("UT-AE-1056-005: should return true for 401 Unauthorized", func() {
+			err := audit.NewHTTPError(401, "Unauthorized")
+			Expect(err.IsAuthError()).To(BeTrue())
+		})
+
+		// UT-AE-1056-006: IsAuthError returns true for 403
+		It("UT-AE-1056-006: should return true for 403 Forbidden", func() {
+			err := audit.NewHTTPError(403, "Forbidden")
+			Expect(err.IsAuthError()).To(BeTrue())
+		})
+
+		// UT-AE-1056-007: IsAuthError returns false for 400
+		It("UT-AE-1056-007: should return false for 400 Bad Request", func() {
+			err := audit.NewHTTPError(400, "Bad Request")
+			Expect(err.IsAuthError()).To(BeFalse())
+		})
+
+		// UT-AE-1056-008: IsAuthError returns false for 500
+		It("UT-AE-1056-008: should return false for 500 Internal Server Error", func() {
+			err := audit.NewHTTPError(500, "Internal Server Error")
+			Expect(err.IsAuthError()).To(BeFalse())
+		})
+	})
+
+	Context("IsAuthError package-level helper (#1056)", func() {
+		// UT-AE-1056-009: Package-level IsAuthError with wrapped 401 error
+		It("UT-AE-1056-009: should return true for wrapped 401 error", func() {
+			innerErr := audit.NewHTTPError(401, "Unauthorized")
+			wrappedErr := fmt.Errorf("DS call failed: %w", innerErr)
+
+			Expect(audit.IsAuthError(wrappedErr)).To(BeTrue())
+		})
+
+		It("should return false for wrapped 400 error", func() {
+			innerErr := audit.NewHTTPError(400, "Bad Request")
+			wrappedErr := fmt.Errorf("DS call failed: %w", innerErr)
+
+			Expect(audit.IsAuthError(wrappedErr)).To(BeFalse())
+		})
+
+		It("should return false for non-HTTP errors", func() {
+			err := audit.NewNetworkError(errors.New("timeout"))
+			Expect(audit.IsAuthError(err)).To(BeFalse())
+		})
+
+		It("should return false for nil error", func() {
+			Expect(audit.IsAuthError(nil)).To(BeFalse())
+		})
+
+		// UT-AE-1056-003: Regression guard - 400 remains non-retryable
+		It("UT-AE-1056-003: 400 should remain non-retryable", func() {
+			err := audit.NewHTTPError(400, "Bad Request")
+			Expect(err.IsRetryable()).To(BeFalse(), "400 must NOT be retryable")
+		})
+
+		// UT-AE-1056-004: Regression guard - 422 remains non-retryable
+		It("UT-AE-1056-004: 422 should remain non-retryable", func() {
+			err := audit.NewHTTPError(422, "Unprocessable Entity")
+			Expect(err.IsRetryable()).To(BeFalse(), "422 must NOT be retryable")
 		})
 	})
 })

--- a/test/unit/audit/store_test.go
+++ b/test/unit/audit/store_test.go
@@ -614,6 +614,43 @@ var _ = Describe("BufferedAuditStore", func() {
 			Expect(hasAuthLog).To(BeTrue(),
 				"401 errors should produce auth-specific log messages for SRE diagnosis")
 		})
+
+		// UT-AS-1056-003: Persistent 401 across all retries → batch dropped
+		It("UT-AS-1056-003: should drop batch after persistent 401 exhausts all retries (#1056)", func() {
+			logSink := &errorCaptureSink{}
+			testLogger := logr.New(logSink)
+
+			config := audit.Config{
+				BufferSize:    100,
+				BatchSize:     10,
+				FlushInterval: 100 * time.Millisecond,
+				MaxRetries:    3,
+			}
+			authStore, err := audit.NewBufferedStore(mockClient, config, "test-service", testLogger)
+			Expect(err).ToNot(HaveOccurred())
+			defer func() { _ = authStore.Close() }()
+
+			// 401 persists for all attempts (e.g., token file is also stale)
+			mockClient.SetCustomError(audit.NewHTTPError(401, "Unauthorized"))
+
+			for i := 0; i < 10; i++ {
+				event := createTestEvent()
+				_ = authStore.StoreAudit(ctx, event)
+			}
+
+			// Wait for all retries to exhaust
+			Eventually(func() int {
+				return mockClient.AttemptCount()
+			}, "30s").Should(BeNumerically(">=", 3))
+
+			// Batch should be dropped (not stuck in infinite loop)
+			Expect(mockClient.BatchCount()).To(Equal(0), "Batch should be dropped after max retries")
+
+			// "AUDIT DATA LOSS" log should appear
+			hasDropLog := logSink.hasErrorContaining("Dropping") || logSink.hasErrorContaining("max retries")
+			Expect(hasDropLog).To(BeTrue(),
+				"Persistent 401 should produce batch-drop log for SRE diagnosis")
+		})
 	})
 
 	// NOTE: Client-side DLQ tests (GAP-10) removed — DD-AUDIT-002 V3.0 removed

--- a/test/unit/audit/store_test.go
+++ b/test/unit/audit/store_test.go
@@ -555,6 +555,65 @@ var _ = Describe("BufferedAuditStore", func() {
 			Expect(mockClient.AttemptCount()).To(BeNumerically(">=", 3), "5xx errors SHOULD be retried")
 			Expect(mockClient.BatchCount()).To(Equal(0), "Batch should be dropped after max retries")
 		})
+
+		// UT-AS-1056-001: 401 auth error retries and succeeds on 2nd attempt
+		It("UT-AS-1056-001: should retry on 401 auth error and succeed after token refresh (#1056)", func() {
+			mockClient.SetCustomError(audit.NewHTTPError(401, "Unauthorized"))
+
+			for i := 0; i < 10; i++ {
+				event := createTestEvent()
+				_ = store.StoreAudit(ctx, event)
+			}
+
+			// Wait for first attempt (401 should be retryable)
+			Eventually(func() int {
+				return mockClient.AttemptCount()
+			}, "5s").Should(BeNumerically(">=", 1))
+
+			// Clear the error so retry succeeds (simulates token refresh)
+			mockClient.SetCustomError(nil)
+
+			// Wait for batch to be written on retry
+			Eventually(func() int {
+				return mockClient.BatchCount()
+			}, "15s").Should(Equal(1), "401 should be retried and batch should succeed after token refresh")
+
+			Expect(mockClient.AttemptCount()).To(BeNumerically(">=", 2),
+				"At least 2 attempts: first fails with 401, retry succeeds")
+		})
+
+		// UT-AS-1056-002: 401 error logging contains auth-specific context
+		It("UT-AS-1056-002: should log auth-specific context for 401 errors (#1056)", func() {
+			logSink := &errorCaptureSink{}
+			testLogger := logr.New(logSink)
+
+			config := audit.Config{
+				BufferSize:    100,
+				BatchSize:     10,
+				FlushInterval: 100 * time.Millisecond,
+				MaxRetries:    3,
+			}
+			authStore, err := audit.NewBufferedStore(mockClient, config, "test-service", testLogger)
+			Expect(err).ToNot(HaveOccurred())
+			defer func() { _ = authStore.Close() }()
+
+			mockClient.SetCustomError(audit.NewHTTPError(401, "Unauthorized"))
+
+			for i := 0; i < 10; i++ {
+				event := createTestEvent()
+				_ = authStore.StoreAudit(ctx, event)
+			}
+
+			// Wait for retries to complete
+			Eventually(func() int {
+				return mockClient.AttemptCount()
+			}, "15s").Should(BeNumerically(">=", 3))
+
+			// Verify auth-specific log message appears
+			hasAuthLog := logSink.hasErrorContaining("auth") || logSink.hasErrorContaining("token")
+			Expect(hasAuthLog).To(BeTrue(),
+				"401 errors should produce auth-specific log messages for SRE diagnosis")
+		})
 	})
 
 	// NOTE: Client-side DLQ tests (GAP-10) removed — DD-AUDIT-002 V3.0 removed

--- a/test/unit/shared/auth/transport_test.go
+++ b/test/unit/shared/auth/transport_test.go
@@ -296,6 +296,8 @@ var _ = Describe("NewServiceAccountTransportWithPath (#1055)", func() {
 		transport := auth.NewServiceAccountTransportWithPath(tokenFile, base)
 		client := &http.Client{Transport: transport}
 
+		Expect(transport.TokenInvalidationCount()).To(Equal(int64(0)))
+
 		req1, _ := http.NewRequest("GET", "http://localhost/test", nil)
 		resp1, err := client.Do(req1)
 		Expect(err).ToNot(HaveOccurred())
@@ -309,6 +311,7 @@ var _ = Describe("NewServiceAccountTransportWithPath (#1055)", func() {
 		Expect(err).ToNot(HaveOccurred())
 		_ = resp2.Body.Close()
 		Expect(resp2.StatusCode).To(Equal(401))
+		Expect(transport.TokenInvalidationCount()).To(Equal(int64(1)))
 
 		// Write new token to file (simulating kubelet rotation)
 		Expect(os.WriteFile(tokenFile, []byte("fresh-token"), 0600)).To(Succeed())
@@ -434,6 +437,36 @@ var _ = Describe("NewServiceAccountTransportWithPath (#1055)", func() {
 			Expect(err).ToNot(HaveOccurred())
 			defer func() { _ = resp.Body.Close() }()
 			Expect(resp.Header.Get("X-Echo-Auth")).To(Equal("Bearer nil-base-token"))
+		})
+
+		It("should degrade gracefully when token file is deleted mid-operation", func() {
+			Expect(os.WriteFile(tokenFile, []byte("initial-token"), 0600)).To(Succeed())
+
+			base := &statusRoundTripper{statusCode: 401}
+			transport := auth.NewServiceAccountTransportWithPath(tokenFile, base)
+			client := &http.Client{Transport: transport}
+
+			// First request: token exists, gets cached, then 401 invalidates cache
+			req1, _ := http.NewRequest("GET", "http://localhost/test", nil)
+			_, _ = client.Do(req1)
+
+			headers := base.getAuthHeaders()
+			Expect(headers[0]).To(Equal("Bearer initial-token"))
+
+			// Delete the token file (simulates SA volume unmount)
+			Expect(os.Remove(tokenFile)).To(Succeed())
+
+			// Next request: cache invalidated by 401, file gone → empty token → no auth header
+			base.setStatus(200)
+			req2, _ := http.NewRequest("GET", "http://localhost/test", nil)
+			resp2, err := client.Do(req2)
+			Expect(err).ToNot(HaveOccurred())
+			_ = resp2.Body.Close()
+
+			headers = base.getAuthHeaders()
+			Expect(headers).To(HaveLen(2))
+			Expect(headers[1]).To(BeEmpty(),
+				"Deleted token file should result in no auth header (graceful degradation)")
 		})
 
 		It("should handle empty token path gracefully", func() {

--- a/test/unit/shared/auth/transport_test.go
+++ b/test/unit/shared/auth/transport_test.go
@@ -95,14 +95,14 @@ var _ = Describe("AuthTransport", func() {
 		})
 	})
 
-	Describe("NewServiceAccountTransport", func() {
+	Describe("NewDefaultTokenSource + NewAuthTransport", func() {
 		// NOTE: "should read token from filesystem" and "should cache token for
 		// 5 minutes" are tested in integration tests with a real filesystem/token.
 		// They do not belong at the unit test tier.
 
 		It("should not inject header if token file doesn't exist", func() {
-			// Create ServiceAccount transport pointing to non-existent file
-			transport := auth.NewServiceAccountTransportWithBase(http.DefaultTransport)
+			ts := auth.NewDefaultTokenSource()
+			transport := auth.NewAuthTransport(ts, http.DefaultTransport)
 			client := &http.Client{Transport: transport}
 
 			// Make request (token file doesn't exist)
@@ -251,7 +251,7 @@ func (s *statusRoundTripper) getAuthHeaders() []string {
 	return cp
 }
 
-var _ = Describe("NewServiceAccountTransportWithPath (#1055)", func() {
+var _ = Describe("NewTokenSource + NewAuthTransport (#1055)", func() {
 	var (
 		tokenDir  string
 		tokenFile string
@@ -273,7 +273,8 @@ var _ = Describe("NewServiceAccountTransportWithPath (#1055)", func() {
 		Expect(os.WriteFile(tokenFile, []byte("custom-token-v1"), 0600)).To(Succeed())
 
 		base := &statusRoundTripper{statusCode: 200}
-		transport := auth.NewServiceAccountTransportWithPath(tokenFile, base)
+		ts := auth.NewTokenSource(tokenFile)
+		transport := auth.NewAuthTransport(ts, base)
 		client := &http.Client{Transport: transport}
 
 		req, err := http.NewRequest("GET", "http://localhost/test", nil)
@@ -293,7 +294,8 @@ var _ = Describe("NewServiceAccountTransportWithPath (#1055)", func() {
 		Expect(os.WriteFile(tokenFile, []byte("stale-token"), 0600)).To(Succeed())
 
 		base := &statusRoundTripper{statusCode: 200}
-		transport := auth.NewServiceAccountTransportWithPath(tokenFile, base)
+		ts := auth.NewTokenSource(tokenFile)
+		transport := auth.NewAuthTransport(ts, base)
 		client := &http.Client{Transport: transport}
 
 		Expect(transport.TokenInvalidationCount()).To(Equal(int64(0)))
@@ -335,7 +337,8 @@ var _ = Describe("NewServiceAccountTransportWithPath (#1055)", func() {
 		Expect(os.WriteFile(tokenFile, []byte("token-v1"), 0600)).To(Succeed())
 
 		base := &statusRoundTripper{statusCode: 401}
-		transport := auth.NewServiceAccountTransportWithPath(tokenFile, base)
+		ts := auth.NewTokenSource(tokenFile)
+		transport := auth.NewAuthTransport(ts, base)
 		client := &http.Client{Transport: transport}
 
 		req1, _ := http.NewRequest("GET", "http://localhost/test", nil)
@@ -362,7 +365,8 @@ var _ = Describe("NewServiceAccountTransportWithPath (#1055)", func() {
 		Expect(os.WriteFile(tokenFile, []byte("cached-token"), 0600)).To(Succeed())
 
 		base := &statusRoundTripper{statusCode: 200}
-		transport := auth.NewServiceAccountTransportWithPath(tokenFile, base)
+		ts := auth.NewTokenSource(tokenFile)
+		transport := auth.NewAuthTransport(ts, base)
 		client := &http.Client{Transport: transport}
 
 		// First request populates cache
@@ -394,7 +398,8 @@ var _ = Describe("NewServiceAccountTransportWithPath (#1055)", func() {
 		Expect(os.WriteFile(tokenFile, []byte("concurrent-token"), 0600)).To(Succeed())
 
 		base := &statusRoundTripper{statusCode: 401}
-		transport := auth.NewServiceAccountTransportWithPath(tokenFile, base)
+		ts := auth.NewTokenSource(tokenFile)
+		transport := auth.NewAuthTransport(ts, base)
 		client := &http.Client{Transport: transport}
 
 		const numGoroutines = 20
@@ -424,7 +429,8 @@ var _ = Describe("NewServiceAccountTransportWithPath (#1055)", func() {
 	Context("nil/zero edge cases", func() {
 		It("should use http.DefaultTransport when base is nil", func() {
 			Expect(os.WriteFile(tokenFile, []byte("nil-base-token"), 0600)).To(Succeed())
-			transport := auth.NewServiceAccountTransportWithPath(tokenFile, nil)
+			ts := auth.NewTokenSource(tokenFile)
+			transport := auth.NewAuthTransport(ts, nil)
 
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				w.Header().Set("X-Echo-Auth", r.Header.Get("Authorization"))
@@ -443,7 +449,8 @@ var _ = Describe("NewServiceAccountTransportWithPath (#1055)", func() {
 			Expect(os.WriteFile(tokenFile, []byte("initial-token"), 0600)).To(Succeed())
 
 			base := &statusRoundTripper{statusCode: 401}
-			transport := auth.NewServiceAccountTransportWithPath(tokenFile, base)
+			ts := auth.NewTokenSource(tokenFile)
+			transport := auth.NewAuthTransport(ts, base)
 			client := &http.Client{Transport: transport}
 
 			// First request: token exists, gets cached, then 401 invalidates cache
@@ -471,7 +478,8 @@ var _ = Describe("NewServiceAccountTransportWithPath (#1055)", func() {
 
 		It("should handle empty token path gracefully", func() {
 			base := &statusRoundTripper{statusCode: 200}
-			transport := auth.NewServiceAccountTransportWithPath("", base)
+			ts := auth.NewTokenSource("")
+			transport := auth.NewAuthTransport(ts, base)
 			client := &http.Client{Transport: transport}
 
 			req, _ := http.NewRequest("GET", "http://localhost/test", nil)
@@ -483,6 +491,67 @@ var _ = Describe("NewServiceAccountTransportWithPath (#1055)", func() {
 			Expect(headers).To(HaveLen(1))
 			Expect(headers[0]).To(BeEmpty(), "Empty path should result in no auth header")
 		})
+	})
+})
+
+var _ = Describe("Shared TokenSource (#1055 — cache convergence)", func() {
+	var (
+		tokenDir  string
+		tokenFile string
+	)
+
+	BeforeEach(func() {
+		var err error
+		tokenDir, err = os.MkdirTemp("", "shared-ts-test-*")
+		Expect(err).ToNot(HaveOccurred())
+		tokenFile = filepath.Join(tokenDir, "token")
+	})
+
+	AfterEach(func() {
+		_ = os.RemoveAll(tokenDir)
+	})
+
+	// UT-AT-1055-009: Two transports share a TokenSource — 401 on A invalidates cache for B
+	It("UT-AT-1055-009: 401 on transport A should invalidate shared cache for transport B", func() {
+		Expect(os.WriteFile(tokenFile, []byte("token-v1"), 0600)).To(Succeed())
+
+		ts := auth.NewTokenSource(tokenFile)
+
+		baseA := &statusRoundTripper{statusCode: 200}
+		baseB := &statusRoundTripper{statusCode: 200}
+		transportA := auth.NewAuthTransport(ts, baseA)
+		transportB := auth.NewAuthTransport(ts, baseB)
+		clientA := &http.Client{Transport: transportA}
+		clientB := &http.Client{Transport: transportB}
+
+		// Both clients use token-v1 initially
+		reqA1, _ := http.NewRequest("GET", "http://localhost/test", nil)
+		_, _ = clientA.Do(reqA1)
+		reqB1, _ := http.NewRequest("GET", "http://localhost/test", nil)
+		_, _ = clientB.Do(reqB1)
+
+		Expect(baseA.getAuthHeaders()[0]).To(Equal("Bearer token-v1"))
+		Expect(baseB.getAuthHeaders()[0]).To(Equal("Bearer token-v1"))
+
+		// Kubelet rotates the token on disk
+		Expect(os.WriteFile(tokenFile, []byte("token-v2"), 0600)).To(Succeed())
+
+		// Transport A gets a 401 — invalidates the SHARED cache
+		baseA.setStatus(401)
+		reqA2, _ := http.NewRequest("GET", "http://localhost/test", nil)
+		_, _ = clientA.Do(reqA2)
+
+		Expect(ts.InvalidationCount()).To(Equal(int64(1)))
+
+		// Transport B (never saw 401) now picks up token-v2 because shared cache was invalidated
+		reqB2, _ := http.NewRequest("GET", "http://localhost/test", nil)
+		_, _ = clientB.Do(reqB2)
+
+		headersB := baseB.getAuthHeaders()
+		Expect(headersB).To(HaveLen(2))
+		Expect(headersB[0]).To(Equal("Bearer token-v1"))
+		Expect(headersB[1]).To(Equal("Bearer token-v2"),
+			"Transport B should use the fresh token after transport A's 401 invalidated the shared cache")
 	})
 })
 

--- a/test/unit/shared/auth/transport_test.go
+++ b/test/unit/shared/auth/transport_test.go
@@ -20,6 +20,10 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -209,6 +213,242 @@ var _ = Describe("AuthTransport", func() {
 			body, err := io.ReadAll(resp.Body)
 			Expect(err).ToNot(HaveOccurred())
 			Expect(string(body)).To(Equal("OK"))
+		})
+	})
+})
+
+// statusRoundTripper returns a configurable status code and tracks requests.
+type statusRoundTripper struct {
+	mu          sync.Mutex
+	statusCode  int32
+	requestLog  []string
+	callCount   int32
+}
+
+func (s *statusRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	atomic.AddInt32(&s.callCount, 1)
+	s.mu.Lock()
+	s.requestLog = append(s.requestLog, req.Header.Get("Authorization"))
+	s.mu.Unlock()
+	code := atomic.LoadInt32(&s.statusCode)
+	return &http.Response{
+		StatusCode: int(code),
+		Header:     http.Header{},
+		Body:       http.NoBody,
+		Request:    req,
+	}, nil
+}
+
+func (s *statusRoundTripper) setStatus(code int) {
+	atomic.StoreInt32(&s.statusCode, int32(code))
+}
+
+func (s *statusRoundTripper) getAuthHeaders() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make([]string, len(s.requestLog))
+	copy(cp, s.requestLog)
+	return cp
+}
+
+var _ = Describe("NewServiceAccountTransportWithPath (#1055)", func() {
+	var (
+		tokenDir  string
+		tokenFile string
+	)
+
+	BeforeEach(func() {
+		var err error
+		tokenDir, err = os.MkdirTemp("", "auth-transport-test-*")
+		Expect(err).ToNot(HaveOccurred())
+		tokenFile = filepath.Join(tokenDir, "token")
+	})
+
+	AfterEach(func() {
+		_ = os.RemoveAll(tokenDir)
+	})
+
+	// UT-AT-1055-001: Custom path constructor reads from specified path
+	It("UT-AT-1055-001: should read token from the specified custom path", func() {
+		Expect(os.WriteFile(tokenFile, []byte("custom-token-v1"), 0600)).To(Succeed())
+
+		base := &statusRoundTripper{statusCode: 200}
+		transport := auth.NewServiceAccountTransportWithPath(tokenFile, base)
+		client := &http.Client{Transport: transport}
+
+		req, err := http.NewRequest("GET", "http://localhost/test", nil)
+		Expect(err).ToNot(HaveOccurred())
+
+		resp, err := client.Do(req)
+		Expect(err).ToNot(HaveOccurred())
+		_ = resp.Body.Close()
+
+		headers := base.getAuthHeaders()
+		Expect(headers).To(HaveLen(1))
+		Expect(headers[0]).To(Equal("Bearer custom-token-v1"))
+	})
+
+	// UT-AT-1055-002: 401 response invalidates token cache
+	It("UT-AT-1055-002: should invalidate token cache when downstream returns 401", func() {
+		Expect(os.WriteFile(tokenFile, []byte("stale-token"), 0600)).To(Succeed())
+
+		base := &statusRoundTripper{statusCode: 200}
+		transport := auth.NewServiceAccountTransportWithPath(tokenFile, base)
+		client := &http.Client{Transport: transport}
+
+		req1, _ := http.NewRequest("GET", "http://localhost/test", nil)
+		resp1, err := client.Do(req1)
+		Expect(err).ToNot(HaveOccurred())
+		_ = resp1.Body.Close()
+		Expect(resp1.StatusCode).To(Equal(200))
+
+		// Now downstream returns 401 — cache should be invalidated
+		base.setStatus(401)
+		req2, _ := http.NewRequest("GET", "http://localhost/test", nil)
+		resp2, err := client.Do(req2)
+		Expect(err).ToNot(HaveOccurred())
+		_ = resp2.Body.Close()
+		Expect(resp2.StatusCode).To(Equal(401))
+
+		// Write new token to file (simulating kubelet rotation)
+		Expect(os.WriteFile(tokenFile, []byte("fresh-token"), 0600)).To(Succeed())
+
+		// Next request should re-read from file (cache was invalidated)
+		base.setStatus(200)
+		req3, _ := http.NewRequest("GET", "http://localhost/test", nil)
+		resp3, err := client.Do(req3)
+		Expect(err).ToNot(HaveOccurred())
+		_ = resp3.Body.Close()
+
+		headers := base.getAuthHeaders()
+		Expect(headers).To(HaveLen(3))
+		Expect(headers[0]).To(Equal("Bearer stale-token"))
+		Expect(headers[1]).To(Equal("Bearer stale-token"))
+		Expect(headers[2]).To(Equal("Bearer fresh-token"))
+	})
+
+	// UT-AT-1055-003: Token re-read after invalidation picks up new file content
+	It("UT-AT-1055-003: should pick up rotated token content after 401 invalidation", func() {
+		Expect(os.WriteFile(tokenFile, []byte("token-v1"), 0600)).To(Succeed())
+
+		base := &statusRoundTripper{statusCode: 401}
+		transport := auth.NewServiceAccountTransportWithPath(tokenFile, base)
+		client := &http.Client{Transport: transport}
+
+		req1, _ := http.NewRequest("GET", "http://localhost/test", nil)
+		_, err := client.Do(req1)
+		Expect(err).ToNot(HaveOccurred())
+
+		// Kubelet writes new token
+		Expect(os.WriteFile(tokenFile, []byte("token-v2"), 0600)).To(Succeed())
+
+		base.setStatus(200)
+		req2, _ := http.NewRequest("GET", "http://localhost/test", nil)
+		resp2, err := client.Do(req2)
+		Expect(err).ToNot(HaveOccurred())
+		_ = resp2.Body.Close()
+
+		headers := base.getAuthHeaders()
+		Expect(headers).To(HaveLen(2))
+		Expect(headers[0]).To(Equal("Bearer token-v1"))
+		Expect(headers[1]).To(Equal("Bearer token-v2"))
+	})
+
+	// UT-AT-1055-004: Non-401 responses do NOT invalidate cache
+	It("UT-AT-1055-004: should NOT invalidate cache for 200 or 500 responses", func() {
+		Expect(os.WriteFile(tokenFile, []byte("cached-token"), 0600)).To(Succeed())
+
+		base := &statusRoundTripper{statusCode: 200}
+		transport := auth.NewServiceAccountTransportWithPath(tokenFile, base)
+		client := &http.Client{Transport: transport}
+
+		// First request populates cache
+		req1, _ := http.NewRequest("GET", "http://localhost/test", nil)
+		_, _ = client.Do(req1)
+
+		// Write different token (should NOT be picked up — cache still valid)
+		Expect(os.WriteFile(tokenFile, []byte("different-token"), 0600)).To(Succeed())
+
+		// 200 response — cache should remain
+		req2, _ := http.NewRequest("GET", "http://localhost/test", nil)
+		_, _ = client.Do(req2)
+
+		// 500 response — cache should still remain
+		base.setStatus(500)
+		req3, _ := http.NewRequest("GET", "http://localhost/test", nil)
+		_, _ = client.Do(req3)
+
+		headers := base.getAuthHeaders()
+		Expect(headers).To(HaveLen(3))
+		for _, h := range headers {
+			Expect(h).To(Equal("Bearer cached-token"),
+				"Non-401 responses must not invalidate cache")
+		}
+	})
+
+	// UT-AT-1055-005: Concurrent RoundTrip under 401 storm
+	It("UT-AT-1055-005: should handle concurrent 401 storm without races", func() {
+		Expect(os.WriteFile(tokenFile, []byte("concurrent-token"), 0600)).To(Succeed())
+
+		base := &statusRoundTripper{statusCode: 401}
+		transport := auth.NewServiceAccountTransportWithPath(tokenFile, base)
+		client := &http.Client{Transport: transport}
+
+		const numGoroutines = 20
+		var wg sync.WaitGroup
+		var errCount int32
+
+		for i := 0; i < numGoroutines; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				req, _ := http.NewRequest("GET", "http://localhost/test", nil)
+				resp, err := client.Do(req)
+				if err != nil {
+					atomic.AddInt32(&errCount, 1)
+					return
+				}
+				_ = resp.Body.Close()
+			}()
+		}
+
+		wg.Wait()
+		Expect(atomic.LoadInt32(&errCount)).To(Equal(int32(0)),
+			"All concurrent requests should complete without error")
+		Expect(int(atomic.LoadInt32(&base.callCount))).To(Equal(numGoroutines))
+	})
+
+	Context("nil/zero edge cases", func() {
+		It("should use http.DefaultTransport when base is nil", func() {
+			Expect(os.WriteFile(tokenFile, []byte("nil-base-token"), 0600)).To(Succeed())
+			transport := auth.NewServiceAccountTransportWithPath(tokenFile, nil)
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("X-Echo-Auth", r.Header.Get("Authorization"))
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer server.Close()
+
+			client := &http.Client{Transport: transport}
+			resp, err := client.Get(server.URL)
+			Expect(err).ToNot(HaveOccurred())
+			defer func() { _ = resp.Body.Close() }()
+			Expect(resp.Header.Get("X-Echo-Auth")).To(Equal("Bearer nil-base-token"))
+		})
+
+		It("should handle empty token path gracefully", func() {
+			base := &statusRoundTripper{statusCode: 200}
+			transport := auth.NewServiceAccountTransportWithPath("", base)
+			client := &http.Client{Transport: transport}
+
+			req, _ := http.NewRequest("GET", "http://localhost/test", nil)
+			resp, err := client.Do(req)
+			Expect(err).ToNot(HaveOccurred())
+			_ = resp.Body.Close()
+
+			headers := base.getAuthHeaders()
+			Expect(headers).To(HaveLen(1))
+			Expect(headers[0]).To(BeEmpty(), "Empty path should result in no auth header")
 		})
 	})
 })


### PR DESCRIPTION
## Summary

- **#1055**: `bearerTransport` in `kubernaut-agent` read the SA token once at startup; after ~1h when kubelet rotates the projected token, all DataStorage and audit calls fail with 401 Unauthorized. Replaced with `AuthTransport` which re-reads from disk every 5 minutes and invalidates the cache immediately on 401 responses.
- **#1056**: All 4xx HTTP errors were classified as non-retryable ("invalid data"), including 401/403. Audit batches were silently dropped. Now 401/403 are classified as retryable auth errors with distinct logging for SRE diagnosis.

## Changes

| File | Change |
|------|--------|
| `pkg/shared/auth/transport.go` | Add `NewServiceAccountTransportWithPath` constructor, `invalidateTokenCache` method, 401 response handling in `RoundTrip`, `TokenInvalidationCount()` counter. Updated DD-AUTH-005 doc. |
| `pkg/audit/errors.go` | Add `IsAuthError()` method + package-level helper. Update `IsRetryable()` for 401/403. Document 401-vs-403 asymmetry. |
| `pkg/audit/store.go` | Auth-specific log in `writeBatchWithRetry`, clarified non-retryable drop message. |
| `cmd/kubernautagent/main.go` | Replace `bearerTransport` with `auth.NewServiceAccountTransportWithPath` in `initDSClients` + `buildAuditStore`. Remove `bearerTransport` type. Add `os.Stat` startup warning. |
| `test/unit/shared/auth/transport_test.go` | 9 new tests: custom path, 401 invalidation + counter, token rotation, non-401 cache, concurrent 401 storm, nil base, empty path, file deleted mid-operation. |
| `test/unit/audit/errors_test.go` | 9 updated/new tests: `IsRetryable` flips for 401/403, `IsAuthError` coverage, regression guards. |
| `test/unit/audit/store_test.go` | 3 new tests: 401 retry succeeds on 2nd attempt, auth-specific log message, persistent 401 exhaustion. |
| `docs/tests/1055-1056/TEST_PLAN.md` | IEEE 829 test plan (NEW). |

## Root Cause

```
kubelet rotates token → bearerTransport holds stale string → DS returns 401
→ audit store: "non-retryable 4xx" → DROP batch silently
→ LLM tools: fail → NoMatchingWorkflows
```

## Behavioral Change Note

**Audit retry latency on auth failures**: Previously, 401/403 batches were immediately dropped (~0s). Now they are retried up to MaxRetries (default 3) with exponential backoff (1s + 4s + 9s = ~14s worst case before drop). During a sustained auth outage, the background writer will spend ~14s per batch in retry backoff. This is acceptable (retrying is strictly better than silent drop) but operators should expect brief audit write latency spikes during token rotation windows.

## 401 vs 403 Design Asymmetry

- **401 (Unauthorized)**: `AuthTransport` invalidates the token cache → next retry re-reads from disk → self-heals.
- **403 (Forbidden)**: `AuthTransport` does NOT invalidate cache (refresh won't fix a permissions issue). Retries for 403 rely on RBAC propagation delays resolving between attempts. If persistent, batch is dropped after MaxRetries.

Both are classified as retryable in `IsAuthError()` to cover transient RBAC propagation delays, but only 401 triggers token refresh.

## Test plan

- [x] 21 new/updated unit tests covering all new behavior
- [x] All tests pass with `-race` (0 races)
- [x] `go build ./...` — 0 errors
- [x] `golangci-lint` — 0 new errors
- [x] `bearerTransport` — 0 references in production code
- [x] 100 Go Mistakes audit (#42, #52, #57, #58, #60, #74, #45) — all verified
- [x] 9-category checkpoint audit passed at all 3 checkpoints

Closes #1055
Closes #1056