### PR TITLE
GA readiness: close remaining audit gaps (Issue #1505)

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -316,6 +316,7 @@ jobs:
     permissions:
       contents: read
       packages: write  # Required for ghcr.io push
+      id-token: write  # Required for Cosign keyless signing (GitHub OIDC)
     env:
       IMAGE_REGISTRY: ghcr.io/${{ github.repository_owner }}/kubernaut
     outputs:
@@ -389,6 +390,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.8.2
+
       - name: Generate image tag
         id: tag
         run: |
@@ -447,6 +451,20 @@ jobs:
           docker push "${IMAGE}"
           echo "✅ Image pushed successfully!"
 
+      - name: Cosign sign image (keyless)
+        run: |
+          IMAGE="${IMAGE_REGISTRY}/${{ matrix.service }}:${{ steps.image-ref.outputs.full_tag }}"
+          echo "Signing ${IMAGE} (keyless, GitHub OIDC)..."
+          cosign sign --yes "${IMAGE}"
+
+      - name: Verify image signature (self-check)
+        run: |
+          IMAGE="${IMAGE_REGISTRY}/${{ matrix.service }}:${{ steps.image-ref.outputs.full_tag }}"
+          cosign verify \
+            --certificate-identity-regexp "^https://github.com/${{ github.repository }}/\.github/workflows/ci-pipeline\.yml@.*$" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "${IMAGE}"
+
       - name: Scan image for CVEs (Trivy)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -480,6 +498,7 @@ jobs:
     permissions:
       contents: read
       packages: write  # Required for ghcr.io push
+      id-token: write  # Required for Cosign keyless signing (GitHub OIDC)
     outputs:
       tag: ${{ steps.tag.outputs.tag }}
     strategy:
@@ -520,6 +539,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.8.2
+
       - name: Generate image tag
         id: tag
         run: |
@@ -550,6 +572,20 @@ jobs:
           docker push ${IMAGE_NAME}:${IMAGE_TAG}
           
           echo "✅ Image pushed successfully!"
+
+      - name: Cosign sign image (keyless)
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/kubernaut/${{ matrix.image_name }}:${{ steps.tag.outputs.tag }}"
+          echo "Signing ${IMAGE} (keyless, GitHub OIDC)..."
+          cosign sign --yes "${IMAGE}"
+
+      - name: Verify image signature (self-check)
+        run: |
+          IMAGE="ghcr.io/${{ github.repository_owner }}/kubernaut/${{ matrix.image_name }}:${{ steps.tag.outputs.tag }}"
+          cosign verify \
+            --certificate-identity-regexp "^https://github.com/${{ github.repository }}/\.github/workflows/ci-pipeline\.yml@.*$" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "${IMAGE}"
 
       - name: Scan image for CVEs (trivy)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
@@ -585,6 +621,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write  # Required for Cosign keyless signing (GitHub OIDC)
     steps:
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v4
@@ -592,6 +629,9 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install Cosign
+        uses: sigstore/cosign-installer@v3.8.2
 
       - name: Create and push multi-arch manifests
         env:
@@ -609,10 +649,19 @@ jobs:
 
             docker manifest push "${BASE}:${IMAGE_TAG}"
             echo "  pushed ${svc}"
+
+            echo "Signing manifest list ${BASE}:${IMAGE_TAG} (keyless, GitHub OIDC)..."
+            cosign sign --yes "${BASE}:${IMAGE_TAG}"
+
+            cosign verify \
+              --certificate-identity-regexp "^https://github.com/${{ github.repository }}/\.github/workflows/ci-pipeline\.yml@.*$" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              "${BASE}:${IMAGE_TAG}"
+            echo "  signed + verified ${svc} manifest list"
           done
 
           echo ""
-          echo "All 12 multi-arch manifests created and pushed."
+          echo "All 12 multi-arch manifests created, pushed, and signed."
 
   # ========================================
   # STAGE 3: INTEGRATION TESTS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -598,7 +598,7 @@ jobs:
 
   sign-and-attest:
     name: "Sign & Attest ${{ matrix.service }}"
-    needs: [prepare, create-manifests]
+    needs: [prepare, create-manifests, security-scan-amd64, security-scan-arm64]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     strategy:
@@ -672,6 +672,29 @@ jobs:
           subject-name: ${{ env.IMAGE_REGISTRY }}/${{ matrix.service }}
           subject-digest: ${{ steps.digests.outputs.manifest }}
           push-to-registry: true
+
+      - name: Download SBOM artifacts
+        uses: actions/download-artifact@v8
+        with:
+          pattern: sbom-${{ matrix.service }}-*
+          path: sboms/
+          merge-multiple: true
+
+      - name: Cosign attest SBOM (amd64)
+        run: |
+          cosign attest --yes \
+            --predicate "sboms/sbom-${{ matrix.service }}-amd64.cdx.json" \
+            --type cyclonedx \
+            "${IMAGE_REGISTRY}/${{ matrix.service }}@${{ steps.digests.outputs.amd64 }}"
+          echo "  Attested ${{ matrix.service }} amd64 SBOM"
+
+      - name: Cosign attest SBOM (arm64)
+        run: |
+          cosign attest --yes \
+            --predicate "sboms/sbom-${{ matrix.service }}-arm64.cdx.json" \
+            --type cyclonedx \
+            "${IMAGE_REGISTRY}/${{ matrix.service }}@${{ steps.digests.outputs.arm64 }}"
+          echo "  Attested ${{ matrix.service }} arm64 SBOM"
 
   # ========================================
   # STAGE 4: HELM CHART PUBLISH

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,10 +70,10 @@ jobs:
   # Helm smoke tests depend on this stage completing (Issue #569).
   #
   # Services (14):
-  #   Go (12): gateway, signalprocessing, aianalysis, authwebhook,
+  #   Go (13): gateway, signalprocessing, aianalysis, authwebhook,
   #            remediationorchestrator, workflowexecution, notification,
   #            datastorage, effectivenessmonitor, db-migrate, kubernautagent,
-  #            apifrontend
+  #            apifrontend, fleetmetadatacache
   #   Bash (1): must-gather
   #
   # Strategy:
@@ -360,6 +360,7 @@ jobs:
           - effectivenessmonitor
           - kubernautagent
           - apifrontend
+          - fleetmetadatacache
           - must-gather
           - db-migrate
     steps:
@@ -406,6 +407,7 @@ jobs:
           - effectivenessmonitor
           - kubernautagent
           - apifrontend
+          - fleetmetadatacache
           - must-gather
           - db-migrate
     steps:
@@ -578,7 +580,7 @@ jobs:
           for svc in datastorage gateway aianalysis authwebhook notification \
                      remediationorchestrator signalprocessing workflowexecution \
                      effectivenessmonitor kubernautagent apifrontend \
-                     must-gather db-migrate; do
+                     fleetmetadatacache must-gather db-migrate; do
             echo "  Tagging $svc:latest..."
             podman manifest rm ${IMAGE_REGISTRY}/$svc:latest 2>/dev/null || true
             podman manifest create ${IMAGE_REGISTRY}/$svc:latest \
@@ -616,6 +618,7 @@ jobs:
           - effectivenessmonitor
           - kubernautagent
           - apifrontend
+          - fleetmetadatacache
           - must-gather
           - db-migrate
     steps:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -40,6 +40,59 @@ Kubernaut operates with elevated Kubernetes RBAC permissions to perform remediat
 - Restrict access to the DataStorage and HAPI APIs
 - Rotate LLM provider credentials regularly
 
+## Supply Chain Security
+
+All container images built by Kubernaut's CI and Release pipelines are signed keylessly with [Cosign](https://github.com/sigstore/cosign) using GitHub Actions OIDC as the signing identity (no long-lived private keys). SBOMs (CycloneDX format) are generated for every image and, for Release images, cryptographically bound to the image digest via Cosign attestation.
+
+| Pipeline | Workflow | Registry | Lifecycle |
+|---|---|---|---|
+| CI | `.github/workflows/ci-pipeline.yml` | `ghcr.io/jordigilh/kubernaut/*` | Ephemeral (14-day retention), used by integration/E2E tests |
+| Release | `.github/workflows/release.yml` | `quay.io/kubernaut-ai/*` | Production, tagged `v*` releases |
+
+### Verifying image signatures
+
+Verify a CI image (signed on every push/PR build):
+
+```bash
+cosign verify \
+  --certificate-identity-regexp "^https://github.com/jordigilh/kubernaut/\.github/workflows/ci-pipeline\.yml@.*$" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/jordigilh/kubernaut/<service>:<tag>
+```
+
+Verify a Release image (signed on `v*` tag push):
+
+```bash
+cosign verify \
+  --certificate-identity-regexp "^https://github.com/jordigilh/kubernaut/\.github/workflows/release\.yml@.*$" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  quay.io/kubernaut-ai/<service>:<version>
+```
+
+### Verifying SBOM provenance
+
+Release images carry their CycloneDX SBOM as a Cosign attestation, bound to the image digest:
+
+```bash
+cosign verify-attestation \
+  --type cyclonedx \
+  --certificate-identity-regexp "^https://github.com/jordigilh/kubernaut/\.github/workflows/release\.yml@.*$" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  quay.io/kubernaut-ai/<service>:<version>
+```
+
+### Verifying SLSA build provenance
+
+Release images also carry SLSA v1.0 build provenance:
+
+```bash
+cosign verify-attestation \
+  --type slsaprovenance \
+  --certificate-identity-regexp "^https://github.com/jordigilh/kubernaut/\.github/workflows/release\.yml@.*$" \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  quay.io/kubernaut-ai/<service>:<version>
+```
+
 ## Disclosure Policy
 
 We follow coordinated disclosure. We ask that you give us reasonable time to address the vulnerability before public disclosure.

--- a/api/openapi/data-storage-v1.yaml
+++ b/api/openapi/data-storage-v1.yaml
@@ -2597,7 +2597,7 @@ components:
           type: string
           minLength: 1
           maxLength: 50
-          enum: [gateway, notification, analysis, aiagent, signalprocessing, workflow, workflowexecution, orchestration, approval, effectiveness, actiontype, apifrontend]
+          enum: [gateway, notification, analysis, aiagent, signalprocessing, workflow, workflowexecution, orchestration, approval, effectiveness, actiontype, apifrontend, security]
           description: |
             Domain-level event category (ADR-034 v1.8, Issue #306).
             Per convention: event_category identifies the business domain of the event.
@@ -2615,6 +2615,7 @@ components:
             - effectiveness: Effectiveness assessment and monitoring events
             - actiontype: ActionType taxonomy lifecycle events (Issue #300)
             - apifrontend: API Frontend service — triage, session, delegation, and user decision events (Issue #1021)
+            - security: Cross-cutting security control events at the HTTP layer (e.g. rate-limit denials) not tied to a single business domain (GAP-09, Issue #1505)
           example: gateway
         event_action:
           type: string
@@ -2731,6 +2732,7 @@ components:
             - $ref: '#/components/schemas/AIAgentInteractiveStartedPayload'
             - $ref: '#/components/schemas/AIAgentInteractiveCompletedPayload'
             - $ref: '#/components/schemas/AIAgentInteractiveK8sCallPayload'
+            - $ref: '#/components/schemas/AIAgentSecretAccessedPayload'
             - $ref: '#/components/schemas/AIAgentSessionObservedPayload'
             - $ref: '#/components/schemas/AIAgentSessionAccessDeniedPayload'
             - $ref: '#/components/schemas/AIAgentInvestigationCancelledPayload'
@@ -2781,6 +2783,9 @@ components:
             - $ref: '#/components/schemas/ApifrontendSeverityTriageFailedPayload'
             - $ref: '#/components/schemas/ApifrontendConfigReloadedPayload'
             - $ref: '#/components/schemas/ApifrontendConfigRejectedPayload'
+            - $ref: '#/components/schemas/DatastorageRatelimitDeniedPayload'
+            - $ref: '#/components/schemas/GatewayConfigReloadedPayload'
+            - $ref: '#/components/schemas/GatewayConfigRejectedPayload'
           discriminator:
             propertyName: event_type
             mapping:
@@ -2862,6 +2867,7 @@ components:
               'aiagent.interactive.started': '#/components/schemas/AIAgentInteractiveStartedPayload'
               'aiagent.interactive.completed': '#/components/schemas/AIAgentInteractiveCompletedPayload'
               'aiagent.interactive.k8s_call': '#/components/schemas/AIAgentInteractiveK8sCallPayload'
+              'aiagent.secret.accessed': '#/components/schemas/AIAgentSecretAccessedPayload'
               'aiagent.session.observed': '#/components/schemas/AIAgentSessionObservedPayload'
               'aiagent.session.access_denied': '#/components/schemas/AIAgentSessionAccessDeniedPayload'
               'aiagent.investigation.cancelled': '#/components/schemas/AIAgentInvestigationCancelledPayload'
@@ -2872,6 +2878,9 @@ components:
               'aiagent.ratelimit.denied': '#/components/schemas/AIAgentRatelimitDeniedPayload'
               'aiagent.auth.failure': '#/components/schemas/AIAgentAuthFailurePayload'
               'aiagent.auth.denied': '#/components/schemas/AIAgentAuthDeniedPayload'
+              'datastorage.ratelimit.denied': '#/components/schemas/DatastorageRatelimitDeniedPayload'
+              'gateway.config.reloaded': '#/components/schemas/GatewayConfigReloadedPayload'
+              'gateway.config.rejected': '#/components/schemas/GatewayConfigRejectedPayload'
               'effectiveness.health.assessed': '#/components/schemas/EffectivenessAssessmentAuditPayload'
               'effectiveness.hash.computed': '#/components/schemas/EffectivenessAssessmentAuditPayload'
               'effectiveness.alert.assessed': '#/components/schemas/EffectivenessAssessmentAuditPayload'
@@ -6219,6 +6228,35 @@ components:
           type: string
           description: Correlation ID linking to the parent remediation request
 
+    AIAgentSecretAccessedPayload:
+      type: object
+      required: [event_type, event_id, verb]
+      description: KubernautAgent Secret access audit payload (aiagent.secret.accessed) — detective control emitted for every K8s Secret Get/List performed by the autonomous investigator's resource resolver, regardless of outcome (GAP-13, Issue #1505). KubernautAgent intentionally retains broad read RBAC on Secrets for investigation completeness; this event is the compensating detective control rather than a narrowed RBAC grant.
+      properties:
+        event_type:
+          type: string
+          enum: ['aiagent.secret.accessed']
+          description: Event type for discriminator (matches parent event_type)
+        event_id:
+          type: string
+          description: Unique event identifier
+        verb:
+          type: string
+          enum: ['get', 'list']
+          description: K8s API verb performed against the Secret resource
+        namespace:
+          type: string
+          description: K8s namespace of the target Secret (empty for a cluster-wide list)
+        secret_name:
+          type: string
+          description: Name of the specific Secret (empty for list operations)
+        tool_name:
+          type: string
+          description: Name of the KubernautAgent tool that triggered the access (e.g. kubectl_get_by_name)
+        outcome_detail:
+          type: string
+          description: Error message when the access failed (e.g. not found, forbidden); empty on success
+
     AIAgentSessionObservedPayload:
       type: object
       required: [event_type, event_id, session_id]
@@ -7500,6 +7538,60 @@ components:
         event_type:
           type: string
           enum: ['aiagent.ratelimit.denied']
+          description: Event type for discriminator (matches parent event_type)
+        event_id:
+          type: string
+          description: Unique event identifier
+        source_ip:
+          type: string
+          description: Source IP address of the rate-limited request
+        path:
+          type: string
+          description: HTTP request path
+        method:
+          type: string
+          description: HTTP request method
+
+    GatewayConfigReloadedPayload:
+      type: object
+      required: [event_type, component]
+      description: Gateway config reloaded event payload (gateway.config.reloaded) — hot-reload configuration accepted (SOC2 CC7.2, GAP-11 Issue #1505)
+      properties:
+        event_type:
+          type: string
+          enum: ['gateway.config.reloaded']
+          description: Event type for discriminator (matches parent event_type)
+        component:
+          type: string
+          description: Hot-reloadable component that was reloaded (e.g. log_level, ca_cert)
+        config_version:
+          type: string
+          description: New configuration version or hash
+
+    GatewayConfigRejectedPayload:
+      type: object
+      required: [event_type, component, rejection_reason]
+      description: Gateway config rejected event payload (gateway.config.rejected) — hot-reload configuration rejected, previous configuration kept (SOC2 CC7.2, GAP-11 Issue #1505)
+      properties:
+        event_type:
+          type: string
+          enum: ['gateway.config.rejected']
+          description: Event type for discriminator (matches parent event_type)
+        component:
+          type: string
+          description: Hot-reloadable component whose reload was rejected (e.g. log_level, ca_cert)
+        rejection_reason:
+          type: string
+          description: Reason configuration was rejected
+
+    DatastorageRatelimitDeniedPayload:
+      type: object
+      required: [event_type, event_id]
+      description: Data Storage rate limit denied event payload (datastorage.ratelimit.denied) — request rejected by per-IP rate limiter on the DS HTTP API (FedRAMP AU-12, GAP-09 Issue #1505)
+      properties:
+        event_type:
+          type: string
+          enum: ['datastorage.ratelimit.denied']
           description: Event type for discriminator (matches parent event_type)
         event_id:
           type: string

--- a/charts/kubernaut/README.md
+++ b/charts/kubernaut/README.md
@@ -193,6 +193,35 @@ kubectl create secret generic my-valkey-credentials \
   -n kubernaut-system
 ```
 
+### Optional: Keyed Audit Hash Chain (GAP-05)
+
+DataStorage tamper-evidences audit events with a hash chain. By default this
+uses a plain (unkeyed) SHA256 hash — sufficient to detect accidental
+corruption, but recomputable by anyone with database read/write access, so an
+attacker with DB privileges could tamper with a row and recompute a
+self-consistent chain.
+
+Enabling `datastorage.config.auditHashKey` switches **newly written** events to
+a keyed HMAC-SHA256 hash chain, using a secret key stored outside the database
+(a Kubernetes Secret). Forging a valid hash without that key is computationally
+infeasible. This is opt-in and backward compatible: existing events keep
+verifying under the legacy algorithm, and disabling it later simply reverts new
+writes to the unkeyed algorithm.
+
+```bash
+# Pre-create the HMAC key Secret (chart does not auto-generate it, same as
+# the PostgreSQL/Valkey secrets above)
+HMAC_KEY=$(openssl rand -base64 32)
+kubectl create secret generic datastorage-audit-hmac-key \
+  --from-literal=audit-hmac-key.yaml="$(printf 'hmacKey: %s' "$HMAC_KEY")" \
+  -n kubernaut-system
+
+helm upgrade kubernaut oci://quay.io/kubernaut-ai/charts/kubernaut \
+  --namespace kubernaut-system \
+  --reuse-values \
+  --set datastorage.config.auditHashKey.enabled=true
+```
+
 ```yaml
 postgresql:
   enabled: false
@@ -205,6 +234,50 @@ valkey:
   host: "redis.example.com"
   existingSecret: my-valkey-credentials
 ```
+
+### Optional: Distributed JWT Replay Cache (GAP-08)
+
+APIFrontend detects replayed JWTs via their `jti` claim. By default this uses
+an in-memory cache that is per-process: in a multi-replica deployment, a token
+replayed against a different replica than the one that first observed it is
+not detected.
+
+Enabling `apifrontend.config.auth.replayCache` shares replay state across all
+APIFrontend replicas via the cluster's Valkey instance (the same instance and
+Secret already used by DataStorage) — closing this HA gap. If Valkey is
+unreachable at runtime, APIFrontend falls back to the in-memory cache and logs
+the degradation rather than disabling replay protection outright.
+
+```bash
+helm upgrade kubernaut oci://quay.io/kubernaut-ai/charts/kubernaut \
+  --namespace kubernaut-system \
+  --reuse-values \
+  --set apifrontend.config.auth.replayCache.enabled=true
+```
+
+No additional Secret is required beyond the existing Valkey credentials
+(`valkey.existingSecret` / the `valkey-secret` created above), since the
+replay cache uses that same shared instance and Secret.
+
+### Optional: Data Storage Per-IP Rate Limiting (GAP-09)
+
+The Data Storage HTTP API does not rate limit requests by default — existing
+deployments may already enforce this at an external ingress/proxy layer.
+Enabling `datastorage.config.server.rateLimit` adds an in-process, per-IP
+token-bucket limiter (SC-5 DoS protection) as a defense-in-depth backstop.
+Denied requests are self-audited (`datastorage.ratelimit.denied`, FedRAMP
+AU-12).
+
+```bash
+helm upgrade kubernaut oci://quay.io/kubernaut-ai/charts/kubernaut \
+  --namespace kubernaut-system \
+  --reuse-values \
+  --set datastorage.config.server.rateLimit.enabled=true
+```
+
+Tune `datastorage.config.server.rateLimit.requestsPerSecond` (default `50`)
+and `.burst` (default `100`) to match expected legitimate traffic (e.g.
+KubernautAgent/APIFrontend polling volume) before enabling in production.
 
 ### OpenShift (OCP)
 
@@ -338,6 +411,13 @@ All LLM configuration is now part of the main `kubernaut-agent-config` ConfigMap
 | `valkey.enabled` | Deploy in-chart Valkey | `true` |
 | `valkey.existingSecret` | Pre-created Secret name (empty = expect `valkey-secret`) | `""` |
 | `valkey.host` | External host (when `enabled=false`) | `""` |
+| `datastorage.config.auditHashKey.enabled` | Enable keyed HMAC-SHA256 audit hash chain (GAP-05); see [Optional: Keyed Audit Hash Chain](#optional-keyed-audit-hash-chain-gap-05) | `false` |
+| `apifrontend.config.auth.replayCache.enabled` | Enable distributed (Valkey-backed) JWT replay cache (GAP-08); see [Optional: Distributed JWT Replay Cache](#optional-distributed-jwt-replay-cache-gap-08) | `false` |
+| `apifrontend.config.auth.replayCache.redisDB` | Valkey logical DB index used for replay cache keys | `1` |
+| `datastorage.config.server.rateLimit.enabled` | Enable per-IP rate limiting on the DS HTTP API (GAP-09); see [Optional: Data Storage Per-IP Rate Limiting](#optional-data-storage-per-ip-rate-limiting-gap-09) | `false` |
+| `datastorage.config.server.rateLimit.requestsPerSecond` | Sustained per-IP requests/second | `50` |
+| `datastorage.config.server.rateLimit.burst` | Per-IP token bucket burst size | `100` |
+| `datastorage.config.auditHashKey.existingSecret` | Pre-created Secret name (empty = expect `datastorage-audit-hmac-key`) | `""` |
 
 ### TLS
 

--- a/charts/kubernaut/templates/_helpers.tpl
+++ b/charts/kubernaut/templates/_helpers.tpl
@@ -120,6 +120,19 @@ When using external Valkey, falls through to the external settings.
 {{- end }}
 
 {{/*
+Return the Secret name for the DataStorage audit hash-chain HMAC key
+(GAP-05, Issue #1505). Only relevant when datastorage.config.auditHashKey.enabled.
+Precedence: datastorage.config.auditHashKey.existingSecret > "datastorage-audit-hmac-key".
+*/}}
+{{- define "kubernaut.datastorage.auditHashKeySecretName" -}}
+{{- if .Values.datastorage.config.auditHashKey.existingSecret -}}
+{{- .Values.datastorage.config.auditHashKey.existingSecret -}}
+{{- else -}}
+  datastorage-audit-hmac-key
+{{- end -}}
+{{- end }}
+
+{{/*
 Return the PostgreSQL host.
 Uses in-chart service DNS when postgresql.enabled, otherwise externalPostgresql.host.
 */}}

--- a/charts/kubernaut/templates/apifrontend/apifrontend.yaml
+++ b/charts/kubernaut/templates/apifrontend/apifrontend.yaml
@@ -157,6 +157,15 @@ data:
           {{- end }}
       {{- end }}
       {{- end }}
+      {{- if .Values.apifrontend.config.auth.replayCache.enabled }}
+      # GAP-08 (Issue #1505): distributed jti replay cache shared across all
+      # APIFrontend replicas via the cluster's Valkey instance.
+      replayCache:
+        backend: redis
+        redisAddr: {{ include "kubernaut.valkey.addr" . }}
+        redisDB: {{ .Values.apifrontend.config.auth.replayCache.redisDB | default 1 }}
+        credentialsPath: "/etc/apifrontend/valkey/valkey-secrets.yaml"
+      {{- end }}
     rbac:
       sarCacheTTL: {{ .Values.apifrontend.config.rbac.sarCacheTTL | default "30s" }}
     logging:
@@ -234,6 +243,11 @@ spec:
             - name: tls-certs
               mountPath: /etc/apifrontend/tls
               readOnly: true
+            {{- if .Values.apifrontend.config.auth.replayCache.enabled }}
+            - name: valkey-secrets
+              mountPath: /etc/apifrontend/valkey
+              readOnly: true
+            {{- end }}
           readinessProbe:
             httpGet:
               path: /readyz
@@ -259,6 +273,14 @@ spec:
           secret:
             secretName: apifrontend-tls
             optional: true
+        {{- if .Values.apifrontend.config.auth.replayCache.enabled }}
+        - name: valkey-secrets
+          secret:
+            secretName: {{ include "kubernaut.valkey.secretName" . }}
+            items:
+              - key: valkey-secrets.yaml
+                path: valkey-secrets.yaml
+        {{- end }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/kubernaut/templates/datastorage/datastorage.yaml
+++ b/charts/kubernaut/templates/datastorage/datastorage.yaml
@@ -24,6 +24,12 @@ data:
         {{- toYaml .Values.datastorage.config.server.corsAllowedOrigins | nindent 8 }}
       {{- end }}
       signerCertDir: {{ .Values.datastorage.config.server.signerCertDir | default "/etc/certs" | quote }}
+      # GAP-09 (Issue #1505) / SC-5: Per-IP rate limiting, disabled by default
+      # (existing deployments may rely on an external ingress/proxy for this).
+      rateLimit:
+        enabled: {{ .Values.datastorage.config.server.rateLimit.enabled | default false }}
+        requestsPerSecond: {{ .Values.datastorage.config.server.rateLimit.requestsPerSecond | default 50 }}
+        burst: {{ .Values.datastorage.config.server.rateLimit.burst | default 100 }}
       tls:
         certDir: {{ include "kubernaut.interServiceTLS.certDir" . | quote }}
     database:
@@ -54,6 +60,12 @@ data:
       interval: {{ .Values.datastorage.config.retention.interval | default "24h" | quote }}
       batchSize: {{ .Values.datastorage.config.retention.batchSize | default 1000 }}
       defaultDays: {{ .Values.datastorage.config.retention.defaultDays | default 2555 }}
+    {{- if .Values.datastorage.config.auditHashKey.enabled }}
+    # GAP-05 (Issue #1505) / AU-9: Keyed HMAC-SHA256 audit hash chain.
+    audit:
+      hashKeySecretsFile: "/etc/datastorage/secrets/audit-hmac-key.yaml"
+      hashKeyKey: {{ .Values.datastorage.config.auditHashKey.secretKey | default "hmacKey" | quote }}
+    {{- end }}
     logging:
       level: {{ .Values.datastorage.logging.level | default "INFO" | upper | quote }}
 ---
@@ -179,6 +191,13 @@ spec:
                   items:
                     - key: valkey-secrets.yaml
                       path: valkey-secrets.yaml
+              {{- if .Values.datastorage.config.auditHashKey.enabled }}
+              - secret:
+                  name: {{ include "kubernaut.datastorage.auditHashKeySecretName" . }}
+                  items:
+                    - key: audit-hmac-key.yaml
+                      path: audit-hmac-key.yaml
+              {{- end }}
         - name: tls-certs
           secret:
             secretName: datastorage-tls

--- a/charts/kubernaut/templates/infrastructure/secrets.yaml
+++ b/charts/kubernaut/templates/infrastructure/secrets.yaml
@@ -57,4 +57,14 @@
 {{- end }}
 {{- end }}
 
+{{/* GAP-05 (Issue #1505): Optional DataStorage audit hash-chain HMAC key.
+     Only validated when datastorage.config.auditHashKey.enabled=true (opt-in). */}}
+{{- if .Values.datastorage.config.auditHashKey.enabled }}
+{{- $auditHmacSecretName := include "kubernaut.datastorage.auditHashKeySecretName" . -}}
+{{- $auditHmacSecret := lookup "v1" "Secret" .Release.Namespace $auditHmacSecretName }}
+{{- if not $auditHmacSecret }}
+{{- fail (printf "Required Secret %q (datastorage.config.auditHashKey) not found in namespace %q. Pre-create it before installing:\n\n  HMAC_KEY=$(openssl rand -base64 32)\n  kubectl create secret generic %s \\\n    --from-literal=audit-hmac-key.yaml=\"$(printf 'hmacKey: %%s' \"$HMAC_KEY\")\" \\\n    -n %s" $auditHmacSecretName .Release.Namespace $auditHmacSecretName .Release.Namespace) }}
+{{- end }}
+{{- end }}
+
 {{- end }}{{/* end $hasCluster */}}

--- a/charts/kubernaut/templates/workflowexecution/workflowexecution.yaml
+++ b/charts/kubernaut/templates/workflowexecution/workflowexecution.yaml
@@ -5,6 +5,13 @@ metadata:
   name: {{ include "kubernaut.workflowNamespace" . }}
   labels:
     {{- include "kubernaut.labels" . | nindent 4 }}
+    # BR-WE-018: Pod Security Admission backstop. Spawned Job/PipelineRun pods are
+    # already hardened to "restricted" in code (pkg/workflowexecution/executor); this
+    # label provides an independent, API-server-enforced guarantee in case that code
+    # ever regresses. Not configurable -- see BR-WE-018 for rationale.
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -372,7 +372,17 @@
                 "maxConcurrentRequests": { "type": "integer", "default": 100, "description": "Maximum concurrent request limit" },
                 "readTimeout": { "type": "string", "default": "30s", "description": "Server read timeout" },
                 "corsAllowedOrigins": { "type": "array", "items": { "type": "string" }, "description": "#1048 Phase 4 / AC-4: CORS allowed origins" },
-                "signerCertDir": { "type": "string", "default": "/etc/certs", "description": "#1048 Phase 5 / AU-9: Directory containing signing cert (tls.crt, tls.key)" }
+                "signerCertDir": { "type": "string", "default": "/etc/certs", "description": "#1048 Phase 5 / AU-9: Directory containing signing cert (tls.crt, tls.key)" },
+                "rateLimit": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "GAP-09 (Issue #1505) / SC-5: Per-IP rate limiting for the DS HTTP API. Disabled by default.",
+                  "properties": {
+                    "enabled": { "type": "boolean", "default": false },
+                    "requestsPerSecond": { "type": "number", "default": 50, "description": "Sustained per-IP requests/second" },
+                    "burst": { "type": "integer", "default": 100, "description": "Per-IP token bucket burst size" }
+                  }
+                }
               }
             },
             "database": {
@@ -414,6 +424,16 @@
                 "interval": { "type": "string", "default": "24h", "description": "How often the retention worker runs" },
                 "batchSize": { "type": "integer", "default": 1000, "description": "Max rows per DELETE batch" },
                 "defaultDays": { "type": "integer", "default": 2555, "description": "Application-level default retention in days (ADR-034: 7 years)" }
+              }
+            },
+            "auditHashKey": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "GAP-05 (Issue #1505) / AU-9: Optional keyed HMAC-SHA256 audit hash chain",
+              "properties": {
+                "enabled": { "type": "boolean", "default": false, "description": "Enable keyed HMAC-SHA256 hash chaining (requires a pre-created Secret)" },
+                "existingSecret": { "type": "string", "default": "", "description": "Pre-created Secret name; defaults to datastorage-audit-hmac-key when unset" },
+                "secretKey": { "type": "string", "default": "hmacKey", "description": "Key name within the secret's audit-hmac-key.yaml file" }
               }
             }
           }
@@ -1115,6 +1135,15 @@
                         }
                       }
                     }
+                  }
+                },
+                "replayCache": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "description": "GAP-08 (Issue #1505): distributed jti replay-detection backend, shared across all APIFrontend replicas via the cluster's Valkey instance. Disabled by default (legacy in-memory, single-process cache).",
+                  "properties": {
+                    "enabled": { "type": "boolean", "default": false },
+                    "redisDB": { "type": "integer", "default": 1, "description": "Valkey logical DB index used for replay cache keys" }
                   }
                 }
               }

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -126,6 +126,13 @@ datastorage:
       corsAllowedOrigins: []
       # #1048 Phase 5 / AU-9: Directory containing signing cert (tls.crt, tls.key).
       signerCertDir: "/etc/certs"
+      # GAP-09 (Issue #1505) / SC-5: Per-IP rate limiting for the DS HTTP API.
+      # Disabled by default — existing deployments may already rate limit at
+      # an external ingress/proxy. Denials are self-audited (datastorage.ratelimit.denied).
+      rateLimit:
+        enabled: false
+        requestsPerSecond: 50
+        burst: 100
     database:
       sslMode: "disable"
       maxOpenConns: 100
@@ -147,6 +154,17 @@ datastorage:
       interval: "24h"
       batchSize: 1000
       defaultDays: 2555
+    # GAP-05 (Issue #1505) / AU-9: Optional keyed HMAC-SHA256 audit hash chain.
+    # When disabled (default), audit events use the legacy unkeyed SHA256
+    # algorithm for backward compatibility with existing deployments. Enable
+    # once the audit HMAC key Secret has been pre-created (see README.md) to
+    # raise the bar against a DB-privileged attacker forging hash chain
+    # entries — an unkeyed hash can be recomputed by anyone with DB access,
+    # a keyed HMAC hash cannot be forged without the key.
+    auditHashKey:
+      enabled: false
+      existingSecret: ""    # defaults to "datastorage-audit-hmac-key" when enabled and unset
+      secretKey: "hmacKey"  # key name within the secret's audit-hmac-key.yaml file
   resources:
     requests:
       memory: 256Mi
@@ -672,6 +690,16 @@ apifrontend:
       #     issuerURL: "https://oidc-discovery-provider.example.com"
       #     jwksURL: "https://spire-spiffe-oidc-discovery-provider.zero-trust-workload-identity-manager.svc:443/keys"
       #     audiences: ["spiffe://trust-domain/ns/kubernaut-system/sa/apifrontend"]
+      # GAP-08 (Issue #1505): jti replay-detection backend. When disabled
+      # (default), APIFrontend uses the legacy in-memory cache — a token
+      # replayed against a different replica in a multi-replica deployment is
+      # not detected. Enable to share replay state across all replicas via the
+      # cluster's shared Valkey instance (same instance/secret used by
+      # DataStorage). Requires enableReplayProtection to be effectively
+      # replaced by this block; leave `enabled: false` to keep the legacy
+      # single-process behavior when replicas=1.
+      replayCache:
+        enabled: false
     rbac:
       sarCacheTTL: "30s"
       personas:

--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/go-logr/zapr"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	adksession "google.golang.org/adk/session"
@@ -1094,6 +1095,83 @@ func bridgeMetricsFrom(reg *metrics.Registry) *handler.MCPBridgeMetrics {
 	}
 }
 
+// replayCacheTTL matches (and slightly exceeds) the maximum expected token
+// lifetime so replayed tokens cannot outlive their own cache entry.
+const replayCacheTTL = 10 * time.Minute
+
+// buildReplayCache constructs the jti replay-detection store selected by
+// cfg (GAP-08, #1505). When cfg specifies a distributed "redis"/"valkey"
+// backend, replay state is shared across all APIFrontend replicas via Valkey;
+// if that backend cannot be constructed (bad address, unreadable credentials),
+// it falls back to the legacy single-process in-memory cache rather than
+// disabling replay protection outright — logged loudly so the HA degradation
+// is observable. legacyEnable preserves the pre-GAP-08 boolean toggle for
+// configs that predate the structured auth.replayCache block.
+func buildReplayCache(cfg *config.ReplayCacheConfig, legacyEnable bool, logger logr.Logger) auth.ReplayCacheStore {
+	if cfg == nil {
+		if legacyEnable {
+			return auth.NewReplayCache(replayCacheTTL)
+		}
+		return nil
+	}
+	if !cfg.IsDistributed() {
+		return auth.NewReplayCache(replayCacheTTL)
+	}
+	rc, err := newValkeyReplayCache(cfg, logger)
+	if err != nil {
+		logger.Error(err, "failed to initialize valkey replay cache; falling back to in-memory cache (HA replay detection degraded)",
+			"redisAddr", cfg.RedisAddr)
+		return auth.NewReplayCache(replayCacheTTL)
+	}
+	logger.Info("auth mode: distributed replay cache (valkey)", "redisAddr", cfg.RedisAddr, "redisDB", cfg.RedisDB)
+	return rc
+}
+
+// newValkeyReplayCache builds a Redis client from cfg and wraps it in a
+// ValkeyReplayCache. Credentials are optional: an empty CredentialsPath
+// connects without authentication (dev/test Valkey instances).
+func newValkeyReplayCache(cfg *config.ReplayCacheConfig, logger logr.Logger) (*auth.ValkeyReplayCache, error) {
+	password, err := loadReplayCachePassword(cfg.CredentialsPath)
+	if err != nil {
+		return nil, fmt.Errorf("load replay cache credentials: %w", err)
+	}
+	client := redis.NewClient(&redis.Options{
+		Addr:     cfg.RedisAddr,
+		Password: password,
+		DB:       cfg.RedisDB,
+	})
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := client.Ping(ctx).Err(); err != nil {
+		_ = client.Close()
+		return nil, fmt.Errorf("ping valkey at %s: %w", cfg.RedisAddr, err)
+	}
+	return auth.NewValkeyReplayCache(client, replayCacheTTL, logger), nil
+}
+
+// loadReplayCachePassword reads the "password" key from a YAML credentials
+// file mounted from a Kubernetes Secret (same "password" key convention as
+// DataStorage's valkey-secrets.yaml projection). Returns "" without error
+// when path is empty (unauthenticated Valkey).
+func loadReplayCachePassword(path string) (string, error) {
+	if path == "" {
+		return "", nil
+	}
+	data, err := os.ReadFile(path) //nolint:gosec // path from trusted, operator-controlled config
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", path, err)
+	}
+	var secrets map[string]string
+	if err := yaml.Unmarshal(data, &secrets); err != nil {
+		return "", fmt.Errorf("parse %s: %w", path, err)
+	}
+	password, ok := secrets["password"]
+	if !ok {
+		return "", fmt.Errorf(`%s: missing required "password" key`, path)
+	}
+	return password, nil
+}
+
 func buildAuthMiddleware(cfg *config.Config, reg *metrics.Registry, auditor audit.Emitter, logger logr.Logger) (func(http.Handler) http.Handler, handler.ReadyChecker) {
 	alwaysReady := handler.ReadyChecker(func() bool { return true })
 
@@ -1140,8 +1218,8 @@ func buildAuthMiddleware(cfg *config.Config, reg *metrics.Registry, auditor audi
 			validatorOpts = append(validatorOpts, auth.WithHTTPClient(httpClient))
 			logger.Info("OIDC JWKS fetcher configured with custom CA", "caFile", cfg.Auth.OIDCCaFile)
 		}
-		if cfg.Auth.EnableReplayProtection {
-			validatorOpts = append(validatorOpts, auth.WithReplayCache(auth.NewReplayCache(10*time.Minute)))
+		if rc := buildReplayCache(cfg.Auth.ReplayCache, cfg.Auth.EnableReplayProtection, logger); rc != nil {
+			validatorOpts = append(validatorOpts, auth.WithReplayCache(rc))
 		}
 		logger.Info("auth mode: OIDC/JWKS", "providers", len(authCfg.JWT))
 	}

--- a/cmd/apifrontend/replay_cache_wiring_test.go
+++ b/cmd/apifrontend/replay_cache_wiring_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-logr/logr"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/config"
+)
+
+// GAP-08 (kubernaut#1505): buildReplayCache selects the distributed Valkey
+// backend when configured, and must fall back to the in-memory cache rather
+// than disabling replay protection outright when the backend is unreachable.
+
+func TestBuildReplayCache_NilConfigLegacyDisabled_ReturnsNil(t *testing.T) {
+	rc := buildReplayCache(nil, false, logr.Discard())
+	if rc != nil {
+		t.Errorf("expected nil replay cache when config is nil and legacy flag disabled, got %T", rc)
+	}
+}
+
+func TestBuildReplayCache_NilConfigLegacyEnabled_ReturnsInMemory(t *testing.T) {
+	rc := buildReplayCache(nil, true, logr.Discard())
+	defer rc.Stop()
+	if _, ok := rc.(*auth.ReplayCache); !ok {
+		t.Errorf("expected legacy enableReplayProtection=true to construct an in-memory ReplayCache, got %T", rc)
+	}
+}
+
+func TestBuildReplayCache_MemoryBackend_ReturnsInMemory(t *testing.T) {
+	rc := buildReplayCache(&config.ReplayCacheConfig{Backend: "memory"}, false, logr.Discard())
+	defer rc.Stop()
+	if _, ok := rc.(*auth.ReplayCache); !ok {
+		t.Errorf("expected backend=memory to construct an in-memory ReplayCache, got %T", rc)
+	}
+}
+
+func TestBuildReplayCache_RedisBackend_ReturnsValkeyReplayCache(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	rc := buildReplayCache(&config.ReplayCacheConfig{
+		Backend:   "redis",
+		RedisAddr: mr.Addr(),
+	}, false, logr.Discard())
+	defer rc.Stop()
+
+	if _, ok := rc.(*auth.ValkeyReplayCache); !ok {
+		t.Errorf("expected backend=redis to construct a ValkeyReplayCache, got %T", rc)
+	}
+	// Sanity check the constructed cache is actually wired to the running instance.
+	if rc.Seen("jti-wiring-check") {
+		t.Error("expected a fresh jti to not be seen yet")
+	}
+	if !rc.Seen("jti-wiring-check") {
+		t.Error("expected the same jti to be detected as seen on the second call")
+	}
+}
+
+func TestBuildReplayCache_RedisBackendUnreachable_FallsBackToInMemory(t *testing.T) {
+	rc := buildReplayCache(&config.ReplayCacheConfig{
+		Backend:   "redis",
+		RedisAddr: "127.0.0.1:1", // nothing listens here — connection refused
+	}, false, logr.Discard())
+	defer rc.Stop()
+
+	if _, ok := rc.(*auth.ReplayCache); !ok {
+		t.Errorf("expected an unreachable redis backend to fall back to in-memory ReplayCache, got %T", rc)
+	}
+}
+
+func TestLoadReplayCachePassword_EmptyPath_ReturnsEmptyNoError(t *testing.T) {
+	password, err := loadReplayCachePassword("")
+	if err != nil {
+		t.Fatalf("unexpected error for empty path: %v", err)
+	}
+	if password != "" {
+		t.Errorf("expected empty password for empty path, got %q", password)
+	}
+}
+
+func TestLoadReplayCachePassword_ValidFile_ReturnsPassword(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "valkey-secrets.yaml")
+	if err := os.WriteFile(path, []byte("password: s3cr3t\n"), 0o600); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	password, err := loadReplayCachePassword(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if password != "s3cr3t" {
+		t.Errorf("expected password %q, got %q", "s3cr3t", password)
+	}
+}
+
+func TestLoadReplayCachePassword_MissingPasswordKey_ReturnsError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "valkey-secrets.yaml")
+	if err := os.WriteFile(path, []byte("username: admin\n"), 0o600); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+
+	if _, err := loadReplayCachePassword(path); err == nil {
+		t.Error("expected an error when the password key is missing")
+	}
+}
+
+func TestLoadReplayCachePassword_MissingFile_ReturnsError(t *testing.T) {
+	if _, err := loadReplayCachePassword(filepath.Join(t.TempDir(), "does-not-exist.yaml")); err == nil {
+		t.Error("expected an error for a missing credentials file")
+	}
+}
+
+func TestBuildReplayCache_UnauthenticatedValkeyStillWorks(t *testing.T) {
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("failed to start miniredis: %v", err)
+	}
+	defer mr.Close()
+
+	rc := buildReplayCache(&config.ReplayCacheConfig{
+		Backend:   "redis",
+		RedisAddr: mr.Addr(),
+		RedisDB:   0,
+	}, false, logr.Discard())
+	defer rc.Stop()
+
+	if rc.MissingJTI("") != true {
+		t.Error("expected MissingJTI(\"\") to be true")
+	}
+}

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -241,10 +241,16 @@ func main() {
 				var partial struct {
 					Logging internalconfig.LoggingConfig `yaml:"logging"`
 				}
-				if err := yaml.Unmarshal([]byte(newContent), &partial); err != nil {
-					return fmt.Errorf("failed to parse config for log level reload: %w", err)
-				}
-				return internalconfig.ParseAndSetLevel(atomicLevel, partial.Logging.Level)
+				reloadErr := func() error {
+					if err := yaml.Unmarshal([]byte(newContent), &partial); err != nil {
+						return fmt.Errorf("failed to parse config for log level reload: %w", err)
+					}
+					return internalconfig.ParseAndSetLevel(atomicLevel, partial.Logging.Level)
+				}()
+				// GAP-11 (Issue #1505): audit every log-level hot-reload attempt,
+				// success or rejection (SOC2 CC7.2 change management).
+				srv.EmitConfigReloadAudit(serverCtx, "log_level", reloadErr)
+				return reloadErr
 			},
 			logger.WithName("log-level-watcher"),
 		)
@@ -261,7 +267,10 @@ func main() {
 	}
 
 	// Issue #756: Start CA file watcher for client-side TLS hot-reload
-	caWatcher, caWatchErr := sharedtls.StartCAFileWatcher(serverCtx, logger)
+	// GAP-11 (Issue #1505): audit every CA-cert hot-reload attempt.
+	caWatcher, caWatchErr := sharedtls.StartCAFileWatcher(serverCtx, logger, func(reloadErr error) {
+		srv.EmitConfigReloadAudit(serverCtx, "ca_cert", reloadErr)
+	})
 	if caWatchErr != nil {
 		logger.Error(caWatchErr, "Failed to start CA file watcher")
 		os.Exit(1)

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -58,25 +58,27 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/shared/types"
 
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/alignment"
-	"github.com/jordigilh/kubernaut/internal/version"
-	kaapi "github.com/jordigilh/kubernaut/internal/kubernautagent/api"
 	alignprompt "github.com/jordigilh/kubernaut/internal/kubernautagent/alignment/prompt"
+	kaapi "github.com/jordigilh/kubernaut/internal/kubernautagent/api"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
 	kaconfig "github.com/jordigilh/kubernaut/internal/kubernautagent/config"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/credentials"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
-	karbac "github.com/jordigilh/kubernaut/internal/kubernautagent/rbac"
 	mcpkg "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
 	mcpadapters "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/adapters"
 	mcptools "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
 	kametrics "github.com/jordigilh/kubernaut/internal/kubernautagent/metrics"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
-	dsschema "github.com/jordigilh/kubernaut/pkg/datastorage/schema"
+	karbac "github.com/jordigilh/kubernaut/internal/kubernautagent/rbac"
 	kaserver "github.com/jordigilh/kubernaut/internal/kubernautagent/server"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/tools/custom"
+	"github.com/jordigilh/kubernaut/internal/version"
+	dsschema "github.com/jordigilh/kubernaut/pkg/datastorage/schema"
+	fleetclient "github.com/jordigilh/kubernaut/pkg/fleet/mcpclient"
+	fleetregistry "github.com/jordigilh/kubernaut/pkg/fleet/registry"
 	amtools "github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/alertmanager"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/investigation"
 	k8stools "github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/k8s"
@@ -87,8 +89,6 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/summarizer"
 	kubelog "github.com/jordigilh/kubernaut/pkg/log"
 	wfclient "github.com/jordigilh/kubernaut/pkg/workflowexecution/client"
-	fleetclient "github.com/jordigilh/kubernaut/pkg/fleet/mcpclient"
-	fleetregistry "github.com/jordigilh/kubernaut/pkg/fleet/registry"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/client-go/rest"
 	metricsclient "k8s.io/metrics/pkg/client/clientset/versioned"
@@ -275,7 +275,7 @@ func main() {
 		logger.Error(nil, "FATAL: DataStorage client initialization failed — KA cannot operate without DS (workflow discovery, audit, enrichment all require it)")
 		os.Exit(1)
 	}
-	reg := buildToolRegistry(cfg, logger, k8sInfra, ds)
+	reg := buildToolRegistry(cfg, logger, k8sInfra, ds, auditStore)
 	fleetClient, fleetToolNames := registerFleetTools(context.Background(), cfg, reg, logger)
 	if len(fleetToolNames) > 0 {
 		investigator.AppendFleetToolsToRCA(phaseTools, fleetToolNames)
@@ -1066,11 +1066,11 @@ func buildAnomalyDetector(cfg *kaconfig.Config, logger logr.Logger) *investigato
 }
 
 // buildToolRegistry creates and populates the tool registry with all available tool sets.
-func buildToolRegistry(cfg *kaconfig.Config, logger logr.Logger, infra *k8sInfra, ds *dsClients) *registry.Registry {
+func buildToolRegistry(cfg *kaconfig.Config, logger logr.Logger, infra *k8sInfra, ds *dsClients, auditStore audit.AuditStore) *registry.Registry {
 	reg := registry.New()
 
 	if infra != nil {
-		registerK8sTools(reg, infra, logger)
+		registerK8sTools(reg, infra, logger, auditStore)
 	}
 
 	if cfg.Integrations.Tools.Prometheus.URL != "" {
@@ -1217,13 +1217,14 @@ func registerFleetTools(ctx context.Context, cfg *kaconfig.Config, reg *registry
 	return resilientClient, toolNames
 }
 
-func registerK8sTools(reg *registry.Registry, infra *k8sInfra, logger logr.Logger) {
+func registerK8sTools(reg *registry.Registry, infra *k8sInfra, logger logr.Logger, auditStore audit.AuditStore) {
 	kindIndex, err := k8stools.BuildKindIndex(infra.clientset.Discovery())
 	if err != nil {
 		logger.Info("failed to build kind index, using empty index", "error", err)
 		kindIndex = make(map[string]schema.GroupKind)
 	}
-	resolver := k8stools.NewDynamicResolver(infra.dynClient, infra.mapper, kindIndex, logger.WithName("k8s-resolver"))
+	resolver := k8stools.NewDynamicResolver(infra.dynClient, infra.mapper, kindIndex, logger.WithName("k8s-resolver"),
+		k8stools.WithSecretAccessObserver(newSecretAccessObserver(auditStore, logger.WithName("secret-access-audit"))))
 
 	for _, t := range k8stools.NewAllTools(infra.clientset, resolver) {
 		reg.Register(t)
@@ -1248,6 +1249,39 @@ func registerK8sTools(reg *registry.Registry, infra *k8sInfra, logger logr.Logge
 		reg.Register(t)
 	}
 	logger.Info("registered node proxy tools", "count", len(k8stools.NodeProxyToolNames))
+}
+
+// newSecretAccessObserver builds the k8stools.SecretAccessObserver wired into
+// the K8s resource resolver (GAP-13, Issue #1505). It is the detective
+// control compensating for KubernautAgent's intentionally broad read RBAC on
+// Secrets (see docs/services/stateless/kubernaut-agent/security-configuration.md):
+// every Secret Get/List — success or failure — becomes an independently
+// queryable aiagent.secret.accessed audit event, correlated to the
+// investigation via the correlationID set on ctx by
+// session.Manager.launchInvestigation.
+func newSecretAccessObserver(auditStore audit.AuditStore, logger logr.Logger) func(ctx context.Context, verb, name, namespace string, err error) {
+	return func(ctx context.Context, verb, name, namespace string, accessErr error) {
+		if auditStore == nil {
+			return
+		}
+		correlationID, _ := audit.CorrelationIDFromContext(ctx)
+
+		event := audit.NewEvent(audit.EventTypeSecretAccessed, correlationID)
+		event.EventAction = audit.ActionSecretAccessed
+		event.EventOutcome = audit.OutcomeSuccess
+		event.Data["verb"] = verb
+		if namespace != "" {
+			event.Data["namespace"] = namespace
+		}
+		if name != "" {
+			event.Data["secret_name"] = name
+		}
+		if accessErr != nil {
+			event.EventOutcome = audit.OutcomeFailure
+			event.Data["outcome_detail"] = accessErr.Error()
+		}
+		audit.StoreBestEffort(ctx, auditStore, event, logger)
+	}
 }
 
 // dsCatalogFetcher implements investigator.CatalogFetcher by querying
@@ -1418,8 +1452,6 @@ func buildMCPHandler(
 		logger.Error(nil, "MCP interactive mode: investigator unavailable")
 		return nil, nil
 	}
-
-	
 
 	// SEC-07: Build controller-runtime client with MCP-specific timeouts.
 	// Scheme includes remediationv1 for RR existence validation (HARM-004)

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -45,6 +45,7 @@ rules:
   - kubernaut.ai
   resources:
   - aianalyses
+  - effectivenessassessments
   - notificationrequests
   - signalprocessings
   - workflowexecutions
@@ -69,6 +70,7 @@ rules:
   - kubernaut.ai
   resources:
   - aianalyses/status
+  - effectivenessassessments/status
   - investigationsessions/status
   - notificationrequests/status
   - signalprocessings/status

--- a/docs/architecture/decisions/DD-AUDIT-003-service-audit-trace-requirements.md
+++ b/docs/architecture/decisions/DD-AUDIT-003-service-audit-trace-requirements.md
@@ -246,6 +246,8 @@ Kubernaut consists of 12 microservices with different responsibilities. Not all 
 | `gateway.signal.deduplicated` | Duplicate signal detected | P0 |
 | `gateway.crd.created` | RemediationRequest CRD created | P0 |
 | `gateway.crd.creation_failed` | CRD creation failed | P0 |
+| `gateway.config.reloaded` | Hot-reloadable config accepted (log level, CA cert) — GAP-11, Issue #1505 | P2 |
+| `gateway.config.rejected` | Hot-reloadable config rejected, previous config kept — GAP-11, Issue #1505 | P2 |
 
 **Industry Precedent**: AWS EventBridge, Google Cloud Pub/Sub, Azure Event Grid
 

--- a/docs/requirements/BR-AUDIT-010-keyed-audit-hash-chain.md
+++ b/docs/requirements/BR-AUDIT-010-keyed-audit-hash-chain.md
@@ -1,0 +1,72 @@
+# BR-AUDIT-010: Keyed Audit Hash Chain (HMAC-SHA256)
+
+**Business Requirement ID**: BR-AUDIT-010
+**Category**: Data Storage Service — Security & Compliance
+**Priority**: **P1 (HIGH)** — Closes a HIGH-severity GA readiness gap
+**Target Version**: **V1.5**
+**Status**: ✅ Implemented (DataStorage) / 🔜 Tracked separately for `kubernaut-operator` (v1.6)
+**Date**: June 30, 2026
+**Related ADRs**: [ADR-034: Unified Audit Table Design](../architecture/decisions/ADR-034-unified-audit-table-design.md)
+**Related BRs**: BR-AUDIT-005 (Core Audit Business Requirement), BR-AUDIT-007 (Tamper-evident audit exports)
+**GitHub Issues**: [#1505](https://github.com/jordigilh/kubernaut/issues/1505) (GAP-05)
+
+---
+
+## Business Need
+
+### Problem Statement
+
+DataStorage's `audit_events` table implements a blockchain-style hash chain (SOC2 Gap #9): each row's `event_hash` is `SHA256(previous_event_hash + event_json)`, so tampering with any row breaks the chain for every subsequent event. Before this BR, that hash was **unkeyed**: anyone with read/write access to the PostgreSQL database — including a DBA, a compromised service account with `UPDATE` on `audit_events`, or an attacker who gained database credentials — could tamper with a row and then recompute a self-consistent SHA256 chain for the rows that follow, defeating the tamper-evidence guarantee entirely.
+
+This was identified as **GAP-05 (HIGH severity)** in the GA Readiness Audit (issue #1505): "the hash chain protects against accidental corruption but not against a database-privileged attacker."
+
+### Impact Without This BR
+
+- **FedRAMP AU-9** (Protection of Audit Information) is only partially satisfied: the chain detects *unintentional* corruption but not a deliberate, DB-privileged forgery.
+- **SOC2 CC8.1** audit reconstruction cannot fully rely on `event_hash`/`previous_event_hash` alone as proof against a database-level compromise — a necessary caveat for any compliance narrative built on this chain.
+
+---
+
+## Decision: Keyed HMAC-SHA256, Opt-In and Backward Compatible
+
+New audit events are hashed with **HMAC-SHA256** using a key stored **outside the database** (a Kubernetes Secret mounted into the DataStorage pod), instead of plain SHA256. Forging a valid HMAC without that key is computationally infeasible, even for an attacker with full database read/write access — closing the gap that made the previous unkeyed chain forgeable by a DB-privileged actor.
+
+Key design choices:
+
+1. **Per-row `hash_algorithm` column** (migration `013_audit_hash_algorithm.sql`): every row records which algorithm produced its `event_hash` (`sha256-unkeyed` or `hmac-sha256`). This supports a **mixed-algorithm chain**: existing rows keep verifying under the legacy algorithm; only new writes made after the HMAC key is provisioned use `hmac-sha256`. There is no retroactive re-hashing of historical data.
+2. **Backward-compatible, opt-in**: when no HMAC key is configured (the default), DataStorage continues using the legacy unkeyed SHA256 algorithm — existing deployments upgrade with zero required action. Operators enable the stronger algorithm by pre-creating a Secret and setting `datastorage.config.auditHashKey.enabled=true` (Helm) — see `charts/kubernaut/README.md`.
+3. **Excluded from the hash payload**: `hash_algorithm` itself is *not* included in the JSON that gets hashed (`PrepareEventForHashing` zeroes it, the same treatment as `EventHash`/`PreviousEventHash`/`EventDate`). This keeps pre-GAP-05 hashes verifiable byte-for-byte against their original JSON representation, which never contained this field.
+4. **Shared verification logic**: `repository.CalculateHashForVerification(hmacKey, previousHash, event)` is the single source of truth for algorithm-aware verification, used by both the `/api/v1/audit/verify-chain` HTTP handler and the `Export` (compliance export) path. Verifying an `hmac-sha256` event without a configured key fails loudly with an explicit error rather than silently reporting a false "tampered" mismatch.
+5. **No chart-managed secret generation**: consistent with the existing `postgresql-secret` / `valkey-secret` convention (`charts/kubernaut/templates/infrastructure/secrets.yaml`), the chart does **not** auto-generate the HMAC key. When `auditHashKey.enabled=true`, Helm validates the Secret exists via `lookup` and fails with an actionable `kubectl create secret` command if missing.
+
+The equivalent wiring for `kubernaut-operator`-managed deployments (which construct their own `DataStorageConfigMap`/`DataStorageDeployment` independently of this Helm chart) is tracked separately: [kubernaut-operator#209](https://github.com/jordigilh/kubernaut-operator/issues/209), milestone v1.6.
+
+### Known Residual Risk (Documented, Not Closed by This BR)
+
+The per-row `hash_algorithm` column is itself ordinary database data. A sufficiently privileged attacker who can rewrite arbitrary rows could, in principle, also rewrite `hash_algorithm` from `hmac-sha256` back to `sha256-unkeyed` and recompute a plain SHA256 hash from scratch (a "downgrade" forgery) — the same fundamental class of risk as an attacker rewriting `event_hash`/`previous_event_hash` directly, which is not blocked by the immutability trigger (migration `012_audit_event_immutability.sql`) because doing so would break existing tamper-*detection* tests that deliberately rely on being able to `UPDATE event_hash` to simulate an attacker (see `test/integration/datastorage/audit_export_integration_test.go`, `test/e2e/datastorage/05_soc2_compliance_test.go`).
+
+Closing this residual risk would require an external, out-of-band anchor (e.g., periodically publishing chain-tip hashes to an external immutable log, or WORM storage) — out of scope for this BR. HMAC-SHA256 still meaningfully raises the bar: it defeats the *straightforward* SHA256-recompute-and-forge attack the unkeyed algorithm was vulnerable to, requiring instead a more complex attack that also depends on hiding evidence of the downgrade itself.
+
+---
+
+## Success Criteria
+
+1. `AuditEventsRepository.Create`/`CreateBatch` stamp `hash_algorithm` and select `hmac-sha256` when an HMAC key is configured (`WithHMACKey`), else `sha256-unkeyed` (backward-compatible default).
+2. `repository.CalculateHashForVerification` is algorithm-aware, used identically by `Export` and the verify-chain HTTP handler.
+3. `hmac-sha256` verification without a configured key fails with an explicit error, not a false "tampered" result.
+4. Pre-GAP-05 events (empty `hash_algorithm`) continue to verify identically to `sha256-unkeyed` events.
+5. Helm: `datastorage.config.auditHashKey.enabled=true` wires the ConfigMap (`audit.hashKeySecretsFile`/`hashKeyKey`), mounts the pre-created Secret, and validates its existence at install/upgrade time. Disabled by default.
+6. FedRAMP/SOC2 control mapping: **AU-9** (Protection of Audit Information) is materially strengthened for post-rollout events; **CC8.1** reconstruction retains a documented, bounded caveat for the residual downgrade risk above.
+
+---
+
+## Related Documents
+
+- [ADR-034: Unified Audit Table Design](../architecture/decisions/ADR-034-unified-audit-table-design.md)
+- [Kubernaut Helm Chart README — Optional: Keyed Audit Hash Chain](../../charts/kubernaut/README.md#optional-keyed-audit-hash-chain-gap-05)
+
+---
+
+**Document Version**: 1.0
+**Last Updated**: June 30, 2026
+**Maintained By**: Kubernaut Architecture Team

--- a/docs/requirements/BR-AUDIT-011-kubernautagent-secret-read-audit.md
+++ b/docs/requirements/BR-AUDIT-011-kubernautagent-secret-read-audit.md
@@ -1,0 +1,60 @@
+# BR-AUDIT-011: KubernautAgent Secret Read Audit (Detective Control)
+
+**Business Requirement ID**: BR-AUDIT-011
+**Category**: KubernautAgent — Security & Compliance
+**Priority**: **P2 (MEDIUM)** — Closes a MEDIUM-severity GA readiness gap
+**Target Version**: **V1.5**
+**Status**: ✅ Implemented
+**Date**: June 30, 2026
+**Related BRs**: BR-AUDIT-005 (Core Audit Business Requirement), BR-SEC-012 (log all secret access attempts), BR-INTERACTIVE-003 (per-request K8s call audit)
+**GitHub Issues**: [#1505](https://github.com/jordigilh/kubernaut/issues/1505) (GAP-13)
+
+---
+
+## Business Need
+
+### Problem Statement
+
+KubernautAgent's autonomous investigator holds broad `get`/`list`/`watch` RBAC on `secrets` (core group), granted deliberately alongside pods/configmaps/events/etc. so that a missing permission never silently degrades root-cause-analysis quality (see [`docs/services/stateless/kubernaut-agent/security-configuration.md`](../services/stateless/kubernaut-agent/security-configuration.md)). Every K8s tool call — including a Secret read via `kubectl_get_by_name`, `kubectl_describe`, `kubectl_get_yaml`, `kubectl_get_by_kind_in_namespace`, etc. — already produced a generic `aiagent.llm.tool_call` audit event, but that event does not distinguish "this tool call touched a Secret" from any other resource read; identifying Secret accesses required parsing the raw `tool_arguments` JSON of every tool-call event after the fact.
+
+This was identified as **GAP-13 (MEDIUM severity)** in the GA Readiness Audit (issue #1505): KubernautAgent's Secret access lacked a dedicated, independently queryable audit trail.
+
+### Decision: Audit-Only, Not RBAC Narrowing
+
+Two options were considered:
+
+1. **Narrow RBAC** — restrict KubernautAgent's ClusterRole so it cannot read `secrets` at all, or only a scoped subset.
+2. **Detective control (chosen)** — keep the existing broad RBAC (preserving investigation completeness) and add a dedicated audit event for every Secret access, so every read is independently reviewable.
+
+Narrowing RBAC was rejected: KubernautAgent frequently needs to inspect Secrets to diagnose issues (e.g. malformed credentials causing a CrashLoopBackOff, expired TLS certs, misconfigured `envFrom` references) and a missing permission produces a *silent* investigation quality regression rather than a visible error. A detective control — auditing every access — achieves the compliance goal (SOC2 CC7.2 change/access review, FedRAMP AU-12 audit generation) without that regression risk.
+
+### Implementation
+
+1. **`aiagent.secret.accessed`** is a new, dedicated audit event type (`internal/kubernautagent/audit/emitter.go`), emitted for every Get/List that the K8s resource resolver resolves to the **core** `secrets` resource — resolved via the `RESTMapper`'s `GroupVersionResource`, not by string-matching the LLM-supplied `kind` argument, so a differently-cased kind string (`"secret"`, `"Secret"`) or an unrelated CRD that happens to be *named* similarly cannot spoof or evade the hook.
+2. **`SecretAccessObserver`** (`pkg/kubernautagent/tools/k8s/resolver.go`) is an optional callback wired into `NewDynamicResolver` via `WithSecretAccessObserver`. It fires on every Get/List against Secrets, success or failure, and is invisible to any of the ~7 tool implementations that route through the resolver — new tools added later automatically get the same detective coverage without additional wiring.
+3. **Correlation**: `session.Manager.launchInvestigation` now sets the investigation's correlation ID on the background context (`audit.WithCorrelationID`), so the observer — running deep inside tool execution with no direct access to the investigation's metadata — can still emit a correctly-correlated event via `audit.CorrelationIDFromContext(ctx)`.
+4. **Redaction unaffected**: the existing `SecretSanitizer` (`pkg/kubernautagent/tools/sanitization/secret.go`) still redacts Secret `data`/`stringData` values in the tool *result* string returned to the LLM and stored on the generic `aiagent.llm.tool_call` event; the new `aiagent.secret.accessed` event never carries the Secret's own data — only verb/namespace/name/outcome.
+5. **Production wiring**: `cmd/kubernautagent/main.go` (`registerK8sTools`, `newSecretAccessObserver`) constructs the observer from the same `audit.AuditStore` already used for every other KubernautAgent audit event, so the event lands in DataStorage identically to `aiagent.llm.tool_call`, `aiagent.session.started`, etc.
+
+---
+
+## Success Criteria
+
+1. Every `dynamicResourceResolver.Get`/`List` call that resolves to the core `Secret` resource invokes the configured `SecretAccessObserver` exactly once, regardless of success/failure — verified by unit tests in `pkg/kubernautagent/tools/k8s/secret_access_observer_test.go`.
+2. Accesses to non-Secret kinds (e.g. `ConfigMap`) never invoke the observer.
+3. `aiagent.secret.accessed` audit events carry `verb` (`get`/`list`), `namespace`, `secret_name` (omitted for list), and `outcome_detail` (error message on failure) — verified in `internal/kubernautagent/audit/secret_access_audit_test.go`.
+4. The investigation's correlation ID (RemediationID) is retrievable from the tool-execution context via `audit.CorrelationIDFromContext`, so every `aiagent.secret.accessed` event is correlated to its parent remediation request per BR-AUDIT-005 (SOC2 CC8.1 reconstruction) — verified in `internal/kubernautagent/session/correlation_id_context_test.go`.
+5. No RBAC change: KubernautAgent's ClusterRole grant on `secrets` is unchanged by this BR.
+
+---
+
+## Related Documents
+
+- [KubernautAgent Security Configuration](../services/stateless/kubernaut-agent/security-configuration.md) — RBAC rationale (broad-by-resource, narrow-by-verb)
+- [DD-AUDIT-003: Service Audit Trace Requirements](../architecture/decisions/DD-AUDIT-003-service-audit-trace-requirements.md)
+
+---
+
+**Document Version**: 1.0
+**Last Updated**: June 30, 2026
+**Maintained By**: Kubernaut Architecture Team

--- a/docs/requirements/BR-SECURITY-1505-distributed-jwt-replay-cache.md
+++ b/docs/requirements/BR-SECURITY-1505-distributed-jwt-replay-cache.md
@@ -1,0 +1,65 @@
+# BR-SECURITY-1505: Distributed JWT Replay Cache (Valkey-backed)
+
+**Business Requirement ID**: BR-SECURITY-1505
+**Category**: API Frontend — Authentication & Security
+**Priority**: **P2 (MEDIUM)** — Closes a MEDIUM-severity GA readiness gap
+**Target Version**: **V1.5**
+**Status**: ✅ Implemented
+**Date**: June 30, 2026
+**GitHub Issues**: [#1505](https://github.com/jordigilh/kubernaut/issues/1505) (GAP-08)
+
+---
+
+## Business Need
+
+### Problem Statement
+
+APIFrontend detects replayed JWTs (a token intercepted and reused after legitimate use) by tracking each token's `jti` claim in a `ReplayCache`. Before this BR, that cache was **in-memory and per-process** (`pkg/apifrontend/auth/replay_cache.go`): each APIFrontend replica maintains its own independent map of seen `jti` values.
+
+This was identified as **GAP-08 (MEDIUM severity)** in the GA Readiness Audit (issue #1505): in a multi-replica deployment (`apifrontend.replicas > 1`, or any HPA-scaled deployment), a token replayed against a *different* replica than the one that first observed it goes undetected — the replay protection silently degrades as replica count grows, without any visible failure.
+
+Separately, `kubernaut-operator`'s `DataStorageConfigMap`-equivalent for APIFrontend already emitted an `auth.replayCache` config block (`backend: redis`, pointing at the cluster's shared Valkey instance) that kubernaut's Go code never consumed — the config contract existed on the operator side with no corresponding implementation.
+
+### Impact Without This BR
+
+- Token replay protection is only as strong as a single replica's uptime and request-routing luck; horizontally scaling APIFrontend for availability directly *weakens* a security control without any indication in logs, metrics, or config validation.
+- `kubernaut-operator`-managed deployments configure a `redis` replay-cache backend that kubernaut's Go code silently ignores (unknown YAML field), giving operators false confidence that distributed replay protection is active.
+
+---
+
+## Decision: Valkey-backed Distributed Cache, Swap-Compatible with the Existing In-Memory Cache
+
+A `ReplayCacheStore` interface (`pkg/apifrontend/auth/replay_cache.go`) now abstracts the replay-detection contract (`MissingJTI`, `Seen`, `Stop`), implemented by both:
+
+1. **`ReplayCache`** (existing, unchanged behavior) — in-memory, single-process. Still the default when no distributed backend is configured, preserving backward compatibility for single-replica and dev/test deployments.
+2. **`ValkeyReplayCache`** (new) — backed by the cluster's shared Valkey/Redis instance (the same instance and Secret already used by DataStorage), using atomic `SET ... NX EX <ttl>` semantics so a single round-trip both checks and marks a `jti`, avoiding a race between two replicas processing the same replayed token near-simultaneously.
+
+Key design choices:
+
+1. **Config-driven backend selection** (`auth.replayCache.backend`: `redis`/`valkey`/`memory`/unset), mirroring the `afReplayCacheYAML` contract already emitted by `kubernaut-operator`, so the same config shape works whether APIFrontend is Helm-managed or operator-managed.
+2. **Fail-open with logged degradation, not fail-closed**: if Valkey is unreachable at startup, APIFrontend falls back to the in-memory cache rather than refusing to start — replay detection is defense-in-depth layered on top of signature/expiry/audience/issuer validation, not the sole authentication control, so a Valkey outage should degrade a secondary control, not take down authentication entirely. The same fail-open behavior applies per-request: if a `SETNX` call to Valkey errors after startup, that single check is treated as "not seen" (allowed) and logged, rather than blocking the request.
+3. **Backward compatible**: the legacy `auth.enableReplayProtection: true` boolean continues to select the in-memory cache when no `auth.replayCache` block is present.
+4. **Reuses existing infrastructure**: no new Secret, Valkey instance, or Helm value beyond an `enabled` flag — the distributed cache uses the same `valkey.existingSecret`/`valkey-secret` and shared Valkey address already deployed for DataStorage.
+
+---
+
+## Success Criteria
+
+1. `ReplayCacheStore` interface allows `JWTValidator` to remain agnostic to the backing store; existing callers using the in-memory `*ReplayCache` are unaffected (interface satisfied without changes).
+2. `ValkeyReplayCache.Seen()` correctly detects a replay across two independent `redis.Client` instances pointed at the same Valkey instance (simulating two APIFrontend replicas).
+3. A Valkey outage at startup falls back to the in-memory cache (logged), rather than failing APIFrontend startup or silently disabling replay protection.
+4. A Valkey outage at request time fails open (request allowed, logged) rather than blocking authenticated traffic.
+5. `auth.replayCache` config validation rejects an unknown backend and a `redis`/`valkey` backend missing `redisAddr`.
+6. Helm: `apifrontend.config.auth.replayCache.enabled=true` wires the ConfigMap block and mounts the existing shared Valkey secret; disabled by default (backward compatible, matches pre-GAP-08 behavior for single-replica/dev deployments).
+
+---
+
+## Related Documents
+
+- [Kubernaut Helm Chart README — Optional: Distributed JWT Replay Cache](../../charts/kubernaut/README.md#optional-distributed-jwt-replay-cache-gap-08)
+
+---
+
+**Document Version**: 1.0
+**Last Updated**: June 30, 2026
+**Maintained By**: Kubernaut Architecture Team

--- a/docs/requirements/BR-STORAGE-1505-datastorage-per-ip-ratelimit.md
+++ b/docs/requirements/BR-STORAGE-1505-datastorage-per-ip-ratelimit.md
@@ -1,0 +1,65 @@
+# BR-STORAGE-1505: Data Storage Per-IP Rate Limiting
+
+**Business Requirement ID**: BR-STORAGE-1505
+**Category**: Data Storage Service — Security & Availability
+**Priority**: **P2 (MEDIUM)** — Closes a MEDIUM-severity GA readiness gap
+**Target Version**: **V1.5**
+**Status**: ✅ Implemented
+**Date**: June 30, 2026
+**GitHub Issues**: [#1505](https://github.com/jordigilh/kubernaut/issues/1505) (GAP-09)
+
+---
+
+## Business Need
+
+### Problem Statement
+
+The Data Storage HTTP API (`pkg/datastorage/server`) had no in-process request-rate control: any single client — a misbehaving internal caller, a compromised service account, or an external actor that reached the API — could send an unbounded volume of requests, competing for goroutines, database connections, and CPU with legitimate traffic from Gateway, KubernautAgent, APIFrontend, and the reconciler-driven audit write path.
+
+This was identified as **GAP-09 (MEDIUM severity)** in the GA Readiness Audit (issue #1505): DataStorage was the only core service without a rate-limiting control comparable to APIFrontend's existing per-IP/per-user limiter (`pkg/apifrontend/ratelimit`).
+
+### Impact Without This BR
+
+- **FedRAMP SC-5** (Denial of Service Protection) relies entirely on infrastructure external to the service (ingress/proxy rate limiting), which may not be present in every deployment topology (e.g. direct in-cluster ClusterIP access from other services, bypassing an ingress).
+- No audit trail exists for rate-limit denials at the DS layer, so a sustained flood against DataStorage would not be independently observable via its own audit trail (**FedRAMP AU-12**: audit generation for security-relevant events).
+
+---
+
+## Decision: In-Process Per-IP Token Bucket, Opt-In and Self-Audited
+
+A per-IP token-bucket rate limiter (`pkg/datastorage/server/middleware.IPLimiter`, modeled on the existing `pkg/apifrontend/ratelimit.IPLimiter` pattern) is applied as Chi middleware, placed **before** authentication in the middleware chain so an unauthenticated flood does not reach TokenReview/SubjectAccessReview calls.
+
+Key design choices:
+
+1. **Opt-in, disabled by default** (`datastorage.config.server.rateLimit.enabled: false`): existing deployments that already rate limit at an ingress/proxy layer are unaffected on upgrade. Operators without that external control can enable this in-process backstop.
+2. **Per-IP, not global**: each client IP gets an independent token bucket (default: 50 req/s sustained, burst 100), so one noisy client cannot exhaust the shared bucket for all others — the same pattern already proven in APIFrontend's `IPLimiter`.
+3. **Self-audited denials**: every denial emits a `datastorage.ratelimit.denied` audit event (new `event_category: security` — the first DS event not tied to a single business domain) via DataStorage's existing internal self-audit path (`InternalAuditClient`, bypassing HTTP/its own REST API to avoid a circular dependency), so a sustained flood is independently reconstructable from the audit trail (FedRAMP AU-12, SOC2 CC8.1).
+4. **RFC 7807 429 response** with a `Retry-After` header, consistent with existing DataStorage error response conventions (`WriteMaxBytesExceeded`, `response.WriteRFC7807Error`).
+5. **New `security` event category** added to the shared `event_category` enum (`api/openapi/data-storage-v1.yaml`): existing categories (`gateway`, `workflow`, `actiontype`, etc.) are all owned by a specific business domain; a pre-auth rate-limit denial has no such domain (the request never reached a handler), so it is classified under a new cross-cutting `security` category rather than forcing it into an unrelated domain category.
+
+### Why Not Reuse the Existing AIAgent/APIFrontend Rate-Limit Audit Payloads?
+
+`AIAgentRatelimitDeniedPayload` (`aiagent.ratelimit.denied`) and `ApifrontendRatelimitDeniedPayload` (`apifrontend.ratelimit.denied`) already exist in the shared OpenAPI schema, but their `event_type` discriminator values are hardcoded to their respective services. Reusing either for DataStorage's own denials would mislabel the emitting service in the audit trail. A new `DatastorageRatelimitDeniedPayload` (`datastorage.ratelimit.denied`) was added instead, mirroring the `AIAgentRatelimitDeniedPayload` shape (`event_id`, `source_ip`, `path`, `method`) for consistency.
+
+---
+
+## Success Criteria
+
+1. `IPLimiter.Allow()` enforces an independent token bucket per client IP; exceeding the burst denies further requests until the bucket refills.
+2. `IPRateLimitMiddleware` returns HTTP 429 with a `Retry-After` header and an RFC 7807 `application/problem+json` body when the limit is exceeded, and passes requests through unmodified otherwise.
+3. Every denial invokes the configured `AuditFunc` exactly once (non-blocking, does not delay the 429 response).
+4. `NewRatelimitDeniedAuditEvent` produces a valid `AuditEventRequest` (non-empty `correlation_id` per OpenAPI `minLength: 1`, category `security`, outcome `failure`) with a typed `DatastorageRatelimitDeniedPayload`.
+5. Disabled by default (`datastorage.config.server.rateLimit.enabled: false`): no behavior change for existing deployments on upgrade.
+6. Helm: `datastorage.config.server.rateLimit.enabled=true` wires `requestsPerSecond`/`burst` into the DataStorage ConfigMap.
+
+---
+
+## Related Documents
+
+- [Kubernaut Helm Chart README — Optional: Data Storage Per-IP Rate Limiting](../../charts/kubernaut/README.md#optional-data-storage-per-ip-rate-limiting-gap-09)
+
+---
+
+**Document Version**: 1.0
+**Last Updated**: June 30, 2026
+**Maintained By**: Kubernaut Architecture Team

--- a/docs/requirements/BR-WE-018-execution-pod-security-hardening.md
+++ b/docs/requirements/BR-WE-018-execution-pod-security-hardening.md
@@ -1,0 +1,104 @@
+# BR-WE-018: Execution Pod Security Hardening
+
+**Business Requirement ID**: BR-WE-018
+**Category**: Workflow Execution Service — Security & Compliance
+**Priority**: **P1 (HIGH)** — Closes a HIGH-severity GA readiness gap
+**Target Version**: **V1.5**
+**Status**: ✅ Implemented
+**Date**: June 30, 2026
+**Related ADRs**: None
+**Related BRs**: BR-WE-014 (Kubernetes Job Execution Backend)
+**GitHub Issues**: [#1505](https://github.com/jordigilh/kubernaut/issues/1505) (GAP-03)
+
+---
+
+## Business Need
+
+### Problem Statement
+
+The WorkflowExecution (WE) controller's own pod runs under a restricted `SecurityContext` (`runAsNonRoot`, `seccompProfile: RuntimeDefault`, `readOnlyRootFilesystem`, dropped capabilities — see `docs/services/crd-controllers/03-workflowexecution/security-configuration.md`). However, the pods the controller *spawns* to actually execute remediation workflows — Kubernetes Jobs (`JobExecutor.buildJob`) and Tekton PipelineRuns (`TektonExecutor.BuildPipelineRun`) — set no `SecurityContext` at all. This is an inconsistency: the component doing the actual remediation work (with cluster-write RBAC) is less hardened than the controller orchestrating it.
+
+This was identified as **GAP-03 (HIGH severity)** in the GA Readiness Audit (issue #1505).
+
+### Impact Without This BR
+
+- Spawned execution pods can run as root, with privilege escalation allowed, a writable root filesystem, and the full default Linux capability set — a materially larger attack surface than necessary for a pod that exists only to apply a Kubernetes patch or run a scripted remediation step.
+- Inconsistent with **FedRAMP AC-6** (Least Privilege) and **CM-7** (Least Functionality): the system does not uniformly enforce minimal privilege across all pods it creates.
+- A compromised or malicious workflow image (supply-chain risk, complementary to GAP-01's image-signing work) has more room to escalate or persist if the pod it runs in is unrestricted.
+
+---
+
+## Decision: Hardcoded Restricted Profile (No Configurability)
+
+**All spawned Job and Tekton execution pods are unconditionally hardened to the Kubernetes "restricted" Pod Security Standard.** There is no CRD field or other mechanism to opt out to a relaxed ("baseline") profile.
+
+This was a deliberate choice, not an oversight:
+
+1. **No demonstrated need**: existing workflow catalog images already run as non-root (`USER 1001`, see `test/fixtures/workflows/*/Dockerfile`) and do no filesystem writes outside of scratch space. Adding an unused escape-hatch field would be speculative (YAGNI) per the Go Anti-Pattern Checklist.
+2. **AI-driven CR creation risk**: `WorkflowExecution` specs are populated by an AI/LLM-driven selection pipeline. A configurable `securityProfile` field would be a lever a compromised or malicious workflow/prompt-injection could manipulate to escape the restricted sandbox. Removing the field entirely closes that vector — any future change to pod hardening requires a reviewed code change (PR), not a runtime configuration value.
+3. **Simpler compliance posture**: a fixed, code-enforced profile is materially easier to assess for FedRAMP/SOC2 than a configurable one, which would require verifying configuration state in every environment rather than verifying a single code path once.
+
+### Asymmetric Hardening: Job vs. Tekton
+
+| Backend | Pod-level `SecurityContext` | Container-level `SecurityContext` |
+|---|---|---|
+| Kubernetes Job | ✅ Applied | ✅ Applied |
+| Tekton PipelineRun | ✅ Applied (via `TaskRunTemplate.PodTemplate.SecurityContext`) | ❌ Not applicable |
+
+This asymmetry is an accepted, API-level constraint, not a gap: Tekton's `PipelineRunSpec.TaskRunTemplate.PodTemplate` (`github.com/tektoncd/pipeline/pkg/apis/pipeline/pod.PodTemplate`, v1.13.1) exposes only `SecurityContext *corev1.PodSecurityContext` (pod-level). Container-level settings belong to the `Task` spec resolved from the OCI bundle at execution time, which is outside the WE controller's authoring control. Pod-level hardening (`runAsNonRoot`, `seccompProfile: RuntimeDefault`) is still enforced for Tekton-executed workflows.
+
+### Restricted Profile Applied
+
+Pod-level (`Job` + `Tekton`):
+- `runAsNonRoot: true`
+- `seccompProfile.type: RuntimeDefault`
+
+Container-level (`Job` only — the `"workflow"` container):
+- `allowPrivilegeEscalation: false`
+- `readOnlyRootFilesystem: true`
+- `runAsNonRoot: true`
+- `capabilities.drop: [ALL]`
+
+A `tmp` `emptyDir` volume is mounted at `/tmp` (with `HOME=/tmp`, `TMPDIR=/tmp`) on the Job container so tools that expect writable scratch space (e.g. `kubectl`'s discovery cache) continue to function under `readOnlyRootFilesystem: true`.
+
+This mirrors the existing `kubernaut.podSecurityContext` / `kubernaut.containerSecurityContext` Helm helpers (`charts/kubernaut/templates/_helpers.tpl`) already applied to the WE controller's own pod, so the spawned-pod profile is consistent with the controller's own posture.
+
+---
+
+## Defense in Depth: Pod Security Admission Backstop
+
+In addition to the controller authoring the `SecurityContext` in code, the `kubernaut-workflows` namespace is labeled with the Kubernetes built-in Pod Security Admission (PSA) `restricted` standard:
+
+```yaml
+labels:
+  pod-security.kubernetes.io/enforce: restricted
+  pod-security.kubernetes.io/audit: restricted
+  pod-security.kubernetes.io/warn: restricted
+```
+
+Since every pod built per this BR already satisfies `restricted`, this is a no-op under normal operation. Its purpose is to provide an independent, API-server-enforced backstop: even if a future code change in `buildJob`/`BuildPipelineRun` regressed the `SecurityContext`, the API server would still reject the resulting pod at admission time, rather than relying solely on the correctness of the Go code path.
+
+This same hardening is tracked as a follow-up for the `kubernaut-operator` repository (which constructs its own `Namespace` object independently of this Helm chart), targeted for milestone v1.6.
+
+---
+
+## Success Criteria
+
+1. `JobExecutor.buildJob()` sets the documented pod-level and container-level `SecurityContext`, plus the `/tmp` scratch volume and `HOME`/`TMPDIR` env vars.
+2. `TektonExecutor.BuildPipelineRun()` sets the documented pod-level `SecurityContext` via `TaskRunTemplate.PodTemplate`.
+3. The `kubernaut-workflows` Namespace (Helm-managed) carries the PSA `restricted` labels.
+4. Unit tests assert the exact `SecurityContext` field values for both backends (no `BeNil()`/`BeEmpty()`-style weak assertions, per `.golangci.yml` `forbidigo` guidance).
+5. FedRAMP/SOC2 control mapping: **AC-6** (Least Privilege), **CM-7** (Least Functionality) — both satisfied by a structural (code-enforced + admission-enforced), non-configurable guarantee.
+
+---
+
+## Related Documents
+
+- [BR-WE-014: Kubernetes Job Execution Backend](./BR-WE-014-kubernetes-job-execution-backend.md)
+- [WorkflowExecution Security Configuration](../services/crd-controllers/03-workflowexecution/security-configuration.md)
+
+---
+
+**Document Version**: 1.0
+**Last Updated**: June 30, 2026
+**Maintained By**: Kubernaut Architecture Team

--- a/docs/services/crd-controllers/03-workflowexecution/security-configuration.md
+++ b/docs/services/crd-controllers/03-workflowexecution/security-configuration.md
@@ -1,13 +1,16 @@
 ## Security Configuration
 
-**Version**: 4.2
-**Last Updated**: 2026-03-21
+**Version**: 4.3
+**Last Updated**: 2026-06-30
 **CRD API Group**: `kubernaut.ai/v1alpha1`
-**Status**: ✅ Updated for Dedicated Execution Namespace (DD-WE-002) and per-workflow ServiceAccounts (DD-WE-005 v2.0)
+**Status**: ✅ Updated for Dedicated Execution Namespace (DD-WE-002), per-workflow ServiceAccounts (DD-WE-005 v2.0), and spawned execution pod hardening (BR-WE-018)
 
 ---
 
 ## Changelog
+
+### Version 4.3 (2026-06-30)
+- ✅ **BR-WE-018** (GitHub #1505 GAP-03): Spawned Job/Tekton execution pods now carry a restricted `SecurityContext`, plus a Pod Security Admission backstop on the `kubernaut-workflows` namespace. See [Spawned Execution Pod Security Context](#spawned-execution-pod-security-context-br-we-018).
 
 ### Version 4.2 (2026-03-21)
 - ✅ **DD-WE-005 v2.0**: PipelineRun execution uses operator-managed **per-workflow** ServiceAccounts referenced from the workflow schema (`serviceAccountName`). Kubernaut no longer ships a platform-managed runner SA via Helm. If no SA is set, Kubernetes uses the execution namespace’s default ServiceAccount.
@@ -611,5 +614,72 @@ spec:
 - **drop ALL capabilities**: Minimal Linux capabilities
 - **seccompProfile**: Syscall filtering for defense-in-depth
 - **emptyDir volumes**: Writable directories for tmp files only
+
+---
+
+### Spawned Execution Pod Security Context (BR-WE-018)
+
+The section above hardens the **WE controller's own pod**. This section covers the pods the controller *spawns* to execute remediation workflows — Kubernetes Jobs (`JobExecutor.buildJob`) and Tekton PipelineRuns (`TektonExecutor.BuildPipelineRun`) — which carry the same restricted profile as of **BR-WE-018** (closing GAP-03 from the GA Readiness Audit, [#1505](https://github.com/jordigilh/kubernaut/issues/1505)).
+
+**This profile is intentionally non-configurable.** There is no CRD field to relax it to a "baseline" profile. See [BR-WE-018](../../../requirements/BR-WE-018-execution-pod-security-hardening.md) for the full rationale, including why a configurable escape hatch was deliberately rejected (an AI/LLM-driven `WorkflowExecution` creation pipeline should not have a runtime lever to weaken pod hardening).
+
+**Kubernetes Job** (`pkg/workflowexecution/executor/job.go`):
+
+```yaml
+spec:
+  template:
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - name: workflow
+        securityContext:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+          runAsNonRoot: true
+          capabilities:
+            drop: ["ALL"]
+        env:
+        - name: HOME
+          value: /tmp
+        - name: TMPDIR
+          value: /tmp
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
+      volumes:
+      - name: tmp
+        emptyDir: {}
+```
+
+The `tmp` `emptyDir` volume (mounted at `/tmp`, with `HOME`/`TMPDIR` pointed at it) provides writable scratch space so tools like `kubectl` — which expect to write a discovery cache under `$HOME` — keep working under `readOnlyRootFilesystem: true`.
+
+**Tekton PipelineRun** (`pkg/workflowexecution/executor/tekton.go`) — **pod-level only**:
+
+```yaml
+spec:
+  taskRunTemplate:
+    podTemplate:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+```
+
+**Asymmetric hardening — why Tekton has no container-level settings**: Tekton's `PipelineRunSpec.TaskRunTemplate.PodTemplate` (`github.com/tektoncd/pipeline/pkg/apis/pipeline/pod.PodTemplate`) exposes only a pod-level `SecurityContext`. Container-level settings (`allowPrivilegeEscalation`, `readOnlyRootFilesystem`, capabilities) belong to the `Task` spec resolved from the OCI bundle at execution time — outside the WE controller's authoring control. This is an accepted, API-level constraint, not a gap.
+
+**Defense in depth — Pod Security Admission backstop**: the `kubernaut-workflows` namespace (Helm-managed, `charts/kubernaut/templates/workflowexecution/workflowexecution.yaml`) carries the Kubernetes built-in Pod Security Admission `restricted` labels:
+
+```yaml
+metadata:
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+```
+
+Since every pod built above already satisfies `restricted`, this is a no-op under normal operation — it exists purely as an independent, API-server-enforced backstop in case the controller's `SecurityContext`-authoring code ever regresses. The same hardening is tracked for the `kubernaut-operator` repository (which builds its own `Namespace` object independently) under milestone v1.6.
 
 ---

--- a/docs/services/stateless/kubernaut-agent/security-configuration.md
+++ b/docs/services/stateless/kubernaut-agent/security-configuration.md
@@ -62,6 +62,7 @@ Binds `kubernaut-agent-investigator` to `kubernaut-agent-sa`.
 - **Least privilege**: Read-only verbs for workload resources; write access limited to `events` for investigation lifecycle tracking
 - **Dynamic client awareness**: The LLM may request any resource kind via `kubectl_*` tools — missing RBAC causes degraded RCA quality (silent tool failures)
 - **Explicit exclusions**: RBAC enumeration (`rbac.authorization.k8s.io/*`) is intentionally excluded for security; `leases`, `limitranges`, `priorityclasses` excluded for low investigation value
+- **Secrets — detective control, not RBAC narrowing** (BR-AUDIT-011, GAP-13, Issue #1505): the broad `secrets` grant above is deliberately *not* narrowed, since a missing permission degrades RCA quality silently. Instead, every Get/List that resolves to the core `Secret` resource emits a dedicated `aiagent.secret.accessed` audit event (verb, namespace, secret name, outcome), independent of the generic `aiagent.llm.tool_call` event already emitted for every tool call — see [BR-AUDIT-011](../../../requirements/BR-AUDIT-011-kubernautagent-secret-read-audit.md).
 
 ---
 

--- a/internal/controller/effectivenessmonitor/reconciler.go
+++ b/internal/controller/effectivenessmonitor/reconciler.go
@@ -168,6 +168,13 @@ func NewReconciler(
 	}
 }
 
+// +kubebuilder:rbac:groups=kubernaut.ai,resources=effectivenessassessments,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=kubernaut.ai,resources=effectivenessassessments/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get
+// +kubebuilder:rbac:groups="",resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=apps,resources=deployments;replicasets;statefulsets;daemonsets,verbs=get;list;watch
+
 // Reconcile handles a single reconciliation of an EffectivenessAssessment.
 // This is the main entry point called by controller-runtime. Steps 1-2 run here;
 // the active reconciliation flow is delegated to reconcileActive (reconcile_orchestrate.go).

--- a/internal/kubernautagent/audit/ds_store.go
+++ b/internal/kubernautagent/audit/ds_store.go
@@ -89,12 +89,12 @@ func buildEventData(event *AuditEvent) (ogenclient.AuditEventRequestEventData, b
 	switch event.EventType {
 	case EventTypeEnrichmentCompleted:
 		payload := ogenclient.AIAgentEnrichmentCompletedPayload{
-			EventType:  ogenclient.AIAgentEnrichmentCompletedPayloadEventTypeAiagentEnrichmentCompleted,
-			EventID:    dataString(event.Data, "event_id"),
-			IncidentID: dataString(event.Data, "incident_id"),
-			RootOwnerKind:   dataString(event.Data, "root_owner_kind"),
-			RootOwnerName:   dataString(event.Data, "root_owner_name"),
-			OwnerChainLength: dataInt(event.Data, "owner_chain_length"),
+			EventType:                 ogenclient.AIAgentEnrichmentCompletedPayloadEventTypeAiagentEnrichmentCompleted,
+			EventID:                   dataString(event.Data, "event_id"),
+			IncidentID:                dataString(event.Data, "incident_id"),
+			RootOwnerKind:             dataString(event.Data, "root_owner_kind"),
+			RootOwnerName:             dataString(event.Data, "root_owner_name"),
+			OwnerChainLength:          dataInt(event.Data, "owner_chain_length"),
 			RemediationHistoryFetched: dataBool(event.Data, "remediation_history_fetched"),
 		}
 		if ns := dataString(event.Data, "root_owner_namespace"); ns != "" {
@@ -104,11 +104,11 @@ func buildEventData(event *AuditEvent) (ogenclient.AuditEventRequestEventData, b
 
 	case EventTypeEnrichmentFailed:
 		payload := ogenclient.AIAgentEnrichmentFailedPayload{
-			EventType:  ogenclient.AIAgentEnrichmentFailedPayloadEventTypeAiagentEnrichmentFailed,
-			EventID:    dataString(event.Data, "event_id"),
-			IncidentID: dataString(event.Data, "incident_id"),
-			Reason:     dataString(event.Data, "reason"),
-			Detail:     dataString(event.Data, "detail"),
+			EventType:            ogenclient.AIAgentEnrichmentFailedPayloadEventTypeAiagentEnrichmentFailed,
+			EventID:              dataString(event.Data, "event_id"),
+			IncidentID:           dataString(event.Data, "incident_id"),
+			Reason:               dataString(event.Data, "reason"),
+			Detail:               dataString(event.Data, "detail"),
 			AffectedResourceKind: dataString(event.Data, "affected_resource_kind"),
 			AffectedResourceName: dataString(event.Data, "affected_resource_name"),
 		}
@@ -429,6 +429,30 @@ func buildEventData(event *AuditEvent) (ogenclient.AuditEventRequestEventData, b
 		}
 		return ogenclient.NewAIAgentInteractiveK8sCallPayloadAuditEventRequestEventData(payload), true
 
+	case EventTypeSecretAccessed:
+		verb := ogenclient.AIAgentSecretAccessedPayloadVerbGet
+		if dataString(event.Data, "verb") == "list" {
+			verb = ogenclient.AIAgentSecretAccessedPayloadVerbList
+		}
+		payload := ogenclient.AIAgentSecretAccessedPayload{
+			EventType: ogenclient.AIAgentSecretAccessedPayloadEventTypeAiagentSecretAccessed,
+			EventID:   dataString(event.Data, "event_id"),
+			Verb:      verb,
+		}
+		if ns := dataString(event.Data, "namespace"); ns != "" {
+			payload.Namespace.SetTo(ns)
+		}
+		if name := dataString(event.Data, "secret_name"); name != "" {
+			payload.SecretName.SetTo(name)
+		}
+		if toolName := dataString(event.Data, "tool_name"); toolName != "" {
+			payload.ToolName.SetTo(toolName)
+		}
+		if detail := dataString(event.Data, "outcome_detail"); detail != "" {
+			payload.OutcomeDetail.SetTo(detail)
+		}
+		return ogenclient.NewAIAgentSecretAccessedPayloadAuditEventRequestEventData(payload), true
+
 	case EventTypeShadowLLMRequest:
 		payload := ogenclient.ShadowLLMRequestPayload{
 			EventType:    ogenclient.ShadowLLMRequestPayloadEventTypeAiagentShadowLlmRequest,
@@ -604,20 +628,20 @@ func toJxRawMap(s string) ogenclient.LLMToolCallPayloadToolArguments {
 }
 
 type investigationResultJSON struct {
-	RCASummary           string                       `json:"rca_summary"`
-	Severity             string                       `json:"severity"`
-	ContributingFactors  []string                     `json:"contributing_factors"`
-	WorkflowID           string                       `json:"workflow_id"`
-	ExecutionBundle      string                       `json:"execution_bundle"`
-	Confidence           float64                      `json:"confidence"`
-	NeedsHumanReview     bool                         `json:"needs_human_review"`
-	HumanReviewReason    string                       `json:"human_review_reason"`
-	Warnings             []string                     `json:"warnings"`
-	Parameters           map[string]interface{}        `json:"parameters"`
-	AlternativeWorkflows []altWorkflowJSON            `json:"alternative_workflows"`
-	RemediationTarget    *remediationTargetJSON       `json:"remediation_target"`
-	CausalChain          []string                     `json:"causal_chain"`
-	DueDiligence         *dueDiligenceJSON            `json:"due_diligence"`
+	RCASummary           string                 `json:"rca_summary"`
+	Severity             string                 `json:"severity"`
+	ContributingFactors  []string               `json:"contributing_factors"`
+	WorkflowID           string                 `json:"workflow_id"`
+	ExecutionBundle      string                 `json:"execution_bundle"`
+	Confidence           float64                `json:"confidence"`
+	NeedsHumanReview     bool                   `json:"needs_human_review"`
+	HumanReviewReason    string                 `json:"human_review_reason"`
+	Warnings             []string               `json:"warnings"`
+	Parameters           map[string]interface{} `json:"parameters"`
+	AlternativeWorkflows []altWorkflowJSON      `json:"alternative_workflows"`
+	RemediationTarget    *remediationTargetJSON `json:"remediation_target"`
+	CausalChain          []string               `json:"causal_chain"`
+	DueDiligence         *dueDiligenceJSON      `json:"due_diligence"`
 }
 
 type dueDiligenceJSON struct {
@@ -659,8 +683,8 @@ func toIncidentResponseData(responseDataJSON string, incidentID string) ogenclie
 		Confidence: float32(ir.Confidence),
 		Timestamp:  time.Now().UTC(),
 		RootCauseAnalysis: ogenclient.IncidentResponseDataRootCauseAnalysis{
-			Summary:            ir.RCASummary,
-			Severity:           mapSeverity(ir.Severity),
+			Summary:             ir.RCASummary,
+			Severity:            mapSeverity(ir.Severity),
 			ContributingFactors: ir.ContributingFactors,
 		},
 	}
@@ -790,7 +814,7 @@ var validHumanReviewReasons = map[string]ogenclient.IncidentResponseDataHumanRev
 	"llm_parsing_error":           ogenclient.IncidentResponseDataHumanReviewReasonLlmParsingError,
 	"investigation_inconclusive":  ogenclient.IncidentResponseDataHumanReviewReasonInvestigationInconclusive,
 	"rca_incomplete":              ogenclient.IncidentResponseDataHumanReviewReasonRcaIncomplete,
-	"alignment_check_failed": ogenclient.IncidentResponseDataHumanReviewReasonAlignmentCheckFailed,
+	"alignment_check_failed":      ogenclient.IncidentResponseDataHumanReviewReasonAlignmentCheckFailed,
 }
 
 // validHumanReviewReason returns the ogen enum value if the string is a recognised

--- a/internal/kubernautagent/audit/emitter.go
+++ b/internal/kubernautagent/audit/emitter.go
@@ -93,45 +93,57 @@ const (
 	EventTypeShadowLLMRequest  = "aiagent.shadow.llm.request"
 	EventTypeShadowLLMResponse = "aiagent.shadow.llm.response"
 
-	EventTypeAuthFailure      = "aiagent.auth.failure"
-	EventTypeAuthDenied       = "aiagent.auth.denied"
-	EventTypeRateLimitDenied  = "aiagent.ratelimit.denied"
+	EventTypeAuthFailure     = "aiagent.auth.failure"
+	EventTypeAuthDenied      = "aiagent.auth.denied"
+	EventTypeRateLimitDenied = "aiagent.ratelimit.denied"
+
+	// EventTypeSecretAccessed is emitted every time KubernautAgent's K8s
+	// resource resolver reads a core Secret (Get or List), regardless of
+	// outcome (GAP-13, Issue #1505). KubernautAgent intentionally retains
+	// broad read RBAC on Secrets for investigation completeness (see
+	// docs/services/stateless/kubernaut-agent/security-configuration.md);
+	// this event is the detective control that compensates for not
+	// narrowing that RBAC — every Secret read is independently queryable
+	// for SOC2 CC7.2 / FedRAMP AU-12 review, separate from the generic
+	// aiagent.llm.tool_call event already emitted for every tool call.
+	EventTypeSecretAccessed = "aiagent.secret.accessed"
 )
 
 const (
-	ActionLLMRequest        = "llm_request"
-	ActionLLMResponse       = "llm_response"
-	ActionToolExecution     = "tool_execution"
-	ActionValidation        = "validation"
-	ActionResponseSent      = "response_sent"
-	ActionResponseFailed    = "response_failed"
-	ActionAlignmentEvaluate          = "alignment_evaluate"
-	ActionAlignmentVerdict           = "alignment_verdict"
-	ActionSameKindGate               = "same_kind_validation_gate"
-	ActionAPIVersionGate             = "api_version_validation_gate"
-	ActionWorkflowAlignmentGate      = "workflow_target_alignment_gate"
-	ActionShadowLLMRequest           = "shadow_llm_request"
-	ActionShadowLLMResponse          = "shadow_llm_response"
-	ActionGroundingRequest           = "grounding_request"
-	ActionGroundingResponse          = "grounding_response"
-	ActionTruncationDetected         = "truncation_detected"
-	ActionEnriched                   = "enriched"
+	ActionLLMRequest            = "llm_request"
+	ActionLLMResponse           = "llm_response"
+	ActionToolExecution         = "tool_execution"
+	ActionValidation            = "validation"
+	ActionResponseSent          = "response_sent"
+	ActionResponseFailed        = "response_failed"
+	ActionAlignmentEvaluate     = "alignment_evaluate"
+	ActionAlignmentVerdict      = "alignment_verdict"
+	ActionSameKindGate          = "same_kind_validation_gate"
+	ActionAPIVersionGate        = "api_version_validation_gate"
+	ActionWorkflowAlignmentGate = "workflow_target_alignment_gate"
+	ActionShadowLLMRequest      = "shadow_llm_request"
+	ActionShadowLLMResponse     = "shadow_llm_response"
+	ActionGroundingRequest      = "grounding_request"
+	ActionGroundingResponse     = "grounding_response"
+	ActionTruncationDetected    = "truncation_detected"
+	ActionEnriched              = "enriched"
 
-	ActionSessionStarted        = "session_started"
-	ActionSessionCancelled      = "session_cancelled"
-	ActionSessionCompleted      = "session_completed"
-	ActionSessionFailed         = "session_failed"
+	ActionSessionStarted         = "session_started"
+	ActionSessionCancelled       = "session_cancelled"
+	ActionSessionCompleted       = "session_completed"
+	ActionSessionFailed          = "session_failed"
 	ActionInvestigationCancelled = "investigation_cancelled"
-	ActionSessionObserved       = "session_observed"
-	ActionSessionAccessDenied   = "session_access_denied"
-	ActionSessionSuspended      = "session_suspended"
-	ActionInteractiveStarted    = "interactive_started"
-	ActionInteractiveCompleted  = "interactive_completed"
-	ActionSessionResumed        = "session_resumed"
-	ActionInteractiveK8sCall    = "interactive_k8s_call"
-	ActionAuthFailure           = "auth_failure"
-	ActionAuthDenied            = "auth_denied"
-	ActionRateLimitDenied       = "ratelimit_denied"
+	ActionSessionObserved        = "session_observed"
+	ActionSessionAccessDenied    = "session_access_denied"
+	ActionSessionSuspended       = "session_suspended"
+	ActionInteractiveStarted     = "interactive_started"
+	ActionInteractiveCompleted   = "interactive_completed"
+	ActionSessionResumed         = "session_resumed"
+	ActionInteractiveK8sCall     = "interactive_k8s_call"
+	ActionAuthFailure            = "auth_failure"
+	ActionAuthDenied             = "auth_denied"
+	ActionRateLimitDenied        = "ratelimit_denied"
+	ActionSecretAccessed         = "secret_accessed"
 )
 
 const (
@@ -172,6 +184,7 @@ var AllEventTypes = []string{
 	EventTypeAuthFailure,
 	EventTypeAuthDenied,
 	EventTypeRateLimitDenied,
+	EventTypeSecretAccessed,
 }
 
 // AuditEvent represents an audit event to be stored.
@@ -251,6 +264,29 @@ func WithClusterName(ctx context.Context, clusterName string) context.Context {
 // ClusterNameFromContext extracts the cluster name from the context.
 func ClusterNameFromContext(ctx context.Context) (string, bool) {
 	v, ok := ctx.Value(clusterNameContextKey{}).(string)
+	return v, ok
+}
+
+type correlationIDContextKey struct{}
+
+// WithCorrelationID returns a context carrying the investigation's
+// correlation ID (typically the RemediationRequest name/RemediationID).
+// Set once per investigation in session.Manager.launchInvestigation, it lets
+// deep call sites — e.g. the K8s resource resolver's secret-access observer
+// (GAP-13, Issue #1505) — emit correctly-correlated audit events without
+// threading correlationID through every function signature down to the tool
+// layer.
+func WithCorrelationID(ctx context.Context, correlationID string) context.Context {
+	if correlationID == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, correlationIDContextKey{}, correlationID)
+}
+
+// CorrelationIDFromContext extracts the investigation correlation ID set by
+// WithCorrelationID.
+func CorrelationIDFromContext(ctx context.Context) (string, bool) {
+	v, ok := ctx.Value(correlationIDContextKey{}).(string)
 	return v, ok
 }
 

--- a/internal/kubernautagent/audit/emitter_test.go
+++ b/internal/kubernautagent/audit/emitter_test.go
@@ -66,8 +66,8 @@ var _ = Describe("Kubernaut Agent Audit Emitter — #433", func() {
 			Entry("aiagent.shadow.llm.response", audit.EventTypeShadowLLMResponse),
 		)
 
-		It("should define exactly 30 event types", func() {
-			Expect(audit.AllEventTypes).To(HaveLen(30))
+		It("should define exactly 31 event types", func() {
+			Expect(audit.AllEventTypes).To(HaveLen(31))
 		})
 
 		It("should include aiagent.rca.complete in AllEventTypes", func() {
@@ -344,6 +344,26 @@ var _ = Describe("Kubernaut Agent Audit Emitter — #433", func() {
 			Expect(store.events).To(HaveLen(1))
 			Expect(store.events[0].ClusterName).To(BeEmpty(),
 				"Single-cluster scenario: ClusterName must remain empty")
+		})
+	})
+
+	Describe("GAP-13 (Issue #1505): WithCorrelationID context pattern", func() {
+		It("WithCorrelationID/CorrelationIDFromContext round-trip", func() {
+			ctx := audit.WithCorrelationID(context.Background(), "rr-1505")
+			id, ok := audit.CorrelationIDFromContext(ctx)
+			Expect(ok).To(BeTrue())
+			Expect(id).To(Equal("rr-1505"))
+		})
+
+		It("CorrelationIDFromContext returns false for empty context", func() {
+			_, ok := audit.CorrelationIDFromContext(context.Background())
+			Expect(ok).To(BeFalse())
+		})
+
+		It("WithCorrelationID with empty string returns original context", func() {
+			ctx := audit.WithCorrelationID(context.Background(), "")
+			_, ok := audit.CorrelationIDFromContext(ctx)
+			Expect(ok).To(BeFalse(), "empty correlation ID should not be stored in context")
 		})
 	})
 })

--- a/internal/kubernautagent/audit/k8s_call_audit_test.go
+++ b/internal/kubernautagent/audit/k8s_call_audit_test.go
@@ -59,8 +59,8 @@ var _ = Describe("K8s Call Audit Event — #898, BR-INTERACTIVE-003, BR-AUDIT-00
 				"AllEventTypes must include aiagent.interactive.k8s_call for event type validation")
 		})
 
-		It("should have a total of 30 event types after adding auth/ratelimit events", func() {
-			Expect(audit.AllEventTypes).To(HaveLen(30))
+		It("should have a total of 31 event types after adding secret-access event (GAP-13)", func() {
+			Expect(audit.AllEventTypes).To(HaveLen(31))
 		})
 
 		It("should have the correct event type string value", func() {

--- a/internal/kubernautagent/audit/secret_access_audit_test.go
+++ b/internal/kubernautagent/audit/secret_access_audit_test.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audit_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+)
+
+// ========================================
+// GAP-13 (Issue #1505): KubernautAgent Secret access audit event
+// ========================================
+//
+// Detective control compensating for KubernautAgent's intentionally broad
+// read RBAC on Secrets: every Get/List against the core Secret resource must
+// produce an independently queryable aiagent.secret.accessed event.
+// ========================================
+
+var _ = Describe("GAP-13: Secret Access Audit Event", func() {
+	Describe("buildEventData produces correct payload for aiagent.secret.accessed", func() {
+		It("populates a success payload for a get", func() {
+			recorder := &fakeOgenClient{}
+			store := audit.NewDSAuditStore(recorder)
+
+			event := audit.NewEvent(audit.EventTypeSecretAccessed, "rr-1505-test")
+			event.EventAction = audit.ActionSecretAccessed
+			event.EventOutcome = audit.OutcomeSuccess
+			event.Data["verb"] = "get"
+			event.Data["namespace"] = "prod"
+			event.Data["secret_name"] = "db-creds"
+
+			Expect(store.StoreAudit(context.Background(), event)).To(Succeed())
+			Expect(recorder.calls).To(HaveLen(1))
+
+			req := recorder.calls[0]
+			Expect(req.EventType).To(Equal(audit.EventTypeSecretAccessed))
+			Expect(req.EventOutcome).To(Equal(ogenclient.AuditEventRequestEventOutcomeSuccess))
+			Expect(req.EventData.Type).NotTo(BeEmpty(),
+				"buildEventData must handle EventTypeSecretAccessed and set a discriminator type")
+
+			payload, ok := req.EventData.GetAIAgentSecretAccessedPayload()
+			Expect(ok).To(BeTrue())
+			Expect(payload.Verb).To(Equal(ogenclient.AIAgentSecretAccessedPayloadVerbGet))
+			Expect(payload.Namespace.Value).To(Equal("prod"))
+			Expect(payload.SecretName.Value).To(Equal("db-creds"))
+			Expect(payload.OutcomeDetail.Set).To(BeFalse())
+		})
+
+		It("populates a failure payload with outcome_detail for a list", func() {
+			recorder := &fakeOgenClient{}
+			store := audit.NewDSAuditStore(recorder)
+
+			event := audit.NewEvent(audit.EventTypeSecretAccessed, "rr-1505-test-2")
+			event.EventAction = audit.ActionSecretAccessed
+			event.EventOutcome = audit.OutcomeFailure
+			event.Data["verb"] = "list"
+			event.Data["namespace"] = "kube-system"
+			event.Data["outcome_detail"] = "forbidden: user cannot list secrets in kube-system"
+
+			Expect(store.StoreAudit(context.Background(), event)).To(Succeed())
+			Expect(recorder.calls).To(HaveLen(1))
+
+			payload, ok := recorder.calls[0].EventData.GetAIAgentSecretAccessedPayload()
+			Expect(ok).To(BeTrue())
+			Expect(payload.Verb).To(Equal(ogenclient.AIAgentSecretAccessedPayloadVerbList))
+			Expect(payload.SecretName.Set).To(BeFalse(), "secret_name must be omitted for list operations")
+			Expect(payload.OutcomeDetail.Value).To(Equal("forbidden: user cannot list secrets in kube-system"))
+		})
+	})
+
+	Describe("EventTypeSecretAccessed is registered in AllEventTypes", func() {
+		It("includes aiagent.secret.accessed", func() {
+			Expect(audit.AllEventTypes).To(ContainElement(audit.EventTypeSecretAccessed))
+		})
+
+		It("has the correct event type string value", func() {
+			Expect(audit.EventTypeSecretAccessed).To(Equal("aiagent.secret.accessed"))
+		})
+
+		It("has a non-empty action constant", func() {
+			Expect(audit.ActionSecretAccessed).NotTo(BeEmpty())
+		})
+	})
+})

--- a/internal/kubernautagent/session/correlation_id_context_test.go
+++ b/internal/kubernautagent/session/correlation_id_context_test.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+	kaaudit "github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// ========================================
+// GAP-13 (Issue #1505): correlation ID propagation on the investigation
+// context, so deep call sites (e.g. the K8s resolver's secret-access
+// observer) can emit correctly-correlated audit events.
+// ========================================
+
+var _ = Describe("GAP-13: correlation ID propagation via launchInvestigation", func() {
+	It("makes the RemediationID retrievable from the investigation context via audit.CorrelationIDFromContext", func() {
+		store := session.NewStore(5 * time.Minute)
+		manager := session.NewManager(store, logr.Discard(), nil, nil)
+
+		var observedCorrelationID string
+		var observedOK bool
+
+		metadata := map[string]string{"remediation_id": "rr-1505-secret-audit"}
+
+		id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+			observedCorrelationID, observedOK = kaaudit.CorrelationIDFromContext(ctx)
+			return &katypes.InvestigationResult{}, nil
+		}, metadata)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(id).NotTo(BeEmpty())
+
+		Eventually(func() session.Status {
+			sess, err := manager.GetSession(id)
+			if err != nil {
+				return ""
+			}
+			return sess.Status
+		}, 2*time.Second, 10*time.Millisecond).Should(Equal(session.StatusCompleted))
+
+		Expect(observedOK).To(BeTrue(), "investigation context must carry a correlation ID")
+		Expect(observedCorrelationID).To(Equal("rr-1505-secret-audit"))
+	})
+})

--- a/internal/kubernautagent/session/manager.go
+++ b/internal/kubernautagent/session/manager.go
@@ -161,6 +161,10 @@ func (m *Manager) launchInvestigation(ctx context.Context, id string, fn Investi
 	bgCtx = WithLazySink(bgCtx, ls)
 	bgCtx = WithSessionID(bgCtx, id)
 	bgCtx = audit.WithClusterName(bgCtx, clusterName)
+	// GAP-13 (Issue #1505): correlationID on ctx lets deep call sites (e.g.
+	// the K8s resolver's secret-access observer) emit correctly-correlated
+	// audit events without threading correlationID through every signature.
+	bgCtx = audit.WithCorrelationID(bgCtx, correlationID)
 
 	m.store.mu.Lock()
 	sess := m.store.sessions[id]
@@ -195,9 +199,9 @@ func (m *Manager) launchInvestigation(ctx context.Context, id string, fn Investi
 					"session_id", id,
 					"attempted_status", string(StatusFailed),
 					"reason", updateErr.Error())
-			if bgCtx.Err() != nil {
-				m.storePartialResult(id, result)
-			}
+				if bgCtx.Err() != nil {
+					m.storePartialResult(id, result)
+				}
 			} else {
 				m.closeEventChan(id)
 				m.emitSessionEvent(context.Background(), audit.EventTypeSessionFailed, audit.ActionSessionFailed, audit.OutcomeFailure, id, correlationID, fnErr)

--- a/migrations/013_audit_hash_algorithm.sql
+++ b/migrations/013_audit_hash_algorithm.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+-- Migration: 013_audit_hash_algorithm
+-- GAP-05 (Issue #1505): Keyed HMAC-SHA256 hash chain algorithm tracking
+-- FedRAMP AU-9: Protection of Audit Information (keyed MAC vs. unkeyed hash)
+-- SOC2 CC8.1: Tamper-evident audit trail
+--
+-- Records which hashing scheme produced event_hash for each row, enabling a
+-- mixed-algorithm chain during HMAC key rollout: existing rows keep using
+-- sha256-unkeyed (the only algorithm that existed before this migration);
+-- new writes use hmac-sha256 once a datastorage audit HMAC key is configured,
+-- or continue using sha256-unkeyed otherwise (backward-compatible default).
+--
+-- A plain (unkeyed) SHA256 hash chain can be recomputed by anyone with
+-- read/write access to the database — an attacker who tampers with a row can
+-- also recompute a self-consistent chain. HMAC-SHA256 requires a secret key
+-- stored outside the database (Kubernetes Secret), so forging a valid hash
+-- without that key is computationally infeasible.
+
+ALTER TABLE audit_events
+    ADD COLUMN hash_algorithm VARCHAR(20) NOT NULL DEFAULT 'sha256-unkeyed';
+
+COMMENT ON COLUMN audit_events.hash_algorithm IS
+    'Hash algorithm used to compute event_hash: sha256-unkeyed (legacy, unkeyed) or hmac-sha256 (keyed, GAP-05/Issue #1505)';
+
+-- +goose Down
+ALTER TABLE audit_events DROP COLUMN IF EXISTS hash_algorithm;

--- a/pkg/apifrontend/auth/jwt.go
+++ b/pkg/apifrontend/auth/jwt.go
@@ -60,7 +60,7 @@ type JWTValidator struct {
 	providers    map[string]*providerRuntime
 	cache        *JWKSCache
 	reviewer     *TokenReviewer
-	replayCache  *ReplayCache
+	replayCache  ReplayCacheStore
 	httpClient   *http.Client
 	cbTimeout    time.Duration
 	cbGauge      *prometheus.GaugeVec
@@ -91,8 +91,9 @@ func WithCBMetrics(g *prometheus.GaugeVec) JWTValidatorOption {
 	return func(v *JWTValidator) { v.cbGauge = g }
 }
 
-// WithReplayCache enables jti-based token replay detection.
-func WithReplayCache(rc *ReplayCache) JWTValidatorOption {
+// WithReplayCache enables jti-based token replay detection using the given
+// store — either the in-memory ReplayCache or the distributed ValkeyReplayCache.
+func WithReplayCache(rc ReplayCacheStore) JWTValidatorOption {
 	return func(v *JWTValidator) { v.replayCache = rc }
 }
 

--- a/pkg/apifrontend/auth/replay_cache.go
+++ b/pkg/apifrontend/auth/replay_cache.go
@@ -5,15 +5,28 @@ import (
 	"time"
 )
 
+// ReplayCacheStore is the interface implemented by both the in-memory
+// ReplayCache and the distributed ValkeyReplayCache (GAP-08, kubernaut#1505),
+// letting JWTValidator remain agnostic to the backing store.
+type ReplayCacheStore interface {
+	// MissingJTI returns true if jti enforcement is active and the token
+	// lacks a jti claim needed for replay protection.
+	MissingJTI(jti string) bool
+	// Seen atomically records jti as observed and reports whether it was
+	// already present (a replay attempt).
+	Seen(jti string) bool
+	// Stop releases any background resources held by the cache.
+	Stop()
+}
+
 // ReplayCache tracks seen JWT IDs (jti claims) to prevent token replay attacks.
 // It uses an in-memory map with periodic eviction of expired entries.
 //
 // HA Limitation: This implementation is per-process. In multi-replica deployments,
-// a token replayed against a different replica will not be detected. To close this
-// gap at FedRAMP High, replace with a distributed cache (Redis SETEX with jti as
-// key and TTL matching token expiry). The interface is designed to be swap-compatible:
-// implement MissingJTI(string) bool and Seen(string) bool against Redis.
-// See: https://github.com/jordigilh/kubernaut/issues (origin:apifrontend)
+// a token replayed against a different replica will not be detected. Deployments
+// running more than one APIFrontend replica should use ValkeyReplayCache instead
+// (auth.replayCache.backend: redis in config), which shares replay state across
+// all replicas via the cluster's Valkey/Redis instance (GAP-08, kubernaut#1505).
 type ReplayCache struct {
 	mu       sync.RWMutex
 	entries  map[string]time.Time

--- a/pkg/apifrontend/auth/replay_cache_valkey.go
+++ b/pkg/apifrontend/auth/replay_cache_valkey.go
@@ -1,0 +1,67 @@
+package auth
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/redis/go-redis/v9"
+)
+
+// ValkeyReplayCache is a distributed jti replay cache backed by Valkey/Redis.
+// It closes the HA gap of the in-memory ReplayCache (GAP-08, kubernaut#1505):
+// in a multi-replica APIFrontend deployment, all replicas share the same
+// backing store, so a token replayed against a different replica than the one
+// that first observed it is still detected.
+type ValkeyReplayCache struct {
+	client *redis.Client
+	ttl    time.Duration
+	logger logr.Logger
+}
+
+// NewValkeyReplayCache creates a distributed jti replay cache. ttl should
+// match or exceed the maximum token lifetime, mirroring NewReplayCache. The
+// caller owns the redis.Client lifecycle (created once in main.go and reused
+// across the process).
+func NewValkeyReplayCache(client *redis.Client, ttl time.Duration, logger logr.Logger) *ValkeyReplayCache {
+	return &ValkeyReplayCache{client: client, ttl: ttl, logger: logger}
+}
+
+// MissingJTI mirrors ReplayCache.MissingJTI: true indicates the token lacks
+// a jti claim needed for replay protection.
+func (c *ValkeyReplayCache) MissingJTI(jti string) bool {
+	return jti == ""
+}
+
+// Seen atomically records jti as observed and reports whether it was already
+// present, using SET-NX-with-TTL semantics so a single round-trip both checks
+// and marks the token — required to avoid a race between concurrent requests
+// replaying the same token against different replicas at nearly the same time.
+//
+// Fail-open on Valkey errors: replay detection is defense-in-depth layered on
+// top of signature/expiry/audience/issuer validation (all of which already
+// passed by the time this is called), not the sole authentication control.
+// Treating a transient infrastructure outage as "not seen" avoids turning a
+// Valkey blip into a full authentication outage. Every failure is logged so
+// the degradation is observable.
+func (c *ValkeyReplayCache) Seen(jti string) bool {
+	if jti == "" {
+		return false
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	stored, err := c.client.SetNX(ctx, replayCacheKey(jti), "1", c.ttl).Result()
+	if err != nil {
+		c.logger.Error(err, "valkey replay cache unavailable; failing open (replay detection degraded for this request)")
+		return false
+	}
+	return !stored
+}
+
+// Stop is a no-op: the redis.Client lifecycle is owned by the caller, not by
+// this cache, so there is nothing for Stop to release here.
+func (c *ValkeyReplayCache) Stop() {}
+
+func replayCacheKey(jti string) string {
+	return "apifrontend:replay:jti:" + jti
+}

--- a/pkg/apifrontend/auth/replay_cache_valkey_test.go
+++ b/pkg/apifrontend/auth/replay_cache_valkey_test.go
@@ -1,0 +1,83 @@
+package auth_test
+
+import (
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
+)
+
+// BR-SECURITY-1505 (GAP-08, kubernaut#1505): distributed jti replay cache
+// closes the HA gap of the in-memory ReplayCache — replay state must be
+// shared across all APIFrontend replicas via Valkey/Redis.
+var _ = Describe("ValkeyReplayCache", func() {
+	var (
+		mr     *miniredis.Miniredis
+		client *redis.Client
+		rc     *auth.ValkeyReplayCache
+	)
+
+	BeforeEach(func() {
+		var err error
+		mr, err = miniredis.Run()
+		Expect(err).NotTo(HaveOccurred())
+		client = redis.NewClient(&redis.Options{Addr: mr.Addr()})
+		rc = auth.NewValkeyReplayCache(client, 1*time.Minute, logr.Discard())
+	})
+
+	AfterEach(func() {
+		rc.Stop()
+		_ = client.Close()
+		mr.Close()
+	})
+
+	It("returns false (not seen) for a new jti", func() {
+		Expect(rc.Seen("jti-abc-123")).To(BeFalse())
+	})
+
+	It("returns true (replay detected) when the same jti is seen twice", func() {
+		Expect(rc.Seen("jti-abc-123")).To(BeFalse())
+		Expect(rc.Seen("jti-abc-123")).To(BeTrue())
+	})
+
+	It("shares replay state across two independent client instances (simulating two replicas)", func() {
+		// A second APIFrontend replica would construct its own redis.Client
+		// pointed at the same Valkey instance; simulate that here.
+		client2 := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+		defer func() { _ = client2.Close() }()
+		rc2 := auth.NewValkeyReplayCache(client2, 1*time.Minute, logr.Discard())
+		defer rc2.Stop()
+
+		Expect(rc.Seen("jti-shared")).To(BeFalse(), "replica 1 observes the token first")
+		Expect(rc2.Seen("jti-shared")).To(BeTrue(), "replica 2 must detect the replay via the shared store")
+	})
+
+	It("always reports empty jti as not-seen without touching the store", func() {
+		Expect(rc.Seen("")).To(BeFalse())
+		Expect(rc.Seen("")).To(BeFalse())
+	})
+
+	It("reports MissingJTI true only for empty jti", func() {
+		Expect(rc.MissingJTI("")).To(BeTrue())
+		Expect(rc.MissingJTI("abc-123")).To(BeFalse())
+	})
+
+	It("expires entries after the configured TTL", func() {
+		shortTTL := auth.NewValkeyReplayCache(client, 50*time.Millisecond, logr.Discard())
+		defer shortTTL.Stop()
+
+		Expect(shortTTL.Seen("jti-expiring")).To(BeFalse())
+		mr.FastForward(100 * time.Millisecond)
+		Expect(shortTTL.Seen("jti-expiring")).To(BeFalse(), "entry should have expired and be treated as new")
+	})
+
+	It("fails open (reports not-seen) when Valkey is unreachable, rather than blocking the request", func() {
+		mr.Close() // simulate an outage
+		Expect(rc.Seen("jti-during-outage")).To(BeFalse())
+	})
+})

--- a/pkg/apifrontend/config/config.go
+++ b/pkg/apifrontend/config/config.go
@@ -100,6 +100,39 @@ type AuthConfig struct {
 	AllowInsecureIssuers   bool   `yaml:"allowInsecureIssuers,omitempty"`
 	// Multi-provider JWT configuration (#1436)
 	JWTProviders []JWTProviderConfig `yaml:"jwtProviders,omitempty"`
+	// ReplayCache selects the jti replay-detection backend (GAP-08, #1505).
+	// When set with backend "redis"/"valkey", replay detection is shared across
+	// all APIFrontend replicas via Valkey — closing the HA gap of the in-memory
+	// cache (a token replayed against a different replica would otherwise go
+	// undetected). When nil, EnableReplayProtection controls the legacy
+	// single-process in-memory cache for backward compatibility.
+	ReplayCache *ReplayCacheConfig `yaml:"replayCache,omitempty"`
+}
+
+// ReplayCacheConfig configures the jti replay-detection backend. Mirrors the
+// afReplayCacheYAML contract emitted by kubernaut-operator's DataStorageConfigMap
+// equivalent for APIFrontend, so the same config shape works whether the
+// deployment is Helm-managed or operator-managed.
+type ReplayCacheConfig struct {
+	// Backend is "redis" (or "valkey", equivalent) for the distributed cache, or
+	// "memory"/"" for the legacy single-process in-memory cache.
+	Backend string `yaml:"backend"`
+	// RedisAddr is the host:port of the shared Valkey/Redis instance. Required
+	// when Backend is "redis"/"valkey".
+	RedisAddr string `yaml:"redisAddr,omitempty"`
+	// RedisDB selects the logical Redis database index (default 0).
+	RedisDB int `yaml:"redisDB,omitempty"`
+	// CredentialsPath points to a YAML file containing a "password" key,
+	// mounted from a Kubernetes Secret (e.g. the shared valkey-secrets.yaml
+	// projection at /etc/apifrontend/valkey/valkey-secrets.yaml). Optional —
+	// leave empty for an unauthenticated Valkey instance.
+	CredentialsPath string `yaml:"credentialsPath,omitempty"`
+}
+
+// IsDistributed reports whether the configured backend is the distributed
+// Valkey/Redis replay cache (as opposed to the legacy in-memory cache).
+func (r *ReplayCacheConfig) IsDistributed() bool {
+	return r != nil && (r.Backend == "redis" || r.Backend == "valkey")
 }
 
 // JWTProviderConfig defines a single JWT provider within the multi-provider
@@ -387,6 +420,9 @@ func (c *Config) validateAuth() error {
 	if err := c.validateJWTProviders(); err != nil {
 		return err
 	}
+	if err := c.validateReplayCache(); err != nil {
+		return err
+	}
 	if c.Auth.IssuerURL == "" {
 		return nil
 	}
@@ -400,6 +436,27 @@ func (c *Config) validateAuth() error {
 	}
 	if c.Auth.OIDCCaFile != "" && !filepath.IsAbs(c.Auth.OIDCCaFile) {
 		return fmt.Errorf("auth.oidcCaFile must be an absolute path, got %q", c.Auth.OIDCCaFile)
+	}
+	return nil
+}
+
+func (c *Config) validateReplayCache() error {
+	rc := c.Auth.ReplayCache
+	if rc == nil {
+		return nil
+	}
+	switch rc.Backend {
+	case "redis", "valkey":
+		if rc.RedisAddr == "" {
+			return fmt.Errorf("auth.replayCache.redisAddr is required when backend is %q", rc.Backend)
+		}
+	case "memory", "":
+		// No additional fields required for the in-memory backend.
+	default:
+		return fmt.Errorf("auth.replayCache.backend must be one of: redis, valkey, memory; got %q", rc.Backend)
+	}
+	if rc.CredentialsPath != "" && !filepath.IsAbs(rc.CredentialsPath) {
+		return fmt.Errorf("auth.replayCache.credentialsPath must be an absolute path, got %q", rc.CredentialsPath)
 	}
 	return nil
 }

--- a/pkg/apifrontend/config/config_test.go
+++ b/pkg/apifrontend/config/config_test.go
@@ -356,6 +356,58 @@ auth:
 		Expect(cfg.Auth.EnableReplayProtection).To(BeTrue())
 	})
 
+	It("GAP-08 (#1505) loads a distributed redis replay cache config", func() {
+		data := []byte(`
+auth:
+  issuerURL: "https://sso.example.com/realms/kubernaut"
+  audience: "apifrontend"
+  replayCache:
+    backend: redis
+    redisAddr: "valkey.kubernaut-system.svc:6379"
+    redisDB: 1
+    credentialsPath: "/etc/apifrontend/valkey/valkey-secrets.yaml"
+`)
+		cfg, err := config.Load(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Validate()).To(Succeed())
+		Expect(cfg.Auth.ReplayCache).NotTo(BeNil())
+		Expect(cfg.Auth.ReplayCache.Backend).To(Equal("redis"))
+		Expect(cfg.Auth.ReplayCache.RedisAddr).To(Equal("valkey.kubernaut-system.svc:6379"))
+		Expect(cfg.Auth.ReplayCache.RedisDB).To(Equal(1))
+		Expect(cfg.Auth.ReplayCache.IsDistributed()).To(BeTrue())
+	})
+
+	It("GAP-08 (#1505) rejects a redis replay cache config missing redisAddr", func() {
+		data := []byte(`
+auth:
+  issuerURL: "https://sso.example.com/realms/kubernaut"
+  audience: "apifrontend"
+  replayCache:
+    backend: redis
+`)
+		cfg, err := config.Load(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Validate()).To(MatchError(ContainSubstring("redisAddr")))
+	})
+
+	It("GAP-08 (#1505) rejects an unknown replay cache backend", func() {
+		data := []byte(`
+auth:
+  issuerURL: "https://sso.example.com/realms/kubernaut"
+  audience: "apifrontend"
+  replayCache:
+    backend: memcached
+`)
+		cfg, err := config.Load(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Validate()).To(MatchError(ContainSubstring(`backend must be one of`)))
+	})
+
+	It("GAP-08 (#1505) treats a nil replayCache block as not distributed", func() {
+		var rc *config.ReplayCacheConfig
+		Expect(rc.IsDistributed()).To(BeFalse())
+	})
+
 	It("UT-AF-1247-001 loads allowInsecureIssuers field", func() {
 		data := []byte(`
 auth:

--- a/pkg/audit/openapi_spec_data.yaml
+++ b/pkg/audit/openapi_spec_data.yaml
@@ -2597,7 +2597,7 @@ components:
           type: string
           minLength: 1
           maxLength: 50
-          enum: [gateway, notification, analysis, aiagent, signalprocessing, workflow, workflowexecution, orchestration, approval, effectiveness, actiontype, apifrontend]
+          enum: [gateway, notification, analysis, aiagent, signalprocessing, workflow, workflowexecution, orchestration, approval, effectiveness, actiontype, apifrontend, security]
           description: |
             Domain-level event category (ADR-034 v1.8, Issue #306).
             Per convention: event_category identifies the business domain of the event.
@@ -2615,6 +2615,7 @@ components:
             - effectiveness: Effectiveness assessment and monitoring events
             - actiontype: ActionType taxonomy lifecycle events (Issue #300)
             - apifrontend: API Frontend service — triage, session, delegation, and user decision events (Issue #1021)
+            - security: Cross-cutting security control events at the HTTP layer (e.g. rate-limit denials) not tied to a single business domain (GAP-09, Issue #1505)
           example: gateway
         event_action:
           type: string
@@ -2731,6 +2732,7 @@ components:
             - $ref: '#/components/schemas/AIAgentInteractiveStartedPayload'
             - $ref: '#/components/schemas/AIAgentInteractiveCompletedPayload'
             - $ref: '#/components/schemas/AIAgentInteractiveK8sCallPayload'
+            - $ref: '#/components/schemas/AIAgentSecretAccessedPayload'
             - $ref: '#/components/schemas/AIAgentSessionObservedPayload'
             - $ref: '#/components/schemas/AIAgentSessionAccessDeniedPayload'
             - $ref: '#/components/schemas/AIAgentInvestigationCancelledPayload'
@@ -2781,6 +2783,9 @@ components:
             - $ref: '#/components/schemas/ApifrontendSeverityTriageFailedPayload'
             - $ref: '#/components/schemas/ApifrontendConfigReloadedPayload'
             - $ref: '#/components/schemas/ApifrontendConfigRejectedPayload'
+            - $ref: '#/components/schemas/DatastorageRatelimitDeniedPayload'
+            - $ref: '#/components/schemas/GatewayConfigReloadedPayload'
+            - $ref: '#/components/schemas/GatewayConfigRejectedPayload'
           discriminator:
             propertyName: event_type
             mapping:
@@ -2862,6 +2867,7 @@ components:
               'aiagent.interactive.started': '#/components/schemas/AIAgentInteractiveStartedPayload'
               'aiagent.interactive.completed': '#/components/schemas/AIAgentInteractiveCompletedPayload'
               'aiagent.interactive.k8s_call': '#/components/schemas/AIAgentInteractiveK8sCallPayload'
+              'aiagent.secret.accessed': '#/components/schemas/AIAgentSecretAccessedPayload'
               'aiagent.session.observed': '#/components/schemas/AIAgentSessionObservedPayload'
               'aiagent.session.access_denied': '#/components/schemas/AIAgentSessionAccessDeniedPayload'
               'aiagent.investigation.cancelled': '#/components/schemas/AIAgentInvestigationCancelledPayload'
@@ -2872,6 +2878,9 @@ components:
               'aiagent.ratelimit.denied': '#/components/schemas/AIAgentRatelimitDeniedPayload'
               'aiagent.auth.failure': '#/components/schemas/AIAgentAuthFailurePayload'
               'aiagent.auth.denied': '#/components/schemas/AIAgentAuthDeniedPayload'
+              'datastorage.ratelimit.denied': '#/components/schemas/DatastorageRatelimitDeniedPayload'
+              'gateway.config.reloaded': '#/components/schemas/GatewayConfigReloadedPayload'
+              'gateway.config.rejected': '#/components/schemas/GatewayConfigRejectedPayload'
               'effectiveness.health.assessed': '#/components/schemas/EffectivenessAssessmentAuditPayload'
               'effectiveness.hash.computed': '#/components/schemas/EffectivenessAssessmentAuditPayload'
               'effectiveness.alert.assessed': '#/components/schemas/EffectivenessAssessmentAuditPayload'
@@ -6219,6 +6228,35 @@ components:
           type: string
           description: Correlation ID linking to the parent remediation request
 
+    AIAgentSecretAccessedPayload:
+      type: object
+      required: [event_type, event_id, verb]
+      description: KubernautAgent Secret access audit payload (aiagent.secret.accessed) — detective control emitted for every K8s Secret Get/List performed by the autonomous investigator's resource resolver, regardless of outcome (GAP-13, Issue #1505). KubernautAgent intentionally retains broad read RBAC on Secrets for investigation completeness; this event is the compensating detective control rather than a narrowed RBAC grant.
+      properties:
+        event_type:
+          type: string
+          enum: ['aiagent.secret.accessed']
+          description: Event type for discriminator (matches parent event_type)
+        event_id:
+          type: string
+          description: Unique event identifier
+        verb:
+          type: string
+          enum: ['get', 'list']
+          description: K8s API verb performed against the Secret resource
+        namespace:
+          type: string
+          description: K8s namespace of the target Secret (empty for a cluster-wide list)
+        secret_name:
+          type: string
+          description: Name of the specific Secret (empty for list operations)
+        tool_name:
+          type: string
+          description: Name of the KubernautAgent tool that triggered the access (e.g. kubectl_get_by_name)
+        outcome_detail:
+          type: string
+          description: Error message when the access failed (e.g. not found, forbidden); empty on success
+
     AIAgentSessionObservedPayload:
       type: object
       required: [event_type, event_id, session_id]
@@ -7500,6 +7538,60 @@ components:
         event_type:
           type: string
           enum: ['aiagent.ratelimit.denied']
+          description: Event type for discriminator (matches parent event_type)
+        event_id:
+          type: string
+          description: Unique event identifier
+        source_ip:
+          type: string
+          description: Source IP address of the rate-limited request
+        path:
+          type: string
+          description: HTTP request path
+        method:
+          type: string
+          description: HTTP request method
+
+    GatewayConfigReloadedPayload:
+      type: object
+      required: [event_type, component]
+      description: Gateway config reloaded event payload (gateway.config.reloaded) — hot-reload configuration accepted (SOC2 CC7.2, GAP-11 Issue #1505)
+      properties:
+        event_type:
+          type: string
+          enum: ['gateway.config.reloaded']
+          description: Event type for discriminator (matches parent event_type)
+        component:
+          type: string
+          description: Hot-reloadable component that was reloaded (e.g. log_level, ca_cert)
+        config_version:
+          type: string
+          description: New configuration version or hash
+
+    GatewayConfigRejectedPayload:
+      type: object
+      required: [event_type, component, rejection_reason]
+      description: Gateway config rejected event payload (gateway.config.rejected) — hot-reload configuration rejected, previous configuration kept (SOC2 CC7.2, GAP-11 Issue #1505)
+      properties:
+        event_type:
+          type: string
+          enum: ['gateway.config.rejected']
+          description: Event type for discriminator (matches parent event_type)
+        component:
+          type: string
+          description: Hot-reloadable component whose reload was rejected (e.g. log_level, ca_cert)
+        rejection_reason:
+          type: string
+          description: Reason configuration was rejected
+
+    DatastorageRatelimitDeniedPayload:
+      type: object
+      required: [event_type, event_id]
+      description: Data Storage rate limit denied event payload (datastorage.ratelimit.denied) — request rejected by per-IP rate limiter on the DS HTTP API (FedRAMP AU-12, GAP-09 Issue #1505)
+      properties:
+        event_type:
+          type: string
+          enum: ['datastorage.ratelimit.denied']
           description: Event type for discriminator (matches parent event_type)
         event_id:
           type: string

--- a/pkg/datastorage/audit/ratelimit_event.go
+++ b/pkg/datastorage/audit/ratelimit_event.go
@@ -1,0 +1,79 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audit
+
+import (
+	"github.com/google/uuid"
+
+	pkgaudit "github.com/jordigilh/kubernaut/pkg/audit"
+	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+)
+
+// BR-STORAGE-1505 (GAP-09, Issue #1505): Data Storage HTTP API self-audited
+// rate-limit denial.
+const (
+	EventTypeRatelimitDenied = "datastorage.ratelimit.denied"
+	EventCategorySecurity    = "security"
+	ActionDenied             = "denied"
+)
+
+// NewRatelimitDeniedAuditEvent creates a self-audit event recording that the
+// Data Storage HTTP API rejected a request due to per-IP rate limiting
+// (BR-STORAGE-1505 / FedRAMP AU-12: audit generation for security-relevant events).
+//
+// sourceIP, path, and method are best-effort context and may be empty.
+func NewRatelimitDeniedAuditEvent(sourceIP, path, method string) *ogenclient.AuditEventRequest {
+	eventID := uuid.New().String()
+
+	auditEvent := pkgaudit.NewAuditEventRequest()
+	pkgaudit.SetEventType(auditEvent, EventTypeRatelimitDenied)
+	pkgaudit.SetEventCategory(auditEvent, EventCategorySecurity)
+	pkgaudit.SetEventAction(auditEvent, ActionDenied)
+	pkgaudit.SetEventOutcome(auditEvent, pkgaudit.OutcomeFailure)
+	pkgaudit.SetActor(auditEvent, "external", firstNonEmpty(sourceIP, "unknown"))
+	pkgaudit.SetResource(auditEvent, "HTTPRequest", eventID)
+	// No upstream correlation ID is available for a pre-auth rate-limit denial
+	// (the request never reached a handler); use the event's own ID so the
+	// event remains independently queryable per ADR-034.
+	pkgaudit.SetCorrelationID(auditEvent, eventID)
+
+	payload := ogenclient.DatastorageRatelimitDeniedPayload{
+		EventType: ogenclient.DatastorageRatelimitDeniedPayloadEventTypeDatastorageRatelimitDenied,
+		EventID:   eventID,
+	}
+	if sourceIP != "" {
+		payload.SourceIP.SetTo(sourceIP)
+	}
+	if path != "" {
+		payload.Path.SetTo(path)
+	}
+	if method != "" {
+		payload.Method.SetTo(method)
+	}
+	auditEvent.EventData = ogenclient.NewDatastorageRatelimitDeniedPayloadAuditEventRequestEventData(payload)
+
+	return auditEvent
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, v := range values {
+		if v != "" {
+			return v
+		}
+	}
+	return ""
+}

--- a/pkg/datastorage/audit/ratelimit_event_test.go
+++ b/pkg/datastorage/audit/ratelimit_event_test.go
@@ -1,0 +1,88 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package audit_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	pkgaudit "github.com/jordigilh/kubernaut/pkg/audit"
+	dsaudit "github.com/jordigilh/kubernaut/pkg/datastorage/audit"
+	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+)
+
+// BR-STORAGE-1505 (GAP-09, Issue #1505): Data Storage self-audits per-IP
+// rate-limit denials (FedRAMP AU-12 — audit generation for security-relevant
+// events).
+var _ = Describe("NewRatelimitDeniedAuditEvent", Label("unit", "audit", "ratelimit"), func() {
+	It("UT-DS-AUDIT-002-001: produces a well-formed, non-empty correlation_id and required envelope fields", func() {
+		event := dsaudit.NewRatelimitDeniedAuditEvent("203.0.113.1", "/api/v1/audit/events", "POST")
+
+		Expect(event.EventType).To(Equal("datastorage.ratelimit.denied"))
+		Expect(string(event.EventCategory)).To(Equal("security"))
+		Expect(event.EventAction).To(Equal("denied"))
+		Expect(event.EventOutcome).To(Equal(pkgaudit.OutcomeFailure))
+		Expect(event.CorrelationID).NotTo(BeEmpty(), "correlation_id must not be empty (OpenAPI minLength: 1)")
+
+		actorType, ok := event.ActorType.Get()
+		Expect(ok).To(BeTrue())
+		Expect(actorType).To(Equal("external"))
+		actorID, ok := event.ActorID.Get()
+		Expect(ok).To(BeTrue())
+		Expect(actorID).To(Equal("203.0.113.1"))
+	})
+
+	It("UT-DS-AUDIT-002-002: sets the typed DatastorageRatelimitDeniedPayload with source IP, path, and method", func() {
+		event := dsaudit.NewRatelimitDeniedAuditEvent("198.51.100.5", "/api/v1/workflows", "GET")
+
+		Expect(event.EventData.IsDatastorageRatelimitDeniedPayload()).To(BeTrue())
+		payload := event.EventData.DatastorageRatelimitDeniedPayload
+
+		sourceIP, ok := payload.SourceIP.Get()
+		Expect(ok).To(BeTrue())
+		Expect(sourceIP).To(Equal("198.51.100.5"))
+
+		path, ok := payload.Path.Get()
+		Expect(ok).To(BeTrue())
+		Expect(path).To(Equal("/api/v1/workflows"))
+
+		method, ok := payload.Method.Get()
+		Expect(ok).To(BeTrue())
+		Expect(method).To(Equal("GET"))
+
+		Expect(payload.EventType).To(Equal(ogenclient.DatastorageRatelimitDeniedPayloadEventTypeDatastorageRatelimitDenied))
+		Expect(payload.EventID).NotTo(BeEmpty())
+	})
+
+	It("UT-DS-AUDIT-002-003: tolerates an empty source IP (falls back to actor \"unknown\")", func() {
+		event := dsaudit.NewRatelimitDeniedAuditEvent("", "", "")
+
+		actorID, ok := event.ActorID.Get()
+		Expect(ok).To(BeTrue())
+		Expect(actorID).To(Equal("unknown"))
+
+		payload := event.EventData.DatastorageRatelimitDeniedPayload
+		_, hasSourceIP := payload.SourceIP.Get()
+		Expect(hasSourceIP).To(BeFalse())
+	})
+
+	It("UT-DS-AUDIT-002-004: generates a distinct correlation_id per call", func() {
+		e1 := dsaudit.NewRatelimitDeniedAuditEvent("10.0.0.1", "/a", "GET")
+		e2 := dsaudit.NewRatelimitDeniedAuditEvent("10.0.0.1", "/a", "GET")
+		Expect(e1.CorrelationID).NotTo(Equal(e2.CorrelationID))
+	})
+})

--- a/pkg/datastorage/config/config.go
+++ b/pkg/datastorage/config/config.go
@@ -58,6 +58,7 @@ type Config struct {
 	Database  DatabaseConfig  `yaml:"database"`
 	Redis     RedisConfig     `yaml:"redis"`
 	Retention RetentionConfig `yaml:"retention"`
+	Audit     AuditConfig     `yaml:"audit,omitempty"`
 
 	// TLSProfile selects the TLS security profile (Old/Intermediate/Modern).
 	// Issue #748: OCP-only — set by kubernaut-operator from the cluster APIServer CR.
@@ -97,6 +98,37 @@ type ServerConfig struct {
 	// #1088 Phase 7 / SRE-L1: Time to wait for K8s endpoint removal propagation.
 	// e.g., "5s" (default: 5s). Overrides the hardcoded endpointRemovalPropagationDelay.
 	EndpointPropagationDelay string `yaml:"endpointPropagationDelay,omitempty"`
+
+	// GAP-09 (Issue #1505) / SC-5: Per-IP rate limiting for the HTTP API.
+	// Disabled by default for backward compatibility with existing deployments
+	// that rely on an external ingress/proxy for rate limiting.
+	RateLimit RateLimitConfig `yaml:"rateLimit,omitempty"`
+}
+
+// RateLimitConfig configures per-IP rate limiting on the Data Storage HTTP
+// API (GAP-09, Issue #1505 / SC-5).
+type RateLimitConfig struct {
+	Enabled           bool    `yaml:"enabled"`
+	RequestsPerSecond float64 `yaml:"requestsPerSecond,omitempty"`
+	Burst             int     `yaml:"burst,omitempty"`
+}
+
+// GetRequestsPerSecond returns the configured per-IP request rate, defaulting
+// to 50 req/s when unset or non-positive.
+func (r *RateLimitConfig) GetRequestsPerSecond() float64 {
+	if r.RequestsPerSecond <= 0 {
+		return 50
+	}
+	return r.RequestsPerSecond
+}
+
+// GetBurst returns the configured per-IP burst size, defaulting to 100 when
+// unset or non-positive.
+func (r *RateLimitConfig) GetBurst() int {
+	if r.Burst <= 0 {
+		return 100
+	}
+	return r.Burst
 }
 
 // LoggingConfig contains logging configuration
@@ -179,6 +211,22 @@ type RedisConfig struct {
 	PasswordKey string `yaml:"passwordKey"` // Key name for password in secret file (e.g., "password")
 
 	TLS RedisTLSConfig `yaml:"tls"` // #1048 Phase 5 / AU-9: Redis TLS for audit data transport
+}
+
+// AuditConfig contains audit hash-chain configuration.
+// GAP-05 (Issue #1505): Optional keyed HMAC-SHA256 hash chain. When
+// HashKeySecretsFile is unset, the datastorage falls back to the legacy
+// unkeyed SHA256 algorithm for backward compatibility with environments that
+// have not yet provisioned the audit HMAC key secret.
+type AuditConfig struct {
+	// Secret file configuration (ADR-030 Section 6), same pattern as
+	// Database.SecretsFile / Redis.SecretsFile. Optional: leave unset to keep
+	// using the legacy unkeyed SHA256 hash chain.
+	HashKeySecretsFile string `yaml:"hashKeySecretsFile,omitempty"`
+	HashKeyKey         string `yaml:"hashKeyKey,omitempty"` // Key name in the secret file (e.g., "hmacKey")
+
+	// HMACKey is NOT in YAML - loaded from secret file via LoadSecrets().
+	HMACKey []byte `yaml:"-"`
 }
 
 // RetentionConfig contains retention worker configuration.
@@ -308,6 +356,39 @@ func (c *Config) LoadSecrets() error {
 	}
 
 	c.Redis.Password = redisPasswordStr
+
+	// GAP-05 (Issue #1505): Load optional HMAC key for keyed audit hash chain.
+	// Unlike database/redis secrets, this is OPTIONAL — omitting it preserves
+	// the legacy unkeyed SHA256 algorithm for backward compatibility.
+	if c.Audit.HashKeySecretsFile != "" {
+		if c.Audit.HashKeyKey == "" {
+			return fmt.Errorf("audit hashKeyKey required when hashKeySecretsFile is set (GAP-05)")
+		}
+
+		auditSecrets, err := loadSecretFile(c.Audit.HashKeySecretsFile)
+		if err != nil {
+			return fmt.Errorf("failed to load audit hash key secrets from %s: %w",
+				c.Audit.HashKeySecretsFile, err)
+		}
+
+		hmacKeyRaw, ok := auditSecrets[c.Audit.HashKeyKey]
+		if !ok {
+			return fmt.Errorf("hash key '%s' not found in audit secret file %s",
+				c.Audit.HashKeyKey, c.Audit.HashKeySecretsFile)
+		}
+
+		hmacKeyStr, isString := hmacKeyRaw.(string)
+		if !isString {
+			return fmt.Errorf("audit hash key '%s' in secret file is not a string",
+				c.Audit.HashKeyKey)
+		}
+		if hmacKeyStr == "" {
+			return fmt.Errorf("audit hash key '%s' in secret file %s is empty",
+				c.Audit.HashKeyKey, c.Audit.HashKeySecretsFile)
+		}
+
+		c.Audit.HMACKey = []byte(hmacKeyStr)
+	}
 
 	return nil
 }

--- a/pkg/datastorage/gap05_hmac_hash_chain_test.go
+++ b/pkg/datastorage/gap05_hmac_hash_chain_test.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastorage_test
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-logr/logr"
+	"github.com/google/uuid"
+	kubelog "github.com/jordigilh/kubernaut/pkg/log"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/datastorage/repository"
+)
+
+// ========================================
+// GAP-05 (Issue #1505): Keyed HMAC-SHA256 Hash Chain
+// ========================================
+//
+// A plain (unkeyed) SHA256 hash chain can be recomputed by anyone with
+// read/write access to the database: an attacker who tampers with a row can
+// also recompute a self-consistent chain. These tests prove:
+//
+//  1. HMAC-SHA256 hashes differ from unkeyed SHA256 hashes for the same input.
+//  2. HMAC hashes are keyed (different keys => different hashes; the key is
+//     required to reproduce a given hash).
+//  3. CalculateHashForVerification honors each event's own HashAlgorithm,
+//     supporting a mixed-algorithm chain across an HMAC key rollout.
+//  4. Verifying an hmac-sha256 event without a configured key fails loudly
+//     rather than silently reporting a false "tampered" mismatch.
+//  5. AuditEventsRepository.Create/CreateBatch stamp hash_algorithm correctly
+//     and persist it via the INSERT statement.
+// ========================================
+
+var _ = Describe("GAP-05: Keyed HMAC-SHA256 Hash Chain", func() {
+	var baseEvent *repository.AuditEvent
+
+	BeforeEach(func() {
+		baseEvent = &repository.AuditEvent{
+			EventID:        uuid.MustParse("11111111-1111-1111-1111-111111111111"),
+			EventTimestamp: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			EventType:      "test.gap05.hmac",
+			EventCategory:  "test",
+			EventAction:    "verify",
+			EventOutcome:   "success",
+			CorrelationID:  "gap05-hmac-test",
+		}
+	})
+
+	Describe("CalculateHashForVerification", func() {
+		It("computes the legacy unkeyed SHA256 hash when HashAlgorithm is sha256-unkeyed", func() {
+			event := *baseEvent
+			event.HashAlgorithm = repository.HashAlgorithmSHA256Unkeyed
+
+			hash, err := repository.CalculateHashForVerification(nil, "", &event)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(hash).To(HaveLen(64), "SHA256 hex digest must be 64 characters")
+		})
+
+		It("treats an empty HashAlgorithm as sha256-unkeyed for backward compatibility", func() {
+			event := *baseEvent
+			event.HashAlgorithm = ""
+
+			unkeyedHash, err := repository.CalculateHashForVerification(nil, "", &event)
+			Expect(err).ToNot(HaveOccurred())
+
+			explicitEvent := *baseEvent
+			explicitEvent.HashAlgorithm = repository.HashAlgorithmSHA256Unkeyed
+			explicitHash, err := repository.CalculateHashForVerification(nil, "", &explicitEvent)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(unkeyedHash).To(Equal(explicitHash),
+				"legacy pre-GAP-05 events (empty HashAlgorithm) must verify identically to sha256-unkeyed")
+		})
+
+		It("computes a different hash for hmac-sha256 than for sha256-unkeyed given the same event", func() {
+			key := []byte("test-hmac-key-0123456789abcdef")
+
+			unkeyedEvent := *baseEvent
+			unkeyedEvent.HashAlgorithm = repository.HashAlgorithmSHA256Unkeyed
+			unkeyedHash, err := repository.CalculateHashForVerification(nil, "", &unkeyedEvent)
+			Expect(err).ToNot(HaveOccurred())
+
+			hmacEvent := *baseEvent
+			hmacEvent.HashAlgorithm = repository.HashAlgorithmHMACSHA256
+			hmacHash, err := repository.CalculateHashForVerification(key, "", &hmacEvent)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(hmacHash).ToNot(Equal(unkeyedHash),
+				"hmac-sha256 and sha256-unkeyed must produce different digests for identical event content")
+			Expect(hmacHash).To(HaveLen(64))
+		})
+
+		It("requires the correct key to reproduce an hmac-sha256 hash (proves keyed-ness)", func() {
+			event := *baseEvent
+			event.HashAlgorithm = repository.HashAlgorithmHMACSHA256
+
+			hashWithKeyA, err := repository.CalculateHashForVerification([]byte("key-a-0123456789abcdef01234567"), "", &event)
+			Expect(err).ToNot(HaveOccurred())
+
+			hashWithKeyB, err := repository.CalculateHashForVerification([]byte("key-b-0123456789abcdef01234567"), "", &event)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(hashWithKeyA).ToNot(Equal(hashWithKeyB),
+				"a different key must produce a different hash for the same event — an attacker without "+
+					"the key cannot forge a matching hash after tampering")
+		})
+
+		It("returns an error when verifying an hmac-sha256 event without a configured key", func() {
+			event := *baseEvent
+			event.HashAlgorithm = repository.HashAlgorithmHMACSHA256
+
+			_, err := repository.CalculateHashForVerification(nil, "", &event)
+			Expect(err).To(HaveOccurred(),
+				"missing key must fail loudly, not silently fall back to unkeyed SHA256 (which would "+
+					"misleadingly report every hmac-sha256 event as tampered)")
+			Expect(err.Error()).To(ContainSubstring("hmac-sha256"))
+		})
+
+		It("returns an error for an unrecognized hash_algorithm value", func() {
+			event := *baseEvent
+			event.HashAlgorithm = "md5-legacy-imaginary"
+
+			_, err := repository.CalculateHashForVerification(nil, "", &event)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unrecognized"))
+		})
+
+		It("is deterministic: same key, previous hash, and event always produce the same hash", func() {
+			key := []byte("deterministic-key-0123456789ab")
+			event := *baseEvent
+			event.HashAlgorithm = repository.HashAlgorithmHMACSHA256
+
+			hash1, err := repository.CalculateHashForVerification(key, "prev-hash", &event)
+			Expect(err).ToNot(HaveOccurred())
+			hash2, err := repository.CalculateHashForVerification(key, "prev-hash", &event)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(hash1).To(Equal(hash2))
+		})
+	})
+
+	Describe("AuditEventsRepository write-time algorithm selection", func() {
+		var (
+			mockDB *sql.DB
+			mock   sqlmock.Sqlmock
+			logger logr.Logger
+			ctx    context.Context
+		)
+
+		BeforeEach(func() {
+			var err error
+			mockDB, mock, err = sqlmock.New()
+			Expect(err).ToNot(HaveOccurred())
+			logger = kubelog.NewLogger(kubelog.DefaultOptions())
+			ctx = context.Background()
+		})
+
+		AfterEach(func() {
+			_ = mockDB.Close()
+		})
+
+		It("stamps hash_algorithm=sha256-unkeyed and persists it when no HMAC key is configured", func() {
+			repo := repository.NewAuditEventsRepository(mockDB, logger)
+			Expect(repo.HMACKey()).To(BeEmpty(), "no HMAC key configured by default")
+
+			event := &repository.AuditEvent{
+				EventType:     "test.gap05.create.unkeyed",
+				EventCategory: "test",
+				EventAction:   "verify",
+				EventOutcome:  "success",
+				CorrelationID: "gap05-create-unkeyed",
+				EventData:     map[string]interface{}{},
+			}
+
+			mock.ExpectBegin()
+			mock.ExpectExec("SELECT pg_advisory_xact_lock").WillReturnResult(sqlmock.NewResult(0, 0))
+			mock.ExpectQuery("SELECT event_hash").
+				WillReturnRows(sqlmock.NewRows([]string{"event_hash"}))
+			mock.ExpectQuery("INSERT INTO audit_events").
+				WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+					sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+					sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+					sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+					sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+					sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+					sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+					sqlmock.AnyArg(), sqlmock.AnyArg(), repository.HashAlgorithmSHA256Unkeyed,
+					sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+				WillReturnRows(sqlmock.NewRows([]string{"event_timestamp"}).AddRow(time.Now()))
+			mock.ExpectCommit()
+
+			created, err := repo.Create(ctx, event)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(created.HashAlgorithm).To(Equal(repository.HashAlgorithmSHA256Unkeyed))
+			Expect(mock.ExpectationsWereMet()).To(Succeed())
+		})
+
+		It("stamps hash_algorithm=hmac-sha256 and persists it when an HMAC key is configured", func() {
+			key := []byte("write-time-hmac-key-0123456789ab")
+			repo := repository.NewAuditEventsRepository(mockDB, logger, repository.WithHMACKey(key))
+			Expect(repo.HMACKey()).To(Equal(key))
+
+			event := &repository.AuditEvent{
+				EventType:     "test.gap05.create.hmac",
+				EventCategory: "test",
+				EventAction:   "verify",
+				EventOutcome:  "success",
+				CorrelationID: "gap05-create-hmac",
+				EventData:     map[string]interface{}{},
+			}
+
+			mock.ExpectBegin()
+			mock.ExpectExec("SELECT pg_advisory_xact_lock").WillReturnResult(sqlmock.NewResult(0, 0))
+			mock.ExpectQuery("SELECT event_hash").
+				WillReturnRows(sqlmock.NewRows([]string{"event_hash"}))
+			mock.ExpectQuery("INSERT INTO audit_events").
+				WithArgs(sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+					sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+					sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+					sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+					sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+					sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+					sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(),
+					sqlmock.AnyArg(), sqlmock.AnyArg(), repository.HashAlgorithmHMACSHA256,
+					sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg(), sqlmock.AnyArg()).
+				WillReturnRows(sqlmock.NewRows([]string{"event_timestamp"}).AddRow(time.Now()))
+			mock.ExpectCommit()
+
+			created, err := repo.Create(ctx, event)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(created.HashAlgorithm).To(Equal(repository.HashAlgorithmHMACSHA256))
+
+			expectedHash, err := repository.CalculateHashForVerification(key, "", created)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(created.EventHash).To(Equal(expectedHash),
+				"the persisted hash must be reproducible via CalculateHashForVerification given the same key")
+
+			Expect(mock.ExpectationsWereMet()).To(Succeed())
+		})
+	})
+
+	Describe("WithHMACKey option", func() {
+		It("is a no-op for a nil/empty key, preserving the legacy unkeyed default", func() {
+			mockDB, _, err := sqlmock.New()
+			Expect(err).ToNot(HaveOccurred())
+			defer func() { _ = mockDB.Close() }()
+
+			repo := repository.NewAuditEventsRepository(mockDB, kubelog.NewLogger(kubelog.DefaultOptions()), repository.WithHMACKey(nil))
+			Expect(repo.HMACKey()).To(BeEmpty())
+		})
+	})
+})

--- a/pkg/datastorage/ogen-client/oas_json_gen.go
+++ b/pkg/datastorage/ogen-client/oas_json_gen.go
@@ -3233,6 +3233,278 @@ func (s *AIAgentResponsePayloadEventType) UnmarshalJSON(data []byte) error {
 }
 
 // Encode implements json.Marshaler.
+func (s *AIAgentSecretAccessedPayload) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *AIAgentSecretAccessedPayload) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("event_type")
+		s.EventType.Encode(e)
+	}
+	{
+		e.FieldStart("event_id")
+		e.Str(s.EventID)
+	}
+	{
+		e.FieldStart("verb")
+		s.Verb.Encode(e)
+	}
+	{
+		if s.Namespace.Set {
+			e.FieldStart("namespace")
+			s.Namespace.Encode(e)
+		}
+	}
+	{
+		if s.SecretName.Set {
+			e.FieldStart("secret_name")
+			s.SecretName.Encode(e)
+		}
+	}
+	{
+		if s.ToolName.Set {
+			e.FieldStart("tool_name")
+			s.ToolName.Encode(e)
+		}
+	}
+	{
+		if s.OutcomeDetail.Set {
+			e.FieldStart("outcome_detail")
+			s.OutcomeDetail.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfAIAgentSecretAccessedPayload = [7]string{
+	0: "event_type",
+	1: "event_id",
+	2: "verb",
+	3: "namespace",
+	4: "secret_name",
+	5: "tool_name",
+	6: "outcome_detail",
+}
+
+// Decode decodes AIAgentSecretAccessedPayload from json.
+func (s *AIAgentSecretAccessedPayload) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AIAgentSecretAccessedPayload to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "event_type":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.EventType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "event_id":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.EventID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_id\"")
+			}
+		case "verb":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				if err := s.Verb.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"verb\"")
+			}
+		case "namespace":
+			if err := func() error {
+				s.Namespace.Reset()
+				if err := s.Namespace.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"namespace\"")
+			}
+		case "secret_name":
+			if err := func() error {
+				s.SecretName.Reset()
+				if err := s.SecretName.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"secret_name\"")
+			}
+		case "tool_name":
+			if err := func() error {
+				s.ToolName.Reset()
+				if err := s.ToolName.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"tool_name\"")
+			}
+		case "outcome_detail":
+			if err := func() error {
+				s.OutcomeDetail.Reset()
+				if err := s.OutcomeDetail.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"outcome_detail\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode AIAgentSecretAccessedPayload")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfAIAgentSecretAccessedPayload) {
+					name = jsonFieldsNameOfAIAgentSecretAccessedPayload[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *AIAgentSecretAccessedPayload) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AIAgentSecretAccessedPayload) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes AIAgentSecretAccessedPayloadEventType as json.
+func (s AIAgentSecretAccessedPayloadEventType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes AIAgentSecretAccessedPayloadEventType from json.
+func (s *AIAgentSecretAccessedPayloadEventType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AIAgentSecretAccessedPayloadEventType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch AIAgentSecretAccessedPayloadEventType(v) {
+	case AIAgentSecretAccessedPayloadEventTypeAiagentSecretAccessed:
+		*s = AIAgentSecretAccessedPayloadEventTypeAiagentSecretAccessed
+	default:
+		*s = AIAgentSecretAccessedPayloadEventType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s AIAgentSecretAccessedPayloadEventType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AIAgentSecretAccessedPayloadEventType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes AIAgentSecretAccessedPayloadVerb as json.
+func (s AIAgentSecretAccessedPayloadVerb) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes AIAgentSecretAccessedPayloadVerb from json.
+func (s *AIAgentSecretAccessedPayloadVerb) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode AIAgentSecretAccessedPayloadVerb to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch AIAgentSecretAccessedPayloadVerb(v) {
+	case AIAgentSecretAccessedPayloadVerbGet:
+		*s = AIAgentSecretAccessedPayloadVerbGet
+	case AIAgentSecretAccessedPayloadVerbList:
+		*s = AIAgentSecretAccessedPayloadVerbList
+	default:
+		*s = AIAgentSecretAccessedPayloadVerb(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s AIAgentSecretAccessedPayloadVerb) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *AIAgentSecretAccessedPayloadVerb) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
 func (s *AIAgentSessionAccessDeniedPayload) Encode(e *jx.Encoder) {
 	e.ObjStart()
 	s.encodeFields(e)
@@ -16108,6 +16380,8 @@ func (s *AuditEventEventCategory) Decode(d *jx.Decoder) error {
 		*s = AuditEventEventCategoryActiontype
 	case AuditEventEventCategoryApifrontend:
 		*s = AuditEventEventCategoryApifrontend
+	case AuditEventEventCategorySecurity:
+		*s = AuditEventEventCategorySecurity
 	default:
 		*s = AuditEventEventCategory(v)
 	}
@@ -18013,6 +18287,44 @@ func (s AuditEventEventData) encodeFields(e *jx.Encoder) {
 				}
 			}
 		}
+	case AIAgentSecretAccessedPayloadAuditEventEventData:
+		e.FieldStart("event_type")
+		e.Str("aiagent.secret.accessed")
+		{
+			s := s.AIAgentSecretAccessedPayload
+			{
+				e.FieldStart("event_id")
+				e.Str(s.EventID)
+			}
+			{
+				e.FieldStart("verb")
+				s.Verb.Encode(e)
+			}
+			{
+				if s.Namespace.Set {
+					e.FieldStart("namespace")
+					s.Namespace.Encode(e)
+				}
+			}
+			{
+				if s.SecretName.Set {
+					e.FieldStart("secret_name")
+					s.SecretName.Encode(e)
+				}
+			}
+			{
+				if s.ToolName.Set {
+					e.FieldStart("tool_name")
+					s.ToolName.Encode(e)
+				}
+			}
+			{
+				if s.OutcomeDetail.Set {
+					e.FieldStart("outcome_detail")
+					s.OutcomeDetail.Encode(e)
+				}
+			}
+		}
 	case AIAgentSessionObservedPayloadAuditEventEventData:
 		e.FieldStart("event_type")
 		e.Str("aiagent.session.observed")
@@ -19598,6 +19910,64 @@ func (s AuditEventEventData) encodeFields(e *jx.Encoder) {
 				}
 			}
 		}
+	case DatastorageRatelimitDeniedPayloadAuditEventEventData:
+		e.FieldStart("event_type")
+		e.Str("datastorage.ratelimit.denied")
+		{
+			s := s.DatastorageRatelimitDeniedPayload
+			{
+				e.FieldStart("event_id")
+				e.Str(s.EventID)
+			}
+			{
+				if s.SourceIP.Set {
+					e.FieldStart("source_ip")
+					s.SourceIP.Encode(e)
+				}
+			}
+			{
+				if s.Path.Set {
+					e.FieldStart("path")
+					s.Path.Encode(e)
+				}
+			}
+			{
+				if s.Method.Set {
+					e.FieldStart("method")
+					s.Method.Encode(e)
+				}
+			}
+		}
+	case GatewayConfigReloadedPayloadAuditEventEventData:
+		e.FieldStart("event_type")
+		e.Str("gateway.config.reloaded")
+		{
+			s := s.GatewayConfigReloadedPayload
+			{
+				e.FieldStart("component")
+				e.Str(s.Component)
+			}
+			{
+				if s.ConfigVersion.Set {
+					e.FieldStart("config_version")
+					s.ConfigVersion.Encode(e)
+				}
+			}
+		}
+	case GatewayConfigRejectedPayloadAuditEventEventData:
+		e.FieldStart("event_type")
+		e.Str("gateway.config.rejected")
+		{
+			s := s.GatewayConfigRejectedPayload
+			{
+				e.FieldStart("component")
+				e.Str(s.Component)
+			}
+			{
+				e.FieldStart("rejection_reason")
+				e.Str(s.RejectionReason)
+			}
+		}
 	}
 }
 
@@ -19843,6 +20213,9 @@ func (s *AuditEventEventData) Decode(d *jx.Decoder) error {
 				case "aiagent.interactive.k8s_call":
 					s.Type = AIAgentInteractiveK8sCallPayloadAuditEventEventData
 					found = true
+				case "aiagent.secret.accessed":
+					s.Type = AIAgentSecretAccessedPayloadAuditEventEventData
+					found = true
 				case "aiagent.session.observed":
 					s.Type = AIAgentSessionObservedPayloadAuditEventEventData
 					found = true
@@ -20035,6 +20408,15 @@ func (s *AuditEventEventData) Decode(d *jx.Decoder) error {
 				case "apifrontend.config.rejected":
 					s.Type = ApifrontendConfigRejectedPayloadAuditEventEventData
 					found = true
+				case "datastorage.ratelimit.denied":
+					s.Type = DatastorageRatelimitDeniedPayloadAuditEventEventData
+					found = true
+				case "gateway.config.reloaded":
+					s.Type = GatewayConfigReloadedPayloadAuditEventEventData
+					found = true
+				case "gateway.config.rejected":
+					s.Type = GatewayConfigRejectedPayloadAuditEventEventData
+					found = true
 				default:
 					return errors.Errorf("unknown type %s", typ)
 				}
@@ -20203,6 +20585,10 @@ func (s *AuditEventEventData) Decode(d *jx.Decoder) error {
 		}
 	case AIAgentInteractiveK8sCallPayloadAuditEventEventData:
 		if err := s.AIAgentInteractiveK8sCallPayload.Decode(d); err != nil {
+			return err
+		}
+	case AIAgentSecretAccessedPayloadAuditEventEventData:
+		if err := s.AIAgentSecretAccessedPayload.Decode(d); err != nil {
 			return err
 		}
 	case AIAgentSessionObservedPayloadAuditEventEventData:
@@ -20403,6 +20789,18 @@ func (s *AuditEventEventData) Decode(d *jx.Decoder) error {
 		}
 	case ApifrontendConfigRejectedPayloadAuditEventEventData:
 		if err := s.ApifrontendConfigRejectedPayload.Decode(d); err != nil {
+			return err
+		}
+	case DatastorageRatelimitDeniedPayloadAuditEventEventData:
+		if err := s.DatastorageRatelimitDeniedPayload.Decode(d); err != nil {
+			return err
+		}
+	case GatewayConfigReloadedPayloadAuditEventEventData:
+		if err := s.GatewayConfigReloadedPayload.Decode(d); err != nil {
+			return err
+		}
+	case GatewayConfigRejectedPayloadAuditEventEventData:
+		if err := s.GatewayConfigRejectedPayload.Decode(d); err != nil {
 			return err
 		}
 	default:
@@ -20972,6 +21370,8 @@ func (s *AuditEventRequestEventCategory) Decode(d *jx.Decoder) error {
 		*s = AuditEventRequestEventCategoryActiontype
 	case AuditEventRequestEventCategoryApifrontend:
 		*s = AuditEventRequestEventCategoryApifrontend
+	case AuditEventRequestEventCategorySecurity:
+		*s = AuditEventRequestEventCategorySecurity
 	default:
 		*s = AuditEventRequestEventCategory(v)
 	}
@@ -22877,6 +23277,44 @@ func (s AuditEventRequestEventData) encodeFields(e *jx.Encoder) {
 				}
 			}
 		}
+	case AIAgentSecretAccessedPayloadAuditEventRequestEventData:
+		e.FieldStart("event_type")
+		e.Str("aiagent.secret.accessed")
+		{
+			s := s.AIAgentSecretAccessedPayload
+			{
+				e.FieldStart("event_id")
+				e.Str(s.EventID)
+			}
+			{
+				e.FieldStart("verb")
+				s.Verb.Encode(e)
+			}
+			{
+				if s.Namespace.Set {
+					e.FieldStart("namespace")
+					s.Namespace.Encode(e)
+				}
+			}
+			{
+				if s.SecretName.Set {
+					e.FieldStart("secret_name")
+					s.SecretName.Encode(e)
+				}
+			}
+			{
+				if s.ToolName.Set {
+					e.FieldStart("tool_name")
+					s.ToolName.Encode(e)
+				}
+			}
+			{
+				if s.OutcomeDetail.Set {
+					e.FieldStart("outcome_detail")
+					s.OutcomeDetail.Encode(e)
+				}
+			}
+		}
 	case AIAgentSessionObservedPayloadAuditEventRequestEventData:
 		e.FieldStart("event_type")
 		e.Str("aiagent.session.observed")
@@ -24462,6 +24900,64 @@ func (s AuditEventRequestEventData) encodeFields(e *jx.Encoder) {
 				}
 			}
 		}
+	case DatastorageRatelimitDeniedPayloadAuditEventRequestEventData:
+		e.FieldStart("event_type")
+		e.Str("datastorage.ratelimit.denied")
+		{
+			s := s.DatastorageRatelimitDeniedPayload
+			{
+				e.FieldStart("event_id")
+				e.Str(s.EventID)
+			}
+			{
+				if s.SourceIP.Set {
+					e.FieldStart("source_ip")
+					s.SourceIP.Encode(e)
+				}
+			}
+			{
+				if s.Path.Set {
+					e.FieldStart("path")
+					s.Path.Encode(e)
+				}
+			}
+			{
+				if s.Method.Set {
+					e.FieldStart("method")
+					s.Method.Encode(e)
+				}
+			}
+		}
+	case GatewayConfigReloadedPayloadAuditEventRequestEventData:
+		e.FieldStart("event_type")
+		e.Str("gateway.config.reloaded")
+		{
+			s := s.GatewayConfigReloadedPayload
+			{
+				e.FieldStart("component")
+				e.Str(s.Component)
+			}
+			{
+				if s.ConfigVersion.Set {
+					e.FieldStart("config_version")
+					s.ConfigVersion.Encode(e)
+				}
+			}
+		}
+	case GatewayConfigRejectedPayloadAuditEventRequestEventData:
+		e.FieldStart("event_type")
+		e.Str("gateway.config.rejected")
+		{
+			s := s.GatewayConfigRejectedPayload
+			{
+				e.FieldStart("component")
+				e.Str(s.Component)
+			}
+			{
+				e.FieldStart("rejection_reason")
+				e.Str(s.RejectionReason)
+			}
+		}
 	}
 }
 
@@ -24707,6 +25203,9 @@ func (s *AuditEventRequestEventData) Decode(d *jx.Decoder) error {
 				case "aiagent.interactive.k8s_call":
 					s.Type = AIAgentInteractiveK8sCallPayloadAuditEventRequestEventData
 					found = true
+				case "aiagent.secret.accessed":
+					s.Type = AIAgentSecretAccessedPayloadAuditEventRequestEventData
+					found = true
 				case "aiagent.session.observed":
 					s.Type = AIAgentSessionObservedPayloadAuditEventRequestEventData
 					found = true
@@ -24899,6 +25398,15 @@ func (s *AuditEventRequestEventData) Decode(d *jx.Decoder) error {
 				case "apifrontend.config.rejected":
 					s.Type = ApifrontendConfigRejectedPayloadAuditEventRequestEventData
 					found = true
+				case "datastorage.ratelimit.denied":
+					s.Type = DatastorageRatelimitDeniedPayloadAuditEventRequestEventData
+					found = true
+				case "gateway.config.reloaded":
+					s.Type = GatewayConfigReloadedPayloadAuditEventRequestEventData
+					found = true
+				case "gateway.config.rejected":
+					s.Type = GatewayConfigRejectedPayloadAuditEventRequestEventData
+					found = true
 				default:
 					return errors.Errorf("unknown type %s", typ)
 				}
@@ -25067,6 +25575,10 @@ func (s *AuditEventRequestEventData) Decode(d *jx.Decoder) error {
 		}
 	case AIAgentInteractiveK8sCallPayloadAuditEventRequestEventData:
 		if err := s.AIAgentInteractiveK8sCallPayload.Decode(d); err != nil {
+			return err
+		}
+	case AIAgentSecretAccessedPayloadAuditEventRequestEventData:
+		if err := s.AIAgentSecretAccessedPayload.Decode(d); err != nil {
 			return err
 		}
 	case AIAgentSessionObservedPayloadAuditEventRequestEventData:
@@ -25267,6 +25779,18 @@ func (s *AuditEventRequestEventData) Decode(d *jx.Decoder) error {
 		}
 	case ApifrontendConfigRejectedPayloadAuditEventRequestEventData:
 		if err := s.ApifrontendConfigRejectedPayload.Decode(d); err != nil {
+			return err
+		}
+	case DatastorageRatelimitDeniedPayloadAuditEventRequestEventData:
+		if err := s.DatastorageRatelimitDeniedPayload.Decode(d); err != nil {
+			return err
+		}
+	case GatewayConfigReloadedPayloadAuditEventRequestEventData:
+		if err := s.GatewayConfigReloadedPayload.Decode(d); err != nil {
+			return err
+		}
+	case GatewayConfigRejectedPayloadAuditEventRequestEventData:
+		if err := s.GatewayConfigRejectedPayload.Decode(d); err != nil {
 			return err
 		}
 	default:
@@ -28020,6 +28544,206 @@ func (s CustomLabels) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *CustomLabels) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *DatastorageRatelimitDeniedPayload) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *DatastorageRatelimitDeniedPayload) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("event_type")
+		s.EventType.Encode(e)
+	}
+	{
+		e.FieldStart("event_id")
+		e.Str(s.EventID)
+	}
+	{
+		if s.SourceIP.Set {
+			e.FieldStart("source_ip")
+			s.SourceIP.Encode(e)
+		}
+	}
+	{
+		if s.Path.Set {
+			e.FieldStart("path")
+			s.Path.Encode(e)
+		}
+	}
+	{
+		if s.Method.Set {
+			e.FieldStart("method")
+			s.Method.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfDatastorageRatelimitDeniedPayload = [5]string{
+	0: "event_type",
+	1: "event_id",
+	2: "source_ip",
+	3: "path",
+	4: "method",
+}
+
+// Decode decodes DatastorageRatelimitDeniedPayload from json.
+func (s *DatastorageRatelimitDeniedPayload) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DatastorageRatelimitDeniedPayload to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "event_type":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.EventType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "event_id":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.EventID = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_id\"")
+			}
+		case "source_ip":
+			if err := func() error {
+				s.SourceIP.Reset()
+				if err := s.SourceIP.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"source_ip\"")
+			}
+		case "path":
+			if err := func() error {
+				s.Path.Reset()
+				if err := s.Path.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"path\"")
+			}
+		case "method":
+			if err := func() error {
+				s.Method.Reset()
+				if err := s.Method.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"method\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode DatastorageRatelimitDeniedPayload")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfDatastorageRatelimitDeniedPayload) {
+					name = jsonFieldsNameOfDatastorageRatelimitDeniedPayload[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *DatastorageRatelimitDeniedPayload) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DatastorageRatelimitDeniedPayload) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes DatastorageRatelimitDeniedPayloadEventType as json.
+func (s DatastorageRatelimitDeniedPayloadEventType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes DatastorageRatelimitDeniedPayloadEventType from json.
+func (s *DatastorageRatelimitDeniedPayloadEventType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode DatastorageRatelimitDeniedPayloadEventType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch DatastorageRatelimitDeniedPayloadEventType(v) {
+	case DatastorageRatelimitDeniedPayloadEventTypeDatastorageRatelimitDenied:
+		*s = DatastorageRatelimitDeniedPayloadEventTypeDatastorageRatelimitDenied
+	default:
+		*s = DatastorageRatelimitDeniedPayloadEventType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s DatastorageRatelimitDeniedPayloadEventType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *DatastorageRatelimitDeniedPayloadEventType) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }
@@ -31433,6 +32157,338 @@ func (s GatewayAuditPayloadSignalType) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements stdjson.Unmarshaler.
 func (s *GatewayAuditPayloadSignalType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *GatewayConfigRejectedPayload) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *GatewayConfigRejectedPayload) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("event_type")
+		s.EventType.Encode(e)
+	}
+	{
+		e.FieldStart("component")
+		e.Str(s.Component)
+	}
+	{
+		e.FieldStart("rejection_reason")
+		e.Str(s.RejectionReason)
+	}
+}
+
+var jsonFieldsNameOfGatewayConfigRejectedPayload = [3]string{
+	0: "event_type",
+	1: "component",
+	2: "rejection_reason",
+}
+
+// Decode decodes GatewayConfigRejectedPayload from json.
+func (s *GatewayConfigRejectedPayload) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode GatewayConfigRejectedPayload to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "event_type":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.EventType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "component":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.Component = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"component\"")
+			}
+		case "rejection_reason":
+			requiredBitSet[0] |= 1 << 2
+			if err := func() error {
+				v, err := d.Str()
+				s.RejectionReason = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"rejection_reason\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode GatewayConfigRejectedPayload")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000111,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfGatewayConfigRejectedPayload) {
+					name = jsonFieldsNameOfGatewayConfigRejectedPayload[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *GatewayConfigRejectedPayload) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *GatewayConfigRejectedPayload) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes GatewayConfigRejectedPayloadEventType as json.
+func (s GatewayConfigRejectedPayloadEventType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes GatewayConfigRejectedPayloadEventType from json.
+func (s *GatewayConfigRejectedPayloadEventType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode GatewayConfigRejectedPayloadEventType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch GatewayConfigRejectedPayloadEventType(v) {
+	case GatewayConfigRejectedPayloadEventTypeGatewayConfigRejected:
+		*s = GatewayConfigRejectedPayloadEventTypeGatewayConfigRejected
+	default:
+		*s = GatewayConfigRejectedPayloadEventType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s GatewayConfigRejectedPayloadEventType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *GatewayConfigRejectedPayloadEventType) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode implements json.Marshaler.
+func (s *GatewayConfigReloadedPayload) Encode(e *jx.Encoder) {
+	e.ObjStart()
+	s.encodeFields(e)
+	e.ObjEnd()
+}
+
+// encodeFields encodes fields.
+func (s *GatewayConfigReloadedPayload) encodeFields(e *jx.Encoder) {
+	{
+		e.FieldStart("event_type")
+		s.EventType.Encode(e)
+	}
+	{
+		e.FieldStart("component")
+		e.Str(s.Component)
+	}
+	{
+		if s.ConfigVersion.Set {
+			e.FieldStart("config_version")
+			s.ConfigVersion.Encode(e)
+		}
+	}
+}
+
+var jsonFieldsNameOfGatewayConfigReloadedPayload = [3]string{
+	0: "event_type",
+	1: "component",
+	2: "config_version",
+}
+
+// Decode decodes GatewayConfigReloadedPayload from json.
+func (s *GatewayConfigReloadedPayload) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode GatewayConfigReloadedPayload to nil")
+	}
+	var requiredBitSet [1]uint8
+
+	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
+		switch string(k) {
+		case "event_type":
+			requiredBitSet[0] |= 1 << 0
+			if err := func() error {
+				if err := s.EventType.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"event_type\"")
+			}
+		case "component":
+			requiredBitSet[0] |= 1 << 1
+			if err := func() error {
+				v, err := d.Str()
+				s.Component = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"component\"")
+			}
+		case "config_version":
+			if err := func() error {
+				s.ConfigVersion.Reset()
+				if err := s.ConfigVersion.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"config_version\"")
+			}
+		default:
+			return d.Skip()
+		}
+		return nil
+	}); err != nil {
+		return errors.Wrap(err, "decode GatewayConfigReloadedPayload")
+	}
+	// Validate required fields.
+	var failures []validate.FieldError
+	for i, mask := range [1]uint8{
+		0b00000011,
+	} {
+		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
+			// Mask only required fields and check equality to mask using XOR.
+			//
+			// If XOR result is not zero, result is not equal to expected, so some fields are missed.
+			// Bits of fields which would be set are actually bits of missed fields.
+			missed := bits.OnesCount8(result)
+			for bitN := 0; bitN < missed; bitN++ {
+				bitIdx := bits.TrailingZeros8(result)
+				fieldIdx := i*8 + bitIdx
+				var name string
+				if fieldIdx < len(jsonFieldsNameOfGatewayConfigReloadedPayload) {
+					name = jsonFieldsNameOfGatewayConfigReloadedPayload[fieldIdx]
+				} else {
+					name = strconv.Itoa(fieldIdx)
+				}
+				failures = append(failures, validate.FieldError{
+					Name:  name,
+					Error: validate.ErrFieldRequired,
+				})
+				// Reset bit.
+				result &^= 1 << bitIdx
+			}
+		}
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s *GatewayConfigReloadedPayload) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *GatewayConfigReloadedPayload) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d)
+}
+
+// Encode encodes GatewayConfigReloadedPayloadEventType as json.
+func (s GatewayConfigReloadedPayloadEventType) Encode(e *jx.Encoder) {
+	e.Str(string(s))
+}
+
+// Decode decodes GatewayConfigReloadedPayloadEventType from json.
+func (s *GatewayConfigReloadedPayloadEventType) Decode(d *jx.Decoder) error {
+	if s == nil {
+		return errors.New("invalid: unable to decode GatewayConfigReloadedPayloadEventType to nil")
+	}
+	v, err := d.StrBytes()
+	if err != nil {
+		return err
+	}
+	// Try to use constant string.
+	switch GatewayConfigReloadedPayloadEventType(v) {
+	case GatewayConfigReloadedPayloadEventTypeGatewayConfigReloaded:
+		*s = GatewayConfigReloadedPayloadEventTypeGatewayConfigReloaded
+	default:
+		*s = GatewayConfigReloadedPayloadEventType(v)
+	}
+
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s GatewayConfigReloadedPayloadEventType) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *GatewayConfigReloadedPayloadEventType) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
 }

--- a/pkg/datastorage/ogen-client/oas_schemas_gen.go
+++ b/pkg/datastorage/ogen-client/oas_schemas_gen.go
@@ -1698,6 +1698,174 @@ func (s *AIAgentResponsePayloadEventType) UnmarshalText(data []byte) error {
 	}
 }
 
+// KubernautAgent Secret access audit payload (aiagent.secret.accessed) — detective control emitted
+// for every K8s Secret Get/List performed by the autonomous investigator's resource resolver,
+// regardless of outcome (GAP-13, Issue.
+// Ref: #/components/schemas/AIAgentSecretAccessedPayload
+type AIAgentSecretAccessedPayload struct {
+	// Event type for discriminator (matches parent event_type).
+	EventType AIAgentSecretAccessedPayloadEventType `json:"event_type"`
+	// Unique event identifier.
+	EventID string `json:"event_id"`
+	// K8s API verb performed against the Secret resource.
+	Verb AIAgentSecretAccessedPayloadVerb `json:"verb"`
+	// K8s namespace of the target Secret (empty for a cluster-wide list).
+	Namespace OptString `json:"namespace"`
+	// Name of the specific Secret (empty for list operations).
+	SecretName OptString `json:"secret_name"`
+	// Name of the KubernautAgent tool that triggered the access (e.g. kubectl_get_by_name).
+	ToolName OptString `json:"tool_name"`
+	// Error message when the access failed (e.g. not found, forbidden); empty on success.
+	OutcomeDetail OptString `json:"outcome_detail"`
+}
+
+// GetEventType returns the value of EventType.
+func (s *AIAgentSecretAccessedPayload) GetEventType() AIAgentSecretAccessedPayloadEventType {
+	return s.EventType
+}
+
+// GetEventID returns the value of EventID.
+func (s *AIAgentSecretAccessedPayload) GetEventID() string {
+	return s.EventID
+}
+
+// GetVerb returns the value of Verb.
+func (s *AIAgentSecretAccessedPayload) GetVerb() AIAgentSecretAccessedPayloadVerb {
+	return s.Verb
+}
+
+// GetNamespace returns the value of Namespace.
+func (s *AIAgentSecretAccessedPayload) GetNamespace() OptString {
+	return s.Namespace
+}
+
+// GetSecretName returns the value of SecretName.
+func (s *AIAgentSecretAccessedPayload) GetSecretName() OptString {
+	return s.SecretName
+}
+
+// GetToolName returns the value of ToolName.
+func (s *AIAgentSecretAccessedPayload) GetToolName() OptString {
+	return s.ToolName
+}
+
+// GetOutcomeDetail returns the value of OutcomeDetail.
+func (s *AIAgentSecretAccessedPayload) GetOutcomeDetail() OptString {
+	return s.OutcomeDetail
+}
+
+// SetEventType sets the value of EventType.
+func (s *AIAgentSecretAccessedPayload) SetEventType(val AIAgentSecretAccessedPayloadEventType) {
+	s.EventType = val
+}
+
+// SetEventID sets the value of EventID.
+func (s *AIAgentSecretAccessedPayload) SetEventID(val string) {
+	s.EventID = val
+}
+
+// SetVerb sets the value of Verb.
+func (s *AIAgentSecretAccessedPayload) SetVerb(val AIAgentSecretAccessedPayloadVerb) {
+	s.Verb = val
+}
+
+// SetNamespace sets the value of Namespace.
+func (s *AIAgentSecretAccessedPayload) SetNamespace(val OptString) {
+	s.Namespace = val
+}
+
+// SetSecretName sets the value of SecretName.
+func (s *AIAgentSecretAccessedPayload) SetSecretName(val OptString) {
+	s.SecretName = val
+}
+
+// SetToolName sets the value of ToolName.
+func (s *AIAgentSecretAccessedPayload) SetToolName(val OptString) {
+	s.ToolName = val
+}
+
+// SetOutcomeDetail sets the value of OutcomeDetail.
+func (s *AIAgentSecretAccessedPayload) SetOutcomeDetail(val OptString) {
+	s.OutcomeDetail = val
+}
+
+// Event type for discriminator (matches parent event_type).
+type AIAgentSecretAccessedPayloadEventType string
+
+const (
+	AIAgentSecretAccessedPayloadEventTypeAiagentSecretAccessed AIAgentSecretAccessedPayloadEventType = "aiagent.secret.accessed"
+)
+
+// AllValues returns all AIAgentSecretAccessedPayloadEventType values.
+func (AIAgentSecretAccessedPayloadEventType) AllValues() []AIAgentSecretAccessedPayloadEventType {
+	return []AIAgentSecretAccessedPayloadEventType{
+		AIAgentSecretAccessedPayloadEventTypeAiagentSecretAccessed,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s AIAgentSecretAccessedPayloadEventType) MarshalText() ([]byte, error) {
+	switch s {
+	case AIAgentSecretAccessedPayloadEventTypeAiagentSecretAccessed:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *AIAgentSecretAccessedPayloadEventType) UnmarshalText(data []byte) error {
+	switch AIAgentSecretAccessedPayloadEventType(data) {
+	case AIAgentSecretAccessedPayloadEventTypeAiagentSecretAccessed:
+		*s = AIAgentSecretAccessedPayloadEventTypeAiagentSecretAccessed
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// K8s API verb performed against the Secret resource.
+type AIAgentSecretAccessedPayloadVerb string
+
+const (
+	AIAgentSecretAccessedPayloadVerbGet  AIAgentSecretAccessedPayloadVerb = "get"
+	AIAgentSecretAccessedPayloadVerbList AIAgentSecretAccessedPayloadVerb = "list"
+)
+
+// AllValues returns all AIAgentSecretAccessedPayloadVerb values.
+func (AIAgentSecretAccessedPayloadVerb) AllValues() []AIAgentSecretAccessedPayloadVerb {
+	return []AIAgentSecretAccessedPayloadVerb{
+		AIAgentSecretAccessedPayloadVerbGet,
+		AIAgentSecretAccessedPayloadVerbList,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s AIAgentSecretAccessedPayloadVerb) MarshalText() ([]byte, error) {
+	switch s {
+	case AIAgentSecretAccessedPayloadVerbGet:
+		return []byte(s), nil
+	case AIAgentSecretAccessedPayloadVerbList:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *AIAgentSecretAccessedPayloadVerb) UnmarshalText(data []byte) error {
+	switch AIAgentSecretAccessedPayloadVerb(data) {
+	case AIAgentSecretAccessedPayloadVerbGet:
+		*s = AIAgentSecretAccessedPayloadVerbGet
+		return nil
+	case AIAgentSecretAccessedPayloadVerbList:
+		*s = AIAgentSecretAccessedPayloadVerbList
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
 // Session access denied event payload (aiagent.session.access_denied) - Emitted when a user attempts
 // to access a session they do not own (SOC2 CC8.1, BR-AUDIT-070).
 // Ref: #/components/schemas/AIAgentSessionAccessDeniedPayload
@@ -7910,7 +8078,9 @@ type AuditEvent struct {
 	// - effectiveness: Effectiveness assessment and monitoring events
 	// - actiontype: ActionType taxonomy lifecycle events (Issue #300)
 	// - apifrontend: API Frontend service — triage, session, delegation, and user decision events
-	// (Issue #1021).
+	// (Issue #1021)
+	// - security: Cross-cutting security control events at the HTTP layer (e.g. rate-limit denials) not
+	// tied to a single business domain (GAP-09, Issue #1505).
 	EventCategory AuditEventEventCategory `json:"event_category"`
 	// Action performed (ADR-034).
 	EventAction string `json:"event_action"`
@@ -8280,7 +8450,9 @@ func (s *AuditEvent) SetLegalHoldPlacedAt(val OptNilDateTime) {
 // - effectiveness: Effectiveness assessment and monitoring events
 // - actiontype: ActionType taxonomy lifecycle events (Issue #300)
 // - apifrontend: API Frontend service — triage, session, delegation, and user decision events
-// (Issue #1021).
+// (Issue #1021)
+// - security: Cross-cutting security control events at the HTTP layer (e.g. rate-limit denials) not
+// tied to a single business domain (GAP-09, Issue #1505).
 type AuditEventEventCategory string
 
 const (
@@ -8296,6 +8468,7 @@ const (
 	AuditEventEventCategoryEffectiveness     AuditEventEventCategory = "effectiveness"
 	AuditEventEventCategoryActiontype        AuditEventEventCategory = "actiontype"
 	AuditEventEventCategoryApifrontend       AuditEventEventCategory = "apifrontend"
+	AuditEventEventCategorySecurity          AuditEventEventCategory = "security"
 )
 
 // AllValues returns all AuditEventEventCategory values.
@@ -8313,6 +8486,7 @@ func (AuditEventEventCategory) AllValues() []AuditEventEventCategory {
 		AuditEventEventCategoryEffectiveness,
 		AuditEventEventCategoryActiontype,
 		AuditEventEventCategoryApifrontend,
+		AuditEventEventCategorySecurity,
 	}
 }
 
@@ -8342,6 +8516,8 @@ func (s AuditEventEventCategory) MarshalText() ([]byte, error) {
 	case AuditEventEventCategoryActiontype:
 		return []byte(s), nil
 	case AuditEventEventCategoryApifrontend:
+		return []byte(s), nil
+	case AuditEventEventCategorySecurity:
 		return []byte(s), nil
 	default:
 		return nil, errors.Errorf("invalid value: %q", s)
@@ -8386,6 +8562,9 @@ func (s *AuditEventEventCategory) UnmarshalText(data []byte) error {
 		return nil
 	case AuditEventEventCategoryApifrontend:
 		*s = AuditEventEventCategoryApifrontend
+		return nil
+	case AuditEventEventCategorySecurity:
+		*s = AuditEventEventCategorySecurity
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)
@@ -8438,6 +8617,7 @@ type AuditEventEventData struct {
 	AIAgentInteractiveStartedPayload             AIAgentInteractiveStartedPayload
 	AIAgentInteractiveCompletedPayload           AIAgentInteractiveCompletedPayload
 	AIAgentInteractiveK8sCallPayload             AIAgentInteractiveK8sCallPayload
+	AIAgentSecretAccessedPayload                 AIAgentSecretAccessedPayload
 	AIAgentSessionObservedPayload                AIAgentSessionObservedPayload
 	AIAgentSessionAccessDeniedPayload            AIAgentSessionAccessDeniedPayload
 	AIAgentInvestigationCancelledPayload         AIAgentInvestigationCancelledPayload
@@ -8488,6 +8668,9 @@ type AuditEventEventData struct {
 	ApifrontendSeverityTriageFailedPayload       ApifrontendSeverityTriageFailedPayload
 	ApifrontendConfigReloadedPayload             ApifrontendConfigReloadedPayload
 	ApifrontendConfigRejectedPayload             ApifrontendConfigRejectedPayload
+	DatastorageRatelimitDeniedPayload            DatastorageRatelimitDeniedPayload
+	GatewayConfigReloadedPayload                 GatewayConfigReloadedPayload
+	GatewayConfigRejectedPayload                 GatewayConfigRejectedPayload
 }
 
 // AuditEventEventDataType is oneOf type of AuditEventEventData.
@@ -8568,6 +8751,7 @@ const (
 	AIAgentInteractiveStartedPayloadAuditEventEventData                              AuditEventEventDataType = "aiagent.interactive.started"
 	AIAgentInteractiveCompletedPayloadAuditEventEventData                            AuditEventEventDataType = "aiagent.interactive.completed"
 	AIAgentInteractiveK8sCallPayloadAuditEventEventData                              AuditEventEventDataType = "aiagent.interactive.k8s_call"
+	AIAgentSecretAccessedPayloadAuditEventEventData                                  AuditEventEventDataType = "aiagent.secret.accessed"
 	AIAgentSessionObservedPayloadAuditEventEventData                                 AuditEventEventDataType = "aiagent.session.observed"
 	AIAgentSessionAccessDeniedPayloadAuditEventEventData                             AuditEventEventDataType = "aiagent.session.access_denied"
 	AIAgentInvestigationCancelledPayloadAuditEventEventData                          AuditEventEventDataType = "aiagent.investigation.cancelled"
@@ -8632,6 +8816,9 @@ const (
 	ApifrontendSeverityTriageFailedPayloadAuditEventEventData                        AuditEventEventDataType = "apifrontend.severity_triage.failed"
 	ApifrontendConfigReloadedPayloadAuditEventEventData                              AuditEventEventDataType = "apifrontend.config.reloaded"
 	ApifrontendConfigRejectedPayloadAuditEventEventData                              AuditEventEventDataType = "apifrontend.config.rejected"
+	DatastorageRatelimitDeniedPayloadAuditEventEventData                             AuditEventEventDataType = "datastorage.ratelimit.denied"
+	GatewayConfigReloadedPayloadAuditEventEventData                                  AuditEventEventDataType = "gateway.config.reloaded"
+	GatewayConfigRejectedPayloadAuditEventEventData                                  AuditEventEventDataType = "gateway.config.rejected"
 )
 
 // IsGatewayAuditPayload reports whether AuditEventEventData is GatewayAuditPayload.
@@ -8867,6 +9054,11 @@ func (s AuditEventEventData) IsAIAgentInteractiveCompletedPayload() bool {
 // IsAIAgentInteractiveK8sCallPayload reports whether AuditEventEventData is AIAgentInteractiveK8sCallPayload.
 func (s AuditEventEventData) IsAIAgentInteractiveK8sCallPayload() bool {
 	return s.Type == AIAgentInteractiveK8sCallPayloadAuditEventEventData
+}
+
+// IsAIAgentSecretAccessedPayload reports whether AuditEventEventData is AIAgentSecretAccessedPayload.
+func (s AuditEventEventData) IsAIAgentSecretAccessedPayload() bool {
+	return s.Type == AIAgentSecretAccessedPayloadAuditEventEventData
 }
 
 // IsAIAgentSessionObservedPayload reports whether AuditEventEventData is AIAgentSessionObservedPayload.
@@ -9132,6 +9324,21 @@ func (s AuditEventEventData) IsApifrontendConfigReloadedPayload() bool {
 // IsApifrontendConfigRejectedPayload reports whether AuditEventEventData is ApifrontendConfigRejectedPayload.
 func (s AuditEventEventData) IsApifrontendConfigRejectedPayload() bool {
 	return s.Type == ApifrontendConfigRejectedPayloadAuditEventEventData
+}
+
+// IsDatastorageRatelimitDeniedPayload reports whether AuditEventEventData is DatastorageRatelimitDeniedPayload.
+func (s AuditEventEventData) IsDatastorageRatelimitDeniedPayload() bool {
+	return s.Type == DatastorageRatelimitDeniedPayloadAuditEventEventData
+}
+
+// IsGatewayConfigReloadedPayload reports whether AuditEventEventData is GatewayConfigReloadedPayload.
+func (s AuditEventEventData) IsGatewayConfigReloadedPayload() bool {
+	return s.Type == GatewayConfigReloadedPayloadAuditEventEventData
+}
+
+// IsGatewayConfigRejectedPayload reports whether AuditEventEventData is GatewayConfigRejectedPayload.
+func (s AuditEventEventData) IsGatewayConfigRejectedPayload() bool {
+	return s.Type == GatewayConfigRejectedPayloadAuditEventEventData
 }
 
 // SetGatewayAuditPayload sets AuditEventEventData to GatewayAuditPayload.
@@ -10220,6 +10427,27 @@ func (s AuditEventEventData) GetAIAgentInteractiveK8sCallPayload() (v AIAgentInt
 func NewAIAgentInteractiveK8sCallPayloadAuditEventEventData(v AIAgentInteractiveK8sCallPayload) AuditEventEventData {
 	var s AuditEventEventData
 	s.SetAIAgentInteractiveK8sCallPayload(v)
+	return s
+}
+
+// SetAIAgentSecretAccessedPayload sets AuditEventEventData to AIAgentSecretAccessedPayload.
+func (s *AuditEventEventData) SetAIAgentSecretAccessedPayload(v AIAgentSecretAccessedPayload) {
+	s.Type = AIAgentSecretAccessedPayloadAuditEventEventData
+	s.AIAgentSecretAccessedPayload = v
+}
+
+// GetAIAgentSecretAccessedPayload returns AIAgentSecretAccessedPayload and true boolean if AuditEventEventData is AIAgentSecretAccessedPayload.
+func (s AuditEventEventData) GetAIAgentSecretAccessedPayload() (v AIAgentSecretAccessedPayload, ok bool) {
+	if !s.IsAIAgentSecretAccessedPayload() {
+		return v, false
+	}
+	return s.AIAgentSecretAccessedPayload, true
+}
+
+// NewAIAgentSecretAccessedPayloadAuditEventEventData returns new AuditEventEventData from AIAgentSecretAccessedPayload.
+func NewAIAgentSecretAccessedPayloadAuditEventEventData(v AIAgentSecretAccessedPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetAIAgentSecretAccessedPayload(v)
 	return s
 }
 
@@ -11383,6 +11611,69 @@ func NewApifrontendConfigRejectedPayloadAuditEventEventData(v ApifrontendConfigR
 	return s
 }
 
+// SetDatastorageRatelimitDeniedPayload sets AuditEventEventData to DatastorageRatelimitDeniedPayload.
+func (s *AuditEventEventData) SetDatastorageRatelimitDeniedPayload(v DatastorageRatelimitDeniedPayload) {
+	s.Type = DatastorageRatelimitDeniedPayloadAuditEventEventData
+	s.DatastorageRatelimitDeniedPayload = v
+}
+
+// GetDatastorageRatelimitDeniedPayload returns DatastorageRatelimitDeniedPayload and true boolean if AuditEventEventData is DatastorageRatelimitDeniedPayload.
+func (s AuditEventEventData) GetDatastorageRatelimitDeniedPayload() (v DatastorageRatelimitDeniedPayload, ok bool) {
+	if !s.IsDatastorageRatelimitDeniedPayload() {
+		return v, false
+	}
+	return s.DatastorageRatelimitDeniedPayload, true
+}
+
+// NewDatastorageRatelimitDeniedPayloadAuditEventEventData returns new AuditEventEventData from DatastorageRatelimitDeniedPayload.
+func NewDatastorageRatelimitDeniedPayloadAuditEventEventData(v DatastorageRatelimitDeniedPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetDatastorageRatelimitDeniedPayload(v)
+	return s
+}
+
+// SetGatewayConfigReloadedPayload sets AuditEventEventData to GatewayConfigReloadedPayload.
+func (s *AuditEventEventData) SetGatewayConfigReloadedPayload(v GatewayConfigReloadedPayload) {
+	s.Type = GatewayConfigReloadedPayloadAuditEventEventData
+	s.GatewayConfigReloadedPayload = v
+}
+
+// GetGatewayConfigReloadedPayload returns GatewayConfigReloadedPayload and true boolean if AuditEventEventData is GatewayConfigReloadedPayload.
+func (s AuditEventEventData) GetGatewayConfigReloadedPayload() (v GatewayConfigReloadedPayload, ok bool) {
+	if !s.IsGatewayConfigReloadedPayload() {
+		return v, false
+	}
+	return s.GatewayConfigReloadedPayload, true
+}
+
+// NewGatewayConfigReloadedPayloadAuditEventEventData returns new AuditEventEventData from GatewayConfigReloadedPayload.
+func NewGatewayConfigReloadedPayloadAuditEventEventData(v GatewayConfigReloadedPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetGatewayConfigReloadedPayload(v)
+	return s
+}
+
+// SetGatewayConfigRejectedPayload sets AuditEventEventData to GatewayConfigRejectedPayload.
+func (s *AuditEventEventData) SetGatewayConfigRejectedPayload(v GatewayConfigRejectedPayload) {
+	s.Type = GatewayConfigRejectedPayloadAuditEventEventData
+	s.GatewayConfigRejectedPayload = v
+}
+
+// GetGatewayConfigRejectedPayload returns GatewayConfigRejectedPayload and true boolean if AuditEventEventData is GatewayConfigRejectedPayload.
+func (s AuditEventEventData) GetGatewayConfigRejectedPayload() (v GatewayConfigRejectedPayload, ok bool) {
+	if !s.IsGatewayConfigRejectedPayload() {
+		return v, false
+	}
+	return s.GatewayConfigRejectedPayload, true
+}
+
+// NewGatewayConfigRejectedPayloadAuditEventEventData returns new AuditEventEventData from GatewayConfigRejectedPayload.
+func NewGatewayConfigRejectedPayloadAuditEventEventData(v GatewayConfigRejectedPayload) AuditEventEventData {
+	var s AuditEventEventData
+	s.SetGatewayConfigRejectedPayload(v)
+	return s
+}
+
 // Result of the event.
 type AuditEventEventOutcome string
 
@@ -11456,7 +11747,9 @@ type AuditEventRequest struct {
 	// - effectiveness: Effectiveness assessment and monitoring events
 	// - actiontype: ActionType taxonomy lifecycle events (Issue #300)
 	// - apifrontend: API Frontend service — triage, session, delegation, and user decision events
-	// (Issue #1021).
+	// (Issue #1021)
+	// - security: Cross-cutting security control events at the HTTP layer (e.g. rate-limit denials) not
+	// tied to a single business domain (GAP-09, Issue #1505).
 	EventCategory AuditEventRequestEventCategory `json:"event_category"`
 	// Action performed (ADR-034).
 	EventAction string `json:"event_action"`
@@ -11736,7 +12029,9 @@ func (s *AuditEventRequest) SetEventData(val AuditEventRequestEventData) {
 // - effectiveness: Effectiveness assessment and monitoring events
 // - actiontype: ActionType taxonomy lifecycle events (Issue #300)
 // - apifrontend: API Frontend service — triage, session, delegation, and user decision events
-// (Issue #1021).
+// (Issue #1021)
+// - security: Cross-cutting security control events at the HTTP layer (e.g. rate-limit denials) not
+// tied to a single business domain (GAP-09, Issue #1505).
 type AuditEventRequestEventCategory string
 
 const (
@@ -11752,6 +12047,7 @@ const (
 	AuditEventRequestEventCategoryEffectiveness     AuditEventRequestEventCategory = "effectiveness"
 	AuditEventRequestEventCategoryActiontype        AuditEventRequestEventCategory = "actiontype"
 	AuditEventRequestEventCategoryApifrontend       AuditEventRequestEventCategory = "apifrontend"
+	AuditEventRequestEventCategorySecurity          AuditEventRequestEventCategory = "security"
 )
 
 // AllValues returns all AuditEventRequestEventCategory values.
@@ -11769,6 +12065,7 @@ func (AuditEventRequestEventCategory) AllValues() []AuditEventRequestEventCatego
 		AuditEventRequestEventCategoryEffectiveness,
 		AuditEventRequestEventCategoryActiontype,
 		AuditEventRequestEventCategoryApifrontend,
+		AuditEventRequestEventCategorySecurity,
 	}
 }
 
@@ -11798,6 +12095,8 @@ func (s AuditEventRequestEventCategory) MarshalText() ([]byte, error) {
 	case AuditEventRequestEventCategoryActiontype:
 		return []byte(s), nil
 	case AuditEventRequestEventCategoryApifrontend:
+		return []byte(s), nil
+	case AuditEventRequestEventCategorySecurity:
 		return []byte(s), nil
 	default:
 		return nil, errors.Errorf("invalid value: %q", s)
@@ -11842,6 +12141,9 @@ func (s *AuditEventRequestEventCategory) UnmarshalText(data []byte) error {
 		return nil
 	case AuditEventRequestEventCategoryApifrontend:
 		*s = AuditEventRequestEventCategoryApifrontend
+		return nil
+	case AuditEventRequestEventCategorySecurity:
+		*s = AuditEventRequestEventCategorySecurity
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)
@@ -11894,6 +12196,7 @@ type AuditEventRequestEventData struct {
 	AIAgentInteractiveStartedPayload             AIAgentInteractiveStartedPayload
 	AIAgentInteractiveCompletedPayload           AIAgentInteractiveCompletedPayload
 	AIAgentInteractiveK8sCallPayload             AIAgentInteractiveK8sCallPayload
+	AIAgentSecretAccessedPayload                 AIAgentSecretAccessedPayload
 	AIAgentSessionObservedPayload                AIAgentSessionObservedPayload
 	AIAgentSessionAccessDeniedPayload            AIAgentSessionAccessDeniedPayload
 	AIAgentInvestigationCancelledPayload         AIAgentInvestigationCancelledPayload
@@ -11944,6 +12247,9 @@ type AuditEventRequestEventData struct {
 	ApifrontendSeverityTriageFailedPayload       ApifrontendSeverityTriageFailedPayload
 	ApifrontendConfigReloadedPayload             ApifrontendConfigReloadedPayload
 	ApifrontendConfigRejectedPayload             ApifrontendConfigRejectedPayload
+	DatastorageRatelimitDeniedPayload            DatastorageRatelimitDeniedPayload
+	GatewayConfigReloadedPayload                 GatewayConfigReloadedPayload
+	GatewayConfigRejectedPayload                 GatewayConfigRejectedPayload
 }
 
 // AuditEventRequestEventDataType is oneOf type of AuditEventRequestEventData.
@@ -12024,6 +12330,7 @@ const (
 	AIAgentInteractiveStartedPayloadAuditEventRequestEventData                                     AuditEventRequestEventDataType = "aiagent.interactive.started"
 	AIAgentInteractiveCompletedPayloadAuditEventRequestEventData                                   AuditEventRequestEventDataType = "aiagent.interactive.completed"
 	AIAgentInteractiveK8sCallPayloadAuditEventRequestEventData                                     AuditEventRequestEventDataType = "aiagent.interactive.k8s_call"
+	AIAgentSecretAccessedPayloadAuditEventRequestEventData                                         AuditEventRequestEventDataType = "aiagent.secret.accessed"
 	AIAgentSessionObservedPayloadAuditEventRequestEventData                                        AuditEventRequestEventDataType = "aiagent.session.observed"
 	AIAgentSessionAccessDeniedPayloadAuditEventRequestEventData                                    AuditEventRequestEventDataType = "aiagent.session.access_denied"
 	AIAgentInvestigationCancelledPayloadAuditEventRequestEventData                                 AuditEventRequestEventDataType = "aiagent.investigation.cancelled"
@@ -12088,6 +12395,9 @@ const (
 	ApifrontendSeverityTriageFailedPayloadAuditEventRequestEventData                               AuditEventRequestEventDataType = "apifrontend.severity_triage.failed"
 	ApifrontendConfigReloadedPayloadAuditEventRequestEventData                                     AuditEventRequestEventDataType = "apifrontend.config.reloaded"
 	ApifrontendConfigRejectedPayloadAuditEventRequestEventData                                     AuditEventRequestEventDataType = "apifrontend.config.rejected"
+	DatastorageRatelimitDeniedPayloadAuditEventRequestEventData                                    AuditEventRequestEventDataType = "datastorage.ratelimit.denied"
+	GatewayConfigReloadedPayloadAuditEventRequestEventData                                         AuditEventRequestEventDataType = "gateway.config.reloaded"
+	GatewayConfigRejectedPayloadAuditEventRequestEventData                                         AuditEventRequestEventDataType = "gateway.config.rejected"
 )
 
 // IsGatewayAuditPayload reports whether AuditEventRequestEventData is GatewayAuditPayload.
@@ -12323,6 +12633,11 @@ func (s AuditEventRequestEventData) IsAIAgentInteractiveCompletedPayload() bool 
 // IsAIAgentInteractiveK8sCallPayload reports whether AuditEventRequestEventData is AIAgentInteractiveK8sCallPayload.
 func (s AuditEventRequestEventData) IsAIAgentInteractiveK8sCallPayload() bool {
 	return s.Type == AIAgentInteractiveK8sCallPayloadAuditEventRequestEventData
+}
+
+// IsAIAgentSecretAccessedPayload reports whether AuditEventRequestEventData is AIAgentSecretAccessedPayload.
+func (s AuditEventRequestEventData) IsAIAgentSecretAccessedPayload() bool {
+	return s.Type == AIAgentSecretAccessedPayloadAuditEventRequestEventData
 }
 
 // IsAIAgentSessionObservedPayload reports whether AuditEventRequestEventData is AIAgentSessionObservedPayload.
@@ -12588,6 +12903,21 @@ func (s AuditEventRequestEventData) IsApifrontendConfigReloadedPayload() bool {
 // IsApifrontendConfigRejectedPayload reports whether AuditEventRequestEventData is ApifrontendConfigRejectedPayload.
 func (s AuditEventRequestEventData) IsApifrontendConfigRejectedPayload() bool {
 	return s.Type == ApifrontendConfigRejectedPayloadAuditEventRequestEventData
+}
+
+// IsDatastorageRatelimitDeniedPayload reports whether AuditEventRequestEventData is DatastorageRatelimitDeniedPayload.
+func (s AuditEventRequestEventData) IsDatastorageRatelimitDeniedPayload() bool {
+	return s.Type == DatastorageRatelimitDeniedPayloadAuditEventRequestEventData
+}
+
+// IsGatewayConfigReloadedPayload reports whether AuditEventRequestEventData is GatewayConfigReloadedPayload.
+func (s AuditEventRequestEventData) IsGatewayConfigReloadedPayload() bool {
+	return s.Type == GatewayConfigReloadedPayloadAuditEventRequestEventData
+}
+
+// IsGatewayConfigRejectedPayload reports whether AuditEventRequestEventData is GatewayConfigRejectedPayload.
+func (s AuditEventRequestEventData) IsGatewayConfigRejectedPayload() bool {
+	return s.Type == GatewayConfigRejectedPayloadAuditEventRequestEventData
 }
 
 // SetGatewayAuditPayload sets AuditEventRequestEventData to GatewayAuditPayload.
@@ -13676,6 +14006,27 @@ func (s AuditEventRequestEventData) GetAIAgentInteractiveK8sCallPayload() (v AIA
 func NewAIAgentInteractiveK8sCallPayloadAuditEventRequestEventData(v AIAgentInteractiveK8sCallPayload) AuditEventRequestEventData {
 	var s AuditEventRequestEventData
 	s.SetAIAgentInteractiveK8sCallPayload(v)
+	return s
+}
+
+// SetAIAgentSecretAccessedPayload sets AuditEventRequestEventData to AIAgentSecretAccessedPayload.
+func (s *AuditEventRequestEventData) SetAIAgentSecretAccessedPayload(v AIAgentSecretAccessedPayload) {
+	s.Type = AIAgentSecretAccessedPayloadAuditEventRequestEventData
+	s.AIAgentSecretAccessedPayload = v
+}
+
+// GetAIAgentSecretAccessedPayload returns AIAgentSecretAccessedPayload and true boolean if AuditEventRequestEventData is AIAgentSecretAccessedPayload.
+func (s AuditEventRequestEventData) GetAIAgentSecretAccessedPayload() (v AIAgentSecretAccessedPayload, ok bool) {
+	if !s.IsAIAgentSecretAccessedPayload() {
+		return v, false
+	}
+	return s.AIAgentSecretAccessedPayload, true
+}
+
+// NewAIAgentSecretAccessedPayloadAuditEventRequestEventData returns new AuditEventRequestEventData from AIAgentSecretAccessedPayload.
+func NewAIAgentSecretAccessedPayloadAuditEventRequestEventData(v AIAgentSecretAccessedPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetAIAgentSecretAccessedPayload(v)
 	return s
 }
 
@@ -14839,6 +15190,69 @@ func NewApifrontendConfigRejectedPayloadAuditEventRequestEventData(v Apifrontend
 	return s
 }
 
+// SetDatastorageRatelimitDeniedPayload sets AuditEventRequestEventData to DatastorageRatelimitDeniedPayload.
+func (s *AuditEventRequestEventData) SetDatastorageRatelimitDeniedPayload(v DatastorageRatelimitDeniedPayload) {
+	s.Type = DatastorageRatelimitDeniedPayloadAuditEventRequestEventData
+	s.DatastorageRatelimitDeniedPayload = v
+}
+
+// GetDatastorageRatelimitDeniedPayload returns DatastorageRatelimitDeniedPayload and true boolean if AuditEventRequestEventData is DatastorageRatelimitDeniedPayload.
+func (s AuditEventRequestEventData) GetDatastorageRatelimitDeniedPayload() (v DatastorageRatelimitDeniedPayload, ok bool) {
+	if !s.IsDatastorageRatelimitDeniedPayload() {
+		return v, false
+	}
+	return s.DatastorageRatelimitDeniedPayload, true
+}
+
+// NewDatastorageRatelimitDeniedPayloadAuditEventRequestEventData returns new AuditEventRequestEventData from DatastorageRatelimitDeniedPayload.
+func NewDatastorageRatelimitDeniedPayloadAuditEventRequestEventData(v DatastorageRatelimitDeniedPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetDatastorageRatelimitDeniedPayload(v)
+	return s
+}
+
+// SetGatewayConfigReloadedPayload sets AuditEventRequestEventData to GatewayConfigReloadedPayload.
+func (s *AuditEventRequestEventData) SetGatewayConfigReloadedPayload(v GatewayConfigReloadedPayload) {
+	s.Type = GatewayConfigReloadedPayloadAuditEventRequestEventData
+	s.GatewayConfigReloadedPayload = v
+}
+
+// GetGatewayConfigReloadedPayload returns GatewayConfigReloadedPayload and true boolean if AuditEventRequestEventData is GatewayConfigReloadedPayload.
+func (s AuditEventRequestEventData) GetGatewayConfigReloadedPayload() (v GatewayConfigReloadedPayload, ok bool) {
+	if !s.IsGatewayConfigReloadedPayload() {
+		return v, false
+	}
+	return s.GatewayConfigReloadedPayload, true
+}
+
+// NewGatewayConfigReloadedPayloadAuditEventRequestEventData returns new AuditEventRequestEventData from GatewayConfigReloadedPayload.
+func NewGatewayConfigReloadedPayloadAuditEventRequestEventData(v GatewayConfigReloadedPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetGatewayConfigReloadedPayload(v)
+	return s
+}
+
+// SetGatewayConfigRejectedPayload sets AuditEventRequestEventData to GatewayConfigRejectedPayload.
+func (s *AuditEventRequestEventData) SetGatewayConfigRejectedPayload(v GatewayConfigRejectedPayload) {
+	s.Type = GatewayConfigRejectedPayloadAuditEventRequestEventData
+	s.GatewayConfigRejectedPayload = v
+}
+
+// GetGatewayConfigRejectedPayload returns GatewayConfigRejectedPayload and true boolean if AuditEventRequestEventData is GatewayConfigRejectedPayload.
+func (s AuditEventRequestEventData) GetGatewayConfigRejectedPayload() (v GatewayConfigRejectedPayload, ok bool) {
+	if !s.IsGatewayConfigRejectedPayload() {
+		return v, false
+	}
+	return s.GatewayConfigRejectedPayload, true
+}
+
+// NewGatewayConfigRejectedPayloadAuditEventRequestEventData returns new AuditEventRequestEventData from GatewayConfigRejectedPayload.
+func NewGatewayConfigRejectedPayloadAuditEventRequestEventData(v GatewayConfigRejectedPayload) AuditEventRequestEventData {
+	var s AuditEventRequestEventData
+	s.SetGatewayConfigRejectedPayload(v)
+	return s
+}
+
 // Result of the event.
 type AuditEventRequestEventOutcome string
 
@@ -15861,6 +16275,107 @@ func (s *CustomLabels) init() CustomLabels {
 		*s = m
 	}
 	return m
+}
+
+// Data Storage rate limit denied event payload (datastorage.ratelimit.denied) — request rejected
+// by per-IP rate limiter on the DS HTTP API (FedRAMP AU-12, GAP-09 Issue.
+// Ref: #/components/schemas/DatastorageRatelimitDeniedPayload
+type DatastorageRatelimitDeniedPayload struct {
+	// Event type for discriminator (matches parent event_type).
+	EventType DatastorageRatelimitDeniedPayloadEventType `json:"event_type"`
+	// Unique event identifier.
+	EventID string `json:"event_id"`
+	// Source IP address of the rate-limited request.
+	SourceIP OptString `json:"source_ip"`
+	// HTTP request path.
+	Path OptString `json:"path"`
+	// HTTP request method.
+	Method OptString `json:"method"`
+}
+
+// GetEventType returns the value of EventType.
+func (s *DatastorageRatelimitDeniedPayload) GetEventType() DatastorageRatelimitDeniedPayloadEventType {
+	return s.EventType
+}
+
+// GetEventID returns the value of EventID.
+func (s *DatastorageRatelimitDeniedPayload) GetEventID() string {
+	return s.EventID
+}
+
+// GetSourceIP returns the value of SourceIP.
+func (s *DatastorageRatelimitDeniedPayload) GetSourceIP() OptString {
+	return s.SourceIP
+}
+
+// GetPath returns the value of Path.
+func (s *DatastorageRatelimitDeniedPayload) GetPath() OptString {
+	return s.Path
+}
+
+// GetMethod returns the value of Method.
+func (s *DatastorageRatelimitDeniedPayload) GetMethod() OptString {
+	return s.Method
+}
+
+// SetEventType sets the value of EventType.
+func (s *DatastorageRatelimitDeniedPayload) SetEventType(val DatastorageRatelimitDeniedPayloadEventType) {
+	s.EventType = val
+}
+
+// SetEventID sets the value of EventID.
+func (s *DatastorageRatelimitDeniedPayload) SetEventID(val string) {
+	s.EventID = val
+}
+
+// SetSourceIP sets the value of SourceIP.
+func (s *DatastorageRatelimitDeniedPayload) SetSourceIP(val OptString) {
+	s.SourceIP = val
+}
+
+// SetPath sets the value of Path.
+func (s *DatastorageRatelimitDeniedPayload) SetPath(val OptString) {
+	s.Path = val
+}
+
+// SetMethod sets the value of Method.
+func (s *DatastorageRatelimitDeniedPayload) SetMethod(val OptString) {
+	s.Method = val
+}
+
+// Event type for discriminator (matches parent event_type).
+type DatastorageRatelimitDeniedPayloadEventType string
+
+const (
+	DatastorageRatelimitDeniedPayloadEventTypeDatastorageRatelimitDenied DatastorageRatelimitDeniedPayloadEventType = "datastorage.ratelimit.denied"
+)
+
+// AllValues returns all DatastorageRatelimitDeniedPayloadEventType values.
+func (DatastorageRatelimitDeniedPayloadEventType) AllValues() []DatastorageRatelimitDeniedPayloadEventType {
+	return []DatastorageRatelimitDeniedPayloadEventType{
+		DatastorageRatelimitDeniedPayloadEventTypeDatastorageRatelimitDenied,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s DatastorageRatelimitDeniedPayloadEventType) MarshalText() ([]byte, error) {
+	switch s {
+	case DatastorageRatelimitDeniedPayloadEventTypeDatastorageRatelimitDenied:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *DatastorageRatelimitDeniedPayloadEventType) UnmarshalText(data []byte) error {
+	switch DatastorageRatelimitDeniedPayloadEventType(data) {
+	case DatastorageRatelimitDeniedPayloadEventTypeDatastorageRatelimitDenied:
+		*s = DatastorageRatelimitDeniedPayloadEventTypeDatastorageRatelimitDenied
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
 }
 
 type DeprecateWorkflowBadRequest RFC7807Problem
@@ -18021,6 +18536,160 @@ func (s *GatewayAuditPayloadSignalType) UnmarshalText(data []byte) error {
 	switch GatewayAuditPayloadSignalType(data) {
 	case GatewayAuditPayloadSignalTypeAlert:
 		*s = GatewayAuditPayloadSignalTypeAlert
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Gateway config rejected event payload (gateway.config.rejected) — hot-reload configuration
+// rejected, previous configuration kept (SOC2 CC7.2, GAP-11 Issue.
+// Ref: #/components/schemas/GatewayConfigRejectedPayload
+type GatewayConfigRejectedPayload struct {
+	// Event type for discriminator (matches parent event_type).
+	EventType GatewayConfigRejectedPayloadEventType `json:"event_type"`
+	// Hot-reloadable component whose reload was rejected (e.g. log_level, ca_cert).
+	Component string `json:"component"`
+	// Reason configuration was rejected.
+	RejectionReason string `json:"rejection_reason"`
+}
+
+// GetEventType returns the value of EventType.
+func (s *GatewayConfigRejectedPayload) GetEventType() GatewayConfigRejectedPayloadEventType {
+	return s.EventType
+}
+
+// GetComponent returns the value of Component.
+func (s *GatewayConfigRejectedPayload) GetComponent() string {
+	return s.Component
+}
+
+// GetRejectionReason returns the value of RejectionReason.
+func (s *GatewayConfigRejectedPayload) GetRejectionReason() string {
+	return s.RejectionReason
+}
+
+// SetEventType sets the value of EventType.
+func (s *GatewayConfigRejectedPayload) SetEventType(val GatewayConfigRejectedPayloadEventType) {
+	s.EventType = val
+}
+
+// SetComponent sets the value of Component.
+func (s *GatewayConfigRejectedPayload) SetComponent(val string) {
+	s.Component = val
+}
+
+// SetRejectionReason sets the value of RejectionReason.
+func (s *GatewayConfigRejectedPayload) SetRejectionReason(val string) {
+	s.RejectionReason = val
+}
+
+// Event type for discriminator (matches parent event_type).
+type GatewayConfigRejectedPayloadEventType string
+
+const (
+	GatewayConfigRejectedPayloadEventTypeGatewayConfigRejected GatewayConfigRejectedPayloadEventType = "gateway.config.rejected"
+)
+
+// AllValues returns all GatewayConfigRejectedPayloadEventType values.
+func (GatewayConfigRejectedPayloadEventType) AllValues() []GatewayConfigRejectedPayloadEventType {
+	return []GatewayConfigRejectedPayloadEventType{
+		GatewayConfigRejectedPayloadEventTypeGatewayConfigRejected,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s GatewayConfigRejectedPayloadEventType) MarshalText() ([]byte, error) {
+	switch s {
+	case GatewayConfigRejectedPayloadEventTypeGatewayConfigRejected:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *GatewayConfigRejectedPayloadEventType) UnmarshalText(data []byte) error {
+	switch GatewayConfigRejectedPayloadEventType(data) {
+	case GatewayConfigRejectedPayloadEventTypeGatewayConfigRejected:
+		*s = GatewayConfigRejectedPayloadEventTypeGatewayConfigRejected
+		return nil
+	default:
+		return errors.Errorf("invalid value: %q", data)
+	}
+}
+
+// Gateway config reloaded event payload (gateway.config.reloaded) — hot-reload configuration
+// accepted (SOC2 CC7.2, GAP-11 Issue.
+// Ref: #/components/schemas/GatewayConfigReloadedPayload
+type GatewayConfigReloadedPayload struct {
+	// Event type for discriminator (matches parent event_type).
+	EventType GatewayConfigReloadedPayloadEventType `json:"event_type"`
+	// Hot-reloadable component that was reloaded (e.g. log_level, ca_cert).
+	Component string `json:"component"`
+	// New configuration version or hash.
+	ConfigVersion OptString `json:"config_version"`
+}
+
+// GetEventType returns the value of EventType.
+func (s *GatewayConfigReloadedPayload) GetEventType() GatewayConfigReloadedPayloadEventType {
+	return s.EventType
+}
+
+// GetComponent returns the value of Component.
+func (s *GatewayConfigReloadedPayload) GetComponent() string {
+	return s.Component
+}
+
+// GetConfigVersion returns the value of ConfigVersion.
+func (s *GatewayConfigReloadedPayload) GetConfigVersion() OptString {
+	return s.ConfigVersion
+}
+
+// SetEventType sets the value of EventType.
+func (s *GatewayConfigReloadedPayload) SetEventType(val GatewayConfigReloadedPayloadEventType) {
+	s.EventType = val
+}
+
+// SetComponent sets the value of Component.
+func (s *GatewayConfigReloadedPayload) SetComponent(val string) {
+	s.Component = val
+}
+
+// SetConfigVersion sets the value of ConfigVersion.
+func (s *GatewayConfigReloadedPayload) SetConfigVersion(val OptString) {
+	s.ConfigVersion = val
+}
+
+// Event type for discriminator (matches parent event_type).
+type GatewayConfigReloadedPayloadEventType string
+
+const (
+	GatewayConfigReloadedPayloadEventTypeGatewayConfigReloaded GatewayConfigReloadedPayloadEventType = "gateway.config.reloaded"
+)
+
+// AllValues returns all GatewayConfigReloadedPayloadEventType values.
+func (GatewayConfigReloadedPayloadEventType) AllValues() []GatewayConfigReloadedPayloadEventType {
+	return []GatewayConfigReloadedPayloadEventType{
+		GatewayConfigReloadedPayloadEventTypeGatewayConfigReloaded,
+	}
+}
+
+// MarshalText implements encoding.TextMarshaler.
+func (s GatewayConfigReloadedPayloadEventType) MarshalText() ([]byte, error) {
+	switch s {
+	case GatewayConfigReloadedPayloadEventTypeGatewayConfigReloaded:
+		return []byte(s), nil
+	default:
+		return nil, errors.Errorf("invalid value: %q", s)
+	}
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (s *GatewayConfigReloadedPayloadEventType) UnmarshalText(data []byte) error {
+	switch GatewayConfigReloadedPayloadEventType(data) {
+	case GatewayConfigReloadedPayloadEventTypeGatewayConfigReloaded:
+		*s = GatewayConfigReloadedPayloadEventTypeGatewayConfigReloaded
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)

--- a/pkg/datastorage/ogen-client/oas_validators_gen.go
+++ b/pkg/datastorage/ogen-client/oas_validators_gen.go
@@ -879,6 +879,60 @@ func (s AIAgentResponsePayloadEventType) Validate() error {
 	}
 }
 
+func (s *AIAgentSecretAccessedPayload) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.EventType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "event_type",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if err := s.Verb.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "verb",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s AIAgentSecretAccessedPayloadEventType) Validate() error {
+	switch s {
+	case "aiagent.secret.accessed":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s AIAgentSecretAccessedPayloadVerb) Validate() error {
+	switch s {
+	case "get":
+		return nil
+	case "list":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
 func (s *AIAgentSessionAccessDeniedPayload) Validate() error {
 	if s == nil {
 		return validate.ErrNilPointer
@@ -3220,6 +3274,8 @@ func (s AuditEventEventCategory) Validate() error {
 		return nil
 	case "apifrontend":
 		return nil
+	case "security":
+		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)
 	}
@@ -3392,6 +3448,11 @@ func (s AuditEventEventData) Validate() error {
 		return nil
 	case AIAgentInteractiveK8sCallPayloadAuditEventEventData:
 		if err := s.AIAgentInteractiveK8sCallPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case AIAgentSecretAccessedPayloadAuditEventEventData:
+		if err := s.AIAgentSecretAccessedPayload.Validate(); err != nil {
 			return err
 		}
 		return nil
@@ -3645,6 +3706,21 @@ func (s AuditEventEventData) Validate() error {
 			return err
 		}
 		return nil
+	case DatastorageRatelimitDeniedPayloadAuditEventEventData:
+		if err := s.DatastorageRatelimitDeniedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case GatewayConfigReloadedPayloadAuditEventEventData:
+		if err := s.GatewayConfigReloadedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case GatewayConfigRejectedPayloadAuditEventEventData:
+		if err := s.GatewayConfigRejectedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
 	default:
 		return errors.Errorf("invalid type %q", s.Type)
 	}
@@ -3856,6 +3932,8 @@ func (s AuditEventRequestEventCategory) Validate() error {
 		return nil
 	case "apifrontend":
 		return nil
+	case "security":
+		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)
 	}
@@ -4028,6 +4106,11 @@ func (s AuditEventRequestEventData) Validate() error {
 		return nil
 	case AIAgentInteractiveK8sCallPayloadAuditEventRequestEventData:
 		if err := s.AIAgentInteractiveK8sCallPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case AIAgentSecretAccessedPayloadAuditEventRequestEventData:
+		if err := s.AIAgentSecretAccessedPayload.Validate(); err != nil {
 			return err
 		}
 		return nil
@@ -4278,6 +4361,21 @@ func (s AuditEventRequestEventData) Validate() error {
 		return nil
 	case ApifrontendConfigRejectedPayloadAuditEventRequestEventData:
 		if err := s.ApifrontendConfigRejectedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case DatastorageRatelimitDeniedPayloadAuditEventRequestEventData:
+		if err := s.DatastorageRatelimitDeniedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case GatewayConfigReloadedPayloadAuditEventRequestEventData:
+		if err := s.GatewayConfigReloadedPayload.Validate(); err != nil {
+			return err
+		}
+		return nil
+	case GatewayConfigRejectedPayloadAuditEventRequestEventData:
+		if err := s.GatewayConfigRejectedPayload.Validate(); err != nil {
 			return err
 		}
 		return nil
@@ -4593,6 +4691,38 @@ func (s CustomLabels) Validate() error {
 		return &validate.Error{Fields: failures}
 	}
 	return nil
+}
+
+func (s *DatastorageRatelimitDeniedPayload) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.EventType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "event_type",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s DatastorageRatelimitDeniedPayloadEventType) Validate() error {
+	switch s {
+	case "datastorage.ratelimit.denied":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
 }
 
 func (s *DetectedLabels) Validate() error {
@@ -5423,6 +5553,70 @@ func (s GatewayAuditPayloadEventType) Validate() error {
 func (s GatewayAuditPayloadSignalType) Validate() error {
 	switch s {
 	case "alert":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s *GatewayConfigRejectedPayload) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.EventType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "event_type",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s GatewayConfigRejectedPayloadEventType) Validate() error {
+	switch s {
+	case "gateway.config.rejected":
+		return nil
+	default:
+		return errors.Errorf("invalid value: %v", s)
+	}
+}
+
+func (s *GatewayConfigReloadedPayload) Validate() error {
+	if s == nil {
+		return validate.ErrNilPointer
+	}
+
+	var failures []validate.FieldError
+	if err := func() error {
+		if err := s.EventType.Validate(); err != nil {
+			return err
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "event_type",
+			Error: err,
+		})
+	}
+	if len(failures) > 0 {
+		return &validate.Error{Fields: failures}
+	}
+	return nil
+}
+
+func (s GatewayConfigReloadedPayloadEventType) Validate() error {
+	switch s {
+	case "gateway.config.reloaded":
 		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)

--- a/pkg/datastorage/prepare_event_for_hashing_test.go
+++ b/pkg/datastorage/prepare_event_for_hashing_test.go
@@ -61,6 +61,7 @@ var _ = Describe("PrepareEventForHashing", func() {
 			IsSensitive:       true,
 			EventHash:         "abc123hash",
 			PreviousEventHash: "prev456hash",
+			HashAlgorithm:     repository.HashAlgorithmHMACSHA256,
 			LegalHold:         true,
 			LegalHoldReason:   "SOX compliance",
 			LegalHoldPlacedBy: "compliance-officer",
@@ -74,6 +75,7 @@ var _ = Describe("PrepareEventForHashing", func() {
 
 		Expect(result.EventHash).To(BeEmpty(), "EventHash should be cleared")
 		Expect(result.PreviousEventHash).To(BeEmpty(), "PreviousEventHash should be cleared")
+		Expect(result.HashAlgorithm).To(BeEmpty(), "HashAlgorithm should be cleared (GAP-05: keeps pre-GAP-05 hashes verifiable)")
 		Expect(result.EventDate).To(Equal(repository.DateOnly{}), "EventDate should be zeroed")
 		Expect(result.LegalHold).To(BeFalse(), "LegalHold should be false")
 		Expect(result.LegalHoldReason).To(BeEmpty(), "LegalHoldReason should be cleared")
@@ -113,6 +115,7 @@ var _ = Describe("PrepareEventForHashing", func() {
 		// Save original values before call
 		originalHash := original.EventHash
 		originalPrevHash := original.PreviousEventHash
+		originalHashAlgorithm := original.HashAlgorithm
 		originalEventDate := original.EventDate
 		originalLegalHold := original.LegalHold
 		originalLegalHoldReason := original.LegalHoldReason
@@ -123,6 +126,7 @@ var _ = Describe("PrepareEventForHashing", func() {
 
 		Expect(original.EventHash).To(Equal(originalHash), "Original EventHash should not be mutated")
 		Expect(original.PreviousEventHash).To(Equal(originalPrevHash), "Original PreviousEventHash should not be mutated")
+		Expect(original.HashAlgorithm).To(Equal(originalHashAlgorithm), "Original HashAlgorithm should not be mutated")
 		Expect(original.EventDate).To(Equal(originalEventDate), "Original EventDate should not be mutated")
 		Expect(original.LegalHold).To(Equal(originalLegalHold), "Original LegalHold should not be mutated")
 		Expect(original.LegalHoldReason).To(Equal(originalLegalHoldReason), "Original LegalHoldReason should not be mutated")

--- a/pkg/datastorage/repository/audit_events_repository.go
+++ b/pkg/datastorage/repository/audit_events_repository.go
@@ -18,6 +18,7 @@ package repository
 
 import (
 	"context"
+	"crypto/hmac"
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
@@ -186,8 +187,14 @@ type AuditEvent struct {
 	// ========================================
 	// SOC2 Gap #9: Tamper-Evidence (Hash Chain)
 	// ========================================
-	EventHash         string `json:"event_hash"`          // SHA256 hash of (previous_event_hash + event_json)
+	EventHash         string `json:"event_hash"`          // Hash of (previous_event_hash + event_json); see HashAlgorithm
 	PreviousEventHash string `json:"previous_event_hash"` // Hash of the previous event in the chain
+
+	// HashAlgorithm records which algorithm produced EventHash: HashAlgorithmHMACSHA256
+	// (keyed, GAP-05/Issue #1505) or HashAlgorithmSHA256Unkeyed (legacy default).
+	// Excluded from the hash payload itself (see PrepareEventForHashing) so that
+	// events written before GAP-05 continue to verify against their original hash.
+	HashAlgorithm string `json:"hash_algorithm,omitempty"`
 
 	// ========================================
 	// SOC2 Gap #8: Legal Hold & Retention
@@ -207,14 +214,45 @@ type AuditEvent struct {
 type AuditEventsRepository struct {
 	db     *sql.DB
 	logger logr.Logger
+
+	// hmacKey enables keyed HMAC-SHA256 hash chaining (GAP-05, Issue #1505) for
+	// newly written events. When empty, the repository falls back to the legacy
+	// unkeyed SHA256 algorithm for backward compatibility with environments that
+	// have not yet provisioned the datastorage audit HMAC key secret.
+	hmacKey []byte
+}
+
+// AuditEventsRepositoryOption configures optional AuditEventsRepository behavior.
+type AuditEventsRepositoryOption func(*AuditEventsRepository)
+
+// WithHMACKey enables keyed HMAC-SHA256 hash chaining (GAP-05, Issue #1505).
+// A nil/empty key is a no-op, preserving the legacy unkeyed SHA256 algorithm.
+func WithHMACKey(key []byte) AuditEventsRepositoryOption {
+	return func(r *AuditEventsRepository) {
+		if len(key) > 0 {
+			r.hmacKey = key
+		}
+	}
 }
 
 // NewAuditEventsRepository creates a new repository instance
-func NewAuditEventsRepository(db *sql.DB, logger logr.Logger) *AuditEventsRepository {
-	return &AuditEventsRepository{
+func NewAuditEventsRepository(db *sql.DB, logger logr.Logger, opts ...AuditEventsRepositoryOption) *AuditEventsRepository {
+	r := &AuditEventsRepository{
 		db:     db,
 		logger: logger,
 	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// HMACKey returns the configured HMAC key, or nil when keyed hashing is disabled.
+// GAP-05 (Issue #1505): exposed so verification paths outside this package (e.g.
+// the /api/v1/audit/verify-chain HTTP handler) can recompute hmac-sha256 hashes
+// using the same key the repository uses at write time.
+func (r *AuditEventsRepository) HMACKey() []byte {
+	return r.hmacKey
 }
 
 // ========================================
@@ -223,15 +261,34 @@ func NewAuditEventsRepository(db *sql.DB, logger logr.Logger) *AuditEventsReposi
 // SOC2 Requirement: Tamper-evident audit logs (SOC 2 Type II, NIST 800-53, Sarbanes-Oxley)
 // ========================================
 
+// GAP-05 (Issue #1505): Hash chain algorithm identifiers, stored per-row in the
+// hash_algorithm column so a mixed-algorithm chain is supported during HMAC key
+// rollout (existing rows keep sha256-unkeyed; new writes use hmac-sha256 once a
+// key is configured).
+const (
+	// HashAlgorithmSHA256Unkeyed is the legacy algorithm used before GAP-05: a
+	// plain SHA256 of (previous_hash + event_json), computable by anyone without
+	// a secret. A DB-privileged attacker can recompute this hash after tampering.
+	HashAlgorithmSHA256Unkeyed = "sha256-unkeyed"
+
+	// HashAlgorithmHMACSHA256 is the GAP-05 keyed algorithm: HMAC-SHA256 of
+	// (previous_hash + event_json) using a key stored outside the database
+	// (Kubernetes Secret). Forging a valid hash without the key is infeasible.
+	HashAlgorithmHMACSHA256 = "hmac-sha256"
+)
+
 // PrepareEventForHashing returns a copy of the event with excluded fields zeroed out.
 // This MUST be used by all hash calculation paths (write-time, export, verify-chain)
 // to ensure consistent hashing across the entire audit pipeline.
 //
 // Excluded fields:
-// 1. EventHash, PreviousEventHash — not yet calculated at write time
-// 2. EventDate — derived from EventTimestamp (DB-generated)
-// 3. LegalHold, LegalHoldReason, LegalHoldPlacedBy, LegalHoldPlacedAt — can change
-//    after event creation (SOC2 Gap #8)
+//  1. EventHash, PreviousEventHash — not yet calculated at write time
+//  2. EventDate — derived from EventTimestamp (DB-generated)
+//  3. LegalHold, LegalHoldReason, LegalHoldPlacedBy, LegalHoldPlacedAt — can change
+//     after event creation (SOC2 Gap #8)
+//  4. HashAlgorithm — GAP-05 metadata describing which algorithm produced EventHash,
+//     not part of the hashed content. Excluding it keeps pre-GAP-05 hashes verifiable
+//     (their original JSON payload never contained this field).
 //
 // Note: EventTimestamp IS included in hash (set before calculation during INSERT).
 func PrepareEventForHashing(event *AuditEvent) AuditEvent {
@@ -239,6 +296,7 @@ func PrepareEventForHashing(event *AuditEvent) AuditEvent {
 	eventCopy.EventHash = ""
 	eventCopy.PreviousEventHash = ""
 	eventCopy.EventDate = DateOnly{}
+	eventCopy.HashAlgorithm = ""
 
 	// SOC2 Gap #8: Legal hold fields can change after event creation
 	eventCopy.LegalHold = false
@@ -252,6 +310,10 @@ func PrepareEventForHashing(event *AuditEvent) AuditEvent {
 // calculateEventHash computes SHA256 hash for blockchain-style chain
 // Hash = SHA256(previous_event_hash + event_json)
 // This creates an immutable chain where tampering with ANY event breaks the chain
+//
+// GAP-05 (Issue #1505): kept for the legacy HashAlgorithmSHA256Unkeyed algorithm.
+// New writes prefer calculateEventHashHMAC when a key is configured (see
+// AuditEventsRepository.hashEvent).
 func calculateEventHash(previousHash string, event *AuditEvent) (string, error) {
 	eventForHashing := PrepareEventForHashing(event)
 
@@ -268,6 +330,71 @@ func calculateEventHash(previousHash string, event *AuditEvent) (string, error) 
 	hashBytes := hasher.Sum(nil)
 
 	return hex.EncodeToString(hashBytes), nil
+}
+
+// calculateEventHashHMAC computes a keyed HMAC-SHA256 hash chain link.
+// Hash = HMAC-SHA256(key, previous_event_hash + event_json)
+//
+// GAP-05 (Issue #1505): unlike calculateEventHash (plain SHA256), forging a
+// valid hash without the key is computationally infeasible even for an
+// attacker with full read/write access to the database — closing the gap
+// where a DB-privileged attacker could tamper with an event and recompute a
+// self-consistent unkeyed SHA256 chain.
+func calculateEventHashHMAC(key []byte, previousHash string, event *AuditEvent) (string, error) {
+	eventForHashing := PrepareEventForHashing(event)
+
+	eventJSON, err := json.Marshal(eventForHashing)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal event for hashing: %w", err)
+	}
+
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(previousHash))
+	mac.Write(eventJSON)
+	hashBytes := mac.Sum(nil)
+
+	return hex.EncodeToString(hashBytes), nil
+}
+
+// hashEvent computes the hash chain link for event using this repository's
+// configured algorithm (HMAC-SHA256 when an HMAC key is set, else the legacy
+// unkeyed SHA256) and stamps event.HashAlgorithm accordingly. Used by both
+// Create and CreateBatch so the algorithm decision lives in exactly one place.
+func (r *AuditEventsRepository) hashEvent(previousHash string, event *AuditEvent) (string, error) {
+	if len(r.hmacKey) > 0 {
+		event.HashAlgorithm = HashAlgorithmHMACSHA256
+		return calculateEventHashHMAC(r.hmacKey, previousHash, event)
+	}
+	event.HashAlgorithm = HashAlgorithmSHA256Unkeyed
+	return calculateEventHash(previousHash, event)
+}
+
+// CalculateHashForVerification computes the expected hash for verification,
+// honoring the event's own HashAlgorithm (set at write time). GAP-05 (Issue
+// #1505): supports both the legacy unkeyed SHA256 algorithm and the newer
+// keyed HMAC-SHA256 algorithm within the same chain, since an HMAC key
+// rollout does not retroactively re-hash pre-existing events.
+//
+// hmacKey may be nil when the caller has no HMAC key configured. Verifying a
+// hmac-sha256 event without a key returns an error rather than silently
+// falling back to the unkeyed formula, which would always mismatch and
+// misleadingly report "tampered" for events that are actually intact.
+// Shared by repository.Export and the /api/v1/audit/verify-chain handler so
+// both verification paths apply identical logic.
+func CalculateHashForVerification(hmacKey []byte, previousHash string, event *AuditEvent) (string, error) {
+	switch event.HashAlgorithm {
+	case HashAlgorithmHMACSHA256:
+		if len(hmacKey) == 0 {
+			return "", fmt.Errorf("event %s uses hash_algorithm=%s but no HMAC key is configured for verification", event.EventID, HashAlgorithmHMACSHA256)
+		}
+		return calculateEventHashHMAC(hmacKey, previousHash, event)
+	case HashAlgorithmSHA256Unkeyed, "":
+		// Empty HashAlgorithm covers rows read before the hash_algorithm column
+		// existed (pre-GAP-05 code paths / tests using bare AuditEvent structs).
+		return calculateEventHash(previousHash, event)
+	default:
+		return "", fmt.Errorf("event %s has unrecognized hash_algorithm %q", event.EventID, event.HashAlgorithm)
+	}
 }
 
 // getPreviousEventHash retrieves the hash of the most recent event for a given correlation_id
@@ -415,7 +542,7 @@ func (r *AuditEventsRepository) Create(ctx context.Context, event *AuditEvent) (
 			return fmt.Errorf("failed to get previous event hash: %w", txErr)
 		}
 
-		eventHash, txErr := calculateEventHash(previousHash, event)
+		eventHash, txErr := r.hashEvent(previousHash, event)
 		if txErr != nil {
 			return fmt.Errorf("failed to calculate event hash: %w", txErr)
 		}
@@ -432,7 +559,7 @@ func (r *AuditEventsRepository) Create(ctx context.Context, event *AuditEvent) (
 				actor_id, actor_type, actor_ip,
 				severity, duration_ms, error_code, error_message,
 				retention_days, is_sensitive, event_data,
-				event_hash, previous_event_hash,
+				event_hash, previous_event_hash, hash_algorithm,
 				legal_hold, legal_hold_reason, legal_hold_placed_by, legal_hold_placed_at
 			) VALUES (
 				$1, $2, $3, $4, $5,
@@ -442,8 +569,8 @@ func (r *AuditEventsRepository) Create(ctx context.Context, event *AuditEvent) (
 				$16, $17, $18,
 				$19, $20, $21, $22,
 				$23, $24, $25,
-				$26, $27,
-				$28, $29, $30, $31
+				$26, $27, $28,
+				$29, $30, $31, $32
 			)
 			RETURNING event_timestamp
 		`
@@ -492,6 +619,7 @@ func (r *AuditEventsRepository) Create(ctx context.Context, event *AuditEvent) (
 			eventDataJSON,
 			event.EventHash,
 			event.PreviousEventHash,
+			event.HashAlgorithm,
 			event.LegalHold,
 			sqlutil.ToNullStringValue(event.LegalHoldReason),
 			sqlutil.ToNullStringValue(event.LegalHoldPlacedBy),
@@ -602,6 +730,7 @@ func (r *AuditEventsRepository) CreateBatch(ctx context.Context, events []*Audit
 		for _, event := range events {
 			event.EventHash = ""
 			event.PreviousEventHash = ""
+			event.HashAlgorithm = ""
 		}
 
 		tx, txErr := r.db.BeginTx(ctx, nil)
@@ -623,7 +752,7 @@ func (r *AuditEventsRepository) CreateBatch(ctx context.Context, events []*Audit
 				actor_id, actor_type, actor_ip,
 				severity, duration_ms, error_code, error_message,
 				retention_days, is_sensitive, event_data,
-				event_hash, previous_event_hash,
+				event_hash, previous_event_hash, hash_algorithm,
 				legal_hold, legal_hold_reason, legal_hold_placed_by, legal_hold_placed_at
 			) VALUES (
 				$1, $2, $3, $4, $5,
@@ -633,8 +762,8 @@ func (r *AuditEventsRepository) CreateBatch(ctx context.Context, events []*Audit
 				$16, $17, $18,
 				$19, $20, $21, $22,
 				$23, $24, $25,
-				$26, $27,
-				$28, $29, $30, $31
+				$26, $27, $28,
+				$29, $30, $31, $32
 			)
 			RETURNING event_timestamp
 		`
@@ -661,15 +790,15 @@ func (r *AuditEventsRepository) CreateBatch(ctx context.Context, events []*Audit
 			for _, ie := range correlationEvents {
 				event := ie.event
 
-			eventDataJSON, marshalErr := json.Marshal(event.EventData)
-			if marshalErr != nil {
-				txErr = fmt.Errorf("failed to marshal event_data for event %s in batch insert: %w", event.EventID, marshalErr)
-				return txErr
-			}
-			eventDate := event.EventTimestamp.Truncate(24 * time.Hour)
+				eventDataJSON, marshalErr := json.Marshal(event.EventData)
+				if marshalErr != nil {
+					txErr = fmt.Errorf("failed to marshal event_data for event %s in batch insert: %w", event.EventID, marshalErr)
+					return txErr
+				}
+				eventDate := event.EventTimestamp.Truncate(24 * time.Hour)
 
 				previousHash := lastHashByCorrelation[event.CorrelationID]
-				eventHash, hashErr := calculateEventHash(previousHash, event)
+				eventHash, hashErr := r.hashEvent(previousHash, event)
 				if hashErr != nil {
 					txErr = fmt.Errorf("failed to calculate event hash for event %s: %w", event.EventID, hashErr)
 					return txErr
@@ -722,6 +851,7 @@ func (r *AuditEventsRepository) CreateBatch(ctx context.Context, events []*Audit
 					eventDataJSON,
 					event.EventHash,
 					event.PreviousEventHash,
+					event.HashAlgorithm,
 					event.LegalHold,
 					sqlutil.ToNullStringValue(event.LegalHoldReason),
 					sqlutil.ToNullStringValue(event.LegalHoldPlacedBy),

--- a/pkg/datastorage/repository/audit_export.go
+++ b/pkg/datastorage/repository/audit_export.go
@@ -18,9 +18,7 @@ package repository
 
 import (
 	"context"
-	"crypto/sha256"
 	"database/sql"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -48,13 +46,13 @@ import (
 
 // ExportFilters contains the query filters for audit export
 type ExportFilters struct {
-	StartTime      *time.Time
-	EndTime        *time.Time
-	CorrelationID  string
-	EventCategory  string
-	Offset         int
-	Limit          int
-	RedactPII      bool // SOC2 Day 10.2: Enable PII redaction for privacy compliance
+	StartTime     *time.Time
+	EndTime       *time.Time
+	CorrelationID string
+	EventCategory string
+	Offset        int
+	Limit         int
+	RedactPII     bool // SOC2 Day 10.2: Enable PII redaction for privacy compliance
 }
 
 // ExportEvent represents an audit event with hash chain validation
@@ -65,13 +63,13 @@ type ExportEvent struct {
 
 // ExportResult contains the exported events and verification statistics
 type ExportResult struct {
-	Events                 []*ExportEvent
-	TotalEventsQueried     int
-	ValidChainEvents       int
-	BrokenChainEvents      int
-	ChainIntegrityPercent  float32
-	TamperedEventIDs       *[]string // Pointer to slice to match OpenAPI client expectation
-	VerificationTimestamp  time.Time
+	Events                []*ExportEvent
+	TotalEventsQueried    int
+	ValidChainEvents      int
+	BrokenChainEvents     int
+	ChainIntegrityPercent float32
+	TamperedEventIDs      *[]string // Pointer to slice to match OpenAPI client expectation
+	VerificationTimestamp time.Time
 }
 
 // Export retrieves audit events matching the filters and verifies hash chain integrity
@@ -86,7 +84,7 @@ func (r *AuditEventsRepository) Export(ctx context.Context, filters ExportFilter
 			namespace, cluster_name, actor_id, actor_type, actor_ip,
 			severity, duration_ms, error_code, error_message,
 			retention_days, is_sensitive, event_data,
-			event_hash, previous_event_hash, legal_hold
+			event_hash, previous_event_hash, hash_algorithm, legal_hold
 		FROM audit_events
 		WHERE 1=1
 	`
@@ -181,6 +179,7 @@ func (r *AuditEventsRepository) Export(ctx context.Context, filters ExportFilter
 			&eventDataJSON,
 			&event.EventHash,
 			&event.PreviousEventHash,
+			&event.HashAlgorithm,
 			&legalHold,
 		)
 		if err != nil {
@@ -195,26 +194,26 @@ func (r *AuditEventsRepository) Export(ctx context.Context, filters ExportFilter
 		// To ensure hash verification works, we must convert to UTC here.
 		event.EventTimestamp = event.EventTimestamp.UTC()
 
-	// Convert sql.NullString to regular strings
-	// NULL → empty string, which will be omitted by `omitempty` JSON tags during hash calculation
-	// This preserves the original JSON structure for hash verification
-	event.ResourceType = resourceType.String
-	event.ResourceID = resourceID.String
-	event.ResourceNamespace = resourceNamespace.String
-	event.ClusterID = clusterID.String
-	event.ActorID = actorID.String
-	event.ActorType = actorType.String
-	event.ActorIP = actorIP.String
-	event.Severity = severity.String
-	event.ErrorCode = errorCode.String
-	event.ErrorMessage = errorMessage.String
+		// Convert sql.NullString to regular strings
+		// NULL → empty string, which will be omitted by `omitempty` JSON tags during hash calculation
+		// This preserves the original JSON structure for hash verification
+		event.ResourceType = resourceType.String
+		event.ResourceID = resourceID.String
+		event.ResourceNamespace = resourceNamespace.String
+		event.ClusterID = clusterID.String
+		event.ActorID = actorID.String
+		event.ActorType = actorType.String
+		event.ActorIP = actorIP.String
+		event.Severity = severity.String
+		event.ErrorCode = errorCode.String
+		event.ErrorMessage = errorMessage.String
 
-	// Convert sql.NullInt64 to int
-	// NULL → 0, which will be omitted by `omitempty` JSON tag during hash calculation
-	event.DurationMs = int(durationMs.Int64)
+		// Convert sql.NullInt64 to int
+		// NULL → 0, which will be omitted by `omitempty` JSON tag during hash calculation
+		event.DurationMs = int(durationMs.Int64)
 
-	// Set legal_hold flag from scanned value
-	event.LegalHold = legalHold
+		// Set legal_hold flag from scanned value
+		event.LegalHold = legalHold
 
 		// Unmarshal event_data JSON
 		// Note: Numbers will be float64 (Go's default for JSON numbers), which matches
@@ -239,12 +238,12 @@ func (r *AuditEventsRepository) Export(ctx context.Context, filters ExportFilter
 	// This ensures JSON serialization produces [] instead of null, matching OpenAPI client expectations
 	tamperedIDs := make([]string, 0)
 	result := &ExportResult{
-		Events:                 make([]*ExportEvent, 0, len(events)),
-		TotalEventsQueried:     len(events),
-		ValidChainEvents:       0,
-		BrokenChainEvents:      0,
-		TamperedEventIDs:       &tamperedIDs,
-		VerificationTimestamp:  time.Now().UTC(),
+		Events:                make([]*ExportEvent, 0, len(events)),
+		TotalEventsQueried:    len(events),
+		ValidChainEvents:      0,
+		BrokenChainEvents:     0,
+		TamperedEventIDs:      &tamperedIDs,
+		VerificationTimestamp: time.Now().UTC(),
 	}
 
 	if len(events) == 0 {
@@ -289,8 +288,8 @@ func (r *AuditEventsRepository) Export(ctx context.Context, filters ExportFilter
 					"expected_previous_hash", previousHash,
 					"actual_previous_hash", event.PreviousEventHash)
 			} else {
-				// Calculate expected hash for this event
-				expectedHash, err := calculateEventHashForVerification(previousHash, event)
+				// Calculate expected hash for this event (GAP-05: algorithm-aware)
+				expectedHash, err := CalculateHashForVerification(r.hmacKey, previousHash, event)
 				if err != nil {
 					r.logger.Error(err, "Failed to calculate expected hash", "event_id", event.EventID)
 					return nil, fmt.Errorf("failed to calculate expected hash: %w", err)
@@ -344,22 +343,3 @@ func (r *AuditEventsRepository) Export(ctx context.Context, filters ExportFilter
 
 	return result, nil
 }
-
-// calculateEventHashForVerification computes the expected SHA256 hash for verification.
-// Uses PrepareEventForHashing to ensure identical field-clearing logic as write-time.
-func calculateEventHashForVerification(previousHash string, event *AuditEvent) (string, error) {
-	eventCopy := PrepareEventForHashing(event)
-
-	eventJSON, err := json.Marshal(eventCopy)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal event for hashing: %w", err)
-	}
-
-	hasher := sha256.New()
-	hasher.Write([]byte(previousHash))
-	hasher.Write(eventJSON)
-	hashBytes := hasher.Sum(nil)
-
-	return hex.EncodeToString(hashBytes), nil
-}
-

--- a/pkg/datastorage/server/audit_verify_chain_handler.go
+++ b/pkg/datastorage/server/audit_verify_chain_handler.go
@@ -18,16 +18,14 @@ package server
 
 import (
 	"context"
-	"crypto/sha256"
 	"database/sql"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
 
-	dsmiddleware "github.com/jordigilh/kubernaut/pkg/datastorage/server/middleware"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/repository"
+	dsmiddleware "github.com/jordigilh/kubernaut/pkg/datastorage/server/middleware"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/server/response"
 )
 
@@ -66,12 +64,12 @@ type VerifyChainResponse struct {
 
 // TamperedEvent contains details about a tampered event
 type TamperedEvent struct {
-	EventID          string    `json:"event_id"`
-	EventTimestamp   time.Time `json:"event_timestamp"`
-	ExpectedHash     string    `json:"expected_hash"`
-	ActualHash       string    `json:"actual_hash"`
-	PreviousHash     string    `json:"previous_hash"`
-	Message          string    `json:"message"`
+	EventID        string    `json:"event_id"`
+	EventTimestamp time.Time `json:"event_timestamp"`
+	ExpectedHash   string    `json:"expected_hash"`
+	ActualHash     string    `json:"actual_hash"`
+	PreviousHash   string    `json:"previous_hash"`
+	Message        string    `json:"message"`
 }
 
 // HandleVerifyChain verifies the hash chain integrity for a correlation_id
@@ -156,7 +154,7 @@ func (s *Server) verifyHashChain(ctx context.Context, correlationID string) (*Ve
 			actor_id, actor_type, actor_ip,
 			severity, duration_ms, error_code, error_message,
 			retention_days, is_sensitive, event_data,
-			event_hash, previous_event_hash,
+			event_hash, previous_event_hash, hash_algorithm,
 			event_version
 		FROM audit_events
 		WHERE correlation_id = $1
@@ -219,6 +217,7 @@ func (s *Server) verifyHashChain(ctx context.Context, correlationID string) (*Ve
 			&eventDataJSON,
 			&event.EventHash,
 			&event.PreviousEventHash,
+			&event.HashAlgorithm,
 			&event.Version,
 		)
 		if err != nil {
@@ -271,11 +270,11 @@ func (s *Server) verifyHashChain(ctx context.Context, correlationID string) (*Ve
 		return response, nil
 	}
 
-	// Verify each event's hash
+	// Verify each event's hash (GAP-05: algorithm-aware, honors each event's own hash_algorithm)
+	hmacKey := s.auditEventsRepo.HMACKey()
 	previousHash := ""
 	for _, event := range events {
-		// Calculate expected hash
-		expectedHash, err := calculateExpectedHash(previousHash, event)
+		expectedHash, err := repository.CalculateHashForVerification(hmacKey, previousHash, event)
 		if err != nil {
 			return nil, err
 		}
@@ -323,25 +322,3 @@ func (s *Server) verifyHashChain(ctx context.Context, correlationID string) (*Ve
 
 	return response, nil
 }
-
-// calculateExpectedHash computes the expected SHA256 hash for verification.
-// Uses repository.PrepareEventForHashing to ensure identical field-clearing
-// logic as write-time, preventing false-positive tampering detections.
-func calculateExpectedHash(previousHash string, event *repository.AuditEvent) (string, error) {
-	eventForHashing := repository.PrepareEventForHashing(event)
-
-	eventJSON, err := json.Marshal(eventForHashing)
-	if err != nil {
-		return "", err
-	}
-
-	hasher := sha256.New()
-	hasher.Write([]byte(previousHash))
-	hasher.Write(eventJSON)
-	hashBytes := hasher.Sum(nil)
-
-	return hex.EncodeToString(hashBytes), nil
-}
-
-
-

--- a/pkg/datastorage/server/middleware/openapi_spec_data.yaml
+++ b/pkg/datastorage/server/middleware/openapi_spec_data.yaml
@@ -2597,7 +2597,7 @@ components:
           type: string
           minLength: 1
           maxLength: 50
-          enum: [gateway, notification, analysis, aiagent, signalprocessing, workflow, workflowexecution, orchestration, approval, effectiveness, actiontype, apifrontend]
+          enum: [gateway, notification, analysis, aiagent, signalprocessing, workflow, workflowexecution, orchestration, approval, effectiveness, actiontype, apifrontend, security]
           description: |
             Domain-level event category (ADR-034 v1.8, Issue #306).
             Per convention: event_category identifies the business domain of the event.
@@ -2615,6 +2615,7 @@ components:
             - effectiveness: Effectiveness assessment and monitoring events
             - actiontype: ActionType taxonomy lifecycle events (Issue #300)
             - apifrontend: API Frontend service — triage, session, delegation, and user decision events (Issue #1021)
+            - security: Cross-cutting security control events at the HTTP layer (e.g. rate-limit denials) not tied to a single business domain (GAP-09, Issue #1505)
           example: gateway
         event_action:
           type: string
@@ -2731,6 +2732,7 @@ components:
             - $ref: '#/components/schemas/AIAgentInteractiveStartedPayload'
             - $ref: '#/components/schemas/AIAgentInteractiveCompletedPayload'
             - $ref: '#/components/schemas/AIAgentInteractiveK8sCallPayload'
+            - $ref: '#/components/schemas/AIAgentSecretAccessedPayload'
             - $ref: '#/components/schemas/AIAgentSessionObservedPayload'
             - $ref: '#/components/schemas/AIAgentSessionAccessDeniedPayload'
             - $ref: '#/components/schemas/AIAgentInvestigationCancelledPayload'
@@ -2781,6 +2783,9 @@ components:
             - $ref: '#/components/schemas/ApifrontendSeverityTriageFailedPayload'
             - $ref: '#/components/schemas/ApifrontendConfigReloadedPayload'
             - $ref: '#/components/schemas/ApifrontendConfigRejectedPayload'
+            - $ref: '#/components/schemas/DatastorageRatelimitDeniedPayload'
+            - $ref: '#/components/schemas/GatewayConfigReloadedPayload'
+            - $ref: '#/components/schemas/GatewayConfigRejectedPayload'
           discriminator:
             propertyName: event_type
             mapping:
@@ -2862,6 +2867,7 @@ components:
               'aiagent.interactive.started': '#/components/schemas/AIAgentInteractiveStartedPayload'
               'aiagent.interactive.completed': '#/components/schemas/AIAgentInteractiveCompletedPayload'
               'aiagent.interactive.k8s_call': '#/components/schemas/AIAgentInteractiveK8sCallPayload'
+              'aiagent.secret.accessed': '#/components/schemas/AIAgentSecretAccessedPayload'
               'aiagent.session.observed': '#/components/schemas/AIAgentSessionObservedPayload'
               'aiagent.session.access_denied': '#/components/schemas/AIAgentSessionAccessDeniedPayload'
               'aiagent.investigation.cancelled': '#/components/schemas/AIAgentInvestigationCancelledPayload'
@@ -2872,6 +2878,9 @@ components:
               'aiagent.ratelimit.denied': '#/components/schemas/AIAgentRatelimitDeniedPayload'
               'aiagent.auth.failure': '#/components/schemas/AIAgentAuthFailurePayload'
               'aiagent.auth.denied': '#/components/schemas/AIAgentAuthDeniedPayload'
+              'datastorage.ratelimit.denied': '#/components/schemas/DatastorageRatelimitDeniedPayload'
+              'gateway.config.reloaded': '#/components/schemas/GatewayConfigReloadedPayload'
+              'gateway.config.rejected': '#/components/schemas/GatewayConfigRejectedPayload'
               'effectiveness.health.assessed': '#/components/schemas/EffectivenessAssessmentAuditPayload'
               'effectiveness.hash.computed': '#/components/schemas/EffectivenessAssessmentAuditPayload'
               'effectiveness.alert.assessed': '#/components/schemas/EffectivenessAssessmentAuditPayload'
@@ -6219,6 +6228,35 @@ components:
           type: string
           description: Correlation ID linking to the parent remediation request
 
+    AIAgentSecretAccessedPayload:
+      type: object
+      required: [event_type, event_id, verb]
+      description: KubernautAgent Secret access audit payload (aiagent.secret.accessed) — detective control emitted for every K8s Secret Get/List performed by the autonomous investigator's resource resolver, regardless of outcome (GAP-13, Issue #1505). KubernautAgent intentionally retains broad read RBAC on Secrets for investigation completeness; this event is the compensating detective control rather than a narrowed RBAC grant.
+      properties:
+        event_type:
+          type: string
+          enum: ['aiagent.secret.accessed']
+          description: Event type for discriminator (matches parent event_type)
+        event_id:
+          type: string
+          description: Unique event identifier
+        verb:
+          type: string
+          enum: ['get', 'list']
+          description: K8s API verb performed against the Secret resource
+        namespace:
+          type: string
+          description: K8s namespace of the target Secret (empty for a cluster-wide list)
+        secret_name:
+          type: string
+          description: Name of the specific Secret (empty for list operations)
+        tool_name:
+          type: string
+          description: Name of the KubernautAgent tool that triggered the access (e.g. kubectl_get_by_name)
+        outcome_detail:
+          type: string
+          description: Error message when the access failed (e.g. not found, forbidden); empty on success
+
     AIAgentSessionObservedPayload:
       type: object
       required: [event_type, event_id, session_id]
@@ -7500,6 +7538,60 @@ components:
         event_type:
           type: string
           enum: ['aiagent.ratelimit.denied']
+          description: Event type for discriminator (matches parent event_type)
+        event_id:
+          type: string
+          description: Unique event identifier
+        source_ip:
+          type: string
+          description: Source IP address of the rate-limited request
+        path:
+          type: string
+          description: HTTP request path
+        method:
+          type: string
+          description: HTTP request method
+
+    GatewayConfigReloadedPayload:
+      type: object
+      required: [event_type, component]
+      description: Gateway config reloaded event payload (gateway.config.reloaded) — hot-reload configuration accepted (SOC2 CC7.2, GAP-11 Issue #1505)
+      properties:
+        event_type:
+          type: string
+          enum: ['gateway.config.reloaded']
+          description: Event type for discriminator (matches parent event_type)
+        component:
+          type: string
+          description: Hot-reloadable component that was reloaded (e.g. log_level, ca_cert)
+        config_version:
+          type: string
+          description: New configuration version or hash
+
+    GatewayConfigRejectedPayload:
+      type: object
+      required: [event_type, component, rejection_reason]
+      description: Gateway config rejected event payload (gateway.config.rejected) — hot-reload configuration rejected, previous configuration kept (SOC2 CC7.2, GAP-11 Issue #1505)
+      properties:
+        event_type:
+          type: string
+          enum: ['gateway.config.rejected']
+          description: Event type for discriminator (matches parent event_type)
+        component:
+          type: string
+          description: Hot-reloadable component whose reload was rejected (e.g. log_level, ca_cert)
+        rejection_reason:
+          type: string
+          description: Reason configuration was rejected
+
+    DatastorageRatelimitDeniedPayload:
+      type: object
+      required: [event_type, event_id]
+      description: Data Storage rate limit denied event payload (datastorage.ratelimit.denied) — request rejected by per-IP rate limiter on the DS HTTP API (FedRAMP AU-12, GAP-09 Issue #1505)
+      properties:
+        event_type:
+          type: string
+          enum: ['datastorage.ratelimit.denied']
           description: Event type for discriminator (matches parent event_type)
         event_id:
           type: string

--- a/pkg/datastorage/server/middleware/ratelimit.go
+++ b/pkg/datastorage/server/middleware/ratelimit.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package middleware
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/go-chi/chi/v5/middleware"
+	"github.com/go-logr/logr"
+	"golang.org/x/time/rate"
+)
+
+// IPLimiterConfig configures the per-IP rate limiter (BR-STORAGE-1505, GAP-09, Issue #1505).
+type IPLimiterConfig struct {
+	// RequestsPerSecond is the sustained per-IP request rate.
+	RequestsPerSecond float64
+	// Burst is the maximum burst size for the token bucket.
+	Burst int
+	// CleanupInterval controls how often stale IP entries are evicted (default 5m).
+	CleanupInterval time.Duration
+	// MaxAge is the idle duration after which an IP entry is evicted (default 10m).
+	MaxAge time.Duration
+}
+
+// IPLimiter provides per-IP token bucket rate limiting for the Data Storage
+// HTTP API — a pre-authentication defense against a single client (or a
+// small set of IPs) exhausting server resources (FedRAMP SC-5, GAP-09).
+type IPLimiter struct {
+	mu       sync.Mutex
+	limiters map[string]*ipEntry
+	cfg      IPLimiterConfig
+	stopCh   chan struct{}
+	stopOnce sync.Once
+}
+
+type ipEntry struct {
+	limiter  *rate.Limiter
+	lastSeen time.Time
+}
+
+// NewIPLimiter creates a per-IP rate limiter and starts background eviction
+// of stale entries. Callers must call Stop() to release the eviction goroutine.
+func NewIPLimiter(cfg IPLimiterConfig) *IPLimiter {
+	if cfg.CleanupInterval <= 0 {
+		cfg.CleanupInterval = 5 * time.Minute
+	}
+	if cfg.MaxAge <= 0 {
+		cfg.MaxAge = 10 * time.Minute
+	}
+	l := &IPLimiter{
+		limiters: make(map[string]*ipEntry),
+		cfg:      cfg,
+		stopCh:   make(chan struct{}),
+	}
+	go l.cleanup()
+	return l
+}
+
+// Allow reports whether the given IP is within its rate limit, creating a
+// fresh token bucket for previously unseen IPs.
+func (l *IPLimiter) Allow(ip string) bool {
+	l.mu.Lock()
+	entry, ok := l.limiters[ip]
+	if !ok {
+		entry = &ipEntry{
+			limiter: rate.NewLimiter(rate.Limit(l.cfg.RequestsPerSecond), l.cfg.Burst),
+		}
+		l.limiters[ip] = entry
+	}
+	entry.lastSeen = time.Now()
+	l.mu.Unlock()
+
+	return entry.limiter.Allow()
+}
+
+// Stop halts the background eviction goroutine. Safe to call multiple times.
+func (l *IPLimiter) Stop() {
+	l.stopOnce.Do(func() { close(l.stopCh) })
+}
+
+func (l *IPLimiter) cleanup() {
+	ticker := time.NewTicker(l.cfg.CleanupInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-l.stopCh:
+			return
+		case <-ticker.C:
+			l.mu.Lock()
+			cutoff := time.Now().Add(-l.cfg.MaxAge)
+			for ip, entry := range l.limiters {
+				if entry.lastSeen.Before(cutoff) {
+					delete(l.limiters, ip)
+				}
+			}
+			l.mu.Unlock()
+		}
+	}
+}
+
+// RatelimitAuditFunc is called (best-effort, non-blocking) when a request is
+// denied by the IP rate limiter, so the denial can be recorded as a
+// self-audit event (FedRAMP AU-12, GAP-09). Implementations must not block.
+type RatelimitAuditFunc func(ctx context.Context, sourceIP, path, method string)
+
+// IPRateLimitMiddlewareConfig holds dependencies for the per-IP rate-limit middleware.
+type IPRateLimitMiddlewareConfig struct {
+	Limiter *IPLimiter
+	Logger  logr.Logger
+	// AuditFunc records a rate-limit denial as a self-audit event. Optional —
+	// when nil, denials are still logged and enforced but not separately audited.
+	AuditFunc RatelimitAuditFunc
+}
+
+// IPRateLimitMiddleware returns Chi middleware enforcing per-IP rate limits on
+// the Data Storage HTTP API (GAP-09, Issue #1505 — SC-5 DoS protection).
+// Returns RFC 7807 429 with Retry-After when the limit is exceeded.
+//
+// Placed before authentication in the middleware chain: an unauthenticated
+// flood should not reach (and pay the cost of) TokenReview/SAR calls.
+func IPRateLimitMiddleware(cfg IPRateLimitMiddlewareConfig) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ip := extractClientIP(r)
+			if !cfg.Limiter.Allow(ip) {
+				cfg.Logger.Info("Rejecting request: per-IP rate limit exceeded (GAP-09, SC-5)",
+					"request_id", middleware.GetReqID(r.Context()),
+					"source_ip", ip,
+					"method", r.Method,
+					"path", r.URL.Path)
+				if cfg.AuditFunc != nil {
+					cfg.AuditFunc(r.Context(), ip, r.URL.Path, r.Method)
+				}
+				retryAfter := 1
+				if cfg.Limiter.cfg.RequestsPerSecond > 0 {
+					retryAfter = int(1.0 / cfg.Limiter.cfg.RequestsPerSecond)
+					if retryAfter < 1 {
+						retryAfter = 1
+					}
+				}
+				w.Header().Set("Retry-After", strconv.Itoa(retryAfter))
+				writeRateLimitExceeded(w, cfg.Logger)
+				return
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// writeRateLimitExceeded writes a 429 RFC 7807 response.
+func writeRateLimitExceeded(w http.ResponseWriter, logger logr.Logger) {
+	problem := map[string]interface{}{
+		"type":   "https://kubernaut.ai/problems/rate-limit-exceeded",
+		"title":  "Rate Limit Exceeded",
+		"status": http.StatusTooManyRequests,
+		"detail": "Too many requests from your IP address. Please retry later.",
+	}
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(http.StatusTooManyRequests)
+	if err := json.NewEncoder(w).Encode(problem); err != nil {
+		logger.Error(err, "Failed to encode 429 RFC 7807 response")
+	}
+}
+
+// extractClientIP returns the request's client IP, preferring the value
+// already resolved by chi's RealIP middleware (X-Forwarded-For/X-Real-IP)
+// which MUST run earlier in the chain (see server.go Handler()).
+func extractClientIP(r *http.Request) string {
+	host, _, err := net.SplitHostPort(r.RemoteAddr)
+	if err != nil {
+		return r.RemoteAddr
+	}
+	return host
+}

--- a/pkg/datastorage/server/middleware/ratelimit_test.go
+++ b/pkg/datastorage/server/middleware/ratelimit_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package middleware_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/datastorage/server/middleware"
+	kubelog "github.com/jordigilh/kubernaut/pkg/log"
+)
+
+// BR-STORAGE-1505 (GAP-09, Issue #1505): per-IP rate limiting for the Data
+// Storage HTTP API (SC-5).
+var _ = Describe("IPLimiter and IPRateLimitMiddleware", func() {
+	var logger = kubelog.NewLogger(kubelog.DefaultOptions())
+
+	okHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	Describe("IPLimiter", func() {
+		It("UT-DS-1505-RL-001: allows requests within the burst, then denies", func() {
+			l := middleware.NewIPLimiter(middleware.IPLimiterConfig{RequestsPerSecond: 1, Burst: 2})
+			defer l.Stop()
+
+			Expect(l.Allow("1.2.3.4")).To(BeTrue())
+			Expect(l.Allow("1.2.3.4")).To(BeTrue())
+			Expect(l.Allow("1.2.3.4")).To(BeFalse())
+		})
+
+		It("UT-DS-1505-RL-002: tracks separate buckets per IP", func() {
+			l := middleware.NewIPLimiter(middleware.IPLimiterConfig{RequestsPerSecond: 1, Burst: 1})
+			defer l.Stop()
+
+			Expect(l.Allow("1.1.1.1")).To(BeTrue())
+			Expect(l.Allow("1.1.1.1")).To(BeFalse())
+			// A different IP has its own independent bucket.
+			Expect(l.Allow("2.2.2.2")).To(BeTrue())
+		})
+
+		It("UT-DS-1505-RL-003: Stop is safe to call multiple times", func() {
+			l := middleware.NewIPLimiter(middleware.IPLimiterConfig{RequestsPerSecond: 1, Burst: 1})
+			Expect(func() {
+				l.Stop()
+				l.Stop()
+			}).NotTo(Panic())
+		})
+	})
+
+	Describe("IPRateLimitMiddleware", func() {
+		It("UT-DS-1505-RL-004: passes requests through while under the limit", func() {
+			limiter := middleware.NewIPLimiter(middleware.IPLimiterConfig{RequestsPerSecond: 10, Burst: 10})
+			defer limiter.Stop()
+
+			mw := middleware.IPRateLimitMiddleware(middleware.IPRateLimitMiddlewareConfig{
+				Limiter: limiter,
+				Logger:  logger,
+			})
+			handler := mw(okHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/events", nil)
+			req.RemoteAddr = "203.0.113.1:54321"
+			rec := httptest.NewRecorder()
+			handler.ServeHTTP(rec, req)
+
+			Expect(rec.Code).To(Equal(http.StatusOK))
+		})
+
+		It("UT-DS-1505-RL-005: returns RFC 7807 429 with Retry-After when the limit is exceeded", func() {
+			limiter := middleware.NewIPLimiter(middleware.IPLimiterConfig{RequestsPerSecond: 1, Burst: 1})
+			defer limiter.Stop()
+
+			mw := middleware.IPRateLimitMiddleware(middleware.IPRateLimitMiddlewareConfig{
+				Limiter: limiter,
+				Logger:  logger,
+			})
+			handler := mw(okHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/events", nil)
+			req.RemoteAddr = "203.0.113.2:54321"
+
+			rec1 := httptest.NewRecorder()
+			handler.ServeHTTP(rec1, req)
+			Expect(rec1.Code).To(Equal(http.StatusOK))
+
+			rec2 := httptest.NewRecorder()
+			handler.ServeHTTP(rec2, req)
+			Expect(rec2.Code).To(Equal(http.StatusTooManyRequests))
+			Expect(rec2.Header().Get("Retry-After")).NotTo(BeEmpty())
+			Expect(rec2.Header().Get("Content-Type")).To(Equal("application/problem+json"))
+
+			var problem map[string]interface{}
+			Expect(json.Unmarshal(rec2.Body.Bytes(), &problem)).To(Succeed())
+			Expect(problem["status"]).To(BeNumerically("==", http.StatusTooManyRequests))
+			Expect(problem["type"]).To(Equal("https://kubernaut.ai/problems/rate-limit-exceeded"))
+		})
+
+		It("UT-DS-1505-RL-006: invokes AuditFunc exactly once on denial, without blocking the response", func() {
+			limiter := middleware.NewIPLimiter(middleware.IPLimiterConfig{RequestsPerSecond: 1, Burst: 1})
+			defer limiter.Stop()
+
+			var mu sync.Mutex
+			var calls []string
+			mw := middleware.IPRateLimitMiddleware(middleware.IPRateLimitMiddlewareConfig{
+				Limiter: limiter,
+				Logger:  logger,
+				AuditFunc: func(_ context.Context, sourceIP, path, method string) {
+					mu.Lock()
+					defer mu.Unlock()
+					calls = append(calls, sourceIP+" "+method+" "+path)
+				},
+			})
+			handler := mw(okHandler)
+
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/audit/events", nil)
+			req.RemoteAddr = "203.0.113.3:1111"
+
+			handler.ServeHTTP(httptest.NewRecorder(), req) // consumes the single token
+			handler.ServeHTTP(httptest.NewRecorder(), req) // denied -> audits
+
+			mu.Lock()
+			defer mu.Unlock()
+			Expect(calls).To(HaveLen(1))
+			Expect(calls[0]).To(Equal("203.0.113.3 POST /api/v1/audit/events"))
+		})
+
+		It("UT-DS-1505-RL-007: does not invoke AuditFunc when nil", func() {
+			limiter := middleware.NewIPLimiter(middleware.IPLimiterConfig{RequestsPerSecond: 1, Burst: 1})
+			defer limiter.Stop()
+
+			mw := middleware.IPRateLimitMiddleware(middleware.IPRateLimitMiddlewareConfig{
+				Limiter: limiter,
+				Logger:  logger,
+			})
+			handler := mw(okHandler)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/audit/events", nil)
+			req.RemoteAddr = "203.0.113.4:2222"
+
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+			rec := httptest.NewRecorder()
+			Expect(func() { handler.ServeHTTP(rec, req) }).NotTo(Panic())
+			Expect(rec.Code).To(Equal(http.StatusTooManyRequests))
+		})
+	})
+})

--- a/pkg/datastorage/server/server.go
+++ b/pkg/datastorage/server/server.go
@@ -38,14 +38,15 @@ import (
 
 	"github.com/jordigilh/kubernaut/pkg/audit"
 	"github.com/jordigilh/kubernaut/pkg/cert"
+	dsaudit "github.com/jordigilh/kubernaut/pkg/datastorage/audit"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/config"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/dlq"
 	dsmetrics "github.com/jordigilh/kubernaut/pkg/datastorage/metrics"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/oci"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/partition"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/repository"
-	"github.com/jordigilh/kubernaut/pkg/datastorage/retention"
 	actiontyperepo "github.com/jordigilh/kubernaut/pkg/datastorage/repository/actiontype"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/retention"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/schema"
 	dsmiddleware "github.com/jordigilh/kubernaut/pkg/datastorage/server/middleware"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/validation"
@@ -126,6 +127,10 @@ type Server struct {
 
 	// #1048 Phase 4: Max request body size in bytes (SC-5 DoS protection)
 	maxBodySize int64
+
+	// GAP-09 (Issue #1505) / SC-5: Optional per-IP rate limiter for the HTTP API.
+	// nil when disabled (default) — see appCfg.Server.RateLimit.Enabled.
+	ipLimiter *dsmiddleware.IPLimiter
 }
 
 func defaultMaxBatchSize(v int) int {
@@ -292,9 +297,17 @@ func NewServer(deps ServerDeps) (*Server, error) {
 	// Create BR-STORAGE-033: Unified audit events repository (ADR-034)
 	// SOC2 Gap #9: PostgreSQL with custom hash chains for tamper detection
 	logger.V(1).Info("Creating ADR-034 unified audit events repository (PostgreSQL)...")
-	auditEventsRepo := repository.NewAuditEventsRepository(db, logger)
+	// GAP-05 (Issue #1505): Enable keyed HMAC-SHA256 hash chaining when an HMAC
+	// key has been provisioned; otherwise fall back to the legacy unkeyed
+	// SHA256 algorithm (backward-compatible default).
+	hashChainAlgorithm := repository.HashAlgorithmSHA256Unkeyed
+	if len(appCfg.Audit.HMACKey) > 0 {
+		hashChainAlgorithm = repository.HashAlgorithmHMACSHA256
+	}
+	auditEventsRepo := repository.NewAuditEventsRepository(db, logger, repository.WithHMACKey(appCfg.Audit.HMACKey))
 	logger.V(1).Info("ADR-034 audit events repository created (PostgreSQL-backed, SOC2 Gap #9)",
-		"audit_events_repo_nil", auditEventsRepo == nil)
+		"audit_events_repo_nil", auditEventsRepo == nil,
+		"hash_chain_algorithm", hashChainAlgorithm)
 
 	// Create BR-STORAGE-012: Self-auditing audit store (DD-STORAGE-012)
 	// Uses InternalAuditClient to avoid circular dependency (cannot call own REST API)
@@ -414,6 +427,19 @@ func NewServer(deps ServerDeps) (*Server, error) {
 		PartitionDropEnabled: appCfg.Retention.PartitionDropEnabled,
 	}, logger)
 
+	// GAP-09 (Issue #1505) / SC-5: Optional per-IP rate limiter, disabled by default.
+	var ipLimiter *dsmiddleware.IPLimiter
+	if appCfg.Server.RateLimit.Enabled {
+		ipLimiter = dsmiddleware.NewIPLimiter(dsmiddleware.IPLimiterConfig{
+			RequestsPerSecond: appCfg.Server.RateLimit.GetRequestsPerSecond(),
+			Burst:             appCfg.Server.RateLimit.GetBurst(),
+		})
+		cleanups = append(cleanups, func() { ipLimiter.Stop() })
+		logger.Info("Per-IP rate limiting enabled (GAP-09, SC-5)",
+			"requestsPerSecond", appCfg.Server.RateLimit.GetRequestsPerSecond(),
+			"burst", appCfg.Server.RateLimit.GetBurst())
+	}
+
 	// DS-FLAKY-003 FIX: Create server with handler assigned to httpServer
 	// This allows graceful shutdown to work in both Start() and httptest scenarios
 	// Previously, handler was only assigned in Start(), causing Shutdown() to hang in tests
@@ -444,6 +470,7 @@ func NewServer(deps ServerDeps) (*Server, error) {
 		openapiValidator:         openapiValidator,
 		corsAllowedOrigins:       appCfg.Server.GetCORSAllowedOrigins(),
 		maxBodySize:              appCfg.Server.GetMaxBodySize(),
+		ipLimiter:                ipLimiter, // GAP-09 (Issue #1505): nil when disabled
 	}
 
 	// DS-FLAKY-003 FIX: Assign handler immediately so Shutdown() can work
@@ -478,6 +505,26 @@ func (s *Server) Handler() http.Handler {
 	// #1048 Phase 4 / SC-5: Request body size limit (DoS protection).
 	// Applied before OpenAPI validation so the body is capped before spec parsing.
 	r.Use(dsmiddleware.MaxBytesReaderMiddleware(s.maxBodySize, s.logger))
+
+	// GAP-09 (Issue #1505) / SC-5: Optional per-IP rate limiting, pre-authentication.
+	// Placed before auth so an unauthenticated flood does not reach TokenReview/SAR calls.
+	if s.ipLimiter != nil {
+		r.Use(dsmiddleware.IPRateLimitMiddleware(dsmiddleware.IPRateLimitMiddlewareConfig{
+			Limiter: s.ipLimiter,
+			Logger:  s.logger,
+			AuditFunc: func(ctx context.Context, sourceIP, path, method string) {
+				if s.auditStore == nil {
+					return
+				}
+				auditCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+				defer cancel()
+				if err := s.auditStore.StoreAudit(auditCtx, dsaudit.NewRatelimitDeniedAuditEvent(sourceIP, path, method)); err != nil {
+					s.logger.Error(err, "Failed to persist rate-limit denial audit event",
+						"source_ip", sourceIP, "path", path, "method", method)
+				}
+			},
+		}))
+	}
 
 	// AC-4: CORS with configurable origins (ADR-030).
 	// SEC-C1: go-chi/cors treats empty AllowedOrigins as "allow all".
@@ -678,7 +725,7 @@ func (s *Server) Start() error {
 //  3. Drain in-flight HTTP connections
 //     3.5 Stop DLQ retry worker (DD-009)
 //  4. Drain DLQ messages to PostgreSQL (DD-008)
-//  4.5. Stop retention worker (AU-11) after DLQ drain, before closing DB
+//     4.5. Stop retention worker (AU-11) after DLQ drain, before closing DB
 //  5. Close external resources (audit store, PostgreSQL)
 //
 // Returns a joined error if any step failed; individual step errors are
@@ -892,6 +939,11 @@ func (s *Server) shutdownStep5CloseResources(shutdownID string) error {
 				"shutdown_id", shutdownID,
 				"dd", "DD-007-step-5-audit-complete")
 		}
+	}
+
+	// GAP-09 (Issue #1505): Stop the per-IP rate limiter's eviction goroutine, if enabled.
+	if s.ipLimiter != nil {
+		s.ipLimiter.Stop()
 	}
 
 	// Close PostgreSQL connection

--- a/pkg/gateway/config_reload_audit_test.go
+++ b/pkg/gateway/config_reload_audit_test.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gateway_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+	gatewaypkg "github.com/jordigilh/kubernaut/pkg/gateway"
+	"github.com/jordigilh/kubernaut/pkg/gateway/config"
+	"github.com/jordigilh/kubernaut/pkg/gateway/metrics"
+	testmocks "github.com/jordigilh/kubernaut/test/shared/mocks"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// ========================================
+// GAP-11 (Issue #1505): Gateway config hot-reload audit events
+// ========================================
+//
+// Verifies that EmitConfigReloadAudit records 'gateway.config.reloaded' on
+// success and 'gateway.config.rejected' (with the rejection reason) on
+// failure, for both hot-reloadable components (log_level, ca_cert) — closing
+// the SOC2 CC7.2 / FedRAMP AU-12 gap where hot-reload outcomes were only
+// logged, not audited.
+// ========================================
+
+var _ = Describe("GAP-11: Gateway config reload audit events", func() {
+	var (
+		mockAudit *testmocks.MockAuditStore
+		server    *gatewaypkg.Server
+		ctx       context.Context
+		scheme    *runtime.Scheme
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		mockAudit = testmocks.NewMockAuditStore()
+
+		Expect(os.Setenv("KUBERNAUT_CONTROLLER_NAMESPACE", "kubernaut-system")).To(Succeed())
+
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		k8sClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+		cfg := &config.ServerConfig{
+			Server: config.ServerSettings{
+				ListenAddr:   "127.0.0.1:0",
+				ReadTimeout:  30 * time.Second,
+				WriteTimeout: 30 * time.Second,
+				IdleTimeout:  120 * time.Second,
+			},
+			Processing: config.ProcessingSettings{
+				Deduplication: config.DeduplicationSettings{
+					CooldownPeriod: 300 * time.Second,
+				},
+				Retry: config.RetrySettings{
+					MaxAttempts:    3,
+					InitialBackoff: 100 * time.Millisecond,
+					MaxBackoff:     1 * time.Second,
+				},
+			},
+		}
+
+		metricsInstance := metrics.NewMetricsWithRegistry(prometheus.NewRegistry())
+
+		var err error
+		server, err = gatewaypkg.NewServerForTesting(cfg, logr.Discard(), metricsInstance, k8sClient, mockAudit, nil, nil, nil)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	Context("when a hot-reload succeeds", func() {
+		It("emits gateway.config.reloaded for the log_level component", func() {
+			server.EmitConfigReloadAudit(ctx, "log_level", nil)
+
+			Expect(mockAudit.GetStoreCalls()).To(Equal(1))
+			event := mockAudit.GetLastEvent()
+			Expect(event).NotTo(BeNil())
+			Expect(event.EventType).To(Equal("gateway.config.reloaded"))
+			Expect(event.EventOutcome).To(Equal(ogenclient.AuditEventRequestEventOutcomeSuccess))
+		})
+
+		It("emits gateway.config.reloaded for the ca_cert component", func() {
+			server.EmitConfigReloadAudit(ctx, "ca_cert", nil)
+
+			event := mockAudit.GetLastEvent()
+			Expect(event).NotTo(BeNil())
+			Expect(event.EventType).To(Equal("gateway.config.reloaded"))
+		})
+	})
+
+	Context("when a hot-reload is rejected", func() {
+		It("emits gateway.config.rejected with the rejection reason", func() {
+			reloadErr := errors.New("failed to parse config for log level reload: yaml: unexpected end of file")
+
+			server.EmitConfigReloadAudit(ctx, "log_level", reloadErr)
+
+			Expect(mockAudit.GetStoreCalls()).To(Equal(1))
+			event := mockAudit.GetLastEvent()
+			Expect(event).NotTo(BeNil())
+			Expect(event.EventType).To(Equal("gateway.config.rejected"))
+			Expect(event.EventOutcome).To(Equal(ogenclient.AuditEventRequestEventOutcomeFailure))
+
+			payload, ok := event.EventData.GetGatewayConfigRejectedPayload()
+			Expect(ok).To(BeTrue())
+			Expect(payload.Component).To(Equal("log_level"))
+			Expect(payload.RejectionReason).To(Equal(reloadErr.Error()))
+		})
+	})
+
+	Context("when no audit store is configured", func() {
+		It("does not panic and does not attempt to store an event", func() {
+			serverWithoutAudit, err := gatewaypkg.NewServerForTesting(
+				&config.ServerConfig{
+					Server: config.ServerSettings{ListenAddr: "127.0.0.1:0"},
+					Processing: config.ProcessingSettings{
+						Retry: config.RetrySettings{MaxAttempts: 1, InitialBackoff: time.Millisecond, MaxBackoff: time.Millisecond},
+					},
+				},
+				logr.Discard(), metrics.NewMetricsWithRegistry(prometheus.NewRegistry()), fake.NewClientBuilder().WithScheme(scheme).Build(), nil, nil, nil, nil,
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(func() {
+				serverWithoutAudit.EmitConfigReloadAudit(ctx, "log_level", nil)
+			}).NotTo(Panic())
+		})
+	})
+})

--- a/pkg/gateway/server.go
+++ b/pkg/gateway/server.go
@@ -31,18 +31,18 @@ import (
 	"github.com/go-chi/chi/v5"
 	chimiddleware "github.com/go-chi/chi/v5/middleware"
 	"github.com/go-logr/logr"
-	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/jordigilh/kubernaut/pkg/shared/circuitbreaker" // BR-GATEWAY-093: Circuit breaker detection
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 
 	gwerrors "github.com/jordigilh/kubernaut/pkg/gateway/errors"
 
 	"github.com/jordigilh/kubernaut/pkg/audit"                       // DD-AUDIT-003: Audit integration
 	api "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client" // Ogen generated audit types
-	"github.com/jordigilh/kubernaut/pkg/shared/auth"                 // BR-GATEWAY-036/037: Shared auth middleware
 	sharedaudit "github.com/jordigilh/kubernaut/pkg/shared/audit"    // BR-AUDIT-005 Gap #7: Standardized error details
+	"github.com/jordigilh/kubernaut/pkg/shared/auth"                 // BR-GATEWAY-036/037: Shared auth middleware
 	"github.com/jordigilh/kubernaut/pkg/shared/backoff"              // ADR-052 Addendum 001: Exponential backoff with jitter
-	sharedhealth "github.com/jordigilh/kubernaut/pkg/shared/health"   // Issue #753: Dedicated health server
-	"github.com/jordigilh/kubernaut/pkg/shared/hotreload"             // Issue #756: FileWatcher for cert rotation
+	sharedhealth "github.com/jordigilh/kubernaut/pkg/shared/health"  // Issue #753: Dedicated health server
+	"github.com/jordigilh/kubernaut/pkg/shared/hotreload"            // Issue #756: FileWatcher for cert rotation
 	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"        // Issue #493/#678: Conditional TLS
 
 	appsv1 "k8s.io/api/apps/v1"
@@ -56,6 +56,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	remediationv1alpha1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/fleet" // ADR-068: Federated scope checking factory
 	"github.com/jordigilh/kubernaut/pkg/gateway/adapters"
 	"github.com/jordigilh/kubernaut/pkg/gateway/config"
 	"github.com/jordigilh/kubernaut/pkg/gateway/k8s"
@@ -66,7 +67,6 @@ import (
 	kubecors "github.com/jordigilh/kubernaut/pkg/http/cors"  // BR-HTTP-015: Shared CORS library
 	"github.com/jordigilh/kubernaut/pkg/shared/sanitization" // DD-005: Shared sanitization library
 	"github.com/jordigilh/kubernaut/pkg/shared/scope"        // BR-SCOPE-002: Resource scope management
-	"github.com/jordigilh/kubernaut/pkg/fleet" // ADR-068: Federated scope checking factory
 )
 
 // Gateway Audit Event Type Constants (from OpenAPI spec)
@@ -76,9 +76,11 @@ const (
 	EventTypeSignalDeduplicated = "gateway.signal.deduplicated" // BR-GATEWAY-191: Duplicate signal detected
 	EventTypeCRDCreated         = "gateway.crd.created"         // DD-AUDIT-003: RR CRD successfully created
 	EventTypeCRDFailed          = "gateway.crd.failed"          // DD-AUDIT-003: RR CRD creation failed
+	EventTypeConfigReloaded     = "gateway.config.reloaded"     // GAP-11 (Issue #1505): Hot-reload accepted (log level, CA cert)
+	EventTypeConfigRejected     = "gateway.config.rejected"     // GAP-11 (Issue #1505): Hot-reload rejected, previous config kept
 	CategoryGateway             = "gateway"                     // Service-level category per ADR-034
 	// EventCategoryGateway is an alias for consistency with other services
-	EventCategoryGateway        = CategoryGateway
+	EventCategoryGateway = CategoryGateway
 )
 
 // Gateway Audit Event Action Constants (ADR-034 event_action field)
@@ -88,6 +90,8 @@ const (
 	ActionDeduplicated = "deduplicated" // Signal was deduplicated to existing RR
 	ActionCreated      = "created"      // RemediationRequest CRD was created
 	ActionFailed       = "failed"       // Operation failed
+	ActionReloaded     = "reloaded"     // GAP-11: Hot-reloadable config accepted
+	ActionRejected     = "rejected"     // GAP-11: Hot-reloadable config rejected
 )
 
 // Server is the main Gateway HTTP server
@@ -127,12 +131,12 @@ const (
 type Server struct {
 	// HTTP servers (Issue #753: 3-port standard — API :8080, Health :8081, Metrics :9090)
 	httpServer    *http.Server
-	healthServer  *http.Server // Issue #753: dedicated health probe server (/healthz, /readyz)
-	metricsServer *http.Server // Issue #753: dedicated metrics server (/metrics)
-	router        chi.Router   // Chi router for adapter registration and route grouping
-	certReloader  *sharedtls.CertReloader      // Issue #756: nil when TLS disabled
-	certWatcher   *hotreload.FileWatcher        // Issue #756: nil when TLS disabled
-	tlsCertDir    string                        // Issue #756: cert dir for FileWatcher path
+	healthServer  *http.Server            // Issue #753: dedicated health probe server (/healthz, /readyz)
+	metricsServer *http.Server            // Issue #753: dedicated metrics server (/metrics)
+	router        chi.Router              // Chi router for adapter registration and route grouping
+	certReloader  *sharedtls.CertReloader // Issue #756: nil when TLS disabled
+	certWatcher   *hotreload.FileWatcher  // Issue #756: nil when TLS disabled
+	tlsCertDir    string                  // Issue #756: cert dir for FileWatcher path
 
 	// Configuration
 	config *config.ServerConfig // ADR-030: Service configuration (needed for middleware setup)
@@ -145,7 +149,7 @@ type Server struct {
 	phaseChecker  *processing.PhaseBasedDeduplicationChecker // Phase-based deduplication logic
 	crdCreator    *processing.CRDCreator
 	lockManager   *processing.DistributedLockManager // BR-GATEWAY-190: K8s Lease-based distributed locking
-	scopeChecker  scope.ScopeChecker            // BR-SCOPE-002 + ADR-068: nil = no scope filtering (backward compat)
+	scopeChecker  scope.ScopeChecker                 // BR-SCOPE-002 + ADR-068: nil = no scope filtering (backward compat)
 
 	// ADR-057: Controller namespace where all CRDs are created and queried
 	controllerNamespace string
@@ -334,9 +338,9 @@ func NewServerForTesting(cfg *config.ServerConfig, logger logr.Logger, metricsIn
 		phaseChecker:        phaseChecker,
 		k8sClient:           k8sClient,
 		ctrlClient:          ctrlClient,
-		apiReader:           ctrlClient, // Test env: ctrlClient is uncached, works for readiness List
-		lockManager:         lockManager, // BR-GATEWAY-190: Multi-replica deduplication safety
-		auditStore:          auditStore, // Injected for testing
+		apiReader:           ctrlClient,   // Test env: ctrlClient is uncached, works for readiness List
+		lockManager:         lockManager,  // BR-GATEWAY-190: Multi-replica deduplication safety
+		auditStore:          auditStore,   // Injected for testing
 		scopeChecker:        scopeChecker, // BR-SCOPE-002: nil = no scope filtering
 		controllerNamespace: controllerNS, // Issue #195: Used by ShouldDeduplicate
 		authMiddleware:      newAuthMiddleware(authenticator, authorizer, controllerNS, logger),
@@ -721,7 +725,7 @@ func createServerWithClients(cfg *config.ServerConfig, logger logr.Logger, metri
 		apiReader:           apiReader, // ADR-057: Used for readiness K8s check (bypasses cache)
 		auditStore:          auditStore,
 		scopeChecker:        scopeCheckerInstance, // BR-SCOPE-002 + ADR-065: Label-based scope filtering (federated when fleet enabled)
-		controllerNamespace: controllerNS, // Issue #195: Used by ShouldDeduplicate
+		controllerNamespace: controllerNS,         // Issue #195: Used by ShouldDeduplicate
 		authMiddleware:      authMW,
 		metricsInstance:     metricsInstance,
 		logger:              logger,
@@ -1580,11 +1584,11 @@ func (s *Server) validateScope(ctx context.Context, signal *types.NormalizedSign
 // TDD REFACTOR: Simplified by extracting helper methods.
 //
 // Pipeline stages:
-// 1. Scope validation → validateScope() rejects unmanaged resources
-// 2. Optional distributed lock (DD-GATEWAY-013) for multi-replica safety
-// 3. Deduplication check → K8s status lookup (DD-GATEWAY-011); if duplicate,
-//    update status.deduplication on the existing RemediationRequest and return HTTP 202
-// 4. CRD creation → createRemediationRequestCRD() for new signals; return HTTP 201
+//  1. Scope validation → validateScope() rejects unmanaged resources
+//  2. Optional distributed lock (DD-GATEWAY-013) for multi-replica safety
+//  3. Deduplication check → K8s status lookup (DD-GATEWAY-011); if duplicate,
+//     update status.deduplication on the existing RemediationRequest and return HTTP 202
+//  4. CRD creation → createRemediationRequestCRD() for new signals; return HTTP 201
 //
 // Note: Environment classification and Priority assignment removed (2025-12-06).
 // These are now owned by Signal Processing service per DD-CATEGORIZATION-001.
@@ -1807,7 +1811,7 @@ func (s *Server) readinessHandler(w http.ResponseWriter, r *http.Request) {
 // writeReadinessUnavailable writes a 503 RFC 7807 response for the readiness probe.
 // logReason appears in the structured log; detail appears in the response body.
 func (s *Server) writeReadinessUnavailable(w http.ResponseWriter, r *http.Request, logReason, detail string) {
-	s.logger.Info("Readiness check failed: "+logReason)
+	s.logger.Info("Readiness check failed: " + logReason)
 
 	w.Header().Set("Content-Type", "application/problem+json")
 	w.WriteHeader(http.StatusServiceUnavailable)
@@ -1831,12 +1835,12 @@ func (s *Server) writeReadinessUnavailable(w http.ResponseWriter, r *http.Reques
 // AlertManager/webhook callers don't need this information - they only need to know
 // if the alert was accepted (HTTP status code).
 type ProcessingResponse struct {
-	Status                      string `json:"status"` // "created", "duplicate", or "rejected"
-	Message                     string `json:"message"`
-	Fingerprint                 string `json:"fingerprint"`
-	Duplicate                   bool   `json:"duplicate"`
-	RemediationRequestName      string `json:"remediationRequestName,omitempty"`
-	RemediationRequestNamespace string `json:"remediationRequestNamespace,omitempty"`
+	Status                      string                            `json:"status"` // "created", "duplicate", or "rejected"
+	Message                     string                            `json:"message"`
+	Fingerprint                 string                            `json:"fingerprint"`
+	Duplicate                   bool                              `json:"duplicate"`
+	RemediationRequestName      string                            `json:"remediationRequestName,omitempty"`
+	RemediationRequestNamespace string                            `json:"remediationRequestNamespace,omitempty"`
 	Metadata                    *processing.DeduplicationMetadata `json:"metadata,omitempty"`
 	// BR-SCOPE-002: Rejection details for unmanaged resource signals
 	Rejection *RejectionResponse `json:"rejection,omitempty"`
@@ -1978,6 +1982,56 @@ func extractRRReconstructionFields(signal *types.NormalizedSignal) (
 	return labels, annotations, originalPayload
 }
 
+// EmitConfigReloadAudit emits 'gateway.config.reloaded' (reloadErr == nil) or
+// 'gateway.config.rejected' (reloadErr != nil) for a hot-reloadable Gateway
+// component (GAP-11, Issue #1505 — SOC2 CC7.2 change management, FedRAMP AU-12).
+//
+// component identifies which hot-reloadable setting was affected, e.g.
+// "log_level" (cmd/gateway/main.go log-level FileWatcher) or "ca_cert"
+// (sharedtls.StartCAFileWatcher). Exported for use from cmd/gateway/main.go,
+// which owns both FileWatcher lifecycles.
+func (s *Server) EmitConfigReloadAudit(ctx context.Context, component string, reloadErr error) {
+	if s.auditStore == nil {
+		// ❌ CRITICAL: This should NEVER happen if init is fixed (ADR-032 §2)
+		s.logger.Error(fmt.Errorf("AuditStore is nil"), "CRITICAL: Cannot record audit event (ADR-032 §1.5 violation)")
+		return
+	}
+
+	event := audit.NewAuditEventRequest()
+	event.Version = "1.0"
+	audit.SetEventCategory(event, CategoryGateway)
+	audit.SetActor(event, "service", "gateway")
+	audit.SetResource(event, "Config", component)
+	audit.SetCorrelationID(event, fmt.Sprintf("config-reload-%s-%d", component, time.Now().UnixNano()))
+
+	if reloadErr != nil {
+		audit.SetEventType(event, EventTypeConfigRejected)
+		audit.SetEventAction(event, ActionRejected)
+		audit.SetEventOutcome(event, audit.OutcomeFailure)
+		payload := api.GatewayConfigRejectedPayload{
+			EventType:       api.GatewayConfigRejectedPayloadEventTypeGatewayConfigRejected,
+			Component:       component,
+			RejectionReason: reloadErr.Error(),
+		}
+		event.EventData = api.NewGatewayConfigRejectedPayloadAuditEventRequestEventData(payload)
+	} else {
+		audit.SetEventType(event, EventTypeConfigReloaded)
+		audit.SetEventAction(event, ActionReloaded)
+		audit.SetEventOutcome(event, audit.OutcomeSuccess)
+		payload := api.GatewayConfigReloadedPayload{
+			EventType: api.GatewayConfigReloadedPayloadEventTypeGatewayConfigReloaded,
+			Component: component,
+		}
+		event.EventData = api.NewGatewayConfigReloadedPayloadAuditEventRequestEventData(payload)
+	}
+
+	// Fire-and-forget: StoreAudit is non-blocking per DD-AUDIT-002
+	if err := s.auditStore.StoreAudit(ctx, event); err != nil {
+		s.logger.Info("DD-AUDIT-003: Failed to emit config reload audit event",
+			"error", err, "component", component)
+	}
+}
+
 // emitSignalReceivedAudit emits 'gateway.signal.received' audit event (BR-GATEWAY-190)
 // This is called when a NEW signal is received and RR is created
 func (s *Server) emitSignalReceivedAudit(ctx context.Context, signal *types.NormalizedSignal, rrName, rrNamespace string) {
@@ -2029,7 +2083,7 @@ func (s *Server) emitSignalReceivedAudit(ctx context.Context, signal *types.Norm
 
 		// Gateway-Specific Metadata
 		SignalType:  toGatewayAuditPayloadSignalType(signal.SourceType),
-		SignalName:   signal.SignalName,
+		SignalName:  signal.SignalName,
 		Namespace:   signal.Namespace,
 		Fingerprint: signal.Fingerprint,
 	}
@@ -2104,7 +2158,7 @@ func (s *Server) emitSignalDeduplicatedAudit(ctx context.Context, signal *types.
 
 		// Gateway-Specific Metadata
 		SignalType:  toGatewayAuditPayloadSignalType(signal.SourceType),
-		SignalName:   signal.SignalName,
+		SignalName:  signal.SignalName,
 		Namespace:   signal.Namespace,
 		Fingerprint: signal.Fingerprint,
 	}
@@ -2164,7 +2218,7 @@ func (s *Server) emitCRDCreatedAudit(ctx context.Context, signal *types.Normaliz
 		EventType: EventTypeCRDCreated, // Required for discriminator
 
 		SignalType:  toGatewayAuditPayloadSignalType(signal.SourceType),
-		SignalName:   signal.SignalName,
+		SignalName:  signal.SignalName,
 		Namespace:   signal.Namespace,
 		Fingerprint: signal.Fingerprint,
 	}
@@ -2264,7 +2318,7 @@ func (s *Server) emitCRDCreationFailedAudit(ctx context.Context, signal *types.N
 		EventType: EventTypeCRDFailed, // Required for discriminator
 
 		SignalType:  toGatewayAuditPayloadSignalType(signal.SourceType),
-		SignalName:   signal.SignalName,
+		SignalName:  signal.SignalName,
 		Namespace:   signal.Namespace,
 		Fingerprint: signal.Fingerprint,
 	}

--- a/pkg/kubernautagent/tools/k8s/resolver.go
+++ b/pkg/kubernautagent/tools/k8s/resolver.go
@@ -45,11 +45,24 @@ type ResourceResolver interface {
 }
 
 type dynamicResourceResolver struct {
-	client    dynamic.Interface
-	mapper    meta.RESTMapper
-	kindIndex map[string]schema.GroupKind
-	logger    logr.Logger
+	client         dynamic.Interface
+	mapper         meta.RESTMapper
+	kindIndex      map[string]schema.GroupKind
+	logger         logr.Logger
+	secretObserver SecretAccessObserver
 }
+
+// SecretAccessObserver is invoked every time the resolver performs a Get or
+// List that resolves to the core Secret resource, regardless of outcome
+// (GAP-13, Issue #1505 — SOC2 CC7.2 / FedRAMP AU-12 detective control).
+// KubernautAgent intentionally keeps broad read RBAC on Secrets for
+// investigation completeness (missing RBAC degrades RCA quality — see
+// docs/services/stateless/kubernaut-agent/security-configuration.md); this
+// hook lets callers record every access as a dedicated, queryable audit
+// event instead of narrowing that RBAC. verb is "get" or "list"; name is
+// empty for List. err is the outcome of the underlying API call (nil on
+// success). Implementations must not block (fire-and-forget).
+type SecretAccessObserver func(ctx context.Context, verb, name, namespace string, err error)
 
 // resettableMapper is implemented by mappers that support Reset() for cache
 // invalidation (e.g. restmapper.DeferredDiscoveryRESTMapper).
@@ -57,11 +70,39 @@ type resettableMapper interface {
 	Reset()
 }
 
+// ResolverOption configures optional behavior on a dynamicResourceResolver.
+type ResolverOption func(*dynamicResourceResolver)
+
+// WithSecretAccessObserver registers a callback invoked on every Get/List
+// that resolves to the core Secret resource (GAP-13, Issue #1505).
+func WithSecretAccessObserver(observer SecretAccessObserver) ResolverOption {
+	return func(r *dynamicResourceResolver) { r.secretObserver = observer }
+}
+
 // NewDynamicResolver creates a ResourceResolver backed by the Kubernetes dynamic client.
 // The kindIndex maps lowercase kind strings to canonical GroupKind values for
 // case-insensitive resolution (e.g. "replicaset" -> {Group:"apps", Kind:"ReplicaSet"}).
-func NewDynamicResolver(client dynamic.Interface, mapper meta.RESTMapper, kindIndex map[string]schema.GroupKind, logger logr.Logger) ResourceResolver {
-	return &dynamicResourceResolver{client: client, mapper: mapper, kindIndex: kindIndex, logger: logger}
+func NewDynamicResolver(client dynamic.Interface, mapper meta.RESTMapper, kindIndex map[string]schema.GroupKind, logger logr.Logger, opts ...ResolverOption) ResourceResolver {
+	r := &dynamicResourceResolver{client: client, mapper: mapper, kindIndex: kindIndex, logger: logger}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// notifySecretAccess invokes the configured SecretAccessObserver only when
+// mapping resolves to the core ("") group's "secrets" resource — resolved via
+// the RESTMapper rather than string-matching the caller-supplied kind, so a
+// differently-cased/aliased kind argument or a same-named CRD in another API
+// group cannot spoof (or evade) the audit hook.
+func (r *dynamicResourceResolver) notifySecretAccess(ctx context.Context, mapping *meta.RESTMapping, verb, name, namespace string, err error) {
+	if r.secretObserver == nil || mapping == nil {
+		return
+	}
+	if mapping.Resource.Group != "" || mapping.Resource.Resource != "secrets" {
+		return
+	}
+	r.secretObserver(ctx, verb, name, namespace, err)
 }
 
 // BuildKindIndex builds a case-insensitive kind-to-GroupKind index from the
@@ -219,7 +260,9 @@ func (r *dynamicResourceResolver) Get(ctx context.Context, kind, name, namespace
 	}
 
 	var lastErr error
+	var lastMapping *meta.RESTMapping
 	for _, mapping := range mappings {
+		lastMapping = mapping
 		obj, getErr := r.scopedClient(mapping, namespace).Get(ctx, name, metav1.GetOptions{})
 		if getErr == nil {
 			if len(mappings) > 1 {
@@ -229,13 +272,16 @@ func (r *dynamicResourceResolver) Get(ctx context.Context, kind, name, namespace
 					"gvr", mapping.Resource.String(),
 					"result", "success")
 			}
+			r.notifySecretAccess(ctx, mapping, "get", name, namespace, nil)
 			return obj, nil
 		}
 		lastErr = getErr
 		if !errors.IsNotFound(getErr) && !errors.IsForbidden(getErr) {
+			r.notifySecretAccess(ctx, mapping, "get", name, namespace, getErr)
 			return nil, fmt.Errorf("get %s/%s in %s: %w", kind, name, namespace, getErr)
 		}
 	}
+	r.notifySecretAccess(ctx, lastMapping, "get", name, namespace, lastErr)
 	return nil, fmt.Errorf("get %s/%s in %s: %w", kind, name, namespace, lastErr)
 }
 
@@ -246,10 +292,13 @@ func (r *dynamicResourceResolver) List(ctx context.Context, kind, namespace, api
 	}
 
 	var lastResult interface{}
+	var lastMapping *meta.RESTMapping
 	for _, mapping := range mappings {
+		lastMapping = mapping
 		result, listErr := r.scopedClient(mapping, namespace).List(ctx, metav1.ListOptions{})
 		if listErr != nil {
 			if !errors.IsNotFound(listErr) && !errors.IsForbidden(listErr) {
+				r.notifySecretAccess(ctx, mapping, "list", "", namespace, listErr)
 				return nil, fmt.Errorf("list %s in %s: %w", kind, namespace, listErr)
 			}
 			continue
@@ -264,11 +313,15 @@ func (r *dynamicResourceResolver) List(ctx context.Context, kind, namespace, api
 					"result", "success",
 					"items", len(result.Items))
 			}
+			r.notifySecretAccess(ctx, mapping, "list", "", namespace, nil)
 			return result, nil
 		}
 	}
 	if lastResult != nil {
+		r.notifySecretAccess(ctx, lastMapping, "list", "", namespace, nil)
 		return lastResult, nil
 	}
-	return nil, fmt.Errorf("list %s in %s: no results from any API group", kind, namespace)
+	err = fmt.Errorf("list %s in %s: no results from any API group", kind, namespace)
+	r.notifySecretAccess(ctx, lastMapping, "list", "", namespace, err)
+	return nil, err
 }

--- a/pkg/kubernautagent/tools/k8s/secret_access_observer_test.go
+++ b/pkg/kubernautagent/tools/k8s/secret_access_observer_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package k8s_test
+
+import (
+	"context"
+	"sync"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/k8s"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+)
+
+// ========================================
+// GAP-13 (Issue #1505): Secret access observer on the K8s resource resolver
+// ========================================
+//
+// KubernautAgent intentionally keeps broad read RBAC on Secrets for
+// investigation completeness (missing RBAC degrades RCA quality — see
+// docs/services/stateless/kubernaut-agent/security-configuration.md).
+// SecretAccessObserver is the compensating detective control: every Get/List
+// that resolves to the core Secret resource must invoke the observer exactly
+// once, with the resolved verb/name/namespace/outcome — while accesses to
+// non-Secret kinds (even ones argued with a misleading kind string) must
+// never trigger it.
+// ========================================
+
+type secretAccessCall struct {
+	verb      string
+	name      string
+	namespace string
+	err       error
+}
+
+type secretAccessRecorder struct {
+	mu    sync.Mutex
+	calls []secretAccessCall
+}
+
+func (r *secretAccessRecorder) observe(_ context.Context, verb, name, namespace string, err error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, secretAccessCall{verb: verb, name: name, namespace: namespace, err: err})
+}
+
+func (r *secretAccessRecorder) Calls() []secretAccessCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]secretAccessCall, len(r.calls))
+	copy(out, r.calls)
+	return out
+}
+
+var _ = Describe("GAP-13: K8s resolver SecretAccessObserver", func() {
+	var (
+		scheme   *runtime.Scheme
+		mapper   *meta.DefaultRESTMapper
+		kindIdx  map[string]schema.GroupKind
+		recorder *secretAccessRecorder
+	)
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		Expect(corev1.AddToScheme(scheme)).To(Succeed())
+		mapper = buildTestMapper()
+		kindIdx = buildTestKindIndex()
+		recorder = &secretAccessRecorder{}
+	})
+
+	Context("when the resolved resource is the core Secret", func() {
+		It("invokes the observer on a successful Get", func() {
+			dynClient := dynamicfake.NewSimpleDynamicClient(scheme,
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{Name: "db-creds", Namespace: "prod"},
+					Data:       map[string][]byte{"password": []byte("hunter2")},
+				},
+			)
+			resolver := k8s.NewDynamicResolver(dynClient, mapper, kindIdx, logr.Discard(),
+				k8s.WithSecretAccessObserver(recorder.observe))
+
+			_, err := resolver.Get(context.Background(), "Secret", "db-creds", "prod", "")
+			Expect(err).NotTo(HaveOccurred())
+
+			calls := recorder.Calls()
+			Expect(calls).To(HaveLen(1))
+			Expect(calls[0].verb).To(Equal("get"))
+			Expect(calls[0].name).To(Equal("db-creds"))
+			Expect(calls[0].namespace).To(Equal("prod"))
+			Expect(calls[0].err).NotTo(HaveOccurred())
+		})
+
+		It("invokes the observer with the error on a failed Get (not found)", func() {
+			dynClient := dynamicfake.NewSimpleDynamicClient(scheme)
+			resolver := k8s.NewDynamicResolver(dynClient, mapper, kindIdx, logr.Discard(),
+				k8s.WithSecretAccessObserver(recorder.observe))
+
+			_, err := resolver.Get(context.Background(), "Secret", "missing", "prod", "")
+			Expect(err).To(HaveOccurred())
+
+			calls := recorder.Calls()
+			Expect(calls).To(HaveLen(1))
+			Expect(calls[0].verb).To(Equal("get"))
+			Expect(calls[0].err).To(HaveOccurred())
+		})
+
+		It("invokes the observer on List with an empty name", func() {
+			dynClient := dynamicfake.NewSimpleDynamicClient(scheme,
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "s1", Namespace: "prod"}},
+			)
+			resolver := k8s.NewDynamicResolver(dynClient, mapper, kindIdx, logr.Discard(),
+				k8s.WithSecretAccessObserver(recorder.observe))
+
+			_, err := resolver.List(context.Background(), "Secret", "prod", "")
+			Expect(err).NotTo(HaveOccurred())
+
+			calls := recorder.Calls()
+			Expect(calls).To(HaveLen(1))
+			Expect(calls[0].verb).To(Equal("list"))
+			Expect(calls[0].name).To(BeEmpty())
+			Expect(calls[0].namespace).To(Equal("prod"))
+		})
+
+		It("is case-insensitive on the requested kind string", func() {
+			dynClient := dynamicfake.NewSimpleDynamicClient(scheme,
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "db-creds", Namespace: "prod"}},
+			)
+			resolver := k8s.NewDynamicResolver(dynClient, mapper, kindIdx, logr.Discard(),
+				k8s.WithSecretAccessObserver(recorder.observe))
+
+			_, err := resolver.Get(context.Background(), "secret", "db-creds", "prod", "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(recorder.Calls()).To(HaveLen(1))
+		})
+	})
+
+	Context("when the resolved resource is not the core Secret", func() {
+		It("does not invoke the observer for ConfigMap reads", func() {
+			dynClient := dynamicfake.NewSimpleDynamicClient(scheme,
+				&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "cfg", Namespace: "prod"}},
+			)
+			resolver := k8s.NewDynamicResolver(dynClient, mapper, kindIdx, logr.Discard(),
+				k8s.WithSecretAccessObserver(recorder.observe))
+
+			_, err := resolver.Get(context.Background(), "ConfigMap", "cfg", "prod", "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(recorder.Calls()).To(BeEmpty())
+		})
+	})
+
+	Context("when no observer is configured", func() {
+		It("does not panic on Secret access", func() {
+			dynClient := dynamicfake.NewSimpleDynamicClient(scheme,
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "db-creds", Namespace: "prod"}},
+			)
+			resolver := k8s.NewDynamicResolver(dynClient, mapper, kindIdx, logr.Discard())
+
+			Expect(func() {
+				_, _ = resolver.Get(context.Background(), "Secret", "db-creds", "prod", "")
+			}).NotTo(Panic())
+		})
+	})
+})

--- a/pkg/shared/assets/migrations/013_audit_hash_algorithm.sql
+++ b/pkg/shared/assets/migrations/013_audit_hash_algorithm.sql
@@ -1,0 +1,26 @@
+-- +goose Up
+-- Migration: 013_audit_hash_algorithm
+-- GAP-05 (Issue #1505): Keyed HMAC-SHA256 hash chain algorithm tracking
+-- FedRAMP AU-9: Protection of Audit Information (keyed MAC vs. unkeyed hash)
+-- SOC2 CC8.1: Tamper-evident audit trail
+--
+-- Records which hashing scheme produced event_hash for each row, enabling a
+-- mixed-algorithm chain during HMAC key rollout: existing rows keep using
+-- sha256-unkeyed (the only algorithm that existed before this migration);
+-- new writes use hmac-sha256 once a datastorage audit HMAC key is configured,
+-- or continue using sha256-unkeyed otherwise (backward-compatible default).
+--
+-- A plain (unkeyed) SHA256 hash chain can be recomputed by anyone with
+-- read/write access to the database — an attacker who tampers with a row can
+-- also recompute a self-consistent chain. HMAC-SHA256 requires a secret key
+-- stored outside the database (Kubernetes Secret), so forging a valid hash
+-- without that key is computationally infeasible.
+
+ALTER TABLE audit_events
+    ADD COLUMN hash_algorithm VARCHAR(20) NOT NULL DEFAULT 'sha256-unkeyed';
+
+COMMENT ON COLUMN audit_events.hash_algorithm IS
+    'Hash algorithm used to compute event_hash: sha256-unkeyed (legacy, unkeyed) or hmac-sha256 (keyed, GAP-05/Issue #1505)';
+
+-- +goose Down
+ALTER TABLE audit_events DROP COLUMN IF EXISTS hash_algorithm;

--- a/pkg/shared/tls/tls.go
+++ b/pkg/shared/tls/tls.go
@@ -114,7 +114,7 @@ func LoadCACert(caFile string) (*x509.CertPool, error) {
 // on error -- prevents permanent failure if CA file isn't yet mounted.
 var (
 	caReloaderInstance *CAReloader
-	singletonMu       sync.Mutex
+	singletonMu        sync.Mutex
 )
 
 // DefaultBaseTransport returns an http.RoundTripper pre-configured with the CA
@@ -180,7 +180,13 @@ func ResetDefaultTransportForTesting() {
 // StartCAFileWatcher initializes the CA reloader singleton and starts a
 // FileWatcher on $TLS_CA_FILE. Returns nil watcher if TLS_CA_FILE is unset.
 // The returned watcher must be stopped by the caller (defer watcher.Stop()).
-func StartCAFileWatcher(ctx context.Context, logger logr.Logger) (*hotreload.FileWatcher, error) {
+// StartCAFileWatcher watches TLS_CA_FILE for changes and hot-reloads the
+// shared CA transport. onReload, if provided, is invoked after every reload
+// attempt (initial load and every subsequent change) with the callback's
+// error (nil on success) — letting callers emit an audit event without this
+// widely-shared helper depending on any particular audit implementation
+// (GAP-11, Issue #1505). At most the first onReload function is used.
+func StartCAFileWatcher(ctx context.Context, logger logr.Logger, onReload ...func(error)) (*hotreload.FileWatcher, error) {
 	caFile := os.Getenv("TLS_CA_FILE")
 	if caFile == "" {
 		return nil, nil
@@ -196,9 +202,19 @@ func StartCAFileWatcher(ctx context.Context, logger logr.Logger) (*hotreload.Fil
 		return nil, nil
 	}
 
+	callback := reloader.ReloadCallback
+	if len(onReload) > 0 && onReload[0] != nil {
+		notify := onReload[0]
+		callback = func(newContent string) error {
+			err := reloader.ReloadCallback(newContent)
+			notify(err)
+			return err
+		}
+	}
+
 	watcher, err := hotreload.NewFileWatcher(
 		caFile,
-		reloader.ReloadCallback,
+		callback,
 		logger.WithName("ca-reloader"),
 	)
 	if err != nil {

--- a/pkg/signalprocessing/status/manager.go
+++ b/pkg/signalprocessing/status/manager.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	k8sretry "k8s.io/client-go/util/retry"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	signalprocessingv1alpha1 "github.com/jordigilh/kubernaut/api/signalprocessing/v1alpha1"
@@ -99,53 +98,5 @@ func (m *Manager) AtomicStatusUpdate(
 
 		return nil
 	})
-}
-
-// UpdatePhase updates the SignalProcessing phase with validation
-// Satisfies BR-SP-XXX: CRD Lifecycle Management
-//
-// NOTE: For phase transitions that include multiple field updates, use AtomicStatusUpdate instead
-// to reduce API calls and eliminate race conditions.
-//
-// This method uses retry logic to handle optimistic locking conflicts.
-func (m *Manager) UpdatePhase(
-	ctx context.Context,
-	sp *signalprocessingv1alpha1.SignalProcessing,
-	newPhase signalprocessingv1alpha1.SignalProcessingPhase,
-	message string,
-) error {
-	return k8sretry.RetryOnConflict(k8sretry.DefaultRetry, func() error {
-		// 1. Refetch to get latest resourceVersion
-		// SP-CACHE-001: Use APIReader to bypass cache
-		if err := m.apiReader.Get(ctx, client.ObjectKeyFromObject(sp), sp); err != nil {
-			return fmt.Errorf("failed to refetch SignalProcessing: %w", err)
-		}
-
-		// 2. Update phase field
-		sp.Status.Phase = newPhase
-	sp.Status.ObservedGeneration = sp.Generation // DD-CONTROLLER-001
-		// Note: SignalProcessing doesn't have a Message field, status details tracked in Conditions
-		_ = message // Suppress unused parameter warning
-
-		// 3. Set completion timestamp for terminal phases
-		if isTerminalPhase(newPhase) {
-			now := metav1.Now()
-			sp.Status.CompletionTime = &now
-		}
-
-		// 4. Update status using status subresource
-		if err := m.client.Status().Update(ctx, sp); err != nil {
-			return fmt.Errorf("failed to update phase: %w", err)
-		}
-
-		return nil
-	})
-}
-
-// isTerminalPhase checks if a phase is terminal (no further transitions allowed)
-// Terminal phases: Completed (success) and Failed (permanent failure)
-func isTerminalPhase(phase signalprocessingv1alpha1.SignalProcessingPhase) bool {
-	return phase == signalprocessingv1alpha1.PhaseCompleted ||
-		phase == signalprocessingv1alpha1.PhaseFailed
 }
 

--- a/pkg/workflowexecution/executor/job.go
+++ b/pkg/workflowexecution/executor/job.go
@@ -216,11 +216,17 @@ func (j *JobExecutor) Cleanup(ctx context.Context, wfe *workflowexecutionv1alpha
 // Parameters are injected as environment variables.
 // DD-WE-006: deps are mounted as volumes when non-nil.
 // #243: Parameters are filtered against DeclaredParameterNames before injection.
+// BR-WE-018: pod and container are hardened to the restricted SecurityContext
+// profile, with a /tmp scratch volume so tools needing writable space (e.g.
+// kubectl's discovery cache) still function under readOnlyRootFilesystem.
 func (j *JobExecutor) buildJob(ctx context.Context, wfe *workflowexecutionv1alpha1.WorkflowExecution, namespace string, opts CreateOptions) *batchv1.Job {
 	logger := log.FromContext(ctx).WithValues("wfe", wfe.Name, "workflowID", wfe.Spec.WorkflowRef.WorkflowID)
 	params := FilterDeclaredParameters(wfe.Spec.Parameters, opts.DeclaredParameterNames, logger)
 	envVars := buildEnvVars(wfe.Spec.TargetResource, params)
+	envVars = append(envVars, scratchSpaceEnvVars()...)
 	volumes, mounts := buildDependencyVolumes(opts.Dependencies)
+	volumes = append(volumes, scratchSpaceVolume())
+	mounts = append(mounts, scratchSpaceVolumeMount())
 
 	jobName := ExecutionResourceName(wfe.Spec.TargetResource)
 
@@ -255,13 +261,15 @@ func (j *JobExecutor) buildJob(ctx context.Context, wfe *workflowexecutionv1alph
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyNever,
 					ServiceAccountName: wfe.Status.ServiceAccountName,
+					SecurityContext:    restrictedPodSecurityContext(),
 					Volumes:            volumes,
 					Containers: []corev1.Container{
 						{
-							Name:         "workflow",
-							Image:        wfe.Spec.WorkflowRef.ExecutionBundle,
-							Env:          envVars,
-							VolumeMounts: mounts,
+							Name:            "workflow",
+							Image:           wfe.Spec.WorkflowRef.ExecutionBundle,
+							Env:             envVars,
+							VolumeMounts:    mounts,
+							SecurityContext: restrictedContainerSecurityContext(),
 						},
 					},
 				},

--- a/pkg/workflowexecution/executor/job_test.go
+++ b/pkg/workflowexecution/executor/job_test.go
@@ -181,6 +181,66 @@ var _ = Describe("UT-WE-054-JOB: JobExecutor", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("get client for cluster"))
 		})
+
+		// BR-WE-018: spawned Job pods must be hardened to the restricted SecurityContext
+		// profile (FedRAMP AC-6/CM-7), matching the WE controller's own pod hardening.
+		It("UT-WE-054-JOB-014: should apply restricted pod and container SecurityContext", func() {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			factory := &mockClientFactory{client: fakeClient}
+			je := executor.NewJobExecutorWithFactory(factory)
+			wfe := newTestWFE("wfe-secctx", "default/deployment/nginx", "")
+
+			result, err := je.Create(ctx, wfe, namespace, executor.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			var job batchv1.Job
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: result.ResourceName, Namespace: namespace}, &job)).To(Succeed())
+
+			podSC := job.Spec.Template.Spec.SecurityContext
+			Expect(podSC).ToNot(BeNil())
+			Expect(*podSC.RunAsNonRoot).To(BeTrue())
+			Expect(podSC.SeccompProfile).ToNot(BeNil())
+			Expect(podSC.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+
+			containerSC := job.Spec.Template.Spec.Containers[0].SecurityContext
+			Expect(containerSC).ToNot(BeNil())
+			Expect(*containerSC.AllowPrivilegeEscalation).To(BeFalse())
+			Expect(*containerSC.ReadOnlyRootFilesystem).To(BeTrue())
+			Expect(*containerSC.RunAsNonRoot).To(BeTrue())
+			Expect(containerSC.Capabilities).ToNot(BeNil())
+			Expect(containerSC.Capabilities.Drop).To(ConsistOf(corev1.Capability("ALL")))
+		})
+
+		It("UT-WE-054-JOB-015: should mount a writable /tmp scratch volume for readOnlyRootFilesystem compatibility", func() {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			factory := &mockClientFactory{client: fakeClient}
+			je := executor.NewJobExecutorWithFactory(factory)
+			wfe := newTestWFE("wfe-scratch", "default/deployment/nginx", "")
+
+			result, err := je.Create(ctx, wfe, namespace, executor.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			var job batchv1.Job
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: result.ResourceName, Namespace: namespace}, &job)).To(Succeed())
+
+			Expect(job.Spec.Template.Spec.Volumes).To(ContainElement(And(
+				HaveField("Name", "tmp"),
+				HaveField("VolumeSource.EmptyDir", Not(BeNil())),
+			)))
+
+			container := job.Spec.Template.Spec.Containers[0]
+			Expect(container.VolumeMounts).To(ContainElement(And(
+				HaveField("Name", "tmp"),
+				HaveField("MountPath", "/tmp"),
+			)))
+
+			envByName := map[string]string{}
+			for _, e := range container.Env {
+				envByName[e.Name] = e.Value
+			}
+			Expect(envByName).To(HaveKeyWithValue("HOME", "/tmp"))
+			Expect(envByName).To(HaveKeyWithValue("TMPDIR", "/tmp"))
+		})
 	})
 
 	Describe("GetStatus", func() {

--- a/pkg/workflowexecution/executor/security.go
+++ b/pkg/workflowexecution/executor/security.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/utils/ptr"
+)
+
+// restrictedPodSecurityContext returns the pod-level SecurityContext applied to
+// every spawned execution pod (Job and Tekton). Mirrors the controller's own
+// restricted profile (charts/kubernaut/templates/_helpers.tpl: kubernaut.podSecurityContext).
+//
+// Authority: BR-WE-018 (Execution Pod Security Hardening), FedRAMP AC-6/CM-7.
+// This profile is intentionally non-configurable -- see BR-WE-018 for rationale.
+func restrictedPodSecurityContext() *corev1.PodSecurityContext {
+	return &corev1.PodSecurityContext{
+		RunAsNonRoot: ptr.To(true),
+		SeccompProfile: &corev1.SeccompProfile{
+			Type: corev1.SeccompProfileTypeRuntimeDefault,
+		},
+	}
+}
+
+// restrictedContainerSecurityContext returns the container-level SecurityContext
+// applied to the "workflow" container in spawned Job pods. Mirrors the
+// controller's own restricted profile (kubernaut.containerSecurityContext).
+//
+// Not applicable to Tekton: PipelineRun's TaskRunTemplate.PodTemplate exposes
+// only a pod-level SecurityContext; container-level settings belong to the
+// Task spec resolved from the OCI bundle, outside WE controller's authoring
+// control (see BR-WE-018 for the asymmetry rationale).
+//
+// Authority: BR-WE-018 (Execution Pod Security Hardening), FedRAMP AC-6/CM-7.
+func restrictedContainerSecurityContext() *corev1.SecurityContext {
+	return &corev1.SecurityContext{
+		AllowPrivilegeEscalation: ptr.To(false),
+		ReadOnlyRootFilesystem:   ptr.To(true),
+		RunAsNonRoot:             ptr.To(true),
+		Capabilities: &corev1.Capabilities{
+			Drop: []corev1.Capability{"ALL"},
+		},
+	}
+}
+
+const scratchSpaceMountPath = "/tmp"
+
+// scratchSpaceVolume returns the emptyDir volume providing writable scratch
+// space for the workflow container under readOnlyRootFilesystem: true.
+//
+// Authority: BR-WE-018 (Execution Pod Security Hardening).
+func scratchSpaceVolume() corev1.Volume {
+	return corev1.Volume{
+		Name: "tmp",
+		VolumeSource: corev1.VolumeSource{
+			EmptyDir: &corev1.EmptyDirVolumeSource{},
+		},
+	}
+}
+
+// scratchSpaceVolumeMount mounts the scratch space volume at /tmp.
+func scratchSpaceVolumeMount() corev1.VolumeMount {
+	return corev1.VolumeMount{
+		Name:      "tmp",
+		MountPath: scratchSpaceMountPath,
+	}
+}
+
+// scratchSpaceEnvVars points HOME and TMPDIR at the writable scratch space so
+// tools that default to writing under $HOME (e.g. kubectl's discovery cache)
+// don't fail under readOnlyRootFilesystem: true.
+func scratchSpaceEnvVars() []corev1.EnvVar {
+	return []corev1.EnvVar{
+		{Name: "HOME", Value: scratchSpaceMountPath},
+		{Name: "TMPDIR", Value: scratchSpaceMountPath},
+	}
+}

--- a/pkg/workflowexecution/executor/tekton.go
+++ b/pkg/workflowexecution/executor/tekton.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/pod"
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -178,6 +179,10 @@ func (t *TektonExecutor) Cleanup(ctx context.Context, wfe *workflowexecutionv1al
 // BuildPipelineRun creates a PipelineRun with bundle resolver.
 // DD-WE-006: deps are added as workspace bindings when non-nil.
 // #243: Parameters are filtered against DeclaredParameterNames before conversion.
+// BR-WE-018: pod-level SecurityContext is hardened to the restricted profile.
+// Container-level settings are not controllable here -- they belong to the
+// Task spec resolved from the OCI bundle (see BR-WE-018 for the asymmetry
+// rationale vs. the Job backend).
 func (t *TektonExecutor) BuildPipelineRun(ctx context.Context, wfe *workflowexecutionv1alpha1.WorkflowExecution, namespace string, opts CreateOptions) *tektonv1.PipelineRun {
 	logger := log.FromContext(ctx).WithValues("wfe", wfe.Name, "workflowID", wfe.Spec.WorkflowRef.WorkflowID)
 	filteredParams := FilterDeclaredParameters(wfe.Spec.Parameters, opts.DeclaredParameterNames, logger)
@@ -219,6 +224,9 @@ func (t *TektonExecutor) BuildPipelineRun(ctx context.Context, wfe *workflowexec
 			Workspaces: workspaces,
 			TaskRunTemplate: tektonv1.PipelineTaskRunTemplate{
 				ServiceAccountName: wfe.Status.ServiceAccountName,
+				PodTemplate: &pod.PodTemplate{
+					SecurityContext: restrictedPodSecurityContext(),
+				},
 			},
 		},
 	}

--- a/pkg/workflowexecution/executor/tekton_test.go
+++ b/pkg/workflowexecution/executor/tekton_test.go
@@ -112,6 +112,30 @@ var _ = Describe("UT-WE-054-TEK: TektonExecutor", func() {
 			Expect(wsNames).To(ContainElement("secret-tls-cert"))
 			Expect(wsNames).To(ContainElement("configmap-pipeline-config"))
 		})
+
+		// BR-WE-018: spawned Tekton pods must be hardened to the restricted pod-level
+		// SecurityContext (FedRAMP AC-6/CM-7). Container-level settings are not
+		// controllable via the PipelineRun API -- see BR-WE-018 for the asymmetry
+		// rationale vs. the Job backend.
+		It("UT-WE-054-TEK-007: should apply restricted pod-level SecurityContext via TaskRunTemplate.PodTemplate", func() {
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+			factory := &mockClientFactory{client: fakeClient}
+			te := executor.NewTektonExecutorWithFactory(factory)
+			wfe := newTestWFE("wfe-tekton-secctx", "default/deployment/frontend", "")
+
+			result, err := te.Create(ctx, wfe, namespace, executor.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			var pr tektonv1.PipelineRun
+			Expect(fakeClient.Get(ctx, client.ObjectKey{Name: result.ResourceName, Namespace: namespace}, &pr)).To(Succeed())
+
+			podTemplate := pr.Spec.TaskRunTemplate.PodTemplate
+			Expect(podTemplate).ToNot(BeNil())
+			Expect(podTemplate.SecurityContext).ToNot(BeNil())
+			Expect(*podTemplate.SecurityContext.RunAsNonRoot).To(BeTrue())
+			Expect(podTemplate.SecurityContext.SeccompProfile).ToNot(BeNil())
+			Expect(podTemplate.SecurityContext.SeccompProfile.Type).To(Equal(corev1.SeccompProfileTypeRuntimeDefault))
+		})
 	})
 
 	Describe("GetStatus", func() {

--- a/pkg/workflowexecution/executor_test.go
+++ b/pkg/workflowexecution/executor_test.go
@@ -1035,7 +1035,8 @@ var _ = Describe("Job Executor Dependencies (DD-WE-006)", func() {
 		var job batchv1.Job
 		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: result.ResourceName, Namespace: "kubernaut-workflows"}, &job)).To(Succeed())
 
-		Expect(job.Spec.Template.Spec.Volumes).To(HaveLen(2))
+		// BR-WE-018: an extra "tmp" scratch-space volume is always present alongside dependency volumes.
+		Expect(job.Spec.Template.Spec.Volumes).To(HaveLen(3))
 		Expect(job.Spec.Template.Spec.Volumes).To(ContainElement(
 			HaveField("Name", "secret-gitea-repo-creds"),
 		))
@@ -1044,7 +1045,7 @@ var _ = Describe("Job Executor Dependencies (DD-WE-006)", func() {
 		))
 
 		container := job.Spec.Template.Spec.Containers[0]
-		Expect(container.VolumeMounts).To(HaveLen(2))
+		Expect(container.VolumeMounts).To(HaveLen(3))
 		Expect(container.VolumeMounts).To(ContainElement(And(
 			HaveField("Name", "secret-gitea-repo-creds"),
 			HaveField("MountPath", "/run/kubernaut/secrets/gitea-repo-creds"),
@@ -1057,7 +1058,7 @@ var _ = Describe("Job Executor Dependencies (DD-WE-006)", func() {
 		)))
 	})
 
-	It("UT-WE-006-023: should create Job without volumes when no dependencies", func() {
+	It("UT-WE-006-023: should create Job with only the tmp scratch volume when no dependencies", func() {
 		wfe := newTestWFE("test-wfe-nodeps", "default", "default/deployment/nodeps-app",
 			"restart", "ghcr.io/kubernaut/workflows/restart:v1.0.0", nil)
 
@@ -1067,9 +1068,10 @@ var _ = Describe("Job Executor Dependencies (DD-WE-006)", func() {
 		var job batchv1.Job
 		Expect(k8sClient.Get(ctx, client.ObjectKey{Name: result.ResourceName, Namespace: "kubernaut-workflows"}, &job)).To(Succeed())
 
-		Expect(job.Spec.Template.Spec.Volumes).To(BeEmpty())
+		// BR-WE-018: no dependency volumes, but the "tmp" scratch-space volume is always present.
+		Expect(job.Spec.Template.Spec.Volumes).To(ConsistOf(HaveField("Name", "tmp")))
 		container := job.Spec.Template.Spec.Containers[0]
-		Expect(container.VolumeMounts).To(BeEmpty())
+		Expect(container.VolumeMounts).To(ConsistOf(HaveField("Name", "tmp")))
 	})
 })
 

--- a/test/e2e/authwebhook/02_workflow_content_integrity_test.go
+++ b/test/e2e/authwebhook/02_workflow_content_integrity_test.go
@@ -57,7 +57,7 @@ func buildRemediationWorkflowCRD(crdName, version, description string) *rwv1alph
 			},
 			Execution: rwv1alpha1.RemediationWorkflowExecution{
 				Engine: "job",
-				Bundle: "quay.io/kubernaut-cicd/test-workflows/placeholder-execution:v1.0.0@sha256:2a07b572d7c2d16845da11ea01ff24198bd2ff366580c81a8d2fbc6ae6b78389",
+				Bundle: "quay.io/kubernaut-cicd/test-workflows/placeholder-execution:v1.0.0@sha256:377de4244cfeffcbb898a7e7cd388dd1266dd680cef43b17147b876845df29cd",
 			},
 			Parameters: []rwv1alpha1.RemediationWorkflowParameter{
 				{

--- a/test/e2e/authwebhook/03_actiontype_lifecycle_test.go
+++ b/test/e2e/authwebhook/03_actiontype_lifecycle_test.go
@@ -232,7 +232,7 @@ var _ = Describe("E2E: ActionType CRD Lifecycle (#300)", Ordered, ContinueOnFail
 				},
 				Execution: rwv1alpha1.RemediationWorkflowExecution{
 					Engine: "job",
-					Bundle: "quay.io/kubernaut-cicd/test-workflows/placeholder-execution:v1.0.0@sha256:2a07b572d7c2d16845da11ea01ff24198bd2ff366580c81a8d2fbc6ae6b78389",
+					Bundle: "quay.io/kubernaut-cicd/test-workflows/placeholder-execution:v1.0.0@sha256:377de4244cfeffcbb898a7e7cd388dd1266dd680cef43b17147b876845df29cd",
 				},
 				Parameters: []rwv1alpha1.RemediationWorkflowParameter{
 					{Name: "TARGET_RESOURCE", Type: "string", Required: true, Description: "Target resource"},

--- a/test/e2e/datastorage/helpers_test.go
+++ b/test/e2e/datastorage/helpers_test.go
@@ -30,7 +30,7 @@ import (
 	. "github.com/onsi/gomega"    //nolint:revive,staticcheck // Ginkgo/Gomega convention
 )
 
-const e2eBundleRef = "quay.io/kubernaut-cicd/test-workflows/placeholder-execution:v1.0.0@sha256:2a07b572d7c2d16845da11ea01ff24198bd2ff366580c81a8d2fbc6ae6b78389"
+const e2eBundleRef = "quay.io/kubernaut-cicd/test-workflows/placeholder-execution:v1.0.0@sha256:377de4244cfeffcbb898a7e7cd388dd1266dd680cef43b17147b876845df29cd"
 
 // e2eTestWorkflowStubContent is valid YAML content for CreateWorkflowInlineRequest.
 // Aligns with DS E2E test expectations: discovery queries (ScaleReplicas, critical/production/P0),

--- a/test/e2e/workflowexecution/workflowexecution_e2e_suite_test.go
+++ b/test/e2e/workflowexecution/workflowexecution_e2e_suite_test.go
@@ -285,6 +285,12 @@ var _ = SynchronizedAfterSuite(
 		if anyFailure {
 			infrastructure.MustGatherPodLogs(clusterName, kubeconfigPath,
 				controllerNamespace, "workflowexecution", GinkgoWriter)
+			// BR-WE-018: spawned Job/Tekton execution pods run in a separate
+			// namespace from the controller; without this, failures in the
+			// spawned pods themselves (e.g. SecurityContext rejections) are
+			// invisible in the must-gather artifact.
+			infrastructure.MustGatherPodLogs(clusterName, kubeconfigPath,
+				"kubernaut-workflows", "workflowexecution", GinkgoWriter)
 		}
 
 		// DD-TEST-007: Collect E2E binary coverage AFTER log export but BEFORE cluster deletion

--- a/test/fixtures/execution-placeholder/Dockerfile
+++ b/test/fixtures/execution-placeholder/Dockerfile
@@ -8,4 +8,8 @@
 #     --manifest quay.io/kubernaut-cicd/test-workflows/placeholder-execution:v1.0.0 \
 #     -f Dockerfile .
 FROM busybox:1.36
+# BR-WE-018: spawned Job pods enforce runAsNonRoot; busybox's default image
+# has no USER directive and runs as root, which kubelet rejects outright
+# (CreateContainerConfigError) once that pod-level SecurityContext applies.
+USER 1000
 CMD ["echo", "kubernaut placeholder execution bundle"]

--- a/test/fixtures/tekton/failing-pipeline.yaml
+++ b/test/fixtures/tekton/failing-pipeline.yaml
@@ -46,6 +46,12 @@ spec:
         steps:
           - name: fail
             image: registry.access.redhat.com/ubi10/ubi-minimal:latest
+            # BR-WE-018: WE controller enforces runAsNonRoot at the pod level for
+            # every Tekton PipelineRun; ubi-minimal has no USER directive and
+            # defaults to root, which kubelet rejects (CreateContainerConfigError)
+            # without this explicit non-root override.
+            securityContext:
+              runAsUser: 1001
             script: |
               #!/bin/sh
               echo "============================================"

--- a/test/fixtures/tekton/hello-world-pipeline.yaml
+++ b/test/fixtures/tekton/hello-world-pipeline.yaml
@@ -48,6 +48,12 @@ spec:
         steps:
           - name: echo-info
             image: registry.access.redhat.com/ubi10/ubi-minimal:latest
+            # BR-WE-018: WE controller enforces runAsNonRoot at the pod level for
+            # every Tekton PipelineRun; ubi-minimal has no USER directive and
+            # defaults to root, which kubelet rejects (CreateContainerConfigError)
+            # without this explicit non-root override.
+            securityContext:
+              runAsUser: 1001
             script: |
               #!/bin/sh
               set -e

--- a/test/fixtures/workflows/ambiguous-kind-fix/workflow-schema.yaml
+++ b/test/fixtures/workflows/ambiguous-kind-fix/workflow-schema.yaml
@@ -23,7 +23,7 @@ spec:
   
   execution:
     engine: job
-    bundle: quay.io/kubernaut-cicd/test-workflows/placeholder-execution:v1.0.0@sha256:2a07b572d7c2d16845da11ea01ff24198bd2ff366580c81a8d2fbc6ae6b78389
+    bundle: quay.io/kubernaut-cicd/test-workflows/placeholder-execution:v1.0.0@sha256:377de4244cfeffcbb898a7e7cd388dd1266dd680cef43b17147b876845df29cd
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/audit-test/workflow-schema.yaml
+++ b/test/fixtures/workflows/audit-test/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/cnv-vm-boot-failure/workflow-schema.yaml
+++ b/test/fixtures/workflows/cnv-vm-boot-failure/workflow-schema.yaml
@@ -29,7 +29,7 @@ spec:
 
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
 
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/crashloop-config-fix/workflow-schema.yaml
+++ b/test/fixtures/workflows/crashloop-config-fix/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
 
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
 
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/dep-configmap-job/workflow-schema.yaml
+++ b/test/fixtures/workflows/dep-configmap-job/workflow-schema.yaml
@@ -23,7 +23,7 @@ spec:
   
   execution:
     engine: job
-    bundle: quay.io/kubernaut-cicd/test-workflows/placeholder-execution:v1.0.0@sha256:2a07b572d7c2d16845da11ea01ff24198bd2ff366580c81a8d2fbc6ae6b78389
+    bundle: quay.io/kubernaut-cicd/test-workflows/placeholder-execution:v1.0.0@sha256:377de4244cfeffcbb898a7e7cd388dd1266dd680cef43b17147b876845df29cd
   
   dependencies:
     configMaps:

--- a/test/fixtures/workflows/dep-configmap-tekton/workflow-schema.yaml
+++ b/test/fixtures/workflows/dep-configmap-tekton/workflow-schema.yaml
@@ -23,7 +23,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   dependencies:
     configMaps:

--- a/test/fixtures/workflows/dep-secret-job/workflow-schema.yaml
+++ b/test/fixtures/workflows/dep-secret-job/workflow-schema.yaml
@@ -23,7 +23,7 @@ spec:
   
   execution:
     engine: job
-    bundle: quay.io/kubernaut-cicd/test-workflows/placeholder-execution:v1.0.0@sha256:2a07b572d7c2d16845da11ea01ff24198bd2ff366580c81a8d2fbc6ae6b78389
+    bundle: quay.io/kubernaut-cicd/test-workflows/placeholder-execution:v1.0.0@sha256:377de4244cfeffcbb898a7e7cd388dd1266dd680cef43b17147b876845df29cd
   
   dependencies:
     secrets:

--- a/test/fixtures/workflows/dep-secret-tekton/workflow-schema.yaml
+++ b/test/fixtures/workflows/dep-secret-tekton/workflow-schema.yaml
@@ -23,7 +23,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   dependencies:
     secrets:

--- a/test/fixtures/workflows/detected-labels-all-fields/workflow-schema.yaml
+++ b/test/fixtures/workflows/detected-labels-all-fields/workflow-schema.yaml
@@ -33,7 +33,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/detected-labels-test/workflow-schema.yaml
+++ b/test/fixtures/workflows/detected-labels-test/workflow-schema.yaml
@@ -27,7 +27,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/discovery-test/workflow-schema.yaml
+++ b/test/fixtures/workflows/discovery-test/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/duplicate-test/workflow-schema.yaml
+++ b/test/fixtures/workflows/duplicate-test/workflow-schema.yaml
@@ -23,7 +23,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/failing/workflow-schema.yaml
+++ b/test/fixtures/workflows/failing/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/failing:v1.0.0@sha256:5d880ed9f9387988bc222ecc2206441ff3b7495a07e0f212583742e2a8193755
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/failing:v1.0.0@sha256:8f57121ab1df255cd2ae644ae38680e19217c3117b320da660efc3c7cefa0dce
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/fix-certificate/workflow-schema.yaml
+++ b/test/fixtures/workflows/fix-certificate/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
   
   execution:
     engine: job
-    bundle: quay.io/kubernaut-cicd/test-workflows/placeholder-execution:v1.0.0@sha256:2a07b572d7c2d16845da11ea01ff24198bd2ff366580c81a8d2fbc6ae6b78389
+    bundle: quay.io/kubernaut-cicd/test-workflows/placeholder-execution:v1.0.0@sha256:377de4244cfeffcbb898a7e7cd388dd1266dd680cef43b17147b876845df29cd
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/generic-restart/workflow-schema.yaml
+++ b/test/fixtures/workflows/generic-restart/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/hello-world/workflow-schema.yaml
+++ b/test/fixtures/workflows/hello-world/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/image-pull-backoff-fix-credentials/workflow-schema.yaml
+++ b/test/fixtures/workflows/image-pull-backoff-fix-credentials/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/imagepull-fix-creds/workflow-schema.yaml
+++ b/test/fixtures/workflows/imagepull-fix-creds/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/istio-authz-fix/workflow-schema.yaml
+++ b/test/fixtures/workflows/istio-authz-fix/workflow-schema.yaml
@@ -25,7 +25,7 @@ spec:
 
   execution:
     engine: job
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
 
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/job-failing/Dockerfile
+++ b/test/fixtures/workflows/job-failing/Dockerfile
@@ -18,6 +18,11 @@ FROM registry.access.redhat.com/ubi10/ubi-minimal:latest
 ENV TARGET_RESOURCE="test/deployment/failing" \
     FAILURE_MESSAGE="Intentional test failure"
 
+# BR-WE-018: spawned Job pods enforce runAsNonRoot; ubi-minimal has no USER
+# directive by default and runs as root, which kubelet rejects outright
+# (CreateContainerConfigError) once the pod-level SecurityContext applies.
+USER 1001
+
 ENTRYPOINT ["/bin/sh", "-c", "\
 echo '============================================' && \
 echo 'Kubernaut Failure Test Job' && \

--- a/test/fixtures/workflows/job-failing/workflow-schema.yaml
+++ b/test/fixtures/workflows/job-failing/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
   
   execution:
     engine: job
-    bundle: quay.io/kubernaut-cicd/test-workflows/job-failing:v1.0.0-exec@sha256:b160392f97472e5b1a80867b55e48398829f52f8352b8926f14bbb243886951e
+    bundle: quay.io/kubernaut-cicd/test-workflows/job-failing:v1.0.0-exec@sha256:c0cde2d0ae5550d3dd95dc998825904766b8de91e5a305a4d17fc590942ee7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/job-hello-world/workflow-schema.yaml
+++ b/test/fixtures/workflows/job-hello-world/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
   
   execution:
     engine: job
-    bundle: quay.io/kubernaut-cicd/test-workflows/placeholder-execution:v1.0.0@sha256:2a07b572d7c2d16845da11ea01ff24198bd2ff366580c81a8d2fbc6ae6b78389
+    bundle: quay.io/kubernaut-cicd/test-workflows/placeholder-execution:v1.0.0@sha256:377de4244cfeffcbb898a7e7cd388dd1266dd680cef43b17147b876845df29cd
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/memory-optimize/workflow-schema.yaml
+++ b/test/fixtures/workflows/memory-optimize/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/node-drain-reboot/workflow-schema.yaml
+++ b/test/fixtures/workflows/node-drain-reboot/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/oom-recovery-aggressive/workflow-schema.yaml
+++ b/test/fixtures/workflows/oom-recovery-aggressive/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/oom-recovery-v1.1/workflow-schema.yaml
+++ b/test/fixtures/workflows/oom-recovery-v1.1/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/oom-recovery-v2.0/workflow-schema.yaml
+++ b/test/fixtures/workflows/oom-recovery-v2.0/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/oom-recovery/workflow-schema.yaml
+++ b/test/fixtures/workflows/oom-recovery/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/oomkill-increase-memory/workflow-schema.yaml
+++ b/test/fixtures/workflows/oomkill-increase-memory/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/param-validation-test/workflow-schema.yaml
+++ b/test/fixtures/workflows/param-validation-test/workflow-schema.yaml
@@ -20,7 +20,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/rollback-deployment-disabled-test/workflow-schema.yaml
+++ b/test/fixtures/workflows/rollback-deployment-disabled-test/workflow-schema.yaml
@@ -23,7 +23,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/rollback-deployment-test/workflow-schema.yaml
+++ b/test/fixtures/workflows/rollback-deployment-test/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/sar-test/workflow-schema.yaml
+++ b/test/fixtures/workflows/sar-test/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/security-gate-test/workflow-schema.yaml
+++ b/test/fixtures/workflows/security-gate-test/workflow-schema.yaml
@@ -23,7 +23,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/fixtures/workflows/test-signal-handler/workflow-schema.yaml
+++ b/test/fixtures/workflows/test-signal-handler/workflow-schema.yaml
@@ -22,7 +22,7 @@ spec:
   
   execution:
     engine: tekton
-    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:c4fc636f28d46f94c3f4a211f4dc07f60545891818ee45262e860b0825296ba0
+    bundle: quay.io/kubernaut-cicd/tekton-bundles/hello-world:v1.0.0@sha256:a663ba9ddf8a074025723a4fbbef5542f520deb4e5eaf9814e07775456ecd7e0
   
   parameters:
     - name: TARGET_RESOURCE_NAME

--- a/test/integration/datastorage/audit_export_integration_test.go
+++ b/test/integration/datastorage/audit_export_integration_test.go
@@ -427,10 +427,11 @@ var _ = Describe("Audit Export Integration Tests - SOC2", func() {
 				// Manually calculate what the hash should be
 				// Hash = SHA256(previous_hash + event_json)
 				// For first event, previous_hash is empty string
-				eventForHashing := *created
-				eventForHashing.EventHash = ""
-				eventForHashing.PreviousEventHash = ""
-				eventForHashing.EventDate = repository.DateOnly{} // Clear generated field
+				//
+				// GAP-05: must use PrepareEventForHashing (not hand-rolled field
+				// clearing) so HashAlgorithm is excluded from the payload exactly
+				// like the production hashing path does.
+				eventForHashing := repository.PrepareEventForHashing(created)
 
 				eventJSON, err := json.Marshal(eventForHashing)
 				Expect(err).ToNot(HaveOccurred())
@@ -488,11 +489,10 @@ var _ = Describe("Audit Export Integration Tests - SOC2", func() {
 				second, err := auditRepo.Create(ctx, event2)
 				Expect(err).ToNot(HaveOccurred())
 
-				// Manually calculate second event's hash
-				eventForHashing := *second
-				eventForHashing.EventHash = ""
-				eventForHashing.PreviousEventHash = ""
-				eventForHashing.EventDate = repository.DateOnly{}
+				// Manually calculate second event's hash.
+				// GAP-05: use PrepareEventForHashing so HashAlgorithm is excluded
+				// from the payload exactly like the production hashing path does.
+				eventForHashing := repository.PrepareEventForHashing(second)
 
 				eventJSON, err := json.Marshal(eventForHashing)
 				Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
## Summary

Consolidated PR closing out the remaining GA readiness gaps from #1505 (GA Readiness Audit). Targets `feature/multi-cluster-federation` per plan — will be exercised on that branch before eventually landing on `main`.

### Implemented in this PR

- **GAP-01** — Cosign keyless image signing in CI + SBOM attestation on release (docs + CI pipeline changes)
- **GAP-02 / GAP-15** — Add `fleetmetadatacache` to the release workflow's build/SBOM/signing/provenance matrices (previously omitted)
- **GAP-03 / BR-WE-018** — Harden WorkflowExecution-spawned Job/Tekton pods with a hardcoded `restricted` Pod Security profile; add PSA `restricted` namespace-label backstop to the Helm-managed `kubernaut-workflows` namespace
- **GAP-05 / BR-AUDIT-010** — Upgrade the ADR-034 audit hash chain from unkeyed SHA-256 to keyed HMAC-SHA256 when an operator-provisioned key is present (adds `hash_algorithm` column, migration 013, Helm secret wiring); falls back to legacy algorithm when unset
- **GAP-08 / BR-SECURITY-1505** — Valkey-backed distributed JWT replay cache for APIFrontend (closes multi-replica replay-detection gap), with in-memory fallback when Valkey isn't configured
- **GAP-09 / BR-STORAGE-1505** — Optional per-IP rate limiting on the Data Storage HTTP API (pre-auth), with `datastorage.ratelimit.denied` audit event on denial
- **GAP-10** — Add missing `kubebuilder:rbac` markers to the EffectivenessMonitor reconciler, regenerate `config/rbac/role.yaml`
- **GAP-11** — Audit every Gateway config hot-reload attempt (log-level, CA-cert) via `gateway.config.reloaded` / `gateway.config.rejected` events
- **GAP-12** — Remove dead `Manager.UpdatePhase` method in `pkg/signalprocessing/status`
- **GAP-13 / BR-AUDIT-011** — Detective control: emit `aiagent.secret.accessed` for every K8s Secret Get/List performed by KubernautAgent's resource resolver, regardless of outcome (KubernautAgent intentionally retains broad Secret read RBAC for investigation completeness)

### Deferred / tracked separately

- **GAP-04, GAP-06, GAP-07** — Verified already resolved in the codebase (audit immutability trigger, SP idle-connection timeout, prompt-injection mitigation via KubernautAgent's sanitizer + shadow-LLM); closed with evidence on #1505
- **GAP-03 (operator)** — kubernaut-operator tracking issue opened for equivalent PSA/SecurityContext support, milestone v1.6
- **GAP-05 (operator)** — kubernaut-operator tracking issue opened for HMAC key Secret + DataStorageDeployment wiring, milestone v1.6
- **GAP-14 (OTel tracing)** — Postponed; tracking issue #1519 opened (existing audit traces + structured logging cover interim needs)

## Test plan

- [x] `go build ./...` — clean
- [x] `golangci-lint run --new-from-rev=<merge-base>` — zero new issues (one pre-existing, unrelated typecheck failure in `docs/spikes/...` predates this branch)
- [x] `go test ./cmd/... ./internal/... ./pkg/...` — 137/137 packages pass, no failures
- [ ] Integration/E2E tiers intentionally **not** run against this branch — known pre-existing failures on `feature/multi-cluster-federation` per prior guidance; to be exercised after merge on the source branch
- [x] New unit tests added for every gap requiring code changes (HMAC hash chain, rate limiting, Valkey replay cache, gateway config-reload audit, KubernautAgent secret-access audit, correlation-ID propagation)