### PR TITLE
feat(authwebhook): graceful degradation for RW re-registration failures (#1246)

### DIFF
--- a/api/openapi/data-storage-v1.yaml
+++ b/api/openapi/data-storage-v1.yaml
@@ -2733,6 +2733,7 @@ components:
             - $ref: '#/components/schemas/ShadowLLMResponsePayload'
             - $ref: '#/components/schemas/RemediationRequestWebhookAuditPayload'
             - $ref: '#/components/schemas/RemediationWorkflowWebhookAuditPayload'
+            - $ref: '#/components/schemas/AuthwebhookWorkflowRegistrationFailedPayload'
             - $ref: '#/components/schemas/EffectivenessAssessmentAuditPayload'
             - $ref: '#/components/schemas/ActionTypeCatalogCreatedPayload'
             - $ref: '#/components/schemas/ActionTypeCatalogUpdatedPayload'
@@ -2814,6 +2815,7 @@ components:
               'remediationworkflow.admitted.update': '#/components/schemas/RemediationWorkflowWebhookAuditPayload'
               'remediationworkflow.admitted.delete': '#/components/schemas/RemediationWorkflowWebhookAuditPayload'
               'remediationworkflow.admitted.denied': '#/components/schemas/RemediationWorkflowWebhookAuditPayload'
+              'authwebhook.workflow.registration_failed': '#/components/schemas/AuthwebhookWorkflowRegistrationFailedPayload'
               'workflow.catalog.actions_listed': '#/components/schemas/WorkflowDiscoveryAuditPayload'
               'workflow.catalog.workflows_listed': '#/components/schemas/WorkflowDiscoveryAuditPayload'
               'workflow.catalog.workflow_retrieved': '#/components/schemas/WorkflowDiscoveryAuditPayload'
@@ -4685,6 +4687,41 @@ components:
           type: string
           description: Reason for denial (only set when action=denied)
           example: "data storage registration failed"
+
+    AuthwebhookWorkflowRegistrationFailedPayload:
+      type: object
+      required: [event_type, workflow_name, reason, message]
+      description: |
+        Audit payload emitted by AuthWebhook's StartupReconciler when a RemediationWorkflow
+        CRD fails to re-register with DataStorage during startup (Issue #1246).
+        Enables operators to identify which workflows are degraded and why.
+      properties:
+        event_type:
+          type: string
+          enum:
+            - 'authwebhook.workflow.registration_failed'
+          description: Event type for discriminator
+        workflow_name:
+          type: string
+          description: Name of the RemediationWorkflow CRD that failed registration
+          example: "crashloop-rollback-v1"
+        namespace:
+          type: string
+          description: Namespace of the RemediationWorkflow CRD
+          example: "kubernaut-system"
+        reason:
+          type: string
+          enum: [DependencyMissing, DataStorageError, ValidationFailed]
+          description: |
+            Structured failure reason matching the Ready condition reason.
+            - DependencyMissing: permanent error (e.g., referenced action type not found)
+            - DataStorageError: transient error exhausted retries or context cancelled
+            - ValidationFailed: CRD content could not be marshaled
+          example: "DependencyMissing"
+        message:
+          type: string
+          description: Human-readable error message with remediation context
+          example: "action_type 'ScaleMemory' is not in the taxonomy"
 
     # ========================================
     # Effectiveness Monitor Audit Payloads

--- a/api/remediationworkflow/v1alpha1/remediationworkflow_types.go
+++ b/api/remediationworkflow/v1alpha1/remediationworkflow_types.go
@@ -204,6 +204,10 @@ type RemediationWorkflowStatus struct {
 	// PreviouslyExisted indicates if this workflow was re-registered after deletion
 	// +optional
 	PreviouslyExisted bool `json:"previouslyExisted,omitempty"`
+
+	// Conditions represent the latest available observations of the workflow's state.
+	// +optional
+	Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -238,3 +242,17 @@ type RemediationWorkflowList struct {
 func init() {
 	SchemeBuilder.Register(&RemediationWorkflow{}, &RemediationWorkflowList{})
 }
+
+// Condition type constants for RemediationWorkflow status.
+const (
+	// ConditionReady indicates whether the workflow is registered and active in DataStorage.
+	ConditionReady = "Ready"
+)
+
+// Condition reason constants for RemediationWorkflow status.
+const (
+	ReasonRegistered       = "Registered"
+	ReasonDependencyMissing = "DependencyMissing"
+	ReasonDataStorageError = "DataStorageError"
+	ReasonValidationFailed = "ValidationFailed"
+)

--- a/api/remediationworkflow/v1alpha1/zz_generated.deepcopy.go
+++ b/api/remediationworkflow/v1alpha1/zz_generated.deepcopy.go
@@ -22,6 +22,7 @@ package v1alpha1
 
 import (
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
@@ -304,6 +305,13 @@ func (in *RemediationWorkflowStatus) DeepCopyInto(out *RemediationWorkflowStatus
 	if in.RegisteredAt != nil {
 		in, out := &in.RegisteredAt, &out.RegisteredAt
 		*out = (*in).DeepCopy()
+	}
+	if in.Conditions != nil {
+		in, out := &in.Conditions, &out.Conditions
+		*out = make([]metav1.Condition, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
 	}
 }
 

--- a/charts/kubernaut/crds/kubernaut.ai_remediationworkflows.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_remediationworkflows.yaml
@@ -325,6 +325,64 @@ spec:
                   - Superseded
                 description: CatalogStatus reflects the DS catalog lifecycle state.
                 type: string
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the workflow's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               previouslyExisted:
                 description: PreviouslyExisted indicates if this workflow was re-registered
                   after deletion

--- a/charts/kubernaut/files/crds/kubernaut.ai_remediationworkflows.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_remediationworkflows.yaml
@@ -325,6 +325,64 @@ spec:
                   - Superseded
                 description: CatalogStatus reflects the DS catalog lifecycle state.
                 type: string
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the workflow's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               previouslyExisted:
                 description: PreviouslyExisted indicates if this workflow was re-registered
                   after deletion

--- a/cmd/authwebhook/main.go
+++ b/cmd/authwebhook/main.go
@@ -253,14 +253,15 @@ func main() {
 	setupLog.Info("Registered ActionType webhook handler with DS client and audit store")
 
 	// Issue #548: Startup reconciler syncs existing CRDs with DataStorage on boot.
-	// Fail-closed: if DS is unreachable within the timeout, the manager won't start,
-	// blocking readiness probes and preventing stale state.
+	// Issue #1246: Graceful degradation — individual RW failures don't crash the pod.
 	startupReconciler := &authwebhook.StartupReconciler{
-		K8sClient:    mgr.GetClient(),
-		DSWorkflow:   rwDSClient,
-		DSActionType: rwDSClient,
-		Logger:       ctrl.Log.WithName("startup-reconciler"),
-		Timeout:      cfg.DataStorage.Timeout,
+		K8sClient:     mgr.GetClient(),
+		DSWorkflow:    rwDSClient,
+		DSActionType:  rwDSClient,
+		Logger:        ctrl.Log.WithName("startup-reconciler"),
+		Timeout:       cfg.DataStorage.Timeout,
+		EventRecorder: mgr.GetEventRecorderFor("authwebhook-startup"),
+		AuditStore:    auditStore,
 	}
 	if err := mgr.Add(startupReconciler); err != nil {
 		setupLog.Error(err, "unable to add startup reconciler")

--- a/config/crd/bases/kubernaut.ai_remediationworkflows.yaml
+++ b/config/crd/bases/kubernaut.ai_remediationworkflows.yaml
@@ -325,6 +325,64 @@ spec:
                   - Superseded
                 description: CatalogStatus reflects the DS catalog lifecycle state.
                 type: string
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the workflow's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               previouslyExisted:
                 description: PreviouslyExisted indicates if this workflow was re-registered
                   after deletion

--- a/docs/architecture/decisions/DD-AUDIT-003-service-audit-trace-requirements.md
+++ b/docs/architecture/decisions/DD-AUDIT-003-service-audit-trace-requirements.md
@@ -2,10 +2,23 @@
 
 **Status**: ✅ **APPROVED** (Production Standard)
 **Date**: November 8, 2025
-**Last Reviewed**: May 19, 2026
-**Version**: 2.0
+**Last Reviewed**: May 23, 2026
+**Version**: 2.1
 **Confidence**: 95%
 **Authority Level**: SYSTEM-WIDE - Defines audit requirements for all 13 services
+
+**Recent Changes** (v2.1 - May 23, 2026):
+- **Auth Webhook**: Added RemediationWorkflow audit events per ADR-058 / Issue #1246:
+  - `remediationworkflow.admitted.create` — RW CREATE admitted by webhook
+  - `remediationworkflow.admitted.update` — RW UPDATE admitted by webhook
+  - `remediationworkflow.admitted.delete` — RW DELETE admitted by webhook (sets CatalogStatus=Disabled)
+  - `remediationworkflow.admitted.denied` — RW CREATE/UPDATE denied (validation/auth failure)
+  - `authwebhook.workflow.registration_failed` — Startup reconciler: RW registration failed (graceful degradation)
+- **Category**: `workflow` (per ADR-034 v1.8 event_category = business domain)
+- **Implementation**: `pkg/authwebhook/remediationworkflow_audit.go`, `pkg/authwebhook/startup_reconciler.go`
+- **Delivery**: Events batched via `pkg/audit.BufferedAuditStore` (non-blocking, best-effort)
+- **Expected Volume**: +100 events/day (RW admission lifecycle + startup re-registration)
+- **Authority**: ADR-058, Issue #1246 (graceful degradation), BR-WORKFLOW-007
 
 **Recent Changes** (v2.0 - May 19, 2026):
 - **API Frontend (AF)**: Added as P0 MUST service (8th P0, 13th overall) per Issue #1156 (SOC2 AU-2)
@@ -463,25 +476,46 @@ Kubernaut consists of 12 microservices with different responsibilities. Not all 
 
 **Audit Events**:
 
-| Event Type | Description | Priority |
-|------------|-------------|----------|
-| `actiontype.admitted.create` | ActionType CREATE admitted by webhook | P0 |
-| `actiontype.admitted.update` | ActionType UPDATE admitted by webhook | P0 |
-| `actiontype.admitted.delete` | ActionType DELETE admitted by webhook (soft-disable) | P0 |
-| `actiontype.denied.delete` | ActionType DELETE denied (active workflow dependencies) | P0 |
+| Event Type | Description | Category | Priority |
+|------------|-------------|----------|----------|
+| `actiontype.admitted.create` | ActionType CREATE admitted by webhook | `actiontype` | P0 |
+| `actiontype.admitted.update` | ActionType UPDATE admitted by webhook | `actiontype` | P0 |
+| `actiontype.admitted.delete` | ActionType DELETE admitted by webhook (soft-disable) | `actiontype` | P0 |
+| `actiontype.denied.create` | ActionType CREATE denied | `actiontype` | P0 |
+| `actiontype.denied.update` | ActionType UPDATE denied | `actiontype` | P0 |
+| `actiontype.denied.delete` | ActionType DELETE denied (active workflow dependencies) | `actiontype` | P0 |
+| `remediationworkflow.admitted.create` | RemediationWorkflow CREATE admitted by webhook | `workflow` | P0 |
+| `remediationworkflow.admitted.update` | RemediationWorkflow UPDATE admitted by webhook | `workflow` | P0 |
+| `remediationworkflow.admitted.delete` | RemediationWorkflow DELETE admitted by webhook | `workflow` | P0 |
+| `remediationworkflow.admitted.denied` | RemediationWorkflow CREATE/UPDATE denied | `workflow` | P0 |
+| `authwebhook.workflow.registration_failed` | Startup reconciler: RW re-registration failed (graceful degradation) | `workflow` | P0 |
 
-**Webhook Admission Events** (v1.7 - March 2026):
+**ActionType Webhook Admission Events** (v1.7 - March 2026):
 - **Authority**: BR-WORKFLOW-007.4, DD-ACTIONTYPE-001, Issue #300
 - **Compliance**: SOC2 Type II requires admission decision audit trail for taxonomy governance
 - **Implementation**: `pkg/authwebhook/actiontype_audit.go`
 - **Payload Structure**: Events carry ActionType spec, user identity, and DS result as typed payloads
 - **Delivery**: Events are batched and written to Data Storage audit API via async buffered store
 
+**RemediationWorkflow Webhook Admission Events** (ADR-058):
+- **Authority**: ADR-058, Issue #300
+- **Compliance**: SOC2 Type II requires admission decision audit trail for workflow governance
+- **Implementation**: `pkg/authwebhook/remediationworkflow_audit.go`
+- **Payload Structure**: Events carry RW name, workflow ID (when available), and DS registration result
+
+**Startup Reconciler Audit Events** (v2.1 - May 2026, Issue #1246):
+- **Authority**: Issue #1246 (graceful degradation for RW re-registration failures)
+- **Compliance**: AU-3 (audit content), SI-11 (error handling observability)
+- **Implementation**: `pkg/authwebhook/startup_reconciler.go`
+- **Actor**: `system:authwebhook-startup` (service account, not user-initiated)
+- **Trigger**: RW registration fails with permanent or deadline-exhausted error during startup sync
+- **Severity**: `high` (operational degradation requiring operator attention)
+
 **Industry Precedent**: Kubernetes Admission Audit Logs, OPA/Gatekeeper decision logs
 
-**Expected Volume**: 100 events/day, 3 MB/month
+**Expected Volume**: 200 events/day, 6 MB/month (ActionType + RemediationWorkflow admission + startup reconciliation)
 
-**Authority**: BR-WORKFLOW-007.4, `pkg/authwebhook/actiontype_audit.go`
+**Authority**: BR-WORKFLOW-007.4, ADR-058, Issue #1246, `pkg/authwebhook/actiontype_audit.go`, `pkg/authwebhook/remediationworkflow_audit.go`, `pkg/authwebhook/startup_reconciler.go`
 
 ---
 
@@ -810,7 +844,7 @@ context_api:
 | **Remediation Execution Controller** | 2,310 | 69,300 | 69.3 MB |
 | **Notification Service** | 550 | 16,500 | 16.5 MB |
 | **Data Storage Service** | 5,100 | 153,000 | 153 MB |
-| **Auth Webhook Service** | 100 | 3,000 | 3 MB |
+| **Auth Webhook Service** | 200 | 6,000 | 6 MB |
 | **Effectiveness Monitor Service** | 500 | 15,000 | 15 MB |
 | **Signal Processing Controller** | 1,000 | 30,000 | 30 MB |
 | **Remediation Orchestrator Controller** | 1,200 | 36,000 | 36 MB |

--- a/docs/generated/crds.md
+++ b/docs/generated/crds.md
@@ -1666,6 +1666,7 @@ _Appears in:_
 | `registeredBy`| _string_| RegisteredBy is the identity of the registrant|
 | `registeredAt`| _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#time-v1-meta)_| RegisteredAt is the timestamp of initial registration|
 | `previouslyExisted`| _boolean_| PreviouslyExisted indicates if this workflow was re-registered after deletion|
+| `conditions`| _[Condition](https://kubernetes.io/docs/reference/generated/kubernetes-api/v/#condition-v1-meta) array_| Conditions represent the latest available observations of the workflow's state.|
 
 
 ### ResourceIdentifier

--- a/docs/tests/1246/TEST_PLAN.md
+++ b/docs/tests/1246/TEST_PLAN.md
@@ -1,0 +1,107 @@
+# Test Plan: Issue #1246 — AW Graceful Degradation for RW Re-Registration
+
+## 1. Test Plan Identifier
+
+**TP-AW-1246** | Version 1.0 | 2026-05-23
+
+## 2. References
+
+- **Issue**: [#1246](https://github.com/jordigilh/kubernaut/issues/1246)
+- **BR**: BR-WORKFLOW-006 (Kubernetes-native workflow schema), BR-PLATFORM-012 (Graceful degradation)
+- **ADR**: ADR-058 (CRD-based workflow registration)
+- **Design**: Issue #548 (StartupReconciler PVC-wipe resilience)
+
+## 3. Introduction
+
+This test plan covers the graceful degradation behavior of AuthWebhook's `StartupReconciler` when individual RemediationWorkflow (RW) CRDs fail to re-register with DataStorage at startup. The feature ensures AW starts successfully even when some RWs have unresolvable dependencies.
+
+## 4. Test Items
+
+| Component | File | Description |
+|-----------|------|-------------|
+| CRD Types | `api/remediationworkflow/v1alpha1/remediationworkflow_types.go` | Conditions field addition |
+| DS Client | `pkg/authwebhook/ds_client.go` | Error classification (IsPermanentError) |
+| StartupReconciler | `pkg/authwebhook/startup_reconciler.go` | Graceful degradation loop |
+| Main wiring | `cmd/authwebhook/main.go` | EventRecorder + AuditStore injection |
+| RW Webhook | `pkg/authwebhook/remediationworkflow_handler.go` | Ready=True condition on success |
+
+## 5. Features to Be Tested
+
+| ID | Feature | Acceptance Criteria |
+|----|---------|---------------------|
+| F-1 | Graceful continuation | AW starts even when 1+ RWs fail registration |
+| F-2 | Status marking | Failed RWs get `CatalogStatus=Disabled` + condition `Ready=False` |
+| F-3 | Error classification | Permanent errors (400, 404) skip retry; transient (5xx, network) retry |
+| F-4 | K8s Event emission | Warning event emitted on RW CR for failures |
+| F-5 | Audit event | Audit trail for each failed re-registration |
+| F-6 | Structured logging | Error-level log with RW name, reason, remediation |
+| F-7 | Self-healing | Re-applying RW CR triggers re-registration via webhook |
+| F-8 | Conditions on success | Successful registration sets `Ready=True` |
+
+## 6. Features Not Tested
+
+- DS side validation logic (tested in DS service)
+- TLS/auth transport (tested in shared/tls)
+- Controller-runtime manager lifecycle (framework concern)
+
+## 7. Approach
+
+### 7.1 Test Pyramid (per Pyramid Invariant)
+
+| Tier | Coverage Target | Scope |
+|------|-----------------|-------|
+| Unit (Ginkgo/Gomega) | >=80% | StartupReconciler logic, error classification, condition helpers |
+| Integration (envtest) | >=80% | Full reconciler with fake DS, real K8s client, status patches |
+| E2E | Deferred | Full Kind cluster (covered by existing E2E infrastructure) |
+
+### 7.2 Strategy
+
+- **TDD Red**: Write failing tests for all 8 features first
+- **TDD Green**: Implement minimal code to pass each test
+- **TDD Refactor**: Improve structure, validate against 100 Go Mistakes
+
+## 8. Test Scenarios
+
+### Unit Tests
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| UT-AW-1246-001 | One RW fails with 400, others succeed | Start() returns nil, failed RW has Disabled+Ready=False |
+| UT-AW-1246-002 | All RWs fail with permanent errors | Start() returns nil, all marked Disabled |
+| UT-AW-1246-003 | IsPermanentError returns true for 400/404 | Helper correctly classifies |
+| UT-AW-1246-004 | IsPermanentError returns false for network/5xx | Helper correctly classifies |
+| UT-AW-1246-005 | Transient error retries then succeeds | RW eventually registered Active |
+| UT-AW-1246-006 | K8s event emitted for failed RW | EventRecorder.Eventf called with Warning |
+| UT-AW-1246-009 | Successful RW gets Ready=True condition | Condition set with correct reason |
+| UT-AW-1246-010 | Audit event emitted on permanent failure | AuditStore.StoreAudit called with category=workflow, type=authwebhook.workflow.registration_failed |
+| UT-AW-1246-011 | Nil AuditStore graceful handling | No panic when AuditStore is nil |
+| UT-AW-1246-012 | Context cancellation marks workflow Disabled | Disabled status + audit emitted |
+| UT-AW-1246-013 | Deadline exhaustion with audit emission | Disabled status + audit + K8s event |
+
+### Integration Tests
+
+| ID | Scenario | Expected |
+|----|----------|----------|
+| IT-AW-1246-001 | Mixed success/failure with fake DS returning 400 | Pod starts, statuses correct |
+| IT-AW-1246-002 | DS unreachable then available (transient) | Retry succeeds, Active status |
+
+## 9. Pass/Fail Criteria
+
+- All unit tests pass with `go test -race`
+- No lint errors (`golangci-lint run`)
+- Coverage >=80% of new code per tier
+- Build succeeds (`go build ./...`)
+
+## 10. Environmental Needs
+
+- Go 1.24+
+- controller-runtime v0.23.3 (fake client)
+- Ginkgo v2 / Gomega
+
+## 11. Risks and Contingencies
+
+| Risk | Mitigation |
+|------|------------|
+| Audit event type not in OpenAPI spec | Use escape hatch (empty EventData.Type) |
+| Status patch race with webhook | Use RetryOnConflict in startup reconciler |
+| Fake client doesn't support status subresource | WithStatusSubresource() already used |

--- a/pkg/audit/openapi_spec_data.yaml
+++ b/pkg/audit/openapi_spec_data.yaml
@@ -2733,6 +2733,7 @@ components:
             - $ref: '#/components/schemas/ShadowLLMResponsePayload'
             - $ref: '#/components/schemas/RemediationRequestWebhookAuditPayload'
             - $ref: '#/components/schemas/RemediationWorkflowWebhookAuditPayload'
+            - $ref: '#/components/schemas/AuthwebhookWorkflowRegistrationFailedPayload'
             - $ref: '#/components/schemas/EffectivenessAssessmentAuditPayload'
             - $ref: '#/components/schemas/ActionTypeCatalogCreatedPayload'
             - $ref: '#/components/schemas/ActionTypeCatalogUpdatedPayload'
@@ -2814,6 +2815,7 @@ components:
               'remediationworkflow.admitted.update': '#/components/schemas/RemediationWorkflowWebhookAuditPayload'
               'remediationworkflow.admitted.delete': '#/components/schemas/RemediationWorkflowWebhookAuditPayload'
               'remediationworkflow.admitted.denied': '#/components/schemas/RemediationWorkflowWebhookAuditPayload'
+              'authwebhook.workflow.registration_failed': '#/components/schemas/AuthwebhookWorkflowRegistrationFailedPayload'
               'workflow.catalog.actions_listed': '#/components/schemas/WorkflowDiscoveryAuditPayload'
               'workflow.catalog.workflows_listed': '#/components/schemas/WorkflowDiscoveryAuditPayload'
               'workflow.catalog.workflow_retrieved': '#/components/schemas/WorkflowDiscoveryAuditPayload'
@@ -4685,6 +4687,41 @@ components:
           type: string
           description: Reason for denial (only set when action=denied)
           example: "data storage registration failed"
+
+    AuthwebhookWorkflowRegistrationFailedPayload:
+      type: object
+      required: [event_type, workflow_name, reason, message]
+      description: |
+        Audit payload emitted by AuthWebhook's StartupReconciler when a RemediationWorkflow
+        CRD fails to re-register with DataStorage during startup (Issue #1246).
+        Enables operators to identify which workflows are degraded and why.
+      properties:
+        event_type:
+          type: string
+          enum:
+            - 'authwebhook.workflow.registration_failed'
+          description: Event type for discriminator
+        workflow_name:
+          type: string
+          description: Name of the RemediationWorkflow CRD that failed registration
+          example: "crashloop-rollback-v1"
+        namespace:
+          type: string
+          description: Namespace of the RemediationWorkflow CRD
+          example: "kubernaut-system"
+        reason:
+          type: string
+          enum: [DependencyMissing, DataStorageError, ValidationFailed]
+          description: |
+            Structured failure reason matching the Ready condition reason.
+            - DependencyMissing: permanent error (e.g., referenced action type not found)
+            - DataStorageError: transient error exhausted retries or context cancelled
+            - ValidationFailed: CRD content could not be marshaled
+          example: "DependencyMissing"
+        message:
+          type: string
+          description: Human-readable error message with remediation context
+          example: "action_type 'ScaleMemory' is not in the taxonomy"
 
     # ========================================
     # Effectiveness Monitor Audit Payloads

--- a/pkg/authwebhook/ds_client.go
+++ b/pkg/authwebhook/ds_client.go
@@ -105,13 +105,13 @@ func (a *DSClientAdapter) CreateWorkflowInline(ctx context.Context, content, sou
 		rw := (*ogenclient.RemediationWorkflow)(v)
 		return mapOgenWorkflowToResult(rw, true), nil
 	case *ogenclient.CreateWorkflowBadRequest:
-		return nil, rfc7807Error("workflow registration rejected", (*ogenclient.RFC7807Problem)(v))
+		return nil, NewPermanentError(rfc7807Error("workflow registration rejected", (*ogenclient.RFC7807Problem)(v)).Error())
 	case *ogenclient.CreateWorkflowConflict:
 		return nil, rfc7807Error("workflow already exists", (*ogenclient.RFC7807Problem)(v))
 	case *ogenclient.CreateWorkflowForbidden:
-		return nil, rfc7807Error("workflow registration forbidden", (*ogenclient.RFC7807Problem)(v))
+		return nil, NewPermanentError(rfc7807Error("workflow registration forbidden", (*ogenclient.RFC7807Problem)(v)).Error())
 	case *ogenclient.CreateWorkflowUnauthorized:
-		return nil, rfc7807Error("workflow registration unauthorized", (*ogenclient.RFC7807Problem)(v))
+		return nil, NewPermanentError(rfc7807Error("workflow registration unauthorized", (*ogenclient.RFC7807Problem)(v)).Error())
 	case *ogenclient.CreateWorkflowInternalServerError:
 		return nil, rfc7807Error("workflow registration server error", (*ogenclient.RFC7807Problem)(v))
 	default:

--- a/pkg/authwebhook/errors.go
+++ b/pkg/authwebhook/errors.go
@@ -1,0 +1,41 @@
+/*
+Copyright 2025 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authwebhook
+
+import "errors"
+
+// PermanentError indicates a non-retryable error from DataStorage.
+// HTTP 400 (validation), 403 (forbidden), 404 (not found) are permanent —
+// retrying will not produce a different result.
+type PermanentError struct {
+	msg string
+}
+
+func (e *PermanentError) Error() string {
+	return e.msg
+}
+
+// NewPermanentError creates a PermanentError with the given message.
+func NewPermanentError(msg string) error {
+	return &PermanentError{msg: msg}
+}
+
+// IsPermanentError returns true if the error (or any wrapped error) is a PermanentError.
+func IsPermanentError(err error) bool {
+	var pe *PermanentError
+	return errors.As(err, &pe)
+}

--- a/pkg/authwebhook/remediationworkflow_handler.go
+++ b/pkg/authwebhook/remediationworkflow_handler.go
@@ -295,6 +295,13 @@ func (h *RemediationWorkflowHandler) updateCRDStatus(namespace, name, registered
 		rw.Status.RegisteredBy = registeredBy
 		rw.Status.RegisteredAt = &now
 		rw.Status.PreviouslyExisted = result.PreviouslyExisted
+		setCondition(&rw.Status.Conditions, metav1.Condition{
+			Type:               rwv1alpha1.ConditionReady,
+			Status:             metav1.ConditionTrue,
+			Reason:             rwv1alpha1.ReasonRegistered,
+			Message:            "Workflow registered successfully in DataStorage catalog",
+			LastTransitionTime: now,
+		})
 
 		return h.k8sClient.Status().Update(ctx, rw)
 	})

--- a/pkg/authwebhook/startup_graceful_test.go
+++ b/pkg/authwebhook/startup_graceful_test.go
@@ -39,7 +39,6 @@ type gracefulDSClient struct {
 	workflowErrors map[string]error // keyed by CRD name; nil means success
 	atResult       *authwebhook.ActionTypeRegistrationResult
 	rwResult       *authwebhook.WorkflowRegistrationResult
-	events         []string // records "audit:<name>" for audit calls
 }
 
 func (m *gracefulDSClient) CreateActionType(_ context.Context, name string, _ ogenclient.ActionTypeDescription, _ string) (*authwebhook.ActionTypeRegistrationResult, error) {

--- a/pkg/authwebhook/startup_graceful_test.go
+++ b/pkg/authwebhook/startup_graceful_test.go
@@ -1,0 +1,566 @@
+/*
+Copyright 2025 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authwebhook_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	atv1alpha1 "github.com/jordigilh/kubernaut/api/actiontype/v1alpha1"
+	rwv1alpha1 "github.com/jordigilh/kubernaut/api/remediationworkflow/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/authwebhook"
+	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// gracefulDSClient supports per-workflow error injection for graceful degradation testing.
+type gracefulDSClient struct {
+	workflowErrors map[string]error // keyed by CRD name; nil means success
+	atResult       *authwebhook.ActionTypeRegistrationResult
+	rwResult       *authwebhook.WorkflowRegistrationResult
+	events         []string // records "audit:<name>" for audit calls
+}
+
+func (m *gracefulDSClient) CreateActionType(_ context.Context, name string, _ ogenclient.ActionTypeDescription, _ string) (*authwebhook.ActionTypeRegistrationResult, error) {
+	if m.atResult != nil {
+		return m.atResult, nil
+	}
+	return &authwebhook.ActionTypeRegistrationResult{ActionType: name, Status: "created"}, nil
+}
+
+func (m *gracefulDSClient) CreateWorkflowInline(_ context.Context, content, source, _ string) (*authwebhook.WorkflowRegistrationResult, error) {
+	if err, ok := m.workflowErrors[source]; ok && err != nil {
+		return nil, err
+	}
+	if m.rwResult != nil {
+		return m.rwResult, nil
+	}
+	return &authwebhook.WorkflowRegistrationResult{
+		WorkflowID:   "wf-uuid-001",
+		WorkflowName: "test",
+		Version:      "1.0.0",
+		Status:       "Active",
+	}, nil
+}
+
+// fakeEventRecorder captures K8s events for assertions.
+type fakeEventRecorder struct {
+	events []recordedEvent
+}
+
+type recordedEvent struct {
+	Object    string
+	EventType string
+	Reason    string
+	Message   string
+}
+
+func (r *fakeEventRecorder) Event(object runtime.Object, eventtype, reason, message string) {
+	r.events = append(r.events, recordedEvent{EventType: eventtype, Reason: reason, Message: message})
+}
+
+func (r *fakeEventRecorder) Eventf(object runtime.Object, eventtype, reason, messageFmt string, args ...interface{}) {
+	r.events = append(r.events, recordedEvent{
+		EventType: eventtype,
+		Reason:    reason,
+		Message:   fmt.Sprintf(messageFmt, args...),
+	})
+}
+
+func (r *fakeEventRecorder) AnnotatedEventf(object runtime.Object, annotations map[string]string, eventtype, reason, messageFmt string, args ...interface{}) {
+	r.events = append(r.events, recordedEvent{
+		EventType: eventtype,
+		Reason:    reason,
+		Message:   fmt.Sprintf(messageFmt, args...),
+	})
+}
+
+var _ = Describe("StartupReconciler Graceful Degradation (#1246)", func() {
+
+	// UT-AW-1246-001: One RW fails with permanent error, others succeed
+	Describe("UT-AW-1246-001: Graceful continuation on individual RW failure", func() {
+		It("should start successfully when one RW fails with a permanent error", func() {
+			scheme := newTestScheme()
+			rw1 := makeWorkflowCRD("wf-good", "ScaleMemory")
+			rw2 := makeWorkflowCRD("wf-bad", "MissingAction")
+
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(rw1, rw2).
+				WithStatusSubresource(&atv1alpha1.ActionType{}, &rwv1alpha1.RemediationWorkflow{}).
+				Build()
+
+			mockDS := &gracefulDSClient{
+				workflowErrors: map[string]error{
+					"wf-bad": authwebhook.NewPermanentError("workflow registration rejected: action_type 'MissingAction' is not in the taxonomy"),
+				},
+			}
+
+			recorder := &fakeEventRecorder{}
+
+			reconciler := &authwebhook.StartupReconciler{
+				K8sClient:      k8sClient,
+				DSWorkflow:     mockDS,
+				DSActionType:   mockDS,
+				Logger:         ctrl.Log.WithName("test"),
+				Timeout:        5 * time.Second,
+				InitialBackoff: 10 * time.Millisecond,
+				EventRecorder:  recorder,
+			}
+
+			ctx := context.Background()
+			err := reconciler.Start(ctx)
+			Expect(err).NotTo(HaveOccurred(), "startup should succeed despite individual RW failure")
+
+			// Verify good RW has Active status
+			good := &rwv1alpha1.RemediationWorkflow{}
+			Expect(k8sClient.Get(ctx, nsName("default", "wf-good"), good)).To(Succeed())
+			Expect(string(good.Status.CatalogStatus)).To(Equal("Active"))
+
+			// Verify bad RW has Disabled status + Ready=False condition
+			bad := &rwv1alpha1.RemediationWorkflow{}
+			Expect(k8sClient.Get(ctx, nsName("default", "wf-bad"), bad)).To(Succeed())
+			Expect(string(bad.Status.CatalogStatus)).To(Equal("Disabled"))
+
+			readyCond := findCondition(bad.Status.Conditions, rwv1alpha1.ConditionReady)
+			Expect(readyCond).NotTo(BeNil(), "Ready condition should exist on failed RW")
+			Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(readyCond.Reason).To(Equal(rwv1alpha1.ReasonDependencyMissing))
+		})
+	})
+
+	// UT-AW-1246-002: All RWs fail with permanent errors
+	Describe("UT-AW-1246-002: All RWs fail with permanent errors", func() {
+		It("should still start successfully and mark all as Disabled", func() {
+			scheme := newTestScheme()
+			rw1 := makeWorkflowCRD("wf-fail-1", "Bad1")
+			rw2 := makeWorkflowCRD("wf-fail-2", "Bad2")
+
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(rw1, rw2).
+				WithStatusSubresource(&atv1alpha1.ActionType{}, &rwv1alpha1.RemediationWorkflow{}).
+				Build()
+
+			mockDS := &gracefulDSClient{
+				workflowErrors: map[string]error{
+					"wf-fail-1": authwebhook.NewPermanentError("rejected"),
+					"wf-fail-2": authwebhook.NewPermanentError("rejected"),
+				},
+			}
+
+			reconciler := &authwebhook.StartupReconciler{
+				K8sClient:      k8sClient,
+				DSWorkflow:     mockDS,
+				DSActionType:   mockDS,
+				Logger:         ctrl.Log.WithName("test"),
+				Timeout:        5 * time.Second,
+				InitialBackoff: 10 * time.Millisecond,
+				EventRecorder:  &fakeEventRecorder{},
+			}
+
+			ctx := context.Background()
+			err := reconciler.Start(ctx)
+			Expect(err).NotTo(HaveOccurred(), "startup must succeed even when all RWs fail")
+
+			for _, name := range []string{"wf-fail-1", "wf-fail-2"} {
+				rw := &rwv1alpha1.RemediationWorkflow{}
+				Expect(k8sClient.Get(ctx, nsName("default", name), rw)).To(Succeed())
+				Expect(string(rw.Status.CatalogStatus)).To(Equal("Disabled"))
+			}
+		})
+	})
+
+	// UT-AW-1246-003: IsPermanentError identifies 400/404 errors
+	Describe("UT-AW-1246-003: IsPermanentError for permanent errors", func() {
+		It("should return true for PermanentError type", func() {
+			permErr := authwebhook.NewPermanentError("action_type not found")
+			Expect(authwebhook.IsPermanentError(permErr)).To(BeTrue())
+		})
+	})
+
+	// UT-AW-1246-004: IsPermanentError identifies transient errors
+	Describe("UT-AW-1246-004: IsPermanentError for transient errors", func() {
+		It("should return false for generic/network errors", func() {
+			transientErr := fmt.Errorf("connection refused")
+			Expect(authwebhook.IsPermanentError(transientErr)).To(BeFalse())
+		})
+	})
+
+	// UT-AW-1246-005: Transient error retries then succeeds
+	Describe("UT-AW-1246-005: Transient error triggers retry", func() {
+		It("should retry transient errors and succeed when DS recovers", func() {
+			scheme := newTestScheme()
+			rw := makeWorkflowCRD("wf-transient", "ScaleMemory")
+
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(rw).
+				WithStatusSubresource(&atv1alpha1.ActionType{}, &rwv1alpha1.RemediationWorkflow{}).
+				Build()
+
+			callCount := 0
+			mockDS := &countingDSClient{
+				callCounter: &callCount,
+				failUntil:   2, // fail first 2 calls, succeed on 3rd
+			}
+
+			reconciler := &authwebhook.StartupReconciler{
+				K8sClient:      k8sClient,
+				DSWorkflow:     mockDS,
+				DSActionType:   mockDS,
+				Logger:         ctrl.Log.WithName("test"),
+				Timeout:        5 * time.Second,
+				InitialBackoff: 10 * time.Millisecond,
+				EventRecorder:  &fakeEventRecorder{},
+			}
+
+			ctx := context.Background()
+			err := reconciler.Start(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &rwv1alpha1.RemediationWorkflow{}
+			Expect(k8sClient.Get(ctx, nsName("default", "wf-transient"), updated)).To(Succeed())
+			Expect(string(updated.Status.CatalogStatus)).To(Equal("Active"))
+			Expect(callCount).To(BeNumerically(">=", 3))
+		})
+	})
+
+	// UT-AW-1246-006: K8s event emitted for failed RW
+	Describe("UT-AW-1246-006: K8s event emission on failure", func() {
+		It("should emit a Warning event on the failed RW CR", func() {
+			scheme := newTestScheme()
+			rw := makeWorkflowCRD("wf-event", "Bad")
+
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(rw).
+				WithStatusSubresource(&atv1alpha1.ActionType{}, &rwv1alpha1.RemediationWorkflow{}).
+				Build()
+
+			mockDS := &gracefulDSClient{
+				workflowErrors: map[string]error{
+					"wf-event": authwebhook.NewPermanentError("rejected"),
+				},
+			}
+
+			recorder := &fakeEventRecorder{}
+
+			reconciler := &authwebhook.StartupReconciler{
+				K8sClient:      k8sClient,
+				DSWorkflow:     mockDS,
+				DSActionType:   mockDS,
+				Logger:         ctrl.Log.WithName("test"),
+				Timeout:        5 * time.Second,
+				InitialBackoff: 10 * time.Millisecond,
+				EventRecorder:  recorder,
+			}
+
+			ctx := context.Background()
+			_ = reconciler.Start(ctx)
+
+			Expect(recorder.events).NotTo(BeEmpty(), "should emit at least one K8s event")
+			Expect(recorder.events[0].EventType).To(Equal("Warning"))
+			Expect(recorder.events[0].Reason).To(Equal("RegistrationFailed"))
+		})
+	})
+
+	// UT-AW-1246-009: Successful RW gets Ready=True condition
+	Describe("UT-AW-1246-009: Ready=True on successful registration", func() {
+		It("should set Ready=True condition on successfully registered RW", func() {
+			scheme := newTestScheme()
+			rw := makeWorkflowCRD("wf-ready", "ScaleMemory")
+
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(rw).
+				WithStatusSubresource(&atv1alpha1.ActionType{}, &rwv1alpha1.RemediationWorkflow{}).
+				Build()
+
+			mockDS := &gracefulDSClient{}
+
+			reconciler := &authwebhook.StartupReconciler{
+				K8sClient:      k8sClient,
+				DSWorkflow:     mockDS,
+				DSActionType:   mockDS,
+				Logger:         ctrl.Log.WithName("test"),
+				Timeout:        5 * time.Second,
+				InitialBackoff: 10 * time.Millisecond,
+				EventRecorder:  &fakeEventRecorder{},
+			}
+
+			ctx := context.Background()
+			err := reconciler.Start(ctx)
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &rwv1alpha1.RemediationWorkflow{}
+			Expect(k8sClient.Get(ctx, nsName("default", "wf-ready"), updated)).To(Succeed())
+
+			readyCond := findCondition(updated.Status.Conditions, rwv1alpha1.ConditionReady)
+			Expect(readyCond).NotTo(BeNil(), "Ready condition should exist")
+			Expect(readyCond.Status).To(Equal(metav1.ConditionTrue))
+			Expect(readyCond.Reason).To(Equal(rwv1alpha1.ReasonRegistered))
+		})
+	})
+
+	// UT-AW-1246-010: Audit event emitted on permanent failure
+	Describe("UT-AW-1246-010: Audit event emission on registration failure", func() {
+		It("should emit an audit event with category 'workflow' and typed payload", func() {
+			scheme := newTestScheme()
+			rw := makeWorkflowCRD("wf-audit", "MissingDep")
+
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(rw).
+				WithStatusSubresource(&atv1alpha1.ActionType{}, &rwv1alpha1.RemediationWorkflow{}).
+				Build()
+
+			mockDS := &gracefulDSClient{
+				workflowErrors: map[string]error{
+					"wf-audit": authwebhook.NewPermanentError("action_type 'MissingDep' not in taxonomy"),
+				},
+			}
+
+			auditMock := &mockAuditStore{}
+
+			reconciler := &authwebhook.StartupReconciler{
+				K8sClient:      k8sClient,
+				DSWorkflow:     mockDS,
+				DSActionType:   mockDS,
+				Logger:         ctrl.Log.WithName("test"),
+				Timeout:        5 * time.Second,
+				InitialBackoff: 10 * time.Millisecond,
+				EventRecorder:  &fakeEventRecorder{},
+				AuditStore:     auditMock,
+			}
+
+			ctx := context.Background()
+			_ = reconciler.Start(ctx)
+
+			Expect(auditMock.storedEvents).To(HaveLen(1), "should emit exactly one audit event")
+			evt := auditMock.storedEvents[0]
+			Expect(evt.EventType).To(Equal(authwebhook.EventTypeRWRegistrationFailed))
+			Expect(string(evt.EventCategory)).To(Equal("workflow"))
+			Expect(evt.EventAction).To(Equal("registration_failed"))
+			Expect(evt.EventOutcome).To(Equal(ogenclient.AuditEventRequestEventOutcomeFailure))
+
+			// Validate typed payload
+			Expect(evt.EventData.Type).To(Equal(ogenclient.AuthwebhookWorkflowRegistrationFailedPayloadAuditEventRequestEventData))
+			payload := evt.EventData.AuthwebhookWorkflowRegistrationFailedPayload
+			Expect(payload.WorkflowName).To(Equal("wf-audit"))
+			Expect(string(payload.Reason)).To(Equal("DependencyMissing"))
+			Expect(payload.Message).To(ContainSubstring("action_type 'MissingDep' not in taxonomy"))
+		})
+	})
+
+	// UT-AW-1246-011: Audit store nil does not panic
+	Describe("UT-AW-1246-011: Nil AuditStore graceful handling", func() {
+		It("should not panic when AuditStore is nil and a workflow fails", func() {
+			scheme := newTestScheme()
+			rw := makeWorkflowCRD("wf-noaudit", "Bad")
+
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(rw).
+				WithStatusSubresource(&atv1alpha1.ActionType{}, &rwv1alpha1.RemediationWorkflow{}).
+				Build()
+
+			mockDS := &gracefulDSClient{
+				workflowErrors: map[string]error{
+					"wf-noaudit": authwebhook.NewPermanentError("rejected"),
+				},
+			}
+
+			reconciler := &authwebhook.StartupReconciler{
+				K8sClient:      k8sClient,
+				DSWorkflow:     mockDS,
+				DSActionType:   mockDS,
+				Logger:         ctrl.Log.WithName("test"),
+				Timeout:        5 * time.Second,
+				InitialBackoff: 10 * time.Millisecond,
+				EventRecorder:  &fakeEventRecorder{},
+				AuditStore:     nil, // explicitly nil
+			}
+
+			ctx := context.Background()
+			Expect(func() { _ = reconciler.Start(ctx) }).NotTo(Panic())
+		})
+	})
+
+	// UT-AW-1246-012: Context cancellation during retry marks workflow as failed
+	Describe("UT-AW-1246-012: Context cancellation marks workflow Disabled", func() {
+		It("should mark workflow as Disabled when context is cancelled during retry", func() {
+			scheme := newTestScheme()
+			rw := makeWorkflowCRD("wf-cancel", "ScaleMemory")
+
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(rw).
+				WithStatusSubresource(&atv1alpha1.ActionType{}, &rwv1alpha1.RemediationWorkflow{}).
+				Build()
+
+			mockDS := &gracefulDSClient{
+				workflowErrors: map[string]error{
+					"wf-cancel": fmt.Errorf("connection timeout"),
+				},
+			}
+
+			auditMock := &mockAuditStore{}
+			recorder := &fakeEventRecorder{}
+
+			reconciler := &authwebhook.StartupReconciler{
+				K8sClient:      k8sClient,
+				DSWorkflow:     mockDS,
+				DSActionType:   mockDS,
+				Logger:         ctrl.Log.WithName("test"),
+				Timeout:        2 * time.Second,
+				InitialBackoff: 10 * time.Millisecond,
+				EventRecorder:  recorder,
+				AuditStore:     auditMock,
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			// Cancel almost immediately so the retry loop detects ctx.Done()
+			go func() {
+				time.Sleep(50 * time.Millisecond)
+				cancel()
+			}()
+
+			err := reconciler.Start(ctx)
+			Expect(err).NotTo(HaveOccurred(), "startup should still succeed gracefully")
+
+			updated := &rwv1alpha1.RemediationWorkflow{}
+			Expect(k8sClient.Get(context.Background(), nsName("default", "wf-cancel"), updated)).To(Succeed())
+			Expect(string(updated.Status.CatalogStatus)).To(Equal("Disabled"))
+
+			readyCond := findCondition(updated.Status.Conditions, rwv1alpha1.ConditionReady)
+			Expect(readyCond).NotTo(BeNil())
+			Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(readyCond.Reason).To(Equal(rwv1alpha1.ReasonDataStorageError))
+
+			Expect(auditMock.storedEvents).To(HaveLen(1), "audit event should be emitted for cancelled workflow")
+			Expect(recorder.events).NotTo(BeEmpty(), "K8s event should be emitted")
+		})
+	})
+
+	// UT-AW-1246-013: Deadline exhaustion marks workflow Disabled with audit
+	Describe("UT-AW-1246-013: Deadline exhaustion with audit emission", func() {
+		It("should mark workflow as Disabled when deadline is exhausted", func() {
+			scheme := newTestScheme()
+			rw := makeWorkflowCRD("wf-deadline", "ScaleMemory")
+
+			k8sClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(rw).
+				WithStatusSubresource(&atv1alpha1.ActionType{}, &rwv1alpha1.RemediationWorkflow{}).
+				Build()
+
+			mockDS := &gracefulDSClient{
+				workflowErrors: map[string]error{
+					"wf-deadline": fmt.Errorf("service unavailable"),
+				},
+			}
+
+			auditMock := &mockAuditStore{}
+			recorder := &fakeEventRecorder{}
+
+			reconciler := &authwebhook.StartupReconciler{
+				K8sClient:      k8sClient,
+				DSWorkflow:     mockDS,
+				DSActionType:   mockDS,
+				Logger:         ctrl.Log.WithName("test"),
+				Timeout:        50 * time.Millisecond,
+				InitialBackoff: 100 * time.Millisecond, // larger than timeout → immediate deadline breach
+				EventRecorder:  recorder,
+				AuditStore:     auditMock,
+			}
+
+			ctx := context.Background()
+			err := reconciler.Start(ctx)
+			Expect(err).NotTo(HaveOccurred(), "startup should succeed gracefully")
+
+			updated := &rwv1alpha1.RemediationWorkflow{}
+			Expect(k8sClient.Get(ctx, nsName("default", "wf-deadline"), updated)).To(Succeed())
+			Expect(string(updated.Status.CatalogStatus)).To(Equal("Disabled"))
+
+			readyCond := findCondition(updated.Status.Conditions, rwv1alpha1.ConditionReady)
+			Expect(readyCond).NotTo(BeNil())
+			Expect(readyCond.Status).To(Equal(metav1.ConditionFalse))
+			Expect(readyCond.Reason).To(Equal(rwv1alpha1.ReasonDataStorageError))
+
+			Expect(auditMock.storedEvents).To(HaveLen(1), "audit event should be emitted for deadline exhaustion")
+			Expect(recorder.events).NotTo(BeEmpty(), "K8s warning event should be emitted")
+		})
+	})
+})
+
+// countingDSClient fails N times with transient errors, then succeeds.
+type countingDSClient struct {
+	callCounter *int
+	failUntil   int
+}
+
+func (m *countingDSClient) CreateActionType(_ context.Context, name string, _ ogenclient.ActionTypeDescription, _ string) (*authwebhook.ActionTypeRegistrationResult, error) {
+	return &authwebhook.ActionTypeRegistrationResult{ActionType: name, Status: "created"}, nil
+}
+
+func (m *countingDSClient) CreateWorkflowInline(_ context.Context, _, _, _ string) (*authwebhook.WorkflowRegistrationResult, error) {
+	*m.callCounter++
+	if *m.callCounter <= m.failUntil {
+		return nil, fmt.Errorf("connection refused")
+	}
+	return &authwebhook.WorkflowRegistrationResult{
+		WorkflowID:   "wf-uuid-recovered",
+		WorkflowName: "test",
+		Version:      "1.0.0",
+		Status:       "Active",
+	}, nil
+}
+
+// mockAuditStore captures audit events emitted by the startup reconciler.
+type mockAuditStore struct {
+	storedEvents []*ogenclient.AuditEventRequest
+	storeError   error
+}
+
+func (m *mockAuditStore) StoreAudit(_ context.Context, event *ogenclient.AuditEventRequest) error {
+	if m.storeError != nil {
+		return m.storeError
+	}
+	m.storedEvents = append(m.storedEvents, event)
+	return nil
+}
+
+func (m *mockAuditStore) Flush(_ context.Context) error { return nil }
+func (m *mockAuditStore) Close() error                  { return nil }
+
+// findCondition looks up a condition by type in the conditions slice.
+func findCondition(conditions []metav1.Condition, condType string) *metav1.Condition {
+	for i := range conditions {
+		if conditions[i].Type == condType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}

--- a/pkg/authwebhook/startup_reconciler.go
+++ b/pkg/authwebhook/startup_reconciler.go
@@ -24,9 +24,12 @@ import (
 	"github.com/go-logr/logr"
 	atv1alpha1 "github.com/jordigilh/kubernaut/api/actiontype/v1alpha1"
 	rwv1alpha1 "github.com/jordigilh/kubernaut/api/remediationworkflow/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/audit"
 	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
 	sharedtypes "github.com/jordigilh/kubernaut/pkg/shared/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -47,6 +50,7 @@ type ActionTypeDSClient interface {
 // controller manager blocks readiness until the reconciliation completes.
 //
 // Issue #548: Ensures PVC-wipe resilience by re-registering CRDs on startup.
+// Issue #1246: Graceful degradation — individual RW failures don't crash the pod.
 // Ordering: ActionType CRDs are synced first, then RemediationWorkflow CRDs,
 // because workflows reference action types.
 type StartupReconciler struct {
@@ -56,6 +60,8 @@ type StartupReconciler struct {
 	Logger         logr.Logger
 	Timeout        time.Duration
 	InitialBackoff time.Duration
+	EventRecorder  record.EventRecorder
+	AuditStore     audit.AuditStore
 }
 
 // NeedLeaderElection returns false so the reconciler runs on every replica,
@@ -165,11 +171,20 @@ func (r *StartupReconciler) syncWorkflows(ctx context.Context, logger logr.Logge
 
 	logger.Info("Syncing RemediationWorkflow CRDs with DS", "count", len(rwList.Items))
 
+	var succeeded, failed int
 	for i := range rwList.Items {
 		rw := &rwList.Items[i]
 		if err := r.syncWorkflowCRD(ctx, logger, rw, deadline); err != nil {
-			return err
+			failed++
+		} else {
+			succeeded++
 		}
+	}
+
+	if failed > 0 {
+		logger.Error(fmt.Errorf("%d workflow(s) failed registration", failed),
+			"Startup reconciliation completed with degraded workflows",
+			"succeeded", succeeded, "failed", failed)
 	}
 	return nil
 }
@@ -179,42 +194,144 @@ func (r *StartupReconciler) syncWorkflowCRD(ctx context.Context, logger logr.Log
 
 	content, err := marshalCleanCRDContent(rw)
 	if err != nil {
-		return fmt.Errorf("failed to marshal workflow %q for DS: %w", rw.Name, err)
+		r.markWorkflowFailed(ctx, rwLogger, rw, rwv1alpha1.ReasonValidationFailed,
+			fmt.Sprintf("failed to marshal workflow: %v", err))
+		return err
 	}
 
 	backoff := r.InitialBackoff
 	for {
-		result, err := r.DSWorkflow.CreateWorkflowInline(ctx, string(content), "crd-startup-reconcile", startupRegisteredBy)
+		result, err := r.DSWorkflow.CreateWorkflowInline(ctx, string(content), rw.Name, startupRegisteredBy)
 		if err == nil {
 			rwLogger.Info("Workflow synced with DS",
 				"workflow_id", result.WorkflowID,
 				"status", result.Status,
 				"previously_existed", result.PreviouslyExisted,
 			)
-
-			rw.Status.WorkflowID = result.WorkflowID
-			rw.Status.CatalogStatus = sharedtypes.CatalogStatus(result.Status)
-			rw.Status.RegisteredBy = startupRegisteredBy
-			now := metav1.Now()
-			rw.Status.RegisteredAt = &now
-			rw.Status.PreviouslyExisted = result.PreviouslyExisted
-
-			if statusErr := r.K8sClient.Status().Update(ctx, rw); statusErr != nil {
-				rwLogger.Error(statusErr, "Failed to update RemediationWorkflow CRD status")
-			}
+			r.markWorkflowSucceeded(ctx, rwLogger, rw, result)
 			return nil
 		}
 
+		if IsPermanentError(err) {
+			rwLogger.Error(err, "Workflow registration permanently failed — marking as Disabled",
+				"remediation", "fix the referenced dependency and re-apply the RW CR")
+			r.markWorkflowFailed(ctx, rwLogger, rw, rwv1alpha1.ReasonDependencyMissing, err.Error())
+			return err
+		}
+
 		if time.Now().Add(backoff).After(deadline) {
-			return fmt.Errorf("DS unavailable for Workflow %q after retries: %w", rw.Name, err)
+			rwLogger.Error(err, "DS unavailable for workflow after retries — marking as Disabled",
+				"remediation", "ensure DataStorage is reachable and re-apply the RW CR")
+			r.markWorkflowFailed(ctx, rwLogger, rw, rwv1alpha1.ReasonDataStorageError,
+				fmt.Sprintf("DS unavailable after retries: %v", err))
+			return err
 		}
 
 		rwLogger.Info("DS unavailable, retrying", "backoff", backoff, "error", err)
 		select {
 		case <-ctx.Done():
+			r.markWorkflowFailed(ctx, rwLogger, rw, rwv1alpha1.ReasonDataStorageError, "context cancelled")
 			return fmt.Errorf("context cancelled while syncing Workflow %q: %w", rw.Name, ctx.Err())
 		case <-time.After(backoff):
 			backoff *= 2
 		}
 	}
+}
+
+func (r *StartupReconciler) markWorkflowSucceeded(ctx context.Context, logger logr.Logger, rw *rwv1alpha1.RemediationWorkflow, result *WorkflowRegistrationResult) {
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		fresh := &rwv1alpha1.RemediationWorkflow{}
+		if getErr := r.K8sClient.Get(ctx, client.ObjectKeyFromObject(rw), fresh); getErr != nil {
+			return getErr
+		}
+
+		now := metav1.Now()
+		fresh.Status.WorkflowID = result.WorkflowID
+		fresh.Status.CatalogStatus = sharedtypes.CatalogStatus(result.Status)
+		fresh.Status.RegisteredBy = startupRegisteredBy
+		fresh.Status.RegisteredAt = &now
+		fresh.Status.PreviouslyExisted = result.PreviouslyExisted
+		setCondition(&fresh.Status.Conditions, metav1.Condition{
+			Type:               rwv1alpha1.ConditionReady,
+			Status:             metav1.ConditionTrue,
+			Reason:             rwv1alpha1.ReasonRegistered,
+			Message:            "Workflow registered successfully in DataStorage catalog",
+			LastTransitionTime: now,
+		})
+		return r.K8sClient.Status().Update(ctx, fresh)
+	})
+	if err != nil {
+		logger.Error(err, "Failed to update RemediationWorkflow CRD status")
+	}
+}
+
+func (r *StartupReconciler) markWorkflowFailed(ctx context.Context, logger logr.Logger, rw *rwv1alpha1.RemediationWorkflow, reason, message string) {
+	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
+		fresh := &rwv1alpha1.RemediationWorkflow{}
+		if getErr := r.K8sClient.Get(ctx, client.ObjectKeyFromObject(rw), fresh); getErr != nil {
+			return getErr
+		}
+
+		now := metav1.Now()
+		fresh.Status.CatalogStatus = sharedtypes.CatalogStatusDisabled
+		setCondition(&fresh.Status.Conditions, metav1.Condition{
+			Type:               rwv1alpha1.ConditionReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             reason,
+			Message:            message,
+			LastTransitionTime: now,
+		})
+		return r.K8sClient.Status().Update(ctx, fresh)
+	})
+	if err != nil {
+		logger.Error(err, "Failed to update RemediationWorkflow CRD status to Disabled")
+	}
+
+	if r.EventRecorder != nil {
+		r.EventRecorder.Eventf(rw, "Warning", "RegistrationFailed",
+			"Workflow registration failed: %s", message)
+	}
+
+	r.emitRegistrationFailedAudit(ctx, rw, reason, message)
+}
+
+// setCondition adds or updates a condition in the slice by type.
+func setCondition(conditions *[]metav1.Condition, cond metav1.Condition) {
+	for i, existing := range *conditions {
+		if existing.Type == cond.Type {
+			(*conditions)[i] = cond
+			return
+		}
+	}
+	*conditions = append(*conditions, cond)
+}
+
+// emitRegistrationFailedAudit emits an audit event when a workflow fails registration
+// during startup reconciliation. Uses best-effort semantics (audit failure doesn't
+// block startup). Category: "workflow", EventType: "authwebhook.workflow.registration_failed".
+func (r *StartupReconciler) emitRegistrationFailedAudit(ctx context.Context, rw *rwv1alpha1.RemediationWorkflow, reason, message string) {
+	if r.AuditStore == nil {
+		return
+	}
+
+	event := audit.NewAuditEventRequest()
+	audit.SetEventType(event, EventTypeRWRegistrationFailed)
+	audit.SetEventCategory(event, EventCategoryWorkflow)
+	audit.SetEventAction(event, "registration_failed")
+	audit.SetEventOutcome(event, ogenclient.AuditEventRequestEventOutcomeFailure)
+	audit.SetActor(event, "system", startupRegisteredBy)
+	audit.SetResource(event, "RemediationWorkflow", rw.Name)
+	audit.SetNamespace(event, rw.Namespace)
+	audit.SetSeverity(event, "high")
+
+	payload := ogenclient.AuthwebhookWorkflowRegistrationFailedPayload{
+		EventType:    ogenclient.AuthwebhookWorkflowRegistrationFailedPayloadEventTypeAuthwebhookWorkflowRegistrationFailed,
+		WorkflowName: rw.Name,
+		Reason:       ogenclient.AuthwebhookWorkflowRegistrationFailedPayloadReason(reason),
+		Message:      message,
+	}
+	payload.Namespace.SetTo(rw.Namespace)
+	event.EventData = ogenclient.NewAuthwebhookWorkflowRegistrationFailedPayloadAuditEventRequestEventData(payload)
+
+	storeAuditBestEffort(ctx, r.AuditStore, event, "startup-reconciler", EventTypeRWRegistrationFailed)
 }

--- a/pkg/authwebhook/types.go
+++ b/pkg/authwebhook/types.go
@@ -19,6 +19,9 @@ const (
 	EventTypeRWAdmittedDelete = "remediationworkflow.admitted.delete"
 	EventTypeRWAdmittedDenied = "remediationworkflow.admitted.denied"
 
+	// Issue #1246: Startup reconciler graceful degradation audit events
+	EventTypeRWRegistrationFailed = "authwebhook.workflow.registration_failed"
+
 	// ADR-059: ActionType CRD admission event types (BR-WORKFLOW-007)
 	EventTypeATAdmittedCreate = "actiontype.admitted.create"
 	EventTypeATAdmittedUpdate = "actiontype.admitted.update"

--- a/pkg/datastorage/ogen-client/oas_json_gen.go
+++ b/pkg/datastorage/ogen-client/oas_json_gen.go
@@ -17723,6 +17723,30 @@ func (s AuditEventEventData) encodeFields(e *jx.Encoder) {
 				}
 			}
 		}
+	case AuthwebhookWorkflowRegistrationFailedPayloadAuditEventEventData:
+		e.FieldStart("event_type")
+		e.Str("authwebhook.workflow.registration_failed")
+		{
+			s := s.AuthwebhookWorkflowRegistrationFailedPayload
+			{
+				e.FieldStart("workflow_name")
+				e.Str(s.WorkflowName)
+			}
+			{
+				if s.Namespace.Set {
+					e.FieldStart("namespace")
+					s.Namespace.Encode(e)
+				}
+			}
+			{
+				e.FieldStart("reason")
+				s.Reason.Encode(e)
+			}
+			{
+				e.FieldStart("message")
+				e.Str(s.Message)
+			}
+		}
 	case AuditEventEventDataEffectivenessAlertAssessedAuditEventEventData, AuditEventEventDataEffectivenessAlertDecayDetectedAuditEventEventData, AuditEventEventDataEffectivenessAssessmentCompletedAuditEventEventData, AuditEventEventDataEffectivenessAssessmentScheduledAuditEventEventData, AuditEventEventDataEffectivenessHashComputedAuditEventEventData, AuditEventEventDataEffectivenessHealthAssessedAuditEventEventData, AuditEventEventDataEffectivenessMetricsAssessedAuditEventEventData:
 		switch s.Type {
 		case AuditEventEventDataEffectivenessAlertAssessedAuditEventEventData:
@@ -19155,6 +19179,9 @@ func (s *AuditEventEventData) Decode(d *jx.Decoder) error {
 				case "remediationworkflow.admitted.update":
 					s.Type = AuditEventEventDataRemediationworkflowAdmittedUpdateAuditEventEventData
 					found = true
+				case "authwebhook.workflow.registration_failed":
+					s.Type = AuthwebhookWorkflowRegistrationFailedPayloadAuditEventEventData
+					found = true
 				case "effectiveness.alert.assessed":
 					s.Type = AuditEventEventDataEffectivenessAlertAssessedAuditEventEventData
 					found = true
@@ -19503,6 +19530,10 @@ func (s *AuditEventEventData) Decode(d *jx.Decoder) error {
 		}
 	case AuditEventEventDataRemediationworkflowAdmittedCreateAuditEventEventData, AuditEventEventDataRemediationworkflowAdmittedDeleteAuditEventEventData, AuditEventEventDataRemediationworkflowAdmittedDeniedAuditEventEventData, AuditEventEventDataRemediationworkflowAdmittedUpdateAuditEventEventData:
 		if err := s.RemediationWorkflowWebhookAuditPayload.Decode(d); err != nil {
+			return err
+		}
+	case AuthwebhookWorkflowRegistrationFailedPayloadAuditEventEventData:
+		if err := s.AuthwebhookWorkflowRegistrationFailedPayload.Decode(d); err != nil {
 			return err
 		}
 	case AuditEventEventDataEffectivenessAlertAssessedAuditEventEventData, AuditEventEventDataEffectivenessAlertDecayDetectedAuditEventEventData, AuditEventEventDataEffectivenessAssessmentCompletedAuditEventEventData, AuditEventEventDataEffectivenessAssessmentScheduledAuditEventEventData, AuditEventEventDataEffectivenessHashComputedAuditEventEventData, AuditEventEventDataEffectivenessHealthAssessedAuditEventEventData, AuditEventEventDataEffectivenessMetricsAssessedAuditEventEventData:
@@ -22439,6 +22470,30 @@ func (s AuditEventRequestEventData) encodeFields(e *jx.Encoder) {
 				}
 			}
 		}
+	case AuthwebhookWorkflowRegistrationFailedPayloadAuditEventRequestEventData:
+		e.FieldStart("event_type")
+		e.Str("authwebhook.workflow.registration_failed")
+		{
+			s := s.AuthwebhookWorkflowRegistrationFailedPayload
+			{
+				e.FieldStart("workflow_name")
+				e.Str(s.WorkflowName)
+			}
+			{
+				if s.Namespace.Set {
+					e.FieldStart("namespace")
+					s.Namespace.Encode(e)
+				}
+			}
+			{
+				e.FieldStart("reason")
+				s.Reason.Encode(e)
+			}
+			{
+				e.FieldStart("message")
+				e.Str(s.Message)
+			}
+		}
 	case AuditEventRequestEventDataEffectivenessAlertAssessedAuditEventRequestEventData, AuditEventRequestEventDataEffectivenessAlertDecayDetectedAuditEventRequestEventData, AuditEventRequestEventDataEffectivenessAssessmentCompletedAuditEventRequestEventData, AuditEventRequestEventDataEffectivenessAssessmentScheduledAuditEventRequestEventData, AuditEventRequestEventDataEffectivenessHashComputedAuditEventRequestEventData, AuditEventRequestEventDataEffectivenessHealthAssessedAuditEventRequestEventData, AuditEventRequestEventDataEffectivenessMetricsAssessedAuditEventRequestEventData:
 		switch s.Type {
 		case AuditEventRequestEventDataEffectivenessAlertAssessedAuditEventRequestEventData:
@@ -23871,6 +23926,9 @@ func (s *AuditEventRequestEventData) Decode(d *jx.Decoder) error {
 				case "remediationworkflow.admitted.update":
 					s.Type = AuditEventRequestEventDataRemediationworkflowAdmittedUpdateAuditEventRequestEventData
 					found = true
+				case "authwebhook.workflow.registration_failed":
+					s.Type = AuthwebhookWorkflowRegistrationFailedPayloadAuditEventRequestEventData
+					found = true
 				case "effectiveness.alert.assessed":
 					s.Type = AuditEventRequestEventDataEffectivenessAlertAssessedAuditEventRequestEventData
 					found = true
@@ -24219,6 +24277,10 @@ func (s *AuditEventRequestEventData) Decode(d *jx.Decoder) error {
 		}
 	case AuditEventRequestEventDataRemediationworkflowAdmittedCreateAuditEventRequestEventData, AuditEventRequestEventDataRemediationworkflowAdmittedDeleteAuditEventRequestEventData, AuditEventRequestEventDataRemediationworkflowAdmittedDeniedAuditEventRequestEventData, AuditEventRequestEventDataRemediationworkflowAdmittedUpdateAuditEventRequestEventData:
 		if err := s.RemediationWorkflowWebhookAuditPayload.Decode(d); err != nil {
+			return err
+		}
+	case AuthwebhookWorkflowRegistrationFailedPayloadAuditEventRequestEventData:
+		if err := s.AuthwebhookWorkflowRegistrationFailedPayload.Decode(d); err != nil {
 			return err
 		}
 	case AuditEventRequestEventDataEffectivenessAlertAssessedAuditEventRequestEventData, AuditEventRequestEventDataEffectivenessAlertDecayDetectedAuditEventRequestEventData, AuditEventRequestEventDataEffectivenessAssessmentCompletedAuditEventRequestEventData, AuditEventRequestEventDataEffectivenessAssessmentScheduledAuditEventRequestEventData, AuditEventRequestEventDataEffectivenessHashComputedAuditEventRequestEventData, AuditEventRequestEventDataEffectivenessHealthAssessedAuditEventRequestEventData, AuditEventRequestEventDataEffectivenessMetricsAssessedAuditEventRequestEventData:
@@ -25832,6 +25894,246 @@ func (s *AuditExportResponseHashChainVerification) MarshalJSON() ([]byte, error)
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *AuditExportResponseHashChainVerification) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *AuthwebhookWorkflowRegistrationFailedPayload) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *AuthwebhookWorkflowRegistrationFailedPayload) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("event_type")
+		s.EventType.Encode(e)
+	}
+	{
+		e.FieldStart("workflow_name")
+		e.Str(s.WorkflowName)
+	}
+	{
+		if s.Namespace.Set {
+			e.FieldStart("namespace")
+			s.Namespace.Encode(e)
+		}
+	}
+	{
+		e.FieldStart("reason")
+		s.Reason.Encode(e)
+	}
+	{
+		e.FieldStart("message")
+		e.Str(s.Message)
+	}
+}
+
+var jsonFieldsNameOfAuthwebhookWorkflowRegistrationFailedPayload = [5]string{
+	0: "event_type",
+	1: "workflow_name",
+	2: "namespace",
+	3: "reason",
+	4: "message",
+}
+
+// Decode decodes AuthwebhookWorkflowRegistrationFailedPayload from json.
+func (s *AuthwebhookWorkflowRegistrationFailedPayload) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AuthwebhookWorkflowRegistrationFailedPayload to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "event_type":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.EventType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "workflow_name":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.WorkflowName = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"workflow_name\"")
+			}
+		case "namespace":
+			if err := func() error {
+				s.Namespace.Reset()
+				if err := s.Namespace.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"namespace\"")
+			}
+		case "reason":
+			requiredBitSet[0] |= 1 << 3
+			if err := func() error {
+				if err := s.Reason.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"reason\"")
+			}
+		case "message":
+			requiredBitSet[0] |= 1 << 4
+			if err := func() error {
+				v, err := d.Str()
+				s.Message = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"message\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode AuthwebhookWorkflowRegistrationFailedPayload")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00011011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfAuthwebhookWorkflowRegistrationFailedPayload) {
+					name = jsonFieldsNameOfAuthwebhookWorkflowRegistrationFailedPayload[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *AuthwebhookWorkflowRegistrationFailedPayload) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AuthwebhookWorkflowRegistrationFailedPayload) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes AuthwebhookWorkflowRegistrationFailedPayloadEventType as json.
+func (s AuthwebhookWorkflowRegistrationFailedPayloadEventType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes AuthwebhookWorkflowRegistrationFailedPayloadEventType from json.
+func (s *AuthwebhookWorkflowRegistrationFailedPayloadEventType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AuthwebhookWorkflowRegistrationFailedPayloadEventType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch AuthwebhookWorkflowRegistrationFailedPayloadEventType(v) {
+	case AuthwebhookWorkflowRegistrationFailedPayloadEventTypeAuthwebhookWorkflowRegistrationFailed:
+		*s = AuthwebhookWorkflowRegistrationFailedPayloadEventTypeAuthwebhookWorkflowRegistrationFailed
+	default:
+		*s = AuthwebhookWorkflowRegistrationFailedPayloadEventType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s AuthwebhookWorkflowRegistrationFailedPayloadEventType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AuthwebhookWorkflowRegistrationFailedPayloadEventType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes AuthwebhookWorkflowRegistrationFailedPayloadReason as json.
+func (s AuthwebhookWorkflowRegistrationFailedPayloadReason) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes AuthwebhookWorkflowRegistrationFailedPayloadReason from json.
+func (s *AuthwebhookWorkflowRegistrationFailedPayloadReason) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AuthwebhookWorkflowRegistrationFailedPayloadReason to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch AuthwebhookWorkflowRegistrationFailedPayloadReason(v) {
+	case AuthwebhookWorkflowRegistrationFailedPayloadReasonDependencyMissing:
+		*s = AuthwebhookWorkflowRegistrationFailedPayloadReasonDependencyMissing
+	case AuthwebhookWorkflowRegistrationFailedPayloadReasonDataStorageError:
+		*s = AuthwebhookWorkflowRegistrationFailedPayloadReasonDataStorageError
+	case AuthwebhookWorkflowRegistrationFailedPayloadReasonValidationFailed:
+		*s = AuthwebhookWorkflowRegistrationFailedPayloadReasonValidationFailed
+	default:
+		*s = AuthwebhookWorkflowRegistrationFailedPayloadReason(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s AuthwebhookWorkflowRegistrationFailedPayloadReason) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AuthwebhookWorkflowRegistrationFailedPayloadReason) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/pkg/datastorage/ogen-client/oas_schemas_gen.go
+++ b/pkg/datastorage/ogen-client/oas_schemas_gen.go
@@ -8081,92 +8081,93 @@ func (s *AuditEventEventCategory) UnmarshalText(data []byte) error {
 // See DD-AUDIT-004 for structured type requirements.
 // AuditEventEventData represents sum type.
 type AuditEventEventData struct {
-	Type                                      AuditEventEventDataType // switch on this field
-	GatewayAuditPayload                       GatewayAuditPayload
-	RemediationOrchestratorAuditPayload       RemediationOrchestratorAuditPayload
-	SignalProcessingAuditPayload              SignalProcessingAuditPayload
-	AIAnalysisAuditPayload                    AIAnalysisAuditPayload
-	WorkflowExecutionAuditPayload             WorkflowExecutionAuditPayload
-	NotificationAuditPayload                  NotificationAuditPayload
-	WorkflowExecutionWebhookAuditPayload      WorkflowExecutionWebhookAuditPayload
-	RemediationApprovalAuditPayload           RemediationApprovalAuditPayload
-	RemediationApprovalDecisionPayload        RemediationApprovalDecisionPayload
-	WorkflowDiscoveryAuditPayload             WorkflowDiscoveryAuditPayload
-	WorkflowCatalogCreatedPayload             WorkflowCatalogCreatedPayload
-	WorkflowCatalogUpdatedPayload             WorkflowCatalogUpdatedPayload
-	AIAnalysisPhaseTransitionPayload          AIAnalysisPhaseTransitionPayload
-	AIAnalysisAIAgentCallPayload              AIAnalysisAIAgentCallPayload
-	AIAnalysisApprovalDecisionPayload         AIAnalysisApprovalDecisionPayload
-	AIAnalysisRegoEvaluationPayload           AIAnalysisRegoEvaluationPayload
-	AIAnalysisErrorPayload                    AIAnalysisErrorPayload
-	NotificationMessageSentPayload            NotificationMessageSentPayload
-	NotificationMessageFailedPayload          NotificationMessageFailedPayload
-	NotificationMessageAcknowledgedPayload    NotificationMessageAcknowledgedPayload
-	NotificationMessageEscalatedPayload       NotificationMessageEscalatedPayload
-	AIAgentResponsePayload                    AIAgentResponsePayload
-	AIAgentRCACompletePayload                 AIAgentRCACompletePayload
-	AIAgentResponseFailedPayload              AIAgentResponseFailedPayload
-	AIAgentEnrichmentCompletedPayload         AIAgentEnrichmentCompletedPayload
-	AIAgentEnrichmentFailedPayload            AIAgentEnrichmentFailedPayload
-	LLMRequestPayload                         LLMRequestPayload
-	LLMResponsePayload                        LLMResponsePayload
-	LLMToolCallPayload                        LLMToolCallPayload
-	WorkflowValidationPayload                 WorkflowValidationPayload
-	AIAgentSessionStartedPayload              AIAgentSessionStartedPayload
-	AIAgentSessionCompletedPayload            AIAgentSessionCompletedPayload
-	AIAgentSessionFailedPayload               AIAgentSessionFailedPayload
-	AIAgentSessionCancelledPayload            AIAgentSessionCancelledPayload
-	AIAgentSessionSuspendedPayload            AIAgentSessionSuspendedPayload
-	AIAgentSessionResumedPayload              AIAgentSessionResumedPayload
-	AIAgentInteractiveStartedPayload          AIAgentInteractiveStartedPayload
-	AIAgentInteractiveCompletedPayload        AIAgentInteractiveCompletedPayload
-	AIAgentInteractiveK8sCallPayload          AIAgentInteractiveK8sCallPayload
-	AIAgentSessionObservedPayload             AIAgentSessionObservedPayload
-	AIAgentSessionAccessDeniedPayload         AIAgentSessionAccessDeniedPayload
-	AIAgentInvestigationCancelledPayload      AIAgentInvestigationCancelledPayload
-	AIAgentAlignmentStepPayload               AIAgentAlignmentStepPayload
-	AIAgentAlignmentVerdictPayload            AIAgentAlignmentVerdictPayload
-	ShadowLLMRequestPayload                   ShadowLLMRequestPayload
-	ShadowLLMResponsePayload                  ShadowLLMResponsePayload
-	RemediationRequestWebhookAuditPayload     RemediationRequestWebhookAuditPayload
-	RemediationWorkflowWebhookAuditPayload    RemediationWorkflowWebhookAuditPayload
-	EffectivenessAssessmentAuditPayload       EffectivenessAssessmentAuditPayload
-	ActionTypeCatalogCreatedPayload           ActionTypeCatalogCreatedPayload
-	ActionTypeCatalogUpdatedPayload           ActionTypeCatalogUpdatedPayload
-	ActionTypeCatalogDisabledPayload          ActionTypeCatalogDisabledPayload
-	ActionTypeCatalogReenabledPayload         ActionTypeCatalogReenabledPayload
-	ActionTypeCatalogDisableDeniedPayload     ActionTypeCatalogDisableDeniedPayload
-	ActionTypeWebhookAuditPayload             ActionTypeWebhookAuditPayload
-	ApifrontendTriageStartedPayload           ApifrontendTriageStartedPayload
-	ApifrontendTriageCompletedPayload         ApifrontendTriageCompletedPayload
-	ApifrontendRRCreatedPayload               ApifrontendRRCreatedPayload
-	ApifrontendRRDeduplicatedPayload          ApifrontendRRDeduplicatedPayload
-	ApifrontendSessionCreatedPayload          ApifrontendSessionCreatedPayload
-	ApifrontendSessionCompletedPayload        ApifrontendSessionCompletedPayload
-	ApifrontendKADelegatedPayload             ApifrontendKADelegatedPayload
-	ApifrontendKAResultReceivedPayload        ApifrontendKAResultReceivedPayload
-	ApifrontendUserDecisionPayload            ApifrontendUserDecisionPayload
-	ApifrontendAuthAccessDeniedPayload        ApifrontendAuthAccessDeniedPayload
-	ApifrontendToolExecutedPayload            ApifrontendToolExecutedPayload
-	ApifrontendAuthSuccessPayload             ApifrontendAuthSuccessPayload
-	ApifrontendAuthFailurePayload             ApifrontendAuthFailurePayload
-	ApifrontendRatelimitDeniedPayload         ApifrontendRatelimitDeniedPayload
-	ApifrontendCircuitbreakerTripPayload      ApifrontendCircuitbreakerTripPayload
-	ApifrontendImpersonationCreatedPayload    ApifrontendImpersonationCreatedPayload
-	ApifrontendJWTDelegationPayload           ApifrontendJWTDelegationPayload
-	ApifrontendSessionPhaseChangedPayload     ApifrontendSessionPhaseChangedPayload
-	ApifrontendSessionDeletedPayload          ApifrontendSessionDeletedPayload
-	ApifrontendSessionAutoCancelledPayload    ApifrontendSessionAutoCancelledPayload
-	ApifrontendSessionRetentionDeletedPayload ApifrontendSessionRetentionDeletedPayload
-	ApifrontendA2ATaskStartedPayload          ApifrontendA2ATaskStartedPayload
-	ApifrontendA2ATaskCompletedPayload        ApifrontendA2ATaskCompletedPayload
-	ApifrontendA2ATaskFailedPayload           ApifrontendA2ATaskFailedPayload
-	ApifrontendMCPToolFailedPayload           ApifrontendMCPToolFailedPayload
-	ApifrontendMCPSessionInitPayload          ApifrontendMCPSessionInitPayload
-	ApifrontendSeverityTriageCompletedPayload ApifrontendSeverityTriageCompletedPayload
-	ApifrontendSeverityTriageFailedPayload    ApifrontendSeverityTriageFailedPayload
-	ApifrontendConfigReloadedPayload          ApifrontendConfigReloadedPayload
-	ApifrontendConfigRejectedPayload          ApifrontendConfigRejectedPayload
+	Type                                         AuditEventEventDataType // switch on this field
+	GatewayAuditPayload                          GatewayAuditPayload
+	RemediationOrchestratorAuditPayload          RemediationOrchestratorAuditPayload
+	SignalProcessingAuditPayload                 SignalProcessingAuditPayload
+	AIAnalysisAuditPayload                       AIAnalysisAuditPayload
+	WorkflowExecutionAuditPayload                WorkflowExecutionAuditPayload
+	NotificationAuditPayload                     NotificationAuditPayload
+	WorkflowExecutionWebhookAuditPayload         WorkflowExecutionWebhookAuditPayload
+	RemediationApprovalAuditPayload              RemediationApprovalAuditPayload
+	RemediationApprovalDecisionPayload           RemediationApprovalDecisionPayload
+	WorkflowDiscoveryAuditPayload                WorkflowDiscoveryAuditPayload
+	WorkflowCatalogCreatedPayload                WorkflowCatalogCreatedPayload
+	WorkflowCatalogUpdatedPayload                WorkflowCatalogUpdatedPayload
+	AIAnalysisPhaseTransitionPayload             AIAnalysisPhaseTransitionPayload
+	AIAnalysisAIAgentCallPayload                 AIAnalysisAIAgentCallPayload
+	AIAnalysisApprovalDecisionPayload            AIAnalysisApprovalDecisionPayload
+	AIAnalysisRegoEvaluationPayload              AIAnalysisRegoEvaluationPayload
+	AIAnalysisErrorPayload                       AIAnalysisErrorPayload
+	NotificationMessageSentPayload               NotificationMessageSentPayload
+	NotificationMessageFailedPayload             NotificationMessageFailedPayload
+	NotificationMessageAcknowledgedPayload       NotificationMessageAcknowledgedPayload
+	NotificationMessageEscalatedPayload          NotificationMessageEscalatedPayload
+	AIAgentResponsePayload                       AIAgentResponsePayload
+	AIAgentRCACompletePayload                    AIAgentRCACompletePayload
+	AIAgentResponseFailedPayload                 AIAgentResponseFailedPayload
+	AIAgentEnrichmentCompletedPayload            AIAgentEnrichmentCompletedPayload
+	AIAgentEnrichmentFailedPayload               AIAgentEnrichmentFailedPayload
+	LLMRequestPayload                            LLMRequestPayload
+	LLMResponsePayload                           LLMResponsePayload
+	LLMToolCallPayload                           LLMToolCallPayload
+	WorkflowValidationPayload                    WorkflowValidationPayload
+	AIAgentSessionStartedPayload                 AIAgentSessionStartedPayload
+	AIAgentSessionCompletedPayload               AIAgentSessionCompletedPayload
+	AIAgentSessionFailedPayload                  AIAgentSessionFailedPayload
+	AIAgentSessionCancelledPayload               AIAgentSessionCancelledPayload
+	AIAgentSessionSuspendedPayload               AIAgentSessionSuspendedPayload
+	AIAgentSessionResumedPayload                 AIAgentSessionResumedPayload
+	AIAgentInteractiveStartedPayload             AIAgentInteractiveStartedPayload
+	AIAgentInteractiveCompletedPayload           AIAgentInteractiveCompletedPayload
+	AIAgentInteractiveK8sCallPayload             AIAgentInteractiveK8sCallPayload
+	AIAgentSessionObservedPayload                AIAgentSessionObservedPayload
+	AIAgentSessionAccessDeniedPayload            AIAgentSessionAccessDeniedPayload
+	AIAgentInvestigationCancelledPayload         AIAgentInvestigationCancelledPayload
+	AIAgentAlignmentStepPayload                  AIAgentAlignmentStepPayload
+	AIAgentAlignmentVerdictPayload               AIAgentAlignmentVerdictPayload
+	ShadowLLMRequestPayload                      ShadowLLMRequestPayload
+	ShadowLLMResponsePayload                     ShadowLLMResponsePayload
+	RemediationRequestWebhookAuditPayload        RemediationRequestWebhookAuditPayload
+	RemediationWorkflowWebhookAuditPayload       RemediationWorkflowWebhookAuditPayload
+	AuthwebhookWorkflowRegistrationFailedPayload AuthwebhookWorkflowRegistrationFailedPayload
+	EffectivenessAssessmentAuditPayload          EffectivenessAssessmentAuditPayload
+	ActionTypeCatalogCreatedPayload              ActionTypeCatalogCreatedPayload
+	ActionTypeCatalogUpdatedPayload              ActionTypeCatalogUpdatedPayload
+	ActionTypeCatalogDisabledPayload             ActionTypeCatalogDisabledPayload
+	ActionTypeCatalogReenabledPayload            ActionTypeCatalogReenabledPayload
+	ActionTypeCatalogDisableDeniedPayload        ActionTypeCatalogDisableDeniedPayload
+	ActionTypeWebhookAuditPayload                ActionTypeWebhookAuditPayload
+	ApifrontendTriageStartedPayload              ApifrontendTriageStartedPayload
+	ApifrontendTriageCompletedPayload            ApifrontendTriageCompletedPayload
+	ApifrontendRRCreatedPayload                  ApifrontendRRCreatedPayload
+	ApifrontendRRDeduplicatedPayload             ApifrontendRRDeduplicatedPayload
+	ApifrontendSessionCreatedPayload             ApifrontendSessionCreatedPayload
+	ApifrontendSessionCompletedPayload           ApifrontendSessionCompletedPayload
+	ApifrontendKADelegatedPayload                ApifrontendKADelegatedPayload
+	ApifrontendKAResultReceivedPayload           ApifrontendKAResultReceivedPayload
+	ApifrontendUserDecisionPayload               ApifrontendUserDecisionPayload
+	ApifrontendAuthAccessDeniedPayload           ApifrontendAuthAccessDeniedPayload
+	ApifrontendToolExecutedPayload               ApifrontendToolExecutedPayload
+	ApifrontendAuthSuccessPayload                ApifrontendAuthSuccessPayload
+	ApifrontendAuthFailurePayload                ApifrontendAuthFailurePayload
+	ApifrontendRatelimitDeniedPayload            ApifrontendRatelimitDeniedPayload
+	ApifrontendCircuitbreakerTripPayload         ApifrontendCircuitbreakerTripPayload
+	ApifrontendImpersonationCreatedPayload       ApifrontendImpersonationCreatedPayload
+	ApifrontendJWTDelegationPayload              ApifrontendJWTDelegationPayload
+	ApifrontendSessionPhaseChangedPayload        ApifrontendSessionPhaseChangedPayload
+	ApifrontendSessionDeletedPayload             ApifrontendSessionDeletedPayload
+	ApifrontendSessionAutoCancelledPayload       ApifrontendSessionAutoCancelledPayload
+	ApifrontendSessionRetentionDeletedPayload    ApifrontendSessionRetentionDeletedPayload
+	ApifrontendA2ATaskStartedPayload             ApifrontendA2ATaskStartedPayload
+	ApifrontendA2ATaskCompletedPayload           ApifrontendA2ATaskCompletedPayload
+	ApifrontendA2ATaskFailedPayload              ApifrontendA2ATaskFailedPayload
+	ApifrontendMCPToolFailedPayload              ApifrontendMCPToolFailedPayload
+	ApifrontendMCPSessionInitPayload             ApifrontendMCPSessionInitPayload
+	ApifrontendSeverityTriageCompletedPayload    ApifrontendSeverityTriageCompletedPayload
+	ApifrontendSeverityTriageFailedPayload       ApifrontendSeverityTriageFailedPayload
+	ApifrontendConfigReloadedPayload             ApifrontendConfigReloadedPayload
+	ApifrontendConfigRejectedPayload             ApifrontendConfigRejectedPayload
 }
 
 // AuditEventEventDataType is oneOf type of AuditEventEventData.
@@ -8259,6 +8260,7 @@ const (
 	AuditEventEventDataRemediationworkflowAdmittedDeleteAuditEventEventData          AuditEventEventDataType = "remediationworkflow.admitted.delete"
 	AuditEventEventDataRemediationworkflowAdmittedDeniedAuditEventEventData          AuditEventEventDataType = "remediationworkflow.admitted.denied"
 	AuditEventEventDataRemediationworkflowAdmittedUpdateAuditEventEventData          AuditEventEventDataType = "remediationworkflow.admitted.update"
+	AuthwebhookWorkflowRegistrationFailedPayloadAuditEventEventData                  AuditEventEventDataType = "authwebhook.workflow.registration_failed"
 	AuditEventEventDataEffectivenessAlertAssessedAuditEventEventData                 AuditEventEventDataType = "effectiveness.alert.assessed"
 	AuditEventEventDataEffectivenessAlertDecayDetectedAuditEventEventData            AuditEventEventDataType = "effectiveness.alert_decay.detected"
 	AuditEventEventDataEffectivenessAssessmentCompletedAuditEventEventData           AuditEventEventDataType = "effectiveness.assessment.completed"
@@ -8592,6 +8594,11 @@ func (s AuditEventEventData) IsRemediationWorkflowWebhookAuditPayload() bool {
 	default:
 		return false
 	}
+}
+
+// IsAuthwebhookWorkflowRegistrationFailedPayload reports whether AuditEventEventData is AuthwebhookWorkflowRegistrationFailedPayload.
+func (s AuditEventEventData) IsAuthwebhookWorkflowRegistrationFailedPayload() bool {
+	return s.Type == AuthwebhookWorkflowRegistrationFailedPayloadAuditEventEventData
 }
 
 // IsEffectivenessAssessmentAuditPayload reports whether AuditEventEventData is EffectivenessAssessmentAuditPayload.
@@ -10092,6 +10099,27 @@ func NewAuditEventEventDataRemediationworkflowAdmittedUpdateAuditEventEventData(
 	return s
 }
 
+// SetAuthwebhookWorkflowRegistrationFailedPayload sets AuditEventEventData to AuthwebhookWorkflowRegistrationFailedPayload.
+func (s *AuditEventEventData) SetAuthwebhookWorkflowRegistrationFailedPayload(v AuthwebhookWorkflowRegistrationFailedPayload) {
+	s.Type = AuthwebhookWorkflowRegistrationFailedPayloadAuditEventEventData
+	s.AuthwebhookWorkflowRegistrationFailedPayload = v
+}
+
+// GetAuthwebhookWorkflowRegistrationFailedPayload returns AuthwebhookWorkflowRegistrationFailedPayload and true boolean if AuditEventEventData is AuthwebhookWorkflowRegistrationFailedPayload.
+func (s AuditEventEventData) GetAuthwebhookWorkflowRegistrationFailedPayload() (v AuthwebhookWorkflowRegistrationFailedPayload, ok bool) {
+	if !s.IsAuthwebhookWorkflowRegistrationFailedPayload() {
+		return v, false
+	}
+	return s.AuthwebhookWorkflowRegistrationFailedPayload, true
+}
+
+// NewAuthwebhookWorkflowRegistrationFailedPayloadAuditEventEventData returns new AuditEventEventData from AuthwebhookWorkflowRegistrationFailedPayload.
+func NewAuthwebhookWorkflowRegistrationFailedPayloadAuditEventEventData(v AuthwebhookWorkflowRegistrationFailedPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetAuthwebhookWorkflowRegistrationFailedPayload(v)
+	return s
+}
+
 // SetEffectivenessAssessmentAuditPayload sets AuditEventEventData to EffectivenessAssessmentAuditPayload.
 // panics if `t` is not associated with EffectivenessAssessmentAuditPayload
 func (s *AuditEventEventData) SetEffectivenessAssessmentAuditPayload(t AuditEventEventDataType, v EffectivenessAssessmentAuditPayload) {
@@ -11425,92 +11453,93 @@ func (s *AuditEventRequestEventCategory) UnmarshalText(data []byte) error {
 // See DD-AUDIT-004 for structured type requirements.
 // AuditEventRequestEventData represents sum type.
 type AuditEventRequestEventData struct {
-	Type                                      AuditEventRequestEventDataType // switch on this field
-	GatewayAuditPayload                       GatewayAuditPayload
-	RemediationOrchestratorAuditPayload       RemediationOrchestratorAuditPayload
-	SignalProcessingAuditPayload              SignalProcessingAuditPayload
-	AIAnalysisAuditPayload                    AIAnalysisAuditPayload
-	WorkflowExecutionAuditPayload             WorkflowExecutionAuditPayload
-	NotificationAuditPayload                  NotificationAuditPayload
-	WorkflowExecutionWebhookAuditPayload      WorkflowExecutionWebhookAuditPayload
-	RemediationApprovalAuditPayload           RemediationApprovalAuditPayload
-	RemediationApprovalDecisionPayload        RemediationApprovalDecisionPayload
-	WorkflowDiscoveryAuditPayload             WorkflowDiscoveryAuditPayload
-	WorkflowCatalogCreatedPayload             WorkflowCatalogCreatedPayload
-	WorkflowCatalogUpdatedPayload             WorkflowCatalogUpdatedPayload
-	AIAnalysisPhaseTransitionPayload          AIAnalysisPhaseTransitionPayload
-	AIAnalysisAIAgentCallPayload              AIAnalysisAIAgentCallPayload
-	AIAnalysisApprovalDecisionPayload         AIAnalysisApprovalDecisionPayload
-	AIAnalysisRegoEvaluationPayload           AIAnalysisRegoEvaluationPayload
-	AIAnalysisErrorPayload                    AIAnalysisErrorPayload
-	NotificationMessageSentPayload            NotificationMessageSentPayload
-	NotificationMessageFailedPayload          NotificationMessageFailedPayload
-	NotificationMessageAcknowledgedPayload    NotificationMessageAcknowledgedPayload
-	NotificationMessageEscalatedPayload       NotificationMessageEscalatedPayload
-	AIAgentResponsePayload                    AIAgentResponsePayload
-	AIAgentRCACompletePayload                 AIAgentRCACompletePayload
-	AIAgentResponseFailedPayload              AIAgentResponseFailedPayload
-	AIAgentEnrichmentCompletedPayload         AIAgentEnrichmentCompletedPayload
-	AIAgentEnrichmentFailedPayload            AIAgentEnrichmentFailedPayload
-	LLMRequestPayload                         LLMRequestPayload
-	LLMResponsePayload                        LLMResponsePayload
-	LLMToolCallPayload                        LLMToolCallPayload
-	WorkflowValidationPayload                 WorkflowValidationPayload
-	AIAgentSessionStartedPayload              AIAgentSessionStartedPayload
-	AIAgentSessionCompletedPayload            AIAgentSessionCompletedPayload
-	AIAgentSessionFailedPayload               AIAgentSessionFailedPayload
-	AIAgentSessionCancelledPayload            AIAgentSessionCancelledPayload
-	AIAgentSessionSuspendedPayload            AIAgentSessionSuspendedPayload
-	AIAgentSessionResumedPayload              AIAgentSessionResumedPayload
-	AIAgentInteractiveStartedPayload          AIAgentInteractiveStartedPayload
-	AIAgentInteractiveCompletedPayload        AIAgentInteractiveCompletedPayload
-	AIAgentInteractiveK8sCallPayload          AIAgentInteractiveK8sCallPayload
-	AIAgentSessionObservedPayload             AIAgentSessionObservedPayload
-	AIAgentSessionAccessDeniedPayload         AIAgentSessionAccessDeniedPayload
-	AIAgentInvestigationCancelledPayload      AIAgentInvestigationCancelledPayload
-	AIAgentAlignmentStepPayload               AIAgentAlignmentStepPayload
-	AIAgentAlignmentVerdictPayload            AIAgentAlignmentVerdictPayload
-	ShadowLLMRequestPayload                   ShadowLLMRequestPayload
-	ShadowLLMResponsePayload                  ShadowLLMResponsePayload
-	RemediationRequestWebhookAuditPayload     RemediationRequestWebhookAuditPayload
-	RemediationWorkflowWebhookAuditPayload    RemediationWorkflowWebhookAuditPayload
-	EffectivenessAssessmentAuditPayload       EffectivenessAssessmentAuditPayload
-	ActionTypeCatalogCreatedPayload           ActionTypeCatalogCreatedPayload
-	ActionTypeCatalogUpdatedPayload           ActionTypeCatalogUpdatedPayload
-	ActionTypeCatalogDisabledPayload          ActionTypeCatalogDisabledPayload
-	ActionTypeCatalogReenabledPayload         ActionTypeCatalogReenabledPayload
-	ActionTypeCatalogDisableDeniedPayload     ActionTypeCatalogDisableDeniedPayload
-	ActionTypeWebhookAuditPayload             ActionTypeWebhookAuditPayload
-	ApifrontendTriageStartedPayload           ApifrontendTriageStartedPayload
-	ApifrontendTriageCompletedPayload         ApifrontendTriageCompletedPayload
-	ApifrontendRRCreatedPayload               ApifrontendRRCreatedPayload
-	ApifrontendRRDeduplicatedPayload          ApifrontendRRDeduplicatedPayload
-	ApifrontendSessionCreatedPayload          ApifrontendSessionCreatedPayload
-	ApifrontendSessionCompletedPayload        ApifrontendSessionCompletedPayload
-	ApifrontendKADelegatedPayload             ApifrontendKADelegatedPayload
-	ApifrontendKAResultReceivedPayload        ApifrontendKAResultReceivedPayload
-	ApifrontendUserDecisionPayload            ApifrontendUserDecisionPayload
-	ApifrontendAuthAccessDeniedPayload        ApifrontendAuthAccessDeniedPayload
-	ApifrontendToolExecutedPayload            ApifrontendToolExecutedPayload
-	ApifrontendAuthSuccessPayload             ApifrontendAuthSuccessPayload
-	ApifrontendAuthFailurePayload             ApifrontendAuthFailurePayload
-	ApifrontendRatelimitDeniedPayload         ApifrontendRatelimitDeniedPayload
-	ApifrontendCircuitbreakerTripPayload      ApifrontendCircuitbreakerTripPayload
-	ApifrontendImpersonationCreatedPayload    ApifrontendImpersonationCreatedPayload
-	ApifrontendJWTDelegationPayload           ApifrontendJWTDelegationPayload
-	ApifrontendSessionPhaseChangedPayload     ApifrontendSessionPhaseChangedPayload
-	ApifrontendSessionDeletedPayload          ApifrontendSessionDeletedPayload
-	ApifrontendSessionAutoCancelledPayload    ApifrontendSessionAutoCancelledPayload
-	ApifrontendSessionRetentionDeletedPayload ApifrontendSessionRetentionDeletedPayload
-	ApifrontendA2ATaskStartedPayload          ApifrontendA2ATaskStartedPayload
-	ApifrontendA2ATaskCompletedPayload        ApifrontendA2ATaskCompletedPayload
-	ApifrontendA2ATaskFailedPayload           ApifrontendA2ATaskFailedPayload
-	ApifrontendMCPToolFailedPayload           ApifrontendMCPToolFailedPayload
-	ApifrontendMCPSessionInitPayload          ApifrontendMCPSessionInitPayload
-	ApifrontendSeverityTriageCompletedPayload ApifrontendSeverityTriageCompletedPayload
-	ApifrontendSeverityTriageFailedPayload    ApifrontendSeverityTriageFailedPayload
-	ApifrontendConfigReloadedPayload          ApifrontendConfigReloadedPayload
-	ApifrontendConfigRejectedPayload          ApifrontendConfigRejectedPayload
+	Type                                         AuditEventRequestEventDataType // switch on this field
+	GatewayAuditPayload                          GatewayAuditPayload
+	RemediationOrchestratorAuditPayload          RemediationOrchestratorAuditPayload
+	SignalProcessingAuditPayload                 SignalProcessingAuditPayload
+	AIAnalysisAuditPayload                       AIAnalysisAuditPayload
+	WorkflowExecutionAuditPayload                WorkflowExecutionAuditPayload
+	NotificationAuditPayload                     NotificationAuditPayload
+	WorkflowExecutionWebhookAuditPayload         WorkflowExecutionWebhookAuditPayload
+	RemediationApprovalAuditPayload              RemediationApprovalAuditPayload
+	RemediationApprovalDecisionPayload           RemediationApprovalDecisionPayload
+	WorkflowDiscoveryAuditPayload                WorkflowDiscoveryAuditPayload
+	WorkflowCatalogCreatedPayload                WorkflowCatalogCreatedPayload
+	WorkflowCatalogUpdatedPayload                WorkflowCatalogUpdatedPayload
+	AIAnalysisPhaseTransitionPayload             AIAnalysisPhaseTransitionPayload
+	AIAnalysisAIAgentCallPayload                 AIAnalysisAIAgentCallPayload
+	AIAnalysisApprovalDecisionPayload            AIAnalysisApprovalDecisionPayload
+	AIAnalysisRegoEvaluationPayload              AIAnalysisRegoEvaluationPayload
+	AIAnalysisErrorPayload                       AIAnalysisErrorPayload
+	NotificationMessageSentPayload               NotificationMessageSentPayload
+	NotificationMessageFailedPayload             NotificationMessageFailedPayload
+	NotificationMessageAcknowledgedPayload       NotificationMessageAcknowledgedPayload
+	NotificationMessageEscalatedPayload          NotificationMessageEscalatedPayload
+	AIAgentResponsePayload                       AIAgentResponsePayload
+	AIAgentRCACompletePayload                    AIAgentRCACompletePayload
+	AIAgentResponseFailedPayload                 AIAgentResponseFailedPayload
+	AIAgentEnrichmentCompletedPayload            AIAgentEnrichmentCompletedPayload
+	AIAgentEnrichmentFailedPayload               AIAgentEnrichmentFailedPayload
+	LLMRequestPayload                            LLMRequestPayload
+	LLMResponsePayload                           LLMResponsePayload
+	LLMToolCallPayload                           LLMToolCallPayload
+	WorkflowValidationPayload                    WorkflowValidationPayload
+	AIAgentSessionStartedPayload                 AIAgentSessionStartedPayload
+	AIAgentSessionCompletedPayload               AIAgentSessionCompletedPayload
+	AIAgentSessionFailedPayload                  AIAgentSessionFailedPayload
+	AIAgentSessionCancelledPayload               AIAgentSessionCancelledPayload
+	AIAgentSessionSuspendedPayload               AIAgentSessionSuspendedPayload
+	AIAgentSessionResumedPayload                 AIAgentSessionResumedPayload
+	AIAgentInteractiveStartedPayload             AIAgentInteractiveStartedPayload
+	AIAgentInteractiveCompletedPayload           AIAgentInteractiveCompletedPayload
+	AIAgentInteractiveK8sCallPayload             AIAgentInteractiveK8sCallPayload
+	AIAgentSessionObservedPayload                AIAgentSessionObservedPayload
+	AIAgentSessionAccessDeniedPayload            AIAgentSessionAccessDeniedPayload
+	AIAgentInvestigationCancelledPayload         AIAgentInvestigationCancelledPayload
+	AIAgentAlignmentStepPayload                  AIAgentAlignmentStepPayload
+	AIAgentAlignmentVerdictPayload               AIAgentAlignmentVerdictPayload
+	ShadowLLMRequestPayload                      ShadowLLMRequestPayload
+	ShadowLLMResponsePayload                     ShadowLLMResponsePayload
+	RemediationRequestWebhookAuditPayload        RemediationRequestWebhookAuditPayload
+	RemediationWorkflowWebhookAuditPayload       RemediationWorkflowWebhookAuditPayload
+	AuthwebhookWorkflowRegistrationFailedPayload AuthwebhookWorkflowRegistrationFailedPayload
+	EffectivenessAssessmentAuditPayload          EffectivenessAssessmentAuditPayload
+	ActionTypeCatalogCreatedPayload              ActionTypeCatalogCreatedPayload
+	ActionTypeCatalogUpdatedPayload              ActionTypeCatalogUpdatedPayload
+	ActionTypeCatalogDisabledPayload             ActionTypeCatalogDisabledPayload
+	ActionTypeCatalogReenabledPayload            ActionTypeCatalogReenabledPayload
+	ActionTypeCatalogDisableDeniedPayload        ActionTypeCatalogDisableDeniedPayload
+	ActionTypeWebhookAuditPayload                ActionTypeWebhookAuditPayload
+	ApifrontendTriageStartedPayload              ApifrontendTriageStartedPayload
+	ApifrontendTriageCompletedPayload            ApifrontendTriageCompletedPayload
+	ApifrontendRRCreatedPayload                  ApifrontendRRCreatedPayload
+	ApifrontendRRDeduplicatedPayload             ApifrontendRRDeduplicatedPayload
+	ApifrontendSessionCreatedPayload             ApifrontendSessionCreatedPayload
+	ApifrontendSessionCompletedPayload           ApifrontendSessionCompletedPayload
+	ApifrontendKADelegatedPayload                ApifrontendKADelegatedPayload
+	ApifrontendKAResultReceivedPayload           ApifrontendKAResultReceivedPayload
+	ApifrontendUserDecisionPayload               ApifrontendUserDecisionPayload
+	ApifrontendAuthAccessDeniedPayload           ApifrontendAuthAccessDeniedPayload
+	ApifrontendToolExecutedPayload               ApifrontendToolExecutedPayload
+	ApifrontendAuthSuccessPayload                ApifrontendAuthSuccessPayload
+	ApifrontendAuthFailurePayload                ApifrontendAuthFailurePayload
+	ApifrontendRatelimitDeniedPayload            ApifrontendRatelimitDeniedPayload
+	ApifrontendCircuitbreakerTripPayload         ApifrontendCircuitbreakerTripPayload
+	ApifrontendImpersonationCreatedPayload       ApifrontendImpersonationCreatedPayload
+	ApifrontendJWTDelegationPayload              ApifrontendJWTDelegationPayload
+	ApifrontendSessionPhaseChangedPayload        ApifrontendSessionPhaseChangedPayload
+	ApifrontendSessionDeletedPayload             ApifrontendSessionDeletedPayload
+	ApifrontendSessionAutoCancelledPayload       ApifrontendSessionAutoCancelledPayload
+	ApifrontendSessionRetentionDeletedPayload    ApifrontendSessionRetentionDeletedPayload
+	ApifrontendA2ATaskStartedPayload             ApifrontendA2ATaskStartedPayload
+	ApifrontendA2ATaskCompletedPayload           ApifrontendA2ATaskCompletedPayload
+	ApifrontendA2ATaskFailedPayload              ApifrontendA2ATaskFailedPayload
+	ApifrontendMCPToolFailedPayload              ApifrontendMCPToolFailedPayload
+	ApifrontendMCPSessionInitPayload             ApifrontendMCPSessionInitPayload
+	ApifrontendSeverityTriageCompletedPayload    ApifrontendSeverityTriageCompletedPayload
+	ApifrontendSeverityTriageFailedPayload       ApifrontendSeverityTriageFailedPayload
+	ApifrontendConfigReloadedPayload             ApifrontendConfigReloadedPayload
+	ApifrontendConfigRejectedPayload             ApifrontendConfigRejectedPayload
 }
 
 // AuditEventRequestEventDataType is oneOf type of AuditEventRequestEventData.
@@ -11603,6 +11632,7 @@ const (
 	AuditEventRequestEventDataRemediationworkflowAdmittedDeleteAuditEventRequestEventData          AuditEventRequestEventDataType = "remediationworkflow.admitted.delete"
 	AuditEventRequestEventDataRemediationworkflowAdmittedDeniedAuditEventRequestEventData          AuditEventRequestEventDataType = "remediationworkflow.admitted.denied"
 	AuditEventRequestEventDataRemediationworkflowAdmittedUpdateAuditEventRequestEventData          AuditEventRequestEventDataType = "remediationworkflow.admitted.update"
+	AuthwebhookWorkflowRegistrationFailedPayloadAuditEventRequestEventData                         AuditEventRequestEventDataType = "authwebhook.workflow.registration_failed"
 	AuditEventRequestEventDataEffectivenessAlertAssessedAuditEventRequestEventData                 AuditEventRequestEventDataType = "effectiveness.alert.assessed"
 	AuditEventRequestEventDataEffectivenessAlertDecayDetectedAuditEventRequestEventData            AuditEventRequestEventDataType = "effectiveness.alert_decay.detected"
 	AuditEventRequestEventDataEffectivenessAssessmentCompletedAuditEventRequestEventData           AuditEventRequestEventDataType = "effectiveness.assessment.completed"
@@ -11936,6 +11966,11 @@ func (s AuditEventRequestEventData) IsRemediationWorkflowWebhookAuditPayload() b
 	default:
 		return false
 	}
+}
+
+// IsAuthwebhookWorkflowRegistrationFailedPayload reports whether AuditEventRequestEventData is AuthwebhookWorkflowRegistrationFailedPayload.
+func (s AuditEventRequestEventData) IsAuthwebhookWorkflowRegistrationFailedPayload() bool {
+	return s.Type == AuthwebhookWorkflowRegistrationFailedPayloadAuditEventRequestEventData
 }
 
 // IsEffectivenessAssessmentAuditPayload reports whether AuditEventRequestEventData is EffectivenessAssessmentAuditPayload.
@@ -13433,6 +13468,27 @@ func NewAuditEventRequestEventDataRemediationworkflowAdmittedDeniedAuditEventReq
 func NewAuditEventRequestEventDataRemediationworkflowAdmittedUpdateAuditEventRequestEventData(v RemediationWorkflowWebhookAuditPayload) AuditEventRequestEventData {
 	var s AuditEventRequestEventData
 	s.SetRemediationWorkflowWebhookAuditPayload(AuditEventRequestEventDataRemediationworkflowAdmittedUpdateAuditEventRequestEventData, v)
+	return s
+}
+
+// SetAuthwebhookWorkflowRegistrationFailedPayload sets AuditEventRequestEventData to AuthwebhookWorkflowRegistrationFailedPayload.
+func (s *AuditEventRequestEventData) SetAuthwebhookWorkflowRegistrationFailedPayload(v AuthwebhookWorkflowRegistrationFailedPayload) {
+	s.Type = AuthwebhookWorkflowRegistrationFailedPayloadAuditEventRequestEventData
+	s.AuthwebhookWorkflowRegistrationFailedPayload = v
+}
+
+// GetAuthwebhookWorkflowRegistrationFailedPayload returns AuthwebhookWorkflowRegistrationFailedPayload and true boolean if AuditEventRequestEventData is AuthwebhookWorkflowRegistrationFailedPayload.
+func (s AuditEventRequestEventData) GetAuthwebhookWorkflowRegistrationFailedPayload() (v AuthwebhookWorkflowRegistrationFailedPayload, ok bool) {
+	if !s.IsAuthwebhookWorkflowRegistrationFailedPayload() {
+		return v, false
+	}
+	return s.AuthwebhookWorkflowRegistrationFailedPayload, true
+}
+
+// NewAuthwebhookWorkflowRegistrationFailedPayloadAuditEventRequestEventData returns new AuditEventRequestEventData from AuthwebhookWorkflowRegistrationFailedPayload.
+func NewAuthwebhookWorkflowRegistrationFailedPayloadAuditEventRequestEventData(v AuthwebhookWorkflowRegistrationFailedPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetAuthwebhookWorkflowRegistrationFailedPayload(v)
 	return s
 }
 
@@ -14955,6 +15011,163 @@ func (s *AuditExportResponseHashChainVerification) SetVerificationTimestamp(val 
 // SetTamperedEventIds sets the value of TamperedEventIds.
 func (s *AuditExportResponseHashChainVerification) SetTamperedEventIds(val []string) {
 	s.TamperedEventIds = val
+}
+
+// Audit payload emitted by AuthWebhook's StartupReconciler when a RemediationWorkflow
+// CRD fails to re-register with DataStorage during startup (Issue #1246).
+// Enables operators to identify which workflows are degraded and why.
+// Ref: #/components/schemas/AuthwebhookWorkflowRegistrationFailedPayload
+type AuthwebhookWorkflowRegistrationFailedPayload struct {
+	// Event type for discriminator.
+	EventType AuthwebhookWorkflowRegistrationFailedPayloadEventType `json:"event_type"`
+	// Name of the RemediationWorkflow CRD that failed registration.
+	WorkflowName string `json:"workflow_name"`
+	// Namespace of the RemediationWorkflow CRD.
+	Namespace OptString `json:"namespace"`
+	// Structured failure reason matching the Ready condition reason.
+	// - DependencyMissing: permanent error (e.g., referenced action type not found)
+	// - DataStorageError: transient error exhausted retries or context cancelled
+	// - ValidationFailed: CRD content could not be marshaled.
+	Reason AuthwebhookWorkflowRegistrationFailedPayloadReason `json:"reason"`
+	// Human-readable error message with remediation context.
+	Message string `json:"message"`
+}
+
+// GetEventType returns the value of EventType.
+func (s *AuthwebhookWorkflowRegistrationFailedPayload) GetEventType() AuthwebhookWorkflowRegistrationFailedPayloadEventType {
+	return s.EventType
+}
+
+// GetWorkflowName returns the value of WorkflowName.
+func (s *AuthwebhookWorkflowRegistrationFailedPayload) GetWorkflowName() string {
+	return s.WorkflowName
+}
+
+// GetNamespace returns the value of Namespace.
+func (s *AuthwebhookWorkflowRegistrationFailedPayload) GetNamespace() OptString {
+	return s.Namespace
+}
+
+// GetReason returns the value of Reason.
+func (s *AuthwebhookWorkflowRegistrationFailedPayload) GetReason() AuthwebhookWorkflowRegistrationFailedPayloadReason {
+	return s.Reason
+}
+
+// GetMessage returns the value of Message.
+func (s *AuthwebhookWorkflowRegistrationFailedPayload) GetMessage() string {
+	return s.Message
+}
+
+// SetEventType sets the value of EventType.
+func (s *AuthwebhookWorkflowRegistrationFailedPayload) SetEventType(val AuthwebhookWorkflowRegistrationFailedPayloadEventType) {
+	s.EventType = val
+}
+
+// SetWorkflowName sets the value of WorkflowName.
+func (s *AuthwebhookWorkflowRegistrationFailedPayload) SetWorkflowName(val string) {
+	s.WorkflowName = val
+}
+
+// SetNamespace sets the value of Namespace.
+func (s *AuthwebhookWorkflowRegistrationFailedPayload) SetNamespace(val OptString) {
+	s.Namespace = val
+}
+
+// SetReason sets the value of Reason.
+func (s *AuthwebhookWorkflowRegistrationFailedPayload) SetReason(val AuthwebhookWorkflowRegistrationFailedPayloadReason) {
+	s.Reason = val
+}
+
+// SetMessage sets the value of Message.
+func (s *AuthwebhookWorkflowRegistrationFailedPayload) SetMessage(val string) {
+	s.Message = val
+}
+
+// Event type for discriminator.
+type AuthwebhookWorkflowRegistrationFailedPayloadEventType string
+
+const (
+	AuthwebhookWorkflowRegistrationFailedPayloadEventTypeAuthwebhookWorkflowRegistrationFailed AuthwebhookWorkflowRegistrationFailedPayloadEventType = "authwebhook.workflow.registration_failed"
+)
+
+// AllValues returns all AuthwebhookWorkflowRegistrationFailedPayloadEventType values.
+func (AuthwebhookWorkflowRegistrationFailedPayloadEventType) AllValues() []AuthwebhookWorkflowRegistrationFailedPayloadEventType {
+	return []AuthwebhookWorkflowRegistrationFailedPayloadEventType{
+		AuthwebhookWorkflowRegistrationFailedPayloadEventTypeAuthwebhookWorkflowRegistrationFailed,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s AuthwebhookWorkflowRegistrationFailedPayloadEventType) MarshalText() ([]byte, error) {
+	switch s {
+	case AuthwebhookWorkflowRegistrationFailedPayloadEventTypeAuthwebhookWorkflowRegistrationFailed:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *AuthwebhookWorkflowRegistrationFailedPayloadEventType) UnmarshalText(data []byte) error {
+	switch AuthwebhookWorkflowRegistrationFailedPayloadEventType(data) {
+	case AuthwebhookWorkflowRegistrationFailedPayloadEventTypeAuthwebhookWorkflowRegistrationFailed:
+		*s = AuthwebhookWorkflowRegistrationFailedPayloadEventTypeAuthwebhookWorkflowRegistrationFailed
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Structured failure reason matching the Ready condition reason.
+// - DependencyMissing: permanent error (e.g., referenced action type not found)
+// - DataStorageError: transient error exhausted retries or context cancelled
+// - ValidationFailed: CRD content could not be marshaled.
+type AuthwebhookWorkflowRegistrationFailedPayloadReason string
+
+const (
+	AuthwebhookWorkflowRegistrationFailedPayloadReasonDependencyMissing AuthwebhookWorkflowRegistrationFailedPayloadReason = "DependencyMissing"
+	AuthwebhookWorkflowRegistrationFailedPayloadReasonDataStorageError  AuthwebhookWorkflowRegistrationFailedPayloadReason = "DataStorageError"
+	AuthwebhookWorkflowRegistrationFailedPayloadReasonValidationFailed  AuthwebhookWorkflowRegistrationFailedPayloadReason = "ValidationFailed"
+)
+
+// AllValues returns all AuthwebhookWorkflowRegistrationFailedPayloadReason values.
+func (AuthwebhookWorkflowRegistrationFailedPayloadReason) AllValues() []AuthwebhookWorkflowRegistrationFailedPayloadReason {
+	return []AuthwebhookWorkflowRegistrationFailedPayloadReason{
+		AuthwebhookWorkflowRegistrationFailedPayloadReasonDependencyMissing,
+		AuthwebhookWorkflowRegistrationFailedPayloadReasonDataStorageError,
+		AuthwebhookWorkflowRegistrationFailedPayloadReasonValidationFailed,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s AuthwebhookWorkflowRegistrationFailedPayloadReason) MarshalText() ([]byte, error) {
+	switch s {
+	case AuthwebhookWorkflowRegistrationFailedPayloadReasonDependencyMissing:
+		return []byte(s), nil
+	case AuthwebhookWorkflowRegistrationFailedPayloadReasonDataStorageError:
+		return []byte(s), nil
+	case AuthwebhookWorkflowRegistrationFailedPayloadReasonValidationFailed:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *AuthwebhookWorkflowRegistrationFailedPayloadReason) UnmarshalText(data []byte) error {
+	switch AuthwebhookWorkflowRegistrationFailedPayloadReason(data) {
+	case AuthwebhookWorkflowRegistrationFailedPayloadReasonDependencyMissing:
+		*s = AuthwebhookWorkflowRegistrationFailedPayloadReasonDependencyMissing
+		return nil
+	case AuthwebhookWorkflowRegistrationFailedPayloadReasonDataStorageError:
+		*s = AuthwebhookWorkflowRegistrationFailedPayloadReasonDataStorageError
+		return nil
+	case AuthwebhookWorkflowRegistrationFailedPayloadReasonValidationFailed:
+		*s = AuthwebhookWorkflowRegistrationFailedPayloadReasonValidationFailed
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
 }
 
 // Ref: #/components/schemas/BatchAuditEventResponse

--- a/pkg/datastorage/ogen-client/oas_validators_gen.go
+++ b/pkg/datastorage/ogen-client/oas_validators_gen.go
@@ -3340,6 +3340,11 @@ func (s AuditEventEventData) Validate() error {
 			return err
 		}
 		return nil
+	case AuthwebhookWorkflowRegistrationFailedPayloadAuditEventEventData:
+		if err := s.AuthwebhookWorkflowRegistrationFailedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
 	case AuditEventEventDataEffectivenessAlertAssessedAuditEventEventData, AuditEventEventDataEffectivenessAlertDecayDetectedAuditEventEventData, AuditEventEventDataEffectivenessAssessmentCompletedAuditEventEventData, AuditEventEventDataEffectivenessAssessmentScheduledAuditEventEventData, AuditEventEventDataEffectivenessHashComputedAuditEventEventData, AuditEventEventDataEffectivenessHealthAssessedAuditEventEventData, AuditEventEventDataEffectivenessMetricsAssessedAuditEventEventData:
 		if err := s.EffectivenessAssessmentAuditPayload.Validate(); err != nil {
 			return err
@@ -3956,6 +3961,11 @@ func (s AuditEventRequestEventData) Validate() error {
 			return err
 		}
 		return nil
+	case AuthwebhookWorkflowRegistrationFailedPayloadAuditEventRequestEventData:
+		if err := s.AuthwebhookWorkflowRegistrationFailedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
 	case AuditEventRequestEventDataEffectivenessAlertAssessedAuditEventRequestEventData, AuditEventRequestEventDataEffectivenessAlertDecayDetectedAuditEventRequestEventData, AuditEventRequestEventDataEffectivenessAssessmentCompletedAuditEventRequestEventData, AuditEventRequestEventDataEffectivenessAssessmentScheduledAuditEventRequestEventData, AuditEventRequestEventDataEffectivenessHashComputedAuditEventRequestEventData, AuditEventRequestEventDataEffectivenessHealthAssessedAuditEventRequestEventData, AuditEventRequestEventDataEffectivenessMetricsAssessedAuditEventRequestEventData:
 		if err := s.EffectivenessAssessmentAuditPayload.Validate(); err != nil {
 			return err
@@ -4311,6 +4321,62 @@ func (s *AuditExportResponseHashChainVerification) Validate() error {
 		return &validate.Error{Fields: failures}
 	}
 	return nil
+}
+
+func (s *AuthwebhookWorkflowRegistrationFailedPayload) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.EventType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "event_type",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := s.Reason.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "reason",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s AuthwebhookWorkflowRegistrationFailedPayloadEventType) Validate() error {
+	switch s {
+	case "authwebhook.workflow.registration_failed":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s AuthwebhookWorkflowRegistrationFailedPayloadReason) Validate() error {
+	switch s {
+	case "DependencyMissing":
+		return nil
+	case "DataStorageError":
+		return nil
+	case "ValidationFailed":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
 }
 
 func (s *CreateActionTypeCreated) Validate() error {

--- a/pkg/datastorage/server/middleware/openapi_spec_data.yaml
+++ b/pkg/datastorage/server/middleware/openapi_spec_data.yaml
@@ -2733,6 +2733,7 @@ components:
             - $ref: '#/components/schemas/ShadowLLMResponsePayload'
             - $ref: '#/components/schemas/RemediationRequestWebhookAuditPayload'
             - $ref: '#/components/schemas/RemediationWorkflowWebhookAuditPayload'
+            - $ref: '#/components/schemas/AuthwebhookWorkflowRegistrationFailedPayload'
             - $ref: '#/components/schemas/EffectivenessAssessmentAuditPayload'
             - $ref: '#/components/schemas/ActionTypeCatalogCreatedPayload'
             - $ref: '#/components/schemas/ActionTypeCatalogUpdatedPayload'
@@ -2814,6 +2815,7 @@ components:
               'remediationworkflow.admitted.update': '#/components/schemas/RemediationWorkflowWebhookAuditPayload'
               'remediationworkflow.admitted.delete': '#/components/schemas/RemediationWorkflowWebhookAuditPayload'
               'remediationworkflow.admitted.denied': '#/components/schemas/RemediationWorkflowWebhookAuditPayload'
+              'authwebhook.workflow.registration_failed': '#/components/schemas/AuthwebhookWorkflowRegistrationFailedPayload'
               'workflow.catalog.actions_listed': '#/components/schemas/WorkflowDiscoveryAuditPayload'
               'workflow.catalog.workflows_listed': '#/components/schemas/WorkflowDiscoveryAuditPayload'
               'workflow.catalog.workflow_retrieved': '#/components/schemas/WorkflowDiscoveryAuditPayload'
@@ -4685,6 +4687,41 @@ components:
           type: string
           description: Reason for denial (only set when action=denied)
           example: "data storage registration failed"
+
+    AuthwebhookWorkflowRegistrationFailedPayload:
+      type: object
+      required: [event_type, workflow_name, reason, message]
+      description: |
+        Audit payload emitted by AuthWebhook's StartupReconciler when a RemediationWorkflow
+        CRD fails to re-register with DataStorage during startup (Issue #1246).
+        Enables operators to identify which workflows are degraded and why.
+      properties:
+        event_type:
+          type: string
+          enum:
+            - 'authwebhook.workflow.registration_failed'
+          description: Event type for discriminator
+        workflow_name:
+          type: string
+          description: Name of the RemediationWorkflow CRD that failed registration
+          example: "crashloop-rollback-v1"
+        namespace:
+          type: string
+          description: Namespace of the RemediationWorkflow CRD
+          example: "kubernaut-system"
+        reason:
+          type: string
+          enum: [DependencyMissing, DataStorageError, ValidationFailed]
+          description: |
+            Structured failure reason matching the Ready condition reason.
+            - DependencyMissing: permanent error (e.g., referenced action type not found)
+            - DataStorageError: transient error exhausted retries or context cancelled
+            - ValidationFailed: CRD content could not be marshaled
+          example: "DependencyMissing"
+        message:
+          type: string
+          description: Human-readable error message with remediation context
+          example: "action_type 'ScaleMemory' is not in the taxonomy"
 
     # ========================================
     # Effectiveness Monitor Audit Payloads

--- a/pkg/shared/assets/crds/kubernaut.ai_remediationworkflows.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_remediationworkflows.yaml
@@ -325,6 +325,64 @@ spec:
                   - Superseded
                 description: CatalogStatus reflects the DS catalog lifecycle state.
                 type: string
+              conditions:
+                description: Conditions represent the latest available observations
+                  of the workflow's state.
+                items:
+                  description: Condition contains details for one aspect of the current
+                    state of this API Resource.
+                  properties:
+                    lastTransitionTime:
+                      description: |-
+                        lastTransitionTime is the last time the condition transitioned from one status to another.
+                        This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                      format: date-time
+                      type: string
+                    message:
+                      description: |-
+                        message is a human readable message indicating details about the transition.
+                        This may be an empty string.
+                      maxLength: 32768
+                      type: string
+                    observedGeneration:
+                      description: |-
+                        observedGeneration represents the .metadata.generation that the condition was set based upon.
+                        For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                        with respect to the current state of the instance.
+                      format: int64
+                      minimum: 0
+                      type: integer
+                    reason:
+                      description: |-
+                        reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                        Producers of specific condition types may define expected values and meanings for this field,
+                        and whether the values are considered a guaranteed API.
+                        The value should be a CamelCase string.
+                        This field may not be empty.
+                      maxLength: 1024
+                      minLength: 1
+                      pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                      type: string
+                    status:
+                      description: status of the condition, one of True, False, Unknown.
+                      enum:
+                      - "True"
+                      - "False"
+                      - Unknown
+                      type: string
+                    type:
+                      description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                      maxLength: 316
+                      pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                      type: string
+                  required:
+                  - lastTransitionTime
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
               previouslyExisted:
                 description: PreviouslyExisted indicates if this workflow was re-registered
                   after deletion


### PR DESCRIPTION
## Summary

- **Issue**: Closes #1246
- Refactors `StartupReconciler.syncWorkflows` to continue on individual RemediationWorkflow failures instead of crashing the pod
- Failed workflows get `CatalogStatus=Disabled`, `Ready=False` condition, K8s Warning event, and typed audit event via `BufferedAuditStore`
- Adds `PermanentError` type to classify non-retryable DS responses (400/401/403) vs transient ones
- Adds `Conditions[]` to `RemediationWorkflowStatus` CRD with structured reason codes
- New `AuthwebhookWorkflowRegistrationFailedPayload` OpenAPI schema for typed audit events
- Updates DD-AUDIT-003 v2.1 with all Auth Webhook event types and categories

## Changes

1. **CRD Schema**: `Conditions []metav1.Condition` on `RemediationWorkflowStatus` + reason constants
2. **Error Classification**: `PermanentError` type + `IsPermanentError` helper; DS client wraps 400/401/403
3. **Graceful Degradation**: `syncWorkflows` iterates gracefully, `markWorkflowFailed`/`markWorkflowSucceeded` with `RetryOnConflict`
4. **Observability**: K8s Warning events + typed audit payload via `AuditStore` (wired in `cmd/authwebhook/main.go`)
5. **OpenAPI**: New discriminated union variant + ogen regeneration
6. **Documentation**: DD-AUDIT-003 v2.1 with 11 Auth Webhook event types, test plan (IEEE 829)

## Test Plan

- **Unit**: 11 new tests (UT-AW-1246-001 through 013) — graceful continuation, error classification, K8s events, typed audit payload, nil safety, context cancellation, deadline exhaustion
- **Integration**: 25/25 passed locally (envtest + Podman DS)
- **E2E**: 19/19 passed locally (Kind cluster)
- **Full AW suite**: 183/183 unit tests passing

## Validation

- [x] `go build ./...` clean
- [x] All pre-commit hooks pass (CRD docs, enum drift, anti-patterns)
- [x] Documentation GA readiness audit passed (event types consistent across code/docs)
- [x] FedRAMP controls: AU-3 (audit content), AU-6 (review), SI-11 (error handling)


Made with [Cursor](https://cursor.com)