### PR TITLE
fix(fleet): add bearer-token auth to ACM Search adapter (#1556)

### DIFF
--- a/charts/kubernaut/README.md
+++ b/charts/kubernaut/README.md
@@ -467,7 +467,7 @@ cluster's other known peers.
 | `gateway.fleet.enabled` | Multi-cluster fleet federation (BR-INTEGRATION-065, ADR-068) | `false` |
 | `gateway.fleet.backend` | Federated scope-check backend: `fleetmetadatacache` or `acm` | `""` (fleetmetadatacache) |
 | `gateway.fleet.endpoint` | Backend endpoint (auto-derived for fleetmetadatacache; required for acm) | `""` |
-| `gateway.fleet.tokenSecretRef` | Secret (key `token`) with an ACM Search bearer token. **Not yet functional** — pre-wires the Helm side ahead of [Issue #1556](https://github.com/jordigilh/kubernaut/issues/1556), which adds the Go-side `FleetConfig` support to actually send it. | `""` |
+| `gateway.fleet.tokenSecretRef` | Secret (key `token`) with an ACM Search bearer token. **Mandatory when `backend: "acm"`** — GW fails `FleetConfig.Validate()` at startup without it ([Issue #1556](https://github.com/jordigilh/kubernaut/issues/1556)). | `""` |
 
 ### RemediationOrchestrator
 
@@ -476,7 +476,7 @@ cluster's other known peers.
 | `remediationorchestrator.fleet.enabled` | Multi-cluster fleet federation (BR-INTEGRATION-065, ADR-068) | `false` |
 | `remediationorchestrator.fleet.backend` | Federated scope-check backend: `fleetmetadatacache` or `acm` | `""` (fleetmetadatacache) |
 | `remediationorchestrator.fleet.endpoint` | Backend endpoint (auto-derived for fleetmetadatacache; required for acm) | `""` |
-| `remediationorchestrator.fleet.tokenSecretRef` | Secret (key `token`) with an ACM Search bearer token. **Not yet functional** — pre-wires the Helm side ahead of [Issue #1556](https://github.com/jordigilh/kubernaut/issues/1556), which adds the Go-side `FleetConfig` support to actually send it. | `""` |
+| `remediationorchestrator.fleet.tokenSecretRef` | Secret (key `token`) with an ACM Search bearer token. **Mandatory when `backend: "acm"`** — RO fails `FleetConfig.Validate()` at startup without it ([Issue #1556](https://github.com/jordigilh/kubernaut/issues/1556)). | `""` |
 
 ### EffectivenessMonitor
 

--- a/charts/kubernaut/templates/gateway/gateway.yaml
+++ b/charts/kubernaut/templates/gateway/gateway.yaml
@@ -82,9 +82,8 @@ data:
       mcpGatewayType: {{ $gatewayFleet.mcpGatewayType | quote }}
       {{- end }}
       tlsCAFile: {{ $gatewayFleet.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
-      {{/* ACM bearer-token wiring (BR-PLATFORM-003, Issue #1589). NOT YET FUNCTIONAL: no
-           FleetConfig field consumes tokenPath until Issue #1556 lands the Go-side support.
-           Rendered ahead of time so enabling it later is a values-only change. */}}
+      {{/* ACM bearer-token wiring (BR-PLATFORM-003, Issue #1589). FleetConfig.TokenPath
+           consumes this (Issue #1556) and Validate() hard-requires it when backend=acm. */}}
       {{- if .Values.gateway.fleet.tokenSecretRef }}
       tokenPath: "/etc/gateway/{{ .Values.gateway.fleet.tokenSecretRef }}/token"
       {{- end }}

--- a/charts/kubernaut/templates/remediationorchestrator/remediationorchestrator.yaml
+++ b/charts/kubernaut/templates/remediationorchestrator/remediationorchestrator.yaml
@@ -84,9 +84,8 @@ data:
       mcpGatewayType: {{ $remediationorchestratorFleet.mcpGatewayType | quote }}
       {{- end }}
       tlsCAFile: {{ $remediationorchestratorFleet.tlsCAFile | default (include "kubernaut.interServiceTLS.caFile" .) | quote }}
-      {{/* ACM bearer-token wiring (BR-PLATFORM-003, Issue #1589). NOT YET FUNCTIONAL: no
-           FleetConfig field consumes tokenPath until Issue #1556 lands the Go-side support.
-           Rendered ahead of time so enabling it later is a values-only change. */}}
+      {{/* ACM bearer-token wiring (BR-PLATFORM-003, Issue #1589). FleetConfig.TokenPath
+           consumes this (Issue #1556) and Validate() hard-requires it when backend=acm. */}}
       {{- if .Values.remediationorchestrator.fleet.tokenSecretRef }}
       tokenPath: "/etc/remediationorchestrator/{{ .Values.remediationorchestrator.fleet.tokenSecretRef }}/token"
       {{- end }}

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -424,7 +424,7 @@
             "mcpGatewayEndpoint": { "type": "string", "default": "", "description": "MCP Gateway endpoint URL for federated scope checks. Required when fleet.enabled=true; falls back to global.fleet.mcpGatewayEndpoint when unset" },
             "mcpGatewayType": { "type": "string", "default": "", "description": "MCP Gateway type: eaigw or kuadrant. Falls back to global.fleet.mcpGatewayType when unset" },
             "tlsCAFile": { "type": "string", "default": "", "description": "Path to a CA bundle for verifying the MCP Gateway's TLS certificate. Falls back to global.fleet.tlsCAFile, then to the shared inter-service CA, when unset" },
-            "tokenSecretRef": { "type": "string", "default": "", "description": "K8s Secret (key: token) with an ACM Search bearer token (backend=acm). NOT YET FUNCTIONAL pending Issue #1556 (Go-side FleetConfig support)." },
+            "tokenSecretRef": { "type": "string", "default": "", "description": "K8s Secret (key: token) with an ACM Search bearer token. Mandatory when backend=acm; FleetConfig.Validate() rejects backend=acm without it (#1556)." },
             "oauth2": { "$ref": "#/definitions/fleetOAuth2" }
           }
         }
@@ -725,7 +725,7 @@
             "mcpGatewayEndpoint": { "type": "string", "default": "", "description": "MCP Gateway endpoint URL for reading remote resource specs (spec hash). Required when fleet.enabled=true; falls back to global.fleet.mcpGatewayEndpoint when unset" },
             "mcpGatewayType": { "type": "string", "default": "", "description": "MCP Gateway type: eaigw or kuadrant. Falls back to global.fleet.mcpGatewayType when unset" },
             "tlsCAFile": { "type": "string", "default": "", "description": "Path to a CA bundle for verifying the MCP Gateway's TLS certificate. Falls back to global.fleet.tlsCAFile, then to the shared inter-service CA, when unset" },
-            "tokenSecretRef": { "type": "string", "default": "", "description": "K8s Secret (key: token) with an ACM Search bearer token (backend=acm). NOT YET FUNCTIONAL pending Issue #1556 (Go-side FleetConfig support)." },
+            "tokenSecretRef": { "type": "string", "default": "", "description": "K8s Secret (key: token) with an ACM Search bearer token. Mandatory when backend=acm; FleetConfig.Validate() rejects backend=acm without it (#1556)." },
             "oauth2": { "$ref": "#/definitions/fleetOAuth2" }
           }
         }

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -154,11 +154,9 @@ gateway:
     # at /etc/tls-ca/ca.crt, when unset.
     tlsCAFile: ""
     # -- K8s Secret (key: "token") with a bearer token for authenticating to the ACM
-    # Search GraphQL API (backend=acm). Mounted and its path passed to GW at startup.
-    # NOT YET FUNCTIONAL: pkg/fleet.FleetConfig has no field to consume this path yet —
-    # the ACM client (pkg/fleet/acm/client.go) never sets an Authorization header today.
-    # This value pre-wires the Helm side ahead of the Go-side fix (tracked in Issue #1556).
-    # Safe to leave unset; ACM Search calls work unauthenticated until #1556 lands.
+    # Search GraphQL API (backend=acm). Mounted and its path passed to GW at startup
+    # as fleet.tokenPath. ACM Search mandatorily requires bearer-token auth (#1556):
+    # when backend=acm, this MUST be set, or GW fails FleetConfig.Validate() at startup.
     tokenSecretRef: ""
     # -- OAuth2 client credentials for MCP Gateway authentication.
     oauth2:
@@ -389,11 +387,9 @@ remediationorchestrator:
     # mounted at /etc/tls-ca/ca.crt, when unset.
     tlsCAFile: ""
     # -- K8s Secret (key: "token") with a bearer token for authenticating to the ACM
-    # Search GraphQL API (backend=acm). Mounted and its path passed to RO at startup.
-    # NOT YET FUNCTIONAL: pkg/fleet.FleetConfig has no field to consume this path yet —
-    # the ACM client (pkg/fleet/acm/client.go) never sets an Authorization header today.
-    # This value pre-wires the Helm side ahead of the Go-side fix (tracked in Issue #1556).
-    # Safe to leave unset; ACM Search calls work unauthenticated until #1556 lands.
+    # Search GraphQL API (backend=acm). Mounted and its path passed to RO at startup
+    # as fleet.tokenPath. ACM Search mandatorily requires bearer-token auth (#1556):
+    # when backend=acm, this MUST be set, or RO fails FleetConfig.Validate() at startup.
     tokenSecretRef: ""
     # -- OAuth2 client credentials for MCP Gateway authentication.
     oauth2:

--- a/docs/architecture/decisions/ADR-068-fleet-federation-architecture.md
+++ b/docs/architecture/decisions/ADR-068-fleet-federation-architecture.md
@@ -335,16 +335,33 @@ than discards) the `ResilientClient`/`ClusterRegistry` object on initial connect
 `Gate` has something to keep probing/retrying instead of the client being silently lost with no path
 back to healthy short of a pod restart.
 
-**Known limitation (tracked separately, not fixed by #1553): ACM backend auth gap (#1556).**
-`pkg/fleet/acm.Client` (`fleet.backend: "acm"`) has never actually sent the `Authorization: Bearer
-<token>` header the real ACM Search API (`stolostron/search-v2-api`) mandatorily requires — despite
-this being spec'd earlier in this ADR (`fleet.acm.tokenSecretRef`, see the ACM Search Production Setup
-Guide below). This is a pre-existing gap, not introduced by #1553. Before #1553, it was silently
-invisible: `IsManagedResource` fail-safe-swallows the resulting 401 into `(false, nil)`. **After
-#1553, any deployment with `fleet.backend: "acm"` will have `/readyz` permanently stuck at
-`NotReady`** (the new `ScopeCheckerProber`'s `Ping` call will always 401) until #1556 is fixed. No
-default deployment is affected (`backend` defaults to `""`, i.e. the FMC path), but operators who have
-configured the ACM backend per this ADR's own setup guide should track #1556.
+**Resolved: ACM backend auth gap (#1556).** `pkg/fleet/acm.Client` (`fleet.backend: "acm"`) never
+actually sent the `Authorization: Bearer <token>` header the real ACM Search API
+(`stolostron/search-v2-api`) mandatorily requires, despite this being spec'd earlier in this ADR
+(see the ACM Search Production Setup Guide below). This was a pre-existing gap, not introduced by
+#1553. Before #1553, it was silently invisible: `IsManagedResource` fail-safe-swallowed the
+resulting 401 into `(false, nil)`. After #1553 and before this fix, any deployment with
+`fleet.backend: "acm"` would have had `/readyz` permanently stuck at `NotReady` (the
+`ScopeCheckerProber`'s `Ping` call always 401'd).
+
+Fixed by composing `pkg/shared/auth.AuthTransport` (the same reusable OAuth2/bearer-token
+`http.RoundTripper` used elsewhere in Fleet) over the ACM client's HTTP transport in
+`pkg/fleet/scope_factory.go`, reading the token from `FleetConfig.TokenPath`.
+`FleetConfig.Validate()` now hard-requires `TokenPath` when `Backend == "acm"`, so a
+misconfigured deployment fails fast at startup instead of silently sending unauthenticated
+requests. A live-cluster spike against ACM 2.16.2 (2026-07-07) also surfaced and fixed a second,
+related defect: `acm.Client.Ping()` sent an empty search filter, which real ACM Search rejects
+with a GraphQL-level error (HTTP 200 with a populated `errors` array) — this alone would have kept
+`/readyz` stuck at `NotReady` even with correct auth. `Ping()` now sends a syntactically valid,
+always-satisfiable `kind=Namespace` filter. See `pkg/fleet/acm/client_test.go` (`UT-ACM-054-013`)
+and `test/integration/acm/acm_factory_test.go` (`IT-ACM-054-002` through `IT-ACM-054-004`).
+
+Both fixes were confirmed end-to-end against the live ACM 2.16.2 instance — not just the
+unit/integration mocked-server tests — by running `fleet.NewScopeChecker()` (the exact production
+factory GW/RO call at startup) from inside a cluster pod with a real bearer token and TLS CA,
+exercising `Ping()` and `IsManagedResource()` against the real Search API. See
+[`docs/spikes/multi-cluster-mcp-gateway/spike-acm-search/README.md`](../../spikes/multi-cluster-mcp-gateway/spike-acm-search/README.md#post-1556-fix-production-go-client-validation-2026-07-07)
+for the full method and results.
 
 ## Implementation Status
 
@@ -363,7 +380,7 @@ configured the ACM backend per this ADR's own setup guide should track #1556.
 | EM Fleet Routing | EM target-read routing via ReaderFactory (BR-FLEET-054) | Complete |
 | AF Fleet Routing | AF kubectl_get/kubectl_list ResourceReader abstraction + list_clusters tool (BR-FLEET-054) | Complete |
 | Fleet Readiness Gate | Fail-closed, pod-wide `/readyz` for runtime Fleet dependency unreachability across all 7 services (#1553) | Complete |
-| ACM bearer-token auth | `acm.Client` authentication per this ADR's `fleet.acm.tokenSecretRef` spec | Planned (#1556) |
+| ACM bearer-token auth | `acm.Client` authentication via `auth.AuthTransport` + `FleetConfig.TokenPath` (hard-required by `Validate()` when backend=acm) | Complete (#1556) |
 | GatewayDiscoverer | Two-phase tool discovery (`list_clusters`/`list_tools_for_cluster`) with Kuadrant and EAIGW implementations | Planned (v1.6) |
 | Rancher Adapter | Rancher v3 API adapter for cluster discovery and scope checks | Planned (v1.6) |
 | Clusterpedia Adapter | Clusterpedia Aggregated API adapter for scope checks | Planned (v1.6) |
@@ -828,7 +845,7 @@ query listClusters($input: [SearchInput]) {
 | **TLS** | The `search-search-api` Service uses TLS with certificates issued by `openshift-service-serving-signer`. For in-cluster access, inject the CA bundle via a ConfigMap with `service.beta.openshift.io/inject-cabundle: "true"` annotation and mount it into the Kubernaut pod. For cross-cluster, export the CA and mount it as a Secret. |
 | **Authentication** | ACM Search enforces K8s authentication. Kubernaut needs a bearer token from a ServiceAccount on the ACM hub, passed as `Authorization: Bearer <token>`. |
 | **Network policy** | Kubernaut pods (GW, RO) must reach the `search-search-api` Service on port 4010. If NetworkPolicies are enforced, add an egress rule from `kubernaut-system` to `open-cluster-management` namespace. |
-| **Kubernaut config** | `fleet.backend: "acm"`, `fleet.endpoint: "https://search-search-api.open-cluster-management.svc:4010"`. If cross-cluster: `fleet.acm.tokenSecretRef: "acm-search-token"`, `fleet.acm.caBundle: "/etc/kubernaut/acm-ca/ca.crt"`. |
+| **Kubernaut config** | `fleet.backend: "acm"`, `fleet.endpoint: "https://search-search-api.open-cluster-management.svc:4010"`, `fleet.tokenPath: "/etc/<service>/acm-search-token/token"` (mandatory; `Validate()` rejects backend=acm without it). Set via the Helm value `<service>.fleet.tokenSecretRef: "acm-search-token"`, which mounts the named Secret and renders `fleet.tokenPath` accordingly. If cross-cluster TLS: `fleet.tlsCAFile: "/etc/kubernaut/acm-ca/ca.crt"`. |
 
 #### ACM Search Production Setup Guide
 
@@ -1023,7 +1040,7 @@ data: {}
 ```
 
 Mount this ConfigMap in the Kubernaut pod and configure
-`fleet.acm.caBundle: "/etc/kubernaut/acm-ca/service-ca.crt"`.
+`fleet.tlsCAFile: "/etc/kubernaut/acm-ca/service-ca.crt"`.
 
 **Verification**
 

--- a/docs/operations/runbooks/fleet-readiness-gate-runbook.md
+++ b/docs/operations/runbooks/fleet-readiness-gate-runbook.md
@@ -1,7 +1,7 @@
 # Fleet Readiness Gate - Production Runbooks
 
-**Version**: v1.0
-**Last Updated**: 2026-07-04
+**Version**: v1.1
+**Last Updated**: 2026-07-07
 **Status**: ✅ Production Ready
 **Applies to**: Gateway (GW), RemediationOrchestrator (RO), EffectivenessMonitor (EM),
 SignalProcessing (SP), WorkflowExecution (WE), APIFrontend (AF), KubernautAgent (KA)
@@ -14,7 +14,7 @@ SignalProcessing (SP), WorkflowExecution (WE), APIFrontend (AF), KubernautAgent 
 | ID | Runbook | Triggers On | Automation |
 |----|---------|-------------|------------|
 | RB-FLEET-001 | [Pod stuck NotReady due to Fleet dependency](#rb-fleet-001-pod-stuck-notready-due-to-fleet-dependency) | `/readyz` returns 503, pod removed from Service endpoints | Alert + Dashboard |
-| RB-FLEET-002 | [ACM backend permanently NotReady (#1556)](#rb-fleet-002-acm-backend-permanently-notready-1556) | `fleet.backend: "acm"` deployments never reach Ready | Alert |
+| RB-FLEET-002 | [ACM backend NotReady due to auth/RBAC misconfiguration](#rb-fleet-002-acm-backend-notready-due-to-authrbac-misconfiguration) | `fleet.backend: "acm"` deployments fail to start or never reach Ready | Alert |
 
 ---
 
@@ -65,8 +65,9 @@ kubectl logs -n kubernaut-system deploy/<service> --since=5m | grep -i "fleet\|r
 kubectl exec -n kubernaut-system deploy/<service> -- curl -sk https://<mcp-gateway-endpoint>/healthz
 #   - FMC scope-check backend:
 kubectl exec -n kubernaut-system deploy/<service> -- curl -s http://<fmc-endpoint>/healthz
-#   - ACM Search backend: see RB-FLEET-002 first — a permanently-unreachable ACM backend is a
-#     known, separate issue (#1556), not a transient outage.
+#   - ACM Search backend: see RB-FLEET-002 first — a permanently-unreachable ACM backend is
+#     usually an auth/RBAC misconfiguration (missing/invalid bearer token, missing RBAC
+#     bindings), not a transient outage.
 
 # Step 4: Check OAuth2 provider reachability if MCP Gateway auth is failing
 kubectl exec -n kubernaut-system deploy/<service> -- curl -sk https://<oauth2-token-url>
@@ -93,38 +94,64 @@ kubectl exec -n kubernaut-system deploy/<service> -- curl -s -o /dev/null -w "%{
 
 ---
 
-## RB-FLEET-002: ACM backend permanently NotReady (#1556)
+## RB-FLEET-002: ACM backend NotReady due to auth/RBAC misconfiguration
+
+> **History**: `pkg/fleet/acm.Client` originally never sent the `Authorization: Bearer <token>`
+> header the real ACM Search GraphQL API (`stolostron/search-v2-api`) mandatorily requires — a
+> pre-existing gap tracked as **[#1556](https://github.com/jordigilh/kubernaut/issues/1556)**.
+> Before #1553, this failed silently (`IsManagedResource` fail-safe-swallowed the 401 into
+> `(false, nil)`). After #1553 and before #1556 landed, it surfaced as a **permanent**
+> `/readyz=NotReady` for every `fleet.backend: "acm"` deployment. **#1556 is now resolved**:
+> `pkg/fleet/scope_factory.go` composes `auth.AuthTransport` (reading the token from
+> `FleetConfig.TokenPath`) into the ACM client's HTTP transport, and `FleetConfig.Validate()`
+> hard-rejects `backend: "acm"` without `TokenPath` set (fail-closed at startup instead of at
+> the readiness probe). A related defect in `acm.Client.Ping()` (sent an empty search filter,
+> which real ACM Search rejects with a GraphQL error) was also found and fixed during a
+> live-cluster spike against ACM 2.16.2. This runbook now covers the auth/RBAC misconfigurations
+> that can still cause ACM-backend `NotReady` after those fixes.
 
 ### Symptoms
 
 - Only affects deployments with `fleet.backend: "acm"` configured.
-- Pod is permanently `NotReady`, and RB-FLEET-001's diagnosis steps show the ACM Search endpoint
-  itself is reachable (e.g., `curl` to the endpoint from outside the pod succeeds, or returns 401
+- **Fails at startup** (pod crash-loops, does not reach `Running`) if `fleet.tokenPath` /
+  `<service>.fleet.tokenSecretRef` is unset — this is expected, fail-closed behavior per #1556,
+  not a bug. `FleetConfig.Validate()` rejects the config before the process starts serving.
+- **Pod is `Running` but permanently `NotReady`** if `TokenPath` is set but the token is invalid,
+  expired, or lacks RBAC visibility — RB-FLEET-001's diagnosis steps will show the ACM Search
+  endpoint itself is reachable (e.g., `curl` from outside the pod succeeds or returns 401/403,
   rather than a connection error).
 
 ### Root Cause
 
-`pkg/fleet/acm.Client` does not currently send the `Authorization: Bearer <token>` header that the
-real ACM Search GraphQL API (`stolostron/search-v2-api`) mandatorily requires (confirmed against the
-upstream project — every request, including the project's own dev-testing `curl` targets, requires
-a bearer token validated via Kubernetes `TokenReview`-backed RBAC). This is a **pre-existing gap**
-in the ACM adapter (it never worked, but previously failed silently — see below), not something
-introduced by #1553. It's tracked separately as **[#1556](https://github.com/jordigilh/kubernaut/issues/1556)**.
+Most commonly one of:
 
-Before #1553: `acm.Client.IsManagedResource` fail-safe-swallowed the resulting 401 into
-`(false, nil)` — scope checks against the ACM backend silently always reported "unmanaged" with no
-visible error.
-
-After #1553: `acm.Client.Ping` (used by `readiness.ScopeCheckerProber`) does **not** swallow the
-error, so the same 401 now correctly surfaces as `/readyz=NotReady` instead of being silently
-absorbed.
+1. **Missing `tokenPath`/`tokenSecretRef`** — `<service>.fleet.backend: "acm"` was set without
+   `<service>.fleet.tokenSecretRef` in Helm values. `Validate()` now catches this at startup
+   (`fleet: tokenPath is required when backend=acm`); it is not a `/readyz` symptom.
+2. **Invalid or expired token** — the ServiceAccount token referenced by `tokenSecretRef` was
+   revoked, rotated out-of-band, or the Secret contains a stale value.
+3. **RBAC not configured on the ACM hub** — per the ADR-068 setup guide below, ACM Search
+   enforces two independent RBAC layers (K8s RBAC + a `view` RoleBinding in each managed
+   cluster's hub namespace). Missing either layer returns `count: 0` or a 403, not a connection
+   error.
+4. **`fine-grained-rbac` MCH component not enabled** — see ADR-068's ACM Search Production
+   Setup Guide, Step 1.
 
 ### Resolution
 
-There is currently no workaround short of not using the ACM backend (`fleet.backend: "acm"`) until
-[#1556](https://github.com/jordigilh/kubernaut/issues/1556) ships bearer-token support. If you need
-Fleet federation today and cannot wait, use the FMC backend (`fleet.backend: "fleetmetadatacache"`,
-the chart default) instead.
+1. Confirm `<service>.fleet.tokenSecretRef` is set in Helm values for the affected service, and
+   that the referenced Secret exists in the pod's namespace with a `token` key:
+   ```bash
+   kubectl get secret -n kubernaut-system <tokenSecretRef> -o jsonpath='{.data.token}' | base64 -d | head -c 20
+   ```
+2. Confirm the mounted token is current and matches what was issued for the `kubernaut-fleet-reader`
+   ServiceAccount on the ACM hub (see [ADR-068](../../architecture/decisions/ADR-068-fleet-federation-architecture.md#acm-search-production-setup-guide),
+   Step 6 for cross-cluster token generation/rotation).
+3. Confirm RBAC per the ADR-068 setup guide: `fine-grained-rbac` MCH component enabled, K8s
+   ClusterRole/ClusterRoleBinding for the SA, and a `view` RoleBinding in each managed cluster's
+   hub namespace.
+4. If none of the above resolves it, use the Verification step to reproduce the exact request
+   the pod is making and inspect the GraphQL response for `errors`.
 
 Do **not** work around this by disabling the readiness gate or reverting to fail-open behavior for
 the ACM backend specifically — that would just restore the previous silent-failure behavior (scope
@@ -133,11 +160,15 @@ visible `NotReady`.
 
 ### Verification
 
-Track [#1556](https://github.com/jordigilh/kubernaut/issues/1556) for the fix. Once shipped, confirm
-via:
-
 ```bash
-kubectl exec -n kubernaut-system deploy/<service> -- curl -sk -H "Authorization: Bearer $(cat /path/to/token)" \
-  -H 'Content-Type: application/json' --data-raw '{"query":"{search(input:[{filters:[]}]){count}}"}' \
-  https://<acm-search-endpoint>/searchapi/graphql
+# Exec into the pod and confirm the mounted token authenticates successfully
+kubectl exec -n kubernaut-system deploy/<service> -- sh -c \
+  'curl -sk -H "Authorization: Bearer $(cat /etc/<service>/<tokenSecretRef>/token)" \
+   -H "Content-Type: application/json" \
+   --data-raw "{\"query\":\"query(\$input:[SearchInput]){searchResult:search(input:\$input){count}}\",\"variables\":{\"input\":[{\"filters\":[{\"property\":\"kind\",\"values\":[\"Namespace\"]}]}]}}" \
+   https://<acm-search-endpoint>/searchapi/graphql'
+# Expected: {"data":{"searchResult":[{"count":N}]}} with N > 0 and no "errors" key.
+# A 401/403 means the token or RBAC is the problem; a populated "errors" array with count:0
+# despite a 200 status usually means the RBAC "view" RoleBinding (Step 5 of the ADR-068 setup
+# guide) is missing on the managed cluster namespace being queried.
 ```

--- a/docs/spikes/multi-cluster-mcp-gateway/spike-acm-search/README.md
+++ b/docs/spikes/multi-cluster-mcp-gateway/spike-acm-search/README.md
@@ -20,6 +20,7 @@ live ACM instance. Answer four yes/no questions to raise confidence from 55% to
 | S4 | Does `search` return `{ searchResult: { items } }` for clusters? | **PASS** | Items are flat `map[string]string` |
 | S5 | Can a ServiceAccount authenticate with bearer token? | **PASS** | SA tokens authenticate (HTTP 200); authorization requires `cluster-admin` |
 | S6 | Go client approach? | **Option A** | Hand-rolled HTTP+JSON; zero new dependencies |
+| S7 | Does Kubernaut's own `pkg/fleet/acm.Client` (post-#1556 bearer-token fix) actually authenticate and return correct results? | **PASS** | See [Post-#1556 Fix: Production Go Client Validation](#post-1556-fix-production-go-client-validation-2026-07-07) below — the earlier S1-S6/RBAC validation used `curl`, not our Go client, and the Go client had a since-fixed auth bug that would have 401'd on every request |
 
 ### Confidence Reassessment
 
@@ -195,6 +196,91 @@ Full step-by-step guide in ADR-068 and `rbac.yaml` in this directory.
 - Secret: `search-api-certs` in `open-cluster-management` namespace
 - In-cluster: inject service CA into a ConfigMap with annotation
   `service.beta.openshift.io/inject-cabundle: "true"`
+
+## Post-#1556 Fix: Production Go Client Validation (2026-07-07)
+
+**Cluster**: OCP (dev.redhat-internal.com), ACM 2.16.2 (fresh install, same session)
+
+### Goal
+
+The validation above (S1-S6, and the "Production RBAC Validation" section) used
+raw `curl` against the ACM Search GraphQL API. It never exercised Kubernaut's
+own Go client, because `pkg/fleet/acm.Client` had a pre-existing bug: it never
+sent the `Authorization: Bearer <token>` header at all (tracked as
+[#1556](https://github.com/jordigilh/kubernaut/issues/1556)). This meant every
+prior "validation" of the adapter was actually validating the wrong thing — the
+real Go client would have 401'd on every request.
+
+After implementing the #1556 fix (`auth.AuthTransport` composed into the ACM
+client's HTTP transport via `pkg/fleet/scope_factory.go`, gated by
+`FleetConfig.Validate()`) and a related fix to `acm.Client.Ping()` (see below),
+this spike closes that gap: it drives the **actual production code path** —
+`fleet.NewScopeChecker()`, the exact factory GW/RO call at startup — against
+the live cluster, from inside a pod (so the real in-cluster DNS name and TLS
+cert both match, unlike a local port-forward).
+
+### Method
+
+1. Enabled the `fine-grained-rbac` MCH component and applied `rbac.yaml` from
+   this directory (scoped `kubernaut-fleet-reader` SA, no cluster-admin).
+2. Generated a bound SA token (`oc create token`) and the service-ca bundle
+   (via the `inject-cabundle` ConfigMap annotation).
+3. Cross-compiled a throwaway `linux/amd64` Go program that calls
+   `fleet.NewScopeChecker()` with `FleetConfig{Backend: "acm", Endpoint:
+   "https://search-search-api.open-cluster-management.svc:4010", TokenPath,
+   TLSCAFile}`, then exercises `Ping()` and `IsManagedResource()` through the
+   returned `*fleet.FederatedScopeChecker`.
+4. Ran it inside a short-lived debug pod in `kubernaut-system` (`oc run` +
+   `oc exec`, files copied in via `cat > file` over `oc exec -i`, since the
+   minimal base image lacked `tar` for `oc cp`).
+5. Deleted the debug pod, CA ConfigMap, and the throwaway program afterward.
+   Left the RBAC (SA + bindings) and `fine-grained-rbac=true` in place, since
+   they match this ADR's documented production setup rather than being
+   spike-only state.
+
+### Results
+
+| Check | Result |
+|-------|--------|
+| `FleetConfig.Validate()` accepts `backend=acm` + `TokenPath` | **PASS** |
+| `fleet.NewScopeChecker()` composes `CAReloader` + `AuthTransport` + `acm.Client` | **PASS** |
+| `Ping()` (readiness-gate call) succeeds with real bearer-token auth | **PASS** |
+| `IsManagedResource()` on a resource that exists (`search-api` Deployment) | **PASS** — `managed=true` |
+| `IsManagedResource()` on a resource that doesn't exist | **PASS** — `managed=false` |
+| `Ping()` with a missing token file fails closed (no silent unauthenticated fallback) | **PASS** — `authentication token unavailable: cannot read SA token from ...` |
+
+```
+PASS Validate(): config accepted
+PASS NewScopeChecker(): factory constructed a checker
+PASS Ping(): ACM Search reports healthy through real bearer-token auth
+PASS IsManagedResource(search-api Deployment): managed=true
+PASS IsManagedResource(nonexistent Deployment): managed=false (expect false)
+PASS: Ping() correctly fails closed with a missing token file: ACM Search
+  unreachable: ... authentication token unavailable: cannot read SA token
+  from /tmp/does-not-exist-token
+```
+
+### `Ping()` query-shape defect found and fixed during this spike
+
+Before this validation, `acm.Client.Ping()` sent an **empty filter set**
+(`searchInput{}` with no `Filters`). Real ACM Search 2.16.2 rejects this with
+a GraphQL-level error (`"query input must contain a filter or keyword"`,
+returned as HTTP 200 with a populated `errors` array — not a transport
+error). Since `readiness.ScopeCheckerProber` treats any `Ping()` error as
+unhealthy, this alone would have kept `/readyz` permanently `NotReady` for
+every `backend: "acm"` deployment, independent of the auth fix. Fixed by
+having `Ping()` send a `kind=Namespace` filter — always valid and always
+satisfiable, since every ACM hub indexes at least one namespace. See
+`UT-ACM-054-013` (`pkg/fleet/acm/client_test.go`) and `IT-ACM-054-004`
+(`test/integration/acm/acm_factory_test.go`) for the regression coverage.
+
+### Confidence
+
+**100%** — this is not a mocked-server test. It is the real `pkg/fleet`
+production factory, the real `pkg/fleet/acm` client, real TLS trust via
+`sharedtls.CAReloader`, real bearer-token injection via `auth.AuthTransport`,
+and a real ACM 2.16.2 Search API, wired exactly as `cmd/gateway` and
+`cmd/remediationorchestrator` wire them.
 
 ### S6: Go Client Decision
 

--- a/docs/spikes/multi-cluster-mcp-gateway/spike-acm-search/rbac.yaml
+++ b/docs/spikes/multi-cluster-mcp-gateway/spike-acm-search/rbac.yaml
@@ -108,4 +108,4 @@ subjects:
 #     service.beta.openshift.io/inject-cabundle: "true"
 # data: {}
 #
-# Mount it and set fleet.acm.caBundle to the injected CA path.
+# Mount it and set fleet.tlsCAFile to the injected CA path.

--- a/internal/config/remediationorchestrator/config_test.go
+++ b/internal/config/remediationorchestrator/config_test.go
@@ -93,4 +93,24 @@ var _ = Describe("BR-FLEET-054/ADR-068: Fleet full-federation validation", func(
 
 		Expect(cfg.Validate()).ToNot(HaveOccurred())
 	})
+
+	// #1556: proves the ACM bearer-token hard-require (FleetConfig.Validate,
+	// UT-FLEET-CFG-070) is actually reachable from RO's own production
+	// Validate() chain (internal/config/remediationorchestrator/config.go ->
+	// c.Fleet.Validate()) — not just from FleetConfig in isolation.
+	It("[UT-RO-FLEET-005] should reject backend=acm with no tokenPath through RO's own Validate() chain", func() {
+		cfg := config.DefaultConfig()
+		cfg.Fleet = fleet.FleetConfig{
+			Enabled:            true,
+			Backend:            "acm",
+			Endpoint:           "https://search-api:4010",
+			MCPGatewayEndpoint: "http://mcp-gateway:8080/mcp",
+			MCPGatewayType:     fleet.GatewayEAIGW,
+		}
+
+		err := cfg.Validate()
+		Expect(err).To(HaveOccurred(),
+			"AC-4/IA-5: RO must fail to start with an ACM backend that has no bearer token configured")
+		Expect(err.Error()).To(ContainSubstring("tokenPath"))
+	})
 })

--- a/pkg/fleet/acm/client.go
+++ b/pkg/fleet/acm/client.go
@@ -121,15 +121,24 @@ func (c *Client) IsManagedResource(ctx context.Context, r scope.ResourceIdentity
 }
 
 // Ping checks connectivity to the ACM Search GraphQL API by issuing the
-// same SearchQuery used by IsManagedResource with an empty filter set.
+// same SearchQuery used by IsManagedResource, filtered on kind=Namespace.
+// ACM Search rejects an empty/nil filter set with a GraphQL business error
+// ("query input must contain a filter or keyword") even when the backend is
+// healthy and fully authenticated (confirmed against a live ACM 2.16.2
+// cluster during the #1556 spike) — so Ping needs a filter that is always
+// syntactically valid and satisfiable on every real ACM hub. Namespace is
+// always indexed (the hub cluster itself always has namespaces), so this
+// filter never depends on Kubernaut-specific fleet state.
 // Unlike IsManagedResource, Ping does NOT swallow errors: the readiness
 // gate (pkg/fleet/readiness.ScopeCheckerProber) needs the real
 // transport/status/GraphQL error to correctly flip /readyz to NotReady
 // when ACM Search is unreachable.
 func (c *Client) Ping(ctx context.Context) error {
 	reqBody := graphQLRequest{
-		Query:     SearchQuery,
-		Variables: map[string]interface{}{"input": []searchInput{{}}},
+		Query: SearchQuery,
+		Variables: map[string]interface{}{
+			"input": []searchInput{{Filters: []searchFilter{{Property: "kind", Values: []string{"Namespace"}}}}},
+		},
 	}
 
 	body, err := json.Marshal(reqBody)

--- a/pkg/fleet/acm/client_test.go
+++ b/pkg/fleet/acm/client_test.go
@@ -256,6 +256,49 @@ var _ = Describe("ACM Search GraphQL Client (BR-INTEGRATION-065, ADR-068)", func
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("unauthorized"))
 		})
+
+		// #1556 spike (2026-07-07, live ACM 2.16.2 on OCP): a real ACM Search
+		// backend rejects an empty/nil filter set with a GraphQL business error
+		// ("query input must contain a filter or keyword") — HTTP 200, but a
+		// non-empty errors array — REGARDLESS of authentication success. Ping's
+		// query must therefore carry a filter that is always syntactically valid
+		// and satisfiable on every real ACM hub (kind=Namespace is always
+		// indexed), or the readiness gate would permanently report the ACM
+		// backend as NotReady even when it is perfectly healthy.
+		It("UT-ACM-054-013 [SC-7]: Ping sends a non-empty filter, not an empty/nil filter set real ACM Search rejects", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				body, _ := io.ReadAll(r.Body)
+				var req map[string]interface{}
+				_ = json.Unmarshal(body, &req)
+				vars, _ := req["variables"].(map[string]interface{})
+				inputs, _ := vars["input"].([]interface{})
+
+				hasFilter := false
+				if len(inputs) > 0 {
+					if input, ok := inputs[0].(map[string]interface{}); ok {
+						if filters, ok := input["filters"].([]interface{}); ok && len(filters) > 0 {
+							hasFilter = true
+						}
+					}
+				}
+
+				w.Header().Set("Content-Type", "application/json")
+				if !hasFilter {
+					// Mirrors real ACM Search v2.16.2's rejection of empty/nil
+					// filter sets, confirmed against a live cluster.
+					_, _ = w.Write([]byte(`{"errors":[{"message":"query input must contain a filter or keyword"}],"data":{"searchResult":[{"count":null}]}}`))
+					return
+				}
+				_, _ = w.Write([]byte(`{"data":{"searchResult":[{"count":0}]}}`))
+			}))
+			client = acm.NewClient(server.URL)
+
+			err := client.Ping(context.Background())
+			Expect(err).ToNot(HaveOccurred(),
+				"SC-7: Ping must send a syntactically valid, always-satisfiable filter "+
+					"so a healthy, fully-authenticated ACM Search backend is correctly "+
+					"reported as ready, not rejected for an invalid query shape")
+		})
 	})
 
 	Describe("UT-ACM-TLS [SC-8]: TLS transport security", func() {

--- a/pkg/fleet/config.go
+++ b/pkg/fleet/config.go
@@ -66,7 +66,7 @@ type FleetConfig struct {
 
 	// Endpoint is the service address for the chosen backend.
 	// For fmc: HTTP URL (e.g., "http://fmc.kubernaut.svc:8080")
-	// For acm: GraphQL URL (e.g., "https://search-api.open-cluster-management.svc:4010")
+	// For acm: GraphQL URL (e.g., "https://search-search-api.open-cluster-management.svc:4010")
 	Endpoint string `yaml:"endpoint,omitempty"`
 
 	// MCPGatewayEndpoint is the MCP Gateway SSE endpoint for remote K8s reads.
@@ -83,6 +83,16 @@ type FleetConfig struct {
 	// instead of InsecureSkipVerify. Typically mounted from the service-ca operator.
 	// +optional
 	TLSCAFile string `yaml:"tlsCAFile,omitempty"`
+
+	// TokenPath is the absolute path to a file containing a bearer token for
+	// authenticating to the ACM Search GraphQL API (backend=acm). ACM Search
+	// mandatorily requires bearer-token auth (#1556); without this, the ACM
+	// client silently sent unauthenticated requests. Rendered by the Helm
+	// chart from fleet.tokenSecretRef as "/etc/<service>/<tokenSecretRef>/token"
+	// (a projected Kubernetes ServiceAccount token or similar auto-rotating
+	// credential). Required when Backend=="acm"; see Validate().
+	// +optional
+	TokenPath string `yaml:"tokenPath,omitempty"`
 
 	// OAuth2 holds optional OAuth2 credentials for MCP Gateway authentication.
 	OAuth2 FleetOAuth2Config `yaml:"oauth2,omitempty"`
@@ -133,6 +143,31 @@ type MCPGatewayConfig struct {
 // (they discover clusters directly via ClusterRegistry watching Backend
 // CRDs), so requiring Backend/Endpoint whenever Enabled=true would force an
 // unused dependency on every MCPGatewayEndpoint-only deployment.
+// validateBackend checks the Backend/Endpoint scope-check adapter fields.
+// Only called when backendConfigured (Backend or Endpoint is set); split out
+// of Validate to keep its cognitive complexity manageable.
+func (c FleetConfig) validateBackend() error {
+	backend := c.effectiveBackend()
+	endpoint := c.EffectiveEndpoint()
+
+	if !supportedBackends[backend] {
+		return fmt.Errorf("fleet: unsupported backend %q; must be one of: fleetmetadatacache, acm", backend)
+	}
+
+	if endpoint == "" {
+		return fmt.Errorf("fleet: endpoint must not be empty when fleet is enabled (backend=%s)", backend)
+	}
+
+	// #1556: ACM Search mandatorily requires bearer-token auth. Without this
+	// check, GW/RO could start with backend=acm and silently send every scope
+	// check unauthenticated instead of failing closed at startup.
+	if backend == BackendACM && c.TokenPath == "" {
+		return fmt.Errorf("fleet: tokenPath is required when backend=acm (ACM Search mandatorily requires bearer-token auth)")
+	}
+
+	return nil
+}
+
 func (c FleetConfig) Validate() error {
 	if !c.Enabled {
 		return nil
@@ -141,15 +176,8 @@ func (c FleetConfig) Validate() error {
 	backendConfigured := c.Backend != "" || c.Endpoint != ""
 
 	if backendConfigured {
-		backend := c.effectiveBackend()
-		endpoint := c.EffectiveEndpoint()
-
-		if !supportedBackends[backend] {
-			return fmt.Errorf("fleet: unsupported backend %q; must be one of: fleetmetadatacache, acm", backend)
-		}
-
-		if endpoint == "" {
-			return fmt.Errorf("fleet: endpoint must not be empty when fleet is enabled (backend=%s)", backend)
+		if err := c.validateBackend(); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/fleet/fleet_test.go
+++ b/pkg/fleet/fleet_test.go
@@ -162,13 +162,46 @@ var _ = Describe("FleetConfig adapter pattern (Phase 2)", func() {
 
 	It("UT-FLEET-CFG-015 [CM-6]: Validate accepts acm backend", func() {
 		cfg := fleet.FleetConfig{
-			Enabled:  true,
-			Backend:  "acm",
-			Endpoint: "https://search-api.open-cluster-management.svc:4010",
+			Enabled:   true,
+			Backend:   "acm",
+			Endpoint:  "https://search-search-api.open-cluster-management.svc:4010",
+			TokenPath: "/etc/gateway/acm-token/token",
 		}
 
 		err := cfg.Validate()
 		Expect(err).ToNot(HaveOccurred())
+	})
+})
+
+// #1556: ACM Search mandatorily requires bearer-token auth, but the acm.Client
+// adapter never sent an Authorization header and nothing forced operators to
+// configure one. This left every ACM-backed deployment silently unauthenticated.
+// TokenPath hard-requirement closes that gap at config-validation time instead
+// of failing at request time inside the ACM Search backend.
+var _ = Describe("FleetConfig.TokenPath — acm backend bearer-token requirement (BR-INTEGRATION-065, #1556)", func() {
+	It("UT-FLEET-CFG-070 [IA-5,AC-4]: Validate rejects acm backend with empty TokenPath", func() {
+		cfg := fleet.FleetConfig{
+			Enabled:  true,
+			Backend:  "acm",
+			Endpoint: "https://search-search-api.open-cluster-management.svc:4010",
+		}
+
+		err := cfg.Validate()
+		Expect(err).To(HaveOccurred(),
+			"IA-5/AC-4: ACM Search mandatorily requires bearer-token auth; starting "+
+				"without TokenPath would silently send unauthenticated requests")
+		Expect(err.Error()).To(ContainSubstring("tokenPath"))
+	})
+
+	It("UT-FLEET-CFG-071 [IA-5,AC-4]: Validate accepts acm backend with TokenPath set", func() {
+		cfg := fleet.FleetConfig{
+			Enabled:   true,
+			Backend:   "acm",
+			Endpoint:  "https://search-search-api.open-cluster-management.svc:4010",
+			TokenPath: "/etc/gateway/acm-token/token",
+		}
+
+		Expect(cfg.Validate()).ToNot(HaveOccurred())
 	})
 })
 

--- a/pkg/fleet/scope_factory.go
+++ b/pkg/fleet/scope_factory.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/jordigilh/kubernaut/pkg/fleet/acm"
 	"github.com/jordigilh/kubernaut/pkg/fleet/fmc"
+	"github.com/jordigilh/kubernaut/pkg/shared/auth"
 	"github.com/jordigilh/kubernaut/pkg/shared/scope"
 	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls"
 )
@@ -85,15 +86,28 @@ func NewScopeChecker(localChecker scope.ScopeChecker, cfg FleetConfig, logger lo
 		remoteChecker := fmc.NewHTTPClient(endpoint)
 		return NewFederatedScopeChecker(localChecker, remoteChecker, logger, checkerOpts...), nil
 	case BackendACM:
-		var acmOpts []acm.ClientOption
+		// #1556: ACM Search mandatorily requires bearer-token auth.
+		// FleetConfig.Validate() hard-requires cfg.TokenPath for BackendACM, so
+		// in practice this branch always composes auth.AuthTransport. The
+		// TokenPath=="" fallback below only matters for direct FleetConfig
+		// construction that bypasses Validate() (e.g. test helpers) — it must
+		// never fabricate a partial/malformed Authorization header.
+		transport := http.DefaultTransport
 		if cfg.TLSCAFile != "" {
 			reloader, err := sharedtls.NewCAReloaderFromFile(cfg.TLSCAFile)
 			if err != nil {
 				return nil, fmt.Errorf("fleet: failed to load ACM TLS CA from %s: %w", cfg.TLSCAFile, err)
 			}
+			transport = reloader
+		}
+		if cfg.TokenPath != "" {
+			transport = auth.NewAuthTransport(auth.NewTokenSource(cfg.TokenPath), transport)
+		}
+		var acmOpts []acm.ClientOption
+		if cfg.TLSCAFile != "" || cfg.TokenPath != "" {
 			acmOpts = append(acmOpts, acm.WithHTTPClient(&http.Client{
 				Timeout:   10 * time.Second,
-				Transport: reloader,
+				Transport: transport,
 			}))
 		}
 		remoteChecker := acm.NewClient(endpoint, acmOpts...)

--- a/pkg/fleet/scope_factory_test.go
+++ b/pkg/fleet/scope_factory_test.go
@@ -17,11 +17,18 @@ limitations under the License.
 package fleet_test
 
 import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/jordigilh/kubernaut/pkg/fleet"
+	"github.com/jordigilh/kubernaut/pkg/shared/scope"
 )
 
 var _ = Describe("NewScopeChecker factory (BR-INTEGRATION-065)", func() {
@@ -69,7 +76,12 @@ var _ = Describe("NewScopeChecker factory (BR-INTEGRATION-065)", func() {
 	})
 
 	It("UT-FLEET-FAC-005 [AC-4]: BackendACM with endpoint returns FederatedScopeChecker using ACM client", func() {
-		cfg := fleet.FleetConfig{Enabled: true, Backend: "acm", Endpoint: "https://search-api:4010"}
+		cfg := fleet.FleetConfig{
+			Enabled:   true,
+			Backend:   "acm",
+			Endpoint:  "https://search-api:4010",
+			TokenPath: "/etc/gateway/acm-token/token",
+		}
 		checker, err := fleet.NewScopeChecker(local, cfg, logr.Discard())
 		Expect(err).ToNot(HaveOccurred())
 		Expect(checker).ToNot(BeIdenticalTo(local),
@@ -94,5 +106,71 @@ var _ = Describe("NewScopeChecker factory (BR-INTEGRATION-065)", func() {
 		Expect(err).To(HaveOccurred(),
 			"empty backend with endpoint must fail validation in factory")
 		Expect(checker).To(BeNil())
+	})
+
+	// #1556: proves the factory actually composes the bearer-token transport,
+	// not just that it returns a FederatedScopeChecker (UT-FLEET-FAC-005 only
+	// checks the type, not the wire behavior).
+	It("UT-FLEET-FAC-008 [SC-7,IA-5]: BackendACM with TokenPath set sends Authorization: Bearer <token> to the ACM endpoint", func() {
+		var gotAuthHeader string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuthHeader = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"searchResult":[{"count":0}]}}`))
+		}))
+		defer server.Close()
+
+		tokenPath := filepath.Join(GinkgoT().TempDir(), "token")
+		Expect(os.WriteFile(tokenPath, []byte("test-acm-token"), 0o600)).To(Succeed())
+
+		cfg := fleet.FleetConfig{
+			Enabled:   true,
+			Backend:   "acm",
+			Endpoint:  server.URL,
+			TokenPath: tokenPath,
+		}
+		checker, err := fleet.NewScopeChecker(local, cfg, logr.Discard())
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = checker.IsManagedResource(context.Background(), scope.ResourceIdentity{
+			ClusterID: "prod-east", Kind: "Deployment", Name: "nginx",
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(gotAuthHeader).To(Equal("Bearer test-acm-token"),
+			"SC-7/IA-5: factory-composed ACM client must authenticate every request "+
+				"with the configured bearer token")
+	})
+
+	// #1556 defense-in-depth: FleetConfig.Validate() hard-requires TokenPath for
+	// BackendACM (UT-FLEET-CFG-070), so this state is unreachable through normal
+	// config loading. This test locks in the factory's own fail-safe behavior
+	// for direct struct construction that bypasses Validate() (e.g. a future
+	// caller or test helper) — it must never send a partial/malformed
+	// Authorization header, only either a correct one or none at all.
+	It("UT-FLEET-FAC-009 [AC-4]: BackendACM without TokenPath (Validate bypassed) sends no Authorization header", func() {
+		var gotAuthHeader string
+		sawRequest := false
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			sawRequest = true
+			gotAuthHeader = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"searchResult":[{"count":0}]}}`))
+		}))
+		defer server.Close()
+
+		cfg := fleet.FleetConfig{Enabled: true, Backend: "acm", Endpoint: server.URL}
+		checker, err := fleet.NewScopeChecker(local, cfg, logr.Discard())
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = checker.IsManagedResource(context.Background(), scope.ResourceIdentity{
+			ClusterID: "prod-east", Kind: "Deployment", Name: "nginx",
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(sawRequest).To(BeTrue(), "request must still reach the ACM endpoint")
+		Expect(gotAuthHeader).To(BeEmpty(),
+			"AC-4: without a configured TokenPath the factory must never send a "+
+				"partial or malformed Authorization header")
 	})
 })

--- a/pkg/gateway/config/config_test.go
+++ b/pkg/gateway/config/config_test.go
@@ -266,6 +266,26 @@ var _ = Describe("BR-GATEWAY-100: Gateway Configuration Validation", func() {
 
 			Expect(cfg.Validate()).ToNot(HaveOccurred())
 		})
+
+		// #1556: proves the ACM bearer-token hard-require (FleetConfig.Validate,
+		// UT-FLEET-CFG-070) is actually reachable from GW's own production
+		// Validate() chain (cmd/gateway/main.go -> serverCfg.Validate() ->
+		// c.Fleet.Validate()) — not just from FleetConfig in isolation.
+		It("[UT-GW-FLEET-007] should reject backend=acm with no tokenPath through GW's own Validate() chain", func() {
+			cfg := config.DefaultServerConfig()
+			cfg.Fleet = fleet.FleetConfig{
+				Enabled:            true,
+				Backend:            "acm",
+				Endpoint:           "https://search-api:4010",
+				MCPGatewayEndpoint: "http://mcp-gateway:8080/mcp",
+				MCPGatewayType:     fleet.GatewayEAIGW,
+			}
+
+			err := cfg.Validate()
+			Expect(err).To(HaveOccurred(),
+				"AC-4/IA-5: GW must fail to start with an ACM backend that has no bearer token configured")
+			Expect(err.Error()).To(ContainSubstring("tokenPath"))
+		})
 	})
 
 	Context("hot reload", func() {

--- a/scripts/helm-smoke-test.sh
+++ b/scripts/helm-smoke-test.sh
@@ -1914,9 +1914,11 @@ for d in docs:
       "DataStorage/APIFrontend alert rules rendered despite monitoring.coreos.com/v1 CRD not being present"
   fi
 
-  # ST-CHART-ACM-001: ACM backend tokenSecretRef wiring (BR-PLATFORM-003, #1556 dependency).
-  # tokenSecretRef is optional (chart wiring is ahead of the Go-side #1556 fix) — no fail()
-  # guard is expected; backend=acm without a token must still render cleanly.
+  # ST-CHART-ACM-001: ACM backend tokenSecretRef wiring (BR-PLATFORM-003, #1556).
+  # The Helm chart itself has no fail() guard for a missing tokenSecretRef — backend=acm
+  # without a token must still render cleanly at the template layer. Enforcement is done
+  # Go-side: FleetConfig.Validate() now hard-rejects backend=acm without TokenPath, so the
+  # rendered Pod will fail to start (fail-closed), even though `helm template` succeeds here.
   local acm_with_token
   acm_with_token=$(helm template test "$CHART_PATH" \
     $(template_common_args) $(template_llm_args) $(policy_flags) \
@@ -1938,14 +1940,14 @@ for d in docs:
     --set gateway.fleet.mcpGatewayEndpoint=https://mcp.example.com 2>&1)
   acm_without_token_exit=$?
   if [[ "$acm_without_token_exit" -eq 0 ]] && ! grep -q "fleet-acm-token" <<< "$acm_without_token"; then
-    tap_ok "ST-CHART-ACM-001b: backend=acm without tokenSecretRef renders cleanly (unauthenticated, pending #1556)"
+    tap_ok "ST-CHART-ACM-001b: backend=acm without tokenSecretRef renders cleanly (fails Go-side Validate() at pod startup, per #1556)"
   else
     tap_not_ok "ST-CHART-ACM-001b: backend=acm without tokenSecretRef" \
       "render failed, or fleet-acm-token volume unexpectedly present without tokenSecretRef set"
   fi
 
   # ST-CHART-ACM-002: same ACM backend tokenSecretRef wiring, ported to RemediationOrchestrator
-  # (BR-PLATFORM-003, #1556 dependency). Mirrors ST-CHART-ACM-001 — this wiring point had zero
+  # (BR-PLATFORM-003, #1556). Mirrors ST-CHART-ACM-001 — this wiring point had zero
   # test coverage despite being identical in shape to Gateway's.
   local ro_acm_with_token
   ro_acm_with_token=$(helm template test "$CHART_PATH" \
@@ -1968,7 +1970,7 @@ for d in docs:
     --set remediationorchestrator.fleet.mcpGatewayEndpoint=https://mcp.example.com 2>&1)
   ro_acm_without_token_exit=$?
   if [[ "$ro_acm_without_token_exit" -eq 0 ]] && ! grep -q "fleet-acm-token" <<< "$ro_acm_without_token"; then
-    tap_ok "ST-CHART-ACM-002b: RemediationOrchestrator backend=acm without tokenSecretRef renders cleanly (unauthenticated, pending #1556)"
+    tap_ok "ST-CHART-ACM-002b: RemediationOrchestrator backend=acm without tokenSecretRef renders cleanly (fails Go-side Validate() at pod startup, per #1556)"
   else
     tap_not_ok "ST-CHART-ACM-002b: RemediationOrchestrator backend=acm without tokenSecretRef" \
       "render failed, or fleet-acm-token volume unexpectedly present without tokenSecretRef set"

--- a/test/integration/acm/acm_factory_test.go
+++ b/test/integration/acm/acm_factory_test.go
@@ -19,14 +19,18 @@ package acm_test
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 
 	"github.com/go-logr/logr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	"github.com/jordigilh/kubernaut/pkg/fleet"
+	"github.com/jordigilh/kubernaut/pkg/fleet/readiness"
 	"github.com/jordigilh/kubernaut/pkg/shared/scope"
 )
 
@@ -83,10 +87,13 @@ var _ = Describe("ACM Search Factory Wiring (BR-INTEGRATION-065)", Ordered, Labe
 		}))
 
 		By("Creating FederatedScopeChecker via production factory with BackendACM")
+		tokenPath := filepath.Join(GinkgoT().TempDir(), "token")
+		Expect(os.WriteFile(tokenPath, []byte("it-acm-054-001-token"), 0o600)).To(Succeed())
 		cfg := fleet.FleetConfig{
-			Enabled:  true,
-			Backend:  fleet.BackendACM,
-			Endpoint: graphQLServer.URL,
+			Enabled:   true,
+			Backend:   fleet.BackendACM,
+			Endpoint:  graphQLServer.URL,
+			TokenPath: tokenPath,
 		}
 		var err error
 		fedChecker, err = fleet.NewScopeChecker(&localAlwaysFalse{}, cfg, logr.Discard())
@@ -136,5 +143,167 @@ var _ = Describe("ACM Search Factory Wiring (BR-INTEGRATION-065)", Ordered, Labe
 			Expect(managed).To(BeFalse(),
 				"AC-4: absent resource must return false through the full production path")
 		})
+	})
+})
+
+// IT-ACM-054-002
+//
+// #1556: ACM Search mandatorily requires bearer-token auth. Before this fix,
+// fleet.NewScopeChecker's BackendACM case never composed an Authorization
+// header, regardless of configuration. This is the Wiring Manifest proof for
+// that composition: factory -> auth.AuthTransport -> acm.Client -> real HTTP
+// wire, exercised through the same production entry point (NewScopeChecker)
+// as UT-FLEET-FAC-008 — kept as a distinct IT per CHECKPOINT W (Wiring
+// Manifest requires an explicit IT test ID per wiring point) rather than
+// relying on the UT tier alone.
+var _ = Describe("ACM Search Factory Bearer-Token Auth (BR-INTEGRATION-065, #1556)", Label("acm", "integration"), func() {
+	It("IT-ACM-054-002 [SC-7,IA-5]: factory-composed transport sends Authorization: Bearer <token> on the real wire", func() {
+		var gotAuthHeader string
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			gotAuthHeader = r.Header.Get("Authorization")
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"searchResult":[{"count":1}]}}`))
+		}))
+		defer server.Close()
+
+		tokenPath := filepath.Join(GinkgoT().TempDir(), "token")
+		Expect(os.WriteFile(tokenPath, []byte("it-acm-054-002-token"), 0o600)).To(Succeed())
+
+		cfg := fleet.FleetConfig{
+			Enabled:   true,
+			Backend:   fleet.BackendACM,
+			Endpoint:  server.URL,
+			TokenPath: tokenPath,
+		}
+		checker, err := fleet.NewScopeChecker(&localAlwaysFalse{}, cfg, logr.Discard())
+		Expect(err).ToNot(HaveOccurred())
+
+		_, err = checker.IsManagedResource(context.Background(), scope.ResourceIdentity{
+			ClusterID: "prod-east", Kind: "Deployment", Namespace: "default", Name: "nginx",
+		})
+		Expect(err).ToNot(HaveOccurred())
+
+		Expect(gotAuthHeader).To(Equal("Bearer it-acm-054-002-token"),
+			"SC-7/IA-5: the production factory dispatch path must authenticate "+
+				"every ACM Search request with the configured bearer token")
+	})
+})
+
+// IT-ACM-054-003
+//
+// #1556: the readiness gate (pkg/fleet/readiness.ScopeCheckerProber) relies on
+// acm.Client.Ping to surface real backend errors so /readyz correctly flips to
+// NotReady when ACM Search rejects the request. This proves that an
+// authentication failure (401, e.g. expired/rotated ServiceAccount token) is
+// not silently swallowed — the service must fail closed, not silently degrade
+// to unauthenticated (and therefore always-failing) scope checks.
+var _ = Describe("ACM Search Factory Readiness Fail-Closed on 401 (BR-INTEGRATION-065, #1556)", Label("acm", "integration"), func() {
+	It("IT-ACM-054-003 [AC-4,IA-5]: Ping surfaces a 401 from ACM Search instead of swallowing it", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") != "Bearer it-acm-054-003-valid-token" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"data":{"searchResult":[{"count":0}]}}`))
+		}))
+		defer server.Close()
+
+		tokenPath := filepath.Join(GinkgoT().TempDir(), "token")
+		Expect(os.WriteFile(tokenPath, []byte("it-acm-054-003-wrong-token"), 0o600)).To(Succeed())
+
+		cfg := fleet.FleetConfig{
+			Enabled:   true,
+			Backend:   fleet.BackendACM,
+			Endpoint:  server.URL,
+			TokenPath: tokenPath,
+		}
+		checker, err := fleet.NewScopeChecker(&localAlwaysFalse{}, cfg, logr.Discard())
+		Expect(err).ToNot(HaveOccurred())
+
+		fed, ok := checker.(*fleet.FederatedScopeChecker)
+		Expect(ok).To(BeTrue(), "factory must return *fleet.FederatedScopeChecker for BackendACM")
+		pinger, ok := fed.Remote().(readiness.Pinger)
+		Expect(ok).To(BeTrue(), "the ACM backend must satisfy the readiness.Pinger interface "+
+			"(this is what wireFleetReadinessGate relies on in cmd/gateway/main.go and cmd/remediationorchestrator/main.go)")
+
+		err = pinger.Ping(context.Background())
+		Expect(err).To(HaveOccurred(),
+			"AC-4/IA-5: readiness gate must fail closed when ACM Search rejects the bearer token")
+		Expect(err.Error()).To(ContainSubstring("401"),
+			"the surfaced error must reflect the real 401 from ACM Search, not a swallowed/generic failure")
+	})
+})
+
+// IT-ACM-054-004
+//
+// Pyramid Invariant closure for the Ping() query-shape fix (#1556 spike,
+// 2026-07-07, live ACM 2.16.2 on OCP): UT-ACM-054-013 proves the corrected
+// query shape in isolation (acm.Client constructed directly); this proves
+// the SAME fix through the real production wiring chain — factory ->
+// FederatedScopeChecker.Remote() -> readiness.Pinger -> acm.Client.Ping() —
+// i.e. exactly what cmd/gateway/main.go and cmd/remediationorchestrator/main.go
+// wire into the readiness gate. The fake server mirrors real ACM Search's
+// rejection of empty/nil filter sets, so this also regression-guards against
+// Ping() ever reverting to an empty filter while going through the actual
+// dispatch path, not just the unit-level client.
+var _ = Describe("ACM Search Factory Readiness Reports Ready When Healthy (BR-INTEGRATION-065, #1556)", Label("acm", "integration"), func() {
+	It("IT-ACM-054-004 [AC-4,IA-5]: Ping succeeds through the full production wiring chain against a healthy, authenticated backend", func() {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get("Authorization") != "Bearer it-acm-054-004-token" {
+				w.WriteHeader(http.StatusUnauthorized)
+				return
+			}
+
+			body, _ := io.ReadAll(r.Body)
+			var req map[string]interface{}
+			_ = json.Unmarshal(body, &req)
+			vars, _ := req["variables"].(map[string]interface{})
+			inputs, _ := vars["input"].([]interface{})
+
+			hasFilter := false
+			if len(inputs) > 0 {
+				if input, ok := inputs[0].(map[string]interface{}); ok {
+					if filters, ok := input["filters"].([]interface{}); ok && len(filters) > 0 {
+						hasFilter = true
+					}
+				}
+			}
+
+			w.Header().Set("Content-Type", "application/json")
+			if !hasFilter {
+				// Mirrors real ACM Search v2.16.2's rejection of empty/nil
+				// filter sets, confirmed against a live cluster.
+				_, _ = w.Write([]byte(`{"errors":[{"message":"query input must contain a filter or keyword"}],"data":{"searchResult":[{"count":null}]}}`))
+				return
+			}
+			_, _ = w.Write([]byte(`{"data":{"searchResult":[{"count":105}]}}`))
+		}))
+		defer server.Close()
+
+		tokenPath := filepath.Join(GinkgoT().TempDir(), "token")
+		Expect(os.WriteFile(tokenPath, []byte("it-acm-054-004-token"), 0o600)).To(Succeed())
+
+		cfg := fleet.FleetConfig{
+			Enabled:   true,
+			Backend:   fleet.BackendACM,
+			Endpoint:  server.URL,
+			TokenPath: tokenPath,
+		}
+		checker, err := fleet.NewScopeChecker(&localAlwaysFalse{}, cfg, logr.Discard())
+		Expect(err).ToNot(HaveOccurred())
+
+		fed, ok := checker.(*fleet.FederatedScopeChecker)
+		Expect(ok).To(BeTrue(), "factory must return *fleet.FederatedScopeChecker for BackendACM")
+		pinger, ok := fed.Remote().(readiness.Pinger)
+		Expect(ok).To(BeTrue(), "the ACM backend must satisfy the readiness.Pinger interface "+
+			"(this is what wireFleetReadinessGate relies on in cmd/gateway/main.go and cmd/remediationorchestrator/main.go)")
+
+		err = pinger.Ping(context.Background())
+		Expect(err).ToNot(HaveOccurred(),
+			"AC-4/IA-5: the readiness gate must report the ACM backend as ready through "+
+				"the real production wiring chain when it is healthy and authenticated — "+
+				"a query-shape regression here would cause every ACM-backed deployment's "+
+				"/readyz to permanently report NotReady")
 	})
 })

--- a/test/integration/workflowexecution/job_lifecycle_integration_test.go
+++ b/test/integration/workflowexecution/job_lifecycle_integration_test.go
@@ -943,9 +943,23 @@ var _ = Describe("Job Resource Governance (DD-WE-008, BR-WE-019)", func() {
 		Expect(container.Resources.Limits.Memory().String()).To(Equal("256Mi"))
 
 		By("Verifying the resolved resources were persisted to WFE.Status.Resources")
-		updated, err := getWFE(wfe.Name, wfe.Namespace)
-		Expect(err).ToNot(HaveOccurred())
-		Expect(updated.Status.Resources).ToNot(BeNil())
+		// Job creation (waitForJobCreation above) and the WFE status update that
+		// persists Status.Resources are two sequential, non-atomic API calls within
+		// the same reconcile (finalizePendingToRunning): the Job becomes visible to
+		// this test as soon as it's created, which can race ahead of the subsequent
+		// Status().Update() -- especially when a concurrent reconcile (e.g. the
+		// Running-phase progress check triggered by the Job's own creation event)
+		// causes a resourceVersion conflict and forces a retry. Poll rather than a
+		// single-shot read to tolerate that expected eventual-consistency gap.
+		var updated *workflowexecutionv1alpha1.WorkflowExecution
+		Eventually(func() *corev1.ResourceRequirements {
+			var err error
+			updated, err = getWFE(wfe.Name, wfe.Namespace)
+			if err != nil {
+				return nil
+			}
+			return updated.Status.Resources
+		}, 5*time.Second, 100*time.Millisecond).ShouldNot(BeNil())
 		Expect(updated.Status.Resources.Requests.Cpu().String()).To(Equal("100m"))
 
 		GinkgoWriter.Printf("✅ IT-WE-019-001: Catalog-resolved resources applied to Job container\n")


### PR DESCRIPTION
## Summary

- `pkg/fleet/acm.Client` (`fleet.backend: "acm"`) never sent the `Authorization: Bearer <token>` header the real ACM Search GraphQL API mandatorily requires — a pre-existing gap tracked as #1556. Before #1553 this failed silently (`IsManagedResource` fail-safe-swallowed the 401); after #1553 it meant `/readyz` was permanently `NotReady` for every `backend: "acm"` deployment.
- Fixes it by composing `pkg/shared/auth.AuthTransport` over the ACM client's HTTP transport in `pkg/fleet/scope_factory.go`, reading the token from a new `FleetConfig.TokenPath` field. `FleetConfig.Validate()` now hard-requires `TokenPath` when `Backend == "acm"`, so a misconfigured deployment fails closed at startup instead of sending unauthenticated requests.
- Also fixes a related defect found during a live-cluster spike: `acm.Client.Ping()` sent an empty search filter, which real ACM Search rejects with a GraphQL-level error (HTTP 200, populated `errors` array) even when healthy and authenticated — this alone would have kept `/readyz` stuck at `NotReady`. `Ping()` now sends an always-satisfiable `kind=Namespace` filter.
- Updates the Helm chart (`gateway`/`remediationorchestrator` templates, `values.yaml`, `values.schema.json`, `README.md`, smoke-test script) to reflect that `fleet.tokenSecretRef`/`tokenPath` is now functional and mandatory when `backend=acm`, rather than the previous "not yet functional, pre-wired ahead of the Go-side fix" state.
- Updates `ADR-068`, the Fleet readiness-gate runbook, and the ACM Search spike docs to reflect the resolved status and correct a stale config-key nesting (`fleet.acm.tokenSecretRef`/`fleet.acm.caBundle` never matched the actual flat `FleetConfig.TokenPath`/`TLSCAFile` fields).

## Validation

Both fixes were confirmed **end-to-end against a live ACM 2.16.2 instance**, not just mocked-server unit/integration tests: `fleet.NewScopeChecker()` (the exact production factory GW/RO call at startup) was driven from inside a cluster pod with a real ServiceAccount bearer token and TLS CA, exercising `Ping()` (readiness-gate call) and `IsManagedResource()` against the real Search API — including a real "managed" resource (`search-api` Deployment), a real "unmanaged" resource, and a fail-closed check with a missing token file. See `docs/spikes/multi-cluster-mcp-gateway/spike-acm-search/README.md` ("Post-#1556 Fix: Production Go Client Validation") for full method and results.

## Test plan

- [x] `go build ./...` passes
- [x] `golangci-lint run` clean on changed packages
- [x] Unit tests: `pkg/fleet/...`, `pkg/fleet/acm/...`, `pkg/gateway/config/...`, `internal/config/remediationorchestrator/...`
- [x] Integration tests: `test/integration/acm/...` (new `IT-ACM-054-002/003/004`)
- [x] `helm lint` / `helm template` clean with `backend=acm` + `tokenSecretRef` set
- [x] Live-cluster spike against real ACM 2.16.2 (see spike README)

Made with [Cursor](https://cursor.com)