### PR TITLE
feat(apifrontend): implement status/subscribe SSE endpoint (#1460)

### DIFF
--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -277,6 +277,11 @@ func run() int {
 		Metrics: metricsReg.RateLimitDenied,
 	})
 
+	var statusHandler http.Handler
+	if deps.TypedClient() != nil {
+		statusHandler = handler.NewStatusHandler(deps.TypedClient(), cfg.Session.Namespace, logger)
+	}
+
 	draining := &atomic.Bool{}
 	routerCfg := handler.RouterConfig{
 		MetricsRegistry:    metricsReg,
@@ -289,6 +294,7 @@ func run() int {
 		PostAuthMiddleware: postAuthMW,
 		ReadyChecker:       handler.AllReady(func() bool { return !draining.Load() }, depsReady, authReady, sessInfra.Healthy.Load),
 		SSETracker:         buildSSETracker(cfg, metricsReg),
+		StatusHandler:      statusHandler,
 		Draining:           draining,
 	}
 	router, err := handler.NewRouter(routerCfg)

--- a/deploy/apifrontend/base/02-rbac.yaml
+++ b/deploy/apifrontend/base/02-rbac.yaml
@@ -59,10 +59,11 @@ rules:
   - apiGroups: ["kubernaut.ai"]
     resources: ["aianalyses"]
     verbs: ["get", "list", "watch"]
-  # EffectivenessAssessment read-only: fetch stabilizationWindow for progress artifacts (#1403)
+  # EffectivenessAssessment: fetch stabilizationWindow for progress artifacts (#1403),
+  # watch EA sub-phase transitions for status/subscribe SSE stream (#1460)
   - apiGroups: ["kubernaut.ai"]
     resources: ["effectivenessassessments"]
-    verbs: ["get"]
+    verbs: ["get", "list", "watch"]
   # SubjectAccessReview: SAR-based tool authorization (ADR-021)
   - apiGroups: ["authorization.k8s.io"]
     resources: ["subjectaccessreviews"]

--- a/docs/architecture/decisions/DD-AF-008-status-subscribe-sse.md
+++ b/docs/architecture/decisions/DD-AF-008-status-subscribe-sse.md
@@ -1,0 +1,123 @@
+# DD-AF-008: Status Subscribe SSE Endpoint
+
+**Status**: Accepted
+**Issue**: #1460
+**Business Requirement**: BR-AF-1460
+**Date**: 2026-06-18
+
+## Context
+
+After workflow selection, the MCP chat session terminates by design (`select_workflow.go:293`).
+The console has no channel to learn about subsequent RR phase changes
+(Executing, Verifying, Completed, etc.). The console team requested a dedicated
+SSE stream for RR phase transitions, independent of the A2A `message/stream`.
+
+## Decision
+
+Implement a standalone HTTP handler on `POST /a2a/status` that accepts a
+JSON-RPC `status/subscribe` request and returns an SSE stream of phase
+transition events.
+
+### Route Design: Standalone Handler (not a2a-go extension)
+
+`status/subscribe` is a kubernaut-specific extension, not an A2A spec method.
+The handler is registered directly in `RouterConfig` and `NewRouter`, reusing
+the same auth middleware chain and SSE tracker but bypassing `a2a-go`'s method
+dispatch (which only knows `message/send` and `message/stream`).
+
+### Contract
+
+**Request:**
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "status-1",
+  "method": "status/subscribe",
+  "params": { "rr_id": "rr-0fd7ce7b49a7-784e8ea4" }
+}
+```
+
+Namespace is resolved server-side per ADR-057 (controller namespace injected at
+startup). The `rr_id` is a plain resource name.
+
+**Response:** SSE stream (`Content-Type: text/event-stream`)
+
+Phase transition events:
+```
+event: status/update
+data: {"jsonrpc":"2.0","method":"status/update","params":{"rr_id":"...","phase":"Verifying","timestamp":"2026-06-18T15:10:00Z","final":false,"metadata":{...}}}
+```
+
+Pre-expiry warning (before token deadline kills stream):
+```
+event: status/closing
+data: {"jsonrpc":"2.0","method":"status/closing","params":{"reason":"token_expiry","reconnect":true}}
+```
+
+Heartbeat (every 15s):
+```
+: heartbeat
+```
+
+**Error codes** (non-streaming JSON-RPC error response):
+
+| Code | Message | When |
+|------|---------|------|
+| -32600 | invalid_request | Malformed JSON-RPC |
+| -32601 | method_not_found | Method is not status/subscribe |
+| -32602 | invalid_params | Missing rr_id |
+| -32001 | rr_not_found | RR does not exist |
+| -32002 | access_denied | User lacks RBAC access |
+
+### Per-Phase Metadata
+
+Metadata uses raw CRD field names. The console computes derived values.
+
+| Phase | Metadata fields |
+|-------|----------------|
+| Pending, Processing, Analyzing, Cancelled | (none) |
+| AwaitingApproval | approval_request_name |
+| Executing | workflow_id, started_at |
+| Verifying | verification_deadline, started_at, ea_phase, stabilization_deadline |
+| Blocked | blocked_until, block_reason, block_message |
+| Completed | outcome |
+| Failed | failure_reason, failure_phase |
+| TimedOut | failure_phase |
+| Skipped | skip_reason |
+
+### EA Sub-Phase Events During Verifying
+
+While the RR stays in `Verifying`, the EffectivenessAssessment (EA) progresses
+through Pending, WaitingForPropagation, Stabilizing, Assessing, Completed, Failed.
+The stream emits `status/update` events with `phase: "Verifying"` unchanged but
+updated `ea_phase` and `stabilization_deadline` in metadata.
+
+EA discovery uses `RR.status.effectivenessAssessmentRef` (corev1.ObjectReference)
+instead of the `EANameForRR()` naming convention.
+
+### Stream Lifecycle
+
+1. On subscribe: GET current RR, send current phase immediately (REQ-2)
+2. If RR is already terminal: send event with `final: true`, close stream
+3. Start K8s watch on RR; on Verifying, start EA watch via effectivenessAssessmentRef
+4. On terminal phase: send event with `final: true`, close stream
+5. On token deadline approaching (~5s before): send `status/closing`
+6. On watch channel close: re-establish watch transparently (reconnection loop)
+7. Heartbeat every 15s
+
+### Token Deadline Handling
+
+The auth middleware sets `context.WithDeadline(ctx, expiresAt - [25-34s] jitter)`.
+This kills the SSE stream before the token expires. The handler sends a
+`status/closing` pre-warning ~5s before the deadline so the client can
+proactively reconnect with a fresh token. REQ-2 (current-state on reconnect) is
+mandatory.
+
+## Consequences
+
+- AF RBAC ClusterRole needs `watch` and `list` verbs on effectivenessassessments
+  (currently only `get`)
+- `HandleWatch` in `crd_tools.go` migrated from `EANameForRR()` to
+  `effectivenessAssessmentRef` for consistency
+- Per-connection K8s watch (REQ-1 shared fan-out deferred to future iteration)
+- Global connection cap (1000) shared with A2A/MCP streams

--- a/docs/spikes/multi-cluster-mcp-write/decision-matrix.md
+++ b/docs/spikes/multi-cluster-mcp-write/decision-matrix.md
@@ -1,0 +1,95 @@
+# MCP Write Path Spike -- Decision Matrix
+
+**Date**: 2026-06-18
+**Status**: All GO -- MCP server is viable as a unified read/write channel for remote workflow execution
+**Cluster**: OCP 4.21 (dev.redhat-internal.com)
+
+## Go/No-Go Questions
+
+| # | Question | Threshold | Result | Evidence |
+|---|----------|-----------|--------|----------|
+| 1 | **Write capability**: Can K8s MCP server create/update/delete Jobs? | Working CRUD | **GO** | `resources_create_or_update` creates Jobs via server-side apply. `resources_delete` removes them. Requires `patch` verb in RBAC. |
+| 2 | **SA boundary**: Does Job run under workflow SA, not MCP server SA? | Clean boundary | **GO** | Job `spec.template.spec.serviceAccountName` controls pod identity. Verified: pod runs as `kubernaut-wf-test`, not `mcp-server-sa`. |
+| 3 | **Secret handling**: Does KA's sanitization pipeline handle MCP-transported secrets? | Fail-closed redaction | **GO** | MCP returns raw Secret data. KA's 3-stage pipeline (G4/K8S-SECRET/I1) redacts before LLM sees it. No RBAC exclusion needed. |
+| 4 | **Gateway routing**: Do write ops work through a network hop (service/route)? | Write through proxy | **GO** | Job creation through K8s Service (in-cluster) succeeds. Route (edge-terminated TLS) confirmed. |
+| 5 | **JWT auth scoping**: Can Keycloak mint differentiated read/write JWTs? | Role-scoped tokens | **GO** | `kubernaut-mcp-spike` client gets `mcp-read` + `mcp-write` roles. `kubernaut-mcp-readonly` gets only `mcp-read`. TTL: 300s. |
+| 6 | **Failure detection**: Can KA detect Job failures, timeouts, and RBAC errors? | All modes detectable | **GO** | `BackoffLimitExceeded`, `DeadlineExceeded`, and SA boundary violations all detectable via Job status conditions. |
+| 7 | **Idempotency**: Is `resources_create_or_update` safe to retry? | No duplicate creation | **GO** | Server-side apply is idempotent. Second call succeeds without creating duplicates. |
+| 8 | **TTL cleanup**: Does `ttlSecondsAfterFinished` auto-remove Jobs? | Automatic cleanup | **GO** | Job with `ttlSecondsAfterFinished: 10` auto-deleted within 18s of completion. |
+
+## Overall Decision
+
+**GO** -- The `containers/kubernetes-mcp-server` is viable as a **unified investigation + execution channel** for Kubernaut's multi-cluster architecture. No separate write API is needed.
+
+## Key Architectural Decisions
+
+### 1. Unified MCP Channel (Read + Write)
+
+The MCP server handles both investigation (read) and workflow execution (write) through the same transport. This eliminates the need for a separate ManifestWork-style API or direct `client-go` connections to remote clusters.
+
+### 2. RBAC Model: Two-Layer
+
+| Layer | SA | Scope | Purpose |
+|-------|-----|-------|---------|
+| **MCP Server SA** | `mcp-server-sa` | ClusterRole: read-all + create/patch/delete Jobs,PipelineRuns | What tools the MCP server exposes |
+| **Workflow SA** | Per-workflow (e.g., `kubernaut-wf-test`) | Namespace-scoped Role: only resources the workflow needs | What the Job pod can actually do |
+
+The MCP server SA has broad permissions (aligned with KA's RBAC). The workflow SA constrains what the remediation pod executes. This is the same privilege separation model KA already uses.
+
+### 3. Secret Handling: Application-Layer Redaction
+
+Secrets are **not** excluded from MCP server RBAC. The MCP server returns raw Secret data, and KA's sanitization pipeline redacts it before the LLM sees it. This matches the existing Kubernaut security model (SOC2-compliant, fail-closed).
+
+### 4. `resources_create_or_update` Requires `patch` Verb
+
+The MCP server's `resources_create_or_update` tool uses server-side apply (PATCH with `application/apply-patch+yaml`), not POST. RBAC must include the `patch` verb for any resource type the MCP server needs to create.
+
+## Spike Findings Summary
+
+| Test | Result | Notes |
+|------|--------|-------|
+| Create Job via MCP | PASS | Server-side apply with `patch` verb |
+| Job runs under workflow SA | PASS | Pod identity = `system:serviceaccount:demo-hpa:kubernaut-wf-test` |
+| Workflow SA RBAC enforced | PASS | Can patch HPAs (allowed), cannot delete deployments or access other namespaces (denied) |
+| Read Job status via MCP | PASS | `resources_get` returns full Job with status conditions |
+| Delete Job via MCP | PASS | `resources_delete` removes Job cleanly |
+| Secret read via MCP | PASS | Returns raw data (KA sanitization handles redaction) |
+| SA pre-validation | PASS | `resources_get` on SA before Job creation detects missing SAs |
+| Job failure detection | PASS | `BackoffLimitExceeded` condition visible in Job status |
+| Job timeout detection | PASS | `DeadlineExceeded` condition from `activeDeadlineSeconds` |
+| Idempotent creation | PASS | Second `resources_create_or_update` succeeds (server-side apply) |
+| TTL auto-cleanup | PASS | `ttlSecondsAfterFinished: 10` removes Job ~8-18s after completion |
+| Non-existent SA handling | PASS | Job creates but pod fails to schedule; detectable via status |
+| Write through K8s Service | PASS | MCP tool call routes through `kubernetes-mcp-server.spike-mcp-write.svc:8080` |
+| JWT minting (full access) | PASS | `resource_access.kubernaut-mcp-spike.roles: [mcp-read, mcp-write]` |
+| JWT minting (read-only) | PASS | `resource_access.kubernaut-mcp-readonly.roles: [mcp-read]` |
+
+## Implementation Impact
+
+### WE Controller Changes
+
+1. **SA pre-validation**: Before creating a Job, call `resources_get` on the target ServiceAccount via MCP. Abort if SA doesn't exist.
+2. **Job creation**: Use `resources_create_or_update` with the full Job manifest including `serviceAccountName`.
+3. **Status polling**: Poll `resources_get` on the Job, check `status.conditions` for `Complete` or `Failed`.
+4. **Failure classification**: Map Job condition reasons to WFE failure types:
+   - `BackoffLimitExceeded` -> `WorkflowFailed`
+   - `DeadlineExceeded` -> `WorkflowTimeout`
+   - SA missing -> `PreconditionFailed`
+5. **Cleanup**: Use `resources_delete` for explicit cleanup, `ttlSecondsAfterFinished` as safety net.
+
+### MCP Server RBAC Template
+
+The MCP server SA needs a ClusterRole with:
+- **Investigation verbs**: `get`, `list`, `watch` on all resource types KA currently reads
+- **Execution verbs**: `create`, `get`, `list`, `watch`, `patch`, `delete` on `jobs` (batch) and `pipelineruns`, `taskruns` (tekton.dev)
+- **SA lookup**: `get` on `serviceaccounts` (for pre-validation)
+
+### Gateway Auth Model (Production)
+
+| Component | Mechanism |
+|-----------|-----------|
+| KA -> Gateway | JWT (Keycloak client_credentials grant) |
+| Gateway -> MCP Server | In-mesh mTLS (Istio) |
+| JWT roles | `mcp-read` (investigation), `mcp-write` (execution) |
+| Gateway enforcement | Kuadrant AuthPolicy validates JWT roles per tool prefix |
+| Token TTL | 300s (short-lived, refreshed per investigation session) |

--- a/docs/spikes/multi-cluster-mcp-write/decision-matrix.md
+++ b/docs/spikes/multi-cluster-mcp-write/decision-matrix.md
@@ -1,7 +1,7 @@
 # MCP Write Path Spike -- Decision Matrix
 
 **Date**: 2026-06-18
-**Status**: All GO -- MCP server is viable as a unified read/write channel for remote workflow execution
+**Status**: All GO -- MCP is viable as a unified protocol for all three execution engines (K8s, Tekton, Ansible)
 **Cluster**: OCP 4.21 (dev.redhat-internal.com)
 
 ## Go/No-Go Questions
@@ -16,10 +16,12 @@
 | 6 | **Failure detection**: Can KA detect Job failures, timeouts, and RBAC errors? | All modes detectable | **GO** | `BackoffLimitExceeded`, `DeadlineExceeded`, and SA boundary violations all detectable via Job status conditions. |
 | 7 | **Idempotency**: Is `resources_create_or_update` safe to retry? | No duplicate creation | **GO** | Server-side apply is idempotent. Second call succeeds without creating duplicates. |
 | 8 | **TTL cleanup**: Does `ttlSecondsAfterFinished` auto-remove Jobs? | Automatic cleanup | **GO** | Job with `ttlSecondsAfterFinished: 10` auto-deleted within 18s of completion. |
+| 9 | **AAP MCP**: Can `ansible/aap-mcp-server` launch and poll Ansible jobs via MCP? | Working launch+poll | **GO** | `job_templates_launch_create` launches templates, `jobs_retrieve` polls status. Same Streamable HTTP transport as K8s MCP. Validated on AAP 2.5 (controller v4.6.21). |
+| 10 | **Unified protocol**: Do K8s MCP and AAP MCP work side-by-side? | Both respond simultaneously | **GO** | K8s Job creation (port 8080) and AAP Job launch (port 3001) succeed in parallel. Same JSON-RPC protocol, different tool names. |
 
 ## Overall Decision
 
-**GO** -- The `containers/kubernetes-mcp-server` is viable as a **unified investigation + execution channel** for Kubernaut's multi-cluster architecture. No separate write API is needed.
+**GO** -- MCP is viable as a **unified protocol for all three execution engines** (K8s Jobs, Tekton PipelineRuns, Ansible job templates). No separate AWX REST API or ManifestWork integration is needed. See [spike-aap-mcp-server.md](spike-aap-mcp-server.md) for the AAP MCP server spike details.
 
 ## Key Architectural Decisions
 

--- a/docs/spikes/multi-cluster-mcp-write/manifests/01-mcp-server-rbac.yaml
+++ b/docs/spikes/multi-cluster-mcp-write/manifests/01-mcp-server-rbac.yaml
@@ -1,0 +1,146 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: spike-mcp-write
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: mcp-server-sa
+  namespace: spike-mcp-write
+---
+# Investigation permissions (aligned with KA's RBAC)
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: spike-mcp-server-investigator
+rules:
+  # Core resources
+  - apiGroups: [""]
+    resources: [pods, pods/log, pods/status, services, endpoints, configmaps,
+                secrets, events, namespaces, nodes, persistentvolumeclaims,
+                persistentvolumes, replicationcontrollers, resourcequotas, limitranges,
+                serviceaccounts]
+    verbs: [get, list, watch]
+  # Apps
+  - apiGroups: [apps]
+    resources: [deployments, replicasets, statefulsets, daemonsets, controllerrevisions]
+    verbs: [get, list, watch]
+  # Batch
+  - apiGroups: [batch]
+    resources: [jobs, cronjobs]
+    verbs: [get, list, watch]
+  # Events
+  - apiGroups: [events.k8s.io]
+    resources: [events]
+    verbs: [get, list, watch]
+  # Autoscaling
+  - apiGroups: [autoscaling]
+    resources: [horizontalpodautoscalers]
+    verbs: [get, list, watch]
+  # Policy
+  - apiGroups: [policy]
+    resources: [poddisruptionbudgets]
+    verbs: [get, list, watch]
+  # Networking
+  - apiGroups: [networking.k8s.io]
+    resources: [networkpolicies, ingresses]
+    verbs: [get, list, watch]
+  # RBAC
+  - apiGroups: [rbac.authorization.k8s.io]
+    resources: [roles, rolebindings, clusterroles, clusterrolebindings]
+    verbs: [get, list, watch]
+  # API extensions
+  - apiGroups: [apiextensions.k8s.io]
+    resources: [customresourcedefinitions]
+    verbs: [get, list, watch]
+  # Storage
+  - apiGroups: [storage.k8s.io]
+    resources: [storageclasses, volumeattachments, csinodes, csidrivers]
+    verbs: [get, list, watch]
+  # Discovery
+  - apiGroups: [discovery.k8s.io]
+    resources: [endpointslices]
+    verbs: [get, list, watch]
+  # Metrics
+  - apiGroups: [metrics.k8s.io]
+    resources: [pods, nodes]
+    verbs: [get, list]
+  # Monitoring (Prometheus)
+  - apiGroups: [monitoring.coreos.com]
+    resources: [prometheusrules, servicemonitors, podmonitors, alertmanagers, prometheuses]
+    verbs: [get, list, watch]
+  # Cert-manager
+  - apiGroups: [cert-manager.io]
+    resources: [certificates, issuers, clusterissuers, certificaterequests]
+    verbs: [get, list, watch]
+  # Scheduling
+  - apiGroups: [scheduling.k8s.io]
+    resources: [priorityclasses]
+    verbs: [get, list, watch]
+  # Admission
+  - apiGroups: [admissionregistration.k8s.io]
+    resources: [mutatingwebhookconfigurations, validatingwebhookconfigurations]
+    verbs: [get, list, watch]
+  # OpenShift-specific
+  - apiGroups: [config.openshift.io]
+    resources: [clusterversions, clusteroperators, infrastructures]
+    verbs: [get, list, watch]
+  - apiGroups: [operators.coreos.com]
+    resources: [clusterserviceversions, subscriptions, installplans]
+    verbs: [get, list, watch]
+  - apiGroups: [route.openshift.io]
+    resources: [routes]
+    verbs: [get, list, watch]
+  - apiGroups: [apps.openshift.io]
+    resources: [deploymentconfigs]
+    verbs: [get, list, watch]
+  - apiGroups: [security.openshift.io]
+    resources: [securitycontextconstraints]
+    verbs: [get, list, watch]
+  - apiGroups: [machine.openshift.io]
+    resources: [machines, machinesets]
+    verbs: [get, list, watch]
+---
+# Execution permissions (Jobs + Tekton)
+# Requires `patch` verb because resources_create_or_update uses server-side apply
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: spike-mcp-server-execution
+rules:
+  - apiGroups: [batch]
+    resources: [jobs]
+    verbs: [create, get, list, watch, patch, delete]
+  - apiGroups: [tekton.dev]
+    resources: [pipelineruns, taskruns]
+    verbs: [create, get, list, watch, patch, delete]
+  - apiGroups: [""]
+    resources: [serviceaccounts]
+    verbs: [get]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: spike-mcp-server-investigator
+subjects:
+  - kind: ServiceAccount
+    name: mcp-server-sa
+    namespace: spike-mcp-write
+roleRef:
+  kind: ClusterRole
+  name: spike-mcp-server-investigator
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: spike-mcp-server-execution
+subjects:
+  - kind: ServiceAccount
+    name: mcp-server-sa
+    namespace: spike-mcp-write
+roleRef:
+  kind: ClusterRole
+  name: spike-mcp-server-execution
+  apiGroup: rbac.authorization.k8s.io

--- a/docs/spikes/multi-cluster-mcp-write/manifests/02-workflow-sa.yaml
+++ b/docs/spikes/multi-cluster-mcp-write/manifests/02-workflow-sa.yaml
@@ -1,0 +1,31 @@
+# Workflow SA: scoped permissions for the remediation pod
+# This SA is referenced in the Job's template.spec.serviceAccountName
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kubernaut-wf-test
+  namespace: demo-hpa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubernaut-wf-test
+  namespace: demo-hpa
+rules:
+  - apiGroups: [autoscaling]
+    resources: [horizontalpodautoscalers]
+    verbs: [get, list, patch]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubernaut-wf-test
+  namespace: demo-hpa
+subjects:
+  - kind: ServiceAccount
+    name: kubernaut-wf-test
+    namespace: demo-hpa
+roleRef:
+  kind: Role
+  name: kubernaut-wf-test
+  apiGroup: rbac.authorization.k8s.io

--- a/docs/spikes/multi-cluster-mcp-write/manifests/03-mcp-server-helm.sh
+++ b/docs/spikes/multi-cluster-mcp-write/manifests/03-mcp-server-helm.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Deploy the K8s MCP server on a workload cluster
+# Prerequisite: manifests/01-mcp-server-rbac.yaml applied
+
+set -euo pipefail
+
+NAMESPACE="${MCP_NAMESPACE:-spike-mcp-write}"
+SA_NAME="${MCP_SA_NAME:-mcp-server-sa}"
+
+helm upgrade -i kubernetes-mcp-server \
+  oci://ghcr.io/containers/charts/kubernetes-mcp-server \
+  -n "$NAMESPACE" \
+  --set openshift=true \
+  --set serviceAccount.create=false \
+  --set serviceAccount.name="$SA_NAME" \
+  --set ingress.enabled=false \
+  --set service.type=ClusterIP \
+  --set service.port=8080
+
+echo "MCP server deployed. Verify:"
+echo "  kubectl -n $NAMESPACE get pods -l app.kubernetes.io/name=kubernetes-mcp-server"
+echo "  kubectl -n $NAMESPACE port-forward svc/kubernetes-mcp-server 8080:8080"

--- a/docs/spikes/multi-cluster-mcp-write/manifests/04-e2e-test-job.yaml
+++ b/docs/spikes/multi-cluster-mcp-write/manifests/04-e2e-test-job.yaml
@@ -1,0 +1,37 @@
+# E2E test job submitted via MCP resources_create_or_update
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: wfe-e2e-patch-hpa
+  namespace: demo-hpa
+  labels:
+    kubernaut.ai/spike: e2e
+    kubernaut.ai/workflow: patch-hpa-v1
+    kubernaut.ai/wfe-id: "12345"
+spec:
+  ttlSecondsAfterFinished: 600
+  activeDeadlineSeconds: 120
+  template:
+    spec:
+      serviceAccountName: kubernaut-wf-test
+      restartPolicy: Never
+      containers:
+      - name: remediate
+        image: registry.redhat.io/openshift4/ose-cli:latest
+        command:
+        - /bin/sh
+        - -c
+        - |
+          echo "Remediation started at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          echo "Workflow: patch-hpa-v1"
+          echo "Checking HPA access..."
+          if oc auth can-i patch horizontalpodautoscalers -n demo-hpa; then
+            echo "RBAC verified: can patch HPAs"
+            echo "Simulating HPA patch..."
+            sleep 2
+            echo "Remediation completed successfully"
+            exit 0
+          else
+            echo "RBAC DENIED: cannot patch HPAs"
+            exit 1
+          fi

--- a/docs/spikes/multi-cluster-mcp-write/spike-aap-mcp-server.md
+++ b/docs/spikes/multi-cluster-mcp-write/spike-aap-mcp-server.md
@@ -1,0 +1,156 @@
+# Spike: AAP MCP Server as Unified Ansible Execution Channel
+
+**Date**: 2026-06-18
+**Status**: GO -- AAP MCP server works as a third execution engine alongside K8s Jobs and Tekton
+**Cluster**: OCP 4.21 (dev.redhat-internal.com), AAP 2.5 (controller v4.6.21)
+
+## Objective
+
+Validate whether the upstream `ansible/aap-mcp-server` can replace direct AWX REST API integration, enabling Kubernaut's WE controller to use a single protocol (MCP) for all three execution engines: K8s Jobs, Tekton PipelineRuns, and Ansible job templates.
+
+## Findings
+
+### AAP MCP Server Deployment
+
+- **Upstream repo**: [ansible/aap-mcp-server](https://github.com/ansible/aap-mcp-server)
+- **Official support**: Ships with AAP 2.6+ (operator or container deployment)
+- **AAP 2.5 compatibility**: Works with a one-line patch to the token validation endpoint (`/api/gateway/v1/me/` -> `/api/v2/me/`) and disabling the gateway path rewrite (`/api/v2/` -> `/api/controller/v2/`). Both are AAP 2.6 gateway-format changes that don't exist in standalone controller mode.
+- **Transport**: Streamable HTTP (JSON-RPC over SSE), same as K8s MCP server
+- **Stateless sessions**: Unlike the K8s MCP server (stateful Mcp-Session-Id), the AAP MCP server is fully stateless. Each request carries its own Bearer token.
+
+### Available Tools (job_management toolset)
+
+| Tool | Method | Purpose |
+|------|--------|---------|
+| `job_templates_list` | GET | List all job templates |
+| `job_templates_retrieve` | GET | Get specific template details |
+| `job_templates_launch_retrieve` | GET | Check launch requirements (prompts, credentials) |
+| `job_templates_launch_create` | POST | **Launch a job template** |
+| `workflow_job_templates_list` | GET | List workflow templates |
+| `workflow_job_templates_retrieve` | GET | Get workflow template details |
+| `workflow_job_templates_launch_create` | POST | **Launch a workflow** |
+| `jobs_list` | GET | List jobs |
+| `jobs_retrieve` | GET | **Get job status** |
+| `jobs_stdout_retrieve` | GET | Get job output |
+| `jobs_job_events_list` | GET | Get job events |
+| `jobs_cancel_create` | POST | Cancel a running job |
+| `jobs_relaunch_create` | POST | Relaunch a failed job |
+| `workflow_jobs_list` | GET | List workflow jobs |
+| `workflow_jobs_retrieve` | GET | Get workflow job status |
+| `workflow_jobs_workflow_nodes_list` | GET | Get workflow node details |
+
+### E2E Validation Results
+
+| Test | Result | Notes |
+|------|--------|-------|
+| List job templates | PASS | Returns all 3 templates (Demo, kubernaut-gitops-update-memory, kubernaut-migrate-postgres-emptydir-to-pvc) |
+| Check launch requirements | PASS | `can_start_without_user_input: true` for Demo template |
+| Launch job template | PASS | Returns `job_id=75`, status=`pending` |
+| Poll job status | PASS | Status transitions: `pending` -> `successful` in 4.7s |
+| Unified test (K8s + AAP MCP simultaneously) | PASS | K8s Job creation and AAP Job launch both succeed in parallel |
+| Auth without token | PASS (rejected) | Returns `Unauthorized: Bearer token or session ID required` |
+| Auth with valid token | PASS | Token validated against AAP's `/api/v2/me/` |
+
+### Auth Model Comparison
+
+| Aspect | K8s MCP Server | AAP MCP Server |
+|--------|---------------|----------------|
+| Auth mechanism | SA token (implicit, in-cluster) | Bearer token (AAP API token) |
+| Client provides | Nothing (SA mounted in pod) | `Authorization: Bearer <token>` header |
+| Session model | Stateful (`Mcp-Session-Id`) | Stateless (token per-request) |
+| RBAC enforcement | K8s RBAC (ClusterRole/Role) | AAP RBAC (user permissions) |
+| Token source | K8s API server | AAP `/api/v2/tokens/` |
+| Token lifetime | Auto-rotated by kubelet | Configurable (no expiry by default) |
+
+### Gateway Auth Implications
+
+When the MCP Gateway fronts both K8s MCP and AAP MCP backends:
+
+1. **KA -> Gateway**: Keycloak JWT with `mcp-read`/`mcp-write` roles
+2. **Gateway -> K8s MCP**: No additional auth (in-mesh mTLS, SA implicit)
+3. **Gateway -> AAP MCP**: Must inject AAP Bearer token from a stored credential (K8s Secret or Keycloak token exchange)
+
+The Kuadrant MCP Gateway supports per-route `BackendPolicy` which can inject headers from Secrets. This is the mechanism for per-backend credential injection.
+
+Alternatively, Keycloak token exchange (RFC 8693) could mint an AAP-scoped token from the KA's JWT, but this requires AAP to trust Keycloak as an identity provider.
+
+## Three-Engine WE Controller Design
+
+```
+WE Controller
+    │
+    ├── K8s Engine Adapter
+    │   └── MCP tools: resources_create_or_update, resources_get, resources_delete
+    │   └── Resources: Job, PipelineRun, TaskRun
+    │   └── Auth: implicit (SA)
+    │   └── Status: Job/PipelineRun status.conditions
+    │
+    ├── Tekton Engine Adapter
+    │   └── MCP tools: resources_create_or_update, resources_get, resources_delete
+    │   └── Resources: PipelineRun, TaskRun
+    │   └── Auth: implicit (SA)
+    │   └── Status: PipelineRun status.conditions
+    │
+    └── Ansible Engine Adapter
+        └── MCP tools: job_templates_launch_create, jobs_retrieve, jobs_cancel_create
+        └── Resources: Job Template, Workflow Template
+        └── Auth: Bearer token
+        └── Status: jobs_retrieve -> status field
+```
+
+All three adapters:
+- Use the same MCP protocol (JSON-RPC over Streamable HTTP)
+- Route through the same MCP Gateway
+- Authenticate via the same Keycloak JWT (KA -> Gateway)
+- Differ only in tool names, resource types, and status polling logic
+
+### WE Controller Lifecycle Mapping
+
+| Phase | K8s/Tekton | Ansible |
+|-------|-----------|---------|
+| Pre-validate | `resources_get` (SA exists?) | `job_templates_launch_retrieve` (can launch?) |
+| Execute | `resources_create_or_update` (Job/PR) | `job_templates_launch_create` |
+| Poll | `resources_get` -> `status.conditions` | `jobs_retrieve` -> `status` |
+| Cancel | `resources_delete` | `jobs_cancel_create` |
+| Cleanup | `resources_delete` / TTL | AAP manages history |
+| Failure types | `BackoffLimitExceeded`, `DeadlineExceeded` | `failed`, `error`, `canceled` |
+
+## Compatibility Notes
+
+### AAP 2.5 vs 2.6+
+
+The AAP MCP server is designed for AAP 2.6+ which includes the Platform Gateway (`/api/controller/v2/` prefix, `/api/gateway/v1/me/` for auth). For AAP 2.5 (standalone controller), two changes are needed:
+
+1. **Token validation**: `/api/gateway/v1/me/` -> `/api/v2/me/`
+2. **Path rewrite**: Skip `/api/v2/` -> `/api/controller/v2/` rewrite
+
+Both can be controlled via environment variables in a production deployment. The upstream repo should be patched to support both modes.
+
+### AAP Deployment Topology (unchanged)
+
+AAP remains centralized. The AAP MCP server deploys alongside AAP (same pod/namespace or adjacent). It does NOT deploy per-cluster. From Kubernaut's perspective, this is transparent -- the MCP Gateway routes to the right backend regardless of where it runs.
+
+```
+Cluster A                 Cluster B              Management Cluster
+┌─────────────┐         ┌─────────────┐         ┌──────────────────────┐
+│ K8s MCP     │         │ K8s MCP     │         │ MCP Gateway          │
+│ (per-cluster)│         │ (per-cluster)│         │   ├── route: cluster_a_* -> A│
+└─────────────┘         └─────────────┘         │   ├── route: cluster_b_* -> B│
+                                                │   └── route: aap_*    -> AAP │
+                                                │                      │
+                                                │ AAP + AAP MCP Server │
+                                                │ (centralized)        │
+                                                │                      │
+                                                │ KA (consumer)        │
+                                                └──────────────────────┘
+```
+
+## Decision
+
+**GO** -- The AAP MCP server provides a clean, protocol-compatible execution channel for Ansible workflows. The WE controller can use a unified MCP interface for all three engines (K8s Jobs, Tekton, Ansible), eliminating the need for a separate AWX REST API integration.
+
+### Open Items
+
+1. **Gateway credential injection**: Validate Kuadrant `BackendPolicy` for per-backend header injection (AAP Bearer token)
+2. **Upstream patch**: Submit env-var-controlled compat mode for AAP 2.5 (skip gateway path rewrite + fallback auth endpoint)
+3. **RBAC mapping**: Define how KA's Keycloak roles map to AAP user permissions (token exchange or pre-provisioned service account)

--- a/docs/tests/1460/TEST_PLAN.md
+++ b/docs/tests/1460/TEST_PLAN.md
@@ -1,0 +1,59 @@
+# Test Plan: Issue #1460 — status/subscribe SSE Endpoint
+
+**Business Requirement**: BR-AF-1460
+**Design Document**: DD-AF-008
+**Date**: 2026-06-18
+
+## Scope
+
+Tests for the `POST /a2a/status` endpoint that delivers RR phase transitions
+as an SSE stream.
+
+## Unit Tests (logic)
+
+| ID | Description | File |
+|----|------------|------|
+| UT-AF-1460-001 | Valid status/subscribe request parses correctly, extracts rr_id | handler/status_handler_test.go |
+| UT-AF-1460-002 | Missing rr_id returns JSON-RPC error -32602 (invalid_params) | handler/status_handler_test.go |
+| UT-AF-1460-003 | Wrong method returns -32601 (method_not_found) | handler/status_handler_test.go |
+| UT-AF-1460-004 | Malformed JSON returns -32600 (invalid_request) | handler/status_handler_test.go |
+| UT-AF-1460-005 | buildPhaseMetadata for Executing phase returns workflow_id, started_at | handler/status_types_test.go |
+| UT-AF-1460-006 | buildPhaseMetadata for Verifying phase returns verification_deadline, started_at, ea_phase, stabilization_deadline | handler/status_types_test.go |
+| UT-AF-1460-007 | buildPhaseMetadata for Blocked phase returns blocked_until, block_reason, block_message | handler/status_types_test.go |
+| UT-AF-1460-008 | buildPhaseMetadata for terminal phases returns outcome/failure_reason/skip_reason | handler/status_types_test.go |
+| UT-AF-1460-030 | HandleWatch uses effectivenessAssessmentRef when available | tools/kubernaut_watch_test.go |
+
+## Integration Tests (wiring)
+
+| ID | Description | File |
+|----|------------|------|
+| IT-AF-1460-010 | REQ-2: subscribe to existing non-terminal RR receives current phase as first SSE event | status_subscribe_test.go |
+| IT-AF-1460-011 | Phase transition: RR Processing->Executing emits SSE event with workflow_id metadata | status_subscribe_test.go |
+| IT-AF-1460-012 | EA sub-phase: Verifying with effectivenessAssessmentRef emits ea_phase in metadata | status_subscribe_test.go |
+| IT-AF-1460-013 | Watch reconnection: handler re-establishes watch transparently on channel close | status_subscribe_test.go |
+| IT-AF-1460-014 | status/closing: pre-warning emitted before token deadline kills stream | status_subscribe_test.go |
+| IT-AF-1460-015 | Terminal phase: Completed emits final:true with outcome, stream closes | status_subscribe_test.go |
+| IT-AF-1460-016 | rr_not_found: subscribe to non-existent RR returns -32001 error | status_subscribe_test.go |
+| IT-AF-1460-017 | Already-terminal: subscribe to Completed RR sends single final event, closes | status_subscribe_test.go |
+| IT-AF-1460-018 | Heartbeat: received within 15s on idle stream | status_subscribe_test.go |
+| IT-AF-1460-019 | Blocked phase: transition emits blocked_until, block_reason in metadata | status_subscribe_test.go |
+| IT-AF-1460-020 | Route dispatch: POST /a2a/status dispatches to StatusHandler through auth chain | router_http_test.go |
+| IT-AF-1460-040 | RBAC parity: AF ClusterRole grants get, list, watch on effectivenessassessments | tools_crd_test.go |
+
+## Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | IT Test ID |
+|-----------|----------------------|---------------------|------------|
+| StatusHandler | RouterConfig.StatusHandler | handler/router.go:NewRouter | IT-AF-1460-020 |
+| POST /a2a/status route | mux.Handle in NewRouter | handler/router.go | IT-AF-1460-020 |
+| StatusHandler construction | main() deps wiring | cmd/apifrontend/main.go | IT-AF-1460-020 |
+| EA watch via effectivenessAssessmentRef | handleSubscribe | handler/status_handler.go | IT-AF-1460-012 |
+| Watch reconnection loop | handleSubscribe | handler/status_handler.go | IT-AF-1460-013 |
+| status/closing pre-warning | handleSubscribe | handler/status_handler.go | IT-AF-1460-014 |
+| HandleWatch EA-ref migration | HandleWatch | tools/crd_tools.go | UT-AF-1460-030 |
+| RBAC EA watch/list | ClusterRole | deploy/apifrontend/base/02-rbac.yaml | IT-AF-1460-040 |
+
+## Coverage Targets
+
+- Unit: >=80% of status_handler.go and status_types.go
+- Integration: >=80% of status_handler.go through production HTTP stack

--- a/pkg/apifrontend/agent/prompt.txt
+++ b/pkg/apifrontend/agent/prompt.txt
@@ -133,6 +133,16 @@ In interactive mode: STOP here and wait for user selection.
    - A brief explanation of what happened during each phase
    - If the outcome is "Inconclusive", explain that the effectiveness assessment could not confirm the remediation resolved the issue, and suggest next steps (manual review, re-investigation, etc.)
 
+### Post-Remediation Follow-ups
+
+After Phase 4 reaches a terminal state, the remediation lifecycle for that RR is complete. If the user asks follow-up questions about the same resource or alert in the same session:
+
+1. **Check conversation history first**: You already have the kubernaut_watch result showing the terminal status and outcome. Use this context before taking any action.
+2. **Use observation tools for status checks**: If the user asks whether the alert is still firing, whether the resource is healthy, etc., use observation tools (list_alerts, kubectl_get, kubernaut_get_remediation) — do NOT call kubernaut_investigate again for the same resource.
+3. **Correlate observations with the completed remediation**: If the alert cleared and the workflow outcome was "Remediated", state that the executed workflow appears to have resolved the issue. Do NOT suggest running another workflow.
+4. **Do NOT re-enter the Phase 1→4 lifecycle**: The RR has already been remediated. Only suggest a new remediation if the user explicitly asks for one (e.g., "try a different approach", "run another workflow").
+5. **Distinguish residual root cause from remediation failure**: If the executed workflow addressed the immediate symptom (e.g., reverted a bad config) but not a deeper structural issue (e.g., memory limits), you may note this as a long-term recommendation — but do NOT frame it as "the workflow did not remediate" or offer to run a workflow unprompted.
+
 ## Tool Inventory (grouped by intent)
 
 ### Investigate an incident

--- a/pkg/apifrontend/handler/router.go
+++ b/pkg/apifrontend/handler/router.go
@@ -27,6 +27,7 @@ type RouterConfig struct {
 	ReadyChecker       func() bool
 	MaxPayloadBytes    int64
 	SSETracker         *streaming.ConnectionTracker
+	StatusHandler      http.Handler
 	Draining           *atomic.Bool
 }
 
@@ -100,6 +101,18 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) { //nolint:gocritic // hu
 	mux.Handle("POST /a2a/invoke", a2aChain)
 	mux.Handle("POST /{$}", a2aChain)
 	mux.Handle("POST /mcp", mcpChain)
+
+	if cfg.StatusHandler != nil {
+		innerStatus := writeDeadlineMiddleware(maxBodyMiddleware(maxBytes, trackSSEConnection(cfg.SSETracker, cfg.StatusHandler)))
+		if cfg.PostAuthMiddleware != nil {
+			innerStatus = cfg.PostAuthMiddleware(innerStatus)
+		}
+		statusChain := cfg.AuthMiddleware(innerStatus)
+		if cfg.PreAuthMiddleware != nil {
+			statusChain = cfg.PreAuthMiddleware(statusChain)
+		}
+		mux.Handle("POST /a2a/status", statusChain)
+	}
 
 	recoverLogger := cfg.Logger
 	if recoverLogger.GetSink() == nil {

--- a/pkg/apifrontend/handler/status_handler.go
+++ b/pkg/apifrontend/handler/status_handler.go
@@ -1,0 +1,302 @@
+package handler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/watch"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	eav1alpha1 "github.com/jordigilh/kubernaut/api/effectivenessassessment/v1alpha1"
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/streaming"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+)
+
+const heartbeatInterval = 15 * time.Second
+
+// StatusHandler serves the POST /a2a/status endpoint (DD-AF-008).
+// It parses JSON-RPC status/subscribe requests and initiates SSE streams
+// for RR phase transition events.
+type StatusHandler struct {
+	client    crclient.WithWatch
+	namespace string
+	logger    logr.Logger
+}
+
+// NewStatusHandler constructs a StatusHandler.
+func NewStatusHandler(client crclient.WithWatch, namespace string, logger logr.Logger) *StatusHandler {
+	if logger.GetSink() == nil {
+		logger = logr.Discard()
+	}
+	return &StatusHandler{
+		client:    client,
+		namespace: namespace,
+		logger:    logger.WithName("status-handler"),
+	}
+}
+
+func (h *StatusHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	req, rpcErr := parseStatusSubscribeRequest(r)
+	if rpcErr != nil {
+		writeJSONRPCError(w, nil, rpcErr.Code, rpcErr.Message)
+		return
+	}
+
+	h.handleSubscribe(w, r, req)
+}
+
+func (h *StatusHandler) handleSubscribe(w http.ResponseWriter, r *http.Request, req *StatusSubscribeRequest) {
+	ctx := r.Context()
+	logger := h.logger.WithValues("rr_id", req.Params.RRID)
+
+	if h.client == nil {
+		logger.Info("no K8s client configured")
+		http.Error(w, "no K8s client configured", http.StatusServiceUnavailable)
+		return
+	}
+
+	var rr remediationv1.RemediationRequest
+	key := crclient.ObjectKey{Namespace: h.namespace, Name: req.Params.RRID}
+	if err := h.client.Get(ctx, key, &rr); err != nil {
+		if apierrors.IsNotFound(err) {
+			writeJSONRPCError(w, req.ID, errCodeRRNotFound, "rr_not_found")
+			return
+		}
+		logger.Error(err, "failed to get RR")
+		writeJSONRPCError(w, req.ID, errCodeRRNotFound, "rr_not_found")
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "streaming unsupported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	phase := string(rr.Status.OverallPhase)
+	isFinal := tools.IsTerminalPhase(phase)
+
+	var ea *eav1alpha1.EffectivenessAssessment
+	if phase == "Verifying" {
+		ea = h.fetchEA(ctx, &rr)
+	}
+
+	h.writeStatusUpdate(w, flusher, req.Params.RRID, phase, isFinal, BuildPhaseMetadata(&rr, ea))
+
+	if isFinal {
+		return
+	}
+
+	rrList := &remediationv1.RemediationRequestList{}
+	rrWatcher, err := h.client.Watch(ctx, rrList,
+		crclient.InNamespace(h.namespace),
+		crclient.MatchingFields{"metadata.name": req.Params.RRID})
+	if err != nil {
+		logger.Error(err, "failed to start RR watch")
+		return
+	}
+	defer rrWatcher.Stop()
+
+	heartbeat := time.NewTicker(heartbeatInterval)
+	defer heartbeat.Stop()
+
+	var eaCh <-chan watch.Event
+	var eaWatcher watch.Interface
+	lastSeenPhase := phase
+
+	var deadlineTimer <-chan time.Time
+	if deadline, ok := ctx.Deadline(); ok {
+		preWarning := time.Until(deadline) - 5*time.Second
+		if preWarning > 0 {
+			timer := time.NewTimer(preWarning)
+			defer timer.Stop()
+			deadlineTimer = timer.C
+		}
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+
+		case <-heartbeat.C:
+			_, _ = w.Write(streaming.HeartbeatFrame())
+			flusher.Flush()
+
+		case <-deadlineTimer:
+			h.writeStatusClosing(w, flusher, "token_expiry", true)
+			deadlineTimer = nil
+
+		case evt, ok := <-rrWatcher.ResultChan():
+			if !ok {
+				rrWatcher, err = h.client.Watch(ctx, rrList,
+					crclient.InNamespace(h.namespace),
+					crclient.MatchingFields{"metadata.name": req.Params.RRID})
+				if err != nil {
+					logger.Error(err, "failed to reconnect RR watch")
+					return
+				}
+				continue
+			}
+			if evt.Type != watch.Modified && evt.Type != watch.Added {
+				continue
+			}
+			rrObj, ok := evt.Object.(*remediationv1.RemediationRequest)
+			if !ok {
+				continue
+			}
+			newPhase := string(rrObj.Status.OverallPhase)
+			if newPhase == lastSeenPhase {
+				continue
+			}
+			lastSeenPhase = newPhase
+
+			if newPhase == "Verifying" && eaCh == nil {
+				ea = h.fetchEA(ctx, rrObj)
+				eaName := tools.ResolveEAName(rrObj)
+				eaList := &eav1alpha1.EffectivenessAssessmentList{}
+				eaWatcher, err = h.client.Watch(ctx, eaList,
+					crclient.InNamespace(h.namespace),
+					crclient.MatchingFields{"metadata.name": eaName})
+				if err == nil {
+					eaCh = eaWatcher.ResultChan()
+					defer eaWatcher.Stop()
+				} else {
+					logger.V(1).Info("EA watch unavailable", "ea_name", eaName, "error", err)
+				}
+			}
+
+			isFinal = tools.IsTerminalPhase(newPhase)
+			meta := BuildPhaseMetadata(rrObj, ea)
+			h.writeStatusUpdate(w, flusher, req.Params.RRID, newPhase, isFinal, meta)
+
+			if isFinal {
+				return
+			}
+
+		case eaEvt, ok := <-eaCh:
+			if !ok {
+				eaCh = nil
+				eaName := tools.ResolveEAName(&rr)
+				eaList := &eav1alpha1.EffectivenessAssessmentList{}
+				eaWatcher, err = h.client.Watch(ctx, eaList,
+					crclient.InNamespace(h.namespace),
+					crclient.MatchingFields{"metadata.name": eaName})
+				if err == nil {
+					eaCh = eaWatcher.ResultChan()
+					defer eaWatcher.Stop()
+				}
+				continue
+			}
+			if eaEvt.Type != watch.Modified && eaEvt.Type != watch.Added {
+				continue
+			}
+			eaObj, ok := eaEvt.Object.(*eav1alpha1.EffectivenessAssessment)
+			if !ok {
+				continue
+			}
+			ea = eaObj
+
+			if err := h.client.Get(ctx, key, &rr); err != nil {
+				logger.V(1).Info("failed to refresh RR for EA event", "error", err)
+				continue
+			}
+			meta := BuildPhaseMetadata(&rr, ea)
+			h.writeStatusUpdate(w, flusher, req.Params.RRID, string(rr.Status.OverallPhase), false, meta)
+		}
+	}
+}
+
+func (h *StatusHandler) fetchEA(ctx context.Context, rr *remediationv1.RemediationRequest) *eav1alpha1.EffectivenessAssessment {
+	eaName := tools.ResolveEAName(rr)
+	var ea eav1alpha1.EffectivenessAssessment
+	if err := h.client.Get(ctx, crclient.ObjectKey{Namespace: h.namespace, Name: eaName}, &ea); err != nil {
+		return nil
+	}
+	return &ea
+}
+
+func (h *StatusHandler) writeStatusUpdate(w http.ResponseWriter, flusher http.Flusher, rrID, phase string, final bool, metadata map[string]any) {
+	params := StatusUpdateParams{
+		RRID:      rrID,
+		Phase:     phase,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Final:     final,
+		Metadata:  metadata,
+	}
+	envelope := map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "status/update",
+		"params":  params,
+	}
+	data, err := json.Marshal(envelope)
+	if err != nil {
+		h.logger.Error(err, "failed to marshal status/update")
+		return
+	}
+	fmt.Fprintf(w, "event: status/update\ndata: %s\n\n", data)
+	flusher.Flush()
+}
+
+func (h *StatusHandler) writeStatusClosing(w http.ResponseWriter, flusher http.Flusher, reason string, reconnect bool) {
+	params := StatusClosingParams{
+		Reason:    reason,
+		Reconnect: reconnect,
+	}
+	envelope := map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "status/closing",
+		"params":  params,
+	}
+	data, err := json.Marshal(envelope)
+	if err != nil {
+		h.logger.Error(err, "failed to marshal status/closing")
+		return
+	}
+	fmt.Fprintf(w, "event: status/closing\ndata: %s\n\n", data)
+	flusher.Flush()
+}
+
+func parseStatusSubscribeRequest(r *http.Request) (*StatusSubscribeRequest, *jsonRPCError) {
+	var req StatusSubscribeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return nil, &jsonRPCError{Code: errCodeInvalidRequest, Message: "invalid_request"}
+	}
+
+	if req.Method != "status/subscribe" {
+		return nil, &jsonRPCError{Code: errCodeMethodNotFound, Message: "method_not_found"}
+	}
+
+	if req.Params.RRID == "" {
+		return nil, &jsonRPCError{Code: errCodeInvalidParams, Message: "invalid_params"}
+	}
+
+	return &req, nil
+}
+
+func writeJSONRPCError(w http.ResponseWriter, id any, code int, message string) {
+	resp := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      id,
+		"error": map[string]any{
+			"code":    code,
+			"message": message,
+		},
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusBadRequest)
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		http.Error(w, fmt.Sprintf("failed to encode error response: %v", err), http.StatusInternalServerError)
+	}
+}

--- a/pkg/apifrontend/handler/status_handler.go
+++ b/pkg/apifrontend/handler/status_handler.go
@@ -296,7 +296,9 @@ func (h *StatusHandler) writeStatusUpdate(w http.ResponseWriter, flusher http.Fl
 		h.logger.Error(err, "failed to marshal status/update")
 		return
 	}
-	fmt.Fprintf(w, "event: status/update\ndata: %s\n\n", data)
+	if _, err = fmt.Fprintf(w, "event: status/update\ndata: %s\n\n", data); err != nil {
+		h.logger.V(1).Info("failed to write status/update frame", "error", err)
+	}
 	flusher.Flush()
 }
 
@@ -315,7 +317,9 @@ func (h *StatusHandler) writeStatusClosing(w http.ResponseWriter, flusher http.F
 		h.logger.Error(err, "failed to marshal status/closing")
 		return
 	}
-	fmt.Fprintf(w, "event: status/closing\ndata: %s\n\n", data)
+	if _, err = fmt.Fprintf(w, "event: status/closing\ndata: %s\n\n", data); err != nil {
+		h.logger.V(1).Info("failed to write status/closing frame", "error", err)
+	}
 	flusher.Flush()
 }
 

--- a/pkg/apifrontend/handler/status_handler.go
+++ b/pkg/apifrontend/handler/status_handler.go
@@ -18,26 +18,36 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
 )
 
-const heartbeatInterval = 15 * time.Second
+const defaultHeartbeatInterval = 15 * time.Second
 
 // StatusHandler serves the POST /a2a/status endpoint (DD-AF-008).
-// It parses JSON-RPC status/subscribe requests and initiates SSE streams
-// for RR phase transition events.
 type StatusHandler struct {
-	client    crclient.WithWatch
-	namespace string
-	logger    logr.Logger
+	client            crclient.WithWatch
+	namespace         string
+	logger            logr.Logger
+	heartbeatInterval time.Duration
 }
 
-// NewStatusHandler constructs a StatusHandler.
+// NewStatusHandler constructs a StatusHandler with the default 15s heartbeat.
 func NewStatusHandler(client crclient.WithWatch, namespace string, logger logr.Logger) *StatusHandler {
+	return newStatusHandler(client, namespace, logger, defaultHeartbeatInterval)
+}
+
+// NewStatusHandlerForTest constructs a StatusHandler with a custom heartbeat
+// interval. Production code should use NewStatusHandler.
+func NewStatusHandlerForTest(client crclient.WithWatch, namespace string, logger logr.Logger, heartbeat time.Duration) *StatusHandler {
+	return newStatusHandler(client, namespace, logger, heartbeat)
+}
+
+func newStatusHandler(client crclient.WithWatch, namespace string, logger logr.Logger, heartbeat time.Duration) *StatusHandler {
 	if logger.GetSink() == nil {
 		logger = logr.Discard()
 	}
 	return &StatusHandler{
-		client:    client,
-		namespace: namespace,
-		logger:    logger.WithName("status-handler"),
+		client:            client,
+		namespace:         namespace,
+		logger:            logger.WithName("status-handler"),
+		heartbeatInterval: heartbeat,
 	}
 }
 
@@ -98,6 +108,8 @@ func (h *StatusHandler) handleSubscribe(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
+	rrResourceVersion := rr.ResourceVersion
+
 	rrList := &remediationv1.RemediationRequestList{}
 	rrWatcher, err := h.client.Watch(ctx, rrList,
 		crclient.InNamespace(h.namespace),
@@ -108,12 +120,24 @@ func (h *StatusHandler) handleSubscribe(w http.ResponseWriter, r *http.Request, 
 	}
 	defer rrWatcher.Stop()
 
-	heartbeat := time.NewTicker(heartbeatInterval)
+	heartbeat := time.NewTicker(h.heartbeatInterval)
 	defer heartbeat.Stop()
 
 	var eaCh <-chan watch.Event
 	var eaWatcher watch.Interface
+	var prevEA *eav1alpha1.EffectivenessAssessment
+	var eaResourceVersion string
 	lastSeenPhase := phase
+
+	if phase == "Verifying" && ea != nil {
+		prevEA = ea.DeepCopy()
+		eaResourceVersion = ea.ResourceVersion
+		eaName := tools.ResolveEAName(&rr)
+		eaWatcher, eaCh = h.startEAWatch(ctx, eaName)
+		if eaWatcher != nil {
+			defer eaWatcher.Stop()
+		}
+	}
 
 	var deadlineTimer <-chan time.Time
 	if deadline, ok := ctx.Deadline(); ok {
@@ -140,6 +164,8 @@ func (h *StatusHandler) handleSubscribe(w http.ResponseWriter, r *http.Request, 
 
 		case evt, ok := <-rrWatcher.ResultChan():
 			if !ok {
+				logger.V(1).Info("RR watch closed, reconnecting", "resourceVersion", rrResourceVersion)
+				rrWatcher.Stop()
 				rrWatcher, err = h.client.Watch(ctx, rrList,
 					crclient.InNamespace(h.namespace),
 					crclient.MatchingFields{"metadata.name": req.Params.RRID})
@@ -156,6 +182,7 @@ func (h *StatusHandler) handleSubscribe(w http.ResponseWriter, r *http.Request, 
 			if !ok {
 				continue
 			}
+			rrResourceVersion = rrObj.ResourceVersion
 			newPhase := string(rrObj.Status.OverallPhase)
 			if newPhase == lastSeenPhase {
 				continue
@@ -164,16 +191,17 @@ func (h *StatusHandler) handleSubscribe(w http.ResponseWriter, r *http.Request, 
 
 			if newPhase == "Verifying" && eaCh == nil {
 				ea = h.fetchEA(ctx, rrObj)
+				if ea != nil {
+					prevEA = ea.DeepCopy()
+					eaResourceVersion = ea.ResourceVersion
+				}
 				eaName := tools.ResolveEAName(rrObj)
-				eaList := &eav1alpha1.EffectivenessAssessmentList{}
-				eaWatcher, err = h.client.Watch(ctx, eaList,
-					crclient.InNamespace(h.namespace),
-					crclient.MatchingFields{"metadata.name": eaName})
-				if err == nil {
-					eaCh = eaWatcher.ResultChan()
+				if eaWatcher != nil {
+					eaWatcher.Stop()
+				}
+				eaWatcher, eaCh = h.startEAWatch(ctx, eaName)
+				if eaWatcher != nil {
 					defer eaWatcher.Stop()
-				} else {
-					logger.V(1).Info("EA watch unavailable", "ea_name", eaName, "error", err)
 				}
 			}
 
@@ -187,15 +215,17 @@ func (h *StatusHandler) handleSubscribe(w http.ResponseWriter, r *http.Request, 
 
 		case eaEvt, ok := <-eaCh:
 			if !ok {
+				logger.V(1).Info("EA watch closed, reconnecting", "resourceVersion", eaResourceVersion)
 				eaCh = nil
-				eaName := tools.ResolveEAName(&rr)
-				eaList := &eav1alpha1.EffectivenessAssessmentList{}
-				eaWatcher, err = h.client.Watch(ctx, eaList,
-					crclient.InNamespace(h.namespace),
-					crclient.MatchingFields{"metadata.name": eaName})
-				if err == nil {
-					eaCh = eaWatcher.ResultChan()
-					defer eaWatcher.Stop()
+				if eaWatcher != nil {
+					eaWatcher.Stop()
+				}
+				if err := h.client.Get(ctx, key, &rr); err == nil {
+					eaName := tools.ResolveEAName(&rr)
+					eaWatcher, eaCh = h.startEAWatch(ctx, eaName)
+					if eaWatcher != nil {
+						defer eaWatcher.Stop()
+					}
 				}
 				continue
 			}
@@ -206,16 +236,37 @@ func (h *StatusHandler) handleSubscribe(w http.ResponseWriter, r *http.Request, 
 			if !ok {
 				continue
 			}
+			eaResourceVersion = eaObj.ResourceVersion
+
+			steps := tools.DiffEASteps(prevEA, eaObj)
+			prevEA = eaObj.DeepCopy()
 			ea = eaObj
+
+			if len(steps) == 0 {
+				continue
+			}
 
 			if err := h.client.Get(ctx, key, &rr); err != nil {
 				logger.V(1).Info("failed to refresh RR for EA event", "error", err)
 				continue
 			}
 			meta := BuildPhaseMetadata(&rr, ea)
+			meta["verification_steps"] = steps
 			h.writeStatusUpdate(w, flusher, req.Params.RRID, string(rr.Status.OverallPhase), false, meta)
 		}
 	}
+}
+
+func (h *StatusHandler) startEAWatch(ctx context.Context, eaName string) (watch.Interface, <-chan watch.Event) {
+	eaList := &eav1alpha1.EffectivenessAssessmentList{}
+	watcher, err := h.client.Watch(ctx, eaList,
+		crclient.InNamespace(h.namespace),
+		crclient.MatchingFields{"metadata.name": eaName})
+	if err != nil {
+		h.logger.V(1).Info("EA watch unavailable", "ea_name", eaName, "error", err)
+		return nil, nil
+	}
+	return watcher, watcher.ResultChan()
 }
 
 func (h *StatusHandler) fetchEA(ctx context.Context, rr *remediationv1.RemediationRequest) *eav1alpha1.EffectivenessAssessment {

--- a/pkg/apifrontend/handler/status_handler_test.go
+++ b/pkg/apifrontend/handler/status_handler_test.go
@@ -1,0 +1,101 @@
+package handler_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/handler"
+)
+
+var _ = Describe("StatusHandler JSON-RPC parsing", func() {
+	var h *handler.StatusHandler
+
+	BeforeEach(func() {
+		h = handler.NewStatusHandler(nil, "kubernaut-system", logr.Discard())
+	})
+
+	It("UT-AF-1460-001: valid status/subscribe request parses correctly", func() {
+		body := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      "status-1",
+			"method":  "status/subscribe",
+			"params":  map[string]any{"rr_id": "rr-0fd7ce7b49a7"},
+		}
+		raw, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/a2a/status", bytes.NewReader(raw))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+
+		h.ServeHTTP(rec, req)
+
+		Expect(rec.Code).To(Equal(http.StatusServiceUnavailable),
+			"valid request with no client returns 503 (parsing succeeded)")
+		Expect(rec.Code).NotTo(Equal(http.StatusBadRequest),
+			"valid request must not return 400")
+	})
+
+	It("UT-AF-1460-002: missing rr_id returns JSON-RPC error -32602", func() {
+		body := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      "status-2",
+			"method":  "status/subscribe",
+			"params":  map[string]any{},
+		}
+		raw, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/a2a/status", bytes.NewReader(raw))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+
+		h.ServeHTTP(rec, req)
+
+		Expect(rec.Code).To(Equal(http.StatusBadRequest))
+		var resp map[string]any
+		Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+		errObj, ok := resp["error"].(map[string]any)
+		Expect(ok).To(BeTrue(), "response must contain error object")
+		Expect(errObj["code"]).To(BeNumerically("==", -32602))
+	})
+
+	It("UT-AF-1460-003: wrong method returns JSON-RPC error -32601", func() {
+		body := map[string]any{
+			"jsonrpc": "2.0",
+			"id":      "status-3",
+			"method":  "status/unsubscribe",
+			"params":  map[string]any{"rr_id": "rr-xxx"},
+		}
+		raw, _ := json.Marshal(body)
+		req := httptest.NewRequest(http.MethodPost, "/a2a/status", bytes.NewReader(raw))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+
+		h.ServeHTTP(rec, req)
+
+		Expect(rec.Code).To(Equal(http.StatusBadRequest))
+		var resp map[string]any
+		Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+		errObj, ok := resp["error"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(errObj["code"]).To(BeNumerically("==", -32601))
+	})
+
+	It("UT-AF-1460-004: malformed JSON returns JSON-RPC error -32600", func() {
+		req := httptest.NewRequest(http.MethodPost, "/a2a/status", bytes.NewReader([]byte("{invalid")))
+		req.Header.Set("Content-Type", "application/json")
+		rec := httptest.NewRecorder()
+
+		h.ServeHTTP(rec, req)
+
+		Expect(rec.Code).To(Equal(http.StatusBadRequest))
+		var resp map[string]any
+		Expect(json.Unmarshal(rec.Body.Bytes(), &resp)).To(Succeed())
+		errObj, ok := resp["error"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(errObj["code"]).To(BeNumerically("==", -32600))
+	})
+})

--- a/pkg/apifrontend/handler/status_types.go
+++ b/pkg/apifrontend/handler/status_types.go
@@ -1,0 +1,120 @@
+package handler
+
+import (
+	"time"
+
+	eav1alpha1 "github.com/jordigilh/kubernaut/api/effectivenessassessment/v1alpha1"
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
+)
+
+// StatusSubscribeRequest represents a JSON-RPC 2.0 status/subscribe request.
+type StatusSubscribeRequest struct {
+	JSONRPC string                `json:"jsonrpc"`
+	ID      any                   `json:"id"`
+	Method  string                `json:"method"`
+	Params  StatusSubscribeParams `json:"params"`
+}
+
+// StatusSubscribeParams contains the parameters for a status/subscribe request.
+type StatusSubscribeParams struct {
+	RRID string `json:"rr_id"`
+}
+
+// StatusUpdateParams represents the params of a status/update SSE event.
+type StatusUpdateParams struct {
+	RRID      string         `json:"rr_id"`
+	Phase     string         `json:"phase"`
+	Timestamp string         `json:"timestamp"`
+	Final     bool           `json:"final"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+}
+
+// StatusClosingParams represents the params of a status/closing SSE event.
+type StatusClosingParams struct {
+	Reason    string `json:"reason"`
+	Reconnect bool   `json:"reconnect"`
+}
+
+// jsonRPCError represents a JSON-RPC 2.0 error object.
+type jsonRPCError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+// JSON-RPC error codes per the agreed contract (DD-AF-008).
+const (
+	errCodeInvalidRequest = -32600
+	errCodeMethodNotFound = -32601
+	errCodeInvalidParams  = -32602
+	errCodeRRNotFound     = -32001
+)
+
+// BuildPhaseMetadata constructs per-phase metadata from CRD status fields.
+// The returned map uses raw CRD field names per the agreed console contract.
+func BuildPhaseMetadata(rr *remediationv1.RemediationRequest, ea *eav1alpha1.EffectivenessAssessment) map[string]any {
+	meta := make(map[string]any)
+	phase := rr.Status.OverallPhase
+
+	switch phase {
+	case remediationv1.PhaseExecuting:
+		if rr.Status.SelectedWorkflowRef != nil {
+			meta["workflow_id"] = rr.Status.SelectedWorkflowRef.WorkflowID
+		}
+		if rr.Status.ExecutingStartTime != nil {
+			meta["started_at"] = rr.Status.ExecutingStartTime.Time.Format(time.RFC3339)
+		}
+
+	case remediationv1.PhaseVerifying:
+		if rr.Status.VerificationDeadline != nil {
+			meta["verification_deadline"] = rr.Status.VerificationDeadline.Time.Format(time.RFC3339)
+		}
+		if rr.Status.ExecutingStartTime != nil {
+			meta["started_at"] = rr.Status.ExecutingStartTime.Time.Format(time.RFC3339)
+		}
+		if ea != nil {
+			meta["ea_phase"] = ea.Status.Phase
+			if ea.Status.PrometheusCheckAfter != nil {
+				meta["stabilization_deadline"] = ea.Status.PrometheusCheckAfter.Time.Format(time.RFC3339)
+			}
+		}
+
+	case remediationv1.PhaseBlocked:
+		if rr.Status.BlockedUntil != nil {
+			meta["blocked_until"] = rr.Status.BlockedUntil.Time.Format(time.RFC3339)
+		}
+		if rr.Status.BlockReason != "" {
+			meta["block_reason"] = string(rr.Status.BlockReason)
+		}
+		if rr.Status.BlockMessage != "" {
+			meta["block_message"] = rr.Status.BlockMessage
+		}
+
+	case remediationv1.PhaseAwaitingApproval:
+		// Approval-related metadata can be extended when RAR ref is available
+
+	case remediationv1.PhaseCompleted:
+		if rr.Status.Outcome != "" {
+			meta["outcome"] = rr.Status.Outcome
+		}
+
+	case remediationv1.PhaseFailed:
+		if rr.Status.FailureReason != nil {
+			meta["failure_reason"] = *rr.Status.FailureReason
+		}
+		if rr.Status.FailurePhase != nil {
+			meta["failure_phase"] = string(*rr.Status.FailurePhase)
+		}
+
+	case remediationv1.PhaseTimedOut:
+		if rr.Status.TimeoutPhase != nil {
+			meta["failure_phase"] = string(*rr.Status.TimeoutPhase)
+		}
+
+	case remediationv1.PhaseSkipped:
+		if rr.Status.SkipReason != "" {
+			meta["skip_reason"] = string(rr.Status.SkipReason)
+		}
+	}
+
+	return meta
+}

--- a/pkg/apifrontend/handler/status_types.go
+++ b/pkg/apifrontend/handler/status_types.go
@@ -66,26 +66,26 @@ func BuildPhaseMetadata(rr *remediationv1.RemediationRequest, ea *eav1alpha1.Eff
 			meta["workflow_id"] = rr.Status.SelectedWorkflowRef.WorkflowID
 		}
 		if rr.Status.ExecutingStartTime != nil {
-			meta["started_at"] = rr.Status.ExecutingStartTime.Time.Format(time.RFC3339)
-		}
+		meta["started_at"] = rr.Status.ExecutingStartTime.Format(time.RFC3339)
+	}
 
 	case remediationv1.PhaseVerifying:
 		if rr.Status.VerificationDeadline != nil {
-			meta["verification_deadline"] = rr.Status.VerificationDeadline.Time.Format(time.RFC3339)
+			meta["verification_deadline"] = rr.Status.VerificationDeadline.Format(time.RFC3339)
 		}
 		if rr.Status.ExecutingStartTime != nil {
-			meta["started_at"] = rr.Status.ExecutingStartTime.Time.Format(time.RFC3339)
+			meta["started_at"] = rr.Status.ExecutingStartTime.Format(time.RFC3339)
 		}
 		if ea != nil {
 			meta["ea_phase"] = ea.Status.Phase
 			if ea.Status.PrometheusCheckAfter != nil {
-				meta["stabilization_deadline"] = ea.Status.PrometheusCheckAfter.Time.Format(time.RFC3339)
+				meta["stabilization_deadline"] = ea.Status.PrometheusCheckAfter.Format(time.RFC3339)
 			}
 		}
 
 	case remediationv1.PhaseBlocked:
 		if rr.Status.BlockedUntil != nil {
-			meta["blocked_until"] = rr.Status.BlockedUntil.Time.Format(time.RFC3339)
+			meta["blocked_until"] = rr.Status.BlockedUntil.Format(time.RFC3339)
 		}
 		if rr.Status.BlockReason != "" {
 			meta["block_reason"] = string(rr.Status.BlockReason)

--- a/pkg/apifrontend/handler/status_types.go
+++ b/pkg/apifrontend/handler/status_types.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"fmt"
 	"time"
 
 	eav1alpha1 "github.com/jordigilh/kubernaut/api/effectivenessassessment/v1alpha1"
@@ -47,6 +48,10 @@ const (
 	errCodeMethodNotFound = -32601
 	errCodeInvalidParams  = -32602
 	errCodeRRNotFound     = -32001
+	// errCodeAccessDenied is reserved for future per-resource authz (SAR).
+	// Today all authenticated users are implicitly authorized; the auth
+	// middleware returns HTTP 401/403 before reaching the handler.
+	errCodeAccessDenied = -32002 //nolint:unused // reserved per DD-AF-008 contract
 )
 
 // BuildPhaseMetadata constructs per-phase metadata from CRD status fields.
@@ -90,7 +95,8 @@ func BuildPhaseMetadata(rr *remediationv1.RemediationRequest, ea *eav1alpha1.Eff
 		}
 
 	case remediationv1.PhaseAwaitingApproval:
-		// Approval-related metadata can be extended when RAR ref is available
+		rarName := fmt.Sprintf("rar-%s", rr.Name)
+		meta["approval_request_name"] = rarName
 
 	case remediationv1.PhaseCompleted:
 		if rr.Status.Outcome != "" {

--- a/pkg/apifrontend/handler/status_types_test.go
+++ b/pkg/apifrontend/handler/status_types_test.go
@@ -1,0 +1,116 @@
+package handler_test
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	eav1alpha1 "github.com/jordigilh/kubernaut/api/effectivenessassessment/v1alpha1"
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/handler"
+)
+
+var _ = Describe("BuildPhaseMetadata", func() {
+	It("UT-AF-1460-005: Executing phase returns workflow_id, started_at", func() {
+		now := metav1.Now()
+		fp := remediationv1.FailurePhaseWorkflowExecution
+		rr := &remediationv1.RemediationRequest{
+			Status: remediationv1.RemediationRequestStatus{
+				OverallPhase:       remediationv1.PhaseExecuting,
+				ExecutingStartTime: &now,
+				SelectedWorkflowRef: &remediationv1.WorkflowReference{
+					WorkflowID: "git-revert-v2",
+				},
+				FailurePhase: &fp,
+			},
+		}
+
+		meta := handler.BuildPhaseMetadata(rr, nil)
+
+		Expect(meta).To(HaveKey("workflow_id"))
+		Expect(meta["workflow_id"]).To(Equal("git-revert-v2"))
+		Expect(meta).To(HaveKey("started_at"))
+	})
+
+	It("UT-AF-1460-006: Verifying phase returns verification_deadline, started_at, ea_phase, stabilization_deadline", func() {
+		now := metav1.Now()
+		deadline := metav1.NewTime(now.Add(10 * time.Minute))
+		rr := &remediationv1.RemediationRequest{
+			Status: remediationv1.RemediationRequestStatus{
+				OverallPhase:         remediationv1.PhaseVerifying,
+				VerificationDeadline: &deadline,
+			},
+		}
+		stabilizationEnd := metav1.NewTime(now.Add(5 * time.Minute))
+		ea := &eav1alpha1.EffectivenessAssessment{
+			Status: eav1alpha1.EffectivenessAssessmentStatus{
+				Phase:                "Stabilizing",
+				PrometheusCheckAfter: &stabilizationEnd,
+			},
+		}
+
+		meta := handler.BuildPhaseMetadata(rr, ea)
+
+		Expect(meta).To(HaveKey("verification_deadline"))
+		Expect(meta).To(HaveKey("ea_phase"))
+		Expect(meta["ea_phase"]).To(Equal("Stabilizing"))
+		Expect(meta).To(HaveKey("stabilization_deadline"))
+	})
+
+	It("UT-AF-1460-007: Blocked phase returns blocked_until, block_reason, block_message", func() {
+		blockedTime := metav1.NewTime(time.Now().Add(1 * time.Hour))
+		rr := &remediationv1.RemediationRequest{
+			Status: remediationv1.RemediationRequestStatus{
+				OverallPhase: remediationv1.PhaseBlocked,
+				BlockReason:  remediationv1.BlockReasonConsecutiveFailures,
+				BlockMessage: "3 consecutive failures. Cooldown expires: 2026-06-18T14:00:00Z",
+				BlockedUntil: &blockedTime,
+			},
+		}
+
+		meta := handler.BuildPhaseMetadata(rr, nil)
+
+		Expect(meta).To(HaveKey("blocked_until"))
+		Expect(meta).To(HaveKey("block_reason"))
+		Expect(meta["block_reason"]).To(Equal(string(remediationv1.BlockReasonConsecutiveFailures)))
+		Expect(meta).To(HaveKey("block_message"))
+	})
+
+	It("UT-AF-1460-008: terminal phases return outcome/failure_reason/skip_reason", func() {
+		rr := &remediationv1.RemediationRequest{
+			Status: remediationv1.RemediationRequestStatus{
+				OverallPhase: remediationv1.PhaseCompleted,
+				Outcome:      "Remediated",
+			},
+		}
+		meta := handler.BuildPhaseMetadata(rr, nil)
+		Expect(meta).To(HaveKey("outcome"))
+		Expect(meta["outcome"]).To(Equal("Remediated"))
+
+		failReason := "workflow execution error"
+		fpPhase := remediationv1.FailurePhaseWorkflowExecution
+		rrFailed := &remediationv1.RemediationRequest{
+			Status: remediationv1.RemediationRequestStatus{
+				OverallPhase:  remediationv1.PhaseFailed,
+				FailureReason: &failReason,
+				FailurePhase:  &fpPhase,
+			},
+		}
+		metaFailed := handler.BuildPhaseMetadata(rrFailed, nil)
+		Expect(metaFailed).To(HaveKey("failure_reason"))
+		Expect(metaFailed["failure_reason"]).To(Equal(failReason))
+		Expect(metaFailed).To(HaveKey("failure_phase"))
+
+		rrSkipped := &remediationv1.RemediationRequest{
+			Status: remediationv1.RemediationRequestStatus{
+				OverallPhase: remediationv1.PhaseSkipped,
+				SkipReason:   remediationv1.SkipReasonRecentlyRemediated,
+			},
+		}
+		metaSkipped := handler.BuildPhaseMetadata(rrSkipped, nil)
+		Expect(metaSkipped).To(HaveKey("skip_reason"))
+		Expect(metaSkipped["skip_reason"]).To(Equal(string(remediationv1.SkipReasonRecentlyRemediated)))
+	})
+})

--- a/pkg/apifrontend/handler/status_types_test.go
+++ b/pkg/apifrontend/handler/status_types_test.go
@@ -78,6 +78,18 @@ var _ = Describe("BuildPhaseMetadata", func() {
 		Expect(meta).To(HaveKey("block_message"))
 	})
 
+	It("UT-AF-1460-008a: AwaitingApproval phase returns approval_request_name", func() {
+		rr := &remediationv1.RemediationRequest{
+			ObjectMeta: metav1.ObjectMeta{Name: "rr-approval-test"},
+			Status: remediationv1.RemediationRequestStatus{
+				OverallPhase: remediationv1.PhaseAwaitingApproval,
+			},
+		}
+		meta := handler.BuildPhaseMetadata(rr, nil)
+		Expect(meta).To(HaveKey("approval_request_name"))
+		Expect(meta["approval_request_name"]).To(Equal("rar-rr-approval-test"))
+	})
+
 	It("UT-AF-1460-008: terminal phases return outcome/failure_reason/skip_reason", func() {
 		rr := &remediationv1.RemediationRequest{
 			Status: remediationv1.RemediationRequestStatus{

--- a/pkg/apifrontend/tools/crd_tools.go
+++ b/pkg/apifrontend/tools/crd_tools.go
@@ -733,7 +733,7 @@ func HandleWatch(ctx context.Context, client crclient.WithWatch, args WatchArgs)
 			})
 			if phase == "Verifying" {
 				verifyingStartedAt = time.Now().UTC()
-				eaName := EANameForRR(args.Name)
+				eaName := ResolveEAName(rrObj)
 				timing := FetchEATimingMetadata(ctx, client, nil, args.Namespace, eaName)
 
 				statusMeta := map[string]any{"type": launcher.MetaTypeStatus}
@@ -769,7 +769,7 @@ func HandleWatch(ctx context.Context, client crclient.WithWatch, args WatchArgs)
 			}
 			progressMeta := map[string]any{"type": "execution_progress"}
 			if phase == "Verifying" {
-				eaName := EANameForRR(args.Name)
+				eaName := ResolveEAName(rrObj)
 				timing := FetchEATimingMetadata(ctx, client, nil, args.Namespace, eaName)
 				if timing.StabilizationWindow != "" {
 					progressMeta["stabilization_window"] = timing.StabilizationWindow

--- a/pkg/apifrontend/tools/execution_progress.go
+++ b/pkg/apifrontend/tools/execution_progress.go
@@ -10,6 +10,7 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	eav1alpha1 "github.com/jordigilh/kubernaut/api/effectivenessassessment/v1alpha1"
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/resilience"
 )
 
@@ -34,6 +35,15 @@ func BuildProgressSnapshot(currentPhase, rrName, startedAt, completedAt string) 
 // pkg/remediationorchestrator/creator/effectivenessassessment.go.
 func EANameForRR(rrName string) string {
 	return fmt.Sprintf("ea-%s", rrName)
+}
+
+// ResolveEAName returns the EA name from the RR's EffectivenessAssessmentRef
+// if populated, falling back to EANameForRR for backward compatibility.
+func ResolveEAName(rr *remediationv1.RemediationRequest) string {
+	if rr.Status.EffectivenessAssessmentRef != nil && rr.Status.EffectivenessAssessmentRef.Name != "" {
+		return rr.Status.EffectivenessAssessmentRef.Name
+	}
+	return EANameForRR(rr.Name)
 }
 
 // EATimingMetadata holds timing fields extracted from an EffectivenessAssessment.

--- a/pkg/apifrontend/tools/kubernaut_watch_test.go
+++ b/pkg/apifrontend/tools/kubernaut_watch_test.go
@@ -600,6 +600,45 @@ var _ = Describe("verification_step events in HandleWatch — #1427", func() {
 		}
 	})
 
+	It("UT-AF-1460-030: HandleWatch uses effectivenessAssessmentRef instead of EANameForRR", func() {
+		refEAName := "custom-ea-name-not-convention"
+		conventionEAName := tools.EANameForRR("rr-ref")
+		Expect(refEAName).NotTo(Equal(conventionEAName), "test precondition: ref name must differ from convention")
+
+		rr := newTypedRR("payments", "rr-ref", "Executing")
+		rr.Status.EffectivenessAssessmentRef = &corev1.ObjectReference{
+			Kind:       "EffectivenessAssessment",
+			Name:       refEAName,
+			Namespace:  "payments",
+			APIVersion: "kubernaut.ai/v1alpha1",
+		}
+
+		var capturedEAGetName string
+		wc := newWatchClientWithInterceptor(interceptor.Funcs{
+			Get: func(ctx context.Context, c crclient.WithWatch, key crclient.ObjectKey, obj crclient.Object, opts ...crclient.GetOption) error {
+				if _, ok := obj.(*eav1alpha1.EffectivenessAssessment); ok {
+					capturedEAGetName = key.Name
+				}
+				return c.Get(ctx, key, obj, opts...)
+			},
+		}, rr)
+
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			updateRRPhase(ctx, wc, "payments", "rr-ref", "Verifying")
+			time.Sleep(50 * time.Millisecond)
+			updateRRTerminal(ctx, wc, "payments", "rr-ref", "Completed", "Remediated", "done")
+		}()
+
+		result, err := tools.HandleWatch(ctx, wc, tools.WatchArgs{Namespace: "payments", Name: "rr-ref"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Status).To(Equal("completed"))
+
+		Expect(capturedEAGetName).To(Equal(refEAName),
+			"HandleWatch must use effectivenessAssessmentRef.Name (%q) for EA lookup, not EANameForRR convention (%q)",
+			refEAName, conventionEAName)
+	})
+
 	It("IT-AF-1427-004: SI-4, AU-3 — alert decay emits alert_check with in_progress and signal name in detail", func() {
 		rr := newTypedRR("payments", "rr-4", "Executing")
 		ea := &eav1alpha1.EffectivenessAssessment{

--- a/test/infrastructure/rbac_parity_test.go
+++ b/test/infrastructure/rbac_parity_test.go
@@ -106,6 +106,7 @@ var _ = Describe("AF RBAC parity (UT-INFRA-RBAC-001)", func() {
 		Entry("pdbs",                "policy",       "poddisruptionbudgets",             []string{"get", "list"}),
 		Entry("leases",              "coordination.k8s.io", "leases",                   []string{"get", "list", "watch"}),
 		Entry("aianalyses",          "kubernaut.ai", "aianalyses",                      []string{"get", "list", "watch"}),
+		Entry("IT-AF-1460-040: EA CRD", "kubernaut.ai", "effectivenessassessments",     []string{"get", "list", "watch"}),
 		Entry("SAR",                 "authorization.k8s.io", "subjectaccessreviews",    []string{"create"}),
 		Entry("token reviews",       "authentication.k8s.io", "tokenreviews",           []string{"create"}),
 	)

--- a/test/infrastructure/rbac_parity_test.go
+++ b/test/infrastructure/rbac_parity_test.go
@@ -111,3 +111,15 @@ var _ = Describe("AF RBAC parity (UT-INFRA-RBAC-001)", func() {
 		Entry("token reviews",       "authentication.k8s.io", "tokenreviews",           []string{"create"}),
 	)
 })
+
+var _ = Describe("IT-AF-1460-021: StatusHandler production wiring", func() {
+	It("StatusHandler is constructed in cmd/apifrontend/main.go", func() {
+		mainPath := filepath.Join(getProjectRoot(), "cmd", "apifrontend", "main.go")
+		data, err := os.ReadFile(mainPath) //nolint:gosec // G304: known project path
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).To(ContainSubstring("NewStatusHandler"),
+			"cmd/apifrontend/main.go must construct StatusHandler")
+		Expect(string(data)).To(ContainSubstring("StatusHandler:"),
+			"cmd/apifrontend/main.go must wire StatusHandler into RouterConfig")
+	})
+})

--- a/test/integration/apifrontend/router_http_test.go
+++ b/test/integration/apifrontend/router_http_test.go
@@ -300,5 +300,35 @@ var _ = Describe("Router HTTP Integration (handler/)", func() {
 				"authenticated request with small body should reach stub handler")
 		})
 	})
+
+	Describe("AC-5: Status subscribe dispatch (#1460)", func() {
+		It("IT-AF-1460-020: POST /a2a/status dispatches through auth chain to StatusHandler", func() {
+			token := signValidToken("it-user-status-020")
+			body := `{"jsonrpc":"2.0","id":"sub-1","method":"status/subscribe","params":{"rr_id":"nonexistent-for-dispatch-test"}}`
+			req, err := http.NewRequest(http.MethodPost, routerServer.URL+"/a2a/status", strings.NewReader(body))
+			Expect(err).NotTo(HaveOccurred())
+			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("Content-Type", "application/json")
+
+			resp, err := http.DefaultClient.Do(req)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+
+			Expect(resp.StatusCode).NotTo(Equal(http.StatusNotFound),
+				"POST /a2a/status must be routed (not 404)")
+			Expect(resp.StatusCode).NotTo(Equal(http.StatusUnauthorized),
+				"authenticated request must pass auth")
+
+			respBody, _ := io.ReadAll(resp.Body)
+			if resp.Header.Get("Content-Type") == "application/json" {
+				var data map[string]any
+				Expect(json.Unmarshal(respBody, &data)).To(Succeed())
+				if errObj, ok := data["error"].(map[string]any); ok {
+					Expect(errObj["code"]).To(BeNumerically("==", -32001),
+						"nonexistent RR should return rr_not_found, not a routing error")
+				}
+			}
+		})
+	})
 })
 

--- a/test/integration/apifrontend/status_subscribe_test.go
+++ b/test/integration/apifrontend/status_subscribe_test.go
@@ -1,0 +1,387 @@
+package apifrontend_test
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+
+	eav1alpha1 "github.com/jordigilh/kubernaut/api/effectivenessassessment/v1alpha1"
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/handler"
+)
+
+func newWatchClient() crclient.WithWatch {
+	wc, err := crclient.NewWithWatch(restCfg, crclient.Options{Scheme: scheme})
+	ExpectWithOffset(1, err).NotTo(HaveOccurred())
+	return wc
+}
+
+func statusSubscribeBody(rrID string) []byte {
+	body := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      "sub-1",
+		"method":  "status/subscribe",
+		"params":  map[string]any{"rr_id": rrID},
+	}
+	raw, _ := json.Marshal(body)
+	return raw
+}
+
+func createTestRR(ctx context.Context, name, ns, phase string) *remediationv1.RemediationRequest {
+	rr := &remediationv1.RemediationRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
+		Spec: remediationv1.RemediationRequestSpec{
+			TargetResource: remediationv1.ResourceIdentifier{
+				Kind: "Deployment",
+				Name: "api-server",
+			},
+		},
+	}
+	ExpectWithOffset(1, k8sClient.Create(ctx, rr)).To(Succeed())
+	rr.Status.OverallPhase = remediationv1.RemediationPhase(phase)
+	ExpectWithOffset(1, k8sClient.Status().Update(ctx, rr)).To(Succeed())
+	return rr
+}
+
+func cleanupTestRR(ctx context.Context, name, ns string) {
+	rr := &remediationv1.RemediationRequest{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns},
+	}
+	_ = k8sClient.Delete(ctx, rr)
+}
+
+type sseEvent struct {
+	Event string
+	Data  string
+}
+
+func collectSSEEvents(resp *http.Response, count int, timeout time.Duration) []sseEvent {
+	var events []sseEvent
+	var mu sync.Mutex
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+		scanner := bufio.NewScanner(resp.Body)
+		var currentEvent, currentData string
+		for scanner.Scan() {
+			line := scanner.Text()
+			switch {
+			case strings.HasPrefix(line, "event: "):
+				currentEvent = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				currentData = strings.TrimPrefix(line, "data: ")
+			case line == "":
+				if currentEvent != "" || currentData != "" {
+					mu.Lock()
+					events = append(events, sseEvent{Event: currentEvent, Data: currentData})
+					if len(events) >= count {
+						mu.Unlock()
+						return
+					}
+					mu.Unlock()
+					currentEvent = ""
+					currentData = ""
+				}
+			}
+		}
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(timeout):
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	result := make([]sseEvent, len(events))
+	copy(result, events)
+	return result
+}
+
+var _ = Describe("status/subscribe SSE endpoint (IT)", func() {
+	var (
+		ctx       context.Context
+		cancel    context.CancelFunc
+		wc        crclient.WithWatch
+		statusSrv *httptest.Server
+		testNS    string
+	)
+
+	BeforeEach(func() {
+		ctx, cancel = context.WithTimeout(context.Background(), 30*time.Second)
+		wc = newWatchClient()
+		testNS = fmt.Sprintf("status-it-%d", time.Now().UnixNano()%100000)
+
+		ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: testNS}}
+		Expect(k8sClient.Create(ctx, ns)).To(Succeed())
+
+		sh := handler.NewStatusHandler(wc, testNS, logf.Log.WithName("status-it"))
+		statusSrv = httptest.NewServer(sh)
+	})
+
+	AfterEach(func() {
+		if statusSrv != nil {
+			statusSrv.Close()
+		}
+		cancel()
+	})
+
+	It("IT-AF-1460-010: REQ-2 current-state delivery on subscribe", func() {
+		rr := createTestRR(ctx, "rr-current-state", testNS, "Processing")
+		defer cleanupTestRR(ctx, rr.Name, testNS)
+
+		resp, err := http.Post(statusSrv.URL, "application/json",
+			bytes.NewReader(statusSubscribeBody(rr.Name)))
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+
+		Expect(resp.Header.Get("Content-Type")).To(ContainSubstring("text/event-stream"))
+
+		events := collectSSEEvents(resp, 1, 5*time.Second)
+		Expect(events).To(HaveLen(1), "must receive at least 1 event (current state)")
+
+		var params map[string]any
+		Expect(json.Unmarshal([]byte(events[0].Data), &params)).To(Succeed())
+		method, _ := params["method"].(string)
+		Expect(method).To(Equal("status/update"))
+		inner, _ := params["params"].(map[string]any)
+		Expect(inner["phase"]).To(Equal("Processing"))
+	})
+
+	It("IT-AF-1460-011: phase transition emits SSE event with metadata", func() {
+		rr := createTestRR(ctx, "rr-phase-trans", testNS, "Processing")
+		defer cleanupTestRR(ctx, rr.Name, testNS)
+
+		resp, err := http.Post(statusSrv.URL, "application/json",
+			bytes.NewReader(statusSubscribeBody(rr.Name)))
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+
+		time.Sleep(200 * time.Millisecond)
+		Expect(k8sClient.Get(ctx, crclient.ObjectKeyFromObject(rr), rr)).To(Succeed())
+		rr.Status.OverallPhase = remediationv1.PhaseExecuting
+		now := metav1.Now()
+		rr.Status.ExecutingStartTime = &now
+		rr.Status.SelectedWorkflowRef = &remediationv1.WorkflowReference{WorkflowID: "git-revert-v2"}
+		Expect(k8sClient.Status().Update(ctx, rr)).To(Succeed())
+
+		events := collectSSEEvents(resp, 2, 5*time.Second)
+		Expect(len(events)).To(BeNumerically(">=", 2))
+
+		var found bool
+		for _, evt := range events {
+			var data map[string]any
+			if json.Unmarshal([]byte(evt.Data), &data) != nil {
+				continue
+			}
+			inner, _ := data["params"].(map[string]any)
+			if inner == nil {
+				continue
+			}
+			if inner["phase"] == "Executing" {
+				meta, _ := inner["metadata"].(map[string]any)
+				Expect(meta).To(HaveKey("workflow_id"))
+				found = true
+			}
+		}
+		Expect(found).To(BeTrue(), "must receive Executing event with workflow_id metadata")
+	})
+
+	It("IT-AF-1460-012: EA sub-phase during Verifying via effectivenessAssessmentRef", func() {
+		rr := createTestRR(ctx, "rr-ea-subphase", testNS, "Executing")
+		defer cleanupTestRR(ctx, rr.Name, testNS)
+
+		eaName := "ea-custom-ref-12"
+		rr.Status.EffectivenessAssessmentRef = &corev1.ObjectReference{
+			Kind:      "EffectivenessAssessment",
+			Name:      eaName,
+			Namespace: testNS,
+		}
+		Expect(k8sClient.Status().Update(ctx, rr)).To(Succeed())
+
+		resp, err := http.Post(statusSrv.URL, "application/json",
+			bytes.NewReader(statusSubscribeBody(rr.Name)))
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+
+		time.Sleep(200 * time.Millisecond)
+
+		Expect(k8sClient.Get(ctx, crclient.ObjectKeyFromObject(rr), rr)).To(Succeed())
+		deadline := metav1.NewTime(time.Now().Add(10 * time.Minute))
+		rr.Status.OverallPhase = remediationv1.PhaseVerifying
+		rr.Status.VerificationDeadline = &deadline
+		Expect(k8sClient.Status().Update(ctx, rr)).To(Succeed())
+
+		time.Sleep(200 * time.Millisecond)
+
+		ea := &eav1alpha1.EffectivenessAssessment{
+			ObjectMeta: metav1.ObjectMeta{Name: eaName, Namespace: testNS},
+			Spec: eav1alpha1.EffectivenessAssessmentSpec{
+				CorrelationID:           rr.Name,
+				RemediationRequestPhase: "Verifying",
+				SignalTarget:            eav1alpha1.TargetResource{Kind: "Deployment", Name: "api-server"},
+				RemediationTarget:       eav1alpha1.TargetResource{Kind: "Deployment", Name: "api-server"},
+				Config: eav1alpha1.EAConfig{
+					StabilizationWindow: metav1.Duration{Duration: 60 * time.Second},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, ea)).To(Succeed())
+		ea.Status.Phase = eav1alpha1.PhaseStabilizing
+		stabDeadline := metav1.NewTime(time.Now().Add(60 * time.Second))
+		ea.Status.PrometheusCheckAfter = &stabDeadline
+		Expect(k8sClient.Status().Update(ctx, ea)).To(Succeed())
+
+		events := collectSSEEvents(resp, 3, 10*time.Second)
+
+		var hasEAPhase bool
+		for _, evt := range events {
+			var data map[string]any
+			if json.Unmarshal([]byte(evt.Data), &data) != nil {
+				continue
+			}
+			inner, _ := data["params"].(map[string]any)
+			if inner == nil {
+				continue
+			}
+			meta, _ := inner["metadata"].(map[string]any)
+			if meta != nil && meta["ea_phase"] != nil {
+				hasEAPhase = true
+			}
+		}
+		Expect(hasEAPhase).To(BeTrue(),
+			"must receive event with ea_phase in metadata during Verifying")
+	})
+
+	It("IT-AF-1460-015: terminal phase sends final:true and closes stream", func() {
+		rr := createTestRR(ctx, "rr-terminal", testNS, "Executing")
+		defer cleanupTestRR(ctx, rr.Name, testNS)
+
+		resp, err := http.Post(statusSrv.URL, "application/json",
+			bytes.NewReader(statusSubscribeBody(rr.Name)))
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+
+		time.Sleep(200 * time.Millisecond)
+		Expect(k8sClient.Get(ctx, crclient.ObjectKeyFromObject(rr), rr)).To(Succeed())
+		rr.Status.OverallPhase = remediationv1.PhaseCompleted
+		rr.Status.Outcome = "Remediated"
+		Expect(k8sClient.Status().Update(ctx, rr)).To(Succeed())
+
+		events := collectSSEEvents(resp, 2, 5*time.Second)
+
+		var hasFinal bool
+		for _, evt := range events {
+			var data map[string]any
+			if json.Unmarshal([]byte(evt.Data), &data) != nil {
+				continue
+			}
+			inner, _ := data["params"].(map[string]any)
+			if inner == nil {
+				continue
+			}
+			if inner["final"] == true {
+				hasFinal = true
+				Expect(inner).To(HaveKey("metadata"))
+				meta, _ := inner["metadata"].(map[string]any)
+				Expect(meta["outcome"]).To(Equal("Remediated"))
+			}
+		}
+		Expect(hasFinal).To(BeTrue(), "terminal phase must emit final:true event")
+	})
+
+	It("IT-AF-1460-016: rr_not_found returns JSON-RPC error -32001", func() {
+		resp, err := http.Post(statusSrv.URL, "application/json",
+			bytes.NewReader(statusSubscribeBody("nonexistent-rr")))
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+
+		Expect(resp.Header.Get("Content-Type")).To(ContainSubstring("application/json"))
+
+		var body map[string]any
+		Expect(json.NewDecoder(resp.Body).Decode(&body)).To(Succeed())
+		errObj, ok := body["error"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(errObj["code"]).To(BeNumerically("==", -32001))
+	})
+
+	It("IT-AF-1460-017: already-terminal RR sends single final event and closes", func() {
+		rr := createTestRR(ctx, "rr-already-done", testNS, "Completed")
+		rr.Status.Outcome = "Remediated"
+		Expect(k8sClient.Status().Update(ctx, rr)).To(Succeed())
+		defer cleanupTestRR(ctx, rr.Name, testNS)
+
+		resp, err := http.Post(statusSrv.URL, "application/json",
+			bytes.NewReader(statusSubscribeBody(rr.Name)))
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+
+		events := collectSSEEvents(resp, 1, 5*time.Second)
+		Expect(events).To(HaveLen(1))
+
+		var data map[string]any
+		Expect(json.Unmarshal([]byte(events[0].Data), &data)).To(Succeed())
+		inner, _ := data["params"].(map[string]any)
+		Expect(inner["final"]).To(BeTrue())
+		Expect(inner["phase"]).To(Equal("Completed"))
+	})
+
+	It("IT-AF-1460-019: Blocked phase emits blocked_until, block_reason", func() {
+		rr := createTestRR(ctx, "rr-blocked", testNS, "Executing")
+		defer cleanupTestRR(ctx, rr.Name, testNS)
+
+		resp, err := http.Post(statusSrv.URL, "application/json",
+			bytes.NewReader(statusSubscribeBody(rr.Name)))
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+
+		time.Sleep(200 * time.Millisecond)
+		Expect(k8sClient.Get(ctx, crclient.ObjectKeyFromObject(rr), rr)).To(Succeed())
+		rr.Status.OverallPhase = remediationv1.PhaseBlocked
+		rr.Status.BlockReason = remediationv1.BlockReasonConsecutiveFailures
+		rr.Status.BlockMessage = "3 consecutive failures"
+		blockedTime := metav1.NewTime(time.Now().Add(1 * time.Hour))
+		rr.Status.BlockedUntil = &blockedTime
+		Expect(k8sClient.Status().Update(ctx, rr)).To(Succeed())
+
+		events := collectSSEEvents(resp, 2, 5*time.Second)
+
+		var hasBlocked bool
+		for _, evt := range events {
+			var data map[string]any
+			if json.Unmarshal([]byte(evt.Data), &data) != nil {
+				continue
+			}
+			inner, _ := data["params"].(map[string]any)
+			if inner == nil {
+				continue
+			}
+			if inner["phase"] == "Blocked" {
+				meta, _ := inner["metadata"].(map[string]any)
+				Expect(meta).To(HaveKey("blocked_until"))
+				Expect(meta).To(HaveKey("block_reason"))
+				hasBlocked = true
+			}
+		}
+		Expect(hasBlocked).To(BeTrue(), "must receive Blocked event with metadata")
+	})
+})

--- a/test/integration/apifrontend/status_subscribe_test.go
+++ b/test/integration/apifrontend/status_subscribe_test.go
@@ -399,7 +399,9 @@ var _ = Describe("status/subscribe SSE endpoint (IT)", func() {
 	})
 
 	It("IT-AF-1460-014: status/closing pre-warning before deadline", func() {
-		deadlineCtx, deadlineCancel := context.WithTimeout(ctx, 3*time.Second)
+		// Deadline must exceed the 5s pre-warning offset so the timer fires.
+		// With 8s deadline, pre-warning fires at ~3s into the stream.
+		deadlineCtx, deadlineCancel := context.WithTimeout(ctx, 8*time.Second)
 		defer deadlineCancel()
 
 		sh := handler.NewStatusHandler(wc, testNS, logf.Log.WithName("status-it-deadline"))
@@ -415,7 +417,7 @@ var _ = Describe("status/subscribe SSE endpoint (IT)", func() {
 		Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()
 
-		events := collectSSEEvents(resp, 2, 5*time.Second)
+		events := collectSSEEvents(resp, 2, 10*time.Second)
 
 		var hasClosing bool
 		for _, evt := range events {

--- a/test/integration/apifrontend/status_subscribe_test.go
+++ b/test/integration/apifrontend/status_subscribe_test.go
@@ -345,6 +345,115 @@ var _ = Describe("status/subscribe SSE endpoint (IT)", func() {
 		Expect(inner["phase"]).To(Equal("Completed"))
 	})
 
+	It("IT-AF-1460-013: watch reconnection re-establishes transparently", func() {
+		rr := createTestRR(ctx, "rr-reconnect", testNS, "Processing")
+
+		resp, err := http.Post(statusSrv.URL, "application/json",
+			bytes.NewReader(statusSubscribeBody(rr.Name)))
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+
+		time.Sleep(200 * time.Millisecond)
+
+		Expect(k8sClient.Get(ctx, crclient.ObjectKeyFromObject(rr), rr)).To(Succeed())
+		rr.Status.OverallPhase = remediationv1.PhaseExecuting
+		now := metav1.Now()
+		rr.Status.ExecutingStartTime = &now
+		Expect(k8sClient.Status().Update(ctx, rr)).To(Succeed())
+
+		time.Sleep(200 * time.Millisecond)
+
+		Expect(k8sClient.Get(ctx, crclient.ObjectKeyFromObject(rr), rr)).To(Succeed())
+		rr.Status.OverallPhase = remediationv1.PhaseCompleted
+		rr.Status.Outcome = "Remediated"
+		Expect(k8sClient.Status().Update(ctx, rr)).To(Succeed())
+
+		events := collectSSEEvents(resp, 3, 5*time.Second)
+		Expect(len(events)).To(BeNumerically(">=", 2),
+			"stream must survive watch lifecycle and deliver multiple phase transitions")
+
+		var hasFinal bool
+		for _, evt := range events {
+			var data map[string]any
+			if json.Unmarshal([]byte(evt.Data), &data) != nil {
+				continue
+			}
+			inner, _ := data["params"].(map[string]any)
+			if inner != nil && inner["final"] == true {
+				hasFinal = true
+			}
+		}
+		Expect(hasFinal).To(BeTrue(), "stream must deliver terminal event")
+	})
+
+	It("IT-AF-1460-014: status/closing pre-warning before deadline", func() {
+		deadlineCtx, deadlineCancel := context.WithTimeout(ctx, 3*time.Second)
+		defer deadlineCancel()
+
+		sh := handler.NewStatusHandler(wc, testNS, logf.Log.WithName("status-it-deadline"))
+		deadlineSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			sh.ServeHTTP(w, r.WithContext(deadlineCtx))
+		}))
+		defer deadlineSrv.Close()
+
+		rr := createTestRR(ctx, "rr-closing", testNS, "Processing")
+
+		resp, err := http.Post(deadlineSrv.URL, "application/json",
+			bytes.NewReader(statusSubscribeBody(rr.Name)))
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+
+		events := collectSSEEvents(resp, 2, 5*time.Second)
+
+		var hasClosing bool
+		for _, evt := range events {
+			if evt.Event == "status/closing" {
+				hasClosing = true
+				var data map[string]any
+				Expect(json.Unmarshal([]byte(evt.Data), &data)).To(Succeed())
+				inner, _ := data["params"].(map[string]any)
+				Expect(inner["reason"]).To(Equal("token_expiry"))
+				Expect(inner["reconnect"]).To(BeTrue())
+			}
+		}
+		Expect(hasClosing).To(BeTrue(),
+			"must receive status/closing event before context deadline kills stream")
+	})
+
+	It("IT-AF-1460-018: heartbeat received on idle stream", func() {
+		shortHeartbeat := handler.NewStatusHandlerForTest(wc, testNS,
+			logf.Log.WithName("status-it-hb"), 500*time.Millisecond)
+		hbSrv := httptest.NewServer(shortHeartbeat)
+		defer hbSrv.Close()
+
+		rr := createTestRR(ctx, "rr-heartbeat", testNS, "Processing")
+
+		resp, err := http.Post(hbSrv.URL, "application/json",
+			bytes.NewReader(statusSubscribeBody(rr.Name)))
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+
+		done := make(chan bool, 1)
+		go func() {
+			scanner := bufio.NewScanner(resp.Body)
+			for scanner.Scan() {
+				line := scanner.Text()
+				if strings.TrimSpace(line) == ": heartbeat" {
+					done <- true
+					return
+				}
+			}
+			done <- false
+		}()
+
+		select {
+		case got := <-done:
+			Expect(got).To(BeTrue(), "must receive heartbeat comment frame")
+		case <-time.After(3 * time.Second):
+			Fail("timed out waiting for heartbeat frame")
+		}
+	})
+
 	It("IT-AF-1460-019: Blocked phase emits blocked_until, block_reason", func() {
 		rr := createTestRR(ctx, "rr-blocked", testNS, "Executing")
 		defer cleanupTestRR(ctx, rr.Name, testNS)

--- a/test/integration/apifrontend/status_subscribe_test.go
+++ b/test/integration/apifrontend/status_subscribe_test.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -43,15 +45,25 @@ func statusSubscribeBody(rrID string) []byte {
 }
 
 func createTestRR(ctx context.Context, name, ns, phase string) *remediationv1.RemediationRequest {
+	h := sha256.Sum256([]byte("status-it-" + name))
 	rr := &remediationv1.RemediationRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: ns,
 		},
 		Spec: remediationv1.RemediationRequestSpec{
+			SignalFingerprint: hex.EncodeToString(h[:]),
+			SignalName:        "StatusITAlert",
+			Severity:          "critical",
+			SignalType:        "alert",
+			SignalSource:      "test-status-it",
+			TargetType:        "kubernetes",
+			FiringTime:        metav1.Now(),
+			ReceivedTime:      metav1.Now(),
 			TargetResource: remediationv1.ResourceIdentifier{
-				Kind: "Deployment",
-				Name: "api-server",
+				Kind:      "Deployment",
+				Name:      "api-server",
+				Namespace: ns,
 			},
 		},
 	}

--- a/test/integration/apifrontend/suite_test.go
+++ b/test/integration/apifrontend/suite_test.go
@@ -583,6 +583,11 @@ timeoutSeconds: 120
 
 	sseTracker := streaming.NewConnectionTracker(metricsRegistry.SSEActiveConnections, 30*time.Second)
 
+	watchClient, wcErr := client.NewWithWatch(restCfg, client.Options{Scheme: scheme})
+	Expect(wcErr).NotTo(HaveOccurred(), "WithWatch client must initialize for StatusHandler IT tests")
+
+	statusHandler := handler.NewStatusHandler(watchClient, "default", logf.Log.WithName("status-it"))
+
 	routerCfg := handler.RouterConfig{
 		MetricsRegistry:  metricsRegistry,
 		Logger:           logf.Log.WithName("router-it"),
@@ -593,6 +598,7 @@ timeoutSeconds: 120
 		ReadyChecker:     func() bool { return true },
 		MaxPayloadBytes:  1 << 20,
 		SSETracker:       sseTracker,
+		StatusHandler:    statusHandler,
 	}
 
 	testRouter, err = handler.NewRouter(routerCfg)


### PR DESCRIPTION
## Summary

- Implements `POST /a2a/status` endpoint accepting JSON-RPC `status/subscribe` requests, returning an SSE stream of RR phase transition events (DD-AF-008, BR-AF-1460)
- Migrates `HandleWatch` from `EANameForRR()` naming convention to `effectivenessAssessmentRef` with `ResolveEAName()` fallback helper
- Updates AF RBAC ClusterRole to add `list` and `watch` verbs for EffectivenessAssessment resources

### Key features
- **Current-state delivery** (REQ-2): first SSE event contains the current RR phase on (re)connect
- **EA sub-phase events**: during Verifying, streams EA phase transitions with `ea_phase` and `stabilization_deadline` metadata
- **Heartbeat**: 15s keep-alive frames via `streaming.HeartbeatFrame()`
- **status/closing pre-warning**: emitted ~5s before token deadline kills the stream
- **Watch reconnection**: transparent re-establishment on channel close
- **Terminal handling**: `final: true` event with phase-specific metadata, then stream closes

### Files changed (14)
| File | Change |
|------|--------|
| `pkg/apifrontend/handler/status_handler.go` | New: StatusHandler with subscribe flow |
| `pkg/apifrontend/handler/status_types.go` | New: JSON-RPC types + BuildPhaseMetadata |
| `pkg/apifrontend/handler/router.go` | Add StatusHandler to RouterConfig + route |
| `cmd/apifrontend/main.go` | Wire StatusHandler construction |
| `pkg/apifrontend/tools/crd_tools.go` | Migrate HandleWatch to ResolveEAName |
| `pkg/apifrontend/tools/execution_progress.go` | Add ResolveEAName helper |
| `deploy/apifrontend/base/02-rbac.yaml` | Add list/watch for EA |
| `test/integration/apifrontend/suite_test.go` | Wire WithWatch client + StatusHandler |

## Test plan

- [x] UT-AF-1460-001..004: JSON-RPC parsing + error codes
- [x] UT-AF-1460-005..008: Per-phase metadata builders
- [x] UT-AF-1460-030: HandleWatch EA-ref migration
- [x] IT-AF-1460-040: RBAC parity (EA get/list/watch)
- [x] IT-AF-1460-010..019: Subscribe flow ITs (current state, phase transitions, EA sub-phase, terminal, blocked, rr_not_found, already-terminal)
- [x] IT-AF-1460-020: Route dispatch through auth chain
- [x] Full build: `go build ./...` passes
- [x] CHECKPOINT W: All 8 wiring manifest rows verified

Closes #1460

Made with [Cursor](https://cursor.com)