### PR TITLE
feat(auth): OIDC-direct authentication mode (#1226)

### DIFF
--- a/charts/kubernaut/templates/apifrontend/apifrontend.yaml
+++ b/charts/kubernaut/templates/apifrontend/apifrontend.yaml
@@ -30,7 +30,7 @@ rules:
     resources: ["events"]
     verbs: ["create", "patch"]
   - apiGroups: [""]
-    resources: ["users", "groups", "serviceaccounts"]
+    resources: ["users", "groups"]
     verbs: ["impersonate"]
   - apiGroups: ["authorization.k8s.io"]
     resources: ["subjectaccessreviews"]

--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -549,7 +549,7 @@ func buildBackendDeps(ctx context.Context, cfg *config.Config, metricsReg *metri
 		DurationHist: metricsReg.DownstreamDuration,
 	})
 
-	deps.DynFactory = auth.AuditingDynamicFactory(buildDynFactory(), auditor)
+	deps.DynFactory = auth.AuditingDynamicFactory(buildDynFactory(cfg), auditor)
 
 	return deps, nil
 }
@@ -710,16 +710,19 @@ func bridgeMetricsFrom(reg *metrics.Registry) *handler.MCPBridgeMetrics {
 	}
 }
 
-func buildDynFactory() auth.DynamicClientFactory {
+func buildDynFactory(cfg *config.Config) auth.DynamicClientFactory {
 	return func(ctx context.Context) (dynamic.Interface, error) {
 		restCfg, err := ctrl.GetConfig()
 		if err != nil {
 			return nil, fmt.Errorf("kubernetes config unavailable: %w", err)
 		}
+
+		if cfg.RBAC.UseOIDCDirect {
+			return auth.NewOIDCDirectDynamicFactory(restCfg)(ctx)
+		}
+
 		identity := auth.UserIdentityFromContext(ctx)
 		if identity == nil {
-			// F-003: Reject requests without validated identity.
-			// Using the pod ServiceAccount for user-scoped operations violates least privilege.
 			return nil, fmt.Errorf("authenticated user identity required for kubernetes operations")
 		}
 		return auth.NewImpersonatingDynamicFactory(restCfg)(ctx)

--- a/deploy/apifrontend/base/02-rbac.yaml
+++ b/deploy/apifrontend/base/02-rbac.yaml
@@ -24,7 +24,7 @@ rules:
     verbs: ["create", "patch"]
   # Impersonation: apifrontend impersonates authenticated users for K8s API calls
   - apiGroups: [""]
-    resources: ["users", "groups", "serviceaccounts"]
+    resources: ["users", "groups"]
     verbs: ["impersonate"]
   # SubjectAccessReview: SAR-based tool authorization (replaces rbac_roles.yaml)
   - apiGroups: ["authorization.k8s.io"]

--- a/docs/services/apifrontend/development/DEVELOPER_GUIDE.md
+++ b/docs/services/apifrontend/development/DEVELOPER_GUIDE.md
@@ -199,6 +199,30 @@ The service watches its ConfigMap file for changes. When changes are detected:
 - Context: Always propagate `context.Context` for cancellation
 - Testing: Ginkgo/Gomega with `UT-AF-XXX-NNN` test IDs
 
+## Configuring OIDC-Direct Mode
+
+The AF supports an opt-in OIDC-direct authentication mode (v1.5+) as an
+alternative to Kubernetes impersonation. In this mode, triage tool K8s API calls
+use the user's raw OIDC JWT as a bearer token directly.
+
+### Enable in Config
+
+```yaml
+rbac:
+  useOIDCDirect: true
+  sarCacheTTL: 30s
+```
+
+### Requirements
+
+1. The K8s API server must trust the AF's OIDC provider (`--oidc-issuer-url`,
+   `--oidc-client-id`, `--oidc-username-claim`, `--oidc-groups-claim`)
+2. Users must have K8s RBAC bindings for their OIDC identity (not the AF SA)
+3. The AF JWT middleware must preserve `RawToken` in `UserIdentity`
+
+See [AUTHENTICATION_AND_RBAC.md](../security/AUTHENTICATION_AND_RBAC.md#31-oidc-direct-mode-opt-in-v15)
+for the full security design.
+
 ## Known Tech Debt (v1.5)
 
 | Item | Target | Notes |

--- a/docs/services/apifrontend/security/AUTHENTICATION_AND_RBAC.md
+++ b/docs/services/apifrontend/security/AUTHENTICATION_AND_RBAC.md
@@ -187,6 +187,69 @@ sequenceDiagram
 
 ---
 
+## 3.1 OIDC-Direct Mode (Opt-in, v1.5+)
+
+As an alternative to impersonation, the AF supports **OIDC-direct mode**
+(`rbac.useOIDCDirect: true`). In this mode, triage tool K8s API calls use the
+user's raw OIDC JWT as a bearer token directly, rather than impersonation headers.
+
+### Benefits
+
+- Eliminates the need for ServiceAccount impersonation privileges
+- Simpler ClusterRole (no `impersonate` verb needed)
+- Token authenticity verified by the K8s API server's OIDC provider configuration
+
+### Configuration
+
+```yaml
+rbac:
+  useOIDCDirect: true
+```
+
+The K8s API server must be configured to trust the same OIDC provider that issues
+tokens to AF users (via `--oidc-issuer-url`, `--oidc-client-id`, etc.).
+
+### OIDC-Direct Flow
+
+```mermaid
+sequenceDiagram
+    participant Tool as af_list_events
+    participant Factory as DynamicClientFactory
+    participant CTX as Context
+    participant K8s as K8s API Server
+
+    Tool->>Factory: factory(ctx)
+    Factory->>CTX: UserIdentityFromContext(ctx)
+    CTX-->>Factory: {username, groups, rawToken, expiresAt}
+    Factory->>Factory: Validate: identity present, token non-empty, not expired
+    Factory->>Factory: rest.CopyConfig(baseCfg)
+    Factory->>Factory: cfg.BearerToken = rawToken
+    Factory->>Factory: Clear BearerTokenFile and Impersonate
+    Factory->>Factory: dynamic.NewForConfig(cfg)
+    Factory-->>Tool: OIDC-direct dynamic.Interface
+    Tool->>K8s: List events (Authorization: Bearer <user-jwt>)
+    K8s->>K8s: Validate JWT via OIDC provider, evaluate user's RBAC
+    K8s-->>Tool: Events (or 401/403)
+```
+
+### Fail-Closed Behavior
+
+The factory rejects requests when:
+- No `UserIdentity` in context (missing authentication)
+- `Username` is empty
+- `RawToken` is empty (no JWT available)
+- Token `ExpiresAt` is in the past
+
+### Source Files
+
+| File | Purpose |
+|------|---------|
+| `pkg/apifrontend/auth/dynamic_impersonation.go` | `NewOIDCDirectDynamicFactory` implementation |
+| `pkg/apifrontend/config/config.go` | `RBACConfig.UseOIDCDirect` flag |
+| `cmd/apifrontend/main.go` | `buildDynFactory(cfg)` routing |
+
+---
+
 ## 4. Kubernetes RBAC (ClusterRole)
 
 The Kustomize-managed ClusterRole (`deploy/kustomize/base/02-rbac.yaml`) grants the AF ServiceAccount:

--- a/docs/tests/1226/TEST_PLAN.md
+++ b/docs/tests/1226/TEST_PLAN.md
@@ -1,0 +1,95 @@
+# Test Plan: Issue #1226 — OIDC-Direct Authentication Mode
+
+| Field               | Value                                                    |
+|---------------------|----------------------------------------------------------|
+| **Issue**           | #1226                                                    |
+| **Author**          | AI Agent (supervised)                                    |
+| **Status**          | Draft                                                    |
+| **Standard**        | IEEE 829 (adapted)                                       |
+| **BR Mapping**      | BR-SECURITY-1226                                         |
+| **Created**         | 2026-05-21                                               |
+
+## 1. Introduction
+
+This test plan covers the implementation of an opt-in OIDC-direct authentication
+mode for the API Frontend. In this mode, triage tool K8s API calls use the user's
+raw OIDC JWT as a bearer token instead of ServiceAccount impersonation.
+
+### 1.1 Acceptance Criteria
+
+| ID     | Criterion                                                                       |
+|--------|---------------------------------------------------------------------------------|
+| AC-01  | `NewOIDCDirectDynamicFactory` creates a `dynamic.Interface` using the user's raw JWT as BearerToken |
+| AC-02  | Factory fails closed: missing identity, empty username, empty token, expired token all return errors |
+| AC-03  | Base `rest.Config` is never mutated (deep copy via `rest.CopyConfig`)           |
+| AC-04  | `BearerTokenFile` is explicitly cleared to prevent conflict with `BearerToken`  |
+| AC-05  | `Impersonate` config is cleared (no residual impersonation headers)             |
+| AC-06  | `ClientWrapper`s (e.g. circuit breaker) are applied in order                    |
+| AC-07  | `UseOIDCDirect` config flag defaults to `false` and parses from YAML            |
+| AC-08  | `buildDynFactory` in `main.go` routes to OIDC-direct or impersonation based on config |
+| AC-09  | `serviceaccounts` removed from impersonation ClusterRole manifests              |
+
+## 2. Test Scenarios
+
+### 2.1 Unit Tests — NewOIDCDirectDynamicFactory
+
+| ID              | Description                                    | AC   | Phase |
+|-----------------|------------------------------------------------|------|-------|
+| UT-AF-1226-001  | Error when no identity in context              | AC-02 | RED  |
+| UT-AF-1226-002  | Error when username is empty                   | AC-02 | RED  |
+| UT-AF-1226-003  | Error when RawToken is empty                   | AC-02 | RED  |
+| UT-AF-1226-004  | Error when token is expired                    | AC-02 | RED  |
+| UT-AF-1226-005  | Success with valid identity and token          | AC-01 | RED  |
+| UT-AF-1226-006  | Client wrappers applied in order               | AC-06 | RED  |
+| UT-AF-1226-007  | Base rest.Config not mutated                   | AC-03 | RED  |
+
+### 2.2 Unit Tests — Config
+
+| ID              | Description                                    | AC   | Phase |
+|-----------------|------------------------------------------------|------|-------|
+| UT-AF-1226-010  | `UseOIDCDirect` defaults to `false`            | AC-07 | RED  |
+| UT-AF-1226-011  | `UseOIDCDirect` parses `true` from YAML        | AC-07 | RED  |
+
+### 2.3 Unit Tests — Manifest Validation
+
+| ID              | Description                                    | AC   | Phase |
+|-----------------|------------------------------------------------|------|-------|
+| UT-AF-1226-030  | Helm ClusterRole has no `serviceaccounts`      | AC-09 | RED  |
+| UT-AF-1226-031  | Deploy base ClusterRole has no `serviceaccounts`| AC-09 | RED  |
+
+### 2.4 Spike: `buildDynFactory` Testability (REMOVED)
+
+UT-AF-1226-020/021 were removed after a preflight spike determined that
+`buildDynFactory` is sufficiently covered by higher-level integration tests,
+and direct unit testing would require complex mocking of `ctrl.GetConfig()`.
+
+## 3. TDD Phases
+
+### Phase 1 — RED
+Write all failing tests from §2. Verify each fails for the correct behavioral
+reason (function not found, field missing, or assertion mismatch).
+
+### Phase 2 — GREEN
+Implement minimal code to pass all tests:
+- `NewOIDCDirectDynamicFactory` in `dynamic_impersonation.go`
+- `UseOIDCDirect` field in `config.go`
+- `buildDynFactory(cfg)` routing in `main.go`
+- Remove `serviceaccounts` from 4 manifest files
+
+### Phase 3 — REFACTOR
+100 Go Mistakes audit. Code quality improvements if warranted.
+
+## 4. GA Readiness Checkpoints
+
+| Checkpoint | After  | Dimensions                                          |
+|------------|--------|-----------------------------------------------------|
+| CP-1       | RED    | Test quality, AC coverage, build, anti-patterns      |
+| CP-2       | GREEN  | Tests pass, coverage, build, vet, race, security     |
+| CP-3       | REFACTOR | Full 12-dimensional audit                          |
+
+## 5. Preflight Spikes (Completed)
+
+| Spike | Finding                                                                |
+|-------|------------------------------------------------------------------------|
+| S-1   | `rest.CopyConfig` does NOT clear `BearerTokenFile` when `BearerToken` is set — must clear explicitly |
+| S-2   | `buildDynFactory` UT deemed unnecessary — covered by IT/E2E            |

--- a/pkg/apifrontend/auth/dynamic_impersonation.go
+++ b/pkg/apifrontend/auth/dynamic_impersonation.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
@@ -40,6 +41,42 @@ func NewImpersonatingDynamicFactory(baseCfg *rest.Config, wrappers ...ClientWrap
 		client, err := dynamic.NewForConfig(impCfg)
 		if err != nil {
 			return nil, fmt.Errorf("creating impersonated dynamic client: %w", err)
+		}
+
+		var wrapped dynamic.Interface = client
+		for _, w := range wrappers {
+			wrapped = w(wrapped)
+		}
+		return wrapped, nil
+	}
+}
+
+// NewOIDCDirectDynamicFactory returns a DynamicClientFactory that creates a
+// dynamic.Interface using the user's raw OIDC JWT as a bearer token.
+// The K8s API server must trust the same OIDC provider.
+// baseCfg is the AF ServiceAccount's rest.Config (never mutated).
+// wrappers are applied in order to the raw client (typically circuit breaker).
+func NewOIDCDirectDynamicFactory(baseCfg *rest.Config, wrappers ...ClientWrapper) DynamicClientFactory {
+	return func(ctx context.Context) (dynamic.Interface, error) {
+		identity := UserIdentityFromContext(ctx)
+		if identity == nil || identity.Username == "" {
+			return nil, fmt.Errorf("OIDC-direct requires authenticated user identity in context")
+		}
+		if identity.RawToken == "" {
+			return nil, fmt.Errorf("OIDC-direct requires a raw JWT in UserIdentity")
+		}
+		if !identity.ExpiresAt.IsZero() && identity.ExpiresAt.Before(time.Now()) {
+			return nil, fmt.Errorf("OIDC-direct token expired at %s", identity.ExpiresAt)
+		}
+
+		cfg := rest.CopyConfig(baseCfg)
+		cfg.BearerToken = identity.RawToken
+		cfg.BearerTokenFile = ""
+		cfg.Impersonate = rest.ImpersonationConfig{}
+
+		client, err := dynamic.NewForConfig(cfg)
+		if err != nil {
+			return nil, fmt.Errorf("creating OIDC-direct dynamic client: %w", err)
 		}
 
 		var wrapped dynamic.Interface = client

--- a/pkg/apifrontend/auth/dynamic_impersonation_test.go
+++ b/pkg/apifrontend/auth/dynamic_impersonation_test.go
@@ -2,6 +2,7 @@ package auth_test
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -67,6 +68,103 @@ var _ = Describe("DynamicClientFactory", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(client).NotTo(BeNil())
 			Expect(wrapperCalled).To(BeTrue())
+		})
+	})
+
+	Describe("NewOIDCDirectDynamicFactory", func() {
+		var baseCfg *rest.Config
+
+		BeforeEach(func() {
+			baseCfg = &rest.Config{
+				Host:            "https://fake-api-server:6443",
+				BearerTokenFile: "/var/run/secrets/token",
+			}
+		})
+
+		It("UT-AF-1226-001: returns error when no identity in context", func() {
+			factory := auth.NewOIDCDirectDynamicFactory(baseCfg)
+			_, err := factory(context.Background())
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("OIDC-direct requires authenticated user identity"))
+		})
+
+		It("UT-AF-1226-002: returns error when username is empty", func() {
+			factory := auth.NewOIDCDirectDynamicFactory(baseCfg)
+			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+				Username: "",
+				RawToken: "eyJhbGciOiJSUzI1NiJ9.valid",
+			})
+			_, err := factory(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("OIDC-direct requires authenticated user identity"))
+		})
+
+		It("UT-AF-1226-003: returns error when RawToken is empty", func() {
+			factory := auth.NewOIDCDirectDynamicFactory(baseCfg)
+			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+				Username: "alice",
+				RawToken: "",
+			})
+			_, err := factory(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("OIDC-direct requires a raw JWT"))
+		})
+
+		It("UT-AF-1226-004: returns error when token is expired", func() {
+			factory := auth.NewOIDCDirectDynamicFactory(baseCfg)
+			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+				Username:  "alice",
+				RawToken:  "eyJhbGciOiJSUzI1NiJ9.expired",
+				ExpiresAt: time.Now().Add(-1 * time.Minute),
+			})
+			_, err := factory(ctx)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("expired"))
+		})
+
+		It("UT-AF-1226-005: creates client successfully with valid identity and token", func() {
+			factory := auth.NewOIDCDirectDynamicFactory(baseCfg)
+			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+				Username:  "alice",
+				Groups:    []string{"sre"},
+				RawToken:  "eyJhbGciOiJSUzI1NiJ9.valid-token",
+				ExpiresAt: time.Now().Add(10 * time.Minute),
+			})
+			client, err := factory(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).NotTo(BeNil())
+		})
+
+		It("UT-AF-1226-006: applies client wrappers in order", func() {
+			var wrapperCalled bool
+			wrapper := auth.ClientWrapper(func(c dynamic.Interface) dynamic.Interface {
+				wrapperCalled = true
+				return c
+			})
+
+			factory := auth.NewOIDCDirectDynamicFactory(baseCfg, wrapper)
+			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+				Username:  "bob",
+				RawToken:  "eyJhbGciOiJSUzI1NiJ9.bobs-token",
+				ExpiresAt: time.Now().Add(10 * time.Minute),
+			})
+			client, err := factory(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).NotTo(BeNil())
+			Expect(wrapperCalled).To(BeTrue())
+		})
+
+		It("UT-AF-1226-007: does not mutate the base rest.Config", func() {
+			factory := auth.NewOIDCDirectDynamicFactory(baseCfg)
+			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+				Username:  "alice",
+				RawToken:  "eyJhbGciOiJSUzI1NiJ9.alices-token",
+				ExpiresAt: time.Now().Add(10 * time.Minute),
+			})
+			_, err := factory(ctx)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(baseCfg.BearerToken).To(BeEmpty(), "base config BearerToken must remain empty")
+			Expect(baseCfg.BearerTokenFile).To(Equal("/var/run/secrets/token"), "base config BearerTokenFile must remain unchanged")
 		})
 	})
 

--- a/pkg/apifrontend/config/config.go
+++ b/pkg/apifrontend/config/config.go
@@ -148,6 +148,11 @@ type RBACConfig struct {
 	// SARCacheTTL controls how long SubjectAccessReview results are cached.
 	// Zero disables caching (every call hits the API server).
 	SARCacheTTL time.Duration `yaml:"sarCacheTTL"`
+
+	// UseOIDCDirect enables OIDC-direct mode: triage tool K8s API calls use
+	// the user's raw JWT as a bearer token instead of ServiceAccount impersonation.
+	// Requires the K8s API server to trust the same OIDC provider.
+	UseOIDCDirect bool `yaml:"useOIDCDirect"`
 }
 
 // DefaultConfig returns a Config populated with production defaults.

--- a/pkg/apifrontend/config/config_test.go
+++ b/pkg/apifrontend/config/config_test.go
@@ -950,6 +950,28 @@ func TestValidate_SeverityTriageValidConfig(t *testing.T) {
 	}
 }
 
+// --- Issue #1226: OIDC-Direct Config ---
+
+func TestDefaultConfig_UseOIDCDirectFalse(t *testing.T) {
+	// UT-AF-1226-010: UseOIDCDirect must default to false (impersonation remains default)
+	cfg := DefaultConfig()
+	if cfg.RBAC.UseOIDCDirect {
+		t.Error("DefaultConfig().RBAC.UseOIDCDirect = true, want false")
+	}
+}
+
+func TestLoad_UseOIDCDirectTrue(t *testing.T) {
+	// UT-AF-1226-011: UseOIDCDirect parses true from YAML
+	data := []byte("rbac:\n  useOIDCDirect: true\n")
+	cfg, err := Load(data)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !cfg.RBAC.UseOIDCDirect {
+		t.Error("RBAC.UseOIDCDirect = false, want true after explicit YAML")
+	}
+}
+
 func TestValidate_SessionNamespaceRequiredWhenTTLsSet(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/apifrontend/handler/manifest_validation_test.go
+++ b/pkg/apifrontend/handler/manifest_validation_test.go
@@ -301,6 +301,73 @@ var _ = Describe("NetworkPolicy manifest", func() {
 })
 
 // ---------------------------------------------------------------------------
+// UT-AF-1226-030/031: Impersonation ClusterRole must not include serviceaccounts
+// ---------------------------------------------------------------------------
+
+var _ = Describe("Impersonation ClusterRole manifests", func() {
+	readYAMLRules := func(path string) []map[string]interface{} {
+		raw, err := os.ReadFile(path)
+		Expect(err).NotTo(HaveOccurred(), "failed to read %s", path)
+		var doc map[string]interface{}
+		Expect(yaml.Unmarshal(raw, &doc)).To(Succeed())
+		rulesRaw, ok := doc["rules"].([]interface{})
+		Expect(ok).To(BeTrue(), "rules missing from %s", path)
+		var rules []map[string]interface{}
+		for _, r := range rulesRaw {
+			rm, ok := r.(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			rules = append(rules, rm)
+		}
+		return rules
+	}
+
+	hasServiceAccounts := func(rules []map[string]interface{}) bool {
+		for _, rule := range rules {
+			verbs, ok := rule["verbs"].([]interface{})
+			if !ok {
+				continue
+			}
+			isImpersonate := false
+			for _, v := range verbs {
+				if v == "impersonate" {
+					isImpersonate = true
+					break
+				}
+			}
+			if !isImpersonate {
+				continue
+			}
+			resources, ok := rule["resources"].([]interface{})
+			if !ok {
+				continue
+			}
+			for _, r := range resources {
+				if r == "serviceaccounts" {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	It("UT-AF-1226-030: Helm ClusterRole must not include serviceaccounts in impersonation", func() {
+		path := filepath.Join(repoRoot(), "charts", "kubernaut", "templates", "apifrontend", "apifrontend.yaml")
+		raw, err := os.ReadFile(path)
+		Expect(err).NotTo(HaveOccurred())
+		content := string(raw)
+		Expect(content).NotTo(ContainSubstring("serviceaccounts"),
+			"Helm ClusterRole template must not reference serviceaccounts in impersonation rules")
+	})
+
+	It("UT-AF-1226-031: Deploy base ClusterRole must not include serviceaccounts in impersonation", func() {
+		path := filepath.Join(repoRoot(), "deploy", "apifrontend", "base", "02-rbac.yaml")
+		rules := readYAMLRules(path)
+		Expect(hasServiceAccounts(rules)).To(BeFalse(),
+			"deploy/apifrontend/base/02-rbac.yaml must not include serviceaccounts in impersonation rules")
+	})
+})
+
+// ---------------------------------------------------------------------------
 // TC-P3-07: Dockerfile FIPS boringcrypto (MED-10, BAC-14)
 // ---------------------------------------------------------------------------
 

--- a/test/e2e/apifrontend/infrastructure/setup.go
+++ b/test/e2e/apifrontend/infrastructure/setup.go
@@ -420,7 +420,7 @@ rules:
     resources: ["events"]
     verbs: ["create", "patch"]
   - apiGroups: [""]
-    resources: ["users", "groups", "serviceaccounts"]
+    resources: ["users", "groups"]
     verbs: ["impersonate"]
   - apiGroups: ["authorization.k8s.io"]
     resources: ["subjectaccessreviews"]

--- a/test/infrastructure/fullpipeline_e2e.go
+++ b/test/infrastructure/fullpipeline_e2e.go
@@ -1143,7 +1143,7 @@ rules:
     resources: ["events"]
     verbs: ["create", "patch"]
   - apiGroups: [""]
-    resources: ["users", "groups", "serviceaccounts"]
+    resources: ["users", "groups"]
     verbs: ["impersonate"]
   - apiGroups: ["authorization.k8s.io"]
     resources: ["subjectaccessreviews"]


### PR DESCRIPTION
## Summary

- Introduce `NewOIDCDirectDynamicFactory` as an opt-in alternative to ServiceAccount impersonation for triage tool K8s API calls. When `rbac.useOIDCDirect: true`, the user's raw OIDC JWT is used as a bearer token directly, requiring the K8s API server to trust the same OIDC provider.
- Remove `serviceaccounts` from the impersonation `resources` list in all 4 ClusterRole manifest locations (Helm template, deploy base, E2E setup, full-pipeline E2E) — the AF only needs to impersonate `users` and `groups`.
- Add 11 unit tests (UT-AF-1226-001..007, 010/011, 030/031), IEEE 829 test plan, and documentation updates to AUTHENTICATION_AND_RBAC.md and DEVELOPER_GUIDE.md.

## Commits

| Commit | Scope |
|--------|-------|
| `f6cec1fc5` feat(auth): add OIDC-direct dynamic client factory | Factory, config field, main.go wiring |
| `73cc28955` fix(rbac): remove serviceaccounts from ClusterRoles | 4 manifests + 2 manifest validation tests |
| `c16512002` test(auth): add unit tests and docs | 7 factory UTs, 2 config UTs, test plan, 2 doc updates |

## Security Design

- **Fail-closed**: Missing identity, empty username, empty token, or expired token all return errors
- **Config immutability**: Base `rest.Config` is deep-copied via `rest.CopyConfig`; `BearerTokenFile` explicitly cleared; `Impersonate` config zeroed
- **Opt-in only**: `UseOIDCDirect` defaults to `false`; existing impersonation behavior is unchanged

## Test plan

- [x] UT-AF-1226-001..004: Error paths (no identity, empty username, empty token, expired token)
- [x] UT-AF-1226-005: Success path with valid identity and token
- [x] UT-AF-1226-006: Client wrappers applied in order
- [x] UT-AF-1226-007: Base rest.Config not mutated
- [x] UT-AF-1226-010/011: Config default and YAML parsing
- [x] UT-AF-1226-030/031: Manifest validation (no serviceaccounts in impersonation rules)
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test -race ./pkg/apifrontend/auth/...` clean
- [x] All existing tests unbroken

Closes #1226


Made with [Cursor](https://cursor.com)