### PR TITLE
ci: cancel in-progress workflows on new push to same PR

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -42,6 +42,10 @@ on:
     branches: [ main, 'release/**' ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   # CRITICAL: Kind must use Podman (we don't have Docker in our CI)
   # This ensures all Kind commands (create, load, etc.) use Podman as the provider


### PR DESCRIPTION
## Summary

Adds `concurrency` block to CI pipeline workflow so that when a new commit is pushed to a PR branch, any in-flight workflow run for that same PR is cancelled immediately — freeing up runners for the latest code.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
  cancel-in-progress: true
```

- PRs: new push cancels previous run (same PR number = same group)
- Main branch: each push gets unique ref, so runs are never cancelled

## Test plan

- [x] Push a second commit to a PR while CI is running → old run should be cancelled

Made with [Cursor](https://cursor.com)