### PR TITLE
feat(apifrontend): hide session-dependent MCP tools when interactive mode is disabled (#1366)

### DIFF
--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -237,7 +237,7 @@ func run() int {
 		Description: "Kubernaut AI-driven remediation agent",
 		URL:         cfg.AgentCard.URL,
 		Version:     version(),
-		Skills:      handler.DefaultAgentSkills(),
+		Skills:      handler.DefaultAgentSkills(cfg.Interactive.Enabled),
 	})
 	if err != nil {
 		logger.Error(err, "failed to create agent card handler")
@@ -716,6 +716,7 @@ func buildMCPHandler(cfg *config.Config, deps *backendDeps, sessInfra *sessionIn
 		UserLimiter:        userLimiter,
 		SessionFinalizer:   sessFinalizer,
 		SessionInitializer: sessInitializer,
+		InteractiveEnabled: cfg.Interactive.Enabled,
 	}
 
 	mcpSessionTimeout := cfg.MCP.SessionIdleTimeout
@@ -788,6 +789,7 @@ func buildA2AHandler(ctx context.Context, cfg *config.Config, deps *backendDeps,
 		ToolCallDuration:      metricsReg.ToolCallDuration,
 		UserLimiter:           userLimiter,
 		ActiveContextRegistry: activeCtxRegistry,
+		InteractiveEnabled:    cfg.Interactive.Enabled,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create root agent: %w", err)

--- a/pkg/apifrontend/agent/config.go
+++ b/pkg/apifrontend/agent/config.go
@@ -81,6 +81,10 @@ type AgentConfig struct {
 	// When non-nil, the phase guard stores/clears the active context on
 	// investigate success and complete/cancel respectively.
 	ActiveContextRegistry *launcher.ActiveContextRegistry
+	// InteractiveEnabled controls whether session-dependent tools are registered
+	// in the A2A agent tool list. When false, tools in tools.SessionDependentTools
+	// are excluded (#1366). DefaultTestConfig sets this to true.
+	InteractiveEnabled bool
 }
 
 // Option applies a configuration override to AgentConfig.
@@ -94,7 +98,8 @@ func WithInstruction(instruction string) Option {
 // DefaultTestConfig returns a config suitable for unit tests with placeholder values.
 func DefaultTestConfig() AgentConfig {
 	return AgentConfig{
-		Instruction: defaultInstruction(),
+		Instruction:        defaultInstruction(),
+		InteractiveEnabled: true,
 	}
 }
 

--- a/pkg/apifrontend/agent/export_test.go
+++ b/pkg/apifrontend/agent/export_test.go
@@ -43,3 +43,11 @@ func (e *emptyState) Get(_ string) (any, error) {
 func (e *emptyState) All() iter.Seq2[string, any] {
 	return func(yield func(string, any) bool) {}
 }
+
+// PhaseGuardToolSets exports the phase guard tool classification sets for
+// consistency testing against tools.SessionDependentTools (#1366 F6).
+var (
+	ExportedMCPDependentTools   = mcpDependentTools
+	ExportedDriverEntryTools    = driverEntryTools
+	ExportedSessionTerminalTools = sessionTerminalTools
+)

--- a/pkg/apifrontend/agent/root.go
+++ b/pkg/apifrontend/agent/root.go
@@ -147,6 +147,9 @@ func buildToolList(cfg AgentConfig) ([]tool.Tool, error) {
 		if err != nil {
 			return nil, fmt.Errorf("creating tool %q: %w", c.name, err)
 		}
+		if !cfg.InteractiveEnabled && tools.SessionDependentTools[t.Name()] {
+			continue
+		}
 		result = append(result, t)
 	}
 

--- a/pkg/apifrontend/agent/root_test.go
+++ b/pkg/apifrontend/agent/root_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
 	sessionpkg "github.com/jordigilh/kubernaut/pkg/apifrontend/session"
+	toolspkg "github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
 )
 
 // newMockToolContext returns a minimal tool.Context with a specific
@@ -738,6 +739,37 @@ var _ = Describe("Root Agent", func() {
 			Expect(err).NotTo(HaveOccurred())
 			Expect(a).NotTo(BeNil())
 		})
+	})
+})
+
+var _ = Describe("Conditional tool registration — interactive mode (#1366)", func() {
+
+	It("UT-AF-1366-010: InteractiveEnabled=false excludes session-dependent tools", func() {
+		cfg := agentpkg.DefaultTestConfig()
+		cfg.InteractiveEnabled = false
+		_, tools, err := agentpkg.NewRootAgent(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tools).To(HaveLen(15), "only 15 stateless tools when interactive disabled (await_session is MCP-only)")
+
+		for _, t := range tools {
+			Expect(toolspkg.SessionDependentTools).NotTo(HaveKey(t.Name()),
+				"session-dependent tool %q should not be registered when interactive disabled", t.Name())
+		}
+	})
+
+	It("UT-AF-1366-011: InteractiveEnabled=true registers all 24 tools", func() {
+		cfg := agentpkg.DefaultTestConfig()
+		cfg.InteractiveEnabled = true
+		_, tools, err := agentpkg.NewRootAgent(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tools).To(HaveLen(24), "all 24 tools when interactive enabled")
+	})
+
+	It("UT-AF-1366-012: default config (InteractiveEnabled zero-value) registers all 24 tools", func() {
+		cfg := agentpkg.DefaultTestConfig()
+		_, tools, err := agentpkg.NewRootAgent(cfg)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(tools).To(HaveLen(24), "backward compat: zero-value InteractiveEnabled means all tools")
 	})
 })
 

--- a/pkg/apifrontend/agent/root_test.go
+++ b/pkg/apifrontend/agent/root_test.go
@@ -773,6 +773,24 @@ var _ = Describe("Conditional tool registration — interactive mode (#1366)", f
 	})
 })
 
+var _ = Describe("Phase guard / SessionDependentTools consistency (#1366 F6)", func() {
+
+	It("UT-AF-1366-040: every phase-guard tool is in SessionDependentTools", func() {
+		for name := range agentpkg.ExportedMCPDependentTools {
+			Expect(toolspkg.SessionDependentTools).To(HaveKey(name),
+				"mcpDependentTools has %q but SessionDependentTools does not — drift detected", name)
+		}
+		for name := range agentpkg.ExportedDriverEntryTools {
+			Expect(toolspkg.SessionDependentTools).To(HaveKey(name),
+				"driverEntryTools has %q but SessionDependentTools does not — drift detected", name)
+		}
+		for name := range agentpkg.ExportedSessionTerminalTools {
+			Expect(toolspkg.SessionDependentTools).To(HaveKey(name),
+				"sessionTerminalTools has %q but SessionDependentTools does not — drift detected", name)
+		}
+	})
+})
+
 type spyAuditEmitter struct {
 	events []*audit.Event
 }

--- a/pkg/apifrontend/config/config.go
+++ b/pkg/apifrontend/config/config.go
@@ -30,6 +30,15 @@ type Config struct {
 	RBAC           RBACConfig           `yaml:"rbac"`
 	SeverityTriage SeverityTriageConfig `yaml:"severityTriage"`
 	Session        SessionConfig        `yaml:"session"`
+	Interactive    InteractiveConfig    `yaml:"interactive"`
+}
+
+// InteractiveConfig controls whether session-dependent MCP tools are registered.
+// When Enabled=false, tools that require a KA interactive session (e.g.
+// kubernaut_investigate, kubernaut_message) are hidden from MCP enumeration
+// and the A2A agent tool list (#1366).
+type InteractiveConfig struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 // SessionConfig holds InvestigationSession CRD controller settings.
@@ -283,6 +292,9 @@ func DefaultConfig() *Config {
 		},
 		RBAC: RBACConfig{
 			SARCacheTTL: 30 * time.Second,
+		},
+		Interactive: InteractiveConfig{
+			Enabled: true,
 		},
 	}
 }

--- a/pkg/apifrontend/config/config_test.go
+++ b/pkg/apifrontend/config/config_test.go
@@ -1263,3 +1263,47 @@ auth:
 		Expect(cfg.Auth.IssuerURL).To(Equal("https://sso.example.com/realms/kubernaut"))
 	})
 })
+
+var _ = Describe("Interactive config (#1366)", func() {
+
+	It("UT-AF-1366-004: DefaultConfig sets interactive.enabled to true", func() {
+		cfg := config.DefaultConfig()
+		Expect(cfg.Interactive.Enabled).To(BeTrue(),
+			"interactive.enabled must default to true for backward compatibility")
+	})
+
+	It("UT-AF-1366-005: Load parses interactive.enabled from YAML", func() {
+		data := []byte(`
+server:
+  port: 8443
+  metricsPort: 9090
+  healthPort: 8081
+agent:
+  kaBaseURL: "http://localhost:8080"
+  kaMCPEndpoint: "http://localhost:8080/api/v1/mcp/"
+  dsBaseURL: "http://localhost:9090"
+interactive:
+  enabled: false
+`)
+		cfg, err := config.Load(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Interactive.Enabled).To(BeFalse())
+	})
+
+	It("UT-AF-1366-006: Load without interactive section defaults to enabled=true", func() {
+		data := []byte(`
+server:
+  port: 8443
+  metricsPort: 9090
+  healthPort: 8081
+agent:
+  kaBaseURL: "http://localhost:8080"
+  kaMCPEndpoint: "http://localhost:8080/api/v1/mcp/"
+  dsBaseURL: "http://localhost:9090"
+`)
+		cfg, err := config.Load(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Interactive.Enabled).To(BeTrue(),
+			"omitting interactive section should default to enabled=true")
+	})
+})

--- a/pkg/apifrontend/handler/agentcard.go
+++ b/pkg/apifrontend/handler/agentcard.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/audit"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/requestid"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
 )
 
 // AgentSkill represents a skill in the agent card.
@@ -135,14 +136,18 @@ func WithAgentCardAudit(h http.Handler, auditor audit.Emitter) http.Handler {
 }
 
 // DefaultAgentSkills returns the agent skills corresponding to the MCP tools.
-func DefaultAgentSkills() []AgentSkill {
-	skills := make([]AgentSkill, len(mcpToolRegistry))
-	for i, t := range mcpToolRegistry {
-		skills[i] = AgentSkill{
+// When interactiveEnabled is false, session-dependent tools are excluded (#1366).
+func DefaultAgentSkills(interactiveEnabled bool) []AgentSkill {
+	skills := make([]AgentSkill, 0, len(mcpToolRegistry))
+	for _, t := range mcpToolRegistry {
+		if !interactiveEnabled && tools.SessionDependentTools[t.Name] {
+			continue
+		}
+		skills = append(skills, AgentSkill{
 			ID:          t.Name,
 			Name:        t.Name,
 			Description: t.Description,
-		}
+		})
 	}
 	return skills
 }

--- a/pkg/apifrontend/handler/agentcard_test.go
+++ b/pkg/apifrontend/handler/agentcard_test.go
@@ -125,7 +125,7 @@ var _ = Describe("Agent Card Handler", func() {
 			Name:    "kubernaut-apifrontend",
 			URL:     "https://kubernaut.example.com",
 			Version: "0.1.0",
-			Skills:  handler.DefaultAgentSkills(),
+			Skills:  handler.DefaultAgentSkills(true),
 		})
 		Expect(err).NotTo(HaveOccurred())
 
@@ -312,3 +312,30 @@ func (s *spyAuditor) Events() []*audit.Event {
 	copy(cp, s.events)
 	return cp
 }
+
+var _ = Describe("DefaultAgentSkills interactive filtering (#1366)", func() {
+
+	It("UT-AF-1366-020: DefaultAgentSkills(false) returns only stateless skills", func() {
+		skills := handler.DefaultAgentSkills(false)
+		Expect(skills).To(HaveLen(11), "only 11 stateless skills when interactive disabled")
+		for _, s := range skills {
+			Expect(s.ID).NotTo(BeElementOf(
+				"kubernaut_investigate",
+				"kubernaut_discover_workflows",
+				"kubernaut_select_workflow",
+				"kubernaut_present_decision",
+				"kubernaut_message",
+				"kubernaut_complete",
+				"kubernaut_cancel",
+				"kubernaut_status",
+				"kubernaut_reconnect",
+				"kubernaut_await_session",
+			), "session-dependent skill %q should be hidden when interactive disabled", s.ID)
+		}
+	})
+
+	It("UT-AF-1366-021: DefaultAgentSkills(true) returns all 21 skills", func() {
+		skills := handler.DefaultAgentSkills(true)
+		Expect(skills).To(HaveLen(21), "all 21 skills when interactive enabled")
+	})
+})

--- a/pkg/apifrontend/handler/mcp.go
+++ b/pkg/apifrontend/handler/mcp.go
@@ -12,6 +12,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/audit"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/httputil"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
 )
 
 // MCPToolDef defines a tool to be registered with the MCP server.
@@ -34,6 +35,9 @@ type MCPConfig struct {
 	Bridge *MCPBridgeConfig
 	// SessionTimeout configures idle session auto-close duration.
 	SessionTimeout time.Duration
+	// InteractiveEnabled controls tool filtering in the stub path. When Bridge
+	// is non-nil, InteractiveEnabled is read from Bridge.InteractiveEnabled instead.
+	InteractiveEnabled bool
 }
 
 func (c MCPConfig) validate() error { //nolint:gocritic // hugeParam: value copy intentional for validation
@@ -70,7 +74,8 @@ func NewMCPHandler(cfg MCPConfig) (http.Handler, error) { //nolint:gocritic // h
 	if cfg.Bridge != nil {
 		RegisterTools(srv, cfg.Bridge)
 	} else {
-		registerStubTools(srv, cfg)
+		interactiveEnabled := cfg.InteractiveEnabled
+		registerStubTools(srv, cfg, interactiveEnabled)
 	}
 
 	opts := &mcp.StreamableHTTPOptions{}
@@ -109,13 +114,13 @@ func NewMCPHandler(cfg MCPConfig) (http.Handler, error) { //nolint:gocritic // h
 	return h, nil
 }
 
-func registerStubTools(srv *mcp.Server, cfg MCPConfig) { //nolint:gocritic // hugeParam: called once at startup
-	tools := cfg.Tools
-	if tools == nil {
-		tools = DefaultMCPTools()
+func registerStubTools(srv *mcp.Server, cfg MCPConfig, interactiveEnabled bool) { //nolint:gocritic // hugeParam: called once at startup
+	defs := cfg.Tools
+	if defs == nil {
+		defs = DefaultMCPTools(interactiveEnabled)
 	}
 
-	for _, t := range tools {
+	for _, t := range defs {
 		toolDef := &mcp.Tool{
 			Name:        t.Name,
 			Description: t.Description,
@@ -148,22 +153,26 @@ func registerStubTools(srv *mcp.Server, cfg MCPConfig) { //nolint:gocritic // hu
 	}
 }
 
-// DefaultMCPTools returns the 20 MCP tool definitions as stub descriptors.
+// DefaultMCPTools returns the MCP tool definitions as stub descriptors.
+// When interactiveEnabled is false, session-dependent tools are excluded (#1366).
 // When Bridge is configured, RegisterTools registers real handlers with
 // SDK-derived input schemas; these stubs serve only the fallback/dev path.
-func DefaultMCPTools() []MCPToolDef {
+func DefaultMCPTools(interactiveEnabled bool) []MCPToolDef {
 	objectSchema := map[string]any{
 		"type":       "object",
 		"properties": map[string]any{},
 	}
 
-	result := make([]MCPToolDef, len(mcpToolRegistry))
-	for i, t := range mcpToolRegistry {
-		result[i] = MCPToolDef{
+	result := make([]MCPToolDef, 0, len(mcpToolRegistry))
+	for _, t := range mcpToolRegistry {
+		if !interactiveEnabled && tools.SessionDependentTools[t.Name] {
+			continue
+		}
+		result = append(result, MCPToolDef{
 			Name:        t.Name,
 			Description: t.Description,
 			InputSchema: objectSchema,
-		}
+		})
 	}
 	return result
 }

--- a/pkg/apifrontend/handler/mcp_bridge.go
+++ b/pkg/apifrontend/handler/mcp_bridge.go
@@ -63,6 +63,9 @@ type MCPBridgeConfig struct {
 	UserLimiter        *ratelimit.UserLimiter
 	SessionFinalizer    ISPhaseFinalizer
 	SessionInitializer  ISSessionInitializer
+	// InteractiveEnabled controls whether session-dependent tools are registered.
+	// When false, tools in tools.SessionDependentTools are skipped (#1366).
+	InteractiveEnabled bool
 }
 
 // MCPBridgeMetrics holds Prometheus collectors specific to MCP bridge operations.
@@ -99,6 +102,8 @@ func (c *MCPBridgeConfig) GetMaxConcurrentTools() int64 {
 }
 
 // RegisterTools registers all MCP domain tools on the server with the real dispatch handlers.
+// When cfg.InteractiveEnabled is false, session-dependent tools (those in
+// tools.SessionDependentTools) are skipped (#1366).
 func RegisterTools(srv *mcp.Server, cfg *MCPBridgeConfig) {
 	if cfg == nil {
 		panic("RegisterTools: cfg must not be nil")
@@ -110,6 +115,17 @@ func RegisterTools(srv *mcp.Server, cfg *MCPBridgeConfig) {
 		cfg.Logger = logr.Discard()
 	}
 	sem := semaphore.NewWeighted(cfg.GetMaxConcurrentTools())
+
+	shouldRegister := func(name string) bool {
+		if cfg.InteractiveEnabled {
+			return true
+		}
+		if tools.SessionDependentTools[name] {
+			cfg.Logger.Info("skipping session-dependent tool (interactive disabled)", "tool", name)
+			return false
+		}
+		return true
+	}
 
 	// K8s CRD tools (ADR-022: all use AF's ServiceAccount)
 	// Namespace is always injected server-side — never exposed to LLM.
@@ -156,51 +172,60 @@ func RegisterTools(srv *mcp.Server, cfg *MCPBridgeConfig) {
 			return tools.HandleWatch(ctx, cfg.K8sClient, args)
 		})
 
-	registerTool(srv, cfg, sem, "kubernaut_await_session", "Wait for KA investigation session to become ready",
-		func(ctx context.Context, args tools.AwaitSessionArgs) (any, error) {
-			args.Namespace = cfg.Namespace
-			return tools.HandleAwaitSession(ctx, cfg.K8sClient, args)
-		})
+	if shouldRegister("kubernaut_await_session") {
+		registerTool(srv, cfg, sem, "kubernaut_await_session", "Wait for KA investigation session to become ready",
+			func(ctx context.Context, args tools.AwaitSessionArgs) (any, error) {
+				args.Namespace = cfg.Namespace
+				return tools.HandleAwaitSession(ctx, cfg.K8sClient, args)
+			})
+	}
 
 	// KA investigation tool (MCP-only, non-blocking).
 	// Uses KADedicatedClient (SDKMCPClient) which creates dedicated non-pooled
 	// sessions for StartInvestigation. PooledMCPClient does not support StartInvestigation.
-	dedicatedClient := cfg.KADedicatedClient
-	if dedicatedClient == nil {
-		dedicatedClient = cfg.KAMCPClient
+	if shouldRegister("kubernaut_investigate") {
+		dedicatedClient := cfg.KADedicatedClient
+		if dedicatedClient == nil {
+			dedicatedClient = cfg.KAMCPClient
+		}
+		isSignaler := buildISSignaler(cfg)
+		var onInvestigateStarted tools.SessionStartedHook
+		if isSignaler == nil {
+			onInvestigateStarted = buildSessionStartedHook(cfg)
+		}
+		registerTool(srv, cfg, sem, "kubernaut_investigate", "Investigate an infrastructure incident",
+			func(ctx context.Context, args tools.InvestigateMCPArgs) (any, error) {
+				return tools.HandleInvestigationMCPWithRegistry(ctx, dedicatedClient, cfg.K8sClient, cfg.Namespace, args, cfg.Auditor, cfg.InvestigationRegistry, onInvestigateStarted, false, nil, "", isSignaler, cfg.Triager)
+			})
 	}
-	isSignaler := buildISSignaler(cfg)
-	var onInvestigateStarted tools.SessionStartedHook
-	if isSignaler == nil {
-		onInvestigateStarted = buildSessionStartedHook(cfg)
-	}
-	registerTool(srv, cfg, sem, "kubernaut_investigate", "Investigate an infrastructure incident",
-		func(ctx context.Context, args tools.InvestigateMCPArgs) (any, error) {
-			return tools.HandleInvestigationMCPWithRegistry(ctx, dedicatedClient, cfg.K8sClient, cfg.Namespace, args, cfg.Auditor, cfg.InvestigationRegistry, onInvestigateStarted, false, nil, "", isSignaler, cfg.Triager)
-		})
 
 	// KA MCP tools
-	registerTool(srv, cfg, sem, "kubernaut_select_workflow", "Select a workflow for an investigation",
-		func(ctx context.Context, args tools.SelectWorkflowArgs) (any, error) {
-			return tools.HandleSelectWorkflow(ctx, cfg.KAMCPClient, args, cfg.Auditor)
-		})
+	if shouldRegister("kubernaut_select_workflow") {
+		registerTool(srv, cfg, sem, "kubernaut_select_workflow", "Select a workflow for an investigation",
+			func(ctx context.Context, args tools.SelectWorkflowArgs) (any, error) {
+				return tools.HandleSelectWorkflow(ctx, cfg.KAMCPClient, args, cfg.Auditor)
+			})
+	}
 
-	registerTool(srv, cfg, sem, "kubernaut_discover_workflows", "Discover available workflows with parameter schemas",
-		func(ctx context.Context, args tools.DiscoverWorkflowsArgs) (any, error) {
-			result, err := tools.HandleDiscoverWorkflows(ctx, cfg.KAMCPClient, args)
-			if err != nil {
-				return result, err
-			}
-			emitAudit(ctx, cfg, "kubernaut_discover_workflows", audit.EventWorkflowDiscovery,
-				map[string]string{"workflow_count": strconv.Itoa(result.Count)})
-			return result, nil
-		})
+	if shouldRegister("kubernaut_discover_workflows") {
+		registerTool(srv, cfg, sem, "kubernaut_discover_workflows", "Discover available workflows with parameter schemas",
+			func(ctx context.Context, args tools.DiscoverWorkflowsArgs) (any, error) {
+				result, err := tools.HandleDiscoverWorkflows(ctx, cfg.KAMCPClient, args)
+				if err != nil {
+					return result, err
+				}
+				emitAudit(ctx, cfg, "kubernaut_discover_workflows", audit.EventWorkflowDiscovery,
+					map[string]string{"workflow_count": strconv.Itoa(result.Count)})
+				return result, nil
+			})
+	}
 
-	// Presentation tool (no backend dependency)
-	registerTool(srv, cfg, sem, "kubernaut_present_decision", "Present a decision point requiring user input",
-		func(_ context.Context, args tools.PresentDecisionArgs) (any, error) {
-			return tools.HandlePresentDecision(args), nil
-		})
+	if shouldRegister("kubernaut_present_decision") {
+		registerTool(srv, cfg, sem, "kubernaut_present_decision", "Present a decision point requiring user input",
+			func(_ context.Context, args tools.PresentDecisionArgs) (any, error) {
+				return tools.HandlePresentDecision(args), nil
+			})
+	}
 
 	// DS tools
 	registerTool(srv, cfg, sem, "kubernaut_list_workflows", "List available workflows",
@@ -236,42 +261,52 @@ func RegisterTools(srv *mcp.Server, cfg *MCPBridgeConfig) {
 		})
 
 	// Interactive investigation tools (G1: 4-phase journey)
-	registerTool(srv, cfg, sem, "kubernaut_message", "Send a message to an active investigation session",
-		func(ctx context.Context, args tools.InteractiveActionArgs) (any, error) {
-			return tools.HandleMessage(ctx, cfg.KAMCPClient, args, cfg.Auditor)
-		})
+	if shouldRegister("kubernaut_message") {
+		registerTool(srv, cfg, sem, "kubernaut_message", "Send a message to an active investigation session",
+			func(ctx context.Context, args tools.InteractiveActionArgs) (any, error) {
+				return tools.HandleMessage(ctx, cfg.KAMCPClient, args, cfg.Auditor)
+			})
+	}
 
-	registerTool(srv, cfg, sem, "kubernaut_complete", "Complete an investigation session",
-		func(ctx context.Context, args tools.InteractiveActionArgs) (any, error) {
-			result, err := tools.HandleComplete(ctx, cfg.KAMCPClient, args, cfg.Auditor)
-			if err == nil && cfg.SessionFinalizer != nil {
-				if fErr := cfg.SessionFinalizer.FinalizeSessionByRR(ctx, cfg.Namespace, args.RRID, isv1alpha1.SessionPhaseCompleted); fErr != nil {
-					cfg.Logger.Error(fErr, "IS CRD phase finalization failed", "rr_id", args.RRID, "phase", "Completed")
+	if shouldRegister("kubernaut_complete") {
+		registerTool(srv, cfg, sem, "kubernaut_complete", "Complete an investigation session",
+			func(ctx context.Context, args tools.InteractiveActionArgs) (any, error) {
+				result, err := tools.HandleComplete(ctx, cfg.KAMCPClient, args, cfg.Auditor)
+				if err == nil && cfg.SessionFinalizer != nil {
+					if fErr := cfg.SessionFinalizer.FinalizeSessionByRR(ctx, cfg.Namespace, args.RRID, isv1alpha1.SessionPhaseCompleted); fErr != nil {
+						cfg.Logger.Error(fErr, "IS CRD phase finalization failed", "rr_id", args.RRID, "phase", "Completed")
+					}
 				}
-			}
-			return result, err
-		})
+				return result, err
+			})
+	}
 
-	registerTool(srv, cfg, sem, "kubernaut_cancel", "Cancel an active investigation session",
-		func(ctx context.Context, args tools.InteractiveActionArgs) (any, error) {
-			result, err := tools.HandleCancel(ctx, cfg.KAMCPClient, args, cfg.Auditor)
-			if err == nil && cfg.SessionFinalizer != nil {
-				if fErr := cfg.SessionFinalizer.FinalizeSessionByRR(ctx, cfg.Namespace, args.RRID, isv1alpha1.SessionPhaseCancelled); fErr != nil {
-					cfg.Logger.Error(fErr, "IS CRD phase finalization failed", "rr_id", args.RRID, "phase", "Cancelled")
+	if shouldRegister("kubernaut_cancel") {
+		registerTool(srv, cfg, sem, "kubernaut_cancel", "Cancel an active investigation session",
+			func(ctx context.Context, args tools.InteractiveActionArgs) (any, error) {
+				result, err := tools.HandleCancel(ctx, cfg.KAMCPClient, args, cfg.Auditor)
+				if err == nil && cfg.SessionFinalizer != nil {
+					if fErr := cfg.SessionFinalizer.FinalizeSessionByRR(ctx, cfg.Namespace, args.RRID, isv1alpha1.SessionPhaseCancelled); fErr != nil {
+						cfg.Logger.Error(fErr, "IS CRD phase finalization failed", "rr_id", args.RRID, "phase", "Cancelled")
+					}
 				}
-			}
-			return result, err
-		})
+				return result, err
+			})
+	}
 
-	registerTool(srv, cfg, sem, "kubernaut_status", "Get the current status of an investigation session",
-		func(ctx context.Context, args tools.InteractiveActionArgs) (any, error) {
-			return tools.HandleStatus(ctx, cfg.KAMCPClient, args, cfg.Auditor)
-		})
+	if shouldRegister("kubernaut_status") {
+		registerTool(srv, cfg, sem, "kubernaut_status", "Get the current status of an investigation session",
+			func(ctx context.Context, args tools.InteractiveActionArgs) (any, error) {
+				return tools.HandleStatus(ctx, cfg.KAMCPClient, args, cfg.Auditor)
+			})
+	}
 
-	registerTool(srv, cfg, sem, "kubernaut_reconnect", "Reconnect to a disconnected investigation session",
-		func(ctx context.Context, args tools.InteractiveActionArgs) (any, error) {
-			return tools.HandleReconnect(ctx, cfg.KAMCPClient, args, cfg.Auditor)
-		})
+	if shouldRegister("kubernaut_reconnect") {
+		registerTool(srv, cfg, sem, "kubernaut_reconnect", "Reconnect to a disconnected investigation session",
+			func(ctx context.Context, args tools.InteractiveActionArgs) (any, error) {
+				return tools.HandleReconnect(ctx, cfg.KAMCPClient, args, cfg.Auditor)
+			})
+	}
 
 	// Stream investigation tool removed — merged into kubernaut_investigate above.
 

--- a/pkg/apifrontend/handler/mcp_bridge_integration_test.go
+++ b/pkg/apifrontend/handler/mcp_bridge_integration_test.go
@@ -65,6 +65,7 @@ var _ = Describe("MCP Bridge Integration (httptest backends)", func() {
 				Metrics:            newBridgeMetrics(),
 				ToolTimeout:        5 * time.Second,
 				MaxConcurrentTools: 10,
+				InteractiveEnabled: true,
 			},
 		}
 
@@ -424,6 +425,7 @@ var _ = Describe("MCP Bridge Integration (httptest backends)", func() {
 					Metrics:            newBridgeMetrics(),
 					ToolTimeout:        5 * time.Second,
 					MaxConcurrentTools: 10,
+					InteractiveEnabled: true,
 				},
 			}
 
@@ -499,6 +501,7 @@ var _ = Describe("MCP Bridge Integration (httptest backends)", func() {
 					Metrics:            newBridgeMetrics(),
 					ToolTimeout:        5 * time.Second,
 					MaxConcurrentTools: 10,
+					InteractiveEnabled: true,
 				},
 			}
 
@@ -540,6 +543,7 @@ var _ = Describe("MCP Bridge Integration (httptest backends)", func() {
 					ToolTimeout:        5 * time.Second,
 					MaxConcurrentTools: 10,
 					SessionInitializer: recorder,
+					InteractiveEnabled: true,
 				},
 			}
 
@@ -599,6 +603,7 @@ var _ = Describe("MCP Bridge Integration (httptest backends)", func() {
 					Namespace:          "kubernaut-system",
 					ToolTimeout:        5 * time.Second,
 					MaxConcurrentTools: 10,
+					InteractiveEnabled: true,
 				},
 			}
 

--- a/pkg/apifrontend/handler/mcp_bridge_test.go
+++ b/pkg/apifrontend/handler/mcp_bridge_test.go
@@ -488,6 +488,7 @@ var _ = Describe("MCP Bridge - Tier 1: Core Dispatch", Label("tier1", "bridge"),
 				Auditor:            auditor,
 				ToolTimeout:        5 * time.Second,
 				MaxConcurrentTools: 10,
+				InteractiveEnabled: true,
 			},
 		}
 		var err error
@@ -514,6 +515,72 @@ var _ = Describe("MCP Bridge - Tier 1: Core Dispatch", Label("tier1", "bridge"),
 			body := rec.Body.String()
 			count := countToolsInResponse(body)
 			Expect(count).To(Equal(21))
+		})
+	})
+
+	Context("Conditional tool registration — interactive mode (#1366)", func() {
+		It("IT-BRIDGE-1366-001: InteractiveEnabled=false registers only 11 stateless tools", func() {
+			cfg := handler.MCPConfig{
+				ServerName:    "kubernaut-apifrontend",
+				ServerVersion: "v0.1.0-test",
+				Enabled:       true,
+				Bridge: &handler.MCPBridgeConfig{
+					K8sClient:          fakeK8s,
+					Namespace:          "default",
+					KAMCPClient:        &ka.MockMCPClient{},
+					DSClient:           newFakeDSClient(),
+					Authorizer:         &allowAllAuthorizer{},
+					Auditor:            auditor,
+					ToolTimeout:        2 * time.Second,
+					InteractiveEnabled: false,
+				},
+			}
+			localH, err := handler.NewMCPHandler(cfg)
+			Expect(err).NotTo(HaveOccurred())
+			localSess := mcpInitialize(localH, testUser)
+
+			listReq := map[string]any{
+				"jsonrpc": "2.0",
+				"id":      3,
+				"method":  "tools/list",
+				"params":  map[string]any{},
+			}
+			rec := mcpPost(localH, localSess, listReq, testUser)
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			count := countToolsInResponse(rec.Body.String())
+			Expect(count).To(Equal(11), "only 11 stateless tools when interactive disabled")
+		})
+
+		It("IT-BRIDGE-1366-002: InteractiveEnabled=true registers all 21 tools", func() {
+			cfg := handler.MCPConfig{
+				ServerName:    "kubernaut-apifrontend",
+				ServerVersion: "v0.1.0-test",
+				Enabled:       true,
+				Bridge: &handler.MCPBridgeConfig{
+					K8sClient:          fakeK8s,
+					Namespace:          "default",
+					KAMCPClient:        &ka.MockMCPClient{},
+					DSClient:           newFakeDSClient(),
+					Authorizer:         &allowAllAuthorizer{},
+					Auditor:            auditor,
+					ToolTimeout:        2 * time.Second,
+					InteractiveEnabled: true,
+				},
+			}
+			localH, err := handler.NewMCPHandler(cfg)
+			Expect(err).NotTo(HaveOccurred())
+			localSess := mcpInitialize(localH, testUser)
+
+			listReq := map[string]any{
+				"jsonrpc": "2.0",
+				"id":      3,
+				"method":  "tools/list",
+				"params":  map[string]any{},
+			}
+			rec := mcpPost(localH, localSess, listReq, testUser)
+			Expect(rec.Code).To(Equal(http.StatusOK))
+			count := countToolsInResponse(rec.Body.String())
+			Expect(count).To(Equal(21), "all 21 tools when interactive enabled")
 		})
 	})
 
@@ -983,13 +1050,13 @@ var _ = Describe("MCP Bridge - Tier 2: Security", Label("tier2", "bridge"), func
 				ServerVersion: "v0.1.0-test",
 				Enabled:       true,
 				Bridge: &handler.MCPBridgeConfig{
-					K8sClient:         fakeK8s,
-					Namespace:         "default",
-
+					K8sClient:          fakeK8s,
+					Namespace:          "default",
 					Authorizer:         &mapAuthorizer{roles: map[string][]string{"sre": {"*"}}},
 					Auditor:            auditor,
 					ToolTimeout:        2 * time.Second,
 					MaxConcurrentTools: 5,
+					InteractiveEnabled: true,
 				},
 			}
 			h, err := handler.NewMCPHandler(cfg)
@@ -2193,14 +2260,15 @@ var _ = Describe("MCP Bridge - discover_workflows (#1176)", Label("bridge", "dis
 			ServerVersion: "v0.1.0-test",
 			Enabled:       true,
 			Bridge: &handler.MCPBridgeConfig{
-				K8sClient:         fakeK8s,
-				Namespace:         "default",
+				K8sClient:          fakeK8s,
+				Namespace:          "default",
 				KAMCPClient:        mockMCP,
 				DSClient:           newFakeDSClient(),
 				Authorizer:         &mapAuthorizer{roles: roles},
 				Auditor:            auditor,
 				ToolTimeout:        5 * time.Second,
 				MaxConcurrentTools: 10,
+				InteractiveEnabled: true,
 			},
 		}
 		h, err := handler.NewMCPHandler(cfg)
@@ -2405,8 +2473,8 @@ var _ = Describe("MCP Bridge - Metrics Wiring", Label("metrics", "wiring"), func
 			ServerVersion: "v0.1.0-test",
 			Enabled:       true,
 			Bridge: &handler.MCPBridgeConfig{
-				K8sClient:         fakeK8s,
-				Namespace:         "default",
+				K8sClient:          fakeK8s,
+				Namespace:          "default",
 				KAMCPClient:        mockMCP,
 				DSClient:           newFakeDSClient(),
 				Authorizer:         &mapAuthorizer{roles: map[string][]string{"sre": {"*"}, "cicd": {"kubernaut_list_remediations"}}},
@@ -2414,6 +2482,7 @@ var _ = Describe("MCP Bridge - Metrics Wiring", Label("metrics", "wiring"), func
 				Metrics:            bridgeMetrics,
 				ToolTimeout:        5 * time.Second,
 				MaxConcurrentTools: 10,
+				InteractiveEnabled: true,
 			},
 		}
 		var err error

--- a/pkg/apifrontend/handler/mcp_conformance_test.go
+++ b/pkg/apifrontend/handler/mcp_conformance_test.go
@@ -39,7 +39,7 @@ var _ = Describe("MCP Protocol Conformance", func() {
 		mcpHandler, err = handler.NewMCPHandler(handler.MCPConfig{
 			ServerName:    "kubernaut-apifrontend",
 			ServerVersion: "v0.1.0",
-			Tools:         handler.DefaultMCPTools(),
+			Tools:         handler.DefaultMCPTools(true),
 			Enabled:       true,
 		})
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/apifrontend/handler/mcp_test.go
+++ b/pkg/apifrontend/handler/mcp_test.go
@@ -1,6 +1,7 @@
 package handler_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/handler"
+	toolspkg "github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
 )
 
 var _ = Describe("MCP Handler", func() {
@@ -76,7 +78,7 @@ var _ = Describe("MCP Handler", func() {
 		toolHandler, err := handler.NewMCPHandler(handler.MCPConfig{
 			ServerName:    "kubernaut-apifrontend",
 			ServerVersion: "v0.1.0",
-			Tools:         handler.DefaultMCPTools(),
+			Tools:         handler.DefaultMCPTools(true),
 			Enabled:       true,
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -84,7 +86,7 @@ var _ = Describe("MCP Handler", func() {
 	})
 
 	It("UT-AF-220-005: tools registered include kubernaut_ or af_ prefix", func() {
-		tools := handler.DefaultMCPTools()
+		tools := handler.DefaultMCPTools(true)
 		for _, t := range tools {
 			hasValid := strings.HasPrefix(t.Name, "kubernaut_") || strings.HasPrefix(t.Name, "af_")
 			Expect(hasValid).To(BeTrue(), "tool %q missing kubernaut_ or af_ prefix", t.Name)
@@ -92,8 +94,82 @@ var _ = Describe("MCP Handler", func() {
 	})
 
 	It("UT-AF-220-006: tools count matches 21 expected tools (#1332: kubernaut_takeover removed)", func() {
-		tools := handler.DefaultMCPTools()
+		tools := handler.DefaultMCPTools(true)
 		Expect(tools).To(HaveLen(21))
+	})
+
+	It("UT-AF-1366-030: DefaultMCPTools(false) returns only stateless tools", func() {
+		tools := handler.DefaultMCPTools(false)
+		Expect(tools).To(HaveLen(11), "only 11 stateless tools when interactive disabled")
+		for _, t := range tools {
+			Expect(toolspkg.SessionDependentTools).NotTo(HaveKey(t.Name),
+				"session-dependent tool %q should be hidden in stub path", t.Name)
+		}
+	})
+
+	It("UT-AF-1366-031: stub path registers only stateless tools when InteractiveEnabled=false", func() {
+		h, err := handler.NewMCPHandler(handler.MCPConfig{
+			ServerName:    "kubernaut-apifrontend",
+			ServerVersion: "v0.1.0-test",
+			Enabled:       true,
+			InteractiveEnabled: false,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		rec := httptest.NewRecorder()
+		initReq := map[string]any{
+			"jsonrpc": "2.0", "id": 1,
+			"method": "initialize",
+			"params": map[string]any{
+				"protocolVersion": "2025-03-26",
+				"capabilities":    map[string]any{},
+				"clientInfo":      map[string]any{"name": "test", "version": "1.0"},
+			},
+		}
+		body, _ := json.Marshal(initReq)
+		req := httptest.NewRequest("POST", "/mcp", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
+		h.ServeHTTP(rec, req)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+		sid := rec.Header().Get("Mcp-Session-Id")
+
+		listReq := map[string]any{
+			"jsonrpc": "2.0", "id": 2,
+			"method": "tools/list",
+			"params": map[string]any{},
+		}
+		body, _ = json.Marshal(listReq)
+		rec2 := httptest.NewRecorder()
+		req2 := httptest.NewRequest("POST", "/mcp", bytes.NewReader(body))
+		req2.Header.Set("Content-Type", "application/json")
+		req2.Header.Set("Accept", "application/json, text/event-stream")
+		req2.Header.Set("Mcp-Session-Id", sid)
+		h.ServeHTTP(rec2, req2)
+		Expect(rec2.Code).To(Equal(http.StatusOK))
+
+		responseBody := rec2.Body.String()
+		Expect(responseBody).NotTo(BeEmpty(), "tools/list response should not be empty")
+
+		jsonPayload := responseBody
+		if strings.Contains(responseBody, "data: ") {
+			for _, line := range strings.Split(responseBody, "\n") {
+				if strings.HasPrefix(line, "data: ") {
+					jsonPayload = strings.TrimPrefix(line, "data: ")
+					break
+				}
+			}
+		}
+
+		var result map[string]any
+		err = json.Unmarshal([]byte(jsonPayload), &result)
+		Expect(err).NotTo(HaveOccurred(), "response should be valid JSON")
+		Expect(result).To(HaveKey("result"))
+		resultObj, ok := result["result"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		registeredTools, ok := resultObj["tools"].([]any)
+		Expect(ok).To(BeTrue())
+		Expect(registeredTools).To(HaveLen(11), "stub path should only register 11 stateless tools")
 	})
 
 	It("UT-AF-220-007: MCP server info includes correct name and version", func() {
@@ -124,7 +200,7 @@ var _ = Describe("MCP Handler", func() {
 	})
 
 	It("UT-AF-220-009: each tool has non-empty description", func() {
-		tools := handler.DefaultMCPTools()
+		tools := handler.DefaultMCPTools(true)
 		for _, t := range tools {
 			Expect(t.Description).NotTo(BeEmpty(), "tool %s missing description", t.Name)
 		}
@@ -144,7 +220,7 @@ var _ = Describe("MCP Handler", func() {
 	})
 
 	It("UT-AF-220-011: each tool has input schema", func() {
-		tools := handler.DefaultMCPTools()
+		tools := handler.DefaultMCPTools(true)
 		for _, t := range tools {
 			Expect(t.InputSchema).NotTo(BeNil(), "tool %s missing input schema", t.Name)
 		}

--- a/pkg/apifrontend/tools/tool_categories.go
+++ b/pkg/apifrontend/tools/tool_categories.go
@@ -1,0 +1,26 @@
+package tools
+
+// SessionDependentTools lists MCP tool names that require KA interactive mode.
+// When interactive mode is disabled in the AF config, these tools should not be
+// registered at the MCP protocol level or in the A2A agent tool list.
+//
+// Classification rationale:
+//   - investigate, discover_workflows, select_workflow, message, complete, cancel,
+//     status, reconnect: require an active KA MCP session
+//   - present_decision: pure formatter but only meaningful during investigations
+//   - await_session: polls for KA session readiness
+//
+// See also: phase_guard.go (mcpDependentTools, driverEntryTools) for the A2A
+// runtime ordering constraint, which is orthogonal to registration filtering.
+var SessionDependentTools = map[string]bool{
+	"kubernaut_investigate":        true,
+	"kubernaut_discover_workflows": true,
+	"kubernaut_select_workflow":    true,
+	"kubernaut_present_decision":   true,
+	"kubernaut_message":            true,
+	"kubernaut_complete":           true,
+	"kubernaut_cancel":             true,
+	"kubernaut_status":             true,
+	"kubernaut_reconnect":          true,
+	"kubernaut_await_session":      true,
+}

--- a/pkg/apifrontend/tools/tool_categories_test.go
+++ b/pkg/apifrontend/tools/tool_categories_test.go
@@ -1,0 +1,56 @@
+package tools_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+)
+
+var _ = Describe("SessionDependentTools (#1366)", func() {
+
+	expectedSessionTools := []string{
+		"kubernaut_investigate",
+		"kubernaut_discover_workflows",
+		"kubernaut_select_workflow",
+		"kubernaut_present_decision",
+		"kubernaut_message",
+		"kubernaut_complete",
+		"kubernaut_cancel",
+		"kubernaut_status",
+		"kubernaut_reconnect",
+		"kubernaut_await_session",
+	}
+
+	expectedStatelessTools := []string{
+		"kubernaut_list_remediations",
+		"kubernaut_get_remediation",
+		"kubernaut_list_approval_requests",
+		"kubernaut_get_approval_request",
+		"kubernaut_approve",
+		"kubernaut_cancel_remediation",
+		"kubernaut_watch",
+		"kubernaut_list_workflows",
+		"kubernaut_get_remediation_history",
+		"kubernaut_get_effectiveness",
+		"kubernaut_get_audit_trail",
+	}
+
+	It("UT-AF-1366-001: contains exactly 10 session-dependent tools", func() {
+		Expect(tools.SessionDependentTools).To(HaveLen(10))
+	})
+
+	It("UT-AF-1366-002: all expected session-dependent tools are present", func() {
+		for _, name := range expectedSessionTools {
+			Expect(tools.SessionDependentTools).To(HaveKey(name),
+				"expected session-dependent tool %q to be in SessionDependentTools", name)
+		}
+	})
+
+	It("UT-AF-1366-003: stateless tools are NOT in SessionDependentTools", func() {
+		for _, name := range expectedStatelessTools {
+			Expect(tools.SessionDependentTools).NotTo(HaveKey(name),
+				"stateless tool %q should NOT be in SessionDependentTools", name)
+		}
+	})
+})


### PR DESCRIPTION
## Summary

- When AF config sets `interactive.enabled: false`, 10 session-dependent MCP tools are hidden from MCP tool registration, A2A agent tool list, and agent card skills
- Prevents confusing "session not found" errors when KA does not have interactive mode enabled
- New `InteractiveConfig` section in AF config (defaults to `enabled: true` for backward compatibility)

**Closes #1366**

### Components added/modified

| Component | Production Entry Point | Wiring Code Location |
|-----------|----------------------|---------------------|
| `SessionDependentTools` | `RegisterTools()` filter | `handler/mcp_bridge.go` |
| `SessionDependentTools` | `buildToolList()` filter | `agent/root.go` |
| `InteractiveConfig` | `loadConfig()` | `config/config.go` |
| `MCPBridgeConfig.InteractiveEnabled` | `buildMCPHandler()` | `cmd/apifrontend/main.go` |
| `AgentConfig.InteractiveEnabled` | `buildA2AHandler()` | `cmd/apifrontend/main.go` |
| `DefaultAgentSkills(interactive)` | `NewAgentCardHandler()` | `handler/agentcard.go` |

## Test plan

- [x] UT-AF-1366-001..003: SessionDependentTools contains exactly 10 tools, validates membership
- [x] UT-AF-1366-004..006: Config defaults interactive.enabled=true, parses from YAML
- [x] UT-AF-1366-010..012: buildToolList returns 15/24 tools based on InteractiveEnabled
- [x] UT-AF-1366-020..021: DefaultAgentSkills returns 11/21 skills based on flag
- [x] IT-BRIDGE-1366-001..002: RegisterTools via MCP protocol returns 11/21 tools
- [x] All 22 existing AF test packages pass (no regressions)

Made with [Cursor](https://cursor.com)