### PR TITLE
fix: eliminate UT-GAP2-001 flaky test race condition

### DIFF
--- a/test/unit/kubernautagent/alignment/wrapper_gap_test.go
+++ b/test/unit/kubernautagent/alignment/wrapper_gap_test.go
@@ -42,6 +42,7 @@ var _ = Describe("GAP-2: InvestigatorWrapper inner error skips verdict — BR-AI
 			inner := &mockInvestigationRunner{result: nil, err: innerErr}
 			client := &mockLLMClient{responses: []llm.ChatResponse{
 				suspiciousResponse(), // canary
+				cleanResponse(),      // signal step (prevents fail-closed circuit breaker race)
 			}}
 			evaluator := alignment.NewEvaluator(client, alignment.EvaluatorConfig{
 				Timeout: 5 * time.Second, MaxRetries: 1,
@@ -51,6 +52,7 @@ var _ = Describe("GAP-2: InvestigatorWrapper inner error skips verdict — BR-AI
 				Evaluator:      evaluator,
 				VerdictTimeout: 5 * time.Second,
 				Logger:         logr.Discard(),
+				Mode:           config.AlignmentModeMonitor,
 			})
 			Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
## Summary

- Fixes flaky `UT-GAP2-001` (`wrapper_gap_test.go`) caused by a race between the signal-step evaluation goroutine and the circuit breaker check in enforce mode
- The mock LLM client had only one response (for the canary); the signal step evaluation exhausted it, got an empty response, fail-closed as suspicious, and triggered `onSuspicious` — cancelling `investCtx` with `ErrCircuitBreaker` before the `circuitBroken` check, which then swallowed the inner error (`err = nil`)
- Fix: use `AlignmentModeMonitor` (no circuit breaker) and supply a `cleanResponse()` for the signal step, so the test deterministically validates inner-error propagation

## Test plan

- [x] `go test -race ./test/unit/kubernautagent/alignment/... --ginkgo.focus="UT-GAP2-001"` passes consistently
- [ ] CI passes


Made with [Cursor](https://cursor.com)