### PR TITLE
fix(af): remove server-level WriteTimeout to prevent SSE stream termination

### DIFF
--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -272,7 +272,6 @@ func run() int {
 		Handler:           router,
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
-		WriteTimeout:      5 * time.Minute,
 		IdleTimeout:       120 * time.Second,
 	}
 

--- a/pkg/apifrontend/handler/router.go
+++ b/pkg/apifrontend/handler/router.go
@@ -120,8 +120,9 @@ func maxBodyMiddleware(maxBytes int64, next http.Handler) http.Handler {
 const defaultWriteDeadline = 60 * time.Second
 
 // writeDeadlineMiddleware sets a per-request write deadline via
-// http.ResponseController. SSE/streaming handlers can extend this by calling
-// SetWriteDeadline(time.Time{}) when they upgrade to long-lived streams.
+// http.ResponseController. This is the sole write deadline authority — the
+// http.Server has no WriteTimeout set. SSE/streaming handlers clear this
+// deadline via trackSSEConnection which calls SetWriteDeadline(time.Time{}).
 func writeDeadlineMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		rc := http.NewResponseController(w)


### PR DESCRIPTION
## Summary

- Removes the 5-minute `http.Server.WriteTimeout` that was forcibly killing long-lived SSE streams during `kubernaut_watch` (workflow execution monitoring)
- The existing per-request middleware chain (`writeDeadlineMiddleware` → `trackSSEConnection`) already correctly manages write deadlines: 60s for normal requests, unlimited for SSE streams
- Root cause: `ResponseController.SetWriteDeadline(time.Time{})` in `trackSSEConnection` was not overriding the server-level `WriteTimeout` when the `a2a-go` library wraps the `ResponseWriter`

## Root Cause Analysis

During a remediation approval + watch flow in Sandbox, the stream was terminated after exactly 5 minutes with:
```
Connection error: peer closed connection without sending complete message body (incomplete chunked read)
```

The `kubernaut_watch` tool was polling the workflow execution status (which was blocked on a missing ServiceAccount). After 5 minutes, Go's `http.Server.WriteTimeout` killed the connection from the server side.

## Test plan

- [x] `go build ./cmd/apifrontend/...` passes
- [x] `go test ./pkg/apifrontend/handler/...` passes
- [x] `go test ./cmd/apifrontend/...` passes  
- [ ] CI pipeline validates no regressions
- [ ] Deploy to Sandbox and run a workflow execution >5 min to confirm streams survive


Made with [Cursor](https://cursor.com)