### PR TITLE
fix: prevent chart releases from claiming GitHub Latest badge

### DIFF
--- a/.github/workflows/chart-release.yml
+++ b/.github/workflows/chart-release.yml
@@ -65,6 +65,7 @@ jobs:
           APP_VERSION: ${{ steps.versions.outputs.app_version }}
         run: |
           gh release create "${TAG}" \
+            --latest=false \
             --title "Chart ${CHART_VERSION}" \
             --notes "Helm chart version **${CHART_VERSION}** for Kubernaut operator **v${APP_VERSION}**.
 


### PR DESCRIPTION
## Summary
- Adds `--latest=false` to the `gh release create` step in `chart-release.yml`
- GitHub only supports a single "Latest" badge on the Releases page — operator releases (`v*`) should always hold it, not chart-only releases (`chart-v*`)

## Context
After releasing `chart-v1.4.1`, it automatically took the "Latest" badge from `v1.4.0`. This was manually corrected, but this fix prevents recurrence for all future chart releases.

## Change
One-line addition in `.github/workflows/chart-release.yml`.

## Test plan
- [x] Verified `v1.4.0` is currently shown as Latest on GitHub
- [ ] Next `chart-v*` release will confirm the flag works as expected


Made with [Cursor](https://cursor.com)