### PR TITLE
fix: audit-driven CRD manifest regeneration and CHANGELOG corrections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Circuit breaker enforcement** (#1076) — When shadow agent detects suspicious content in enforce mode, the primary investigation is cancelled via `context.WithCancelCause(ErrCircuitBreaker)`. New `alignmentCircuitBreakerTotal` Prometheus counter.
 - **RO alignment verdict notifications** (#1076) — Manual review notifications render shadow agent findings prominently. `alignment_check_failed` SubReason escalates to `NotificationPriorityCritical`.
 - **Shadow agent LLM token audit events** (#1059) — Per-step audit trail with shadow LLM request/response payloads and token counts for cost tracking.
+- **RCA completion audit event** (#847) — `aiagent.rca.complete` audit event with causal chain and due diligence propagation from Phase 1 to final result. Prometheus `match[]` filter added.
 - **Mock-LLM tool call scenarios** (#657) — Per-scenario `ForceText` override, `ToolCallOverride` for custom tool call bypass, `injection_configmap_read` scenario, and `CreatePoisonedConfigMap` E2E fixture for security testing.
 
 #### Notification Channels (#60, #593)
@@ -46,6 +47,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **CRD-aware engine registration** (#868) — Engine registration validates CRD availability; enters degraded status when required CRDs are missing.
 - **Session hardening** (#1078) — Panic recovery in investigation goroutines, two-tier TTL eviction (terminal after `ttl`, non-terminal after `maxSessionAge`), and 25-minute wall-clock investigation timeout.
 - **LLMProxy bypass fix** (C-1) — `PinDecorator` ensures `LLMProxy` is re-applied around pinned `SwappableClient` snapshots, preventing unmonitored LLM traffic.
+- **Authenticated audit actor** (#998) — Propagates the authenticated user identity into all audit events for SOC2 attribution.
+- **LLM and DS circuit breaker** (OPS-2) — Circuit breaker wrapping LLM and DataStorage HTTP clients for graceful degradation under downstream failures.
 
 #### Gateway
 
@@ -53,8 +56,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Dynamic owner resolution** (#1029, #1032) — Dynamic API resource registry with existence validation. Batch-independent alert processing with FedRAMP readiness remediation.
 - **Prometheus reserved label denylist** (#1045, #1067) — `namespace` and Prometheus-reserved labels excluded from dynamic kind resolution to prevent misrouting.
 
+#### Orchestrator Resilience
+
+- **RO config hot-reload** (#835) — FileWatcher-based hot-reload for RO ConfigMap fields. Thread-safe config access via `ReloadCallback` eliminates pod restarts for runtime tuning.
+- **Cache sync readiness gating** (#852, #853) — Controller readiness probes now gate on informer cache sync completion. HTTP retry transport with exponential backoff for transient DataStorage failures.
+
 #### Infrastructure
 
+- **Inter-service TLS with security profiles** (#748) — TLS wired between all 10 services (Gateway, DataStorage, KA, RO, WE, EM, NT, SP, AuthWebhook, Operator). Configurable `tlsProfile` field selects built-in cipher/protocol profiles (Modern, Intermediate, Old). ADR-TLS-001 documents the design.
+- **SBOM and license scan** (COMP-1) — `go-licenses` SBOM and license compliance scan added to CI pipeline.
 - **NetworkPolicy templates** (#285) — 12 NetworkPolicy templates for all Kubernaut services with default-deny posture, configurable CIDRs, and per-service toggle.
 - **FileWatcher routing hot-reload** (#244) — Notification routing ConfigMap informer replaced with FileWatcher. `SLACK_WEBHOOK_URL` environment variable dependency removed.
 - **Defense-in-depth parameter filtering** (#243) — WE controller filters workflow parameters against the workflow schema with consolidated DataStorage calls.
@@ -67,7 +77,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - **KA config camelCase migration** (#908) — All KA YAML config fields migrated from `snake_case` to `camelCase` per ADR-030. **Breaking**: existing KA ConfigMaps must be updated.
-- **KA config restructured into 3 domains** (#908) — Config reorganized into `server`, `ai`, and `tools` concern domains. **Breaking**: config field paths have changed.
+- **KA config restructured into 3 domains** (#908) — Config reorganized into `runtime`, `ai`, and `integrations` top-level domains (`server` nested under `runtime`; `tools` nested under `integrations`). **Breaking**: config field paths have changed.
 - **KA config split** (#916) — KA config split into static ConfigMap and hot-reloadable ConfigMap. Runtime changes to AI/tool settings take effect without pod restart.
 - **Verdict label rename** (#1077) — `VerdictClean` changed from `"clean"` to `"aligned"` for API consistency. **Breaking**: Prometheus `result` label changes from `result="clean"` to `result="aligned"`.
 - **Standardized log levels** (#875) — Log level configuration standardized across all services with consistent YAML key naming.
@@ -105,11 +115,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Upgrade Notes
 
 - **Breaking: KA config camelCase** (#908, ADR-030) — All KA YAML config fields migrated from `snake_case` to `camelCase`. Update your KA ConfigMap before upgrading.
-- **Breaking: KA config restructured** (#908) — Config reorganized into `server`, `ai`, and `tools` domains. Field paths have changed (e.g., `llm_provider` → `ai.llmProvider`).
+- **Breaking: KA config restructured** (#908) — Config reorganized into `runtime`, `ai`, and `integrations` top-level domains (e.g., `llm_provider` → `ai.llmProvider`, `server` is now under `runtime`, `tools` under `integrations`).
 - **Breaking: KA config split** (#916) — KA now reads from two ConfigMaps: a static one (mounted at startup) and a hot-reloadable one (watched at runtime). Update Helm values accordingly.
 - **Breaking: Prometheus verdict label** (#1077) — Shadow agent Prometheus metric `result` label changed from `"clean"` to `"aligned"`. Update dashboard queries and alerting rules.
 - **Database migrations required** — Run v1.4 migrations before upgrading controllers. The Helm pre-upgrade hook handles this automatically.
-- **NetworkPolicy** (#285) — NetworkPolicies are now deployed for all services by default with a default-deny posture. Verify your cluster's CNI supports NetworkPolicy enforcement. Disable per-service with `networkPolicy.<service>.enabled: false`.
+- **NetworkPolicy** (#285) — NetworkPolicies are now deployed for all services by default with a default-deny posture. Verify your cluster's CNI supports NetworkPolicy enforcement. Disable per-service with `networkPolicies.<service>.enabled: false`.
 
 [1.4.0]: https://github.com/jordigilh/kubernaut/compare/v1.3.2...v1.4.0
 

--- a/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
@@ -63,7 +63,7 @@ spec:
               AIAnalysis represents an immutable event (AI investigation).
               Once created by RemediationOrchestrator, spec cannot be modified to ensure:
               - Audit trail integrity (AI investigation matches original RCA request)
-              - No tampering with RCA targets post-HAPI validation
+              - No tampering with RCA targets post-KA validation
               - No workflow selection modification after AI recommendation
 
               To re-analyze, delete and recreate the AIAnalysis CRD.
@@ -271,7 +271,7 @@ spec:
                           SignalMode indicates whether this is a reactive or proactive signal.
                           BR-AI-084: Proactive Signal Mode Prompt Strategy
                           Copied from SignalProcessing status by RemediationOrchestrator.
-                          Used by HAPI to switch investigation prompt (RCA vs. predict & prevent).
+                          Used by Kubernaut Agent to switch investigation prompt (RCA vs. predict & prevent).
                         enum:
                         - reactive
                         - proactive
@@ -692,7 +692,7 @@ spec:
               humanReviewReason:
                 description: |-
                   Reason why human review needed (when NeedsHumanReview=true)
-                  BR-HAPI-197: Maps to HAPI's human_review_reason enum values
+                  BR-HAPI-197: Maps to KA's human_review_reason enum values
                   BR-AI-601: alignment_check_failed added for shadow agent alignment verdicts
                 enum:
                 - workflow_not_found
@@ -717,9 +717,9 @@ spec:
                 description: |-
                   ========================================
                   INVESTIGATION SESSION (BR-AA-HAPI-064)
-                  Tracks the async submit/poll session with HAPI
+                  Tracks the async submit/poll session with Kubernaut Agent
                   ========================================
-                  InvestigationSession tracks the async HAPI session for submit/poll pattern
+                  InvestigationSession tracks the async KA session for submit/poll pattern
                 properties:
                   createdAt:
                     description: CreatedAt timestamp when the current session was
@@ -733,8 +733,8 @@ spec:
                     minimum: 0
                     type: integer
                   id:
-                    description: Session ID returned by HAPI on submit (cleared on
-                      session loss)
+                    description: Session ID returned by Kubernaut Agent on submit
+                      (cleared on session loss)
                     type: string
                   lastPolled:
                     description: LastPolled timestamp of the last poll attempt
@@ -753,9 +753,9 @@ spec:
               investigationTime:
                 description: |-
                   NOTE: TokensUsed REMOVED (Dec 2025)
-                  Reason: LLM token tracking is HAPI's responsibility (they call the LLM)
+                  Reason: LLM token tracking is KA's responsibility (it calls the LLM)
                   Observability: KA exposes kubernaut_agent_llm_token_usage_total Prometheus metric
-                  Correlation: Use InvestigationID to link AIAnalysis CRD to HAPI metrics
+                  Correlation: Use InvestigationID to link AIAnalysis CRD to KA metrics
                   Design Decision: DD-COST-001 - Cost observability is provider's responsibility
                   Investigation duration in seconds
                 format: int64
@@ -767,9 +767,9 @@ spec:
                 description: |-
                   ========================================
                   HUMAN REVIEW SIGNALING (BR-HAPI-197)
-                  Set by HAPI when AI cannot produce reliable result
+                  Set by Kubernaut Agent when AI cannot produce reliable result
                   ========================================
-                  True if human review required (HAPI decision: RCA incomplete/unreliable)
+                  True if human review required (KA decision: RCA incomplete/unreliable)
                   BR-HAPI-197: Triggers NotificationRequest creation in RO
                   BR-496 v2: Set when root_owner missing (rca_incomplete) or validation/confidence issues.
                 type: boolean
@@ -795,14 +795,14 @@ spec:
                 description: |-
                   ========================================
                   POST-RCA CONTEXT (ADR-056)
-                  Runtime-computed cluster characteristics from HAPI
+                  Runtime-computed cluster characteristics from Kubernaut Agent
                   ========================================
-                  PostRCAContext holds data computed by HAPI after RCA (e.g., DetectedLabels).
+                  PostRCAContext holds data computed by Kubernaut Agent after RCA (e.g., DetectedLabels).
                   Immutable once set — use CEL validation on the PostRCAContext type.
                 properties:
                   detectedLabels:
                     description: |-
-                      DetectedLabels contains cluster characteristics computed by HAPI's
+                      DetectedLabels contains cluster characteristics computed by KA's
                       LabelDetector during get_namespaced_resource_context or get_cluster_resource_context tool invocations.
                     properties:
                       failedDetections:
@@ -963,7 +963,7 @@ spec:
                   severity:
                     description: |-
                       Severity determined by RCA (normalized per DD-SEVERITY-001 v1.1)
-                      DD-SEVERITY-001 v1.1: Aligned with HAPI/workflow catalog (critical, high, medium, low, unknown)
+                      DD-SEVERITY-001 v1.1: Aligned with KA/workflow catalog (critical, high, medium, low, unknown)
                     enum:
                     - critical
                     - high
@@ -992,7 +992,7 @@ spec:
                   actionType:
                     description: |-
                       Action type from DD-WORKFLOW-016 taxonomy (e.g., ScaleReplicas, RestartPod).
-                      Propagated from HAPI three-step discovery protocol to RO audit events.
+                      Propagated from KA three-step discovery protocol to RO audit events.
                     type: string
                   confidence:
                     description: Confidence score (0.0-1.0)
@@ -1081,13 +1081,13 @@ spec:
                 type: integer
               validationAttemptsHistory:
                 description: |-
-                  ValidationAttemptsHistory contains complete history of all HAPI validation attempts
-                  Per DD-HAPI-002 v1.4: HAPI retries up to 3 times with LLM self-correction
+                  ValidationAttemptsHistory contains complete history of all KA validation attempts
+                  Per DD-HAPI-002 v1.4: KA retries up to 3 times with LLM self-correction
                   This field provides audit trail for operator notifications and debugging
                 items:
                   description: |-
-                    ValidationAttempt contains details of a single HAPI validation attempt
-                    Per DD-HAPI-002 v1.4: HAPI retries up to 3 times with LLM self-correction
+                    ValidationAttempt contains details of a single KA validation attempt
+                    Per DD-HAPI-002 v1.4: KA retries up to 3 times with LLM self-correction
                     Each attempt feeds validation errors back to the LLM for correction
                   properties:
                     attempt:
@@ -1121,7 +1121,7 @@ spec:
               warnings:
                 description: |-
                   ========================================
-                  HAPI RESPONSE METADATA
+                  KA RESPONSE METADATA
                   ========================================
                   Non-fatal warnings from KA (e.g., low confidence)
                 items:

--- a/charts/kubernaut/crds/kubernaut.ai_effectivenessassessments.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_effectivenessassessments.yaml
@@ -135,7 +135,7 @@ spec:
               remediationTarget:
                 description: |-
                   RemediationTarget is the resource the workflow modified.
-                  Source: AA.Status.RootCauseAnalysis.RemediationTarget (from HAPI RCA resolution).
+                  Source: AA.Status.RootCauseAnalysis.RemediationTarget (from KA RCA resolution).
                   Used by: spec hash computation, drift detection (DD-EM-003).
                 properties:
                   apiVersion:

--- a/charts/kubernaut/crds/kubernaut.ai_notificationrequests.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_notificationrequests.yaml
@@ -181,7 +181,7 @@ spec:
                           circuit breaker terminated the investigation early.
                         type: boolean
                       humanReviewReason:
-                        description: HumanReviewReason from HAPI when needs_human_review=true
+                        description: HumanReviewReason from Kubernaut Agent when needs_human_review=true
                           (BR-HAPI-197).
                         type: string
                       reason:

--- a/charts/kubernaut/crds/kubernaut.ai_remediationrequests.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_remediationrequests.yaml
@@ -423,8 +423,9 @@ spec:
               consecutiveFailureCount:
                 description: |-
                   ConsecutiveFailureCount tracks how many times this fingerprint has failed consecutively.
-                  Updated by RO when RR transitions to Failed phase.
-                  Reset to 0 when RR completes successfully.
+                  Updated by RO when RR transitions to Failed phase or completes with Outcome=Inconclusive
+                  (EA confirms alert still firing, treated as functional failure per BR-ORCH-042.6, #1091).
+                  Reset to 0 when RR enters Verifying phase after successful remediation.
                   Reference: BR-ORCH-042
                 format: int32
                 type: integer
@@ -667,11 +668,12 @@ spec:
               nextAllowedExecution:
                 description: |-
                   NextAllowedExecution indicates when this RR can be retried after exponential backoff.
-                  Set when RR fails due to pre-execution failures (infrastructure, validation, etc.).
+                  Set when RR transitions to Failed phase (pre-execution failures) or when EA
+                  determines an Inconclusive outcome (alert still firing after remediation, #1091).
                   Implements progressive delay: 1m, 2m, 4m, 8m, capped at 10m.
                   Formula: min(Base × 2^(failures-1), Max)
                   Nil means no exponential backoff is active.
-                  Reference: DD-WE-004 (Exponential Backoff Cooldown)
+                  Reference: DD-WE-004 (Exponential Backoff Cooldown), BR-ORCH-042.6 (#1091)
                 format: date-time
                 type: string
               notificationRequestRefs:

--- a/charts/kubernaut/crds/kubernaut.ai_signalprocessings.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_signalprocessings.yaml
@@ -512,7 +512,7 @@ spec:
                 description: |-
                   Severity determination (DD-SEVERITY-001 v1.1)
                   Normalized severity determined by Rego policy: "critical", "high", "medium", "low", or "unknown"
-                  Aligned with HAPI/workflow catalog severity levels for consistency across platform
+                  Aligned with KA/workflow catalog severity levels for consistency across platform
                   Enables downstream services (AIAnalysis, RemediationOrchestrator, Notification)
                   to interpret alert urgency without understanding external severity schemes.
                 enum:
@@ -539,7 +539,7 @@ spec:
                   BR-SP-106: Signal Name Normalization
                   For proactive signals (e.g., "PredictedOOMKill"), this is the base name (e.g., "OOMKilled").
                   For reactive signals, this matches Spec.Signal.Name unchanged.
-                  This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, HAPI).
+                  This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, KA).
                 type: string
               sourceSignalName:
                 description: |-

--- a/charts/kubernaut/crds/kubernaut.ai_workflowexecutions.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_workflowexecutions.yaml
@@ -67,7 +67,7 @@ spec:
               WorkflowExecution represents an immutable event (workflow execution attempt).
               Once created by RemediationOrchestrator, spec cannot be modified to ensure:
               - Audit trail integrity (executed spec matches approved spec)
-              - No parameter tampering after HAPI validation
+              - No parameter tampering after KA validation
               - No target resource changes after routing decisions
 
               To change execution parameters, delete and recreate the WorkflowExecution.

--- a/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
@@ -63,7 +63,7 @@ spec:
               AIAnalysis represents an immutable event (AI investigation).
               Once created by RemediationOrchestrator, spec cannot be modified to ensure:
               - Audit trail integrity (AI investigation matches original RCA request)
-              - No tampering with RCA targets post-HAPI validation
+              - No tampering with RCA targets post-KA validation
               - No workflow selection modification after AI recommendation
 
               To re-analyze, delete and recreate the AIAnalysis CRD.
@@ -271,7 +271,7 @@ spec:
                           SignalMode indicates whether this is a reactive or proactive signal.
                           BR-AI-084: Proactive Signal Mode Prompt Strategy
                           Copied from SignalProcessing status by RemediationOrchestrator.
-                          Used by HAPI to switch investigation prompt (RCA vs. predict & prevent).
+                          Used by Kubernaut Agent to switch investigation prompt (RCA vs. predict & prevent).
                         enum:
                         - reactive
                         - proactive
@@ -692,7 +692,7 @@ spec:
               humanReviewReason:
                 description: |-
                   Reason why human review needed (when NeedsHumanReview=true)
-                  BR-HAPI-197: Maps to HAPI's human_review_reason enum values
+                  BR-HAPI-197: Maps to KA's human_review_reason enum values
                   BR-AI-601: alignment_check_failed added for shadow agent alignment verdicts
                 enum:
                 - workflow_not_found
@@ -717,9 +717,9 @@ spec:
                 description: |-
                   ========================================
                   INVESTIGATION SESSION (BR-AA-HAPI-064)
-                  Tracks the async submit/poll session with HAPI
+                  Tracks the async submit/poll session with Kubernaut Agent
                   ========================================
-                  InvestigationSession tracks the async HAPI session for submit/poll pattern
+                  InvestigationSession tracks the async KA session for submit/poll pattern
                 properties:
                   createdAt:
                     description: CreatedAt timestamp when the current session was
@@ -733,8 +733,8 @@ spec:
                     minimum: 0
                     type: integer
                   id:
-                    description: Session ID returned by HAPI on submit (cleared on
-                      session loss)
+                    description: Session ID returned by Kubernaut Agent on submit
+                      (cleared on session loss)
                     type: string
                   lastPolled:
                     description: LastPolled timestamp of the last poll attempt
@@ -753,9 +753,9 @@ spec:
               investigationTime:
                 description: |-
                   NOTE: TokensUsed REMOVED (Dec 2025)
-                  Reason: LLM token tracking is HAPI's responsibility (they call the LLM)
+                  Reason: LLM token tracking is KA's responsibility (it calls the LLM)
                   Observability: KA exposes kubernaut_agent_llm_token_usage_total Prometheus metric
-                  Correlation: Use InvestigationID to link AIAnalysis CRD to HAPI metrics
+                  Correlation: Use InvestigationID to link AIAnalysis CRD to KA metrics
                   Design Decision: DD-COST-001 - Cost observability is provider's responsibility
                   Investigation duration in seconds
                 format: int64
@@ -767,9 +767,9 @@ spec:
                 description: |-
                   ========================================
                   HUMAN REVIEW SIGNALING (BR-HAPI-197)
-                  Set by HAPI when AI cannot produce reliable result
+                  Set by Kubernaut Agent when AI cannot produce reliable result
                   ========================================
-                  True if human review required (HAPI decision: RCA incomplete/unreliable)
+                  True if human review required (KA decision: RCA incomplete/unreliable)
                   BR-HAPI-197: Triggers NotificationRequest creation in RO
                   BR-496 v2: Set when root_owner missing (rca_incomplete) or validation/confidence issues.
                 type: boolean
@@ -795,14 +795,14 @@ spec:
                 description: |-
                   ========================================
                   POST-RCA CONTEXT (ADR-056)
-                  Runtime-computed cluster characteristics from HAPI
+                  Runtime-computed cluster characteristics from Kubernaut Agent
                   ========================================
-                  PostRCAContext holds data computed by HAPI after RCA (e.g., DetectedLabels).
+                  PostRCAContext holds data computed by Kubernaut Agent after RCA (e.g., DetectedLabels).
                   Immutable once set — use CEL validation on the PostRCAContext type.
                 properties:
                   detectedLabels:
                     description: |-
-                      DetectedLabels contains cluster characteristics computed by HAPI's
+                      DetectedLabels contains cluster characteristics computed by KA's
                       LabelDetector during get_namespaced_resource_context or get_cluster_resource_context tool invocations.
                     properties:
                       failedDetections:
@@ -963,7 +963,7 @@ spec:
                   severity:
                     description: |-
                       Severity determined by RCA (normalized per DD-SEVERITY-001 v1.1)
-                      DD-SEVERITY-001 v1.1: Aligned with HAPI/workflow catalog (critical, high, medium, low, unknown)
+                      DD-SEVERITY-001 v1.1: Aligned with KA/workflow catalog (critical, high, medium, low, unknown)
                     enum:
                     - critical
                     - high
@@ -992,7 +992,7 @@ spec:
                   actionType:
                     description: |-
                       Action type from DD-WORKFLOW-016 taxonomy (e.g., ScaleReplicas, RestartPod).
-                      Propagated from HAPI three-step discovery protocol to RO audit events.
+                      Propagated from KA three-step discovery protocol to RO audit events.
                     type: string
                   confidence:
                     description: Confidence score (0.0-1.0)
@@ -1081,13 +1081,13 @@ spec:
                 type: integer
               validationAttemptsHistory:
                 description: |-
-                  ValidationAttemptsHistory contains complete history of all HAPI validation attempts
-                  Per DD-HAPI-002 v1.4: HAPI retries up to 3 times with LLM self-correction
+                  ValidationAttemptsHistory contains complete history of all KA validation attempts
+                  Per DD-HAPI-002 v1.4: KA retries up to 3 times with LLM self-correction
                   This field provides audit trail for operator notifications and debugging
                 items:
                   description: |-
-                    ValidationAttempt contains details of a single HAPI validation attempt
-                    Per DD-HAPI-002 v1.4: HAPI retries up to 3 times with LLM self-correction
+                    ValidationAttempt contains details of a single KA validation attempt
+                    Per DD-HAPI-002 v1.4: KA retries up to 3 times with LLM self-correction
                     Each attempt feeds validation errors back to the LLM for correction
                   properties:
                     attempt:
@@ -1121,7 +1121,7 @@ spec:
               warnings:
                 description: |-
                   ========================================
-                  HAPI RESPONSE METADATA
+                  KA RESPONSE METADATA
                   ========================================
                   Non-fatal warnings from KA (e.g., low confidence)
                 items:

--- a/charts/kubernaut/files/crds/kubernaut.ai_effectivenessassessments.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_effectivenessassessments.yaml
@@ -135,7 +135,7 @@ spec:
               remediationTarget:
                 description: |-
                   RemediationTarget is the resource the workflow modified.
-                  Source: AA.Status.RootCauseAnalysis.RemediationTarget (from HAPI RCA resolution).
+                  Source: AA.Status.RootCauseAnalysis.RemediationTarget (from KA RCA resolution).
                   Used by: spec hash computation, drift detection (DD-EM-003).
                 properties:
                   apiVersion:

--- a/charts/kubernaut/files/crds/kubernaut.ai_notificationrequests.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_notificationrequests.yaml
@@ -181,7 +181,7 @@ spec:
                           circuit breaker terminated the investigation early.
                         type: boolean
                       humanReviewReason:
-                        description: HumanReviewReason from HAPI when needs_human_review=true
+                        description: HumanReviewReason from Kubernaut Agent when needs_human_review=true
                           (BR-HAPI-197).
                         type: string
                       reason:

--- a/charts/kubernaut/files/crds/kubernaut.ai_remediationrequests.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_remediationrequests.yaml
@@ -423,8 +423,9 @@ spec:
               consecutiveFailureCount:
                 description: |-
                   ConsecutiveFailureCount tracks how many times this fingerprint has failed consecutively.
-                  Updated by RO when RR transitions to Failed phase.
-                  Reset to 0 when RR completes successfully.
+                  Updated by RO when RR transitions to Failed phase or completes with Outcome=Inconclusive
+                  (EA confirms alert still firing, treated as functional failure per BR-ORCH-042.6, #1091).
+                  Reset to 0 when RR enters Verifying phase after successful remediation.
                   Reference: BR-ORCH-042
                 format: int32
                 type: integer
@@ -667,11 +668,12 @@ spec:
               nextAllowedExecution:
                 description: |-
                   NextAllowedExecution indicates when this RR can be retried after exponential backoff.
-                  Set when RR fails due to pre-execution failures (infrastructure, validation, etc.).
+                  Set when RR transitions to Failed phase (pre-execution failures) or when EA
+                  determines an Inconclusive outcome (alert still firing after remediation, #1091).
                   Implements progressive delay: 1m, 2m, 4m, 8m, capped at 10m.
                   Formula: min(Base × 2^(failures-1), Max)
                   Nil means no exponential backoff is active.
-                  Reference: DD-WE-004 (Exponential Backoff Cooldown)
+                  Reference: DD-WE-004 (Exponential Backoff Cooldown), BR-ORCH-042.6 (#1091)
                 format: date-time
                 type: string
               notificationRequestRefs:

--- a/charts/kubernaut/files/crds/kubernaut.ai_signalprocessings.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_signalprocessings.yaml
@@ -512,7 +512,7 @@ spec:
                 description: |-
                   Severity determination (DD-SEVERITY-001 v1.1)
                   Normalized severity determined by Rego policy: "critical", "high", "medium", "low", or "unknown"
-                  Aligned with HAPI/workflow catalog severity levels for consistency across platform
+                  Aligned with KA/workflow catalog severity levels for consistency across platform
                   Enables downstream services (AIAnalysis, RemediationOrchestrator, Notification)
                   to interpret alert urgency without understanding external severity schemes.
                 enum:
@@ -539,7 +539,7 @@ spec:
                   BR-SP-106: Signal Name Normalization
                   For proactive signals (e.g., "PredictedOOMKill"), this is the base name (e.g., "OOMKilled").
                   For reactive signals, this matches Spec.Signal.Name unchanged.
-                  This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, HAPI).
+                  This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, KA).
                 type: string
               sourceSignalName:
                 description: |-

--- a/charts/kubernaut/files/crds/kubernaut.ai_workflowexecutions.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_workflowexecutions.yaml
@@ -67,7 +67,7 @@ spec:
               WorkflowExecution represents an immutable event (workflow execution attempt).
               Once created by RemediationOrchestrator, spec cannot be modified to ensure:
               - Audit trail integrity (executed spec matches approved spec)
-              - No parameter tampering after HAPI validation
+              - No parameter tampering after KA validation
               - No target resource changes after routing decisions
 
               To change execution parameters, delete and recreate the WorkflowExecution.

--- a/config/crd/bases/kubernaut.ai_aianalyses.yaml
+++ b/config/crd/bases/kubernaut.ai_aianalyses.yaml
@@ -63,7 +63,7 @@ spec:
               AIAnalysis represents an immutable event (AI investigation).
               Once created by RemediationOrchestrator, spec cannot be modified to ensure:
               - Audit trail integrity (AI investigation matches original RCA request)
-              - No tampering with RCA targets post-HAPI validation
+              - No tampering with RCA targets post-KA validation
               - No workflow selection modification after AI recommendation
 
               To re-analyze, delete and recreate the AIAnalysis CRD.
@@ -271,7 +271,7 @@ spec:
                           SignalMode indicates whether this is a reactive or proactive signal.
                           BR-AI-084: Proactive Signal Mode Prompt Strategy
                           Copied from SignalProcessing status by RemediationOrchestrator.
-                          Used by HAPI to switch investigation prompt (RCA vs. predict & prevent).
+                          Used by Kubernaut Agent to switch investigation prompt (RCA vs. predict & prevent).
                         enum:
                         - reactive
                         - proactive
@@ -692,7 +692,7 @@ spec:
               humanReviewReason:
                 description: |-
                   Reason why human review needed (when NeedsHumanReview=true)
-                  BR-HAPI-197: Maps to HAPI's human_review_reason enum values
+                  BR-HAPI-197: Maps to KA's human_review_reason enum values
                   BR-AI-601: alignment_check_failed added for shadow agent alignment verdicts
                 enum:
                 - workflow_not_found
@@ -717,9 +717,9 @@ spec:
                 description: |-
                   ========================================
                   INVESTIGATION SESSION (BR-AA-HAPI-064)
-                  Tracks the async submit/poll session with HAPI
+                  Tracks the async submit/poll session with Kubernaut Agent
                   ========================================
-                  InvestigationSession tracks the async HAPI session for submit/poll pattern
+                  InvestigationSession tracks the async KA session for submit/poll pattern
                 properties:
                   createdAt:
                     description: CreatedAt timestamp when the current session was
@@ -733,8 +733,8 @@ spec:
                     minimum: 0
                     type: integer
                   id:
-                    description: Session ID returned by HAPI on submit (cleared on
-                      session loss)
+                    description: Session ID returned by Kubernaut Agent on submit
+                      (cleared on session loss)
                     type: string
                   lastPolled:
                     description: LastPolled timestamp of the last poll attempt
@@ -753,9 +753,9 @@ spec:
               investigationTime:
                 description: |-
                   NOTE: TokensUsed REMOVED (Dec 2025)
-                  Reason: LLM token tracking is HAPI's responsibility (they call the LLM)
+                  Reason: LLM token tracking is KA's responsibility (it calls the LLM)
                   Observability: KA exposes kubernaut_agent_llm_token_usage_total Prometheus metric
-                  Correlation: Use InvestigationID to link AIAnalysis CRD to HAPI metrics
+                  Correlation: Use InvestigationID to link AIAnalysis CRD to KA metrics
                   Design Decision: DD-COST-001 - Cost observability is provider's responsibility
                   Investigation duration in seconds
                 format: int64
@@ -767,9 +767,9 @@ spec:
                 description: |-
                   ========================================
                   HUMAN REVIEW SIGNALING (BR-HAPI-197)
-                  Set by HAPI when AI cannot produce reliable result
+                  Set by Kubernaut Agent when AI cannot produce reliable result
                   ========================================
-                  True if human review required (HAPI decision: RCA incomplete/unreliable)
+                  True if human review required (KA decision: RCA incomplete/unreliable)
                   BR-HAPI-197: Triggers NotificationRequest creation in RO
                   BR-496 v2: Set when root_owner missing (rca_incomplete) or validation/confidence issues.
                 type: boolean
@@ -795,14 +795,14 @@ spec:
                 description: |-
                   ========================================
                   POST-RCA CONTEXT (ADR-056)
-                  Runtime-computed cluster characteristics from HAPI
+                  Runtime-computed cluster characteristics from Kubernaut Agent
                   ========================================
-                  PostRCAContext holds data computed by HAPI after RCA (e.g., DetectedLabels).
+                  PostRCAContext holds data computed by Kubernaut Agent after RCA (e.g., DetectedLabels).
                   Immutable once set — use CEL validation on the PostRCAContext type.
                 properties:
                   detectedLabels:
                     description: |-
-                      DetectedLabels contains cluster characteristics computed by HAPI's
+                      DetectedLabels contains cluster characteristics computed by KA's
                       LabelDetector during get_namespaced_resource_context or get_cluster_resource_context tool invocations.
                     properties:
                       failedDetections:
@@ -963,7 +963,7 @@ spec:
                   severity:
                     description: |-
                       Severity determined by RCA (normalized per DD-SEVERITY-001 v1.1)
-                      DD-SEVERITY-001 v1.1: Aligned with HAPI/workflow catalog (critical, high, medium, low, unknown)
+                      DD-SEVERITY-001 v1.1: Aligned with KA/workflow catalog (critical, high, medium, low, unknown)
                     enum:
                     - critical
                     - high
@@ -992,7 +992,7 @@ spec:
                   actionType:
                     description: |-
                       Action type from DD-WORKFLOW-016 taxonomy (e.g., ScaleReplicas, RestartPod).
-                      Propagated from HAPI three-step discovery protocol to RO audit events.
+                      Propagated from KA three-step discovery protocol to RO audit events.
                     type: string
                   confidence:
                     description: Confidence score (0.0-1.0)
@@ -1081,13 +1081,13 @@ spec:
                 type: integer
               validationAttemptsHistory:
                 description: |-
-                  ValidationAttemptsHistory contains complete history of all HAPI validation attempts
-                  Per DD-HAPI-002 v1.4: HAPI retries up to 3 times with LLM self-correction
+                  ValidationAttemptsHistory contains complete history of all KA validation attempts
+                  Per DD-HAPI-002 v1.4: KA retries up to 3 times with LLM self-correction
                   This field provides audit trail for operator notifications and debugging
                 items:
                   description: |-
-                    ValidationAttempt contains details of a single HAPI validation attempt
-                    Per DD-HAPI-002 v1.4: HAPI retries up to 3 times with LLM self-correction
+                    ValidationAttempt contains details of a single KA validation attempt
+                    Per DD-HAPI-002 v1.4: KA retries up to 3 times with LLM self-correction
                     Each attempt feeds validation errors back to the LLM for correction
                   properties:
                     attempt:
@@ -1121,7 +1121,7 @@ spec:
               warnings:
                 description: |-
                   ========================================
-                  HAPI RESPONSE METADATA
+                  KA RESPONSE METADATA
                   ========================================
                   Non-fatal warnings from KA (e.g., low confidence)
                 items:

--- a/config/crd/bases/kubernaut.ai_effectivenessassessments.yaml
+++ b/config/crd/bases/kubernaut.ai_effectivenessassessments.yaml
@@ -135,7 +135,7 @@ spec:
               remediationTarget:
                 description: |-
                   RemediationTarget is the resource the workflow modified.
-                  Source: AA.Status.RootCauseAnalysis.RemediationTarget (from HAPI RCA resolution).
+                  Source: AA.Status.RootCauseAnalysis.RemediationTarget (from KA RCA resolution).
                   Used by: spec hash computation, drift detection (DD-EM-003).
                 properties:
                   apiVersion:

--- a/config/crd/bases/kubernaut.ai_notificationrequests.yaml
+++ b/config/crd/bases/kubernaut.ai_notificationrequests.yaml
@@ -181,7 +181,7 @@ spec:
                           circuit breaker terminated the investigation early.
                         type: boolean
                       humanReviewReason:
-                        description: HumanReviewReason from HAPI when needs_human_review=true
+                        description: HumanReviewReason from Kubernaut Agent when needs_human_review=true
                           (BR-HAPI-197).
                         type: string
                       reason:

--- a/config/crd/bases/kubernaut.ai_remediationrequests.yaml
+++ b/config/crd/bases/kubernaut.ai_remediationrequests.yaml
@@ -423,8 +423,9 @@ spec:
               consecutiveFailureCount:
                 description: |-
                   ConsecutiveFailureCount tracks how many times this fingerprint has failed consecutively.
-                  Updated by RO when RR transitions to Failed phase.
-                  Reset to 0 when RR completes successfully.
+                  Updated by RO when RR transitions to Failed phase or completes with Outcome=Inconclusive
+                  (EA confirms alert still firing, treated as functional failure per BR-ORCH-042.6, #1091).
+                  Reset to 0 when RR enters Verifying phase after successful remediation.
                   Reference: BR-ORCH-042
                 format: int32
                 type: integer
@@ -667,11 +668,12 @@ spec:
               nextAllowedExecution:
                 description: |-
                   NextAllowedExecution indicates when this RR can be retried after exponential backoff.
-                  Set when RR fails due to pre-execution failures (infrastructure, validation, etc.).
+                  Set when RR transitions to Failed phase (pre-execution failures) or when EA
+                  determines an Inconclusive outcome (alert still firing after remediation, #1091).
                   Implements progressive delay: 1m, 2m, 4m, 8m, capped at 10m.
                   Formula: min(Base × 2^(failures-1), Max)
                   Nil means no exponential backoff is active.
-                  Reference: DD-WE-004 (Exponential Backoff Cooldown)
+                  Reference: DD-WE-004 (Exponential Backoff Cooldown), BR-ORCH-042.6 (#1091)
                 format: date-time
                 type: string
               notificationRequestRefs:

--- a/config/crd/bases/kubernaut.ai_signalprocessings.yaml
+++ b/config/crd/bases/kubernaut.ai_signalprocessings.yaml
@@ -512,7 +512,7 @@ spec:
                 description: |-
                   Severity determination (DD-SEVERITY-001 v1.1)
                   Normalized severity determined by Rego policy: "critical", "high", "medium", "low", or "unknown"
-                  Aligned with HAPI/workflow catalog severity levels for consistency across platform
+                  Aligned with KA/workflow catalog severity levels for consistency across platform
                   Enables downstream services (AIAnalysis, RemediationOrchestrator, Notification)
                   to interpret alert urgency without understanding external severity schemes.
                 enum:
@@ -539,7 +539,7 @@ spec:
                   BR-SP-106: Signal Name Normalization
                   For proactive signals (e.g., "PredictedOOMKill"), this is the base name (e.g., "OOMKilled").
                   For reactive signals, this matches Spec.Signal.Name unchanged.
-                  This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, HAPI).
+                  This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, KA).
                 type: string
               sourceSignalName:
                 description: |-

--- a/config/crd/bases/kubernaut.ai_workflowexecutions.yaml
+++ b/config/crd/bases/kubernaut.ai_workflowexecutions.yaml
@@ -67,7 +67,7 @@ spec:
               WorkflowExecution represents an immutable event (workflow execution attempt).
               Once created by RemediationOrchestrator, spec cannot be modified to ensure:
               - Audit trail integrity (executed spec matches approved spec)
-              - No parameter tampering after HAPI validation
+              - No parameter tampering after KA validation
               - No target resource changes after routing decisions
 
               To change execution parameters, delete and recreate the WorkflowExecution.

--- a/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
@@ -63,7 +63,7 @@ spec:
               AIAnalysis represents an immutable event (AI investigation).
               Once created by RemediationOrchestrator, spec cannot be modified to ensure:
               - Audit trail integrity (AI investigation matches original RCA request)
-              - No tampering with RCA targets post-HAPI validation
+              - No tampering with RCA targets post-KA validation
               - No workflow selection modification after AI recommendation
 
               To re-analyze, delete and recreate the AIAnalysis CRD.
@@ -271,7 +271,7 @@ spec:
                           SignalMode indicates whether this is a reactive or proactive signal.
                           BR-AI-084: Proactive Signal Mode Prompt Strategy
                           Copied from SignalProcessing status by RemediationOrchestrator.
-                          Used by HAPI to switch investigation prompt (RCA vs. predict & prevent).
+                          Used by Kubernaut Agent to switch investigation prompt (RCA vs. predict & prevent).
                         enum:
                         - reactive
                         - proactive
@@ -692,7 +692,7 @@ spec:
               humanReviewReason:
                 description: |-
                   Reason why human review needed (when NeedsHumanReview=true)
-                  BR-HAPI-197: Maps to HAPI's human_review_reason enum values
+                  BR-HAPI-197: Maps to KA's human_review_reason enum values
                   BR-AI-601: alignment_check_failed added for shadow agent alignment verdicts
                 enum:
                 - workflow_not_found
@@ -717,9 +717,9 @@ spec:
                 description: |-
                   ========================================
                   INVESTIGATION SESSION (BR-AA-HAPI-064)
-                  Tracks the async submit/poll session with HAPI
+                  Tracks the async submit/poll session with Kubernaut Agent
                   ========================================
-                  InvestigationSession tracks the async HAPI session for submit/poll pattern
+                  InvestigationSession tracks the async KA session for submit/poll pattern
                 properties:
                   createdAt:
                     description: CreatedAt timestamp when the current session was
@@ -733,8 +733,8 @@ spec:
                     minimum: 0
                     type: integer
                   id:
-                    description: Session ID returned by HAPI on submit (cleared on
-                      session loss)
+                    description: Session ID returned by Kubernaut Agent on submit
+                      (cleared on session loss)
                     type: string
                   lastPolled:
                     description: LastPolled timestamp of the last poll attempt
@@ -753,9 +753,9 @@ spec:
               investigationTime:
                 description: |-
                   NOTE: TokensUsed REMOVED (Dec 2025)
-                  Reason: LLM token tracking is HAPI's responsibility (they call the LLM)
+                  Reason: LLM token tracking is KA's responsibility (it calls the LLM)
                   Observability: KA exposes kubernaut_agent_llm_token_usage_total Prometheus metric
-                  Correlation: Use InvestigationID to link AIAnalysis CRD to HAPI metrics
+                  Correlation: Use InvestigationID to link AIAnalysis CRD to KA metrics
                   Design Decision: DD-COST-001 - Cost observability is provider's responsibility
                   Investigation duration in seconds
                 format: int64
@@ -767,9 +767,9 @@ spec:
                 description: |-
                   ========================================
                   HUMAN REVIEW SIGNALING (BR-HAPI-197)
-                  Set by HAPI when AI cannot produce reliable result
+                  Set by Kubernaut Agent when AI cannot produce reliable result
                   ========================================
-                  True if human review required (HAPI decision: RCA incomplete/unreliable)
+                  True if human review required (KA decision: RCA incomplete/unreliable)
                   BR-HAPI-197: Triggers NotificationRequest creation in RO
                   BR-496 v2: Set when root_owner missing (rca_incomplete) or validation/confidence issues.
                 type: boolean
@@ -795,14 +795,14 @@ spec:
                 description: |-
                   ========================================
                   POST-RCA CONTEXT (ADR-056)
-                  Runtime-computed cluster characteristics from HAPI
+                  Runtime-computed cluster characteristics from Kubernaut Agent
                   ========================================
-                  PostRCAContext holds data computed by HAPI after RCA (e.g., DetectedLabels).
+                  PostRCAContext holds data computed by Kubernaut Agent after RCA (e.g., DetectedLabels).
                   Immutable once set — use CEL validation on the PostRCAContext type.
                 properties:
                   detectedLabels:
                     description: |-
-                      DetectedLabels contains cluster characteristics computed by HAPI's
+                      DetectedLabels contains cluster characteristics computed by KA's
                       LabelDetector during get_namespaced_resource_context or get_cluster_resource_context tool invocations.
                     properties:
                       failedDetections:
@@ -963,7 +963,7 @@ spec:
                   severity:
                     description: |-
                       Severity determined by RCA (normalized per DD-SEVERITY-001 v1.1)
-                      DD-SEVERITY-001 v1.1: Aligned with HAPI/workflow catalog (critical, high, medium, low, unknown)
+                      DD-SEVERITY-001 v1.1: Aligned with KA/workflow catalog (critical, high, medium, low, unknown)
                     enum:
                     - critical
                     - high
@@ -992,7 +992,7 @@ spec:
                   actionType:
                     description: |-
                       Action type from DD-WORKFLOW-016 taxonomy (e.g., ScaleReplicas, RestartPod).
-                      Propagated from HAPI three-step discovery protocol to RO audit events.
+                      Propagated from KA three-step discovery protocol to RO audit events.
                     type: string
                   confidence:
                     description: Confidence score (0.0-1.0)
@@ -1081,13 +1081,13 @@ spec:
                 type: integer
               validationAttemptsHistory:
                 description: |-
-                  ValidationAttemptsHistory contains complete history of all HAPI validation attempts
-                  Per DD-HAPI-002 v1.4: HAPI retries up to 3 times with LLM self-correction
+                  ValidationAttemptsHistory contains complete history of all KA validation attempts
+                  Per DD-HAPI-002 v1.4: KA retries up to 3 times with LLM self-correction
                   This field provides audit trail for operator notifications and debugging
                 items:
                   description: |-
-                    ValidationAttempt contains details of a single HAPI validation attempt
-                    Per DD-HAPI-002 v1.4: HAPI retries up to 3 times with LLM self-correction
+                    ValidationAttempt contains details of a single KA validation attempt
+                    Per DD-HAPI-002 v1.4: KA retries up to 3 times with LLM self-correction
                     Each attempt feeds validation errors back to the LLM for correction
                   properties:
                     attempt:
@@ -1121,7 +1121,7 @@ spec:
               warnings:
                 description: |-
                   ========================================
-                  HAPI RESPONSE METADATA
+                  KA RESPONSE METADATA
                   ========================================
                   Non-fatal warnings from KA (e.g., low confidence)
                 items:

--- a/pkg/shared/assets/crds/kubernaut.ai_effectivenessassessments.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_effectivenessassessments.yaml
@@ -135,7 +135,7 @@ spec:
               remediationTarget:
                 description: |-
                   RemediationTarget is the resource the workflow modified.
-                  Source: AA.Status.RootCauseAnalysis.RemediationTarget (from HAPI RCA resolution).
+                  Source: AA.Status.RootCauseAnalysis.RemediationTarget (from KA RCA resolution).
                   Used by: spec hash computation, drift detection (DD-EM-003).
                 properties:
                   apiVersion:

--- a/pkg/shared/assets/crds/kubernaut.ai_notificationrequests.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_notificationrequests.yaml
@@ -181,7 +181,7 @@ spec:
                           circuit breaker terminated the investigation early.
                         type: boolean
                       humanReviewReason:
-                        description: HumanReviewReason from HAPI when needs_human_review=true
+                        description: HumanReviewReason from Kubernaut Agent when needs_human_review=true
                           (BR-HAPI-197).
                         type: string
                       reason:

--- a/pkg/shared/assets/crds/kubernaut.ai_remediationrequests.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_remediationrequests.yaml
@@ -423,8 +423,9 @@ spec:
               consecutiveFailureCount:
                 description: |-
                   ConsecutiveFailureCount tracks how many times this fingerprint has failed consecutively.
-                  Updated by RO when RR transitions to Failed phase.
-                  Reset to 0 when RR completes successfully.
+                  Updated by RO when RR transitions to Failed phase or completes with Outcome=Inconclusive
+                  (EA confirms alert still firing, treated as functional failure per BR-ORCH-042.6, #1091).
+                  Reset to 0 when RR enters Verifying phase after successful remediation.
                   Reference: BR-ORCH-042
                 format: int32
                 type: integer
@@ -667,11 +668,12 @@ spec:
               nextAllowedExecution:
                 description: |-
                   NextAllowedExecution indicates when this RR can be retried after exponential backoff.
-                  Set when RR fails due to pre-execution failures (infrastructure, validation, etc.).
+                  Set when RR transitions to Failed phase (pre-execution failures) or when EA
+                  determines an Inconclusive outcome (alert still firing after remediation, #1091).
                   Implements progressive delay: 1m, 2m, 4m, 8m, capped at 10m.
                   Formula: min(Base × 2^(failures-1), Max)
                   Nil means no exponential backoff is active.
-                  Reference: DD-WE-004 (Exponential Backoff Cooldown)
+                  Reference: DD-WE-004 (Exponential Backoff Cooldown), BR-ORCH-042.6 (#1091)
                 format: date-time
                 type: string
               notificationRequestRefs:

--- a/pkg/shared/assets/crds/kubernaut.ai_signalprocessings.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_signalprocessings.yaml
@@ -512,7 +512,7 @@ spec:
                 description: |-
                   Severity determination (DD-SEVERITY-001 v1.1)
                   Normalized severity determined by Rego policy: "critical", "high", "medium", "low", or "unknown"
-                  Aligned with HAPI/workflow catalog severity levels for consistency across platform
+                  Aligned with KA/workflow catalog severity levels for consistency across platform
                   Enables downstream services (AIAnalysis, RemediationOrchestrator, Notification)
                   to interpret alert urgency without understanding external severity schemes.
                 enum:
@@ -539,7 +539,7 @@ spec:
                   BR-SP-106: Signal Name Normalization
                   For proactive signals (e.g., "PredictedOOMKill"), this is the base name (e.g., "OOMKilled").
                   For reactive signals, this matches Spec.Signal.Name unchanged.
-                  This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, HAPI).
+                  This is the AUTHORITATIVE signal name for all downstream consumers (RO, AA, KA).
                 type: string
               sourceSignalName:
                 description: |-

--- a/pkg/shared/assets/crds/kubernaut.ai_workflowexecutions.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_workflowexecutions.yaml
@@ -67,7 +67,7 @@ spec:
               WorkflowExecution represents an immutable event (workflow execution attempt).
               Once created by RemediationOrchestrator, spec cannot be modified to ensure:
               - Audit trail integrity (executed spec matches approved spec)
-              - No parameter tampering after HAPI validation
+              - No parameter tampering after KA validation
               - No target resource changes after routing decisions
 
               To change execution parameters, delete and recreate the WorkflowExecution.


### PR DESCRIPTION
## Summary

Addresses findings from the multi-dimensional readiness audit on PR #1104:

- **BLOCKER resolved**: Regenerated 24 CRD YAML manifests across 4 locations (`charts/crds`, `charts/files/crds`, `config/crd/bases`, `pkg/shared/assets/crds`) that were out of sync after the HAPI → KA rename in api/ source comments (#1103)
- **CHANGELOG accuracy fixes**:
  - `networkPolicy` → `networkPolicies` (plural) in upgrade notes to match actual Helm values key
  - KA config domains corrected from `server/ai/tools` to `runtime/ai/integrations` (actual top-level YAML keys)
- **Missing features added to CHANGELOG**:
  - Inter-service TLS with security profiles (#748)
  - RO config hot-reload (#835)
  - Cache sync readiness gating (#852, #853)
  - Authenticated audit actor (#998)
  - LLM/DS circuit breaker (OPS-2)
  - SBOM/license scan (COMP-1)
  - RCA completion audit event (#847)

## Test plan

- [x] `go build ./...` passes
- [x] `go test -run='^$' ./...` compiles all test packages
- [x] Pre-commit hooks pass (CRD docs drift, enum drift, anti-patterns)
- [x] Zero HAPI prose in CRD YAML manifests (only BR-HAPI-* artifact IDs remain)
- [x] `networkPolicies` key matches `charts/kubernaut/values.yaml`
- [x] KA config domain names match `internal/kubernautagent/config/config.go` struct tags


Made with [Cursor](https://cursor.com)