### PR TITLE
feat(aianalysis): add action_type to Rego approval policy input (#247)

### DIFF
--- a/docs/architecture/decisions/DD-AIANALYSIS-001-rego-policy-loading-strategy.md
+++ b/docs/architecture/decisions/DD-AIANALYSIS-001-rego-policy-loading-strategy.md
@@ -3,6 +3,8 @@
 ## Status
 **✅ APPROVED** (2025-11-29)
 **Updated**: 2025-12-05 (OPA v1 syntax requirement)
+**Updated**: 2026-07-07 (#247: `action_type` added to `rego.PolicyInput` -- see [BR-AI-085 FR-AI-085-006](../../requirements/BR-AI-085-rego-policy-input-schema.md#fr-ai-085-006-action_type-based-infrastructure-action-approval) for the schema/rule addition; no change to this DD's loading/hot-reload strategy)
+**Updated**: 2026-07-07 (#247 follow-up: `rego.PolicyInput` decomposed into `SignalContext`/`Classification`/`KAResponse` sub-structs to remediate a Go Anti-Pattern Checklist "God struct" finding -- see [BR-AI-085 v1.4 changelog](../../requirements/BR-AI-085-rego-policy-input-schema.md); Go-side organization only, no change to the Rego input contract or this DD's loading strategy)
 **Follows**: Gateway pattern (DD-GATEWAY-XXX)
 **Confidence**: 95%
 

--- a/docs/requirements/BR-AI-085-rego-policy-input-schema.md
+++ b/docs/requirements/BR-AI-085-rego-policy-input-schema.md
@@ -317,6 +317,50 @@ require_approval if {
 
 ---
 
+### **FR-AI-085-006: `action_type`-Based Infrastructure-Action Approval**
+
+**Requirement**: AIAnalysis MUST expose `action_type` in the Rego policy input schema so approval policies can force human approval for infrastructure-impacting action types, independent of `remediation_target.kind` (the ADR-055-ADDENDUM-001 rename of `affected_resource`).
+
+**Rationale (Issue #247)**: `remediation_target.kind`-based rules (FR-AI-085-005's `is_sensitive_resource`) require human approval for sensitive resource *kinds* (`Node`, `StatefulSet`). However, for infrastructure-provisioning workflows such as `ProvisionNode`, the LLM's RCA identifies the **source workload** (e.g. `Deployment`) as the remediation target -- not the `Node` actually being provisioned -- because the workload, not the not-yet-created node, is what the investigation observed. `remediation_target.kind` alone therefore cannot gate on "this action provisions infrastructure"; the *action type itself* is a more reliable signal, since `action_type` is catalog-authoritative (sourced from the `action_type_taxonomy` table via the KA three-step discovery protocol, per DD-WORKFLOW-016) rather than LLM-inferred.
+
+**PolicyInput Struct** (`pkg/aianalysis/rego/evaluator.go`):
+```go
+type PolicyInput struct {
+    // ... existing fields ...
+
+    // ActionType is the catalog action type selected for remediation
+    // (DD-WORKFLOW-016 taxonomy, e.g. ScaleReplicas, ProvisionNode).
+    // Unlike RemediationTarget.Kind, this is catalog-authoritative
+    // (not LLM-inferred), enabling reliable gating on infrastructure-
+    // impacting actions regardless of which resource the LLM reports
+    // as the remediation target (#247).
+    ActionType string `json:"action_type"`
+}
+```
+
+**Example Rego Rule**:
+```rego
+package aianalysis.approval
+
+# #247: Infrastructure-provisioning action types always require approval,
+# regardless of the (LLM-reported) remediation_target kind.
+is_infrastructure_action if {
+    input.action_type == "ProvisionNode"
+}
+
+require_approval if {
+    is_infrastructure_action
+}
+```
+
+**Acceptance Criteria**:
+1. ✅ `PolicyInput` struct includes `ActionType string` field, populated from `Status.SelectedWorkflow.ActionType`
+2. ✅ Default Rego approval policy includes an `is_infrastructure_action` rule gating on `action_type`
+3. ✅ Unit tests verify that `action_type == "ProvisionNode"` triggers `require_approval` regardless of `remediation_target.kind` or confidence
+4. ✅ Integration tests verify the rule against the real OPA evaluator (compile + query + extract)
+
+---
+
 ## 📊 **Non-Functional Requirements**
 
 ### **NFR-AI-085-001: Performance Impact**
@@ -493,9 +537,13 @@ require_approval if {
 
 **Document Control**:
 - **Created**: 2026-01-20
-- **Last Updated**: 2026-02-12
-- **Version**: 1.2
+- **Last Updated**: 2026-07-07
+- **Version**: 1.4
 - **Status**: ✅ Approved
 - **Changes in 1.1**: Added FR-AI-085-005 (default-deny for missing `affected_resource`), added ADR-055 reference, documented `target_in_owner_chain` supersession, added Example 5 (default-deny safety pattern).
 - **Changes in 1.2**: Added `ConfidenceThreshold *float64` to PolicyInput schema (#225). Confidence threshold is now configurable via `input.confidence_threshold` in the Rego policy, with a built-in default of 0.8. Stepping stone toward BR-HAPI-198.
+- **Changes in 1.3**: Added FR-AI-085-006 (`action_type`-based infrastructure-action approval, #247). `action_type` is now exposed in the Rego policy input alongside `remediation_target` (the ADR-055-ADDENDUM-001 rename of `affected_resource`), so infrastructure-provisioning workflows (e.g. `ProvisionNode`) require approval based on the catalog-authoritative action type rather than the (potentially LLM-misreported) remediation target kind.
+- **Changes in 1.4**: `#247` follow-up -- decomposed the Go `PolicyInput` struct into `SignalContext`/`Classification`/`KAResponse` sub-structs to keep the top-level field count below the AGENTS.md Go Anti-Pattern Checklist's "God struct" threshold (had reached 15 fields). Go-side organization only: `buildRegoInputMap` still flattens to the same top-level Rego input keys, so this is **not a Rego policy contract change** -- no `.rego` policy file needs updating.
 - **Next Review**: After BR-HAPI-198 V1.1 implementation
+
+**Note on field naming**: This document's earlier FRs (001-005) use the original `affected_resource` naming from when this BR was authored. Per [ADR-055-ADDENDUM-001](../architecture/decisions/remediation-target-rename.md) (#542), this field was subsequently renamed to `remediation_target` end-to-end (Go struct, JSON tag, Rego input key) to avoid LLM misinterpretation. FR-AI-085-006 uses the current `remediation_target` naming; the code examples in FR-AI-085-001 through 005 are retained as historical context and should be read as `remediation_target` in the current implementation.

--- a/docs/services/crd-controllers/02-aianalysis/REGO_POLICY_EXAMPLES.md
+++ b/docs/services/crd-controllers/02-aianalysis/REGO_POLICY_EXAMPLES.md
@@ -8,6 +8,15 @@
 
 ---
 
+> ⚠️ **SUPERSEDED / STALE (as of 2026-07-07, #247)**: This is early design-exploration content from before the schema stabilized, and it no longer reflects the implemented input/output schema. Notably: the real Go types are `rego.PolicyInput`/`rego.PolicyResult` (not `ApprovalPolicyInput`/`ApprovalDecision`/`DetectedLabelsInput` shown below); there is no `action`/`Action` or `AutoApprove`/`Timestamp` field in the real schema; `target_in_owner_chain` was replaced by `remediation_target` (ADR-055-ADDENDUM-001); and `confidence_threshold` (#225), `identity` (#774), and `action_type` (#247) are missing from the examples entirely. **Do not use this document as a schema reference.** For the authoritative schema and rules, see:
+> - [BR-AI-085](../../../requirements/BR-AI-085-rego-policy-input-schema.md) -- policy input schema requirements
+> - `pkg/aianalysis/rego/evaluator.go` -- `PolicyInput`/`PolicyResult` Go types (source of truth)
+> - `pkg/aianalysis/testdata/policies/approval.rego` / `test/integration/aianalysis/testdata/policies/approval.rego` -- working Rego policy fixtures
+>
+> The rest of this document is retained as historical design context only.
+
+---
+
 ## ⚠️ OPA v1 Syntax
 
 All policies in this document use OPA v1 syntax (required for `github.com/open-policy-agent/opa/v1/rego`):

--- a/pkg/aianalysis/analyzing_handler_post_rca_test.go
+++ b/pkg/aianalysis/analyzing_handler_post_rca_test.go
@@ -127,9 +127,9 @@ var _ = Describe("AnalyzingHandler PostRCAContext Rego Integration (ADR-056)", f
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(spy.LastInput).NotTo(BeNil())
-		Expect(spy.LastInput.DetectedLabels).NotTo(BeNil())
+		Expect(spy.LastInput.Classification.DetectedLabels).NotTo(BeNil())
 
-		dl := spy.LastInput.DetectedLabels
+		dl := spy.LastInput.Classification.DetectedLabels
 		Expect(dl["git_ops_managed"]).To(BeTrue(), "gitOpsManaged from PostRCAContext")
 		Expect(dl["git_ops_tool"]).To(Equal("argocd"), "gitOpsTool from PostRCAContext")
 		Expect(dl["pdb_protected"]).To(BeTrue(), "pdbProtected from PostRCAContext")
@@ -153,9 +153,9 @@ var _ = Describe("AnalyzingHandler PostRCAContext Rego Integration (ADR-056)", f
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(spy.LastInput).NotTo(BeNil())
-		Expect(spy.LastInput.FailedDetections).To(HaveLen(2))
-		Expect(spy.LastInput.FailedDetections).To(ContainElement("pdbProtected"))
-		Expect(spy.LastInput.FailedDetections).To(ContainElement("hpaEnabled"))
+		Expect(spy.LastInput.KAResponse.FailedDetections).To(HaveLen(2))
+		Expect(spy.LastInput.KAResponse.FailedDetections).To(ContainElement("pdbProtected"))
+		Expect(spy.LastInput.KAResponse.FailedDetections).To(ContainElement("hpaEnabled"))
 	})
 
 	// ═══════════════════════════════════════════════════════════════════════
@@ -172,7 +172,7 @@ var _ = Describe("AnalyzingHandler PostRCAContext Rego Integration (ADR-056)", f
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(spy.LastInput).NotTo(BeNil())
-		dl := spy.LastInput.DetectedLabels
+		dl := spy.LastInput.Classification.DetectedLabels
 		Expect(dl["stateful"]).To(BeTrue(),
 			"ADR-056: DetectedLabels from PostRCAContext")
 		Expect(dl["git_ops_managed"]).To(BeTrue(),
@@ -192,9 +192,9 @@ var _ = Describe("AnalyzingHandler PostRCAContext Rego Integration (ADR-056)", f
 
 		Expect(err).NotTo(HaveOccurred())
 		Expect(spy.LastInput).NotTo(BeNil())
-		Expect(spy.LastInput.DetectedLabels).NotTo(BeNil(),
+		Expect(spy.LastInput.Classification.DetectedLabels).NotTo(BeNil(),
 			"DetectedLabels must be non-nil empty map, not nil")
-		Expect(spy.LastInput.DetectedLabels).To(BeEmpty(),
+		Expect(spy.LastInput.Classification.DetectedLabels).To(BeEmpty(),
 			"DetectedLabels must be empty when PostRCAContext is nil")
 	})
 

--- a/pkg/aianalysis/analyzing_handler_test.go
+++ b/pkg/aianalysis/analyzing_handler_test.go
@@ -435,7 +435,7 @@ var _ = Describe("AnalyzingHandler", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(spy.LastInput).NotTo(BeNil())
-				Expect(spy.LastInput.Environment).To(Equal("staging"))
+				Expect(spy.LastInput.SignalContext.Environment).To(Equal("staging"))
 			})
 
 			It("should pass confidence from SelectedWorkflow", func() {
@@ -445,7 +445,7 @@ var _ = Describe("AnalyzingHandler", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(spy.LastInput).NotTo(BeNil())
-				Expect(spy.LastInput.Confidence).To(BeNumerically("~", 0.92, 0.01))
+				Expect(spy.LastInput.KAResponse.Confidence).To(BeNumerically("~", 0.92, 0.01))
 			})
 
 			// ADR-055: TargetInOwnerChain replaced by RemediationTarget
@@ -471,6 +471,20 @@ var _ = Describe("AnalyzingHandler", func() {
 				Expect(spy.LastInput.RemediationTarget.Namespace).To(Equal("production"))
 			})
 
+			// #247: ActionType is catalog-authoritative (DD-WORKFLOW-016), unlike
+			// RemediationTarget.Kind which is LLM-inferred, so it's a reliable
+			// gating signal for infrastructure-impacting actions like ProvisionNode.
+			It("should pass ActionType from SelectedWorkflow to policy input", func() {
+				analysis := createTestAnalysis()
+				analysis.Status.SelectedWorkflow.ActionType = "ProvisionNode"
+
+				_, err := handler.Handle(ctx, analysis)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(spy.LastInput).NotTo(BeNil())
+				Expect(spy.LastInput.ActionType).To(Equal("ProvisionNode"))
+			})
+
 			It("should pass Warnings from status", func() {
 				analysis := createTestAnalysis()
 				analysis.Status.Warnings = []string{"High memory pressure", "Node scheduling delayed"}
@@ -479,8 +493,8 @@ var _ = Describe("AnalyzingHandler", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(spy.LastInput).NotTo(BeNil())
-				Expect(spy.LastInput.Warnings).To(HaveLen(2))
-				Expect(spy.LastInput.Warnings).To(ContainElement("High memory pressure"))
+				Expect(spy.LastInput.KAResponse.Warnings).To(HaveLen(2))
+				Expect(spy.LastInput.KAResponse.Warnings).To(ContainElement("High memory pressure"))
 			})
 
 			// BR-AI-012: Extended PolicyInput fields (per IMPLEMENTATION_PLAN_V1.0.md)
@@ -494,9 +508,9 @@ var _ = Describe("AnalyzingHandler", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(spy.LastInput).NotTo(BeNil())
-				Expect(spy.LastInput.SignalType).To(Equal("OOMKilled"))
-				Expect(spy.LastInput.Severity).To(Equal("critical"))
-				Expect(spy.LastInput.BusinessPriority).To(Equal("P0"))
+				Expect(spy.LastInput.SignalContext.SignalType).To(Equal("OOMKilled"))
+				Expect(spy.LastInput.SignalContext.Severity).To(Equal("critical"))
+				Expect(spy.LastInput.SignalContext.BusinessPriority).To(Equal("P0"))
 			})
 
 			It("should pass target resource fields", func() {
@@ -529,11 +543,11 @@ var _ = Describe("AnalyzingHandler", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(spy.LastInput).NotTo(BeNil())
-				Expect(spy.LastInput.CustomLabels).NotTo(BeNil())
-				Expect(spy.LastInput.CustomLabels["constraint"]).To(ContainElement("cost-constrained"))
-				Expect(spy.LastInput.CustomLabels["constraint"]).To(ContainElement("stateful-safe"))
-				Expect(spy.LastInput.CustomLabels["team"]).To(ContainElement("name=payments"))
-				Expect(spy.LastInput.CustomLabels["region"]).To(ContainElement("us-east-1"))
+				Expect(spy.LastInput.Classification.CustomLabels).NotTo(BeNil())
+				Expect(spy.LastInput.Classification.CustomLabels["constraint"]).To(ContainElement("cost-constrained"))
+				Expect(spy.LastInput.Classification.CustomLabels["constraint"]).To(ContainElement("stateful-safe"))
+				Expect(spy.LastInput.Classification.CustomLabels["team"]).To(ContainElement("name=payments"))
+				Expect(spy.LastInput.Classification.CustomLabels["region"]).To(ContainElement("us-east-1"))
 			})
 
 			// BR-AI-012: Empty CustomLabels returns empty map
@@ -547,8 +561,8 @@ var _ = Describe("AnalyzingHandler", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(spy.LastInput).NotTo(BeNil())
-				Expect(spy.LastInput.CustomLabels).NotTo(BeNil())
-				Expect(spy.LastInput.CustomLabels).To(BeEmpty())
+				Expect(spy.LastInput.Classification.CustomLabels).NotTo(BeNil())
+				Expect(spy.LastInput.Classification.CustomLabels).To(BeEmpty())
 			})
 
 			// BR-SP-002, BR-SP-080, BR-SP-081: BusinessClassification pass-through to Rego policy
@@ -565,11 +579,11 @@ var _ = Describe("AnalyzingHandler", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(spy.LastInput).NotTo(BeNil())
-				Expect(spy.LastInput.BusinessClassification).NotTo(BeNil())
-				Expect(spy.LastInput.BusinessClassification).To(HaveKeyWithValue("business_unit", "payments"))
-				Expect(spy.LastInput.BusinessClassification).To(HaveKeyWithValue("service_owner", "team-checkout"))
-				Expect(spy.LastInput.BusinessClassification).To(HaveKeyWithValue("criticality", string(sharedtypes.CriticalityCritical)))
-				Expect(spy.LastInput.BusinessClassification).To(HaveKeyWithValue("sla_requirement", string(sharedtypes.SLARequirementPlatinum)))
+				Expect(spy.LastInput.Classification.BusinessClassification).NotTo(BeNil())
+				Expect(spy.LastInput.Classification.BusinessClassification).To(HaveKeyWithValue("business_unit", "payments"))
+				Expect(spy.LastInput.Classification.BusinessClassification).To(HaveKeyWithValue("service_owner", "team-checkout"))
+				Expect(spy.LastInput.Classification.BusinessClassification).To(HaveKeyWithValue("criticality", string(sharedtypes.CriticalityCritical)))
+				Expect(spy.LastInput.Classification.BusinessClassification).To(HaveKeyWithValue("sla_requirement", string(sharedtypes.SLARequirementPlatinum)))
 			})
 
 			It("should not set BusinessClassification when nil in EnrichmentResults", func() {
@@ -580,7 +594,7 @@ var _ = Describe("AnalyzingHandler", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(spy.LastInput).NotTo(BeNil())
-				Expect(spy.LastInput.BusinessClassification).To(BeNil())
+				Expect(spy.LastInput.Classification.BusinessClassification).To(BeNil())
 			})
 
 			It("should map only populated BusinessClassification fields", func() {
@@ -593,8 +607,8 @@ var _ = Describe("AnalyzingHandler", func() {
 
 				Expect(err).NotTo(HaveOccurred())
 				Expect(spy.LastInput).NotTo(BeNil())
-				Expect(spy.LastInput.BusinessClassification).To(HaveLen(1))
-				Expect(spy.LastInput.BusinessClassification).To(HaveKeyWithValue("criticality", string(sharedtypes.CriticalityHigh)))
+				Expect(spy.LastInput.Classification.BusinessClassification).To(HaveLen(1))
+				Expect(spy.LastInput.Classification.BusinessClassification).To(HaveKeyWithValue("criticality", string(sharedtypes.CriticalityHigh)))
 			})
 		})
 

--- a/pkg/aianalysis/handlers/analyzing.go
+++ b/pkg/aianalysis/handlers/analyzing.go
@@ -384,10 +384,12 @@ func (h *AnalyzingHandler) populateApprovalContext(analysis *aianalysisv1.AIAnal
 func (h *AnalyzingHandler) buildPolicyInput(analysis *aianalysisv1.AIAnalysis) *rego.PolicyInput {
 	input := &rego.PolicyInput{
 		// Signal context (from Spec.AnalysisRequest.SignalContext)
-		SignalType:       analysis.Spec.AnalysisRequest.SignalContext.SignalName,
-		Severity:         analysis.Spec.AnalysisRequest.SignalContext.Severity,
-		Environment:      analysis.Spec.AnalysisRequest.SignalContext.Environment,
-		BusinessPriority: analysis.Spec.AnalysisRequest.SignalContext.BusinessPriority,
+		SignalContext: rego.SignalContextInput{
+			SignalType:       analysis.Spec.AnalysisRequest.SignalContext.SignalName,
+			Severity:         analysis.Spec.AnalysisRequest.SignalContext.Severity,
+			Environment:      analysis.Spec.AnalysisRequest.SignalContext.Environment,
+			BusinessPriority: analysis.Spec.AnalysisRequest.SignalContext.BusinessPriority,
+		},
 
 		// Target resource
 		TargetResource: rego.TargetResourceInput{
@@ -397,12 +399,17 @@ func (h *AnalyzingHandler) buildPolicyInput(analysis *aianalysisv1.AIAnalysis) *
 		},
 
 		// KA response data
-		Warnings: analysis.Status.Warnings,
+		KAResponse: rego.KAResponseInput{
+			Warnings: analysis.Status.Warnings,
+		},
 	}
 
-	// Get confidence from SelectedWorkflow (populated by InvestigatingHandler)
+	// Get confidence and action type from SelectedWorkflow (populated by InvestigatingHandler)
+	// #247: ActionType enables infrastructure-action approval gating independent
+	// of remediation_target.kind (see rego.PolicyInput.ActionType doc comment).
 	if analysis.Status.SelectedWorkflow != nil {
-		input.Confidence = analysis.Status.SelectedWorkflow.Confidence
+		input.KAResponse.Confidence = analysis.Status.SelectedWorkflow.Confidence
+		input.ActionType = analysis.Status.SelectedWorkflow.ActionType
 	}
 
 	// ADR-055: Populate RemediationTarget for Rego policy evaluation
@@ -417,25 +424,25 @@ func (h *AnalyzingHandler) buildPolicyInput(analysis *aianalysisv1.AIAnalysis) *
 
 	// ADR-056: DetectedLabels read exclusively from PostRCAContext (HAPI post-RCA).
 	dl := h.resolveDetectedLabels(analysis)
-	input.DetectedLabels = h.detectedLabelsToMap(dl)
+	input.Classification.DetectedLabels = h.detectedLabelsToMap(dl)
 
 	if dl != nil {
-		input.FailedDetections = dl.FailedDetections
+		input.KAResponse.FailedDetections = dl.FailedDetections
 	}
 
 	// Populate CustomLabels from EnrichmentResults (Issue #113: now on KubernetesContext)
 	er := analysis.Spec.AnalysisRequest.SignalContext.EnrichmentResults
 	if er.KubernetesContext != nil && er.KubernetesContext.CustomLabels != nil {
-		input.CustomLabels = er.KubernetesContext.CustomLabels
+		input.Classification.CustomLabels = er.KubernetesContext.CustomLabels
 	} else {
-		input.CustomLabels = make(map[string][]string)
+		input.Classification.CustomLabels = make(map[string][]string)
 	}
 
 	// #225: Pass operator-configurable threshold to Rego policy
 	input.ConfidenceThreshold = h.confidenceThreshold
 
 	// Populate BusinessClassification from EnrichmentResults (BR-SP-002, BR-SP-080, BR-SP-081)
-	input.BusinessClassification = buildBusinessClassification(er.BusinessClassification)
+	input.Classification.BusinessClassification = buildBusinessClassification(er.BusinessClassification)
 
 	// #774: Populate identity from InteractiveSession status (user-driven flows).
 	// Nil for autonomous (alert-driven) flows; Rego policies handle absence

--- a/pkg/aianalysis/rego/evaluator.go
+++ b/pkg/aianalysis/rego/evaluator.go
@@ -47,38 +47,72 @@ type IdentityInput struct {
 	Groups []string `json:"groups,omitempty"`
 }
 
-// PolicyInput represents input to Rego policy
-// Per IMPLEMENTATION_PLAN_V1.0.md lines 1756-1785 (ApprovalInput schema)
-// Fields align with AIAnalysis status fields captured by InvestigatingHandler
-type PolicyInput struct {
-	// Signal context (from SignalProcessing)
+// SignalContextInput carries signal-source metadata (from SignalProcessing)
+// used by Rego policies for environment/severity/priority-based approval
+// rules. Grouped out of PolicyInput (Go Anti-Pattern Checklist "God struct"
+// remediation, #247 follow-up) — these four fields are always populated
+// together from AnalysisRequest.SignalContext.
+type SignalContextInput struct {
 	SignalType       string `json:"signal_type"`
 	Severity         string `json:"severity"`
 	Environment      string `json:"environment"`
 	BusinessPriority string `json:"business_priority"`
+}
 
-	// Target resource
-	TargetResource TargetResourceInput `json:"target_resource"`
-
-	// Detected labels (ADR-056: computed by KA post-RCA)
+// ClassificationInput carries label and business-classification metadata
+// used by Rego policies for classification-based approval rules. Grouped
+// out of PolicyInput (Go Anti-Pattern Checklist "God struct" remediation,
+// #247 follow-up) — these fields are all sourced from EnrichmentResults/
+// post-RCA context, distinct from the KA investigation response.
+type ClassificationInput struct {
+	// DetectedLabels (ADR-056: computed by KA post-RCA)
 	DetectedLabels map[string]interface{} `json:"detected_labels"`
 
-	// Custom labels (customer-defined via Rego)
+	// CustomLabels (customer-defined via Rego)
 	CustomLabels map[string][]string `json:"custom_labels"`
 
-	// Business classification from SP categorization (BR-SP-002, BR-SP-080, BR-SP-081)
+	// BusinessClassification from SP categorization (BR-SP-002, BR-SP-080, BR-SP-081)
 	BusinessClassification map[string]string `json:"business_classification,omitempty"`
+}
 
-	// KA response data
+// KAResponseInput carries fields populated from the Kubernaut Agent's (KA)
+// investigation/RCA response. Grouped out of PolicyInput (Go Anti-Pattern
+// Checklist "God struct" remediation, #247 follow-up).
+type KAResponseInput struct {
 	Confidence float64  `json:"confidence"`
 	Warnings   []string `json:"warnings,omitempty"`
+
+	// FailedDetections (DD-WORKFLOW-001 v2.1)
+	FailedDetections []string `json:"failed_detections,omitempty"`
+}
+
+// PolicyInput represents input to Rego policy
+// Per IMPLEMENTATION_PLAN_V1.0.md lines 1756-1785 (ApprovalInput schema)
+// Fields align with AIAnalysis status fields captured by InvestigatingHandler
+//
+// Field groups (SignalContext/Classification/KAResponse) are Go-side
+// organization only — buildRegoInputMap still flattens them to the same
+// top-level Rego input keys (e.g. input.environment, input.confidence), so
+// this restructuring does not change the Rego policy contract. Introduced
+// to keep the top-level field count away from the "God struct" threshold
+// (AGENTS.md Go Anti-Pattern Checklist) as the schema has grown across many
+// BRs (#225, #774, #247).
+type PolicyInput struct {
+	// SignalContext carries signal-source metadata (from SignalProcessing).
+	SignalContext SignalContextInput `json:"signal_context"`
+
+	// TargetResource identifies the resource the signal was raised against.
+	TargetResource TargetResourceInput `json:"target_resource"`
+
+	// Classification carries label/business-classification metadata.
+	Classification ClassificationInput `json:"classification"`
+
+	// KAResponse carries fields from the Kubernaut Agent's investigation response.
+	KAResponse KAResponseInput `json:"ka_response"`
 
 	// ADR-055: Remediation target identified by LLM during RCA
 	// Replaces target_in_owner_chain boolean with structured resource data
 	RemediationTarget *RemediationTargetInput `json:"remediation_target,omitempty"`
-
-	// FailedDetections (DD-WORKFLOW-001 v2.1)
-	FailedDetections []string `json:"failed_detections,omitempty"`
 
 	// #225: Operator-configurable confidence threshold for auto-approval.
 	// When nil, the Rego policy uses its built-in default (0.8).
@@ -90,6 +124,15 @@ type PolicyInput struct {
 	// access input.identity.user and input.identity.groups for role-based
 	// approval decisions (BR-AI-085, #774).
 	Identity *IdentityInput `json:"identity,omitempty"`
+
+	// ActionType is the catalog action type selected for remediation
+	// (DD-WORKFLOW-016 taxonomy, e.g. ScaleReplicas, ProvisionNode).
+	// Unlike RemediationTarget.Kind, this is catalog-authoritative (sourced
+	// from the action_type_taxonomy table via KA's three-step discovery),
+	// not LLM-inferred, enabling reliable gating on infrastructure-impacting
+	// actions regardless of which resource the LLM reports as the
+	// remediation target (BR-AI-085 FR-AI-085-006, #247).
+	ActionType string `json:"action_type"`
 }
 
 // TargetResourceInput contains target resource identification
@@ -221,10 +264,10 @@ func (e *Evaluator) resolveCompiledQuery(ctx context.Context) (rego.PreparedEval
 func buildRegoInputMap(input *PolicyInput) map[string]interface{} {
 	inputMap := map[string]interface{}{
 		// Signal context
-		"signal_type":       input.SignalType,
-		"severity":          input.Severity,
-		"environment":       input.Environment,
-		"business_priority": input.BusinessPriority,
+		"signal_type":       input.SignalContext.SignalType,
+		"severity":          input.SignalContext.Severity,
+		"environment":       input.SignalContext.Environment,
+		"business_priority": input.SignalContext.BusinessPriority,
 		// Target resource
 		"target_resource": map[string]interface{}{
 			"kind":      input.TargetResource.Kind,
@@ -232,17 +275,19 @@ func buildRegoInputMap(input *PolicyInput) map[string]interface{} {
 			"namespace": input.TargetResource.Namespace,
 		},
 		// Detected labels
-		"detected_labels": input.DetectedLabels,
-		"custom_labels":   input.CustomLabels,
+		"detected_labels": input.Classification.DetectedLabels,
+		"custom_labels":   input.Classification.CustomLabels,
 		// Business classification (BR-SP-002)
-		"business_classification": input.BusinessClassification,
+		"business_classification": input.Classification.BusinessClassification,
 		// KA response data
-		"confidence": input.Confidence,
-		"warnings":   input.Warnings,
+		"confidence": input.KAResponse.Confidence,
+		"warnings":   input.KAResponse.Warnings,
 		// ADR-055: Remediation target for granular per-kind policies
 		"remediation_target": input.RemediationTarget,
 		// FailedDetections
-		"failed_detections": input.FailedDetections,
+		"failed_detections": input.KAResponse.FailedDetections,
+		// #247: Catalog-authoritative action type for infrastructure-action gating
+		"action_type": input.ActionType,
 	}
 
 	// #225: Only include confidence_threshold when explicitly configured.

--- a/pkg/aianalysis/rego_case_insensitive_test.go
+++ b/pkg/aianalysis/rego_case_insensitive_test.go
@@ -69,11 +69,13 @@ var _ = Describe("Rego Case-Insensitive Matching (#604)", func() {
 		DescribeTable("UT-AIA-604: case-insensitive environment matching",
 			func(env string, confidence float64, remediationTarget *rego.RemediationTargetInput, expectedApproval bool, description string) {
 				input := &rego.PolicyInput{
-					Environment:       env,
-					Confidence:        confidence,
+					SignalContext:     rego.SignalContextInput{Environment: env},
 					RemediationTarget: remediationTarget,
-					FailedDetections:  []string{},
-					Warnings:          []string{},
+					KAResponse: rego.KAResponseInput{
+						Confidence:       confidence,
+						FailedDetections: []string{},
+						Warnings:         []string{},
+					},
 				}
 
 				result, err := evaluator.Evaluate(ctx, input)
@@ -119,14 +121,15 @@ var _ = Describe("Rego Case-Insensitive Matching (#604)", func() {
 
 		It("UT-AIA-604-005: PascalCase 'Critical' severity is recognized", func() {
 			input := &rego.PolicyInput{
-				Severity:    "Critical",
-				Environment: "production",
+				SignalContext: rego.SignalContextInput{Severity: "Critical", Environment: "production"},
 				RemediationTarget: &rego.RemediationTargetInput{
 					Kind: "Deployment", Name: "api", Namespace: "production",
 				},
-				Confidence:       0.9,
-				FailedDetections: []string{},
-				Warnings:         []string{},
+				KAResponse: rego.KAResponseInput{
+					Confidence:       0.9,
+					FailedDetections: []string{},
+					Warnings:         []string{},
+				},
 			}
 
 			result, err := evaluator.Evaluate(ctx, input)

--- a/pkg/aianalysis/rego_evaluator_test.go
+++ b/pkg/aianalysis/rego_evaluator_test.go
@@ -74,17 +74,21 @@ var _ = Describe("RegoEvaluator", func() {
 			// BR-AI-013, #206: Production with clean state and confidence >= 0.8 → auto-approve
 			It("should auto-approve production environment with clean state and high confidence", func() {
 				input := &rego.PolicyInput{
-					Environment: "production",
+					SignalContext: rego.SignalContextInput{Environment: "production"},
 					RemediationTarget: &rego.RemediationTargetInput{
 						Kind: "Deployment", Name: "api", Namespace: "production",
 					},
-					Confidence: 0.85,
-					DetectedLabels: map[string]interface{}{
-						"gitOpsManaged": true,
-						"pdbProtected":  true,
+					Classification: rego.ClassificationInput{
+						DetectedLabels: map[string]interface{}{
+							"gitOpsManaged": true,
+							"pdbProtected":  true,
+						},
 					},
-					FailedDetections: []string{},
-					Warnings:         []string{},
+					KAResponse: rego.KAResponseInput{
+						Confidence:       0.85,
+						FailedDetections: []string{},
+						Warnings:         []string{},
+					},
 				}
 
 				result, err := evaluator.Evaluate(ctx, input)
@@ -112,11 +116,13 @@ var _ = Describe("RegoEvaluator", func() {
 			DescribeTable("based on environment and data quality",
 				func(env string, remediationTarget *rego.RemediationTargetInput, confidence float64, failedDetections []string, warnings []string, expectedApproval bool) {
 					input := &rego.PolicyInput{
-						Environment:      env,
+						SignalContext:     rego.SignalContextInput{Environment: env},
 						RemediationTarget: remediationTarget,
-						Confidence:       confidence,
-						FailedDetections: failedDetections,
-						Warnings:         warnings,
+						KAResponse: rego.KAResponseInput{
+							Confidence:       confidence,
+							FailedDetections: failedDetections,
+							Warnings:         warnings,
+						},
 					}
 
 					result, err := evaluator.Evaluate(ctx, input)
@@ -150,11 +156,13 @@ var _ = Describe("RegoEvaluator", func() {
 		DescribeTable("confidence-based auto-approval in production",
 			func(confidence float64, remediationTarget *rego.RemediationTargetInput, failedDetections []string, warnings []string, expectedApproval bool, expectedReasonSubstring string) {
 				input := &rego.PolicyInput{
-					Environment:      "production",
+					SignalContext:     rego.SignalContextInput{Environment: "production"},
 					RemediationTarget: remediationTarget,
-					Confidence:       confidence,
-					FailedDetections: failedDetections,
-					Warnings:         warnings,
+					KAResponse: rego.KAResponseInput{
+						Confidence:       confidence,
+						FailedDetections: failedDetections,
+						Warnings:         warnings,
+					},
 				}
 
 				result, err := evaluator.Evaluate(ctx, input)
@@ -210,12 +218,11 @@ var _ = Describe("RegoEvaluator", func() {
 		DescribeTable("based on environment and severity",
 				func(severity string, env string, expectedApproval bool) {
 					input := &rego.PolicyInput{
-						Environment: env,
+						SignalContext: rego.SignalContextInput{Environment: env, Severity: severity},
 						RemediationTarget: &rego.RemediationTargetInput{
 							Kind: "Deployment", Name: "api", Namespace: env,
 						},
-						Confidence: 0.9, // High confidence
-						Severity:   severity,
+						KAResponse: rego.KAResponseInput{Confidence: 0.9}, // High confidence
 					}
 
 					result, err := evaluator.Evaluate(ctx, input)
@@ -240,20 +247,62 @@ var _ = Describe("RegoEvaluator", func() {
 					"P0", "staging", false),
 			)
 
+		// #247: Infrastructure-impacting action types (e.g. ProvisionNode) must
+		// always require approval, since the LLM-reported remediation_target
+		// (e.g. the source Deployment) does not reflect the actual infrastructure
+		// being provisioned. action_type is catalog-authoritative (DD-WORKFLOW-016),
+		// unlike remediation_target.kind which is LLM-inferred.
+		DescribeTable("infrastructure-impacting action approval based on action_type",
+			func(actionType string, confidence float64, remediationTarget *rego.RemediationTargetInput, expectedApproval bool, desc string) {
+				input := &rego.PolicyInput{
+					SignalContext:     rego.SignalContextInput{Environment: "development"}, // non-production: would otherwise auto-approve
+					ActionType:        actionType,
+					RemediationTarget: remediationTarget,
+					KAResponse: rego.KAResponseInput{
+						Confidence:       confidence,
+						FailedDetections: []string{},
+						Warnings:         []string{},
+					},
+				}
+
+				result, err := evaluator.Evaluate(ctx, input)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.ApprovalRequired).To(Equal(expectedApproval), desc)
+			},
+			Entry("UT-AIA-ACT-001: ProvisionNode + high confidence + non-production → require approval",
+				"ProvisionNode", 0.99,
+				&rego.RemediationTargetInput{Kind: "Deployment", Name: "batch-processor", Namespace: "default"},
+				true, "action_type=ProvisionNode must force approval regardless of confidence/environment/remediation_target.kind"),
+			Entry("UT-AIA-ACT-002: ProvisionNode + missing remediation_target → require approval",
+				"ProvisionNode", 0.99, (*rego.RemediationTargetInput)(nil),
+				true, "action_type=ProvisionNode must force approval even without a remediation_target"),
+			Entry("UT-AIA-ACT-003: non-infrastructure action_type + high confidence + non-production → auto-approve",
+				"ScaleReplicas", 0.99,
+				&rego.RemediationTargetInput{Kind: "Deployment", Name: "api", Namespace: "default"},
+				false, "unrelated action_type must not trigger the infrastructure-action rule"),
+			Entry("UT-AIA-ACT-004: empty action_type + high confidence + non-production → auto-approve",
+				"", 0.99,
+				&rego.RemediationTargetInput{Kind: "Deployment", Name: "api", Namespace: "default"},
+				false, "empty action_type must not falsely match the infrastructure-action rule"),
+		)
+
 		// #225: Configurable confidence threshold via input.confidence_threshold
 		// The Rego policy should read confidence_threshold from input when provided,
 		// falling back to its built-in default (0.8) when not provided.
 		DescribeTable("configurable confidence threshold (#225)",
 			func(confidence float64, threshold *float64, expectedApproval bool, desc string) {
 				input := &rego.PolicyInput{
-					Environment: "production",
+					SignalContext: rego.SignalContextInput{Environment: "production"},
 					RemediationTarget: &rego.RemediationTargetInput{
 						Kind: "Deployment", Name: "api", Namespace: "production",
 					},
-					Confidence:          confidence,
 					ConfidenceThreshold: threshold,
-					FailedDetections:    []string{},
-					Warnings:            []string{},
+					KAResponse: rego.KAResponseInput{
+						Confidence:       confidence,
+						FailedDetections: []string{},
+						Warnings:         []string{},
+					},
 				}
 
 				result, err := evaluator.Evaluate(ctx, input)
@@ -288,10 +337,12 @@ var _ = Describe("RegoEvaluator", func() {
 		Context("handles signal context fields", func() {
 				It("should pass all signal context fields to policy", func() {
 					input := &rego.PolicyInput{
-						SignalType:       "OOMKilled",
-						Severity:         "critical",
-						Environment:      "development",
-						BusinessPriority: "P0",
+						SignalContext: rego.SignalContextInput{
+							SignalType:       "OOMKilled",
+							Severity:         "critical",
+							Environment:      "development",
+							BusinessPriority: "P0",
+						},
 						TargetResource: rego.TargetResourceInput{
 							Kind:      "Pod",
 							Name:      "test-pod",
@@ -300,7 +351,7 @@ var _ = Describe("RegoEvaluator", func() {
 						RemediationTarget: &rego.RemediationTargetInput{
 							Kind: "Deployment", Name: "api", Namespace: "default",
 						},
-						Confidence: 0.9,
+						KAResponse: rego.KAResponseInput{Confidence: 0.9},
 					}
 
 					result, err := evaluator.Evaluate(ctx, input)
@@ -322,7 +373,7 @@ var _ = Describe("RegoEvaluator", func() {
 
 			It("should default to manual approval (graceful degradation)", func() {
 				result, err := evaluator.Evaluate(ctx, &rego.PolicyInput{
-					Environment: "production",
+					SignalContext: rego.SignalContextInput{Environment: "production"},
 				})
 
 				// Should not error - graceful degradation
@@ -342,7 +393,7 @@ var _ = Describe("RegoEvaluator", func() {
 
 			It("should default to manual approval (graceful degradation)", func() {
 				result, err := evaluator.Evaluate(ctx, &rego.PolicyInput{
-					Environment: "production",
+					SignalContext: rego.SignalContextInput{Environment: "production"},
 				})
 
 				Expect(err).NotTo(HaveOccurred())

--- a/pkg/aianalysis/rego_identity_test.go
+++ b/pkg/aianalysis/rego_identity_test.go
@@ -49,9 +49,8 @@ var _ = Describe("Rego Identity Input — #774, BR-AI-085, BR-INTERACTIVE-001", 
 	Describe("UT-KA-774-009: Rego evaluator includes identity in inputMap when present", func() {
 		It("should auto-approve when identity has SRE group (policy checks input.identity.groups)", func() {
 			input := &rego.PolicyInput{
-				SignalType: "alert",
-				Severity:   "high",
-				Confidence: 0.95,
+				SignalContext: rego.SignalContextInput{SignalType: "alert", Severity: "high"},
+				KAResponse:    rego.KAResponseInput{Confidence: 0.95},
 				Identity: &rego.IdentityInput{
 					User:   "alice@example.com",
 					Groups: []string{"engineering", "sre"},
@@ -67,9 +66,8 @@ var _ = Describe("Rego Identity Input — #774, BR-AI-085, BR-INTERACTIVE-001", 
 
 		It("should require approval when identity has no SRE group", func() {
 			input := &rego.PolicyInput{
-				SignalType: "alert",
-				Severity:   "high",
-				Confidence: 0.95,
+				SignalContext: rego.SignalContextInput{SignalType: "alert", Severity: "high"},
+				KAResponse:    rego.KAResponseInput{Confidence: 0.95},
 				Identity: &rego.IdentityInput{
 					User:   "bob@example.com",
 					Groups: []string{"engineering", "dev"},
@@ -86,10 +84,9 @@ var _ = Describe("Rego Identity Input — #774, BR-AI-085, BR-INTERACTIVE-001", 
 	Describe("UT-KA-774-010: Nil identity handled gracefully in Rego input", func() {
 		It("should not panic when Identity is nil (autonomous flow)", func() {
 			input := &rego.PolicyInput{
-				SignalType: "alert",
-				Severity:   "warning",
-				Confidence: 0.9,
-				Identity:   nil,
+				SignalContext: rego.SignalContextInput{SignalType: "alert", Severity: "warning"},
+				KAResponse:    rego.KAResponseInput{Confidence: 0.9},
+				Identity:      nil,
 			}
 
 			result, err := evaluator.Evaluate(context.Background(), input)
@@ -102,9 +99,8 @@ var _ = Describe("Rego Identity Input — #774, BR-AI-085, BR-INTERACTIVE-001", 
 	Describe("UT-KA-774-011: buildPolicyInput produces nil identity for non-interactive flows", func() {
 		It("should produce PolicyInput with nil Identity by default", func() {
 			input := &rego.PolicyInput{
-				SignalType: "alert",
-				Severity:   "low",
-				Confidence: 0.8,
+				SignalContext: rego.SignalContextInput{SignalType: "alert", Severity: "low"},
+				KAResponse:    rego.KAResponseInput{Confidence: 0.8},
 			}
 
 			Expect(input.Identity).To(BeNil(),

--- a/pkg/aianalysis/rego_startup_validation_test.go
+++ b/pkg/aianalysis/rego_startup_validation_test.go
@@ -118,8 +118,8 @@ approval {
 				// Verify Evaluate() uses cached policy (no file I/O)
 				// If caching works, should be able to Evaluate even if file is deleted
 				result, err := evaluator.Evaluate(ctx, &rego.PolicyInput{
-					Environment: "staging",
-					Confidence:  0.9,
+					SignalContext: rego.SignalContextInput{Environment: "staging"},
+					KAResponse:    rego.KAResponseInput{Confidence: 0.9},
 				})
 
 				Expect(err).NotTo(HaveOccurred())
@@ -238,8 +238,8 @@ approval = result if {
 
 			// Verify initial policy works
 			result, err := evaluator.Evaluate(ctx, &rego.PolicyInput{
-				Environment: "staging",
-				Confidence:  0.9,
+				SignalContext: rego.SignalContextInput{Environment: "staging"},
+				KAResponse:    rego.KAResponseInput{Confidence: 0.9},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.ApprovalRequired).To(BeFalse(), "Staging should auto-approve initially")
@@ -262,8 +262,8 @@ approval {
 
 			// Verify evaluator still works with old policy
 			result, err = evaluator.Evaluate(ctx, &rego.PolicyInput{
-				Environment: "staging",
-				Confidence:  0.9,
+				SignalContext: rego.SignalContextInput{Environment: "staging"},
+				KAResponse:    rego.KAResponseInput{Confidence: 0.9},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.ApprovalRequired).To(BeFalse(), "Should still use old policy (graceful degradation)")
@@ -295,8 +295,8 @@ approval = result if {
 
 			// Verify new policy is applied
 			result, err := evaluator.Evaluate(ctx, &rego.PolicyInput{
-				Environment: "production", // Previously required approval
-				Confidence:  0.9,
+				SignalContext: rego.SignalContextInput{Environment: "production"}, // Previously required approval
+				KAResponse:    rego.KAResponseInput{Confidence: 0.9},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.ApprovalRequired).To(BeFalse(), "Production should now auto-approve (new policy)")
@@ -339,8 +339,8 @@ approval = result if {
 
 			// Evaluate should still work (using cached compiled policy)
 			result, err := evaluator.Evaluate(ctx, &rego.PolicyInput{
-				Environment: "staging",
-				Confidence:  0.9,
+				SignalContext: rego.SignalContextInput{Environment: "staging"},
+				KAResponse:    rego.KAResponseInput{Confidence: 0.9},
 			})
 
 			// Note: This test will fail if Evaluate() tries to read from disk

--- a/pkg/aianalysis/testdata/policies/approval.rego
+++ b/pkg/aianalysis/testdata/policies/approval.rego
@@ -31,6 +31,24 @@ has_remediation_target if {
     input.remediation_target.kind != ""
 }
 
+# #247: Infrastructure-provisioning action types always require approval,
+# regardless of the (LLM-reported) remediation_target kind.
+is_infrastructure_action if {
+    input.action_type == "ProvisionNode"
+}
+
+# ADR-055: Check if remediation target is a sensitive kind.
+# Added in REFACTOR (#247) to close a pre-existing divergence from the
+# integration fixture (test/integration/aianalysis/testdata/policies/approval.rego),
+# which already had this rule.
+is_sensitive_resource if {
+    input.remediation_target.kind == "Node"
+}
+
+is_sensitive_resource if {
+    input.remediation_target.kind == "StatefulSet"
+}
+
 has_warnings if {
     count(input.warnings) > 0
 }
@@ -62,6 +80,18 @@ require_approval if {
     not has_remediation_target
 }
 
+# #247: Infrastructure-provisioning actions always require approval
+require_approval if {
+    is_infrastructure_action
+}
+
+# ADR-055: Production + sensitive resource kind ALWAYS requires approval
+# (REFACTOR #247: closes pre-existing divergence from the integration fixture)
+require_approval if {
+    is_production
+    is_sensitive_resource
+}
+
 # Production + low confidence → require approval
 require_approval if {
     is_production
@@ -88,6 +118,18 @@ require_approval if {
 
 risk_factors contains {"score": 90, "reason": "Missing remediation target - cannot determine resource to remediate (BR-AI-085-005)"} if {
     not has_remediation_target
+}
+
+# #247: Highest score -- infrastructure-provisioning actions always require
+# approval, independent of environment/confidence, so the reason must be
+# unambiguous regardless of what other risk factors might also apply.
+risk_factors contains {"score": 95, "reason": "Infrastructure-provisioning action type requires manual approval (#247)"} if {
+    is_infrastructure_action
+}
+
+risk_factors contains {"score": 80, "reason": "Production environment with sensitive resource kind - requires manual approval"} if {
+    is_production
+    is_sensitive_resource
 }
 
 risk_factors contains {"score": 60, "reason": "Data quality issues detected in production environment"} if {

--- a/test/integration/aianalysis/rego_identity_integration_test.go
+++ b/test/integration/aianalysis/rego_identity_integration_test.go
@@ -57,10 +57,8 @@ var _ = Describe("Rego Identity Integration — #774, BR-AI-085", Label("integra
 	Describe("IT-KA-774-003: End-to-end identity chain — buildPolicyInput -> Rego evaluator sees identity", func() {
 		It("should auto-approve when PolicyInput has SRE group identity", func() {
 			input := &rego.PolicyInput{
-				SignalType:  "alert",
-				Severity:    "high",
-				Environment: "production",
-				Confidence:  0.95,
+				SignalContext: rego.SignalContextInput{SignalType: "alert", Severity: "high", Environment: "production"},
+				KAResponse:    rego.KAResponseInput{Confidence: 0.95},
 				TargetResource: rego.TargetResourceInput{
 					Kind:      "Pod",
 					Name:      "api-server-abc123",
@@ -81,10 +79,8 @@ var _ = Describe("Rego Identity Integration — #774, BR-AI-085", Label("integra
 
 		It("should require approval when PolicyInput identity has no SRE group", func() {
 			input := &rego.PolicyInput{
-				SignalType:  "alert",
-				Severity:    "high",
-				Environment: "production",
-				Confidence:  0.95,
+				SignalContext: rego.SignalContextInput{SignalType: "alert", Severity: "high", Environment: "production"},
+				KAResponse:    rego.KAResponseInput{Confidence: 0.95},
 				TargetResource: rego.TargetResourceInput{
 					Kind:      "Pod",
 					Name:      "api-server-abc123",
@@ -104,10 +100,8 @@ var _ = Describe("Rego Identity Integration — #774, BR-AI-085", Label("integra
 
 		It("should require approval when PolicyInput has nil identity (autonomous flow)", func() {
 			input := &rego.PolicyInput{
-				SignalType:  "alert",
-				Severity:    "warning",
-				Environment: "staging",
-				Confidence:  0.90,
+				SignalContext: rego.SignalContextInput{SignalType: "alert", Severity: "warning", Environment: "staging"},
+				KAResponse:    rego.KAResponseInput{Confidence: 0.90},
 				TargetResource: rego.TargetResourceInput{
 					Kind:      "Deployment",
 					Name:      "worker",

--- a/test/integration/aianalysis/rego_integration_test.go
+++ b/test/integration/aianalysis/rego_integration_test.go
@@ -64,11 +64,13 @@ var _ = Describe("Rego Policy Integration", Label("integration", "rego"), func()
 	Context("Production Approval Policy - BR-AI-013", func() {
 		It("should auto-approve staging environment", func() {
 			result, err := evaluator.Evaluate(evalCtx, &rego.PolicyInput{
-				Environment:      "staging",
+				SignalContext:     rego.SignalContextInput{Environment: "staging"},
 				RemediationTarget: &rego.RemediationTargetInput{Kind: "Deployment", Name: "api", Namespace: "staging"},
-				FailedDetections: []string{},
-				Warnings:         []string{},
-				Confidence:       0.95,
+				KAResponse: rego.KAResponseInput{
+					FailedDetections: []string{},
+					Warnings:         []string{},
+					Confidence:       0.95,
+				},
 			})
 
 			Expect(err).NotTo(HaveOccurred())
@@ -80,10 +82,12 @@ var _ = Describe("Rego Policy Integration", Label("integration", "rego"), func()
 		// ADR-055 + BR-AI-085-005: Missing remediation_target = default-deny
 		It("should require approval when remediation target is missing", func() {
 			result, err := evaluator.Evaluate(evalCtx, &rego.PolicyInput{
-				Environment:      "production",
-				FailedDetections: []string{},
-				Warnings:         []string{},
-				Confidence:       0.90,
+				SignalContext: rego.SignalContextInput{Environment: "production"},
+				KAResponse: rego.KAResponseInput{
+					FailedDetections: []string{},
+					Warnings:         []string{},
+					Confidence:       0.90,
+				},
 			})
 
 			Expect(err).NotTo(HaveOccurred())
@@ -94,11 +98,13 @@ var _ = Describe("Rego Policy Integration", Label("integration", "rego"), func()
 
 		It("should require approval for production with failed detections", func() {
 			result, err := evaluator.Evaluate(evalCtx, &rego.PolicyInput{
-				Environment:      "production",
+				SignalContext:     rego.SignalContextInput{Environment: "production"},
 				RemediationTarget: &rego.RemediationTargetInput{Kind: "Deployment", Name: "api", Namespace: "production"},
-				FailedDetections: []string{"gitOpsManaged"},
-				Warnings:         []string{},
-				Confidence:       0.79,
+				KAResponse: rego.KAResponseInput{
+					FailedDetections: []string{"gitOpsManaged"},
+					Warnings:         []string{},
+					Confidence:       0.79,
+				},
 			})
 
 			Expect(err).NotTo(HaveOccurred())
@@ -108,14 +114,18 @@ var _ = Describe("Rego Policy Integration", Label("integration", "rego"), func()
 
 		It("should auto-approve production with all validations passing", func() {
 			result, err := evaluator.Evaluate(evalCtx, &rego.PolicyInput{
-				Environment:      "production",
+				SignalContext:     rego.SignalContextInput{Environment: "production"},
 				RemediationTarget: &rego.RemediationTargetInput{Kind: "Deployment", Name: "api", Namespace: "production"},
-				FailedDetections: []string{},
-				Warnings:         []string{},
-				Confidence:       0.95,
-				DetectedLabels: map[string]interface{}{
-					"gitOpsManaged": true,
-					"pdbProtected":  true,
+				KAResponse: rego.KAResponseInput{
+					FailedDetections: []string{},
+					Warnings:         []string{},
+					Confidence:       0.95,
+				},
+				Classification: rego.ClassificationInput{
+					DetectedLabels: map[string]interface{}{
+						"gitOpsManaged": true,
+						"pdbProtected":  true,
+					},
 				},
 			})
 
@@ -129,10 +139,12 @@ var _ = Describe("Rego Policy Integration", Label("integration", "rego"), func()
 	Context("Environment-Specific Rules - BR-AI-013", func() {
 		It("should auto-approve development environment with affected resource", func() {
 			result, err := evaluator.Evaluate(evalCtx, &rego.PolicyInput{
-				Environment:      "development",
+				SignalContext:     rego.SignalContextInput{Environment: "development"},
 				RemediationTarget: &rego.RemediationTargetInput{Kind: "Deployment", Name: "api", Namespace: "development"},
-				FailedDetections: []string{"gitOpsManaged"},
-				Confidence:       0.50,
+				KAResponse: rego.KAResponseInput{
+					FailedDetections: []string{"gitOpsManaged"},
+					Confidence:       0.50,
+				},
 			})
 
 			Expect(err).NotTo(HaveOccurred())
@@ -141,10 +153,12 @@ var _ = Describe("Rego Policy Integration", Label("integration", "rego"), func()
 
 		It("should auto-approve qa environment", func() {
 			result, err := evaluator.Evaluate(evalCtx, &rego.PolicyInput{
-				Environment:      "qa",
+				SignalContext:     rego.SignalContextInput{Environment: "qa"},
 				RemediationTarget: &rego.RemediationTargetInput{Kind: "Deployment", Name: "api", Namespace: "qa"},
-				FailedDetections: []string{},
-				Confidence:       0.75,
+				KAResponse: rego.KAResponseInput{
+					FailedDetections: []string{},
+					Confidence:       0.75,
+				},
 			})
 
 			Expect(err).NotTo(HaveOccurred())
@@ -153,9 +167,9 @@ var _ = Describe("Rego Policy Integration", Label("integration", "rego"), func()
 
 		It("should auto-approve test environment", func() {
 			result, err := evaluator.Evaluate(evalCtx, &rego.PolicyInput{
-				Environment:      "test",
+				SignalContext:     rego.SignalContextInput{Environment: "test"},
 				RemediationTarget: &rego.RemediationTargetInput{Kind: "Deployment", Name: "api", Namespace: "test"},
-				Confidence:       0.80,
+				KAResponse:        rego.KAResponseInput{Confidence: 0.80},
 			})
 
 			Expect(err).NotTo(HaveOccurred())
@@ -166,11 +180,13 @@ var _ = Describe("Rego Policy Integration", Label("integration", "rego"), func()
 	Context("Warning Handling - BR-AI-011", func() {
 		It("should require approval for production with warnings", func() {
 			result, err := evaluator.Evaluate(evalCtx, &rego.PolicyInput{
-				Environment:      "production",
+				SignalContext:     rego.SignalContextInput{Environment: "production"},
 				RemediationTarget: &rego.RemediationTargetInput{Kind: "Deployment", Name: "api", Namespace: "production"},
-				FailedDetections: []string{},
-				Warnings:         []string{"High resource utilization detected"},
-				Confidence:       0.79,
+				KAResponse: rego.KAResponseInput{
+					FailedDetections: []string{},
+					Warnings:         []string{"High resource utilization detected"},
+					Confidence:       0.79,
+				},
 			})
 
 			Expect(err).NotTo(HaveOccurred())
@@ -184,18 +200,63 @@ var _ = Describe("Rego Policy Integration", Label("integration", "rego"), func()
 			// Kind "Deployment" (not "StatefulSet") isolates the is_stateful rule (score 50)
 			// from the is_sensitive_resource rule (score 80), which would mask the reason.
 			result, err := evaluator.Evaluate(evalCtx, &rego.PolicyInput{
-				Environment:      "production",
+				SignalContext:     rego.SignalContextInput{Environment: "production"},
 				RemediationTarget: &rego.RemediationTargetInput{Kind: "Deployment", Name: "db", Namespace: "production"},
-				FailedDetections: []string{},
-				Confidence:       0.79,
-				DetectedLabels: map[string]interface{}{
-					"stateful": true,
+				KAResponse: rego.KAResponseInput{
+					FailedDetections: []string{},
+					Confidence:       0.79,
+				},
+				Classification: rego.ClassificationInput{
+					DetectedLabels: map[string]interface{}{
+						"stateful": true,
+					},
 				},
 			})
 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.ApprovalRequired).To(BeTrue())
 			Expect(result.Reason).To(ContainSubstring("Stateful"))
+		})
+	})
+
+	// #247: Infrastructure-provisioning action types (e.g. ProvisionNode) must
+	// always require approval, since the LLM-reported remediation_target
+	// reflects the source workload observed during RCA, not the not-yet-created
+	// infrastructure the action actually provisions. action_type is
+	// catalog-authoritative (DD-WORKFLOW-016), unlike remediation_target.kind.
+	Context("Infrastructure Action Approval - #247", func() {
+		It("should require approval for ProvisionNode regardless of confidence, environment, or remediation_target kind", func() {
+			result, err := evaluator.Evaluate(evalCtx, &rego.PolicyInput{
+				SignalContext:     rego.SignalContextInput{Environment: "development"}, // would otherwise auto-approve
+				ActionType:        "ProvisionNode",
+				RemediationTarget: &rego.RemediationTargetInput{Kind: "Deployment", Name: "batch-processor", Namespace: "default"},
+				KAResponse: rego.KAResponseInput{
+					FailedDetections: []string{},
+					Warnings:         []string{},
+					Confidence:       0.99,
+				},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.ApprovalRequired).To(BeTrue())
+			Expect(result.Degraded).To(BeFalse())
+			Expect(result.Reason).To(ContainSubstring("Infrastructure-provisioning"))
+		})
+
+		It("should not require approval for a non-infrastructure action_type outside production", func() {
+			result, err := evaluator.Evaluate(evalCtx, &rego.PolicyInput{
+				SignalContext:     rego.SignalContextInput{Environment: "development"},
+				ActionType:        "ScaleReplicas",
+				RemediationTarget: &rego.RemediationTargetInput{Kind: "Deployment", Name: "api", Namespace: "default"},
+				KAResponse: rego.KAResponseInput{
+					FailedDetections: []string{},
+					Warnings:         []string{},
+					Confidence:       0.99,
+				},
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.ApprovalRequired).To(BeFalse())
 		})
 	})
 
@@ -207,7 +268,7 @@ var _ = Describe("Rego Policy Integration", Label("integration", "rego"), func()
 			}, logr.Discard())
 
 			result, err := badEvaluator.Evaluate(evalCtx, &rego.PolicyInput{
-				Environment: "staging",
+				SignalContext: rego.SignalContextInput{Environment: "staging"},
 			})
 
 			// Should NOT return error - graceful degradation
@@ -223,10 +284,12 @@ var _ = Describe("Rego Policy Integration", Label("integration", "rego"), func()
 		It("should handle complete policy input with all fields", func() {
 			result, err := evaluator.Evaluate(evalCtx, &rego.PolicyInput{
 				// Signal context
-				SignalType:       "alert",
-				Severity:         "high",
-				Environment:      "staging",
-				BusinessPriority: "P1",
+				SignalContext: rego.SignalContextInput{
+					SignalType:       "alert",
+					Severity:         "high",
+					Environment:      "staging",
+					BusinessPriority: "P1",
+				},
 
 				// Target resource
 				TargetResource: rego.TargetResourceInput{
@@ -235,28 +298,28 @@ var _ = Describe("Rego Policy Integration", Label("integration", "rego"), func()
 					Namespace: "staging",
 				},
 
-				// Detected labels
-				DetectedLabels: map[string]interface{}{
-					"gitOpsManaged": true,
-					"pdbProtected":  true,
-					"stateful":      false,
-				},
-
-				// Custom labels
-				CustomLabels: map[string][]string{
-					"team":        {"platform"},
-					"criticality": {"high"},
+				// Detected/custom labels
+				Classification: rego.ClassificationInput{
+					DetectedLabels: map[string]interface{}{
+						"gitOpsManaged": true,
+						"pdbProtected":  true,
+						"stateful":      false,
+					},
+					CustomLabels: map[string][]string{
+						"team":        {"platform"},
+						"criticality": {"high"},
+					},
 				},
 
 				// ADR-055: Affected resource (replaces target_in_owner_chain)
 				RemediationTarget: &rego.RemediationTargetInput{Kind: "Deployment", Name: "web-app", Namespace: "staging"},
 
 				// KA response data
-				Confidence: 0.92,
-				Warnings:   []string{},
-
-				// Failed detections
-				FailedDetections: []string{},
+				KAResponse: rego.KAResponseInput{
+					Confidence:       0.92,
+					Warnings:         []string{},
+					FailedDetections: []string{},
+				},
 			})
 
 			Expect(err).NotTo(HaveOccurred())

--- a/test/integration/aianalysis/testdata/policies/approval.rego
+++ b/test/integration/aianalysis/testdata/policies/approval.rego
@@ -58,6 +58,12 @@ is_sensitive_resource if {
     input.remediation_target.kind == "StatefulSet"
 }
 
+# #247: Infrastructure-provisioning action types always require approval,
+# regardless of the (LLM-reported) remediation_target kind.
+is_infrastructure_action if {
+    input.action_type == "ProvisionNode"
+}
+
 has_warnings if {
     count(input.warnings) > 0
 }
@@ -114,6 +120,12 @@ require_approval if {
     is_sensitive_resource
 }
 
+# #247: Infrastructure-provisioning actions always require approval,
+# regardless of environment or confidence.
+require_approval if {
+    is_infrastructure_action
+}
+
 # Production + failed detections + low confidence
 require_approval if {
     is_production
@@ -152,6 +164,13 @@ risk_factors contains {"score": 90, "reason": "Missing remediation target - cann
 risk_factors contains {"score": 80, "reason": "Production environment with sensitive resource kind - requires manual approval"} if {
     is_production
     is_sensitive_resource
+}
+
+# #247: Highest score -- infrastructure-provisioning actions always require
+# approval, independent of environment/confidence, so the reason must be
+# unambiguous regardless of what other risk factors might also apply.
+risk_factors contains {"score": 95, "reason": "Infrastructure-provisioning action type requires manual approval (#247)"} if {
+    is_infrastructure_action
 }
 
 risk_factors contains {"score": 70, "reason": "Production environment with failed detections - requires manual approval"} if {


### PR DESCRIPTION
## Summary

- Adds `action_type` to the Rego approval policy input so infrastructure-provisioning workflows (e.g. `ProvisionNode`) always require human approval, regardless of `remediation_target.kind` (the source workload the LLM's RCA reports, not the not-yet-created infrastructure the action actually provisions). `action_type` is catalog-authoritative (DD-WORKFLOW-016), unlike `remediation_target.kind` which is LLM-inferred.
- Plumbs `SelectedWorkflow.ActionType` through `buildPolicyInput` → `rego.PolicyInput` → `buildRegoInputMap`, and adds an `is_infrastructure_action` Rego rule integrated into the existing `risk_factors`/reason aggregation (both unit and integration test fixtures). Also closes a pre-existing `is_sensitive_resource` divergence between the two fixtures.
- Follow-up refactor: decomposes `rego.PolicyInput` into `SignalContext`/`Classification`/`KAResponse` sub-structs (Go-side grouping only -- `buildRegoInputMap` still flattens to the same Rego input keys, no policy contract change) to bring the struct back under the AGENTS.md Go Anti-Pattern Checklist's "God struct" threshold, which the `action_type` addition pushed to exactly 15 fields.
- Adds a stale/superseded banner to `REGO_POLICY_EXAMPLES.md`, which predates the current schema and has drifted on multiple fields (not scoped for a full rewrite here).
- Updates BR-AI-085 (new FR-AI-085-006) and DD-AIANALYSIS-001 changelogs.

## Test plan

- [x] Unit tests: `buildPolicyInput` ActionType wiring + Rego rule logic against unit fixture (`go test ./pkg/aianalysis/...`)
- [x] Integration tests: real OPA evaluator against both fixtures (16/16 `rego`-labeled specs passing)
- [x] `go build ./...` / `go vet ./...` clean repo-wide
- [x] `golangci-lint run` -- 0 issues
- [x] CHECKPOINT W: `ActionType` flows through the existing production entry point (`AnalyzingHandler.buildPolicyInput`), no orphaned `pkg/` code

## Related

- Closes #247
- Tracking issue filed on `kubernaut-docs` for the Rego reference guide sync (post-merge)

Made with [Cursor](https://cursor.com)