### PR TITLE
perf(datastorage): parallelize workflow validation external checks (#1070)

### DIFF
--- a/pkg/datastorage/metrics/metrics.go
+++ b/pkg/datastorage/metrics/metrics.go
@@ -47,6 +47,9 @@ const (
 
 	// Audit write API metrics (GAP-10)
 	MetricNameAuditLagSeconds = "datastorage_audit_lag_seconds"
+
+	// Workflow validation phase metrics (Issue #1070)
+	MetricNameWorkflowValidationDuration = "datastorage_workflow_validation_duration_seconds"
 )
 
 // Write operation metrics
@@ -68,6 +71,29 @@ var (
 			Buckets: prometheus.DefBuckets,
 		},
 		[]string{"table"},
+	)
+)
+
+// Workflow validation phase metrics (Issue #1070)
+// BR-STORAGE-014: Workflow catalog management
+
+var (
+	// WorkflowValidationDuration tracks the duration of each validation phase
+	// during workflow registration.
+	//
+	// Labels:
+	//   - phase: Validation phase ("action_type", "bundle_exists", "dependency", "total")
+	//   - result: Outcome ("ok", "error")
+	//
+	// Example Prometheus query:
+	//   histogram_quantile(0.95, rate(datastorage_workflow_validation_duration_seconds_bucket{phase="total"}[5m]))
+	WorkflowValidationDuration = promauto.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    MetricNameWorkflowValidationDuration,
+			Help:    "Duration of workflow validation phases in seconds",
+			Buckets: []float64{.001, .005, .01, .025, .05, .1, .25, .5, 1, 2.5, 5},
+		},
+		[]string{"phase", "result"},
 	)
 )
 
@@ -94,9 +120,10 @@ var (
 
 // Metrics Summary:
 //
-// Total Metrics: 2 (external-facing per GitHub issue #294)
+// Total Metrics: 3 (external-facing per GitHub issue #294, #1070)
 // - WriteDuration (Histogram with labels) - write operation performance
 // - AuditLagSeconds (Histogram with labels) - audit lag observability
+// - WorkflowValidationDuration (Histogram with labels) - validation phase timing (Issue #1070)
 //
 // Performance Target: < 5% overhead
 // BR Coverage: BR-STORAGE-001, 002, 007, 008, 012, 013, 019

--- a/pkg/datastorage/server/workflow_handlers.go
+++ b/pkg/datastorage/server/workflow_handlers.go
@@ -26,11 +26,14 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/go-logr/logr"
 	"github.com/jackc/pgx/v5/pgconn"
 	dsaudit "github.com/jordigilh/kubernaut/pkg/datastorage/audit"
+	dsmetrics "github.com/jordigilh/kubernaut/pkg/datastorage/metrics"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/models"
 	api "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/schema"
@@ -109,55 +112,13 @@ func (h *Handler) HandleCreateWorkflow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Step 5a: Validate action_type against taxonomy (GAP-4, DD-WORKFLOW-016)
-	if h.actionTypeValidator != nil {
-		exists, err := h.actionTypeValidator.ActionTypeExists(r.Context(), workflow.ActionType)
-		if err != nil {
-			h.logger.Error(err, "Failed to validate action_type against taxonomy",
-				"action_type", workflow.ActionType,
-			)
-			response.WriteRFC7807Error(w, http.StatusInternalServerError, "internal-error", "Internal Server Error",
-				"Failed to validate action type", h.logger)
-			return
-		}
-		if !exists {
-			detail := fmt.Sprintf("action_type '%s' is not in the action type taxonomy (DD-WORKFLOW-016)", workflow.ActionType)
-			response.WriteRFC7807Error(w, http.StatusBadRequest, "validation-error", "Validation Error",
-				detail, h.logger)
-			return
-		}
-	}
-
-	// Step 5b: Validate execution bundle image exists in the registry (skip for ansible — Git repo)
-	if workflow.ExecutionBundle != nil && *workflow.ExecutionBundle != "" && workflow.ExecutionEngine != models.ExecutionEngineAnsible {
-		if h.schemaExtractor != nil {
-			if err := h.schemaExtractor.ValidateBundleExists(r.Context(), *workflow.ExecutionBundle); err != nil {
-				h.logger.Error(err, "Execution bundle image not found in registry",
-					"execution_bundle", *workflow.ExecutionBundle,
-				)
-				response.WriteRFC7807Error(w, http.StatusBadRequest, "bundle-not-found", "Execution Bundle Not Found",
-					fmt.Sprintf("execution.bundle image not found: %v", err), h.logger)
-				return
-			}
-		}
-	}
-
-	// Step 5c: Validate schema-declared dependencies exist in execution namespace (DD-WE-006)
-	if h.dependencyValidator != nil && parsedSchema.Dependencies != nil {
-		deps := schema.NewParser().ExtractDependencies(parsedSchema)
-		if deps != nil {
-			if err := h.dependencyValidator.ValidateDependencies(r.Context(), h.executionNamespace, deps); err != nil {
-				h.logger.Error(err, "Dependency validation failed",
-					"execution_namespace", h.executionNamespace,
-				)
-				response.WriteRFC7807Error(w, http.StatusBadRequest, "dependency-validation-error",
-					"Dependency Validation Error",
-					fmt.Sprintf("Schema-declared dependency not satisfied: %v. Ensure all dependencies "+
-						"are provisioned in namespace %q before registering the workflow (DD-WE-006).", err, h.executionNamespace),
-					h.logger)
-				return
-			}
-		}
+	// Steps 5a–5c: Validate external checks in parallel (Issue #1070)
+	// Typed-result-slot pattern: each check writes to its own error slot,
+	// then we check slots in priority order so callers always see the same
+	// RFC 7807 error type regardless of goroutine completion order.
+	if err := h.validateExternalChecks(r.Context(), schemaParser, parsedSchema, workflow); err != nil {
+		err.writeTo(w, h.logger)
+		return
 	}
 
 	// Step 6: Create workflow in repository (with content integrity checking)
@@ -261,6 +222,153 @@ func (h *Handler) HandleCreateWorkflow(w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(workflow); err != nil {
 		h.logger.Error(err, "Failed to encode workflow create response")
 	}
+}
+
+// validationError carries all fields needed to produce an RFC 7807 response.
+// Returned by validateExternalChecks so HandleCreateWorkflow can write the error
+// without duplicating RFC 7807 construction logic.
+type validationError struct {
+	status    int
+	errorType string
+	title     string
+	detail    string
+}
+
+// writeTo writes the validationError as an RFC 7807 Problem Details response.
+func (ve *validationError) writeTo(w http.ResponseWriter, logger logr.Logger) {
+	response.WriteRFC7807Error(w, ve.status, ve.errorType, ve.title, ve.detail, logger)
+}
+
+// validateExternalChecks runs Steps 5a–5c (action-type, bundle-exists,
+// dependency validation) in parallel and returns the highest-priority
+// error, preserving the original sequential error contract.
+//
+// Issue #1070: Typed-result-slot pattern — each goroutine writes to its
+// own slot; after all goroutines complete we check slots in priority order.
+func (h *Handler) validateExternalChecks(
+	ctx context.Context,
+	schemaParser *schema.Parser,
+	parsedSchema *models.WorkflowSchema,
+	workflow *models.RemediationWorkflow,
+) *validationError {
+	const (
+		slotActionType = iota
+		slotBundle
+		slotDependency
+		slotCount
+	)
+
+	var (
+		slots [slotCount]*validationError
+		mu    sync.Mutex
+		wg    sync.WaitGroup
+	)
+
+	totalStart := time.Now()
+
+	setSlot := func(idx int, ve *validationError) {
+		mu.Lock()
+		slots[idx] = ve
+		mu.Unlock()
+	}
+
+	// 5a: Validate action_type against taxonomy (GAP-4, DD-WORKFLOW-016)
+	if h.actionTypeValidator != nil {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			start := time.Now()
+			exists, err := h.actionTypeValidator.ActionTypeExists(ctx, workflow.ActionType)
+			if err != nil {
+				dsmetrics.WorkflowValidationDuration.WithLabelValues("action_type", "error").Observe(time.Since(start).Seconds())
+				h.logger.Error(err, "Failed to validate action_type against taxonomy",
+					"action_type", workflow.ActionType,
+				)
+				setSlot(slotActionType, &validationError{
+					status:    http.StatusInternalServerError,
+					errorType: "internal-error",
+					title:     "Internal Server Error",
+					detail:    "Failed to validate action type",
+				})
+				return
+			}
+			if !exists {
+				dsmetrics.WorkflowValidationDuration.WithLabelValues("action_type", "error").Observe(time.Since(start).Seconds())
+				setSlot(slotActionType, &validationError{
+					status:    http.StatusBadRequest,
+					errorType: "validation-error",
+					title:     "Validation Error",
+					detail:    fmt.Sprintf("action_type '%s' is not in the action type taxonomy (DD-WORKFLOW-016)", workflow.ActionType),
+				})
+				return
+			}
+			dsmetrics.WorkflowValidationDuration.WithLabelValues("action_type", "ok").Observe(time.Since(start).Seconds())
+		}()
+	}
+
+	// 5b: Validate execution bundle image exists in the registry (skip for ansible — Git repo)
+	if workflow.ExecutionBundle != nil && *workflow.ExecutionBundle != "" &&
+		workflow.ExecutionEngine != models.ExecutionEngineAnsible && h.schemaExtractor != nil {
+		bundleRef := *workflow.ExecutionBundle
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			start := time.Now()
+			if err := h.schemaExtractor.ValidateBundleExists(ctx, bundleRef); err != nil {
+				dsmetrics.WorkflowValidationDuration.WithLabelValues("bundle_exists", "error").Observe(time.Since(start).Seconds())
+				h.logger.Error(err, "Execution bundle image not found in registry",
+					"execution_bundle", bundleRef,
+				)
+				setSlot(slotBundle, &validationError{
+					status:    http.StatusBadRequest,
+					errorType: "bundle-not-found",
+					title:     "Execution Bundle Not Found",
+					detail:    fmt.Sprintf("execution.bundle image not found: %v", err),
+				})
+				return
+			}
+			dsmetrics.WorkflowValidationDuration.WithLabelValues("bundle_exists", "ok").Observe(time.Since(start).Seconds())
+		}()
+	}
+
+	// 5c: Validate schema-declared dependencies exist in execution namespace (DD-WE-006)
+	if h.dependencyValidator != nil && parsedSchema.Dependencies != nil {
+		deps := schemaParser.ExtractDependencies(parsedSchema)
+		if deps != nil {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				start := time.Now()
+				if err := h.dependencyValidator.ValidateDependencies(ctx, h.executionNamespace, deps); err != nil {
+					dsmetrics.WorkflowValidationDuration.WithLabelValues("dependency", "error").Observe(time.Since(start).Seconds())
+					h.logger.Error(err, "Dependency validation failed",
+						"execution_namespace", h.executionNamespace,
+					)
+					setSlot(slotDependency, &validationError{
+						status:    http.StatusBadRequest,
+						errorType: "dependency-validation-error",
+						title:     "Dependency Validation Error",
+						detail: fmt.Sprintf("Schema-declared dependency not satisfied: %v. Ensure all dependencies "+
+							"are provisioned in namespace %q before registering the workflow (DD-WE-006).", err, h.executionNamespace),
+					})
+					return
+				}
+				dsmetrics.WorkflowValidationDuration.WithLabelValues("dependency", "ok").Observe(time.Since(start).Seconds())
+			}()
+		}
+	}
+
+	wg.Wait()
+
+	// Return the highest-priority error (lowest slot index).
+	for _, slot := range slots {
+		if slot != nil {
+			dsmetrics.WorkflowValidationDuration.WithLabelValues("total", "error").Observe(time.Since(totalStart).Seconds())
+			return slot
+		}
+	}
+	dsmetrics.WorkflowValidationDuration.WithLabelValues("total", "ok").Observe(time.Since(totalStart).Seconds())
+	return nil
 }
 
 // contentIntegrityError is returned when an active workflow with the same

--- a/pkg/datastorage/validation/dependency_validator.go
+++ b/pkg/datastorage/validation/dependency_validator.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 
+	"golang.org/x/sync/errgroup"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -47,33 +48,44 @@ func NewK8sDependencyValidator(c client.Reader) *K8sDependencyValidator {
 }
 
 // ValidateDependencies checks each declared Secret/ConfigMap exists with non-empty data.
-// Returns an error describing the first missing or empty dependency found.
+// All K8s Gets are issued concurrently via errgroup; the first error cancels remaining checks.
+// Issue #1070: Parallelized from sequential loop for reduced latency on multi-dependency schemas.
 func (v *K8sDependencyValidator) ValidateDependencies(ctx context.Context, namespace string, deps *models.WorkflowDependencies) error {
 	if deps == nil {
 		return nil
 	}
 
+	g, gctx := errgroup.WithContext(ctx)
+
 	for _, s := range deps.Secrets {
-		var secret corev1.Secret
-		key := client.ObjectKey{Name: s.Name, Namespace: namespace}
-		if err := v.client.Get(ctx, key, &secret); err != nil {
-			return fmt.Errorf("dependency Secret %q not found in namespace %q: %w", s.Name, namespace, err)
-		}
-		if len(secret.Data) == 0 {
-			return fmt.Errorf("dependency Secret %q in namespace %q has empty data", s.Name, namespace)
-		}
+		name := s.Name
+		g.Go(func() error {
+			var secret corev1.Secret
+			key := client.ObjectKey{Name: name, Namespace: namespace}
+			if err := v.client.Get(gctx, key, &secret); err != nil {
+				return fmt.Errorf("dependency Secret %q not found in namespace %q: %w", name, namespace, err)
+			}
+			if len(secret.Data) == 0 {
+				return fmt.Errorf("dependency Secret %q in namespace %q has empty data", name, namespace)
+			}
+			return nil
+		})
 	}
 
 	for _, cm := range deps.ConfigMaps {
-		var configMap corev1.ConfigMap
-		key := client.ObjectKey{Name: cm.Name, Namespace: namespace}
-		if err := v.client.Get(ctx, key, &configMap); err != nil {
-			return fmt.Errorf("dependency ConfigMap %q not found in namespace %q: %w", cm.Name, namespace, err)
-		}
-		if len(configMap.Data) == 0 && len(configMap.BinaryData) == 0 {
-			return fmt.Errorf("dependency ConfigMap %q in namespace %q has empty data", cm.Name, namespace)
-		}
+		name := cm.Name
+		g.Go(func() error {
+			var configMap corev1.ConfigMap
+			key := client.ObjectKey{Name: name, Namespace: namespace}
+			if err := v.client.Get(gctx, key, &configMap); err != nil {
+				return fmt.Errorf("dependency ConfigMap %q not found in namespace %q: %w", name, namespace, err)
+			}
+			if len(configMap.Data) == 0 && len(configMap.BinaryData) == 0 {
+				return fmt.Errorf("dependency ConfigMap %q in namespace %q has empty data", name, namespace)
+			}
+			return nil
+		})
 	}
 
-	return nil
+	return g.Wait()
 }

--- a/test/integration/datastorage/workflow_dependency_validation_test.go
+++ b/test/integration/datastorage/workflow_dependency_validation_test.go
@@ -284,6 +284,9 @@ var _ = Describe("Schema-Declared Dependency Validation (DD-WE-006)", Label("int
 			detail, _ := errResp["detail"].(string)
 			Expect(detail).To(ContainSubstring("it-missing-secret-002"),
 				"error should name the missing resource")
+			errType, _ := errResp["type"].(string)
+			Expect(errType).To(ContainSubstring("dependency-validation-error"),
+				"#1070: RFC 7807 type must identify dependency validation failure")
 		})
 
 		It("IT-DS-006-003: should reject workflow when declared Secret has empty data", func() {
@@ -312,6 +315,9 @@ var _ = Describe("Schema-Declared Dependency Validation (DD-WE-006)", Label("int
 			detail, _ := errResp["detail"].(string)
 			Expect(detail).To(ContainSubstring("empty"),
 				"error should indicate empty data")
+			errType, _ := errResp["type"].(string)
+			Expect(errType).To(ContainSubstring("dependency-validation-error"),
+				"#1070: RFC 7807 type must identify dependency validation failure")
 		})
 
 		It("IT-DS-006-004: should reject workflow when declared ConfigMap is missing", func() {
@@ -333,6 +339,9 @@ var _ = Describe("Schema-Declared Dependency Validation (DD-WE-006)", Label("int
 			detail, _ := errResp["detail"].(string)
 			Expect(detail).To(ContainSubstring("it-missing-cm-004"),
 				"error should name the missing resource")
+			errType, _ := errResp["type"].(string)
+			Expect(errType).To(ContainSubstring("dependency-validation-error"),
+				"#1070: RFC 7807 type must identify dependency validation failure")
 		})
 
 		It("IT-DS-006-005: should reject workflow when declared ConfigMap has empty data", func() {
@@ -361,6 +370,9 @@ var _ = Describe("Schema-Declared Dependency Validation (DD-WE-006)", Label("int
 			detail, _ := errResp["detail"].(string)
 			Expect(detail).To(ContainSubstring("empty"),
 				"error should indicate empty data")
+			errType, _ := errResp["type"].(string)
+			Expect(errType).To(ContainSubstring("dependency-validation-error"),
+				"#1070: RFC 7807 type must identify dependency validation failure")
 		})
 
 		It("IT-DS-006-006: should accept workflow without dependencies section", func() {

--- a/test/unit/datastorage/workflow_create_concurrent_test.go
+++ b/test/unit/datastorage/workflow_create_concurrent_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2025 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastorage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/datastorage/models"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/oci"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/schema"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/server"
+	sharedtypes "github.com/jordigilh/kubernaut/pkg/shared/types"
+	"github.com/jordigilh/kubernaut/test/testutil"
+)
+
+// ========================================
+// Issue #1070: Concurrent Handler Safety
+// ========================================
+// Authority: BR-STORAGE-014, Issue #1070
+// Purpose: Pre-parallelization baseline proving HandleCreateWorkflow is
+// safe to call from multiple goroutines. Intended to be run with -race.
+//
+// Pattern: Fire N concurrent requests at a handler wired with mock validators.
+// Assert every response returns a valid HTTP status (no panics, no races).
+// ========================================
+
+var _ = Describe("Issue #1070: Concurrent HandleCreateWorkflow Safety", Label("unit", "issue-1070", "concurrent"), func() {
+
+	const concurrency = 10
+
+	It("UT-WF-1070-CONC-001: concurrent requests produce valid responses without data races", func() {
+		schemaYAML := func() string {
+			crd := testutil.NewTestWorkflowCRD("concurrent-test-wf", "RestartPod", "job")
+			crd.Spec.Description = sharedtypes.StructuredDescription{
+				What:      "Concurrent safety test workflow",
+				WhenToUse: "When testing #1070 race conditions",
+			}
+			crd.Spec.Execution.Bundle = "quay.io/kubernaut/concurrent-test:v1.0.0@sha256:f313b9632f3a8d0ffd41150b12715a43a41c6c8e7871bb830fd82c09b5988cc4"
+			crd.Spec.Dependencies = &models.WorkflowDependencies{
+				Secrets: []models.ResourceDependency{{Name: "test-secret"}},
+			}
+			return testutil.MarshalWorkflowCRD(crd)
+		}()
+
+		mockPuller := oci.NewMockImagePuller(schemaYAML)
+		extractor := oci.NewSchemaExtractor(mockPuller, schema.NewParser())
+
+		acceptingValidator := &mockActionTypeValidator{
+			existsFn: func(_ context.Context, _ string) (bool, error) {
+				return true, nil
+			},
+		}
+
+		depValidator := &mockDependencyValidator{
+			err: fmt.Errorf("secret test-secret not found"),
+		}
+
+		handler := server.NewHandler(nil,
+			server.WithActionTypeValidator(acceptingValidator),
+			server.WithSchemaExtractor(extractor),
+			server.WithDependencyValidator(depValidator, "test-ns"),
+		)
+
+		var wg sync.WaitGroup
+		results := make([]int, concurrency)
+
+		for i := 0; i < concurrency; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				defer GinkgoRecover()
+
+				body := map[string]string{"content": schemaYAML}
+				jsonBody, err := json.Marshal(body)
+				Expect(err).ToNot(HaveOccurred())
+
+				req := httptest.NewRequest(http.MethodPost, "/api/v1/workflows", bytes.NewReader(jsonBody))
+				rr := httptest.NewRecorder()
+
+				handler.HandleCreateWorkflow(rr, req)
+				results[idx] = rr.Code
+			}(i)
+		}
+
+		wg.Wait()
+
+		for i, code := range results {
+			Expect(code).To(BeNumerically(">=", 200),
+				fmt.Sprintf("request %d: expected valid HTTP status, got %d", i, code))
+			Expect(code).To(BeNumerically("<", 600),
+				fmt.Sprintf("request %d: HTTP status %d out of valid range", i, code))
+		}
+	})
+})

--- a/test/unit/datastorage/workflow_validation_priority_test.go
+++ b/test/unit/datastorage/workflow_validation_priority_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright 2025 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastorage
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/datastorage/models"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/oci"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/schema"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/server"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/validation"
+	sharedtypes "github.com/jordigilh/kubernaut/pkg/shared/types"
+	"github.com/jordigilh/kubernaut/test/testutil"
+)
+
+// ========================================
+// Issue #1070: Validation Error Priority Contract Tests
+// ========================================
+// Authority: BR-STORAGE-014, BR-WORKFLOW-006, Issue #1070
+// Purpose: Lock the sequential error priority of HandleCreateWorkflow so
+// parallelization (Issue #1070) preserves the same RFC 7807 error type
+// for callers regardless of which check finishes first.
+//
+// Validation order (as defined in HandleCreateWorkflow):
+//   Step 3:  Schema validation         → type = validation-error
+//   Step 5a: Action-type taxonomy      → type = validation-error
+//   Step 5b: Bundle-exists (OCI)       → type = bundle-not-found
+//   Step 5c: Dependency validation     → type = dependency-validation-error
+//
+// These tests wire all validators so every step *would* fail,
+// then assert only the highest-priority error is returned.
+// ========================================
+
+// mockDependencyValidator implements validation.DependencyValidator for testing.
+type mockDependencyValidator struct {
+	err error
+}
+
+func (m *mockDependencyValidator) ValidateDependencies(_ context.Context, _ string, _ *models.WorkflowDependencies) error {
+	return m.err
+}
+
+// validSchemaForPriorityTests returns a well-formed schema YAML with dependencies
+// and a known action type, used as the baseline for priority tests.
+func validSchemaForPriorityTests() string {
+	crd := testutil.NewTestWorkflowCRD("priority-test-wf", "RestartPod", "job")
+	crd.Spec.Description = sharedtypes.StructuredDescription{
+		What:      "Priority test workflow",
+		WhenToUse: "When testing validation priority (#1070)",
+	}
+	crd.Spec.Execution.Bundle = "quay.io/kubernaut/priority-test:v1.0.0@sha256:f313b9632f3a8d0ffd41150b12715a43a41c6c8e7871bb830fd82c09b5988cc4"
+	crd.Spec.Dependencies = &models.WorkflowDependencies{
+		Secrets: []models.ResourceDependency{{Name: "missing-secret"}},
+	}
+	return testutil.MarshalWorkflowCRD(crd)
+}
+
+// rejectingActionTypeValidator returns a validator where ActionTypeExists
+// always returns false (action type not in taxonomy).
+func rejectingActionTypeValidator() *mockActionTypeValidator {
+	return &mockActionTypeValidator{
+		existsFn: func(_ context.Context, _ string) (bool, error) {
+			return false, nil
+		},
+	}
+}
+
+var _ = Describe("Issue #1070: HandleCreateWorkflow Validation Error Priority", Label("unit", "issue-1070"), func() {
+
+	makeRequest := func(content string) *http.Request {
+		body := map[string]string{"content": content}
+		jsonBody, err := json.Marshal(body)
+		Expect(err).ToNot(HaveOccurred())
+		return httptest.NewRequest(http.MethodPost, "/api/v1/workflows", bytes.NewReader(jsonBody))
+	}
+
+	parseRFC7807 := func(rr *httptest.ResponseRecorder) map[string]interface{} {
+		var problem map[string]interface{}
+		Expect(json.Unmarshal(rr.Body.Bytes(), &problem)).To(Succeed())
+		return problem
+	}
+
+	Context("Sequential error priority (pre-parallelization baseline)", func() {
+
+		It("UT-WF-1070-001: schema validation error beats all downstream failures", func() {
+			schemaYAML := validSchemaForPriorityTests()
+			failingPuller := oci.NewMockImagePullerWithFailingExists(schemaYAML, fmt.Errorf("bundle not found"))
+			extractor := oci.NewSchemaExtractor(failingPuller, schema.NewParser())
+
+			handler := server.NewHandler(nil,
+				server.WithActionTypeValidator(rejectingActionTypeValidator()),
+				server.WithSchemaExtractor(extractor),
+				server.WithDependencyValidator(
+					&mockDependencyValidator{err: fmt.Errorf("secret missing-secret not found")},
+					"test-ns",
+				),
+			)
+
+			req := makeRequest("invalid yaml {{{")
+			rr := httptest.NewRecorder()
+
+			handler.HandleCreateWorkflow(rr, req)
+
+			Expect(rr.Code).To(Equal(http.StatusBadRequest))
+			problem := parseRFC7807(rr)
+			Expect(problem["type"]).To(Equal("https://kubernaut.ai/problems/validation-error"),
+				"Schema validation must be the first error, regardless of downstream failures")
+		})
+
+		It("UT-WF-1070-002: action-type error beats bundle-not-found and dependency errors", func() {
+			schemaYAML := validSchemaForPriorityTests()
+			failingPuller := oci.NewMockImagePullerWithFailingExists(schemaYAML, fmt.Errorf("bundle not found"))
+			extractor := oci.NewSchemaExtractor(failingPuller, schema.NewParser())
+
+			handler := server.NewHandler(nil,
+				server.WithActionTypeValidator(rejectingActionTypeValidator()),
+				server.WithSchemaExtractor(extractor),
+				server.WithDependencyValidator(
+					&mockDependencyValidator{err: fmt.Errorf("secret missing-secret not found")},
+					"test-ns",
+				),
+			)
+
+			req := makeRequest(schemaYAML)
+			rr := httptest.NewRecorder()
+
+			handler.HandleCreateWorkflow(rr, req)
+
+			Expect(rr.Code).To(Equal(http.StatusBadRequest))
+			problem := parseRFC7807(rr)
+			Expect(problem["type"]).To(Equal("https://kubernaut.ai/problems/validation-error"),
+				"Action-type rejection must take priority over bundle and dependency errors")
+			Expect(problem["detail"]).To(ContainSubstring("action_type"),
+				"Error detail should mention action_type")
+		})
+
+		It("UT-WF-1070-003: bundle-not-found beats dependency-validation-error", func() {
+			schemaYAML := validSchemaForPriorityTests()
+			failingPuller := oci.NewMockImagePullerWithFailingExists(schemaYAML, fmt.Errorf("bundle image not in registry"))
+			extractor := oci.NewSchemaExtractor(failingPuller, schema.NewParser())
+
+			acceptingValidator := &mockActionTypeValidator{
+				existsFn: func(_ context.Context, _ string) (bool, error) {
+					return true, nil
+				},
+			}
+
+			handler := server.NewHandler(nil,
+				server.WithActionTypeValidator(acceptingValidator),
+				server.WithSchemaExtractor(extractor),
+				server.WithDependencyValidator(
+					&mockDependencyValidator{err: fmt.Errorf("secret missing-secret not found")},
+					"test-ns",
+				),
+			)
+
+			req := makeRequest(schemaYAML)
+			rr := httptest.NewRecorder()
+
+			handler.HandleCreateWorkflow(rr, req)
+
+			Expect(rr.Code).To(Equal(http.StatusBadRequest))
+			problem := parseRFC7807(rr)
+			Expect(problem["type"]).To(Equal("https://kubernaut.ai/problems/bundle-not-found"),
+				"Bundle-not-found must take priority over dependency validation error")
+		})
+
+		It("UT-WF-1070-004: dependency-validation-error returned when no higher-priority failures", func() {
+			schemaYAML := validSchemaForPriorityTests()
+			mockPuller := oci.NewMockImagePuller(schemaYAML)
+			extractor := oci.NewSchemaExtractor(mockPuller, schema.NewParser())
+
+			acceptingValidator := &mockActionTypeValidator{
+				existsFn: func(_ context.Context, _ string) (bool, error) {
+					return true, nil
+				},
+			}
+
+			handler := server.NewHandler(nil,
+				server.WithActionTypeValidator(acceptingValidator),
+				server.WithSchemaExtractor(extractor),
+				server.WithDependencyValidator(
+					&mockDependencyValidator{err: fmt.Errorf("secret missing-secret not found")},
+					"test-ns",
+				),
+			)
+
+			req := makeRequest(schemaYAML)
+			rr := httptest.NewRecorder()
+
+			handler.HandleCreateWorkflow(rr, req)
+
+			Expect(rr.Code).To(Equal(http.StatusBadRequest))
+			problem := parseRFC7807(rr)
+			Expect(problem["type"]).To(Equal("https://kubernaut.ai/problems/dependency-validation-error"),
+				"Dependency error should surface when no higher-priority validation fails")
+		})
+
+		It("UT-WF-1070-005: all validations pass — no error returned", func() {
+			schemaYAML := validSchemaForPriorityTests()
+			mockPuller := oci.NewMockImagePuller(schemaYAML)
+			extractor := oci.NewSchemaExtractor(mockPuller, schema.NewParser())
+
+			acceptingValidator := &mockActionTypeValidator{
+				existsFn: func(_ context.Context, _ string) (bool, error) {
+					return true, nil
+				},
+			}
+
+			handler := server.NewHandler(nil,
+				server.WithActionTypeValidator(acceptingValidator),
+				server.WithSchemaExtractor(extractor),
+				server.WithDependencyValidator(
+					&mockDependencyValidator{err: nil},
+					"test-ns",
+				),
+			)
+
+			req := makeRequest(schemaYAML)
+			rr := httptest.NewRecorder()
+
+			handler.HandleCreateWorkflow(rr, req)
+
+			Expect(rr.Code).ToNot(Equal(http.StatusBadRequest),
+				"No validation error should occur when all checks pass")
+		})
+	})
+})
+
+// Compile-time assertion that mockDependencyValidator satisfies the interface.
+var _ validation.DependencyValidator = &mockDependencyValidator{}


### PR DESCRIPTION
## Summary

- Parallelizes the three independent external validation calls (action-type taxonomy, OCI bundle existence, K8s dependency checks) in `HandleCreateWorkflow` using a **typed-result-slot pattern** that preserves the original sequential error priority contract (RFC 7807)
- Parallelizes individual Secret/ConfigMap Gets in `K8sDependencyValidator.ValidateDependencies` using `errgroup`
- Adds `WorkflowValidationDuration` histogram metric with `phase`/`result` labels for validation phase observability
- Fixes redundant `schema.NewParser()` allocation (reuses existing instance)

### Regression Safety

- 5 new error priority tests (UT-WF-1070-001..005) lock the validation error contract, ensuring the highest-priority error is always returned regardless of goroutine completion order
- 1 concurrent smoke test (UT-WF-1070-CONC-001) validates no data races with `-race`
- RFC 7807 `type` assertions added to IT-DS-006-002..005 integration tests
- All 673 existing unit tests pass unchanged with `-race` enabled

Closes #1070

## Test plan

- [x] UT-WF-1070-001: schema validation error beats all downstream failures
- [x] UT-WF-1070-002: action-type error beats bundle-not-found and dependency errors
- [x] UT-WF-1070-003: bundle-not-found beats dependency-validation-error
- [x] UT-WF-1070-004: dependency-validation-error returned when no higher-priority failures
- [x] UT-WF-1070-005: all validations pass — no error returned
- [x] UT-WF-1070-CONC-001: concurrent requests produce valid responses without data races
- [x] IT-DS-006-002..005: RFC 7807 `type=dependency-validation-error` assertion
- [x] Full unit test suite (673 specs) passes with `-race`
- [x] Full codebase `go build ./...` succeeds


Made with [Cursor](https://cursor.com)