### PR TITLE
fix(docker): use go build for cross-arch goose compilation

### DIFF
--- a/docker/db-migrate.Dockerfile
+++ b/docker/db-migrate.Dockerfile
@@ -18,8 +18,12 @@ ARG BUILD_DATE=unknown
 
 FROM --platform=$BUILDPLATFORM golang:1.25.10-bookworm AS goose-builder
 ARG TARGETARCH
-ENV CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GOBIN=/go/bin
-RUN go install github.com/pressly/goose/v3/cmd/goose@v3.27.1
+ENV CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH}
+RUN GOMODCACHE=$(mktemp -d) && \
+    cd "$GOMODCACHE" && \
+    go mod init tmp && \
+    go get github.com/pressly/goose/v3/cmd/goose@v3.27.1 && \
+    go build -o /go/bin/goose github.com/pressly/goose/v3/cmd/goose
 
 FROM registry.access.redhat.com/ubi10/ubi-minimal:latest AS production
 


### PR DESCRIPTION
## Summary
- `go install` cannot cross-compile when `GOBIN` is set (`go: cannot install cross-compiled binaries when GOBIN is set`)
- Replace with `go build -o /go/bin/goose` which explicitly sets the output path and works correctly for cross-compilation (BUILDPLATFORM=amd64, TARGETARCH=arm64)
- Fixes db-migrate arm64 QEMU build failure in the release workflow

## Test plan
- [ ] Release workflow db-migrate (arm64, QEMU) job passes
- [ ] Release workflow db-migrate (amd64) job still passes

Made with [Cursor](https://cursor.com)