### PR TITLE
fix(kubernautagent): wire ai.llm.reasoning config into real Anthropic requests

### DIFF
--- a/cmd/kubernautagent/ds_transport_test.go
+++ b/cmd/kubernautagent/ds_transport_test.go
@@ -18,39 +18,31 @@ package main
 
 import (
 	"net/http"
-	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	"github.com/jordigilh/kubernaut/pkg/shared/types"
 )
 
-func TestBuildDSBaseTransport_WithCAFile(t *testing.T) {
-	caPath := generateTestCACert(t, "DS Test CA")
+var _ = Describe("buildDSBaseTransport", func() {
+	It("returns a custom non-default transport when a valid CA file is set", func() {
+		caPath := generateTestCACert(GinkgoTB(), "DS Test CA")
 
-	transport, err := buildDSBaseTransport(caPath, types.LLMCircuitBreaker{})
-	if err != nil {
-		t.Fatalf("expected no error with valid CA file, got: %v", err)
-	}
-	if transport == nil {
-		t.Fatal("expected non-nil transport when caFile is set")
-	}
-	if transport == http.DefaultTransport {
-		t.Fatal("expected custom transport, got http.DefaultTransport")
-	}
-}
+		transport, err := buildDSBaseTransport(caPath, types.LLMCircuitBreaker{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(transport).NotTo(BeNil())
+		Expect(transport).NotTo(BeIdenticalTo(http.DefaultTransport))
+	})
 
-func TestBuildDSBaseTransport_EmptyCAFile(t *testing.T) {
-	transport, err := buildDSBaseTransport("", types.LLMCircuitBreaker{})
-	if err != nil {
-		t.Fatalf("expected no error with empty caFile, got: %v", err)
-	}
-	if transport == nil {
-		t.Fatal("expected non-nil transport (default fallback)")
-	}
-}
+	It("returns a non-nil default-fallback transport when caFile is empty", func() {
+		transport, err := buildDSBaseTransport("", types.LLMCircuitBreaker{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(transport).NotTo(BeNil())
+	})
 
-func TestBuildDSBaseTransport_InvalidCAFile(t *testing.T) {
-	_, err := buildDSBaseTransport("/nonexistent/ca.crt", types.LLMCircuitBreaker{})
-	if err == nil {
-		t.Fatal("expected error with invalid CA file path, got nil")
-	}
-}
+	It("returns an error for an invalid CA file path", func() {
+		_, err := buildDSBaseTransport("/nonexistent/ca.crt", types.LLMCircuitBreaker{})
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/cmd/kubernautagent/fleet_readiness_wiring_test.go
+++ b/cmd/kubernautagent/fleet_readiness_wiring_test.go
@@ -19,10 +19,11 @@ package main
 import (
 	"context"
 	"net/http/httptest"
-	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	kaconfig "github.com/jordigilh/kubernaut/internal/kubernautagent/config"
 	"github.com/jordigilh/kubernaut/pkg/fleet/mcpclient"
@@ -41,123 +42,103 @@ import (
 // carries an MCPClientProber.
 //
 // Test Plan: Wave 5 of the fail-closed Fleet readiness gate rollout (#1553).
+var _ = Describe("registerFleetTools and wireFleetReadinessGate wiring (#1553)", func() {
 
-// --- registerFleetTools retention behavior (#1553) ---
+	Describe("registerFleetTools retention behavior", func() {
+		It("IT-KA-1553-001: is a no-op when fleet is disabled (no client, no tools)", func() {
+			cfg := kaconfig.DefaultConfig()
+			reg := registry.New()
 
-func TestRegisterFleetTools_Disabled_NoOp(t *testing.T) {
-	cfg := kaconfig.DefaultConfig()
-	reg := registry.New()
+			fc, toolNames := registerFleetTools(context.Background(), cfg, reg, logr.Discard())
+			Expect(fc).To(BeNil(), "*mcpclient.ResilientClient must remain nil when fleet gatewayType/endpoint are unset")
+			Expect(toolNames).To(BeNil(), "no tool names expected when fleet is disabled")
+		})
 
-	fc, toolNames := registerFleetTools(context.Background(), cfg, reg, logr.Discard())
-	if fc != nil {
-		t.Error("IT-KA-1553-001: *mcpclient.ResilientClient must remain nil when fleet gatewayType/endpoint are unset")
-	}
-	if toolNames != nil {
-		t.Errorf("IT-KA-1553-001: no tool names expected when fleet is disabled, got %v", toolNames)
-	}
-}
+		It("IT-KA-1553-001: wires the client and tools when the gateway is reachable", func() {
+			gw := mockgw.NewMockGateway()
+			DeferCleanup(gw.Close)
 
-func TestRegisterFleetTools_EnabledReachable_WiresClientAndTools(t *testing.T) {
-	gw := mockgw.NewMockGateway()
-	t.Cleanup(gw.Close)
+			cfg := kaconfig.DefaultConfig()
+			cfg.Integrations.Fleet.Endpoint = gw.URL()
+			cfg.Integrations.Fleet.GatewayType = "eaigw"
+			reg := registry.New()
 
-	cfg := kaconfig.DefaultConfig()
-	cfg.Integrations.Fleet.Endpoint = gw.URL()
-	cfg.Integrations.Fleet.GatewayType = "eaigw"
-	reg := registry.New()
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			DeferCleanup(cancel)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+			fc, _ := registerFleetTools(ctx, cfg, reg, logr.Discard())
+			Expect(fc).NotTo(BeNil(), "*mcpclient.ResilientClient must be returned when the Fleet MCP Gateway is reachable")
+			DeferCleanup(func() { _ = fc.Close() })
 
-	fc, _ := registerFleetTools(ctx, cfg, reg, logr.Discard())
-	if fc == nil {
-		t.Fatal("IT-KA-1553-001: *mcpclient.ResilientClient must be returned when the Fleet MCP Gateway is reachable")
-	}
-	t.Cleanup(func() { _ = fc.Close() })
-	if !fc.Ready() {
-		t.Error("IT-KA-1553-001: client must report Ready() when the initial connection succeeded")
-	}
-}
+			Expect(fc.Ready()).To(BeTrue(), "client must report Ready() when the initial connection succeeded")
+		})
 
-func TestRegisterFleetTools_EnabledUnreachable_RetainsClient(t *testing.T) {
-	cfg := kaconfig.DefaultConfig()
-	cfg.Integrations.Fleet.Endpoint = "http://127.0.0.1:1/unreachable"
-	cfg.Integrations.Fleet.GatewayType = "eaigw"
-	reg := registry.New()
+		It("IT-KA-1553-001: retains the client (not discarded) when the gateway is unreachable", func() {
+			cfg := kaconfig.DefaultConfig()
+			cfg.Integrations.Fleet.Endpoint = "http://127.0.0.1:1/unreachable"
+			cfg.Integrations.Fleet.GatewayType = "eaigw"
+			reg := registry.New()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
-	defer cancel()
+			ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+			DeferCleanup(cancel)
 
-	fc, toolNames := registerFleetTools(ctx, cfg, reg, logr.Discard())
-	if fc == nil {
-		t.Fatal("IT-KA-1553-001: *mcpclient.ResilientClient must be kept (not discarded) when the Fleet " +
-			"MCP Gateway is unreachable so the readiness gate's periodic probe can keep retrying it (#1553)")
-	}
-	t.Cleanup(func() { _ = fc.Close() })
-	if fc.Ready() {
-		t.Error("IT-KA-1553-001: the kept client must not report Ready() when its initial connection failed")
-	}
-	if toolNames != nil {
-		t.Errorf("IT-KA-1553-001: no fleet tools should be registered when the initial connection failed, got %v", toolNames)
-	}
-}
+			fc, toolNames := registerFleetTools(ctx, cfg, reg, logr.Discard())
+			Expect(fc).NotTo(BeNil(), "*mcpclient.ResilientClient must be kept (not discarded) when the Fleet "+
+				"MCP Gateway is unreachable so the readiness gate's periodic probe can keep retrying it (#1553)")
+			DeferCleanup(func() { _ = fc.Close() })
 
-// --- wireFleetReadinessGate wiring (#1553) ---
+			Expect(fc.Ready()).To(BeFalse(), "the kept client must not report Ready() when its initial connection failed")
+			Expect(toolNames).To(BeNil(), "no fleet tools should be registered when the initial connection failed")
+		})
+	})
 
-func TestWireFleetReadinessGate_KA_Disabled_NoGate(t *testing.T) {
-	gate := wireFleetReadinessGate(context.Background(), nil, logr.Discard())
-	if gate != nil {
-		t.Fatal("IT-FLEET-READY-KA-001a: readiness.Gate must remain nil when fleetClient is nil")
-	}
-}
+	Describe("wireFleetReadinessGate wiring", func() {
+		It("IT-FLEET-READY-KA-001a: remains nil when fleetClient is nil", func() {
+			gate := wireFleetReadinessGate(context.Background(), nil, logr.Discard())
+			Expect(gate).To(BeNil())
+		})
 
-func TestWireFleetReadinessGate_KA_EnabledReachable_ReadyImmediately(t *testing.T) {
-	gw := mockgw.NewMockGateway()
-	t.Cleanup(gw.Close)
+		It("IT-FLEET-READY-KA-001b: reports ready immediately when a resilient client is present and reachable", func() {
+			gw := mockgw.NewMockGateway()
+			DeferCleanup(gw.Close)
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancel()
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			DeferCleanup(cancel)
 
-	resilienceCfg := mcpclient.DefaultResilienceConfig()
-	resilienceCfg.MaxElapsedTime = 5 * time.Second
-	fleetClient, err := mcpclient.NewResilient(ctx, gw.URL(), resilienceCfg, logr.Discard())
-	if err != nil {
-		t.Fatalf("unexpected error connecting to mock MCP Gateway: %v", err)
-	}
-	t.Cleanup(func() { _ = fleetClient.Close() })
+			resilienceCfg := mcpclient.DefaultResilienceConfig()
+			resilienceCfg.MaxElapsedTime = 5 * time.Second
+			fleetClient, err := mcpclient.NewResilient(ctx, gw.URL(), resilienceCfg, logr.Discard())
+			Expect(err).NotTo(HaveOccurred())
+			DeferCleanup(func() { _ = fleetClient.Close() })
 
-	gate := wireFleetReadinessGate(ctx, fleetClient, logr.Discard())
-	if gate == nil {
-		t.Fatal("IT-FLEET-READY-KA-001b: readiness.Gate must be wired when a resilient client is present")
-	}
-	t.Cleanup(gate.Stop)
+			gate := wireFleetReadinessGate(ctx, fleetClient, logr.Discard())
+			Expect(gate).NotTo(BeNil(), "readiness.Gate must be wired when a resilient client is present")
+			DeferCleanup(gate.Stop)
 
-	if err := gate.Check(httptest.NewRequest("GET", "/readyz", nil)); err != nil {
-		t.Fatalf("IT-FLEET-READY-KA-001b: gate must report ready immediately when the MCP Gateway is reachable, got: %v", err)
-	}
-}
+			Expect(gate.Check(httptest.NewRequest("GET", "/readyz", nil))).NotTo(HaveOccurred(),
+				"gate must report ready immediately when the MCP Gateway is reachable")
+		})
 
-func TestWireFleetReadinessGate_KA_EnabledUnreachable_NotReady(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
+		It("IT-FLEET-READY-KA-001c: reports NotReady when the gateway is unreachable", func() {
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			DeferCleanup(cancel)
 
-	resilienceCfg := mcpclient.DefaultResilienceConfig()
-	resilienceCfg.InitialInterval = 50 * time.Millisecond
-	resilienceCfg.MaxElapsedTime = 500 * time.Millisecond
-	fleetClient, connErr := mcpclient.NewResilient(ctx, "http://127.0.0.1:1/unreachable", resilienceCfg, logr.Discard())
-	_ = connErr
-	if fleetClient != nil {
-		t.Cleanup(func() { _ = fleetClient.Close() })
-	}
+			resilienceCfg := mcpclient.DefaultResilienceConfig()
+			resilienceCfg.InitialInterval = 50 * time.Millisecond
+			resilienceCfg.MaxElapsedTime = 500 * time.Millisecond
+			fleetClient, connErr := mcpclient.NewResilient(ctx, "http://127.0.0.1:1/unreachable", resilienceCfg, logr.Discard())
+			_ = connErr
+			if fleetClient != nil {
+				DeferCleanup(func() { _ = fleetClient.Close() })
+			}
 
-	gate := wireFleetReadinessGate(ctx, fleetClient, logr.Discard())
-	if gate == nil {
-		t.Fatal("IT-FLEET-READY-KA-001c: readiness.Gate must still be wired (and report NotReady) when the MCP Gateway is unreachable")
-	}
-	t.Cleanup(gate.Stop)
+			gate := wireFleetReadinessGate(ctx, fleetClient, logr.Discard())
+			Expect(gate).NotTo(BeNil(), "readiness.Gate must still be wired (and report NotReady) when the MCP Gateway is unreachable")
+			DeferCleanup(gate.Stop)
 
-	if err := gate.Check(httptest.NewRequest("GET", "/readyz", nil)); err == nil {
-		t.Fatal("BR-INTEGRATION-054 / #1553: gate must report NotReady when the configured MCP Gateway is " +
-			"unreachable, so Kubernetes removes the pod from Service endpoints (pod-wide fail closed)")
-	}
-}
+			err := gate.Check(httptest.NewRequest("GET", "/readyz", nil))
+			Expect(err).To(HaveOccurred(), "BR-INTEGRATION-054 / #1553: gate must report NotReady when the configured "+
+				"MCP Gateway is unreachable, so Kubernetes removes the pod from Service endpoints (pod-wide fail closed)")
+		})
+	})
+})

--- a/cmd/kubernautagent/llm_builder.go
+++ b/cmd/kubernautagent/llm_builder.go
@@ -51,6 +51,7 @@ func buildLLMClientFromConfig(ctx context.Context, cfg types.LLMConfig) (llm.Cli
 			timeout = time.Duration(cfg.TimeoutSeconds) * time.Second
 		}
 		vertexOpts = append(vertexOpts, anthropicfamily.WithHTTPTimeout(timeout))
+		vertexOpts = append(vertexOpts, anthropicReasoningOptions(cfg)...)
 
 		chain, err := buildTransportChain(cfg)
 		if err != nil {
@@ -84,6 +85,7 @@ func buildAnthropicNativeClient(cfg types.LLMConfig) (llm.Client, error) {
 		timeout = time.Duration(cfg.TimeoutSeconds) * time.Second
 	}
 	opts = append(opts, anthropicfamily.WithHTTPTimeout(timeout))
+	opts = append(opts, anthropicReasoningOptions(cfg)...)
 
 	chain, err := buildTransportChain(cfg)
 	if err != nil {
@@ -94,6 +96,27 @@ func buildAnthropicNativeClient(cfg types.LLMConfig) (llm.Client, error) {
 	}
 
 	return anthropicfamily.NewWithAPIKey(cfg.APIKey, cfg.Model, opts...)
+}
+
+// anthropicReasoningOptions maps the operator's ai.llm.reasoning config into
+// an anthropicfamily.WithReasoning construction option, resolved once here
+// rather than threaded per-call from investigator business logic
+// (DD-HAPI-019, llm.ReasoningRequest doc contract).
+//
+// #1578 wiring-gap fix: before this, cfg.Reasoning.Enabled/BudgetTokens were
+// parsed and validated but never read anywhere in this file (only
+// cfg.Reasoning.CapabilityOverride was, for the unrelated OpenAI-compatible
+// replay-mode auto-detection below) — so ai.llm.reasoning.enabled: true had
+// no effect on any real Anthropic/Vertex call. anthropicfamily.Client now
+// applies this default whenever a per-call req.Options.Reasoning is nil.
+func anthropicReasoningOptions(cfg types.LLMConfig) []anthropicfamily.Option {
+	if cfg.Reasoning == nil || !cfg.Reasoning.Enabled {
+		return nil
+	}
+	return []anthropicfamily.Option{anthropicfamily.WithReasoning(llm.ReasoningRequest{
+		Enabled:      true,
+		BudgetTokens: cfg.Reasoning.BudgetTokens,
+	})}
 }
 
 // buildOpenAICompatClient constructs the shared-core-backed kaopenai.Client
@@ -116,6 +139,14 @@ func buildOpenAICompatClient(cfg types.LLMConfig) (llm.Client, error) {
 	}
 
 	opts := []kaopenai.Option{kaopenai.WithHTTPClient(httpClient)}
+	// Only CapabilityOverride is threaded here — the OpenAI Chat Completions
+	// wire protocol has no request-side "enable reasoning" field (unlike
+	// Anthropic's "thinking" param, see anthropicReasoningOptions above).
+	// cfg.Reasoning.Enabled/BudgetTokens are intentionally NOT read: reasoning
+	// capture for this family is unconditional and model-driven (DeepSeek
+	// -reasoner-class models always emit reasoning_content; see
+	// openaicompat's AC3 "always capture" behavior). CapabilityOverride only
+	// controls DetectReasoningMode's replay-mode auto-detection.
 	if cfg.Reasoning != nil && cfg.Reasoning.CapabilityOverride != "" {
 		opts = append(opts, kaopenai.WithCapabilityOverride(cfg.Reasoning.CapabilityOverride))
 	}

--- a/cmd/kubernautagent/llm_builder_tls_test.go
+++ b/cmd/kubernautagent/llm_builder_tls_test.go
@@ -17,73 +17,61 @@ limitations under the License.
 package main
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	kaconfig "github.com/jordigilh/kubernaut/internal/kubernautagent/config"
 )
 
-func TestBuildTransportChain_TLSCaFile(t *testing.T) {
-	caPath := generateTestCACert(t, "Test CA")
+var _ = Describe("buildTransportChain — TLS wiring", func() {
+	It("returns a non-nil transport when tlsCaFile is set", func() {
+		caPath := generateTestCACert(GinkgoTB(), "Test CA")
 
-	cfg := kaconfig.DefaultConfig()
-	cfg.AI.LLM.TLSCaFile = caPath
+		cfg := kaconfig.DefaultConfig()
+		cfg.AI.LLM.TLSCaFile = caPath
 
-	merged := mergeLLMConfig(cfg.AI.LLM, &kaconfig.LLMRuntimeConfig{})
+		merged := mergeLLMConfig(cfg.AI.LLM, &kaconfig.LLMRuntimeConfig{})
 
-	transport, err := buildTransportChain(merged)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if transport == nil {
-		t.Fatal("expected non-nil transport when tlsCaFile is set, got nil")
-	}
-}
+		transport, err := buildTransportChain(merged)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(transport).NotTo(BeNil())
+	})
 
-func TestBuildTransportChain_NoTLSCaFile(t *testing.T) {
-	cfg := kaconfig.DefaultConfig()
+	It("returns a nil transport when no custom TLS config is set", func() {
+		cfg := kaconfig.DefaultConfig()
 
-	merged := mergeLLMConfig(cfg.AI.LLM, &kaconfig.LLMRuntimeConfig{})
+		merged := mergeLLMConfig(cfg.AI.LLM, &kaconfig.LLMRuntimeConfig{})
 
-	transport, err := buildTransportChain(merged)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if transport != nil {
-		t.Fatalf("expected nil transport when no custom config, got %T", transport)
-	}
-}
+		transport, err := buildTransportChain(merged)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(transport).To(BeNil())
+	})
 
-// UT-KA-1342-030: buildTransportChain returns error for invalid CA file (fail-hard per SC-8)
-func TestBuildTransportChain_InvalidCaFile(t *testing.T) {
-	cfg := kaconfig.DefaultConfig()
-	cfg.AI.LLM.TLSCaFile = "/nonexistent/ca.crt"
+	// UT-KA-1342-030: buildTransportChain returns error for invalid CA file (fail-hard per SC-8)
+	It("returns an error for an invalid CA file (fail-hard per SC-8)", func() {
+		cfg := kaconfig.DefaultConfig()
+		cfg.AI.LLM.TLSCaFile = "/nonexistent/ca.crt"
 
-	merged := mergeLLMConfig(cfg.AI.LLM, &kaconfig.LLMRuntimeConfig{})
+		merged := mergeLLMConfig(cfg.AI.LLM, &kaconfig.LLMRuntimeConfig{})
 
-	_, err := buildTransportChain(merged)
-	if err == nil {
-		t.Fatal("expected error for invalid CA file, got nil")
-	}
-}
+		_, err := buildTransportChain(merged)
+		Expect(err).To(HaveOccurred())
+	})
 
-// UT-KA-1342-020: buildTransportChain passes WithClientCert when cert fields are set
-func TestBuildTransportChain_mTLS(t *testing.T) {
-	caPath := generateTestCACert(t, "Test CA")
+	// UT-KA-1342-020: buildTransportChain passes WithClientCert when cert fields are set
+	It("builds a non-nil transport for a full mTLS config (ca + cert + key)", func() {
+		caPath := generateTestCACert(GinkgoTB(), "Test CA")
+		certPath, keyPath := generateTestClientCert(GinkgoTB(), caPath)
 
-	certPath, keyPath := generateTestClientCert(t, caPath)
+		cfg := kaconfig.DefaultConfig()
+		cfg.AI.LLM.TLSCaFile = caPath
+		cfg.AI.LLM.TLSCertFile = certPath
+		cfg.AI.LLM.TLSKeyFile = keyPath
 
-	cfg := kaconfig.DefaultConfig()
-	cfg.AI.LLM.TLSCaFile = caPath
-	cfg.AI.LLM.TLSCertFile = certPath
-	cfg.AI.LLM.TLSKeyFile = keyPath
+		merged := mergeLLMConfig(cfg.AI.LLM, &kaconfig.LLMRuntimeConfig{})
 
-	merged := mergeLLMConfig(cfg.AI.LLM, &kaconfig.LLMRuntimeConfig{})
-
-	chain, err := buildTransportChain(merged)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if chain == nil {
-		t.Fatal("expected non-nil transport for mTLS config")
-	}
-}
+		chain, err := buildTransportChain(merged)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(chain).NotTo(BeNil())
+	})
+})

--- a/cmd/kubernautagent/llm_builder_wiring_1580_1581_test.go
+++ b/cmd/kubernautagent/llm_builder_wiring_1580_1581_test.go
@@ -26,6 +26,76 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/shared/types"
 )
 
+// IT-KA-1578-001: anthropicReasoningOptions — the exact mapping used by both
+// buildAnthropicNativeClient and the vertex_ai case in
+// buildLLMClientFromConfig — is proven independently of the (untestable
+// without a live network seam) SDK HTTP call. anthropicfamily's own
+// httptest-based suite (thinking_1580_test.go, UT-KA-1578-201..204) proves
+// WithReasoning's effect once applied; this proves the config->option
+// mapping that used to be entirely missing (#1578 wiring-gap fix).
+func TestAnthropicReasoningOptions_Wiring(t *testing.T) {
+	t.Run("enabled config produces exactly one WithReasoning option", func(t *testing.T) {
+		cfg := types.LLMConfig{
+			Reasoning: &types.LLMReasoningConfig{Enabled: true, BudgetTokens: 8192},
+		}
+		opts := anthropicReasoningOptions(cfg)
+		if len(opts) != 1 {
+			t.Fatalf("expected exactly 1 option for reasoning.enabled=true, got %d", len(opts))
+		}
+	})
+
+	t.Run("nil Reasoning produces no options (no regression for existing deployments)", func(t *testing.T) {
+		cfg := types.LLMConfig{}
+		opts := anthropicReasoningOptions(cfg)
+		if len(opts) != 0 {
+			t.Fatalf("expected 0 options when cfg.Reasoning is nil, got %d", len(opts))
+		}
+	})
+
+	t.Run("reasoning.enabled=false produces no options", func(t *testing.T) {
+		cfg := types.LLMConfig{
+			Reasoning: &types.LLMReasoningConfig{Enabled: false, BudgetTokens: 8192},
+		}
+		opts := anthropicReasoningOptions(cfg)
+		if len(opts) != 0 {
+			t.Fatalf("expected 0 options when cfg.Reasoning.Enabled is false, got %d", len(opts))
+		}
+	})
+}
+
+// IT-KA-1578-002: buildAnthropicNativeClient dispatches a reasoning-enabled
+// config through the real production construction path without error
+// (CHECKPOINT W row: config -> client construction). Combined with
+// TestAnthropicReasoningOptions_Wiring (proves the exact cfg->option
+// mapping) and anthropicfamily's own httptest-based suite (proves
+// WithReasoning's wire-level effect once applied), these three together
+// prove the full chain: operator config -> constructed option -> applied
+// client default -> outgoing "thinking" param. A live end-to-end Chat()
+// call through this exact function is not exercised here because
+// buildAnthropicNativeClient has no cfg-driven seam to redirect the SDK's
+// base URL away from api.anthropic.com without a real network call.
+func TestBuildAnthropicNativeClient_Reasoning_Wiring(t *testing.T) {
+	cfg := types.LLMConfig{
+		Provider:  types.LLMProviderAnthropic,
+		Model:     "claude-sonnet-4-6",
+		APIKey:    "sk-ant-fake-test-key",
+		Reasoning: &types.LLMReasoningConfig{Enabled: true, BudgetTokens: 2048},
+	}
+
+	client, err := buildAnthropicNativeClient(cfg)
+	if err != nil {
+		t.Fatalf("buildAnthropicNativeClient unexpected error: %v", err)
+	}
+	if _, ok := client.(*anthropicfamily.Client); !ok {
+		t.Fatalf("expected *anthropicfamily.Client, got %T", client)
+	}
+	// anthropicReasoningOptions is exercised as part of the construction
+	// path above (it is unconditionally appended to opts in
+	// buildAnthropicNativeClient); TestAnthropicReasoningOptions_Wiring
+	// proves its mapping precisely, and anthropicfamily's own suite proves
+	// WithReasoning's wire-level effect once applied to a Client.
+}
+
 // IT-KA-1580-001: buildLLMClientFromConfig dispatches provider "anthropic"
 // (LLMProviderAnthropic, native API-key auth) to anthropicfamily.NewWithAPIKey
 // through the actual production switch statement — not just a direct call to

--- a/cmd/kubernautagent/llm_builder_wiring_1580_1581_test.go
+++ b/cmd/kubernautagent/llm_builder_wiring_1580_1581_test.go
@@ -18,170 +18,230 @@ package main
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"net/http"
 	"net/http/httptest"
-	"testing"
 
+	"github.com/anthropics/anthropic-sdk-go/option"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm/anthropicfamily"
 	kaopenai "github.com/jordigilh/kubernaut/pkg/kubernautagent/llm/openai"
 	"github.com/jordigilh/kubernaut/pkg/shared/types"
 )
 
-// IT-KA-1578-001: anthropicReasoningOptions — the exact mapping used by both
-// buildAnthropicNativeClient and the vertex_ai case in
-// buildLLMClientFromConfig — is proven independently of the (untestable
-// without a live network seam) SDK HTTP call. anthropicfamily's own
-// httptest-based suite (thinking_1580_test.go, UT-KA-1578-201..204) proves
-// WithReasoning's effect once applied; this proves the config->option
-// mapping that used to be entirely missing (#1578 wiring-gap fix).
-func TestAnthropicReasoningOptions_Wiring(t *testing.T) {
-	t.Run("enabled config produces exactly one WithReasoning option", func(t *testing.T) {
-		cfg := types.LLMConfig{
-			Reasoning: &types.LLMReasoningConfig{Enabled: true, BudgetTokens: 8192},
-		}
-		opts := anthropicReasoningOptions(cfg)
-		if len(opts) != 1 {
-			t.Fatalf("expected exactly 1 option for reasoning.enabled=true, got %d", len(opts))
-		}
+// helloChatRequest is a minimal single-turn request shared by the
+// request-side wiring specs below; its content is irrelevant — only the
+// resulting outgoing "thinking" param (or its absence) is asserted.
+func helloChatRequest() llm.ChatRequest {
+	return llm.ChatRequest{Messages: []llm.Message{{Role: "user", Content: "hello"}}}
+}
+
+var _ = Describe("buildLLMClientFromConfig — provider dispatch wiring (#1578 #1580 #1581)", func() {
+
+	Describe("anthropicReasoningOptions — cfg.Reasoning -> anthropicfamily.Option mapping (IT-KA-1578-001)", func() {
+		// The exact mapping used by both buildAnthropicNativeClient and the
+		// vertex_ai case in buildLLMClientFromConfig, proven independently of
+		// the (untestable without a live network seam) SDK HTTP call.
+		// anthropicfamily's own httptest-based suite (thinking_1580_test.go,
+		// UT-KA-1578-201..204) proves WithReasoning's effect once applied;
+		// this proves the config->option mapping that used to be entirely
+		// missing (#1578 wiring-gap fix).
+
+		It("produces exactly one WithReasoning option when reasoning is enabled", func() {
+			cfg := types.LLMConfig{
+				Reasoning: &types.LLMReasoningConfig{Enabled: true, BudgetTokens: 8192},
+			}
+			opts := anthropicReasoningOptions(cfg)
+			Expect(opts).To(HaveLen(1))
+		})
+
+		It("produces no options when Reasoning is nil (no regression for existing deployments)", func() {
+			cfg := types.LLMConfig{}
+			opts := anthropicReasoningOptions(cfg)
+			Expect(opts).To(BeEmpty())
+		})
+
+		It("produces no options when reasoning.enabled is false", func() {
+			cfg := types.LLMConfig{
+				Reasoning: &types.LLMReasoningConfig{Enabled: false, BudgetTokens: 8192},
+			}
+			opts := anthropicReasoningOptions(cfg)
+			Expect(opts).To(BeEmpty())
+		})
 	})
 
-	t.Run("nil Reasoning produces no options (no regression for existing deployments)", func(t *testing.T) {
-		cfg := types.LLMConfig{}
-		opts := anthropicReasoningOptions(cfg)
-		if len(opts) != 0 {
-			t.Fatalf("expected 0 options when cfg.Reasoning is nil, got %d", len(opts))
-		}
+	Describe("buildAnthropicNativeClient — reasoning-enabled config dispatch (IT-KA-1578-002)", func() {
+		// Proves buildAnthropicNativeClient dispatches a reasoning-enabled
+		// config through the real production construction path without error
+		// (CHECKPOINT W row: config -> client construction).
+		It("constructs a client without error and applies the reasoning option", func() {
+			cfg := types.LLMConfig{
+				Provider:  types.LLMProviderAnthropic,
+				Model:     "claude-sonnet-4-6",
+				APIKey:    "sk-ant-fake-test-key",
+				Reasoning: &types.LLMReasoningConfig{Enabled: true, BudgetTokens: 2048},
+			}
+
+			client, err := buildAnthropicNativeClient(cfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).To(BeAssignableToTypeOf(&anthropicfamily.Client{}))
+		})
 	})
 
-	t.Run("reasoning.enabled=false produces no options", func(t *testing.T) {
-		cfg := types.LLMConfig{
-			Reasoning: &types.LLMReasoningConfig{Enabled: false, BudgetTokens: 8192},
-		}
-		opts := anthropicReasoningOptions(cfg)
-		if len(opts) != 0 {
-			t.Fatalf("expected 0 options when cfg.Reasoning.Enabled is false, got %d", len(opts))
-		}
+	Describe("request-side wiring end-to-end: cfg.Reasoning -> outgoing \"thinking\" param (IT-KA-1578-003)", func() {
+		// Closes the full chain that the two Describe blocks above prove in
+		// isolation: this test replicates buildAnthropicNativeClient's exact
+		// option composition (anthropicReasoningOptions(cfg), the same
+		// unexported helper the production dispatch path calls) against a
+		// live httptest server, and asserts the real outgoing HTTP body
+		// contains "thinking". buildAnthropicNativeClient itself cannot be
+		// redirected to a test server in production code (Anthropic's native
+		// API has no operator-facing "endpoint override" concept — unlike
+		// openai_compatible, see buildOpenAICompatClient — so adding one
+		// purely for testability would be speculative code with no real
+		// deployment use case). anthropicfamily.WithSDKOptions is already
+		// documented as test-only for exactly this purpose.
+		var (
+			server       *httptest.Server
+			receivedBody map[string]interface{}
+		)
+
+		BeforeEach(func() {
+			receivedBody = nil
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &receivedBody)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"claude-sonnet-4-6","stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+			}))
+		})
+
+		AfterEach(func() {
+			server.Close()
+		})
+
+		It("sends the thinking param on the wire when the operator's config has reasoning.enabled=true", func() {
+			cfg := types.LLMConfig{
+				Provider:  types.LLMProviderAnthropic,
+				Model:     "claude-sonnet-4-6",
+				APIKey:    "sk-ant-fake-test-key",
+				Reasoning: &types.LLMReasoningConfig{Enabled: true, BudgetTokens: 4096},
+			}
+
+			opts := append(anthropicReasoningOptions(cfg), anthropicfamily.WithSDKOptions(option.WithBaseURL(server.URL)))
+			client, err := anthropicfamily.NewWithAPIKey(cfg.APIKey, cfg.Model, opts...)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = client.Chat(context.Background(), helloChatRequest())
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(receivedBody).To(HaveKey("thinking"),
+				"operator config ai.llm.reasoning.enabled=true must reach the outgoing Anthropic request")
+			thinking := receivedBody["thinking"].(map[string]interface{})
+			Expect(thinking["budget_tokens"]).To(BeNumerically("==", 4096))
+		})
+
+		It("omits the thinking param when the operator's config has no reasoning block (no regression)", func() {
+			cfg := types.LLMConfig{
+				Provider: types.LLMProviderAnthropic,
+				Model:    "claude-sonnet-4-6",
+				APIKey:   "sk-ant-fake-test-key",
+			}
+
+			opts := append(anthropicReasoningOptions(cfg), anthropicfamily.WithSDKOptions(option.WithBaseURL(server.URL)))
+			client, err := anthropicfamily.NewWithAPIKey(cfg.APIKey, cfg.Model, opts...)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = client.Chat(context.Background(), helloChatRequest())
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(receivedBody).NotTo(HaveKey("thinking"))
+		})
 	})
-}
 
-// IT-KA-1578-002: buildAnthropicNativeClient dispatches a reasoning-enabled
-// config through the real production construction path without error
-// (CHECKPOINT W row: config -> client construction). Combined with
-// TestAnthropicReasoningOptions_Wiring (proves the exact cfg->option
-// mapping) and anthropicfamily's own httptest-based suite (proves
-// WithReasoning's wire-level effect once applied), these three together
-// prove the full chain: operator config -> constructed option -> applied
-// client default -> outgoing "thinking" param. A live end-to-end Chat()
-// call through this exact function is not exercised here because
-// buildAnthropicNativeClient has no cfg-driven seam to redirect the SDK's
-// base URL away from api.anthropic.com without a real network call.
-func TestBuildAnthropicNativeClient_Reasoning_Wiring(t *testing.T) {
-	cfg := types.LLMConfig{
-		Provider:  types.LLMProviderAnthropic,
-		Model:     "claude-sonnet-4-6",
-		APIKey:    "sk-ant-fake-test-key",
-		Reasoning: &types.LLMReasoningConfig{Enabled: true, BudgetTokens: 2048},
-	}
+	Describe("buildLLMClientFromConfig — provider anthropic dispatch (IT-KA-1580-001)", func() {
+		// buildLLMClientFromConfig dispatches provider "anthropic"
+		// (LLMProviderAnthropic, native API-key auth) to
+		// anthropicfamily.NewWithAPIKey through the actual production switch
+		// statement — not just a direct call to the constructor in a
+		// package-local test (CHECKPOINT W, Wiring Manifest row 1).
+		It("dispatches to the native anthropicfamily.Client constructor", func() {
+			cfg := types.LLMConfig{
+				Provider: types.LLMProviderAnthropic,
+				Model:    "claude-sonnet-4-6",
+				APIKey:   "sk-ant-fake-test-key",
+			}
 
-	client, err := buildAnthropicNativeClient(cfg)
-	if err != nil {
-		t.Fatalf("buildAnthropicNativeClient unexpected error: %v", err)
-	}
-	if _, ok := client.(*anthropicfamily.Client); !ok {
-		t.Fatalf("expected *anthropicfamily.Client, got %T", client)
-	}
-	// anthropicReasoningOptions is exercised as part of the construction
-	// path above (it is unconditionally appended to opts in
-	// buildAnthropicNativeClient); TestAnthropicReasoningOptions_Wiring
-	// proves its mapping precisely, and anthropicfamily's own suite proves
-	// WithReasoning's wire-level effect once applied to a Client.
-}
+			client, err := buildLLMClientFromConfig(context.Background(), cfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).To(BeAssignableToTypeOf(&anthropicfamily.Client{}))
+		})
 
-// IT-KA-1580-001: buildLLMClientFromConfig dispatches provider "anthropic"
-// (LLMProviderAnthropic, native API-key auth) to anthropicfamily.NewWithAPIKey
-// through the actual production switch statement — not just a direct call to
-// the constructor in a package-local test (CHECKPOINT W, Wiring Manifest row 1).
-func TestBuildLLMClientFromConfig_AnthropicNative_Wiring(t *testing.T) {
-	cfg := types.LLMConfig{
-		Provider: types.LLMProviderAnthropic,
-		Model:    "claude-sonnet-4-6",
-		APIKey:   "sk-ant-fake-test-key",
-	}
+		// UT-KA-1580-001b: the anthropic provider case fails fast with no API
+		// key, matching NewWithAPIKey's own validation (production dispatch
+		// must not silently construct a client that will fail on first use).
+		It("fails fast when no apiKey is configured", func() {
+			cfg := types.LLMConfig{
+				Provider: types.LLMProviderAnthropic,
+				Model:    "claude-sonnet-4-6",
+			}
 
-	client, err := buildLLMClientFromConfig(context.Background(), cfg)
-	if err != nil {
-		t.Fatalf("buildLLMClientFromConfig(anthropic) unexpected error: %v", err)
-	}
-	if client == nil {
-		t.Fatal("buildLLMClientFromConfig(anthropic) returned nil client")
-	}
-	if _, ok := client.(*anthropicfamily.Client); !ok {
-		t.Fatalf("expected *anthropicfamily.Client, got %T — provider %q must dispatch to the native constructor",
-			client, types.LLMProviderAnthropic)
-	}
-}
+			_, err := buildLLMClientFromConfig(context.Background(), cfg)
+			Expect(err).To(HaveOccurred())
+		})
+	})
 
-// UT-KA-1580-001b: the anthropic provider case fails fast with no API key,
-// matching NewWithAPIKey's own validation (production dispatch must not
-// silently construct a client that will fail on first use).
-func TestBuildLLMClientFromConfig_AnthropicNative_RequiresAPIKey(t *testing.T) {
-	cfg := types.LLMConfig{
-		Provider: types.LLMProviderAnthropic,
-		Model:    "claude-sonnet-4-6",
-	}
+	Describe("buildLLMClientFromConfig — provider openai/openai_compatible dispatch (IT-KA-1581-002)", func() {
+		// buildLLMClientFromConfig dispatches providers "openai" and
+		// "openai_compatible" to the shared-core-backed kaopenai.Client
+		// through the actual production switch statement (CHECKPOINT W,
+		// Wiring Manifest row 3).
+		var server *httptest.Server
 
-	_, err := buildLLMClientFromConfig(context.Background(), cfg)
-	if err == nil {
-		t.Fatal("expected an error when provider=anthropic has no apiKey configured")
-	}
-}
+		BeforeEach(func() {
+			server = httptest.NewServer(nil)
+		})
 
-// IT-KA-1581-002: buildLLMClientFromConfig dispatches providers "openai" and
-// "openai_compatible" to the shared-core-backed kaopenai.Client through the
-// actual production switch statement (CHECKPOINT W, Wiring Manifest row 3).
-func TestBuildLLMClientFromConfig_OpenAICompat_Wiring(t *testing.T) {
-	server := httptest.NewServer(nil)
-	defer server.Close()
+		AfterEach(func() {
+			server.Close()
+		})
 
-	for _, provider := range []string{types.LLMProviderOpenAI, types.LLMProviderOpenAICompatible} {
-		cfg := types.LLMConfig{
-			Provider: provider,
-			Model:    "gpt-4o",
-			Endpoint: server.URL,
-			APIKey:   "sk-fake-test-key",
-		}
+		DescribeTable("dispatches to the shared-core kaopenai.Client wrapper",
+			func(provider string) {
+				cfg := types.LLMConfig{
+					Provider: provider,
+					Model:    "gpt-4o",
+					Endpoint: server.URL,
+					APIKey:   "sk-fake-test-key",
+				}
 
-		client, err := buildLLMClientFromConfig(context.Background(), cfg)
-		if err != nil {
-			t.Fatalf("buildLLMClientFromConfig(%s) unexpected error: %v", provider, err)
-		}
-		if client == nil {
-			t.Fatalf("buildLLMClientFromConfig(%s) returned nil client", provider)
-		}
-		if _, ok := client.(*kaopenai.Client); !ok {
-			t.Fatalf("provider %q: expected *kaopenai.Client, got %T — must dispatch to the shared-core wrapper",
-				provider, client)
-		}
-	}
-}
+				client, err := buildLLMClientFromConfig(context.Background(), cfg)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(client).To(BeAssignableToTypeOf(&kaopenai.Client{}))
+			},
+			Entry("provider=openai", types.LLMProviderOpenAI),
+			Entry("provider=openai_compatible", types.LLMProviderOpenAICompatible),
+		)
+	})
 
-// UT-KA-1581-002b: an unrecognized provider (Gemini native, never had a
-// langchaingo case either) still falls through to the default branch and
-// gets an explicit error, proving the new anthropic/openai cases above are
-// additive and the removed-langchaingo default path fails loudly rather
-// than silently.
-func TestBuildLLMClientFromConfig_UnsupportedProvider_ReturnsError(t *testing.T) {
-	cfg := types.LLMConfig{
-		Provider: types.LLMProviderGemini,
-		Model:    "gemini-not-yet-migrated",
-	}
+	Describe("buildLLMClientFromConfig — unsupported provider (UT-KA-1581-002b)", func() {
+		// An unrecognized provider (Gemini native, never had a langchaingo
+		// case either) still falls through to the default branch and gets an
+		// explicit error, proving the anthropic/openai cases above are
+		// additive and the removed-langchaingo default path fails loudly
+		// rather than silently.
+		It("returns an explicit error for gemini: no langchaingo fallback exists anymore", func() {
+			cfg := types.LLMConfig{
+				Provider: types.LLMProviderGemini,
+				Model:    "gemini-not-yet-migrated",
+			}
 
-	// Gemini has no dedicated case in buildLLMClientFromConfig (only
-	// anthropic/openai/openai-compatible are wired) and langchaingo has been
-	// fully removed (#1580/#1581 M4), so the default case must return an
-	// explicit "unsupported LLM provider" error rather than silently falling
-	// through to a removed dependency.
-	_, err := buildLLMClientFromConfig(context.Background(), cfg)
-	if err == nil {
-		t.Fatal("expected an error for gemini: no langchaingo fallback exists anymore")
-	}
-}
+			_, err := buildLLMClientFromConfig(context.Background(), cfg)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/cmd/kubernautagent/mcp_handler_guards_test.go
+++ b/cmd/kubernautagent/mcp_handler_guards_test.go
@@ -18,56 +18,51 @@ package main
 
 import (
 	"context"
-	"testing"
 
 	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"k8s.io/client-go/rest"
 
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
 	auth "github.com/jordigilh/kubernaut/pkg/shared/auth"
 )
 
-// TestBuildMCPHandler_Guards is a characterization test for buildMCPHandler's
-// three required-dependency guard clauses (Issue #1520 Phase 2: pins behavior
-// before the mcpHandlerParams struct extraction, per AGENTS.md's TDD mandate
-// for zero-coverage refactor targets). Each case returns before touching the
-// network (ctrlclient.New), so no live cluster is needed.
-func TestBuildMCPHandler_Guards(t *testing.T) {
-	validInfra := &k8sInfra{kubeConfig: &rest.Config{}}
-	validAuthMw := &auth.Middleware{}
-	validInv := &investigator.Investigator{}
+// buildMCPHandler's three required-dependency guard clauses — characterization
+// tests (Issue #1520 Phase 2: pins behavior before the mcpHandlerParams struct
+// extraction, per AGENTS.md's TDD mandate for zero-coverage refactor
+// targets). Each case returns before touching the network (ctrlclient.New),
+// so no live cluster is needed.
+var _ = Describe("buildMCPHandler — required-dependency guards", func() {
+	var (
+		validInfra  *k8sInfra
+		validAuthMw *auth.Middleware
+		validInv    *investigator.Investigator
+	)
 
-	tests := []struct {
-		name   string
-		params mcpHandlerParams
-	}{
-		{
-			name:   "nil infra",
-			params: mcpHandlerParams{infra: nil, authMw: validAuthMw, inv: validInv, logger: logr.Discard()},
-		},
-		{
-			name:   "infra with nil kubeConfig",
-			params: mcpHandlerParams{infra: &k8sInfra{}, authMw: validAuthMw, inv: validInv, logger: logr.Discard()},
-		},
-		{
-			name:   "nil auth middleware (DD-AUTH-MCP-001)",
-			params: mcpHandlerParams{infra: validInfra, authMw: nil, inv: validInv, logger: logr.Discard()},
-		},
-		{
-			name:   "nil investigator (SEC-05)",
-			params: mcpHandlerParams{infra: validInfra, authMw: validAuthMw, inv: nil, logger: logr.Discard()},
-		},
-	}
+	BeforeEach(func() {
+		validInfra = &k8sInfra{kubeConfig: &rest.Config{}}
+		validAuthMw = &auth.Middleware{}
+		validInv = &investigator.Investigator{}
+	})
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			handler, drainer := buildMCPHandler(context.Background(), tt.params)
-			if handler != nil {
-				t.Errorf("expected nil handler, got %v", handler)
-			}
-			if drainer != nil {
-				t.Errorf("expected nil session drainer, got %v", drainer)
-			}
-		})
-	}
-}
+	DescribeTable("returns a nil handler and nil drainer when a required dependency is missing",
+		func(paramsFn func() mcpHandlerParams) {
+			handler, drainer := buildMCPHandler(context.Background(), paramsFn())
+			Expect(handler).To(BeNil())
+			Expect(drainer).To(BeNil())
+		},
+		Entry("nil infra", func() mcpHandlerParams {
+			return mcpHandlerParams{infra: nil, authMw: validAuthMw, inv: validInv, logger: logr.Discard()}
+		}),
+		Entry("infra with nil kubeConfig", func() mcpHandlerParams {
+			return mcpHandlerParams{infra: &k8sInfra{}, authMw: validAuthMw, inv: validInv, logger: logr.Discard()}
+		}),
+		Entry("nil auth middleware (DD-AUTH-MCP-001)", func() mcpHandlerParams {
+			return mcpHandlerParams{infra: validInfra, authMw: nil, inv: validInv, logger: logr.Discard()}
+		}),
+		Entry("nil investigator (SEC-05)", func() mcpHandlerParams {
+			return mcpHandlerParams{infra: validInfra, authMw: validAuthMw, inv: nil, logger: logr.Discard()}
+		}),
+	)
+})

--- a/cmd/kubernautagent/readiness_handler_test.go
+++ b/cmd/kubernautagent/readiness_handler_test.go
@@ -22,10 +22,11 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
-	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	karbac "github.com/jordigilh/kubernaut/internal/kubernautagent/rbac"
 	"github.com/jordigilh/kubernaut/pkg/fleet/readiness"
@@ -40,110 +41,96 @@ func (fakeUnreadyProber) Probe(context.Context) error {
 	return errors.New("fake: fleet dependency unreachable")
 }
 
-// UT-KA-JWKS-001: readinessHandler reports not_ready before the main API
-// server has started listening, even when shutdownFlag and the LLM client
-// are otherwise ready. This guards against the race fixed alongside the JWKS
-// pre-warm startup reorder: the health server now starts before the
-// route-setup closure (which performs the JWKS pre-warm), so /readyz must
-// not report ready until the main API server is actually about to listen.
-func TestReadinessHandler_NotReadyBeforeAPIServerListening(t *testing.T) {
+var _ = Describe("readinessHandler", func() {
 	var shutdownFlag, apiServerReady int32
-	swappable := setupSwappable(t)
-	interactive := karbac.NewInteractiveReadiness()
 
-	handler := readinessHandler(&shutdownFlag, &apiServerReady, swappable, nil, interactive, nil)
+	BeforeEach(func() {
+		shutdownFlag = 0
+		apiServerReady = 0
+	})
 
-	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
-	rec := httptest.NewRecorder()
-	handler(rec, req)
-
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Fatalf("UT-KA-JWKS-001: expected 503 before apiServerReady is set, got %d", rec.Code)
+	doRequest := func(handler http.HandlerFunc) *httptest.ResponseRecorder {
+		req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
+		rec := httptest.NewRecorder()
+		handler(rec, req)
+		return rec
 	}
-}
 
-// UT-KA-JWKS-002: readinessHandler reports ready once apiServerReady is set
-// (and all other dependencies are healthy).
-func TestReadinessHandler_ReadyAfterAPIServerListening(t *testing.T) {
-	var shutdownFlag, apiServerReady int32
-	atomic.StoreInt32(&apiServerReady, 1)
-	swappable := setupSwappable(t)
-	interactive := karbac.NewInteractiveReadiness()
+	// UT-KA-JWKS-001: readinessHandler reports not_ready before the main API
+	// server has started listening, even when shutdownFlag and the LLM client
+	// are otherwise ready. This guards against the race fixed alongside the
+	// JWKS pre-warm startup reorder: the health server now starts before the
+	// route-setup closure (which performs the JWKS pre-warm), so /readyz must
+	// not report ready until the main API server is actually about to listen.
+	It("UT-KA-JWKS-001: reports not_ready before the API server has started listening", func() {
+		swappable := setupSwappable(GinkgoTB())
+		interactive := karbac.NewInteractiveReadiness()
 
-	handler := readinessHandler(&shutdownFlag, &apiServerReady, swappable, nil, interactive, nil)
+		handler := readinessHandler(&shutdownFlag, &apiServerReady, swappable, nil, interactive, nil)
 
-	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
-	rec := httptest.NewRecorder()
-	handler(rec, req)
+		rec := doRequest(handler)
+		Expect(rec.Code).To(Equal(http.StatusServiceUnavailable))
+	})
 
-	if rec.Code != http.StatusOK {
-		t.Fatalf("UT-KA-JWKS-002: expected 200 once apiServerReady is set, got %d (body: %s)", rec.Code, rec.Body.String())
-	}
-}
+	// UT-KA-JWKS-002: readinessHandler reports ready once apiServerReady is
+	// set (and all other dependencies are healthy).
+	It("UT-KA-JWKS-002: reports ready once the API server is listening", func() {
+		atomic.StoreInt32(&apiServerReady, 1)
+		swappable := setupSwappable(GinkgoTB())
+		interactive := karbac.NewInteractiveReadiness()
 
-// UT-KA-JWKS-003: shutdownFlag takes priority over apiServerReady -- once
-// shutdown begins, the probe must fail even if the API server was ready.
-func TestReadinessHandler_ShutdownTakesPriority(t *testing.T) {
-	var shutdownFlag, apiServerReady int32
-	atomic.StoreInt32(&apiServerReady, 1)
-	atomic.StoreInt32(&shutdownFlag, 1)
-	swappable := setupSwappable(t)
-	interactive := karbac.NewInteractiveReadiness()
+		handler := readinessHandler(&shutdownFlag, &apiServerReady, swappable, nil, interactive, nil)
 
-	handler := readinessHandler(&shutdownFlag, &apiServerReady, swappable, nil, interactive, nil)
+		rec := doRequest(handler)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+	})
 
-	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
-	rec := httptest.NewRecorder()
-	handler(rec, req)
+	// UT-KA-JWKS-003: shutdownFlag takes priority over apiServerReady -- once
+	// shutdown begins, the probe must fail even if the API server was ready.
+	It("UT-KA-JWKS-003: shutdownFlag takes priority over apiServerReady", func() {
+		atomic.StoreInt32(&apiServerReady, 1)
+		atomic.StoreInt32(&shutdownFlag, 1)
+		swappable := setupSwappable(GinkgoTB())
+		interactive := karbac.NewInteractiveReadiness()
 
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Fatalf("UT-KA-JWKS-003: expected 503 during shutdown, got %d", rec.Code)
-	}
-}
+		handler := readinessHandler(&shutdownFlag, &apiServerReady, swappable, nil, interactive, nil)
 
-// UT-KA-1553-001: readinessHandler must report 503 when the injected Fleet
-// readiness gate is NotReady, even though every other dependency (API
-// server, LLM client, interactive mode) is healthy. This is the pod-wide
-// fail-closed behavior mandated by ADR-068 decision #11 / BR-INTEGRATION-054
-// (#1553): an unreachable Fleet MCP Gateway must remove the whole pod from
-// Service endpoints, not just silently degrade fleet-scoped functionality.
-func TestReadinessHandler_FleetGateNotReady_ReturnsUnavailable(t *testing.T) {
-	var shutdownFlag, apiServerReady int32
-	atomic.StoreInt32(&apiServerReady, 1)
-	swappable := setupSwappable(t)
-	interactive := karbac.NewInteractiveReadiness()
+		rec := doRequest(handler)
+		Expect(rec.Code).To(Equal(http.StatusServiceUnavailable))
+	})
 
-	gate := readiness.NewGate(time.Hour, logr.Discard(), fakeUnreadyProber{})
-	gate.Start(context.Background())
-	t.Cleanup(gate.Stop)
+	// UT-KA-1553-001: readinessHandler must report 503 when the injected Fleet
+	// readiness gate is NotReady, even though every other dependency (API
+	// server, LLM client, interactive mode) is healthy. This is the pod-wide
+	// fail-closed behavior mandated by ADR-068 decision #11 / BR-INTEGRATION-054
+	// (#1553): an unreachable Fleet MCP Gateway must remove the whole pod from
+	// Service endpoints, not just silently degrade fleet-scoped functionality.
+	It("UT-KA-1553-001: reports 503 when the Fleet readiness gate is NotReady", func() {
+		atomic.StoreInt32(&apiServerReady, 1)
+		swappable := setupSwappable(GinkgoTB())
+		interactive := karbac.NewInteractiveReadiness()
 
-	handler := readinessHandler(&shutdownFlag, &apiServerReady, swappable, nil, interactive, gate)
+		gate := readiness.NewGate(time.Hour, logr.Discard(), fakeUnreadyProber{})
+		gate.Start(context.Background())
+		DeferCleanup(gate.Stop)
 
-	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
-	rec := httptest.NewRecorder()
-	handler(rec, req)
+		handler := readinessHandler(&shutdownFlag, &apiServerReady, swappable, nil, interactive, gate)
 
-	if rec.Code != http.StatusServiceUnavailable {
-		t.Fatalf("UT-KA-1553-001: expected 503 when the fleet readiness gate is NotReady, got %d (body: %s)", rec.Code, rec.Body.String())
-	}
-}
+		rec := doRequest(handler)
+		Expect(rec.Code).To(Equal(http.StatusServiceUnavailable))
+	})
 
-// UT-KA-1553-002: readinessHandler must report 200 when the injected Fleet
-// readiness gate is nil (fleet mode not configured), matching the existing
-// soft-dependency convention used for ds.
-func TestReadinessHandler_NilFleetGate_DoesNotBlockReady(t *testing.T) {
-	var shutdownFlag, apiServerReady int32
-	atomic.StoreInt32(&apiServerReady, 1)
-	swappable := setupSwappable(t)
-	interactive := karbac.NewInteractiveReadiness()
+	// UT-KA-1553-002: readinessHandler must report 200 when the injected Fleet
+	// readiness gate is nil (fleet mode not configured), matching the existing
+	// soft-dependency convention used for ds.
+	It("UT-KA-1553-002: reports 200 when the Fleet readiness gate is nil (fleet mode not configured)", func() {
+		atomic.StoreInt32(&apiServerReady, 1)
+		swappable := setupSwappable(GinkgoTB())
+		interactive := karbac.NewInteractiveReadiness()
 
-	handler := readinessHandler(&shutdownFlag, &apiServerReady, swappable, nil, interactive, nil)
+		handler := readinessHandler(&shutdownFlag, &apiServerReady, swappable, nil, interactive, nil)
 
-	req := httptest.NewRequest(http.MethodGet, "/readyz", nil)
-	rec := httptest.NewRecorder()
-	handler(rec, req)
-
-	if rec.Code != http.StatusOK {
-		t.Fatalf("UT-KA-1553-002: expected 200 when fleet mode is not configured (nil gate), got %d (body: %s)", rec.Code, rec.Body.String())
-	}
-}
+		rec := doRequest(handler)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+	})
+})

--- a/cmd/kubernautagent/reload_callback_1470_test.go
+++ b/cmd/kubernautagent/reload_callback_1470_test.go
@@ -19,12 +19,15 @@ package main
 import (
 	"testing"
 
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 )
 
-func setupPhaseResolver(t *testing.T) (*llm.SwappableClient, *investigator.DefaultPhaseResolver) {
+func setupPhaseResolver(t testing.TB) (*llm.SwappableClient, *investigator.DefaultPhaseResolver) {
 	t.Helper()
 	inner := &stubLLMClient{}
 	sc, err := llm.NewSwappableClient(inner, "default-model")
@@ -35,13 +38,14 @@ func setupPhaseResolver(t *testing.T) (*llm.SwappableClient, *investigator.Defau
 	return sc, resolver
 }
 
-// IT-AI-1470-004a (CM-3): Hot-reload with phaseModels rebuild
-func TestReloadAI1470_004a_PhaseModelsRebuild(t *testing.T) {
-	sc, resolver := setupPhaseResolver(t)
+var _ = Describe("llmRuntimeReloadCallback — per-phase model wiring (#1470)", func() {
+	// IT-AI-1470-004a (CM-3): Hot-reload with phaseModels rebuild
+	It("rebuilds phase overrides on reload and leaves unlisted phases on the reloaded default", func() {
+		sc, resolver := setupPhaseResolver(GinkgoTB())
 
-	cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), resolver)
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), resolver)
 
-	err := cb(`model: gpt-4
+		err := cb(`model: gpt-4
 endpoint: http://localhost:11434
 apiKey: test-key
 phaseModels:
@@ -49,33 +53,25 @@ phaseModels:
     model: gpt-4-mini
     endpoint: http://fast-endpoint:11434
 `)
-	if err != nil {
-		t.Fatalf("reload with phaseModels should succeed, got: %v", err)
-	}
+		Expect(err).NotTo(HaveOccurred())
 
-	_, wfModel, _ := resolver.ResolvePhase(katypes.PhaseWorkflowDiscovery)
-	if wfModel != "gpt-4-mini" {
-		t.Fatalf("expected workflow_discovery model gpt-4-mini, got %s", wfModel)
-	}
+		_, wfModel, _ := resolver.ResolvePhase(katypes.PhaseWorkflowDiscovery)
+		Expect(wfModel).To(Equal("gpt-4-mini"))
 
-	_, rcaModel, _ := resolver.ResolvePhase(katypes.PhaseRCA)
-	if rcaModel != "gpt-4" {
-		t.Fatalf("expected RCA to use default (reloaded) model gpt-4, got %s", rcaModel)
-	}
-}
+		_, rcaModel, _ := resolver.ResolvePhase(katypes.PhaseRCA)
+		Expect(rcaModel).To(Equal("gpt-4"), "RCA should use the default (reloaded) model")
+	})
 
-// IT-AI-1470-004b: Hot-reload adding a new phase override
-func TestReloadAI1470_004b_AddPhaseOverride(t *testing.T) {
-	sc, resolver := setupPhaseResolver(t)
+	// IT-AI-1470-004b: Hot-reload adding a new phase override
+	It("adds a new phase override on reload", func() {
+		sc, resolver := setupPhaseResolver(GinkgoTB())
 
-	_, rcaModelBefore, _ := resolver.ResolvePhase(katypes.PhaseRCA)
-	if rcaModelBefore != "default-model" {
-		t.Fatalf("before reload, expected default model, got %s", rcaModelBefore)
-	}
+		_, rcaModelBefore, _ := resolver.ResolvePhase(katypes.PhaseRCA)
+		Expect(rcaModelBefore).To(Equal("default-model"))
 
-	cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), resolver)
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), resolver)
 
-	err := cb(`model: gpt-4
+		err := cb(`model: gpt-4
 endpoint: http://localhost:11434
 apiKey: test-key
 phaseModels:
@@ -83,61 +79,46 @@ phaseModels:
     model: claude-sonnet
     endpoint: http://anthropic:443
 `)
-	if err != nil {
-		t.Fatalf("reload adding rca override should succeed, got: %v", err)
-	}
+		Expect(err).NotTo(HaveOccurred())
 
-	_, rcaModel, _ := resolver.ResolvePhase(katypes.PhaseRCA)
-	if rcaModel != "claude-sonnet" {
-		t.Fatalf("expected rca model claude-sonnet, got %s", rcaModel)
-	}
-}
+		_, rcaModel, _ := resolver.ResolvePhase(katypes.PhaseRCA)
+		Expect(rcaModel).To(Equal("claude-sonnet"))
+	})
 
-// IT-AI-1470-004c: Hot-reload removing a phase override
-func TestReloadAI1470_004c_RemovePhaseOverride(t *testing.T) {
-	sc, resolver := setupPhaseResolver(t)
+	// IT-AI-1470-004c: Hot-reload removing a phase override
+	It("removes a phase override on reload, falling back to the reloaded default", func() {
+		sc, resolver := setupPhaseResolver(GinkgoTB())
 
-	wfInner := &stubLLMClient{}
-	wfSw, err := llm.NewSwappableClient(wfInner, "fast-model")
-	if err != nil {
-		t.Fatal(err)
-	}
-	resolver.SetPhaseSwappable(katypes.PhaseWorkflowDiscovery, wfSw)
+		wfInner := &stubLLMClient{}
+		wfSw, err := llm.NewSwappableClient(wfInner, "fast-model")
+		Expect(err).NotTo(HaveOccurred())
+		resolver.SetPhaseSwappable(katypes.PhaseWorkflowDiscovery, wfSw)
 
-	_, wfModelBefore, _ := resolver.ResolvePhase(katypes.PhaseWorkflowDiscovery)
-	if wfModelBefore != "fast-model" {
-		t.Fatalf("before reload, expected fast-model, got %s", wfModelBefore)
-	}
+		_, wfModelBefore, _ := resolver.ResolvePhase(katypes.PhaseWorkflowDiscovery)
+		Expect(wfModelBefore).To(Equal("fast-model"))
 
-	cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), resolver)
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), resolver)
 
-	err = cb(`model: gpt-4
+		err = cb(`model: gpt-4
 endpoint: http://localhost:11434
 apiKey: test-key
 `)
-	if err != nil {
-		t.Fatalf("reload without phaseModels should succeed, got: %v", err)
-	}
+		Expect(err).NotTo(HaveOccurred())
 
-	_, wfModelAfter, _ := resolver.ResolvePhase(katypes.PhaseWorkflowDiscovery)
-	if wfModelAfter != "gpt-4" {
-		t.Fatalf("after removing phase override, expected default (reloaded) model gpt-4, got %s", wfModelAfter)
-	}
-}
+		_, wfModelAfter, _ := resolver.ResolvePhase(katypes.PhaseWorkflowDiscovery)
+		Expect(wfModelAfter).To(Equal("gpt-4"), "removing a phase override should fall back to the reloaded default")
+	})
 
-// Backward compat: nil resolver does not break existing reload
-func TestReloadAI1470_NilResolverBackwardCompat(t *testing.T) {
-	sc := setupSwappable(t)
-	cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
+	// Backward compat: nil resolver does not break existing reload
+	It("does not break reload when the resolver is nil (backward compat)", func() {
+		sc := setupSwappable(GinkgoTB())
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
 
-	err := cb(`model: gpt-4-turbo
+		err := cb(`model: gpt-4-turbo
 endpoint: http://localhost:11434
 apiKey: test-key
 `)
-	if err != nil {
-		t.Fatalf("reload with nil resolver should succeed, got: %v", err)
-	}
-	if sc.ModelName() != "gpt-4-turbo" {
-		t.Fatalf("expected model gpt-4-turbo, got %s", sc.ModelName())
-	}
-}
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sc.ModelName()).To(Equal("gpt-4-turbo"))
+	})
+})

--- a/cmd/kubernautagent/reload_callback_783_test.go
+++ b/cmd/kubernautagent/reload_callback_783_test.go
@@ -21,6 +21,9 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
 	kaconfig "github.com/jordigilh/kubernaut/internal/kubernautagent/config"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 )
@@ -36,7 +39,11 @@ func staticCfg() *kaconfig.Config {
 	return cfg
 }
 
-func setupSwappable(t *testing.T) *llm.SwappableClient {
+// setupSwappable accepts testing.TB (not *testing.T) so both plain
+// `testing.T`-based tests and Ginkgo specs (via GinkgoTB(), which implements
+// testing.TB) can share this
+// fixture.
+func setupSwappable(t testing.TB) *llm.SwappableClient {
 	t.Helper()
 	inner := &stubLLMClient{}
 	sc, err := llm.NewSwappableClient(inner, "gpt-4")
@@ -58,84 +65,68 @@ func (s *stubLLMClient) StreamChat(_ context.Context, _ llm.ChatRequest, _ func(
 
 func (s *stubLLMClient) Close() error { return nil }
 
-func TestReloadRejectsEmptyContent(t *testing.T) {
-	sc := setupSwappable(t)
-	cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
+var _ = Describe("llmRuntimeReloadCallback (#783)", func() {
+	It("rejects empty content and does not change the model", func() {
+		sc := setupSwappable(GinkgoTB())
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
 
-	err := cb("")
-	if err == nil {
-		t.Fatal("expected error for empty content")
-	}
-	if sc.ModelName() != "gpt-4" {
-		t.Fatalf("model should not change on rejected reload, got %s", sc.ModelName())
-	}
-}
+		err := cb("")
+		Expect(err).To(HaveOccurred())
+		Expect(sc.ModelName()).To(Equal("gpt-4"))
+	})
 
-func TestReloadRejectsWhitespaceContent(t *testing.T) {
-	sc := setupSwappable(t)
-	cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
+	It("rejects whitespace-only content", func() {
+		sc := setupSwappable(GinkgoTB())
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
 
-	err := cb("   \n  \t  ")
-	if err == nil {
-		t.Fatal("expected error for whitespace-only content")
-	}
-}
+		err := cb("   \n  \t  ")
+		Expect(err).To(HaveOccurred())
+	})
 
-func TestReloadAcceptsModelChange(t *testing.T) {
-	sc := setupSwappable(t)
-	cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
+	It("accepts a model change", func() {
+		sc := setupSwappable(GinkgoTB())
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
 
-	err := cb(`model: gpt-4-turbo
+		err := cb(`model: gpt-4-turbo
 endpoint: http://localhost:11434
 apiKey: test-key
 `)
-	if err != nil {
-		t.Fatalf("model change should succeed, got: %v", err)
-	}
-	if sc.ModelName() != "gpt-4-turbo" {
-		t.Fatalf("expected model gpt-4-turbo, got %s", sc.ModelName())
-	}
-}
+		Expect(err).NotTo(HaveOccurred())
+		Expect(sc.ModelName()).To(Equal("gpt-4-turbo"))
+	})
 
-func TestReloadAcceptsEndpointChange(t *testing.T) {
-	sc := setupSwappable(t)
-	cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
+	It("accepts an endpoint change", func() {
+		sc := setupSwappable(GinkgoTB())
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
 
-	err := cb(`model: gpt-4
+		err := cb(`model: gpt-4
 endpoint: http://new-endpoint:8080
 apiKey: test-key
 `)
-	if err != nil {
-		t.Fatalf("endpoint change should succeed, got: %v", err)
-	}
-}
+		Expect(err).NotTo(HaveOccurred())
+	})
 
-func TestReloadRejectsValidationFailure(t *testing.T) {
-	sc := setupSwappable(t)
-	cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
+	It("rejects a validation failure and does not change the model", func() {
+		sc := setupSwappable(GinkgoTB())
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
 
-	err := cb(`model: ""
+		err := cb(`model: ""
 endpoint: http://localhost:11434
 apiKey: test-key
 `)
-	if err == nil {
-		t.Fatal("expected error for validation failure (empty model)")
-	}
-	if sc.ModelName() != "gpt-4" {
-		t.Fatalf("model should not change on rejected reload, got %s", sc.ModelName())
-	}
-}
+		Expect(err).To(HaveOccurred())
+		Expect(sc.ModelName()).To(Equal("gpt-4"))
+	})
 
-func TestReloadAcceptsTemperatureChange(t *testing.T) {
-	sc := setupSwappable(t)
-	cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
+	It("accepts a temperature change", func() {
+		sc := setupSwappable(GinkgoTB())
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
 
-	err := cb(`model: gpt-4
+		err := cb(`model: gpt-4
 endpoint: http://localhost:11434
 apiKey: test-key
 temperature: 0.9
 `)
-	if err != nil {
-		t.Fatalf("temperature change should succeed, got: %v", err)
-	}
-}
+		Expect(err).NotTo(HaveOccurred())
+	})
+})

--- a/cmd/kubernautagent/routes_mcphandler_characterization_test.go
+++ b/cmd/kubernautagent/routes_mcphandler_characterization_test.go
@@ -21,13 +21,14 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/go-logr/logr/funcr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/prometheus/client_golang/prometheus"
 	"k8s.io/client-go/rest"
 
@@ -69,7 +70,7 @@ func (c *jsonLogCapture) capture(obj string) {
 	c.lines = append(c.lines, obj)
 }
 
-func (c *jsonLogCapture) findByMessage(t *testing.T, msg string) map[string]interface{} {
+func (c *jsonLogCapture) findByMessage(t testing.TB, msg string) map[string]interface{} {
 	t.Helper()
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -86,11 +87,11 @@ func (c *jsonLogCapture) findByMessage(t *testing.T, msg string) map[string]inte
 	return nil
 }
 
-func newMCPTestAgentMetrics(_ *testing.T) *kametrics.Metrics {
+func newMCPTestAgentMetrics() *kametrics.Metrics {
 	return kametrics.NewMetricsWithRegistry(prometheus.NewRegistry())
 }
 
-func newMCPTestAutoMgr(_ *testing.T) *session.Manager {
+func newMCPTestAutoMgr() *session.Manager {
 	return session.NewManager(session.NewStore(time.Hour), logr.Discard(), nil, nil)
 }
 
@@ -98,7 +99,7 @@ func newMCPTestAutoMgr(_ *testing.T) *session.Manager {
 // request is made against it synchronously by buildMCPHandler (only the
 // disconnect-triggered background reconstruction path calls DS), so an empty
 // 200 handler is sufficient.
-func newMCPTestDSClients(t *testing.T) *dsClients {
+func newMCPTestDSClients(t testing.TB) *dsClients {
 	t.Helper()
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -127,7 +128,7 @@ func validMCPInteractiveConfig() *kaconfig.Config {
 // unreachable rest.Config host (per preflight spike: ctrlclient.New makes no
 // network call at construction; ReconcileOrphanedLeases fails fast/fail-open
 // against a refused connection).
-func validMCPHandlerParams(t *testing.T) mcpHandlerParams {
+func validMCPHandlerParams(t testing.TB) mcpHandlerParams {
 	t.Helper()
 	return mcpHandlerParams{
 		cfg:          validMCPInteractiveConfig(),
@@ -135,64 +136,97 @@ func validMCPHandlerParams(t *testing.T) mcpHandlerParams {
 		ds:           newMCPTestDSClients(t),
 		inv:          &investigator.Investigator{},
 		enricher:     &enrichment.Enricher{},
-		autoMgr:      newMCPTestAutoMgr(t),
+		autoMgr:      newMCPTestAutoMgr(),
 		authMw:       &auth.Middleware{},
-		agentMetrics: newMCPTestAgentMetrics(t),
+		agentMetrics: newMCPTestAgentMetrics(),
 		auditStore:   audit.NopAuditStore{},
 		logger:       logr.Discard(),
 	}
 }
 
-func TestBuildMCPHandler_FullyWired(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+var _ = Describe("buildMCPHandler — construction-path characterization", func() {
+	var (
+		ctx    context.Context
+		cancel context.CancelFunc
+	)
 
-	handler, drainer := buildMCPHandler(ctx, validMCPHandlerParams(t))
+	BeforeEach(func() {
+		ctx, cancel = context.WithCancel(context.Background())
+		DeferCleanup(cancel)
+	})
 
-	if handler == nil {
-		t.Fatal("expected non-nil http.Handler for fully-wired params")
-	}
-	if drainer == nil {
-		t.Fatal("expected non-nil session drainer for fully-wired params")
-	}
-}
+	It("returns a non-nil handler and drainer for fully-wired params", func() {
+		handler, drainer := buildMCPHandler(ctx, validMCPHandlerParams(GinkgoTB()))
 
-// TestBuildMCPHandler_NilDS_DegradesGracefully proves the bug fix for a
-// production panic discovered during Wave 5 Phase 0b coverage-gate testing:
-// the ContextReconstructor branch was correctly nil-guarded (falls back to
-// noopReconstructor when ds == nil), but the workflow-catalog querier a few
-// lines later dereferenced ds unconditionally, so a nil ds (DataStorage
-// integration disabled/unreachable at startup) crashed the whole MCP
-// interactive-mode handler construction instead of degrading like every
-// other DS-optional dependency in this function (see also buildToolRegistry
-// and readinessHandler, which both guard `ds != nil` the same way).
-//
-// BR-INTERACTIVE-001 / AU-3: MCP interactive mode must remain available
-// (investigate/select-workflow/complete-no-action) even when DataStorage is
-// unavailable; workflow-catalog-dependent lookups must fail with a clear,
-// per-call error rather than taking down the whole handler at construction.
-func TestBuildMCPHandler_NilDS_DegradesGracefully(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
+		Expect(handler).NotTo(BeNil(), "expected non-nil http.Handler for fully-wired params")
+		Expect(drainer).NotTo(BeNil(), "expected non-nil session drainer for fully-wired params")
+	})
 
-	capture := &jsonLogCapture{}
-	logger := funcr.NewJSON(capture.capture, funcr.Options{})
+	// TestBuildMCPHandler_NilDS_DegradesGracefully proves the bug fix for a
+	// production panic discovered during Wave 5 Phase 0b coverage-gate testing:
+	// the ContextReconstructor branch was correctly nil-guarded (falls back to
+	// noopReconstructor when ds == nil), but the workflow-catalog querier a few
+	// lines later dereferenced ds unconditionally, so a nil ds (DataStorage
+	// integration disabled/unreachable at startup) crashed the whole MCP
+	// interactive-mode handler construction instead of degrading like every
+	// other DS-optional dependency in this function (see also buildToolRegistry
+	// and readinessHandler, which both guard `ds != nil` the same way).
+	//
+	// BR-INTERACTIVE-001 / AU-3: MCP interactive mode must remain available
+	// (investigate/select-workflow/complete-no-action) even when DataStorage is
+	// unavailable; workflow-catalog-dependent lookups must fail with a clear,
+	// per-call error rather than taking down the whole handler at construction.
+	It("degrades gracefully (non-nil handler, logged warning) when ds is nil", func() {
+		capture := &jsonLogCapture{}
+		logger := funcr.NewJSON(capture.capture, funcr.Options{})
 
-	p := validMCPHandlerParams(t)
-	p.ds = nil
-	p.logger = logger
+		p := validMCPHandlerParams(GinkgoTB())
+		p.ds = nil
+		p.logger = logger
 
-	handler, drainer := buildMCPHandler(ctx, p)
+		handler, drainer := buildMCPHandler(ctx, p)
 
-	if handler == nil {
-		t.Fatal("expected non-nil http.Handler when ds is nil (DS-optional degradation, not a hard dependency)")
-	}
-	if drainer == nil {
-		t.Fatal("expected non-nil session drainer when ds is nil")
-	}
+		Expect(handler).NotTo(BeNil(), "expected non-nil http.Handler when ds is nil (DS-optional degradation, not a hard dependency)")
+		Expect(drainer).NotTo(BeNil(), "expected non-nil session drainer when ds is nil")
 
-	capture.findByMessage(t, "MCP interactive mode: DS unavailable — workflow catalog lookups disabled")
-}
+		capture.findByMessage(GinkgoTB(), "MCP interactive mode: DS unavailable — workflow catalog lookups disabled")
+	})
+
+	It("disables enrichment in select-workflow when enricher is nil", func() {
+		capture := &jsonLogCapture{}
+		logger := funcr.NewJSON(capture.capture, funcr.Options{})
+
+		p := validMCPHandlerParams(GinkgoTB())
+		p.enricher = nil
+		p.logger = logger
+
+		handler, drainer := buildMCPHandler(ctx, p)
+
+		Expect(handler).NotTo(BeNil(), "expected non-nil http.Handler when enricher is nil")
+		Expect(drainer).NotTo(BeNil(), "expected non-nil session drainer when enricher is nil")
+
+		fields := capture.findByMessage(GinkgoTB(), "MCP interactive mode fully wired")
+		Expect(fields["enrichment_in_select_workflow"]).To(BeFalse(),
+			"expected enrichment_in_select_workflow=false when enricher is nil")
+	})
+
+	It("returns a nil handler and drainer when controller-runtime client construction fails", func() {
+		p := validMCPHandlerParams(GinkgoTB())
+		// A CAFile that cannot be read fails rest.HTTPClientFor synchronously
+		// (confirmed via preflight spike), without any network round-trip.
+		p.infra = &k8sInfra{kubeConfig: &rest.Config{
+			Host: "https://127.0.0.1:1",
+			TLSClientConfig: rest.TLSClientConfig{
+				CAFile: "/nonexistent/path/to/definitely-does-not-exist-kubernaut-test.pem",
+			},
+		}}
+
+		handler, drainer := buildMCPHandler(ctx, p)
+
+		Expect(handler).To(BeNil(), "expected nil handler when controller-runtime client construction fails")
+		Expect(drainer).To(BeNil(), "expected nil session drainer when controller-runtime client construction fails")
+	})
+})
 
 // TestNoopWorkflowQuerier_ReturnsDescriptiveError proves the noop fallback
 // used when ds is nil surfaces a clear, actionable error through the same
@@ -201,62 +235,12 @@ func TestBuildMCPHandler_NilDS_DegradesGracefully(t *testing.T) {
 // and returns it as a normal tool error to the LLM/client), rather than a nil
 // pointer panic or a silently-empty result that would look like "workflow not
 // found" instead of "DataStorage unavailable".
-func TestNoopWorkflowQuerier_ReturnsDescriptiveError(t *testing.T) {
-	q := &noopWorkflowQuerier{}
+var _ = Describe("noopWorkflowQuerier", func() {
+	It("returns a descriptive error explaining DataStorage is unavailable", func() {
+		q := &noopWorkflowQuerier{}
 
-	if _, err := q.ResolveWorkflowCatalogMetadata(context.Background(), "wf-123"); err == nil {
-		t.Fatal("expected ResolveWorkflowCatalogMetadata to return an error when DS is unavailable")
-	} else if got := err.Error(); !strings.Contains(got, "DataStorage") && !strings.Contains(got, "unavailable") {
-		t.Errorf("expected error to explain DS is unavailable, got %q", got)
-	}
-}
-
-func TestBuildMCPHandler_NilEnricher_DisablesEnrichmentInSelectWorkflow(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	capture := &jsonLogCapture{}
-	logger := funcr.NewJSON(capture.capture, funcr.Options{})
-
-	p := validMCPHandlerParams(t)
-	p.enricher = nil
-	p.logger = logger
-
-	handler, drainer := buildMCPHandler(ctx, p)
-
-	if handler == nil {
-		t.Fatal("expected non-nil http.Handler when enricher is nil")
-	}
-	if drainer == nil {
-		t.Fatal("expected non-nil session drainer when enricher is nil")
-	}
-
-	fields := capture.findByMessage(t, "MCP interactive mode fully wired")
-	if enrichmentEnabled, ok := fields["enrichment_in_select_workflow"].(bool); !ok || enrichmentEnabled {
-		t.Errorf("expected enrichment_in_select_workflow=false when enricher is nil, got %v", fields["enrichment_in_select_workflow"])
-	}
-}
-
-func TestBuildMCPHandler_ControllerClientConstructionFails(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	t.Cleanup(cancel)
-
-	p := validMCPHandlerParams(t)
-	// A CAFile that cannot be read fails rest.HTTPClientFor synchronously
-	// (confirmed via preflight spike), without any network round-trip.
-	p.infra = &k8sInfra{kubeConfig: &rest.Config{
-		Host: "https://127.0.0.1:1",
-		TLSClientConfig: rest.TLSClientConfig{
-			CAFile: "/nonexistent/path/to/definitely-does-not-exist-kubernaut-test.pem",
-		},
-	}}
-
-	handler, drainer := buildMCPHandler(ctx, p)
-
-	if handler != nil {
-		t.Errorf("expected nil handler when controller-runtime client construction fails, got %v", handler)
-	}
-	if drainer != nil {
-		t.Errorf("expected nil session drainer when controller-runtime client construction fails, got %v", drainer)
-	}
-}
+		_, err := q.ResolveWorkflowCatalogMetadata(context.Background(), "wf-123")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Or(ContainSubstring("DataStorage"), ContainSubstring("unavailable")))
+	})
+})

--- a/cmd/kubernautagent/shutdown_timeout_test.go
+++ b/cmd/kubernautagent/shutdown_timeout_test.go
@@ -17,30 +17,28 @@ limitations under the License.
 package main
 
 import (
-	"testing"
 	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	kaconfig "github.com/jordigilh/kubernaut/internal/kubernautagent/config"
 )
 
-// UT-KA-1329-004: shutdownTimeout returns configured value (CM-3)
-func TestShutdownTimeout_UsesConfig(t *testing.T) {
-	cfg := kaconfig.DefaultConfig()
-	cfg.Runtime.Shutdown.DrainSeconds = 3
+var _ = Describe("shutdownTimeout", func() {
+	// UT-KA-1329-004: shutdownTimeout returns configured value (CM-3)
+	It("returns the configured value", func() {
+		cfg := kaconfig.DefaultConfig()
+		cfg.Runtime.Shutdown.DrainSeconds = 3
 
-	timeout := shutdownTimeout(cfg)
-	if timeout != 3*time.Second {
-		t.Errorf("UT-KA-1329-004: CM-3: expected 3s from config, got %v", timeout)
-	}
-}
+		Expect(shutdownTimeout(cfg)).To(Equal(3 * time.Second))
+	})
 
-// UT-KA-1329-005: shutdownTimeout returns 30s default on zero (CM-3)
-func TestShutdownTimeout_DefaultsOnZero(t *testing.T) {
-	cfg := kaconfig.DefaultConfig()
-	cfg.Runtime.Shutdown.DrainSeconds = 0
+	// UT-KA-1329-005: shutdownTimeout returns 30s default on zero (CM-3)
+	It("defaults to 30s when unset", func() {
+		cfg := kaconfig.DefaultConfig()
+		cfg.Runtime.Shutdown.DrainSeconds = 0
 
-	timeout := shutdownTimeout(cfg)
-	if timeout != 30*time.Second {
-		t.Errorf("UT-KA-1329-005: CM-3: expected 30s default, got %v", timeout)
-	}
-}
+		Expect(shutdownTimeout(cfg)).To(Equal(30 * time.Second))
+	})
+})

--- a/cmd/kubernautagent/suite_test.go
+++ b/cmd/kubernautagent/suite_test.go
@@ -1,0 +1,37 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// TestKubernautAgentCmd is the Ginkgo bootstrap for package main's
+// white-box test suite (unexported production functions such as
+// buildLLMClientFromConfig, buildAnthropicNativeClient, and
+// anthropicReasoningOptions require same-package test access, so this
+// suite lives in `package main` rather than `main_test`). Per AGENTS.md
+// ("Testing Requirements": Ginkgo/Gomega BDD is mandatory for business
+// logic tests), this is the single RunSpecs entry point for every
+// Describe/It block added under cmd/kubernautagent going forward.
+func TestKubernautAgentCmd(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "KubernautAgent cmd Suite")
+}

--- a/cmd/kubernautagent/testutil_ca_test.go
+++ b/cmd/kubernautagent/testutil_ca_test.go
@@ -32,7 +32,11 @@ import (
 
 // generateTestCACert creates a self-signed CA certificate PEM file under
 // t.TempDir() and returns its path. The cert is valid for 24 hours.
-func generateTestCACert(t *testing.T, cn string) string {
+//
+// Accepts testing.TB (not *testing.T) so both plain `testing.T`-based tests
+// and Ginkgo specs (via GinkgoTB(), which implements testing.TB) can share
+// this fixture.
+func generateTestCACert(t testing.TB, cn string) string {
 	t.Helper()
 	caDir := t.TempDir()
 	caPath := filepath.Join(caDir, "ca.crt")
@@ -63,7 +67,7 @@ func generateTestCACert(t *testing.T, cn string) string {
 
 // generateTestClientCert creates a self-signed certificate and key pair
 // suitable for mTLS testing. Returns the cert and key file paths.
-func generateTestClientCert(t *testing.T, _ string) (certPath, keyPath string) {
+func generateTestClientCert(t testing.TB, _ string) (certPath, keyPath string) {
 	t.Helper()
 	dir := t.TempDir()
 	certPath = filepath.Join(dir, "client.crt")

--- a/cmd/kubernautagent/toolregistry_test.go
+++ b/cmd/kubernautagent/toolregistry_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 
 	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 
 	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
 
@@ -50,105 +52,6 @@ import (
 // so any future change to that behavior is a deliberate, reviewed decision.
 // ============================================================================
 
-func TestBuildToolRegistry_NoIntegrationsConfigured_OnlyRegistersBaselineTool(t *testing.T) {
-	cfg := &kaconfig.Config{}
-
-	reg := buildToolRegistry(cfg, logr.Discard(), nil, nil, nil)
-
-	all := reg.All()
-	if len(all) != 1 {
-		t.Fatalf("BR-SECURITY-AC6: expected exactly 1 baseline tool (least privilege) when no integrations "+
-			"are configured, got %d: %v", len(all), toolNames(all))
-	}
-	if _, err := reg.Get("todo_write"); err != nil {
-		t.Fatalf("expected the baseline todo_write tool to always be registered: %v", err)
-	}
-}
-
-func TestBuildToolRegistry_PrometheusNotConfigured_DoesNotRegisterPrometheusTools(t *testing.T) {
-	cfg := &kaconfig.Config{}
-
-	reg := buildToolRegistry(cfg, logr.Discard(), nil, nil, nil)
-
-	for _, name := range promtools.AllToolNames {
-		if _, err := reg.Get(name); err == nil {
-			t.Errorf("BR-SECURITY-AC6: tool %q must not be registered when Prometheus is not configured", name)
-		}
-	}
-}
-
-func TestBuildToolRegistry_PrometheusConfigured_RegistersAllPrometheusTools(t *testing.T) {
-	cfg := &kaconfig.Config{}
-	cfg.Integrations.Tools.Prometheus.URL = "http://localhost:9090"
-
-	reg := buildToolRegistry(cfg, logr.Discard(), nil, nil, nil)
-
-	for _, name := range promtools.AllToolNames {
-		if _, err := reg.Get(name); err != nil {
-			t.Errorf("BR-SECURITY-AC6: expected Prometheus tool %q to be registered when Prometheus.URL is set: %v", name, err)
-		}
-	}
-}
-
-func TestBuildToolRegistry_PrometheusWithValidTLSCaFile_RegistersToolsOverSecureTransport(t *testing.T) {
-	caPath := generateTestCACert(t, "Prometheus Test CA")
-	cfg := &kaconfig.Config{}
-	cfg.Integrations.Tools.Prometheus.URL = "https://prometheus.example.com"
-	cfg.Integrations.Tools.Prometheus.TLSCaFile = caPath
-
-	reg := buildToolRegistry(cfg, logr.Discard(), nil, nil, nil)
-
-	for _, name := range promtools.AllToolNames {
-		if _, err := reg.Get(name); err != nil {
-			t.Errorf("SC-8: expected Prometheus tool %q to be registered when a valid TLSCaFile is configured: %v", name, err)
-		}
-	}
-}
-
-func TestBuildToolRegistry_PrometheusWithInvalidTLSCaFile_FailsOpenToDefaultTransportButStillRegistersTools(t *testing.T) {
-	cfg := &kaconfig.Config{}
-	cfg.Integrations.Tools.Prometheus.URL = "https://prometheus.example.com"
-	cfg.Integrations.Tools.Prometheus.TLSCaFile = "/nonexistent/ca.crt"
-
-	reg := buildToolRegistry(cfg, logr.Discard(), nil, nil, nil)
-
-	// SC-8 characterization: a broken CA bundle degrades to the default
-	// transport (logged, not fatal) rather than refusing to register the
-	// tool set. This test locks in that documented behavior.
-	for _, name := range promtools.AllToolNames {
-		if _, err := reg.Get(name); err != nil {
-			t.Errorf("expected Prometheus tool %q to still be registered despite invalid TLSCaFile (fail-open transport, not fail-closed registration): %v", name, err)
-		}
-	}
-}
-
-func TestBuildToolRegistry_AlertmanagerConfigured_RegistersAllAlertmanagerTools(t *testing.T) {
-	cfg := &kaconfig.Config{}
-	cfg.Integrations.Tools.Alertmanager.URL = "http://localhost:9093"
-
-	reg := buildToolRegistry(cfg, logr.Discard(), nil, nil, nil)
-
-	for _, name := range amtools.AllToolNames {
-		if _, err := reg.Get(name); err != nil {
-			t.Errorf("BR-SECURITY-AC6: expected Alertmanager tool %q to be registered when Alertmanager.URL is set: %v", name, err)
-		}
-	}
-}
-
-func TestBuildToolRegistry_AlertmanagerWithInvalidTLSCaFile_FailsOpenToDefaultTransportButStillRegistersTools(t *testing.T) {
-	cfg := &kaconfig.Config{}
-	cfg.Integrations.Tools.Alertmanager.URL = "https://alertmanager.example.com"
-	cfg.Integrations.Tools.Alertmanager.TLSCaFile = "/nonexistent/ca.crt"
-
-	reg := buildToolRegistry(cfg, logr.Discard(), nil, nil, nil)
-
-	for _, name := range amtools.AllToolNames {
-		if _, err := reg.Get(name); err != nil {
-			t.Errorf("expected Alertmanager tool %q to still be registered despite invalid TLSCaFile (fail-open transport, not fail-closed registration): %v", name, err)
-		}
-	}
-}
-
 func toolNames(all []tools.Tool) []string {
 	names := make([]string, 0, len(all))
 	for _, tl := range all {
@@ -156,6 +59,97 @@ func toolNames(all []tools.Tool) []string {
 	}
 	return names
 }
+
+var _ = Describe("buildToolRegistry", func() {
+	It("BR-SECURITY-AC6: registers only the baseline tool (least privilege) when no integrations are configured", func() {
+		cfg := &kaconfig.Config{}
+
+		reg := buildToolRegistry(cfg, logr.Discard(), nil, nil, nil)
+
+		all := reg.All()
+		Expect(all).To(HaveLen(1), "expected exactly 1 baseline tool (least privilege), got %v", toolNames(all))
+		_, err := reg.Get("todo_write")
+		Expect(err).NotTo(HaveOccurred(), "expected the baseline todo_write tool to always be registered")
+	})
+
+	It("BR-SECURITY-AC6: does not register Prometheus tools when Prometheus is not configured", func() {
+		cfg := &kaconfig.Config{}
+
+		reg := buildToolRegistry(cfg, logr.Discard(), nil, nil, nil)
+
+		for _, name := range promtools.AllToolNames {
+			_, err := reg.Get(name)
+			Expect(err).To(HaveOccurred(), "tool %q must not be registered when Prometheus is not configured", name)
+		}
+	})
+
+	It("BR-SECURITY-AC6: registers all Prometheus tools when Prometheus.URL is set", func() {
+		cfg := &kaconfig.Config{}
+		cfg.Integrations.Tools.Prometheus.URL = "http://localhost:9090"
+
+		reg := buildToolRegistry(cfg, logr.Discard(), nil, nil, nil)
+
+		for _, name := range promtools.AllToolNames {
+			_, err := reg.Get(name)
+			Expect(err).NotTo(HaveOccurred(), "expected Prometheus tool %q to be registered when Prometheus.URL is set", name)
+		}
+	})
+
+	It("SC-8: registers Prometheus tools over a secure transport when a valid TLSCaFile is configured", func() {
+		caPath := generateTestCACert(GinkgoTB(), "Prometheus Test CA")
+		cfg := &kaconfig.Config{}
+		cfg.Integrations.Tools.Prometheus.URL = "https://prometheus.example.com"
+		cfg.Integrations.Tools.Prometheus.TLSCaFile = caPath
+
+		reg := buildToolRegistry(cfg, logr.Discard(), nil, nil, nil)
+
+		for _, name := range promtools.AllToolNames {
+			_, err := reg.Get(name)
+			Expect(err).NotTo(HaveOccurred(), "expected Prometheus tool %q to be registered when a valid TLSCaFile is configured", name)
+		}
+	})
+
+	// SC-8 characterization: a broken CA bundle degrades to the default
+	// transport (logged, not fatal) rather than refusing to register the
+	// tool set. This test locks in that documented behavior.
+	It("SC-8: still registers Prometheus tools (fail-open transport, not fail-closed registration) despite an invalid TLSCaFile", func() {
+		cfg := &kaconfig.Config{}
+		cfg.Integrations.Tools.Prometheus.URL = "https://prometheus.example.com"
+		cfg.Integrations.Tools.Prometheus.TLSCaFile = "/nonexistent/ca.crt"
+
+		reg := buildToolRegistry(cfg, logr.Discard(), nil, nil, nil)
+
+		for _, name := range promtools.AllToolNames {
+			_, err := reg.Get(name)
+			Expect(err).NotTo(HaveOccurred(), "expected Prometheus tool %q to still be registered despite invalid TLSCaFile", name)
+		}
+	})
+
+	It("BR-SECURITY-AC6: registers all Alertmanager tools when Alertmanager.URL is set", func() {
+		cfg := &kaconfig.Config{}
+		cfg.Integrations.Tools.Alertmanager.URL = "http://localhost:9093"
+
+		reg := buildToolRegistry(cfg, logr.Discard(), nil, nil, nil)
+
+		for _, name := range amtools.AllToolNames {
+			_, err := reg.Get(name)
+			Expect(err).NotTo(HaveOccurred(), "expected Alertmanager tool %q to be registered when Alertmanager.URL is set", name)
+		}
+	})
+
+	It("still registers Alertmanager tools (fail-open transport, not fail-closed registration) despite an invalid TLSCaFile", func() {
+		cfg := &kaconfig.Config{}
+		cfg.Integrations.Tools.Alertmanager.URL = "https://alertmanager.example.com"
+		cfg.Integrations.Tools.Alertmanager.TLSCaFile = "/nonexistent/ca.crt"
+
+		reg := buildToolRegistry(cfg, logr.Discard(), nil, nil, nil)
+
+		for _, name := range amtools.AllToolNames {
+			_, err := reg.Get(name)
+			Expect(err).NotTo(HaveOccurred(), "expected Alertmanager tool %q to still be registered despite invalid TLSCaFile", name)
+		}
+	})
+})
 
 // ============================================================================
 // dsCatalogFetcher.FetchValidator — characterization tests (RED phase, Wave 5).
@@ -210,7 +204,7 @@ func workflowJSON(workflowID, content string) map[string]interface{} {
 	}
 }
 
-func newDSCatalogFetcherForTest(t *testing.T, handler http.Handler) *dsCatalogFetcher {
+func newDSCatalogFetcherForTest(t testing.TB, handler http.Handler) *dsCatalogFetcher {
 	t.Helper()
 	server := httptest.NewServer(handler)
 	t.Cleanup(server.Close)
@@ -222,109 +216,80 @@ func newDSCatalogFetcherForTest(t *testing.T, handler http.Handler) *dsCatalogFe
 	return newDSCatalogFetcher(&dsClients{ogenClient: ogenC}, logr.Discard())
 }
 
-func TestFetchValidator_EmptyCatalog_FailsClosed(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("GET /api/v1/workflows", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{"workflows": []interface{}{}})
-	})
-
-	f := newDSCatalogFetcherForTest(t, mux)
-	validator, err := f.FetchValidator(context.Background())
-
-	if err == nil {
-		t.Fatal("BR-SECURITY-SI10: expected an error when the workflow catalog is empty (fail-closed, no implicit allow-all)")
-	}
-	if validator != nil {
-		t.Fatal("expected a nil validator on empty catalog")
-	}
-}
-
-func TestFetchValidator_ListWorkflowsFails_ReturnsWrappedError(t *testing.T) {
-	mux := http.NewServeMux()
-	mux.HandleFunc("GET /api/v1/workflows", func(w http.ResponseWriter, _ *http.Request) {
-		w.WriteHeader(http.StatusInternalServerError)
-	})
-
-	f := newDSCatalogFetcherForTest(t, mux)
-	validator, err := f.FetchValidator(context.Background())
-
-	if err == nil {
-		t.Fatal("expected an error when the DataStorage ListWorkflows call fails")
-	}
-	if validator != nil {
-		t.Fatal("expected a nil validator when ListWorkflows fails")
-	}
-}
-
-func TestFetchValidator_ValidCatalog_BuildsAllowlistWithCatalogMetadata(t *testing.T) {
-	const wfID = "550e8400-e29b-41d4-a716-446655440000"
-	mux := http.NewServeMux()
-	mux.HandleFunc("GET /api/v1/workflows", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			"workflows": []interface{}{workflowJSON(wfID, validWorkflowSchemaYAML)},
+var _ = Describe("dsCatalogFetcher.FetchValidator", func() {
+	It("BR-SECURITY-SI10: fails closed when the workflow catalog is empty", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /api/v1/workflows", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{"workflows": []interface{}{}})
 		})
+
+		f := newDSCatalogFetcherForTest(GinkgoTB(), mux)
+		validator, err := f.FetchValidator(context.Background())
+
+		Expect(err).To(HaveOccurred(), "expected an error when the workflow catalog is empty (fail-closed, no implicit allow-all)")
+		Expect(validator).To(BeNil())
 	})
 
-	f := newDSCatalogFetcherForTest(t, mux)
-	validator, err := f.FetchValidator(context.Background())
-	if err != nil {
-		t.Fatalf("expected no error building the validator from a valid catalog: %v", err)
-	}
-	if validator == nil {
-		t.Fatal("expected a non-nil validator")
-	}
-
-	meta, ok := validator.GetWorkflowMeta(wfID)
-	if !ok {
-		t.Fatalf("BR-SECURITY-AC6: expected workflow %q to be part of the allowlist", wfID)
-	}
-	if meta.ExecutionEngine != "tekton" {
-		t.Errorf("expected ExecutionEngine=tekton, got %q", meta.ExecutionEngine)
-	}
-	if meta.Version != "1.0.0" {
-		t.Errorf("expected Version=1.0.0, got %q", meta.Version)
-	}
-	if meta.ServiceAccountName != "workflow-runner" {
-		t.Errorf("expected ServiceAccountName=workflow-runner, got %q", meta.ServiceAccountName)
-	}
-	if meta.ExecutionBundleDigest != "sha256:aaa" {
-		t.Errorf("expected ExecutionBundleDigest=sha256:aaa, got %q", meta.ExecutionBundleDigest)
-	}
-	if len(meta.Parameters) != 1 || meta.Parameters[0].Name != "TARGET_NAMESPACE" {
-		t.Errorf("expected the schema's TARGET_NAMESPACE parameter to be present, got %+v", meta.Parameters)
-	}
-}
-
-func TestFetchValidator_MalformedSchemaContent_StripsParametersFailClosed(t *testing.T) {
-	const wfID = "550e8400-e29b-41d4-a716-446655440001"
-	mux := http.NewServeMux()
-	mux.HandleFunc("GET /api/v1/workflows", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]interface{}{
-			// Content is not a valid RemediationWorkflow CRD envelope (missing
-			// apiVersion/kind/metadata.name) — dsschema.Parser.Parse must fail.
-			"workflows": []interface{}{workflowJSON(wfID, "not: a-valid-workflow-schema")},
+	It("returns a wrapped error when the DataStorage ListWorkflows call fails", func() {
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /api/v1/workflows", func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
 		})
+
+		f := newDSCatalogFetcherForTest(GinkgoTB(), mux)
+		validator, err := f.FetchValidator(context.Background())
+
+		Expect(err).To(HaveOccurred(), "expected an error when the DataStorage ListWorkflows call fails")
+		Expect(validator).To(BeNil())
 	})
 
-	f := newDSCatalogFetcherForTest(t, mux)
-	validator, err := f.FetchValidator(context.Background())
-	if err != nil {
-		t.Fatalf("BR-SECURITY-SI10: a single workflow's malformed schema must not fail the whole catalog fetch: %v", err)
-	}
+	It("builds an allowlist with catalog metadata from a valid catalog", func() {
+		const wfID = "550e8400-e29b-41d4-a716-446655440000"
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /api/v1/workflows", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"workflows": []interface{}{workflowJSON(wfID, validWorkflowSchemaYAML)},
+			})
+		})
 
-	meta, ok := validator.GetWorkflowMeta(wfID)
-	if !ok {
-		t.Fatalf("expected workflow %q to still be present in the allowlist (identity is not affected by schema parse failure)", wfID)
-	}
-	if len(meta.Parameters) != 0 {
-		t.Errorf("BR-SECURITY-SI10: expected Parameters to be stripped (fail-closed) when schema Content fails to parse, got %+v", meta.Parameters)
-	}
-	// Non-parameter metadata (sourced from the catalog entry itself, not the
-	// parsed schema body) must still be populated.
-	if meta.ExecutionEngine != "tekton" {
-		t.Errorf("expected ExecutionEngine to still be populated from the catalog entry, got %q", meta.ExecutionEngine)
-	}
-}
+		f := newDSCatalogFetcherForTest(GinkgoTB(), mux)
+		validator, err := f.FetchValidator(context.Background())
+		Expect(err).NotTo(HaveOccurred())
+		Expect(validator).NotTo(BeNil())
+
+		meta, ok := validator.GetWorkflowMeta(wfID)
+		Expect(ok).To(BeTrue(), "BR-SECURITY-AC6: expected workflow %q to be part of the allowlist", wfID)
+		Expect(meta.ExecutionEngine).To(Equal("tekton"))
+		Expect(meta.Version).To(Equal("1.0.0"))
+		Expect(meta.ServiceAccountName).To(Equal("workflow-runner"))
+		Expect(meta.ExecutionBundleDigest).To(Equal("sha256:aaa"))
+		Expect(meta.Parameters).To(HaveLen(1))
+		Expect(meta.Parameters[0].Name).To(Equal("TARGET_NAMESPACE"))
+	})
+
+	It("strips parameters (fail-closed) when a workflow's schema content is malformed, but keeps it in the allowlist", func() {
+		const wfID = "550e8400-e29b-41d4-a716-446655440001"
+		mux := http.NewServeMux()
+		mux.HandleFunc("GET /api/v1/workflows", func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				// Content is not a valid RemediationWorkflow CRD envelope (missing
+				// apiVersion/kind/metadata.name) — dsschema.Parser.Parse must fail.
+				"workflows": []interface{}{workflowJSON(wfID, "not: a-valid-workflow-schema")},
+			})
+		})
+
+		f := newDSCatalogFetcherForTest(GinkgoTB(), mux)
+		validator, err := f.FetchValidator(context.Background())
+		Expect(err).NotTo(HaveOccurred(), "BR-SECURITY-SI10: a single workflow's malformed schema must not fail the whole catalog fetch")
+
+		meta, ok := validator.GetWorkflowMeta(wfID)
+		Expect(ok).To(BeTrue(), "expected workflow %q to still be present in the allowlist (identity is not affected by schema parse failure)", wfID)
+		Expect(meta.Parameters).To(BeEmpty(), "BR-SECURITY-SI10: expected Parameters to be stripped (fail-closed) when schema Content fails to parse")
+		// Non-parameter metadata (sourced from the catalog entry itself, not the
+		// parsed schema body) must still be populated.
+		Expect(meta.ExecutionEngine).To(Equal("tekton"), "expected ExecutionEngine to still be populated from the catalog entry")
+	})
+})

--- a/docs/architecture/DESIGN_DECISIONS.md
+++ b/docs/architecture/DESIGN_DECISIONS.md
@@ -118,6 +118,7 @@
 | DD-LLM-004 | Remove langchaingo, Generalize Anthropic-Family Client, Extract Shared OpenAI-Compatible Core | 📋 Proposed | 2026-07-06 | [DD-LLM-004-langchaingo-removal-generalized-clients.md](decisions/DD-LLM-004-langchaingo-removal-generalized-clients.md) |
 | DD-LLM-005 | Model-Aware Reasoning/Thinking Token Support | 📋 Proposed | 2026-07-06 | [DD-LLM-005-model-aware-reasoning-support.md](decisions/DD-LLM-005-model-aware-reasoning-support.md) |
 | DD-LLM-006 | AWS Bedrock Provider Support via Dual-Client Routing | 📋 Proposed | 2026-07-06 | [DD-LLM-006-bedrock-dual-client-routing.md](decisions/DD-LLM-006-bedrock-dual-client-routing.md) |
+| DD-LLM-007 | AF and KA Intentionally Do Not Share an Anthropic Client | ✅ Approved | 2026-07-06 | [DD-LLM-007-af-ka-anthropic-client-divergence.md](decisions/DD-LLM-007-af-ka-anthropic-client-divergence.md) |
 
 **Note**: For complete decision details, alternatives considered, implementation guidance, and consequences, see the individual DD-* files in `docs/architecture/decisions/`.
 

--- a/docs/architecture/decisions/DD-LLM-007-af-ka-anthropic-client-divergence.md
+++ b/docs/architecture/decisions/DD-LLM-007-af-ka-anthropic-client-divergence.md
@@ -1,0 +1,68 @@
+# DD-LLM-007: AF and KA Intentionally Do Not Share an Anthropic Client
+
+**Status**: ✅ Approved
+**Priority**: P3 (documentation of existing architecture, no code change)
+**Owner**: KubernautAgent Team
+**Scope**: `pkg/kubernautagent/llm/anthropicfamily`, `pkg/apifrontend/launcher/model.go`
+**Related**: [DD-HAPI-019-001](./DD-HAPI-019-go-rewrite-design/DD-HAPI-019-001-framework-selection.md) (Framework Isolation Pattern), [DD-LLM-004](./DD-LLM-004-langchaingo-removal-generalized-clients.md) (langchaingo removal, shared OpenAI-compatible core), [DD-LLM-005](./DD-LLM-005-model-aware-reasoning-support.md) (reasoning/thinking support), [BR-AI-086](../../requirements/BR-AI-086-llm-reasoning-token-support.md), Issue #1578, #1601
+
+---
+
+## Context & Problem
+
+While fixing #1578's reasoning-request wiring gap (KA's `ai.llm.reasoning.enabled` was never threaded into any real Anthropic API call — see #1601), the question arose: KA and AF both talk to Claude (native Anthropic API and Vertex AI). AF's LLM path for Claude uses `github.com/Alcova-AI/adk-anthropic-go`'s `NewModel`; KA's uses the hand-rolled `pkg/kubernautagent/llm/anthropicfamily.Client` built directly on `github.com/anthropics/anthropic-sdk-go`. Given DD-LLM-004 already unified AF and KA on a single shared `pkg/shared/llm/openaicompat` core for the OpenAI-Chat-Completions protocol (and reasoning support came "for free" to AF's OpenAI-compatible surface as a result), should the Anthropic/Claude surface be unified the same way — either by making KA adopt AF's `adk-anthropic-go`-based client, or vice versa?
+
+This DD documents why the answer is **no**, and records that this is a deliberate architectural boundary, not an oversight or inconsistency to be fixed.
+
+### Why AF and KA differ here in the first place
+
+- **KA has no agent framework by design.** DD-HAPI-019-001 ("Framework Isolation Pattern") chose to keep KA's business logic (`internal/kubernautagent/investigator/*`) behind a Kubernaut-owned `llm.Client` interface specifically so that framework/library churn is absorbed by a thin adapter (~120 LOC) rather than leaking into business logic. This is the same principle that made removing `langchaingo` (DD-LLM-004) a contained refactor instead of a rewrite.
+- **AF's entire agent loop is built on Google's ADK-Go framework** (`google.golang.org/adk`) — session management, event streaming, and tool execution are all ADK constructs. `adk-anthropic-go` is not a general-purpose Anthropic client; it is a bridge that implements ADK's `model.LLM` interface (`genai.Content`/`genai.Part` types) so that AF's ADK-based loop can address Claude. Using it outside of an ADK-based loop provides no benefit over using `anthropic-sdk-go` directly — it only adds a translation hop.
+
+Both `adk-anthropic-go` and KA's `anthropicfamily` are, underneath, thin layers over the same official `anthropic-sdk-go`. `adk-anthropic-go` does not wrap a materially different or more capable Anthropic implementation; it wraps the identical SDK for ADK-interface compatibility.
+
+## Alternatives Considered
+
+### Alternative A — KA adopts `adk-anthropic-go` (and, transitively, Google ADK) for its Anthropic/Vertex path (rejected)
+
+- **Pros**: Single Anthropic client implementation shared by AF and KA; one place to fix Anthropic-specific bugs.
+- **Cons**: Requires either (a) KA adopting Google ADK as its full agent framework — reversing DD-HAPI-019's explicit "no framework" decision for an unrelated reason (Anthropic client reuse), a disproportionate architectural cost — or (b) using `adk-anthropic-go`'s model wrapper as a bolted-on dependency outside of ADK, which adds an extra KA-types → `genai.Content`/`Part` → adk-anthropic-go → `anthropic-sdk-go` translation hop in place of KA's current direct KA-types → `anthropic-sdk-go` hop. Either way, dependency footprint and indirection increase with no corresponding capability gain, since both paths bottom out in the same SDK. Directly contradicts the "lean dependency footprint" and "framework isolation" decision drivers from DD-HAPI-019-001.
+
+### Alternative B — AF adopts KA's `anthropicfamily.Client` for its Anthropic/Vertex path (rejected)
+
+- **Pros**: Single Anthropic client implementation; KA's client already has reasoning/thinking support (DD-LLM-005) and structured tool-call handling proven in production.
+- **Cons**: `anthropicfamily.Client` implements KA's own `llm.Client` interface (`Chat`/`StreamChat` over KA's `ChatRequest`/`ChatResponse` types), not ADK's `model.LLM` interface. AF's entire launcher, event bridge, and streaming executor are wired against ADK's `model.LLM` contract (`genai.Content`/`Part`, ADK session/event semantics — see `pkg/apifrontend/launcher/part_converter.go`'s `Thought`-part routing to the interactive "ThinkingPanel", which has no equivalent in KA's `llm.Client` interface). Adopting `anthropicfamily.Client` in AF would require either writing and maintaining a `model.LLM`-shaped adapter around it (functionally identical cost/shape to what `adk-anthropic-go` already provides) or restructuring AF's launcher away from ADK — again a disproportionate cost relative to the goal of "one Anthropic client."
+
+### Alternative C — Extract only the framework-independent, protocol-pure pieces that are genuinely reusable, leave the two model-wrapper layers separate (chosen — already partially in place)
+
+- **Pros**: Captures the real, available reuse without forcing an agent-framework decision. `anthropicfamily.Client` already does this today: it imports `adk-anthropic-go/converters.ThinkingConfigToAnthropic` for model-tier thinking-budget detection (adaptive vs. manual-only), specifically to avoid a second, independently-maintained tier-detection table (DD-LLM-005) — while implementing `buildParams`/`mapResponse`/message conversion itself, with zero ADK coupling. This mirrors exactly what DD-LLM-004 did for the OpenAI-compatible protocol core (`pkg/shared/llm/openaicompat`), which *was* genuinely wire-protocol-identical and worth sharing between AF and KA.
+- **Cons**: Two Anthropic call sites still exist (AF's ADK-wrapped one, KA's direct one); a genuine Anthropic-SDK-level bug fix (e.g. in message conversion) must be applied in both places if both are affected. Mitigated by both being thin, well-tested layers over the same upstream `anthropic-sdk-go` — bugs are far more likely to be in that shared upstream dependency (fixed once, upstream) than independently in each ~150-300 LOC adapter.
+
+### Decision
+
+**Alternative C** — no change to the current architecture. AF continues to use `adk-anthropic-go` (because AF is an ADK-based agent); KA continues to use `anthropicfamily.Client` (because KA is deliberately framework-independent per DD-HAPI-019). Reuse is scoped to genuinely framework-independent protocol logic (as already done for `converters.ThinkingConfigToAnthropic`, and as DD-LLM-004 did wholesale for the OpenAI-compatible protocol core, where AF and KA's needs were wire-protocol-identical).
+
+This directly answers the "shouldn't we have parity" question raised while scoping E2E coverage for #1601: parity in the sense of "one shared Anthropic client" is not achievable without collapsing one of the two intentionally-different architectural choices (framework-based vs. framework-isolated) that predate and are orthogonal to the reasoning-token work. Parity in the sense of "both surfaces should support reasoning" is a separate, legitimate question — AF's Anthropic/Gemini surface via ADK does not currently read `cfg.Reasoning` at all (unlike AF's OpenAI-compatible surface, which gained it for free via `openaicompat`); if AF-side Claude/Gemini extended-thinking support is wanted, it should be scoped as its own BR against ADK's own thinking-config surface, not as an adoption of KA's client.
+
+## Consequences
+
+### Positive
+- No disproportionate architectural cost (ADK adoption by KA, or ADK removal from AF) is incurred to chase client-implementation parity that would not, in practice, reduce risk (both paths already sit on the same upstream SDK).
+- Preserves DD-HAPI-019's framework-isolation guarantee for KA and AF's ADK-native integration (ThinkingPanel routing, session/event semantics) without compromise.
+- Leaves the door open for future, narrowly-scoped reuse of specific `adk-anthropic-go`/`anthropic-sdk-go` protocol-logic pieces (as already done for thinking-tier detection), consistent with CHECKPOINT B.
+
+### Negative
+- Two independent Anthropic message-conversion/tool-call-mapping implementations remain (AF's via ADK, KA's in `anthropicfamily`). A future correctness fix discovered in one may need to be checked against the other. Mitigated by both being thin (AF's is entirely `adk-anthropic-go`'s responsibility; KA's is ~300 LOC with its own test suite) and both ultimately bounded by `anthropic-sdk-go`'s own behavior.
+- AF's Anthropic/Vertex (and Gemini) surface has no reasoning/thinking-token support today, and this DD does not add any. If needed, track as a separate BR scoped to AF + ADK's thinking-config surface.
+
+## Related Decisions
+- **Builds on**: DD-HAPI-019-001 (Framework Isolation Pattern — the reason KA's and AF's LLM layers are structured differently in the first place)
+- **Contrasts with**: DD-LLM-004 (where AF/KA sharing *was* the right call, because the OpenAI-Chat-Completions protocol is wire-identical between them — unlike the Anthropic surface, where AF's consumer is ADK's `model.LLM` interface and KA's is KA's own `llm.Client`)
+- **Referenced by**: #1601 (KA reasoning-request wiring fix), while scoping E2E coverage for that fix
+
+---
+
+**Document Control**:
+- **Created**: 2026-07-06
+- **Version**: 1.0
+- **Status**: Approved

--- a/pkg/apifrontend/launcher/model.go
+++ b/pkg/apifrontend/launcher/model.go
@@ -41,6 +41,17 @@ import (
 // NewModelFromConfig constructs an ADK model.LLM from the AF LLM configuration.
 // It builds the appropriate transport chain (TLS CA, OAuth2, custom headers,
 // circuit breaker) and creates the provider-specific model client.
+//
+// The Anthropic/Vertex cases below use adk-anthropic-go's model.LLM wrapper
+// rather than kubernautagent's anthropicfamily.Client: AF's launcher is
+// entirely ADK-based (session/event/tool semantics all speak ADK's
+// model.LLM contract), while anthropicfamily implements KA's own,
+// deliberately framework-independent llm.Client interface (DD-HAPI-019-001).
+// This is an intentional architectural boundary, not an inconsistency to
+// converge — see DD-LLM-007. Note neither case below threads cfg.Reasoning:
+// AF has no reasoning/thinking-token support today (unlike its OpenAI-
+// compatible path, which gained it for free via the shared openaicompat
+// core, DD-LLM-004) — tracked as a gap in DD-LLM-007, not fixed by it.
 func NewModelFromConfig(ctx context.Context, cfg types.LLMConfig) (model.LLM, error) {
 	switch cfg.Provider {
 	case types.LLMProviderVertexAI:

--- a/pkg/kubernautagent/llm/anthropicfamily/client.go
+++ b/pkg/kubernautagent/llm/anthropicfamily/client.go
@@ -33,6 +33,13 @@ limitations under the License.
 // logic the API Frontend uses — rather than an independently-maintained
 // second copy (DD-LLM-005).
 //
+// This package is deliberately NOT shared with the API Frontend's Anthropic
+// path (which uses adk-anthropic-go's full model.LLM wrapper for Google
+// ADK compatibility): KA is framework-isolated by design (DD-HAPI-019-001)
+// while AF's entire agent loop is ADK-based. Only framework-independent
+// protocol logic (like the converters import above) is reused; the model
+// wrapper layers stay separate on purpose. See DD-LLM-007.
+//
 // Reference: https://docs.anthropic.com/en/api/claude-on-vertex-ai
 // Reference: https://github.com/anthropics/anthropic-sdk-go
 package anthropicfamily

--- a/pkg/kubernautagent/llm/anthropicfamily/client.go
+++ b/pkg/kubernautagent/llm/anthropicfamily/client.go
@@ -62,10 +62,11 @@ import (
 type Option func(*clientOpts)
 
 type clientOpts struct {
-	extraSDKOpts  []option.RequestOption
-	logger        logr.Logger
-	httpTimeout   time.Duration
-	baseTransport http.RoundTripper
+	extraSDKOpts     []option.RequestOption
+	logger           logr.Logger
+	httpTimeout      time.Duration
+	baseTransport    http.RoundTripper
+	defaultReasoning *llm.ReasoningRequest
 }
 
 // WithSDKOptions injects additional Anthropic SDK request options (e.g. base URL
@@ -95,12 +96,27 @@ func WithBaseTransport(rt http.RoundTripper) Option {
 	return func(o *clientOpts) { o.baseTransport = rt }
 }
 
+// WithReasoning resolves the operator's reasoning/thinking configuration
+// ONCE at client-construction time, per the documented contract on
+// llm.ReasoningRequest ("resolved once at LLM-client-construction time from
+// operator config, never threaded per-call from business logic",
+// DD-HAPI-019). Chat/StreamChat apply this default whenever the caller's
+// per-call req.Options.Reasoning is nil; an explicit per-call value (set or
+// unset) still wins, preserving test/override flexibility (#1578 fix: prior
+// to this, no production call site ever set Options.Reasoning, making
+// ai.llm.reasoning.enabled a structural no-op for every real Anthropic
+// call — see cmd/kubernautagent/llm_builder.go for the config wiring).
+func WithReasoning(r llm.ReasoningRequest) Option {
+	return func(o *clientOpts) { o.defaultReasoning = &r }
+}
+
 // Client implements llm.Client for Claude on Vertex AI using the official
 // Anthropic Go SDK with the vertex middleware.
 type Client struct {
-	sdk    anthropic.Client
-	model  string
-	logger logr.Logger
+	sdk              anthropic.Client
+	model            string
+	logger           logr.Logger
+	defaultReasoning *llm.ReasoningRequest
 }
 
 // New creates a Client for Claude on Vertex AI.
@@ -130,7 +146,7 @@ func New(ctx context.Context, model string, credentialsJSON []byte, project, loc
 	}
 
 	sdk := anthropic.NewClient(buildSDKOptions(o, vertexOpt, tokenSource)...)
-	return &Client{sdk: sdk, model: model, logger: o.logger}, nil
+	return &Client{sdk: sdk, model: model, logger: o.logger, defaultReasoning: o.defaultReasoning}, nil
 }
 
 // NewWithAPIKey creates a Client for Claude via the native Anthropic API
@@ -148,7 +164,7 @@ func NewWithAPIKey(apiKey, model string, opts ...Option) (*Client, error) {
 	sdkOpts = append(sdkOpts, o.extraSDKOpts...)
 
 	sdk := anthropic.NewClient(sdkOpts...)
-	return &Client{sdk: sdk, model: model, logger: o.logger}, nil
+	return &Client{sdk: sdk, model: model, logger: o.logger, defaultReasoning: o.defaultReasoning}, nil
 }
 
 // newClientOpts applies functional Options over a clientOpts pre-populated
@@ -269,8 +285,12 @@ func (c *Client) buildParams(req llm.ChatRequest) anthropic.MessageNewParams {
 		params.Tools = buildAnthropicTools(req.Tools, c.logger)
 	}
 
-	if req.Options.Reasoning != nil && req.Options.Reasoning.Enabled {
-		params.Thinking = resolveThinkingParam(req.Options.Reasoning, anthropic.Model(c.model))
+	reasoning := req.Options.Reasoning
+	if reasoning == nil {
+		reasoning = c.defaultReasoning
+	}
+	if reasoning != nil && reasoning.Enabled {
+		params.Thinking = resolveThinkingParam(reasoning, anthropic.Model(c.model))
 	}
 
 	return params

--- a/pkg/kubernautagent/llm/anthropicfamily/thinking_1580_test.go
+++ b/pkg/kubernautagent/llm/anthropicfamily/thinking_1580_test.go
@@ -101,6 +101,75 @@ var _ = Describe("anthropicfamily thinking/reasoning wiring — #1580", func() {
 		})
 	})
 
+	Describe("WithReasoning — construction-time default (#1578 wiring-gap fix)", func() {
+		// Prior to this fix, no production code path ever set
+		// ChatRequest.Options.Reasoning: llm_builder.go never read
+		// cfg.Reasoning.Enabled/BudgetTokens, and no investigator call site
+		// set Options.Reasoning per-call. Operator config's
+		// ai.llm.reasoning.enabled=true was therefore a structural dead end —
+		// the "thinking" param was never sent on a real Anthropic call,
+		// regardless of config. WithReasoning closes this by resolving the
+		// operator's setting ONCE at client-construction time (matching the
+		// documented intent on llm.ReasoningRequest: "resolved once at
+		// LLM-client-construction time from operator config, never threaded
+		// per-call from business logic").
+		newTestClientWithReasoning := func(model string, r llm.ReasoningRequest) *anthropicfamily.Client {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &receivedBody)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(responseBody))
+			}))
+			client, err := anthropicfamily.NewWithAPIKey("sk-ant-fake-key", model,
+				anthropicfamily.WithSDKOptions(option.WithBaseURL(server.URL)),
+				anthropicfamily.WithReasoning(r),
+			)
+			Expect(err).NotTo(HaveOccurred())
+			return client
+		}
+
+		It("UT-KA-1578-201: a client constructed WithReasoning(Enabled:true) sends thinking on a call with no per-call Options.Reasoning", func() {
+			client := newTestClientWithReasoning("claude-sonnet-4-6", llm.ReasoningRequest{Enabled: true, BudgetTokens: 4096})
+			_, err := client.Chat(context.Background(), llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "hello"}},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(receivedBody).To(HaveKey("thinking"),
+				"the construction-time default must apply when the caller (business logic) never sets Options.Reasoning per-call")
+			thinking := receivedBody["thinking"].(map[string]interface{})
+			Expect(thinking["budget_tokens"]).To(BeNumerically("==", 4096))
+		})
+
+		It("UT-KA-1578-202: a client constructed without WithReasoning still omits thinking (no regression for existing deployments)", func() {
+			client := newTestClient("claude-sonnet-4-6")
+			_, err := client.Chat(context.Background(), llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "hello"}},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(receivedBody).NotTo(HaveKey("thinking"))
+		})
+
+		It("UT-KA-1578-203: an explicit per-call Options.Reasoning still overrides the construction-time default (disable wins)", func() {
+			client := newTestClientWithReasoning("claude-sonnet-4-6", llm.ReasoningRequest{Enabled: true, BudgetTokens: 4096})
+			_, err := client.Chat(context.Background(), llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "hello"}},
+				Options:  llm.ChatOptions{Reasoning: &llm.ReasoningRequest{Enabled: false}},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(receivedBody).NotTo(HaveKey("thinking"),
+				"a per-call override must win over the client's construction-time default")
+		})
+
+		It("UT-KA-1578-204: WithReasoning(Enabled:false) never sends thinking, even with a BudgetTokens set", func() {
+			client := newTestClientWithReasoning("claude-sonnet-4-6", llm.ReasoningRequest{Enabled: false, BudgetTokens: 4096})
+			_, err := client.Chat(context.Background(), llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "hello"}},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(receivedBody).NotTo(HaveKey("thinking"))
+		})
+	})
+
 	Describe("request wiring — model-aware tier detection (adk-anthropic-go/converters reuse)", func() {
 		It("UT-KA-1580-103: adaptive-capable model (claude-sonnet-4-6) with no explicit budget gets adaptive thinking", func() {
 			client := newTestClient("claude-sonnet-4-6")


### PR DESCRIPTION
## Summary

Post-merge follow-up to #1598. While auditing test coverage for the reasoning-token feature (BR-AI-086), found that `ai.llm.reasoning.enabled` / `budgetTokens` was **never actually wired into any real LLM call**:

- Every `llm.ChatOptions{}` construction site in `internal/kubernautagent/investigator/*.go` and `internal/kubernautagent/alignment/*.go` only sets `JSONMode`/`OutputSchema`/`MaxTokens`/`Temperature` — none ever set `.Reasoning`.
- `cmd/kubernautagent/llm_builder.go` only read `cfg.Reasoning.CapabilityOverride` (for the OpenAI-compatible replay-mode auto-detection), never `.Enabled`/`.BudgetTokens`.
- `anthropicfamily.Client` had no construction-time option to bake in a default; it only honored a per-call `Options.Reasoning`, which nothing ever set.

Net effect: `ai.llm.reasoning.enabled: true` parsed, validated, and hot-reloaded correctly, but never caused a real Anthropic/Vertex API call to include the `thinking` request parameter — a structural no-op for the exact provider (Claude) that motivated BR-AI-086 (OLS-3442).

This was fully masked by test doubles:
- `E2E-KA-AUDIT-001`'s mock-llm unconditionally returns `reasoning_content` regardless of the incoming request, so it proves capture/audit-surfacing but not that reasoning was ever *requested*.
- That E2E test only exercises the OpenAI-compatible provider path (`provider: "openai"`) — Anthropic's request-side `thinking` param was never exercised by anything above the unit-test tier (hand-authored fixtures only).

## Fix

- Add `anthropicfamily.WithReasoning(llm.ReasoningRequest)`, a construction-time option matching the documented contract on `llm.ReasoningRequest` ("resolved once at client construction, never threaded per-call from business logic"). `Client.buildParams` now falls back to this default whenever a per-call `Options.Reasoning` is nil; an explicit per-call value still wins.
- Wire `cfg.Reasoning` into both the `anthropic` and `vertex_ai` construction paths in `llm_builder.go` via a new `anthropicReasoningOptions` helper.
- Document (via code comment) why the OpenAI-compatible path intentionally does *not* thread `.Enabled`/`.BudgetTokens`: that wire protocol has no request-side reasoning toggle — capture there is correctly unconditional/model-driven (DeepSeek-reasoner-class models).

## Test plan

- [x] New UT-KA-1578-201..204 in `pkg/kubernautagent/llm/anthropicfamily/thinking_1580_test.go`: construction-time default applies when no per-call override is set, no regression when `WithReasoning` isn't used, per-call override still wins, `Enabled:false` never sends `thinking`.
- [x] New wiring tests in `cmd/kubernautagent/llm_builder_wiring_1580_1581_test.go`: `anthropicReasoningOptions` config→option mapping, and `buildAnthropicNativeClient` dispatch with a reasoning-enabled config.
- [x] `go build ./...`, `go vet ./...` clean.
- [x] `golangci-lint run` clean on changed packages.
- [x] Full `go test ./pkg/kubernautagent/... ./cmd/kubernautagent/... ./internal/kubernautagent/... ./pkg/shared/llm/... ./pkg/shared/types/...` passes, no regressions.

Made with [Cursor](https://cursor.com)