### PR TITLE
feat(e2e): wire DD-TEST-007 coverage instrumentation for AF E2E (#1196)

### DIFF
--- a/test/e2e/apifrontend/e2e_suite_test.go
+++ b/test/e2e/apifrontend/e2e_suite_test.go
@@ -146,11 +146,8 @@ var _ = SynchronizedAfterSuite(
 
 		if os.Getenv("E2E_COVERAGE") == "true" {
 			_, _ = fmt.Fprintln(GinkgoWriter, "\nCollecting E2E binary coverage data (DD-TEST-007)...")
-			profilePath, err := infrastructure.CollectE2EBinaryCoverage(e2eClusterName, GinkgoWriter)
-			if err != nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: Coverage collection failed: %v\n", err)
-			} else {
-				_, _ = fmt.Fprintf(GinkgoWriter, "Coverage profile: %s\n", profilePath)
+			if err := infrastructure.CollectE2EBinaryCoverage(e2eClusterName, GinkgoWriter); err != nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: Coverage collection failed (non-fatal): %v\n", err)
 			}
 		}
 

--- a/test/e2e/apifrontend/e2e_suite_test.go
+++ b/test/e2e/apifrontend/e2e_suite_test.go
@@ -144,11 +144,9 @@ var _ = SynchronizedAfterSuite(
 				e2eNamespace, "apifrontend", GinkgoWriter)
 		}
 
-		if os.Getenv("E2E_COVERAGE") == "true" {
-			_, _ = fmt.Fprintln(GinkgoWriter, "\nCollecting E2E binary coverage data (DD-TEST-007)...")
-			if err := infrastructure.CollectE2EBinaryCoverage(e2eClusterName, GinkgoWriter); err != nil {
-				_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: Coverage collection failed (non-fatal): %v\n", err)
-			}
+		_, _ = fmt.Fprintln(GinkgoWriter, "\nCollecting E2E binary coverage data (DD-TEST-007)...")
+		if err := infrastructure.CollectE2EBinaryCoverage(e2eClusterName, GinkgoWriter); err != nil {
+			_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: Coverage collection failed (non-fatal): %v\n", err)
 		}
 
 		if os.Getenv("AF_E2E_SKIP_TEARDOWN") == "true" {

--- a/test/e2e/apifrontend/infrastructure/coverage.go
+++ b/test/e2e/apifrontend/infrastructure/coverage.go
@@ -4,66 +4,31 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
-	"path/filepath"
+
+	kinfra "github.com/jordigilh/kubernaut/test/infrastructure"
 )
 
 // CollectE2EBinaryCoverage collects Go coverage data from the Kind node's
-// hostPath volume and merges it into a text profile. This implements the
-// DD-TEST-007 pattern from kubernaut.
+// hostPath volume and merges it into a text profile. This delegates to the
+// shared DD-TEST-007 pipeline in test/infrastructure/coverage.go which handles
+// scale-down, extraction, path remapping, and profile generation.
 //
 // Prerequisites:
-//   - AF built with GOFLAGS=-cover
+//   - AF built with GOFLAGS=-cover (E2E_COVERAGE=true)
 //   - Pod deployed with GOCOVERDIR=/coverdata
 //   - Kind node has hostPath /coverdata mounted
-//
-// Returns the path to the merged coverage profile, or an error.
-func CollectE2EBinaryCoverage(clusterName string, writer io.Writer) (string, error) {
-	localDir := filepath.Join(os.TempDir(), "af-e2e-coverage")
-	if err := os.MkdirAll(localDir, 0o750); err != nil { //nolint:gosec // G301: test dir, not production
-		return "", fmt.Errorf("create local coverage dir: %w", err)
-	}
-
-	_, _ = fmt.Fprintln(writer, "Collecting coverage data from Kind node...")
-
-	// Get the Kind node container name
-	nodeName := clusterName + "-control-plane"
-
-	// Copy coverage data from the Kind node
-	cpCmd := exec.Command("podman", "cp", nodeName+":/coverdata/.", localDir) //nolint:gosec // G204: test infra, args from test constants
-	cpCmd.Stdout = writer
-	cpCmd.Stderr = writer
-	if err := cpCmd.Run(); err != nil {
-		return "", fmt.Errorf("podman cp coverage data: %w", err)
-	}
-
-	// Check if we got any coverage files
-	entries, err := os.ReadDir(localDir)
+func CollectE2EBinaryCoverage(clusterName string, writer io.Writer) error {
+	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return "", fmt.Errorf("read coverage dir: %w", err)
+		return fmt.Errorf("resolve home dir for kubeconfig: %w", err)
 	}
-	if len(entries) == 0 {
-		return "", fmt.Errorf("no coverage data files found in %s", localDir)
-	}
+	kcPath := fmt.Sprintf("%s/.kube/%s-config", homeDir, clusterName)
 
-	_, _ = fmt.Fprintf(writer, "Found %d coverage data files\n", len(entries))
-
-	// Merge into a text profile
-	profilePath := filepath.Join(os.TempDir(), "coverage_e2e_apifrontend_binary.out")
-	mergeCmd := exec.Command("go", "tool", "covdata", "textfmt", "-i="+localDir, "-o="+profilePath) //nolint:gosec // G204: test infra
-	mergeCmd.Stdout = writer
-	mergeCmd.Stderr = writer
-	if err := mergeCmd.Run(); err != nil {
-		return "", fmt.Errorf("go tool covdata textfmt: %w", err)
-	}
-
-	_, _ = fmt.Fprintf(writer, "Coverage profile written to %s\n", profilePath)
-
-	// Print summary
-	funcCmd := exec.Command("go", "tool", "cover", "-func="+profilePath) //nolint:gosec // G204: test infra
-	funcCmd.Stdout = writer
-	funcCmd.Stderr = writer
-	_ = funcCmd.Run()
-
-	return profilePath, nil
+	return kinfra.CollectE2EBinaryCoverage(kinfra.E2ECoverageOptions{
+		ServiceName:    "apifrontend",
+		ClusterName:    clusterName,
+		DeploymentName: "apifrontend",
+		Namespace:      "kubernaut-system",
+		KubeconfigPath: kcPath,
+	}, writer)
 }

--- a/test/e2e/apifrontend/infrastructure/kind.go
+++ b/test/e2e/apifrontend/infrastructure/kind.go
@@ -43,13 +43,15 @@ func CreateAFKindCluster(kubeconfigPath string, writer io.Writer) error {
 	return kinfra.CreateKindClusterWithConfig(opts, writer)
 }
 
-// BuildAFImage builds the apifrontend container image locally for development.
-// In CI, SetupE2EInfrastructure uses the pre-built GHCR image instead.
+// BuildAFImage builds the apifrontend container image locally with coverage
+// instrumentation (GOFLAGS=-cover). Coverage is always enabled because the
+// overhead is negligible for E2E and the data is always useful.
 func BuildAFImage(writer io.Writer) (string, error) {
 	cfg := kinfra.E2EImageConfig{
 		ServiceName:    "apifrontend",
 		ImageName:      "apifrontend",
 		DockerfilePath: "docker/apifrontend.Dockerfile",
+		EnableCoverage: true,
 	}
 	return kinfra.BuildImageForKind(cfg, writer)
 }

--- a/test/e2e/apifrontend/infrastructure/setup.go
+++ b/test/e2e/apifrontend/infrastructure/setup.go
@@ -82,13 +82,19 @@ func SetupE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath, na
 		}(svc.name, svc.image, svc.dockerfile, svc.buildCtx)
 	}
 
-	// AF: IMAGE_REGISTRY + IMAGE_TAG => registry image; else local BuildAFImage
+	// AF: IMAGE_REGISTRY + IMAGE_TAG => registry image; else local BuildAFImage.
+	// DD-TEST-007: When E2E_COVERAGE=true, always build locally with GOFLAGS=-cover
+	// so the binary writes coverage counters to GOCOVERDIR at runtime.
+	enableCoverage := os.Getenv("E2E_COVERAGE") == "true"
 	go func() {
-		if imageRegistry != "" && imageTag != "" {
+		if imageRegistry != "" && imageTag != "" && !enableCoverage {
 			img := strings.TrimRight(imageRegistry, "/") + "/apifrontend:" + imageTag
 			_, _ = fmt.Fprintf(writer, "  apifrontend: using registry image %s\n", img)
 			results <- buildResult{"apifrontend", img, nil}
 		} else {
+			if enableCoverage {
+				_, _ = fmt.Fprintln(writer, "  apifrontend: building locally with coverage instrumentation (E2E_COVERAGE=true)")
+			}
 			img, err := BuildAFImage(writer)
 			results <- buildResult{"apifrontend", img, err}
 		}
@@ -129,8 +135,14 @@ func SetupE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath, na
 	// from the registry inside the Kind node (same as KA/fullpipeline E2E).
 	// In local mode: load locally-built images via kind load.
 	// ═══════════════════════════════════════════════════════════════════════
-	if imageRegistry != "" {
+	if imageRegistry != "" && !enableCoverage {
 		_, _ = fmt.Fprintln(writer, "\nPHASE 3: Skipping image loading (CI/CD: IMAGE_REGISTRY set, Kind pulls from public GHCR)")
+	} else if imageRegistry != "" && enableCoverage {
+		_, _ = fmt.Fprintln(writer, "\nPHASE 3: Loading coverage-instrumented AF image into Kind...")
+		if err := kinfra.LoadImageToKind(images["apifrontend"], "apifrontend", clusterName, writer); err != nil {
+			return fmt.Errorf("failed to load apifrontend image: %w", err)
+		}
+		_, _ = fmt.Fprintln(writer, "  apifrontend loaded (coverage build)")
 	} else {
 		_, _ = fmt.Fprintln(writer, "\nPHASE 3: Loading images into Kind...")
 
@@ -218,7 +230,7 @@ func SetupE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath, na
 	}
 
 	afImage := images["apifrontend"]
-	if err := deployAPIFrontendService(ctx, kubeconfigPath, namespace, afImage, writer); err != nil {
+	if err := deployAPIFrontendService(ctx, kubeconfigPath, namespace, afImage, enableCoverage, writer); err != nil {
 		return fmt.Errorf("failed to deploy AF service: %w", err)
 	}
 
@@ -446,7 +458,10 @@ subjects:
 }
 
 // deployAPIFrontendService deploys the AF ConfigMaps, Deployment, and NodePort Service (programmatic E2E manifest).
-func deployAPIFrontendService(ctx context.Context, kubeconfigPath, namespace, afImage string, writer io.Writer) error {
+// When enableCoverage is true (E2E_COVERAGE=true), the pod is configured with
+// GOCOVERDIR=/coverdata and a hostPath volume mount so the coverage-instrumented
+// binary writes runtime counters that CollectE2EBinaryCoverage can harvest.
+func deployAPIFrontendService(ctx context.Context, kubeconfigPath, namespace, afImage string, enableCoverage bool, writer io.Writer) error {
 	projectRoot := getAFProjectRoot()
 	configData, err := os.ReadFile(filepath.Join(projectRoot, "deploy", "apifrontend", "overlays", "e2e", "config.yaml")) //nolint:gosec // G304
 	if err != nil {
@@ -457,9 +472,33 @@ func deployAPIFrontendService(ctx context.Context, kubeconfigPath, namespace, af
 		return fmt.Errorf("failed to read rbac_roles.yaml: %w", err)
 	}
 	pullPolicy := "IfNotPresent"
-	if os.Getenv("IMAGE_REGISTRY") != "" {
+	if os.Getenv("IMAGE_REGISTRY") != "" && !enableCoverage {
 		pullPolicy = "Always"
 	}
+
+	// DD-TEST-007: Coverage instrumentation YAML fragments
+	covEnvYAML := ""
+	covVolMountYAML := ""
+	covVolYAML := ""
+	covSecCtxYAML := ""
+	if enableCoverage {
+		covEnvYAML = `
+            - name: GOCOVERDIR
+              value: /coverdata`
+		covVolMountYAML = `
+            - name: coverdata
+              mountPath: /coverdata`
+		covVolYAML = `
+        - name: coverdata
+          hostPath:
+            path: /coverdata
+            type: DirectoryOrCreate`
+		covSecCtxYAML = `
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0`
+	}
+
 	manifest := fmt.Sprintf(`apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -494,7 +533,7 @@ spec:
         app: apifrontend
     spec:
       serviceAccountName: apifrontend
-      automountServiceAccountToken: true
+      automountServiceAccountToken: true%s
       containers:
         - name: apifrontend
           image: %s
@@ -516,7 +555,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: LLM_API_KEY
-              value: "mock-key"
+              value: "mock-key"%s
           volumeMounts:
             - name: config
               mountPath: /etc/apifrontend
@@ -526,7 +565,7 @@ spec:
               readOnly: true
             - name: inter-service-ca
               mountPath: /etc/apifrontend/inter-service-ca
-              readOnly: true
+              readOnly: true%s
           readinessProbe:
             httpGet:
               path: /readyz
@@ -566,7 +605,7 @@ spec:
             optional: false
         - name: inter-service-ca
           configMap:
-            name: inter-service-ca
+            name: inter-service-ca%s
 ---
 apiVersion: v1
 kind: Service
@@ -591,7 +630,8 @@ spec:
     app: apifrontend
 `, namespace, indentYAML(string(configData), 4),
 		namespace, indentYAML(string(rbacRolesData), 4),
-		namespace, afImage, pullPolicy, namespace)
+		namespace, covSecCtxYAML, afImage, pullPolicy,
+		covEnvYAML, covVolMountYAML, covVolYAML, namespace)
 	return kubectlApplyStdin(ctx, kubeconfigPath, manifest, writer)
 }
 

--- a/test/e2e/apifrontend/infrastructure/setup.go
+++ b/test/e2e/apifrontend/infrastructure/setup.go
@@ -82,22 +82,12 @@ func SetupE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath, na
 		}(svc.name, svc.image, svc.dockerfile, svc.buildCtx)
 	}
 
-	// AF: IMAGE_REGISTRY + IMAGE_TAG => registry image; else local BuildAFImage.
-	// DD-TEST-007: When E2E_COVERAGE=true, always build locally with GOFLAGS=-cover
-	// so the binary writes coverage counters to GOCOVERDIR at runtime.
-	enableCoverage := os.Getenv("E2E_COVERAGE") == "true"
+	// DD-TEST-007: AF is always built locally with GOFLAGS=-cover so the
+	// binary writes coverage counters to GOCOVERDIR at runtime. The overhead
+	// is negligible for E2E and coverage data is always useful.
 	go func() {
-		if imageRegistry != "" && imageTag != "" && !enableCoverage {
-			img := strings.TrimRight(imageRegistry, "/") + "/apifrontend:" + imageTag
-			_, _ = fmt.Fprintf(writer, "  apifrontend: using registry image %s\n", img)
-			results <- buildResult{"apifrontend", img, nil}
-		} else {
-			if enableCoverage {
-				_, _ = fmt.Fprintln(writer, "  apifrontend: building locally with coverage instrumentation (E2E_COVERAGE=true)")
-			}
-			img, err := BuildAFImage(writer)
-			results <- buildResult{"apifrontend", img, err}
-		}
+		img, err := BuildAFImage(writer)
+		results <- buildResult{"apifrontend", img, err}
 	}()
 
 	images := make(map[string]string, 4)
@@ -135,14 +125,14 @@ func SetupE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath, na
 	// from the registry inside the Kind node (same as KA/fullpipeline E2E).
 	// In local mode: load locally-built images via kind load.
 	// ═══════════════════════════════════════════════════════════════════════
-	if imageRegistry != "" && !enableCoverage {
-		_, _ = fmt.Fprintln(writer, "\nPHASE 3: Skipping image loading (CI/CD: IMAGE_REGISTRY set, Kind pulls from public GHCR)")
-	} else if imageRegistry != "" && enableCoverage {
-		_, _ = fmt.Fprintln(writer, "\nPHASE 3: Loading coverage-instrumented AF image into Kind...")
+	// AF is always built locally (coverage-instrumented), so it must always
+	// be loaded into Kind. Other images use the registry in CI mode.
+	if imageRegistry != "" {
+		_, _ = fmt.Fprintln(writer, "\nPHASE 3: Loading AF image into Kind (coverage build); others pull from GHCR...")
 		if err := kinfra.LoadImageToKind(images["apifrontend"], "apifrontend", clusterName, writer); err != nil {
 			return fmt.Errorf("failed to load apifrontend image: %w", err)
 		}
-		_, _ = fmt.Fprintln(writer, "  apifrontend loaded (coverage build)")
+		_, _ = fmt.Fprintln(writer, "  apifrontend loaded")
 	} else {
 		_, _ = fmt.Fprintln(writer, "\nPHASE 3: Loading images into Kind...")
 
@@ -230,7 +220,7 @@ func SetupE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath, na
 	}
 
 	afImage := images["apifrontend"]
-	if err := deployAPIFrontendService(ctx, kubeconfigPath, namespace, afImage, enableCoverage, writer); err != nil {
+	if err := deployAPIFrontendService(ctx, kubeconfigPath, namespace, afImage, writer); err != nil {
 		return fmt.Errorf("failed to deploy AF service: %w", err)
 	}
 
@@ -457,11 +447,10 @@ subjects:
 	return nil
 }
 
-// deployAPIFrontendService deploys the AF ConfigMaps, Deployment, and NodePort Service (programmatic E2E manifest).
-// When enableCoverage is true (E2E_COVERAGE=true), the pod is configured with
-// GOCOVERDIR=/coverdata and a hostPath volume mount so the coverage-instrumented
-// binary writes runtime counters that CollectE2EBinaryCoverage can harvest.
-func deployAPIFrontendService(ctx context.Context, kubeconfigPath, namespace, afImage string, enableCoverage bool, writer io.Writer) error {
+// deployAPIFrontendService deploys the AF ConfigMaps, Deployment, and NodePort Service.
+// The pod is always configured with GOCOVERDIR=/coverdata and a hostPath volume
+// mount so the coverage-instrumented binary writes runtime counters (DD-TEST-007).
+func deployAPIFrontendService(ctx context.Context, kubeconfigPath, namespace, afImage string, writer io.Writer) error {
 	projectRoot := getAFProjectRoot()
 	configData, err := os.ReadFile(filepath.Join(projectRoot, "deploy", "apifrontend", "overlays", "e2e", "config.yaml")) //nolint:gosec // G304
 	if err != nil {
@@ -470,33 +459,6 @@ func deployAPIFrontendService(ctx context.Context, kubeconfigPath, namespace, af
 	rbacRolesData, err := os.ReadFile(filepath.Join(projectRoot, "deploy", "apifrontend", "base", "rbac_roles.yaml")) //nolint:gosec // G304
 	if err != nil {
 		return fmt.Errorf("failed to read rbac_roles.yaml: %w", err)
-	}
-	pullPolicy := "IfNotPresent"
-	if os.Getenv("IMAGE_REGISTRY") != "" && !enableCoverage {
-		pullPolicy = "Always"
-	}
-
-	// DD-TEST-007: Coverage instrumentation YAML fragments
-	covEnvYAML := ""
-	covVolMountYAML := ""
-	covVolYAML := ""
-	covSecCtxYAML := ""
-	if enableCoverage {
-		covEnvYAML = `
-            - name: GOCOVERDIR
-              value: /coverdata`
-		covVolMountYAML = `
-            - name: coverdata
-              mountPath: /coverdata`
-		covVolYAML = `
-        - name: coverdata
-          hostPath:
-            path: /coverdata
-            type: DirectoryOrCreate`
-		covSecCtxYAML = `
-      securityContext:
-        runAsUser: 0
-        runAsGroup: 0`
 	}
 
 	manifest := fmt.Sprintf(`apiVersion: v1
@@ -533,11 +495,14 @@ spec:
         app: apifrontend
     spec:
       serviceAccountName: apifrontend
-      automountServiceAccountToken: true%s
+      automountServiceAccountToken: true
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
       containers:
         - name: apifrontend
           image: %s
-          imagePullPolicy: %s
+          imagePullPolicy: IfNotPresent
           ports:
             - name: https
               containerPort: 8443
@@ -555,7 +520,9 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: LLM_API_KEY
-              value: "mock-key"%s
+              value: "mock-key"
+            - name: GOCOVERDIR
+              value: /coverdata
           volumeMounts:
             - name: config
               mountPath: /etc/apifrontend
@@ -565,7 +532,9 @@ spec:
               readOnly: true
             - name: inter-service-ca
               mountPath: /etc/apifrontend/inter-service-ca
-              readOnly: true%s
+              readOnly: true
+            - name: coverdata
+              mountPath: /coverdata
           readinessProbe:
             httpGet:
               path: /readyz
@@ -605,7 +574,11 @@ spec:
             optional: false
         - name: inter-service-ca
           configMap:
-            name: inter-service-ca%s
+            name: inter-service-ca
+        - name: coverdata
+          hostPath:
+            path: /coverdata
+            type: DirectoryOrCreate
 ---
 apiVersion: v1
 kind: Service
@@ -630,8 +603,7 @@ spec:
     app: apifrontend
 `, namespace, indentYAML(string(configData), 4),
 		namespace, indentYAML(string(rbacRolesData), 4),
-		namespace, covSecCtxYAML, afImage, pullPolicy,
-		covEnvYAML, covVolMountYAML, covVolYAML, namespace)
+		namespace, afImage, namespace)
 	return kubectlApplyStdin(ctx, kubeconfigPath, manifest, writer)
 }
 


### PR DESCRIPTION
## Summary

- AF E2E now always builds with `GOFLAGS=-cover` and deploys with `GOCOVERDIR=/coverdata` + hostPath volume mount, implementing the DD-TEST-007 binary coverage standard
- `CollectE2EBinaryCoverage` delegates to the shared `test/infrastructure/coverage.go` pipeline (scale-down, extraction, path remapping, profile generation) instead of a local reimplementation
- Coverage is unconditional — no `E2E_COVERAGE` flag needed since CI always sets it and the overhead is negligible

Closes #1196

## Test plan

- [ ] CI E2E (apifrontend) job passes — AF pod starts with GOCOVERDIR set
- [ ] Coverage report shows non-zero E2E % for apifrontend (was 0.0%)
- [ ] Other E2E services unaffected (no shared code changes)


Made with [Cursor](https://cursor.com)