### PR TITLE
docs: shadow agent technical documentation readiness

### DIFF
--- a/docs/operations/runbooks/shadow-agent-escalation-runbook.md
+++ b/docs/operations/runbooks/shadow-agent-escalation-runbook.md
@@ -1,0 +1,212 @@
+# Shadow Agent Escalation — Production Runbook
+
+**Version**: v1.0
+**Last Updated**: 2026-05-10
+**Status**: Production Ready
+**Related**: [Shadow Agent Configuration Guide](../../services/kubernaut-agent/shadow-agent-configuration.md) | [ADR-KA-001](../../architecture/decisions/ADR-KA-001-shadow-agent-alignment-check.md)
+**FedRAMP Controls**: AU-2 (Audit Events), AU-3 (Audit Content), IR-6 (Incident Reporting), SI-4 (System Monitoring)
+
+---
+
+## Runbook Index
+
+| ID | Runbook | Triggers On | Automation |
+|----|---------|-------------|------------|
+| RB-SA-001 | [Suspicious Verdict Escalation](#rb-sa-001-suspicious-verdict-escalation) | `kubernaut_alignment_verdict_total{result="suspicious"}` | Alert |
+| RB-SA-002 | [Circuit Breaker Activation](#rb-sa-002-circuit-breaker-activation) | `alignment_verdict.circuit_breaker_activated=true` in AA status | Alert |
+| RB-SA-003 | [Canary Integrity Failure](#rb-sa-003-canary-integrity-failure) | `kubernaut_alignment_canary_total{result="fail"}` | Alert |
+| RB-SA-004 | [High Verdict Timeout Rate](#rb-sa-004-high-verdict-timeout-rate) | `kubernaut_alignment_step_total{outcome="panic"}` spike | Dashboard |
+| RB-SA-005 | [Shadow Agent Unavailable](#rb-sa-005-shadow-agent-unavailable) | KA startup failure with alignment enabled | Alert |
+
+---
+
+## RB-SA-001: Suspicious Verdict Escalation
+
+### When This Fires
+
+The shadow agent detected content in an LLM response or tool output that resembles a prompt injection attempt. The investigation has been escalated to human review with `humanReviewReason: alignment_check_failed`.
+
+### Alert Definition
+
+```yaml
+groups:
+  - name: shadow-agent
+    rules:
+      - alert: ShadowAgentSuspiciousVerdict
+        expr: rate(kubernaut_alignment_verdict_total{result="suspicious"}[5m]) > 0
+        for: 1m
+        labels:
+          severity: warning
+          component: kubernaut-agent
+        annotations:
+          summary: "Shadow agent flagged suspicious content"
+          description: "{{ $labels.instance }} reported {{ $value | humanize }} suspicious verdicts/sec in the last 5 minutes (mode={{ $labels.mode }})"
+```
+
+### Triage Steps
+
+1. **Identify the investigation**: Check the `AIAnalysis` CR with `humanReviewReason: alignment_check_failed`:
+
+   ```bash
+   kubectl get aianalysis -A -o jsonpath='{range .items[?(@.status.humanReviewReason=="alignment_check_failed")]}{.metadata.namespace}/{.metadata.name} {.status.alignmentVerdict.summary}{"\n"}{end}'
+   ```
+
+2. **Read the alignment verdict**: The `status.alignmentVerdict` field contains the structured verdict:
+
+   ```bash
+   kubectl get aianalysis <name> -n <namespace> -o jsonpath='{.status.alignmentVerdict}' | jq .
+   ```
+
+   Key fields:
+   - `result`: `"suspicious"` confirms the escalation
+   - `findings[].explanation`: What the shadow agent detected
+   - `findings[].step_kind` / `findings[].tool`: Where the suspicious content appeared
+   - `circuit_breaker_activated`: Whether the primary investigation was cancelled
+
+3. **Check audit trail**: Query Data Storage for detailed per-step audit events:
+
+   - Event type `aiagent.alignment.step`: individual flagged steps with explanations
+   - Event type `aiagent.alignment.verdict`: final verdict with token usage
+   - Filter by `correlation_id` (RemediationRequest name)
+
+4. **Assess the finding**:
+   - **True positive**: The content genuinely contains injection patterns (e.g., role impersonation, instruction override). Escalate per your incident response process.
+   - **False positive**: The content is legitimate but resembles injection (e.g., log lines containing `SYSTEM:` headers). See tuning steps below.
+
+### Resolution
+
+- **True positive**: Follow your organization's incident response procedure. The suspicious content is preserved in the audit trail and AA status for forensic review.
+- **False positive**: Consider tuning `maxStepTokens` (increase to preserve context) or switching to a more capable shadow model. If false positives are frequent, temporarily switch to `mode: monitor` while tuning.
+
+---
+
+## RB-SA-002: Circuit Breaker Activation
+
+### When This Fires
+
+The shadow agent detected suspicious content **during** an active investigation in `enforce` mode and cancelled the primary LLM via the circuit breaker. The primary LLM results may be incomplete or compromised.
+
+### Alert Definition
+
+```yaml
+      - alert: ShadowAgentCircuitBreakerActivated
+        expr: rate(kubernaut_alignment_verdict_total{result="suspicious",mode="enforce"}[5m]) > 0
+        for: 0m
+        labels:
+          severity: critical
+          component: kubernaut-agent
+        annotations:
+          summary: "Shadow agent circuit breaker activated"
+          description: "{{ $labels.instance }} cancelled a primary LLM investigation due to detected prompt injection"
+```
+
+### Triage Steps
+
+1. **Identify the investigation**: Same as RB-SA-001 step 1, but filter for `circuitBreakerActivated`:
+
+   ```bash
+   kubectl get aianalysis -A -o jsonpath='{range .items[?(@.status.alignmentVerdict.circuitBreakerActivated==true)]}{.metadata.namespace}/{.metadata.name}{"\n"}{end}'
+   ```
+
+2. **Review the notification**: The `NotificationRequest` for this investigation contains both the shadow agent's findings (prominently displayed) and the relegated primary LLM RCA. The primary results should be treated as potentially compromised.
+
+3. **Assess the signal source**: Determine whether the signal that triggered the investigation contained malicious content:
+   - Check the originating alert/event for injection patterns
+   - Review the `signal_input` step in the audit trail (step 0)
+   - If the signal source is compromised, investigate the upstream alerting pipeline
+
+### Resolution
+
+- **Confirmed injection**: The circuit breaker worked as designed. Document the incident, review the signal source for compromise, and ensure the injection vector is mitigated.
+- **False positive**: The circuit breaker cancelled a legitimate investigation. Switch to `mode: monitor` temporarily, re-trigger the investigation, and tune the shadow model or `maxStepTokens`.
+
+---
+
+## RB-SA-003: Canary Integrity Failure
+
+### When This Fires
+
+The pre-investigation canary check failed — the shadow model did not flag a known-malicious payload. This indicates the shadow model may be compromised, misconfigured, or degraded.
+
+### Alert Definition
+
+```yaml
+      - alert: ShadowAgentCanaryFailure
+        expr: kubernaut_alignment_canary_total{result="fail"} > 0
+        for: 0m
+        labels:
+          severity: critical
+          component: kubernaut-agent
+        annotations:
+          summary: "Shadow agent canary integrity check failed"
+          description: "{{ $labels.instance }} canary failure — shadow model may be compromised or misconfigured"
+```
+
+### Triage Steps
+
+1. **Check shadow LLM health**: Verify the shadow model endpoint is reachable and returning valid responses.
+2. **Check model configuration**: Ensure the correct model is configured in `ai.alignmentCheck.llm`. A model swap (e.g., from a security-tuned model to a general model) could cause canary failures.
+3. **Review shadow LLM audit events**: Check `aiagent.shadow.llm.request` and `aiagent.shadow.llm.response` events for error patterns.
+
+### Resolution
+
+- **Model degraded**: Restart the shadow model or switch to a backup model.
+- **Model compromised**: Rotate API keys, switch providers, and escalate per security incident response.
+- **Configuration error**: Fix the `ai.alignmentCheck.llm` configuration and restart KA.
+
+---
+
+## RB-SA-004: High Verdict Timeout Rate
+
+### When This Fires
+
+Shadow evaluations are frequently timing out or panicking, leading to fail-closed suspicious verdicts that may not represent actual injection attempts.
+
+### Alert Definition
+
+```yaml
+      - alert: ShadowAgentHighTimeoutRate
+        expr: rate(kubernaut_alignment_step_total{outcome="panic"}[10m]) / rate(kubernaut_alignment_step_total[10m]) > 0.1
+        for: 5m
+        labels:
+          severity: warning
+          component: kubernaut-agent
+        annotations:
+          summary: "Shadow agent high evaluation failure rate"
+          description: "{{ $labels.instance }} has >10% panic/timeout rate in shadow evaluations"
+```
+
+### Triage Steps
+
+1. **Check shadow LLM latency**: High latency causes per-step timeouts. Check `kubernaut_alignment_verdict_duration_seconds` histogram.
+2. **Check concurrency**: With the default limit of 10 concurrent evaluations and high-volume investigations, evaluations may queue behind the semaphore.
+3. **Check shadow LLM error rate**: Query `aiagent.shadow.llm.response` audit events for error responses.
+
+### Resolution
+
+- **High latency**: Use a faster shadow model, increase `timeout`, or use a dedicated LLM to avoid contention.
+- **High error rate**: Check shadow LLM provider status, rotate API keys if rate-limited.
+- **Concurrency saturation**: This is expected under load; the concurrency cap protects the shadow LLM from overload. Consider increasing `verdictTimeout` to allow more time for queued evaluations.
+
+---
+
+## RB-SA-005: Shadow Agent Unavailable
+
+### When This Fires
+
+KA failed to start because the shadow agent is enabled but the dedicated shadow LLM client could not be built. The process exits (fail-closed).
+
+### Triage Steps
+
+1. **Check KA pod logs**: Look for startup errors related to alignment check configuration.
+
+   ```bash
+   kubectl logs -l app=kubernaut-agent -n kubernaut --tail=50 | grep -i alignment
+   ```
+
+2. **Validate configuration**: Ensure `ai.alignmentCheck.llm` fields are correct (provider, model, endpoint, API key).
+
+### Resolution
+
+- Fix the LLM configuration and redeploy.
+- If immediate investigation capability is needed, set `ai.alignmentCheck.enabled: false` to disable the shadow agent and restart. Investigations will proceed without alignment checks.

--- a/docs/services/kubernaut-agent/configuration-reference.md
+++ b/docs/services/kubernaut-agent/configuration-reference.md
@@ -252,6 +252,19 @@ When `enabled` is true and `llm` is nil, startup logs **error-level** diagnostic
 
 Overrides do not duplicate `tlsCaFile` here; TLS trust stays on `ai.llm.tlsCaFile` for LangChain transports.
 
+### 7.2 Enforcement modes and circuit breaker
+
+The `mode` field controls how suspicious verdicts affect the investigation:
+
+| Mode | Suspicious verdict behavior | Circuit breaker | Use case |
+|------|-----------------------------|-----------------|----------|
+| `enforce` | Sets `HumanReviewNeeded=true`, `HumanReviewReason="alignment_check_failed"`, appends warning. Circuit breaker cancels the primary LLM context mid-investigation when the first suspicious step is detected. | Active | Production environments where prompt injection must be blocked. |
+| `monitor` | Logs verdict, emits audit events and Prometheus metrics. Investigation proceeds normally. | Inactive | Initial rollout, false-positive tuning, observability-only deployment. |
+
+The alignment circuit breaker is distinct from the Data Storage circuit breaker (§8.1). The DS circuit breaker protects against backend failures using request-count thresholds, while the alignment circuit breaker is a per-investigation safety mechanism that cancels the primary LLM on detected prompt injection. The alignment circuit breaker has no configurable thresholds — it fires on the first suspicious evaluation in `enforce` mode.
+
+For the complete shadow agent operational guide, see [shadow-agent-configuration.md](shadow-agent-configuration.md).
+
 ## 8. Integrations
 
 YAML path: `integrations`

--- a/docs/services/kubernaut-agent/shadow-agent-configuration.md
+++ b/docs/services/kubernaut-agent/shadow-agent-configuration.md
@@ -1,9 +1,10 @@
 # Shadow Agent (Alignment Check) — Configuration Guide
 
-**Version**: 1.0
+**Version**: 2.0
 **Feature**: Prompt Injection Guardrails ([#601](https://github.com/jordigilh/kubernaut/issues/601))
 **Since**: v1.4
 **ADR**: [ADR-KA-001](../../architecture/decisions/ADR-KA-001-shadow-agent-alignment-check.md)
+**Issues**: [#1076](https://github.com/jordigilh/kubernaut/issues/1076), [#1077](https://github.com/jordigilh/kubernaut/issues/1077), [#1078](https://github.com/jordigilh/kubernaut/issues/1078)
 
 ---
 
@@ -11,14 +12,18 @@
 
 The Shadow Agent is a parallel security auditor that runs alongside the Kubernaut Agent's primary investigation loop. It monitors every piece of content entering the agentic pipeline — LLM responses, tool outputs, and signal context — and flags prompt injection attempts before they can influence remediation decisions.
 
-When the shadow agent detects suspicious content, the investigation is automatically escalated to human review rather than proceeding to automated remediation.
+The shadow agent operates in one of two modes:
+
+- **Enforce** (default): Suspicious verdicts escalate the investigation to human review. If a circuit breaker fires mid-investigation, the primary LLM is cancelled and the shadow agent's findings become the primary content presented to the operator.
+- **Monitor**: Suspicious verdicts are logged and audited but do not block the investigation or trigger the circuit breaker. Use this mode during initial rollout to observe false-positive rates before enabling enforcement.
 
 ### Key Properties
 
 - **Transparent**: No modification to the investigation logic — operates as a proxy layer
-- **Fail-closed**: Any error (timeout, LLM failure, malformed response) results in human review escalation
-- **Per-investigation isolation**: Each investigation gets a fresh observer; no state leaks across requests
+- **Fail-closed**: Any error (timeout, LLM failure, malformed response, evaluator panic) results in a suspicious verdict
+- **Per-investigation isolation**: Each investigation gets a fresh Observer; no state leaks across requests
 - **Concurrent**: Shadow evaluations run in parallel with the investigation, adding minimal latency
+- **Canary integrity check**: Before each investigation, a known-malicious payload is sent to the shadow evaluator to detect compromised or misconfigured shadow models
 
 ---
 
@@ -30,17 +35,25 @@ When the shadow agent detects suspicious content, the investigation is automatic
 kubernautAgent:
   alignmentCheck:
     enabled: true
+    mode: "enforce"
     timeout: "10s"
+    verdictTimeout: "30s"
     maxStepTokens: 500
 ```
 
 ### Via Service Configuration (ConfigMap)
 
 ```yaml
-alignmentCheck:
-  enabled: true
-  timeout: 10s
-  maxStepTokens: 500
+ai:
+  alignmentCheck:
+    enabled: true
+    mode: enforce
+    timeout: 10s
+    verdictTimeout: 30s
+    maxStepTokens: 500
+    maxRetries: 1
+    canary:
+      forceEscalation: true
 ```
 
 The shadow agent is **disabled by default** (`enabled: false`). When disabled, the investigation pipeline operates exactly as in v1.3 with zero overhead.
@@ -49,21 +62,37 @@ The shadow agent is **disabled by default** (`enabled: false`). When disabled, t
 
 ## Configuration Reference
 
+YAML path: `ai.alignmentCheck`
+
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `enabled` | bool | `false` | Enable the shadow agent alignment check |
+| `enabled` | bool | `false` | Enable the shadow agent alignment check. |
+| `mode` | string | `enforce` | `enforce`: suspicious verdicts escalate to human review and activate the circuit breaker. `monitor`: suspicious verdicts are logged and audited only. |
 | `timeout` | duration | `10s` | Per-step evaluation timeout. Each tool output or LLM response is evaluated independently with this timeout. |
+| `verdictTimeout` | duration | `30s` | Maximum time to wait for all pending shadow evaluations to complete after the primary investigation finishes. Pending evaluations after this timeout trigger a fail-closed suspicious verdict. |
 | `maxStepTokens` | int | `500` | Maximum runes per evaluated step. Content exceeding this limit is truncated using a head+tail strategy that preserves the beginning and end of the content. |
+| `maxRetries` | int | `1` | Number of retries for failed evaluator calls (per step). |
+| `canary.forceEscalation` | bool | `true` | When true, a canary failure forces human review escalation regardless of the `mode` setting. When false, canary failures only escalate in `enforce` mode. |
 | `llm.provider` | string | *(inherits)* | LLM provider for shadow evaluation. If omitted, reuses the investigation LLM. |
 | `llm.model` | string | *(inherits)* | Model name. Required when `llm` block is specified. |
 | `llm.endpoint` | string | *(inherits)* | Provider endpoint URL. Required for non-managed providers. |
 | `llm.apiKey` | string | *(inherits)* | API key for the shadow LLM. |
 
+For the complete LLM override surface (`azureApiVersion`, `vertexProject`, etc.), see [configuration-reference.md §7.1](configuration-reference.md#71-aialignmentcheckllm-overrides-llmoverrideconfig).
+
+### Startup Behavior
+
+- When `enabled=true` and `llm` is **nil**: KA logs an **error-level** warning that shadow traffic shares the primary LLM client (contention risk).
+- When `enabled=true` and the dedicated shadow client **fails to build**: the process **exits** (fail-closed — a non-functional shadow agent is worse than no shadow agent).
+
 ### Validation Rules
 
 When `enabled: true`:
+- `mode` must be `enforce` or `monitor`
 - `timeout` must be a positive duration
+- `verdictTimeout` must be a positive duration
 - `maxStepTokens` must be a positive integer
+- `maxRetries` must be >= 0
 - If `llm` is specified, `model` must be non-empty
 - If `llm.provider` is not a managed provider (openai, anthropic, bedrock, huggingface), `endpoint` is required
 
@@ -106,7 +135,7 @@ kubernautAgent:
       apiKey: "sk-..."
 ```
 
-**Trade-offs**: Requires a second API key and model access. Recommended for production: `gpt-4o-mini` is ~10x cheaper than `gpt-4o` and sufficient for binary suspicious/clean classification.
+**Trade-offs**: Requires a second API key and model access. Recommended for production: `gpt-4o-mini` is ~10x cheaper than `gpt-4o` and sufficient for binary suspicious/aligned classification.
 
 ### Strategy 3: Cross-Provider Shadow
 
@@ -135,22 +164,45 @@ kubernautAgent:
 ### Investigation Flow (Shadow Enabled)
 
 ```
-1. Signal arrives → InvestigatorWrapper creates Observer
-2. Signal context submitted as Step 0 (StepKindSignalInput)
-3. Primary investigation begins:
+1. Signal arrives → InvestigatorWrapper runs canary integrity check
+2. Canary result:
+   - PASS → proceed normally
+   - FAIL → log warning; escalate to human review if mode=enforce or canary.forceEscalation=true
+3. InvestigatorWrapper creates per-investigation Observer
+4. Signal context submitted as Step 0 (StepKindSignalInput)
+5. Primary investigation begins:
    a. LLMProxy intercepts each Chat() → submits LLM response as step
    b. ToolProxy intercepts each Execute() → submits tool result as step
-   c. Observer dispatches each step to Evaluator asynchronously
-   d. Evaluator sends step to shadow LLM with security prompt
+   c. Observer dispatches each step to Evaluator asynchronously (max 10 concurrent)
+   d. Evaluator sends step to shadow LLM with boundary-wrapped security prompt
    e. Shadow LLM returns {suspicious: bool, explanation: string}
-4. Primary investigation completes
-5. Observer.WaitForCompletion(30s) — collects all evaluations
-6. Verdict rendered:
-   - Clean → result returned unchanged
-   - Suspicious → HumanReviewNeeded=true, warnings appended
-   - Timeout → fail-closed, treated as suspicious
-7. Audit events emitted for every flagged step + final verdict
+6. Primary investigation completes
+7. Observer.WaitForCompletion(verdictTimeout) — collects all evaluations
+8. Verdict rendered:
+   - Aligned → alignment_verdict populated with result="aligned"
+   - Suspicious + enforce → HumanReviewNeeded=true, reason="alignment_check_failed"
+   - Suspicious + monitor → logged and audited only, investigation proceeds
+   - Timeout / pending evals → fail-closed, treated as suspicious
+9. alignment_verdict populated on InvestigationResult for ALL investigations
+10. Audit events emitted for every flagged step + final verdict
 ```
+
+### Circuit Breaker (Enforce Mode)
+
+In `enforce` mode, when the shadow agent detects suspicious content during an active investigation, the circuit breaker activates:
+
+1. The Observer's `onSuspicious` callback fires (via `sync.Once` — exactly once per investigation)
+2. The primary LLM investigation context is cancelled via `context.WithCancelCause(ErrCircuitBreaker)`
+3. Shadow evaluations continue on the parent context (they are not cancelled)
+4. The partial primary LLM results are preserved but relegated in the notification
+5. The alignment verdict's `circuit_breaker_activated` flag is set to `true`
+6. The operator notification prominently displays the shadow agent's findings
+
+In `monitor` mode, the circuit breaker does not fire. Suspicious verdicts are logged and audited but the primary investigation runs to completion.
+
+### LLMProxy and Client Pinning
+
+When the investigation LLM uses hot-reloadable configuration (`SwappableClient`), the investigator pins a client snapshot at the start of each investigation to prevent mid-flight configuration changes. The `PinDecorator` ensures that the `LLMProxy` wrapper is re-applied around the pinned snapshot, so all LLM traffic remains observable by the shadow agent even after pinning. Without this, pinned clients would bypass the shadow proxy.
 
 ### Content Evaluation
 
@@ -174,34 +226,116 @@ The boundary token is cryptographically random per evaluation. Content containin
 
 ---
 
+## API Surface
+
+### KA OpenAPI — `IncidentResponse.alignment_verdict`
+
+Every investigation response includes an `alignment_verdict` object:
+
+```json
+{
+  "alignment_verdict": {
+    "result": "aligned",
+    "circuit_breaker_activated": false,
+    "summary": "all steps passed alignment check",
+    "flagged": 0,
+    "total": 12,
+    "findings": []
+  }
+}
+```
+
+When suspicious content is detected:
+
+```json
+{
+  "alignment_verdict": {
+    "result": "suspicious",
+    "circuit_breaker_activated": true,
+    "summary": "step 3 (get_pod_logs): Role impersonation via SYSTEM: header",
+    "flagged": 1,
+    "total": 12,
+    "findings": [
+      {
+        "step_index": 3,
+        "step_kind": "tool_result",
+        "tool": "get_pod_logs",
+        "explanation": "Role impersonation via SYSTEM: header in log output"
+      }
+    ]
+  }
+}
+```
+
+### AIAnalysis CRD — `status.alignmentVerdict`
+
+The AA controller maps the KA response into the `AIAnalysis` status:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status.alignmentVerdict.result` | string | `"aligned"` or `"suspicious"` |
+| `status.alignmentVerdict.circuitBreakerActivated` | bool | Whether the circuit breaker cancelled the primary investigation |
+| `status.alignmentVerdict.summary` | string | Human-readable verdict summary |
+| `status.alignmentVerdict.flagged` | int | Number of flagged steps |
+| `status.alignmentVerdict.total` | int | Total evaluated steps |
+| `status.alignmentVerdict.findings` | array | Per-step findings (stepIndex, stepKind, tool, explanation) |
+
+### NotificationRequest CRD — `ReviewContext`
+
+When alignment triggers human review, the `NotificationRequest` carries:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `context.review.alignmentVerdict` | string | Rendered verdict summary text |
+| `context.review.circuitBreakerActivated` | bool | Whether the circuit breaker was active |
+
+The Remediation Orchestrator renders the alignment verdict prominently in the notification body. When the circuit breaker is activated, the shadow agent's findings are displayed first and the primary LLM's RCA is relegated with a warning that it may be incomplete or compromised.
+
+---
+
 ## Observability
+
+### Prometheus Metrics
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `kubernaut_alignment_verdict_total` | Counter | `result` (aligned, suspicious), `mode` (enforce, monitor) | Total alignment verdicts emitted |
+| `kubernaut_alignment_step_total` | Counter | `outcome` (aligned, suspicious, panic) | Per-step evaluation outcomes |
+| `kubernaut_alignment_canary_total` | Counter | `result` (pass, fail) | Canary integrity check results |
+| `kubernaut_alignment_verdict_duration_seconds` | Histogram | *(default buckets)* | Time from canary start to verdict completion |
+| `kubernaut_alignment_shadow_audit_total` | Counter | `event_type` (request, response) | Shadow LLM audit events emitted to Data Storage |
 
 ### Logs
 
 When the shadow agent is enabled, KA logs include:
 
 ```
-# Clean investigation
+# Aligned investigation
 INFO  shadow agent alignment check passed  signal=my-alert namespace=production total=8
 
-# Suspicious investigation
+# Suspicious investigation (enforce mode)
 INFO  shadow agent flagged suspicious content  signal=my-alert namespace=production
-      flagged=2 total=8 pending=0 timed_out=false
+      flagged=2 total=8 pending=0 timed_out=false escalated=true mode=enforce
       summary="step 3 (get_pod_logs): Role impersonation via SYSTEM: header in log output"
+
+# Suspicious investigation (monitor mode)
+INFO  shadow agent flagged suspicious content  signal=my-alert namespace=production
+      flagged=2 total=8 pending=0 timed_out=false escalated=false mode=monitor
+      summary="step 3 (get_pod_logs): Role impersonation via SYSTEM: header in log output"
+
+# Canary failure
+INFO  shadow agent canary failed: shadow model did not flag known-malicious content
+      signal=my-alert namespace=production explanation="..."
 ```
 
 ### Audit Events
 
 | Event Type | Trigger | Key Fields |
 |------------|---------|------------|
-| `alignment.step` | Each flagged step | `step_index`, `step_kind`, `tool`, `explanation` |
-| `alignment.verdict` | Investigation complete | `result` (clean/suspicious), `summary`, `flagged`, `total` |
-
-### Metrics
-
-Shadow agent activity is observable through the existing KA investigation metrics:
-- Investigations with `HumanReviewNeeded=true` and `HumanReviewReason="alignment_check_failed"` indicate shadow agent escalations
-- Shadow LLM calls appear in the instrumented client's request/latency metrics
+| `aiagent.alignment.step` | Each flagged step | `step_index`, `step_kind`, `tool`, `explanation` |
+| `aiagent.alignment.verdict` | Investigation complete | `result` (aligned/suspicious), `summary`, `flagged`, `total`, `shadow_prompt_tokens`, `shadow_completion_tokens`, `shadow_total_tokens` |
+| `aiagent.shadow.llm.request` | Shadow LLM call sent | `correlation_id`, `model`, `provider` |
+| `aiagent.shadow.llm.response` | Shadow LLM call returned | `correlation_id`, `model`, `prompt_tokens`, `completion_tokens`, `total_tokens` |
 
 ---
 
@@ -215,7 +349,8 @@ If the shadow agent flags too many legitimate investigations:
 2. **Review flagged steps** — Use audit events to identify patterns. Common false positives:
    - Application logs containing "ERROR:" or "WARNING:" prefixes
    - Kubernetes events with descriptive messages that resemble instructions
-3. **Consider a more capable shadow model** — `gpt-4o-mini` may flag ambiguous content that `gpt-4o` would correctly classify as clean.
+3. **Consider a more capable shadow model** — `gpt-4o-mini` may flag ambiguous content that `gpt-4o` would correctly classify as aligned.
+4. **Start in `monitor` mode** — Run with `mode: monitor` to observe verdicts without impacting investigations, then switch to `enforce` once the false-positive rate is acceptable.
 
 ### High Latency
 
@@ -223,7 +358,8 @@ If investigations take too long with shadow enabled:
 
 1. **Use a dedicated shadow LLM** — Avoids contention on the primary LLM client.
 2. **Reduce `timeout`** — Default 10s per step is conservative. For fast models, 5s is often sufficient.
-3. **Monitor `timed_out` verdicts** — If verdicts frequently time out, the shadow LLM is too slow or overloaded.
+3. **Monitor `timed_out` verdicts** — If verdicts frequently time out, the shadow LLM is too slow or overloaded. Check `kubernaut_alignment_verdict_total{result="suspicious"}` and correlate with `kubernaut_alignment_step_total{outcome="panic"}`.
+4. **Reduce `verdictTimeout`** — Default 30s waits for all evaluations. If most complete within 10-15s, lowering this reduces tail latency at the cost of more fail-closed verdicts.
 
 ### Cost Optimization
 
@@ -238,15 +374,17 @@ Shadow evaluations generate N+1 LLM calls per investigation (N tool/LLM steps + 
 - **v1.4 scope**: Global enable/disable only — no per-namespace or per-signal granularity
 - **No streaming support**: Shadow evaluation is batch-per-step, not streaming token-by-token
 - **Restart required**: Toggling `enabled` requires a pod restart (no hot-reload for this config in v1.4)
-- **Single shadow model**: One evaluator per KA instance (multi-model consensus deferred to #648)
+- **Single shadow model**: One evaluator per KA instance (multi-model consensus deferred to [#648](https://github.com/jordigilh/kubernaut/issues/648))
+- **Verdict timeout waiter**: The internal goroutine waiting for evaluations to complete is not cancelled when `verdictTimeout` fires. It self-heals within `timeout` (default 10s) as all pending evaluations carry per-step timeouts. A clean fix (Observer-scoped context cancellation) is deferred to a follow-up PR.
 
 ---
 
 ## Migration from v1.3
 
-No migration required. The shadow agent is a new additive feature:
+The shadow agent is a new additive feature with the following migration considerations:
 
 1. **Disabled by default** — v1.3 behavior preserved when `alignmentCheck.enabled: false`
-2. **No CRD changes** — Shadow agent uses existing `InvestigationResult` fields (`HumanReviewNeeded`, `HumanReviewReason`, `Warnings`)
-3. **No API changes** — Transparent to consumers of the investigation API
-4. **Rollback** — Set `alignmentCheck.enabled: false` and restart KA to disable
+2. **New API fields** — `alignment_verdict` is added to `IncidentResponse` (KA OpenAPI) and `AIAnalysisStatus` (CRD). These are optional fields; existing consumers that do not read them are unaffected.
+3. **New CRD fields** — `alignmentVerdict` and `circuitBreakerActivated` are added to `NotificationRequest.ReviewContext`. Existing notification routing rules continue to work; new rules can match on these fields.
+4. **Verdict labels** — The shadow agent uses `"aligned"` (not `"clean"`) and `"suspicious"` as verdict result values. This applies to Prometheus metric labels, audit event data, and API response fields.
+5. **Rollback** — Set `alignmentCheck.enabled: false` and restart KA to disable. The `alignment_verdict` field will be absent from subsequent responses.

--- a/internal/kubernautagent/alignment/doc.go
+++ b/internal/kubernautagent/alignment/doc.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package alignment implements the shadow agent alignment check subsystem
+// for the Kubernaut Agent.
+//
+// The shadow agent runs as a transparent proxy layer around the primary
+// investigation pipeline. It monitors every piece of content entering the
+// agentic loop — LLM responses (via [LLMProxy]), tool outputs (via
+// [ToolProxy]), and signal context — and evaluates each for prompt
+// injection indicators using a dedicated or shared LLM.
+//
+// # Architecture
+//
+// The subsystem is composed of the following components:
+//
+//   - [InvestigatorWrapper]: Wraps the inner InvestigationRunner. Creates a
+//     per-investigation [Observer], runs a canary integrity check, delegates
+//     to the inner runner, collects the verdict, and applies enforcement
+//     policy (enforce vs monitor mode).
+//
+//   - [Observer]: Per-investigation collector that receives steps via
+//     [Observer.SubmitAsync], dispatches them to the [Evaluator] as
+//     concurrent goroutines (capped at [DefaultMaxConcurrentEvals]),
+//     and renders a final [Verdict] via [Observer.RenderVerdict].
+//
+//   - [Evaluator]: Sends each step to the shadow LLM wrapped in
+//     cryptographically random boundary markers. Parses the LLM's
+//     structured response into an [Observation] (suspicious/aligned +
+//     explanation). Boundary escape attempts are immediately flagged.
+//
+//   - [LLMProxy]: Transparent decorator around [llm.Client] that intercepts
+//     Chat calls and submits each LLM response to the [Observer] as a
+//     StepKindLLMReasoning step.
+//
+//   - [ToolProxy]: Transparent decorator around the tool executor that
+//     submits each tool result to the [Observer] as a StepKindToolResult step.
+//
+// # Fail-Closed Design
+//
+// The subsystem is designed to fail closed: any error path results in a
+// suspicious verdict rather than silently passing content through.
+//
+//   - Evaluator timeout → suspicious observation
+//   - Evaluator panic → suspicious observation (recovered, logged)
+//   - Pending evaluations after verdictTimeout → suspicious verdict
+//   - Canary failure → human review escalation (enforce mode or forceEscalation)
+//
+// # Verdict Values
+//
+// Verdicts use the constants [VerdictClean] ("aligned") and
+// [VerdictSuspicious] ("suspicious"). These values are used in Prometheus
+// metric labels, audit event data, API responses, and CRD status fields.
+//
+// # Metrics
+//
+// The package registers the following Prometheus metrics:
+//
+//   - kubernaut_alignment_verdict_total (labels: result, mode)
+//   - kubernaut_alignment_step_total (labels: outcome)
+//   - kubernaut_alignment_canary_total (labels: result)
+//   - kubernaut_alignment_verdict_duration_seconds
+//   - kubernaut_alignment_shadow_audit_total (labels: event_type)
+package alignment


### PR DESCRIPTION
## Summary

- **Update `shadow-agent-configuration.md` to v2.0** (DOC-1, CRITICAL): Rewrites the primary operator-facing guide to reflect the current implementation after PRs #1076-#1082. Adds `mode`, `verdictTimeout`, `maxRetries`, `canary.forceEscalation` to the config table. Replaces stale "clean" verdict references with "aligned". Removes false "No API changes" claim and documents the new `alignment_verdict` fields on API responses and CRDs. Adds circuit breaker section, Prometheus metrics table (5 metrics), full audit events table (4 event types), updated investigation flow diagram, API surface documentation with JSON examples, and notification rendering semantics.

- **Add circuit breaker semantics to `configuration-reference.md` section 7.2** (DOC-7): New sub-section contrasting alignment enforce/monitor modes and distinguishing the alignment circuit breaker from the Data Storage circuit breaker.

- **Create shadow agent escalation runbook** (DOC-4): New production runbook with 5 scenarios (RB-SA-001 through RB-SA-005) covering suspicious verdict triage, circuit breaker activation, canary failure, high timeout rate, and shadow agent startup failure. Includes Prometheus alert definitions, kubectl triage commands, and FedRAMP control mappings (AU-2, AU-3, IR-6, SI-4).

- **Add `doc.go` for alignment package** (DOC-5): Package-level documentation covering architecture, fail-closed design, verdict values, and registered Prometheus metrics.

## Test plan

- [ ] Verify `shadow-agent-configuration.md` renders correctly on GitHub (tables, code blocks, flow diagram)
- [ ] Verify `configuration-reference.md` section 7.2 renders correctly and links to shadow config guide
- [ ] Verify runbook alert YAML is valid Prometheus rule syntax
- [ ] Verify `doc.go` compiles (`go build ./internal/kubernautagent/alignment/...`)
- [ ] Cross-reference config parameters against `configuration-reference.md` section 7 for consistency


Made with [Cursor](https://cursor.com)