### PR TITLE
feat(llm): unified reasoning-effort knob for OpenAI/DeepSeek/Anthropic (#1604)

### DIFF
--- a/cmd/kubernautagent/llm_builder.go
+++ b/cmd/kubernautagent/llm_builder.go
@@ -116,6 +116,7 @@ func anthropicReasoningOptions(cfg types.LLMConfig) []anthropicfamily.Option {
 	return []anthropicfamily.Option{anthropicfamily.WithReasoning(llm.ReasoningRequest{
 		Enabled:      true,
 		BudgetTokens: cfg.Reasoning.BudgetTokens,
+		Effort:       cfg.Reasoning.Effort,
 	})}
 }
 
@@ -139,19 +140,37 @@ func buildOpenAICompatClient(cfg types.LLMConfig) (llm.Client, error) {
 	}
 
 	opts := []kaopenai.Option{kaopenai.WithHTTPClient(httpClient)}
-	// Only CapabilityOverride is threaded here — the OpenAI Chat Completions
-	// wire protocol has no request-side "enable reasoning" field (unlike
-	// Anthropic's "thinking" param, see anthropicReasoningOptions above).
-	// cfg.Reasoning.Enabled/BudgetTokens are intentionally NOT read: reasoning
-	// capture for this family is unconditional and model-driven (DeepSeek
-	// -reasoner-class models always emit reasoning_content; see
-	// openaicompat's AC3 "always capture" behavior). CapabilityOverride only
-	// controls DetectReasoningMode's replay-mode auto-detection.
+	// CapabilityOverride only controls DetectReasoningMode's replay-mode
+	// auto-detection — reasoning-content CAPTURE for this family is
+	// unconditional and model-driven (DeepSeek-reasoner-class models always
+	// emit reasoning_content; see openaicompat's AC3 "always capture"
+	// behavior), so Enabled/BudgetTokens are never read for that purpose.
+	// BudgetTokens has no OpenAI-Chat-Completions equivalent (no
+	// token-budget concept in "reasoning_effort") and stays Anthropic-only.
+	// Effort DOES have a real wire equivalent here (#1604's
+	// reasoning_effort request-side control) — see openaiReasoningOptions.
 	if cfg.Reasoning != nil && cfg.Reasoning.CapabilityOverride != "" {
 		opts = append(opts, kaopenai.WithCapabilityOverride(cfg.Reasoning.CapabilityOverride))
 	}
+	opts = append(opts, openaiReasoningOptions(cfg)...)
 
 	return kaopenai.New(cfg.Model, cfg.Endpoint, cfg.APIKey, opts...), nil
+}
+
+// openaiReasoningOptions maps the operator's ai.llm.reasoning.effort config
+// into a kaopenai.WithReasoning construction option (#1604), resolved once
+// here rather than threaded per-call from investigator business logic
+// (DD-HAPI-019), mirroring anthropicReasoningOptions above. Unlike that
+// function, BudgetTokens is not passed through: it has no
+// OpenAI-Chat-Completions wire equivalent.
+func openaiReasoningOptions(cfg types.LLMConfig) []kaopenai.Option {
+	if cfg.Reasoning == nil || !cfg.Reasoning.Enabled {
+		return nil
+	}
+	return []kaopenai.Option{kaopenai.WithReasoning(llm.ReasoningRequest{
+		Enabled: true,
+		Effort:  cfg.Reasoning.Effort,
+	})}
 }
 
 // buildTransportChain composes the HTTP transport stack from the merged config,

--- a/cmd/kubernautagent/llm_builder_effort_1604_test.go
+++ b/cmd/kubernautagent/llm_builder_effort_1604_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/anthropics/anthropic-sdk-go/option"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm/anthropicfamily"
+	kaopenai "github.com/jordigilh/kubernaut/pkg/kubernautagent/llm/openai"
+	"github.com/jordigilh/kubernaut/pkg/shared/types"
+)
+
+// Issue #1604 / BR-AI-086: unified Effort knob config->option wiring for
+// both LLM client families, closing the same class of wiring gap #1601
+// closed for cfg.Reasoning.Enabled/BudgetTokens on Anthropic.
+var _ = Describe("buildLLMClientFromConfig — Effort knob wiring (#1604)", func() {
+
+	Describe("anthropicReasoningOptions threads Effort through to WithReasoning", func() {
+		var (
+			server       *httptest.Server
+			receivedBody map[string]interface{}
+		)
+
+		BeforeEach(func() {
+			receivedBody = nil
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &receivedBody)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"id":"msg_test","type":"message","role":"assistant","content":[{"type":"text","text":"ok"}],"model":"claude-sonnet-4-6","stop_reason":"end_turn","usage":{"input_tokens":1,"output_tokens":1}}`))
+			}))
+		})
+
+		AfterEach(func() {
+			server.Close()
+		})
+
+		It("sends the configured Effort as an output_config.effort hint on the wire", func() {
+			cfg := types.LLMConfig{
+				Provider:  types.LLMProviderAnthropic,
+				Model:     "claude-sonnet-4-6",
+				APIKey:    "sk-ant-fake-test-key",
+				Reasoning: &types.LLMReasoningConfig{Enabled: true, Effort: "low"},
+			}
+
+			opts := append(anthropicReasoningOptions(cfg), anthropicfamily.WithSDKOptions(option.WithBaseURL(server.URL)))
+			client, err := anthropicfamily.NewWithAPIKey(cfg.APIKey, cfg.Model, opts...)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = client.Chat(context.Background(), helloChatRequest())
+			Expect(err).NotTo(HaveOccurred())
+
+			outputConfig := receivedBody["output_config"].(map[string]interface{})
+			Expect(outputConfig["effort"]).To(Equal("low"))
+		})
+	})
+
+	Describe("openaiReasoningOptions — cfg.Reasoning -> kaopenai.Option mapping", func() {
+		It("produces exactly one WithReasoning option when reasoning is enabled", func() {
+			cfg := types.LLMConfig{
+				Reasoning: &types.LLMReasoningConfig{Enabled: true, Effort: "high"},
+			}
+			Expect(openaiReasoningOptions(cfg)).To(HaveLen(1))
+		})
+
+		It("produces no options when Reasoning is nil (no regression)", func() {
+			Expect(openaiReasoningOptions(types.LLMConfig{})).To(BeEmpty())
+		})
+
+		It("produces no options when reasoning.enabled is false", func() {
+			cfg := types.LLMConfig{
+				Reasoning: &types.LLMReasoningConfig{Enabled: false, Effort: "high"},
+			}
+			Expect(openaiReasoningOptions(cfg)).To(BeEmpty())
+		})
+	})
+
+	Describe("buildOpenAICompatClient — request-side wiring end-to-end: cfg.Reasoning.Effort -> outgoing reasoning_effort", func() {
+		var (
+			server       *httptest.Server
+			receivedBody map[string]interface{}
+		)
+
+		BeforeEach(func() {
+			receivedBody = nil
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				_ = json.Unmarshal(body, &receivedBody)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+			}))
+		})
+
+		AfterEach(func() {
+			server.Close()
+		})
+
+		It("sends reasoning_effort on the wire when the operator's config has reasoning.enabled=true and effort set", func() {
+			cfg := types.LLMConfig{
+				Provider:  types.LLMProviderOpenAI,
+				Model:     "gpt-5",
+				Endpoint:  server.URL,
+				APIKey:    "sk-fake-test-key",
+				Reasoning: &types.LLMReasoningConfig{Enabled: true, Effort: "medium"},
+			}
+
+			client, err := buildLLMClientFromConfig(context.Background(), cfg)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(client).To(BeAssignableToTypeOf(&kaopenai.Client{}))
+
+			_, err = client.Chat(context.Background(), helloChatRequest())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(receivedBody["reasoning_effort"]).To(Equal("medium"),
+				"operator config ai.llm.reasoning.effort must reach the outgoing OpenAI request")
+		})
+
+		It("omits reasoning_effort when the operator's config has no reasoning block (no regression)", func() {
+			cfg := types.LLMConfig{
+				Provider: types.LLMProviderOpenAI,
+				Model:    "gpt-5",
+				Endpoint: server.URL,
+				APIKey:   "sk-fake-test-key",
+			}
+
+			client, err := buildLLMClientFromConfig(context.Background(), cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = client.Chat(context.Background(), helloChatRequest())
+			Expect(err).NotTo(HaveOccurred())
+			Expect(receivedBody).NotTo(HaveKey("reasoning_effort"))
+		})
+	})
+})

--- a/docs/architecture/decisions/DD-LLM-005-model-aware-reasoning-support.md
+++ b/docs/architecture/decisions/DD-LLM-005-model-aware-reasoning-support.md
@@ -4,7 +4,7 @@
 **Priority**: P2
 **Owner**: KubernautAgent Team
 **Scope**: `pkg/kubernautagent/llm/types.go`, `pkg/kubernautagent/llm/anthropicfamily`, `pkg/kubernautagent/llm/openai`, `pkg/shared/llm/openaicompat`, `pkg/shared/types/llm.go`
-**Related**: [BR-AI-086](../../requirements/BR-AI-086-llm-reasoning-token-support.md), [DD-LLM-004](./DD-LLM-004-langchaingo-removal-generalized-clients.md), [DD-HAPI-019](./DD-HAPI-019-go-rewrite-design), Issue #1578, #1580, #1581
+**Related**: [BR-AI-086](../../requirements/BR-AI-086-llm-reasoning-token-support.md), [DD-LLM-004](./DD-LLM-004-langchaingo-removal-generalized-clients.md), [DD-HAPI-019](./DD-HAPI-019-go-rewrite-design), Issue #1578, #1580, #1581, #1601, #1604
 
 ---
 
@@ -83,12 +83,23 @@ type ChatOptions struct {
     Reasoning *ReasoningRequest `json:"reasoning,omitempty"`
 }
 type ReasoningRequest struct {
-    Enabled      bool `json:"enabled,omitempty"`
-    BudgetTokens int  `json:"budget_tokens,omitempty"`
+    Enabled      bool   `json:"enabled,omitempty"`
+    BudgetTokens int    `json:"budget_tokens,omitempty"`
+    Effort       string `json:"effort,omitempty"` // "", none/minimal/low/medium/high/xhigh (#1604)
 }
 ```
 
 Reasoning is resolved once at client-construction time (auto-detect from model name + `LLMReasoningConfig.CapabilityOverride`), never threaded per-call from the investigator — `internal/kubernautagent/investigator/*` remains completely unaware of reasoning.
+
+### Addendum (#1604): unified `Effort` knob
+
+`Effort` is a single, provider-agnostic reasoning-depth value using OpenAI's own vocabulary (the vendor with the widest tier granularity), reused as the canonical form for every provider rather than exposing a separate per-provider knob — the same "one config surface, provider-specific mapping under the hood" pattern this DD already established for `ReasoningMode`/`DetectReasoningMode`. Each client maps/clamps it into its own wire dialect:
+
+- **Anthropic (native/Vertex)**: mapped onto `genai.ThinkingLevel` and passed through the same `converters.ThinkingConfigToAnthropic` call this DD already reuses — the effort hint (`ThinkingMapping.Effort`, Anthropic's `output_config.effort`) that call already computed for adaptive-capable models but which was previously discarded is now applied. `xhigh` clamps to `High`: `genai.ThinkingLevel` has no tier above High, even though Anthropic's raw `OutputConfigEffort` enum does (up to `max`) — staying within the shared converter's intermediate representation was chosen over hand-mapping a second, independently-maintained table straight to the SDK's fuller enum, consistent with this DD's Alternative-B rationale.
+- **Real OpenAI/Azure o-series and gpt-5-family models**: passed through verbatim as Chat Completions' `reasoning_effort` field (`pkg/shared/llm/openaicompat`'s new `EffortDialectOpenAI`).
+- **DeepSeek (openai_compatible)**: downscaled to DeepSeek's own two-tier dialect (`high`/`max`) plus an explicit `thinking.type` enabled/disabled toggle (`EffortDialectDeepSeek`).
+- **`effort: none` + `enabled: true` for an Anthropic-family provider is a config-validation error (fail-closed at startup)**, not a runtime clamp — a deliberate exception to this DD's own compatibility-floor/graceful-degrade principle, because this is a known, deterministic operator-facing contradiction on a provider always identified by vendor enum, not an unknown-capability case the floor principle is meant to cover.
+- **AF's OpenAI-compatible adapter (`pkg/apifrontend/launcher/openai`) gets the same Effort knob**, via a construction-time-only `WithReasoningEffort` option wired from `cfg.Reasoning.Effort` in `pkg/apifrontend/launcher/model.go`'s `newOpenAICompatibleModel` — the openai/deepseek dialect detection and wire mapping are the exact same `pkg/shared/llm/openaicompat` code KA's wrapper calls, so there is no drift risk between the two call sites. Unlike KA's `Options.Reasoning`, AF has no per-call override: ADK's `model.LLMRequest` carries no reasoning field, so the construction-time default is the only knob for this family, consistent with AF's existing reasoning-capture wiring (`DetectReasoningMode`) having no per-call override either. AF's Anthropic/Vertex path (via `adk-anthropic-go`) still has no reasoning/effort support at all — that gap remains tracked separately in DD-LLM-007, unaffected by this addendum.
 
 ## Consequences
 

--- a/docs/architecture/decisions/DD-LLM-007-af-ka-anthropic-client-divergence.md
+++ b/docs/architecture/decisions/DD-LLM-007-af-ka-anthropic-client-divergence.md
@@ -55,10 +55,12 @@ This directly answers the "shouldn't we have parity" question raised while scopi
 - Two independent Anthropic message-conversion/tool-call-mapping implementations remain (AF's via ADK, KA's in `anthropicfamily`). A future correctness fix discovered in one may need to be checked against the other. Mitigated by both being thin (AF's is entirely `adk-anthropic-go`'s responsibility; KA's is ~300 LOC with its own test suite) and both ultimately bounded by `anthropic-sdk-go`'s own behavior.
 - AF's Anthropic/Vertex (and Gemini) surface has no reasoning/thinking-token support today, and this DD does not add any. If needed, track as a separate BR scoped to AF + ADK's thinking-config surface.
 
+**Update (#1604)**: the unified `Effort` reasoning-depth knob extended the "gained it for free via `openaicompat`" parity above from reasoning-content capture to the effort/depth-control dial as well — AF's OpenAI-compatible surface (`pkg/apifrontend/launcher/openai`) now carries `WithReasoningEffort`, wired from `cfg.Reasoning.Effort` in `pkg/apifrontend/launcher/model.go`, at parity with KA's equivalent wrapper. This is the same shared `pkg/shared/llm/openaicompat` dialect code on both sides — no new divergence introduced. The Anthropic/Vertex/Gemini gap noted above is unchanged by this update.
+
 ## Related Decisions
 - **Builds on**: DD-HAPI-019-001 (Framework Isolation Pattern — the reason KA's and AF's LLM layers are structured differently in the first place)
 - **Contrasts with**: DD-LLM-004 (where AF/KA sharing *was* the right call, because the OpenAI-Chat-Completions protocol is wire-identical between them — unlike the Anthropic surface, where AF's consumer is ADK's `model.LLM` interface and KA's is KA's own `llm.Client`)
-- **Referenced by**: #1601 (KA reasoning-request wiring fix), while scoping E2E coverage for that fix
+- **Referenced by**: #1601 (KA reasoning-request wiring fix), while scoping E2E coverage for that fix; #1604 (unified Effort knob, extended to AF's OpenAI-compatible surface)
 
 ---
 

--- a/docs/requirements/BR-AI-086-llm-reasoning-token-support.md
+++ b/docs/requirements/BR-AI-086-llm-reasoning-token-support.md
@@ -13,7 +13,7 @@
 - [DD-LLM-005: Model-Aware Reasoning/Thinking Token Support](../architecture/decisions/DD-LLM-005-model-aware-reasoning-support.md)
 - [DD-LLM-006: AWS Bedrock Provider Support via Dual-Client Routing](../architecture/decisions/DD-LLM-006-bedrock-dual-client-routing.md)
 
-**Related Issues**: #1578 (parent), #1580, #1581, #1582
+**Related Issues**: #1578 (parent), #1580, #1581, #1582, #1601, #1604
 
 **Note**: This requirement supersedes no prior BR. `BR-HAPI-263` (conversation continuity) describes the API surface of the deprecated Python HolmesGPT-API (HAPI) service (`InvestigateRequest.previous_messages`, `investigate_issues`/`prompt_call`) and does not apply to Kubernaut Agent (KA)'s current Go implementation. HAPI is no longer a service in Kubernaut and must not be referenced or extended by current or future work; this BR is written fresh against KA's actual `llm.Client`/`Investigator` implementation.
 
@@ -47,6 +47,12 @@ Add opt-in, model-aware reasoning/thinking token support across every LLM provid
 5. Self-hosted/custom models (served via the OpenAI-compatible client) support an explicit capability override (`auto` / `force_on` / `force_off`) since they cannot be reliably identified by vendor enum alone.
 6. Captured reasoning content is surfaced in the investigation audit trail per SOC2 CC7.2 / BR-AUDIT-005.
 7. No regression to current investigation behavior for any provider/model when reasoning is left at its default-disabled state.
+8. A single, provider-agnostic reasoning-depth knob (`LLMReasoningConfig.Effort`: `""`/`none`/`minimal`/`low`/`medium`/`high`/`xhigh`) controls how hard the model thinks, mapped into each client's own wire dialect (issue #1604):
+   - Anthropic (native/Vertex): maps onto `genai.ThinkingLevel` via the shared `adk-anthropic-go/converters` mapping (DD-LLM-005), surfacing the resulting `output_config.effort` hint on adaptive-capable models.
+   - Real OpenAI/Azure o-series and gpt-5-family models: passed through verbatim as Chat Completions' `reasoning_effort` field.
+   - DeepSeek (openai_compatible): downscaled to DeepSeek's own two-tier dialect (`high`/`max`) plus an explicit thinking-enabled/disabled toggle.
+   - An explicit `BudgetTokens` always wins over `Effort` for Anthropic (an exact-value power-user override). `effort: none` combined with `enabled: true` for an Anthropic-family provider is rejected at config validation (fail-closed, not silently reinterpreted) — Anthropic's wire concept for "reasoning enabled, zero effort" is achievable but a contradictory pairing for operator-facing config clarity. Leaving `Effort` unset applies the provider's own vendor default (OpenAI/DeepSeek) or the pre-#1604 High-tier default (Anthropic).
+   - AF's OpenAI-compatible adapter (`pkg/apifrontend/launcher/openai`) carries the same `Effort` knob at parity with KA, via the identical shared `pkg/shared/llm/openaicompat` dialect detection/mapping — construction-time only (no per-call override, since ADK's `model.LLMRequest` has no reasoning field). AF's Anthropic/Vertex path (`adk-anthropic-go`) has no reasoning/effort support at all — a known, separately-tracked gap (DD-LLM-007), not addressed by issue #1604.
 
 ---
 

--- a/pkg/apifrontend/launcher/model.go
+++ b/pkg/apifrontend/launcher/model.go
@@ -48,10 +48,13 @@ import (
 // model.LLM contract), while anthropicfamily implements KA's own,
 // deliberately framework-independent llm.Client interface (DD-HAPI-019-001).
 // This is an intentional architectural boundary, not an inconsistency to
-// converge — see DD-LLM-007. Note neither case below threads cfg.Reasoning:
-// AF has no reasoning/thinking-token support today (unlike its OpenAI-
-// compatible path, which gained it for free via the shared openaicompat
-// core, DD-LLM-004) — tracked as a gap in DD-LLM-007, not fixed by it.
+// converge — see DD-LLM-007. Note the Anthropic/Vertex cases below still
+// don't thread cfg.Reasoning: AF has no reasoning/thinking-token support on
+// that path today (unlike its OpenAI-compatible path, which gained
+// reasoning-content capture for free via the shared openaicompat core,
+// DD-LLM-004, and now also threads cfg.Reasoning.Effort, #1604, via
+// newOpenAICompatibleModel below) — the Anthropic/Vertex gap remains
+// tracked in DD-LLM-007, not fixed by it.
 func NewModelFromConfig(ctx context.Context, cfg types.LLMConfig) (model.LLM, error) {
 	switch cfg.Provider {
 	case types.LLMProviderVertexAI:
@@ -207,6 +210,9 @@ func newOpenAICompatibleModel(cfg types.LLMConfig) (model.LLM, error) {
 	}
 	if httpClient != nil {
 		opts = append(opts, openaimodel.WithHTTPClient(httpClient))
+	}
+	if cfg.Reasoning != nil && cfg.Reasoning.Enabled {
+		opts = append(opts, openaimodel.WithReasoningEffort(cfg.Reasoning.Effort))
 	}
 
 	return openaimodel.NewModel(cfg.Model, cfg.Endpoint, cfg.APIKey, opts...), nil

--- a/pkg/apifrontend/launcher/openai/adapter.go
+++ b/pkg/apifrontend/launcher/openai/adapter.go
@@ -26,6 +26,8 @@ type Model struct {
 	name          string
 	client        *openaicompat.Client
 	reasoningMode openaicompat.ReasoningMode
+	effortDialect openaicompat.EffortDialect
+	effort        string
 }
 
 // Option configures the Model.
@@ -33,6 +35,7 @@ type Option func(*modelOpts)
 
 type modelOpts struct {
 	httpClient *http.Client
+	effort     string
 }
 
 // WithHTTPClient injects a custom HTTP client for transport chain support.
@@ -42,10 +45,26 @@ func WithHTTPClient(c *http.Client) Option {
 	}
 }
 
+// WithReasoningEffort sets the construction-time reasoning-depth value
+// (#1604's unified Effort knob — one of "", "none", "minimal", "low",
+// "medium", "high", "xhigh"). Unlike KA's kaopenai.WithReasoning, there is
+// no per-call override here: ADK's model.LLMRequest carries no reasoning
+// field, so this is the only knob (DD-LLM-005 addendum). An empty value
+// (the default) sends no effort parameter at all — the provider's own
+// vendor default applies, matching KA's zero-regression behavior.
+func WithReasoningEffort(effort string) Option {
+	return func(o *modelOpts) {
+		o.effort = effort
+	}
+}
+
 // NewModel creates a new OpenAI-compatible model adapter. The reasoning
 // round-trip mode is auto-detected from modelName (BR-AI-086, DD-LLM-005) —
 // unrecognized models default to no reasoning capture/replay, preserving
-// today's behavior exactly for every currently-configured model.
+// today's behavior exactly for every currently-configured model. The effort
+// wire dialect is likewise auto-detected (#1604); WithReasoningEffort's
+// value is only ever sent for a recognized dialect (see applyEffort in the
+// shared openaicompat package).
 func NewModel(modelName, endpoint, apiKey string, opts ...Option) *Model {
 	o := &modelOpts{}
 	for _, opt := range opts {
@@ -61,6 +80,8 @@ func NewModel(modelName, endpoint, apiKey string, opts ...Option) *Model {
 		name:          modelName,
 		client:        openaicompat.New(modelName, endpoint, apiKey, clientOpts...),
 		reasoningMode: openaicompat.DetectReasoningMode(modelName, ""),
+		effortDialect: openaicompat.DetectEffortDialect(modelName),
+		effort:        o.effort,
 	}
 }
 
@@ -96,6 +117,10 @@ func (m *Model) buildRequest(req *model.LLMRequest) openaicompat.Request {
 	compatReq := openaicompat.Request{
 		Model:         m.name,
 		ReasoningMode: m.reasoningMode,
+	}
+	if m.effort != "" {
+		compatReq.Effort = m.effort
+		compatReq.EffortDialect = m.effortDialect
 	}
 
 	if req.Config != nil && req.Config.SystemInstruction != nil {

--- a/pkg/apifrontend/launcher/openai/effort_1604_test.go
+++ b/pkg/apifrontend/launcher/openai/effort_1604_test.go
@@ -1,0 +1,132 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openai_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"google.golang.org/adk/model"
+	"google.golang.org/genai"
+
+	openaimodel "github.com/jordigilh/kubernaut/pkg/apifrontend/launcher/openai"
+)
+
+// Issue #1604 / BR-AI-086: unified Effort knob wiring for AF's ADK-facing
+// OpenAI-Chat-Completions-compatible adapter. Mirrors
+// pkg/kubernautagent/llm/openai's WithReasoning construction-time-default
+// pattern (effort_1604_test.go, UT-KA-1604-301..306) for cross-family
+// symmetry (DD-LLM-005) — AF has no per-call reasoning override the way
+// KA's Options.Reasoning does, since ADK's model.LLMRequest carries no
+// such field, so the construction-time default is the only knob here.
+var _ = Describe("apifrontend/launcher/openai.Model Effort knob wiring — #1604", func() {
+	var (
+		server       *httptest.Server
+		receivedBody map[string]any
+	)
+
+	AfterEach(func() {
+		if server != nil {
+			server.Close()
+		}
+	})
+
+	newTestServer := func() {
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			receivedBody = nil
+			_ = json.NewDecoder(r.Body).Decode(&receivedBody)
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(chatCompletionResponse("ok"))
+		}))
+	}
+
+	simpleRequest := func() *model.LLMRequest {
+		return &model.LLMRequest{
+			Contents: []*genai.Content{
+				{Role: "user", Parts: []*genai.Part{{Text: "hello"}}},
+			},
+		}
+	}
+
+	// UT-AF-1604-301 [BR-AI-086 AC8]: WithReasoningEffort sends the configured
+	// Effort as reasoning_effort for a real OpenAI reasoning model.
+	It("UT-AF-1604-301: WithReasoningEffort sends the configured Effort as reasoning_effort for a real OpenAI reasoning model", func() {
+		newTestServer()
+		m := openaimodel.NewModel("gpt-5", server.URL, "test-key", openaimodel.WithReasoningEffort("high"))
+		for resp, err := range m.GenerateContent(context.Background(), simpleRequest(), false) {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).NotTo(BeNil())
+		}
+		Expect(receivedBody["reasoning_effort"]).To(Equal("high"))
+	})
+
+	// UT-AF-1604-302 [BR-AI-086 AC8]: WithReasoningEffort has no effect on a
+	// non-reasoning model (no effort dialect recognized) — compatibility floor.
+	It("UT-AF-1604-302: WithReasoningEffort has no effect on a non-reasoning model", func() {
+		newTestServer()
+		m := openaimodel.NewModel("gpt-4o", server.URL, "test-key", openaimodel.WithReasoningEffort("high"))
+		for resp, err := range m.GenerateContent(context.Background(), simpleRequest(), false) {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).NotTo(BeNil())
+		}
+		Expect(receivedBody).NotTo(HaveKey("reasoning_effort"))
+	})
+
+	// UT-AF-1604-303 [BR-AI-086 AC8]: downscales to DeepSeek's own dialect for
+	// a deepseek-v4-pro model, same mapping as KA's wrapper (shared openaicompat).
+	It("UT-AF-1604-303: downscales to DeepSeek's dialect for a deepseek-v4-pro model", func() {
+		newTestServer()
+		m := openaimodel.NewModel("deepseek-v4-pro", server.URL, "test-key", openaimodel.WithReasoningEffort("xhigh"))
+		for resp, err := range m.GenerateContent(context.Background(), simpleRequest(), false) {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).NotTo(BeNil())
+		}
+		Expect(receivedBody["reasoning_effort"]).To(Equal("max"))
+		thinking, ok := receivedBody["thinking"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(thinking["type"]).To(Equal("enabled"))
+	})
+
+	// UT-AF-1604-304 [BR-AI-086 AC8]: without WithReasoningEffort, no effort
+	// field is ever sent (zero-regression default).
+	It("UT-AF-1604-304: without WithReasoningEffort, no effort field is ever sent", func() {
+		newTestServer()
+		m := openaimodel.NewModel("gpt-5", server.URL, "test-key")
+		for resp, err := range m.GenerateContent(context.Background(), simpleRequest(), false) {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).NotTo(BeNil())
+		}
+		Expect(receivedBody).NotTo(HaveKey("reasoning_effort"))
+	})
+
+	// UT-AF-1604-305 [BR-AI-086 AC8]: an empty Effort ("" — vendor default) is
+	// a no-op even on a recognized reasoning model, mirroring KA's behavior.
+	It("UT-AF-1604-305: an empty Effort sends no reasoning_effort even on a recognized model", func() {
+		newTestServer()
+		m := openaimodel.NewModel("gpt-5", server.URL, "test-key", openaimodel.WithReasoningEffort(""))
+		for resp, err := range m.GenerateContent(context.Background(), simpleRequest(), false) {
+			Expect(err).NotTo(HaveOccurred())
+			Expect(resp).NotTo(BeNil())
+		}
+		Expect(receivedBody).NotTo(HaveKey("reasoning_effort"))
+	})
+})

--- a/pkg/kubernautagent/llm/anthropicfamily/client.go
+++ b/pkg/kubernautagent/llm/anthropicfamily/client.go
@@ -297,26 +297,80 @@ func (c *Client) buildParams(req llm.ChatRequest) anthropic.MessageNewParams {
 		reasoning = c.defaultReasoning
 	}
 	if reasoning != nil && reasoning.Enabled {
-		params.Thinking = resolveThinkingParam(reasoning, anthropic.Model(c.model))
+		thinking, effort := resolveThinkingParam(reasoning, anthropic.Model(c.model))
+		params.Thinking = thinking
+		if effort != "" {
+			params.OutputConfig.Effort = effort
+		}
 	}
 
 	return params
 }
 
 // resolveThinkingParam maps a KA ReasoningRequest to the Anthropic thinking
-// parameter, delegating model-tier detection (adaptive-capable vs
-// manual-budget-only) to adk-anthropic-go/converters — the same logic AF
-// uses, avoiding a second, independently-maintained tier-detection table
-// (DD-LLM-005). An explicit BudgetTokens always wins with a manual budget
-// regardless of tier; omitting it lets the per-tier default apply (adaptive
-// on adaptive-capable models, a high-effort manual budget otherwise).
-func resolveThinkingParam(r *llm.ReasoningRequest, model anthropic.Model) anthropic.ThinkingConfigParamUnion {
-	cfg := &genai.ThinkingConfig{ThinkingLevel: genai.ThinkingLevelHigh}
+// parameter and output_config effort hint, delegating model-tier detection
+// (adaptive-capable vs manual-budget-only) to adk-anthropic-go/converters —
+// the same logic AF uses, avoiding a second, independently-maintained
+// tier-detection table (DD-LLM-005). An explicit BudgetTokens always wins
+// with a manual budget regardless of tier or Effort (an exact-value
+// power-user override); otherwise Effort (#1604), mapped onto
+// genai.ThinkingLevel, selects the tier; with neither set, the per-tier
+// default applies (adaptive-high on adaptive-capable models, a
+// high-effort manual budget otherwise) — the pre-#1604, zero-regression
+// behavior.
+//
+// The returned effort hint (adk-anthropic-go's ThinkingMapping.Effort) is
+// only meaningful — non-empty — for adaptive-capable models; manual-budget
+// models have no separate effort dial on the wire, so callers should only
+// set params.OutputConfig.Effort when it is non-empty.
+func resolveThinkingParam(r *llm.ReasoningRequest, model anthropic.Model) (anthropic.ThinkingConfigParamUnion, anthropic.OutputConfigEffort) {
+	cfg := effortToThinkingConfig(r)
+	mapping := converters.ThinkingConfigToAnthropic(cfg, model)
+	return mapping.Thinking, mapping.Effort
+}
+
+// effortToThinkingConfig resolves the effective genai.ThinkingConfig for a
+// ReasoningRequest. See resolveThinkingParam for the precedence rule.
+func effortToThinkingConfig(r *llm.ReasoningRequest) *genai.ThinkingConfig {
 	if r.BudgetTokens > 0 {
 		budget := int32(r.BudgetTokens)
-		cfg = &genai.ThinkingConfig{ThinkingBudget: &budget}
+		return &genai.ThinkingConfig{ThinkingBudget: &budget}
 	}
-	return converters.ThinkingConfigToAnthropic(cfg, model).Thinking
+	if level, ok := effortToThinkingLevel(r.Effort); ok {
+		return &genai.ThinkingConfig{ThinkingLevel: level}
+	}
+	return &genai.ThinkingConfig{ThinkingLevel: genai.ThinkingLevelHigh}
+}
+
+// effortToThinkingLevel maps the canonical, provider-agnostic Effort
+// vocabulary (#1604) onto genai.ThinkingLevel. "none" maps to Minimal —
+// genai's Minimal already means "no thinking" via the converter (a
+// coherent, real off-state, not a contradiction at this layer); the
+// enabled:true + effort:none contradiction is rejected earlier, at config
+// validation (shared/types.LLMConfig.Validate), for operator-facing
+// clarity — this mapping stays defensively correct even if that gate is
+// ever bypassed. "xhigh" clamps to High: genai.ThinkingLevel has no tier
+// above High, even though Anthropic's raw OutputConfigEffort enum does
+// (up to "max") — reusing the shared converter (DD-LLM-005) means staying
+// within its intermediate representation rather than hand-mapping a
+// second, independently-maintained table straight to the SDK's fuller
+// enum. The empty string (unset) is intentionally not handled here; it is
+// only reachable via effortToThinkingConfig's default-High fallback.
+func effortToThinkingLevel(effort string) (genai.ThinkingLevel, bool) {
+	switch effort {
+	case "none":
+		return genai.ThinkingLevelMinimal, true
+	case "minimal":
+		return genai.ThinkingLevelMinimal, true
+	case "low":
+		return genai.ThinkingLevelLow, true
+	case "medium":
+		return genai.ThinkingLevelMedium, true
+	case "high", "xhigh":
+		return genai.ThinkingLevelHigh, true
+	default:
+		return "", false
+	}
 }
 
 // convertMessagesToAnthropic translates Kubernaut's role-tagged message

--- a/pkg/kubernautagent/llm/anthropicfamily/effort_1604_test.go
+++ b/pkg/kubernautagent/llm/anthropicfamily/effort_1604_test.go
@@ -1,0 +1,175 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package anthropicfamily_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/anthropics/anthropic-sdk-go/option"
+
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm/anthropicfamily"
+)
+
+// Issue #1604 / BR-AI-086: unified Effort knob wiring for the Anthropic
+// client family. Effort maps onto genai.ThinkingLevel and is resolved via
+// the same adk-anthropic-go/converters.ThinkingConfigToAnthropic call
+// resolveThinkingParam already delegates to (DD-LLM-005) — these tests
+// additionally cover the OutputConfig.Effort hint that ThinkingMapping
+// already computes for adaptive-capable models but which, prior to this
+// change, was silently discarded (only .Thinking was read).
+var _ = Describe("anthropicfamily Effort knob wiring — #1604", func() {
+	var (
+		server        *httptest.Server
+		receivedBody  map[string]interface{}
+		responseBody  string
+		newTestClient func(model string) *anthropicfamily.Client
+	)
+
+	BeforeEach(func() {
+		receivedBody = nil
+		responseBody = `{
+			"id": "msg_effort_default",
+			"type": "message",
+			"role": "assistant",
+			"model": "claude-sonnet-4-6",
+			"stop_reason": "end_turn",
+			"content": [{"type": "text", "text": "conclusion"}],
+			"usage": {"input_tokens": 10, "output_tokens": 5}
+		}`
+	})
+
+	AfterEach(func() {
+		if server != nil {
+			server.Close()
+		}
+	})
+
+	newTestClient = func(model string) *anthropicfamily.Client {
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			receivedBody = nil
+			_ = json.Unmarshal(body, &receivedBody)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(responseBody))
+		}))
+		client, err := anthropicfamily.NewWithAPIKey("sk-ant-fake-key", model,
+			anthropicfamily.WithSDKOptions(option.WithBaseURL(server.URL)),
+		)
+		Expect(err).NotTo(HaveOccurred())
+		return client
+	}
+
+	Describe("adaptive-capable model (claude-sonnet-4-6) — Effort surfaces as an output_config.effort hint", func() {
+		DescribeTable("maps the canonical Effort value to the matching output_config.effort hint",
+			func(effort, wantWireEffort string) {
+				client := newTestClient("claude-sonnet-4-6")
+				_, err := client.Chat(context.Background(), llm.ChatRequest{
+					Messages: []llm.Message{{Role: "user", Content: "hello"}},
+					Options:  llm.ChatOptions{Reasoning: &llm.ReasoningRequest{Enabled: true, Effort: effort}},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(receivedBody).To(HaveKey("thinking"))
+				thinking := receivedBody["thinking"].(map[string]interface{})
+				Expect(thinking["type"]).To(Equal("adaptive"))
+				outputConfig, ok := receivedBody["output_config"].(map[string]interface{})
+				Expect(ok).To(BeTrue(), "expected an output_config object in the request body")
+				Expect(outputConfig["effort"]).To(Equal(wantWireEffort))
+			},
+			Entry("low", "low", "low"),
+			Entry("medium", "medium", "medium"),
+			Entry("high", "high", "high"),
+			Entry("xhigh clamps to high (genai.ThinkingLevel has no tier above High)", "xhigh", "high"),
+		)
+
+		It("UT-KA-1604-101: Effort: minimal turns thinking off entirely (Anthropic has no minimal thinking tier)", func() {
+			client := newTestClient("claude-sonnet-4-6")
+			_, err := client.Chat(context.Background(), llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "hello"}},
+				Options:  llm.ChatOptions{Reasoning: &llm.ReasoningRequest{Enabled: true, Effort: "minimal"}},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(receivedBody).NotTo(HaveKey("thinking"))
+			Expect(receivedBody).NotTo(HaveKey("output_config"))
+		})
+
+		It("UT-KA-1604-102: no Effort and no BudgetTokens defaults to the zero-regression High tier (adaptive + high effort)", func() {
+			client := newTestClient("claude-sonnet-4-6")
+			_, err := client.Chat(context.Background(), llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "hello"}},
+				Options:  llm.ChatOptions{Reasoning: &llm.ReasoningRequest{Enabled: true}},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			thinking := receivedBody["thinking"].(map[string]interface{})
+			Expect(thinking["type"]).To(Equal("adaptive"))
+			outputConfig := receivedBody["output_config"].(map[string]interface{})
+			Expect(outputConfig["effort"]).To(Equal("high"))
+		})
+
+		It("UT-KA-1604-103: an explicit BudgetTokens always wins over Effort, even on an adaptive-capable model", func() {
+			client := newTestClient("claude-sonnet-4-6")
+			_, err := client.Chat(context.Background(), llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "hello"}},
+				Options:  llm.ChatOptions{Reasoning: &llm.ReasoningRequest{Enabled: true, Effort: "low", BudgetTokens: 2048}},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			thinking := receivedBody["thinking"].(map[string]interface{})
+			Expect(thinking["type"]).To(Equal("enabled"))
+			Expect(thinking["budget_tokens"]).To(BeNumerically("==", 2048))
+			Expect(receivedBody).NotTo(HaveKey("output_config"),
+				"a manual budget takes the non-adaptive path, which has no effort hint")
+		})
+	})
+
+	Describe("manual-budget-only model (claude-sonnet-4-5) — Effort maps to a manual token budget, no effort hint", func() {
+		DescribeTable("maps the canonical Effort value to the matching manual budget",
+			func(effort string, wantBudget int) {
+				client := newTestClient("claude-sonnet-4-5")
+				_, err := client.Chat(context.Background(), llm.ChatRequest{
+					Messages: []llm.Message{{Role: "user", Content: "hello"}},
+					Options:  llm.ChatOptions{Reasoning: &llm.ReasoningRequest{Enabled: true, Effort: effort}},
+				})
+				Expect(err).NotTo(HaveOccurred())
+				thinking := receivedBody["thinking"].(map[string]interface{})
+				Expect(thinking["type"]).To(Equal("enabled"))
+				Expect(thinking["budget_tokens"]).To(BeNumerically("==", wantBudget))
+				Expect(receivedBody).NotTo(HaveKey("output_config"))
+			},
+			Entry("low", "low", 1024),
+			Entry("medium", "medium", 5000),
+			Entry("high", "high", 10000),
+			Entry("xhigh clamps to high's budget", "xhigh", 10000),
+		)
+
+		It("UT-KA-1604-104: Effort: minimal turns thinking off entirely on a manual-only model too", func() {
+			client := newTestClient("claude-sonnet-4-5")
+			_, err := client.Chat(context.Background(), llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "hello"}},
+				Options:  llm.ChatOptions{Reasoning: &llm.ReasoningRequest{Enabled: true, Effort: "minimal"}},
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(receivedBody).NotTo(HaveKey("thinking"))
+		})
+	})
+})

--- a/pkg/kubernautagent/llm/openai/client.go
+++ b/pkg/kubernautagent/llm/openai/client.go
@@ -36,8 +36,10 @@ import (
 
 // Client implements llm.Client for OpenAI-protocol-compatible endpoints.
 type Client struct {
-	client        *openaicompat.Client
-	reasoningMode openaicompat.ReasoningMode
+	client           *openaicompat.Client
+	reasoningMode    openaicompat.ReasoningMode
+	effortDialect    openaicompat.EffortDialect
+	defaultReasoning *llm.ReasoningRequest
 }
 
 // Option configures the Client.
@@ -46,6 +48,7 @@ type Option func(*clientOpts)
 type clientOpts struct {
 	httpClient         *http.Client
 	capabilityOverride string
+	defaultReasoning   *llm.ReasoningRequest
 }
 
 // WithHTTPClient injects a custom HTTP client for transport chain support
@@ -72,6 +75,17 @@ func WithCapabilityOverride(override string) Option {
 	return func(o *clientOpts) { o.capabilityOverride = override }
 }
 
+// WithReasoning sets the construction-time default reasoning/effort request,
+// applied whenever a per-call req.Options.Reasoning is nil (#1604, mirroring
+// anthropicfamily.WithReasoning for cross-family symmetry). Unlike the
+// Anthropic family, this controls only the request-side Effort knob
+// ("reasoning_effort") — reasoning-content capture for this family remains
+// unconditional and model-driven (BR-AI-086 AC3), independent of this
+// option.
+func WithReasoning(r llm.ReasoningRequest) Option {
+	return func(o *clientOpts) { o.defaultReasoning = &r }
+}
+
 // New creates a Client for the given model and OpenAI-Chat-Completions-
 // compatible endpoint. The reasoning round-trip mode is auto-detected from
 // model (BR-AI-086, DD-LLM-005) unless overridden.
@@ -87,8 +101,10 @@ func New(model, endpoint, apiKey string, opts ...Option) *Client {
 	}
 
 	return &Client{
-		client:        openaicompat.New(model, endpoint, apiKey, compatOpts...),
-		reasoningMode: openaicompat.DetectReasoningMode(model, o.capabilityOverride),
+		client:           openaicompat.New(model, endpoint, apiKey, compatOpts...),
+		reasoningMode:    openaicompat.DetectReasoningMode(model, o.capabilityOverride),
+		effortDialect:    openaicompat.DetectEffortDialect(model),
+		defaultReasoning: o.defaultReasoning,
 	}
 }
 
@@ -158,6 +174,15 @@ func (c *Client) buildRequest(req llm.ChatRequest) openaicompat.Request {
 	}
 	if len(req.Options.OutputSchema) > 0 {
 		out.ResponseSchema = req.Options.OutputSchema
+	}
+
+	reasoning := req.Options.Reasoning
+	if reasoning == nil {
+		reasoning = c.defaultReasoning
+	}
+	if reasoning != nil && reasoning.Enabled {
+		out.Effort = reasoning.Effort
+		out.EffortDialect = c.effortDialect
 	}
 	return out
 }

--- a/pkg/kubernautagent/llm/openai/effort_1604_test.go
+++ b/pkg/kubernautagent/llm/openai/effort_1604_test.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openai_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	kaopenai "github.com/jordigilh/kubernaut/pkg/kubernautagent/llm/openai"
+)
+
+// Issue #1604 / BR-AI-086: unified Effort knob wiring for KA's
+// OpenAI-Chat-Completions-compatible wrapper. Mirrors the
+// anthropicfamily.WithReasoning construction-time-default pattern
+// (thinking_1580_test.go, UT-KA-1578-201..204) for symmetry across the two
+// client families.
+var _ = Describe("kubernautagent/llm/openai.Client Effort knob wiring — #1604", func() {
+	var (
+		server       *httptest.Server
+		receivedBody map[string]interface{}
+	)
+
+	BeforeEach(func() {
+		receivedBody = nil
+	})
+
+	AfterEach(func() {
+		if server != nil {
+			server.Close()
+		}
+	})
+
+	newTestServer := func() {
+		server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			receivedBody = nil
+			_ = json.Unmarshal(body, &receivedBody)
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+		}))
+	}
+
+	It("UT-KA-1604-301: WithReasoning sends the configured Effort as reasoning_effort for a real OpenAI reasoning model", func() {
+		newTestServer()
+		client := kaopenai.New("gpt-5", server.URL, "test-key",
+			kaopenai.WithReasoning(llm.ReasoningRequest{Enabled: true, Effort: "high"}))
+		_, err := client.Chat(context.Background(), llm.ChatRequest{
+			Messages: []llm.Message{{Role: "user", Content: "hello"}},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(receivedBody["reasoning_effort"]).To(Equal("high"))
+	})
+
+	It("UT-KA-1604-302: a per-call Options.Reasoning overrides the construction-time default", func() {
+		newTestServer()
+		client := kaopenai.New("gpt-5", server.URL, "test-key",
+			kaopenai.WithReasoning(llm.ReasoningRequest{Enabled: true, Effort: "low"}))
+		_, err := client.Chat(context.Background(), llm.ChatRequest{
+			Messages: []llm.Message{{Role: "user", Content: "hello"}},
+			Options:  llm.ChatOptions{Reasoning: &llm.ReasoningRequest{Enabled: true, Effort: "xhigh"}},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(receivedBody["reasoning_effort"]).To(Equal("xhigh"))
+	})
+
+	It("UT-KA-1604-303: WithReasoning has no effect on a non-reasoning model (no effort dialect recognized)", func() {
+		newTestServer()
+		client := kaopenai.New("gpt-4o", server.URL, "test-key",
+			kaopenai.WithReasoning(llm.ReasoningRequest{Enabled: true, Effort: "high"}))
+		_, err := client.Chat(context.Background(), llm.ChatRequest{
+			Messages: []llm.Message{{Role: "user", Content: "hello"}},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(receivedBody).NotTo(HaveKey("reasoning_effort"))
+	})
+
+	It("UT-KA-1604-304: WithReasoning(Enabled:false) never sends reasoning_effort, even with Effort set", func() {
+		newTestServer()
+		client := kaopenai.New("gpt-5", server.URL, "test-key",
+			kaopenai.WithReasoning(llm.ReasoningRequest{Enabled: false, Effort: "high"}))
+		_, err := client.Chat(context.Background(), llm.ChatRequest{
+			Messages: []llm.Message{{Role: "user", Content: "hello"}},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(receivedBody).NotTo(HaveKey("reasoning_effort"))
+	})
+
+	It("UT-KA-1604-305: downscales to DeepSeek's dialect for a deepseek-v4-pro model", func() {
+		newTestServer()
+		client := kaopenai.New("deepseek-v4-pro", server.URL, "test-key",
+			kaopenai.WithReasoning(llm.ReasoningRequest{Enabled: true, Effort: "xhigh"}))
+		_, err := client.Chat(context.Background(), llm.ChatRequest{
+			Messages: []llm.Message{{Role: "user", Content: "hello"}},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(receivedBody["reasoning_effort"]).To(Equal("max"))
+		thinking := receivedBody["thinking"].(map[string]interface{})
+		Expect(thinking["type"]).To(Equal("enabled"))
+	})
+
+	It("UT-KA-1604-306: without WithReasoning, no effort field is ever sent (no regression)", func() {
+		newTestServer()
+		client := kaopenai.New("gpt-5", server.URL, "test-key")
+		_, err := client.Chat(context.Background(), llm.ChatRequest{
+			Messages: []llm.Message{{Role: "user", Content: "hello"}},
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(receivedBody).NotTo(HaveKey("reasoning_effort"))
+	})
+})

--- a/pkg/kubernautagent/llm/types.go
+++ b/pkg/kubernautagent/llm/types.go
@@ -144,4 +144,10 @@ type ChatOptions struct {
 type ReasoningRequest struct {
 	Enabled      bool `json:"enabled,omitempty"`
 	BudgetTokens int  `json:"budget_tokens,omitempty"`
+	// Effort is the canonical, provider-agnostic reasoning-depth value
+	// ("", "none", "minimal", "low", "medium", "high", "xhigh" — #1604).
+	// BudgetTokens, when > 0, always wins over Effort for Anthropic (an
+	// exact-value power-user override); Effort is otherwise ignored by
+	// clients with no effort-dial concept.
+	Effort string `json:"effort,omitempty"`
 }

--- a/pkg/kubernautagent/llm/types_test.go
+++ b/pkg/kubernautagent/llm/types_test.go
@@ -182,5 +182,24 @@ var _ = Describe("LLM Types — #433", func() {
 			Expect(restored.Reasoning.Enabled).To(BeTrue())
 			Expect(restored.Reasoning.BudgetTokens).To(Equal(2048))
 		})
+
+		It("should round-trip a ReasoningRequest's Effort field (#1604)", func() {
+			original := llm.ChatOptions{
+				Reasoning: &llm.ReasoningRequest{
+					Enabled: true,
+					Effort:  "high",
+				},
+			}
+
+			data, err := json.Marshal(original)
+			Expect(err).NotTo(HaveOccurred())
+
+			var restored llm.ChatOptions
+			err = json.Unmarshal(data, &restored)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(restored.Reasoning).NotTo(BeNil())
+			Expect(restored.Reasoning.Effort).To(Equal("high"))
+		})
 	})
 })

--- a/pkg/shared/llm/openaicompat/client.go
+++ b/pkg/shared/llm/openaicompat/client.go
@@ -155,7 +155,52 @@ func buildRequestBody(model string, req Request, stream bool) map[string]any {
 			"json_schema": json.RawMessage(req.ResponseSchema),
 		}
 	}
+	applyEffort(body, req.Effort, req.EffortDialect)
 	return body
+}
+
+// applyEffort maps the canonical, provider-agnostic Effort value onto the
+// wire dialect the model actually speaks (#1604). A no-op — no field is
+// added at all — when Effort is empty (the provider's own vendor default
+// applies) or EffortDialect is EffortDialectNone (the model has no
+// recognized effort knob; never send a speculative field a bare-bones
+// server might reject, the same compatibility-floor principle as
+// DetectReasoningMode).
+func applyEffort(body map[string]any, effort string, dialect EffortDialect) {
+	if effort == "" {
+		return
+	}
+	switch dialect {
+	case EffortDialectOpenAI:
+		body["reasoning_effort"] = effort
+	case EffortDialectDeepSeek:
+		applyDeepSeekEffort(body, effort)
+	}
+}
+
+// deepSeekEffortTiers downscales the canonical 6-value vocabulary onto
+// DeepSeek's own 2-tier dialect, per DeepSeek's published compatibility
+// mapping (https://api-docs.deepseek.com/guides/thinking_mode): low/medium
+// map up to high (DeepSeek's floor), xhigh maps to max (DeepSeek's
+// ceiling). "none" is handled separately below — it disables thinking
+// entirely rather than mapping to a low tier.
+var deepSeekEffortTiers = map[string]string{
+	"minimal": "high",
+	"low":     "high",
+	"medium":  "high",
+	"high":    "high",
+	"xhigh":   "max",
+}
+
+func applyDeepSeekEffort(body map[string]any, effort string) {
+	if effort == "none" {
+		body["thinking"] = map[string]any{"type": "disabled"}
+		return
+	}
+	if wireEffort, ok := deepSeekEffortTiers[effort]; ok {
+		body["reasoning_effort"] = wireEffort
+		body["thinking"] = map[string]any{"type": "enabled"}
+	}
 }
 
 // buildMessages translates the shared Message list into the OpenAI wire

--- a/pkg/shared/llm/openaicompat/effort_1604_test.go
+++ b/pkg/shared/llm/openaicompat/effort_1604_test.go
@@ -1,0 +1,224 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package openaicompat_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/shared/llm/openaicompat"
+)
+
+// Issue #1604 / BR-AI-086: a unified, provider-agnostic reasoning-effort
+// knob for the OpenAI-Chat-Completions-compatible client family. langchaingo
+// (tmc/langchaingo#1394, #1499) took roughly a year of incremental PRs to
+// reach the same "reasoning_effort on Chat Completions" scope — this closes
+// only that scope, deliberately excluding the OpenAI Responses API (#1604
+// tracks that separately; it requires a new SDK dependency and its own DD).
+var _ = Describe("openaicompat effort knob — #1604", func() {
+	Describe("DetectEffortDialect — model-aware detection of which effort wire dialect a model speaks", func() {
+		DescribeTable("real OpenAI reasoning models detect to the OpenAI dialect",
+			func(model string) {
+				Expect(openaicompat.DetectEffortDialect(model)).To(Equal(openaicompat.EffortDialectOpenAI))
+			},
+			Entry("o1", "o1"),
+			Entry("o1-mini", "o1-mini"),
+			Entry("o1-preview", "o1-preview"),
+			Entry("o3", "o3"),
+			Entry("o3-mini", "o3-mini"),
+			Entry("o3-pro", "o3-pro"),
+			Entry("o4-mini", "o4-mini"),
+			Entry("gpt-5", "gpt-5"),
+			Entry("gpt-5-mini", "gpt-5-mini"),
+			Entry("gpt-5.1", "gpt-5.1"),
+			Entry("gpt-5-codex", "gpt-5-codex"),
+		)
+
+		DescribeTable("DeepSeek reasoning models detect to the DeepSeek dialect",
+			func(model string) {
+				Expect(openaicompat.DetectEffortDialect(model)).To(Equal(openaicompat.EffortDialectDeepSeek))
+			},
+			Entry("deepseek-reasoner (legacy)", "deepseek-reasoner"),
+			Entry("deepseek-r1", "deepseek-r1"),
+			Entry("deepseek-v4-pro", "deepseek-v4-pro"),
+			Entry("deepseek-v4-flash", "deepseek-v4-flash"),
+		)
+
+		DescribeTable("every other model detects to no dialect (no effort parameter is ever sent)",
+			func(model string) {
+				Expect(openaicompat.DetectEffortDialect(model)).To(Equal(openaicompat.EffortDialectNone))
+			},
+			Entry("gpt-4o", "gpt-4o"),
+			Entry("gpt-3.5-turbo", "gpt-3.5-turbo"),
+			Entry("llama3 (self-hosted)", "llama3"),
+			Entry("unrecognized future model", "some-future-model-9000"),
+		)
+	})
+
+	Describe("wire-level effort mapping — real OpenAI dialect", func() {
+		var (
+			server       *httptest.Server
+			receivedBody map[string]interface{}
+		)
+		BeforeEach(func() {
+			receivedBody = nil
+		})
+		AfterEach(func() {
+			if server != nil {
+				server.Close()
+			}
+		})
+		newTestClient := func(model string) *openaicompat.Client {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				receivedBody = nil
+				_ = json.Unmarshal(body, &receivedBody)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+			}))
+			return openaicompat.New(model, server.URL, "test-key")
+		}
+
+		DescribeTable("passes the canonical effort value through verbatim as reasoning_effort",
+			func(effort string) {
+				client := newTestClient("gpt-5")
+				_, err := client.Chat(context.Background(), openaicompat.Request{
+					Messages:      []openaicompat.Message{{Role: "user", Content: "hi"}},
+					Effort:        effort,
+					EffortDialect: openaicompat.EffortDialectOpenAI,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(receivedBody["reasoning_effort"]).To(Equal(effort))
+			},
+			Entry("none", "none"),
+			Entry("minimal", "minimal"),
+			Entry("low", "low"),
+			Entry("medium", "medium"),
+			Entry("high", "high"),
+			Entry("xhigh", "xhigh"),
+		)
+
+		It("UT-KA-1604-001: sends no reasoning_effort field when Effort is empty (vendor default applies)", func() {
+			client := newTestClient("gpt-5")
+			_, err := client.Chat(context.Background(), openaicompat.Request{
+				Messages:      []openaicompat.Message{{Role: "user", Content: "hi"}},
+				EffortDialect: openaicompat.EffortDialectOpenAI,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(receivedBody).NotTo(HaveKey("reasoning_effort"))
+		})
+
+		It("UT-KA-1604-002: sends no reasoning_effort field when EffortDialect is none, even if Effort is set", func() {
+			client := newTestClient("gpt-4o")
+			_, err := client.Chat(context.Background(), openaicompat.Request{
+				Messages:      []openaicompat.Message{{Role: "user", Content: "hi"}},
+				Effort:        "high",
+				EffortDialect: openaicompat.EffortDialectNone,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(receivedBody).NotTo(HaveKey("reasoning_effort"))
+		})
+
+		It("UT-KA-1604-003: never sends a DeepSeek-specific thinking field for the OpenAI dialect", func() {
+			client := newTestClient("gpt-5")
+			_, err := client.Chat(context.Background(), openaicompat.Request{
+				Messages:      []openaicompat.Message{{Role: "user", Content: "hi"}},
+				Effort:        "high",
+				EffortDialect: openaicompat.EffortDialectOpenAI,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(receivedBody).NotTo(HaveKey("thinking"))
+		})
+	})
+
+	Describe("wire-level effort mapping — DeepSeek dialect (downscaled two-tier + explicit toggle)", func() {
+		var (
+			server       *httptest.Server
+			receivedBody map[string]interface{}
+		)
+		BeforeEach(func() {
+			receivedBody = nil
+		})
+		AfterEach(func() {
+			if server != nil {
+				server.Close()
+			}
+		})
+		newTestClient := func(model string) *openaicompat.Client {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				receivedBody = nil
+				_ = json.Unmarshal(body, &receivedBody)
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"choices":[{"index":0,"message":{"role":"assistant","content":"ok"},"finish_reason":"stop"}]}`))
+			}))
+			return openaicompat.New(model, server.URL, "test-key")
+		}
+
+		DescribeTable("downscales the canonical effort value to DeepSeek's high/max dialect and enables thinking",
+			func(effort, wantWireEffort string) {
+				client := newTestClient("deepseek-v4-pro")
+				_, err := client.Chat(context.Background(), openaicompat.Request{
+					Messages:      []openaicompat.Message{{Role: "user", Content: "hi"}},
+					Effort:        effort,
+					EffortDialect: openaicompat.EffortDialectDeepSeek,
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(receivedBody["reasoning_effort"]).To(Equal(wantWireEffort))
+				thinking, ok := receivedBody["thinking"].(map[string]interface{})
+				Expect(ok).To(BeTrue(), "expected a thinking object in the request body")
+				Expect(thinking["type"]).To(Equal("enabled"))
+			},
+			Entry("minimal maps up to DeepSeek's floor (high)", "minimal", "high"),
+			Entry("low maps up to DeepSeek's floor (high)", "low", "high"),
+			Entry("medium maps up to DeepSeek's floor (high)", "medium", "high"),
+			Entry("high maps to high", "high", "high"),
+			Entry("xhigh maps to DeepSeek's ceiling (max)", "xhigh", "max"),
+		)
+
+		It("UT-KA-1604-004: effort: none disables thinking entirely rather than mapping to a tier", func() {
+			client := newTestClient("deepseek-v4-pro")
+			_, err := client.Chat(context.Background(), openaicompat.Request{
+				Messages:      []openaicompat.Message{{Role: "user", Content: "hi"}},
+				Effort:        "none",
+				EffortDialect: openaicompat.EffortDialectDeepSeek,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(receivedBody).NotTo(HaveKey("reasoning_effort"))
+			thinking, ok := receivedBody["thinking"].(map[string]interface{})
+			Expect(ok).To(BeTrue())
+			Expect(thinking["type"]).To(Equal("disabled"))
+		})
+
+		It("UT-KA-1604-005: sends no effort/thinking fields at all when Effort is empty (vendor default applies)", func() {
+			client := newTestClient("deepseek-v4-pro")
+			_, err := client.Chat(context.Background(), openaicompat.Request{
+				Messages:      []openaicompat.Message{{Role: "user", Content: "hi"}},
+				EffortDialect: openaicompat.EffortDialectDeepSeek,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(receivedBody).NotTo(HaveKey("reasoning_effort"))
+			Expect(receivedBody).NotTo(HaveKey("thinking"))
+		})
+	})
+})

--- a/pkg/shared/llm/openaicompat/reasoning.go
+++ b/pkg/shared/llm/openaicompat/reasoning.go
@@ -86,3 +86,60 @@ func shouldReplayReasoning(mode ReasoningMode, hadToolCalls bool) bool {
 		return false
 	}
 }
+
+// EffortDialect identifies which wire dialect, if any, a model speaks for
+// the request-side reasoning-depth knob (#1604). This is a distinct axis
+// from ReasoningMode: ReasoningMode governs replaying already-captured
+// reasoning text back to the provider; EffortDialect governs asking the
+// provider to think harder or less in the first place. A model can have
+// either, both, or neither independently (e.g. a bare-bones self-hosted
+// server has neither; DeepSeek has both; real OpenAI o-series/gpt-5 has
+// only the effort dial, since Chat Completions never returns their
+// reasoning text at all — see #1604's non-goal on the Responses API).
+type EffortDialect string
+
+const (
+	// EffortDialectNone: no request-side effort parameter is recognized.
+	// The compatibility-floor default (BR-AI-086) — an unrecognized model
+	// never receives a speculative field it might reject.
+	EffortDialectNone EffortDialect = "none"
+
+	// EffortDialectOpenAI: real OpenAI/Azure o-series and gpt-5-family
+	// reasoning models. The canonical effort vocabulary ("none", "minimal",
+	// "low", "medium", "high", "xhigh") is OpenAI's own and is passed
+	// through verbatim as the wire "reasoning_effort" field.
+	EffortDialectOpenAI EffortDialect = "openai"
+
+	// EffortDialectDeepSeek: DeepSeek's own two-tier dialect ("high"/"max")
+	// plus a separate thinking-enabled/disabled toggle, per DeepSeek's own
+	// compatibility mapping (https://api-docs.deepseek.com/guides/thinking_mode).
+	EffortDialectDeepSeek EffortDialect = "deepseek"
+)
+
+// DetectEffortDialect infers which effort wire dialect a model speaks from
+// its name, implementing the same compatibility-floor default as
+// DetectReasoningMode: any unrecognized model gets EffortDialectNone, never
+// a speculative dialect that could send an unsupported field to a
+// bare-bones OpenAI-compatible server.
+func DetectEffortDialect(model string) EffortDialect {
+	lower := strings.ToLower(model)
+
+	if strings.Contains(lower, "deepseek-reasoner") || strings.Contains(lower, "deepseek-r1") ||
+		strings.HasPrefix(lower, "deepseek-v4") {
+		return EffortDialectDeepSeek
+	}
+
+	// Real OpenAI o-series and gpt-5-family reasoning models. Heuristic
+	// mirrors langchaingo's own model-family detection (tmc/langchaingo
+	// llms/openai/openaillm.go SupportsReasoning) — the same problem has
+	// the same shape of answer in every Go OpenAI client, not a shortcut
+	// unique to this package.
+	if lower == "o1" || strings.HasPrefix(lower, "o1-") ||
+		lower == "o3" || strings.HasPrefix(lower, "o3-") ||
+		lower == "o4" || strings.HasPrefix(lower, "o4-") ||
+		strings.HasPrefix(lower, "o5-") ||
+		strings.HasPrefix(lower, "gpt-5") {
+		return EffortDialectOpenAI
+	}
+	return EffortDialectNone
+}

--- a/pkg/shared/llm/openaicompat/types.go
+++ b/pkg/shared/llm/openaicompat/types.go
@@ -81,6 +81,16 @@ type Request struct {
 	// zero value ("none") by accident for a model that needs a different
 	// mode, and never guessed per-call from business logic (DD-HAPI-019).
 	ReasoningMode ReasoningMode
+	// Effort is the canonical, provider-agnostic reasoning-depth value
+	// ("", "none", "minimal", "low", "medium", "high", "xhigh" — #1604).
+	// Distinct from ReasoningMode/Message.Reasoning: this asks the
+	// provider to think harder or less; it never controls whether
+	// already-captured reasoning text is replayed.
+	Effort string
+	// EffortDialect governs how Effort is mapped onto the wire. Resolved
+	// once via DetectEffortDialect at client-construction time, same
+	// pattern as ReasoningMode.
+	EffortDialect EffortDialect
 }
 
 // Response is the mapped, non-streaming reply from a Chat Completions call.

--- a/pkg/shared/types/llm.go
+++ b/pkg/shared/types/llm.go
@@ -69,11 +69,55 @@ type LLMConfig struct {
 type LLMReasoningConfig struct {
 	Enabled      bool `yaml:"enabled,omitempty" json:"enabled,omitempty"`
 	BudgetTokens int  `yaml:"budgetTokens,omitempty" json:"budgetTokens,omitempty"`
+	// Effort is a unified, provider-agnostic reasoning-depth knob (#1604):
+	// one of "" (unset — no effort parameter sent, the provider's own
+	// vendor default applies), "none", "minimal", "low", "medium", "high",
+	// or "xhigh". The same value means the same thing regardless of which
+	// provider is configured — switching providers never requires
+	// re-tuning this field — but each client maps/clamps it into its own
+	// wire dialect:
+	//   - Anthropic (native/Vertex): maps to genai.ThinkingLevel tiers.
+	//     "xhigh" clamps to "high" (Anthropic's ceiling — a range clamp,
+	//     not a contradiction). "none" while Enabled is a genuine
+	//     contradiction (Anthropic has no "thinking enabled with zero
+	//     effort" state) and is rejected by Validate rather than silently
+	//     reinterpreted — see validateReasoning.
+	//   - Real OpenAI/Azure o-series & gpt-5 models: passed through
+	//     verbatim as the wire "reasoning_effort" value.
+	//   - DeepSeek (openai_compatible): downscaled to DeepSeek's own
+	//     two-tier dialect ("high"/"max" plus a separate thinking-enabled
+	//     toggle), per DeepSeek's own compatibility mapping.
+	//   - BudgetTokens, when set, always wins over Effort for Anthropic
+	//     (an exact-value power-user override); Effort is otherwise
+	//     ignored where a provider has no effort-dial concept at all.
+	Effort string `yaml:"effort,omitempty" json:"effort,omitempty"`
 	// CapabilityOverride short-circuits vendor/model-name auto-detection for
 	// self-hosted/custom models served via the OpenAI-compatible client,
 	// which cannot be reliably identified by vendor enum alone (AC5).
 	// One of "auto" (default), "force_on", or "force_off".
 	CapabilityOverride string `yaml:"capabilityOverride,omitempty" json:"capabilityOverride,omitempty"`
+}
+
+// validReasoningEfforts is the canonical, provider-agnostic effort
+// vocabulary (#1604). Empty string means "unset" and is always valid
+// (vendor default applies).
+var validReasoningEfforts = map[string]bool{
+	"":        true,
+	"none":    true,
+	"minimal": true,
+	"low":     true,
+	"medium":  true,
+	"high":    true,
+	"xhigh":   true,
+}
+
+// anthropicFamilyProviders are the providers routed to the Anthropic
+// thinking API (native and Vertex-hosted Claude) — see
+// cmd/kubernautagent/llm_builder.go's provider dispatch, which sends both
+// through anthropicfamily.Client.
+var anthropicFamilyProviders = map[string]bool{
+	LLMProviderAnthropic: true,
+	LLMProviderVertexAI:  true,
 }
 
 // LLMOAuth2Config holds OAuth2 client credentials for auth-gated LLM gateways.
@@ -170,7 +214,36 @@ func (c *LLMConfig) Validate(prefix string) error {
 	if err := c.validateCircuitBreaker(prefix); err != nil {
 		return err
 	}
+	if err := c.validateReasoning(prefix); err != nil {
+		return err
+	}
 	return c.validatePhaseModels(prefix)
+}
+
+// validateReasoning checks Reasoning.Effort against the canonical
+// provider-agnostic vocabulary and fails closed on a known contradiction:
+// "none" while Enabled for an Anthropic-family provider, which has no
+// "thinking enabled with zero effort" wire state (#1604). This is
+// deliberately NOT the same as the compatibility-floor graceful-degrade
+// principle (DD-LLM-005) — that principle covers models/providers we
+// cannot possibly identify; this is a known, deterministic contradiction
+// on a provider we always recognize, so it must be observable at startup
+// rather than silently reinterpreted at runtime.
+func (c *LLMConfig) validateReasoning(prefix string) error {
+	if c.Reasoning == nil {
+		return nil
+	}
+	if !validReasoningEfforts[c.Reasoning.Effort] {
+		return fmt.Errorf("%s.reasoning.effort must be one of \"\", \"none\", \"minimal\", \"low\", \"medium\", \"high\", \"xhigh\"; got %q",
+			prefix, c.Reasoning.Effort)
+	}
+	if c.Reasoning.Enabled && c.Reasoning.Effort == "none" && anthropicFamilyProviders[c.Provider] {
+		return fmt.Errorf("%s.reasoning: effort: none is not supported for provider %q while reasoning is enabled "+
+			"(Anthropic has no \"thinking enabled with zero effort\" state); use enabled: false to fully disable "+
+			"reasoning, or effort: minimal for Anthropic's lowest real tier",
+			prefix, c.Provider)
+	}
+	return nil
 }
 
 // validateProviderAndModel checks that Provider is one of the supported enum

--- a/pkg/shared/types/llm_test.go
+++ b/pkg/shared/types/llm_test.go
@@ -448,3 +448,128 @@ phaseModels:
 		Expect(*restored.Reasoning).To(Equal(*original.Reasoning))
 	})
 })
+
+var _ = Describe("UT-SH-AI-086-016: LLMReasoningConfig.Effort — unified cross-provider effort knob (#1604)", func() {
+	It("should deserialize the effort field from YAML", func() {
+		input := `
+provider: openai
+model: gpt-5
+endpoint: "https://api.openai.com/v1"
+apiKeyFile: "/etc/credentials/openai_key"
+reasoning:
+  enabled: true
+  effort: high
+`
+		var cfg types.LLMConfig
+		Expect(yaml.Unmarshal([]byte(input), &cfg)).To(Succeed())
+		Expect(cfg.Reasoning).NotTo(BeNil())
+		Expect(cfg.Reasoning.Effort).To(Equal("high"))
+	})
+
+	It("should default Effort to empty (vendor default applies) when omitted", func() {
+		input := `
+provider: openai
+model: gpt-5
+endpoint: "https://api.openai.com/v1"
+apiKeyFile: "/etc/credentials/openai_key"
+reasoning:
+  enabled: true
+`
+		var cfg types.LLMConfig
+		Expect(yaml.Unmarshal([]byte(input), &cfg)).To(Succeed())
+		Expect(cfg.Reasoning.Effort).To(BeEmpty())
+	})
+
+	DescribeTable("Validate should accept every canonical effort value for a non-Anthropic provider",
+		func(effort string) {
+			cfg := types.LLMConfig{
+				Provider:   types.LLMProviderOpenAI,
+				Model:      "gpt-5",
+				Endpoint:   "https://api.openai.com/v1",
+				APIKeyFile: "/etc/credentials/openai_key",
+				Reasoning:  &types.LLMReasoningConfig{Enabled: true, Effort: effort},
+			}
+			Expect(cfg.Validate("llm")).To(Succeed())
+		},
+		Entry("empty (vendor default)", ""),
+		Entry("none", "none"),
+		Entry("minimal", "minimal"),
+		Entry("low", "low"),
+		Entry("medium", "medium"),
+		Entry("high", "high"),
+		Entry("xhigh", "xhigh"),
+	)
+
+	It("should reject an unrecognized effort value", func() {
+		cfg := types.LLMConfig{
+			Provider:   types.LLMProviderOpenAI,
+			Model:      "gpt-5",
+			Endpoint:   "https://api.openai.com/v1",
+			APIKeyFile: "/etc/credentials/openai_key",
+			Reasoning:  &types.LLMReasoningConfig{Enabled: true, Effort: "extreme"},
+		}
+		err := cfg.Validate("llm")
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("effort"))
+	})
+
+	DescribeTable("Validate should fail closed on effort: none for Anthropic-family providers while enabled",
+		func(provider string) {
+			cfg := types.LLMConfig{
+				Provider:       provider,
+				Model:          "claude-sonnet-4-6",
+				APIKeyFile:     "/etc/credentials/anthropic_key",
+				VertexProject:  "my-project",
+				VertexLocation: "us-central1",
+				Reasoning:      &types.LLMReasoningConfig{Enabled: true, Effort: "none"},
+			}
+			err := cfg.Validate("llm")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("effort: none"))
+			Expect(err.Error()).To(ContainSubstring("enabled: false"))
+		},
+		Entry("anthropic (native)", types.LLMProviderAnthropic),
+		Entry("vertex_ai (Claude-on-Vertex)", types.LLMProviderVertexAI),
+	)
+
+	It("should accept effort: none for Anthropic when reasoning is disabled (no contradiction)", func() {
+		cfg := types.LLMConfig{
+			Provider:   types.LLMProviderAnthropic,
+			Model:      "claude-sonnet-4-6",
+			APIKeyFile: "/etc/credentials/anthropic_key",
+			Reasoning:  &types.LLMReasoningConfig{Enabled: false, Effort: "none"},
+		}
+		Expect(cfg.Validate("llm")).To(Succeed())
+	})
+
+	It("should accept effort: xhigh for Anthropic (a ceiling clamp, not a contradiction)", func() {
+		cfg := types.LLMConfig{
+			Provider:   types.LLMProviderAnthropic,
+			Model:      "claude-sonnet-4-6",
+			APIKeyFile: "/etc/credentials/anthropic_key",
+			Reasoning:  &types.LLMReasoningConfig{Enabled: true, Effort: "xhigh"},
+		}
+		Expect(cfg.Validate("llm")).To(Succeed())
+	})
+
+	It("should round-trip Effort through YAML marshal/unmarshal unchanged", func() {
+		original := types.LLMConfig{
+			Provider: "openai_compatible",
+			Model:    "deepseek-v4-pro",
+			Endpoint: "https://api.deepseek.com",
+			Reasoning: &types.LLMReasoningConfig{
+				Enabled: true,
+				Effort:  "high",
+			},
+		}
+
+		data, err := yaml.Marshal(&original)
+		Expect(err).NotTo(HaveOccurred())
+
+		var restored types.LLMConfig
+		Expect(yaml.Unmarshal(data, &restored)).To(Succeed())
+
+		Expect(restored.Reasoning).NotTo(BeNil())
+		Expect(*restored.Reasoning).To(Equal(*original.Reasoning))
+	})
+})

--- a/test/integration/workflowexecution/job_lifecycle_integration_test.go
+++ b/test/integration/workflowexecution/job_lifecycle_integration_test.go
@@ -943,9 +943,23 @@ var _ = Describe("Job Resource Governance (DD-WE-008, BR-WE-019)", func() {
 		Expect(container.Resources.Limits.Memory().String()).To(Equal("256Mi"))
 
 		By("Verifying the resolved resources were persisted to WFE.Status.Resources")
-		updated, err := getWFE(wfe.Name, wfe.Namespace)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(updated.Status.Resources).ToNot(BeNil())
+		// Job creation (waitForJobCreation above) and the WFE status update that
+		// persists Status.Resources are two sequential, non-atomic API calls within
+		// the same reconcile (finalizePendingToRunning): the Job becomes visible to
+		// this test as soon as it's created, which can race ahead of the subsequent
+		// Status().Update() -- especially when a concurrent reconcile (e.g. the
+		// Running-phase progress check triggered by the Job's own creation event)
+		// causes a resourceVersion conflict and forces a retry. Poll rather than a
+		// single-shot read to tolerate that expected eventual-consistency gap.
+		var updated *workflowexecutionv1alpha1.WorkflowExecution
+		Eventually(func() *corev1.ResourceRequirements {
+			var err error
+			updated, err = getWFE(wfe.Name, wfe.Namespace)
+			if err != nil {
+				return nil
+			}
+			return updated.Status.Resources
+		}, 5*time.Second, 100*time.Millisecond).ShouldNot(BeNil())
 		Expect(updated.Status.Resources.Requests.Cpu().String()).To(Equal("100m"))
 
 		GinkgoWriter.Printf("✅ IT-WE-019-001: Catalog-resolved resources applied to Job container\n")


### PR DESCRIPTION
## Summary

Closes the "Piece A" scope of #1604: a single, provider-agnostic reasoning-depth knob (`LLMReasoningConfig.Effort`) that controls how hard a model thinks, mapped into each client's own wire dialect. Full OpenAI Responses-API integration (visible reasoning summaries, agentic tool loop) remains out of scope — re-scoped as a future decision requiring its own BR + DD, per the #1604 spike.

- **Real OpenAI/Azure o-series & gpt-5-family models**: `Effort` passed through verbatim as Chat Completions' `reasoning_effort` field.
- **DeepSeek** (`openai_compatible`): downscaled to DeepSeek's own two-tier dialect (`high`/`max`) plus an explicit `thinking.type` enabled/disabled toggle, per DeepSeek's published compatibility mapping.
- **Anthropic (native/Vertex)**: mapped onto `genai.ThinkingLevel` via the same `adk-anthropic-go/converters` call this DD-LLM-005 already reuses for tier detection — applying the `output_config.effort` hint that call already computed but previously discarded.
- **Fail-closed validation**: `effort: none` combined with `enabled: true` for an Anthropic-family provider is rejected at config-validation time (a genuine, deterministic contradiction — Anthropic has no "thinking enabled, zero effort" wire state), not silently reinterpreted.
- **AF parity**: `pkg/apifrontend/launcher/openai`'s adapter gets the identical knob (`WithReasoningEffort`, wired from `cfg.Reasoning.Effort`), closing the OpenAI-compatible-surface gap flagged in DD-LLM-007 — using the exact same shared `pkg/shared/llm/openaicompat` dialect code as KA, so there's no drift risk between the two call sites. AF's Anthropic/Vertex/Gemini surface (via `adk-anthropic-go`) still has no reasoning/effort support at all; that gap remains tracked separately in DD-LLM-007, unaffected by this PR.

Helm chart exposure (`kubernautAgent.llm.reasoning.effort`) has been folded into #1603 directly (that PR already covers `enabled`/`budgetTokens`/`capabilityOverride`) rather than duplicated here.

## Changes

- `pkg/shared/types/llm.go`: `LLMReasoningConfig.Effort` field + enum validation + fail-closed Anthropic contradiction check.
- `pkg/shared/llm/openaicompat`: `EffortDialect` detection (`DetectEffortDialect`) + wire-level `Effort` mapping (OpenAI verbatim, DeepSeek downscaled).
- `pkg/kubernautagent/llm/anthropicfamily/client.go`: `Effort` → `genai.ThinkingLevel` mapping, applies `output_config.effort` for adaptive-capable models.
- `pkg/kubernautagent/llm/openai/client.go`: `WithReasoning` construction-time default + per-call `Options.Reasoning` override.
- `pkg/apifrontend/launcher/openai/adapter.go` + `pkg/apifrontend/launcher/model.go`: `WithReasoningEffort` construction-time knob (no per-call override — ADK's `model.LLMRequest` has no reasoning field).
- `cmd/kubernautagent/llm_builder.go`: threads `cfg.Reasoning.Effort` to both Anthropic and OpenAI-compatible clients.
- `docs/requirements/BR-AI-086-llm-reasoning-token-support.md` (AC8), `docs/architecture/decisions/DD-LLM-005-model-aware-reasoning-support.md` (addendum), `docs/architecture/decisions/DD-LLM-007-af-ka-anthropic-client-divergence.md` (update note): documented rationale, mapping rules, and AF-parity extension.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run` — 0 issues on all affected packages
- [x] New RED→GREEN unit tests per package: `pkg/shared/types` (enum + fail-closed), `pkg/shared/llm/openaicompat` (dialect detection + wire mapping), `pkg/kubernautagent/llm/anthropicfamily`, `pkg/kubernautagent/llm/openai`, `pkg/apifrontend/launcher/openai`, `cmd/kubernautagent` (wiring) — all passing
- [x] Full affected suites pass: `pkg/apifrontend/...`, `pkg/kubernautagent/llm/...`, `pkg/shared/...`, `cmd/kubernautagent/...`

## Related

- BR-AI-086: Model-Aware LLM Reasoning/Thinking Token Support
- DD-LLM-005: Model-Aware Reasoning Support (addendum added)
- DD-LLM-007: AF/KA Anthropic Client Divergence (update note added)
- #1604 (parent issue), #1601 (reasoning-request wiring fix this builds on), #1603 (Helm exposure, includes `effort` field)

Made with [Cursor](https://cursor.com)