### PR TITLE
feat: add mTLS client certificate support for LLM transport (#1342)

### DIFF
--- a/cmd/kubernautagent/llm_builder.go
+++ b/cmd/kubernautagent/llm_builder.go
@@ -48,18 +48,31 @@ func buildLLMClientFromConfig(ctx context.Context, cfg *kaconfig.Config, rt *kac
 			timeout = time.Duration(rt.TimeoutSeconds) * time.Second
 		}
 		vertexOpts = append(vertexOpts, vertexanthropic.WithHTTPTimeout(timeout))
+
+		chain, err := buildTransportChain(cfg, rt)
+		if err != nil {
+			return nil, fmt.Errorf("vertex_ai transport chain: %w", err)
+		}
+		if chain != nil {
+			vertexOpts = append(vertexOpts, vertexanthropic.WithBaseTransport(chain))
+		}
+
 		return vertexanthropic.New(ctx,
 			rt.Model, []byte(rt.APIKey),
 			cfg.AI.LLM.VertexProject, cfg.AI.LLM.VertexLocation,
 			vertexOpts...)
 	default:
+		providerOpts, err := buildLLMProviderOpts(cfg, rt)
+		if err != nil {
+			return nil, err
+		}
 		return langchaingo.New(cfg.AI.LLM.Provider, rt.Endpoint, rt.Model, rt.APIKey,
-			buildLLMProviderOpts(cfg, rt)...)
+			providerOpts...)
 	}
 }
 
 // buildLLMProviderOpts returns provider-specific LangChainGo options.
-func buildLLMProviderOpts(cfg *kaconfig.Config, rt *kaconfig.LLMRuntimeConfig) []langchaingo.Option {
+func buildLLMProviderOpts(cfg *kaconfig.Config, rt *kaconfig.LLMRuntimeConfig) ([]langchaingo.Option, error) {
 	var opts []langchaingo.Option
 	if cfg.AI.LLM.AzureAPIVersion != "" {
 		opts = append(opts, langchaingo.WithAzureAPIVersion(cfg.AI.LLM.AzureAPIVersion))
@@ -81,7 +94,10 @@ func buildLLMProviderOpts(cfg *kaconfig.Config, rt *kaconfig.LLMRuntimeConfig) [
 		timeout = time.Duration(rt.TimeoutSeconds) * time.Second
 	}
 
-	customTransport := buildTransportChain(cfg, rt)
+	customTransport, err := buildTransportChain(cfg, rt)
+	if err != nil {
+		return nil, fmt.Errorf("llm transport chain: %w", err)
+	}
 	httpClient := &http.Client{Timeout: timeout}
 	if customTransport != nil {
 		httpClient.Transport = customTransport
@@ -95,7 +111,7 @@ func buildLLMProviderOpts(cfg *kaconfig.Config, rt *kaconfig.LLMRuntimeConfig) [
 			return nil
 		}))
 	}
-	return opts
+	return opts, nil
 }
 
 // buildTransportChain composes the HTTP transport stack from static (TLS CA,
@@ -106,14 +122,18 @@ func buildLLMProviderOpts(cfg *kaconfig.Config, rt *kaconfig.LLMRuntimeConfig) [
 //
 // Issue #902: When tlsCaFile is set, uses sharedtls.NewTLSTransport as the
 // base instead of http.DefaultTransport.
-func buildTransportChain(cfg *kaconfig.Config, rt *kaconfig.LLMRuntimeConfig) http.RoundTripper {
+func buildTransportChain(cfg *kaconfig.Config, rt *kaconfig.LLMRuntimeConfig) (http.RoundTripper, error) {
 	var base = http.DefaultTransport
 	needsCustom := false
 
 	if cfg.AI.LLM.TLSCaFile != "" {
-		tlsTransport, err := sharedtls.NewTLSTransport(cfg.AI.LLM.TLSCaFile)
+		var tlsOpts []sharedtls.TLSTransportOption
+		if cfg.AI.LLM.TLSCertFile != "" {
+			tlsOpts = append(tlsOpts, sharedtls.WithClientCert(cfg.AI.LLM.TLSCertFile, cfg.AI.LLM.TLSKeyFile))
+		}
+		tlsTransport, err := sharedtls.NewTLSTransport(cfg.AI.LLM.TLSCaFile, tlsOpts...)
 		if err != nil {
-			return nil
+			return nil, fmt.Errorf("llm TLS transport: %w", err)
 		}
 		base = tlsTransport
 		needsCustom = true
@@ -143,9 +163,9 @@ func buildTransportChain(cfg *kaconfig.Config, rt *kaconfig.LLMRuntimeConfig) ht
 	}
 
 	if !needsCustom {
-		return nil
+		return nil, nil
 	}
-	return base
+	return base, nil
 }
 
 // llmRuntimeReloadCallback creates a hotreload.ReloadCallback for LLM runtime

--- a/cmd/kubernautagent/llm_builder_tls_test.go
+++ b/cmd/kubernautagent/llm_builder_tls_test.go
@@ -30,7 +30,10 @@ func TestBuildTransportChain_TLSCaFile(t *testing.T) {
 
 	rt := &kaconfig.LLMRuntimeConfig{}
 
-	transport := buildTransportChain(cfg, rt)
+	transport, err := buildTransportChain(cfg, rt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if transport == nil {
 		t.Fatal("expected non-nil transport when tlsCaFile is set, got nil")
 	}
@@ -40,18 +43,46 @@ func TestBuildTransportChain_NoTLSCaFile(t *testing.T) {
 	cfg := kaconfig.DefaultConfig()
 	rt := &kaconfig.LLMRuntimeConfig{}
 
-	transport := buildTransportChain(cfg, rt)
+	transport, err := buildTransportChain(cfg, rt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 	if transport != nil {
 		t.Fatalf("expected nil transport when no custom config, got %T", transport)
 	}
 }
 
+// UT-KA-1342-030: buildTransportChain returns error for invalid CA file (fail-hard per SC-8)
 func TestBuildTransportChain_InvalidCaFile(t *testing.T) {
 	cfg := kaconfig.DefaultConfig()
 	cfg.AI.LLM.TLSCaFile = "/nonexistent/ca.crt"
 
 	rt := &kaconfig.LLMRuntimeConfig{}
 
-	transport := buildTransportChain(cfg, rt)
-	_ = transport
+	_, err := buildTransportChain(cfg, rt)
+	if err == nil {
+		t.Fatal("expected error for invalid CA file, got nil")
+	}
+}
+
+// UT-KA-1342-020: buildTransportChain passes WithClientCert when cert fields are set
+func TestBuildTransportChain_mTLS(t *testing.T) {
+	caPath := generateTestCACert(t, "Test CA")
+
+	certPath, keyPath := generateTestClientCert(t, caPath)
+
+	cfg := kaconfig.DefaultConfig()
+	cfg.AI.LLM.TLSCaFile = caPath
+	cfg.AI.LLM.TLSCertFile = certPath
+	cfg.AI.LLM.TLSKeyFile = keyPath
+
+	rt := &kaconfig.LLMRuntimeConfig{}
+
+	chain, err := buildTransportChain(cfg, rt)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if chain == nil {
+		t.Fatal("expected non-nil transport for mTLS config")
+	}
 }

--- a/cmd/kubernautagent/testutil_ca_test.go
+++ b/cmd/kubernautagent/testutil_ca_test.go
@@ -60,3 +60,40 @@ func generateTestCACert(t *testing.T, cn string) string {
 	}
 	return caPath
 }
+
+// generateTestClientCert creates a self-signed certificate and key pair
+// suitable for mTLS testing. Returns the cert and key file paths.
+func generateTestClientCert(t *testing.T, _ string) (certPath, keyPath string) {
+	t.Helper()
+	dir := t.TempDir()
+	certPath = filepath.Join(dir, "client.crt")
+	keyPath = filepath.Join(dir, "client.key")
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject:      pkix.Name{CommonName: "test-client"},
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0644); err != nil {
+		t.Fatal(err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0600); err != nil {
+		t.Fatal(err)
+	}
+	return certPath, keyPath
+}

--- a/internal/kubernautagent/config/config.go
+++ b/internal/kubernautagent/config/config.go
@@ -77,6 +77,8 @@ type LLMConfig struct {
 	VertexLocation  string              `yaml:"vertexLocation"`
 	BedrockRegion   string              `yaml:"bedrockRegion"`
 	TLSCaFile       string              `yaml:"tlsCaFile,omitempty"`
+	TLSCertFile     string              `yaml:"tlsCertFile,omitempty"`
+	TLSKeyFile      string              `yaml:"tlsKeyFile,omitempty"`
 	OAuth2          OAuth2Config        `yaml:"oauth2,omitempty"`
 	CircuitBreaker  CircuitBreakerCfg   `yaml:"circuitBreaker,omitempty"`
 }
@@ -541,6 +543,9 @@ func (c *Config) Validate() error {
 			return fmt.Errorf("ai.llm.oauth2.credentialsDir is required when oauth2.enabled=true")
 		}
 	}
+	if err := validateTLSCertPair("ai.llm", c.AI.LLM.TLSCertFile, c.AI.LLM.TLSKeyFile, c.AI.LLM.TLSCaFile); err != nil {
+		return err
+	}
 	if c.Runtime.Server.RateLimit.RequestsPerSecond <= 0 {
 		return fmt.Errorf("runtime.server.rateLimit.requestsPerSecond must be positive, got %v", c.Runtime.Server.RateLimit.RequestsPerSecond)
 	}
@@ -683,4 +688,28 @@ func DefaultLLMRuntime() *LLMRuntimeConfig {
 		MaxRetries:     3,
 		TimeoutSeconds: 120,
 	}
+}
+
+// validateTLSCertPair validates that tlsCertFile and tlsKeyFile are set
+// together, use absolute paths, and require tlsCaFile (server verification
+// remains mandatory per SC-8).
+func validateTLSCertPair(prefix, certFile, keyFile, caFile string) error {
+	hasCert := certFile != ""
+	hasKey := keyFile != ""
+	if hasCert != hasKey {
+		return fmt.Errorf("%s.tlsCertFile and %s.tlsKeyFile must both be set or both be empty", prefix, prefix)
+	}
+	if !hasCert {
+		return nil
+	}
+	if !filepath.IsAbs(certFile) {
+		return fmt.Errorf("%s.tlsCertFile must be an absolute path, got %q", prefix, certFile)
+	}
+	if !filepath.IsAbs(keyFile) {
+		return fmt.Errorf("%s.tlsKeyFile must be an absolute path, got %q", prefix, keyFile)
+	}
+	if caFile == "" {
+		return fmt.Errorf("%s.tlsCaFile is required when client certificates are configured (server verification is mandatory)", prefix)
+	}
+	return nil
 }

--- a/pkg/apifrontend/config/config.go
+++ b/pkg/apifrontend/config/config.go
@@ -142,6 +142,8 @@ type LLMConfig struct {
 	VertexProject  string            `yaml:"vertexProject,omitempty"`
 	VertexLocation string            `yaml:"vertexLocation,omitempty"`
 	TLSCaFile      string            `yaml:"tlsCaFile,omitempty"`
+	TLSCertFile    string            `yaml:"tlsCertFile,omitempty"`
+	TLSKeyFile     string            `yaml:"tlsKeyFile,omitempty"`
 	TimeoutSeconds int               `yaml:"timeoutSeconds,omitempty"`
 	OAuth2         LLMOAuth2Config   `yaml:"oauth2,omitempty"`
 	CircuitBreaker LLMCircuitBreaker `yaml:"circuitBreaker,omitempty"`
@@ -416,6 +418,9 @@ func (c *Config) validateLLM() error {
 	if llm.TLSCaFile != "" && !filepath.IsAbs(llm.TLSCaFile) {
 		return fmt.Errorf("agent.llm.tlsCaFile must be an absolute path, got %q", llm.TLSCaFile)
 	}
+	if err := validateTLSCertPair("agent.llm", llm.TLSCertFile, llm.TLSKeyFile, llm.TLSCaFile); err != nil {
+		return err
+	}
 	if llm.Endpoint != "" {
 		if err := validateURL("agent.llm.endpoint", llm.Endpoint); err != nil {
 			return err
@@ -441,19 +446,6 @@ func (c *Config) validateLLM() error {
 		}
 		if llm.CircuitBreaker.Timeout <= 0 {
 			return fmt.Errorf("agent.llm.circuitBreaker.timeout must be positive")
-		}
-	}
-	if llm.Provider != LLMProviderGemini {
-		hasTransportConfig := llm.TLSCaFile != "" || llm.OAuth2.Enabled || len(llm.CustomHeaders) > 0 || llm.CircuitBreaker.Enabled
-		if hasTransportConfig && llm.Provider == LLMProviderVertexAI {
-			return fmt.Errorf("agent.llm: transport options (tlsCaFile, oauth2, customHeaders, circuitBreaker) "+
-				"are not applicable for provider %q — Vertex AI uses GCP-managed authentication",
-				LLMProviderVertexAI)
-		}
-		if hasTransportConfig && llm.Provider == LLMProviderAnthropic {
-			return fmt.Errorf("agent.llm: transport options (tlsCaFile, oauth2, customHeaders, circuitBreaker) "+
-				"are not yet supported for provider %q — use apiKeyFile and endpoint instead",
-				LLMProviderAnthropic)
 		}
 	}
 	return nil
@@ -636,6 +628,30 @@ func validatePortsDistinct(apiPort, metricsPort, healthPort int) error {
 	}
 	if metricsPort == healthPort {
 		return fmt.Errorf("server.metricsPort and server.healthPort must be distinct, both are %d", metricsPort)
+	}
+	return nil
+}
+
+// validateTLSCertPair validates that tlsCertFile and tlsKeyFile are set
+// together, use absolute paths, and require tlsCaFile (server verification
+// remains mandatory per SC-8).
+func validateTLSCertPair(prefix, certFile, keyFile, caFile string) error {
+	hasCert := certFile != ""
+	hasKey := keyFile != ""
+	if hasCert != hasKey {
+		return fmt.Errorf("%s.tlsCertFile and %s.tlsKeyFile must both be set or both be empty", prefix, prefix)
+	}
+	if !hasCert {
+		return nil
+	}
+	if !filepath.IsAbs(certFile) {
+		return fmt.Errorf("%s.tlsCertFile must be an absolute path, got %q", prefix, certFile)
+	}
+	if !filepath.IsAbs(keyFile) {
+		return fmt.Errorf("%s.tlsKeyFile must be an absolute path, got %q", prefix, keyFile)
+	}
+	if caFile == "" {
+		return fmt.Errorf("%s.tlsCaFile is required when client certificates are configured (server verification is mandatory)", prefix)
 	}
 	return nil
 }

--- a/pkg/apifrontend/config/config_test.go
+++ b/pkg/apifrontend/config/config_test.go
@@ -1016,6 +1016,138 @@ agent:
 	})
 })
 
+var _ = Describe("Tier 10: LLM mTLS Config Validation (Issue #1342)", func() {
+
+	// UT-AF-1342-010: tlsCertFile without tlsKeyFile is rejected
+	It("UT-AF-1342-010: rejects tlsCertFile without tlsKeyFile", func() {
+		cfg := validConfig()
+		cfg.Agent.LLM.Provider = config.LLMProviderGemini
+		cfg.Agent.LLM.Model = "gemini-2.0-flash"
+		cfg.Agent.LLM.APIKeyFile = "/etc/secrets/llm-key"
+		cfg.Agent.LLM.TLSCaFile = "/etc/ca/ca.pem"
+		cfg.Agent.LLM.TLSCertFile = "/etc/certs/client.crt"
+		cfg.Agent.LLM.TLSKeyFile = ""
+		err := cfg.Validate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("tlsCertFile"))
+		Expect(err.Error()).To(ContainSubstring("tlsKeyFile"))
+	})
+
+	// UT-AF-1342-011: tlsKeyFile without tlsCertFile is rejected
+	It("UT-AF-1342-011: rejects tlsKeyFile without tlsCertFile", func() {
+		cfg := validConfig()
+		cfg.Agent.LLM.Provider = config.LLMProviderGemini
+		cfg.Agent.LLM.Model = "gemini-2.0-flash"
+		cfg.Agent.LLM.APIKeyFile = "/etc/secrets/llm-key"
+		cfg.Agent.LLM.TLSCaFile = "/etc/ca/ca.pem"
+		cfg.Agent.LLM.TLSCertFile = ""
+		cfg.Agent.LLM.TLSKeyFile = "/etc/certs/client.key"
+		err := cfg.Validate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("tlsCertFile"))
+	})
+
+	// UT-AF-1342-012: relative tlsCertFile path is rejected
+	It("UT-AF-1342-012: rejects relative tlsCertFile path", func() {
+		cfg := validConfig()
+		cfg.Agent.LLM.Provider = config.LLMProviderGemini
+		cfg.Agent.LLM.Model = "gemini-2.0-flash"
+		cfg.Agent.LLM.APIKeyFile = "/etc/secrets/llm-key"
+		cfg.Agent.LLM.TLSCaFile = "/etc/ca/ca.pem"
+		cfg.Agent.LLM.TLSCertFile = "relative/client.crt"
+		cfg.Agent.LLM.TLSKeyFile = "/etc/certs/client.key"
+		err := cfg.Validate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("tlsCertFile"))
+		Expect(err.Error()).To(ContainSubstring("absolute path"))
+	})
+
+	// UT-AF-1342-013: relative tlsKeyFile path is rejected
+	It("UT-AF-1342-013: rejects relative tlsKeyFile path", func() {
+		cfg := validConfig()
+		cfg.Agent.LLM.Provider = config.LLMProviderGemini
+		cfg.Agent.LLM.Model = "gemini-2.0-flash"
+		cfg.Agent.LLM.APIKeyFile = "/etc/secrets/llm-key"
+		cfg.Agent.LLM.TLSCaFile = "/etc/ca/ca.pem"
+		cfg.Agent.LLM.TLSCertFile = "/etc/certs/client.crt"
+		cfg.Agent.LLM.TLSKeyFile = "relative/client.key"
+		err := cfg.Validate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("tlsKeyFile"))
+		Expect(err.Error()).To(ContainSubstring("absolute path"))
+	})
+
+	// UT-AF-1342-014: mTLS without tlsCaFile is rejected (SC-8: server verification mandatory)
+	It("UT-AF-1342-014: rejects mTLS without tlsCaFile", func() {
+		cfg := validConfig()
+		cfg.Agent.LLM.Provider = config.LLMProviderGemini
+		cfg.Agent.LLM.Model = "gemini-2.0-flash"
+		cfg.Agent.LLM.APIKeyFile = "/etc/secrets/llm-key"
+		cfg.Agent.LLM.TLSCaFile = ""
+		cfg.Agent.LLM.TLSCertFile = "/etc/certs/client.crt"
+		cfg.Agent.LLM.TLSKeyFile = "/etc/certs/client.key"
+		err := cfg.Validate()
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("tlsCaFile"))
+		Expect(err.Error()).To(ContainSubstring("server verification"))
+	})
+
+	// UT-AF-1342-015: valid mTLS config accepted
+	It("UT-AF-1342-015: accepts valid mTLS config", func() {
+		cfg := validConfig()
+		cfg.Agent.LLM.Provider = config.LLMProviderGemini
+		cfg.Agent.LLM.Model = "gemini-2.0-flash"
+		cfg.Agent.LLM.APIKeyFile = "/etc/secrets/llm-key"
+		cfg.Agent.LLM.TLSCaFile = "/etc/ca/ca.pem"
+		cfg.Agent.LLM.TLSCertFile = "/etc/certs/client.crt"
+		cfg.Agent.LLM.TLSKeyFile = "/etc/certs/client.key"
+		Expect(cfg.Validate()).To(Succeed())
+	})
+
+	// UT-AF-1342-016: vertex_ai with transport options is accepted (gate removed)
+	It("UT-AF-1342-016: accepts vertex_ai with transport options", func() {
+		cfg := validConfig()
+		cfg.Agent.LLM.Provider = config.LLMProviderVertexAI
+		cfg.Agent.LLM.Model = "claude-sonnet-4-20250514"
+		cfg.Agent.LLM.VertexProject = "my-project"
+		cfg.Agent.LLM.VertexLocation = "us-central1"
+		cfg.Agent.LLM.TLSCaFile = "/etc/ca/ca.pem"
+		cfg.Agent.LLM.TLSCertFile = "/etc/certs/client.crt"
+		cfg.Agent.LLM.TLSKeyFile = "/etc/certs/client.key"
+		Expect(cfg.Validate()).To(Succeed())
+	})
+
+	// UT-AF-1342-017: anthropic with transport options is accepted (gate removed)
+	It("UT-AF-1342-017: accepts anthropic with transport options", func() {
+		cfg := validConfig()
+		cfg.Agent.LLM.Provider = config.LLMProviderAnthropic
+		cfg.Agent.LLM.Model = "claude-sonnet-4-20250514"
+		cfg.Agent.LLM.APIKeyFile = "/etc/secrets/llm-key"
+		cfg.Agent.LLM.TLSCaFile = "/etc/ca/ca.pem"
+		cfg.Agent.LLM.TLSCertFile = "/etc/certs/client.crt"
+		cfg.Agent.LLM.TLSKeyFile = "/etc/certs/client.key"
+		Expect(cfg.Validate()).To(Succeed())
+	})
+
+	// UT-AF-1342-018: YAML parsing includes tlsCertFile and tlsKeyFile
+	It("UT-AF-1342-018: parses mTLS fields from YAML", func() {
+		data := []byte(`
+agent:
+  llm:
+    provider: gemini
+    model: gemini-2.0-flash
+    apiKeyFile: "/etc/secrets/llm-key"
+    tlsCaFile: "/etc/ca/ca.pem"
+    tlsCertFile: "/etc/certs/client.crt"
+    tlsKeyFile: "/etc/certs/client.key"
+`)
+		cfg, err := config.Load(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Agent.LLM.TLSCertFile).To(Equal("/etc/certs/client.crt"))
+		Expect(cfg.Agent.LLM.TLSKeyFile).To(Equal("/etc/certs/client.key"))
+	})
+})
+
 var _ = Describe("AF SA Token Config (#1287)", func() {
 	It("UT-AF-1287-001: KABearerTokenFile parsed from YAML", func() {
 		data := []byte(`

--- a/pkg/apifrontend/launcher/model.go
+++ b/pkg/apifrontend/launcher/model.go
@@ -130,17 +130,23 @@ func buildLLMHTTPClient(cfg config.LLMConfig) (*http.Client, error) {
 // Chain order (outermost first): CircuitBreaker -> CustomHeaders -> OAuth2 -> TLS/base
 // Returns (nil, nil) when no custom transport is needed.
 //
-// NOTE: This transport chain is currently only applied to the Gemini provider
-// (via buildLLMHTTPClient). Vertex AI uses GCP-managed auth (ADC) and the
-// Anthropic ADK wrapper does not expose HTTP client injection. If support is
-// added for Anthropic transport in the future, validateLLM() must be updated
-// to allow it, and newAnthropicModel must call buildLLMHTTPClient.
+// Issue #1342: This transport chain is applied to the Gemini provider (via
+// buildLLMHTTPClient). Vertex AI and Anthropic providers cannot receive a custom
+// transport yet because the ADK wrapper (adk-anthropic-go) does not expose HTTP
+// client injection. An upstream PR adding BaseTransport to Config is pending;
+// once merged, newVertexAIModel and newAnthropicModel should call
+// buildLLMHTTPClient. The AF validation gate for these providers has been
+// removed (Phase 3) to allow transport config in preparation.
 func buildTransportChain(cfg config.LLMConfig) (http.RoundTripper, error) {
 	base := http.DefaultTransport
 	needsCustom := false
 
 	if cfg.TLSCaFile != "" {
-		tlsTransport, err := sharedtls.NewTLSTransport(cfg.TLSCaFile)
+		var tlsOpts []sharedtls.TLSTransportOption
+		if cfg.TLSCertFile != "" {
+			tlsOpts = append(tlsOpts, sharedtls.WithClientCert(cfg.TLSCertFile, cfg.TLSKeyFile))
+		}
+		tlsTransport, err := sharedtls.NewTLSTransport(cfg.TLSCaFile, tlsOpts...)
 		if err != nil {
 			return nil, fmt.Errorf("load TLS CA %q: %w", cfg.TLSCaFile, err)
 		}

--- a/pkg/apifrontend/launcher/transport_chain_test.go
+++ b/pkg/apifrontend/launcher/transport_chain_test.go
@@ -1,6 +1,13 @@
 package launcher_test
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
 	"os"
 	"path/filepath"
 	"time"
@@ -11,6 +18,31 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/config"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
 )
+
+func generateTestCertPair(dir string) (certFile, keyFile string) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	Expect(err).ToNot(HaveOccurred())
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(99),
+		Subject:      pkix.Name{CommonName: "test-client"},
+		NotBefore:    time.Now().Add(-1 * time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	Expect(err).ToNot(HaveOccurred())
+
+	certFile = filepath.Join(dir, "client.crt")
+	Expect(os.WriteFile(certFile, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER}), 0644)).To(Succeed())
+
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	Expect(err).ToNot(HaveOccurred())
+	keyFile = filepath.Join(dir, "client.key")
+	Expect(os.WriteFile(keyFile, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0600)).To(Succeed())
+
+	return certFile, keyFile
+}
 
 var _ = Describe("Transport Chain", func() {
 	Describe("BuildTransportChain", func() {
@@ -86,6 +118,47 @@ var _ = Describe("Transport Chain", func() {
 			rt, err := launcher.BuildTransportChainForTest(cfg)
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("resolve OAuth2 secrets"))
+			Expect(rt).To(BeNil())
+		})
+
+		// UT-AF-1342-020: mTLS transport chain construction
+		It("UT-AF-1342-020: constructs mTLS transport chain with client cert", func() {
+			dir := GinkgoT().TempDir()
+			caFile := filepath.Join(dir, "ca.crt")
+			Expect(os.WriteFile(caFile, []byte(testCACert), 0o600)).To(Succeed())
+
+			certFile, keyFile := generateTestCertPair(dir)
+
+			cfg := config.LLMConfig{
+				Provider:    config.LLMProviderGemini,
+				Model:       "gemini-2.0-flash",
+				APIKey:      "test-key",
+				TLSCaFile:   caFile,
+				TLSCertFile: certFile,
+				TLSKeyFile:  keyFile,
+			}
+			rt, err := launcher.BuildTransportChainForTest(cfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rt).NotTo(BeNil())
+		})
+
+		// UT-AF-1342-021: mTLS with invalid cert returns error
+		It("UT-AF-1342-021: returns error for invalid client cert file", func() {
+			dir := GinkgoT().TempDir()
+			caFile := filepath.Join(dir, "ca.crt")
+			Expect(os.WriteFile(caFile, []byte(testCACert), 0o600)).To(Succeed())
+
+			cfg := config.LLMConfig{
+				Provider:    config.LLMProviderGemini,
+				Model:       "gemini-2.0-flash",
+				APIKey:      "test-key",
+				TLSCaFile:   caFile,
+				TLSCertFile: "/nonexistent/client.crt",
+				TLSKeyFile:  "/nonexistent/client.key",
+			}
+			rt, err := launcher.BuildTransportChainForTest(cfg)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("client certificate"))
 			Expect(rt).To(BeNil())
 		})
 	})

--- a/pkg/kubernautagent/llm/vertexanthropic/client.go
+++ b/pkg/kubernautagent/llm/vertexanthropic/client.go
@@ -33,6 +33,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
 	"strings"
 	"time"
 
@@ -40,6 +41,7 @@ import (
 	"github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/anthropics/anthropic-sdk-go/vertex"
 	"github.com/go-logr/logr"
+	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
@@ -49,9 +51,10 @@ import (
 type Option func(*clientOpts)
 
 type clientOpts struct {
-	extraSDKOpts []option.RequestOption
-	logger       logr.Logger
-	httpTimeout  time.Duration
+	extraSDKOpts  []option.RequestOption
+	logger        logr.Logger
+	httpTimeout   time.Duration
+	baseTransport http.RoundTripper
 }
 
 // WithSDKOptions injects additional Anthropic SDK request options (e.g. base URL
@@ -70,6 +73,15 @@ func WithLogger(l logr.Logger) Option {
 // by the Anthropic SDK, preventing unbounded network calls (#956).
 func WithHTTPTimeout(d time.Duration) Option {
 	return func(o *clientOpts) { o.httpTimeout = d }
+}
+
+// WithBaseTransport sets a custom base RoundTripper (e.g. mTLS, circuit breaker,
+// custom headers) that will be wrapped with GCP OAuth2 authentication.
+// The SDK's vertex middleware (URL rewriting, anthropic_version) is preserved;
+// only the HTTP client is replaced with one that layers OAuth2 on top of this
+// transport. Issue #1342: enterprise mTLS for LLM gateways.
+func WithBaseTransport(rt http.RoundTripper) Option {
+	return func(o *clientOpts) { o.baseTransport = rt }
 }
 
 // Client implements llm.Client for Claude on Vertex AI using the official
@@ -105,6 +117,7 @@ func New(ctx context.Context, model string, credentialsJSON []byte, project, loc
 	}
 
 	var vertexOpt option.RequestOption
+	var tokenSource oauth2.TokenSource
 
 	trimmed := bytes.TrimSpace(credentialsJSON)
 	if len(trimmed) > 0 {
@@ -119,11 +132,17 @@ func New(ctx context.Context, model string, credentialsJSON []byte, project, loc
 			return nil, fmt.Errorf("vertexanthropic: invalid credentials JSON: %w", err)
 		}
 		vertexOpt = vertex.WithCredentials(ctx, location, project, creds)
+		tokenSource = creds.TokenSource
 	} else {
 		var adcErr error
 		vertexOpt, adcErr = safeWithGoogleAuth(ctx, location, project)
 		if adcErr != nil {
 			return nil, adcErr
+		}
+		adcCreds, err := google.FindDefaultCredentials(ctx,
+			"https://www.googleapis.com/auth/cloud-platform")
+		if err == nil {
+			tokenSource = adcCreds.TokenSource
 		}
 	}
 
@@ -131,6 +150,18 @@ func New(ctx context.Context, model string, credentialsJSON []byte, project, loc
 	if o.httpTimeout > 0 {
 		sdkOpts = append(sdkOpts, option.WithRequestTimeout(o.httpTimeout))
 	}
+
+	if o.baseTransport != nil && tokenSource != nil {
+		oauthClient := &http.Client{
+			Transport: &oauth2.Transport{
+				Base:   o.baseTransport,
+				Source: tokenSource,
+			},
+			Timeout: o.httpTimeout,
+		}
+		sdkOpts = append(sdkOpts, option.WithHTTPClient(oauthClient))
+	}
+
 	sdkOpts = append(sdkOpts, o.extraSDKOpts...)
 	sdk := anthropic.NewClient(sdkOpts...)
 

--- a/pkg/shared/tls/tls.go
+++ b/pkg/shared/tls/tls.go
@@ -210,18 +210,54 @@ func StartCAFileWatcher(ctx context.Context, logger logr.Logger) (*hotreload.Fil
 	return watcher, nil
 }
 
+// TLSTransportOption configures optional features on transports created by
+// NewTLSTransport. Use WithClientCert to enable mTLS.
+type TLSTransportOption func(*tlsTransportOpts)
+
+type tlsTransportOpts struct {
+	certFile string
+	keyFile  string
+}
+
+// WithClientCert enables mutual TLS (mTLS) by loading a client certificate
+// and private key that will be presented during the TLS handshake.
+// Both certFile and keyFile must be valid PEM-encoded files.
+// BR-NET-002: Certificate-based authentication for enterprise LLM gateways.
+func WithClientCert(certFile, keyFile string) TLSTransportOption {
+	return func(o *tlsTransportOpts) {
+		o.certFile = certFile
+		o.keyFile = keyFile
+	}
+}
+
 // NewTLSTransport creates an http.Transport configured with a custom CA pool
 // for verifying server certificates on outbound HTTPS calls.
-func NewTLSTransport(caFile string) (*http.Transport, error) {
+// Optional TLSTransportOption values (e.g. WithClientCert) extend the transport
+// with mTLS or other features without breaking existing callers.
+func NewTLSTransport(caFile string, opts ...TLSTransportOption) (*http.Transport, error) {
 	pool, err := LoadCACert(caFile)
 	if err != nil {
 		return nil, err
+	}
+
+	var o tlsTransportOpts
+	for _, fn := range opts {
+		fn(&o)
 	}
 
 	tlsCfg := &tls.Config{
 		RootCAs:    pool,
 		MinVersion: tls.VersionTLS12,
 	}
+
+	if o.certFile != "" && o.keyFile != "" {
+		cert, err := tls.LoadX509KeyPair(o.certFile, o.keyFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load client certificate (%s, %s): %w", o.certFile, o.keyFile, err)
+		}
+		tlsCfg.Certificates = []tls.Certificate{cert}
+	}
+
 	ApplyProfile(tlsCfg, getDefaultSecurityProfile())
 	return &http.Transport{TLSClientConfig: tlsCfg}, nil
 }

--- a/pkg/shared/tls/tls_test.go
+++ b/pkg/shared/tls/tls_test.go
@@ -150,6 +150,70 @@ var _ = Describe("Shared TLS Helper (#493)", func() {
 			Expect(transport.TLSClientConfig.RootCAs.Subjects()).ToNot(BeEmpty(), //nolint:staticcheck // no alternative for validating cert pool content
 				"transport CA pool should contain the loaded CA certificate")
 		})
+
+		// UT-TLS-1342-001: WithClientCert loads client certificate into transport
+		// BR-NET-002: Certificate-based authentication for enterprise LLM gateways
+		It("UT-TLS-1342-001: should load client certificate when WithClientCert is provided", func() {
+			generateSelfSignedCert(certPath, keyPath)
+
+			transport, err := sharedtls.NewTLSTransport(certPath,
+				sharedtls.WithClientCert(certPath, keyPath),
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(transport.TLSClientConfig.Certificates).To(HaveLen(1),
+				"mTLS transport must contain exactly one client certificate")
+			Expect(transport.TLSClientConfig.RootCAs.Subjects()).ToNot(BeEmpty(), //nolint:staticcheck // no alternative for validating cert pool content
+				"mTLS transport must still have CA pool for server verification")
+		})
+
+		// UT-TLS-1342-002: WithClientCert returns error for invalid cert file
+		It("UT-TLS-1342-002: should return error when client cert file is invalid", func() {
+			generateSelfSignedCert(certPath, keyPath)
+
+			_, err := sharedtls.NewTLSTransport(certPath,
+				sharedtls.WithClientCert("/nonexistent/client.crt", "/nonexistent/client.key"),
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("client certificate"))
+		})
+
+		// UT-TLS-1342-003: WithClientCert returns error for mismatched cert/key pair
+		It("UT-TLS-1342-003: should return error when client cert and key do not match", func() {
+			generateSelfSignedCert(certPath, keyPath)
+
+			otherCertPath := filepath.Join(certDir, "other.crt")
+			otherKeyPath := filepath.Join(certDir, "other.key")
+			generateSelfSignedCert(otherCertPath, otherKeyPath)
+
+			_, err := sharedtls.NewTLSTransport(certPath,
+				sharedtls.WithClientCert(certPath, otherKeyPath),
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("client certificate"))
+		})
+
+		// UT-TLS-1342-004: NewTLSTransport without options is backward-compatible
+		It("UT-TLS-1342-004: should work without options (backward-compatible)", func() {
+			generateSelfSignedCert(certPath, keyPath)
+
+			transport, err := sharedtls.NewTLSTransport(certPath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(transport.TLSClientConfig.Certificates).To(BeEmpty(),
+				"transport without WithClientCert must have no client certificates")
+		})
+
+		// UT-TLS-1342-005: Security profile is applied to mTLS transport
+		// BR-ENC-001: FIPS 140-2 approved algorithms
+		It("UT-TLS-1342-005: should apply security profile to mTLS transport", func() {
+			generateSelfSignedCert(certPath, keyPath)
+
+			transport, err := sharedtls.NewTLSTransport(certPath,
+				sharedtls.WithClientCert(certPath, keyPath),
+			)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(transport.TLSClientConfig.MinVersion).To(BeNumerically(">=", tls.VersionTLS12),
+				"mTLS transport must enforce TLS 1.2+ (SC-8)")
+		})
 	})
 
 	Describe("DefaultBaseTransport (#753)", func() {

--- a/test/integration/shared/tls/tls_integration_test.go
+++ b/test/integration/shared/tls/tls_integration_test.go
@@ -244,4 +244,159 @@ var _ = Describe("TLS Integration Tests (#493)", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("certificate"))
 	})
+
+	// --- mTLS tests (Issue #1342) ---
+
+	// Helper: generate client cert signed by the CA
+	generateClientCert := func() (clientCertPath, clientKeyPath string) {
+		clientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		Expect(err).ToNot(HaveOccurred())
+
+		clientTemplate := &x509.Certificate{
+			SerialNumber: big.NewInt(3),
+			Subject:      pkix.Name{CommonName: "test-client"},
+			NotBefore:    time.Now().Add(-1 * time.Hour),
+			NotAfter:     time.Now().Add(24 * time.Hour),
+			KeyUsage:     x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		}
+
+		clientCertDER, err := x509.CreateCertificate(rand.Reader, clientTemplate, caCert, &clientKey.PublicKey, caKey)
+		Expect(err).ToNot(HaveOccurred())
+
+		clientCertPath = filepath.Join(certDir, "client.crt")
+		clientCertPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: clientCertDER})
+		Expect(os.WriteFile(clientCertPath, clientCertPEM, 0644)).To(Succeed())
+
+		clientKeyPath = filepath.Join(certDir, "client.key")
+		clientKeyDER, err := x509.MarshalECPrivateKey(clientKey)
+		Expect(err).ToNot(HaveOccurred())
+		clientKeyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: clientKeyDER})
+		Expect(os.WriteFile(clientKeyPath, clientKeyPEM, 0600)).To(Succeed())
+
+		return clientCertPath, clientKeyPath
+	}
+
+	// Helper: start a TLS server that requires client certificates (mTLS)
+	startMTLSServer := func() (*http.Server, string) {
+		generateServerCert()
+
+		caPool, err := sharedtls.LoadCACert(caCertPath)
+		Expect(err).ToNot(HaveOccurred())
+
+		mux := http.NewServeMux()
+		mux.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("ok"))
+		})
+
+		serverCert, err := tls.LoadX509KeyPair(
+			filepath.Join(certDir, "tls.crt"),
+			filepath.Join(certDir, "tls.key"),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		tlsCfg := &tls.Config{
+			Certificates: []tls.Certificate{serverCert},
+			ClientCAs:    caPool,
+			ClientAuth:   tls.RequireAndVerifyClientCert,
+			MinVersion:   tls.VersionTLS12,
+		}
+
+		listener, err := tls.Listen("tcp", "127.0.0.1:0", tlsCfg)
+		Expect(err).ToNot(HaveOccurred())
+
+		server := &http.Server{Handler: mux}
+		go func() {
+			defer GinkgoRecover()
+			_ = server.Serve(listener)
+		}()
+
+		addr := listener.Addr().(*net.TCPAddr)
+		return server, fmt.Sprintf("https://127.0.0.1:%d", addr.Port)
+	}
+
+	// IT-TLS-1342-001: mTLS handshake succeeds with valid client cert
+	// BR-NET-002: Certificate-based authentication
+	It("IT-TLS-1342-001: should complete mTLS handshake with valid client certificate", func() {
+		server, url := startMTLSServer()
+		defer func() { _ = server.Close() }()
+
+		clientCertPath, clientKeyPath := generateClientCert()
+
+		transport, err := sharedtls.NewTLSTransport(caCertPath,
+			sharedtls.WithClientCert(clientCertPath, clientKeyPath),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		client := &http.Client{Transport: transport, Timeout: 5 * time.Second}
+		resp, err := client.Get(url + "/health")
+		Expect(err).ToNot(HaveOccurred())
+		defer func() { _ = resp.Body.Close() }()
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+	})
+
+	// IT-TLS-1342-002: mTLS handshake fails without client cert when server requires it
+	It("IT-TLS-1342-002: should fail mTLS handshake when client cert is missing", func() {
+		server, url := startMTLSServer()
+		defer func() { _ = server.Close() }()
+
+		transport, err := sharedtls.NewTLSTransport(caCertPath)
+		Expect(err).ToNot(HaveOccurred())
+
+		client := &http.Client{Transport: transport, Timeout: 2 * time.Second}
+		_, err = client.Get(url + "/health")
+		Expect(err).To(HaveOccurred())
+	})
+
+	// IT-TLS-1342-003: mTLS handshake fails with client cert signed by wrong CA
+	It("IT-TLS-1342-003: should fail mTLS handshake when client cert is signed by wrong CA", func() {
+		server, url := startMTLSServer()
+		defer func() { _ = server.Close() }()
+
+		wrongCAKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		Expect(err).ToNot(HaveOccurred())
+		wrongCATemplate := &x509.Certificate{
+			SerialNumber:          big.NewInt(99),
+			Subject:               pkix.Name{CommonName: "Wrong CA"},
+			NotBefore:             time.Now().Add(-1 * time.Hour),
+			NotAfter:              time.Now().Add(24 * time.Hour),
+			IsCA:                  true,
+			BasicConstraintsValid: true,
+			KeyUsage:              x509.KeyUsageCertSign,
+		}
+		wrongCACertDER, err := x509.CreateCertificate(rand.Reader, wrongCATemplate, wrongCATemplate, &wrongCAKey.PublicKey, wrongCAKey)
+		Expect(err).ToNot(HaveOccurred())
+
+		wrongClientKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+		Expect(err).ToNot(HaveOccurred())
+		wrongCACert, err := x509.ParseCertificate(wrongCACertDER)
+		Expect(err).ToNot(HaveOccurred())
+		wrongClientTemplate := &x509.Certificate{
+			SerialNumber: big.NewInt(4),
+			Subject:      pkix.Name{CommonName: "wrong-client"},
+			NotBefore:    time.Now().Add(-1 * time.Hour),
+			NotAfter:     time.Now().Add(24 * time.Hour),
+			KeyUsage:     x509.KeyUsageDigitalSignature,
+			ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+		}
+		wrongClientCertDER, err := x509.CreateCertificate(rand.Reader, wrongClientTemplate, wrongCACert, &wrongClientKey.PublicKey, wrongCAKey)
+		Expect(err).ToNot(HaveOccurred())
+
+		wrongClientCertPath := filepath.Join(certDir, "wrong-client.crt")
+		Expect(os.WriteFile(wrongClientCertPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: wrongClientCertDER}), 0644)).To(Succeed())
+		wrongClientKeyPath := filepath.Join(certDir, "wrong-client.key")
+		wrongClientKeyDER, err := x509.MarshalECPrivateKey(wrongClientKey)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(os.WriteFile(wrongClientKeyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: wrongClientKeyDER}), 0600)).To(Succeed())
+
+		transport, err := sharedtls.NewTLSTransport(caCertPath,
+			sharedtls.WithClientCert(wrongClientCertPath, wrongClientKeyPath),
+		)
+		Expect(err).ToNot(HaveOccurred())
+
+		client := &http.Client{Transport: transport, Timeout: 2 * time.Second}
+		_, err = client.Get(url + "/health")
+		Expect(err).To(HaveOccurred())
+	})
 })


### PR DESCRIPTION
## Summary

- Add `WithClientCert` functional option to `NewTLSTransport` for mutual TLS (mTLS) support, enabling certificate-based authentication for enterprise LLM gateways (BR-NET-002)
- Add `tlsCertFile` and `tlsKeyFile` config fields to both AF and KA LLM configs with pair validation, absolute path enforcement, and mandatory CA requirement (SC-8)
- Remove AF validation gate that blocked transport options for `vertex_ai` and `anthropic` providers
- Add `WithBaseTransport` to KA `vertexanthropic` client that composes GCP OAuth2 on top of custom transport (preserves Vertex middleware while layering mTLS)
- Fix KA `buildTransportChain` to return error on TLS failure instead of silent fallback (SC-8 fail-hard compliance)
- Wire `WithClientCert` into both AF and KA `buildTransportChain` functions

### Provider coverage

| Provider | KA | AF | Status |
|---|---|---|---|
| `vertex` (Gemini) | Full chain | Full chain + mTLS | Complete |
| `vertex_ai` (Claude) | Full chain + mTLS via `WithBaseTransport` | Deferred | Pending upstream `adk-anthropic-go` PR |
| `anthropic` (direct) | Full chain via langchaingo | Deferred | Pending upstream `adk-anthropic-go` PR |

### NIST 800-53 controls addressed

- **SC-8**: TLS 1.2+ enforced, `InsecureSkipVerify` never set, fail-hard on TLS errors
- **IA-5**: Client cert/key from K8s Secrets, pair validation at startup
- **BR-NET-002**: Certificate-based authentication for enterprise LLM gateways
- **CM-3**: Static fields require pod restart (documented)

### Operator tracking

kubernaut-operator/issues/154 opened for CRD + Secret mounting changes

## Test plan

- [x] 5 new UT for `WithClientCert` (cert loading, error cases, backward compat, security profile)
- [x] 3 new IT for real mTLS handshake (success, missing cert, wrong CA)
- [x] 9 new UT for Tier 10 config validation (pair, path, CA requirement, provider acceptance, YAML)
- [x] 2 new KA UT (mTLS chain construction, fail-hard on TLS error)
- [x] 2 new AF UT (mTLS chain construction, invalid cert error)
- [x] All existing tests pass (61 shared TLS UT, 8 IT, 150 AF config, 140 launcher, 109 KA config, 4 KA builder)


Made with [Cursor](https://cursor.com)