### PR TITLE
fix: remediation history contract (#1462), bridge timeout accuracy (#1451), cluster-scoped namespace (#1371)

### DIFF
--- a/docs/testing/1371/TEST_PLAN.md
+++ b/docs/testing/1371/TEST_PLAN.md
@@ -1,0 +1,113 @@
+# Test Plan: Fix #1371 extractNamespace Defaults to "default" for Cluster-Scoped Resources
+
+**Issue**: [#1371](https://github.com/jordigilh/kubernaut/issues/1371)
+**Service Type**: [x] CRD Controller (Gateway)
+**Date**: 2026-06-26
+**Status**: Active
+
+---
+
+## Business Requirements
+
+| BR ID | Description |
+|---|---|
+| BR-GATEWAY-001 | Signal ingestion and resource identification |
+| BR-GATEWAY-004 | Signal fingerprinting (owner-chain-based deduplication) |
+
+## FedRAMP Control Objectives
+
+| Control | Objective | How This Fix Maps |
+|---------|-----------|-------------------|
+| SI-10 (Information Input Validation) | Namespace must reflect actual K8s resource scope | Empty string for cluster-scoped, "default" fallback only for namespaced |
+| AU-3 (Content of Audit Records) | Signals carry correct namespace for audit trail | RR CRD created with accurate namespace; downstream consumers already handle `""` |
+
+## Fingerprint Impact
+
+Changing namespace from `"default"` to `""` for cluster-scoped resources alters `CalculateOwnerFingerprint` output (`sha256(namespace:kind:name)`). This is a **one-time transition** — new fingerprints are correct, old ones age out. Accepted per issue #1371.
+
+---
+
+## Test Scenario Naming Convention
+
+**Format**: `{TIER}-{SERVICE}-1371-{SEQUENCE}`
+
+- `GW` = Gateway
+
+---
+
+## Component 1: APIResourceRegistry.IsNamespacedKind (New Method)
+
+### Unit Tests — Scope Detection (SI-10)
+
+| ID | Scenario | Expected Outcome |
+|---|---|---|
+| UT-GW-1371-001 | `IsNamespacedKind("Deployment")` — namespaced workload | Returns `true` — namespace required for Deployments |
+| UT-GW-1371-002 | `IsNamespacedKind("Node")` — cluster-scoped infrastructure | Returns `false` — Nodes have no namespace |
+| UT-GW-1371-003 | `IsNamespacedKind("Namespace")` — cluster-scoped meta | Returns `false` — Namespace resource is itself cluster-scoped |
+| UT-GW-1371-004 | `IsNamespacedKind("PersistentVolume")` — cluster-scoped storage | Returns `false` — PVs are cluster-scoped (PVCs are namespaced) |
+| UT-GW-1371-005 | `IsNamespacedKind("UnknownKind")` — unknown kind | Returns `true` — conservative default avoids dropping namespace |
+| UT-GW-1371-006 | `IsNamespacedKind` with nil snapshot (pre-initialization) | Returns `true` — graceful degradation before registry ready |
+
+---
+
+## Component 2: extractNamespace (Signature Change)
+
+### Unit Tests — Label Extraction (SI-10)
+
+| ID | Scenario | Expected Outcome |
+|---|---|---|
+| UT-GW-1371-007 | No namespace labels present | Returns `("", false)` — caller decides based on kind scope |
+| UT-GW-1371-008 | `namespace` label present | Returns `("production", true)` — explicit namespace honored |
+| UT-GW-1371-009 | `exported_namespace` label present | Returns `("staging", true)` — federation namespace takes precedence (#1029) |
+| UT-GW-1371-010 | Both `namespace` and `exported_namespace` present | Returns `exported_namespace` value — precedence rule: exported > namespace |
+
+---
+
+## Component 3: Alert Parsing Pipeline (Scope-Aware Namespace)
+
+### Unit Tests — End-to-End Namespace Resolution (AU-3)
+
+| ID | Scenario | Expected Outcome |
+|---|---|---|
+| UT-GW-1371-011 | Cluster-scoped Node alert (no namespace label) | `signal.Resource.Namespace == ""` — RR created with empty namespace |
+| UT-GW-1371-012 | Namespaced Deployment alert (no namespace label) | `signal.Resource.Namespace == "default"` — "default" fallback only for namespaced kinds |
+| UT-GW-1371-013 | Namespaced Deployment alert (explicit namespace) | `signal.Resource.Namespace == "production"` — explicit namespace always honored |
+| UT-GW-1371-014 | Cluster-scoped Node alert WITH explicit namespace label | `signal.Resource.Namespace == "monitoring"` — if user provides namespace, honor it |
+
+### Integration Tests (Wiring)
+
+| ID | Scenario | Expected Outcome |
+|---|---|---|
+| IT-GW-1371-015 | Full `adapter.Parse()` of KubeNodeNotReady alert | Signal produced with `Namespace == ""` through complete production parse path |
+
+---
+
+## Existing Tests to Update
+
+| ID | File | Required Change |
+|---|---|---|
+| (unnamed) | resource_extraction_test.go | Cluster-scoped test: change `Equal("default")` to `BeEmpty()` |
+| (unnamed) | resource_extraction_business_test.go | Node test (line 125): change `Equal("default")` to `BeEmpty()` |
+| (unnamed) | resource_extraction_business_test.go | NodeDiskPressure test: change `Equal("default")` to `BeEmpty()` |
+
+---
+
+## Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | IT Test ID |
+|---|---|---|---|
+| IsNamespacedKind | extractNamespace call sites in ConvertToSignal/Parse | pkg/gateway/adapters/prometheus_adapter.go | IT-GW-1371-015 |
+| kindNamespaced in snapshot | buildSnapshot | pkg/gateway/adapters/resource_registry.go | UT-GW-1371-001 |
+
+---
+
+## Test Execution Summary
+
+| Test Category | Tests | Status |
+|---|---|---|
+| GW Unit Tests — Scope Detection (UT-GW-1371-001..006) | 6 | Pending |
+| GW Unit Tests — Label Extraction (UT-GW-1371-007..010) | 4 | Pending |
+| GW Unit Tests — Pipeline (UT-GW-1371-011..014) | 4 | Pending |
+| GW Integration Tests (IT-GW-1371-015) | 1 | Pending |
+| Existing Test Updates | 3 | Pending |
+| **Total** | **18** | **Pending** |

--- a/docs/testing/1451/TEST_PLAN.md
+++ b/docs/testing/1451/TEST_PLAN.md
@@ -1,0 +1,104 @@
+# Test Plan: Fix #1451 bridgeEventsCollectSummary Reports "completed" on Inactivity Timeout
+
+**Issue**: [#1451](https://github.com/jordigilh/kubernaut/issues/1451)
+**Service Type**: [x] Stateless HTTP API (API Frontend)
+**Date**: 2026-06-26
+**Status**: Active
+
+---
+
+## Business Requirements
+
+| BR ID | Description |
+|---|---|
+| BR-AF-MCP-003 | Event bridge goroutine must accurately report investigation outcome |
+
+## FedRAMP Control Objectives
+
+| Control | Objective | How This Fix Maps |
+|---------|-----------|-------------------|
+| SI-4 (System Monitoring) | Status must accurately reflect investigation state | "timed_out" vs "completed" distinction prevents LLM confusion loops |
+| AU-3 (Content of Audit Records) | Log entries must report correct status | Audit trail must not claim "completed" when investigation was abandoned due to inactivity |
+
+---
+
+## Test Scenario Naming Convention
+
+**Format**: `{TIER}-{SERVICE}-1451-{SEQUENCE}`
+
+- `AF` = API Frontend
+
+---
+
+## Component 1: bridgeEventsCollectSummary (Exit Reason)
+
+### Unit Tests — Exit Path Accuracy (SI-4)
+
+| ID | Scenario | Expected Outcome |
+|---|---|---|
+| UT-AF-1451-001 | No events arrive within inactivity timeout | Third return value == `"inactivity_timeout"` — investigation hung, not completed |
+| UT-AF-1451-002 | Events channel closes normally (KA session ended) | Third return value == `"channel_closed"` — natural completion |
+| UT-AF-1451-003 | Context cancelled externally (SIGTERM / caller timeout) | Third return value == `"ctx_cancelled"` — external termination |
+
+### Unit Tests — Timer Behavior (SI-4)
+
+| ID | Scenario | Expected Outcome |
+|---|---|---|
+| UT-AF-1451-007 | Default `BridgeInactivityTimeout` value | `BridgeInactivityTimeout == 180 * time.Second` |
+| UT-AF-1451-008 | Inactivity timer resets on each received event | Event at T+170s resets timer; channel close at T+340s → exit reason `"channel_closed"` (not timeout) |
+
+### Unit Tests — Data Preservation on Timeout (AU-3)
+
+| ID | Scenario | Expected Outcome |
+|---|---|---|
+| UT-AF-1451-009 | Summary text accumulated before inactivity timeout is preserved | Partial summary string returned; non-empty even on timeout |
+| UT-AF-1451-010 | RCA extracted from events before inactivity timeout is preserved | `*InvestigateRCA` non-nil when RCA event arrived before timeout |
+
+---
+
+## Component 2: HandleInvestigationMCPWithRegistry Caller (Status Mapping)
+
+### Unit Tests — Status Mapping (AU-3)
+
+| ID | Scenario | Expected Outcome |
+|---|---|---|
+| UT-AF-1451-004 | Exit reason `"inactivity_timeout"` → status `"timed_out"` | `InvestigateMCPResult.Status == "timed_out"` — LLM told investigation is hung |
+| UT-AF-1451-005 | Exit reason `"channel_closed"` → status `"completed"` | `InvestigateMCPResult.Status == "completed"` — only natural close reports completed |
+| UT-AF-1451-006 | Exit reason `"ctx_cancelled"` → status `"timeout"` | `InvestigateMCPResult.Status == "timeout"` — external cancellation |
+
+---
+
+## Existing Tests to Update
+
+The following tests call `BridgeEventsCollectSummary` and must handle the new third return value:
+
+| ID | File | Required Change |
+|---|---|---|
+| IT-AF-1420-001 | ka_investigate_verdict_1420_test.go | Capture third return value (exit reason) |
+| UT-AF-1438-010 | terminal_event_1438_test.go | Capture third return value |
+| UT-AF-1438-027 | terminal_event_1438_test.go | Capture third return value |
+| UT-AF-1396-020 | ka_investigate_rca_test.go | Capture third return value |
+| UT-AF-1396-021 | ka_investigate_rca_test.go | Capture third return value |
+
+---
+
+## Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | IT Test ID |
+|---|---|---|---|
+| Exit reason return value | HandleInvestigationMCPWithRegistry blocking path | pkg/apifrontend/tools/ka_investigate_mcp.go:445 | UT-AF-1451-004 |
+
+Note: Signature change to an existing wired function. Existing IT tests (IT-AF-1420-001) already prove the wiring; new tests prove the logic change (exit reason to status mapping).
+
+---
+
+## Test Execution Summary
+
+| Test Category | Tests | Status |
+|---|---|---|
+| AF Unit Tests — Exit Paths (UT-AF-1451-001..003) | 3 | Pending |
+| AF Unit Tests — Timer Behavior (UT-AF-1451-007..008) | 2 | Pending |
+| AF Unit Tests — Data Preservation (UT-AF-1451-009..010) | 2 | Pending |
+| AF Unit Tests — Status Mapping (UT-AF-1451-004..006) | 3 | Pending |
+| Existing Test Updates | 5 | Pending |
+| **Total** | **15** | **Pending** |

--- a/docs/testing/1462/TEST_PLAN.md
+++ b/docs/testing/1462/TEST_PLAN.md
@@ -1,0 +1,102 @@
+# Test Plan: Fix #1462 AF Tool Does Not Pass Required Parameters to DS Remediation History Endpoint
+
+**Issue**: [#1462](https://github.com/jordigilh/kubernaut/issues/1462)
+**Service Type**: [x] Stateless HTTP API (API Frontend)
+**Date**: 2026-06-26
+**Status**: Active
+
+---
+
+## Business Requirements
+
+| BR ID | Description |
+|---|---|
+| BR-HAPI-016 | Remediation history context for LLM prompt enrichment |
+
+## FedRAMP Control Objectives
+
+| Control | Objective | How This Fix Maps |
+|---------|-----------|-------------------|
+| SI-10 (Information Input Validation) | AF must validate required parameters before sending to DS | Validation rejects empty kind, name, spec_hash with descriptive errors |
+| AU-3 (Content of Audit Records) | Spec hash enables causal chain integrity | Wiring spec_hash enables hash-chain regression detection in audit trail |
+
+---
+
+## Test Scenario Naming Convention
+
+**Format**: `{TIER}-{SERVICE}-1462-{SEQUENCE}`
+
+- `AF` = API Frontend
+
+---
+
+## Component 1: HandleGetRemediationHistory (AF Tool Handler)
+
+### Unit Tests — Input Validation (SI-10)
+
+| ID | Scenario | Expected Outcome |
+|---|---|---|
+| UT-AF-1462-001 | Empty `kind` in args → validation error | Error returned containing "kind is required"; DS client NOT called |
+| UT-AF-1462-002 | Empty `name` in args → validation error | Error returned containing "name is required"; DS client NOT called |
+| UT-AF-1462-003 | Empty `spec_hash` in args → validation error | Error returned containing "spec_hash is required"; DS client NOT called |
+
+### Unit Tests — Happy Path (AU-3)
+
+| ID | Scenario | Expected Outcome |
+|---|---|---|
+| UT-AF-1462-004 | All params valid including `spec_hash` → DS client receives all params | `opts.SpecHash == "sha256:abc123"` in captured DS client call; result returned without error |
+| UT-AF-1462-005 | Empty `namespace` is allowed (cluster-scoped resources) | No error when namespace is empty; DS client called with empty namespace |
+| UT-AF-1462-006 | `since` parameter pass-through | `opts.Since == "24h"` in captured DS client call |
+
+---
+
+## Component 2: OgenClient.GetRemediationHistory (DS Client)
+
+### Unit Tests — Parameter Wiring (AU-3)
+
+| ID | Scenario | Expected Outcome |
+|---|---|---|
+| UT-AF-1462-007 | `CurrentSpecHash` set in ogen query params | HTTP request to DS contains `currentSpecHash=sha256:abc123` in query string |
+
+---
+
+## Integration Tests (Wiring)
+
+| ID | Scenario | Expected Outcome |
+|---|---|---|
+| IT-AF-1462-008 | Full tool → DS round-trip with all params | 200 response from DS with non-empty `tier1.chain`; spec hash used for hash-chain correlation |
+
+---
+
+## Existing Tests to Update
+
+The following existing tests must be updated to include `spec_hash` in args to remain valid:
+
+| ID | Required Change |
+|---|---|
+| UT-AF-122-001 | Add `SpecHash: "sha256:test"` to args |
+| UT-AF-122-002 | Add `SpecHash: "sha256:test"` to args |
+| UT-AF-122-003 | Add `SpecHash: "sha256:test"` to args |
+| UT-AF-122-004 | Add `SpecHash: "sha256:test"` to args |
+
+---
+
+## Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | IT Test ID |
+|---|---|---|---|
+| SpecHash in HistoryOpts | OgenClient.GetRemediationHistory | pkg/apifrontend/ds/ogen_client.go | IT-AF-1462-008 |
+| Validation in HandleGetRemediationHistory | MCP tool registration | pkg/apifrontend/tools/ds_tools.go | IT-AF-1462-008 |
+
+---
+
+## Test Execution Summary
+
+| Test Category | Tests | Status |
+|---|---|---|
+| AF Unit Tests — Validation (UT-AF-1462-001..003) | 3 | Pending |
+| AF Unit Tests — Happy Path (UT-AF-1462-004..006) | 3 | Pending |
+| AF Unit Tests — Client Wiring (UT-AF-1462-007) | 1 | Pending |
+| AF Integration Tests (IT-AF-1462-008) | 1 | Pending |
+| Existing Test Updates (UT-AF-122-001..004) | 4 | Pending |
+| **Total** | **12** | **Pending** |

--- a/pkg/apifrontend/audit/audit.go
+++ b/pkg/apifrontend/audit/audit.go
@@ -58,9 +58,10 @@ const (
 	EventTriageCompleted  EventType = "triage.completed"
 	EventRRCreated        EventType = "rr.created"
 	EventRRDeduplicated   EventType = "rr.deduplicated"
-	EventKADelegated      EventType = "ka.delegated"
-	EventKAResultReceived EventType = "ka.result_received"
-	EventUserDecision     EventType = "user.decision"
+	EventKADelegated              EventType = "ka.delegated"
+	EventKAResultReceived         EventType = "ka.result_received"
+	EventUserDecision             EventType = "user.decision"
+	EventInvestigationTimeout     EventType = "investigation.timeout"
 )
 
 // Event represents a SOC2-compatible audit event.

--- a/pkg/apifrontend/audit/store_adapter.go
+++ b/pkg/apifrontend/audit/store_adapter.go
@@ -196,6 +196,7 @@ var actionMap = map[EventType]string{
 	EventKAResultReceived:        "received",
 	EventUserDecision:            "decided",
 	EventAgentCardAccessed:       "accessed",
+	EventInvestigationTimeout:    "timed_out",
 }
 
 func eventAction(t EventType) string {

--- a/pkg/apifrontend/ds/client.go
+++ b/pkg/apifrontend/ds/client.go
@@ -32,6 +32,7 @@ type HistoryOpts struct {
 	Kind      string
 	Name      string
 	Since     string
+	SpecHash  string
 }
 
 // HistoricalRemediation is a past remediation record from the Data Store.

--- a/pkg/apifrontend/ds/ogen_client.go
+++ b/pkg/apifrontend/ds/ogen_client.go
@@ -91,6 +91,7 @@ func (c *OgenClient) GetRemediationHistory(ctx context.Context, opts HistoryOpts
 		TargetKind:      opts.Kind,
 		TargetName:      opts.Name,
 		TargetNamespace: opts.Namespace,
+		CurrentSpecHash: opts.SpecHash,
 	}
 	if opts.Since != "" {
 		params.Tier1Window = ogenclient.NewOptString(opts.Since)

--- a/pkg/apifrontend/ds/ogen_client_methods_test.go
+++ b/pkg/apifrontend/ds/ogen_client_methods_test.go
@@ -125,6 +125,24 @@ func TestOgenClient_ListWorkflows_ServerError(t *testing.T) {
 	}
 }
 
+// UT-AF-1462-007: GetRemediationHistory sends currentSpecHash in query params
+func TestOgenClient_GetRemediationHistory_SendsSpecHash(t *testing.T) {
+	var capturedSpecHash string
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		capturedSpecHash = r.URL.Query().Get("currentSpecHash")
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	client := newTestOgenClient(t, mux)
+	_, _ = client.GetRemediationHistory(context.Background(), HistoryOpts{
+		Kind: "Deployment", Name: "api", Namespace: "prod", SpecHash: "sha256:abc123",
+	})
+	if capturedSpecHash != "sha256:abc123" {
+		t.Errorf("currentSpecHash = %q, want %q", capturedSpecHash, "sha256:abc123")
+	}
+}
+
 // UT-AF-038-037: Network failure returns wrapped error
 func TestOgenClient_NetworkFailure(t *testing.T) {
 	client, err := NewOgenClient(OgenClientConfig{

--- a/pkg/apifrontend/handler/mcp_bridge_integration_test.go
+++ b/pkg/apifrontend/handler/mcp_bridge_integration_test.go
@@ -196,7 +196,7 @@ var _ = Describe("MCP Bridge Integration (httptest backends)", func() {
 			}), mockDS)
 
 			status, body := mcpCallTool(h, sessionID, "kubernaut_get_remediation_history", map[string]any{
-				"namespace": "prod",
+				"namespace": "prod", "kind": "Deployment", "name": "api", "spec_hash": "sha256:abc123",
 			}, testUser)
 
 			Expect(status).To(Equal(http.StatusOK))

--- a/pkg/apifrontend/handler/mcp_bridge_test.go
+++ b/pkg/apifrontend/handler/mcp_bridge_test.go
@@ -726,7 +726,7 @@ var _ = Describe("MCP Bridge - Tier 1: Core Dispatch", Label("tier1", "bridge"),
 
 		It("UT-AF-B-012: kubernaut_get_remediation_history dispatches correctly", func() {
 			_, body := mcpCallTool(h, sessionID, "kubernaut_get_remediation_history",
-				map[string]any{}, testUser)
+				map[string]any{"kind": "Deployment", "name": "api", "spec_hash": "sha256:abc123"}, testUser)
 			text := extractTextContent(body)
 			Expect(text).To(ContainSubstring("remediations"))
 		})

--- a/pkg/apifrontend/tools/bridge_exit_reason_1451_test.go
+++ b/pkg/apifrontend/tools/bridge_exit_reason_1451_test.go
@@ -1,0 +1,182 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+)
+
+var _ = Describe("bridgeEventsCollectSummary exit reason — #1451 (BR-AF-MCP-003)", func() {
+
+	Describe("Exit Path Accuracy (SI-4)", func() {
+
+		It("UT-AF-1451-001: no events within inactivity timeout → inactivity_timeout", func() {
+			events := make(chan ka.InvestigationEvent, 5)
+			ctx := context.Background()
+
+			_, _, exitReason := tools.BridgeEventsCollectSummary(ctx, events, 50*time.Millisecond)
+
+			Expect(exitReason).To(Equal("inactivity_timeout"),
+				"SI-4: bridge must report inactivity_timeout when no events arrive")
+		})
+
+		It("UT-AF-1451-002: channel closes normally → channel_closed", func() {
+			events := make(chan ka.InvestigationEvent, 5)
+			close(events)
+			ctx := context.Background()
+
+			_, _, exitReason := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+
+			Expect(exitReason).To(Equal("channel_closed"),
+				"SI-4: bridge must report channel_closed when events channel closes normally")
+		})
+
+		It("UT-AF-1451-003: context cancelled → ctx_cancelled", func() {
+			events := make(chan ka.InvestigationEvent, 5)
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			_, _, exitReason := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+
+			Expect(exitReason).To(Equal("ctx_cancelled"),
+				"SI-4: bridge must report ctx_cancelled when context is done")
+		})
+	})
+
+	Describe("Status Mapping (AU-3)", func() {
+
+		It("UT-AF-1451-004: inactivity_timeout maps to timed_out status", func() {
+			events := make(chan ka.InvestigationEvent, 5)
+			ctx := context.Background()
+
+			_, _, exitReason := tools.BridgeEventsCollectSummary(ctx, events, 50*time.Millisecond)
+			Expect(exitReason).To(Equal("inactivity_timeout"))
+
+			status := tools.ExitReasonToStatus(exitReason)
+			Expect(status).To(Equal("timed_out"),
+				"AU-3: inactivity_timeout must map to timed_out so LLM knows investigation is hung")
+		})
+
+		It("UT-AF-1451-005: channel_closed maps to completed status", func() {
+			events := make(chan ka.InvestigationEvent, 5)
+			close(events)
+			ctx := context.Background()
+
+			_, _, exitReason := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+			Expect(exitReason).To(Equal("channel_closed"))
+
+			status := tools.ExitReasonToStatus(exitReason)
+			Expect(status).To(Equal("completed"),
+				"AU-3: channel_closed must map to completed — natural investigation end")
+		})
+
+		It("UT-AF-1451-006: ctx_cancelled maps to timeout status", func() {
+			events := make(chan ka.InvestigationEvent, 5)
+			ctx, cancel := context.WithCancel(context.Background())
+			cancel()
+
+			_, _, exitReason := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+			Expect(exitReason).To(Equal("ctx_cancelled"))
+
+			status := tools.ExitReasonToStatus(exitReason)
+			Expect(status).To(Equal("timeout"),
+				"AU-3: ctx_cancelled must map to timeout — external cancellation")
+		})
+	})
+
+	Describe("Timer Behavior (SI-4)", func() {
+
+		It("UT-AF-1451-007: default BridgeInactivityTimeout is 180s", func() {
+			Expect(tools.BridgeInactivityTimeout).To(Equal(180*time.Second),
+				"SI-4: default inactivity timeout must be 180s to avoid premature hang detection")
+		})
+
+		It("UT-AF-1451-008: timer resets on event arrival", func() {
+			events := make(chan ka.InvestigationEvent, 5)
+			ctx := context.Background()
+
+			go func() {
+				time.Sleep(40 * time.Millisecond)
+				events <- ka.InvestigationEvent{
+					Type: ka.EventTypeReasoningDelta,
+					Data: json.RawMessage(`{"text":"thinking..."}`),
+				}
+				time.Sleep(40 * time.Millisecond)
+				close(events)
+			}()
+
+			_, _, exitReason := tools.BridgeEventsCollectSummary(ctx, events, 50*time.Millisecond)
+
+			Expect(exitReason).To(Equal("channel_closed"),
+				"SI-4: event arrival must reset inactivity timer; channel close at T+80ms with 50ms timeout should not trigger timeout")
+		})
+	})
+
+	Describe("Data Preservation on Timeout (AU-3)", func() {
+
+		It("UT-AF-1451-009: summary text accumulated before timeout is preserved", func() {
+			events := make(chan ka.InvestigationEvent, 5)
+			ctx := context.Background()
+
+			events <- ka.InvestigationEvent{
+				Type: ka.EventTypeReasoningDelta,
+				Data: json.RawMessage(`{"text":"partial analysis of the issue"}`),
+			}
+
+			summary, _, exitReason := tools.BridgeEventsCollectSummary(ctx, events, 50*time.Millisecond)
+
+			Expect(exitReason).To(Equal("inactivity_timeout"))
+			Expect(summary).To(ContainSubstring("partial analysis of the issue"),
+				"AU-3: accumulated summary text must be preserved even on inactivity timeout")
+		})
+
+		It("UT-AF-1451-010: RCA data preserved on timeout", func() {
+			events := make(chan ka.InvestigationEvent, 5)
+			ctx := context.Background()
+
+			rcaPayload := map[string]interface{}{
+				"severity":    "critical",
+				"confidence":  0.91,
+				"rca_summary": "OOMKill from memory leak",
+				"target":      "Deployment/api in production",
+			}
+			rcaJSON, err := json.Marshal(rcaPayload)
+			Expect(err).NotTo(HaveOccurred())
+
+			events <- ka.InvestigationEvent{
+				Type: ka.EventTypeComplete,
+				Data: rcaJSON,
+			}
+
+			_, rca, exitReason := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+
+			Expect(exitReason).To(Equal("channel_closed"),
+				"EventTypeComplete triggers immediate return with channel_closed")
+			Expect(rca).NotTo(BeNil(), "AU-3: RCA data must be preserved")
+			Expect(rca.Severity).To(Equal("critical"))
+			Expect(rca.RCASummary).To(Equal("OOMKill from memory leak"))
+		})
+	})
+})

--- a/pkg/apifrontend/tools/bridge_exit_reason_1451_test.go
+++ b/pkg/apifrontend/tools/bridge_exit_reason_1451_test.go
@@ -134,6 +134,21 @@ var _ = Describe("bridgeEventsCollectSummary exit reason — #1451 (BR-AF-MCP-00
 		})
 	})
 
+	Describe("Audit Emission on Timeout (AU-3)", func() {
+
+		It("UT-AF-1451-E01: ExitReasonToStatus returns timed_out for inactivity_timeout", func() {
+			Expect(tools.ExitReasonToStatus(tools.ExitReasonInactivityTimeout)).To(Equal("timed_out"))
+		})
+
+		It("UT-AF-1451-E02: ExitReasonToStatus returns completed for channel_closed", func() {
+			Expect(tools.ExitReasonToStatus(tools.ExitReasonChannelClosed)).To(Equal("completed"))
+		})
+
+		It("UT-AF-1451-E03: ExitReasonToStatus returns timeout for ctx_cancelled", func() {
+			Expect(tools.ExitReasonToStatus(tools.ExitReasonCtxCancelled)).To(Equal("timeout"))
+		})
+	})
+
 	Describe("Data Preservation on Timeout (AU-3)", func() {
 
 		It("UT-AF-1451-009: summary text accumulated before timeout is preserved", func() {

--- a/pkg/apifrontend/tools/ds_tools.go
+++ b/pkg/apifrontend/tools/ds_tools.go
@@ -70,6 +70,7 @@ type GetRemediationHistoryArgs struct {
 	Kind      string `json:"kind,omitempty"`
 	Name      string `json:"name,omitempty"`
 	Since     string `json:"since,omitempty"`
+	SpecHash  string `json:"spec_hash,omitempty"`
 }
 
 // HistoricalRemediation is a past remediation record from the Data Store.
@@ -92,8 +93,17 @@ func HandleGetRemediationHistory(ctx context.Context, client ds.Client, args Get
 	if client == nil {
 		return GetRemediationHistoryResult{}, ErrDSUnavailable
 	}
+	if args.Kind == "" {
+		return GetRemediationHistoryResult{}, fmt.Errorf("kind is required for remediation history lookup")
+	}
+	if args.Name == "" {
+		return GetRemediationHistoryResult{}, fmt.Errorf("name is required for remediation history lookup")
+	}
+	if args.SpecHash == "" {
+		return GetRemediationHistoryResult{}, fmt.Errorf("spec_hash is required for remediation history lookup")
+	}
 	history, err := client.GetRemediationHistory(ctx, ds.HistoryOpts{
-		Namespace: args.Namespace, Kind: args.Kind, Name: args.Name, Since: args.Since,
+		Namespace: args.Namespace, Kind: args.Kind, Name: args.Name, Since: args.Since, SpecHash: args.SpecHash,
 	})
 	if err != nil {
 		return GetRemediationHistoryResult{}, fmt.Errorf("querying remediation history: %w", err)
@@ -113,7 +123,7 @@ func HandleGetRemediationHistory(ctx context.Context, client ds.Client, args Get
 func NewGetRemediationHistoryTool(client ds.Client) (tool.Tool, error) {
 	return functiontool.New(functiontool.Config{
 		Name:        "kubernaut_get_remediation_history",
-		Description: "Query historical remediations from the Data Store with optional filtering",
+		Description: "Query historical remediations from the Data Store. Required params: kind, name, spec_hash. Optional: namespace, since.",
 	}, func(ctx tool.Context, args GetRemediationHistoryArgs) (GetRemediationHistoryResult, error) {
 		return HandleGetRemediationHistory(ctx, client, args)
 	})

--- a/pkg/apifrontend/tools/ds_tools.go
+++ b/pkg/apifrontend/tools/ds_tools.go
@@ -102,6 +102,9 @@ func HandleGetRemediationHistory(ctx context.Context, client ds.Client, args Get
 	if args.SpecHash == "" {
 		return GetRemediationHistoryResult{}, fmt.Errorf("spec_hash is required for remediation history lookup")
 	}
+	if !strings.HasPrefix(args.SpecHash, "sha256:") {
+		return GetRemediationHistoryResult{}, fmt.Errorf("spec_hash must use sha256: prefix (got %q)", args.SpecHash)
+	}
 	history, err := client.GetRemediationHistory(ctx, ds.HistoryOpts{
 		Namespace: args.Namespace, Kind: args.Kind, Name: args.Name, Since: args.Since, SpecHash: args.SpecHash,
 	})

--- a/pkg/apifrontend/tools/ka_investigate_mcp.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp.go
@@ -447,6 +447,19 @@ func HandleInvestigationMCPWithRegistry(ctx context.Context, cfg *InvestigateCon
 		logger.Info("bridgeEventsCollectSummary: finished",
 			"rr_id", args.RRID, "status", status, "exit_reason", exitReason, "summary_len", len(summary))
 
+		if exitReason == ExitReasonInactivityTimeout && cfg.Auditor != nil {
+			cfg.Auditor.Emit(ctx, &audit.Event{
+				Type: audit.EventInvestigationTimeout,
+				Detail: map[string]string{
+					"rr_id":              args.RRID,
+					"session_id":         result.SessionID,
+					"exit_reason":        exitReason,
+					"inactivity_timeout": BridgeInactivityTimeout.String(),
+					"summary_len":        fmt.Sprintf("%d", len(summary)),
+				},
+			})
+		}
+
 		// Fallback: when KA produced no RCA (e.g. user-driving mode with
 		// no autonomous session) but severity triage completed during RR
 		// creation, emit progressive events using the triage data so the

--- a/pkg/apifrontend/tools/ka_investigate_mcp.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp.go
@@ -442,15 +442,10 @@ func HandleInvestigationMCPWithRegistry(ctx context.Context, cfg *InvestigateCon
 		logger.Info("bridgeEventsCollectSummary: starting blocking event bridge",
 			"rr_id", args.RRID, "session_id", result.SessionID, "ctx_err", ctx.Err())
 		bridgeCtx := WithRRID(ctx, args.RRID)
-		summary, rca := bridgeEventsCollectSummary(bridgeCtx, result.Events, BridgeInactivityTimeout)
-		status := "completed"
-		if ctx.Err() != nil {
-			status = "timeout"
-			logger.Info("bridgeEventsCollectSummary: context cancelled",
-				"rr_id", args.RRID, "ctx_err", ctx.Err(), "summary_len", len(summary))
-		}
+		summary, rca, exitReason := bridgeEventsCollectSummary(bridgeCtx, result.Events, BridgeInactivityTimeout)
+		status := ExitReasonToStatus(exitReason)
 		logger.Info("bridgeEventsCollectSummary: finished",
-			"rr_id", args.RRID, "status", status, "summary_len", len(summary))
+			"rr_id", args.RRID, "status", status, "exit_reason", exitReason, "summary_len", len(summary))
 
 		// Fallback: when KA produced no RCA (e.g. user-driving mode with
 		// no autonomous session) but severity triage completed during RR
@@ -598,19 +593,39 @@ var NonBlockingBridgeTTL = 15 * time.Minute
 // so investigations of any wall-clock duration succeed as long as KA keeps
 // producing events (token deltas, tool calls, keepalives).
 // Exported so that tests can override it without modifying production code.
-var BridgeInactivityTimeout = 60 * time.Second
+var BridgeInactivityTimeout = 180 * time.Second
+
+// Exit reason constants returned as the third value from bridgeEventsCollectSummary.
+const (
+	ExitReasonInactivityTimeout = "inactivity_timeout"
+	ExitReasonChannelClosed     = "channel_closed"
+	ExitReasonCtxCancelled      = "ctx_cancelled"
+)
 
 // BridgeEventsCollectSummary is the exported entry point for bridgeEventsCollectSummary.
 // It is used by integration tests and the blocking MCP investigation path.
-func BridgeEventsCollectSummary(ctx context.Context, events <-chan ka.InvestigationEvent, inactivityTimeout time.Duration) (string, *InvestigateRCA) {
+func BridgeEventsCollectSummary(ctx context.Context, events <-chan ka.InvestigationEvent, inactivityTimeout time.Duration) (string, *InvestigateRCA, string) {
 	return bridgeEventsCollectSummary(ctx, events, inactivityTimeout)
+}
+
+// ExitReasonToStatus maps the exit reason returned by bridgeEventsCollectSummary
+// to a user-facing investigation status string.
+func ExitReasonToStatus(exitReason string) string {
+	switch exitReason {
+	case ExitReasonInactivityTimeout:
+		return "timed_out"
+	case ExitReasonCtxCancelled:
+		return "timeout"
+	default:
+		return "completed"
+	}
 }
 
 // bridgeEventsCollectSummary bridges events (same as BridgeEventsToA2A) and
 // accumulates reasoning_delta text into a summary returned when the channel
 // closes, the context is cancelled, or no events arrive within
 // inactivityTimeout (hang detection).
-func bridgeEventsCollectSummary(ctx context.Context, events <-chan ka.InvestigationEvent, inactivityTimeout time.Duration) (string, *InvestigateRCA) {
+func bridgeEventsCollectSummary(ctx context.Context, events <-chan ka.InvestigationEvent, inactivityTimeout time.Duration) (string, *InvestigateRCA, string) {
 	var summary strings.Builder
 	var rcaResult *InvestigateRCA
 	keepalive := time.NewTicker(5 * time.Second)
@@ -620,14 +635,14 @@ func bridgeEventsCollectSummary(ctx context.Context, events <-chan ka.Investigat
 	for {
 		select {
 		case <-ctx.Done():
-			return summary.String(), rcaResult
+			return summary.String(), rcaResult, ExitReasonCtxCancelled
 		case <-inactivity.C:
-			return summary.String(), rcaResult
+			return summary.String(), rcaResult, ExitReasonInactivityTimeout
 		case <-keepalive.C:
 			_ = launcher.EmitKeepaliveDotSafe(ctx)
 		case evt, ok := <-events:
 			if !ok {
-				return summary.String(), rcaResult
+				return summary.String(), rcaResult, ExitReasonChannelClosed
 			}
 			inactivity.Reset(inactivityTimeout)
 			// #1438: Handle session_ended before generic emit to avoid double-emit.
@@ -641,7 +656,7 @@ func bridgeEventsCollectSummary(ctx context.Context, events <-chan ka.Investigat
 						"reason":   evt.Phase,
 						"terminal": true,
 					})
-				return summary.String(), rcaResult
+				return summary.String(), rcaResult, ExitReasonChannelClosed
 			}
 			emitEventToA2A(ctx, evt, FormatEventForUser(evt))
 			switch evt.Type {
@@ -675,9 +690,9 @@ func bridgeEventsCollectSummary(ctx context.Context, events <-chan ka.Investigat
 						emitEarlyRCA(ctx, &rca)
 					}
 				}
-				return summary.String(), rcaResult
+				return summary.String(), rcaResult, ExitReasonChannelClosed
 			case ka.EventTypeCancelled:
-				return summary.String(), rcaResult
+				return summary.String(), rcaResult, ExitReasonChannelClosed
 			}
 		}
 	}

--- a/pkg/apifrontend/tools/ka_investigate_rca_test.go
+++ b/pkg/apifrontend/tools/ka_investigate_rca_test.go
@@ -58,7 +58,7 @@ var _ = Describe("bridgeEventsCollectSummary RCA Parsing — TP-1395-1396 (#1396
 			}
 
 			ctx := context.Background()
-			summary, rca := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+			summary, rca, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 
 			Expect(summary).To(ContainSubstring("Investigating..."))
 			Expect(rca).NotTo(BeNil(), "RCA should be populated from complete event Data")
@@ -85,7 +85,7 @@ var _ = Describe("bridgeEventsCollectSummary RCA Parsing — TP-1395-1396 (#1396
 			}
 
 			ctx := context.Background()
-			summary, rca := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+			summary, rca, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 
 			Expect(summary).To(Equal("Found the issue."))
 			Expect(rca).To(BeNil(), "RCA should be nil when complete event has no Data")
@@ -122,7 +122,7 @@ var _ = Describe("Progressive RCA Emission — #1407", func() {
 				Data: rcaJSON,
 			}
 
-			_, rca := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+			_, rca, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 			Expect(rca).NotTo(BeNil())
 
 			allEvents := queue.Events()
@@ -169,7 +169,7 @@ var _ = Describe("Progressive RCA Emission — #1407", func() {
 				Type: ka.EventTypeComplete,
 			}
 
-			_, rca := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+			_, rca, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 			Expect(rca).To(BeNil())
 
 			allEvents := queue.Events()
@@ -204,7 +204,7 @@ var _ = Describe("Progressive RCA Emission — #1407", func() {
 				Data: rcaJSON,
 			}
 
-			tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+			_, _, _ = tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 
 			allEvents := queue.Events()
 			var decisionEvt *a2a.TaskStatusUpdateEvent
@@ -246,7 +246,7 @@ var _ = Describe("Progressive RCA Emission — #1407", func() {
 			}
 
 			ctx := context.Background()
-			summary, rca := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+			summary, rca, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 			Expect(rca).NotTo(BeNil())
 			Expect(summary).To(ContainSubstring("Should not panic"))
 		})

--- a/pkg/apifrontend/tools/ka_investigate_verdict_1420_test.go
+++ b/pkg/apifrontend/tools/ka_investigate_verdict_1420_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Issue #1420: AF Bridge Alignment Verdict Handling (SC-7)", fun
 		ctx := launcher.WithEventBridge(context.Background(), q, taskID, "ctx-1420", nil)
 		ctx = tools.WithRRID(ctx, "rr-1420-001")
 
-		summary, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+		summary, _, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 		_ = summary
 
 		found := false
@@ -111,7 +111,7 @@ var _ = Describe("Issue #1420: AF Bridge Alignment Verdict Handling (SC-7)", fun
 		ctx := launcher.WithEventBridge(context.Background(), q, taskID, "ctx-1420-002", nil)
 		ctx = tools.WithRRID(ctx, "rr-1420-002")
 
-		tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+		_, _, _ = tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 
 		found := false
 		for _, evt := range q.Events() {

--- a/pkg/apifrontend/tools/kubernaut_get_remediation_history_test.go
+++ b/pkg/apifrontend/tools/kubernaut_get_remediation_history_test.go
@@ -146,6 +146,33 @@ var _ = Describe("kubernaut_get_remediation_history", func() {
 		Expect(capturedOpts.Namespace).To(BeEmpty())
 	})
 
+	It("UT-AF-1462-E01: spec_hash without sha256: prefix returns format error", func() {
+		mock := &ds.MockClient{
+			GetRemediationHistoryFn: func(ctx context.Context, opts ds.HistoryOpts) ([]ds.HistoricalRemediation, error) {
+				Fail("DS client should not be called with malformed spec_hash")
+				return nil, nil
+			},
+		}
+		_, err := tools.HandleGetRemediationHistory(ctx, mock, tools.GetRemediationHistoryArgs{
+			Kind: "Deployment", Name: "api", SpecHash: "md5:badprefix",
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("sha256: prefix"))
+	})
+
+	It("UT-AF-1462-E02: spec_hash with valid sha256: prefix passes validation", func() {
+		mock := &ds.MockClient{
+			GetRemediationHistoryFn: func(ctx context.Context, opts ds.HistoryOpts) ([]ds.HistoricalRemediation, error) {
+				return []ds.HistoricalRemediation{{ID: "rr-1"}}, nil
+			},
+		}
+		result, err := tools.HandleGetRemediationHistory(ctx, mock, tools.GetRemediationHistoryArgs{
+			Kind: "Deployment", Name: "api", SpecHash: "sha256:e3b0c44298fc1c149afbf4c8996fb924",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Count).To(Equal(1))
+	})
+
 	It("UT-AF-1462-006: since parameter passes through correctly", func() {
 		var capturedOpts ds.HistoryOpts
 		mock := &ds.MockClient{

--- a/pkg/apifrontend/tools/kubernaut_get_remediation_history_test.go
+++ b/pkg/apifrontend/tools/kubernaut_get_remediation_history_test.go
@@ -26,7 +26,9 @@ var _ = Describe("kubernaut_get_remediation_history", func() {
 				}, nil
 			},
 		}
-		result, err := tools.HandleGetRemediationHistory(ctx, mock, tools.GetRemediationHistoryArgs{Namespace: "payments"})
+		result, err := tools.HandleGetRemediationHistory(ctx, mock, tools.GetRemediationHistoryArgs{
+			Kind: "Deployment", Name: "api", SpecHash: "sha256:test", Namespace: "payments",
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.Count).To(Equal(1))
 	})
@@ -37,7 +39,9 @@ var _ = Describe("kubernaut_get_remediation_history", func() {
 				return nil, nil
 			},
 		}
-		result, err := tools.HandleGetRemediationHistory(ctx, mock, tools.GetRemediationHistoryArgs{Namespace: "empty"})
+		result, err := tools.HandleGetRemediationHistory(ctx, mock, tools.GetRemediationHistoryArgs{
+			Kind: "Deployment", Name: "api", SpecHash: "sha256:test", Namespace: "empty",
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.Count).To(Equal(0))
 	})
@@ -48,7 +52,9 @@ var _ = Describe("kubernaut_get_remediation_history", func() {
 				return nil, fmt.Errorf("connection refused")
 			},
 		}
-		_, err := tools.HandleGetRemediationHistory(ctx, mock, tools.GetRemediationHistoryArgs{Namespace: "pay"})
+		_, err := tools.HandleGetRemediationHistory(ctx, mock, tools.GetRemediationHistoryArgs{
+			Kind: "Deployment", Name: "api", SpecHash: "sha256:test", Namespace: "pay",
+		})
 		Expect(err).To(HaveOccurred())
 	})
 
@@ -59,8 +65,99 @@ var _ = Describe("kubernaut_get_remediation_history", func() {
 				return []ds.HistoricalRemediation{{ID: "rr-1"}}, nil
 			},
 		}
-		result, err := tools.HandleGetRemediationHistory(ctx, mock, tools.GetRemediationHistoryArgs{Since: "2026-01-01"})
+		result, err := tools.HandleGetRemediationHistory(ctx, mock, tools.GetRemediationHistoryArgs{
+			Kind: "Deployment", Name: "api", SpecHash: "sha256:test", Since: "2026-01-01",
+		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.Count).To(Equal(1))
+	})
+
+	It("UT-AF-1462-001: empty kind returns validation error", func() {
+		mock := &ds.MockClient{
+			GetRemediationHistoryFn: func(ctx context.Context, opts ds.HistoryOpts) ([]ds.HistoricalRemediation, error) {
+				Fail("DS client should not be called when kind is empty")
+				return nil, nil
+			},
+		}
+		_, err := tools.HandleGetRemediationHistory(ctx, mock, tools.GetRemediationHistoryArgs{
+			Kind: "", Name: "api", SpecHash: "sha256:abc123",
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("kind is required"))
+	})
+
+	It("UT-AF-1462-002: empty name returns validation error", func() {
+		mock := &ds.MockClient{
+			GetRemediationHistoryFn: func(ctx context.Context, opts ds.HistoryOpts) ([]ds.HistoricalRemediation, error) {
+				Fail("DS client should not be called when name is empty")
+				return nil, nil
+			},
+		}
+		_, err := tools.HandleGetRemediationHistory(ctx, mock, tools.GetRemediationHistoryArgs{
+			Kind: "Deployment", Name: "", SpecHash: "sha256:abc123",
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("name is required"))
+	})
+
+	It("UT-AF-1462-003: empty spec_hash returns validation error", func() {
+		mock := &ds.MockClient{
+			GetRemediationHistoryFn: func(ctx context.Context, opts ds.HistoryOpts) ([]ds.HistoricalRemediation, error) {
+				Fail("DS client should not be called when spec_hash is empty")
+				return nil, nil
+			},
+		}
+		_, err := tools.HandleGetRemediationHistory(ctx, mock, tools.GetRemediationHistoryArgs{
+			Kind: "Deployment", Name: "api", SpecHash: "",
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("spec_hash is required"))
+	})
+
+	It("UT-AF-1462-004: all params valid passes spec_hash to DS client", func() {
+		var capturedOpts ds.HistoryOpts
+		mock := &ds.MockClient{
+			GetRemediationHistoryFn: func(ctx context.Context, opts ds.HistoryOpts) ([]ds.HistoricalRemediation, error) {
+				capturedOpts = opts
+				return []ds.HistoricalRemediation{{ID: "rr-1", Namespace: "prod", Phase: "Completed"}}, nil
+			},
+		}
+		result, err := tools.HandleGetRemediationHistory(ctx, mock, tools.GetRemediationHistoryArgs{
+			Namespace: "prod", Kind: "Deployment", Name: "api", SpecHash: "sha256:abc123",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Count).To(Equal(1))
+		Expect(capturedOpts.SpecHash).To(Equal("sha256:abc123"))
+	})
+
+	It("UT-AF-1462-005: empty namespace is allowed for cluster-scoped resources", func() {
+		var capturedOpts ds.HistoryOpts
+		mock := &ds.MockClient{
+			GetRemediationHistoryFn: func(ctx context.Context, opts ds.HistoryOpts) ([]ds.HistoricalRemediation, error) {
+				capturedOpts = opts
+				return []ds.HistoricalRemediation{{ID: "rr-2"}}, nil
+			},
+		}
+		result, err := tools.HandleGetRemediationHistory(ctx, mock, tools.GetRemediationHistoryArgs{
+			Kind: "ClusterRole", Name: "admin", SpecHash: "sha256:def456",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Count).To(Equal(1))
+		Expect(capturedOpts.Namespace).To(BeEmpty())
+	})
+
+	It("UT-AF-1462-006: since parameter passes through correctly", func() {
+		var capturedOpts ds.HistoryOpts
+		mock := &ds.MockClient{
+			GetRemediationHistoryFn: func(ctx context.Context, opts ds.HistoryOpts) ([]ds.HistoricalRemediation, error) {
+				capturedOpts = opts
+				return []ds.HistoricalRemediation{{ID: "rr-3"}}, nil
+			},
+		}
+		_, err := tools.HandleGetRemediationHistory(ctx, mock, tools.GetRemediationHistoryArgs{
+			Kind: "Deployment", Name: "api", SpecHash: "sha256:abc123", Since: "24h",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(capturedOpts.Since).To(Equal("24h"))
 	})
 })

--- a/pkg/apifrontend/tools/terminal_event_1438_test.go
+++ b/pkg/apifrontend/tools/terminal_event_1438_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Terminal event emission to A2A — #1438", func() {
 				Phase: "inactivity_timeout",
 			}
 
-			summary, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+			summary, _, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 			_ = summary
 
 			queuedEvents := queue.Events()
@@ -190,7 +190,7 @@ var _ = Describe("Terminal event emission to A2A — #1438", func() {
 				Phase: "inactivity_timeout",
 			}
 
-			tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+			_, _, _ = tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 
 			queuedEvents := queue.Events()
 			statusCount := 0

--- a/pkg/gateway/adapters/prometheus_adapter.go
+++ b/pkg/gateway/adapters/prometheus_adapter.go
@@ -208,8 +208,15 @@ func (a *PrometheusAdapter) Parse(ctx context.Context, rawData []byte) (*types.N
 	// from previous scenario runs) must be skipped rather than dropping the entire batch.
 	var lastErr error
 	for i, alert := range webhook.Alerts {
-		ns := extractNamespace(alert.Labels)
+		ns, nsFound := extractNamespace(alert.Labels)
 		kind, name := extractTargetResource(ctx, alert.Labels, ns, a.registry)
+		if !nsFound {
+			if a.registry != nil && !a.registry.IsNamespacedKind(kind) {
+				ns = ""
+			} else {
+				ns = "default"
+			}
+		}
 		resource := types.ResourceIdentifier{
 			Kind:      kind,
 			Name:      name,
@@ -278,8 +285,15 @@ func (a *PrometheusAdapter) ParseBatch(ctx context.Context, rawData []byte) ([]*
 
 	var signals []*types.NormalizedSignal
 	for i, alert := range webhook.Alerts {
-		ns := extractNamespace(alert.Labels)
+		ns, nsFound := extractNamespace(alert.Labels)
 		kind, name := extractTargetResource(ctx, alert.Labels, ns, a.registry)
+		if !nsFound {
+			if a.registry != nil && !a.registry.IsNamespacedKind(kind) {
+				ns = ""
+			} else {
+				ns = "default"
+			}
+		}
 		resource := types.ResourceIdentifier{
 			Kind:      kind,
 			Name:      name,
@@ -379,7 +393,7 @@ func (a *PrometheusAdapter) GetMetadata() AdapterMetadata {
 //
 // Examples (with OwnerResolver):
 // - Pod "payment-api-789" owned by Deployment "payment-api" → SHA256(prod:Deployment:payment-api)
-// - Node "worker-node-1" (no owner) → SHA256(default:Node:worker-node-1)
+// - Node "worker-node-1" (no owner) → SHA256(:Node:worker-node-1)
 //
 // Examples (without OwnerResolver):
 // - SHA256(prod:Pod:payment-api-789) — resource from labels, no alertname
@@ -459,19 +473,19 @@ func extractTargetResource(ctx context.Context, labels map[string]string, namesp
 // Extraction order (#1029 update — exported_namespace takes precedence):
 // 1. exported_namespace label (for federated Prometheus — points to the real namespace)
 // 2. namespace label
-// 3. default → "default"
+// 3. ("", false) — caller decides based on resource kind scope (#1371)
 //
 // In federated setups, the "namespace" label often points to the federation
 // namespace (e.g., "monitoring"), while "exported_namespace" contains the
 // actual workload namespace (e.g., "production").
-func extractNamespace(labels map[string]string) string {
+func extractNamespace(labels map[string]string) (string, bool) {
 	if ns, ok := labels["exported_namespace"]; ok && ns != "" && isValidK8sName(ns) {
-		return ns
+		return ns, true
 	}
 	if ns, ok := labels["namespace"]; ok && isValidK8sName(ns) {
-		return ns
+		return ns, true
 	}
-	return "default"
+	return "", false
 }
 
 // isValidK8sName returns true if s conforms to RFC 1123 label naming rules

--- a/pkg/gateway/adapters/resource_extraction_business_test.go
+++ b/pkg/gateway/adapters/resource_extraction_business_test.go
@@ -120,10 +120,8 @@ var _ = Describe("Prometheus Adapter - Resource Extraction for Workflow Selectio
 				"Kind=Node enables RO to select cluster infrastructure workflows")
 			Expect(signal.Resource.Name).To(Equal("worker-node-1"),
 				"Node name enables WE to target: kubectl cordon worker-node-1")
-			// Note: extractNamespace() defaults to "default" when no namespace label present
-			// This is safe behavior for cluster-scoped resources
-			Expect(signal.Resource.Namespace).To(Equal("default"),
-				"Nodes get default namespace (safe fallback for cluster-scoped resources)")
+			Expect(signal.Resource.Namespace).To(BeEmpty(),
+				"Cluster-scoped resources (Node) get empty namespace (#1371)")
 		})
 
 		It("extracts StatefulSet kind for stateful application workflows", func() {
@@ -239,8 +237,8 @@ var _ = Describe("Prometheus Adapter - Resource Extraction for Workflow Selectio
 				"Federated Prometheus: exported_namespace fallback preserves multi-cluster context")
 		})
 
-		It("defaults to 'default' namespace when not specified", func() {
-			// BUSINESS OUTCOME: Cluster-scoped alerts without namespace use safe default
+		It("uses empty namespace for cluster-scoped resources (#1371)", func() {
+			// BUSINESS OUTCOME: Cluster-scoped alerts (Node) get empty namespace
 			payload := `{
 				"alerts": [{
 					"status": "firing",
@@ -255,8 +253,8 @@ var _ = Describe("Prometheus Adapter - Resource Extraction for Workflow Selectio
 			signal, err := adapter.Parse(context.Background(), []byte(payload))
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(signal.Namespace).To(Equal("default"),
-				"Safe default namespace prevents remediation errors")
+			Expect(signal.Namespace).To(BeEmpty(),
+				"Cluster-scoped resources (Node) get empty namespace (#1371)")
 		})
 	})
 

--- a/pkg/gateway/adapters/resource_extraction_test.go
+++ b/pkg/gateway/adapters/resource_extraction_test.go
@@ -347,9 +347,9 @@ var _ = Describe("Prometheus Adapter - Resource Extraction for Workflow Selectio
 				"exported_namespace supports federated Prometheus multi-cluster monitoring")
 		})
 
-		It("uses default namespace when not specified", func() {
-			// BUSINESS OUTCOME: Cluster-scoped resources get default namespace
-			// Node alerts don't have namespace - default used for CRD creation
+		It("uses empty namespace for cluster-scoped resources (#1371)", func() {
+			// BUSINESS OUTCOME: Cluster-scoped resources get empty namespace
+			// Node alerts don't have namespace - empty string for CRD creation
 			payload := map[string]interface{}{
 				"alerts": []map[string]interface{}{
 					{
@@ -372,8 +372,136 @@ var _ = Describe("Prometheus Adapter - Resource Extraction for Workflow Selectio
 			signal, err := adapter.Parse(ctx, payloadBytes)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(signal.Namespace).To(Equal("default"),
-				"Default namespace used for cluster-scoped resources (Node, ClusterRole)")
+			Expect(signal.Namespace).To(BeEmpty(),
+				"Cluster-scoped resources (Node) get empty namespace (#1371)")
+		})
+	})
+})
+
+var _ = Describe("Prometheus Adapter - Scope-Aware Namespace Resolution (#1371)", func() {
+	var (
+		adapter *adapters.PrometheusAdapter
+		ctx     context.Context
+	)
+
+	BeforeEach(func() {
+		adapter = adapters.NewPrometheusAdapter(nil, adapters.NewTestAPIResourceRegistry())
+		ctx = context.Background()
+	})
+
+	Context("BR-GATEWAY-001, BR-GATEWAY-004: Scope-Aware Namespace Resolution (#1371)", func() {
+		It("UT-GW-1371-011: cluster-scoped Node alert without namespace label gets empty namespace", func() {
+			payload := map[string]interface{}{
+				"alerts": []map[string]interface{}{
+					{
+						"labels": map[string]interface{}{
+							"alertname": "KubeNodeNotReady",
+							"node":      "worker-node-1",
+							"severity":  "critical",
+						},
+						"annotations": map[string]interface{}{
+							"summary": "Node is not ready",
+						},
+						"status":      "firing",
+						"startsAt":    time.Now().Format(time.RFC3339),
+						"fingerprint": "test-fingerprint",
+					},
+				},
+			}
+
+			payloadBytes, _ := json.Marshal(payload)
+			signal, err := adapter.Parse(ctx, payloadBytes)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(signal.Resource.Kind).To(Equal("Node"))
+			Expect(signal.Resource.Namespace).To(BeEmpty(),
+				"Cluster-scoped Node alert must have empty namespace, not 'default'")
+		})
+
+		It("UT-GW-1371-012: namespaced Deployment alert without namespace label gets 'default'", func() {
+			payload := map[string]interface{}{
+				"alerts": []map[string]interface{}{
+					{
+						"labels": map[string]interface{}{
+							"alertname":  "DeploymentReplicasMismatch",
+							"deployment": "payment-api",
+							"severity":   "warning",
+						},
+						"annotations": map[string]interface{}{
+							"summary": "Deployment replicas mismatch",
+						},
+						"status":      "firing",
+						"startsAt":    time.Now().Format(time.RFC3339),
+						"fingerprint": "test-fingerprint",
+					},
+				},
+			}
+
+			payloadBytes, _ := json.Marshal(payload)
+			signal, err := adapter.Parse(ctx, payloadBytes)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(signal.Resource.Kind).To(Equal("Deployment"))
+			Expect(signal.Resource.Namespace).To(Equal("default"),
+				"Namespaced kind without explicit namespace falls back to 'default'")
+		})
+
+		It("UT-GW-1371-013: namespaced Deployment alert with explicit namespace uses provided value", func() {
+			payload := map[string]interface{}{
+				"alerts": []map[string]interface{}{
+					{
+						"labels": map[string]interface{}{
+							"alertname":  "DeploymentReplicasMismatch",
+							"deployment": "payment-api",
+							"namespace":  "production",
+							"severity":   "warning",
+						},
+						"annotations": map[string]interface{}{
+							"summary": "Deployment replicas mismatch",
+						},
+						"status":      "firing",
+						"startsAt":    time.Now().Format(time.RFC3339),
+						"fingerprint": "test-fingerprint",
+					},
+				},
+			}
+
+			payloadBytes, _ := json.Marshal(payload)
+			signal, err := adapter.Parse(ctx, payloadBytes)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(signal.Resource.Kind).To(Equal("Deployment"))
+			Expect(signal.Resource.Namespace).To(Equal("production"),
+				"Explicit namespace always honored regardless of kind scope")
+		})
+
+		It("UT-GW-1371-014: cluster-scoped Node alert with explicit namespace label honors it", func() {
+			payload := map[string]interface{}{
+				"alerts": []map[string]interface{}{
+					{
+						"labels": map[string]interface{}{
+							"alertname": "KubeNodeNotReady",
+							"node":      "worker-node-1",
+							"namespace": "monitoring",
+							"severity":  "critical",
+						},
+						"annotations": map[string]interface{}{
+							"summary": "Node is not ready",
+						},
+						"status":      "firing",
+						"startsAt":    time.Now().Format(time.RFC3339),
+						"fingerprint": "test-fingerprint",
+					},
+				},
+			}
+
+			payloadBytes, _ := json.Marshal(payload)
+			signal, err := adapter.Parse(ctx, payloadBytes)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(signal.Resource.Kind).To(Equal("Node"))
+			Expect(signal.Resource.Namespace).To(Equal("monitoring"),
+				"Explicit namespace label honored even for cluster-scoped resources")
 		})
 	})
 })

--- a/pkg/gateway/adapters/resource_registry.go
+++ b/pkg/gateway/adapters/resource_registry.go
@@ -49,9 +49,10 @@ var (
 )
 
 type registrySnapshot struct {
-	labelToKind map[string]string
-	kindToGVR   map[string]schema.GroupVersionResource
-	kindToGroup map[string]string
+	labelToKind    map[string]string
+	kindToGVR      map[string]schema.GroupVersionResource
+	kindToGroup    map[string]string
+	kindNamespaced map[string]bool
 }
 
 type existenceCacheEntry struct {
@@ -184,6 +185,7 @@ func buildSnapshot(dc discovery.DiscoveryInterface) (*registrySnapshot, error) {
 	labelToKind := make(map[string]string, totalResources)
 	kindToGVR := make(map[string]schema.GroupVersionResource, totalResources)
 	kindToGroup := make(map[string]string, totalResources)
+	kindNamespaced := make(map[string]bool, totalResources)
 
 	for _, list := range lists {
 		if list == nil {
@@ -211,6 +213,7 @@ func buildSnapshot(dc discovery.DiscoveryInterface) (*registrySnapshot, error) {
 			if _, exists := kindToGVR[res.Kind]; !exists {
 				kindToGVR[res.Kind] = gvr
 				kindToGroup[res.Kind] = gv.Group
+				kindNamespaced[res.Kind] = res.Namespaced
 			}
 
 			singular := res.SingularName
@@ -231,9 +234,10 @@ func buildSnapshot(dc discovery.DiscoveryInterface) (*registrySnapshot, error) {
 	}
 
 	return &registrySnapshot{
-		labelToKind: labelToKind,
-		kindToGVR:   kindToGVR,
-		kindToGroup: kindToGroup,
+		labelToKind:    labelToKind,
+		kindToGVR:      kindToGVR,
+		kindToGroup:    kindToGroup,
+		kindNamespaced: kindNamespaced,
 	}, nil
 }
 
@@ -261,6 +265,24 @@ func (r *APIResourceRegistry) KindToGVR(kind string) (schema.GroupVersionResourc
 	}
 	gvr, ok := snap.kindToGVR[kind]
 	return gvr, ok
+}
+
+// IsNamespacedKind returns true if the given Kind is namespaced according to
+// API discovery. Returns true (conservative default) for unknown kinds or when
+// the registry snapshot is not yet initialized — this avoids accidentally
+// dropping namespace information for resources that actually need it.
+func (r *APIResourceRegistry) IsNamespacedKind(kind string) bool {
+	r.mu.RLock()
+	snap := r.snapshot
+	r.mu.RUnlock()
+	if snap == nil {
+		return true
+	}
+	namespaced, ok := snap.kindNamespaced[kind]
+	if !ok {
+		return true
+	}
+	return namespaced
 }
 
 // TierForKind returns the priority tier for a given Kind.

--- a/pkg/gateway/adapters/resource_registry_test.go
+++ b/pkg/gateway/adapters/resource_registry_test.go
@@ -509,6 +509,70 @@ var _ = Describe("API Resource Registry (#1029)", func() {
 	})
 
 	// =========================================================================
+	// Scope Detection: IsNamespacedKind (#1371)
+	// =========================================================================
+	Context("IsNamespacedKind (#1371)", func() {
+		It("UT-GW-1371-001: returns true for namespaced kind (Deployment)", func() {
+			fd := newFakeDiscovery(standardResources())
+			registry, err := adapters.NewAPIResourceRegistry(fd)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(registry.IsNamespacedKind("Deployment")).To(BeTrue(),
+				"Deployment is namespaced — namespace required")
+		})
+
+		It("UT-GW-1371-002: returns false for cluster-scoped kind (Node)", func() {
+			fd := newFakeDiscovery(standardResources())
+			registry, err := adapters.NewAPIResourceRegistry(fd)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(registry.IsNamespacedKind("Node")).To(BeFalse(),
+				"Node is cluster-scoped — no namespace")
+		})
+
+		It("UT-GW-1371-003: returns false for cluster-scoped kind (Namespace)", func() {
+			fd := newFakeDiscovery(standardResources(), namespaceResource())
+			registry, err := adapters.NewAPIResourceRegistry(fd)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(registry.IsNamespacedKind("Namespace")).To(BeFalse(),
+				"Namespace resource is itself cluster-scoped")
+		})
+
+		It("UT-GW-1371-004: returns false for cluster-scoped kind (PersistentVolume)", func() {
+			pvResource := []*metav1.APIResourceList{
+				{
+					GroupVersion: "v1",
+					APIResources: []metav1.APIResource{
+						{Name: "persistentvolumes", SingularName: "persistentvolume", Kind: "PersistentVolume", Namespaced: false},
+					},
+				},
+			}
+			fd := newFakeDiscovery(standardResources(), pvResource)
+			registry, err := adapters.NewAPIResourceRegistry(fd)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(registry.IsNamespacedKind("PersistentVolume")).To(BeFalse(),
+				"PersistentVolume is cluster-scoped (PVCs are namespaced, PVs are not)")
+		})
+
+		It("UT-GW-1371-005: returns true for unknown kind (conservative default)", func() {
+			fd := newFakeDiscovery(standardResources())
+			registry, err := adapters.NewAPIResourceRegistry(fd)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(registry.IsNamespacedKind("UnknownKind")).To(BeTrue(),
+				"Unknown kind defaults to namespaced (conservative — avoids dropping namespace)")
+		})
+
+		It("UT-GW-1371-006: returns true with nil snapshot (graceful degradation)", func() {
+			nilRegistry := adapters.NewTestAPIResourceRegistryNilSnapshot()
+			Expect(nilRegistry.IsNamespacedKind("AnyKind")).To(BeTrue(),
+				"Nil snapshot returns true for graceful degradation before registry is ready")
+		})
+	})
+
+	// =========================================================================
 	// OpenShift CRD Discovery (supplement for Phase 1)
 	// =========================================================================
 	Context("OpenShift CRD Discovery", func() {

--- a/pkg/gateway/adapters/resource_registry_test.go
+++ b/pkg/gateway/adapters/resource_registry_test.go
@@ -54,7 +54,14 @@ func standardResources() []*metav1.APIResourceList {
 				{Name: "pods", SingularName: "pod", Kind: "Pod", Namespaced: true},
 				{Name: "nodes", SingularName: "node", Kind: "Node", Namespaced: false},
 				{Name: "services", SingularName: "service", Kind: "Service", Namespaced: true},
+				{Name: "persistentvolumes", SingularName: "persistentvolume", Kind: "PersistentVolume", Namespaced: false},
 				{Name: "persistentvolumeclaims", SingularName: "persistentvolumeclaim", Kind: "PersistentVolumeClaim", Namespaced: true},
+			},
+		},
+		{
+			GroupVersion: "rbac.authorization.k8s.io/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "clusterroles", SingularName: "clusterrole", Kind: "ClusterRole", Namespaced: false},
 			},
 		},
 		{
@@ -540,20 +547,23 @@ var _ = Describe("API Resource Registry (#1029)", func() {
 		})
 
 		It("UT-GW-1371-004: returns false for cluster-scoped kind (PersistentVolume)", func() {
-			pvResource := []*metav1.APIResourceList{
-				{
-					GroupVersion: "v1",
-					APIResources: []metav1.APIResource{
-						{Name: "persistentvolumes", SingularName: "persistentvolume", Kind: "PersistentVolume", Namespaced: false},
-					},
-				},
-			}
-			fd := newFakeDiscovery(standardResources(), pvResource)
-			registry, err := adapters.NewAPIResourceRegistry(fd)
-			Expect(err).ToNot(HaveOccurred())
-
+			registry := adapters.NewTestAPIResourceRegistry()
 			Expect(registry.IsNamespacedKind("PersistentVolume")).To(BeFalse(),
 				"PersistentVolume is cluster-scoped (PVCs are namespaced, PVs are not)")
+		})
+
+		It("UT-GW-1371-E01: returns false for cluster-scoped kind (ClusterRole)", func() {
+			registry := adapters.NewTestAPIResourceRegistry()
+			Expect(registry.IsNamespacedKind("ClusterRole")).To(BeFalse(),
+				"ClusterRole is cluster-scoped — RBAC roles at cluster level")
+		})
+
+		It("UT-GW-1371-E02: PersistentVolumeClaim remains namespaced alongside PersistentVolume", func() {
+			registry := adapters.NewTestAPIResourceRegistry()
+			Expect(registry.IsNamespacedKind("PersistentVolumeClaim")).To(BeTrue(),
+				"PVC is namespaced even though PV is cluster-scoped")
+			Expect(registry.IsNamespacedKind("PersistentVolume")).To(BeFalse(),
+				"PV is cluster-scoped")
 		})
 
 		It("UT-GW-1371-005: returns true for unknown kind (conservative default)", func() {

--- a/pkg/gateway/adapters/testing_exports.go
+++ b/pkg/gateway/adapters/testing_exports.go
@@ -17,6 +17,9 @@ limitations under the License.
 package adapters
 
 import (
+	"time"
+
+	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakediscovery "k8s.io/client-go/discovery/fake"
 	fakeclientset "k8s.io/client-go/kubernetes/fake"
@@ -76,6 +79,19 @@ func NewTestAPIResourceRegistry() *APIResourceRegistry {
 		panic("NewTestAPIResourceRegistry: " + err.Error())
 	}
 	return registry
+}
+
+// NewTestAPIResourceRegistryNilSnapshot creates an APIResourceRegistry with a
+// nil snapshot, simulating the state before discovery has completed. Used to
+// test graceful degradation of IsNamespacedKind and other snapshot-dependent
+// methods.
+func NewTestAPIResourceRegistryNilSnapshot() *APIResourceRegistry {
+	return &APIResourceRegistry{
+		cache:        make(map[string]existenceCacheEntry),
+		cacheTTL:     30 * time.Second,
+		maxCacheSize: DefaultMaxCacheSize,
+		logger:       logr.Discard(),
+	}
 }
 
 // NewTestAPIResourceRegistryWithNamespace creates an APIResourceRegistry that

--- a/pkg/gateway/adapters/testing_exports.go
+++ b/pkg/gateway/adapters/testing_exports.go
@@ -30,8 +30,9 @@ import (
 // of passing a nil registry to NewPrometheusAdapter.
 //
 // Registered resources: Deployment, StatefulSet, DaemonSet, ReplicaSet (apps/v1),
-// Pod, Node, Service, PersistentVolumeClaim (v1), Job, CronJob (batch/v1),
-// HorizontalPodAutoscaler (autoscaling/v2), PodDisruptionBudget (policy/v1).
+// Pod, Node, Service, PersistentVolume, PersistentVolumeClaim (v1),
+// Job, CronJob (batch/v1), HorizontalPodAutoscaler (autoscaling/v2),
+// PodDisruptionBudget (policy/v1), ClusterRole (rbac.authorization.k8s.io/v1).
 func NewTestAPIResourceRegistry() *APIResourceRegistry {
 	cs := fakeclientset.NewSimpleClientset()
 	fd := cs.Discovery().(*fakediscovery.FakeDiscovery)
@@ -51,7 +52,14 @@ func NewTestAPIResourceRegistry() *APIResourceRegistry {
 				{Name: "pods", SingularName: "pod", Kind: "Pod", Namespaced: true},
 				{Name: "nodes", SingularName: "node", Kind: "Node", Namespaced: false},
 				{Name: "services", SingularName: "service", Kind: "Service", Namespaced: true},
+				{Name: "persistentvolumes", SingularName: "persistentvolume", Kind: "PersistentVolume", Namespaced: false},
 				{Name: "persistentvolumeclaims", SingularName: "persistentvolumeclaim", Kind: "PersistentVolumeClaim", Namespaced: true},
+			},
+		},
+		{
+			GroupVersion: "rbac.authorization.k8s.io/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "clusterroles", SingularName: "clusterrole", Kind: "ClusterRole", Namespaced: false},
 			},
 		},
 		{
@@ -119,7 +127,14 @@ func NewTestAPIResourceRegistryWithNamespace() *APIResourceRegistry {
 				{Name: "nodes", SingularName: "node", Kind: "Node", Namespaced: false},
 				{Name: "services", SingularName: "service", Kind: "Service", Namespaced: true},
 				{Name: "namespaces", SingularName: "namespace", Kind: "Namespace", Namespaced: false},
+				{Name: "persistentvolumes", SingularName: "persistentvolume", Kind: "PersistentVolume", Namespaced: false},
 				{Name: "persistentvolumeclaims", SingularName: "persistentvolumeclaim", Kind: "PersistentVolumeClaim", Namespaced: true},
+			},
+		},
+		{
+			GroupVersion: "rbac.authorization.k8s.io/v1",
+			APIResources: []metav1.APIResource{
+				{Name: "clusterroles", SingularName: "clusterrole", Kind: "ClusterRole", Namespaced: false},
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

Fixes three open bugs and adds follow-up enhancements:

**Bug Fixes:**
- **#1462** — AF tool now validates and passes `kind`, `name`, and `spec_hash` (with `sha256:` prefix) to the DS remediation history endpoint, fixing the contract mismatch that caused 400 errors
- **#1451** — `bridgeEventsCollectSummary` returns an explicit exit reason (`inactivity_timeout`, `channel_closed`, `ctx_cancelled`) instead of always reporting `completed`, with default timeout increased from 60s to 180s
- **#1371** — Gateway `extractNamespace` returns `(namespace, found)` tuple; scope-aware resolution uses `APIResourceRegistry.IsNamespacedKind()` to assign empty namespace for cluster-scoped resources instead of defaulting to `"default"`

**Enhancements:**
- `spec_hash` format validation rejects values without `sha256:` prefix at the AF boundary (SI-10)
- `EventInvestigationTimeout` audit event emitted on inactivity timeout for SOC alerting (AU-3)
- `PersistentVolume` and `ClusterRole` added to test API resource registries for broader cluster-scoped coverage

**Infrastructure:**
- IEEE 829 test plans for all three issues (`docs/testing/{1462,1451,1371}/`)
- Refactored `buildMCPHandler`/`buildA2AHandler` to use dependency structs (eliminates 9-10 positional params anti-pattern)
- Stabilized flaky `UT-KA-1420-013` race condition
- Updated `.govulncheck-ignore.yaml` for false positive vulns

## Test plan

- [x] All new tests pass: `UT-AF-1462-*`, `UT-AF-1451-*`, `UT-GW-1371-*` (including enhancement tests `-E01`, `-E02`)
- [x] Full test suites green: `pkg/apifrontend/tools`, `pkg/apifrontend/audit`, `pkg/gateway/adapters`
- [x] `go build ./...` — clean
- [x] `go vet` — clean on affected packages
- [x] No new lint violations introduced

Closes #1462, closes #1451, closes #1371


Made with [Cursor](https://cursor.com)