### PR TITLE
ci: publish coverage report to job summary for all contributors

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1386,6 +1386,15 @@ jobs:
             echo "   (Non-blocking in V1.5 rollout; will become blocking after Phase 9)"
           fi
 
+      - name: Publish coverage report to job summary
+        # Works for every PR (fork or same-repo) and every event type: writing
+        # to GITHUB_STEP_SUMMARY needs no token permissions at all, unlike the
+        # sticky PR comment below. This is the primary, permission-agnostic
+        # place contributors should look -- linked directly from the "Test
+        # Suite Summary" entry on the PR's Checks tab even for forks.
+        if: always()
+        run: cat coverage-summary.md >> "$GITHUB_STEP_SUMMARY"
+
       - name: Post coverage report to PR
         # Fork PRs get a read-only GITHUB_TOKEN on `pull_request` events -- a
         # GitHub security restriction that cannot be elevated via the
@@ -1393,9 +1402,10 @@ jobs:
         # https://docs.github.com/en/actions/reference/security/securely-using-pull_request_target).
         # Posting the sticky comment there fails with "403 Resource not
         # accessible by integration" and would fail this job (and Merge Gate
-        # with it) for every external contributor PR. Skip for forks instead;
-        # the coverage report is still printed in the step above and visible
-        # in the job logs.
+        # with it) for every external contributor PR. Skip for forks instead
+        # -- the job summary step above already gives them the full report
+        # regardless of token permissions; this step is just the inline-PR-
+        # comment convenience for same-repo PRs.
         if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3
         with:


### PR DESCRIPTION
## Summary

Follow-up to #1575. Skipping the sticky PR comment for fork PRs fixed
the CI failure, but it also meant fork contributors -- the primary
source of external contributions -- got **no** inline coverage
visibility at all, while same-repo PRs still did. That made the comment
feature effectively moot for its main audience.

## Fix

Write `coverage-summary.md` to `GITHUB_STEP_SUMMARY` unconditionally, in
addition to the existing sticky-comment step:

- Requires no token permissions (plain file write, no GitHub API call),
  so it works identically for forks and same-repo PRs.
- Linked directly from the "Test Suite Summary" job on the PR's Checks
  tab -- one click away instead of inline, but present for every
  contributor regardless of fork status.
- The sticky PR comment is kept as-is for same-repo PRs (nicer inline
  UX where the token allows it).

## Test plan

- [x] `yaml.safe_load` validates the workflow
- [x] `actionlint` reports no new structural issues
- [ ] Verify the coverage table renders correctly in this PR's "Test Suite Summary" job summary

Made with [Cursor](https://cursor.com)