### PR TITLE
feat(apifrontend): multi-provider LLM support (Vertex AI, Gemini, Anthropic)

### DIFF
--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -622,6 +622,10 @@ func buildMCPHandler(cfg *config.Config, deps *backendDeps, metricsReg *metrics.
 // buildA2AHandler creates the A2A JSON-RPC handler when an LLM provider is
 // configured. Returns a 501 stub when provider is empty, preserving backward
 // compatibility for deployments that don't set it.
+//
+// The LLM model and transport chain are built once at startup and are NOT
+// reloaded when the ConfigMap changes. Changes to agent.llm fields require
+// a pod restart (consistent with KA's LLM wiring pattern).
 func buildA2AHandler(ctx context.Context, cfg *config.Config, deps *backendDeps, sessInfra *sessionInfra, metricsReg *metrics.Registry, authorizer auth.ToolAuthorizer, auditor audit.Emitter, logger logr.Logger, userLimiter *ratelimit.UserLimiter) (http.Handler, error) {
 	if cfg.Agent.LLM.Provider == "" {
 		logger.Info("LLM provider not configured — A2A handler returns 501")

--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -18,9 +18,7 @@ import (
 	"github.com/go-logr/zapr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"google.golang.org/adk/model/gemini"
 	adksession "google.golang.org/adk/session"
-	"google.golang.org/genai"
 	"gopkg.in/yaml.v3"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
@@ -69,7 +67,11 @@ func run() int {
 		z.Error("failed to load config", zap.Error(err))
 		return 1
 	}
-	cfg.ResolveDefaults()
+	if err := cfg.ResolveDefaults(); err != nil {
+		z, _ := zap.NewProduction()
+		z.Error("failed to resolve config defaults", zap.Error(err))
+		return 1
+	}
 
 	logLevel, _ := parseLogLevel(cfg.Logging.Level)
 	zapLogger := newZapLogger(logLevel)
@@ -177,7 +179,9 @@ func run() int {
 		if err := yaml.Unmarshal(newContent, &newCfg); err != nil {
 			return fmt.Errorf("parse config: %w", err)
 		}
-		newCfg.ResolveDefaults()
+		if err := newCfg.ResolveDefaults(); err != nil {
+			return fmt.Errorf("resolve defaults: %w", err)
+		}
 		return newCfg.Validate()
 	}, config.WithAuditor(auditor))
 	if err != nil {
@@ -615,24 +619,18 @@ func buildMCPHandler(cfg *config.Config, deps *backendDeps, metricsReg *metrics.
 	return h, depsReady, nil
 }
 
-// buildA2AHandler creates the A2A JSON-RPC handler when an LLM endpoint is
-// configured. Returns a 501 stub when LLMEndpoint is empty, preserving backward
+// buildA2AHandler creates the A2A JSON-RPC handler when an LLM provider is
+// configured. Returns a 501 stub when provider is empty, preserving backward
 // compatibility for deployments that don't set it.
 func buildA2AHandler(ctx context.Context, cfg *config.Config, deps *backendDeps, sessInfra *sessionInfra, metricsReg *metrics.Registry, authorizer auth.ToolAuthorizer, auditor audit.Emitter, logger logr.Logger, userLimiter *ratelimit.UserLimiter) (http.Handler, error) {
-	if cfg.Agent.LLMEndpoint == "" {
-		logger.Info("LLM endpoint not configured — A2A handler returns 501")
+	if cfg.Agent.LLM.Provider == "" {
+		logger.Info("LLM provider not configured — A2A handler returns 501")
 		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			http.Error(w, "A2A not configured", http.StatusNotImplemented)
 		}), nil
 	}
 
-	llmModel, err := gemini.NewModel(ctx, cfg.Agent.LLMModel, &genai.ClientConfig{
-		APIKey:  cfg.Agent.LLMAPIKey,
-		Backend: genai.BackendGeminiAPI,
-		HTTPOptions: genai.HTTPOptions{
-			BaseURL: cfg.Agent.LLMEndpoint,
-		},
-	})
+	llmModel, err := launcher.NewModelFromConfig(ctx, cfg.Agent.LLM)
 	if err != nil {
 		return nil, fmt.Errorf("create LLM model: %w", err)
 	}
@@ -680,8 +678,8 @@ func buildA2AHandler(ctx context.Context, cfg *config.Config, deps *backendDeps,
 	}
 
 	logger.Info("A2A handler wired with LLM backend",
-		"endpoint", cfg.Agent.LLMEndpoint,
-		"model", cfg.Agent.LLMModel,
+		"provider", cfg.Agent.LLM.Provider,
+		"model", cfg.Agent.LLM.Model,
 	)
 	return h, nil
 }

--- a/cmd/apifrontend/main_wiring_test.go
+++ b/cmd/apifrontend/main_wiring_test.go
@@ -500,9 +500,10 @@ func TestBuildA2AHandler_WithLLMEndpoint_ReturnsHandler(t *testing.T) {
 	t.Cleanup(mockLLM.Close)
 
 	cfg := &config.Config{}
-	cfg.Agent.LLMEndpoint = mockLLM.URL
-	cfg.Agent.LLMModel = "mock-model"
-	cfg.Agent.LLMAPIKey = "test-key"
+	cfg.Agent.LLM.Provider = config.LLMProviderGemini
+	cfg.Agent.LLM.Endpoint = mockLLM.URL
+	cfg.Agent.LLM.Model = "mock-model"
+	cfg.Agent.LLM.APIKey = "test-key"
 	reg := metrics.NewRegistry()
 
 	h, err := buildA2AHandler(context.Background(), cfg, testBackendDeps(), nil, reg, nil, nil, logr.Discard(), nil)
@@ -524,9 +525,10 @@ func TestBuildA2AHandler_WithSessionInfra_UsesDecorator(t *testing.T) {
 	t.Cleanup(mockLLM.Close)
 
 	cfg := &config.Config{}
-	cfg.Agent.LLMEndpoint = mockLLM.URL
-	cfg.Agent.LLMModel = "mock-model"
-	cfg.Agent.LLMAPIKey = "test-key"
+	cfg.Agent.LLM.Provider = config.LLMProviderGemini
+	cfg.Agent.LLM.Endpoint = mockLLM.URL
+	cfg.Agent.LLM.Model = "mock-model"
+	cfg.Agent.LLM.APIKey = "test-key"
 	reg := metrics.NewRegistry()
 
 	infra := buildSessionInfra(cfg, reg, nil, logr.Discard())
@@ -552,9 +554,10 @@ func TestBuildA2AHandler_ThreadsK8sClient(t *testing.T) {
 	t.Cleanup(mockLLM.Close)
 
 	cfg := &config.Config{}
-	cfg.Agent.LLMEndpoint = mockLLM.URL
-	cfg.Agent.LLMModel = "mock-model"
-	cfg.Agent.LLMAPIKey = "test-key"
+	cfg.Agent.LLM.Provider = config.LLMProviderGemini
+	cfg.Agent.LLM.Endpoint = mockLLM.URL
+	cfg.Agent.LLM.Model = "mock-model"
+	cfg.Agent.LLM.APIKey = "test-key"
 	reg := metrics.NewRegistry()
 
 	deps := testBackendDeps()
@@ -583,9 +586,10 @@ func TestBuildA2AHandler_ThreadsKAClient(t *testing.T) {
 	t.Cleanup(mockLLM.Close)
 
 	cfg := &config.Config{}
-	cfg.Agent.LLMEndpoint = mockLLM.URL
-	cfg.Agent.LLMModel = "mock-model"
-	cfg.Agent.LLMAPIKey = "test-key"
+	cfg.Agent.LLM.Provider = config.LLMProviderGemini
+	cfg.Agent.LLM.Endpoint = mockLLM.URL
+	cfg.Agent.LLM.Model = "mock-model"
+	cfg.Agent.LLM.APIKey = "test-key"
 	reg := metrics.NewRegistry()
 
 	deps := testBackendDeps()
@@ -616,9 +620,10 @@ func TestBuildA2AHandler_ThreadsDSClient(t *testing.T) {
 	t.Cleanup(dsBackend.Close)
 
 	cfg := &config.Config{}
-	cfg.Agent.LLMEndpoint = mockLLM.URL
-	cfg.Agent.LLMModel = "mock-model"
-	cfg.Agent.LLMAPIKey = "test-key"
+	cfg.Agent.LLM.Provider = config.LLMProviderGemini
+	cfg.Agent.LLM.Endpoint = mockLLM.URL
+	cfg.Agent.LLM.Model = "mock-model"
+	cfg.Agent.LLM.APIKey = "test-key"
 	reg := metrics.NewRegistry()
 
 	dsClient, dsErr := ds.NewOgenClient(ds.OgenClientConfig{BaseURL: dsBackend.URL})
@@ -649,9 +654,10 @@ func TestBuildA2AHandler_ThreadsUserLimiter(t *testing.T) {
 	t.Cleanup(mockLLM.Close)
 
 	cfg := &config.Config{}
-	cfg.Agent.LLMEndpoint = mockLLM.URL
-	cfg.Agent.LLMModel = "mock-model"
-	cfg.Agent.LLMAPIKey = "test-key"
+	cfg.Agent.LLM.Provider = config.LLMProviderGemini
+	cfg.Agent.LLM.Endpoint = mockLLM.URL
+	cfg.Agent.LLM.Model = "mock-model"
+	cfg.Agent.LLM.APIKey = "test-key"
 	reg := metrics.NewRegistry()
 
 	limiter := ratelimit.NewUserLimiter(ratelimit.PerUserConfig{

--- a/cmd/apifrontend/reload_test.go
+++ b/cmd/apifrontend/reload_test.go
@@ -31,7 +31,9 @@ rateLimit:
 	if err != nil {
 		t.Fatalf("config.Load: %v", err)
 	}
-	cfg.ResolveDefaults()
+	if err := cfg.ResolveDefaults(); err != nil {
+		t.Fatalf("config.ResolveDefaults: %v", err)
+	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("config.Validate: %v", err)
 	}

--- a/deploy/apifrontend/base/config.yaml
+++ b/deploy/apifrontend/base/config.yaml
@@ -5,8 +5,6 @@ server:
     required: true
 
 agent:
-  gcpProject: ""
-  gcpRegion: "us-central1"
   kaBaseURL: "https://kubernaut-agent:8443"
   kaMCPEndpoint: "https://kubernaut-agent:8443/api/v1/mcp/"
   dsBaseURL: "https://data-storage:8443"

--- a/deploy/apifrontend/overlays/e2e/config.yaml
+++ b/deploy/apifrontend/overlays/e2e/config.yaml
@@ -6,17 +6,17 @@ server:
     required: true
 
 agent:
-  gcpProject: ""
-  gcpRegion: "us-central1"
   kaBaseURL: "https://kubernaut-agent.kubernaut-system.svc:8080"
   kaMCPEndpoint: "https://kubernaut-agent.kubernaut-system.svc:8080/api/v1/mcp/"
   dsBaseURL: "https://data-storage-service.kubernaut-system.svc:8080"
   dsBearerTokenFile: "/var/run/secrets/kubernetes.io/serviceaccount/token"
   kaTlsCaFile: /etc/apifrontend/inter-service-ca/ca.crt
   dsTlsCaFile: /etc/apifrontend/inter-service-ca/ca.crt
-  llmEndpoint: "http://mock-llm.kubernaut-system.svc:8080"
-  llmModel: "mock-model"
-  llmApiKeyFile: "/etc/apifrontend/secrets/llm-api-key"
+  llm:
+    provider: gemini
+    model: mock-model
+    endpoint: "http://mock-llm.kubernaut-system.svc:8080"
+    apiKeyFile: "/etc/apifrontend/llm-credentials/llm-api-key"
 
 session:
   namespace: kubernaut-system

--- a/deploy/apifrontend/overlays/e2e/patch-deployment.yaml
+++ b/deploy/apifrontend/overlays/e2e/patch-deployment.yaml
@@ -9,10 +9,6 @@ spec:
       containers:
         - name: apifrontend
           imagePullPolicy: IfNotPresent
-          volumeMounts:
-            - name: llm-key
-              mountPath: /etc/apifrontend/secrets
-              readOnly: true
           resources:
             requests:
               cpu: 50m
@@ -20,3 +16,11 @@ spec:
             limits:
               cpu: 250m
               memory: 256Mi
+          volumeMounts:
+            - name: llm-credentials
+              mountPath: /etc/apifrontend/llm-credentials
+              readOnly: true
+      volumes:
+        - name: llm-credentials
+          secret:
+            secretName: apifrontend-llm-key

--- a/pkg/apifrontend/agent/config.go
+++ b/pkg/apifrontend/agent/config.go
@@ -22,10 +22,6 @@ import (
 //
 //nolint:revive // stutters with package name but preferred for clarity across the codebase
 type AgentConfig struct {
-	// GCPProject is the Vertex AI project for the Claude model.
-	GCPProject string
-	// GCPRegion is the Vertex AI region.
-	GCPRegion string
 	// Instruction is the system prompt guiding agent behavior.
 	Instruction string
 	// SkipTools disables tool registration (for testing error paths).
@@ -73,16 +69,6 @@ type AgentConfig struct {
 // Option applies a configuration override to AgentConfig.
 type Option func(*AgentConfig)
 
-// WithGCPProject sets the Vertex AI project.
-func WithGCPProject(project string) Option {
-	return func(c *AgentConfig) { c.GCPProject = project }
-}
-
-// WithGCPRegion sets the Vertex AI region.
-func WithGCPRegion(region string) Option {
-	return func(c *AgentConfig) { c.GCPRegion = region }
-}
-
 // WithInstruction sets the system prompt.
 func WithInstruction(instruction string) Option {
 	return func(c *AgentConfig) { c.Instruction = instruction }
@@ -106,8 +92,6 @@ func WithDSBaseURL(url string) Option {
 // DefaultTestConfig returns a config suitable for unit tests with placeholder values.
 func DefaultTestConfig() AgentConfig {
 	return AgentConfig{
-		GCPProject:    "test-project",
-		GCPRegion:     "us-central1",
 		Instruction:   defaultInstruction(),
 		KABaseURL:     "http://localhost:8080",
 		KAMCPEndpoint: "http://localhost:8080/api/v1/mcp/",

--- a/pkg/apifrontend/agent/root_test.go
+++ b/pkg/apifrontend/agent/root_test.go
@@ -49,8 +49,6 @@ var _ = Describe("Root Agent", func() {
 	Describe("NewRootAgent", func() {
 		It("UT-AF-100-001: returns configured agent with model", func() {
 			cfg := agentpkg.AgentConfig{
-				GCPProject:  "test-project",
-				GCPRegion:   "us-central1",
 				Instruction: "You are a test agent",
 			}
 			a, tools, err := agentpkg.NewRootAgent(cfg)
@@ -186,8 +184,6 @@ var _ = Describe("Root Agent", func() {
 
 		It("UT-AF-100-012: agent creation with empty tool list returns error", func() {
 			cfg := agentpkg.AgentConfig{
-				GCPProject:  "test-project",
-				GCPRegion:   "us-central1",
 				Instruction: "You are a test agent",
 				SkipTools:   true,
 			}
@@ -345,18 +341,6 @@ var _ = Describe("Root Agent", func() {
 	})
 
 	Describe("Functional Options", func() {
-		It("WithGCPProject overrides project", func() {
-			cfg := agentpkg.DefaultTestConfig()
-			cfg = cfg.Apply(agentpkg.WithGCPProject("new-project"))
-			Expect(cfg.GCPProject).To(Equal("new-project"))
-		})
-
-		It("WithGCPRegion overrides region", func() {
-			cfg := agentpkg.DefaultTestConfig()
-			cfg = cfg.Apply(agentpkg.WithGCPRegion("eu-west1"))
-			Expect(cfg.GCPRegion).To(Equal("eu-west1"))
-		})
-
 		It("WithInstruction overrides instruction", func() {
 			cfg := agentpkg.DefaultTestConfig()
 			cfg = cfg.Apply(agentpkg.WithInstruction("Custom prompt"))
@@ -383,7 +367,7 @@ var _ = Describe("Root Agent", func() {
 
 		It("NewRootAgent accepts functional options", func() {
 			cfg := agentpkg.DefaultTestConfig()
-			a, _, err := agentpkg.NewRootAgent(cfg, agentpkg.WithGCPProject("override-project"))
+			a, _, err := agentpkg.NewRootAgent(cfg, agentpkg.WithInstruction("custom prompt"))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(a).NotTo(BeNil())
 		})

--- a/pkg/apifrontend/config/config.go
+++ b/pkg/apifrontend/config/config.go
@@ -130,7 +130,7 @@ type LLMConfig struct {
 	Provider       string            `yaml:"provider"`
 	Model          string            `yaml:"model"`
 	Endpoint       string            `yaml:"endpoint,omitempty"`
-	ApiKeyFile     string            `yaml:"apiKeyFile,omitempty"`
+	APIKeyFile     string            `yaml:"apiKeyFile,omitempty"`
 	VertexProject  string            `yaml:"vertexProject,omitempty"`
 	VertexLocation string            `yaml:"vertexLocation,omitempty"`
 	TLSCaFile      string            `yaml:"tlsCaFile,omitempty"`
@@ -138,7 +138,7 @@ type LLMConfig struct {
 	OAuth2         LLMOAuth2Config   `yaml:"oauth2,omitempty"`
 	CircuitBreaker LLMCircuitBreaker `yaml:"circuitBreaker,omitempty"`
 	CustomHeaders  []LLMHeader       `yaml:"customHeaders,omitempty"`
-	// APIKey is resolved from ApiKeyFile at startup. Not serialized.
+	// APIKey is resolved from APIKeyFile at startup. Not serialized.
 	APIKey string `yaml:"-"`
 }
 
@@ -370,11 +370,11 @@ func (c *Config) validateLLM() error {
 			return fmt.Errorf("agent.llm.vertexLocation is required for provider %q", llm.Provider)
 		}
 	}
-	if (llm.Provider == LLMProviderGemini || llm.Provider == LLMProviderAnthropic) && llm.ApiKeyFile == "" && !llm.OAuth2.Enabled {
+	if (llm.Provider == LLMProviderGemini || llm.Provider == LLMProviderAnthropic) && llm.APIKeyFile == "" && !llm.OAuth2.Enabled {
 		return fmt.Errorf("agent.llm.apiKeyFile (or oauth2) is required for provider %q", llm.Provider)
 	}
-	if llm.ApiKeyFile != "" && !filepath.IsAbs(llm.ApiKeyFile) {
-		return fmt.Errorf("agent.llm.apiKeyFile must be an absolute path, got %q", llm.ApiKeyFile)
+	if llm.APIKeyFile != "" && !filepath.IsAbs(llm.APIKeyFile) {
+		return fmt.Errorf("agent.llm.apiKeyFile must be an absolute path, got %q", llm.APIKeyFile)
 	}
 	if llm.TLSCaFile != "" && !filepath.IsAbs(llm.TLSCaFile) {
 		return fmt.Errorf("agent.llm.tlsCaFile must be an absolute path, got %q", llm.TLSCaFile)
@@ -515,20 +515,20 @@ func validateDependencyConfig(prefix string, cfg *DependencyConfig) error {
 
 // ResolveDefaults fills in derived fields that depend on other config values.
 // For example, AgentCard.URL is derived from Server.Port if left empty.
-// LLM API key is resolved from the mounted Secret file at ApiKeyFile.
+// LLM API key is resolved from the mounted Secret file at APIKeyFile.
 // Returns an error if a required credential file is configured but unreadable/empty.
 func (c *Config) ResolveDefaults() error {
 	if c.AgentCard.URL == "" {
 		c.AgentCard.URL = fmt.Sprintf("https://localhost:%d", c.Server.Port)
 	}
-	if c.Agent.LLM.APIKey == "" && c.Agent.LLM.ApiKeyFile != "" {
-		data, err := os.ReadFile(c.Agent.LLM.ApiKeyFile)
+	if c.Agent.LLM.APIKey == "" && c.Agent.LLM.APIKeyFile != "" {
+		data, err := os.ReadFile(c.Agent.LLM.APIKeyFile)
 		if err != nil {
-			return fmt.Errorf("agent.llm.apiKeyFile %q: %w", c.Agent.LLM.ApiKeyFile, err)
+			return fmt.Errorf("agent.llm.apiKeyFile %q: %w", c.Agent.LLM.APIKeyFile, err)
 		}
 		key := strings.TrimSpace(string(data))
 		if key == "" {
-			return fmt.Errorf("agent.llm.apiKeyFile %q: file is empty", c.Agent.LLM.ApiKeyFile)
+			return fmt.Errorf("agent.llm.apiKeyFile %q: file is empty", c.Agent.LLM.APIKeyFile)
 		}
 		c.Agent.LLM.APIKey = key
 	}

--- a/pkg/apifrontend/config/config.go
+++ b/pkg/apifrontend/config/config.go
@@ -114,27 +114,67 @@ type ServerTLSConfig struct {
 
 // AgentConfig holds ADK agent and backend connectivity settings.
 type AgentConfig struct {
-	GCPProject        string `yaml:"gcpProject"`
-	GCPRegion         string `yaml:"gcpRegion"`
-	KABaseURL         string `yaml:"kaBaseURL"`
-	KAMCPEndpoint     string `yaml:"kaMCPEndpoint"`
-	DSBaseURL         string `yaml:"dsBaseURL"`
-	DSBearerTokenFile string `yaml:"dsBearerTokenFile,omitempty"`
-	KATLSCaFile       string `yaml:"kaTlsCaFile,omitempty"`
-	DSTLSCaFile       string `yaml:"dsTlsCaFile,omitempty"`
-	// LLMEndpoint is the base URL of a Gemini-compatible LLM endpoint.
-	// When set, AF wires the A2A handler with a real ADK agent backed by this
-	// endpoint. When empty, POST /a2a/invoke returns 501.
-	LLMEndpoint string `yaml:"llmEndpoint,omitempty"`
-	// LLMModel is the model name passed in generateContent requests.
-	LLMModel string `yaml:"llmModel,omitempty"`
-	// LLMApiKeyFile is the path to a mounted Secret file containing the LLM
-	// API key. ResolveDefaults reads the file and populates LLMAPIKey.
-	LLMApiKeyFile string `yaml:"llmApiKeyFile,omitempty"`
-	// LLMAPIKey is the API key for the LLM endpoint, populated from the file
-	// at LLMApiKeyFile during ResolveDefaults. Not serialized to YAML.
-	LLMAPIKey string `yaml:"-"`
+	KABaseURL         string    `yaml:"kaBaseURL"`
+	KAMCPEndpoint     string    `yaml:"kaMCPEndpoint"`
+	DSBaseURL         string    `yaml:"dsBaseURL"`
+	DSBearerTokenFile string    `yaml:"dsBearerTokenFile,omitempty"`
+	KATLSCaFile       string    `yaml:"kaTlsCaFile,omitempty"`
+	DSTLSCaFile       string    `yaml:"dsTlsCaFile,omitempty"`
+	LLM               LLMConfig `yaml:"llm"`
 }
+
+// LLMConfig holds LLM provider settings for the A2A handler. The schema
+// mirrors KA's ai.llm section so operators use one config style across services.
+// When Provider is empty, the A2A handler returns 501 (not configured).
+type LLMConfig struct {
+	Provider       string            `yaml:"provider"`
+	Model          string            `yaml:"model"`
+	Endpoint       string            `yaml:"endpoint,omitempty"`
+	ApiKeyFile     string            `yaml:"apiKeyFile,omitempty"`
+	VertexProject  string            `yaml:"vertexProject,omitempty"`
+	VertexLocation string            `yaml:"vertexLocation,omitempty"`
+	TLSCaFile      string            `yaml:"tlsCaFile,omitempty"`
+	TimeoutSeconds int               `yaml:"timeoutSeconds,omitempty"`
+	OAuth2         LLMOAuth2Config   `yaml:"oauth2,omitempty"`
+	CircuitBreaker LLMCircuitBreaker `yaml:"circuitBreaker,omitempty"`
+	CustomHeaders  []LLMHeader       `yaml:"customHeaders,omitempty"`
+	// APIKey is resolved from ApiKeyFile at startup. Not serialized.
+	APIKey string `yaml:"-"`
+}
+
+// LLMOAuth2Config holds OAuth2 client credentials for auth-gated LLM gateways.
+type LLMOAuth2Config struct {
+	Enabled        bool     `yaml:"enabled"`
+	TokenURL       string   `yaml:"tokenURL"`
+	Scopes         []string `yaml:"scopes,omitempty"`
+	CredentialsDir string   `yaml:"credentialsDir"`
+}
+
+// LLMCircuitBreaker configures resilience for LLM HTTP calls.
+type LLMCircuitBreaker struct {
+	Enabled          bool          `yaml:"enabled"`
+	MaxRequests      uint32        `yaml:"maxRequests"`
+	Interval         time.Duration `yaml:"interval"`
+	Timeout          time.Duration `yaml:"timeout"`
+	FailureThreshold uint32        `yaml:"failureThreshold"`
+}
+
+// LLMHeader describes a custom HTTP header injected into outbound LLM requests.
+type LLMHeader struct {
+	Name     string `yaml:"name"`
+	Value    string `yaml:"value,omitempty"`
+	FilePath string `yaml:"filePath,omitempty"`
+}
+
+// DefaultLLMTimeoutSeconds is the fallback HTTP timeout for LLM requests.
+const DefaultLLMTimeoutSeconds = 120
+
+// Supported LLM provider values.
+const (
+	LLMProviderVertexAI  = "vertex_ai"
+	LLMProviderGemini    = "gemini"
+	LLMProviderAnthropic = "anthropic"
+)
 
 // MCPConfig holds Model Context Protocol feature flags.
 type MCPConfig struct {
@@ -163,10 +203,12 @@ func DefaultConfig() *Config {
 			Port: 8443,
 		},
 		Agent: AgentConfig{
-			GCPRegion:     "us-central1",
 			KABaseURL:     "http://localhost:8080",
 			KAMCPEndpoint: "http://localhost:8080/api/v1/mcp/",
 			DSBaseURL:     "http://localhost:9090",
+			LLM: LLMConfig{
+				VertexLocation: "us-central1",
+			},
 		},
 		MCP: MCPConfig{
 			Enabled:     false,
@@ -269,8 +311,8 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("agent.dsBearerTokenFile %q is not accessible: %w", c.Agent.DSBearerTokenFile, err)
 		}
 	}
-	if c.Agent.LLMApiKeyFile != "" && !filepath.IsAbs(c.Agent.LLMApiKeyFile) {
-		return fmt.Errorf("agent.llmApiKeyFile must be an absolute path, got %q", c.Agent.LLMApiKeyFile)
+	if err := c.validateLLM(); err != nil {
+		return err
 	}
 	if err := c.validateAuth(); err != nil {
 		return err
@@ -302,6 +344,80 @@ func (c *Config) Validate() error {
 func (c *Config) validateSession() error {
 	if c.Session.Namespace == "" && (c.Session.DisconnectTTL > 0 || c.Session.RetentionTTL > 0) {
 		return fmt.Errorf("session.namespace must be set when session TTLs are configured")
+	}
+	return nil
+}
+
+func (c *Config) validateLLM() error {
+	llm := &c.Agent.LLM
+	if llm.Provider == "" {
+		return nil
+	}
+	switch llm.Provider {
+	case LLMProviderVertexAI, LLMProviderGemini, LLMProviderAnthropic:
+	default:
+		return fmt.Errorf("agent.llm.provider must be one of %q, %q, %q; got %q",
+			LLMProviderVertexAI, LLMProviderGemini, LLMProviderAnthropic, llm.Provider)
+	}
+	if llm.Model == "" {
+		return fmt.Errorf("agent.llm.model is required when provider is set")
+	}
+	if llm.Provider == LLMProviderVertexAI {
+		if llm.VertexProject == "" {
+			return fmt.Errorf("agent.llm.vertexProject is required for provider %q", llm.Provider)
+		}
+		if llm.VertexLocation == "" {
+			return fmt.Errorf("agent.llm.vertexLocation is required for provider %q", llm.Provider)
+		}
+	}
+	if (llm.Provider == LLMProviderGemini || llm.Provider == LLMProviderAnthropic) && llm.ApiKeyFile == "" && !llm.OAuth2.Enabled {
+		return fmt.Errorf("agent.llm.apiKeyFile (or oauth2) is required for provider %q", llm.Provider)
+	}
+	if llm.ApiKeyFile != "" && !filepath.IsAbs(llm.ApiKeyFile) {
+		return fmt.Errorf("agent.llm.apiKeyFile must be an absolute path, got %q", llm.ApiKeyFile)
+	}
+	if llm.TLSCaFile != "" && !filepath.IsAbs(llm.TLSCaFile) {
+		return fmt.Errorf("agent.llm.tlsCaFile must be an absolute path, got %q", llm.TLSCaFile)
+	}
+	if llm.Endpoint != "" {
+		if err := validateURL("agent.llm.endpoint", llm.Endpoint); err != nil {
+			return err
+		}
+	}
+	if llm.OAuth2.Enabled {
+		if llm.OAuth2.TokenURL == "" {
+			return fmt.Errorf("agent.llm.oauth2.tokenURL is required when oauth2 is enabled")
+		}
+		if err := validateURL("agent.llm.oauth2.tokenURL", llm.OAuth2.TokenURL); err != nil {
+			return err
+		}
+		if llm.OAuth2.CredentialsDir == "" {
+			return fmt.Errorf("agent.llm.oauth2.credentialsDir is required when oauth2 is enabled")
+		}
+		if !filepath.IsAbs(llm.OAuth2.CredentialsDir) {
+			return fmt.Errorf("agent.llm.oauth2.credentialsDir must be an absolute path, got %q", llm.OAuth2.CredentialsDir)
+		}
+	}
+	if llm.CircuitBreaker.Enabled {
+		if llm.CircuitBreaker.FailureThreshold == 0 || llm.CircuitBreaker.FailureThreshold > 100 {
+			return fmt.Errorf("agent.llm.circuitBreaker.failureThreshold must be 1-100, got %d", llm.CircuitBreaker.FailureThreshold)
+		}
+		if llm.CircuitBreaker.Timeout <= 0 {
+			return fmt.Errorf("agent.llm.circuitBreaker.timeout must be positive")
+		}
+	}
+	if llm.Provider != LLMProviderGemini {
+		hasTransportConfig := llm.TLSCaFile != "" || llm.OAuth2.Enabled || len(llm.CustomHeaders) > 0 || llm.CircuitBreaker.Enabled
+		if hasTransportConfig && llm.Provider == LLMProviderVertexAI {
+			return fmt.Errorf("agent.llm: transport options (tlsCaFile, oauth2, customHeaders, circuitBreaker) "+
+				"are not applicable for provider %q — Vertex AI uses GCP-managed authentication",
+				LLMProviderVertexAI)
+		}
+		if hasTransportConfig && llm.Provider == LLMProviderAnthropic {
+			return fmt.Errorf("agent.llm: transport options (tlsCaFile, oauth2, customHeaders, circuitBreaker) "+
+				"are not yet supported for provider %q — use apiKeyFile and endpoint instead",
+				LLMProviderAnthropic)
+		}
 	}
 	return nil
 }
@@ -399,17 +515,37 @@ func validateDependencyConfig(prefix string, cfg *DependencyConfig) error {
 
 // ResolveDefaults fills in derived fields that depend on other config values.
 // For example, AgentCard.URL is derived from Server.Port if left empty.
-// LLMAPIKey is populated from the file at LLMApiKeyFile (mounted Secret).
-func (c *Config) ResolveDefaults() {
+// LLM API key is resolved from the mounted Secret file at ApiKeyFile.
+// Returns an error if a required credential file is configured but unreadable/empty.
+func (c *Config) ResolveDefaults() error {
 	if c.AgentCard.URL == "" {
 		c.AgentCard.URL = fmt.Sprintf("https://localhost:%d", c.Server.Port)
 	}
-	if c.Agent.LLMAPIKey == "" && c.Agent.LLMApiKeyFile != "" {
-		data, err := os.ReadFile(c.Agent.LLMApiKeyFile)
-		if err == nil {
-			c.Agent.LLMAPIKey = strings.TrimSpace(string(data))
+	if c.Agent.LLM.APIKey == "" && c.Agent.LLM.ApiKeyFile != "" {
+		data, err := os.ReadFile(c.Agent.LLM.ApiKeyFile)
+		if err != nil {
+			return fmt.Errorf("agent.llm.apiKeyFile %q: %w", c.Agent.LLM.ApiKeyFile, err)
+		}
+		key := strings.TrimSpace(string(data))
+		if key == "" {
+			return fmt.Errorf("agent.llm.apiKeyFile %q: file is empty", c.Agent.LLM.ApiKeyFile)
+		}
+		c.Agent.LLM.APIKey = key
+	}
+	if c.Agent.LLM.OAuth2.Enabled && c.Agent.LLM.OAuth2.CredentialsDir != "" {
+		dir := c.Agent.LLM.OAuth2.CredentialsDir
+		for _, f := range []string{"client-id", "client-secret"} {
+			p := filepath.Join(dir, f)
+			data, err := os.ReadFile(p)
+			if err != nil {
+				return fmt.Errorf("agent.llm.oauth2.credentialsDir/%s: %w", f, err)
+			}
+			if strings.TrimSpace(string(data)) == "" {
+				return fmt.Errorf("agent.llm.oauth2.credentialsDir/%s: file is empty", f)
+			}
 		}
 	}
+	return nil
 }
 
 func (c *Config) validateSeverityTriage() error {

--- a/pkg/apifrontend/config/config_test.go
+++ b/pkg/apifrontend/config/config_test.go
@@ -13,8 +13,6 @@ func validConfig() *Config {
 	return &Config{
 		Server: ServerConfig{Port: 8443},
 		Agent: AgentConfig{
-			GCPProject:    "test-project",
-			GCPRegion:     "us-central1",
 			KABaseURL:     "http://localhost:8080",
 			KAMCPEndpoint: "http://localhost:8080/api/v1/mcp/",
 			DSBaseURL:     "http://localhost:9090",
@@ -47,11 +45,11 @@ func TestLoad_ValidFullYAML(t *testing.T) {
 	if cfg.Server.Port != 9090 {
 		t.Errorf("Server.Port = %d, want 9090", cfg.Server.Port)
 	}
-	if cfg.Agent.GCPProject != "my-project" {
-		t.Errorf("Agent.GCPProject = %q, want %q", cfg.Agent.GCPProject, "my-project")
+	if cfg.Agent.LLM.VertexProject != "my-project" {
+		t.Errorf("Agent.LLM.VertexProject = %q, want %q", cfg.Agent.LLM.VertexProject, "my-project")
 	}
-	if cfg.Agent.GCPRegion != "us-east1" {
-		t.Errorf("Agent.GCPRegion = %q, want %q", cfg.Agent.GCPRegion, "us-east1")
+	if cfg.Agent.LLM.VertexLocation != "us-east1" {
+		t.Errorf("Agent.LLM.VertexLocation = %q, want %q", cfg.Agent.LLM.VertexLocation, "us-east1")
 	}
 	if cfg.Agent.KABaseURL != "https://ka.example.com" {
 		t.Errorf("Agent.KABaseURL = %q, want %q", cfg.Agent.KABaseURL, "https://ka.example.com")
@@ -72,7 +70,7 @@ func TestLoad_ValidFullYAML(t *testing.T) {
 
 func TestLoad_AppliesDefaultsForOmittedFields(t *testing.T) {
 	// UT-AF-039-002
-	data := []byte("agent:\n  gcpProject: \"p\"\n")
+	data := []byte("agent:\n  llm:\n    vertexProject: \"p\"\n")
 	cfg, err := Load(data)
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
@@ -81,8 +79,8 @@ func TestLoad_AppliesDefaultsForOmittedFields(t *testing.T) {
 	if cfg.Server.Port != defaults.Server.Port {
 		t.Errorf("Server.Port = %d, want default %d", cfg.Server.Port, defaults.Server.Port)
 	}
-	if cfg.Agent.GCPRegion != defaults.Agent.GCPRegion {
-		t.Errorf("Agent.GCPRegion = %q, want default %q", cfg.Agent.GCPRegion, defaults.Agent.GCPRegion)
+	if cfg.Agent.LLM.VertexLocation != defaults.Agent.LLM.VertexLocation {
+		t.Errorf("Agent.LLM.VertexLocation = %q, want default %q", cfg.Agent.LLM.VertexLocation, defaults.Agent.LLM.VertexLocation)
 	}
 }
 
@@ -148,7 +146,7 @@ func TestLoad_PortAsInteger(t *testing.T) {
 
 func TestLoad_PartialYAMLMergesWithDefaults(t *testing.T) {
 	// UT-AF-039-008
-	data := []byte("server:\n  port: 7777\nagent:\n  gcpProject: \"partial\"\n")
+	data := []byte("server:\n  port: 7777\nagent:\n  llm:\n    vertexProject: \"partial\"\n")
 	cfg, err := Load(data)
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
@@ -156,12 +154,12 @@ func TestLoad_PartialYAMLMergesWithDefaults(t *testing.T) {
 	if cfg.Server.Port != 7777 {
 		t.Errorf("Server.Port = %d, want 7777", cfg.Server.Port)
 	}
-	if cfg.Agent.GCPProject != "partial" {
-		t.Errorf("Agent.GCPProject = %q, want %q", cfg.Agent.GCPProject, "partial")
+	if cfg.Agent.LLM.VertexProject != "partial" {
+		t.Errorf("Agent.LLM.VertexProject = %q, want %q", cfg.Agent.LLM.VertexProject, "partial")
 	}
 	defaults := DefaultConfig()
-	if cfg.Agent.GCPRegion != defaults.Agent.GCPRegion {
-		t.Errorf("Agent.GCPRegion = %q, want default %q", cfg.Agent.GCPRegion, defaults.Agent.GCPRegion)
+	if cfg.Agent.LLM.VertexLocation != defaults.Agent.LLM.VertexLocation {
+		t.Errorf("Agent.LLM.VertexLocation = %q, want default %q", cfg.Agent.LLM.VertexLocation, defaults.Agent.LLM.VertexLocation)
 	}
 }
 
@@ -319,7 +317,9 @@ func TestResolveDefaults_SetsAgentCardURLFromPort(t *testing.T) {
 	cfg := validConfig()
 	cfg.AgentCard.URL = ""
 	cfg.Server.Port = 8443
-	cfg.ResolveDefaults()
+	if err := cfg.ResolveDefaults(); err != nil {
+		t.Fatalf("ResolveDefaults() = %v", err)
+	}
 	want := "https://localhost:8443"
 	if cfg.AgentCard.URL != want {
 		t.Errorf("AgentCard.URL = %q, want %q", cfg.AgentCard.URL, want)
@@ -330,7 +330,9 @@ func TestResolveDefaults_PreservesExplicitURL(t *testing.T) {
 	// UT-AF-039-022
 	cfg := validConfig()
 	cfg.AgentCard.URL = "https://custom.example.com"
-	cfg.ResolveDefaults()
+	if err := cfg.ResolveDefaults(); err != nil {
+		t.Fatalf("ResolveDefaults() = %v", err)
+	}
 	if cfg.AgentCard.URL != "https://custom.example.com" {
 		t.Errorf("AgentCard.URL = %q, want preserved value", cfg.AgentCard.URL)
 	}
@@ -341,9 +343,13 @@ func TestResolveDefaults_Idempotent(t *testing.T) {
 	cfg := validConfig()
 	cfg.AgentCard.URL = ""
 	cfg.Server.Port = 9000
-	cfg.ResolveDefaults()
+	if err := cfg.ResolveDefaults(); err != nil {
+		t.Fatalf("ResolveDefaults() = %v", err)
+	}
 	first := cfg.AgentCard.URL
-	cfg.ResolveDefaults()
+	if err := cfg.ResolveDefaults(); err != nil {
+		t.Fatalf("ResolveDefaults() second call = %v", err)
+	}
 	if cfg.AgentCard.URL != first {
 		t.Errorf("second ResolveDefaults() changed URL: %q -> %q", first, cfg.AgentCard.URL)
 	}
@@ -354,7 +360,9 @@ func TestResolveDefaults_CalledBeforeValidate(t *testing.T) {
 	cfg := validConfig()
 	cfg.AgentCard.URL = ""
 	cfg.Server.Port = 8443
-	cfg.ResolveDefaults()
+	if err := cfg.ResolveDefaults(); err != nil {
+		t.Fatalf("ResolveDefaults() = %v", err)
+	}
 	if err := cfg.Validate(); err != nil {
 		t.Errorf("Validate() after ResolveDefaults() = %v, want nil", err)
 	}
@@ -1153,104 +1161,252 @@ func TestValidate_AuthOIDCCaFileEmptyIsOptional(t *testing.T) {
 	}
 }
 
-// --- Tier 9: LLM API Key File (Issue #1251) ---
+// --- Tier 9: LLM Config Validation (Issue #1252) ---
 
-func TestLoad_LLMApiKeyFile(t *testing.T) {
-	// UT-AF-1251-002: llmApiKeyFile field is parsed from YAML.
-	data := []byte(`
-agent:
-  gcpProject: "test"
-  llmApiKeyFile: "/etc/apifrontend/secrets/llm-api-key"
-`)
-	cfg, err := Load(data)
-	if err != nil {
-		t.Fatalf("Load() error = %v", err)
-	}
-	if cfg.Agent.LLMApiKeyFile != "/etc/apifrontend/secrets/llm-api-key" {
-		t.Errorf("Agent.LLMApiKeyFile = %q, want %q", cfg.Agent.LLMApiKeyFile, "/etc/apifrontend/secrets/llm-api-key")
-	}
-}
-
-func TestLoad_LLMApiKeyFileOmitted(t *testing.T) {
-	// UT-AF-1251-003: llmApiKeyFile defaults to empty when omitted.
-	data := []byte(`
-agent:
-  gcpProject: "test"
-`)
-	cfg, err := Load(data)
-	if err != nil {
-		t.Fatalf("Load() error = %v", err)
-	}
-	if cfg.Agent.LLMApiKeyFile != "" {
-		t.Errorf("Agent.LLMApiKeyFile = %q, want empty", cfg.Agent.LLMApiKeyFile)
-	}
-}
-
-func TestValidate_LLMApiKeyFileRelativePath(t *testing.T) {
-	// UT-AF-1251-004: Relative llmApiKeyFile path is rejected.
+func TestValidate_LLMEmptyProviderIsOptional(t *testing.T) {
 	cfg := validConfig()
-	cfg.Agent.LLMApiKeyFile = "relative/path/key"
+	cfg.Agent.LLM.Provider = ""
+	if err := cfg.Validate(); err != nil {
+		t.Errorf("expected no error for empty LLM provider (A2A disabled), got: %v", err)
+	}
+}
+
+func TestValidate_LLMUnknownProviderRejected(t *testing.T) {
+	cfg := validConfig()
+	cfg.Agent.LLM.Provider = "openai"
+	cfg.Agent.LLM.Model = "gpt-4"
 	err := cfg.Validate()
 	if err == nil {
-		t.Fatal("expected error for relative llmApiKeyFile path")
+		t.Fatal("expected error for unknown provider")
 	}
-	if !strings.Contains(err.Error(), "llmApiKeyFile") {
-		t.Errorf("error = %q, want to contain 'llmApiKeyFile'", err.Error())
+	if !strings.Contains(err.Error(), "agent.llm.provider") {
+		t.Errorf("error = %q, want to contain 'agent.llm.provider'", err.Error())
 	}
 }
 
-func TestValidate_LLMApiKeyFileAbsolutePath(t *testing.T) {
-	// UT-AF-1251-005: Absolute llmApiKeyFile path passes validation.
+func TestValidate_LLMModelRequiredWhenProviderSet(t *testing.T) {
 	cfg := validConfig()
-	cfg.Agent.LLMApiKeyFile = "/etc/apifrontend/secrets/llm-api-key"
+	cfg.Agent.LLM.Provider = LLMProviderGemini
+	cfg.Agent.LLM.Model = ""
 	err := cfg.Validate()
-	if err != nil {
+	if err == nil {
+		t.Fatal("expected error for empty model with provider set")
+	}
+	if !strings.Contains(err.Error(), "agent.llm.model") {
+		t.Errorf("error = %q, want to contain 'agent.llm.model'", err.Error())
+	}
+}
+
+func TestValidate_LLMVertexAIRequiresProject(t *testing.T) {
+	cfg := validConfig()
+	cfg.Agent.LLM.Provider = LLMProviderVertexAI
+	cfg.Agent.LLM.Model = "claude-sonnet-4-20250514"
+	cfg.Agent.LLM.VertexProject = ""
+	cfg.Agent.LLM.VertexLocation = "us-central1"
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for vertex_ai without project")
+	}
+	if !strings.Contains(err.Error(), "vertexProject") {
+		t.Errorf("error = %q, want to contain 'vertexProject'", err.Error())
+	}
+}
+
+func TestValidate_LLMVertexAIRequiresLocation(t *testing.T) {
+	cfg := validConfig()
+	cfg.Agent.LLM.Provider = LLMProviderVertexAI
+	cfg.Agent.LLM.Model = "claude-sonnet-4-20250514"
+	cfg.Agent.LLM.VertexProject = "my-project"
+	cfg.Agent.LLM.VertexLocation = ""
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for vertex_ai without location")
+	}
+	if !strings.Contains(err.Error(), "vertexLocation") {
+		t.Errorf("error = %q, want to contain 'vertexLocation'", err.Error())
+	}
+}
+
+func TestValidate_LLMGeminiAccepted(t *testing.T) {
+	cfg := validConfig()
+	cfg.Agent.LLM.Provider = LLMProviderGemini
+	cfg.Agent.LLM.Model = "gemini-2.0-flash"
+	cfg.Agent.LLM.ApiKeyFile = "/etc/secrets/llm-key"
+	if err := cfg.Validate(); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
 
-func TestValidate_LLMApiKeyFileEmptyIsOptional(t *testing.T) {
-	// UT-AF-1251-006: Empty llmApiKeyFile is valid (A2A disabled).
+func TestValidate_LLMAnthropicAccepted(t *testing.T) {
 	cfg := validConfig()
-	cfg.Agent.LLMApiKeyFile = ""
-	err := cfg.Validate()
-	if err != nil {
+	cfg.Agent.LLM.Provider = LLMProviderAnthropic
+	cfg.Agent.LLM.Model = "claude-sonnet-4-20250514"
+	cfg.Agent.LLM.ApiKeyFile = "/etc/secrets/llm-key"
+	if err := cfg.Validate(); err != nil {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidate_LLMGeminiRequiresCredentials(t *testing.T) {
+	cfg := validConfig()
+	cfg.Agent.LLM.Provider = LLMProviderGemini
+	cfg.Agent.LLM.Model = "gemini-2.0-flash"
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for gemini without apiKeyFile or oauth2")
+	}
+	if !strings.Contains(err.Error(), "apiKeyFile") {
+		t.Errorf("error = %q, want to contain 'apiKeyFile'", err.Error())
+	}
+}
+
+func TestValidate_LLMApiKeyFileRelativeRejected(t *testing.T) {
+	cfg := validConfig()
+	cfg.Agent.LLM.Provider = LLMProviderGemini
+	cfg.Agent.LLM.Model = "gemini-2.0-flash"
+	cfg.Agent.LLM.ApiKeyFile = "relative/path/key"
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for relative apiKeyFile")
+	}
+	if !strings.Contains(err.Error(), "apiKeyFile") {
+		t.Errorf("error = %q, want to contain 'apiKeyFile'", err.Error())
+	}
+}
+
+func TestValidate_LLMOAuth2RequiresTokenURL(t *testing.T) {
+	cfg := validConfig()
+	cfg.Agent.LLM.Provider = LLMProviderGemini
+	cfg.Agent.LLM.Model = "gemini-2.0-flash"
+	cfg.Agent.LLM.OAuth2.Enabled = true
+	cfg.Agent.LLM.OAuth2.TokenURL = ""
+	cfg.Agent.LLM.OAuth2.CredentialsDir = "/etc/creds"
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for oauth2 without tokenURL")
+	}
+	if !strings.Contains(err.Error(), "tokenURL") {
+		t.Errorf("error = %q, want to contain 'tokenURL'", err.Error())
+	}
+}
+
+func TestValidate_LLMOAuth2RequiresCredentialsDir(t *testing.T) {
+	cfg := validConfig()
+	cfg.Agent.LLM.Provider = LLMProviderGemini
+	cfg.Agent.LLM.Model = "gemini-2.0-flash"
+	cfg.Agent.LLM.OAuth2.Enabled = true
+	cfg.Agent.LLM.OAuth2.TokenURL = "https://auth.example.com/token"
+	cfg.Agent.LLM.OAuth2.CredentialsDir = ""
+	err := cfg.Validate()
+	if err == nil {
+		t.Fatal("expected error for oauth2 without credentialsDir")
+	}
+	if !strings.Contains(err.Error(), "credentialsDir") {
+		t.Errorf("error = %q, want to contain 'credentialsDir'", err.Error())
 	}
 }
 
 func TestResolveDefaults_LLMApiKeyFromFile(t *testing.T) {
-	// UT-AF-1251-007: ResolveDefaults reads LLMAPIKey from llmApiKeyFile.
 	dir := t.TempDir()
-	keyPath := filepath.Join(dir, "llm-key")
-	if err := os.WriteFile(keyPath, []byte("sk-test-key-12345\n"), 0o600); err != nil {
-		t.Fatalf("write key file: %v", err)
+	keyFile := filepath.Join(dir, "llm-api-key")
+	if err := os.WriteFile(keyFile, []byte("  secret-key-123  \n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
 	}
 	cfg := validConfig()
-	cfg.Agent.LLMApiKeyFile = keyPath
-	cfg.ResolveDefaults()
-	if cfg.Agent.LLMAPIKey != "sk-test-key-12345" {
-		t.Errorf("LLMAPIKey = %q, want %q", cfg.Agent.LLMAPIKey, "sk-test-key-12345")
+	cfg.Agent.LLM.ApiKeyFile = keyFile
+	if err := cfg.ResolveDefaults(); err != nil {
+		t.Fatalf("ResolveDefaults() = %v", err)
+	}
+	if cfg.Agent.LLM.APIKey != "secret-key-123" {
+		t.Errorf("APIKey = %q, want %q", cfg.Agent.LLM.APIKey, "secret-key-123")
+	}
+}
+
+func TestResolveDefaults_LLMApiKeyFileNotFound(t *testing.T) {
+	cfg := validConfig()
+	cfg.Agent.LLM.ApiKeyFile = "/nonexistent/path/key"
+	err := cfg.ResolveDefaults()
+	if err == nil {
+		t.Fatalf("ResolveDefaults() = nil, want error for missing apiKeyFile")
+	}
+	if !strings.Contains(err.Error(), "/nonexistent/path/key") {
+		t.Errorf("error should reference path, got: %v", err)
 	}
 }
 
 func TestResolveDefaults_LLMApiKeyFileEmpty(t *testing.T) {
-	// UT-AF-1251-008: ResolveDefaults leaves LLMAPIKey empty when no file configured.
+	dir := t.TempDir()
+	keyFile := filepath.Join(dir, "llm-api-key")
+	if err := os.WriteFile(keyFile, []byte("   \n"), 0o600); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
 	cfg := validConfig()
-	cfg.Agent.LLMApiKeyFile = ""
-	cfg.Agent.LLMAPIKey = ""
-	cfg.ResolveDefaults()
-	if cfg.Agent.LLMAPIKey != "" {
-		t.Errorf("LLMAPIKey = %q, want empty when no file configured", cfg.Agent.LLMAPIKey)
+	cfg.Agent.LLM.ApiKeyFile = keyFile
+	err := cfg.ResolveDefaults()
+	if err == nil {
+		t.Fatalf("ResolveDefaults() = nil, want error for empty key file")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("error should mention 'empty', got: %v", err)
 	}
 }
 
-func TestResolveDefaults_LLMApiKeyFileMissing(t *testing.T) {
-	// UT-AF-1251-009: ResolveDefaults leaves LLMAPIKey empty if file doesn't exist.
-	cfg := validConfig()
-	cfg.Agent.LLMApiKeyFile = "/nonexistent/llm-key"
-	cfg.ResolveDefaults()
-	if cfg.Agent.LLMAPIKey != "" {
-		t.Errorf("LLMAPIKey = %q, want empty when file missing", cfg.Agent.LLMAPIKey)
+func TestLoad_LLMConfigFromYAML(t *testing.T) {
+	data := []byte(`
+agent:
+  llm:
+    provider: anthropic
+    model: claude-sonnet-4-20250514
+    endpoint: "https://anthropic.example.com"
+    apiKeyFile: "/etc/secrets/anthropic-key"
+    tlsCaFile: "/etc/ca/custom.pem"
+    oauth2:
+      enabled: true
+      tokenURL: "https://auth.example.com/token"
+      scopes: ["llm:invoke"]
+      credentialsDir: "/etc/oauth2"
+    circuitBreaker:
+      enabled: true
+      maxRequests: 5
+      interval: 15s
+      timeout: 45s
+      failureThreshold: 3
+    customHeaders:
+      - name: X-Tenant-ID
+        value: "kubernaut"
+`)
+	cfg, err := Load(data)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if cfg.Agent.LLM.Provider != LLMProviderAnthropic {
+		t.Errorf("Provider = %q, want %q", cfg.Agent.LLM.Provider, LLMProviderAnthropic)
+	}
+	if cfg.Agent.LLM.Model != "claude-sonnet-4-20250514" {
+		t.Errorf("Model = %q", cfg.Agent.LLM.Model)
+	}
+	if cfg.Agent.LLM.Endpoint != "https://anthropic.example.com" {
+		t.Errorf("Endpoint = %q", cfg.Agent.LLM.Endpoint)
+	}
+	if !cfg.Agent.LLM.OAuth2.Enabled {
+		t.Error("OAuth2.Enabled should be true")
+	}
+	if cfg.Agent.LLM.OAuth2.TokenURL != "https://auth.example.com/token" {
+		t.Errorf("OAuth2.TokenURL = %q", cfg.Agent.LLM.OAuth2.TokenURL)
+	}
+	if len(cfg.Agent.LLM.OAuth2.Scopes) != 1 || cfg.Agent.LLM.OAuth2.Scopes[0] != "llm:invoke" {
+		t.Errorf("OAuth2.Scopes = %v", cfg.Agent.LLM.OAuth2.Scopes)
+	}
+	if !cfg.Agent.LLM.CircuitBreaker.Enabled {
+		t.Error("CircuitBreaker.Enabled should be true")
+	}
+	if cfg.Agent.LLM.CircuitBreaker.MaxRequests != 5 {
+		t.Errorf("CircuitBreaker.MaxRequests = %d", cfg.Agent.LLM.CircuitBreaker.MaxRequests)
+	}
+	if len(cfg.Agent.LLM.CustomHeaders) != 1 {
+		t.Fatalf("CustomHeaders len = %d, want 1", len(cfg.Agent.LLM.CustomHeaders))
+	}
+	if cfg.Agent.LLM.CustomHeaders[0].Name != "X-Tenant-ID" {
+		t.Errorf("CustomHeaders[0].Name = %q", cfg.Agent.LLM.CustomHeaders[0].Name)
 	}
 }

--- a/pkg/apifrontend/config/config_test.go
+++ b/pkg/apifrontend/config/config_test.go
@@ -1231,7 +1231,7 @@ func TestValidate_LLMGeminiAccepted(t *testing.T) {
 	cfg := validConfig()
 	cfg.Agent.LLM.Provider = LLMProviderGemini
 	cfg.Agent.LLM.Model = "gemini-2.0-flash"
-	cfg.Agent.LLM.ApiKeyFile = "/etc/secrets/llm-key"
+	cfg.Agent.LLM.APIKeyFile = "/etc/secrets/llm-key"
 	if err := cfg.Validate(); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -1241,7 +1241,7 @@ func TestValidate_LLMAnthropicAccepted(t *testing.T) {
 	cfg := validConfig()
 	cfg.Agent.LLM.Provider = LLMProviderAnthropic
 	cfg.Agent.LLM.Model = "claude-sonnet-4-20250514"
-	cfg.Agent.LLM.ApiKeyFile = "/etc/secrets/llm-key"
+	cfg.Agent.LLM.APIKeyFile = "/etc/secrets/llm-key"
 	if err := cfg.Validate(); err != nil {
 		t.Errorf("unexpected error: %v", err)
 	}
@@ -1260,11 +1260,11 @@ func TestValidate_LLMGeminiRequiresCredentials(t *testing.T) {
 	}
 }
 
-func TestValidate_LLMApiKeyFileRelativeRejected(t *testing.T) {
+func TestValidate_LLMAPIKeyFileRelativeRejected(t *testing.T) {
 	cfg := validConfig()
 	cfg.Agent.LLM.Provider = LLMProviderGemini
 	cfg.Agent.LLM.Model = "gemini-2.0-flash"
-	cfg.Agent.LLM.ApiKeyFile = "relative/path/key"
+	cfg.Agent.LLM.APIKeyFile = "relative/path/key"
 	err := cfg.Validate()
 	if err == nil {
 		t.Fatal("expected error for relative apiKeyFile")
@@ -1313,7 +1313,7 @@ func TestResolveDefaults_LLMApiKeyFromFile(t *testing.T) {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	cfg := validConfig()
-	cfg.Agent.LLM.ApiKeyFile = keyFile
+	cfg.Agent.LLM.APIKeyFile = keyFile
 	if err := cfg.ResolveDefaults(); err != nil {
 		t.Fatalf("ResolveDefaults() = %v", err)
 	}
@@ -1322,9 +1322,9 @@ func TestResolveDefaults_LLMApiKeyFromFile(t *testing.T) {
 	}
 }
 
-func TestResolveDefaults_LLMApiKeyFileNotFound(t *testing.T) {
+func TestResolveDefaults_LLMAPIKeyFileNotFound(t *testing.T) {
 	cfg := validConfig()
-	cfg.Agent.LLM.ApiKeyFile = "/nonexistent/path/key"
+	cfg.Agent.LLM.APIKeyFile = "/nonexistent/path/key"
 	err := cfg.ResolveDefaults()
 	if err == nil {
 		t.Fatalf("ResolveDefaults() = nil, want error for missing apiKeyFile")
@@ -1334,14 +1334,14 @@ func TestResolveDefaults_LLMApiKeyFileNotFound(t *testing.T) {
 	}
 }
 
-func TestResolveDefaults_LLMApiKeyFileEmpty(t *testing.T) {
+func TestResolveDefaults_LLMAPIKeyFileEmpty(t *testing.T) {
 	dir := t.TempDir()
 	keyFile := filepath.Join(dir, "llm-api-key")
 	if err := os.WriteFile(keyFile, []byte("   \n"), 0o600); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	cfg := validConfig()
-	cfg.Agent.LLM.ApiKeyFile = keyFile
+	cfg.Agent.LLM.APIKeyFile = keyFile
 	err := cfg.ResolveDefaults()
 	if err == nil {
 		t.Fatalf("ResolveDefaults() = nil, want error for empty key file")

--- a/pkg/apifrontend/config/testdata/valid.yaml
+++ b/pkg/apifrontend/config/testdata/valid.yaml
@@ -1,11 +1,14 @@
 server:
   port: 9090
 agent:
-  gcpProject: "my-project"
-  gcpRegion: "us-east1"
   kaBaseURL: "https://ka.example.com"
   kaMCPEndpoint: "https://ka.example.com/api/v1/mcp/"
   dsBaseURL: "https://ds.example.com"
+  llm:
+    provider: vertex_ai
+    model: claude-sonnet-4-20250514
+    vertexProject: "my-project"
+    vertexLocation: "us-east1"
 mcp:
   enabled: true
 agentCard:

--- a/pkg/apifrontend/launcher/export_test.go
+++ b/pkg/apifrontend/launcher/export_test.go
@@ -2,11 +2,14 @@ package launcher
 
 import (
 	"context"
+	"net/http"
 
 	"github.com/a2aproject/a2a-go/a2a"
 	"google.golang.org/adk/server/adka2a"
 	"google.golang.org/adk/session"
 	"google.golang.org/genai"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/config"
 )
 
 // EnrichRRDetailForTest exports enrichRRDetail for unit testing.
@@ -33,4 +36,14 @@ func BuiltConverterIsNonNil() bool {
 // ExpectedOutputMode returns the OutputMode constant wired in the ExecutorConfig.
 func ExpectedOutputMode() adka2a.OutputMode {
 	return adka2a.OutputArtifactPerEvent
+}
+
+// BuildTransportChainForTest exports buildTransportChain for unit testing.
+func BuildTransportChainForTest(cfg config.LLMConfig) (http.RoundTripper, error) {
+	return buildTransportChain(cfg)
+}
+
+// BuildLLMHTTPClientForTest exports buildLLMHTTPClient for unit testing.
+func BuildLLMHTTPClientForTest(cfg config.LLMConfig) (*http.Client, error) {
+	return buildLLMHTTPClient(cfg)
 }

--- a/pkg/apifrontend/launcher/model.go
+++ b/pkg/apifrontend/launcher/model.go
@@ -1,40 +1,195 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package launcher
 
-import "fmt"
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strings"
+	"time"
 
-// Supported model providers.
-const (
-	ProviderVertexAI  = "vertexai"
-	ProviderAnthropic = "anthropic"
+	adkanthropic "github.com/Alcova-AI/adk-anthropic-go"
+	"github.com/anthropics/anthropic-sdk-go"
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/model/gemini"
+	"google.golang.org/genai"
+
+	kaconfig "github.com/jordigilh/kubernaut/internal/kubernautagent/config"
+	internaltransport "github.com/jordigilh/kubernaut/internal/kubernautagent/llm/transport"
+	pkgconfig "github.com/jordigilh/kubernaut/pkg/kubernautagent/config"
+	llmtransport "github.com/jordigilh/kubernaut/pkg/kubernautagent/llm/transport"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/config"
+	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
+	"github.com/jordigilh/kubernaut/pkg/shared/transport"
 )
 
-// ModelConfig holds configuration for the LLM model used by the agent.
-type ModelConfig struct {
-	Provider      string
-	Model         string
-	JWTDelegation bool
-}
-
-// DefaultModelConfig returns the default model configuration targeting
-// Claude Sonnet 4.6 via Vertex AI with JWT delegation enabled.
-// TODO(PR6+): wired when model selection is configurable via env/CRD.
-func DefaultModelConfig() ModelConfig {
-	return ModelConfig{
-		Provider:      ProviderVertexAI,
-		Model:         "claude-sonnet-4-20250514",
-		JWTDelegation: true,
-	}
-}
-
-// Validate checks that the model configuration is well-formed.
-func (c ModelConfig) Validate() error {
-	if c.Model == "" {
-		return fmt.Errorf("model must not be empty")
-	}
-	switch c.Provider {
-	case ProviderVertexAI, ProviderAnthropic:
-		return nil
+// NewModelFromConfig constructs an ADK model.LLM from the AF LLM configuration.
+// It builds the appropriate transport chain (TLS CA, OAuth2, custom headers,
+// circuit breaker) and creates the provider-specific model client.
+func NewModelFromConfig(ctx context.Context, cfg config.LLMConfig) (model.LLM, error) {
+	switch cfg.Provider {
+	case config.LLMProviderVertexAI:
+		return newVertexAIModel(ctx, cfg)
+	case config.LLMProviderGemini:
+		return newGeminiModel(ctx, cfg)
+	case config.LLMProviderAnthropic:
+		return newAnthropicModel(ctx, cfg)
 	default:
-		return fmt.Errorf("unsupported provider %q; must be %q or %q", c.Provider, ProviderVertexAI, ProviderAnthropic)
+		return nil, fmt.Errorf("unsupported LLM provider: %q", cfg.Provider)
+	}
+}
+
+func newVertexAIModel(ctx context.Context, cfg config.LLMConfig) (model.LLM, error) {
+	adkCfg := &adkanthropic.Config{
+		Variant:         adkanthropic.VariantVertexAI,
+		VertexProjectID: cfg.VertexProject,
+		VertexLocation:  cfg.VertexLocation,
+	}
+	if cfg.Endpoint != "" {
+		adkCfg.BaseURL = cfg.Endpoint
+	}
+	return adkanthropic.NewModel(ctx, anthropic.Model(cfg.Model), adkCfg)
+}
+
+func newGeminiModel(ctx context.Context, cfg config.LLMConfig) (model.LLM, error) {
+	clientCfg := &genai.ClientConfig{
+		APIKey:  cfg.APIKey,
+		Backend: genai.BackendGeminiAPI,
+	}
+	if cfg.Endpoint != "" {
+		clientCfg.HTTPOptions = genai.HTTPOptions{
+			BaseURL: cfg.Endpoint,
+		}
+	}
+
+	httpClient, err := buildLLMHTTPClient(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("build HTTP client: %w", err)
+	}
+	if httpClient != nil {
+		clientCfg.HTTPClient = httpClient
+	}
+
+	return gemini.NewModel(ctx, cfg.Model, clientCfg)
+}
+
+func newAnthropicModel(ctx context.Context, cfg config.LLMConfig) (model.LLM, error) {
+	adkCfg := &adkanthropic.Config{
+		Variant: adkanthropic.VariantAnthropicAPI,
+		APIKey:  cfg.APIKey,
+	}
+	if cfg.Endpoint != "" {
+		adkCfg.BaseURL = cfg.Endpoint
+	}
+	return adkanthropic.NewModel(ctx, anthropic.Model(cfg.Model), adkCfg)
+}
+
+// buildLLMHTTPClient constructs an HTTP client with the transport chain
+// (TLS CA, OAuth2, custom headers, circuit breaker) when any auth/resilience
+// options are configured. Returns (nil, nil) when no custom transport is needed.
+func buildLLMHTTPClient(cfg config.LLMConfig) (*http.Client, error) {
+	rt, err := buildTransportChain(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if rt == nil {
+		return nil, nil
+	}
+	timeout := time.Duration(config.DefaultLLMTimeoutSeconds) * time.Second
+	if cfg.TimeoutSeconds > 0 {
+		timeout = time.Duration(cfg.TimeoutSeconds) * time.Second
+	}
+	return &http.Client{
+		Transport: rt,
+		Timeout:   timeout,
+	}, nil
+}
+
+// buildTransportChain composes the HTTP transport stack from config.
+// Chain order (outermost first): CircuitBreaker -> CustomHeaders -> OAuth2 -> TLS/base
+// Returns (nil, nil) when no custom transport is needed.
+func buildTransportChain(cfg config.LLMConfig) (http.RoundTripper, error) {
+	base := http.DefaultTransport
+	needsCustom := false
+
+	if cfg.TLSCaFile != "" {
+		tlsTransport, err := sharedtls.NewTLSTransport(cfg.TLSCaFile)
+		if err != nil {
+			return nil, fmt.Errorf("load TLS CA %q: %w", cfg.TLSCaFile, err)
+		}
+		base = tlsTransport
+		needsCustom = true
+	}
+
+	if cfg.OAuth2.Enabled {
+		oauth2Cfg := kaconfig.OAuth2Config{
+			Enabled:        cfg.OAuth2.Enabled,
+			TokenURL:       cfg.OAuth2.TokenURL,
+			Scopes:         cfg.OAuth2.Scopes,
+			CredentialsDir: cfg.OAuth2.CredentialsDir,
+		}
+		resolveOAuth2Secrets(&oauth2Cfg)
+		base = internaltransport.NewOAuth2ClientCredentialsTransport(oauth2Cfg, base)
+		needsCustom = true
+	}
+
+	if len(cfg.CustomHeaders) > 0 {
+		headers := make([]pkgconfig.HeaderDefinition, 0, len(cfg.CustomHeaders))
+		for _, h := range cfg.CustomHeaders {
+			headers = append(headers, pkgconfig.HeaderDefinition{
+				Name:     h.Name,
+				Value:    h.Value,
+				FilePath: h.FilePath,
+			})
+		}
+		base = llmtransport.NewAuthHeadersTransport(headers, base)
+		needsCustom = true
+	}
+
+	if cfg.CircuitBreaker.Enabled {
+		base = transport.NewCircuitBreakerTransport(base, transport.CircuitBreakerConfig{
+			Enabled:          true,
+			Name:             "af-llm",
+			MaxRequests:      cfg.CircuitBreaker.MaxRequests,
+			Interval:         cfg.CircuitBreaker.Interval,
+			Timeout:          cfg.CircuitBreaker.Timeout,
+			FailureThreshold: cfg.CircuitBreaker.FailureThreshold,
+		})
+		needsCustom = true
+	}
+
+	if !needsCustom {
+		return nil, nil
+	}
+	return base, nil
+}
+
+// resolveOAuth2Secrets reads client-id and client-secret from the mounted
+// secrets directory (same layout as KA: <credentialsDir>/client-id, client-secret).
+func resolveOAuth2Secrets(cfg *kaconfig.OAuth2Config) {
+	if cfg.CredentialsDir == "" {
+		return
+	}
+	if data, err := os.ReadFile(cfg.CredentialsDir + "/client-id"); err == nil {
+		cfg.ClientID = strings.TrimSpace(string(data))
+	}
+	if data, err := os.ReadFile(cfg.CredentialsDir + "/client-secret"); err == nil {
+		cfg.ClientSecret = strings.TrimSpace(string(data))
 	}
 }

--- a/pkg/apifrontend/launcher/model.go
+++ b/pkg/apifrontend/launcher/model.go
@@ -55,7 +55,12 @@ func NewModelFromConfig(ctx context.Context, cfg config.LLMConfig) (model.LLM, e
 	}
 }
 
-func newVertexAIModel(ctx context.Context, cfg config.LLMConfig) (model.LLM, error) {
+func newVertexAIModel(ctx context.Context, cfg config.LLMConfig) (m model.LLM, err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("vertex_ai: GCP ADC unavailable — set GOOGLE_APPLICATION_CREDENTIALS or provide credentials: %v", r)
+		}
+	}()
 	adkCfg := &adkanthropic.Config{
 		Variant:         adkanthropic.VariantVertexAI,
 		VertexProjectID: cfg.VertexProject,

--- a/pkg/apifrontend/launcher/model.go
+++ b/pkg/apifrontend/launcher/model.go
@@ -124,6 +124,12 @@ func buildLLMHTTPClient(cfg config.LLMConfig) (*http.Client, error) {
 // buildTransportChain composes the HTTP transport stack from config.
 // Chain order (outermost first): CircuitBreaker -> CustomHeaders -> OAuth2 -> TLS/base
 // Returns (nil, nil) when no custom transport is needed.
+//
+// NOTE: This transport chain is currently only applied to the Gemini provider
+// (via buildLLMHTTPClient). Vertex AI uses GCP-managed auth (ADC) and the
+// Anthropic ADK wrapper does not expose HTTP client injection. If support is
+// added for Anthropic transport in the future, validateLLM() must be updated
+// to allow it, and newAnthropicModel must call buildLLMHTTPClient.
 func buildTransportChain(cfg config.LLMConfig) (http.RoundTripper, error) {
 	base := http.DefaultTransport
 	needsCustom := false
@@ -144,7 +150,9 @@ func buildTransportChain(cfg config.LLMConfig) (http.RoundTripper, error) {
 			Scopes:         cfg.OAuth2.Scopes,
 			CredentialsDir: cfg.OAuth2.CredentialsDir,
 		}
-		resolveOAuth2Secrets(&oauth2Cfg)
+		if err := resolveOAuth2Secrets(&oauth2Cfg); err != nil {
+			return nil, fmt.Errorf("resolve OAuth2 secrets: %w", err)
+		}
 		base = internaltransport.NewOAuth2ClientCredentialsTransport(oauth2Cfg, base)
 		needsCustom = true
 	}
@@ -182,14 +190,20 @@ func buildTransportChain(cfg config.LLMConfig) (http.RoundTripper, error) {
 
 // resolveOAuth2Secrets reads client-id and client-secret from the mounted
 // secrets directory (same layout as KA: <credentialsDir>/client-id, client-secret).
-func resolveOAuth2Secrets(cfg *kaconfig.OAuth2Config) {
+func resolveOAuth2Secrets(cfg *kaconfig.OAuth2Config) error {
 	if cfg.CredentialsDir == "" {
-		return
+		return nil
 	}
-	if data, err := os.ReadFile(cfg.CredentialsDir + "/client-id"); err == nil {
-		cfg.ClientID = strings.TrimSpace(string(data))
+	data, err := os.ReadFile(cfg.CredentialsDir + "/client-id")
+	if err != nil {
+		return fmt.Errorf("read oauth2 client-id from %s: %w", cfg.CredentialsDir, err)
 	}
-	if data, err := os.ReadFile(cfg.CredentialsDir + "/client-secret"); err == nil {
-		cfg.ClientSecret = strings.TrimSpace(string(data))
+	cfg.ClientID = strings.TrimSpace(string(data))
+
+	data, err = os.ReadFile(cfg.CredentialsDir + "/client-secret")
+	if err != nil {
+		return fmt.Errorf("read oauth2 client-secret from %s: %w", cfg.CredentialsDir, err)
 	}
+	cfg.ClientSecret = strings.TrimSpace(string(data))
+	return nil
 }

--- a/pkg/apifrontend/launcher/model_test.go
+++ b/pkg/apifrontend/launcher/model_test.go
@@ -1,53 +1,71 @@
 package launcher_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/config"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
 )
 
-var _ = Describe("Model", func() {
-	Describe("NewModelConfig", func() {
-		It("UT-AF-210-008: default config uses Claude Sonnet via Vertex AI", func() {
-			cfg := launcher.DefaultModelConfig()
-			Expect(cfg.Provider).To(Equal("vertexai"))
-			Expect(cfg.Model).To(ContainSubstring("claude"))
-		})
-
-		It("UT-AF-210-009: validates provider is supported", func() {
-			cfg := launcher.ModelConfig{Provider: "unsupported", Model: "test"}
-			err := cfg.Validate()
+var _ = Describe("Model Factory", func() {
+	Describe("NewModelFromConfig", func() {
+		It("UT-AF-1252-001: rejects unsupported provider", func() {
+			cfg := config.LLMConfig{Provider: "unsupported", Model: "test"}
+			_, err := launcher.NewModelFromConfig(context.Background(), cfg)
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("unsupported provider"))
+			Expect(err.Error()).To(ContainSubstring("unsupported LLM provider"))
 		})
 
-		It("UT-AF-210-010: validates model name is non-empty", func() {
-			cfg := launcher.ModelConfig{Provider: "vertexai", Model: ""}
-			err := cfg.Validate()
-			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("model"))
-		})
-
-		It("UT-AF-210-011: accepts vertexai provider", func() {
-			cfg := launcher.ModelConfig{Provider: "vertexai", Model: "claude-sonnet-4-20250514"}
-			err := cfg.Validate()
+		It("UT-AF-1252-002: constructs gemini model with API key and endpoint", func() {
+			cfg := config.LLMConfig{
+				Provider: config.LLMProviderGemini,
+				Model:    "gemini-2.0-flash",
+				Endpoint: "http://localhost:8888/v1",
+				APIKey:   "test-key",
+			}
+			m, err := launcher.NewModelFromConfig(context.Background(), cfg)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(m).NotTo(BeNil())
+			Expect(m.Name()).To(ContainSubstring("gemini"))
 		})
 
-		It("UT-AF-210-012: accepts anthropic provider", func() {
-			cfg := launcher.ModelConfig{Provider: "anthropic", Model: "claude-sonnet-4-20250514"}
-			err := cfg.Validate()
+		It("UT-AF-1252-003: constructs anthropic model with API key", func() {
+			cfg := config.LLMConfig{
+				Provider: config.LLMProviderAnthropic,
+				Model:    "claude-sonnet-4-20250514",
+				APIKey:   "sk-ant-test-key",
+			}
+			m, err := launcher.NewModelFromConfig(context.Background(), cfg)
 			Expect(err).NotTo(HaveOccurred())
+			Expect(m).NotTo(BeNil())
+		})
+
+		It("UT-AF-1252-004: vertex_ai requires valid GCP project/location", func() {
+			cfg := config.LLMConfig{
+				Provider:       config.LLMProviderVertexAI,
+				Model:          "claude-sonnet-4-20250514",
+				VertexProject:  "test-project",
+				VertexLocation: "us-central1",
+			}
+			// This will fail in CI without real GCP ADC, but should not panic
+			_, err := launcher.NewModelFromConfig(context.Background(), cfg)
+			// Accept both success (if ADC is available) and specific auth error
+			if err != nil {
+				Expect(err.Error()).To(SatisfyAny(
+					ContainSubstring("credentials"),
+					ContainSubstring("auth"),
+					ContainSubstring("token"),
+					ContainSubstring("transport"),
+					ContainSubstring("could not find"),
+				))
+			}
 		})
 	})
 
-	Describe("JWT Delegation", func() {
-		It("UT-AF-210-013: JWTDelegationEnabled defaults to true", func() {
-			cfg := launcher.DefaultModelConfig()
-			Expect(cfg.JWTDelegation).To(BeTrue())
-		})
-
+	Describe("A2AConfig", func() {
 		It("UT-AF-210-014: A2AConfig validation rejects nil Agent", func() {
 			_, err := launcher.NewA2AHandler(launcher.A2AConfig{
 				Agent:          nil,

--- a/pkg/apifrontend/launcher/model_test.go
+++ b/pkg/apifrontend/launcher/model_test.go
@@ -52,8 +52,7 @@ var _ = Describe("Model Factory", func() {
 			}
 			_, err := launcher.NewModelFromConfig(context.Background(), cfg)
 			if err != nil {
-				// Without real GCP ADC, the SDK returns a specific ADC error.
-				Expect(err.Error()).To(ContainSubstring("could not find default credentials"))
+				Expect(err.Error()).To(ContainSubstring("GCP ADC unavailable"))
 			}
 		})
 	})

--- a/pkg/apifrontend/launcher/model_test.go
+++ b/pkg/apifrontend/launcher/model_test.go
@@ -50,17 +50,10 @@ var _ = Describe("Model Factory", func() {
 				VertexProject:  "test-project",
 				VertexLocation: "us-central1",
 			}
-			// This will fail in CI without real GCP ADC, but should not panic
 			_, err := launcher.NewModelFromConfig(context.Background(), cfg)
-			// Accept both success (if ADC is available) and specific auth error
 			if err != nil {
-				Expect(err.Error()).To(SatisfyAny(
-					ContainSubstring("credentials"),
-					ContainSubstring("auth"),
-					ContainSubstring("token"),
-					ContainSubstring("transport"),
-					ContainSubstring("could not find"),
-				))
+				// Without real GCP ADC, the SDK returns a specific ADC error.
+				Expect(err.Error()).To(ContainSubstring("could not find default credentials"))
 			}
 		})
 	})

--- a/pkg/apifrontend/launcher/transport_chain_test.go
+++ b/pkg/apifrontend/launcher/transport_chain_test.go
@@ -1,0 +1,161 @@
+package launcher_test
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/config"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
+)
+
+var _ = Describe("Transport Chain", func() {
+	Describe("BuildTransportChain", func() {
+		It("UT-AF-1252-TC-001: returns nil when no transport config is set", func() {
+			cfg := config.LLMConfig{
+				Provider: config.LLMProviderGemini,
+				Model:    "gemini-2.0-flash",
+				APIKey:   "test-key",
+			}
+			rt, err := launcher.BuildTransportChainForTest(cfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rt).To(BeNil())
+		})
+
+		It("UT-AF-1252-TC-002: constructs TLS-only transport chain", func() {
+			dir := GinkgoT().TempDir()
+			caFile := filepath.Join(dir, "ca.crt")
+			Expect(os.WriteFile(caFile, []byte(testCACert), 0o600)).To(Succeed())
+
+			cfg := config.LLMConfig{
+				Provider:  config.LLMProviderGemini,
+				Model:     "gemini-2.0-flash",
+				APIKey:    "test-key",
+				TLSCaFile: caFile,
+			}
+			rt, err := launcher.BuildTransportChainForTest(cfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rt).NotTo(BeNil())
+		})
+
+		It("UT-AF-1252-TC-003: returns error for invalid TLS CA file", func() {
+			cfg := config.LLMConfig{
+				Provider:  config.LLMProviderGemini,
+				Model:     "gemini-2.0-flash",
+				APIKey:    "test-key",
+				TLSCaFile: "/nonexistent/ca.crt",
+			}
+			rt, err := launcher.BuildTransportChainForTest(cfg)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("load TLS CA"))
+			Expect(rt).To(BeNil())
+		})
+
+		It("UT-AF-1252-TC-004: constructs circuit-breaker-only transport chain", func() {
+			cfg := config.LLMConfig{
+				Provider: config.LLMProviderGemini,
+				Model:    "gemini-2.0-flash",
+				APIKey:   "test-key",
+				CircuitBreaker: config.LLMCircuitBreaker{
+					Enabled:          true,
+					MaxRequests:      3,
+					Interval:         10 * time.Second,
+					Timeout:          30 * time.Second,
+					FailureThreshold: 5,
+				},
+			}
+			rt, err := launcher.BuildTransportChainForTest(cfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rt).NotTo(BeNil())
+		})
+
+		It("UT-AF-1252-TC-005: returns error when OAuth2 credential files are missing", func() {
+			cfg := config.LLMConfig{
+				Provider: config.LLMProviderGemini,
+				Model:    "gemini-2.0-flash",
+				APIKey:   "test-key",
+				OAuth2: config.LLMOAuth2Config{
+					Enabled:        true,
+					TokenURL:       "https://auth.example.com/token",
+					CredentialsDir: "/nonexistent/creds",
+				},
+			}
+			rt, err := launcher.BuildTransportChainForTest(cfg)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("resolve OAuth2 secrets"))
+			Expect(rt).To(BeNil())
+		})
+	})
+
+	Describe("BuildLLMHTTPClient", func() {
+		It("UT-AF-1252-TC-006: returns nil client when no transport config", func() {
+			cfg := config.LLMConfig{
+				Provider: config.LLMProviderGemini,
+				Model:    "gemini-2.0-flash",
+				APIKey:   "test-key",
+			}
+			client, err := launcher.BuildLLMHTTPClientForTest(cfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).To(BeNil())
+		})
+
+		It("UT-AF-1252-TC-007: applies configured timeout", func() {
+			dir := GinkgoT().TempDir()
+			caFile := filepath.Join(dir, "ca.crt")
+			Expect(os.WriteFile(caFile, []byte(testCACert), 0o600)).To(Succeed())
+
+			cfg := config.LLMConfig{
+				Provider:       config.LLMProviderGemini,
+				Model:          "gemini-2.0-flash",
+				APIKey:         "test-key",
+				TLSCaFile:      caFile,
+				TimeoutSeconds: 60,
+			}
+			client, err := launcher.BuildLLMHTTPClientForTest(cfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).NotTo(BeNil())
+			Expect(client.Timeout).To(Equal(60 * time.Second))
+		})
+
+		It("UT-AF-1252-TC-008: uses default timeout when not configured", func() {
+			dir := GinkgoT().TempDir()
+			caFile := filepath.Join(dir, "ca.crt")
+			Expect(os.WriteFile(caFile, []byte(testCACert), 0o600)).To(Succeed())
+
+			cfg := config.LLMConfig{
+				Provider:  config.LLMProviderGemini,
+				Model:     "gemini-2.0-flash",
+				APIKey:    "test-key",
+				TLSCaFile: caFile,
+			}
+			client, err := launcher.BuildLLMHTTPClientForTest(cfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).NotTo(BeNil())
+			Expect(client.Timeout).To(Equal(time.Duration(config.DefaultLLMTimeoutSeconds) * time.Second))
+		})
+	})
+})
+
+// testCACert is a self-signed CA certificate for testing TLS transport construction.
+const testCACert = `-----BEGIN CERTIFICATE-----
+MIIDAzCCAeugAwIBAgIUe0eB61uYLyO7ZNkfNmH+zzSjqOYwDQYJKoZIhvcNAQEL
+BQAwETEPMA0GA1UEAwwGVGVzdENBMB4XDTI2MDUyNDAwMDI1OFoXDTI3MDUyNDAw
+MDI1OFowETEPMA0GA1UEAwwGVGVzdENBMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8A
+MIIBCgKCAQEAu6gaNCj6skPlixo6BDyYTMYWMkm25skLYxqiC7/ocNLmkO6nMYAT
+naKxfZE28/Ebx7XwGUHbA+yajFWWod5JH8HosXMBli2XCs0yJQpsinmztZUOOEWB
+PYIyv8HeuARqH/RiO+aeVybkc54UDKh367zxPdda/YkcpkMLBDlX152HGkhjTGNO
+dePMU9jdcDi7fgQty1K3kHY0zshKnolXDt7kqsWQptPtfdk+f619B+kByWQnyJmA
+qi+vX9Ixa1lxCf68DdfS/l3PJ6PWbSLeD6vs7I6CAfX2hlcLjj6xNkrnqaI5/ZOO
+tkF4H5gWoBJtVHYHqAMKQPOebJTwJ3Z+OwIDAQABo1MwUTAdBgNVHQ4EFgQUB6SU
+CmZY7/HdcM0dwDB1poV6bmEwHwYDVR0jBBgwFoAUB6SUCmZY7/HdcM0dwDB1poV6
+bmEwDwYDVR0TAQH/BAUwAwEB/zANBgkqhkiG9w0BAQsFAAOCAQEAHvL1JjCEIoY6
+g8MytDNzZv2R4UYjHi4HkeinP8uu/uF2kyT1qsGRZW+eOsQ+D8Nr4ounmUODZz4k
+Wge57pu9F4AzvxtC5z4jLcDAWGvAGTvOUqx/Kc50VJ2w6GBqunW4oPQ53OgrrqqJ
+AEJwNJqC+xkWMNM6O9FL6v7NDGLqOookAw/bTY6hByRnmvGQIvZCpekeQbzq06iV
+J7/w9nCZ4qAQZtyXnb5rKMZ9x4oe2L+CtSD+ZfmE4PRVm2LCbYwgxmoskUMLxPpj
+HQTWeS9GcO9/pD8+DJtP8wIbitnT3oSsKZ1WaoegsEB5IEIrk8CD4lgkAEYAv7GZ
+McX6RiIchA==
+-----END CERTIFICATE-----`

--- a/test/e2e/apifrontend/infrastructure/setup.go
+++ b/test/e2e/apifrontend/infrastructure/setup.go
@@ -639,8 +639,8 @@ spec:
             - name: inter-service-ca
               mountPath: /etc/apifrontend/inter-service-ca
               readOnly: true
-            - name: llm-key
-              mountPath: /etc/apifrontend/secrets
+            - name: llm-credentials
+              mountPath: /etc/apifrontend/llm-credentials
               readOnly: true
             - name: coverdata
               mountPath: /coverdata
@@ -677,7 +677,7 @@ spec:
         - name: inter-service-ca
           configMap:
             name: inter-service-ca
-        - name: llm-key
+        - name: llm-credentials
           secret:
             secretName: apifrontend-llm-key
         - name: coverdata
@@ -706,7 +706,17 @@ spec:
       nodePort: 30081
   selector:
     app: apifrontend
-`, namespace, indentYAML(string(configData), 4), afImage)
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: apifrontend-llm-key
+  namespace: %s
+type: Opaque
+stringData:
+  llm-api-key: "mock-key"
+`, namespace, indentYAML(string(configData), 4),
+		namespace, afImage, namespace, namespace)
 	return kubectlApplyStdin(ctx, kubeconfigPath, manifest, writer)
 }
 

--- a/test/e2e/apifrontend/infrastructure/setup.go
+++ b/test/e2e/apifrontend/infrastructure/setup.go
@@ -706,17 +706,7 @@ spec:
       nodePort: 30081
   selector:
     app: apifrontend
----
-apiVersion: v1
-kind: Secret
-metadata:
-  name: apifrontend-llm-key
-  namespace: %s
-type: Opaque
-stringData:
-  llm-api-key: "mock-key"
-`, namespace, indentYAML(string(configData), 4),
-		namespace, afImage, namespace, namespace)
+`, namespace, indentYAML(string(configData), 4), afImage)
 	return kubectlApplyStdin(ctx, kubeconfigPath, manifest, writer)
 }
 

--- a/test/infrastructure/fullpipeline_e2e.go
+++ b/test/infrastructure/fullpipeline_e2e.go
@@ -1298,8 +1298,8 @@ spec:
             - name: inter-service-ca
               mountPath: /etc/apifrontend/inter-service-ca
               readOnly: true
-            - name: llm-key
-              mountPath: /etc/apifrontend/secrets
+            - name: llm-credentials
+              mountPath: /etc/apifrontend/llm-credentials
               readOnly: true
           readinessProbe:
             httpGet:
@@ -1334,7 +1334,7 @@ spec:
         - name: inter-service-ca
           configMap:
             name: inter-service-ca
-        - name: llm-key
+        - name: llm-credentials
           secret:
             secretName: apifrontend-llm-key
 ---


### PR DESCRIPTION
## Summary

Implements multi-provider LLM support for the API Frontend A2A handler, aligning with KA's configuration patterns:

- **Unified LLM config schema** — nested `agent.llm` section with provider, model, endpoint, apiKeyFile, OAuth2, circuit breaker, custom headers, and TLS CA fields
- **Provider factory** — `launcher.NewModelFromConfig` creates ADK `model.LLM` instances for `vertex_ai`, `gemini`, and `anthropic`
- **Transport chain** — TLS CA, OAuth2, custom headers, and circuit breaker composed into a layered HTTP client (applied to Gemini; Vertex uses GCP ADC; Anthropic uses API key)
- **FedRAMP hardening** — file-based secrets (IA-5), URL/endpoint validation (SC-7), error propagation from TLS construction (SC-12), credential presence enforcement, CB bounds validation

### Commits

1. `feat(config)` — LLMConfig types + validation + ResolveDefaults hardening
2. `feat(launcher)` — NewModelFromConfig factory + transport chain
3. `feat(apifrontend)` — Wire factory in buildA2AHandler
4. `refactor(agent)` — Remove superseded GCPProject/GCPRegion fields
5. `chore(deploy)` — Update base/E2E manifests for new schema

### Breaking Changes

- Removes flat `agent.llmEndpoint`, `agent.llmModel`, `agent.llmAPIKey`, `agent.gcpProject`, `agent.gcpRegion` config fields
- Replaces `LLM_API_KEY` env var with file-based secret mount

Closes #1252.

## Test plan

- [x] Unit tests for config validation (14 new tests covering provider enum, required fields, URL validation, CB bounds, credential enforcement)
- [x] Unit tests for factory (all 3 providers + error cases)
- [x] Wiring test updated for new config structure
- [x] ResolveDefaults tests for key file read, missing file error, empty file error
- [x] Build passes (`go build ./...`)
- [x] Full AF test suite passes (`go test ./pkg/apifrontend/... ./cmd/apifrontend/...`)
- [ ] E2E AF tests pass in CI with updated manifests


Made with [Cursor](https://cursor.com)