### PR TITLE
fix(fleet): wire FleetReaderFactory/ClusterRegistry into AF/EM/RO; remote-only fleet E2E topology

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -240,7 +240,8 @@ clean: ## Clean build artifacts
 
 # Coverage Directory Setup
 .PHONY: ensure-coverage-dirs
-ensure-coverage-dirs: ## Ensure coverage directories exist for all test tiers
+ensure-coverage-dirs: ## Ensure coverage directories exist for all test tiers, purged of any stale runs
+	@rm -rf coverdata coverage-reports
 	@mkdir -p coverdata coverage-reports
 	@chmod -f 777 coverdata coverage-reports 2>/dev/null || true
 

--- a/cmd/apifrontend/backend_deps.go
+++ b/cmd/apifrontend/backend_deps.go
@@ -392,6 +392,7 @@ func buildFleetReaderDeps(ctx context.Context, cfg *config.Config, deps *backend
 			ClientIDPath:     basePath + "/client-id",
 			ClientSecretPath: basePath + "/client-secret",
 			Scopes:           cfg.Fleet.OAuth2.Scopes,
+			TlsCaFile:        cfg.Fleet.OAuth2.TLSCAFile,
 		}
 		opts = append(opts, mcpclient.WithReloadableOAuth2Transport(reloadCfg, fleetLog))
 	}

--- a/cmd/effectivenessmonitor/main.go
+++ b/cmd/effectivenessmonitor/main.go
@@ -447,6 +447,7 @@ func buildFleetReaderFactory(ctx context.Context, localClient client.Client, dyn
 			ClientIDPath:     basePath + "/client-id",
 			ClientSecretPath: basePath + "/client-secret",
 			Scopes:           cfg.Fleet.OAuth2.Scopes,
+			TlsCaFile:        cfg.Fleet.OAuth2.TLSCAFile,
 		}
 		opts = append(opts, mcpclient.WithReloadableOAuth2Transport(reloadCfg, fleetLog))
 	}

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -260,6 +260,7 @@ func registerAdapters(
 				ClientIDPath:     basePath + "/client-id",
 				ClientSecretPath: basePath + "/client-secret",
 				Scopes:           fleetclient.DefaultFleetScopes(serverCfg.Fleet.OAuth2.Scopes),
+				TlsCaFile:        serverCfg.Fleet.OAuth2.TLSCAFile,
 			}
 			fleetOpts = append(fleetOpts,
 				fleetclient.WithReloadableOAuth2Transport(reloadCfg, fleetLog),

--- a/cmd/remediationorchestrator/main.go
+++ b/cmd/remediationorchestrator/main.go
@@ -581,6 +581,7 @@ func buildFleetReaderFactory(ctx context.Context, localClient client.Client, cfg
 			ClientIDPath:     basePath + "/client-id",
 			ClientSecretPath: basePath + "/client-secret",
 			Scopes:           cfg.Fleet.OAuth2.Scopes,
+			TlsCaFile:        cfg.Fleet.OAuth2.TLSCAFile,
 		}
 		opts = append(opts, mcpclient.WithReloadableOAuth2Transport(reloadCfg, fleetLog))
 	}

--- a/cmd/signalprocessing/main.go
+++ b/cmd/signalprocessing/main.go
@@ -309,6 +309,7 @@ func main() {
 				ClientSecretPath: basePath + "/client-secret",
 				Scopes:           fleetclient.DefaultFleetScopes(cfg.Fleet.OAuth2.Scopes),
 				TokenTimeout:     10 * time.Second,
+				TlsCaFile:        cfg.Fleet.OAuth2.TLSCAFile,
 			}
 			fleetOpts = append(fleetOpts,
 				fleetclient.WithReloadableOAuth2Transport(reloadCfg, fleetLog),

--- a/cmd/workflowexecution/main.go
+++ b/cmd/workflowexecution/main.go
@@ -426,6 +426,7 @@ func buildClientFactory(ctx context.Context, cfg *weconfig.Config, mgr ctrl.Mana
 			ClientSecretPath: basePath + "/client-secret",
 			Scopes:           fleetclient.DefaultFleetScopes(cfg.Fleet.OAuth2.Scopes),
 			TokenTimeout:     10 * time.Second,
+			TlsCaFile:        cfg.Fleet.OAuth2.TLSCAFile,
 		}
 		fleetOpts = append(fleetOpts,
 			fleetclient.WithReloadableOAuth2Transport(reloadCfg, fleetLog),

--- a/pkg/fleet/config.go
+++ b/pkg/fleet/config.go
@@ -94,6 +94,17 @@ type FleetOAuth2Config struct {
 	TokenURL             string   `yaml:"tokenURL"`
 	CredentialsSecretRef string   `yaml:"credentialsSecretRef"`
 	Scopes               []string `yaml:"scopes,omitempty"`
+
+	// TLSCAFile is the path to a CA certificate bundle used to verify the
+	// TokenURL's TLS certificate when the OAuth2 provider (e.g. Keycloak,
+	// Dex) presents a certificate not signed by a public/system CA — for
+	// example a cluster-local or self-signed issuer. When empty, the
+	// token-fetch HTTP client falls back to the system CA trust store.
+	// Mirrors fmc/config.OAuth2Config.TlsCaFile, which every GW/RO/SP/WE/
+	// EM/AF caller was missing until this field was added (root cause of
+	// "tls: failed to verify certificate: x509: certificate signed by
+	// unknown authority" against an in-cluster OIDC provider).
+	TLSCAFile string `yaml:"tlsCAFile,omitempty"`
 }
 
 // MCPGatewayConfig holds MCP Gateway connectivity settings shared by services

--- a/pkg/fleet/fleet_test.go
+++ b/pkg/fleet/fleet_test.go
@@ -21,6 +21,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
 
 	"github.com/jordigilh/kubernaut/pkg/fleet"
 )
@@ -308,6 +309,42 @@ var _ = Describe("FleetConfig.ValidateFullFederation — GW/RO dual-capability r
 			MCPGatewayType:     fleet.GatewayEAIGW,
 		}
 		Expect(cfg.ValidateFullFederation()).ToNot(HaveOccurred())
+	})
+})
+
+// Root cause of the "tls: failed to verify certificate: x509: certificate
+// signed by unknown authority" failures observed against an in-cluster
+// Keycloak/Dex OIDC provider from GW/RO/SP/WE/EM/AF: FleetOAuth2Config had
+// no way to name a CA bundle for the token-fetch HTTP client, unlike FMC's
+// own (separate) OAuth2Config.TlsCaFile. This Describe block locks in the
+// field's presence and YAML round-trip so a future refactor cannot silently
+// drop it again.
+var _ = Describe("FleetOAuth2Config.TLSCAFile (BR-INTEGRATION-065)", func() {
+	It("UT-FLEET-CFG-050 [SC-8]: TLSCAFile is settable and defaults to empty (system CA trust)", func() {
+		cfg := fleet.FleetOAuth2Config{
+			Enabled:  true,
+			TokenURL: "https://keycloak:8443/realms/kubernaut-fleet/protocol/openid-connect/token",
+		}
+		Expect(cfg.TLSCAFile).To(BeEmpty(),
+			"zero-value TLSCAFile must fall back to the system CA trust store")
+
+		cfg.TLSCAFile = "/etc/gateway/tls-ca/ca.crt"
+		Expect(cfg.TLSCAFile).To(Equal("/etc/gateway/tls-ca/ca.crt"))
+	})
+
+	It("UT-FLEET-CFG-051 [SC-8]: TLSCAFile survives a YAML round-trip via the tlsCAFile key", func() {
+		cfg := fleet.FleetOAuth2Config{
+			Enabled:   true,
+			TokenURL:  "https://keycloak:8443/token",
+			TLSCAFile: "/etc/gateway/tls-ca/ca.crt",
+		}
+		data, err := yaml.Marshal(cfg)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(data)).To(ContainSubstring("tlsCAFile: /etc/gateway/tls-ca/ca.crt"))
+
+		var roundTripped fleet.FleetOAuth2Config
+		Expect(yaml.Unmarshal(data, &roundTripped)).To(Succeed())
+		Expect(roundTripped.TLSCAFile).To(Equal(cfg.TLSCAFile))
 	})
 })
 

--- a/pkg/signalprocessing/config/config.go
+++ b/pkg/signalprocessing/config/config.go
@@ -86,6 +86,13 @@ type FleetOAuth2 struct {
 	TokenURL             string   `yaml:"tokenURL"`
 	CredentialsSecretRef string   `yaml:"credentialsSecretRef"`
 	Scopes               []string `yaml:"scopes,omitempty"`
+
+	// TLSCAFile is the path to a CA bundle for verifying TokenURL's TLS
+	// certificate when the OAuth2 provider presents one not signed by a
+	// public/system CA (e.g. a cluster-local Keycloak/Dex issuer). Mirrors
+	// pkg/fleet.FleetOAuth2Config.TLSCAFile; see that field's doc comment
+	// for the root cause this addresses.
+	TLSCAFile string `yaml:"tlsCAFile,omitempty"`
 }
 
 // EnrichmentConfig holds settings for K8s context enrichment.

--- a/pkg/workflowexecution/config/config.go
+++ b/pkg/workflowexecution/config/config.go
@@ -77,6 +77,13 @@ type FleetOAuth2 struct {
 	TokenURL             string   `yaml:"tokenURL"`
 	CredentialsSecretRef string   `yaml:"credentialsSecretRef"`
 	Scopes               []string `yaml:"scopes,omitempty"`
+
+	// TLSCAFile is the path to a CA bundle for verifying TokenURL's TLS
+	// certificate when the OAuth2 provider presents one not signed by a
+	// public/system CA (e.g. a cluster-local Keycloak/Dex issuer). Mirrors
+	// pkg/fleet.FleetOAuth2Config.TLSCAFile; see that field's doc comment
+	// for the root cause this addresses.
+	TLSCAFile string `yaml:"tlsCAFile,omitempty"`
 }
 
 // TektonConfig controls Tekton Pipelines engine registration (Issue #868).

--- a/test/e2e/fleet/02_sp_remote_enrichment_test.go
+++ b/test/e2e/fleet/02_sp_remote_enrichment_test.go
@@ -32,7 +32,7 @@ import (
 // Authority: Issue #54, ADR-068
 // FedRAMP: SI-4 (information system monitoring -- remote enrichment)
 var _ = Describe("E2E-FLEET-003 [SI-4]: SP remote enrichment via MCP gateway populates KubernetesContext without degraded mode (BR-INTEGRATION-054)", Label("fleet"), func() {
-	It("enriches a SignalProcessing CR targeting a remote-cluster resource via loopback MCP gateway", func() {
+	It("enriches a SignalProcessing CR targeting a resource on the remote cluster via MCP gateway", func() {
 		// Issue #54 flakiness fix: real Kubernetes Pods get a generated name
 		// suffix (e.g. "coredns-66bc5c9577-dmj24"), so hardcoding "coredns" as
 		// the target Pod name never resolves and the k8s-enricher permanently
@@ -40,7 +40,7 @@ var _ = Describe("E2E-FLEET-003 [SI-4]: SP remote enrichment via MCP gateway pop
 		// mode"). Discover an actual running CoreDNS pod name instead.
 		//
 		// Discovered on the REMOTE cluster (DD-TEST-013): ClusterID:
-		// "loopback-cluster" below now resolves through AllRegistrationsRemote's
+		// "remote-cluster" below now resolves through AllRegistrationsRemote's
 		// bridge, so the enricher reads kube-system from the remote cluster,
 		// not the primary one -- their CoreDNS pod names differ.
 		var podList corev1.PodList
@@ -69,7 +69,7 @@ var _ = Describe("E2E-FLEET-003 [SI-4]: SP remote enrichment via MCP gateway pop
 					Severity:     "high",
 					Type:         "alert",
 					TargetType:   "kubernetes",
-					ClusterID:    "loopback-cluster",
+					ClusterID:    "remote-cluster",
 					ReceivedTime: metav1.Now(),
 					TargetResource: signalprocessingv1.ResourceIdentifier{
 						Kind:      "Pod",
@@ -81,7 +81,7 @@ var _ = Describe("E2E-FLEET-003 [SI-4]: SP remote enrichment via MCP gateway pop
 		}
 		Expect(k8sClient.Create(ctx, sp)).To(Succeed())
 
-		By("Waiting for KubernetesContext enrichment via MCP gateway (remote cluster loopback)")
+		By("Waiting for KubernetesContext enrichment via MCP gateway (remote cluster)")
 		Eventually(func() bool {
 			var updated signalprocessingv1.SignalProcessing
 			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(sp), &updated); err != nil {

--- a/test/e2e/fleet/03_ro_clusterid_routing_test.go
+++ b/test/e2e/fleet/03_ro_clusterid_routing_test.go
@@ -33,7 +33,7 @@ import (
 var _ = Describe("E2E-FLEET-004 [AC-6]: RO creates RR with clusterID and routes to fleet-aware workflow (BR-INTEGRATION-054)", Label("fleet"), func() {
 	It("should route alert with cluster_id to a workflow that respects cluster scope", func() {
 		payload := buildPrometheusAlertWithCluster("FleetRouting", namespace, "critical",
-			"Deployment", "memory-eater", "loopback-cluster")
+			"Deployment", "memory-eater", "remote-cluster")
 
 		gatewayURL := "http://localhost:30080"
 		_, body := postFleetAlertUntilAccepted(gatewayURL, payload)
@@ -44,19 +44,19 @@ var _ = Describe("E2E-FLEET-004 [AC-6]: RO creates RR with clusterID and routes 
 
 		rrName := response["remediationRequestName"].(string)
 
-		By("Verifying RR has clusterID=loopback-cluster and enters workflow processing (AC-6)")
+		By("Verifying RR has clusterID=remote-cluster and enters workflow processing (AC-6)")
 		Eventually(func(g Gomega) {
 			var rr remediationv1.RemediationRequest
 			g.Expect(k8sClient.Get(ctx, client.ObjectKey{
 				Name: rrName, Namespace: namespace,
 			}, &rr)).To(Succeed())
-			g.Expect(rr.Spec.ClusterID).To(Equal("loopback-cluster"),
+			g.Expect(rr.Spec.ClusterID).To(Equal("remote-cluster"),
 				"AC-6: RR must carry cluster identity for scoped workflow routing")
 			g.Expect(rr.Status.OverallPhase).ToNot(BeEmpty(),
 				"RR should enter workflow processing via RO")
 		}, timeout, interval).Should(Succeed())
 
-		By("Verifying WFE carries clusterID=loopback-cluster (AC-3)")
+		By("Verifying WFE carries clusterID=remote-cluster (AC-3)")
 		Eventually(func(g Gomega) {
 			var rr remediationv1.RemediationRequest
 			g.Expect(k8sClient.Get(ctx, client.ObjectKey{
@@ -77,7 +77,7 @@ var _ = Describe("E2E-FLEET-004 [AC-6]: RO creates RR with clusterID and routes 
 			}
 			g.Expect(owned).ToNot(BeNil(),
 				"RO should have created a WFE owned by this RR")
-			g.Expect(owned.Spec.ClusterID).To(Equal("loopback-cluster"),
+			g.Expect(owned.Spec.ClusterID).To(Equal("remote-cluster"),
 				"AC-3: WFE must carry ClusterID for remote cluster execution routing")
 		}, timeout, interval).Should(Succeed())
 	})

--- a/test/e2e/fleet/04_we_remote_job_test.go
+++ b/test/e2e/fleet/04_we_remote_job_test.go
@@ -36,8 +36,8 @@ import (
 //
 // This test validates that the MCP gateway exposes the tools needed for
 // remote Job creation, and that a tool call routed through the gateway
-// successfully creates a resource on the loopback cluster.
-var _ = Describe("E2E-FLEET-005 [AC-3]: WE dispatches remote Job via MCP gateway to loopback cluster (BR-INTEGRATION-054)", Label("fleet"), func() {
+// successfully creates a resource on the remote cluster.
+var _ = Describe("E2E-FLEET-005 [AC-3]: WE dispatches remote Job via MCP gateway to remote cluster (BR-INTEGRATION-054)", Label("fleet"), func() {
 	It("should discover job-creation tools via MCP gateway and verify tool availability", func() {
 		mcpCtx := context.Background()
 		authClient, err := fleetAuthenticatedHTTPClient()
@@ -63,16 +63,16 @@ var _ = Describe("E2E-FLEET-005 [AC-3]: WE dispatches remote Job via MCP gateway
 				toolNames[tool.Name] = true
 			}
 
-			g.Expect(toolNames).To(HaveKey("loopback_cluster_resources_create_or_update"),
+			g.Expect(toolNames).To(HaveKey("remote_cluster_resources_create_or_update"),
 				"AC-3: resources_create_or_update tool must be available for remote Job dispatch")
-			g.Expect(toolNames).To(HaveKey("loopback_cluster_resources_get"),
+			g.Expect(toolNames).To(HaveKey("remote_cluster_resources_get"),
 				"resources_get tool needed for WE status polling")
 		}, 90*time.Second, 5*time.Second).Should(Succeed())
 	})
 
 	It("should execute a read operation on the remote cluster via MCP gateway", func() {
 		mcpCtx := context.Background()
-		mcpClient, err := newFleetMCPClient(mcpCtx, "loopback-cluster")
+		mcpClient, err := newFleetMCPClient(mcpCtx, "remote-cluster")
 		Expect(err).ToNot(HaveOccurred(), "should connect to MCP gateway via NodePort")
 		defer mcpClient.Close()
 
@@ -83,6 +83,6 @@ var _ = Describe("E2E-FLEET-005 [AC-3]: WE dispatches remote Job via MCP gateway
 		Expect(err).ToNot(HaveOccurred(),
 			"AC-3: MCP gateway must support remote list operations")
 		Expect(podList.Items).ToNot(BeEmpty(),
-			"loopback cluster must have pods in kube-system")
+			"remote cluster must have pods in kube-system")
 	})
 })

--- a/test/e2e/fleet/04_we_remote_job_test.go
+++ b/test/e2e/fleet/04_we_remote_job_test.go
@@ -40,7 +40,9 @@ import (
 var _ = Describe("E2E-FLEET-005 [AC-3]: WE dispatches remote Job via MCP gateway to loopback cluster (BR-INTEGRATION-054)", Label("fleet"), func() {
 	It("should discover job-creation tools via MCP gateway and verify tool availability", func() {
 		mcpCtx := context.Background()
-		mcpClient, err := mcpclient.New(mcpCtx, mcpGatewayURL)
+		authClient, err := fleetAuthenticatedHTTPClient()
+		Expect(err).ToNot(HaveOccurred(), "should acquire Keycloak token for MCP gateway")
+		mcpClient, err := mcpclient.New(mcpCtx, mcpGatewayURL, mcpclient.WithHTTPClient(authClient))
 		Expect(err).ToNot(HaveOccurred(), "should connect to MCP gateway via NodePort")
 		defer mcpClient.Close()
 

--- a/test/e2e/fleet/05_af_preflight_oauth2_test.go
+++ b/test/e2e/fleet/05_af_preflight_oauth2_test.go
@@ -61,7 +61,7 @@ var _ = Describe("E2E-FLEET-006 [IA-5, SC-8]: AF performs preflight checks via M
 
 	It("should execute a preflight read via MCP gateway to validate cluster accessibility", func() {
 		mcpCtx := context.Background()
-		mcpClient, err := newFleetMCPClient(mcpCtx, "loopback-cluster")
+		mcpClient, err := newFleetMCPClient(mcpCtx, "remote-cluster")
 		Expect(err).ToNot(HaveOccurred(), "should connect to MCP gateway for preflight")
 		defer mcpClient.Close()
 
@@ -72,7 +72,7 @@ var _ = Describe("E2E-FLEET-006 [IA-5, SC-8]: AF performs preflight checks via M
 		Expect(err).ToNot(HaveOccurred(),
 			"SC-8: preflight namespace list via MCP gateway must succeed")
 		Expect(nsList.Items).ToNot(BeEmpty(),
-			"loopback cluster must have namespaces accessible via MCP")
+			"remote cluster must have namespaces accessible via MCP")
 
 		By("Verifying kubernaut-system namespace is accessible (preflight check)")
 		found := false
@@ -88,7 +88,7 @@ var _ = Describe("E2E-FLEET-006 [IA-5, SC-8]: AF performs preflight checks via M
 
 	It("should list pods in kubernaut-system via MCP gateway with label selector", func() {
 		mcpCtx := context.Background()
-		mcpClient, err := newFleetMCPClient(mcpCtx, "loopback-cluster")
+		mcpClient, err := newFleetMCPClient(mcpCtx, "remote-cluster")
 		Expect(err).ToNot(HaveOccurred())
 		defer mcpClient.Close()
 

--- a/test/e2e/fleet/05_af_preflight_oauth2_test.go
+++ b/test/e2e/fleet/05_af_preflight_oauth2_test.go
@@ -18,12 +18,14 @@ package fleet
 
 import (
 	"context"
+	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/jordigilh/kubernaut/pkg/fleet/mcpclient"
 	"github.com/jordigilh/kubernaut/test/infrastructure"
+	testauth "github.com/jordigilh/kubernaut/test/shared/auth"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,7 +49,8 @@ var _ = Describe("E2E-FLEET-006 [IA-5, SC-8]: AF performs preflight checks via M
 
 		By("Verifying MCP gateway is reachable via NodePort")
 		mcpCtx := context.Background()
-		mcpClient, err := mcpclient.New(mcpCtx, mcpGatewayURL)
+		authClient := &http.Client{Transport: testauth.NewStaticTokenTransport(token)}
+		mcpClient, err := mcpclient.New(mcpCtx, mcpGatewayURL, mcpclient.WithHTTPClient(authClient))
 		Expect(err).ToNot(HaveOccurred(), "MCP gateway must be reachable via NodePort")
 		defer mcpClient.Close()
 

--- a/test/e2e/fleet/06_aa_fleet_investigation_test.go
+++ b/test/e2e/fleet/06_aa_fleet_investigation_test.go
@@ -33,7 +33,7 @@ import (
 var _ = Describe("E2E-FLEET-007 [SI-4]: AA investigation with fleet context uses MCP-backed K8s reader (BR-INTEGRATION-054)", Label("fleet"), func() {
 	It("should read deployment status from remote cluster via MCP gateway for investigation context", func() {
 		mcpCtx := context.Background()
-		mcpClient, err := newFleetMCPClient(mcpCtx, "loopback-cluster")
+		mcpClient, err := newFleetMCPClient(mcpCtx, "remote-cluster")
 		Expect(err).ToNot(HaveOccurred(), "should connect to MCP gateway for fleet investigation")
 		defer mcpClient.Close()
 
@@ -64,7 +64,7 @@ var _ = Describe("E2E-FLEET-007 [SI-4]: AA investigation with fleet context uses
 
 	It("should read pod events from remote cluster for root cause analysis", func() {
 		mcpCtx := context.Background()
-		mcpClient, err := newFleetMCPClient(mcpCtx, "loopback-cluster")
+		mcpClient, err := newFleetMCPClient(mcpCtx, "remote-cluster")
 		Expect(err).ToNot(HaveOccurred())
 		defer mcpClient.Close()
 

--- a/test/e2e/fleet/08_full_fleet_journey_test.go
+++ b/test/e2e/fleet/08_full_fleet_journey_test.go
@@ -39,17 +39,18 @@ import (
 // FedRAMP: AC-3, AC-4, SI-4 (end-to-end fleet remediation)
 //
 // This is the integration test that validates the complete multi-cluster
-// remediation lifecycle using the loopback pattern. It exercises:
+// remediation lifecycle against the genuinely remote cluster (AllRegistrationsRemote,
+// DD-TEST-013). It exercises:
 //   1. Gateway receives alert with cluster_id
 //   2. RR is created with spec.clusterID
 //   3. SP enriches the signal via MCP gateway (remote)
 //   4. RO routes the RR through the workflow pipeline
 var _ = Describe("E2E-FLEET-009 [AC-3, AC-4, SI-4]: Full fleet journey from alert to enrichment (BR-INTEGRATION-054)", Label("fleet"), func() {
 	It("should complete the full fleet remediation pipeline: alert -> RR -> SP enrichment", func() {
-		By("Step 1: Sending alert with cluster_id=loopback-cluster to Gateway (AC-4)")
+		By("Step 1: Sending alert with cluster_id=remote-cluster to Gateway (AC-4)")
 		// Issue #54 flakiness fix: distinct resource name from E2E-FLEET-004
 		// (03_ro_clusterid_routing_test.go), which also used "memory-eater" +
-		// "loopback-cluster" and therefore produced an identical dedup fingerprint
+		// "remote-cluster" and therefore produced an identical dedup fingerprint
 		// (see pkg/gateway/types/fingerprint.go). Running in parallel Ginkgo
 		// processes, the two specs raced for the same dedup slot.
 		//
@@ -86,7 +87,7 @@ var _ = Describe("E2E-FLEET-009 [AC-3, AC-4, SI-4]: Full fleet journey from aler
 		DeferCleanup(func() { _ = remoteK8sClient.Delete(context.Background(), dep) })
 
 		payload := buildPrometheusAlertWithCluster("FleetJourney", namespace, "critical",
-			"Deployment", targetName, "loopback-cluster")
+			"Deployment", targetName, "remote-cluster")
 
 		gatewayURL := "http://localhost:30080"
 		_, body := postFleetAlertUntilAccepted(gatewayURL, payload)
@@ -97,14 +98,14 @@ var _ = Describe("E2E-FLEET-009 [AC-3, AC-4, SI-4]: Full fleet journey from aler
 
 		rrName := response["remediationRequestName"].(string)
 
-		By("Step 2: Verifying RR created with spec.clusterID=loopback-cluster (AC-3)")
+		By("Step 2: Verifying RR created with spec.clusterID=remote-cluster (AC-3)")
 		Eventually(func(g Gomega) {
 			var rr remediationv1.RemediationRequest
 			g.Expect(k8sClient.Get(ctx, client.ObjectKey{
 				Name: rrName, Namespace: namespace,
 			}, &rr)).To(Succeed())
-			g.Expect(rr.Spec.ClusterID).To(Equal("loopback-cluster"),
-				"AC-3: RR must carry loopback-cluster identity")
+			g.Expect(rr.Spec.ClusterID).To(Equal("remote-cluster"),
+				"AC-3: RR must carry remote-cluster identity")
 		}, timeout, interval).Should(Succeed())
 
 		By("Step 3: Verifying SP is created for signal enrichment")
@@ -115,14 +116,14 @@ var _ = Describe("E2E-FLEET-009 [AC-3, AC-4, SI-4]: Full fleet journey from aler
 			var foundSP *signalprocessingv1.SignalProcessing
 			for i := range spList.Items {
 				sp := &spList.Items[i]
-				if sp.Spec.Signal.ClusterID == "loopback-cluster" &&
+				if sp.Spec.Signal.ClusterID == "remote-cluster" &&
 					sp.Spec.RemediationRequestRef.Name == rrName {
 					foundSP = sp
 					break
 				}
 			}
 			g.Expect(foundSP).ToNot(BeNil(),
-				"SP should be created for the fleet signal with clusterID=loopback-cluster")
+				"SP should be created for the fleet signal with clusterID=remote-cluster")
 		}, timeout, interval).Should(Succeed())
 
 		By("Step 4: Waiting for SP enrichment to complete via MCP gateway (SI-4)")
@@ -132,7 +133,7 @@ var _ = Describe("E2E-FLEET-009 [AC-3, AC-4, SI-4]: Full fleet journey from aler
 
 			for i := range spList.Items {
 				sp := &spList.Items[i]
-				if sp.Spec.Signal.ClusterID == "loopback-cluster" &&
+				if sp.Spec.Signal.ClusterID == "remote-cluster" &&
 					sp.Spec.RemediationRequestRef.Name == rrName {
 					g.Expect(sp.Status.KubernetesContext).ToNot(BeNil(),
 						"SI-4: SP should be enriched via MCP gateway for remote cluster signal")

--- a/test/e2e/fleet/09_kuadrant_gateway_test.go
+++ b/test/e2e/fleet/09_kuadrant_gateway_test.go
@@ -63,25 +63,25 @@ var _ = Describe("E2E-FLEET-KUA: Kuadrant MCP Gateway Pipeline", Label("fleet"),
 			for _, tool := range tools.Tools {
 				toolNames = append(toolNames, tool.Name)
 			}
-			g.Expect(toolNames).To(ContainElement(HavePrefix("loopback_cluster_")),
+			g.Expect(toolNames).To(ContainElement(HavePrefix("remote_cluster_")),
 				"CM-6: tool names must use prefix from MCPServerRegistration.spec.prefix")
 		}, 90*time.Second, 5*time.Second).Should(Succeed())
 	})
 
 	It("E2E-FLEET-KUA-002 [AC-3]: tool call routes through Kuadrant broker to kube-mcp-server backend", func() {
 		mcpCtx := context.Background()
-		mcpClient, err := newFleetMCPClient(mcpCtx, "loopback-cluster")
+		mcpClient, err := newFleetMCPClient(mcpCtx, "remote-cluster")
 		Expect(err).ToNot(HaveOccurred())
 		defer mcpClient.Close()
 
 		By("Executing namespaces_list tool call through Kuadrant gateway")
 		result, err := mcpClient.Session().CallTool(mcpCtx, &mcp.CallToolParams{
-			Name: "loopback_cluster_namespaces_list",
+			Name: "remote_cluster_namespaces_list",
 		})
 		Expect(err).ToNot(HaveOccurred(),
 			"AC-3: tool call must route through Kuadrant broker to kube-mcp-server")
 		Expect(result.Content).ToNot(BeEmpty(),
-			"tool call response must contain namespace data from loopback cluster")
+			"tool call response must contain namespace data from remote cluster")
 	})
 
 	It("E2E-FLEET-KUA-003 [CM-6]: FMC is running and healthy with gatewayType=kuadrant", func() {
@@ -95,15 +95,15 @@ var _ = Describe("E2E-FLEET-KUA: Kuadrant MCP Gateway Pipeline", Label("fleet"),
 		Expect(strings.TrimSpace(string(out))).To(Equal("1"),
 			"CM-6: FMC deployment must have 1 ready replica")
 
-		By("Verifying MCPServerRegistration 'loopback-cluster' exists")
+		By("Verifying MCPServerRegistration 'remote-cluster' exists")
 		regCmd := exec.CommandContext(context.Background(),
-			"kubectl", "get", "mcpserverregistration", "loopback-cluster",
+			"kubectl", "get", "mcpserverregistration", "remote-cluster",
 			"-n", namespace, "--kubeconfig", kubeconfigPath,
 			"-o", "name")
 		regOut, regErr := regCmd.Output()
 		Expect(regErr).ToNot(HaveOccurred(), "MCPServerRegistration must exist")
-		Expect(strings.TrimSpace(string(regOut))).To(ContainSubstring("loopback-cluster"),
-			"CM-6: MCPServerRegistration 'loopback-cluster' must be present")
+		Expect(strings.TrimSpace(string(regOut))).To(ContainSubstring("remote-cluster"),
+			"CM-6: MCPServerRegistration 'remote-cluster' must be present")
 
 		By("Verifying Valkey deployment is ready")
 		valkeyCmd := exec.CommandContext(context.Background(),

--- a/test/e2e/fleet/09_kuadrant_gateway_test.go
+++ b/test/e2e/fleet/09_kuadrant_gateway_test.go
@@ -40,7 +40,9 @@ import (
 var _ = Describe("E2E-FLEET-KUA: Kuadrant MCP Gateway Pipeline", Label("fleet"), func() {
 	It("E2E-FLEET-KUA-001 [CM-6]: Kuadrant broker responds to MCP initialize and exposes tools with correct prefix", func() {
 		mcpCtx := context.Background()
-		mcpClient, err := mcpclient.New(mcpCtx, mcpGatewayURL)
+		authClient, err := fleetAuthenticatedHTTPClient()
+		Expect(err).ToNot(HaveOccurred(), "should acquire Keycloak token for MCP gateway")
+		mcpClient, err := mcpclient.New(mcpCtx, mcpGatewayURL, mcpclient.WithHTTPClient(authClient))
 		Expect(err).ToNot(HaveOccurred(), "should connect to Kuadrant MCP gateway via NodePort")
 		defer mcpClient.Close()
 

--- a/test/e2e/fleet/10_two_phase_discovery_test.go
+++ b/test/e2e/fleet/10_two_phase_discovery_test.go
@@ -144,11 +144,22 @@ var _ = Describe("E2E-FLEET-DISC: Two-Phase Discovery Journey", Label("fleet"), 
 			"scoped tools must include namespaces_list")
 
 		By("Phase 3: Call a discovered tool — namespaces_list via the scoped session")
-		result, err := c.Session().CallTool(mcpCtx, &mcp.CallToolParams{
-			Name: "loopback_cluster_namespaces_list",
-		})
-		Expect(err).ToNot(HaveOccurred(),
-			"AC-3: tool call through two-phase discovery must succeed end-to-end")
+		// Unlike Phase 1/2 above, this was previously a single unretried call
+		// -- kube-mcp-server negotiates its session with the remote cluster
+		// lazily on first use, so this exact call is where a CI run observed
+		// "authorization required" during the thundering-herd race at suite
+		// start (12 parallel processes all opening fresh sessions within the
+		// same ~150ms window). Eventually here mirrors Phase 1/2's existing
+		// retry budget instead of leaving this call as the one unprotected
+		// step in an otherwise-retried journey.
+		var result *mcp.CallToolResult
+		Eventually(func(g Gomega) {
+			result, err = c.Session().CallTool(mcpCtx, &mcp.CallToolParams{
+				Name: "loopback_cluster_namespaces_list",
+			})
+			g.Expect(err).ToNot(HaveOccurred(),
+				"AC-3: tool call through two-phase discovery must succeed end-to-end")
+		}).WithTimeout(60 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
 		Expect(len(result.Content)).To(BeNumerically(">=", 1),
 			"tool call response must contain at least one content block with namespace data")
 		Expect(result.IsError).To(BeFalse(),

--- a/test/e2e/fleet/10_two_phase_discovery_test.go
+++ b/test/e2e/fleet/10_two_phase_discovery_test.go
@@ -39,7 +39,7 @@ import (
 // FedRAMP: CM-6 (Configuration Settings), AC-3 (Access Enforcement)
 var _ = Describe("E2E-FLEET-DISC: Two-Phase Discovery Journey", Label("fleet"), func() {
 
-	It("E2E-FLEET-DISC-001 [CM-6]: ListClusters discovers loopback-cluster via discover_tools meta-tool", func() {
+	It("E2E-FLEET-DISC-001 [CM-6]: ListClusters discovers remote-cluster via discover_tools meta-tool", func() {
 		mcpCtx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 		defer cancel()
 
@@ -63,13 +63,13 @@ var _ = Describe("E2E-FLEET-DISC: Two-Phase Discovery Journey", Label("fleet"), 
 			for _, cl := range clusters {
 				names = append(names, cl.Name)
 			}
-			g.Expect(names).To(ContainElement("loopback-cluster"),
-				"CM-6: loopback-cluster must be discoverable via discover_tools")
+			g.Expect(names).To(ContainElement("remote-cluster"),
+				"CM-6: remote-cluster must be discoverable via discover_tools")
 		}).WithTimeout(60 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
 
 	})
 
-	It("E2E-FLEET-DISC-002 [AC-3]: ToolsForCluster returns scoped tools for loopback-cluster via select_tools", func() {
+	It("E2E-FLEET-DISC-002 [AC-3]: ToolsForCluster returns scoped tools for remote-cluster via select_tools", func() {
 		mcpCtx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 		defer cancel()
 
@@ -87,19 +87,19 @@ var _ = Describe("E2E-FLEET-DISC: Two-Phase Discovery Journey", Label("fleet"), 
 		By("Calling ToolsForCluster (wraps select_tools + ListTools)")
 		var tools []mcpclient.ToolDefinition
 		Eventually(func(g Gomega) {
-			tools, err = discoverer.ToolsForCluster(mcpCtx, "loopback-cluster")
+			tools, err = discoverer.ToolsForCluster(mcpCtx, "remote-cluster")
 			g.Expect(err).ToNot(HaveOccurred(), "ToolsForCluster must succeed")
 			names := make([]string, 0, len(tools))
 			for _, t := range tools {
 				names = append(names, t.Name)
 			}
-			g.Expect(names).To(ContainElement("loopback_cluster_namespaces_list"),
-				"AC-3: scoped tools must include namespaces_list for loopback-cluster")
+			g.Expect(names).To(ContainElement("remote_cluster_namespaces_list"),
+				"AC-3: scoped tools must include namespaces_list for remote-cluster")
 		}).WithTimeout(60 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
 
-		By("Verifying tool names use the loopback_cluster_ prefix")
+		By("Verifying tool names use the remote_cluster_ prefix")
 		for _, tool := range tools {
-			Expect(tool.Name).To(HavePrefix("loopback_cluster_"),
+			Expect(tool.Name).To(HavePrefix("remote_cluster_"),
 				"AC-3: all scoped tools must carry the cluster prefix")
 		}
 
@@ -108,7 +108,7 @@ var _ = Describe("E2E-FLEET-DISC: Two-Phase Discovery Journey", Label("fleet"), 
 		for _, tool := range tools {
 			toolNames = append(toolNames, tool.Name)
 		}
-		Expect(toolNames).To(ContainElement("loopback_cluster_namespaces_list"),
+		Expect(toolNames).To(ContainElement("remote_cluster_namespaces_list"),
 			"kube-mcp-server must expose namespaces_list through the gateway")
 	})
 
@@ -135,18 +135,18 @@ var _ = Describe("E2E-FLEET-DISC: Two-Phase Discovery Journey", Label("fleet"), 
 			for _, cl := range clusters {
 				names = append(names, cl.Name)
 			}
-			g.Expect(names).To(ContainElement("loopback-cluster"),
-				"discover_tools must return loopback-cluster")
+			g.Expect(names).To(ContainElement("remote-cluster"),
+				"discover_tools must return remote-cluster")
 		}).WithTimeout(60 * time.Second).WithPolling(5 * time.Second).Should(Succeed())
 
-		By("Phase 2: ToolsForCluster — scope session to loopback-cluster")
-		tools, err := discoverer.ToolsForCluster(mcpCtx, "loopback-cluster")
+		By("Phase 2: ToolsForCluster — scope session to remote-cluster")
+		tools, err := discoverer.ToolsForCluster(mcpCtx, "remote-cluster")
 		Expect(err).ToNot(HaveOccurred())
 		scopedNames := make([]string, 0, len(tools))
 		for _, t := range tools {
 			scopedNames = append(scopedNames, t.Name)
 		}
-		Expect(scopedNames).To(ContainElement("loopback_cluster_namespaces_list"),
+		Expect(scopedNames).To(ContainElement("remote_cluster_namespaces_list"),
 			"scoped tools must include namespaces_list")
 
 		By("Phase 3: Call a discovered tool — namespaces_list via the scoped session")
@@ -161,7 +161,7 @@ var _ = Describe("E2E-FLEET-DISC: Two-Phase Discovery Journey", Label("fleet"), 
 		var result *mcp.CallToolResult
 		Eventually(func(g Gomega) {
 			result, err = c.Session().CallTool(mcpCtx, &mcp.CallToolParams{
-				Name: "loopback_cluster_namespaces_list",
+				Name: "remote_cluster_namespaces_list",
 			})
 			g.Expect(err).ToNot(HaveOccurred(),
 				"AC-3: tool call through two-phase discovery must succeed end-to-end")

--- a/test/e2e/fleet/10_two_phase_discovery_test.go
+++ b/test/e2e/fleet/10_two_phase_discovery_test.go
@@ -44,7 +44,9 @@ var _ = Describe("E2E-FLEET-DISC: Two-Phase Discovery Journey", Label("fleet"), 
 		defer cancel()
 
 		By("Connecting to Kuadrant MCP gateway")
-		c, err := mcpclient.New(mcpCtx, mcpGatewayURL)
+		authClient, err := fleetAuthenticatedHTTPClient()
+		Expect(err).ToNot(HaveOccurred(), "should acquire Keycloak token for MCP gateway")
+		c, err := mcpclient.New(mcpCtx, mcpGatewayURL, mcpclient.WithHTTPClient(authClient))
 		Expect(err).ToNot(HaveOccurred(), "should connect to MCP gateway")
 		defer c.Close()
 
@@ -72,7 +74,9 @@ var _ = Describe("E2E-FLEET-DISC: Two-Phase Discovery Journey", Label("fleet"), 
 		defer cancel()
 
 		By("Connecting to Kuadrant MCP gateway")
-		c, err := mcpclient.New(mcpCtx, mcpGatewayURL)
+		authClient, err := fleetAuthenticatedHTTPClient()
+		Expect(err).ToNot(HaveOccurred(), "should acquire Keycloak token for MCP gateway")
+		c, err := mcpclient.New(mcpCtx, mcpGatewayURL, mcpclient.WithHTTPClient(authClient))
 		Expect(err).ToNot(HaveOccurred())
 		defer c.Close()
 
@@ -113,7 +117,9 @@ var _ = Describe("E2E-FLEET-DISC: Two-Phase Discovery Journey", Label("fleet"), 
 		defer cancel()
 
 		By("Connecting to Kuadrant MCP gateway")
-		c, err := mcpclient.New(mcpCtx, mcpGatewayURL)
+		authClient, err := fleetAuthenticatedHTTPClient()
+		Expect(err).ToNot(HaveOccurred(), "should acquire Keycloak token for MCP gateway")
+		c, err := mcpclient.New(mcpCtx, mcpGatewayURL, mcpclient.WithHTTPClient(authClient))
 		Expect(err).ToNot(HaveOccurred())
 		defer c.Close()
 

--- a/test/e2e/fleet/13_cluster_scoped_workflow_targeting_test.go
+++ b/test/e2e/fleet/13_cluster_scoped_workflow_targeting_test.go
@@ -98,13 +98,13 @@ var _ = Describe("E2E-FLEET-1511-001 [AC-4, SC-7]: Cluster-scoped workflow targe
 		matchWorkflowName := "fleet-cluster-match-" + suffix
 		mismatchWorkflowName := "fleet-cluster-mismatch-" + suffix
 
-		By("Step 1: Registering a workflow classified for the loopback-cluster's fleet classification (production)")
+		By("Step 1: Registering a workflow classified for the remote-cluster's fleet classification (production)")
 		registerFleetClusterWorkflow(matchWorkflowName, []string{"production"})
 
 		By("Step 1b: Registering a workflow classified for a DIFFERENT cluster (staging-eu) -- must be excluded on mismatch")
 		registerFleetClusterWorkflow(mismatchWorkflowName, []string{"staging-eu"})
 
-		By("Step 2: Sending a fleet alert (cluster_id=loopback-cluster) to Gateway (AC-4)")
+		By("Step 2: Sending a fleet alert (cluster_id=remote-cluster) to Gateway (AC-4)")
 		// Distinct target name from other fleet E2E specs to avoid a duplicate
 		// dedup fingerprint race (see 08_full_fleet_journey_test.go's note on
 		// the identical issue for "memory-eater").
@@ -134,7 +134,7 @@ var _ = Describe("E2E-FLEET-1511-001 [AC-4, SC-7]: Cluster-scoped workflow targe
 		DeferCleanup(func() { _ = remoteK8sClient.Delete(context.Background(), dep) })
 
 		payload := buildPrometheusAlertWithCluster("FleetClusterScoped", namespace, "critical",
-			"Deployment", targetName, "loopback-cluster")
+			"Deployment", targetName, "remote-cluster")
 
 		gatewayURL := "http://localhost:30080"
 		_, body := postFleetAlertUntilAccepted(gatewayURL, payload)
@@ -152,7 +152,7 @@ var _ = Describe("E2E-FLEET-1511-001 [AC-4, SC-7]: Cluster-scoped workflow targe
 
 			for i := range spList.Items {
 				candidate := &spList.Items[i]
-				if candidate.Spec.Signal.ClusterID == "loopback-cluster" &&
+				if candidate.Spec.Signal.ClusterID == "remote-cluster" &&
 					candidate.Spec.RemediationRequestRef.Name == rrName {
 					sp = candidate
 					break
@@ -160,7 +160,7 @@ var _ = Describe("E2E-FLEET-1511-001 [AC-4, SC-7]: Cluster-scoped workflow targe
 			}
 			g.Expect(sp).ToNot(BeNil(), "SP should be created for the fleet signal")
 			g.Expect(sp.Status.ClusterClassification).To(Equal("production"),
-				"BR-FLEET-003: SP Rego must classify loopback-cluster as 'production' "+
+				"BR-FLEET-003: SP Rego must classify remote-cluster as 'production' "+
 					"from the MCPServerRegistration's environment=production onboarding label")
 		}, timeout, interval).Should(Succeed())
 

--- a/test/e2e/fleet/suite_test.go
+++ b/test/e2e/fleet/suite_test.go
@@ -69,6 +69,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -240,9 +242,61 @@ func newFleetMCPClient(ctx context.Context, clusterID string) (*mcpclient.Client
 		}
 		c.Close()
 
-		return mcpclient.New(ctx, mcpGatewayURL, mcpclient.WithClusterID(clusterID), mcpclient.WithToolPrefix(prefix))
+		finalClient, err := mcpclient.New(ctx, mcpGatewayURL, mcpclient.WithClusterID(clusterID), mcpclient.WithToolPrefix(prefix))
+		if err != nil {
+			lastErr = fmt.Errorf("create final MCP client for %q (attempt %d/%d): %w", clusterID, attempt+1, maxRetries+1, err)
+			time.Sleep(retryInterval)
+			continue
+		}
+
+		// warmUpFleetMCPSession's own probeAuthenticatedResourcesList (mirrored
+		// below) proved the *broker's* route/AuthPolicy had converged once,
+		// globally, during SynchronizedBeforeSuite (WaitForFleetReady). It did
+		// not prove that THIS brand-new session (the one just created above)
+		// can complete its own first real call: kube-mcp-server negotiates a
+		// session with the remote cluster lazily, on first use, per client --
+		// see mcp-gateway broker logs from a 2026-07-04 CI run, where 7 specs
+		// across 12 parallel processes all opened their first fresh session
+		// within the same ~150ms window right after SynchronizedBeforeSuite
+		// returned, and several got "failed to create client: transport
+		// error: authorization required" even though the readiness probe's
+		// own (single, earlier, non-concurrent) session had already
+		// succeeded. Absorb that thundering-herd race here, once per test
+		// client, instead of leaving every call site to retry independently.
+		if err := warmUpFleetMCPSession(ctx, finalClient); err != nil {
+			finalClient.Close()
+			lastErr = fmt.Errorf("warm up MCP session for %q (attempt %d/%d): %w", clusterID, attempt+1, maxRetries+1, err)
+			GinkgoWriter.Printf("  Waiting for broker session warm-up (attempt %d/%d): %v\n", attempt+1, maxRetries+1, err)
+			time.Sleep(retryInterval)
+			continue
+		}
+
+		return finalClient, nil
 	}
 	return nil, fmt.Errorf("broker sync timeout after %d attempts: %w", maxRetries+1, lastErr)
+}
+
+// warmUpFleetMCPSession performs one cheap, real resources_list call
+// (Pods, cluster-wide) on a freshly created client to force kube-mcp-server's
+// lazy per-session negotiation with the remote cluster to complete before the
+// caller's actual test assertions run. Retries internally for up to 15s --
+// the race window observed in CI closed within ~1s once the burst of
+// concurrent session negotiations settled, so this budget is deliberately
+// short relative to newFleetMCPClient's own 90s broker-sync retry loop.
+func warmUpFleetMCPSession(ctx context.Context, c *mcpclient.Client) error {
+	deadline := time.Now().Add(15 * time.Second)
+	var lastErr error
+	for time.Now().Before(deadline) {
+		list := &unstructured.UnstructuredList{}
+		list.SetGroupVersionKind(schema.GroupVersionKind{Version: "v1", Kind: "PodList"})
+		if err := c.List(ctx, list); err != nil {
+			lastErr = err
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("session warm-up did not succeed within 15s: %w", lastErr)
 }
 
 func TestFleetE2E(t *testing.T) {

--- a/test/e2e/fleet/suite_test.go
+++ b/test/e2e/fleet/suite_test.go
@@ -23,7 +23,7 @@ limitations under the License.
 //
 //	Alert → GW → SP(MCP enrich) → AA(MCP investigate) → WE(MCP dispatch) → EM → NT
 //
-// Every registered cluster identity (loopback-cluster, prod-east, prod-west)
+// Every registered cluster identity (remote-cluster, prod-east, prod-west)
 // is backed by the SAME remote bridge to the remote cluster's kube-mcp-server
 // (KubeMCPServerAuthConfig.AllRegistrationsRemote, test/infrastructure/fleet_e2e.go)
 // -- unlike the "loopback" pattern this suite used before, there is no local
@@ -31,7 +31,7 @@ limitations under the License.
 // primary cluster. kube-mcp-server runs in passthrough mode with a real RFC
 // 8693 Standard Token Exchange against Keycloak (mirrors the FMC E2E lane;
 // Keycloak replaces DEX here because DEX has no Standard Token Exchange,
-// Spike S17/S20). Tool names use the `loopback_cluster_` prefix from
+// Spike S17/S20). Tool names use the `remote_cluster_` prefix from
 // MCPServerRegistration.
 //
 // Because every fleet cluster identity is now remote, any K8s object a test
@@ -112,7 +112,7 @@ var (
 	apiReader client.Reader
 
 	// remoteK8sClient targets the second Kind cluster (DD-TEST-013) that
-	// backs loopback-cluster/prod-east/prod-west (AllRegistrationsRemote,
+	// backs remote-cluster/prod-east/prod-west (AllRegistrationsRemote,
 	// see test/infrastructure/fleet_e2e.go). Kubernaut's own CRDs
 	// (RemediationRequest, SignalProcessing, etc.) are reconciled by
 	// controllers running in the PRIMARY cluster and stay on k8sClient;
@@ -169,7 +169,7 @@ func postWithFleetAuth(url, contentType string, body io.Reader) (*http.Response,
 // resource created/labeled by a test immediately before posting an alert is
 // only guaranteed to be visible to FMC's scope-check endpoint after the next
 // full sync tick. Because syncAll() iterates every registered cluster
-// (loopback-cluster, prod-east, prod-west) x 6 resource kinds sequentially,
+// (remote-cluster, prod-east, prod-west) x 6 resource kinds sequentially,
 // a single cycle can itself take non-trivial wall time, so worst-case
 // staleness exceeds the nominal 10s interval. 45s gives ~2 sync cycles of
 // margin; a 15s window (the previous value) was measured insufficient and
@@ -248,7 +248,7 @@ func fleetAuthenticatedHTTPClient() (*http.Client, error) {
 }
 
 // newFleetMCPClient creates an MCP client with auto-discovered tool prefix.
-// Kuadrant uses "loopback_cluster_" (from MCPServerRegistration spec.prefix),
+// Kuadrant uses "remote_cluster_" (from MCPServerRegistration spec.prefix),
 // not the EAIGW "{clusterID}__" convention. DiscoverToolPrefix queries
 // tools/list and extracts the correct prefix for the given cluster.
 //
@@ -436,7 +436,7 @@ var _ = SynchronizedBeforeSuite(
 			Expect(labelNSErr).ToNot(HaveOccurred(), "Failed to label namespace %s: %s", ns, string(labelNSOut))
 		}
 
-		// The shared "memory-eater" fixture (referenced by clusterID=loopback-cluster/
+		// The shared "memory-eater" fixture (referenced by clusterID=remote-cluster/
 		// prod-east/prod-west across 01_signal_ingestion_test.go and
 		// 03_ro_clusterid_routing_test.go) must live on the REMOTE cluster now that
 		// AllRegistrationsRemote backs every registered cluster identity with the
@@ -510,7 +510,7 @@ var _ = SynchronizedBeforeSuite(
 		apiReader, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 		Expect(err).ToNot(HaveOccurred())
 
-		By("Creating remote cluster's Kubernetes client (DD-TEST-013: backs loopback-cluster/prod-east/prod-west)")
+		By("Creating remote cluster's Kubernetes client (DD-TEST-013: backs remote-cluster/prod-east/prod-west)")
 		remoteCfg, remoteCfgErr := clientcmd.BuildConfigFromFlags("", remoteKubeconfigPath)
 		Expect(remoteCfgErr).ToNot(HaveOccurred(), "failed to build remote cluster kubeconfig")
 		remoteK8sClient, err = client.New(remoteCfg, client.Options{Scheme: scheme.Scheme})
@@ -568,7 +568,7 @@ var _ = SynchronizedAfterSuite(
 			GinkgoWriter.Println("CLUSTER PRESERVED FOR DEBUGGING")
 			GinkgoWriter.Printf("   To access: export KUBECONFIG=%s\n", kubeconfigPath)
 			GinkgoWriter.Printf("   To delete: kind delete cluster --name %s\n", clusterName)
-			GinkgoWriter.Printf("   Remote cluster (DD-TEST-013, backs loopback-cluster/prod-east/prod-west): export KUBECONFIG=%s\n", remoteKubeconfigPath)
+			GinkgoWriter.Printf("   Remote cluster (DD-TEST-013, backs remote-cluster/prod-east/prod-west): export KUBECONFIG=%s\n", remoteKubeconfigPath)
 			GinkgoWriter.Printf("   To delete: kind delete cluster --name %s\n", remoteClusterName)
 			return
 		}

--- a/test/e2e/fleet/suite_test.go
+++ b/test/e2e/fleet/suite_test.go
@@ -206,6 +206,47 @@ func postFleetAlertUntilAccepted(gatewayURL string, payload []byte, acceptableSt
 	return statusCode, respBody
 }
 
+// fleetKeycloakNodePort is this suite's Keycloak NodePort (DD-TEST-001, same
+// dedicated port as the FMC E2E lane -- see keycloakHostPortFleet in
+// test/infrastructure/fleet_e2e.go, which is unexported and so can't be
+// referenced directly from this package).
+const fleetKeycloakNodePort = 30557
+
+// fleetAuthenticatedHTTPClient fetches a Keycloak client_credentials token
+// (kubernaut-fleet-read / kube-mcp-server-audience -- the same identity
+// FMC, SP, and every other fleet-aware production service use) and returns
+// an *http.Client that injects it as "Authorization: Bearer <token>" on
+// every outbound request.
+//
+// Required because kube-mcp-server's RequireOAuth resource-server check
+// gates the mcp-gateway broker's *per-client* upstream session negotiation
+// on tools/call (not just its own tools/list discovery, which the broker
+// serves from its aggregated catalog using its own static
+// BrokerCredentialToken and therefore succeeds even for an unauthenticated
+// caller). A raw mcpclient.New(ctx, mcpGatewayURL) with no WithHTTPClient
+// option sends no Authorization header at all, so any tools/call it makes
+// fails with "rejected by transport: sending \"tools/call\": Internal Server
+// Error" (jsonrpc2 -32005) once the target registration is backed by the
+// RequireOAuth-protected remote kube-mcp-server (AllRegistrationsRemote) --
+// confirmed by reproducing the exact broker/router error via a raw MCP
+// tools/call through mcp-gateway-istio with and without a client-supplied
+// token (2026-07-04 RCA). The token has a 3600s lifespan
+// (keycloak-realm-fleet.json accessTokenLifespan) -- comfortably longer than
+// any single test or this suite's ~20 minute runtime -- so fetching once per
+// client construction (no refresh) is sufficient; mirrors
+// probeAuthenticatedResourcesList's bearerTokenTransport in
+// test/infrastructure/fleet_e2e.go, which proved the same pattern during
+// SynchronizedBeforeSuite's readiness probe.
+func fleetAuthenticatedHTTPClient() (*http.Client, error) {
+	cfg := infrastructure.DefaultKeycloakFleetReadConfig(fleetKeycloakNodePort)
+	cfg.Scopes = []string{"kube-mcp-server-audience"}
+	token, err := infrastructure.GetKeycloakClientCredentialsToken(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("acquire Keycloak client_credentials token: %w", err)
+	}
+	return &http.Client{Transport: testauth.NewStaticTokenTransport(token)}, nil
+}
+
 // newFleetMCPClient creates an MCP client with auto-discovered tool prefix.
 // Kuadrant uses "loopback_cluster_" (from MCPServerRegistration spec.prefix),
 // not the EAIGW "{clusterID}__" convention. DiscoverToolPrefix queries
@@ -220,9 +261,14 @@ func newFleetMCPClient(ctx context.Context, clusterID string) (*mcpclient.Client
 		retryInterval = 5 * time.Second
 	)
 
+	authClient, err := fleetAuthenticatedHTTPClient()
+	if err != nil {
+		return nil, fmt.Errorf("build authenticated MCP HTTP client for %q: %w", clusterID, err)
+	}
+
 	var lastErr error
 	for attempt := 0; attempt <= maxRetries; attempt++ {
-		c, err := mcpclient.New(ctx, mcpGatewayURL)
+		c, err := mcpclient.New(ctx, mcpGatewayURL, mcpclient.WithHTTPClient(authClient))
 		if err != nil {
 			lastErr = fmt.Errorf("connect to MCP gateway (attempt %d/%d): %w", attempt+1, maxRetries+1, err)
 			time.Sleep(retryInterval)
@@ -242,7 +288,7 @@ func newFleetMCPClient(ctx context.Context, clusterID string) (*mcpclient.Client
 		}
 		c.Close()
 
-		finalClient, err := mcpclient.New(ctx, mcpGatewayURL, mcpclient.WithClusterID(clusterID), mcpclient.WithToolPrefix(prefix))
+		finalClient, err := mcpclient.New(ctx, mcpGatewayURL, mcpclient.WithClusterID(clusterID), mcpclient.WithToolPrefix(prefix), mcpclient.WithHTTPClient(authClient))
 		if err != nil {
 			lastErr = fmt.Errorf("create final MCP client for %q (attempt %d/%d): %w", clusterID, attempt+1, maxRetries+1, err)
 			time.Sleep(retryInterval)

--- a/test/infrastructure/fleet_e2e.go
+++ b/test/infrastructure/fleet_e2e.go
@@ -382,21 +382,29 @@ func SetupFleetE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPat
 	}
 	kubeMCPAuthConfig.BrokerCredentialToken = brokerCredToken
 
+	// ── OAuth2 credentials Secret for every fleet-aware service ──────────
+	// Must exist BEFORE DeployFleetInfra: its Phase 5/5b/5c patch Gateway,
+	// RemediationOrchestrator, and SignalProcessing Deployments to mount
+	// this Secret as a volume (patchDeploymentAddFleetOAuth2Volume). If the
+	// Secret doesn't exist yet, the resulting Pod gets stuck in
+	// ContainerCreating (missing volume source) and the rollout-status wait
+	// times out -- see fleetOAuth2SecretName's doc comment.
+	_, _ = fmt.Fprintln(writer, "\n🔑 Creating shared fleet OAuth2 credentials Secret...")
+	if err := deployFleetOAuth2Secret(ctx, namespace, kubeconfigPath, writer); err != nil {
+		return builtImages, seededUUIDs, afRemediateNS, "", err
+	}
+
 	if deployErr := DeployFleetInfra(ctx, namespace, kubeconfigPath, fmcImage, kubeMCPAuthConfig, fmcOAuth2Config, writer); deployErr != nil {
 		return builtImages, seededUUIDs, afRemediateNS, "", fmt.Errorf("fleet infra deployment failed: %w", deployErr)
 	}
 
-	// ── OAuth2 wiring for every fleet-aware service ──────────────────────
+	// ── OAuth2 wiring for the remaining fleet-aware services ─────────────
 	// RequireOAuth=true now gates the ONE remote kube-mcp-server every
-	// registration shares (AllRegistrationsRemote), so AF/EM/SP/WE (which
-	// previously had no fleet config in this suite at all) and GW/RO/SP
-	// (whose existing patches above only set enabled/endpoint fields) all
-	// need a valid Bearer token to get past it -- see
-	// fleetOAuth2SecretName's doc comment.
+	// registration shares (AllRegistrationsRemote), so AF/EM/WE (which
+	// previously had no fleet config in this suite at all) also need a
+	// valid Bearer token to get past it -- see fleetOAuth2SecretName's doc
+	// comment. GW/RO/SP were already wired above (inside DeployFleetInfra).
 	_, _ = fmt.Fprintln(writer, "\n🔑 Wiring fleet OAuth2 credentials into AF/EM/WE (GW/RO/SP already wired above)...")
-	if err := deployFleetOAuth2Secret(ctx, namespace, kubeconfigPath, writer); err != nil {
-		return builtImages, seededUUIDs, afRemediateNS, "", err
-	}
 	if err := patchAPIFrontendConfigForFleet(ctx, namespace, kubeconfigPath, writer); err != nil {
 		return builtImages, seededUUIDs, afRemediateNS, "", err
 	}

--- a/test/infrastructure/fleet_e2e.go
+++ b/test/infrastructure/fleet_e2e.go
@@ -823,6 +823,47 @@ func appendYAMLBlockToConfigMap(ctx context.Context, kubeconfigPath, namespace, 
 // preflight/kubectl-tool paths never exercised the remote-cluster wiring
 // this suite exists to prove (BR-INTEGRATION-054).
 func patchAPIFrontendConfigForFleet(ctx context.Context, namespace, kubeconfigPath string, writer io.Writer) error {
+	// cmd/apifrontend/backend_deps.go's buildFleetReaderDeps starts a
+	// registry.ClusterRegistry (BR-FLEET-054, list_clusters/multi-cluster
+	// kubectl routing) that watches MCPServerRegistration CRs cluster-wide
+	// via an informer; without this RBAC grant the informer never syncs
+	// ("mcpserverregistrations.mcp.kuadrant.io is forbidden ... at the
+	// cluster scope"), clusterRegistry.Start returns an error, and AF exits
+	// at startup. Mirrors patchSignalProcessingConfigForFleet's identical
+	// grant for the same reason.
+	rbacManifest := `---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: apifrontend-fleet-cluster-registry
+  labels:
+    app: apifrontend
+    component: fleet
+rules:
+- apiGroups: ["mcp.kuadrant.io"]
+  resources: ["mcpserverregistrations"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: apifrontend-fleet-cluster-registry
+  labels:
+    app: apifrontend
+    component: fleet
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: apifrontend-fleet-cluster-registry
+subjects:
+- kind: ServiceAccount
+  name: apifrontend
+  namespace: ` + namespace + `
+`
+	if err := kubectlApplyManifest(ctx, kubeconfigPath, writer, rbacManifest); err != nil {
+		return fmt.Errorf("apifrontend-fleet-cluster-registry RBAC creation failed: %w", err)
+	}
+
 	fleetBlock := `
 fleet:
   enabled: true
@@ -845,6 +886,44 @@ fleet:
 // buildFleetReaderFactory (cmd/effectivenessmonitor/main.go) was never
 // exercised here).
 func patchEffectivenessMonitorConfigForFleet(ctx context.Context, namespace, kubeconfigPath string, writer io.Writer) error {
+	// buildFleetReaderFactory (cmd/effectivenessmonitor/main.go) starts a
+	// registry.ClusterRegistry exactly like AF's buildFleetReaderDeps --
+	// see patchAPIFrontendConfigForFleet's doc comment for why this RBAC
+	// grant is required (ClusterRegistry.Start returns an error, which is
+	// fatal at startup, without it).
+	rbacManifest := `---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: effectivenessmonitor-fleet-cluster-registry
+  labels:
+    app: effectivenessmonitor-controller
+    component: fleet
+rules:
+- apiGroups: ["mcp.kuadrant.io"]
+  resources: ["mcpserverregistrations"]
+  verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: effectivenessmonitor-fleet-cluster-registry
+  labels:
+    app: effectivenessmonitor-controller
+    component: fleet
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: effectivenessmonitor-fleet-cluster-registry
+subjects:
+- kind: ServiceAccount
+  name: effectivenessmonitor-controller
+  namespace: ` + namespace + `
+`
+	if err := kubectlApplyManifest(ctx, kubeconfigPath, writer, rbacManifest); err != nil {
+		return fmt.Errorf("effectivenessmonitor-fleet-cluster-registry RBAC creation failed: %w", err)
+	}
+
 	fleetBlock := `
 fleet:
   enabled: true

--- a/test/infrastructure/fleet_e2e.go
+++ b/test/infrastructure/fleet_e2e.go
@@ -154,7 +154,8 @@ type KubeMCPServerAuthConfig struct {
 	RemoteBridge *RemoteClusterBridgeConfig
 
 	// AllRegistrationsRemote, when true (requires RemoteBridge to be
-	// non-nil), makes ALL THREE registrations (loopback-cluster, prod-east,
+	// non-nil), makes ALL THREE registrations (the first one renamed
+	// "remote-cluster" instead of "loopback-cluster", plus prod-east,
 	// prod-west) target the remote bridge instead of only "prod-east" --
 	// and skips deploying a local kube-mcp-server entirely
 	// (deployKubeMCPServerAndRegister). This is the "fleet" full-pipeline
@@ -261,10 +262,10 @@ func (c KubeMCPServerAuthConfig) tomlString() string {
 // NodePort mapping (31975 for Kuadrant MCP) -- already present in
 // kind-fullpipeline-config.yaml.
 //
-// The loopback pattern is used: the K8s MCP Server connects to the same cluster
-// where it runs, but kubernaut treats it as a remote cluster with clusterID
-// "loopback-cluster". This validates the full remote code path without needing
-// a second Kind cluster.
+// Unlike the FMC E2E lanes' loopback pattern, this suite backs EVERY
+// registration (including the one named "remote-cluster") with a genuinely
+// separate second Kind cluster (AllRegistrationsRemote, DD-TEST-013) so no
+// fleet-routed reconciliation can silently fall back to the primary cluster.
 //
 // Total additional memory over fullpipeline: ~388 MB
 // (Istio ~250 MB + Kuadrant ~60 MB + kube-mcp-server ~16 MB + Valkey ~30 MB + FMC ~32 MB).
@@ -275,7 +276,7 @@ func (c KubeMCPServerAuthConfig) tomlString() string {
 const keycloakHostPortFleet = 30557
 
 // SetupFleetE2EInfrastructure returns remoteKubeconfigPath, the second Kind
-// cluster's kubeconfig (DD-TEST-013) backing loopback-cluster/prod-east/
+// cluster's kubeconfig (DD-TEST-013) backing remote-cluster/prod-east/
 // prod-west (AllRegistrationsRemote) -- callers (suite_test.go) must
 // populate a remote K8s client from it and tear that cluster down alongside
 // the primary one.
@@ -318,8 +319,9 @@ func SetupFleetE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPat
 	// Backs EVERY registration (AllRegistrationsRemote) with a genuinely
 	// separate Kubernetes control plane -- unlike the FMC E2E lane, which
 	// only bridges "prod-east" for isolation testing, this suite's whole
-	// point is that "loopback-cluster" (the identity nearly every fleet
-	// test targets) is no longer the same physical cluster.
+	// point is that "remote-cluster" (the identity nearly every fleet
+	// test targets) is a genuinely separate physical cluster, not the
+	// primary one.
 	_, _ = fmt.Fprintln(writer, "\n🌍 Provisioning remote cluster (ALL registrations remote, DD-TEST-013)...")
 	remoteClusterName := clusterName + "-remote"
 	remoteKubeconfigPath = filepath.Join(filepath.Dir(kubeconfigPath), remoteClusterName+"-config")
@@ -423,15 +425,15 @@ func SetupFleetE2EInfrastructure(ctx context.Context, clusterName, kubeconfigPat
 			Scopes:        fmcOAuth2Config.Scopes,
 		})
 	}
-	if readyErr := WaitForFleetReady(keycloakFleetReadTokenFunc, 31975, "loopback_cluster_", writer); readyErr != nil {
+	if readyErr := WaitForFleetReady(keycloakFleetReadTokenFunc, 31975, "remote_cluster_", writer); readyErr != nil {
 		return builtImages, seededUUIDs, afRemediateNS, "", fmt.Errorf("fleet readiness check failed: %w", readyErr)
 	}
 
 	_, _ = fmt.Fprintln(writer, "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 	_, _ = fmt.Fprintln(writer, "✅ Fleet E2E Infrastructure READY")
 	_, _ = fmt.Fprintln(writer, "  MCP Gateway:  http://localhost:31975/mcp")
-	_, _ = fmt.Fprintln(writer, "  Loopback cluster ID: loopback-cluster (genuinely remote, DD-TEST-013)")
-	_, _ = fmt.Fprintln(writer, "  Loopback tool prefix: loopback_cluster_")
+	_, _ = fmt.Fprintln(writer, "  Remote cluster ID: remote-cluster (genuinely remote, DD-TEST-013)")
+	_, _ = fmt.Fprintln(writer, "  Remote tool prefix: remote_cluster_")
 	_, _ = fmt.Fprintf(writer, "  Remote kubeconfig: %s\n", remoteKubeconfigPath)
 	_, _ = fmt.Fprintln(writer, "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━")
 
@@ -1806,9 +1808,10 @@ stringData:
 	// (DD-TEST-013, Spike S19); otherwise it shares the loopback HTTPRoute
 	// like every other registration -- the original, unmodified behavior
 	// for any caller that leaves RemoteBridge nil. When AllRegistrationsRemote
-	// is also set (the "fleet" suite), loopback-cluster and prod-west route
+	// is also set (the "fleet" suite), the first registration (renamed
+	// "remote-cluster", see loopbackClusterName below) and prod-west route
 	// through the same remote HTTPRoute too, instead of only prod-east --
-	// every fleet test hardcodes "loopback-cluster" as its target identity
+	// every fleet test hardcodes "remote-cluster" as its target identity
 	// (not "prod-east"), so that name must be the one backed by the remote
 	// cluster for the suite to exercise genuinely remote reads end-to-end.
 	loopbackRouteName := "kube-mcp-server-route"
@@ -1872,11 +1875,25 @@ spec:
 `, namespace)
 	}
 
+	// The first registration is named/prefixed "loopback-cluster" /
+	// "loopback_cluster_" everywhere EXCEPT when AllRegistrationsRemote is
+	// set (the "fleet" suite): there, it is backed by the genuinely remote
+	// bridge cluster (loopbackRouteName above), so it is renamed
+	// "remote-cluster" / "remote_cluster_" to avoid implying it's the local
+	// loopback cluster it named for every other caller of this shared
+	// function (FMC E2E lanes).
+	loopbackClusterName := "loopback-cluster"
+	loopbackClusterPrefix := "loopback_cluster_"
+	if authConfig.AllRegistrationsRemote {
+		loopbackClusterName = "remote-cluster"
+		loopbackClusterPrefix = "remote_cluster_"
+	}
+
 	routeManifest := fmt.Sprintf(`%[2]s%[5]s%[8]s---
 apiVersion: mcp.kuadrant.io/v1alpha1
 kind: MCPServerRegistration
 metadata:
-  name: loopback-cluster
+  name: %[9]s
   namespace: %[1]s
   labels:
     kubernaut.ai/managed: "true"
@@ -1884,7 +1901,7 @@ metadata:
     # cluster rule (input.cluster.labels.environment) via ClusterRegistry.
     environment: "production"
 spec:
-  prefix: "loopback_cluster_"
+  prefix: %[10]q
 %[3]s  targetRef:
     group: gateway.networking.k8s.io
     kind: HTTPRoute
@@ -1920,12 +1937,12 @@ spec:
     kind: HTTPRoute
     name: %[7]s
     namespace: %[1]s
-`, namespace, brokerCredSecretManifest, brokerCredRefYAML, prodEastRouteName, remoteRouteManifest, loopbackRouteName, prodWestRouteName, localRouteManifest)
+`, namespace, brokerCredSecretManifest, brokerCredRefYAML, prodEastRouteName, remoteRouteManifest, loopbackRouteName, prodWestRouteName, localRouteManifest, loopbackClusterName, loopbackClusterPrefix)
 
 	if err := kubectlApplyManifest(ctx, kubeconfigPath, writer, routeManifest); err != nil {
 		return fmt.Errorf("httpRoute/MCPServerRegistration creation failed: %w", err)
 	}
-	_, _ = fmt.Fprintln(writer, "    ✅ MCPServerRegistrations created (loopback-cluster, prod-east, prod-west)")
+	_, _ = fmt.Fprintf(writer, "    ✅ MCPServerRegistrations created (%s, prod-east, prod-west)\n", loopbackClusterName)
 	return nil
 }
 

--- a/test/infrastructure/fleet_e2e.go
+++ b/test/infrastructure/fleet_e2e.go
@@ -514,7 +514,7 @@ data:
       backend: fleetmetadatacache
       mcpGatewayEndpoint: "http://mcp-gateway-istio.gateway-system.svc:8080/mcp"
       mcpGatewayType: kuadrant
-`+fleetOAuth2YAMLBlock(6)+`
+`+fleetOAuth2YAMLBlock(6, fleetTLSCAFile("/etc/gateway"))+`
 `, namespace)
 
 	if err := kubectlApplyManifest(ctx, kubeconfigPath, writer, gatewayConfigPatch); err != nil {
@@ -610,7 +610,7 @@ fleet:
   endpoint: "http://mcp-gateway-istio.gateway-system.svc:8080/mcp"
   mcpGatewayType: kuadrant
   namespace: "%s"
-`, namespace) + fleetOAuth2YAMLBlock(2)
+`, namespace) + fleetOAuth2YAMLBlock(2, fleetTLSCAFile("/etc/signalprocessing"))
 	if err := appendYAMLBlockToConfigMap(ctx, kubeconfigPath, namespace, "signalprocessing-config", "config.yaml", fleetBlock, writer); err != nil {
 		return fmt.Errorf("signalprocessing-config fleet patch failed: %w", err)
 	}
@@ -667,32 +667,59 @@ stringData:
 	return nil
 }
 
+// fleetTLSCAMountDir is the directory every fleet-aware service mounts
+// deployFleetOAuth2Secret's neighboring "inter-service-ca" ConfigMap into,
+// derived from that service's own /etc/<service> base path (e.g.
+// "/etc/gateway/tls-ca"). fleetTLSCAFile appends the ConfigMap's "ca.crt"
+// key name, giving the exact path each cmd/*/main.go wires into
+// FleetOAuth2Config.TLSCAFile / ReloadableOAuth2Config.TlsCaFile.
+func fleetTLSCAMountDir(basePath string) string {
+	return basePath + "/tls-ca"
+}
+
+func fleetTLSCAFile(basePath string) string {
+	return fleetTLSCAMountDir(basePath) + "/ca.crt"
+}
+
 // fleetOAuth2YAMLBlock renders the "oauth2:" sub-block every fleet-aware
 // service's config nests under its own "fleet:" key (see
 // deployFleetOAuth2Secret). indent is the number of leading spaces for the
 // "oauth2:" line itself; nested lines are indented two spaces further,
-// matching this repo's two-space YAML convention.
-func fleetOAuth2YAMLBlock(indent int) string {
+// matching this repo's two-space YAML convention. tlsCAFile must match the
+// path patchDeploymentAddFleetOAuth2Volume mounts the inter-service-ca
+// ConfigMap at (fleetTLSCAFile(basePath)) -- without it, the OAuth2
+// token-fetch HTTP client falls back to the system CA trust store and
+// cannot verify Keycloak's self-signed cert (root cause of "tls: failed to
+// verify certificate: x509: certificate signed by unknown authority"
+// against https://keycloak:8443, which silently disabled remote owner
+// resolution/MCP reads for every one of these services).
+func fleetOAuth2YAMLBlock(indent int, tlsCAFile string) string {
 	pad := strings.Repeat(" ", indent)
 	return fmt.Sprintf(`%[1]soauth2:
 %[1]s  enabled: true
 %[1]s  tokenURL: %[2]q
 %[1]s  credentialsSecretRef: %[3]q
+%[1]s  tlsCAFile: %[4]q
 %[1]s  scopes:
 %[1]s    - "kube-mcp-server-audience"
-`, pad, fleetKeycloakTokenURL, fleetOAuth2SecretName)
+`, pad, fleetKeycloakTokenURL, fleetOAuth2SecretName, tlsCAFile)
 }
 
 // patchDeploymentAddFleetOAuth2Volume strategic-merge-patches an existing
 // Deployment to mount deployFleetOAuth2Secret's Secret into containerName at
 // mountPath (matching the basePath each service's cmd/*/main.go derives from
 // cfg.Fleet.OAuth2.CredentialsSecretRef, e.g.
-// "/etc/remediationorchestrator/fleet-oauth2-creds"). This patch changes
-// spec.template, so Kubernetes rolls the Deployment automatically -- callers
-// should NOT also issue an explicit `rollout restart` (that would trigger a
-// redundant second rollout) and should call this AFTER any ConfigMap content
-// patch, so the one resulting rollout picks up both changes together.
+// "/etc/remediationorchestrator/fleet-oauth2-creds"), plus the
+// "inter-service-ca" ConfigMap (Keycloak's self-signed CA, see
+// interservice_tls.go) at fleetTLSCAMountDir(basePath) so the token-fetch
+// HTTP client (fleetOAuth2YAMLBlock's tlsCAFile) can verify Keycloak's TLS
+// certificate. This patch changes spec.template, so Kubernetes rolls the
+// Deployment automatically -- callers should NOT also issue an explicit
+// `rollout restart` (that would trigger a redundant second rollout) and
+// should call this AFTER any ConfigMap content patch, so the one resulting
+// rollout picks up both changes together.
 func patchDeploymentAddFleetOAuth2Volume(ctx context.Context, namespace, kubeconfigPath, deploymentName, containerName, mountPath string, writer io.Writer) error {
+	tlsCAMountDir := fleetTLSCAMountDir(filepath.Dir(mountPath))
 	patch := map[string]interface{}{
 		"spec": map[string]interface{}{
 			"template": map[string]interface{}{
@@ -704,6 +731,12 @@ func patchDeploymentAddFleetOAuth2Volume(ctx context.Context, namespace, kubecon
 								"secretName": fleetOAuth2SecretName,
 							},
 						},
+						{
+							"name": "fleet-tls-ca",
+							"configMap": map[string]interface{}{
+								"name": "inter-service-ca",
+							},
+						},
 					},
 					"containers": []map[string]interface{}{
 						{
@@ -712,6 +745,11 @@ func patchDeploymentAddFleetOAuth2Volume(ctx context.Context, namespace, kubecon
 								{
 									"name":      "fleet-oauth2",
 									"mountPath": mountPath,
+									"readOnly":  true,
+								},
+								{
+									"name":      "fleet-tls-ca",
+									"mountPath": tlsCAMountDir,
 									"readOnly":  true,
 								},
 							},
@@ -790,7 +828,7 @@ fleet:
   enabled: true
   mcpGatewayEndpoint: "http://mcp-gateway-istio.gateway-system.svc:8080/mcp"
   mcpGatewayType: kuadrant
-` + fleetOAuth2YAMLBlock(2)
+` + fleetOAuth2YAMLBlock(2, fleetTLSCAFile("/etc/apifrontend"))
 	if err := appendYAMLBlockToConfigMap(ctx, kubeconfigPath, namespace, "apifrontend-config", "config.yaml", fleetBlock, writer); err != nil {
 		return fmt.Errorf("apifrontend-config fleet patch failed: %w", err)
 	}
@@ -812,7 +850,7 @@ fleet:
   enabled: true
   mcpGatewayEndpoint: "http://mcp-gateway-istio.gateway-system.svc:8080/mcp"
   mcpGatewayType: kuadrant
-` + fleetOAuth2YAMLBlock(2)
+` + fleetOAuth2YAMLBlock(2, fleetTLSCAFile("/etc/effectivenessmonitor"))
 	if err := appendYAMLBlockToConfigMap(ctx, kubeconfigPath, namespace, "effectivenessmonitor-config", "effectivenessmonitor.yaml", fleetBlock, writer); err != nil {
 		return fmt.Errorf("effectivenessmonitor-config fleet patch failed: %w", err)
 	}
@@ -834,7 +872,7 @@ func patchWorkflowExecutionConfigForFleet(ctx context.Context, namespace, kubeco
 	fleetBlock := `
 fleet:
   endpoint: "http://mcp-gateway-istio.gateway-system.svc:8080/mcp"
-` + fleetOAuth2YAMLBlock(2)
+` + fleetOAuth2YAMLBlock(2, fleetTLSCAFile("/etc/workflowexecution"))
 	if err := appendYAMLBlockToConfigMap(ctx, kubeconfigPath, namespace, "workflowexecution-config", "workflowexecution.yaml", fleetBlock, writer); err != nil {
 		return fmt.Errorf("workflowexecution-config fleet patch failed: %w", err)
 	}
@@ -2118,7 +2156,7 @@ fleet:
   endpoint: "http://fleetmetadatacache-service.%[1]s.svc.cluster.local:8080"
   mcpGatewayEndpoint: "http://mcp-gateway-istio.gateway-system.svc:8080/mcp"
   mcpGatewayType: kuadrant
-`, namespace) + fleetOAuth2YAMLBlock(2)
+`, namespace) + fleetOAuth2YAMLBlock(2, fleetTLSCAFile("/etc/remediationorchestrator"))
 	patchedConfig := string(currentConfig) + fleetBlock
 
 	patchPayload, err := json.Marshal(map[string]interface{}{


### PR DESCRIPTION
## Summary

- Fixes a production wiring gap (Issue #54 follow-up): `FleetConfig` fields for AF/EM were parsed but never wired into the actual `FleetReaderFactory`/`ClusterRegistry` used by business logic, and GW/RO's config validation didn't enforce that *both* scope-checking (`Backend`/`Endpoint`) and remote-read (`MCPGatewayEndpoint`) config were present together when fleet is enabled (`pkg/fleet.FleetConfig.ValidateFullFederation()`).
- Rebuilds the "fleet" E2E suite's topology so it actually proves this fix: replaces the old loopback-only pattern (every registered cluster identity secretly resolving back to the same primary cluster) with a genuinely separate remote Kind cluster (DD-TEST-013) that `loopback-cluster`/`prod-east`/`prod-west` all bridge to (`AllRegistrationsRemote`).
- Migrates the suite's OIDC provider from DEX to Keycloak, and `kube-mcp-server` to passthrough mode with a real RFC 8693 Standard Token Exchange -- mirroring the already-proven FMC E2E lane (DEX has no Standard Token Exchange, per Spike S17/S20 in `docs/spikes/`).
- Since the shared remote `kube-mcp-server` now requires OAuth2 for every caller, wires OAuth2 credentials (secret + volume mount + config) into all 6 fleet-aware services: AF, EM, GW, RO, SP, WE. AF/EM/WE previously had no fleet config at all in this suite, and SP/WE had no `fleet.endpoint`, meaning their "remote" code paths were never actually exercised.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./test/...` passes
- [x] `golangci-lint run` clean on all touched packages
- [x] New unit tests: `pkg/fleet/fleet_test.go`, `pkg/gateway/config/config_test.go`, `internal/config/remediationorchestrator/config_test.go`
- [x] New wiring integration tests: `cmd/apifrontend/fleet_wiring_test.go`, `cmd/effectivenessmonitor/fleet_wiring_test.go`, `cmd/remediationorchestrator/fleet_wiring_test.go`
- [ ] CI: `FLEET_E2E=true` fleet E2E suite (`test/e2e/fleet/...`) -- validates the full remote-only topology end-to-end (local run blocked by host memory constraints; deferring to CI)
- [ ] CI: FMC E2E regression (`test/e2e/fleetmetadatacache/...`) -- confirms shared helpers (`SetupRemoteClusterForFMC`, `DeployKeycloakInfra`, `patchAPIServerForOIDCConfig`) reused by this change didn't regress the existing lane


Made with [Cursor](https://cursor.com)