### PR TITLE
ci(lint): remove merge-base scoping from golangci-lint, enforce full-repo

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -183,7 +183,7 @@ jobs:
         uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a # v9
         with:
           version: v2.9.0
-          args: --timeout=10m --new-from-merge-base=origin/${{ github.base_ref }} --whole-files cmd/... pkg/... internal/... test/...
+          args: --timeout=10m cmd/... pkg/... internal/... test/...
 
       - name: Dependency vulnerability scan (govulncheck)
         run: |


### PR DESCRIPTION
## Summary

Closes #1314.

`golangci-lint`'s CI invocation used `--new-from-merge-base=origin/${{ github.base_ref }} --whole-files`, which only flags lint issues introduced by a PR's own diff against its merge base — any pre-existing violations elsewhere in the repo are permanently masked and can silently accumulate. This removes that scoping so CI lints the whole repo on every run.

No remediation was needed: verified full-repo `golangci-lint run` (same `v2.9.0` config, all 20 currently-enabled linters) already reports **0 issues** against current `main` before making this change — prior complexity-lint-gate work (funlen/gocyclo/gocognit/nestif/maintidx enablement, etc.) already drove the whole repo clean, not just touched files.

## Test plan

- [x] Ran `golangci-lint run --timeout=10m cmd/... pkg/... internal/... test/...` (no merge-base scoping) locally against current `main` — 0 issues
- [ ] CI `Lint (Go Services)` job passes with the unscoped args

Made with [Cursor](https://cursor.com)