### PR TITLE
fix(security): resolve 14 HIGH CVEs in db-migrate image (x/crypto, x/net)

### DIFF
--- a/docker/db-migrate.Dockerfile
+++ b/docker/db-migrate.Dockerfile
@@ -24,6 +24,8 @@ RUN GOMODCACHE=$(mktemp -d) && \
     cd "$GOMODCACHE" && \
     go mod init tmp && \
     go get github.com/pressly/goose/v3/cmd/goose@v3.27.1 && \
+    go get golang.org/x/crypto@v0.53.0 && \
+    go get golang.org/x/net@v0.56.0 && \
     go build -o /go/bin/goose github.com/pressly/goose/v3/cmd/goose
 
 FROM registry.access.redhat.com/ubi10/ubi-minimal:latest AS production


### PR DESCRIPTION
## Summary

- Pins `golang.org/x/crypto` to v0.53.0 and `golang.org/x/net` to v0.56.0 in the db-migrate Dockerfile build stage
- Resolves 14 HIGH CVEs that block all CI pipelines (Trivy scan gate)

## Root Cause

The `db-migrate.Dockerfile` builds goose v3.27.1 in an isolated module (`go mod init tmp`). This inherits transitive dependencies from goose's own `go.mod`, which pulls `golang.org/x/crypto@v0.50.0` and `golang.org/x/net@v0.53.0` — both of which have known CVEs.

## CVEs Resolved

**golang.org/x/crypto** (8 CVEs, fixed >= v0.52.0):
- CVE-2026-39827, CVE-2026-39828, CVE-2026-39829, CVE-2026-39830
- CVE-2026-39835, CVE-2026-42508, CVE-2026-46595, CVE-2026-46597

**golang.org/x/net** (6 CVEs, fixed >= v0.55.0):
- CVE-2026-25680, CVE-2026-25681, CVE-2026-27136
- CVE-2026-39821, CVE-2026-42502, CVE-2026-42506

## Test plan

- [ ] CI Trivy scan passes on db-migrate image
- [x] Pinned versions match main project (`go.mod` has crypto@v0.53.0, net@v0.56.0)


Made with [Cursor](https://cursor.com)