### PR TITLE
feat(mock-llm): add Gemini generateContent endpoint for AF A2A integration

### DIFF
--- a/test/integration/mockllm/gemini_test.go
+++ b/test/integration/mockllm/gemini_test.go
@@ -1,0 +1,248 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package mockllm_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/test/services/mock-llm/handlers"
+	"github.com/jordigilh/kubernaut/test/services/mock-llm/response"
+	"github.com/jordigilh/kubernaut/test/services/mock-llm/scenarios"
+)
+
+var _ = Describe("Gemini generateContent Endpoint (issue #1157)", func() {
+
+	var server *httptest.Server
+
+	BeforeEach(func() {
+		registry := scenarios.DefaultRegistry()
+		router := handlers.NewRouter(registry, false, "")
+		server = httptest.NewServer(router)
+	})
+
+	AfterEach(func() {
+		server.Close()
+	})
+
+	Describe("IT-MOCK-GEMINI-001: POST /v1beta/models/{model}:generateContent", func() {
+		It("IT-MOCK-GEMINI-001-001: should return text response for request without tools", func() {
+			body := geminiRequest("- Signal Name: OOMKilled\n- Namespace: default", nil)
+			resp, err := http.Post(server.URL+"/v1beta/models/gemini-2.0-flash:generateContent", "application/json", body)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+
+			var result response.GeminiResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&result)).To(Succeed())
+			Expect(result.Candidates).To(HaveLen(1))
+			Expect(result.Candidates[0].Content.Role).To(Equal("model"))
+			Expect(result.Candidates[0].FinishReason).To(Equal("STOP"))
+			Expect(result.Candidates[0].Content.Parts).To(HaveLen(1))
+			Expect(result.Candidates[0].Content.Parts[0].Text).To(ContainSubstring("root_cause_analysis"))
+			Expect(result.ModelVersion).To(Equal("mock-model"))
+		})
+
+		It("IT-MOCK-GEMINI-001-002: should return function call when tools are provided", func() {
+			tools := []response.GeminiToolDecl{
+				{FunctionDeclarations: []response.GeminiFunctionDecl{
+					{Name: "search_workflow_catalog", Description: "Search workflows"},
+				}},
+			}
+			body := geminiRequestWithTools("- Signal Name: OOMKilled\n- Namespace: default", tools)
+			resp, err := http.Post(server.URL+"/v1beta/models/gemini-2.0-flash:generateContent", "application/json", body)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+
+			var result response.GeminiResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&result)).To(Succeed())
+			Expect(result.Candidates).To(HaveLen(1))
+			parts := result.Candidates[0].Content.Parts
+			Expect(parts).To(HaveLen(1))
+			Expect(parts[0].FunctionCall.Name).To(Equal("search_workflow_catalog"))
+		})
+
+		It("IT-MOCK-GEMINI-001-003: should return text after function response is provided", func() {
+			contents := []response.GeminiContent{
+				{Role: "user", Parts: []response.GeminiPart{{Text: "- Signal Name: OOMKilled\n- Namespace: default"}}},
+				{Role: "model", Parts: []response.GeminiPart{
+					{FunctionCall: &response.GeminiFunctionCall{Name: "search_workflow_catalog", Args: map[string]interface{}{"query": "OOMKilled"}}},
+				}},
+				{Role: "user", Parts: []response.GeminiPart{
+					{FunctionResponse: &response.GeminiFunctionResp{Name: "search_workflow_catalog", Response: map[string]string{"result": "found"}}},
+				}},
+			}
+			tools := []response.GeminiToolDecl{
+				{FunctionDeclarations: []response.GeminiFunctionDecl{
+					{Name: "search_workflow_catalog", Description: "Search workflows"},
+				}},
+			}
+			body := geminiRequestFull(contents, tools, nil)
+			resp, err := http.Post(server.URL+"/v1beta/models/gemini-2.0-flash:generateContent", "application/json", body)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+
+			var result response.GeminiResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&result)).To(Succeed())
+			Expect(result.Candidates).To(HaveLen(1))
+			parts := result.Candidates[0].Content.Parts
+			Expect(parts).To(HaveLen(1))
+			// After function results come back, should return text (or submit tool)
+			hasText := parts[0].Text != ""
+			hasFuncCall := parts[0].FunctionCall != nil
+			Expect(hasText || hasFuncCall).To(BeTrue(),
+				"expected either text or a follow-up function call after function response")
+		})
+
+		It("IT-MOCK-GEMINI-001-004: should return 500 for permanent error keyword", func() {
+			body := geminiRequest("mock_rca_permanent_error", nil)
+			resp, err := http.Post(server.URL+"/v1beta/models/gemini-2.0-flash:generateContent", "application/json", body)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(500))
+		})
+
+		It("IT-MOCK-GEMINI-001-005: should return 405 for non-POST methods", func() {
+			resp, err := http.Get(server.URL + "/v1beta/models/gemini-2.0-flash:generateContent")
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(405))
+		})
+
+		It("IT-MOCK-GEMINI-001-006: should return 404 for paths without :generateContent suffix", func() {
+			body := geminiRequest("hello", nil)
+			resp, err := http.Post(server.URL+"/v1beta/models/gemini-2.0-flash:streamGenerateContent", "application/json", body)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(404))
+		})
+
+		It("IT-MOCK-GEMINI-001-007: should return 400 for invalid JSON", func() {
+			resp, err := http.Post(server.URL+"/v1beta/models/gemini-2.0-flash:generateContent", "application/json", bytes.NewBufferString("{invalid"))
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(400))
+		})
+	})
+
+	Describe("IT-MOCK-GEMINI-002: Force-text mode for Gemini", func() {
+		It("IT-MOCK-GEMINI-002-001: should return text even when tools are provided in force-text mode", func() {
+			registry := scenarios.DefaultRegistry()
+			router := handlers.NewRouter(registry, true, "")
+			ftServer := httptest.NewServer(router)
+			defer ftServer.Close()
+
+			tools := []response.GeminiToolDecl{
+				{FunctionDeclarations: []response.GeminiFunctionDecl{
+					{Name: "search_workflow_catalog", Description: "Search workflows"},
+				}},
+			}
+			body := geminiRequestWithTools("- Signal Name: OOMKilled", tools)
+			resp, err := http.Post(ftServer.URL+"/v1beta/models/gemini-2.0-flash:generateContent", "application/json", body)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+
+			var result response.GeminiResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&result)).To(Succeed())
+			Expect(result.Candidates[0].Content.Parts[0].Text).To(ContainSubstring("root_cause_analysis"))
+			Expect(result.Candidates[0].Content.Parts[0].FunctionCall).To(BeNil())
+		})
+	})
+
+	Describe("IT-MOCK-GEMINI-002b: Interactive mode for Gemini", func() {
+		It("IT-MOCK-GEMINI-002b-001: should always return text in interactive mode even with tools", func() {
+			registry := scenarios.DefaultRegistry()
+			router := handlers.NewRouter(registry, false, "interactive")
+			iServer := httptest.NewServer(router)
+			defer iServer.Close()
+
+			tools := []response.GeminiToolDecl{
+				{FunctionDeclarations: []response.GeminiFunctionDecl{
+					{Name: "search_workflow_catalog", Description: "Search workflows"},
+				}},
+			}
+			body := geminiRequestWithTools("- Signal Name: OOMKilled\n- Namespace: default", tools)
+			resp, err := http.Post(iServer.URL+"/v1beta/models/gemini-2.0-flash:generateContent", "application/json", body)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+
+			var result response.GeminiResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&result)).To(Succeed())
+			Expect(result.Candidates[0].Content.Parts[0].Text).To(ContainSubstring("root_cause_analysis"))
+			Expect(result.Candidates[0].Content.Parts[0].FunctionCall).To(BeNil())
+		})
+	})
+
+	Describe("IT-MOCK-GEMINI-003: Scenario detection via Gemini", func() {
+		It("IT-MOCK-GEMINI-003-001: should detect OOMKilled scenario from Gemini content", func() {
+			body := geminiRequest("- Signal Name: OOMKilled\n- Namespace: production", nil)
+			resp, err := http.Post(server.URL+"/v1beta/models/gemini-2.0-flash:generateContent", "application/json", body)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+
+			var result response.GeminiResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&result)).To(Succeed())
+			Expect(result.Candidates[0].Content.Parts[0].Text).To(ContainSubstring("memory"))
+		})
+
+		It("IT-MOCK-GEMINI-003-002: should detect CrashLoopBackOff scenario from Gemini content", func() {
+			body := geminiRequest("- Signal Name: CrashLoopBackOff\n- Namespace: staging", nil)
+			resp, err := http.Post(server.URL+"/v1beta/models/gemini-2.0-flash:generateContent", "application/json", body)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(200))
+
+			var result response.GeminiResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&result)).To(Succeed())
+			Expect(result.Candidates[0].Content.Parts[0].Text).To(ContainSubstring("root_cause_analysis"))
+		})
+	})
+})
+
+func geminiRequest(userText string, tools []response.GeminiToolDecl) *bytes.Buffer {
+	req := response.GeminiRequest{
+		Contents: []response.GeminiContent{
+			{Role: "user", Parts: []response.GeminiPart{{Text: userText}}},
+		},
+		Tools: tools,
+	}
+	data, _ := json.Marshal(req)
+	return bytes.NewBuffer(data)
+}
+
+func geminiRequestWithTools(userText string, tools []response.GeminiToolDecl) *bytes.Buffer {
+	return geminiRequest(userText, tools)
+}
+
+func geminiRequestFull(contents []response.GeminiContent, tools []response.GeminiToolDecl, sysInst *response.GeminiContent) *bytes.Buffer {
+	req := response.GeminiRequest{
+		Contents:          contents,
+		SystemInstruction: sysInst,
+		Tools:             tools,
+	}
+	data, _ := json.Marshal(req)
+	return bytes.NewBuffer(data)
+}

--- a/test/services/mock-llm/handlers/gemini.go
+++ b/test/services/mock-llm/handlers/gemini.go
@@ -1,0 +1,220 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package handlers
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	openai "github.com/jordigilh/kubernaut/pkg/shared/types/openai"
+	"github.com/jordigilh/kubernaut/test/services/mock-llm/config"
+	"github.com/jordigilh/kubernaut/test/services/mock-llm/response"
+	"github.com/jordigilh/kubernaut/test/services/mock-llm/scenarios"
+)
+
+const geminiPathSuffix = ":generateContent"
+
+// handleGemini handles Gemini generateContent requests.
+// Path format: POST /v1beta/models/{model}:generateContent
+func (h *handler) handleGemini(w http.ResponseWriter, r *http.Request) {
+	start := time.Now()
+
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "method not allowed"})
+		return
+	}
+
+	path := r.URL.Path
+	if !strings.HasSuffix(path, geminiPathSuffix) {
+		writeJSON(w, http.StatusNotFound, map[string]string{"error": "not found"})
+		return
+	}
+
+	if h.headerRecorder != nil {
+		h.headerRecorder.RecordFrom(r)
+	}
+
+	if h.tracker != nil {
+		h.tracker.IncrementRequestCount()
+	}
+
+	if h.faultInjector != nil && h.faultInjector.IsActive() {
+		applyFaultDelay(h.faultInjector)
+		writeJSON(w, h.faultInjector.StatusCode(), response.BuildGeminiErrorResponse(h.faultInjector.Message()))
+		return
+	}
+
+	var req response.GeminiRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "invalid JSON"})
+		return
+	}
+
+	lastUserText, allText := response.ExtractTextFromContents(req.Contents, req.SystemInstruction)
+	hasFunctionResults := response.HasFunctionResponse(req.Contents)
+
+	content := strings.ToLower(lastUserText)
+	allTextLower := strings.ToLower(allText)
+
+	isProactive := strings.Contains(content, "proactive mode") ||
+		strings.Contains(content, "proactive signal") ||
+		(strings.Contains(content, "predicted") && strings.Contains(content, "not yet occurred"))
+
+	detCtx := &scenarios.DetectionContext{
+		Content:     content,
+		AllText:     allTextLower,
+		IsProactive: isProactive,
+	}
+
+	if isPermanentError(detCtx) {
+		writeJSON(w, http.StatusInternalServerError, response.BuildGeminiErrorResponse("Mock permanent LLM error for testing"))
+		return
+	}
+
+	result := h.registry.Detect(detCtx)
+	if result == nil {
+		writeJSON(w, http.StatusOK, response.BuildGeminiTextResponse(scenarios.MockScenarioConfig{
+			ScenarioName: "default", RootCause: "Unable to determine root cause", Severity: "medium",
+			InvestigationOutcome: "actionable", IsActionable: scenarios.BoolPtr(true), Confidence: 0.5,
+		}))
+		h.recordRequestMetric(r.URL.Path, http.StatusOK, "default", time.Since(start).Seconds())
+		return
+	}
+
+	if h.tracker != nil {
+		h.tracker.RecordScenario(result.Scenario.Name())
+	}
+
+	scenarioWithCfg, ok := result.Scenario.(scenarios.ScenarioWithConfig)
+	if !ok {
+		writeJSON(w, http.StatusOK, response.BuildGeminiTextResponse(scenarios.MockScenarioConfig{}))
+		return
+	}
+	cfg := scenarioWithCfg.Config()
+
+	scenarioName := cfg.ScenarioName
+	h.recordScenarioMetric(scenarioName, result.Method)
+
+	hasTools := len(req.Tools) > 0
+	hasSplit := geminiHasSubmitWithWorkflowTool(req.Tools)
+	resolved := isResolvedOutcome(cfg)
+
+	log.Printf("[mock-llm/gemini] scenario=%s mode=%s outcome=%s workflowID=%q tools=%d hasSplitTool=%v hasFuncResults=%v",
+		scenarioName, h.mode, cfg.InvestigationOutcome, cfg.WorkflowID, len(req.Tools), hasSplit, hasFunctionResults)
+
+	switch h.mode {
+	case config.ModeInteractive:
+		writeJSON(w, http.StatusOK, response.BuildGeminiTextResponse(cfg))
+
+	default: // config.ModeAutonomous, config.ModeFull, or unset
+		effectiveForceText := h.forceText
+		if h.mode == config.ModeAutonomous {
+			effectiveForceText = true
+		}
+		if cfg.ForceText != nil {
+			effectiveForceText = *cfg.ForceText
+		}
+
+		if effectiveForceText || !hasTools {
+			if hasSplit && !resolved {
+				h.respondGeminiWithSubmitToolCall(w, cfg)
+			} else {
+				writeJSON(w, http.StatusOK, response.BuildGeminiTextResponse(cfg))
+			}
+		} else {
+			h.handleGeminiToolResponse(w, cfg, req.Tools, hasFunctionResults, hasSplit, resolved)
+		}
+	}
+
+	h.recordRequestMetric(r.URL.Path, http.StatusOK, scenarioName, time.Since(start).Seconds())
+}
+
+// handleGeminiToolResponse handles the tool-calling path for Gemini requests.
+func (h *handler) handleGeminiToolResponse(
+	w http.ResponseWriter,
+	cfg scenarios.MockScenarioConfig,
+	tools []response.GeminiToolDecl,
+	hasFunctionResults, hasSplit, resolved bool,
+) {
+	if len(cfg.MultiToolCalls) > 0 && !hasFunctionResults {
+		for _, tc := range cfg.MultiToolCalls {
+			h.trackToolCall(tc.Name)
+		}
+		writeJSON(w, http.StatusOK, response.BuildGeminiMultiToolCallResponse(cfg.MultiToolCalls))
+		return
+	}
+
+	if cfg.ToolCallName != "" && !hasFunctionResults {
+		h.trackToolCall(cfg.ToolCallName)
+		writeJSON(w, http.StatusOK, response.BuildGeminiToolCallResponse(cfg.ToolCallName, cfg))
+		return
+	}
+
+	// When no explicit tool call is configured but tools are declared and no
+	// function results have come back yet, call the first declared tool.
+	// This mirrors the DAG engine's initial step behavior for the OpenAI path.
+	if !hasFunctionResults {
+		if firstTool := firstDeclaredTool(tools); firstTool != "" {
+			h.trackToolCall(firstTool)
+			writeJSON(w, http.StatusOK, response.BuildGeminiToolCallResponse(firstTool, cfg))
+			return
+		}
+	}
+
+	if hasSplit && !resolved {
+		h.respondGeminiWithSubmitToolCall(w, cfg)
+	} else {
+		writeJSON(w, http.StatusOK, response.BuildGeminiTextResponse(cfg))
+	}
+}
+
+// respondGeminiWithSubmitToolCall writes the appropriate submit_result tool call in Gemini format.
+func (h *handler) respondGeminiWithSubmitToolCall(w http.ResponseWriter, cfg scenarios.MockScenarioConfig) {
+	toolName := openai.ToolSubmitResultWithWorkflow
+	if cfg.WorkflowID == "" {
+		toolName = openai.ToolSubmitResultNoWorkflow
+	}
+	h.trackToolCall(toolName)
+	writeJSON(w, http.StatusOK, response.BuildGeminiToolCallResponse(toolName, cfg))
+}
+
+// geminiHasSubmitWithWorkflowTool checks if the Gemini tools contain the split submit tools.
+func geminiHasSubmitWithWorkflowTool(tools []response.GeminiToolDecl) bool {
+	for _, t := range tools {
+		for _, fd := range t.FunctionDeclarations {
+			if fd.Name == openai.ToolSubmitResultWithWorkflow || fd.Name == openai.ToolSubmitResultNoWorkflow {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// firstDeclaredTool returns the name of the first function declaration across all tool groups.
+func firstDeclaredTool(tools []response.GeminiToolDecl) string {
+	for _, t := range tools {
+		for _, fd := range t.FunctionDeclarations {
+			if fd.Name != "" {
+				return fd.Name
+			}
+		}
+	}
+	return ""
+}
+

--- a/test/services/mock-llm/handlers/router.go
+++ b/test/services/mock-llm/handlers/router.go
@@ -106,6 +106,9 @@ func NewFullRouterWithMetrics(
 	mux.HandleFunc("/v1/chat/completions", h.handleOpenAI)
 	mux.HandleFunc("/chat/completions", h.handleOpenAI)
 
+	// Gemini endpoint (issue #1157: AF A2A integration via google-adk genai SDK)
+	mux.HandleFunc("/v1beta/models/", h.handleGemini)
+
 	// Ollama endpoints
 	mux.HandleFunc("/api/chat", h.handleOllama)
 	mux.HandleFunc("/api/generate", h.handleOllama)

--- a/test/services/mock-llm/response/gemini.go
+++ b/test/services/mock-llm/response/gemini.go
@@ -1,0 +1,223 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package response
+
+import (
+	"encoding/json"
+
+	"github.com/jordigilh/kubernaut/test/services/mock-llm/scenarios"
+)
+
+// GeminiRequest represents a Gemini API generateContent request.
+type GeminiRequest struct {
+	Contents          []GeminiContent    `json:"contents"`
+	SystemInstruction *GeminiContent     `json:"systemInstruction,omitempty"`
+	Tools             []GeminiToolDecl   `json:"tools,omitempty"`
+	GenerationConfig  *GeminiGenConfig   `json:"generationConfig,omitempty"`
+}
+
+// GeminiContent represents a content block with role and parts.
+type GeminiContent struct {
+	Role  string       `json:"role"`
+	Parts []GeminiPart `json:"parts"`
+}
+
+// GeminiPart represents a single part within a content block.
+type GeminiPart struct {
+	Text             string               `json:"text,omitempty"`
+	FunctionCall     *GeminiFunctionCall  `json:"functionCall,omitempty"`
+	FunctionResponse *GeminiFunctionResp  `json:"functionResponse,omitempty"`
+}
+
+// GeminiFunctionCall represents a function call issued by the model.
+type GeminiFunctionCall struct {
+	Name string                 `json:"name"`
+	Args map[string]interface{} `json:"args,omitempty"`
+}
+
+// GeminiFunctionResp represents a function response sent by the client.
+type GeminiFunctionResp struct {
+	Name     string      `json:"name"`
+	Response interface{} `json:"response"`
+}
+
+// GeminiToolDecl represents a tool declaration in the request.
+type GeminiToolDecl struct {
+	FunctionDeclarations []GeminiFunctionDecl `json:"functionDeclarations,omitempty"`
+}
+
+// GeminiFunctionDecl describes a function available to the model.
+type GeminiFunctionDecl struct {
+	Name        string      `json:"name"`
+	Description string      `json:"description,omitempty"`
+	Parameters  interface{} `json:"parameters,omitempty"`
+}
+
+// GeminiGenConfig holds generation configuration parameters.
+type GeminiGenConfig struct {
+	Temperature     float64 `json:"temperature,omitempty"`
+	MaxOutputTokens int     `json:"maxOutputTokens,omitempty"`
+}
+
+// GeminiResponse represents a Gemini API generateContent response.
+type GeminiResponse struct {
+	Candidates   []GeminiCandidate `json:"candidates"`
+	ModelVersion string            `json:"modelVersion"`
+}
+
+// GeminiCandidate represents a single candidate in the response.
+type GeminiCandidate struct {
+	Content      GeminiContent `json:"content"`
+	FinishReason string        `json:"finishReason"`
+}
+
+const geminiModelVersion = "mock-model"
+
+// BuildGeminiTextResponse creates a Gemini response with a text part.
+func BuildGeminiTextResponse(cfg scenarios.MockScenarioConfig) GeminiResponse {
+	text := buildAnalysisText(cfg)
+	return GeminiResponse{
+		Candidates: []GeminiCandidate{
+			{
+				Content: GeminiContent{
+					Role:  "model",
+					Parts: []GeminiPart{{Text: text}},
+				},
+				FinishReason: "STOP",
+			},
+		},
+		ModelVersion: geminiModelVersion,
+	}
+}
+
+// BuildGeminiToolCallResponse creates a Gemini response with a single function call.
+func BuildGeminiToolCallResponse(toolName string, cfg scenarios.MockScenarioConfig) GeminiResponse {
+	args := buildToolArguments(toolName, cfg)
+	return GeminiResponse{
+		Candidates: []GeminiCandidate{
+			{
+				Content: GeminiContent{
+					Role: "model",
+					Parts: []GeminiPart{
+						{
+							FunctionCall: &GeminiFunctionCall{
+								Name: toolName,
+								Args: args,
+							},
+						},
+					},
+				},
+				FinishReason: "STOP",
+			},
+		},
+		ModelVersion: geminiModelVersion,
+	}
+}
+
+// BuildGeminiMultiToolCallResponse creates a Gemini response with multiple function calls.
+func BuildGeminiMultiToolCallResponse(toolEntries []scenarios.MultiToolCallEntry) GeminiResponse {
+	parts := make([]GeminiPart, len(toolEntries))
+	for i, entry := range toolEntries {
+		args := make(map[string]interface{}, len(entry.Arguments))
+		for k, v := range entry.Arguments {
+			args[k] = v
+		}
+		parts[i] = GeminiPart{
+			FunctionCall: &GeminiFunctionCall{
+				Name: entry.Name,
+				Args: args,
+			},
+		}
+	}
+	return GeminiResponse{
+		Candidates: []GeminiCandidate{
+			{
+				Content: GeminiContent{
+					Role:  "model",
+					Parts: parts,
+				},
+				FinishReason: "STOP",
+			},
+		},
+		ModelVersion: geminiModelVersion,
+	}
+}
+
+// BuildGeminiErrorResponse creates a Gemini-compatible error response body.
+func BuildGeminiErrorResponse(message string) map[string]interface{} {
+	return map[string]interface{}{
+		"error": map[string]interface{}{
+			"code":    500,
+			"message": message,
+			"status":  "INTERNAL",
+		},
+	}
+}
+
+// HasFunctionResponse returns true if any content in the request contains a functionResponse part.
+func HasFunctionResponse(contents []GeminiContent) bool {
+	for _, c := range contents {
+		for _, p := range c.Parts {
+			if p.FunctionResponse != nil {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ExtractTextFromContents extracts all text parts from Gemini contents,
+// returning the last user text (for Content field) and all text joined (for AllText field).
+func ExtractTextFromContents(contents []GeminiContent, systemInstruction *GeminiContent) (lastUserText string, allText string) {
+	var allParts []string
+
+	if systemInstruction != nil {
+		for _, p := range systemInstruction.Parts {
+			if p.Text != "" {
+				allParts = append(allParts, p.Text)
+			}
+		}
+	}
+
+	for _, c := range contents {
+		for _, p := range c.Parts {
+			if p.Text != "" {
+				allParts = append(allParts, p.Text)
+				if c.Role == "user" {
+					lastUserText = p.Text
+				}
+			}
+			if p.FunctionCall != nil {
+				argsJSON, _ := json.Marshal(p.FunctionCall.Args)
+				allParts = append(allParts, p.FunctionCall.Name+" "+string(argsJSON))
+			}
+			if p.FunctionResponse != nil {
+				respJSON, _ := json.Marshal(p.FunctionResponse.Response)
+				allParts = append(allParts, p.FunctionResponse.Name+" "+string(respJSON))
+			}
+		}
+	}
+
+	var joined string
+	for i, s := range allParts {
+		if i > 0 {
+			joined += " "
+		}
+		joined += s
+	}
+	allText = joined
+	return lastUserText, allText
+}

--- a/test/unit/mockllm/gemini_response_test.go
+++ b/test/unit/mockllm/gemini_response_test.go
@@ -1,0 +1,205 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package mockllm_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/shared/uuid"
+	"github.com/jordigilh/kubernaut/test/services/mock-llm/response"
+	"github.com/jordigilh/kubernaut/test/services/mock-llm/scenarios"
+)
+
+var _ = Describe("Gemini Response Builders (issue #1157)", func() {
+
+	var cfg scenarios.MockScenarioConfig
+
+	BeforeEach(func() {
+		cfg = scenarios.MockScenarioConfig{
+			ScenarioName:         "oomkilled",
+			SignalName:           "OOMKilled",
+			Severity:             "critical",
+			WorkflowName:         "oomkill-increase-memory-v1",
+			WorkflowID:           uuid.DeterministicUUID("oomkill-increase-memory-v1"),
+			WorkflowTitle:        "OOMKill Recovery - Increase Memory Limits",
+			Confidence:           0.95,
+			RootCause:            "Container exceeded memory limits due to traffic spike",
+			ResourceKind:         "Deployment",
+			ResourceNS:           "production",
+			ResourceName:         "api-server",
+			InvestigationOutcome: "actionable",
+			IsActionable:         scenarios.BoolPtr(true),
+			Parameters:           map[string]string{"MEMORY_LIMIT_NEW": "512Mi"},
+		}
+	})
+
+	Describe("UT-MOCK-GEMINI-001: Gemini text response builder", func() {
+		It("UT-MOCK-GEMINI-001-001: should produce valid response with role=model and finishReason=STOP", func() {
+			resp := response.BuildGeminiTextResponse(cfg)
+			Expect(resp.Candidates).To(HaveLen(1))
+			Expect(resp.Candidates[0].Content.Role).To(Equal("model"))
+			Expect(resp.Candidates[0].FinishReason).To(Equal("STOP"))
+			Expect(resp.ModelVersion).To(Equal("mock-model"))
+		})
+
+		It("UT-MOCK-GEMINI-001-002: should include analysis text in parts with no function call", func() {
+			resp := response.BuildGeminiTextResponse(cfg)
+			Expect(resp.Candidates[0].Content.Parts).To(HaveLen(1))
+			Expect(resp.Candidates[0].Content.Parts[0].Text).To(ContainSubstring("root_cause_analysis"))
+			Expect(resp.Candidates[0].Content.Parts[0].FunctionCall).To(BeNil())
+		})
+
+		It("UT-MOCK-GEMINI-001-003: should include root cause in response text", func() {
+			resp := response.BuildGeminiTextResponse(cfg)
+			Expect(resp.Candidates[0].Content.Parts[0].Text).To(ContainSubstring("Container exceeded memory limits"))
+		})
+	})
+
+	Describe("UT-MOCK-GEMINI-002: Gemini tool call response builder", func() {
+		It("UT-MOCK-GEMINI-002-001: should produce function call with correct tool name", func() {
+			resp := response.BuildGeminiToolCallResponse("search_workflow_catalog", cfg)
+			Expect(resp.Candidates).To(HaveLen(1))
+			Expect(resp.Candidates[0].Content.Role).To(Equal("model"))
+			Expect(resp.Candidates[0].Content.Parts).To(HaveLen(1))
+			Expect(resp.Candidates[0].Content.Parts[0].FunctionCall.Name).To(Equal("search_workflow_catalog"))
+		})
+
+		It("UT-MOCK-GEMINI-002-002: should include query arg in function call arguments", func() {
+			resp := response.BuildGeminiToolCallResponse("search_workflow_catalog", cfg)
+			args := resp.Candidates[0].Content.Parts[0].FunctionCall.Args
+			Expect(args).To(HaveKey("query"))
+		})
+
+		It("UT-MOCK-GEMINI-002-003: should have finishReason=STOP", func() {
+			resp := response.BuildGeminiToolCallResponse("search_workflow_catalog", cfg)
+			Expect(resp.Candidates[0].FinishReason).To(Equal("STOP"))
+		})
+
+		It("UT-MOCK-GEMINI-002-004: should have no text part when function call is present", func() {
+			resp := response.BuildGeminiToolCallResponse("search_workflow_catalog", cfg)
+			Expect(resp.Candidates[0].Content.Parts[0].Text).To(BeEmpty())
+		})
+	})
+
+	Describe("UT-MOCK-GEMINI-003: Gemini multi-tool call response builder", func() {
+		It("UT-MOCK-GEMINI-003-001: should produce multiple function calls in parts", func() {
+			entries := []scenarios.MultiToolCallEntry{
+				{Name: "kubectl_get_yaml", Arguments: map[string]string{"kind": "Pod", "namespace": "default"}},
+				{Name: "get_resource_context", Arguments: map[string]string{"kind": "Deployment", "name": "api"}},
+			}
+			resp := response.BuildGeminiMultiToolCallResponse(entries)
+			Expect(resp.Candidates).To(HaveLen(1))
+			Expect(resp.Candidates[0].Content.Parts).To(HaveLen(2))
+			Expect(resp.Candidates[0].Content.Parts[0].FunctionCall.Name).To(Equal("kubectl_get_yaml"))
+			Expect(resp.Candidates[0].Content.Parts[1].FunctionCall.Name).To(Equal("get_resource_context"))
+		})
+
+		It("UT-MOCK-GEMINI-003-002: should pass arguments correctly for each tool call", func() {
+			entries := []scenarios.MultiToolCallEntry{
+				{Name: "kubectl_get_yaml", Arguments: map[string]string{"kind": "Pod"}},
+			}
+			resp := response.BuildGeminiMultiToolCallResponse(entries)
+			args := resp.Candidates[0].Content.Parts[0].FunctionCall.Args
+			Expect(args).To(HaveKeyWithValue("kind", "Pod"))
+		})
+	})
+
+	Describe("UT-MOCK-GEMINI-004: Gemini content text extraction", func() {
+		It("UT-MOCK-GEMINI-004-001: should extract last user text from contents", func() {
+			contents := []response.GeminiContent{
+				{Role: "user", Parts: []response.GeminiPart{{Text: "first question"}}},
+				{Role: "model", Parts: []response.GeminiPart{{Text: "model reply"}}},
+				{Role: "user", Parts: []response.GeminiPart{{Text: "second question about OOMKilled"}}},
+			}
+			lastUser, allText := response.ExtractTextFromContents(contents, nil)
+			Expect(lastUser).To(Equal("second question about OOMKilled"))
+			Expect(allText).To(ContainSubstring("first question"))
+			Expect(allText).To(ContainSubstring("model reply"))
+			Expect(allText).To(ContainSubstring("second question about OOMKilled"))
+		})
+
+		It("UT-MOCK-GEMINI-004-002: should include system instruction in allText", func() {
+			sysInst := &response.GeminiContent{
+				Role:  "system",
+				Parts: []response.GeminiPart{{Text: "You are a remediation agent"}},
+			}
+			contents := []response.GeminiContent{
+				{Role: "user", Parts: []response.GeminiPart{{Text: "help me"}}},
+			}
+			lastUser, allText := response.ExtractTextFromContents(contents, sysInst)
+			Expect(lastUser).To(Equal("help me"))
+			Expect(allText).To(ContainSubstring("You are a remediation agent"))
+			Expect(allText).To(ContainSubstring("help me"))
+		})
+
+		It("UT-MOCK-GEMINI-004-003: should include function call names and args in allText", func() {
+			contents := []response.GeminiContent{
+				{Role: "user", Parts: []response.GeminiPart{{Text: "investigate pods"}}},
+				{Role: "model", Parts: []response.GeminiPart{
+					{FunctionCall: &response.GeminiFunctionCall{Name: "kubectl_get_yaml", Args: map[string]interface{}{"kind": "Pod"}}},
+				}},
+			}
+			_, allText := response.ExtractTextFromContents(contents, nil)
+			Expect(allText).To(ContainSubstring("kubectl_get_yaml"))
+			Expect(allText).To(ContainSubstring("Pod"))
+		})
+
+		It("UT-MOCK-GEMINI-004-004: should include function response data in allText", func() {
+			contents := []response.GeminiContent{
+				{Role: "user", Parts: []response.GeminiPart{
+					{FunctionResponse: &response.GeminiFunctionResp{
+						Name:     "kubectl_get_yaml",
+						Response: map[string]string{"result": "pod-data"},
+					}},
+				}},
+			}
+			_, allText := response.ExtractTextFromContents(contents, nil)
+			Expect(allText).To(ContainSubstring("kubectl_get_yaml"))
+			Expect(allText).To(ContainSubstring("pod-data"))
+		})
+	})
+
+	Describe("UT-MOCK-GEMINI-005: HasFunctionResponse detection", func() {
+		It("UT-MOCK-GEMINI-005-001: should return false when no function responses present", func() {
+			contents := []response.GeminiContent{
+				{Role: "user", Parts: []response.GeminiPart{{Text: "hello"}}},
+				{Role: "model", Parts: []response.GeminiPart{{Text: "hi"}}},
+			}
+			Expect(response.HasFunctionResponse(contents)).To(BeFalse())
+		})
+
+		It("UT-MOCK-GEMINI-005-002: should return true when function response is present", func() {
+			contents := []response.GeminiContent{
+				{Role: "user", Parts: []response.GeminiPart{
+					{FunctionResponse: &response.GeminiFunctionResp{Name: "tool1", Response: "ok"}},
+				}},
+			}
+			Expect(response.HasFunctionResponse(contents)).To(BeTrue())
+		})
+	})
+
+	Describe("UT-MOCK-GEMINI-006: Gemini error response builder", func() {
+		It("UT-MOCK-GEMINI-006-001: should produce error with correct structure", func() {
+			resp := response.BuildGeminiErrorResponse("something went wrong")
+			errObj, ok := resp["error"].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(errObj["message"]).To(Equal("something went wrong"))
+			Expect(errObj["status"]).To(Equal("INTERNAL"))
+			Expect(errObj["code"]).To(BeEquivalentTo(500))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Closes #1157

Adds `POST /v1beta/models/{model}:generateContent` endpoint to mock-LLM, enabling the API Frontend's A2A handler (which uses Google ADK / `genai` SDK with Gemini wire protocol) to work end-to-end in E2E tests without a real Gemini API.

- **New handler** (`handlers/gemini.go`): Parses Gemini request format, bridges to existing scenario detection engine, returns Gemini-shaped responses
- **New response builders** (`response/gemini.go`): Types and builders for Gemini text, function call, multi-tool call, and error responses
- **Route registration** in `router.go`: Prefix route `/v1beta/models/` with `:generateContent` suffix validation
- **16 unit tests** covering response builders, text extraction, and function response detection
- **10 integration tests** covering full HTTP roundtrip (text, tool calls, multi-turn, error cases, force-text mode, scenario detection)

### Design decisions

- Reuses existing `scenarios.Registry.Detect()` — no new detection logic
- When tools are declared but no explicit `ToolCallName` configured in scenario, calls the first declared tool (mirrors DAG engine initial step)
- `streamGenerateContent` is explicitly out of scope (per issue)
- SDK headers (`X-Goog-Api-Key`, etc.) are captured by header recorder but not validated

### AF team validation

All 4 protocol questions answered and confirmed by AF team:
1. Path: `/v1beta/models/{model}:generateContent` ✅
2. Full conversation history in every request ✅
3. Only `contents`, `systemInstruction`, `tools`, `generationConfig` needed ✅
4. Tool call correlation by name (no ID required for v1) ✅

## Test plan

- [x] Unit tests pass (16/16 Gemini specs)
- [x] Integration tests pass (10/10 Gemini specs)
- [x] Full mock-LLM unit suite passes (163 specs)
- [x] Full mock-LLM integration suite passes (77 specs)
- [x] Full project builds (`go build ./...`)
- [x] `go vet` clean
- [ ] CI passes
- [ ] AF team uncomments E2E config and validates their 55 scenarios


Made with [Cursor](https://cursor.com)