### PR TITLE
chore: add workspace-level MCP config for project isolation

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,20 @@
+{
+  "mcpServers": {
+    "hindsight-docs": {
+      "type": "http",
+      "url": "http://localhost:8888/mcp/kubernaut-docs/"
+    },
+    "hindsight-issues": {
+      "type": "http",
+      "url": "http://localhost:8888/mcp/kubernaut-issues/"
+    },
+    "cocoindex-code": {
+      "command": "/Users/jgil/.hindsight/venv/bin/python3",
+      "args": ["/Users/jgil/.hindsight/cocoindex-search.py"],
+      "type": "stdio",
+      "env": {
+        "COCOINDEX_PG_URL": "postgresql://hindsight:hindsight@localhost:5432/hindsight"
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `.cursor/mcp.json` with kubernaut-specific MCP servers (hindsight-docs, hindsight-issues, cocoindex-code)
- These servers will be moved out of the global `~/.cursor/mcp.json` to enable project isolation
- When opening this workspace, Cursor merges the workspace-level config with the global one
- Other projects (e.g., DCM) will have their own workspace-level configs pointing to their own banks

## Test plan

- [ ] Verify MCP servers connect correctly when opening this workspace
- [ ] Verify hindsight-docs, hindsight-issues, cocoindex-code all appear in Cursor MCP settings

Made with [Cursor](https://cursor.com)