### PR TITLE
chore: v1.4.0 GA release preparation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Circuit breaker enforcement** (#1076) — When shadow agent detects suspicious content in enforce mode, the primary investigation is cancelled via `context.WithCancelCause(ErrCircuitBreaker)`. New `alignmentCircuitBreakerTotal` Prometheus counter.
 - **RO alignment verdict notifications** (#1076) — Manual review notifications render shadow agent findings prominently. `alignment_check_failed` SubReason escalates to `NotificationPriorityCritical`.
 - **Shadow agent LLM token audit events** (#1059) — Per-step audit trail with shadow LLM request/response payloads and token counts for cost tracking.
+- **RCA completion audit event** (#847) — `aiagent.rca.complete` audit event with causal chain and due diligence propagation from Phase 1 to final result. Prometheus `match[]` filter added.
 - **Mock-LLM tool call scenarios** (#657) — Per-scenario `ForceText` override, `ToolCallOverride` for custom tool call bypass, `injection_configmap_read` scenario, and `CreatePoisonedConfigMap` E2E fixture for security testing.
 
 #### Notification Channels (#60, #593)
@@ -46,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CRD-aware engine registration** (#868) — Engine registration validates CRD availability; enters degraded status when required CRDs are missing.
 - **Session hardening** (#1078) — Panic recovery in investigation goroutines, two-tier TTL eviction (terminal after `ttl`, non-terminal after `maxSessionAge`), and 25-minute wall-clock investigation timeout.
 - **LLMProxy bypass fix** (C-1) — `PinDecorator` ensures `LLMProxy` is re-applied around pinned `SwappableClient` snapshots, preventing unmonitored LLM traffic.
+- **Authenticated audit actor** (#998) — Propagates the authenticated user identity into all audit events for SOC2 attribution.
+- **LLM and DS circuit breaker** (OPS-2) — Circuit breaker wrapping LLM and DataStorage HTTP clients for graceful degradation under downstream failures.
 
 #### Gateway
 
@@ -53,8 +56,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dynamic owner resolution** (#1029, #1032) — Dynamic API resource registry with existence validation. Batch-independent alert processing with FedRAMP readiness remediation.
 - **Prometheus reserved label denylist** (#1045, #1067) — `namespace` and Prometheus-reserved labels excluded from dynamic kind resolution to prevent misrouting.
 
+#### Orchestrator Resilience
+
+- **RO config hot-reload** (#835) — FileWatcher-based hot-reload for RO ConfigMap fields. Thread-safe config access via `ReloadCallback` eliminates pod restarts for runtime tuning.
+- **Cache sync readiness gating** (#852, #853) — Controller readiness probes now gate on informer cache sync completion. HTTP retry transport with exponential backoff for transient DataStorage failures.
+
 #### Infrastructure
 
+- **Inter-service TLS with security profiles** (#748) — TLS wired between all 10 services (Gateway, DataStorage, KA, RO, WE, EM, NT, SP, AuthWebhook, Operator). Configurable `tlsProfile` field selects built-in cipher/protocol profiles (Modern, Intermediate, Old). ADR-TLS-001 documents the design.
+- **SBOM and license scan** (COMP-1) — `go-licenses` SBOM and license compliance scan added to CI pipeline.
 - **NetworkPolicy templates** (#285) — 12 NetworkPolicy templates for all Kubernaut services with default-deny posture, configurable CIDRs, and per-service toggle.
 - **FileWatcher routing hot-reload** (#244) — Notification routing ConfigMap informer replaced with FileWatcher. `SLACK_WEBHOOK_URL` environment variable dependency removed.
 - **Defense-in-depth parameter filtering** (#243) — WE controller filters workflow parameters against the workflow schema with consolidated DataStorage calls.
@@ -67,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **KA config camelCase migration** (#908) — All KA YAML config fields migrated from `snake_case` to `camelCase` per ADR-030. **Breaking**: existing KA ConfigMaps must be updated.
-- **KA config restructured into 3 domains** (#908) — Config reorganized into `server`, `ai`, and `tools` concern domains. **Breaking**: config field paths have changed.
+- **KA config restructured into 3 domains** (#908) — Config reorganized into `runtime`, `ai`, and `integrations` top-level domains (`server` nested under `runtime`; `tools` nested under `integrations`). **Breaking**: config field paths have changed.
 - **KA config split** (#916) — KA config split into static ConfigMap and hot-reloadable ConfigMap. Runtime changes to AI/tool settings take effect without pod restart.
 - **Verdict label rename** (#1077) — `VerdictClean` changed from `"clean"` to `"aligned"` for API consistency. **Breaking**: Prometheus `result` label changes from `result="clean"` to `result="aligned"`.
 - **Standardized log levels** (#875) — Log level configuration standardized across all services with consistent YAML key naming.
@@ -105,11 +115,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Upgrade Notes
 
 - **Breaking: KA config camelCase** (#908, ADR-030) — All KA YAML config fields migrated from `snake_case` to `camelCase`. Update your KA ConfigMap before upgrading.
-- **Breaking: KA config restructured** (#908) — Config reorganized into `server`, `ai`, and `tools` domains. Field paths have changed (e.g., `llm_provider` → `ai.llmProvider`).
+- **Breaking: KA config restructured** (#908) — Config reorganized into `runtime`, `ai`, and `integrations` top-level domains (e.g., `llm_provider` → `ai.llmProvider`, `server` is now under `runtime`, `tools` under `integrations`).
 - **Breaking: KA config split** (#916) — KA now reads from two ConfigMaps: a static one (mounted at startup) and a hot-reloadable one (watched at runtime). Update Helm values accordingly.
 - **Breaking: Prometheus verdict label** (#1077) — Shadow agent Prometheus metric `result` label changed from `"clean"` to `"aligned"`. Update dashboard queries and alerting rules.
 - **Database migrations required** — Run v1.4 migrations before upgrading controllers. The Helm pre-upgrade hook handles this automatically.
-- **NetworkPolicy** (#285) — NetworkPolicies are now deployed for all services by default with a default-deny posture. Verify your cluster's CNI supports NetworkPolicy enforcement. Disable per-service with `networkPolicy.<service>.enabled: false`.
+- **NetworkPolicy** (#285) — NetworkPolicies are now deployed for all services by default with a default-deny posture. Verify your cluster's CNI supports NetworkPolicy enforcement. Disable per-service with `networkPolicies.<service>.enabled: false`.
 
 [1.4.0]: https://github.com/jordigilh/kubernaut/compare/v1.3.2...v1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,44 +5,113 @@ All notable changes to Kubernaut will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.4.0] - 2026-05-12
 
 ### Added
 
-- **Full-context grounding review for shadow agent** (#1096) — Added a second evaluation layer that reviews the entire RCA conversation through the shadow LLM in a single call, triggered at the RCA-to-workflow-discovery boundary. Detects distributed prompt injection that per-step isolation cannot catch (boiling frog attacks). Runs in parallel with workflow discovery for zero added latency. New `EvaluateGrounding` method on Evaluator, `StartGroundingReview`/`NotifyRCAComplete` integration points, `GroundingReview` config section, 2 new Prometheus metrics (`kubernaut_alignment_grounding_total`, `kubernaut_alignment_grounding_duration_seconds`), and 2 new audit event types (`aiagent.alignment.grounding.request`, `aiagent.alignment.grounding.response`). Gated behind `ai.alignmentCheck.groundingReview.enabled: true`. 29 unit tests covering observer integration, evaluator, config, metrics, and concurrency.
-- **Shadow agent alignment verdict schema** (#1076) — New `alignment_verdict` field on KA `IncidentResponse` (OpenAPI) and AA `AIAnalysisStatus` (CRD). Carries shadow agent verdict (`result`, `circuit_breaker_activated`, `summary`, `findings`) for ALL investigations. Enables structured reporting of shadow agent findings alongside primary LLM results.
-- **Circuit breaker for shadow agent enforcement** (#1076) — When shadow agent detects suspicious LLM content in enforce mode, the primary investigation is cancelled via `context.WithCancelCause(ErrCircuitBreaker)`. Shadow evaluations continue on parent context. New `alignmentCircuitBreakerTotal` Prometheus counter.
-- **LLMProxy bypass fix** (C-1) — `PinDecorator` on investigator ensures `LLMProxy` is re-applied around pinned `SwappableClient` snapshots, preventing unmonitored LLM traffic.
-- **RO alignment verdict notifications** (#1076) — Manual review notifications now render shadow agent findings prominently before (relegated) primary LLM RCA. Circuit breaker verdicts show `SUSPICIOUS (Circuit Breaker Activated)`. `alignment_check_failed` SubReason escalates to `NotificationPriorityCritical`.
-- **`ReviewContext` CRD fields** — `alignmentVerdict` and `circuitBreakerActivated` fields on NotificationRequest ReviewContext for routing rule support.
-- **Session panic recovery** (#1078) — Investigation goroutines now recover from panics, log stack traces, and transition to `StatusFailed`.
-- **Two-tier session TTL eviction** (#1078) — Terminal sessions (`Completed`/`Failed`) evicted after `ttl`; non-terminal (`Pending`/`Running`) after configurable `maxSessionAge` (default `2×ttl`).
-- **AA investigation timeout** (#1078) — Wall-clock cap (`DefaultMaxInvestigationDuration = 25min`) prevents unbounded investigation sessions. Transitions to `PhaseFailed` with `Reason=TransientError`.
+#### Prompt Injection Defense — Shadow Agent (#601, #1076, #1096)
+
+- **Shadow agent alignment check** (#601) — Fail-closed shadow agent evaluates every LLM tool output for prompt injection using random boundary markers, head+tail truncation, and data exfiltration detection. 82 unit tests, E2E tests with poisoned ConfigMap injection.
+- **Full-context grounding review** (#1096) — Second evaluation layer reviews the entire RCA conversation through the shadow LLM at the RCA-to-workflow boundary. Detects distributed injection (boiling frog attacks) that per-step isolation cannot catch. Runs in parallel with workflow discovery for zero added latency. Fail-closed design with `hasDuplicateGroundedKey` pre-scan for duplicate JSON key attacks. 2 new Prometheus metrics (`kubernaut_alignment_grounding_total`, `kubernaut_alignment_grounding_duration_seconds`) and 2 new audit events.
+- **Alignment verdict schema** (#1076) — New `alignment_verdict` field on KA `IncidentResponse` (OpenAPI) and AA `AIAnalysisStatus` (CRD) carrying shadow agent verdict (`result`, `circuit_breaker_activated`, `summary`, `findings`). `alignmentVerdict` and `circuitBreakerActivated` fields added to NotificationRequest `ReviewContext` for routing rule support.
+- **Circuit breaker enforcement** (#1076) — When shadow agent detects suspicious content in enforce mode, the primary investigation is cancelled via `context.WithCancelCause(ErrCircuitBreaker)`. New `alignmentCircuitBreakerTotal` Prometheus counter.
+- **RO alignment verdict notifications** (#1076) — Manual review notifications render shadow agent findings prominently. `alignment_check_failed` SubReason escalates to `NotificationPriorityCritical`.
+- **Shadow agent LLM token audit events** (#1059) — Per-step audit trail with shadow LLM request/response payloads and token counts for cost tracking.
+- **Mock-LLM tool call scenarios** (#657) — Per-scenario `ForceText` override, `ToolCallOverride` for custom tool call bypass, `injection_configmap_read` scenario, and `CreatePoisonedConfigMap` E2E fixture for security testing.
+
+#### Notification Channels (#60, #593)
+
+- **PagerDuty delivery channel** (#60) — Events API v2 delivery adapter with circuit breaker, hot-reload routing integration, and configurable URL override for E2E testability.
+- **Microsoft Teams delivery channel** (#593) — Adaptive Card delivery adapter with circuit breaker and hot-reload routing integration.
+- **Generic circuit breaker for delivery channels** (#60, #593) — Unified circuit breaker pattern replaces per-channel implementations.
+
+#### Orchestrator Enhancements
+
+- **RAR operator workflow overrides** (#594) — Operators can override AIA-selected workflows via RAR status. Validated by authwebhook (verifies override RW exists and is Active), merged by RO (`ResolveWorkflow` merge logic — RAR override takes precedence over AIA).
+- **RO Phase Handler Registry** (#666) — Refactored the 2.5k-line monolithic RO reconciler into 7 modular phase handlers (Pending, Processing, Executing, Verifying, Blocked, Analyzing, AwaitingApproval) dispatched via a `PhaseHandlerRegistry`. Removed ~705 lines of dead legacy code. ADR-062 documents the architectural decision.
+- **Dry-run mode** (#712, #736) — When `dryRun` is enabled in RO config, the pipeline stops after AI analysis — no WFE, RAR, or EA CRDs are created. RemediationRequest completes with outcome `DryRun`. `NextAllowedExecution` set for Gateway dedup suppression.
+- **Execution-time dedup classification** (#190) — RO dedup handler classifies execution-time resource collisions as `Deduplicated`. Outcome aligned with CRD enum and OpenAPI spec.
+- **DuplicateInProgress outcome inheritance** (#614) — Generalized inherited transitions so DuplicateInProgress outcomes inherit from the original WFE instead of re-running the pipeline.
+- **CRD TTL enforcement** (#265) — 24h retention TTL on terminal RemediationRequests with `RetentionConfig` and Helm-configurable `retention.period`.
+
+#### Kubernaut Agent
+
+- **Parallel tool execution** (#970) — LLM loop executes multiple tool calls concurrently when the LLM returns batched tool requests.
+- **Tool call batching directive** (#971) — Investigation prompt instructs the LLM to batch independent tool calls for reduced round-trips.
+- **apiVersion validation gate** (#1044) — Detects ambiguous CRD Kinds (multiple API groups for same Kind), triggers human review on gate exhaustion. Prevents incorrect `kubectl` operations against wrong API group.
+- **Signal annotations forwarding** (#462) — `RR.spec.signalAnnotations` forwarded through KA handler, prompt builder, and investigation template. Anti-confirmation-bias guardrail added to investigation prompt.
+- **DetectedLabels wiring** (#1052) — DetectedLabels from enrichment wired to DS catalog queries. Unified into single canonical type in `pkg/shared/types`.
+- **SA token refresh and audit auth handling** (#1055, #1056) — Custom token path constructor with 401 cache invalidation for SA token refresh. Audit 401/403 reclassified as retryable auth errors. `TokenSource` extracted for shared token cache across all callers.
+- **OAuth2 client credentials transport** (#417) — Support for enterprise LLM gateways requiring OAuth2 token acquisition with configurable custom authentication headers.
+- **CRD-aware engine registration** (#868) — Engine registration validates CRD availability; enters degraded status when required CRDs are missing.
+- **Session hardening** (#1078) — Panic recovery in investigation goroutines, two-tier TTL eviction (terminal after `ttl`, non-terminal after `maxSessionAge`), and 25-minute wall-clock investigation timeout.
+- **LLMProxy bypass fix** (C-1) — `PinDecorator` ensures `LLMProxy` is re-applied around pinned `SwappableClient` snapshots, preventing unmonitored LLM traffic.
+
+#### Gateway
+
+- **Security hardening** (#673) — 14-finding security audit remediation: 256KB body limits via `MaxBytesReader`, generic error responses (RFC 7807), `X-Auth-Request-User` header stripping, RBAC least-privilege, per-handler K8s API timeout (15s), trusted proxy RealIP middleware (fail-closed), CORS restrictive default, image tag pinning.
+- **Dynamic owner resolution** (#1029, #1032) — Dynamic API resource registry with existence validation. Batch-independent alert processing with FedRAMP readiness remediation.
+- **Prometheus reserved label denylist** (#1045, #1067) — `namespace` and Prometheus-reserved labels excluded from dynamic kind resolution to prevent misrouting.
+
+#### Infrastructure
+
+- **NetworkPolicy templates** (#285) — 12 NetworkPolicy templates for all Kubernaut services with default-deny posture, configurable CIDRs, and per-service toggle.
+- **FileWatcher routing hot-reload** (#244) — Notification routing ConfigMap informer replaced with FileWatcher. `SLACK_WEBHOOK_URL` environment variable dependency removed.
+- **Defense-in-depth parameter filtering** (#243) — WE controller filters workflow parameters against the workflow schema with consolidated DataStorage calls.
+- **Unified monitoring config** (#463) — Prometheus and AlertManager configuration unified into a single `monitoring` block for EM and KA.
+- **CRD-to-OpenAPI enum drift detection** (#838) — Automated detection of enum value mismatches between CRD Go types and OpenAPI specs.
+- **Workflow validation duration metric** — New `datastorage_workflow_validation_duration_seconds` Prometheus histogram with `phase` and `result` labels.
+- **ADR-060** — Architecture decision record documenting parallel validation patterns and error priority contract.
+- **`-race` detector enforcement** (#1073) — All E2E test targets now run with Go's race detector enabled.
 
 ### Changed
 
-- **Verdict label rename** (#1077) — `VerdictClean` constant changed from `"clean"` to `"aligned"` for OpenAPI/API consistency. **Breaking**: Prometheus `result` label changes from `result="clean"` to `result="aligned"` — update dashboard queries.
-- **Parallelized workflow validation** (#1070) — External validation checks (action-type taxonomy, OCI bundle existence, K8s dependency validation) now run concurrently during workflow registration, reducing registration latency from sum-of-three to max-of-three backend calls. Error priority contract preserved via typed-result-slot pattern (ADR-060).
-- **Concurrency cap on dependency validation** (#1070) — `ValidateDependencies` now limits concurrent K8s API calls to 10 via `errgroup.SetLimit`, preventing API server overload from schemas with many dependencies.
-- **Validation timeout budget** (#1070) — `validateExternalChecks` enforces a 10-second timeout to prevent degraded backends from consuming the full server WriteTimeout.
+- **KA config camelCase migration** (#908) — All KA YAML config fields migrated from `snake_case` to `camelCase` per ADR-030. **Breaking**: existing KA ConfigMaps must be updated.
+- **KA config restructured into 3 domains** (#908) — Config reorganized into `server`, `ai`, and `tools` concern domains. **Breaking**: config field paths have changed.
+- **KA config split** (#916) — KA config split into static ConfigMap and hot-reloadable ConfigMap. Runtime changes to AI/tool settings take effect without pod restart.
+- **Verdict label rename** (#1077) — `VerdictClean` changed from `"clean"` to `"aligned"` for API consistency. **Breaking**: Prometheus `result` label changes from `result="clean"` to `result="aligned"`.
+- **Standardized log levels** (#875) — Log level configuration standardized across all services with consistent YAML key naming.
+- **logr logging standard** (#935) — KA migrated to `go-logr/logr` per DD-005 v2.0.
+- **Parallelized workflow validation** (#1070) — External validation checks run concurrently during workflow registration. Concurrency capped at 10 via `errgroup.SetLimit` with 10-second timeout budget.
+- **gobreaker v1 to v2 migration** (#1087) — `github.com/sony/gobreaker` upgraded from v1.0.0 to v2.4.0. Generic type parameters eliminate unsafe `interface{}` type assertions. `ManagerConfig` API encapsulates gobreaker so consumers never import it directly.
+- **Generic delivery timeout** (#60, #593) — `SlackTimeout` renamed to `DeliveryTimeout` for channel-agnostic configuration.
 
 ### Fixed
 
-- **Shadow agent false positive on standard K8s/OCP metadata** (#1094) — Refined shadow agent evaluation prompt to reduce false positives on standard Kubernetes and OpenShift metadata. Narrowed classification rule #4 to target imperative agent-manipulation intent rather than incidental keyword matches. Added explicit CLEAN whitelist for well-known annotation namespaces (`kubernetes.io/*`, `kubectl.kubernetes.io/*`, `openshift.io/*`, etc.), container spec commands, probe exec commands, K8s event lifecycle messages, RBAC verbs, and registry URLs. Added 3 new CLEAN few-shot examples (OCP Secret metadata, container commands/probes, K8s events) and 6 new test payloads (5 CLEAN + 1 adversarial SUSPICIOUS).
-- **Inconclusive RR flood prevention** (#1091) — `Inconclusive` outcomes (EA confirms alert still firing, `alertScore=0`) now trigger exponential backoff and 3-strikes blocking. `completeVerificationIfNeeded` increments `ConsecutiveFailureCount` and sets `NextAllowedExecution`. `CheckConsecutiveFailures` counts `Completed+Inconclusive` as a functional failure instead of a chain-breaker. Prevents 30+ RR flood for persistent alerts. **BR-ORCH-042.6 updated**.
-- **Request body size limit** — `HandleCreateWorkflow` now caps request body at 2 MiB via `http.MaxBytesReader` to prevent memory exhaustion from oversized payloads.
-- **Deployment manifest probe paths** — Fixed `deploy/data-storage/deployment.yaml` liveness and readiness probes from `/health` to `/healthz` and `/readyz` to match the health server implementation.
-- **OpenAPI domain mismatch** (UX-2) — Fixed `kubernaut.io` → `kubernaut.ai` in RFC 7807 problem type URIs across all OpenAPI specs (5 files). Domain now matches the URIs emitted by Go code.
-- **Copyright year** (COMPAT-3) — Updated copyright headers from 2025 to 2026 in test files modified by this PR.
+- **Shadow agent false positives on K8s/OCP metadata** (#1094) — Narrowed classification rule #4 to target imperative agent-manipulation intent. Added CLEAN whitelist for well-known K8s/OCP annotation namespaces, container commands, probe commands, event messages, RBAC verbs, and registry URLs.
+- **Shadow agent evaluates raw tool output** (#1101) — Moved `SubmitToolStep` from post-summarizer to post-sanitizer so the shadow agent evaluates raw external data, not LLM-generated directive language from the summarizer. Eliminates false positives from summarized analysis content.
+- **Inconclusive RR flood prevention** (#1091) — `Inconclusive` outcomes now trigger exponential backoff and 3-strikes blocking, preventing 30+ RR flood for persistent alerts.
+- **CompletedAt on PhaseSkipped** (#612) — Skip handlers (`ResourceBusy`, `RecentlyRemediated`) now set `CompletedAt` when transitioning to `PhaseSkipped`.
+- **Enrichment NotFound exemption** (#1039) — `NotFound` errors exempt from `HardFail` for deleted resources. Deleted-resource warning surfaced and propagated to workflow result.
+- **apiVersion propagation** (#1040) — `apiVersion` propagated through the full remediation target pipeline (schema → API → CRD).
+- **SignalToPrompt label override** (#1061) — Signal prompt now prefers `target_resource` labels over enrichment labels.
+- **Multi-group/multi-version kind resolution** (#1062, #1064) — `K8sAdapter` tries all API groups for ambiguous kinds. `RESTMappings` fallback for multi-version resolution.
+- **Prometheus reserved label `namespace`** (#1067) — `namespace` added to reserved label denylist to prevent gateway misrouting.
+- **Audit data quality** (#1033) — Outcome vocabulary normalized; `workflow_name` added to audit events.
+- **Shadow agent Vertex AI provider** (#922) — Shadow agent uses `buildLLMClientFromConfig` for Vertex AI compatibility.
+- **Markdown fences in shadow responses** (#925) — Markdown code fences stripped from shadow agent evaluator responses before JSON parsing.
+- **Target-workflow alignment gate** (#934) — Phase 3 validates workflow Component scope against RCA remediation target kind.
+- **tool_result always set** (#929) — `LLMToolCallPayload` always includes `tool_result` field, preventing OpenAPI validation failures on empty tool output.
+- **Request body size limit** — `HandleCreateWorkflow` caps request body at 2 MiB via `MaxBytesReader`.
+- **Flaky UT-GAP2-001 test** (#1098) — Eliminated race condition in wrapper gap test by providing clean response for signal step and using monitor mode.
+- **Stale HAPI references in CRD docs** (#1103) — Renamed 32 stale `HAPI` → `Kubernaut Agent`/`KA` references in Go source comments across 5 `api/` type files. Regenerated `docs/generated/crds.md`.
+- **OpenAPI domain mismatch** — Fixed `kubernaut.io` → `kubernaut.ai` in RFC 7807 problem type URIs across all OpenAPI specs.
+- **Deployment manifest probe paths** — Fixed liveness/readiness probes from `/health` to `/healthz` and `/readyz`.
 
-### Added
+### Removed
 
-- **Workflow validation duration metric** — New `datastorage_workflow_validation_duration_seconds` Prometheus histogram with `phase` and `result` labels for per-phase observability.
-- **ADR-060** — Architecture decision record documenting the parallel validation patterns and error priority contract.
-- **RFC 7807 type constraint** (UX-1) — OpenAPI `RFC7807Problem.type` field now uses a `pattern` constraint (`^https://kubernaut\.ai/problems/.+`) with documented common types across all Data Storage API specs.
-- **Concurrency guidelines** (DX-5) — Added concurrency patterns section to project guidelines documenting `errgroup`, typed-result-slot, and timeout budget patterns.
-- **DD-WE-006 v2.2** (DOC-4) — Added changelog entry noting dependency validation parallelization per Issue #1070.
-- **CONTRIBUTING.md Go version** (DX-4) — Updated prerequisite Go version from 1.25.3+ to 1.25.6+ to match `go.mod`.
+- **Conversation API** (#867) — Conversational mode for Kubernaut Agent (#592) removed from v1.4; deferred to v1.5 (`development/v1.5` branch).
+
+### Upgrade Notes
+
+- **Breaking: KA config camelCase** (#908, ADR-030) — All KA YAML config fields migrated from `snake_case` to `camelCase`. Update your KA ConfigMap before upgrading.
+- **Breaking: KA config restructured** (#908) — Config reorganized into `server`, `ai`, and `tools` domains. Field paths have changed (e.g., `llm_provider` → `ai.llmProvider`).
+- **Breaking: KA config split** (#916) — KA now reads from two ConfigMaps: a static one (mounted at startup) and a hot-reloadable one (watched at runtime). Update Helm values accordingly.
+- **Breaking: Prometheus verdict label** (#1077) — Shadow agent Prometheus metric `result` label changed from `"clean"` to `"aligned"`. Update dashboard queries and alerting rules.
+- **Database migrations required** — Run v1.4 migrations before upgrading controllers. The Helm pre-upgrade hook handles this automatically.
+- **NetworkPolicy** (#285) — NetworkPolicies are now deployed for all services by default with a default-deny posture. Verify your cluster's CNI supports NetworkPolicy enforcement. Disable per-service with `networkPolicy.<service>.enabled: false`.
+
+[1.4.0]: https://github.com/jordigilh/kubernaut/compare/v1.3.2...v1.4.0
 
 ## [1.2.0] - 2026-04-06
 

--- a/api/aianalysis/v1alpha1/aianalysis_types.go
+++ b/api/aianalysis/v1alpha1/aianalysis_types.go
@@ -38,7 +38,7 @@ import (
 // AIAnalysis represents an immutable event (AI investigation).
 // Once created by RemediationOrchestrator, spec cannot be modified to ensure:
 // - Audit trail integrity (AI investigation matches original RCA request)
-// - No tampering with RCA targets post-HAPI validation
+// - No tampering with RCA targets post-KA validation
 // - No workflow selection modification after AI recommendation
 //
 // To re-analyze, delete and recreate the AIAnalysis CRD.
@@ -157,7 +157,7 @@ type SignalContextInput struct {
 	// SignalMode indicates whether this is a reactive or proactive signal.
 	// BR-AI-084: Proactive Signal Mode Prompt Strategy
 	// Copied from SignalProcessing status by RemediationOrchestrator.
-	// Used by HAPI to switch investigation prompt (RCA vs. predict & prevent).
+	// Used by Kubernaut Agent to switch investigation prompt (RCA vs. predict & prevent).
 	// +kubebuilder:validation:Enum=reactive;proactive
 	// +optional
 	SignalMode string `json:"signalMode,omitempty"`
@@ -376,14 +376,14 @@ type AIAnalysisStatus struct {
 
 	// ========================================
 	// HUMAN REVIEW SIGNALING (BR-HAPI-197)
-	// Set by HAPI when AI cannot produce reliable result
+	// Set by Kubernaut Agent when AI cannot produce reliable result
 	// ========================================
-	// True if human review required (HAPI decision: RCA incomplete/unreliable)
+	// True if human review required (KA decision: RCA incomplete/unreliable)
 	// BR-HAPI-197: Triggers NotificationRequest creation in RO
 	// BR-496 v2: Set when root_owner missing (rca_incomplete) or validation/confidence issues.
 	NeedsHumanReview bool `json:"needsHumanReview"`
 	// Reason why human review needed (when NeedsHumanReview=true)
-	// BR-HAPI-197: Maps to HAPI's human_review_reason enum values
+	// BR-HAPI-197: Maps to KA's human_review_reason enum values
 	// BR-AI-601: alignment_check_failed added for shadow agent alignment verdicts
 	// +kubebuilder:validation:Enum=workflow_not_found;image_mismatch;parameter_validation_failed;no_matching_workflows;low_confidence;llm_parsing_error;investigation_inconclusive;rca_incomplete;alignment_check_failed
 	// +optional
@@ -411,21 +411,21 @@ type AIAnalysisStatus struct {
 	// +kubebuilder:validation:MaxLength=253
 	InvestigationID string `json:"investigationId,omitempty"`
 	// NOTE: TokensUsed REMOVED (Dec 2025)
-	// Reason: LLM token tracking is HAPI's responsibility (they call the LLM)
+	// Reason: LLM token tracking is KA's responsibility (it calls the LLM)
 	// Observability: KA exposes kubernaut_agent_llm_token_usage_total Prometheus metric
-	// Correlation: Use InvestigationID to link AIAnalysis CRD to HAPI metrics
+	// Correlation: Use InvestigationID to link AIAnalysis CRD to KA metrics
 	// Design Decision: DD-COST-001 - Cost observability is provider's responsibility
 	// Investigation duration in seconds
 	// +kubebuilder:validation:Minimum=0
 	InvestigationTime int64 `json:"investigationTime,omitempty"`
 
 	// ========================================
-	// HAPI RESPONSE METADATA
+	// KA RESPONSE METADATA
 	// ========================================
 	// Non-fatal warnings from KA (e.g., low confidence)
 	Warnings []string `json:"warnings,omitempty"`
-	// ValidationAttemptsHistory contains complete history of all HAPI validation attempts
-	// Per DD-HAPI-002 v1.4: HAPI retries up to 3 times with LLM self-correction
+	// ValidationAttemptsHistory contains complete history of all KA validation attempts
+	// Per DD-HAPI-002 v1.4: KA retries up to 3 times with LLM self-correction
 	// This field provides audit trail for operator notifications and debugging
 	// +optional
 	ValidationAttemptsHistory []ValidationAttempt `json:"validationAttemptsHistory,omitempty"`
@@ -448,17 +448,17 @@ type AIAnalysisStatus struct {
 
 	// ========================================
 	// INVESTIGATION SESSION (BR-AA-HAPI-064)
-	// Tracks the async submit/poll session with HAPI
+	// Tracks the async submit/poll session with Kubernaut Agent
 	// ========================================
-	// InvestigationSession tracks the async HAPI session for submit/poll pattern
+	// InvestigationSession tracks the async KA session for submit/poll pattern
 	// +optional
 	InvestigationSession *InvestigationSession `json:"investigationSession,omitempty"`
 
 	// ========================================
 	// POST-RCA CONTEXT (ADR-056)
-	// Runtime-computed cluster characteristics from HAPI
+	// Runtime-computed cluster characteristics from Kubernaut Agent
 	// ========================================
-	// PostRCAContext holds data computed by HAPI after RCA (e.g., DetectedLabels).
+	// PostRCAContext holds data computed by Kubernaut Agent after RCA (e.g., DetectedLabels).
 	// Immutable once set — use CEL validation on the PostRCAContext type.
 	// +optional
 	PostRCAContext *PostRCAContext `json:"postRCAContext,omitempty"`
@@ -467,15 +467,15 @@ type AIAnalysisStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// PostRCAContext holds data computed by HAPI after the RCA phase.
-// ADR-056: DetectedLabels are computed at runtime by HAPI's LabelDetector
-// and returned in the HAPI response for storage in the AIAnalysis status.
+// PostRCAContext holds data computed by Kubernaut Agent after the RCA phase.
+// ADR-056: DetectedLabels are computed at runtime by KA's LabelDetector
+// and returned in the KA response for storage in the AIAnalysis status.
 // This data is used by Rego policies for approval gating (e.g., stateful
 // workload detection) and is immutable once set.
 //
 // +kubebuilder:validation:XValidation:rule="!has(oldSelf.setAt) || self == oldSelf",message="postRCAContext is immutable once setAt is populated (ADR-056)"
 type PostRCAContext struct {
-	// DetectedLabels contains cluster characteristics computed by HAPI's
+	// DetectedLabels contains cluster characteristics computed by KA's
 	// LabelDetector during get_namespaced_resource_context or get_cluster_resource_context tool invocations.
 	// +optional
 	DetectedLabels *sharedtypes.DetectedLabels `json:"detectedLabels,omitempty"`
@@ -486,11 +486,11 @@ type PostRCAContext struct {
 	SetAt *metav1.Time `json:"setAt,omitempty"`
 }
 
-// InvestigationSession tracks the async HAPI session lifecycle.
+// InvestigationSession tracks the async Kubernaut Agent session lifecycle.
 // BR-AA-HAPI-064.4: AA controller session tracking
-// BR-AA-HAPI-064.5: Session regeneration on 404 (HAPI restart)
+// BR-AA-HAPI-064.5: Session regeneration on 404 (KA restart)
 type InvestigationSession struct {
-	// Session ID returned by HAPI on submit (cleared on session loss)
+	// Session ID returned by Kubernaut Agent on submit (cleared on session loss)
 	ID string `json:"id,omitempty"`
 	// Generation counter tracking session regenerations (0 = first session, incremented on 404)
 	// +kubebuilder:validation:Minimum=0
@@ -513,7 +513,7 @@ type RootCauseAnalysis struct {
 	// Brief summary of root cause
 	Summary string `json:"summary"`
 	// Severity determined by RCA (normalized per DD-SEVERITY-001 v1.1)
-	// DD-SEVERITY-001 v1.1: Aligned with HAPI/workflow catalog (critical, high, medium, low, unknown)
+	// DD-SEVERITY-001 v1.1: Aligned with KA/workflow catalog (critical, high, medium, low, unknown)
 	// +kubebuilder:validation:Enum=critical;high;medium;low;unknown
 	Severity string `json:"severity"`
 	// Signal type determined by RCA (may differ from input)
@@ -555,7 +555,7 @@ type SelectedWorkflow struct {
 	// +kubebuilder:validation:Required
 	WorkflowID string `json:"workflowId"`
 	// Action type from DD-WORKFLOW-016 taxonomy (e.g., ScaleReplicas, RestartPod).
-	// Propagated from HAPI three-step discovery protocol to RO audit events.
+	// Propagated from KA three-step discovery protocol to RO audit events.
 	// +optional
 	ActionType string `json:"actionType,omitempty"`
 	// Workflow version
@@ -611,8 +611,8 @@ type AlternativeWorkflow struct {
 	Rationale string `json:"rationale"`
 }
 
-// ValidationAttempt contains details of a single HAPI validation attempt
-// Per DD-HAPI-002 v1.4: HAPI retries up to 3 times with LLM self-correction
+// ValidationAttempt contains details of a single KA validation attempt
+// Per DD-HAPI-002 v1.4: KA retries up to 3 times with LLM self-correction
 // Each attempt feeds validation errors back to the LLM for correction
 type ValidationAttempt struct {
 	// Attempt number (1, 2, or 3)

--- a/api/effectivenessassessment/v1alpha1/effectivenessassessment_types.go
+++ b/api/effectivenessassessment/v1alpha1/effectivenessassessment_types.go
@@ -116,7 +116,7 @@ type EffectivenessAssessmentSpec struct {
 	SignalTarget TargetResource `json:"signalTarget"`
 
 	// RemediationTarget is the resource the workflow modified.
-	// Source: AA.Status.RootCauseAnalysis.RemediationTarget (from HAPI RCA resolution).
+	// Source: AA.Status.RootCauseAnalysis.RemediationTarget (from KA RCA resolution).
 	// Used by: spec hash computation, drift detection (DD-EM-003).
 	// +kubebuilder:validation:Required
 	RemediationTarget TargetResource `json:"remediationTarget"`

--- a/api/notification/v1alpha1/notificationrequest_types.go
+++ b/api/notification/v1alpha1/notificationrequest_types.go
@@ -275,7 +275,7 @@ type ReviewContext struct {
 	// SubReason provides granular detail (e.g., "WorkflowNotFound").
 	// +optional
 	SubReason string `json:"subReason,omitempty"`
-	// HumanReviewReason from HAPI when needs_human_review=true (BR-HAPI-197).
+	// HumanReviewReason from Kubernaut Agent when needs_human_review=true (BR-HAPI-197).
 	// +optional
 	HumanReviewReason string `json:"humanReviewReason,omitempty"`
 	// RootCauseAnalysis from AIAnalysis if available.

--- a/api/signalprocessing/v1alpha1/signalprocessing_types.go
+++ b/api/signalprocessing/v1alpha1/signalprocessing_types.go
@@ -208,7 +208,7 @@ type SignalProcessingStatus struct {
 
 	// Severity determination (DD-SEVERITY-001 v1.1)
 	// Normalized severity determined by Rego policy: "critical", "high", "medium", "low", or "unknown"
-	// Aligned with HAPI/workflow catalog severity levels for consistency across platform
+	// Aligned with KA/workflow catalog severity levels for consistency across platform
 	// Enables downstream services (AIAnalysis, RemediationOrchestrator, Notification)
 	// to interpret alert urgency without understanding external severity schemes.
 	// +kubebuilder:validation:Enum=critical;high;medium;low;unknown
@@ -234,7 +234,7 @@ type SignalProcessingStatus struct {
 	// BR-SP-106: Signal Name Normalization
 	// For proactive signals (e.g., "PredictedOOMKill"), this is the base name (e.g., "OOMKilled").
 	// For reactive signals, this matches Spec.Signal.Name unchanged.
-	// This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, HAPI).
+	// This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, KA).
 	// +optional
 	SignalName string `json:"signalName,omitempty"`
 

--- a/api/workflowexecution/v1alpha1/workflowexecution_types.go
+++ b/api/workflowexecution/v1alpha1/workflowexecution_types.go
@@ -134,7 +134,7 @@ import (
 // WorkflowExecution represents an immutable event (workflow execution attempt).
 // Once created by RemediationOrchestrator, spec cannot be modified to ensure:
 // - Audit trail integrity (executed spec matches approved spec)
-// - No parameter tampering after HAPI validation
+// - No parameter tampering after KA validation
 // - No target resource changes after routing decisions
 //
 // To change execution parameters, delete and recreate the WorkflowExecution.

--- a/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
@@ -63,7 +63,7 @@ spec:
               AIAnalysis represents an immutable event (AI investigation).
               Once created by RemediationOrchestrator, spec cannot be modified to ensure:
               - Audit trail integrity (AI investigation matches original RCA request)
-              - No tampering with RCA targets post-HAPI validation
+              - No tampering with RCA targets post-KA validation
               - No workflow selection modification after AI recommendation
 
               To re-analyze, delete and recreate the AIAnalysis CRD.
@@ -271,7 +271,7 @@ spec:
                           SignalMode indicates whether this is a reactive or proactive signal.
                           BR-AI-084: Proactive Signal Mode Prompt Strategy
                           Copied from SignalProcessing status by RemediationOrchestrator.
-                          Used by HAPI to switch investigation prompt (RCA vs. predict & prevent).
+                          Used by Kubernaut Agent to switch investigation prompt (RCA vs. predict & prevent).
                         enum:
                         - reactive
                         - proactive
@@ -692,7 +692,7 @@ spec:
               humanReviewReason:
                 description: |-
                   Reason why human review needed (when NeedsHumanReview=true)
-                  BR-HAPI-197: Maps to HAPI's human_review_reason enum values
+                  BR-HAPI-197: Maps to KA's human_review_reason enum values
                   BR-AI-601: alignment_check_failed added for shadow agent alignment verdicts
                 enum:
                 - workflow_not_found
@@ -717,9 +717,9 @@ spec:
                 description: |-
                   ========================================
                   INVESTIGATION SESSION (BR-AA-HAPI-064)
-                  Tracks the async submit/poll session with HAPI
+                  Tracks the async submit/poll session with Kubernaut Agent
                   ========================================
-                  InvestigationSession tracks the async HAPI session for submit/poll pattern
+                  InvestigationSession tracks the async KA session for submit/poll pattern
                 properties:
                   createdAt:
                     description: CreatedAt timestamp when the current session was
@@ -733,8 +733,8 @@ spec:
                     minimum: 0
                     type: integer
                   id:
-                    description: Session ID returned by HAPI on submit (cleared on
-                      session loss)
+                    description: Session ID returned by Kubernaut Agent on submit
+                      (cleared on session loss)
                     type: string
                   lastPolled:
                     description: LastPolled timestamp of the last poll attempt
@@ -753,9 +753,9 @@ spec:
               investigationTime:
                 description: |-
                   NOTE: TokensUsed REMOVED (Dec 2025)
-                  Reason: LLM token tracking is HAPI's responsibility (they call the LLM)
+                  Reason: LLM token tracking is KA's responsibility (it calls the LLM)
                   Observability: KA exposes kubernaut_agent_llm_token_usage_total Prometheus metric
-                  Correlation: Use InvestigationID to link AIAnalysis CRD to HAPI metrics
+                  Correlation: Use InvestigationID to link AIAnalysis CRD to KA metrics
                   Design Decision: DD-COST-001 - Cost observability is provider's responsibility
                   Investigation duration in seconds
                 format: int64
@@ -767,9 +767,9 @@ spec:
                 description: |-
                   ========================================
                   HUMAN REVIEW SIGNALING (BR-HAPI-197)
-                  Set by HAPI when AI cannot produce reliable result
+                  Set by Kubernaut Agent when AI cannot produce reliable result
                   ========================================
-                  True if human review required (HAPI decision: RCA incomplete/unreliable)
+                  True if human review required (KA decision: RCA incomplete/unreliable)
                   BR-HAPI-197: Triggers NotificationRequest creation in RO
                   BR-496 v2: Set when root_owner missing (rca_incomplete) or validation/confidence issues.
                 type: boolean
@@ -795,14 +795,14 @@ spec:
                 description: |-
                   ========================================
                   POST-RCA CONTEXT (ADR-056)
-                  Runtime-computed cluster characteristics from HAPI
+                  Runtime-computed cluster characteristics from Kubernaut Agent
                   ========================================
-                  PostRCAContext holds data computed by HAPI after RCA (e.g., DetectedLabels).
+                  PostRCAContext holds data computed by Kubernaut Agent after RCA (e.g., DetectedLabels).
                   Immutable once set — use CEL validation on the PostRCAContext type.
                 properties:
                   detectedLabels:
                     description: |-
-                      DetectedLabels contains cluster characteristics computed by HAPI's
+                      DetectedLabels contains cluster characteristics computed by KA's
                       LabelDetector during get_namespaced_resource_context or get_cluster_resource_context tool invocations.
                     properties:
                       failedDetections:
@@ -963,7 +963,7 @@ spec:
                   severity:
                     description: |-
                       Severity determined by RCA (normalized per DD-SEVERITY-001 v1.1)
-                      DD-SEVERITY-001 v1.1: Aligned with HAPI/workflow catalog (critical, high, medium, low, unknown)
+                      DD-SEVERITY-001 v1.1: Aligned with KA/workflow catalog (critical, high, medium, low, unknown)
                     enum:
                     - critical
                     - high
@@ -992,7 +992,7 @@ spec:
                   actionType:
                     description: |-
                       Action type from DD-WORKFLOW-016 taxonomy (e.g., ScaleReplicas, RestartPod).
-                      Propagated from HAPI three-step discovery protocol to RO audit events.
+                      Propagated from KA three-step discovery protocol to RO audit events.
                     type: string
                   confidence:
                     description: Confidence score (0.0-1.0)
@@ -1081,13 +1081,13 @@ spec:
                 type: integer
               validationAttemptsHistory:
                 description: |-
-                  ValidationAttemptsHistory contains complete history of all HAPI validation attempts
-                  Per DD-HAPI-002 v1.4: HAPI retries up to 3 times with LLM self-correction
+                  ValidationAttemptsHistory contains complete history of all KA validation attempts
+                  Per DD-HAPI-002 v1.4: KA retries up to 3 times with LLM self-correction
                   This field provides audit trail for operator notifications and debugging
                 items:
                   description: |-
-                    ValidationAttempt contains details of a single HAPI validation attempt
-                    Per DD-HAPI-002 v1.4: HAPI retries up to 3 times with LLM self-correction
+                    ValidationAttempt contains details of a single KA validation attempt
+                    Per DD-HAPI-002 v1.4: KA retries up to 3 times with LLM self-correction
                     Each attempt feeds validation errors back to the LLM for correction
                   properties:
                     attempt:
@@ -1121,7 +1121,7 @@ spec:
               warnings:
                 description: |-
                   ========================================
-                  HAPI RESPONSE METADATA
+                  KA RESPONSE METADATA
                   ========================================
                   Non-fatal warnings from KA (e.g., low confidence)
                 items:

--- a/charts/kubernaut/crds/kubernaut.ai_effectivenessassessments.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_effectivenessassessments.yaml
@@ -135,7 +135,7 @@ spec:
               remediationTarget:
                 description: |-
                   RemediationTarget is the resource the workflow modified.
-                  Source: AA.Status.RootCauseAnalysis.RemediationTarget (from HAPI RCA resolution).
+                  Source: AA.Status.RootCauseAnalysis.RemediationTarget (from KA RCA resolution).
                   Used by: spec hash computation, drift detection (DD-EM-003).
                 properties:
                   apiVersion:

--- a/charts/kubernaut/crds/kubernaut.ai_notificationrequests.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_notificationrequests.yaml
@@ -181,7 +181,7 @@ spec:
                           circuit breaker terminated the investigation early.
                         type: boolean
                       humanReviewReason:
-                        description: HumanReviewReason from HAPI when needs_human_review=true
+                        description: HumanReviewReason from Kubernaut Agent when needs_human_review=true
                           (BR-HAPI-197).
                         type: string
                       reason:

--- a/charts/kubernaut/crds/kubernaut.ai_remediationrequests.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_remediationrequests.yaml
@@ -423,8 +423,9 @@ spec:
               consecutiveFailureCount:
                 description: |-
                   ConsecutiveFailureCount tracks how many times this fingerprint has failed consecutively.
-                  Updated by RO when RR transitions to Failed phase.
-                  Reset to 0 when RR completes successfully.
+                  Updated by RO when RR transitions to Failed phase or completes with Outcome=Inconclusive
+                  (EA confirms alert still firing, treated as functional failure per BR-ORCH-042.6, #1091).
+                  Reset to 0 when RR enters Verifying phase after successful remediation.
                   Reference: BR-ORCH-042
                 format: int32
                 type: integer
@@ -667,11 +668,12 @@ spec:
               nextAllowedExecution:
                 description: |-
                   NextAllowedExecution indicates when this RR can be retried after exponential backoff.
-                  Set when RR fails due to pre-execution failures (infrastructure, validation, etc.).
+                  Set when RR transitions to Failed phase (pre-execution failures) or when EA
+                  determines an Inconclusive outcome (alert still firing after remediation, #1091).
                   Implements progressive delay: 1m, 2m, 4m, 8m, capped at 10m.
                   Formula: min(Base × 2^(failures-1), Max)
                   Nil means no exponential backoff is active.
-                  Reference: DD-WE-004 (Exponential Backoff Cooldown)
+                  Reference: DD-WE-004 (Exponential Backoff Cooldown), BR-ORCH-042.6 (#1091)
                 format: date-time
                 type: string
               notificationRequestRefs:

--- a/charts/kubernaut/crds/kubernaut.ai_signalprocessings.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_signalprocessings.yaml
@@ -512,7 +512,7 @@ spec:
                 description: |-
                   Severity determination (DD-SEVERITY-001 v1.1)
                   Normalized severity determined by Rego policy: "critical", "high", "medium", "low", or "unknown"
-                  Aligned with HAPI/workflow catalog severity levels for consistency across platform
+                  Aligned with KA/workflow catalog severity levels for consistency across platform
                   Enables downstream services (AIAnalysis, RemediationOrchestrator, Notification)
                   to interpret alert urgency without understanding external severity schemes.
                 enum:
@@ -539,7 +539,7 @@ spec:
                   BR-SP-106: Signal Name Normalization
                   For proactive signals (e.g., "PredictedOOMKill"), this is the base name (e.g., "OOMKilled").
                   For reactive signals, this matches Spec.Signal.Name unchanged.
-                  This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, HAPI).
+                  This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, KA).
                 type: string
               sourceSignalName:
                 description: |-

--- a/charts/kubernaut/crds/kubernaut.ai_workflowexecutions.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_workflowexecutions.yaml
@@ -67,7 +67,7 @@ spec:
               WorkflowExecution represents an immutable event (workflow execution attempt).
               Once created by RemediationOrchestrator, spec cannot be modified to ensure:
               - Audit trail integrity (executed spec matches approved spec)
-              - No parameter tampering after HAPI validation
+              - No parameter tampering after KA validation
               - No target resource changes after routing decisions
 
               To change execution parameters, delete and recreate the WorkflowExecution.

--- a/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
@@ -63,7 +63,7 @@ spec:
               AIAnalysis represents an immutable event (AI investigation).
               Once created by RemediationOrchestrator, spec cannot be modified to ensure:
               - Audit trail integrity (AI investigation matches original RCA request)
-              - No tampering with RCA targets post-HAPI validation
+              - No tampering with RCA targets post-KA validation
               - No workflow selection modification after AI recommendation
 
               To re-analyze, delete and recreate the AIAnalysis CRD.
@@ -271,7 +271,7 @@ spec:
                           SignalMode indicates whether this is a reactive or proactive signal.
                           BR-AI-084: Proactive Signal Mode Prompt Strategy
                           Copied from SignalProcessing status by RemediationOrchestrator.
-                          Used by HAPI to switch investigation prompt (RCA vs. predict & prevent).
+                          Used by Kubernaut Agent to switch investigation prompt (RCA vs. predict & prevent).
                         enum:
                         - reactive
                         - proactive
@@ -692,7 +692,7 @@ spec:
               humanReviewReason:
                 description: |-
                   Reason why human review needed (when NeedsHumanReview=true)
-                  BR-HAPI-197: Maps to HAPI's human_review_reason enum values
+                  BR-HAPI-197: Maps to KA's human_review_reason enum values
                   BR-AI-601: alignment_check_failed added for shadow agent alignment verdicts
                 enum:
                 - workflow_not_found
@@ -717,9 +717,9 @@ spec:
                 description: |-
                   ========================================
                   INVESTIGATION SESSION (BR-AA-HAPI-064)
-                  Tracks the async submit/poll session with HAPI
+                  Tracks the async submit/poll session with Kubernaut Agent
                   ========================================
-                  InvestigationSession tracks the async HAPI session for submit/poll pattern
+                  InvestigationSession tracks the async KA session for submit/poll pattern
                 properties:
                   createdAt:
                     description: CreatedAt timestamp when the current session was
@@ -733,8 +733,8 @@ spec:
                     minimum: 0
                     type: integer
                   id:
-                    description: Session ID returned by HAPI on submit (cleared on
-                      session loss)
+                    description: Session ID returned by Kubernaut Agent on submit
+                      (cleared on session loss)
                     type: string
                   lastPolled:
                     description: LastPolled timestamp of the last poll attempt
@@ -753,9 +753,9 @@ spec:
               investigationTime:
                 description: |-
                   NOTE: TokensUsed REMOVED (Dec 2025)
-                  Reason: LLM token tracking is HAPI's responsibility (they call the LLM)
+                  Reason: LLM token tracking is KA's responsibility (it calls the LLM)
                   Observability: KA exposes kubernaut_agent_llm_token_usage_total Prometheus metric
-                  Correlation: Use InvestigationID to link AIAnalysis CRD to HAPI metrics
+                  Correlation: Use InvestigationID to link AIAnalysis CRD to KA metrics
                   Design Decision: DD-COST-001 - Cost observability is provider's responsibility
                   Investigation duration in seconds
                 format: int64
@@ -767,9 +767,9 @@ spec:
                 description: |-
                   ========================================
                   HUMAN REVIEW SIGNALING (BR-HAPI-197)
-                  Set by HAPI when AI cannot produce reliable result
+                  Set by Kubernaut Agent when AI cannot produce reliable result
                   ========================================
-                  True if human review required (HAPI decision: RCA incomplete/unreliable)
+                  True if human review required (KA decision: RCA incomplete/unreliable)
                   BR-HAPI-197: Triggers NotificationRequest creation in RO
                   BR-496 v2: Set when root_owner missing (rca_incomplete) or validation/confidence issues.
                 type: boolean
@@ -795,14 +795,14 @@ spec:
                 description: |-
                   ========================================
                   POST-RCA CONTEXT (ADR-056)
-                  Runtime-computed cluster characteristics from HAPI
+                  Runtime-computed cluster characteristics from Kubernaut Agent
                   ========================================
-                  PostRCAContext holds data computed by HAPI after RCA (e.g., DetectedLabels).
+                  PostRCAContext holds data computed by Kubernaut Agent after RCA (e.g., DetectedLabels).
                   Immutable once set — use CEL validation on the PostRCAContext type.
                 properties:
                   detectedLabels:
                     description: |-
-                      DetectedLabels contains cluster characteristics computed by HAPI's
+                      DetectedLabels contains cluster characteristics computed by KA's
                       LabelDetector during get_namespaced_resource_context or get_cluster_resource_context tool invocations.
                     properties:
                       failedDetections:
@@ -963,7 +963,7 @@ spec:
                   severity:
                     description: |-
                       Severity determined by RCA (normalized per DD-SEVERITY-001 v1.1)
-                      DD-SEVERITY-001 v1.1: Aligned with HAPI/workflow catalog (critical, high, medium, low, unknown)
+                      DD-SEVERITY-001 v1.1: Aligned with KA/workflow catalog (critical, high, medium, low, unknown)
                     enum:
                     - critical
                     - high
@@ -992,7 +992,7 @@ spec:
                   actionType:
                     description: |-
                       Action type from DD-WORKFLOW-016 taxonomy (e.g., ScaleReplicas, RestartPod).
-                      Propagated from HAPI three-step discovery protocol to RO audit events.
+                      Propagated from KA three-step discovery protocol to RO audit events.
                     type: string
                   confidence:
                     description: Confidence score (0.0-1.0)
@@ -1081,13 +1081,13 @@ spec:
                 type: integer
               validationAttemptsHistory:
                 description: |-
-                  ValidationAttemptsHistory contains complete history of all HAPI validation attempts
-                  Per DD-HAPI-002 v1.4: HAPI retries up to 3 times with LLM self-correction
+                  ValidationAttemptsHistory contains complete history of all KA validation attempts
+                  Per DD-HAPI-002 v1.4: KA retries up to 3 times with LLM self-correction
                   This field provides audit trail for operator notifications and debugging
                 items:
                   description: |-
-                    ValidationAttempt contains details of a single HAPI validation attempt
-                    Per DD-HAPI-002 v1.4: HAPI retries up to 3 times with LLM self-correction
+                    ValidationAttempt contains details of a single KA validation attempt
+                    Per DD-HAPI-002 v1.4: KA retries up to 3 times with LLM self-correction
                     Each attempt feeds validation errors back to the LLM for correction
                   properties:
                     attempt:
@@ -1121,7 +1121,7 @@ spec:
               warnings:
                 description: |-
                   ========================================
-                  HAPI RESPONSE METADATA
+                  KA RESPONSE METADATA
                   ========================================
                   Non-fatal warnings from KA (e.g., low confidence)
                 items:

--- a/charts/kubernaut/files/crds/kubernaut.ai_effectivenessassessments.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_effectivenessassessments.yaml
@@ -135,7 +135,7 @@ spec:
               remediationTarget:
                 description: |-
                   RemediationTarget is the resource the workflow modified.
-                  Source: AA.Status.RootCauseAnalysis.RemediationTarget (from HAPI RCA resolution).
+                  Source: AA.Status.RootCauseAnalysis.RemediationTarget (from KA RCA resolution).
                   Used by: spec hash computation, drift detection (DD-EM-003).
                 properties:
                   apiVersion:

--- a/charts/kubernaut/files/crds/kubernaut.ai_notificationrequests.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_notificationrequests.yaml
@@ -181,7 +181,7 @@ spec:
                           circuit breaker terminated the investigation early.
                         type: boolean
                       humanReviewReason:
-                        description: HumanReviewReason from HAPI when needs_human_review=true
+                        description: HumanReviewReason from Kubernaut Agent when needs_human_review=true
                           (BR-HAPI-197).
                         type: string
                       reason:

--- a/charts/kubernaut/files/crds/kubernaut.ai_remediationrequests.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_remediationrequests.yaml
@@ -423,8 +423,9 @@ spec:
               consecutiveFailureCount:
                 description: |-
                   ConsecutiveFailureCount tracks how many times this fingerprint has failed consecutively.
-                  Updated by RO when RR transitions to Failed phase.
-                  Reset to 0 when RR completes successfully.
+                  Updated by RO when RR transitions to Failed phase or completes with Outcome=Inconclusive
+                  (EA confirms alert still firing, treated as functional failure per BR-ORCH-042.6, #1091).
+                  Reset to 0 when RR enters Verifying phase after successful remediation.
                   Reference: BR-ORCH-042
                 format: int32
                 type: integer
@@ -667,11 +668,12 @@ spec:
               nextAllowedExecution:
                 description: |-
                   NextAllowedExecution indicates when this RR can be retried after exponential backoff.
-                  Set when RR fails due to pre-execution failures (infrastructure, validation, etc.).
+                  Set when RR transitions to Failed phase (pre-execution failures) or when EA
+                  determines an Inconclusive outcome (alert still firing after remediation, #1091).
                   Implements progressive delay: 1m, 2m, 4m, 8m, capped at 10m.
                   Formula: min(Base × 2^(failures-1), Max)
                   Nil means no exponential backoff is active.
-                  Reference: DD-WE-004 (Exponential Backoff Cooldown)
+                  Reference: DD-WE-004 (Exponential Backoff Cooldown), BR-ORCH-042.6 (#1091)
                 format: date-time
                 type: string
               notificationRequestRefs:

--- a/charts/kubernaut/files/crds/kubernaut.ai_signalprocessings.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_signalprocessings.yaml
@@ -512,7 +512,7 @@ spec:
                 description: |-
                   Severity determination (DD-SEVERITY-001 v1.1)
                   Normalized severity determined by Rego policy: "critical", "high", "medium", "low", or "unknown"
-                  Aligned with HAPI/workflow catalog severity levels for consistency across platform
+                  Aligned with KA/workflow catalog severity levels for consistency across platform
                   Enables downstream services (AIAnalysis, RemediationOrchestrator, Notification)
                   to interpret alert urgency without understanding external severity schemes.
                 enum:
@@ -539,7 +539,7 @@ spec:
                   BR-SP-106: Signal Name Normalization
                   For proactive signals (e.g., "PredictedOOMKill"), this is the base name (e.g., "OOMKilled").
                   For reactive signals, this matches Spec.Signal.Name unchanged.
-                  This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, HAPI).
+                  This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, KA).
                 type: string
               sourceSignalName:
                 description: |-

--- a/charts/kubernaut/files/crds/kubernaut.ai_workflowexecutions.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_workflowexecutions.yaml
@@ -67,7 +67,7 @@ spec:
               WorkflowExecution represents an immutable event (workflow execution attempt).
               Once created by RemediationOrchestrator, spec cannot be modified to ensure:
               - Audit trail integrity (executed spec matches approved spec)
-              - No parameter tampering after HAPI validation
+              - No parameter tampering after KA validation
               - No target resource changes after routing decisions
 
               To change execution parameters, delete and recreate the WorkflowExecution.

--- a/config/crd/bases/kubernaut.ai_aianalyses.yaml
+++ b/config/crd/bases/kubernaut.ai_aianalyses.yaml
@@ -63,7 +63,7 @@ spec:
               AIAnalysis represents an immutable event (AI investigation).
               Once created by RemediationOrchestrator, spec cannot be modified to ensure:
               - Audit trail integrity (AI investigation matches original RCA request)
-              - No tampering with RCA targets post-HAPI validation
+              - No tampering with RCA targets post-KA validation
               - No workflow selection modification after AI recommendation
 
               To re-analyze, delete and recreate the AIAnalysis CRD.
@@ -271,7 +271,7 @@ spec:
                           SignalMode indicates whether this is a reactive or proactive signal.
                           BR-AI-084: Proactive Signal Mode Prompt Strategy
                           Copied from SignalProcessing status by RemediationOrchestrator.
-                          Used by HAPI to switch investigation prompt (RCA vs. predict & prevent).
+                          Used by Kubernaut Agent to switch investigation prompt (RCA vs. predict & prevent).
                         enum:
                         - reactive
                         - proactive
@@ -692,7 +692,7 @@ spec:
               humanReviewReason:
                 description: |-
                   Reason why human review needed (when NeedsHumanReview=true)
-                  BR-HAPI-197: Maps to HAPI's human_review_reason enum values
+                  BR-HAPI-197: Maps to KA's human_review_reason enum values
                   BR-AI-601: alignment_check_failed added for shadow agent alignment verdicts
                 enum:
                 - workflow_not_found
@@ -717,9 +717,9 @@ spec:
                 description: |-
                   ========================================
                   INVESTIGATION SESSION (BR-AA-HAPI-064)
-                  Tracks the async submit/poll session with HAPI
+                  Tracks the async submit/poll session with Kubernaut Agent
                   ========================================
-                  InvestigationSession tracks the async HAPI session for submit/poll pattern
+                  InvestigationSession tracks the async KA session for submit/poll pattern
                 properties:
                   createdAt:
                     description: CreatedAt timestamp when the current session was
@@ -733,8 +733,8 @@ spec:
                     minimum: 0
                     type: integer
                   id:
-                    description: Session ID returned by HAPI on submit (cleared on
-                      session loss)
+                    description: Session ID returned by Kubernaut Agent on submit
+                      (cleared on session loss)
                     type: string
                   lastPolled:
                     description: LastPolled timestamp of the last poll attempt
@@ -753,9 +753,9 @@ spec:
               investigationTime:
                 description: |-
                   NOTE: TokensUsed REMOVED (Dec 2025)
-                  Reason: LLM token tracking is HAPI's responsibility (they call the LLM)
+                  Reason: LLM token tracking is KA's responsibility (it calls the LLM)
                   Observability: KA exposes kubernaut_agent_llm_token_usage_total Prometheus metric
-                  Correlation: Use InvestigationID to link AIAnalysis CRD to HAPI metrics
+                  Correlation: Use InvestigationID to link AIAnalysis CRD to KA metrics
                   Design Decision: DD-COST-001 - Cost observability is provider's responsibility
                   Investigation duration in seconds
                 format: int64
@@ -767,9 +767,9 @@ spec:
                 description: |-
                   ========================================
                   HUMAN REVIEW SIGNALING (BR-HAPI-197)
-                  Set by HAPI when AI cannot produce reliable result
+                  Set by Kubernaut Agent when AI cannot produce reliable result
                   ========================================
-                  True if human review required (HAPI decision: RCA incomplete/unreliable)
+                  True if human review required (KA decision: RCA incomplete/unreliable)
                   BR-HAPI-197: Triggers NotificationRequest creation in RO
                   BR-496 v2: Set when root_owner missing (rca_incomplete) or validation/confidence issues.
                 type: boolean
@@ -795,14 +795,14 @@ spec:
                 description: |-
                   ========================================
                   POST-RCA CONTEXT (ADR-056)
-                  Runtime-computed cluster characteristics from HAPI
+                  Runtime-computed cluster characteristics from Kubernaut Agent
                   ========================================
-                  PostRCAContext holds data computed by HAPI after RCA (e.g., DetectedLabels).
+                  PostRCAContext holds data computed by Kubernaut Agent after RCA (e.g., DetectedLabels).
                   Immutable once set — use CEL validation on the PostRCAContext type.
                 properties:
                   detectedLabels:
                     description: |-
-                      DetectedLabels contains cluster characteristics computed by HAPI's
+                      DetectedLabels contains cluster characteristics computed by KA's
                       LabelDetector during get_namespaced_resource_context or get_cluster_resource_context tool invocations.
                     properties:
                       failedDetections:
@@ -963,7 +963,7 @@ spec:
                   severity:
                     description: |-
                       Severity determined by RCA (normalized per DD-SEVERITY-001 v1.1)
-                      DD-SEVERITY-001 v1.1: Aligned with HAPI/workflow catalog (critical, high, medium, low, unknown)
+                      DD-SEVERITY-001 v1.1: Aligned with KA/workflow catalog (critical, high, medium, low, unknown)
                     enum:
                     - critical
                     - high
@@ -992,7 +992,7 @@ spec:
                   actionType:
                     description: |-
                       Action type from DD-WORKFLOW-016 taxonomy (e.g., ScaleReplicas, RestartPod).
-                      Propagated from HAPI three-step discovery protocol to RO audit events.
+                      Propagated from KA three-step discovery protocol to RO audit events.
                     type: string
                   confidence:
                     description: Confidence score (0.0-1.0)
@@ -1081,13 +1081,13 @@ spec:
                 type: integer
               validationAttemptsHistory:
                 description: |-
-                  ValidationAttemptsHistory contains complete history of all HAPI validation attempts
-                  Per DD-HAPI-002 v1.4: HAPI retries up to 3 times with LLM self-correction
+                  ValidationAttemptsHistory contains complete history of all KA validation attempts
+                  Per DD-HAPI-002 v1.4: KA retries up to 3 times with LLM self-correction
                   This field provides audit trail for operator notifications and debugging
                 items:
                   description: |-
-                    ValidationAttempt contains details of a single HAPI validation attempt
-                    Per DD-HAPI-002 v1.4: HAPI retries up to 3 times with LLM self-correction
+                    ValidationAttempt contains details of a single KA validation attempt
+                    Per DD-HAPI-002 v1.4: KA retries up to 3 times with LLM self-correction
                     Each attempt feeds validation errors back to the LLM for correction
                   properties:
                     attempt:
@@ -1121,7 +1121,7 @@ spec:
               warnings:
                 description: |-
                   ========================================
-                  HAPI RESPONSE METADATA
+                  KA RESPONSE METADATA
                   ========================================
                   Non-fatal warnings from KA (e.g., low confidence)
                 items:

--- a/config/crd/bases/kubernaut.ai_effectivenessassessments.yaml
+++ b/config/crd/bases/kubernaut.ai_effectivenessassessments.yaml
@@ -135,7 +135,7 @@ spec:
               remediationTarget:
                 description: |-
                   RemediationTarget is the resource the workflow modified.
-                  Source: AA.Status.RootCauseAnalysis.RemediationTarget (from HAPI RCA resolution).
+                  Source: AA.Status.RootCauseAnalysis.RemediationTarget (from KA RCA resolution).
                   Used by: spec hash computation, drift detection (DD-EM-003).
                 properties:
                   apiVersion:

--- a/config/crd/bases/kubernaut.ai_notificationrequests.yaml
+++ b/config/crd/bases/kubernaut.ai_notificationrequests.yaml
@@ -181,7 +181,7 @@ spec:
                           circuit breaker terminated the investigation early.
                         type: boolean
                       humanReviewReason:
-                        description: HumanReviewReason from HAPI when needs_human_review=true
+                        description: HumanReviewReason from Kubernaut Agent when needs_human_review=true
                           (BR-HAPI-197).
                         type: string
                       reason:

--- a/config/crd/bases/kubernaut.ai_remediationrequests.yaml
+++ b/config/crd/bases/kubernaut.ai_remediationrequests.yaml
@@ -423,8 +423,9 @@ spec:
               consecutiveFailureCount:
                 description: |-
                   ConsecutiveFailureCount tracks how many times this fingerprint has failed consecutively.
-                  Updated by RO when RR transitions to Failed phase.
-                  Reset to 0 when RR completes successfully.
+                  Updated by RO when RR transitions to Failed phase or completes with Outcome=Inconclusive
+                  (EA confirms alert still firing, treated as functional failure per BR-ORCH-042.6, #1091).
+                  Reset to 0 when RR enters Verifying phase after successful remediation.
                   Reference: BR-ORCH-042
                 format: int32
                 type: integer
@@ -667,11 +668,12 @@ spec:
               nextAllowedExecution:
                 description: |-
                   NextAllowedExecution indicates when this RR can be retried after exponential backoff.
-                  Set when RR fails due to pre-execution failures (infrastructure, validation, etc.).
+                  Set when RR transitions to Failed phase (pre-execution failures) or when EA
+                  determines an Inconclusive outcome (alert still firing after remediation, #1091).
                   Implements progressive delay: 1m, 2m, 4m, 8m, capped at 10m.
                   Formula: min(Base × 2^(failures-1), Max)
                   Nil means no exponential backoff is active.
-                  Reference: DD-WE-004 (Exponential Backoff Cooldown)
+                  Reference: DD-WE-004 (Exponential Backoff Cooldown), BR-ORCH-042.6 (#1091)
                 format: date-time
                 type: string
               notificationRequestRefs:

--- a/config/crd/bases/kubernaut.ai_signalprocessings.yaml
+++ b/config/crd/bases/kubernaut.ai_signalprocessings.yaml
@@ -512,7 +512,7 @@ spec:
                 description: |-
                   Severity determination (DD-SEVERITY-001 v1.1)
                   Normalized severity determined by Rego policy: "critical", "high", "medium", "low", or "unknown"
-                  Aligned with HAPI/workflow catalog severity levels for consistency across platform
+                  Aligned with KA/workflow catalog severity levels for consistency across platform
                   Enables downstream services (AIAnalysis, RemediationOrchestrator, Notification)
                   to interpret alert urgency without understanding external severity schemes.
                 enum:
@@ -539,7 +539,7 @@ spec:
                   BR-SP-106: Signal Name Normalization
                   For proactive signals (e.g., "PredictedOOMKill"), this is the base name (e.g., "OOMKilled").
                   For reactive signals, this matches Spec.Signal.Name unchanged.
-                  This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, HAPI).
+                  This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, KA).
                 type: string
               sourceSignalName:
                 description: |-

--- a/config/crd/bases/kubernaut.ai_workflowexecutions.yaml
+++ b/config/crd/bases/kubernaut.ai_workflowexecutions.yaml
@@ -67,7 +67,7 @@ spec:
               WorkflowExecution represents an immutable event (workflow execution attempt).
               Once created by RemediationOrchestrator, spec cannot be modified to ensure:
               - Audit trail integrity (executed spec matches approved spec)
-              - No parameter tampering after HAPI validation
+              - No parameter tampering after KA validation
               - No target resource changes after routing decisions
 
               To change execution parameters, delete and recreate the WorkflowExecution.

--- a/docs/generated/crds.md
+++ b/docs/generated/crds.md
@@ -52,7 +52,7 @@ AIAnalysisSpec defines the desired state of AIAnalysis.
 AIAnalysis represents an immutable event (AI investigation).
 Once created by RemediationOrchestrator, spec cannot be modified to ensure:
 - Audit trail integrity (AI investigation matches original RCA request)
-- No tampering with RCA targets post-HAPI validation
+- No tampering with RCA targets post-KA validation
 - No workflow selection modification after AI recommendation
 
 To re-analyze, delete and recreate the AIAnalysis CRD.
@@ -92,19 +92,19 @@ _Appears in:_
 | `approvalRequired`| _boolean_| True if approval is required (confidence < 80% or policy requires)|
 | `approvalReason`| _string_| Reason why approval is required (when ApprovalRequired=true)|
 | `approvalContext`| _[ApprovalContext](#approvalcontext)_| Rich context for approval notification|
-| `needsHumanReview`| _boolean_| Set by HAPI when AI cannot produce reliable result<br />True if human review required (HAPI decision: RCA incomplete/unreliable)<br /> Triggers NotificationRequest creation in RO<br />BR-496 v2: Set when root_owner missing (rca_incomplete) or validation/confidence issues.|
-| `humanReviewReason`| _string_| Reason why human review needed (when NeedsHumanReview=true)<br /> Maps to HAPI's human_review_reason enum values<br /> alignment_check_failed added for shadow agent alignment verdicts|
+| `needsHumanReview`| _boolean_| Set by Kubernaut Agent when AI cannot produce reliable result<br />True if human review required (KA decision: RCA incomplete/unreliable)<br /> Triggers NotificationRequest creation in RO<br />BR-496 v2: Set when root_owner missing (rca_incomplete) or validation/confidence issues.|
+| `humanReviewReason`| _string_| Reason why human review needed (when NeedsHumanReview=true)<br /> Maps to KA's human_review_reason enum values<br /> alignment_check_failed added for shadow agent alignment verdicts|
 | `alignmentVerdict`| _[AlignmentVerdictStatus](#alignmentverdictstatus)_| Shadow agent alignment verdict from KA (, #1076).<br />When CircuitBreakerActivated=true, the investigation was terminated early<br />and LLM results (RootCauseAnalysis, SelectedWorkflow) may be incomplete<br />or compromised. Users should treat shadow findings as the primary content.|
 | `actionability`| _string_| #388: LLM's assessment of whether the alert warrants action.<br />Empty when not yet assessed (pre-investigation or error paths).<br />"Actionable" when the LLM determines the alert warrants action (default for all processed alerts).<br />"NotActionable" when the LLM determines the alert is benign (e.g., orphaned PVCs).|
 | `investigationId`| _string_| KA investigation ID for correlation|
 | `investigationTime`| _integer_| Investigation duration in seconds|
 | `warnings`| _string array_| Non-fatal warnings from KA (e.g., low confidence)|
-| `validationAttemptsHistory`| _[ValidationAttempt](#validationattempt) array_| ValidationAttemptsHistory contains complete history of all HAPI validation attempts<br />Per HAPI retries up to 3 times with LLM self-correction<br />This field provides audit trail for operator notifications and debugging|
+| `validationAttemptsHistory`| _[ValidationAttempt](#validationattempt) array_| ValidationAttemptsHistory contains complete history of all KA validation attempts<br />Per KA retries up to 3 times with LLM self-correction<br />This field provides audit trail for operator notifications and debugging|
 | `degradedMode`| _boolean_| DegradedMode indicates if the analysis ran with degraded capabilities<br />(e.g., Rego policy evaluation failed, using safe defaults)|
 | `totalAnalysisTime`| _integer_| TotalAnalysisTime is the total duration of the analysis in seconds|
 | `consecutiveFailures`| _integer_| ConsecutiveFailures tracks retry attempts for exponential backoff<br /> Reset to 0 on success, increment on transient failure<br />Used with for retry logic with jitter|
-| `investigationSession`| _[InvestigationSession](#investigationsession)_| Tracks the async submit/poll session with HAPI<br />InvestigationSession tracks the async HAPI session for submit/poll pattern|
-| `postRCAContext`| _[PostRCAContext](#postrcacontext)_| Runtime-computed cluster characteristics from HAPI<br />PostRCAContext holds data computed by HAPI after RCA (e.g., DetectedLabels).<br />Immutable once set — use CEL validation on the PostRCAContext type.|
+| `investigationSession`| _[InvestigationSession](#investigationsession)_| Tracks the async submit/poll session with Kubernaut Agent<br />InvestigationSession tracks the async KA session for submit/poll pattern|
+| `postRCAContext`| _[PostRCAContext](#postrcacontext)_| Runtime-computed cluster characteristics from Kubernaut Agent<br />PostRCAContext holds data computed by Kubernaut Agent after RCA (e.g., DetectedLabels).<br />Immutable once set — use CEL validation on the PostRCAContext type.|
 | `conditions`| _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#condition-v1-meta) array_| Conditions|
 
 
@@ -615,7 +615,7 @@ _Appears in:_
 | `correlationID`| _string_| CorrelationID is the name of the parent RemediationRequest.<br />Used as the correlation ID for audit events .|
 | `remediationRequestPhase`| _string_| RemediationRequestPhase is the RemediationRequest's OverallPhase at the time<br />the EA was created. Captured as an immutable spec field so the EM can branch<br />assessment logic based on the RR outcome (Verifying, Completed, Failed, TimedOut).<br />Verifying: happy path — WFE succeeded, EA created while RR awaits assessment .<br />Previously stored as the mutable label kubernaut.ai/rr-phase; moved to spec<br />for immutability and security.|
 | `signalTarget`| _[TargetResource](#targetresource)_| SignalTarget is the resource that triggered the alert.<br />Source: RR.Spec.TargetResource (from Gateway alert extraction).<br />Used by: health assessment, alert resolution, metrics queries .|
-| `remediationTarget`| _[TargetResource](#targetresource)_| RemediationTarget is the resource the workflow modified.<br />Source: AA.Status.RootCauseAnalysis.RemediationTarget (from HAPI RCA resolution).<br />Used by: spec hash computation, drift detection .|
+| `remediationTarget`| _[TargetResource](#targetresource)_| RemediationTarget is the resource the workflow modified.<br />Source: AA.Status.RootCauseAnalysis.RemediationTarget (from KA RCA resolution).<br />Used by: spec hash computation, drift detection .|
 | `config`| _[EAConfig](#eaconfig)_| Config contains the assessment configuration parameters.|
 | `remediationCreatedAt`| _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#time-v1-meta)_| RemediationCreatedAt is the creation timestamp of the parent RemediationRequest.<br />Set by the RO at EA creation time from rr.CreationTimestamp.<br />Used by the audit manager to compute resolution_time_seconds in the<br />assessment.completed event (CompletedAt - RemediationCreatedAt).|
 | `signalName`| _string_| SignalName is the original alert/signal name from the parent RemediationRequest.<br />Set by the RO at EA creation time from rr.Spec.SignalName.<br />Used by the audit manager to populate the signal_name field in assessment.completed<br />events (OBS-1: distinct from CorrelationID which is the RR name).|
@@ -800,16 +800,16 @@ _Validation:_
 ### InvestigationSession
 
 
-InvestigationSession tracks the async HAPI session lifecycle.
+InvestigationSession tracks the async Kubernaut Agent session lifecycle.
  AA controller session tracking
- Session regeneration on 404 (HAPI restart)
+ Session regeneration on 404 (KA restart)
 
 _Appears in:_
 - [AIAnalysisStatus](#aianalysisstatus)
 
 | Field| Type| Description|
 | ---| ---| ---|
-| `id`| _string_| Session ID returned by HAPI on submit (cleared on session loss)|
+| `id`| _string_| Session ID returned by Kubernaut Agent on submit (cleared on session loss)|
 | `generation`| _integer_| Generation counter tracking session regenerations (0 = first session, incremented on 404)|
 | `lastPolled`| _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#time-v1-meta)_| LastPolled timestamp of the last poll attempt|
 | `createdAt`| _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#time-v1-meta)_| CreatedAt timestamp when the current session was created|
@@ -1074,9 +1074,9 @@ _Appears in:_
 ### PostRCAContext
 
 
-PostRCAContext holds data computed by HAPI after the RCA phase.
- DetectedLabels are computed at runtime by HAPI's LabelDetector
-and returned in the HAPI response for storage in the AIAnalysis status.
+PostRCAContext holds data computed by Kubernaut Agent after the RCA phase.
+ DetectedLabels are computed at runtime by KA's LabelDetector
+and returned in the KA response for storage in the AIAnalysis status.
 This data is used by Rego policies for approval gating (e.g., stateful
 workload detection) and is immutable once set.
 
@@ -1085,7 +1085,7 @@ _Appears in:_
 
 | Field| Type| Description|
 | ---| ---| ---|
-| `detectedLabels`| _DetectedLabels_| DetectedLabels contains cluster characteristics computed by HAPI's<br />LabelDetector during get_namespaced_resource_context or get_cluster_resource_context tool invocations.|
+| `detectedLabels`| _DetectedLabels_| DetectedLabels contains cluster characteristics computed by KA's<br />LabelDetector during get_namespaced_resource_context or get_cluster_resource_context tool invocations.|
 | `setAt`| _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#time-v1-meta)_| SetAt records when the PostRCAContext was populated.<br />Used as the immutability guard: once SetAt is non-nil, the entire<br />PostRCAContext becomes immutable via CEL validation.|
 
 
@@ -1617,7 +1617,7 @@ _Appears in:_
 | ---| ---| ---|
 | `reason`| _string_| Reason is the high-level failure reason (e.g., "WorkflowResolutionFailed").|
 | `subReason`| _string_| SubReason provides granular detail (e.g., "WorkflowNotFound").|
-| `humanReviewReason`| _string_| HumanReviewReason from HAPI when needs_human_review=true .|
+| `humanReviewReason`| _string_| HumanReviewReason from Kubernaut Agent when needs_human_review=true .|
 | `rootCauseAnalysis`| _string_| RootCauseAnalysis from AIAnalysis if available.|
 | `alignmentVerdict`| _string_| AlignmentVerdict is the shadow agent's overall verdict (aligned/suspicious).<br /> Present when shadow agent alignment check is enabled.|
 | `circuitBreakerActivated`| _boolean_| CircuitBreakerActivated indicates whether the circuit breaker terminated the investigation early.|
@@ -1652,7 +1652,7 @@ _Appears in:_
 | Field| Type| Description|
 | ---| ---| ---|
 | `summary`| _string_| Brief summary of root cause|
-| `severity`| _string_| Severity determined by RCA <br /> Aligned with HAPI/workflow catalog (critical, high, medium, low, unknown)|
+| `severity`| _string_| Severity determined by RCA <br /> Aligned with KA/workflow catalog (critical, high, medium, low, unknown)|
 | `signalType`| _string_| Signal type determined by RCA (may differ from input)|
 | `contributingFactors`| _string array_| Contributing factors|
 | `remediationTarget`| _[RemediationTarget](#remediationtarget)_| RemediationTarget identifies the actual resource the LLM determined should be remediated.<br /> The LLM may identify a higher-level resource (e.g., Deployment) rather than<br />the Pod that generated the signal. The WFE creator should prefer this over the RR's<br />TargetResource when available to ensure the correct resource is patched.|
@@ -1670,7 +1670,7 @@ _Appears in:_
 | Field| Type| Description|
 | ---| ---| ---|
 | `workflowId`| _string_| Workflow identifier (catalog lookup key)|
-| `actionType`| _string_| Action type from taxonomy (e.g., ScaleReplicas, RestartPod).<br />Propagated from HAPI three-step discovery protocol to RO audit events.|
+| `actionType`| _string_| Action type from taxonomy (e.g., ScaleReplicas, RestartPod).<br />Propagated from KA three-step discovery protocol to RO audit events.|
 | `version`| _string_| Workflow version|
 | `executionBundle`| _string_| Execution bundle OCI reference (digest-pinned) - resolved by KA|
 | `executionBundleDigest`| _string_| Execution bundle digest for audit trail|
@@ -1696,7 +1696,7 @@ _Appears in:_
 | `fingerprint`| _string_| Signal fingerprint for correlation|
 | `severity`| _string_| Signal severity: critical, high, medium, low, unknown (normalized by SignalProcessing Rego - )|
 | `signalName`| _string_| Signal name (e.g., OOMKilled, CrashLoopBackOff)<br />Normalized by SignalProcessing: proactive names mapped to base names|
-| `signalMode`| _string_| SignalMode indicates whether this is a reactive or proactive signal.<br /> Proactive Signal Mode Prompt Strategy<br />Copied from SignalProcessing status by RemediationOrchestrator.<br />Used by HAPI to switch investigation prompt (RCA vs. predict & prevent).|
+| `signalMode`| _string_| SignalMode indicates whether this is a reactive or proactive signal.<br /> Proactive Signal Mode Prompt Strategy<br />Copied from SignalProcessing status by RemediationOrchestrator.<br />Used by Kubernaut Agent to switch investigation prompt (RCA vs. predict & prevent).|
 | `environment`| _string_| Environment classification<br />Examples: "production", "staging", "development", "qa-eu", "canary"|
 | `businessPriority`| _string_| Business priority<br />Best practice examples: P0 (critical), P1 (high), P2 (normal), P3 (low)|
 | `targetResource`| _[TargetResource](#targetresource)_| Target resource identification|
@@ -1812,10 +1812,10 @@ _Appears in:_
 | `environmentClassification`| _[EnvironmentClassification](#environmentclassification)_| Categorization results|
 | `priorityAssignment`| _[PriorityAssignment](#priorityassignment)_||
 | `businessClassification`| _BusinessClassification_||
-| `severity`| _string_| Severity determination <br />Normalized severity determined by Rego policy: "critical", "high", "medium", "low", or "unknown"<br />Aligned with HAPI/workflow catalog severity levels for consistency across platform<br />Enables downstream services (AIAnalysis, RemediationOrchestrator, Notification)<br />to interpret alert urgency without understanding external severity schemes.|
+| `severity`| _string_| Severity determination <br />Normalized severity determined by Rego policy: "critical", "high", "medium", "low", or "unknown"<br />Aligned with KA/workflow catalog severity levels for consistency across platform<br />Enables downstream services (AIAnalysis, RemediationOrchestrator, Notification)<br />to interpret alert urgency without understanding external severity schemes.|
 | `policyHash`| _string_| PolicyHash is the SHA256 hash of the Rego policy used for severity determination<br />Provides audit trail and policy version tracking for compliance requirements<br />Expected format: 64-character hexadecimal string (SHA256 hash)|
 | `signalMode`| _string_| SignalMode indicates whether this is a reactive or proactive signal.<br /> Proactive Signal Mode Classification<br /> Proactive Signal Mode Classification and Prompt Strategy<br />Set during the Classifying phase alongside severity, environment, and priority.<br />All signals MUST be classified — "reactive" is the default for unmapped types.|
-| `signalName`| _string_| SignalName is the normalized signal name after proactive-to-base mapping.<br /> Signal Name Normalization<br />For proactive signals (e.g., "PredictedOOMKill"), this is the base name (e.g., "OOMKilled").<br />For reactive signals, this matches Spec.Signal.Name unchanged.<br />This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, HAPI).|
+| `signalName`| _string_| SignalName is the normalized signal name after proactive-to-base mapping.<br /> Signal Name Normalization<br />For proactive signals (e.g., "PredictedOOMKill"), this is the base name (e.g., "OOMKilled").<br />For reactive signals, this matches Spec.Signal.Name unchanged.<br />This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, KA).|
 | `sourceSignalName`| _string_| SourceSignalName preserves the pre-normalization signal name for audit trail.<br /> Audit trail preservation (SOC2 CC7.4)<br />Only populated for proactive signals (e.g., "PredictedOOMKill").<br />Empty for reactive signals.|
 | `conditions`| _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#condition-v1-meta) array_| Conditions for detailed status|
 | `error`| _string_| Error information|
@@ -1893,8 +1893,8 @@ _Appears in:_
 ### ValidationAttempt
 
 
-ValidationAttempt contains details of a single HAPI validation attempt
-Per HAPI retries up to 3 times with LLM self-correction
+ValidationAttempt contains details of a single KA validation attempt
+Per KA retries up to 3 times with LLM self-correction
 Each attempt feeds validation errors back to the LLM for correction
 
 _Appears in:_
@@ -1968,7 +1968,7 @@ WorkflowExecutionSpec defines the desired state of WorkflowExecution
 WorkflowExecution represents an immutable event (workflow execution attempt).
 Once created by RemediationOrchestrator, spec cannot be modified to ensure:
 - Audit trail integrity (executed spec matches approved spec)
-- No parameter tampering after HAPI validation
+- No parameter tampering after KA validation
 - No target resource changes after routing decisions
 
 To change execution parameters, delete and recreate the WorkflowExecution.

--- a/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
@@ -63,7 +63,7 @@ spec:
               AIAnalysis represents an immutable event (AI investigation).
               Once created by RemediationOrchestrator, spec cannot be modified to ensure:
               - Audit trail integrity (AI investigation matches original RCA request)
-              - No tampering with RCA targets post-HAPI validation
+              - No tampering with RCA targets post-KA validation
               - No workflow selection modification after AI recommendation
 
               To re-analyze, delete and recreate the AIAnalysis CRD.
@@ -271,7 +271,7 @@ spec:
                           SignalMode indicates whether this is a reactive or proactive signal.
                           BR-AI-084: Proactive Signal Mode Prompt Strategy
                           Copied from SignalProcessing status by RemediationOrchestrator.
-                          Used by HAPI to switch investigation prompt (RCA vs. predict & prevent).
+                          Used by Kubernaut Agent to switch investigation prompt (RCA vs. predict & prevent).
                         enum:
                         - reactive
                         - proactive
@@ -692,7 +692,7 @@ spec:
               humanReviewReason:
                 description: |-
                   Reason why human review needed (when NeedsHumanReview=true)
-                  BR-HAPI-197: Maps to HAPI's human_review_reason enum values
+                  BR-HAPI-197: Maps to KA's human_review_reason enum values
                   BR-AI-601: alignment_check_failed added for shadow agent alignment verdicts
                 enum:
                 - workflow_not_found
@@ -717,9 +717,9 @@ spec:
                 description: |-
                   ========================================
                   INVESTIGATION SESSION (BR-AA-HAPI-064)
-                  Tracks the async submit/poll session with HAPI
+                  Tracks the async submit/poll session with Kubernaut Agent
                   ========================================
-                  InvestigationSession tracks the async HAPI session for submit/poll pattern
+                  InvestigationSession tracks the async KA session for submit/poll pattern
                 properties:
                   createdAt:
                     description: CreatedAt timestamp when the current session was
@@ -733,8 +733,8 @@ spec:
                     minimum: 0
                     type: integer
                   id:
-                    description: Session ID returned by HAPI on submit (cleared on
-                      session loss)
+                    description: Session ID returned by Kubernaut Agent on submit
+                      (cleared on session loss)
                     type: string
                   lastPolled:
                     description: LastPolled timestamp of the last poll attempt
@@ -753,9 +753,9 @@ spec:
               investigationTime:
                 description: |-
                   NOTE: TokensUsed REMOVED (Dec 2025)
-                  Reason: LLM token tracking is HAPI's responsibility (they call the LLM)
+                  Reason: LLM token tracking is KA's responsibility (it calls the LLM)
                   Observability: KA exposes kubernaut_agent_llm_token_usage_total Prometheus metric
-                  Correlation: Use InvestigationID to link AIAnalysis CRD to HAPI metrics
+                  Correlation: Use InvestigationID to link AIAnalysis CRD to KA metrics
                   Design Decision: DD-COST-001 - Cost observability is provider's responsibility
                   Investigation duration in seconds
                 format: int64
@@ -767,9 +767,9 @@ spec:
                 description: |-
                   ========================================
                   HUMAN REVIEW SIGNALING (BR-HAPI-197)
-                  Set by HAPI when AI cannot produce reliable result
+                  Set by Kubernaut Agent when AI cannot produce reliable result
                   ========================================
-                  True if human review required (HAPI decision: RCA incomplete/unreliable)
+                  True if human review required (KA decision: RCA incomplete/unreliable)
                   BR-HAPI-197: Triggers NotificationRequest creation in RO
                   BR-496 v2: Set when root_owner missing (rca_incomplete) or validation/confidence issues.
                 type: boolean
@@ -795,14 +795,14 @@ spec:
                 description: |-
                   ========================================
                   POST-RCA CONTEXT (ADR-056)
-                  Runtime-computed cluster characteristics from HAPI
+                  Runtime-computed cluster characteristics from Kubernaut Agent
                   ========================================
-                  PostRCAContext holds data computed by HAPI after RCA (e.g., DetectedLabels).
+                  PostRCAContext holds data computed by Kubernaut Agent after RCA (e.g., DetectedLabels).
                   Immutable once set — use CEL validation on the PostRCAContext type.
                 properties:
                   detectedLabels:
                     description: |-
-                      DetectedLabels contains cluster characteristics computed by HAPI's
+                      DetectedLabels contains cluster characteristics computed by KA's
                       LabelDetector during get_namespaced_resource_context or get_cluster_resource_context tool invocations.
                     properties:
                       failedDetections:
@@ -963,7 +963,7 @@ spec:
                   severity:
                     description: |-
                       Severity determined by RCA (normalized per DD-SEVERITY-001 v1.1)
-                      DD-SEVERITY-001 v1.1: Aligned with HAPI/workflow catalog (critical, high, medium, low, unknown)
+                      DD-SEVERITY-001 v1.1: Aligned with KA/workflow catalog (critical, high, medium, low, unknown)
                     enum:
                     - critical
                     - high
@@ -992,7 +992,7 @@ spec:
                   actionType:
                     description: |-
                       Action type from DD-WORKFLOW-016 taxonomy (e.g., ScaleReplicas, RestartPod).
-                      Propagated from HAPI three-step discovery protocol to RO audit events.
+                      Propagated from KA three-step discovery protocol to RO audit events.
                     type: string
                   confidence:
                     description: Confidence score (0.0-1.0)
@@ -1081,13 +1081,13 @@ spec:
                 type: integer
               validationAttemptsHistory:
                 description: |-
-                  ValidationAttemptsHistory contains complete history of all HAPI validation attempts
-                  Per DD-HAPI-002 v1.4: HAPI retries up to 3 times with LLM self-correction
+                  ValidationAttemptsHistory contains complete history of all KA validation attempts
+                  Per DD-HAPI-002 v1.4: KA retries up to 3 times with LLM self-correction
                   This field provides audit trail for operator notifications and debugging
                 items:
                   description: |-
-                    ValidationAttempt contains details of a single HAPI validation attempt
-                    Per DD-HAPI-002 v1.4: HAPI retries up to 3 times with LLM self-correction
+                    ValidationAttempt contains details of a single KA validation attempt
+                    Per DD-HAPI-002 v1.4: KA retries up to 3 times with LLM self-correction
                     Each attempt feeds validation errors back to the LLM for correction
                   properties:
                     attempt:
@@ -1121,7 +1121,7 @@ spec:
               warnings:
                 description: |-
                   ========================================
-                  HAPI RESPONSE METADATA
+                  KA RESPONSE METADATA
                   ========================================
                   Non-fatal warnings from KA (e.g., low confidence)
                 items:

--- a/pkg/shared/assets/crds/kubernaut.ai_effectivenessassessments.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_effectivenessassessments.yaml
@@ -135,7 +135,7 @@ spec:
               remediationTarget:
                 description: |-
                   RemediationTarget is the resource the workflow modified.
-                  Source: AA.Status.RootCauseAnalysis.RemediationTarget (from HAPI RCA resolution).
+                  Source: AA.Status.RootCauseAnalysis.RemediationTarget (from KA RCA resolution).
                   Used by: spec hash computation, drift detection (DD-EM-003).
                 properties:
                   apiVersion:

--- a/pkg/shared/assets/crds/kubernaut.ai_notificationrequests.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_notificationrequests.yaml
@@ -181,7 +181,7 @@ spec:
                           circuit breaker terminated the investigation early.
                         type: boolean
                       humanReviewReason:
-                        description: HumanReviewReason from HAPI when needs_human_review=true
+                        description: HumanReviewReason from Kubernaut Agent when needs_human_review=true
                           (BR-HAPI-197).
                         type: string
                       reason:

--- a/pkg/shared/assets/crds/kubernaut.ai_remediationrequests.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_remediationrequests.yaml
@@ -423,8 +423,9 @@ spec:
               consecutiveFailureCount:
                 description: |-
                   ConsecutiveFailureCount tracks how many times this fingerprint has failed consecutively.
-                  Updated by RO when RR transitions to Failed phase.
-                  Reset to 0 when RR completes successfully.
+                  Updated by RO when RR transitions to Failed phase or completes with Outcome=Inconclusive
+                  (EA confirms alert still firing, treated as functional failure per BR-ORCH-042.6, #1091).
+                  Reset to 0 when RR enters Verifying phase after successful remediation.
                   Reference: BR-ORCH-042
                 format: int32
                 type: integer
@@ -667,11 +668,12 @@ spec:
               nextAllowedExecution:
                 description: |-
                   NextAllowedExecution indicates when this RR can be retried after exponential backoff.
-                  Set when RR fails due to pre-execution failures (infrastructure, validation, etc.).
+                  Set when RR transitions to Failed phase (pre-execution failures) or when EA
+                  determines an Inconclusive outcome (alert still firing after remediation, #1091).
                   Implements progressive delay: 1m, 2m, 4m, 8m, capped at 10m.
                   Formula: min(Base × 2^(failures-1), Max)
                   Nil means no exponential backoff is active.
-                  Reference: DD-WE-004 (Exponential Backoff Cooldown)
+                  Reference: DD-WE-004 (Exponential Backoff Cooldown), BR-ORCH-042.6 (#1091)
                 format: date-time
                 type: string
               notificationRequestRefs:

--- a/pkg/shared/assets/crds/kubernaut.ai_signalprocessings.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_signalprocessings.yaml
@@ -512,7 +512,7 @@ spec:
                 description: |-
                   Severity determination (DD-SEVERITY-001 v1.1)
                   Normalized severity determined by Rego policy: "critical", "high", "medium", "low", or "unknown"
-                  Aligned with HAPI/workflow catalog severity levels for consistency across platform
+                  Aligned with KA/workflow catalog severity levels for consistency across platform
                   Enables downstream services (AIAnalysis, RemediationOrchestrator, Notification)
                   to interpret alert urgency without understanding external severity schemes.
                 enum:
@@ -539,7 +539,7 @@ spec:
                   BR-SP-106: Signal Name Normalization
                   For proactive signals (e.g., "PredictedOOMKill"), this is the base name (e.g., "OOMKilled").
                   For reactive signals, this matches Spec.Signal.Name unchanged.
-                  This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, HAPI).
+                  This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, KA).
                 type: string
               sourceSignalName:
                 description: |-

--- a/pkg/shared/assets/crds/kubernaut.ai_workflowexecutions.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_workflowexecutions.yaml
@@ -67,7 +67,7 @@ spec:
               WorkflowExecution represents an immutable event (workflow execution attempt).
               Once created by RemediationOrchestrator, spec cannot be modified to ensure:
               - Audit trail integrity (executed spec matches approved spec)
-              - No parameter tampering after HAPI validation
+              - No parameter tampering after KA validation
               - No target resource changes after routing decisions
 
               To change execution parameters, delete and recreate the WorkflowExecution.


### PR DESCRIPTION
## Summary

- **docs(crds): rename stale HAPI references to Kubernaut Agent** (#1103) — Replaced 32 prose HAPI references with Kubernaut Agent/KA in Go source comments across 5 `api/` type files. Design decision IDs (`DD-HAPI-*`, `BR-HAPI-*`, `BR-AA-HAPI-*`) preserved. Regenerated `docs/generated/crds.md` — zero HAPI/HolmesGPT prose remains. Closes #1103.
- **chore: update CHANGELOG for v1.4.0 GA release** — Comprehensive changelog covering all v1.4 changes since v1.3.2 (50+ items across 7 Added subsections, 9 Changed, 19 Fixed, 1 Removed, 6 Upgrade Notes). Excludes v1.3.x items and v1.5 deferred features.

## Post-merge

After merging, tag `main` HEAD as `v1.4.0` and create the GitHub GA release.

## Test plan

- [x] `go build ./...` passes
- [x] `make generate-crd-docs` regenerated cleanly
- [x] Zero `HAPI`/`HolmesGPT` prose in `docs/generated/crds.md`
- [x] Pre-commit hooks pass (anti-pattern detection, CRD drift check)

Made with [Cursor](https://cursor.com)