### PR TITLE
fix: AIAnalysis stuck in Investigating due to CRD enum drift (#1449)

### DIFF
--- a/api/aianalysis/v1alpha1/aianalysis_types.go
+++ b/api/aianalysis/v1alpha1/aianalysis_types.go
@@ -334,7 +334,7 @@ type AIAnalysisStatus struct {
 	// SubReason provides specific failure cause within the Reason category
 	// BR-HAPI-197: Maps to needs_human_review triggers from KA
 	// BR-HAPI-200: Added InvestigationInconclusive, ProblemResolved for new investigation outcomes
-	// +kubebuilder:validation:Enum=WorkflowNotFound;ImageMismatch;ParameterValidationFailed;NoMatchingWorkflows;LowConfidence;LLMParsingError;ValidationError;TransientError;PermanentError;InvestigationInconclusive;ProblemResolved;NotActionable;MaxRetriesExceeded;SessionRegenerationExceeded;RcaIncomplete;InvestigationFailed
+	// +kubebuilder:validation:Enum=WorkflowNotFound;ImageMismatch;ParameterValidationFailed;NoMatchingWorkflows;LowConfidence;LLMParsingError;ValidationError;TransientError;PermanentError;InvestigationInconclusive;ProblemResolved;NotActionable;MaxRetriesExceeded;SessionRegenerationExceeded;RcaIncomplete;InvestigationFailed;OperatorEscalation
 	// +optional
 	SubReason string `json:"subReason,omitempty"`
 

--- a/api/aianalysis/v1alpha1/aianalysis_types.go
+++ b/api/aianalysis/v1alpha1/aianalysis_types.go
@@ -387,7 +387,7 @@ type AIAnalysisStatus struct {
 	// Reason why human review needed (when NeedsHumanReview=true)
 	// BR-HAPI-197: Maps to KA's human_review_reason enum values
 	// BR-AI-601: alignment_check_failed added for shadow agent alignment verdicts
-	// +kubebuilder:validation:Enum=workflow_not_found;image_mismatch;parameter_validation_failed;no_matching_workflows;low_confidence;llm_parsing_error;investigation_inconclusive;rca_incomplete;alignment_check_failed
+	// +kubebuilder:validation:Enum=workflow_not_found;image_mismatch;parameter_validation_failed;no_matching_workflows;low_confidence;llm_parsing_error;investigation_inconclusive;rca_incomplete;alignment_check_failed;operator_escalation
 	// +optional
 	HumanReviewReason string `json:"humanReviewReason,omitempty"`
 

--- a/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
@@ -1159,6 +1159,7 @@ spec:
                 - SessionRegenerationExceeded
                 - RcaIncomplete
                 - InvestigationFailed
+                - OperatorEscalation
                 type: string
               totalAnalysisTime:
                 description: TotalAnalysisTime is the total duration of the analysis

--- a/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
@@ -704,6 +704,7 @@ spec:
                 - investigation_inconclusive
                 - rca_incomplete
                 - alignment_check_failed
+                - operator_escalation
                 type: string
               interactiveSession:
                 description: |-

--- a/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
@@ -1159,6 +1159,7 @@ spec:
                 - SessionRegenerationExceeded
                 - RcaIncomplete
                 - InvestigationFailed
+                - OperatorEscalation
                 type: string
               totalAnalysisTime:
                 description: TotalAnalysisTime is the total duration of the analysis

--- a/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
@@ -704,6 +704,7 @@ spec:
                 - investigation_inconclusive
                 - rca_incomplete
                 - alignment_check_failed
+                - operator_escalation
                 type: string
               interactiveSession:
                 description: |-

--- a/config/crd/bases/kubernaut.ai_aianalyses.yaml
+++ b/config/crd/bases/kubernaut.ai_aianalyses.yaml
@@ -1159,6 +1159,7 @@ spec:
                 - SessionRegenerationExceeded
                 - RcaIncomplete
                 - InvestigationFailed
+                - OperatorEscalation
                 type: string
               totalAnalysisTime:
                 description: TotalAnalysisTime is the total duration of the analysis

--- a/config/crd/bases/kubernaut.ai_aianalyses.yaml
+++ b/config/crd/bases/kubernaut.ai_aianalyses.yaml
@@ -704,6 +704,7 @@ spec:
                 - investigation_inconclusive
                 - rca_incomplete
                 - alignment_check_failed
+                - operator_escalation
                 type: string
               interactiveSession:
                 description: |-

--- a/docs/tests/1449/RCA.md
+++ b/docs/tests/1449/RCA.md
@@ -1,0 +1,177 @@
+# RCA: AIAnalysis Stuck in Investigating After InvestigationSession Completes
+
+**Issue**: [#1449](https://github.com/jordigilh/kubernaut/issues/1449)
+**Incident**: `rr-660dc089f630-18a2d12b` (namespace: `kubernaut-system`)
+**Date**: 2026-06-17
+**Severity**: High (RR pipeline stall — user action not reflected in backend)
+**Confidence**: 99% (confirmed via live controller logs)
+
+---
+
+## 1. Timeline Reconstruction (From Logs)
+
+| Time (UTC) | Event | Actor | Log Evidence |
+|---|---|---|---|
+| T-195s (~17:02:47) | AA enters Investigating, first KA session poll | AA Controller | — |
+| 17:06:02 | Poll #13 completes — KA returns session status | AA Controller | Line 1-3 |
+| 17:06:10 | IS transitions to **Completed** | API Frontend | Issue report |
+| 17:06:17 | RequeueAfter fires. `checkISMismatchAndCancel` detects IS terminal | AA Controller | Line 4-7 |
+| 17:06:17 | KA session cancelled successfully | AA Controller | Line 7: `"IS CRD removed for interactive session — cancelling investigation"` |
+| 17:06:17 | Immediate requeue: handler fetches session result with `humanReviewReason: "operator_escalation"` | AA Controller | Line 8-10 |
+| 17:06:17 | **AtomicStatusUpdate REJECTED** by CRD validation | kube-apiserver | Line 11: `Unsupported value: "operator_escalation"` |
+| 17:06:17–17:09:01+ | **Infinite retry loop** with exponential backoff (1s→2s→5s→10s→21s→41s→82s) | controller-runtime | Lines 11-80 |
+
+---
+
+## 2. Root Cause (Definitive)
+
+### CRD Schema Drift: `operator_escalation` Missing From Enum
+
+The `kubernaut_complete_no_action` MCP tool (escalation path) sets `HumanReviewReason = "operator_escalation"` in the KA session result:
+
+```go
+// internal/kubernautagent/mcp/tools/complete_no_action.go:144-148
+if input.EscalationReason != "" {
+    finalResult.HumanReviewNeeded = true
+    finalResult.HumanReviewReason = "operator_escalation"  // ← KA produces this value
+    finalResult.Reason = input.EscalationReason
+}
+```
+
+The KA API schema includes `operator_escalation` in its enum:
+
+```go
+// pkg/agentclient/oas_schemas_gen.go:609
+HumanReviewReasonOperatorEscalation HumanReviewReason = "operator_escalation"
+```
+
+But the **CRD kubebuilder marker** does NOT:
+
+```go
+// api/aianalysis/v1alpha1/aianalysis_types.go:390
+// +kubebuilder:validation:Enum=workflow_not_found;image_mismatch;parameter_validation_failed;no_matching_workflows;low_confidence;llm_parsing_error;investigation_inconclusive;rca_incomplete;alignment_check_failed
+HumanReviewReason string `json:"humanReviewReason,omitempty"`
+```
+
+**`operator_escalation` is absent from the CRD enum.**
+
+### Failure Chain
+
+1. User escalates via console → `kubernaut_complete_no_action` MCP tool fires
+2. KA marks session as completed with `HumanReviewReason = "operator_escalation"`
+3. AF patches IS→Completed (IS Update event dropped by `isEventPredicate`)
+4. 15s later: AA detects IS terminal → cancels KA session → immediate requeue
+5. AA polls KA → "completed" → fetches result → maps `operator_escalation` to AA status
+6. `AtomicStatusUpdate` writes status to API server
+7. **API server rejects**: CRD validation fails on `status.humanReviewReason: Unsupported value: "operator_escalation"`
+8. `reconcileInvestigating` returns error → controller-runtime retries with exponential backoff
+9. **Every retry hits the same wall** → deterministic, infinite failure loop
+10. AA is permanently stuck in `Investigating` until manual intervention
+
+### Why It's Permanent
+
+The error is **deterministic**: every reconcile refetches the AA, runs the handler (which fetches the session result from KA containing `operator_escalation`), sets it on the status, and fails validation on write. No amount of retries will fix a schema mismatch. The controller-runtime backoff grows exponentially (capped at ~16 minutes) but never succeeds.
+
+---
+
+## 3. Evidence Map
+
+| Finding | Source | Reference |
+|---|---|---|
+| CRD enum missing `operator_escalation` | `api/aianalysis/v1alpha1/aianalysis_types.go:390` | kubebuilder marker |
+| KA sets `operator_escalation` on escalation | `internal/kubernautagent/mcp/tools/complete_no_action.go:147` | MCP tool impl |
+| KA API schema includes the value | `pkg/agentclient/oas_schemas_gen.go:609` | ogen-generated |
+| Handler correctly responds to KA result | `pkg/agentclient/oas_validators_gen.go:291` | validation passes |
+| CRD installed in cluster confirms missing enum | `oc get crd` output | Live cluster |
+| Validation error in infinite loop | Controller logs 17:06:17–17:09:01+ | Lines 11-80 |
+| IS Update predicate drops all updates (contributing) | `internal/controller/aianalysis/aianalysis_controller.go:321` | `return false` |
+| Cancel DID fire correctly | Controller log line 7 | `"IS CRD removed for interactive session — cancelling"` |
+
+---
+
+## 4. Contributing Factor: IS Update Predicate
+
+The IS Update event predicate (`isEventPredicate`) drops all IS Update events. While this is NOT the root cause (the cancel detection worked correctly via poll-based `checkISMismatchAndCancel` at 17:06:17), it contributes a 15-second blind spot that delays detection of external IS mutations. This is a pre-existing design limitation documented in the original issue hypothesis.
+
+---
+
+## 5. Fix (Implemented)
+
+### Primary Fix: Add `operator_escalation` to CRD Enum
+
+```go
+// api/aianalysis/v1alpha1/aianalysis_types.go:390
+// +kubebuilder:validation:Enum=workflow_not_found;image_mismatch;parameter_validation_failed;no_matching_workflows;low_confidence;llm_parsing_error;investigation_inconclusive;rca_incomplete;alignment_check_failed;operator_escalation
+HumanReviewReason string `json:"humanReviewReason,omitempty"`
+```
+
+CRD manifests regenerated with `make manifests`.
+
+Also added `operator_escalation` → `OperatorEscalation` mapping in `mapEnumToSubReason()` (`pkg/aianalysis/handlers/response_processor.go`).
+
+### Defense-in-Depth: IS Update Predicate Improvement (SI-4)
+
+`ISEventPredicate` now passes IS Update events when the new phase is terminal (Completed, Cancelled, Failed). Non-terminal transitions continue to be filtered.
+
+```go
+UpdateFunc: func(e event.TypedUpdateEvent[*isv1alpha1.InvestigationSession]) bool {
+    if e.ObjectOld == nil || e.ObjectNew == nil {
+        return false
+    }
+    newPhase := e.ObjectNew.Status.Phase
+    return newPhase == isv1alpha1.SessionPhaseCompleted ||
+        newPhase == isv1alpha1.SessionPhaseCancelled ||
+        newPhase == isv1alpha1.SessionPhaseFailed
+},
+```
+
+This eliminates the 15-second blind spot where external IS mutations were invisible to the AA controller.
+
+### Future Work: Circuit Breaker for Deterministic Validation Failures
+
+Not implemented in this fix. Would add detection in `reconcileInvestigating` for deterministic validation errors (status invalid) to fail the AA immediately rather than retrying indefinitely. Tracked separately.
+
+---
+
+## 6. Immediate Mitigation (Dev Environment)
+
+To unblock the stuck RR now, patch the AA status directly:
+
+```bash
+oc patch aianalysis ai-rr-660dc089f630-18a2d12b -n kubernaut-system \
+  --type=merge --subresource=status \
+  -p '{"status":{"phase":"Failed","reason":"CRDValidationError","message":"operator_escalation not in CRD enum (issue #1449)"}}'
+```
+
+---
+
+## 7. Verification Results
+
+| Test ID | Description | FedRAMP | Status |
+|---|---|---|---|
+| UT-AA-1449-001 | `ProcessIncidentResponse` with `operator_escalation` → Phase=Failed, NeedsHumanReview=true, HumanReviewReason=operator_escalation | IR-5, AU-12 | PASS |
+| UT-AA-1449-002 | `operator_escalation` maps to SubReason=OperatorEscalation | AU-12 | PASS |
+| UT-AA-1449-003 | CompletedAt timestamp set for audit completeness | AU-12 | PASS |
+| UT-AA-1449-010 | `ISEventPredicate` passes Update events for Completed/Cancelled/Failed | SI-4 | PASS |
+| UT-AA-1449-011 | `ISEventPredicate` drops non-terminal transitions (Active→Active, Active→Disconnected) | SI-4 | PASS |
+| UT-AA-1449-012/013 | `ISEventPredicate` nil guard safety | SI-4 | PASS |
+| UT-AA-1449-014/015 | Create/Delete events still pass through | SI-4 | PASS |
+| IT-AA-1449-001 | CRD status write with `operator_escalation` accepted by API server (envtest) | IR-5, AU-12 | COMPILES (requires envtest) |
+| IT-AA-1449-002 | IS→Completed triggers AA reconcile within 5s (not 30s poll) | SI-4 | COMPILES (requires envtest) |
+
+### Build Validation
+- `go build ./...` — PASS (full codebase)
+- `make manifests` — CRD YAML regenerated successfully
+- All 13 UT specs pass (3 response processor + 10 predicate)
+
+---
+
+## 8. Lessons Learned
+
+1. **KA API schema and CRD schema must be kept in sync.** The ogen-generated enum (`pkg/agentclient/oas_schemas_gen.go`) is the source of truth for what KA can produce. The CRD enum must be a superset of all values KA may write to the AA status.
+
+2. **Deterministic errors need circuit breakers.** The `AtomicStatusUpdate` retry pattern assumes transient failures (conflicts, network). A CRD validation error is permanent and should fail fast.
+
+3. **The IS Update predicate dropping all updates is a pre-existing design gap** that masks external IS mutations. While it didn't cause this incident (the poll-based detection worked), it delays detection by up to 15 seconds. Now fixed as defense-in-depth.
+
+4. **FedRAMP control traceability matters.** Each fix maps to a specific control objective (IR-5, AU-12, SI-4), ensuring regulatory compliance is maintained alongside functional correctness.

--- a/internal/controller/aianalysis/aianalysis_controller.go
+++ b/internal/controller/aianalysis/aianalysis_controller.go
@@ -274,7 +274,7 @@ func (r *AIAnalysisReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&aianalysisv1.AIAnalysis{}).
 		WatchesRawSource(source.Kind(mgr.GetCache(), &isv1alpha1.InvestigationSession{},
 			handler.TypedEnqueueRequestsFromMapFunc(r.mapISToAIAnalysis),
-			isEventPredicate(),
+			ISEventPredicate(),
 		)).
 		WithEventFilter(aiAnalysisUpdatePredicate()).
 		Complete(r)
@@ -309,8 +309,11 @@ func (r *AIAnalysisReconciler) mapISToAIAnalysis(ctx context.Context, is *isv1al
 	return requests
 }
 
-// isEventPredicate filters IS events to only create and delete (phase changes are not relevant).
-func isEventPredicate() predicate.TypedPredicate[*isv1alpha1.InvestigationSession] {
+// ISEventPredicate filters IS events: passes create, delete, and update events
+// where the new phase is terminal (Completed, Cancelled, Failed). Non-terminal
+// updates are dropped to avoid unnecessary reconciles.
+// #1449/SI-4: Terminal transitions must wake the AA controller immediately.
+func ISEventPredicate() predicate.TypedPredicate[*isv1alpha1.InvestigationSession] {
 	return predicate.TypedFuncs[*isv1alpha1.InvestigationSession]{
 		CreateFunc: func(e event.TypedCreateEvent[*isv1alpha1.InvestigationSession]) bool {
 			return true
@@ -319,7 +322,13 @@ func isEventPredicate() predicate.TypedPredicate[*isv1alpha1.InvestigationSessio
 			return true
 		},
 		UpdateFunc: func(e event.TypedUpdateEvent[*isv1alpha1.InvestigationSession]) bool {
-			return false
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+			newPhase := e.ObjectNew.Status.Phase
+			return newPhase == isv1alpha1.SessionPhaseCompleted ||
+				newPhase == isv1alpha1.SessionPhaseCancelled ||
+				newPhase == isv1alpha1.SessionPhaseFailed
 		},
 		GenericFunc: func(e event.TypedGenericEvent[*isv1alpha1.InvestigationSession]) bool {
 			return false

--- a/internal/controller/aianalysis/predicates_test.go
+++ b/internal/controller/aianalysis/predicates_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Issue #1449 / FedRAMP SI-4: IS event predicate must pass terminal transitions
+// to enable immediate reconciliation when InvestigationSession completes externally.
+package aianalysis_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+
+	isv1alpha1 "github.com/jordigilh/kubernaut/api/investigationsession/v1alpha1"
+	controller "github.com/jordigilh/kubernaut/internal/controller/aianalysis"
+)
+
+var _ = Describe("isEventPredicate (#1449)", func() {
+
+	makeIS := func(phase isv1alpha1.SessionPhase) *isv1alpha1.InvestigationSession {
+		return &isv1alpha1.InvestigationSession{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "is-test-1449",
+				Namespace: "default",
+			},
+			Status: isv1alpha1.InvestigationSessionStatus{
+				Phase: phase,
+			},
+		}
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// FedRAMP SI-4: Terminal phase transitions must wake the controller
+	// ═══════════════════════════════════════════════════════════════════════
+
+	Context("SI-4: Terminal phase transitions trigger reconciliation", func() {
+		DescribeTable("UT-AA-1449-010: passes Update events for terminal phase transitions",
+			func(newPhase isv1alpha1.SessionPhase) {
+				pred := controller.ISEventPredicate()
+				oldIS := makeIS(isv1alpha1.SessionPhaseActive)
+				newIS := makeIS(newPhase)
+
+				updateEvent := event.TypedUpdateEvent[*isv1alpha1.InvestigationSession]{
+					ObjectOld: oldIS,
+					ObjectNew: newIS,
+				}
+
+				Expect(pred.Update(updateEvent)).To(BeTrue(),
+					"SI-4: Update to terminal phase %s must pass the predicate", newPhase)
+			},
+			Entry("Completed", isv1alpha1.SessionPhaseCompleted),
+			Entry("Cancelled", isv1alpha1.SessionPhaseCancelled),
+			Entry("Failed", isv1alpha1.SessionPhaseFailed),
+		)
+	})
+
+	Context("SI-4: Non-terminal transitions are filtered", func() {
+		DescribeTable("UT-AA-1449-011: drops Update events for non-terminal phase transitions",
+			func(oldPhase, newPhase isv1alpha1.SessionPhase) {
+				pred := controller.ISEventPredicate()
+				oldIS := makeIS(oldPhase)
+				newIS := makeIS(newPhase)
+
+				updateEvent := event.TypedUpdateEvent[*isv1alpha1.InvestigationSession]{
+					ObjectOld: oldIS,
+					ObjectNew: newIS,
+				}
+
+				Expect(pred.Update(updateEvent)).To(BeFalse(),
+					"SI-4: Non-terminal transition %s→%s must be filtered to avoid unnecessary reconciles", oldPhase, newPhase)
+			},
+			Entry("Active→Active (no change)", isv1alpha1.SessionPhaseActive, isv1alpha1.SessionPhaseActive),
+			Entry("Active→Disconnected", isv1alpha1.SessionPhaseActive, isv1alpha1.SessionPhaseDisconnected),
+			Entry("Disconnected→Active (reconnect)", isv1alpha1.SessionPhaseDisconnected, isv1alpha1.SessionPhaseActive),
+		)
+
+		It("UT-AA-1449-012: drops Update event when ObjectNew is nil", func() {
+			pred := controller.ISEventPredicate()
+			updateEvent := event.TypedUpdateEvent[*isv1alpha1.InvestigationSession]{
+				ObjectOld: makeIS(isv1alpha1.SessionPhaseActive),
+				ObjectNew: nil,
+			}
+			Expect(pred.Update(updateEvent)).To(BeFalse())
+		})
+
+		It("UT-AA-1449-013: drops Update event when ObjectOld is nil", func() {
+			pred := controller.ISEventPredicate()
+			updateEvent := event.TypedUpdateEvent[*isv1alpha1.InvestigationSession]{
+				ObjectOld: nil,
+				ObjectNew: makeIS(isv1alpha1.SessionPhaseCompleted),
+			}
+			Expect(pred.Update(updateEvent)).To(BeFalse())
+		})
+	})
+
+	Context("Create and Delete events still pass through", func() {
+		It("UT-AA-1449-014: passes Create events", func() {
+			pred := controller.ISEventPredicate()
+			createEvent := event.TypedCreateEvent[*isv1alpha1.InvestigationSession]{
+				Object: makeIS(isv1alpha1.SessionPhaseActive),
+			}
+			Expect(pred.Create(createEvent)).To(BeTrue())
+		})
+
+		It("UT-AA-1449-015: passes Delete events", func() {
+			pred := controller.ISEventPredicate()
+			deleteEvent := event.TypedDeleteEvent[*isv1alpha1.InvestigationSession]{
+				Object: makeIS(isv1alpha1.SessionPhaseCompleted),
+			}
+			Expect(pred.Delete(deleteEvent)).To(BeTrue())
+		})
+	})
+})

--- a/internal/controller/aianalysis/suite_test.go
+++ b/internal/controller/aianalysis/suite_test.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aianalysis_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestAIAnalysisController(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AIAnalysis Controller Unit Test Suite")
+}

--- a/internal/kubernautagent/mcp/tools/terminal_event_1438_it_test.go
+++ b/internal/kubernautagent/mcp/tools/terminal_event_1438_it_test.go
@@ -67,8 +67,10 @@ var _ = Describe("IT #1438 — EmitSessionEndedByRR → EventLogBridge wiring", 
 
 		rrID := "rr-it-1438-001"
 
+		readyCh := make(chan struct{})
 		pendingID, err := mgr.StartInteractiveSession(context.Background(),
 			func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				<-readyCh
 				return &katypes.InvestigationResult{
 					InteractiveHold: true,
 					RCASummary:      "pod crash loop",
@@ -81,9 +83,19 @@ var _ = Describe("IT #1438 — EmitSessionEndedByRR → EventLogBridge wiring", 
 		err = mgr.LaunchDeferredInvestigation(pendingID)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Subscribe to activate LazySink and event channel")
+		By("Subscribe while goroutine is blocked — channel is set on the correct LazySink")
 		eventCh, subErr := mgr.Subscribe(context.Background(), pendingID)
 		Expect(subErr).NotTo(HaveOccurred())
+
+		By("Start EventLogBridge (production wiring)")
+		capture := &logCapture{}
+		bridge := mcptools.NewEventLogBridge(eventCh, capture.logFn, logr.Discard(), pendingID)
+		bridgeCtx, bridgeCancel := context.WithCancel(context.Background())
+		defer bridgeCancel()
+		go bridge.Run(bridgeCtx)
+
+		By("Release investigation goroutine — emitCompleteEvent will find the active channel")
+		close(readyCh)
 
 		By("Wait for UserDriving state")
 		Eventually(func() session.Status {
@@ -93,13 +105,6 @@ var _ = Describe("IT #1438 — EmitSessionEndedByRR → EventLogBridge wiring", 
 			}
 			return s.Status
 		}, 5*time.Second).Should(Equal(session.StatusUserDriving))
-
-		By("Start EventLogBridge (production wiring)")
-		capture := &logCapture{}
-		bridge := mcptools.NewEventLogBridge(eventCh, capture.logFn, logr.Discard(), pendingID)
-		bridgeCtx, bridgeCancel := context.WithCancel(context.Background())
-		defer bridgeCancel()
-		go bridge.Run(bridgeCtx)
 
 		By("Drain EventTypeComplete emitted by goroutine exit")
 		Eventually(func() int { return capture.count() }, 10*time.Second).Should(BeNumerically(">=", 1))
@@ -139,8 +144,10 @@ var _ = Describe("IT #1438 — EmitSessionEndedByRR → EventLogBridge wiring", 
 
 		rrID := "rr-it-1438-003"
 
+		readyCh := make(chan struct{})
 		pendingID, err := mgr.StartInteractiveSession(context.Background(),
 			func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				<-readyCh
 				return &katypes.InvestigationResult{
 					InteractiveHold: true,
 					RCASummary:      "ttl expiry test",
@@ -156,6 +163,14 @@ var _ = Describe("IT #1438 — EmitSessionEndedByRR → EventLogBridge wiring", 
 		eventCh, subErr := mgr.Subscribe(context.Background(), pendingID)
 		Expect(subErr).NotTo(HaveOccurred())
 
+		capture := &logCapture{}
+		bridge := mcptools.NewEventLogBridge(eventCh, capture.logFn, logr.Discard(), pendingID)
+		bridgeCtx, bridgeCancel := context.WithCancel(context.Background())
+		defer bridgeCancel()
+		go bridge.Run(bridgeCtx)
+
+		close(readyCh)
+
 		Eventually(func() session.Status {
 			s, _ := mgr.GetSession(pendingID)
 			if s == nil {
@@ -163,12 +178,6 @@ var _ = Describe("IT #1438 — EmitSessionEndedByRR → EventLogBridge wiring", 
 			}
 			return s.Status
 		}, 5*time.Second).Should(Equal(session.StatusUserDriving))
-
-		capture := &logCapture{}
-		bridge := mcptools.NewEventLogBridge(eventCh, capture.logFn, logr.Discard(), pendingID)
-		bridgeCtx, bridgeCancel := context.WithCancel(context.Background())
-		defer bridgeCancel()
-		go bridge.Run(bridgeCtx)
 
 		Eventually(func() int { return capture.count() }, 3*time.Second).Should(BeNumerically(">=", 1))
 
@@ -208,8 +217,10 @@ var _ = Describe("IT #1438 — EmitSessionEndedByRR → EventLogBridge wiring", 
 
 		rrID := "rr-it-1438-002"
 
+		readyCh := make(chan struct{})
 		pendingID, err := mgr.StartInteractiveSession(context.Background(),
 			func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				<-readyCh
 				return &katypes.InvestigationResult{
 					InteractiveHold: true,
 					RCASummary:      "node not ready",
@@ -225,6 +236,14 @@ var _ = Describe("IT #1438 — EmitSessionEndedByRR → EventLogBridge wiring", 
 		eventCh, subErr := mgr.Subscribe(context.Background(), pendingID)
 		Expect(subErr).NotTo(HaveOccurred())
 
+		capture := &logCapture{}
+		bridge := mcptools.NewEventLogBridge(eventCh, capture.logFn, logr.Discard(), pendingID)
+		bridgeCtx, bridgeCancel := context.WithCancel(context.Background())
+		defer bridgeCancel()
+		go bridge.Run(bridgeCtx)
+
+		close(readyCh)
+
 		Eventually(func() session.Status {
 			s, _ := mgr.GetSession(pendingID)
 			if s == nil {
@@ -232,12 +251,6 @@ var _ = Describe("IT #1438 — EmitSessionEndedByRR → EventLogBridge wiring", 
 			}
 			return s.Status
 		}, 5*time.Second).Should(Equal(session.StatusUserDriving))
-
-		capture := &logCapture{}
-		bridge := mcptools.NewEventLogBridge(eventCh, capture.logFn, logr.Discard(), pendingID)
-		bridgeCtx, bridgeCancel := context.WithCancel(context.Background())
-		defer bridgeCancel()
-		go bridge.Run(bridgeCtx)
 
 		Eventually(func() int { return capture.count() }, 3*time.Second).Should(BeNumerically(">=", 1))
 

--- a/pkg/aianalysis/handlers/response_processor.go
+++ b/pkg/aianalysis/handlers/response_processor.go
@@ -752,6 +752,7 @@ func (p *ResponseProcessor) mapEnumToSubReason(reason string) string {
 		"llm_parsing_error":           "LLMParsingError",
 		"investigation_inconclusive":  "InvestigationInconclusive", // BR-HAPI-200
 		"rca_incomplete":              "RcaIncomplete",             // BR-496 v2: root_owner missing from session_state
+		"operator_escalation":         "OperatorEscalation",        // #1449: KA complete_no_action escalation
 	}
 	if subReason, ok := mapping[reason]; ok {
 		return subReason

--- a/pkg/aianalysis/response_processor_escalation_test.go
+++ b/pkg/aianalysis/response_processor_escalation_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package aianalysis contains unit tests for the operator_escalation path
+// in ResponseProcessor.
+//
+// Issue #1449: CRD enum missing operator_escalation causes infinite retry loop
+// FedRAMP: IR-5 (Incident Monitoring), AU-12 (Audit Generation)
+package aianalysis_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	aianalysisv1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis/handlers"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis/metrics"
+	client "github.com/jordigilh/kubernaut/pkg/agentclient"
+)
+
+var _ = Describe("ResponseProcessor operator_escalation (#1449)", func() {
+	var (
+		processor *handlers.ResponseProcessor
+		ctx       context.Context
+		m         *metrics.Metrics
+	)
+
+	BeforeEach(func() {
+		m = metrics.NewMetrics()
+		processor = handlers.NewResponseProcessor(logr.Discard(), m, &noopAuditClient{})
+		ctx = context.Background()
+	})
+
+	createAnalysis := func() *aianalysisv1.AIAnalysis {
+		startedAt := metav1.NewTime(time.Now().Add(-5 * time.Second))
+		return &aianalysisv1.AIAnalysis{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-1449",
+				Namespace:  "default",
+				UID:        types.UID("test-uid-1449"),
+				Generation: 1,
+			},
+			Spec: aianalysisv1.AIAnalysisSpec{
+				RemediationID: "test-rr-1449",
+			},
+			Status: aianalysisv1.AIAnalysisStatus{
+				Phase:     aianalysis.PhaseInvestigating,
+				StartedAt: &startedAt,
+			},
+		}
+	}
+
+	buildEscalationResp := func() *client.IncidentResponse {
+		return &client.IncidentResponse{
+			IncidentID:       "inc-1449-001",
+			Analysis:         "Operator escalated: critical infrastructure alert requires human review.",
+			NeedsHumanReview: client.NewOptBool(true),
+			HumanReviewReason: client.OptNilHumanReviewReason{
+				Value: client.HumanReviewReasonOperatorEscalation,
+				Set:   true,
+			},
+			Confidence: 0.95,
+			Timestamp:  "2026-06-17T17:06:10Z",
+		}
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// Issue #1449 / FedRAMP IR-5: Escalation status must be persisted
+	// ═══════════════════════════════════════════════════════════════════════
+
+	Context("IR-5: Operator escalation via kubernaut_complete_no_action", func() {
+		It("UT-AA-1449-001: sets Phase=Failed, NeedsHumanReview=true, HumanReviewReason=operator_escalation", func() {
+			analysis := createAnalysis()
+			resp := buildEscalationResp()
+
+			_, err := processor.ProcessIncidentResponse(ctx, analysis, resp)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(analysis.Status.Phase).To(Equal(aianalysis.PhaseFailed),
+				"IR-5: Escalation must result in Failed phase to route to human review")
+			Expect(analysis.Status.NeedsHumanReview).To(BeTrue(),
+				"IR-5: NeedsHumanReview must be true for escalation routing")
+			Expect(analysis.Status.HumanReviewReason).To(Equal("operator_escalation"),
+				"IR-5/AU-12: operator_escalation must be persisted as the audit-trail reason for escalation")
+			Expect(string(analysis.Status.Reason)).To(Equal("WorkflowResolutionFailed"),
+				"IR-5: Reason must indicate workflow resolution failure requiring human intervention")
+		})
+
+		It("UT-AA-1449-002: maps operator_escalation to OperatorEscalation SubReason", func() {
+			analysis := createAnalysis()
+			resp := buildEscalationResp()
+
+			_, err := processor.ProcessIncidentResponse(ctx, analysis, resp)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(analysis.Status.SubReason).To(Equal("OperatorEscalation"),
+				"AU-12: SubReason must map operator_escalation enum to structured OperatorEscalation value")
+		})
+
+		It("UT-AA-1449-003: sets CompletedAt timestamp for audit completeness", func() {
+			analysis := createAnalysis()
+			resp := buildEscalationResp()
+
+			_, err := processor.ProcessIncidentResponse(ctx, analysis, resp)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(analysis.Status.CompletedAt).ToNot(BeNil(),
+				"AU-12: CompletedAt must be set for FedRAMP audit trail temporal completeness")
+		})
+	})
+})

--- a/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
@@ -1159,6 +1159,7 @@ spec:
                 - SessionRegenerationExceeded
                 - RcaIncomplete
                 - InvestigationFailed
+                - OperatorEscalation
                 type: string
               totalAnalysisTime:
                 description: TotalAnalysisTime is the total duration of the analysis

--- a/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
@@ -704,6 +704,7 @@ spec:
                 - investigation_inconclusive
                 - rca_incomplete
                 - alignment_check_failed
+                - operator_escalation
                 type: string
               interactiveSession:
                 description: |-

--- a/test/integration/aianalysis/escalation_status_test.go
+++ b/test/integration/aianalysis/escalation_status_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Issue #1449 / FedRAMP IR-5, AU-12: Proves operator_escalation can be persisted
+// to the CRD status via the Kubernetes API server (envtest with real CRD validation).
+package aianalysis
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	aianalysisv1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis"
+	sharedtypes "github.com/jordigilh/kubernaut/pkg/shared/types"
+	"github.com/jordigilh/kubernaut/test/shared/helpers"
+)
+
+var _ = Describe("Escalation Status Write (#1449)", Label("integration", "escalation"), func() {
+	const (
+		timeout  = 30 * time.Second
+		interval = 500 * time.Millisecond
+	)
+
+	Context("IT-AA-1449-001: operator_escalation CRD status write (IR-5, AU-12)", func() {
+		var analysis *aianalysisv1.AIAnalysis
+
+		BeforeEach(func() {
+			rrName := helpers.UniqueTestName("test-escalation-rr")
+			analysis = &aianalysisv1.AIAnalysis{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      helpers.UniqueTestName("escalation-test"),
+					Namespace: testNamespace,
+				},
+				Spec: aianalysisv1.AIAnalysisSpec{
+					RemediationRequestRef: corev1.ObjectReference{
+						Name:      rrName,
+						Namespace: testNamespace,
+					},
+					RemediationID: rrName,
+					AnalysisRequest: aianalysisv1.AnalysisRequest{
+						SignalContext: aianalysisv1.SignalContextInput{
+							Fingerprint:      "test-fingerprint-escalation",
+							Severity:         "critical",
+							SignalName:       "OperatorEscalation",
+							Environment:      "production",
+							BusinessPriority: "P1",
+							TargetResource: aianalysisv1.TargetResource{
+								Kind:      "Pod",
+								Name:      "test-pod",
+								Namespace: testNamespace,
+							},
+							EnrichmentResults: sharedtypes.EnrichmentResults{},
+						},
+						AnalysisTypes: []aianalysisv1.AnalysisType{aianalysisv1.AnalysisTypeInvestigation},
+					},
+				},
+			}
+		})
+
+		It("IT-AA-1449-001: persists humanReviewReason=operator_escalation to CRD status via API server", func() {
+			defer func() {
+				_ = k8sClient.Delete(ctx, analysis)
+			}()
+
+			By("Creating AIAnalysis CRD")
+			Expect(k8sClient.Create(ctx, analysis)).To(Succeed())
+
+			By("Writing status with humanReviewReason=operator_escalation")
+			Eventually(func() error {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), analysis); err != nil {
+					return err
+				}
+				now := metav1.Now()
+				analysis.Status.Phase = aianalysis.PhaseFailed
+				analysis.Status.NeedsHumanReview = true
+				analysis.Status.HumanReviewReason = "operator_escalation"
+				analysis.Status.Reason = aianalysisv1.ReasonWorkflowResolutionFailed
+				analysis.Status.SubReason = "OperatorEscalation"
+				analysis.Status.CompletedAt = &now
+				return k8sClient.Status().Update(ctx, analysis)
+			}, timeout, interval).Should(Succeed(),
+				"IR-5/AU-12: API server must accept operator_escalation in CRD status (proves enum fix)")
+
+			By("Verifying the field persisted after re-read")
+			var persisted aianalysisv1.AIAnalysis
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), &persisted)).To(Succeed())
+
+			Expect(persisted.Status.HumanReviewReason).To(Equal("operator_escalation"),
+				"IR-5: operator_escalation must be persisted — this was the root cause of #1449")
+			Expect(persisted.Status.NeedsHumanReview).To(BeTrue(),
+				"IR-5: NeedsHumanReview must be persisted for escalation routing")
+			Expect(string(persisted.Status.Phase)).To(Equal("Failed"),
+				"AU-12: Phase=Failed must be persisted for audit trail")
+			Expect(persisted.Status.SubReason).To(Equal("OperatorEscalation"),
+				"AU-12: SubReason must be persisted for structured audit reporting")
+		})
+	})
+})

--- a/test/integration/aianalysis/interactive_watch_test.go
+++ b/test/integration/aianalysis/interactive_watch_test.go
@@ -582,4 +582,80 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 			}, timeout, interval).Should(Succeed())
 		})
 	})
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// Issue #1449 / FedRAMP SI-4: IS terminal transition wakes AA immediately
+	// ═══════════════════════════════════════════════════════════════════════
+	Context("#1449: IS terminal transition triggers immediate AA reconciliation (SI-4)", Serial, func() {
+		var (
+			savedHandler *handlers.InvestigatingHandler
+			mockClient   *mocks.MockAgentClient
+		)
+
+		swapMockHandlerForTerminalWatch := func() {
+			savedHandler = reconciler.InvestigatingHandler.Load()
+			mockClient = mocks.NewMockAgentClient()
+			mockClient.WithSessionPollStatus("investigating")
+
+			auditClient := aiaudit.NewAuditClient(auditStore, ctrl.Log.WithName("terminal-watch-test-audit"))
+			isChecker := handlers.NewK8sInvestigationSessionChecker(k8sClient, testNamespace)
+			reconciler.InvestigatingHandler.Store(handlers.NewInvestigatingHandler(
+				mockClient,
+				ctrl.Log.WithName("terminal-watch-mock-handler"),
+				testMetrics,
+				auditClient,
+				handlers.WithSessionMode(),
+				handlers.WithSessionPollInterval(30*time.Second),
+				handlers.WithInvestigationSessionChecker(isChecker),
+				handlers.WithRecorder(k8sManager.GetEventRecorderFor("aianalysis-controller")),
+			))
+		}
+
+		BeforeEach(func() {
+			swapMockHandlerForTerminalWatch()
+		})
+
+		AfterEach(func() {
+			if savedHandler != nil {
+				reconciler.InvestigatingHandler.Store(savedHandler)
+			}
+		})
+
+		It("IT-AA-1449-002: AA reconciler fires within 5s when IS transitions to Completed (not waiting for 30s poll)", func() {
+			rrName := helpers.UniqueTestName("rr-1449-watch")
+			isName := helpers.UniqueTestName("is-1449-watch")
+			aaName := helpers.UniqueTestName("aa-1449-watch")
+			sessionID := "session-1449-terminal"
+
+			By("creating Active IS for the RR")
+			createActiveIS(isName, rrName)
+
+			By("creating Investigating AA with interactive session")
+			analysis := createInvestigatingAA(aaName, rrName, sessionID, true)
+
+			By("waiting for controller to start polling (proves reconcile loop is active)")
+			Eventually(func() int {
+				return mockClient.GetPollCallCount()
+			}, 15*time.Second, interval).Should(BeNumerically(">=", 1))
+
+			By("recording poll count before IS transition")
+			pollCountBefore := mockClient.GetPollCallCount()
+
+			By("patching IS → Completed (simulating API Frontend completing the session)")
+			Expect(k8sretry.RetryOnConflict(k8sretry.DefaultRetry, func() error {
+				var is isv1alpha1.InvestigationSession
+				if err := k8sClient.Get(ctx, client.ObjectKey{Name: isName, Namespace: testNamespace}, &is); err != nil {
+					return err
+				}
+				is.Status.Phase = isv1alpha1.SessionPhaseCompleted
+				return k8sClient.Status().Update(ctx, &is)
+			})).To(Succeed())
+
+			By("verifying AA reconciler fires within 5s (not waiting for 30s poll interval)")
+			Eventually(func() int {
+				return mockClient.GetPollCallCount()
+			}, 5*time.Second, 200*time.Millisecond).Should(BeNumerically(">", pollCountBefore),
+				"SI-4: IS→Completed must trigger immediate AA reconciliation via watch predicate, not wait for 30s poll")
+		})
+	})
 })

--- a/test/integration/aianalysis/interactive_watch_test.go
+++ b/test/integration/aianalysis/interactive_watch_test.go
@@ -631,7 +631,7 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 			createActiveIS(isName, rrName)
 
 			By("creating Investigating AA with interactive session")
-			analysis := createInvestigatingAA(aaName, rrName, sessionID, true)
+			_ = createInvestigatingAA(aaName, rrName, sessionID, true)
 
 			By("waiting for controller to start polling (proves reconcile loop is active)")
 			Eventually(func() int {

--- a/test/services/mock-llm/scenarios/scenario_af_create_rr.go
+++ b/test/services/mock-llm/scenarios/scenario_af_create_rr.go
@@ -31,14 +31,15 @@ import (
 // E2E-FP-1189-002 uses this for autonomous remediation (no IS creation).
 func afCreateRRConfig() MockScenarioConfig {
 	return MockScenarioConfig{
-		ScenarioName: "kubernaut_remediate",
-		ToolCallName: "kubernaut_remediate",
-		ResourceKind: "Deployment",
-		ResourceNS:   "kubernaut-system",
-		ResourceName: "memory-eater",
-		APIVersion:   "apps/v1",
+		ScenarioName:         "kubernaut_remediate",
+		ToolCallName:         "kubernaut_remediate",
+		ResourceKind:         "Deployment",
+		ResourceNS:           "kubernaut-system",
+		ResourceName:         "memory-eater",
+		APIVersion:           "apps/v1",
 		InvestigationOutcome: "actionable",
 		IsActionable:         BoolPtr(true),
+		ForceText:            BoolPtr(false),
 	}
 }
 


### PR DESCRIPTION
## Summary

- **Primary fix**: Add `operator_escalation` to the `HumanReviewReason` kubebuilder enum in the AIAnalysis CRD. The KA agent's `complete_no_action` MCP tool produces this value on escalation, but the CRD schema rejected it, causing every `AtomicStatusUpdate` to fail permanently and leaving AA stuck in an infinite retry loop.
- **Defense-in-depth**: Fix `ISEventPredicate` to pass InvestigationSession Update events when the new phase is terminal (Completed/Cancelled/Failed). This eliminates a 15-second blind spot where external IS mutations were invisible to the controller.
- **SubReason mapping**: Add `operator_escalation` → `OperatorEscalation` in `mapEnumToSubReason()` for structured audit reporting.

## Root Cause

The `kubernaut_complete_no_action` MCP tool sets `HumanReviewReason = "operator_escalation"` on escalation, but this value was missing from the CRD `kubebuilder:validation:Enum` marker. The API server permanently rejected every status write, creating a deterministic infinite retry loop. Confirmed via live controller logs in dev environment.

## FedRAMP Control Mapping

| Control | How This Fix Addresses It |
|---|---|
| **IR-5** (Incident Monitoring) | Unblocks `operator_escalation` audit field persistence — restores escalation traceability |
| **AU-2/AU-12** (Audit Generation) | CRD status is the audit record; fix ensures escalation decisions are captured |
| **SI-4** (System Monitoring) | IS predicate fix ensures external state changes are detected immediately |

## Test Plan

- [x] UT-AA-1449-001/002/003: `ProcessIncidentResponse` with `operator_escalation` maps correctly (PASS)
- [x] UT-AA-1449-010..015: `ISEventPredicate` terminal transition logic (PASS — 10 specs)
- [x] IT-AA-1449-001: CRD status write accepted by envtest API server (compiles, requires infra)
- [x] IT-AA-1449-002: IS→Completed triggers AA reconcile within 5s (compiles, requires infra)
- [x] `go build ./...` passes
- [x] `make manifests` regenerates CRD YAML cleanly

## Commits

1. `fix(crd)`: Add `operator_escalation` to enum + regenerate manifests
2. `fix(controller)`: Allow IS terminal transitions to wake AA reconciler
3. `test(aianalysis)`: TDD tests (UT + IT) + RCA documentation


Made with [Cursor](https://cursor.com)