### PR TITLE
docs: ServiceNow signal design -- DD-INT-020 and ADR-063 refinements

### DIFF
--- a/docs/architecture/decisions/ADR-063-servicenow-signal-integration.md
+++ b/docs/architecture/decisions/ADR-063-servicenow-signal-integration.md
@@ -1,14 +1,13 @@
 # ADR-063: ServiceNow Signal Integration Architecture
 
 **Status**: PROPOSED
-**Date**: 2026-06-03
+**Date**: 2026-06-04
 **Decision Makers**: Architecture Team
-**Confidence**: 92%
+**Confidence**: 94%
 
 **Related Decisions**:
 - [DD-INT-020](DD-INT-020-servicenow-signal-target-type.md) -- Detailed design for ServiceNow signal target type
-- [ADR-EM-001](ADR-EM-001-effectiveness-monitor-service-integration.md) -- EM service integration (extended by this ADR)
-- [ADR-041](adr-041-llm-contract/ADR-041-llm-prompt-response-contract.md) -- LLM prompt response contract (extended for verification)
+- [ADR-041](adr-041-llm-contract/ADR-041-llm-prompt-response-contract.md) -- LLM prompt response contract (extended for ServiceNow investigation)
 - [ADR-001](ADR-001-crd-microservices-architecture.md) -- CRD microservices architecture
 
 ---
@@ -17,6 +16,7 @@
 
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
+| 1.1 | 2026-06-04 | Architecture Team | Dropped decisions 3 (KA verification endpoint), 4 (contract-driven verification), and 5 (EM early-exit). ServiceNow audit trail sufficient for POC. |
 | 1.0 | 2026-06-03 | Architecture Team | Initial ADR: four architectural decisions for ServiceNow signal integration |
 
 ---
@@ -25,14 +25,14 @@
 
 Kubernaut's remediation pipeline is designed around Kubernetes-originated signals. Every component in the chain -- from enrichment through investigation to effectiveness verification -- assumes K8s API access and K8s resource semantics.
 
-Extending the pipeline to support ServiceNow tickets as signal sources requires four architectural decisions:
+Extending the pipeline to support ServiceNow tickets as signal sources requires two architectural decisions:
 
 1. How to discriminate ServiceNow signals from K8s signals throughout the pipeline
 2. How to gate K8s-specific behavior (enrichment, hashing, scope) for non-K8s targets
-3. How KA should investigate ServiceNow tickets (tools, prompts, correlation reasoning)
-4. How EM should verify ServiceNow remediation outcomes without K8s deterministic checks
 
-This ADR captures these four decisions as a cohesive architecture.
+Additionally, KA investigation (tools, prompts, correlation reasoning) is covered in DD-INT-020 as an implementation detail rather than an architectural decision.
+
+EM verification for ServiceNow signals has been deferred -- ServiceNow's native audit trail makes automated effectiveness assessment redundant for the POC scope.
 
 ---
 
@@ -60,11 +60,11 @@ The pipeline has two candidate fields for distinguishing signal sources: `Signal
 
 ---
 
-## 3. Decision: KA Verification Endpoint for EM
+## 3. Decision: No EM Verification for ServiceNow (POC Scope)
 
 ### Context
 
-EM currently uses four deterministic scorers (hash, health, alert, metrics) that assume K8s API access. For ServiceNow signals, verification requires reasoning about whether a workflow achieved its stated objectives (e.g., "Did it close the ticket with the right close code? Did it create an escalation ticket with RCA details?").
+EM currently uses four deterministic scorers (hash, health, alert, metrics) that assume K8s API access. The question is whether ServiceNow signals need an analogous verification mechanism.
 
 Three approaches were considered:
 
@@ -72,134 +72,26 @@ Three approaches were considered:
 |----------|-------------|---------|
 | **Deterministic rules** | Check specific field values (state=resolved) | Insufficient -- verifies state change, not intent fulfillment |
 | **LLM client in EM** | Embed LLM client directly in EM controller | Rejected -- duplicates KA infrastructure, makes EM non-deterministic |
-| **KA verification endpoint** | New REST endpoint in KA; EM calls as HTTP client | **Chosen** |
+| **KA verification endpoint** | New REST endpoint in KA; EM calls as HTTP client | Deferred -- solves a problem that doesn't exist for ServiceNow |
+| **No EM verification** | WFE success/failure is sufficient; ServiceNow audit trail self-documents | **Chosen for POC** |
 
 ### Decision
 
-**Expose `POST /verify-effectiveness` in KA.** EM calls it as an HTTP client (same pattern as Prometheus/AlertManager). KA is reused as infrastructure only -- the verification session is completely independent from investigation (separate prompt, separate guardrails, separate schema).
-
-### Architecture
-
-```
-EM ServiceNow Scorer
-  │
-  ├─1─▶ Read EA.Spec.ProviderData (pre-remediation snapshot)
-  ├─2─▶ Fetch current ticket from ServiceNow API (post-remediation)
-  ├─3─▶ Fetch RemediationWorkflow CRD (workflow contract)
-  │
-  └─4─▶ POST /verify-effectiveness to KA
-           │
-           ├── workflow_contract (description.what/whenToUse/preconditions)
-           ├── rca_summary
-           ├── pre_remediation_state (ProviderData)
-           └── post_remediation_state (ServiceNow API response)
-                 │
-                 ▼
-           KA renders verify_effectiveness.tmpl
-           LLM evaluates contract claims vs evidence
-                 │
-                 ▼
-           VerifyEffectivenessResponse
-           {effective, confidence, contract_evaluation[], reasoning}
-                 │
-                 ▼
-           EM maps to ComponentResult{Assessed: true, Score: &confidence}
-```
+**EM does not perform ServiceNow-specific verification for the POC.** WFE success/failure is the only signal EM needs.
 
 ### Rationale
 
-- **No duplication**: KA already has LLM client, prompt builder, structured output parser, token tracking, metrics
-- **Clean separation**: EM orchestrates *when* to verify; KA handles *how* to reason
-- **Testable boundary**: KA endpoint tests with mock LLM; EM scorer tests with mock HTTP server
-- **Graceful degradation**: If KA is unavailable, EM treats it like Prometheus/AlertManager being down (assessed-as-skipped, requeue)
-- **Not "grading own homework"**: The verification session shares zero context with investigation -- different prompt, different guardrails, different schema. KA is the execution engine, not a biased evaluator
+- **ServiceNow is its own audit trail**: Every ticket state change is recorded with timestamps, actors, and reasons. This is fundamentally different from K8s resources, where Kubernaut has no visibility into what changed.
+- **WFE binary outcome is sufficient**: If the ServiceNow CLI container exits 0, the API calls succeeded (ticket closed, escalation created, etc.). If it exits non-zero, the Job failed. The ServiceNow audit trail documents exactly what happened in either case.
+- **Avoid speculative complexity**: Contract-driven verification via a KA endpoint is a sophisticated mechanism that solves a problem that doesn't exist for ServiceNow tickets. Building it now would be speculative engineering.
+- **Clear upgrade path**: If a future requirement emerges (e.g., complex multi-step workflows with partial-success semantics), the KA verification endpoint can be introduced as a new feature, not retrofitted into a codebase that was designed around it.
 
 ### Consequences
 
-- KA gains a new OpenAPI endpoint (auto-routed by ogen after codegen)
-- KA gains `verify_effectiveness.tmpl` + `VerificationResultSchema()` + parser
-- EM gains `KAEndpointURL` config (same pattern as `PrometheusURL`)
-- EM ServiceNow scorer is an HTTP client, not an LLM integration
-
----
-
-## 4. Decision: Contract-Driven Verification
-
-### Context
-
-How should the verification LLM know what to check? Hardcoded rules (e.g., "for close workflows, check state=resolved") are brittle and require code changes for each new workflow.
-
-### Decision
-
-**Use the workflow's `RemediationWorkflowDescription.What` field as the agentic contract.** The LLM evaluates each claim in the `what` field against post-remediation evidence.
-
-### Example
-
-Workflow CRD:
-```yaml
-description:
-  what: "Closes the ServiceNow incident as false alarm caused by scheduled maintenance.
-         Sets state to Resolved, close_code to 'Solved (Permanently)', adds close_notes
-         referencing the maintenance change request."
-```
-
-Verification LLM output:
-```json
-{
-  "effective": true,
-  "confidence": 0.93,
-  "contract_evaluation": [
-    {"criterion": "Sets ticket state to Resolved", "met": true, "evidence": "state: active -> resolved"},
-    {"criterion": "Sets close_code to Solved (Permanently)", "met": true, "evidence": "close_code='solved'"},
-    {"criterion": "Adds close_notes referencing maintenance CR", "met": true, "evidence": "close_notes contains CHG0012345"}
-  ]
-}
-```
-
-### Rationale
-
-- **Workflow authors define acceptance criteria** in natural language via the existing `description.what` field
-- **No hardcoded verification logic** -- works for any ServiceNow workflow without code changes
-- **Per-criterion transparency** -- each claim has a pass/fail with evidence, valuable for customer demos
-- **Reuses existing CRD field** -- `RemediationWorkflowDescription` is already defined and populated
-
-### Consequences
-
-- Verification quality depends on workflow authors writing precise `description.what` fields
-- Vague contracts produce vague verdicts (mitigation: documentation + templates for ServiceNow workflows)
-
----
-
-## 5. Decision: EM Early-Exit Branch for Non-K8s Targets
-
-### Context
-
-EM's component pipeline runs hash, health, alert, and metrics checks in a hardcoded sequence. Health and hash are always required in `allComponentsDone()` (unlike alert/metrics which have config-disabled escape hatches).
-
-### Decision
-
-**Add an early-exit branch at the top of `runComponentPipeline` for non-K8s target types.** This mirrors the existing `scopeNoExecution` pattern.
-
-```go
-if ea.Spec.TargetType == "servicenow" {
-    r.runServiceNowCheck(ctx, rctx)
-    result, err := r.completeAssessmentWithReason(ctx, ea, eav1.AssessmentReasonServiceNowVerified)
-    return result, true, err
-}
-```
-
-### Rationale
-
-- Clean separation: K8s pipeline is untouched for K8s signals
-- Avoids modifying `allComponentsDone`/`determineAssessmentReason` branching logic
-- Pattern proven by `scopeNoExecution` and `scopePartial` early exits
-- ServiceNow assessment has only one component (the KA verification call)
-
-### Consequences
-
-- New `AssessmentReason` enum value: `"servicenow_verified"`
-- EA CRD gains `ServiceNowAssessed` and `ServiceNowScore` component fields
-- EM completion logic updated to handle the new reason
+- EM is untouched for the POC -- zero regression risk for K8s signals
+- No EA CRD changes needed (no `TargetType`, `ProviderData`, `ServiceNowAssessed` fields)
+- No new `AssessmentReason` enum values
+- ServiceNow EAs complete through the standard degraded/no-execution path
 
 ---
 
@@ -215,21 +107,22 @@ Key fields: `instance_url`, `ticket.sys_id`, `ticket.number`, `ticket.short_desc
 
 ### In Scope (Customer Evaluation)
 
-- Pipeline plumbing (Part A)
-- KA investigation + prompt + tools (Part B)
-- RO guardrails (Part C)
-- EM ServiceNow verification via KA endpoint (Part D)
+- Pipeline plumbing (Part A): propagate `TargetType` + `ProviderData` through AA boundary
+- KA investigation + prompt + tools (Part B, B1-B5): enrichment gating, prompt templates, dynamic tool registration, parser/types for correlation fields
+- RO guardrails (Part C, C1-C2): `CapturePreRemediationHash` guard for non-K8s targets
 - ServiceNow Go REST API client with mock httptest server
 - Two RemediationWorkflow CRDs (close + escalate)
 - E2E test with mock ServiceNow + mock LLM
 
 ### Deferred to Production GA
 
+- EM ServiceNow verification (Part D): contract-driven verification via KA endpoint
+- KA verification endpoint (Part B6): `POST /verify-effectiveness`
+- ProviderData propagation to EA (Part C3): only needed if EM verification is introduced
 - ServiceNow API circuit breaker and rate-limit handling
 - CMDB response caching
 - Multi-instance ServiceNow support
 - Shared `ResourceResolver` interface (K8s + ServiceNow)
-- SLO definitions for KA verification endpoint
 - Credential rotation runbook
 - `targetType`-based scope bypass in `scope.Manager.IsManaged` (namespace fallback sufficient for POC)
 
@@ -240,9 +133,8 @@ Key fields: `instance_url`, `ticket.sys_id`, `ticket.number`, `ticket.short_desc
 - [DD-INT-020](DD-INT-020-servicenow-signal-target-type.md): Detailed design document
 - Issue #1338: feat: Add ServiceNow as a signal target type
 - `api/remediationworkflow/v1alpha1/remediationworkflow_types.go`: `RemediationWorkflowDescription`
-- `internal/controller/effectivenessmonitor/reconcile_components.go`: EM component pipeline
 
 ---
 
-**Document Version**: 1.0
-**Last Updated**: 2026-06-03
+**Document Version**: 1.1
+**Last Updated**: 2026-06-04

--- a/docs/architecture/decisions/ADR-063-servicenow-signal-integration.md
+++ b/docs/architecture/decisions/ADR-063-servicenow-signal-integration.md
@@ -116,6 +116,8 @@ Key fields: `instance_url`, `ticket.sys_id`, `ticket.number`, `ticket.short_desc
 
 ### Deferred to Production GA
 
+- **CHG (Change Request) use case**: Post-change validation -- after a change is deployed, investigate whether affected resources are healthy. Same pipeline, new prompt blocks and workflow CRDs (confirm success / roll back / escalate incident). No architecture changes required.
+- **PRB (Problem) use case**: Problem investigation -- correlate multiple incidents on the same CI, find common root cause. Same pipeline, new prompt blocks and workflow CRDs (link RCA to problem / escalate to engineering). No architecture changes required.
 - EM ServiceNow verification (Part D): contract-driven verification via KA endpoint
 - KA verification endpoint (Part B6): `POST /verify-effectiveness`
 - ProviderData propagation to EA (Part C3): only needed if EM verification is introduced
@@ -125,6 +127,8 @@ Key fields: `instance_url`, `ticket.sys_id`, `ticket.number`, `ticket.short_desc
 - Shared `ResourceResolver` interface (K8s + ServiceNow)
 - Credential rotation runbook
 - `targetType`-based scope bypass in `scope.Manager.IsManaged` (namespace fallback sufficient for POC)
+
+**Extensibility note**: The POC targets INC (incident) tickets only. The architecture is ticket-type-agnostic by design: `TargetType="servicenow"` is not incident-specific, `ProviderData` holds any ServiceNow ticket type (INC, CHG, PRB all share the same core fields), ServiceNow tools are generic, and workflow selection is driven by RemediationWorkflow CRDs. Extending to CHG and PRB is additive -- new prompt conditional blocks + new workflow CRDs, no pipeline or architecture changes.
 
 ---
 

--- a/docs/architecture/decisions/DD-INT-020-servicenow-signal-target-type.md
+++ b/docs/architecture/decisions/DD-INT-020-servicenow-signal-target-type.md
@@ -2,7 +2,7 @@
 
 **Status**: Proposed
 **Decision Date**: 2026-06-03
-**Version**: 1.1
+**Version**: 1.2
 **Confidence**: 94%
 **Deciders**: Architecture Team
 **Applies To**: API Frontend, Signal Processing, Remediation Orchestrator, AI Analysis, Kubernaut Agent, Workflow Execution
@@ -26,6 +26,7 @@
 
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
+| 1.2 | 2026-06-04 | Architecture Team | B2 clarified: KA injects full ticket data (not summaries) as raw context; LLM triages related tickets against resource state. Workflow selection is mandatory unless ticket is already closed (mirrors K8s flow). |
 | 1.1 | 2026-06-04 | Architecture Team | Dropped Part D (EM verification) and B6 (KA verification endpoint). ServiceNow is its own audit trail -- WFE success/failure is sufficient. Removed C3 (ProviderData to EA) since EM no longer consumes it. Simplified scope and file count. |
 | 1.0 | 2026-06-03 | Architecture Team | Initial design: pipeline plumbing, KA enrichment/prompt/tools, RO guards, EM contract-driven verification, ProviderData schema |
 
@@ -176,12 +177,23 @@ Also skip re-enrichment (post-RCA target resolution). Downstream consumers handl
 #### B2: Prompt Templates
 
 **Phase 1** (`incident_investigation.tmpl`): Add `{{ if eq .TargetType "servicenow" }}` conditional block (mirrors existing `{{ if eq .SignalMode "proactive" }}` pattern) containing:
-- ServiceNow ticket context from ProviderData (number, description, state, CMDB CI)
-- Pre-fetched related active ticket summaries
-- Tool guidance for ServiceNow-specific investigation tools
-- Modified `submit_result` schema guidance including `is_false_alarm`, `explained_by_ticket`, `correlation_reasoning`
+
+- **Full original ticket data** from ProviderData (number, description, state, priority, CMDB CI, timestamps, assignment details) -- injected as raw context, not pre-digested summaries
+- **Full related open ticket data** for the same CMDB CI (fetched by KA pre-enrichment) -- each ticket's complete details, not summaries
+- **Investigation instructions** directing the LLM to triage the related tickets against the state of the resource: the LLM must determine whether the symptoms in the original ticket are explained by what the related tickets describe (scheduled maintenance, known changes, etc.) or whether the problem is independent
+- **`submit_result` schema guidance** including `is_false_alarm`, `explained_by_ticket`, `correlation_reasoning` fields
+
+The key design principle: KA provides the raw evidence (original ticket + related tickets + CMDB CI context). The LLM does the triage -- cross-referencing related tickets against the actual resource state to determine causality. KA does not pre-process or summarize the tickets.
 
 **Phase 3** (`phase3_workflow_selection.tmpl`): Add ServiceNow action-type selection rules (CloseAlert vs EscalateTicket) alongside existing K8s/GitOps rules.
+
+**Workflow selection is mandatory** unless the ticket is already closed at investigation time (early exit with "no action needed"). The RCA outcome (explained by maintenance or not) informs which workflow is selected but never skips selection. This mirrors the K8s flow:
+
+| RCA Outcome | Workflow Selection |
+|---|---|
+| Explained by related tickets (maintenance) | CloseServiceNowAlert |
+| Not explained by related tickets | EscalateServiceNowTicket |
+| Ticket already closed at investigation time | No workflow -- early exit ("nothing to do") |
 
 #### B3: Dynamic Tool Gating
 
@@ -339,5 +351,5 @@ Serves as KA investigation context. If EM verification is introduced in the futu
 
 ---
 
-**Document Version**: 1.1
+**Document Version**: 1.2
 **Last Updated**: 2026-06-04

--- a/docs/architecture/decisions/DD-INT-020-servicenow-signal-target-type.md
+++ b/docs/architecture/decisions/DD-INT-020-servicenow-signal-target-type.md
@@ -26,7 +26,7 @@
 
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
-| 1.2 | 2026-06-04 | Architecture Team | B2 clarified: KA injects full ticket data (not summaries) as raw context; LLM triages related tickets against resource state. Workflow selection is mandatory unless ticket is already closed (mirrors K8s flow). |
+| 1.2 | 2026-06-04 | Architecture Team | B2 clarified: KA injects lightweight list (numbers + titles) of related tickets, LLM uses ServiceNow tools to drill into details (mirrors K8s tool-driven investigation pattern). Workflow selection is mandatory unless ticket is already closed. |
 | 1.1 | 2026-06-04 | Architecture Team | Dropped Part D (EM verification) and B6 (KA verification endpoint). ServiceNow is its own audit trail -- WFE success/failure is sufficient. Removed C3 (ProviderData to EA) since EM no longer consumes it. Simplified scope and file count. |
 | 1.0 | 2026-06-03 | Architecture Team | Initial design: pipeline plumbing, KA enrichment/prompt/tools, RO guards, EM contract-driven verification, ProviderData schema |
 
@@ -178,12 +178,12 @@ Also skip re-enrichment (post-RCA target resolution). Downstream consumers handl
 
 **Phase 1** (`incident_investigation.tmpl`): Add `{{ if eq .TargetType "servicenow" }}` conditional block (mirrors existing `{{ if eq .SignalMode "proactive" }}` pattern) containing:
 
-- **Full original ticket data** from ProviderData (number, description, state, priority, CMDB CI, timestamps, assignment details) -- injected as raw context, not pre-digested summaries
-- **Full related open ticket data** for the same CMDB CI (fetched by KA pre-enrichment) -- each ticket's complete details, not summaries
-- **Investigation instructions** directing the LLM to triage the related tickets against the state of the resource: the LLM must determine whether the symptoms in the original ticket are explained by what the related tickets describe (scheduled maintenance, known changes, etc.) or whether the problem is independent
+- **Original ticket context** from ProviderData (number, description, state, priority, CMDB CI, timestamps, assignment details)
+- **Lightweight list of related open tickets** for the same CMDB CI (fetched by KA pre-enrichment) -- ticket numbers and titles only, not full details
+- **Tool-driven investigation instructions** directing the LLM to use ServiceNow tools (`servicenow_get_ticket`, etc.) to drill into the related tickets, extract summaries and relevant details, and triage them against the state of the resource to determine whether the symptoms in the original ticket are explained by the related tickets (scheduled maintenance, known changes, etc.) or whether the problem is independent
 - **`submit_result` schema guidance** including `is_false_alarm`, `explained_by_ticket`, `correlation_reasoning` fields
 
-The key design principle: KA provides the raw evidence (original ticket + related tickets + CMDB CI context). The LLM does the triage -- cross-referencing related tickets against the actual resource state to determine causality. KA does not pre-process or summarize the tickets.
+The key design principle mirrors the K8s investigation pattern: KA provides the signal context (original ticket + lightweight list of related ticket numbers/titles) and the LLM uses tools to investigate. The LLM decides which related tickets to drill into, fetches their details via ServiceNow tools, and does the triage itself. KA does not pre-load full ticket data into the prompt -- the LLM drives the investigation through tool calls, just as it uses `kubectl_describe` and `kubectl_logs` for K8s signals.
 
 **Phase 3** (`phase3_workflow_selection.tmpl`): Add ServiceNow action-type selection rules (CloseAlert vs EscalateTicket) alongside existing K8s/GitOps rules.
 

--- a/docs/architecture/decisions/DD-INT-020-servicenow-signal-target-type.md
+++ b/docs/architecture/decisions/DD-INT-020-servicenow-signal-target-type.md
@@ -306,6 +306,7 @@ Serves as KA investigation context. If EM verification is introduced in the futu
 2. EM remains untouched for the POC -- zero regression risk for K8s signals
 3. Minimal blast radius: ServiceNow-specific logic isolated to KA (tools, prompts, gating)
 4. WFE success/failure + ServiceNow audit trail provide sufficient verification
+5. Architecture is ticket-type-agnostic: POC targets INC (incidents), but CHG (change requests) and PRB (problems) can be added later with new prompt blocks + workflow CRDs only -- no pipeline or architecture changes
 
 ### Negative Consequences
 

--- a/docs/architecture/decisions/DD-INT-020-servicenow-signal-target-type.md
+++ b/docs/architecture/decisions/DD-INT-020-servicenow-signal-target-type.md
@@ -2,24 +2,22 @@
 
 **Status**: Proposed
 **Decision Date**: 2026-06-03
-**Version**: 1.0
-**Confidence**: 92%
+**Version**: 1.1
+**Confidence**: 94%
 **Deciders**: Architecture Team
-**Applies To**: API Frontend, Signal Processing, Remediation Orchestrator, AI Analysis, Kubernaut Agent, Workflow Execution, Effectiveness Monitor
+**Applies To**: API Frontend, Signal Processing, Remediation Orchestrator, AI Analysis, Kubernaut Agent, Workflow Execution
 
 **Related Business Requirements**:
 - BR-INT-004: ServiceNow ticket creation/tracking
 - BR-INT-020: ServiceNow as signal target type
 
 **Related Design Decisions**:
-- DD-EM-002: Canonical spec hash (pre/post comparison model)
 - DD-HAPI-019: KA Go rewrite design (prompt builder, parser, tool registry)
 - DD-WORKFLOW-001: Mandatory label schema (workflow contract description)
 - DD-RO-002: Centralized routing responsibility (scope, blocking conditions)
 
 **Related ADRs**:
 - ADR-063: ServiceNow Signal Integration Architecture
-- ADR-EM-001: Effectiveness Monitor Service Integration
 - ADR-041: LLM Prompt Response Contract
 
 ---
@@ -28,6 +26,7 @@
 
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
+| 1.1 | 2026-06-04 | Architecture Team | Dropped Part D (EM verification) and B6 (KA verification endpoint). ServiceNow is its own audit trail -- WFE success/failure is sufficient. Removed C3 (ProviderData to EA) since EM no longer consumes it. Simplified scope and file count. |
 | 1.0 | 2026-06-03 | Architecture Team | Initial design: pipeline plumbing, KA enrichment/prompt/tools, RO guards, EM contract-driven verification, ProviderData schema |
 
 ---
@@ -45,13 +44,11 @@ Customers need to investigate ServiceNow tickets that reference cloud objects (c
 1. Accept signals derived from ServiceNow tickets
 2. Correlate maintenance tickets with reported issues (false alarm detection)
 3. Choose between closing the alert (maintenance-caused) or escalating with a new ticket
-4. Verify that the chosen workflow actually achieved its intended outcome
 
 ### Constraints
 
 - `TargetType` and `ProviderData` are dropped at the AA boundary (9-hop plumbing gap)
 - KA enrichment assumes K8s API access (would attempt `Pod/<ticket-number>` lookup without gating)
-- EM is purely deterministic (no LLM client) -- cannot reason about ServiceNow ticket outcomes
 - Scope is customer evaluation readiness (POC/demo), not full production GA
 - CMDB CIs are at cluster/node level only (no application-level CIs)
 
@@ -60,10 +57,9 @@ Customers need to investigate ServiceNow tickets that reference cloud objects (c
 ## Decision Drivers
 
 1. **Customer demand**: Evaluation deployment requires ServiceNow integration end-to-end
-2. **Pipeline reuse**: Maximize reuse of existing RR -> SP -> AA -> KA -> WFE -> EM pipeline
+2. **Pipeline reuse**: Maximize reuse of existing RR -> SP -> AA -> KA -> WFE pipeline
 3. **Isolation**: ServiceNow-specific logic must not pollute K8s signal processing
-4. **Verification depth**: "Did the workflow complete?" is insufficient -- need "Did the workflow do what it promised?"
-5. **Minimal blast radius**: Prefer composition over modification of existing components
+4. **Minimal blast radius**: Prefer composition over modification of existing components
 
 ---
 
@@ -103,57 +99,47 @@ Customers need to investigate ServiceNow tickets that reference cloud objects (c
 - Makes EM non-deterministic for all target types
 - Large blast radius in a controller that is currently purely deterministic
 
-**Confidence**: 0% (rejected in favor of KA verification endpoint)
+**Confidence**: 0% (rejected)
 
-### Alternative D: KA verification endpoint for EM -- CHOSEN
+### Alternative D: KA verification endpoint for EM -- DEFERRED
 
 **Approach**: Expose `POST /verify-effectiveness` in KA. EM calls it as an HTTP client. KA reuses existing LLM infrastructure for a completely independent reasoning session.
 
-**Pros**:
-- Zero duplication of LLM infrastructure
-- EM stays thin (HTTP client, same pattern as Prometheus/AlertManager)
-- Clean separation: KA = reasoning engine, EM = orchestrator
-- Independent session with dedicated prompt and guardrails
+**Rationale for deferral**: ServiceNow is its own audit trail. Every ticket state change is recorded with timestamps, actors, and reasons. Unlike K8s resources (where we have no visibility into what changed and must verify post-remediation state), ServiceNow verification would be validating that a ticket did what it was supposed to do -- which the ticket history already confirms. WFE success/failure is sufficient for the POC. If a future need arises (e.g., complex multi-step ServiceNow workflows where partial success is possible), the verification endpoint can be revisited as a new requirement.
 
-**Cons**:
-- KA availability becomes a dependency for EM ServiceNow verification
-
-**Confidence**: 92%
+**Confidence**: N/A (deferred)
 
 ---
 
 ## Decision
 
-### Chosen: Alternative B (TargetType) + Alternative D (KA verification endpoint)
+### Chosen: Alternative B (TargetType) + No EM verification for ServiceNow (POC)
 
 ### Architecture
 
 ```
-                         ┌──────────────────────────────────────────────┐
-                         │              ServiceNow API                  │
-                         └──────┬───────────────┬───────────────┬──────┘
-                                │               │               │
-                           AF fetches      KA queries      EM fetches
-                           originating     related         current
-                           ticket          tickets         ticket
-                                │               │               │
-  ┌─────┐   ┌────┐   ┌────┐   ▼   ┌────┐      ▼   ┌─────┐    ▼   ┌────┐
-  │  AF │──▶│ RR │──▶│ SP │──────▶│ AA │─────────▶│ KA  │───────▶│ WFE│
-  └─────┘   └────┘   └────┘       └────┘          └──┬──┘        └──┬─┘
-              │                                       │              │
-              │  targetType + ProviderData             │              │
-              │  propagated through pipeline           │              │
-              │                                       │              │
-              ▼                                       │              ▼
-           ┌────┐                                     │           ┌────┐
-           │ EA │◀────────────────────────────────────┘           │ EM │
-           └────┘  RO copies ProviderData into EA                └──┬─┘
-              ▲                                                     │
-              │                          POST /verify-effectiveness │
-              │                          (workflow contract +       │
-              │                           pre/post ticket state)    │
-              └─────────────────────────────────────────────────────┘
+                         ┌──────────────────────────────────┐
+                         │          ServiceNow API           │
+                         └──────┬───────────────┬───────────┘
+                                │               │
+                           AF fetches      KA queries
+                           originating     related
+                           ticket          tickets
+                                │               │
+  ┌─────┐   ┌────┐   ┌────┐   ▼   ┌────┐      ▼   ┌─────┐        ┌─────┐
+  │  AF │──▶│ RR │──▶│ SP │──────▶│ AA │─────────▶│ KA  │───────▶│ WFE │
+  └─────┘   └────┘   └────┘       └────┘          └─────┘        └─────┘
+              │                                                      │
+              │  targetType + ProviderData                           │
+              │  propagated through pipeline                  WFE success/failure
+              │                                              is sufficient for EM
+              ▼
+           ┌────┐
+           │ EA │  EM skips ServiceNow signals (no K8s checks apply,
+           └────┘  ServiceNow audit trail is self-documenting)
 ```
+
+**EM note**: For the POC, EM does not perform ServiceNow-specific verification. ServiceNow is its own audit trail -- every ticket state change is recorded with timestamps, actors, and reasons. WFE success/failure provides sufficient signal. Contract-driven verification via a KA endpoint could be added as a future requirement if complex multi-step workflows require partial-success detection.
 
 ### Part A: Pipeline Plumbing (9 files + codegen)
 
@@ -220,45 +206,11 @@ Add to `InvestigationResult`:
 
 Add corresponding fields to `llmResponse` in parser, JSON schema in `schema.go`, and response mapper in `handler.go`.
 
-#### B6: KA Verification Endpoint
+#### B6: KA Verification Endpoint -- DEFERRED (not in POC)
 
-New `POST /verify-effectiveness` endpoint for contract-driven EM verification.
+Dropped from POC scope. ServiceNow's native audit trail makes contract-driven verification redundant for the demo. See "Decision Drivers" and "Alternatives Considered > Alternative D" for full rationale.
 
-**Request** (`VerifyEffectivenessRequest`):
-```json
-{
-  "correlation_id": "rr-abc-123",
-  "target_type": "servicenow",
-  "workflow_id": "servicenow-close-maintenance-v1",
-  "workflow_contract": {
-    "what": "Closes the ServiceNow incident as false alarm...",
-    "when_to_use": "When RCA determines incident is caused by maintenance...",
-    "preconditions": "Active maintenance change request exists..."
-  },
-  "rca_summary": "Alert caused by scheduled maintenance CHG0012345...",
-  "pre_remediation_state": { "ticket": { "...ProviderData snapshot..." } },
-  "post_remediation_state": {
-    "tickets": [
-      { "sys_id": "abc123", "number": "INC0067890", "state": "resolved", "..." : "..." }
-    ]
-  }
-}
-```
-
-**Response** (`VerifyEffectivenessResponse`):
-```json
-{
-  "effective": true,
-  "confidence": 0.93,
-  "contract_evaluation": [
-    {"criterion": "Sets ticket state to Resolved", "met": true, "evidence": "state: active -> resolved"},
-    {"criterion": "Adds close_notes referencing maintenance CR", "met": true, "evidence": "close_notes contains CHG0012345"}
-  ],
-  "reasoning": "All contract criteria met."
-}
-```
-
-The workflow contract comes from the `RemediationWorkflow` CRD's `description.what` field. EM fetches the CRD and sends the contract in the request. KA evaluates each claim against post-remediation evidence using a dedicated `verify_effectiveness.tmpl` prompt template.
+If revisited for production GA, the design would expose a `POST /verify-effectiveness` endpoint in KA for EM to call as an HTTP client. The endpoint would use the workflow's `RemediationWorkflowDescription.What` field as the agentic contract and evaluate each claim against post-remediation ServiceNow state.
 
 ### Part C: RO Guardrails
 
@@ -276,63 +228,30 @@ if rr.Spec.TargetType != "" && rr.Spec.TargetType != "kubernetes" {
 
 Skip semantics: `preHash = ""` causes downstream EA creation to have empty `PreRemediationSpecHash`, which EM handles gracefully (hash comparison returns "no pre-hash for comparison").
 
-#### C3: ProviderData into EA Spec
+#### C3: ProviderData into EA Spec -- DEFERRED (not in POC)
 
-RO copies `rr.Spec.ProviderData` into `EA.Spec.ProviderData` at creation time, so EM can read the pre-remediation ticket snapshot directly from the EA.
+Originally planned so EM could read the pre-remediation ticket snapshot. With EM verification dropped, there is no consumer of `ProviderData` on the EA. Deferred to GA if/when EM verification is introduced.
 
 #### CheckUnmanagedResource (no change needed for POC)
 
 `scope.Manager.IsManaged` skips resource-level label checks for unknown K8s kinds and falls back to namespace label. ServiceNow signals in a managed namespace pass scope checks without code changes.
 
-### Part D: EM ServiceNow Verification
+### Part D: EM ServiceNow Verification -- DROPPED FROM POC
 
-#### D1: EA CRD Extension
+**Decision**: EM does not perform ServiceNow-specific verification for the POC.
 
-Add optional fields to `EffectivenessAssessmentSpec`:
-- `TargetType string` (discriminator for EM pipeline)
-- `ProviderData string` (pre-remediation ServiceNow ticket snapshot)
-- `WorkflowID string` (for contract lookup)
+**Rationale**: ServiceNow is its own audit trail. Every ticket state change (creation, resolution, escalation, comment) is recorded with timestamps, actors, and reasons. Unlike K8s resources -- where Kubernaut has no visibility into what changed and must verify post-remediation state via spec hashing and health checks -- ServiceNow ticket history already confirms what happened. Verifying that the workflow "did what it was supposed to do" adds little value when the ticket history already documents the outcome.
 
-Add to `EAComponents`:
-- `ServiceNowAssessed bool`
-- `ServiceNowScore *float64`
+For the POC, WFE success/failure is the only signal EM needs. If WFE reports success, the ServiceNow CLI container executed its API calls successfully (ticket closed, escalation created, etc.). If WFE reports failure, the Job failed.
 
-Add `AssessmentReason` enum value: `"servicenow_verified"`.
+**What this means for EM**: ServiceNow EAs will complete through the standard K8s-skip path with no ServiceNow-specific components. The existing `scopeNoExecution` / degraded mode patterns in EM handle this gracefully.
 
-CEL `self == oldSelf` on spec is unaffected (new optional fields are additive).
-
-#### D2: EA Creator
-
-RO populates new EA spec fields from RR and AA at creation time.
-
-#### D3: ServiceNow Scorer
-
-HTTP client calling KA `/verify-effectiveness`. Flow:
-
-1. Read `ea.Spec.ProviderData` (pre-remediation state)
-2. Fetch current ticket from ServiceNow API (post-remediation state)
-3. Fetch `RemediationWorkflow` CRD for `ea.Spec.WorkflowID` (get `description` contract)
-4. Build `VerifyEffectivenessRequest` with contract + pre/post state + RCA summary
-5. POST to KA `/verify-effectiveness`
-6. Map `VerifyEffectivenessResponse` to `ComponentResult{Assessed: true, Score: &confidence}`
-
-#### D5: Pipeline Integration (Early-Exit Branch)
-
-At top of `runComponentPipeline` (after scope determination):
-
-```go
-if ea.Spec.TargetType == "servicenow" {
-    r.runServiceNowCheck(ctx, rctx)
-    result, err := r.completeAssessmentWithReason(ctx, ea, eav1.AssessmentReasonServiceNowVerified)
-    return result, true, err
-}
-```
-
-This skips all K8s components (hash, health, alert, metrics) and runs only the ServiceNow scorer. Pattern matches existing `scopeNoExecution` early exit.
-
-#### D6: Completion Logic
-
-`allComponentsDone` and `determineAssessmentReason` updated to handle `targetType == "servicenow"` (only `ServiceNowAssessed` required, K8s components treated as N/A).
+**Deferred items** (if revisited for production GA):
+- D1: EA CRD extension (`TargetType`, `ProviderData`, `WorkflowID`, `ServiceNowAssessed`, `ServiceNowScore`)
+- D2: EA creator populating ServiceNow fields
+- D3: ServiceNow scorer as HTTP client to KA verification endpoint
+- D5: Early-exit branch in `runComponentPipeline`
+- D6: Completion logic for `servicenow_verified` assessment reason
 
 ### ProviderData Schema
 
@@ -363,7 +282,7 @@ This skips all K8s components (hash, health, alert, metrics) and runs only the S
 }
 ```
 
-Serves dual purpose: KA investigation context AND EM pre-remediation baseline.
+Serves as KA investigation context. If EM verification is introduced in the future, this same snapshot serves as the pre-remediation baseline.
 
 ---
 
@@ -371,27 +290,26 @@ Serves dual purpose: KA investigation context AND EM pre-remediation baseline.
 
 ### Positive Consequences
 
-1. End-to-end ServiceNow signal support reusing existing pipeline
-2. Contract-driven verification is workflow-agnostic -- works for any future ServiceNow workflow
-3. KA verification endpoint is reusable for other non-K8s target types
-4. EM remains deterministic for K8s signals (zero regression risk)
+1. End-to-end ServiceNow signal support (AF -> RR -> SP -> AA -> KA -> WFE) reusing existing pipeline
+2. EM remains untouched for the POC -- zero regression risk for K8s signals
+3. Minimal blast radius: ServiceNow-specific logic isolated to KA (tools, prompts, gating)
+4. WFE success/failure + ServiceNow audit trail provide sufficient verification
 
 ### Negative Consequences
 
 1. 9-file plumbing change for AA boundary gap
    - **Mitigation**: Mechanical field propagation, validated by spikes
-2. KA availability becomes EM dependency for ServiceNow verification
-   - **Mitigation**: Same graceful degradation pattern as Prometheus/AlertManager (assessed-as-skipped, requeue)
-3. Two prompt templates need ServiceNow awareness (Phase 1 + Phase 3)
+2. Two prompt templates need ServiceNow awareness (Phase 1 + Phase 3)
    - **Mitigation**: Conditional blocks mirror existing `SignalMode` pattern
+3. No automated verification of ServiceNow workflow outcomes beyond WFE success/failure
+   - **Mitigation**: ServiceNow's native audit trail documents what changed. For the POC, this is acceptable. For GA, a KA verification endpoint could be added.
 
 ### Risks
 
 | Risk | Likelihood | Impact | Mitigation |
 |------|-----------|--------|------------|
-| Verification prompt produces inconsistent results | Medium | Low | Structured output schema constrains LLM; per-criterion evaluation provides transparency |
-| ServiceNow API rate limiting during EM verification | Low | Medium | Graceful degradation; requeue with backoff |
 | Phase 3 template ServiceNow action types not matched by DS catalog | Low | High | Ensure ServiceNow RemediationWorkflow CRDs deployed before demo |
+| WFE reports success but API call partially failed | Low | Medium | ServiceNow API returns errors on partial failure; CLI container exits non-zero |
 
 ---
 
@@ -400,17 +318,16 @@ Serves dual purpose: KA investigation context AND EM pre-remediation baseline.
 | Requirement | Status | Notes |
 |-------------|--------|-------|
 | BR-INT-004 | Partial | ServiceNow ticket creation via WFE Job executor |
-| BR-INT-020 | Full | ServiceNow as signal target type end-to-end |
+| BR-INT-020 | Full | ServiceNow as signal target type end-to-end (AF through WFE) |
 
 ---
 
 ## Validation Strategy
 
-1. **Unit tests**: Per-component logic (parser, prompt rendering, scorer) with mock dependencies
+1. **Unit tests**: Per-component logic (parser, prompt rendering, tool gating) with mock dependencies
 2. **Integration tests**: Pipeline plumbing (RR -> SP -> AA -> KA) with test CRDs
 3. **E2E tests**: Full pipeline with mock ServiceNow API + mock LLM
-4. **Contract verification tests**: Verify `description.what` parsing and per-criterion evaluation
-5. **Spike validation**: 11 spikes executed pre-implementation confirming all assumptions
+4. **Spike validation**: 11 spikes executed pre-implementation confirming all assumptions
 
 ---
 
@@ -419,9 +336,8 @@ Serves dual purpose: KA investigation context AND EM pre-remediation baseline.
 - Issue #1338: feat: Add ServiceNow as a signal target type
 - `api/remediationworkflow/v1alpha1/remediationworkflow_types.go`: Workflow description contract
 - `internal/kubernautagent/api/openapi.json`: KA OpenAPI specification
-- `internal/controller/effectivenessmonitor/reconcile_components.go`: EM component pipeline
 
 ---
 
-**Document Version**: 1.0
-**Last Updated**: 2026-06-03
+**Document Version**: 1.1
+**Last Updated**: 2026-06-04


### PR DESCRIPTION
## Summary

- Drop EM verification for ServiceNow from POC scope (Part D, B6, C3). ServiceNow's native audit trail makes contract-driven verification redundant -- WFE success/failure is sufficient.
- Clarify KA prompt design (B2): tool-driven investigation pattern where KA pre-enrichment provides a lightweight list of related tickets (numbers + titles), and the LLM uses ServiceNow tools to drill into details and triage them against the resource state.
- Workflow selection is mandatory unless the ticket is already closed (mirrors K8s flow).
- Add CHG (change request) and PRB (problem) as planned extensions in deferred scope. Architecture is ticket-type-agnostic by design.

## Files Changed

- `docs/architecture/decisions/DD-INT-020-servicenow-signal-target-type.md` (v1.0 -> v1.2)
- `docs/architecture/decisions/ADR-063-servicenow-signal-integration.md` (v1.0 -> v1.1)

## Test plan

- [ ] DD-INT-020 and ADR-063 reviewed for consistency
- [ ] Deferred items clearly separated from POC scope
- [ ] Wiring Manifest and file counts updated to reflect reduced scope (37 -> 24 files)

Refs: #1338

Made with [Cursor](https://cursor.com)