### PR TITLE
fix(af): MCP session stale after pool injection (#1386)

### DIFF
--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -535,9 +535,19 @@ func buildBackendDeps(ctx context.Context, cfg *config.Config, metricsReg *metri
 		Transport: kaMCPAuth,
 		Timeout:   cfg.Resilience.KA.RequestTimeout,
 	}
+	// #1386: Separate HTTP client for long-lived MCP sessions (SSE streams).
+	// Go's http.Client.Timeout is a deadline on the entire response including
+	// body reads. For persistent SSE connections, the 30s timeout kills the
+	// stream after idle periods, causing "session not found" on next tool call.
+	// The MCP SDK manages session lifecycle via context cancellation and
+	// session.Close(); no global timeout is needed.
+	kaMCPStreamClient := &http.Client{
+		Transport: kaMCPAuth,
+	}
 	mcpClient := ka.NewSDKMCPClient(
 		cfg.Agent.KAMCPEndpoint,
 		kaMCPHTTPClient,
+		kaMCPStreamClient,
 		logger,
 	)
 	mcpClient.WithDownstreamDuration(metricsReg.DownstreamDuration)
@@ -551,7 +561,7 @@ func buildBackendDeps(ctx context.Context, cfg *config.Config, metricsReg *metri
 		Factory: func(ctx context.Context) (ka.PoolSession, error) {
 			transport := &mcp.StreamableClientTransport{
 				Endpoint:   kaMCPEndpoint,
-				HTTPClient: kaMCPHTTPClient,
+				HTTPClient: kaMCPStreamClient,
 			}
 			return mcpClient.ConnectSession(ctx, transport)
 		},

--- a/cmd/apifrontend/main_wiring_test.go
+++ b/cmd/apifrontend/main_wiring_test.go
@@ -895,7 +895,7 @@ func (m *mockPoolSession) Close() error { return nil }
 func TestSDKMCPClient_DownstreamDurationWired(t *testing.T) {
 	t.Parallel()
 	reg := metrics.NewRegistry()
-	mcpClient := ka.NewSDKMCPClient("http://localhost:0", &http.Client{}, logr.Discard())
+	mcpClient := ka.NewSDKMCPClient("http://localhost:0", &http.Client{}, nil, logr.Discard())
 	result := mcpClient.WithDownstreamDuration(reg.DownstreamDuration)
 	if result == nil {
 		t.Fatal("IT-AF-1234-W12: WithDownstreamDuration must return the client")

--- a/pkg/apifrontend/ka/invoke_action_test.go
+++ b/pkg/apifrontend/ka/invoke_action_test.go
@@ -77,7 +77,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			result, err := client.InvokeAction(withIdentityCtx("alice@example.com", []string{"sre"}), ka.InvokeActionArgs{
 				RRID:   "prod/rr-pod-crash-001",
@@ -102,7 +102,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(withIdentityCtx("alice@example.com", []string{"sre"}), ka.InvokeActionArgs{
 				RRID:    "prod/rr-pod-crash-001",
@@ -128,7 +128,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(withIdentityCtx("alice@example.com", []string{"sre"}), ka.InvokeActionArgs{
 				RRID:    "prod/rr-001",
@@ -153,7 +153,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(withIdentityCtx("alice@example.com", []string{"sre"}), ka.InvokeActionArgs{
 				RRID:   "prod/rr-001",
@@ -177,7 +177,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(withIdentityCtx("alice@example.com", []string{"sre"}), ka.InvokeActionArgs{
 				RRID:   "prod/rr-001",
@@ -202,7 +202,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(withIdentityCtx("alice@example.com", []string{"sre"}), ka.InvokeActionArgs{
 				RRID:   "prod/rr-001",
@@ -225,7 +225,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "bob@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(withIdentityCtx("bob@example.com", []string{"sre", "admin"}), ka.InvokeActionArgs{
 				RRID:   "prod/rr-001",
@@ -251,7 +251,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "anonymous"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(context.Background(), ka.InvokeActionArgs{
 				RRID:   "prod/rr-001",
@@ -265,7 +265,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 	Describe("Error handling", func() {
 		It("UT-AF-1234-009: KA unavailable returns user-friendly error", func() {
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient("http://localhost:1/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient("http://localhost:1/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(withIdentityCtx("alice@example.com", []string{"sre"}), ka.InvokeActionArgs{
 				RRID:   "prod/rr-001",
@@ -290,7 +290,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(withIdentityCtx("alice@example.com", []string{"sre"}), ka.InvokeActionArgs{
 				RRID:   "prod/rr-001",
@@ -317,7 +317,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "sre@kubernaut.ai"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			result, err := client.InvokeAction(withIdentityCtx("sre@kubernaut.ai", []string{"sre"}), ka.InvokeActionArgs{
 				RRID:   "monitoring/rr-oom-456",
@@ -345,7 +345,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "dev@kubernaut.ai"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(withIdentityCtx("dev@kubernaut.ai", []string{"dev-team", "viewers"}), ka.InvokeActionArgs{
 				RRID:   "prod/rr-crash-789",
@@ -364,7 +364,7 @@ var _ = Describe("InvokeAction (G3: Args + Identity)", func() {
 			}))
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.InvokeAction(withIdentityCtx("alice@example.com", []string{"sre"}), ka.InvokeActionArgs{
 				RRID:   "prod/rr-001",

--- a/pkg/apifrontend/ka/mcp_sdk_client.go
+++ b/pkg/apifrontend/ka/mcp_sdk_client.go
@@ -26,12 +26,11 @@ type SDKMCPClient struct {
 	endpoint           string
 	client             *mcp.Client
 	httpClient         *http.Client
+	streamHTTPClient   *http.Client
 	logger             logr.Logger
 	downstreamDuration *prometheus.HistogramVec
 }
 
-// NewSDKMCPClient creates a new MCP client for KA communication.
-// The httpClient should include auth transport (e.g., bearerTokenTransport for SA token).
 // WithDownstreamDuration injects the af_downstream_request_duration_seconds
 // histogram for MCP call latency instrumentation (G18).
 func (c *SDKMCPClient) WithDownstreamDuration(h *prometheus.HistogramVec) *SDKMCPClient {
@@ -39,17 +38,27 @@ func (c *SDKMCPClient) WithDownstreamDuration(h *prometheus.HistogramVec) *SDKMC
 	return c
 }
 
-func NewSDKMCPClient(endpoint string, httpClient *http.Client, logger logr.Logger) *SDKMCPClient {
+// NewSDKMCPClient creates a new MCP client for KA communication.
+// httpClient (with timeout) is used for short-lived session-per-call tool invocations.
+// streamHTTPClient (no timeout) is used for long-lived MCP sessions
+// (StartInvestigation, ConnectSession) where SSE streams must survive idle periods.
+// If streamHTTPClient is nil, httpClient is used for all connections.
+func NewSDKMCPClient(endpoint string, httpClient *http.Client, streamHTTPClient *http.Client, logger logr.Logger) *SDKMCPClient {
 	mcpClient := mcp.NewClient(&mcp.Implementation{
 		Name:    "kubernaut-apifrontend",
 		Version: "0.1.0",
 	}, nil)
 
+	if streamHTTPClient == nil {
+		streamHTTPClient = httpClient
+	}
+
 	return &SDKMCPClient{
-		endpoint:   endpoint,
-		client:     mcpClient,
-		httpClient: httpClient,
-		logger:     logger.WithName("ka-mcp"),
+		endpoint:         endpoint,
+		client:           mcpClient,
+		httpClient:       httpClient,
+		streamHTTPClient: streamHTTPClient,
+		logger:           logger.WithName("ka-mcp"),
 	}
 }
 
@@ -279,7 +288,7 @@ func (c *SDKMCPClient) StartInvestigation(ctx context.Context, args StartInvesti
 
 	transport := &mcp.StreamableClientTransport{
 		Endpoint:   c.endpoint,
-		HTTPClient: c.httpClient,
+		HTTPClient: c.streamHTTPClient,
 	}
 
 	// Use a detached context for the MCP session so its lifetime is not tied

--- a/pkg/apifrontend/ka/mcp_sdk_client_test.go
+++ b/pkg/apifrontend/ka/mcp_sdk_client_test.go
@@ -75,7 +75,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "alice@example.com",
@@ -130,7 +130,7 @@ var _ = Describe("SDKMCPClient", func() {
 			ts = httptest.NewServer(mux)
 
 			httpClient := &http.Client{Transport: &auth.ContextJWTDelegationTransport{}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "bob@example.com",
@@ -156,7 +156,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: ""}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			_, err := client.SelectWorkflow(context.Background(), ka.SelectWorkflowArgs{
 				RRID:       "rr-test-002",
@@ -182,7 +182,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "alice@example.com",
@@ -210,7 +210,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "alice@example.com",
@@ -235,7 +235,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "alice@example.com",
@@ -261,7 +261,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "alice@example.com",
@@ -284,7 +284,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "alice@example.com",
@@ -310,7 +310,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "alice@example.com",
@@ -340,7 +340,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "alice@example.com",
@@ -373,7 +373,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "alice@example.com",
@@ -403,7 +403,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "bob@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "bob@example.com",
@@ -436,7 +436,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "alice@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "alice@example.com",
@@ -468,7 +468,7 @@ var _ = Describe("SDKMCPClient", func() {
 			})
 
 			httpClient := &http.Client{Transport: &authedRoundTripper{user: "bob@example.com"}}
-			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, logr.Discard())
+			client = ka.NewSDKMCPClient(ts.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 				Username: "bob@example.com",

--- a/pkg/apifrontend/ka/pooled_mcp_client.go
+++ b/pkg/apifrontend/ka/pooled_mcp_client.go
@@ -3,7 +3,9 @@ package ka
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -69,7 +71,7 @@ func (c *PooledMCPClient) InvokeAction(ctx context.Context, args InvokeActionArg
 		argsMap["message"] = args.Message
 	}
 
-	raw, err := c.callPooledTool(ctx, session, "kubernaut_investigate", argsMap)
+	raw, err := c.callPooledTool(ctx, session, "kubernaut_investigate", argsMap, args.RRID, identity.Username)
 	if err != nil {
 		return nil, err
 	}
@@ -110,7 +112,7 @@ func (c *PooledMCPClient) DiscoverWorkflows(ctx context.Context, args DiscoverWo
 		"acting_user_groups": identity.Groups,
 	}
 
-	raw, err := c.callPooledTool(ctx, session, "kubernaut_investigate", argsMap)
+	raw, err := c.callPooledTool(ctx, session, "kubernaut_investigate", argsMap, args.RRID, identity.Username)
 	if err != nil {
 		return nil, err
 	}
@@ -151,7 +153,7 @@ func (c *PooledMCPClient) SelectWorkflow(ctx context.Context, args SelectWorkflo
 		argsMap["parameters"] = args.Parameters
 	}
 
-	raw, err := c.callPooledTool(ctx, session, "kubernaut_select_workflow", argsMap)
+	raw, err := c.callPooledTool(ctx, session, "kubernaut_select_workflow", argsMap, args.RRID, identity.Username)
 	if err != nil {
 		return nil, err
 	}
@@ -172,7 +174,24 @@ func (c *PooledMCPClient) StartInvestigation(_ context.Context, _ StartInvestiga
 
 // callPooledTool dispatches a tool call to the given pooled session, handling
 // error response parsing and security redaction consistently with SDKMCPClient.
-func (c *PooledMCPClient) callPooledTool(ctx context.Context, session PoolSession, name string, args map[string]any) (json.RawMessage, error) {
+// On stale-session errors (#1386), it evicts the dead entry and retries once
+// with a fresh session from the pool factory.
+func (c *PooledMCPClient) callPooledTool(ctx context.Context, session PoolSession, name string, args map[string]any, rrID, username string) (json.RawMessage, error) {
+	raw, err := c.doCallTool(ctx, session, name, args)
+	if err != nil && isStaleSessionError(err) {
+		c.logger.Info("stale MCP session detected, evicting and retrying",
+			"rr_id", rrID, "error", err.Error())
+		c.pool.Release(rrID, username)
+		newSession, acqErr := c.pool.Acquire(ctx, rrID, username)
+		if acqErr != nil {
+			return nil, fmt.Errorf("re-acquire MCP session after stale eviction: %w", acqErr)
+		}
+		raw, err = c.doCallTool(ctx, newSession, name, args)
+	}
+	return raw, err
+}
+
+func (c *PooledMCPClient) doCallTool(ctx context.Context, session PoolSession, name string, args map[string]any) (json.RawMessage, error) {
 	result, err := session.CallTool(ctx, &mcp.CallToolParams{
 		Name:      name,
 		Arguments: args,
@@ -200,6 +219,19 @@ func (c *PooledMCPClient) callPooledTool(ctx context.Context, session PoolSessio
 	}
 
 	return json.RawMessage("{}"), nil
+}
+
+// isStaleSessionError returns true if the error indicates the MCP transport
+// session is no longer valid on the server (e.g., SSE stream died, pod
+// restarted, or proxy idle timeout).
+func isStaleSessionError(err error) bool {
+	if errors.Is(err, mcp.ErrSessionMissing) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "session not found") ||
+		strings.Contains(msg, "failed to connect") ||
+		strings.Contains(msg, "failed to reconnect")
 }
 
 // Compile-time interface check.

--- a/pkg/apifrontend/ka/pooled_mcp_client_test.go
+++ b/pkg/apifrontend/ka/pooled_mcp_client_test.go
@@ -230,4 +230,130 @@ var _ = Describe("PooledMCPClient (#1306)", func() {
 		// implement MCPClient, the test file won't compile.
 		var _ ka.MCPClient = (*ka.PooledMCPClient)(nil)
 	})
+
+	Describe("Stale-session evict+retry (#1386)", func() {
+		It("UT-AF-1386-001: retries on stale session and succeeds with fresh session", func() {
+			var callCount atomic.Int32
+			staleSession := &mockPoolSession{
+				callFn: func(_ context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+					return nil, fmt.Errorf("MCP call kubernaut_investigate: failed to connect (session ID: WVIPJI3): %w", mcp.ErrSessionMissing)
+				},
+			}
+			freshSession := &mockPoolSession{
+				callFn: func(_ context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+					callCount.Add(1)
+					resp := `{"status":"active","session_id":"sess-fresh"}`
+					return &mcp.CallToolResult{
+						Content: []mcp.Content{&mcp.TextContent{Text: resp}},
+					}, nil
+				},
+			}
+
+			retryPool := ka.NewKASessionPool(ka.PoolConfig{
+				Factory: func(_ context.Context) (ka.PoolSession, error) {
+					return freshSession, nil
+				},
+				Logger: logr.Discard(),
+			})
+
+			client := ka.NewPooledMCPClient(retryPool, logr.Discard())
+			ctx := ctxWithIdentity("alice", []string{"sre"})
+
+			retryPool.Inject("ns/rr-stale", "alice", staleSession)
+			Expect(retryPool.Size()).To(Equal(1))
+
+			result, err := client.InvokeAction(ctx, ka.InvokeActionArgs{
+				RRID: "ns/rr-stale", Action: "takeover",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			Expect(result.Status).To(Equal("active"))
+			Expect(callCount.Load()).To(Equal(int32(1)),
+				"fresh session should have been called once after retry")
+		})
+
+		It("UT-AF-1386-002: retries on 'session not found' string match", func() {
+			staleSession := &mockPoolSession{
+				callFn: func(_ context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+					return nil, fmt.Errorf("MCP call kubernaut_investigate: sending request: session not found")
+				},
+			}
+			freshSession := &mockPoolSession{
+				callFn: func(_ context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+					resp := `{"workflows":[],"count":0}`
+					return &mcp.CallToolResult{
+						Content: []mcp.Content{&mcp.TextContent{Text: resp}},
+					}, nil
+				},
+			}
+
+			retryPool := ka.NewKASessionPool(ka.PoolConfig{
+				Factory: func(_ context.Context) (ka.PoolSession, error) {
+					return freshSession, nil
+				},
+				Logger: logr.Discard(),
+			})
+
+			client := ka.NewPooledMCPClient(retryPool, logr.Discard())
+			ctx := ctxWithIdentity("alice", []string{"sre"})
+
+			retryPool.Inject("ns/rr-stale2", "alice", staleSession)
+
+			result, err := client.DiscoverWorkflows(ctx, ka.DiscoverWorkflowsArgs{RRID: "ns/rr-stale2"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+		})
+
+		It("UT-AF-1386-003: non-stale errors are not retried", func() {
+			failSession := &mockPoolSession{
+				callFn: func(_ context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+					return nil, fmt.Errorf("MCP call kubernaut_investigate: internal server error")
+				},
+			}
+
+			noRetryPool := ka.NewKASessionPool(ka.PoolConfig{
+				Factory: func(_ context.Context) (ka.PoolSession, error) {
+					return failSession, nil
+				},
+				Logger: logr.Discard(),
+			})
+
+			client := ka.NewPooledMCPClient(noRetryPool, logr.Discard())
+			ctx := ctxWithIdentity("alice", []string{"sre"})
+
+			_, err := client.InvokeAction(ctx, ka.InvokeActionArgs{
+				RRID: "ns/rr-fail", Action: "takeover",
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("internal server error"))
+			Expect(noRetryPool.Size()).To(Equal(1),
+				"pool entry should NOT be evicted for non-stale errors")
+		})
+
+		It("UT-AF-1386-004: retry fails if re-acquire fails", func() {
+			staleSession := &mockPoolSession{
+				callFn: func(_ context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+					return nil, fmt.Errorf("MCP call: %w", mcp.ErrSessionMissing)
+				},
+			}
+
+			failPool := ka.NewKASessionPool(ka.PoolConfig{
+				Factory: func(_ context.Context) (ka.PoolSession, error) {
+					return nil, fmt.Errorf("KA unreachable")
+				},
+				Logger: logr.Discard(),
+			})
+
+			client := ka.NewPooledMCPClient(failPool, logr.Discard())
+			ctx := ctxWithIdentity("alice", []string{"sre"})
+
+			failPool.Inject("ns/rr-dead", "alice", staleSession)
+
+			_, err := client.InvokeAction(ctx, ka.InvokeActionArgs{
+				RRID: "ns/rr-dead", Action: "takeover",
+			})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("re-acquire MCP session after stale eviction"))
+		})
+	})
 })

--- a/pkg/apifrontend/ka/resilience_mcp_test.go
+++ b/pkg/apifrontend/ka/resilience_mcp_test.go
@@ -50,7 +50,7 @@ var _ = Describe("MCP Resilience (G10: Retry/CB)", func() {
 					base: cbt,
 				},
 			}
-			client := ka.NewSDKMCPClient(failServer.URL+"/mcp", httpClient, logr.Discard())
+			client := ka.NewSDKMCPClient(failServer.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := withIdentityCtx("alice@example.com")
 			for i := 0; i < 4; i++ {
@@ -119,7 +119,7 @@ var _ = Describe("MCP Resilience (G10: Retry/CB)", func() {
 					base: cbt,
 				},
 			}
-			client := ka.NewSDKMCPClient(failServer.URL+"/mcp", httpClient, logr.Discard())
+			client := ka.NewSDKMCPClient(failServer.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := withIdentityCtx("alice@example.com")
 			for i := 0; i < 6; i++ {
@@ -188,7 +188,7 @@ var _ = Describe("MCP Resilience (G10: Retry/CB)", func() {
 					base: cbt,
 				},
 			}
-			client := ka.NewSDKMCPClient(failServer.URL+"/mcp", httpClient, logr.Discard())
+			client := ka.NewSDKMCPClient(failServer.URL+"/mcp", httpClient, nil, logr.Discard())
 
 			ctx := withIdentityCtx("alice@example.com")
 			for i := 0; i < 4; i++ {


### PR DESCRIPTION
## Summary

- **Layer 1**: Create a dedicated `kaMCPStreamClient` (no `http.Client.Timeout`) for long-lived MCP sessions (SSE streams), separate from the 30s-timeout client used for short REST calls. Wire it into `SDKMCPClient.StartInvestigation`, `ConnectSession`, and the pool factory.
- **Layer 2**: Add stale-session evict-and-retry in `PooledMCPClient.callPooledTool` — when an `ErrSessionMissing` or connection failure is detected, the dead pool entry is released and a fresh session is acquired before retrying once.

## Root Cause

Go's `http.Client.Timeout` is a deadline on the **entire response including body reads**. The MCP SDK opens a persistent SSE GET stream using the same `http.Client`. After investigation events stop flowing, the SSE stream idles, the 30s timeout kills it, and subsequent tool calls (e.g. `discover_workflows`) get `"session not found"`.

Evidence from OCP cluster logs in #1386.

## Test plan

- [x] UT-AF-1386-001: Retries on stale session (`ErrSessionMissing`) and succeeds with fresh session
- [x] UT-AF-1386-002: Retries on `"session not found"` string match
- [x] UT-AF-1386-003: Non-stale errors are not retried
- [x] UT-AF-1386-004: Retry fails if re-acquire fails
- [x] All 95 existing `ka` package tests pass
- [x] Full AF unit test suite (23 packages) green
- [x] Full KA unit test suite green
- [x] `go build ./...` clean
- [x] `golangci-lint --new-from-rev=main` — 0 issues

Fixes #1386
Follow-up: #1387

Made with [Cursor](https://cursor.com)