### PR TITLE
fix: prevent stale session hijacking via ActiveContextRegistry idle timeout (#1446)

### DIFF
--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -937,7 +937,7 @@ func buildA2AHandler(ctx context.Context, cfg *config.Config, deps *backendDeps,
 		sessionSvcForAgent = sessInfra.SessionService
 	}
 
-	activeCtxRegistry := launcher.NewActiveContextRegistry(launcher.DefaultRegistryTTL)
+	activeCtxRegistry := launcher.NewActiveContextRegistry(launcher.DefaultRegistryTTL, launcher.DefaultRegistryIdleTimeout)
 
 	rootAgent, _, err := agentpkg.NewRootAgent(agentpkg.AgentConfig{
 		Instruction:           agentpkg.BuildInstruction(cfg.Session.Namespace),

--- a/pkg/apifrontend/agent/phase_guard.go
+++ b/pkg/apifrontend/agent/phase_guard.go
@@ -93,13 +93,25 @@ func newPhaseGuard(registry *launcher.ActiveContextRegistry) (llmagent.BeforeToo
 		isEntry := driverEntryTools[toolName]
 		isTerminal := sessionTerminalTools[toolName]
 
+		isSuccess := callErr == nil && resp != nil
+		if isSuccess {
+			if errVal, ok := resp["error"]; ok && errVal != nil {
+				isSuccess = false
+			}
+		}
+
+		// Refresh idle timer for any successful tool call to keep the
+		// active session alive during ongoing engagement (#1446, AU-3).
+		if registry != nil && isSuccess && !isEntry && !isTerminal {
+			if identity := auth.UserIdentityFromContext(ctx); identity != nil && identity.Username != "" {
+				registry.Refresh(identity.Username)
+			}
+		}
+
 		if !isEntry && !isTerminal {
 			return resp, callErr
 		}
-		if callErr != nil || resp == nil {
-			return resp, callErr
-		}
-		if errVal, ok := resp["error"]; ok && errVal != nil {
+		if !isSuccess {
 			return resp, callErr
 		}
 

--- a/pkg/apifrontend/agent/phase_guard_test.go
+++ b/pkg/apifrontend/agent/phase_guard_test.go
@@ -283,7 +283,7 @@ var _ = Describe("Phase Guard — ActiveContextRegistry Integration (BR-SESS-020
 	)
 
 	BeforeEach(func() {
-		registry = launcher.NewActiveContextRegistry(2 * time.Hour)
+		registry = launcher.NewActiveContextRegistry(2*time.Hour, 10*time.Minute)
 		state = newMapState()
 		ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
 			Username: "alice", Groups: []string{"sre"},
@@ -377,5 +377,48 @@ var _ = Describe("Phase Guard — ActiveContextRegistry Integration (BR-SESS-020
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).NotTo(BeNil(),
 			"Phase guard must still block MCP-dependent tools before investigate when registry is present")
+	})
+
+	It("UT-AF-1446-007: AU-3 — Refresh called on successful non-entry/non-terminal tool call (#1446)", func() {
+		registry.Set("alice", "ctx-session-abc")
+
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+			"session_id": "ka-sess-001", "rr_id": "rr-123",
+		}, nil)
+
+		shortIdleRegistry := launcher.NewActiveContextRegistry(2*time.Hour, 10*time.Millisecond)
+		shortIdleRegistry.Set("alice", "ctx-session-abc")
+		_, afterShort := NewPhaseGuardWithRegistryForTest(shortIdleRegistry)
+
+		time.Sleep(5 * time.Millisecond)
+
+		_, _ = afterShort(toolCtx, fakeTool{name: "kubectl_get"}, nil, map[string]any{
+			"result": "pod/nginx Running",
+		}, nil)
+
+		time.Sleep(7 * time.Millisecond)
+
+		contextID, ok := shortIdleRegistry.Get("alice")
+		Expect(ok).To(BeTrue(),
+			"AU-3: successful non-entry tool call must refresh idle timer to keep session alive for audit scope accuracy")
+		Expect(contextID).To(Equal("ctx-session-abc"))
+	})
+
+	It("UT-AF-1446-008: AU-3 — Refresh NOT called on failed tool call (#1446)", func() {
+		shortIdleRegistry := launcher.NewActiveContextRegistry(2*time.Hour, 10*time.Millisecond)
+		shortIdleRegistry.Set("alice", "ctx-session-abc")
+		_, afterShort := NewPhaseGuardWithRegistryForTest(shortIdleRegistry)
+
+		time.Sleep(5 * time.Millisecond)
+
+		_, _ = afterShort(toolCtx, fakeTool{name: "kubectl_get"}, nil, map[string]any{
+			"error": "forbidden",
+		}, nil)
+
+		time.Sleep(7 * time.Millisecond)
+
+		_, ok := shortIdleRegistry.Get("alice")
+		Expect(ok).To(BeFalse(),
+			"AU-3: failed tool calls must not extend session lifetime — prevents phantom sessions from corrupting audit scope boundaries")
 	})
 })

--- a/pkg/apifrontend/agent/prompt.go
+++ b/pkg/apifrontend/agent/prompt.go
@@ -87,12 +87,16 @@ func BuildInstruction(namespace string) string {
 // Raw group names are never included in output (AC-6).
 var roleGuidanceMap = map[string]string{
 	"sre": "You have full operational access. You may investigate, remediate, " +
-		"and manage all incidents. Proactively suggest root cause analysis " +
-		"and remediation workflows when issues are detected. " +
+		"and manage all incidents. When the user asks you to investigate or fix an issue, " +
+		"suggest root cause analysis and remediation workflows. " +
+		"Do NOT proactively investigate or act on existing incidents unless " +
+		"the user explicitly requests it. " +
 		"Approval/rejection actions are handled exclusively via the Console UI.",
 	"ai-orchestrator": "You have full operational access. You may investigate, remediate, " +
-		"and manage all incidents. Proactively suggest root cause analysis " +
-		"and remediation workflows when issues are detected. " +
+		"and manage all incidents. When the user asks you to investigate or fix an issue, " +
+		"suggest root cause analysis and remediation workflows. " +
+		"Do NOT proactively investigate or act on existing incidents unless " +
+		"the user explicitly requests it. " +
 		"Approval/rejection actions are handled exclusively via the Console UI.",
 	"observability": "You have read-only access. Focus on presenting cluster state, " +
 		"investigation results, and audit trails. Do not initiate remediations or approvals.",

--- a/pkg/apifrontend/agent/prompt.txt
+++ b/pkg/apifrontend/agent/prompt.txt
@@ -52,14 +52,21 @@ Behavior: Proceed through the full Phase 1 → 2 → 3 → 4 flow. In interactiv
 ### Observation Mode (read-only)
 Triggered by: "show me", "list", "status", "check", "what's the status of"
 Tool: Use observation tools only (kubernaut_list_remediations, kubectl_get, kubectl_list, etc.).
-Behavior: Do not initiate investigations or remediations. kubectl queries answer WHAT is happening (pod status, events, resource state). For WHY something is failing, always delegate to kubernaut_investigate or kubernaut_remediate.
+Behavior: Do not initiate investigations or remediations. Even if there are active,
+timed-out, or completed remediation items visible in the conversation history, do NOT
+resume, investigate, or act on them unless the user EXPLICITLY requests it. The existence
+of prior investigations in the session context is NOT an implicit request to continue them.
+kubectl queries answer WHAT is happening (pod status, events, resource state).
+For WHY something is failing, always delegate to kubernaut_investigate or kubernaut_remediate —
+but ONLY when the user explicitly asks for investigation or remediation.
 
 ### Decision Algorithm
 
 When unsure which tool to call, use this logic:
-1. Does the user just want it fixed with no follow-up? → `kubernaut_remediate`
-2. Does the user want to see findings, choose a workflow, or monitor progress? → `kubernaut_investigate`
-3. Is there already an autonomous investigation running that needs intervention? → `kubernaut_investigate` with the rr_id (it automatically detects autonomous sessions and signals takeover)
+1. Is the user asking a simple informational question (list, status, show)? → Observation tools ONLY. Do NOT investigate or remediate.
+2. Does the user just want it fixed with no follow-up? → `kubernaut_remediate`
+3. Does the user want to see findings, choose a workflow, or monitor progress? → `kubernaut_investigate`
+4. Is there already an autonomous investigation running that the user EXPLICITLY asked to intervene in? → `kubernaut_investigate` with the rr_id (it automatically detects autonomous sessions and signals takeover)
 
 DO NOT chain kubectl_get + kubectl_list_events + your own analysis as a substitute for kubernaut_investigate or kubernaut_remediate. This bypasses the audit trail, produces ungrounded analysis, and skips workflow recommendations. Use kubectl ONLY for preliminary observation to identify the target, then delegate to the appropriate kubernaut tool.
 

--- a/pkg/apifrontend/launcher/active_context_registry.go
+++ b/pkg/apifrontend/launcher/active_context_registry.go
@@ -5,52 +5,90 @@ import (
 	"time"
 )
 
-// DefaultRegistryTTL is the default time-to-live for active context entries.
+// DefaultRegistryTTL is the default max time-to-live for active context entries.
 // Exposed as a variable for testability without config surface expansion.
 var DefaultRegistryTTL = 2 * time.Hour
 
+// DefaultRegistryIdleTimeout is the default idle timeout for active context
+// entries. If no tool call refreshes the entry within this window, the session
+// is considered stale and the next message starts a fresh session (#1446).
+var DefaultRegistryIdleTimeout = 10 * time.Minute
+
 type contextEntry struct {
-	contextID string
-	createdAt time.Time
+	contextID  string
+	createdAt  time.Time
+	lastActive time.Time
 }
 
 // ActiveContextRegistry maintains a per-user mapping of active A2A context IDs.
 // It enables multi-turn conversation continuity (BR-SESS-020) by allowing the
 // SessionInterceptor to redirect new messages into an existing ADK session.
 //
+// Entries expire when either the max TTL or the idle timeout is exceeded (#1446,
+// SC-7 boundary protection). The idle timeout prevents stale investigation
+// sessions from hijacking unrelated conversations.
+//
 // Thread-safe via sync.Map; passive TTL checked on Get (no background goroutine).
 type ActiveContextRegistry struct {
-	entries sync.Map
-	ttl     time.Duration
+	entries     sync.Map
+	ttl         time.Duration
+	idleTimeout time.Duration
 }
 
-// NewActiveContextRegistry creates a registry with the given entry TTL.
-// Entries older than ttl are treated as expired on access.
-func NewActiveContextRegistry(ttl time.Duration) *ActiveContextRegistry {
-	return &ActiveContextRegistry{ttl: ttl}
+// NewActiveContextRegistry creates a registry with the given max TTL and idle
+// timeout. Entries older than ttl OR idle longer than idleTimeout are treated
+// as expired on access.
+func NewActiveContextRegistry(ttl, idleTimeout time.Duration) *ActiveContextRegistry {
+	return &ActiveContextRegistry{ttl: ttl, idleTimeout: idleTimeout}
 }
 
 // Set stores or overwrites the active context ID for the given username.
 func (r *ActiveContextRegistry) Set(username, contextID string) {
+	now := time.Now()
 	r.entries.Store(username, contextEntry{
-		contextID: contextID,
-		createdAt: time.Now(),
+		contextID:  contextID,
+		createdAt:  now,
+		lastActive: now,
 	})
 }
 
+// Refresh updates the idle timer for the given username without modifying
+// createdAt or contextID. No-op if the entry does not exist (SI-10).
+// Called by the phase_guard after-callback on every successful tool call
+// to keep active sessions alive (#1446, AU-3).
+func (r *ActiveContextRegistry) Refresh(username string) {
+	raw, ok := r.entries.Load(username)
+	if !ok {
+		return
+	}
+	entry := raw.(contextEntry)
+	entry.lastActive = time.Now()
+	r.entries.Store(username, entry)
+}
+
 // Get returns the active context ID for the given username.
-// Returns ("", false) if no entry exists or the entry has expired.
+// Returns ("", false) if no entry exists or the entry has expired by
+// either max TTL or idle timeout (#1446, SC-7).
 func (r *ActiveContextRegistry) Get(username string) (string, bool) {
 	raw, ok := r.entries.Load(username)
 	if !ok {
 		return "", false
 	}
 	entry := raw.(contextEntry)
-	if time.Since(entry.createdAt) > r.ttl {
+	now := time.Now()
+	if now.Sub(entry.createdAt) > r.ttl || now.Sub(entry.lastActive) > r.idleTimeout {
 		r.entries.Delete(username)
 		return "", false
 	}
 	return entry.contextID, true
+}
+
+// HasEntry returns true if an entry exists for the username, regardless of
+// whether it is expired. Used by SessionInterceptor to distinguish between
+// "no entry" and "stale entry evicted by Get" for audit logging (#1446).
+func (r *ActiveContextRegistry) HasEntry(username string) bool {
+	_, ok := r.entries.Load(username)
+	return ok
 }
 
 // Clear removes the active context entry for the given username.

--- a/pkg/apifrontend/launcher/active_context_registry_test.go
+++ b/pkg/apifrontend/launcher/active_context_registry_test.go
@@ -10,11 +10,53 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
 )
 
+var _ = Describe("ActiveContextRegistry — Idle Timeout (#1446, BR-SESS-023)", func() {
+
+	It("UT-AF-1446-001: SC-7 — Get returns false when entry exceeds idle timeout but is within max TTL", func() {
+		registry := launcher.NewActiveContextRegistry(2*time.Hour, 1*time.Millisecond)
+		registry.Set("alice", "ctx-stale")
+
+		time.Sleep(5 * time.Millisecond)
+
+		contextID, ok := registry.Get("alice")
+		Expect(ok).To(BeFalse(),
+			"SC-7: stale session context must not cross conversation boundaries — idle timeout must expire the entry")
+		Expect(contextID).To(BeEmpty())
+	})
+
+	It("UT-AF-1446-002: SC-7 — Refresh resets idle timer, keeping entry alive past idle timeout", func() {
+		registry := launcher.NewActiveContextRegistry(2*time.Hour, 10*time.Millisecond)
+		registry.Set("bob", "ctx-active")
+
+		time.Sleep(5 * time.Millisecond)
+		registry.Refresh("bob")
+		time.Sleep(7 * time.Millisecond)
+
+		contextID, ok := registry.Get("bob")
+		Expect(ok).To(BeTrue(),
+			"SC-7: active sessions must maintain boundary continuity — Refresh must reset idle timer")
+		Expect(contextID).To(Equal("ctx-active"))
+	})
+
+	It("UT-AF-1446-003: SI-10 — Refresh is a no-op for non-existent entries", func() {
+		registry := launcher.NewActiveContextRegistry(2*time.Hour, 10*time.Minute)
+
+		Expect(func() {
+			registry.Refresh("nonexistent-user")
+		}).NotTo(Panic(),
+			"SI-10: refresh of non-existent entry must be safe — no panic, no phantom creation")
+
+		_, ok := registry.Get("nonexistent-user")
+		Expect(ok).To(BeFalse(),
+			"SI-10: Refresh must not create phantom entries for unknown users")
+	})
+})
+
 var _ = Describe("ActiveContextRegistry (BR-SESS-020, BR-SESS-022, BR-SESS-024)", func() {
 	var registry *launcher.ActiveContextRegistry
 
 	BeforeEach(func() {
-		registry = launcher.NewActiveContextRegistry(2 * time.Hour)
+		registry = launcher.NewActiveContextRegistry(2*time.Hour, 10*time.Minute)
 	})
 
 	It("UT-AF-SESS-020-001: Set stores username-to-contextID mapping (SC-7)", func() {
@@ -49,7 +91,7 @@ var _ = Describe("ActiveContextRegistry (BR-SESS-020, BR-SESS-022, BR-SESS-024)"
 	})
 
 	It("UT-AF-SESS-020-005: Get returns false for expired entry (AC-2)", func() {
-		shortTTL := launcher.NewActiveContextRegistry(1 * time.Millisecond)
+		shortTTL := launcher.NewActiveContextRegistry(1*time.Millisecond, 1*time.Millisecond)
 		shortTTL.Set("dave", "ctx-expired")
 
 		time.Sleep(5 * time.Millisecond)

--- a/pkg/apifrontend/launcher/session_interceptor.go
+++ b/pkg/apifrontend/launcher/session_interceptor.go
@@ -56,8 +56,14 @@ func (s *SessionInterceptor) Before(ctx context.Context, callCtx *a2asrv.CallCon
 		return ctx, nil
 	}
 
+	hadEntry := s.registry.HasEntry(identity.Username)
 	activeCtx, found := s.registry.Get(identity.Username)
 	if !found {
+		if hadEntry {
+			s.logger.Info("clearing stale context — idle-expired session will not redirect (#1446)",
+				"user", identity.Username,
+			)
+		}
 		return ctx, nil
 	}
 

--- a/pkg/apifrontend/launcher/session_interceptor_it_test.go
+++ b/pkg/apifrontend/launcher/session_interceptor_it_test.go
@@ -59,7 +59,7 @@ var _ = Describe("SessionInterceptor Integration (BR-SESS-020)", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		sessionSvc = adksession.InMemoryService()
-		registry = launcher.NewActiveContextRegistry(2 * time.Hour)
+		registry = launcher.NewActiveContextRegistry(2*time.Hour, 10*time.Minute)
 		logBuf = &syncBuffer{}
 		logger = funcr.New(func(prefix, args string) {
 			_, _ = logBuf.WriteString(prefix + " " + args + "\n")
@@ -137,6 +137,60 @@ var _ = Describe("SessionInterceptor Integration (BR-SESS-020)", func() {
 		Expect(json.Unmarshal(rec2.Body.Bytes(), &resp2)).To(Succeed())
 		Expect(resp1).To(HaveKey("result"))
 		Expect(resp2).To(HaveKey("result"))
+	})
+
+	It("IT-AF-1446-004: SC-7 — Message with empty contextId is NOT redirected when registry entry is idle-expired (#1446)", func() {
+		shortIdleRegistry := launcher.NewActiveContextRegistry(2*time.Hour, 1*time.Millisecond)
+		shortIdleRegistry.Set("diana", "ctx-stale-investigation")
+
+		time.Sleep(5 * time.Millisecond)
+
+		interceptor := launcher.NewSessionInterceptor(shortIdleRegistry, logger)
+		h, err := launcher.NewA2AHandler(launcher.A2AConfig{
+			Agent:              rootAgent,
+			SessionService:     sessionSvc,
+			AppName:            "kubernaut-apifrontend",
+			Logger:             logger,
+			SessionInterceptor: interceptor,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		rec := sendMessage(h, "diana", "", "list active alerts")
+		Expect(rec.Code).To(Equal(http.StatusOK))
+
+		Expect(logBuf.String()).NotTo(ContainSubstring("overriding context_id"),
+			"SC-7: idle-expired sessions must NOT hijack new conversations through the full dispatch chain")
+		Expect(logBuf.String()).To(ContainSubstring("clearing stale context"),
+			"SC-7: interceptor must log stale entry clearing for audit trail")
+
+		_, ok := shortIdleRegistry.Get("diana")
+		Expect(ok).To(BeFalse(),
+			"SC-7: stale registry entry must be evicted after idle-expired redirect attempt")
+	})
+
+	It("IT-AF-1446-005: SC-7, AC-2 — Active session stays alive via Refresh through tool call sequence (#1446)", func() {
+		shortIdleRegistry := launcher.NewActiveContextRegistry(2*time.Hour, 50*time.Millisecond)
+		shortIdleRegistry.Set("edgar", "ctx-active-investigation")
+
+		interceptor := launcher.NewSessionInterceptor(shortIdleRegistry, logger)
+		h, err := launcher.NewA2AHandler(launcher.A2AConfig{
+			Agent:              rootAgent,
+			SessionService:     sessionSvc,
+			AppName:            "kubernaut-apifrontend",
+			Logger:             logger,
+			SessionInterceptor: interceptor,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		time.Sleep(30 * time.Millisecond)
+		shortIdleRegistry.Refresh("edgar")
+		time.Sleep(30 * time.Millisecond)
+
+		rec := sendMessage(h, "edgar", "", "show me the RCA")
+		Expect(rec.Code).To(Equal(http.StatusOK))
+
+		Expect(logBuf.String()).To(ContainSubstring("overriding context_id"),
+			"SC-7, AC-2: active sessions must maintain multi-turn continuity — boundary is intentional")
 	})
 
 	It("IT-AF-SESS-020-006: Explicit contextId is preserved even when active context exists (SC-7)", func() {

--- a/pkg/apifrontend/launcher/session_interceptor_test.go
+++ b/pkg/apifrontend/launcher/session_interceptor_test.go
@@ -24,7 +24,7 @@ var _ = Describe("SessionInterceptor (BR-SESS-020, BR-SESS-021, BR-SESS-023)", f
 	)
 
 	BeforeEach(func() {
-		registry = launcher.NewActiveContextRegistry(2 * time.Hour)
+		registry = launcher.NewActiveContextRegistry(2*time.Hour, 10*time.Minute)
 		logBuf = &bytes.Buffer{}
 		logger := funcr.New(func(prefix, args string) {
 			logBuf.WriteString(prefix + " " + args + "\n")
@@ -177,6 +177,39 @@ var _ = Describe("SessionInterceptor (BR-SESS-020, BR-SESS-021, BR-SESS-023)", f
 		logOutput := logBuf.String()
 		Expect(logOutput).NotTo(ContainSubstring("overriding context_id"),
 			"No override log when explicit ContextID is provided")
+	})
+
+	It("UT-AF-1446-006: SC-7, AC-6 — Does NOT override contextId when session is idle-expired; clears stale entry (#1446)", func() {
+		shortIdle := launcher.NewActiveContextRegistry(2*time.Hour, 1*time.Millisecond)
+		logBuf.Reset()
+		logger := funcr.New(func(prefix, args string) {
+			logBuf.WriteString(prefix + " " + args + "\n")
+		}, funcr.Options{})
+		staleInterceptor := launcher.NewSessionInterceptor(shortIdle, logger)
+
+		shortIdle.Set("hank", "ctx-stale-investigation")
+		time.Sleep(5 * time.Millisecond)
+
+		ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+			Username: "hank", Groups: []string{"sre"},
+		})
+		callCtx := newTestCallContext()
+		msg := &a2a.Message{ContextID: ""}
+		req := &a2asrv.Request{
+			Payload: &a2a.MessageSendParams{Message: msg},
+		}
+
+		_, err := staleInterceptor.Before(ctx, callCtx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(msg.ContextID).To(BeEmpty(),
+			"SC-7: idle-expired session must NOT hijack new conversations — contextId must remain empty")
+
+		_, ok := shortIdle.Get("hank")
+		Expect(ok).To(BeFalse(),
+			"AC-6: stale registry entry must be cleared to prevent repeated redirect attempts")
+
+		Expect(logBuf.String()).To(ContainSubstring("clearing stale context"),
+			"AU-3: stale entry clearing must be logged for audit traceability")
 	})
 
 	It("UT-AF-SESS-020-017: Overrides empty ContextID when active context exists (#1345)", func() {


### PR DESCRIPTION
## Summary

Fixes #1446 — the agent autonomously investigates active RemediationRequests on simple queries like "list active alerts", disregarding user intent.

**Root cause**: `SessionInterceptor` blindly routes messages with empty `contextID` to `ActiveContextRegistry` entries that persist long after the investigation ended or became idle. The 2-hour TTL was insufficient — sessions could become stale within minutes of user disengagement.

**Three-layer fix**:

- **Idle timeout in ActiveContextRegistry**: Entries now track `lastActive` timestamps. `Get()` evicts entries idle longer than `DefaultRegistryIdleTimeout` (10m). `Refresh()` resets the idle timer on active engagement. `HasEntry()` enables the interceptor to distinguish "not found" from "stale eviction" for audit logging.

- **phase_guard idle refresh**: The after-callback calls `Refresh()` on every successful non-entry/non-terminal tool call, keeping active sessions alive during ongoing engagement. Failed tool calls do not extend the timer.

- **Prompt hardening**: Observation Mode explicitly forbids resuming prior investigations unless the user explicitly requests it. Decision Algorithm prioritizes informational queries first. SRE/ai-orchestrator role guidance changed from proactive to reactive investigation suggestions.

## Test Plan

### Unit Tests (8 new)
- [x] UT-AF-1446-001: SC-7 — Get returns false when entry exceeds idle timeout but within max TTL
- [x] UT-AF-1446-002: SC-7 — Refresh resets idle timer, keeping entry alive past idle timeout
- [x] UT-AF-1446-003: SI-10 — Refresh is a no-op for non-existent entries
- [x] UT-AF-1446-006: SC-7, AC-6 — SessionInterceptor does NOT override contextId when idle-expired; clears stale entry
- [x] UT-AF-1446-007: AU-3 — phase_guard calls Refresh on successful non-entry/non-terminal tool calls
- [x] UT-AF-1446-008: AU-3 — phase_guard does NOT call Refresh on failed tool calls

### Integration Tests (2 new)
- [x] IT-AF-1446-004: SC-7 — Message with empty contextId is NOT redirected when registry entry is idle-expired
- [x] IT-AF-1446-005: SC-7, AC-2 — Active session stays alive via Refresh through tool call sequence

### Regression
- [x] 272/272 launcher specs pass
- [x] 152/152 agent specs pass
- [x] cmd/apifrontend tests pass
- [x] `go build ./...` clean
- [x] `go vet ./pkg/apifrontend/...` clean

### FedRAMP Control Coverage
| Control | Tests |
|---|---|
| SC-7 (Boundary Protection) | 001, 002, 006, IT-004, IT-005 |
| AC-2 (Account Management) | IT-005 |
| AC-6 (Least Privilege) | 006 |
| AU-3 (Audit Content) | 007, 008 |
| SI-10 (Input Validation) | 003 |


Made with [Cursor](https://cursor.com)