### PR TITLE
feat(af): make metrics and health listen ports configurable (#1339)

### DIFF
--- a/charts/kubernaut/templates/apifrontend/apifrontend.yaml
+++ b/charts/kubernaut/templates/apifrontend/apifrontend.yaml
@@ -247,7 +247,7 @@ metadata:
     {{- include "kubernaut.labels" . | nindent 4 }}
   annotations:
     prometheus.io/scrape: "true"
-    prometheus.io/port: "9090"
+    prometheus.io/port: "{{ .Values.apifrontend.config.server.metricsPort | default 9090 }}"
 spec:
   type: ClusterIP
   ports:
@@ -255,10 +255,10 @@ spec:
       port: {{ .Values.apifrontend.config.server.httpPort | default 8443 }}
       targetPort: https
     - name: metrics
-      port: 9090
+      port: {{ .Values.apifrontend.config.server.metricsPort | default 9090 }}
       targetPort: metrics
     - name: health
-      port: 8081
+      port: {{ .Values.apifrontend.config.server.healthPort | default 8081 }}
       targetPort: health
   selector:
     app: apifrontend

--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -60,11 +60,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/tlswiring"
 )
 
-const (
-	configPath     = "/etc/apifrontend/config.yaml"
-	defaultHealthz = ":8081"
-	defaultMetrics = ":9090"
-)
+const configPath = "/etc/apifrontend/config.yaml"
 
 func main() { os.Exit(run()) }
 
@@ -280,9 +276,12 @@ func run() int {
 		IdleTimeout:       120 * time.Second,
 	}
 
+	healthAddr := fmt.Sprintf(":%d", cfg.Server.HealthPort)
+	metricsAddr := fmt.Sprintf(":%d", cfg.Server.MetricsPort)
+
 	healthMux := buildHealthMux(handler.AllReady(depsReady, authReady, sessInfra.Healthy.Load), draining)
 	healthServer := &http.Server{
-		Addr:              defaultHealthz,
+		Addr:              healthAddr,
 		Handler:           healthMux,
 		ReadHeaderTimeout: 5 * time.Second,
 	}
@@ -290,7 +289,7 @@ func run() int {
 	metricsMux := http.NewServeMux()
 	metricsMux.Handle("/metrics", metricsReg.Handler())
 	metricsServer := &http.Server{
-		Addr:              defaultMetrics,
+		Addr:              metricsAddr,
 		Handler:           metricsMux,
 		ReadHeaderTimeout: 5 * time.Second,
 	}

--- a/pkg/apifrontend/config/config.go
+++ b/pkg/apifrontend/config/config.go
@@ -107,6 +107,8 @@ type ShutdownConfig struct {
 // ServerConfig holds HTTP server settings.
 type ServerConfig struct {
 	Port              int             `yaml:"port"`
+	MetricsPort       int             `yaml:"metricsPort"`
+	HealthPort        int             `yaml:"healthPort"`
 	TLS               ServerTLSConfig `yaml:"tls"`
 	MaxSSEConnections int             `yaml:"maxSSEConnections,omitempty"`
 }
@@ -206,7 +208,9 @@ type RBACConfig struct {
 func DefaultConfig() *Config {
 	return &Config{
 		Server: ServerConfig{
-			Port: 8443,
+			Port:        8443,
+			MetricsPort: 9090,
+			HealthPort:  8081,
 		},
 		Agent: AgentConfig{
 			KABaseURL:     "http://localhost:8080",
@@ -299,6 +303,15 @@ func Load(data []byte) (*Config, error) {
 func (c *Config) Validate() error {
 	if c.Server.Port < 1024 || c.Server.Port > 65535 {
 		return fmt.Errorf("server.port must be 1024-65535 (non-privileged), got %d", c.Server.Port)
+	}
+	if c.Server.MetricsPort < 1024 || c.Server.MetricsPort > 65535 {
+		return fmt.Errorf("server.metricsPort must be 1024-65535 (non-privileged), got %d", c.Server.MetricsPort)
+	}
+	if c.Server.HealthPort < 1024 || c.Server.HealthPort > 65535 {
+		return fmt.Errorf("server.healthPort must be 1024-65535 (non-privileged), got %d", c.Server.HealthPort)
+	}
+	if err := validatePortsDistinct(c.Server.Port, c.Server.MetricsPort, c.Server.HealthPort); err != nil {
+		return err
 	}
 	if c.Agent.KABaseURL == "" {
 		return fmt.Errorf("agent.kaBaseURL is required")
@@ -610,6 +623,19 @@ func (c *Config) validateTLSPaths() error {
 		if _, err := os.Stat(p.path); err != nil {
 			return fmt.Errorf("%s: CA file %q is not accessible: %w", p.field, p.path, err)
 		}
+	}
+	return nil
+}
+
+func validatePortsDistinct(apiPort, metricsPort, healthPort int) error {
+	if apiPort == metricsPort {
+		return fmt.Errorf("server.port and server.metricsPort must be distinct, both are %d", apiPort)
+	}
+	if apiPort == healthPort {
+		return fmt.Errorf("server.port and server.healthPort must be distinct, both are %d", apiPort)
+	}
+	if metricsPort == healthPort {
+		return fmt.Errorf("server.metricsPort and server.healthPort must be distinct, both are %d", metricsPort)
 	}
 	return nil
 }

--- a/pkg/apifrontend/config/config_test.go
+++ b/pkg/apifrontend/config/config_test.go
@@ -15,7 +15,7 @@ import (
 // validConfig returns a Config that passes Validate() for use as a base in tests.
 func validConfig() *config.Config {
 	return &config.Config{
-		Server: config.ServerConfig{Port: 8443},
+		Server: config.ServerConfig{Port: 8443, MetricsPort: 9090, HealthPort: 8081},
 		Agent: config.AgentConfig{
 			KABaseURL:     "http://localhost:8080",
 			KAMCPEndpoint: "http://localhost:8080/api/v1/mcp/",
@@ -456,6 +456,79 @@ var _ = Describe("TC-P2C-03: DefaultConfig field assertions", func() {
 		Expect(cfg.Resilience.KA.CBFailureThreshold).To(BeNumerically(">", 0))
 		Expect(cfg.Resilience.DS.CBFailureThreshold).To(BeNumerically(">", 0))
 		Expect(cfg.Resilience.K8s.CBFailureThreshold).To(BeNumerically(">", 0))
+	})
+})
+
+var _ = Describe("Tier 5b: Configurable Ports (Issue #1339)", func() {
+	It("UT-AF-1339-001 DefaultConfig metricsPort is 9090", func() {
+		cfg := config.DefaultConfig()
+		Expect(cfg.Server.MetricsPort).To(Equal(9090))
+	})
+
+	It("UT-AF-1339-002 YAML override for metricsPort", func() {
+		data := []byte("server:\n  metricsPort: 9191\n")
+		cfg, err := config.Load(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Server.MetricsPort).To(Equal(9191))
+	})
+
+	It("UT-AF-1339-003 DefaultConfig healthPort is 8081", func() {
+		cfg := config.DefaultConfig()
+		Expect(cfg.Server.HealthPort).To(Equal(8081))
+	})
+
+	It("UT-AF-1339-004 YAML override for healthPort", func() {
+		data := []byte("server:\n  healthPort: 8082\n")
+		cfg, err := config.Load(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Server.HealthPort).To(Equal(8082))
+	})
+
+	DescribeTable("UT-AF-1339-005 port range validation",
+		func(field string, mutate func(*config.Config), wantSub string) {
+			cfg := validConfig()
+			mutate(cfg)
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(wantSub))
+		},
+		Entry("metricsPort = 0", "metricsPort", func(c *config.Config) { c.Server.MetricsPort = 0 }, "server.metricsPort"),
+		Entry("metricsPort = 80", "metricsPort", func(c *config.Config) { c.Server.MetricsPort = 80 }, "server.metricsPort"),
+		Entry("metricsPort = 70000", "metricsPort", func(c *config.Config) { c.Server.MetricsPort = 70000 }, "server.metricsPort"),
+		Entry("healthPort = 0", "healthPort", func(c *config.Config) { c.Server.HealthPort = 0 }, "server.healthPort"),
+		Entry("healthPort = 1023", "healthPort", func(c *config.Config) { c.Server.HealthPort = 1023 }, "server.healthPort"),
+		Entry("healthPort = 70000", "healthPort", func(c *config.Config) { c.Server.HealthPort = 70000 }, "server.healthPort"),
+	)
+
+	DescribeTable("UT-AF-1339-006 port collision validation",
+		func(port, metrics, health int, wantSub string) {
+			cfg := validConfig()
+			cfg.Server.Port = port
+			cfg.Server.MetricsPort = metrics
+			cfg.Server.HealthPort = health
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(wantSub))
+		},
+		Entry("port == metricsPort", 9090, 9090, 8081, "server.port and server.metricsPort must be distinct"),
+		Entry("port == healthPort", 8081, 9090, 8081, "server.port and server.healthPort must be distinct"),
+		Entry("metricsPort == healthPort", 8443, 9090, 9090, "server.metricsPort and server.healthPort must be distinct"),
+	)
+
+	It("UT-AF-1339-007 accepts valid distinct ports", func() {
+		cfg := validConfig()
+		cfg.Server.Port = 8443
+		cfg.Server.MetricsPort = 9191
+		cfg.Server.HealthPort = 8082
+		Expect(cfg.Validate()).To(Succeed())
+	})
+
+	It("UT-AF-1339-008 omitted ports use defaults from Load", func() {
+		data := []byte("server:\n  port: 8443\n")
+		cfg, err := config.Load(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Server.MetricsPort).To(Equal(9090))
+		Expect(cfg.Server.HealthPort).To(Equal(8081))
 	})
 })
 


### PR DESCRIPTION
## Summary

- Add `metricsPort` and `healthPort` integer fields to AF `ServerConfig`, defaulting to 9090 and 8081. The AF binary now reads these from `config.yaml` instead of hardcoded constants, allowing operators to resolve port conflicts (e.g., Envoy sidecar on 9090).
- Validation enforces 1024-65535 range and ensures all three server ports are distinct.
- Fix Helm chart Service ports and `prometheus.io/port` annotation to use Values instead of hardcoded values.

## Operator tracking

Production deployment changes tracked in kubernaut-operator#153 — the operator team needs to update their ConfigMap generation, Deployment, Service, and NetworkPolicy builders to emit and use the new config fields.

## Test plan

- [x] UT-AF-1339-001: DefaultConfig metricsPort is 9090
- [x] UT-AF-1339-002: YAML override for metricsPort
- [x] UT-AF-1339-003: DefaultConfig healthPort is 8081
- [x] UT-AF-1339-004: YAML override for healthPort
- [x] UT-AF-1339-005: Port range validation (privileged/out-of-range rejected)
- [x] UT-AF-1339-006: Port collision validation (duplicate ports rejected)
- [x] UT-AF-1339-007: Accepts valid distinct ports
- [x] UT-AF-1339-008: Omitted ports use defaults from Load()
- [x] Build compiles cleanly
- [x] All 141 config tests pass

Made with [Cursor](https://cursor.com)