### PR TITLE
fix(test-infra): reuse CI-loaded image artifacts in integration test bootstraps

### DIFF
--- a/test/infrastructure/datastorage_bootstrap.go
+++ b/test/infrastructure/datastorage_bootstrap.go
@@ -236,6 +236,20 @@ func BuildDataStorageImage(ctx context.Context, serviceName string, writer io.Wr
 	imageTag := generateInfrastructureImageTag("datastorage", serviceName)
 	imageName := fmt.Sprintf("kubernaut/datastorage:%s", imageTag)
 
+	// Step -1: Use a CI-loaded artifact if one was already podman-loaded for
+	// this service under the agreed-upon fixed tag (artifact-based CI mode,
+	// no registry involved). Mirrors StartGenericContainer's equivalent
+	// check (container_management.go) — without it, every suite that calls
+	// StartDSBootstrap unconditionally re-runs a --no-cache local build even
+	// though CI already built and loaded this exact image.
+	if artifactTag := os.Getenv("KUBERNAUT_CI_ARTIFACT_TAG"); artifactTag != "" {
+		prebuiltImage := fmt.Sprintf("localhost/datastorage:%s", artifactTag)
+		if checkCmd := exec.CommandContext(ctx, "podman", "image", "exists", prebuiltImage); checkCmd.Run() == nil {
+			_, _ = fmt.Fprintf(writer, "   ✅ Using CI-prebuilt artifact: %s\n", prebuiltImage)
+			return prebuiltImage, nil
+		}
+	}
+
 	// DEBUG: Show environment variable status
 	registry := os.Getenv("IMAGE_REGISTRY")
 	tag := os.Getenv("IMAGE_TAG")

--- a/test/infrastructure/mock_llm.go
+++ b/test/infrastructure/mock_llm.go
@@ -106,6 +106,18 @@ func BuildMockLLMImage(ctx context.Context, serviceName string, writer io.Writer
 	baseImageName := "localhost/mock-llm:latest"
 	uniqueImageName := GenerateInfraImageName("mock-llm", serviceName)
 
+	// Step -1: Use a CI-loaded artifact if one was already podman-loaded for
+	// this service under the agreed-upon fixed tag (artifact-based CI mode,
+	// no registry involved). Mirrors StartGenericContainer's equivalent
+	// check (container_management.go).
+	if artifactTag := os.Getenv("KUBERNAUT_CI_ARTIFACT_TAG"); artifactTag != "" {
+		prebuiltImage := fmt.Sprintf("localhost/mock-llm:%s", artifactTag)
+		if checkCmd := exec.CommandContext(ctx, "podman", "image", "exists", prebuiltImage); checkCmd.Run() == nil {
+			_, _ = fmt.Fprintf(writer, "   ✅ Using CI-prebuilt artifact: %s\n", prebuiltImage)
+			return prebuiltImage, nil
+		}
+	}
+
 	// DEBUG: Show environment variable status
 	registry := os.Getenv("IMAGE_REGISTRY")
 	tag := os.Getenv("IMAGE_TAG")

--- a/test/infrastructure/shared_e2e.go
+++ b/test/infrastructure/shared_e2e.go
@@ -615,6 +615,18 @@ func BuildKubernautAgentImage(ctx context.Context, serviceName string, writer io
 	imageTag := generateInfrastructureImageTag("kubernautagent", serviceName)
 	localImageName := fmt.Sprintf("localhost/kubernautagent:%s", imageTag)
 
+	// Step -1: Use a CI-loaded artifact if one was already podman-loaded for
+	// this service under the agreed-upon fixed tag (artifact-based CI mode,
+	// no registry involved). Mirrors StartGenericContainer's equivalent
+	// check (container_management.go).
+	if artifactTag := os.Getenv("KUBERNAUT_CI_ARTIFACT_TAG"); artifactTag != "" {
+		prebuiltImage := fmt.Sprintf("localhost/kubernautagent:%s", artifactTag)
+		if checkCmd := exec.CommandContext(ctx, "podman", "image", "exists", prebuiltImage); checkCmd.Run() == nil {
+			_, _ = fmt.Fprintf(writer, "   ✅ Using CI-prebuilt artifact: %s\n", prebuiltImage)
+			return prebuiltImage, nil
+		}
+	}
+
 	registry := os.Getenv("IMAGE_REGISTRY")
 	tag := os.Getenv("IMAGE_TAG")
 	_, _ = fmt.Fprintf(writer, "   🔍 Environment check: IMAGE_REGISTRY=%q IMAGE_TAG=%q\n", registry, tag)


### PR DESCRIPTION
## Summary
- `BuildDataStorageImage`, `BuildKubernautAgentImage`, and `BuildMockLLMImage` (`test/infrastructure/`) only checked `IMAGE_REGISTRY`/`IMAGE_TAG` (ghcr.io pull mode) before falling back to an unconditional `podman build --no-cache`.
- They never checked `KUBERNAUT_CI_ARTIFACT_TAG`, so in CI's artifact-based mode (the mode actually used by the `integration-tests` job — no registry involved) they always rebuilt from scratch, even though `build-images`/`build-infra-images` already built and `podman load`-ed these exact images earlier in the same workflow run (`load-ci-images` composite action).
- `StartGenericContainer` (`container_management.go`) already has the correct "Step -1" pre-loaded-artifact check for this. This PR applies the identical pattern to the three builders above.
- Local dev is unaffected: the env var is CI-only, so when unset the existing registry-pull → local-build fallback chain is unchanged.

## Root cause of the recurring `Integration (kubernautagent)` suite timeout
`StartDSBootstrap` (used by 13 integration suites, incl. 4 `kubernautagent` subsuites) calls `BuildDataStorageImage`, which spent ~120s in a `--no-cache` rebuild on every single call because `generateInfrastructureImageTag()` derives the tag from `time.Now().UnixNano()`, so the plain "does this exact tag already exist locally" cache-hit check could never match. That ~120s repeatedly eats into `kubernautagent`'s shared 15-minute Ginkgo suite timeout budget, and downstream subsuites (`k8s`, `prometheus`, `summarizer`, `transport`) never get to run — confirmed on two separate unrelated `main` runs ([28786450977](https://github.com/jordigilh/kubernaut/actions/runs/28786450977), [28763799427](https://github.com/jordigilh/kubernaut/actions/runs/28763799427)).

Same gap also exists for `BuildKubernautAgentImage` (used by `apifrontend`, `aianalysis`) and `BuildMockLLMImage` (used by `apifrontend`, `aianalysis`, `kubernautagent/mcp` — this one didn't even have the plain local-exists fallback, going straight to an unconditional build).

## Test plan
- [x] `go build ./test/...` — clean
- [x] `go vet ./test/infrastructure/...` — clean
- [x] `golangci-lint run test/infrastructure/...` — 0 issues
- [x] No existing unit tests cover these podman-exec-wrapping helpers (consistent with `StartGenericContainer`, which also has none — they require a live Podman daemon and are exercised implicitly by every integration suite run)
- [ ] Follow-up: confirm on the next CI run that `kubernautagent` integration no longer times out and that per-job wall time drops for the affected suites

Made with [Cursor](https://cursor.com)