### PR TITLE
fix(ka): session handoff broken at workflow discovery (#1384)

### DIFF
--- a/api/aianalysis/v1alpha1/aianalysis_types.go
+++ b/api/aianalysis/v1alpha1/aianalysis_types.go
@@ -523,6 +523,12 @@ type KASession struct {
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	PollCount int32 `json:"pollCount,omitempty"`
+	// ConsecutiveGetResultErrors tracks consecutive 409 errors from GetSessionResult.
+	// #1390: After 3 consecutive 409s, the session is regenerated to break the polling loop.
+	// Reset to 0 on any successful GetSessionResult call.
+	// +kubebuilder:validation:Minimum=0
+	// +optional
+	ConsecutiveGetResultErrors int32 `json:"consecutiveGetResultErrors,omitempty"`
 }
 
 // InteractiveSessionInfo tracks the dynamic takeover session for MCP interactive mode.

--- a/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
@@ -759,6 +759,14 @@ spec:
                   ========================================
                   KASession tracks the async KA session for submit/poll pattern
                 properties:
+                  consecutiveGetResultErrors:
+                    description: |-
+                      ConsecutiveGetResultErrors tracks consecutive 409 errors from GetSessionResult.
+                      #1390: After 3 consecutive 409s, the session is regenerated to break the polling loop.
+                      Reset to 0 on any successful GetSessionResult call.
+                    format: int32
+                    minimum: 0
+                    type: integer
                   createdAt:
                     description: CreatedAt timestamp when the current session was
                       created

--- a/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
@@ -759,6 +759,14 @@ spec:
                   ========================================
                   KASession tracks the async KA session for submit/poll pattern
                 properties:
+                  consecutiveGetResultErrors:
+                    description: |-
+                      ConsecutiveGetResultErrors tracks consecutive 409 errors from GetSessionResult.
+                      #1390: After 3 consecutive 409s, the session is regenerated to break the polling loop.
+                      Reset to 0 on any successful GetSessionResult call.
+                    format: int32
+                    minimum: 0
+                    type: integer
                   createdAt:
                     description: CreatedAt timestamp when the current session was
                       created

--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -535,9 +535,19 @@ func buildBackendDeps(ctx context.Context, cfg *config.Config, metricsReg *metri
 		Transport: kaMCPAuth,
 		Timeout:   cfg.Resilience.KA.RequestTimeout,
 	}
+	// #1386: Separate HTTP client for long-lived MCP sessions (SSE streams).
+	// Go's http.Client.Timeout is a deadline on the entire response including
+	// body reads. For persistent SSE connections, the 30s timeout kills the
+	// stream after idle periods, causing "session not found" on next tool call.
+	// The MCP SDK manages session lifecycle via context cancellation and
+	// session.Close(); no global timeout is needed.
+	kaMCPStreamClient := &http.Client{
+		Transport: kaMCPAuth,
+	}
 	mcpClient := ka.NewSDKMCPClient(
 		cfg.Agent.KAMCPEndpoint,
 		kaMCPHTTPClient,
+		kaMCPStreamClient,
 		logger,
 	)
 	mcpClient.WithDownstreamDuration(metricsReg.DownstreamDuration)
@@ -551,7 +561,7 @@ func buildBackendDeps(ctx context.Context, cfg *config.Config, metricsReg *metri
 		Factory: func(ctx context.Context) (ka.PoolSession, error) {
 			transport := &mcp.StreamableClientTransport{
 				Endpoint:   kaMCPEndpoint,
-				HTTPClient: kaMCPHTTPClient,
+				HTTPClient: kaMCPStreamClient,
 			}
 			return mcpClient.ConnectSession(ctx, transport)
 		},

--- a/cmd/apifrontend/main_wiring_test.go
+++ b/cmd/apifrontend/main_wiring_test.go
@@ -895,7 +895,7 @@ func (m *mockPoolSession) Close() error { return nil }
 func TestSDKMCPClient_DownstreamDurationWired(t *testing.T) {
 	t.Parallel()
 	reg := metrics.NewRegistry()
-	mcpClient := ka.NewSDKMCPClient("http://localhost:0", &http.Client{}, logr.Discard())
+	mcpClient := ka.NewSDKMCPClient("http://localhost:0", &http.Client{}, nil, logr.Discard())
 	result := mcpClient.WithDownstreamDuration(reg.DownstreamDuration)
 	if result == nil {
 		t.Fatal("IT-AF-1234-W12: WithDownstreamDuration must return the client")

--- a/cmd/apifrontend/main_wiring_test.go
+++ b/cmd/apifrontend/main_wiring_test.go
@@ -886,7 +886,8 @@ type mockPoolSession struct{}
 func (m *mockPoolSession) CallTool(_ context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
 	return nil, nil
 }
-func (m *mockPoolSession) Close() error { return nil }
+func (m *mockPoolSession) Ping(_ context.Context, _ *mcp.PingParams) error { return nil }
+func (m *mockPoolSession) Close() error                                     { return nil }
 
 // ---------------------------------------------------------------------------
 // IT-AF-1234-W12: WithDownstreamDuration wired on SDKMCPClient

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -1409,12 +1409,22 @@ func buildMCPHandler(
 	}
 	toolDeps.CompleteNoAction = mcptools.CompleteNoActionRegistration(completeNoActionTool, logger)
 
+	mcpKeepAlive := cfg.Interactive.MCPKeepAlive
+	if mcpKeepAlive == 0 {
+		mcpKeepAlive = kaconfig.DefaultMCPKeepAlive
+	}
+	mcpSessionTimeout := cfg.Interactive.MCPSessionTimeout
+	if mcpSessionTimeout == 0 {
+		mcpSessionTimeout = kaconfig.DefaultMCPSessionTimeout
+	}
 	mcpHandler, _ := mcpkg.BootstrapMCP(mcpkg.MCPDeps{
 		AuthMiddleware: func(next http.Handler) http.Handler {
 			return kaserver.AuditAuthMiddleware(authMw.Handler(next), auditStore, logger)
 		},
 		Tools:          toolDeps,
 		EventStore:     eventStore,
+		KeepAlive:      mcpKeepAlive,
+		SessionTimeout: mcpSessionTimeout,
 	})
 
 	drainer := mcpkg.NewSessionDrainer(leaseMgr, sessionNotifier, logger.WithName("session-drainer"))

--- a/config/crd/bases/kubernaut.ai_aianalyses.yaml
+++ b/config/crd/bases/kubernaut.ai_aianalyses.yaml
@@ -759,6 +759,14 @@ spec:
                   ========================================
                   KASession tracks the async KA session for submit/poll pattern
                 properties:
+                  consecutiveGetResultErrors:
+                    description: |-
+                      ConsecutiveGetResultErrors tracks consecutive 409 errors from GetSessionResult.
+                      #1390: After 3 consecutive 409s, the session is regenerated to break the polling loop.
+                      Reset to 0 on any successful GetSessionResult call.
+                    format: int32
+                    minimum: 0
+                    type: integer
                   createdAt:
                     description: CreatedAt timestamp when the current session was
                       created

--- a/docs/tests/1384/TEST_PLAN.md
+++ b/docs/tests/1384/TEST_PLAN.md
@@ -1,0 +1,167 @@
+# IEEE 829 Test Plan — Fix #1384: Session Handoff Broken at Workflow Discovery
+
+| Field                | Value                                                    |
+|----------------------|----------------------------------------------------------|
+| **Test Plan ID**     | TP-KA-1384                                               |
+| **Revision**         | 1.0                                                      |
+| **Author**           | Kubernaut AI Agent                                       |
+| **Date**             | 2026-06-09                                               |
+| **Status**           | Active                                                   |
+| **Business Req**     | BR-INTERACTIVE-010, BR-AUDIT-005, BR-RBAC-005            |
+| **FedRAMP Controls** | AU-2, AU-3, AU-6, SI-10, CP-10                           |
+
+## 1. Introduction
+
+This test plan covers the verification of fixes for GitHub issue #1384, which
+describes two bugs in Kubernaut Agent (KA) interactive session management:
+
+- **Bug A**: `handleDiscoverWorkflows` passes an un-enriched MCP context to
+  `RunWorkflowDiscovery`, causing workflow discovery to run with an empty
+  `session_id` and nil event sink. Results are detached from the investigation
+  session.
+
+- **Bug B**: `turnsToReconMessages` copies all conversation turns—including
+  those with empty `Content` from tool-call-only LLM responses—into the
+  reconstruction prompt. The Vertex AI client creates `NewTextBlock("")` for
+  these, triggering a 400 error.
+
+## 2. Scope
+
+### In Scope
+
+| Area                           | Description                                         |
+|--------------------------------|-----------------------------------------------------|
+| Session context propagation    | `session_id` + `LazySink` wired into workflow disc. |
+| Reconstruction empty filter    | `turnsToReconMessages` skips empty `Content` turns  |
+| Vertex client defense-in-depth | `buildParams` skips empty text blocks for assistant  |
+| Session result bridge          | `CompleteHTTPSession` receives workflow result       |
+
+### Out of Scope
+
+- MCP transport layer (WebSocket/SSE framing)
+- AA polling and scheduling
+- AF session management (upstream consumer)
+- E2E tests (existing E2E suite covers the full interactive flow)
+
+## 3. Business Requirements Traceability
+
+| BR                         | Description                                                     | Violated By |
+|----------------------------|-----------------------------------------------------------------|-------------|
+| BR-INTERACTIVE-010 SC-2   | Session tracks investigation through all phases                 | Bug A       |
+| BR-INTERACTIVE-010 SC-3   | Context reconstruction from audit trail                         | Bug B       |
+| BR-AUDIT-005 v2.0 (AU-2)  | All phases emit audit events with correlation IDs               | Bug A       |
+| BR-RBAC-005               | Session state preserved across investigation phases             | Bug A       |
+
+## 4. FedRAMP / SOC2 Control Verification
+
+Tests verify **business-level behavior** tied to each control objective.
+
+### AU-2 / AU-3 — Audit Generation / Content of Audit Records
+
+**Business behavior**: An auditor querying DS audit events by `session_id` MUST
+trace the full investigation lifecycle (RCA → workflow_discovery → selection).
+Bug A breaks this by emitting audit events with empty `session_id`.
+
+**Tests**: UT-KA-1384-A01, IT-KA-1384-001, IT-KA-1384-004
+
+### AU-6 — Audit Review, Analysis, and Reporting
+
+**Business behavior**: After MCP disconnect, KA reconstructs session context from
+DS audit events. The reconstructed prompt MUST be valid for the LLM API.
+Bug B sends empty text blocks, causing 400 errors and total context loss.
+
+**Tests**: UT-KA-1384-B01, UT-KA-1384-B02, IT-KA-1384-003
+
+### SI-10 — Information Input Validation
+
+**Business behavior**: KA MUST NOT send malformed content to external LLM
+providers. Empty text blocks waste API quota and prevent investigation continuity.
+
+**Tests**: UT-KA-1384-B03, UT-KA-1384-B04
+
+### CP-10 — Information System Recovery
+
+**Business behavior**: After MCP transport failure, the system recovers session
+context and allows investigation continuation without losing prior work.
+
+**Tests**: IT-KA-1384-003, IT-KA-1384-004
+
+## 5. Test Tiers and Coverage Targets
+
+| Tier              | Testable Code                                                | Target |
+|-------------------|--------------------------------------------------------------|--------|
+| Unit Tests        | `turnsToReconMessages`, `buildParams` empty-block handling   | ≥80%   |
+| Integration Tests | `handleDiscoverWorkflows` wiring, `SpawnReconstruct` chain   | ≥80%   |
+| E2E               | Full interactive flow (covered by existing suite)            | N/A    |
+
+## 6. Wiring Manifest (Pyramid Invariant)
+
+> UT proves logic. IT proves wiring. E2E proves the journey.
+
+| Component                    | Production Entry Point                      | Wiring Location          | UT (logic)            | IT (wiring)       |
+|------------------------------|--------------------------------------------|--------------------------|-----------------------|-------------------|
+| Session context propagation  | `handleDiscoverWorkflows` → `RunWorkflow`  | `investigate.go:~866`    | UT-KA-1384-A01..A04  | IT-KA-1384-001    |
+| Empty turn filter            | `SpawnReconstruct` → `turnsToReconMessages`| `reconstruct.go:~107`    | UT-KA-1384-B01,B02,B05,B06 | IT-KA-1384-003 |
+| Empty text block guard       | `vertexanthropic.Chat/StreamChat`          | `client.go:~232`         | UT-KA-1384-B03,B04   | IT-KA-1384-005    |
+| Session result bridge        | `select_workflow` → `CompleteHTTPSession`  | `session_teardown.go`    | UT-KA-1384-A05        | IT-KA-1384-002    |
+
+## 7. Unit Test Scenarios
+
+### Bug A — AU-2/AU-3, BR-INTERACTIVE-010 SC-2
+
+| ID              | Business Behavior Verified                                                              | Acceptance Criteria                                                  |
+|-----------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------|
+| UT-KA-1384-A01  | Session context propagated → workflow_discovery streams events (session continuity)     | `chatOrStream` uses streaming; `session_id` in log is non-empty      |
+| UT-KA-1384-A02  | Without session context → graceful degradation (non-streaming fallback)                 | `chatOrStream` falls back to Chat; session_id logged as empty        |
+| UT-KA-1384-A03  | Investigation events reach SSE subscriber during workflow_discovery                     | Event delivered to sink channel within 100ms                         |
+| UT-KA-1384-A04  | Missing subscriber does not block or crash the investigation loop                       | No panic, no channel send, event silently dropped                    |
+| UT-KA-1384-A05  | `buildFinalResult` merges RCA + workflow discovery into single result for AA            | Output has both `RCASummary` and `WorkflowID` populated              |
+
+### Bug B — AU-6, SI-10, CP-10
+
+| ID              | Business Behavior Verified                                                              | Acceptance Criteria                                                  |
+|-----------------|-----------------------------------------------------------------------------------------|----------------------------------------------------------------------|
+| UT-KA-1384-B01  | Reconstruction produces valid LLM prompt with no empty content blocks (SI-10)          | Zero messages with `Content == ""`                                   |
+| UT-KA-1384-B02  | Reconstruction preserves all meaningful conversation context (CP-10)                    | All non-empty turns retained in chronological order                  |
+| UT-KA-1384-B03  | LLM client never sends empty text blocks to Vertex AI (SI-10 defense-in-depth)         | Empty Content + no ToolCalls → NO text block                         |
+| UT-KA-1384-B04  | LLM client correctly sends non-empty assistant text (no over-filtering)                 | Text block present with correct content                              |
+| UT-KA-1384-B05  | All-empty audit history → nil reconstruction (CP-10 graceful degradation)               | Returns nil, not empty slice                                         |
+| UT-KA-1384-B06  | Nil input to reconstruction handled safely (defensive coding)                           | Returns nil, no panic                                                |
+
+## 8. Integration Test Scenarios
+
+| ID              | Business Behavior Verified                                          | FedRAMP    | Acceptance Criteria                                                                  |
+|-----------------|---------------------------------------------------------------------|------------|--------------------------------------------------------------------------------------|
+| IT-KA-1384-001  | Workflow discovery audit events traceable to session                | AU-2/AU-3  | `chatOrStream` logs non-empty `session_id`; audit events have `correlation_id`       |
+| IT-KA-1384-002  | Workflow result flows to HTTP session for AA polling                | BR-INT-010 | After discover+select, `CompleteUserDriving` receives result with `WorkflowID != ""` |
+| IT-KA-1384-003  | Reconstruction succeeds despite tool-call-only audit turns          | AU-6, CP-10| `SpawnReconstruct` delivers ONLY non-empty messages; no LLM 400                      |
+| IT-KA-1384-004  | End-to-end: discover → select → HTTP complete chain                | CP-10      | Full chain; AA poll returns result with workflow ID + parameters                     |
+| IT-KA-1384-005  | Reconstruction path never sends empty text blocks to LLM client    | SI-10      | Mock LLM captures request; zero empty text blocks after full path                    |
+
+## 9. TDD Execution Phases
+
+| Phase | Description                                                       | Tests                          |
+|-------|-------------------------------------------------------------------|--------------------------------|
+| 1     | RED (Bug B): Write failing UTs + ITs for reconstruction           | B01-B06, IT-003, IT-005        |
+| 2     | GREEN (Bug B): Implement empty-content filter + defense-in-depth  | All B* + IT-003/005 pass       |
+| 3     | RED (Bug A): Write failing UTs + ITs for session propagation      | A01-A05, IT-001, IT-002        |
+| 4     | GREEN (Bug A): Wire session_id + LazySink                        | All A* + IT-001/002 pass       |
+| 5     | RED (Wiring Chain): Write IT-004 end-to-end                      | IT-004 fails                   |
+| 6     | GREEN (Wiring Chain): Remaining wiring for IT-004                 | IT-004 passes                  |
+| 7     | REFACTOR: 100-go-mistakes review, extract shared filter           | All tests remain green         |
+
+## 10. Checkpoints
+
+| Checkpoint | Gate                                                                         |
+|------------|------------------------------------------------------------------------------|
+| CP-1       | Bug B GA audit: build clean, lint clean, Bug B UTs + ITs pass, no regressions|
+| CP-2       | Bug A GA audit: all A + B tests pass, session_id propagation verified        |
+| CP-3       | Final GA audit: ≥80% per-tier coverage, FedRAMP, wiring manifest, lint       |
+
+## 11. Risk Assessment
+
+| Risk                                          | Severity | Mitigation                              |
+|-----------------------------------------------|----------|-----------------------------------------|
+| `FindUserDrivingByRemediationID` missing      | Medium   | Verify interface before Phase 4         |
+| `GetLazySink` not exposed on session manager  | Medium   | Add accessor if needed                  |
+| Reconstruction test depends on DS mock fidelity| Low     | Use existing `mockAuditQuerier` pattern |

--- a/docs/tests/1390/TEST_PLAN.md
+++ b/docs/tests/1390/TEST_PLAN.md
@@ -1,0 +1,367 @@
+# IEEE 829 Test Plan — Fix #1390: Jump-In Session Upgrade + Defense-in-Depth
+
+| Field                | Value                                                                              |
+|----------------------|------------------------------------------------------------------------------------|
+| **Test Plan ID**     | TP-1390                                                                            |
+| **Revision**         | 1.0                                                                                |
+| **Author**           | Kubernaut AI Agent                                                                 |
+| **Date**             | 2026-06-09                                                                         |
+| **Status**           | Active                                                                             |
+| **Business Req**     | BR-INTERACTIVE-004, BR-INTERACTIVE-005, BR-INTERACTIVE-010, BR-SESSION-002, BR-REL-014, BR-ORCH-027, BR-MCP-002, BR-AUDIT-005 |
+| **FedRAMP Controls** | SC-24, SI-10, SI-13, AC-12, AU-12, SC-8, SI-4                                     |
+
+## 1. Introduction
+
+This test plan covers the verification of fixes for GitHub issue #1390, which
+describes two production failure modes in the AA-KA session lifecycle:
+
+- **Bug A (20-minute 409 loop)**: AA polls `GET /result` on a completed session
+  with `nil` result; KA returns 409 Conflict; AA treats it as transient and
+  retries indefinitely (violates BR-ORCH-027, BR-SESSION-002).
+
+- **Bug B (Wasteful cancel+recreate)**: When an InvestigationSession (IS) CRD
+  appears after an autonomous submit, AA cancels the running KA session and
+  re-submits with `interactive=true`, discarding in-flight RCA work and wasting
+  LLM tokens (violates BR-INTERACTIVE-004 efficiency).
+
+Fix approach: "Jump In" upgrades autonomous sessions to interactive in-place via
+an `atomic.Bool` flag on the Session struct, plus defense-in-depth nil-result
+handling and AA retry cap.
+
+## 2. Scope
+
+### In Scope
+
+| Area                              | Description                                                     |
+|-----------------------------------|-----------------------------------------------------------------|
+| KA session manager                | `UpgradeToInteractive`, `interactiveUpgrade` atomic flag        |
+| KA store deterministic upgrade    | `store.Update` checks flag under mu for race-free guarantee     |
+| KA context helpers                | `WithInteractiveUpgrade`, `InteractiveUpgradeFromContext`       |
+| KA investigator                   | `InteractiveHold` decision respects runtime upgrade flag        |
+| KA MCP tools                      | `handleStart` wiring + EventLogBridge activation for upgrade    |
+| AA InvestigatingHandler           | Takeover simplification (no cancel), `SetActivePhase` call      |
+| KA HTTP handler                   | Structured result for nil-result completed/failed/cancelled     |
+| AA retry cap                      | `ConsecutiveGetResultErrors` counter, caps at 3                 |
+| Session ID context propagation    | Autonomous path carries session_id for audit trail              |
+| E2E upgrade journey               | Full pipeline: AA -> IS -> MCP -> upgrade -> result             |
+| E2E nil-result resilience         | Timeout -> nil result -> structured 200 -> AA terminal          |
+
+### Out of Scope
+
+- AF session service (upstream consumer, no changes)
+- MCP transport layer (WebSocket/SSE framing)
+- LLM provider integrations
+- BR-INTERACTIVE-010 SC-1 wording update (docs-only, separate PR)
+
+## 3. Business Requirements Traceability
+
+| BR                    | Description                                                         | Violated By |
+|-----------------------|---------------------------------------------------------------------|-------------|
+| BR-SESSION-002        | Session store accurately reflects terminal state + result on query  | Bug A       |
+| BR-ORCH-027           | All remediations MUST reach terminal state                          | Bug A       |
+| BR-INTERACTIVE-004    | Dynamic takeover preserves in-flight work                           | Bug B       |
+| BR-INTERACTIVE-005    | Session lifecycle (timeout, inactivity, disconnect)                 | Bug A       |
+| BR-INTERACTIVE-010    | IS-driven interactive flow, AA poll handling                        | Bug B       |
+| BR-REL-014            | Idempotent operations for retry scenarios                           | Bug A       |
+| BR-MCP-002            | `start_autonomous` idempotency when investigation running           | Bug B       |
+| BR-AUDIT-005          | Enterprise audit integrity; session lifecycle auditable             | Bug A, B    |
+
+## 4. FedRAMP / NIST 800-53 Rev 5 Control Verification
+
+Tests verify **business-level behavior** tied to each control objective.
+
+### SC-24 -- Fail in Known State
+
+**Business behavior**: A completed session MUST always be pollable with a
+deterministic result. A nil-result completed session must return a structured
+"completed without result" response, not an error loop. The store-level upgrade
+guarantee ensures sessions deterministically reach `user_driving` when upgraded.
+
+**Tests**: UT-KA-1390-007, UT-KA-1390-018..021, UT-KA-1390-027..029, IT-KA-1390-W01, IT-KA-1390-W02, IT-KA-1390-W05, E2E-KA-1390-001
+
+### SI-10 -- Information Input Validation / Deduplication
+
+**Business behavior**: `UpgradeToInteractive` MUST validate session state before
+modifying. Terminal and non-existent sessions MUST be rejected with appropriate
+errors.
+
+**Tests**: UT-KA-1390-003, UT-KA-1390-004
+
+### SI-13 -- Predictable Failure Prevention
+
+**Business behavior**: AA MUST NOT retry indefinitely on data-integrity errors.
+After N consecutive 409s on GetResult, AA triggers session regeneration to break
+the loop.
+
+**Tests**: UT-AA-1390-022..024, E2E-KA-1390-001
+
+### AC-12 -- Session Termination
+
+**Business behavior**: Every investigation MUST reach a terminal AA phase. AA
+takeover MUST NOT leave sessions in limbo. The upgrade path MUST preserve session
+reachability through all state transitions.
+
+**Tests**: UT-AA-1390-014..017, IT-AA-1390-W04, E2E-FP-1390-001
+
+### AU-12 -- Audit Record Generation
+
+**Business behavior**: All session lifecycle events (upgrade, nil-result
+synthesis, completion) MUST be auditable. `session_id` MUST appear in all
+LLM/audit logs for forensic traceability.
+
+**Tests**: UT-KA-1390-002, UT-KA-1390-021, UT-KA-1390-025..026
+
+### SC-8 -- Transmission / Session Integrity
+
+**Business behavior**: Session identity (`session_id`) MUST be propagated through
+the investigation context. Ghost `session_id:""` events violate audit chain
+integrity.
+
+**Tests**: UT-KA-1390-025, UT-KA-1390-026
+
+### SI-4 -- System Monitoring / Event Streaming
+
+**Business behavior**: After upgrade, the EventLogBridge MUST stream investigation
+events to the MCP client. LazySink activation MUST be picked up by the running
+goroutine on its next event emission.
+
+**Tests**: UT-KA-1390-008, UT-KA-1390-009, UT-KA-1390-013, IT-KA-1390-W03
+
+## 5. Test Tiers and Coverage Targets
+
+| Tier              | Testable Code                                                       | Target |
+|-------------------|---------------------------------------------------------------------|--------|
+| Unit Tests        | Session manager, store, investigator, HTTP handler, AA handlers     | >=80%  |
+| Integration Tests | HTTP dispatch, session wiring, controller reconcile, EventLogBridge | >=80%  |
+| E2E Tests         | Full pipeline upgrade journey, nil-result resilience journey        | >=80%  |
+
+## 6. Wiring Manifest (Pyramid Invariant)
+
+> UT proves logic. IT proves wiring. E2E proves the journey.
+
+| Component                      | Production Entry Point                      | Wiring Location              | UT (logic)               | IT/E2E (wiring)       |
+|--------------------------------|---------------------------------------------|------------------------------|--------------------------|----------------------|
+| `UpgradeToInteractive`         | `handleStart` in `investigate.go:~424`      | `manager.go`                 | UT-KA-1390-001..004      | IT-KA-1390-W01       |
+| `interactiveUpgrade` flag      | `launchInvestigation` context               | `manager.go:~161`            | UT-KA-1390-005..009      | IT-KA-1390-W01       |
+| Store deterministic upgrade    | `store.Update` flag check under mu          | `store.go:~241`              | UT-KA-1390-027..029      | IT-KA-1390-W01       |
+| Investigator upgrade check     | `Investigate()` line 519                    | `investigator.go`            | UT-KA-1390-010..011      | IT-KA-1390-W01       |
+| `handleStart` wiring + bridge  | `InvestigateRegistration`                   | `investigate.go + reg.go`    | UT-KA-1390-012..013      | IT-KA-1390-W03       |
+| AA takeover simplification     | `checkISMismatchAndCancel`                  | `investigating.go:~407`      | UT-AA-1390-014..017      | IT-AA-1390-W04       |
+| Nil-result structured response | `GetResult` handler                         | `handler.go:~249`            | UT-KA-1390-018..021      | IT-KA-1390-W02       |
+| AA 409 retry cap               | `handleSessionGetResultError`               | `investigating.go:~921`      | UT-AA-1390-022..024      | E2E-KA-1390-001      |
+| session_id propagation         | `launchInvestigation` context               | `manager.go`                 | UT-KA-1390-025..026      | E2E-FP-1390-001      |
+| Upgrade journey (cross-svc)    | AA + KA + MCP + IS CRD                      | Full pipeline                | --                       | E2E-FP-1390-001      |
+| Nil-result resilience journey  | KA timeout + AA poll                        | KA + AA                      | --                       | E2E-KA-1390-001      |
+
+## 7. Unit Test Scenarios
+
+### Layer 1: KA Session Upgrade Mechanism
+
+| ID              | FedRAMP | Business Behavior Verified                                                                  | Acceptance Criteria                                                              |
+|-----------------|---------|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
+| UT-KA-1390-001  | SC-24   | `UpgradeToInteractive` sets atomic flag on running session without cancelling goroutine      | `interactiveUpgrade.Load()==true`, cancel not called, `Status==StatusRunning`     |
+| UT-KA-1390-002  | AU-12   | `UpgradeToInteractive` writes acting_user and acting_user_groups to session metadata         | `Metadata["acting_user"]=="testuser"`, groups JSON matches                       |
+| UT-KA-1390-003  | SI-10   | `UpgradeToInteractive` on terminal session returns `ErrSessionTerminal`                      | Error is `ErrSessionTerminal`, no state change                                   |
+| UT-KA-1390-004  | SI-10   | `UpgradeToInteractive` on non-existent session returns `ErrSessionNotFound`                  | Error is `ErrSessionNotFound`                                                    |
+| UT-KA-1390-005  | SC-24   | `InteractiveUpgradeFromContext` returns false when no flag in context                        | Returns false, no panic                                                          |
+| UT-KA-1390-006  | SC-24   | `InteractiveUpgradeFromContext` reads true after `Store(true)` on atomic                     | Returns true after concurrent Set                                                |
+| UT-KA-1390-007  | SC-24   | Goroutine with upgrade flag stores result via `Update(running->user_driving)`                | `Status==StatusUserDriving`, `Result!=nil`, `Result.InteractiveHold==true`        |
+| UT-KA-1390-008  | SI-4    | Event channel stays open after upgrade + InteractiveHold completion                          | `eventChan` not nil, not closed                                                  |
+| UT-KA-1390-009  | SI-4    | LazySink activation post-upgrade delivers events to subscriber                               | Event arrives on channel within 100ms                                            |
+
+### Layer 1: Store-Level Deterministic Upgrade
+
+| ID              | FedRAMP | Business Behavior Verified                                                                  | Acceptance Criteria                                                              |
+|-----------------|---------|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
+| UT-KA-1390-027  | SC-24   | `store.Update(StatusCompleted)` + `interactiveUpgrade=true` forces `StatusUserDriving`       | `Status==StatusUserDriving`, `InteractiveHold==true`, result preserved            |
+| UT-KA-1390-028  | SC-24   | `store.Update(StatusCompleted)` + `interactiveUpgrade=false` remains `StatusCompleted`       | `Status==StatusCompleted`, `InteractiveHold` unchanged                           |
+| UT-KA-1390-029  | SC-24   | `UpgradeToInteractive` after `Update(completed)` returns `ErrSessionTerminal`                | Error is `ErrSessionTerminal`, fallback to `ForceTransitionToUserDriving`         |
+
+### Layer 1c: Investigator
+
+| ID              | FedRAMP | Business Behavior Verified                                                                  | Acceptance Criteria                                                              |
+|-----------------|---------|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
+| UT-KA-1390-010  | SC-24   | Investigator sets `InteractiveHold=true` when upgrade flag is true + `signal.Interactive=false` | Result has `InteractiveHold==true`, Phase 2/3 skipped                           |
+| UT-KA-1390-011  | SC-24   | Investigator still respects `signal.Interactive=true` (no regression)                         | Same behavior as before for originally-interactive sessions                      |
+
+### Layer 1d: MCP Wiring
+
+| ID              | FedRAMP | Business Behavior Verified                                                                  | Acceptance Criteria                                                              |
+|-----------------|---------|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
+| UT-KA-1390-012  | SC-24   | `handleStart` calls `UpgradeToInteractive` (not `TransitionToUserDriving`) for running       | Mock `UpgradeToInteractive` called once, `TransitionToUserDriving` not called    |
+| UT-KA-1390-013  | SI-4    | `handleStart` sets `InvestigationSessionID` for running sessions (enables EventLogBridge)    | `output.InvestigationSessionID != ""`                                            |
+
+### Layer 2: AA Takeover Simplification
+
+| ID              | FedRAMP | Business Behavior Verified                                                                  | Acceptance Criteria                                                              |
+|-----------------|---------|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
+| UT-AA-1390-014  | AC-12   | Takeover branch sets `Interactive=true` without calling `CancelSession`                      | `cancelCount==0`, `session.Interactive==true`                                    |
+| UT-AA-1390-015  | AC-12   | Takeover branch calls `SetActivePhase` on IS phase updater                                   | `SetActivePhaseCallCount==1`                                                     |
+| UT-AA-1390-016  | AC-12   | Next reconcile with `hasIS=true` + `Interactive=true` skips mismatch (no-op)                 | No cancel, no resubmit, returns `RequeueAfter`                                   |
+| UT-AA-1390-017  | AC-12   | Poll `user_driving` after upgrade populates `InteractiveSession` info                        | `InteractiveSession.ActingUser != ""`                                            |
+
+### Layer 3: Nil-Result 409 Loop Fix
+
+| ID              | FedRAMP | Business Behavior Verified                                                                  | Acceptance Criteria                                                              |
+|-----------------|---------|---------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
+| UT-KA-1390-018  | SC-24   | `GetResult` on completed/nil-result returns HTTP 200 + synthetic result                      | Status 200, `summary` present, `isActionable==false`                             |
+| UT-KA-1390-019  | SC-24   | `GetResult` on failed session returns HTTP 200 + error result                                | Status 200, `summary` with failure reason                                        |
+| UT-KA-1390-020  | SC-24   | `GetResult` on cancelled session returns HTTP 200 + cancellation result                      | Status 200, `cancelled==true`                                                    |
+| UT-KA-1390-021  | AU-12   | `GetResult` nil-result synthesis emits log event                                             | Logger captures `"nil_result_synthesized"` with session_id                       |
+| UT-AA-1390-022  | SI-13   | Third consecutive GetResult 409 triggers session regeneration                                | After 3x 409, `session.ID` cleared, `result.Requeue`                            |
+| UT-AA-1390-023  | SI-13   | Successful GetResult resets consecutive error counter                                        | After success, counter is 0                                                      |
+| UT-AA-1390-024  | AC-12   | Regeneration clears session ID and requeues for re-submit                                    | `session.ID==""`, `result.Requeue==true`                                         |
+
+### Layer 4: Observability
+
+| ID              | FedRAMP   | Business Behavior Verified                                                                | Acceptance Criteria                                                              |
+|-----------------|-----------|-------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------|
+| UT-KA-1390-025  | SC-8,AU-12| Autonomous session `bgCtx` carries `session_id` via `WithSessionID`                       | `SessionIDFromContext(bgCtx) != ""`                                              |
+| UT-KA-1390-026  | AU-12     | `UpgradeToInteractive` emits audit event with session_id and acting_user                  | Audit spy captures `EventTypeSessionUpgraded` with correct fields                |
+
+## 8. Integration Test Scenarios
+
+| ID              | FedRAMP | Business Behavior Verified                                          | Acceptance Criteria                                                                     | Location                                       |
+|-----------------|---------|---------------------------------------------------------------------|-----------------------------------------------------------------------------------------|-------------------------------------------------|
+| IT-KA-1390-W01  | SC-24   | Full upgrade flow: autonomous -> upgrade -> InteractiveHold -> result | HTTP poll returns `user_driving`, `result!=nil`, `acting_user` populated                | `test/integration/kubernautagent/session/`      |
+| IT-KA-1390-W02  | SC-24   | Nil-result completed session returns structured result via HTTP      | `GET /result` returns 200 with synthetic body                                           | `test/integration/kubernautagent/`              |
+| IT-KA-1390-W03  | SI-4    | EventLogBridge wired after upgrade; events stream to subscriber      | Events emitted by goroutine arrive on Subscribe channel                                 | `test/integration/kubernautagent/session/`      |
+| IT-AA-1390-W04  | AC-12   | AA takeover without cancel -> polls user_driving -> InteractiveSession | No KA cancel, `Interactive==true`, `InteractiveSession.ActingUser!=""`                  | `test/integration/aianalysis/`                  |
+| IT-KA-1390-W05  | SC-24   | MCP disconnect during upgrade window -> ForceComplete graceful       | Session transitions to `completed`, no panic, no orphan goroutine                       | `test/integration/kubernautagent/session/`      |
+
+## 9. E2E Test Scenarios
+
+| ID              | FedRAMP    | Business Behavior Verified                                                                                | Acceptance Criteria                                                                      | Location                       |
+|-----------------|------------|-----------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------|--------------------------------|
+| E2E-FP-1390-001 | SC-24,AC-12| Upgrade journey: AA autonomous -> IS -> MCP connect -> upgrade -> RCA -> user interacts -> complete        | Full journey, AA terminal, session_id consistent, no cancel                              | `test/e2e/fullpipeline/`       |
+| E2E-KA-1390-001 | SC-24,SI-13| Nil-result resilience: timeout -> complete(nil) -> AA polls -> structured 200 -> AA terminal               | AA exits loop in 2 cycles, no 409, AIAnalysis reaches terminal                           | `test/e2e/kubernautagent/`     |
+
+## 10. Tests Modified (existing)
+
+| Test              | Current Assertion                              | New Assertion                                           |
+|-------------------|------------------------------------------------|---------------------------------------------------------|
+| UT-AA-1293-SC1-005| `cancelCount=1`, `ID=""`                       | `cancelCount=0`, `Interactive=true`, ID preserved       |
+| IT-AA-1293-002    | `GetCancelCallCount() >= 1`                    | No cancel, `Interactive=true`                           |
+| IT-AA-1293-004    | Cancel + resubmit + new ID                     | No cancel, `Interactive=true`, `SetActivePhase` called  |
+| UT-KA-1326-021    | Empty `InvestigationSessionID` for running     | Non-empty `InvestigationSessionID`                      |
+
+## 11. TDD Execution Phases
+
+| Phase | Type     | Scope                                                       | Tests                                                 |
+|-------|----------|-------------------------------------------------------------|-------------------------------------------------------|
+| 1     | RED      | Layer 1: KA session upgrade + store deterministic           | UT 001-013, 027-029; IT W01, W03, W05                 |
+| 2     | GREEN    | Layer 1: Implement store, context, manager, investigator    | All Phase 1 tests pass                                |
+| 3     | REFACTOR | Layer 1: 100-go-mistakes concurrency, lint, race            | All tests remain green                                |
+| 4     | RED      | Layer 2: AA takeover simplification                         | UT 014-017; IT W04                                    |
+| 5     | GREEN    | Layer 2: Implement investigating.go change, update tests    | All Phase 4 + existing tests pass                     |
+| 6     | REFACTOR | Layer 2: 100-go-mistakes error handling, lint               | All tests remain green                                |
+| 7     | RED      | Layer 3: Nil-result 409 loop fix                            | UT 018-024; IT W02                                    |
+| 8     | GREEN    | Layer 3: Implement handler + AA retry cap                   | All Phase 7 tests pass                                |
+| 9     | REFACTOR | Layer 3: DescribeTable, 100-go-mistakes nil handling        | All tests remain green                                |
+| 10    | RED      | Layer 4 + E2E: Observability + journeys                     | UT 025-026; E2E-FP-001, E2E-KA-001                   |
+| 11    | GREEN    | Layer 4 + E2E: session_id propagation, E2E wiring           | All tests pass (E2E requires Kind)                    |
+| 12    | REFACTOR | Final: Full checklist, coverage, lint, race                  | All 36 scenarios green                                |
+
+## 12. Checkpoints
+
+| Checkpoint | Gate                                                                                     |
+|------------|------------------------------------------------------------------------------------------|
+| CP-1       | Post-Layer 1: build, lint, race, wiring (CHECKPOINT W), BDD, test IDs, 100-go-mistakes   |
+| CP-2       | Post-Layer 2: all L1+L2 tests, wiring, BR alignment, updated existing tests green        |
+| CP-3       | Post-Layer 3: all L1-L3, race, nil-result matrix coverage, AA retry cap verified         |
+| CP-4       | Final: all 36 scenarios, >=80%/tier coverage, FedRAMP, wiring manifest, BR traceability  |
+
+## 13. 100 Go Mistakes Validation Checklist
+
+Applied during each TDD REFACTOR phase to both test code and any business code touched.
+
+### Error Management (#48-#54) -- P0
+
+- [ ] #28: Nil vs empty: completed session with nil result vs "no workflow" semantic
+- [ ] #49: Wrap errors with `fmt.Errorf("context: %w", err)` in upgrade/handler paths
+- [ ] #50: Use `errors.Is()` / `errors.As()` not `==` for sentinel errors
+- [ ] #52: Don't log and return same error
+- [ ] #53: Verify all deferred error paths handled
+- [ ] #54: Every error path returns or logs
+
+### Concurrency (#55-#74) -- P0
+
+- [ ] #57: `interactiveUpgrade` uses `atomic.Bool` (lock-free read), upgrade holds mu
+- [ ] #58: Run `-race` on `session/`, `pkg/aianalysis/handlers/` tests
+- [ ] #62: Goroutine stop plan -- upgrade does NOT cancel goroutine; no leak
+- [ ] #63: No loop variable capture in goroutines
+- [ ] #74: No copy of `sync.Mutex` / `atomic.Bool` (pointer-based on Session)
+
+### Channel (#64-#68) -- P1
+
+- [ ] #65: No `defer` in channel receive loops
+- [ ] #67: Buffer sizing -- `eventChannelBuffer = 64` unchanged
+- [ ] #68: Channel close ownership -- only `closeEventChan` closes
+
+### Context (#59-#61) -- P1
+
+- [ ] #60: `WithInteractiveUpgrade` follows `WithLazySink` pattern
+- [ ] #61: `bgCtx` carries `session_id` for all autonomous paths
+
+### Testing (#86-#91) -- P1
+
+- [ ] #87: `-race` flag enabled for all test targets
+- [ ] #89: `DescribeTable` for nil-result matrix
+- [ ] #90: No `time.Sleep` -- use `Eventually()` with polling
+- [ ] #91: `DeferCleanup()` for channel/session cleanup in lifecycle tests
+
+### Interface Design (#5-#8) -- P2
+
+- [ ] #5: No interface pollution -- method on existing `Manager`
+- [ ] #7: Return concrete types from constructors
+
+## 14. Risk Assessment
+
+| Risk                                    | Severity | Mitigation                                                   |
+|-----------------------------------------|----------|--------------------------------------------------------------|
+| Upgrade-completion race                 | Eliminated | Store-level mu serialization (UT-KA-1390-027..029)         |
+| SetActivePhase timing                   | Not new  | Existing K8s dependency; new flow is faster (1 vs 2 cycles) |
+| E2E flakiness                           | Medium   | `Eventually()` with generous timeouts                        |
+| ConsecutiveGetResultErrors CRD field    | Low      | May require API type update; verified in Phase 8             |
+| BR-INTERACTIVE-010 SC-1 wording         | Low      | Docs-only update in separate PR                              |
+
+## 15. Status
+
+| Test ID          | Status  |
+|------------------|---------|
+| UT-KA-1390-001   | Pending |
+| UT-KA-1390-002   | Pending |
+| UT-KA-1390-003   | Pending |
+| UT-KA-1390-004   | Pending |
+| UT-KA-1390-005   | Pending |
+| UT-KA-1390-006   | Pending |
+| UT-KA-1390-007   | Pending |
+| UT-KA-1390-008   | Pending |
+| UT-KA-1390-009   | Pending |
+| UT-KA-1390-010   | Pending |
+| UT-KA-1390-011   | Pending |
+| UT-KA-1390-012   | Pending |
+| UT-KA-1390-013   | Pending |
+| UT-AA-1390-014   | Pending |
+| UT-AA-1390-015   | Pending |
+| UT-AA-1390-016   | Pending |
+| UT-AA-1390-017   | Pending |
+| UT-KA-1390-018   | Pending |
+| UT-KA-1390-019   | Pending |
+| UT-KA-1390-020   | Pending |
+| UT-KA-1390-021   | Pending |
+| UT-AA-1390-022   | Pending |
+| UT-AA-1390-023   | Pending |
+| UT-AA-1390-024   | Pending |
+| UT-KA-1390-025   | Pending |
+| UT-KA-1390-026   | Pending |
+| UT-KA-1390-027   | Pending |
+| UT-KA-1390-028   | Pending |
+| UT-KA-1390-029   | Pending |
+| IT-KA-1390-W01   | Pending |
+| IT-KA-1390-W02   | Pending |
+| IT-KA-1390-W03   | Pending |
+| IT-AA-1390-W04   | Pending |
+| IT-KA-1390-W05   | Pending |
+| E2E-FP-1390-001  | Pending |
+| E2E-KA-1390-001  | Pending |

--- a/internal/kubernautagent/config/config.go
+++ b/internal/kubernautagent/config/config.go
@@ -220,7 +220,20 @@ type InteractiveConfig struct {
 	RateLimitPerUser      int                 `yaml:"rateLimitPerUser"`
 	MaxAnalyzingTimeout   time.Duration       `yaml:"maxAnalyzingTimeout"`
 	JWTProviders []JWTProviderConfig `yaml:"jwtProviders,omitempty"`
+
+	// MCPKeepAlive is the server-side ping interval for MCP sessions (#1387).
+	// Keeps SSE streams alive through OCP router idle timeouts.
+	// Zero means no keepalive pings. Default: 15s.
+	MCPKeepAlive time.Duration `yaml:"mcpKeepAlive"`
+	// MCPSessionTimeout auto-closes idle MCP sessions that AF abandoned
+	// without a proper disconnect (#1387). Zero means never. Default: 10m.
+	MCPSessionTimeout time.Duration `yaml:"mcpSessionTimeout"`
 }
+
+const (
+	DefaultMCPKeepAlive      = 15 * time.Second
+	DefaultMCPSessionTimeout = 10 * time.Minute
+)
 
 // JWTProviderConfig defines a trusted JWT issuer for Pattern B authentication.
 // DD-AUTH-MCP-001 v2.0: KA validates JWT signatures via JWKS and extracts

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -513,10 +513,9 @@ func (inv *Investigator) Investigate(ctx context.Context, signal katypes.SignalC
 
 	inv.emitRCAComplete(ctx, rcaResult, tokens, correlationID)
 
-	// BR-INTERACTIVE-010: When interactive, skip Phase 2+3 (re-enrichment and
-	// workflow selection). Return the RCA result with InteractiveHold=true so
-	// the session transitions to StatusUserDriving for turn-by-turn refinement.
-	if signal.Interactive {
+	// BR-INTERACTIVE-010 / #1390: When interactive (either via signal or runtime
+	// upgrade flag), skip Phase 2+3 and return with InteractiveHold=true.
+	if signal.Interactive || session.InteractiveUpgradeFromContext(ctx) {
 		backfillSeverity(rcaResult, signal)
 		attachDetectedLabels(rcaResult, enrichData)
 		InjectRemediationTarget(rcaResult, signal, enrichData)

--- a/internal/kubernautagent/investigator/investigator_upgrade_test.go
+++ b/internal/kubernautagent/investigator/investigator_upgrade_test.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	"context"
+	"sync/atomic"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+var _ = Describe("Fix #1390: Investigator Upgrade Flag — BR-INTERACTIVE-004", func() {
+
+	newInvestigator := func() *investigator.Investigator {
+		client := &interactiveHoldMockClient{}
+		logger := logr.Discard()
+		builder, _ := prompt.NewBuilder()
+		rp := parser.NewResultParser()
+		enricher := enrichment.NewEnricher(nopK8sClient{}, nopDSClient{}, audit.NopAuditStore{}, logger)
+
+		return investigator.New(investigator.Config{
+			Client:       client,
+			Builder:      builder,
+			ResultParser: rp,
+			Enricher:     enricher,
+			AuditStore:   audit.NopAuditStore{},
+			Logger:       logger,
+			MaxTurns:     15,
+			PhaseTools:   investigator.DefaultPhaseToolMap(),
+		})
+	}
+
+	Describe("UT-KA-1390-010 [SC-24]: Investigator sets InteractiveHold=true when upgrade flag is true and signal.Interactive=false", func() {
+		It("should return InteractiveHold=true using context upgrade flag for originally-autonomous sessions", func() {
+			inv := newInvestigator()
+
+			flag := &atomic.Bool{}
+			flag.Store(true)
+			ctx := session.WithInteractiveUpgrade(context.Background(), flag)
+
+			signal := katypes.SignalContext{
+				Name:          "api-server",
+				Namespace:     "production",
+				Severity:      "critical",
+				Message:       "OOMKilled",
+				RemediationID: "rem-upgrade-010",
+				Interactive:   false,
+			}
+
+			result, err := inv.Investigate(ctx, signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.InteractiveHold).To(BeTrue(),
+				"InteractiveHold must be true when upgrade flag is set, even if signal.Interactive=false")
+			Expect(result.WorkflowID).To(BeEmpty(),
+				"Phase 2/3 must be skipped when InteractiveHold fires")
+		})
+	})
+
+	Describe("UT-KA-1390-011 [SC-24]: Investigator still respects signal.Interactive=true (no regression)", func() {
+		It("should return InteractiveHold=true via the original signal.Interactive path", func() {
+			inv := newInvestigator()
+
+			signal := katypes.SignalContext{
+				Name:          "api-server",
+				Namespace:     "production",
+				Severity:      "critical",
+				Message:       "OOMKilled",
+				RemediationID: "rem-regression-011",
+				Interactive:   true,
+			}
+
+			result, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.InteractiveHold).To(BeTrue(),
+				"InteractiveHold must remain true for originally-interactive sessions")
+		})
+	})
+})

--- a/internal/kubernautagent/mcp/reconstruct.go
+++ b/internal/kubernautagent/mcp/reconstruct.go
@@ -107,9 +107,15 @@ func turnsToReconMessages(turns []ConversationTurn) []ReconMessage {
 	if len(turns) == 0 {
 		return nil
 	}
-	messages := make([]ReconMessage, len(turns))
-	for i, t := range turns {
-		messages[i] = ReconMessage{Role: t.Role, Content: t.Content}
+	messages := make([]ReconMessage, 0, len(turns))
+	for _, t := range turns {
+		if t.Content == "" {
+			continue
+		}
+		messages = append(messages, ReconMessage{Role: t.Role, Content: t.Content})
+	}
+	if len(messages) == 0 {
+		return nil
 	}
 	return messages
 }

--- a/internal/kubernautagent/mcp/reconstruct_1384_it_test.go
+++ b/internal/kubernautagent/mcp/reconstruct_1384_it_test.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+)
+
+var _ = Describe("Fix #1384 Bug B — Integration Tests (AU-6, SI-10, CP-10)", func() {
+
+	Describe("IT-KA-1384-003: Reconstruction succeeds despite tool-call-only audit turns (AU-6, CP-10)", func() {
+		It("should deliver ONLY non-empty messages through the full reconstruct chain", func() {
+			now := time.Now()
+
+			querier := &mockAuditQuerier{
+				response: &ogenclient.AuditEventsQueryResponse{
+					Data: []ogenclient.AuditEvent{
+						makeLLMRequestEvent("rr-it-003", "Investigate the pod crash", now.Add(-4*time.Minute)),
+						makeLLMResponseEvent("rr-it-003", "Let me check the logs.", now.Add(-3*time.Minute)),
+						makeLLMRequestEvent("rr-it-003", "What do the events say?", now.Add(-2*time.Minute)),
+						// Tool-call-only response: AnalysisPreview is empty
+						makeLLMResponseEvent("rr-it-003", "", now.Add(-1*time.Minute)),
+					},
+				},
+			}
+
+			reconstructor := mcpinternal.NewDSContextReconstructor(querier, 5*time.Second, logr.Discard())
+			runner := &reconSpawnRunner{}
+			spawner := mcpinternal.NewReconstructionSpawner(runner, reconstructor, logr.Discard())
+
+			err := spawner.SpawnReconstruct(context.Background(), &mcpinternal.ReconstructionContext{
+				CorrelationID: "rr-it-003",
+				SessionID:     "sess-it-003",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(runner.called.Load()).To(Equal(int32(1)))
+
+			By("verifying no empty content messages reach the LLM runner")
+			for i, msg := range runner.receivedMessages {
+				Expect(msg.Content).NotTo(BeEmpty(),
+					"message[%d] (role=%s) has empty Content — would cause LLM 400 (SI-10 violation)", i, msg.Role)
+			}
+
+			By("verifying meaningful messages are preserved in order")
+			Expect(runner.receivedMessages).To(HaveLen(3),
+				"expected 3 messages (2 user + 1 non-empty assistant)")
+			Expect(runner.receivedMessages[0].Role).To(Equal("user"))
+			Expect(runner.receivedMessages[0].Content).To(Equal("Investigate the pod crash"))
+			Expect(runner.receivedMessages[1].Role).To(Equal("assistant"))
+			Expect(runner.receivedMessages[1].Content).To(Equal("Let me check the logs."))
+			Expect(runner.receivedMessages[2].Role).To(Equal("user"))
+			Expect(runner.receivedMessages[2].Content).To(Equal("What do the events say?"))
+		})
+	})
+
+	Describe("IT-KA-1384-005: Reconstruction through production dispatch never sends empty text blocks to LLM (SI-10)", func() {
+		It("should produce a clean message array even when DS returns tool-call-only audit events", func() {
+			now := time.Now()
+
+			querier := &mockAuditQuerier{
+				response: &ogenclient.AuditEventsQueryResponse{
+					Data: []ogenclient.AuditEvent{
+						makeLLMRequestEvent("rr-it-005", "Why is the VM not booting?", now.Add(-3*time.Minute)),
+						// Two consecutive empty assistant turns (tool-call-only LLM responses)
+						makeLLMResponseEvent("rr-it-005", "", now.Add(-2*time.Minute)),
+						makeLLMResponseEvent("rr-it-005", "", now.Add(-90*time.Second)),
+						makeLLMRequestEvent("rr-it-005", "Check the CNV operator logs", now.Add(-1*time.Minute)),
+						makeLLMResponseEvent("rr-it-005", "The CNV operator shows a crash loop.", now.Add(-30*time.Second)),
+					},
+				},
+			}
+
+			reconstructor := mcpinternal.NewDSContextReconstructor(querier, 5*time.Second, logr.Discard())
+
+			capturedRunner := &reconSpawnRunner{}
+			spawner := mcpinternal.NewReconstructionSpawner(capturedRunner, reconstructor, logr.Discard())
+
+			err := spawner.SpawnReconstruct(context.Background(), &mcpinternal.ReconstructionContext{
+				CorrelationID: "rr-it-005",
+				SessionID:     "sess-it-005",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("asserting zero empty text blocks in the messages array")
+			for i, msg := range capturedRunner.receivedMessages {
+				Expect(msg.Content).NotTo(BeEmpty(),
+					"message[%d] (role=%s) has empty Content — would create empty NewTextBlock in vertexanthropic (SI-10)", i, msg.Role)
+			}
+
+			By("asserting correct message count after filtering")
+			Expect(capturedRunner.receivedMessages).To(HaveLen(3),
+				"expected 3 messages (2 user + 1 non-empty assistant); two empty assistant turns filtered")
+		})
+	})
+})

--- a/internal/kubernautagent/mcp/reconstruct_1384_test.go
+++ b/internal/kubernautagent/mcp/reconstruct_1384_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+)
+
+var _ = Describe("Fix #1384 Bug B — Reconstruction empty-content filter (AU-6, SI-10, CP-10)", func() {
+
+	var (
+		ctx    context.Context
+		logger logr.Logger
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		logger = logr.Discard()
+	})
+
+	Describe("UT-KA-1384-B01: Reconstruction produces valid LLM prompt with no empty content blocks (SI-10)", func() {
+		It("should filter out turns with empty Content before passing to RunReconTurn", func() {
+			runner := &reconSpawnRunner{}
+			recon := &reconSpawnRecon{
+				turns: []mcpinternal.ConversationTurn{
+					{Role: "user", Content: "Investigate the OOMKilled pod", Timestamp: time.Now().Add(-3 * time.Minute)},
+					{Role: "assistant", Content: "", Timestamp: time.Now().Add(-2 * time.Minute)},
+					{Role: "assistant", Content: "The root cause is memory pressure.", Timestamp: time.Now().Add(-1 * time.Minute)},
+				},
+			}
+
+			spawner := mcpinternal.NewReconstructionSpawner(runner, recon, logger)
+			err := spawner.SpawnReconstruct(ctx, &mcpinternal.ReconstructionContext{
+				CorrelationID: "rr-1384-b01",
+				SessionID:     "sess-b01",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(runner.called.Load()).To(Equal(int32(1)))
+
+			for i, msg := range runner.receivedMessages {
+				Expect(msg.Content).NotTo(BeEmpty(),
+					"message[%d] (role=%s) has empty Content — violates SI-10 boundary validation", i, msg.Role)
+			}
+			Expect(runner.receivedMessages).To(HaveLen(2),
+				"expected 2 messages (1 user + 1 non-empty assistant); got %d", len(runner.receivedMessages))
+		})
+	})
+
+	Describe("UT-KA-1384-B02: Reconstruction preserves all meaningful conversation context (CP-10)", func() {
+		It("should retain non-empty turns in original chronological order", func() {
+			now := time.Now()
+			runner := &reconSpawnRunner{}
+			recon := &reconSpawnRecon{
+				turns: []mcpinternal.ConversationTurn{
+					{Role: "user", Content: "First question", Timestamp: now.Add(-4 * time.Minute)},
+					{Role: "assistant", Content: "", Timestamp: now.Add(-3 * time.Minute)},
+					{Role: "user", Content: "Second question", Timestamp: now.Add(-2 * time.Minute)},
+					{Role: "assistant", Content: "Answer to second", Timestamp: now.Add(-1 * time.Minute)},
+				},
+			}
+
+			spawner := mcpinternal.NewReconstructionSpawner(runner, recon, logger)
+			err := spawner.SpawnReconstruct(ctx, &mcpinternal.ReconstructionContext{
+				CorrelationID: "rr-1384-b02",
+				SessionID:     "sess-b02",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(runner.receivedMessages).To(HaveLen(3))
+			Expect(runner.receivedMessages[0].Content).To(Equal("First question"))
+			Expect(runner.receivedMessages[1].Content).To(Equal("Second question"))
+			Expect(runner.receivedMessages[2].Content).To(Equal("Answer to second"))
+		})
+	})
+
+	Describe("UT-KA-1384-B05: All-empty audit history produces nil reconstruction (CP-10)", func() {
+		It("should return nil messages when all turns have empty Content", func() {
+			runner := &reconSpawnRunner{}
+			recon := &reconSpawnRecon{
+				turns: []mcpinternal.ConversationTurn{
+					{Role: "assistant", Content: "", Timestamp: time.Now().Add(-2 * time.Minute)},
+					{Role: "assistant", Content: "", Timestamp: time.Now().Add(-1 * time.Minute)},
+				},
+			}
+
+			spawner := mcpinternal.NewReconstructionSpawner(runner, recon, logger)
+			err := spawner.SpawnReconstruct(ctx, &mcpinternal.ReconstructionContext{
+				CorrelationID: "rr-1384-b05",
+				SessionID:     "sess-b05",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(runner.called.Load()).To(Equal(int32(1)))
+			Expect(runner.receivedMessages).To(BeNil(),
+				"all-empty turns should produce nil messages, not empty slice")
+		})
+	})
+
+	Describe("UT-KA-1384-B06: Nil input to reconstruction handled safely", func() {
+		It("should return nil messages for nil turns input (no panic)", func() {
+			runner := &reconSpawnRunner{}
+			recon := &reconSpawnRecon{turns: nil}
+
+			spawner := mcpinternal.NewReconstructionSpawner(runner, recon, logger)
+			err := spawner.SpawnReconstruct(ctx, &mcpinternal.ReconstructionContext{
+				CorrelationID: "rr-1384-b06",
+				SessionID:     "sess-b06",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(runner.receivedMessages).To(BeNil())
+		})
+	})
+})

--- a/internal/kubernautagent/mcp/server.go
+++ b/internal/kubernautagent/mcp/server.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"net/http"
 	"sync/atomic"
+	"time"
 
 	sharedauth "github.com/jordigilh/kubernaut/pkg/shared/auth"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
@@ -35,13 +36,17 @@ type MCPServer struct {
 // NewMCPServer creates a new MCP server instance configured for Kubernaut Agent
 // interactive mode. The server starts with zero tools; tools are registered
 // via RegisterTools before the handler is created.
-func NewMCPServer() *MCPServer {
+func NewMCPServer(keepAlive time.Duration) *MCPServer {
 	impl := &mcpsdk.Implementation{
 		Name:    "kubernaut-agent-interactive",
 		Version: "1.5.0",
 	}
 
-	server := mcpsdk.NewServer(impl, nil)
+	var opts *mcpsdk.ServerOptions
+	if keepAlive > 0 {
+		opts = &mcpsdk.ServerOptions{KeepAlive: keepAlive}
+	}
+	server := mcpsdk.NewServer(impl, opts)
 
 	return &MCPServer{
 		server: server,
@@ -84,6 +89,13 @@ type MCPDeps struct {
 	AuthMiddleware func(http.Handler) http.Handler
 	Tools          ToolDeps
 	EventStore     *DelegatingEventStore // nil = no stream resumption or disconnect detection
+
+	// KeepAlive is the server-side ping interval for MCP sessions (#1387).
+	// Zero means no keepalive pings.
+	KeepAlive time.Duration
+	// SessionTimeout auto-closes idle MCP HTTP sessions (#1387).
+	// Zero means never.
+	SessionTimeout time.Duration
 }
 
 // userFromContext extracts the authenticated user identity from the request
@@ -133,13 +145,17 @@ func BootstrapMCP(deps MCPDeps) (http.Handler, *MCPServer) {
 		panic("MCP interactive mode enabled but auth middleware is nil — refusing to start without authentication")
 	}
 
-	srv := NewMCPServer()
+	srv := NewMCPServer(deps.KeepAlive)
 	srv.registerTools(deps.Tools)
 
 	var opts *mcpsdk.StreamableHTTPOptions
-	if deps.EventStore != nil {
-		opts = &mcpsdk.StreamableHTTPOptions{
-			EventStore: deps.EventStore,
+	if deps.EventStore != nil || deps.SessionTimeout > 0 {
+		opts = &mcpsdk.StreamableHTTPOptions{}
+		if deps.EventStore != nil {
+			opts.EventStore = deps.EventStore
+		}
+		if deps.SessionTimeout > 0 {
+			opts.SessionTimeout = deps.SessionTimeout
 		}
 	}
 

--- a/internal/kubernautagent/mcp/server_test.go
+++ b/internal/kubernautagent/mcp/server_test.go
@@ -28,6 +28,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	kaconfig "github.com/jordigilh/kubernaut/internal/kubernautagent/config"
 	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
 )
 
@@ -35,7 +36,7 @@ var _ = Describe("MCP Server — #703", func() {
 
 	Describe("UT-KA-703-F01: NewMCPServer returns non-nil server with Implementation", func() {
 		It("should create a valid MCP server instance", func() {
-			srv := mcpinternal.NewMCPServer()
+			srv := mcpinternal.NewMCPServer(0)
 			Expect(srv).NotTo(BeNil())
 			Expect(srv.Implementation()).NotTo(BeNil())
 			Expect(srv.Implementation().Name).To(Equal("kubernaut-agent-interactive"))
@@ -69,7 +70,7 @@ var _ = Describe("MCP Server — #703", func() {
 
 	Describe("UT-KA-703-F05: MCP server registers zero tools initially", func() {
 		It("should have an empty tool list on creation", func() {
-			srv := mcpinternal.NewMCPServer()
+			srv := mcpinternal.NewMCPServer(0)
 			tools := srv.ToolCount()
 			Expect(tools).To(Equal(0))
 		})
@@ -84,6 +85,65 @@ var _ = Describe("MCP Server — #703", func() {
 			Expect(handler).NotTo(BeNil())
 			Expect(srv).NotTo(BeNil())
 		})
+	})
+})
+
+var _ = Describe("MCP Session Resilience — #1387", func() {
+	noopAuth := func(next http.Handler) http.Handler { return next }
+
+	It("UT-KA-1387-001 [SC-8]: server with KeepAlive preserves transport integrity through proxy idle timeouts", func() {
+		handler, srv := mcpinternal.BootstrapMCP(mcpinternal.MCPDeps{
+			AuthMiddleware: noopAuth,
+			KeepAlive:      15 * time.Second,
+		})
+		Expect(handler).NotTo(BeNil(),
+			"SC-8: handler must be created when keepalive is configured")
+		Expect(srv).NotTo(BeNil())
+		Expect(srv.Implementation().Name).To(Equal("kubernaut-agent-interactive"))
+
+		jsonRPC := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+		req := httptest.NewRequest(http.MethodPost, "/mcp", strings.NewReader(jsonRPC))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
+		rec := httptest.NewRecorder()
+		handler.ServeHTTP(rec, req)
+		Expect(rec.Code).To(Equal(http.StatusOK),
+			"SC-8: MCP server with keepalive must accept initialize handshake")
+	})
+
+	It("UT-KA-1387-002 [SC-10]: server with SessionTimeout terminates abandoned sessions after inactivity", func() {
+		handler, srv := mcpinternal.BootstrapMCP(mcpinternal.MCPDeps{
+			AuthMiddleware: noopAuth,
+			SessionTimeout: 10 * time.Minute,
+		})
+		Expect(handler).NotTo(BeNil(),
+			"SC-10: handler must be created when session timeout is configured")
+		Expect(srv).NotTo(BeNil())
+	})
+
+	It("UT-KA-1387-003 [SC-8, SC-10]: keepalive and session timeout coexist without conflict", func() {
+		handler, srv := mcpinternal.BootstrapMCP(mcpinternal.MCPDeps{
+			AuthMiddleware: noopAuth,
+			KeepAlive:      15 * time.Second,
+			SessionTimeout: 10 * time.Minute,
+		})
+		Expect(handler).NotTo(BeNil(),
+			"SC-8+SC-10: both resilience controls must be simultaneously active")
+		Expect(srv).NotTo(BeNil())
+	})
+
+	It("UT-KA-1387-004 [SA-8]: default config values match security baseline", func() {
+		Expect(kaconfig.DefaultMCPKeepAlive).To(Equal(15 * time.Second),
+			"SA-8: keepalive must be < OCP router idle timeout (30s) to prevent silent stream death")
+		Expect(kaconfig.DefaultMCPSessionTimeout).To(Equal(10 * time.Minute),
+			"SA-8: session cap prevents resource exhaustion from abandoned connections")
+	})
+
+	It("UT-KA-1387-005 [SA-8]: zero-value config produces server without keepalive (explicit opt-in)", func() {
+		srv := mcpinternal.NewMCPServer(0)
+		Expect(srv).NotTo(BeNil())
+		Expect(srv.Server()).NotTo(BeNil(),
+			"SA-8: server without keepalive is valid for environments with no proxy idle timeout")
 	})
 })
 

--- a/internal/kubernautagent/mcp/tools/channel_lifecycle_1389_it_test.go
+++ b/internal/kubernautagent/mcp/tools/channel_lifecycle_1389_it_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	mcptools "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// it1389Runner implements InvestigatorRunner for the #1389 IT.
+type it1389Runner struct {
+	rcaResult       *katypes.InvestigationResult
+	discoveryResult *katypes.InvestigationResult
+}
+
+func (r *it1389Runner) RunInteractiveTurn(_ context.Context, _ []mcptools.LLMMessage, _ string) (string, error) {
+	return "", nil
+}
+
+func (r *it1389Runner) RunRCAExtraction(_ context.Context, _ []mcptools.LLMMessage, _ string) (*katypes.InvestigationResult, error) {
+	return r.rcaResult, nil
+}
+
+func (r *it1389Runner) RunWorkflowDiscovery(_ context.Context, _ katypes.SignalContext, _ *katypes.InvestigationResult, _ *prompt.EnrichmentData, _ string) (*katypes.InvestigationResult, error) {
+	return r.discoveryResult, nil
+}
+
+func (r *it1389Runner) RunFullInvestigation(_ context.Context, _ katypes.SignalContext) (*katypes.InvestigationResult, error) {
+	return r.rcaResult, nil
+}
+
+var _ = Describe("Fix #1389 — Channel lifecycle IT (Pyramid Invariant: wiring proof)", func() {
+
+	// IT-KA-1389-001: Exercises the production wiring path:
+	//   StartInteractiveSession → LaunchDeferredInvestigation → Subscribe →
+	//   goroutine exits (InteractiveHold) → channel stays open →
+	//   discover_workflows → select_workflow → CompleteHTTPSession →
+	//   real Manager.CompleteUserDriving → closeEventChan → channel closed.
+	//
+	// Uses the real session.Manager as HTTPSessionCompleter (not a mock).
+	It("IT-KA-1389-001: CompleteHTTPSession through real Manager closes event channel after goroutine exits", func() {
+		store := session.NewStore(30 * time.Minute)
+		mgr := session.NewManager(store, logr.Discard(), audit.NopAuditStore{}, nil)
+
+		rrID := "rr-it-1389-001"
+		wfID := "restart-pod-v1"
+
+		runner := &it1389Runner{
+			rcaResult: &katypes.InvestigationResult{
+				RCASummary:      "OOM on api-server pod",
+				Confidence:      0.9,
+				InteractiveHold: true,
+				RemediationTarget: katypes.RemediationTarget{
+					Kind: "Pod", Name: "api-server", Namespace: "prod",
+				},
+			},
+			discoveryResult: &katypes.InvestigationResult{
+				RCASummary: "OOM on api-server pod",
+				WorkflowID: wfID,
+				Confidence: 0.85,
+			},
+		}
+
+		By("Step 1: Create interactive session and launch investigation")
+		pendingID, err := mgr.StartInteractiveSession(context.Background(),
+			func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				return runner.rcaResult, nil
+			},
+			map[string]string{"remediation_id": rrID},
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = mgr.LaunchDeferredInvestigation(pendingID)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Step 2: Subscribe to activate LazySink and event channel")
+		eventCh, subErr := mgr.Subscribe(context.Background(), pendingID)
+		Expect(subErr).NotTo(HaveOccurred())
+		Expect(eventCh).NotTo(BeNil())
+
+		By("Step 3: Wait for goroutine to exit — status becomes UserDriving")
+		Eventually(func() session.Status {
+			s, _ := mgr.GetSession(pendingID)
+			if s == nil {
+				return ""
+			}
+			return s.Status
+		}, 5*time.Second).Should(Equal(session.StatusUserDriving))
+
+		time.Sleep(50 * time.Millisecond)
+
+		By("Step 4: Verify channel is still open (LazySink writable)")
+		ls, found := mgr.GetSessionLazySink(pendingID)
+		Expect(found).To(BeTrue())
+		activeSink := ls.Get()
+		Expect(activeSink).NotTo(BeNil(),
+			"LazySink must still be writable after goroutine exits")
+
+		By("Step 5: Call CompleteHTTPSession through production wiring (real Manager)")
+		// mgr implements HTTPSessionCompleter — this is the production path.
+		mcptools.CompleteHTTPSession(
+			mgr, rrID,
+			&katypes.InvestigationResult{WorkflowID: wfID, RCASummary: "OOM"},
+			logr.Discard(), "select_workflow",
+		)
+
+		By("Step 6: Verify event channel is now closed")
+		Eventually(func() bool {
+			select {
+			case _, ok := <-eventCh:
+				return !ok
+			default:
+				return false
+			}
+		}, 2*time.Second).Should(BeTrue(),
+			"IT-KA-1389-001: event channel must be closed after CompleteHTTPSession → CompleteUserDriving")
+
+		By("Step 7: Verify LazySink is cleared (defense-in-depth)")
+		clearedSink := ls.Get()
+		Expect(clearedSink).To(BeNil(),
+			"IT-KA-1389-001: LazySink must be nil after CompleteUserDriving")
+	})
+})

--- a/internal/kubernautagent/mcp/tools/interactive_start_test.go
+++ b/internal/kubernautagent/mcp/tools/interactive_start_test.go
@@ -49,8 +49,11 @@ func (m *interactiveAutoMgr) FindByRemediationID(_ string) (string, bool) {
 	return m.findResult, m.findOK
 }
 
-func (m *interactiveAutoMgr) CancelInvestigation(_ string) error { return nil }
+func (m *interactiveAutoMgr) CancelInvestigation(_ string) error  { return nil }
 func (m *interactiveAutoMgr) SuspendInvestigation(_ string) error { return nil }
+func (m *interactiveAutoMgr) UpgradeToInteractive(_ string, _ string, _ []string) error {
+	return nil
+}
 
 func (m *interactiveAutoMgr) TransitionToUserDriving(_ string, _ string, _ []string) error {
 	m.transitionCalled.Add(1)
@@ -256,3 +259,108 @@ var _ = Describe("BR-INTERACTIVE-010: handleStart with pending interactive sessi
 		})
 	})
 })
+
+var _ = Describe("Fix #1390: handleStart upgrade wiring — BR-INTERACTIVE-004", func() {
+
+	Describe("UT-KA-1390-012 [SC-24]: handleStart calls UpgradeToInteractive (not TransitionToUserDriving) for running sessions", func() {
+		It("should call UpgradeToInteractive instead of TransitionToUserDriving for running auto sessions", func() {
+			sessionMgr := &mockSessionManager{
+				takeoverSession: &mcpinternal.InteractiveSession{
+					SessionID:     "lease-sess-012",
+					CorrelationID: "rr-upgrade-012",
+				},
+			}
+			autoMgr := &upgradeTrackingAutoMgr{
+				findResult: "http-auto-sess-012",
+				findOK:     true,
+			}
+			runner := &mockInvestigatorRunner{}
+			recon := &mockContextReconstructor{turns: []mcpinternal.ConversationTurn{}}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr)
+			_, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-upgrade-012",
+				Action: mcptools.ActionStart,
+			}, mcpinternal.UserInfo{Username: "alice", Groups: []string{"sre"}})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(autoMgr.upgradeCalled.Load()).To(Equal(int32(1)),
+				"UpgradeToInteractive must be called once for running session")
+			Expect(autoMgr.transitionCalled.Load()).To(Equal(int32(0)),
+				"TransitionToUserDriving must NOT be called — replaced by UpgradeToInteractive")
+		})
+	})
+
+	Describe("UT-KA-1390-013 [SI-4]: handleStart sets InvestigationSessionID for running sessions (enables EventLogBridge)", func() {
+		It("should populate InvestigationSessionID with the auto session ID", func() {
+			sessionMgr := &mockSessionManager{
+				takeoverSession: &mcpinternal.InteractiveSession{
+					SessionID:     "lease-sess-013",
+					CorrelationID: "rr-upgrade-013",
+				},
+			}
+			autoMgr := &upgradeTrackingAutoMgr{
+				findResult: "http-auto-sess-013",
+				findOK:     true,
+			}
+			runner := &mockInvestigatorRunner{}
+			recon := &mockContextReconstructor{turns: []mcpinternal.ConversationTurn{}}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr)
+			out, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-upgrade-013",
+				Action: mcptools.ActionStart,
+			}, mcpinternal.UserInfo{Username: "bob"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(out.InvestigationSessionID).To(Equal("http-auto-sess-013"),
+				"InvestigationSessionID must be set to enable EventLogBridge for upgraded sessions")
+		})
+	})
+})
+
+// upgradeTrackingAutoMgr tracks calls to UpgradeToInteractive vs TransitionToUserDriving.
+type upgradeTrackingAutoMgr struct {
+	findResult       string
+	findOK           bool
+	upgradeCalled    atomic.Int32
+	upgradeErr       error
+	transitionCalled atomic.Int32
+	transitionErr    error
+}
+
+func (m *upgradeTrackingAutoMgr) FindByRemediationID(_ string) (string, bool) {
+	return m.findResult, m.findOK
+}
+func (m *upgradeTrackingAutoMgr) CancelInvestigation(_ string) error  { return nil }
+func (m *upgradeTrackingAutoMgr) SuspendInvestigation(_ string) error { return nil }
+func (m *upgradeTrackingAutoMgr) TransitionToUserDriving(_ string, _ string, _ []string) error {
+	m.transitionCalled.Add(1)
+	return m.transitionErr
+}
+func (m *upgradeTrackingAutoMgr) ForceTransitionToUserDriving(_ string, _ string, _ []string) error {
+	return nil
+}
+func (m *upgradeTrackingAutoMgr) UpgradeToInteractive(_ string, _ string, _ []string) error {
+	m.upgradeCalled.Add(1)
+	return m.upgradeErr
+}
+func (m *upgradeTrackingAutoMgr) FindPendingByRemediationID(_ string) (string, bool) {
+	return "", false
+}
+func (m *upgradeTrackingAutoMgr) LaunchDeferredInvestigation(_ string) error { return nil }
+func (m *upgradeTrackingAutoMgr) GetLatestRCASummaryByRemediationID(_ string) (string, bool) {
+	return "", false
+}
+func (m *upgradeTrackingAutoMgr) GetLatestRCAResultByRemediationID(_ string) (*katypes.InvestigationResult, bool) {
+	return nil, false
+}
+func (m *upgradeTrackingAutoMgr) StartInvestigation(_ context.Context, _ session.InvestigateFunc, _ map[string]string) (string, error) {
+	return "", nil
+}
+func (m *upgradeTrackingAutoMgr) Subscribe(_ context.Context, _ string) (<-chan session.InvestigationEvent, error) {
+	return nil, nil
+}
+func (m *upgradeTrackingAutoMgr) GetSessionLazySink(_ string) (*session.LazySink, bool) {
+	return nil, false
+}

--- a/internal/kubernautagent/mcp/tools/interactive_start_test.go
+++ b/internal/kubernautagent/mcp/tools/interactive_start_test.go
@@ -82,6 +82,9 @@ func (m *interactiveAutoMgr) GetLatestRCASummaryByRemediationID(_ string) (strin
 func (m *interactiveAutoMgr) GetLatestRCAResultByRemediationID(_ string) (*katypes.InvestigationResult, bool) {
 	return nil, false
 }
+func (m *interactiveAutoMgr) GetSessionLazySink(_ string) (*session.LazySink, bool) {
+	return nil, false
+}
 
 var _ = Describe("BR-INTERACTIVE-010: handleStart with pending interactive session — #1293", func() {
 

--- a/internal/kubernautagent/mcp/tools/investigate.go
+++ b/internal/kubernautagent/mcp/tools/investigate.go
@@ -103,6 +103,8 @@ type AutonomousSessionManager interface {
 	SuspendInvestigation(id string) error
 	TransitionToUserDriving(id, username string, groups []string) error
 	ForceTransitionToUserDriving(rrID, username string, groups []string) error
+	// #1390: Upgrade a running autonomous session to interactive in-place.
+	UpgradeToInteractive(id, username string, groups []string) error
 
 	// BR-INTERACTIVE-010: Find pending interactive session by remediation ID.
 	FindPendingByRemediationID(rrID string) (string, bool)
@@ -151,6 +153,7 @@ func (NopAutonomousManager) CancelInvestigation(string) error                   
 func (NopAutonomousManager) SuspendInvestigation(string) error                           { return nil }
 func (NopAutonomousManager) TransitionToUserDriving(string, string, []string) error      { return nil }
 func (NopAutonomousManager) ForceTransitionToUserDriving(string, string, []string) error { return nil }
+func (NopAutonomousManager) UpgradeToInteractive(string, string, []string) error         { return nil }
 func (NopAutonomousManager) FindPendingByRemediationID(string) (string, bool)            { return "", false }
 func (NopAutonomousManager) LaunchDeferredInvestigation(string) error                    { return nil }
 func (NopAutonomousManager) GetLatestRCASummaryByRemediationID(string) (string, bool)    { return "", false }
@@ -412,26 +415,27 @@ func (t *InvestigateTool) handleStart(ctx context.Context, input InvestigateInpu
 		}
 	}
 
-	// Transition any running autonomous session to user-driven mode so that
-	// complete_no_action / action:complete can find and close it via
-	// FindUserDrivingByRemediationID. Without this, the autonomous HTTP
-	// session keeps running after the MCP lease is released.
+	// #1390: Upgrade running autonomous session in-place (Jump In) instead of
+	// cancelling and recreating. UpgradeToInteractive sets the atomic flag so
+	// the goroutine's next InteractiveHold check sees it, and store.Update's
+	// deterministic check catches completion that already happened.
 	// Skip when we just launched a pending session — its RCA goroutine will
 	// self-transition via InteractiveHold once complete.
 	if !launchedPending {
 		autoSessionID, found := t.autoMgr.FindByRemediationID(input.RRID)
 		if found {
-			if transErr := t.autoMgr.TransitionToUserDriving(autoSessionID, user.Username, user.Groups); transErr != nil {
-				if errors.Is(transErr, session.ErrSessionTerminal) {
+			if upgradeErr := t.autoMgr.UpgradeToInteractive(autoSessionID, user.Username, user.Groups); upgradeErr != nil {
+				if errors.Is(upgradeErr, session.ErrSessionTerminal) {
 					if forceErr := t.autoMgr.ForceTransitionToUserDriving(input.RRID, user.Username, user.Groups); forceErr != nil {
-						t.logger.Error(forceErr, "start: force-transition to user-driving failed",
+						t.logger.Error(forceErr, "start: force-transition to user-driving failed (session terminal)",
 							"rr_id", input.RRID, "auto_session_id", autoSessionID)
 					}
 				} else {
-					t.logger.Error(transErr, "start: transition autonomous session to user-driving",
+					t.logger.Error(upgradeErr, "start: upgrade autonomous session to interactive",
 						"rr_id", input.RRID, "auto_session_id", autoSessionID)
 				}
 			}
+			investigationSessionID = autoSessionID
 		} else {
 			if forceErr := t.autoMgr.ForceTransitionToUserDriving(input.RRID, user.Username, user.Groups); forceErr != nil {
 				t.logger.Error(forceErr, "start: force-transition to user-driving (no running session found)",

--- a/internal/kubernautagent/mcp/tools/investigate.go
+++ b/internal/kubernautagent/mcp/tools/investigate.go
@@ -117,6 +117,8 @@ type AutonomousSessionManager interface {
 	StartInvestigation(ctx context.Context, fn session.InvestigateFunc, metadata map[string]string) (string, error)
 	// BR-MCP-003: Subscribe to the event channel for a running investigation, activating the LazySink.
 	Subscribe(ctx context.Context, id string) (<-chan session.InvestigationEvent, error)
+	// #1384: Get the LazySink for a session so workflow_discovery can stream events.
+	GetSessionLazySink(id string) (*session.LazySink, bool)
 }
 
 // RRExistenceChecker validates that a RemediationRequest exists before
@@ -161,6 +163,7 @@ func (NopAutonomousManager) StartInvestigation(context.Context, session.Investig
 func (NopAutonomousManager) Subscribe(context.Context, string) (<-chan session.InvestigationEvent, error) {
 	return nil, nil
 }
+func (NopAutonomousManager) GetSessionLazySink(string) (*session.LazySink, bool) { return nil, false }
 
 // InvestigateTool handles the kubernaut_investigate MCP tool actions:
 // start, message, complete, cancel, takeover, discover_workflows.
@@ -860,7 +863,21 @@ func (t *InvestigateTool) handleDiscoverWorkflows(ctx context.Context, input Inv
 		}
 	}
 
-	// Step 3: Run Phase 3 workflow discovery using the structured RCA.
+	// Step 3: Enrich context with the HTTP investigation session so that
+	// workflow discovery can emit audit events with session_id and stream
+	// events to the subscriber (#1384: Bug A fix).
+	if t.httpCompleter != nil {
+		if httpSessionID, found := t.httpCompleter.FindUserDrivingByRemediationID(input.RRID); found {
+			ctx = session.WithSessionID(ctx, httpSessionID)
+			if ls, ok := t.autoMgr.GetSessionLazySink(httpSessionID); ok {
+				ctx = session.WithLazySink(ctx, ls)
+			}
+			t.logger.V(1).Info("discover_workflows: enriched context with HTTP session",
+				"rr_id", input.RRID, "http_session_id", httpSessionID)
+		}
+	}
+
+	// Step 4: Run Phase 3 workflow discovery using the structured RCA.
 	// The investigator resolves enrichment internally when its enricher is wired,
 	// falling back to nil when not available.
 	workflowResult, err := t.runner.RunWorkflowDiscovery(ctx, signal, rcaResult, nil, input.RRID)

--- a/internal/kubernautagent/mcp/tools/session_handoff_1384_test.go
+++ b/internal/kubernautagent/mcp/tools/session_handoff_1384_test.go
@@ -1,0 +1,552 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools_test
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+	mcptools "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// ctxCapturingDiscoveryRunner captures the context passed to RunWorkflowDiscovery
+// for verifying session context propagation (Bug A #1384).
+type ctxCapturingDiscoveryRunner struct {
+	mu                  sync.Mutex
+	capturedDiscoveryCtx context.Context
+	rcaResult           *katypes.InvestigationResult
+	discoveryResult     *katypes.InvestigationResult
+}
+
+func (r *ctxCapturingDiscoveryRunner) RunInteractiveTurn(ctx context.Context, _ []mcptools.LLMMessage, _ string) (string, error) {
+	return "interactive response", nil
+}
+
+func (r *ctxCapturingDiscoveryRunner) RunRCAExtraction(_ context.Context, _ []mcptools.LLMMessage, _ string) (*katypes.InvestigationResult, error) {
+	if r.rcaResult != nil {
+		return r.rcaResult, nil
+	}
+	return &katypes.InvestigationResult{RCASummary: "mock RCA"}, nil
+}
+
+func (r *ctxCapturingDiscoveryRunner) RunWorkflowDiscovery(ctx context.Context, _ katypes.SignalContext, _ *katypes.InvestigationResult, _ *prompt.EnrichmentData, _ string) (*katypes.InvestigationResult, error) {
+	r.mu.Lock()
+	r.capturedDiscoveryCtx = ctx
+	r.mu.Unlock()
+
+	if r.discoveryResult != nil {
+		return r.discoveryResult, nil
+	}
+	return &katypes.InvestigationResult{
+		RCASummary: "mock RCA",
+		WorkflowID: "mock-workflow-001",
+		Confidence: 0.85,
+	}, nil
+}
+
+func (r *ctxCapturingDiscoveryRunner) RunFullInvestigation(_ context.Context, _ katypes.SignalContext) (*katypes.InvestigationResult, error) {
+	return &katypes.InvestigationResult{RCASummary: "mock"}, nil
+}
+
+func (r *ctxCapturingDiscoveryRunner) getCapturedCtx() context.Context {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.capturedDiscoveryCtx
+}
+
+// mockAutoMgrWithHTTPSession extends NopAutonomousManager to simulate an HTTP
+// session in user_driving state with a stored RCA result. This mirrors the
+// production scenario where launchInvestigation has created a session with
+// a LazySink and session_id, and the session has been transitioned to
+// user_driving status via takeover.
+type mockAutoMgrWithHTTPSession struct {
+	mcptools.NopAutonomousManager
+	mu             sync.Mutex
+	httpSessionID  string
+	rcaResult      *katypes.InvestigationResult
+	subscribeCh    <-chan session.InvestigationEvent
+	subscribeErr   error
+	subscribedID   string
+}
+
+func (m *mockAutoMgrWithHTTPSession) FindUserDrivingByRemediationID(_ string) (string, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.httpSessionID == "" {
+		return "", false
+	}
+	return m.httpSessionID, true
+}
+
+func (m *mockAutoMgrWithHTTPSession) GetLatestRCAResultByRemediationID(_ string) (*katypes.InvestigationResult, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.rcaResult == nil {
+		return nil, false
+	}
+	return m.rcaResult, true
+}
+
+func (m *mockAutoMgrWithHTTPSession) Subscribe(_ context.Context, id string) (<-chan session.InvestigationEvent, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.subscribedID = id
+	return m.subscribeCh, m.subscribeErr
+}
+
+func (m *mockAutoMgrWithHTTPSession) GetSessionLazySink(_ string) (*session.LazySink, bool) {
+	return nil, false
+}
+
+var _ = Describe("Fix #1384 Bug A — Session context propagation (AU-2/AU-3, BR-INTERACTIVE-010 SC-2)", func() {
+
+	Describe("UT-KA-1384-A01: Session context propagated to workflow_discovery (streaming path)", func() {
+		It("should enrich ctx with session_id from the HTTP investigation session", func() {
+			sess := &mcpinternal.InteractiveSession{
+				SessionID:     "mcp-sess-a01",
+				CorrelationID: "rr-a01",
+				ActingUser:    mcpinternal.UserInfo{Username: "alice"},
+			}
+			sessionMgr := &mockSessionManager{
+				isActive:        true,
+				getDriverResult: sess,
+			}
+			runner := &ctxCapturingDiscoveryRunner{
+				rcaResult: &katypes.InvestigationResult{
+					RCASummary: "OOM on pod",
+					Confidence: 0.9,
+				},
+			}
+			recon := &mockContextReconstructor{}
+			resolver := &mockSignalResolver{}
+
+			autoMgr := &mockAutoMgrWithHTTPSession{
+				rcaResult: &katypes.InvestigationResult{
+					RCASummary: "OOM on pod",
+					Confidence: 0.9,
+				},
+			}
+
+			completer := &mockHTTPCompleter{
+				foundID: "http-sess-a01",
+				found:   true,
+			}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr,
+				mcptools.WithSignalContextResolver(resolver),
+				mcptools.WithHTTPCompleter(completer))
+
+			output, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-a01",
+				Action: mcptools.ActionDiscoverWorkflows,
+			}, mcpinternal.UserInfo{Username: "alice"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output.Status).To(Equal("workflows_discovered"))
+
+			capturedCtx := runner.getCapturedCtx()
+			Expect(capturedCtx).NotTo(BeNil(), "RunWorkflowDiscovery should have been called")
+
+			sessionID := session.SessionIDFromContext(capturedCtx)
+			Expect(sessionID).NotTo(BeEmpty(),
+				"session_id MUST be propagated to workflow_discovery ctx — AU-2/AU-3 requires traceable audit events")
+			Expect(sessionID).To(Equal("http-sess-a01"),
+				"session_id should match the HTTP investigation session, not the MCP lease ID")
+		})
+	})
+
+	Describe("UT-KA-1384-A02: Without HTTP session, degrades gracefully (no crash)", func() {
+		It("should still succeed with empty session context when no HTTP session exists", func() {
+			sess := &mcpinternal.InteractiveSession{
+				SessionID:     "mcp-sess-a02",
+				CorrelationID: "rr-a02",
+				ActingUser:    mcpinternal.UserInfo{Username: "alice"},
+			}
+			sessionMgr := &mockSessionManager{
+				isActive:        true,
+				getDriverResult: sess,
+			}
+			runner := &ctxCapturingDiscoveryRunner{}
+			recon := &mockContextReconstructor{turns: []mcpinternal.ConversationTurn{
+				{Role: "user", Content: "pod crash"},
+				{Role: "assistant", Content: "investigating"},
+			}}
+			resolver := &mockSignalResolver{}
+
+			autoMgr := &mockAutoMgrWithHTTPSession{
+				httpSessionID: "",
+			}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr,
+				mcptools.WithSignalContextResolver(resolver))
+
+			output, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-a02",
+				Action: mcptools.ActionDiscoverWorkflows,
+			}, mcpinternal.UserInfo{Username: "alice"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output.Status).To(Equal("workflows_discovered"))
+		})
+	})
+
+	Describe("UT-KA-1384-A03: Investigation events reach sink during workflow_discovery", func() {
+		It("should propagate LazySink so events can be streamed to subscriber", func() {
+			sess := &mcpinternal.InteractiveSession{
+				SessionID:     "mcp-sess-a03",
+				CorrelationID: "rr-a03",
+				ActingUser:    mcpinternal.UserInfo{Username: "alice"},
+			}
+			sessionMgr := &mockSessionManager{
+				isActive:        true,
+				getDriverResult: sess,
+			}
+			runner := &ctxCapturingDiscoveryRunner{
+				rcaResult: &katypes.InvestigationResult{
+					RCASummary: "OOM on pod",
+					Confidence: 0.9,
+				},
+			}
+			recon := &mockContextReconstructor{}
+			resolver := &mockSignalResolver{}
+
+			completer := &mockHTTPCompleter{
+				foundID: "http-sess-a03",
+				found:   true,
+			}
+
+			autoMgr := &mockAutoMgrWithHTTPSession{
+				rcaResult: &katypes.InvestigationResult{
+					RCASummary: "OOM on pod",
+					Confidence: 0.9,
+				},
+			}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr,
+				mcptools.WithSignalContextResolver(resolver),
+				mcptools.WithHTTPCompleter(completer))
+
+			_, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-a03",
+				Action: mcptools.ActionDiscoverWorkflows,
+			}, mcpinternal.UserInfo{Username: "alice"})
+			Expect(err).NotTo(HaveOccurred())
+
+			capturedCtx := runner.getCapturedCtx()
+			Expect(capturedCtx).NotTo(BeNil())
+
+			sessionID := session.SessionIDFromContext(capturedCtx)
+			Expect(sessionID).To(Equal("http-sess-a03"),
+				"session_id must be propagated for event correlation")
+		})
+	})
+
+	Describe("UT-KA-1384-A04: Missing subscriber does not block or crash", func() {
+		It("should not panic when no subscriber exists for the HTTP session", func() {
+			sess := &mcpinternal.InteractiveSession{
+				SessionID:     "mcp-sess-a04",
+				CorrelationID: "rr-a04",
+				ActingUser:    mcpinternal.UserInfo{Username: "alice"},
+			}
+			sessionMgr := &mockSessionManager{
+				isActive:        true,
+				getDriverResult: sess,
+			}
+			runner := &ctxCapturingDiscoveryRunner{}
+			recon := &mockContextReconstructor{turns: []mcpinternal.ConversationTurn{
+				{Role: "user", Content: "pod crash"},
+				{Role: "assistant", Content: "investigating"},
+			}}
+			resolver := &mockSignalResolver{}
+
+			// No HTTP session → no sink
+			autoMgr := &mockAutoMgrWithHTTPSession{}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr,
+				mcptools.WithSignalContextResolver(resolver))
+
+			Expect(func() {
+				_, _ = tool.Handle(context.Background(), mcptools.InvestigateInput{
+					RRID:   "rr-a04",
+					Action: mcptools.ActionDiscoverWorkflows,
+				}, mcpinternal.UserInfo{Username: "alice"})
+			}).NotTo(Panic(), "discover_workflows must not panic when no subscriber exists")
+		})
+	})
+
+	Describe("UT-KA-1384-A05: buildFinalResult merges RCA + discovery into single result", func() {
+		It("should produce InvestigationResult with both RCASummary and WorkflowID", func() {
+			rca := &katypes.InvestigationResult{
+				RCASummary: "OOMKilled due to memory leak in api-server",
+				Confidence: 0.92,
+				RemediationTarget: katypes.RemediationTarget{
+					Kind:      "Pod",
+					Name:      "api-server",
+					Namespace: "prod",
+				},
+			}
+
+			discovery := &mcpinternal.WorkflowDiscoveryResult{
+				Recommended: &mcpinternal.DiscoveredWorkflow{
+					WorkflowID: "restart-pod-v2",
+					Confidence: 0.88,
+					Rationale:  "Pod restart resolves transient OOM",
+					Parameters: map[string]interface{}{
+						"pod_name":  "api-server",
+						"namespace": "prod",
+					},
+				},
+				FullResult: &katypes.InvestigationResult{
+					Confidence:           0.88,
+					InvestigationOutcome: "actionable",
+				},
+			}
+
+			workflow := &mcptools.CatalogWorkflow{
+				WorkflowID:      "restart-pod-v2",
+				ExecutionEngine: "argo",
+				ExecutionBundle: "ghcr.io/kubernaut/workflows/restart-pod:v2",
+				Version:         "2.0.0",
+			}
+
+			result := mcptools.BuildFinalResult(rca, workflow, discovery)
+
+			Expect(result).NotTo(BeNil())
+			Expect(result.RCASummary).To(Equal("OOMKilled due to memory leak in api-server"),
+				"RCA summary from Phase 2 must be preserved")
+			Expect(result.WorkflowID).To(Equal("restart-pod-v2"),
+				"WorkflowID from user selection must be set")
+			Expect(result.ExecutionEngine).To(Equal("argo"))
+			Expect(result.RemediationTarget.Kind).To(Equal("Pod"),
+				"RemediationTarget from RCA should be preserved when discovery doesn't override")
+			Expect(result.Confidence).To(BeNumerically("==", 0.88),
+				"Confidence should use Phase 3 discovery confidence")
+		})
+	})
+})
+
+var _ = Describe("Fix #1384 — Wiring Chain IT (discover -> select -> HTTP complete)", func() {
+
+	Describe("IT-KA-1384-004: End-to-end discover->select->HTTP complete (CP-10, BR-INTERACTIVE-010)", func() {
+		It("should propagate session context through discovery and deliver result to AA via HTTP complete", func() {
+			rrID := "rr-it-004"
+			wfID := "restart-pod-v2"
+
+			sess := &mcpinternal.InteractiveSession{
+				SessionID:     "mcp-sess-it004",
+				CorrelationID: rrID,
+				ActingUser:    mcpinternal.UserInfo{Username: "alice"},
+			}
+			sessionMgr := &mockSessionManager{
+				isActive:        true,
+				getDriverResult: sess,
+			}
+
+			discoveryRunner := &ctxCapturingDiscoveryRunner{
+				rcaResult: &katypes.InvestigationResult{
+					RCASummary: "OOM on api-server pod",
+					Confidence: 0.9,
+					RemediationTarget: katypes.RemediationTarget{
+						Kind: "Pod", Name: "api-server", Namespace: "prod",
+					},
+				},
+				discoveryResult: &katypes.InvestigationResult{
+					RCASummary: "OOM on api-server pod",
+					WorkflowID: wfID,
+					Confidence: 0.85,
+				},
+			}
+
+			completer := &mockHTTPCompleter{
+				foundID: "http-sess-it004",
+				found:   true,
+			}
+
+			autoMgr := &mockAutoMgrWithHTTPSession{
+				rcaResult: &katypes.InvestigationResult{
+					RCASummary: "OOM on api-server pod",
+					Confidence: 0.9,
+					RemediationTarget: katypes.RemediationTarget{
+						Kind: "Pod", Name: "api-server", Namespace: "prod",
+					},
+				},
+			}
+
+			resolver := &mockSignalResolver{
+				signal: &katypes.SignalContext{IncidentID: "inc-it004", Severity: "critical"},
+			}
+
+			investTool := mcptools.NewInvestigateTool(sessionMgr, discoveryRunner, &mockContextReconstructor{}, autoMgr,
+				mcptools.WithSignalContextResolver(resolver),
+				mcptools.WithHTTPCompleter(completer))
+
+			By("Step 1: discover_workflows with session context enrichment")
+			discoverOut, err := investTool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   rrID,
+				Action: mcptools.ActionDiscoverWorkflows,
+			}, mcpinternal.UserInfo{Username: "alice"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(discoverOut.Status).To(Equal("workflows_discovered"))
+
+			capturedCtx := discoveryRunner.getCapturedCtx()
+			Expect(session.SessionIDFromContext(capturedCtx)).To(Equal("http-sess-it004"),
+				"session_id must be propagated to workflow_discovery")
+
+			By("Step 2: Verify session has discovery results stored")
+			Expect(sess.DiscoveryResult).NotTo(BeNil())
+			Expect(sess.RCAResult).NotTo(BeNil())
+
+			By("Step 3: select_workflow triggers CompleteHTTPSession with workflow result")
+			catalog := &mockWorkflowCatalog{
+				workflow: &mcptools.CatalogWorkflow{
+					WorkflowID:      wfID,
+					ExecutionEngine: "argo",
+					ExecutionBundle: "ghcr.io/kubernaut/workflows/restart-pod:v2",
+					Version:         "2.0.0",
+				},
+			}
+
+			selectTool := mcptools.NewSelectWorkflowTool(catalog, sessionMgr,
+				mcptools.WithHTTPSessionCompleter(completer),
+				mcptools.WithMutexProvider(investTool))
+
+			selectOut, err := selectTool.Handle(context.Background(), mcptools.SelectWorkflowInput{
+				RRID:       rrID,
+				WorkflowID: wfID,
+			}, mcpinternal.UserInfo{Username: "alice"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(selectOut.Status).To(Equal("workflow_selected"))
+			Expect(selectOut.Workflow).NotTo(BeNil())
+			Expect(selectOut.Workflow.WorkflowID).To(Equal(wfID))
+
+			By("Step 4: Verify HTTP completer received the final result (async goroutine)")
+			Eventually(func() string {
+				id, _ := completer.getCompleted()
+				return id
+			}).WithTimeout(time.Second).WithPolling(10 * time.Millisecond).Should(Equal("http-sess-it004"),
+				"IT-KA-1384-004: HTTP session must be completed via CompleteUserDriving")
+
+			_, completedResult := completer.getCompleted()
+			Expect(completedResult).NotTo(BeNil())
+			Expect(completedResult.WorkflowID).To(Equal(wfID),
+				"IT-KA-1384-004: result must contain the selected WorkflowID")
+			Expect(completedResult.RCASummary).NotTo(BeEmpty(),
+				"IT-KA-1384-004: result must preserve RCA summary from Phase 2")
+		})
+	})
+})
+
+var _ = Describe("Fix #1384 Bug A — Integration Tests (session wiring)", func() {
+
+	Describe("IT-KA-1384-001: Workflow discovery audit events traceable to session (AU-2/AU-3)", func() {
+		It("should propagate HTTP session_id to RunWorkflowDiscovery context", func() {
+			sess := &mcpinternal.InteractiveSession{
+				SessionID:     "mcp-sess-it001",
+				CorrelationID: "rr-it-001",
+				ActingUser:    mcpinternal.UserInfo{Username: "alice"},
+			}
+			sessionMgr := &mockSessionManager{
+				isActive:        true,
+				getDriverResult: sess,
+			}
+			runner := &ctxCapturingDiscoveryRunner{
+				rcaResult: &katypes.InvestigationResult{
+					RCASummary: "OOM",
+					Confidence: 0.9,
+				},
+			}
+			recon := &mockContextReconstructor{}
+			resolver := &mockSignalResolver{
+				signal: &katypes.SignalContext{IncidentID: "inc-it001", Severity: "critical"},
+			}
+
+			completer := &mockHTTPCompleter{
+				foundID: "http-sess-it001",
+				found:   true,
+			}
+
+			autoMgr := &mockAutoMgrWithHTTPSession{
+				rcaResult: &katypes.InvestigationResult{
+					RCASummary: "OOM",
+					Confidence: 0.9,
+				},
+			}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr,
+				mcptools.WithSignalContextResolver(resolver),
+				mcptools.WithHTTPCompleter(completer))
+
+			output, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-it-001",
+				Action: mcptools.ActionDiscoverWorkflows,
+			}, mcpinternal.UserInfo{Username: "alice"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output.Status).To(Equal("workflows_discovered"))
+
+			capturedCtx := runner.getCapturedCtx()
+			sessionID := session.SessionIDFromContext(capturedCtx)
+			Expect(sessionID).To(Equal("http-sess-it001"),
+				"IT-KA-1384-001: session_id MUST be non-empty and match HTTP session — AU-2/AU-3 audit correlation")
+		})
+	})
+
+	Describe("IT-KA-1384-002: Workflow result flows to HTTP session for AA polling (BR-INTERACTIVE-010)", func() {
+		It("should allow CompleteUserDriving to receive result with WorkflowID after discover+select", func() {
+			completer := &mockHTTPCompleter{
+				foundID: "http-sess-it002",
+				found:   true,
+			}
+
+			rca := &katypes.InvestigationResult{
+				RCASummary: "OOM crash",
+				Confidence: 0.9,
+			}
+			discovery := &mcpinternal.WorkflowDiscoveryResult{
+				Recommended: &mcpinternal.DiscoveredWorkflow{
+					WorkflowID: "restart-pod-v2",
+					Confidence: 0.85,
+					Parameters: map[string]interface{}{"pod_name": "api-server"},
+				},
+			}
+			workflow := &mcptools.CatalogWorkflow{
+				WorkflowID:      "restart-pod-v2",
+				ExecutionEngine: "argo",
+				ExecutionBundle: "ghcr.io/kubernaut/workflows/restart-pod:v2",
+			}
+
+			result := mcptools.BuildFinalResult(rca, workflow, discovery)
+			Expect(result.WorkflowID).To(Equal("restart-pod-v2"))
+
+			mcptools.CompleteHTTPSession(completer, "rr-it-002", result, logr.Discard(), "select_workflow")
+
+			completedID, completedResult := completer.getCompleted()
+			Expect(completedID).To(Equal("http-sess-it002"),
+				"CompleteUserDriving should be called with the HTTP session ID")
+			Expect(completedResult).NotTo(BeNil())
+			Expect(completedResult.WorkflowID).To(Equal("restart-pod-v2"),
+				"IT-KA-1384-002: AA must receive result with WorkflowID from interactive discovery")
+		})
+	})
+})

--- a/internal/kubernautagent/mcp/tools/status_test.go
+++ b/internal/kubernautagent/mcp/tools/status_test.go
@@ -65,6 +65,7 @@ func (m *statusAutoMgr) GetLatestRCAResultByRemediationID(_ string) (*katypes.In
 }
 func (m *statusAutoMgr) StartInvestigation(_ context.Context, _ session.InvestigateFunc, _ map[string]string) (string, error) { return "", nil }
 func (m *statusAutoMgr) Subscribe(_ context.Context, _ string) (<-chan session.InvestigationEvent, error) { return nil, nil }
+func (m *statusAutoMgr) GetSessionLazySink(_ string) (*session.LazySink, bool) { return nil, false }
 
 var _ = Describe("action=status — PR4 PROD-01 BR-INTERACTIVE-002", func() {
 

--- a/internal/kubernautagent/mcp/tools/status_test.go
+++ b/internal/kubernautagent/mcp/tools/status_test.go
@@ -57,6 +57,7 @@ func (m *statusAutoMgr) CancelInvestigation(_ string) error                     
 func (m *statusAutoMgr) SuspendInvestigation(_ string) error                             { return nil }
 func (m *statusAutoMgr) TransitionToUserDriving(_ string, _ string, _ []string) error    { return nil }
 func (m *statusAutoMgr) ForceTransitionToUserDriving(_ string, _ string, _ []string) error { return nil }
+func (m *statusAutoMgr) UpgradeToInteractive(_ string, _ string, _ []string) error         { return nil }
 func (m *statusAutoMgr) FindPendingByRemediationID(_ string) (string, bool)              { return "", false }
 func (m *statusAutoMgr) LaunchDeferredInvestigation(_ string) error                       { return nil }
 func (m *statusAutoMgr) GetLatestRCASummaryByRemediationID(_ string) (string, bool)       { return "", false }

--- a/internal/kubernautagent/mcp/tools/takeover_test.go
+++ b/internal/kubernautagent/mcp/tools/takeover_test.go
@@ -107,6 +107,7 @@ func (m *takeoverAutoMgr) GetLatestRCAResultByRemediationID(_ string) (*katypes.
 }
 func (m *takeoverAutoMgr) StartInvestigation(_ context.Context, _ session.InvestigateFunc, _ map[string]string) (string, error) { return "", nil }
 func (m *takeoverAutoMgr) Subscribe(_ context.Context, _ string) (<-chan session.InvestigationEvent, error) { return nil, nil }
+func (m *takeoverAutoMgr) GetSessionLazySink(_ string) (*session.LazySink, bool) { return nil, false }
 
 // takeoverSessMgr mocks mcpinternal.SessionManager for takeover tests.
 type takeoverSessMgr struct {

--- a/internal/kubernautagent/mcp/tools/takeover_test.go
+++ b/internal/kubernautagent/mcp/tools/takeover_test.go
@@ -98,6 +98,9 @@ func (m *takeoverAutoMgr) TransitionToUserDriving(_ string, _ string, _ []string
 func (m *takeoverAutoMgr) ForceTransitionToUserDriving(_ string, _ string, _ []string) error {
 	return nil
 }
+func (m *takeoverAutoMgr) UpgradeToInteractive(_ string, _ string, _ []string) error {
+	return nil
+}
 
 func (m *takeoverAutoMgr) FindPendingByRemediationID(_ string) (string, bool)         { return "", false }
 func (m *takeoverAutoMgr) LaunchDeferredInvestigation(_ string) error                  { return nil }

--- a/internal/kubernautagent/server/handler.go
+++ b/internal/kubernautagent/server/handler.go
@@ -235,7 +235,7 @@ func (h *Handler) IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResu
 		return nil, errors.New("internal server error")
 	}
 
-	if sess.Status != session.StatusCompleted {
+	if !session.IsTerminal(sess.Status) {
 		return &agentclient.IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetConflict{
 			Type:     "https://kubernaut.ai/problems/session-not-completed",
 			Title:    "Session Not Completed",
@@ -245,21 +245,17 @@ func (h *Handler) IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResu
 		}, nil
 	}
 
-	result := sess.Result
-	if result == nil {
-		h.logger.Error(nil, "nil result in completed session", "session_id", sess.ID)
-		return &agentclient.IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetConflict{
-			Type:     "https://kubernaut.ai/problems/session-not-completed",
-			Title:    "Session Not Completed",
-			Detail:   "session result is not an investigation result",
-			Status:   409,
-			Instance: fmt.Sprintf("/api/v1/incident/session/%s/result", params.SessionID),
-		}, nil
-	}
-
 	var incidentID string
 	if sess.Metadata != nil {
 		incidentID = sess.Metadata["incident_id"]
+	}
+
+	result := sess.Result
+	if result == nil {
+		h.logger.Info("nil_result_synthesized", "session_id", sess.ID, "status", string(sess.Status))
+		synthetic := synthesizeNilResult(sess)
+		resp := mapInvestigationResultToResponse(h.logger, synthetic, incidentID)
+		return resp, nil
 	}
 
 	resp := mapInvestigationResultToResponse(h.logger, result, incidentID)
@@ -608,6 +604,35 @@ func mapSessionStatusToAPI(s session.Status) string {
 		return "user_driving"
 	default:
 		return "unknown"
+	}
+}
+
+// synthesizeNilResult creates a minimal InvestigationResult for terminal sessions
+// whose goroutine produced no result. This prevents AA from entering a 409 polling
+// loop (#1390). The synthetic result is always non-actionable.
+func synthesizeNilResult(sess *session.Session) *katypes.InvestigationResult {
+	switch sess.Status {
+	case session.StatusFailed:
+		reason := "Investigation failed"
+		if sess.Error != nil {
+			reason = fmt.Sprintf("Investigation failed: %s", sess.Error.Error())
+		}
+		return &katypes.InvestigationResult{
+			RCASummary:        reason,
+			Confidence:        0,
+			HumanReviewNeeded: true,
+			HumanReviewReason: "investigation_failed",
+		}
+	case session.StatusCancelled:
+		return &katypes.InvestigationResult{
+			RCASummary: "Investigation cancelled",
+			Confidence: 0,
+		}
+	default:
+		return &katypes.InvestigationResult{
+			RCASummary: "Investigation completed without result",
+			Confidence: 0,
+		}
 	}
 }
 

--- a/internal/kubernautagent/server/nil_result_handler_test.go
+++ b/internal/kubernautagent/server/nil_result_handler_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server_test
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+	"github.com/jordigilh/kubernaut/pkg/agentclient"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/server"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// ========================================
+// Fix #1390: Nil-Result 409 Loop Fix — KA Handler Tests
+//
+// UT-KA-1390-018..021: Validate that the GetResult handler synthesizes
+// a structured result for completed/failed/cancelled sessions with nil result
+// instead of returning 409 Conflict.
+// ========================================
+
+var _ = Describe("Fix #1390: Nil-Result Structured Response — BR-SESSION-002", func() {
+	var (
+		store   *session.Store
+		manager *session.Manager
+		handler *server.Handler
+	)
+
+	BeforeEach(func() {
+		store = session.NewStore(5 * time.Minute)
+		manager = session.NewManager(store, logr.Discard(), nil, nil)
+		handler = server.NewHandler(manager, nil, logr.Discard(), nil)
+	})
+
+	getResult := func(sessionID string) (agentclient.IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetRes, error) {
+		params := agentclient.IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetParams{
+			SessionID: sessionID,
+		}
+		return handler.IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGet(context.Background(), params)
+	}
+
+	DescribeTable("UT-KA-1390-018..020 [SC-24]: GetResult on terminal nil-result session returns HTTP 200 + synthetic result",
+		func(testID string, investigateFn func(context.Context) (*katypes.InvestigationResult, error), expectedStatus session.Status, needsCancel bool, analysisSubstring string) {
+			id, err := manager.StartInvestigation(context.Background(), investigateFn, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			if needsCancel {
+				Expect(manager.CancelInvestigation(id)).To(Succeed())
+			}
+
+			Eventually(func() session.Status {
+				sess, _ := manager.GetSession(id)
+				if sess == nil {
+					return ""
+				}
+				return sess.Status
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(expectedStatus))
+
+			resp, err := getResult(id)
+			Expect(err).NotTo(HaveOccurred())
+
+			incidentResp, ok := resp.(*agentclient.IncidentResponse)
+			Expect(ok).To(BeTrue(), "%s: response must be *IncidentResponse (HTTP 200), not 409 Conflict", testID)
+			Expect(incidentResp.Analysis).To(ContainSubstring(analysisSubstring),
+				"%s: synthetic result analysis must contain expected substring", testID)
+		},
+		Entry("UT-KA-1390-018: completed + nil result",
+			"UT-KA-1390-018",
+			func(_ context.Context) (*katypes.InvestigationResult, error) { return nil, nil },
+			session.StatusCompleted, false, "Investigation completed without result",
+		),
+		Entry("UT-KA-1390-019: failed + nil result",
+			"UT-KA-1390-019",
+			func(_ context.Context) (*katypes.InvestigationResult, error) {
+				return nil, fmt.Errorf("LLM timeout after 30s")
+			},
+			session.StatusFailed, false, "LLM timeout",
+		),
+		Entry("UT-KA-1390-020: cancelled + nil result",
+			"UT-KA-1390-020",
+			func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			},
+			session.StatusCancelled, true, "cancelled",
+		),
+	)
+
+	Context("UT-KA-1390-021 [AU-12]: GetResult nil-result synthesis emits audit/log event", func() {
+		It("should log nil_result_synthesized message with session_id", func() {
+			id, err := manager.StartInvestigation(context.Background(), func(_ context.Context) (*katypes.InvestigationResult, error) {
+				return nil, nil
+			}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				sess, _ := manager.GetSession(id)
+				if sess == nil {
+					return ""
+				}
+				return sess.Status
+			}, 2*time.Second, 10*time.Millisecond).Should(Equal(session.StatusCompleted))
+
+			resp, err := getResult(id)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, ok := resp.(*agentclient.IncidentResponse)
+			Expect(ok).To(BeTrue(), "response must be *IncidentResponse (HTTP 200)")
+		})
+	})
+})

--- a/internal/kubernautagent/session/channel_lifecycle_1389_test.go
+++ b/internal/kubernautagent/session/channel_lifecycle_1389_test.go
@@ -116,6 +116,49 @@ var _ = Describe("Event channel lifecycle (#1389)", func() {
 				"if it panics, the defer closeEventChan bug (#1389) is present")
 	})
 
+	// UT-KA-1389-003: lazySink must be non-nil for every session, including
+	// pending interactive sessions that have not yet launched their goroutine.
+	// This guarantees that terminateSession/closeEventChan/Shutdown can always
+	// call lazySink.Set(nil) without a nil-pointer panic.
+	It("UT-KA-1389-003: lazySink is non-nil for pending interactive sessions", func() {
+		store := session.NewStore(30 * time.Minute)
+		mgr := session.NewManager(store, logr.Discard(), audit.NopAuditStore{}, nil)
+
+		id, err := mgr.StartInteractiveSession(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+			return &katypes.InvestigationResult{}, nil
+		}, map[string]string{"remediation_id": "rr-1389-003"})
+		Expect(err).NotTo(HaveOccurred())
+
+		sess, err := mgr.GetSession(id)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sess.Status).To(Equal(session.StatusPending))
+
+		ls, found := mgr.GetSessionLazySink(id)
+		Expect(found).To(BeTrue(), "lazySink must exist for pending sessions")
+		Expect(ls).NotTo(BeNil(), "lazySink must be non-nil by construction")
+	})
+
+	// UT-KA-1389-004: CancelInvestigation on a StatusPending interactive
+	// session must not panic. Before the fix, lazySink was nil for pending
+	// sessions, so terminateSession's lazySink.Set(nil) caused a nil deref.
+	It("UT-KA-1389-004: CancelInvestigation on pending session does not panic", func() {
+		store := session.NewStore(30 * time.Minute)
+		mgr := session.NewManager(store, logr.Discard(), audit.NopAuditStore{}, nil)
+
+		id, err := mgr.StartInteractiveSession(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+			return &katypes.InvestigationResult{}, nil
+		}, map[string]string{"remediation_id": "rr-1389-004"})
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(func() {
+			_ = mgr.CancelInvestigation(id)
+		}).NotTo(Panic(), "CancelInvestigation on a pending session must not panic")
+
+		sess, err := mgr.GetSession(id)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sess.Status).To(Equal(session.StatusCancelled))
+	})
+
 	// UT-KA-1389-002: Verifies that CompleteUserDriving closes the channel.
 	It("UT-KA-1389-002: CompleteUserDriving closes the event channel", func() {
 		store := session.NewStore(30 * time.Minute)

--- a/internal/kubernautagent/session/channel_lifecycle_1389_test.go
+++ b/internal/kubernautagent/session/channel_lifecycle_1389_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// trySend attempts a non-blocking send on the channel. Returns true if the
+// event was accepted, false if dropped (buffer full or nil sink), and panics
+// if the channel is closed — which is the exact production symptom of #1389.
+func trySend(ch chan<- session.InvestigationEvent, evt session.InvestigationEvent) (sent bool) {
+	defer func() {
+		if r := recover(); r != nil {
+			panic(r)
+		}
+	}()
+	if ch == nil {
+		return false
+	}
+	select {
+	case ch <- evt:
+		return true
+	default:
+		return false
+	}
+}
+
+var _ = Describe("Event channel lifecycle (#1389)", func() {
+
+	// UT-KA-1389-001: The core regression test.
+	// With the buggy defer, the investigation goroutine closes the channel
+	// on exit, so sending on it panics. With the fix, the channel stays
+	// open until session completion and workflow_discovery can emit events.
+	It("UT-KA-1389-001: event channel stays open after investigation goroutine exits", func() {
+		store := session.NewStore(30 * time.Minute)
+		mgr := session.NewManager(store, logr.Discard(), audit.NopAuditStore{}, nil)
+
+		subscribed := make(chan struct{})
+		id, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+			<-subscribed
+			return &katypes.InvestigationResult{
+				RCASummary:      "done",
+				InteractiveHold: true,
+			}, nil
+		}, map[string]string{"remediation_id": "rr-1389-001"})
+		Expect(err).NotTo(HaveOccurred())
+
+		ch, subErr := mgr.Subscribe(context.Background(), id)
+		Expect(subErr).NotTo(HaveOccurred())
+		Expect(ch).NotTo(BeNil())
+		close(subscribed)
+
+		// Wait for the goroutine to transition the session to UserDriving.
+		Eventually(func() session.Status {
+			s, _ := mgr.GetSession(id)
+			if s == nil {
+				return ""
+			}
+			return s.Status
+		}, 5*time.Second).Should(Equal(session.StatusUserDriving))
+
+		// Allow defers to fully complete.
+		time.Sleep(100 * time.Millisecond)
+
+		// Drain any buffered events (including EventTypeComplete).
+	drainLoop:
+		for {
+			select {
+			case _, ok := <-ch:
+				if !ok {
+					break drainLoop
+				}
+			default:
+				break drainLoop
+			}
+		}
+
+		// The LazySink must still be writable so workflow_discovery can
+		// emit events. With the buggy defer, the channel is closed and
+		// this send panics.
+		ls, found := mgr.GetSessionLazySink(id)
+		Expect(found).To(BeTrue(), "LazySink must still exist")
+		activeSink := ls.Get()
+
+		Expect(func() {
+			trySend(activeSink, session.InvestigationEvent{
+				Type:  session.EventTypeTokenDelta,
+				Phase: "workflow_discovery",
+			})
+		}).NotTo(Panic(),
+			"sending on event channel after investigation goroutine exits must not panic — "+
+				"if it panics, the defer closeEventChan bug (#1389) is present")
+	})
+
+	// UT-KA-1389-002: Verifies that CompleteUserDriving closes the channel.
+	It("UT-KA-1389-002: CompleteUserDriving closes the event channel", func() {
+		store := session.NewStore(30 * time.Minute)
+		mgr := session.NewManager(store, logr.Discard(), audit.NopAuditStore{}, nil)
+
+		subscribed := make(chan struct{})
+		id, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+			<-subscribed
+			return &katypes.InvestigationResult{
+				RCASummary:      "done",
+				InteractiveHold: true,
+			}, nil
+		}, map[string]string{"remediation_id": "rr-1389-002"})
+		Expect(err).NotTo(HaveOccurred())
+
+		ch, subErr := mgr.Subscribe(context.Background(), id)
+		Expect(subErr).NotTo(HaveOccurred())
+		close(subscribed)
+
+		// Wait for UserDriving status.
+		Eventually(func() session.Status {
+			s, _ := mgr.GetSession(id)
+			if s == nil {
+				return ""
+			}
+			return s.Status
+		}, 5*time.Second).Should(Equal(session.StatusUserDriving))
+
+		// Drain buffered events.
+	drainLoop:
+		for {
+			select {
+			case _, ok := <-ch:
+				if !ok {
+					break drainLoop
+				}
+			default:
+				break drainLoop
+			}
+		}
+
+		// Complete the session — this should close the channel.
+		err = mgr.CompleteUserDriving(id, &katypes.InvestigationResult{WorkflowID: "wf-1"})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Channel must be closed.
+		Eventually(func() bool {
+			select {
+			case _, ok := <-ch:
+				return !ok
+			default:
+				return false
+			}
+		}, 2*time.Second).Should(BeTrue(),
+			"event channel must be closed after CompleteUserDriving")
+	})
+})

--- a/internal/kubernautagent/session/event_sink.go
+++ b/internal/kubernautagent/session/event_sink.go
@@ -19,6 +19,7 @@ package session
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 )
 
 type eventSinkKey struct{}
@@ -100,4 +101,23 @@ func ActingUserFromContext(ctx context.Context) string {
 		return v
 	}
 	return ""
+}
+
+type interactiveUpgradeKey struct{}
+
+// WithInteractiveUpgrade returns a derived context carrying the interactive
+// upgrade atomic flag. The investigator goroutine checks this flag to decide
+// whether to set InteractiveHold=true on the result (BR-INTERACTIVE-004, #1390).
+func WithInteractiveUpgrade(ctx context.Context, flag *atomic.Bool) context.Context {
+	return context.WithValue(ctx, interactiveUpgradeKey{}, flag)
+}
+
+// InteractiveUpgradeFromContext reads the interactive upgrade flag from ctx.
+// Returns false if no flag was attached or the flag is false.
+func InteractiveUpgradeFromContext(ctx context.Context) bool {
+	flag, ok := ctx.Value(interactiveUpgradeKey{}).(*atomic.Bool)
+	if !ok || flag == nil {
+		return false
+	}
+	return flag.Load()
 }

--- a/internal/kubernautagent/session/event_sink_test.go
+++ b/internal/kubernautagent/session/event_sink_test.go
@@ -18,6 +18,7 @@ package session_test
 
 import (
 	"context"
+	"sync/atomic"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -80,6 +81,32 @@ var _ = Describe("Session ID Context Helpers — BR-AUDIT-070", func() {
 
 			Expect(session.SessionIDFromContext(ctx)).To(Equal("sess-coexist"))
 			Expect(session.EventSinkFromContext(ctx)).NotTo(BeNil())
+		})
+	})
+})
+
+var _ = Describe("Interactive Upgrade Context Helpers — #1390", func() {
+
+	Describe("UT-KA-1390-005 [SC-24]: InteractiveUpgradeFromContext returns false when no flag in context", func() {
+		It("returns false without panic on a plain context", func() {
+			ctx := context.Background()
+			Expect(session.InteractiveUpgradeFromContext(ctx)).To(BeFalse(),
+				"no upgrade flag attached — must return false")
+		})
+	})
+
+	Describe("UT-KA-1390-006 [SC-24]: InteractiveUpgradeFromContext reads true after Store(true) on atomic", func() {
+		It("returns true after a concurrent Store(true) on the shared atomic.Bool", func() {
+			flag := &atomic.Bool{}
+			ctx := session.WithInteractiveUpgrade(context.Background(), flag)
+
+			Expect(session.InteractiveUpgradeFromContext(ctx)).To(BeFalse(),
+				"before Store(true), must return false")
+
+			flag.Store(true)
+
+			Expect(session.InteractiveUpgradeFromContext(ctx)).To(BeTrue(),
+				"after Store(true), must return true via shared pointer")
 		})
 	})
 })

--- a/internal/kubernautagent/session/manager.go
+++ b/internal/kubernautagent/session/manager.go
@@ -582,18 +582,11 @@ func (m *Manager) Subscribe(ctx context.Context, id string) (<-chan Investigatio
 	if sess.eventChan == nil {
 		ch := make(chan InvestigationEvent, eventChannelBuffer)
 		sess.eventChan = ch
-		if sess.lazySink != nil {
-			sess.lazySink.Set(ch)
-			m.logger.Info("Subscribe: LazySink channel activated",
-				"session_id", id,
-				"status", string(sess.Status),
-				"has_lazy_sink", true,
-				"chan_ptr", fmt.Sprintf("%p", ch))
-		} else {
-			m.logger.Info("Subscribe: LazySink is nil — events will NOT flow",
-				"session_id", id,
-				"status", string(sess.Status))
-		}
+		sess.lazySink.Set(ch)
+		m.logger.Info("Subscribe: LazySink channel activated",
+			"session_id", id,
+			"status", string(sess.Status),
+			"chan_ptr", fmt.Sprintf("%p", ch))
 	}
 
 	ch := sess.eventChan
@@ -644,9 +637,7 @@ func (m *Manager) Shutdown() {
 				sess.cancel()
 			}
 			sess.Status = StatusCancelled
-			if sess.lazySink != nil {
-				sess.lazySink.Set(nil)
-			}
+			sess.lazySink.Set(nil)
 			if sess.eventChan != nil {
 				close(sess.eventChan)
 				sess.eventChan = nil
@@ -746,7 +737,7 @@ func (m *Manager) GetSessionLazySink(id string) (*LazySink, bool) {
 	m.store.mu.RLock()
 	defer m.store.mu.RUnlock()
 	sess, ok := m.store.sessions[id]
-	if !ok || sess.lazySink == nil {
+	if !ok {
 		return nil, false
 	}
 	return sess.lazySink, true

--- a/internal/kubernautagent/session/manager.go
+++ b/internal/kubernautagent/session/manager.go
@@ -357,6 +357,11 @@ func (m *Manager) terminateSession(id, eventType, action string) error {
 		sess.cancel()
 	}
 	sess.Status = StatusCancelled
+	sess.lazySink.Set(nil)
+	if sess.eventChan != nil {
+		close(sess.eventChan)
+		sess.eventChan = nil
+	}
 	correlationID := sess.Metadata["remediation_id"]
 	m.store.mu.Unlock()
 
@@ -619,9 +624,7 @@ func (m *Manager) closeEventChan(id string) {
 	if !ok {
 		return
 	}
-	if sess.lazySink != nil {
-		sess.lazySink.Set(nil)
-	}
+	sess.lazySink.Set(nil)
 	if sess.eventChan != nil {
 		close(sess.eventChan)
 		sess.eventChan = nil
@@ -767,9 +770,7 @@ func (m *Manager) ForceCompleteByRemediationID(rrID string, result *katypes.Inve
 			}
 			sess.Status = StatusCompleted
 			sess.Result = result
-			if sess.lazySink != nil {
-				sess.lazySink.Set(nil)
-			}
+			sess.lazySink.Set(nil)
 			if sess.eventChan != nil {
 				close(sess.eventChan)
 				sess.eventChan = nil

--- a/internal/kubernautagent/session/manager.go
+++ b/internal/kubernautagent/session/manager.go
@@ -165,6 +165,7 @@ func (m *Manager) launchInvestigation(ctx context.Context, id string, fn Investi
 	sess := m.store.sessions[id]
 	sess.cancel = cancelFn
 	sess.lazySink = ls
+	bgCtx = WithInteractiveUpgrade(bgCtx, sess.interactiveUpgrade)
 	m.logger.Info("launchInvestigation: LazySink attached to session",
 		"session_id", id,
 		"status", string(sess.Status),
@@ -318,6 +319,47 @@ func (m *Manager) LaunchDeferredInvestigation(id string) error {
 
 	_, err := m.launchInvestigation(context.Background(), id, fn, correlationID, signalName, severity, startExtra)
 	return err
+}
+
+// UpgradeToInteractive sets the interactive upgrade flag on a running session
+// without cancelling its goroutine. The background goroutine reads this flag
+// via InteractiveUpgradeFromContext to decide InteractiveHold. The store-level
+// mutex serialization in Update() guarantees a deterministic outcome (#1390).
+// Returns ErrSessionNotFound or ErrSessionTerminal on invalid state.
+func (m *Manager) UpgradeToInteractive(id string, username string, groups []string) error {
+	m.store.mu.Lock()
+	sess, ok := m.store.sessions[id]
+	if !ok {
+		m.store.mu.Unlock()
+		return ErrSessionNotFound
+	}
+	if IsTerminal(sess.Status) || sess.Status == StatusUserDriving {
+		m.store.mu.Unlock()
+		return ErrSessionTerminal
+	}
+	sess.interactiveUpgrade.Store(true)
+	if sess.Metadata == nil {
+		sess.Metadata = make(map[string]string)
+	}
+	sess.Metadata["acting_user"] = username
+	if len(groups) > 0 {
+		groupsJSON, _ := json.Marshal(groups)
+		sess.Metadata["acting_user_groups"] = string(groupsJSON)
+	}
+	correlationID := sess.Metadata["remediation_id"]
+	m.store.mu.Unlock()
+
+	m.logger.Info("session upgraded to interactive in-place",
+		"session_id", id,
+		"acting_user", username,
+		"remediation_id", correlationID)
+
+	m.emitSessionEvent(context.Background(),
+		audit.EventTypeSessionSuspended, audit.ActionSessionSuspended,
+		audit.OutcomeSuccess, id, correlationID, nil,
+		"acting_user", username, "upgrade_type", "jump_in")
+
+	return nil
 }
 
 // CancelInvestigation stops a running investigation by cancelling its context

--- a/internal/kubernautagent/session/manager.go
+++ b/internal/kubernautagent/session/manager.go
@@ -182,7 +182,6 @@ func (m *Manager) launchInvestigation(ctx context.Context, id string, fn Investi
 	go func() {
 		start := time.Now()
 		defer m.recordSessionMetrics(id, start)
-		defer m.closeEventChan(id)
 		defer m.recoverPanic(id, correlationID)
 
 		result, fnErr := fn(bgCtx)
@@ -198,6 +197,7 @@ func (m *Manager) launchInvestigation(ctx context.Context, id string, fn Investi
 					m.storePartialResult(id, nil)
 				}
 			} else {
+				m.closeEventChan(id)
 				m.emitSessionEvent(context.Background(), audit.EventTypeSessionFailed, audit.ActionSessionFailed, audit.OutcomeFailure, id, correlationID, fnErr)
 			}
 			return
@@ -215,6 +215,9 @@ func (m *Manager) launchInvestigation(ctx context.Context, id string, fn Investi
 				m.storePartialResult(id, result)
 			}
 		} else {
+			if targetStatus != StatusUserDriving {
+				m.closeEventChan(id)
+			}
 			m.emitSessionEvent(context.Background(), audit.EventTypeSessionCompleted, audit.ActionSessionCompleted, audit.OutcomeSuccess, id, correlationID, nil)
 		}
 	}()
@@ -616,6 +619,9 @@ func (m *Manager) closeEventChan(id string) {
 	if !ok {
 		return
 	}
+	if sess.lazySink != nil {
+		sess.lazySink.Set(nil)
+	}
 	if sess.eventChan != nil {
 		close(sess.eventChan)
 		sess.eventChan = nil
@@ -635,6 +641,13 @@ func (m *Manager) Shutdown() {
 				sess.cancel()
 			}
 			sess.Status = StatusCancelled
+			if sess.lazySink != nil {
+				sess.lazySink.Set(nil)
+			}
+			if sess.eventChan != nil {
+				close(sess.eventChan)
+				sess.eventChan = nil
+			}
 			running = append(running, id)
 		}
 	}
@@ -689,6 +702,8 @@ func (m *Manager) CompleteUserDriving(id string, result *katypes.InvestigationRe
 	if err := m.store.CompleteUserDriving(id, result); err != nil {
 		return err
 	}
+	m.closeEventChan(id)
+
 	m.store.mu.RLock()
 	sess := m.store.sessions[id]
 	var correlationID string
@@ -744,7 +759,6 @@ func (m *Manager) GetSessionLazySink(id string) (*LazySink, bool) {
 // already completed before takeover.
 func (m *Manager) ForceCompleteByRemediationID(rrID string, result *katypes.InvestigationResult) error {
 	m.store.mu.Lock()
-	defer m.store.mu.Unlock()
 	for _, sess := range m.store.sessions {
 		if sess.Metadata["remediation_id"] == rrID && !IsTerminal(sess.Status) {
 			prevStatus := sess.Status
@@ -753,11 +767,20 @@ func (m *Manager) ForceCompleteByRemediationID(rrID string, result *katypes.Inve
 			}
 			sess.Status = StatusCompleted
 			sess.Result = result
+			if sess.lazySink != nil {
+				sess.lazySink.Set(nil)
+			}
+			if sess.eventChan != nil {
+				close(sess.eventChan)
+				sess.eventChan = nil
+			}
+			m.store.mu.Unlock()
 			m.logger.Info("Force-completed session by remediation ID",
 				"remediation_id", rrID, "previous_status", string(prevStatus))
 			return nil
 		}
 	}
+	m.store.mu.Unlock()
 	return ErrSessionNotFound
 }
 

--- a/internal/kubernautagent/session/manager.go
+++ b/internal/kubernautagent/session/manager.go
@@ -721,6 +721,19 @@ func (m *Manager) FindUserDrivingByRemediationID(rrID string) (string, bool) {
 	return "", false
 }
 
+// GetSessionLazySink returns the LazySink for the given session ID so that
+// callers (e.g. handleDiscoverWorkflows) can attach it to a context for
+// streaming events during workflow discovery (#1384).
+func (m *Manager) GetSessionLazySink(id string) (*LazySink, bool) {
+	m.store.mu.RLock()
+	defer m.store.mu.RUnlock()
+	sess, ok := m.store.sessions[id]
+	if !ok || sess.lazySink == nil {
+		return nil, false
+	}
+	return sess.lazySink, true
+}
+
 // ForceCompleteByRemediationID locates any session (Running, UserDriving, or
 // Completed) matching the given remediation ID and forces it to StatusCompleted
 // with the provided result. Cancels the investigation goroutine if still running.

--- a/internal/kubernautagent/session/manager_upgrade_test.go
+++ b/internal/kubernautagent/session/manager_upgrade_test.go
@@ -1,0 +1,425 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+type spyAuditStore struct {
+	mu     sync.Mutex
+	events []*audit.AuditEvent
+}
+
+func (s *spyAuditStore) StoreAudit(_ context.Context, event *audit.AuditEvent) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.events = append(s.events, event)
+	return nil
+}
+
+func (s *spyAuditStore) Events() []*audit.AuditEvent {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	cp := make([]*audit.AuditEvent, len(s.events))
+	copy(cp, s.events)
+	return cp
+}
+
+var _ = Describe("Fix #1390: Jump-In Session Upgrade (BR-INTERACTIVE-004, BR-REL-014)", func() {
+
+	var (
+		store   *session.Store
+		manager *session.Manager
+	)
+
+	BeforeEach(func() {
+		store = session.NewStore(5 * time.Minute)
+		manager = session.NewManager(store, logr.Discard(), nil, nil)
+	})
+
+	Describe("UT-KA-1390-001 [SC-24]: UpgradeToInteractive sets atomic flag without cancelling goroutine", func() {
+		It("should set upgrade flag while keeping session running and goroutine alive", func() {
+			doneCh := make(chan struct{})
+			id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				<-ctx.Done()
+				close(doneCh)
+				return &katypes.InvestigationResult{RCASummary: "cancelled"}, nil
+			}, map[string]string{"remediation_id": "rr-upgrade-001"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				s, _ := manager.GetSession(id)
+				if s == nil {
+					return ""
+				}
+				return s.Status
+			}, 2*time.Second, 50*time.Millisecond).Should(Equal(session.StatusRunning))
+
+			err = manager.UpgradeToInteractive(id, "testuser", []string{"group1"})
+			Expect(err).NotTo(HaveOccurred())
+
+			sess, err := manager.GetSession(id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sess.Status).To(Equal(session.StatusRunning),
+				"status must remain running — upgrade does not change it")
+
+			Consistently(doneCh, 200*time.Millisecond).ShouldNot(BeClosed(),
+				"goroutine must NOT be cancelled by upgrade")
+		})
+	})
+
+	Describe("UT-KA-1390-002 [AU-12]: UpgradeToInteractive writes acting_user and groups to metadata", func() {
+		It("should populate acting_user and acting_user_groups in session metadata", func() {
+			id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}, map[string]string{"remediation_id": "rr-upgrade-002"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				s, _ := manager.GetSession(id)
+				if s == nil {
+					return ""
+				}
+				return s.Status
+			}, 2*time.Second, 50*time.Millisecond).Should(Equal(session.StatusRunning))
+
+			err = manager.UpgradeToInteractive(id, "alice", []string{"sre-team", "on-call"})
+			Expect(err).NotTo(HaveOccurred())
+
+			sess, err := manager.GetSession(id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sess.Metadata["acting_user"]).To(Equal("alice"))
+			Expect(sess.Metadata["acting_user_groups"]).To(ContainSubstring("sre-team"))
+			Expect(sess.Metadata["acting_user_groups"]).To(ContainSubstring("on-call"))
+		})
+	})
+
+	Describe("UT-KA-1390-003 [SI-10]: UpgradeToInteractive on terminal session returns ErrSessionTerminal", func() {
+		It("should reject upgrade on a completed session", func() {
+			id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				return &katypes.InvestigationResult{RCASummary: "done"}, nil
+			}, map[string]string{"remediation_id": "rr-upgrade-003"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				s, _ := manager.GetSession(id)
+				if s == nil {
+					return ""
+				}
+				return s.Status
+			}, 2*time.Second, 50*time.Millisecond).Should(Equal(session.StatusCompleted))
+
+			err = manager.UpgradeToInteractive(id, "bob", nil)
+			Expect(err).To(MatchError(session.ErrSessionTerminal))
+		})
+	})
+
+	Describe("UT-KA-1390-004 [SI-10]: UpgradeToInteractive on non-existent session returns ErrSessionNotFound", func() {
+		It("should return ErrSessionNotFound for unknown ID", func() {
+			err := manager.UpgradeToInteractive("nonexistent-session-id", "bob", nil)
+			Expect(err).To(MatchError(session.ErrSessionNotFound))
+		})
+	})
+
+	Describe("UT-KA-1390-007 [SC-24]: Goroutine with upgrade flag stores result via Update(running->user_driving)", func() {
+		It("should transition to user_driving with result when upgrade flag is set before InteractiveHold check", func() {
+			upgradeDone := make(chan struct{})
+			id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				<-upgradeDone
+				return &katypes.InvestigationResult{
+					RCASummary:      "RCA with upgrade",
+					Confidence:      0.95,
+					InteractiveHold: session.InteractiveUpgradeFromContext(ctx),
+				}, nil
+			}, map[string]string{"remediation_id": "rr-upgrade-007"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				s, _ := manager.GetSession(id)
+				if s == nil {
+					return ""
+				}
+				return s.Status
+			}, 2*time.Second, 50*time.Millisecond).Should(Equal(session.StatusRunning))
+
+			Expect(manager.UpgradeToInteractive(id, "testuser", nil)).To(Succeed())
+			close(upgradeDone)
+
+			Eventually(func() session.Status {
+				s, _ := manager.GetSession(id)
+				if s == nil {
+					return ""
+				}
+				return s.Status
+			}, 2*time.Second, 50*time.Millisecond).Should(Equal(session.StatusUserDriving))
+
+			sess, err := manager.GetSession(id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sess.Result).NotTo(BeNil())
+			Expect(sess.Result.InteractiveHold).To(BeTrue())
+			Expect(sess.Result.RCASummary).To(Equal("RCA with upgrade"))
+		})
+	})
+
+	Describe("UT-KA-1390-008 [SI-4]: Event channel stays open after upgrade + InteractiveHold completion", func() {
+		It("should keep event channel open for post-RCA streaming (workflow discovery)", func() {
+			ready := make(chan struct{})
+			proceed := make(chan struct{})
+			id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				close(ready)
+				<-proceed
+				return &katypes.InvestigationResult{
+					RCASummary:      "RCA complete",
+					InteractiveHold: session.InteractiveUpgradeFromContext(ctx),
+				}, nil
+			}, map[string]string{"remediation_id": "rr-upgrade-008"})
+			Expect(err).NotTo(HaveOccurred())
+
+			<-ready
+			Expect(manager.UpgradeToInteractive(id, "testuser", nil)).To(Succeed())
+			close(proceed)
+
+			Eventually(func() session.Status {
+				s, _ := manager.GetSession(id)
+				if s == nil {
+					return ""
+				}
+				return s.Status
+			}, 2*time.Second, 50*time.Millisecond).Should(Equal(session.StatusUserDriving))
+
+			ch, err := manager.Subscribe(context.Background(), id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ch).NotTo(BeNil(), "event channel must be open for post-RCA events")
+		})
+	})
+
+	Describe("UT-KA-1390-009 [SI-4]: LazySink activation post-upgrade delivers events to subscriber", func() {
+		It("should deliver events via LazySink after Subscribe on an upgraded session", func() {
+			eventSent := make(chan struct{})
+			id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				sink := session.EventSinkFromContext(ctx)
+				for sink == nil {
+					time.Sleep(10 * time.Millisecond)
+					sink = session.EventSinkFromContext(ctx)
+				}
+				sink <- session.InvestigationEvent{Type: session.EventTypeReasoningDelta, Data: json.RawMessage(`"streaming-after-upgrade"`)}
+				close(eventSent)
+				return &katypes.InvestigationResult{
+					RCASummary:      "streamed RCA",
+					InteractiveHold: session.InteractiveUpgradeFromContext(ctx),
+				}, nil
+			}, map[string]string{"remediation_id": "rr-upgrade-009"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				s, _ := manager.GetSession(id)
+				if s == nil {
+					return ""
+				}
+				return s.Status
+			}, 2*time.Second, 50*time.Millisecond).Should(Equal(session.StatusRunning))
+
+			Expect(manager.UpgradeToInteractive(id, "testuser", nil)).To(Succeed())
+
+			ch, err := manager.Subscribe(context.Background(), id)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(eventSent, 2*time.Second).Should(BeClosed())
+			Eventually(ch, 500*time.Millisecond).Should(Receive(HaveField("Data", json.RawMessage(`"streaming-after-upgrade"`))))
+		})
+	})
+
+	Describe("Store-Level Deterministic Upgrade (eliminates race window)", func() {
+
+		Context("UT-KA-1390-027 [SC-24]: store.Update with StatusCompleted + interactiveUpgrade=true forces StatusUserDriving", func() {
+			It("should force user_driving and set InteractiveHold when upgrade flag was set before completion", func() {
+				id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+					return &katypes.InvestigationResult{
+						RCASummary:      "Autonomous RCA — investigator did not see upgrade flag",
+						Confidence:      0.9,
+						InteractiveHold: false,
+					}, nil
+				}, map[string]string{"remediation_id": "rr-upgrade-027"})
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(manager.UpgradeToInteractive(id, "testuser", nil)).To(Succeed())
+
+				Eventually(func() session.Status {
+					s, _ := manager.GetSession(id)
+					if s == nil {
+						return ""
+					}
+					return s.Status
+				}, 2*time.Second, 50*time.Millisecond).Should(Equal(session.StatusUserDriving),
+					"store.Update must force user_driving when interactiveUpgrade is set")
+
+				sess, err := manager.GetSession(id)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(sess.Result).NotTo(BeNil())
+				Expect(sess.Result.InteractiveHold).To(BeTrue(),
+					"store.Update must set InteractiveHold=true on the result")
+				Expect(sess.Result.RCASummary).To(Equal("Autonomous RCA — investigator did not see upgrade flag"))
+			})
+		})
+
+		Context("UT-KA-1390-028 [SC-24]: store.Update with StatusCompleted + interactiveUpgrade=false remains StatusCompleted", func() {
+			It("should not falsely promote to user_driving when no upgrade was requested", func() {
+				id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+					return &katypes.InvestigationResult{
+						RCASummary:      "Normal autonomous completion",
+						InteractiveHold: false,
+					}, nil
+				}, map[string]string{"remediation_id": "rr-upgrade-028"})
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() session.Status {
+					s, _ := manager.GetSession(id)
+					if s == nil {
+						return ""
+					}
+					return s.Status
+				}, 2*time.Second, 50*time.Millisecond).Should(Equal(session.StatusCompleted))
+
+				sess, err := manager.GetSession(id)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(sess.Result).NotTo(BeNil())
+				Expect(sess.Result.InteractiveHold).To(BeFalse(),
+					"no upgrade flag — InteractiveHold must remain false")
+			})
+		})
+
+		Context("UT-KA-1390-029 [SC-24]: UpgradeToInteractive after store.Update(completed) returns ErrSessionTerminal", func() {
+			It("should return ErrSessionTerminal when goroutine won the lock race", func() {
+				id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+					return &katypes.InvestigationResult{
+						RCASummary:      "Fast autonomous completion",
+						InteractiveHold: false,
+					}, nil
+				}, map[string]string{"remediation_id": "rr-upgrade-029"})
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(func() session.Status {
+					s, _ := manager.GetSession(id)
+					if s == nil {
+						return ""
+					}
+					return s.Status
+				}, 2*time.Second, 50*time.Millisecond).Should(Equal(session.StatusCompleted))
+
+				err = manager.UpgradeToInteractive(id, "late-user", nil)
+				Expect(err).To(MatchError(session.ErrSessionTerminal),
+					"upgrade on a completed session must fail so handleStart falls back to ForceTransitionToUserDriving")
+			})
+		})
+	})
+})
+
+// ========================================
+// Fix #1390 Layer 4: Observability
+// ========================================
+
+var _ = Describe("Fix #1390 Layer 4: Session Observability", func() {
+	var (
+		manager  *session.Manager
+		auditSpy *spyAuditStore
+	)
+
+	BeforeEach(func() {
+		store := session.NewStore(5 * time.Minute)
+		auditSpy = &spyAuditStore{}
+		manager = session.NewManager(store, logr.Discard(), auditSpy, nil)
+	})
+
+	Context("UT-KA-1390-025 [SC-8, AU-12]: Autonomous session bgCtx carries session_id", func() {
+		It("should propagate session_id into the investigation goroutine context", func() {
+			var capturedSessionID string
+			ready := make(chan struct{})
+			proceed := make(chan struct{})
+
+			id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				capturedSessionID = session.SessionIDFromContext(ctx)
+				close(ready)
+				<-proceed
+				return &katypes.InvestigationResult{RCASummary: "done"}, nil
+			}, nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			<-ready
+			close(proceed)
+
+			Expect(capturedSessionID).To(Equal(id),
+				"bgCtx must carry session_id via WithSessionID for audit traceability")
+		})
+	})
+
+	Context("UT-KA-1390-026 [AU-12]: UpgradeToInteractive emits audit event with session_id and acting_user", func() {
+		It("should emit session.suspended audit event with correct fields on upgrade", func() {
+			ready := make(chan struct{})
+			proceed := make(chan struct{})
+
+			id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				close(ready)
+				<-proceed
+				return &katypes.InvestigationResult{
+					RCASummary:      "RCA with upgrade",
+					InteractiveHold: session.InteractiveUpgradeFromContext(ctx),
+				}, nil
+			}, map[string]string{"remediation_id": "rr-audit-026"})
+			Expect(err).NotTo(HaveOccurred())
+
+			<-ready
+			err = manager.UpgradeToInteractive(id, "sre-auditor@example.com", []string{"sre-team"})
+			Expect(err).NotTo(HaveOccurred())
+			close(proceed)
+
+			sess, getErr := manager.GetSession(id)
+			Expect(getErr).NotTo(HaveOccurred())
+			Expect(sess.Metadata["acting_user"]).To(Equal("sre-auditor@example.com"),
+				"acting_user must be set in metadata for audit traceability")
+
+			events := auditSpy.Events()
+			var upgradeEvent *audit.AuditEvent
+			for _, e := range events {
+				if e.EventType == audit.EventTypeSessionSuspended && e.SessionID == id {
+					upgradeEvent = e
+					break
+				}
+			}
+			Expect(upgradeEvent).NotTo(BeNil(),
+				"UpgradeToInteractive must emit EventTypeSessionSuspended audit event")
+			Expect(upgradeEvent.CorrelationID).To(Equal("rr-audit-026"),
+				"audit event must carry correlation ID from session metadata")
+			Expect(upgradeEvent.Data).To(HaveKeyWithValue("acting_user", "sre-auditor@example.com"),
+				"audit event must include acting_user in data")
+			Expect(upgradeEvent.Data).To(HaveKeyWithValue("upgrade_type", "jump_in"),
+				"audit event must include upgrade_type=jump_in in data")
+		})
+	})
+})

--- a/internal/kubernautagent/session/store.go
+++ b/internal/kubernautagent/session/store.go
@@ -21,6 +21,7 @@ import (
 	"errors"
 	"fmt"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -64,6 +65,11 @@ type Session struct {
 	cancel    context.CancelFunc
 	eventChan chan InvestigationEvent
 	lazySink  *LazySink
+
+	// interactiveUpgrade is set by UpgradeToInteractive under store.mu.
+	// Checked by store.Update under the same lock to guarantee deterministic
+	// upgrade when the goroutine completes (#1390).
+	interactiveUpgrade *atomic.Bool
 
 	// deferredFn holds the investigation function for interactive sessions
 	// created in pending state (BR-INTERACTIVE-010). Consumed by
@@ -139,10 +145,11 @@ func NewStore(ttl time.Duration, opts ...StoreOption) *Store {
 func (s *Store) Create() (string, error) {
 	id := uuid.New().String()
 	sess := &Session{
-		ID:        id,
-		Status:    StatusPending,
-		CreatedAt: time.Now(),
-		lazySink:  &LazySink{},
+		ID:                 id,
+		Status:             StatusPending,
+		CreatedAt:          time.Now(),
+		lazySink:           &LazySink{},
+		interactiveUpgrade: &atomic.Bool{},
 	}
 	s.mu.Lock()
 	if s.maxConcurrent > 0 {
@@ -210,6 +217,11 @@ func IsTerminal(st Status) bool {
 	return st == StatusCompleted || st == StatusFailed || st == StatusCancelled
 }
 
+// IsTerminal reports whether this status represents a final state.
+func (st Status) IsTerminal() bool {
+	return IsTerminal(st)
+}
+
 // SetMetadata stores request-level metadata on an existing session.
 // Deprecated: Use SetContext for typed access. Retained for backward compatibility.
 func (s *Store) SetMetadata(id string, metadata map[string]string) {
@@ -231,6 +243,11 @@ func (s *Store) SetContext(id string, ctx SessionContext) {
 
 // Update modifies an existing session. Returns ErrSessionTerminal if the
 // session has already reached a terminal state (completed, cancelled, failed).
+//
+// Deterministic upgrade (#1390): if the goroutine completes with StatusCompleted
+// but UpgradeToInteractive has set interactiveUpgrade=true (under this same mu),
+// the status is forced to StatusUserDriving and result.InteractiveHold is set.
+// This serialization eliminates the race between upgrade and completion.
 func (s *Store) Update(id string, status Status, result *katypes.InvestigationResult, err error) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -240,6 +257,12 @@ func (s *Store) Update(id string, status Status, result *katypes.InvestigationRe
 	}
 	if IsTerminal(sess.Status) || sess.Status == StatusUserDriving {
 		return ErrSessionTerminal
+	}
+	if status == StatusCompleted && sess.interactiveUpgrade != nil && sess.interactiveUpgrade.Load() {
+		status = StatusUserDriving
+		if result != nil {
+			result.InteractiveHold = true
+		}
 	}
 	sess.Status = status
 	sess.Result = result

--- a/internal/kubernautagent/session/store.go
+++ b/internal/kubernautagent/session/store.go
@@ -142,6 +142,7 @@ func (s *Store) Create() (string, error) {
 		ID:        id,
 		Status:    StatusPending,
 		CreatedAt: time.Now(),
+		lazySink:  &LazySink{},
 	}
 	s.mu.Lock()
 	if s.maxConcurrent > 0 {

--- a/pkg/aianalysis/handlers/constants.go
+++ b/pkg/aianalysis/handlers/constants.go
@@ -67,6 +67,11 @@ const (
 	// BR-AA-HAPI-064.6: Cap at 5 regenerations
 	MaxSessionRegenerations int32 = 5
 
+	// MaxConsecutiveGetResultErrors is the maximum number of consecutive 409 errors
+	// from GetSessionResult before the session is regenerated. #1390: Breaks the
+	// nil-result 409 polling loop by treating repeated 409s as a non-recoverable state.
+	MaxConsecutiveGetResultErrors int32 = 3
+
 	// DefaultSessionPollInterval is the constant polling interval for session status checks.
 	// BR-AA-HAPI-064.8: Polling is not error recovery -- KA is healthy, just not done yet.
 	// A constant interval is simpler, predictable, and sufficient for async LLM investigations.

--- a/pkg/aianalysis/handlers/investigating.go
+++ b/pkg/aianalysis/handlers/investigating.go
@@ -385,8 +385,10 @@ func (h *InvestigatingHandler) handleSessionBased(ctx context.Context, analysis 
 }
 
 // checkISMismatchAndCancel detects when the InvestigationSession CRD state has changed
-// since the last submit and cancels the KA session to trigger re-submit or terminal failure.
-// Returns (result, true) if cancellation was initiated, (_, false) to proceed with normal polling.
+// since the last submit and handles the transition. For autonomous→interactive upgrade
+// (#1390), sets Interactive=true and calls SetActivePhase instead of cancelling, preserving
+// the running KA session. For IS deletion, cancels the KA session.
+// Returns (result, true) if action was taken, (_, false) to proceed with normal polling.
 func (h *InvestigatingHandler) checkISMismatchAndCancel(ctx context.Context, analysis *aianalysisv1.AIAnalysis) (ctrl.Result, bool) {
 	if h.isChecker == nil {
 		return ctrl.Result{}, false
@@ -406,14 +408,18 @@ func (h *InvestigatingHandler) checkISMismatchAndCancel(ctx context.Context, ana
 
 	switch {
 	case hasIS && !session.Interactive:
-		// IS appeared after autonomous submit → cancel for interactive takeover
-		h.log.Info("IS CRD detected for autonomous session — cancelling for interactive takeover",
+		// #1390: IS appeared for autonomous session → upgrade in-place (no cancel).
+		// KA's UpgradeToInteractive sets the atomic flag; the goroutine will hold
+		// the session open for MCP takeover. Session ID is preserved.
+		h.log.Info("IS CRD detected for autonomous session — upgrading to interactive in-place",
 			"sessionID", session.ID, "rrName", rrName)
-		if cancelErr := h.kaClient.CancelSession(ctx, session.ID); cancelErr != nil {
-			h.log.Error(cancelErr, "Failed to cancel session for takeover; will retry", "sessionID", session.ID)
-			return ctrl.Result{RequeueAfter: 5 * time.Second}, true
+		session.Interactive = true
+		if h.isPhaseUpdater != nil {
+			if phaseErr := h.isPhaseUpdater.SetActivePhase(ctx, rrName); phaseErr != nil {
+				h.log.Error(phaseErr, "Failed to set IS phase to Active after upgrade (best-effort)",
+					"rrName", rrName, "sessionID", session.ID)
+			}
 		}
-		session.ID = ""
 		return ctrl.Result{Requeue: true}, true
 
 	case !hasIS && session.Interactive:
@@ -732,6 +738,9 @@ func (h *InvestigatingHandler) handleSessionIncidentResult(ctx context.Context, 
 		return h.handleSessionGetResultError(ctx, analysis, err)
 	}
 
+	// #1390: Reset consecutive 409 error counter on successful result retrieval.
+	session.ConsecutiveGetResultErrors = 0
+
 	// Set investigation metadata
 	analysis.Status.InvestigationTime = investigationTime
 	analysis.Status.ObservedGeneration = analysis.Generation
@@ -919,7 +928,7 @@ func (h *InvestigatingHandler) handleSessionLost(ctx context.Context, analysis *
 }
 
 // handleSessionGetResultError handles errors when fetching the session result.
-// BR-AA-HAPI-064: 409 Conflict treated as transient (re-poll gracefully at standard interval)
+// BR-AA-HAPI-064: 409 Conflict tracked with consecutive error counter (#1390)
 // AA-HIGH-1: 404 triggers session regeneration (same as poll 404)
 func (h *InvestigatingHandler) handleSessionGetResultError(ctx context.Context, analysis *aianalysisv1.AIAnalysis, err error) (ctrl.Result, error) {
 	var apiErr *agentclient.APIError
@@ -931,11 +940,19 @@ func (h *InvestigatingHandler) handleSessionGetResultError(ctx context.Context, 
 			)
 			return h.handleSessionLost(ctx, analysis)
 		case 409:
-			h.log.Info("GetSessionResult returned 409 Conflict, treating as transient",
-				"sessionID", analysis.Status.KASession.ID,
+			session := analysis.Status.KASession
+			session.ConsecutiveGetResultErrors++
+			h.log.Info("GetSessionResult returned 409 Conflict",
+				"sessionID", session.ID,
+				"consecutiveErrors", session.ConsecutiveGetResultErrors,
 			)
-			// PollCount and LastPolled already incremented by handleSessionPollCompleted
-			// which is the only caller of handleSessionIncidentResult.
+			if session.ConsecutiveGetResultErrors >= MaxConsecutiveGetResultErrors {
+				h.log.Info("409 retry cap reached, regenerating session",
+					"sessionID", session.ID,
+					"cap", MaxConsecutiveGetResultErrors,
+				)
+				return h.handleSessionLost(ctx, analysis)
+			}
 			return ctrl.Result{RequeueAfter: h.sessionPollInterval}, nil
 		}
 	}

--- a/pkg/aianalysis/investigating_handler_recovery_test.go
+++ b/pkg/aianalysis/investigating_handler_recovery_test.go
@@ -25,6 +25,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	aianalysisv1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/agentclient"
 	aiaudit "github.com/jordigilh/kubernaut/pkg/aianalysis/audit"
 	"github.com/jordigilh/kubernaut/pkg/aianalysis/handlers"
 	"github.com/jordigilh/kubernaut/pkg/aianalysis/metrics"
@@ -95,5 +96,128 @@ var _ = Describe("AA-H4: Investigating Handler Session Recovery", func() {
 		// PollCount should be incremented by the handler
 		Expect(analysis.Status.KASession.PollCount).To(Equal(int32(4)),
 			"PollCount must increment after successful poll")
+	})
+})
+
+// ========================================
+// Fix #1390: AA 409 Retry Cap
+//
+// UT-AA-1390-022..024: Validate that the handler caps consecutive 409 errors
+// from GetSessionResult and triggers session regeneration after 3 consecutive failures.
+// ========================================
+
+var _ = Describe("Fix #1390: AA GetResult 409 Retry Cap — BR-REL-014", func() {
+	var (
+		ctx             context.Context
+		mockAgentClient *mocks.MockAgentClient
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		mockAgentClient = mocks.NewMockAgentClient()
+	})
+
+	createCompletedAnalysis := func(sessionID string, consecutiveErrors int32) *aianalysisv1.AIAnalysis {
+		now := metav1.Now()
+		return &aianalysisv1.AIAnalysis{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "aa-1390-retry",
+				Namespace: "default",
+			},
+			Status: aianalysisv1.AIAnalysisStatus{
+				Phase: "Investigating",
+				KASession: &aianalysisv1.KASession{
+					ID:                         sessionID,
+					CreatedAt:                  &now,
+					PollCount:                  5,
+					ConsecutiveGetResultErrors: consecutiveErrors,
+				},
+			},
+		}
+	}
+
+	Context("UT-AA-1390-022 [SI-13]: Third consecutive GetResult 409 triggers session regeneration", func() {
+		It("should clear session ID and requeue after 3 consecutive 409 errors", func() {
+			mockAgentClient.WithSessionPollStatus("completed")
+			mockAgentClient.GetResultErr = &agentclient.APIError{StatusCode: 409, Message: "session result is not an investigation result"}
+
+			mockAuditStore := NewMockAuditStore()
+			auditClient := aiaudit.NewAuditClient(mockAuditStore, ctrl.Log.WithName("test-409-cap"))
+			testMetrics := metrics.NewMetrics()
+			handler := handlers.NewInvestigatingHandler(
+				mockAgentClient,
+				ctrl.Log.WithName("test-1390-022"),
+				testMetrics,
+				auditClient,
+				handlers.WithSessionMode(),
+			)
+
+			analysis := createCompletedAnalysis("session-409-cap", 2)
+
+			result, err := handler.Handle(ctx, analysis)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(analysis.Status.KASession.ID).To(BeEmpty(),
+				"session ID must be cleared after 3 consecutive 409 errors")
+			Expect(result.Requeue).To(BeTrue(),
+				"should requeue for re-submit (session regeneration)")
+		})
+	})
+
+	Context("UT-AA-1390-023 [SI-13]: Successful GetResult resets consecutive error counter to 0", func() {
+		It("should reset ConsecutiveGetResultErrors to 0 on successful result retrieval", func() {
+			mockAgentClient.WithSessionPollStatus("completed")
+			mockAgentClient.Response = &agentclient.IncidentResponse{
+				IncidentID: "test-success",
+				Analysis:   "Test completed successfully",
+				Confidence: 0.9,
+			}
+
+			mockAuditStore := NewMockAuditStore()
+			auditClient := aiaudit.NewAuditClient(mockAuditStore, ctrl.Log.WithName("test-409-reset"))
+			testMetrics := metrics.NewMetrics()
+			handler := handlers.NewInvestigatingHandler(
+				mockAgentClient,
+				ctrl.Log.WithName("test-1390-023"),
+				testMetrics,
+				auditClient,
+				handlers.WithSessionMode(),
+			)
+
+			analysis := createCompletedAnalysis("session-409-reset", 2)
+
+			_, err := handler.Handle(ctx, analysis)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(analysis.Status.KASession.ConsecutiveGetResultErrors).To(Equal(int32(0)),
+				"ConsecutiveGetResultErrors must be reset to 0 after successful result")
+		})
+	})
+
+	Context("UT-AA-1390-024 [AC-12]: Regeneration clears session ID and requeues for re-submit", func() {
+		It("should increment consecutive errors and requeue on first 409", func() {
+			mockAgentClient.WithSessionPollStatus("completed")
+			mockAgentClient.GetResultErr = &agentclient.APIError{StatusCode: 409, Message: "session not completed"}
+
+			mockAuditStore := NewMockAuditStore()
+			auditClient := aiaudit.NewAuditClient(mockAuditStore, ctrl.Log.WithName("test-409-inc"))
+			testMetrics := metrics.NewMetrics()
+			handler := handlers.NewInvestigatingHandler(
+				mockAgentClient,
+				ctrl.Log.WithName("test-1390-024"),
+				testMetrics,
+				auditClient,
+				handlers.WithSessionMode(),
+			)
+
+			analysis := createCompletedAnalysis("session-409-first", 0)
+
+			result, err := handler.Handle(ctx, analysis)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(analysis.Status.KASession.ConsecutiveGetResultErrors).To(Equal(int32(1)),
+				"ConsecutiveGetResultErrors must increment on 409")
+			Expect(analysis.Status.KASession.ID).NotTo(BeEmpty(),
+				"session ID must NOT be cleared on first 409 — only after 3")
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0),
+				"should requeue for next poll at standard interval")
+		})
 	})
 })

--- a/pkg/aianalysis/investigating_handler_session_test.go
+++ b/pkg/aianalysis/investigating_handler_session_test.go
@@ -29,6 +29,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	aianalysisv1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
+	isv1alpha1 "github.com/jordigilh/kubernaut/api/investigationsession/v1alpha1"
 	"github.com/jordigilh/kubernaut/internal/controller/aianalysis"
 	"github.com/jordigilh/kubernaut/pkg/aianalysis/handlers"
 	"github.com/jordigilh/kubernaut/pkg/aianalysis/metrics"
@@ -906,13 +907,13 @@ var _ = Describe("InvestigatingHandler IS Mismatch Detection", func() {
 		recorder = record.NewFakeRecorder(10)
 	})
 
-	Context("UT-AA-1293-SC1-005: Autonomous session + IS appears → cancel for takeover", func() {
-		It("should cancel the session and clear ID for re-submit", func() {
-			cancelClient := mocks.NewMockAgentClient()
-			cancelClient.WithSessionPollStatus("investigating")
+	Context("UT-AA-1293-SC1-005: Autonomous session + IS appears → upgrade in-place (#1390)", func() {
+		It("should set Interactive=true and preserve session ID without cancel", func() {
+			upgradeClient := mocks.NewMockAgentClient()
+			upgradeClient.WithSessionPollStatus("investigating")
 			isChecker := &mockISChecker{hasSession: true}
 			testMetrics := metrics.NewMetrics()
-			h := handlers.NewInvestigatingHandler(cancelClient, ctrl.Log.WithName("test-takeover"), testMetrics, auditSpy,
+			h := handlers.NewInvestigatingHandler(upgradeClient, ctrl.Log.WithName("test-takeover"), testMetrics, auditSpy,
 				handlers.WithSessionMode(), handlers.WithRecorder(recorder),
 				handlers.WithInvestigationSessionChecker(isChecker))
 
@@ -932,8 +933,12 @@ var _ = Describe("InvestigatingHandler IS Mismatch Detection", func() {
 			result, err := h.Handle(context.Background(), analysis)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.Requeue).To(BeTrue())
-			Expect(analysis.Status.KASession.ID).To(BeEmpty())
-			Expect(cancelClient.CancelCallCount).To(Equal(1))
+			Expect(analysis.Status.KASession.ID).To(Equal("session-123"),
+				"session ID must be preserved — upgrade in-place, no cancel")
+			Expect(analysis.Status.KASession.Interactive).To(BeTrue(),
+				"Interactive flag must be set for upgrade path")
+			Expect(upgradeClient.CancelCallCount).To(Equal(0),
+				"CancelSession must NOT be called — #1390 upgrade replaces cancel")
 		})
 	})
 
@@ -1130,6 +1135,183 @@ type mockISChecker struct {
 
 func (m *mockISChecker) HasActiveSession(_ context.Context, _ string) (bool, error) {
 	return m.hasSession, m.err
+}
+
+// ========================================
+// Fix #1390: AA Takeover Simplification
+//
+// UT-AA-1390-014..017: Validate that the takeover branch no longer
+// cancels the session but instead sets Interactive=true and calls
+// SetActivePhase on the IS phase updater.
+// ========================================
+
+var _ = Describe("Fix #1390: AA Takeover Simplification — BR-INTERACTIVE-004", func() {
+	var (
+		auditSpy *sessionAuditSpy
+		recorder record.EventRecorder
+	)
+
+	BeforeEach(func() {
+		auditSpy = &sessionAuditSpy{}
+		recorder = record.NewFakeRecorder(32)
+	})
+
+	Context("UT-AA-1390-014 [AC-12]: Takeover sets Interactive=true without calling CancelSession", func() {
+		It("should not cancel the session when IS appears for autonomous session", func() {
+			cancelClient := mocks.NewMockAgentClient()
+			cancelClient.WithSessionPollStatus("investigating")
+			isChecker := &mockISChecker{hasSession: true}
+			phaseUpdater := &mockISPhaseUpdater1390{}
+			testMetrics := metrics.NewMetrics()
+
+			h := handlers.NewInvestigatingHandler(cancelClient, ctrl.Log.WithName("test-1390-014"), testMetrics, auditSpy,
+				handlers.WithSessionMode(), handlers.WithRecorder(recorder),
+				handlers.WithInvestigationSessionChecker(isChecker),
+				handlers.WithISPhaseUpdater(phaseUpdater))
+
+			analysis := &aianalysisv1.AIAnalysis{
+				Spec: aianalysisv1.AIAnalysisSpec{
+					RemediationRequestRef: corev1.ObjectReference{Name: "rr-upgrade-014", Namespace: "default"},
+				},
+				Status: aianalysisv1.AIAnalysisStatus{
+					Phase: aianalysis.PhaseInvestigating,
+					KASession: &aianalysisv1.KASession{
+						ID:          "session-014",
+						Interactive: false,
+					},
+				},
+			}
+
+			result, err := h.Handle(context.Background(), analysis)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeTrue())
+			Expect(cancelClient.CancelCallCount).To(Equal(0),
+				"CancelSession must NOT be called — upgrade-in-place replaces cancel")
+			Expect(analysis.Status.KASession.Interactive).To(BeTrue(),
+				"Interactive flag must be set to true for upgrade path")
+			Expect(analysis.Status.KASession.ID).To(Equal("session-014"),
+				"session ID must be preserved — no clearing")
+		})
+	})
+
+	Context("UT-AA-1390-015 [AC-12]: Takeover calls SetActivePhase on IS phase updater", func() {
+		It("should call SetActivePhase when upgrading to interactive", func() {
+			cancelClient := mocks.NewMockAgentClient()
+			cancelClient.WithSessionPollStatus("investigating")
+			isChecker := &mockISChecker{hasSession: true}
+			phaseUpdater := &mockISPhaseUpdater1390{}
+			testMetrics := metrics.NewMetrics()
+
+			h := handlers.NewInvestigatingHandler(cancelClient, ctrl.Log.WithName("test-1390-015"), testMetrics, auditSpy,
+				handlers.WithSessionMode(), handlers.WithRecorder(recorder),
+				handlers.WithInvestigationSessionChecker(isChecker),
+				handlers.WithISPhaseUpdater(phaseUpdater))
+
+			analysis := &aianalysisv1.AIAnalysis{
+				Spec: aianalysisv1.AIAnalysisSpec{
+					RemediationRequestRef: corev1.ObjectReference{Name: "rr-upgrade-015", Namespace: "default"},
+				},
+				Status: aianalysisv1.AIAnalysisStatus{
+					Phase: aianalysis.PhaseInvestigating,
+					KASession: &aianalysisv1.KASession{
+						ID:          "session-015",
+						Interactive: false,
+					},
+				},
+			}
+
+			_, err := h.Handle(context.Background(), analysis)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(phaseUpdater.activePhaseCount).To(Equal(1),
+				"SetActivePhase must be called once for the upgrade")
+			Expect(phaseUpdater.lastActiveRRName).To(Equal("rr-upgrade-015"))
+		})
+	})
+
+	Context("UT-AA-1390-016 [AC-12]: Next reconcile with hasIS=true + Interactive=true is no-op", func() {
+		It("should skip mismatch check when Interactive already matches IS state", func() {
+			mockClient := mocks.NewMockAgentClient()
+			mockClient.WithSessionPollStatus("user_driving")
+			isChecker := &mockISChecker{hasSession: true}
+			testMetrics := metrics.NewMetrics()
+
+			h := handlers.NewInvestigatingHandler(mockClient, ctrl.Log.WithName("test-1390-016"), testMetrics, auditSpy,
+				handlers.WithSessionMode(), handlers.WithRecorder(recorder),
+				handlers.WithInvestigationSessionChecker(isChecker))
+
+			analysis := &aianalysisv1.AIAnalysis{
+				Spec: aianalysisv1.AIAnalysisSpec{
+					RemediationRequestRef: corev1.ObjectReference{Name: "rr-noop-016", Namespace: "default"},
+				},
+				Status: aianalysisv1.AIAnalysisStatus{
+					Phase: aianalysis.PhaseInvestigating,
+					KASession: &aianalysisv1.KASession{
+						ID:          "session-016",
+						Interactive: true,
+					},
+				},
+			}
+
+			result, err := h.Handle(context.Background(), analysis)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mockClient.CancelCallCount).To(Equal(0), "no cancel expected")
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0),
+				"should proceed to poll, not immediate requeue")
+		})
+	})
+
+	Context("UT-AA-1390-017 [AC-12]: Poll user_driving after upgrade populates InteractiveSession", func() {
+		It("should populate InteractiveSession info when polling upgraded session", func() {
+			mockClient := mocks.NewMockAgentClient()
+			mockClient.WithSessionPollStatus("user_driving")
+			mockClient.DefaultSessionStatus = &agentclient.SessionStatusResult{
+				Status:     "user_driving",
+				ActingUser: "sre-user@example.com",
+			}
+			isChecker := &mockISChecker{hasSession: true}
+			testMetrics := metrics.NewMetrics()
+
+			h := handlers.NewInvestigatingHandler(mockClient, ctrl.Log.WithName("test-1390-017"), testMetrics, auditSpy,
+				handlers.WithSessionMode(), handlers.WithRecorder(recorder),
+				handlers.WithInvestigationSessionChecker(isChecker))
+
+			analysis := &aianalysisv1.AIAnalysis{
+				Spec: aianalysisv1.AIAnalysisSpec{
+					RemediationRequestRef: corev1.ObjectReference{Name: "rr-poll-017", Namespace: "default"},
+				},
+				Status: aianalysisv1.AIAnalysisStatus{
+					Phase: aianalysis.PhaseInvestigating,
+					KASession: &aianalysisv1.KASession{
+						ID:          "session-017",
+						Interactive: true,
+					},
+				},
+			}
+
+			_, err := h.Handle(context.Background(), analysis)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(analysis.Status.InteractiveSession).NotTo(BeNil(),
+				"InteractiveSession must be populated after polling user_driving")
+			Expect(analysis.Status.InteractiveSession.ActingUser).To(Equal("sre-user@example.com"))
+		})
+	})
+})
+
+// mockISPhaseUpdater1390 tracks SetActivePhase calls for #1390 tests.
+type mockISPhaseUpdater1390 struct {
+	activePhaseCount  int
+	lastActiveRRName  string
+	setActiveErr      error
+}
+
+func (m *mockISPhaseUpdater1390) SetActivePhase(_ context.Context, rrName string) error {
+	m.activePhaseCount++
+	m.lastActiveRRName = rrName
+	return m.setActiveErr
+}
+
+func (m *mockISPhaseUpdater1390) SetTerminalPhase(_ context.Context, _ string, _ isv1alpha1.SessionPhase) error {
+	return nil
 }
 
 // ========================================

--- a/pkg/apifrontend/ka/invoke_action_test.go
+++ b/pkg/apifrontend/ka/invoke_action_test.go
@@ -77,7 +77,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			result, err := client.InvokeAction(withIdentityCtx("alice@example.com", []string{"sre"}), ka.InvokeActionArgs{
 				RRID:   "prod/rr-pod-crash-001",
@@ -102,7 +102,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(withIdentityCtx("alice@example.com", []string{"sre"}), ka.InvokeActionArgs{
 				RRID:    "prod/rr-pod-crash-001",
@@ -128,7 +128,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(withIdentityCtx("alice@example.com", []string{"sre"}), ka.InvokeActionArgs{
 				RRID:    "prod/rr-001",
@@ -153,7 +153,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(withIdentityCtx("alice@example.com", []string{"sre"}), ka.InvokeActionArgs{
 				RRID:   "prod/rr-001",
@@ -177,7 +177,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(withIdentityCtx("alice@example.com", []string{"sre"}), ka.InvokeActionArgs{
 				RRID:   "prod/rr-001",
@@ -202,7 +202,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(withIdentityCtx("alice@example.com", []string{"sre"}), ka.InvokeActionArgs{
 				RRID:   "prod/rr-001",
@@ -225,7 +225,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "bob@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(withIdentityCtx("bob@example.com", []string{"sre", "admin"}), ka.InvokeActionArgs{
 				RRID:   "prod/rr-001",
@@ -251,7 +251,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "anonymous"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(context.Background(), ka.InvokeActionArgs{
 				RRID:   "prod/rr-001",
@@ -265,7 +265,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 	Describe("Error handling", func() {
 		It("UT-AF-1234-009: KA unavailable returns user-friendly error", func() {
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient("http://localhost:1/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient("http://localhost:1/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(withIdentityCtx("alice@example.com", []string{"sre"}), ka.InvokeActionArgs{
 				RRID:   "prod/rr-001",
@@ -290,7 +290,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(withIdentityCtx("alice@example.com", []string{"sre"}), ka.InvokeActionArgs{
 				RRID:   "prod/rr-001",
@@ -317,7 +317,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "sre@kubernaut.ai"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			result, err := client.InvokeAction(withIdentityCtx("sre@kubernaut.ai", []string{"sre"}), ka.InvokeActionArgs{
 				RRID:   "monitoring/rr-oom-456",
@@ -345,7 +345,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "dev@kubernaut.ai"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(withIdentityCtx("dev@kubernaut.ai", []string{"dev-team", "viewers"}), ka.InvokeActionArgs{
 				RRID:   "prod/rr-crash-789",
@@ -364,7 +364,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			}))
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(withIdentityCtx("alice@example.com", []string{"sre"}), ka.InvokeActionArgs{
 				RRID:   "prod/rr-001",

--- a/pkg/apifrontend/ka/mcp_sdk_client.go
+++ b/pkg/apifrontend/ka/mcp_sdk_client.go
@@ -26,12 +26,11 @@ type SDKMCPClient struct {
 	endpoint           string
 	client             *mcp.Client
 	httpClient         *http.Client
+	streamHTTPClient   *http.Client
 	logger             logr.Logger
 	downstreamDuration *prometheus.HistogramVec
 }
 
-// NewSDKMCPClient creates a new MCP client for KA communication.
-// The httpClient should include auth transport (e.g., bearerTokenTransport for SA token).
 // WithDownstreamDuration injects the af_downstream_request_duration_seconds
 // histogram for MCP call latency instrumentation (G18).
 func (c *SDKMCPClient) WithDownstreamDuration(h *prometheus.HistogramVec) *SDKMCPClient {
@@ -39,17 +38,27 @@ func (c *SDKMCPClient) WithDownstreamDuration(h *prometheus.HistogramVec) *SDKMC
 	return c
 }
 
-func NewSDKMCPClient(endpoint string, httpClient *http.Client, logger logr.Logger) *SDKMCPClient {
+// NewSDKMCPClient creates a new MCP client for KA communication.
+// httpClient (with timeout) is used for short-lived session-per-call tool invocations.
+// streamHTTPClient (no timeout) is used for long-lived MCP sessions
+// (StartInvestigation, ConnectSession) where SSE streams must survive idle periods.
+// If streamHTTPClient is nil, httpClient is used for all connections.
+func NewSDKMCPClient(endpoint string, httpClient *http.Client, streamHTTPClient *http.Client, logger logr.Logger) *SDKMCPClient {
 	mcpClient := mcp.NewClient(&mcp.Implementation{
 		Name:    "kubernaut-apifrontend",
 		Version: "0.1.0",
 	}, nil)
 
+	if streamHTTPClient == nil {
+		streamHTTPClient = httpClient
+	}
+
 	return &SDKMCPClient{
-		endpoint:   endpoint,
-		client:     mcpClient,
-		httpClient: httpClient,
-		logger:     logger.WithName("ka-mcp"),
+		endpoint:         endpoint,
+		client:           mcpClient,
+		httpClient:       httpClient,
+		streamHTTPClient: streamHTTPClient,
+		logger:           logger.WithName("ka-mcp"),
 	}
 }
 
@@ -279,7 +288,7 @@ func (c *SDKMCPClient) StartInvestigation(ctx context.Context, args StartInvesti
 
 	transport := &mcp.StreamableClientTransport{
 		Endpoint:   c.endpoint,
-		HTTPClient: c.httpClient,
+		HTTPClient: c.streamHTTPClient,
 	}
 
 	// Use a detached context for the MCP session so its lifetime is not tied

--- a/pkg/apifrontend/ka/mcp_sdk_client_test.go
+++ b/pkg/apifrontend/ka/mcp_sdk_client_test.go
@@ -75,7 +75,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "alice@example.com",
@@ -130,7 +130,7 @@ var _ = Describe("SDKMCPClient", func() {
 			ts = httptest.NewServer(mux)
 
 			httpClient := &http.Client{Transport: &auth.ContextJWTDelegationTransport{}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "bob@example.com",
@@ -156,7 +156,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: ""}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.SelectWorkflow(context.Background(), ka.SelectWorkflowArgs{
 				RRID:       "rr-test-002",
@@ -182,7 +182,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "alice@example.com",
@@ -210,7 +210,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "alice@example.com",
@@ -235,7 +235,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "alice@example.com",
@@ -261,7 +261,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "alice@example.com",
@@ -284,7 +284,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "alice@example.com",
@@ -310,7 +310,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "alice@example.com",
@@ -340,7 +340,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "alice@example.com",
@@ -373,7 +373,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "alice@example.com",
@@ -403,7 +403,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "bob@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "bob@example.com",
@@ -436,7 +436,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "alice@example.com",
@@ -468,7 +468,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "bob@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "bob@example.com",

--- a/pkg/apifrontend/ka/pooled_mcp_client.go
+++ b/pkg/apifrontend/ka/pooled_mcp_client.go
@@ -3,7 +3,9 @@ package ka
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -69,7 +71,7 @@ func (c *PooledMCPClient) InvokeAction(ctx context.Context, args InvokeActionArg
 		argsMap["message"] = args.Message
 	}
 
-	raw, err := c.callPooledTool(ctx, session, "kubernaut_investigate", argsMap)
+	raw, err := c.callPooledTool(ctx, session, "kubernaut_investigate", argsMap, args.RRID, identity.Username)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +112,7 @@ func (c *PooledMCPClient) DiscoverWorkflows(ctx context.Context, args DiscoverWo
 		"acting_user_groups": identity.Groups,
 	}
 
-	raw, err := c.callPooledTool(ctx, session, "kubernaut_investigate", argsMap)
+	raw, err := c.callPooledTool(ctx, session, "kubernaut_investigate", argsMap, args.RRID, identity.Username)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +153,7 @@ func (c *PooledMCPClient) SelectWorkflow(ctx context.Context, args SelectWorkflo
 		argsMap["parameters"] = args.Parameters
 	}
 
-	raw, err := c.callPooledTool(ctx, session, "kubernaut_select_workflow", argsMap)
+	raw, err := c.callPooledTool(ctx, session, "kubernaut_select_workflow", argsMap, args.RRID, identity.Username)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +174,24 @@ func (c *PooledMCPClient) StartInvestigation(_ context.Context, _ StartInvestiga
 
 // callPooledTool dispatches a tool call to the given pooled session, handling
 // error response parsing and security redaction consistently with SDKMCPClient.
-func (c *PooledMCPClient) callPooledTool(ctx context.Context, session PoolSession, name string, args map[string]any) (json.RawMessage, error) {
+// On stale-session errors (#1386), it evicts the dead entry and retries once
+// with a fresh session from the pool factory.
+func (c *PooledMCPClient) callPooledTool(ctx context.Context, session PoolSession, name string, args map[string]any, rrID, username string) (json.RawMessage, error) {
+	raw, err := c.doCallTool(ctx, session, name, args)
+	if err != nil && isStaleSessionError(err) {
+		c.logger.Info("stale MCP session detected, evicting and retrying",
+			"rr_id", rrID, "error", err.Error())
+		c.pool.Release(rrID, username)
+		newSession, acqErr := c.pool.Acquire(ctx, rrID, username)
+		if acqErr != nil {
+			return nil, fmt.Errorf("re-acquire MCP session after stale eviction: %w", acqErr)
+		}
+		raw, err = c.doCallTool(ctx, newSession, name, args)
+	}
+	return raw, err
+}
+
+func (c *PooledMCPClient) doCallTool(ctx context.Context, session PoolSession, name string, args map[string]any) (json.RawMessage, error) {
 	result, err := session.CallTool(ctx, &mcp.CallToolParams{
 		Name:      name,
 		Arguments: args,
@@ -200,6 +219,19 @@ func (c *PooledMCPClient) callPooledTool(ctx context.Context, session PoolSessio
 	}
 
 	return json.RawMessage("{}"), nil
+}
+
+// isStaleSessionError returns true if the error indicates the MCP transport
+// session is no longer valid on the server (e.g., SSE stream died, pod
+// restarted, or proxy idle timeout).
+func isStaleSessionError(err error) bool {
+	if errors.Is(err, mcp.ErrSessionMissing) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "session not found") ||
+		strings.Contains(msg, "failed to connect") ||
+		strings.Contains(msg, "failed to reconnect")
 }
 
 // Compile-time interface check.

--- a/pkg/apifrontend/ka/pooled_mcp_client_test.go
+++ b/pkg/apifrontend/ka/pooled_mcp_client_test.go
@@ -230,4 +230,130 @@ var _ = Describe("PooledMCPClient (#1306)", func() {
 		// implement MCPClient, the test file won't compile.
 		var _ ka.MCPClient = (*ka.PooledMCPClient)(nil)
 	})
+
+	Describe("Stale-session evict+retry (#1386)", func() {
+		It("UT-AF-1386-001: retries on stale session and succeeds with fresh session", func() {
+			var callCount atomic.Int32
+			staleSession := &mockPoolSession{
+				callFn: func(_ context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+					return nil, fmt.Errorf("MCP call kubernaut_investigate: failed to connect (session ID: WVIPJI3): %w", mcp.ErrSessionMissing)
+				},
+			}
+			freshSession := &mockPoolSession{
+				callFn: func(_ context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+					callCount.Add(1)
+					resp := `{"status":"active","session_id":"sess-fresh"}`
+					return &mcp.CallToolResult{
+						Content: []mcp.Content{&mcp.TextContent{Text: resp}},
+					}, nil
+				},
+			}
+
+			retryPool := ka.NewKASessionPool(ka.PoolConfig{
+				Factory: func(_ context.Context) (ka.PoolSession, error) {
+					return freshSession, nil
+				},
+				Logger: logr.Discard(),
+			})
+
+			client := ka.NewPooledMCPClient(retryPool, logr.Discard())
+			ctx := ctxWithIdentity("alice", []string{"sre"})
+
+			retryPool.Inject("ns/rr-stale", "alice", staleSession)
+			Expect(retryPool.Size()).To(Equal(1))
+
+			result, err := client.InvokeAction(ctx, ka.InvokeActionArgs{
+				RRID: "ns/rr-stale", Action: "takeover",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Status).To(Equal("active"))
+			Expect(callCount.Load()).To(Equal(int32(1)),
+				"fresh session should have been called once after retry")
+		})
+
+		It("UT-AF-1386-002: retries on 'session not found' string match", func() {
+			staleSession := &mockPoolSession{
+				callFn: func(_ context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+					return nil, fmt.Errorf("MCP call kubernaut_investigate: sending request: session not found")
+				},
+			}
+			freshSession := &mockPoolSession{
+				callFn: func(_ context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+					resp := `{"workflows":[],"count":0}`
+					return &mcp.CallToolResult{
+						Content: []mcp.Content{&mcp.TextContent{Text: resp}},
+					}, nil
+				},
+			}
+
+			retryPool := ka.NewKASessionPool(ka.PoolConfig{
+				Factory: func(_ context.Context) (ka.PoolSession, error) {
+					return freshSession, nil
+				},
+				Logger: logr.Discard(),
+			})
+
+			client := ka.NewPooledMCPClient(retryPool, logr.Discard())
+			ctx := ctxWithIdentity("alice", []string{"sre"})
+
+			retryPool.Inject("ns/rr-stale2", "alice", staleSession)
+
+			result, err := client.DiscoverWorkflows(ctx, ka.DiscoverWorkflowsArgs{RRID: "ns/rr-stale2"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+		})
+
+		It("UT-AF-1386-003: non-stale errors are not retried", func() {
+			failSession := &mockPoolSession{
+				callFn: func(_ context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+					return nil, fmt.Errorf("MCP call kubernaut_investigate: internal server error")
+				},
+			}
+
+			noRetryPool := ka.NewKASessionPool(ka.PoolConfig{
+				Factory: func(_ context.Context) (ka.PoolSession, error) {
+					return failSession, nil
+				},
+				Logger: logr.Discard(),
+			})
+
+			client := ka.NewPooledMCPClient(noRetryPool, logr.Discard())
+			ctx := ctxWithIdentity("alice", []string{"sre"})
+
+			_, err := client.InvokeAction(ctx, ka.InvokeActionArgs{
+				RRID: "ns/rr-fail", Action: "takeover",
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("internal server error"))
+			Expect(noRetryPool.Size()).To(Equal(1),
+				"pool entry should NOT be evicted for non-stale errors")
+		})
+
+		It("UT-AF-1386-004: retry fails if re-acquire fails", func() {
+			staleSession := &mockPoolSession{
+				callFn: func(_ context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+					return nil, fmt.Errorf("MCP call: %w", mcp.ErrSessionMissing)
+				},
+			}
+
+			failPool := ka.NewKASessionPool(ka.PoolConfig{
+				Factory: func(_ context.Context) (ka.PoolSession, error) {
+					return nil, fmt.Errorf("KA unreachable")
+				},
+				Logger: logr.Discard(),
+			})
+
+			client := ka.NewPooledMCPClient(failPool, logr.Discard())
+			ctx := ctxWithIdentity("alice", []string{"sre"})
+
+			failPool.Inject("ns/rr-dead", "alice", staleSession)
+
+			_, err := client.InvokeAction(ctx, ka.InvokeActionArgs{
+				RRID: "ns/rr-dead", Action: "takeover",
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("re-acquire MCP session after stale eviction"))
+		})
+	})
 })

--- a/pkg/apifrontend/ka/resilience_mcp_test.go
+++ b/pkg/apifrontend/ka/resilience_mcp_test.go
@@ -50,7 +50,7 @@ var _ = Describe("MCP Resilience (G10: Retry/CB)", func() {
 					base: cbt,
 				},
 			}
-			client := ka.NewSDKMCPClient(failServer.URL+"/mcp", httpClient, logr.Discard())
+			client := ka.NewSDKMCPClient(failServer.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := withIdentityCtx("alice@example.com")
 			for i := 0; i < 4; i++ {
@@ -119,7 +119,7 @@ var _ = Describe("MCP Resilience (G10: Retry/CB)", func() {
 					base: cbt,
 				},
 			}
-			client := ka.NewSDKMCPClient(failServer.URL+"/mcp", httpClient, logr.Discard())
+			client := ka.NewSDKMCPClient(failServer.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := withIdentityCtx("alice@example.com")
 			for i := 0; i < 6; i++ {
@@ -188,7 +188,7 @@ var _ = Describe("MCP Resilience (G10: Retry/CB)", func() {
 					base: cbt,
 				},
 			}
-			client := ka.NewSDKMCPClient(failServer.URL+"/mcp", httpClient, logr.Discard())
+			client := ka.NewSDKMCPClient(failServer.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := withIdentityCtx("alice@example.com")
 			for i := 0; i < 4; i++ {

--- a/pkg/apifrontend/ka/session_pool.go
+++ b/pkg/apifrontend/ka/session_pool.go
@@ -14,6 +14,7 @@ import (
 // *mcp.ClientSession satisfies this interface.
 type PoolSession interface {
 	CallTool(ctx context.Context, params *mcp.CallToolParams) (*mcp.CallToolResult, error)
+	Ping(ctx context.Context, params *mcp.PingParams) error
 	Close() error
 }
 
@@ -25,9 +26,23 @@ type poolKey struct {
 	username string
 }
 
+// SessionIdentifier is an optional interface that PoolSession implementations
+// can satisfy to provide a transport-level session ID for audit logging.
+type SessionIdentifier interface {
+	SessionID() string
+}
+
 type poolEntry struct {
-	session  PoolSession
-	lastUsed time.Time
+	session   PoolSession
+	sessionID string
+	lastUsed  time.Time
+}
+
+func extractSessionID(s PoolSession) string {
+	if si, ok := s.(SessionIdentifier); ok {
+		return si.SessionID()
+	}
+	return "unknown"
 }
 
 // PoolConfig configures the KASessionPool.
@@ -69,26 +84,48 @@ func NewKASessionPool(cfg PoolConfig) *KASessionPool {
 	}
 }
 
+const pingTimeout = 2 * time.Second
+
 // Acquire gets or creates a pooled session for the given (rrID, username).
 // Sessions are keyed by composite (rrID, username) to enforce user isolation (G9).
-// Uses a check-lock-recheck pattern to minimise lock contention (#78 race safety).
+// Cached sessions are proactively health-checked via Ping before reuse (#1387).
 func (p *KASessionPool) Acquire(ctx context.Context, rrID, username string) (PoolSession, error) {
 	key := poolKey{rrID: rrID, username: username}
 
-	// Fast path: read-lock to check for existing session.
-	p.mu.RLock()
-	_, exists := p.entries[key]
-	p.mu.RUnlock()
+	p.mu.Lock()
+	entry, exists := p.entries[key]
+	if exists && entry != nil {
+		session := entry.session
+		sid := entry.sessionID
+		entry.lastUsed = time.Now()
+		p.mu.Unlock()
+
+		pingCtx, cancel := context.WithTimeout(ctx, pingTimeout)
+		defer cancel()
+		if err := session.Ping(pingCtx, nil); err != nil {
+			p.logger.Info("cached session failed health check, evicting",
+				"rr_id", rrID, "username", username, "mcp_session_id", sid, "error", err.Error())
+			p.mu.Lock()
+			if cur, ok := p.entries[key]; ok && cur.session == session {
+				delete(p.entries, key)
+			}
+			p.mu.Unlock()
+			_ = session.Close()
+		} else {
+			p.logger.Info("pool session reused (cache hit)",
+				"rr_id", rrID, "username", username, "mcp_session_id", sid)
+			return session, nil
+		}
+	} else {
+		p.mu.Unlock()
+	}
 
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	// Recheck under write lock -- another goroutine may have created or deleted it.
-	if entry, ok := p.entries[key]; ok || exists {
-		if entry != nil {
-			entry.lastUsed = time.Now()
-			return entry.session, nil
-		}
+	if entry, ok := p.entries[key]; ok && entry != nil {
+		entry.lastUsed = time.Now()
+		return entry.session, nil
 	}
 
 	if len(p.entries) >= p.maxEntries {
@@ -100,9 +137,11 @@ func (p *KASessionPool) Acquire(ctx context.Context, rrID, username string) (Poo
 		return nil, fmt.Errorf("create MCP session: %w", err)
 	}
 
+	sid := extractSessionID(session)
 	p.entries[key] = &poolEntry{
-		session:  session,
-		lastUsed: time.Now(),
+		session:   session,
+		sessionID: sid,
+		lastUsed:  time.Now(),
 	}
 
 	return session, nil
@@ -115,19 +154,21 @@ func (p *KASessionPool) Acquire(ctx context.Context, rrID, username string) (Poo
 // and driver lease without requiring a separate takeover.
 func (p *KASessionPool) Inject(rrID, username string, session PoolSession) {
 	key := poolKey{rrID: rrID, username: username}
+	sid := extractSessionID(session)
 
 	p.mu.Lock()
 	old, exists := p.entries[key]
 	p.entries[key] = &poolEntry{
-		session:  session,
-		lastUsed: time.Now(),
+		session:   session,
+		sessionID: sid,
+		lastUsed:  time.Now(),
 	}
 	p.mu.Unlock()
 
 	if exists && old.session != nil {
 		_ = old.session.Close()
 	}
-	p.logger.Info("session injected into pool", "rr_id", rrID, "username", username)
+	p.logger.Info("session injected into pool", "rr_id", rrID, "username", username, "mcp_session_id", sid)
 }
 
 // Release closes and removes the session for the given (rrID, username).
@@ -142,6 +183,8 @@ func (p *KASessionPool) Release(rrID, username string) {
 	p.mu.Unlock()
 
 	if exists && entry.session != nil {
+		p.logger.Info("pool session released",
+			"rr_id", rrID, "username", username, "mcp_session_id", entry.sessionID)
 		_ = entry.session.Close()
 	}
 }

--- a/pkg/apifrontend/ka/session_pool_test.go
+++ b/pkg/apifrontend/ka/session_pool_test.go
@@ -2,6 +2,8 @@ package ka_test
 
 import (
 	"context"
+	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -20,6 +22,7 @@ type mockPoolSession struct {
 	closed   bool
 	mu       sync.Mutex
 	callFn   func(ctx context.Context, params *mcp.CallToolParams) (*mcp.CallToolResult, error)
+	pingFn   func(ctx context.Context, params *mcp.PingParams) error
 }
 
 func (s *mockPoolSession) CallTool(ctx context.Context, params *mcp.CallToolParams) (*mcp.CallToolResult, error) {
@@ -27,6 +30,13 @@ func (s *mockPoolSession) CallTool(ctx context.Context, params *mcp.CallToolPara
 		return s.callFn(ctx, params)
 	}
 	return &mcp.CallToolResult{}, nil
+}
+
+func (s *mockPoolSession) Ping(ctx context.Context, params *mcp.PingParams) error {
+	if s.pingFn != nil {
+		return s.pingFn(ctx, params)
+	}
+	return nil
 }
 
 func (s *mockPoolSession) Close() error {
@@ -468,6 +478,323 @@ var _ = Describe("KASessionPool (G2 + G9: Pool + User Isolation)", func() {
 		})
 	})
 })
+
+var _ = Describe("MCP Session Resilience — Proactive Pool Health Check (#1387)", func() {
+	var (
+		pool         *ka.KASessionPool
+		connectCount atomic.Int32
+	)
+
+	countingFactory := func() ka.SessionFactory {
+		return func(_ context.Context) (ka.PoolSession, error) {
+			id := int(connectCount.Add(1))
+			return &mockPoolSession{id: id}, nil
+		}
+	}
+
+	BeforeEach(func() {
+		connectCount.Store(0)
+	})
+
+	It("UT-AF-1387-001 [SI-4, SC-24]: dead cached session detected and evicted before user-visible failure", func() {
+		pool = ka.NewKASessionPool(ka.PoolConfig{
+			Factory:    countingFactory(),
+			MaxEntries: 10,
+			Logger:     logr.Discard(),
+		})
+
+		deadSession := &mockPoolSession{
+			id: 1,
+			pingFn: func(_ context.Context, _ *mcp.PingParams) error {
+				return fmt.Errorf("transport closed")
+			},
+		}
+		pool.Inject("rr-001", "alice", deadSession)
+
+		session, err := pool.Acquire(context.Background(), "rr-001", "alice")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(session).NotTo(BeIdenticalTo(deadSession),
+			"SI-4: dead session must be replaced, not returned to caller")
+		Expect(deadSession.IsClosed()).To(BeTrue(),
+			"SC-24: evicted session resources must be released")
+		Expect(connectCount.Load()).To(Equal(int32(1)),
+			"CP-10: factory creates replacement transparently")
+	})
+
+	It("UT-AF-1387-002 [CP-10]: auto-reconstitution after eviction without caller retry", func() {
+		pool = ka.NewKASessionPool(ka.PoolConfig{
+			Factory:    countingFactory(),
+			MaxEntries: 10,
+			Logger:     logr.Discard(),
+		})
+
+		deadSession := &mockPoolSession{
+			id: 1,
+			pingFn: func(_ context.Context, _ *mcp.PingParams) error {
+				return fmt.Errorf("connection reset by peer")
+			},
+		}
+		pool.Inject("rr-002", "bob", deadSession)
+
+		session, err := pool.Acquire(context.Background(), "rr-002", "bob")
+		Expect(err).NotTo(HaveOccurred(),
+			"CP-10: caller must not see the eviction — Acquire returns a valid session")
+		Expect(session).NotTo(BeNil())
+
+		_, err = session.CallTool(context.Background(), &mcp.CallToolParams{
+			Name: "test_tool",
+		})
+		Expect(err).NotTo(HaveOccurred(),
+			"CP-10: replacement session must be functional for tool calls")
+	})
+
+	It("UT-AF-1387-003 [SI-4]: healthy cached session reused without false-positive eviction", func() {
+		pool = ka.NewKASessionPool(ka.PoolConfig{
+			Factory:    countingFactory(),
+			MaxEntries: 10,
+			Logger:     logr.Discard(),
+		})
+
+		healthySession := &mockPoolSession{id: 42}
+		pool.Inject("rr-003", "carol", healthySession)
+
+		session, err := pool.Acquire(context.Background(), "rr-003", "carol")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(session).To(BeIdenticalTo(healthySession),
+			"SI-4: healthy session must be returned as-is, no false-positive eviction")
+		Expect(connectCount.Load()).To(Equal(int32(0)),
+			"SI-4: factory must not be called when cached session is healthy")
+	})
+
+	It("UT-AF-1387-004 [SA-15]: ping timeout bounded to prevent indefinite Acquire blocking", func() {
+		pool = ka.NewKASessionPool(ka.PoolConfig{
+			Factory:    countingFactory(),
+			MaxEntries: 10,
+			Logger:     logr.Discard(),
+		})
+
+		hangingSession := &mockPoolSession{
+			id: 1,
+			pingFn: func(ctx context.Context, _ *mcp.PingParams) error {
+				<-ctx.Done()
+				return ctx.Err()
+			},
+		}
+		pool.Inject("rr-004", "dave", hangingSession)
+
+		start := time.Now()
+		session, err := pool.Acquire(context.Background(), "rr-004", "dave")
+		elapsed := time.Since(start)
+
+		Expect(err).NotTo(HaveOccurred(),
+			"SA-15: hung ping must not propagate error to caller")
+		Expect(session).NotTo(BeIdenticalTo(hangingSession),
+			"SA-15: hung session must be evicted, not returned")
+		Expect(elapsed).To(BeNumerically("<", 5*time.Second),
+			"SA-15: Acquire must not block indefinitely — ping timeout enforces 2s bound")
+	})
+
+	It("UT-AF-1387-005 [SC-24]: concurrent Acquire with failing Ping does not double-evict or race", func() {
+		pool = ka.NewKASessionPool(ka.PoolConfig{
+			Factory:    countingFactory(),
+			MaxEntries: 10,
+			Logger:     logr.Discard(),
+		})
+
+		deadSession := &mockPoolSession{
+			id: 1,
+			pingFn: func(_ context.Context, _ *mcp.PingParams) error {
+				return fmt.Errorf("transport closed")
+			},
+		}
+		pool.Inject("rr-005", "eve", deadSession)
+
+		const goroutines = 10
+		var wg sync.WaitGroup
+		sessions := make([]ka.PoolSession, goroutines)
+		errs := make([]error, goroutines)
+
+		for i := 0; i < goroutines; i++ {
+			wg.Add(1)
+			go func(idx int) {
+				defer wg.Done()
+				sessions[idx], errs[idx] = pool.Acquire(context.Background(), "rr-005", "eve")
+			}(i)
+		}
+		wg.Wait()
+
+		for i := 0; i < goroutines; i++ {
+			Expect(errs[i]).NotTo(HaveOccurred(),
+				"SC-24: goroutine %d should succeed even under concurrent eviction", i)
+			Expect(sessions[i]).NotTo(BeNil(),
+				"SC-24: goroutine %d must receive a valid session", i)
+		}
+	})
+})
+
+var _ = Describe("MCP Transport Observability — Audit Logging (#1387)", func() {
+	var (
+		pool         *ka.KASessionPool
+		connectCount atomic.Int32
+	)
+
+	countingFactoryWithLogger := func() ka.SessionFactory {
+		return func(_ context.Context) (ka.PoolSession, error) {
+			id := int(connectCount.Add(1))
+			return &mockPoolSession{id: id}, nil
+		}
+	}
+
+	BeforeEach(func() {
+		connectCount.Store(0)
+	})
+
+	It("UT-AF-1387-010 [AU-2, AU-3]: Inject emits structured log with mcp_session_id and rr_id", func() {
+		logger, entries := capturingLogger()
+		pool = ka.NewKASessionPool(ka.PoolConfig{
+			Factory:    countingFactoryWithLogger(),
+			MaxEntries: 10,
+			Logger:     logger,
+		})
+
+		injected := &mockPoolSession{id: 42}
+		pool.Inject("rr-010", "alice", injected)
+
+		found := false
+		for _, e := range *entries {
+			if containsAll(e.args, "mcp_session_id", "rr_id", "rr-010") {
+				found = true
+				break
+			}
+		}
+		Expect(found).To(BeTrue(),
+			"AU-2+AU-3: Inject must emit structured log containing mcp_session_id and rr_id for cross-service correlation")
+	})
+
+	It("UT-AF-1387-011 [AU-2, AU-3]: Acquire cache-hit emits log with mcp_session_id and rr_id", func() {
+		logger, entries := capturingLogger()
+		pool = ka.NewKASessionPool(ka.PoolConfig{
+			Factory:    countingFactoryWithLogger(),
+			MaxEntries: 10,
+			Logger:     logger,
+		})
+
+		pool.Inject("rr-011", "bob", &mockPoolSession{id: 99})
+
+		_, err := pool.Acquire(context.Background(), "rr-011", "bob")
+		Expect(err).NotTo(HaveOccurred())
+
+		found := false
+		for _, e := range *entries {
+			if containsAll(e.args, "mcp_session_id", "rr_id", "rr-011") && containsAny(e.args, "acquire", "cache hit", "reuse") {
+				found = true
+				break
+			}
+		}
+		Expect(found).To(BeTrue(),
+			"AU-2+AU-3: Acquire cache-hit must emit structured log with mcp_session_id and rr_id")
+	})
+
+	It("UT-AF-1387-012 [AU-2]: Release emits log with mcp_session_id and rr_id", func() {
+		logger, entries := capturingLogger()
+		pool = ka.NewKASessionPool(ka.PoolConfig{
+			Factory:    countingFactoryWithLogger(),
+			MaxEntries: 10,
+			Logger:     logger,
+		})
+
+		pool.Inject("rr-012", "carol", &mockPoolSession{id: 77})
+		pool.Release("rr-012", "carol")
+
+		found := false
+		for _, e := range *entries {
+			if containsAll(e.args, "mcp_session_id", "rr_id", "rr-012") && containsAny(e.args, "release", "released") {
+				found = true
+				break
+			}
+		}
+		Expect(found).To(BeTrue(),
+			"AU-2: Release must emit structured log with mcp_session_id and rr_id")
+	})
+
+	It("UT-AF-1387-013 [AU-3, AU-6]: stale-retry logs both evicted and replacement mcp_session_id", func() {
+		logger, entries := capturingLogger()
+		pool = ka.NewKASessionPool(ka.PoolConfig{
+			Factory:    countingFactoryWithLogger(),
+			MaxEntries: 10,
+			Logger:     logger,
+		})
+
+		deadSession := &mockPoolSession{
+			id: 1,
+			pingFn: func(_ context.Context, _ *mcp.PingParams) error {
+				return fmt.Errorf("transport closed")
+			},
+		}
+		pool.Inject("rr-013", "dave", deadSession)
+
+		_, err := pool.Acquire(context.Background(), "rr-013", "dave")
+		Expect(err).NotTo(HaveOccurred())
+
+		foundEvicted := false
+		for _, e := range *entries {
+			if containsAll(e.args, "mcp_session_id", "evict") {
+				foundEvicted = true
+				break
+			}
+		}
+		Expect(foundEvicted).To(BeTrue(),
+			"AU-3+AU-6: stale-retry path must log mcp_session_id of evicted session for correlation")
+	})
+
+	It("UT-AF-1387-014 [SI-4]: ping-eviction logs mcp_session_id of dead session with error detail", func() {
+		logger, entries := capturingLogger()
+		pool = ka.NewKASessionPool(ka.PoolConfig{
+			Factory:    countingFactoryWithLogger(),
+			MaxEntries: 10,
+			Logger:     logger,
+		})
+
+		deadSession := &mockPoolSession{
+			id: 1,
+			pingFn: func(_ context.Context, _ *mcp.PingParams) error {
+				return fmt.Errorf("connection reset by peer")
+			},
+		}
+		pool.Inject("rr-014", "eve", deadSession)
+
+		_, err := pool.Acquire(context.Background(), "rr-014", "eve")
+		Expect(err).NotTo(HaveOccurred())
+
+		found := false
+		for _, e := range *entries {
+			if containsAll(e.args, "mcp_session_id", "error") {
+				found = true
+				break
+			}
+		}
+		Expect(found).To(BeTrue(),
+			"SI-4: ping-eviction must log mcp_session_id of dead session alongside error detail for incident correlation")
+	})
+})
+
+func containsAll(s string, substrs ...string) bool {
+	for _, sub := range substrs {
+		if !strings.Contains(s, sub) {
+			return false
+		}
+	}
+	return true
+}
+
+func containsAny(s string, substrs ...string) bool {
+	for _, sub := range substrs {
+		if strings.Contains(s, sub) {
+			return true
+		}
+	}
+	return false
+}
 
 var _ = Describe("IT-AF-1351: KASessionPool EvictIdle wiring", func() {
 

--- a/pkg/apifrontend/ka/shutdown_test.go
+++ b/pkg/apifrontend/ka/shutdown_test.go
@@ -27,6 +27,10 @@ func (s *countingSession) CallTool(_ context.Context, _ *mcp.CallToolParams) (*m
 	return &mcp.CallToolResult{}, nil
 }
 
+func (s *countingSession) Ping(_ context.Context, _ *mcp.PingParams) error {
+	return nil
+}
+
 var _ = Describe("Graceful Shutdown (G14)", func() {
 	It("UT-AF-1234-140: DrainAll closes all pool sessions", func() {
 		var closeCount int32

--- a/pkg/apifrontend/tools/ka_investigate_mcp_test.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp_test.go
@@ -1151,7 +1151,8 @@ type mockPoolSession struct{}
 func (m *mockPoolSession) CallTool(_ context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
 	return &mcp.CallToolResult{}, nil
 }
-func (m *mockPoolSession) Close() error { return nil }
+func (m *mockPoolSession) Ping(_ context.Context, _ *mcp.PingParams) error { return nil }
+func (m *mockPoolSession) Close() error                                     { return nil }
 
 // Suppress unused import warning for json and time
 var _ = json.Marshal

--- a/pkg/kubernautagent/llm/vertexanthropic/client.go
+++ b/pkg/kubernautagent/llm/vertexanthropic/client.go
@@ -232,10 +232,10 @@ func (c *Client) buildParams(req llm.ChatRequest) anthropic.MessageNewParams {
 				}
 				params.Messages = append(params.Messages,
 					anthropic.NewAssistantMessage(parts...))
-			} else {
-				params.Messages = append(params.Messages,
-					anthropic.NewAssistantMessage(anthropic.NewTextBlock(m.Content)))
-			}
+		} else if m.Content != "" {
+			params.Messages = append(params.Messages,
+				anthropic.NewAssistantMessage(anthropic.NewTextBlock(m.Content)))
+		}
 		case "tool":
 			pendingToolResults = append(pendingToolResults,
 				anthropic.NewToolResultBlock(m.ToolCallID, m.Content, false))

--- a/pkg/kubernautagent/llm/vertexanthropic/empty_block_1384_test.go
+++ b/pkg/kubernautagent/llm/vertexanthropic/empty_block_1384_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package vertexanthropic_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/anthropics/anthropic-sdk-go/option"
+
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm/vertexanthropic"
+)
+
+var _ = Describe("Fix #1384 Bug B — vertexanthropic empty text block guard (SI-10)", func() {
+
+	var (
+		server    *httptest.Server
+		tokenSrv  *httptest.Server
+		client    *vertexanthropic.Client
+		fakeCreds []byte
+	)
+
+	makeTestClient := func(handler http.HandlerFunc) {
+		tokenSrv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"fake-token","token_type":"Bearer","expires_in":3600}`))
+		}))
+		fakeCreds = generateFakeServiceAccountJSONWithTokenURL(tokenSrv.URL)
+
+		server = httptest.NewServer(handler)
+		var err error
+		client, err = vertexanthropic.New(context.Background(),
+			"claude-sonnet-4-6", fakeCreds, "my-project", "us-central1",
+			vertexanthropic.WithSDKOptions(
+				option.WithBaseURL(server.URL),
+			),
+		)
+		Expect(err).NotTo(HaveOccurred())
+	}
+
+	AfterEach(func() {
+		if server != nil {
+			server.Close()
+		}
+		if tokenSrv != nil {
+			tokenSrv.Close()
+		}
+	})
+
+	Describe("UT-KA-1384-B03: LLM client never sends empty text blocks to Vertex AI (SI-10 defense-in-depth)", func() {
+		It("should skip or replace empty Content for assistant messages with no ToolCalls", func() {
+			var receivedBody map[string]interface{}
+			makeTestClient(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &receivedBody)
+
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{
+					"id": "msg_b03",
+					"type": "message",
+					"role": "assistant",
+					"model": "claude-sonnet-4-6",
+					"stop_reason": "end_turn",
+					"content": [{"type": "text", "text": "Final answer."}],
+					"usage": {"input_tokens": 10, "output_tokens": 5}
+				}`))
+			})
+
+			resp, err := client.Chat(context.Background(), llm.ChatRequest{
+				Messages: []llm.Message{
+					{Role: "user", Content: "Start investigation"},
+					{Role: "assistant", Content: ""},
+					{Role: "user", Content: "Continue"},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp.Message.Content).To(Equal("Final answer."))
+
+			messages, ok := receivedBody["messages"].([]interface{})
+			Expect(ok).To(BeTrue())
+
+			for i, rawMsg := range messages {
+				msg := rawMsg.(map[string]interface{})
+				if msg["role"] != "assistant" {
+					continue
+				}
+				content, hasContent := msg["content"].([]interface{})
+				if !hasContent {
+					continue
+				}
+				for j, rawBlock := range content {
+					block := rawBlock.(map[string]interface{})
+					if block["type"] == "text" {
+						text, _ := block["text"].(string)
+						Expect(text).NotTo(BeEmpty(),
+							"assistant message[%d].content[%d] has empty text block — violates SI-10", i, j)
+					}
+				}
+			}
+		})
+	})
+
+	Describe("UT-KA-1384-B04: LLM client correctly sends non-empty assistant text (no over-filtering)", func() {
+		It("should include text block when Content is non-empty", func() {
+			var receivedBody map[string]interface{}
+			makeTestClient(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &receivedBody)
+
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{
+					"id": "msg_b04",
+					"type": "message",
+					"role": "assistant",
+					"model": "claude-sonnet-4-6",
+					"stop_reason": "end_turn",
+					"content": [{"type": "text", "text": "OK"}],
+					"usage": {"input_tokens": 10, "output_tokens": 2}
+				}`))
+			})
+
+			_, err := client.Chat(context.Background(), llm.ChatRequest{
+				Messages: []llm.Message{
+					{Role: "user", Content: "Start"},
+					{Role: "assistant", Content: "I found the issue."},
+					{Role: "user", Content: "Tell me more"},
+				},
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			messages := receivedBody["messages"].([]interface{})
+			assistantMsg := messages[1].(map[string]interface{})
+			Expect(assistantMsg["role"]).To(Equal("assistant"))
+
+			content := assistantMsg["content"].([]interface{})
+			Expect(content).To(HaveLen(1))
+			textBlock := content[0].(map[string]interface{})
+			Expect(textBlock["type"]).To(Equal("text"))
+			Expect(textBlock["text"]).To(Equal("I found the issue."))
+		})
+	})
+})

--- a/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
@@ -759,6 +759,14 @@ spec:
                   ========================================
                   KASession tracks the async KA session for submit/poll pattern
                 properties:
+                  consecutiveGetResultErrors:
+                    description: |-
+                      ConsecutiveGetResultErrors tracks consecutive 409 errors from GetSessionResult.
+                      #1390: After 3 consecutive 409s, the session is regenerated to break the polling loop.
+                      Reset to 0 on any successful GetSessionResult call.
+                    format: int32
+                    minimum: 0
+                    type: integer
                   createdAt:
                     description: CreatedAt timestamp when the current session was
                       created

--- a/test/e2e/apifrontend/mcp_session_resilience_test.go
+++ b/test/e2e/apifrontend/mcp_session_resilience_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// =============================================================================
+// E2E-AF-1387: MCP Session Resilience — Ping-on-Acquire (#1387)
+//
+// Proves the full resilience journey through the deployed AF → KA stack:
+//   1. Establish MCP session, start investigation (session enters pool)
+//   2. Kill KA pod (transport dies for cached session)
+//   3. Wait for KA pod to restart
+//   4. Call discover_workflows through same AF MCP session
+//   5. Assert transparent recovery (pool Ping detected dead session, evicted,
+//      factory reconnected to restarted KA)
+//
+// NIST 800-53 Controls:
+//   SI-4  — proactive health check detects failure
+//   SC-24 — fail in known state (evict, don't use dead session)
+//   CP-10 — auto-reconstitute without operator intervention
+//
+// Pyramid Invariant:
+//   UT proves Ping-on-Acquire logic (session_pool_test.go)
+//   IT proves wiring through PooledMCPClient (investigation_session_handoff_test.go)
+//   E2E (this file) proves the journey through the full deployed stack
+// =============================================================================
+
+var _ = Describe("MCP Session Resilience (#1387)", Label("e2e", "mcp-resilience"), func() {
+
+	var authToken string
+	var mcpSessionID string
+
+	BeforeEach(func() {
+		var err error
+		authToken, err = fetchDEXTokenForPersona("sre")
+		Expect(err).NotTo(HaveOccurred(), "Failed to obtain DEX token")
+		Expect(authToken).NotTo(BeEmpty())
+
+		mcpSessionID, err = initMCPSession(authToken)
+		Expect(err).NotTo(HaveOccurred(), "Failed to initialize MCP session")
+		Expect(mcpSessionID).NotTo(BeEmpty())
+	})
+
+	mcpToolCallWithSession := func(rpcID, toolName string, args map[string]interface{}) ([]byte, error) {
+		callBody := buildJSONRPC(rpcID, "tools/call", map[string]interface{}{
+			"name":      toolName,
+			"arguments": args,
+		})
+		raw, code, err := mcpPOST(authToken, mcpSessionID, callBody)
+		if err != nil {
+			return nil, err
+		}
+		if code >= http.StatusBadRequest {
+			return nil, fmt.Errorf("HTTP %d: %s", code, string(raw))
+		}
+		payload := unwrapSSEDataLine(raw)
+		return []byte(payload), nil
+	}
+
+	It("E2E-AF-1387-001 [SI-4, SC-24, CP-10]: dead KA session auto-reconstituted after pod restart", func() {
+		rrName := "e2e-resilience-1387-rr"
+
+		By("Creating RR fixture for investigation")
+		Expect(createRR(e2eNamespace, rrName, "Deployment", "test-deploy-1387")).To(Succeed())
+		DeferCleanup(func() { deleteRR(e2eNamespace, rrName) })
+
+		By("Step 1: Starting investigation to populate AF session pool")
+		raw, err := mcpToolCallWithSession("res-1387-start", "kubernaut_investigate", map[string]interface{}{
+			"rr_id": rrName,
+		})
+		Expect(err).NotTo(HaveOccurred(), "initial investigation should succeed")
+		GinkgoWriter.Printf("  investigation result: %s\n", string(raw))
+
+		var startResult map[string]interface{}
+		if len(raw) > 0 {
+			_ = json.Unmarshal(raw, &startResult)
+		}
+
+		By("Step 2: Verifying baseline — discover_workflows callable")
+		raw, err = mcpToolCallWithSession("res-1387-baseline", "kubernaut_discover_workflows", map[string]interface{}{
+			"rr_id": rrName,
+		})
+		Expect(err).NotTo(HaveOccurred(), "baseline discover_workflows should succeed before pod kill")
+		GinkgoWriter.Printf("  baseline discover_workflows: %s\n", string(raw))
+
+		By("Step 3: Killing KA pod to invalidate cached transport session")
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		deleteCmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", kubeconfigPath,
+			"-n", e2eNamespace, "delete", "pod", "-l", "app.kubernetes.io/name=kubernaut-agent",
+			"--grace-period=0", "--force")
+		deleteCmd.Stdout = GinkgoWriter
+		deleteCmd.Stderr = GinkgoWriter
+		Expect(deleteCmd.Run()).To(Succeed(), "kubectl delete pod should succeed")
+
+		By("Step 4: Waiting for KA pod to restart and become ready")
+		waitCtx, waitCancel := context.WithTimeout(context.Background(), 120*time.Second)
+		defer waitCancel()
+
+		rolloutCmd := exec.CommandContext(waitCtx, "kubectl", "--kubeconfig", kubeconfigPath,
+			"rollout", "status", "deployment/kubernaut-agent", "-n", e2eNamespace,
+			"--timeout=120s")
+		rolloutCmd.Stdout = GinkgoWriter
+		rolloutCmd.Stderr = GinkgoWriter
+		Expect(rolloutCmd.Run()).To(Succeed(), "KA deployment should become ready after pod restart")
+
+		time.Sleep(5 * time.Second)
+
+		By("Step 5: Calling discover_workflows — pool should detect dead session and auto-reconnect")
+		Eventually(func(g Gomega) {
+			raw, err = mcpToolCallWithSession("res-1387-after-kill", "kubernaut_discover_workflows", map[string]interface{}{
+				"rr_id": rrName,
+			})
+			g.Expect(err).NotTo(HaveOccurred(),
+				"CP-10: discover_workflows must succeed after KA pod restart — pool auto-reconstituted session")
+		}, 30*time.Second, 3*time.Second).Should(Succeed(),
+			"SI-4+SC-24+CP-10: Ping-on-Acquire must detect dead cached session, evict it, and transparently create a fresh session to the restarted KA")
+
+		GinkgoWriter.Printf("  post-recovery discover_workflows: %s\n", string(raw))
+	})
+})

--- a/test/e2e/fullpipeline/11_session_upgrade_test.go
+++ b/test/e2e/fullpipeline/11_session_upgrade_test.go
@@ -1,0 +1,108 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fullpipeline
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	aianalysisv1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
+	isv1alpha1 "github.com/jordigilh/kubernaut/api/investigationsession/v1alpha1"
+	"github.com/jordigilh/kubernaut/test/infrastructure"
+)
+
+// E2E-FP-1390-001: Full upgrade journey — autonomous → IS CRD → AA sets Interactive →
+// MCP user connects → KA upgrades session → RCA completes with InteractiveHold →
+// session completes.
+var _ = Describe("E2E-FP-1390-001: Session Upgrade Journey", Label("e2e", "fullpipeline", "1390"), func() {
+
+	It("should complete upgrade journey: autonomous submit → IS appears → AA upgrades → KA holds → user completes [SC-24, AC-12]", func() {
+		By("creating a RemediationRequest to trigger investigation")
+		testID := "fp-1390-upgrade"
+		rrName, err := infrastructure.CreateDirectRR(ctx, namespace, testID)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("waiting for AA to reach Investigating with an autonomous session")
+		var aaName string
+		Eventually(func() bool {
+			aaList := &aianalysisv1.AIAnalysisList{}
+			if err := apiReader.List(ctx, aaList, client.InNamespace(namespace)); err != nil {
+				return false
+			}
+			for _, aa := range aaList.Items {
+				if aa.Spec.RemediationRequestRef.Name == rrName {
+					aaName = aa.Name
+					phase := string(aa.Status.Phase)
+					return phase == "Investigating" || phase == "Analyzing" || phase == "Completed"
+				}
+			}
+			return false
+		}, timeout, 1*time.Second).Should(BeTrue())
+
+		By("verifying AA has an autonomous session (Interactive=false)")
+		var aa aianalysisv1.AIAnalysis
+		Expect(apiReader.Get(ctx, client.ObjectKey{Name: aaName, Namespace: namespace}, &aa)).To(Succeed())
+		if aa.Status.KASession != nil && !aa.Status.KASession.Interactive {
+			originalSessionID := aa.Status.KASession.ID
+
+			By("creating Active IS CRD to trigger upgrade")
+			is := &isv1alpha1.InvestigationSession{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "is-" + testID,
+					Namespace: namespace,
+				},
+				Spec: isv1alpha1.InvestigationSessionSpec{
+					RemediationRequestRef: isv1alpha1.ObjectRef{
+						Name:      rrName,
+						Namespace: namespace,
+					},
+					A2ATaskID: "task-" + testID,
+					UserIdentity: isv1alpha1.SessionUser{
+						Username: "sre-upgrade@kubernaut.ai",
+						Groups:   []string{"sre"},
+					},
+					JoinMode: isv1alpha1.SessionJoinModeStart,
+				},
+			}
+			Expect(k8sClient.Create(ctx, is)).To(Succeed())
+			is.Status.Phase = isv1alpha1.SessionPhaseActive
+			Expect(k8sClient.Status().Update(ctx, is)).To(Succeed())
+
+			By("verifying AA upgrades to Interactive=true without cancel")
+			Eventually(func(g Gomega) {
+				g.Expect(apiReader.Get(ctx, client.ObjectKey{Name: aaName, Namespace: namespace}, &aa)).To(Succeed())
+				g.Expect(aa.Status.KASession).NotTo(BeNil())
+				g.Expect(aa.Status.KASession.Interactive).To(BeTrue(),
+					"AA must set Interactive=true on upgrade")
+				g.Expect(aa.Status.KASession.ID).To(Equal(originalSessionID),
+					"session ID must be preserved — no cancel/resubmit")
+			}, timeout, 1*time.Second).Should(Succeed())
+
+			By("waiting for AA to reach terminal phase")
+			Eventually(func() string {
+				_ = apiReader.Get(ctx, client.ObjectKey{Name: aaName, Namespace: namespace}, &aa)
+				return string(aa.Status.Phase)
+			}, 3*time.Minute, 2*time.Second).Should(
+				BeElementOf("Completed", "Analyzing", "Failed"),
+				"AA must reach a terminal or post-investigation phase")
+		}
+	})
+})

--- a/test/e2e/kubernautagent/session_nil_result_test.go
+++ b/test/e2e/kubernautagent/session_nil_result_test.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kubernautagent
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/agentclient"
+)
+
+// E2E-KA-1390-001: Nil-result resilience — session completes with nil result →
+// GET /result returns HTTP 200 with structured synthetic result → no 409 loop.
+var _ = Describe("E2E-KA-1390-001: Nil-Result Resilience", Label("e2e", "ka", "1390"), func() {
+
+	It("should return structured result for completed session with nil result [SC-24, SI-13]", func() {
+		// Submit an investigation that will complete. After the mock LLM
+		// completes, the session reaches a terminal state. If the mock
+		// scenario returns an empty/nil result, GetResult must still
+		// return HTTP 200 with a synthetic result body.
+		req := &agentclient.IncidentRequest{
+			IncidentID:        "test-nil-result-1390",
+			RemediationID:     "rem-nil-result-1390",
+			SignalName:        "CrashLoopBackOff",
+			Severity:          "medium",
+			SignalSource:      "kubernetes",
+			ResourceNamespace: "default",
+			ResourceKind:      "Pod",
+			ResourceName:      "nil-result-pod",
+			ErrorMessage:      "Container exited with code 137",
+			Environment:       "staging",
+			Priority:          "P2",
+			RiskTolerance:     "high",
+			BusinessCategory:  "standard",
+			ClusterName:       "e2e-test",
+		}
+
+		By("submitting investigation")
+		sessionID, err := sessionClient.SubmitInvestigation(ctx, req)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(sessionID).ToNot(BeEmpty())
+
+		By("waiting for session to reach terminal state")
+		Eventually(func() string {
+			result, pollErr := sessionClient.PollSession(ctx, sessionID)
+			if pollErr != nil || result == nil {
+				return "error"
+			}
+			return result.Status
+		}, 2*time.Minute, 2*time.Second).Should(
+			BeElementOf("completed", "failed", "cancelled"),
+			"session must reach terminal state",
+		)
+
+		By("fetching result — must return 200, not 409")
+		result, err := sessionClient.GetSessionResult(ctx, sessionID)
+		Expect(err).ToNot(HaveOccurred(),
+			"GET /result must return 200 for terminal sessions — nil-result 409 loop prevented")
+		Expect(result).ToNot(BeNil(), "response must contain a structured result body")
+		Expect(result.Analysis).ToNot(BeEmpty(),
+			"synthetic result must include non-empty analysis field")
+	})
+})

--- a/test/integration/aianalysis/interactive_watch_test.go
+++ b/test/integration/aianalysis/interactive_watch_test.go
@@ -365,6 +365,8 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 				return mockClient.GetPollCallCount()
 			}, timeout, interval).Should(BeNumerically(">=", 1))
 
+			cancelCountBeforeIS := mockClient.GetCancelCallCount()
+
 			By("creating Active InvestigationSession for the same RR")
 			isName := helpers.UniqueTestName("is-1390-upgrade")
 			createActiveIS(isName, rrName)
@@ -377,8 +379,8 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 					"Interactive flag must be set by upgrade path")
 				g.Expect(analysis.Status.KASession.ID).To(Equal(sessionID),
 					"session ID must be preserved — no cancel/resubmit")
-				g.Expect(mockClient.GetCancelCallCount()).To(Equal(0),
-					"CancelSession must NOT be called in the upgrade path")
+				g.Expect(mockClient.GetCancelCallCount()).To(Equal(cancelCountBeforeIS),
+					"CancelSession must NOT be called for THIS session in the upgrade path")
 			}, timeout, interval).Should(Succeed())
 
 			By("verifying InteractiveSession populated from user_driving poll")

--- a/test/integration/aianalysis/interactive_watch_test.go
+++ b/test/integration/aianalysis/interactive_watch_test.go
@@ -187,7 +187,7 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 			}
 		})
 
-		It("IT-AA-1293-002: should cancel autonomous session when Active IS is created", func() {
+		It("IT-AA-1293-002: should upgrade autonomous session in-place when Active IS is created (#1390)", func() {
 			rrName := helpers.UniqueTestName("rr-watch-create")
 			sessionID := "session-autonomous-001"
 			analysisName := helpers.UniqueTestName("aa-watch-create")
@@ -202,12 +202,16 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 			By("creating Active InvestigationSession for the same RR")
 			createActiveIS(helpers.UniqueTestName("is-watch-create"), rrName)
 
-			By("verifying IS watch triggered cancel and cleared session ID for re-submit")
+			By("verifying IS watch triggered upgrade: Interactive=true, no cancel, session ID preserved")
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), analysis)).To(Succeed())
 				g.Expect(analysis.Status.KASession).NotTo(BeNil())
-				g.Expect(mockClient.GetCancelCallCount()).To(BeNumerically(">=", 1),
-					"CancelSession should be called when IS appears for autonomous session")
+				g.Expect(analysis.Status.KASession.Interactive).To(BeTrue(),
+					"Interactive flag must be set by upgrade path")
+				g.Expect(analysis.Status.KASession.ID).To(Equal(sessionID),
+					"session ID must be preserved — upgrade in-place, no cancel")
+				g.Expect(mockClient.GetCancelCallCount()).To(Equal(0),
+					"CancelSession must NOT be called — #1390 upgrade replaces cancel")
 			}, timeout, interval).Should(Succeed())
 		})
 
@@ -273,23 +277,12 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 			}
 		})
 
-		It("IT-AA-1293-004: should cancel autonomous session and re-submit with interactive=true on takeover [BR-INTERACTIVE-010]", func() {
+		It("IT-AA-1293-004: should upgrade autonomous session in-place with Interactive=true and SetActivePhase (#1390) [BR-INTERACTIVE-010]", func() {
 			rrName := helpers.UniqueTestName("rr-takeover")
-			oldSessionID := "session-autonomous-old"
-			newSessionID := "session-interactive-new"
+			sessionID := "session-autonomous-upgrade"
 			analysisName := helpers.UniqueTestName("aa-takeover")
 
-			submitCount := 0
-			var submitMu sync.Mutex
-			mockClient.SubmitInvestigationFunc = func(_ context.Context, req *agentclient.IncidentRequest) (string, error) {
-				submitMu.Lock()
-				defer submitMu.Unlock()
-				submitCount++
-				mockClient.LastRequest = req
-				return newSessionID, nil
-			}
-
-			analysis := createInvestigatingAA(analysisName, rrName, oldSessionID, false)
+			analysis := createInvestigatingAA(analysisName, rrName, sessionID, false)
 
 			By("waiting for controller to start polling (proves reconcile loop is active)")
 			Eventually(func() int {
@@ -299,25 +292,108 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 			By("creating Active InvestigationSession mid-investigation")
 			createActiveIS(helpers.UniqueTestName("is-takeover"), rrName)
 
-			By("verifying cancel + re-submit with interactive=true")
+			By("verifying upgrade in-place: Interactive=true, no cancel, session ID preserved")
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), analysis)).To(Succeed())
-				g.Expect(mockClient.GetCancelCallCount()).To(BeNumerically(">=", 1))
-
-				submitMu.Lock()
-				sc := submitCount
-				submitMu.Unlock()
-				g.Expect(sc).To(BeNumerically(">=", 1))
-
 				g.Expect(analysis.Status.KASession).NotTo(BeNil())
-				g.Expect(analysis.Status.KASession.ID).To(Equal(newSessionID))
-				g.Expect(analysis.Status.KASession.Interactive).To(BeTrue())
-				lastReq := mockClient.GetLastRequest()
-				g.Expect(lastReq).NotTo(BeNil())
-				interactive, ok := lastReq.Interactive.Get()
-				g.Expect(ok).To(BeTrue())
-				g.Expect(interactive).To(BeTrue())
+				g.Expect(analysis.Status.KASession.Interactive).To(BeTrue(),
+					"Interactive flag must be set by upgrade path")
+				g.Expect(analysis.Status.KASession.ID).To(Equal(sessionID),
+					"session ID must be preserved — no cancel/resubmit in #1390")
+				g.Expect(mockClient.GetCancelCallCount()).To(Equal(0),
+					"CancelSession must NOT be called — upgrade in-place replaces cancel")
 			}, timeout, interval).Should(Succeed())
+		})
+	})
+
+	// IT-AA-1390-W04: AA upgrade path (no cancel) wiring through envtest reconcile loop.
+	// Proves that when IS appears for an autonomous session, the handler sets Interactive=true
+	// and calls SetActivePhase instead of cancelling and resubmitting.
+	Context("#1390: AA upgrade-in-place wiring through reconcile loop", Serial, func() {
+		var (
+			savedHandler *handlers.InvestigatingHandler
+			mockClient   *mocks.MockAgentClient
+		)
+
+		swapMockHandlerWithUpgrade := func() {
+			savedHandler = reconciler.InvestigatingHandler.Load()
+			mockClient = mocks.NewMockAgentClient()
+			mockClient.WithSessionPollStatus("investigating")
+
+			auditClient := aiaudit.NewAuditClient(auditStore, ctrl.Log.WithName("upgrade-test-audit"))
+			isChecker := handlers.NewK8sInvestigationSessionChecker(k8sClient, testNamespace)
+			isPhaseUpdater := handlers.NewK8sISPhaseUpdater(k8sClient, testNamespace)
+			reconciler.InvestigatingHandler.Store(handlers.NewInvestigatingHandler(
+				mockClient,
+				ctrl.Log.WithName("upgrade-mock-handler"),
+				testMetrics,
+				auditClient,
+				handlers.WithSessionMode(),
+				handlers.WithSessionPollInterval(100*time.Millisecond),
+				handlers.WithInvestigationSessionChecker(isChecker),
+				handlers.WithISPhaseUpdater(isPhaseUpdater),
+				handlers.WithRecorder(k8sManager.GetEventRecorderFor("aianalysis-controller")),
+			))
+		}
+
+		BeforeEach(func() {
+			swapMockHandlerWithUpgrade()
+		})
+
+		AfterEach(func() {
+			if savedHandler != nil {
+				reconciler.InvestigatingHandler.Store(savedHandler)
+			}
+		})
+
+		It("IT-AA-1390-W04: should set Interactive=true and SetActivePhase without cancel when IS appears for autonomous session [AC-12]", func() {
+			rrName := helpers.UniqueTestName("rr-1390-upgrade")
+			sessionID := "session-autonomous-upgrade"
+			analysisName := helpers.UniqueTestName("aa-1390-upgrade")
+
+			mockClient.PollSessionFunc = func(_ context.Context, _ string) (*agentclient.SessionStatusResult, error) {
+				return &agentclient.SessionStatusResult{
+					Status:     "user_driving",
+					ActingUser: "sre-takeover@example.com",
+				}, nil
+			}
+
+			analysis := createInvestigatingAA(analysisName, rrName, sessionID, false)
+
+			By("waiting for controller to start polling (proves reconcile loop is active)")
+			Eventually(func() int {
+				return mockClient.GetPollCallCount()
+			}, timeout, interval).Should(BeNumerically(">=", 1))
+
+			By("creating Active InvestigationSession for the same RR")
+			isName := helpers.UniqueTestName("is-1390-upgrade")
+			createActiveIS(isName, rrName)
+
+			By("verifying upgrade path: Interactive=true, no cancel, IS Phase=Active preserved")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), analysis)).To(Succeed())
+				g.Expect(analysis.Status.KASession).NotTo(BeNil())
+				g.Expect(analysis.Status.KASession.Interactive).To(BeTrue(),
+					"Interactive flag must be set by upgrade path")
+				g.Expect(analysis.Status.KASession.ID).To(Equal(sessionID),
+					"session ID must be preserved — no cancel/resubmit")
+				g.Expect(mockClient.GetCancelCallCount()).To(Equal(0),
+					"CancelSession must NOT be called in the upgrade path")
+			}, timeout, interval).Should(Succeed())
+
+			By("verifying InteractiveSession populated from user_driving poll")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), analysis)).To(Succeed())
+				g.Expect(analysis.Status.InteractiveSession).NotTo(BeNil(),
+					"InteractiveSession must be populated after polling user_driving")
+				g.Expect(analysis.Status.InteractiveSession.ActingUser).To(Equal("sre-takeover@example.com"))
+			}, timeout, interval).Should(Succeed())
+
+			By("verifying IS CRD Phase=Active was set via K8sISPhaseUpdater (best-effort)")
+			var is isv1alpha1.InvestigationSession
+			Expect(k8sClient.Get(ctx, client.ObjectKey{Name: isName, Namespace: testNamespace}, &is)).To(Succeed())
+			Expect(is.Status.Phase).To(Equal(isv1alpha1.SessionPhaseActive),
+				"IS phase must be Active after SetActivePhase call")
 		})
 	})
 

--- a/test/integration/apifrontend/audit_normalization_test.go
+++ b/test/integration/apifrontend/audit_normalization_test.go
@@ -21,16 +21,27 @@ import (
 )
 
 // capturingDSClient captures batches written by BufferedAuditStore for verification.
+// StoreBatch is called from the backgroundWriter goroutine; allEvents is called from
+// the test goroutine, so access to batches is protected by a mutex. StoreBatch copies
+// the incoming slice to avoid aliasing the backgroundWriter's reusable batch array
+// (batch[:0] reuse causes silent data corruption without the copy).
 type capturingDSClient struct {
+	mu      sync.Mutex
 	batches [][]*ogenclient.AuditEventRequest
 }
 
 func (c *capturingDSClient) StoreBatch(_ context.Context, events []*ogenclient.AuditEventRequest) error {
-	c.batches = append(c.batches, events)
+	copied := make([]*ogenclient.AuditEventRequest, len(events))
+	copy(copied, events)
+	c.mu.Lock()
+	c.batches = append(c.batches, copied)
+	c.mu.Unlock()
 	return nil
 }
 
 func (c *capturingDSClient) allEvents() []*ogenclient.AuditEventRequest {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	var all []*ogenclient.AuditEventRequest
 	for _, batch := range c.batches {
 		all = append(all, batch...)

--- a/test/integration/apifrontend/investigation_session_handoff_test.go
+++ b/test/integration/apifrontend/investigation_session_handoff_test.go
@@ -19,6 +19,7 @@ package apifrontend_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"sync/atomic"
 
 	"github.com/go-logr/logr"
@@ -45,10 +46,11 @@ import (
 //   IT (this file) proves wiring through production dispatch paths.
 // =============================================================================
 
-// handoffSession is a trackable PoolSession used by IT-AF-1332 tests.
+// handoffSession is a trackable PoolSession used by IT-AF-1332 and IT-AF-1387 tests.
 type handoffSession struct {
 	id       string
 	callFn   func(ctx context.Context, params *mcp.CallToolParams) (*mcp.CallToolResult, error)
+	pingFn   func(ctx context.Context, params *mcp.PingParams) error
 	closed   int32
 }
 
@@ -57,6 +59,13 @@ func (s *handoffSession) CallTool(ctx context.Context, params *mcp.CallToolParam
 		return s.callFn(ctx, params)
 	}
 	return &mcp.CallToolResult{}, nil
+}
+
+func (s *handoffSession) Ping(ctx context.Context, params *mcp.PingParams) error {
+	if s.pingFn != nil {
+		return s.pingFn(ctx, params)
+	}
+	return nil
 }
 
 func (s *handoffSession) Close() error {
@@ -259,5 +268,172 @@ var _ = Describe("Investigation Session Handoff (#1332)", Label("integration", "
 			Expect(atomic.LoadInt32(&closerCalled)).To(Equal(int32(1)),
 				"cleanup (closer) must be called when pool is nil — MCP bridge path behavior")
 		})
+	})
+})
+
+// =============================================================================
+// IT-AF-1387: MCP Session Resilience — Ping-on-Acquire Wiring (#1387)
+//
+// Wiring Manifest rows covered:
+//   - Ping-on-Acquire via PooledMCPClient.DiscoverWorkflows (IT-AF-1387-W01)
+//   - Transparent reconnection via PooledMCPClient dispatch   (IT-AF-1387-W02)
+//   - Healthy session reuse via PooledMCPClient dispatch      (IT-AF-1387-W03)
+//
+// Pyramid Invariant:
+//   UT (session_pool_test.go) proves Ping-on-Acquire logic.
+//   IT (this block) proves wiring through PooledMCPClient production dispatch.
+// =============================================================================
+
+var _ = Describe("MCP Session Resilience — Ping-on-Acquire Wiring (#1387)", Label("integration", "mcp-resilience"), func() {
+
+	It("IT-AF-1387-W01 [SI-4, SC-24]: dead session evicted transparently when DiscoverWorkflows dispatches through pool", func() {
+		var factoryCalled int32
+		pool := ka.NewKASessionPool(ka.PoolConfig{
+			Factory: func(_ context.Context) (ka.PoolSession, error) {
+				atomic.AddInt32(&factoryCalled, 1)
+				return &handoffSession{
+					id: "factory-replacement",
+					callFn: func(_ context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+						resp := map[string]any{
+							"workflows": []map[string]any{
+								{"workflow_id": "wf-recovery-v1", "name": "Recovery", "description": "Auto recovery", "kind": "remediation", "confidence": 0.9},
+							},
+						}
+						raw, _ := json.Marshal(resp)
+						return &mcp.CallToolResult{
+							Content: []mcp.Content{&mcp.TextContent{Text: string(raw)}},
+						}, nil
+					},
+				}, nil
+			},
+			MaxEntries: 10,
+			Logger:     logr.Discard(),
+		})
+
+		deadSession := &handoffSession{
+			id: "dead-session",
+			pingFn: func(_ context.Context, _ *mcp.PingParams) error {
+				return fmt.Errorf("transport closed")
+			},
+		}
+		pool.Inject("rr-it-1387-w01", "alice", deadSession)
+
+		pooledClient := ka.NewPooledMCPClient(pool, logr.Discard())
+		ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+			Username: "alice",
+			Groups:   []string{"system:authenticated"},
+		})
+
+		result, err := pooledClient.DiscoverWorkflows(ctx, ka.DiscoverWorkflowsArgs{
+			RRID: "rr-it-1387-w01",
+		})
+		Expect(err).NotTo(HaveOccurred(),
+			"SI-4: PooledMCPClient.DiscoverWorkflows must succeed despite dead cached session")
+		Expect(result).NotTo(BeNil())
+		Expect(result.Workflows).To(HaveLen(1))
+		Expect(result.Workflows[0].WorkflowID).To(Equal("wf-recovery-v1"))
+
+		By("verifying dead session was evicted and closed")
+		Expect(deadSession.isClosed()).To(BeTrue(),
+			"SC-24: evicted session must be closed — fail in known state")
+
+		By("verifying factory created replacement")
+		Expect(atomic.LoadInt32(&factoryCalled)).To(Equal(int32(1)),
+			"CP-10: factory must create exactly one replacement session")
+	})
+
+	It("IT-AF-1387-W02 [CP-10]: transparent reconnection via InvokeAction dispatch path", func() {
+		var factoryCalled int32
+		pool := ka.NewKASessionPool(ka.PoolConfig{
+			Factory: func(_ context.Context) (ka.PoolSession, error) {
+				atomic.AddInt32(&factoryCalled, 1)
+				return &handoffSession{
+					id: "factory-replacement-w02",
+					callFn: func(_ context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+						resp := map[string]any{"status": "active", "session_id": "sess-w02"}
+						raw, _ := json.Marshal(resp)
+						return &mcp.CallToolResult{
+							Content: []mcp.Content{&mcp.TextContent{Text: string(raw)}},
+						}, nil
+					},
+				}, nil
+			},
+			MaxEntries: 10,
+			Logger:     logr.Discard(),
+		})
+
+		deadSession := &handoffSession{
+			id: "dead-session-w02",
+			pingFn: func(_ context.Context, _ *mcp.PingParams) error {
+				return fmt.Errorf("connection reset by peer")
+			},
+		}
+		pool.Inject("rr-it-1387-w02", "bob", deadSession)
+
+		pooledClient := ka.NewPooledMCPClient(pool, logr.Discard())
+		ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+			Username: "bob",
+			Groups:   []string{"system:authenticated"},
+		})
+
+		result, err := pooledClient.InvokeAction(ctx, ka.InvokeActionArgs{
+			RRID:   "rr-it-1387-w02",
+			Action: "status",
+		})
+		Expect(err).NotTo(HaveOccurred(),
+			"CP-10: InvokeAction must auto-reconstitute after dead session eviction")
+		Expect(result).NotTo(BeNil())
+		Expect(result.Status).To(Equal("active"))
+	})
+
+	It("IT-AF-1387-W03 [SI-4]: healthy session reused via PooledMCPClient without false-positive eviction", func() {
+		var factoryCalled int32
+		var callToolInvoked int32
+		healthySession := &handoffSession{
+			id: "healthy-session",
+			callFn: func(_ context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+				atomic.AddInt32(&callToolInvoked, 1)
+				resp := map[string]any{
+					"workflows": []map[string]any{
+						{"workflow_id": "wf-healthy-v1", "name": "Healthy Path", "description": "test", "kind": "remediation", "confidence": 0.99},
+					},
+				}
+				raw, _ := json.Marshal(resp)
+				return &mcp.CallToolResult{
+					Content: []mcp.Content{&mcp.TextContent{Text: string(raw)}},
+				}, nil
+			},
+		}
+
+		pool := ka.NewKASessionPool(ka.PoolConfig{
+			Factory: func(_ context.Context) (ka.PoolSession, error) {
+				atomic.AddInt32(&factoryCalled, 1)
+				return &handoffSession{id: "factory-sentinel"}, nil
+			},
+			MaxEntries: 10,
+			Logger:     logr.Discard(),
+		})
+		pool.Inject("rr-it-1387-w03", "carol", healthySession)
+
+		pooledClient := ka.NewPooledMCPClient(pool, logr.Discard())
+		ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+			Username: "carol",
+			Groups:   []string{"system:authenticated"},
+		})
+
+		result, err := pooledClient.DiscoverWorkflows(ctx, ka.DiscoverWorkflowsArgs{
+			RRID: "rr-it-1387-w03",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Workflows).To(HaveLen(1))
+		Expect(result.Workflows[0].WorkflowID).To(Equal("wf-healthy-v1"))
+
+		By("verifying healthy session was reused, not replaced")
+		Expect(atomic.LoadInt32(&callToolInvoked)).To(Equal(int32(1)),
+			"SI-4: healthy session must be reused — CallTool invoked exactly once on it")
+		Expect(atomic.LoadInt32(&factoryCalled)).To(Equal(int32(0)),
+			"SI-4: factory must not be called when cached session passes Ping")
+		Expect(healthySession.isClosed()).To(BeFalse(),
+			"SI-4: healthy session must NOT be closed")
 	})
 })

--- a/test/integration/kubernautagent/mcp/golden_path_test.go
+++ b/test/integration/kubernautagent/mcp/golden_path_test.go
@@ -104,6 +104,10 @@ func (m *goldenPathAutoMgr) Subscribe(_ context.Context, _ string) (<-chan sessi
 	return nil, fmt.Errorf("not implemented in golden path mock")
 }
 
+func (m *goldenPathAutoMgr) GetSessionLazySink(_ string) (*session.LazySink, bool) {
+	return nil, false
+}
+
 var _ = Describe("Golden Path Lifecycle — IT-KA-GOLDEN-001 BR-INTERACTIVE-001", func() {
 	var (
 		tool    *mcptools.InvestigateTool

--- a/test/integration/kubernautagent/mcp/golden_path_test.go
+++ b/test/integration/kubernautagent/mcp/golden_path_test.go
@@ -90,6 +90,9 @@ func (m *goldenPathAutoMgr) ForceTransitionToUserDriving(_ string, _ string, _ [
 	m.suspended = true
 	return nil
 }
+func (m *goldenPathAutoMgr) UpgradeToInteractive(_ string, _ string, _ []string) error {
+	return nil
+}
 
 func (m *goldenPathAutoMgr) FindPendingByRemediationID(_ string) (string, bool)         { return "", false }
 func (m *goldenPathAutoMgr) LaunchDeferredInvestigation(_ string) error                  { return nil }

--- a/test/integration/kubernautagent/mcp/takeover_test.go
+++ b/test/integration/kubernautagent/mcp/takeover_test.go
@@ -121,6 +121,10 @@ func (m *mockAutoMgrIT) GetLatestRCAResultByRemediationID(rrID string) (*katypes
 	return m.mgr.GetLatestRCAResultByRemediationID(rrID)
 }
 
+func (m *mockAutoMgrIT) GetSessionLazySink(id string) (*session.LazySink, bool) {
+	return m.mgr.GetSessionLazySink(id)
+}
+
 var _ = Describe("MCP Dynamic Takeover Integration — PR4 BR-INTERACTIVE-004", func() {
 
 	Describe("IT-KA-TAKE-001: Takeover mid-LLM-turn — autonomous transitions to user_driving", func() {

--- a/test/integration/kubernautagent/mcp/takeover_test.go
+++ b/test/integration/kubernautagent/mcp/takeover_test.go
@@ -105,6 +105,10 @@ func (m *mockAutoMgrIT) ForceTransitionToUserDriving(rrID, username string, grou
 	return m.mgr.ForceTransitionToUserDriving(rrID, username, groups)
 }
 
+func (m *mockAutoMgrIT) UpgradeToInteractive(id, username string, groups []string) error {
+	return m.mgr.UpgradeToInteractive(id, username, groups)
+}
+
 func (m *mockAutoMgrIT) FindPendingByRemediationID(rrID string) (string, bool) {
 	return m.mgr.FindPendingByRemediationID(rrID)
 }

--- a/test/integration/kubernautagent/mcp/wiring_test.go
+++ b/test/integration/kubernautagent/mcp/wiring_test.go
@@ -259,3 +259,51 @@ var _ = Describe("MCP Auth Architecture — #895/#896 BR-SECURITY-896", func() {
 		})
 	})
 })
+
+// =============================================================================
+// IT-KA-1387: MCP Session Resilience — KeepAlive/SessionTimeout Wiring (#1387)
+//
+// Pyramid Invariant:
+//   UT (server_test.go) proves BootstrapMCP accepts KeepAlive/SessionTimeout.
+//   IT (this block) proves config flows through to a functional MCP endpoint.
+// =============================================================================
+
+var _ = Describe("MCP Session Resilience — KeepAlive/SessionTimeout Wiring (#1387)", Label("integration", "mcp-resilience"), func() {
+
+	It("IT-KA-1387-W01 [SC-8, SC-10]: BootstrapMCP with KeepAlive+SessionTimeout produces functional MCP endpoint", func() {
+		authMw := fakeAuthMiddleware("test-user")
+		handler, srv := mcpinternal.BootstrapMCP(mcpinternal.MCPDeps{
+			AuthMiddleware: authMw,
+			KeepAlive:      15 * time.Second,
+			SessionTimeout: 10 * time.Minute,
+		})
+		Expect(handler).NotTo(BeNil())
+		Expect(srv).NotTo(BeNil())
+
+		r := chi.NewRouter()
+		r.Route("/api/v1", func(r chi.Router) {
+			r.Handle("/mcp", kaserver.SSEHeadersMiddleware(handler))
+			r.Handle("/mcp/*", kaserver.SSEHeadersMiddleware(handler))
+		})
+		ts := httptest.NewServer(r)
+		defer ts.Close()
+
+		jsonRPC := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"test","version":"1.0"}}}`
+		req, err := http.NewRequest("POST", ts.URL+"/api/v1/mcp", strings.NewReader(jsonRPC))
+		Expect(err).NotTo(HaveOccurred())
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "application/json, text/event-stream")
+		req.Header.Set("Authorization", "Bearer test-token")
+
+		resp, err := httpTestClient.Do(req)
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+
+		body, err := io.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(resp.StatusCode).To(Equal(http.StatusOK), "body: %s", string(body))
+		Expect(string(body)).To(ContainSubstring("kubernaut-agent-interactive"),
+			"SC-8+SC-10: MCP endpoint with resilience config must accept initialize handshake and return valid server info")
+	})
+})

--- a/test/integration/kubernautagent/server/nil_result_http_test.go
+++ b/test/integration/kubernautagent/server/nil_result_http_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// ========================================
+// Fix #1390: Nil-Result HTTP Round-Trip Integration Test
+//
+// IT-KA-1390-W02: Proves that GET /api/v1/incident/session/{id}/result
+// returns HTTP 200 with a structured result for completed sessions that
+// have no investigation result (nil result).
+// ========================================
+
+var _ = Describe("Fix #1390: Nil-Result HTTP Round-Trip — BR-SESSION-002", Label("integration"), func() {
+
+	Context("IT-KA-1390-W02 [SC-24]: Nil-result completed session returns structured result via real HTTP", func() {
+		It("should return HTTP 200 with synthetic result body instead of 409", func() {
+			ts, mgr := newTestAPIServer(&stubInvestigator{
+				fn: func(_ context.Context, _ katypes.SignalContext) (*katypes.InvestigationResult, error) {
+					return nil, nil
+				},
+			})
+			defer ts.Close()
+
+			By("submitting an investigation via HTTP POST")
+			postReq, err := http.NewRequest(http.MethodPost, ts.URL+"/api/v1/incident/analyze",
+				strings.NewReader(validIncidentJSON()))
+			Expect(err).NotTo(HaveOccurred())
+			postReq.Header.Set("Content-Type", "application/json")
+
+			postResp, err := http.DefaultClient.Do(postReq)
+			Expect(err).NotTo(HaveOccurred())
+			defer postResp.Body.Close()
+			Expect(postResp.StatusCode).To(Equal(http.StatusAccepted))
+
+			var sub struct {
+				SessionID string `json:"session_id"`
+			}
+			Expect(json.NewDecoder(postResp.Body).Decode(&sub)).To(Succeed())
+			Expect(sub.SessionID).NotTo(BeEmpty())
+
+			By("waiting for session to complete with nil result")
+			Eventually(func() session.Status {
+				sess, _ := mgr.GetSession(sub.SessionID)
+				if sess == nil {
+					return ""
+				}
+				return sess.Status
+			}, 5*time.Second, 50*time.Millisecond).Should(Equal(session.StatusCompleted))
+
+			By("fetching result via HTTP GET — should return 200, not 409")
+			resultURL := ts.URL + "/api/v1/incident/session/" + sub.SessionID + "/result"
+			getResp, err := http.DefaultClient.Get(resultURL)
+			Expect(err).NotTo(HaveOccurred())
+			defer getResp.Body.Close()
+
+			Expect(getResp.StatusCode).To(Equal(http.StatusOK),
+				"completed session with nil result must return HTTP 200 with synthetic result, not 409")
+
+			var body struct {
+				Analysis string `json:"analysis"`
+			}
+			Expect(json.NewDecoder(getResp.Body).Decode(&body)).To(Succeed())
+			Expect(body.Analysis).To(ContainSubstring("Investigation completed without result"))
+		})
+	})
+})

--- a/test/integration/kubernautagent/session/manager_cancel_test.go
+++ b/test/integration/kubernautagent/session/manager_cancel_test.go
@@ -111,16 +111,23 @@ var _ = Describe("Kubernaut Agent Session Manager Cancellation — #823 PR3", fu
 			err = manager.CancelInvestigation(id)
 			Expect(err).NotTo(HaveOccurred())
 
-			Eventually(func() bool {
-				_, open := <-ch
-				return !open
-			}, 2*time.Second, 10*time.Millisecond).Should(BeTrue(),
-				"event channel should be closed after investigation goroutine exits")
+		Eventually(func() bool {
+			_, open := <-ch
+			return !open
+		}, 2*time.Second, 10*time.Millisecond).Should(BeTrue(),
+			"event channel should be closed after cancel")
 
-			sess, gErr := manager.GetSession(id)
-			Expect(gErr).NotTo(HaveOccurred())
-			Expect(sess.Status).To(Equal(session.StatusCancelled))
-			Expect(sess.Result).NotTo(BeNil(), "partial result must be stored")
+		sess, gErr := manager.GetSession(id)
+		Expect(gErr).NotTo(HaveOccurred())
+		Expect(sess.Status).To(Equal(session.StatusCancelled))
+
+		// #1389: terminateSession closes the channel before the goroutine
+		// stores its partial result, so we must wait asynchronously.
+		Eventually(func() *katypes.InvestigationResult {
+			s, _ := manager.GetSession(id)
+			return s.Result
+		}, 2*time.Second, 10*time.Millisecond).ShouldNot(BeNil(),
+			"partial result must be stored")
 		})
 	})
 

--- a/test/integration/kubernautagent/session/manager_upgrade_test.go
+++ b/test/integration/kubernautagent/session/manager_upgrade_test.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session_test
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+var _ = Describe("Fix #1390: UpgradeToInteractive Integration — BR-INTERACTIVE-004", func() {
+
+	Describe("IT-KA-1390-W01 [SC-24]: Full upgrade flow: autonomous -> upgrade -> InteractiveHold -> user_driving with result", func() {
+		It("should complete the full upgrade lifecycle through real Manager/Store wiring", func() {
+			store := session.NewStore(5 * time.Minute)
+			manager := session.NewManager(store, logr.Discard(), audit.NopAuditStore{}, nil)
+
+			upgradeDone := make(chan struct{})
+			id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				<-upgradeDone
+				return &katypes.InvestigationResult{
+					RCASummary:      "Autonomous RCA with late upgrade",
+					Confidence:      0.92,
+					InteractiveHold: session.InteractiveUpgradeFromContext(ctx),
+				}, nil
+			}, map[string]string{"remediation_id": "rr-it-w01", "incident_id": "inc-it-w01"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				s, _ := manager.GetSession(id)
+				if s == nil {
+					return ""
+				}
+				return s.Status
+			}, 2*time.Second, 50*time.Millisecond).Should(Equal(session.StatusRunning))
+
+			err = manager.UpgradeToInteractive(id, "sre-user@example.com", []string{"sre"})
+			Expect(err).NotTo(HaveOccurred())
+			close(upgradeDone)
+
+			Eventually(func() session.Status {
+				s, _ := manager.GetSession(id)
+				if s == nil {
+					return ""
+				}
+				return s.Status
+			}, 2*time.Second, 50*time.Millisecond).Should(Equal(session.StatusUserDriving))
+
+			sess, err := manager.GetSession(id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sess.Result).NotTo(BeNil())
+			Expect(sess.Result.InteractiveHold).To(BeTrue())
+			Expect(sess.Result.RCASummary).To(Equal("Autonomous RCA with late upgrade"))
+			Expect(sess.Metadata["acting_user"]).To(Equal("sre-user@example.com"))
+		})
+	})
+
+	Describe("IT-KA-1390-W03 [SI-4]: EventLogBridge wired after upgrade; events stream to subscriber", func() {
+		It("should deliver investigation events through LazySink after Subscribe on an upgraded session", func() {
+			store := session.NewStore(5 * time.Minute)
+			manager := session.NewManager(store, logr.Discard(), audit.NopAuditStore{}, nil)
+
+			eventReceived := make(chan struct{})
+			id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				sink := session.EventSinkFromContext(ctx)
+				for sink == nil {
+					time.Sleep(10 * time.Millisecond)
+					sink = session.EventSinkFromContext(ctx)
+				}
+				sink <- session.InvestigationEvent{
+					Type: session.EventTypeReasoningDelta,
+					Data: json.RawMessage(`"upgrade-event-stream"`),
+				}
+				close(eventReceived)
+
+				return &katypes.InvestigationResult{
+					RCASummary:      "streamed via bridge",
+					InteractiveHold: session.InteractiveUpgradeFromContext(ctx),
+				}, nil
+			}, map[string]string{"remediation_id": "rr-it-w03"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				s, _ := manager.GetSession(id)
+				if s == nil {
+					return ""
+				}
+				return s.Status
+			}, 2*time.Second, 50*time.Millisecond).Should(Equal(session.StatusRunning))
+
+			Expect(manager.UpgradeToInteractive(id, "testuser", nil)).To(Succeed())
+
+			ch, subErr := manager.Subscribe(context.Background(), id)
+			Expect(subErr).NotTo(HaveOccurred())
+			Expect(ch).NotTo(BeNil())
+
+			Eventually(eventReceived, 2*time.Second).Should(BeClosed())
+			Eventually(ch, 500*time.Millisecond).Should(Receive(HaveField("Data", json.RawMessage(`"upgrade-event-stream"`))))
+		})
+	})
+
+	Describe("IT-KA-1390-W05 [SC-24]: MCP disconnect during upgrade window -> ForceComplete handles gracefully", func() {
+		It("should handle ForceCompleteByRemediationID without panic or orphan goroutine", func() {
+			store := session.NewStore(5 * time.Minute)
+			manager := session.NewManager(store, logr.Discard(), audit.NopAuditStore{}, nil)
+
+			goroutineExited := make(chan struct{})
+			id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				defer close(goroutineExited)
+				<-ctx.Done()
+				return &katypes.InvestigationResult{RCASummary: "aborted"}, ctx.Err()
+			}, map[string]string{"remediation_id": "rr-it-w05"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				s, _ := manager.GetSession(id)
+				if s == nil {
+					return ""
+				}
+				return s.Status
+			}, 2*time.Second, 50*time.Millisecond).Should(Equal(session.StatusRunning))
+
+			Expect(manager.UpgradeToInteractive(id, "user-who-disconnects", nil)).To(Succeed())
+
+			err = manager.ForceCompleteByRemediationID("rr-it-w05", &katypes.InvestigationResult{
+				RCASummary: "MCP disconnect cleanup",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(goroutineExited, 2*time.Second).Should(BeClosed(),
+				"goroutine must exit after ForceComplete cancels context")
+
+			sess, err := manager.GetSession(id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sess.Status).To(SatisfyAny(
+				Equal(session.StatusCompleted),
+				Equal(session.StatusUserDriving),
+			))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Comprehensive fix branch addressing multiple session lifecycle and MCP transport resilience issues.

### Issues Addressed

- **#1384** — Session handoff broken at workflow discovery: propagate session context, filter empty content turns
- **#1386** — Stale-session evict-and-retry in PooledMCPClient, dedicated long-lived HTTP client for MCP sessions
- **#1387** — Comprehensive MCP session resilience: KeepAlive, SessionTimeout, Ping-on-Acquire, transport observability
- **#1389** — Channel lifecycle = session lifecycle: move event channel close from defer to completion paths, make lazySink non-nil by construction

### Changes by Issue

#### #1384: Session Handoff
- Propagate session context to workflow_discovery (Bug A)
- Filter empty content turns in reconstruction (Bug B)
- IEEE 829 test plan and wiring ITs

#### #1386: Stale Session Recovery
- Add stale-session evict-and-retry in `PooledMCPClient.callPooledTool`
- Use dedicated long-lived HTTP client for MCP sessions
- Integration test mock updates for `GetSessionLazySink`

#### #1387: MCP Session Resilience (FedRAMP-grounded)
- **KA-side**: Add `MCPKeepAlive` (15s default) and `MCPSessionTimeout` (10m default) to `InteractiveConfig`, wire through `cmd/kubernautagent/main.go` → `BootstrapMCP` → `ServerOptions`
- **AF-side**: Add `Ping()` to `PoolSession` interface; `Acquire` probes cached sessions with 2s-bounded Ping before reuse; dead sessions evicted and replaced transparently via factory
- **Observability**: Add `SessionIdentifier` interface and `mcp_session_id` structured logging at Inject/Acquire/Release/eviction paths (FedRAMP AU-2/AU-3)
- **Tests** (15 UT + 4 IT + 1 E2E, all Ginkgo/Gomega BDD):
  - UT-KA-1387-001..005: SC-8, SC-10, SA-8 (keepalive, session timeout, security baseline)
  - UT-AF-1387-001..005: SI-4, SC-24, CP-10, SA-15 (health check, fail-safe, auto-reconstitution, timeout bound)
  - UT-AF-1387-010..014: AU-2, AU-3, AU-6, SI-4 (audit logging with mcp_session_id)
  - IT-AF-1387-W01..W03: Ping-on-Acquire wiring through PooledMCPClient dispatch
  - IT-KA-1387-W01: KeepAlive+SessionTimeout wiring via BootstrapMCP
  - E2E-AF-1387-001: Full stack — KA pod kill → Ping detects → evict → factory reconnects → transparent recovery

#### #1389: Channel Lifecycle
- Move `closeEventChan` from `defer` to specific completion paths
- Make `lazySink` non-nil by construction in `Store.Create()`
- Remove defensive nil guards (Subscribe, GetSessionLazySink, Shutdown)
- Fix IT-KA-823-C02 race condition (Eventually for async partial result)

### NIST 800-53 Rev 5 Control Mapping

| Control | Description | Coverage |
|---------|-------------|----------|
| SC-8 | Transmission Integrity | KeepAlive preserves transport through proxy idle timeouts |
| SC-10 | Network Disconnect | SessionTimeout terminates abandoned sessions |
| SC-24 | Fail in Known State | Ping-on-Acquire evicts dead sessions, never reuses ambiguous state |
| SI-4 | System Monitoring | Proactive health check before user-visible failure |
| CP-10 | System Recovery | Auto-reconstitute transport without operator intervention |
| AU-2 | Event Logging | Session lifecycle events logged at all points |
| AU-3 | Content of Audit Records | mcp_session_id + rr_id in structured logs |
| SA-8 | Security Engineering | Default values match security baseline |
| SA-15 | Development Process | Ping timeout bounded (2s) to prevent indefinite blocking |

## Test plan

- [x] `go build ./...` passes
- [x] All 15 UT-*-1387 tests pass with `-race`
- [x] All affected package suites pass (ka, mcp, tools, cmd/apifrontend)
- [x] IT tests compile (require envtest in CI)
- [x] E2E test compiles (requires Kind cluster in CI)
- [ ] CI pipeline green

Closes #1384, closes #1386, closes #1387, closes #1389