### PR TITLE
feat(ka): configurable shutdown drain and structured JSON logging (#1329, #1330)

### DIFF
--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -118,10 +118,16 @@ func main() {
 	}
 
 	atomicLevel := cfg.Runtime.Logging.NewAtomicLevel()
-	logger = kubelog.NewLoggerWithAtomicLevel(kubelog.Options{ServiceName: "kubernaut-agent"}, atomicLevel)
+	logger = kubelog.NewLoggerWithAtomicLevel(kubelog.Options{
+		ServiceName: "kubernaut-agent",
+		Development: cfg.Runtime.Logging.IsConsoleFormat(),
+	}, atomicLevel)
 	defer kubelog.Sync(logger)
 
-	logger.Info("log level configured", "level", cfg.Runtime.Logging.Level)
+	logger.Info("logging configured",
+		"level", cfg.Runtime.Logging.Level,
+		"format", cfg.Runtime.Logging.Format,
+	)
 
 	llmRtData, err := os.ReadFile(llmRuntimePath)
 	if err != nil {
@@ -645,7 +651,7 @@ func main() {
 	logger.Info("shutting down...")
 	mgr.Shutdown()
 
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout(cfg))
 	defer cancel()
 
 	if sessionDrainer != nil {
@@ -659,6 +665,13 @@ func main() {
 	eventEmitter.Shutdown()
 	logger.Info("flushing audit store...")
 	auditCleanup()
+}
+
+func shutdownTimeout(cfg *kaconfig.Config) time.Duration {
+	if cfg.Runtime.Shutdown.DrainSeconds > 0 {
+		return time.Duration(cfg.Runtime.Shutdown.DrainSeconds) * time.Second
+	}
+	return 30 * time.Second
 }
 
 func shutdownServer(ctx context.Context, srv *http.Server, name string, logger logr.Logger) {

--- a/cmd/kubernautagent/shutdown_timeout_test.go
+++ b/cmd/kubernautagent/shutdown_timeout_test.go
@@ -1,0 +1,46 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+	"time"
+
+	kaconfig "github.com/jordigilh/kubernaut/internal/kubernautagent/config"
+)
+
+// UT-KA-1329-004: shutdownTimeout returns configured value (CM-3)
+func TestShutdownTimeout_UsesConfig(t *testing.T) {
+	cfg := kaconfig.DefaultConfig()
+	cfg.Runtime.Shutdown.DrainSeconds = 3
+
+	timeout := shutdownTimeout(cfg)
+	if timeout != 3*time.Second {
+		t.Errorf("UT-KA-1329-004: CM-3: expected 3s from config, got %v", timeout)
+	}
+}
+
+// UT-KA-1329-005: shutdownTimeout returns 30s default on zero (CM-3)
+func TestShutdownTimeout_DefaultsOnZero(t *testing.T) {
+	cfg := kaconfig.DefaultConfig()
+	cfg.Runtime.Shutdown.DrainSeconds = 0
+
+	timeout := shutdownTimeout(cfg)
+	if timeout != 30*time.Second {
+		t.Errorf("UT-KA-1329-005: CM-3: expected 30s default, got %v", timeout)
+	}
+}

--- a/docs/tests/1329/TEST_PLAN.md
+++ b/docs/tests/1329/TEST_PLAN.md
@@ -1,0 +1,68 @@
+# Test Plan: KA Configurable Graceful Shutdown Drain Duration (#1329)
+
+**IEEE 829 Standard** | **Version**: 1.0 | **Status**: Draft
+
+## 1. Test Plan Identifier
+
+TP-KA-1329-V1
+
+## 2. References
+
+- **Business Requirement**: BR-PLATFORM-1329
+- **Issue**: https://github.com/jordigilh/kubernaut/issues/1329
+- **Operator Issue**: kubernaut-operator#142
+- **Related**: AF implementation in `pkg/apifrontend/config/config.go` (ShutdownConfig)
+
+## 3. Introduction
+
+The Kubernaut Agent binary uses a hardcoded 10-second shutdown timeout in
+`cmd/kubernautagent/main.go`. The operator already renders
+`runtime.shutdown.drainSeconds: 30` in the KA ConfigMap, but KA ignores this
+value. This test plan covers the addition of a `ShutdownConfig` struct to
+the KA config, its validation, default values, and wiring into the shutdown
+sequence.
+
+## 4. FedRAMP Control Mapping
+
+| Control | Test Coverage |
+|---|---|
+| CM-6 (Configuration Settings) | UT-KA-1329-001, UT-KA-1329-002: shutdown duration is configurable via YAML |
+| SC-5 (Denial of Service Protection) | UT-KA-1329-003: validation rejects invalid drain values that could cause premature termination |
+| CM-3 (Configuration Change Control) | UT-KA-1329-004, UT-KA-1329-005: config-driven shutdown timeout replaces hardcoded value |
+
+## 5. Test Items
+
+| Item | Location |
+|---|---|
+| `ShutdownConfig` struct | `internal/kubernautagent/config/config.go` |
+| `ShutdownConfig` validation | `internal/kubernautagent/config/config.go` `Validate()` |
+| `DefaultConfig()` shutdown defaults | `internal/kubernautagent/config/config.go` |
+| `shutdownTimeout()` helper | `cmd/kubernautagent/main.go` |
+| Shutdown context wiring | `cmd/kubernautagent/main.go` line 648 |
+
+## 6. Test Scenarios
+
+### Unit Tests (Logic)
+
+| Test ID | Description | FedRAMP | Pass Criteria |
+|---|---|---|---|
+| UT-KA-1329-001 | `runtime.shutdown.drainSeconds` YAML field round-trips correctly | CM-6 | `cfg.Runtime.Shutdown.DrainSeconds == 45` after parsing `drainSeconds: 45` |
+| UT-KA-1329-002 | `DefaultConfig()` sets `drainSeconds` to 30 | CM-6 | `DefaultConfig().Runtime.Shutdown.DrainSeconds == 30` |
+| UT-KA-1329-003 | `Validate()` rejects `drainSeconds <= 0` | SC-5 | `Validate()` returns error containing `"runtime.shutdown.drainSeconds"` |
+| UT-KA-1329-004 | `shutdownTimeout()` returns configured value | CM-3 | `shutdownTimeout(cfg) == 3*time.Second` when `DrainSeconds == 3` |
+| UT-KA-1329-005 | `shutdownTimeout()` returns 30s default on zero | CM-3 | `shutdownTimeout(cfg) == 30*time.Second` when `DrainSeconds == 0` |
+
+### Pyramid Invariant
+
+- **UT** proves logic: config parsing, validation, timeout computation
+- **Wiring** is verified via CHECKPOINT W: `shutdownTimeout(cfg)` is called in `cmd/kubernautagent/main.go` shutdown sequence
+- No IT needed: the wiring is a single `context.WithTimeout` call with no I/O dispatch
+
+## 7. Pass/Fail Criteria
+
+All 5 unit tests must pass. CHECKPOINT W must confirm production caller in `cmd/`.
+
+## 8. Environmental Needs
+
+- Go test environment with Ginkgo/Gomega
+- No external dependencies (no K8s cluster, no network)

--- a/docs/tests/1330/TEST_PLAN.md
+++ b/docs/tests/1330/TEST_PLAN.md
@@ -1,0 +1,73 @@
+# Test Plan: KA Structured JSON Logging Format (#1330)
+
+**IEEE 829 Standard** | **Version**: 1.0 | **Status**: Draft
+
+## 1. Test Plan Identifier
+
+TP-CFG-1330-V1
+
+## 2. References
+
+- **Business Requirement**: BR-PLATFORM-1330
+- **Issue**: https://github.com/jordigilh/kubernaut/issues/1330
+- **Operator Issue**: kubernaut-operator#144
+- **Related**: `pkg/log/logger.go` Options.Development, LOG_FORMAT env var
+
+## 3. Introduction
+
+The KA config struct lacks a `Format` field in its `LoggingConfig`. The
+operator renders `runtime.logging.format: json` in the KA ConfigMap, but KA
+ignores it since the field is not defined. This test plan covers adding
+`Format` to the shared `LoggingConfig`, its validation, and wiring into the
+KA logger construction.
+
+## 4. FedRAMP Control Mapping
+
+| Control | Test Coverage |
+|---|---|
+| AU-3 (Content of Audit Records) | UT-CFG-1330-001, UT-CFG-1330-004: structured JSON ensures machine-parseable audit trail |
+| CM-6 (Configuration Settings) | UT-KA-1330-005, UT-KA-1330-006: log format is configurable via YAML |
+| CM-3 (Configuration Change Control) | UT-CFG-1330-002: format validation prevents misconfiguration |
+
+## 5. Test Items
+
+| Item | Location |
+|---|---|
+| `Format` field on `LoggingConfig` | `internal/config/logging.go` |
+| `ValidFormats` map | `internal/config/logging.go` |
+| `IsConsoleFormat()` method | `internal/config/logging.go` |
+| `DefaultLoggingConfig()` format default | `internal/config/logging.go` |
+| KA logger construction wiring | `cmd/kubernautagent/main.go` line 121 |
+
+## 6. Test Scenarios
+
+### Unit Tests (Logic) -- Shared LoggingConfig
+
+| Test ID | Description | FedRAMP | Pass Criteria |
+|---|---|---|---|
+| UT-CFG-1330-001 | `DefaultLoggingConfig()` returns `Format: "json"` | AU-3 | `DefaultLoggingConfig().Format == "json"` |
+| UT-CFG-1330-002 | `Validate()` accepts "json"/"console", rejects "yaml"/"text" | CM-3 | Valid formats pass, invalid return error containing "log format" |
+| UT-CFG-1330-003 | `IsConsoleFormat()` returns correct boolean | AU-3 | `true` for "console"/"CONSOLE", `false` for "json"/"" |
+| UT-CFG-1330-004 | Empty format defaults to JSON behavior | AU-3 | `IsConsoleFormat() == false` when `Format == ""` |
+
+### Unit Tests (Logic) -- KA Config Integration
+
+| Test ID | Description | FedRAMP | Pass Criteria |
+|---|---|---|---|
+| UT-KA-1330-005 | `runtime.logging.format: console` YAML round-trip | CM-6 | `cfg.Runtime.Logging.Format == "console"` after parsing |
+| UT-KA-1330-006 | KA `Validate()` delegates format validation | CM-6 | Invalid format causes `Validate()` error |
+
+### Pyramid Invariant
+
+- **UT** proves logic: format parsing, validation, IsConsoleFormat helper
+- **Wiring** is verified via CHECKPOINT W: `Development: cfg.Runtime.Logging.IsConsoleFormat()` passed to `Options` in `cmd/kubernautagent/main.go`
+- No IT needed: the wiring is a boolean flag passed to the logger factory with no I/O dispatch
+
+## 7. Pass/Fail Criteria
+
+All 6 unit tests must pass. CHECKPOINT W must confirm `IsConsoleFormat()` is called in `cmd/`.
+
+## 8. Environmental Needs
+
+- Go test environment with Ginkgo/Gomega
+- No external dependencies (no K8s cluster, no network)

--- a/internal/config/logging.go
+++ b/internal/config/logging.go
@@ -15,12 +15,13 @@ import (
 // changing log level requires configmaps write access, not deployments.
 // Combined with hot-reload, level changes take effect without pod restarts.
 type LoggingConfig struct {
-	Level string `yaml:"level"` // DEBUG, INFO, WARN, ERROR
+	Level  string `yaml:"level"`            // DEBUG, INFO, WARN, ERROR
+	Format string `yaml:"format,omitempty"` // json, console
 }
 
 // DefaultLoggingConfig returns production defaults.
 func DefaultLoggingConfig() LoggingConfig {
-	return LoggingConfig{Level: "INFO"}
+	return LoggingConfig{Level: "INFO", Format: "json"}
 }
 
 // ValidLevels contains the accepted log level strings.
@@ -31,15 +32,28 @@ var ValidLevels = map[string]bool{
 	"ERROR": true,
 }
 
-// Validate checks that the configured level is recognised.
+// ValidFormats contains the accepted log format strings.
+var ValidFormats = map[string]bool{
+	"json":    true,
+	"console": true,
+}
+
+// Validate checks that the configured level and format are recognised.
 func (l LoggingConfig) Validate() error {
-	if l.Level == "" {
-		return nil
-	}
-	if !ValidLevels[strings.ToUpper(l.Level)] {
+	if l.Level != "" && !ValidLevels[strings.ToUpper(l.Level)] {
 		return fmt.Errorf("invalid log level: %s (must be DEBUG, INFO, WARN, or ERROR)", l.Level)
 	}
+	if l.Format != "" && !ValidFormats[strings.ToLower(l.Format)] {
+		return fmt.Errorf("invalid log format: %s (must be json or console)", l.Format)
+	}
 	return nil
+}
+
+// IsConsoleFormat returns true when the configured format is "console",
+// which maps to human-readable development-mode output. Returns false
+// for "json", empty string (default), or any other value.
+func (l LoggingConfig) IsConsoleFormat() bool {
+	return strings.ToLower(l.Format) == "console"
 }
 
 // ZapLevel converts the configured level string to a zapcore.Level.

--- a/internal/config/logging_test.go
+++ b/internal/config/logging_test.go
@@ -93,6 +93,63 @@ var _ = Describe("Shared LoggingConfig — BR-PLATFORM-875", func() {
 		)
 	})
 
+	Describe("UT-CFG-1330-001: DefaultLoggingConfig returns Format json (AU-3)", func() {
+		It("should default to json for machine-parseable audit trail", func() {
+			cfg := config.DefaultLoggingConfig()
+			Expect(cfg.Format).To(Equal("json"),
+				"AU-3: default log format must be JSON for structured audit records")
+		})
+	})
+
+	Describe("UT-CFG-1330-002: Validate accepts valid formats, rejects invalid (CM-3)", func() {
+		DescribeTable("valid formats",
+			func(format string) {
+				cfg := config.LoggingConfig{Level: "INFO", Format: format}
+				Expect(cfg.Validate()).To(Succeed())
+			},
+			Entry("json", "json"),
+			Entry("console", "console"),
+			Entry("JSON (case-insensitive)", "JSON"),
+			Entry("Console (case-insensitive)", "Console"),
+			Entry("empty (backward compat)", ""),
+		)
+
+		DescribeTable("invalid formats",
+			func(format string) {
+				cfg := config.LoggingConfig{Level: "INFO", Format: format}
+				err := cfg.Validate()
+				Expect(err).To(HaveOccurred())
+				Expect(err.Error()).To(ContainSubstring("log format"))
+			},
+			Entry("yaml", "yaml"),
+			Entry("text", "text"),
+			Entry("logfmt", "logfmt"),
+			Entry("XML", "XML"),
+		)
+	})
+
+	Describe("UT-CFG-1330-003: IsConsoleFormat returns correct boolean (AU-3)", func() {
+		DescribeTable("format detection",
+			func(format string, expected bool) {
+				cfg := config.LoggingConfig{Format: format}
+				Expect(cfg.IsConsoleFormat()).To(Equal(expected))
+			},
+			Entry("console -> true", "console", true),
+			Entry("CONSOLE -> true (case-insensitive)", "CONSOLE", true),
+			Entry("json -> false", "json", false),
+			Entry("JSON -> false (case-insensitive)", "JSON", false),
+			Entry("empty -> false (default JSON)", "", false),
+		)
+	})
+
+	Describe("UT-CFG-1330-004: empty Format defaults to JSON behavior (AU-3)", func() {
+		It("should treat empty format as JSON", func() {
+			cfg := config.LoggingConfig{Format: ""}
+			Expect(cfg.IsConsoleFormat()).To(BeFalse(),
+				"AU-3: empty format must default to JSON for production audit compliance")
+		})
+	})
+
 	Describe("UT-CFG-875-007: ParseAndSetLevel hot-reload helper", func() {
 		It("should update AtomicLevel from INFO to DEBUG", func() {
 			al := zap.NewAtomicLevelAt(zapcore.InfoLevel)

--- a/internal/kubernautagent/config/config.go
+++ b/internal/kubernautagent/config/config.go
@@ -39,10 +39,18 @@ type Config struct {
 
 // RuntimeConfig holds operational infrastructure settings.
 type RuntimeConfig struct {
-	Logging internalconfig.LoggingConfig `yaml:"logging"`
-	Server  ServerConfig                 `yaml:"server"`
-	Session SessionConfig                `yaml:"session"`
-	Audit   AuditConfig                  `yaml:"audit"`
+	Logging  internalconfig.LoggingConfig `yaml:"logging"`
+	Server   ServerConfig                 `yaml:"server"`
+	Session  SessionConfig                `yaml:"session"`
+	Audit    AuditConfig                  `yaml:"audit"`
+	Shutdown ShutdownConfig               `yaml:"shutdown"`
+}
+
+// ShutdownConfig holds graceful shutdown parameters.
+// The operator renders runtime.shutdown.drainSeconds from the CRD's
+// spec.kubernautAgent.shutdown.drainSeconds field.
+type ShutdownConfig struct {
+	DrainSeconds int `yaml:"drainSeconds"`
 }
 
 // AIConfig holds LLM, investigation behavior, and safety guardrails.
@@ -231,6 +239,9 @@ type ClaimMappings struct {
 }
 
 const maxURLLength = 2048
+
+// maxDrainSeconds mirrors the operator CRD's max(300) for shutdown.drainSeconds.
+const maxDrainSeconds = 300
 
 // validateJWTProviders checks all configured JWT providers for required fields,
 // validates URL format and length, applies claim mapping defaults, and rejects
@@ -515,6 +526,15 @@ func (c *Config) Validate() error {
 	default:
 		return fmt.Errorf("runtime.audit.verbosity must be full, standard, or minimal, got %q", c.Runtime.Audit.Verbosity)
 	}
+	if c.Runtime.Shutdown.DrainSeconds <= 0 {
+		return fmt.Errorf("runtime.shutdown.drainSeconds must be positive, got %d; "+
+			"the operator default is 30s", c.Runtime.Shutdown.DrainSeconds)
+	}
+	if c.Runtime.Shutdown.DrainSeconds > maxDrainSeconds {
+		return fmt.Errorf("runtime.shutdown.drainSeconds must not exceed %d, got %d; "+
+			"the operator enforces this upper bound via CRD validation",
+			maxDrainSeconds, c.Runtime.Shutdown.DrainSeconds)
+	}
 
 	if c.AI.Investigation.MaxTurns <= 0 {
 		return fmt.Errorf("ai.investigation.maxTurns must be positive, got %d", c.AI.Investigation.MaxTurns)
@@ -635,6 +655,7 @@ func DefaultConfig() *Config {
 				BatchSize:  10,
 				Verbosity:  "full",
 			},
+			Shutdown: ShutdownConfig{DrainSeconds: 30},
 		},
 		AI: AIConfig{
 			LLM:           types.LLMConfig{Provider: "openai"},

--- a/internal/kubernautagent/config/config_test.go
+++ b/internal/kubernautagent/config/config_test.go
@@ -600,6 +600,97 @@ var _ = Describe("AlignmentCheck EffectiveLLM merge — BR-AI-601", func() {
 	})
 })
 
+var _ = Describe("ShutdownConfig — BR-PLATFORM-1329", func() {
+
+	Describe("UT-KA-1329-001: runtime.shutdown.drainSeconds YAML round-trip (CM-6)", func() {
+		It("should parse drainSeconds from YAML", func() {
+			yaml := []byte(`
+runtime:
+  shutdown:
+    drainSeconds: 45
+  session:
+    ttl: 30m
+`)
+			cfg, err := config.Load(yaml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.Runtime.Shutdown.DrainSeconds).To(Equal(45),
+				"CM-6: shutdown drain duration must be configurable via YAML config")
+		})
+	})
+
+	Describe("UT-KA-1329-002: DefaultConfig sets drainSeconds to 30 (CM-6)", func() {
+		It("should default to 30s matching operator default", func() {
+			cfg := config.DefaultConfig()
+			Expect(cfg.Runtime.Shutdown.DrainSeconds).To(Equal(30),
+				"CM-6: default drain duration must match operator default of 30s")
+		})
+	})
+
+	Describe("UT-KA-1329-003: Validate rejects drainSeconds <= 0 (SC-5)", func() {
+		It("should reject zero drainSeconds", func() {
+			cfg := config.DefaultConfig()
+			cfg.Runtime.Shutdown.DrainSeconds = 0
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("runtime.shutdown.drainSeconds"),
+				"SC-5: invalid drain duration must be rejected to prevent premature termination")
+		})
+
+		It("should reject negative drainSeconds", func() {
+			cfg := config.DefaultConfig()
+			cfg.Runtime.Shutdown.DrainSeconds = -5
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("runtime.shutdown.drainSeconds"))
+		})
+
+		It("should reject drainSeconds exceeding operator max of 300", func() {
+			cfg := config.DefaultConfig()
+			cfg.Runtime.Shutdown.DrainSeconds = 301
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("must not exceed 300"))
+		})
+
+		It("should accept drainSeconds at operator max boundary", func() {
+			cfg := config.DefaultConfig()
+			cfg.Runtime.Shutdown.DrainSeconds = 300
+			Expect(cfg.Validate()).To(Succeed())
+		})
+	})
+})
+
+var _ = Describe("LoggingConfig Format — BR-PLATFORM-1330", func() {
+
+	Describe("UT-KA-1330-005: runtime.logging.format YAML round-trip (CM-6)", func() {
+		It("should parse format from YAML", func() {
+			yaml := []byte(`
+runtime:
+  logging:
+    level: INFO
+    format: console
+  session:
+    ttl: 30m
+`)
+			cfg, err := config.Load(yaml)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(cfg.Runtime.Logging.Format).To(Equal("console"),
+				"CM-6: log format must be configurable via YAML config")
+		})
+	})
+
+	Describe("UT-KA-1330-006: KA Validate delegates format validation (CM-6)", func() {
+		It("should reject invalid format via shared LoggingConfig.Validate", func() {
+			cfg := config.DefaultConfig()
+			cfg.Runtime.Logging.Format = "yaml"
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("log format"),
+				"CM-6: invalid format must be rejected by validation")
+		})
+	})
+})
+
 var _ = Describe("Config.Validate — GAP-C3 (#954)", func() {
 	DescribeTable("should reject invalid config values",
 		func(mutate func(*config.Config), substr string) {
@@ -639,6 +730,12 @@ var _ = Describe("Config.Validate — GAP-C3 (#954)", func() {
 			c.AI.AlignmentCheck.Enabled = true
 			c.AI.AlignmentCheck.MaxRetries = -1
 		}, "maxRetries"),
+		Entry("shutdown drainSeconds=0", func(c *config.Config) {
+			c.Runtime.Shutdown.DrainSeconds = 0
+		}, "drainSeconds"),
+		Entry("shutdown drainSeconds=301 exceeds max", func(c *config.Config) {
+			c.Runtime.Shutdown.DrainSeconds = 301
+		}, "drainSeconds"),
 	)
 
 	It("should accept DefaultConfig as valid", func() {


### PR DESCRIPTION
## Summary

- **#1329**: Make KA graceful shutdown drain duration configurable via `runtime.shutdown.drainSeconds`. Replaces hardcoded `10*time.Second` with config-driven `shutdownTimeout()` helper (default 30s, matching operator). Includes max bound validation (300s) per operator CRD constraint.
- **#1330**: Add `Format` field to shared `LoggingConfig` (`json`/`console`, default `json`). Wire `IsConsoleFormat()` into KA logger construction so operator-rendered `runtime.logging.format` is respected. Case-insensitive parsing consistent with existing level handling.

Both features follow TDD RED-GREEN-REFACTOR with IEEE 829 test plans, Wiring Manifests, and FedRAMP control mappings (CM-6, CM-3, AU-3, SC-5).

## FedRAMP Controls

| Control | Coverage |
|---|---|
| CM-6 (Configuration Settings) | Both features make operational parameters configurable |
| CM-3 (Configuration Change Control) | Config-driven values replace hardcoded literals |
| AU-3 (Content of Audit Records) | #1330: structured JSON ensures machine-parseable audit trail |
| SC-5 (DoS Protection) | #1329: configurable drain prevents premature session termination |

## Test Plan

- [x] UT-KA-1329-001 through 005: ShutdownConfig parsing, defaults, validation, shutdownTimeout() helper
- [x] UT-CFG-1330-001 through 004: Format field parsing, validation, IsConsoleFormat() helper
- [x] UT-KA-1330-005 through 006: KA config YAML round-trip, validation delegation
- [x] CHECKPOINT W: production callers verified in `cmd/kubernautagent/main.go`
- [x] `go build ./...` passes
- [x] All affected test suites pass

Closes #1329
Closes #1330


Made with [Cursor](https://cursor.com)