### PR TITLE
ci: skip coverage PR comment for fork PRs (read-only GITHUB_TOKEN)

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1387,7 +1387,16 @@ jobs:
           fi
 
       - name: Post coverage report to PR
-        if: github.event_name == 'pull_request'
+        # Fork PRs get a read-only GITHUB_TOKEN on `pull_request` events -- a
+        # GitHub security restriction that cannot be elevated via the
+        # `permissions:` block above (see
+        # https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target).
+        # Posting the sticky comment there fails with "403 Resource not
+        # accessible by integration" and would fail this job (and Merge Gate
+        # with it) for every external contributor PR. Skip for forks instead;
+        # the coverage report is still printed in the step above and visible
+        # in the job logs.
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3
         with:
           header: coverage-report


### PR DESCRIPTION
## Summary

- Fork PRs get a **read-only** `GITHUB_TOKEN` on `pull_request` events --
  a GitHub security restriction that `permissions: pull-requests: write`
  cannot override (same root cause already fixed for `ghcr.io` pushes in
  #1574).
- The "Post coverage report to PR" step (`sticky-pull-request-comment`)
  was failing with `403 Resource not accessible by integration` on every
  external contributor PR, taking **Test Suite Summary** and **Merge
  Gate** down with it -- even though every actual build/test job passed.
- Observed live on fork PR #1573, [run
  28757030370](https://github.com/jordigilh/kubernaut/actions/runs/28757030370/job/85269363279):
  70 jobs succeeded, only the coverage-comment step and its two dependent
  gate jobs failed.

## Fix

Skip the comment-posting step when the PR is from a fork
(`github.event.pull_request.head.repo.full_name != github.repository`)
instead of switching to `pull_request_target`, which runs with elevated
trust and is explicitly discouraged by GitHub's own security guide for
this kind of use unless carefully scoped. The coverage report is still
printed in the preceding "Enforce coverage gate" step's logs; only the
sticky PR comment convenience is lost for fork contributors.

## Test plan

- [x] `yaml.safe_load` validates the workflow
- [x] `actionlint` reports no new structural issues (pre-existing
      shellcheck style notes only, unrelated to this change)
- [ ] Verify on this PR that Test Suite Summary / Merge Gate pass (same-repo
      PR, so the comment step still runs normally)
- [ ] Re-run PR #1573's CI after merge to confirm the fork-PR path is now green end-to-end

Made with [Cursor](https://cursor.com)