### PR TITLE
fix(ci): widen sync-embed glob to include all CRDs and add CI check

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -138,6 +138,9 @@ jobs:
           fi
           echo "✅ Generated files are up-to-date"
 
+      - name: Validate embedded assets (CRDs, migrations)
+        run: make validate-embed
+
       - name: Lint Go code
         uses: golangci/golangci-lint-action@v9
         with:

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ sync-embed: ## Sync migration SQL and CRD YAMLs into pkg/shared/assets/ for Go e
 	@echo "📋 Syncing embedded assets for kubernaut-operator..."
 	@mkdir -p pkg/shared/assets/migrations pkg/shared/assets/crds
 	@cp -f migrations/*.sql pkg/shared/assets/migrations/
-	@cp -f config/crd/bases/kubernaut.ai_*.yaml pkg/shared/assets/crds/
+	@cp -f config/crd/bases/*.yaml pkg/shared/assets/crds/
 	@echo "✅ pkg/shared/assets/ updated (migrations + CRDs)"
 
 .PHONY: validate-embed


### PR DESCRIPTION
## Summary
- Widens `sync-embed` Makefile target glob from `kubernaut.ai_*.yaml` to `*.yaml` so the `apifrontend.kubernaut.ai_investigationsessions.yaml` CRD is included when syncing to `pkg/shared/assets/crds/`
- Adds `make validate-embed` step to the CI Lint job to catch drift between `config/crd/bases/` and `pkg/shared/assets/crds/` early

## Test plan
- [x] `make sync-embed` succeeds and includes the AF CRD
- [x] `make validate-embed` passes (no drift detected)
- [ ] CI Lint job runs the new step without failure

Closes #1213

Made with [Cursor](https://cursor.com)