### PR TITLE
fix(apifrontend): resolve SSE cap E2E flakiness without Serial (#1544)

### DIFF
--- a/deploy/apifrontend/overlays/e2e/config.yaml
+++ b/deploy/apifrontend/overlays/e2e/config.yaml
@@ -1,6 +1,14 @@
 server:
   port: 8443
-  maxSSEConnections: 5
+  # 50 (was 5): trackSSEConnection wraps every /a2a/invoke, /mcp, and
+  # /a2a/status request (not just SSE-Accept ones), so with a cap this low
+  # ANY concurrent A2A/MCP call from another parallel Ginkgo E2E process
+  # transiently consumes a slot -- causing TC-E2E-SSE-CAP-01 to intermittently
+  # see 503s on connections that should have been within cap. 50 gives a
+  # generous margin above realistic concurrent E2E traffic while keeping the
+  # cap meaningfully enforced. Keep test/e2e/apifrontend/streaming_test.go's
+  # AF_E2E_MAX_SSE fallback in sync with this value.
+  maxSSEConnections: 50
   tls:
     certDir: /etc/apifrontend/tls
     required: true

--- a/test/e2e/apifrontend/streaming_test.go
+++ b/test/e2e/apifrontend/streaming_test.go
@@ -178,21 +178,39 @@ var _ = Describe("Investigation Streaming (G3)", Ordered, Label("e2e", "phase3",
 	})
 
 	It("TC-E2E-STREAM-04 / TC-E2E-SSE-CAP-01: Connection cap enforcement", func() {
-		// Wait for all SSE slots to drain. Prior tests (STREAM-01/02/03) open
-		// SSE or MCP connections whose server-side handlers may run until the
-		// LLM investigation completes or the connection timeout fires (~120s).
-		// Use 300s to accommodate CI variability and slow handler teardown.
-		Eventually(func() float64 {
-			return counterValue(scrapeMetrics(), "af_sse_active_connections")
-		}, 300*time.Second, 3*time.Second).Should(BeZero(),
-			"all SSE slots must be released before cap enforcement test")
-
-		maxStr := getEnvOrDefault("AF_E2E_MAX_SSE", "5")
-		maxSSE := 5
+		// trackSSEConnection (router.go) tracks EVERY /a2a/invoke, /mcp, and
+		// /a2a/status request -- not just ones with Accept: text/event-stream
+		// -- for the full handler duration. Since apifrontend E2E tests run
+		// with --procs > 1 (true parallel Ginkgo OS processes sharing the
+		// same deployed apifrontend + ConnectionTracker), any concurrently
+		// running spec in ANY other process can transiently hold a slot.
+		// Assuming a zero baseline (as this test previously did) makes it
+		// flaky under CI load. Instead, sample the current baseline and fill
+		// only the remaining headroom, requiring a generous minimum margin
+		// so legitimate concurrent E2E traffic can't plausibly collide with
+		// this test's own fill loop. The deterministic cap-enforcement LOGIC
+		// itself is proven race-free at the unit tier (UT-AF-STREAM04-001/002
+		// in pkg/apifrontend/streaming/tracker_test.go) and the router-wiring
+		// of the 503 response is proven at the integration tier
+		// (IT-AF-SSE-CAP-001 in test/integration/apifrontend/router_http_test.go)
+		// against an isolated tracker -- this E2E test is a smoke-level
+		// confirmation against the real deployed cap, not the sole proof.
+		maxStr := getEnvOrDefault("AF_E2E_MAX_SSE", "50")
+		maxSSE := 50
 		var parsed int
 		if n, _ := fmt.Sscanf(strings.TrimSpace(maxStr), "%d", &parsed); n == 1 && parsed > 0 {
 			maxSSE = parsed
 		}
+
+		const minHeadroom = 20
+		var baseline int
+		Eventually(func() int {
+			baseline = int(counterValue(scrapeMetrics(), "af_sse_active_connections"))
+			return maxSSE - baseline
+		}, 300*time.Second, 3*time.Second).Should(BeNumerically(">=", minHeadroom),
+			"need enough SSE headroom for a deterministic cap-enforcement window despite legitimate concurrent E2E traffic")
+
+		slotsToFill := maxSSE - baseline
 
 		type slotResult struct {
 			idx    int
@@ -200,14 +218,14 @@ var _ = Describe("Investigation Streaming (G3)", Ordered, Label("e2e", "phase3",
 			err    error
 		}
 		var mu sync.Mutex
-		cancels := make([]context.CancelFunc, maxSSE)
+		cancels := make([]context.CancelFunc, slotsToFill)
 		ready := make(chan slotResult, 1)
 		var wg sync.WaitGroup
 
 		// Establish SSE connections sequentially to avoid a race where all
 		// goroutines hit the server simultaneously and some are rejected
 		// before prior connections are fully registered in the semaphore.
-		for i := 0; i < maxSSE; i++ {
+		for i := 0; i < slotsToFill; i++ {
 			wg.Add(1)
 			go func(idx int) {
 				defer wg.Done()

--- a/test/integration/apifrontend/router_http_test.go
+++ b/test/integration/apifrontend/router_http_test.go
@@ -4,11 +4,13 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/handler"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/httputil"
@@ -328,6 +330,93 @@ var _ = Describe("Router HTTP Integration (handler/)", func() {
 						"nonexistent RR should return rr_not_found, not a routing error")
 				}
 			}
+		})
+	})
+
+	// DOS-01, SC-5: deterministic proof that trackSSEConnection wiring returns
+	// 503 "too many concurrent connections" once the ConnectionTracker cap is
+	// reached. The Add()/Remove() cap-enforcement LOGIC is already proven at
+	// the unit tier (UT-AF-STREAM04-001/002 in
+	// pkg/apifrontend/streaming/tracker_test.go); this IT proves the router
+	// middleware is correctly WIRED to that logic. Uses its own isolated
+	// router + ConnectionTracker (not the shared routerServer) so this test
+	// is fully deterministic and immune to the cross-process E2E flakiness
+	// that motivated raising the E2E-deployed cap (see
+	// test/e2e/apifrontend/streaming_test.go TC-E2E-SSE-CAP-01).
+	Describe("AC-9: SSE connection cap enforcement (DOS-01, SC-5)", func() {
+		It("IT-AF-SSE-CAP-001: trackSSEConnection returns 503 once the tracker cap is reached", func() {
+			release := make(chan struct{})
+			blockingA2A := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				select {
+				case <-release:
+				case <-r.Context().Done():
+				}
+				w.WriteHeader(http.StatusOK)
+			})
+
+			capTracker := streaming.NewConnectionTracker(
+				prometheus.NewGauge(prometheus.GaugeOpts{Name: "test_af_sse_active_connections_it_sse_cap_001"}),
+				0,
+			)
+			capTracker.MaxConnections = 2
+
+			capRouter, err := handler.NewRouter(handler.RouterConfig{
+				MetricsRegistry:  metricsRegistry,
+				Logger:           logf.Log.WithName("sse-cap-it"),
+				A2AHandler:       blockingA2A,
+				MCPHandler:       http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(200) }),
+				AgentCardHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(200) }),
+				AuthMiddleware:   func(next http.Handler) http.Handler { return next },
+				ReadyChecker:     func() bool { return true },
+				SSETracker:       capTracker,
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			capServer := httptest.NewServer(capRouter)
+			var wg sync.WaitGroup
+			// Deferred cleanup runs LIFO: close(release) unblocks the two
+			// blocking handlers first, then wg.Wait() lets them finish and
+			// close their response bodies, then capServer.Close() can
+			// cleanly wait for the (now-idle) connections to close.
+			defer capServer.Close()
+			defer wg.Wait()
+			defer close(release)
+
+			sendBlocking := func() (*http.Response, error) {
+				req, rerr := http.NewRequest(http.MethodPost, capServer.URL+"/a2a/invoke", strings.NewReader(`{}`))
+				Expect(rerr).NotTo(HaveOccurred())
+				req.Header.Set("Accept", "text/event-stream")
+				return http.DefaultClient.Do(req)
+			}
+
+			// Fill both slots. Each request blocks server-side on `release`,
+			// so the client-side call itself blocks until we signal below --
+			// run each in a goroutine and wait for the tracker to observe it.
+			for i := 0; i < capTracker.MaxConnections; i++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					resp, serr := sendBlocking()
+					if serr == nil {
+						_ = resp.Body.Close()
+					}
+				}()
+			}
+			Eventually(capTracker.Count, "2s", "10ms").Should(Equal(2),
+				"both blocking requests must register with the tracker before the overflow attempt")
+
+			overflowReq, err := http.NewRequest(http.MethodPost, capServer.URL+"/a2a/invoke", strings.NewReader(`{}`))
+			Expect(err).NotTo(HaveOccurred())
+			overflowReq.Header.Set("Accept", "text/event-stream")
+			overflowResp, err := http.DefaultClient.Do(overflowReq)
+			Expect(err).NotTo(HaveOccurred())
+			defer overflowResp.Body.Close()
+
+			Expect(overflowResp.StatusCode).To(Equal(http.StatusServiceUnavailable),
+				"third connection must be rejected once the tracker cap (2) is reached")
+			overflowBody, err := io.ReadAll(overflowResp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(strings.ToLower(string(overflowBody))).To(ContainSubstring("too many concurrent connections"))
 		})
 	})
 })


### PR DESCRIPTION
Fixes #1544

## Summary

Fixes the flaky `TC-E2E-STREAM-04 / TC-E2E-SSE-CAP-01` E2E test surfaced in [CI run 28683859204](https://github.com/jordigilh/kubernaut/actions/runs/28683859204/job/85074221354) and tracked in #1544.

**Root cause:** `trackSSEConnection` (router middleware) tracks *every* `/a2a/invoke`, `/mcp`, and `/a2a/status` request for the full handler duration — not just `Accept: text/event-stream` requests. The E2E deployment capped `maxSSEConnections` at 5, and apifrontend E2E specs run with `--procs > 1` against one shared deployed instance + `ConnectionTracker`. Any legitimate concurrent request from another parallel Ginkgo process could transiently occupy a slot, so the test's assumption of a zero-connection baseline was fragile and intermittently caused false-positive 503s.

Per project convention, `Serial` was **not** used to work around this (parallel test execution is required unless a case has been explicitly vetted, which this one has not).

## Changes

- `deploy/apifrontend/overlays/e2e/config.yaml`: raise `maxSSEConnections` from 5 to 50, giving realistic headroom above concurrent E2E traffic while still meaningfully enforcing the cap.
- `test/e2e/apifrontend/streaming_test.go`: `TC-E2E-SSE-CAP-01` now samples the current `af_sse_active_connections` baseline, waits for at least 20 slots of headroom, and fills only the remaining slots instead of assuming a zero baseline.
- `test/integration/apifrontend/router_http_test.go`: adds `IT-AF-SSE-CAP-001`, a deterministic integration test against an isolated router + `ConnectionTracker` (`httptest.NewServer`, cap=2) that proves the 503 "too many concurrent connections" response is correctly wired — independent of shared E2E state or timing.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run` on changed packages: 0 issues
- [x] New `IT-AF-SSE-CAP-001` passes
- [x] Full `apifrontend` integration suite (163 specs): all green, no regressions
- [x] `pkg/apifrontend/streaming` unit tests (17 specs): all green
- [x] `config.yaml` validated as parseable YAML with `maxSSEConnections: 50`
- [ ] CI E2E run for `apifrontend` (to confirm the flakiness is resolved in the real pipeline)