### PR TITLE
fix: audit result_type enum validation, IS race condition, and SchemaValidationFailed guards (#1455, #1458, #1449)

### DIFF
--- a/api/openapi/data-storage-v1.yaml
+++ b/api/openapi/data-storage-v1.yaml
@@ -7325,7 +7325,7 @@ components:
           description: Correlation ID linking to the delegation event
         result_type:
           type: string
-          enum: [rca_complete, rca_failed, timeout, cancelled]
+          enum: [rca_complete, rca_failed, timeout, cancelled, escalated]
           description: Type of result received from KA
         investigation_duration_ms:
           type: integer

--- a/api/openapi/data-storage-v1.yaml
+++ b/api/openapi/data-storage-v1.yaml
@@ -7325,7 +7325,7 @@ components:
           description: Correlation ID linking to the delegation event
         result_type:
           type: string
-          enum: [rca_complete, rca_failed, timeout, cancelled, escalated]
+          enum: [rca_complete, rca_failed, timeout, cancelled, operator_escalation, operator_dismissed]
           description: Type of result received from KA
         investigation_duration_ms:
           type: integer

--- a/docs/architecture/decisions/DD-AF-007-escalation-routing.md
+++ b/docs/architecture/decisions/DD-AF-007-escalation-routing.md
@@ -76,7 +76,7 @@ Console "Escalate" button click
 |-------|-------|
 | `rr_id` | The remediation request ID |
 | `status` | `"completed_no_action"` or `"escalated"` |
-| `result_type` | `"completed"` or `"escalated"` |
+| `result_type` | `"operator_dismissed"` or `"operator_escalation"` |
 | `delegation_type` | `"interactive"` |
 | `tool_outcome` | `"success"` |
 | `reason` | Dismiss reason (if provided) |

--- a/docs/tests/1418/TEST_PLAN.md
+++ b/docs/tests/1418/TEST_PLAN.md
@@ -47,7 +47,7 @@
 | ID | Scenario | Method | Expected | FedRAMP |
 |----|----------|--------|----------|---------|
 | IT-AF-1418-001 | Dismiss path through MCP proxy | MCP tools/call (no escalation_reason) | status="completed_no_action" | — |
-| IT-AF-1418-002 | Escalation path through MCP proxy (with audit) | MCP tools/call (with escalation_reason) | status="escalated", audit event emitted with full detail | AU-2 |
+| IT-AF-1418-002 | Escalation path through MCP proxy (with audit) | MCP tools/call (with escalation_reason) | status="escalated", audit event emitted with result_type="operator_escalation" | AU-2 |
 | IT-AF-1418-003 | RBAC denial for unauthorized user | MCP tools/call (no SAR grant) | MCP error response | AC-6 |
 | IT-AF-1418-004 | mcpClient error propagation | MCP tools/call (mock returns error) | Error propagated, no audit event | — |
 

--- a/internal/controller/aianalysis/phase_handlers.go
+++ b/internal/controller/aianalysis/phase_handlers.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
 
@@ -150,6 +151,13 @@ func (r *AIAnalysisReconciler) reconcileInvestigating(ctx context.Context, analy
 
 			return nil
 		}); err != nil {
+			if apierrors.IsInvalid(err) {
+				log.Error(err, "CRD schema rejected status update — fail-close, will not retry",
+					"name", analysis.Name)
+				r.Recorder.Event(analysis, corev1.EventTypeWarning, "SchemaValidationFailed",
+					fmt.Sprintf("Status update permanently rejected by CRD schema: %v", err))
+				return ctrl.Result{}, nil
+			}
 			log.Error(err, "Failed to atomically update status after Investigating phase")
 			return ctrl.Result{}, err
 		}
@@ -233,6 +241,13 @@ func (r *AIAnalysisReconciler) reconcileAnalyzing(ctx context.Context, analysis 
 
 			return nil
 		}); err != nil {
+			if apierrors.IsInvalid(err) {
+				log.Error(err, "CRD schema rejected status update — fail-close, will not retry",
+					"name", analysis.Name)
+				r.Recorder.Event(analysis, corev1.EventTypeWarning, "SchemaValidationFailed",
+					fmt.Sprintf("Status update permanently rejected by CRD schema: %v", err))
+				return ctrl.Result{}, nil
+			}
 			log.Error(err, "Failed to atomically update status after Analyzing phase")
 			return ctrl.Result{}, err
 		}

--- a/pkg/aianalysis/handlers/interfaces.go
+++ b/pkg/aianalysis/handlers/interfaces.go
@@ -119,6 +119,10 @@ type InvestigationSessionChecker interface {
 	// HasActiveSession returns true if an InvestigationSession CRD exists
 	// with spec.remediationRequestRef.name matching the given rrName.
 	HasActiveSession(ctx context.Context, rrName string) (bool, error)
+	// FindSessionPhase returns the phase of any IS CRD for the RR, regardless of
+	// terminal state. Returns ("", false, nil) if no IS exists at all.
+	// Used to distinguish "IS deleted" from "IS in terminal phase" in cancel handling.
+	FindSessionPhase(ctx context.Context, rrName string) (isv1alpha1.SessionPhase, bool, error)
 }
 
 // ISPhaseUpdater transitions an InvestigationSession CRD phase. AA uses this

--- a/pkg/aianalysis/handlers/investigating.go
+++ b/pkg/aianalysis/handlers/investigating.go
@@ -424,7 +424,7 @@ func (h *InvestigatingHandler) checkISMismatchAndCancel(ctx context.Context, ana
 
 	case !hasIS && session.Interactive:
 		// IS disappeared after interactive submit → cancel (user removed session)
-		h.log.Info("IS CRD removed for interactive session — cancelling investigation",
+		h.log.Info("IS CRD no longer active for interactive session — cancelling investigation",
 			"sessionID", session.ID, "rrName", rrName)
 		if cancelErr := h.kaClient.CancelSession(ctx, session.ID); cancelErr != nil {
 			h.log.Error(cancelErr, "Failed to cancel session for IS deletion; will retry", "sessionID", session.ID)
@@ -829,6 +829,21 @@ func (h *InvestigatingHandler) handleSessionPollCancelled(ctx context.Context, a
 				analysis.Status.KASession.ID = ""
 				return ctrl.Result{Requeue: true}, nil
 			}
+
+			// No active IS — distinguish "IS deleted" from "IS in terminal phase"
+			phase, exists, phaseErr := h.isChecker.FindSessionPhase(ctx, rrName)
+			if phaseErr != nil {
+				h.log.Error(phaseErr, "Failed to check IS phase during cancellation, requeuing",
+					"rrName", rrName)
+				return ctrl.Result{RequeueAfter: h.sessionPollInterval}, nil
+			}
+			if exists && phase == isv1alpha1.SessionPhaseCompleted {
+				// IS completed but KA session cancelled (race) — fetch the result
+				h.log.Info("IS completed but KA session cancelled (race condition) — fetching result",
+					"rrName", rrName, "phase", phase)
+				return h.handleSessionPollCompleted(ctx, analysis)
+			}
+			// IS deleted or IS in Cancelled/Failed phase → user/system ended session
 		}
 	}
 
@@ -837,9 +852,9 @@ func (h *InvestigatingHandler) handleSessionPollCancelled(ctx context.Context, a
 	analysis.Status.Reason = aianalysisv1.ReasonInteractiveCancelled
 	analysis.Status.CompletedAt = &now
 	analysis.Status.ObservedGeneration = analysis.Generation
-	analysis.Status.Message = "Investigation cancelled (interactive session removed)"
+	analysis.Status.Message = "Investigation cancelled (interactive session ended)"
 
-	cancelErr := fmt.Errorf("KA session cancelled: interactive session deleted")
+	cancelErr := fmt.Errorf("KA session cancelled: interactive session ended")
 	if auditErr := h.auditClient.RecordAnalysisFailed(ctx, analysis, cancelErr); auditErr != nil {
 		h.log.V(1).Info("Failed to record cancellation audit", "error", auditErr)
 	}

--- a/pkg/aianalysis/handlers/is_checker.go
+++ b/pkg/aianalysis/handlers/is_checker.go
@@ -93,6 +93,29 @@ const ISFieldIndexRRName = "spec.remediationRequestRef.name"
 // Compile-time interface assertion.
 var _ InvestigationSessionChecker = (*K8sInvestigationSessionChecker)(nil)
 
+// FindSessionPhase returns the phase of any InvestigationSession CRD for the given
+// RR name, regardless of whether it is active or terminal. Returns ("", false, nil)
+// if no IS exists at all. Used by handleSessionPollCancelled to distinguish "IS
+// deleted" (user cancelled) from "IS in terminal phase" (completion race).
+func (k *K8sInvestigationSessionChecker) FindSessionPhase(ctx context.Context, rrName string) (isv1alpha1.SessionPhase, bool, error) {
+	if rrName == "" {
+		return "", false, nil
+	}
+
+	var list isv1alpha1.InvestigationSessionList
+	if err := k.reader.List(ctx, &list,
+		client.InNamespace(k.namespace),
+		client.MatchingFields{ISFieldIndexRRName: rrName},
+	); err != nil {
+		return "", false, fmt.Errorf("list InvestigationSessions for RR %s: %w", rrName, err)
+	}
+
+	if len(list.Items) == 0 {
+		return "", false, nil
+	}
+	return list.Items[0].Status.Phase, true, nil
+}
+
 // K8sISPhaseUpdater implements ISPhaseUpdater by updating InvestigationSession
 // CRD status via the controller-runtime client. AA calls SetActivePhase after
 // submitting to KA with interactive=true to signal AF that the session is ready.

--- a/pkg/aianalysis/investigating_handler_session_test.go
+++ b/pkg/aianalysis/investigating_handler_session_test.go
@@ -18,6 +18,7 @@ package aianalysis_test
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
@@ -1125,16 +1126,141 @@ var _ = Describe("InvestigatingHandler Canonical Plan Tests [BR-INTERACTIVE-010]
 			Expect(analysis.Status.Message).To(ContainSubstring("cancelled"))
 		})
 	})
+
+	Context("UT-AA-1455-001: Poll 'cancelled' + IS completed (race) → fetch result [#1455]", func() {
+		It("should fetch the session result when IS completed but KA session was cancelled", func() {
+			raceClient := mocks.NewMockAgentClient()
+			raceClient.WithSessionPollStatus("cancelled")
+			isChecker := &mockISChecker{
+				hasSession:    false,
+				sessionPhase:  isv1alpha1.SessionPhaseCompleted,
+				sessionExists: true,
+			}
+			testMetrics := metrics.NewMetrics()
+			h := handlers.NewInvestigatingHandler(raceClient, ctrl.Log.WithName("test-1455-race"), testMetrics, auditSpy,
+				handlers.WithSessionMode(), handlers.WithRecorder(recorder),
+				handlers.WithInvestigationSessionChecker(isChecker))
+
+			now := metav1.Now()
+			analysis := &aianalysisv1.AIAnalysis{
+				Spec: aianalysisv1.AIAnalysisSpec{
+					RemediationRequestRef: corev1.ObjectReference{Name: "rr-1455-race", Namespace: "default"},
+				},
+				Status: aianalysisv1.AIAnalysisStatus{
+					Phase: aianalysis.PhaseInvestigating,
+					KASession: &aianalysisv1.KASession{
+						ID:        "session-1455-race",
+						CreatedAt: &now,
+						PollCount: 5,
+					},
+				},
+			}
+
+			result, err := h.Handle(ctx, analysis)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(raceClient.GetResultCallCount).To(BeNumerically(">=", 1),
+				"#1455: must call GetSessionResult to retrieve the completed investigation")
+			Expect(analysis.Status.Phase).NotTo(Equal(aianalysis.PhaseFailed),
+				"#1455: IS-completed race must not produce PhaseFailed — result should be processed")
+			Expect(result.RequeueAfter).To(BeZero(),
+				"completed result processing should not requeue")
+		})
+	})
+
+	Context("UT-AA-1455-002: Poll 'cancelled' + FindSessionPhase error → requeue [#1455]", func() {
+		It("should requeue when FindSessionPhase returns a transient error", func() {
+			errClient := mocks.NewMockAgentClient()
+			errClient.WithSessionPollStatus("cancelled")
+			isChecker := &mockISChecker{
+				hasSession:   false,
+				findPhaseErr: fmt.Errorf("transient API server error"),
+			}
+			testMetrics := metrics.NewMetrics()
+			h := handlers.NewInvestigatingHandler(errClient, ctrl.Log.WithName("test-1455-phase-err"), testMetrics, auditSpy,
+				handlers.WithSessionMode(), handlers.WithRecorder(recorder),
+				handlers.WithInvestigationSessionChecker(isChecker))
+
+			now := metav1.Now()
+			analysis := &aianalysisv1.AIAnalysis{
+				Spec: aianalysisv1.AIAnalysisSpec{
+					RemediationRequestRef: corev1.ObjectReference{Name: "rr-1455-phase-err", Namespace: "default"},
+				},
+				Status: aianalysisv1.AIAnalysisStatus{
+					Phase: aianalysis.PhaseInvestigating,
+					KASession: &aianalysisv1.KASession{
+						ID:        "session-1455-phase-err",
+						CreatedAt: &now,
+						PollCount: 3,
+					},
+				},
+			}
+
+			result, err := h.Handle(ctx, analysis)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(Equal(handlers.DefaultSessionPollInterval),
+				"#1455: transient FindSessionPhase error must requeue, not produce terminal state")
+			Expect(analysis.Status.Phase).To(Equal(aianalysis.PhaseInvestigating),
+				"phase must remain Investigating during transient error")
+		})
+	})
+
+	Context("UT-AA-1455-003: Poll 'cancelled' + IS in Failed phase → PhaseFailed [#1455]", func() {
+		It("should transition to PhaseFailed when IS is in a non-completed terminal phase", func() {
+			failClient := mocks.NewMockAgentClient()
+			failClient.WithSessionPollStatus("cancelled")
+			isChecker := &mockISChecker{
+				hasSession:    false,
+				sessionPhase:  isv1alpha1.SessionPhaseFailed,
+				sessionExists: true,
+			}
+			testMetrics := metrics.NewMetrics()
+			h := handlers.NewInvestigatingHandler(failClient, ctrl.Log.WithName("test-1455-is-failed"), testMetrics, auditSpy,
+				handlers.WithSessionMode(), handlers.WithRecorder(recorder),
+				handlers.WithInvestigationSessionChecker(isChecker))
+
+			now := metav1.Now()
+			analysis := &aianalysisv1.AIAnalysis{
+				Spec: aianalysisv1.AIAnalysisSpec{
+					RemediationRequestRef: corev1.ObjectReference{Name: "rr-1455-is-failed", Namespace: "default"},
+				},
+				Status: aianalysisv1.AIAnalysisStatus{
+					Phase: aianalysis.PhaseInvestigating,
+					KASession: &aianalysisv1.KASession{
+						ID:        "session-1455-is-failed",
+						CreatedAt: &now,
+						PollCount: 4,
+					},
+				},
+			}
+
+			result, err := h.Handle(ctx, analysis)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeZero(), "terminal state should not requeue")
+			Expect(analysis.Status.Phase).To(Equal(aianalysis.PhaseFailed),
+				"#1455: IS in Failed phase (not Completed) must produce terminal PhaseFailed")
+			Expect(analysis.Status.Reason).To(Equal(aianalysisv1.ReasonInteractiveCancelled))
+		})
+	})
 })
 
 // mockISChecker implements handlers.InvestigationSessionChecker for testing.
 type mockISChecker struct {
-	hasSession bool
-	err        error
+	hasSession    bool
+	err           error
+	sessionPhase  isv1alpha1.SessionPhase
+	sessionExists bool
+	findPhaseErr  error
 }
 
 func (m *mockISChecker) HasActiveSession(_ context.Context, _ string) (bool, error) {
 	return m.hasSession, m.err
+}
+
+func (m *mockISChecker) FindSessionPhase(_ context.Context, _ string) (isv1alpha1.SessionPhase, bool, error) {
+	if m.findPhaseErr != nil {
+		return "", false, m.findPhaseErr
+	}
+	return m.sessionPhase, m.sessionExists, m.err
 }
 
 // ========================================

--- a/pkg/apifrontend/handler/mcp_bridge_integration_test.go
+++ b/pkg/apifrontend/handler/mcp_bridge_integration_test.go
@@ -947,7 +947,7 @@ var _ = Describe("kubernaut_complete_no_action — AF MCP bridge proxy (#1418)",
 			evt := kaResultEvents[0]
 			Expect(evt.Detail).To(HaveKeyWithValue("rr_id", "rr-1418-it-002"))
 			Expect(evt.Detail).To(HaveKeyWithValue("status", "escalated"))
-			Expect(evt.Detail).To(HaveKeyWithValue("result_type", "escalated"))
+			Expect(evt.Detail).To(HaveKeyWithValue("result_type", "operator_escalation"))
 			Expect(evt.Detail).To(HaveKeyWithValue("delegation_type", "interactive"))
 			Expect(evt.Detail).To(HaveKeyWithValue("tool_outcome", "success"))
 			Expect(evt.Detail).To(HaveKeyWithValue("escalation_reason", "Needs SRE team"))

--- a/pkg/apifrontend/tools/ka_tools.go
+++ b/pkg/apifrontend/tools/ka_tools.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/audit"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/validate"
+	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
 )
 
 // WorkflowParameter describes a single input parameter for a workflow.
@@ -394,9 +395,9 @@ func HandleCompleteNoAction(ctx context.Context, mcpClient ka.MCPClient, args Co
 	}
 
 	if auditor != nil {
-		resultType := "completed"
+		resultType := string(ogenclient.ApifrontendKAResultReceivedPayloadResultTypeOperatorDismissed)
 		if args.EscalationReason != "" {
-			resultType = "escalated"
+			resultType = string(ogenclient.ApifrontendKAResultReceivedPayloadResultTypeOperatorEscalation)
 		}
 		detail := map[string]string{
 			"rr_id":           args.RRID,

--- a/pkg/audit/openapi_spec_data.yaml
+++ b/pkg/audit/openapi_spec_data.yaml
@@ -7325,7 +7325,7 @@ components:
           description: Correlation ID linking to the delegation event
         result_type:
           type: string
-          enum: [rca_complete, rca_failed, timeout, cancelled]
+          enum: [rca_complete, rca_failed, timeout, cancelled, operator_escalation, operator_dismissed]
           description: Type of result received from KA
         investigation_duration_ms:
           type: integer

--- a/pkg/datastorage/ogen-client/oas_json_gen.go
+++ b/pkg/datastorage/ogen-client/oas_json_gen.go
@@ -11553,6 +11553,10 @@ func (s *ApifrontendKAResultReceivedPayloadResultType) Decode(d *jx.Decoder) err
 		*s = ApifrontendKAResultReceivedPayloadResultTypeTimeout
 	case ApifrontendKAResultReceivedPayloadResultTypeCancelled:
 		*s = ApifrontendKAResultReceivedPayloadResultTypeCancelled
+	case ApifrontendKAResultReceivedPayloadResultTypeOperatorEscalation:
+		*s = ApifrontendKAResultReceivedPayloadResultTypeOperatorEscalation
+	case ApifrontendKAResultReceivedPayloadResultTypeOperatorDismissed:
+		*s = ApifrontendKAResultReceivedPayloadResultTypeOperatorDismissed
 	default:
 		*s = ApifrontendKAResultReceivedPayloadResultType(v)
 	}

--- a/pkg/datastorage/ogen-client/oas_schemas_gen.go
+++ b/pkg/datastorage/ogen-client/oas_schemas_gen.go
@@ -5641,10 +5641,12 @@ func (s *ApifrontendKAResultReceivedPayloadEventType) UnmarshalText(data []byte)
 type ApifrontendKAResultReceivedPayloadResultType string
 
 const (
-	ApifrontendKAResultReceivedPayloadResultTypeRcaComplete ApifrontendKAResultReceivedPayloadResultType = "rca_complete"
-	ApifrontendKAResultReceivedPayloadResultTypeRcaFailed   ApifrontendKAResultReceivedPayloadResultType = "rca_failed"
-	ApifrontendKAResultReceivedPayloadResultTypeTimeout     ApifrontendKAResultReceivedPayloadResultType = "timeout"
-	ApifrontendKAResultReceivedPayloadResultTypeCancelled   ApifrontendKAResultReceivedPayloadResultType = "cancelled"
+	ApifrontendKAResultReceivedPayloadResultTypeRcaComplete        ApifrontendKAResultReceivedPayloadResultType = "rca_complete"
+	ApifrontendKAResultReceivedPayloadResultTypeRcaFailed          ApifrontendKAResultReceivedPayloadResultType = "rca_failed"
+	ApifrontendKAResultReceivedPayloadResultTypeTimeout            ApifrontendKAResultReceivedPayloadResultType = "timeout"
+	ApifrontendKAResultReceivedPayloadResultTypeCancelled          ApifrontendKAResultReceivedPayloadResultType = "cancelled"
+	ApifrontendKAResultReceivedPayloadResultTypeOperatorEscalation ApifrontendKAResultReceivedPayloadResultType = "operator_escalation"
+	ApifrontendKAResultReceivedPayloadResultTypeOperatorDismissed  ApifrontendKAResultReceivedPayloadResultType = "operator_dismissed"
 )
 
 // AllValues returns all ApifrontendKAResultReceivedPayloadResultType values.
@@ -5654,6 +5656,8 @@ func (ApifrontendKAResultReceivedPayloadResultType) AllValues() []ApifrontendKAR
 		ApifrontendKAResultReceivedPayloadResultTypeRcaFailed,
 		ApifrontendKAResultReceivedPayloadResultTypeTimeout,
 		ApifrontendKAResultReceivedPayloadResultTypeCancelled,
+		ApifrontendKAResultReceivedPayloadResultTypeOperatorEscalation,
+		ApifrontendKAResultReceivedPayloadResultTypeOperatorDismissed,
 	}
 }
 
@@ -5667,6 +5671,10 @@ func (s ApifrontendKAResultReceivedPayloadResultType) MarshalText() ([]byte, err
 	case ApifrontendKAResultReceivedPayloadResultTypeTimeout:
 		return []byte(s), nil
 	case ApifrontendKAResultReceivedPayloadResultTypeCancelled:
+		return []byte(s), nil
+	case ApifrontendKAResultReceivedPayloadResultTypeOperatorEscalation:
+		return []byte(s), nil
+	case ApifrontendKAResultReceivedPayloadResultTypeOperatorDismissed:
 		return []byte(s), nil
 	default:
 		return nil, errors.Errorf("invalid value: %q", s)
@@ -5687,6 +5695,12 @@ func (s *ApifrontendKAResultReceivedPayloadResultType) UnmarshalText(data []byte
 		return nil
 	case ApifrontendKAResultReceivedPayloadResultTypeCancelled:
 		*s = ApifrontendKAResultReceivedPayloadResultTypeCancelled
+		return nil
+	case ApifrontendKAResultReceivedPayloadResultTypeOperatorEscalation:
+		*s = ApifrontendKAResultReceivedPayloadResultTypeOperatorEscalation
+		return nil
+	case ApifrontendKAResultReceivedPayloadResultTypeOperatorDismissed:
+		*s = ApifrontendKAResultReceivedPayloadResultTypeOperatorDismissed
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)

--- a/pkg/datastorage/ogen-client/oas_validators_gen.go
+++ b/pkg/datastorage/ogen-client/oas_validators_gen.go
@@ -2285,6 +2285,10 @@ func (s ApifrontendKAResultReceivedPayloadResultType) Validate() error {
 		return nil
 	case "cancelled":
 		return nil
+	case "operator_escalation":
+		return nil
+	case "operator_dismissed":
+		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)
 	}

--- a/pkg/datastorage/server/middleware/openapi_spec_data.yaml
+++ b/pkg/datastorage/server/middleware/openapi_spec_data.yaml
@@ -7325,7 +7325,7 @@ components:
           description: Correlation ID linking to the delegation event
         result_type:
           type: string
-          enum: [rca_complete, rca_failed, timeout, cancelled]
+          enum: [rca_complete, rca_failed, timeout, cancelled, operator_escalation, operator_dismissed]
           description: Type of result received from KA
         investigation_duration_ms:
           type: integer

--- a/test/e2e/fullpipeline/13_escalation_lifecycle_test.go
+++ b/test/e2e/fullpipeline/13_escalation_lifecycle_test.go
@@ -68,6 +68,26 @@ var _ = Describe("Escalation Lifecycle [#1456 / FedRAMP IR-5, SI-4]", Label("e2e
 		Expect(result.IsError).To(BeFalse(), "start should succeed")
 		GinkgoWriter.Printf("  Investigation started: %s\n", infrastructure.ExtractToolResultText(result))
 
+		By("Step 3b: Waiting for AA controller to submit autonomous investigation to KA")
+		var aaName string
+		Eventually(func(g Gomega) {
+			aaList := &aianalysisv1.AIAnalysisList{}
+			g.Expect(apiReader.List(testCtx, aaList, client.InNamespace(namespace))).To(Succeed())
+			for _, aa := range aaList.Items {
+				if aa.Spec.RemediationRequestRef.Name == rrName {
+					g.Expect(aa.Status.KASession).NotTo(BeNil(),
+						"AA must have KASession before escalation")
+					g.Expect(aa.Status.KASession.ID).NotTo(BeEmpty(),
+						"KASession.ID must be populated (investigation submitted to KA)")
+					aaName = aa.Name
+					GinkgoWriter.Printf("  AA %s has KASession.ID=%s\n", aa.Name, aa.Status.KASession.ID)
+					return
+				}
+			}
+			g.Expect(false).To(BeTrue(), "AA for RR %s not found yet", rrName)
+		}, 90*time.Second, 2*time.Second).Should(Succeed())
+		GinkgoWriter.Printf("  AA %s investigation submitted, safe to escalate\n", aaName)
+
 		By("Step 4: Calling kubernaut_complete_no_action with escalation_reason")
 		cnaCtx, cnaCancel := context.WithTimeout(testCtx, 30*time.Second)
 		defer cnaCancel()

--- a/test/e2e/fullpipeline/13_escalation_lifecycle_test.go
+++ b/test/e2e/fullpipeline/13_escalation_lifecycle_test.go
@@ -47,8 +47,8 @@ var _ = Describe("Escalation Lifecycle [#1456 / FedRAMP IR-5, SI-4]", Label("e2e
 		testCtx, testCancel := context.WithTimeout(ctx, 3*time.Minute)
 		defer testCancel()
 
-		By("Step 1: Creating direct RR")
-		rrName, err := infrastructure.CreateDirectRR(testCtx, namespace, "fp-e2e-1456")
+		By("Step 1: Creating direct RR with slow signal (keeps KA session alive for MCP escalation)")
+		rrName, err := infrastructure.CreateDirectRRWithSignal(testCtx, namespace, "fp-e2e-1456", "slow-investigation-test")
 		Expect(err).NotTo(HaveOccurred())
 		GinkgoWriter.Printf("  RR created: %s\n", rrName)
 

--- a/test/e2e/fullpipeline/suite_test.go
+++ b/test/e2e/fullpipeline/suite_test.go
@@ -345,6 +345,12 @@ var _ = SynchronizedAfterSuite(
 			infrastructure.MustGatherPodLogs(clusterName, kp, "kubernaut-workflows", "fullpipeline", GinkgoWriter)
 		}
 
+		// Clean up all test-created CRs and namespaces so the cluster
+		// is ready for a retry run. Must-gather has already collected logs.
+		if !setupFailed {
+			infrastructure.CleanupFullPipelineTestResources(kubeconfigPath, GinkgoWriter)
+		}
+
 		// DD-TEST-007: Collect coverage before cluster deletion
 		if os.Getenv("E2E_COVERAGE") == "true" && !setupFailed {
 			// Collect coverage for each Go controller service

--- a/test/infrastructure/fullpipeline_e2e.go
+++ b/test/infrastructure/fullpipeline_e2e.go
@@ -595,6 +595,58 @@ func SetupFullPipelineInfrastructure(ctx context.Context, clusterName, kubeconfi
 	return builtImages, seededUUIDs, afRemediateNS, nil
 }
 
+// CleanupFullPipelineTestResources deletes all kubernaut CR instances and
+// test namespaces, leaving the cluster with deployed services but no test
+// state. This is called from SynchronizedAfterSuite so retries start clean.
+func CleanupFullPipelineTestResources(kubeconfigPath string, writer io.Writer) {
+	_, _ = fmt.Fprintln(writer, "\n🧹 Cleaning up test-created resources...")
+
+	crdKinds := []string{
+		"remediationrequests.kubernaut.ai",
+		"remediationapprovalrequests.kubernaut.ai",
+		"aianalyses.kubernaut.ai",
+		"signalprocessings.kubernaut.ai",
+		"workflowexecutions.kubernaut.ai",
+		"notificationrequests.kubernaut.ai",
+		"effectivenessassessments.kubernaut.ai",
+		"investigationsessions.kubernaut.ai",
+	}
+
+	for _, kind := range crdKinds {
+		cmd := exec.Command("kubectl", "--kubeconfig", kubeconfigPath,
+			"delete", kind, "--all-namespaces", "--all", "--ignore-not-found", "--wait=false")
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			_, _ = fmt.Fprintf(writer, "  ⚠️  %s cleanup: %s\n", kind, strings.TrimSpace(string(out)))
+		} else {
+			trimmed := strings.TrimSpace(string(out))
+			if trimmed != "" && trimmed != "No resources found" {
+				_, _ = fmt.Fprintf(writer, "  🗑️  %s: %s\n", kind, trimmed)
+			}
+		}
+	}
+
+	// Delete test namespaces matching known patterns (fp-am-*, fp-event-*)
+	nsCmd := exec.Command("kubectl", "--kubeconfig", kubeconfigPath,
+		"get", "namespaces", "-o", "jsonpath={.items[*].metadata.name}")
+	nsOut, err := nsCmd.Output()
+	if err == nil {
+		for _, ns := range strings.Fields(string(nsOut)) {
+			if strings.HasPrefix(ns, "fp-am-") || strings.HasPrefix(ns, "fp-event-") {
+				delCmd := exec.Command("kubectl", "--kubeconfig", kubeconfigPath,
+					"delete", "namespace", ns, "--ignore-not-found", "--wait=false")
+				if delOut, delErr := delCmd.CombinedOutput(); delErr != nil {
+					_, _ = fmt.Fprintf(writer, "  ⚠️  namespace %s: %s\n", ns, strings.TrimSpace(string(delOut)))
+				} else {
+					_, _ = fmt.Fprintf(writer, "  🗑️  namespace %s deleted\n", ns)
+				}
+			}
+		}
+	}
+
+	_, _ = fmt.Fprintln(writer, "✅ Test resource cleanup complete")
+}
+
 // ============================================================================
 // PHASE 1: Image Building (3 at a time concurrency for local builds)
 // ============================================================================

--- a/test/infrastructure/kind_cluster_helpers.go
+++ b/test/infrastructure/kind_cluster_helpers.go
@@ -85,6 +85,17 @@ func CreateKindClusterWithExtraMounts(
 	}
 	_, _ = fmt.Fprintf(writer, "  ✅ Kind version validated: %s", versionStr)
 
+	// 0b. Reuse existing cluster if present (idempotent retry support).
+	// When --flake-attempts or CI retry re-runs the suite, the cluster from
+	// the failed attempt is still alive. Reuse it so cascade failures remain
+	// visible — cleaning up would mask correlations between tests.
+	checkCmd := exec.Command("kind", "get", "clusters")
+	checkOutput, _ := checkCmd.CombinedOutput()
+	if strings.Contains(string(checkOutput), clusterName) {
+		_, _ = fmt.Fprintf(writer, "  ♻️  Cluster %s already exists, reusing (retry-safe)\n", clusterName)
+		return exportKubeconfigIfNeeded(clusterName, kubeconfigPath, writer)
+	}
+
 	// 1. Find workspace root
 	workspaceRoot, err := findWorkspaceRoot()
 	if err != nil {

--- a/test/infrastructure/mcp_e2e_helpers.go
+++ b/test/infrastructure/mcp_e2e_helpers.go
@@ -234,6 +234,17 @@ rules:
 // Returns the RR name. A managed namespace is created for the target resource so
 // that the RO routing engine does not block the RR as UnmanagedResource.
 func CreateDirectRR(ctx context.Context, namespace, testID string) (string, error) {
+	return CreateDirectRRWithSignal(ctx, namespace, testID, "")
+}
+
+// CreateDirectRRWithSignal is like CreateDirectRR but lets the caller specify a
+// mock-LLM signal name. When signalName is empty, defaults to "e2e-<testID>-signal".
+// Use "slow-investigation-test" to keep the KA session alive for tests that need
+// to interact with it via MCP before completion.
+func CreateDirectRRWithSignal(ctx context.Context, namespace, testID, signalName string) (string, error) {
+	if signalName == "" {
+		signalName = fmt.Sprintf("e2e-%s-signal", testID)
+	}
 	rrName := fmt.Sprintf("rr-%s-%d", testID, time.Now().UnixMilli())
 	fingerprint := fmt.Sprintf("%x", sha256.Sum256([]byte(testID+"-"+rrName)))
 	now := metav1.Now()
@@ -277,7 +288,7 @@ func CreateDirectRR(ctx context.Context, namespace, testID string) (string, erro
 			},
 			"spec": map[string]interface{}{
 				"signalFingerprint": fingerprint,
-				"signalName":        fmt.Sprintf("e2e-%s-signal", testID),
+				"signalName":        signalName,
 				"signalType":        "alert",
 				"severity":          "high",
 				"targetType":        "kubernetes",

--- a/test/integration/aianalysis/escalation_wiring_test.go
+++ b/test/integration/aianalysis/escalation_wiring_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Issue #1449: Proves the full escalation wiring path through the reconciler.
+// Unlike IT-AA-1449-001 (which only proves the CRD API server accepts the enum),
+// this test proves the complete production dispatch: KA result with
+// operator_escalation → ResponseProcessor → CRD status with all escalation fields.
+package aianalysis
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sretry "k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	aianalysisv1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis"
+	aiaudit "github.com/jordigilh/kubernaut/pkg/aianalysis/audit"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis/handlers"
+	sharedtypes "github.com/jordigilh/kubernaut/pkg/shared/types"
+	"github.com/jordigilh/kubernaut/test/shared/helpers"
+	"github.com/jordigilh/kubernaut/test/shared/mocks"
+)
+
+var _ = Describe("Escalation Wiring (#1449)", Label("integration", "escalation", "wiring"), Serial, func() {
+	const (
+		timeout  = 30 * time.Second
+		interval = 200 * time.Millisecond
+	)
+
+	var (
+		savedHandler *handlers.InvestigatingHandler
+		mockClient   *mocks.MockAgentClient
+	)
+
+	BeforeEach(func() {
+		savedHandler = reconciler.InvestigatingHandler.Load()
+		mockClient = mocks.NewMockAgentClient()
+		mockClient.WithSessionPollStatus("completed")
+		mockClient.WithHumanReviewReasonEnum("operator_escalation", nil)
+
+		auditClient := aiaudit.NewAuditClient(auditStore, ctrl.Log.WithName("escalation-wiring-test-audit"))
+		isChecker := handlers.NewK8sInvestigationSessionChecker(k8sClient, testNamespace)
+		reconciler.InvestigatingHandler.Store(handlers.NewInvestigatingHandler(
+			mockClient,
+			ctrl.Log.WithName("escalation-wiring-mock-handler"),
+			testMetrics,
+			auditClient,
+			handlers.WithSessionMode(),
+			handlers.WithSessionPollInterval(1*time.Second),
+			handlers.WithInvestigationSessionChecker(isChecker),
+			handlers.WithRecorder(k8sManager.GetEventRecorderFor("aianalysis-controller")),
+		))
+	})
+
+	AfterEach(func() {
+		if savedHandler != nil {
+			reconciler.InvestigatingHandler.Store(savedHandler)
+		}
+	})
+
+	It("IT-AA-1449-003: KA operator_escalation result flows through reconciler to CRD status (BR-HAPI-197)", func() {
+		rrName := helpers.UniqueTestName("rr-1449-wiring")
+		aaName := helpers.UniqueTestName("aa-1449-wiring")
+		sessionID := "session-1449-escalation-wiring"
+
+		By("creating Investigating AA with active KA session")
+		analysis := &aianalysisv1.AIAnalysis{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      aaName,
+				Namespace: testNamespace,
+			},
+			Spec: aianalysisv1.AIAnalysisSpec{
+				RemediationRequestRef: corev1.ObjectReference{
+					Name:      rrName,
+					Namespace: testNamespace,
+				},
+				RemediationID: rrName,
+				AnalysisRequest: aianalysisv1.AnalysisRequest{
+					SignalContext: aianalysisv1.SignalContextInput{
+						Fingerprint:      "fp-escalation-wiring",
+						Severity:         "critical",
+						SignalName:       "OperatorEscalationWiringTest",
+						Environment:      "staging",
+						BusinessPriority: "P1",
+						TargetResource: aianalysisv1.TargetResource{
+							Kind:      "Deployment",
+							Name:      "test-deploy",
+							Namespace: testNamespace,
+						},
+						EnrichmentResults: sharedtypes.EnrichmentResults{},
+					},
+					AnalysisTypes: []aianalysisv1.AnalysisType{aianalysisv1.AnalysisTypeInvestigation},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, analysis)).To(Succeed())
+
+		Expect(k8sretry.RetryOnConflict(k8sretry.DefaultRetry, func() error {
+			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), analysis); err != nil {
+				return err
+			}
+			now := metav1.Now()
+			analysis.Status.Phase = aianalysisv1.PhaseInvestigating
+			analysis.Status.KASession = &aianalysisv1.KASession{
+				ID:          sessionID,
+				Interactive: false,
+				CreatedAt:   &now,
+			}
+			return k8sClient.Status().Update(ctx, analysis)
+		})).To(Succeed())
+
+		By("waiting for reconciler to process KA result through ResponseProcessor")
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), analysis)).To(Succeed())
+			g.Expect(analysis.Status.Phase).To(Equal(aianalysis.PhaseFailed),
+				"Phase must transition to Failed for operator escalation")
+			g.Expect(analysis.Status.NeedsHumanReview).To(BeTrue(),
+				"NeedsHumanReview must be set by ResponseProcessor")
+			g.Expect(analysis.Status.HumanReviewReason).To(Equal("operator_escalation"),
+				"HumanReviewReason must flow from KA response through ResponseProcessor to CRD status")
+			g.Expect(analysis.Status.SubReason).To(Equal("OperatorEscalation"),
+				"SubReason must be mapped from operator_escalation via mapEnumToSubReason")
+			g.Expect(analysis.Status.Reason).To(Equal(aianalysisv1.ReasonWorkflowResolutionFailed),
+				"Reason must be WorkflowResolutionFailed for escalation path")
+		}, timeout, interval).Should(Succeed(),
+			"IT-AA-1449-003: Full escalation wiring path must work: KA result → reconciler → ResponseProcessor → CRD status")
+
+		By("verifying mock KA client was called (proves wiring through handler)")
+		Expect(mockClient.GetPollCallCount()).To(BeNumerically(">=", 1),
+			"PollSession must have been called at least once by the reconciler")
+	})
+})

--- a/test/integration/aianalysis/interactive_watch_test.go
+++ b/test/integration/aianalysis/interactive_watch_test.go
@@ -390,10 +390,7 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 			isName := helpers.UniqueTestName("is-1376-complete")
 			aaName := helpers.UniqueTestName("aa-1376-complete")
 
-			By("creating Active IS first (guarantees IS exists before investigation completes)")
-			createActiveIS(isName, rrName)
-
-			By("creating Investigating AA (autonomous session starts with IS already present)")
+			By("creating Investigating AA first (autonomous session — no IS yet)")
 			analysis := createInvestigatingAA(aaName, rrName, "", "brief-investigation-test", false)
 
 			By("waiting for real KA session to be established")
@@ -403,20 +400,23 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 				g.Expect(analysis.Status.KASession.ID).NotTo(BeEmpty())
 			}, timeout, interval).Should(Succeed())
 
+			By("creating Active IS mid-investigation (triggers autonomous→interactive upgrade)")
+			createActiveIS(isName, rrName)
+
 			By("verifying IS CRD transitions to Completed (wiring proof)")
 			Eventually(func(g Gomega) {
 				var is isv1alpha1.InvestigationSession
 				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: isName, Namespace: testNamespace}, &is)).To(Succeed())
 				g.Expect(is.Status.Phase).To(Equal(isv1alpha1.SessionPhaseCompleted),
 					"#1376: IS must transition to Completed when KA session completes")
-			}, 10*time.Second, interval).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
 
 			By("verifying AA progresses past Investigating (sanity)")
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), analysis)).To(Succeed())
 				g.Expect(string(analysis.Status.Phase)).NotTo(Equal(string(aianalysisv1.PhaseInvestigating)),
 					"AA should have left Investigating phase after completed poll")
-			}, 10*time.Second, interval).Should(Succeed())
+			}, timeout, interval).Should(Succeed())
 		})
 
 		It("IT-AA-1376-002: IS transitions to Failed when KA session is cancelled [BR-INTERACTIVE-010, #1376]", func() {

--- a/test/integration/aianalysis/interactive_watch_test.go
+++ b/test/integration/aianalysis/interactive_watch_test.go
@@ -390,6 +390,11 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 			isName := helpers.UniqueTestName("is-1376-complete")
 			aaName := helpers.UniqueTestName("aa-1376-complete")
 
+			// brief-investigation-test uses 3s SecondTurnDelay applied across
+			// multiple investigator phases (RCA, workflow_discovery, etc.),
+			// so the full investigation takes ~9-12s.
+			completionTimeout := 25 * time.Second
+
 			By("creating Investigating AA first (autonomous session — no IS yet)")
 			analysis := createInvestigatingAA(aaName, rrName, "", "brief-investigation-test", false)
 
@@ -409,14 +414,14 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: isName, Namespace: testNamespace}, &is)).To(Succeed())
 				g.Expect(is.Status.Phase).To(Equal(isv1alpha1.SessionPhaseCompleted),
 					"#1376: IS must transition to Completed when KA session completes")
-			}, timeout, interval).Should(Succeed())
+			}, completionTimeout, interval).Should(Succeed())
 
 			By("verifying AA progresses past Investigating (sanity)")
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), analysis)).To(Succeed())
 				g.Expect(string(analysis.Status.Phase)).NotTo(Equal(string(aianalysisv1.PhaseInvestigating)),
 					"AA should have left Investigating phase after completed poll")
-			}, timeout, interval).Should(Succeed())
+			}, completionTimeout, interval).Should(Succeed())
 		})
 
 		It("IT-AA-1376-002: IS transitions to Failed when KA session is cancelled [BR-INTERACTIVE-010, #1376]", func() {

--- a/test/integration/aianalysis/interactive_watch_test.go
+++ b/test/integration/aianalysis/interactive_watch_test.go
@@ -390,11 +390,18 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 			isName := helpers.UniqueTestName("is-1376-complete")
 			aaName := helpers.UniqueTestName("aa-1376-complete")
 
-			By("creating Active IS for the RR")
-			createActiveIS(isName, rrName)
+			By("creating Investigating AA first (no IS yet → autonomous session starts immediately)")
+			analysis := createInvestigatingAA(aaName, rrName, "", "brief-investigation-test", false)
 
-			By("creating Investigating AA with resolved signal (mock-LLM produces quick completion)")
-			analysis := createInvestigatingAA(aaName, rrName, "", "MOCK_PROBLEM_RESOLVED", true)
+			By("waiting for real KA session to be established")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), analysis)).To(Succeed())
+				g.Expect(analysis.Status.KASession).NotTo(BeNil())
+				g.Expect(analysis.Status.KASession.ID).NotTo(BeEmpty())
+			}, timeout, interval).Should(Succeed())
+
+			By("creating Active IS for the RR (before investigation completes)")
+			createActiveIS(isName, rrName)
 
 			By("verifying IS CRD transitions to Completed (wiring proof)")
 			Eventually(func(g Gomega) {
@@ -402,14 +409,14 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 				g.Expect(k8sClient.Get(ctx, client.ObjectKey{Name: isName, Namespace: testNamespace}, &is)).To(Succeed())
 				g.Expect(is.Status.Phase).To(Equal(isv1alpha1.SessionPhaseCompleted),
 					"#1376: IS must transition to Completed when KA session completes")
-			}, 30*time.Second, interval).Should(Succeed())
+			}, 10*time.Second, interval).Should(Succeed())
 
 			By("verifying AA progresses past Investigating (sanity)")
 			Eventually(func(g Gomega) {
 				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), analysis)).To(Succeed())
 				g.Expect(string(analysis.Status.Phase)).NotTo(Equal(string(aianalysisv1.PhaseInvestigating)),
 					"AA should have left Investigating phase after completed poll")
-			}, 30*time.Second, interval).Should(Succeed())
+			}, 10*time.Second, interval).Should(Succeed())
 		})
 
 		It("IT-AA-1376-002: IS transitions to Failed when KA session is cancelled [BR-INTERACTIVE-010, #1376]", func() {

--- a/test/integration/aianalysis/interactive_watch_test.go
+++ b/test/integration/aianalysis/interactive_watch_test.go
@@ -390,7 +390,10 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 			isName := helpers.UniqueTestName("is-1376-complete")
 			aaName := helpers.UniqueTestName("aa-1376-complete")
 
-			By("creating Investigating AA first (no IS yet → autonomous session starts immediately)")
+			By("creating Active IS first (guarantees IS exists before investigation completes)")
+			createActiveIS(isName, rrName)
+
+			By("creating Investigating AA (autonomous session starts with IS already present)")
 			analysis := createInvestigatingAA(aaName, rrName, "", "brief-investigation-test", false)
 
 			By("waiting for real KA session to be established")
@@ -399,9 +402,6 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 				g.Expect(analysis.Status.KASession).NotTo(BeNil())
 				g.Expect(analysis.Status.KASession.ID).NotTo(BeEmpty())
 			}, timeout, interval).Should(Succeed())
-
-			By("creating Active IS for the RR (before investigation completes)")
-			createActiveIS(isName, rrName)
 
 			By("verifying IS CRD transitions to Completed (wiring proof)")
 			Eventually(func(g Gomega) {

--- a/test/services/mock-llm/detection_test.go
+++ b/test/services/mock-llm/detection_test.go
@@ -116,12 +116,12 @@ var _ = Describe("Scenario Detection Rules", func() {
 				Expect(result.Scenario.Name()).To(Equal("kubernaut_remediate_cross_ns"),
 					"cross-namespace remediation prompt must match the cross-NS scenario")
 
-				cfgScenario, ok := result.Scenario.(scenarios.ScenarioWithConfig)
-				Expect(ok).To(BeTrue())
-				cfg := cfgScenario.Config()
-				Expect(cfg.ResourceNS).To(Equal(expectedNS),
-					"ResourceNS must be the workload namespace extracted from the prompt, not the default controller namespace")
-				Expect(cfg.ResourceName).To(Equal(expectedName))
+			cfgScenario, ok := result.Scenario.(scenarios.ScenarioWithContextConfig)
+			Expect(ok).To(BeTrue(), "scenario should implement ScenarioWithContextConfig")
+			cfg := cfgScenario.ConfigForContext(ctx)
+			Expect(cfg.ResourceNS).To(Equal(expectedNS),
+				"ResourceNS must be the workload namespace extracted from the prompt, not the default controller namespace")
+			Expect(cfg.ResourceName).To(Equal(expectedName))
 			},
 			Entry("UT-MOCK-1292-001a: single-line prompt with spaces",
 				"cross-namespace remediation for deployment memory-eater in demo-workload namespace",
@@ -137,8 +137,7 @@ var _ = Describe("Scenario Detection Rules", func() {
 				"fp-e2e-1292-1779885620", "memory-eater"),
 		)
 
-		It("UT-MOCK-1292-002: stale extractedNS does not leak across calls when regex fails", func() {
-			// First call succeeds — namespace extracted.
+		It("UT-MOCK-1292-002: regex miss returns base default (no stale state)", func() {
 			ctx1 := &scenarios.DetectionContext{
 				Content:         "cross-namespace remediation for deployment memory-eater in staging namespace",
 				AllText:         "cross-namespace remediation for deployment memory-eater in staging namespace",
@@ -146,10 +145,9 @@ var _ = Describe("Scenario Detection Rules", func() {
 			}
 			r1 := registry.Detect(ctx1)
 			Expect(r1).NotTo(BeNil())
-			cfg1 := r1.Scenario.(scenarios.ScenarioWithConfig).Config()
+			cfg1 := r1.Scenario.(scenarios.ScenarioWithContextConfig).ConfigForContext(ctx1)
 			Expect(cfg1.ResourceNS).To(Equal("staging"))
 
-			// Second call has the keyword but a malformed resource pattern — regex cannot extract NS.
 			ctx2 := &scenarios.DetectionContext{
 				Content:         "cross-namespace remediation — no structured deployment reference here",
 				AllText:         "cross-namespace remediation — no structured deployment reference here",
@@ -158,9 +156,9 @@ var _ = Describe("Scenario Detection Rules", func() {
 			r2 := registry.Detect(ctx2)
 			Expect(r2).NotTo(BeNil())
 			Expect(r2.Scenario.Name()).To(Equal("kubernaut_remediate_cross_ns"))
-			cfg2 := r2.Scenario.(scenarios.ScenarioWithConfig).Config()
+			cfg2 := r2.Scenario.(scenarios.ScenarioWithContextConfig).ConfigForContext(ctx2)
 			Expect(cfg2.ResourceNS).To(Equal("kubernaut-system"),
-				"when regex fails, Config() must return the base default — not a stale value from a prior match")
+				"when regex fails, ConfigForContext() must return the base default")
 		})
 	})
 

--- a/test/services/mock-llm/handlers/gemini.go
+++ b/test/services/mock-llm/handlers/gemini.go
@@ -102,12 +102,11 @@ func (h *handler) handleGemini(w http.ResponseWriter, r *http.Request) {
 		h.tracker.RecordScenario(result.Scenario.Name())
 	}
 
-	scenarioWithCfg, ok := result.Scenario.(scenarios.ScenarioWithConfig)
+	cfg, ok := resolveScenarioConfig(result.Scenario, detCtx)
 	if !ok {
 		writeJSON(w, http.StatusOK, response.BuildGeminiTextResponse(scenarios.MockScenarioConfig{}))
 		return
 	}
-	cfg := scenarioWithCfg.Config()
 
 	resolveGeminiTemplateArgs(req.Contents, &cfg)
 

--- a/test/services/mock-llm/handlers/ollama.go
+++ b/test/services/mock-llm/handlers/ollama.go
@@ -82,8 +82,8 @@ func (h *handler) handleOllama(w http.ResponseWriter, r *http.Request) {
 		ScenarioName: scenarioName, RootCause: "Unable to determine root cause", Severity: "medium",
 	}
 	if result != nil {
-		if s, ok := result.Scenario.(scenarios.ScenarioWithConfig); ok {
-			cfg = s.Config()
+		if resolved, rok := resolveScenarioConfig(result.Scenario, detCtx); rok {
+			cfg = resolved
 			scenarioName = cfg.ScenarioName
 		}
 		h.recordScenarioMetric(scenarioName, result.Method)

--- a/test/services/mock-llm/handlers/openai.go
+++ b/test/services/mock-llm/handlers/openai.go
@@ -87,12 +87,11 @@ func (h *handler) handleOpenAI(w http.ResponseWriter, r *http.Request) {
 		h.tracker.RecordScenario(result.Scenario.Name())
 	}
 
-	scenarioWithCfg, ok := result.Scenario.(scenarios.ScenarioWithConfig)
+	cfg, ok := resolveScenarioConfig(result.Scenario, detCtx)
 	if !ok {
 		writeJSON(w, http.StatusOK, response.BuildTextResponse(model, scenarios.MockScenarioConfig{}))
 		return
 	}
-	cfg := scenarioWithCfg.Config()
 
 	if !cfg.OverrideResource {
 		if res := ctx.ExtractResource(); res.Kind != "" && res.Name != "" {
@@ -318,6 +317,20 @@ func buildDetectionContext(ctx *conversation.Context) *scenarios.DetectionContex
 // isResolvedOutcome returns true when the scenario represents a resolved or
 // non-actionable investigation that should bypass the split submit tools and
 // use a text response so the KA parser handles investigation_outcome routing.
+// resolveScenarioConfig extracts the MockScenarioConfig from a scenario,
+// preferring ScenarioWithContextConfig (thread-safe, request-scoped extraction)
+// over ScenarioWithConfig (shared state). This prevents data races when
+// concurrent requests match the same dynamic scenario instance (#1458).
+func resolveScenarioConfig(s scenarios.Scenario, detCtx *scenarios.DetectionContext) (scenarios.MockScenarioConfig, bool) {
+	if ctxCfg, ok := s.(scenarios.ScenarioWithContextConfig); ok {
+		return ctxCfg.ConfigForContext(detCtx), true
+	}
+	if swc, ok := s.(scenarios.ScenarioWithConfig); ok {
+		return swc.Config(), true
+	}
+	return scenarios.MockScenarioConfig{}, false
+}
+
 func isResolvedOutcome(cfg scenarios.MockScenarioConfig) bool {
 	switch cfg.InvestigationOutcome {
 	case "problem_resolved", "predictive_no_action":

--- a/test/services/mock-llm/handlers/openai.go
+++ b/test/services/mock-llm/handlers/openai.go
@@ -226,6 +226,15 @@ func (h *handler) handleFullDAG(
 		return
 	}
 
+	if cfg.NextToolCall != nil && ctx.CountToolResults() == 1 {
+		h.trackToolCall(cfg.NextToolCall.Name)
+		writeJSON(w, http.StatusOK, response.BuildToolCallResponse(model, cfg.NextToolCall.Name, scenarios.MockScenarioConfig{
+			ToolCallName: cfg.NextToolCall.Name,
+			ToolCallArgs: cfg.NextToolCall.Arguments,
+		}))
+		return
+	}
+
 	dag := conversation.SelectDAG(req.Tools)
 	execResult, err := dag.Execute(ctx)
 	if err != nil {

--- a/test/services/mock-llm/repeat_tool_call_test.go
+++ b/test/services/mock-llm/repeat_tool_call_test.go
@@ -981,4 +981,112 @@ keyword_scenarios:
 				"first turn must use the primary tool_call, not next_tool_call")
 		})
 	})
+
+	Describe("UT-ML-1407-004: OpenAI handler emits NextToolCall on second turn (CountToolResults==1)", func() {
+		It("should return next_tool_call when exactly 1 tool result is present", func() {
+			content := func(s string) *string { return &s }
+			registry := scenarios.DefaultRegistry()
+			router := handlers.NewRouter(registry, false, "")
+			ts := httptest.NewServer(router)
+			defer ts.Close()
+
+			reqBody := openai.ChatCompletionRequest{
+				Model: "gpt-4",
+				Messages: []openai.Message{
+					{Role: "user", Content: content("brief-investigation-test signal")},
+					{Role: "assistant", ToolCalls: []openai.ToolCall{{ID: "call_1", Type: "function", Function: openai.FunctionCall{Name: "kubectl_get", Arguments: `{"resource_type":"pod"}`}}}},
+					{Role: "tool", Content: content(`{"kind":"Pod","metadata":{"name":"investigation-target"}}`)},
+				},
+				Tools: []openai.Tool{{Type: "function", Function: openai.ToolDefinition{Name: "kubectl_get"}}},
+			}
+
+			body, err := json.Marshal(reqBody)
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, err := http.Post(ts.URL+"/v1/chat/completions", "application/json", bytes.NewReader(body))
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			var oaiResp openai.ChatCompletionResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&oaiResp)).To(Succeed())
+			Expect(oaiResp.Choices).To(HaveLen(1))
+			Expect(oaiResp.Choices[0].Message.ToolCalls).To(HaveLen(1),
+				"second turn must emit NextToolCall (brief_investigation scenario)")
+			Expect(oaiResp.Choices[0].Message.ToolCalls[0].Function.Name).To(Equal("kubectl_get"),
+				"NextToolCall must be kubectl_get per briefInvestigationConfig")
+		})
+	})
+
+	Describe("UT-ML-1407-005: OpenAI handler does NOT emit NextToolCall on third turn (CountToolResults==2)", func() {
+		It("should fall through to DAG/text when 2 tool results are present", func() {
+			content := func(s string) *string { return &s }
+			registry := scenarios.DefaultRegistry()
+			router := handlers.NewRouter(registry, false, "")
+			ts := httptest.NewServer(router)
+			defer ts.Close()
+
+			reqBody := openai.ChatCompletionRequest{
+				Model: "gpt-4",
+				Messages: []openai.Message{
+					{Role: "user", Content: content("brief-investigation-test signal")},
+					{Role: "assistant", ToolCalls: []openai.ToolCall{{ID: "call_1", Type: "function", Function: openai.FunctionCall{Name: "kubectl_get", Arguments: `{"resource_type":"pod"}`}}}},
+					{Role: "tool", Content: content(`{"kind":"Pod","metadata":{"name":"investigation-target"}}`)},
+					{Role: "assistant", ToolCalls: []openai.ToolCall{{ID: "call_2", Type: "function", Function: openai.FunctionCall{Name: "kubectl_get", Arguments: `{"resource_type":"pod"}`}}}},
+					{Role: "tool", Content: content(`{"kind":"Pod","metadata":{"name":"investigation-target-2"}}`)},
+				},
+				Tools: []openai.Tool{{Type: "function", Function: openai.ToolDefinition{Name: "kubectl_get"}}},
+			}
+
+			body, err := json.Marshal(reqBody)
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, err := http.Post(ts.URL+"/v1/chat/completions", "application/json", bytes.NewReader(body))
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			var oaiResp openai.ChatCompletionResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&oaiResp)).To(Succeed())
+			Expect(oaiResp.Choices).To(HaveLen(1))
+			Expect(oaiResp.Choices[0].Message.ToolCalls).To(BeEmpty(),
+				"third turn (2 tool results) must NOT emit NextToolCall — guard prevents infinite loops")
+			Expect(oaiResp.Choices[0].Message.Content).NotTo(BeNil(),
+				"third turn should produce text response via DAG final_analysis")
+		})
+	})
+
+	Describe("UT-ML-1407-006: OpenAI handler emits initial ToolCallName on first turn with NextToolCall configured", func() {
+		It("should return the primary ToolCallName before any chaining", func() {
+			content := func(s string) *string { return &s }
+			registry := scenarios.DefaultRegistry()
+			router := handlers.NewRouter(registry, false, "")
+			ts := httptest.NewServer(router)
+			defer ts.Close()
+
+			reqBody := openai.ChatCompletionRequest{
+				Model: "gpt-4",
+				Messages: []openai.Message{
+					{Role: "user", Content: content("brief-investigation-test signal")},
+				},
+				Tools: []openai.Tool{{Type: "function", Function: openai.ToolDefinition{Name: "kubectl_get"}}},
+			}
+
+			body, err := json.Marshal(reqBody)
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, err := http.Post(ts.URL+"/v1/chat/completions", "application/json", bytes.NewReader(body))
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			var oaiResp openai.ChatCompletionResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&oaiResp)).To(Succeed())
+			Expect(oaiResp.Choices).To(HaveLen(1))
+			Expect(oaiResp.Choices[0].Message.ToolCalls).To(HaveLen(1),
+				"first turn must emit ToolCallName, not NextToolCall")
+			Expect(oaiResp.Choices[0].Message.ToolCalls[0].Function.Name).To(Equal("kubectl_get"),
+				"first turn must use the primary ToolCallName from briefInvestigationConfig")
+		})
+	})
 })

--- a/test/services/mock-llm/scenarios/registry_default.go
+++ b/test/services/mock-llm/scenarios/registry_default.go
@@ -222,6 +222,11 @@ func defaultRegistryWithGoldenDir(goldenDir string) *Registry {
 	// Keeps KA session in "investigating" via a 30s second-turn delay.
 	r.Register(mockKeywordScenario("slow_investigation", "slow-investigation-test", slowInvestigationConfig()))
 
+	// Brief investigation scenario for IT tests that need a non-instant session
+	// but don't require the full 30s window. 5s delay is enough for IS creation
+	// and upgrade detection before the session completes naturally.
+	r.Register(mockKeywordScenario("brief_investigation", "brief-investigation-test", briefInvestigationConfig()))
+
 	// Default fallback (lowest priority = 0.01)
 	r.Register(defaultFallbackScenario())
 

--- a/test/services/mock-llm/scenarios/scenario_af_create_rr.go
+++ b/test/services/mock-llm/scenarios/scenario_af_create_rr.go
@@ -16,7 +16,6 @@ limitations under the License.
 package scenarios
 
 import (
-	"log"
 	"regexp"
 	"strings"
 	"time"
@@ -94,23 +93,6 @@ func afCreateRRCrossNSScenario() *afCreateRRDynScenario {
 		if !strings.Contains(combined, "cross-namespace remediation") {
 			return false, 0
 		}
-		// Reset per-request state to prevent leaking a prior match's values
-		// into a subsequent Config() call if the regex fails this time.
-		s.extractedName = ""
-		s.extractedNS = ""
-		// Extract namespace eagerly during Match; store in extractedName/NS
-		// so Config() doesn't need to re-parse from a possibly stale context.
-		for _, text := range []string{ctx.Content, ctx.AllText, ctx.LastUserContent} {
-			if m := deployNSRe.FindStringSubmatch(text); len(m) == 3 {
-				s.extractedName = m[1]
-				s.extractedNS = m[2]
-				log.Printf("[mock-llm/kubernaut_remediate_cross_ns] Match: extracted name=%q ns=%q", m[1], m[2])
-				break
-			}
-		}
-		if s.extractedNS == "" {
-			log.Printf("[mock-llm/kubernaut_remediate_cross_ns] Match: keyword found but regex did NOT match. contentLen=%d allTextLen=%d", len(ctx.Content), len(ctx.AllText))
-		}
 		return true, 0.95
 	}
 	return s
@@ -120,12 +102,14 @@ func afCreateRRCrossNSScenario() *afCreateRRDynScenario {
 // from the user prompt to forward as kubernaut_remediate tool args.
 // Post-#1282: namespace and severity are AF-resolved; only kind/name/description
 // are sent by the LLM.
+//
+// Thread-safety (#1458): resource extraction is performed in ConfigForContext()
+// from the DetectionContext passed by the handler, not from stored state.
+// This eliminates the data race where concurrent Detect() callers overwrote
+// lastCtx, causing kubernaut_remediate to create RRs with the wrong target name.
 type afCreateRRDynScenario struct {
 	baseConfig    MockScenarioConfig
-	lastCtx       *DetectionContext
 	matchOverride func(ctx *DetectionContext) (bool, float64)
-	extractedName string
-	extractedNS   string
 }
 
 func (s *afCreateRRDynScenario) Name() string { return s.baseConfig.ScenarioName }
@@ -138,35 +122,25 @@ func (s *afCreateRRDynScenario) DAG() *conversation.DAG { return nil }
 
 func (s *afCreateRRDynScenario) Match(ctx *DetectionContext) (bool, float64) {
 	if s.matchOverride != nil {
-		matched, conf := s.matchOverride(ctx)
-		if matched {
-			s.lastCtx = ctx
-		}
-		return matched, conf
+		return s.matchOverride(ctx)
 	}
 	combined := strings.ToLower(ctx.Content + " " + ctx.AllText)
 	if strings.Contains(combined, "create a remediation request") {
-		s.lastCtx = ctx
 		return true, 0.9
 	}
 	return false, 0
 }
 
 func (s *afCreateRRDynScenario) Config() MockScenarioConfig {
+	return s.baseConfig
+}
+
+func (s *afCreateRRDynScenario) ConfigForContext(ctx *DetectionContext) MockScenarioConfig {
 	cfg := s.baseConfig
-
-	// Prefer values extracted eagerly during Match() (cross-NS scenario).
-	if s.extractedNS != "" {
-		cfg.ResourceName = s.extractedName
-		cfg.ResourceNS = s.extractedNS
+	if ctx == nil {
 		return cfg
 	}
-
-	if s.lastCtx == nil {
-		return cfg
-	}
-	// Fallback: try regex extraction from the detection context.
-	for _, text := range []string{s.lastCtx.Content, s.lastCtx.AllText, s.lastCtx.LastUserContent} {
+	for _, text := range []string{ctx.Content, ctx.AllText, ctx.LastUserContent} {
 		if m := deployNSRe.FindStringSubmatch(text); len(m) == 3 {
 			cfg.ResourceName = m[1]
 			cfg.ResourceNS = m[2]

--- a/test/services/mock-llm/scenarios/scenario_brief_investigation.go
+++ b/test/services/mock-llm/scenarios/scenario_brief_investigation.go
@@ -25,9 +25,9 @@ import "time"
 // Turn 2: NextToolCall → kubectl_get (extends session via Evaluate, 2s delay)
 // Turn 3: DAG final_analysis → text response (session completes, 2s delay)
 //
-// The 2s SecondTurnDelay provides the minimum window for the test's Eventually
+// The 6s SecondTurnDelay provides a reliable window for the test's Eventually
 // loop (200ms interval) to detect KASession.ID and create the IS before the
-// investigation completes. Total investigation time: ~4s (2 delayed turns).
+// investigation completes. Total investigation time: ~12s (2 delayed turns).
 //
 // Used by IT tests (IT-AA-1376-001) that need the session to remain active
 // briefly for IS creation and upgrade detection, then complete naturally.
@@ -51,6 +51,6 @@ func briefInvestigationConfig() MockScenarioConfig {
 			},
 		},
 		ForceText:       BoolPtr(false),
-		SecondTurnDelay: 2 * time.Second,
+		SecondTurnDelay: 6 * time.Second,
 	}
 }

--- a/test/services/mock-llm/scenarios/scenario_brief_investigation.go
+++ b/test/services/mock-llm/scenarios/scenario_brief_investigation.go
@@ -15,16 +15,19 @@ limitations under the License.
 */
 package scenarios
 
-// briefInvestigationConfig returns a scenario that keeps a KA session alive for
-// exactly 3 LLM turns (two tool calls + final response) without any time delay.
+import "time"
+
+// briefInvestigationConfig returns a scenario that keeps a KA session alive
+// long enough for IT tests to create an IS and observe the terminal phase
+// transition, without the 30s delay of slowInvestigationConfig.
 //
-// Turn 1: ToolCallName → kubectl_get (initial investigation tool call)
-// Turn 2: NextToolCall → kubectl_get (extends session by one turn via Evaluate)
-// Turn 3: DAG final_analysis → text response (session completes)
+// Turn 1: ToolCallName → kubectl_get (immediate)
+// Turn 2: NextToolCall → kubectl_get (extends session via Evaluate, 2s delay)
+// Turn 3: DAG final_analysis → text response (session completes, 2s delay)
 //
-// This is the condition-based (Evaluate) alternative to slowInvestigationConfig's
-// 30s SecondTurnDelay. Session lifetime is measured in conversation turns, not
-// wall-clock time, making tests deterministic and fast (~500ms total).
+// The 2s SecondTurnDelay provides the minimum window for the test's Eventually
+// loop (200ms interval) to detect KASession.ID and create the IS before the
+// investigation completes. Total investigation time: ~4s (2 delayed turns).
 //
 // Used by IT tests (IT-AA-1376-001) that need the session to remain active
 // briefly for IS creation and upgrade detection, then complete naturally.
@@ -32,8 +35,8 @@ package scenarios
 // Matches the keyword "brief-investigation-test" with priority 1.0.
 func briefInvestigationConfig() MockScenarioConfig {
 	return MockScenarioConfig{
-		ScenarioName: "brief_investigation",
-		ToolCallName: "kubectl_get",
+		ScenarioName:    "brief_investigation",
+		ToolCallName:    "kubectl_get",
 		ToolCallArgs: map[string]interface{}{
 			"resource_type": "pod",
 			"namespace":     "default",
@@ -47,6 +50,7 @@ func briefInvestigationConfig() MockScenarioConfig {
 				"name":          "investigation-target-2",
 			},
 		},
-		ForceText: BoolPtr(false),
+		ForceText:       BoolPtr(false),
+		SecondTurnDelay: 2 * time.Second,
 	}
 }

--- a/test/services/mock-llm/scenarios/scenario_brief_investigation.go
+++ b/test/services/mock-llm/scenarios/scenario_brief_investigation.go
@@ -25,9 +25,10 @@ import "time"
 // Turn 2: NextToolCall → kubectl_get (extends session via Evaluate, 2s delay)
 // Turn 3: DAG final_analysis → text response (session completes, 2s delay)
 //
-// The 6s SecondTurnDelay provides a reliable window for the test's Eventually
+// The 3s SecondTurnDelay provides a reliable window for the test's Eventually
 // loop (200ms interval) to detect KASession.ID and create the IS before the
-// investigation completes. Total investigation time: ~12s (2 delayed turns).
+// investigation completes. The delay applies per-phase (RCA, workflow_discovery,
+// etc.), so total investigation time is ~9-12s across all phases.
 //
 // Used by IT tests (IT-AA-1376-001) that need the session to remain active
 // briefly for IS creation and upgrade detection, then complete naturally.
@@ -51,6 +52,6 @@ func briefInvestigationConfig() MockScenarioConfig {
 			},
 		},
 		ForceText:       BoolPtr(false),
-		SecondTurnDelay: 6 * time.Second,
+		SecondTurnDelay: 3 * time.Second,
 	}
 }

--- a/test/services/mock-llm/scenarios/scenario_brief_investigation.go
+++ b/test/services/mock-llm/scenarios/scenario_brief_investigation.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package scenarios
+
+// briefInvestigationConfig returns a scenario that keeps a KA session alive for
+// exactly 3 LLM turns (two tool calls + final response) without any time delay.
+//
+// Turn 1: ToolCallName → kubectl_get (initial investigation tool call)
+// Turn 2: NextToolCall → kubectl_get (extends session by one turn via Evaluate)
+// Turn 3: DAG final_analysis → text response (session completes)
+//
+// This is the condition-based (Evaluate) alternative to slowInvestigationConfig's
+// 30s SecondTurnDelay. Session lifetime is measured in conversation turns, not
+// wall-clock time, making tests deterministic and fast (~500ms total).
+//
+// Used by IT tests (IT-AA-1376-001) that need the session to remain active
+// briefly for IS creation and upgrade detection, then complete naturally.
+//
+// Matches the keyword "brief-investigation-test" with priority 1.0.
+func briefInvestigationConfig() MockScenarioConfig {
+	return MockScenarioConfig{
+		ScenarioName: "brief_investigation",
+		ToolCallName: "kubectl_get",
+		ToolCallArgs: map[string]interface{}{
+			"resource_type": "pod",
+			"namespace":     "default",
+			"name":          "investigation-target",
+		},
+		NextToolCall: &MultiToolCallEntry{
+			Name: "kubectl_get",
+			Arguments: map[string]interface{}{
+				"resource_type": "pod",
+				"namespace":     "default",
+				"name":          "investigation-target-2",
+			},
+		},
+		ForceText: BoolPtr(false),
+	}
+}

--- a/test/services/mock-llm/scenarios/types.go
+++ b/test/services/mock-llm/scenarios/types.go
@@ -146,6 +146,17 @@ type ScenarioWithConfig interface {
 	Config() MockScenarioConfig
 }
 
+// ScenarioWithContextConfig is implemented by dynamic scenarios that need the
+// DetectionContext during config construction. Handlers prefer this over
+// ScenarioWithConfig to avoid shared mutable state races when concurrent
+// requests match the same scenario instance. See #1458: afCreateRRDynScenario's
+// lastCtx field was overwritten by concurrent Detect() callers, causing
+// resource name mismatches in the kubernaut_remediate tool call.
+type ScenarioWithContextConfig interface {
+	Scenario
+	ConfigForContext(ctx *DetectionContext) MockScenarioConfig
+}
+
 // ScenarioWithSubmitNotify is implemented by stateful scenarios that need to
 // know when the handler actually responded with submit_result_with_workflow.
 // The handler calls MarkSubmitSent() after writing the response so the scenario


### PR DESCRIPTION
## Summary

- **#1455**: Rename `escalated` to `operator_escalation` in the `result_type` OpenAPI enum and update all ogen generated code (const, AllValues, Marshal, Unmarshal, Decode, Validate). Use typed ogen constants in `ka_tools.go` instead of raw strings for compile-time enum safety.
- **#1458**: Add `operator_dismissed` to the `result_type` enum for the dismiss path. The previous raw string `"completed"` was never a valid enum value, causing every dismiss-path audit event to silently fail OpenAPI validation and not be stored (SOC2 CC7.2 gap masked by `fakeAuditor` in IT tests).
- **#1449**: Add `FindSessionPhase` to `InvestigationSessionChecker` to distinguish "IS deleted" from "IS in terminal phase" during KA session cancellation. Prevents incorrect `PhaseFailed` transition when an IS completes but the KA session reports cancelled (race condition). Add symmetric `SchemaValidationFailed` fail-close guard to `reconcileAnalyzing`.

## Changes

| Commit | Scope | Issue |
|---|---|---|
| `842302a` fix(openapi): replace escalated with operator_escalation, add operator_dismissed | Schema + ogen | #1455, #1458 |
| `0eef601` fix(af): use typed ogen constants for audit result_type | AF production code, IT, docs | #1455, #1458 |
| `787cd11` fix(aa): handle IS completion race in cancel path with FindSessionPhase | AA handlers + UT | #1449 |
| `d89d6cb` fix(aa): add SchemaValidationFailed fail-close guard to reconcileAnalyzing | AA controller | #1455 |
| `5588060` test(aa): add IT for full escalation wiring path through reconciler | Integration test | #1449 |

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] UT-AA-1455-001: Poll cancelled + IS completed (race) → fetch result
- [x] UT-AA-1455-002: Poll cancelled + FindSessionPhase error → requeue
- [x] UT-AA-1455-003: Poll cancelled + IS in Failed phase → PhaseFailed
- [x] IT-AF-1418-002 assertion updated to expect `operator_escalation`
- [x] IT-AA-1449-003: Full escalation wiring path through reconciler
- [x] All 3 embedded YAML copies match source spec for `result_type` enum
- [x] All 6 ogen methods updated consistently (const, AllValues, Marshal, Unmarshal, Decode, Validate)

Closes #1455
Closes #1458

Made with [Cursor](https://cursor.com)