### PR TITLE
fix(ds): DLQ critical data-loss fixes (DF-1, DF-2, DF-3) - #1048 Phase 2

### DIFF
--- a/docs/architecture/decisions/DD-008-dlq-drain-graceful-shutdown.md
+++ b/docs/architecture/decisions/DD-008-dlq-drain-graceful-shutdown.md
@@ -75,9 +75,9 @@ DataStorage service uses a Dead Letter Queue (DLQ) to store audit messages that 
 - ✅ **Graceful Degradation**: If timeout, at least some messages saved
 
 **Cons**:
-- ⚠️ **Partial Loss Possible**: If DLQ drain times out, remaining messages lost
+- ⚠️ **Partial Drain Possible**: If DLQ drain times out, remaining messages stay in Redis
   - **Mitigation**: 10 seconds is sufficient for typical DLQ depth
-  - **Rationale**: Better to save some than none
+  - **Note**: Messages are NOT lost — they remain in Redis and will be retried on next startup
 
 **Confidence**: 95% (approved - pragmatic balance)
 
@@ -148,6 +148,9 @@ defer cancel()
 stats, err := s.dlqClient.DrainWithTimeout(ctx, s.repository, s.auditEventsRepo)
 
 // 3. For each stream (notifications, events):
+//    Two-pass cursor-based iteration (ARCH-F1 fix):
+//    Pass 1: forward sweep, XDel only after successful write
+//    Pass 2 (if any writes failed): retry from "-" for remaining messages
 for each message in stream {
     // Check timeout before processing
     if ctx.Done() { return processed, nil }
@@ -155,10 +158,13 @@ for each message in stream {
     // Parse message
     dlqMsg := parseStreamMessage(msg)
 
-    // Write to database (best effort)
-    writeMessageToDB(ctx, auditType, dlqMsg, repo)
+    // Write to database
+    if err := writeMessageToDB(ctx, auditType, dlqMsg, repo); err != nil {
+        // Message stays in Redis — NOT deleted (DF-3 fix)
+        continue
+    }
 
-    // Remove from DLQ
+    // Remove from DLQ only on success
     XDel(ctx, streamKey, msg.ID)
 
     processed++
@@ -180,7 +186,7 @@ return DrainStats{
 **If DLQ drain times out**:
 - ✅ Already-processed messages are persisted
 - ✅ Shutdown continues (timeout is non-fatal)
-- ⚠️ Remaining DLQ messages are lost
+- ✅ Remaining DLQ messages stay in Redis for the next startup's retry worker (#1048 DF-3)
 - 📊 Drain statistics logged for monitoring
 
 **Metrics** (via Prometheus):
@@ -204,8 +210,9 @@ return DrainStats{
 
 1. ⚠️ **Shutdown Delay**: Additional 10s maximum
    - **Mitigation**: Acceptable for audit completeness, configurable timeout
-2. ⚠️ **Partial Loss Possible**: If timeout, remaining messages lost
+2. ⚠️ **Partial Drain Possible**: If timeout, remaining messages stay in Redis
    - **Mitigation**: Typical DLQ depth low (monitored), 10s sufficient for most cases
+   - **Note**: Messages are NOT lost — they remain in Redis for the next startup's retry worker (#1048 DF-3)
 3. ⚠️ **Complexity**: Additional shutdown step
    - **Mitigation**: Well-tested (5/5 tests passing), clear logging
 

--- a/docs/architecture/decisions/DD-009-audit-write-error-recovery.md
+++ b/docs/architecture/decisions/DD-009-audit-write-error-recovery.md
@@ -236,10 +236,12 @@ func DefaultDLQRetryWorkerConfig() DLQRetryWorkerConfig {
     }
 }
 
-// NewDLQRetryWorker creates a new DLQ retry worker
+// NewDLQRetryWorker creates a new DLQ retry worker.
+// #1048 DF-1: Added notificationRepo so notification DLQ messages are persisted.
 func NewDLQRetryWorker(
     dlqClient *dlq.Client,
-    auditRepo *repository.AuditEventsRepository,
+    auditRepo dlq.EventCreator,
+    notificationRepo dlq.NotificationCreator,
     config DLQRetryWorkerConfig,
     logger logr.Logger,
 ) *DLQRetryWorker {
@@ -795,7 +797,7 @@ func (s *Server) Start() error {
     // Start DLQ retry worker (DD-009 V1.0)
     dlqConfig := DefaultDLQRetryWorkerConfig()
     dlqConfig.ConsumerName = s.podName // Use pod name for consumer group distribution
-    s.dlqRetryWorker = NewDLQRetryWorker(s.dlqClient, s.auditRepo, dlqConfig, s.logger)
+    s.dlqRetryWorker = NewDLQRetryWorker(s.dlqClient, s.auditEventsRepo, s.repository, dlqConfig, s.logger)
     s.dlqRetryWorker.Start()
 
     return nil

--- a/pkg/datastorage/dlq/client.go
+++ b/pkg/datastorage/dlq/client.go
@@ -597,41 +597,50 @@ func (c *Client) DrainWithTimeout(ctx context.Context, notificationRepo interfac
 	return stats, nil
 }
 
-// drainStream processes all messages from a specific DLQ stream
+// drainBatchSize limits the number of messages read per XRangeN call during
+// drain to bound memory usage (PERF-3).
+const drainBatchSize int64 = 100
+
+// drainStream processes all messages from a specific DLQ stream using
+// cursor-based iteration.
+//
+// #1048 DF-3: Only XDel after confirmed DB write success. Failed messages
+// remain in the stream for the next startup's retry worker to pick up.
+//
+// #1048 PERF-3: Uses XRangeN with cursor to avoid loading the entire stream
+// into memory at once.
 func (c *Client) drainStream(ctx context.Context, auditType string, repo interface{}) (int, error) {
 	streamKey := c.getStreamKey(auditType)
 	processed := 0
+	cursor := "-"
 
-	// Read all messages in stream (no consumer group needed for drain)
 	for {
-		// Check timeout
 		select {
 		case <-ctx.Done():
 			return processed, nil
 		default:
 		}
 
-		// Read next batch of messages (up to 100 at a time)
-		messages, err := c.redisClient.XRange(ctx, streamKey, "-", "+").Result()
+		messages, err := c.redisClient.XRangeN(ctx, streamKey, cursor, "+", drainBatchSize).Result()
 		if err != nil {
 			return processed, fmt.Errorf("failed to read stream: %w", err)
 		}
 
-		// No more messages
 		if len(messages) == 0 {
 			break
 		}
 
-		// Process each message
 		for _, msg := range messages {
-			// Check timeout before processing each message
 			select {
 			case <-ctx.Done():
 				return processed, nil
 			default:
 			}
 
-			// Parse message
+			// Advance cursor past this message regardless of outcome to
+			// prevent re-reading on the next outer-loop iteration.
+			cursor = "(" + msg.ID
+
 			dlqMsg, err := c.parseStreamMessage(msg)
 			if err != nil {
 				c.logger.Error(err, "Failed to parse DLQ message during drain",
@@ -640,16 +649,14 @@ func (c *Client) drainStream(ctx context.Context, auditType string, repo interfa
 				continue
 			}
 
-			// Write to database (best effort)
 			if err := c.writeMessageToDB(ctx, auditType, dlqMsg, repo); err != nil {
 				c.logger.Error(err, "Failed to write DLQ message to database during drain",
 					"message_id", msg.ID,
 					"audit_type", auditType,
 					"correlation_id", dlqMsg.AuditMessage.CorrelationID())
-				// Continue processing other messages even if one fails
+				continue
 			}
 
-			// Remove message from stream (processed, whether successful or not)
 			if err := c.redisClient.XDel(ctx, streamKey, msg.ID).Err(); err != nil {
 				c.logger.Error(err, "Failed to delete DLQ message during drain",
 					"message_id", msg.ID,

--- a/pkg/datastorage/dlq/client.go
+++ b/pkg/datastorage/dlq/client.go
@@ -57,6 +57,25 @@ import (
 //
 // ========================================
 
+// EventCreator abstracts audit event persistence for dependency injection.
+// Defined in the dlq package to avoid duplicate declarations (ARCH-M2).
+type EventCreator interface {
+	Create(context.Context, *repository.AuditEvent) (*repository.AuditEvent, error)
+}
+
+// NotificationCreator abstracts notification persistence for dependency injection.
+// Defined in the dlq package to avoid duplicate declarations (ARCH-M2).
+type NotificationCreator interface {
+	Create(context.Context, *models.NotificationAudit) (*models.NotificationAudit, error)
+}
+
+// maxPayloadSize caps the DLQ message payload that will be unmarshalled,
+// preventing unbounded memory allocation from oversized messages (SI-10).
+const maxPayloadSize = 1 << 20 // 1 MiB
+
+// MaxPayloadSize returns the maximum allowed DLQ payload size in bytes.
+func MaxPayloadSize() int { return maxPayloadSize }
+
 // Client provides Dead Letter Queue functionality using Redis Streams.
 type Client struct {
 	redisClient *redis.Client
@@ -243,23 +262,23 @@ func (c *Client) HealthCheck(ctx context.Context) error {
 // Messages are claimed by this consumer and must be acknowledged with AckMessage.
 //
 // Parameters:
-// - auditType: Type of audit messages to read ("events" or "notifications")
-// - consumerGroup: Consumer group name (e.g., "audit-retry-workers")
-// - consumerName: Consumer instance name (e.g., "worker-1")
-// - timeout: How long to block waiting for messages
-//
-// Returns up to 10 messages per call.
-func (c *Client) ReadMessages(ctx context.Context, auditType, consumerGroup, consumerName string, timeout time.Duration) ([]*DLQMessage, error) {
+//   - auditType: Type of audit messages to read ("events" or "notifications")
+//   - consumerGroup: Consumer group name (e.g., "audit-retry-workers")
+//   - consumerName: Consumer instance name (e.g., "worker-1")
+//   - count: Maximum number of messages to return per call
+//   - timeout: How long to block waiting for messages
+func (c *Client) ReadMessages(ctx context.Context, auditType, consumerGroup, consumerName string, count int64, timeout time.Duration) ([]*DLQMessage, error) {
 	streamKey := fmt.Sprintf("audit:dlq:%s", auditType)
 
 	// Create consumer group if it doesn't exist
 	// MKSTREAM creates the stream if it doesn't exist
 	err := c.redisClient.XGroupCreateMkStream(ctx, streamKey, consumerGroup, "0").Err()
-	if err != nil && err.Error() != "BUSYGROUP Consumer Group name already exists" {
-		// Ignore "already exists" error, but fail on other errors
-		if !isConsumerGroupExistsError(err) {
-			return nil, fmt.Errorf("failed to create consumer group: %w", err)
-		}
+	if err != nil && !isConsumerGroupExistsError(err) {
+		return nil, fmt.Errorf("failed to create consumer group: %w", err)
+	}
+
+	if count <= 0 {
+		count = 10
 	}
 
 	// Read messages using XREADGROUP
@@ -268,7 +287,7 @@ func (c *Client) ReadMessages(ctx context.Context, auditType, consumerGroup, con
 		Group:    consumerGroup,
 		Consumer: consumerName,
 		Streams:  []string{streamKey, ">"},
-		Count:    10,
+		Count:    count,
 		Block:    timeout,
 	}).Result()
 
@@ -350,7 +369,8 @@ func (c *Client) MoveToDeadLetter(ctx context.Context, auditType string, msg *DL
 	// Add to dead letter stream
 	_, err = c.redisClient.XAdd(ctx, &redis.XAddArgs{
 		Stream: deadLetterKey,
-		MaxLen: 10000, // Cap dead letter queue
+		MaxLen: c.maxLen,
+		Approx: true,
 		ID:     "*",
 		Values: map[string]interface{}{
 			"message":           string(messageJSON),
@@ -402,7 +422,8 @@ func (c *Client) IncrementRetryCount(ctx context.Context, auditType string, msg 
 	// Add updated message to stream (new ID)
 	_, err = c.redisClient.XAdd(ctx, &redis.XAddArgs{
 		Stream: streamKey,
-		MaxLen: 10000,
+		MaxLen: c.maxLen,
+		Approx: true,
 		ID:     "*",
 		Values: map[string]interface{}{
 			"message": string(messageJSON),
@@ -468,16 +489,16 @@ func isConsumerGroupExistsError(err error) bool {
 	if err == nil {
 		return false
 	}
-	return err.Error() == "BUSYGROUP Consumer Group name already exists"
+	return strings.Contains(err.Error(), "BUSYGROUP")
 }
 
-// isNoSuchKeyError checks if the error indicates the stream doesn't exist.
+// isNoSuchKeyError checks if the error indicates the stream or consumer group doesn't exist.
 func isNoSuchKeyError(err error) bool {
 	if err == nil {
 		return false
 	}
-	// Redis returns this error when XPending is called on a non-existent stream
-	return err.Error() == "NOGROUP No such key 'audit:dlq:events' or consumer group 'test-consumer-group' in XINFO GROUPS reply"
+	errStr := err.Error()
+	return strings.Contains(errStr, "NOGROUP") || strings.Contains(errStr, "no such key")
 }
 
 // isNoGroupError checks if the error indicates the stream or consumer group doesn't exist during XREADGROUP.
@@ -532,7 +553,7 @@ type DrainStats struct {
 // - error: Only returns error for critical failures (Redis unavailable, etc.)
 //
 // Business Requirement: BR-AUDIT-001 - Complete audit trail with no data loss
-func (c *Client) DrainWithTimeout(ctx context.Context, notificationRepo interface{}, eventsRepo interface{}) (*DrainStats, error) {
+func (c *Client) DrainWithTimeout(ctx context.Context, notificationRepo NotificationCreator, eventsRepo EventCreator) (*DrainStats, error) {
 	startTime := time.Now()
 	stats := &DrainStats{}
 
@@ -602,28 +623,61 @@ func (c *Client) DrainWithTimeout(ctx context.Context, notificationRepo interfac
 const drainBatchSize int64 = 100
 
 // drainStream processes all messages from a specific DLQ stream using
-// cursor-based iteration.
+// cursor-based iteration with a bounded retry pass.
 //
 // #1048 DF-3: Only XDel after confirmed DB write success. Failed messages
 // remain in the stream for the next startup's retry worker to pick up.
+//
+// #1048 ARCH-F1: Two-pass drain ensures that messages skipped by the forward
+// cursor after a write failure get a second chance within the same shutdown
+// window. Pass 1 sweeps forward; if any writes fail, pass 2 restarts from "-"
+// to retry the survivors (XDel'd messages are gone, so only failures remain).
+// Bounded at 2 passes to prevent infinite loops on permanent failures.
 //
 // #1048 PERF-3: Uses XRangeN with cursor to avoid loading the entire stream
 // into memory at once.
 func (c *Client) drainStream(ctx context.Context, auditType string, repo interface{}) (int, error) {
 	streamKey := c.getStreamKey(auditType)
+	total := 0
+
+	n, hadFailures, err := c.drainStreamPass(ctx, streamKey, auditType, repo)
+	total += n
+	if err != nil {
+		return total, err
+	}
+
+	// Retry pass: if any writes failed, sweep from "-" once more.
+	// Successfully XDel'd messages won't reappear. Messages that fail
+	// a second time remain in Redis for the next startup's retry worker.
+	if hadFailures {
+		n, _, err = c.drainStreamPass(ctx, streamKey, auditType, repo)
+		total += n
+		if err != nil {
+			return total, err
+		}
+	}
+
+	return total, nil
+}
+
+// drainStreamPass performs a single forward sweep of the stream.
+// Returns the number of messages successfully written+deleted, whether any
+// write failures occurred, and any stream-level read error.
+func (c *Client) drainStreamPass(ctx context.Context, streamKey, auditType string, repo interface{}) (int, bool, error) {
 	processed := 0
+	hadFailures := false
 	cursor := "-"
 
 	for {
 		select {
 		case <-ctx.Done():
-			return processed, nil
+			return processed, hadFailures, nil
 		default:
 		}
 
 		messages, err := c.redisClient.XRangeN(ctx, streamKey, cursor, "+", drainBatchSize).Result()
 		if err != nil {
-			return processed, fmt.Errorf("failed to read stream: %w", err)
+			return processed, hadFailures, fmt.Errorf("failed to read stream: %w", err)
 		}
 
 		if len(messages) == 0 {
@@ -633,12 +687,12 @@ func (c *Client) drainStream(ctx context.Context, auditType string, repo interfa
 		for _, msg := range messages {
 			select {
 			case <-ctx.Done():
-				return processed, nil
+				return processed, hadFailures, nil
 			default:
 			}
 
-			// Advance cursor past this message regardless of outcome to
-			// prevent re-reading on the next outer-loop iteration.
+			// Advance cursor past this message to prevent re-reading on the
+			// next outer-loop iteration. Failed messages are retried in pass 2.
 			cursor = "(" + msg.ID
 
 			dlqMsg, err := c.parseStreamMessage(msg)
@@ -646,6 +700,7 @@ func (c *Client) drainStream(ctx context.Context, auditType string, repo interfa
 				c.logger.Error(err, "Failed to parse DLQ message during drain",
 					"message_id", msg.ID,
 					"audit_type", auditType)
+				hadFailures = true
 				continue
 			}
 
@@ -654,6 +709,7 @@ func (c *Client) drainStream(ctx context.Context, auditType string, repo interfa
 					"message_id", msg.ID,
 					"audit_type", auditType,
 					"correlation_id", dlqMsg.AuditMessage.CorrelationID())
+				hadFailures = true
 				continue
 			}
 
@@ -667,63 +723,52 @@ func (c *Client) drainStream(ctx context.Context, auditType string, repo interfa
 		}
 	}
 
-	return processed, nil
+	return processed, hadFailures, nil
 }
 
-// writeMessageToDB writes a DLQ message to the database
-// This is a helper for drainStream that handles the repository interface
+// writeMessageToDB writes a DLQ message to the database.
+// Uses the package-level EventCreator/NotificationCreator interfaces (ARCH-M2).
+// SI-10: Rejects payloads exceeding maxPayloadSize before unmarshalling.
 func (c *Client) writeMessageToDB(ctx context.Context, auditType string, msg *DLQMessage, repo interface{}) error {
-	// Skip write if repository is nil
 	if repo == nil {
 		return fmt.Errorf("repository is nil for audit type: %s", auditType)
 	}
 
+	if len(msg.AuditMessage.Payload) > maxPayloadSize {
+		return fmt.Errorf("payload exceeds maximum size (%d > %d bytes)", len(msg.AuditMessage.Payload), maxPayloadSize)
+	}
+
 	switch auditType {
 	case "notifications":
-		// Try type assertion with method check
-		type NotificationCreator interface {
-			Create(context.Context, *models.NotificationAudit) (*models.NotificationAudit, error)
+		notifRepo, ok := repo.(NotificationCreator)
+		if !ok {
+			return fmt.Errorf("repository does not implement NotificationCreator interface (type: %T)", repo)
 		}
-
-		if notifRepo, ok := repo.(NotificationCreator); ok {
-			var audit models.NotificationAudit
-			if err := json.Unmarshal(msg.AuditMessage.Payload, &audit); err != nil {
-				return fmt.Errorf("failed to unmarshal notification audit: %w", err)
-			}
-			_, err := notifRepo.Create(ctx, &audit)
-			return err
+		var notifAudit models.NotificationAudit
+		if err := json.Unmarshal(msg.AuditMessage.Payload, &notifAudit); err != nil {
+			return fmt.Errorf("failed to unmarshal notification audit: %w", err)
 		}
-		return fmt.Errorf("repository does not implement NotificationCreator interface (type: %T)", repo)
+		_, err := notifRepo.Create(ctx, &notifAudit)
+		return err
 
 	case "events":
-		// Check for repository.AuditEventsRepository.Create method
-		type EventCreator interface {
-			Create(context.Context, *repository.AuditEvent) (*repository.AuditEvent, error)
+		eventsRepo, ok := repo.(EventCreator)
+		if !ok {
+			return fmt.Errorf("repository does not implement EventCreator interface (type: %T)", repo)
 		}
-
-		if eventsRepo, ok := repo.(EventCreator); ok {
-			// Step 1: Unmarshal into audit.AuditEvent (DLQ storage format)
-			var auditEvent audit.AuditEvent
-			if err := json.Unmarshal(msg.AuditMessage.Payload, &auditEvent); err != nil {
-				return fmt.Errorf("failed to unmarshal audit event: %w", err)
-			}
-
-			// Step 2: Handle missing EventData (provide default empty JSON object)
-			if len(auditEvent.EventData) == 0 {
-				auditEvent.EventData = []byte("{}")
-			}
-
-			// Step 3: Convert to repository.AuditEvent using existing helper
-			repoEvent, err := helpers.ConvertToRepositoryAuditEvent(&auditEvent)
-			if err != nil {
-				return fmt.Errorf("failed to convert audit event: %w", err)
-			}
-
-			// Step 4: Write to database
-			_, err = eventsRepo.Create(ctx, repoEvent)
-			return err
+		var auditEvent audit.AuditEvent
+		if err := json.Unmarshal(msg.AuditMessage.Payload, &auditEvent); err != nil {
+			return fmt.Errorf("failed to unmarshal audit event: %w", err)
 		}
-		return fmt.Errorf("repository does not implement EventCreator interface (type: %T)", repo)
+		if len(auditEvent.EventData) == 0 {
+			auditEvent.EventData = []byte("{}")
+		}
+		repoEvent, err := helpers.ConvertToRepositoryAuditEvent(&auditEvent)
+		if err != nil {
+			return fmt.Errorf("failed to convert audit event: %w", err)
+		}
+		_, err = eventsRepo.Create(ctx, repoEvent)
+		return err
 
 	default:
 		return fmt.Errorf("unknown audit type: %s", auditType)

--- a/pkg/datastorage/server/dlq_retry_worker.go
+++ b/pkg/datastorage/server/dlq_retry_worker.go
@@ -19,13 +19,17 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"time"
 
 	"github.com/go-logr/logr"
 
+	"github.com/jordigilh/kubernaut/pkg/audit"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/dlq"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/models"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/repository"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/server/helpers"
 )
 
 // ========================================
@@ -79,14 +83,25 @@ func DefaultDLQRetryWorkerConfig() DLQRetryWorkerConfig {
 	}
 }
 
+// EventCreator abstracts audit event persistence for dependency injection.
+type EventCreator interface {
+	Create(context.Context, *repository.AuditEvent) (*repository.AuditEvent, error)
+}
+
+// NotificationCreator abstracts notification persistence for dependency injection.
+type NotificationCreator interface {
+	Create(context.Context, *models.NotificationAudit) (*models.NotificationAudit, error)
+}
+
 // DLQRetryWorker processes DLQ messages and retries writes to PostgreSQL.
 // V1.0: Runs as goroutine inside Data Storage server (DD-007 lifecycle).
 type DLQRetryWorker struct {
-	dlqClient     *dlq.Client
-	auditRepo     *repository.AuditEventsRepository
-	logger        logr.Logger
-	consumerGroup string
-	consumerName  string
+	dlqClient        *dlq.Client
+	auditRepo        EventCreator
+	notificationRepo NotificationCreator
+	logger           logr.Logger
+	consumerGroup    string
+	consumerName     string
 
 	// Configuration
 	pollInterval     time.Duration
@@ -99,15 +114,19 @@ type DLQRetryWorker struct {
 }
 
 // NewDLQRetryWorker creates a new DLQ retry worker.
+// #1048 DF-1: Added notificationRepo parameter so notification DLQ messages
+// are persisted instead of silently dropped.
 func NewDLQRetryWorker(
 	dlqClient *dlq.Client,
-	auditRepo *repository.AuditEventsRepository,
+	auditRepo EventCreator,
+	notificationRepo NotificationCreator,
 	config DLQRetryWorkerConfig,
 	logger logr.Logger,
 ) *DLQRetryWorker {
 	return &DLQRetryWorker{
 		dlqClient:        dlqClient,
 		auditRepo:        auditRepo,
+		notificationRepo: notificationRepo,
 		logger:           logger.WithName("dlq-retry-worker"),
 		consumerGroup:    config.ConsumerGroup,
 		consumerName:     config.ConsumerName,
@@ -218,62 +237,41 @@ func (w *DLQRetryWorker) processMessage(ctx context.Context, auditType string, m
 	}
 }
 
+// writeToPostgres persists a DLQ message to PostgreSQL.
+// #1048 DF-1: Added "notifications" case (was silently returning nil).
+// #1048 DF-2: Replaced manual getString parsing with json.Unmarshal +
+// ConvertToRepositoryAuditEvent, aligning with the drain path in dlq/client.go.
 func (w *DLQRetryWorker) writeToPostgres(ctx context.Context, auditType string, msg *dlq.DLQMessage) error {
-	// Direct PostgreSQL write (bypass HTTP layer)
 	switch auditType {
 	case "events":
-		// Parse JSON payload and create audit event
-		event, err := w.parseAuditEventPayload(msg.AuditMessage.Payload)
+		var auditEvent audit.AuditEvent
+		if err := json.Unmarshal(msg.AuditMessage.Payload, &auditEvent); err != nil {
+			return fmt.Errorf("failed to unmarshal audit event payload: %w", err)
+		}
+		if len(auditEvent.EventData) == 0 {
+			auditEvent.EventData = []byte("{}")
+		}
+		repoEvent, err := helpers.ConvertToRepositoryAuditEvent(&auditEvent)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to convert audit event: %w", err)
 		}
-		_, err = w.auditRepo.Create(ctx, event)
+		_, err = w.auditRepo.Create(ctx, repoEvent)
 		return err
-	default:
-		// For other types, log and skip
-		w.logger.Info("Unsupported audit type for DLQ retry",
-			"audit_type", auditType,
-			"message_id", msg.ID,
-		)
-		return nil
-	}
-}
 
-// parseAuditEventPayload parses JSON payload into AuditEvent.
-func (w *DLQRetryWorker) parseAuditEventPayload(payload []byte) (*repository.AuditEvent, error) {
-	var data map[string]interface{}
-	if err := json.Unmarshal(payload, &data); err != nil {
-		return nil, err
-	}
-
-	// Extract required fields
-	event := &repository.AuditEvent{
-		EventType:    getString(data, "event_type"),
-		EventAction:  getString(data, "event_action"),
-		EventOutcome: getString(data, "event_outcome"),
-		ActorType:    getString(data, "actor_type"),
-		ActorID:      getString(data, "actor_id"),
-	}
-
-	// Set defaults for missing fields
-	if event.EventAction == "" {
-		event.EventAction = getString(data, "operation")
-	}
-	if event.EventOutcome == "" {
-		event.EventOutcome = getString(data, "outcome")
-	}
-
-	return event, nil
-}
-
-// getString safely extracts a string from map.
-func getString(data map[string]interface{}, key string) string {
-	if v, ok := data[key]; ok {
-		if s, ok := v.(string); ok {
-			return s
+	case "notifications":
+		if w.notificationRepo == nil {
+			return fmt.Errorf("notification repository not configured; cannot persist notification DLQ message")
 		}
+		var notifAudit models.NotificationAudit
+		if err := json.Unmarshal(msg.AuditMessage.Payload, &notifAudit); err != nil {
+			return fmt.Errorf("failed to unmarshal notification audit payload: %w", err)
+		}
+		_, err := w.notificationRepo.Create(ctx, &notifAudit)
+		return err
+
+	default:
+		return fmt.Errorf("unknown audit type for DLQ retry: %s", auditType)
 	}
-	return ""
 }
 
 func (w *DLQRetryWorker) handleRetryFailure(ctx context.Context, auditType string, msg *dlq.DLQMessage, writeErr error) {

--- a/pkg/datastorage/server/dlq_retry_worker.go
+++ b/pkg/datastorage/server/dlq_retry_worker.go
@@ -28,7 +28,6 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/audit"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/dlq"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/models"
-	"github.com/jordigilh/kubernaut/pkg/datastorage/repository"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/server/helpers"
 )
 
@@ -83,22 +82,12 @@ func DefaultDLQRetryWorkerConfig() DLQRetryWorkerConfig {
 	}
 }
 
-// EventCreator abstracts audit event persistence for dependency injection.
-type EventCreator interface {
-	Create(context.Context, *repository.AuditEvent) (*repository.AuditEvent, error)
-}
-
-// NotificationCreator abstracts notification persistence for dependency injection.
-type NotificationCreator interface {
-	Create(context.Context, *models.NotificationAudit) (*models.NotificationAudit, error)
-}
-
 // DLQRetryWorker processes DLQ messages and retries writes to PostgreSQL.
 // V1.0: Runs as goroutine inside Data Storage server (DD-007 lifecycle).
 type DLQRetryWorker struct {
 	dlqClient        *dlq.Client
-	auditRepo        EventCreator
-	notificationRepo NotificationCreator
+	auditRepo        dlq.EventCreator
+	notificationRepo dlq.NotificationCreator
 	logger           logr.Logger
 	consumerGroup    string
 	consumerName     string
@@ -118,8 +107,8 @@ type DLQRetryWorker struct {
 // are persisted instead of silently dropped.
 func NewDLQRetryWorker(
 	dlqClient *dlq.Client,
-	auditRepo EventCreator,
-	notificationRepo NotificationCreator,
+	auditRepo dlq.EventCreator,
+	notificationRepo dlq.NotificationCreator,
 	config DLQRetryWorkerConfig,
 	logger logr.Logger,
 ) *DLQRetryWorker {
@@ -185,7 +174,7 @@ func (w *DLQRetryWorker) processRetryBatch(ctx context.Context) {
 	auditTypes := []string{"events", "notifications"}
 
 	for _, auditType := range auditTypes {
-		messages, err := w.dlqClient.ReadMessages(ctx, auditType, w.consumerGroup, w.consumerName, -1)
+		messages, err := w.dlqClient.ReadMessages(ctx, auditType, w.consumerGroup, w.consumerName, w.maxBatchSize, -1)
 		if err != nil {
 			w.logger.Error(err, "Failed to read from DLQ", "audit_type", auditType)
 			continue
@@ -242,8 +231,15 @@ func (w *DLQRetryWorker) processMessage(ctx context.Context, auditType string, m
 // #1048 DF-2: Replaced manual getString parsing with json.Unmarshal +
 // ConvertToRepositoryAuditEvent, aligning with the drain path in dlq/client.go.
 func (w *DLQRetryWorker) writeToPostgres(ctx context.Context, auditType string, msg *dlq.DLQMessage) error {
+	if len(msg.AuditMessage.Payload) > dlq.MaxPayloadSize() {
+		return fmt.Errorf("payload exceeds maximum size (%d > %d bytes)", len(msg.AuditMessage.Payload), dlq.MaxPayloadSize())
+	}
+
 	switch auditType {
 	case "events":
+		if w.auditRepo == nil {
+			return fmt.Errorf("audit event repository not configured; cannot persist event DLQ message")
+		}
 		var auditEvent audit.AuditEvent
 		if err := json.Unmarshal(msg.AuditMessage.Payload, &auditEvent); err != nil {
 			return fmt.Errorf("failed to unmarshal audit event payload: %w", err)

--- a/pkg/datastorage/server/helpers/openapi_conversion.go
+++ b/pkg/datastorage/server/helpers/openapi_conversion.go
@@ -162,6 +162,23 @@ func ConvertToRepositoryAuditEvent(event *audit.AuditEvent) (*repository.AuditEv
 		durationMs = *event.DurationMs
 	}
 
+	// DF-H1: Preserve original RetentionDays and IsSensitive from the source event.
+	// Fall back to defaults only when the source value is unset (zero-value).
+	retentionDays := event.RetentionDays
+	if retentionDays <= 0 {
+		retentionDays = 2555 // Default: 7 years (SOC 2 / ISO 27001)
+	}
+
+	errorCode := ""
+	if event.ErrorCode != nil {
+		errorCode = *event.ErrorCode
+	}
+
+	errorMessage := ""
+	if event.ErrorMessage != nil {
+		errorMessage = *event.ErrorMessage
+	}
+
 	return &repository.AuditEvent{
 		EventID:           event.EventID,
 		Version:           event.EventVersion, // Map EventVersion to Version (DB column event_version)
@@ -179,11 +196,13 @@ func ConvertToRepositoryAuditEvent(event *audit.AuditEvent) (*repository.AuditEv
 		ClusterID:         clusterID,
 		Severity:          severity,
 		DurationMs:        durationMs,
+		ErrorCode:         errorCode,
+		ErrorMessage:      errorMessage,
 		ActorID:           event.ActorID,
 		ActorType:         event.ActorType,
 		EventData:         eventDataMap,
-		RetentionDays:     2555,  // Default: 7 years
-		IsSensitive:       false, // Default: not sensitive
+		RetentionDays:     retentionDays,
+		IsSensitive:       event.IsSensitive,
 	}, nil
 }
 

--- a/pkg/datastorage/server/server.go
+++ b/pkg/datastorage/server/server.go
@@ -357,9 +357,10 @@ func NewServer(deps ServerDeps) (*Server, error) {
 		"fingerprint", signer.GetCertificateFingerprint())
 
 	// DD-009 V1.0: Create DLQ retry worker (goroutine inside server)
+	// #1048 DF-1: Pass notification repo so notification DLQ messages are persisted
 	dlqWorkerConfig := DefaultDLQRetryWorkerConfig()
 	dlqWorkerConfig.ConsumerName = fmt.Sprintf("worker-%d", os.Getpid())
-	dlqRetryWorker := NewDLQRetryWorker(dlqClient, auditEventsRepo, dlqWorkerConfig, logger)
+	dlqRetryWorker := NewDLQRetryWorker(dlqClient, auditEventsRepo, repo, dlqWorkerConfig, logger)
 
 	// DS-FLAKY-003 FIX: Create server with handler assigned to httpServer
 	// This allows graceful shutdown to work in both Start() and httptest scenarios

--- a/test/integration/datastorage/dlq_test.go
+++ b/test/integration/datastorage/dlq_test.go
@@ -434,19 +434,19 @@ var _ = Describe("DLQ Client Integration", Serial, func() {
 				Expect(err).ToNot(HaveOccurred())
 
 				// ACT: Read messages
-				messages, err := dlqClient.ReadMessages(ctx, "events", consumerGroup, consumerName, 2*time.Second)
+				messages, err := dlqClient.ReadMessages(ctx, "events", consumerGroup, consumerName, 10, 2*time.Second)
 
 				// ASSERT
 				Expect(err).ToNot(HaveOccurred())
 				Expect(messages).To(HaveLen(1))
-				Expect(messages[0].ID).ToNot(BeEmpty())
+				Expect(messages[0].ID).To(MatchRegexp(`\d+-\d+`), "Redis stream ID format")
 				Expect(messages[0].AuditMessage.Type).To(Equal("audit_event"))
 				Expect(messages[0].AuditMessage.CorrelationID()).To(Equal("remediation-read-test"))
 			})
 
 			It("should return empty slice when DLQ is empty", func() {
 				// ACT: Read from empty DLQ
-				messages, err := dlqClient.ReadMessages(ctx, "events", consumerGroup, consumerName, 1*time.Second)
+				messages, err := dlqClient.ReadMessages(ctx, "events", consumerGroup, consumerName, 10, 1*time.Second)
 
 				// ASSERT
 				Expect(err).ToNot(HaveOccurred())
@@ -476,7 +476,7 @@ var _ = Describe("DLQ Client Integration", Serial, func() {
 				}
 
 				// ACT: Read all messages
-				messages, err := dlqClient.ReadMessages(ctx, "events", consumerGroup, consumerName, 2*time.Second)
+				messages, err := dlqClient.ReadMessages(ctx, "events", consumerGroup, consumerName, 10, 2*time.Second)
 
 				// ASSERT
 				Expect(err).ToNot(HaveOccurred())
@@ -506,7 +506,7 @@ var _ = Describe("DLQ Client Integration", Serial, func() {
 				err := dlqClient.EnqueueAuditEvent(ctx, auditEvent, fmt.Errorf("ack test error"))
 				Expect(err).ToNot(HaveOccurred())
 
-				messages, err := dlqClient.ReadMessages(ctx, "events", consumerGroup, consumerName, 2*time.Second)
+				messages, err := dlqClient.ReadMessages(ctx, "events", consumerGroup, consumerName, 10, 2*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(messages).To(HaveLen(1))
 
@@ -545,7 +545,7 @@ var _ = Describe("DLQ Client Integration", Serial, func() {
 				err := dlqClient.EnqueueAuditEvent(ctx, auditEvent, fmt.Errorf("permanent failure"))
 				Expect(err).ToNot(HaveOccurred())
 
-				messages, err := dlqClient.ReadMessages(ctx, "events", consumerGroup, consumerName, 2*time.Second)
+				messages, err := dlqClient.ReadMessages(ctx, "events", consumerGroup, consumerName, 10, 2*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(messages).To(HaveLen(1))
 
@@ -590,7 +590,7 @@ var _ = Describe("DLQ Client Integration", Serial, func() {
 				err := dlqClient.EnqueueAuditEvent(ctx, auditEvent, fmt.Errorf("retry error"))
 				Expect(err).ToNot(HaveOccurred())
 
-				messages, err := dlqClient.ReadMessages(ctx, "events", consumerGroup, consumerName, 2*time.Second)
+				messages, err := dlqClient.ReadMessages(ctx, "events", consumerGroup, consumerName, 10, 2*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(messages).To(HaveLen(1))
 				Expect(messages[0].AuditMessage.RetryCount).To(Equal(0))
@@ -607,7 +607,7 @@ var _ = Describe("DLQ Client Integration", Serial, func() {
 
 				// Read again with new consumer group
 				newConsumerGroup := fmt.Sprintf("test-consumer-group-verify-%d", time.Now().UnixNano())
-				updatedMessages, err := dlqClient.ReadMessages(ctx, "events", newConsumerGroup, consumerName, 2*time.Second)
+				updatedMessages, err := dlqClient.ReadMessages(ctx, "events", newConsumerGroup, consumerName, 10, 2*time.Second)
 				Expect(err).ToNot(HaveOccurred())
 				Expect(updatedMessages).To(HaveLen(1))
 				Expect(updatedMessages[0].AuditMessage.RetryCount).To(Equal(1))

--- a/test/unit/datastorage/dlq/dlq_data_loss_fixes_test.go
+++ b/test/unit/datastorage/dlq/dlq_data_loss_fixes_test.go
@@ -1,0 +1,609 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dlq
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/jordigilh/kubernaut/pkg/audit"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/dlq"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/models"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/repository"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/server"
+	kubelog "github.com/jordigilh/kubernaut/pkg/log"
+)
+
+// ========================================
+// PHASE 2 (P0): DLQ CRITICAL DATA-LOSS FIX TESTS
+// Issue #1048 | BR-AUDIT-001 | ADR-032
+// ========================================
+//
+// FINDING-DF-1: Notification retry ACK-without-write
+// FINDING-DF-2: Retry worker event payload parsing misalignment
+// FINDING-DF-3: Drain XDel-on-DB-failure
+//
+// TDD RED PHASE: These tests define the contract for the fixes.
+// ========================================
+
+var _ = Describe("DLQ Critical Data-Loss Fixes (#1048 Phase 2)", func() {
+
+	// ========================================
+	// DF-1: Notification retry must persist, not silently drop
+	// ========================================
+	Describe("DF-1: Notification retry worker must persist notifications (UT-DS-1048-DF1)", func() {
+		var (
+			miniRedis   *miniredis.Miniredis
+			redisClient *redis.Client
+			dlqClient   *dlq.Client
+			logger      logr.Logger
+		)
+
+		BeforeEach(func() {
+			var err error
+			miniRedis = miniredis.RunT(GinkgoT())
+			redisClient = redis.NewClient(&redis.Options{Addr: miniRedis.Addr()})
+			logger = logr.Discard()
+			dlqClient, err = dlq.NewClient(redisClient, logger, 1000)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			if redisClient != nil {
+				_ = redisClient.Close()
+			}
+			if miniRedis != nil {
+				miniRedis.Close()
+			}
+		})
+
+		It("should persist notification audit records via the retry worker (UT-DS-1048-DF1-001)", func() {
+			ctx := context.Background()
+
+			// ARRANGE: Insert a notification DLQ message with a timestamp far enough
+			// in the past that IsReadyForRetry returns true (backoff for retry 0 = 1m).
+			notif := &models.NotificationAudit{
+				RemediationID:   "remediation-df1-test",
+				NotificationID:  uuid.New().String(),
+				Recipient:       "oncall@example.com",
+				Channel:         "slack",
+				MessageSummary:  "DF-1 test notification",
+				Status:          "sent",
+				SentAt:          time.Now(),
+				EscalationLevel: 0,
+			}
+			err := addDLQMessageWithPastTimestamp(ctx, redisClient, "notifications", notif, 2*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+
+			// ARRANGE: Create mock notification repo that tracks Create calls
+			mockNotifRepo := &MockNotificationRepository{
+				createdAudits: []models.NotificationAudit{},
+			}
+
+			// ARRANGE: Create retry worker WITH notification repo
+			workerConfig := server.DLQRetryWorkerConfig{
+				PollInterval:  100 * time.Millisecond,
+				MaxBatchSize:  10,
+				MaxRetries:    6,
+				ConsumerGroup: "test-df1-workers",
+				ConsumerName:  "test-df1-worker-1",
+			}
+			worker := server.NewDLQRetryWorker(dlqClient, nil, mockNotifRepo, workerConfig, logger)
+
+			// ACT: Start and let the worker process one cycle
+			worker.Start(ctx)
+			// ✅ APPROVED EXCEPTION: Waiting for goroutine-based retry worker poll cycle
+			time.Sleep(300 * time.Millisecond)
+			worker.Stop()
+
+			// ASSERT: Notification was persisted (not silently dropped)
+			Expect(mockNotifRepo.createdAudits).To(HaveLen(1),
+				"DF-1: notification retry must persist via NotificationAuditRepository.Create, not silently drop")
+			Expect(mockNotifRepo.createdAudits[0].RemediationID).To(Equal("remediation-df1-test"))
+			Expect(mockNotifRepo.createdAudits[0].Channel).To(Equal("slack"))
+		})
+
+		It("should handle notification write failure with retry (UT-DS-1048-DF1-002)", func() {
+			ctx := context.Background()
+
+			// ARRANGE: Insert a notification DLQ message with past timestamp
+			notif := &models.NotificationAudit{
+				RemediationID:  "remediation-df1-fail",
+				NotificationID: uuid.New().String(),
+				Recipient:      "oncall@example.com",
+				Channel:        "slack",
+				MessageSummary: "DF-1 failure test",
+				Status:         "sent",
+				SentAt:         time.Now(),
+			}
+			err := addDLQMessageWithPastTimestamp(ctx, redisClient, "notifications", notif, 2*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+
+			// ARRANGE: Mock repo that fails on Create
+			failingNotifRepo := &MockNotificationRepository{
+				createError: fmt.Errorf("simulated persistent DB error"),
+			}
+
+			workerConfig := server.DLQRetryWorkerConfig{
+				PollInterval:  100 * time.Millisecond,
+				MaxBatchSize:  10,
+				MaxRetries:    6,
+				ConsumerGroup: "test-df1-fail-workers",
+				ConsumerName:  "test-df1-fail-1",
+			}
+			worker := server.NewDLQRetryWorker(dlqClient, nil, failingNotifRepo, workerConfig, logger)
+
+			// ACT: Let worker attempt processing
+			worker.Start(ctx)
+			// ✅ APPROVED EXCEPTION: Waiting for goroutine-based retry worker poll cycle
+			time.Sleep(300 * time.Millisecond)
+			worker.Stop()
+
+			// ASSERT: Message should NOT have been ACKed (it's still pending)
+			// The message remains in the DLQ for future retry
+			depth, err := dlqClient.GetDLQDepth(ctx, "notifications")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(depth).To(BeNumerically(">=", 1),
+				"DF-1: failed notification write must NOT ack the message")
+		})
+	})
+
+	// ========================================
+	// DF-2: Retry worker event parsing must align with drain path
+	// ========================================
+	Describe("DF-2: Retry worker event parsing must use proper unmarshal (UT-DS-1048-DF2)", func() {
+		var (
+			miniRedis   *miniredis.Miniredis
+			redisClient *redis.Client
+			dlqClient   *dlq.Client
+			logger      logr.Logger
+		)
+
+		BeforeEach(func() {
+			var err error
+			miniRedis = miniredis.RunT(GinkgoT())
+			redisClient = redis.NewClient(&redis.Options{Addr: miniRedis.Addr()})
+			logger = logr.Discard()
+			dlqClient, err = dlq.NewClient(redisClient, logger, 1000)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			if redisClient != nil {
+				_ = redisClient.Close()
+			}
+			if miniRedis != nil {
+				miniRedis.Close()
+			}
+		})
+
+		It("should preserve all audit event fields through retry (UT-DS-1048-DF2-001)", func() {
+			ctx := context.Background()
+
+			// ARRANGE: Create a rich audit event with all fields populated
+			eventID := uuid.New()
+			event := &audit.AuditEvent{
+				EventID:        eventID,
+				EventVersion:   "1.0",
+				EventType:      "workflow.execution.started",
+				EventCategory:  "workflow",
+				EventAction:    "started",
+				EventOutcome:   "success",
+				EventTimestamp: time.Now().UTC().Truncate(time.Millisecond),
+				CorrelationID:  "corr-df2-full-fidelity",
+				ActorType:      "service",
+				ActorID:        "workflow-service",
+				ResourceType:   "workflow",
+				ResourceID:     "wf-123",
+				EventData:      []byte(`{"workflow_id":"wf-123","step":"start","metadata":{"version":"2.1"}}`),
+				RetentionDays:  2555,
+			}
+			err := addDLQMessageWithPastTimestamp(ctx, redisClient, "events", event, 2*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+
+			// ARRANGE: Mock repo that captures the full repository.AuditEvent
+			mockEventsRepo := &MockRepositoryEventsRepository{
+				createdEvents: []*repository.AuditEvent{},
+			}
+
+			workerConfig := server.DLQRetryWorkerConfig{
+				PollInterval:  100 * time.Millisecond,
+				MaxBatchSize:  10,
+				MaxRetries:    6,
+				ConsumerGroup: "test-df2-workers",
+				ConsumerName:  "test-df2-worker-1",
+			}
+			worker := server.NewDLQRetryWorker(dlqClient, mockEventsRepo, nil, workerConfig, logger)
+
+			// ACT: Process one cycle
+			worker.Start(ctx)
+			// ✅ APPROVED EXCEPTION: Waiting for goroutine-based retry worker poll cycle
+			time.Sleep(300 * time.Millisecond)
+			worker.Stop()
+
+			// ASSERT: Event was persisted with ALL fields intact
+			Expect(mockEventsRepo.createdEvents).To(HaveLen(1),
+				"DF-2: retry worker must persist events using proper unmarshal")
+
+			persisted := mockEventsRepo.createdEvents[0]
+			Expect(persisted.EventID).To(Equal(eventID), "EventID must round-trip")
+			Expect(persisted.Version).To(Equal("1.0"), "EventVersion -> Version must round-trip")
+			Expect(persisted.EventType).To(Equal("workflow.execution.started"))
+			Expect(persisted.EventCategory).To(Equal("workflow"))
+			Expect(persisted.EventAction).To(Equal("started"))
+			Expect(persisted.EventOutcome).To(Equal("success"))
+			Expect(persisted.CorrelationID).To(Equal("corr-df2-full-fidelity"),
+				"DF-2: CorrelationID must be preserved (was lost by old getString parser)")
+			Expect(persisted.ActorType).To(Equal("service"))
+			Expect(persisted.ActorID).To(Equal("workflow-service"))
+			Expect(persisted.ResourceType).To(Equal("workflow"))
+			Expect(persisted.ResourceID).To(Equal("wf-123"))
+			Expect(persisted.EventData).To(HaveKey("workflow_id"),
+				"DF-2: EventData must be preserved as map (was lost by old getString parser)")
+			Expect(persisted.EventData["workflow_id"]).To(Equal("wf-123"))
+		})
+
+		It("should handle empty EventData gracefully (UT-DS-1048-DF2-002)", func() {
+			ctx := context.Background()
+
+			// ARRANGE: Event with no EventData, inserted with past timestamp
+			event := &audit.AuditEvent{
+				EventID:        uuid.New(),
+				EventVersion:   "1.0",
+				EventType:      "system.health.check",
+				EventCategory:  "system",
+				EventAction:    "checked",
+				EventOutcome:   "success",
+				EventTimestamp: time.Now().UTC(),
+				CorrelationID:  "corr-df2-empty-data",
+				ActorType:      "service",
+				ActorID:        "health-service",
+				ResourceType:   "system",
+				ResourceID:     "sys-1",
+				RetentionDays:  2555,
+			}
+			err := addDLQMessageWithPastTimestamp(ctx, redisClient, "events", event, 2*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+
+			mockEventsRepo := &MockRepositoryEventsRepository{
+				createdEvents: []*repository.AuditEvent{},
+			}
+
+			workerConfig := server.DLQRetryWorkerConfig{
+				PollInterval:  100 * time.Millisecond,
+				MaxBatchSize:  10,
+				MaxRetries:    6,
+				ConsumerGroup: "test-df2-empty-workers",
+				ConsumerName:  "test-df2-empty-1",
+			}
+			worker := server.NewDLQRetryWorker(dlqClient, mockEventsRepo, nil, workerConfig, logger)
+
+			worker.Start(ctx)
+			// ✅ APPROVED EXCEPTION: Waiting for goroutine-based retry worker poll cycle
+			time.Sleep(300 * time.Millisecond)
+			worker.Stop()
+
+			// ASSERT: Event persisted with default empty EventData
+			Expect(mockEventsRepo.createdEvents).To(HaveLen(1),
+				"DF-2: empty EventData must not cause parsing failure")
+		})
+	})
+
+	// ========================================
+	// DF-3: Drain must NOT delete messages on DB write failure
+	// ========================================
+	Describe("DF-3: Drain must preserve messages on DB write failure (UT-DS-1048-DF3)", func() {
+		var (
+			miniRedis   *miniredis.Miniredis
+			redisClient *redis.Client
+			dlqClient   *dlq.Client
+			logger      logr.Logger
+		)
+
+		BeforeEach(func() {
+			var err error
+			miniRedis = miniredis.RunT(GinkgoT())
+			redisClient = redis.NewClient(&redis.Options{Addr: miniRedis.Addr()})
+			logger = kubelog.NewLogger(kubelog.DefaultOptions())
+			dlqClient, err = dlq.NewClient(redisClient, logger, 1000)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			if redisClient != nil {
+				_ = redisClient.Close()
+			}
+			if miniRedis != nil {
+				miniRedis.Close()
+			}
+		})
+
+		It("should NOT delete messages from Redis when DB write fails (UT-DS-1048-DF3-001)", func() {
+			ctx := context.Background()
+
+			// ARRANGE: Enqueue 3 events to DLQ
+			for i := 0; i < 3; i++ {
+				event := &audit.AuditEvent{
+					EventID:        uuid.New(),
+					EventVersion:   "1.0",
+					EventType:      fmt.Sprintf("test.event.%d", i),
+					EventCategory:  "test",
+					EventAction:    "tested",
+					EventOutcome:   "success",
+					EventTimestamp: time.Now().UTC(),
+					CorrelationID:  fmt.Sprintf("corr-df3-%d", i),
+					ActorType:      "service",
+					ActorID:        "test-service",
+					ResourceType:   "test",
+					ResourceID:     fmt.Sprintf("test-%d", i),
+					EventData:      []byte(`{"key":"value"}`),
+					RetentionDays:  2555,
+				}
+				err := dlqClient.EnqueueAuditEvent(ctx, event, fmt.Errorf("DB error"))
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			// Verify 3 messages in DLQ
+			depth, err := dlqClient.GetDLQDepth(ctx, "events")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(depth).To(Equal(int64(3)))
+
+			// ARRANGE: Mock repo that ALWAYS fails
+			failingRepo := &MockRepositoryEventsRepository{
+				createError: fmt.Errorf("persistent database failure"),
+			}
+			mockNotifRepo := &MockNotificationRepository{}
+
+			// ACT: Drain with failing repo
+			drainCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+			stats, err := dlqClient.DrainWithTimeout(drainCtx, mockNotifRepo, failingRepo)
+
+			// ASSERT: Drain completes without panic
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stats.TotalProcessed).To(Equal(0),
+				"no messages should be marked as processed when all writes fail")
+
+			// ASSERT: Messages are STILL in Redis (not deleted)
+			finalDepth, err := dlqClient.GetDLQDepth(ctx, "events")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(finalDepth).To(Equal(int64(3)),
+				"DF-3: messages must NOT be deleted from Redis when DB write fails")
+		})
+
+		It("should delete messages only on successful DB write (UT-DS-1048-DF3-002)", func() {
+			ctx := context.Background()
+
+			// ARRANGE: Enqueue 2 events
+			for i := 0; i < 2; i++ {
+				event := &audit.AuditEvent{
+					EventID:        uuid.New(),
+					EventVersion:   "1.0",
+					EventType:      "test.event.success",
+					EventCategory:  "test",
+					EventAction:    "tested",
+					EventOutcome:   "success",
+					EventTimestamp: time.Now().UTC(),
+					CorrelationID:  fmt.Sprintf("corr-df3-success-%d", i),
+					ActorType:      "service",
+					ActorID:        "test-service",
+					ResourceType:   "test",
+					ResourceID:     fmt.Sprintf("test-%d", i),
+					EventData:      []byte(`{"ok":true}`),
+					RetentionDays:  2555,
+				}
+				err := dlqClient.EnqueueAuditEvent(ctx, event, fmt.Errorf("DB error"))
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			// ARRANGE: Mock repo that succeeds
+			successRepo := &MockRepositoryEventsRepository{
+				createdEvents: []*repository.AuditEvent{},
+			}
+			mockNotifRepo := &MockNotificationRepository{}
+
+			// ACT: Drain with successful repo
+			drainCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+			stats, err := dlqClient.DrainWithTimeout(drainCtx, mockNotifRepo, successRepo)
+
+			// ASSERT: All messages processed and removed
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stats.EventsProcessed).To(Equal(2))
+
+			finalDepth, err := dlqClient.GetDLQDepth(ctx, "events")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(finalDepth).To(Equal(int64(0)),
+				"DF-3: messages must be deleted after successful DB write")
+
+			// ASSERT: Events persisted
+			Expect(successRepo.createdEvents).To(HaveLen(2))
+		})
+
+		It("should not enter infinite loop when DB write fails (UT-DS-1048-DF3-003)", func() {
+			ctx := context.Background()
+
+			// ARRANGE: Single message that will fail
+			event := &audit.AuditEvent{
+				EventID:        uuid.New(),
+				EventVersion:   "1.0",
+				EventType:      "test.event.loop",
+				EventCategory:  "test",
+				EventAction:    "tested",
+				EventOutcome:   "failure",
+				EventTimestamp: time.Now().UTC(),
+				CorrelationID:  "corr-df3-loop",
+				ActorType:      "service",
+				ActorID:        "test-service",
+				ResourceType:   "test",
+				ResourceID:     "test-loop",
+				EventData:      []byte(`{"loop":"test"}`),
+				RetentionDays:  2555,
+			}
+			err := dlqClient.EnqueueAuditEvent(ctx, event, fmt.Errorf("DB error"))
+			Expect(err).ToNot(HaveOccurred())
+
+			failingRepo := &MockRepositoryEventsRepository{
+				createError: fmt.Errorf("permanent failure"),
+			}
+			mockNotifRepo := &MockNotificationRepository{}
+
+			// ACT: Drain must complete within 2 seconds (no infinite loop)
+			drainCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+			defer cancel()
+
+			start := time.Now()
+			stats, err := dlqClient.DrainWithTimeout(drainCtx, mockNotifRepo, failingRepo)
+			elapsed := time.Since(start)
+
+			// ASSERT: Completes quickly (cursor advances past failed message)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stats.TotalProcessed).To(Equal(0))
+			Expect(elapsed).To(BeNumerically("<", 1*time.Second),
+				"DF-3: drain must not spin in infinite loop on DB failure; cursor must advance")
+
+			// ASSERT: Message preserved in Redis
+			depth, err := dlqClient.GetDLQDepth(ctx, "events")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(depth).To(Equal(int64(1)), "failed message must remain in stream")
+		})
+
+		It("should process remaining messages after one fails (UT-DS-1048-DF3-004)", func() {
+			ctx := context.Background()
+
+			// ARRANGE: Enqueue 3 events
+			eventIDs := make([]uuid.UUID, 3)
+			for i := 0; i < 3; i++ {
+				eventIDs[i] = uuid.New()
+				event := &audit.AuditEvent{
+					EventID:        eventIDs[i],
+					EventVersion:   "1.0",
+					EventType:      fmt.Sprintf("test.event.mixed.%d", i),
+					EventCategory:  "test",
+					EventAction:    "tested",
+					EventOutcome:   "success",
+					EventTimestamp: time.Now().UTC(),
+					CorrelationID:  fmt.Sprintf("corr-df3-mixed-%d", i),
+					ActorType:      "service",
+					ActorID:        "test-service",
+					ResourceType:   "test",
+					ResourceID:     fmt.Sprintf("test-%d", i),
+					EventData:      []byte(fmt.Sprintf(`{"index":%d}`, i)),
+					RetentionDays:  2555,
+				}
+				err := dlqClient.EnqueueAuditEvent(ctx, event, fmt.Errorf("DB error"))
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			// ARRANGE: Mock repo that fails on the second event only
+			selectiveRepo := &SelectiveFailEventsRepository{
+				createdEvents: []*repository.AuditEvent{},
+				failOnIndex:   1,
+				callCount:     0,
+			}
+			mockNotifRepo := &MockNotificationRepository{}
+
+			// ACT: Drain
+			drainCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+			stats, err := dlqClient.DrainWithTimeout(drainCtx, mockNotifRepo, selectiveRepo)
+
+			// ASSERT: 2 of 3 succeeded (events 0 and 2 written)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stats.EventsProcessed).To(Equal(2))
+			Expect(selectiveRepo.createdEvents).To(HaveLen(2),
+				"DF-3: successful events must still be written even when one fails")
+
+			// ASSERT: Only the failed message remains in Redis
+			finalDepth, err := dlqClient.GetDLQDepth(ctx, "events")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(finalDepth).To(Equal(int64(1)),
+				"DF-3: only the failed message should remain in the stream")
+		})
+	})
+})
+
+// ========================================
+// MOCK: Selective failure repository
+// ========================================
+
+// SelectiveFailEventsRepository fails on a specific call index.
+type SelectiveFailEventsRepository struct {
+	createdEvents []*repository.AuditEvent
+	failOnIndex   int
+	callCount     int
+}
+
+func (m *SelectiveFailEventsRepository) Create(ctx context.Context, event *repository.AuditEvent) (*repository.AuditEvent, error) {
+	idx := m.callCount
+	m.callCount++
+	if idx == m.failOnIndex {
+		return nil, fmt.Errorf("selective failure on call %d", idx)
+	}
+	m.createdEvents = append(m.createdEvents, event)
+	return event, nil
+}
+
+// ========================================
+// Mock for notification repo (used by DF-1 tests)
+// The existing MockNotificationRepository from drain_test.go is in the same
+// package so we reuse it. If it weren't, we'd define it here.
+// getString and parseAuditEventPayload have been replaced, so no mocks needed.
+// ========================================
+
+// addDLQMessageWithPastTimestamp inserts a DLQ message directly into Redis
+// with a timestamp far enough in the past that IsReadyForRetry returns true.
+// This bypasses the Enqueue* methods which always set Timestamp to time.Now().
+func addDLQMessageWithPastTimestamp(ctx context.Context, redisClient *redis.Client, auditType string, payload interface{}, age time.Duration) error {
+	payloadJSON, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("failed to marshal payload: %w", err)
+	}
+
+	auditMsg := dlq.AuditMessage{
+		Type:       auditType,
+		Payload:    payloadJSON,
+		Timestamp:  time.Now().Add(-age),
+		RetryCount: 0,
+		LastError:  "simulated error",
+	}
+
+	messageJSON, err := json.Marshal(auditMsg)
+	if err != nil {
+		return fmt.Errorf("failed to marshal audit message: %w", err)
+	}
+
+	streamKey := fmt.Sprintf("audit:dlq:%s", auditType)
+	return redisClient.XAdd(ctx, &redis.XAddArgs{
+		Stream: streamKey,
+		MaxLen: 10000,
+		Approx: true,
+		ID:     "*",
+		Values: map[string]interface{}{
+			"message": string(messageJSON),
+		},
+	}).Err()
+}

--- a/test/unit/datastorage/dlq/dlq_data_loss_fixes_test.go
+++ b/test/unit/datastorage/dlq/dlq_data_loss_fixes_test.go
@@ -313,6 +313,211 @@ var _ = Describe("DLQ Critical Data-Loss Fixes (#1048 Phase 2)", func() {
 	})
 
 	// ========================================
+	// ARCH-F1: Cursor policy must not permanently skip failed messages
+	// ========================================
+	Describe("ARCH-F1: Drain retry pass must recover skipped messages (UT-DS-1048-ARCH-F1)", func() {
+		var (
+			miniRedis   *miniredis.Miniredis
+			redisClient *redis.Client
+			dlqClient   *dlq.Client
+			logger      logr.Logger
+		)
+
+		BeforeEach(func() {
+			var err error
+			miniRedis = miniredis.RunT(GinkgoT())
+			redisClient = redis.NewClient(&redis.Options{Addr: miniRedis.Addr()})
+			logger = logr.Discard()
+			dlqClient, err = dlq.NewClient(redisClient, logger, 1000)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			if redisClient != nil {
+				_ = redisClient.Close()
+			}
+			if miniRedis != nil {
+				miniRedis.Close()
+			}
+		})
+
+		It("should recover transiently-failed messages via retry pass (UT-DS-1048-ARCH-F1-001)", func() {
+			ctx := context.Background()
+
+			// ARRANGE: Enqueue 2 events
+			for i := 0; i < 2; i++ {
+				event := &audit.AuditEvent{
+					EventID:        uuid.New(),
+					EventVersion:   "1.0",
+					EventType:      fmt.Sprintf("test.event.transient.%d", i),
+					EventCategory:  "test",
+					EventAction:    "tested",
+					EventOutcome:   "success",
+					EventTimestamp: time.Now().UTC(),
+					CorrelationID:  fmt.Sprintf("corr-arch-f1-%d", i),
+					ActorType:      "service",
+					ActorID:        "test-service",
+					ResourceType:   "test",
+					ResourceID:     fmt.Sprintf("test-%d", i),
+					EventData:      []byte(fmt.Sprintf(`{"index":%d}`, i)),
+					RetentionDays:  2555,
+				}
+				err := dlqClient.EnqueueAuditEvent(ctx, event, fmt.Errorf("DB error"))
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			// ARRANGE: Repo that fails on the FIRST call only (transient error).
+			// Pass 1: event 0 fails (call 0), event 1 succeeds (call 1).
+			// Pass 2: event 0 retried (call 2) and succeeds.
+			transientRepo := &TransientFailEventsRepository{
+				createdEvents:   []*repository.AuditEvent{},
+				failFirstNCalls: 1,
+			}
+			mockNotifRepo := &MockNotificationRepository{}
+
+			// ACT: Drain
+			drainCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+			stats, err := dlqClient.DrainWithTimeout(drainCtx, mockNotifRepo, transientRepo)
+
+			// ASSERT: All 2 messages processed (1 in pass 1, 1 recovered in pass 2)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stats.EventsProcessed).To(Equal(2),
+				"ARCH-F1: both messages must be processed; retry pass recovers transient failures")
+			Expect(transientRepo.createdEvents).To(HaveLen(2))
+
+			// ASSERT: DLQ is empty
+			finalDepth, err := dlqClient.GetDLQDepth(ctx, "events")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(finalDepth).To(Equal(int64(0)),
+				"ARCH-F1: retry pass should have recovered the transiently-failed message")
+		})
+
+		It("should leave permanently-failing messages after retry pass (UT-DS-1048-ARCH-F1-002)", func() {
+			ctx := context.Background()
+
+			// ARRANGE: Enqueue 2 events
+			for i := 0; i < 2; i++ {
+				event := &audit.AuditEvent{
+					EventID:        uuid.New(),
+					EventVersion:   "1.0",
+					EventType:      fmt.Sprintf("test.event.perm.%d", i),
+					EventCategory:  "test",
+					EventAction:    "tested",
+					EventOutcome:   "success",
+					EventTimestamp: time.Now().UTC(),
+					CorrelationID:  fmt.Sprintf("corr-arch-f1-perm-%d", i),
+					ActorType:      "service",
+					ActorID:        "test-service",
+					ResourceType:   "test",
+					ResourceID:     fmt.Sprintf("test-%d", i),
+					EventData:      []byte(fmt.Sprintf(`{"index":%d}`, i)),
+					RetentionDays:  2555,
+				}
+				err := dlqClient.EnqueueAuditEvent(ctx, event, fmt.Errorf("DB error"))
+				Expect(err).ToNot(HaveOccurred())
+			}
+
+			// ARRANGE: Repo that ALWAYS fails
+			failingRepo := &MockRepositoryEventsRepository{
+				createError: fmt.Errorf("permanent failure"),
+			}
+			mockNotifRepo := &MockNotificationRepository{}
+
+			// ACT: Drain (two passes, both fail)
+			drainCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+			defer cancel()
+			stats, err := dlqClient.DrainWithTimeout(drainCtx, mockNotifRepo, failingRepo)
+
+			// ASSERT: No messages processed
+			Expect(err).ToNot(HaveOccurred())
+			Expect(stats.EventsProcessed).To(Equal(0))
+
+			// ASSERT: Both messages still in Redis for next startup
+			finalDepth, err := dlqClient.GetDLQDepth(ctx, "events")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(finalDepth).To(Equal(int64(2)),
+				"ARCH-F1: permanently failing messages must remain in Redis after both passes")
+		})
+	})
+
+	// ========================================
+	// SRE-M1: Nil auditRepo guard in retry worker
+	// ========================================
+	Describe("SRE-M1: Nil auditRepo guard in retry worker (UT-DS-1048-SRE-M1)", func() {
+		var (
+			miniRedis   *miniredis.Miniredis
+			redisClient *redis.Client
+			dlqClient   *dlq.Client
+			logger      logr.Logger
+		)
+
+		BeforeEach(func() {
+			var err error
+			miniRedis = miniredis.RunT(GinkgoT())
+			redisClient = redis.NewClient(&redis.Options{Addr: miniRedis.Addr()})
+			logger = logr.Discard()
+			dlqClient, err = dlq.NewClient(redisClient, logger, 1000)
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			if redisClient != nil {
+				_ = redisClient.Close()
+			}
+			if miniRedis != nil {
+				miniRedis.Close()
+			}
+		})
+
+		It("should not panic when auditRepo is nil (UT-DS-1048-SRE-M1-001)", func() {
+			ctx := context.Background()
+
+			// ARRANGE: Enqueue an event DLQ message with past timestamp
+			event := &audit.AuditEvent{
+				EventID:        uuid.New(),
+				EventVersion:   "1.0",
+				EventType:      "test.nil.guard",
+				EventCategory:  "test",
+				EventAction:    "tested",
+				EventOutcome:   "success",
+				EventTimestamp: time.Now().UTC(),
+				CorrelationID:  "corr-sre-m1-nil",
+				ActorType:      "service",
+				ActorID:        "test-service",
+				ResourceType:   "test",
+				ResourceID:     "test-nil",
+				EventData:      []byte(`{"guard":"nil"}`),
+				RetentionDays:  2555,
+			}
+			err := addDLQMessageWithPastTimestamp(ctx, redisClient, "events", event, 2*time.Minute)
+			Expect(err).ToNot(HaveOccurred())
+
+			// ARRANGE: Worker with nil auditRepo (and nil notificationRepo)
+			workerConfig := server.DLQRetryWorkerConfig{
+				PollInterval:  100 * time.Millisecond,
+				MaxBatchSize:  10,
+				MaxRetries:    6,
+				ConsumerGroup: "test-nil-guard",
+				ConsumerName:  "test-nil-1",
+			}
+			worker := server.NewDLQRetryWorker(dlqClient, nil, nil, workerConfig, logger)
+
+			// ACT: Start and let the worker attempt processing (must not panic)
+			worker.Start(ctx)
+			// ✅ APPROVED EXCEPTION: Waiting for goroutine-based retry worker poll cycle
+			time.Sleep(300 * time.Millisecond)
+			worker.Stop()
+
+			// ASSERT: Message is NOT ACK'd (still in DLQ for retry after repo is configured)
+			depth, err := dlqClient.GetDLQDepth(ctx, "events")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(depth).To(BeNumerically(">=", 1),
+				"SRE-M1: nil auditRepo must return error, message stays in DLQ for retry")
+		})
+	})
+
+	// ========================================
 	// DF-3: Drain must NOT delete messages on DB write failure
 	// ========================================
 	Describe("DF-3: Drain must preserve messages on DB write failure (UT-DS-1048-DF3)", func() {
@@ -491,7 +696,7 @@ var _ = Describe("DLQ Critical Data-Loss Fixes (#1048 Phase 2)", func() {
 			Expect(depth).To(Equal(int64(1)), "failed message must remain in stream")
 		})
 
-		It("should process remaining messages after one fails (UT-DS-1048-DF3-004)", func() {
+		It("should process remaining messages after one fails and recover via retry pass (UT-DS-1048-DF3-004)", func() {
 			ctx := context.Background()
 
 			// ARRANGE: Enqueue 3 events
@@ -518,7 +723,9 @@ var _ = Describe("DLQ Critical Data-Loss Fixes (#1048 Phase 2)", func() {
 				Expect(err).ToNot(HaveOccurred())
 			}
 
-			// ARRANGE: Mock repo that fails on the second event only
+			// ARRANGE: Mock repo that fails on the second event only (transient).
+			// Pass 1 writes events 0+2, skips event 1. Pass 2 retries event 1
+			// (call index 3 != failOnIndex 1) and succeeds.
 			selectiveRepo := &SelectiveFailEventsRepository{
 				createdEvents: []*repository.AuditEvent{},
 				failOnIndex:   1,
@@ -531,17 +738,18 @@ var _ = Describe("DLQ Critical Data-Loss Fixes (#1048 Phase 2)", func() {
 			defer cancel()
 			stats, err := dlqClient.DrainWithTimeout(drainCtx, mockNotifRepo, selectiveRepo)
 
-			// ASSERT: 2 of 3 succeeded (events 0 and 2 written)
+			// ASSERT: All 3 recovered (2 in pass 1, 1 in retry pass)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(stats.EventsProcessed).To(Equal(2))
-			Expect(selectiveRepo.createdEvents).To(HaveLen(2),
-				"DF-3: successful events must still be written even when one fails")
+			Expect(stats.EventsProcessed).To(Equal(3),
+				"ARCH-F1: retry pass must recover the transiently-failed message")
+			Expect(selectiveRepo.createdEvents).To(HaveLen(3),
+				"DF-3+ARCH-F1: all events must be written after two-pass drain")
 
-			// ASSERT: Only the failed message remains in Redis
+			// ASSERT: DLQ fully drained
 			finalDepth, err := dlqClient.GetDLQDepth(ctx, "events")
 			Expect(err).ToNot(HaveOccurred())
-			Expect(finalDepth).To(Equal(int64(1)),
-				"DF-3: only the failed message should remain in the stream")
+			Expect(finalDepth).To(Equal(int64(0)),
+				"ARCH-F1: retry pass should have recovered all messages")
 		})
 	})
 })
@@ -568,6 +776,298 @@ func (m *SelectiveFailEventsRepository) Create(ctx context.Context, event *repos
 }
 
 // ========================================
+// MOCK: Transient failure repository (ARCH-F1 tests)
+// ========================================
+
+// TransientFailEventsRepository fails for the first N calls, then succeeds.
+type TransientFailEventsRepository struct {
+	createdEvents   []*repository.AuditEvent
+	failFirstNCalls int
+	callCount       int
+}
+
+func (m *TransientFailEventsRepository) Create(_ context.Context, event *repository.AuditEvent) (*repository.AuditEvent, error) {
+	m.callCount++
+	if m.callCount <= m.failFirstNCalls {
+		return nil, fmt.Errorf("transient failure on call %d", m.callCount)
+	}
+	m.createdEvents = append(m.createdEvents, event)
+	return event, nil
+}
+
+// ========================================
+// QE-H1: Context cancellation branch tests
+// ========================================
+
+var _ = Describe("#1048 QE-H1: Drain context cancellation branches", func() {
+	var (
+		ctx         context.Context
+		miniRedis   *miniredis.Miniredis
+		redisClient *redis.Client
+		dlqClient   *dlq.Client
+		logger      logr.Logger
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		miniRedis = miniredis.RunT(GinkgoT())
+		redisClient = redis.NewClient(&redis.Options{Addr: miniRedis.Addr()})
+		logger = kubelog.NewLogger(kubelog.DefaultOptions())
+		var err error
+		dlqClient, err = dlq.NewClient(redisClient, logger, 1000)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		_ = redisClient.Close()
+		miniRedis.Close()
+	})
+
+	It("UT-DS-1048-QEH1-001: should stop draining when context is cancelled mid-batch", func() {
+		// ARRANGE: Add enough messages to span multiple iterations
+		successRepo := &MockRepositoryEventsRepository{createdEvents: []*repository.AuditEvent{}}
+		mockNotifRepo := &MockNotificationRepository{}
+		for i := 0; i < 5; i++ {
+			event := &audit.AuditEvent{
+				EventID:       uuid.New(),
+				EventVersion:  "1.0",
+				EventType:     "test.cancel.event",
+				EventCategory: "test",
+				EventAction:   "processed",
+				EventOutcome:  "success",
+				EventTimestamp: time.Now(),
+				CorrelationID: fmt.Sprintf("corr-cancel-%d", i),
+				ActorType:     "service",
+				ActorID:       "test-service",
+				ResourceType:  "test",
+				ResourceID:    fmt.Sprintf("res-%d", i),
+				EventData:     []byte(`{"k":"v"}`),
+			}
+			err := dlqClient.EnqueueAuditEvent(ctx, event, fmt.Errorf("test"))
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		// ACT: Create a context that is already cancelled
+		cancelCtx, cancelFn := context.WithCancel(ctx)
+		cancelFn()
+
+		stats, err := dlqClient.DrainWithTimeout(cancelCtx, mockNotifRepo, successRepo)
+
+		// ASSERT: Drain returns without error but processes zero messages
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stats.TotalProcessed).To(Equal(0))
+		Expect(stats.TimedOut).To(BeTrue())
+
+		// Messages remain in DLQ
+		depth, err := dlqClient.GetDLQDepth(ctx, "events")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(depth).To(Equal(int64(5)))
+	})
+
+	It("UT-DS-1048-QEH1-002: should handle context deadline mid-processing", func() {
+		// ARRANGE: A repo that cancels context after first write
+		mockNotifRepo := &MockNotificationRepository{}
+		cancelCtx, cancelFn := context.WithCancel(ctx)
+		wrappedRepo := &CancellingEventsRepository{
+			cancelAfterN: 1,
+			cancelFn:     cancelFn,
+		}
+		for i := 0; i < 3; i++ {
+			event := &audit.AuditEvent{
+				EventID:       uuid.New(),
+				EventVersion:  "1.0",
+				EventType:     "test.cancel.mid",
+				EventCategory: "test",
+				EventAction:   "processed",
+				EventOutcome:  "success",
+				EventTimestamp: time.Now(),
+				CorrelationID: fmt.Sprintf("corr-mid-%d", i),
+				ActorType:     "service",
+				ActorID:       "test-service",
+				ResourceType:  "test",
+				ResourceID:    fmt.Sprintf("res-%d", i),
+				EventData:     []byte(`{"k":"v"}`),
+			}
+			err := dlqClient.EnqueueAuditEvent(ctx, event, fmt.Errorf("test"))
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		// ACT
+		stats, err := dlqClient.DrainWithTimeout(cancelCtx, mockNotifRepo, wrappedRepo)
+
+		// ASSERT: Partial drain — at most 1 message processed before cancel
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stats.EventsProcessed).To(BeNumerically("<=", 1))
+
+		// Remaining messages still in DLQ
+		depth, err := dlqClient.GetDLQDepth(context.Background(), "events")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(depth).To(BeNumerically(">=", 2))
+	})
+})
+
+// ========================================
+// QE-M2: Missing branch coverage tests
+// ========================================
+
+var _ = Describe("#1048 QE-M2: DLQ branch coverage", func() {
+	var (
+		ctx         context.Context
+		miniRedis   *miniredis.Miniredis
+		redisClient *redis.Client
+		dlqClient   *dlq.Client
+		logger      logr.Logger
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		miniRedis = miniredis.RunT(GinkgoT())
+		redisClient = redis.NewClient(&redis.Options{Addr: miniRedis.Addr()})
+		logger = kubelog.NewLogger(kubelog.DefaultOptions())
+		var err error
+		dlqClient, err = dlq.NewClient(redisClient, logger, 1000)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	AfterEach(func() {
+		_ = redisClient.Close()
+		miniRedis.Close()
+	})
+
+	It("UT-DS-1048-QEM2-001: should handle unmarshal failure in drain (malformed payload)", func() {
+		mockNotifRepo := &MockNotificationRepository{}
+		successRepo := &MockRepositoryEventsRepository{createdEvents: []*repository.AuditEvent{}}
+
+		// ARRANGE: Insert a stream entry where the "message" value is not valid
+		// AuditMessage JSON. This simulates a corrupt entry in the Redis stream.
+		streamKey := "audit:dlq:events"
+		err := redisClient.XAdd(ctx, &redis.XAddArgs{
+			Stream: streamKey,
+			ID:     "*",
+			Values: map[string]interface{}{"message": `{not valid json at all`},
+		}).Err()
+		Expect(err).ToNot(HaveOccurred())
+
+		// ACT
+		drainCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		stats, err := dlqClient.DrainWithTimeout(drainCtx, mockNotifRepo, successRepo)
+
+		// ASSERT: No error returned, but message stays in DLQ (parse failed)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stats.EventsProcessed).To(Equal(0))
+
+		depth, err := dlqClient.GetDLQDepth(ctx, "events")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(depth).To(Equal(int64(1)), "malformed message remains in stream")
+	})
+
+	It("UT-DS-1048-QEM2-002: should reject oversized payload (FEDRAMP SI-10)", func() {
+		mockNotifRepo := &MockNotificationRepository{}
+		successRepo := &MockRepositoryEventsRepository{createdEvents: []*repository.AuditEvent{}}
+
+		// ARRANGE: Build an AuditMessage whose Payload exceeds maxPayloadSize.
+		// We create a valid JSON object with a large string field.
+		largeValue := make([]byte, dlq.MaxPayloadSize()+100)
+		for i := range largeValue {
+			largeValue[i] = 'x'
+		}
+		bigPayload := []byte(fmt.Sprintf(`{"big":"%s"}`, string(largeValue)))
+
+		bigMsg := dlq.AuditMessage{
+			Type:      "audit_event",
+			Payload:   bigPayload,
+			Timestamp: time.Now(),
+		}
+		msgJSON, err := json.Marshal(bigMsg)
+		Expect(err).ToNot(HaveOccurred())
+
+		streamKey := "audit:dlq:events"
+		err = redisClient.XAdd(ctx, &redis.XAddArgs{
+			Stream: streamKey,
+			ID:     "*",
+			Values: map[string]interface{}{"message": string(msgJSON)},
+		}).Err()
+		Expect(err).ToNot(HaveOccurred())
+
+		// ACT
+		drainCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+		stats, err := dlqClient.DrainWithTimeout(drainCtx, mockNotifRepo, successRepo)
+
+		// ASSERT: Oversized payload rejected, message stays
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stats.EventsProcessed).To(Equal(0))
+
+		depth, err := dlqClient.GetDLQDepth(ctx, "events")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(depth).To(Equal(int64(1)), "oversized message remains in stream")
+	})
+
+	It("UT-DS-1048-QEM2-003: should handle drain pagination (>100 messages)", func() {
+		mockNotifRepo := &MockNotificationRepository{}
+		successRepo := &MockRepositoryEventsRepository{createdEvents: []*repository.AuditEvent{}}
+
+		// ARRANGE: Enqueue 150 event messages (drainBatchSize is 100)
+		for i := 0; i < 150; i++ {
+			event := &audit.AuditEvent{
+				EventID:       uuid.New(),
+				EventVersion:  "1.0",
+				EventType:     "test.pagination",
+				EventCategory: "test",
+				EventAction:   "processed",
+				EventOutcome:  "success",
+				EventTimestamp: time.Now(),
+				CorrelationID: fmt.Sprintf("corr-page-%d", i),
+				ActorType:     "service",
+				ActorID:       "test-service",
+				ResourceType:  "test",
+				ResourceID:    fmt.Sprintf("res-%d", i),
+				EventData:     []byte(`{"k":"v"}`),
+			}
+			err := dlqClient.EnqueueAuditEvent(ctx, event, fmt.Errorf("test"))
+			Expect(err).ToNot(HaveOccurred())
+		}
+
+		depth, err := dlqClient.GetDLQDepth(ctx, "events")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(depth).To(Equal(int64(150)))
+
+		// ACT
+		drainCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+		stats, err := dlqClient.DrainWithTimeout(drainCtx, mockNotifRepo, successRepo)
+
+		// ASSERT: All 150 messages processed across multiple batches
+		Expect(err).ToNot(HaveOccurred())
+		Expect(stats.EventsProcessed).To(Equal(150))
+		Expect(successRepo.createdEvents).To(HaveLen(150))
+
+		finalDepth, err := dlqClient.GetDLQDepth(ctx, "events")
+		Expect(err).ToNot(HaveOccurred())
+		Expect(finalDepth).To(Equal(int64(0)))
+	})
+})
+
+// ========================================
+// CancellingEventsRepository: cancels context after N successful writes (for QE-H1)
+// ========================================
+
+type CancellingEventsRepository struct {
+	cancelAfterN int
+	cancelFn     context.CancelFunc
+	callCount    int
+}
+
+func (m *CancellingEventsRepository) Create(_ context.Context, event *repository.AuditEvent) (*repository.AuditEvent, error) {
+	m.callCount++
+	if m.callCount >= m.cancelAfterN {
+		m.cancelFn()
+	}
+	return event, nil
+}
+
+// ========================================
 // Mock for notification repo (used by DF-1 tests)
 // The existing MockNotificationRepository from drain_test.go is in the same
 // package so we reuse it. If it weren't, we'd define it here.
@@ -583,8 +1083,18 @@ func addDLQMessageWithPastTimestamp(ctx context.Context, redisClient *redis.Clie
 		return fmt.Errorf("failed to marshal payload: %w", err)
 	}
 
+	// QE-M3: Use production-consistent Type values.
+	// Production enqueues "notification_audit" / "audit_event"; match those here.
+	msgType := auditType
+	switch auditType {
+	case "notifications":
+		msgType = "notification_audit"
+	case "events":
+		msgType = "audit_event"
+	}
+
 	auditMsg := dlq.AuditMessage{
-		Type:       auditType,
+		Type:       msgType,
 		Payload:    payloadJSON,
 		Timestamp:  time.Now().Add(-age),
 		RetryCount: 0,

--- a/test/unit/datastorage/dlq/retry_worker_test.go
+++ b/test/unit/datastorage/dlq/retry_worker_test.go
@@ -248,7 +248,7 @@ var _ = Describe("DLQ Retry Worker (DD-009 V1.0)", func() {
 				ConsumerName:  "test-worker-1",
 			}
 
-			worker := server.NewDLQRetryWorker(dlqClient, nil, workerConfig, logger)
+			worker := server.NewDLQRetryWorker(dlqClient, nil, nil, workerConfig, logger)
 
 			// ACT: Start the worker (launches goroutine)
 			worker.Start(context.Background())


### PR DESCRIPTION
## Summary

Fixes three critical data-loss bugs in the DLQ (Dead Letter Queue) subsystem discovered during the #1048 Data Storage Readiness Audit.

- **DF-1 (Notification ACK-without-write)**: The retry worker silently dropped notification DLQ messages by returning nil from `writeToPostgres` without persisting. Added `NotificationCreator` interface and `notificationRepo` field so notifications are properly unmarshaled and written via `Create()`.
- **DF-2 (Retry payload parsing misalignment)**: The retry worker used a manual `getString` map parser that only extracted 5 of 20+ fields, losing `correlation_id`, `event_data`, timestamps, resource fields, and more. Replaced with `json.Unmarshal` into `audit.AuditEvent` + `ConvertToRepositoryAuditEvent`, aligning with the drain path.
- **DF-3 (Drain XDel-on-failure)**: `drainStream` deleted Redis messages via `XDel` even when `writeMessageToDB` failed, causing permanent audit data loss during shutdown. Refactored to cursor-based `XRangeN` iteration: only `XDel` after confirmed DB write success, and advance cursor past all seen messages to prevent infinite loops. Also addresses PERF-3 by bounding memory per iteration.

Additionally introduced `EventCreator` interface for `auditRepo` to enable proper dependency injection and testability.

## Business Requirements

- BR-AUDIT-001: Complete audit trail with no data loss
- ADR-032: "No Audit Loss" mandate
- DD-009: Audit Write Error Recovery

## Test plan

- [x] 8 new unit tests (2 for DF-1, 2 for DF-2, 4 for DF-3)
- [x] All 30 DLQ unit tests pass
- [x] All DS unit tests pass (10 packages)
- [x] Full codebase builds cleanly (`go build ./...`)
- [x] `go vet ./...` passes
- [x] Pre-commit anti-pattern hooks pass


Made with [Cursor](https://cursor.com)