### PR TITLE
feat(release): add Trivy scan, SBOM, Cosign signing, SLSA attestation (#1315, #1319)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,17 +1,21 @@
 name: Release
 
 # Triggered by version tag push (e.g., v1.0.0, v1.1.0-rc0)
-# Builds multi-arch images (amd64 + arm64) for all 12 services in parallel,
-# runs Helm smoke tests against the amd64 images, publishes Helm chart to
-# OCI registry, and creates a GitHub Release gated on smoke test success.
+# Builds multi-arch images (amd64 + arm64) for all 13 services in parallel,
+# runs Helm smoke tests against the amd64 images, scans all images for CVEs
+# (Trivy) and generates SBOMs (CycloneDX), signs images with Cosign (keyless),
+# generates SLSA build provenance, publishes Helm chart to OCI registry,
+# and creates a GitHub Release gated on smoke test + security scan success.
 # Pre-release tags (-rc*, -alpha*, -beta*) create a pre-release and skip :latest tagging.
 #
 # Prerequisites:
 #   - Quay.io robot account with Creator role in kubernaut-ai org
 #   - GitHub Actions secrets: QUAY_ROBOT_USERNAME, QUAY_ROBOT_TOKEN
 #
-# Authority: Issue #257 (sub-issue of #80), Issue #569
+# Authority: Issue #257 (sub-issue of #80), Issue #569, Issue #1315, Issue #1319
 # Business Requirement: BR-PLATFORM-RELEASE-001
+# FedRAMP Controls: SA-12 (Supply Chain), RA-5 (Vulnerability Scanning),
+#                   CM-14 (Signed Components), AU-3 (Audit Content)
 
 on:
   push:
@@ -19,6 +23,9 @@ on:
 
 permissions:
   contents: write
+  id-token: write       # Cosign keyless signing via GitHub OIDC
+  attestations: write   # SLSA build provenance attestation
+  packages: write       # OCI artifact push (Cosign signatures, attestations)
 
 env:
   IMAGE_REGISTRY: quay.io/kubernaut-ai
@@ -325,6 +332,99 @@ jobs:
           podman push "${IMAGE}"
 
   # ========================================
+  # STAGE 1d: SECURITY SCAN (amd64)
+  # Runs Trivy CVE scan and generates CycloneDX SBOM for each amd64 image.
+  # Gates the GitHub Release — any CRITICAL/HIGH unfixed CVE blocks release.
+  # Authority: Issue #1315 | FedRAMP RA-5, SA-12
+  # ========================================
+
+  security-scan-amd64:
+    name: "Security Scan ${{ matrix.service }} (amd64)"
+    needs: [prepare, build-amd64]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - gateway
+          - signalprocessing
+          - aianalysis
+          - authwebhook
+          - remediationorchestrator
+          - workflowexecution
+          - notification
+          - datastorage
+          - effectivenessmonitor
+          - kubernautagent
+          - apifrontend
+          - must-gather
+          - db-migrate
+    steps:
+      - name: Scan for CVEs (Trivy)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE_REGISTRY }}/${{ matrix.service }}:${{ needs.prepare.outputs.version }}-amd64
+          format: table
+          exit-code: 1
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
+      - name: Generate SBOM (CycloneDX)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          image: ${{ env.IMAGE_REGISTRY }}/${{ matrix.service }}:${{ needs.prepare.outputs.version }}-amd64
+          format: cyclonedx-json
+          output-file: sbom-${{ matrix.service }}-amd64.cdx.json
+          artifact-name: sbom-${{ matrix.service }}-amd64
+
+  # ========================================
+  # STAGE 1e: SECURITY SCAN (arm64)
+  # Same as 1d but for arm64 images. Depends on both arm64 build stages.
+  # Authority: Issue #1315 | FedRAMP RA-5, SA-12
+  # ========================================
+
+  security-scan-arm64:
+    name: "Security Scan ${{ matrix.service }} (arm64)"
+    needs: [prepare, build-arm64, build-arm64-qemu]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - gateway
+          - signalprocessing
+          - aianalysis
+          - authwebhook
+          - remediationorchestrator
+          - workflowexecution
+          - notification
+          - datastorage
+          - effectivenessmonitor
+          - kubernautagent
+          - apifrontend
+          - must-gather
+          - db-migrate
+    steps:
+      - name: Scan for CVEs (Trivy)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.IMAGE_REGISTRY }}/${{ matrix.service }}:${{ needs.prepare.outputs.version }}-arm64
+          format: table
+          exit-code: 1
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
+      - name: Generate SBOM (CycloneDX)
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          image: ${{ env.IMAGE_REGISTRY }}/${{ matrix.service }}:${{ needs.prepare.outputs.version }}-arm64
+          format: cyclonedx-json
+          output-file: sbom-${{ matrix.service }}-arm64.cdx.json
+          artifact-name: sbom-${{ matrix.service }}-arm64
+
+  # ========================================
   # STAGE 2: HELM SMOKE TESTS (Issue #569)
   # Depends ONLY on build-amd64. Runs as soon as amd64 images are in Quay.
   # arm64 builds continue in parallel and do NOT block this stage.
@@ -487,22 +587,89 @@ jobs:
           done
           echo "All images tagged as latest"
 
-      - name: Scan release images for CVEs (Trivy)
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: ${{ env.IMAGE_REGISTRY }}/kubernautagent:${{ needs.prepare.outputs.version }}-amd64
-          format: table
-          exit-code: 1
-          severity: CRITICAL,HIGH
-          ignore-unfixed: true
+  # ========================================
+  # STAGE 3b: COSIGN SIGNING & SLSA ATTESTATION
+  # Signs all arch-tagged images and manifest lists with Cosign (keyless),
+  # then generates SLSA v1.0 build provenance for each manifest list.
+  # Authority: Issue #1315, #1319 | FedRAMP CM-14, AU-3, SA-12
+  # ========================================
 
-      - name: Generate SBOM (CycloneDX)
-        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+  sign-and-attest:
+    name: "Sign & Attest ${{ matrix.service }}"
+    needs: [prepare, create-manifests]
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        service:
+          - gateway
+          - signalprocessing
+          - aianalysis
+          - authwebhook
+          - remediationorchestrator
+          - workflowexecution
+          - notification
+          - datastorage
+          - effectivenessmonitor
+          - kubernautagent
+          - apifrontend
+          - must-gather
+          - db-migrate
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.8.2
+
+      - name: Login to Quay.io (Cosign)
+        run: |
+          cosign login -u "${{ secrets.QUAY_ROBOT_USERNAME }}" \
+                       -p "${{ secrets.QUAY_ROBOT_TOKEN }}" \
+                       quay.io
+
+      - name: Resolve image digests
+        id: digests
+        run: |
+          VERSION="${{ needs.prepare.outputs.version }}"
+          SVC="${{ matrix.service }}"
+
+          AMD64_DIGEST=$(skopeo inspect --format '{{.Digest}}' "docker://${IMAGE_REGISTRY}/${SVC}:${VERSION}-amd64")
+          ARM64_DIGEST=$(skopeo inspect --format '{{.Digest}}' "docker://${IMAGE_REGISTRY}/${SVC}:${VERSION}-arm64")
+          MANIFEST_DIGEST=$(skopeo inspect --format '{{.Digest}}' "docker://${IMAGE_REGISTRY}/${SVC}:${VERSION}")
+
+          echo "amd64=${AMD64_DIGEST}" >> $GITHUB_OUTPUT
+          echo "arm64=${ARM64_DIGEST}" >> $GITHUB_OUTPUT
+          echo "manifest=${MANIFEST_DIGEST}" >> $GITHUB_OUTPUT
+
+          echo "Digests for ${SVC}:"
+          echo "  amd64:    ${AMD64_DIGEST}"
+          echo "  arm64:    ${ARM64_DIGEST}"
+          echo "  manifest: ${MANIFEST_DIGEST}"
+
+      - name: Cosign sign images (keyless)
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          SVC: ${{ matrix.service }}
+        run: |
+          echo "Signing ${{ matrix.service }} images (keyless, GitHub OIDC)..."
+
+          cosign sign --yes "${IMAGE_REGISTRY}/${SVC}@${{ steps.digests.outputs.amd64 }}"
+          echo "  Signed ${SVC} amd64"
+
+          cosign sign --yes "${IMAGE_REGISTRY}/${SVC}@${{ steps.digests.outputs.arm64 }}"
+          echo "  Signed ${SVC} arm64"
+
+          cosign sign --yes "${IMAGE_REGISTRY}/${SVC}@${{ steps.digests.outputs.manifest }}"
+          echo "  Signed ${SVC} manifest list"
+
+      - name: SLSA build provenance attestation
+        uses: actions/attest-build-provenance@v2
         with:
-          image: ${{ env.IMAGE_REGISTRY }}/kubernautagent:${{ needs.prepare.outputs.version }}-amd64
-          format: cyclonedx-json
-          output-file: sbom-kubernautagent.cdx.json
-          artifact-name: sbom-kubernautagent
+          subject-name: ${{ env.IMAGE_REGISTRY }}/${{ matrix.service }}
+          subject-digest: ${{ steps.digests.outputs.manifest }}
+          push-to-registry: true
 
   # ========================================
   # STAGE 4: HELM CHART PUBLISH
@@ -547,21 +714,32 @@ jobs:
           echo "Helm chart published: oci://quay.io/kubernaut-ai/charts/kubernaut:${CHART_VERSION}"
 
   # ========================================
-  # STAGE 5: GITHUB RELEASE
+  # STAGE 6: GITHUB RELEASE
   # Creates a GitHub Release with auto-generated release notes.
-  # Gated on smoke tests, manifests, AND Helm publish (Issue #569).
+  # Gated on smoke tests, manifests, security scans, signing,
+  # AND Helm publish.
+  # Downloads SBOMs from security scan jobs and attaches them
+  # to the release for customer consumption.
+  # Authority: Issue #569, #1315 | FedRAMP SA-12
   # ========================================
 
   release:
     name: Create GitHub Release
-    needs: [prepare, helm-smoke-test, create-manifests, helm-publish]
+    needs: [prepare, helm-smoke-test, create-manifests, helm-publish, security-scan-amd64, security-scan-arm64, sign-and-attest]
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
           fetch-depth: 0
+
+      - name: Download all SBOM artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: sbom-*
+          path: sboms/
+          merge-multiple: true
 
       - name: Create GitHub Release
         env:
@@ -595,3 +773,19 @@ jobs:
           echo ""
           echo "Install with:"
           echo "  helm install kubernaut oci://quay.io/kubernaut-ai/charts/kubernaut --version ${VERSION}"
+
+      - name: Attach SBOMs to release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          echo "Attaching SBOMs to release ${TAG}..."
+          SBOM_COUNT=0
+          for sbom in sboms/*.cdx.json; do
+            if [ -f "$sbom" ]; then
+              echo "  Uploading $(basename "$sbom")..."
+              gh release upload "${TAG}" "$sbom" --clobber
+              SBOM_COUNT=$((SBOM_COUNT + 1))
+            fi
+          done
+          echo "Attached ${SBOM_COUNT} SBOMs to release ${TAG}"


### PR DESCRIPTION
## Summary

Implements #1315 and #1319 to make release images production-ready with comprehensive supply chain security. Also delivers SLSA Build L2 provenance as a stepping stone toward #1109 (SLSA L3, targeted v1.6.0).

- **Trivy CVE scanning**: All 13 services scanned on both amd64 and arm64 (26 scans total). CRITICAL/HIGH unfixed CVEs block the release.
- **CycloneDX SBOM generation**: Machine-readable software bill of materials for every image, attached to the GitHub Release.
- **Cosign keyless signing**: All 39 images signed (13 services x 3 images: amd64, arm64, manifest list) using GitHub OIDC identity via Sigstore.
- **SLSA Build L2 provenance**: `actions/attest-build-provenance@v2` generates SLSA v1.0 provenance for each manifest list, pushed to Quay.io registry. Upgrade to SLSA L3 (non-falsifiable, isolated builder) tracked in #1109.

### New jobs added to release pipeline

| Job | Matrix | Purpose |
|-----|--------|---------|
| `security-scan-amd64` | 13 services | Trivy scan + SBOM (amd64) |
| `security-scan-arm64` | 13 services | Trivy scan + SBOM (arm64) |
| `sign-and-attest` | 13 services | Cosign sign + SLSA L2 attest |

### Pipeline DAG

```
prepare
 ├─ build-amd64 (13) ──┬─ security-scan-amd64 (13) ────────────────┐
 │                      ├─ helm-smoke-test ─┬─ create-manifests ──┐ │
 ├─ build-arm64 (11) ──┤                   │                     │ │
 ├─ build-arm64-qemu (2)─┬─ security-scan-arm64 (13) ────────────┤ │
 │                      │ ├─ helm-publish                         │ │
 │                      │ └─ sign-and-attest (13) ───────────────>│ │
 └──────────────────────┴────────────────────────────────────────> release
```

### FedRAMP controls addressed

- **SA-12** (Supply Chain Protection): SBOM, Cosign, SLSA provenance
- **RA-5** (Vulnerability Scanning): Trivy CRITICAL/HIGH gate
- **CM-14** (Signed Components): Cosign keyless signatures
- **AU-3** (Audit Content): Rekor transparency log entries

### Compliance coverage

| Framework | Requirement | Satisfied by |
|-----------|-------------|-------------|
| CISA Attestation Form (EO 14028) | Provenance for code + 3rd-party components | SLSA L2 + SBOM |
| FedRAMP SA-12 | Supply chain protection | Cosign + SLSA L2 |
| NIST SSDF PS.3.1/PS.3.2 | Archive releases, share provenance | SLSA L2 + SBOM |
| EU CRA (2027 enforcement) | Provenance + SBOM | SLSA L2 + SBOM (L3 in v1.6.0) |

### Spike validation

Cosign keyless signing and SLSA attestation against Quay.io were validated in [spike run #28264631299](https://github.com/jordigilh/kubernaut/actions/runs/28264631299) before implementation.

## Test plan

- [x] YAML syntax validated locally (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Job dependency graph verified programmatically
- [ ] Trigger a test release tag to validate end-to-end pipeline
- [ ] Verify SBOMs appear as GitHub Release assets
- [ ] Verify `cosign verify` succeeds against signed images
- [ ] Verify SLSA attestation appears in Quay.io OCI artifacts

Closes #1315
Closes #1319