### PR TITLE
chore: bump Kind CLI to v0.32.0 and kindest/node to v1.36.1

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -956,9 +956,9 @@ jobs:
           sudo apt-get install -y podman
       - name: Load pre-built images (artifact-based, no registry)
         uses: ./.github/actions/load-ci-images
-      - name: Install Kind v0.30.0
+      - name: Install Kind v0.32.0
         run: |
-          KIND_VERSION="v0.30.0"
+          KIND_VERSION="v0.32.0"
           curl -Lo ./kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64"
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
@@ -1177,7 +1177,7 @@ jobs:
 
       - name: Install Kind
         run: |
-          KIND_VERSION="v0.30.0"
+          KIND_VERSION="v0.32.0"
           curl -Lo ./kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64"
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind

--- a/.github/workflows/e2e-test-template.yml
+++ b/.github/workflows/e2e-test-template.yml
@@ -56,12 +56,12 @@ jobs:
       # ========================================
       # Infrastructure Setup
       # ========================================
-      - name: Install Kind v0.30.0
+      - name: Install Kind v0.32.0
         run: |
-          # Install Kind v0.30.0 (required by E2E test infrastructure)
+          # Install Kind v0.32.0 (required by E2E test infrastructure)
           # Authority: test/infrastructure/kind_cluster_helpers.go (version validation)
           # Uses GitHub releases URL (kind.sigs.k8s.io/dl/ returns HTML, not binary)
-          KIND_VERSION="v0.30.0"
+          KIND_VERSION="v0.32.0"
           echo "Installing Kind version: ${KIND_VERSION}"
           curl -Lo ./kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64"
           chmod +x ./kind

--- a/.github/workflows/fleet-e2e-memory-spike.yml
+++ b/.github/workflows/fleet-e2e-memory-spike.yml
@@ -35,9 +35,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      - name: Install Kind v0.30.0
+      - name: Install Kind v0.32.0
         run: |
-          KIND_VERSION="v0.30.0"
+          KIND_VERSION="v0.32.0"
           curl -Lo ./kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64"
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind

--- a/.github/workflows/helm-smoke-test.yml
+++ b/.github/workflows/helm-smoke-test.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Install Kind
         run: |
-          KIND_VERSION="v0.30.0"
+          KIND_VERSION="v0.32.0"
           curl -Lo ./kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64"
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind

--- a/.github/workflows/integration-test-template.yml
+++ b/.github/workflows/integration-test-template.yml
@@ -54,13 +54,13 @@ jobs:
           sudo apt-get install -y podman
           podman --version
 
-      - name: Install Kind v0.30.0
+      - name: Install Kind v0.32.0
         if: inputs.infrastructure == 'kind'
         run: |
-          # Install Kind v0.30.0 (required by integration test infrastructure)
+          # Install Kind v0.32.0 (required by integration test infrastructure)
           # Authority: test/infrastructure/kind_cluster_helpers.go (version validation)
           # Uses GitHub releases URL (kind.sigs.k8s.io/dl/ returns HTML, not binary)
-          KIND_VERSION="v0.30.0"
+          KIND_VERSION="v0.32.0"
           echo "Installing Kind version: ${KIND_VERSION}"
           curl -Lo ./kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64"
           chmod +x ./kind

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -473,7 +473,7 @@ jobs:
 
       - name: Install Kind
         run: |
-          KIND_VERSION="v0.30.0"
+          KIND_VERSION="v0.32.0"
           curl -Lo ./kind "https://github.com/kubernetes-sigs/kind/releases/download/${KIND_VERSION}/kind-linux-amd64"
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind

--- a/charts/kubernaut/README.md
+++ b/charts/kubernaut/README.md
@@ -317,6 +317,17 @@ All values are validated against `values.schema.json`. Run `helm lint` to check 
 | `global.image.pullPolicy` | Image pull policy | `IfNotPresent` |
 | `global.nodeSelector` | Global node selector | `{}` |
 | `global.tolerations` | Global tolerations | `[]` |
+| `global.fleet.mcpGatewayEndpoint` | Shared MCP Gateway endpoint URL, used as fallback when a service's own `fleet.mcpGatewayEndpoint` is unset | `""` |
+| `global.fleet.mcpGatewayType` | Shared MCP Gateway type (`eaigw` or `kuadrant`), used as fallback when a service's own `fleet.mcpGatewayType` is unset | `""` |
+| `global.fleet.tlsCAFile` | Shared CA bundle for verifying the MCP Gateway's TLS cert, used as fallback when a service's own `fleet.tlsCAFile` is unset | `""` |
+| `global.fleet.oauth2.tokenURL` | Shared MCP Gateway OAuth2 token URL, used as fallback when a service's own `fleet.oauth2.tokenURL` is unset | `""` |
+| `global.fleet.oauth2.credentialsSecretRef` | Shared MCP Gateway OAuth2 credentials Secret (keys: `client-id`, `client-secret`), used as fallback | `""` |
+| `global.fleet.oauth2.scopes` | Shared MCP Gateway OAuth2 scopes, used as fallback | `[]` |
+| `global.fleet.oauth2.tlsCAFile` | Shared CA bundle for verifying `tokenURL`'s TLS cert, used as fallback | `""` |
+
+Every fleet-integration-capable service (`gateway`, `signalprocessing`, `remediationorchestrator`, `effectivenessmonitor`, `apifrontend`, `fleetmetadatacache`) points at the same physical MCP Gateway instance, so set its endpoint, type, CA bundle, and OAuth2 credentials once here instead of duplicating them per service. Each service's own `fleet.mcpGatewayEndpoint` / `fleet.mcpGatewayType` / `fleet.tlsCAFile` / `fleet.oauth2.*` (or, for `fleetmetadatacache`, top-level equivalents) still takes precedence when set. Per-service `fleet.enabled` / `fleet.oauth2.enabled` (fleet integration on/off) remains independent per service and is not controlled by these globals.
+
+`gateway.fleet.mcpGatewayEndpoint`, `remediationorchestrator.fleet.mcpGatewayEndpoint`, and `fleetmetadatacache.mcpGatewayEndpoint` are required (directly or via the global fallback) when their respective `fleet.enabled` / `fleetmetadatacache.enabled` is `true` — `helm install`/`upgrade` fails fast with a remediation message if neither is set. It's optional for `effectivenessmonitor` and `apifrontend`, where an empty value just means those services fall back to reading local-cluster-only state instead of federating through the MCP Gateway.
 
 ### Demo Content
 

--- a/charts/kubernaut/README.md
+++ b/charts/kubernaut/README.md
@@ -424,14 +424,16 @@ All LLM configuration is now part of the main `kubernaut-agent-config` ConfigMap
 | Parameter | Description | Default |
 |---|---|---|
 | `tls.mode` | `hook` (self-signed), `cert-manager` (production), or `manual` | `hook` |
-| `tls.certManager.issuerRef.name` | Issuer name (required when mode=cert-manager) | `""` |
+| `tls.certManager.issuerRef.name` | Issuer/ClusterIssuer name. When mode=cert-manager and left empty, auto-selected via `lookup` if exactly one exists in the cluster (real `helm install`/`upgrade` only); required if rendering via `helm template`/GitOps or if multiple issuers exist | `""` |
 
 ### NetworkPolicies
 
 | Parameter | Description | Default |
 |---|---|---|
 | `networkPolicies.enabled` | Enable default-deny NetworkPolicies for all services | `true` |
-| `networkPolicies.apiServerCIDR` | K8s API server CIDR (e.g., `10.96.0.1/32`) | `""` |
+| `networkPolicies.apiServerCIDR` | K8s API server real backend endpoint CIDR (e.g., `10.89.0.2/32` -- NOT the `kubernetes` Service ClusterIP). Usually left empty: auto-discovered via `lookup` on a real `helm install`/`upgrade`; required if rendering via `helm template`/GitOps | `""` |
+| `networkPolicies.apiServerCIDRs` | Additional API server backend endpoint CIDRs for HA (multiple control-plane nodes). Merged with `apiServerCIDR`; usually left empty (see above) | `[]` |
+| `networkPolicies.apiServerPort` | API server backend endpoint port (commonly 6443). `0` = auto-discover alongside the CIDR | `0` |
 | `networkPolicies.monitoring.namespace` | Namespace for Prometheus metrics scraping ingress | `""` |
 | `networkPolicies.monitoring.prometheusPort` | Prometheus port (9090 vanilla, 9091 OCP) | `9090` |
 | `networkPolicies.monitoring.alertManagerPort` | AlertManager port (9093 vanilla, 9094 OCP) | `9093` |
@@ -444,17 +446,26 @@ When enabled, each service gets a NetworkPolicy with:
 - **Egress**: most services restrict egress to DNS, K8s API, and known peers; **Kubernaut Agent uses an ingress-only policy** (unrestricted egress) because it must reach arbitrary LLM providers, MCP servers, and tool endpoints
 - **Datastorage**: allows egress to PostgreSQL, Valkey, and external container registries (configurable CIDR for OCI bundle validation)
 
-Example:
+Example (API server CIDR/port are auto-discovered here; only set them explicitly for `helm template`/GitOps rendering, see [NetworkPolicy API Server Discovery](#networkpolicy-api-server-discovery)):
 
 ```bash
 helm install kubernaut charts/kubernaut \
   --set networkPolicies.enabled=true \
-  --set networkPolicies.apiServerCIDR=10.96.0.1/32 \
   --set networkPolicies.monitoring.namespace=monitoring \
   --set "networkPolicies.gateway.ingressNamespaces[0]=monitoring"
 ```
 
 On OpenShift, the `values-ocp.yaml` overlay sets monitoring ports to 9091/9094.
+
+#### NetworkPolicy API Server Discovery
+
+During a real `helm install`/`upgrade`, the chart auto-discovers the kube-apiserver's real backend endpoint IP(s) and port via `lookup` against the live `kubernetes` Endpoints object, so `networkPolicies.apiServerCIDR(s)`/`apiServerPort` usually don't need to be set. Set them explicitly if:
+
+- **You render via `helm template` for GitOps (ArgoCD, Flux).** These tools render manifests via `helm template` internally, not a live install/upgrade, so `lookup` always returns empty -- auto-discovery never applies.
+- **The Helm installer ServiceAccount lacks permission to read `Endpoints` in the `default` namespace.** The chart fails with a clear error in this case rather than silently omitting the rule.
+- **Auto-discovery picks the wrong address**, or you want to pin a specific one.
+
+If neither an override nor discovery succeeds, `helm install`/`upgrade` fails with remediation instructions (see `kubectl get endpoints kubernetes -o wide` to find the real address manually). Use `apiServerCIDR` for single-control-plane clusters; use `apiServerCIDRs` (a list) for HA clusters with multiple control-plane nodes -- auto-discovery already collects every backend address automatically.
 
 ### Common Controller Parameters
 

--- a/charts/kubernaut/templates/_helpers.tpl
+++ b/charts/kubernaut/templates/_helpers.tpl
@@ -69,6 +69,55 @@ Usage: {{ include "kubernaut.tls.issuerName" . }}
 {{- end }}
 
 {{/*
+Merged fleet OAuth2 config: a service's own fleet.oauth2 fields fall back to
+global.fleet.oauth2 when unset, since every fleet-integration-capable
+service (gateway, signalprocessing, remediationorchestrator,
+effectivenessmonitor, apifrontend, fleetmetadatacache) authenticates to the
+*same* MCP Gateway with the same OAuth2 client in practice -- set it once in
+global.fleet.oauth2 instead of duplicating it per service. Per-service
+`fleet.oauth2.enabled` (fleet integration on/off) is intentionally NOT
+handled here and stays independent per service.
+Named templates can only return a string, so the merged config is
+serialized as YAML -- parse it back with `fromYaml` at the call site.
+Usage:
+  {{- $o := include "kubernaut.fleet.oauth2" (dict "root" $ "svc" .Values.gateway.fleet.oauth2) | fromYaml }}
+  {{ $o.tokenURL }}
+*/}}
+{{- define "kubernaut.fleet.oauth2" -}}
+{{- $g := .root.Values.global.fleet.oauth2 -}}
+{{- $svc := .svc -}}
+{{- dict
+    "tokenURL" ($svc.tokenURL | default $g.tokenURL)
+    "credentialsSecretRef" ($svc.credentialsSecretRef | default $g.credentialsSecretRef)
+    "scopes" ($svc.scopes | default $g.scopes)
+    "tlsCAFile" ($svc.tlsCAFile | default $g.tlsCAFile)
+  | toYaml -}}
+{{- end }}
+
+{{/*
+Merged fleet MCP Gateway config (endpoint/type/CA, distinct from OAuth2
+credentials -- see kubernaut.fleet.oauth2): a service's own
+fleet.mcpGatewayEndpoint/mcpGatewayType/tlsCAFile fall back to
+global.fleet.* when unset, since every fleet-integration-capable service
+points at the *same* physical MCP Gateway instance. Uses sprig `get` (not
+dot access) so this also works for callers whose `svc` dict doesn't declare
+one of these keys at all (e.g. signalprocessing has no top-level
+fleet.tlsCAFile) without erroring.
+Usage:
+  {{- $f := include "kubernaut.fleet.config" (dict "root" $ "svc" .Values.gateway.fleet) | fromYaml }}
+  {{ $f.mcpGatewayEndpoint }}
+*/}}
+{{- define "kubernaut.fleet.config" -}}
+{{- $g := .root.Values.global.fleet -}}
+{{- $svc := .svc -}}
+{{- dict
+    "mcpGatewayEndpoint" ((get $svc "mcpGatewayEndpoint") | default $g.mcpGatewayEndpoint)
+    "mcpGatewayType" ((get $svc "mcpGatewayType") | default $g.mcpGatewayType)
+    "tlsCAFile" ((get $svc "tlsCAFile") | default $g.tlsCAFile)
+  | toYaml -}}
+{{- end }}
+
+{{/*
 Common labels applied to every resource.
 */}}
 {{- define "kubernaut.labels" -}}

--- a/charts/kubernaut/templates/_helpers.tpl
+++ b/charts/kubernaut/templates/_helpers.tpl
@@ -504,17 +504,46 @@ Usage: {{ include "kubernaut.np.dnsEgress" . | nindent 4 }}
 {{- end }}
 
 {{/*
-K8s API server egress rule: allow TCP 443 to configured CIDR.
+Merged, de-duplicated list of API server backend endpoint ipBlock peers, one
+per control-plane node. Most real clusters run multiple control-plane nodes
+for HA, each a distinct backend endpoint behind the "kubernetes" Service --
+ipBlock rules are evaluated against the post-DNAT destination on most CNIs,
+so every backend IP needs its own allow entry, not just one. apiServerCIDR
+(singular) and apiServerCIDRs (list) are merged so single-endpoint callers
+can keep using the simpler singular field. Renders as a raw (unindented)
+list of `- ipBlock: {cidr: ...}` entries usable under either an egress `to:`
+or ingress `from:` key -- shared because NetworkPolicyPeer is identical for
+both. Empty output (no trailing newline) if no CIDR is configured.
+Usage: {{ include "kubernaut.np.apiServerPeers" . | nindent 4 }}
+*/}}
+{{- define "kubernaut.np.apiServerPeers" -}}
+{{- $cidrs := list -}}
+{{- if .Values.networkPolicies.apiServerCIDR -}}
+{{- $cidrs = append $cidrs .Values.networkPolicies.apiServerCIDR -}}
+{{- end -}}
+{{- if .Values.networkPolicies.apiServerCIDRs -}}
+{{- $cidrs = concat $cidrs .Values.networkPolicies.apiServerCIDRs -}}
+{{- end -}}
+{{- $lines := list -}}
+{{- range (uniq $cidrs) -}}
+{{- $lines = append $lines (printf "- ipBlock:\n    cidr: %s" .) -}}
+{{- end -}}
+{{- join "\n" $lines -}}
+{{- end }}
+
+{{/*
+K8s API server egress rule: allow TCP to the configured API server backend
+endpoint CIDR(s). See kubernaut.np.apiServerPeers for the CIDR merge logic.
 Usage: {{ include "kubernaut.np.apiServerEgress" . | nindent 4 }}
 */}}
 {{- define "kubernaut.np.apiServerEgress" -}}
-{{- if .Values.networkPolicies.apiServerCIDR }}
+{{- $peers := include "kubernaut.np.apiServerPeers" . -}}
+{{- if $peers }}
 - ports:
     - port: {{ .Values.networkPolicies.apiServerPort | default 443 }}
       protocol: TCP
   to:
-    - ipBlock:
-        cidr: {{ .Values.networkPolicies.apiServerCIDR }}
+    {{- $peers | nindent 4 }}
 {{- end }}
 {{- end }}
 

--- a/charts/kubernaut/templates/_helpers.tpl
+++ b/charts/kubernaut/templates/_helpers.tpl
@@ -510,7 +510,7 @@ Usage: {{ include "kubernaut.np.apiServerEgress" . | nindent 4 }}
 {{- define "kubernaut.np.apiServerEgress" -}}
 {{- if .Values.networkPolicies.apiServerCIDR }}
 - ports:
-    - port: 443
+    - port: {{ .Values.networkPolicies.apiServerPort | default 443 }}
       protocol: TCP
   to:
     - ipBlock:

--- a/charts/kubernaut/templates/_helpers.tpl
+++ b/charts/kubernaut/templates/_helpers.tpl
@@ -15,6 +15,60 @@ Create a default fully qualified app name.
 {{- end }}
 
 {{/*
+Whether we have real cluster access for `lookup`-based auto-discovery of
+values that would otherwise require an explicit override. During
+`helm template` / `helm install --dry-run=client` -- and for GitOps
+controllers (ArgoCD, Flux) that render manifests via `helm template`
+internally rather than a live install/upgrade -- `lookup` always returns
+empty, so those callers MUST set the relevant override value(s) explicitly;
+auto-discovery only works for a real `helm install`/`upgrade` against a live
+cluster. Mirrors the canary in templates/infrastructure/secrets.yaml.
+Usage: {{ if eq (include "kubernaut.hasClusterAccess" .) "true" }}...{{ end }}
+*/}}
+{{- define "kubernaut.hasClusterAccess" -}}
+{{- if lookup "v1" "Namespace" "" "kube-system" -}}true{{- end -}}
+{{- end }}
+
+{{/*
+cert-manager Issuer/ClusterIssuer name for tls.mode=cert-manager.
+
+Precedence: explicit tls.certManager.issuerRef.name always wins (the only
+path available during `helm template` / GitOps rendering, since `lookup`
+has no live cluster access there). Otherwise, during a real
+`helm install`/`upgrade`, auto-select it if exactly one
+Issuer/ClusterIssuer (per tls.certManager.issuerRef.kind) exists in the
+cluster -- most clusters only run one. Fails loudly with remediation
+instructions if the name can't be determined either way: zero found (no
+cert-manager issuer provisioned), 2+ found (ambiguous -- picking the wrong
+CA silently would be a security-relevant mistake, never guess), or no live
+cluster access (helm template/GitOps must set this explicitly).
+Usage: {{ include "kubernaut.tls.issuerName" . }}
+*/}}
+{{- define "kubernaut.tls.issuerName" -}}
+{{- if .Values.tls.certManager.issuerRef.name -}}
+{{- .Values.tls.certManager.issuerRef.name -}}
+{{- else if eq (include "kubernaut.hasClusterAccess" .) "true" -}}
+{{- $kind := .Values.tls.certManager.issuerRef.kind -}}
+{{- $apiVersion := printf "%s/v1" .Values.tls.certManager.issuerRef.group -}}
+{{- $ns := "" -}}
+{{- if eq $kind "Issuer" -}}{{- $ns = .Release.Namespace -}}{{- end -}}
+{{- $result := lookup $apiVersion $kind $ns "" -}}
+{{- $issuers := ($result.items | default list) -}}
+{{- if eq (len $issuers) 1 -}}
+{{- (index $issuers 0).metadata.name -}}
+{{- else if eq (len $issuers) 0 -}}
+{{- fail (printf "tls.mode=cert-manager but no %s was found and tls.certManager.issuerRef.name is not set. Install cert-manager and create a %s, or set tls.certManager.issuerRef.name explicitly (e.g. \"letsencrypt-prod\" or \"selfsigned-issuer\")." $kind $kind) -}}
+{{- else -}}
+{{- $names := list -}}
+{{- range $issuers -}}{{- $names = append $names .metadata.name -}}{{- end -}}
+{{- fail (printf "tls.mode=cert-manager but tls.certManager.issuerRef.name is not set and multiple %ss exist, so auto-selection is ambiguous. Set tls.certManager.issuerRef.name to one of: %s" $kind (join ", " $names)) -}}
+{{- end -}}
+{{- else -}}
+{{- fail "tls.certManager.issuerRef.name is required when tls.mode=cert-manager and rendering without live cluster access (helm template / GitOps via ArgoCD or Flux always renders this way) -- auto-discovery only works during a real helm install/upgrade." -}}
+{{- end -}}
+{{- end }}
+
+{{/*
 Common labels applied to every resource.
 */}}
 {{- define "kubernaut.labels" -}}
@@ -508,12 +562,25 @@ Merged, de-duplicated list of API server backend endpoint ipBlock peers, one
 per control-plane node. Most real clusters run multiple control-plane nodes
 for HA, each a distinct backend endpoint behind the "kubernetes" Service --
 ipBlock rules are evaluated against the post-DNAT destination on most CNIs,
-so every backend IP needs its own allow entry, not just one. apiServerCIDR
-(singular) and apiServerCIDRs (list) are merged so single-endpoint callers
-can keep using the simpler singular field. Renders as a raw (unindented)
-list of `- ipBlock: {cidr: ...}` entries usable under either an egress `to:`
-or ingress `from:` key -- shared because NetworkPolicyPeer is identical for
-both. Empty output (no trailing newline) if no CIDR is configured.
+so every backend IP needs its own allow entry, not just one (see PR #1571
+investigation trail).
+
+Precedence: explicit networkPolicies.apiServerCIDR (singular) and/or
+apiServerCIDRs (list) always win when set, merged together -- this is the
+only path available during `helm template` / GitOps rendering (ArgoCD,
+Flux), since `lookup` has no live cluster access there. Otherwise, during a
+real `helm install`/`upgrade`, auto-discover every backend address from the
+live "kubernetes" Endpoints object so most users never need to set this at
+all. If neither an override nor discovery succeeds (e.g. the installer
+ServiceAccount lacks permission to read Endpoints), fail loudly with
+remediation instructions rather than silently omitting the rule -- pods
+would otherwise crash-loop against a default-deny NetworkPolicy with no
+indication why.
+
+Renders as a raw (unindented) list of `- ipBlock: {cidr: ...}` entries
+usable under either an egress `to:` or ingress `from:` key -- shared because
+NetworkPolicyPeer is identical for both. Empty output if apiServerCIDR(s) is
+deliberately left unset AND there's no live cluster access (helm template).
 Usage: {{ include "kubernaut.np.apiServerPeers" . | nindent 4 }}
 */}}
 {{- define "kubernaut.np.apiServerPeers" -}}
@@ -524,6 +591,21 @@ Usage: {{ include "kubernaut.np.apiServerPeers" . | nindent 4 }}
 {{- if .Values.networkPolicies.apiServerCIDRs -}}
 {{- $cidrs = concat $cidrs .Values.networkPolicies.apiServerCIDRs -}}
 {{- end -}}
+{{- if not $cidrs -}}
+{{- if eq (include "kubernaut.hasClusterAccess" .) "true" -}}
+{{- $ep := lookup "v1" "Endpoints" "default" "kubernetes" -}}
+{{- if $ep -}}
+{{- range ($ep.subsets | default list) -}}
+{{- range (.addresses | default list) -}}
+{{- $cidrs = append $cidrs (printf "%s/32" .ip) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if not $cidrs -}}
+{{- fail "networkPolicies.enabled=true but could not auto-discover the kube-apiserver endpoint (`lookup \"v1\" \"Endpoints\" \"default\" \"kubernetes\"` returned no addresses -- possible causes: the Helm installer ServiceAccount lacks permission to read Endpoints in the default namespace, or this is an unusual cluster). Set networkPolicies.apiServerCIDR (single control-plane) or networkPolicies.apiServerCIDRs (HA, one entry per control-plane node) explicitly -- see `kubectl get endpoints kubernetes -o wide`." -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
 {{- $lines := list -}}
 {{- range (uniq $cidrs) -}}
 {{- $lines = append $lines (printf "- ipBlock:\n    cidr: %s" .) -}}
@@ -532,15 +614,45 @@ Usage: {{ include "kubernaut.np.apiServerPeers" . | nindent 4 }}
 {{- end }}
 
 {{/*
+Port the API server's backend endpoint(s) listen on (commonly 6443, not the
+"kubernetes" Service's port 443). Precedence: explicit
+networkPolicies.apiServerPort (nonzero) always wins; otherwise, when no
+apiServerCIDR(s) override is set either, auto-discovered from the same live
+Endpoints lookup as kubernaut.np.apiServerPeers; otherwise defaults to 443
+(only correct if the real backend happens to also listen on 443).
+Usage: {{ include "kubernaut.np.apiServerPort" . }}
+*/}}
+{{- define "kubernaut.np.apiServerPort" -}}
+{{- $port := 0 -}}
+{{- if .Values.networkPolicies.apiServerPort -}}
+{{- $port = .Values.networkPolicies.apiServerPort -}}
+{{- else if and (not .Values.networkPolicies.apiServerCIDR) (not .Values.networkPolicies.apiServerCIDRs) (eq (include "kubernaut.hasClusterAccess" .) "true") -}}
+{{- $ep := lookup "v1" "Endpoints" "default" "kubernetes" -}}
+{{- if $ep -}}
+{{- $subsets := $ep.subsets | default list -}}
+{{- if gt (len $subsets) 0 -}}
+{{- $ports := (index $subsets 0).ports | default list -}}
+{{- if gt (len $ports) 0 -}}
+{{- $port = (index $ports 0).port -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- if not $port -}}{{- $port = 443 -}}{{- end -}}
+{{- $port -}}
+{{- end }}
+
+{{/*
 K8s API server egress rule: allow TCP to the configured API server backend
-endpoint CIDR(s). See kubernaut.np.apiServerPeers for the CIDR merge logic.
+endpoint CIDR(s). See kubernaut.np.apiServerPeers for the CIDR discovery
+logic.
 Usage: {{ include "kubernaut.np.apiServerEgress" . | nindent 4 }}
 */}}
 {{- define "kubernaut.np.apiServerEgress" -}}
 {{- $peers := include "kubernaut.np.apiServerPeers" . -}}
 {{- if $peers }}
 - ports:
-    - port: {{ .Values.networkPolicies.apiServerPort | default 443 }}
+    - port: {{ include "kubernaut.np.apiServerPort" . }}
       protocol: TCP
   to:
     {{- $peers | nindent 4 }}

--- a/charts/kubernaut/templates/apifrontend/apifrontend.yaml
+++ b/charts/kubernaut/templates/apifrontend/apifrontend.yaml
@@ -1,10 +1,12 @@
 {{- if .Values.apifrontend.enabled }}
+{{- $apifrontendOauth2 := include "kubernaut.fleet.oauth2" (dict "root" $ "svc" .Values.apifrontend.fleet.oauth2) | fromYaml }}
+{{- $apifrontendFleet := include "kubernaut.fleet.config" (dict "root" $ "svc" .Values.apifrontend.fleet) | fromYaml }}
 {{- if and .Values.apifrontend.fleet.enabled .Values.apifrontend.fleet.oauth2.enabled }}
-{{- if not .Values.apifrontend.fleet.oauth2.tokenURL }}
-{{- fail "apifrontend.fleet.oauth2.tokenURL is required when apifrontend.fleet.oauth2.enabled=true" }}
+{{- if not $apifrontendOauth2.tokenURL }}
+{{- fail "apifrontend.fleet.oauth2.tokenURL is required when apifrontend.fleet.oauth2.enabled=true (set it directly, or set global.fleet.oauth2.tokenURL if shared across services)" }}
 {{- end }}
-{{- if not .Values.apifrontend.fleet.oauth2.credentialsSecretRef }}
-{{- fail "apifrontend.fleet.oauth2.credentialsSecretRef is required when apifrontend.fleet.oauth2.enabled=true (Secret must contain keys: client-id, client-secret)" }}
+{{- if not $apifrontendOauth2.credentialsSecretRef }}
+{{- fail "apifrontend.fleet.oauth2.credentialsSecretRef is required when apifrontend.fleet.oauth2.enabled=true (Secret must contain keys: client-id, client-secret; set it directly, or set global.fleet.oauth2.credentialsSecretRef if shared across services)" }}
 {{- end }}
 {{- end }}
 ---
@@ -76,7 +78,7 @@ rules:
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]
     verbs: ["create"]
-  {{- if eq .Values.apifrontend.fleet.mcpGatewayType "kuadrant" }}
+  {{- if eq $apifrontendFleet.mcpGatewayType "kuadrant" }}
   # BR-FLEET-054: AF's ClusterRegistry watches MCPServerRegistration CRs
   # directly via a dynamic informer when the Kuadrant MCP Gateway is used.
   - apiGroups: ["mcp.kuadrant.io"]
@@ -189,23 +191,23 @@ data:
     {{- if .Values.apifrontend.fleet.enabled }}
     fleet:
       enabled: true
-      mcpGatewayEndpoint: {{ .Values.apifrontend.fleet.mcpGatewayEndpoint | quote }}
-      {{- if .Values.apifrontend.fleet.mcpGatewayType }}
-      mcpGatewayType: {{ .Values.apifrontend.fleet.mcpGatewayType | quote }}
+      mcpGatewayEndpoint: {{ $apifrontendFleet.mcpGatewayEndpoint | quote }}
+      {{- if $apifrontendFleet.mcpGatewayType }}
+      mcpGatewayType: {{ $apifrontendFleet.mcpGatewayType | quote }}
       {{- end }}
-      tlsCAFile: {{ .Values.apifrontend.fleet.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
+      tlsCAFile: {{ $apifrontendFleet.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
       {{- if .Values.apifrontend.fleet.oauth2.enabled }}
       oauth2:
         enabled: true
-        tokenURL: {{ .Values.apifrontend.fleet.oauth2.tokenURL | quote }}
-        credentialsSecretRef: {{ .Values.apifrontend.fleet.oauth2.credentialsSecretRef | quote }}
-        {{- if .Values.apifrontend.fleet.oauth2.scopes }}
+        tokenURL: {{ $apifrontendOauth2.tokenURL | quote }}
+        credentialsSecretRef: {{ $apifrontendOauth2.credentialsSecretRef | quote }}
+        {{- if $apifrontendOauth2.scopes }}
         scopes:
-          {{- range .Values.apifrontend.fleet.oauth2.scopes }}
+          {{- range $apifrontendOauth2.scopes }}
           - {{ . | quote }}
           {{- end }}
         {{- end }}
-        tlsCAFile: {{ .Values.apifrontend.fleet.oauth2.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
+        tlsCAFile: {{ $apifrontendOauth2.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
       {{- end }}
     {{- end }}
 ---
@@ -291,7 +293,7 @@ spec:
               readOnly: true
             {{- if .Values.apifrontend.fleet.oauth2.enabled }}
             - name: oauth2-credentials
-              mountPath: "/etc/apifrontend/{{ .Values.apifrontend.fleet.oauth2.credentialsSecretRef }}"
+              mountPath: "/etc/apifrontend/{{ $apifrontendOauth2.credentialsSecretRef }}"
               readOnly: true
             {{- end }}
             {{- end }}
@@ -336,7 +338,7 @@ spec:
         {{- if .Values.apifrontend.fleet.oauth2.enabled }}
         - name: oauth2-credentials
           secret:
-            secretName: {{ .Values.apifrontend.fleet.oauth2.credentialsSecretRef }}
+            secretName: {{ $apifrontendOauth2.credentialsSecretRef }}
         {{- end }}
         {{- end }}
 ---

--- a/charts/kubernaut/templates/authwebhook/authwebhook.yaml
+++ b/charts/kubernaut/templates/authwebhook/authwebhook.yaml
@@ -149,40 +149,32 @@ spec:
 
               CA_BUNDLE=$(base64 < "$CA_FILE" | tr -d '\n')
 
-              # Issue #1542 follow-up: freshly-created pods can briefly be unable to
-              # reach the in-cluster API server ClusterIP while kube-proxy/CNI finish
-              # wiring up routes (observed with kindest/node:v1.36.1 in CI). kubectl's
-              # own discovery-client retry is slow (~30s per poll, ~2min before giving
-              # up), so a single failed attempt burns most of this init container's
-              # CrashLoopBackOff budget. Poll with a short per-attempt timeout and fast
-              # retry cadence so we converge quickly once networking is up, instead of
-              # relying on Kubernetes' growing CrashLoopBackOff delay between restarts.
-              echo "==> Waiting for API server connectivity..."
-              API_READY=false
-              LAST_ERR=""
-              i=0
-              while [ "$i" -lt 30 ]; do
-                LAST_ERR=$(kubectl get --raw=/healthz --request-timeout=3s 2>&1) && {
-                  API_READY=true
-                  break
-                }
-                i=$((i + 1))
-                sleep 2
-              done
-              if [ "$API_READY" != "true" ]; then
-                # Diagnostic: surface the actual kubectl error (auth/RBAC vs.
-                # network vs. timeout) instead of masking it — a bare "not
-                # reachable" message was indistinguishable from a permissions
-                # error and cost a full CI round-trip to even start narrowing down.
-                echo "ERROR: API server not reachable after 60s of retries. Last error: ${LAST_ERR}"
-                exit 1
-              fi
-              echo "==> API server reachable"
+              # Issue #1542 follow-up: this init container's failures were
+              # initially misdiagnosed as kube-proxy/CNI warm-up races (retry
+              # loops were added and, later, a whole-cluster network-readiness
+              # gate). Instrumenting the retries surfaced the real error:
+              # "The connection to the server localhost:8080 was refused" —
+              # i.e. kubectl's ambient in-cluster config auto-detection was
+              # failing in this image, not the cluster network (verified: all
+              # 12 other pods and kube-proxy/CNI/apiserver logs were healthy
+              # the whole time). Configure the in-cluster API server
+              # explicitly from the mounted service account on every
+              # invocation instead of relying on kubectl auto-detection, and
+              # avoid writing a kubeconfig file since this container's root
+              # filesystem is read-only.
+              KUBE_SA="/var/run/secrets/kubernetes.io/serviceaccount"
+              KUBE_TOKEN=$(cat "${KUBE_SA}/token")
+              kube() {
+                kubectl --server="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}" \
+                  --certificate-authority="${KUBE_SA}/ca.crt" \
+                  --token="${KUBE_TOKEN}" \
+                  "$@"
+              }
 
               patch_webhooks() {
                 KIND="$1"
                 NAME="$2"
-                COUNT=$(kubectl get "$KIND" "$NAME" --request-timeout=10s -o jsonpath='{.webhooks[*].name}' | wc -w | tr -d ' ')
+                COUNT=$(kube get "$KIND" "$NAME" --request-timeout=10s -o jsonpath='{.webhooks[*].name}' | wc -w | tr -d ' ')
                 PATCH="["
                 i=0
                 while [ "$i" -lt "$COUNT" ]; do
@@ -192,7 +184,7 @@ spec:
                 done
                 PATCH="${PATCH}]"
                 echo "  Patching $NAME ($COUNT webhooks)..."
-                kubectl patch "$KIND" "$NAME" --request-timeout=10s --type='json' -p "$PATCH"
+                kube patch "$KIND" "$NAME" --request-timeout=10s --type='json' -p "$PATCH"
               }
 
               echo "==> Init-container: patching webhook caBundle (#377 self-healing)..."

--- a/charts/kubernaut/templates/authwebhook/authwebhook.yaml
+++ b/charts/kubernaut/templates/authwebhook/authwebhook.yaml
@@ -149,32 +149,61 @@ spec:
 
               CA_BUNDLE=$(base64 < "$CA_FILE" | tr -d '\n')
 
-              # Issue #1542 follow-up: this init container's failures were
-              # initially misdiagnosed as kube-proxy/CNI warm-up races (retry
-              # loops were added and, later, a whole-cluster network-readiness
-              # gate). Instrumenting the retries surfaced the real error:
-              # "The connection to the server localhost:8080 was refused" —
-              # i.e. kubectl's ambient in-cluster config auto-detection was
-              # failing in this image, not the cluster network (verified: all
-              # 12 other pods and kube-proxy/CNI/apiserver logs were healthy
-              # the whole time). Configure the in-cluster API server
-              # explicitly from the mounted service account on every
-              # invocation instead of relying on kubectl auto-detection, and
-              # avoid writing a kubeconfig file since this container's root
-              # filesystem is read-only.
+              # Issue #1542 follow-up, round 1: this init container's failures
+              # were initially misdiagnosed as kube-proxy/CNI warm-up races
+              # (a retry loop, then a whole-cluster network-readiness gate).
+              # Instrumenting the retries surfaced "the connection to the
+              # server localhost:8080 was refused" — kubectl's ambient
+              # in-cluster config auto-detection was failing in this image.
+              # Configure the in-cluster API server explicitly from the
+              # mounted service account on every invocation instead of
+              # relying on kubectl auto-detection, and avoid writing a
+              # kubeconfig file since this container's root filesystem is
+              # read-only.
               KUBE_SA="/var/run/secrets/kubernetes.io/serviceaccount"
               KUBE_TOKEN=$(cat "${KUBE_SA}/token")
               kube() {
                 kubectl --server="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}" \
                   --certificate-authority="${KUBE_SA}/ca.crt" \
                   --token="${KUBE_TOKEN}" \
+                  --request-timeout=5s \
                   "$@"
+              }
+
+              # Issue #1542 follow-up, round 2: with the config bug fixed, the
+              # *real* underlying issue became visible directly — genuine
+              # "context deadline exceeded" / connection timeouts reaching
+              # the in-cluster API server ClusterIP that persist for
+              # ~60-90s, recurring on every fresh pod (install, upgrade, and
+              # dev quick-start all hit it, ruling out a one-time cluster
+              # startup warm-up). Long-running controller pods never surface
+              # this: client-go retries silently in the background and their
+              # readiness probes have a generous initialDelaySeconds, so they
+              # just take a little longer to go Ready. This single-shot,
+              # `set -e` init container has no such tolerance, so retry each
+              # kubectl call explicitly with a budget wide enough to span the
+              # observed window instead of failing (and burning a
+              # CrashLoopBackOff cycle) on the first transient timeout.
+              kube_retry() {
+                attempt=0
+                err=""
+                while [ "$attempt" -lt 20 ]; do
+                  if out=$(kube "$@" 2>&1); then
+                    printf '%s\n' "$out"
+                    return 0
+                  fi
+                  err="$out"
+                  attempt=$((attempt + 1))
+                  sleep 3
+                done
+                echo "ERROR: 'kubectl $*' failed after ${attempt} attempts. Last error: ${err}" >&2
+                return 1
               }
 
               patch_webhooks() {
                 KIND="$1"
                 NAME="$2"
-                COUNT=$(kube get "$KIND" "$NAME" --request-timeout=10s -o jsonpath='{.webhooks[*].name}' | wc -w | tr -d ' ')
+                COUNT=$(kube_retry get "$KIND" "$NAME" -o jsonpath='{.webhooks[*].name}' | wc -w | tr -d ' ')
                 PATCH="["
                 i=0
                 while [ "$i" -lt "$COUNT" ]; do
@@ -184,7 +213,7 @@ spec:
                 done
                 PATCH="${PATCH}]"
                 echo "  Patching $NAME ($COUNT webhooks)..."
-                kube patch "$KIND" "$NAME" --request-timeout=10s --type='json' -p "$PATCH"
+                kube_retry patch "$KIND" "$NAME" --type='json' -p "$PATCH"
               }
 
               echo "==> Init-container: patching webhook caBundle (#377 self-healing)..."

--- a/charts/kubernaut/templates/authwebhook/authwebhook.yaml
+++ b/charts/kubernaut/templates/authwebhook/authwebhook.yaml
@@ -149,10 +149,35 @@ spec:
 
               CA_BUNDLE=$(base64 < "$CA_FILE" | tr -d '\n')
 
+              # Issue #1542 follow-up: freshly-created pods can briefly be unable to
+              # reach the in-cluster API server ClusterIP while kube-proxy/CNI finish
+              # wiring up routes (observed with kindest/node:v1.36.1 in CI). kubectl's
+              # own discovery-client retry is slow (~30s per poll, ~2min before giving
+              # up), so a single failed attempt burns most of this init container's
+              # CrashLoopBackOff budget. Poll with a short per-attempt timeout and fast
+              # retry cadence so we converge quickly once networking is up, instead of
+              # relying on Kubernetes' growing CrashLoopBackOff delay between restarts.
+              echo "==> Waiting for API server connectivity..."
+              API_READY=false
+              i=0
+              while [ "$i" -lt 30 ]; do
+                if kubectl get --raw=/healthz --request-timeout=3s >/dev/null 2>&1; then
+                  API_READY=true
+                  break
+                fi
+                i=$((i + 1))
+                sleep 2
+              done
+              if [ "$API_READY" != "true" ]; then
+                echo "ERROR: API server not reachable after 60s of retries"
+                exit 1
+              fi
+              echo "==> API server reachable"
+
               patch_webhooks() {
                 KIND="$1"
                 NAME="$2"
-                COUNT=$(kubectl get "$KIND" "$NAME" -o jsonpath='{.webhooks[*].name}' | wc -w | tr -d ' ')
+                COUNT=$(kubectl get "$KIND" "$NAME" --request-timeout=10s -o jsonpath='{.webhooks[*].name}' | wc -w | tr -d ' ')
                 PATCH="["
                 i=0
                 while [ "$i" -lt "$COUNT" ]; do
@@ -162,7 +187,7 @@ spec:
                 done
                 PATCH="${PATCH}]"
                 echo "  Patching $NAME ($COUNT webhooks)..."
-                kubectl patch "$KIND" "$NAME" --type='json' -p "$PATCH"
+                kubectl patch "$KIND" "$NAME" --request-timeout=10s --type='json' -p "$PATCH"
               }
 
               echo "==> Init-container: patching webhook caBundle (#377 self-healing)..."

--- a/charts/kubernaut/templates/authwebhook/authwebhook.yaml
+++ b/charts/kubernaut/templates/authwebhook/authwebhook.yaml
@@ -159,17 +159,22 @@ spec:
               # relying on Kubernetes' growing CrashLoopBackOff delay between restarts.
               echo "==> Waiting for API server connectivity..."
               API_READY=false
+              LAST_ERR=""
               i=0
               while [ "$i" -lt 30 ]; do
-                if kubectl get --raw=/healthz --request-timeout=3s >/dev/null 2>&1; then
+                LAST_ERR=$(kubectl get --raw=/healthz --request-timeout=3s 2>&1) && {
                   API_READY=true
                   break
-                fi
+                }
                 i=$((i + 1))
                 sleep 2
               done
               if [ "$API_READY" != "true" ]; then
-                echo "ERROR: API server not reachable after 60s of retries"
+                # Diagnostic: surface the actual kubectl error (auth/RBAC vs.
+                # network vs. timeout) instead of masking it — a bare "not
+                # reachable" message was indistinguishable from a permissions
+                # error and cost a full CI round-trip to even start narrowing down.
+                echo "ERROR: API server not reachable after 60s of retries. Last error: ${LAST_ERR}"
                 exit 1
               fi
               echo "==> API server reachable"

--- a/charts/kubernaut/templates/authwebhook/certificate.yaml
+++ b/charts/kubernaut/templates/authwebhook/certificate.yaml
@@ -14,7 +14,7 @@ spec:
     algorithm: RSA
     size: 2048
   issuerRef:
-    name: {{ required "tls.certManager.issuerRef.name is required when tls.mode=cert-manager" .Values.tls.certManager.issuerRef.name }}
+    name: {{ include "kubernaut.tls.issuerName" . }}
     kind: {{ .Values.tls.certManager.issuerRef.kind }}
     group: {{ .Values.tls.certManager.issuerRef.group }}
   dnsNames:

--- a/charts/kubernaut/templates/authwebhook/networkpolicy.yaml
+++ b/charts/kubernaut/templates/authwebhook/networkpolicy.yaml
@@ -15,13 +15,13 @@ spec:
     - Ingress
     - Egress
   ingress:
-    {{- if .Values.networkPolicies.apiServerCIDR }}
+    {{- $peers := include "kubernaut.np.apiServerPeers" . }}
+    {{- if $peers }}
     - ports:
         - port: 9443
           protocol: TCP
       from:
-        - ipBlock:
-            cidr: {{ .Values.networkPolicies.apiServerCIDR }}
+        {{- $peers | nindent 8 }}
     {{- end }}
   egress:
     {{- include "kubernaut.np.commonEgress" . | nindent 4 }}

--- a/charts/kubernaut/templates/effectivenessmonitor/effectivenessmonitor.yaml
+++ b/charts/kubernaut/templates/effectivenessmonitor/effectivenessmonitor.yaml
@@ -1,10 +1,12 @@
 {{- include "kubernaut.monitoring.validate" . -}}
+{{- $effectivenessmonitorOauth2 := include "kubernaut.fleet.oauth2" (dict "root" $ "svc" .Values.effectivenessmonitor.fleet.oauth2) | fromYaml }}
+{{- $effectivenessmonitorFleet := include "kubernaut.fleet.config" (dict "root" $ "svc" .Values.effectivenessmonitor.fleet) | fromYaml }}
 {{- if and .Values.effectivenessmonitor.fleet.enabled .Values.effectivenessmonitor.fleet.oauth2.enabled }}
-{{- if not .Values.effectivenessmonitor.fleet.oauth2.tokenURL }}
-{{- fail "effectivenessmonitor.fleet.oauth2.tokenURL is required when effectivenessmonitor.fleet.oauth2.enabled=true" }}
+{{- if not $effectivenessmonitorOauth2.tokenURL }}
+{{- fail "effectivenessmonitor.fleet.oauth2.tokenURL is required when effectivenessmonitor.fleet.oauth2.enabled=true (set it directly, or set global.fleet.oauth2.tokenURL if shared across services)" }}
 {{- end }}
-{{- if not .Values.effectivenessmonitor.fleet.oauth2.credentialsSecretRef }}
-{{- fail "effectivenessmonitor.fleet.oauth2.credentialsSecretRef is required when effectivenessmonitor.fleet.oauth2.enabled=true (Secret must contain keys: client-id, client-secret)" }}
+{{- if not $effectivenessmonitorOauth2.credentialsSecretRef }}
+{{- fail "effectivenessmonitor.fleet.oauth2.credentialsSecretRef is required when effectivenessmonitor.fleet.oauth2.enabled=true (Secret must contain keys: client-id, client-secret; set it directly, or set global.fleet.oauth2.credentialsSecretRef if shared across services)" }}
 {{- end }}
 {{- end }}
 ---
@@ -48,23 +50,23 @@ data:
     {{- if .Values.effectivenessmonitor.fleet.enabled }}
     fleet:
       enabled: true
-      mcpGatewayEndpoint: {{ .Values.effectivenessmonitor.fleet.mcpGatewayEndpoint | quote }}
-      {{- if .Values.effectivenessmonitor.fleet.mcpGatewayType }}
-      mcpGatewayType: {{ .Values.effectivenessmonitor.fleet.mcpGatewayType | quote }}
+      mcpGatewayEndpoint: {{ $effectivenessmonitorFleet.mcpGatewayEndpoint | quote }}
+      {{- if $effectivenessmonitorFleet.mcpGatewayType }}
+      mcpGatewayType: {{ $effectivenessmonitorFleet.mcpGatewayType | quote }}
       {{- end }}
-      tlsCAFile: {{ .Values.effectivenessmonitor.fleet.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
+      tlsCAFile: {{ $effectivenessmonitorFleet.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
       {{- if .Values.effectivenessmonitor.fleet.oauth2.enabled }}
       oauth2:
         enabled: true
-        tokenURL: {{ .Values.effectivenessmonitor.fleet.oauth2.tokenURL | quote }}
-        credentialsSecretRef: {{ .Values.effectivenessmonitor.fleet.oauth2.credentialsSecretRef | quote }}
-        {{- if .Values.effectivenessmonitor.fleet.oauth2.scopes }}
+        tokenURL: {{ $effectivenessmonitorOauth2.tokenURL | quote }}
+        credentialsSecretRef: {{ $effectivenessmonitorOauth2.credentialsSecretRef | quote }}
+        {{- if $effectivenessmonitorOauth2.scopes }}
         scopes:
-          {{- range .Values.effectivenessmonitor.fleet.oauth2.scopes }}
+          {{- range $effectivenessmonitorOauth2.scopes }}
           - {{ . | quote }}
           {{- end }}
         {{- end }}
-        tlsCAFile: {{ .Values.effectivenessmonitor.fleet.oauth2.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
+        tlsCAFile: {{ $effectivenessmonitorOauth2.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
       {{- end }}
     {{- end }}
 {{/* DEPRECATED v1.4 (Issue #848): OCP service-ca inject-cabundle ConfigMap.
@@ -138,7 +140,7 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  {{- if eq .Values.effectivenessmonitor.fleet.mcpGatewayType "kuadrant" }}
+  {{- if eq $effectivenessmonitorFleet.mcpGatewayType "kuadrant" }}
   # BR-FLEET-054: EM's ClusterRegistry watches MCPServerRegistration CRs
   # directly via a dynamic informer when the Kuadrant MCP Gateway is used.
   - apiGroups: ["mcp.kuadrant.io"]
@@ -279,7 +281,7 @@ spec:
               readOnly: true
             {{- if and .Values.effectivenessmonitor.fleet.enabled .Values.effectivenessmonitor.fleet.oauth2.enabled }}
             - name: oauth2-credentials
-              mountPath: "/etc/effectivenessmonitor/{{ .Values.effectivenessmonitor.fleet.oauth2.credentialsSecretRef }}"
+              mountPath: "/etc/effectivenessmonitor/{{ $effectivenessmonitorOauth2.credentialsSecretRef }}"
               readOnly: true
             {{- end }}
           resources:
@@ -300,7 +302,7 @@ spec:
         {{- if and .Values.effectivenessmonitor.fleet.enabled .Values.effectivenessmonitor.fleet.oauth2.enabled }}
         - name: oauth2-credentials
           secret:
-            secretName: {{ .Values.effectivenessmonitor.fleet.oauth2.credentialsSecretRef }}
+            secretName: {{ $effectivenessmonitorOauth2.credentialsSecretRef }}
         {{- end }}
 {{/* DEPRECATED v1.4 (Issue #848): OCP monitoring RBAC block. Removed in v1.5. */}}
 {{- if include "kubernaut.monitoring.ocpRbac" . }}

--- a/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
+++ b/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
@@ -1,9 +1,14 @@
 {{- if .Values.fleetmetadatacache.enabled }}
-{{- if not .Values.fleetmetadatacache.oauth2.tokenURL }}
-{{- fail "fleetmetadatacache.oauth2.tokenURL is required when fleetmetadatacache.enabled=true — MCP Gateway requires OAuth2 authentication" }}
+{{- $fmcOauth2 := include "kubernaut.fleet.oauth2" (dict "root" $ "svc" .Values.fleetmetadatacache.oauth2) | fromYaml }}
+{{- $fmcFleet := include "kubernaut.fleet.config" (dict "root" $ "svc" .Values.fleetmetadatacache) | fromYaml }}
+{{- if not $fmcFleet.mcpGatewayEndpoint }}
+{{- fail "fleetmetadatacache.mcpGatewayEndpoint is required when fleetmetadatacache.enabled=true — FleetMetadataCache polls remote clusters via the MCP Gateway (set it directly, or set global.fleet.mcpGatewayEndpoint if shared across services)" }}
 {{- end }}
-{{- if not .Values.fleetmetadatacache.oauth2.credentialsSecretRef }}
-{{- fail "fleetmetadatacache.oauth2.credentialsSecretRef is required when fleetmetadatacache.enabled=true (Secret must contain keys: client-id, client-secret)" }}
+{{- if not $fmcOauth2.tokenURL }}
+{{- fail "fleetmetadatacache.oauth2.tokenURL is required when fleetmetadatacache.enabled=true — MCP Gateway requires OAuth2 authentication (set it directly, or set global.fleet.oauth2.tokenURL if shared across services)" }}
+{{- end }}
+{{- if not $fmcOauth2.credentialsSecretRef }}
+{{- fail "fleetmetadatacache.oauth2.credentialsSecretRef is required when fleetmetadatacache.enabled=true (Secret must contain keys: client-id, client-secret; set it directly, or set global.fleet.oauth2.credentialsSecretRef if shared across services)" }}
 {{- end }}
 ---
 apiVersion: v1
@@ -21,7 +26,7 @@ data:
       apiAddr: ":8080"
       metricsAddr: ":8081"
     mcpGateway:
-      endpoint: {{ .Values.fleetmetadatacache.mcpGatewayEndpoint | quote }}
+      endpoint: {{ $fmcFleet.mcpGatewayEndpoint | quote }}
       gatewayType: {{ .Values.fleetmetadatacache.gatewayType | quote }}
       namespace: {{ .Values.fleetmetadatacache.namespace | quote }}
     valkey:
@@ -30,7 +35,7 @@ data:
       interval: {{ .Values.fleetmetadatacache.syncInterval | quote }}
       keyTtl: {{ .Values.fleetmetadatacache.keyTTL | quote }}
     oauth2:
-      tokenUrl: {{ .Values.fleetmetadatacache.oauth2.tokenURL | quote }}
+      tokenUrl: {{ $fmcOauth2.tokenURL | quote }}
       credentialsDir: "/etc/fleetmetadatacache/fleet-oauth2"
 ---
 apiVersion: apps/v1
@@ -104,7 +109,7 @@ spec:
             name: fleetmetadatacache-config
         - name: oauth2-credentials
           secret:
-            secretName: {{ .Values.fleetmetadatacache.oauth2.credentialsSecretRef }}
+            secretName: {{ $fmcOauth2.credentialsSecretRef }}
 ---
 apiVersion: v1
 kind: Service

--- a/charts/kubernaut/templates/gateway/gateway.yaml
+++ b/charts/kubernaut/templates/gateway/gateway.yaml
@@ -1,9 +1,16 @@
-{{- if and .Values.gateway.fleet.enabled .Values.gateway.fleet.oauth2.enabled }}
-{{- if not .Values.gateway.fleet.oauth2.tokenURL }}
-{{- fail "gateway.fleet.oauth2.tokenURL is required when gateway.fleet.oauth2.enabled=true" }}
+{{- $gatewayOauth2 := include "kubernaut.fleet.oauth2" (dict "root" $ "svc" .Values.gateway.fleet.oauth2) | fromYaml }}
+{{- $gatewayFleet := include "kubernaut.fleet.config" (dict "root" $ "svc" .Values.gateway.fleet) | fromYaml }}
+{{- if .Values.gateway.fleet.enabled }}
+{{- if not $gatewayFleet.mcpGatewayEndpoint }}
+{{- fail "gateway.fleet.mcpGatewayEndpoint is required when gateway.fleet.enabled=true (set it directly, or set global.fleet.mcpGatewayEndpoint if shared across services)" }}
 {{- end }}
-{{- if not .Values.gateway.fleet.oauth2.credentialsSecretRef }}
-{{- fail "gateway.fleet.oauth2.credentialsSecretRef is required when gateway.fleet.oauth2.enabled=true (Secret must contain keys: client-id, client-secret)" }}
+{{- if .Values.gateway.fleet.oauth2.enabled }}
+{{- if not $gatewayOauth2.tokenURL }}
+{{- fail "gateway.fleet.oauth2.tokenURL is required when gateway.fleet.oauth2.enabled=true (set it directly, or set global.fleet.oauth2.tokenURL if shared across services)" }}
+{{- end }}
+{{- if not $gatewayOauth2.credentialsSecretRef }}
+{{- fail "gateway.fleet.oauth2.credentialsSecretRef is required when gateway.fleet.oauth2.enabled=true (Secret must contain keys: client-id, client-secret; set it directly, or set global.fleet.oauth2.credentialsSecretRef if shared across services)" }}
+{{- end }}
 {{- end }}
 {{- end }}
 ---
@@ -70,23 +77,23 @@ data:
       {{- else if eq (default "fleetmetadatacache" .Values.gateway.fleet.backend) "fleetmetadatacache" }}
       endpoint: {{ include "kubernaut.fleetmetadatacache.url" . | quote }}
       {{- end }}
-      mcpGatewayEndpoint: {{ .Values.gateway.fleet.mcpGatewayEndpoint | quote }}
-      {{- if .Values.gateway.fleet.mcpGatewayType }}
-      mcpGatewayType: {{ .Values.gateway.fleet.mcpGatewayType | quote }}
+      mcpGatewayEndpoint: {{ $gatewayFleet.mcpGatewayEndpoint | quote }}
+      {{- if $gatewayFleet.mcpGatewayType }}
+      mcpGatewayType: {{ $gatewayFleet.mcpGatewayType | quote }}
       {{- end }}
-      tlsCAFile: {{ .Values.gateway.fleet.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
+      tlsCAFile: {{ $gatewayFleet.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
       {{- if .Values.gateway.fleet.oauth2.enabled }}
       oauth2:
         enabled: true
-        tokenURL: {{ .Values.gateway.fleet.oauth2.tokenURL | quote }}
-        credentialsSecretRef: {{ .Values.gateway.fleet.oauth2.credentialsSecretRef | quote }}
-        {{- if .Values.gateway.fleet.oauth2.scopes }}
+        tokenURL: {{ $gatewayOauth2.tokenURL | quote }}
+        credentialsSecretRef: {{ $gatewayOauth2.credentialsSecretRef | quote }}
+        {{- if $gatewayOauth2.scopes }}
         scopes:
-          {{- range .Values.gateway.fleet.oauth2.scopes }}
+          {{- range $gatewayOauth2.scopes }}
           - {{ . | quote }}
           {{- end }}
         {{- end }}
-        tlsCAFile: {{ .Values.gateway.fleet.oauth2.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
+        tlsCAFile: {{ $gatewayOauth2.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
       {{- end }}
     {{- end }}
 ---
@@ -220,7 +227,7 @@ spec:
               readOnly: true
             {{- if and .Values.gateway.fleet.enabled .Values.gateway.fleet.oauth2.enabled }}
             - name: oauth2-credentials
-              mountPath: "/etc/gateway/{{ .Values.gateway.fleet.oauth2.credentialsSecretRef }}"
+              mountPath: "/etc/gateway/{{ $gatewayOauth2.credentialsSecretRef }}"
               readOnly: true
             {{- end }}
           livenessProbe:
@@ -252,7 +259,7 @@ spec:
         {{- if and .Values.gateway.fleet.enabled .Values.gateway.fleet.oauth2.enabled }}
         - name: oauth2-credentials
           secret:
-            secretName: {{ .Values.gateway.fleet.oauth2.credentialsSecretRef }}
+            secretName: {{ $gatewayOauth2.credentialsSecretRef }}
         {{- end }}
 ---
 apiVersion: v1

--- a/charts/kubernaut/templates/remediationorchestrator/remediationorchestrator.yaml
+++ b/charts/kubernaut/templates/remediationorchestrator/remediationorchestrator.yaml
@@ -1,9 +1,16 @@
-{{- if and .Values.remediationorchestrator.fleet.enabled .Values.remediationorchestrator.fleet.oauth2.enabled }}
-{{- if not .Values.remediationorchestrator.fleet.oauth2.tokenURL }}
-{{- fail "remediationorchestrator.fleet.oauth2.tokenURL is required when remediationorchestrator.fleet.oauth2.enabled=true" }}
+{{- $remediationorchestratorOauth2 := include "kubernaut.fleet.oauth2" (dict "root" $ "svc" .Values.remediationorchestrator.fleet.oauth2) | fromYaml }}
+{{- $remediationorchestratorFleet := include "kubernaut.fleet.config" (dict "root" $ "svc" .Values.remediationorchestrator.fleet) | fromYaml }}
+{{- if .Values.remediationorchestrator.fleet.enabled }}
+{{- if not $remediationorchestratorFleet.mcpGatewayEndpoint }}
+{{- fail "remediationorchestrator.fleet.mcpGatewayEndpoint is required when remediationorchestrator.fleet.enabled=true (set it directly, or set global.fleet.mcpGatewayEndpoint if shared across services)" }}
 {{- end }}
-{{- if not .Values.remediationorchestrator.fleet.oauth2.credentialsSecretRef }}
-{{- fail "remediationorchestrator.fleet.oauth2.credentialsSecretRef is required when remediationorchestrator.fleet.oauth2.enabled=true (Secret must contain keys: client-id, client-secret)" }}
+{{- if .Values.remediationorchestrator.fleet.oauth2.enabled }}
+{{- if not $remediationorchestratorOauth2.tokenURL }}
+{{- fail "remediationorchestrator.fleet.oauth2.tokenURL is required when remediationorchestrator.fleet.oauth2.enabled=true (set it directly, or set global.fleet.oauth2.tokenURL if shared across services)" }}
+{{- end }}
+{{- if not $remediationorchestratorOauth2.credentialsSecretRef }}
+{{- fail "remediationorchestrator.fleet.oauth2.credentialsSecretRef is required when remediationorchestrator.fleet.oauth2.enabled=true (Secret must contain keys: client-id, client-secret; set it directly, or set global.fleet.oauth2.credentialsSecretRef if shared across services)" }}
+{{- end }}
 {{- end }}
 {{- end }}
 ---
@@ -72,23 +79,23 @@ data:
       {{- else if eq (default "fleetmetadatacache" .Values.remediationorchestrator.fleet.backend) "fleetmetadatacache" }}
       endpoint: {{ include "kubernaut.fleetmetadatacache.url" . | quote }}
       {{- end }}
-      mcpGatewayEndpoint: {{ .Values.remediationorchestrator.fleet.mcpGatewayEndpoint | quote }}
-      {{- if .Values.remediationorchestrator.fleet.mcpGatewayType }}
-      mcpGatewayType: {{ .Values.remediationorchestrator.fleet.mcpGatewayType | quote }}
+      mcpGatewayEndpoint: {{ $remediationorchestratorFleet.mcpGatewayEndpoint | quote }}
+      {{- if $remediationorchestratorFleet.mcpGatewayType }}
+      mcpGatewayType: {{ $remediationorchestratorFleet.mcpGatewayType | quote }}
       {{- end }}
-      tlsCAFile: {{ .Values.remediationorchestrator.fleet.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
+      tlsCAFile: {{ $remediationorchestratorFleet.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
       {{- if .Values.remediationorchestrator.fleet.oauth2.enabled }}
       oauth2:
         enabled: true
-        tokenURL: {{ .Values.remediationorchestrator.fleet.oauth2.tokenURL | quote }}
-        credentialsSecretRef: {{ .Values.remediationorchestrator.fleet.oauth2.credentialsSecretRef | quote }}
-        {{- if .Values.remediationorchestrator.fleet.oauth2.scopes }}
+        tokenURL: {{ $remediationorchestratorOauth2.tokenURL | quote }}
+        credentialsSecretRef: {{ $remediationorchestratorOauth2.credentialsSecretRef | quote }}
+        {{- if $remediationorchestratorOauth2.scopes }}
         scopes:
-          {{- range .Values.remediationorchestrator.fleet.oauth2.scopes }}
+          {{- range $remediationorchestratorOauth2.scopes }}
           - {{ . | quote }}
           {{- end }}
         {{- end }}
-        tlsCAFile: {{ .Values.remediationorchestrator.fleet.oauth2.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
+        tlsCAFile: {{ $remediationorchestratorOauth2.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
       {{- end }}
     {{- end }}
 ---
@@ -294,7 +301,7 @@ spec:
               readOnly: true
             {{- if and .Values.remediationorchestrator.fleet.enabled .Values.remediationorchestrator.fleet.oauth2.enabled }}
             - name: oauth2-credentials
-              mountPath: "/etc/remediationorchestrator/{{ .Values.remediationorchestrator.fleet.oauth2.credentialsSecretRef }}"
+              mountPath: "/etc/remediationorchestrator/{{ $remediationorchestratorOauth2.credentialsSecretRef }}"
               readOnly: true
             {{- end }}
           resources:
@@ -310,7 +317,7 @@ spec:
         {{- if and .Values.remediationorchestrator.fleet.enabled .Values.remediationorchestrator.fleet.oauth2.enabled }}
         - name: oauth2-credentials
           secret:
-            secretName: {{ .Values.remediationorchestrator.fleet.oauth2.credentialsSecretRef }}
+            secretName: {{ $remediationorchestratorOauth2.credentialsSecretRef }}
         {{- end }}
 ---
 apiVersion: v1

--- a/charts/kubernaut/templates/signalprocessing/signalprocessing.yaml
+++ b/charts/kubernaut/templates/signalprocessing/signalprocessing.yaml
@@ -1,9 +1,11 @@
+{{- $signalprocessingOauth2 := include "kubernaut.fleet.oauth2" (dict "root" $ "svc" .Values.signalprocessing.fleet.oauth2) | fromYaml }}
+{{- $signalprocessingFleet := include "kubernaut.fleet.config" (dict "root" $ "svc" .Values.signalprocessing.fleet) | fromYaml }}
 {{- if .Values.signalprocessing.fleet.oauth2.enabled }}
-{{- if not .Values.signalprocessing.fleet.oauth2.tokenURL }}
-{{- fail "signalprocessing.fleet.oauth2.tokenURL is required when signalprocessing.fleet.oauth2.enabled=true" }}
+{{- if not $signalprocessingOauth2.tokenURL }}
+{{- fail "signalprocessing.fleet.oauth2.tokenURL is required when signalprocessing.fleet.oauth2.enabled=true (set it directly, or set global.fleet.oauth2.tokenURL if shared across services)" }}
 {{- end }}
-{{- if not .Values.signalprocessing.fleet.oauth2.credentialsSecretRef }}
-{{- fail "signalprocessing.fleet.oauth2.credentialsSecretRef is required when signalprocessing.fleet.oauth2.enabled=true (Secret must contain keys: client-id, client-secret)" }}
+{{- if not $signalprocessingOauth2.credentialsSecretRef }}
+{{- fail "signalprocessing.fleet.oauth2.credentialsSecretRef is required when signalprocessing.fleet.oauth2.enabled=true (Secret must contain keys: client-id, client-secret; set it directly, or set global.fleet.oauth2.credentialsSecretRef if shared across services)" }}
 {{- end }}
 {{- end }}
 {{- if not .Values.signalprocessing.policies.existingConfigMap }}
@@ -74,8 +76,8 @@ data:
     {{- if .Values.signalprocessing.fleet.endpoint }}
     fleet:
       endpoint: {{ .Values.signalprocessing.fleet.endpoint | quote }}
-      {{- if .Values.signalprocessing.fleet.mcpGatewayType }}
-      mcpGatewayType: {{ .Values.signalprocessing.fleet.mcpGatewayType | quote }}
+      {{- if $signalprocessingFleet.mcpGatewayType }}
+      mcpGatewayType: {{ $signalprocessingFleet.mcpGatewayType | quote }}
       {{- end }}
       {{- if .Values.signalprocessing.fleet.namespace }}
       namespace: {{ .Values.signalprocessing.fleet.namespace | quote }}
@@ -83,15 +85,15 @@ data:
       {{- if .Values.signalprocessing.fleet.oauth2.enabled }}
       oauth2:
         enabled: true
-        tokenURL: {{ .Values.signalprocessing.fleet.oauth2.tokenURL | quote }}
-        credentialsSecretRef: {{ .Values.signalprocessing.fleet.oauth2.credentialsSecretRef | quote }}
-        {{- if .Values.signalprocessing.fleet.oauth2.scopes }}
+        tokenURL: {{ $signalprocessingOauth2.tokenURL | quote }}
+        credentialsSecretRef: {{ $signalprocessingOauth2.credentialsSecretRef | quote }}
+        {{- if $signalprocessingOauth2.scopes }}
         scopes:
-          {{- range .Values.signalprocessing.fleet.oauth2.scopes }}
+          {{- range $signalprocessingOauth2.scopes }}
           - {{ . | quote }}
           {{- end }}
         {{- end }}
-        tlsCAFile: {{ .Values.signalprocessing.fleet.oauth2.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
+        tlsCAFile: {{ $signalprocessingOauth2.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
       {{- end }}
     {{- end }}
 ---
@@ -138,7 +140,7 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  {{- if eq .Values.signalprocessing.fleet.mcpGatewayType "kuadrant" }}
+  {{- if eq $signalprocessingFleet.mcpGatewayType "kuadrant" }}
   # BR-FLEET-003 (#1511): SP's ClusterRegistry watches MCPServerRegistration
   # CRs directly via a dynamic informer to evaluate the `cluster`
   # classification dimension when the Kuadrant MCP Gateway is used.
@@ -242,7 +244,7 @@ spec:
               readOnly: true
             {{- if .Values.signalprocessing.fleet.oauth2.enabled }}
             - name: oauth2-credentials
-              mountPath: "/etc/signalprocessing/{{ .Values.signalprocessing.fleet.oauth2.credentialsSecretRef }}"
+              mountPath: "/etc/signalprocessing/{{ $signalprocessingOauth2.credentialsSecretRef }}"
               readOnly: true
             {{- end }}
           resources:
@@ -264,7 +266,7 @@ spec:
         {{- if .Values.signalprocessing.fleet.oauth2.enabled }}
         - name: oauth2-credentials
           secret:
-            secretName: {{ .Values.signalprocessing.fleet.oauth2.credentialsSecretRef }}
+            secretName: {{ $signalprocessingOauth2.credentialsSecretRef }}
         {{- end }}
 ---
 apiVersion: v1

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -177,6 +177,54 @@
           "items": { "$ref": "#/definitions/toleration" },
           "default": [],
           "description": "Pod tolerations"
+        },
+        "fleet": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "mcpGatewayEndpoint": {
+              "type": "string",
+              "default": "",
+              "description": "Shared MCP Gateway endpoint URL, used as the fallback when a service's own fleet.mcpGatewayEndpoint is unset"
+            },
+            "mcpGatewayType": {
+              "type": "string",
+              "default": "",
+              "description": "Shared MCP Gateway type (eaigw or kuadrant), used as the fallback when a service's own fleet.mcpGatewayType is unset"
+            },
+            "tlsCAFile": {
+              "type": "string",
+              "default": "",
+              "description": "Shared CA bundle path for verifying the MCP Gateway's TLS certificate, used as the fallback when a service's own fleet.tlsCAFile is unset"
+            },
+            "oauth2": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "tokenURL": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Shared OAuth2 token URL for MCP Gateway authentication, used as the fallback when a service's own fleet.oauth2.tokenURL is unset"
+                },
+                "credentialsSecretRef": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Shared Secret name (keys: client-id, client-secret) for MCP Gateway OAuth2, used as the fallback when a service's own fleet.oauth2.credentialsSecretRef is unset"
+                },
+                "scopes": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "default": [],
+                  "description": "Shared OAuth2 scopes for MCP Gateway authentication, used as the fallback when a service's own fleet.oauth2.scopes is unset"
+                },
+                "tlsCAFile": {
+                  "type": "string",
+                  "default": "",
+                  "description": "Shared CA bundle path for verifying tokenURL's TLS certificate, used as the fallback when a service's own fleet.oauth2.tlsCAFile is unset"
+                }
+              }
+            }
+          }
         }
       }
     },
@@ -361,9 +409,9 @@
             "enabled": { "type": "boolean", "default": false },
             "backend": { "type": "string", "default": "", "description": "Backend adapter: fleetmetadatacache or acm" },
             "endpoint": { "type": "string", "default": "", "description": "Endpoint for the selected backend" },
-            "mcpGatewayEndpoint": { "type": "string", "default": "", "description": "MCP Gateway endpoint URL for federated scope checks" },
-            "mcpGatewayType": { "type": "string", "default": "", "description": "MCP Gateway type: eaigw or kuadrant" },
-            "tlsCAFile": { "type": "string", "default": "", "description": "Path to a CA bundle for verifying the MCP Gateway's TLS certificate; defaults to the shared inter-service CA when empty" },
+            "mcpGatewayEndpoint": { "type": "string", "default": "", "description": "MCP Gateway endpoint URL for federated scope checks. Required when fleet.enabled=true; falls back to global.fleet.mcpGatewayEndpoint when unset" },
+            "mcpGatewayType": { "type": "string", "default": "", "description": "MCP Gateway type: eaigw or kuadrant. Falls back to global.fleet.mcpGatewayType when unset" },
+            "tlsCAFile": { "type": "string", "default": "", "description": "Path to a CA bundle for verifying the MCP Gateway's TLS certificate. Falls back to global.fleet.tlsCAFile, then to the shared inter-service CA, when unset" },
             "oauth2": { "$ref": "#/definitions/fleetOAuth2" }
           }
         }
@@ -537,7 +585,7 @@
           "additionalProperties": false,
           "properties": {
             "endpoint": { "type": "string", "default": "", "description": "MCP Gateway endpoint URL for remote cluster resource reads" },
-            "mcpGatewayType": { "type": "string", "default": "", "description": "MCP Gateway type: eaigw or kuadrant; required to evaluate the cluster classification dimension" },
+            "mcpGatewayType": { "type": "string", "default": "", "description": "MCP Gateway type: eaigw or kuadrant; required to evaluate the cluster classification dimension. Falls back to global.fleet.mcpGatewayType when unset" },
             "namespace": { "type": "string", "default": "", "description": "Restricts the ClusterRegistry CRD watch; empty watches all namespaces" },
             "oauth2": { "$ref": "#/definitions/fleetOAuth2" }
           }
@@ -660,9 +708,9 @@
             "enabled": { "type": "boolean", "default": false },
             "backend": { "type": "string", "default": "", "description": "Backend adapter: fleetmetadatacache or acm" },
             "endpoint": { "type": "string", "default": "", "description": "Endpoint for the selected backend" },
-            "mcpGatewayEndpoint": { "type": "string", "default": "", "description": "MCP Gateway endpoint URL for reading remote resource specs (spec hash)" },
-            "mcpGatewayType": { "type": "string", "default": "", "description": "MCP Gateway type: eaigw or kuadrant" },
-            "tlsCAFile": { "type": "string", "default": "", "description": "Path to a CA bundle for verifying the MCP Gateway's TLS certificate; defaults to the shared inter-service CA when empty" },
+            "mcpGatewayEndpoint": { "type": "string", "default": "", "description": "MCP Gateway endpoint URL for reading remote resource specs (spec hash). Required when fleet.enabled=true; falls back to global.fleet.mcpGatewayEndpoint when unset" },
+            "mcpGatewayType": { "type": "string", "default": "", "description": "MCP Gateway type: eaigw or kuadrant. Falls back to global.fleet.mcpGatewayType when unset" },
+            "tlsCAFile": { "type": "string", "default": "", "description": "Path to a CA bundle for verifying the MCP Gateway's TLS certificate. Falls back to global.fleet.tlsCAFile, then to the shared inter-service CA, when unset" },
             "oauth2": { "$ref": "#/definitions/fleetOAuth2" }
           }
         }
@@ -809,9 +857,9 @@
           "additionalProperties": false,
           "properties": {
             "enabled": { "type": "boolean", "default": false },
-            "mcpGatewayEndpoint": { "type": "string", "default": "", "description": "MCP Gateway endpoint URL for remote cluster reads" },
-            "mcpGatewayType": { "type": "string", "default": "", "description": "MCP Gateway type: eaigw or kuadrant" },
-            "tlsCAFile": { "type": "string", "default": "", "description": "Path to a CA bundle for verifying the MCP Gateway's TLS certificate; defaults to the shared inter-service CA when empty" },
+            "mcpGatewayEndpoint": { "type": "string", "default": "", "description": "MCP Gateway endpoint URL for remote cluster reads. Optional; falls back to global.fleet.mcpGatewayEndpoint when unset" },
+            "mcpGatewayType": { "type": "string", "default": "", "description": "MCP Gateway type: eaigw or kuadrant. Falls back to global.fleet.mcpGatewayType when unset" },
+            "tlsCAFile": { "type": "string", "default": "", "description": "Path to a CA bundle for verifying the MCP Gateway's TLS certificate. Falls back to global.fleet.tlsCAFile, then to the shared inter-service CA, when unset" },
             "oauth2": { "$ref": "#/definitions/fleetOAuth2" }
           }
         },
@@ -925,25 +973,6 @@
                     }
                   }
                 }
-              }
-            }
-          }
-        },
-        "fleet": {
-          "type": "object",
-          "description": "Multi-cluster fleet configuration (ADR-065)",
-          "additionalProperties": false,
-          "properties": {
-            "endpoint": { "type": "string", "default": "", "description": "MCP Gateway endpoint URL" },
-            "oauth2": {
-              "type": "object",
-              "additionalProperties": false,
-              "properties": {
-                "enabled": { "type": "boolean", "default": false },
-                "tokenURL": { "type": "string", "default": "" },
-                "clientID": { "type": "string", "default": "" },
-                "clientSecretFile": { "type": "string", "default": "" },
-                "credentialsSecretRef": { "type": "string", "default": "", "description": "K8s Secret with keys: client-id, client-secret" }
               }
             }
           }
@@ -1085,7 +1114,7 @@
         },
         "syncInterval": { "type": "string", "default": "30s" },
         "keyTTL": { "type": "string", "default": "45s" },
-        "mcpGatewayEndpoint": { "type": "string", "default": "" },
+        "mcpGatewayEndpoint": { "type": "string", "default": "", "description": "Required when fleetmetadatacache.enabled=true; falls back to global.fleet.mcpGatewayEndpoint when unset" },
         "gatewayType": { "type": "string", "enum": ["eaigw", "kuadrant"], "default": "eaigw", "description": "MCP Gateway type: eaigw (Envoy AI Gateway) or kuadrant (Kuadrant MCP Gateway)" },
         "valkeyAddr": { "type": "string", "default": "" },
         "namespace": { "type": "string", "default": "kubernaut-system" },
@@ -1124,9 +1153,9 @@
           "additionalProperties": false,
           "properties": {
             "enabled": { "type": "boolean", "default": false },
-            "mcpGatewayEndpoint": { "type": "string", "default": "", "description": "MCP Gateway endpoint URL for remote cluster reads" },
-            "mcpGatewayType": { "type": "string", "default": "", "description": "MCP Gateway type: eaigw or kuadrant" },
-            "tlsCAFile": { "type": "string", "default": "", "description": "Path to a CA bundle for verifying the MCP Gateway's TLS certificate; defaults to the shared inter-service CA when empty" },
+            "mcpGatewayEndpoint": { "type": "string", "default": "", "description": "MCP Gateway endpoint URL for remote cluster reads. Optional; falls back to global.fleet.mcpGatewayEndpoint when unset" },
+            "mcpGatewayType": { "type": "string", "default": "", "description": "MCP Gateway type: eaigw or kuadrant. Falls back to global.fleet.mcpGatewayType when unset" },
+            "tlsCAFile": { "type": "string", "default": "", "description": "Path to a CA bundle for verifying the MCP Gateway's TLS certificate. Falls back to global.fleet.tlsCAFile, then to the shared inter-service CA, when unset" },
             "oauth2": { "$ref": "#/definitions/fleetOAuth2" }
           }
         },

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -1314,7 +1314,12 @@
         "apiServerCIDR": {
           "type": "string",
           "default": "",
-          "description": "K8s API server CIDR (e.g., 10.96.0.1/32)"
+          "description": "K8s API server real backend endpoint IP as a /32 CIDR (e.g., 10.89.0.2/32) -- NOT the 'kubernetes' Service ClusterIP, which most CNIs ignore for NetworkPolicy egress. See `kubectl get endpoints kubernetes -o wide`."
+        },
+        "apiServerPort": {
+          "type": "integer",
+          "default": 443,
+          "description": "Port the K8s API server's real backend endpoint listens on (commonly 6443), not necessarily the 'kubernetes' Service's port (443)"
         },
         "monitoring": {
           "type": "object",

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -1314,12 +1314,18 @@
         "apiServerCIDR": {
           "type": "string",
           "default": "",
-          "description": "K8s API server real backend endpoint IP as a /32 CIDR (e.g., 10.89.0.2/32) -- NOT the 'kubernetes' Service ClusterIP, which most CNIs ignore for NetworkPolicy egress. See `kubectl get endpoints kubernetes -o wide`."
+          "description": "K8s API server real backend endpoint IP as a /32 CIDR (e.g., 10.89.0.2/32) -- NOT the 'kubernetes' Service ClusterIP, which most CNIs ignore for NetworkPolicy egress. See `kubectl get endpoints kubernetes -o wide`. Use for single-control-plane clusters; use apiServerCIDRs for HA."
+        },
+        "apiServerCIDRs": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Additional K8s API server backend endpoint IPs as /32 CIDRs, for HA clusters with multiple control-plane nodes. Merged with apiServerCIDR."
         },
         "apiServerPort": {
           "type": "integer",
           "default": 443,
-          "description": "Port the K8s API server's real backend endpoint listens on (commonly 6443), not necessarily the 'kubernetes' Service's port (443)"
+          "description": "Port the K8s API server's real backend endpoint(s) listen on (commonly 6443), not necessarily the 'kubernetes' Service's port (443)"
         },
         "monitoring": {
           "type": "object",

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -212,7 +212,7 @@
                 "name": {
                   "type": "string",
                   "default": "",
-                  "description": "Name of the Issuer or ClusterIssuer (required when tls.mode=cert-manager)"
+                  "description": "Name of the Issuer or ClusterIssuer. Usually left empty when tls.mode=cert-manager: auto-selected via `lookup` if exactly one exists in the cluster. Set explicitly for helm template/GitOps rendering or when multiple issuers exist."
                 },
                 "kind": {
                   "type": "string",
@@ -1314,18 +1314,18 @@
         "apiServerCIDR": {
           "type": "string",
           "default": "",
-          "description": "K8s API server real backend endpoint IP as a /32 CIDR (e.g., 10.89.0.2/32) -- NOT the 'kubernetes' Service ClusterIP, which most CNIs ignore for NetworkPolicy egress. See `kubectl get endpoints kubernetes -o wide`. Use for single-control-plane clusters; use apiServerCIDRs for HA."
+          "description": "K8s API server real backend endpoint IP as a /32 CIDR (e.g., 10.89.0.2/32) -- NOT the 'kubernetes' Service ClusterIP, which most CNIs ignore for NetworkPolicy egress. Usually left empty: auto-discovered via `lookup` during a real helm install/upgrade. Set explicitly only for helm template/GitOps rendering, restricted-RBAC installers, or to override discovery. Use for single-control-plane clusters; use apiServerCIDRs for HA."
         },
         "apiServerCIDRs": {
           "type": "array",
           "items": { "type": "string" },
           "default": [],
-          "description": "Additional K8s API server backend endpoint IPs as /32 CIDRs, for HA clusters with multiple control-plane nodes. Merged with apiServerCIDR."
+          "description": "Additional K8s API server backend endpoint IPs as /32 CIDRs, for HA clusters with multiple control-plane nodes. Merged with apiServerCIDR. Usually left empty (see apiServerCIDR)."
         },
         "apiServerPort": {
           "type": "integer",
-          "default": 443,
-          "description": "Port the K8s API server's real backend endpoint(s) listen on (commonly 6443), not necessarily the 'kubernetes' Service's port (443)"
+          "default": 0,
+          "description": "Port the K8s API server's real backend endpoint(s) listen on (commonly 6443), not necessarily the 'kubernetes' Service's port (443). 0 means auto-discover via `lookup` (falls back to 443 if unavailable)."
         },
         "monitoring": {
           "type": "object",

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -697,10 +697,20 @@ networkPolicies:
   # must be the kube-apiserver's real backend endpoint IP (see
   # `kubectl get endpoints kubernetes -o wide`), NOT the "kubernetes"
   # Service's ClusterIP -- the ClusterIP is silently ignored by most
-  # implementations. See PR #1571 for the investigation trail.
+  # implementations. See PR #1571 for the investigation trail. Use this
+  # field for single-control-plane clusters; use apiServerCIDRs below for HA.
   apiServerCIDR: ""
-  # -- Port the kube-apiserver's real backend endpoint listens on (commonly
-  # 6443), not necessarily the "kubernetes" Service's port (443).
+  # -- Additional API server backend endpoint IPs as /32 CIDRs, for HA
+  # clusters (the norm for real production deployments) where the
+  # "kubernetes" Service fronts multiple control-plane nodes -- every
+  # backend IP needs its own allow rule. Merged with apiServerCIDR above.
+  # Populate from all addresses in `kubectl get endpoints kubernetes -o
+  # jsonpath='{.subsets[0].addresses[*].ip}'`.
+  apiServerCIDRs: []
+  # -- Port the kube-apiserver's real backend endpoint(s) listen on (commonly
+  # 6443), not necessarily the "kubernetes" Service's port (443). Assumes all
+  # control-plane nodes listen on the same port, which holds for standard
+  # kubeadm HA setups.
   apiServerPort: 443
   monitoring:
     namespace: ""

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -26,7 +26,13 @@ tls:
   mode: hook  # "hook", "cert-manager", or "manual"
   certManager:
     issuerRef:
-      name: ""    # required when tls.mode=cert-manager (e.g., "letsencrypt-prod" or "selfsigned-issuer")
+      # -- Usually safe to leave empty when tls.mode=cert-manager: during a
+      # real `helm install`/`upgrade`, the chart auto-selects the cluster's
+      # Issuer/ClusterIssuer via `lookup` if exactly one exists. Set this
+      # explicitly (e.g., "letsencrypt-prod" or "selfsigned-issuer") if you
+      # render via `helm template` for GitOps (ArgoCD, Flux), have multiple
+      # issuers, or want to pin a specific one.
+      name: ""
       kind: ClusterIssuer
       group: cert-manager.io
   # Issue #753: Inter-service TLS is always enabled (mandatory).
@@ -692,26 +698,40 @@ monitoring:
 # -- NetworkPolicies: default-deny with explicit allow rules (Issue #285)
 networkPolicies:
   enabled: true
-  # -- CAUTION: on most CNIs (kindnetd, Calico, Cilium, etc.) NetworkPolicy
-  # ipBlock rules are evaluated against the post-DNAT destination, so this
-  # must be the kube-apiserver's real backend endpoint IP (see
-  # `kubectl get endpoints kubernetes -o wide`), NOT the "kubernetes"
-  # Service's ClusterIP -- the ClusterIP is silently ignored by most
-  # implementations. See PR #1571 for the investigation trail. Use this
-  # field for single-control-plane clusters; use apiServerCIDRs below for HA.
+  # -- Usually safe to leave empty: during a real `helm install`/`upgrade`,
+  # the chart auto-discovers the kube-apiserver's real backend endpoint
+  # IP(s) via `lookup` against the live "kubernetes" Endpoints object, so
+  # most users never need to set this. Set it explicitly only if:
+  #   (a) you render manifests via `helm template` for GitOps (ArgoCD,
+  #       Flux) -- `lookup` has no live cluster access in that mode, or
+  #   (b) the Helm installer ServiceAccount lacks permission to read
+  #       Endpoints in the default namespace, or
+  #   (c) auto-discovery picks the wrong address for some other reason.
+  # CAUTION if setting manually: on most CNIs (kindnetd, Calico, Cilium,
+  # etc.) NetworkPolicy ipBlock rules are evaluated against the post-DNAT
+  # destination, so this must be the kube-apiserver's real backend endpoint
+  # IP (see `kubectl get endpoints kubernetes -o wide`), NOT the
+  # "kubernetes" Service's ClusterIP -- the ClusterIP is silently ignored by
+  # most implementations. See PR #1571 for the investigation trail. Use
+  # this field for single-control-plane clusters; use apiServerCIDRs below
+  # for HA (setting either disables auto-discovery for both).
   apiServerCIDR: ""
   # -- Additional API server backend endpoint IPs as /32 CIDRs, for HA
   # clusters (the norm for real production deployments) where the
   # "kubernetes" Service fronts multiple control-plane nodes -- every
   # backend IP needs its own allow rule. Merged with apiServerCIDR above.
-  # Populate from all addresses in `kubectl get endpoints kubernetes -o
-  # jsonpath='{.subsets[0].addresses[*].ip}'`.
+  # Only needed in the same cases as apiServerCIDR above (auto-discovery
+  # already collects every backend address, not just one). If setting
+  # manually, populate from all addresses in `kubectl get endpoints
+  # kubernetes -o jsonpath='{.subsets[0].addresses[*].ip}'`.
   apiServerCIDRs: []
   # -- Port the kube-apiserver's real backend endpoint(s) listen on (commonly
-  # 6443), not necessarily the "kubernetes" Service's port (443). Assumes all
-  # control-plane nodes listen on the same port, which holds for standard
-  # kubeadm HA setups.
-  apiServerPort: 443
+  # 6443, not the "kubernetes" Service's port 443). 0 means "auto": use the
+  # port from the same live Endpoints lookup as apiServerCIDR (falling back
+  # to 443 only if that's unavailable too, e.g. `helm template`/GitOps).
+  # Assumes all control-plane nodes listen on the same port, which holds for
+  # standard kubeadm HA setups.
+  apiServerPort: 0
   monitoring:
     namespace: ""
     prometheusPort: 9090

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -9,6 +9,36 @@ global:
   imagePullSecrets: []
   nodeSelector: {}
   tolerations: []
+  # -- Shared MCP Gateway configuration, used by every fleet-integration-
+  # capable service (gateway, signalprocessing, remediationorchestrator,
+  # effectivenessmonitor, apifrontend, fleetmetadatacache). All of these
+  # point at the *same* physical MCP Gateway instance, so in practice they
+  # share one endpoint/type/CA/OAuth2 client -- set it once here instead of
+  # duplicating it per service. Each service's own `fleet.*` (or, for
+  # fleetmetadatacache, top-level equivalents) still takes precedence when
+  # set, for the rare case a service needs a different value. Per-service
+  # `fleet.enabled` / `fleet.oauth2.enabled` (fleet integration on/off)
+  # remains independent and is NOT controlled here.
+  fleet:
+    # -- Shared MCP Gateway endpoint URL, used as the fallback when a
+    # service's own fleet.mcpGatewayEndpoint is unset.
+    mcpGatewayEndpoint: ""  # e.g., "http://envoy-ai-gateway.kubernaut-system.svc:8080/mcp"
+    # -- Shared MCP Gateway type ("eaigw" or "kuadrant"), used as the
+    # fallback when a service's own fleet.mcpGatewayType is unset.
+    mcpGatewayType: ""
+    # -- Shared CA bundle path for verifying the MCP Gateway's TLS
+    # certificate, used as the fallback when a service's own
+    # fleet.tlsCAFile is unset. Defaults to the shared inter-service CA
+    # (/etc/tls-ca/ca.crt) when left empty everywhere.
+    tlsCAFile: ""
+    oauth2:
+      tokenURL: ""
+      credentialsSecretRef: ""
+      scopes: []
+      # -- Path to a CA bundle for verifying tokenURL's TLS certificate.
+      # Defaults to the shared inter-service CA (/etc/tls-ca/ca.crt) when
+      # left empty, same as each service's own oauth2.tlsCAFile fallback.
+      tlsCAFile: ""
 
 nameOverride: ""
 fullnameOverride: ""
@@ -114,13 +144,16 @@ gateway:
     backend: ""
     # -- Endpoint for the selected backend. Auto-derived for fleetmetadatacache; required for acm.
     endpoint: ""
-    # -- MCP Gateway endpoint URL for federated scope checks. Required when fleet.enabled=true.
+    # -- MCP Gateway endpoint URL for federated scope checks. Required when
+    # fleet.enabled=true; falls back to global.fleet.mcpGatewayEndpoint when unset.
     mcpGatewayEndpoint: ""  # e.g., "http://envoy-ai-gateway.kubernaut-system.svc:8080/mcp"
-    # -- MCP Gateway type: "eaigw" (Envoy AI Gateway) or "kuadrant" (Kuadrant MCP Gateway).
+    # -- MCP Gateway type: "eaigw" (Envoy AI Gateway) or "kuadrant" (Kuadrant MCP
+    # Gateway). Falls back to global.fleet.mcpGatewayType when unset.
     mcpGatewayType: ""
     # -- Path to a CA bundle for verifying the MCP Gateway's TLS certificate when it
-    # presents one not signed by a public/system CA. Defaults to the shared
-    # inter-service CA already mounted at /etc/tls-ca/ca.crt when left empty.
+    # presents one not signed by a public/system CA. Falls back to
+    # global.fleet.tlsCAFile, then to the shared inter-service CA already mounted
+    # at /etc/tls-ca/ca.crt, when unset.
     tlsCAFile: ""
     # -- OAuth2 client credentials for MCP Gateway authentication.
     oauth2:
@@ -260,7 +293,7 @@ signalprocessing:
   # informer (see the RBAC grant below).
   fleet:
     endpoint: ""       # e.g., "http://envoy-ai-gateway.kubernaut-system.svc:8080/mcp"
-    mcpGatewayType: "" # "eaigw" or "kuadrant"
+    mcpGatewayType: "" # "eaigw" or "kuadrant"; falls back to global.fleet.mcpGatewayType when unset
     namespace: ""      # restricts the ClusterRegistry CRD watch; empty watches all namespaces
     oauth2:
       enabled: false
@@ -330,13 +363,16 @@ remediationorchestrator:
     backend: ""
     # -- Endpoint for the selected backend. Auto-derived for fleetmetadatacache; required for acm.
     endpoint: ""
-    # -- MCP Gateway endpoint URL for reading remote resource specs (spec hash). Required when fleet.enabled=true.
+    # -- MCP Gateway endpoint URL for reading remote resource specs (spec hash).
+    # Required when fleet.enabled=true; falls back to global.fleet.mcpGatewayEndpoint when unset.
     mcpGatewayEndpoint: ""  # e.g., "http://envoy-ai-gateway.kubernaut-system.svc:8080/mcp"
-    # -- MCP Gateway type: "eaigw" (Envoy AI Gateway) or "kuadrant" (Kuadrant MCP Gateway).
+    # -- MCP Gateway type: "eaigw" (Envoy AI Gateway) or "kuadrant" (Kuadrant MCP
+    # Gateway). Falls back to global.fleet.mcpGatewayType when unset.
     mcpGatewayType: ""
     # -- Path to a CA bundle for verifying the MCP Gateway's TLS certificate when it
-    # presents one not signed by a public/system CA. Defaults to the shared
-    # inter-service CA already mounted at /etc/tls-ca/ca.crt when left empty.
+    # presents one not signed by a public/system CA. Falls back to
+    # global.fleet.tlsCAFile, then to the shared inter-service CA already
+    # mounted at /etc/tls-ca/ca.crt, when unset.
     tlsCAFile: ""
     # -- OAuth2 client credentials for MCP Gateway authentication.
     oauth2:
@@ -432,10 +468,12 @@ effectivenessmonitor:
   # CRs directly via a ClusterRegistry informer (see the RBAC grant below).
   fleet:
     enabled: false
+    # -- Optional: falls back to global.fleet.mcpGatewayEndpoint when unset.
     mcpGatewayEndpoint: ""  # e.g., "http://envoy-ai-gateway.kubernaut-system.svc:8080/mcp"
-    mcpGatewayType: ""      # "eaigw" or "kuadrant"
-    # -- Path to a CA bundle for verifying the MCP Gateway's TLS certificate. Defaults
-    # to the shared inter-service CA already mounted at /etc/tls-ca/ca.crt when left empty.
+    mcpGatewayType: ""      # "eaigw" or "kuadrant"; falls back to global.fleet.mcpGatewayType when unset
+    # -- Path to a CA bundle for verifying the MCP Gateway's TLS certificate. Falls
+    # back to global.fleet.tlsCAFile, then to the shared inter-service CA already
+    # mounted at /etc/tls-ca/ca.crt, when unset.
     tlsCAFile: ""
     oauth2:
       enabled: false
@@ -543,18 +581,6 @@ kubernautAgent:
     #   model: "gpt-4o-mini"
     #   endpoint: ""
     #   apiKey: ""
-  # -- Multi-cluster fleet configuration (ADR-065).
-  # When enabled, KA discovers remote cluster tools via the MCP Gateway's
-  # tools/list and registers them as BridgeTools alongside local K8s tools.
-  # Requires an external MCP Gateway (Envoy AI Gateway) to be deployed separately.
-  fleet:
-    # -- MCP Gateway endpoint URL. Empty disables fleet integration.
-    endpoint: ""  # e.g., "http://envoy-ai-gateway.kubernaut-system.svc:8080"
-    # -- OAuth2 client credentials for MCP Gateway authentication.
-    oauth2:
-      enabled: false
-      tokenURL: ""              # e.g., "https://dex.kubernaut-system.svc/token"
-      credentialsSecretRef: ""  # K8s Secret with keys: client-id, client-secret
 
 # -- AuthWebhook admission controller
 authwebhook:
@@ -640,6 +666,9 @@ fleetmetadatacache:
     pullPolicy: IfNotPresent
   syncInterval: "30s"
   keyTTL: "45s"
+  # -- Required when fleetmetadatacache.enabled=true (this service's entire
+  # purpose is polling remote clusters via the MCP Gateway); falls back to
+  # global.fleet.mcpGatewayEndpoint when unset.
   mcpGatewayEndpoint: ""  # e.g., "http://envoy-ai-gateway.kubernaut-system.svc:8080/mcp"
   gatewayType: "eaigw"  # MCP Gateway type: "eaigw" (Envoy AI Gateway) or "kuadrant" (Kuadrant MCP Gateway)
   valkeyAddr: ""  # e.g., "valkey:6379" — uses shared Valkey instance
@@ -786,10 +815,12 @@ apifrontend:
   # ClusterRegistry informer (see the RBAC grant below).
   fleet:
     enabled: false
+    # -- Optional: falls back to global.fleet.mcpGatewayEndpoint when unset.
     mcpGatewayEndpoint: ""  # e.g., "http://envoy-ai-gateway.kubernaut-system.svc:8080/mcp"
-    mcpGatewayType: ""      # "eaigw" or "kuadrant"
-    # -- Path to a CA bundle for verifying the MCP Gateway's TLS certificate. Defaults
-    # to the shared inter-service CA already mounted at /etc/tls-ca/ca.crt when left empty.
+    mcpGatewayType: ""      # "eaigw" or "kuadrant"; falls back to global.fleet.mcpGatewayType when unset
+    # -- Path to a CA bundle for verifying the MCP Gateway's TLS certificate. Falls
+    # back to global.fleet.tlsCAFile, then to the shared inter-service CA already
+    # mounted at /etc/tls-ca/ca.crt, when unset.
     tlsCAFile: ""
     oauth2:
       enabled: false

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -692,7 +692,16 @@ monitoring:
 # -- NetworkPolicies: default-deny with explicit allow rules (Issue #285)
 networkPolicies:
   enabled: true
+  # -- CAUTION: on most CNIs (kindnetd, Calico, Cilium, etc.) NetworkPolicy
+  # ipBlock rules are evaluated against the post-DNAT destination, so this
+  # must be the kube-apiserver's real backend endpoint IP (see
+  # `kubectl get endpoints kubernetes -o wide`), NOT the "kubernetes"
+  # Service's ClusterIP -- the ClusterIP is silently ignored by most
+  # implementations. See PR #1571 for the investigation trail.
   apiServerCIDR: ""
+  # -- Port the kube-apiserver's real backend endpoint listens on (commonly
+  # 6443), not necessarily the "kubernetes" Service's port (443).
+  apiServerPort: 443
   monitoring:
     namespace: ""
     prometheusPort: 9090

--- a/deploy/apifrontend/overlays/e2e/kind-config.yaml
+++ b/deploy/apifrontend/overlays/e2e/kind-config.yaml
@@ -2,4 +2,4 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-    image: kindest/node:v1.32.5@sha256:e3b2327e3a5ab8c76f5ece68936e4cafaa82edf58486b769727ab0b3b97a5b0d
+    image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5  # K8s 1.36.1 (kind v0.32.0 default); matches client-go/controller-runtime v0.36 baseline

--- a/docs/architecture/decisions/DD-CICD-001-optimized-parallel-test-strategy.md
+++ b/docs/architecture/decisions/DD-CICD-001-optimized-parallel-test-strategy.md
@@ -203,7 +203,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install Kind
         run: |
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.30.0/kind-linux-amd64
+          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.32.0/kind-linux-amd64
           chmod +x ./kind && sudo mv ./kind /usr/local/bin/kind
       - name: Run gateway integration tests
         run: make test-integration-gateway-service
@@ -454,7 +454,7 @@ jobs:
           go-version: '1.21'
       - name: Install Kind
         run: |
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.30.0/kind-linux-amd64
+          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.32.0/kind-linux-amd64
           chmod +x ./kind && sudo mv ./kind /usr/local/bin/kind
       - name: Run gateway integration tests
         run: make test-integration-gateway-service

--- a/docs/services/crd-controllers/standards/make-targets-and-infrastructure.md
+++ b/docs/services/crd-controllers/standards/make-targets-and-infrastructure.md
@@ -358,7 +358,7 @@ make cleanup-integration-env-<service>
 [Service-specific env vars listed above]
 
 **Dependencies**:
-- Kind: `brew install kind` (macOS) or `curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.30.0/kind-linux-amd64`
+- Kind: `brew install kind` (macOS) or `curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.32.0/kind-linux-amd64`
 - Podman: `brew install podman` (macOS) or `sudo apt-get install podman` (Linux)
 - kubectl: Standard Kubernetes CLI
 
@@ -420,7 +420,7 @@ jobs:
 
       - name: Install Kind
         run: |
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.30.0/kind-linux-amd64
+          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.32.0/kind-linux-amd64
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
 
@@ -445,7 +445,7 @@ jobs:
 
       - name: Install Kind
         run: |
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.30.0/kind-linux-amd64
+          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.32.0/kind-linux-amd64
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
 

--- a/docs/testing/INTEGRATION_TEST_INFRASTRUCTURE.md
+++ b/docs/testing/INTEGRATION_TEST_INFRASTRUCTURE.md
@@ -385,7 +385,7 @@ jobs:
           go-version: '1.22'
       - name: Install Kind
         run: |
-          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.30.0/kind-linux-amd64
+          curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.32.0/kind-linux-amd64
           chmod +x ./kind
           sudo mv ./kind /usr/local/bin/kind
       - name: Run Dynamic Toolset Tests

--- a/scripts/helm-smoke-test.sh
+++ b/scripts/helm-smoke-test.sh
@@ -346,74 +346,6 @@ cleanup_port_forward() {
 }
 
 # ---------------------------------------------------------------------------
-# Cluster network readiness gate
-# ---------------------------------------------------------------------------
-# Issue #1542 follow-up: on a freshly-created Kind cluster, pods can briefly be
-# unable to reach the in-cluster API server ClusterIP while kube-proxy/CNI
-# finish wiring up routes (observed with kindest/node:v1.36.1 in CI: kube-proxy
-# and the API server report ready almost immediately, but pod-to-ClusterIP
-# routing can still take 1-3 minutes to stabilize). This job creates a bare
-# Kind cluster with no other workloads deployed first, so the full chart's 13
-# pods land in that window. Run a real in-cluster probe pod (not just a host
-# `kubectl` check, which talks to the API server's exposed port directly and
-# doesn't exercise the same pod-network-namespace path) and wait for it to
-# succeed before deploying the chart, instead of finding out via CrashLoopBackOff
-# once every app pod hits the same problem. Best-effort: never fails the run,
-# it only buys the network more time to stabilize before deploying real pods.
-# Bounded to ~150s total so a genuinely broken cluster still fails fast via
-# the existing pod-readiness checks instead of hanging here indefinitely.
-wait_for_cluster_network_ready() {
-  if [[ "$PLATFORM" != "kind" ]]; then
-    return 0
-  fi
-
-  local probe_image
-  probe_image=$(grep -A5 'tlsCerts:' "$CHART_PATH/values.yaml" | grep 'image:' | awk '{print $2}' | head -1)
-  if [[ -z "$probe_image" ]]; then
-    echo "# WARNING: could not determine probe image, skipping cluster network readiness gate"
-    return 0
-  fi
-
-  echo "# Waiting for in-cluster pod networking to reach the API server (kube-proxy/CNI warm-up)..."
-  kubectl delete pod netcheck -n default --ignore-not-found --force --grace-period=0 >/dev/null 2>&1 || true
-
-  # Retry INSIDE a single long-lived pod rather than creating/destroying many
-  # short-lived pods and polling from the host: pod scheduling + container
-  # start + kubectl binary startup overhead (1-3s per attempt) otherwise
-  # dominates a short host-side polling window and makes the gate measure
-  # pod-creation noise instead of actual network reachability.
-  kubectl run netcheck -n default --image="$probe_image" --restart=Never \
-    --command -- /bin/sh -c '
-      i=0
-      err=""
-      while [ "$i" -lt 60 ]; do
-        err=$(kubectl get --raw=/healthz --request-timeout=3s 2>&1) && exit 0
-        i=$((i + 1))
-        sleep 2
-      done
-      echo "netcheck: /healthz still unreachable after ${i} attempts, last error: ${err}"
-      exit 1
-    ' >/dev/null 2>&1
-
-  local wait_result=0
-  kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/netcheck -n default --timeout=150s >/dev/null 2>&1 || wait_result=$?
-
-  # Diagnostic: capture the probe's own output regardless of outcome, so a
-  # failure is self-explanatory from this job's log alone instead of requiring
-  # a must-gather round-trip to learn *why* /healthz was unreachable.
-  echo "# netcheck probe output:"
-  kubectl logs pod/netcheck -n default 2>&1 | sed 's/^/#   /' || true
-
-  if [[ "$wait_result" -eq 0 ]]; then
-    echo "# In-cluster networking is ready"
-  else
-    echo "# WARNING: in-cluster networking did not confirm ready within the wait budget; proceeding anyway"
-  fi
-  kubectl delete pod netcheck -n default --ignore-not-found --force --grace-period=0 >/dev/null 2>&1 || true
-  return 0
-}
-
-# ---------------------------------------------------------------------------
 # Cleanup helper
 # ---------------------------------------------------------------------------
 full_cleanup() {
@@ -1635,10 +1567,6 @@ main() {
 
   # Template tests run first (no cluster required)
   run_template_tests
-
-  # Give a freshly-created Kind cluster's CNI/kube-proxy a chance to finish
-  # wiring up pod-to-ClusterIP routing before we deploy any real workloads.
-  wait_for_cluster_network_ready
 
   # Always start clean
   full_cleanup

--- a/scripts/helm-smoke-test.sh
+++ b/scripts/helm-smoke-test.sh
@@ -384,6 +384,23 @@ common_install_flags() {
   flags+=" --set monitoring.alertManager.enabled=false"
   if [[ "$PLATFORM" == "kind" ]]; then
     flags+=" --set global.image.pullPolicy=IfNotPresent"
+    # Issue #1542 follow-up, round 3: networkPolicies.enabled defaults to
+    # true, but kubernaut.np.apiServerEgress (the rule that allows egress to
+    # the Kubernetes API server) is a no-op unless apiServerCIDR is set —
+    # this smoke test's template-rendering tests already assumed
+    # 10.96.0.1/32 (Kind's default "kubernetes" Service ClusterIP) but this
+    # value was never actually wired into the real `helm install` used
+    # against the live cluster. That gap went unnoticed because Kind's
+    # default CNI (kindnetd) only started enforcing NetworkPolicy objects as
+    # of kind v0.24.0; bumping to v0.32.0 here made the gap bite for real.
+    # See PR #1571 investigation for the full root-cause trail (initially
+    # misdiagnosed as a kube-proxy/CNI warm-up race). NOTE: every other
+    # NetworkPolicy-protected service has this same gap and is currently
+    # only unaffected because their controller-runtime managers appear to
+    # establish their one persistent API connection early enough to avoid
+    # being blocked — this is not something to rely on; the same
+    # apiServerCIDR gap likely needs addressing chart-wide as a follow-up.
+    flags+=" --set networkPolicies.apiServerCIDR=10.96.0.1/32"
   fi
   echo "$flags"
 }

--- a/scripts/helm-smoke-test.sh
+++ b/scripts/helm-smoke-test.sh
@@ -37,9 +37,11 @@ PF_PID=""
 POLICY_AA_FILE=""
 POLICY_SP_FILE=""
 
-# Real kube-apiserver backend endpoint (populated by discover_api_server_endpoint
-# for kind only), used to wire networkPolicies.apiServerCIDR/apiServerPort.
-API_SERVER_CIDR=""
+# Real kube-apiserver backend endpoint(s) (populated by
+# discover_api_server_endpoint for kind only), used to wire
+# networkPolicies.apiServerCIDRs/apiServerPort. An array because HA clusters
+# have one backend IP per control-plane node.
+API_SERVER_CIDRS=()
 API_SERVER_PORT=""
 
 # ---------------------------------------------------------------------------
@@ -373,11 +375,11 @@ full_cleanup() {
 }
 
 # ---------------------------------------------------------------------------
-# Discover the kube-apiserver's real backend endpoint (kind only)
+# Discover the kube-apiserver's real backend endpoint(s) (kind only)
 # ---------------------------------------------------------------------------
 # Issue #1542 follow-up, round 3: NetworkPolicies are now enforced by Kind's
 # CNI (kindnetd, as of kind v0.24.0+), but kubernaut.np.apiServerEgress is a
-# no-op unless networkPolicies.apiServerCIDR is set -- so authwebhook's
+# no-op unless networkPolicies.apiServerCIDR(s) is set -- so authwebhook's
 # patch-cabundle init container (and, latently, every other
 # NetworkPolicy-protected controller) has no egress path to the API server.
 #
@@ -389,21 +391,31 @@ full_cleanup() {
 # `kubectl get endpoints kubernetes`) must be used instead. That endpoint is
 # only known once the cluster exists, so it can't be a chart default -- this
 # smoke test discovers it dynamically after cluster creation.
+#
+# The chart is generic (not Kind-specific) and must work against any real
+# Kubernetes distribution, where multiple control-plane nodes (HA) is the
+# norm -- each is a distinct backend IP behind the "kubernetes" Service, so
+# ALL addresses are collected here, not just the first (Kind's single-node
+# smoke test cluster happens to only ever have one, but the discovery logic
+# itself must not assume that).
 discover_api_server_endpoint() {
   [[ "$PLATFORM" == "kind" ]] || return 0
 
-  local ip port
-  ip=$(kubectl get endpoints kubernetes -n default -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null || true)
+  local ips port
+  ips=$(kubectl get endpoints kubernetes -n default -o jsonpath='{.subsets[0].addresses[*].ip}' 2>/dev/null || true)
   port=$(kubectl get endpoints kubernetes -n default -o jsonpath='{.subsets[0].ports[0].port}' 2>/dev/null || true)
 
-  if [[ -z "$ip" || -z "$port" ]]; then
+  if [[ -z "$ips" || -z "$port" ]]; then
     echo "# WARNING: could not discover kube-apiserver endpoint; NetworkPolicy egress to the API server will not be allowed (pods behind default-deny NetworkPolicies will fail)"
     return 0
   fi
 
-  API_SERVER_CIDR="${ip}/32"
+  local ip
+  for ip in $ips; do
+    API_SERVER_CIDRS+=("${ip}/32")
+  done
   API_SERVER_PORT="$port"
-  echo "# Discovered kube-apiserver endpoint: ${API_SERVER_CIDR}:${API_SERVER_PORT}"
+  echo "# Discovered kube-apiserver endpoint(s): ${API_SERVER_CIDRS[*]} (port ${API_SERVER_PORT})"
 }
 
 # ---------------------------------------------------------------------------
@@ -423,9 +435,12 @@ common_install_flags() {
   flags+=" --set monitoring.alertManager.enabled=false"
   if [[ "$PLATFORM" == "kind" ]]; then
     flags+=" --set global.image.pullPolicy=IfNotPresent"
-    if [[ -n "$API_SERVER_CIDR" ]]; then
-      flags+=" --set networkPolicies.apiServerCIDR=${API_SERVER_CIDR}"
+    if [[ "${#API_SERVER_CIDRS[@]}" -gt 0 ]]; then
       flags+=" --set networkPolicies.apiServerPort=${API_SERVER_PORT}"
+      local i
+      for i in "${!API_SERVER_CIDRS[@]}"; do
+        flags+=" --set networkPolicies.apiServerCIDRs[${i}]=${API_SERVER_CIDRS[$i]}"
+      done
     fi
   fi
   echo "$flags"

--- a/scripts/helm-smoke-test.sh
+++ b/scripts/helm-smoke-test.sh
@@ -346,6 +346,62 @@ cleanup_port_forward() {
 }
 
 # ---------------------------------------------------------------------------
+# Cluster network readiness gate
+# ---------------------------------------------------------------------------
+# Issue #1542 follow-up: on a freshly-created Kind cluster, pods can briefly be
+# unable to reach the in-cluster API server ClusterIP while kube-proxy/CNI
+# finish wiring up routes (observed with kindest/node:v1.36.1 in CI: kube-proxy
+# and the API server report ready almost immediately, but pod-to-ClusterIP
+# routing can still take 1-3 minutes to stabilize). This job creates a bare
+# Kind cluster with no other workloads deployed first, so the full chart's 13
+# pods land in that window. Run a real in-cluster probe pod (not just a host
+# `kubectl` check, which talks to the API server's exposed port directly and
+# doesn't exercise the same pod-network-namespace path) and wait for it to
+# succeed before deploying the chart, instead of finding out via CrashLoopBackOff
+# once every app pod hits the same problem. Best-effort: never fails the run,
+# it only buys the network more time to stabilize before deploying real pods.
+wait_for_cluster_network_ready() {
+  if [[ "$PLATFORM" != "kind" ]]; then
+    return 0
+  fi
+
+  local probe_image
+  probe_image=$(grep -A5 'tlsCerts:' "$CHART_PATH/values.yaml" | grep 'image:' | awk '{print $2}' | head -1)
+  if [[ -z "$probe_image" ]]; then
+    echo "# WARNING: could not determine probe image, skipping cluster network readiness gate"
+    return 0
+  fi
+
+  echo "# Waiting for in-cluster pod networking to reach the API server (kube-proxy/CNI warm-up)..."
+  local attempt phase
+  for attempt in $(seq 1 20); do
+    kubectl delete pod netcheck -n default --ignore-not-found --force --grace-period=0 >/dev/null 2>&1 || true
+    kubectl run netcheck -n default --image="$probe_image" --restart=Never \
+      --command -- kubectl get --raw=/healthz --request-timeout=3s >/dev/null 2>&1 || true
+
+    phase=""
+    local waited=0
+    while [[ "$waited" -lt 8 ]]; do
+      phase=$(kubectl get pod netcheck -n default -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
+      [[ "$phase" == "Succeeded" || "$phase" == "Failed" ]] && break
+      sleep 1
+      waited=$((waited + 1))
+    done
+
+    if [[ "$phase" == "Succeeded" ]]; then
+      echo "# In-cluster networking is ready (attempt ${attempt}/20)"
+      kubectl delete pod netcheck -n default --ignore-not-found --force --grace-period=0 >/dev/null 2>&1 || true
+      return 0
+    fi
+    sleep 2
+  done
+
+  echo "# WARNING: in-cluster networking did not confirm ready after 20 attempts; proceeding anyway"
+  kubectl delete pod netcheck -n default --ignore-not-found --force --grace-period=0 >/dev/null 2>&1 || true
+  return 0
+}
+
+# ---------------------------------------------------------------------------
 # Cleanup helper
 # ---------------------------------------------------------------------------
 full_cleanup() {
@@ -1567,6 +1623,10 @@ main() {
 
   # Template tests run first (no cluster required)
   run_template_tests
+
+  # Give a freshly-created Kind cluster's CNI/kube-proxy a chance to finish
+  # wiring up pod-to-ClusterIP routing before we deploy any real workloads.
+  wait_for_cluster_network_ready
 
   # Always start clean
   full_cleanup

--- a/scripts/helm-smoke-test.sh
+++ b/scripts/helm-smoke-test.sh
@@ -37,6 +37,11 @@ PF_PID=""
 POLICY_AA_FILE=""
 POLICY_SP_FILE=""
 
+# Real kube-apiserver backend endpoint (populated by discover_api_server_endpoint
+# for kind only), used to wire networkPolicies.apiServerCIDR/apiServerPort.
+API_SERVER_CIDR=""
+API_SERVER_PORT=""
+
 # ---------------------------------------------------------------------------
 # Argument parsing
 # ---------------------------------------------------------------------------
@@ -368,6 +373,40 @@ full_cleanup() {
 }
 
 # ---------------------------------------------------------------------------
+# Discover the kube-apiserver's real backend endpoint (kind only)
+# ---------------------------------------------------------------------------
+# Issue #1542 follow-up, round 3: NetworkPolicies are now enforced by Kind's
+# CNI (kindnetd, as of kind v0.24.0+), but kubernaut.np.apiServerEgress is a
+# no-op unless networkPolicies.apiServerCIDR is set -- so authwebhook's
+# patch-cabundle init container (and, latently, every other
+# NetworkPolicy-protected controller) has no egress path to the API server.
+#
+# Round 3a naively pointed apiServerCIDR at the "kubernetes" Service's
+# ClusterIP (10.96.0.1/32) -- this is a well-documented dead end: ipBlock
+# egress rules are evaluated against the post-DNAT destination on most CNIs
+# (kindnetd, Calico, Cilium all confirmed), so the ClusterIP is silently
+# never matched. The API server's *real* backend endpoint IP:port (from
+# `kubectl get endpoints kubernetes`) must be used instead. That endpoint is
+# only known once the cluster exists, so it can't be a chart default -- this
+# smoke test discovers it dynamically after cluster creation.
+discover_api_server_endpoint() {
+  [[ "$PLATFORM" == "kind" ]] || return 0
+
+  local ip port
+  ip=$(kubectl get endpoints kubernetes -n default -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null || true)
+  port=$(kubectl get endpoints kubernetes -n default -o jsonpath='{.subsets[0].ports[0].port}' 2>/dev/null || true)
+
+  if [[ -z "$ip" || -z "$port" ]]; then
+    echo "# WARNING: could not discover kube-apiserver endpoint; NetworkPolicy egress to the API server will not be allowed (pods behind default-deny NetworkPolicies will fail)"
+    return 0
+  fi
+
+  API_SERVER_CIDR="${ip}/32"
+  API_SERVER_PORT="$port"
+  echo "# Discovered kube-apiserver endpoint: ${API_SERVER_CIDR}:${API_SERVER_PORT}"
+}
+
+# ---------------------------------------------------------------------------
 # Platform-specific install flags
 # ---------------------------------------------------------------------------
 common_install_flags() {
@@ -384,23 +423,10 @@ common_install_flags() {
   flags+=" --set monitoring.alertManager.enabled=false"
   if [[ "$PLATFORM" == "kind" ]]; then
     flags+=" --set global.image.pullPolicy=IfNotPresent"
-    # Issue #1542 follow-up, round 3: networkPolicies.enabled defaults to
-    # true, but kubernaut.np.apiServerEgress (the rule that allows egress to
-    # the Kubernetes API server) is a no-op unless apiServerCIDR is set —
-    # this smoke test's template-rendering tests already assumed
-    # 10.96.0.1/32 (Kind's default "kubernetes" Service ClusterIP) but this
-    # value was never actually wired into the real `helm install` used
-    # against the live cluster. That gap went unnoticed because Kind's
-    # default CNI (kindnetd) only started enforcing NetworkPolicy objects as
-    # of kind v0.24.0; bumping to v0.32.0 here made the gap bite for real.
-    # See PR #1571 investigation for the full root-cause trail (initially
-    # misdiagnosed as a kube-proxy/CNI warm-up race). NOTE: every other
-    # NetworkPolicy-protected service has this same gap and is currently
-    # only unaffected because their controller-runtime managers appear to
-    # establish their one persistent API connection early enough to avoid
-    # being blocked — this is not something to rely on; the same
-    # apiServerCIDR gap likely needs addressing chart-wide as a follow-up.
-    flags+=" --set networkPolicies.apiServerCIDR=10.96.0.1/32"
+    if [[ -n "$API_SERVER_CIDR" ]]; then
+      flags+=" --set networkPolicies.apiServerCIDR=${API_SERVER_CIDR}"
+      flags+=" --set networkPolicies.apiServerPort=${API_SERVER_PORT}"
+    fi
   fi
   echo "$flags"
 }
@@ -1584,6 +1610,8 @@ main() {
 
   # Template tests run first (no cluster required)
   run_template_tests
+
+  discover_api_server_endpoint
 
   # Always start clean
   full_cleanup

--- a/scripts/helm-smoke-test.sh
+++ b/scripts/helm-smoke-test.sh
@@ -385,17 +385,26 @@ wait_for_cluster_network_ready() {
   kubectl run netcheck -n default --image="$probe_image" --restart=Never \
     --command -- /bin/sh -c '
       i=0
+      err=""
       while [ "$i" -lt 60 ]; do
-        if kubectl get --raw=/healthz --request-timeout=3s >/dev/null 2>&1; then
-          exit 0
-        fi
+        err=$(kubectl get --raw=/healthz --request-timeout=3s 2>&1) && exit 0
         i=$((i + 1))
         sleep 2
       done
+      echo "netcheck: /healthz still unreachable after ${i} attempts, last error: ${err}"
       exit 1
     ' >/dev/null 2>&1
 
-  if kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/netcheck -n default --timeout=150s >/dev/null 2>&1; then
+  local wait_result=0
+  kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/netcheck -n default --timeout=150s >/dev/null 2>&1 || wait_result=$?
+
+  # Diagnostic: capture the probe's own output regardless of outcome, so a
+  # failure is self-explanatory from this job's log alone instead of requiring
+  # a must-gather round-trip to learn *why* /healthz was unreachable.
+  echo "# netcheck probe output:"
+  kubectl logs pod/netcheck -n default 2>&1 | sed 's/^/#   /' || true
+
+  if [[ "$wait_result" -eq 0 ]]; then
     echo "# In-cluster networking is ready"
   else
     echo "# WARNING: in-cluster networking did not confirm ready within the wait budget; proceeding anyway"

--- a/scripts/helm-smoke-test.sh
+++ b/scripts/helm-smoke-test.sh
@@ -37,13 +37,6 @@ PF_PID=""
 POLICY_AA_FILE=""
 POLICY_SP_FILE=""
 
-# Real kube-apiserver backend endpoint(s) (populated by
-# discover_api_server_endpoint for kind only), used to wire
-# networkPolicies.apiServerCIDRs/apiServerPort. An array because HA clusters
-# have one backend IP per control-plane node.
-API_SERVER_CIDRS=()
-API_SERVER_PORT=""
-
 # ---------------------------------------------------------------------------
 # Argument parsing
 # ---------------------------------------------------------------------------
@@ -375,52 +368,17 @@ full_cleanup() {
 }
 
 # ---------------------------------------------------------------------------
-# Discover the kube-apiserver's real backend endpoint(s) (kind only)
-# ---------------------------------------------------------------------------
-# Issue #1542 follow-up, round 3: NetworkPolicies are now enforced by Kind's
-# CNI (kindnetd, as of kind v0.24.0+), but kubernaut.np.apiServerEgress is a
-# no-op unless networkPolicies.apiServerCIDR(s) is set -- so authwebhook's
-# patch-cabundle init container (and, latently, every other
-# NetworkPolicy-protected controller) has no egress path to the API server.
-#
-# Round 3a naively pointed apiServerCIDR at the "kubernetes" Service's
-# ClusterIP (10.96.0.1/32) -- this is a well-documented dead end: ipBlock
-# egress rules are evaluated against the post-DNAT destination on most CNIs
-# (kindnetd, Calico, Cilium all confirmed), so the ClusterIP is silently
-# never matched. The API server's *real* backend endpoint IP:port (from
-# `kubectl get endpoints kubernetes`) must be used instead. That endpoint is
-# only known once the cluster exists, so it can't be a chart default -- this
-# smoke test discovers it dynamically after cluster creation.
-#
-# The chart is generic (not Kind-specific) and must work against any real
-# Kubernetes distribution, where multiple control-plane nodes (HA) is the
-# norm -- each is a distinct backend IP behind the "kubernetes" Service, so
-# ALL addresses are collected here, not just the first (Kind's single-node
-# smoke test cluster happens to only ever have one, but the discovery logic
-# itself must not assume that).
-discover_api_server_endpoint() {
-  [[ "$PLATFORM" == "kind" ]] || return 0
-
-  local ips port
-  ips=$(kubectl get endpoints kubernetes -n default -o jsonpath='{.subsets[0].addresses[*].ip}' 2>/dev/null || true)
-  port=$(kubectl get endpoints kubernetes -n default -o jsonpath='{.subsets[0].ports[0].port}' 2>/dev/null || true)
-
-  if [[ -z "$ips" || -z "$port" ]]; then
-    echo "# WARNING: could not discover kube-apiserver endpoint; NetworkPolicy egress to the API server will not be allowed (pods behind default-deny NetworkPolicies will fail)"
-    return 0
-  fi
-
-  local ip
-  for ip in $ips; do
-    API_SERVER_CIDRS+=("${ip}/32")
-  done
-  API_SERVER_PORT="$port"
-  echo "# Discovered kube-apiserver endpoint(s): ${API_SERVER_CIDRS[*]} (port ${API_SERVER_PORT})"
-}
-
-# ---------------------------------------------------------------------------
 # Platform-specific install flags
 # ---------------------------------------------------------------------------
+# Note: networkPolicies.apiServerCIDR(s)/apiServerPort are intentionally NOT
+# set here. The chart auto-discovers the kube-apiserver's real backend
+# endpoint IP(s)/port via `lookup` against the live "kubernetes" Endpoints
+# object during a real helm install/upgrade (see
+# kubernaut.np.apiServerPeers/apiServerPort in _helpers.tpl) -- this smoke
+# test exercises that auto-discovery path rather than working around it.
+# See PR #1571 for the investigation trail that led here (round 3 initially
+# discovered the endpoint in bash and passed it via --set; that approach was
+# superseded once the chart learned to discover it itself).
 common_install_flags() {
   local flags=""
   flags+=" --set global.image.tag=${IMAGE_TAG}"
@@ -435,13 +393,6 @@ common_install_flags() {
   flags+=" --set monitoring.alertManager.enabled=false"
   if [[ "$PLATFORM" == "kind" ]]; then
     flags+=" --set global.image.pullPolicy=IfNotPresent"
-    if [[ "${#API_SERVER_CIDRS[@]}" -gt 0 ]]; then
-      flags+=" --set networkPolicies.apiServerPort=${API_SERVER_PORT}"
-      local i
-      for i in "${!API_SERVER_CIDRS[@]}"; do
-        flags+=" --set networkPolicies.apiServerCIDRs[${i}]=${API_SERVER_CIDRS[$i]}"
-      done
-    fi
   fi
   echo "$flags"
 }
@@ -1625,8 +1576,6 @@ main() {
 
   # Template tests run first (no cluster required)
   run_template_tests
-
-  discover_api_server_endpoint
 
   # Always start clean
   full_cleanup

--- a/scripts/helm-smoke-test.sh
+++ b/scripts/helm-smoke-test.sh
@@ -360,6 +360,8 @@ cleanup_port_forward() {
 # succeed before deploying the chart, instead of finding out via CrashLoopBackOff
 # once every app pod hits the same problem. Best-effort: never fails the run,
 # it only buys the network more time to stabilize before deploying real pods.
+# Bounded to ~150s total so a genuinely broken cluster still fails fast via
+# the existing pod-readiness checks instead of hanging here indefinitely.
 wait_for_cluster_network_ready() {
   if [[ "$PLATFORM" != "kind" ]]; then
     return 0
@@ -373,30 +375,31 @@ wait_for_cluster_network_ready() {
   fi
 
   echo "# Waiting for in-cluster pod networking to reach the API server (kube-proxy/CNI warm-up)..."
-  local attempt phase
-  for attempt in $(seq 1 20); do
-    kubectl delete pod netcheck -n default --ignore-not-found --force --grace-period=0 >/dev/null 2>&1 || true
-    kubectl run netcheck -n default --image="$probe_image" --restart=Never \
-      --command -- kubectl get --raw=/healthz --request-timeout=3s >/dev/null 2>&1 || true
+  kubectl delete pod netcheck -n default --ignore-not-found --force --grace-period=0 >/dev/null 2>&1 || true
 
-    phase=""
-    local waited=0
-    while [[ "$waited" -lt 8 ]]; do
-      phase=$(kubectl get pod netcheck -n default -o jsonpath='{.status.phase}' 2>/dev/null || echo "")
-      [[ "$phase" == "Succeeded" || "$phase" == "Failed" ]] && break
-      sleep 1
-      waited=$((waited + 1))
-    done
+  # Retry INSIDE a single long-lived pod rather than creating/destroying many
+  # short-lived pods and polling from the host: pod scheduling + container
+  # start + kubectl binary startup overhead (1-3s per attempt) otherwise
+  # dominates a short host-side polling window and makes the gate measure
+  # pod-creation noise instead of actual network reachability.
+  kubectl run netcheck -n default --image="$probe_image" --restart=Never \
+    --command -- /bin/sh -c '
+      i=0
+      while [ "$i" -lt 60 ]; do
+        if kubectl get --raw=/healthz --request-timeout=3s >/dev/null 2>&1; then
+          exit 0
+        fi
+        i=$((i + 1))
+        sleep 2
+      done
+      exit 1
+    ' >/dev/null 2>&1
 
-    if [[ "$phase" == "Succeeded" ]]; then
-      echo "# In-cluster networking is ready (attempt ${attempt}/20)"
-      kubectl delete pod netcheck -n default --ignore-not-found --force --grace-period=0 >/dev/null 2>&1 || true
-      return 0
-    fi
-    sleep 2
-  done
-
-  echo "# WARNING: in-cluster networking did not confirm ready after 20 attempts; proceeding anyway"
+  if kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/netcheck -n default --timeout=150s >/dev/null 2>&1; then
+    echo "# In-cluster networking is ready"
+  else
+    echo "# WARNING: in-cluster networking did not confirm ready within the wait budget; proceeding anyway"
+  fi
   kubectl delete pod netcheck -n default --ignore-not-found --force --grace-period=0 >/dev/null 2>&1 || true
   return 0
 }

--- a/test/e2e/datastorage/README.md
+++ b/test/e2e/datastorage/README.md
@@ -100,7 +100,7 @@ Each test creates a unique namespace (e.g., `datastorage-e2e-test-1`) to ensure 
 # Install Kind
 brew install kind  # macOS
 # OR
-curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.30.0/kind-linux-amd64
+curl -Lo ./kind https://github.com/kubernetes-sigs/kind/releases/download/v0.32.0/kind-linux-amd64
 chmod +x ./kind
 sudo mv ./kind /usr/local/bin/kind
 

--- a/test/infrastructure/awx_e2e.go
+++ b/test/infrastructure/awx_e2e.go
@@ -661,7 +661,13 @@ func ConfigureAWX(ctx context.Context, awxBaseURL string, writer io.Writer) (*AW
 					}
 				}
 			}
-			return nil, fmt.Errorf("failed to create project: HTTP %d (and could not find existing)", projectStatus)
+			// The "already exists" write may not yet be visible to a subsequent
+			// read (AWX task-queue/DB replication lag right after pod readiness,
+			// same class of race as the admin-401 issue above). Retry instead of
+			// failing hard on the first lookup miss.
+			_, _ = fmt.Fprintf(writer, "   ⚠️  Project lookup by name did not find it yet (attempt %d/6), retrying in 10s...\n", attempt+1)
+			time.Sleep(10 * time.Second)
+			continue
 		}
 		if projectStatus >= 500 || projectStatus == http.StatusUnauthorized || projectStatus == http.StatusForbidden {
 			_, _ = fmt.Fprintf(writer, "   ⚠️  Project creation returned HTTP %d (attempt %d/6), retrying in 10s...\n", projectStatus, attempt+1)
@@ -671,7 +677,7 @@ func ConfigureAWX(ctx context.Context, awxBaseURL string, writer io.Writer) (*AW
 		return nil, fmt.Errorf("failed to create project: HTTP %d", projectStatus)
 	}
 	if !projectCreated {
-		return nil, fmt.Errorf("failed to create project after 6 attempts: HTTP %d", projectStatus)
+		return nil, fmt.Errorf("failed to create project after 6 attempts: HTTP %d (and could not find existing)", projectStatus)
 	}
 	cfg.ProjectID = int(projectResult["id"].(float64))
 	_, _ = fmt.Fprintf(writer, "   ✅ Project ID: %d\n", cfg.ProjectID)

--- a/test/infrastructure/kind-aianalysis-config.yaml
+++ b/test/infrastructure/kind-aianalysis-config.yaml
@@ -20,7 +20,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a  # K8s 1.34.0 with containerd 2.1.3 (avoids v2.2.0 mount-manager regression)
+  image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5  # K8s 1.36.1 (kind v0.32.0 default); matches client-go/controller-runtime v0.36 baseline
   # Expose AIAnalysis Controller ports via NodePort to host machine
   # This eliminates kubectl port-forward instability for E2E tests
   # DD-TEST-007: Mount coverage directory for E2E coverage collection

--- a/test/infrastructure/kind-datastorage-config.yaml
+++ b/test/infrastructure/kind-datastorage-config.yaml
@@ -5,7 +5,7 @@ nodes:
   # DD-AUTH-014: Allocate more resources for API server under SAR middleware load
   # SAR middleware adds 2 K8s API calls per HTTP request (TokenReview + SAR)
   # With 12 parallel test processes, API server needs more CPU/memory
-  image: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a  # K8s 1.34.0 with containerd 2.1.3 (avoids v2.2.0 mount-manager regression)
+  image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5  # K8s 1.36.1 (kind v0.32.0 default); matches client-go/controller-runtime v0.36 baseline
   
   # Expose Data Storage NodePort to host machine
   # This eliminates kubectl port-forward instability

--- a/test/infrastructure/kind-effectivenessmonitor-config.yaml
+++ b/test/infrastructure/kind-effectivenessmonitor-config.yaml
@@ -38,7 +38,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a  # K8s 1.34.0 with containerd 2.1.3 (avoids v2.2.0 mount-manager regression)
+  image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5  # K8s 1.36.1 (kind v0.32.0 default); matches client-go/controller-runtime v0.36 baseline
   extraPortMappings:
   # DataStorage API (for audit event queries in E2E tests)
   - containerPort: 30081

--- a/test/infrastructure/kind-fleetmetadatacache-config.yaml
+++ b/test/infrastructure/kind-fleetmetadatacache-config.yaml
@@ -43,7 +43,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a  # K8s 1.34.0 with containerd 2.1.3 (avoids v2.2.0 mount-manager regression)
+  image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5  # K8s 1.36.1 (kind v0.32.0 default); matches client-go/controller-runtime v0.36 baseline
   extraMounts:
   - hostPath: ./coverdata
     containerPath: /coverdata

--- a/test/infrastructure/kind-fleetmetadatacache-eaigw-config.yaml
+++ b/test/infrastructure/kind-fleetmetadatacache-eaigw-config.yaml
@@ -33,7 +33,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a  # K8s 1.34.0 with containerd 2.1.3 (avoids v2.2.0 mount-manager regression)
+  image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5  # K8s 1.36.1 (kind v0.32.0 default); matches client-go/controller-runtime v0.36 baseline
   extraMounts:
   - hostPath: ./coverdata
     containerPath: /coverdata

--- a/test/infrastructure/kind-fleetmetadatacache-remote-config.yaml
+++ b/test/infrastructure/kind-fleetmetadatacache-remote-config.yaml
@@ -18,7 +18,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a  # K8s 1.34.0 with containerd 2.1.3 (avoids v2.2.0 mount-manager regression)
+  image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5  # K8s 1.36.1 (kind v0.32.0 default); matches client-go/controller-runtime v0.36 baseline
   kubeadmConfigPatches:
   - |
     kind: ClusterConfiguration

--- a/test/infrastructure/kind-fullpipeline-config.yaml
+++ b/test/infrastructure/kind-fullpipeline-config.yaml
@@ -49,7 +49,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a  # K8s 1.34.0 with containerd 2.1.3 (avoids v2.2.0 mount-manager regression)
+  image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5  # K8s 1.36.1 (kind v0.32.0 default); matches client-go/controller-runtime v0.36 baseline
   # Expose service ports via NodePort to host machine
   # Gateway (for event-exporter webhook delivery)
   extraPortMappings:

--- a/test/infrastructure/kind-gateway-config.yaml
+++ b/test/infrastructure/kind-gateway-config.yaml
@@ -16,7 +16,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a  # K8s 1.34.0 with containerd 2.1.3 (avoids v2.2.0 mount-manager regression)
+  image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5  # K8s 1.36.1 (kind v0.32.0 default); matches client-go/controller-runtime v0.36 baseline
   # DD-TEST-007: Mount coverage directory on control-plane node
   # Gateway pods run on control-plane due to nodeSelector
   extraMounts:

--- a/test/infrastructure/kind-notification-config.yaml
+++ b/test/infrastructure/kind-notification-config.yaml
@@ -4,7 +4,7 @@ nodes:
 - role: control-plane
   # Upgraded to K8s 1.34.3 (latest z-stream) for CRD selectableFields support (requires 1.30+)
   # Matches project's k8s.io/api v0.34.1, pinned with digest for reproducibility
-  image: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a  # K8s 1.34.0 with containerd 2.1.3 (avoids v2.2.0 mount-manager regression)
+  image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5  # K8s 1.36.1 (kind v0.32.0 default); matches client-go/controller-runtime v0.36 baseline
   
   # Expose Notification Controller metrics via NodePort to host machine
   # This eliminates kubectl port-forward instability for E2E tests

--- a/test/infrastructure/kind-remediationorchestrator-config.yaml
+++ b/test/infrastructure/kind-remediationorchestrator-config.yaml
@@ -24,7 +24,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a  # K8s 1.34.0 with containerd 2.1.3 (avoids v2.2.0 mount-manager regression)
+  image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5  # K8s 1.36.1 (kind v0.32.0 default); matches client-go/controller-runtime v0.36 baseline
   # Expose RemediationOrchestrator Controller ports via NodePort to host machine
   # This eliminates kubectl port-forward instability for E2E tests
   extraPortMappings:

--- a/test/infrastructure/kind-signalprocessing-config.yaml
+++ b/test/infrastructure/kind-signalprocessing-config.yaml
@@ -21,7 +21,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a  # K8s 1.34.0 with containerd 2.1.3 (avoids v2.2.0 mount-manager regression)
+  image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5  # K8s 1.36.1 (kind v0.32.0 default); matches client-go/controller-runtime v0.36 baseline
   # Expose SignalProcessing Controller ports via NodePort to host machine
   # This eliminates kubectl port-forward instability for E2E tests
   extraPortMappings:

--- a/test/infrastructure/kind-workflowexecution-config.yaml
+++ b/test/infrastructure/kind-workflowexecution-config.yaml
@@ -2,7 +2,7 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
 - role: control-plane
-  image: kindest/node:v1.34.0@sha256:7416a61b42b1662ca6ca89f02028ac133a309a2a30ba309614e8ec94d976dc5a  # K8s 1.34.0 with containerd 2.1.3 (avoids v2.2.0 mount-manager regression)
+  image: kindest/node:v1.36.1@sha256:3489c7674813ba5d8b1a9977baea8a6e553784dab7b84759d1014dbd78f7ebd5  # K8s 1.36.1 (kind v0.32.0 default); matches client-go/controller-runtime v0.36 baseline
   # Expose WorkflowExecution Controller ports via NodePort to host machine
   # Per DD-TEST-001 port allocation strategy
   extraPortMappings:

--- a/test/infrastructure/kind_cluster_helpers.go
+++ b/test/infrastructure/kind_cluster_helpers.go
@@ -22,8 +22,66 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 )
+
+// minKindVersionMajor, minKindVersionMinor define the minimum supported Kind
+// CLI version. Kind CLI v0.32.0 is the first release that can `kind load` node
+// images using containerd's config v4 format (see kindest/node:v1.36.1+ and
+// https://github.com/kubernetes-sigs/kind/releases/tag/v0.32.0). Older CLI
+// versions fail with "unknown containerd config version: 4".
+//
+// This is a minimum-version check (not exact-match) so future Kind patch/minor
+// releases don't require a code change here -- only the CI install step
+// (KIND_VERSION) needs bumping when we want to pick up a newer default.
+const (
+	minKindVersionMajor = 0
+	minKindVersionMinor = 32
+)
+
+var kindVersionPattern = regexp.MustCompile(`kind v(\d+)\.(\d+)\.(\d+)`)
+
+// checkKindVersionOutput parses `kind version` output (format: "kind v0.32.0
+// go1.26.4 linux/amd64") and returns an error if the installed CLI is older
+// than the minimum required version. Pure function (no I/O) so it is
+// independently unit-testable from the exec.Command wrapper below.
+func checkKindVersionOutput(versionStr string) error {
+	matches := kindVersionPattern.FindStringSubmatch(versionStr)
+	if matches == nil {
+		return fmt.Errorf("could not parse kind version from output: %s", versionStr)
+	}
+
+	major, _ := strconv.Atoi(matches[1])
+	minor, _ := strconv.Atoi(matches[2])
+
+	if major < minKindVersionMajor || (major == minKindVersionMajor && minor < minKindVersionMinor) {
+		return fmt.Errorf("kind version too old: required >= v%d.%d.0, got: %s", minKindVersionMajor, minKindVersionMinor, versionStr)
+	}
+	return nil
+}
+
+// validateKindVersion shells out to `kind version` and validates the result
+// against the minimum required version, logging progress to writer.
+func validateKindVersion(writer io.Writer) error {
+	versionCmd := exec.Command("kind", "version")
+	versionOutput, err := versionCmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to get kind version: %w", err)
+	}
+	versionStr := string(versionOutput)
+
+	if err := checkKindVersionOutput(versionStr); err != nil {
+		_, _ = fmt.Fprintf(writer, "  ⚠️  WARNING: Kind version too old\n")
+		_, _ = fmt.Fprintf(writer, "     Current: %s", versionStr)
+		_, _ = fmt.Fprintf(writer, "     Required: kind v%d.%d.0 or newer\n", minKindVersionMajor, minKindVersionMinor)
+		_, _ = fmt.Fprintf(writer, "     Install: go install sigs.k8s.io/kind@v%d.%d.0\n", minKindVersionMajor, minKindVersionMinor)
+		return err
+	}
+	_, _ = fmt.Fprintf(writer, "  ✅ Kind version validated: %s", versionStr)
+	return nil
+}
 
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 // Shared Kind Cluster Helpers - Reusable across all E2E test services
@@ -67,23 +125,10 @@ func CreateKindClusterWithExtraMounts(
 	extraMounts []ExtraMount,
 	writer io.Writer,
 ) error {
-	// 0. Validate Kind version (v0.30.x required for E2E tests)
-	versionCmd := exec.Command("kind", "version")
-	versionOutput, err := versionCmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to get kind version: %w", err)
+	// 0. Validate Kind version (minimum version required for E2E tests)
+	if err := validateKindVersion(writer); err != nil {
+		return err
 	}
-	versionStr := string(versionOutput)
-
-	// Extract version (format: "kind v0.30.0 go1.25.0 darwin/arm64")
-	if !strings.Contains(versionStr, "kind v0.30.") {
-		_, _ = fmt.Fprintf(writer, "  ⚠️  WARNING: Unexpected Kind version detected\n")
-		_, _ = fmt.Fprintf(writer, "     Current: %s", versionStr)
-		_, _ = fmt.Fprintf(writer, "     Expected: kind v0.30.x\n")
-		_, _ = fmt.Fprintf(writer, "     Install: go install sigs.k8s.io/kind@v0.30.0\n")
-		return fmt.Errorf("kind version mismatch: expected v0.30.x, got: %s", versionStr)
-	}
-	_, _ = fmt.Fprintf(writer, "  ✅ Kind version validated: %s", versionStr)
 
 	// 0b. Reuse existing cluster if present (idempotent retry support).
 	// When --flake-attempts or CI retry re-runs the suite, the cluster from
@@ -294,23 +339,10 @@ type KindClusterOptions struct {
 func CreateKindClusterWithConfig(opts KindClusterOptions, writer io.Writer) error {
 	_, _ = fmt.Fprintf(writer, "🔧 Creating Kind cluster: %s\n", opts.ClusterName)
 
-	// 0. Validate Kind version (v0.30.x required for E2E tests)
-	versionCmd := exec.Command("kind", "version")
-	versionOutput, err := versionCmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("failed to get kind version: %w", err)
+	// 0. Validate Kind version (minimum version required for E2E tests)
+	if err := validateKindVersion(writer); err != nil {
+		return err
 	}
-	versionStr := string(versionOutput)
-
-	// Extract version (format: "kind v0.30.0 go1.25.0 darwin/arm64")
-	if !strings.Contains(versionStr, "kind v0.30.") {
-		_, _ = fmt.Fprintf(writer, "  ⚠️  WARNING: Unexpected Kind version detected\n")
-		_, _ = fmt.Fprintf(writer, "     Current: %s", versionStr)
-		_, _ = fmt.Fprintf(writer, "     Expected: kind v0.30.x\n")
-		_, _ = fmt.Fprintf(writer, "     Install: go install sigs.k8s.io/kind@v0.30.0\n")
-		return fmt.Errorf("kind version mismatch: expected v0.30.x, got: %s", versionStr)
-	}
-	_, _ = fmt.Fprintf(writer, "  ✅ Kind version validated: %s", versionStr)
 
 	// 1. Check if cluster already exists
 	checkCmd := exec.Command("kind", "get", "clusters")

--- a/test/infrastructure/kind_cluster_helpers_test.go
+++ b/test/infrastructure/kind_cluster_helpers_test.go
@@ -1,0 +1,55 @@
+/*
+Copyright 2025 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package infrastructure
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Issue #1542 follow-up: Kind CLI v0.30.0 was hard-pinned via exact-match
+// string comparison ("kind v0.30."), which broke every time the CLI needed
+// a bump (e.g. containerd config v4 support requires Kind CLI >= v0.32.0
+// for kindest/node:v1.36.1+). checkKindVersionOutput replaces the exact
+// match with a minimum-version check so future Kind releases don't require
+// a code change here.
+var _ = Describe("checkKindVersionOutput", func() {
+	DescribeTable("version validation against the minimum supported Kind CLI version",
+		func(versionOutput string, expectErr bool) {
+			err := checkKindVersionOutput(versionOutput)
+			if expectErr {
+				Expect(err).To(HaveOccurred())
+			} else {
+				Expect(err).NotTo(HaveOccurred())
+			}
+		},
+		Entry("UT-INFRA-KIND-001: accepts the exact minimum version",
+			"kind v0.32.0 go1.26.4 linux/amd64", false),
+		Entry("UT-INFRA-KIND-002: accepts a newer minor version",
+			"kind v0.33.1 go1.26.4 linux/amd64", false),
+		Entry("UT-INFRA-KIND-003: accepts a newer major version",
+			"kind v1.0.0 go1.26.4 linux/amd64", false),
+		Entry("UT-INFRA-KIND-004: rejects a version below the minimum minor",
+			"kind v0.30.0 go1.25.0 darwin/arm64", true),
+		Entry("UT-INFRA-KIND-005: rejects a much older version",
+			"kind v0.20.0 go1.24.0 linux/amd64", true),
+		Entry("UT-INFRA-KIND-006: rejects unparsable output",
+			"command not found: kind", true),
+		Entry("UT-INFRA-KIND-007: rejects empty output",
+			"", true),
+	)
+})


### PR DESCRIPTION
## Summary

Issue #1542 follow-up. Bumps Kind CLI `v0.30.0` → `v0.32.0` and `kindest/node` `v1.34.0` → `v1.36.1` (K8s 1.36) together, re-applying the node image bump that was reverted in #1568 (containerd config v4 needed Kind CLI >= v0.32.0).

**Why now**: the Kind CLI pin was never actually about CRD `selectableFields` validation (that only required the `kindest/node` K8s version, already at 1.34+ and stable per DD-CRD-003) — it was a separate "tested version" pin. With that constraint gone, bumping closes a real version-skew gap: `go.mod` already pins `k8s.io/api`/`client-go`/`apimachinery` at `v0.36.2`, and `controller-runtime v0.24.1` is only officially tested against `k8s.io/* v0.36` — but E2E was still validating against a K8s 1.34 API server, two minor versions behind our client libraries.

- Kind CLI `v0.30.0` → `v0.32.0` in all 6 CI workflow files that install it
- `kindest/node` `v1.34.0` → `v1.36.1` in all 12 `kind-*-config.yaml` files, plus the previously-inconsistent `deploy/apifrontend/overlays/e2e/kind-config.yaml` (was pinned to `v1.32.5`)
- Replaced the hardcoded exact-match Kind CLI version check (`"kind v0.30."`) with a minimum-version check (`>= v0.32.0`), extracted into a pure `checkKindVersionOutput()` function with unit test coverage (`UT-INFRA-KIND-001..007`) so future Kind releases don't require touching this file again
- Updated stale doc references to the new download URL

**Residual risk**: containerd's mount-manager plugin had regressions in the 2.2.x-2.3.x line (fixed piecemeal through June 2026). I could not independently confirm the exact containerd version bundled in `kindest/node:v1.36.1` from documentation, so this relies on full CI (Integration + E2E across all 12 services) to validate.

Authority: https://github.com/kubernetes-sigs/kind/releases/tag/v0.32.0

## Test plan
- [x] `go build ./...` and `go vet ./...` pass
- [x] New unit tests (`UT-INFRA-KIND-001..007`) pass, `golangci-lint` clean
- [ ] Full CI green (Unit + Integration + E2E across all services) — monitoring

Made with [Cursor](https://cursor.com)