### PR TITLE
fix(ci): increase lint timeouts to prevent CI failures

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -115,7 +115,7 @@ jobs:
     needs: [detect-changes]
     if: needs.detect-changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v7

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,7 @@
 version: "2"
 
 run:
-  timeout: 5m
+  timeout: 10m
   tests: true
 
 linters:


### PR DESCRIPTION
## Summary
- Bumps golangci-lint `run.timeout` from 5m to 10m and the CI `lint-go` job `timeout-minutes` from 8 to 15
- The last successful lint run took 5m03s, right at the edge of the previous 5m tool timeout — the growing codebase needs more headroom

## Test plan
- [ ] Verify the `Lint (Go Services)` job passes on this PR's CI run

Made with [Cursor](https://cursor.com)