### PR TITLE
docs(adr): update ADR-064 from MCP Gateway to direct KA→OCP MCP Server

### DIFF
--- a/docs/architecture/decisions/ADR-064-multi-cluster-mcp-gateway.md
+++ b/docs/architecture/decisions/ADR-064-multi-cluster-mcp-gateway.md
@@ -1,14 +1,14 @@
-# ADR-064: Multi-Cluster Investigation via MCP Gateway
+# ADR-064: Multi-Cluster Investigation via OCP MCP Server
 
-**Status**: Deferred to v1.6+ (v1.5 MVP uses Thanos -- see DD-INT-020 v1.4 Part E)
+**Status**: Deferred to v1.6+ (v1.5 MVP uses Thanos -- see DD-INT-020 v1.5 Part E)
 **Date**: 2026-06-04
-**Updated**: 2026-06-05
+**Updated**: 2026-06-13
 **Deciders**: Architecture Team
 **Context**: ServiceNow signal investigation requires multi-cluster K8s access
 
 ## v1.5 Decision
 
-For v1.5 MVP, multi-cluster resource status is achieved via **Thanos Querier** (existing Prometheus tools, zero new code). This provides metrics-based health assessment (up/down, CPU, memory, active alerts) across all clusters that feed into Thanos. The MCP Gateway architecture described below is validated (spike complete, prototype working) and deferred to v1.6+ for full K8s API access (events, logs, resource specs).
+For v1.5 MVP, multi-cluster resource status is achieved via **Thanos Querier** (existing Prometheus tools, zero new code). The direct KA→OCP MCP architecture described below is validated (spike complete, prototype working) and deferred to v1.6+ for full K8s API access (events, logs, resource specs).
 
 ## Context
 
@@ -18,17 +18,43 @@ Single-cluster investigation is insufficient for a real ServiceNow use case.
 
 ## Decision
 
-Adopt **Red Hat's MCP Gateway** (Kuadrant / Connectivity Link) as the multi-cluster investigation architecture:
+KA connects **directly** to per-cluster OCP MCP servers, authenticating with a short-lived JWT per cluster. No MCP Gateway.
 
-1. **Per-cluster OCP MCP servers**: Deploy `openshift/openshift-mcp-server` on each workload cluster in read-only mode with investigation-scoped RBAC.
+```
+Management Cluster
+└── KA ──JWT──> OCP MCP Server (Workload Cluster A, read-only)
+    ──JWT──> OCP MCP Server (Workload Cluster B, read-only)
+```
 
-2. **MCP Gateway**: Deploy in the management cluster to aggregate per-cluster MCP servers behind a single endpoint. Each cluster is registered with a unique tool prefix (e.g., `cluster_a_`).
+1. **Per-cluster OCP MCP servers**: Deploy `openshift/openshift-mcp-server` on each workload cluster in read-only mode (`--read-only --stateless`) with investigation-scoped RBAC.
 
-3. **KA as MCP client**: KA connects to the MCP Gateway via `StreamableClientTransport`, discovers tools at startup, and wraps them as KA `tools.Tool` via the `BridgeTool` adapter in `pkg/kubernautagent/tools/mcp/`.
+2. **KA as direct MCP client**: KA connects to each OCP MCP server via `StreamableClientTransport`. A cluster registry (ConfigMap or Secret) maps cluster names to MCP server endpoints + auth credentials.
 
-4. **Cluster routing**: CMDB CI -> cluster prefix mapping via `ClusterResolver` (ConfigMap-backed lookup table). KA filters tools by prefix for each ServiceNow investigation.
+3. **Per-cluster JWT authentication**: KA mints or obtains a short-lived token per cluster. Options (in order of preference):
+   - **Projected SA token with audience**: `TokenRequest` API targeting the OCP MCP server's expected audience per cluster
+   - **ACM managed cluster credentials**: Leverage existing hub-spoke auth (kubeconfig secrets in management cluster)
+   - **OIDC federation**: Management cluster's SA token issuer trusted by workload clusters
+
+4. **Cluster routing**: CMDB CI name → cluster endpoint lookup from the cluster registry. KA connects to exactly one MCP server per investigation -- no tool aggregation needed.
 
 5. **Dual tool path**: K8s-originated signals continue using local `client-go` tools. ServiceNow signals use MCP Bridge tools for remote cluster access.
+
+## Why Not MCP Gateway
+
+The MCP Gateway (Kuadrant / Connectivity Link) was evaluated in the spike (4 spikes, all GO). It was **removed** from the architecture because:
+
+| Gateway Capability | Does KA need it? | Reason |
+|-------------------|-----------------|--------|
+| Tool prefix routing (aggregate N servers) | **No** | KA knows the target cluster from `ProviderData.cmdb_ci` -- connects to exactly one server per investigation |
+| Centralized auth | **No** | KA authenticates per-connection with JWT |
+| Rate limiting | **No** | KA self-limits; investigation tool calls are sequential |
+| Observability | **No** | KA instruments its own MCP calls |
+
+**Net effect of removing the gateway:**
+- Eliminates Istio + Gateway API + MCP Gateway operator dependency
+- Eliminates Technology Preview risk (MCP Gateway is not GA)
+- ~10-50ms lower latency per tool call (no gateway hop)
+- Simpler deployment: OCP MCP server per cluster + cluster registry Secret
 
 ## Consequences
 
@@ -37,44 +63,45 @@ Adopt **Red Hat's MCP Gateway** (Kuadrant / Connectivity Link) as the multi-clus
 - Multi-cluster investigation without modifying KA's existing K8s tool surface
 - Security: per-cluster ServiceAccounts with least-privilege RBAC
 - Failure isolation: one cluster's MCP server failing doesn't affect others
-- Scale: adding clusters is declarative (deploy MCP server + register)
+- No Technology Preview dependencies
+- Lower latency than gateway architecture
 - Same MCP SDK (`modelcontextprotocol/go-sdk v1.6.1`) already in use
 - OCP MCP server provides bonus tools (nodes_log, alertmanager_alerts) KA doesn't have
+- `StreamableProvider` prototype already supports direct connections
 
 ### Negative
 
-- Additional infrastructure: MCP Gateway + per-cluster MCP server pods
-- Tool name explosion with prefixes (~20 tools per cluster visible to LLM)
-- Session-per-call latency overhead (~10-50ms per tool call through gateway)
-- Technology Preview: MCP Gateway is not GA (API may change)
+- KA manages N MCP client connections (one per cluster) instead of 1
+- Cluster registry (endpoint + credential per cluster) must be maintained
+- No Envoy-level observability on MCP traffic (KA instruments its own calls)
 
 ### Risks
 
 | Risk | Likelihood | Impact | Mitigation |
 |------|-----------|--------|------------|
-| MCP Gateway TP instability | Medium | High | Pin version, monitor upstream, fallback to direct MCP client |
-| Tool prefix pollution | Low | Medium | LLM prompt restricts to target cluster prefix |
-| Cross-cluster network issues | Medium | Medium | Health checks in MCPServerRegistration, graceful degradation |
+| Network connectivity to workload clusters | Medium | High | Leverage ACM hub-spoke connectivity; OCP MCP server exposed via Route |
+| Credential rotation across N clusters | Low | Medium | Short-lived projected SA tokens; no long-lived secrets |
+| Cross-cluster latency | Low | Low | Investigation tools are sequential, not latency-critical |
 
 ## Alternatives Considered
 
-### A: Multi-kubeconfig in KA -- Rejected
+### A: MCP Gateway (Kuadrant) -- Rejected
 
-KA directly manages kubeconfigs for all workload clusters.
+**Approach**: Deploy MCP Gateway in management cluster, register per-cluster OCP MCP servers with tool prefixes.
 
-**Rejected because**: No auth/rate-limiting infrastructure, no observability, violates separation of concerns. KA becomes a cluster access point.
+**Rejected because**: Gateway adds infrastructure complexity (Istio + Gateway API + operator) without value -- KA already knows the target cluster and doesn't need tool aggregation. Technology Preview risk. Spike validated it works but the simpler direct approach is preferred.
 
-### B: Single multi-context OCP MCP server -- Rejected
+### B: Multi-kubeconfig in KA -- Rejected
+
+KA directly manages kubeconfigs for all workload clusters via `client-go`.
+
+**Rejected because**: Doesn't leverage OCP MCP server's toolset. Requires KA to reimplement tool logic for remote clusters.
+
+### C: Single multi-context OCP MCP server -- Rejected
 
 One OCP MCP server with kubeconfig containing all cluster contexts.
 
 **Rejected because**: Single point of failure, violates least-privilege (one SA for all clusters), kubeconfig rotation requires restart.
-
-### C: KA connects directly to per-cluster MCP servers -- Rejected
-
-No gateway; KA manages individual MCP client connections.
-
-**Rejected because**: Loses gateway benefits (auth, rate limiting, aggregation, observability). More complex session management.
 
 ## Validation
 
@@ -83,14 +110,12 @@ Spike evidence in `docs/spikes/multi-cluster-mcp-gateway/`:
 | Spike | Status | Key Finding |
 |-------|--------|-------------|
 | Spike 1: Tool Coverage | GO | OCP MCP server covers 82% of KA's investigation tools |
-| Spike 2: Gateway Deployment | GO | Manifests ready; Helm + OLM paths documented |
-| Spike 3: KA MCP Client | GO | StreamableProvider + BridgeTool working (14 tests passing) |
-| Spike 4: Cluster Routing | GO | Per-cluster prefix with ClusterResolver is clean and scalable |
+| Spike 2: Gateway Deployment | GO (architecture validated, gateway removed from design) | Manifests documented but gateway deemed unnecessary |
+| Spike 3: KA MCP Client | GO | `StreamableProvider` + `BridgeTool` working (14 tests). Works for direct connections -- no gateway needed. |
+| Spike 4: Cluster Routing | GO | Direct cluster endpoint lookup replaces prefix routing |
 
 ## References
 
-- DD-INT-020 v1.3: ServiceNow Signal Target Type (Part E)
+- DD-INT-020 v1.5: ServiceNow Signal Target Type (Part E)
 - ADR-063: ServiceNow Signal Integration Architecture
 - `openshift/openshift-mcp-server`: https://github.com/openshift/openshift-mcp-server
-- Kuadrant MCP Gateway: https://github.com/Kuadrant/mcp-gateway
-- Red Hat Connectivity Link MCP Gateway docs: https://docs.redhat.com/en/documentation/red_hat_connectivity_link/1.3/html/installing_the_mcp_gateway

--- a/docs/architecture/decisions/DD-INT-020-servicenow-signal-target-type.md
+++ b/docs/architecture/decisions/DD-INT-020-servicenow-signal-target-type.md
@@ -18,7 +18,7 @@
 
 **Related ADRs**:
 - ADR-063: ServiceNow Signal Integration Architecture
-- ADR-064: Multi-Cluster Investigation via MCP Gateway
+- ADR-064: Multi-Cluster Investigation via OCP MCP Server
 - ADR-041: LLM Prompt Response Contract
 
 ---
@@ -436,14 +436,14 @@ pressure) and check for active alerts.
 | Pod specs, events, logs | No | Acceptable -- metrics + ServiceNow context is sufficient for triage |
 | Resource YAML/describe | No | Acceptable -- deferred to v1.6+ |
 
-### E7. v1.6+ Path: MCP Gateway
+### E7. v1.6+ Path: Direct KA→OCP MCP Server
 
-For v1.6+, the MCP Gateway (Kuadrant/Connectivity Link) provides full K8s API access to remote clusters (events, logs, resource specs). The spike validated this architecture:
+For v1.6+, KA connects directly to per-cluster OCP MCP servers (no MCP Gateway) for full K8s API access to remote clusters (events, logs, resource specs). KA authenticates with a short-lived JWT per cluster. The spike validated:
 - OCP MCP server covers 82% of KA's investigation tools
 - KA MCP client prototype working (`StreamableProvider` + `BridgeTool`, 14 tests passing)
-- Deployment manifests and routing strategy documented
+- MCP Gateway evaluated and removed from design -- KA knows the target cluster from CMDB CI, so gateway aggregation adds no value
 
-See `docs/spikes/multi-cluster-mcp-gateway/` for full spike reports and ADR-064 for the deferred architecture.
+See `docs/spikes/multi-cluster-mcp-gateway/` for spike reports and ADR-064 for the deferred architecture.
 
 ### E8. Files Affected (v1.5)
 


### PR DESCRIPTION
## Summary

- Updates ADR-064 to reflect spike findings: MCP Gateway (Kuadrant/Connectivity Link) removed from architecture in favor of direct KA→OCP MCP Server connections with per-cluster JWT auth
- KA knows the target cluster from CMDB CI, making gateway aggregation unnecessary
- Updates DD-INT-020 cross-reference to match renamed ADR-064

## Test plan

- [x] Docs-only change, no code affected

Made with [Cursor](https://cursor.com)