### PR TITLE
docs: add kubernaut-operator to Related Repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ See the [Installation Guide](https://jordigilh.github.io/kubernaut-docs/latest/g
 
 | Repository | Description |
 |---|---|
+| [kubernaut-operator](https://github.com/jordigilh/kubernaut-operator) | OLM operator — deploys and manages Kubernaut services on OpenShift |
 | [kubernaut-docs](https://github.com/jordigilh/kubernaut-docs) | Documentation website (MkDocs Material) |
 | [kubernaut-demo-scenarios](https://github.com/jordigilh/kubernaut-demo-scenarios) | Demo scenarios, scripts, and recordings |
 


### PR DESCRIPTION
## Summary

Adds the [kubernaut-operator](https://github.com/jordigilh/kubernaut-operator) repo to the Related Repositories table in the README. This is the OLM operator that deploys and manages Kubernaut services on OpenShift.

## Test plan

- [ ] Link resolves to the operator repo

Made with [Cursor](https://cursor.com)