### PR TITLE
fix(e2e/fleet): replace Skip() with deterministic hub-only RR fixture

### DIFF
--- a/test/e2e/fleet/12_reconstruction_test.go
+++ b/test/e2e/fleet/12_reconstruction_test.go
@@ -18,12 +18,18 @@ package fleet
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
 
 	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
 	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
@@ -92,10 +98,10 @@ var _ = Describe("E2E-FLEET-CC81-001: Fleet Reconstruction Compliance [CC8.1]", 
 	})
 
 	It("should reconstruct with valid correlation_id", func() {
-		if correlationID == "" {
-			Skip("no fleet RR found in previous test")
-		}
-
+		// No Skip guard here: correlationID is only ever empty if the
+		// preceding ordered spec's Eventually failed, and Ginkgo's Ordered
+		// decorator on the enclosing Describe already skips subsequent specs
+		// automatically when an earlier one in the same container fails.
 		By("Verifying correlation_id in reconstruction response")
 		result, err := dataStorageClient.ReconstructRemediationRequest(ctx, ogenclient.ReconstructRemediationRequestParams{
 			CorrelationID: correlationID,
@@ -109,45 +115,88 @@ var _ = Describe("E2E-FLEET-CC81-001: Fleet Reconstruction Compliance [CC8.1]", 
 
 	Context("reconstruction without fleet cluster context", func() {
 		It("should return empty cluster_name for hub-only RRs", func() {
-			By("Finding a hub-only RR (no ClusterID)")
-			rrList := &remediationv1.RemediationRequestList{}
-			err := k8sClient.List(ctx, rrList, client.InNamespace(namespace))
-			Expect(err).ToNot(HaveOccurred())
-
-			var hubRRName string
-			for _, rr := range rrList.Items {
-				if rr.Spec.ClusterID == "" && rr.Status.OverallPhase != "" {
-					hubRRName = rr.Name
-					break
-				}
+			// Deliberately create a hub-only RR rather than opportunistically
+			// scanning existing RRs for one without spec.clusterID: every RR
+			// in this suite is fleet-scoped (DD-TEST-014: fleet E2E targets
+			// only the remote cluster for reconciliation), so scanning would
+			// never find one and always Skip -- which the project forbids
+			// (no Skip()/pending tests; see AGENTS.md TDD Anti-Patterns).
+			// Submitting a signal with no "cluster" label reproduces the
+			// genuine backward-compatibility case: prometheus_adapter.go
+			// reads spec.clusterID from commonLabels["cluster"], which is
+			// empty here, so resolverForCluster falls back to the local/hub
+			// resolver and the resulting RR's spec.clusterID stays empty.
+			By("Creating a hub-only (non-fleet) target resource on the local/hub cluster")
+			const targetName = "hub-only-reconstruction-target"
+			dep := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      targetName,
+					Namespace: namespace,
+					Labels:    map[string]string{"kubernaut.ai/managed": "true"},
+				},
+				Spec: appsv1.DeploymentSpec{
+					Replicas: ptr.To[int32](0),
+					Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": targetName}},
+					Template: corev1.PodTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": targetName}},
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "app", Image: "busybox:1.36"}},
+						},
+					},
+				},
 			}
-
-			if hubRRName == "" {
-				Skip("no hub-only RR found for backward compatibility test")
+			if createErr := k8sClient.Create(ctx, dep); createErr != nil && !apierrors.IsAlreadyExists(createErr) {
+				Expect(createErr).NotTo(HaveOccurred(), "Failed to create %s fixture", targetName)
 			}
+			DeferCleanup(func() { _ = k8sClient.Delete(context.Background(), dep) })
+
+			By("Submitting a signal with no cluster label to create a hub-only RR")
+			payload := buildPrometheusAlertWithCluster("HubOnlyReconstruction", namespace, "warning",
+				"Deployment", targetName, "")
+			gatewayURL := "http://localhost:30080"
+			_, body := postFleetAlertUntilAccepted(gatewayURL, payload)
+
+			var response map[string]interface{}
+			Expect(json.Unmarshal(body, &response)).To(Succeed())
+			Expect(response["status"]).To(Equal("created"),
+				"Alert should result in a new hub-only RemediationRequest")
+			hubRRName, ok := response["remediationRequestName"].(string)
+			Expect(ok).To(BeTrue(), "Response must contain remediationRequestName")
+
+			By("Waiting for the hub-only RR to be picked up by reconciliation")
+			Eventually(func(g Gomega) {
+				var rr remediationv1.RemediationRequest
+				g.Expect(k8sClient.Get(ctx, client.ObjectKey{
+					Name: hubRRName, Namespace: namespace,
+				}, &rr)).To(Succeed())
+				g.Expect(rr.Spec.ClusterID).To(BeEmpty(), "hub-only RR must not have spec.clusterID set")
+				g.Expect(rr.Status.OverallPhase).To(BeElementOf(
+					remediationv1.PhasePending, remediationv1.PhaseProcessing, remediationv1.PhaseAnalyzing,
+					remediationv1.PhaseAwaitingApproval, remediationv1.PhaseExecuting, remediationv1.PhaseVerifying,
+					remediationv1.PhaseBlocked, remediationv1.PhaseCompleted, remediationv1.PhaseFailed,
+					remediationv1.PhaseTimedOut, remediationv1.PhaseSkipped),
+					"RR must have entered a known reconciliation phase, got %q", rr.Status.OverallPhase)
+			}, timeout, interval).Should(Succeed())
+
+			By("Waiting for audit events to be persisted (async pipeline)")
+			time.Sleep(10 * time.Second)
 
 			By(fmt.Sprintf("Reconstructing hub-only RR: %s", hubRRName))
-			result, err := dataStorageClient.ReconstructRemediationRequest(ctx, ogenclient.ReconstructRemediationRequestParams{
-				CorrelationID: hubRRName,
-			})
-			if err != nil {
-				if strings.Contains(err.Error(), "400") || strings.Contains(err.Error(), "404") {
-					Skip("hub-only RR has no audit events yet")
-				}
-				Expect(err).ToNot(HaveOccurred())
-			}
+			var resp *ogenclient.ReconstructionResponse
+			Eventually(func(g Gomega) {
+				result, err := dataStorageClient.ReconstructRemediationRequest(ctx, ogenclient.ReconstructRemediationRequestParams{
+					CorrelationID: hubRRName,
+				})
+				g.Expect(err).ToNot(HaveOccurred())
+				reconResp, ok := result.(*ogenclient.ReconstructionResponse)
+				g.Expect(ok).To(BeTrue(), "expected ReconstructionResponse, got %T", result)
+				resp = reconResp
+			}, 30*time.Second, 2*time.Second).Should(Succeed())
 
-			reconResp, ok := result.(*ogenclient.ReconstructionResponse)
-			Expect(ok).To(BeTrue())
-
-			Expect(reconResp.ClusterName.Set).To(BeFalse(),
+			Expect(resp.ClusterName.Set).To(BeFalse(),
 				"hub-only RR should not have cluster_name set")
 
 			GinkgoWriter.Printf("Backward compat PASS: hub-only RR %s has no cluster_name\n", hubRRName)
 		})
 	})
 })
-
-// suppressUnused prevents the compiler from complaining about imported but
-// potentially unused symbols when the test file compiles independently.
-var _ context.Context


### PR DESCRIPTION
## Summary

Found while monitoring the post-merge CI run for #1560: `E2E (fleet)` job hit `[SKIPPED]` at `test/e2e/fleet/12_reconstruction_test.go:126` ("should return empty cluster_name for hub-only RRs"). Kubernaut has a hard no-Skip() policy (AGENTS.md TDD Anti-Patterns; `.golangci.yml` forbidigo rule: `Skip() forbidden ... Use Fail() instead`), so this is a real violation, not a benign flake.

## Root cause

The spec opportunistically scanned existing `RemediationRequest`s in the namespace for one without `spec.clusterID` (a "hub-only" RR) to prove the reconstruction API's backward-compat behavior. Since DD-TEST-014 made the `fleet` E2E suite target **only** the remote cluster for all reconciliation, every RR this suite produces is fleet-scoped — the scan could never find a hub-only RR and always hit `Skip("no hub-only RR found for backward compatibility test")`. A second `Skip()` on the reconstruction API returning 400/404 made this worse (masking real errors as "not ready yet").

## Fix

- Submit a Prometheus alert with no `cluster` label so `prometheus_adapter.go`'s `resolverForCluster` falls back to the local/hub resolver and the resulting RR's `spec.clusterID` stays empty — deterministically reproducing the genuine backward-compatibility scenario instead of hoping one already exists.
- Wait via `Eventually` for the RR to be picked up (validated against the known `RemediationPhase` enum via `BeElementOf`, not just non-empty — the forbidigo NULL-TESTING rule flagged the original `ToNot(BeEmpty())` pattern) and for audit persistence, then reconstruct.
- Dropped a second, redundant `Skip()` in the preceding ordered spec: Ginkgo's `Ordered` decorator already auto-skips subsequent specs when an earlier one in the same container fails, so the manual guard was dead code that also violated the policy on paper.

## Test plan

- [x] `go build ./...` and `go build -tags e2e ./...` clean
- [x] `go vet -tags e2e ./test/e2e/fleet/...` clean
- [x] `golangci-lint run --build-tags=e2e ./test/e2e/fleet/...` — 0 issues (confirmed the original `Skip()`/`ToNot(BeEmpty())` patterns are flagged by forbidigo; the rewrite is clean)
- [ ] CI: `E2E (fleet)` — watching for `E2E-FLEET-CC81-001` "should return empty cluster_name for hub-only RRs" to run and pass (not skip)

Made with [Cursor](https://cursor.com)