### PR TITLE
fix(ka,aa,af): resolve interactive pipeline GA readiness bugs (#1351)

### DIFF
--- a/api/aianalysis/v1alpha1/aianalysis_types.go
+++ b/api/aianalysis/v1alpha1/aianalysis_types.go
@@ -333,7 +333,7 @@ type AIAnalysisStatus struct {
 	// SubReason provides specific failure cause within the Reason category
 	// BR-HAPI-197: Maps to needs_human_review triggers from KA
 	// BR-HAPI-200: Added InvestigationInconclusive, ProblemResolved for new investigation outcomes
-	// +kubebuilder:validation:Enum=WorkflowNotFound;ImageMismatch;ParameterValidationFailed;NoMatchingWorkflows;LowConfidence;LLMParsingError;ValidationError;TransientError;PermanentError;InvestigationInconclusive;ProblemResolved;NotActionable;MaxRetriesExceeded;SessionRegenerationExceeded;RcaIncomplete
+	// +kubebuilder:validation:Enum=WorkflowNotFound;ImageMismatch;ParameterValidationFailed;NoMatchingWorkflows;LowConfidence;LLMParsingError;ValidationError;TransientError;PermanentError;InvestigationInconclusive;ProblemResolved;NotActionable;MaxRetriesExceeded;SessionRegenerationExceeded;RcaIncomplete;InvestigationFailed
 	// +optional
 	SubReason string `json:"subReason,omitempty"`
 

--- a/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
@@ -1116,10 +1116,11 @@ spec:
                 - MaxRetriesExceeded
                 - SessionRegenerationExceeded
                 - RcaIncomplete
+                - InvestigationFailed
                 type: string
               totalAnalysisTime:
                 description: TotalAnalysisTime is the total duration of the analysis
-                  in seconds
+                  in milliseconds
                 format: int64
                 minimum: 0
                 type: integer

--- a/charts/kubernaut/crds/kubernaut.ai_investigationsessions.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_investigationsessions.yaml
@@ -79,9 +79,13 @@ spec:
                 properties:
                   name:
                     description: Name of the referenced object.
+                    maxLength: 253
+                    minLength: 1
                     type: string
                   namespace:
                     description: Namespace of the referenced object.
+                    maxLength: 63
+                    minLength: 1
                     type: string
                 required:
                 - name
@@ -95,9 +99,12 @@ spec:
                     description: Groups from JWT groups claim (RBAC-relevant only).
                     items:
                       type: string
+                    maxItems: 64
                     type: array
                   username:
                     description: Username from JWT sub claim.
+                    maxLength: 253
+                    minLength: 1
                     type: string
                 required:
                 - username

--- a/charts/kubernaut/crds/kubernaut.ai_remediationapprovalrequests.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_remediationapprovalrequests.yaml
@@ -349,6 +349,13 @@ spec:
               decidedBy:
                 description: Who made the decision (username or "system" for timeout)
                 type: string
+              decidedVia:
+                description: |-
+                  Who facilitated the decision (trusted intermediary SA identity).
+                  Empty for direct decisions (kubectl, CLI). Set by webhook when a trusted
+                  intermediary (AF SA) delegates approval on behalf of a human user.
+                  Operational visibility field — DS audit trail is authoritative.
+                type: string
               decision:
                 description: |-
                   Decision made by operator or system (timeout)

--- a/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
@@ -1116,10 +1116,11 @@ spec:
                 - MaxRetriesExceeded
                 - SessionRegenerationExceeded
                 - RcaIncomplete
+                - InvestigationFailed
                 type: string
               totalAnalysisTime:
                 description: TotalAnalysisTime is the total duration of the analysis
-                  in seconds
+                  in milliseconds
                 format: int64
                 minimum: 0
                 type: integer

--- a/charts/kubernaut/files/crds/kubernaut.ai_investigationsessions.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_investigationsessions.yaml
@@ -79,9 +79,13 @@ spec:
                 properties:
                   name:
                     description: Name of the referenced object.
+                    maxLength: 253
+                    minLength: 1
                     type: string
                   namespace:
                     description: Namespace of the referenced object.
+                    maxLength: 63
+                    minLength: 1
                     type: string
                 required:
                 - name
@@ -95,9 +99,12 @@ spec:
                     description: Groups from JWT groups claim (RBAC-relevant only).
                     items:
                       type: string
+                    maxItems: 64
                     type: array
                   username:
                     description: Username from JWT sub claim.
+                    maxLength: 253
+                    minLength: 1
                     type: string
                 required:
                 - username

--- a/charts/kubernaut/files/crds/kubernaut.ai_remediationapprovalrequests.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_remediationapprovalrequests.yaml
@@ -349,6 +349,13 @@ spec:
               decidedBy:
                 description: Who made the decision (username or "system" for timeout)
                 type: string
+              decidedVia:
+                description: |-
+                  Who facilitated the decision (trusted intermediary SA identity).
+                  Empty for direct decisions (kubectl, CLI). Set by webhook when a trusted
+                  intermediary (AF SA) delegates approval on behalf of a human user.
+                  Operational visibility field — DS audit trail is authoritative.
+                type: string
               decision:
                 description: |-
                   Decision made by operator or system (timeout)

--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -186,6 +186,25 @@ func run() int {
 		}
 	}()
 
+	// AF-HIGH-2: Schedule periodic idle session eviction to prevent pool growth.
+	evictStop := make(chan struct{})
+	if deps.Pool != nil {
+		go func() {
+			ticker := time.NewTicker(2 * time.Minute)
+			defer ticker.Stop()
+			for {
+				select {
+				case <-ticker.C:
+					if n := deps.Pool.EvictIdle(); n > 0 {
+						logger.V(1).Info("evicted idle KA sessions", "count", n)
+					}
+				case <-evictStop:
+					return
+				}
+			}
+		}()
+	}
+
 	mcpHandler, depsReady, err := buildMCPHandler(cfg, deps, sessInfra, metricsReg, sarChecker, auditor, logger, userLimiter)
 	if err != nil {
 		logger.Error(err, "failed to create MCP handler")
@@ -368,6 +387,7 @@ func run() int {
 	}
 
 	// WIRE-16: Stop background goroutines in limiters to prevent leaks.
+	close(evictStop)
 	ipLimiter.Stop()
 	userLimiter.Stop()
 
@@ -510,7 +530,10 @@ func buildBackendDeps(ctx context.Context, cfg *config.Config, metricsReg *metri
 			tokenFile: cfg.Agent.KABearerTokenFile,
 		}
 	}
-	kaMCPHTTPClient := &http.Client{Transport: kaMCPAuth}
+	kaMCPHTTPClient := &http.Client{
+		Transport: kaMCPAuth,
+		Timeout:   cfg.Resilience.KA.RequestTimeout,
+	}
 	mcpClient := ka.NewSDKMCPClient(
 		cfg.Agent.KAMCPEndpoint,
 		kaMCPHTTPClient,

--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -884,13 +884,25 @@ func buildAuthMiddleware(cfg *config.Config, reg *metrics.Registry, auditor audi
 	if len(ac.JWT) == 0 {
 		restCfg, k8sErr := ctrl.GetConfig()
 		if k8sErr != nil {
-			logger.Info("WARNING: no auth issuer configured and kubeconfig unavailable — using pass-through auth (not suitable for production)")
-			return func(next http.Handler) http.Handler { return next }, alwaysReady
+			logger.Error(k8sErr, "CRITICAL: no auth issuer configured and kubeconfig unavailable — denying all authenticated requests (AF-CRIT-1)")
+			denyAll := func(next http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					http.Error(w, "authentication system unavailable", http.StatusServiceUnavailable)
+				})
+			}
+			notReady := handler.ReadyChecker(func() bool { return false })
+			return denyAll, notReady
 		}
 		k8sClient, k8sErr := kubernetes.NewForConfig(restCfg)
 		if k8sErr != nil {
-			logger.Error(k8sErr, "failed to create kubernetes client for TokenReview")
-			return func(next http.Handler) http.Handler { return next }, alwaysReady
+			logger.Error(k8sErr, "CRITICAL: failed to create kubernetes client for TokenReview — denying all authenticated requests (AF-CRIT-1)")
+			denyAll := func(next http.Handler) http.Handler {
+				return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+					http.Error(w, "authentication system unavailable", http.StatusServiceUnavailable)
+				})
+			}
+			notReady := handler.ReadyChecker(func() bool { return false })
+			return denyAll, notReady
 		}
 		validatorOpts = append(validatorOpts, auth.WithTokenReviewer(auth.NewTokenReviewer(k8sClient)))
 		logger.Info("auth mode: TokenReview (no OIDC issuer configured)")

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -1279,6 +1279,8 @@ func buildMCPHandler(
 					"session_id", sessionID)
 				return
 			}
+			// KA-CRIT-2: Resolve the HTTP session so AA stops polling user_driving.
+			mcptools.CompleteHTTPSession(autoMgr, rrID, nil, logger, "inactivity_timeout")
 			emitDisconnectAudit(sessionID, rrID, "inactivity_timeout")
 			// T1-4: Decrement gauge on timeout expiry to prevent drift.
 			agentMetrics.RecordInteractiveSessionEnded()
@@ -1313,6 +1315,9 @@ func buildMCPHandler(
 				"error", err.Error())
 			return
 		}
+
+		// KA-CRIT-2: Resolve the HTTP session so AA stops polling user_driving.
+		mcptools.CompleteHTTPSession(autoMgr, rrID, nil, logger, "disconnect")
 
 		// Emit audit event for disconnect-driven completion (M1: timeout/TTL/disconnect paths).
 		emitDisconnectAudit(interactiveSessionID, rrID, "disconnect")

--- a/config/crd/bases/kubernaut.ai_aianalyses.yaml
+++ b/config/crd/bases/kubernaut.ai_aianalyses.yaml
@@ -1116,10 +1116,11 @@ spec:
                 - MaxRetriesExceeded
                 - SessionRegenerationExceeded
                 - RcaIncomplete
+                - InvestigationFailed
                 type: string
               totalAnalysisTime:
                 description: TotalAnalysisTime is the total duration of the analysis
-                  in seconds
+                  in milliseconds
                 format: int64
                 minimum: 0
                 type: integer

--- a/config/crd/bases/kubernaut.ai_investigationsessions.yaml
+++ b/config/crd/bases/kubernaut.ai_investigationsessions.yaml
@@ -79,9 +79,13 @@ spec:
                 properties:
                   name:
                     description: Name of the referenced object.
+                    maxLength: 253
+                    minLength: 1
                     type: string
                   namespace:
                     description: Namespace of the referenced object.
+                    maxLength: 63
+                    minLength: 1
                     type: string
                 required:
                 - name
@@ -95,9 +99,12 @@ spec:
                     description: Groups from JWT groups claim (RBAC-relevant only).
                     items:
                       type: string
+                    maxItems: 64
                     type: array
                   username:
                     description: Username from JWT sub claim.
+                    maxLength: 253
+                    minLength: 1
                     type: string
                 required:
                 - username

--- a/config/crd/bases/kubernaut.ai_remediationapprovalrequests.yaml
+++ b/config/crd/bases/kubernaut.ai_remediationapprovalrequests.yaml
@@ -349,6 +349,13 @@ spec:
               decidedBy:
                 description: Who made the decision (username or "system" for timeout)
                 type: string
+              decidedVia:
+                description: |-
+                  Who facilitated the decision (trusted intermediary SA identity).
+                  Empty for direct decisions (kubectl, CLI). Set by webhook when a trusted
+                  intermediary (AF SA) delegates approval on behalf of a human user.
+                  Operational visibility field — DS audit trail is authoritative.
+                type: string
               decision:
                 description: |-
                   Decision made by operator or system (timeout)

--- a/docs/tests/1351/TEST_PLAN.md
+++ b/docs/tests/1351/TEST_PLAN.md
@@ -1,0 +1,334 @@
+# Test Plan — #1351: Interactive Pipeline GA Readiness Bug Fixes
+
+**IEEE 829 Compliant** | **Issue**: [#1351](https://github.com/jordigilh/kubernaut/issues/1351)
+
+## 1. Test Plan Identifier
+
+TP-1351-INTERACTIVE-PIPELINE-GA
+
+## 2. Introduction
+
+This test plan covers the 49 validated bugs across KA, AA, and AF services discovered during the interactive workflow pipeline GA readiness audit. The fixes restore correctness to the interactive session lifecycle, result propagation, timeout enforcement, error recovery, and access control.
+
+### 2.1 Authoritative References for Grounding
+
+| Document | Path | Relevance |
+|----------|------|-----------|
+| BR-INTERACTIVE-001..008 | `docs/requirements/BR-INTERACTIVE.md` | Session lifecycle, takeover, audit attribution, RBAC |
+| BR-INTERACTIVE-010 | `docs/requirements/BR-INTERACTIVE-010.md` | IS CRD as interactive signal, AA poll handling, timeout edge cases |
+| DD-INTERACTIVE-002 | `docs/architecture/decisions/DD-INTERACTIVE-002-dynamic-takeover-model.md` | Dynamic takeover model, cancel+reconstruct, timeout policy |
+| BR-HAPI-197 | `docs/requirements/BR-HAPI-197-needs-human-review-field.md` | Confidence threshold enforcement, human review triggers |
+| BR-HAPI-198 | `docs/requirements/BR-HAPI-198-configurable-confidence-thresholds.md` | Operator-configurable thresholds, V1.1 Rego integration |
+| BR-ORCH-027/028 | `docs/requirements/BR-ORCH-027-028-timeout-management.md` | Global 1h cap, per-phase timeouts, timeout-phase recording |
+| 11_SECURITY_ACCESS_CONTROL | `docs/requirements/11_SECURITY_ACCESS_CONTROL.md` | BR-RBAC-001..020, session management, audit |
+| DD-AUTH-MCP-001 | `docs/architecture/decisions/DD-AUTH-MCP-001-mcp-endpoint-security.md` | MCP endpoint auth, user impersonation |
+| DD-EVENT-001 | `docs/architecture/decisions/DD-EVENT-001-controller-event-registry.md` | K8s event emission policy |
+
+### 2.2 FedRAMP Control Objectives
+
+| Control | Title | Bugs Addressed | Test Coverage Strategy |
+|---------|-------|----------------|------------------------|
+| AC-2 | Account Management | AF-CRIT-1, AF-CRIT-2 | UT: auth config rejects pass-through; IT: session cap enforced |
+| AC-6 | Least Privilege | AA-MED-4, AF-MED-8 | UT: Rego denies when identity absent; UT: rate limit applied |
+| AU-2 | Audit Events | KA-MED-7, AA-MED-1, AA-MED-5 | UT: Error-level log on result loss; UT: Reason/SubReason set |
+| AU-12 | Audit Generation | KA-CRIT-1/2 | IT: cancel/timeout emits completion audit |
+| IA-2 | Identification & Authentication | AF-CRIT-1, AF-HIGH-3/4 | UT: startup fails without auth; UT: errors redacted |
+| SC-8 | Transmission Confidentiality | AF-HIGH-3, AF-HIGH-4 | UT: RedactError applied to all client-facing errors |
+| SC-13 | Cryptographic Protection | KA-MED-1 | UT: ExecutionBundleDigest propagated in interactive path |
+| SI-2 | Flaw Remediation | All 49 bugs | Full TDD coverage per this plan |
+| SI-10 | Information Input Validation | AF-MED-2 | UT: invalid rr_id rejected before reaching KA |
+| CP-10 | System Recovery | AA-CRIT-2, AA-HIGH-1/2 | UT: transient errors don't permanently fail; IT: regeneration on 404 |
+
+### 2.3 Referenced Acceptance Criteria from BRs
+
+| BR | AC | Violated By |
+|----|-----|------------|
+| BR-INTERACTIVE-010 SC-7.3 | "On cancelled with IS deleted: PhaseFailed with ReasonInteractiveCancelled" | AA-HIGH-2 (IS check error → terminal without IS check) |
+| BR-INTERACTIVE-010 SC-7.2 | "On cancelled with IS still Active: re-submit with interactive=true" | AA-HIGH-2 (API error blocks re-submit) |
+| BR-INTERACTIVE-010 Edge Case | "Pending session abandoned: AA 25m cap fails investigation" | AA-CRIT-1 (cap missing for user_driving) |
+| BR-HAPI-197 AC-4 | "Confidence < 0.7 → needs_human_review=true" | KA-HIGH-1 (confidence 0.00 propagated) |
+| BR-ORCH-027 AC-1 | "All remediations MUST reach terminal state" | AA-CRIT-1 (unbounded user_driving) |
+| BR-ORCH-028 AC-3 | "Per-phase timeout with phase recording" | AA-HIGH-3 (AA/RO timeout conflict) |
+| DD-INTERACTIVE-002 §Timeout | "Global timeout 1h as hard cap. Dynamic extension bounded." | AA-MED-9 (maxInvestigationDuration not configurable) |
+| BR-RBAC-001 | "MUST authenticate users before granting access" | AF-CRIT-1 (pass-through on misconfig) |
+| BR-RBAC-005 | "MUST provide secure session management with configurable timeouts" | AF-CRIT-2 (MaxConcurrentSessions dead code) |
+| BR-INTERACTIVE-004 §5 | "Only the active driver may terminate the session" (SEC-CRIT-01) | KA-HIGH-2 (unmutexed complete/cancel races) |
+
+## 3. Test Items
+
+### 3.1 KA — Kubernaut Agent
+
+| Item | File | Bugs |
+|------|------|------|
+| `handleCancel` | `internal/kubernautagent/mcp/tools/investigate.go` | KA-CRIT-1 |
+| TimeoutManager callback | `cmd/kubernautagent/main.go` | KA-CRIT-2 |
+| SessionClosedHandler | `cmd/kubernautagent/main.go` | KA-CRIT-2 |
+| `buildFinalResult` | `internal/kubernautagent/mcp/tools/select_workflow.go` | KA-HIGH-1, KA-MED-1/2/8 |
+| `handleComplete` | `internal/kubernautagent/mcp/tools/investigate.go` | KA-HIGH-2, KA-MED-6 |
+| `SelectWorkflowTool.Handle` goroutine | `internal/kubernautagent/mcp/tools/select_workflow.go` | KA-HIGH-3, KA-MED-7 |
+| `SetResult` | `internal/kubernautagent/session/store.go` | KA-HIGH-4 |
+| `GetLatestRCAResultByRemediationID` | `internal/kubernautagent/session/manager.go` | KA-HIGH-5 |
+| `CompleteNoActionTool.Handle` | `internal/kubernautagent/mcp/tools/complete_no_action.go` | KA-MED-4/5 |
+
+### 3.2 AA — AIAnalysis Controller
+
+| Item | File | Bugs |
+|------|------|------|
+| `handleSessionPollUserDriving` | `pkg/aianalysis/handlers/investigating.go` | AA-CRIT-1, AA-MED-5 |
+| `handleError` / poll success paths | `pkg/aianalysis/handlers/investigating.go` | AA-CRIT-2 |
+| `handleSessionGetResultError` | `pkg/aianalysis/handlers/investigating.go` | AA-HIGH-1, AA-MED-3 |
+| `handleSessionPollCancelled` | `pkg/aianalysis/handlers/investigating.go` | AA-HIGH-2 |
+| `handleSessionPollPending` timeout | `pkg/aianalysis/handlers/investigating.go` | AA-HIGH-3, AA-MED-2/9 |
+| `handleInvestigating` (idempotency) | `internal/controller/aianalysis/phase_handlers.go` | AA-HIGH-4 |
+| `handleSessionPollFailed` | `pkg/aianalysis/handlers/investigating.go` | AA-MED-1 |
+| `buildPolicyInput` | `pkg/aianalysis/handlers/analyzing.go` | AA-MED-4 |
+| `handleDeletion` | `internal/controller/aianalysis/deletion_handler.go` | AA-MED-8 |
+
+### 3.3 AF — API Frontend
+
+| Item | File | Bugs |
+|------|------|------|
+| `buildAuthMiddleware` | `cmd/apifrontend/main.go` | AF-CRIT-1 |
+| `UserLimiter.AcquireSession` wiring | `pkg/apifrontend/ratelimit/ratelimit.go` | AF-CRIT-2 |
+| `kaMCPHTTPClient` construction | `cmd/apifrontend/main.go` | AF-HIGH-1 |
+| `KASessionPool` lifecycle | `pkg/apifrontend/ka/session_pool.go` | AF-HIGH-2 |
+| `SDKMCPClient.StartInvestigation` error | `pkg/apifrontend/ka/mcp_sdk_client.go` | AF-HIGH-3 |
+| `FormatEventForUser` | `pkg/apifrontend/tools/ka_investigate_mcp.go` | AF-HIGH-4 |
+| `SDKMCPClient.StartInvestigation` context | `pkg/apifrontend/ka/mcp_sdk_client.go` | AF-HIGH-5 |
+| Router `/metrics` | `pkg/apifrontend/handler/router.go` | AF-MED-1 |
+| `HandleDiscoverWorkflows` / `HandleSelectWorkflow` | `pkg/apifrontend/tools/ka_tools.go` | AF-MED-2 |
+
+## 4. Pyramid Invariant
+
+```
+UT  proves logic   --> buildFinalResult merges Phase 3 fields; handleCancel bridges HTTP;
+                       SetResult guards user_driving; auth rejects pass-through; error redaction
+IT  proves wiring  --> main.go timeout callback → httpCompleter wired; AcquireSession called
+                       from A2A handler; EvictIdle goroutine started; router denies /metrics
+E2E proves journey --> Interactive takeover → select_workflow → AA poll → confidence passes
+                       → WorkflowExecution created with correct fields
+```
+
+## 5. Features to Be Tested
+
+### 5.1 KA Tier 1: Unit Tests — Prove Logic
+
+#### Session Lifecycle Unification (KA-CRIT-1, KA-CRIT-2, KA-MED-3/4/5)
+
+| ID | BR | FedRAMP | Scenario | Asserts |
+|----|-----|---------|----------|---------|
+| UT-KA-1351-001 | BR-INTERACTIVE-004 | AU-12 | `handleCancel` calls `httpCompleter.CompleteUserDriving` | HTTP session transitions to completed after MCP cancel |
+| UT-KA-1351-002 | BR-INTERACTIVE-004 | AU-12 | `handleCancel` calls `ForceCompleteByRemediationID` as fallback | HTTP session resolved even without user_driving match |
+| UT-KA-1351-003 | BR-INTERACTIVE-005 | CP-10 | TimeoutManager `onExpire` resolves HTTP session | Expired session has HTTP `StatusCompleted` with cancellation result |
+| UT-KA-1351-004 | BR-INTERACTIVE-005 | CP-10 | SessionClosedHandler disconnect resolves HTTP session | Disconnected session has HTTP `StatusCompleted` |
+| UT-KA-1351-005 | BR-INTERACTIVE-004 | AU-2 | `complete_no_action` calls `StopTracking` | TimeoutManager no longer fires after completion |
+| UT-KA-1351-006 | BR-INTERACTIVE-004 | AU-2 | `complete_no_action` clears `sessionMu` and `reconHistory` | No stale state on next session for same rr_id |
+| UT-KA-1351-007 | BR-INTERACTIVE-010 SC-7 | CP-10 | HTTP cancel on `user_driving` session also releases MCP lease | No split-brain between HTTP and MCP |
+
+#### Phase 3 Result Propagation (KA-HIGH-1, KA-MED-1/2/8)
+
+| ID | BR | FedRAMP | Scenario | Asserts |
+|----|-----|---------|----------|---------|
+| UT-KA-1351-010 | BR-HAPI-197 AC-4 | SI-2 | `buildFinalResult` propagates `discovery.FullResult.Confidence` | `result.Confidence == 0.82` when RCA has `0.0` and Phase 3 has `0.82` |
+| UT-KA-1351-011 | BR-HAPI-197 AC-4 | SC-13 | `buildFinalResult` propagates `ExecutionBundleDigest` | Digest matches catalog entry |
+| UT-KA-1351-012 | BR-HAPI-197 AC-4 | SI-2 | `buildFinalResult` propagates `AlternativeWorkflows` | Alternatives from Phase 3 present in final result |
+| UT-KA-1351-013 | BR-HAPI-197 | SI-2 | `buildFinalResult` propagates `DetectedLabels`, `IsActionable`, `InvestigationOutcome`, `Warnings` | All Phase 3 fields merged into final result |
+| UT-KA-1351-014 | BR-HAPI-197 | SI-2 | `buildFinalResult` with nil `discovery.FullResult` gracefully degrades | No panic; falls back to RCA-only fields |
+
+#### Mutex and Race Fixes (KA-HIGH-2/3/4/5, KA-MED-6/7)
+
+| ID | BR | FedRAMP | Scenario | Asserts |
+|----|-----|---------|----------|---------|
+| UT-KA-1351-020 | BR-INTERACTIVE-004 §5 | AC-6 | `handleComplete` acquires per-rrID mutex | Concurrent `handleMessage` blocked during completion |
+| UT-KA-1351-021 | BR-INTERACTIVE-004 §5 | AC-6 | `handleCancel` acquires per-rrID mutex | Concurrent `handleDiscoverWorkflows` blocked during cancel |
+| UT-KA-1351-022 | BR-INTERACTIVE-005 | SI-2 | `select_workflow` completion is synchronous (or mutex-held) | No TOCTOU between response and HTTP/lease cleanup |
+| UT-KA-1351-023 | BR-INTERACTIVE-010 | SI-2 | `SetResult` rejects writes when `StatusUserDriving` | Cancelled goroutine cannot overwrite user-driven session result |
+| UT-KA-1351-024 | BR-INTERACTIVE-010 | SI-2 | `GetLatestRCAResultByRemediationID` filters cancelled sessions | Returns only non-cancelled, non-stale results |
+| UT-KA-1351-025 | BR-HAPI-197 | AU-2 | `handleComplete` builds minimal `InvestigationResult` instead of nil | HTTP session has non-nil result after `action=complete` |
+| UT-KA-1351-026 | BR-HAPI-197 | AU-2 | Goroutine result-loss logged at Error level | Both-paths-fail scenario produces `logger.Error` (not `V(1).Info`) |
+
+### 5.2 AA Tier 1: Unit Tests — Prove Logic
+
+#### Timeout and Failure Handling (AA-CRIT-1/2, AA-HIGH-1/2/3/4, AA-MED-1/2/3/9)
+
+| ID | BR | FedRAMP | Scenario | Asserts |
+|----|-----|---------|----------|---------|
+| UT-AA-1351-001 | BR-ORCH-027 AC-1 | CP-10 | `handleSessionPollUserDriving` enforces `maxInvestigationDuration` | `PhaseFailed` after 25m even in `user_driving` |
+| UT-AA-1351-002 | BR-ORCH-027 | CP-10 | `user_driving` timeout sets `Reason`, `SubReason`, and `SetInvestigationComplete` | All terminal fields populated consistently |
+| UT-AA-1351-003 | BR-AI-009 | CP-10 | `ConsecutiveFailures` reset to 0 on successful poll | Intermittent errors don't accumulate across successes |
+| UT-AA-1351-004 | BR-AA-HAPI-064.5 | CP-10 | `GetSessionResult` 404 triggers session regeneration (like poll 404) | `handleSessionLost` called, not `handleError` |
+| UT-AA-1351-005 | BR-INTERACTIVE-010 SC-7.2 | SI-2 | `handleSessionPollCancelled` requeues on IS check error | Transient API error → `RequeueAfter` (not terminal) |
+| UT-AA-1351-006 | BR-ORCH-028 | SI-2 | AA communicates timeout cap to RO-compatible boundary | `maxInvestigationDuration` wired from config |
+| UT-AA-1351-007 | BR-AI-009 | SI-2 | `InvestigationTime > 0` with `Phase=Investigating` triggers recovery (not skip) | Handler requeues or re-evaluates instead of returning empty |
+| UT-AA-1351-008 | BR-HAPI-197 | AU-2 | `handleSessionPollFailed` sets `Reason=InvestigationFailed` and `SubReason` | No stale retry metadata on terminal status |
+| UT-AA-1351-009 | BR-ORCH-027 | SI-2 | Timeout path calls `SetInvestigationComplete(false, ...)` | `InvestigationComplete` condition consistent with `PhaseFailed` |
+| UT-AA-1351-010 | BR-AA-HAPI-064 | CP-10 | 409 on `GetSessionResult` has bounded retry (cap at N attempts) | Does not re-poll indefinitely; fails after cap |
+| UT-AA-1351-011 | DD-EVENT-001 | AU-2 | `user_driving` event emission rate-limited (not every 15s) | Max 1 event per 5-minute window (or similar) |
+
+### 5.3 AF Tier 1: Unit Tests — Prove Logic
+
+#### Auth Hardening (AF-CRIT-1, AF-CRIT-2, AF-MED-8)
+
+| ID | BR | FedRAMP | Scenario | Asserts |
+|----|-----|---------|----------|---------|
+| UT-AF-1351-001 | BR-RBAC-001 | IA-2, AC-2 | `buildAuthMiddleware` returns deny-all when no JWT AND kubeconfig fails | Requests receive 503 (not pass-through) |
+| UT-AF-1351-002 | BR-RBAC-001 | IA-2, AC-2 | `buildAuthMiddleware` returns deny-all when K8s client creation fails | Requests receive 503 |
+| UT-AF-1351-003 | BR-RBAC-005 | AC-2 | `AcquireSession` called on investigation start | Session count incremented for user |
+| UT-AF-1351-004 | BR-RBAC-005 | AC-2 | `ReleaseSession` called on investigation end/disconnect | Session count decremented |
+| UT-AF-1351-005 | BR-RBAC-005 | AC-2 | Investigation rejected when `AcquireSession` returns false | 429 returned to client |
+
+#### Resource Management (AF-HIGH-1/2/5)
+
+| ID | BR | FedRAMP | Scenario | Asserts |
+|----|-----|---------|----------|---------|
+| UT-AF-1351-010 | BR-RBAC-005 | CP-10 | KA MCP HTTP client has configured Timeout | `http.Client.Timeout > 0` |
+| UT-AF-1351-011 | BR-RBAC-005 | CP-10 | `EvictIdle` called periodically | Pool entries older than IdleTTL are removed |
+| UT-AF-1351-012 | BR-INTERACTIVE-005 | CP-10 | Investigation session context tied to request lifecycle | Client disconnect cancels MCP session within timeout |
+
+#### Error Redaction (AF-HIGH-3/4)
+
+| ID | BR | FedRAMP | Scenario | Asserts |
+|----|-----|---------|----------|---------|
+| UT-AF-1351-020 | BR-RBAC-016 | SC-8 | `StartInvestigation` error path applies `security.RedactError` | Raw KA text never reaches client |
+| UT-AF-1351-021 | BR-RBAC-016 | SC-8 | `FormatEventForUser` with `EventTypeError` applies `security.RedactError` | Internal error details stripped before SSE emission |
+
+#### Input Validation (AF-MED-2)
+
+| ID | BR | FedRAMP | Scenario | Asserts |
+|----|-----|---------|----------|---------|
+| UT-AF-1351-030 | BR-RBAC-016 | SI-10 | `HandleDiscoverWorkflows` validates `rr_id` format | Non-DNS-1123 rr_id returns validation error |
+| UT-AF-1351-031 | BR-RBAC-016 | SI-10 | `HandleSelectWorkflow` validates `rr_id` format | Non-DNS-1123 rr_id returns validation error |
+| UT-AF-1351-032 | BR-RBAC-016 | SI-10 | `HandleInvestigateMCP` validates `rr_id` format | Non-DNS-1123 rr_id returns validation error |
+
+### 5.4 Tier 2: Integration Tests — Prove Wiring
+
+#### KA Wiring (`test/integration/kubernautagent/`)
+
+| ID | BR | FedRAMP | Scenario | Asserts |
+|----|-----|---------|----------|---------|
+| IT-KA-1351-001 | BR-INTERACTIVE-004 | AU-12 | Cancel via MCP → HTTP session completed | Full stack: MCP tool call → httpCompleter wired in main.go → session store updated |
+| IT-KA-1351-002 | BR-INTERACTIVE-005 | CP-10 | Inactivity timeout → HTTP session completed | TimeoutManager fires → httpCompleter called → poll returns `completed` |
+| IT-KA-1351-003 | BR-INTERACTIVE-005 | CP-10 | MCP disconnect → HTTP session completed | SessionClosedHandler → httpCompleter → poll returns `completed` |
+| IT-KA-1351-004 | BR-HAPI-197 AC-4 | SI-2 | `select_workflow` through full stack returns correct confidence | End-to-end: tool call → buildFinalResult → HTTP result has Phase 3 confidence |
+
+#### AA Wiring (`test/integration/aianalysis/`)
+
+| ID | BR | FedRAMP | Scenario | Asserts |
+|----|-----|---------|----------|---------|
+| IT-AA-1351-001 | BR-ORCH-027 | CP-10 | `maxInvestigationDuration` wired from config in main.go | Handler constructed with config value (not default) |
+| IT-AA-1351-002 | BR-AI-009 | CP-10 | Poll success resets `ConsecutiveFailures` on CR status | After transient error + success, failures = 0 |
+| IT-AA-1351-003 | BR-INTERACTIVE-010 SC-7 | SI-2 | KA `cancelled` + IS check error → requeue (not terminal) | CR status remains `Investigating` after transient IS API error |
+
+#### AF Wiring (`test/integration/apifrontend/`)
+
+| ID | BR | FedRAMP | Scenario | Asserts |
+|----|-----|---------|----------|---------|
+| IT-AF-1351-001 | BR-RBAC-001 | IA-2 | AF startup without kubeconfig returns 503 (not pass-through) | `GET /a2a/invoke` returns 503 |
+| IT-AF-1351-002 | BR-RBAC-005 | AC-2 | Concurrent session limit enforced at A2A layer | N+1th investigation returns 429 |
+| IT-AF-1351-003 | BR-RBAC-005 | CP-10 | `EvictIdle` goroutine runs in production wiring | Pool size decreases after IdleTTL elapsed |
+
+### 5.5 Tier 3: E2E Tests — Prove the Journey
+
+| ID | BR | FedRAMP | Scenario | Asserts |
+|----|-----|---------|----------|---------|
+| E2E-1351-001 | BR-HAPI-197, BR-INTERACTIVE-010 | SI-2 | Interactive takeover → select_workflow → AA confidence ≥ 0.7 → WorkflowExecution created | Full pipeline: AF → KA → AA → RO → WE; confidence correctly propagated |
+| E2E-1351-002 | BR-ORCH-027, BR-INTERACTIVE-005 | CP-10 | Interactive session exceeds 25m → AA fails with timeout | user_driving session has bounded lifetime |
+| E2E-1351-003 | BR-INTERACTIVE-004, BR-INTERACTIVE-010 | AU-12 | MCP cancel during interactive → AA observes completed → no stuck RR | Pipeline reaches terminal state after cancel |
+
+## 6. Features Not to Be Tested
+
+| Feature | Reason |
+|---------|--------|
+| `maxUserDrivingDuration` (separate from investigation timeout) | Explicitly deferred to v1.6+ per BR-INTERACTIVE-010 "Out of Scope" |
+| Multi-replica session affinity | Deferred per BR-INTERACTIVE-010 |
+| RR cancellation propagation to KA session | Noted as "pre-existing gap" in BR-INTERACTIVE-010 |
+| Rego policy correctness (approval.rego logic) | Operator-managed; test plan covers structural identity propagation only |
+
+## 7. Approach
+
+### 7.1 TDD Methodology
+
+Each bug fix follows RED → GREEN → REFACTOR:
+
+1. **RED**: Write the test(s) from this plan that expose the bug. Verify they fail against current code.
+2. **GREEN**: Implement the minimal fix. Verify test passes.
+3. **REFACTOR**: Consolidate, extract helpers, remove duplication.
+
+### 7.2 Anti-Patterns to Avoid
+
+| Anti-Pattern | Mitigation |
+|--------------|-----------|
+| Testing implementation details | Assert observable behavior (HTTP status, CR status, result fields) not internal state |
+| Shared mutable test state | Each `It` block creates its own Manager/Store/Handler instances |
+| Sleep-based synchronization | Use `Eventually`/`Consistently` with timeouts (Gomega async assertions) |
+| Overly-specific mocks | Mock only external boundaries (K8s API, LLM, HTTP transport); use real business logic |
+| Table-driven tests without context | Each entry has a descriptive name and documents the BR/AC it validates |
+| Testing private functions directly | Test through public API; use `export_test.go` only for pure computational helpers |
+| Ignoring error paths | Every error branch in scope has at least one test exercising it |
+| Non-deterministic time | Inject `clock` interface or use `fakeclock` for timeout tests |
+
+### 7.3 Coverage Targets (Per-Tier Testable Code)
+
+| Tier | Target | Scope |
+|------|--------|-------|
+| Unit Tests | ≥80% of unit-testable code | Pure logic: buildFinalResult, SetResult guards, error classification, auth config |
+| Integration Tests | ≥80% of integration-testable code | Wiring: main.go callbacks, handler→store paths, config injection |
+| E2E Tests | ≥80% of full service code | Full journey: AF→KA→AA→RO pipeline for interactive flows |
+
+## 8. Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | IT Test ID |
+|-----------|----------------------|---------------------|------------|
+| httpCompleter in handleCancel | `InvestigateTool.handleCancel` | `cmd/kubernautagent/main.go` (tool construction) | IT-KA-1351-001 |
+| httpCompleter in TimeoutManager | TimeoutManager `onExpire` callback | `cmd/kubernautagent/main.go:1272-1285` | IT-KA-1351-002 |
+| httpCompleter in SessionClosedHandler | disconnect callback | `cmd/kubernautagent/main.go:1294-1335` | IT-KA-1351-003 |
+| AcquireSession in A2A handler | `HandleInvestigateMCP` | `pkg/apifrontend/tools/ka_investigate_mcp.go` | IT-AF-1351-002 |
+| EvictIdle goroutine | startup | `cmd/apifrontend/main.go` (pool lifecycle) | IT-AF-1351-003 |
+| WithMaxInvestigationDuration(cfg) | handler construction | `cmd/aianalysis/main.go:281-286` | IT-AA-1351-001 |
+| ConsecutiveFailures reset | poll success path | `pkg/aianalysis/handlers/investigating.go` | IT-AA-1351-002 |
+| IS check error requeue | handleSessionPollCancelled | `pkg/aianalysis/handlers/investigating.go` | IT-AA-1351-003 |
+| Auth deny-all on config failure | buildAuthMiddleware | `cmd/apifrontend/main.go:884-893` | IT-AF-1351-001 |
+
+## 9. Pass/Fail Criteria
+
+### 9.1 Individual Test
+
+- **Pass**: Test assertion succeeds; no panics; no data races (`-race` flag)
+- **Fail**: Any assertion failure, panic, or detected race condition
+
+### 9.2 Test Plan
+
+- **Pass**: ALL tests in sections 5.1–5.5 pass; coverage ≥80% per tier on changed files; `go build ./...` clean; `golangci-lint run --timeout=5m` clean
+- **Fail**: Any test failure; coverage <80% on any tier's testable code; lint errors
+
+## 10. Test Environment
+
+| Tier | Environment | Dependencies |
+|------|-------------|-------------|
+| UT | Go test runner + httptest | fakeclock, mock interfaces (HTTPSessionCompleter, LeaseSessionManager) |
+| IT | envtest (real kube-apiserver, etcd) | controller-runtime envtest, real session stores, real handlers |
+| E2E | Kind cluster | DEX (auth), mock-LLM, TLS certs, full service deployment |
+
+## 11. Test Deliverables
+
+| Deliverable | Location |
+|-------------|----------|
+| KA unit tests | `internal/kubernautagent/mcp/tools/*_test.go`, `internal/kubernautagent/session/*_test.go` |
+| AA unit tests | `pkg/aianalysis/handlers/*_test.go`, `pkg/aianalysis/investigating_handler_test.go` |
+| AF unit tests | `pkg/apifrontend/ka/*_test.go`, `pkg/apifrontend/tools/*_test.go`, `cmd/apifrontend/main_wiring_test.go` |
+| KA integration tests | `test/integration/kubernautagent/session_lifecycle_test.go` |
+| AA integration tests | `test/integration/aianalysis/investigating_handler_test.go` |
+| AF integration tests | `test/integration/apifrontend/auth_session_test.go` |
+| E2E tests | `test/e2e/interactive_pipeline_test.go` |
+
+## 12. Schedule
+
+| Phase | Commit Group | Bugs | Estimated Effort |
+|-------|-------------|------|-----------------|
+| 1 | KA session lifecycle unification | KA-CRIT-1/2, KA-MED-3/4/5 | 2 days |
+| 2 | KA buildFinalResult Phase 3 merge | KA-HIGH-1, KA-MED-1/2/8 | 1 day |
+| 3 | KA mutex and race fixes | KA-HIGH-2/3/4/5, KA-MED-6/7 | 2 days |
+| 4 | AA timeout and failure handling | AA-CRIT-1/2, AA-HIGH-1/2/3/4, AA-MED-1/2/3/9 | 2 days |
+| 5 | AF auth hardening and resources | AF-CRIT-1/2, AF-HIGH-1/2/3/4/5 | 2 days |
+| 6 | AF input validation and lifecycle | AF-MED-1-8 | 1 day |
+| 7 | E2E validation | E2E-1351-001/002/003 | 1 day |

--- a/internal/kubernautagent/mcp/tools/cancel_lifecycle_test.go
+++ b/internal/kubernautagent/mcp/tools/cancel_lifecycle_test.go
@@ -1,0 +1,206 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools_test
+
+import (
+	"context"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+	mcptools "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+var _ = Describe("#1351 KA Session Lifecycle — handleCancel HTTP bridge", func() {
+
+	Describe("UT-KA-1351-001: handleCancel calls httpCompleter.CompleteUserDriving", func() {
+		It("should transition the HTTP session to completed after MCP cancel", func() {
+			completer := &cancelLifecycleHTTPCompleter{
+				foundID: "http-sess-001",
+				found:   true,
+			}
+			sessionMgr := &mockSessionManager{
+				isActive: true,
+				getDriverResult: &mcpinternal.InteractiveSession{
+					SessionID:     "mcp-sess-001",
+					CorrelationID: "rr-cancel-001",
+					ActingUser:    mcpinternal.UserInfo{Username: "alice"},
+				},
+			}
+
+			tool := mcptools.NewInvestigateTool(
+				sessionMgr,
+				&mockInvestigatorRunner{},
+				&mockContextReconstructor{},
+				mcptools.NopAutonomousManager{},
+				mcptools.WithHTTPCompleter(completer),
+			)
+
+			out, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-cancel-001",
+				Action: mcptools.ActionCancel,
+			}, mcpinternal.UserInfo{Username: "alice"})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out.Status).To(Equal("cancelled"))
+
+			completedID, completedResult := completer.getCompleted()
+			Expect(completedID).To(Equal("http-sess-001"),
+				"handleCancel must call CompleteUserDriving on the HTTP session (KA-CRIT-1)")
+			_ = completedResult
+		})
+	})
+
+	Describe("UT-KA-1351-002: handleCancel uses ForceComplete as fallback", func() {
+		It("should force-complete the HTTP session when FindUserDriving returns not-found", func() {
+			completer := &cancelLifecycleHTTPCompleter{
+				found: false, // FindUserDrivingByRemediationID returns not-found
+			}
+			sessionMgr := &mockSessionManager{
+				isActive: true,
+				getDriverResult: &mcpinternal.InteractiveSession{
+					SessionID:     "mcp-sess-002",
+					CorrelationID: "rr-cancel-002",
+					ActingUser:    mcpinternal.UserInfo{Username: "bob"},
+				},
+			}
+
+			tool := mcptools.NewInvestigateTool(
+				sessionMgr,
+				&mockInvestigatorRunner{},
+				&mockContextReconstructor{},
+				mcptools.NopAutonomousManager{},
+				mcptools.WithHTTPCompleter(completer),
+			)
+
+			out, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-cancel-002",
+				Action: mcptools.ActionCancel,
+			}, mcpinternal.UserInfo{Username: "bob"})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out.Status).To(Equal("cancelled"))
+
+			Expect(completer.forceCompleteCalled()).To(BeTrue(),
+				"handleCancel must call ForceCompleteByRemediationID as fallback (KA-CRIT-1)")
+		})
+	})
+
+	Describe("UT-KA-1351-005: complete_no_action calls StopTracking", func() {
+		It("should stop the timeout tracker on completion", func() {
+			tracker := &mockTimeoutTracker{}
+			completer := &cancelLifecycleHTTPCompleter{
+				foundID: "http-sess-005",
+				found:   true,
+			}
+			sessionMgr := &mockSessionManager{
+				isActive: true,
+				getDriverResult: &mcpinternal.InteractiveSession{
+					SessionID:     "mcp-sess-005",
+					CorrelationID: "rr-cna-001",
+					ActingUser:    mcpinternal.UserInfo{Username: "alice"},
+				},
+			}
+
+			tool := mcptools.NewCompleteNoActionTool(
+				sessionMgr,
+				mcptools.WithCompleteNoActionHTTPCompleter(completer),
+				mcptools.WithCompleteNoActionTimeoutTracker(tracker),
+			)
+
+			out, err := tool.Handle(context.Background(), mcptools.CompleteNoActionInput{
+				RRID:   "rr-cna-001",
+				Reason: "not actionable",
+			}, mcpinternal.UserInfo{Username: "alice"})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out.Status).To(Equal("completed_no_action"))
+			Expect(tracker.stoppedSessionID()).To(Equal("mcp-sess-005"),
+				"complete_no_action must call StopTracking (KA-MED-4)")
+		})
+	})
+})
+
+// cancelLifecycleHTTPCompleter tracks calls for lifecycle test assertions.
+type cancelLifecycleHTTPCompleter struct {
+	mu                    sync.Mutex
+	foundID               string
+	found                 bool
+	completedID           string
+	completedResult       *katypes.InvestigationResult
+	forceCompleteWasCalled bool
+}
+
+func (c *cancelLifecycleHTTPCompleter) FindUserDrivingByRemediationID(_ string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.foundID, c.found
+}
+
+func (c *cancelLifecycleHTTPCompleter) CompleteUserDriving(id string, result *katypes.InvestigationResult) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.completedID = id
+	c.completedResult = result
+	return nil
+}
+
+func (c *cancelLifecycleHTTPCompleter) ForceCompleteByRemediationID(_ string, result *katypes.InvestigationResult) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.forceCompleteWasCalled = true
+	c.completedResult = result
+	return nil
+}
+
+func (c *cancelLifecycleHTTPCompleter) getCompleted() (string, *katypes.InvestigationResult) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.completedID, c.completedResult
+}
+
+func (c *cancelLifecycleHTTPCompleter) forceCompleteCalled() bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.forceCompleteWasCalled
+}
+
+// mockTimeoutTracker tracks StopTracking calls.
+type mockTimeoutTracker struct {
+	mu        sync.Mutex
+	sessionID string
+}
+
+func (t *mockTimeoutTracker) StartTracking(_ string, _ func(string)) {}
+
+func (t *mockTimeoutTracker) StopTracking(sessionID string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.sessionID = sessionID
+}
+
+func (t *mockTimeoutTracker) ResetInactivity(_ string) {}
+
+func (t *mockTimeoutTracker) stoppedSessionID() string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return t.sessionID
+}
+

--- a/internal/kubernautagent/mcp/tools/cancel_lifecycle_test.go
+++ b/internal/kubernautagent/mcp/tools/cancel_lifecycle_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -135,6 +136,36 @@ var _ = Describe("#1351 KA Session Lifecycle — handleCancel HTTP bridge", func
 			Expect(tracker.stoppedSessionID()).To(Equal("mcp-sess-005"),
 				"complete_no_action must call StopTracking (KA-MED-4)")
 		})
+	})
+})
+
+var _ = Describe("UT-KA-1351-003: TimeoutManager onExpire resolves HTTP session (KA-CRIT-2)", func() {
+	It("should complete the HTTP session when called with a valid rrID", func() {
+		completer := &cancelLifecycleHTTPCompleter{
+			foundID: "http-sess-timeout",
+			found:   true,
+		}
+		logger := logr.Discard()
+
+		mcptools.CompleteHTTPSession(completer, "rr-timeout-001", nil, logger, "inactivity_timeout")
+
+		completedID, _ := completer.getCompleted()
+		Expect(completedID).To(Equal("http-sess-timeout"),
+			"CompleteHTTPSession must call CompleteUserDriving for timeout path (KA-CRIT-2)")
+	})
+})
+
+var _ = Describe("UT-KA-1351-004: SessionClosedHandler disconnect resolves HTTP session (KA-CRIT-2)", func() {
+	It("should complete the HTTP session via ForceComplete when no user_driving match", func() {
+		completer := &cancelLifecycleHTTPCompleter{
+			found: false, // No active user_driving session
+		}
+		logger := logr.Discard()
+
+		mcptools.CompleteHTTPSession(completer, "rr-disconnect-001", nil, logger, "disconnect")
+
+		Expect(completer.forceCompleteCalled()).To(BeTrue(),
+			"CompleteHTTPSession must fall back to ForceComplete on disconnect (KA-CRIT-2)")
 	})
 })
 

--- a/internal/kubernautagent/mcp/tools/complete_no_action.go
+++ b/internal/kubernautagent/mcp/tools/complete_no_action.go
@@ -44,10 +44,11 @@ type CompleteNoActionOutput struct {
 // Allows the user to explicitly conclude an investigation without selecting
 // a workflow. No discovery gate — can be called at any point in the session.
 type CompleteNoActionTool struct {
-	sessions      mcpinternal.SessionManager
-	httpCompleter HTTPSessionCompleter
-	mutexProvider SessionMutexProvider
-	logger        logr.Logger
+	sessions       mcpinternal.SessionManager
+	httpCompleter  HTTPSessionCompleter
+	mutexProvider  SessionMutexProvider
+	timeoutTracker TimeoutTracker
+	logger         logr.Logger
 }
 
 // CompleteNoActionOption configures optional dependencies.
@@ -72,6 +73,15 @@ func WithCompleteNoActionMutexProvider(provider SessionMutexProvider) CompleteNo
 	return func(t *CompleteNoActionTool) {
 		if provider != nil {
 			t.mutexProvider = provider
+		}
+	}
+}
+
+// WithCompleteNoActionTimeoutTracker sets the timeout tracker for session cleanup.
+func WithCompleteNoActionTimeoutTracker(tt TimeoutTracker) CompleteNoActionOption {
+	return func(t *CompleteNoActionTool) {
+		if tt != nil {
+			t.timeoutTracker = tt
 		}
 	}
 }
@@ -137,19 +147,11 @@ func (t *CompleteNoActionTool) Handle(_ context.Context, input CompleteNoActionI
 	finalResult.IsActionable = &notActionable
 	finalResult.Warnings = append(finalResult.Warnings, "Alert not actionable")
 
-	// Write result to HTTP session store.
-	if t.httpCompleter != nil {
-		httpSessionID, found := t.httpCompleter.FindUserDrivingByRemediationID(input.RRID)
-		if found {
-			if completeErr := t.httpCompleter.CompleteUserDriving(httpSessionID, finalResult); completeErr != nil {
-				t.logger.Error(completeErr, "failed to complete HTTP session",
-					"rr_id", input.RRID, "http_session_id", httpSessionID)
-			}
-		} else if completeErr := t.httpCompleter.ForceCompleteByRemediationID(input.RRID, finalResult); completeErr != nil {
-			t.logger.V(1).Info("no HTTP session found to force-complete (may already be terminal)",
-				"rr_id", input.RRID, "error", completeErr)
-		}
+	if t.timeoutTracker != nil {
+		t.timeoutTracker.StopTracking(driver.SessionID)
 	}
+
+	completeHTTPSession(t.httpCompleter, input.RRID, finalResult, t.logger, "complete_no_action")
 
 	// Release the MCP interactive lease.
 	if releaseErr := t.sessions.Release(driver.SessionID, "complete_no_action"); releaseErr != nil {

--- a/internal/kubernautagent/mcp/tools/complete_no_action.go
+++ b/internal/kubernautagent/mcp/tools/complete_no_action.go
@@ -151,7 +151,7 @@ func (t *CompleteNoActionTool) Handle(_ context.Context, input CompleteNoActionI
 		t.timeoutTracker.StopTracking(driver.SessionID)
 	}
 
-	completeHTTPSession(t.httpCompleter, input.RRID, finalResult, t.logger, "complete_no_action")
+	CompleteHTTPSession(t.httpCompleter, input.RRID, finalResult, t.logger, "complete_no_action")
 
 	// Release the MCP interactive lease.
 	if releaseErr := t.sessions.Release(driver.SessionID, "complete_no_action"); releaseErr != nil {

--- a/internal/kubernautagent/mcp/tools/investigate.go
+++ b/internal/kubernautagent/mcp/tools/investigate.go
@@ -623,6 +623,10 @@ func (t *InvestigateTool) handleMessage(ctx context.Context, input InvestigateIn
 }
 
 func (t *InvestigateTool) handleComplete(input InvestigateInput, user mcpinternal.UserInfo) (InvestigateOutput, error) {
+	mu := t.getSessionMutex(input.RRID)
+	mu.Lock()
+	defer mu.Unlock()
+
 	if !t.sessions.IsDriverActive(input.RRID) {
 		return InvestigateOutput{}, ErrCodeNotFound
 	}
@@ -653,18 +657,7 @@ func (t *InvestigateTool) handleComplete(input InvestigateInput, user mcpinterna
 
 	t.emitInteractiveCompleted(sess.SessionID, input.RRID, user.Username, "complete")
 
-	if t.httpCompleter != nil {
-		httpSessionID, found := t.httpCompleter.FindUserDrivingByRemediationID(input.RRID)
-		if found {
-			if completeErr := t.httpCompleter.CompleteUserDriving(httpSessionID, nil); completeErr != nil {
-				t.logger.Error(completeErr, "failed to complete HTTP session on action:complete",
-					"rr_id", input.RRID, "http_session_id", httpSessionID)
-			}
-		} else if completeErr := t.httpCompleter.ForceCompleteByRemediationID(input.RRID, nil); completeErr != nil {
-			t.logger.V(1).Info("no HTTP session found to force-complete on action:complete",
-				"rr_id", input.RRID, "error", completeErr)
-		}
-	}
+	completeHTTPSession(t.httpCompleter, input.RRID, nil, t.logger, "complete")
 
 	if t.metrics != nil {
 		t.metrics.RecordInteractiveSessionEnded()
@@ -919,6 +912,10 @@ func extractDiscoveryResult(result *katypes.InvestigationResult) *mcpinternal.Wo
 }
 
 func (t *InvestigateTool) handleCancel(input InvestigateInput, user mcpinternal.UserInfo) (InvestigateOutput, error) {
+	mu := t.getSessionMutex(input.RRID)
+	mu.Lock()
+	defer mu.Unlock()
+
 	if !t.sessions.IsDriverActive(input.RRID) {
 		return InvestigateOutput{}, ErrNoActiveSession
 	}
@@ -938,10 +935,14 @@ func (t *InvestigateTool) handleCancel(input InvestigateInput, user mcpinternal.
 	}
 
 	if err := t.sessions.Release(sess.SessionID, "explicit"); err != nil {
-		return InvestigateOutput{}, fmt.Errorf("release session: %w", err)
+		if !errors.Is(err, mcpinternal.ErrSessionNotFound) {
+			return InvestigateOutput{}, fmt.Errorf("release session: %w", err)
+		}
 	}
 
 	t.emitInteractiveCompleted(sess.SessionID, input.RRID, user.Username, "cancel")
+
+	completeHTTPSession(t.httpCompleter, input.RRID, nil, t.logger, "cancel")
 
 	if t.metrics != nil {
 		t.metrics.RecordInteractiveSessionEnded()

--- a/internal/kubernautagent/mcp/tools/investigate.go
+++ b/internal/kubernautagent/mcp/tools/investigate.go
@@ -657,7 +657,7 @@ func (t *InvestigateTool) handleComplete(input InvestigateInput, user mcpinterna
 
 	t.emitInteractiveCompleted(sess.SessionID, input.RRID, user.Username, "complete")
 
-	completeHTTPSession(t.httpCompleter, input.RRID, nil, t.logger, "complete")
+	CompleteHTTPSession(t.httpCompleter, input.RRID, nil, t.logger, "complete")
 
 	if t.metrics != nil {
 		t.metrics.RecordInteractiveSessionEnded()
@@ -942,7 +942,7 @@ func (t *InvestigateTool) handleCancel(input InvestigateInput, user mcpinternal.
 
 	t.emitInteractiveCompleted(sess.SessionID, input.RRID, user.Username, "cancel")
 
-	completeHTTPSession(t.httpCompleter, input.RRID, nil, t.logger, "cancel")
+	CompleteHTTPSession(t.httpCompleter, input.RRID, nil, t.logger, "cancel")
 
 	if t.metrics != nil {
 		t.metrics.RecordInteractiveSessionEnded()

--- a/internal/kubernautagent/mcp/tools/select_workflow.go
+++ b/internal/kubernautagent/mcp/tools/select_workflow.go
@@ -41,13 +41,14 @@ type WorkflowCatalog interface {
 // CatalogWorkflow represents the essential fields from a DataStorage workflow
 // entry needed for the interactive selection response.
 type CatalogWorkflow struct {
-	WorkflowID         string `json:"workflow_id"`
-	WorkflowName       string `json:"workflow_name"`
-	ActionType         string `json:"action_type"`
-	Version            string `json:"version"`
-	ExecutionEngine    string `json:"execution_engine,omitempty"`
-	ExecutionBundle    string `json:"execution_bundle,omitempty"`
-	ServiceAccountName string `json:"service_account_name,omitempty"`
+	WorkflowID            string `json:"workflow_id"`
+	WorkflowName          string `json:"workflow_name"`
+	ActionType            string `json:"action_type"`
+	Version               string `json:"version"`
+	ExecutionEngine       string `json:"execution_engine,omitempty"`
+	ExecutionBundle       string `json:"execution_bundle,omitempty"`
+	ExecutionBundleDigest string `json:"execution_bundle_digest,omitempty"`
+	ServiceAccountName    string `json:"service_account_name,omitempty"`
 }
 
 // PreSelectionContext accumulates results from pre-selection pipeline hooks
@@ -278,8 +279,16 @@ func (t *SelectWorkflowTool) Handle(ctx context.Context, input SelectWorkflowInp
 		logger := t.logger
 		completer := t.httpCompleter
 		sessions := t.sessions
+		mutexProvider := t.mutexProvider
 		go func() {
-			completeHTTPSession(completer, rrID, finalResult, logger, "select_workflow")
+			// KA-HIGH-3: Re-acquire the session mutex to prevent TOCTOU
+			// between response delivery and HTTP/lease cleanup.
+			if mutexProvider != nil {
+				mu := mutexProvider.GetSessionMutex(rrID)
+				mu.Lock()
+				defer mu.Unlock()
+			}
+			CompleteHTTPSession(completer, rrID, finalResult, logger, "select_workflow")
 
 			if releaseErr := sessions.Release(sessionID, "workflow_selected"); releaseErr != nil {
 				if !errors.Is(releaseErr, mcpinternal.ErrSessionNotFound) {
@@ -336,6 +345,7 @@ func buildFinalResult(rca *katypes.InvestigationResult, workflow *CatalogWorkflo
 		result.WorkflowID = workflow.WorkflowID
 		result.ExecutionEngine = workflow.ExecutionEngine
 		result.ExecutionBundle = workflow.ExecutionBundle
+		result.ExecutionBundleDigest = workflow.ExecutionBundleDigest
 		result.ServiceAccountName = workflow.ServiceAccountName
 		result.WorkflowVersion = workflow.Version
 		result.WorkflowRationale = "User-selected via interactive mode"

--- a/internal/kubernautagent/mcp/tools/select_workflow.go
+++ b/internal/kubernautagent/mcp/tools/select_workflow.go
@@ -275,22 +275,15 @@ func (t *SelectWorkflowTool) Handle(ctx context.Context, input SelectWorkflowInp
 		}
 		sessionID := driver.SessionID
 		rrID := input.RRID
-		workflowID := input.WorkflowID
+		logger := t.logger
+		completer := t.httpCompleter
+		sessions := t.sessions
 		go func() {
-			httpSessionID, found := t.httpCompleter.FindUserDrivingByRemediationID(rrID)
-			if found {
-				if completeErr := t.httpCompleter.CompleteUserDriving(httpSessionID, finalResult); completeErr != nil {
-					t.logger.Error(completeErr, "failed to complete HTTP session",
-						"rr_id", rrID, "http_session_id", httpSessionID, "workflow_id", workflowID)
-				}
-			} else if completeErr := t.httpCompleter.ForceCompleteByRemediationID(rrID, finalResult); completeErr != nil {
-				t.logger.V(1).Info("no HTTP session found to force-complete on select_workflow",
-					"rr_id", rrID, "error", completeErr)
-			}
+			completeHTTPSession(completer, rrID, finalResult, logger, "select_workflow")
 
-			if releaseErr := t.sessions.Release(sessionID, "workflow_selected"); releaseErr != nil {
+			if releaseErr := sessions.Release(sessionID, "workflow_selected"); releaseErr != nil {
 				if !errors.Is(releaseErr, mcpinternal.ErrSessionNotFound) {
-					t.logger.Error(releaseErr, "failed to release MCP lease", "session_id", sessionID)
+					logger.Error(releaseErr, "failed to release MCP lease", "session_id", sessionID)
 				}
 			}
 		}()
@@ -333,6 +326,12 @@ func buildFinalResult(rca *katypes.InvestigationResult, workflow *CatalogWorkflo
 		result.RemediationTarget = discovery.FullResult.RemediationTarget
 	}
 
+	// KA-HIGH-1: Use Phase 3 confidence when a discovery recommendation exists,
+	// since Phase 3 has additional workflow-specific scoring context.
+	if discovery != nil && discovery.Recommended != nil && discovery.Recommended.Confidence > 0 {
+		result.Confidence = discovery.Recommended.Confidence
+	}
+
 	if workflow != nil {
 		result.WorkflowID = workflow.WorkflowID
 		result.ExecutionEngine = workflow.ExecutionEngine
@@ -346,6 +345,22 @@ func buildFinalResult(rca *katypes.InvestigationResult, workflow *CatalogWorkflo
 		if params, found := lookupDiscoveredParameters(workflow.WorkflowID, discovery); found {
 			result.Parameters = cloneParameterMap(params)
 		}
+	}
+
+	// KA-MED-2: Propagate alternative workflows from discovery so AA and the
+	// operator have visibility into what other options were available.
+	if discovery != nil && len(discovery.Alternatives) > 0 {
+		alts := make([]katypes.AlternativeWorkflow, 0, len(discovery.Alternatives))
+		for _, alt := range discovery.Alternatives {
+			alts = append(alts, katypes.AlternativeWorkflow{
+				WorkflowID:      alt.WorkflowID,
+				ExecutionBundle: alt.ExecutionBundle,
+				Confidence:      alt.Confidence,
+				Rationale:       alt.Rationale,
+				Parameters:      cloneParameterMap(alt.Parameters),
+			})
+		}
+		result.AlternativeWorkflows = alts
 	}
 
 	// Re-inject KA-managed target resource parameters after the discovery

--- a/internal/kubernautagent/mcp/tools/select_workflow_test.go
+++ b/internal/kubernautagent/mcp/tools/select_workflow_test.go
@@ -839,6 +839,68 @@ var _ = Describe("kubernaut_select_workflow — helper functions", func() {
 		})
 	})
 
+	Describe("UT-KA-1351-010: buildFinalResult propagates Phase 3 confidence (KA-HIGH-1)", func() {
+		It("should use discovery confidence when higher than Phase 2 RCA", func() {
+			rca := &katypes.InvestigationResult{
+				RCASummary: "Pod OOM",
+				Confidence: 0.65,
+			}
+			discovery := &mcpinternal.WorkflowDiscoveryResult{
+				Recommended: &mcpinternal.DiscoveredWorkflow{
+					WorkflowID: "wf-scale",
+					Confidence: 0.92,
+				},
+			}
+			workflow := &mcptools.CatalogWorkflow{WorkflowID: "wf-scale"}
+
+			result := mcptools.BuildFinalResult(rca, workflow, discovery)
+
+			Expect(result.Confidence).To(Equal(0.92),
+				"buildFinalResult must use Phase 3 discovery confidence, not stale Phase 2 RCA confidence (KA-HIGH-1)")
+		})
+
+		It("should keep RCA confidence when discovery is nil", func() {
+			rca := &katypes.InvestigationResult{
+				RCASummary: "Pod OOM",
+				Confidence: 0.88,
+			}
+			workflow := &mcptools.CatalogWorkflow{WorkflowID: "wf-restart"}
+
+			result := mcptools.BuildFinalResult(rca, workflow, nil)
+
+			Expect(result.Confidence).To(Equal(0.88),
+				"without discovery context, confidence must remain from Phase 2")
+		})
+	})
+
+	Describe("UT-KA-1351-011: buildFinalResult propagates AlternativeWorkflows (KA-MED-2)", func() {
+		It("should populate AlternativeWorkflows from discovery alternatives", func() {
+			rca := &katypes.InvestigationResult{
+				RCASummary: "CPU throttled",
+				Confidence: 0.85,
+			}
+			discovery := &mcpinternal.WorkflowDiscoveryResult{
+				Recommended: &mcpinternal.DiscoveredWorkflow{
+					WorkflowID: "wf-scale",
+					Confidence: 0.92,
+					Rationale:  "high correlation",
+				},
+				Alternatives: []mcpinternal.DiscoveredWorkflow{
+					{WorkflowID: "wf-restart", Confidence: 0.75, Rationale: "simpler fix"},
+					{WorkflowID: "wf-rollback", Confidence: 0.60, Rationale: "last resort"},
+				},
+			}
+			workflow := &mcptools.CatalogWorkflow{WorkflowID: "wf-scale"}
+
+			result := mcptools.BuildFinalResult(rca, workflow, discovery)
+
+			Expect(result.AlternativeWorkflows).To(HaveLen(2),
+				"buildFinalResult must propagate discovery alternatives to the final result (KA-MED-2)")
+			Expect(result.AlternativeWorkflows[0].WorkflowID).To(Equal("wf-restart"))
+			Expect(result.AlternativeWorkflows[1].WorkflowID).To(Equal("wf-rollback"))
+		})
+	})
+
 	Describe("UT-KA-SW-ISWF-001: isWorkflowInDiscoveryResult edge cases", func() {
 		It("should match recommended workflow", func() {
 			dr := &mcpinternal.WorkflowDiscoveryResult{

--- a/internal/kubernautagent/mcp/tools/select_workflow_test.go
+++ b/internal/kubernautagent/mcp/tools/select_workflow_test.go
@@ -901,6 +901,36 @@ var _ = Describe("kubernaut_select_workflow — helper functions", func() {
 		})
 	})
 
+	Describe("UT-KA-1351-011-digest: buildFinalResult propagates ExecutionBundleDigest (KA-MED-1)", func() {
+		It("should copy ExecutionBundleDigest from workflow to result", func() {
+			rca := &katypes.InvestigationResult{RCASummary: "OOM", Confidence: 0.8}
+			workflow := &mcptools.CatalogWorkflow{
+				WorkflowID:            "wf-restart",
+				ExecutionBundle:       "bundle.tar.gz",
+				ExecutionBundleDigest: "sha256:abc123",
+			}
+			result := mcptools.BuildFinalResult(rca, workflow, nil)
+			Expect(result.ExecutionBundleDigest).To(Equal("sha256:abc123"),
+				"buildFinalResult must propagate ExecutionBundleDigest from catalog (KA-MED-1)")
+		})
+	})
+
+	Describe("UT-KA-1351-014: buildFinalResult with nil discovery gracefully degrades (KA-MED-8)", func() {
+		It("should not panic and fall back to RCA-only fields", func() {
+			rca := &katypes.InvestigationResult{
+				RCASummary: "Disk full",
+				Confidence: 0.75,
+			}
+			workflow := &mcptools.CatalogWorkflow{WorkflowID: "wf-cleanup"}
+
+			// Should not panic with nil discovery
+			result := mcptools.BuildFinalResult(rca, workflow, nil)
+			Expect(result.Confidence).To(Equal(0.75))
+			Expect(result.RCASummary).To(Equal("Disk full"))
+			Expect(result.WorkflowID).To(Equal("wf-cleanup"))
+		})
+	})
+
 	Describe("UT-KA-SW-ISWF-001: isWorkflowInDiscoveryResult edge cases", func() {
 		It("should match recommended workflow", func() {
 			dr := &mcpinternal.WorkflowDiscoveryResult{

--- a/internal/kubernautagent/mcp/tools/session_teardown.go
+++ b/internal/kubernautagent/mcp/tools/session_teardown.go
@@ -22,10 +22,11 @@ import (
 	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 )
 
-// completeHTTPSession bridges the MCP session lifecycle event to the HTTP session
+// CompleteHTTPSession bridges the MCP session lifecycle event to the HTTP session
 // store that the AA controller polls. It attempts FindUserDriving first, falling
 // back to ForceComplete when the session is not in user_driving status.
-func completeHTTPSession(completer HTTPSessionCompleter, rrID string, result *katypes.InvestigationResult, logger logr.Logger, action string) {
+// Exported for use by cmd/kubernautagent/main.go (timeout/disconnect handlers).
+func CompleteHTTPSession(completer HTTPSessionCompleter, rrID string, result *katypes.InvestigationResult, logger logr.Logger, action string) {
 	if completer == nil {
 		return
 	}

--- a/internal/kubernautagent/mcp/tools/session_teardown.go
+++ b/internal/kubernautagent/mcp/tools/session_teardown.go
@@ -1,0 +1,42 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools
+
+import (
+	"github.com/go-logr/logr"
+
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// completeHTTPSession bridges the MCP session lifecycle event to the HTTP session
+// store that the AA controller polls. It attempts FindUserDriving first, falling
+// back to ForceComplete when the session is not in user_driving status.
+func completeHTTPSession(completer HTTPSessionCompleter, rrID string, result *katypes.InvestigationResult, logger logr.Logger, action string) {
+	if completer == nil {
+		return
+	}
+	httpSessionID, found := completer.FindUserDrivingByRemediationID(rrID)
+	if found {
+		if err := completer.CompleteUserDriving(httpSessionID, result); err != nil {
+			logger.Error(err, "failed to complete HTTP session",
+				"action", action, "rr_id", rrID, "http_session_id", httpSessionID)
+		}
+	} else if err := completer.ForceCompleteByRemediationID(rrID, result); err != nil {
+		logger.V(1).Info("no HTTP session found to force-complete",
+			"action", action, "rr_id", rrID, "error", err)
+	}
+}

--- a/internal/kubernautagent/session/manager.go
+++ b/internal/kubernautagent/session/manager.go
@@ -507,9 +507,11 @@ func (m *Manager) GetLatestRCASummaryByRemediationID(rrID string) (string, bool)
 }
 
 // GetLatestRCAResultByRemediationID returns the full InvestigationResult from
-// the most recent completed session for the given remediation_id. This gives
-// workflow discovery access to the complete RemediationTarget produced by the
-// autonomous Phase 1 RCA, avoiding a lossy re-extraction from conversation.
+// the most recent completed (non-cancelled) session for the given remediation_id.
+// This gives workflow discovery access to the complete RemediationTarget produced
+// by the autonomous Phase 1 RCA, avoiding a lossy re-extraction from conversation.
+// Cancelled sessions are excluded because their partial results may be stale or
+// incomplete (KA-HIGH-5).
 func (m *Manager) GetLatestRCAResultByRemediationID(rrID string) (*katypes.InvestigationResult, bool) {
 	m.store.mu.RLock()
 	defer m.store.mu.RUnlock()
@@ -520,6 +522,9 @@ func (m *Manager) GetLatestRCAResultByRemediationID(rrID string) (*katypes.Inves
 			continue
 		}
 		if sess.Result == nil {
+			continue
+		}
+		if sess.Status == StatusCancelled {
 			continue
 		}
 		if sess.CreatedAt.After(latestTime) {

--- a/internal/kubernautagent/session/store.go
+++ b/internal/kubernautagent/session/store.go
@@ -249,13 +249,16 @@ func (s *Store) Update(id string, status Status, result *katypes.InvestigationRe
 // SetResult attaches a result to an existing session without changing its
 // status. Used to persist partial investigation state on cancelled sessions
 // where Store.Update would reject the status transition (BR-SESSION-002).
-// Skips if the session already has a result set by CompleteUserDriving to
-// prevent a race where the cancelled investigation goroutine overwrites the
-// user-provided result with nil.
+// Skips if the session is in StatusUserDriving (owned by the interactive driver)
+// or already completed with a result to prevent a race where the cancelled
+// investigation goroutine overwrites the user-provided result.
 func (s *Store) SetResult(id string, result *katypes.InvestigationResult) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if sess, ok := s.sessions[id]; ok {
+		if sess.Status == StatusUserDriving {
+			return
+		}
 		if sess.Status == StatusCompleted && sess.Result != nil {
 			return
 		}

--- a/internal/kubernautagent/session/wiring_1351_test.go
+++ b/internal/kubernautagent/session/wiring_1351_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session_test
+
+// IT-KA-1351-STORE: Proves SetResult + GetLatestRCA wiring through Manager
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+var _ = Describe("IT-KA-1351: Session wiring for user_driving guards", func() {
+
+	Describe("IT-KA-1351-STORE: SetResult + Manager user_driving guard (KA-HIGH-4)", func() {
+		It("rejects SetResult writes when session is StatusUserDriving", func() {
+			store := session.NewStore(1 * time.Hour)
+			mgr := session.NewManager(store, logr.Discard(), nil, nil)
+
+			id, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}, map[string]string{"remediation_id": "rr-guard-001"})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = mgr.TransitionToUserDriving(id, "alice", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			store.SetResult(id, &katypes.InvestigationResult{RCASummary: "stale"})
+
+			sess, err := store.Get(id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sess.Result).To(BeNil(),
+				"SetResult must not write when session is StatusUserDriving (KA-HIGH-4)")
+		})
+	})
+
+	Describe("IT-KA-1351-RCA: GetLatestRCAResultByRemediationID via Manager (KA-HIGH-5)", func() {
+		It("returns completed RCA and excludes cancelled sessions", func() {
+			store := session.NewStore(1 * time.Hour)
+			mgr := session.NewManager(store, logr.Discard(), nil, nil)
+
+			id1, err := store.Create()
+			Expect(err).NotTo(HaveOccurred())
+			store.SetMetadata(id1, map[string]string{"remediation_id": "rr-filter-001"})
+			goodResult := &katypes.InvestigationResult{RCASummary: "good RCA"}
+			store.SetResult(id1, goodResult)
+			Expect(store.Update(id1, session.StatusCompleted, goodResult, nil)).To(Succeed())
+
+			id2, err := store.Create()
+			Expect(err).NotTo(HaveOccurred())
+			store.SetMetadata(id2, map[string]string{"remediation_id": "rr-filter-001"})
+			staleResult := &katypes.InvestigationResult{RCASummary: "stale from cancelled"}
+			store.SetResult(id2, staleResult)
+			Expect(store.Update(id2, session.StatusCancelled, staleResult, nil)).To(Succeed())
+
+			result, found := mgr.GetLatestRCAResultByRemediationID("rr-filter-001")
+			Expect(found).To(BeTrue())
+			Expect(result.RCASummary).To(Equal("good RCA"),
+				"GetLatestRCAResultByRemediationID must filter cancelled sessions (KA-HIGH-5)")
+		})
+	})
+})

--- a/pkg/aianalysis/handlers/investigating.go
+++ b/pkg/aianalysis/handlers/investigating.go
@@ -571,6 +571,30 @@ func (h *InvestigatingHandler) handleSessionPoll(ctx context.Context, analysis *
 func (h *InvestigatingHandler) handleSessionPollUserDriving(ctx context.Context, analysis *aianalysisv1.AIAnalysis, status *agentclient.SessionStatusResult) (ctrl.Result, error) {
 	session := analysis.Status.KASession
 
+	// AA-CRIT-1: user_driving must NOT bypass MaxInvestigationDuration.
+	// A malicious or stalled interactive session cannot hold the pipeline indefinitely.
+	if session.CreatedAt != nil {
+		elapsed := time.Since(session.CreatedAt.Time)
+		if elapsed > h.maxInvestigationDuration {
+			h.log.Info("Interactive session exceeded max duration, failing",
+				"sessionID", session.ID,
+				"elapsed", elapsed,
+				"maxDuration", h.maxInvestigationDuration,
+			)
+			now := metav1.Now()
+			analysis.Status.Phase = aianalysis.PhaseFailed
+			analysis.Status.ObservedGeneration = analysis.Generation
+			analysis.Status.CompletedAt = &now
+			analysis.Status.Reason = aianalysisv1.ReasonTransientError
+			analysis.Status.SubReason = "TransientError"
+			analysis.Status.Message = fmt.Sprintf(
+				"Interactive investigation timed out after %s (limit: %s)",
+				elapsed.Truncate(time.Second), h.maxInvestigationDuration,
+			)
+			return ctrl.Result{}, nil
+		}
+	}
+
 	session.PollCount++
 	now := metav1.Now()
 	session.LastPolled = &now

--- a/pkg/aianalysis/handlers/investigating.go
+++ b/pkg/aianalysis/handlers/investigating.go
@@ -545,6 +545,10 @@ func (h *InvestigatingHandler) handleSessionPoll(ctx context.Context, analysis *
 		return h.handleSessionPollError(ctx, analysis, err)
 	}
 
+	// AA-CRIT-2: Reset consecutive failure counter on successful poll to prevent
+	// transient errors from accumulating across successful intervals.
+	analysis.Status.ConsecutiveFailures = 0
+
 	switch status.Status {
 	case "pending", "investigating":
 		return h.handleSessionPollPending(ctx, analysis, status)
@@ -729,6 +733,7 @@ func (h *InvestigatingHandler) handleSessionIncidentResult(ctx context.Context, 
 
 // handleSessionPollFailed handles poll results where investigation has failed on KA side.
 // BR-AA-HAPI-064: Surface KA-side failure to operators via CRD status
+// AA-MED-1: Ensure Reason and SubReason are set for structured failure reporting.
 func (h *InvestigatingHandler) handleSessionPollFailed(ctx context.Context, analysis *aianalysisv1.AIAnalysis, status *agentclient.SessionStatusResult) (ctrl.Result, error) {
 	h.log.Info("KA session failed",
 		"sessionID", analysis.Status.KASession.ID,
@@ -737,6 +742,8 @@ func (h *InvestigatingHandler) handleSessionPollFailed(ctx context.Context, anal
 
 	now := metav1.Now()
 	analysis.Status.Phase = aianalysis.PhaseFailed
+	analysis.Status.Reason = aianalysisv1.ReasonAPIError
+	analysis.Status.SubReason = "InvestigationFailed"
 	analysis.Status.CompletedAt = &now
 	analysis.Status.ObservedGeneration = analysis.Generation
 	analysis.Status.Message = status.Error
@@ -771,12 +778,17 @@ func (h *InvestigatingHandler) handleSessionPollCancelled(ctx context.Context, a
 	if h.isChecker != nil {
 		rrName := analysis.Spec.RemediationRequestRef.Name
 		if rrName != "" {
-			if hasIS, checkErr := h.isChecker.HasActiveSession(ctx, rrName); checkErr != nil {
-				h.log.Error(checkErr, "Failed to check IS existence during cancellation, treating as terminal")
-			} else if hasIS {
+			hasIS, checkErr := h.isChecker.HasActiveSession(ctx, rrName)
+			if checkErr != nil {
+				// AA-HIGH-2: Transient API error must not cause premature terminal state.
+				// Requeue to retry the IS check instead of assuming cancellation.
+				h.log.Error(checkErr, "Failed to check IS existence during cancellation, requeuing",
+					"rrName", rrName)
+				return ctrl.Result{RequeueAfter: h.sessionPollInterval}, nil
+			}
+			if hasIS {
 				h.log.Info("IS CRD still active after cancellation — re-submitting with interactive=true (takeover)",
 					"rrName", rrName)
-				// Clear the old session ID to trigger a fresh submit on next reconcile.
 				analysis.Status.KASession.ID = ""
 				return ctrl.Result{Requeue: true}, nil
 			}
@@ -879,18 +891,26 @@ func (h *InvestigatingHandler) handleSessionLost(ctx context.Context, analysis *
 
 // handleSessionGetResultError handles errors when fetching the session result.
 // BR-AA-HAPI-064: 409 Conflict treated as transient (re-poll gracefully at standard interval)
+// AA-HIGH-1: 404 triggers session regeneration (same as poll 404)
 func (h *InvestigatingHandler) handleSessionGetResultError(ctx context.Context, analysis *aianalysisv1.AIAnalysis, err error) (ctrl.Result, error) {
-	// Check for 409 Conflict - treat as transient, re-poll at standard interval
 	var apiErr *agentclient.APIError
-	if errors.As(err, &apiErr) && apiErr.StatusCode == 409 {
-		h.log.Info("GetSessionResult returned 409 Conflict, treating as transient",
-			"sessionID", analysis.Status.KASession.ID,
-		)
-		session := analysis.Status.KASession
-		now := metav1.Now()
-		session.LastPolled = &now
-		session.PollCount++
-		return ctrl.Result{RequeueAfter: h.sessionPollInterval}, nil
+	if errors.As(err, &apiErr) {
+		switch apiErr.StatusCode {
+		case 404:
+			h.log.Info("GetSessionResult returned 404, triggering session regeneration",
+				"sessionID", analysis.Status.KASession.ID,
+			)
+			return h.handleSessionLost(ctx, analysis)
+		case 409:
+			h.log.Info("GetSessionResult returned 409 Conflict, treating as transient",
+				"sessionID", analysis.Status.KASession.ID,
+			)
+			session := analysis.Status.KASession
+			now := metav1.Now()
+			session.LastPolled = &now
+			session.PollCount++
+			return ctrl.Result{RequeueAfter: h.sessionPollInterval}, nil
+		}
 	}
 
 	// For other errors, use standard error classification

--- a/pkg/aianalysis/investigation_timeout_test.go
+++ b/pkg/aianalysis/investigation_timeout_test.go
@@ -18,6 +18,7 @@ package aianalysis_test
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -31,6 +32,7 @@ import (
 	"github.com/jordigilh/kubernaut/internal/controller/aianalysis"
 	"github.com/jordigilh/kubernaut/pkg/aianalysis/handlers"
 	"github.com/jordigilh/kubernaut/pkg/aianalysis/metrics"
+	"github.com/jordigilh/kubernaut/pkg/agentclient"
 	"github.com/jordigilh/kubernaut/test/shared/mocks"
 )
 
@@ -204,6 +206,69 @@ var _ = Describe("AA-Side Investigation Timeout — #1078", func() {
 				"user_driving within time limit must continue polling")
 			Expect(result.RequeueAfter).To(BeNumerically(">", 0),
 				"should requeue for next poll")
+		})
+	})
+
+	Describe("UT-AA-1351-004: GetSessionResult 404 triggers session regeneration (AA-HIGH-1)", func() {
+		It("should increment generation and clear session ID like poll 404", func() {
+			analysis := createTimeoutTestAnalysis(time.Now().Add(-5 * time.Minute))
+			mockClient.WithSessionPollStatus("completed")
+			mockClient.WithSessionResultError(&agentclient.APIError{StatusCode: 404, Message: "Session not found"})
+
+			result, err := handler.Handle(ctx, analysis)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(analysis.Status.KASession.Generation).To(Equal(int32(1)),
+				"GetSessionResult 404 must trigger handleSessionLost regeneration (AA-HIGH-1)")
+			Expect(analysis.Status.KASession.ID).To(BeEmpty(), "session ID should be cleared for re-submit")
+			Expect(result.Requeue).To(BeTrue(), "should requeue immediately for re-submit")
+			Expect(analysis.Status.Phase).To(Equal(aianalysis.PhaseInvestigating),
+				"should not use handleError terminal path on result 404")
+		})
+	})
+
+	Describe("UT-AA-1351-005: handleSessionPollCancelled requeues on IS check error (AA-HIGH-2)", func() {
+		It("should requeue at poll interval when IS existence check fails", func() {
+			isChecker := &mockISChecker{err: fmt.Errorf("apiserver unavailable")}
+			isHandler := handlers.NewInvestigatingHandler(
+				mockClient, ctrl.Log.WithName("test-cancel-is-err"), metrics.NewMetrics(), &noopAuditClient{},
+				handlers.WithSessionMode(),
+				handlers.WithRecorder(recorder),
+				handlers.WithInvestigationSessionChecker(isChecker),
+			)
+
+			analysis := createTimeoutTestAnalysis(time.Now().Add(-5 * time.Minute))
+			mockClient.WithSessionPollStatus("cancelled")
+
+			result, err := isHandler.Handle(ctx, analysis)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(analysis.Status.Phase).To(Equal(aianalysis.PhaseInvestigating),
+				"transient IS check error must not cause premature terminal state (AA-HIGH-2)")
+			Expect(result.RequeueAfter).To(Equal(handlers.DefaultSessionPollInterval),
+				"should requeue to retry IS check instead of failing")
+		})
+	})
+
+	Describe("UT-AA-1351-008: handleSessionPollFailed sets Reason and SubReason (AA-MED-1)", func() {
+		It("should set structured failure fields when KA session poll returns failed", func() {
+			analysis := createTimeoutTestAnalysis(time.Now().Add(-5 * time.Minute))
+			mockClient.PollSessionFunc = func(ctx context.Context, sessionID string) (*agentclient.SessionStatusResult, error) {
+				return &agentclient.SessionStatusResult{
+					Status: "failed",
+					Error:  "LLM provider error: rate limit exceeded",
+				}, nil
+			}
+
+			result, err := handler.Handle(ctx, analysis)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(analysis.Status.Phase).To(Equal(aianalysis.PhaseFailed))
+			Expect(analysis.Status.Reason).To(Equal(aianalysisv1.ReasonAPIError))
+			Expect(analysis.Status.SubReason).To(Equal("InvestigationFailed"))
+			Expect(analysis.Status.Message).To(ContainSubstring("rate limit"))
+			Expect(analysis.Status.CompletedAt).NotTo(BeNil())
+			Expect(result.RequeueAfter).To(BeZero(), "terminal failure should not requeue for polling")
 		})
 	})
 })

--- a/pkg/aianalysis/investigation_timeout_test.go
+++ b/pkg/aianalysis/investigation_timeout_test.go
@@ -160,4 +160,36 @@ var _ = Describe("AA-Side Investigation Timeout — #1078", func() {
 				"default 25-minute timeout must apply when WithMaxInvestigationDuration is not set")
 		})
 	})
+
+	Describe("UT-AA-1351-TOUT-005: user_driving respects MaxInvestigationDuration (AA-CRIT-1)", func() {
+		It("should transition to PhaseFailed when user_driving exceeds MaxInvestigationDuration", func() {
+			// Session created 30 minutes ago (exceeds 25 minute limit)
+			analysis := createTimeoutTestAnalysis(time.Now().Add(-30 * time.Minute))
+			mockClient.WithSessionPollStatus("user_driving")
+
+			result, err := handler.Handle(ctx, analysis)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(analysis.Status.Phase).To(Equal(aianalysis.PhaseFailed),
+				"user_driving sessions must NOT bypass MaxInvestigationDuration (AA-CRIT-1)")
+			Expect(analysis.Status.Message).To(ContainSubstring("timed out"),
+				"timeout message must explain the failure reason")
+			Expect(result.RequeueAfter).To(BeZero(),
+				"timed-out analysis should not requeue for polling")
+		})
+
+		It("should continue polling user_driving within time limit", func() {
+			// Session created 10 minutes ago (within 25 minute limit)
+			analysis := createTimeoutTestAnalysis(time.Now().Add(-10 * time.Minute))
+			mockClient.WithSessionPollStatus("user_driving")
+
+			result, err := handler.Handle(ctx, analysis)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(analysis.Status.Phase).To(Equal(aianalysis.PhaseInvestigating),
+				"user_driving within time limit must continue polling")
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0),
+				"should requeue for next poll")
+		})
+	})
 })

--- a/pkg/aianalysis/investigation_timeout_test.go
+++ b/pkg/aianalysis/investigation_timeout_test.go
@@ -161,6 +161,20 @@ var _ = Describe("AA-Side Investigation Timeout — #1078", func() {
 		})
 	})
 
+	Describe("UT-AA-1351-TOUT-006: successful poll resets ConsecutiveFailures (AA-CRIT-2)", func() {
+		It("should reset ConsecutiveFailures to 0 on successful poll", func() {
+			analysis := createTimeoutTestAnalysis(time.Now().Add(-5 * time.Minute))
+			analysis.Status.ConsecutiveFailures = 3
+			mockClient.WithSessionPollStatus("investigating")
+
+			_, err := handler.Handle(ctx, analysis)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(analysis.Status.ConsecutiveFailures).To(Equal(int32(0)),
+				"successful poll must reset ConsecutiveFailures to prevent transient error accumulation (AA-CRIT-2)")
+		})
+	})
+
 	Describe("UT-AA-1351-TOUT-005: user_driving respects MaxInvestigationDuration (AA-CRIT-1)", func() {
 		It("should transition to PhaseFailed when user_driving exceeds MaxInvestigationDuration", func() {
 			// Session created 30 minutes ago (exceeds 25 minute limit)

--- a/pkg/apifrontend/ka/mcp_sdk_client.go
+++ b/pkg/apifrontend/ka/mcp_sdk_client.go
@@ -308,7 +308,7 @@ func (c *SDKMCPClient) StartInvestigation(ctx context.Context, args StartInvesti
 		"acting_user_groups": identity.Groups,
 	}
 
-	callCtx, callCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	callCtx, callCancel := context.WithTimeout(ctx, 30*time.Second)
 	defer callCancel()
 	result, err := session.CallTool(callCtx, &mcp.CallToolParams{
 		Name:      "kubernaut_investigate",

--- a/pkg/apifrontend/ka/session_pool_test.go
+++ b/pkg/apifrontend/ka/session_pool_test.go
@@ -468,3 +468,25 @@ var _ = Describe("KASessionPool (G2 + G9: Pool + User Isolation)", func() {
 		})
 	})
 })
+
+var _ = Describe("IT-AF-1351: KASessionPool EvictIdle wiring", func() {
+
+	It("IT-AF-1351-EVICT: EvictIdle removes entries older than IdleTTL", func() {
+		pool := ka.NewKASessionPool(ka.PoolConfig{
+			Factory: func(ctx context.Context) (ka.PoolSession, error) {
+				return &mockPoolSession{}, nil
+			},
+			MaxEntries: 10,
+			IdleTTL:    50 * time.Millisecond,
+			Logger:     logr.Discard(),
+		})
+
+		pool.Inject("rr-1", "user-1", &mockPoolSession{})
+
+		time.Sleep(100 * time.Millisecond)
+
+		evicted := pool.EvictIdle()
+		Expect(evicted).To(Equal(1), "EvictIdle must remove entries older than IdleTTL (AF-HIGH-2)")
+		Expect(pool.Size()).To(Equal(0))
+	})
+})

--- a/pkg/apifrontend/security/redact.go
+++ b/pkg/apifrontend/security/redact.go
@@ -14,6 +14,7 @@ var sensitiveKeys = []string{
 var (
 	urlPattern  = regexp.MustCompile(`[a-zA-Z][a-zA-Z0-9+.-]*://[^\s"']+`)
 	pathPattern = regexp.MustCompile(`(/[a-zA-Z0-9._-]+){2,}`)
+	ipv4Pattern = regexp.MustCompile(`\b(?:\d{1,3}\.){3}\d{1,3}(?::\d{1,5})?\b`)
 
 	// Value patterns for detecting secrets embedded in arbitrary values.
 	jwtPattern    = regexp.MustCompile(`eyJ[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}\.[A-Za-z0-9_-]{20,}`)
@@ -49,6 +50,7 @@ func RedactError(err error) string {
 	}
 	msg := err.Error()
 	msg = urlPattern.ReplaceAllString(msg, "[URL_REDACTED]")
+	msg = ipv4Pattern.ReplaceAllString(msg, "[HOST_REDACTED]")
 	msg = pathPattern.ReplaceAllString(msg, "[PATH_REDACTED]")
 	msg = jwtPattern.ReplaceAllString(msg, "[JWT_REDACTED]")
 	msg = bearerPattern.ReplaceAllString(msg, "[BEARER_REDACTED]")

--- a/pkg/apifrontend/tools/ka_investigate_mcp.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp.go
@@ -36,7 +36,9 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/security"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/severity"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/validate"
 )
 
 // isPhaseActivePollTimeout caps the IS phase Active polling after AIA readiness.
@@ -126,6 +128,12 @@ func HandleInvestigationMCPWithRegistry(ctx context.Context, mcpClient ka.MCPCli
 
 	if !hasRRID && !hasResourceArgs {
 		return InvestigateMCPResult{}, fmt.Errorf("rr_id or namespace/kind/name required")
+	}
+
+	if hasRRID {
+		if err := validate.RRID(args.RRID); err != nil {
+			return InvestigateMCPResult{}, fmt.Errorf("invalid rr_id: %w", err)
+		}
 	}
 
 	identity := auth.UserIdentityFromContext(ctx)
@@ -458,7 +466,7 @@ func FormatEventForUser(evt ka.InvestigationEvent) string {
 	case ka.EventTypeError:
 		errMsg := extractJSONField(evt.Data, "error")
 		if errMsg != "" {
-			return "Error: " + errMsg
+			return "Error: " + security.RedactError(fmt.Errorf("%s", errMsg))
 		}
 		return "Investigation error occurred"
 	case ka.EventTypeComplete:

--- a/pkg/apifrontend/tools/ka_investigate_mcp_test.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp_test.go
@@ -236,6 +236,20 @@ var _ = Describe("formatEventForUser — #1326 BR-MCP-008 event filtering", func
 		})
 	})
 
+	Describe("UT-AF-1351-021: FormatEventForUser applies RedactError on error events (AF-HIGH-4)", func() {
+		It("should redact internal error details before returning to user", func() {
+			evt := ka.InvestigationEvent{
+				Type: ka.EventTypeError,
+				Data: json.RawMessage(`{"error": "connection refused: dial tcp 10.0.0.1:8080: connect: connection refused"}`),
+			}
+			text := tools.FormatEventForUser(evt)
+			Expect(text).NotTo(ContainSubstring("10.0.0.1"),
+				"Internal IP addresses must be redacted from user-facing error events (AF-HIGH-4)")
+			Expect(text).To(HavePrefix("Error: "),
+				"Error events should still have the Error: prefix")
+		})
+	})
+
 	Describe("UT-AF-1326-043: complete events produce terminal text", func() {
 		It("should return 'Investigation complete.'", func() {
 			evt := ka.InvestigationEvent{

--- a/pkg/apifrontend/tools/ka_tools.go
+++ b/pkg/apifrontend/tools/ka_tools.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/audit"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/validate"
 )
 
 // WorkflowParameter describes a single input parameter for a workflow.
@@ -50,6 +51,11 @@ type DiscoverWorkflowsResult struct {
 //
 //nolint:gocritic // hugeParam: args passed by value for simplicity
 func HandleDiscoverWorkflows(ctx context.Context, mcpClient ka.MCPClient, args DiscoverWorkflowsArgs) (DiscoverWorkflowsResult, error) {
+	if args.RRID != "" {
+		if err := validate.RRID(args.RRID); err != nil {
+			return DiscoverWorkflowsResult{}, fmt.Errorf("invalid rr_id: %w", err)
+		}
+	}
 	if mcpClient == nil {
 		return DiscoverWorkflowsResult{}, fmt.Errorf("workflow discovery is not available: MCP client not configured")
 	}
@@ -203,6 +209,9 @@ type SelectWorkflowResult struct {
 //
 //nolint:gocritic // hugeParam: args passed by value for simplicity; not performance-critical
 func HandleSelectWorkflow(ctx context.Context, mcpClient ka.MCPClient, args SelectWorkflowArgs, auditor audit.Emitter) (SelectWorkflowResult, error) {
+	if err := validate.RRID(args.RRID); err != nil {
+		return SelectWorkflowResult{}, fmt.Errorf("invalid rr_id: %w", err)
+	}
 	if mcpClient == nil {
 		return SelectWorkflowResult{}, fmt.Errorf("workflow selection is not available: MCP client not configured")
 	}

--- a/pkg/apifrontend/tools/redaction_wiring_test.go
+++ b/pkg/apifrontend/tools/redaction_wiring_test.go
@@ -1,0 +1,32 @@
+package tools_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+)
+
+var _ = Describe("IT-AF-1351: Error redaction wiring", func() {
+
+	It("IT-AF-1351-REDACT: FormatEventForUser redacts IPs from error events end-to-end", func() {
+		evt := ka.InvestigationEvent{
+			Type: ka.EventTypeError,
+			Data: []byte(`{"error": "dial tcp 192.168.1.100:6443: connect: connection refused"}`),
+		}
+		text := tools.FormatEventForUser(evt)
+		Expect(text).NotTo(ContainSubstring("192.168.1.100"))
+		Expect(text).To(HavePrefix("Error: "))
+	})
+
+	It("IT-AF-1351-REDACT-URL: FormatEventForUser redacts URLs from error events", func() {
+		evt := ka.InvestigationEvent{
+			Type: ka.EventTypeError,
+			Data: []byte(`{"error": "POST https://internal-ka.svc:8443/api/investigate failed: timeout"}`),
+		}
+		text := tools.FormatEventForUser(evt)
+		Expect(text).NotTo(ContainSubstring("https://"))
+		Expect(text).NotTo(ContainSubstring("internal-ka.svc"))
+	})
+})

--- a/pkg/apifrontend/tools/validation_test.go
+++ b/pkg/apifrontend/tools/validation_test.go
@@ -1,0 +1,68 @@
+package tools_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+)
+
+var _ = Describe("#1351 AF Input Validation", func() {
+
+	Describe("UT-AF-1351-030: HandleDiscoverWorkflows validates rr_id format (AF-MED-2)", func() {
+		It("should reject rr_id with invalid characters", func() {
+			mockMCP := &ka.MockMCPClient{}
+			_, err := tools.HandleDiscoverWorkflows(context.Background(), mockMCP, tools.DiscoverWorkflowsArgs{
+				RRID: "../../etc/passwd",
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid rr_id"))
+		})
+	})
+
+	Describe("UT-AF-1351-031: HandleSelectWorkflow validates rr_id format (AF-MED-2)", func() {
+		It("should reject rr_id with invalid characters", func() {
+			mockMCP := &ka.MockMCPClient{}
+			_, err := tools.HandleSelectWorkflow(context.Background(), mockMCP, tools.SelectWorkflowArgs{
+				RRID:       "drop table; --",
+				WorkflowID: "wf-1",
+			}, nil)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid rr_id"))
+		})
+	})
+
+	Describe("UT-AF-1351-032: HandleInvestigateMCP validates rr_id format (AF-MED-2)", func() {
+		It("should reject rr_id with invalid characters", func() {
+			mockMCP := &ka.MockMCPClient{}
+			_, err := tools.HandleInvestigationMCPWithRegistry(
+				context.Background(), mockMCP, nil, "ns",
+				tools.InvestigateMCPArgs{RRID: "../../etc/passwd"},
+				nil, nil, nil, false, nil, "", nil, nil,
+			)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid rr_id"))
+		})
+
+		It("should accept valid namespace/name format", func() {
+			mockMCP := &ka.MockMCPClient{
+				StartInvestigationFn: func(ctx context.Context, args ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+					return &ka.StartInvestigationResult{SessionID: "sess-1", Status: "investigating"}, nil
+				},
+			}
+			// Valid rr_id should pass validation (may fail later for other reasons)
+			_, err := tools.HandleInvestigationMCPWithRegistry(
+				context.Background(), mockMCP, nil, "default",
+				tools.InvestigateMCPArgs{RRID: "prod/my-rr-001"},
+				nil, nil, nil, false, nil, "user1", nil, nil,
+			)
+			// Should not fail with validation error
+			if err != nil {
+				Expect(err.Error()).NotTo(ContainSubstring("invalid rr_id"))
+			}
+		})
+	})
+})

--- a/pkg/apifrontend/validate/k8s.go
+++ b/pkg/apifrontend/validate/k8s.go
@@ -35,6 +35,25 @@ func ResourceName(name string) error {
 	return nil
 }
 
+// RRID validates a Remediation Request ID, which may be in namespace/name format
+// or just a plain resource name. Both parts must be valid Kubernetes identifiers.
+func RRID(rrid string) error {
+	if rrid == "" {
+		return fmt.Errorf("rr_id must not be empty")
+	}
+	parts := strings.SplitN(rrid, "/", 2)
+	if len(parts) == 2 {
+		if err := Namespace(parts[0]); err != nil {
+			return fmt.Errorf("invalid rr_id namespace: %w", err)
+		}
+		if err := ResourceName(parts[1]); err != nil {
+			return fmt.Errorf("invalid rr_id name: %w", err)
+		}
+		return nil
+	}
+	return ResourceName(rrid)
+}
+
 // Kind validates that k is a valid Kubernetes resource kind (PascalCase identifier, ASCII alphanumeric only).
 func Kind(k string) error {
 	if k == "" {

--- a/pkg/apifrontend/validate/k8s_test.go
+++ b/pkg/apifrontend/validate/k8s_test.go
@@ -101,3 +101,31 @@ var _ = Describe("LabelValue", func() {
 		Entry("unicode", "日本語", "invalid label value"),
 	)
 })
+
+var _ = Describe("IT-AF-1351: RRID validation wiring", func() {
+
+	Describe("IT-AF-1351-VALID: valid namespace/name formats accepted", func() {
+		DescribeTable("accepts valid rr_id values",
+			func(rrid string) {
+				Expect(validate.RRID(rrid)).To(Succeed())
+			},
+			Entry("simple name", "my-rr-001"),
+			Entry("namespace/name", "prod/my-rr-001"),
+			Entry("long valid name", "my-namespace/my-long-remediation-request-name-123"),
+		)
+	})
+
+	Describe("IT-AF-1351-INVALID: invalid formats rejected", func() {
+		DescribeTable("rejects invalid rr_id values",
+			func(rrid string) {
+				Expect(validate.RRID(rrid)).NotTo(Succeed())
+			},
+			Entry("path traversal", "../../etc/passwd"),
+			Entry("SQL injection", "drop table; --"),
+			Entry("empty", ""),
+			Entry("spaces", "my namespace/my name"),
+			Entry("too many slashes", "a/b/c"),
+			Entry("uppercase not DNS", "MyNamespace/MyRR"),
+		)
+	})
+})

--- a/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
@@ -1116,10 +1116,11 @@ spec:
                 - MaxRetriesExceeded
                 - SessionRegenerationExceeded
                 - RcaIncomplete
+                - InvestigationFailed
                 type: string
               totalAnalysisTime:
                 description: TotalAnalysisTime is the total duration of the analysis
-                  in seconds
+                  in milliseconds
                 format: int64
                 minimum: 0
                 type: integer

--- a/pkg/shared/assets/crds/kubernaut.ai_investigationsessions.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_investigationsessions.yaml
@@ -79,9 +79,13 @@ spec:
                 properties:
                   name:
                     description: Name of the referenced object.
+                    maxLength: 253
+                    minLength: 1
                     type: string
                   namespace:
                     description: Namespace of the referenced object.
+                    maxLength: 63
+                    minLength: 1
                     type: string
                 required:
                 - name
@@ -95,9 +99,12 @@ spec:
                     description: Groups from JWT groups claim (RBAC-relevant only).
                     items:
                       type: string
+                    maxItems: 64
                     type: array
                   username:
                     description: Username from JWT sub claim.
+                    maxLength: 253
+                    minLength: 1
                     type: string
                 required:
                 - username

--- a/pkg/shared/assets/crds/kubernaut.ai_remediationapprovalrequests.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_remediationapprovalrequests.yaml
@@ -349,6 +349,13 @@ spec:
               decidedBy:
                 description: Who made the decision (username or "system" for timeout)
                 type: string
+              decidedVia:
+                description: |-
+                  Who facilitated the decision (trusted intermediary SA identity).
+                  Empty for direct decisions (kubectl, CLI). Set by webhook when a trusted
+                  intermediary (AF SA) delegates approval on behalf of a human user.
+                  Operational visibility field — DS audit trail is authoritative.
+                type: string
               decision:
                 description: |-
                   Decision made by operator or system (timeout)


### PR DESCRIPTION
## Summary

Fixes 49 validated latent bugs across KA, AA, and AF services in the interactive workflow selection pipeline, ensuring GA readiness. Key fixes:

- **KA Session Lifecycle**: Timeout/disconnect handlers now properly resolve HTTP sessions, preventing AA controller from polling indefinitely (KA-CRIT-2)
- **KA Concurrency**: Session mutex re-acquired in async goroutines to prevent race conditions during workflow selection teardown (KA-HIGH-3, KA-HIGH-4, KA-HIGH-5)
- **KA Phase 3**: `ExecutionBundleDigest` now propagated in `buildFinalResult` (KA-MED-1)
- **AA Timeout Handling**: `ConsecutiveFailures` reset on successful poll; 404 on GetSessionResult triggers regeneration; requeue on transient IS check errors (AA-CRIT-2, AA-HIGH-1, AA-HIGH-2)
- **AA CRD Schema**: Added `InvestigationFailed` to SubReason validation enum (AA-MED-1)
- **AF Security**: IPv4 address redaction in user-facing error messages (AF-HIGH-4); RRID input validation with namespace/name support (AF-MED-2)
- **AF Resource Management**: HTTP client timeout from config; EvictIdle goroutine for KASessionPool with graceful shutdown (AF-HIGH-1, AF-HIGH-2)
- **AF Context Propagation**: StartInvestigation callCtx derived from request context for cancellation support (AF-HIGH-5)

Includes Pyramid Invariant compliance tests (UT + IT) proving both logic and wiring for all fixes.

## Commits

1. `fix(ka,aa,af): resolve critical interactive pipeline GA bugs` — Core production fixes across all three services
2. `fix(ka,aa,af): resolve remaining GA readiness bugs` — Additional fixes identified in comprehensive bug hunt
3. `fix(af): add IPv4 address redaction to error sanitization` — Security hardening for user-facing errors
4. `fix(aa): add InvestigationFailed to SubReason CRD validation enum` — CRD schema fix unblocking AA status transitions
5. `test(ka,aa,af): add Pyramid Invariant compliance tests` — UT and IT proving logic + wiring

## Test plan

- [x] `make test-unit-kubernautagent` — 95/95 PASS (81.6% coverage)
- [x] `make test-integration-kubernautagent` — 2/2 PASS
- [x] `make test-integration-aianalysis` — 71/71 PASS (64.4% coverage)
- [x] `make test-integration-apifrontend` — 130/130 PASS (35.9% coverage)
- [x] `go build ./...` — clean build, no errors
- [ ] E2E tests (require Kind cluster)

Closes #1351

Made with [Cursor](https://cursor.com)