### PR TITLE
feat(af): hardcode agent card name and description

### DIFF
--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -203,8 +203,8 @@ func run() int {
 	}
 
 	agentCardBase, err := handler.NewAgentCardHandler(handler.AgentCardConfig{
-		Name:        cfg.AgentCard.Name,
-		Description: "Kubernaut AI-driven remediation API Frontend",
+		Name:        "Kubernaut Agent",
+		Description: "Kubernaut AI-driven remediation agent",
 		URL:         cfg.AgentCard.URL,
 		Version:     version(),
 		Skills:      handler.DefaultAgentSkills(),

--- a/deploy/apifrontend/base/config.yaml
+++ b/deploy/apifrontend/base/config.yaml
@@ -25,7 +25,6 @@ mcp:
     kubernaut_stream_investigation: 15m
 
 agentCard:
-  name: "Kubernaut Agent"
   url: "https://apifrontend.kubernaut-system.svc:8443"
 
 auth:

--- a/pkg/apifrontend/config/config.go
+++ b/pkg/apifrontend/config/config.go
@@ -185,14 +185,9 @@ type MCPConfig struct {
 	ToolTimeouts       map[string]time.Duration   `yaml:"toolTimeouts,omitempty"`
 }
 
-// MaxAgentCardNameLength is the upper bound for the agent card display name.
-// The A2A spec does not mandate a limit; 128 is a sensible cap for UI/log contexts.
-const MaxAgentCardNameLength = 128
-
 // AgentCardConfig holds the agent card endpoint configuration.
 type AgentCardConfig struct {
-	Name string `yaml:"name,omitempty"`
-	URL  string `yaml:"url"`
+	URL string `yaml:"url"`
 }
 
 // RBACConfig holds SAR-based RBAC authorization configuration.
@@ -315,15 +310,6 @@ func (c *Config) Validate() error {
 	if c.Agent.DSBearerTokenFile != "" {
 		if _, err := os.Stat(c.Agent.DSBearerTokenFile); err != nil {
 			return fmt.Errorf("agent.dsBearerTokenFile %q is not accessible: %w", c.Agent.DSBearerTokenFile, err)
-		}
-	}
-	if c.AgentCard.Name != "" {
-		trimmed := strings.TrimSpace(c.AgentCard.Name)
-		if trimmed == "" {
-			return fmt.Errorf("agentCard.name must not be whitespace-only")
-		}
-		if runeCount := len([]rune(c.AgentCard.Name)); runeCount > MaxAgentCardNameLength {
-			return fmt.Errorf("agentCard.name must be at most %d characters, got %d", MaxAgentCardNameLength, runeCount)
 		}
 	}
 	if err := c.validateLLM(); err != nil {
@@ -533,9 +519,6 @@ func validateDependencyConfig(prefix string, cfg *DependencyConfig) error {
 // LLM API key is resolved from the mounted Secret file at APIKeyFile.
 // Returns an error if a required credential file is configured but unreadable/empty.
 func (c *Config) ResolveDefaults() error {
-	if c.AgentCard.Name == "" {
-		c.AgentCard.Name = "Kubernaut Agent"
-	}
 	if c.AgentCard.URL == "" {
 		c.AgentCard.URL = fmt.Sprintf("https://localhost:%d", c.Server.Port)
 	}

--- a/pkg/apifrontend/config/config_test.go
+++ b/pkg/apifrontend/config/config_test.go
@@ -66,9 +66,6 @@ func TestLoad_ValidFullYAML(t *testing.T) {
 	if cfg.AgentCard.URL != "https://af.example.com" {
 		t.Errorf("AgentCard.URL = %q, want %q", cfg.AgentCard.URL, "https://af.example.com")
 	}
-	if cfg.AgentCard.Name != "Kubernaut Agent" {
-		t.Errorf("AgentCard.Name = %q, want %q", cfg.AgentCard.Name, "Kubernaut Agent")
-	}
 }
 
 func TestLoad_AppliesDefaultsForOmittedFields(t *testing.T) {
@@ -1101,126 +1098,6 @@ func TestValidate_SessionNamespaceRequiredWhenTTLsSet(t *testing.T) {
 				t.Errorf("error = %q, want to contain 'session.namespace'", err.Error())
 			}
 		})
-	}
-}
-
-// --- Tier 7b: Agent Card Config (Issue #1259) ---
-
-func TestLoad_AgentCardName(t *testing.T) {
-	// UT-AF-1259-001: agentCard.name field is parsed from YAML.
-	data := []byte(`
-agentCard:
-  name: "Kubernaut Agent"
-  url: "https://af.example.com"
-`)
-	cfg, err := Load(data)
-	if err != nil {
-		t.Fatalf("Load() error = %v", err)
-	}
-	if cfg.AgentCard.Name != "Kubernaut Agent" {
-		t.Errorf("AgentCard.Name = %q, want %q", cfg.AgentCard.Name, "Kubernaut Agent")
-	}
-}
-
-func TestLoad_AgentCardNameOmitted(t *testing.T) {
-	// UT-AF-1259-002: agentCard.name defaults to empty when omitted.
-	data := []byte(`
-agentCard:
-  url: "https://af.example.com"
-`)
-	cfg, err := Load(data)
-	if err != nil {
-		t.Fatalf("Load() error = %v", err)
-	}
-	if cfg.AgentCard.Name != "" {
-		t.Errorf("AgentCard.Name = %q, want empty", cfg.AgentCard.Name)
-	}
-}
-
-func TestValidate_AgentCardNameTooLong(t *testing.T) {
-	// UT-AF-1259-003: names > 128 characters are rejected.
-	cfg := validConfig()
-	cfg.AgentCard.Name = strings.Repeat("a", 129)
-	err := cfg.Validate()
-	if err == nil {
-		t.Fatal("expected error for name > 128 chars")
-	}
-	if !strings.Contains(err.Error(), "agentCard.name") {
-		t.Errorf("error = %q, want to contain 'agentCard.name'", err.Error())
-	}
-}
-
-func TestValidate_AgentCardNameAtLimit(t *testing.T) {
-	// UT-AF-1259-004: name exactly 128 chars is accepted.
-	cfg := validConfig()
-	cfg.AgentCard.Name = strings.Repeat("a", 128)
-	if err := cfg.Validate(); err != nil {
-		t.Errorf("unexpected error for 128-char name: %v", err)
-	}
-}
-
-func TestValidate_AgentCardNameEmptyIsValid(t *testing.T) {
-	// UT-AF-1259-005: empty name is valid (falls back to default at wiring).
-	cfg := validConfig()
-	cfg.AgentCard.Name = ""
-	if err := cfg.Validate(); err != nil {
-		t.Errorf("unexpected error for empty agentCard.name: %v", err)
-	}
-}
-
-func TestValidate_AgentCardNameWhitespaceOnlyRejected(t *testing.T) {
-	// UT-AF-1259-009: whitespace-only name is rejected.
-	cfg := validConfig()
-	cfg.AgentCard.Name = "   \t\n"
-	err := cfg.Validate()
-	if err == nil {
-		t.Fatal("expected error for whitespace-only name")
-	}
-	if !strings.Contains(err.Error(), "agentCard.name") {
-		t.Errorf("error = %q, want to contain 'agentCard.name'", err.Error())
-	}
-}
-
-func TestValidate_AgentCardNameRuneLength(t *testing.T) {
-	// UT-AF-1259-010: length is measured in runes, not bytes.
-	// 128 CJK characters = 384 bytes in UTF-8, but should pass the 128-rune limit.
-	cfg := validConfig()
-	cfg.AgentCard.Name = strings.Repeat("あ", 128)
-	if err := cfg.Validate(); err != nil {
-		t.Errorf("unexpected error for 128-rune CJK name: %v", err)
-	}
-
-	cfg.AgentCard.Name = strings.Repeat("あ", 129)
-	err := cfg.Validate()
-	if err == nil {
-		t.Fatal("expected error for 129-rune CJK name")
-	}
-	if !strings.Contains(err.Error(), "agentCard.name") {
-		t.Errorf("error = %q, want to contain 'agentCard.name'", err.Error())
-	}
-}
-
-func TestResolveDefaults_AgentCardNameFallback(t *testing.T) {
-	// UT-AF-1259-006: empty name is set to "kubernaut-apifrontend" by ResolveDefaults.
-	cfg := validConfig()
-	cfg.AgentCard.Name = ""
-	if err := cfg.ResolveDefaults(); err != nil {
-		t.Fatalf("ResolveDefaults() = %v", err)
-	}
-	if cfg.AgentCard.Name != "Kubernaut Agent" {
-		t.Errorf("AgentCard.Name = %q, want %q", cfg.AgentCard.Name, "Kubernaut Agent")
-	}
-}
-
-func TestResolveDefaults_AgentCardNamePreservesExplicit(t *testing.T) {
-	// UT-AF-1259-007: explicit name is preserved by ResolveDefaults.
-	cfg := validConfig()
-	cfg.AgentCard.Name = "Kubernaut Agent"
-	if err := cfg.ResolveDefaults(); err != nil {
-		t.Fatalf("ResolveDefaults() = %v", err)
-	}
-	if cfg.AgentCard.Name != "Kubernaut Agent" {
-		t.Errorf("AgentCard.Name = %q, want %q", cfg.AgentCard.Name, "Kubernaut Agent")
 	}
 }
 

--- a/pkg/apifrontend/config/testdata/valid.yaml
+++ b/pkg/apifrontend/config/testdata/valid.yaml
@@ -12,5 +12,4 @@ agent:
 mcp:
   enabled: true
 agentCard:
-  name: "Kubernaut Agent"
   url: "https://af.example.com"

--- a/pkg/apifrontend/handler/agentcard_test.go
+++ b/pkg/apifrontend/handler/agentcard_test.go
@@ -69,8 +69,8 @@ var _ = Describe("Agent Card Handler", func() {
 
 	It("UT-AF-230-005: card includes name and description", func() {
 		h, err := handler.NewAgentCardHandler(handler.AgentCardConfig{
-			Name:        "kubernaut-apifrontend",
-			Description: "Kubernaut API Frontend agent for incident triage",
+			Name:        "Kubernaut Agent",
+			Description: "Kubernaut AI-driven remediation agent",
 			URL:         "https://kubernaut.example.com",
 			Version:     "0.1.0",
 		})
@@ -82,11 +82,11 @@ var _ = Describe("Agent Card Handler", func() {
 
 		var card map[string]any
 		_ = json.Unmarshal(rec.Body.Bytes(), &card)
-		Expect(card["name"]).To(Equal("kubernaut-apifrontend"))
-		Expect(card["description"]).To(Equal("Kubernaut API Frontend agent for incident triage"))
+		Expect(card["name"]).To(Equal("Kubernaut Agent"))
+		Expect(card["description"]).To(Equal("Kubernaut AI-driven remediation agent"))
 	})
 
-	It("UT-AF-1259-008: card reflects operator-configured name", func() {
+	It("UT-AF-1264-001: card shows hardcoded brand name", func() {
 		h, err := handler.NewAgentCardHandler(handler.AgentCardConfig{
 			Name:    "Kubernaut Agent",
 			URL:     "https://kubernaut.example.com",


### PR DESCRIPTION
## Summary

- Hardcodes agent card name to `"Kubernaut Agent"` and description to `"Kubernaut AI-driven remediation agent"` — removes `agentCard.name` config field to prevent unintentional rebranding
- Removes `MaxAgentCardNameLength` constant, name validation logic (whitespace-only, rune-length), and `ResolveDefaults` fallback since the field no longer exists
- Updates deploy YAML and test fixtures to remove the now-unused `name` key

## Test plan

- [x] Config package tests pass (no `AgentCard.Name` references remain)
- [x] Handler tests updated: `UT-AF-1264-001` verifies hardcoded brand name, `UT-AF-230-005` verifies name + description in served JSON
- [x] Full `go build ./...` passes
- [x] Net change: -150 lines (simplification)

Closes #1264

Made with [Cursor](https://cursor.com)