### PR TITLE
feat: surface LLM-populated workflow parameters in discover_workflows MCP response (#1169)

### DIFF
--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -1367,6 +1367,10 @@ func buildMCPHandler(
 	// HARM-004: Validate RR existence before creating interactive Leases.
 	rrChecker := mcptools.NewK8sRRExistenceChecker(ctrlCli, namespace)
 
+	// Signal context resolver: reads RR CR to provide signal name, severity,
+	// and resource targeting for Phase 3 workflow discovery prompts.
+	signalResolver := mcpadapters.NewK8sSignalContextResolver(ctrlCli, namespace)
+
 	// Build the InvestigateTool with optional dependencies.
 	investigateOpts := []mcptools.InvestigateOption{
 		mcptools.WithToolMetrics(agentMetrics),
@@ -1376,6 +1380,7 @@ func buildMCPHandler(
 		mcptools.WithRRExistenceChecker(rrChecker),
 		mcptools.WithHTTPCompleter(autoMgr),
 		mcptools.WithAuditStore(auditStore, logger.WithName("mcp-audit")),
+		mcptools.WithSignalContextResolver(signalResolver),
 	}
 	investigateTool := mcptools.NewInvestigateTool(leaseMgr, investigatorRunner, recon, autoMgr, investigateOpts...)
 

--- a/docs/architecture/decisions/ADR-045-aianalysis-holmesgpt-api-contract.md
+++ b/docs/architecture/decisions/ADR-045-aianalysis-holmesgpt-api-contract.md
@@ -514,10 +514,29 @@ ProblemDetails:
 
 ---
 
+## Addendum: MCP `DiscoveredWorkflow` Parameters (#1169)
+
+The MCP `DiscoveredWorkflow` struct (used in `discover_workflows` responses) diverges from
+the REST `AlternativeWorkflow` struct by including a `parameters` field (`map[string]interface{}`).
+This enables the MCP client (AF) to display per-workflow parameter previews before selection.
+
+The REST `AlternativeWorkflow` (used in the KA→AA HTTP API) was designed for audit/context only
+(v1.2) and intentionally excluded `parameters`. The MCP DTO adds them because:
+
+1. AF needs to display parameter previews for operator decision-making
+2. `select_workflow` needs to merge the selected workflow's parameters into the final result
+3. Parameter values come from the LLM's Phase 3 structured output, not from the catalog
+
+See [docs/mcp/discover-workflows-contract.md](../../mcp/discover-workflows-contract.md) for the
+authoritative MCP tool contract.
+
+---
+
 ## Version History
 
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
+| 1.3 | 2026-05-17 | KA Team | Addendum: MCP `DiscoveredWorkflow` includes `parameters` (#1169) |
 | 1.2 | 2025-12-05 | HAPI Team | Implemented `alternativeWorkflows[]` for audit/context (NOT for execution) |
 | 1.1 | 2025-12-02 | HAPI Team | Added `targetInOwnerChain` and `warnings[]` fields per AIAnalysis request |
 | 1.0 | 2025-12-02 | HAPI Team | Initial creation (converted from DD-HAPI-004) |

--- a/docs/mcp/discover-workflows-contract.md
+++ b/docs/mcp/discover-workflows-contract.md
@@ -4,7 +4,7 @@
 **Date**: May 2026
 **Status**: Authoritative
 **GitHub Issue**: [#1169](https://github.com/jordigilh/kubernaut/issues/1169)
-**Related BRs**: BR-INTERACTIVE-001, BR-INTERACTIVE-005
+**Related BRs**: BR-INTERACTIVE-001, BR-INTERACTIVE-005, BR-INTERACTIVE-009
 
 ---
 

--- a/docs/mcp/discover-workflows-contract.md
+++ b/docs/mcp/discover-workflows-contract.md
@@ -1,0 +1,120 @@
+# MCP Tool Contract: `discover_workflows` and `select_workflow`
+
+**Version**: 1.0
+**Date**: May 2026
+**Status**: Authoritative
+**GitHub Issue**: [#1169](https://github.com/jordigilh/kubernaut/issues/1169)
+**Related BRs**: BR-INTERACTIVE-001, BR-INTERACTIVE-005
+
+---
+
+## Overview
+
+The `kubernaut_investigate` MCP tool supports a `discover_workflows` action that triggers KA's Phase 3 (workflow selection) LLM call. The response surfaces a **recommended** workflow and zero or more **alternative** workflows, each with per-workflow `parameters` populated by the LLM.
+
+A subsequent `kubernaut_select_workflow` call selects one of the discovered workflows for execution. The per-workflow parameters from discovery are merged into the final `InvestigationResult` delivered to the HTTP session store.
+
+---
+
+## `discover_workflows` Action
+
+### Request
+
+```json
+{
+  "rr_id": "<remediation-request-id>",
+  "action": "discover_workflows"
+}
+```
+
+### Response
+
+The tool returns a JSON envelope with `status: "workflows_discovered"` and a `response` field containing a JSON string with the discovery results.
+
+```json
+{
+  "status": "workflows_discovered",
+  "response": "<inner-json-string>"
+}
+```
+
+### Inner Response JSON Schema
+
+```json
+{
+  "recommended": {
+    "workflow_id": "string",
+    "execution_bundle": "string (optional)",
+    "confidence": "number (0-1)",
+    "rationale": "string",
+    "parameters": { "PARAM_NAME": "value", ... }
+  },
+  "alternatives": [
+    {
+      "workflow_id": "string",
+      "execution_bundle": "string (optional)",
+      "confidence": "number (0-1)",
+      "rationale": "string",
+      "parameters": { "PARAM_NAME": "value", ... }
+    }
+  ]
+}
+```
+
+### Parameter Semantics
+
+| Scenario | JSON representation |
+|----------|-------------------|
+| LLM provides parameters | `"parameters": {"KEY": "val"}` |
+| LLM provides empty parameters | `"parameters": {}` |
+| LLM omits parameters | `"parameters"` key absent from JSON |
+| LLM provides null parameters | `"parameters": null` |
+
+- Parameters are `map[string]interface{}` internally but are typically string-valued in LLM output.
+- Parameter keys are **not validated** against the workflow catalog schema in v1.5. See [#1170](https://github.com/jordigilh/kubernaut/issues/1170) for the validation regression tracking.
+- Downstream, AA normalizes `map[string]interface{}` to `map[string]string` via `convertMapToStringMap` before CRD/WFE consumption.
+
+---
+
+## `select_workflow` Tool
+
+### Request
+
+```json
+{
+  "rr_id": "<remediation-request-id>",
+  "workflow_id": "<workflow-id-from-discovery>"
+}
+```
+
+### Gating Rules (v1.5)
+
+1. `discover_workflows` **must** be called before `select_workflow`.
+2. `workflow_id` **must** match either `recommended.workflow_id` or one of `alternatives[].workflow_id`.
+3. Any `message` action after `discover_workflows` invalidates the discovery results.
+
+### Parameter Merge Behavior
+
+When `select_workflow` builds the final `InvestigationResult`:
+
+1. If the selected `workflow_id` matches the **recommended** workflow, `recommended.parameters` are used.
+2. If the selected `workflow_id` matches an **alternative**, that alternative's `parameters` are used.
+3. If the selected `workflow_id` is not found in discovery (graceful fallback), the RCA's original parameters are preserved.
+4. If `discovery` is `nil` (legacy path), the RCA's original parameters pass through unchanged.
+5. Parameter maps are **cloned** (Go mistake #78) to prevent aliasing between the final result and stored session state.
+
+---
+
+## Backward Compatibility
+
+- Workflows without parameters: the `parameters` key is omitted from the JSON response (Go `omitempty` on `map[string]interface{}`).
+- Existing clients that do not read `parameters` are unaffected.
+- The `select_workflow` gating rules are unchanged.
+
+---
+
+## Related Documents
+
+- [BR-INTERACTIVE.md](../requirements/BR-INTERACTIVE.md) — Business requirements for interactive mode
+- [ADR-045](../architecture/decisions/ADR-045-aianalysis-holmesgpt-api-contract.md) — AIAnalysis HolmesGPT API contract
+- [#1170](https://github.com/jordigilh/kubernaut/issues/1170) — Parameter validation regression from HAPI migration

--- a/docs/requirements/BR-INTERACTIVE.md
+++ b/docs/requirements/BR-INTERACTIVE.md
@@ -175,6 +175,31 @@ Interactive mode must be additive. Failures in interactive infrastructure must n
 
 ---
 
+## BR-INTERACTIVE-009: Workflow Discovery with Per-Workflow Parameters
+
+**Business Requirement ID**: BR-INTERACTIVE-009
+**Priority**: P1
+**Status**: Implemented
+**GitHub Issue**: [#1169](https://github.com/jordigilh/kubernaut/issues/1169)
+
+### Business Need
+
+When the LLM discovers workflows during interactive investigation, each workflow (recommended and alternatives) may have specific parameters (e.g., `MEMORY_LIMIT_NEW`, `REPLICA_COUNT`). These parameters must be surfaced to the MCP client so the AF UI can display them, and they must flow through to the workflow execution engine when a workflow is selected.
+
+### Success Criteria
+
+1. `discover_workflows` action returns `parameters` on both recommended and alternative workflows in the MCP JSON response
+2. `select_workflow` merges the selected workflow's parameters into the final `InvestigationResult`
+3. Selecting an alternative workflow uses that alternative's parameters, not the recommended workflow's
+4. Parameter maps are cloned to prevent aliasing between session state and the completed result
+5. Workflows without parameters omit the `parameters` key from JSON (backward compatible)
+
+### Contract Reference
+
+See [docs/mcp/discover-workflows-contract.md](../mcp/discover-workflows-contract.md) for the authoritative MCP tool contract.
+
+---
+
 ## Traceability Matrix
 
 | BR ID | PR | Checkpoint | Test Tier |
@@ -187,3 +212,4 @@ Interactive mode must be additive. Failures in interactive infrastructure must n
 | BR-INTERACTIVE-006 | PR2 + PR3 | CP-3 | Unit + Integration |
 | BR-INTERACTIVE-007 | PR1 | CP-1 | Unit |
 | BR-INTERACTIVE-008 | PR2 + PR6 | CP-2 + CP-5 | Unit + E2E |
+| BR-INTERACTIVE-009 | #1169 | — | Unit + IT + E2E |

--- a/docs/tests/1169/TEST_PLAN.md
+++ b/docs/tests/1169/TEST_PLAN.md
@@ -1,0 +1,479 @@
+# Test Plan: Surface LLM-Populated Workflow Parameters in discover_workflows (#1169)
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+>
+> Based on IEEE 829-2008 (Standard for Software and System Test Documentation) with
+> Kubernaut-specific extensions for TDD phase tracking, business requirement traceability,
+> and per-tier coverage policy.
+
+**Test Plan Identifier**: TP-1169-v1
+**Feature**: Per-workflow parameters in MCP discover_workflows response for AF/interactive clients
+**Version**: 1.0
+**Created**: 2026-05-17
+**Author**: AI-assisted
+**Status**: Draft
+**Branch**: `feat/1169-discover-workflows-parameters`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This test plan validates that LLM-populated workflow parameters are surfaced to
+interactive MCP clients (AF and others) in the `discover_workflows` response, and
+that selecting any workflow (recommended or alternative) merges the correct
+per-workflow parameters into the final `InvestigationResult`.
+
+Currently, `InvestigationResult.Parameters` only carries the **recommended**
+workflow's parameters. Alternative workflows have no parameter slot at any layer
+(types, parser, LLM schema, MCP DTOs). When a user selects an alternative via
+`select_workflow`, the recommended workflow's parameters leak into the final
+result — a **correctness bug** that blocks AF from showing accurate parameter
+previews.
+
+### 1.2 Objectives
+
+1. **Parser fidelity**: `parseLLMFormat` extracts `parameters` from `alternative_workflows` items and propagates them into `katypes.AlternativeWorkflow.Parameters`
+2. **Discovery completeness**: `extractDiscoveryResult` copies per-workflow parameters onto `DiscoveredWorkflow` for both recommended and alternatives
+3. **Selection correctness**: `buildFinalResult` replaces `InvestigationResult.Parameters` with the parameters from the user-selected workflow (recommended or alternative), not stale RCA params
+4. **Schema alignment**: LLM JSON schema, Go types, and MCP DTOs all include `parameters` on alternative workflows
+5. **Backward compatibility**: Omitted parameters remain `nil` / omitted in JSON (no breaking change for existing consumers)
+
+### 1.3 Success Metrics
+
+- Unit test pass rate: 100% (`go test ./internal/kubernautagent/parser/... ./internal/kubernautagent/mcp/tools/...`)
+- Unit-testable code coverage: >=80% on changed functions (`parseLLMFormat` alternatives loop, `extractDiscoveryResult`, `buildFinalResult`, `lookupDiscoveredParameters`)
+- Integration test pass rate: 100% (`go test ./test/integration/kubernautagent/mcp/...`)
+- Backward compatibility: 0 regressions — all existing tests pass without modification (except signature updates)
+- Feature-specific: discover_workflows JSON contains `parameters` on recommended and alternatives when LLM provides them
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- BR-LLM-024/026: LLM structured extraction must produce complete parameter sets
+- BR-INTERACTIVE: Interactive MCP tool surface (kubernaut_select_workflow, discover_workflows)
+- ADR-045 v1.2: Alternative workflows for audit and operator context
+- Issue #1169: Parent feature issue
+- Issue #1166: Parent KA MCP tracking issue
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../.cursor/rules/03-testing-strategy.mdc)
+- [Anti-Pattern Detection](../ANTI_PATTERN_DETECTION.md)
+- [Integration/E2E No-Mocks Policy](../INTEGRATION_E2E_NO_MOCKS_POLICY.md)
+- [Testing Guidelines](../../development/business-requirements/TESTING_GUIDELINES.md)
+
+---
+
+## 3. Risks & Mitigations
+
+### 3.1 Risk Register
+
+- R1: Cross-cutting schema change across 5 representations of AlternativeWorkflow
+  - Impact: Type inconsistency breaks serialization
+  - Probability: Medium
+  - Affected Tests: UT-KA-433-PRS-010, UT-KA-EDR-001/002/003
+  - Mitigation: TDD RED phase ensures all representations are exercised before implementation
+
+- R2: `buildFinalResult` signature change breaks 3 existing tests
+  - Impact: Compile failure in test suite
+  - Probability: High (certain)
+  - Affected Tests: UT-KA-SW-BUILDFINAL-001 (3 It blocks)
+  - Mitigation: Update existing tests to pass nil as third arg during GREEN phase
+
+- R3: Prompt engineering risk — LLM may not produce parameters for alternatives
+  - Impact: Empty parameters in production (feature not exercised)
+  - Probability: Medium
+  - Affected Tests: E2E (FP-MCP-005)
+  - Mitigation: Mock-LLM produces deterministic JSON; production LLM guided by updated prompt
+
+- R4: JSON round-trip fidelity — numbers deserialize as float64 (100-go-mistakes #77)
+  - Impact: Type mismatch in parameter values
+  - Probability: Low
+  - Affected Tests: UT-KA-433-PRS-010
+  - Mitigation: Tests use string parameter values; document float64 behavior
+
+- R5: `extractDiscoveryResult` has ZERO existing tests (QE audit finding)
+  - Impact: Parameter mapping bugs undetected
+  - Probability: High
+  - Affected Tests: UT-KA-EDR-001/002/003 (new)
+  - Mitigation: Add dedicated unit tests in RED phase
+
+- R6: Stale recommended params leak when user selects alternative (product audit finding)
+  - Impact: Wrong parameters applied to workflow execution — correctness bug
+  - Probability: High (current behavior)
+  - Affected Tests: UT-KA-SW-BUILDFINAL-002b, UT-KA-SW-BUILDFINAL-002d
+  - Mitigation: `buildFinalResult` discovery-aware merge replaces params based on selected workflow
+
+- R7: No parameter validation against catalog schema before execution (security audit finding)
+  - Impact: LLM-hallucinated keys pass through to workflow execution
+  - Probability: Medium
+  - Affected Tests: Out of scope (tracked separately)
+  - Mitigation: WE `FilterDeclaredParameters` provides defense-in-depth when catalog declares parameter names
+
+- R8: No dedicated audit event for select_workflow choice (security audit finding)
+  - Impact: Forensics gap when operator picks non-recommended workflow
+  - Probability: Low (informational)
+  - Affected Tests: Out of scope
+  - Mitigation: Existing session completion audit captures final InvestigationResult
+
+### 3.2 Risk-to-Test Traceability
+
+- R1 mitigated by: UT-KA-433-PRS-010, UT-KA-EDR-001/002/003, UT-KA-SW-BUILDFINAL-002a/b/c/d
+- R2 mitigated by: UT-KA-SW-BUILDFINAL-001 (updated)
+- R5 mitigated by: UT-KA-EDR-001/002/003
+- R6 mitigated by: UT-KA-SW-BUILDFINAL-002b, UT-KA-SW-BUILDFINAL-002d
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **Parser alternative parameter extraction** (`internal/kubernautagent/parser/parser.go`): LLM JSON with `parameters` on `alternative_workflows` items is faithfully extracted into `katypes.AlternativeWorkflow.Parameters`
+- **Discovery result parameter propagation** (`internal/kubernautagent/mcp/tools/investigate.go`): `extractDiscoveryResult` copies parameters from `InvestigationResult` onto `DiscoveredWorkflow` for both recommended and alternatives
+- **Per-workflow parameter merge** (`internal/kubernautagent/mcp/tools/select_workflow.go`): `buildFinalResult` replaces `InvestigationResult.Parameters` with the parameters from the user-selected workflow in the discovery result
+- **MCP types** (`internal/kubernautagent/mcp/interfaces.go`): `DiscoveredWorkflow.Parameters` serializes correctly in JSON
+- **LLM schema** (`internal/kubernautagent/parser/schema.go`): `alternative_workflows` items schema includes `parameters`
+
+### 4.2 Features Not to be Tested
+
+- **CRD AlternativeWorkflow type** (`api/aianalysis/v1alpha1/`): CRD stores selected workflow parameters only; alternatives are informational
+- **Ogen/OpenAPI client generation**: HTTP API path already carries parameters on `InvestigationResult`
+- **AA controller response processor**: Maps from HTTP API response, not MCP discovery
+- **Parameter validation against catalog schema**: Tracked as separate security hardening work
+- **Mock-LLM scenario updates**: Separate concern; current mock-LLM does not produce alternative parameters
+- **Audit event for select_workflow**: Tracked as separate observability work
+
+### 4.3 Design Decisions
+
+- `buildFinalResult` uses variadic `discovery` parameter (not required) to maintain backward compatibility with nil callers
+- `lookupDiscoveredParameters` returns nil (not empty map) when workflow has no parameters, causing `omitempty` to omit the field in JSON
+- Parameters are `map[string]interface{}` (not `map[string]string`) to match existing `InvestigationResult.Parameters` type and preserve LLM fidelity
+- `DiscoveredWorkflow.Parameters` may duplicate `FullResult.Parameters` for the recommended workflow — this is intentional for MCP client convenience (AF does not need to cross-reference FullResult)
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+**Authority**: `03-testing-strategy.mdc` — Per-Tier Testable Code Coverage.
+
+- **Unit**: >=80% of unit-testable code (parseLLMFormat alternatives loop, extractDiscoveryResult, buildFinalResult, lookupDiscoveredParameters)
+- **Integration**: >=80% of integration-testable code (discover -> select flow parameter assertions in IT-KA-DISC-001)
+- **E2E**: Deferred — depends on mock-LLM producing alternative parameters (separate concern)
+
+### 5.2 Two-Tier Minimum
+
+Every business requirement is covered by at least 2 test tiers:
+- **Unit tests**: Parser extraction, discovery mapping, merge logic (fast, isolated)
+- **Integration tests**: Full discover -> select flow with real session manager and HTTP completer
+
+### 5.3 Business Outcome Quality Bar
+
+Tests validate business outcomes:
+- "AF receives per-workflow parameters in discover_workflows JSON" (not "Parameters field is not nil")
+- "Selecting an alternative replaces recommended params" (not "buildFinalResult returns a result")
+- "Omitted parameters are absent from JSON" (not "Parameters is nil")
+
+### 5.4 Pass/Fail Criteria
+
+**PASS** — all of the following must be true:
+
+1. All P0 tests pass (0 failures)
+2. Per-tier code coverage meets >=80% threshold on changed functions
+3. No regressions in existing test suites
+4. discover_workflows JSON contains `parameters` on recommended and alternatives when LLM provides them
+5. Selecting an alternative workflow produces correct per-workflow parameters in final InvestigationResult
+
+**FAIL** — any of the following:
+
+1. Any P0 test fails
+2. Per-tier coverage falls below 80% on any tier
+3. Existing tests that were passing before the change now fail
+4. Stale recommended parameters appear when selecting an alternative
+
+### 5.5 Suspension & Resumption Criteria
+
+**Suspend testing when**:
+- Build broken (code does not compile due to cross-cutting type changes)
+- extractDiscoveryResult or buildFinalResult signature mismatch between export_test.go and production
+
+**Resume testing when**:
+- All types, parser, MCP interfaces, and export wrappers are aligned
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code (pure logic, no I/O)
+
+- `pkg/kubernautagent/types/types.go`: `AlternativeWorkflow` struct (~5 lines)
+- `internal/kubernautagent/parser/parser.go`: `llmAlternative` struct + `parseLLMFormat` alternatives loop (~10 lines)
+- `internal/kubernautagent/parser/schema.go`: `investigationResultSchemaJSON` alternatives items (~3 lines)
+- `internal/kubernautagent/mcp/interfaces.go`: `DiscoveredWorkflow` struct (~8 lines)
+- `internal/kubernautagent/mcp/tools/investigate.go`: `extractDiscoveryResult` function (~30 lines)
+- `internal/kubernautagent/mcp/tools/select_workflow.go`: `buildFinalResult` + `lookupDiscoveredParameters` (~25 lines)
+
+### 6.2 Integration-Testable Code (I/O, wiring, cross-component)
+
+- `internal/kubernautagent/mcp/tools/select_workflow.go`: `Handle` method (production caller of buildFinalResult) (~75 lines)
+
+---
+
+## 7. BR Coverage Matrix
+
+- BR-LLM-024: Parser extracts complete parameter sets from LLM JSON (P0, Unit, UT-KA-433-PRS-010, Pending)
+- BR-LLM-026: All workflows (recommended + alternatives) carry LLM-populated parameters (P0, Unit, UT-KA-EDR-001/002, Pending)
+- BR-INTERACTIVE: discover_workflows response includes per-workflow parameters for AF preview (P0, Unit+IT, UT-KA-EDR-001, IT-KA-DISC-001, Pending)
+- ADR-045 v1.2: Alternative workflows carry context including parameters (P1, Unit, UT-KA-EDR-002/003, Pending)
+- BR-INTERACTIVE: select_workflow merges correct per-workflow parameters (P0, Unit, UT-KA-SW-BUILDFINAL-002a/b/c/d, Pending)
+
+---
+
+## 8. Test Scenarios
+
+### Test ID Naming Convention
+
+Format: `{TIER}-{SERVICE}-{BR_NUMBER}-{SEQUENCE}`
+- **TIER**: `UT` (Unit), `IT` (Integration)
+- **SERVICE**: `KA` (Kubernaut Agent)
+
+### Tier 1: Unit Tests
+
+**Testable code scope**: parser alternatives loop, extractDiscoveryResult, buildFinalResult, lookupDiscoveredParameters (>=80% coverage target)
+
+- `UT-KA-433-PRS-010`: Parser extracts parameters from alternative_workflows items (BR-LLM-024, Pending)
+- `UT-KA-EDR-001`: extractDiscoveryResult copies recommended workflow parameters (BR-LLM-026, Pending)
+- `UT-KA-EDR-002`: extractDiscoveryResult copies alternative workflow parameters (BR-LLM-026, Pending)
+- `UT-KA-EDR-003`: extractDiscoveryResult handles alternatives with nil parameters (ADR-045, Pending)
+- `UT-KA-SW-BUILDFINAL-002a`: buildFinalResult uses recommended workflow parameters when selecting recommended (BR-INTERACTIVE, Pending)
+- `UT-KA-SW-BUILDFINAL-002b`: buildFinalResult replaces parameters when selecting alternative (BR-INTERACTIVE, Pending)
+- `UT-KA-SW-BUILDFINAL-002c`: buildFinalResult passes RCA params through when discovery is nil (BR-INTERACTIVE, Pending)
+- `UT-KA-SW-BUILDFINAL-002d`: buildFinalResult clears params when alternative has nil parameters (BR-INTERACTIVE, Pending)
+
+### Tier 2: Integration Tests
+
+**Testable code scope**: Full discover -> select flow with parameter assertions
+
+- `IT-KA-DISC-001` (existing, update): Assert `alternatives[].parameters` in discover_workflows response (BR-INTERACTIVE, Pending)
+
+### Tier Skip Rationale
+
+- **E2E**: Deferred — FP-MCP-005 exercises discover + select but mock-LLM does not produce alternative parameters. Mock-LLM scenario update is a separate concern tracked outside this issue.
+
+---
+
+## 9. Test Cases
+
+### UT-KA-433-PRS-010: Parser extracts parameters from alternative_workflows
+
+**BR**: BR-LLM-024
+**Priority**: P0
+**Type**: Unit
+**File**: `internal/kubernautagent/parser/adversarial_parser_test.go`
+
+**Test Steps**:
+1. **Given**: LLM JSON with `selected_workflow.parameters` and `alternative_workflows[0].parameters` and `alternative_workflows[1]` without parameters
+2. **When**: `parser.Parse(content)` is called
+3. **Then**: `result.AlternativeWorkflows[0].Parameters` contains the LLM-provided parameter map; `result.AlternativeWorkflows[1].Parameters` is nil; `result.Parameters` contains selected workflow parameters
+
+**Acceptance Criteria**:
+- **Behavior**: Parser faithfully extracts per-alternative parameters
+- **Correctness**: Parameter keys and values match LLM JSON exactly
+- **Accuracy**: Alternatives without parameters have nil Parameters (not empty map)
+
+### UT-KA-EDR-001: extractDiscoveryResult copies recommended workflow parameters
+
+**BR**: BR-LLM-026
+**Priority**: P0
+**Type**: Unit
+**File**: `internal/kubernautagent/mcp/tools/select_workflow_test.go` (or investigate_test.go)
+
+**Test Steps**:
+1. **Given**: InvestigationResult with WorkflowID, Parameters, and AlternativeWorkflows
+2. **When**: extractDiscoveryResult is called
+3. **Then**: Recommended DiscoveredWorkflow has Parameters matching InvestigationResult.Parameters
+
+### UT-KA-SW-BUILDFINAL-002b: buildFinalResult replaces parameters when selecting alternative
+
+**BR**: BR-INTERACTIVE
+**Priority**: P0
+**Type**: Unit
+**File**: `internal/kubernautagent/mcp/tools/select_workflow_test.go`
+
+**Test Steps**:
+1. **Given**: RCA with recommended params `{MEMORY_LIMIT_NEW: 512Mi}`, discovery with alternative `{REPLICA_COUNT: 5, MAX_SURGE: 2}`
+2. **When**: buildFinalResult is called with the alternative's catalog workflow and the discovery
+3. **Then**: Result.Parameters contains `{REPLICA_COUNT: 5, MAX_SURGE: 2}` and does NOT contain `MEMORY_LIMIT_NEW`
+
+**Acceptance Criteria**:
+- **Behavior**: Alternative parameters fully replace recommended parameters
+- **Correctness**: No parameter key leakage from recommended workflow
+- **Accuracy**: Result.Parameters exactly matches the alternative's parameters from discovery
+
+---
+
+## 10. Environmental Needs
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Mocks**: None for parser; mockSessionManager + mockHTTPCompleter for buildFinalResult context
+- **Location**: `internal/kubernautagent/parser/`, `internal/kubernautagent/mcp/tools/`
+
+### 10.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Mocks**: ZERO mocks (real session manager, real HTTP completer)
+- **Infrastructure**: In-process server
+- **Location**: `test/integration/kubernautagent/mcp/`
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Blocking Dependencies
+
+- None — PRs #1163 and #1168 are merged
+
+### 11.2 Execution Order
+
+1. **Phase 1 (RED)**: Write all failing tests — parser, extractDiscoveryResult, buildFinalResult
+2. **Phase 2 (GREEN)**: Minimal implementation — types, parser, schema, MCP types, extractDiscoveryResult, buildFinalResult, export_test, production caller, prompt
+3. **Phase 3 (REFACTOR)**: Code cleanup, 100-go-mistakes validation, slice pre-allocation, nil guards
+4. **Phase 4 (WIRING VERIFICATION)**: Integration test update (IT-KA-DISC-001)
+5. **Phase 5 (COMMIT)**: Logical commit groups, push, PR creation
+
+---
+
+## 12. Test Deliverables
+
+- This test plan: `docs/tests/1169/TEST_PLAN.md`
+- Unit test suite: `internal/kubernautagent/parser/adversarial_parser_test.go`, `internal/kubernautagent/mcp/tools/select_workflow_test.go`
+- Integration test update: `test/integration/kubernautagent/mcp/discovery_flow_test.go`
+- Coverage report: CI artifact
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests — parser
+go test ./internal/kubernautagent/parser/... -ginkgo.focus="UT-KA-433-PRS-010" -ginkgo.v
+
+# Unit tests — MCP tools
+go test ./internal/kubernautagent/mcp/tools/... -ginkgo.focus="UT-KA-EDR|UT-KA-SW-BUILDFINAL-002" -ginkgo.v
+
+# Integration tests
+go test ./test/integration/kubernautagent/mcp/... -ginkgo.focus="IT-KA-DISC-001" -ginkgo.v
+
+# Coverage
+go test ./internal/kubernautagent/mcp/tools/... -coverprofile=coverage.out
+go tool cover -func=coverage.out
+```
+
+---
+
+## 14. Wiring Verification (TDD Phase 4)
+
+- `lookupDiscoveredParameters`: Entry=`buildFinalResult` / Exit=`InvestigationResult.Parameters` / Wiring IT=IT-KA-DISC-001 / Status=Pending
+- `extractDiscoveryResult` parameters: Entry=`handleDiscoverWorkflows` / Exit=MCP JSON response / Wiring IT=IT-KA-DISC-001 / Status=Pending
+- `buildFinalResult` discovery merge: Entry=`SelectWorkflowTool.Handle` / Exit=HTTP session completion / Wiring IT=IT-KA-DISC-001 / Status=Pending
+
+---
+
+## 15. Existing Tests Requiring Updates
+
+- `UT-KA-SW-BUILDFINAL-001` (lines 490, 510, 519): Currently calls `BuildFinalResult(rca, workflow)` with 2 args. Must add `nil` as third arg: `BuildFinalResult(rca, workflow, nil)`. Reason: signature change to accept optional discovery parameter.
+- `export_test.go` (line 25): Wrapper must match new 3-arg signature of `buildFinalResult`. Reason: bridge between internal function and external test package.
+
+---
+
+## 16. GA Readiness Audit Findings
+
+### QE Findings (incorporated into test design)
+
+- extractDiscoveryResult had ZERO tests — addressed by UT-KA-EDR-001/002/003
+- No IT/E2E asserts discover_workflows response content — addressed by IT-KA-DISC-001 update
+- Mock-LLM does not produce alternative parameters — deferred (separate concern)
+
+### Product Findings (incorporated into design decisions)
+
+- No explicit BR for this feature — mapped to BR-LLM-024/026 + BR-INTERACTIVE
+- buildFinalResult stale params bug — addressed by UT-KA-SW-BUILDFINAL-002b/d
+- discover_workflows JSON schema undocumented — out of scope (AF team notified via issue)
+
+### Security Findings (tracked separately)
+
+- Parameter validation against catalog schema — out of scope (defense-in-depth via WE FilterDeclaredParameters)
+- Parameter redaction — out of scope (no secrets expected in workflow parameters by design)
+- Audit event for select_workflow — out of scope (existing session completion audit sufficient for v1.5)
+
+### Test Quality Findings (incorporated into test improvements)
+
+- Tests must use different RCA vs discovery params in recommended case (prevents false positive)
+- Tests must include BR references in Describe blocks
+- Tests must cover empty map `{}` vs nil parameter behavior
+
+---
+
+## 17. GA Readiness Audit — Additional Dimensions
+
+### Documentation Readiness
+
+- **CRITICAL**: No `docs/mcp/` directory — no MCP tool response format documentation exists
+- **HIGH**: ADR-045 `AlternativeWorkflow` has no `parameters` — needs clarification that MCP DTO diverges
+- **HIGH**: BR-INTERACTIVE does not define `discover_workflows` behavior or per-workflow parameters
+- **HIGH**: User guide (`docs/user-guide/interactive-mode.md`) has no MCP tool list or discovery section
+- **MEDIUM**: Phase 3 prompt not documented under `docs/services/kubernaut-agent/`
+- **Action**: Create minimal MCP contract doc; update BR-INTERACTIVE; add ADR note
+
+### Observability Readiness
+
+- **MEDIUM**: `handleDiscoverWorkflows` has no structured success logging (workflow count, parameter presence)
+- **MEDIUM**: No Prometheus counters for discover_workflows outcomes; SLO histogram merges all actions
+- **MEDIUM**: No OpenTelemetry spans in MCP tool handlers
+- **Action**: Add structured log on discovery success; consider action-level metrics (deferred to separate issue)
+
+### Performance Readiness
+
+- **HIGH**: Map aliasing — `buildFinalResult` does `result := *rca` (shallow copy). `Parameters` map is shared with original. Mutating result.Parameters corrupts RCA. `lookupDiscoveredParameters` MUST assign new map, not mutate.
+- **MEDIUM**: Payload size unbounded if LLM produces rich parameter maps
+- **LOW**: extractDiscoveryResult and buildFinalResult are cold path (single call each, dominated by LLM latency)
+- **Action**: Clone parameter map in buildFinalResult; add mutation test
+
+### Reliability/Resilience Readiness
+
+- **HIGH**: `handleComplete`/`handleCancel` do NOT acquire per-rrID session mutex (pre-existing gap, not caused by #1169)
+- **MEDIUM**: `json.Unmarshal` into `map[string]interface{}` fails if LLM produces `"parameters": "not-an-object"` — parser returns error (graceful)
+- **LOW**: nil AlternativeWorkflows on InvestigationResult — range over nil slice is safe in Go
+- **Action**: Add adversarial test for malformed parameters type; document mutex gap for future fix
+
+### Compliance/Audit Readiness
+
+- **HIGH**: No dedicated audit event for `select_workflow` — auditors cannot trace who selected which workflow from which discovery set
+- **HIGH**: `ResultToAuditJSON` omits per-alternative parameters — forensic gap
+- **MEDIUM**: Discovery result is ephemeral (session-scoped, no durable record) — long-term evidence depends on downstream InvestigationResult
+- **MEDIUM**: `select_workflow` does not call `emitInteractiveCompleted` — audit gap for "workflow selected" exit path
+- **Action**: Update `ResultToAuditJSON` alt serialization to include parameters; track audit event as follow-up
+
+### Deployment/Release Readiness
+
+- **MEDIUM**: If OpenAPI changes, Ogen regen required (`make generate-agentclient`)
+- **LOW**: No DB migration needed (JSON audit blobs are schema-flexible)
+- **LOW**: No CRD change needed (MCP-only surface)
+- **LOW**: No new Go dependencies
+- **Action**: Add CHANGELOG entry; no Helm changes needed
+
+---
+
+## 18. Changelog
+
+- v1.0 (2026-05-17): Initial test plan with QE, product, UX, security, and test quality audit findings
+- v1.1 (2026-05-17): Added documentation, observability, performance, reliability, compliance, and deployment audits. Removed backward compatibility requirement per user direction. Added map aliasing risk (R6) and audit serialization gap (R7).

--- a/docs/user-guide/interactive-mode.md
+++ b/docs/user-guide/interactive-mode.md
@@ -157,6 +157,24 @@ kubernautAgent:
 | `rateLimitPerUser` | `10` | MCP requests per second per authenticated user (max: 100) |
 | `maxAnalyzingTimeout` | `45m` | Extended analyzing timeout in Remediation Orchestrator while an interactive session is active, preventing RO from timing out the RR during operator investigation |
 
+## Workflow Discovery and Selection
+
+Interactive mode supports a structured workflow discovery and selection flow:
+
+1. **Discover Workflows**: Call `kubernaut_investigate` with `action: "discover_workflows"` to trigger KA's Phase 3 LLM analysis. The response includes a recommended workflow and zero or more alternatives, each with:
+   - `workflow_id` — unique identifier for catalog lookup
+   - `confidence` — LLM confidence score (0-1)
+   - `rationale` — why this workflow was recommended
+   - `parameters` — LLM-populated execution parameters (e.g., `{"MEMORY_LIMIT_NEW": "512Mi"}`)
+
+2. **Select Workflow**: Call `kubernaut_select_workflow` with the chosen `workflow_id`. The selected workflow's parameters are merged into the final investigation result and forwarded to the workflow execution engine.
+
+3. **Complete Without Action**: Call `kubernaut_complete_no_action` if no workflow is appropriate.
+
+Selecting a workflow auto-completes the interactive session: the final result is written to the HTTP session store, the MCP lease is released, and the AA controller transitions to completion.
+
+For the detailed MCP tool contract including JSON schemas, parameter semantics, and gating rules, see [docs/mcp/discover-workflows-contract.md](../mcp/discover-workflows-contract.md).
+
 ## Disconnect Behavior
 
 If your MCP connection drops (network issue, client crash):

--- a/internal/kubernautagent/mcp/adapters/signal_resolver.go
+++ b/internal/kubernautagent/mcp/adapters/signal_resolver.go
@@ -1,0 +1,65 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapters
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// K8sSignalContextResolver reads the RemediationRequest CR from the K8s API
+// and maps its spec fields to a SignalContext for Phase 3 workflow discovery.
+type K8sSignalContextResolver struct {
+	client    client.Reader
+	namespace string
+}
+
+// NewK8sSignalContextResolver creates a resolver that reads RR CRs from the
+// given namespace.
+func NewK8sSignalContextResolver(c client.Reader, namespace string) *K8sSignalContextResolver {
+	return &K8sSignalContextResolver{client: c, namespace: namespace}
+}
+
+// ResolveSignalContext fetches the RR CR and maps spec fields to SignalContext.
+func (r *K8sSignalContextResolver) ResolveSignalContext(ctx context.Context, rrID string) (*katypes.SignalContext, error) {
+	var rr remediationv1.RemediationRequest
+	key := client.ObjectKey{Namespace: r.namespace, Name: rrID}
+	if err := r.client.Get(ctx, key, &rr); err != nil {
+		return nil, fmt.Errorf("resolve signal context for %s: %w", rrID, err)
+	}
+
+	return &katypes.SignalContext{
+		Name:           rr.Spec.SignalName,
+		Severity:       rr.Spec.Severity,
+		ResourceKind:   rr.Spec.TargetResource.Kind,
+		ResourceName:   rr.Spec.TargetResource.Name,
+		Namespace:      rr.Spec.TargetResource.Namespace,
+		RemediationID:  rr.Name,
+	}, nil
+}
+
+// ResolveEnrichmentData returns empty enrichment data. Full enrichment is
+// handled by the investigator's enrichment pipeline, not the signal resolver.
+func (r *K8sSignalContextResolver) ResolveEnrichmentData(_ context.Context, _ string) (*prompt.EnrichmentData, error) {
+	return &prompt.EnrichmentData{}, nil
+}

--- a/internal/kubernautagent/mcp/adapters/signal_resolver_test.go
+++ b/internal/kubernautagent/mcp/adapters/signal_resolver_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package adapters_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/adapters"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+)
+
+var _ = Describe("K8sSignalContextResolver — #1175", func() {
+
+	var scheme *runtime.Scheme
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+		Expect(remediationv1.AddToScheme(scheme)).To(Succeed())
+	})
+
+	Describe("UT-KA-1175-SCR-001: maps RR spec fields to SignalContext", func() {
+		It("should populate Name, Severity, Namespace, ResourceKind, ResourceName from the RR", func() {
+			rr := &remediationv1.RemediationRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rr-oom-001",
+					Namespace: "kubernaut-system",
+				},
+				Spec: remediationv1.RemediationRequestSpec{
+					SignalFingerprint: "aaaa",
+					SignalName:        "OOMKilled",
+					Severity:          "critical",
+					SignalType:        "alert",
+					TargetType:        "kubernetes",
+					TargetResource: remediationv1.ResourceIdentifier{
+						Kind:      "Deployment",
+						Name:      "api-server",
+						Namespace: "production",
+					},
+					FiringTime:   metav1.Now(),
+					ReceivedTime: metav1.Now(),
+				},
+			}
+
+			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rr).Build()
+			resolver := adapters.NewK8sSignalContextResolver(cli, "kubernaut-system")
+
+			sc, err := resolver.ResolveSignalContext(context.Background(), "rr-oom-001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sc).NotTo(BeNil())
+			Expect(sc.Name).To(Equal("OOMKilled"))
+			Expect(sc.Severity).To(Equal("critical"))
+			Expect(sc.ResourceKind).To(Equal("Deployment"))
+			Expect(sc.ResourceName).To(Equal("api-server"))
+			Expect(sc.Namespace).To(Equal("production"))
+			Expect(sc.RemediationID).To(Equal("rr-oom-001"))
+		})
+	})
+
+	Describe("UT-KA-1175-SCR-002: returns error when RR does not exist", func() {
+		It("should return an error for a non-existent RR", func() {
+			cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+			resolver := adapters.NewK8sSignalContextResolver(cli, "kubernaut-system")
+
+			_, err := resolver.ResolveSignalContext(context.Background(), "rr-nonexistent")
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
+	Describe("UT-KA-1175-SCR-003: ResolveEnrichmentData returns empty data", func() {
+		It("should return non-nil empty EnrichmentData", func() {
+			cli := fake.NewClientBuilder().WithScheme(scheme).Build()
+			resolver := adapters.NewK8sSignalContextResolver(cli, "kubernaut-system")
+
+			ed, err := resolver.ResolveEnrichmentData(context.Background(), "rr-any")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ed).NotTo(BeNil())
+		})
+	})
+
+	Describe("UT-KA-1175-SCR-004: compile-time interface check", func() {
+		It("should satisfy tools.SignalContextResolver", func() {
+			var _ tools.SignalContextResolver = &adapters.K8sSignalContextResolver{}
+		})
+	})
+})

--- a/internal/kubernautagent/mcp/adapters/signal_resolver_test.go
+++ b/internal/kubernautagent/mcp/adapters/signal_resolver_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -81,12 +82,14 @@ var _ = Describe("K8sSignalContextResolver — #1175", func() {
 	})
 
 	Describe("UT-KA-1175-SCR-002: returns error when RR does not exist", func() {
-		It("should return an error for a non-existent RR", func() {
+		It("should return a NotFound error for a non-existent RR", func() {
 			cli := fake.NewClientBuilder().WithScheme(scheme).Build()
 			resolver := adapters.NewK8sSignalContextResolver(cli, "kubernaut-system")
 
 			_, err := resolver.ResolveSignalContext(context.Background(), "rr-nonexistent")
 			Expect(err).To(HaveOccurred())
+			Expect(errors.IsNotFound(err)).To(BeTrue(),
+				"should wrap a K8s NotFound error, got: %v", err)
 		})
 	})
 
@@ -98,6 +101,37 @@ var _ = Describe("K8sSignalContextResolver — #1175", func() {
 			ed, err := resolver.ResolveEnrichmentData(context.Background(), "rr-any")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(ed).NotTo(BeNil())
+		})
+	})
+
+	Describe("UT-KA-1175-SCR-005: RR in different namespace returns NotFound", func() {
+		It("should not resolve an RR from another namespace", func() {
+			rr := &remediationv1.RemediationRequest{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "rr-other-ns",
+					Namespace: "other-namespace",
+				},
+				Spec: remediationv1.RemediationRequestSpec{
+					SignalFingerprint: "bbbb",
+					SignalName:        "CrashLoop",
+					Severity:          "high",
+					SignalType:        "alert",
+					TargetType:        "kubernetes",
+					TargetResource: remediationv1.ResourceIdentifier{
+						Kind: "Pod", Name: "crash-pod", Namespace: "other-namespace",
+					},
+					FiringTime:   metav1.Now(),
+					ReceivedTime: metav1.Now(),
+				},
+			}
+
+			cli := fake.NewClientBuilder().WithScheme(scheme).WithObjects(rr).Build()
+			resolver := adapters.NewK8sSignalContextResolver(cli, "kubernaut-system")
+
+			_, err := resolver.ResolveSignalContext(context.Background(), "rr-other-ns")
+			Expect(err).To(HaveOccurred())
+			Expect(errors.IsNotFound(err)).To(BeTrue(),
+				"RR in a different namespace must not be resolved")
 		})
 	})
 

--- a/internal/kubernautagent/mcp/interfaces.go
+++ b/internal/kubernautagent/mcp/interfaces.go
@@ -100,10 +100,11 @@ type WorkflowDiscoveryResult struct {
 
 // DiscoveredWorkflow represents a single workflow recommendation from Phase 3.
 type DiscoveredWorkflow struct {
-	WorkflowID      string  `json:"workflow_id"`
-	ExecutionBundle string  `json:"execution_bundle,omitempty"`
-	Confidence      float64 `json:"confidence"`
-	Rationale       string  `json:"rationale"`
+	WorkflowID      string                 `json:"workflow_id"`
+	ExecutionBundle string                 `json:"execution_bundle,omitempty"`
+	Confidence      float64                `json:"confidence"`
+	Rationale       string                 `json:"rationale"`
+	Parameters      map[string]interface{} `json:"parameters,omitempty"`
 }
 
 // SessionManager manages interactive session lifecycle: takeover, release, and

--- a/internal/kubernautagent/mcp/tools/export_test.go
+++ b/internal/kubernautagent/mcp/tools/export_test.go
@@ -22,11 +22,16 @@ import (
 )
 
 // BuildFinalResult exposes buildFinalResult for external test packages.
-var BuildFinalResult = func(rca *katypes.InvestigationResult, workflow *CatalogWorkflow) *katypes.InvestigationResult {
-	return buildFinalResult(rca, workflow)
+var BuildFinalResult = func(rca *katypes.InvestigationResult, workflow *CatalogWorkflow, discovery *mcpinternal.WorkflowDiscoveryResult) *katypes.InvestigationResult {
+	return buildFinalResult(rca, workflow, discovery)
 }
 
 // IsWorkflowInDiscoveryResult exposes isWorkflowInDiscoveryResult for external test packages.
 var IsWorkflowInDiscoveryResult = func(workflowID string, dr *mcpinternal.WorkflowDiscoveryResult) bool {
 	return isWorkflowInDiscoveryResult(workflowID, dr)
+}
+
+// ExtractDiscoveryResult exposes extractDiscoveryResult for external test packages.
+var ExtractDiscoveryResult = func(result *katypes.InvestigationResult) *mcpinternal.WorkflowDiscoveryResult {
+	return extractDiscoveryResult(result)
 }

--- a/internal/kubernautagent/mcp/tools/investigate.go
+++ b/internal/kubernautagent/mcp/tools/investigate.go
@@ -763,16 +763,21 @@ func extractDiscoveryResult(result *katypes.InvestigationResult) *mcpinternal.Wo
 			ExecutionBundle: result.ExecutionBundle,
 			Confidence:      result.Confidence,
 			Rationale:       result.WorkflowRationale,
+			Parameters:      result.Parameters,
 		}
 	}
 
-	for _, alt := range result.AlternativeWorkflows {
-		dr.Alternatives = append(dr.Alternatives, mcpinternal.DiscoveredWorkflow{
-			WorkflowID:      alt.WorkflowID,
-			ExecutionBundle: alt.ExecutionBundle,
-			Confidence:      alt.Confidence,
-			Rationale:       alt.Rationale,
-		})
+	if len(result.AlternativeWorkflows) > 0 {
+		dr.Alternatives = make([]mcpinternal.DiscoveredWorkflow, 0, len(result.AlternativeWorkflows))
+		for _, alt := range result.AlternativeWorkflows {
+			dr.Alternatives = append(dr.Alternatives, mcpinternal.DiscoveredWorkflow{
+				WorkflowID:      alt.WorkflowID,
+				ExecutionBundle: alt.ExecutionBundle,
+				Confidence:      alt.Confidence,
+				Rationale:       alt.Rationale,
+				Parameters:      alt.Parameters,
+			})
+		}
 	}
 
 	return dr

--- a/internal/kubernautagent/mcp/tools/investigate.go
+++ b/internal/kubernautagent/mcp/tools/investigate.go
@@ -708,11 +708,17 @@ func (t *InvestigateTool) handleDiscoverWorkflows(ctx context.Context, input Inv
 	var enrichData *prompt.EnrichmentData
 	if t.signalResolver != nil {
 		resolved, resolveErr := t.signalResolver.ResolveSignalContext(ctx, input.RRID)
-		if resolveErr == nil && resolved != nil {
+		if resolveErr != nil {
+			t.logger.V(1).Info("signal context resolution failed, using empty context",
+				"rr_id", input.RRID, "error", resolveErr)
+		} else if resolved != nil {
 			signal = *resolved
 		}
 		enrichResolved, enrichErr := t.signalResolver.ResolveEnrichmentData(ctx, input.RRID)
-		if enrichErr == nil {
+		if enrichErr != nil {
+			t.logger.V(1).Info("enrichment data resolution failed",
+				"rr_id", input.RRID, "error", enrichErr)
+		} else {
 			enrichData = enrichResolved
 		}
 	}

--- a/internal/kubernautagent/mcp/tools/investigate.go
+++ b/internal/kubernautagent/mcp/tools/investigate.go
@@ -763,7 +763,7 @@ func extractDiscoveryResult(result *katypes.InvestigationResult) *mcpinternal.Wo
 			ExecutionBundle: result.ExecutionBundle,
 			Confidence:      result.Confidence,
 			Rationale:       result.WorkflowRationale,
-			Parameters:      result.Parameters,
+			Parameters:      cloneParameterMap(result.Parameters),
 		}
 	}
 
@@ -775,7 +775,7 @@ func extractDiscoveryResult(result *katypes.InvestigationResult) *mcpinternal.Wo
 				ExecutionBundle: alt.ExecutionBundle,
 				Confidence:      alt.Confidence,
 				Rationale:       alt.Rationale,
-				Parameters:      alt.Parameters,
+				Parameters:      cloneParameterMap(alt.Parameters),
 			})
 		}
 	}

--- a/internal/kubernautagent/mcp/tools/select_workflow.go
+++ b/internal/kubernautagent/mcp/tools/select_workflow.go
@@ -244,7 +244,7 @@ func (t *SelectWorkflowTool) Handle(ctx context.Context, input SelectWorkflowInp
 	// Auto-complete: build final InvestigationResult from RCA + selected workflow,
 	// write to HTTP session store, and release the MCP lease.
 	if t.httpCompleter != nil && driver.RCAResult != nil {
-		finalResult := buildFinalResult(driver.RCAResult, workflow)
+		finalResult := buildFinalResult(driver.RCAResult, workflow, driver.DiscoveryResult)
 		httpSessionID, found := t.httpCompleter.FindUserDrivingByRemediationID(input.RRID)
 		if found {
 			if completeErr := t.httpCompleter.CompleteUserDriving(httpSessionID, finalResult); completeErr != nil {
@@ -287,8 +287,9 @@ func isWorkflowInDiscoveryResult(workflowID string, dr *mcpinternal.WorkflowDisc
 }
 
 // buildFinalResult constructs the final InvestigationResult by merging the RCA
-// with the selected workflow details from the catalog.
-func buildFinalResult(rca *katypes.InvestigationResult, workflow *CatalogWorkflow) *katypes.InvestigationResult {
+// with the selected workflow details from the catalog and per-workflow parameters
+// from the discovery result (#1169).
+func buildFinalResult(rca *katypes.InvestigationResult, workflow *CatalogWorkflow, discovery *mcpinternal.WorkflowDiscoveryResult) *katypes.InvestigationResult {
 	result := *rca
 	if workflow != nil {
 		result.WorkflowID = workflow.WorkflowID
@@ -298,7 +299,41 @@ func buildFinalResult(rca *katypes.InvestigationResult, workflow *CatalogWorkflo
 		result.WorkflowVersion = workflow.Version
 		result.WorkflowRationale = "User-selected via interactive mode"
 	}
+
+	if discovery != nil && workflow != nil {
+		if params, found := lookupDiscoveredParameters(workflow.WorkflowID, discovery); found {
+			result.Parameters = cloneParameterMap(params)
+		}
+	}
+
 	return &result
+}
+
+// lookupDiscoveredParameters finds the parameter map for a given workflow_id
+// in the discovery result (recommended or alternatives).
+func lookupDiscoveredParameters(workflowID string, dr *mcpinternal.WorkflowDiscoveryResult) (map[string]interface{}, bool) {
+	if dr.Recommended != nil && dr.Recommended.WorkflowID == workflowID {
+		return dr.Recommended.Parameters, true
+	}
+	for _, alt := range dr.Alternatives {
+		if alt.WorkflowID == workflowID {
+			return alt.Parameters, true
+		}
+	}
+	return nil, false
+}
+
+// cloneParameterMap creates a shallow clone of a parameter map to prevent
+// aliasing between the result and the stored discovery/RCA maps (Go mistake #78).
+func cloneParameterMap(src map[string]interface{}) map[string]interface{} {
+	if src == nil {
+		return nil
+	}
+	dst := make(map[string]interface{}, len(src))
+	for k, v := range src {
+		dst[k] = v
+	}
+	return dst
 }
 
 func validateSelectWorkflowInput(input SelectWorkflowInput) error {

--- a/internal/kubernautagent/mcp/tools/select_workflow.go
+++ b/internal/kubernautagent/mcp/tools/select_workflow.go
@@ -245,6 +245,10 @@ func (t *SelectWorkflowTool) Handle(ctx context.Context, input SelectWorkflowInp
 	// write to HTTP session store, and release the MCP lease.
 	if t.httpCompleter != nil && driver.RCAResult != nil {
 		finalResult := buildFinalResult(driver.RCAResult, workflow, driver.DiscoveryResult)
+		if finalResult.Parameters == nil && driver.DiscoveryResult != nil {
+			t.logger.V(1).Info("no discovered parameters resolved for selected workflow",
+				"rr_id", input.RRID, "workflow_id", input.WorkflowID)
+		}
 		httpSessionID, found := t.httpCompleter.FindUserDrivingByRemediationID(input.RRID)
 		if found {
 			if completeErr := t.httpCompleter.CompleteUserDriving(httpSessionID, finalResult); completeErr != nil {

--- a/internal/kubernautagent/mcp/tools/select_workflow_test.go
+++ b/internal/kubernautagent/mcp/tools/select_workflow_test.go
@@ -487,7 +487,7 @@ var _ = Describe("kubernaut_select_workflow — helper functions", func() {
 				Version:            "v1.2.0",
 			}
 
-			result := mcptools.BuildFinalResult(rca, workflow)
+			result := mcptools.BuildFinalResult(rca, workflow, nil)
 			Expect(result.RCASummary).To(Equal("Pod OOM due to memory leak"))
 			Expect(result.Confidence).To(Equal(0.92))
 			Expect(result.Severity).To(Equal("critical"))
@@ -507,7 +507,7 @@ var _ = Describe("kubernaut_select_workflow — helper functions", func() {
 				Confidence: 0.5,
 			}
 
-			result := mcptools.BuildFinalResult(rca, nil)
+			result := mcptools.BuildFinalResult(rca, nil, nil)
 			Expect(result.RCASummary).To(Equal("test rca"))
 			Expect(result.WorkflowID).To(BeEmpty())
 		})
@@ -516,9 +516,184 @@ var _ = Describe("kubernaut_select_workflow — helper functions", func() {
 			rca := &katypes.InvestigationResult{RCASummary: "original"}
 			workflow := &mcptools.CatalogWorkflow{WorkflowID: "wf-001"}
 
-			result := mcptools.BuildFinalResult(rca, workflow)
+			result := mcptools.BuildFinalResult(rca, workflow, nil)
 			Expect(result.WorkflowID).To(Equal("wf-001"))
 			Expect(rca.WorkflowID).To(BeEmpty(), "original RCA must not be mutated")
+		})
+	})
+
+	Describe("UT-KA-SW-BUILDFINAL-002: buildFinalResult merges per-workflow parameters (BR-INTERACTIVE, #1169)", func() {
+		It("should use discovery recommended parameters instead of stale RCA params", func() {
+			rca := &katypes.InvestigationResult{
+				RCASummary: "OOM",
+				Parameters: map[string]interface{}{
+					"STALE_KEY": "stale_val",
+				},
+			}
+			workflow := &mcptools.CatalogWorkflow{WorkflowID: "wf-rec"}
+			discovery := &mcpinternal.WorkflowDiscoveryResult{
+				Recommended: &mcpinternal.DiscoveredWorkflow{
+					WorkflowID: "wf-rec",
+					Parameters: map[string]interface{}{"MEMORY_LIMIT_NEW": "512Mi"},
+				},
+			}
+
+			result := mcptools.BuildFinalResult(rca, workflow, discovery)
+			Expect(result.Parameters).To(HaveKey("MEMORY_LIMIT_NEW"),
+				"interactive workflow selection must expose parameters from the discovery recommendation")
+			Expect(result.Parameters["MEMORY_LIMIT_NEW"]).To(Equal("512Mi"),
+				"downstream automation needs the discovery memory limit, not an arbitrary placeholder")
+			Expect(result.Parameters).NotTo(HaveKey("STALE_KEY"),
+				"stale RCA parameters must not leak after a fresh discovery recommendation")
+		})
+
+		It("should replace parameters when selecting an alternative workflow", func() {
+			rca := &katypes.InvestigationResult{
+				RCASummary: "rollout stuck",
+				Parameters: map[string]interface{}{
+					"RECOMMENDED_ONLY": "should-not-appear",
+				},
+			}
+			altID := "wf-alt-params"
+			workflow := &mcptools.CatalogWorkflow{WorkflowID: altID}
+			discovery := &mcpinternal.WorkflowDiscoveryResult{
+				Recommended: &mcpinternal.DiscoveredWorkflow{
+					WorkflowID: "wf-recommended",
+					Parameters: map[string]interface{}{"RECOMMENDED_ONLY": "rec-val"},
+				},
+				Alternatives: []mcpinternal.DiscoveredWorkflow{
+					{
+						WorkflowID: altID,
+						Parameters: map[string]interface{}{
+							"REPLICA_COUNT": "5",
+							"MAX_SURGE":     "2",
+						},
+					},
+				},
+			}
+
+			result := mcptools.BuildFinalResult(rca, workflow, discovery)
+			Expect(result.Parameters).To(HaveKey("REPLICA_COUNT"),
+				"the chosen alternative workflow must drive rollout parameters for AA")
+			Expect(result.Parameters).To(HaveKey("MAX_SURGE"),
+				"surge settings must come from the alternative workflow the user picked")
+			Expect(result.Parameters).NotTo(HaveKey("RECOMMENDED_ONLY"),
+				"recommended-workflow parameters must not remain when an alternative is selected")
+		})
+
+		It("should pass through RCA params when discovery is nil", func() {
+			rca := &katypes.InvestigationResult{
+				RCASummary: "no discovery snapshot",
+				Parameters: map[string]interface{}{
+					"PRESERVE_ME": "yes",
+				},
+			}
+			workflow := &mcptools.CatalogWorkflow{WorkflowID: "wf-001"}
+
+			result := mcptools.BuildFinalResult(rca, workflow, nil)
+			Expect(result.Parameters).To(HaveKey("PRESERVE_ME"),
+				"without discovery context, hand-off must keep the RCA-supplied parameters")
+			Expect(result.Parameters["PRESERVE_ME"]).To(Equal("yes"),
+				"legacy completion paths must not drop parameters when discovery is unavailable")
+		})
+
+		It("should clear params when selected alternative has nil parameters", func() {
+			rca := &katypes.InvestigationResult{
+				RCASummary: "alt without params",
+				Parameters: map[string]interface{}{
+					"OLD": "old",
+				},
+			}
+			altID := "wf-alt-empty-params"
+			workflow := &mcptools.CatalogWorkflow{WorkflowID: altID}
+			discovery := &mcpinternal.WorkflowDiscoveryResult{
+				Recommended: &mcpinternal.DiscoveredWorkflow{
+					WorkflowID: "wf-rec",
+					Parameters: map[string]interface{}{"OLD": "rec"},
+				},
+				Alternatives: []mcpinternal.DiscoveredWorkflow{
+					{WorkflowID: altID, Parameters: nil},
+				},
+			}
+
+			result := mcptools.BuildFinalResult(rca, workflow, discovery)
+			Expect(result.Parameters).To(BeEmpty(),
+				"an alternative that defines no parameters must yield an empty parameter map for execution")
+		})
+
+		It("should keep RCA params when workflow not found in discovery", func() {
+			rca := &katypes.InvestigationResult{
+				RCASummary: "fallback path",
+				Parameters: map[string]interface{}{
+					"FROM_RCA": "keep",
+				},
+			}
+			workflow := &mcptools.CatalogWorkflow{WorkflowID: "wf-not-in-discovery"}
+			discovery := &mcpinternal.WorkflowDiscoveryResult{
+				Recommended: &mcpinternal.DiscoveredWorkflow{
+					WorkflowID: "wf-rec",
+					Parameters: map[string]interface{}{"DISC_ONLY": "x"},
+				},
+				Alternatives: []mcpinternal.DiscoveredWorkflow{
+					{WorkflowID: "wf-alt", Parameters: map[string]interface{}{"ALT_ONLY": "y"}},
+				},
+			}
+
+			result := mcptools.BuildFinalResult(rca, workflow, discovery)
+			Expect(result.Parameters).To(HaveKey("FROM_RCA"),
+				"graceful fallback must retain RCA parameters when discovery cannot map the catalog workflow")
+			Expect(result.Parameters["FROM_RCA"]).To(Equal("keep"),
+				"operators rely on RCA parameters when discovery IDs and catalog IDs diverge")
+		})
+
+		It("should clear recommended params when recommended has nil parameters", func() {
+			rca := &katypes.InvestigationResult{
+				RCASummary: "rec nil params",
+				Parameters: map[string]interface{}{
+					"RCA_PARAM": "v",
+				},
+			}
+			recID := "wf-rec-nil-params"
+			workflow := &mcptools.CatalogWorkflow{WorkflowID: recID}
+			discovery := &mcpinternal.WorkflowDiscoveryResult{
+				Recommended: &mcpinternal.DiscoveredWorkflow{
+					WorkflowID: recID,
+					Parameters: nil,
+				},
+			}
+
+			result := mcptools.BuildFinalResult(rca, workflow, discovery)
+			Expect(result.Parameters).To(BeEmpty(),
+				"explicit nil parameters on the recommended workflow must override stale RCA parameter maps")
+		})
+
+		It("should not mutate original RCA or discovery parameter maps", func() {
+			rcaParams := map[string]interface{}{"RCA_K": "rca_v"}
+			recParams := map[string]interface{}{"DISC_K": "disc_v"}
+			rca := &katypes.InvestigationResult{
+				RCASummary: "immutability",
+				Parameters: rcaParams,
+			}
+			workflow := &mcptools.CatalogWorkflow{WorkflowID: "wf-immut"}
+			discovery := &mcpinternal.WorkflowDiscoveryResult{
+				Recommended: &mcpinternal.DiscoveredWorkflow{
+					WorkflowID: "wf-immut",
+					Parameters: recParams,
+				},
+			}
+
+			result := mcptools.BuildFinalResult(rca, workflow, discovery)
+			Expect(result.Parameters).NotTo(BeNil(),
+				"buildFinalResult should produce a distinct parameters map for safe mutation downstream")
+			result.Parameters["MUTATED"] = "after"
+			Expect(rcaParams).NotTo(HaveKey("MUTATED"),
+				"session RCA storage must remain untouched when the completer mutates the merged result")
+			Expect(recParams).NotTo(HaveKey("MUTATED"),
+				"stored discovery recommendations must stay immutable for audit and replay")
+			Expect(rcaParams).To(HaveKey("RCA_K"),
+				"original RCA parameter keys must be preserved in the source map")
+			Expect(recParams).To(HaveKey("DISC_K"),
+				"original discovery parameter keys must be preserved in the source map")
 		})
 	})
 
@@ -564,6 +739,161 @@ var _ = Describe("kubernaut_select_workflow — helper functions", func() {
 		It("should handle empty discovery result", func() {
 			dr := &mcpinternal.WorkflowDiscoveryResult{}
 			Expect(mcptools.IsWorkflowInDiscoveryResult("wf-any", dr)).To(BeFalse())
+		})
+	})
+})
+
+var _ = Describe("extractDiscoveryResult — parameter propagation (BR-LLM-026, #1169)", func() {
+
+	Describe("UT-KA-EDR-001: recommended parameters (BR-LLM-026, #1169)", func() {
+		It("should copy recommended workflow parameters from InvestigationResult", func() {
+			inv := &katypes.InvestigationResult{
+				WorkflowID: "wf-rec",
+				Parameters: map[string]interface{}{"KEY": "val"},
+			}
+
+			dr := mcptools.ExtractDiscoveryResult(inv)
+			Expect(dr).NotTo(BeNil(), "operators need a discovery envelope even when only parameters change")
+			Expect(dr.Recommended).NotTo(BeNil(), "a primary workflow must be advertised when WorkflowID is present")
+			Expect(dr.Recommended.Parameters).To(HaveKeyWithValue("KEY", "val"),
+				"discovered recommended workflow must surface LLM parameter bindings for execution")
+		})
+	})
+
+	Describe("UT-KA-EDR-002: alternative parameters (BR-LLM-026, #1169)", func() {
+		It("should copy alternative workflow parameters", func() {
+			inv := &katypes.InvestigationResult{
+				AlternativeWorkflows: []katypes.AlternativeWorkflow{
+					{
+						WorkflowID: "wf-alt",
+						Parameters: map[string]interface{}{"ALT_KEY": "alt_val"},
+					},
+				},
+			}
+
+			dr := mcptools.ExtractDiscoveryResult(inv)
+			Expect(dr).NotTo(BeNil(), "discovery extraction must return a non-nil result for downstream MCP serialization")
+			Expect(dr.Alternatives).NotTo(BeEmpty(), "alternatives from LLM output must appear in discovery")
+			Expect(dr.Alternatives[0].Parameters).To(HaveKeyWithValue("ALT_KEY", "alt_val"),
+				"each alternative must retain its own parameter map for fair operator comparison")
+		})
+	})
+
+	Describe("UT-KA-EDR-003: nil alternative parameters (BR-LLM-026, #1169)", func() {
+		It("should propagate nil parameters on alternatives without parameters", func() {
+			inv := &katypes.InvestigationResult{
+				AlternativeWorkflows: []katypes.AlternativeWorkflow{
+					{WorkflowID: "wf-alt-no-params"},
+				},
+			}
+
+			dr := mcptools.ExtractDiscoveryResult(inv)
+			Expect(dr.Alternatives).To(HaveLen(1), "single alternative must be preserved without inventing fields")
+			Expect(dr.Alternatives[0].Parameters).To(BeNil(),
+				"absent alternative parameters must stay nil so callers can distinguish missing from empty maps")
+		})
+	})
+
+	Describe("UT-KA-EDR-004: nil investigation input (BR-LLM-026, #1169)", func() {
+		It("should return empty result for nil input", func() {
+			dr := mcptools.ExtractDiscoveryResult(nil)
+			Expect(dr).NotTo(BeNil(), "nil-safe extraction avoids panics in interactive session handlers")
+			Expect(dr.Recommended).To(BeNil(), "without an investigation there must be no recommended workflow")
+			Expect(dr.Alternatives).To(BeEmpty(), "without an investigation there must be no alternative list")
+		})
+	})
+
+	Describe("UT-KA-EDR-005: alternatives only (BR-LLM-026, #1169)", func() {
+		It("should populate alternatives without recommended when WorkflowID is empty", func() {
+			inv := &katypes.InvestigationResult{
+				WorkflowID: "",
+				AlternativeWorkflows: []katypes.AlternativeWorkflow{
+					{
+						WorkflowID: "wf-alt-only",
+						Parameters: map[string]interface{}{"ONLY": "one"},
+					},
+				},
+			}
+
+			dr := mcptools.ExtractDiscoveryResult(inv)
+			Expect(dr.Recommended).To(BeNil(), "no primary workflow must be fabricated when WorkflowID is absent")
+			Expect(dr.Alternatives).To(HaveLen(1), "alternatives-only Phase 3 output must still populate discovery")
+			Expect(dr.Alternatives[0].Parameters).To(HaveKeyWithValue("ONLY", "one"),
+				"parameters on alternatives must propagate even when no recommended row exists")
+		})
+	})
+
+	Describe("UT-KA-EDR-006: empty recommended parameter map (BR-LLM-026, #1169)", func() {
+		It("should propagate empty parameter map on recommended", func() {
+			inv := &katypes.InvestigationResult{
+				WorkflowID: "wf-rec",
+				Parameters: map[string]interface{}{},
+			}
+
+			dr := mcptools.ExtractDiscoveryResult(inv)
+			Expect(dr.Recommended).NotTo(BeNil(), "recommended workflow must exist when WorkflowID is set")
+			Expect(dr.Recommended.Parameters).NotTo(BeNil(),
+				"explicit empty maps from the LLM must not collapse to nil and hide the parameter layer")
+			Expect(dr.Recommended.Parameters).To(BeEmpty(),
+				"non-nil parameter map with zero entries must round-trip for schema-stable clients")
+		})
+	})
+})
+
+var _ = Describe("kubernaut_select_workflow — per-workflow parameter hand-off (BR-INTERACTIVE, #1169)", func() {
+	Describe("UT-KA-SW-AC-002: select_workflow propagates per-workflow parameters to completer (BR-INTERACTIVE, #1169)", func() {
+		It("should deliver alternative workflow parameters to the interactive session completer", func() {
+			altID := "wf-alt-params"
+			catalog := &mockWorkflowCatalog{
+				workflow: &mcptools.CatalogWorkflow{
+					WorkflowID:      altID,
+					WorkflowName:    "alt-with-params",
+					ExecutionEngine: "argo",
+					ExecutionBundle: "oci://alt:v1",
+					Version:         "v1.0",
+				},
+			}
+			completer := &mockHTTPCompleter{foundID: "http-ac-002", found: true}
+			sessions := &mockSessionManager{
+				isActive: true,
+				getDriverResult: &mcpinternal.InteractiveSession{
+					SessionID:     "sess-ac-002",
+					CorrelationID: "rr-ac-002",
+					ActingUser:    mcpinternal.UserInfo{Username: "alice"},
+					RCAResult:     &katypes.InvestigationResult{RCASummary: "needs rollout tuning"},
+					DiscoveryResult: &mcpinternal.WorkflowDiscoveryResult{
+						Recommended: &mcpinternal.DiscoveredWorkflow{
+							WorkflowID: "wf-recommended",
+							Parameters: map[string]interface{}{"REC_KEY": "rec_val"},
+						},
+						Alternatives: []mcpinternal.DiscoveredWorkflow{
+							{
+								WorkflowID: altID,
+								Parameters: map[string]interface{}{"ALT_KEY": "alt_val"},
+							},
+						},
+					},
+				},
+			}
+
+			tool := mcptools.NewSelectWorkflowTool(catalog, sessions,
+				mcptools.WithHTTPSessionCompleter(completer),
+			)
+			_, err := tool.Handle(context.Background(), mcptools.SelectWorkflowInput{
+				RRID:       "rr-ac-002",
+				WorkflowID: altID,
+			}, mcpinternal.UserInfo{Username: "alice"})
+			Expect(err).NotTo(HaveOccurred(),
+				"select_workflow must succeed when the user picks a discovery-listed alternative")
+
+			Expect(completer.completedResult).NotTo(BeNil(),
+				"the HTTP completer must receive the merged investigation result for session completion")
+			Expect(completer.completedResult.Parameters).To(HaveKey("ALT_KEY"),
+				"the completer must forward parameters for the workflow the user actually selected")
+			Expect(completer.completedResult.Parameters["ALT_KEY"]).To(Equal("alt_val"),
+				"downstream automation must see concrete values from the alternative workflow")
+			Expect(completer.completedResult.Parameters).NotTo(HaveKey("REC_KEY"),
+				"recommended-workflow parameters must not leak after an explicit alternative choice")
 		})
 	})
 })

--- a/internal/kubernautagent/parser/adversarial_parser_test.go
+++ b/internal/kubernautagent/parser/adversarial_parser_test.go
@@ -182,6 +182,150 @@ End of analysis.`
 		})
 	})
 
+	Describe("UT-KA-433-PRS-010: alternative_workflows parameters extraction (BR-LLM-024, #1169)", func() {
+		It("should preserve primary workflow parameters and map per-alternative parameters by workflow id for stable discovery", func() {
+			input := `{
+				"root_cause_analysis": {"summary": "Memory pressure on workload"},
+				"selected_workflow": {
+					"workflow_id": "oomkill-increase-memory-v1",
+					"confidence": 0.92,
+					"parameters": {
+						"MEMORY_LIMIT_NEW": "512Mi"
+					}
+				},
+				"alternative_workflows": [
+					{
+						"workflow_id": "horizontal-scale-alt",
+						"confidence": 0.65,
+						"rationale": "Scale replicas to spread memory pressure",
+						"parameters": {
+							"REPLICA_COUNT": "5",
+							"MAX_SURGE": "2"
+						}
+					},
+					{
+						"workflow_id": "defer-investigation-alt",
+						"confidence": 0.4,
+						"rationale": "Defer until on-call confirms blast radius"
+					}
+				]
+			}`
+
+			result, err := p.Parse(input)
+			Expect(err).NotTo(HaveOccurred(),
+				"parser must accept structured LLM alternatives with parameters for BR-LLM-024 / #1169")
+			Expect(result.Parameters).To(HaveKey("MEMORY_LIMIT_NEW"),
+				"primary selected_workflow parameters must populate result.Parameters (#1169, BR-LLM-024)")
+			altsByID := make(map[string]map[string]interface{})
+			for _, alt := range result.AlternativeWorkflows {
+				altsByID[alt.WorkflowID] = alt.Parameters
+			}
+			Expect(altsByID).To(HaveKey("horizontal-scale-alt"),
+				"expected parameterized alternative to be indexed by workflow_id (#1169, BR-LLM-024)")
+			Expect(altsByID).To(HaveKey("defer-investigation-alt"),
+				"expected alternative without parameters to still be present by workflow_id (#1169, BR-LLM-024)")
+			Expect(altsByID["horizontal-scale-alt"]).To(HaveKey("REPLICA_COUNT"),
+				"alternative_workflows must surface REPLICA_COUNT when LLM provides it (#1169, BR-LLM-024)")
+			Expect(altsByID["horizontal-scale-alt"]).To(HaveKey("MAX_SURGE"),
+				"alternative_workflows must surface MAX_SURGE when LLM provides it (#1169, BR-LLM-024)")
+			Expect(altsByID["defer-investigation-alt"]).To(BeNil(),
+				"alternatives omitting parameters must leave Parameters nil (#1169, BR-LLM-024)")
+		})
+	})
+
+	Describe("UT-KA-433-PRS-010b: empty parameters object on alternative (BR-LLM-024, #1169)", func() {
+		It("should materialize an empty JSON object as a non-nil empty parameter map on the alternative", func() {
+			input := `{
+				"root_cause_analysis": {"summary": "RCA with empty alt parameters"},
+				"selected_workflow": {"workflow_id": "primary-wf", "confidence": 0.9},
+				"alternative_workflows": [
+					{
+						"workflow_id": "empty-object-alt",
+						"confidence": 0.55,
+						"rationale": "explicit empty parameters",
+						"parameters": {}
+					}
+				]
+			}`
+
+			result, err := p.Parse(input)
+			Expect(err).NotTo(HaveOccurred(),
+				"empty parameters object must parse for BR-LLM-024 / #1169")
+			Expect(result.AlternativeWorkflows).To(HaveLen(1),
+				"single alternative must round-trip (#1169, BR-LLM-024)")
+			Expect(result.AlternativeWorkflows[0].Parameters).NotTo(BeNil(),
+				"{} must decode to non-nil map on AlternativeWorkflow.Parameters (#1169, BR-LLM-024)")
+			Expect(result.AlternativeWorkflows[0].Parameters).To(BeEmpty(),
+				"explicit empty parameters must not invent keys (#1169, BR-LLM-024)")
+		})
+	})
+
+	Describe("UT-KA-433-PRS-010c: explicit null parameters on alternative (BR-LLM-024, #1169)", func() {
+		It("should record null parameters on an alternative as absent", func() {
+			input := `{
+				"root_cause_analysis": {"summary": "RCA with null alt parameters"},
+				"selected_workflow": {"workflow_id": "primary-wf", "confidence": 0.9},
+				"alternative_workflows": [
+					{
+						"workflow_id": "null-params-alt",
+						"confidence": 0.55,
+						"rationale": "null parameters",
+						"parameters": null
+					}
+				]
+			}`
+
+			result, err := p.Parse(input)
+			Expect(err).NotTo(HaveOccurred(),
+				"null parameters must parse for BR-LLM-024 / #1169")
+			Expect(result.AlternativeWorkflows).To(HaveLen(1),
+				"single alternative must round-trip (#1169, BR-LLM-024)")
+			Expect(result.AlternativeWorkflows[0].Parameters).To(BeNil(),
+				"JSON null parameters must leave AlternativeWorkflow.Parameters nil (#1169, BR-LLM-024)")
+		})
+	})
+
+	Describe("UT-KA-433-PRS-010d: malformed parameters type on alternative (BR-LLM-024, #1169)", func() {
+		It("should fail parsing when alternative parameters are not a JSON object", func() {
+			input := `{
+				"root_cause_analysis": {"summary": "RCA with invalid alt parameters type"},
+				"selected_workflow": {"workflow_id": "primary-wf", "confidence": 0.9},
+				"alternative_workflows": [
+					{
+						"workflow_id": "bad-params-alt",
+						"confidence": 0.5,
+						"rationale": "parameters scalar",
+						"parameters": "not-an-object"
+					}
+				]
+			}`
+
+			result, err := p.Parse(input)
+			Expect(err).To(HaveOccurred(),
+				"non-object parameters on alternative_workflows must surface a parse error (#1169, BR-LLM-024)")
+			Expect(result).To(BeNil(),
+				"malformed alternative parameters must not produce a partial InvestigationResult (#1169, BR-LLM-024)")
+		})
+	})
+
+	Describe("UT-KA-433-PRS-010e: omitted alternative_workflows key (BR-LLM-024, #1169)", func() {
+		It("should leave alternatives empty when the LLM response has no alternative_workflows field", func() {
+			input := `{
+				"root_cause_analysis": {"summary": "Standard RCA without alternatives"},
+				"selected_workflow": {
+					"workflow_id": "oom-recovery",
+					"confidence": 0.88
+				}
+			}`
+
+			result, err := p.Parse(input)
+			Expect(err).NotTo(HaveOccurred(),
+				"standard RCA JSON without alternative_workflows must still parse (#1169, BR-LLM-024)")
+			Expect(result.AlternativeWorkflows).To(BeEmpty(),
+				"omitted alternative_workflows must yield nil or empty slice (#1169, BR-LLM-024)")
+		})
+	})
+
 	Describe("UT-KA-433-PRS-009: Parser ignores LLM needs_human_review (BR-HAPI-200)", func() {
 		It("should clear LLM-set HR fields and re-derive from outcome routing", func() {
 			input := `{

--- a/internal/kubernautagent/parser/parser.go
+++ b/internal/kubernautagent/parser/parser.go
@@ -228,9 +228,10 @@ func (r *llmResponse) resolvedRCA() *llmRCA {
 }
 
 type llmAlternative struct {
-	WorkflowID string  `json:"workflow_id"`
-	Confidence float64 `json:"confidence"`
-	Rationale  string  `json:"rationale"`
+	WorkflowID string                 `json:"workflow_id"`
+	Confidence float64                `json:"confidence"`
+	Rationale  string                 `json:"rationale"`
+	Parameters map[string]interface{} `json:"parameters,omitempty"`
 }
 
 type llmRCA struct {
@@ -466,6 +467,7 @@ func parseLLMFormat(jsonStr string, logger logr.Logger) (*katypes.InvestigationR
 			WorkflowID: alt.WorkflowID,
 			Confidence: alt.Confidence,
 			Rationale:  alt.Rationale,
+			Parameters: alt.Parameters,
 		})
 	}
 

--- a/internal/kubernautagent/parser/schema.go
+++ b/internal/kubernautagent/parser/schema.go
@@ -178,7 +178,8 @@ const investigationResultSchemaJSON = `{
         "properties": {
           "workflow_id": { "type": "string" },
           "confidence": { "type": "number" },
-          "rationale": { "type": "string" }
+          "rationale": { "type": "string" },
+          "parameters": { "type": "object", "additionalProperties": { "type": "string" } }
         },
         "required": ["workflow_id", "confidence"]
       }

--- a/internal/kubernautagent/prompt/templates/phase3_workflow_selection.tmpl
+++ b/internal/kubernautagent/prompt/templates/phase3_workflow_selection.tmpl
@@ -133,7 +133,7 @@ Set `selected_workflow` to None, include `actionable: false`.
     "execution_engine": "job"
   },
   "alternative_workflows": [
-    {"workflow_id": "alt-id", "confidence": 0.75, "rationale": "Why considered"}
+    {"workflow_id": "alt-id", "confidence": 0.75, "rationale": "Why considered", "parameters": {"PARAM_NAME": "value"}}
   ],
   "severity": "high",
   "confidence": 0.95,

--- a/pkg/kubernautagent/types/types.go
+++ b/pkg/kubernautagent/types/types.go
@@ -139,10 +139,11 @@ type ValidationAttemptRecord struct {
 // Matches the OpenAPI AlternativeWorkflow schema (ADR-045 v1.2).
 // Alternatives are for CONTEXT and AUDIT only, not for automatic fallback execution.
 type AlternativeWorkflow struct {
-	WorkflowID      string  `json:"workflow_id"`
-	ExecutionBundle string  `json:"execution_bundle,omitempty"`
-	Confidence      float64 `json:"confidence"`
-	Rationale       string  `json:"rationale"`
+	WorkflowID      string                 `json:"workflow_id"`
+	ExecutionBundle string                 `json:"execution_bundle,omitempty"`
+	Confidence      float64                `json:"confidence"`
+	Rationale       string                 `json:"rationale"`
+	Parameters      map[string]interface{} `json:"parameters,omitempty"`
 }
 
 // AlignmentVerdictResult holds the shadow agent's overall verdict on an investigation.

--- a/test/e2e/aianalysis/03_full_flow_test.go
+++ b/test/e2e/aianalysis/03_full_flow_test.go
@@ -27,7 +27,6 @@ import (
 
 	aianalysisv1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
 	"github.com/jordigilh/kubernaut/pkg/shared/types"
-	"github.com/jordigilh/kubernaut/pkg/shared/uuid"
 )
 
 var _ = Describe("Full User Journey E2E", Label("e2e", "full-flow"), func() {
@@ -334,11 +333,17 @@ var _ = Describe("Full User Journey E2E", Label("e2e", "full-flow"), func() {
 
 			By("Verifying AlternativeWorkflows populated (mock low_confidence scenario returns exactly 2 alternatives)")
 			Expect(analysis.Status.AlternativeWorkflows).To(HaveLen(2))
-			Expect(analysis.Status.AlternativeWorkflows[0].WorkflowID).To(Equal(uuid.DeterministicUUID("oomkill-increase-memory-v1")))
-			Expect(analysis.Status.AlternativeWorkflows[0].Rationale).To(Equal("Alternative approach for ambiguous root cause"))
-			Expect(analysis.Status.AlternativeWorkflows[1].WorkflowID).To(Equal(uuid.DeterministicUUID("node-drain-reboot-v1")))
-			Expect(analysis.Status.AlternativeWorkflows[1].Rationale).To(Equal("Requires human expertise to determine correct remediation"))
-			Expect(analysis.Status.AlternativeWorkflows[0].Confidence).To(BeNumerically(">", analysis.Status.AlternativeWorkflows[1].Confidence))
+			alt0 := analysis.Status.AlternativeWorkflows[0]
+			alt1 := analysis.Status.AlternativeWorkflows[1]
+			Expect(alt0.WorkflowID).NotTo(BeEmpty(),
+				"alternative[0] must have a workflow ID (may be DS-overridden or deterministic)")
+			Expect(alt0.Rationale).To(Equal("Alternative approach for ambiguous root cause"))
+			Expect(alt1.WorkflowID).NotTo(BeEmpty(),
+				"alternative[1] must have a workflow ID (may be DS-overridden or deterministic)")
+			Expect(alt1.Rationale).To(Equal("Requires human expertise to determine correct remediation"))
+			Expect(alt0.WorkflowID).NotTo(Equal(alt1.WorkflowID),
+				"alternatives must reference distinct workflows")
+			Expect(alt0.Confidence).To(BeNumerically(">", alt1.Confidence))
 		})
 	})
 

--- a/test/e2e/kubernautagent/interactive_discovery_e2e_test.go
+++ b/test/e2e/kubernautagent/interactive_discovery_e2e_test.go
@@ -125,6 +125,27 @@ var _ = Describe("E2E-KA-DISC: Interactive Workflow Discovery", Label("e2e", "ka
 			Expect(ok).To(BeTrue(), "recommended workflow should have a workflow_id")
 			GinkgoWriter.Printf("Using recommended workflow_id: %s\n", recommendedID)
 
+			By("Verifying recommended workflow has parameters (#1169)")
+			recParams, _ := recommended["parameters"].(map[string]any)
+			Expect(recParams).NotTo(BeEmpty(),
+				"recommended workflow must include LLM-provided parameters in discovery response (#1169)")
+			GinkgoWriter.Printf("Recommended parameters: %v\n", recParams)
+
+			By("Verifying alternatives have parameters (#1169)")
+			alts, _ := innerData["alternatives"].([]any)
+			if len(alts) > 0 {
+				for i, a := range alts {
+					altMap, _ := a.(map[string]any)
+					if altMap != nil {
+						altParams, _ := altMap["parameters"].(map[string]any)
+						if len(altParams) > 0 {
+							GinkgoWriter.Printf("Alternative[%d] (%s) parameters: %v\n",
+								i, altMap["workflow_id"], altParams)
+						}
+					}
+				}
+			}
+
 			By("Selecting the recommended workflow from discovery results")
 			result, err = infrastructure.CallSelectWorkflow(ctx, session, map[string]any{
 				"rr_id":       rrID,
@@ -241,6 +262,92 @@ var _ = Describe("E2E-KA-DISC: Interactive Workflow Discovery", Label("e2e", "ka
 			})
 
 			GinkgoWriter.Println("E2E-KA-DISC-003: select_workflow gating validated")
+		})
+	})
+
+	Describe("E2E-KA-DISC-004: select alternative workflow propagates parameters through real KA (#1169)", func() {
+		It("should discover alternatives with parameters and successfully select one", func() {
+			rrID := fmt.Sprintf("rr-disc004-%d", time.Now().Unix())
+			createTestRemediationRequest(ctx, rrID)
+
+			By("Connecting MCP client")
+			session, err := infrastructure.ConnectMCPClient(ctx, infrastructure.MCPClientConfig{
+				Endpoint:     mcpEndpoint,
+				SAToken:      saToken,
+				TLSTransport: tlsTransport,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			defer session.Close()
+
+			By("Starting interactive session")
+			result, err := infrastructure.CallInvestigate(ctx, session, map[string]any{
+				"rr_id":  rrID,
+				"action": "start",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IsError).To(BeFalse())
+
+			By("Sending OOMKill-themed message to steer to oomkilled scenario")
+			result, err = infrastructure.CallInvestigate(ctx, session, map[string]any{
+				"rr_id":   rrID,
+				"action":  "message",
+				"message": "What is the root cause of this OOMKill event?",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IsError).To(BeFalse())
+
+			By("Discovering workflows")
+			result, err = infrastructure.CallInvestigate(ctx, session, map[string]any{
+				"rr_id":  rrID,
+				"action": "discover_workflows",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IsError).To(BeFalse())
+
+			By("Extracting alternative workflow_id from discovery results")
+			discoverText := infrastructure.ExtractToolResultText(result)
+			var outerData map[string]any
+			Expect(json.Unmarshal([]byte(discoverText), &outerData)).To(Succeed())
+			responseStr, ok := outerData["response"].(string)
+			Expect(ok).To(BeTrue())
+			var innerData map[string]any
+			Expect(json.Unmarshal([]byte(responseStr), &innerData)).To(Succeed())
+
+			alts, _ := innerData["alternatives"].([]any)
+			Expect(alts).NotTo(BeEmpty(),
+				"discovery must return at least one alternative for the oomkilled scenario (#1169)")
+
+			alt0, _ := alts[0].(map[string]any)
+			altID, ok := alt0["workflow_id"].(string)
+			Expect(ok).To(BeTrue(), "alternative must have a workflow_id")
+			GinkgoWriter.Printf("Selecting alternative workflow_id: %s\n", altID)
+
+			altParams, _ := alt0["parameters"].(map[string]any)
+			GinkgoWriter.Printf("Alternative parameters: %v\n", altParams)
+
+			By("Selecting the alternative workflow")
+			result, err = infrastructure.CallSelectWorkflow(ctx, session, map[string]any{
+				"rr_id":       rrID,
+				"workflow_id": altID,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			selectText := infrastructure.ExtractToolResultText(result)
+			GinkgoWriter.Printf("select_workflow result: %s\n", selectText)
+			Expect(result.IsError).To(BeFalse(),
+				"select_workflow must succeed for a discovery-listed alternative (#1169)")
+
+			By("Verifying Lease released after auto-complete")
+			clientset, err := getKubernetesClientset()
+			Expect(err).NotTo(HaveOccurred())
+			Eventually(func() bool {
+				_, err := clientset.CoordinationV1().Leases(sharedNamespace).Get(
+					ctx, leaseNameForRR(rrID), metav1.GetOptions{})
+				return err != nil
+			}, 15*time.Second, 500*time.Millisecond).Should(BeTrue(),
+				"Lease should be deleted after selecting alternative workflow")
+
+			GinkgoWriter.Println("E2E-KA-DISC-004: Alternative workflow selection completed")
 		})
 	})
 })

--- a/test/e2e/kubernautagent/interactive_discovery_e2e_test.go
+++ b/test/e2e/kubernautagent/interactive_discovery_e2e_test.go
@@ -125,24 +125,23 @@ var _ = Describe("E2E-KA-DISC: Interactive Workflow Discovery", Label("e2e", "ka
 			Expect(ok).To(BeTrue(), "recommended workflow should have a workflow_id")
 			GinkgoWriter.Printf("Using recommended workflow_id: %s\n", recommendedID)
 
-			By("Verifying recommended workflow has parameters (#1169)")
+			By("Verifying recommended workflow has oomkilled scenario parameters (#1169)")
 			recParams, _ := recommended["parameters"].(map[string]any)
-			Expect(recParams).NotTo(BeEmpty(),
-				"recommended workflow must include LLM-provided parameters (#1169)")
+			Expect(recParams).To(HaveKey("MEMORY_LIMIT_NEW"),
+				"recommended workflow must include MEMORY_LIMIT_NEW from oomkilled scenario (#1169)")
 			GinkgoWriter.Printf("Recommended parameters: %v\n", recParams)
 
-			By("Verifying alternatives have parameters (#1169)")
+			By("Verifying alternatives exist with parameters (#1169)")
 			alts, _ := innerData["alternatives"].([]any)
 			Expect(alts).NotTo(BeEmpty(),
 				"oomkilled scenario must return at least one alternative (#1169)")
-			for i, a := range alts {
-				altMap, _ := a.(map[string]any)
-				if altMap != nil {
-					altParams, _ := altMap["parameters"].(map[string]any)
-					GinkgoWriter.Printf("Alternative[%d] (%s) parameters: %v\n",
-						i, altMap["workflow_id"], altParams)
-				}
-			}
+			alt0, _ := alts[0].(map[string]any)
+			Expect(alt0).NotTo(BeNil())
+			alt0Params, _ := alt0["parameters"].(map[string]any)
+			Expect(alt0Params).To(HaveKey("REPLICA_COUNT"),
+				"first alternative must include REPLICA_COUNT from oomkilled scenario (#1169)")
+			GinkgoWriter.Printf("Alternative[0] (%s) parameters: %v\n",
+				alt0["workflow_id"], alt0Params)
 
 			By("Selecting the recommended workflow from discovery results")
 			result, err = infrastructure.CallSelectWorkflow(ctx, session, map[string]any{
@@ -321,6 +320,8 @@ var _ = Describe("E2E-KA-DISC: Interactive Workflow Discovery", Label("e2e", "ka
 			GinkgoWriter.Printf("Selecting alternative workflow_id: %s\n", altID)
 
 			altParams, _ := alt0["parameters"].(map[string]any)
+			Expect(altParams).NotTo(BeEmpty(),
+				"alternative workflow must include LLM-provided parameters (#1169)")
 			GinkgoWriter.Printf("Alternative parameters: %v\n", altParams)
 
 			By("Selecting the alternative workflow")

--- a/test/e2e/kubernautagent/interactive_discovery_e2e_test.go
+++ b/test/e2e/kubernautagent/interactive_discovery_e2e_test.go
@@ -60,7 +60,7 @@ var _ = Describe("E2E-KA-DISC: Interactive Workflow Discovery", Label("e2e", "ka
 	Describe("E2E-KA-DISC-001: Full discovery lifecycle", func() {
 		It("should execute start -> message -> discover_workflows -> select_workflow", func() {
 			rrID := fmt.Sprintf("rr-disc001-%d", time.Now().Unix())
-			createTestRemediationRequest(ctx, rrID)
+			createTestRemediationRequest(ctx, rrID, withSignalName("OOMKilled"))
 
 			By("Connecting MCP client")
 			session, err := infrastructure.ConnectMCPClient(ctx, infrastructure.MCPClientConfig{
@@ -128,21 +128,19 @@ var _ = Describe("E2E-KA-DISC: Interactive Workflow Discovery", Label("e2e", "ka
 			By("Verifying recommended workflow has parameters (#1169)")
 			recParams, _ := recommended["parameters"].(map[string]any)
 			Expect(recParams).NotTo(BeEmpty(),
-				"recommended workflow must include LLM-provided parameters in discovery response (#1169)")
+				"recommended workflow must include LLM-provided parameters (#1169)")
 			GinkgoWriter.Printf("Recommended parameters: %v\n", recParams)
 
 			By("Verifying alternatives have parameters (#1169)")
 			alts, _ := innerData["alternatives"].([]any)
-			if len(alts) > 0 {
-				for i, a := range alts {
-					altMap, _ := a.(map[string]any)
-					if altMap != nil {
-						altParams, _ := altMap["parameters"].(map[string]any)
-						if len(altParams) > 0 {
-							GinkgoWriter.Printf("Alternative[%d] (%s) parameters: %v\n",
-								i, altMap["workflow_id"], altParams)
-						}
-					}
+			Expect(alts).NotTo(BeEmpty(),
+				"oomkilled scenario must return at least one alternative (#1169)")
+			for i, a := range alts {
+				altMap, _ := a.(map[string]any)
+				if altMap != nil {
+					altParams, _ := altMap["parameters"].(map[string]any)
+					GinkgoWriter.Printf("Alternative[%d] (%s) parameters: %v\n",
+						i, altMap["workflow_id"], altParams)
 				}
 			}
 
@@ -268,7 +266,7 @@ var _ = Describe("E2E-KA-DISC: Interactive Workflow Discovery", Label("e2e", "ka
 	Describe("E2E-KA-DISC-004: select alternative workflow propagates parameters through real KA (#1169)", func() {
 		It("should discover alternatives with parameters and successfully select one", func() {
 			rrID := fmt.Sprintf("rr-disc004-%d", time.Now().Unix())
-			createTestRemediationRequest(ctx, rrID)
+			createTestRemediationRequest(ctx, rrID, withSignalName("OOMKilled"))
 
 			By("Connecting MCP client")
 			session, err := infrastructure.ConnectMCPClient(ctx, infrastructure.MCPClientConfig{

--- a/test/e2e/kubernautagent/interactive_helpers_test.go
+++ b/test/e2e/kubernautagent/interactive_helpers_test.go
@@ -33,10 +33,20 @@ import (
 	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
 )
 
+// rrOption configures optional overrides for createTestRemediationRequest.
+type rrOption func(*remediationv1.RemediationRequestSpec)
+
+// withSignalName overrides the default "E2ETestSignal" signal name on the RR.
+func withSignalName(name string) rrOption {
+	return func(spec *remediationv1.RemediationRequestSpec) {
+		spec.SignalName = name
+	}
+}
+
 // createTestRemediationRequest provisions a minimal RemediationRequest CRD in the
 // Kind cluster so that the RRExistenceChecker (HARM-004) allows the session to start.
 // The RR is created with the bare minimum fields required by the CRD validation schema.
-func createTestRemediationRequest(testCtx context.Context, rrID string) {
+func createTestRemediationRequest(testCtx context.Context, rrID string, opts ...rrOption) {
 	GinkgoHelper()
 
 	scheme := k8sruntime.NewScheme()
@@ -73,7 +83,11 @@ func createTestRemediationRequest(testCtx context.Context, rrID string) {
 		},
 	}
 
+	for _, o := range opts {
+		o(&rr.Spec)
+	}
+
 	Expect(cli.Create(testCtx, rr)).To(Succeed(),
 		"should create RemediationRequest %s for E2E test", rrID)
-	GinkgoWriter.Printf("  📋 Created RR fixture: %s/%s\n", sharedNamespace, rrID)
+	GinkgoWriter.Printf("  📋 Created RR fixture: %s/%s (signal=%s)\n", sharedNamespace, rrID, rr.Spec.SignalName)
 }

--- a/test/integration/kubernautagent/mcp/discovery_flow_test.go
+++ b/test/integration/kubernautagent/mcp/discovery_flow_test.go
@@ -18,6 +18,7 @@ package mcp_test
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http/httptest"
 	"time"
@@ -126,6 +127,15 @@ var _ = Describe("Interactive Workflow Discovery — IT flows", Label("integrati
 				RCASummary: "Pod OOM due to memory leak in deployment/web",
 				WorkflowID: discoveredWorkflowID,
 				Confidence: 0.88,
+				Parameters: map[string]interface{}{"MEMORY_LIMIT_NEW": "512Mi"},
+				AlternativeWorkflows: []katypes.AlternativeWorkflow{
+					{
+						WorkflowID: alternativeWfID,
+						Confidence: 0.65,
+						Rationale:  "Rollback to previous deployment version",
+						Parameters: map[string]interface{}{"REPLICA_COUNT": "3"},
+					},
+				},
 			},
 		}
 
@@ -141,8 +151,8 @@ var _ = Describe("Interactive Workflow Discovery — IT flows", Label("integrati
 		stack.Close()
 	})
 
-	Describe("IT-KA-DISC-001: start -> message -> discover_workflows -> select_workflow (auto-complete)", func() {
-		It("should complete the full discovery flow and auto-complete the HTTP session", func() {
+	Describe("IT-KA-DISC-001: start -> message -> discover_workflows -> select_workflow (auto-complete) (#1169)", func() {
+		It("should complete the full discovery flow with per-workflow parameters and auto-complete the HTTP session", func() {
 			sess, err := connectMCP(stack.Server, "alice@acme.io")
 			Expect(err).NotTo(HaveOccurred())
 			defer func() { _ = sess.Close() }()
@@ -178,7 +188,27 @@ var _ = Describe("Interactive Workflow Discovery — IT flows", Label("integrati
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output["status"]).To(Equal("workflows_discovered"))
 
-			By("selecting a workflow")
+			By("verifying discovery response contains parameters (#1169)")
+			responseStr, ok := output["response"].(string)
+			Expect(ok).To(BeTrue(), "response field must be a JSON string")
+			var discovery map[string]interface{}
+			Expect(json.Unmarshal([]byte(responseStr), &discovery)).To(Succeed(),
+				"inner response JSON must parse for parameter inspection")
+
+			rec, _ := discovery["recommended"].(map[string]interface{})
+			Expect(rec).NotTo(BeNil(), "recommended workflow must be present in discovery response")
+			recParams, _ := rec["parameters"].(map[string]interface{})
+			Expect(recParams).To(HaveKeyWithValue("MEMORY_LIMIT_NEW", "512Mi"),
+				"recommended workflow must surface LLM-provided parameters (#1169)")
+
+			alts, _ := discovery["alternatives"].([]interface{})
+			Expect(alts).To(HaveLen(1), "one alternative must be present in discovery response")
+			alt0, _ := alts[0].(map[string]interface{})
+			alt0Params, _ := alt0["parameters"].(map[string]interface{})
+			Expect(alt0Params).To(HaveKeyWithValue("REPLICA_COUNT", "3"),
+				"alternative workflow must surface LLM-provided parameters (#1169)")
+
+			By("selecting the recommended workflow")
 			result, err = callTool(sess, "kubernaut_select_workflow", map[string]any{
 				"rr_id":       "rr-disc-001",
 				"workflow_id": discoveredWorkflowID,
@@ -189,10 +219,14 @@ var _ = Describe("Interactive Workflow Discovery — IT flows", Label("integrati
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output["status"]).To(Equal("workflow_selected"))
 
-			By("verifying auto-complete wrote to HTTP session")
+			By("verifying auto-complete wrote recommended parameters to HTTP session (#1169)")
 			Expect(completer.completedID).To(Equal("http-sess-discovery"))
 			Expect(completer.completedResult).NotTo(BeNil())
 			Expect(completer.completedResult.WorkflowID).To(Equal(discoveredWorkflowID))
+			Expect(completer.completedResult.Parameters).To(HaveKeyWithValue("MEMORY_LIMIT_NEW", "512Mi"),
+				"recommended parameters must flow through to the HTTP session completer (#1169)")
+			Expect(completer.completedResult.Parameters).NotTo(HaveKey("REPLICA_COUNT"),
+				"alternative parameters must not leak to the recommended workflow's completion (#1169)")
 		})
 	})
 
@@ -436,6 +470,52 @@ var _ = Describe("Interactive Workflow Discovery — IT flows", Label("integrati
 				"should use default reason when none provided")
 			Expect(completer.completedResult.RCASummary).To(ContainSubstring("without workflow"),
 				"should use minimal RCA summary when no prior RCA exists")
+		})
+	})
+
+	Describe("IT-KA-DISC-008: select alternative workflow propagates per-workflow parameters (#1169)", func() {
+		It("should deliver alternative parameters to the completer instead of recommended parameters", func() {
+			sess, err := connectMCP(stack.Server, "alice@acme.io")
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = sess.Close() }()
+
+			By("starting a session")
+			result, err := callInvestigate(sess, map[string]any{
+				"rr_id":  "rr-disc-008",
+				"action": "start",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IsError).To(BeFalse())
+
+			By("discovering workflows")
+			result, err = callInvestigate(sess, map[string]any{
+				"rr_id":  "rr-disc-008",
+				"action": "discover_workflows",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IsError).To(BeFalse())
+
+			By("selecting the alternative workflow")
+			completer.completedResult = nil
+			result, err = callTool(sess, "kubernaut_select_workflow", map[string]any{
+				"rr_id":       "rr-disc-008",
+				"workflow_id": alternativeWfID,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.IsError).To(BeFalse())
+			output, err := decodeOutput(result)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output["status"]).To(Equal("workflow_selected"))
+
+			By("verifying completer received alternative parameters (#1169)")
+			Expect(completer.completedResult).NotTo(BeNil(),
+				"HTTP session completion must occur for alternative workflow selection")
+			Expect(completer.completedResult.WorkflowID).To(Equal(alternativeWfID),
+				"the selected alternative workflow ID must be on the completed result")
+			Expect(completer.completedResult.Parameters).To(HaveKeyWithValue("REPLICA_COUNT", "3"),
+				"alternative workflow parameters must flow through to the completer (#1169)")
+			Expect(completer.completedResult.Parameters).NotTo(HaveKey("MEMORY_LIMIT_NEW"),
+				"recommended parameters must not leak when an alternative is selected (#1169)")
 		})
 	})
 })

--- a/test/integration/kubernautagent/mcp/discovery_flow_test.go
+++ b/test/integration/kubernautagent/mcp/discovery_flow_test.go
@@ -402,8 +402,12 @@ var _ = Describe("Interactive Workflow Discovery — IT flows", Label("integrati
 			Expect(output["status"]).To(Equal("completed_no_action"))
 
 			Expect(completer.completedResult).NotTo(BeNil())
-			Expect(completer.completedResult.RCASummary).NotTo(BeEmpty(),
-				"should propagate the RCA summary from discover_workflows extraction")
+			Expect(completer.completedResult.RCASummary).To(
+				Equal("Unable to determine specific root cause"),
+				"must propagate exact RCA from extraction step, not the complete_no_action fallback")
+			Expect(completer.completedResult.RCASummary).NotTo(
+				Equal("Investigation completed without workflow selection"),
+				"must NOT use the complete_no_action no-discovery fallback")
 		})
 	})
 

--- a/test/integration/kubernautagent/mcp/discovery_flow_test.go
+++ b/test/integration/kubernautagent/mcp/discovery_flow_test.go
@@ -402,7 +402,7 @@ var _ = Describe("Interactive Workflow Discovery — IT flows", Label("integrati
 			Expect(output["status"]).To(Equal("completed_no_action"))
 
 			Expect(completer.completedResult).NotTo(BeNil())
-			Expect(completer.completedResult.RCASummary).To(ContainSubstring("OOM"),
+			Expect(completer.completedResult.RCASummary).NotTo(BeEmpty(),
 				"should propagate the RCA summary from discover_workflows extraction")
 		})
 	})

--- a/test/integration/kubernautagent/mcp/discovery_flow_test.go
+++ b/test/integration/kubernautagent/mcp/discovery_flow_test.go
@@ -29,35 +29,32 @@ import (
 	. "github.com/onsi/gomega"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
 	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/adapters"
 	mcptools "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
 	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm/langchaingo"
+	"github.com/jordigilh/kubernaut/pkg/shared/uuid"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-// discoveryRunner provides canned RCA extraction and workflow discovery responses
-// for the discover_workflows flow, while still forwarding interactive turns
-// to the real Mock LLM for message handling.
-type discoveryRunner struct {
-	goldenPathRunner
-	rcaResult      *katypes.InvestigationResult
-	workflowResult *katypes.InvestigationResult
-}
-
-func (r *discoveryRunner) RunRCAExtraction(_ context.Context, _ []mcptools.LLMMessage, _ string) (*katypes.InvestigationResult, error) {
-	return r.rcaResult, nil
-}
-
-func (r *discoveryRunner) RunWorkflowDiscovery(_ context.Context, _ katypes.SignalContext, _ *katypes.InvestigationResult, _ *prompt.EnrichmentData, _ string) (*katypes.InvestigationResult, error) {
-	return r.workflowResult, nil
-}
-
-// discoverySignalResolver provides canned signal context for tests.
+// discoverySignalResolver returns a signal context that triggers the oomkilled
+// scenario in the real Mock LLM container. The Phase 3 prompt template emits
+// "Signal Name: OOMKilled" which the Mock LLM's signalScenario matcher detects.
 type discoverySignalResolver struct{}
 
 func (d *discoverySignalResolver) ResolveSignalContext(_ context.Context, _ string) (*katypes.SignalContext, error) {
-	return &katypes.SignalContext{Severity: "critical"}, nil
+	return &katypes.SignalContext{
+		Name:         "OOMKilled",
+		Severity:     "critical",
+		ResourceKind: "Deployment",
+		Namespace:    "production",
+		ResourceName: "api-server",
+	}, nil
 }
 
 func (d *discoverySignalResolver) ResolveEnrichmentData(_ context.Context, _ string) (*prompt.EnrichmentData, error) {
@@ -97,15 +94,14 @@ func callTool(sess *mcpsdk.ClientSession, toolName string, args map[string]any) 
 
 var _ = Describe("Interactive Workflow Discovery — IT flows", Label("integration", "discovery"), func() {
 
-	const (
-		discoveredWorkflowID = "restart-pod-v2"
-		alternativeWfID      = "rollback-deploy-v1"
+	var (
+		recommendedWfID = uuid.DeterministicUUID("oomkill-increase-memory-v1")
+		alternativeWfID = uuid.DeterministicUUID("generic-restart-v1")
 	)
 
 	var (
 		stack     *realMCPTestStack
 		nsName    string
-		runner    *discoveryRunner
 		completer *discoveryHTTPCompleter
 	)
 
@@ -113,38 +109,9 @@ var _ = Describe("Interactive Workflow Discovery — IT flows", Label("integrati
 		nsName = uniqueNamespace("disc")
 		createNamespace(context.Background(), sharedK8sClient, nsName)
 
-		runner = &discoveryRunner{
-			goldenPathRunner: goldenPathRunner{
-				response: "I found OOM in deployment/web",
-				delay:    50 * time.Millisecond,
-			},
-			rcaResult: &katypes.InvestigationResult{
-				RCASummary: "Pod OOM due to memory leak in deployment/web",
-				Confidence: 0.92,
-				Severity:   "critical",
-			},
-			workflowResult: &katypes.InvestigationResult{
-				RCASummary: "Pod OOM due to memory leak in deployment/web",
-				WorkflowID: discoveredWorkflowID,
-				Confidence: 0.88,
-				Parameters: map[string]interface{}{"MEMORY_LIMIT_NEW": "512Mi"},
-				AlternativeWorkflows: []katypes.AlternativeWorkflow{
-					{
-						WorkflowID: alternativeWfID,
-						Confidence: 0.65,
-						Rationale:  "Rollback to previous deployment version",
-						Parameters: map[string]interface{}{"REPLICA_COUNT": "3"},
-					},
-				},
-			},
-		}
-
 		completer = &discoveryHTTPCompleter{}
 
-		opts := defaultRealStackOpts()
-		opts.customRunner = runner
-
-		stack = newRealMCPTestStackWithDiscovery(sharedK8sClient, nsName, opts, runner, completer)
+		stack = newRealMCPTestStackWithDiscovery(sharedK8sClient, nsName, defaultRealStackOpts(), completer)
 	})
 
 	AfterEach(func() {
@@ -188,7 +155,7 @@ var _ = Describe("Interactive Workflow Discovery — IT flows", Label("integrati
 			Expect(err).NotTo(HaveOccurred())
 			Expect(output["status"]).To(Equal("workflows_discovered"))
 
-			By("verifying discovery response contains parameters (#1169)")
+			By("verifying discovery response contains parameters from real Mock LLM (#1169)")
 			responseStr, ok := output["response"].(string)
 			Expect(ok).To(BeTrue(), "response field must be a JSON string")
 			var discovery map[string]interface{}
@@ -211,7 +178,7 @@ var _ = Describe("Interactive Workflow Discovery — IT flows", Label("integrati
 			By("selecting the recommended workflow")
 			result, err = callTool(sess, "kubernaut_select_workflow", map[string]any{
 				"rr_id":       "rr-disc-001",
-				"workflow_id": discoveredWorkflowID,
+				"workflow_id": recommendedWfID,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.IsError).To(BeFalse())
@@ -222,7 +189,7 @@ var _ = Describe("Interactive Workflow Discovery — IT flows", Label("integrati
 			By("verifying auto-complete wrote recommended parameters to HTTP session (#1169)")
 			Expect(completer.completedID).To(Equal("http-sess-discovery"))
 			Expect(completer.completedResult).NotTo(BeNil())
-			Expect(completer.completedResult.WorkflowID).To(Equal(discoveredWorkflowID))
+			Expect(completer.completedResult.WorkflowID).To(Equal(recommendedWfID))
 			Expect(completer.completedResult.Parameters).To(HaveKeyWithValue("MEMORY_LIMIT_NEW", "512Mi"),
 				"recommended parameters must flow through to the HTTP session completer (#1169)")
 			Expect(completer.completedResult.Parameters).NotTo(HaveKey("REPLICA_COUNT"),
@@ -303,7 +270,7 @@ var _ = Describe("Interactive Workflow Discovery — IT flows", Label("integrati
 			By("attempting select_workflow (should be rejected)")
 			result, err = callTool(sess, "kubernaut_select_workflow", map[string]any{
 				"rr_id":       "rr-disc-003",
-				"workflow_id": discoveredWorkflowID,
+				"workflow_id": recommendedWfID,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.IsError).To(BeTrue(), "select_workflow should fail after message invalidated discovery")
@@ -319,7 +286,7 @@ var _ = Describe("Interactive Workflow Discovery — IT flows", Label("integrati
 			By("selecting workflow after re-discovery (should succeed)")
 			result, err = callTool(sess, "kubernaut_select_workflow", map[string]any{
 				"rr_id":       "rr-disc-003",
-				"workflow_id": discoveredWorkflowID,
+				"workflow_id": recommendedWfID,
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.IsError).To(BeFalse())
@@ -520,15 +487,35 @@ var _ = Describe("Interactive Workflow Discovery — IT flows", Label("integrati
 	})
 })
 
-// newRealMCPTestStackWithDiscovery builds a test stack with select_workflow and complete_no_action
-// tools wired up, using custom runner and HTTP completer for discovery testing.
-func newRealMCPTestStackWithDiscovery(k8sClient client.Client, namespace string, opts realStackOpts, runner *discoveryRunner, completer *discoveryHTTPCompleter) *realMCPTestStack {
+// newRealMCPTestStackWithDiscovery builds a test stack with select_workflow and
+// complete_no_action tools wired up, using the REAL investigator via langchaingo
+// against the shared Podman Mock LLM container. No stubbed runners.
+func newRealMCPTestStackWithDiscovery(k8sClient client.Client, namespace string, opts realStackOpts, completer *discoveryHTTPCompleter) *realMCPTestStack {
 	stack := &realMCPTestStack{
 		K8sClient: k8sClient,
 		Namespace: namespace,
 	}
 
 	logrLogger := logr.Discard()
+
+	// Real LLM client via langchaingo -> Podman Mock LLM
+	llmAdapter, err := langchaingo.New("openai", sharedMockLLMEndpoint, "test-model", "test-key")
+	Expect(err).ToNot(HaveOccurred(), "langchaingo adapter should build against Mock LLM at %s", sharedMockLLMEndpoint)
+	stack.LLMClient = llmAdapter
+
+	promptBuilder, buildErr := prompt.NewBuilder()
+	Expect(buildErr).ToNot(HaveOccurred(), "prompt builder should build")
+
+	inv := investigator.New(investigator.Config{
+		Client:       llmAdapter,
+		Builder:      promptBuilder,
+		ResultParser: parser.NewResultParser(),
+		AuditStore:   audit.NopAuditStore{},
+		Logger:       logrLogger,
+		MaxTurns:     15,
+		ModelName:    "test-model",
+	})
+	runner := adapters.NewInvestigatorRunnerAdapter(inv)
 
 	recon := mcpinternal.NewDSContextReconstructor(sharedDSClient, 5*time.Second, logrLogger)
 
@@ -562,21 +549,23 @@ func newRealMCPTestStackWithDiscovery(k8sClient client.Client, namespace string,
 	}
 	investigateTool := mcptools.NewInvestigateTool(stack.SessionMgr, runner, recon, mcptools.NopAutonomousManager{}, investigateOpts...)
 
-	// Wire catalog that returns the discovered workflow
+	// Catalog uses the Mock LLM's oomkilled scenario workflow IDs
+	oomkillWfID := uuid.DeterministicUUID("oomkill-increase-memory-v1")
+	restartWfID := uuid.DeterministicUUID("generic-restart-v1")
 	catalog := &discoveryMockCatalog{
 		workflows: map[string]*mcptools.CatalogWorkflow{
-			"restart-pod-v2": {
-				WorkflowID:      "restart-pod-v2",
-				WorkflowName:    "Restart Pod",
-				ExecutionEngine: "argo",
-				ExecutionBundle: "oci://restart:v2",
-				Version:         "v2.0",
+			oomkillWfID: {
+				WorkflowID:      oomkillWfID,
+				WorkflowName:    "OOMKill Recovery - Increase Memory Limits",
+				ExecutionEngine: "job",
+				ExecutionBundle: "oci://oomkill-increase-memory:v1",
+				Version:         "v1.0",
 			},
-			"rollback-deploy-v1": {
-				WorkflowID:      "rollback-deploy-v1",
-				WorkflowName:    "Rollback Deploy",
-				ExecutionEngine: "argo",
-				ExecutionBundle: "oci://rollback:v1",
+			restartWfID: {
+				WorkflowID:      restartWfID,
+				WorkflowName:    "Generic Restart",
+				ExecutionEngine: "job",
+				ExecutionBundle: "oci://generic-restart:v1",
 				Version:         "v1.0",
 			},
 		},

--- a/test/services/mock-llm/override_apply_test.go
+++ b/test/services/mock-llm/override_apply_test.go
@@ -55,6 +55,38 @@ var _ = Describe("Override Application (BR-TESTING-657)", func() {
 		})
 	})
 
+	Describe("UT-MOCK-1169-005: alternative workflow UUIDs are replaced from overrides", func() {
+		It("should replace the deterministic alternative UUID with the DS-assigned UUID", func() {
+			overrides := &config.Overrides{
+				Scenarios: map[string]config.ScenarioOverride{
+					"generic-restart-v1:production": {
+						WorkflowID: "real-ds-uuid-for-generic-restart",
+					},
+				},
+			}
+
+			registry := scenarios.DefaultRegistryWithOverrides(overrides)
+			ctx := &scenarios.DetectionContext{
+				Content:    "- Signal Name: OOMKilled\n- Namespace: default",
+				AllText:    "- Signal Name: OOMKilled\n- Namespace: default",
+				SignalName: "",
+			}
+			result := registry.Detect(ctx)
+			Expect(result).NotTo(BeNil())
+			Expect(result.Scenario.Name()).To(Equal("oomkilled"))
+
+			cfgScenario, ok := result.Scenario.(scenarios.ScenarioWithConfig)
+			Expect(ok).To(BeTrue())
+
+			cfg := cfgScenario.Config()
+			Expect(cfg.Alternatives).NotTo(BeEmpty(),
+				"oomkilled scenario must have at least one alternative")
+			Expect(cfg.Alternatives[0].WorkflowName).To(Equal("generic-restart-v1"))
+			Expect(cfg.Alternatives[0].WorkflowID).To(Equal("real-ds-uuid-for-generic-restart"),
+				"alternative UUID should be replaced by the override from DataStorage")
+		})
+	})
+
 	Describe("UT-MOCK-657-004: applyOverride applies ToolCall fields to MockScenarioConfig", func() {
 		It("should propagate ToolCallName and ToolCallArgs from override to scenario config", func() {
 			forceText := false

--- a/test/services/mock-llm/response/openai.go
+++ b/test/services/mock-llm/response/openai.go
@@ -236,11 +236,15 @@ func analysisJSON(cfg scenarios.MockScenarioConfig) map[string]interface{} {
 	if len(cfg.Alternatives) > 0 {
 		alts := make([]map[string]interface{}, 0, len(cfg.Alternatives))
 		for _, a := range cfg.Alternatives {
-			alts = append(alts, map[string]interface{}{
+			alt := map[string]interface{}{
 				"workflow_id": a.WorkflowID,
 				"confidence":  a.Confidence,
 				"rationale":   a.Rationale,
-			})
+			}
+			if len(a.Parameters) > 0 {
+				alt["parameters"] = a.Parameters
+			}
+			alts = append(alts, alt)
 		}
 		obj["alternative_workflows"] = alts
 	}

--- a/test/services/mock-llm/scenarios/registry_default.go
+++ b/test/services/mock-llm/scenarios/registry_default.go
@@ -57,6 +57,20 @@ func applyOverride(cs *configScenario, ov config.ScenarioOverride) {
 	}
 }
 
+// applyAlternativeOverrides replaces deterministic UUIDs in a scenario's
+// Alternatives with the real DataStorage UUIDs from the overrides map.
+func applyAlternativeOverrides(cs *configScenario, overrides map[string]config.ScenarioOverride) {
+	for i := range cs.config.Alternatives {
+		alt := &cs.config.Alternatives[i]
+		if alt.WorkflowName == "" {
+			continue
+		}
+		if ov, found := findOverrideByWorkflowName(overrides, alt.WorkflowName); found && ov.WorkflowID != "" {
+			alt.WorkflowID = ov.WorkflowID
+		}
+	}
+}
+
 // findOverrideByWorkflowName searches override keys for entries matching the
 // given workflow name. Keys have format "workflow_name:environment". When
 // multiple environments match, ":production" is preferred since the E2E
@@ -92,13 +106,13 @@ func DefaultRegistryFull(overrides *config.Overrides, goldenDir string) *Registr
 			}
 			if ov, found := overrides.Scenarios[cs.config.ScenarioName]; found {
 				applyOverride(cs, ov)
-				continue
+			} else if cs.config.WorkflowName != "" {
+				if ov, found := findOverrideByWorkflowName(overrides.Scenarios, cs.config.WorkflowName); found {
+					applyOverride(cs, ov)
+				}
 			}
-			if cs.config.WorkflowName == "" {
-				continue
-			}
-			if ov, found := findOverrideByWorkflowName(overrides.Scenarios, cs.config.WorkflowName); found {
-				applyOverride(cs, ov)
+			if len(cs.config.Alternatives) > 0 {
+				applyAlternativeOverrides(cs, overrides.Scenarios)
 			}
 		}
 

--- a/test/services/mock-llm/scenarios/scenario_oomkilled.go
+++ b/test/services/mock-llm/scenarios/scenario_oomkilled.go
@@ -29,7 +29,7 @@ func oomkilledConfig() MockScenarioConfig {
 		Parameters: map[string]string{"MEMORY_LIMIT_NEW": "512Mi"}, ExecutionEngine: "job",
 		Contributing: []string{"traffic_spike", "insufficient_memory_limits", "no_HPA_configured"},
 		Alternatives: []MockAlternativeWorkflow{
-			{WorkflowName: "generic-restart-v1", WorkflowID: uuid.DeterministicUUID("generic-restart-v1"), Confidence: 0.60, Rationale: "Restart would temporarily resolve the OOM but doesn't address the underlying memory limit issue"},
+			{WorkflowName: "generic-restart-v1", WorkflowID: uuid.DeterministicUUID("generic-restart-v1"), Confidence: 0.60, Rationale: "Restart would temporarily resolve the OOM but doesn't address the underlying memory limit issue", Parameters: map[string]string{"REPLICA_COUNT": "3"}},
 		},
 		InvestigationOutcome: "actionable",
 		IsActionable:         BoolPtr(true),

--- a/test/services/mock-llm/scenarios/types.go
+++ b/test/services/mock-llm/scenarios/types.go
@@ -25,6 +25,7 @@ type MockAlternativeWorkflow struct {
 	WorkflowID   string
 	Confidence   float64
 	Rationale    string
+	Parameters   map[string]string
 }
 
 // MultiToolCallEntry describes a single tool call within a multi-tool-call batch.


### PR DESCRIPTION
## Summary

- Surface per-workflow `parameters` (populated by the LLM) on both recommended and alternative workflows in the `discover_workflows` MCP response, enabling the AF UI to display parameter previews before operator selection
- Extend `select_workflow` to merge the selected workflow's parameters into the final `InvestigationResult`, with map cloning to prevent aliasing (Go mistake #78)
- Add comprehensive test coverage across UT (19 new scenarios), IT (2 new/updated), and E2E (2 new/updated) tiers with TDD methodology (Red-Green-Refactor)
- Create authoritative MCP contract documentation (`docs/mcp/discover-workflows-contract.md`) for AF team consumption

## Changes

### Production (KA)
- `AlternativeWorkflow.Parameters` (`map[string]interface{}`) added to types
- `llmAlternative.Parameters` added to parser with copy in `parseLLMFormat`
- `DiscoveredWorkflow.Parameters` added to MCP DTO with copy in `extractDiscoveryResult`
- `buildFinalResult` extended to 3-arg with `lookupDiscoveredParameters` and `cloneParameterMap`
- LLM JSON schema updated to include `parameters` on `alternative_workflows` items
- Phase 3 prompt template updated with parameters example on alternatives

### Mock LLM
- `MockAlternativeWorkflow.Parameters` field added
- `analysisJSON` emits `parameters` on alternatives when non-empty
- `oomkilled` scenario seeded with `REPLICA_COUNT: "3"` on `generic-restart-v1` alternative

### Documentation
- **NEW**: `docs/mcp/discover-workflows-contract.md` — authoritative MCP tool contract
- **UPDATED**: BR-INTERACTIVE-009 added for workflow discovery parameters
- **UPDATED**: ADR-045 v1.3 addendum for MCP DiscoveredWorkflow parameter divergence
- **UPDATED**: User guide with workflow discovery and selection section

### Known Gaps (tracked separately)
- Parameter validation regression from HAPI migration: [#1170](https://github.com/jordigilh/kubernaut/issues/1170)
- Parameter type tightening (`map[string]string` at parser level): v1.6 follow-up
- `ResultToAuditJSON` per-alternative parameters: v1.6 follow-up

## Test plan

- [x] Parser tests: PRS-010/b/c/d/e (alternative parameter extraction edge cases)
- [x] extractDiscoveryResult tests: EDR-001..006 (parameter propagation)
- [x] buildFinalResult tests: BUILDFINAL-002a..g (parameter merging + map aliasing safety)
- [x] Handle flow test: AC-002 (parameter hand-off to completer)
- [x] IT: DISC-001 updated with parameter assertions, DISC-008 for alternative selection
- [x] E2E: DISC-001 updated with parameter assertions, DISC-004 for alternative selection
- [x] All 123 parser tests pass, all 94 MCP tools tests pass, 0 regressions

Closes #1169


Made with [Cursor](https://cursor.com)