### PR TITLE
feat(test): add second Kind cluster for genuine FMC E2E cross-cluster isolation (DD-TEST-013)

### DIFF
--- a/docs/architecture/decisions/DD-TEST-013-fmc-e2e-cross-cluster-bridge.md
+++ b/docs/architecture/decisions/DD-TEST-013-fmc-e2e-cross-cluster-bridge.md
@@ -1,0 +1,125 @@
+# DD-TEST-013: FMC E2E Cross-Cluster Bridge (Second Kind Cluster)
+
+**Status**: ✅ Approved
+**Date**: 2026-07-02
+**Author**: AI Assistant
+**Related**: Issue #54, ADR-068, BR-INTEGRATION-065, [Spike S19](../../spikes/multi-cluster-mcp-gateway/spike-s19-fmc-e2e-second-cluster/README.md), DD-TEST-001
+
+---
+
+## Context
+
+The Fleet Metadata Cache (FMC) E2E lanes (`test/e2e/fleetmetadatacache/`
+Kuadrant + EAIGW variants) register three "clusters" with the MCP Gateway:
+`loopback-cluster`, `prod-east`, `prod-west`. All three currently target the
+**same** physical Kind cluster and the same `kube-mcp-server` Deployment (the
+"loopback pattern," documented in `SetupFleetE2EInfrastructure`). This proves
+the multi-cluster *code path* (three distinct `MCPServerRegistration`/
+`Backend` objects, three distinct tool-name prefixes, FMC's per-cluster scope
+resolution) but does not prove genuine cross-cluster *data isolation* --
+every "cluster" sees identical Kubernetes API state because there is only
+one API server behind all three registrations.
+
+For SOC2 CC8.1 / FedRAMP AC-4 (information flow enforcement) coverage of
+Issue #54's multi-cluster federation claim, at least one registered cluster
+should be backed by a genuinely separate Kubernetes control plane, so tests
+can assert that a resource created only in `prod-east`'s backing cluster is
+never visible through `loopback-cluster`'s or `prod-west`'s scope, and vice
+versa.
+
+## Decision
+
+Bridge `prod-east` to a **second, independent Kind cluster** using only
+`Service`+`Endpoints` objects over the shared podman `kind` bridge network --
+no service mesh, no Istio multi-cluster, no VPN. This was validated
+empirically end-to-end in Spike S19 (2026-07-02, all 4 phases passed) before
+being folded into production test infrastructure code.
+
+### Architecture
+
+```
+┌─────────────────────────────┐        podman "kind" bridge network        ┌─────────────────────────────┐
+│   Primary Kind cluster       │◄───────────────────────────────────────►│   Remote Kind cluster        │
+│   (fmc-e2e / fmc-eaigw-e2e)  │        (NodePort ↔ NodePort, no host)     │   (fmc-e2e-remote / ...)     │
+│                               │                                            │                               │
+│  Keycloak (real IdP)          │◄── bridge Svc "keycloak" (remote:8443) ───│  API server (OIDC-patched     │
+│  kube-mcp-server (loopback)   │                                            │   against bridged Keycloak)   │
+│  Kuadrant/EAIGW Gateway        │                                            │  kube-mcp-server-2            │
+│    - loopback-cluster ─► local kube-mcp-server                            │    (passthrough + STS,        │
+│    - prod-east ─► bridge Svc "kube-mcp-server-remote" (remote NodePort) ──┼──► same RFC 8693 exchange)    │
+│    - prod-west ─► local kube-mcp-server                                   │                               │
+└─────────────────────────────┘                                            └─────────────────────────────┘
+```
+
+Both directions use the same primitive: a `Service` with a hand-authored
+`Endpoints` object (no selector) whose address is the peer cluster's node
+bridge IP (`podman inspect <node> --format
+{{.NetworkSettings.Networks.kind.IPAddress}}`) and port is the peer's
+NodePort.
+
+### Key implementation details (from Spike S19)
+
+1. **Bridge Service port must match the dialed hostname:port, not the
+   NodePort.** The remote cluster's API server dials
+   `https://keycloak:8443/...` (hardcoded to match production's Keycloak
+   port), so the bridge Service in the remote cluster must expose port
+   `8443` with `Endpoints` pointing at the primary's actual Keycloak
+   NodePort (`30557`) -- these are two different numbers and must not be
+   conflated.
+2. **`applyExchangedIdentityRBAC` must run against the remote cluster too**,
+   binding the same Keycloak-exchanged identity (`keycloak:service-account-
+   kubernaut-fleet-read`) to `view` there. `kube-mcp-server`'s own
+   ServiceAccount RBAC is vestigial in passthrough mode.
+3. **CA reuse requires zero code changes**: the primary cluster's
+   `inter-service-ca.pem` bytes are copied to the same relative path next to
+   the remote cluster's kubeconfig, and `patchAPIServerForOIDCConfig`
+   (called unmodified) trusts it.
+4. Existing helpers (`patchAPIServerForOIDCConfig`,
+   `patchAPIServerPodHostsForIssuer`) needed **zero changes** -- both
+   resolve the issuer hostname via `kubectl get svc <host> -o
+   jsonpath={.spec.clusterIP}`, which is agnostic to whether the Service's
+   Endpoints are real (kube-proxy-selected Pods) or hand-authored (a
+   bridge).
+
+## Alternatives Considered
+
+| Alternative | Rejected because |
+|---|---|
+| Istio multi-cluster / shared control plane | Massive complexity and resource cost for a test-only need; the FMC E2E lane deliberately avoids a service mesh spanning clusters (see `SetupFMCE2EInfrastructure`'s "Skips" list) |
+| `kind` cluster with multiple "logical" API servers (e.g. separate namespaces + fake ClusterID labels) | Does not prove genuine control-plane isolation -- same failure mode as today's loopback pattern, just with more indirection |
+| VPN / WireGuard tunnel between two Kind clusters on different hosts | Unnecessary: podman's `kind` bridge network already places both clusters' nodes on one routable L3 network when both clusters are created by the same podman daemon (CI already sets `KIND_EXPERIMENTAL_PROVIDER=podman`) |
+| `kubectl port-forward`-based bridging | Explicitly rejected project-wide per DD-TEST-001 (NodePort mandated for E2E stability); port-forward processes are also a poor fit for a bridge that must stay up for the whole suite |
+
+## Consequences
+
+- **Positive**: `prod-east` now proves genuine cross-cluster isolation
+  end-to-end (SOC2 CC8.1, FedRAMP AC-4), closing a real gap in Issue #54's
+  claimed multi-cluster federation coverage.
+- **Positive**: `RemoteBridge` is an opt-in, nil-safe field on
+  `KubeMCPServerAuthConfig` -- the "fleet" full-pipeline suite
+  (`DeployFleetInfra`/`DefaultKubeMCPServerAuthConfig`) is entirely
+  unaffected; only the two FMC E2E lanes set it.
+- **Negative**: both FMC E2E lanes now create and tear down **two** Kind
+  clusters instead of one, increasing CI wall-clock time and resource usage
+  (~95s cluster creation + kube-mcp-server-2 deployment, measured in Spike
+  S19). This is the primary open risk flagged when this design was approved
+  (see confidence assessment): CI resource/time budget for two concurrent
+  Kind clusters per lane was not validated in Spike S19 (local-only) and is
+  the first thing to check in this feature's initial CI run.
+- **Negative**: must-gather diagnostics on failure must now cover both
+  clusters' kubeconfigs, not just the primary's.
+
+## Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | IT/E2E Test ID |
+|---|---|---|---|
+| `KindNodeBridgeIP` / `CreateServiceBridge` | Called by `SetupRemoteClusterForFMC` and `deployKuadrantRegistrations`/`deployEnvoyAIGatewayRegistrations` | `test/infrastructure/kind_bridge.go` | E2E-FMC-054-015 / E2E-FMC-EAIGW-054-015 |
+| `SetupRemoteClusterForFMC` | Called from `setupFMCE2EInfrastructure` before `DeployFleetCoreInfra` | `test/infrastructure/fleetmetadatacache_remote_cluster.go`, `test/infrastructure/fleetmetadatacache_e2e.go` | E2E-FMC-054-015 / E2E-FMC-EAIGW-054-015 |
+| `KubeMCPServerAuthConfig.RemoteBridge` | Read by `deployKuadrantRegistrations`/`deployEnvoyAIGatewayRegistrations` to select `prod-east`'s backend hostname | `test/infrastructure/fleet_e2e.go` | E2E-FMC-054-015 / E2E-FMC-EAIGW-054-015 |
+| `shared.Harness.RemoteK8sClient` | Populated in both suites' `SynchronizedBeforeSuite`, used by the cross-cluster isolation scenario to create resources directly against the remote cluster | `test/e2e/fleetmetadatacache/suite_test.go`, `test/e2e/fleetmetadatacache/eaigw/suite_test.go` | E2E-FMC-054-015 / E2E-FMC-EAIGW-054-015 |
+| `shared.CrossClusterIsolation` | Registered by both variant packages' `*_test.go` wiring files | `test/e2e/fleetmetadatacache/shared/cross_cluster_isolation.go` | E2E-FMC-054-015 / E2E-FMC-EAIGW-054-015 |
+
+## Authority
+
+Issue #54, ADR-068, BR-INTEGRATION-065, Spike S19
+(`docs/spikes/multi-cluster-mcp-gateway/spike-s19-fmc-e2e-second-cluster/`).

--- a/docs/spikes/multi-cluster-mcp-gateway/spike-s19-fmc-e2e-second-cluster/README.md
+++ b/docs/spikes/multi-cluster-mcp-gateway/spike-s19-fmc-e2e-second-cluster/README.md
@@ -1,0 +1,152 @@
+# Spike S19: FMC E2E Second Kind Cluster (Cross-Cluster Isolation Bridge)
+
+**Date**: 2026-07-02
+**Status**: PASSED (all 4 phases) -- confidence raised from 78% to ~92%
+**Authority**: Issue #54, follow-up to Spikes S17/S18 (Keycloak migration, EAIGW)
+
+## Goal
+
+The FMC E2E lanes (`test/e2e/fleetmetadatacache/` Kuadrant + EAIGW variants)
+register three "clusters" (`loopback-cluster`, `prod-east`, `prod-west`), but
+all three are a loopback pattern -- every `MCPServerRegistration`/`Backend`
+targets the *same* backend (a single physical Kind cluster). This proves the
+multi-cluster *code path* but not genuine cross-cluster *data isolation*.
+
+This spike answers: can `prod-east` be bridged to a genuinely separate,
+second Kind cluster -- with its own independent kube-mcp-server and its own
+Kubernetes API server -- using only a `Service`+`Endpoints` bridge over the
+podman `kind` network (no Istio multi-cluster, no service mesh)?
+
+## Result: YES, with one bug found and fixed during the spike
+
+All 4 phases passed. Confidence for the full implementation plan raised from
+78% (pre-spike, static code reading only) to ~92% (post-spike, empirically
+validated against real Keycloak, real OIDC, real RFC 8693 token exchange,
+real Kubernetes API servers on two independent Kind clusters).
+
+### Phase A: primary cluster setup (baseline, unmodified)
+
+Ran the real `SetupFMCE2EInfrastructure` unmodified to get a realistic
+baseline (Keycloak + Kuadrant MCP Gateway + kube-mcp-server + Valkey + FMC).
+PASSED, ~369s.
+
+### Phase B: remote cluster + Keycloak bridge + OIDC patch
+
+Created a second Kind cluster (`spike-remote`), bridged a `keycloak` Service
+in it back to the primary cluster's real Keycloak (over the podman `kind`
+bridge network), copied the primary's inter-service CA bytes locally (no new
+CA generated), and OIDC-patched the remote cluster's own API server against
+it. PASSED, ~95s.
+
+**Important caveat discovered**: the API server's `readyz` going stable here
+does NOT by itself prove the bridge is live end-to-end -- `kube-apiserver`
+validates the OIDC flags syntactically at startup but only performs an eager
+connectivity check to the issuer lazily, on first real token validation.
+Phase C is what actually proves this bridge works.
+
+### Phase C: kube-mcp-server on the remote cluster (the real proof)
+
+Deployed a second, independent kube-mcp-server into the remote cluster,
+applied `applyExchangedIdentityRBAC` there too, exposed it via NodePort, and
+ran a real authenticated `tools/call` (list Pods) against it using a
+Keycloak-issued token.
+
+**First attempt FAILED**: `Error: unable to setup OIDC provider: Get
+"https://keycloak:8443/...": dial tcp 10.96.66.113:8443: connect: connection
+refused`.
+
+**Root cause**: the bridge `Service`'s `port` field was set to `8080`
+(matching the *NodePort* value used elsewhere in this codebase), but
+in-cluster clients dial `https://keycloak:8443/...` -- the Service must
+expose port **8443** (matching the hardcoded issuer/authorization URL), with
+`targetPort`/Endpoints pointing at the actual remote NodePort (`30557`).
+DNS resolution alone succeeding masked this until an actual client tried to
+connect.
+
+**Fix**: `spikeCreateServiceBridge` takes `servicePort` (what clients dial)
+and `remotePort` (the actual NodePort) as separate parameters. This is
+directly relevant to the real implementation: `createServiceBridge` must not
+assume the Service port equals the NodePort number.
+
+**After the fix**: PASSED immediately (~4s, since the cluster/RBAC/NodePort
+Service already existed from the failed attempt). This proves:
+- The bridged Keycloak validates kube-mcp-server-2's incoming token
+- kube-mcp-server-2 performs a real RFC 8693 exchange through the same bridge
+- The remote cluster's own (OIDC-patched) API server validates the exchanged
+  token and authorizes it
+- **`applyExchangedIdentityRBAC` IS required on the remote cluster too** --
+  kube-mcp-server's own ServiceAccount `view` binding is vestigial in
+  passthrough mode (only the exchanged identity's RBAC actually matters),
+  confirming an open risk item from the implementation plan.
+
+### Phase D: reverse bridge (primary cluster -> remote cluster)
+
+Created a `kube-mcp-server-remote` bridge Service+Endpoints in the *primary*
+cluster pointing at the remote cluster's kube-mcp-server NodePort, then
+proved in-cluster reachability from a throwaway pod using pure Service DNS
+(`kube-mcp-server-remote.kubernaut-system.svc.cluster.local:8080`).
+
+PASSED. Manually re-verified with a verbose curl for certainty:
+
+```
+< HTTP/1.1 200 OK
+< Content-Length: 0
+```
+
+This is exactly the mechanism a Kuadrant `HTTPRoute.backendRefs` or an EAIGW
+`Backend.spec.endpoints[].fqdn` would use in the real implementation.
+
+## Key findings for the real implementation
+
+1. **Bridge Service port must match the dialed hostname:port, not the
+   NodePort.** `createServiceBridge(serviceName, servicePort, remoteIP,
+   remotePort)` needs both as distinct parameters.
+2. **`applyExchangedIdentityRBAC` must run against the remote cluster too**,
+   not just the primary -- add this as an explicit step in
+   `SetupRemoteClusterForFMC`.
+3. **CA reuse works with zero code changes**: copying the primary's
+   `inter-service-ca.pem` bytes to the same relative path next to the
+   remote cluster's kubeconfig makes `patchAPIServerForOIDCConfig` (called
+   verbatim, no modification) trust Keycloak's real certificate.
+4. **`patchAPIServerForOIDCConfig`/`patchAPIServerPodHostsForIssuer` need
+   zero changes** -- they resolve the issuer hostname via `kubectl get svc
+   <host> -o jsonpath={.spec.clusterIP}`, which works identically whether
+   the Service has real or hand-authored Endpoints.
+5. **API server `readyz` stability is not sufficient evidence that OIDC
+   trust actually works** -- only a real, eager-validating client (like
+   kube-mcp-server's own OIDC provider setup) proves the bridge is live.
+   The real implementation's validation step should rely on the E2E
+   scenario's real authenticated call, not just readiness checks.
+6. The podman `kind` shared-bridge-network assumption (Kind clusters on the
+   same host share one bridge network, enabling direct NodePort-to-NodePort
+   reachability) held on this second, independent attempt -- consistent
+   with CI's `KIND_EXPERIMENTAL_PROVIDER: podman` setting.
+
+## How to re-run
+
+This file uses `//go:build ignore` and lives outside `test/infrastructure/`
+so it does not affect normal builds. To re-run: copy
+`second_cluster_spike_test.go` (remove the `//go:build ignore` line) and
+`kind-spike-remote-config.yaml` into `test/infrastructure/`, then:
+
+```bash
+RUN_SPIKE=true go test -run TestSpikeA_PrimarySetup -v -timeout 20m ./test/infrastructure/...
+RUN_SPIKE=true go test -run TestSpikeB_RemoteClusterAndKeycloakBridge -v -timeout 10m ./test/infrastructure/...
+RUN_SPIKE=true go test -run TestSpikeC_KubeMCPOnRemote -v -timeout 10m ./test/infrastructure/...
+RUN_SPIKE=true go test -run TestSpikeD_BridgeBackIntoPrimary -v -timeout 5m ./test/infrastructure/...
+```
+
+Cleanup:
+
+```bash
+kind delete cluster --name spike-primary
+kind delete cluster --name spike-remote
+rm -rf /tmp/kubernaut-spike
+```
+
+## Relationship to the implementation plan
+
+See the FMC E2E Second Kind Cluster plan (Phase 0 gate). This spike closes
+Phase 0 with a YES decision. Findings 1-2 above are already folded into the
+plan's implementation steps 2-4 (bridge primitives, remote cluster
+provisioning).

--- a/docs/spikes/multi-cluster-mcp-gateway/spike-s19-fmc-e2e-second-cluster/kind-spike-remote-config.yaml
+++ b/docs/spikes/multi-cluster-mcp-gateway/spike-s19-fmc-e2e-second-cluster/kind-spike-remote-config.yaml
@@ -1,0 +1,16 @@
+# SPIKE config -- second Kind cluster for the cross-cluster bridge design
+# (Phase 0 of the FMC E2E second-Kind-cluster plan). Validated end-to-end on
+# 2026-07-02 (all 4 spike phases passed). Kept intentionally in case the
+# design needs to be revisited -- not wired into any real E2E lane.
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a
+  extraPortMappings:
+  # Spike-only: lets the host-side test process curl kube-mcp-server-2
+  # directly for verification. NOT needed for the real cross-cluster path
+  # (that goes node-bridge-IP to node-bridge-IP, no host mapping required).
+  - containerPort: 30180
+    hostPort: 8180
+    protocol: TCP

--- a/docs/spikes/multi-cluster-mcp-gateway/spike-s19-fmc-e2e-second-cluster/second_cluster_spike_test.go
+++ b/docs/spikes/multi-cluster-mcp-gateway/spike-s19-fmc-e2e-second-cluster/second_cluster_spike_test.go
@@ -1,0 +1,433 @@
+//go:build ignore
+
+/*
+SPIKE S19 -- FMC E2E second Kind cluster (cross-cluster isolation bridge).
+
+Validated end-to-end on 2026-07-02. See README.md in this directory for
+the goal, architecture, and findings.
+
+This file is kept for reference / future revision, NOT for standalone
+compilation: it depends on unexported helpers in package `infrastructure`
+(patchAPIServerForOIDCConfig, KubeMCPServerAuthConfig, kubectlApplyManifest,
+CreateKindClusterWithConfig, waitForDeployment, InterServiceCAPath,
+TLSCAVolumeYAML/MountYAML, applyExchangedIdentityRBAC,
+probeAuthenticatedResourcesList, indentPEM, KubeMCPServerImage,
+KubeMCPServerAuthModePassthrough). The `//go:build ignore` tag above keeps
+`go build ./...` / `go vet ./...` / golangci-lint from picking this up in
+its current location.
+
+To re-run: copy this file (and kind-spike-remote-config.yaml, adjusting its
+ConfigPath below to test/infrastructure/kind-spike-remote-config.yaml) into
+test/infrastructure/ as a `_test.go` file with `package infrastructure`,
+remove the `//go:build ignore` line, then:
+
+  RUN_SPIKE=true go test -run TestSpikeA_PrimarySetup -v -timeout 20m ./test/infrastructure/...
+  RUN_SPIKE=true go test -run TestSpikeB_RemoteClusterAndKeycloakBridge -v -timeout 10m ./test/infrastructure/...
+  RUN_SPIKE=true go test -run TestSpikeC_KubeMCPOnRemote -v -timeout 10m ./test/infrastructure/...
+  RUN_SPIKE=true go test -run TestSpikeD_BridgeBackIntoPrimary -v -timeout 5m ./test/infrastructure/...
+
+Cleanup:
+  kind delete cluster --name spike-primary
+  kind delete cluster --name spike-remote
+  rm -rf /tmp/kubernaut-spike
+*/
+
+package infrastructure
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jordigilh/kubernaut/pkg/fleet/registry"
+)
+
+const (
+	spikeDir            = "/tmp/kubernaut-spike"
+	spikePrimaryCluster = "spike-primary"
+	spikeRemoteCluster  = "spike-remote"
+	spikeNamespace      = "kubernaut-system"
+)
+
+func spikePrimaryKubeconfig() string { return filepath.Join(spikeDir, "primary-kubeconfig.yaml") }
+func spikeRemoteKubeconfig() string  { return filepath.Join(spikeDir, "remote-kubeconfig.yaml") }
+
+func skipUnlessSpike(t *testing.T) {
+	if os.Getenv("RUN_SPIKE") != "true" {
+		t.Skip("set RUN_SPIKE=true to run this throwaway spike")
+	}
+}
+
+// TestSpikeA_PrimarySetup stands up the primary FMC cluster exactly as the
+// real Kuadrant lane does today (unmodified SetupFMCE2EInfrastructure).
+func TestSpikeA_PrimarySetup(t *testing.T) {
+	skipUnlessSpike(t)
+	require(t, os.MkdirAll(spikeDir, 0o755))
+
+	ctx := context.Background()
+	_, err := SetupFMCE2EInfrastructure(ctx, spikePrimaryCluster, spikePrimaryKubeconfig(), os.Stdout)
+	if err != nil {
+		t.Fatalf("primary cluster setup failed: %v", err)
+	}
+	t.Log("✅ Phase A done: primary cluster fully up (Keycloak + Kuadrant + kube-mcp-server + FMC)")
+}
+
+// TestSpikeB_RemoteClusterAndKeycloakBridge creates the second Kind cluster,
+// bridges its "keycloak" hostname back to the primary cluster's real
+// Keycloak over the shared podman bridge network, and OIDC-patches the
+// remote cluster's own API server against it. This is the highest-risk,
+// never-before-tested part of the design.
+//
+// NOTE (finding from this spike): the API server's readyz going stable here
+// does NOT by itself prove the bridge works -- kube-apiserver validates the
+// OIDC flags syntactically at startup but only does an EAGER connectivity
+// check to the issuer lazily, on first real token validation. Phase C is
+// what actually proves this bridge is live end-to-end.
+func TestSpikeB_RemoteClusterAndKeycloakBridge(t *testing.T) {
+	skipUnlessSpike(t)
+	ctx := context.Background()
+	w := os.Stdout
+
+	t.Log("── creating remote Kind cluster ──")
+	opts := KindClusterOptions{
+		ClusterName:             spikeRemoteCluster,
+		KubeconfigPath:          spikeRemoteKubeconfig(),
+		ConfigPath:              "test/infrastructure/kind-spike-remote-config.yaml",
+		WaitTimeout:             "5m",
+		UsePodman:               true,
+		ProjectRootAsWorkingDir: true,
+	}
+	if err := CreateKindClusterWithConfig(opts, w); err != nil {
+		t.Fatalf("remote cluster creation failed: %v", err)
+	}
+
+	if err := createTestNamespace(spikeNamespace, spikeRemoteKubeconfig(), w); err != nil {
+		t.Fatalf("remote namespace creation failed: %v", err)
+	}
+
+	t.Log("── discovering primary cluster's node bridge IP ──")
+	primaryIP, err := spikeNodeBridgeIP(spikePrimaryCluster + "-control-plane")
+	if err != nil {
+		t.Fatalf("failed to discover primary node bridge IP: %v", err)
+	}
+	t.Logf("primary node bridge IP: %s", primaryIP)
+
+	t.Log("── bridging 'keycloak' Service in remote cluster -> primary Keycloak NodePort ──")
+	// Service port MUST be 8443 (matching the hardcoded "https://keycloak:8443/..."
+	// issuer/authorization URLs) -- NOT the NodePort number. Bug found during
+	// this spike: an 8080 Service port caused "connection refused" (DNS
+	// resolved fine, but nothing listens on ClusterIP:8443).
+	if err := spikeCreateServiceBridge(ctx, spikeRemoteKubeconfig(), spikeNamespace, "keycloak", 8443, primaryIP, 30557, w); err != nil {
+		t.Fatalf("keycloak bridge Service creation failed: %v", err)
+	}
+
+	t.Log("── copying primary's inter-service CA to remote (local file + ConfigMap) ──")
+	if err := spikeCopyInterServiceCA(ctx, spikePrimaryKubeconfig(), spikeRemoteKubeconfig(), spikeNamespace, w); err != nil {
+		t.Fatalf("CA copy failed: %v", err)
+	}
+
+	t.Log("── OIDC-patching remote cluster's API server against the bridged Keycloak ──")
+	oidcCfg := OIDCPatchConfig{
+		IssuerURL:      "https://keycloak:8443/realms/kubernaut-fleet",
+		ClientID:       "k8s-api",
+		UsernameClaim:  "preferred_username",
+		UsernamePrefix: "keycloak:",
+	}
+	if err := patchAPIServerForOIDCConfig(ctx, spikeRemoteCluster, spikeRemoteKubeconfig(), oidcCfg, w); err != nil {
+		t.Fatalf("remote API server OIDC patch failed: %v", err)
+	}
+
+	t.Log("✅ Phase B done: remote cluster's own API server trusts primary's real Keycloak over the bridge")
+}
+
+// TestSpikeC_KubeMCPOnRemote deploys a second, independent kube-mcp-server
+// into the remote cluster and proves it can authenticate an incoming
+// Keycloak-issued token, exchange it via RFC 8693, and successfully read
+// real Pods from the REMOTE cluster's own (now OIDC-trusting) API server.
+//
+// RESULT: passed on first successful run (after the Phase B port fix),
+// confirming applyExchangedIdentityRBAC IS required on the remote cluster
+// too (kube-mcp-server's own ServiceAccount RBAC is vestigial in
+// passthrough mode -- only the exchanged identity's RBAC matters).
+func TestSpikeC_KubeMCPOnRemote(t *testing.T) {
+	skipUnlessSpike(t)
+	ctx := context.Background()
+	w := os.Stdout
+
+	authConfig := KubeMCPServerAuthConfig{
+		Mode:             KubeMCPServerAuthModePassthrough,
+		GatewayType:      registry.GatewayKuadrant,
+		RequireOAuth:     true,
+		AuthorizationURL: "https://keycloak:8443/realms/kubernaut-fleet",
+		OAuthAudience:    "kube-mcp-server",
+		StsClientID:      "kube-mcp-server",
+		StsClientSecret:  "e2e-kube-mcp-server-secret",
+		StsAudience:      "k8s-api",
+		StsScopes:        []string{"k8s-api-audience"},
+		CAFilePath:       "/etc/tls-ca/ca.crt",
+	}
+
+	t.Log("── deploying kube-mcp-server-2 into remote cluster ──")
+	if err := spikeDeployKubeMCPServer(ctx, spikeNamespace, spikeRemoteKubeconfig(), authConfig, w); err != nil {
+		t.Fatalf("kube-mcp-server-2 deployment failed: %v", err)
+	}
+
+	t.Log("── applying exchanged-identity RBAC in remote cluster ──")
+	if err := applyExchangedIdentityRBAC(ctx, spikeRemoteKubeconfig(), w); err != nil {
+		t.Fatalf("exchanged-identity RBAC failed: %v", err)
+	}
+
+	t.Log("── exposing kube-mcp-server-2 via NodePort 30180 ──")
+	npManifest := fmt.Sprintf(`---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-mcp-server-nodeport
+  namespace: %s
+spec:
+  type: NodePort
+  selector:
+    app: kube-mcp-server
+  ports:
+  - port: 8080
+    targetPort: 8080
+    nodePort: 30180
+`, spikeNamespace)
+	if err := kubectlApplyManifest(ctx, spikeRemoteKubeconfig(), w, npManifest); err != nil {
+		t.Fatalf("NodePort expose failed: %v", err)
+	}
+
+	t.Log("── authenticated tools/call against kube-mcp-server-2 (proves Keycloak bridge + STS + remote API server trust all work) ──")
+	tokenFunc := func() (string, error) {
+		return GetKeycloakClientCredentialsToken(KeycloakFleetTokenConfig{
+			TokenEndpoint: "https://localhost:30557/realms/kubernaut-fleet/protocol/openid-connect/token",
+			ClientID:      "kubernaut-fleet-read",
+			ClientSecret:  "e2e-fleet-secret",
+			Scopes:        []string{"kube-mcp-server-audience"},
+		})
+	}
+
+	deadline := time.Now().Add(90 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		if err := probeAuthenticatedResourcesList(tokenFunc, "http://localhost:8180/mcp", ""); err != nil {
+			lastErr = err
+			time.Sleep(3 * time.Second)
+			continue
+		}
+		t.Log("✅ Phase C done: kube-mcp-server-2 authenticated + exchanged + read real Pods from the REMOTE cluster's own API server")
+		return
+	}
+	t.Fatalf("authenticated tools/call against kube-mcp-server-2 never succeeded: %v", lastErr)
+}
+
+// TestSpikeD_BridgeBackIntoPrimary proves the reverse direction: a bridge
+// Service created in the PRIMARY cluster, pointing at the remote cluster's
+// kube-mcp-server NodePort, is reachable via pure in-cluster Service DNS --
+// exactly how a Kuadrant HTTPRoute / EAIGW Backend would reach it for real.
+//
+// RESULT: passed, confirmed via a manual verbose curl too (HTTP/1.1 200 OK
+// from kube-mcp-server-remote.kubernaut-system.svc.cluster.local:8080/healthz).
+func TestSpikeD_BridgeBackIntoPrimary(t *testing.T) {
+	skipUnlessSpike(t)
+	ctx := context.Background()
+	w := os.Stdout
+
+	t.Log("── discovering remote cluster's node bridge IP ──")
+	remoteIP, err := spikeNodeBridgeIP(spikeRemoteCluster + "-control-plane")
+	if err != nil {
+		t.Fatalf("failed to discover remote node bridge IP: %v", err)
+	}
+	t.Logf("remote node bridge IP: %s", remoteIP)
+
+	t.Log("── bridging 'kube-mcp-server-remote' Service in primary cluster -> remote kube-mcp-server NodePort ──")
+	if err := spikeCreateServiceBridge(ctx, spikePrimaryKubeconfig(), spikeNamespace, "kube-mcp-server-remote", 8080, remoteIP, 30180, w); err != nil {
+		t.Fatalf("reverse bridge Service creation failed: %v", err)
+	}
+
+	t.Log("── proving in-cluster reachability from a throwaway pod in the primary cluster ──")
+	curlCmd := exec.CommandContext(ctx, "kubectl", "--kubeconfig", spikePrimaryKubeconfig(),
+		"run", "spike-curl", "--rm", "-i", "--restart=Never", "--image=curlimages/curl",
+		"--namespace", spikeNamespace, "--command", "--",
+		"curl", "-sS", "-m", "5", "http://kube-mcp-server-remote.kubernaut-system.svc.cluster.local:8080/healthz")
+	out, err := curlCmd.CombinedOutput()
+	t.Logf("curl output: %s", string(out))
+	if err != nil {
+		t.Fatalf("in-cluster bridge reachability check failed: %v", err)
+	}
+	t.Log("✅ Phase D done: primary cluster reaches remote cluster's kube-mcp-server via a pure Service+Endpoints bridge")
+}
+
+// ── spike-only helpers (throwaway; NOT the real implementation) ──────────
+
+func spikeNodeBridgeIP(nodeName string) (string, error) {
+	cmd := exec.Command("podman", "inspect", nodeName,
+		"--format", "{{.NetworkSettings.Networks.kind.IPAddress}}")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("podman inspect %s failed: %w (%s)", nodeName, err, string(out))
+	}
+	ip := strings.TrimSpace(string(out))
+	if ip == "" {
+		return "", fmt.Errorf("empty bridge IP for node %s (is it on the 'kind' podman network?)", nodeName)
+	}
+	return ip, nil
+}
+
+// servicePort is what in-cluster DNS clients dial (must match whatever
+// hostname:port is hardcoded elsewhere, e.g. "keycloak:8443"); remotePort is
+// the actual NodePort listening on remoteIP.
+func spikeCreateServiceBridge(ctx context.Context, kubeconfigPath, namespace, serviceName string, servicePort int, remoteIP string, remotePort int, w *os.File) error {
+	manifest := fmt.Sprintf(`---
+apiVersion: v1
+kind: Service
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  ports:
+  - port: %[4]d
+    targetPort: %[5]d
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+subsets:
+- addresses:
+  - ip: %[3]s
+  ports:
+  - port: %[5]d
+`, serviceName, namespace, remoteIP, servicePort, remotePort)
+	return kubectlApplyManifest(ctx, kubeconfigPath, w, manifest)
+}
+
+func spikeCopyInterServiceCA(ctx context.Context, primaryKubeconfig, remoteKubeconfig, namespace string, w *os.File) error {
+	caBytes, err := os.ReadFile(InterServiceCAPath(primaryKubeconfig))
+	if err != nil {
+		return fmt.Errorf("read primary CA: %w", err)
+	}
+	if err := os.WriteFile(InterServiceCAPath(remoteKubeconfig), caBytes, 0o600); err != nil {
+		return fmt.Errorf("write CA next to remote kubeconfig: %w", err)
+	}
+	cmName := "inter-service-ca"
+	cmManifest := fmt.Sprintf(`---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: %s
+  namespace: %s
+data:
+  ca.crt: |
+%s
+`, cmName, namespace, indentPEM(string(caBytes), 4))
+	return kubectlApplyManifest(ctx, remoteKubeconfig, w, cmManifest)
+}
+
+// spikeDeployKubeMCPServer duplicates (does not refactor) the kube-mcp-server
+// manifest from deployKubeMCPServerAndRegister -- for the spike only. The
+// real implementation extracts a shared deployKubeMCPServer function instead
+// of duplicating this (see the FMC E2E second-cluster plan).
+func spikeDeployKubeMCPServer(ctx context.Context, namespace, kubeconfigPath string, authConfig KubeMCPServerAuthConfig, w *os.File) error {
+	manifest := fmt.Sprintf(`---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: kube-mcp-server
+  namespace: %[1]s
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kube-mcp-server-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- kind: ServiceAccount
+  name: kube-mcp-server
+  namespace: %[1]s
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-mcp-server-config
+  namespace: %[1]s
+data:
+  config.toml: |
+%[3]s
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kube-mcp-server
+  namespace: %[1]s
+  labels:
+    app: kube-mcp-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kube-mcp-server
+  template:
+    metadata:
+      labels:
+        app: kube-mcp-server
+    spec:
+      serviceAccountName: kube-mcp-server
+      containers:
+      - name: kube-mcp-server
+        image: %[2]s
+        args:
+        - "--port=8080"
+        - "--cluster-provider=in-cluster"
+        - "--toolsets=core"
+        - "--stateless"
+        - "--list-output=yaml"
+        - "--config=/etc/kubernetes-mcp-server/config.toml"
+        - "--log-level=6"
+        ports:
+        - name: http
+          containerPort: 8080
+        volumeMounts:
+        - name: config
+          mountPath: /etc/kubernetes-mcp-server
+          readOnly: true%[4]s
+        readinessProbe:
+          httpGet:
+            path: /healthz
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 5
+        resources:
+          requests:
+            memory: "32Mi"
+            cpu: "50m"
+          limits:
+            memory: "128Mi"
+            cpu: "250m"
+      volumes:
+      - name: config
+        configMap:
+          name: kube-mcp-server-config%[5]s
+`, namespace, KubeMCPServerImage, indentPEM(authConfig.tomlString(), 4), TLSCAVolumeMountYAML(8), TLSCAVolumeYAML(6))
+
+	if err := kubectlApplyManifest(ctx, kubeconfigPath, w, manifest); err != nil {
+		return fmt.Errorf("kube-mcp-server-2 deployment failed: %w", err)
+	}
+	return waitForDeployment(ctx, "kube-mcp-server", namespace, kubeconfigPath, 120*time.Second, w)
+}
+
+func require(t *testing.T, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("setup precondition failed: %v", err)
+	}
+}

--- a/docs/testing/BR-INTEGRATION-054/TEST_PLAN.md
+++ b/docs/testing/BR-INTEGRATION-054/TEST_PLAN.md
@@ -110,27 +110,31 @@ scope is therefore narrower than the full fleet-architecture set above.
 | E2E-FMC-054-012 | E2E | [SI-4, CP-10] FMC's `/readyz` genuinely degrades to 503 when the real Valkey dependency fails, then auto-recovers and resumes writing fresh cache entries once Valkey self-heals, without requiring FMC's own restart | SI-4, CP-10 | BR-INTEGRATION-065 | `test/e2e/fleetmetadatacache/resilience_test.go` |
 | E2E-FMC-054-013 | E2E | [SI-4, CM-6] FMC's cluster registry reacts live to a real MCPServerRegistration CRD being created and deleted, without disturbing the fixed cluster set | SI-4, CM-6 | BR-INTEGRATION-065 | `test/e2e/fleetmetadatacache/dynamic_registration_test.go` |
 | E2E-FMC-054-014 | E2E | [AC-6] kube-mcp-server performs a real RFC 8693 Standard Token Exchange against Keycloak (subject token audienced for kube-mcp-server -> exchanged token audienced for k8s-api), and the real Kubernetes API server honors the exchanged token while rejecting the un-exchanged subject token, proving the exchange step is a real security boundary rather than an inert passthrough (Spike S17/S18) | AC-6 | BR-INTEGRATION-065 | `test/e2e/fleetmetadatacache/token_exchange_test.go` |
+| E2E-FMC-054-015 | E2E | [AC-4] `prod-east` is backed by a genuinely separate Kubernetes control plane (a second, independent Kind cluster bridged over the shared podman network, DD-TEST-013): a resource created only in the remote cluster is reported managed via `prod-east` but never via `loopback-cluster`/`prod-west`, and a resource created only in the primary cluster is reported managed via `loopback-cluster`/`prod-west` but never via `prod-east` | AC-4 | BR-INTEGRATION-065 | `test/e2e/fleetmetadatacache/cross_cluster_isolation_test.go` |
 
-**Note on cross-cluster isolation**: the 3 fixed clusters (`loopback-cluster`,
-`prod-east`, `prod-west`) are a loopback pattern -- all 3 `MCPServerRegistration`s
-target the *same* `HTTPRoute`/backend (single physical Kind cluster), differentiated
-only by MCP tool-name prefix. This validates the multi-cluster *code path* but cannot
-prove genuine cross-cluster data isolation (a resource "leaking" as managed across two
-truly separate API servers). A dedicated second Kind cluster with real cross-cluster
-networking would be required to close that specific gap; deferred as a follow-up
-(feasibility already assessed as resource-wise viable -- ~1.1-1.3GB vs. the `fleet`
-suite's 6.1GB budget -- with the open question being Kuadrant's same-cluster-backend
-assumption, which needs a NodePort + cross-cluster Service/EndpointSlice bridge; the
-Keycloak-migration precondition for this follow-up spike is now satisfied).
+**Cross-cluster isolation architecture (DD-TEST-013)**: `loopback-cluster` and
+`prod-west` remain a loopback pattern (both `MCPServerRegistration`s/`Backend`s target
+the same physical primary-cluster `kube-mcp-server`, differentiated only by MCP
+tool-name prefix). `prod-east` is now bridged to a second, independent Kind cluster
+(`SetupRemoteClusterForFMC`) running its own `kube-mcp-server` and performing the same
+RFC 8693 exchange against the same (bridged) Keycloak instance -- proving genuine
+cross-cluster data isolation, not just the multi-cluster code path. The bridge uses
+plain `Service`+`Endpoints` objects over the shared podman `kind` network (no service
+mesh, no VPN); see
+[DD-TEST-013](../../architecture/decisions/DD-TEST-013-fmc-e2e-cross-cluster-bridge.md)
+and
+[Spike S19](../../spikes/multi-cluster-mcp-gateway/spike-s19-fmc-e2e-second-cluster/README.md)
+for the full design and empirical validation. `KubeMCPServerAuthConfig.RemoteBridge` is
+nil-safe and opt-in -- the "fleet" full-pipeline suite is unaffected.
 
 **Shared scenario implementation**: the Kuadrant and EAIGW lanes' Describe/It bodies
 are gateway-agnostic and live once in `test/e2e/fleetmetadatacache/shared/`
 (`sync_journey.go`, `least_privilege.go`, `resilience.go`,
-`dynamic_registration.go`, `token_exchange.go`), parameterized by a `shared.Variant`
-implementation per lane. Each `*_test.go` file listed in the tables below is a thin
-(~5-line) wiring file that registers the shared scenario with that lane's variant;
-the only gateway-specific code lives in each lane's own `variant.go` (dynamic
-cluster-resource CRD factory + RBAC checks).
+`dynamic_registration.go`, `token_exchange.go`, `cross_cluster_isolation.go`),
+parameterized by a `shared.Variant` implementation per lane. Each `*_test.go` file
+listed in the tables below is a thin (~5-line) wiring file that registers the shared
+scenario with that lane's variant; the only gateway-specific code lives in each lane's
+own `variant.go` (dynamic cluster-resource CRD factory + RBAC checks).
 
 ---
 
@@ -157,6 +161,7 @@ DD-TEST-001) so both lanes can run in CI without port collisions.
 | E2E-FMC-EAIGW-054-012 | E2E | [SI-4, CP-10] FMC's `/readyz` genuinely degrades to 503 when the real Valkey dependency fails, then auto-recovers and resumes writing fresh cache entries once Valkey self-heals, without requiring FMC's own restart | SI-4, CP-10 | BR-INTEGRATION-065 | `test/e2e/fleetmetadatacache/eaigw/resilience_test.go` |
 | E2E-FMC-EAIGW-054-013 | E2E | [SI-4, CM-6] FMC's cluster registry reacts live to a real `Backend` CRD being created and deleted (no `MCPRoute`/broker indirection), without disturbing the fixed cluster set | SI-4, CM-6 | BR-INTEGRATION-065 | `test/e2e/fleetmetadatacache/eaigw/dynamic_registration_test.go` |
 | E2E-FMC-EAIGW-054-014 | E2E | [AC-6] kube-mcp-server performs a real RFC 8693 Standard Token Exchange against Keycloak (subject token audienced for kube-mcp-server -> exchanged token audienced for k8s-api), and the real Kubernetes API server honors the exchanged token while rejecting the un-exchanged subject token, proving the exchange step is a real security boundary rather than an inert passthrough | AC-6 | BR-INTEGRATION-065 | `test/e2e/fleetmetadatacache/eaigw/token_exchange_test.go` |
+| E2E-FMC-EAIGW-054-015 | E2E | [AC-4] `prod-east` is backed by a genuinely separate Kubernetes control plane (a second, independent Kind cluster bridged over the shared podman network, DD-TEST-013): a resource created only in the remote cluster is reported managed via `prod-east` but never via `loopback-cluster`/`prod-west`, and a resource created only in the primary cluster is reported managed via `loopback-cluster`/`prod-west` but never via `prod-east` | AC-4 | BR-INTEGRATION-065 | `test/e2e/fleetmetadatacache/eaigw/cross_cluster_isolation_test.go` |
 
 ---
 
@@ -176,6 +181,7 @@ DD-TEST-001) so both lanes can run in CI without port collisions.
 | Control | Covered By |
 |---------|-----------|
 | AC-3 (Access enforcement) | IT-FLEET-DEXCC-001, IT-FLEET-AUTH-REJECT-001, UT-FLEET-RES-006, UT-WE-054-003, E2E-FMC-054-010, E2E-FMC-EAIGW-054-010 |
+| AC-4 (Information flow enforcement) | E2E-FMC-054-015, E2E-FMC-EAIGW-054-015 |
 | AC-6 (Least privilege) | IT-FLEET-006, E2E-FMC-054-011, E2E-FMC-054-014, E2E-FMC-EAIGW-054-011, E2E-FMC-EAIGW-054-014 |
 | AU-3 (Audit content) | E2E-SP-054-REMOTE |
 | CM-6 (Configuration change) | E2E-FMC-054-013, E2E-FMC-EAIGW-054-013 |
@@ -200,5 +206,7 @@ DD-TEST-001) so both lanes can run in CI without port collisions.
 
 - [ADR-068: Fleet Federation Architecture](../../architecture/decisions/ADR-068-fleet-federation-architecture.md)
 - [ADR-065: Fleet Cluster Identity on RR](../../architecture/decisions/ADR-065-fleet-cluster-identity-on-rr.md)
+- [DD-TEST-013: FMC E2E Cross-Cluster Bridge](../../architecture/decisions/DD-TEST-013-fmc-e2e-cross-cluster-bridge.md)
 - Issue #54: Multi-cluster federation
 - Spike S11: WE Remote Execution via MCP Gateway
+- [Spike S19: FMC E2E second Kind cluster](../../spikes/multi-cluster-mcp-gateway/spike-s19-fmc-e2e-second-cluster/README.md)

--- a/test/e2e/fleetmetadatacache/cross_cluster_isolation_test.go
+++ b/test/e2e/fleetmetadatacache/cross_cluster_isolation_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fleetmetadatacache
+
+import "github.com/jordigilh/kubernaut/test/e2e/fleetmetadatacache/shared"
+
+// E2E-FMC-054-015. See shared.CrossClusterIsolation for the scenario body
+// (shared verbatim with the EAIGW lane) and DD-TEST-013 for the
+// cross-cluster bridge design.
+var _ = shared.CrossClusterIsolation(harness, kuadrantVariant{})

--- a/test/e2e/fleetmetadatacache/eaigw/cross_cluster_isolation_test.go
+++ b/test/e2e/fleetmetadatacache/eaigw/cross_cluster_isolation_test.go
@@ -1,0 +1,24 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package eaigw
+
+import "github.com/jordigilh/kubernaut/test/e2e/fleetmetadatacache/shared"
+
+// E2E-FMC-EAIGW-054-015. See shared.CrossClusterIsolation for the scenario
+// body (shared verbatim with the Kuadrant lane) and DD-TEST-013 for the
+// cross-cluster bridge design.
+var _ = shared.CrossClusterIsolation(harness, eaigwVariant{})

--- a/test/e2e/fleetmetadatacache/eaigw/suite_test.go
+++ b/test/e2e/fleetmetadatacache/eaigw/suite_test.go
@@ -45,10 +45,12 @@ limitations under the License.
 //
 //	ginkgo -v ./test/e2e/fleetmetadatacache/eaigw/...
 //
-// Memory footprint: ~1.3-1.8GB (Keycloak + fleet-core w/ EAIGW; no
-// DataStorage -- FMC is audit-exempt per DD-AUDIT-003. EAIGW's own footprint
-// (~316MB, Spike S18) is comparable to or lighter than Kuadrant's
-// Istio+controller+broker stack).
+// Memory footprint: ~1.5-2.0GB (Keycloak + fleet-core w/ EAIGW in the primary
+// cluster, plus a second, minimal Kind cluster running only kube-mcp-server
+// for the cross-cluster isolation bridge, DD-TEST-013; no DataStorage -- FMC
+// is audit-exempt per DD-AUDIT-003. EAIGW's own footprint (~316MB, Spike
+// S18) is comparable to or lighter than Kuadrant's Istio+controller+broker
+// stack).
 package eaigw
 
 import (
@@ -57,6 +59,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -64,6 +67,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -116,7 +120,7 @@ var _ = SynchronizedBeforeSuite(
 
 		By("Setting up FMC EAIGW E2E infrastructure (Issue #54, Spike S18)")
 		bgCtx := context.Background()
-		fmcImage, setupErr := infrastructure.SetupFMCE2EInfrastructureEAIGW(bgCtx, clusterName, tempKubeconfigPath, GinkgoWriter)
+		fmcImage, remoteKubeconfigPath, setupErr := infrastructure.SetupFMCE2EInfrastructureEAIGW(bgCtx, clusterName, tempKubeconfigPath, GinkgoWriter)
 		Expect(setupErr).ToNot(HaveOccurred(), "FMC EAIGW E2E infrastructure setup failed")
 		_ = fmcImage
 
@@ -124,10 +128,12 @@ var _ = SynchronizedBeforeSuite(
 		Expect(os.Setenv("KUBECONFIG", tempKubeconfigPath)).To(Succeed())
 
 		GinkgoWriter.Println("FMC EAIGW E2E infrastructure ready (Process 1)")
-		return []byte(tempKubeconfigPath)
+		return []byte(tempKubeconfigPath + "\n" + remoteKubeconfigPath)
 	},
 	func(data []byte) {
-		harness.KubeconfigPath = string(data)
+		parts := strings.SplitN(string(data), "\n", 2)
+		harness.KubeconfigPath = parts[0]
+		harness.RemoteKubeconfigPath = parts[1]
 		harness.Ctx, cancel = context.WithCancel(context.TODO())
 
 		GinkgoWriter.Printf("FMC EAIGW E2E - Setup (Process %d)\n", GinkgoParallelProcess())
@@ -145,6 +151,12 @@ var _ = SynchronizedBeforeSuite(
 
 		var clientErr error
 		harness.K8sClient, clientErr = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+		Expect(clientErr).ToNot(HaveOccurred())
+
+		By("Creating remote cluster's Kubernetes client (DD-TEST-013, Spike S19)")
+		remoteCfg, remoteCfgErr := clientcmd.BuildConfigFromFlags("", harness.RemoteKubeconfigPath)
+		Expect(remoteCfgErr).ToNot(HaveOccurred(), "failed to build remote cluster kubeconfig")
+		harness.RemoteK8sClient, clientErr = client.New(remoteCfg, client.Options{Scheme: scheme.Scheme})
 		Expect(clientErr).ToNot(HaveOccurred())
 
 		By("Setting up FMC HTTP client (NodePort 30150, host 8150 per DD-TEST-001)")
@@ -175,10 +187,14 @@ var _ = SynchronizedAfterSuite(
 		defer infrastructure.CleanupFailureMarker(clusterName)
 		preserveCluster := os.Getenv("PRESERVE_E2E_CLUSTER") == "true" || os.Getenv("KEEP_CLUSTER") == "true"
 
+		remoteClusterName := clusterName + "-remote"
+
 		if preserveCluster {
 			GinkgoWriter.Println("CLUSTER PRESERVED FOR DEBUGGING")
 			GinkgoWriter.Printf("   To access: export KUBECONFIG=%s\n", harness.KubeconfigPath)
 			GinkgoWriter.Printf("   To delete: kind delete cluster --name %s\n", clusterName)
+			GinkgoWriter.Printf("   Remote cluster (prod-east, DD-TEST-013): export KUBECONFIG=%s\n", harness.RemoteKubeconfigPath)
+			GinkgoWriter.Printf("   To delete: kind delete cluster --name %s\n", remoteClusterName)
 			return
 		}
 
@@ -193,6 +209,13 @@ var _ = SynchronizedAfterSuite(
 			// istio-system must-gather (see suite_test.go there).
 			for _, ns := range []string{"envoy-gateway-system", "envoy-ai-gateway-system"} {
 				infrastructure.MustGatherPodLogs(clusterName, harness.KubeconfigPath, ns, "fleetmetadatacache", GinkgoWriter)
+			}
+
+			// Remote cluster (DD-TEST-013, Spike S19): only kube-mcp-server
+			// runs there, but it's the component the "prod-east" cross-cluster
+			// isolation scenario depends on most heavily.
+			if harness.RemoteKubeconfigPath != "" {
+				infrastructure.MustGatherPodLogs(remoteClusterName, harness.RemoteKubeconfigPath, namespace, "fleetmetadatacache", GinkgoWriter)
 			}
 		}
 
@@ -211,6 +234,11 @@ var _ = SynchronizedAfterSuite(
 		By("Deleting Kind cluster")
 		if delErr := infrastructure.DeleteCluster(clusterName, "fleetmetadatacache-eaigw", anyFailure, GinkgoWriter); delErr != nil {
 			GinkgoWriter.Printf("Warning: Failed to delete cluster: %v\n", delErr)
+		}
+
+		By("Deleting remote Kind cluster (DD-TEST-013, Spike S19)")
+		if delErr := infrastructure.TeardownRemoteClusterForFMC(remoteClusterName, harness.RemoteKubeconfigPath, "fleetmetadatacache-eaigw", anyFailure, GinkgoWriter); delErr != nil {
+			GinkgoWriter.Printf("Warning: Failed to delete remote cluster: %v\n", delErr)
 		}
 
 		By("Removing isolated kubeconfig file")

--- a/test/e2e/fleetmetadatacache/shared/cross_cluster_isolation.go
+++ b/test/e2e/fleetmetadatacache/shared/cross_cluster_isolation.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package shared
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck // Ginkgo DSL dot-import convention
+	. "github.com/onsi/gomega"    //nolint:staticcheck // Ginkgo/Gomega DSL dot-import convention
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CrossClusterIsolation proves "prod-east" is backed by a genuinely
+// separate Kubernetes control plane (DD-TEST-013, Spike S19), not the
+// loopback pattern "loopback-cluster"/"prod-west" share: a resource created
+// only in the remote cluster is visible through FMC's scope check for
+// "prod-east" but invisible for "loopback-cluster"/"prod-west", and a
+// resource created only in the primary cluster is visible for
+// "loopback-cluster"/"prod-west" but invisible for "prod-east".
+//
+// Before DD-TEST-013, this scenario would have failed to distinguish
+// anything meaningful: all three registered clusters targeted the same
+// physical API server (the "loopback pattern" documented in
+// SetupFleetE2EInfrastructure), so a resource created anywhere was
+// trivially visible through every cluster ID. The reverse assertion below
+// (a primary-only resource must NOT be visible via prod-east) is the one
+// that would have caught a regression back to that shared-backend state.
+//
+// {ScenarioPrefix}-015, e.g. E2E-FMC-054-015 (Kuadrant) /
+// E2E-FMC-EAIGW-054-015 (EAIGW).
+//
+// Authority: Issue #54, DD-TEST-013, ADR-068 (AC-4 information flow
+// enforcement), SOC2 CC8.1.
+func CrossClusterIsolation(h *Harness, v Variant) bool {
+	return Describe(fmt.Sprintf(
+		"%s-015: prod-east is backed by a genuinely separate Kubernetes control plane (DD-TEST-013)",
+		v.ScenarioPrefix(),
+	), Ordered, func() {
+		It("reports a resource created only in the remote cluster as managed via prod-east, but not via loopback-cluster/prod-west", func() {
+			svcName := fmt.Sprintf("%s-remote-only-%d", v.ResourcePrefix(), time.Now().UnixNano())
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      svcName,
+					Namespace: h.Namespace,
+					Labels:    map[string]string{"kubernaut.ai/managed": "true"},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{Port: 80}},
+				},
+			}
+			Expect(h.RemoteK8sClient.Create(h.Ctx, svc)).To(Succeed())
+			DeferCleanup(func() {
+				_ = h.RemoteK8sClient.Delete(h.Ctx, svc)
+			})
+
+			Eventually(func(g Gomega) {
+				g.Expect(ScopeCheck(g, h, "prod-east", "", "v1", "Service", h.Namespace, svcName)).To(BeTrue(),
+					"a resource created only in the remote cluster must be reported managed via prod-east's real, separate API server")
+			}, SyncTimeout, Interval).Should(Succeed())
+
+			Consistently(func(g Gomega) {
+				g.Expect(ScopeCheck(g, h, "loopback-cluster", "", "v1", "Service", h.Namespace, svcName)).To(BeFalse(),
+					"a remote-cluster-only resource must never be visible through loopback-cluster's (primary-backed) scope")
+				g.Expect(ScopeCheck(g, h, "prod-west", "", "v1", "Service", h.Namespace, svcName)).To(BeFalse(),
+					"a remote-cluster-only resource must never be visible through prod-west's (primary-backed) scope")
+			}, 10*time.Second, Interval).Should(Succeed())
+		})
+
+		It("reports a resource created only in the primary cluster as managed via loopback-cluster/prod-west, but not via prod-east", func() {
+			svcName := fmt.Sprintf("%s-primary-only-%d", v.ResourcePrefix(), time.Now().UnixNano())
+			svc := &corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      svcName,
+					Namespace: h.Namespace,
+					Labels:    map[string]string{"kubernaut.ai/managed": "true"},
+				},
+				Spec: corev1.ServiceSpec{
+					Ports: []corev1.ServicePort{{Port: 80}},
+				},
+			}
+			Expect(h.K8sClient.Create(h.Ctx, svc)).To(Succeed())
+			DeferCleanup(func() {
+				_ = h.K8sClient.Delete(h.Ctx, svc)
+			})
+
+			Eventually(func(g Gomega) {
+				g.Expect(ScopeCheck(g, h, "loopback-cluster", "", "v1", "Service", h.Namespace, svcName)).To(BeTrue(),
+					"a resource created only in the primary cluster must be reported managed via loopback-cluster")
+			}, SyncTimeout, Interval).Should(Succeed())
+
+			// This is the regression-sensitive assertion (DD-TEST-013): before
+			// the cross-cluster bridge, prod-east shared the primary cluster's
+			// API server, so a primary-only resource was trivially visible
+			// here too. It must now report false, proving prod-east's
+			// backend is genuinely a different control plane.
+			Consistently(func(g Gomega) {
+				g.Expect(ScopeCheck(g, h, "prod-east", "", "v1", "Service", h.Namespace, svcName)).To(BeFalse(),
+					"a primary-cluster-only resource must never be visible through prod-east's (remote-backed) scope -- otherwise prod-east is not a genuinely separate control plane")
+			}, 10*time.Second, Interval).Should(Succeed())
+		})
+	})
+}

--- a/test/e2e/fleetmetadatacache/shared/harness.go
+++ b/test/e2e/fleetmetadatacache/shared/harness.go
@@ -78,4 +78,13 @@ type Harness struct {
 
 	FMCHTTPClient *http.Client
 	FMCAPIBaseURL string
+
+	// RemoteK8sClient/RemoteKubeconfigPath target the second, independent
+	// Kind cluster backing the "prod-east" registration (DD-TEST-013, Spike
+	// S19). Used by the cross-cluster isolation scenario to create/verify
+	// resources directly against the remote control plane, proving genuine
+	// isolation from loopback-cluster/prod-west (which share the primary
+	// cluster's API server).
+	RemoteK8sClient      client.Client
+	RemoteKubeconfigPath string
 }

--- a/test/e2e/fleetmetadatacache/suite_test.go
+++ b/test/e2e/fleetmetadatacache/suite_test.go
@@ -64,10 +64,12 @@ limitations under the License.
 //
 //	ginkgo -v ./test/e2e/fleetmetadatacache/...
 //
-// Memory footprint: ~1.0-1.5GB (Keycloak + fleet-core; Keycloak costs
-// substantially more than DEX's ~64MB, accepted to validate the real
-// production token-exchange wiring end-to-end), still lighter than the full
-// "fleet" suite (~6.1GB).
+// Memory footprint: ~1.2-1.7GB (Keycloak + fleet-core in the primary cluster,
+// plus a second, minimal Kind cluster running only kube-mcp-server for the
+// cross-cluster isolation bridge, DD-TEST-013 -- Keycloak costs substantially
+// more than DEX's ~64MB, accepted to validate the real production
+// token-exchange wiring end-to-end), still lighter than the full "fleet"
+// suite (~6.1GB).
 package fleetmetadatacache
 
 import (
@@ -76,6 +78,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 	"time"
 
@@ -83,6 +86,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -135,7 +139,7 @@ var _ = SynchronizedBeforeSuite(
 
 		By("Setting up FMC E2E infrastructure (Issue #54)")
 		bgCtx := context.Background()
-		fmcImage, setupErr := infrastructure.SetupFMCE2EInfrastructure(bgCtx, clusterName, tempKubeconfigPath, GinkgoWriter)
+		fmcImage, remoteKubeconfigPath, setupErr := infrastructure.SetupFMCE2EInfrastructure(bgCtx, clusterName, tempKubeconfigPath, GinkgoWriter)
 		Expect(setupErr).ToNot(HaveOccurred(), "FMC E2E infrastructure setup failed")
 		_ = fmcImage
 
@@ -143,10 +147,12 @@ var _ = SynchronizedBeforeSuite(
 		Expect(os.Setenv("KUBECONFIG", tempKubeconfigPath)).To(Succeed())
 
 		GinkgoWriter.Println("FMC E2E infrastructure ready (Process 1)")
-		return []byte(tempKubeconfigPath)
+		return []byte(tempKubeconfigPath + "\n" + remoteKubeconfigPath)
 	},
 	func(data []byte) {
-		harness.KubeconfigPath = string(data)
+		parts := strings.SplitN(string(data), "\n", 2)
+		harness.KubeconfigPath = parts[0]
+		harness.RemoteKubeconfigPath = parts[1]
 		harness.Ctx, cancel = context.WithCancel(context.TODO())
 
 		GinkgoWriter.Printf("FMC E2E - Setup (Process %d)\n", GinkgoParallelProcess())
@@ -164,6 +170,12 @@ var _ = SynchronizedBeforeSuite(
 
 		var clientErr error
 		harness.K8sClient, clientErr = client.New(cfg, client.Options{Scheme: scheme.Scheme})
+		Expect(clientErr).ToNot(HaveOccurred())
+
+		By("Creating remote cluster's Kubernetes client (DD-TEST-013, Spike S19)")
+		remoteCfg, remoteCfgErr := clientcmd.BuildConfigFromFlags("", harness.RemoteKubeconfigPath)
+		Expect(remoteCfgErr).ToNot(HaveOccurred(), "failed to build remote cluster kubeconfig")
+		harness.RemoteK8sClient, clientErr = client.New(remoteCfg, client.Options{Scheme: scheme.Scheme})
 		Expect(clientErr).ToNot(HaveOccurred())
 
 		By("Setting up FMC HTTP client (NodePort 30150, host 8150 per DD-TEST-001)")
@@ -194,10 +206,14 @@ var _ = SynchronizedAfterSuite(
 		defer infrastructure.CleanupFailureMarker(clusterName)
 		preserveCluster := os.Getenv("PRESERVE_E2E_CLUSTER") == "true" || os.Getenv("KEEP_CLUSTER") == "true"
 
+		remoteClusterName := clusterName + "-remote"
+
 		if preserveCluster {
 			GinkgoWriter.Println("CLUSTER PRESERVED FOR DEBUGGING")
 			GinkgoWriter.Printf("   To access: export KUBECONFIG=%s\n", harness.KubeconfigPath)
 			GinkgoWriter.Printf("   To delete: kind delete cluster --name %s\n", clusterName)
+			GinkgoWriter.Printf("   Remote cluster (prod-east, DD-TEST-013): export KUBECONFIG=%s\n", harness.RemoteKubeconfigPath)
+			GinkgoWriter.Printf("   To delete: kind delete cluster --name %s\n", remoteClusterName)
 			return
 		}
 
@@ -212,6 +228,13 @@ var _ = SynchronizedAfterSuite(
 			// Envoy/AuthPolicy layer because these namespaces were never gathered.
 			for _, ns := range []string{"mcp-system", "gateway-system", "istio-system"} {
 				infrastructure.MustGatherPodLogs(clusterName, harness.KubeconfigPath, ns, "fleetmetadatacache", GinkgoWriter)
+			}
+
+			// Remote cluster (DD-TEST-013, Spike S19): only kube-mcp-server
+			// runs there, but it's the component the "prod-east" cross-cluster
+			// isolation scenario depends on most heavily.
+			if harness.RemoteKubeconfigPath != "" {
+				infrastructure.MustGatherPodLogs(remoteClusterName, harness.RemoteKubeconfigPath, namespace, "fleetmetadatacache", GinkgoWriter)
 			}
 		}
 
@@ -230,6 +253,11 @@ var _ = SynchronizedAfterSuite(
 		By("Deleting Kind cluster")
 		if delErr := infrastructure.DeleteCluster(clusterName, "fleetmetadatacache", anyFailure, GinkgoWriter); delErr != nil {
 			GinkgoWriter.Printf("Warning: Failed to delete cluster: %v\n", delErr)
+		}
+
+		By("Deleting remote Kind cluster (DD-TEST-013, Spike S19)")
+		if delErr := infrastructure.TeardownRemoteClusterForFMC(remoteClusterName, harness.RemoteKubeconfigPath, "fleetmetadatacache", anyFailure, GinkgoWriter); delErr != nil {
+			GinkgoWriter.Printf("Warning: Failed to delete remote cluster: %v\n", delErr)
 		}
 
 		By("Removing isolated kubeconfig file")

--- a/test/infrastructure/fleet_e2e.go
+++ b/test/infrastructure/fleet_e2e.go
@@ -142,6 +142,36 @@ type KubeMCPServerAuthConfig struct {
 	// for the lifetime of the cluster -- see accessTokenLifespan in
 	// keycloak-realm-fleet.json).
 	BrokerCredentialToken string
+
+	// RemoteBridge, when non-nil, makes the "prod-east" registration target
+	// a genuinely separate Kind cluster's kube-mcp-server via a
+	// Service+Endpoints bridge (DD-TEST-013, Spike S19) instead of the
+	// local loopback kube-mcp-server every other registration uses. Nil
+	// (the default, zero value) preserves the original loopback-only
+	// behavior for every existing caller -- only the FMC E2E lanes
+	// (fleetmetadatacache_e2e.go) set this field.
+	RemoteBridge *RemoteClusterBridgeConfig
+}
+
+// RemoteClusterBridgeConfig describes the bridge Service that makes a
+// second, independent Kind cluster's kube-mcp-server reachable from the
+// primary cluster's MCP Gateway, backing the "prod-east" registration with
+// a genuinely separate Kubernetes control plane (DD-TEST-013). Built by
+// SetupRemoteClusterForFMC.
+type RemoteClusterBridgeConfig struct {
+	// BridgeServiceName is the Service name to create in the PRIMARY
+	// cluster (e.g. "kube-mcp-server-remote"), used as the "prod-east"
+	// backend hostname in place of the local kube-mcp-server Service.
+	BridgeServiceName string
+	// BridgeServicePort is the port in-cluster Gateway clients dial --
+	// must match the remote kube-mcp-server's container port (8080).
+	BridgeServicePort int
+	// RemoteNodeIP is the remote cluster's control-plane node's IP on the
+	// shared podman "kind" bridge network (see KindNodeBridgeIP).
+	RemoteNodeIP string
+	// RemoteNodePort is the NodePort exposing kube-mcp-server on the
+	// remote cluster.
+	RemoteNodePort int
 }
 
 // DefaultKubeMCPServerAuthConfig returns the "fleet" full-pipeline E2E
@@ -849,6 +879,21 @@ func deployEnvoyAIGatewayRegistrations(ctx context.Context, namespace, kubeconfi
 	keycloakHostname := fmt.Sprintf("keycloak.%s.svc.cluster.local", namespace)
 	jwksURI := authConfig.AuthorizationURL + "/protocol/openid-connect/certs"
 
+	// prod-east's Backend targets a genuinely separate Kind cluster's
+	// kube-mcp-server via a Service+Endpoints bridge when RemoteBridge is
+	// set (DD-TEST-013, Spike S19); otherwise it shares the loopback
+	// hostname like every other Backend -- the original, unmodified
+	// behavior for any caller that leaves RemoteBridge nil.
+	prodEastHostname, prodEastPort := kubeMCPHostname, 8080
+	if rb := authConfig.RemoteBridge; rb != nil {
+		_, _ = fmt.Fprintln(writer, "    Bridging prod-east to remote cluster's kube-mcp-server (DD-TEST-013)...")
+		if err := CreateServiceBridge(ctx, kubeconfigPath, namespace, rb.BridgeServiceName, rb.BridgeServicePort, rb.RemoteNodeIP, rb.RemoteNodePort, writer); err != nil {
+			return fmt.Errorf("prod-east remote bridge Service creation failed: %w", err)
+		}
+		prodEastHostname = fmt.Sprintf("%s.%s.svc.cluster.local", rb.BridgeServiceName, namespace)
+		prodEastPort = rb.BridgeServicePort
+	}
+
 	manifest := fmt.Sprintf(`---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend
@@ -901,8 +946,8 @@ metadata:
 spec:
   endpoints:
   - fqdn:
-      hostname: %[3]s
-      port: 8080
+      hostname: %[8]s
+      port: %[9]d
 ---
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: Backend
@@ -962,7 +1007,7 @@ spec:
             port: 8443
       protectedResourceMetadata:
         resource: %[7]q
-`, namespace, keycloakHostname, kubeMCPHostname, authConfig.AuthorizationURL, authConfig.OAuthAudience, jwksURI, mcpGatewayEndpoint)
+`, namespace, keycloakHostname, kubeMCPHostname, authConfig.AuthorizationURL, authConfig.OAuthAudience, jwksURI, mcpGatewayEndpoint, prodEastHostname, prodEastPort)
 
 	if err := kubectlApplyManifest(ctx, kubeconfigPath, writer, manifest); err != nil {
 		return fmt.Errorf("backend/MCPRoute creation failed: %w", err)
@@ -977,6 +1022,29 @@ spec:
 // selected by authConfig.GatewayType: Kuadrant's HTTPRoute+MCPServerRegistration
 // or EAIGW's Backend+MCPRoute (Spike S18).
 func deployKubeMCPServerAndRegister(ctx context.Context, namespace, kubeconfigPath, mcpGatewayEndpoint string, authConfig KubeMCPServerAuthConfig, writer io.Writer) error {
+	if err := deployKubeMCPServer(ctx, namespace, kubeconfigPath, authConfig, writer); err != nil {
+		return err
+	}
+
+	if authConfig.GatewayType == registry.GatewayEAIGW {
+		return deployEnvoyAIGatewayRegistrations(ctx, namespace, kubeconfigPath, mcpGatewayEndpoint, authConfig, writer)
+	}
+	return deployKuadrantRegistrations(ctx, namespace, kubeconfigPath, authConfig, writer)
+}
+
+// deployKubeMCPServer deploys the gateway-agnostic kube-mcp-server
+// Deployment+Service (ServiceAccount, RBAC, ConfigMap, Deployment, Service)
+// into the given cluster/namespace and waits for its rollout, without
+// creating any gateway registration (HTTPRoute/MCPServerRegistration or
+// Backend/MCPRoute -- see deployKubeMCPServerAndRegister for that).
+//
+// Extracted so SetupRemoteClusterForFMC (DD-TEST-013) can deploy a second,
+// independent kube-mcp-server into a remote Kind cluster using the exact
+// same manifest/auth-config logic as the primary cluster's loopback
+// instance, without registering it as a local Gateway backend (the primary
+// cluster's registration functions bridge to it instead -- see
+// KubeMCPServerAuthConfig.RemoteBridge).
+func deployKubeMCPServer(ctx context.Context, namespace, kubeconfigPath string, authConfig KubeMCPServerAuthConfig, writer io.Writer) error {
 	// Issue #54 RCA background: kube-mcp-server v0.0.63 defaults
 	// cluster_auth_mode to "passthrough", which forwards any incoming
 	// Authorization: Bearer header straight to the Kubernetes API. FMC's
@@ -1119,11 +1187,7 @@ spec:
 		return fmt.Errorf("kube-mcp-server rollout failed: %w", err)
 	}
 	_, _ = fmt.Fprintln(writer, "    ✅ kube-mcp-server ready")
-
-	if authConfig.GatewayType == registry.GatewayEAIGW {
-		return deployEnvoyAIGatewayRegistrations(ctx, namespace, kubeconfigPath, mcpGatewayEndpoint, authConfig, writer)
-	}
-	return deployKuadrantRegistrations(ctx, namespace, kubeconfigPath, authConfig, writer)
+	return nil
 }
 
 // deployKuadrantRegistrations creates the HTTPRoute + three
@@ -1160,7 +1224,40 @@ stringData:
 		brokerCredRefYAML = "  credentialRef:\n    name: kube-mcp-server-broker-cred\n"
 	}
 
-	routeManifest := fmt.Sprintf(`%[2]s---
+	// prod-east routes through a dedicated HTTPRoute bridged to a genuinely
+	// separate Kind cluster's kube-mcp-server when RemoteBridge is set
+	// (DD-TEST-013, Spike S19); otherwise it shares the loopback HTTPRoute
+	// like every other registration -- the original, unmodified behavior
+	// for the "fleet" suite and any other caller that leaves RemoteBridge nil.
+	prodEastRouteName := "kube-mcp-server-route"
+	var remoteRouteManifest string
+	if rb := authConfig.RemoteBridge; rb != nil {
+		_, _ = fmt.Fprintln(writer, "    Bridging prod-east to remote cluster's kube-mcp-server (DD-TEST-013)...")
+		if err := CreateServiceBridge(ctx, kubeconfigPath, namespace, rb.BridgeServiceName, rb.BridgeServicePort, rb.RemoteNodeIP, rb.RemoteNodePort, writer); err != nil {
+			return fmt.Errorf("prod-east remote bridge Service creation failed: %w", err)
+		}
+		prodEastRouteName = "kube-mcp-server-remote-route"
+		remoteRouteManifest = fmt.Sprintf(`---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: %[3]s
+  namespace: %[1]s
+spec:
+  hostnames:
+  - kube-mcp-server-remote.127-0-0-1.sslip.io
+  parentRefs:
+  - name: mcp-gateway
+    namespace: gateway-system
+    sectionName: mcp
+  rules:
+  - backendRefs:
+    - name: %[2]s
+      port: %[4]d
+`, namespace, rb.BridgeServiceName, prodEastRouteName, rb.BridgeServicePort)
+	}
+
+	routeManifest := fmt.Sprintf(`%[2]s%[5]s---
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -1205,7 +1302,7 @@ spec:
 %[3]s  targetRef:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
-    name: kube-mcp-server-route
+    name: %[4]s
     namespace: %[1]s
 ---
 apiVersion: mcp.kuadrant.io/v1alpha1
@@ -1222,7 +1319,7 @@ spec:
     kind: HTTPRoute
     name: kube-mcp-server-route
     namespace: %[1]s
-`, namespace, brokerCredSecretManifest, brokerCredRefYAML)
+`, namespace, brokerCredSecretManifest, brokerCredRefYAML, prodEastRouteName, remoteRouteManifest)
 
 	if err := kubectlApplyManifest(ctx, kubeconfigPath, writer, routeManifest); err != nil {
 		return fmt.Errorf("httpRoute/MCPServerRegistration creation failed: %w", err)

--- a/test/infrastructure/fleetmetadatacache_e2e.go
+++ b/test/infrastructure/fleetmetadatacache_e2e.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
 	"github.com/jordigilh/kubernaut/pkg/fleet/registry"
 )
@@ -55,8 +56,14 @@ const keycloakHostPortFMC = 30557
 // (test/infrastructure/fleet_e2e.go DeployFleetInfra) still uses Dex, since
 // Dex does not implement RFC 8693 Standard Token Exchange.
 //
-// Authority: Issue #54, ADR-068, BR-INTEGRATION-065.
-func SetupFMCE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath string, writer io.Writer) (fmcImage string, err error) {
+// The returned remoteKubeconfigPath is the second, independent Kind
+// cluster's kubeconfig (DD-TEST-013, Spike S19) backing the "prod-east"
+// registration -- callers (suite_test.go) must populate
+// shared.Harness.RemoteKubeconfigPath/RemoteK8sClient from it and tear that
+// cluster down alongside the primary one in SynchronizedAfterSuite.
+//
+// Authority: Issue #54, ADR-068, BR-INTEGRATION-065, DD-TEST-013.
+func SetupFMCE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath string, writer io.Writer) (fmcImage, remoteKubeconfigPath string, err error) {
 	return setupFMCE2EInfrastructure(ctx, clusterName, kubeconfigPath, registry.GatewayKuadrant, writer)
 }
 
@@ -72,11 +79,11 @@ func SetupFMCE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath 
 // Uses kind-fleetmetadatacache-eaigw-config.yaml (a separate, isolated Kind
 // cluster) so this lane can run alongside the Kuadrant lane in CI without
 // port collisions.
-func SetupFMCE2EInfrastructureEAIGW(ctx context.Context, clusterName, kubeconfigPath string, writer io.Writer) (fmcImage string, err error) {
+func SetupFMCE2EInfrastructureEAIGW(ctx context.Context, clusterName, kubeconfigPath string, writer io.Writer) (fmcImage, remoteKubeconfigPath string, err error) {
 	return setupFMCE2EInfrastructure(ctx, clusterName, kubeconfigPath, registry.GatewayEAIGW, writer)
 }
 
-func setupFMCE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath string, gatewayType registry.MCPGatewayType, writer io.Writer) (fmcImage string, err error) {
+func setupFMCE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath string, gatewayType registry.MCPGatewayType, writer io.Writer) (fmcImage, remoteKubeconfigPath string, err error) {
 	gatewayLabel := "Kuadrant MCP Gateway"
 	kindConfigPath := "test/infrastructure/kind-fleetmetadatacache-config.yaml"
 	mcpGatewayNodePort := 31975
@@ -112,7 +119,7 @@ func setupFMCE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath 
 	}
 	fmcImage, err = BuildImageForKind(buildCfg, writer)
 	if err != nil {
-		return "", fmt.Errorf("fleetmetadatacache image build failed: %w", err)
+		return "", "", fmt.Errorf("fleetmetadatacache image build failed: %w", err)
 	}
 	_, _ = fmt.Fprintf(writer, "  ✅ FleetMetadataCache image built: %s\n", fmcImage)
 
@@ -129,17 +136,17 @@ func setupFMCE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath 
 		ProjectRootAsWorkingDir: true, // DD-TEST-007: For ./coverdata resolution
 	}
 	if clusterErr := CreateKindClusterWithConfig(opts, writer); clusterErr != nil {
-		return "", fmt.Errorf("failed to create Kind cluster: %w", clusterErr)
+		return "", "", fmt.Errorf("failed to create Kind cluster: %w", clusterErr)
 	}
 
 	if nsErr := createTestNamespace(namespace, kubeconfigPath, writer); nsErr != nil {
-		return "", fmt.Errorf("failed to create namespace: %w", nsErr)
+		return "", "", fmt.Errorf("failed to create namespace: %w", nsErr)
 	}
 
 	// ── Phase 3: Load image into Kind ────────────────────────────────────
 	_, _ = fmt.Fprintln(writer, "\n📦 PHASE 3: Loading image into Kind...")
 	if loadErr := LoadImageToKind(fmcImage, "fleetmetadatacache", clusterName, writer); loadErr != nil {
-		return "", fmt.Errorf("failed to load fleetmetadatacache image: %w", loadErr)
+		return "", "", fmt.Errorf("failed to load fleetmetadatacache image: %w", loadErr)
 	}
 
 	// ── Phase 4: Inter-service TLS (must precede Keycloak) ───────────────
@@ -148,13 +155,13 @@ func setupFMCE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath 
 	// not deploy DataStorage (FMC is audit-exempt, DD-AUDIT-003).
 	_, _ = fmt.Fprintln(writer, "\n🔐 PHASE 4: Generating inter-service TLS...")
 	if _, tlsErr := GenerateInterServiceTLS(ctx, kubeconfigPath, namespace, writer); tlsErr != nil {
-		return "", fmt.Errorf("failed to generate inter-service TLS: %w", tlsErr)
+		return "", "", fmt.Errorf("failed to generate inter-service TLS: %w", tlsErr)
 	}
 
 	// ── Phase 5: Keycloak OIDC + token-exchange provider (must be ready before API server OIDC patch) ─
 	_, _ = fmt.Fprintln(writer, "\n🔑 PHASE 5: Deploying Keycloak OIDC provider...")
 	if kcErr := DeployKeycloakInfra(ctx, namespace, kubeconfigPath, keycloakHostPortFMC, writer); kcErr != nil {
-		return "", fmt.Errorf("failed to deploy Keycloak: %w", kcErr)
+		return "", "", fmt.Errorf("failed to deploy Keycloak: %w", kcErr)
 	}
 
 	// ── Phase 6: Patch API server for OIDC (needs Keycloak already running) ──
@@ -171,7 +178,34 @@ func setupFMCE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath 
 		UsernamePrefix: "keycloak:",
 	}
 	if oidcErr := patchAPIServerForOIDCConfig(ctx, clusterName, kubeconfigPath, oidcCfg, writer); oidcErr != nil {
-		return "", fmt.Errorf("API server OIDC patching failed: %w", oidcErr)
+		return "", "", fmt.Errorf("API server OIDC patching failed: %w", oidcErr)
+	}
+
+	// ── Phase 6b: Provision remote cluster for cross-cluster isolation ──
+	// Backs "prod-east" with a genuinely separate Kubernetes control plane
+	// (DD-TEST-013, Spike S19) instead of the loopback pattern every other
+	// registered cluster uses. Must run after Phase 5 (Keycloak up) and
+	// Phase 6 (primary cluster exists, for its node bridge IP), and before
+	// Phase 7 builds the primary's kube-mcp-server auth config with
+	// RemoteBridge set.
+	_, _ = fmt.Fprintln(writer, "\n🌍 PHASE 6b: Provisioning remote cluster (cross-cluster isolation, DD-TEST-013)...")
+	remoteClusterName := clusterName + "-remote"
+	remoteKubeconfigPath = filepath.Join(filepath.Dir(kubeconfigPath), remoteClusterName+"-config")
+	remoteKubeMCPAuthConfig := KubeMCPServerAuthConfig{
+		Mode:             KubeMCPServerAuthModePassthrough,
+		GatewayType:      gatewayType,
+		RequireOAuth:     true,
+		AuthorizationURL: "https://keycloak:8443/realms/kubernaut-fleet",
+		OAuthAudience:    "kube-mcp-server",
+		StsClientID:      "kube-mcp-server",
+		StsClientSecret:  "e2e-kube-mcp-server-secret",
+		StsAudience:      "k8s-api",
+		StsScopes:        []string{"k8s-api-audience"},
+		CAFilePath:       "/etc/tls-ca/ca.crt",
+	}
+	remoteBridge, remoteErr := SetupRemoteClusterForFMC(ctx, clusterName, kubeconfigPath, remoteClusterName, remoteKubeconfigPath, namespace, oidcCfg.IssuerURL, keycloakHostPortFMC, remoteKubeMCPAuthConfig, writer)
+	if remoteErr != nil {
+		return "", "", fmt.Errorf("remote cluster provisioning failed: %w", remoteErr)
 	}
 
 	// ── Phase 7: Fleet core (Istio + Kuadrant + kube-mcp-server + Valkey + FMC) ─
@@ -205,6 +239,7 @@ func setupFMCE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath 
 		StsAudience:      "k8s-api",
 		StsScopes:        []string{"k8s-api-audience"},
 		CAFilePath:       "/etc/tls-ca/ca.crt",
+		RemoteBridge:     remoteBridge,
 	}
 
 	// Only Kuadrant needs a static broker credential: its broker maintains
@@ -221,13 +256,13 @@ func setupFMCE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath 
 			Scopes:        fmcOAuth2Config.Scopes,
 		})
 		if brokerCredErr != nil {
-			return "", fmt.Errorf("failed to obtain Kuadrant broker's kube-mcp-server discovery credential: %w", brokerCredErr)
+			return "", "", fmt.Errorf("failed to obtain Kuadrant broker's kube-mcp-server discovery credential: %w", brokerCredErr)
 		}
 		kubeMCPAuthConfig.BrokerCredentialToken = brokerCredToken
 	}
 
 	if coreErr := DeployFleetCoreInfra(ctx, namespace, kubeconfigPath, fmcImage, kubeMCPAuthConfig, fmcOAuth2Config, writer); coreErr != nil {
-		return "", fmt.Errorf("fleet-core infra deployment failed: %w", coreErr)
+		return "", "", fmt.Errorf("fleet-core infra deployment failed: %w", coreErr)
 	}
 
 	// ── Phase 7b: RBAC for the token-exchange-preserved FMC identity ────
@@ -238,7 +273,7 @@ func setupFMCE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath 
 	// under cluster_auth_mode=kubeconfig.
 	_, _ = fmt.Fprintln(writer, "\n🔑 PHASE 7b: Creating RBAC for the exchanged FMC identity...")
 	if rbacErr := applyExchangedIdentityRBAC(ctx, kubeconfigPath, writer); rbacErr != nil {
-		return "", fmt.Errorf("exchanged-identity RBAC creation failed: %w", rbacErr)
+		return "", "", fmt.Errorf("exchanged-identity RBAC creation failed: %w", rbacErr)
 	}
 
 	// Keycloak-based token func for the readiness probe's authenticated
@@ -252,7 +287,7 @@ func setupFMCE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPath 
 		})
 	}
 	if readyErr := WaitForFleetReady(keycloakFleetReadTokenFunc, mcpGatewayNodePort, loopbackToolPrefix, writer); readyErr != nil {
-		return "", fmt.Errorf("fleet readiness check failed: %w", readyErr)
+		return "", "", fmt.Errorf("fleet readiness check failed: %w", readyErr)
 	}
 
 	// ── Phase 8: Expose FMC's own API via NodePort ───────────────────────
@@ -281,7 +316,7 @@ spec:
     nodePort: 30150
 `, namespace)
 	if npErr := kubectlApplyManifest(ctx, kubeconfigPath, writer, fmcNodePortManifest); npErr != nil {
-		return "", fmt.Errorf("failed to expose FMC API via NodePort: %w", npErr)
+		return "", "", fmt.Errorf("failed to expose FMC API via NodePort: %w", npErr)
 	}
 	_, _ = fmt.Fprintln(writer, "    ✅ FMC API reachable at http://localhost:8150")
 
@@ -290,9 +325,10 @@ spec:
 	_, _ = fmt.Fprintln(writer, "  FMC API:      http://localhost:8150")
 	_, _ = fmt.Fprintf(writer, "  MCP Gateway:  http://localhost:%d/mcp (%s)\n", mcpGatewayNodePort, gatewayLabel)
 	_, _ = fmt.Fprintln(writer, "  Keycloak:     https://localhost:30557/realms/kubernaut-fleet")
+	_, _ = fmt.Fprintf(writer, "  Remote cluster (prod-east): %s\n", remoteClusterName)
 	_, _ = fmt.Fprintln(writer, "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 
-	return fmcImage, nil
+	return fmcImage, remoteKubeconfigPath, nil
 }
 
 // applyExchangedIdentityRBAC binds the K8s identity that survives kube-mcp-server's

--- a/test/infrastructure/fleetmetadatacache_remote_cluster.go
+++ b/test/infrastructure/fleetmetadatacache_remote_cluster.go
@@ -1,0 +1,198 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package infrastructure
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+)
+
+// remoteKubeMCPServerNodePort is the fixed NodePort exposing the remote
+// cluster's kube-mcp-server. Safe to hardcode: this cluster has no host
+// port mapping (see kind-fleetmetadatacache-remote-config.yaml) and is
+// reached only via KindNodeBridgeIP from the primary cluster, so there is
+// no cross-lane collision risk even when both FMC E2E lanes run in
+// parallel CI jobs (each pair of clusters is fully isolated).
+const remoteKubeMCPServerNodePort = 30180
+
+// remoteBridgeServiceName is the Service name created in the PRIMARY
+// cluster to bridge to the remote cluster's kube-mcp-server, backing the
+// "prod-east" registration (DD-TEST-013).
+const remoteBridgeServiceName = "kube-mcp-server-remote"
+
+// SetupRemoteClusterForFMC provisions a second, independent Kind cluster
+// and wires it into the FMC E2E lane's cross-cluster bridge (DD-TEST-013,
+// validated in Spike S19): a genuinely separate Kubernetes control plane
+// backing the "prod-east" registration, instead of the loopback pattern
+// every other registered cluster uses.
+//
+// Must be called AFTER Keycloak is deployed and reachable in the primary
+// cluster (Keycloak must already be running for the remote cluster's own
+// API server OIDC patch to succeed) and AFTER the primary cluster's node
+// exists (its bridge IP is discovered here). authConfig must be the same
+// passthrough+STS config used for the primary cluster's kube-mcp-server --
+// this function deploys an identical kube-mcp-server into the remote
+// cluster so both perform the same RFC 8693 exchange against the same
+// bridged Keycloak.
+//
+// Returns a RemoteClusterBridgeConfig for the caller to set on
+// KubeMCPServerAuthConfig.RemoteBridge before calling DeployFleetCoreInfra
+// for the primary cluster.
+func SetupRemoteClusterForFMC(ctx context.Context, primaryClusterName, primaryKubeconfigPath, remoteClusterName, remoteKubeconfigPath, namespace string, keycloakIssuerURL string, keycloakNodePort int, authConfig KubeMCPServerAuthConfig, writer io.Writer) (*RemoteClusterBridgeConfig, error) {
+	_, _ = fmt.Fprintln(writer, "\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+	_, _ = fmt.Fprintln(writer, "🌍 Provisioning remote cluster for cross-cluster isolation (DD-TEST-013)...")
+	_, _ = fmt.Fprintln(writer, "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+
+	opts := KindClusterOptions{
+		ClusterName:             remoteClusterName,
+		KubeconfigPath:          remoteKubeconfigPath,
+		ConfigPath:              "test/infrastructure/kind-fleetmetadatacache-remote-config.yaml",
+		WaitTimeout:             "5m",
+		UsePodman:               true,
+		ProjectRootAsWorkingDir: true,
+	}
+	if err := CreateKindClusterWithConfig(opts, writer); err != nil {
+		return nil, fmt.Errorf("remote cluster creation failed: %w", err)
+	}
+
+	if err := createTestNamespace(namespace, remoteKubeconfigPath, writer); err != nil {
+		return nil, fmt.Errorf("remote namespace creation failed: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(writer, "  Discovering primary cluster's node bridge IP...")
+	primaryIP, err := KindNodeBridgeIP(primaryClusterName + "-control-plane")
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover primary node bridge IP: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(writer, "  Bridging 'keycloak' Service in remote cluster -> primary Keycloak NodePort...")
+	// Service port MUST match the port embedded in keycloakIssuerURL
+	// (currently 8443, the port kube-apiserver's OIDC discovery dials) --
+	// NOT the NodePort number. A mismatch here reproduces the exact
+	// "connection refused" bug found in Spike S19.
+	if err := CreateServiceBridge(ctx, remoteKubeconfigPath, namespace, "keycloak", 8443, primaryIP, keycloakNodePort, writer); err != nil {
+		return nil, fmt.Errorf("keycloak bridge Service creation failed: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(writer, "  Copying primary's inter-service CA to remote cluster...")
+	if err := copyInterServiceCAToRemoteCluster(primaryKubeconfigPath, remoteKubeconfigPath); err != nil {
+		return nil, fmt.Errorf("CA copy to remote cluster failed: %w", err)
+	}
+
+	// deployKubeMCPServer mounts the "inter-service-ca" ConfigMap as the
+	// tls-ca volume (TLSCAVolumeYAML); it must exist in-cluster before that
+	// deployment is applied, not just on-disk next to the kubeconfig.
+	_, _ = fmt.Fprintln(writer, "  Replicating inter-service-ca ConfigMap into remote cluster...")
+	if err := ReplicateInterServiceCAConfigMap(ctx, remoteKubeconfigPath, namespace, writer); err != nil {
+		return nil, fmt.Errorf("CA ConfigMap replication to remote cluster failed: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(writer, "  OIDC-patching remote cluster's API server against the bridged Keycloak...")
+	oidcCfg := OIDCPatchConfig{
+		IssuerURL:      keycloakIssuerURL,
+		ClientID:       "k8s-api",
+		UsernameClaim:  "preferred_username",
+		UsernamePrefix: "keycloak:",
+	}
+	if err := patchAPIServerForOIDCConfig(ctx, remoteClusterName, remoteKubeconfigPath, oidcCfg, writer); err != nil {
+		return nil, fmt.Errorf("remote API server OIDC patching failed: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(writer, "  Deploying kube-mcp-server into remote cluster...")
+	if err := deployKubeMCPServer(ctx, namespace, remoteKubeconfigPath, authConfig, writer); err != nil {
+		return nil, fmt.Errorf("remote kube-mcp-server deployment failed: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(writer, "  Applying exchanged-identity RBAC in remote cluster...")
+	if err := applyExchangedIdentityRBAC(ctx, remoteKubeconfigPath, writer); err != nil {
+		return nil, fmt.Errorf("remote exchanged-identity RBAC failed: %w", err)
+	}
+
+	_, _ = fmt.Fprintf(writer, "  Exposing remote kube-mcp-server via NodePort %d...\n", remoteKubeMCPServerNodePort)
+	npManifest := fmt.Sprintf(`---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kube-mcp-server-nodeport
+  namespace: %[1]s
+spec:
+  type: NodePort
+  selector:
+    app: kube-mcp-server
+  ports:
+  - port: 8080
+    targetPort: 8080
+    nodePort: %[2]d
+`, namespace, remoteKubeMCPServerNodePort)
+	if err := kubectlApplyManifest(ctx, remoteKubeconfigPath, writer, npManifest); err != nil {
+		return nil, fmt.Errorf("remote kube-mcp-server NodePort expose failed: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(writer, "  Discovering remote cluster's node bridge IP...")
+	remoteIP, err := KindNodeBridgeIP(remoteClusterName + "-control-plane")
+	if err != nil {
+		return nil, fmt.Errorf("failed to discover remote node bridge IP: %w", err)
+	}
+
+	_, _ = fmt.Fprintln(writer, "✅ Remote cluster ready for cross-cluster bridging")
+	_, _ = fmt.Fprintln(writer, "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
+
+	return &RemoteClusterBridgeConfig{
+		BridgeServiceName: remoteBridgeServiceName,
+		BridgeServicePort: 8080,
+		RemoteNodeIP:      remoteIP,
+		RemoteNodePort:    remoteKubeMCPServerNodePort,
+	}, nil
+}
+
+// copyInterServiceCAToRemoteCluster copies the primary cluster's
+// inter-service CA bytes to the path InterServiceCAPath expects next to the
+// remote cluster's kubeconfig, so patchAPIServerForOIDCConfig (called
+// unmodified against the remote cluster) trusts the bridged Keycloak's TLS
+// certificate -- both are signed by the same CA (interservice_tls.go).
+//
+// primaryKubeconfigPath and remoteKubeconfigPath must differ (each cluster
+// has its own kubeconfig file); passing the same path for both is a caller
+// error since it would make the copy a no-op self-read.
+func copyInterServiceCAToRemoteCluster(primaryKubeconfigPath, remoteKubeconfigPath string) error {
+	caPEM, err := os.ReadFile(InterServiceCAPath(primaryKubeconfigPath))
+	if err != nil {
+		return fmt.Errorf("read primary inter-service CA: %w", err)
+	}
+	if err := os.WriteFile(InterServiceCAPath(remoteKubeconfigPath), caPEM, 0o600); err != nil {
+		return fmt.Errorf("write inter-service CA next to remote kubeconfig: %w", err)
+	}
+	return nil
+}
+
+// TeardownRemoteClusterForFMC deletes the remote cluster created by
+// SetupRemoteClusterForFMC. Mirrors infrastructure.DeleteCluster's
+// preserve-on-failure semantics so both clusters are kept together for
+// debugging when preserveCluster/anyFailure applies.
+func TeardownRemoteClusterForFMC(remoteClusterName, remoteKubeconfigPath, serviceName string, testsFailed bool, writer io.Writer) error {
+	if delErr := DeleteCluster(remoteClusterName, serviceName, testsFailed, writer); delErr != nil {
+		return fmt.Errorf("remote cluster deletion failed: %w", delErr)
+	}
+	defaultConfig := os.ExpandEnv("$HOME/.kube/config")
+	if remoteKubeconfigPath != "" && remoteKubeconfigPath != defaultConfig {
+		_ = os.Remove(remoteKubeconfigPath)
+		_ = os.Remove(InterServiceCAPath(remoteKubeconfigPath))
+	}
+	return nil
+}

--- a/test/infrastructure/interservice_tls.go
+++ b/test/infrastructure/interservice_tls.go
@@ -257,6 +257,34 @@ stringData:
 	return caPEMPath, nil
 }
 
+// ReplicateInterServiceCAConfigMap creates the "inter-service-ca" ConfigMap in
+// a cluster from a CA PEM that was already generated elsewhere (e.g. by
+// GenerateInterServiceTLS in the primary cluster) and copied to this
+// cluster's kubeconfig-adjacent path via InterServiceCAPath. Used by remote
+// clusters that must trust inter-service TLS certs signed by the primary
+// cluster's CA without re-running key generation (DD-TEST-013).
+func ReplicateInterServiceCAConfigMap(ctx context.Context, kubeconfigPath, namespace string, writer io.Writer) error {
+	caPEMPath := InterServiceCAPath(kubeconfigPath)
+	caPEM, err := os.ReadFile(caPEMPath)
+	if err != nil {
+		return fmt.Errorf("read CA PEM from %s: %w", caPEMPath, err)
+	}
+
+	caConfigMap := fmt.Sprintf(`apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inter-service-ca
+data:
+  ca.crt: |
+%s`, indentPEM(string(caPEM), 4))
+
+	if err := kubectlApply(ctx, kubeconfigPath, namespace, caConfigMap, writer); err != nil {
+		return fmt.Errorf("create inter-service-ca ConfigMap: %w", err)
+	}
+	_, _ = fmt.Fprintln(writer, "  ✅ inter-service-ca ConfigMap replicated")
+	return nil
+}
+
 // NewTLSAwareClient creates an HTTP client that trusts the inter-service CA.
 // Used by host-side E2E test code to call HTTPS NodePort endpoints.
 //

--- a/test/infrastructure/kind-fleetmetadatacache-remote-config.yaml
+++ b/test/infrastructure/kind-fleetmetadatacache-remote-config.yaml
@@ -1,0 +1,32 @@
+# Kind cluster configuration for the FMC E2E "remote" cluster (DD-TEST-013).
+#
+# Backs the "prod-east" registration with a genuinely separate Kubernetes
+# control plane, bridged to the primary FMC E2E cluster's real Keycloak over
+# the shared podman "kind" bridge network (no service mesh, no VPN --
+# validated in Spike S19). Shared by both the Kuadrant lane
+# (kind-fleetmetadatacache-config.yaml) and the EAIGW lane
+# (kind-fleetmetadatacache-eaigw-config.yaml) -- each passes its own
+# cluster name (e.g. "fmc-e2e-remote" / "fmc-eaigw-e2e-remote") via
+# KindClusterOptions.ClusterName, so this file needs no per-lane variant.
+#
+# No extraPortMappings: unlike the primary cluster, nothing on the host
+# needs to reach this cluster directly -- all traffic flows node-bridge-IP
+# to node-bridge-IP (KindNodeBridgeIP / CreateServiceBridge in
+# kind_bridge.go), in both directions (Keycloak bridge into this cluster,
+# kube-mcp-server bridge back out of it).
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  image: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a  # K8s 1.34.0 with containerd 2.1.3 (avoids v2.2.0 mount-manager regression)
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+      extraArgs:
+        max-requests-inflight: "800"
+        max-mutating-requests-inflight: "400"
+    controllerManager:
+      extraArgs:
+        kube-api-qps: "100"
+        kube-api-burst: "200"

--- a/test/infrastructure/kind_bridge.go
+++ b/test/infrastructure/kind_bridge.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package infrastructure
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"strings"
+)
+
+// KindNodeBridgeIP returns the given Kind node's IP address on the podman
+// "kind" bridge network. Two Kind clusters created by the same podman
+// daemon share this network, so any node's IP is directly routable from any
+// other node's containers -- no host port mapping required. This is the
+// foundation of the FMC E2E second-cluster cross-cluster bridge (DD-TEST-013,
+// validated empirically in Spike S19).
+//
+// nodeName is conventionally "<clusterName>-control-plane" for a
+// single-node Kind cluster (the only topology this project's E2E lanes use).
+func KindNodeBridgeIP(nodeName string) (string, error) {
+	cmd := exec.Command("podman", "inspect", nodeName,
+		"--format", "{{.NetworkSettings.Networks.kind.IPAddress}}")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("podman inspect %s failed: %w (%s)", nodeName, err, string(out))
+	}
+	ip := strings.TrimSpace(string(out))
+	if ip == "" {
+		return "", fmt.Errorf("empty bridge IP for node %s (is it on the 'kind' podman network?)", nodeName)
+	}
+	return ip, nil
+}
+
+// CreateServiceBridge creates a Service+Endpoints pair in the cluster
+// identified by kubeconfigPath that makes serviceName resolvable via normal
+// in-cluster DNS (e.g. "keycloak", "kube-mcp-server-remote"), routing
+// traffic to a NodePort listening on a peer cluster's node bridge IP
+// (see KindNodeBridgeIP). No selector is set on the Service -- Endpoints are
+// hand-authored, exactly like an ExternalName-style bridge but resolvable by
+// plain ClusterIP (some callers, e.g. kube-apiserver's OIDC discovery, do
+// not honor ExternalName DNS CNAMEs).
+//
+// servicePort is what in-cluster clients dial (must match whatever
+// hostname:port is hardcoded elsewhere, e.g. the OIDC issuer URL
+// "https://keycloak:8443/..."); remotePort is the actual NodePort listening
+// on remoteIP. These are frequently different numbers -- Spike S19 found a
+// bridge created with servicePort equal to the NodePort value caused
+// "connection refused" because in-cluster clients dial the well-known port,
+// not the peer's NodePort number.
+func CreateServiceBridge(ctx context.Context, kubeconfigPath, namespace, serviceName string, servicePort int, remoteIP string, remotePort int, writer io.Writer) error {
+	manifest := fmt.Sprintf(`---
+apiVersion: v1
+kind: Service
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+spec:
+  ports:
+  - port: %[4]d
+    targetPort: %[5]d
+---
+apiVersion: v1
+kind: Endpoints
+metadata:
+  name: %[1]s
+  namespace: %[2]s
+subsets:
+- addresses:
+  - ip: %[3]s
+  ports:
+  - port: %[5]d
+`, serviceName, namespace, remoteIP, servicePort, remotePort)
+	return kubectlApplyManifest(ctx, kubeconfigPath, writer, manifest)
+}


### PR DESCRIPTION
## Summary

- Provisions a real, independent second Kind cluster (`prod-east`) for both FMC E2E lanes (Kuadrant and EAIGW variants), replacing the loopback pattern where every registered "cluster" was actually backed by the same control plane.
- Bridges the remote cluster to the primary over the shared podman network (hand-authored Service+Endpoints, no service mesh/VPN), including OIDC trust propagation to the bridged Keycloak and inter-service CA replication so the remote `kube-mcp-server` can perform the same RFC 8693 token exchange.
- Adds a new `CrossClusterIsolation` shared E2E scenario (`E2E-FMC-054-015` / `E2E-FMC-EAIGW-054-015`) proving that a resource created only in the remote cluster is visible via `prod-east` but not `loopback-cluster`/`prod-west`, and vice versa — closing a SOC2 CC8.1 / FedRAMP AC-4 coverage gap the loopback pattern couldn't prove.
- Retains the time-boxed Spike S19 investigation artifacts under `docs/spikes/` per team request, and documents the architecture/rejected alternatives in `docs/architecture/decisions/DD-TEST-013-fmc-e2e-cross-cluster-bridge.md`.
- Updates `docs/testing/BR-INTEGRATION-054/TEST_PLAN.md` with the new scenario and FedRAMP control mapping.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet` + `golangci-lint run` clean on all changed packages
- [x] `make test-e2e-fleetmetadatacache-kuadrant` — 13/13 specs passed, including both new cross-cluster isolation specs
- [x] `make test-e2e-fleetmetadatacache-eaigw` — 13/13 specs passed, including both new cross-cluster isolation specs
- [ ] `make test-e2e-fleet` (existing loopback-pattern regression, unaffected by this change since `RemoteBridge` is nil there) — running locally; will report back if it surfaces anything

Made with [Cursor](https://cursor.com)