### PR TITLE
fix(#1441): prevent duplicate workflow narration in Phase 3 discovery

### DIFF
--- a/internal/kubernautagent/prompt/templates/phase3_workflow_selection.tmpl
+++ b/internal/kubernautagent/prompt/templates/phase3_workflow_selection.tmpl
@@ -68,7 +68,7 @@ If the response includes `pagination.hasNext`, call the tool again with `page: "
 **Step 2**: Call `list_workflows` with `action_type` set to your chosen action type from Step 1.
 DO NOT GUESS workflow IDs. You MUST call `list_workflows` to see what is available.
 **CRITICAL**: If the response includes `pagination.hasNext`, call the tool again with `page: "next"` and `cursor` set to the `nextCursor` value to review ALL workflows before selecting one.
-**DISPLAY RULE**: When presenting discovered workflows to the user, ALWAYS use the `workflow_name` (human-readable name) — NEVER display raw `workflow_id` UUIDs. Include the confidence score alongside the name.
+**DISPLAY RULE**: When presenting discovered workflows to the user, ALWAYS use the `workflow_name` (human-readable name) — NEVER display raw `workflow_id` UUIDs. Only present workflows that were actually returned by `list_workflows`. Do NOT assign or display confidence scores during discovery — confidence is determined at selection time in `submit_result_with_workflow`.
 
 **Step 3**: Call `get_workflow` with the `workflow_id` of your selected workflow to retrieve its full parameter schema.
 
@@ -165,7 +165,7 @@ Set `selected_workflow` to None, include `actionable: false`.
 - Call `submit_result_with_workflow` when a workflow is selected
 - Call `submit_result_no_workflow` when no workflow matches (self-resolved, inconclusive, not actionable, or no automated remediation)
 - Select ONE workflow per incident as `selected_workflow`
-- Include up to 2-3 `alternative_workflows` (for audit/context only)
+- Include up to 2-3 `alternative_workflows` ONLY if `list_workflows` returned other distinct workflows besides the selected one. Never repeat the selected workflow in alternatives. If only one workflow was returned by the tool call, leave `alternative_workflows` empty.
 - All fields in root_cause_analysis.summary and selected_workflow are required when actionable
 - Top-level severity must match root_cause_analysis.severity
 - Top-level confidence must match selected_workflow.confidence


### PR DESCRIPTION
## Summary

- Fixes the Phase 3 LLM narrating the same workflow twice with different confidence scores (e.g., `git-revert-v2 (95%)` and `git-revert-v2 (35%)`) when only one workflow exists for the selected action type.
- Root cause confirmed via live cluster logs: DS returned exactly 1 workflow for `GitRevertCommit`, but the prompt instructed the LLM to "include up to 2-3 alternatives" and "include the confidence score alongside the name" during discovery narration — causing it to fabricate a duplicate entry.
- Two prompt changes in `phase3_workflow_selection.tmpl`:
  1. **DISPLAY RULE**: Remove premature confidence assignment during discovery; confidence is determined at `submit_result_with_workflow` time only.
  2. **alternative_workflows rule**: Restrict alternatives to distinct workflows actually returned by `list_workflows`; leave empty when only one exists.

## Evidence (from live cluster triage)

| Component | Finding |
|---|---|
| DS `list_workflows` | `action_type=GitRevertCommit, total_count=1, returned_count=1` |
| Audit trail | `list_workflows` tool result: single `git-revert-v2` (no confidence field) |
| LLM analysis_full | "git-revert-v2 — the only GitRevertCommit workflow" |
| Prompt (before fix) | "Include up to 2-3 alternative_workflows" + "Include the confidence score alongside the name" |

## Test plan

- [x] `go test ./internal/kubernautagent/prompt/...` — 112/112 passed
- [x] `go test ./internal/kubernautagent/investigator/...` — 224/224 passed
- [x] `go test ./internal/kubernautagent/parser/...` — 177/177 passed
- [ ] Manual validation: trigger workflow discovery for a single-workflow action type and verify narration shows only one entry without confidence

Closes #1441

Made with [Cursor](https://cursor.com)