### PR TITLE
fix(ci): skip GitHub release creation when release already exists

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -553,23 +553,28 @@ jobs:
           VERSION: ${{ needs.prepare.outputs.version }}
           IS_PRERELEASE: ${{ needs.prepare.outputs.is_prerelease }}
         run: |
-          PRERELEASE_FLAG=""
-          if [ "$IS_PRERELEASE" = "true" ]; then
-            PRERELEASE_FLAG="--prerelease"
+          if gh release view "${TAG}" &>/dev/null; then
+            echo "Release ${TAG} already exists — skipping creation."
+          else
+            PRERELEASE_FLAG=""
+            if [ "$IS_PRERELEASE" = "true" ]; then
+              PRERELEASE_FLAG="--prerelease"
+            fi
+
+            gh release create "${TAG}" \
+              --title "Kubernaut ${TAG}" \
+              --generate-notes \
+              ${PRERELEASE_FLAG} \
+              --notes-start-tag "$(git tag --sort=-creatordate | grep '^v' | sed -n '2p')" || \
+            gh release create "${TAG}" \
+              --title "Kubernaut ${TAG}" \
+              --generate-notes \
+              ${PRERELEASE_FLAG}
+
+            echo ""
+            echo "Release created: https://github.com/${{ github.repository }}/releases/tag/${TAG}"
           fi
 
-          gh release create "${TAG}" \
-            --title "Kubernaut ${TAG}" \
-            --generate-notes \
-            ${PRERELEASE_FLAG} \
-            --notes-start-tag "$(git tag --sort=-creatordate | grep '^v' | sed -n '2p')" || \
-          gh release create "${TAG}" \
-            --title "Kubernaut ${TAG}" \
-            --generate-notes \
-            ${PRERELEASE_FLAG}
-
-          echo ""
-          echo "Release created: https://github.com/${{ github.repository }}/releases/tag/${TAG}"
           echo ""
           echo "Install with:"
           echo "  helm install kubernaut oci://quay.io/kubernaut-ai/charts/kubernaut --version ${VERSION}"


### PR DESCRIPTION
## Summary

- Guard Stage 5 (Create GitHub Release) of the release workflow with `gh release view` to detect whether a release for the tag already exists. If it does, the step logs a message and exits cleanly instead of failing on a duplicate `gh release create` call.
- This prevents the final job from going red when all upstream artifacts (multi-arch images, manifests, Helm chart) succeeded but the release was already created manually or by an earlier run.

## Test plan

- [x] Verified `gh release view v1.5.0-rc6` returns exit 0 (release exists)
- [x] Verified `gh release view v99.0.0` returns exit 1 (release does not exist)
- [ ] Next tag push will exercise the guard in CI

Made with [Cursor](https://cursor.com)