### PR TITLE
fix(lint): broaden containedctx test exclusion to cover test/ harnesses

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -158,8 +158,12 @@ linters:
         text: "Consider preallocating|argument-limit"
       # containedctx: test doubles that embed context.Context to satisfy an
       # interface (e.g. tool.Context, agent.ReadonlyContext fakes) are not the
-      # long-lived-context anti-pattern this linter targets.
-      - path: _test\.go
+      # long-lived-context anti-pattern this linter targets. Also covers
+      # non-_test.go suite harnesses under test/ (e.g. Ginkgo Harness structs
+      # populated in SynchronizedBeforeSuite and read by It() closures across
+      # the whole suite lifetime) — same idiom as the govet-shadow/prealloc/
+      # revive test exclusions above.
+      - path: (_test\.go|^test/)
         linters:
           - containedctx
 


### PR DESCRIPTION
## Summary
- `main`'s lint job is currently failing after PR #1537 merged: `containedctx` flags `Harness.Ctx context.Context` in `test/e2e/fleetmetadatacache/shared/harness.go:73`.
- This is the same accepted Ginkgo suite idiom already excluded for `govet shadow`/`prealloc`/`revive` (a suite-scoped value set once in `SynchronizedBeforeSuite` and read by `It()` closures for the suite's lifetime) — it is not the long-lived-context anti-pattern `containedctx` targets.
- The `containedctx` exclusion was scoped to `_test\.go` only, so it missed shared, non-`_test.go` harness/helper files under `test/`.
- Broadens the exclusion path to `(_test\.go|^test/)`, matching the pattern used by the other three test-idiom exclusions in `.golangci.yml`.

## Test plan
- [x] `golangci-lint run` scoped to `test/e2e/fleetmetadatacache/...` on top of `main` → 0 issues (previously 1 `containedctx` finding)
- [x] No production-code exclusion widening — `containedctx` still fails CI for non-test paths

Made with [Cursor](https://cursor.com)