### PR TITLE
#1048 Phase 5: FedRAMP AU Fixes (AU-2, AU-3, AU-9, AU-11, SC-8)

### DIFF
--- a/charts/kubernaut/templates/datastorage/datastorage.yaml
+++ b/charts/kubernaut/templates/datastorage/datastorage.yaml
@@ -25,6 +25,7 @@ data:
       {{- else }}
         - "*"
       {{- end }}
+      signerCertDir: {{ .Values.datastorage.config.server.signerCertDir | default "/etc/certs" | quote }}
       tls:
         certDir: {{ include "kubernaut.interServiceTLS.certDir" . | quote }}
     database:
@@ -42,7 +43,7 @@ data:
       passwordKey: "password"
     redis:
       addr: {{ include "kubernaut.valkey.addr" . }}
-      dlqMaxLen: 1000
+      dlqMaxLen: {{ .Values.datastorage.config.redis.dlqMaxLen | default "10000" }}
       secretsFile: "/etc/datastorage/secrets/valkey-secrets.yaml"
       passwordKey: "password"
     logging:

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -105,11 +105,16 @@ datastorage:
       # Override with explicit origins for production (e.g., ["https://dashboard.example.com"]).
       corsAllowedOrigins:
         - "*"
+      # #1048 Phase 5 / AU-9: Directory containing signing cert (tls.crt, tls.key).
+      signerCertDir: "/etc/certs"
     database:
       sslMode: "disable"
       maxOpenConns: 100
       maxIdleConns: 20
       connMaxLifetime: "1h"
+    redis:
+      # #1048 Phase 5 / AU-11: Redis DLQ MAXLEN bound (streams: audit:dlq:* , audit:dead-letter:* )
+      dlqMaxLen: 10000
   resources:
     requests:
       memory: 256Mi

--- a/config/data-storage.yaml
+++ b/config/data-storage.yaml
@@ -10,6 +10,9 @@ server:
   # #1048 Phase 4 / AC-4: CORS allowed origins (default: ["*"])
   corsAllowedOrigins:
     - "*"
+  # #1048 Phase 5 / AU-9: Directory containing signing certificate (tls.crt, tls.key)
+  # Default: /etc/certs. Override for Helm environments where cert-manager mounts differ.
+  # signerCertDir: "/etc/certs"
 
 logging:
   level: "info"
@@ -33,3 +36,19 @@ redis:
   # DD-009: Redis used for Dead Letter Queue (DLQ) fallback
   # when PostgreSQL is unavailable
   dlqMaxLen: 10000
+  # #1048 Phase 5 / AU-9, SC-8: Redis TLS for audit data transport encryption
+  # Server-side Valkey TLS: tracked in kubernaut-operator#89
+  tls:
+    enabled: false
+    # certFile: ""       # Client cert for mTLS (optional)
+    # keyFile: ""        # Client key for mTLS (optional)
+    # caFile: ""         # CA bundle to verify Valkey server
+    # insecureSkipVerify: false
+
+# #1048 Phase 5 / AU-11, BR-AUDIT-009: Audit data retention enforcement
+retention:
+  enabled: false         # Opt-in: destructive operation (BR-AUDIT-004 safe default)
+  interval: "24h"        # How often the worker runs
+  batchSize: 1000        # Max rows per DELETE batch
+  defaultDays: 2555      # ADR-034: 7 years (SOC 2 / ISO 27001)
+  partitionDropEnabled: false

--- a/deploy/data-storage/configmap.yaml
+++ b/deploy/data-storage/configmap.yaml
@@ -17,6 +17,9 @@ data:
       # Production should list explicit origins, e.g. ["https://dashboard.kubernaut.ai"]
       corsAllowedOrigins:
         - "*"
+      # #1048 Phase 5 / AU-9: Directory containing signing certificate (tls.crt, tls.key)
+      # Default: /etc/certs. Override for Helm environments where cert-manager mounts differ.
+      # signerCertDir: "/etc/certs"
 
     logging:
       level: "info"

--- a/docs/tests/1048/PHASE5_TEST_PLAN.md
+++ b/docs/tests/1048/PHASE5_TEST_PLAN.md
@@ -1,0 +1,485 @@
+# Test Plan: Data Storage Phase 5 — FedRAMP AU Fixes (#1048)
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+>
+> Based on IEEE 829-2008 (Standard for Software and System Test Documentation) with
+> Kubernaut-specific extensions for TDD phase tracking, business requirement traceability,
+> and per-tier coverage policy.
+
+**Test Plan Identifier**: TP-1048-P5-v1.0
+**Feature**: FedRAMP AU compliance for Data Storage — signer fail-hard, retention worker lifecycle, retention default alignment (ADR-034), actor\_id enrichment, PEL recovery, Redis TLS client, DLQ trim alerting
+**Version**: 1.0
+**Created**: 2026-05-11
+**Author**: AI Assistant
+**Status**: Draft
+**Branch**: `development/v1.5`
+**Parent Issue**: [#1048](https://github.com/jordigilh/kubernaut/issues/1048)
+**Tracking Issue**: [#1088](https://github.com/jordigilh/kubernaut/issues/1088)
+**Operator Dependencies**: [kubernaut-operator#89](https://github.com/jordigilh/kubernaut-operator/issues/89) (Valkey TLS), [kubernaut-operator#90](https://github.com/jordigilh/kubernaut-operator/issues/90) (signing cert mount)
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This test plan validates Phase 5 of the Data Storage Readiness Audit (#1048). Phase 5 addresses FedRAMP AU (Audit) control family requirements:
+
+| FedRAMP Control | Phase 5 Item | Description |
+|-----------------|--------------|-------------|
+| AU-9 | Item 1 | Signer fail-hard (no self-signed fallback) |
+| AU-11 | Item 2 | Retention worker lifecycle |
+| AU-11 | Item 3 | Retention DEFAULT alignment with ADR-034 (2555 days) |
+| AU-3 | Item 4 | Actor identity from auth token |
+| AU-2 | Item 5 | PEL recovery for stuck DLQ messages |
+| AU-9, SC-8 | Item 6 | Redis TLS client support |
+| AU-11 | Item 7 | DLQ MaxLen trim alerting + RPO documentation |
+
+### 1.2 Objectives
+
+1. **Signer integrity**: Data Storage refuses to start without a valid signing certificate (no ephemeral fallback).
+2. **Retention lifecycle**: Background retention worker starts/stops with server, purges expired rows in batches, respects legal hold.
+3. **Retention default**: Column default aligns with ADR-034 (2555 days / ~7 years); configurable via Helm.
+4. **Actor attribution**: Audit events record the authenticated human identity from `X-Auth-Request-User`, not a synthetic default.
+5. **PEL recovery**: Orphaned DLQ messages are reclaimed and reprocessed; poison messages are dead-lettered.
+6. **Redis TLS**: Data Storage client supports TLS for Redis/Valkey connections.
+7. **Trim visibility**: DLQ stream trim events are metered; RPO trade-off is documented.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./test/unit/datastorage/...` |
+| Integration test pass rate | 100% | `go test ./test/integration/datastorage/...` |
+| Unit-testable code coverage | >=80% | Signer init, retention eligibility, actor enrichment, PEL logic |
+| Integration-testable code coverage | >=80% | Worker lifecycle, Redis TLS, PEL recovery with real Redis |
+| Safety: no fallback cert | 100% | UT-DS-1048-P5-001 through -003 |
+| Safety: retention disabled by default | 100% | UT-DS-1048-P5-010 |
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- **ADR-034**: Unified audit table design — `retention_days INTEGER DEFAULT 2555` (7 years, SOC 2 / ISO 27001)
+- **ADR-032**: Data access layer isolation — "Audit data retention must meet regulatory requirements (7+ years)"
+- **BR-AUDIT-007**: Tamper-evident audit exports (signed)
+- **BR-AUDIT-009**: Retention policies meeting regulatory requirements
+- **BR-AUDIT-004**: Immutable audit logs with integrity protection
+- **DD-007 / DD-008 / DD-009**: Graceful shutdown, DLQ drain, DLQ retry worker lifecycle
+- **FedRAMP**: AU-2, AU-3, AU-9, AU-11, SC-8
+
+### 2.2 Cross-References
+
+- [Phase 5 readiness audit findings](https://github.com/jordigilh/kubernaut/issues/1088)
+- [TP-485 (Retention Enforcement)](../485/TEST_PLAN.md) — retention eligibility and purge SQL tests
+- [Testing Strategy](.cursor/rules/03-testing-strategy.mdc)
+- [V1.0 Test Plan Template](../../development/testing/V1_0_SERVICE_MATURITY_TEST_PLAN_TEMPLATE.md)
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | Removing signer fallback crashes existing deployments | Service outage | High | UT-DS-1048-P5-001..003 | Configurable cert path; operator issue #90 for cert provisioning |
+| R2 | Retention worker purges held rows | Legal/compliance violation | High | UT-DS-1048-P5-013, IT-DS-1048-P5-011 | PurgeSQL WHERE `legal_hold = FALSE`; integration test with trigger |
+| R3 | PEL recovery creates duplicate inserts | Noisy logs (at-least-once OK) | Medium | IT-DS-1048-P5-020..022 | PK prevents double rows (accepted: DF-M1) |
+| R4 | XAUTOCLAIM not supported in Valkey version | PEL recovery fails | Medium | IT-DS-1048-P5-020 | Version check at startup; fallback to XPENDING+XCLAIM |
+| R5 | Redis TLS misconfiguration | Connection failure at startup | Medium | UT-DS-1048-P5-030..032 | Fail-hard on TLS handshake error; clear error message |
+| R6 | Actor\_id override policy confusion (header vs body) | Incorrect attribution | Medium | UT-DS-1048-P5-040..045 | Server-side header always wins; documented policy |
+| R7 | DLQ trim discards unprocessed audit events | Data loss | Medium | UT-DS-1048-P5-050..051 | Trim counter metric + alert; RPO documentation |
+
+---
+
+## 4. Test Scenarios
+
+### 4.1 Item 1: Signer Fail-Hard (AU-9)
+
+**Business Requirement**: BR-AUDIT-007 (tamper-evident audit exports)
+**Files Under Test**: `pkg/datastorage/server/server.go` (`loadSigningCertificate`), `pkg/datastorage/config/config.go`
+
+| ID | Tier | TDD Phase | Description | Expected Result |
+|----|------|-----------|-------------|-----------------|
+| UT-DS-1048-P5-001 | Unit | RED | `loadSigningCertificate` returns error when cert file missing | `error` returned, no fallback |
+| UT-DS-1048-P5-002 | Unit | RED | `loadSigningCertificate` returns error when key file missing | `error` returned, no fallback |
+| UT-DS-1048-P5-003 | Unit | RED | `loadSigningCertificate` returns error when cert is corrupt/invalid | `error` returned, no fallback |
+| UT-DS-1048-P5-004 | Unit | RED | `loadSigningCertificate` succeeds with valid cert+key pair | `*cert.Signer` returned |
+| UT-DS-1048-P5-005 | Unit | GREEN | `signerCertDir` config field parsed from YAML | Config struct populated |
+| UT-DS-1048-P5-006 | Unit | GREEN | `signerCertDir` defaults to `/etc/certs` when not set | Default applied |
+| UT-DS-1048-P5-007 | Unit | REFACTOR | `generateFallbackCertificate` removed (dead code) | Build succeeds without it |
+
+**Test File**: `test/unit/datastorage/signer_test.go` (new)
+
+#### Test Approach
+
+Tests use `os.MkdirTemp` with generated test certificates (via `cert.GenerateSelfSigned` in test setup) to validate file system paths. The test creates valid/invalid cert files and asserts `loadSigningCertificate` behavior.
+
+```go
+Describe("UT-DS-1048-P5-001: Signer fail-hard on missing cert", func() {
+    It("should return error when cert file does not exist", func() {
+        // Given: empty temp directory (no tls.crt)
+        // When: loadSigningCertificate(logger)
+        // Then: error contains "cert" or "not found"
+    })
+})
+```
+
+---
+
+### 4.2 Item 2: Retention Worker Lifecycle
+
+**Business Requirement**: BR-AUDIT-009 (retention policies)
+**Files Under Test**: `pkg/datastorage/retention/worker.go` (new), `pkg/datastorage/server/server.go`
+
+| ID | Tier | TDD Phase | Description | Expected Result |
+|----|------|-----------|-------------|-----------------|
+| UT-DS-1048-P5-010 | Unit | RED | Worker does not start when `enabled: false` | No goroutine spawned |
+| UT-DS-1048-P5-011 | Unit | RED | Worker `Start()` begins periodic purge loop | Tick callback invoked |
+| UT-DS-1048-P5-012 | Unit | RED | Worker `Stop()` cancels context and returns | Goroutine exits cleanly |
+| UT-DS-1048-P5-013 | Unit | RED | Purge skips rows with `legal_hold = TRUE` | SQL WHERE includes `legal_hold = FALSE` |
+| UT-DS-1048-P5-014 | Unit | GREEN | Purge uses `Config.BatchSize` as LIMIT | SQL includes `LIMIT $2` |
+| UT-DS-1048-P5-015 | Unit | GREEN | Worker logs purge results (rows\_scanned, rows\_deleted) | Structured log emitted |
+| UT-DS-1048-P5-016 | Unit | REFACTOR | Worker writes `retention_operations` record per run | Operation record created with status |
+| IT-DS-1048-P5-010 | Integration | RED | Worker purges expired rows from real PostgreSQL | Rows deleted; non-expired remain |
+| IT-DS-1048-P5-011 | Integration | RED | Worker skips legal-held rows (trigger interaction) | Legal-held rows survive purge |
+| IT-DS-1048-P5-012 | Integration | GREEN | Worker shutdown ordering: stops before DB close | Worker.Stop() called before db.Close() in Shutdown() |
+| IT-DS-1048-P5-013 | Integration | REFACTOR | `retention_operations` populated with correct metadata | run\_id, rows\_deleted, duration\_ms present |
+
+**Test Files**:
+- `test/unit/datastorage/retention/worker_test.go` (new)
+- `test/integration/datastorage/retention_worker_test.go` (new)
+
+#### Config Wiring
+
+```yaml
+# config/data-storage.yaml
+retention:
+  enabled: false          # Opt-in (BR-AUDIT-004: safe default)
+  interval: 24h
+  batchSize: 1000
+  defaultDays: 2555       # ADR-034: 7 years (SOC 2 / ISO 27001)
+  partitionDropEnabled: false
+```
+
+---
+
+### 4.3 Item 3: Retention DEFAULT Alignment (AU-11)
+
+**Business Requirement**: BR-AUDIT-009, ADR-034
+**Files Under Test**: `migrations/009_retention_default_alignment.sql` (new), `pkg/datastorage/config/config.go`
+
+| ID | Tier | TDD Phase | Description | Expected Result |
+|----|------|-----------|-------------|-----------------|
+| UT-DS-1048-P5-020 | Unit | RED | Config `retention.defaultDays` parsed from YAML | Field populated with 2555 |
+| UT-DS-1048-P5-021 | Unit | GREEN | `retention.defaultDays` used in `ConvertAuditEventRequest` when body omits | Default 2555 applied |
+| IT-DS-1048-P5-020 | Integration | RED | After migration 009, column DEFAULT is 2555 | `INSERT` without retention\_days gets 2555 |
+| IT-DS-1048-P5-021 | Integration | GREEN | Existing rows with retention\_days=1 (from 008) unaffected | No data migration; column default only |
+
+**Migration 009** (illustrative):
+
+```sql
+-- +goose Up
+-- Align column default with ADR-034 (SOC 2 / ISO 27001: 7 years)
+-- Migration 008 set DEFAULT 1 (minimum); restore to ADR-034 authority.
+ALTER TABLE audit_events ALTER COLUMN retention_days SET DEFAULT 2555;
+
+-- +goose Down
+ALTER TABLE audit_events ALTER COLUMN retention_days SET DEFAULT 1;
+```
+
+**Design Decision**: The `retention.defaultDays` config field allows operators to override the application-level default (e.g., 90 days for non-regulated environments) without changing the DB column default. The column default (2555) is the safety net for bare SQL inserts.
+
+---
+
+### 4.4 Item 4: Actor Identity Enrichment (AU-3)
+
+**Business Requirement**: BR-AUDIT-002 (user attribution), FedRAMP AU-3
+**Files Under Test**: `pkg/datastorage/server/audit_events_handler.go`, `pkg/datastorage/server/audit_events_batch_handler.go`, `pkg/datastorage/server/helpers/openapi_conversion.go`
+
+| ID | Tier | TDD Phase | Description | Expected Result |
+|----|------|-----------|-------------|-----------------|
+| UT-DS-1048-P5-040 | Unit | RED | `X-Auth-Request-User` header present → overrides body `actor_id` | Stored `actor_id` matches header |
+| UT-DS-1048-P5-041 | Unit | RED | `X-Auth-Request-User` header absent → body `actor_id` used | Stored `actor_id` matches body |
+| UT-DS-1048-P5-042 | Unit | RED | Both header and body absent → synthetic default `{category}-service` | Backward compatible |
+| UT-DS-1048-P5-043 | Unit | RED | `X-Auth-Request-User` header empty string → treated as absent | Body or synthetic used |
+| UT-DS-1048-P5-044 | Unit | GREEN | Batch endpoint: single header applies to all events | All N events get header `actor_id` |
+| UT-DS-1048-P5-045 | Unit | GREEN | `actor_type` set to `"user"` when header present, `"service"` when absent | Correct type attribution |
+| UT-DS-1048-P5-046 | Unit | REFACTOR | `ConvertAuditEventRequest` accepts `authenticatedActorID` parameter | Signature updated |
+
+**Test File**: `test/unit/datastorage/actor_enrichment_test.go` (new)
+
+#### Policy (SEC-S1 resolution)
+
+Server-side attribution from `X-Auth-Request-User` (trusted proxy header) **always overrides** client-provided `actor_id` in the request body. This prevents spoofing and satisfies FedRAMP AU-3 accountability.
+
+| Scenario | Header | Body actor\_id | Stored actor\_id | Stored actor\_type |
+|----------|--------|---------------|-----------------|-------------------|
+| Authenticated user | `user@example.com` | `other-user` | `user@example.com` | `user` |
+| Authenticated user, no body | `user@example.com` | (absent) | `user@example.com` | `user` |
+| Service-to-service | (absent) | `gateway-service` | `gateway-service` | `service` |
+| No attribution | (absent) | (absent) | `{category}-service` | `service` |
+
+---
+
+### 4.5 Item 5: PEL Recovery (AU-2)
+
+**Business Requirement**: BR-AUDIT-009, FedRAMP AU-2 (no audit event loss)
+**Files Under Test**: `pkg/datastorage/dlq/client.go`, `pkg/datastorage/server/dlq_retry_worker.go`
+
+| ID | Tier | TDD Phase | Description | Expected Result |
+|----|------|-----------|-------------|-----------------|
+| UT-DS-1048-P5-050 | Unit | RED | Two-phase startup: worker reads PEL (ID `"0"`) before `">"` | `ReadMessages` called with `"0"` first |
+| UT-DS-1048-P5-051 | Unit | RED | Worker switches to `">"` after PEL drained (empty response) | Subsequent reads use `">"` |
+| UT-DS-1048-P5-052 | Unit | RED | XAUTOCLAIM wrapper claims messages idle > `minIdleTime` | `XAUTOCLAIM` called with correct args |
+| UT-DS-1048-P5-053 | Unit | RED | Poison message (delivery count > 5) → dead-letter + XACK | `MoveToDeadLetter` called; message ACKed |
+| UT-DS-1048-P5-054 | Unit | GREEN | Janitor sweep runs every 30s (configurable) | Timer triggers claim loop |
+| UT-DS-1048-P5-055 | Unit | GREEN | Reclaimed message processed normally (retry logic) | Same path as new message after claim |
+| UT-DS-1048-P5-056 | Unit | REFACTOR | Valkey version check at startup for XAUTOCLAIM support | Log warning if < 6.2 |
+| IT-DS-1048-P5-050 | Integration | RED | Orphaned message recovered after consumer restart (real Redis) | Message processed and ACKed |
+| IT-DS-1048-P5-051 | Integration | RED | Poison message dead-lettered after max deliveries (real Redis) | Message in dead-letter stream; original ACKed |
+| IT-DS-1048-P5-052 | Integration | GREEN | PEL drain at startup processes all pending before new messages | All pre-existing pending processed first |
+
+**Test Files**:
+- `test/unit/datastorage/pel_recovery_test.go` (new)
+- `test/integration/datastorage/pel_recovery_test.go` (new)
+
+#### Design: Two-Phase Startup
+
+```
+Worker.Start():
+  1. phase = "pel_drain"
+  2. loop: ReadMessages(ctx, auditType, group, consumer, "0", count, timeout)
+     - if empty → phase = "live"; break
+     - else → process each message normally
+  3. phase = "live"
+  4. loop: ReadMessages(ctx, auditType, group, consumer, ">", count, timeout)
+     - normal retry worker behavior
+```
+
+#### Design: XAUTOCLAIM Janitor
+
+```
+Every 30s:
+  1. XAUTOCLAIM stream group consumer minIdleTime(60s) startID("0-0") COUNT 10
+  2. For each claimed message:
+     a. Check delivery count (from XPENDING or XAUTOCLAIM response)
+     b. If deliveryCount > maxDeliveries(5) → MoveToDeadLetter + XACK
+     c. Else → process normally (same as processMessage)
+```
+
+#### DLQ Client Addition
+
+```go
+func (c *Client) AutoClaimMessages(ctx context.Context, auditType, consumerGroup, consumer string,
+    minIdleTime time.Duration, startID string, count int64) ([]DLQMessage, string, error)
+```
+
+Wraps `redis.XAutoClaim` and returns claimed messages + new start ID for cursor-based pagination.
+
+---
+
+### 4.6 Item 6: Redis TLS Client (AU-9, SC-8)
+
+**Business Requirement**: FedRAMP AU-9, SC-8
+**Files Under Test**: `pkg/datastorage/config/config.go` (`RedisConfig.TLS`), `pkg/datastorage/server/server.go`
+**Operator Dependency**: [kubernaut-operator#89](https://github.com/jordigilh/kubernaut-operator/issues/89)
+
+| ID | Tier | TDD Phase | Description | Expected Result |
+|----|------|-----------|-------------|-----------------|
+| UT-DS-1048-P5-060 | Unit | RED | `RedisConfig.TLS` parsed from YAML with all fields | Config struct populated |
+| UT-DS-1048-P5-061 | Unit | RED | `TLS.Enabled = true` without cert paths → startup error | Error returned from NewServer |
+| UT-DS-1048-P5-062 | Unit | RED | `TLS.Enabled = false` → `redis.Options.TLSConfig` is nil | Plaintext connection |
+| UT-DS-1048-P5-063 | Unit | GREEN | `TLS.Enabled = true` with valid paths → `tls.Config` populated | TLSConfig has CA, cert, key |
+| UT-DS-1048-P5-064 | Unit | GREEN | `TLS.InsecureSkipVerify` propagated to `tls.Config` | Field set correctly |
+| UT-DS-1048-P5-065 | Unit | REFACTOR | Config validation: TLS enabled requires at minimum `caFile` | Validation error on missing CA |
+
+**Test File**: `test/unit/datastorage/redis_tls_test.go` (new)
+
+#### Config Addition
+
+```yaml
+redis:
+  addr: "valkey:6379"
+  dlqMaxLen: 10000
+  secretsFile: "/etc/datastorage/secrets/redis-credentials.yaml" # pre-commit:allow-sensitive
+  passwordKey: "password"
+  tls:
+    enabled: false
+    certFile: ""       # Client cert (mTLS)
+    keyFile: ""        # Client key (mTLS)
+    caFile: ""         # CA bundle to verify server
+    insecureSkipVerify: false
+```
+
+**Note**: Integration tests for actual TLS handshake require a TLS-enabled Redis/Valkey instance. This depends on operator issue #89. Until then, unit tests validate config wiring and `tls.Config` construction.
+
+---
+
+### 4.7 Item 7: DLQ Trim Alerting (AU-11)
+
+**Business Requirement**: BR-AUDIT-009, FedRAMP AU-11
+**Files Under Test**: `pkg/datastorage/dlq/client.go`, `pkg/datastorage/dlq/metrics.go`
+
+| ID | Tier | TDD Phase | Description | Expected Result |
+|----|------|-----------|-------------|-----------------|
+| UT-DS-1048-P5-070 | Unit | RED | `datastorage_dlq_stream_trim_total` counter incremented on XADD | Counter +1 per enqueue |
+| UT-DS-1048-P5-071 | Unit | RED | Counter has `stream` label (e.g., `notifications`, `audit_events`) | Labels correct |
+| UT-DS-1048-P5-072 | Unit | GREEN | Helm `dlqMaxLen` default aligned to `10000` (not `1000`) | Helm template renders 10000 |
+| UT-DS-1048-P5-073 | Unit | REFACTOR | RPO documentation added to runbook | Markdown present in docs/ |
+
+**Test File**: `test/unit/datastorage/dlq_trim_metrics_test.go` (new)
+
+#### Metric Definition
+
+```go
+var DLQStreamTrimTotal = promauto.NewCounterVec(
+    prometheus.CounterOpts{
+        Namespace: "datastorage",
+        Subsystem: "dlq",
+        Name:      "stream_xadd_total",
+        Help:      "Total XADD operations (each may trigger MAXLEN~ trim)",
+    },
+    []string{"stream"},
+)
+```
+
+**Note**: Redis does not report whether a trim actually occurred on `XADD MAXLEN ~`. The metric counts XADD operations; combined with `datastorage_dlq_depth` gauge (existing), operators can detect when depth plateaus at `maxLen` — indicating active trimming.
+
+#### RPO Documentation
+
+A new section in `docs/operations/runbooks/data-storage.md` documenting:
+- `dlqMaxLen` × avg message size = max unsynced audit data at risk
+- Alert threshold: `datastorage_dlq_depth / dlqMaxLen > 0.95` sustained for 5 minutes
+- Response: increase `dlqMaxLen`, investigate Postgres availability, check DLQ retry worker health
+
+---
+
+## 5. Test Execution Order (TDD Phases)
+
+Following RED → GREEN → REFACTOR per Kubernaut core rules.
+
+### Phase RED (write failing tests first)
+
+| Order | Test IDs | Item | Rationale |
+|-------|----------|------|-----------|
+| 1 | UT-DS-1048-P5-001..004 | Signer fail-hard | Foundation: server won't start without cert |
+| 2 | UT-DS-1048-P5-010..013 | Retention worker | Core lifecycle + safety (legal hold) |
+| 3 | UT-DS-1048-P5-020..021 | Retention default | Config alignment with ADR-034 |
+| 4 | UT-DS-1048-P5-040..043 | Actor enrichment | AU-3 identity attribution |
+| 5 | UT-DS-1048-P5-050..053 | PEL recovery | AU-2 no audit loss |
+| 6 | UT-DS-1048-P5-060..062 | Redis TLS config | AU-9 transport security |
+| 7 | UT-DS-1048-P5-070..071 | Trim metrics | AU-11 visibility |
+| 8 | IT-DS-1048-P5-010..011 | Retention integration | Real PostgreSQL purge |
+| 9 | IT-DS-1048-P5-020..021 | Retention migration | DDL verification |
+| 10 | IT-DS-1048-P5-050..052 | PEL integration | Real Redis XAUTOCLAIM |
+
+### Phase GREEN (minimal implementation to pass)
+
+| Order | Test IDs | Item |
+|-------|----------|------|
+| 1 | UT-DS-1048-P5-005..006 | Signer config wiring |
+| 2 | UT-DS-1048-P5-014..015 | Retention batch + logging |
+| 3 | UT-DS-1048-P5-044..045 | Actor batch + type |
+| 4 | UT-DS-1048-P5-054..055 | PEL janitor interval + processing |
+| 5 | UT-DS-1048-P5-063..064 | Redis TLS construction |
+| 6 | UT-DS-1048-P5-072 | Helm alignment |
+| 7 | IT-DS-1048-P5-012..013 | Retention shutdown + operations |
+| 8 | IT-DS-1048-P5-052 | PEL startup drain ordering |
+
+### Phase REFACTOR (enhance existing code)
+
+| Order | Test IDs | Item |
+|-------|----------|------|
+| 1 | UT-DS-1048-P5-007 | Dead code removal (fallback) |
+| 2 | UT-DS-1048-P5-016 | Retention operations table |
+| 3 | UT-DS-1048-P5-046 | ConvertAuditEventRequest signature |
+| 4 | UT-DS-1048-P5-056 | Valkey version check |
+| 5 | UT-DS-1048-P5-065 | TLS config validation |
+| 6 | UT-DS-1048-P5-073 | RPO documentation |
+
+---
+
+## 6. Test Infrastructure Requirements
+
+| Requirement | Status | Notes |
+|-------------|--------|-------|
+| Ginkgo/Gomega BDD framework | Available | Standard for all kubernaut tests |
+| PostgreSQL (integration) | Available | Existing `test/integration/datastorage/` infrastructure |
+| Redis/Valkey (integration) | Available | Used by existing DLQ integration tests |
+| Test certificates (unit) | Generate in test | Use `cert.GenerateSelfSigned` from `pkg/cert/` |
+| `os.MkdirTemp` for cert paths | Standard library | Signer tests write temp cert files |
+| Mock `*sql.DB` | Available | Existing `DATA-MOCK` pattern in `repository_test.go` |
+| XAUTOCLAIM support | Verify | Must confirm Valkey version >= 6.2 equivalent |
+
+---
+
+## 7. Coverage Targets
+
+| Tier | Scope | Target | Measurement |
+|------|-------|--------|-------------|
+| Unit | Signer init, retention config, actor enrichment, PEL logic, TLS config, trim metrics | >=80% | `go test -cover ./pkg/datastorage/...` |
+| Integration | Retention purge, PEL recovery, migration DDL | >=80% | `go test -cover ./test/integration/datastorage/...` |
+| All tiers merged | Phase 5 code | >=80% | Line-by-line dedup |
+
+---
+
+## 8. Compliance Sign-Off
+
+### Pre-Implementation Checklist
+
+| Requirement | Evidence | Status |
+|-------------|----------|--------|
+| All test scenarios mapped to BR/FedRAMP control | This document §4 | ✅ |
+| TDD execution order defined (RED → GREEN → REFACTOR) | This document §5 | ✅ |
+| Risk-to-test traceability complete | This document §3 | ✅ |
+| Operator dependencies tracked | Issues #89, #90 | ✅ |
+| Retention default aligned with ADR-034 | §4.3 | ✅ |
+| PEL recovery design specified | §4.5 | ✅ |
+| Actor enrichment policy documented | §4.4 | ✅ |
+
+### Post-Implementation Checklist
+
+| Requirement | Evidence | Status |
+|-------------|----------|--------|
+| All unit tests passing | `go test` output | ⬜ |
+| All integration tests passing | `go test` output | ⬜ |
+| Build succeeds (`go build ./...`) | Build output | ⬜ |
+| No lint errors (`golangci-lint run`) | Lint output | ⬜ |
+| Coverage >= 80% per tier | Coverage report | ⬜ |
+| Readiness audit confidence >= 95% | Audit document | ⬜ |
+
+### Approval
+
+| Role | Name | Date | Signature |
+|------|------|------|-----------|
+| Developer | | | ⬜ |
+| Reviewer | | | ⬜ |
+| Team Lead | | | ⬜ |
+
+---
+
+## Appendix A: Test File Locations
+
+| Test Category | Location |
+|---------------|----------|
+| Signer fail-hard (unit) | `test/unit/datastorage/signer_test.go` |
+| Retention worker (unit) | `test/unit/datastorage/retention/worker_test.go` |
+| Retention config (unit) | `test/unit/datastorage/retention/retention_test.go` (existing + extend) |
+| Actor enrichment (unit) | `test/unit/datastorage/actor_enrichment_test.go` |
+| PEL recovery (unit) | `test/unit/datastorage/pel_recovery_test.go` |
+| Redis TLS (unit) | `test/unit/datastorage/redis_tls_test.go` |
+| DLQ trim metrics (unit) | `test/unit/datastorage/dlq_trim_metrics_test.go` |
+| Retention worker (integration) | `test/integration/datastorage/retention_worker_test.go` |
+| Retention migration (integration) | `test/integration/datastorage/retention_test.go` (existing + extend) |
+| PEL recovery (integration) | `test/integration/datastorage/pel_recovery_test.go` |
+
+## Appendix B: Deferred to Later Phases
+
+| Item | Phase | Rationale |
+|------|-------|-----------|
+| PEL metrics (pending count, max idle) | Phase 7 (Observability) | SRE-H1 scope |
+| Retention Prometheus metrics (purge count, duration) | Phase 7 (Observability) | SRE-S3 scope |
+| Redis TLS integration test (real TLS handshake) | After operator#89 | Requires Valkey TLS server |
+| Doc cleanup: DD-AUDIT-003 / security-configuration.md retention inconsistencies | Phase 15 (Product docs) | PROD-M2 scope |

--- a/migrations/009_retention_default_alignment.sql
+++ b/migrations/009_retention_default_alignment.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- Migration 009: Align retention_days column default with ADR-034 (SOC 2 / ISO 27001)
+-- #1048 Phase 5 / AU-11: Migration 008 set DEFAULT 1 (minimum); restore to ADR-034 authority.
+-- Operators can override via config `retention.defaultDays` at the application level.
+ALTER TABLE audit_events ALTER COLUMN retention_days SET DEFAULT 2555;
+
+-- +goose Down
+-- Restore migration 008 default (minimum retention)
+ALTER TABLE audit_events ALTER COLUMN retention_days SET DEFAULT 1;

--- a/pkg/datastorage/config/config.go
+++ b/pkg/datastorage/config/config.go
@@ -17,6 +17,8 @@ limitations under the License.
 package config
 
 import (
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -47,10 +49,11 @@ import (
 
 // Config represents the complete Data Storage service configuration
 type Config struct {
-	Server   ServerConfig   `yaml:"server"`
-	Logging  LoggingConfig  `yaml:"logging"`
-	Database DatabaseConfig `yaml:"database"`
-	Redis    RedisConfig    `yaml:"redis"`
+	Server    ServerConfig    `yaml:"server"`
+	Logging   LoggingConfig   `yaml:"logging"`
+	Database  DatabaseConfig  `yaml:"database"`
+	Redis     RedisConfig     `yaml:"redis"`
+	Retention RetentionConfig `yaml:"retention"`
 
 	// TLSProfile selects the TLS security profile (Old/Intermediate/Modern).
 	// Issue #748: OCP-only — set by kubernaut-operator from the cluster APIServer CR.
@@ -76,6 +79,10 @@ type ServerConfig struct {
 
 	// #1048 Phase 4 / AC-4: CORS allowed origins (default: ["*"] with startup warning)
 	CORSAllowedOrigins []string `yaml:"corsAllowedOrigins,omitempty"`
+
+	// #1048 Phase 5 / AU-9: Directory containing signing certificate (tls.crt, tls.key)
+	// Default: /etc/certs. Configurable for Helm vs Kustomize path alignment.
+	SignerCertDir string `yaml:"signerCertDir,omitempty"`
 }
 
 // LoggingConfig contains logging configuration
@@ -104,6 +111,48 @@ type DatabaseConfig struct {
 	PasswordKey string `yaml:"passwordKey"` // Key name for password in secret file (e.g., "password")
 }
 
+// RedisTLSConfig selects TLS settings for Redis/Valkey client connections (#1048 Phase 5 / AU-9).
+type RedisTLSConfig struct {
+	Enabled            bool   `yaml:"enabled"`
+	CertFile           string `yaml:"certFile"`
+	KeyFile            string `yaml:"keyFile"`
+	CAFile             string `yaml:"caFile"`
+	InsecureSkipVerify bool   `yaml:"insecureSkipVerify"`
+}
+
+// BuildTLSConfig returns a tls.Config when TLS is enabled, or nil if disabled.
+func (t *RedisTLSConfig) BuildTLSConfig() (*tls.Config, error) {
+	if !t.Enabled {
+		return nil, nil
+	}
+
+	tlsConfig := &tls.Config{
+		InsecureSkipVerify: t.InsecureSkipVerify, //nolint:gosec // G402: operator-controlled flag for dev/test environments
+	}
+
+	if t.CAFile != "" {
+		caCert, err := os.ReadFile(t.CAFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read Redis CA file %s: %w", t.CAFile, err)
+		}
+		caCertPool := x509.NewCertPool()
+		if !caCertPool.AppendCertsFromPEM(caCert) {
+			return nil, fmt.Errorf("failed to parse CA certificate from %s", t.CAFile)
+		}
+		tlsConfig.RootCAs = caCertPool
+	}
+
+	if t.CertFile != "" && t.KeyFile != "" {
+		cert, err := tls.LoadX509KeyPair(t.CertFile, t.KeyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load Redis client certificate: %w", err)
+		}
+		tlsConfig.Certificates = []tls.Certificate{cert}
+	}
+
+	return tlsConfig, nil
+}
+
 // RedisConfig contains Redis configuration for DLQ
 type RedisConfig struct {
 	Addr      string `yaml:"addr"`      // e.g., "localhost:6379"
@@ -113,6 +162,46 @@ type RedisConfig struct {
 	// Secret file configuration (ADR-030 Section 6)
 	SecretsFile string `yaml:"secretsFile"` // Full path to secret file, e.g., "/etc/secrets/redis/credentials.yaml"
 	PasswordKey string `yaml:"passwordKey"` // Key name for password in secret file (e.g., "password")
+
+	TLS RedisTLSConfig `yaml:"tls"` // #1048 Phase 5 / AU-9: Redis TLS for audit data transport
+}
+
+// RetentionConfig contains retention worker configuration.
+// #1048 Phase 5 / AU-11, BR-AUDIT-009: Audit data retention enforcement.
+type RetentionConfig struct {
+	Enabled              bool   `yaml:"enabled"`              // Master switch (default: false, opt-in)
+	Interval             string `yaml:"interval"`             // How often the worker runs (default: "24h")
+	BatchSize            int    `yaml:"batchSize"`            // Max rows per DELETE batch (default: 1000)
+	DefaultDays          int    `yaml:"defaultDays"`          // Application-level default retention (default: 2555 per ADR-034)
+	PartitionDropEnabled bool   `yaml:"partitionDropEnabled"` // Whether to attempt DROP PARTITION on empty months
+}
+
+func (r *RetentionConfig) GetInterval() time.Duration {
+	if r.Interval == "" {
+		return 24 * time.Hour
+	}
+	d, err := time.ParseDuration(r.Interval)
+	if err != nil {
+		return 24 * time.Hour
+	}
+	return d
+}
+
+func (r *RetentionConfig) GetBatchSize() int {
+	if r.BatchSize <= 0 {
+		return 1000
+	}
+	return r.BatchSize
+}
+
+func (r *RetentionConfig) GetDefaultDays() int {
+	if r.DefaultDays <= 0 {
+		return 2555
+	}
+	if r.DefaultDays > 2555 {
+		return 2555
+	}
+	return r.DefaultDays
 }
 
 // LoadFromFile loads configuration from a YAML file
@@ -306,6 +395,21 @@ func (c *Config) Validate() error {
 	if c.Redis.Addr == "" {
 		return fmt.Errorf("redis address required")
 	}
+	if c.Redis.TLS.Enabled {
+		if c.Redis.TLS.CAFile == "" && !c.Redis.TLS.InsecureSkipVerify {
+			return fmt.Errorf("redis TLS enabled but no caFile specified and insecureSkipVerify is false")
+		}
+	}
+
+	// Validate retention configuration
+	if c.Retention.Interval != "" {
+		if _, err := time.ParseDuration(c.Retention.Interval); err != nil {
+			return fmt.Errorf("invalid retention interval: %w", err)
+		}
+	}
+	if c.Retention.DefaultDays < 0 {
+		return fmt.Errorf("retention defaultDays must be non-negative, got: %d", c.Retention.DefaultDays)
+	}
 
 	// Validate logging configuration (case-insensitive per Issue #875)
 	validLevels := map[string]bool{
@@ -397,10 +501,10 @@ func (c *ServerConfig) GetShutdownTimeout() time.Duration {
 // 5 MiB accommodates batch audit event requests (500 events × ~2-5 KB each).
 func (c *ServerConfig) GetMaxBodySize() int64 {
 	const (
-		mib            = 1 << 20
-		defaultSize    = 5 * mib
-		minSize        = 1 * mib
-		maxSize        = 50 * mib
+		mib         = 1 << 20
+		defaultSize = 5 * mib
+		minSize     = 1 * mib
+		maxSize     = 50 * mib
 	)
 	if c.MaxBodySize == "" {
 		return int64(defaultSize)
@@ -428,6 +532,15 @@ func (c *ServerConfig) GetCORSAllowedOrigins() []string {
 		return []string{"*"}
 	}
 	return c.CORSAllowedOrigins
+}
+
+// GetSignerCertDir returns the directory holding tls.crt/tls.key for audit export signing.
+// #1048 Phase 5 / AU-9: Defaults to /etc/certs when unset.
+func (c *ServerConfig) GetSignerCertDir() string {
+	if c.SignerCertDir == "" {
+		return "/etc/certs"
+	}
+	return c.SignerCertDir
 }
 
 // GetConnectionString returns the PostgreSQL connection string with PG-level timeouts.

--- a/pkg/datastorage/dlq/client.go
+++ b/pkg/datastorage/dlq/client.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/redis/go-redis/v9"
 
 	"github.com/jordigilh/kubernaut/pkg/audit"
@@ -81,6 +82,9 @@ type Client struct {
 	redisClient *redis.Client
 	logger      logr.Logger
 	maxLen      int64 // Maximum DLQ stream length (for capacity monitoring - Gap 3.3)
+
+	// xaddCounter is optional (#1048 Phase 5 / AU-11); nil if not wired by server wiring.
+	xaddCounter *prometheus.CounterVec
 }
 
 // AuditMessage represents a message in the DLQ.
@@ -127,6 +131,34 @@ func NewClient(redisClient *redis.Client, logger logr.Logger, maxLen int64) (*Cl
 	}, nil
 }
 
+// SetXAddCounter wires the Prometheus counter for successful XADD calls (optional).
+func (c *Client) SetXAddCounter(counter *prometheus.CounterVec) {
+	c.xaddCounter = counter
+}
+
+// xaddStreamMetricLabel maps Redis stream keys to bounded Prometheus label values (#1048 / AU-11).
+func xaddStreamMetricLabel(streamKey string) string {
+	switch streamKey {
+	case "audit:dlq:notifications":
+		return "notifications"
+	case "audit:dlq:events":
+		return "audit_events"
+	case "audit:dead-letter:notifications":
+		return "dead_letter_notifications"
+	case "audit:dead-letter:events":
+		return "dead_letter_audit_events"
+	default:
+		return "unknown"
+	}
+}
+
+func (c *Client) observeXAddSuccess(streamKey string) {
+	if c.xaddCounter == nil {
+		return
+	}
+	c.xaddCounter.WithLabelValues(xaddStreamMetricLabel(streamKey)).Inc()
+}
+
 // EnqueueNotificationAudit adds a NotificationAudit record to the DLQ.
 // This is called when the primary write to PostgreSQL fails.
 func (c *Client) EnqueueNotificationAudit(ctx context.Context, audit *models.NotificationAudit, originalError error) error {
@@ -166,6 +198,7 @@ func (c *Client) EnqueueNotificationAudit(ctx context.Context, audit *models.Not
 	if err != nil {
 		return fmt.Errorf("failed to enqueue to DLQ: %w", err)
 	}
+	c.observeXAddSuccess(streamKey)
 
 	// Gap 3.3 REFACTOR: Monitor DLQ capacity using extracted monitoring function
 	c.monitorDLQCapacity(ctx, "notifications", streamKey, "notification_audit")
@@ -215,6 +248,7 @@ func (c *Client) EnqueueAuditEvent(ctx context.Context, audit *audit.AuditEvent,
 	if err != nil {
 		return fmt.Errorf("failed to add audit event to DLQ: %w", err)
 	}
+	c.observeXAddSuccess(streamKey)
 
 	// Gap 3.3 REFACTOR: Monitor DLQ capacity using extracted monitoring function
 	c.monitorDLQCapacity(ctx, "events", streamKey, "audit_event")
@@ -329,6 +363,109 @@ func (c *Client) ReadMessages(ctx context.Context, auditType, consumerGroup, con
 	return messages, nil
 }
 
+// AutoClaimMessages reclaims messages that have been idle for longer than minIdleTime.
+// #1048 Phase 5 / AU-2: PEL recovery for stuck unprocessable messages.
+// Returns claimed messages and the next cursor ID for incremental XAUTOCLAIM sweeps (Redis next-start).
+func (c *Client) AutoClaimMessages(ctx context.Context, auditType, consumerGroup, consumer string,
+	minIdleTime time.Duration, startID string, count int64) ([]DLQMessage, string, error) {
+	streamKey := fmt.Sprintf("audit:dlq:%s", auditType)
+
+	err := c.redisClient.XGroupCreateMkStream(ctx, streamKey, consumerGroup, "0").Err()
+	if err != nil && !isConsumerGroupExistsError(err) {
+		return nil, "", fmt.Errorf("failed to ensure consumer group for XAUTOCLAIM: %w", err)
+	}
+
+	if count <= 0 {
+		count = 10
+	}
+
+	redisMsgs, nextStart, err := c.redisClient.XAutoClaim(ctx, &redis.XAutoClaimArgs{
+		Stream:   streamKey,
+		Group:    consumerGroup,
+		Consumer: consumer,
+		MinIdle:  minIdleTime,
+		Start:    startID,
+		Count:    count,
+	}).Result()
+	if err != nil {
+		return nil, "", fmt.Errorf("XAUTOCLAIM failed for stream %s: %w", streamKey, err)
+	}
+
+	var messages []DLQMessage
+	for _, msg := range redisMsgs {
+		dlqMsg, parseErr := c.parseStreamMessage(msg)
+		if parseErr != nil {
+			c.logger.Error(parseErr, "Invalid message format in PEL claim",
+				"stream", streamKey,
+				"message_id", msg.ID)
+			continue
+		}
+		messages = append(messages, *dlqMsg)
+	}
+
+	return messages, nextStart, nil
+}
+
+// ReadPendingMessages reads messages from this consumer's pending entries list (PEL).
+// Used for two-phase startup: drain pending before reading new messages.
+// Pass startID "0" (or "0-0") to read from the beginning of the consumer's pending backlog.
+//
+// Blocking: Uses non-blocking XREADGROUP (same pattern as ReadMessages with negative Block).
+func (c *Client) ReadPendingMessages(ctx context.Context, auditType, consumerGroup, consumer string,
+	count int64, startID string) ([]DLQMessage, error) {
+	streamKey := fmt.Sprintf("audit:dlq:%s", auditType)
+
+	err := c.redisClient.XGroupCreateMkStream(ctx, streamKey, consumerGroup, "0").Err()
+	if err != nil && !isConsumerGroupExistsError(err) {
+		return nil, fmt.Errorf("failed to create consumer group: %w", err)
+	}
+
+	if count <= 0 {
+		count = 10
+	}
+
+	if startID == "" {
+		startID = "0"
+	}
+
+	// Block must be negative so go-redis omits BLOCK and the call returns immediately
+	// (see redis.XReadGroup: negative Block skips the block argument).
+	const noBlock time.Duration = -1
+
+	streams, err := c.redisClient.XReadGroup(ctx, &redis.XReadGroupArgs{
+		Group:    consumerGroup,
+		Consumer: consumer,
+		Streams:  []string{streamKey, startID},
+		Count:    count,
+		Block:    noBlock,
+	}).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return nil, nil
+		}
+		if isNoGroupError(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("failed to read pending messages: %w", err)
+	}
+
+	var messages []DLQMessage
+	for _, stream := range streams {
+		for _, msg := range stream.Messages {
+			dlqMsg, parseErr := c.parseStreamMessage(msg)
+			if parseErr != nil {
+				c.logger.Error(parseErr, "Failed to unmarshal pending message",
+					"stream", streamKey,
+					"message_id", msg.ID)
+				continue
+			}
+			messages = append(messages, *dlqMsg)
+		}
+	}
+
+	return messages, nil
+}
+
 // AckMessage acknowledges a successfully processed message.
 //
 // After acknowledgment, the message is removed from the pending entries list
@@ -382,6 +519,7 @@ func (c *Client) MoveToDeadLetter(ctx context.Context, auditType string, msg *DL
 	if err != nil {
 		return fmt.Errorf("failed to write to dead letter: %w", err)
 	}
+	c.observeXAddSuccess(deadLetterKey)
 
 	// Remove from original DLQ stream
 	_, err = c.redisClient.XDel(ctx, sourceStreamKey, msg.ID).Result()
@@ -432,6 +570,7 @@ func (c *Client) IncrementRetryCount(ctx context.Context, auditType string, msg 
 	if err != nil {
 		return fmt.Errorf("failed to re-add message with incremented retry count: %w", err)
 	}
+	c.observeXAddSuccess(streamKey)
 
 	// Remove old message
 	_, err = c.redisClient.XDel(ctx, streamKey, msg.ID).Result()

--- a/pkg/datastorage/metrics/metrics.go
+++ b/pkg/datastorage/metrics/metrics.go
@@ -51,6 +51,9 @@ const (
 	// #1048 Phase 4 / BR-STORAGE-019: OpenAPI + DLQ validation failure counters
 	MetricNameValidationFailures    = "datastorage_validation_failures_total"
 	MetricNameDLQValidationFailures = "datastorage_dlq_validation_failures_total"
+
+	// #1048 Phase 5 / AU-11: XADD + MAXLEN~ trim observability (combined with DLQ depth gauge)
+	MetricNameDLQStreamXAddTotal = "datastorage_dlq_stream_xadd_total"
 )
 
 // Write operation metrics
@@ -100,6 +103,16 @@ var (
 		},
 		[]string{"audit_type", "reason"},
 	)
+
+	// #1048 Phase 5 / AU-11: Counts XADD operations that may trigger MAXLEN~ trimming.
+	// Combined with dlq_depth gauge, operators can detect active trimming.
+	DLQStreamXAddTotal = promauto.NewCounterVec(
+		prometheus.CounterOpts{
+			Name: MetricNameDLQStreamXAddTotal,
+			Help: "Total XADD operations per stream (each may trigger MAXLEN~ trim)",
+		},
+		[]string{"stream"},
+	)
 )
 
 // Audit write API metrics (GAP-10)
@@ -115,7 +128,7 @@ var (
 	//   histogram_quantile(0.95, rate(datastorage_audit_lag_seconds_bucket[5m]))
 	AuditLagSeconds = promauto.NewHistogramVec(
 		prometheus.HistogramOpts{
-			Name: MetricNameAuditLagSeconds, // DD-005 V3.0: Pattern B (full name),
+			Name:    MetricNameAuditLagSeconds, // DD-005 V3.0: Pattern B (full name),
 			Help:    "Time lag between event occurrence and audit write in seconds",
 			Buckets: prometheus.DefBuckets,
 		},
@@ -125,11 +138,12 @@ var (
 
 // Metrics Summary:
 //
-// Total Metrics: 4 (external-facing per GitHub issue #294, #1048)
+// Total Metrics: 5 (external-facing per GitHub issue #294, #1048)
 // - WriteDuration (Histogram with labels) - write operation performance
 // - AuditLagSeconds (Histogram with labels) - audit lag observability
 // - ValidationFailures (Counter with labels) - OpenAPI validation rejections (#1048)
 // - DLQValidationFailures (Counter with labels) - DLQ replay validation failures (#1048)
+// - DLQStreamXAddTotal (Counter with labels) - DLQ stream XADD / trim correlation (#1048 Phase 5)
 //
 // Performance Target: < 5% overhead
 // BR Coverage: BR-STORAGE-001, 002, 007, 008, 012, 013, 019
@@ -182,6 +196,9 @@ type Metrics struct {
 	ValidationFailures    *prometheus.CounterVec // OpenAPI middleware rejections
 	DLQValidationFailures *prometheus.CounterVec // DLQ replay validation failures
 
+	// #1048 Phase 5 / AU-11: XADD observability for MAXLEN~ trimming
+	DLQStreamXAddTotal *prometheus.CounterVec // Per-stream XADD (may trigger trimming)
+
 	// Store registry for testing
 	registry prometheus.Registerer
 }
@@ -208,6 +225,7 @@ func NewMetricsWithRegistry(namespace, subsystem string, reg prometheus.Register
 		m.WriteDuration = WriteDuration
 		m.ValidationFailures = ValidationFailures
 		m.DLQValidationFailures = DLQValidationFailures
+		m.DLQStreamXAddTotal = DLQStreamXAddTotal
 	} else {
 		// Testing: Create isolated metrics with custom registry
 		// Testing: Create isolated metrics with full names (DD-005 V3.0: Pattern B)
@@ -245,11 +263,20 @@ func NewMetricsWithRegistry(namespace, subsystem string, reg prometheus.Register
 			[]string{"audit_type", "reason"},
 		)
 
+		m.DLQStreamXAddTotal = prometheus.NewCounterVec(
+			prometheus.CounterOpts{
+				Name: MetricNameDLQStreamXAddTotal,
+				Help: "Total XADD operations per stream (each may trigger MAXLEN~ trim)",
+			},
+			[]string{"stream"},
+		)
+
 		reg.MustRegister(
 			m.AuditLagSeconds,
 			m.WriteDuration,
 			m.ValidationFailures,
 			m.DLQValidationFailures,
+			m.DLQStreamXAddTotal,
 		)
 	}
 

--- a/pkg/datastorage/retention/retention.go
+++ b/pkg/datastorage/retention/retention.go
@@ -41,6 +41,22 @@ func DefaultConfig() Config {
 	}
 }
 
+// GetInterval returns Interval or the default when unset or non-positive.
+func (c Config) GetInterval() time.Duration {
+	if c.Interval <= 0 {
+		return DefaultConfig().Interval
+	}
+	return c.Interval
+}
+
+// GetBatchSize returns BatchSize or the default when unset or non-positive.
+func (c Config) GetBatchSize() int {
+	if c.BatchSize <= 0 {
+		return DefaultConfig().BatchSize
+	}
+	return c.BatchSize
+}
+
 // MinRetentionDays is the minimum allowed retention period.
 const MinRetentionDays = 1
 
@@ -127,6 +143,16 @@ func ValidateRetentionDays(days int) error {
 const PurgeSQL = `DELETE FROM audit_events
 WHERE event_date + (retention_days * INTERVAL '1 day') < $1::DATE
   AND legal_hold = FALSE`
+
+// PurgeSQLBatched is PurgeSQL with a LIMIT clause for batched deletion.
+// Prevents long-running transactions on large tables.
+const PurgeSQLBatched = `DELETE FROM audit_events
+WHERE ctid IN (
+    SELECT ctid FROM audit_events
+    WHERE event_date + (retention_days * INTERVAL '1 day') < $1::DATE
+      AND legal_hold = FALSE
+    LIMIT $2
+)`
 
 // Clock is re-exported from the partition package for retention worker usage.
 type Clock = partition.Clock

--- a/pkg/datastorage/retention/worker.go
+++ b/pkg/datastorage/retention/worker.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2025 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retention
+
+import (
+	"context"
+	"database/sql"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+)
+
+// Worker periodically purges expired audit events from PostgreSQL.
+// BR-AUDIT-009: Retention policies for audit data.
+// Lifecycle matches DLQRetryWorker (Start/Stop).
+type Worker struct {
+	db     *sql.DB
+	config Config
+	logger logr.Logger
+	clock  Clock
+
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
+}
+
+// NewWorker creates a retention worker. Does not start automatically.
+func NewWorker(db *sql.DB, config Config, logger logr.Logger) *Worker {
+	return &Worker{
+		db:     db,
+		config: config,
+		logger: logger.WithName("retention-worker"),
+		clock:  UTCClock{},
+	}
+}
+
+// Start begins the periodic purge loop. No-op if retention is disabled.
+func (w *Worker) Start(ctx context.Context) {
+	if !w.config.Enabled {
+		w.logger.Info("Retention worker disabled (config.retention.enabled=false)")
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	workerCtx, cancel := context.WithCancel(ctx)
+	w.cancel = cancel
+
+	w.wg.Add(1)
+	go w.run(workerCtx)
+
+	w.logger.Info("Retention worker started",
+		"interval", w.config.GetInterval(),
+		"batch_size", w.config.GetBatchSize(),
+	)
+}
+
+// Stop cancels the worker and waits for completion. Safe if Start was skipped or disabled.
+func (w *Worker) Stop() {
+	if w.cancel == nil {
+		return
+	}
+	w.cancel()
+	w.wg.Wait()
+	w.cancel = nil
+	w.logger.Info("Retention worker stopped")
+}
+
+func (w *Worker) run(ctx context.Context) {
+	defer w.wg.Done()
+
+	ticker := time.NewTicker(w.config.GetInterval())
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			w.executePurge(ctx)
+		}
+	}
+}
+
+func (w *Worker) executePurge(ctx context.Context) {
+	runID := uuid.New()
+	start := time.Now()
+
+	w.logger.Info("Starting retention purge run",
+		"run_id", runID,
+		"batch_size", w.config.GetBatchSize(),
+	)
+
+	now := w.clock.Now()
+	totalDeleted := int64(0)
+
+	for {
+		result, err := w.db.ExecContext(ctx,
+			PurgeSQLBatched,
+			now,
+			w.config.GetBatchSize(),
+		)
+		if err != nil {
+			w.logger.Error(err, "Retention purge batch failed",
+				"run_id", runID,
+				"total_deleted_so_far", totalDeleted,
+			)
+			w.recordOperation(ctx, runID, totalDeleted, start, "failed", err.Error())
+			return
+		}
+
+		rowsAffected, _ := result.RowsAffected()
+		totalDeleted += rowsAffected
+
+		if rowsAffected < int64(w.config.GetBatchSize()) {
+			break
+		}
+	}
+
+	duration := time.Since(start)
+	w.logger.Info("Retention purge run completed",
+		"run_id", runID,
+		"rows_deleted", totalDeleted,
+		"duration", duration,
+	)
+
+	w.recordOperation(ctx, runID, totalDeleted, start, "completed", "")
+}
+
+func (w *Worker) recordOperation(ctx context.Context, runID uuid.UUID, rowsDeleted int64, start time.Time, status, errMsg string) {
+	duration := time.Since(start)
+	_, err := w.db.ExecContext(ctx,
+		`INSERT INTO retention_operations (run_id, rows_deleted, status, error_message, operation_start, operation_end, operation_duration_ms)
+		 VALUES ($1, $2, $3, NULLIF($4, ''), $5, $6, $7)`,
+		runID, rowsDeleted, status, errMsg, start, time.Now().UTC(), duration.Milliseconds(),
+	)
+	if err != nil {
+		w.logger.Error(err, "Failed to record retention operation",
+			"run_id", runID,
+		)
+	}
+}

--- a/pkg/datastorage/server/audit_events_batch_handler.go
+++ b/pkg/datastorage/server/audit_events_batch_handler.go
@@ -115,6 +115,8 @@ func (s *Server) handleCreateAuditEventsBatch(w http.ResponseWriter, r *http.Req
 
 	s.logger.V(1).Info("Parsing batch of audit events", "count", len(requests))
 
+	authenticatedActorID := r.Header.Get("X-Auth-Request-User")
+
 	// 3. Validate and convert ALL events BEFORE persisting any (atomic batch)
 	auditEvents := make([]*audit.AuditEvent, 0, len(requests))
 	repositoryEvents := make([]*repository.AuditEvent, 0, len(requests))
@@ -128,7 +130,7 @@ func (s *Server) handleCreateAuditEventsBatch(w http.ResponseWriter, r *http.Req
 		}
 
 		// Convert to internal type
-		internalEvent, err := helpers.ConvertAuditEventRequest(req)
+		internalEvent, err := helpers.ConvertAuditEventRequest(req, authenticatedActorID)
 		if err != nil {
 			s.logger.Info("Batch conversion failed", "index", i, "error", err)
 			response.WriteRFC7807Error(w, http.StatusBadRequest, "conversion_error", "Conversion Error", fmt.Sprintf("event at index %d: %s", i, err.Error()), s.logger)

--- a/pkg/datastorage/server/audit_events_handler.go
+++ b/pkg/datastorage/server/audit_events_handler.go
@@ -119,9 +119,10 @@ func (s *Server) handleCreateAuditEvent(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	// 3. Convert OpenAPI request to internal audit event
+	// 3. Convert OpenAPI request to internal audit event (trusted actor from oauth-proxy header)
 	s.logger.V(1).Info("Converting OpenAPI request to internal type...")
-	auditEvent, err := helpers.ConvertAuditEventRequest(req)
+	authenticatedActorID := r.Header.Get("X-Auth-Request-User")
+	auditEvent, err := helpers.ConvertAuditEventRequest(req, authenticatedActorID)
 	if err != nil {
 		s.logger.Error(err, "Failed to convert audit event request",
 			"event_type", req.EventType,

--- a/pkg/datastorage/server/dlq_retry_worker.go
+++ b/pkg/datastorage/server/dlq_retry_worker.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -53,6 +54,14 @@ import (
 // - After max retries: Move to dead letter
 //
 // ========================================
+
+// PEL recovery tuning (#1048 Phase 5 / FedRAMP AU-2). Exported for unit test contract checks.
+const (
+	PelRecoveryClaimInterval = 30 * time.Second
+	PelRecoveryMinIdleTime   = 60 * time.Second
+	PelRecoveryClaimCount    = int64(10)
+	PelRecoveryMaxDeliveries = 5
+)
 
 // backoffIntervals defines the exponential backoff schedule per DD-009.
 // After 6 retries, messages are moved to dead letter for manual investigation.
@@ -106,6 +115,9 @@ type DLQRetryWorker struct {
 	// Lifecycle: cancel func interrupts blocking Redis reads on Stop()
 	cancel context.CancelFunc
 	doneCh chan struct{}
+
+	// #1048 Phase 5 / AU-2: after first processRetryBatch, PEL backlog was drained ahead of live ">" reads.
+	pelDrained bool
 }
 
 // NewDLQRetryWorker creates a new DLQ retry worker.
@@ -141,7 +153,20 @@ func NewDLQRetryWorker(
 func (w *DLQRetryWorker) Start(ctx context.Context) {
 	ctx, cancel := context.WithCancel(ctx)
 	w.cancel = cancel
-	go w.retryLoop(ctx)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		w.retryLoop(ctx)
+	}()
+	go func() {
+		defer wg.Done()
+		w.runClaimJanitor(ctx)
+	}()
+	go func() {
+		wg.Wait()
+		close(w.doneCh)
+	}()
 	w.logger.Info("DLQ retry worker started (DD-009 V1.0)",
 		"poll_interval", w.pollInterval,
 		"max_batch_size", w.maxBatchSize,
@@ -161,8 +186,6 @@ func (w *DLQRetryWorker) Stop() {
 }
 
 func (w *DLQRetryWorker) retryLoop(ctx context.Context) {
-	defer close(w.doneCh)
-
 	ticker := time.NewTicker(w.pollInterval)
 	defer ticker.Stop()
 
@@ -181,6 +204,17 @@ func (w *DLQRetryWorker) processRetryBatch(ctx context.Context) {
 	// Process both audit types
 	auditTypes := []string{"events", "notifications"}
 
+	// Two-phase startup (AU-2): drain this consumer's PEL before reading new messages (">").
+	if !w.pelDrained {
+		for _, auditType := range auditTypes {
+			if ctx.Err() != nil {
+				return
+			}
+			w.drainPEL(ctx, auditType)
+		}
+		w.pelDrained = true
+	}
+
 	for _, auditType := range auditTypes {
 		messages, err := w.dlqClient.ReadMessages(ctx, auditType, w.consumerGroup, w.consumerName, w.maxBatchSize, -1)
 		if err != nil {
@@ -189,12 +223,99 @@ func (w *DLQRetryWorker) processRetryBatch(ctx context.Context) {
 		}
 
 		for _, msg := range messages {
-			w.processMessage(ctx, auditType, msg)
+			_ = w.processMessage(ctx, auditType, msg)
 		}
 	}
 }
 
-func (w *DLQRetryWorker) processMessage(ctx context.Context, auditType string, msg *dlq.DLQMessage) {
+func (w *DLQRetryWorker) drainPEL(ctx context.Context, auditType string) {
+	w.logger.Info("PEL drain phase: processing previously unacknowledged messages",
+		"audit_type", auditType)
+
+	const pelDrainBatch = int64(10)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		messages, err := w.dlqClient.ReadPendingMessages(ctx, auditType,
+			w.consumerGroup, w.consumerName, pelDrainBatch, "0")
+		if err != nil {
+			w.logger.Error(err, "Failed to read pending messages during PEL drain",
+				"audit_type", auditType)
+			return
+		}
+
+		if len(messages) == 0 {
+			w.logger.Info("PEL drain complete: no more pending messages",
+				"audit_type", auditType)
+			return
+		}
+
+		progressed := false
+		for i := range messages {
+			msg := messages[i]
+			if w.processMessage(ctx, auditType, &msg) {
+				progressed = true
+			}
+		}
+		if !progressed {
+			w.logger.Info("PEL drain stalled on backoff; remaining entries remain pending until idle reclaim",
+				"audit_type", auditType)
+			return
+		}
+	}
+}
+
+func (w *DLQRetryWorker) runClaimJanitor(ctx context.Context) {
+	ticker := time.NewTicker(PelRecoveryClaimInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			w.claimOrphanedMessages(ctx)
+		}
+	}
+}
+
+func (w *DLQRetryWorker) claimOrphanedMessages(ctx context.Context) {
+	auditTypes := []string{"events", "notifications"}
+
+	for _, auditType := range auditTypes {
+		messages, _, err := w.dlqClient.AutoClaimMessages(ctx, auditType,
+			w.consumerGroup, w.consumerName, PelRecoveryMinIdleTime, "0-0", PelRecoveryClaimCount)
+		if err != nil {
+			w.logger.V(1).Info("XAUTOCLAIM sweep returned error (may be empty PEL or transient Redis)",
+				"audit_type", auditType,
+				"error", err.Error())
+			continue
+		}
+
+		for i := range messages {
+			msg := messages[i]
+			if msg.AuditMessage.RetryCount > PelRecoveryMaxDeliveries {
+				w.logger.Info("Poison message detected in PEL, moving to dead letter",
+					"message_id", msg.ID,
+					"retry_count", msg.AuditMessage.RetryCount,
+					"audit_type", auditType)
+				w.moveToDeadLetter(ctx, auditType, &msg)
+				continue
+			}
+
+			w.processMessage(ctx, auditType, &msg)
+		}
+	}
+}
+
+// processMessage attempts to persist a DLQ entry. Returns false when the message was skipped
+// (for example backoff not elapsed). Returns true when a side-effect occurred (dead-letter,
+// retry increment, or ack attempted) so PEL drains avoid busy-spinning unready entries (AU-2).
+func (w *DLQRetryWorker) processMessage(ctx context.Context, auditType string, msg *dlq.DLQMessage) bool {
 	// Check if message is ready for retry (backoff period elapsed)
 	if !IsReadyForRetry(msg.AuditMessage.RetryCount, msg.AuditMessage.Timestamp) {
 		w.logger.V(1).Info("Message not ready for retry (backoff not elapsed)",
@@ -202,20 +323,20 @@ func (w *DLQRetryWorker) processMessage(ctx context.Context, auditType string, m
 			"retry_count", msg.AuditMessage.RetryCount,
 			"created_at", msg.AuditMessage.Timestamp,
 		)
-		return
+		return false
 	}
 
 	// Check if max retries exceeded
 	if msg.AuditMessage.RetryCount >= w.maxRetriesPerMsg {
 		w.moveToDeadLetter(ctx, auditType, msg)
-		return
+		return true
 	}
 
 	// Attempt write to PostgreSQL
 	err := w.writeToPostgres(ctx, auditType, msg)
 	if err != nil {
 		w.handleRetryFailure(ctx, auditType, msg, err)
-		return
+		return true
 	}
 
 	// Success - acknowledge message
@@ -224,14 +345,15 @@ func (w *DLQRetryWorker) processMessage(ctx context.Context, auditType string, m
 			"message_id", msg.ID,
 			"audit_type", auditType,
 		)
-	} else {
-		w.logger.Info("DLQ message processed successfully",
-			"message_id", msg.ID,
-			"audit_type", auditType,
-			"retry_count", msg.AuditMessage.RetryCount,
-			"correlation_id", msg.AuditMessage.CorrelationID(),
-		)
+		return true
 	}
+	w.logger.Info("DLQ message processed successfully",
+		"message_id", msg.ID,
+		"audit_type", auditType,
+		"retry_count", msg.AuditMessage.RetryCount,
+		"correlation_id", msg.AuditMessage.CorrelationID(),
+	)
+	return true
 }
 
 // writeToPostgres persists a DLQ message to PostgreSQL.

--- a/pkg/datastorage/server/helpers/openapi_conversion.go
+++ b/pkg/datastorage/server/helpers/openapi_conversion.go
@@ -46,28 +46,37 @@ import (
 // This performs the conversion from the REST API request type (OpenAPI-generated)
 // to the internal audit event type used by the audit system.
 //
+// When authenticatedActorID is non-empty (typically from oauth-proxy header
+// X-Auth-Request-User), server-side attribution overrides client body actor fields
+// to prevent spoofing (SEC-S1 / AU-3).
+//
 // Parameters:
 //   - req: OpenAPI-generated audit event request
+//   - authenticatedActorID: trusted human identity when present; otherwise use body defaults
 //
 // Returns:
 //   - *audit.AuditEvent: Internal audit event ready for storage
 //   - error: Conversion error (e.g., invalid event_data JSON)
-func ConvertAuditEventRequest(req ogenclient.AuditEventRequest) (*audit.AuditEvent, error) {
+func ConvertAuditEventRequest(req ogenclient.AuditEventRequest, authenticatedActorID string) (*audit.AuditEvent, error) {
 	// Convert event_data from map to JSON bytes
 	eventDataJSON, err := json.Marshal(req.EventData)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal event_data: %w", err)
 	}
 
-	// Extract optional fields with defaults
-	actorType := "service" // Default
-	if req.ActorType.IsSet() {
-		actorType = req.ActorType.Value
-	}
+	actorType := "service"
+	actorID := string(req.EventCategory) + "-service"
 
-	actorID := string(req.EventCategory) + "-service" // Default: category-service
-	if req.ActorID.IsSet() {
-		actorID = req.ActorID.Value
+	if authenticatedActorID != "" {
+		actorType = "user"
+		actorID = authenticatedActorID
+	} else {
+		if req.ActorType.IsSet() {
+			actorType = req.ActorType.Value
+		}
+		if req.ActorID.IsSet() {
+			actorID = req.ActorID.Value
+		}
 	}
 
 	resourceType := string(req.EventCategory) // Default

--- a/pkg/datastorage/server/server.go
+++ b/pkg/datastorage/server/server.go
@@ -37,18 +37,19 @@ import (
 
 	"github.com/jordigilh/kubernaut/pkg/audit"
 	"github.com/jordigilh/kubernaut/pkg/cert"
-	"github.com/jordigilh/kubernaut/pkg/datastorage/partition"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/config"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/dlq"
 	dsmetrics "github.com/jordigilh/kubernaut/pkg/datastorage/metrics"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/oci"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/partition"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/repository"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/retention"
 	actiontyperepo "github.com/jordigilh/kubernaut/pkg/datastorage/repository/actiontype"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/schema"
 	dsmiddleware "github.com/jordigilh/kubernaut/pkg/datastorage/server/middleware"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/validation"
 	"github.com/jordigilh/kubernaut/pkg/shared/auth"
-	"github.com/jordigilh/kubernaut/pkg/shared/hotreload"      // Issue #756: FileWatcher for cert rotation
+	"github.com/jordigilh/kubernaut/pkg/shared/hotreload"     // Issue #756: FileWatcher for cert rotation
 	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls" // Issue #493/#678: Conditional TLS
 )
 
@@ -65,9 +66,9 @@ type Server struct {
 	httpServer *http.Server
 
 	// Issue #756: TLS cert hot-reload support
-	certReloader *sharedtls.CertReloader      // nil when TLS disabled
-	certWatcher  *hotreload.FileWatcher        // nil when TLS disabled
-	tlsCertDir   string                        // cert dir for FileWatcher path
+	certReloader *sharedtls.CertReloader // nil when TLS disabled
+	certWatcher  *hotreload.FileWatcher  // nil when TLS disabled
+	tlsCertDir   string                  // cert dir for FileWatcher path
 
 	// DD-007: Graceful shutdown coordination flag
 	// Thread-safe flag for readiness probe coordination during shutdown
@@ -101,6 +102,9 @@ type Server struct {
 	// DD-009 V1.0: DLQ retry worker (background goroutine for async persistence)
 	// Processes 202 Accepted events from Redis DLQ back to PostgreSQL
 	dlqRetryWorker *DLQRetryWorker
+
+	// #1048 Phase 5 / AU-11: Retention worker (background purge)
+	retentionWorker *retention.Worker
 
 	// DD-AUTH-014: Authentication and authorization via dependency injection
 	// Authenticator validates tokens (TokenReview)
@@ -148,17 +152,17 @@ const (
 // ServerDeps groups the dependencies required to create a Data Storage HTTP server.
 // Replaces the previous long positional parameter list for clarity and extensibility.
 type ServerDeps struct {
-	DBConnStr     string            // PostgreSQL connection string
-	RedisAddr     string            // Redis address for DLQ (format: "localhost:6379")
-	RedisPassword string            // Redis password (from mounted secret)
-	Logger        logr.Logger       // Structured logger
-	AppConfig     *config.Config    // Full application configuration (includes database pool settings)
-	ServerConfig  *Config           // Server-specific configuration (port, timeouts)
-	DLQMaxLen     int64             // Maximum DLQ stream length for capacity monitoring (Gap 3.3)
+	DBConnStr     string             // PostgreSQL connection string
+	RedisAddr     string             // Redis address for DLQ (format: "localhost:6379")
+	RedisPassword string             // Redis password (from mounted secret)
+	Logger        logr.Logger        // Structured logger
+	AppConfig     *config.Config     // Full application configuration (includes database pool settings)
+	ServerConfig  *Config            // Server-specific configuration (port, timeouts)
+	DLQMaxLen     int64              // Maximum DLQ stream length for capacity monitoring (Gap 3.3)
 	Authenticator auth.Authenticator // Token validator (DD-AUTH-014)
-	Authorizer    auth.Authorizer   // Permission checker (DD-AUTH-014)
-	AuthNamespace string            // Namespace for SAR checks (DD-AUTH-014)
-	HandlerOpts   []HandlerOption   // Optional handler options (e.g. WithDependencyValidator for DD-WE-006)
+	Authorizer    auth.Authorizer    // Permission checker (DD-AUTH-014)
+	AuthNamespace string             // Namespace for SAR checks (DD-AUTH-014)
+	HandlerOpts   []HandlerOption    // Optional handler options (e.g. WithDependencyValidator for DD-WE-006)
 }
 
 // NewServer creates a new Data Storage HTTP server.
@@ -249,10 +253,19 @@ func NewServer(deps ServerDeps) (*Server, error) {
 	)
 
 	// Connect to Redis for DLQ (DD-009)
-	redisClient := redis.NewClient(&redis.Options{
+	redisOpts := &redis.Options{
 		Addr:     deps.RedisAddr,
 		Password: deps.RedisPassword, // ADR-030: Password from mounted secret
-	})
+	}
+	if appCfg.Redis.TLS.Enabled {
+		redisTLS, err := appCfg.Redis.TLS.BuildTLSConfig()
+		if err != nil {
+			return nil, fmt.Errorf("failed to configure Redis TLS: %w", err)
+		}
+		redisOpts.TLSConfig = redisTLS
+		logger.Info("Redis TLS enabled", "ca_file", appCfg.Redis.TLS.CAFile)
+	}
+	redisClient := redis.NewClient(redisOpts)
 	if err := redisClient.Ping(context.Background()).Err(); err != nil {
 		return nil, fmt.Errorf("failed to connect to Redis: %w", err)
 	}
@@ -320,6 +333,9 @@ func NewServer(deps ServerDeps) (*Server, error) {
 		"namespace", "datastorage",
 	)
 
+	// #1048 Phase 5 / AU-11: DLQ stream XADD / MAXLEN~ trim observability.
+	dlqClient.SetXAddCounter(metrics.DLQStreamXAddTotal)
+
 	// BR-STORAGE-013, BR-STORAGE-014: Create workflow catalog dependencies
 	logger.V(1).Info("Creating workflow catalog dependencies...")
 	sqlxDB := sqlx.NewDb(db, "pgx") // Wrap *sql.DB with sqlx for workflow repository
@@ -367,8 +383,9 @@ func NewServer(deps ServerDeps) (*Server, error) {
 
 	// SOC2 Day 9.1: Load signing certificate for audit exports
 	// BR-AUDIT-007: Digital signatures for tamper-evident audit exports
-	logger.V(1).Info("Loading signing certificate from /etc/certs...")
-	signer, err := loadSigningCertificate(logger)
+	signerCertDir := deps.AppConfig.Server.GetSignerCertDir()
+	logger.V(1).Info("Loading signing certificate...", "cert_dir", signerCertDir)
+	signer, err := loadSigningCertificate(logger, signerCertDir)
 	if err != nil {
 		return nil, fmt.Errorf("failed to load signing certificate: %w", err) // cleanups run via defer
 	}
@@ -394,6 +411,13 @@ func NewServer(deps ServerDeps) (*Server, error) {
 	dlqWorkerConfig.ConsumerName = fmt.Sprintf("worker-%d", os.Getpid())
 	dlqRetryWorker := NewDLQRetryWorker(dlqClient, auditEventsRepo, repo, dlqWorkerConfig, logger, metrics.DLQValidationFailures)
 
+	retentionWorker := retention.NewWorker(db, retention.Config{
+		Enabled:              appCfg.Retention.Enabled,
+		Interval:             appCfg.Retention.GetInterval(),
+		BatchSize:            appCfg.Retention.GetBatchSize(),
+		PartitionDropEnabled: appCfg.Retention.PartitionDropEnabled,
+	}, logger)
+
 	// DS-FLAKY-003 FIX: Create server with handler assigned to httpServer
 	// This allows graceful shutdown to work in both Start() and httptest scenarios
 	// Previously, handler was only assigned in Start(), causing Shutdown() to hang in tests
@@ -406,17 +430,18 @@ func NewServer(deps ServerDeps) (*Server, error) {
 			ReadTimeout:  serverCfg.ReadTimeout,
 			WriteTimeout: serverCfg.WriteTimeout,
 		},
-		repository:      repo,
-		dlqClient:       dlqClient,
-		validator:       validator,
-		auditEventsRepo:        auditEventsRepo,
-		auditStore:             auditStore,
-		metrics:         metrics,
-		signer:          signer,
-		dlqRetryWorker:           dlqRetryWorker,       // DD-009 V1.0: DLQ retry worker
-		authenticator:            deps.Authenticator, // DD-AUTH-014: Injected at runtime
-		authorizer:               deps.Authorizer,    // DD-AUTH-014: Injected at runtime
-		authNamespace:            deps.AuthNamespace,  // DD-AUTH-014: Dynamic namespace for SAR checks
+		repository:               repo,
+		dlqClient:                dlqClient,
+		validator:                validator,
+		auditEventsRepo:          auditEventsRepo,
+		auditStore:               auditStore,
+		metrics:                  metrics,
+		signer:                   signer,
+		dlqRetryWorker:           dlqRetryWorker,                                  // DD-009 V1.0: DLQ retry worker
+		retentionWorker:          retentionWorker,                                 // #1048 Phase 5 / AU-11: retention purge
+		authenticator:            deps.Authenticator,                              // DD-AUTH-014: Injected at runtime
+		authorizer:               deps.Authorizer,                                 // DD-AUTH-014: Injected at runtime
+		authNamespace:            deps.AuthNamespace,                              // DD-AUTH-014: Dynamic namespace for SAR checks
 		maxBatchSize:             defaultMaxBatchSize(appCfg.Server.MaxBatchSize), // Issue #667 / BR-STORAGE-043
 		endpointPropagationDelay: endpointRemovalPropagationDelay,
 		openapiValidator:         openapiValidator,
@@ -597,6 +622,7 @@ func (s *Server) Start() error {
 	// DD-009 V1.0: Start DLQ retry worker before accepting HTTP traffic
 	// Issue #667/M4: Use a server-scoped context instead of context.Background()
 	s.dlqRetryWorker.Start(context.Background())
+	s.retentionWorker.Start(context.Background())
 
 	// Issue #756: Start cert file watcher for hot-reload before accepting connections
 	if s.certReloader != nil {
@@ -627,8 +653,9 @@ func (s *Server) Start() error {
 //  1. Set readiness flag (Kubernetes removes pod from endpoints)
 //  2. Wait for endpoint removal propagation
 //  3. Drain in-flight HTTP connections
-//  3.5 Stop DLQ retry worker (DD-009)
+//     3.5 Stop DLQ retry worker (DD-009)
 //  4. Drain DLQ messages to PostgreSQL (DD-008)
+//  4.5. Stop retention worker (AU-11) after DLQ drain, before closing DB
 //  5. Close external resources (audit store, PostgreSQL)
 //
 // Returns a joined error if any step failed; individual step errors are
@@ -664,6 +691,9 @@ func (s *Server) Shutdown(ctx context.Context) error {
 
 	// STEP 4: Drain DLQ messages (DD-008)
 	s.shutdownStep4DrainDLQ(ctx)
+
+	// STEP 4.5: Stop retention worker before closing PostgreSQL (#1048 Phase 5 / AU-11)
+	s.retentionWorker.Stop()
 
 	// STEP 5: Close external resources (database)
 	if err := s.shutdownStep5CloseResources(); err != nil {
@@ -838,47 +868,33 @@ func (s *Server) GetDLQClient() *dlq.Client {
 // SOC2 Day 9.1: Digital signatures for audit exports
 // BR-AUDIT-007: Tamper-evident audit logs
 //
-// Certificate Location: /etc/certs/ (mounted from datastorage-signing-cert Secret)
-// - /etc/certs/tls.crt (PEM certificate)
-// - /etc/certs/tls.key (PEM private key)
+// Certificate files (under certDir, default /etc/certs from config):
+// - tls.crt (PEM certificate)
+// - tls.key (PEM private key)
 //
 // cert-manager Compatibility:
 // - Managed by Certificate CRD (deploy/data-storage/certificate.yaml)
 // - Auto-rotates 30 days before expiry
 // - Self-signed via selfsigned-issuer ClusterIssuer
 //
-// Fallback: If cert-manager not available, generate self-signed cert
-func loadSigningCertificate(logger logr.Logger) (*cert.Signer, error) {
-	certFile := "/etc/certs/tls.crt"
-	keyFile := "/etc/certs/tls.key"
+// #1048 Phase 5 / AU-9: Missing or invalid provisioning is a fatal startup error (no fallback).
+func loadSigningCertificate(logger logr.Logger, certDir string) (*cert.Signer, error) {
+	certFile := filepath.Join(certDir, "tls.crt")
+	keyFile := filepath.Join(certDir, "tls.key")
 
-	// Check if cert-manager provided certificate exists
-	_, statErr := os.Stat(certFile)
-	if os.IsNotExist(statErr) {
-		logger.Info("cert-manager certificate not found, generating self-signed certificate",
-			"cert_file", certFile)
-		return generateFallbackCertificate(logger)
+	if _, err := os.Stat(certFile); os.IsNotExist(err) {
+		return nil, fmt.Errorf("signing certificate not found at %s: cert-manager Certificate must be provisioned (AU-9)", certFile)
 	}
 
-	// Check if key file exists
 	if _, err := os.Stat(keyFile); os.IsNotExist(err) {
-		logger.Info("cert-manager key file not found, generating self-signed certificate",
-			"key_file", keyFile)
-		return generateFallbackCertificate(logger)
+		return nil, fmt.Errorf("signing key not found at %s: cert-manager Certificate must be provisioned (AU-9)", keyFile)
 	}
 
-	// Load certificate from cert-manager Secret
 	tlsCert, err := tls.LoadX509KeyPair(certFile, keyFile)
 	if err != nil {
-		// Fallback to self-signed if cert-manager cert is invalid/corrupt
-		logger.Info("cert-manager certificate invalid or corrupt, generating self-signed certificate",
-			"cert_file", certFile,
-			"key_file", keyFile,
-			"load_error", err.Error())
-		return generateFallbackCertificate(logger)
+		return nil, fmt.Errorf("signing certificate at %s is invalid or corrupt: %w", certFile, err)
 	}
 
-	// Create signer from TLS certificate
 	signer, err := cert.NewSignerFromTLSCertificate(&tlsCert)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create signer from certificate: %w", err)
@@ -888,40 +904,6 @@ func loadSigningCertificate(logger logr.Logger) (*cert.Signer, error) {
 		"cert_file", certFile,
 		"algorithm", signer.GetAlgorithm(),
 		"fingerprint", signer.GetCertificateFingerprint())
-
-	return signer, nil
-}
-
-// generateFallbackCertificate generates a self-signed certificate if cert-manager is unavailable
-// Used in development or when cert-manager is not yet installed
-func generateFallbackCertificate(logger logr.Logger) (*cert.Signer, error) {
-	logger.Info("Generating fallback self-signed certificate",
-		"validity", "1 year",
-		"key_size", "2048-bit RSA")
-
-	// Generate self-signed certificate
-	certPair, err := cert.GenerateSelfSigned(cert.CertificateOptions{
-		CommonName:       "data-storage-service",
-		Organization:     "Kubernaut",
-		DNSNames:         []string{"data-storage-service", "data-storage-service.kubernaut-system.svc.cluster.local"},
-		ValidityDuration: 8760 * time.Hour, // 1 year (cert-manager default)
-		KeySize:          2048,             // cert-manager default
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate fallback certificate: %w", err)
-	}
-
-	// Create signer from generated certificate
-	signer, err := cert.NewSignerFromPEM(certPair.CertPEM, certPair.KeyPEM)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create signer from generated certificate: %w", err)
-	}
-
-	logger.Info("Fallback certificate generated successfully",
-		"algorithm", signer.GetAlgorithm(),
-		"fingerprint", signer.GetCertificateFingerprint(),
-		"not_before", certPair.NotBefore,
-		"not_after", certPair.NotAfter)
 
 	return signer, nil
 }

--- a/test/integration/datastorage/actiontype_audit_test.go
+++ b/test/integration/datastorage/actiontype_audit_test.go
@@ -72,7 +72,7 @@ var _ = Describe("IT-AT-300-006: ActionType Audit Events", Label("integration", 
 		// Override correlation_id for test isolation
 		ogenEvent.CorrelationID = fmt.Sprintf("it-at-006-%s-%s", testID, uuid.New().String()[:8])
 
-		internalEvent, err := helpers.ConvertAuditEventRequest(*ogenEvent)
+		internalEvent, err := helpers.ConvertAuditEventRequest(*ogenEvent, "")
 		Expect(err).ToNot(HaveOccurred(), "ConvertAuditEventRequest should succeed")
 
 		repoEvent, err := helpers.ConvertToRepositoryAuditEvent(internalEvent)

--- a/test/integration/datastorage/batch_size_limit_test.go
+++ b/test/integration/datastorage/batch_size_limit_test.go
@@ -156,8 +156,9 @@ func newBatchLimitTestServer(maxBatchSize int) *httptest.Server {
 
 	appCfg := &dsconfig.Config{
 		Server: dsconfig.ServerConfig{
-			Port:         18090,
-			MaxBatchSize: maxBatchSize,
+			Port:          18090,
+			MaxBatchSize:  maxBatchSize,
+			SignerCertDir: datastorageIntegrationSigningCertDirOrDie(),
 		},
 		Database: dsconfig.DatabaseConfig{
 			MaxOpenConns:    5,

--- a/test/integration/datastorage/context_propagation_test.go
+++ b/test/integration/datastorage/context_propagation_test.go
@@ -175,6 +175,9 @@ func newContextPropagationTestServer() *httptest.Server {
 	redisAddr := fmt.Sprintf("%s:%s", redisHost, redisPort)
 
 	appCfg := &dsconfig.Config{
+		Server: dsconfig.ServerConfig{
+			SignerCertDir: datastorageIntegrationSigningCertDirOrDie(),
+		},
 		Database: dsconfig.DatabaseConfig{
 			MaxOpenConns:    5,
 			MaxIdleConns:    2,

--- a/test/integration/datastorage/graceful_shutdown_integration_test.go
+++ b/test/integration/datastorage/graceful_shutdown_integration_test.go
@@ -1059,6 +1059,9 @@ func createTestServerWithAccess() (*httptest.Server, *httptest.Server, *server.S
 
 	// Create application config with database pool settings
 	appCfg := &config.Config{
+		Server: config.ServerConfig{
+			SignerCertDir: datastorageIntegrationSigningCertDirOrDie(),
+		},
 		Database: config.DatabaseConfig{
 			MaxOpenConns:    25,
 			MaxIdleConns:    5,

--- a/test/integration/datastorage/suite_test.go
+++ b/test/integration/datastorage/suite_test.go
@@ -24,7 +24,9 @@ import (
 	"net/http/httptest"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -36,6 +38,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/redis/go-redis/v9"
+
+	"github.com/jordigilh/kubernaut/pkg/cert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -44,12 +48,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 
+	dsconfig "github.com/jordigilh/kubernaut/pkg/datastorage/config"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/dlq"
 	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/partition"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/repository"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/server"
-	dsconfig "github.com/jordigilh/kubernaut/pkg/datastorage/config"
 	"github.com/jordigilh/kubernaut/pkg/shared/auth"
 	"github.com/jordigilh/kubernaut/test/infrastructure"
 )
@@ -103,6 +107,10 @@ var (
 	// Shared envtest (process 1 only), stopped in AfterSuite Phase 2. Mimics Gateway integration.
 	sharedDSEnvTest   *envtest.Environment
 	sharedDSEnvConfig *rest.Config
+
+	// #1048 Phase 5 / AU-9: Per-process PEM dir for audit signing (replacing DS startup fallback certs).
+	datastorageIntegrationSigningCertDir  string
+	datastorageIntegrationSigningCertOnce sync.Once
 )
 
 // This enables parallel test execution by ensuring each test has unique data
@@ -116,6 +124,27 @@ func generateTestID() string { //nolint:unused
 // Used for audit events and other UUID-based records
 func generateTestUUID() uuid.UUID { //nolint:unused
 	return uuid.New()
+}
+
+// datastorageIntegrationSigningCertDirOrDie prepares tls.crt/tls.key once per parallel process
+// so in-process DataStorage servers satisfy BR-AUDIT-007 without relying on deprecated runtime fallbacks.
+func datastorageIntegrationSigningCertDirOrDie() string {
+	datastorageIntegrationSigningCertOnce.Do(func() {
+		tmpDir, err := os.MkdirTemp("", "ds-int-audit-signing-*")
+		Expect(err).ToNot(HaveOccurred())
+		pair, err := cert.GenerateSelfSigned(cert.CertificateOptions{
+			CommonName:       "data-storage-integration",
+			Organization:     "Kubernaut",
+			DNSNames:         []string{"localhost"},
+			ValidityDuration: 8760 * time.Hour,
+			KeySize:          2048,
+		})
+		Expect(err).ToNot(HaveOccurred())
+		Expect(os.WriteFile(filepath.Join(tmpDir, "tls.crt"), pair.CertPEM, 0o600)).To(Succeed())
+		Expect(os.WriteFile(filepath.Join(tmpDir, "tls.key"), pair.KeyPEM, 0o600)).To(Succeed())
+		datastorageIntegrationSigningCertDir = tmpDir
+	})
+	return datastorageIntegrationSigningCertDir
 }
 
 // preflightCheck validates the test environment before running tests
@@ -832,6 +861,9 @@ func seedActionTypesViaInProcessServer() {
 	redisAddr := fmt.Sprintf("%s:%s", redisHost, redisPort)
 
 	appCfg := &dsconfig.Config{
+		Server: dsconfig.ServerConfig{
+			SignerCertDir: datastorageIntegrationSigningCertDirOrDie(),
+		},
 		Database: dsconfig.DatabaseConfig{
 			MaxOpenConns:    5,
 			MaxIdleConns:    2,

--- a/test/integration/datastorage/workflow_content_integrity_test.go
+++ b/test/integration/datastorage/workflow_content_integrity_test.go
@@ -71,6 +71,9 @@ func createIntegrityTestServer(schemaYAML string) (*httptest.Server, *server.Ser
 	redisAddr := fmt.Sprintf("%s:%s", redisHost, redisPort)
 
 	appCfg := &config.Config{
+		Server: config.ServerConfig{
+			SignerCertDir: datastorageIntegrationSigningCertDirOrDie(),
+		},
 		Database: config.DatabaseConfig{
 			MaxOpenConns:    25,
 			MaxIdleConns:    5,

--- a/test/integration/datastorage/workflow_dependency_validation_test.go
+++ b/test/integration/datastorage/workflow_dependency_validation_test.go
@@ -153,6 +153,9 @@ func createDepTestServer(schemaYAML string) (*httptest.Server, *server.Server) {
 	redisAddr := fmt.Sprintf("%s:%s", redisHost, redisPort)
 
 	appCfg := &config.Config{
+		Server: config.ServerConfig{
+			SignerCertDir: datastorageIntegrationSigningCertDirOrDie(),
+		},
 		Database: config.DatabaseConfig{
 			MaxOpenConns:    25,
 			MaxIdleConns:    5,

--- a/test/integration/datastorage/workflow_deterministic_uuid_test.go
+++ b/test/integration/datastorage/workflow_deterministic_uuid_test.go
@@ -60,6 +60,9 @@ var _ = Describe("Deterministic UUID Integration (#548)", Ordered, func() {
 		redisAddr := fmt.Sprintf("%s:%s", redisHost, redisPort)
 
 		appCfg := &dsconfig.Config{
+			Server: dsconfig.ServerConfig{
+				SignerCertDir: datastorageIntegrationSigningCertDirOrDie(),
+			},
 			Database: dsconfig.DatabaseConfig{
 				MaxOpenConns:    5,
 				MaxIdleConns:    2,

--- a/test/unit/datastorage/actor_enrichment_test.go
+++ b/test/unit/datastorage/actor_enrichment_test.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2025 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastorage
+
+import (
+	"time"
+
+	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/server/helpers"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("UT-DS-1048-P5: Actor Identity Enrichment (AU-3)", func() {
+	var baseReq *ogenclient.AuditEventRequest
+
+	BeforeEach(func() {
+		baseReq = &ogenclient.AuditEventRequest{
+			Version:        "1.0",
+			EventType:      "test.event",
+			EventCategory:  ogenclient.AuditEventRequestEventCategory("remediation"),
+			EventAction:    "create",
+			EventOutcome:   ogenclient.AuditEventRequestEventOutcomeSuccess,
+			EventTimestamp: time.Now().UTC().Truncate(time.Millisecond),
+			CorrelationID:  "corr-enrichment-test",
+			EventData:        ogenclient.AuditEventRequestEventData{},
+		}
+	})
+
+	Describe("UT-DS-1048-P5-040: Header present overrides body actor_id", func() {
+		It("should use authenticated actor from header", func() {
+			baseReq.ActorType.SetTo("service")
+			baseReq.ActorID.SetTo("other-service")
+
+			event, err := helpers.ConvertAuditEventRequest(*baseReq, "user@example.com")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.ActorID).To(Equal("user@example.com"))
+			Expect(event.ActorType).To(Equal("user"))
+		})
+	})
+
+	Describe("UT-DS-1048-P5-041: Header absent uses body actor_id", func() {
+		It("should use body actor_id when header is absent", func() {
+			baseReq.ActorType.SetTo("service")
+			baseReq.ActorID.SetTo("gateway-service")
+
+			event, err := helpers.ConvertAuditEventRequest(*baseReq, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.ActorID).To(Equal("gateway-service"))
+			Expect(event.ActorType).To(Equal("service"))
+		})
+	})
+
+	Describe("UT-DS-1048-P5-042: Both absent uses synthetic default", func() {
+		It("should generate synthetic actor_id from category", func() {
+			event, err := helpers.ConvertAuditEventRequest(*baseReq, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.ActorID).To(Equal("remediation-service"))
+			Expect(event.ActorType).To(Equal("service"))
+		})
+	})
+
+	Describe("UT-DS-1048-P5-043: Empty header treated as absent", func() {
+		It("should treat empty header as absent", func() {
+			baseReq.ActorType.SetTo("service")
+			baseReq.ActorID.SetTo("test-actor")
+
+			event, err := helpers.ConvertAuditEventRequest(*baseReq, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.ActorID).To(Equal("test-actor"))
+			Expect(event.ActorType).To(Equal("service"))
+		})
+	})
+
+	Describe("UT-DS-1048-P5-045: actor_type set correctly", func() {
+		It("should set actor_type to 'user' when header present", func() {
+			event, err := helpers.ConvertAuditEventRequest(*baseReq, "admin@company.com")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.ActorType).To(Equal("user"))
+		})
+
+		It("should preserve actor_type from body when header absent", func() {
+			baseReq.ActorType.SetTo("external")
+			baseReq.ActorID.SetTo("aws-cloudwatch")
+
+			event, err := helpers.ConvertAuditEventRequest(*baseReq, "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(event.ActorType).To(Equal("external"))
+		})
+	})
+})

--- a/test/unit/datastorage/dlq_trim_metrics_test.go
+++ b/test/unit/datastorage/dlq_trim_metrics_test.go
@@ -1,0 +1,64 @@
+/*
+Copyright 2025 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastorage
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+
+	"github.com/jordigilh/kubernaut/pkg/datastorage/metrics"
+)
+
+// #1048 Phase 5 / AU-11 / BR-STORAGE-019: DLQ XADD vs MAXLEN~ trimming observability.
+var _ = Describe("UT-DS-1048-P5: DLQ Trim Metrics (AU-11)", func() {
+	newIsolatedMetrics := func() *metrics.Metrics {
+		reg := prometheus.NewRegistry()
+		return metrics.NewMetricsWithRegistry("datastorage", "", reg)
+	}
+
+	Describe("UT-DS-1048-P5-070: DLQStreamXAddTotal metric exists", func() {
+		It("should expose datastorage_dlq_stream_xadd_total on the Metrics bundle", func() {
+			m := newIsolatedMetrics()
+			Expect(m.DLQStreamXAddTotal).NotTo(BeNil())
+
+			var metric dto.Metric
+			err := m.DLQStreamXAddTotal.WithLabelValues("notifications").Write(&metric)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metric.GetCounter().GetValue()).To(Equal(float64(0)))
+		})
+	})
+
+	Describe("UT-DS-1048-P5-071: Counter has stream label", func() {
+		It("should separate time series per stream label", func() {
+			m := newIsolatedMetrics()
+			m.DLQStreamXAddTotal.WithLabelValues("notifications").Inc()
+			m.DLQStreamXAddTotal.WithLabelValues("audit_events").Inc()
+			m.DLQStreamXAddTotal.WithLabelValues("audit_events").Inc()
+
+			var metric dto.Metric
+			err := m.DLQStreamXAddTotal.WithLabelValues("notifications").Write(&metric)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metric.GetCounter().GetValue()).To(Equal(float64(1)))
+
+			err = m.DLQStreamXAddTotal.WithLabelValues("audit_events").Write(&metric)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metric.GetCounter().GetValue()).To(Equal(float64(2)))
+		})
+	})
+})

--- a/test/unit/datastorage/pel_recovery_test.go
+++ b/test/unit/datastorage/pel_recovery_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastorage
+
+import (
+	"time"
+
+	"github.com/jordigilh/kubernaut/pkg/datastorage/server"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("UT-DS-1048-P5: PEL Recovery (AU-2)", func() {
+	Describe("UT-DS-1048-P5-050: Two-phase startup and PEL sweep contract", func() {
+		It("should expose AU-2 PEL recovery tuning (BR-AUDIT-001)", func() {
+			Expect(server.PelRecoveryClaimInterval).To(Equal(30 * time.Second))
+			Expect(server.PelRecoveryMinIdleTime).To(Equal(60 * time.Second))
+			Expect(server.PelRecoveryClaimCount).To(Equal(int64(10)))
+
+			Expect(server.PelRecoveryClaimInterval > 0).To(BeTrue())
+			Expect(server.PelRecoveryMinIdleTime > 0).To(BeTrue())
+			Expect(server.PelRecoveryClaimCount).To(BeNumerically(">", 0))
+		})
+	})
+
+	Describe("UT-DS-1048-P5-053: Poison message threshold", func() {
+		It("should define PelRecoveryMaxDeliveries at 5 (BR-AUDIT-001 integration follows in IT tier)", func() {
+			Expect(server.PelRecoveryMaxDeliveries).To(Equal(5))
+		})
+	})
+})

--- a/test/unit/datastorage/redis_tls_test.go
+++ b/test/unit/datastorage/redis_tls_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastorage
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/datastorage/config"
+)
+
+var _ = Describe("UT-DS-1048-P5: Redis TLS Configuration", func() {
+	Describe("UT-DS-1048-P5-060: RedisTLSConfig parsing", func() {
+		It("should have all TLS fields accessible", func() {
+			cfg := config.RedisTLSConfig{
+				Enabled:            true,
+				CertFile:           "/etc/redis/tls.crt",
+				KeyFile:            "/etc/redis/tls.key",
+				CAFile:             "/etc/redis/ca.crt",
+				InsecureSkipVerify: false,
+			}
+			Expect(cfg.Enabled).To(BeTrue())
+			Expect(cfg.CertFile).To(Equal("/etc/redis/tls.crt"))
+			Expect(cfg.KeyFile).To(Equal("/etc/redis/tls.key"))
+			Expect(cfg.CAFile).To(Equal("/etc/redis/ca.crt"))
+			Expect(cfg.InsecureSkipVerify).To(BeFalse())
+		})
+	})
+
+	Describe("UT-DS-1048-P5-061: TLS enabled without cert paths", func() {
+		It("should fail validation when TLS enabled without caFile and insecureSkipVerify is false", func() {
+			cfg := &config.Config{
+				Server: config.ServerConfig{Port: 8080, Host: "0.0.0.0"},
+				Database: config.DatabaseConfig{
+					Host: "localhost", Port: 5432, Name: "test", User: "test",
+					StatementTimeout: "30s", LockTimeout: "10s",
+				},
+				Redis: config.RedisConfig{
+					Addr: "localhost:6379",
+					TLS: config.RedisTLSConfig{
+						Enabled: true,
+					},
+				},
+			}
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("redis TLS enabled"))
+		})
+	})
+
+	Describe("UT-DS-1048-P5-062: TLS disabled returns nil config", func() {
+		It("should return nil TLS config when disabled", func() {
+			cfg := config.RedisTLSConfig{Enabled: false}
+			tlsCfg, err := cfg.BuildTLSConfig()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tlsCfg).To(BeNil())
+		})
+	})
+
+	Describe("UT-DS-1048-P5-064: InsecureSkipVerify propagated", func() {
+		It("should propagate InsecureSkipVerify when TLS enabled", func() {
+			cfg := config.RedisTLSConfig{
+				Enabled:            true,
+				InsecureSkipVerify: true,
+			}
+			tlsCfg, err := cfg.BuildTLSConfig()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(tlsCfg).NotTo(BeNil())
+			Expect(tlsCfg.InsecureSkipVerify).To(BeTrue())
+		})
+	})
+
+	Describe("UT-DS-1048-P5-065: TLS validation passes with valid config", func() {
+		It("should pass validation when TLS enabled with caFile", func() {
+			cfg := &config.Config{
+				Server: config.ServerConfig{Port: 8080, Host: "0.0.0.0"},
+				Database: config.DatabaseConfig{
+					Host: "localhost", Port: 5432, Name: "test", User: "test",
+					StatementTimeout: "30s", LockTimeout: "10s",
+				},
+				Redis: config.RedisConfig{
+					Addr: "localhost:6379",
+					TLS: config.RedisTLSConfig{
+						Enabled: true,
+						CAFile:  "/etc/redis/ca.crt",
+					},
+				},
+			}
+			err := cfg.Validate()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should pass validation when TLS enabled with insecureSkipVerify", func() {
+			cfg := &config.Config{
+				Server: config.ServerConfig{Port: 8080, Host: "0.0.0.0"},
+				Database: config.DatabaseConfig{
+					Host: "localhost", Port: 5432, Name: "test", User: "test",
+					StatementTimeout: "30s", LockTimeout: "10s",
+				},
+				Redis: config.RedisConfig{
+					Addr: "localhost:6379",
+					TLS: config.RedisTLSConfig{
+						Enabled:            true,
+						InsecureSkipVerify: true,
+					},
+				},
+			}
+			err := cfg.Validate()
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/test/unit/datastorage/retention/worker_test.go
+++ b/test/unit/datastorage/retention/worker_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2025 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package retention_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/datastorage/retention"
+)
+
+// BR-AUDIT-009: Retention policies for audit data
+var _ = Describe("UT-DS-1048-P5: Retention Worker", func() {
+	Describe("UT-DS-1048-P5-010: Worker disabled", func() {
+		It("should not start when enabled is false", func() {
+			w := retention.NewWorker(nil, retention.Config{
+				Enabled: false,
+			}, GinkgoLogr)
+			w.Start(context.Background())
+			w.Stop()
+		})
+	})
+
+	Describe("UT-DS-1048-P5-012: Worker Stop", func() {
+		It("should stop cleanly even if never started", func() {
+			w := retention.NewWorker(nil, retention.Config{
+				Enabled: false,
+			}, GinkgoLogr)
+			w.Stop()
+		})
+	})
+
+	Describe("PurgeSQLBatched", func() {
+		It("should contain LIMIT clause", func() {
+			Expect(retention.PurgeSQLBatched).To(ContainSubstring("LIMIT"))
+		})
+
+		It("should filter legal_hold = FALSE", func() {
+			Expect(retention.PurgeSQLBatched).To(ContainSubstring("legal_hold = FALSE"))
+		})
+	})
+})

--- a/test/unit/datastorage/retention_config_test.go
+++ b/test/unit/datastorage/retention_config_test.go
@@ -1,0 +1,86 @@
+package datastorage_test
+
+import (
+	"time"
+
+	"github.com/jordigilh/kubernaut/pkg/datastorage/config"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("UT-DS-1048-P5: Retention Configuration", func() {
+	Describe("UT-DS-1048-P5-020: RetentionConfig defaults", func() {
+		It("should default interval to 24h when empty", func() {
+			cfg := config.RetentionConfig{}
+			Expect(cfg.GetInterval()).To(Equal(24 * time.Hour))
+		})
+
+		It("should default batchSize to 1000 when zero", func() {
+			cfg := config.RetentionConfig{}
+			Expect(cfg.GetBatchSize()).To(Equal(1000))
+		})
+
+		It("should default defaultDays to 2555 (ADR-034) when zero", func() {
+			cfg := config.RetentionConfig{}
+			Expect(cfg.GetDefaultDays()).To(Equal(2555))
+		})
+
+		It("should clamp defaultDays to 2555 when exceeding max", func() {
+			cfg := config.RetentionConfig{DefaultDays: 9999}
+			Expect(cfg.GetDefaultDays()).To(Equal(2555))
+		})
+	})
+
+	Describe("UT-DS-1048-P5-021: RetentionConfig custom values", func() {
+		It("should parse custom interval", func() {
+			cfg := config.RetentionConfig{Interval: "12h"}
+			Expect(cfg.GetInterval()).To(Equal(12 * time.Hour))
+		})
+
+		It("should accept custom batchSize", func() {
+			cfg := config.RetentionConfig{BatchSize: 500}
+			Expect(cfg.GetBatchSize()).To(Equal(500))
+		})
+
+		It("should accept custom defaultDays within range", func() {
+			cfg := config.RetentionConfig{DefaultDays: 90}
+			Expect(cfg.GetDefaultDays()).To(Equal(90))
+		})
+	})
+
+	Describe("Retention config validation", func() {
+		It("should reject invalid interval duration", func() {
+			cfg := &config.Config{
+				Server: config.ServerConfig{Port: 8080, Host: "0.0.0.0"},
+				Database: config.DatabaseConfig{
+					Host: "localhost", Port: 5432, Name: "test", User: "test",
+					StatementTimeout: "30s", LockTimeout: "10s",
+				},
+				Redis: config.RedisConfig{Addr: "localhost:6379"},
+				Retention: config.RetentionConfig{Interval: "not-a-duration"},
+			}
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("retention interval"))
+		})
+
+		It("should accept valid retention config", func() {
+			cfg := &config.Config{
+				Server: config.ServerConfig{Port: 8080, Host: "0.0.0.0"},
+				Database: config.DatabaseConfig{
+					Host: "localhost", Port: 5432, Name: "test", User: "test",
+					StatementTimeout: "30s", LockTimeout: "10s",
+				},
+				Redis: config.RedisConfig{Addr: "localhost:6379"},
+				Retention: config.RetentionConfig{
+					Enabled:     false,
+					Interval:    "24h",
+					BatchSize:   1000,
+					DefaultDays: 2555,
+				},
+			}
+			err := cfg.Validate()
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})

--- a/test/unit/datastorage/signer_test.go
+++ b/test/unit/datastorage/signer_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2025 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastorage_test
+
+import (
+	"github.com/jordigilh/kubernaut/pkg/datastorage/config"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("UT-DS-1048-P5: Signer Configuration", func() {
+	Describe("UT-DS-1048-P5-005: SignerCertDir config field", func() {
+		It("should parse signerCertDir from YAML", func() {
+			cfg := &config.ServerConfig{
+				SignerCertDir: "/custom/certs",
+			}
+			Expect(cfg.GetSignerCertDir()).To(Equal("/custom/certs"))
+		})
+	})
+
+	Describe("UT-DS-1048-P5-006: SignerCertDir default", func() {
+		It("should default to /etc/certs when not set", func() {
+			cfg := &config.ServerConfig{}
+			Expect(cfg.GetSignerCertDir()).To(Equal("/etc/certs"))
+		})
+
+		It("should default to /etc/certs when empty string", func() {
+			cfg := &config.ServerConfig{SignerCertDir: ""}
+			Expect(cfg.GetSignerCertDir()).To(Equal("/etc/certs"))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Phase 5 of the Data Storage Readiness Audit (#1048). Addresses FedRAMP Audit (AU) control family requirements across 7 items:

- **Item 1 (AU-9)**: Remove signer fallback to self-signed cert — fail-hard with configurable `signerCertDir`
- **Item 2 (AU-11)**: Retention worker lifecycle — background purge with batched DELETE, `retention_operations` logging
- **Item 3 (AU-11)**: Retention DEFAULT alignment — migration 009 restores 2555d (ADR-034 / SOC 2)
- **Item 4 (AU-3)**: Actor identity enrichment — `X-Auth-Request-User` overrides body `actor_id`
- **Item 5 (AU-2)**: PEL recovery — two-phase startup drain + XAUTOCLAIM janitor (30s sweep, poison dead-lettering)
- **Item 6 (AU-9, SC-8)**: Redis TLS client support — `RedisTLSConfig` with `BuildTLSConfig()` wiring
- **Item 7 (AU-11)**: DLQ trim alerting — `datastorage_dlq_stream_xadd_total` counter, fix Helm `dlqMaxLen` default

### Operator dependencies (v1.5 milestone)
- [kubernaut-operator#89](https://github.com/jordigilh/kubernaut-operator/issues/89) — Valkey server-side TLS
- [kubernaut-operator#90](https://github.com/jordigilh/kubernaut-operator/issues/90) — Signing cert volume mount

### Readiness audit
- 15-dimension audit with 95% confidence achieved pre-implementation
- Test plan: `docs/tests/1048/PHASE5_TEST_PLAN.md` (47 scenarios, 7 risks mapped)

## Test plan

- [x] `go build ./pkg/datastorage/... ./cmd/datastorage/...` — passes
- [x] `go test ./test/unit/datastorage/...` — all suites pass (10 packages)
- [x] `golangci-lint run ./pkg/datastorage/...` — 0 issues
- [x] Pre-commit anti-pattern hooks — all pass
- [x] New unit tests: signer config, retention config, Redis TLS, actor enrichment, PEL recovery, DLQ trim metrics
- [x] Integration test infrastructure updated for signer fail-hard (test cert generation)


Made with [Cursor](https://cursor.com)