### PR TITLE
feat(apifrontend): add POST / A2A root alias (issue #1268)

### DIFF
--- a/api/apifrontend/openapi/apifrontend-v1.yaml
+++ b/api/apifrontend/openapi/apifrontend-v1.yaml
@@ -129,6 +129,45 @@ paths:
         "413":
           description: Request body exceeds 1 MiB limit
 
+  /:
+    post:
+      operationId: postA2ARoot
+      summary: A2A JSON-RPC 2.0 root alias (issue #1268)
+      description: |
+        Compatibility alias for POST /a2a/invoke. Identical behavior, auth, and
+        rate limiting. Added for kagenti and A2A ecosystem clients that POST
+        JSON-RPC messages to the root path per de facto convention.
+      tags: [a2a]
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/JsonRpcRequest"
+      responses:
+        "200":
+          description: JSON-RPC 2.0 response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/JsonRpcResponse"
+        "401":
+          description: Missing or invalid Bearer token
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "429":
+          description: Rate limit exceeded
+          content:
+            application/problem+json:
+              schema:
+                $ref: "#/components/schemas/ProblemDetail"
+        "413":
+          description: Request body exceeds 1 MiB limit
+
   /mcp:
     post:
       operationId: postMCP

--- a/docs/services/apifrontend/security/AUDIT_EVENT_CATALOG.md
+++ b/docs/services/apifrontend/security/AUDIT_EVENT_CATALOG.md
@@ -2,17 +2,18 @@
 
 Authoritative reference for all structured audit events emitted by the kubernaut-apifrontend service.
 
-**Source of truth:** `internal/audit/audit.go` (EventType constants)
+**Source of truth:** `pkg/apifrontend/audit/audit.go` (EventType constants)
 **Schema:** All events conform to the `audit.Event` struct:
 
 ```go
 type Event struct {
-    Timestamp time.Time         `json:"timestamp"`
-    Type      EventType         `json:"type"`
-    RequestID string            `json:"request_id,omitempty"`
-    UserID    string            `json:"user_id,omitempty"`
-    SourceIP  string            `json:"source_ip,omitempty"`
-    Detail    map[string]string `json:"detail,omitempty"`
+    Timestamp     time.Time         `json:"timestamp"`
+    Type          EventType         `json:"type"`
+    CorrelationID string            `json:"correlation_id,omitempty"`
+    RequestID     string            `json:"request_id,omitempty"`
+    UserID        string            `json:"user_id,omitempty"`
+    SourceIP      string            `json:"source_ip,omitempty"`
+    Detail        map[string]string `json:"detail,omitempty"`
 }
 ```
 
@@ -24,11 +25,10 @@ type Event struct {
 |-----------|----------|-------------|---------|---------------|
 | `auth.success` | `EventAuthSuccess` | AU-2, AC-7 | JWT validated or TokenReview accepted | `issuer`, `groups` |
 | `auth.failure` | `EventAuthFailure` | AU-2, AC-7 | JWT rejected or TokenReview denied | `reason` |
-| `rbac.denied` | `EventRBACDenied` | AC-3, AC-6 | Tool call blocked by RBAC guard | `tool`, `role`, `reason` |
-| ~~`impersonation.created`~~ | ~~`EventImpersonation`~~ | — | **Removed** (ADR-022: impersonation deprecated; user attribution via `tool.executed` events) | — |
+| `auth.access_denied` | `EventAuthAccessDenied` | AC-3, AC-6 | Tool call blocked by RBAC guard (consolidated from `rbac.denied` + `mcp.tool_denied`, Issue #1156) | `tool_name`, `user_role`, `endpoint`, `reason` |
 | `jwt.delegation` | `EventJWTDelegation` | AC-3, AU-12 | Original JWT forwarded to downstream service (KA) | `target_service` |
 
-**Emitted from:** `internal/auth/middleware.go`, `internal/agent/root.go` (RBAC guard)
+**Emitted from:** `pkg/apifrontend/auth/middleware.go`, `pkg/apifrontend/agent/root.go` (RBAC guard), `pkg/apifrontend/handler/mcp_bridge.go`
 
 ---
 
@@ -36,10 +36,12 @@ type Event struct {
 
 | Event Type | Constant | NIST Control | Trigger | Detail Fields |
 |-----------|----------|-------------|---------|---------------|
-| `tool.invoked` | `EventToolInvoked` | AU-12, AU-2 | Any ADK tool call completes (success or error) | `tool`, `result` (`success`/`error`), `namespace` (if applicable), `error` (on failure) |
-| `mcp.tool_invoked` | `EventMCPToolInvoked` | AU-12 | MCP protocol tool/call request handled | `tool`, `session_id` |
+| `tool.executed` | `EventToolExecuted` | AU-12, AU-2 | Any tool call completes (consolidated from `tool.invoked` + `mcp.tool_invoked`, Issue #1156) | `tool_name`, `tool_outcome` (`success`/`error`), `session_id`, `execution_duration_ms`, `namespace` (if applicable), `error` (on failure) |
+| `mcp.tool_failed` | `EventMCPToolFailed` | AU-12 | MCP tool/call request fails (panic, rate limit, throttle, error, marshal failure) | `tool_name`, `error` |
+| `mcp.session_init` | `EventMCPSessionInit` | AU-12 | MCP `initialize` JSON-RPC request handled (first per session) | `mcp_session_id`, `protocol_version` |
+| `workflow.discovery` | `EventWorkflowDiscovery` | AU-12 | `kubernaut_discover_workflows` tool returns workflow list | `workflow_count` |
 
-**Emitted from:** `internal/agent/root.go` (afterAudit callback), `internal/handler/mcp.go`
+**Emitted from:** `pkg/apifrontend/agent/root.go` (afterAudit callback), `pkg/apifrontend/handler/mcp.go`, `pkg/apifrontend/handler/mcp_bridge.go`, `pkg/apifrontend/tools/ka_interactive.go`
 
 ---
 
@@ -49,11 +51,12 @@ type Event struct {
 |-----------|----------|-------------|---------|---------------|
 | `session.created` | `EventSessionCreated` | AU-2, SC-4 | InvestigationSession CRD created | `session_id`, `user`, `rr_ref` |
 | `session.deleted` | `EventSessionDeleted` | AU-2 | Session CRD deleted (user or TTL) | `session_id`, `reason` |
-| `session.phase_changed` | `EventSessionPhaseChanged` | AU-2 | Session transitions state (e.g. active → completed) | `session_id`, `from`, `to` |
+| `session.phase_changed` | `EventSessionPhaseChanged` | AU-2 | Session transitions state (e.g. active -> completed) | `session_id`, `from`, `to` |
+| `session.completed` | `EventSessionCompleted` | AU-2 | Session reaches terminal phase (Completed/Failed/Cancelled) | `session_id`, `terminal_phase`, `total_duration_ms` |
 | `session.auto_cancelled` | `EventSessionAutoCancelled` | AU-2 | Session cancelled due to inactivity timeout | `session_id`, `idle_duration` |
 | `session.retention_deleted` | `EventSessionRetentionDeleted` | AU-2, SC-28 | Session deleted by retention policy (TTL controller) | `session_id`, `age` |
 
-**Emitted from:** `internal/session/service.go`, `internal/controller/ttl.go`
+**Emitted from:** `pkg/apifrontend/session/statemachine.go`, `pkg/apifrontend/session/service.go`, `pkg/apifrontend/controller/ttl.go`
 
 ---
 
@@ -61,11 +64,59 @@ type Event struct {
 
 | Event Type | Constant | NIST Control | Trigger | Detail Fields |
 |-----------|----------|-------------|---------|---------------|
-| `a2a.task_started` | `EventA2ATaskStarted` | AU-2 | A2A `message/send` begins execution | `task_id`, `user` |
+| `a2a.task_started` | `EventA2ATaskStarted` | AU-2 | A2A `message/send` begins execution | `task_id`, `user`, `session_id` |
 | `a2a.task_completed` | `EventA2ATaskCompleted` | AU-2 | A2A task finishes successfully | `task_id`, `duration_ms` |
 | `a2a.task_failed` | `EventA2ATaskFailed` | AU-2 | A2A task fails with error | `task_id`, `error` |
+| `a2a.stream_opened` | `EventA2AStreamOpened` | AU-2 | SSE stream opened for `message/stream` | *(defined; not yet emitted — logged only, see `streaming_executor.go`)* |
+| `a2a.stream_closed` | `EventA2AStreamClosed` | AU-2 | SSE stream closed | *(defined; not yet emitted — logged only, see `streaming_executor.go`)* |
 
-**Emitted from:** `internal/launcher/launcher.go` (BeforeExecute/AfterExecute callbacks)
+**Emitted from:** `pkg/apifrontend/launcher/launcher.go` (BeforeExecute/AfterExecute callbacks)
+
+---
+
+## Triage & Remediation
+
+| Event Type | Constant | NIST Control | Trigger | Detail Fields |
+|-----------|----------|-------------|---------|---------------|
+| `triage.started` | `EventTriageStarted` | AU-2, AU-12 | Triage pipeline begins for a session | `session_id`, `persona` |
+| `triage.completed` | `EventTriageCompleted` | AU-2, AU-12 | Triage pipeline completes | `session_id`, `triage_outcome`, `triage_duration_ms` |
+| `severity_triage.completed` | `EventSeverityTriageCompleted` | AU-2, AU-12 | Severity triage pipeline determines severity | `tier`, `severity`, `source`, `duration_ms`, `alert_name` (if Tier 1), `rule_name` (if Tier 1.5/2/2.5) |
+| `severity_triage.failed` | `EventSeverityTriageFailed` | AU-2 | All severity triage tiers fail or LLM error | `error` (redacted), `tier` (last attempted), `namespace`, `kind`, `name` |
+| `rr.created` | `EventRRCreated` | AU-2 | RemediationRequest CRD created | `session_id`, `rr_name`, `rr_namespace`, `fingerprint` |
+| `rr.deduplicated` | `EventRRDeduplicated` | AU-2 | Duplicate RemediationRequest detected, creation skipped | `session_id`, `fingerprint`, `existing_rr_name` |
+
+**Emitted from:** `pkg/apifrontend/launcher/launcher.go`, `pkg/apifrontend/tools/af_create_rr.go`
+
+---
+
+## KubernautAgent Delegation
+
+| Event Type | Constant | NIST Control | Trigger | Detail Fields |
+|-----------|----------|-------------|---------|---------------|
+| `ka.delegated` | `EventKADelegated` | AU-2, AU-12 | Work delegated to KubernautAgent (takeover, reconnect, REST) | `session_id`, `ka_correlation_id`, `delegation_type` |
+| `ka.result_received` | `EventKAResultReceived` | AU-2, AU-12 | Result received from KubernautAgent (complete, cancel, REST) | `session_id`, `ka_correlation_id`, `result_type` |
+
+**Emitted from:** `pkg/apifrontend/tools/ka_tools.go`, `pkg/apifrontend/tools/ka_interactive.go`
+
+---
+
+## User Interaction
+
+| Event Type | Constant | NIST Control | Trigger | Detail Fields |
+|-----------|----------|-------------|---------|---------------|
+| `user.decision` | `EventUserDecision` | AU-2 | User accepts/rejects a remediation workflow | `session_id`, `decision`, `workflow_id` |
+
+**Emitted from:** `pkg/apifrontend/tools/ka_tools.go`
+
+---
+
+## Discovery
+
+| Event Type | Constant | NIST Control | Trigger | Detail Fields |
+|-----------|----------|-------------|---------|---------------|
+| `discovery.agent_card_accessed` | `EventAgentCardAccessed` | AU-2, AU-3 | Agent card endpoint queried (Issue #1259) | `source_ip`, `user_agent` |
+
+**Emitted from:** `pkg/apifrontend/handler/agentcard.go`
 
 ---
 
@@ -76,7 +127,7 @@ type Event struct {
 | `ratelimit.denied` | `EventRateLimitDenied` | SC-5 | Request rejected by rate limiter | `client_ip`, `limit`, `window` |
 | `circuitbreaker.trip` | `EventCircuitBreakerTrip` | SI-17 | Circuit breaker opens (dependency unhealthy) | `dependency`, `failures` |
 
-**Emitted from:** `internal/ratelimit/ratelimit.go`, (circuit breaker state change)
+**Emitted from:** `pkg/apifrontend/ratelimit/ratelimit.go`, (circuit breaker state change)
 
 ---
 
@@ -84,10 +135,10 @@ type Event struct {
 
 | Event Type | Constant | NIST Control | Trigger | Detail Fields |
 |-----------|----------|-------------|---------|---------------|
-| `config.reloaded` | `EventConfigReloaded` | CM-3 | Hot-reload applied new configuration successfully | `source`, `keys_changed` |
+| `config.reloaded` | `EventConfigReloaded` | CM-3 | Hot-reload applied new configuration successfully | `source`, `keys_changed`, `config_version` |
 | `config.rejected` | `EventConfigRejected` | CM-3 | Hot-reload rejected invalid configuration | `source`, `reason` |
 
-**Emitted from:** `internal/config/hotreload.go`
+**Emitted from:** `pkg/apifrontend/config/hotreload.go`
 
 ---
 
@@ -97,31 +148,20 @@ Events are delivered through the `audit.Emitter` interface. Two implementations 
 
 | Implementation | Package | Behavior |
 |---------------|---------|----------|
-| `LogEmitter` | `internal/audit` | Writes structured log entries via `logr` (stdout/stderr) |
-| `BufferedEmitter` | `internal/audit` | Batches events and flushes to `audit.Writer` (Data Store API) with overflow protection |
+| `LogEmitter` | `pkg/apifrontend/audit` | Writes structured log entries via `logr` (stdout/stderr) |
+| `StoreAdapter` | `pkg/apifrontend/audit` | Normalizes events to `apifrontend.<event_type>` format, classifies severity, and forwards to Data Store API with correlation-ID enrichment |
 
-**Buffering contract (ADR-019):** The `BufferedEmitter` holds up to `MaxPending` events in memory. If the buffer overflows, oldest events are dropped and `af_audit_buffer_overflow_total` metric increments. On graceful shutdown, `Close()` flushes remaining events with a context deadline.
-
----
-
-## Severity Triage
-
-| Event Type | Constant | NIST Control | Trigger | Detail Fields |
-|-----------|----------|-------------|---------|---------------|
-| `severity.triage.completed` | `EventSeverityTriageCompleted` | AU-2, AU-12 | Triage pipeline determines severity | `tier`, `severity`, `source`, `duration_ms`, `alert_name` (if Tier 1), `rule_name` (if Tier 1.5/2/2.5) |
-| `severity.triage.failed` | `EventSeverityTriageFailed` | AU-2 | All triage tiers fail or LLM error | `error` (redacted), `tier` (last attempted), `namespace`, `kind`, `name` |
-
-**Emitted from:** `internal/severity/triage.go` (via tool handler integration in `internal/tools/af_create_rr.go`)
+**Buffering contract (ADR-019):** The `StoreAdapter` holds up to `MaxPending` events in memory. If the buffer overflows, oldest events are dropped and `af_audit_buffer_overflow_total` metric increments. On graceful shutdown, `Close()` flushes remaining events with a context deadline.
 
 ---
 
 ## Adding New Events
 
-1. Define the `EventType` constant in `internal/audit/audit.go`
+1. Define the `EventType` constant in `pkg/apifrontend/audit/audit.go`
 2. Add the emit call at the appropriate location with `Detail` fields
 3. Update this catalog with the new event's trigger, fields, and NIST mapping
 4. Ensure tests verify emission (check `Emit` call count or captured events)
 
 ---
 
-*Last updated: 2026-05-10 | Covers v1.5 milestone (issues #52, #56, #92)*
+*Last updated: 2026-05-19 | Covers v1.5 milestone (issues #52, #56, #92, #1156, #1259, #1268)*

--- a/pkg/apifrontend/handler/handler_test.go
+++ b/pkg/apifrontend/handler/handler_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Router", func() {
 	})
 
 	It("UT-AF-200-001: NewRouter returns mux with all expected routes", func() {
-		routes := []string{"/healthz", "/readyz", "/metrics", "/a2a/invoke", "/mcp", "/.well-known/agent-card.json"}
+		routes := []string{"/healthz", "/readyz", "/metrics", "/a2a/invoke", "/mcp", "/.well-known/agent-card.json", "/"}
 		for _, path := range routes {
 			req := httptest.NewRequest("GET", path, http.NoBody)
 			req.Header.Set("Authorization", "Bearer test-token")
@@ -125,6 +125,42 @@ var _ = Describe("Router", func() {
 		metricsRec := httptest.NewRecorder()
 		router.ServeHTTP(metricsRec, metricsReq)
 		Expect(metricsRec.Body.String()).To(ContainSubstring("af_http_request_duration_seconds"))
+	})
+
+	It("UT-AF-1268-001: POST / returns 401 without bearer token (BR-INTEGRATION-1268)", func() {
+		req := httptest.NewRequest("POST", "/", http.NoBody)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		Expect(rec.Code).To(Equal(http.StatusUnauthorized))
+	})
+
+	It("UT-AF-1268-002: POST / reaches A2A handler with valid auth (BR-INTEGRATION-1268)", func() {
+		req := httptest.NewRequest("POST", "/", http.NoBody)
+		req.Header.Set("Authorization", "Bearer test-token")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+	})
+
+	It("UT-AF-1268-004: POST / metrics labeled as /a2a/invoke not unknown (BR-INTEGRATION-1268)", func() {
+		req := httptest.NewRequest("POST", "/", http.NoBody)
+		req.Header.Set("Authorization", "Bearer test-token")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		metricsReq := httptest.NewRequest("GET", "/metrics", http.NoBody)
+		metricsRec := httptest.NewRecorder()
+		router.ServeHTTP(metricsRec, metricsReq)
+		body := metricsRec.Body.String()
+		Expect(body).To(ContainSubstring(`af_http_requests_total{method="POST",path="/a2a/invoke",status="200"}`))
+	})
+
+	It("UT-AF-1268-003: POST /unknown-path still returns 404 (BR-INTEGRATION-1268)", func() {
+		req := httptest.NewRequest("POST", "/unknown-path", http.NoBody)
+		req.Header.Set("Authorization", "Bearer test-token")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		Expect(rec.Code).To(Equal(http.StatusNotFound))
 	})
 
 	It("UT-AF-200-010: Unknown path returns 404", func() {

--- a/pkg/apifrontend/handler/middleware.go
+++ b/pkg/apifrontend/handler/middleware.go
@@ -33,7 +33,7 @@ func normalizePath(p string) string {
 	switch {
 	case p == "/healthz", p == "/readyz", p == "/metrics":
 		return p
-	case strings.HasPrefix(p, "/a2a/"):
+	case p == "/" || strings.HasPrefix(p, "/a2a/"):
 		return "/a2a/invoke"
 	case p == "/mcp":
 		return "/mcp"

--- a/pkg/apifrontend/handler/router.go
+++ b/pkg/apifrontend/handler/router.go
@@ -98,6 +98,7 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) { //nolint:gocritic // hu
 	}
 
 	mux.Handle("POST /a2a/invoke", a2aChain)
+	mux.Handle("POST /{$}", a2aChain)
 	mux.Handle("POST /mcp", mcpChain)
 
 	recoverLogger := cfg.Logger

--- a/test/e2e/apifrontend/a2a_test.go
+++ b/test/e2e/apifrontend/a2a_test.go
@@ -516,6 +516,50 @@ var _ = Describe("A2A Handler (E2E)", Label("e2e", "a2a"), func() {
 	})
 
 	// ===================================================================
+	// Category 8: Root Alias Compatibility (issue #1268)
+	// ===================================================================
+	Context("Category 8: Root Alias Compatibility (issue #1268)", func() {
+
+		It("E2E-AF-1268-001: POST / dispatches to A2A handler (kagenti compat)", func() {
+			body := a2aTasksSend("1268-001", "List all remediations in the default namespace")
+			req, err := http.NewRequest(http.MethodPost, baseURL+"/", strings.NewReader(body))
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+sreToken)
+
+			resp, err := httpClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = resp.Body.Close() }()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusOK), "POST / should reach A2A handler")
+
+			rpc, err := parseRPCResponse(resp)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rpc.Error).To(BeNil(), "1268-001: unexpected JSON-RPC error: %+v", rpc.Error)
+			Expect(rpc.Result).NotTo(BeNil())
+
+			task, err := extractTaskFromResult(rpc.Result)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(task.ID).NotTo(BeEmpty(), "1268-001: task ID must not be empty")
+			Expect(task.Status.State).To(BeElementOf("completed", "working", "failed"),
+				"1268-001: task should reach a valid state")
+		})
+
+		It("E2E-AF-1268-002: POST / returns 401 without auth", func() {
+			req, err := http.NewRequest(http.MethodPost, baseURL+"/", strings.NewReader(`{"jsonrpc":"2.0","method":"message/send","id":"1268-unauth"}`))
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := httpClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = resp.Body.Close() }()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized),
+				"POST / without auth must be rejected")
+		})
+	})
+
+	// ===================================================================
 	// Category 6: Session Lifecycle (3 tests)
 	// ===================================================================
 	Context("Category 6: Session Lifecycle", func() {

--- a/test/integration/apifrontend/router_http_test.go
+++ b/test/integration/apifrontend/router_http_test.go
@@ -67,6 +67,51 @@ var _ = Describe("Router HTTP Integration (handler/)", func() {
 		})
 	})
 
+	Describe("AC-9: Root alias for kagenti compatibility (issue #1268)", func() {
+		It("IT-AF-1268-001: dispatches authenticated POST / to A2A handler", func() {
+			token := signValidToken("it-user-1268-001")
+			req, err := http.NewRequest(http.MethodPost, routerServer.URL+"/", strings.NewReader(`{"jsonrpc":"2.0","method":"message/send","id":"1268"}`))
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := http.DefaultClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+			body, err := io.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(string(body)).To(ContainSubstring(`"result"`))
+		})
+
+		It("IT-AF-1268-002: POST / rejects request without auth", func() {
+			req, err := http.NewRequest(http.MethodPost, routerServer.URL+"/", strings.NewReader(`{}`))
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := http.DefaultClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+		})
+
+		It("IT-AF-1268-003: POST /unknown-subpath returns 404 (not catch-all)", func() {
+			token := signValidToken("it-user-1268-003")
+			req, err := http.NewRequest(http.MethodPost, routerServer.URL+"/not-a-real-path", strings.NewReader(`{}`))
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := http.DefaultClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
+		})
+	})
+
 	Describe("AC-2: Public endpoints serve without auth", func() {
 		It("IT-AF-1195-003: /healthz returns 200 ok", func() {
 			resp, err := http.Get(routerServer.URL + "/healthz")


### PR DESCRIPTION
## Summary

- Register `POST /{$}` as a compatibility alias for `POST /a2a/invoke`, enabling kagenti and A2A ecosystem clients that POST JSON-RPC to the root path per de facto convention. The route shares the identical middleware chain (auth, rate-limit, body-limit, panic-recovery).
- Fix `normalizePath()` to map `"/"` to `"/a2a/invoke"` so Prometheus metrics (`af_http_requests_total`, `af_http_request_duration_seconds`) attribute root alias traffic correctly instead of labeling it `"unknown"`.
- Document `POST /` in the OpenAPI spec (`postA2ARoot` operation) with the same security, request, and response schemas.
- Refresh `AUDIT_EVENT_CATALOG.md` to align with actual `EventType` constants in `audit.go`: replace stale event names (`rbac.denied` → `auth.access_denied`, `tool.invoked` → `tool.executed`), add 15 missing events, fix package paths (`internal/` → `pkg/apifrontend/`), and update struct schema.

## Test plan

- [x] `UT-AF-1268-001`: POST `/` returns 401 without bearer token
- [x] `UT-AF-1268-002`: POST `/` reaches A2A handler with valid auth
- [x] `UT-AF-1268-003`: POST `/unknown-path` still returns 404
- [x] `UT-AF-1268-004`: POST `/` metrics labeled as `/a2a/invoke` (not `unknown`)
- [x] `IT-AF-1268-001`: Authenticated POST `/` dispatches to A2A handler
- [x] `IT-AF-1268-002`: POST `/` rejects request without auth
- [x] `IT-AF-1268-003`: POST `/unknown-subpath` returns 404
- [x] `E2E-AF-1268-001`: POST `/` dispatches to A2A handler on deployed stack
- [x] `E2E-AF-1268-002`: POST `/` returns 401 without auth on deployed stack
- [x] `go build ./...` passes
- [x] `go vet ./...` clean
- [x] 186/186 handler unit tests pass

Closes #1268

Made with [Cursor](https://cursor.com)