### PR TITLE
feat(mock-llm): support keyword_scenarios in YAML override for consumer-defined tool fixtures

### DIFF
--- a/test/services/mock-llm/config/overrides.go
+++ b/test/services/mock-llm/config/overrides.go
@@ -39,10 +39,20 @@ type ScenarioOverride struct {
 	ToolCalls  []ToolCallOverride `yaml:"tool_calls,omitempty"`
 }
 
+// KeywordScenarioOverride defines a keyword-matched scenario injected via YAML.
+// Consumers (e.g., AF E2E tests) use this to map prompt keywords to specific
+// tool call responses without modifying mock-LLM code.
+type KeywordScenarioOverride struct {
+	Name     string           `yaml:"name"`
+	Keywords []string         `yaml:"keywords"`
+	ToolCall ToolCallOverride `yaml:"tool_call"`
+}
+
 // Overrides holds the parsed YAML override configuration.
 type Overrides struct {
-	Mode      string                      `yaml:"mode"`
-	Scenarios map[string]ScenarioOverride `yaml:"scenarios"`
+	Mode             string                      `yaml:"mode"`
+	Scenarios        map[string]ScenarioOverride `yaml:"scenarios"`
+	KeywordScenarios []KeywordScenarioOverride   `yaml:"keyword_scenarios,omitempty"`
 }
 
 // LoadYAMLOverrides reads a YAML overrides file. If the path is empty or the

--- a/test/services/mock-llm/scenarios/registry_default.go
+++ b/test/services/mock-llm/scenarios/registry_default.go
@@ -101,6 +101,19 @@ func DefaultRegistryFull(overrides *config.Overrides, goldenDir string) *Registr
 				applyOverride(cs, ov)
 			}
 		}
+
+		// Register consumer-defined keyword scenarios from YAML (issue #1160).
+		// These use the same priority (1.0) as built-in keyword scenarios and
+		// override the default fallback (0.01).
+		for _, ks := range overrides.KeywordScenarios {
+			cfg := MockScenarioConfig{
+				ScenarioName: ks.Name,
+				ToolCallName: ks.ToolCall.Name,
+				ToolCallArgs: ks.ToolCall.Arguments,
+				ForceText:    BoolPtr(false),
+			}
+			r.Register(mockKeywordScenarioMulti(ks.Name, ks.Keywords, cfg))
+		}
 	}
 	return r
 }

--- a/test/unit/mockllm/keyword_scenarios_test.go
+++ b/test/unit/mockllm/keyword_scenarios_test.go
@@ -1,0 +1,200 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package mockllm_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/test/services/mock-llm/config"
+	"github.com/jordigilh/kubernaut/test/services/mock-llm/scenarios"
+)
+
+var _ = Describe("Keyword Scenarios YAML Override (issue #1160)", func() {
+
+	Describe("UT-MOCK-KW-001: YAML parsing of keyword_scenarios", func() {
+		It("UT-MOCK-KW-001-001: should parse keyword_scenarios from YAML", func() {
+			yaml := `
+keyword_scenarios:
+  - name: "af_start_investigation"
+    keywords: ["start investigation", "begin investigation"]
+    tool_call:
+      name: "kubernaut_start_investigation"
+      arguments:
+        namespace: "default"
+        pod_name: "nginx"
+  - name: "af_get_pods"
+    keywords: ["get pods"]
+    tool_call:
+      name: "af_get_pods"
+      arguments:
+        namespace: "default"
+`
+			tmpFile := filepath.Join(GinkgoT().TempDir(), "overrides.yaml")
+			Expect(os.WriteFile(tmpFile, []byte(yaml), 0644)).To(Succeed())
+
+			overrides, err := config.LoadYAMLOverrides(tmpFile)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(overrides.KeywordScenarios).To(HaveLen(2))
+			Expect(overrides.KeywordScenarios[0].Name).To(Equal("af_start_investigation"))
+			Expect(overrides.KeywordScenarios[0].Keywords).To(ConsistOf("start investigation", "begin investigation"))
+			Expect(overrides.KeywordScenarios[0].ToolCall.Name).To(Equal("kubernaut_start_investigation"))
+			Expect(overrides.KeywordScenarios[0].ToolCall.Arguments).To(HaveKeyWithValue("namespace", "default"))
+			Expect(overrides.KeywordScenarios[0].ToolCall.Arguments).To(HaveKeyWithValue("pod_name", "nginx"))
+		})
+
+		It("UT-MOCK-KW-001-002: should coexist with existing scenario overrides", func() {
+			yaml := `
+scenarios:
+  oomkilled:
+    workflow_id: "custom-uuid"
+keyword_scenarios:
+  - name: "af_get_pods"
+    keywords: ["get pods"]
+    tool_call:
+      name: "af_get_pods"
+`
+			tmpFile := filepath.Join(GinkgoT().TempDir(), "overrides.yaml")
+			Expect(os.WriteFile(tmpFile, []byte(yaml), 0644)).To(Succeed())
+
+			overrides, err := config.LoadYAMLOverrides(tmpFile)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(overrides.Scenarios).To(HaveKey("oomkilled"))
+			Expect(overrides.Scenarios["oomkilled"].WorkflowID).To(Equal("custom-uuid"))
+			Expect(overrides.KeywordScenarios).To(HaveLen(1))
+			Expect(overrides.KeywordScenarios[0].Name).To(Equal("af_get_pods"))
+		})
+
+		It("UT-MOCK-KW-001-003: should handle missing keyword_scenarios gracefully", func() {
+			yaml := `
+scenarios:
+  oomkilled:
+    workflow_id: "custom-uuid"
+`
+			tmpFile := filepath.Join(GinkgoT().TempDir(), "overrides.yaml")
+			Expect(os.WriteFile(tmpFile, []byte(yaml), 0644)).To(Succeed())
+
+			overrides, err := config.LoadYAMLOverrides(tmpFile)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(overrides.KeywordScenarios).To(BeEmpty())
+		})
+	})
+
+	Describe("UT-MOCK-KW-002: Registry detection of keyword scenarios", func() {
+		It("UT-MOCK-KW-002-001: should detect scenario by keyword match", func() {
+			overrides := &config.Overrides{
+				Scenarios: map[string]config.ScenarioOverride{},
+				KeywordScenarios: []config.KeywordScenarioOverride{
+					{
+						Name:     "af_start_investigation",
+						Keywords: []string{"start investigation"},
+						ToolCall: config.ToolCallOverride{
+							Name:      "kubernaut_start_investigation",
+							Arguments: map[string]string{"namespace": "default"},
+						},
+					},
+				},
+			}
+			registry := scenarios.DefaultRegistryWithOverrides(overrides)
+
+			detCtx := &scenarios.DetectionContext{
+				Content: "please start investigation on pod nginx",
+				AllText: "please start investigation on pod nginx",
+			}
+			result := registry.Detect(detCtx)
+			Expect(result.Confidence).To(Equal(1.0))
+			Expect(result.Scenario.Name()).To(Equal("af_start_investigation"))
+
+			scenarioWithCfg, ok := result.Scenario.(scenarios.ScenarioWithConfig)
+			Expect(ok).To(BeTrue())
+			cfg := scenarioWithCfg.Config()
+			Expect(cfg.ToolCallName).To(Equal("kubernaut_start_investigation"))
+			Expect(cfg.ToolCallArgs).To(HaveKeyWithValue("namespace", "default"))
+		})
+
+		It("UT-MOCK-KW-002-002: should not match when keyword is absent", func() {
+			overrides := &config.Overrides{
+				Scenarios: map[string]config.ScenarioOverride{},
+				KeywordScenarios: []config.KeywordScenarioOverride{
+					{
+						Name:     "af_start_investigation",
+						Keywords: []string{"start investigation"},
+						ToolCall: config.ToolCallOverride{Name: "kubernaut_start_investigation"},
+					},
+				},
+			}
+			registry := scenarios.DefaultRegistryWithOverrides(overrides)
+
+			detCtx := &scenarios.DetectionContext{
+				Content: "something completely unrelated",
+				AllText: "something completely unrelated",
+			}
+			result := registry.Detect(detCtx)
+			// Should fall through to default fallback, not keyword scenario
+			Expect(result.Scenario.Name()).ToNot(Equal("af_start_investigation"))
+		})
+
+		It("UT-MOCK-KW-002-003: should support multiple keywords for same scenario", func() {
+			overrides := &config.Overrides{
+				Scenarios: map[string]config.ScenarioOverride{},
+				KeywordScenarios: []config.KeywordScenarioOverride{
+					{
+						Name:     "af_get_pods",
+						Keywords: []string{"get pods", "list pods", "show pods"},
+						ToolCall: config.ToolCallOverride{Name: "af_get_pods"},
+					},
+				},
+			}
+			registry := scenarios.DefaultRegistryWithOverrides(overrides)
+
+			for _, keyword := range []string{"get pods", "list pods", "show pods"} {
+				detCtx := &scenarios.DetectionContext{
+					Content: "I need to " + keyword + " in namespace default",
+					AllText: "I need to " + keyword + " in namespace default",
+				}
+				result := registry.Detect(detCtx)
+				Expect(result.Scenario.Name()).To(Equal("af_get_pods"),
+					"expected af_get_pods for keyword %q", keyword)
+			}
+		})
+
+		It("UT-MOCK-KW-002-004: keyword scenario should have ForceText=false for tool calls", func() {
+			overrides := &config.Overrides{
+				Scenarios: map[string]config.ScenarioOverride{},
+				KeywordScenarios: []config.KeywordScenarioOverride{
+					{
+						Name:     "af_tool",
+						Keywords: []string{"trigger tool"},
+						ToolCall: config.ToolCallOverride{Name: "my_tool"},
+					},
+				},
+			}
+			registry := scenarios.DefaultRegistryWithOverrides(overrides)
+
+			detCtx := &scenarios.DetectionContext{
+				Content: "trigger tool now",
+				AllText: "trigger tool now",
+			}
+			result := registry.Detect(detCtx)
+			scenarioWithCfg := result.Scenario.(scenarios.ScenarioWithConfig)
+			cfg := scenarioWithCfg.Config()
+			Expect(cfg.ForceText).To(Equal(scenarios.BoolPtr(false)))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- Adds `keyword_scenarios` YAML field to `config.Overrides`, allowing consumers to inject prompt→tool_call mappings via ConfigMap without code changes
- Registers consumer-defined keyword scenarios in `DefaultRegistryFull` with priority 1.0 (overrides default fallback)
- Fully backward-compatible: new field is optional, existing tests unaffected (170 unit + 78 integration specs pass)

## Test plan

- [x] Unit tests: YAML parsing, coexistence with scenario overrides, graceful absence handling
- [x] Unit tests: registry detection by keyword, multi-keyword support, no false positives, ForceText=false enforcement
- [x] Full unit suite: 170/170 pass
- [x] Full integration suite: 78/78 pass
- [x] `go vet` clean
- [ ] CI pipeline green

Closes #1160
Refs: #1157

Made with [Cursor](https://cursor.com)