### PR TITLE
chore(deps): migrate gobreaker from v1.0.0 to v2.4.0

### DIFF
--- a/cmd/notification/main.go
+++ b/cmd/notification/main.go
@@ -56,7 +56,6 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/shared/hotreload"
 	"github.com/jordigilh/kubernaut/pkg/shared/sanitization"
 	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls" // Issue #678: Inter-service TLS
-	"github.com/sony/gobreaker/v2"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -109,15 +108,14 @@ func validateFileOutputDirectory(dir string) error {
 	return nil
 }
 
-// stateToString converts gobreaker.State to human-readable string
-// Used for logging circuit breaker state transitions
-func stateToString(state gobreaker.State) string {
+// stateToString converts a circuit breaker State to a human-readable string.
+func stateToString(state circuitbreaker.State) string {
 	switch state {
-	case gobreaker.StateClosed:
+	case circuitbreaker.StateClosed:
 		return "closed"
-	case gobreaker.StateOpen:
+	case circuitbreaker.StateOpen:
 		return "open"
-	case gobreaker.StateHalfOpen:
+	case circuitbreaker.StateHalfOpen:
 		return "half-open"
 	default:
 		return "unknown"
@@ -355,22 +353,17 @@ func main() {
 	//
 	// See: docs/services/crd-controllers/06-notification/README.md#circuit-breaker
 	// ========================================
-	circuitBreakerManager := circuitbreaker.NewManager(gobreaker.Settings{
-		MaxRequests: 2, // Allow 2 test requests in half-open state
-		Interval:    10 * time.Second,
-		Timeout:     30 * time.Second, // Stay open for 30s before recovery attempt
-		ReadyToTrip: func(counts gobreaker.Counts) bool {
-			// Trip circuit after 3 consecutive failures
-			return counts.ConsecutiveFailures >= 3
-		},
-		OnStateChange: func(name string, from gobreaker.State, to gobreaker.State) {
-			// Log circuit breaker state transitions
+	circuitBreakerManager := circuitbreaker.NewManager(circuitbreaker.ManagerConfig{
+		MaxRequests:                 2,
+		Interval:                   10 * time.Second,
+		Timeout:                    30 * time.Second,
+		ConsecutiveFailureThreshold: 3,
+		OnStateChange: func(name string, from, to circuitbreaker.State) {
 			logger.Info("Circuit breaker state changed",
 				"channel", name,
 				"from", stateToString(from),
 				"to", stateToString(to))
 
-			// Update Prometheus metric
 			if metricsRecorder != nil {
 				metricsRecorder.UpdateCircuitBreakerState(name, int(to))
 			}

--- a/cmd/notification/main.go
+++ b/cmd/notification/main.go
@@ -56,7 +56,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/shared/hotreload"
 	"github.com/jordigilh/kubernaut/pkg/shared/sanitization"
 	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls" // Issue #678: Inter-service TLS
-	"github.com/sony/gobreaker"
+	"github.com/sony/gobreaker/v2"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/prometheus/client_model v0.6.2
 	github.com/redis/go-redis/v9 v9.18.0
 	github.com/slack-go/slack v0.19.0
-	github.com/sony/gobreaker v1.0.0
+	github.com/sony/gobreaker/v2 v2.4.0
 	github.com/tektoncd/pipeline v1.10.1
 	github.com/tmc/langchaingo v0.1.14
 	go.opentelemetry.io/otel v1.42.0

--- a/go.sum
+++ b/go.sum
@@ -403,8 +403,8 @@ github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w
 github.com/sirupsen/logrus v1.9.4/go.mod h1:ftWc9WdOfJ0a92nsE2jF5u5ZwH8Bv2zdeOC42RjbV2g=
 github.com/slack-go/slack v0.19.0 h1:J8lL/nGTsIUX53HU8YxZeI3PDkA+sxZsFrI2Dew7h44=
 github.com/slack-go/slack v0.19.0/go.mod h1:K81UmCivcYd/5Jmz8vLBfuyoZ3B4rQC2GHVXHteXiAE=
-github.com/sony/gobreaker v1.0.0 h1:feX5fGGXSl3dYd4aHZItw+FpHLvvoaqkawKjVNiFMNQ=
-github.com/sony/gobreaker v1.0.0/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
+github.com/sony/gobreaker/v2 v2.4.0 h1:g2KJRW1Ubty3+ZOcSEUN7K+REQJdN6yo6XvaML+jptg=
+github.com/sony/gobreaker/v2 v2.4.0/go.mod h1:pTyFJgcZ3h2tdQVLZZruK2C0eoFL1fb/G83wK1ZQl+s=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/pkg/gateway/k8s/client_with_circuit_breaker.go
+++ b/pkg/gateway/k8s/client_with_circuit_breaker.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"time"
 
-	"github.com/sony/gobreaker"
+	"github.com/sony/gobreaker/v2"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 
 	remediationv1alpha1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
@@ -52,7 +52,7 @@ import (
 // - OnStateChange callback updates gateway_circuit_breaker_state metric
 type ClientWithCircuitBreaker struct {
 	*Client                        // Embed base client for non-circuit-breaker methods
-	cb      *gobreaker.CircuitBreaker
+	cb      *gobreaker.CircuitBreaker[any]
 	metrics *metrics.Metrics
 }
 
@@ -67,7 +67,7 @@ type ClientWithCircuitBreaker struct {
 // - Recovery: 30s timeout before testing recovery
 // - Half-Open: Allow 3 test requests during recovery
 func NewClientWithCircuitBreaker(client *Client, metricsInstance *metrics.Metrics) *ClientWithCircuitBreaker {
-	cb := gobreaker.NewCircuitBreaker(gobreaker.Settings{
+	cb := gobreaker.NewCircuitBreaker[any](gobreaker.Settings{
 		Name:        "k8s-api",
 		MaxRequests: 3, // Allow 3 test requests in half-open state
 		Interval:    10 * time.Second,

--- a/pkg/gateway/server.go
+++ b/pkg/gateway/server.go
@@ -32,7 +32,7 @@ import (
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/sony/gobreaker" // BR-GATEWAY-093: Circuit breaker detection
+	"github.com/sony/gobreaker/v2" // BR-GATEWAY-093: Circuit breaker detection
 
 	gwerrors "github.com/jordigilh/kubernaut/pkg/gateway/errors"
 

--- a/pkg/gateway/server.go
+++ b/pkg/gateway/server.go
@@ -32,7 +32,7 @@ import (
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/sony/gobreaker/v2" // BR-GATEWAY-093: Circuit breaker detection
+	"github.com/jordigilh/kubernaut/pkg/shared/circuitbreaker" // BR-GATEWAY-093: Circuit breaker detection
 
 	gwerrors "github.com/jordigilh/kubernaut/pkg/gateway/errors"
 
@@ -2161,7 +2161,7 @@ func (s *Server) emitCRDCreationFailedAudit(ctx context.Context, signal *types.N
 	// BR-AUDIT-005 Gap #7: Standardized error_details
 	// GW-INT-AUD-019 (BR-GATEWAY-093): Detect circuit breaker errors for audit compliance
 	var errorDetails *sharedaudit.ErrorDetails
-	if errors.Is(err, gobreaker.ErrOpenState) {
+	if errors.Is(err, circuitbreaker.ErrOpenState) {
 		// Circuit breaker is open - create specialized error details
 		// BR-GATEWAY-093: Circuit breaker for K8s API
 		errorDetails = sharedaudit.NewErrorDetails(

--- a/pkg/notification/delivery/circuit_breaker.go
+++ b/pkg/notification/delivery/circuit_breaker.go
@@ -19,7 +19,7 @@ package delivery
 import (
 	"context"
 
-	"github.com/sony/gobreaker"
+	"github.com/sony/gobreaker/v2"
 
 	notificationv1alpha1 "github.com/jordigilh/kubernaut/api/notification/v1alpha1"
 	"github.com/jordigilh/kubernaut/pkg/shared/circuitbreaker"

--- a/pkg/notification/delivery/circuit_breaker.go
+++ b/pkg/notification/delivery/circuit_breaker.go
@@ -19,8 +19,6 @@ package delivery
 import (
 	"context"
 
-	"github.com/sony/gobreaker/v2"
-
 	notificationv1alpha1 "github.com/jordigilh/kubernaut/api/notification/v1alpha1"
 	"github.com/jordigilh/kubernaut/pkg/shared/circuitbreaker"
 )
@@ -48,13 +46,10 @@ func NewCircuitBreakerService(inner Service, cbManager *circuitbreaker.Manager, 
 }
 
 // Deliver sends the notification through the circuit breaker.
-// When the circuit is open, returns gobreaker.ErrOpenState.
+// When the circuit is open, returns circuitbreaker.ErrOpenState.
 func (s *CircuitBreakerService) Deliver(ctx context.Context, notification *notificationv1alpha1.NotificationRequest) error {
 	_, err := s.cbManager.Execute(s.breakerName, func() (interface{}, error) {
 		return nil, s.inner.Deliver(ctx, notification)
 	})
-	if err == gobreaker.ErrOpenState {
-		return err
-	}
 	return err
 }

--- a/pkg/shared/circuitbreaker/manager.go
+++ b/pkg/shared/circuitbreaker/manager.go
@@ -19,7 +19,7 @@ package circuitbreaker
 import (
 	"sync"
 
-	"github.com/sony/gobreaker"
+	"github.com/sony/gobreaker/v2"
 )
 
 // Manager manages multiple circuit breakers (one per resource/channel)
@@ -55,7 +55,7 @@ import (
 //	    return nil, k8sClient.Create(ctx, crd)
 //	})
 type Manager struct {
-	breakers map[string]*gobreaker.CircuitBreaker
+	breakers map[string]*gobreaker.CircuitBreaker[any]
 	settings gobreaker.Settings
 	mu       sync.RWMutex
 }
@@ -67,7 +67,7 @@ type Manager struct {
 //   Note: settings.Name will be overridden per channel
 func NewManager(settings gobreaker.Settings) *Manager {
 	return &Manager{
-		breakers: make(map[string]*gobreaker.CircuitBreaker),
+		breakers: make(map[string]*gobreaker.CircuitBreaker[any]),
 		settings: settings,
 	}
 }
@@ -172,7 +172,7 @@ func (m *Manager) RecordFailure(channel string) {
 // write lock only for slow path (create new breaker).
 //
 // Note: Caller does not need to hold lock, this method handles locking internally.
-func (m *Manager) getOrCreate(channel string) *gobreaker.CircuitBreaker {
+func (m *Manager) getOrCreate(channel string) *gobreaker.CircuitBreaker[any] {
 	// Fast path: breaker already exists
 	m.mu.RLock()
 	if cb, exists := m.breakers[channel]; exists {
@@ -195,7 +195,7 @@ func (m *Manager) getOrCreate(channel string) *gobreaker.CircuitBreaker {
 	settings.Name = channel
 
 	// Create and store circuit breaker for this channel
-	cb := gobreaker.NewCircuitBreaker(settings)
+	cb := gobreaker.NewCircuitBreaker[any](settings)
 	m.breakers[channel] = cb
 	return cb
 }

--- a/pkg/shared/circuitbreaker/manager.go
+++ b/pkg/shared/circuitbreaker/manager.go
@@ -18,9 +18,47 @@ package circuitbreaker
 
 import (
 	"sync"
+	"time"
 
 	"github.com/sony/gobreaker/v2"
 )
+
+// State represents the circuit breaker state. Re-exported so callers
+// never need to import gobreaker directly.
+type State = gobreaker.State
+
+const (
+	StateClosed   = gobreaker.StateClosed
+	StateHalfOpen = gobreaker.StateHalfOpen
+	StateOpen     = gobreaker.StateOpen
+)
+
+// ErrOpenState is returned when the circuit breaker is open and rejects
+// the call. Re-exported so callers never need to import gobreaker.
+var ErrOpenState = gobreaker.ErrOpenState
+
+// ManagerConfig controls the circuit breaker Manager behavior.
+// Mirrors transport.CircuitBreakerConfig so that callers never import
+// gobreaker directly.
+type ManagerConfig struct {
+	// MaxRequests is the number of requests allowed in half-open state.
+	MaxRequests uint32
+
+	// Interval is the cyclic period of the closed state for clearing
+	// internal counts. If 0, internal counts are never cleared.
+	Interval time.Duration
+
+	// Timeout is the period of the open state, after which the state
+	// transitions to half-open.
+	Timeout time.Duration
+
+	// ConsecutiveFailureThreshold trips the circuit when consecutive
+	// failures reach this count. 0 means never trip.
+	ConsecutiveFailureThreshold uint32
+
+	// OnStateChange is called when any channel's breaker transitions state.
+	OnStateChange func(name string, from, to State)
+}
 
 // Manager manages multiple circuit breakers (one per resource/channel)
 //
@@ -37,22 +75,13 @@ import (
 //
 // Notification Service (multi-channel):
 //
-//	manager := circuitbreaker.NewManager(gobreaker.Settings{
-//	    MaxRequests: 2,
-//	    Timeout:     30 * time.Second,
-//	    ReadyToTrip: func(counts gobreaker.Counts) bool {
-//	        return counts.ConsecutiveFailures >= 3
-//	    },
+//	manager := circuitbreaker.NewManager(circuitbreaker.ManagerConfig{
+//	    MaxRequests:                 2,
+//	    Timeout:                    30 * time.Second,
+//	    ConsecutiveFailureThreshold: 3,
 //	})
 //	_, err := manager.Execute("slack", func() (interface{}, error) {
 //	    return nil, slackService.Deliver(ctx, notification)
-//	})
-//
-// Gateway Service (single K8s API):
-//
-//	cb := gobreaker.NewCircuitBreaker(gobreaker.Settings{...})
-//	_, err := cb.Execute(func() (interface{}, error) {
-//	    return nil, k8sClient.Create(ctx, crd)
 //	})
 type Manager struct {
 	breakers map[string]*gobreaker.CircuitBreaker[any]
@@ -60,82 +89,51 @@ type Manager struct {
 	mu       sync.RWMutex
 }
 
-// NewManager creates a circuit breaker manager with shared settings
-//
-// Parameters:
-// - settings: Base gobreaker.Settings applied to all channels
-//   Note: settings.Name will be overridden per channel
-func NewManager(settings gobreaker.Settings) *Manager {
+// NewManager creates a circuit breaker manager with shared settings.
+// The ManagerConfig is translated to gobreaker.Settings internally so
+// that callers never depend on gobreaker types.
+func NewManager(cfg ManagerConfig) *Manager {
+	settings := gobreaker.Settings{
+		MaxRequests: cfg.MaxRequests,
+		Interval:    cfg.Interval,
+		Timeout:     cfg.Timeout,
+	}
+
+	if cfg.ConsecutiveFailureThreshold > 0 {
+		threshold := cfg.ConsecutiveFailureThreshold
+		settings.ReadyToTrip = func(counts gobreaker.Counts) bool {
+			return counts.ConsecutiveFailures >= threshold
+		}
+	}
+
+	if cfg.OnStateChange != nil {
+		settings.OnStateChange = cfg.OnStateChange
+	}
+
 	return &Manager{
 		breakers: make(map[string]*gobreaker.CircuitBreaker[any]),
 		settings: settings,
 	}
 }
 
-// Execute runs a function with circuit breaker protection for a specific channel
+// Execute runs a function with circuit breaker protection for a specific channel.
 //
-// This is the recommended method as it automatically tracks success/failure
-// and handles state transitions.
-//
-// Parameters:
-// - channel: Resource identifier (e.g., "slack", "console", "k8s-api")
-// - fn: Function to execute with circuit breaker protection
-//
-// Returns:
-// - result: Function return value (or nil if error)
-// - error: gobreaker.ErrOpenState if circuit is open, or function error
-//
-// Example:
-//
-//	result, err := manager.Execute("slack", func() (interface{}, error) {
-//	    return slackService.Deliver(ctx, notification)
-//	})
-//	if err == gobreaker.ErrOpenState {
-//	    // Circuit breaker is open, fail fast
-//	}
+// Returns ErrOpenState when the circuit is open (fail-fast).
 func (m *Manager) Execute(channel string, fn func() (interface{}, error)) (interface{}, error) {
 	cb := m.getOrCreate(channel)
 	return cb.Execute(fn)
 }
 
-// AllowRequest checks if circuit breaker allows requests for a channel
-//
-// This method is provided for backward compatibility with existing code
-// that manually checks circuit breaker state before operations.
-//
-// Returns:
-// - true: Circuit is Closed or HalfOpen (allow requests)
-// - false: Circuit is Open (reject requests)
-//
-// Example:
-//
-//	if !manager.AllowRequest("slack") {
-//	    return fmt.Errorf("slack circuit breaker is open")
-//	}
+// AllowRequest checks if circuit breaker allows requests for a channel.
+// Returns false when the circuit is Open (reject requests).
 func (m *Manager) AllowRequest(channel string) bool {
 	cb := m.getOrCreate(channel)
-	return cb.State() != gobreaker.StateOpen
+	return cb.State() != StateOpen
 }
 
 // State returns the current state of a channel's circuit breaker
-//
-// Returns:
-// - gobreaker.StateClosed: Normal operation (0)
-// - gobreaker.StateHalfOpen: Testing recovery (1)
-// - gobreaker.StateOpen: Blocking requests (2)
-//
-// Example:
-//
-//	state := manager.State("slack")
-//	switch state {
-//	case gobreaker.StateClosed:
-//	    // Normal operation
-//	case gobreaker.StateOpen:
-//	    // Failing fast
-//	case gobreaker.StateHalfOpen:
-//	    // Testing recovery
-//	}
-func (m *Manager) State(channel string) gobreaker.State {
+// (StateClosed, StateHalfOpen, or StateOpen).
+func (m *Manager) State(channel string) State {
 	cb := m.getOrCreate(channel)
 	return cb.State()
 }

--- a/pkg/shared/transport/circuit_breaker.go
+++ b/pkg/shared/transport/circuit_breaker.go
@@ -22,7 +22,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
-	"github.com/sony/gobreaker"
+	"github.com/sony/gobreaker/v2"
 )
 
 // CircuitBreakerConfig controls the circuit breaker behavior.
@@ -85,7 +85,7 @@ func DefaultCircuitBreakerConfig(name string) CircuitBreakerConfig {
 // This ensures that when the circuit is open, no retries are wasted.
 type CircuitBreakerTransport struct {
 	next http.RoundTripper
-	cb   *gobreaker.CircuitBreaker
+	cb   *gobreaker.CircuitBreaker[*http.Response]
 }
 
 // NewCircuitBreakerTransport creates a CircuitBreakerTransport wrapping
@@ -129,14 +129,14 @@ func NewCircuitBreakerTransport(next http.RoundTripper, cfg CircuitBreakerConfig
 
 	return &CircuitBreakerTransport{
 		next: next,
-		cb:   gobreaker.NewCircuitBreaker(settings),
+		cb:   gobreaker.NewCircuitBreaker[*http.Response](settings),
 	}
 }
 
 // RoundTrip executes the HTTP request through the circuit breaker.
 // Returns gobreaker.ErrOpenState when the circuit is open.
 func (t *CircuitBreakerTransport) RoundTrip(req *http.Request) (*http.Response, error) {
-	result, err := t.cb.Execute(func() (interface{}, error) {
+	resp, err := t.cb.Execute(func() (*http.Response, error) {
 		resp, err := t.next.RoundTrip(req)
 		if err != nil {
 			return nil, err
@@ -148,13 +148,13 @@ func (t *CircuitBreakerTransport) RoundTrip(req *http.Request) (*http.Response, 
 	})
 
 	if err != nil {
-		if resp, ok := result.(*http.Response); ok && resp != nil {
+		if resp != nil {
 			return resp, nil
 		}
 		return nil, err
 	}
 
-	return result.(*http.Response), nil
+	return resp, nil
 }
 
 // State returns the current circuit breaker state (for observability).

--- a/test/integration/notification/performance_concurrent_test.go
+++ b/test/integration/notification/performance_concurrent_test.go
@@ -29,7 +29,6 @@ import (
 
 	notificationv1alpha1 "github.com/jordigilh/kubernaut/api/notification/v1alpha1"
 	"github.com/jordigilh/kubernaut/pkg/shared/circuitbreaker"
-	"github.com/sony/gobreaker/v2"
 )
 
 // P0 TESTS: Concurrent Deliveries + Circuit Breaker (6 tests)
@@ -261,16 +260,11 @@ var _ = Describe("P0: Concurrent Deliveries + Circuit Breaker", Label("p0", "con
 			// BEHAVIOR: Circuit breaker blocks requests to protect failing service
 			// BUSINESS CONTEXT: Prevents overwhelming unhealthy service with more requests
 
-			// Configure circuit breaker with low threshold for testing
-			// Migrated to github.com/sony/gobreaker via Manager wrapper
-			circuitBreaker := circuitbreaker.NewManager(gobreaker.Settings{
-				MaxRequests: 2, // Allow 2 test requests in half-open
-				Interval:    10 * time.Second,
-				Timeout:     5 * time.Second, // Transition to half-open after 5s
-				ReadyToTrip: func(counts gobreaker.Counts) bool {
-					// Trip after 3 consecutive failures
-					return counts.ConsecutiveFailures >= 3
-				},
+			circuitBreaker := circuitbreaker.NewManager(circuitbreaker.ManagerConfig{
+				MaxRequests:                 2,
+				Interval:                   10 * time.Second,
+				Timeout:                    5 * time.Second,
+				ConsecutiveFailureThreshold: 3,
 			})
 
 			// BEHAVIOR VALIDATION: Initial state allows requests
@@ -306,14 +300,11 @@ var _ = Describe("P0: Concurrent Deliveries + Circuit Breaker", Label("p0", "con
 			// BEHAVIOR: Circuit breaker allows requests again after service recovers
 			// BUSINESS CONTEXT: Returns to normal operation once service proves it's healthy
 
-			// Migrated to github.com/sony/gobreaker via Manager wrapper
-			circuitBreaker := circuitbreaker.NewManager(gobreaker.Settings{
-				MaxRequests: 2, // Allow 2 test requests in half-open
-				Interval:    10 * time.Second,
-				Timeout:     100 * time.Millisecond, // Quick transition to half-open for testing
-				ReadyToTrip: func(counts gobreaker.Counts) bool {
-					return counts.ConsecutiveFailures >= 3
-				},
+			circuitBreaker := circuitbreaker.NewManager(circuitbreaker.ManagerConfig{
+				MaxRequests:                 2,
+				Interval:                   10 * time.Second,
+				Timeout:                    100 * time.Millisecond,
+				ConsecutiveFailureThreshold: 3,
 			})
 
 			// Trigger circuit breaker (open state) by making actual Execute() calls

--- a/test/integration/notification/performance_concurrent_test.go
+++ b/test/integration/notification/performance_concurrent_test.go
@@ -29,7 +29,7 @@ import (
 
 	notificationv1alpha1 "github.com/jordigilh/kubernaut/api/notification/v1alpha1"
 	"github.com/jordigilh/kubernaut/pkg/shared/circuitbreaker"
-	"github.com/sony/gobreaker"
+	"github.com/sony/gobreaker/v2"
 )
 
 // P0 TESTS: Concurrent Deliveries + Circuit Breaker (6 tests)

--- a/test/integration/notification/suite_test.go
+++ b/test/integration/notification/suite_test.go
@@ -62,7 +62,7 @@ import (
 	"github.com/jordigilh/kubernaut/test/infrastructure"
 	"github.com/jordigilh/kubernaut/test/shared/helpers"
 	"github.com/jordigilh/kubernaut/test/shared/integration"
-	"github.com/sony/gobreaker"
+	"github.com/sony/gobreaker/v2"
 	// +kubebuilder:scaffold:imports
 )
 

--- a/test/integration/notification/suite_test.go
+++ b/test/integration/notification/suite_test.go
@@ -62,7 +62,6 @@ import (
 	"github.com/jordigilh/kubernaut/test/infrastructure"
 	"github.com/jordigilh/kubernaut/test/shared/helpers"
 	"github.com/jordigilh/kubernaut/test/shared/integration"
-	"github.com/sony/gobreaker/v2"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -544,15 +543,12 @@ receivers:
 
 	// Create circuit breaker for integration tests
 	// Per BR-NOT-055: Circuit breaker provides per-channel isolation
-	circuitBreakerManager := circuitbreaker.NewManager(gobreaker.Settings{
-		MaxRequests: 2,
-		Interval:    10 * time.Second,
-		Timeout:     30 * time.Second,
-		ReadyToTrip: func(counts gobreaker.Counts) bool {
-			return counts.ConsecutiveFailures >= 3
-		},
-		OnStateChange: func(name string, from gobreaker.State, to gobreaker.State) {
-			// Update metrics on state change
+	circuitBreakerManager := circuitbreaker.NewManager(circuitbreaker.ManagerConfig{
+		MaxRequests:                 2,
+		Interval:                   10 * time.Second,
+		Timeout:                    30 * time.Second,
+		ConsecutiveFailureThreshold: 3,
+		OnStateChange: func(name string, from, to circuitbreaker.State) {
 			if metricsRecorder != nil {
 				metricsRecorder.UpdateCircuitBreakerState(name, int(to))
 			}

--- a/test/unit/notification/controller_events_test.go
+++ b/test/unit/notification/controller_events_test.go
@@ -44,7 +44,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/shared/events"
 	"github.com/jordigilh/kubernaut/pkg/shared/sanitization"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sony/gobreaker"
+	"github.com/sony/gobreaker/v2"
 )
 
 // drainEvents reads all available events from the FakeRecorder channel.

--- a/test/unit/notification/controller_events_test.go
+++ b/test/unit/notification/controller_events_test.go
@@ -44,7 +44,6 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/shared/events"
 	"github.com/jordigilh/kubernaut/pkg/shared/sanitization"
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/sony/gobreaker/v2"
 )
 
 // drainEvents reads all available events from the FakeRecorder channel.
@@ -157,9 +156,7 @@ var _ = Describe("Notification Controller K8s Events [DD-EVENT-001]", func() {
 			)
 			orchestrator.RegisterChannel(string(notificationv1alpha1.ChannelConsole), delivery.NewConsoleDeliveryService())
 
-			cbManager := circuitbreaker.NewManager(gobreaker.Settings{
-				ReadyToTrip: func(gobreaker.Counts) bool { return false },
-			})
+			cbManager := circuitbreaker.NewManager(circuitbreaker.ManagerConfig{})
 
 			reconciler := &notificationcontroller.NotificationRequestReconciler{
 				Client:               fakeClient,
@@ -232,9 +229,7 @@ var _ = Describe("Notification Controller K8s Events [DD-EVENT-001]", func() {
 			)
 			orchestrator.RegisterChannel(string(notificationv1alpha1.ChannelConsole), delivery.NewConsoleDeliveryService())
 
-			cbManager := circuitbreaker.NewManager(gobreaker.Settings{
-				ReadyToTrip: func(gobreaker.Counts) bool { return false },
-			})
+			cbManager := circuitbreaker.NewManager(circuitbreaker.ManagerConfig{})
 
 			reconciler := &notificationcontroller.NotificationRequestReconciler{
 				Client:               fakeClient,

--- a/test/unit/notification/delivery/circuit_breaker_test.go
+++ b/test/unit/notification/delivery/circuit_breaker_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/sony/gobreaker"
+	"github.com/sony/gobreaker/v2"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"

--- a/test/unit/notification/delivery/circuit_breaker_test.go
+++ b/test/unit/notification/delivery/circuit_breaker_test.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/sony/gobreaker/v2"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -31,13 +29,11 @@ var _ = Describe("Generic CircuitBreakerService (BR-NOT-055)", func() {
 	)
 
 	BeforeEach(func() {
-		cbManager = circuitbreaker.NewManager(gobreaker.Settings{
-			MaxRequests: 1,
-			Interval:    60 * time.Second,
-			Timeout:     60 * time.Second,
-			ReadyToTrip: func(counts gobreaker.Counts) bool {
-				return counts.ConsecutiveFailures >= 2
-			},
+		cbManager = circuitbreaker.NewManager(circuitbreaker.ManagerConfig{
+			MaxRequests:                 1,
+			Interval:                   60 * time.Second,
+			Timeout:                    60 * time.Second,
+			ConsecutiveFailureThreshold: 2,
 		})
 		nr = newTestNotification("cb-test", "ns", notificationv1alpha1.NotificationTypeSimple, notificationv1alpha1.NotificationPriorityMedium)
 	})
@@ -72,7 +68,7 @@ var _ = Describe("Generic CircuitBreakerService (BR-NOT-055)", func() {
 		_ = svc.Deliver(context.Background(), nr)
 
 		err := svc.Deliver(context.Background(), nr)
-		Expect(err).To(Equal(gobreaker.ErrOpenState))
+		Expect(err).To(Equal(circuitbreaker.ErrOpenState))
 		Expect(callCount).To(Equal(2), "inner should not be called when circuit is open")
 	})
 
@@ -90,7 +86,7 @@ var _ = Describe("Generic CircuitBreakerService (BR-NOT-055)", func() {
 		_ = pdSvc.Deliver(context.Background(), nr)
 		_ = pdSvc.Deliver(context.Background(), nr)
 		err := pdSvc.Deliver(context.Background(), nr)
-		Expect(err).To(Equal(gobreaker.ErrOpenState), "pagerduty breaker should be open")
+		Expect(err).To(Equal(circuitbreaker.ErrOpenState), "pagerduty breaker should be open")
 
 		Expect(teamsSvc.Deliver(context.Background(), nr)).To(Succeed(),
 			"teams breaker should still be closed")

--- a/test/unit/notification/retry_test.go
+++ b/test/unit/notification/retry_test.go
@@ -23,7 +23,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sony/gobreaker"
+	"github.com/sony/gobreaker/v2"
 
 	"github.com/jordigilh/kubernaut/pkg/notification/retry"
 	"github.com/jordigilh/kubernaut/pkg/shared/circuitbreaker"
@@ -283,8 +283,8 @@ var _ = Describe("BR-NOT-061: Circuit Breaker Manager", func() {
 
 	Context("Manager Creation", func() {
 		It("should create manager with shared settings", func() {
-			// BEHAVIOR: Manager initializes successfully
-			Expect(manager).ToNot(BeNil())
+			Expect(manager.AllowRequest("new-channel")).To(BeTrue(),
+				"Newly created manager should allow requests on any channel")
 		})
 
 		It("should allow initial requests (circuit starts closed)", func() {

--- a/test/unit/notification/retry_test.go
+++ b/test/unit/notification/retry_test.go
@@ -23,7 +23,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sony/gobreaker/v2"
 
 	"github.com/jordigilh/kubernaut/pkg/notification/retry"
 	"github.com/jordigilh/kubernaut/pkg/shared/circuitbreaker"
@@ -271,13 +270,11 @@ var _ = Describe("BR-NOT-061: Circuit Breaker Manager", func() {
 
 	BeforeEach(func() {
 		// Create manager with test-friendly settings
-		manager = circuitbreaker.NewManager(gobreaker.Settings{
-			MaxRequests: 2,
-			Interval:    10 * time.Second,
-			Timeout:     1 * time.Second,
-			ReadyToTrip: func(counts gobreaker.Counts) bool {
-				return counts.ConsecutiveFailures >= 3
-			},
+		manager = circuitbreaker.NewManager(circuitbreaker.ManagerConfig{
+			MaxRequests:                 2,
+			Interval:                   10 * time.Second,
+			Timeout:                    1 * time.Second,
+			ConsecutiveFailureThreshold: 3,
 		})
 	})
 
@@ -291,7 +288,7 @@ var _ = Describe("BR-NOT-061: Circuit Breaker Manager", func() {
 			// BEHAVIOR: New channels start in closed state (normal operation)
 			Expect(manager.AllowRequest("slack")).To(BeTrue(),
 				"New circuit should allow requests initially")
-			Expect(manager.State("slack")).To(Equal(gobreaker.StateClosed),
+			Expect(manager.State("slack")).To(Equal(circuitbreaker.StateClosed),
 				"New circuit should start in Closed state")
 		})
 	})
@@ -316,7 +313,7 @@ var _ = Describe("BR-NOT-061: Circuit Breaker Manager", func() {
 			// CORRECTNESS: Console circuit should still be closed
 			Expect(manager.AllowRequest("console")).To(BeTrue(),
 				"Console circuit should remain closed (independent from slack)")
-			Expect(manager.State("console")).To(Equal(gobreaker.StateClosed),
+			Expect(manager.State("console")).To(Equal(circuitbreaker.StateClosed),
 				"Console circuit should be in Closed state")
 		})
 
@@ -365,12 +362,11 @@ var _ = Describe("BR-NOT-061: Circuit Breaker Manager", func() {
 				})
 			}
 
-			// BEHAVIOR: Execute returns gobreaker.ErrOpenState
 			_, err := manager.Execute("slack", func() (interface{}, error) {
 				Fail("Function should not be called when circuit is open")
 				return nil, nil
 			})
-			Expect(err).To(Equal(gobreaker.ErrOpenState),
+			Expect(err).To(Equal(circuitbreaker.ErrOpenState),
 				"Should return ErrOpenState when circuit is open")
 		})
 	})
@@ -378,7 +374,7 @@ var _ = Describe("BR-NOT-061: Circuit Breaker Manager", func() {
 	Context("State Method", func() {
 		It("should return Closed state initially", func() {
 			state := manager.State("new-channel")
-			Expect(state).To(Equal(gobreaker.StateClosed))
+			Expect(state).To(Equal(circuitbreaker.StateClosed))
 		})
 
 		It("should return Open state after threshold failures", func() {
@@ -390,7 +386,7 @@ var _ = Describe("BR-NOT-061: Circuit Breaker Manager", func() {
 			}
 
 			state := manager.State("slack")
-			Expect(state).To(Equal(gobreaker.StateOpen))
+			Expect(state).To(Equal(circuitbreaker.StateOpen))
 		})
 	})
 

--- a/test/unit/shared/transport/circuit_breaker_test.go
+++ b/test/unit/shared/transport/circuit_breaker_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sony/gobreaker"
+	"github.com/sony/gobreaker/v2"
 
 	"github.com/jordigilh/kubernaut/pkg/shared/transport"
 )

--- a/test/unit/shared/transport/circuit_breaker_test.go
+++ b/test/unit/shared/transport/circuit_breaker_test.go
@@ -26,8 +26,8 @@ import (
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"github.com/sony/gobreaker/v2"
 
+	"github.com/jordigilh/kubernaut/pkg/shared/circuitbreaker"
 	"github.com/jordigilh/kubernaut/pkg/shared/transport"
 )
 
@@ -100,7 +100,7 @@ var _ = Describe("CircuitBreakerTransport — OPS-2 / BR-AI-982", func() {
 			req, err := http.NewRequest(http.MethodGet, server.URL, nil)
 			Expect(err).NotTo(HaveOccurred())
 			_, err = rt.RoundTrip(req)
-			Expect(err).To(MatchError(gobreaker.ErrOpenState))
+			Expect(err).To(MatchError(circuitbreaker.ErrOpenState))
 
 			Expect(callCount.Load()).To(BeNumerically("<", 6),
 				"circuit should have opened, preventing some requests from reaching the server")
@@ -135,7 +135,7 @@ var _ = Describe("CircuitBreakerTransport — OPS-2 / BR-AI-982", func() {
 
 			cbt, ok := rt.(*transport.CircuitBreakerTransport)
 			Expect(ok).To(BeTrue())
-			Expect(cbt.State()).To(Equal(gobreaker.StateClosed))
+			Expect(cbt.State()).To(Equal(circuitbreaker.StateClosed))
 		})
 	})
 
@@ -155,7 +155,7 @@ var _ = Describe("CircuitBreakerTransport — OPS-2 / BR-AI-982", func() {
 				Timeout:          30 * time.Second,
 				FailureThreshold: 3,
 				FailureRatio:     0.5,
-				OnStateChange: func(name string, from, to gobreaker.State) {
+				OnStateChange: func(name string, from, to circuitbreaker.State) {
 					transitions = append(transitions, fmt.Sprintf("%s->%s", from.String(), to.String()))
 				},
 			})
@@ -197,7 +197,7 @@ var _ = Describe("CircuitBreakerTransport — OPS-2 / BR-AI-982", func() {
 
 			cbt, ok := rt.(*transport.CircuitBreakerTransport)
 			Expect(ok).To(BeTrue())
-			Expect(cbt.State()).To(Equal(gobreaker.StateOpen))
+			Expect(cbt.State()).To(Equal(circuitbreaker.StateOpen))
 		})
 	})
 


### PR DESCRIPTION
## Summary

- Upgrade `github.com/sony/gobreaker` from v1.0.0 to v2.4.0 (`github.com/sony/gobreaker/v2`)
- Leverage generic type parameters (`CircuitBreaker[T]`) to eliminate unsafe `interface{}` type assertions
- **Encapsulate gobreaker** behind `ManagerConfig` and re-exported constants so only 3 core implementation files import gobreaker directly — all consumers (cmd/, test/, notification delivery) use `pkg/shared/circuitbreaker` types
- Align notification service wiring pattern with KA and GW (gobreaker is an implementation detail)

## Key Changes

### Commit 1: v2 Migration
- Import path: `github.com/sony/gobreaker` → `github.com/sony/gobreaker/v2`
- `CircuitBreakerTransport` uses `CircuitBreaker[*http.Response]` for type-safe HTTP round-trips
- `Manager` uses `CircuitBreaker[any]` for multi-channel generic usage
- `Gateway K8s client` uses `CircuitBreaker[any]` for mixed return types
- Remove `result.(*http.Response)` type assertion in `RoundTrip` (now type-safe)

### Commit 2: Encapsulation
- Add `ManagerConfig` struct with `ConsecutiveFailureThreshold`, `MaxRequests`, `Interval`, `Timeout`, `OnStateChange`
- Re-export `State`, `StateClosed`, `StateHalfOpen`, `StateOpen`, `ErrOpenState` from `pkg/shared/circuitbreaker`
- Remove gobreaker imports from `cmd/notification/main.go`, `pkg/notification/delivery/circuit_breaker.go`, `pkg/gateway/server.go`, and all 6 test files

## gobreaker Import Surface (after)

Only 3 files import `github.com/sony/gobreaker/v2`:
- `pkg/shared/circuitbreaker/manager.go`
- `pkg/shared/transport/circuit_breaker.go`
- `pkg/gateway/k8s/client_with_circuit_breaker.go`

## Test plan

- [x] `go build ./...` passes
- [x] All transport unit tests pass
- [x] All notification unit tests pass (392/392 specs)
- [x] Integration tests compile cleanly
- [x] No remaining gobreaker imports outside the 3 core packages
- [ ] CI pipeline passes