### PR TITLE
fix(af): enforce decision enum via InputSchema on kubernaut_approve tool

### DIFF
--- a/pkg/apifrontend/handler/mcp_bridge_test.go
+++ b/pkg/apifrontend/handler/mcp_bridge_test.go
@@ -535,9 +535,9 @@ var _ = Describe("MCP Bridge - Tier 1: Core Dispatch", Label("tier1", "bridge"),
 
 		It("UT-AF-B-004: kubernaut_approve dispatches correctly", func() {
 			_, body := mcpCallTool(h, sessionID, "kubernaut_approve",
-				map[string]any{"rar_name": "test-rar", "decision": "approved"}, testUser)
+				map[string]any{"rar_name": "test-rar", "decision": "Approved"}, testUser)
 			text := extractTextContent(body)
-			Expect(text).To(ContainSubstring("approved"))
+			Expect(text).To(ContainSubstring("Approved"))
 		})
 
 		It("UT-AF-B-005: kubernaut_cancel_remediation dispatches correctly", func() {

--- a/pkg/apifrontend/tools/crd_tools.go
+++ b/pkg/apifrontend/tools/crd_tools.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/dynamic"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
 
@@ -484,8 +485,9 @@ func HandleApprove(ctx context.Context, client dynamic.Interface, args ApproveAr
 	if args.Decision == "" {
 		return ApproveResult{}, fmt.Errorf("%w: decision must not be empty", ErrInvalidInput)
 	}
-	// CRD enum requires capitalized values: Approved, Rejected, Expired
-	normalizedDecision := strings.ToUpper(args.Decision[:1]) + strings.ToLower(args.Decision[1:])
+	if args.Decision != "Approved" && args.Decision != "Rejected" {
+		return ApproveResult{}, fmt.Errorf("%w: decision %q is not valid; must be exactly one of: Approved, Rejected", ErrInvalidInput, args.Decision)
+	}
 	_, err := client.Resource(rarGVR).Namespace(args.Namespace).Get(ctx, args.RARName, metav1.GetOptions{})
 	if err != nil {
 		return ApproveResult{}, ToUserFriendlyError(err)
@@ -493,7 +495,7 @@ func HandleApprove(ctx context.Context, client dynamic.Interface, args ApproveAr
 
 	now := time.Now().UTC().Format(time.RFC3339)
 	statusPatch := map[string]interface{}{
-		"decision":  normalizedDecision,
+		"decision":  args.Decision,
 		"decidedBy": username,
 		"decidedAt": now,
 	}
@@ -532,11 +534,41 @@ func HandleApprove(ctx context.Context, client dynamic.Interface, args ApproveAr
 func NewApproveTool(client dynamic.Interface, controllerNS string) (tool.Tool, error) {
 	return functiontool.New(functiontool.Config{
 		Name:        "kubernaut_approve",
-		Description: "Approve or reject a pending remediation approval request",
+		Description: "Approve or reject a pending remediation approval request. The decision field accepts exactly 'Approved' or 'Rejected'.",
+		InputSchema: approveInputSchema(),
 	}, func(ctx tool.Context, args ApproveArgs) (ApproveResult, error) {
 		args.Namespace = controllerNS
 		return HandleApprove(ctx, client, args, usernameFromContext(ctx))
 	})
+}
+
+// approveInputSchema returns a JSON schema with an enum constraint on the
+// decision field, so the LLM sees the valid values directly in the tool definition.
+func approveInputSchema() *jsonschema.Schema {
+	return &jsonschema.Schema{
+		Type: "object",
+		Properties: map[string]*jsonschema.Schema{
+			"rar_name": {
+				Type:        "string",
+				Description: "Name of the RemediationApprovalRequest resource to approve or reject",
+			},
+			"decision": {
+				Type:        "string",
+				Description: "The approval decision",
+				Enum:        []any{"Approved", "Rejected"},
+			},
+			"reason": {
+				Type:        "string",
+				Description: "Optional reason for the decision",
+			},
+			"workflow_override": {
+				Type:        "string",
+				Description: "Optional workflow name to override the recommended workflow",
+			},
+		},
+		Required:      []string{"rar_name", "decision"},
+		PropertyOrder: []string{"rar_name", "decision", "reason", "workflow_override"},
+	}
 }
 
 // usernameFromContext extracts the authenticated username from tool context.

--- a/pkg/apifrontend/tools/kubernaut_approve_test.go
+++ b/pkg/apifrontend/tools/kubernaut_approve_test.go
@@ -150,4 +150,64 @@ var _ = Describe("kubernaut_approve", func() {
 		Expect(err).To(HaveOccurred())
 		Expect(err.Error()).To(ContainSubstring("invalid input"))
 	})
+
+	Context("strict decision enum validation (#1353)", func() {
+		It("UT-AF-1353-001: rejects verb form 'Approve' with actionable error", func() {
+			client := newDynamicFakeClient(newFakeRAR("payments", "rar-1"))
+			_, err := tools.HandleApprove(ctx, client, tools.ApproveArgs{
+				Namespace: "payments",
+				RARName:   "rar-1",
+				Decision:  "Approve",
+			}, "bob")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid input"))
+			Expect(err.Error()).To(ContainSubstring("Approved"))
+			Expect(err.Error()).To(ContainSubstring("Rejected"))
+		})
+
+		It("UT-AF-1353-002: rejects verb form 'Reject' with actionable error", func() {
+			client := newDynamicFakeClient(newFakeRAR("payments", "rar-1"))
+			_, err := tools.HandleApprove(ctx, client, tools.ApproveArgs{
+				Namespace: "payments",
+				RARName:   "rar-1",
+				Decision:  "Reject",
+			}, "bob")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid input"))
+			Expect(err.Error()).To(ContainSubstring("Approved"))
+		})
+
+		It("UT-AF-1353-003: rejects arbitrary string 'maybe'", func() {
+			client := newDynamicFakeClient(newFakeRAR("payments", "rar-1"))
+			_, err := tools.HandleApprove(ctx, client, tools.ApproveArgs{
+				Namespace: "payments",
+				RARName:   "rar-1",
+				Decision:  "maybe",
+			}, "bob")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid input"))
+		})
+
+		It("UT-AF-1353-004: accepts exact enum value 'Approved'", func() {
+			client := newDynamicFakeClient(newFakeRAR("payments", "rar-1"))
+			result, err := tools.HandleApprove(ctx, client, tools.ApproveArgs{
+				Namespace: "payments",
+				RARName:   "rar-1",
+				Decision:  "Approved",
+			}, "bob")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Status).To(Equal("Approved"))
+		})
+
+		It("UT-AF-1353-005: accepts exact enum value 'Rejected'", func() {
+			client := newDynamicFakeClient(newFakeRAR("payments", "rar-1"))
+			result, err := tools.HandleApprove(ctx, client, tools.ApproveArgs{
+				Namespace: "payments",
+				RARName:   "rar-1",
+				Decision:  "Rejected",
+			}, "bob")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Status).To(Equal("Rejected"))
+		})
+	})
 })

--- a/test/e2e/apifrontend/a2a_test.go
+++ b/test/e2e/apifrontend/a2a_test.go
@@ -297,7 +297,7 @@ var _ = Describe("A2A Handler (E2E)", Label("e2e", "a2a"), func() {
 			if err == nil && obsSID != "" {
 				body := buildJSONRPC("met04-rbac-deny", "tools/call", map[string]interface{}{
 					"name":      "kubernaut_approve",
-					"arguments": map[string]interface{}{"rar_name": "x", "decision": "approved"},
+					"arguments": map[string]interface{}{"rar_name": "x", "decision": "Approved"},
 				})
 				_, _, _ = mcpPOST(obsToken, obsSID, body)
 			}

--- a/test/e2e/apifrontend/mcp_fullpath_test.go
+++ b/test/e2e/apifrontend/mcp_fullpath_test.go
@@ -108,7 +108,7 @@ var _ = Describe("MCP Full-Path Validation (G1)", Label("e2e", "phase2", "g1"), 
 			"name": "kubernaut_approve",
 			"arguments": map[string]interface{}{
 				"rar_name":  rarName,
-				"decision":  "approved",
+				"decision":  "Approved",
 				"reason":    "MCP G1 full-path E2E",
 			},
 		})

--- a/test/e2e/apifrontend/rr_lifecycle_test.go
+++ b/test/e2e/apifrontend/rr_lifecycle_test.go
@@ -163,7 +163,7 @@ var _ = Describe("RAR Flow (G5)", Label("e2e", "phase2", "g5"), func() {
 			"name": "kubernaut_approve",
 			"arguments": map[string]interface{}{
 				"rar_name":  rarName,
-				"decision":  "approved",
+				"decision":  "Approved",
 				"reason":    "E2E G5 approval",
 			},
 		})
@@ -189,7 +189,7 @@ var _ = Describe("RAR Flow (G5)", Label("e2e", "phase2", "g5"), func() {
 			"name": "kubernaut_approve",
 			"arguments": map[string]interface{}{
 				"rar_name":  "e2e-rar-does-not-exist-xyz",
-				"decision":  "approved",
+				"decision":  "Approved",
 			},
 		})
 		raw, code, err := mcpPOST(tok, sid, body)
@@ -229,7 +229,7 @@ var _ = Describe("RAR Flow (G5)", Label("e2e", "phase2", "g5"), func() {
 			"name": "kubernaut_approve",
 			"arguments": map[string]interface{}{
 				"rar_name":  rarName,
-				"decision":  "approved",
+				"decision":  "Approved",
 			},
 		})
 		araw, acode, err := mcpPOST(sreTok, sreSession, apBody)

--- a/test/e2e/fullpipeline/05_mcp_interactive_lifecycle_test.go
+++ b/test/e2e/fullpipeline/05_mcp_interactive_lifecycle_test.go
@@ -454,17 +454,17 @@ var _ = Describe("FP-MCP-005: discover_workflows and select_workflow", Label("e2
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.IsError).To(BeFalse(), "takeover should succeed")
 
-		By("Calling discover_workflows (with retry — audit traces may lag autonomous completion)")
-		Eventually(func(g Gomega) {
-			discoverCtx, discoverCancel := context.WithTimeout(ctx, 15*time.Second)
-			defer discoverCancel()
-			result, err = infrastructure.CallInvestigate(discoverCtx, setup.Session, map[string]any{
-				"rr_id":  rrName,
-				"action": "discover_workflows",
-			})
-			g.Expect(err).NotTo(HaveOccurred())
-			g.Expect(result.IsError).To(BeFalse(), "discover_workflows should succeed")
-		}, 30*time.Second, 3*time.Second).Should(Succeed())
+	By("Calling discover_workflows (with retry — KA session may need time after takeover)")
+	Eventually(func(g Gomega) {
+		discoverCtx, discoverCancel := context.WithTimeout(ctx, 15*time.Second)
+		defer discoverCancel()
+		result, err = infrastructure.CallInvestigate(discoverCtx, setup.Session, map[string]any{
+			"rr_id":  rrName,
+			"action": "discover_workflows",
+		})
+		g.Expect(err).NotTo(HaveOccurred())
+		g.Expect(result.IsError).To(BeFalse(), "discover_workflows should succeed")
+	}, 60*time.Second, 5*time.Second).Should(Succeed())
 
 		text := infrastructure.ExtractToolResultText(result)
 		GinkgoWriter.Printf("  DiscoverWorkflows response (first 300 chars): %.300s\n", text)

--- a/test/e2e/workflowexecution/02_observability_test.go
+++ b/test/e2e/workflowexecution/02_observability_test.go
@@ -223,26 +223,27 @@ var _ = Describe("WorkflowExecution Observability E2E", func() {
 
 			GinkgoWriter.Println("✅ WFE completed, checking metrics...")
 
-			// Query metrics endpoint via NodePort
-			// Per DD-TEST-001: Metrics NodePort is 30185
-			metricsURL := fmt.Sprintf("http://127.0.0.1:%d/metrics", infrastructure.WorkflowExecutionMetricsHostPort)
+		// Query metrics endpoint via NodePort
+		// Per DD-TEST-001: Metrics NodePort is 30185
+		metricsURL := fmt.Sprintf("http://127.0.0.1:%d/metrics", infrastructure.WorkflowExecutionMetricsHostPort)
+		metricsClient := &http.Client{Timeout: 5 * time.Second}
 
-			// Business Behavior: Metrics should be scrapable by Prometheus
-			var metricsBody string
-			Eventually(func() error {
-				resp, err := http.Get(metricsURL)
-				if err != nil {
-					return err
-				}
-				defer func() { _ = resp.Body.Close() }()
+		// Business Behavior: Metrics should be scrapable by Prometheus
+		var metricsBody string
+		Eventually(func() error {
+			resp, err := metricsClient.Get(metricsURL)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = resp.Body.Close() }()
 
-				body, err := io.ReadAll(resp.Body)
-				if err != nil {
-					return err
-				}
-				metricsBody = string(body)
-				return nil
-			}, 30*time.Second).Should(Succeed(), "Should be able to scrape metrics endpoint")
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+			metricsBody = string(body)
+			return nil
+		}, 60*time.Second, 2*time.Second).Should(Succeed(), "Should be able to scrape metrics endpoint")
 
 			// Verify expected business metrics are present
 			// Using constants from pkg/workflowexecution/metrics to prevent typos (DRY principle)
@@ -269,27 +270,28 @@ var _ = Describe("WorkflowExecution Observability E2E", func() {
 			GinkgoWriter.Println("✅ BR-WE-008: All expected Prometheus metrics exposed")
 		})
 
-		It("should increment workflowexecution_total{outcome=Completed} on successful completion", func() {
-			// Business Outcome: SREs can track completion rate via Prometheus
-			// This test validates metrics are actually incremented when workflows complete
+	It("should increment workflowexecution_total{outcome=Completed} on successful completion", func() {
+		// Business Outcome: SREs can track completion rate via Prometheus
+		// This test validates metrics are actually incremented when workflows complete
 
-			// Query initial metric value
-			metricsURL := fmt.Sprintf("http://127.0.0.1:%d/metrics", infrastructure.WorkflowExecutionMetricsHostPort)
+		// Query initial metric value
+		metricsURL := fmt.Sprintf("http://127.0.0.1:%d/metrics", infrastructure.WorkflowExecutionMetricsHostPort)
+		metricsClient := &http.Client{Timeout: 5 * time.Second}
 
-			var initialMetricsBody string
-			Eventually(func() error {
-				resp, err := http.Get(metricsURL)
-				if err != nil {
-					return err
-				}
-				defer func() { _ = resp.Body.Close() }()
-				body, err := io.ReadAll(resp.Body)
-				if err != nil {
-					return err
-				}
-				initialMetricsBody = string(body)
-				return nil
-			}, 30*time.Second).Should(Succeed(), "Should be able to scrape metrics endpoint initially")
+		var initialMetricsBody string
+		Eventually(func() error {
+			resp, err := metricsClient.Get(metricsURL)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = resp.Body.Close() }()
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+			initialMetricsBody = string(body)
+			return nil
+		}, 60*time.Second, 2*time.Second).Should(Succeed(), "Should be able to scrape metrics endpoint initially")
 
 			// Extract initial count (parse Prometheus format)
 			initialCompletedCount := extractMetricValue(initialMetricsBody, wemetrics.MetricNameExecutionTotal, wemetrics.LabelOutcomeCompleted)
@@ -317,22 +319,22 @@ var _ = Describe("WorkflowExecution Observability E2E", func() {
 
 			GinkgoWriter.Println("✅ Workflow completed, checking metrics...")
 
-			// Verify metric incremented
-			Eventually(func() bool {
-				resp, err := http.Get(metricsURL)
-				if err != nil {
-					return false
-				}
-				defer func() { _ = resp.Body.Close() }()
-				body, _ := io.ReadAll(resp.Body)
-				metricsBody := string(body)
+		// Verify metric incremented
+		Eventually(func() bool {
+			resp, err := metricsClient.Get(metricsURL)
+			if err != nil {
+				return false
+			}
+			defer func() { _ = resp.Body.Close() }()
+			body, _ := io.ReadAll(resp.Body)
+			metricsBody := string(body)
 
-				currentCount := extractMetricValue(metricsBody, wemetrics.MetricNameExecutionTotal, wemetrics.LabelOutcomeCompleted)
-				GinkgoWriter.Printf("Current %s{outcome=%s}: %.0f (initial: %.0f)\n", wemetrics.MetricNameExecutionTotal, wemetrics.LabelOutcomeCompleted, currentCount, initialCompletedCount)
+			currentCount := extractMetricValue(metricsBody, wemetrics.MetricNameExecutionTotal, wemetrics.LabelOutcomeCompleted)
+			GinkgoWriter.Printf("Current %s{outcome=%s}: %.0f (initial: %.0f)\n", wemetrics.MetricNameExecutionTotal, wemetrics.LabelOutcomeCompleted, currentCount, initialCompletedCount)
 
-				return currentCount > initialCompletedCount
-			}, 30*time.Second, 2*time.Second).Should(BeTrue(),
-				fmt.Sprintf("%s{outcome=%s} should increment after workflow completion", wemetrics.MetricNameExecutionTotal, wemetrics.LabelOutcomeCompleted))
+			return currentCount > initialCompletedCount
+		}, 60*time.Second, 2*time.Second).Should(BeTrue(),
+			fmt.Sprintf("%s{outcome=%s} should increment after workflow completion", wemetrics.MetricNameExecutionTotal, wemetrics.LabelOutcomeCompleted))
 
 			GinkgoWriter.Println("✅ BR-WE-008: Completion metric incremented on successful workflow")
 		})
@@ -341,26 +343,27 @@ var _ = Describe("WorkflowExecution Observability E2E", func() {
 			// Business Outcome: SREs can track failure rate via Prometheus
 			// This test validates metrics are actually incremented when workflows fail
 
-			// Query initial metric value
-			metricsURL := fmt.Sprintf("http://127.0.0.1:%d/metrics", infrastructure.WorkflowExecutionMetricsHostPort)
+		// Query initial metric value
+		metricsURL := fmt.Sprintf("http://127.0.0.1:%d/metrics", infrastructure.WorkflowExecutionMetricsHostPort)
+		metricsClient := &http.Client{Timeout: 5 * time.Second}
 
-			var initialMetricsBody string
-			Eventually(func() error {
-				resp, err := http.Get(metricsURL)
-				if err != nil {
-					return err
-				}
-				defer func() { _ = resp.Body.Close() }()
-				body, err := io.ReadAll(resp.Body)
-				if err != nil {
-					return err
-				}
-				initialMetricsBody = string(body)
-				return nil
-			}, 30*time.Second).Should(Succeed(), "Should be able to scrape metrics endpoint initially")
+		var initialMetricsBody string
+		Eventually(func() error {
+			resp, err := metricsClient.Get(metricsURL)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = resp.Body.Close() }()
+			body, err := io.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+			initialMetricsBody = string(body)
+			return nil
+		}, 60*time.Second, 2*time.Second).Should(Succeed(), "Should be able to scrape metrics endpoint initially")
 
-			// Extract initial count
-			initialFailedCount := extractMetricValue(initialMetricsBody, wemetrics.MetricNameExecutionTotal, wemetrics.LabelOutcomeFailed)
+		// Extract initial count
+		initialFailedCount := extractMetricValue(initialMetricsBody, wemetrics.MetricNameExecutionTotal, wemetrics.LabelOutcomeFailed)
 			GinkgoWriter.Printf("Initial %s{outcome=%s}: %.0f\n", wemetrics.MetricNameExecutionTotal, wemetrics.LabelOutcomeFailed, initialFailedCount)
 
 			// Run a workflow that intentionally fails (tekton-bundles/failing exits non-zero)
@@ -413,22 +416,22 @@ var _ = Describe("WorkflowExecution Observability E2E", func() {
 
 			GinkgoWriter.Println("✅ Workflow failed as expected, checking metrics...")
 
-			// Verify metric incremented
-			Eventually(func() bool {
-				resp, err := http.Get(metricsURL)
-				if err != nil {
-					return false
-				}
-				defer func() { _ = resp.Body.Close() }()
-				body, _ := io.ReadAll(resp.Body)
-				metricsBody := string(body)
+		// Verify metric incremented
+		Eventually(func() bool {
+			resp, err := metricsClient.Get(metricsURL)
+			if err != nil {
+				return false
+			}
+			defer func() { _ = resp.Body.Close() }()
+			body, _ := io.ReadAll(resp.Body)
+			metricsBody := string(body)
 
-				currentCount := extractMetricValue(metricsBody, wemetrics.MetricNameExecutionTotal, wemetrics.LabelOutcomeFailed)
-				GinkgoWriter.Printf("Current %s{outcome=%s}: %.0f (initial: %.0f)\n", wemetrics.MetricNameExecutionTotal, wemetrics.LabelOutcomeFailed, currentCount, initialFailedCount)
+			currentCount := extractMetricValue(metricsBody, wemetrics.MetricNameExecutionTotal, wemetrics.LabelOutcomeFailed)
+			GinkgoWriter.Printf("Current %s{outcome=%s}: %.0f (initial: %.0f)\n", wemetrics.MetricNameExecutionTotal, wemetrics.LabelOutcomeFailed, currentCount, initialFailedCount)
 
-				return currentCount > initialFailedCount
-			}, 30*time.Second, 2*time.Second).Should(BeTrue(),
-				fmt.Sprintf("%s{outcome=%s} should increment after workflow failure", wemetrics.MetricNameExecutionTotal, wemetrics.LabelOutcomeFailed))
+			return currentCount > initialFailedCount
+		}, 60*time.Second, 2*time.Second).Should(BeTrue(),
+			fmt.Sprintf("%s{outcome=%s} should increment after workflow failure", wemetrics.MetricNameExecutionTotal, wemetrics.LabelOutcomeFailed))
 
 			GinkgoWriter.Println("✅ BR-WE-008: Failure metric incremented on failed workflow")
 		})


### PR DESCRIPTION
## Summary

- The `kubernaut_approve` tool's `decision` field lacked schema constraints, causing the LLM to send verb forms (`"Approve"`, `"Reject"`) instead of CRD-valid values (`"Approved"`, `"Rejected"`)
- The authwebhook correctly rejected invalid values, but the error was wrapped as a misleading "access denied" message
- Instead of normalizing invalid inputs, this fix **exposes the enum constraint directly in the tool's JSON schema** via `functiontool.Config.InputSchema`, so the LLM sees valid values in the tool definition and sends them correctly
- Invalid values are rejected with an actionable error that names the allowed values, enabling the LLM to self-correct on retry

## Changes

- Provide custom `InputSchema` with `enum: ["Approved", "Rejected"]` on the `decision` property
- Replace naive capitalization normalization with strict validation
- Update tool description to reference exact enum values
- Pass validated decision directly to CRD patch (no silent normalization)

## Test plan

- [x] UT-AF-1353-001: rejects verb form "Approve" with actionable error listing valid values
- [x] UT-AF-1353-002: rejects verb form "Reject" with actionable error
- [x] UT-AF-1353-003: rejects arbitrary string "maybe"
- [x] UT-AF-1353-004: accepts exact enum value "Approved"
- [x] UT-AF-1353-005: accepts exact enum value "Rejected"
- [x] All 22 AF test suites pass (no regressions)

Closes #1353