### PR TITLE
feat(kubernautagent): restart-required LLM identity lock + phase-resolver race fix (#1599, #1610)

### DIFF
--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -497,11 +497,18 @@ func startIdleSessionEviction(pool *ka.KASessionPool, logger logr.Logger) chan s
 	return evictStop
 }
 
-// startConfigWatcher wires CM-02 config file drift detection + audit trail.
-// Returns a cleanup func to stop the watcher; safe to call unconditionally
-// even if the watcher was never started.
-func startConfigWatcher(ctx context.Context, cfg *config.Config, auditor audit.Emitter, logger logr.Logger) func() {
-	cfgWatcher, err := config.NewFileWatcher(configPath, func(newContent []byte) error {
+// configReloadCallback returns the CM-02 config-drift-detection callback used
+// by startConfigWatcher's file watcher. It parses and validates the candidate
+// content for audit/drift-detection purposes only. By design (#1599 /
+// DD-LLM-008: LLM provider/model changes must require a restart, and — since
+// AF has no live-swap mechanism for any config field — every field is
+// effectively restart-only today), the parsed result is never assigned back
+// into cfg or any other live state; a restart is required to actually apply
+// any change, including LLM Provider/Model. See the
+// "configReloadCallback — restart-required LLM identity" Describe block in
+// reload_identity_test.go for the regression coverage proving this.
+func configReloadCallback(cfg *config.Config) func(newContent []byte) error {
+	return func(newContent []byte) error {
 		var newCfg config.Config
 		if err := yaml.Unmarshal(newContent, &newCfg); err != nil {
 			return fmt.Errorf("parse config: %w", err)
@@ -510,7 +517,15 @@ func startConfigWatcher(ctx context.Context, cfg *config.Config, auditor audit.E
 			return fmt.Errorf("resolve defaults: %w", err)
 		}
 		return newCfg.Validate()
-	}, config.WithLogger(logger.WithName("config-watcher")), config.WithAuditor(auditor))
+	}
+}
+
+// startConfigWatcher wires CM-02 config file drift detection + audit trail.
+// Returns a cleanup func to stop the watcher; safe to call unconditionally
+// even if the watcher was never started.
+func startConfigWatcher(ctx context.Context, cfg *config.Config, auditor audit.Emitter, logger logr.Logger) func() {
+	cfgWatcher, err := config.NewFileWatcher(configPath, configReloadCallback(cfg),
+		config.WithLogger(logger.WithName("config-watcher")), config.WithAuditor(auditor))
 	if err != nil {
 		logger.Info("config file watcher unavailable", "error", err)
 		return func() {}

--- a/cmd/apifrontend/reload_identity_suite_test.go
+++ b/cmd/apifrontend/reload_identity_suite_test.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// TestAPIFrontendCmdReloadIdentity is the Ginkgo bootstrap for the #1599
+// restart-required LLM identity regression coverage under package main
+// (configReloadCallback requires same-package test access). Per AGENTS.md
+// ("Testing Requirements": Ginkgo/Gomega BDD is mandatory for business logic
+// tests), new Describe/It coverage in this package should use this suite
+// rather than plain testing.T (pre-existing *_test.go files in this package
+// predate that convention and are out of scope to convert here).
+func TestAPIFrontendCmdReloadIdentity(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "APIFrontend cmd Reload Identity Suite")
+}

--- a/cmd/apifrontend/reload_identity_test.go
+++ b/cmd/apifrontend/reload_identity_test.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/config"
+	"github.com/jordigilh/kubernaut/pkg/shared/types"
+)
+
+// IT-AF-1599-001: AF has no live-swap mechanism for any LLM config field
+// (unlike KA's SwappableClient), so it is restart-only by construction. This
+// test proves that property holds for the CM-02 config-drift-detection
+// callback specifically: a hot-reload attempt that changes LLM Provider/Model
+// (or any other field) must validate successfully (for audit/drift-detection
+// purposes) without ever mutating the live *config.Config passed to
+// startConfigWatcher. See #1599.
+var _ = Describe("configReloadCallback — restart-required LLM identity (#1599)", func() {
+	It("validates a Provider/Model change but never mutates the live config", func() {
+		cfg := &config.Config{}
+		cfg.Agent.LLM.Provider = "openai"
+		cfg.Agent.LLM.Model = "gpt-4o"
+		cfg.SeverityTriage.LLM = &types.LLMConfig{Provider: "openai", Model: "gpt-4o-mini"}
+
+		originalAgentProvider := cfg.Agent.LLM.Provider
+		originalAgentModel := cfg.Agent.LLM.Model
+		originalTriageProvider := cfg.SeverityTriage.LLM.Provider
+		originalTriageModel := cfg.SeverityTriage.LLM.Model
+
+		cb := configReloadCallback(cfg)
+
+		keyFile := filepath.Join(GinkgoT().TempDir(), "anthropic-key")
+		Expect(os.WriteFile(keyFile, []byte("test-key-value"), 0o600)).To(Succeed())
+
+		// Start from a fully-valid default config and only change the fields
+		// under test (Provider/Model, base and SeverityTriage), so the fixture
+		// doesn't need to hand-duplicate every other required field/default.
+		candidate := config.DefaultConfig()
+		candidate.Agent.LLM.Provider = "anthropic"
+		candidate.Agent.LLM.Model = "claude-3-5-sonnet"
+		candidate.Agent.LLM.APIKeyFile = keyFile
+		candidate.SeverityTriage.LLM = &types.LLMConfig{
+			Provider:   "anthropic",
+			Model:      "claude-haiku",
+			APIKeyFile: keyFile,
+		}
+		newContent, marshalErr := yaml.Marshal(candidate)
+		Expect(marshalErr).NotTo(HaveOccurred())
+
+		err := cb(newContent)
+		Expect(err).NotTo(HaveOccurred(), "candidate content must still pass audit/drift-detection validation")
+
+		Expect(cfg.Agent.LLM.Provider).To(Equal(originalAgentProvider), "live config Provider must never be mutated by reload")
+		Expect(cfg.Agent.LLM.Model).To(Equal(originalAgentModel), "live config Model must never be mutated by reload")
+		Expect(cfg.SeverityTriage.LLM.Provider).To(Equal(originalTriageProvider), "live SeverityTriage Provider must never be mutated by reload")
+		Expect(cfg.SeverityTriage.LLM.Model).To(Equal(originalTriageModel), "live SeverityTriage Model must never be mutated by reload")
+	})
+
+	It("rejects invalid content and never mutates the live config", func() {
+		cfg := &config.Config{}
+		cfg.Agent.LLM.Provider = "openai"
+		cfg.Agent.LLM.Model = "gpt-4o"
+
+		cb := configReloadCallback(cfg)
+
+		err := cb([]byte("not: valid: yaml: [structure"))
+		Expect(err).To(HaveOccurred())
+		Expect(cfg.Agent.LLM.Provider).To(Equal("openai"))
+		Expect(cfg.Agent.LLM.Model).To(Equal("gpt-4o"))
+	})
+})

--- a/cmd/kubernautagent/bootstrap.go
+++ b/cmd/kubernautagent/bootstrap.go
@@ -420,17 +420,6 @@ func buildInvestigationRunner(p investigationRunnerParams) *investigationStack {
 	}
 }
 
-// wireHotReload configures conditional server TLS (with hot-reload), the
-// LLM-runtime config watcher, the OCP TLS security profile, and the
-// CA-file watcher. Mutates httpServer.TLSConfig in place when TLS is
-// enabled. Terminates the process on unrecoverable wiring failures, matching
-// the original inline main() behavior.
-//
-// Returns a single cleanup function that stops every watcher that was
-// successfully started; the caller must defer it in its own scope so the
-// watchers live for the server's lifetime, not just this function's call
-// (GO-ANTIPATTERN-AUDIT-2026-07-01 Phase 4f — same pattern as
-// watchLoopState.stopEAWatcher in Phase 4e).
 // wireServerTLS configures conditional TLS on httpServer (Issue #493) and,
 // when TLS is enabled, starts a FileWatcher for hot-reloading the server
 // certificate (Issue #756). Returns a stopper for the cert watcher, or nil
@@ -475,9 +464,10 @@ func wireLLMRuntimeWatcher(
 	llmRuntimePath string,
 	swappable *llm.SwappableClient,
 	phaseResolver *investigator.DefaultPhaseResolver,
+	bootRuntime *kaconfig.LLMRuntimeConfig,
 	logger logr.Logger,
 ) func() {
-	rtCallback := llmRuntimeReloadCallback(cfg, swappable, logger, phaseResolver)
+	rtCallback := llmRuntimeReloadCallback(cfg, swappable, logger, phaseResolver, bootRuntime)
 	rtWatcher, rtWatchErr := hotreload.NewFileWatcher(
 		llmRuntimePath,
 		rtCallback,
@@ -495,6 +485,26 @@ func wireLLMRuntimeWatcher(
 	return rtWatcher.Stop
 }
 
+// hotReloadParams groups wireHotReload's non-context dependencies. Extracted
+// per AGENTS.md's 8+-param Options-pattern rule
+// (GO-ANTIPATTERN-AUDIT-2026-07-01 Phase 4f), same pattern as
+// shutdownDeps/routerBuildParams/handlerDeps in cmd/apifrontend —
+// bootRuntime (#1599) tipped this function's positional param count to 8.
+// ctx is deliberately kept as wireHotReload's own first parameter rather
+// than a struct field (AGENTS.md Go Anti-Pattern Checklist: "Context stored
+// in struct fields").
+type hotReloadParams struct {
+	Cfg            *kaconfig.Config
+	HTTPServer     *http.Server
+	LLMRuntimePath string
+	Swappable      *llm.SwappableClient
+	PhaseResolver  *investigator.DefaultPhaseResolver
+	// BootRuntime is the frozen LLM runtime snapshot loaded at process start,
+	// used to enforce the #1599 restart-required identity lock.
+	BootRuntime *kaconfig.LLMRuntimeConfig
+	Logger      logr.Logger
+}
+
 // wireHotReload configures conditional server TLS (with hot-reload), the
 // LLM-runtime config watcher, the OCP TLS security profile, and the
 // CA-file watcher. Mutates httpServer.TLSConfig in place when TLS is
@@ -506,22 +516,15 @@ func wireLLMRuntimeWatcher(
 // watchers live for the server's lifetime, not just this function's call
 // (GO-ANTIPATTERN-AUDIT-2026-07-01 Phase 4f — same pattern as
 // watchLoopState.stopEAWatcher in Phase 4e).
-func wireHotReload(
-	ctx context.Context,
-	cfg *kaconfig.Config,
-	httpServer *http.Server,
-	llmRuntimePath string,
-	swappable *llm.SwappableClient,
-	phaseResolver *investigator.DefaultPhaseResolver,
-	logger logr.Logger,
-) func() {
+func wireHotReload(ctx context.Context, p hotReloadParams) func() {
+	cfg, httpServer, logger := p.Cfg, p.HTTPServer, p.Logger
 	var stoppers []func()
 
 	if stop := wireServerTLS(ctx, cfg, httpServer, logger); stop != nil {
 		stoppers = append(stoppers, stop)
 	}
 
-	if stop := wireLLMRuntimeWatcher(ctx, cfg, llmRuntimePath, swappable, phaseResolver, logger); stop != nil {
+	if stop := wireLLMRuntimeWatcher(ctx, cfg, p.LLMRuntimePath, p.Swappable, p.PhaseResolver, p.BootRuntime, logger); stop != nil {
 		stoppers = append(stoppers, stop)
 	}
 

--- a/cmd/kubernautagent/llm_builder.go
+++ b/cmd/kubernautagent/llm_builder.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"sort"
 	"strings"
 	"time"
 
@@ -236,30 +237,30 @@ func mergeLLMConfig(base types.LLMConfig, rt *kaconfig.LLMRuntimeConfig) types.L
 // llmRuntimeReloadCallback creates a hotreload.ReloadCallback for LLM runtime
 // config file changes. It parses the new content, validates it, merges with
 // static config, builds a new LLM client, and swaps it into the SwappableClient.
+//
+// #1599 / DD-LLM-008: LLM identity (provider+model, at both base and
+// per-phase-override level) is immutable after process start — a
+// cross-provider hot-swap risks replaying one provider's opaque reasoning
+// signature (e.g. Anthropic's thinking-block Signature bytes) against a
+// different provider/model, which that provider never issued. Any attempt
+// to change identity is rejected in full (the whole candidate reload, base
+// and phase tuning alike) and requires a restart; bootRuntime is the frozen
+// LLM runtime snapshot captured once at boot and is the source of truth for
+// "what identity is this process currently running", independent of
+// anything a later reload attempted.
 func llmRuntimeReloadCallback(
 	staticCfg *kaconfig.Config,
 	swappable *llm.SwappableClient,
 	logger logr.Logger,
 	phaseResolver *investigator.DefaultPhaseResolver,
+	bootRuntime *kaconfig.LLMRuntimeConfig,
 ) func(newContent string) error {
 	return func(newContent string) error {
 		oldModel := swappable.ModelName()
 
-		if strings.TrimSpace(newContent) == "" {
-			logger.Info("llm_runtime_reload rejected: empty content",
-				"event", "llm_runtime_reload", "status", "rejected", "reason", "empty_content")
-			return fmt.Errorf("llm runtime reload rejected: empty or whitespace-only content")
-		}
-
-		rt, err := kaconfig.LoadLLMRuntime([]byte(newContent))
+		rt, err := parseAndAuthorizeReload(staticCfg, phaseResolver, bootRuntime, newContent, logger)
 		if err != nil {
-			return fmt.Errorf("reload: parsing llm runtime config: %w", err)
-		}
-
-		if err := rt.Validate(staticCfg.AI.LLM.Provider); err != nil {
-			logger.Info("llm_runtime_reload rejected: validation failed",
-				"event", "llm_runtime_reload", "status", "rejected", "error", err)
-			return fmt.Errorf("reload: validation failed: %w", err)
+			return err
 		}
 
 		merged := mergeLLMConfig(staticCfg.AI.LLM, rt)
@@ -291,6 +292,92 @@ func llmRuntimeReloadCallback(
 		}
 		return nil
 	}
+}
+
+// parseAndAuthorizeReload parses, validates, and applies the #1599
+// restart-required identity lock to a candidate llm-runtime reload payload.
+// Returns the parsed *kaconfig.LLMRuntimeConfig on success (safe to merge and
+// apply), or an error if the content is empty, malformed, fails field
+// validation, or would change base or per-phase LLM identity. Extracted from
+// llmRuntimeReloadCallback to keep that function's cognitive complexity
+// within the AGENTS.md Go Anti-Pattern Checklist budget.
+func parseAndAuthorizeReload(
+	staticCfg *kaconfig.Config,
+	phaseResolver *investigator.DefaultPhaseResolver,
+	bootRuntime *kaconfig.LLMRuntimeConfig,
+	newContent string,
+	logger logr.Logger,
+) (*kaconfig.LLMRuntimeConfig, error) {
+	if bootRuntime == nil {
+		return nil, fmt.Errorf("reload: internal error: boot runtime snapshot not configured")
+	}
+
+	if strings.TrimSpace(newContent) == "" {
+		logger.Info("llm_runtime_reload rejected: empty content",
+			"event", "llm_runtime_reload", "status", "rejected", "reason", "empty_content")
+		return nil, fmt.Errorf("llm runtime reload rejected: empty or whitespace-only content")
+	}
+
+	rt, err := kaconfig.LoadLLMRuntime([]byte(newContent))
+	if err != nil {
+		return nil, fmt.Errorf("reload: parsing llm runtime config: %w", err)
+	}
+
+	if err := rt.Validate(staticCfg.AI.LLM.Provider); err != nil {
+		logger.Info("llm_runtime_reload rejected: validation failed",
+			"event", "llm_runtime_reload", "status", "rejected", "error", err)
+		return nil, fmt.Errorf("reload: validation failed: %w", err)
+	}
+
+	if rt.Model != bootRuntime.Model {
+		logger.Info("llm_runtime_reload rejected: model change requires restart",
+			"event", "llm_runtime_reload", "status", "rejected", "reason", "identity_change",
+			"boot_model", bootRuntime.Model, "requested_model", rt.Model)
+		return nil, fmt.Errorf("reload: model change from %q to %q requires a process restart (see #1599)", bootRuntime.Model, rt.Model)
+	}
+
+	if phaseResolver != nil {
+		if err := validatePhaseIdentity(staticCfg, bootRuntime, rt); err != nil {
+			logger.Info("llm_runtime_reload rejected: phase identity change requires restart",
+				"event", "llm_runtime_reload", "status", "rejected", "error", err)
+			return nil, fmt.Errorf("reload: %w", err)
+		}
+	}
+
+	return rt, nil
+}
+
+// validatePhaseIdentity checks that no phase's effective LLM identity
+// (provider+model) differs between the frozen boot-time snapshot and the
+// reload candidate. Per #1599, phase identity is subject to the same
+// restart-required rule as base identity; hot-reload may only alter
+// non-identity tuning fields (endpoint, temperature, timeouts, headers,
+// custom auth) within a phase override, whether that override is new,
+// existing, or being removed. Returns a single error naming every phase
+// that would require a restart, or nil if the candidate is safe to apply.
+func validatePhaseIdentity(staticCfg *kaconfig.Config, bootRuntime, rt *kaconfig.LLMRuntimeConfig) error {
+	phases := make(map[string]struct{}, len(bootRuntime.PhaseModels)+len(rt.PhaseModels))
+	for name := range bootRuntime.PhaseModels {
+		phases[name] = struct{}{}
+	}
+	for name := range rt.PhaseModels {
+		phases[name] = struct{}{}
+	}
+
+	violations := make([]string, 0, len(phases))
+	for name := range phases {
+		bootLLM, bootRT := bootRuntime.EffectivePhaseConfig(name, staticCfg.AI.LLM, *bootRuntime)
+		newLLM, newRT := rt.EffectivePhaseConfig(name, staticCfg.AI.LLM, *rt)
+		if bootLLM.Provider != newLLM.Provider || bootRT.Model != newRT.Model {
+			violations = append(violations, fmt.Sprintf("%s: %s/%s -> %s/%s",
+				name, bootLLM.Provider, bootRT.Model, newLLM.Provider, newRT.Model))
+		}
+	}
+	if len(violations) == 0 {
+		return nil
+	}
+	sort.Strings(violations)
+	return fmt.Errorf("phase identity change requires a process restart (see #1599): %s", strings.Join(violations, "; "))
 }
 
 // resolveAPIKeyForReload fills in merged.APIKey when the runtime reload

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -98,12 +98,17 @@ func buildRouterAndRateLimiter(cfg *kaconfig.Config, agentMetrics *kametrics.Met
 // construct the HTTP server, wire hot-reload, and start serving. Extracted
 // per AGENTS.md's 8+-param Options-pattern rule.
 type apiServerStartParams struct {
-	r                  chi.Router
-	cfg                *kaconfig.Config
-	addr               string
-	llmRuntimePath     string
-	swappable          *llm.SwappableClient
-	phaseResolver      *investigator.DefaultPhaseResolver
+	r              chi.Router
+	cfg            *kaconfig.Config
+	addr           string
+	llmRuntimePath string
+	swappable      *llm.SwappableClient
+	phaseResolver  *investigator.DefaultPhaseResolver
+	// bootRuntime is the frozen LLM runtime snapshot loaded at process start.
+	// Threaded into wireHotReload so the reload callback can enforce the
+	// #1599 restart-required identity lock against the boot-time
+	// provider/model, independent of any later reload attempt.
+	bootRuntime        *kaconfig.LLMRuntimeConfig
 	core               *coreServices
 	inv                *investigator.Investigator
 	mgr                *session.Manager
@@ -146,7 +151,10 @@ func startAPIServer(ctx context.Context, p apiServerStartParams) (httpServer *ht
 		// connections that would be killed by a finite WriteTimeout.
 	}
 
-	stopHotReload := wireHotReload(ctx, p.cfg, httpServer, p.llmRuntimePath, p.swappable, p.phaseResolver, p.logger)
+	stopHotReload := wireHotReload(ctx, hotReloadParams{
+		Cfg: p.cfg, HTTPServer: httpServer, LLMRuntimePath: p.llmRuntimePath,
+		Swappable: p.swappable, PhaseResolver: p.phaseResolver, BootRuntime: p.bootRuntime, Logger: p.logger,
+	})
 
 	p.store.StartCleanupLoop(ctx, p.cfg.Runtime.Session.TTL/2)
 
@@ -266,7 +274,7 @@ func main() {
 
 	httpServer, sessionDrainer, cleanupServers := startAPIServer(ctx, apiServerStartParams{
 		r: r, cfg: cfg, addr: addr, llmRuntimePath: llmRuntimePath,
-		swappable: swappable, phaseResolver: stack.phaseResolver, core: core, inv: stack.inv,
+		swappable: swappable, phaseResolver: stack.phaseResolver, bootRuntime: llmRuntime, core: core, inv: stack.inv,
 		mgr: stack.mgr, store: stack.store, agentMetrics: stack.agentMetrics, instrumentedAudit: stack.instrumentedAudit,
 		ogenSrv: stack.ogenSrv, apiRateLimiter: apiRateLimiter, maxRequestBodySize: maxRequestBodySize,
 		apiServerReady: &apiServerReady, logger: logger,

--- a/cmd/kubernautagent/reload_callback_1470_test.go
+++ b/cmd/kubernautagent/reload_callback_1470_test.go
@@ -22,15 +22,19 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	kaconfig "github.com/jordigilh/kubernaut/internal/kubernautagent/config"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 )
 
+// setupPhaseResolver returns a base SwappableClient pinned to "gpt-4" (matching
+// the base model used by every reload YAML in this file) and an empty
+// DefaultPhaseResolver (no boot-time phase overrides).
 func setupPhaseResolver(t testing.TB) (*llm.SwappableClient, *investigator.DefaultPhaseResolver) {
 	t.Helper()
 	inner := &stubLLMClient{}
-	sc, err := llm.NewSwappableClient(inner, "default-model")
+	sc, err := llm.NewSwappableClient(inner, "gpt-4")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,38 +42,51 @@ func setupPhaseResolver(t testing.TB) (*llm.SwappableClient, *investigator.Defau
 	return sc, resolver
 }
 
-var _ = Describe("llmRuntimeReloadCallback — per-phase model wiring (#1470)", func() {
-	// IT-AI-1470-004a (CM-3): Hot-reload with phaseModels rebuild
-	It("rebuilds phase overrides on reload and leaves unlisted phases on the reloaded default", func() {
+var _ = Describe("llmRuntimeReloadCallback — per-phase model wiring (#1470, restart-required identity lock #1599)", func() {
+	// IT-KA-1599-002: tuning an existing-at-boot phase override's non-identity
+	// fields (endpoint) succeeds because the phase's effective identity
+	// (provider+model) does not change.
+	It("accepts tuning an existing phase override's endpoint when identity is unchanged", func() {
 		sc, resolver := setupPhaseResolver(GinkgoTB())
 
-		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), resolver)
+		wfInner := &stubLLMClient{}
+		wfSw, err := llm.NewSwappableClient(wfInner, "gpt-4")
+		Expect(err).NotTo(HaveOccurred())
+		resolver.SetPhaseSwappable(katypes.PhaseWorkflowDiscovery, wfSw)
 
-		err := cb(`model: gpt-4
+		bootRuntime := &kaconfig.LLMRuntimeConfig{
+			Model: "gpt-4",
+			PhaseModels: map[string]*kaconfig.LLMOverrideConfig{
+				"workflow_discovery": {Endpoint: "http://fast-endpoint:11434"},
+			},
+		}
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), resolver, bootRuntime)
+
+		err = cb(`model: gpt-4
 endpoint: http://localhost:11434
 apiKey: test-key
 phaseModels:
   workflow_discovery:
-    model: gpt-4-mini
-    endpoint: http://fast-endpoint:11434
+    endpoint: http://new-fast-endpoint:11434
 `)
 		Expect(err).NotTo(HaveOccurred())
 
 		_, wfModel, _ := resolver.ResolvePhase(katypes.PhaseWorkflowDiscovery)
-		Expect(wfModel).To(Equal("gpt-4-mini"))
+		Expect(wfModel).To(Equal("gpt-4"), "identity is unchanged; only endpoint was tuned")
 
 		_, rcaModel, _ := resolver.ResolvePhase(katypes.PhaseRCA)
-		Expect(rcaModel).To(Equal("gpt-4"), "RCA should use the default (reloaded) model")
+		Expect(rcaModel).To(Equal("gpt-4"), "unlisted phase falls back to the base model, unchanged")
 	})
 
-	// IT-AI-1470-004b: Hot-reload adding a new phase override
-	It("adds a new phase override on reload", func() {
+	// IT-KA-1599-003: adding a brand-new phase key via hot-reload is rejected
+	// when its effective identity (provider+model) differs from base — this
+	// is the exact cross-provider signature-replay case #1599 exists to
+	// prevent (was previously accepted; see git history of this test).
+	It("rejects adding a new phase override whose identity differs from base", func() {
 		sc, resolver := setupPhaseResolver(GinkgoTB())
+		bootRuntime := bootRuntimeFor("gpt-4")
 
-		_, rcaModelBefore, _ := resolver.ResolvePhase(katypes.PhaseRCA)
-		Expect(rcaModelBefore).To(Equal("default-model"))
-
-		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), resolver)
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), resolver, bootRuntime)
 
 		err := cb(`model: gpt-4
 endpoint: http://localhost:11434
@@ -79,14 +96,61 @@ phaseModels:
     model: claude-sonnet
     endpoint: http://anthropic:443
 `)
-		Expect(err).NotTo(HaveOccurred())
+		Expect(err).To(HaveOccurred())
 
+		Expect(resolver.PhaseSwappable(katypes.PhaseRCA)).To(BeNil(), "rejected reload must not register a new phase override")
 		_, rcaModel, _ := resolver.ResolvePhase(katypes.PhaseRCA)
-		Expect(rcaModel).To(Equal("claude-sonnet"))
+		Expect(rcaModel).To(Equal("gpt-4"), "RCA still falls back to the unaffected base model")
 	})
 
-	// IT-AI-1470-004c: Hot-reload removing a phase override
-	It("removes a phase override on reload, falling back to the reloaded default", func() {
+	// IT-KA-1599-004: adding a brand-new phase key is allowed when its
+	// effective identity matches base (i.e. it introduces no new identity —
+	// just additional non-identity tuning scoped to that phase).
+	It("accepts adding a new phase override whose identity matches base", func() {
+		sc, resolver := setupPhaseResolver(GinkgoTB())
+		bootRuntime := bootRuntimeFor("gpt-4")
+
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), resolver, bootRuntime)
+
+		err := cb(`model: gpt-4
+endpoint: http://localhost:11434
+apiKey: test-key
+phaseModels:
+  validation:
+    endpoint: http://validation-endpoint:11434
+`)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(resolver.PhaseSwappable(katypes.PhaseValidation)).NotTo(BeNil())
+		_, validationModel, _ := resolver.ResolvePhase(katypes.PhaseValidation)
+		Expect(validationModel).To(Equal("gpt-4"), "identity is unchanged from base; only endpoint tuning was added")
+	})
+
+	// IT-KA-1599-005: rejects a hot-reload attempt to change an existing
+	// phase override's provider (identity), even when the model string
+	// happens to stay the same. Provider is part of identity, not just Model.
+	It("rejects a phase override provider-only change", func() {
+		sc, resolver := setupPhaseResolver(GinkgoTB())
+		bootRuntime := bootRuntimeFor("gpt-4")
+
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), resolver, bootRuntime)
+
+		err := cb(`model: gpt-4
+endpoint: http://localhost:11434
+apiKey: test-key
+phaseModels:
+  rca:
+    provider: anthropic
+    model: gpt-4
+`)
+		Expect(err).To(HaveOccurred())
+		Expect(resolver.PhaseSwappable(katypes.PhaseRCA)).To(BeNil())
+	})
+
+	// IT-KA-1599-006: removing a phase override via hot-reload is rejected
+	// when doing so would change that phase's effective identity (falling
+	// back to a base identity different from the override's).
+	It("rejects removing a phase override that would change effective identity", func() {
 		sc, resolver := setupPhaseResolver(GinkgoTB())
 
 		wfInner := &stubLLMClient{}
@@ -94,10 +158,42 @@ phaseModels:
 		Expect(err).NotTo(HaveOccurred())
 		resolver.SetPhaseSwappable(katypes.PhaseWorkflowDiscovery, wfSw)
 
-		_, wfModelBefore, _ := resolver.ResolvePhase(katypes.PhaseWorkflowDiscovery)
-		Expect(wfModelBefore).To(Equal("fast-model"))
+		bootRuntime := &kaconfig.LLMRuntimeConfig{
+			Model: "gpt-4",
+			PhaseModels: map[string]*kaconfig.LLMOverrideConfig{
+				"workflow_discovery": {Model: "fast-model"},
+			},
+		}
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), resolver, bootRuntime)
 
-		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), resolver)
+		err = cb(`model: gpt-4
+endpoint: http://localhost:11434
+apiKey: test-key
+`)
+		Expect(err).To(HaveOccurred())
+
+		_, wfModel, _ := resolver.ResolvePhase(katypes.PhaseWorkflowDiscovery)
+		Expect(wfModel).To(Equal("fast-model"), "rejected removal must leave the existing override serving unaffected")
+	})
+
+	// IT-KA-1599-007: removing a phase override is allowed when doing so
+	// does not change effective identity (the override never actually
+	// differed from base — it only carried non-identity tuning).
+	It("accepts removing a phase override when identity is unchanged", func() {
+		sc, resolver := setupPhaseResolver(GinkgoTB())
+
+		wfInner := &stubLLMClient{}
+		wfSw, err := llm.NewSwappableClient(wfInner, "gpt-4")
+		Expect(err).NotTo(HaveOccurred())
+		resolver.SetPhaseSwappable(katypes.PhaseWorkflowDiscovery, wfSw)
+
+		bootRuntime := &kaconfig.LLMRuntimeConfig{
+			Model: "gpt-4",
+			PhaseModels: map[string]*kaconfig.LLMOverrideConfig{
+				"workflow_discovery": {Endpoint: "http://a:1"},
+			},
+		}
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), resolver, bootRuntime)
 
 		err = cb(`model: gpt-4
 endpoint: http://localhost:11434
@@ -105,20 +201,22 @@ apiKey: test-key
 `)
 		Expect(err).NotTo(HaveOccurred())
 
-		_, wfModelAfter, _ := resolver.ResolvePhase(katypes.PhaseWorkflowDiscovery)
-		Expect(wfModelAfter).To(Equal("gpt-4"), "removing a phase override should fall back to the reloaded default")
+		_, wfModel, _ := resolver.ResolvePhase(katypes.PhaseWorkflowDiscovery)
+		Expect(wfModel).To(Equal("gpt-4"), "override removed, falls back to base — identity was unchanged either way")
 	})
 
-	// Backward compat: nil resolver does not break existing reload
-	It("does not break reload when the resolver is nil (backward compat)", func() {
+	// Backward compat: nil resolver does not break existing reload, and the
+	// base-model identity lock (#1599) still applies when no resolver is
+	// configured.
+	It("rejects a base model change and does not break reload when the resolver is nil (backward compat)", func() {
 		sc := setupSwappable(GinkgoTB())
-		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil, bootRuntimeFor("gpt-4"))
 
 		err := cb(`model: gpt-4-turbo
 endpoint: http://localhost:11434
 apiKey: test-key
 `)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(sc.ModelName()).To(Equal("gpt-4-turbo"))
+		Expect(err).To(HaveOccurred())
+		Expect(sc.ModelName()).To(Equal("gpt-4"))
 	})
 })

--- a/cmd/kubernautagent/reload_callback_783_test.go
+++ b/cmd/kubernautagent/reload_callback_783_test.go
@@ -39,6 +39,13 @@ func staticCfg() *kaconfig.Config {
 	return cfg
 }
 
+// bootRuntimeFor builds the boot-time LLMRuntimeConfig snapshot passed to
+// llmRuntimeReloadCallback (#1599). Tests that don't exercise PhaseModels
+// only need the boot Model to match the SwappableClient's initial model.
+func bootRuntimeFor(model string) *kaconfig.LLMRuntimeConfig {
+	return &kaconfig.LLMRuntimeConfig{Model: model}
+}
+
 // setupSwappable accepts testing.TB (not *testing.T) so both plain
 // `testing.T`-based tests and Ginkgo specs (via GinkgoTB(), which implements
 // testing.TB) can share this
@@ -68,7 +75,7 @@ func (s *stubLLMClient) Close() error { return nil }
 var _ = Describe("llmRuntimeReloadCallback (#783)", func() {
 	It("rejects empty content and does not change the model", func() {
 		sc := setupSwappable(GinkgoTB())
-		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil, bootRuntimeFor("gpt-4"))
 
 		err := cb("")
 		Expect(err).To(HaveOccurred())
@@ -77,27 +84,30 @@ var _ = Describe("llmRuntimeReloadCallback (#783)", func() {
 
 	It("rejects whitespace-only content", func() {
 		sc := setupSwappable(GinkgoTB())
-		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil, bootRuntimeFor("gpt-4"))
 
 		err := cb("   \n  \t  ")
 		Expect(err).To(HaveOccurred())
 	})
 
-	It("accepts a model change", func() {
+	// IT-KA-1599-001: base Model is immutable after boot; a hot-reload
+	// attempt to change it must be rejected and the previously-active
+	// client must keep serving (restart required per #1599).
+	It("rejects a model change and does not change the model", func() {
 		sc := setupSwappable(GinkgoTB())
-		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil, bootRuntimeFor("gpt-4"))
 
 		err := cb(`model: gpt-4-turbo
 endpoint: http://localhost:11434
 apiKey: test-key
 `)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(sc.ModelName()).To(Equal("gpt-4-turbo"))
+		Expect(err).To(HaveOccurred())
+		Expect(sc.ModelName()).To(Equal("gpt-4"))
 	})
 
 	It("accepts an endpoint change", func() {
 		sc := setupSwappable(GinkgoTB())
-		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil, bootRuntimeFor("gpt-4"))
 
 		err := cb(`model: gpt-4
 endpoint: http://new-endpoint:8080
@@ -108,7 +118,7 @@ apiKey: test-key
 
 	It("rejects a validation failure and does not change the model", func() {
 		sc := setupSwappable(GinkgoTB())
-		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil, bootRuntimeFor("gpt-4"))
 
 		err := cb(`model: ""
 endpoint: http://localhost:11434
@@ -120,7 +130,7 @@ apiKey: test-key
 
 	It("accepts a temperature change", func() {
 		sc := setupSwappable(GinkgoTB())
-		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil)
+		cb := llmRuntimeReloadCallback(staticCfg(), sc, testReloadLogger(), nil, bootRuntimeFor("gpt-4"))
 
 		err := cb(`model: gpt-4
 endpoint: http://localhost:11434

--- a/docs/architecture/DESIGN_DECISIONS.md
+++ b/docs/architecture/DESIGN_DECISIONS.md
@@ -119,6 +119,7 @@
 | DD-LLM-005 | Model-Aware Reasoning/Thinking Token Support | 📋 Proposed | 2026-07-06 | [DD-LLM-005-model-aware-reasoning-support.md](decisions/DD-LLM-005-model-aware-reasoning-support.md) |
 | DD-LLM-006 | AWS Bedrock Provider Support via Dual-Client Routing | 📋 Proposed | 2026-07-06 | [DD-LLM-006-bedrock-dual-client-routing.md](decisions/DD-LLM-006-bedrock-dual-client-routing.md) |
 | DD-LLM-007 | AF and KA Intentionally Do Not Share an Anthropic Client | ✅ Approved | 2026-07-06 | [DD-LLM-007-af-ka-anthropic-client-divergence.md](decisions/DD-LLM-007-af-ka-anthropic-client-divergence.md) |
+| DD-LLM-008 | LLM Identity (Provider+Model) Requires a Restart to Change | ✅ Approved & Implemented | 2026-07-06 | [DD-LLM-008-restart-required-llm-identity-lock.md](decisions/DD-LLM-008-restart-required-llm-identity-lock.md) |
 
 **Note**: For complete decision details, alternatives considered, implementation guidance, and consequences, see the individual DD-* files in `docs/architecture/decisions/`.
 

--- a/docs/architecture/decisions/DD-LLM-008-restart-required-llm-identity-lock.md
+++ b/docs/architecture/decisions/DD-LLM-008-restart-required-llm-identity-lock.md
@@ -1,0 +1,93 @@
+# DD-LLM-008: LLM Identity (Provider+Model) Requires a Restart to Change
+
+**Status**: ✅ Approved & Implemented
+**Priority**: P1
+**Owner**: KubernautAgent Team
+**Scope**: `cmd/kubernautagent/llm_builder.go`, `cmd/kubernautagent/bootstrap.go`, `cmd/kubernautagent/main.go`, `cmd/apifrontend/main.go`, `internal/kubernautagent/config/config_types.go`
+**Related**: [DD-LLM-005](./DD-LLM-005-model-aware-reasoning-support.md), [DD-LLM-007](./DD-LLM-007-af-ka-anthropic-client-divergence.md), [BR-HAPI-199](../../requirements/BR-HAPI-199-configmap-hot-reload.md) (superseded, see below), Issue #1599, #1578, #1580
+
+---
+
+## Context & Problem
+
+Issue #1578 (LLM reasoning/thinking token support) and #1580 (Anthropic reasoning-block `Signature` handling) introduced provider-issued opaque signature bytes attached to reasoning content (e.g. Anthropic's thinking-block `Signature`, used to prove a reasoning block was genuinely produced by that model and hasn't been tampered with). While reviewing the pyramid-invariant coverage that landed with PR #1598, a pre-existing architectural gap surfaced: Kubernaut Agent's (KA) LLM hot-reload path allowed the `model` field — and, via `phaseModels` overrides, the `provider` field too — to change live, with no restart, at both the base and per-phase level.
+
+This is a real risk, not a theoretical one: if a phase's LLM identity is hot-swapped from, say, Anthropic/`claude-sonnet` to OpenAI/`gpt-4o` mid-deployment, any reasoning-block replay logic (or a future feature building on the same signature-carrying data model) could end up attempting to validate or replay a signature issued by one provider against a completely different provider/model that never issued it. Even absent an active exploit, silently swapping the model backing a phase invalidates any assumption an operator or auditor makes about "which model made this decision" for that phase going forward — a correctness and auditability problem in its own right (see BR-AUDIT-005 / SOC2 CC8.1: audit reconstruction must be able to name the actual model that acted).
+
+Two services were in scope:
+
+- **KA** (`cmd/kubernautagent`): has a real hot-swap mechanism (`llm.SwappableClient`, wired through `llmRuntimeReloadCallback`) that actively swaps the live LLM client on every FileWatcher-detected change to `llm-runtime.yaml` — including, prior to this DD, the `model` field and, for `phaseModels` overrides, `provider` too.
+- **API Frontend** (`cmd/apifrontend`, "AF"): investigated as part of this same effort. AF's config-drift-detection watcher (`configReloadCallback`, extracted from an anonymous closure in `main.go` as part of this change for testability) only *validates* candidate config for audit purposes — it was already, by construction, never wired to mutate the live `*config.Config` or rebuild AF's LLM client. AF requires a full process restart to apply *any* config change, LLM identity included. This DD's guard therefore applies only to KA; AF needed a regression test (not new production logic) proving this already-restart-only behavior holds, so a future refactor doesn't accidentally wire live-apply into that callback.
+
+## Alternatives Considered
+
+### Alternative A — Allow live provider/model swaps, but strip/ignore `Signature` on cross-provider swap (rejected)
+
+- **Pros**: Preserves today's "everything is hot-reloadable" UX for LLM identity.
+- **Cons**: Requires reliably detecting "this in-flight investigation phase's pinned client identity differs from what the resolver now serves" at every consumption point of reasoning data, forever, as a permanent defensive layer — fragile, and does nothing for the auditability concern (an operator still can't trust "which model acted" without cross-referencing hot-reload history). Rejected as treating a symptom instead of the cause.
+
+### Alternative B — Restart-required LLM identity lock, tuning fields remain hot-reloadable (chosen)
+
+- **Pros**: Provider+Model become a fixed identity contract for the life of the process, matching how a human operator already reasons about "which model is running" and eliminating the cross-provider replay risk at the source rather than downstream. All genuinely safe-to-hot-reload fields (temperature, timeouts, retries, endpoint, API key rotation, custom headers) keep working exactly as before — this is not a blanket "disable hot-reload" change. Symmetric with AF, which (per the investigation above) was already restart-only for every field, LLM identity included.
+- **Cons**: Operators who were relying on live provider/model swaps (if any — no production use of this was found; `phaseModels` cross-provider examples existed only in docs, not confirmed live traffic) must restart the pod to change LLM identity going forward. Mitigated by: the Kubernaut Operator already forces a rolling restart on any `llm-runtime` ConfigMap change today (see Deployment Note below), so operator-managed deployments see no behavior change at all; only Helm-only/GitOps deployments without an equivalent restart trigger are newly affected, and are the ones this DD's documentation update specifically targets.
+
+### Decision
+
+**Alternative B.** Approved 2026-07-06 after preflight confirmed AF was unaffected (already restart-only) and confirmed KA's in-flight-phase-pinning mechanism (`DefaultPhaseResolver.ResolvePhase`, #783/#1470) already protects *running* investigations from any hot-swap — the risk was specifically about the *next* phase/investigation picking up a silently-changed identity, not about corrupting work in progress.
+
+## Design
+
+### What counts as "identity"
+
+Provider + Model, evaluated per LLM configuration scope:
+
+- **Base**: `staticCfg.AI.LLM.Provider` (static config, already immutable — `LLMRuntimeConfig` has no `Provider` field) + `llmRuntime.Model` (was hot-reloadable; now locked).
+- **Per-phase** (`phaseModels.<phase>`): the *effective* provider+model for that phase after merging the override onto the base (`LLMRuntimeConfig.EffectivePhaseConfig`) — an override that sets neither `provider` nor `model` inherits the base identity and is therefore never an identity change by construction; a phase override that changes only `endpoint`, `apiKeyFile`, `azureApiVersion`, `vertexProject`, `vertexLocation`, or `bedrockRegion` is tuning, not identity.
+- **`AlignmentCheckConfig.LLM`**: confirmed static (loaded once from `staticCfg`, never hot-reloaded) — out of scope, no change needed.
+
+### Enforcement point and failure mode
+
+`cmd/kubernautagent/llm_builder.go`:
+
+- `llmRuntimeReloadCallback` takes a new `bootRuntime *kaconfig.LLMRuntimeConfig` parameter: the frozen `LLMRuntimeConfig` snapshot loaded once at process start (`cmd/kubernautagent/main.go`'s `llmRuntime`, threaded through `apiServerStartParams.bootRuntime` → `hotReloadParams.BootRuntime` → `wireLLMRuntimeWatcher`). This snapshot is never mutated across reloads — it is the single source of truth for "what identity is this process currently running," independent of what any later reload attempted (successful or rejected).
+- `parseAndAuthorizeReload` (extracted from `llmRuntimeReloadCallback` to keep cognitive complexity within the AGENTS.md anti-pattern budget) rejects the *entire* candidate reload — atomically, before any client is built or any `SwappableClient.Swap` call happens — if either:
+  1. `rt.Model != bootRuntime.Model` (base identity change), or
+  2. `validatePhaseIdentity` finds any phase (new, existing, or being removed) whose effective provider/model differs between `bootRuntime` and the candidate `rt`.
+- Rejection returns a normal error from the reload callback. `pkg/shared/hotreload.FileWatcher` (already, prior to this DD) treats any callback error as "keep the previous, known-good config" — no new rejection-handling mechanism was needed; #1599 only needed to make the callback itself judge more changes as errors.
+- This makes the reload atomic in the sense that matters for #1599: an identity violation in *any* part of the payload (base or one phase among several) fails the whole reload, so a config that both wants to safely tune an unrelated field *and* illegally swap one phase's provider is rejected in full, not partially applied.
+
+### What is intentionally unaffected
+
+Every other hot-reloadable field keeps working exactly as before this DD: `temperature`, `maxRetries`, `timeoutSeconds`, `endpoint`, `apiKeyFile`/API key rotation, `customHeaders`, and non-identity phase overrides (adding/removing/tuning a phase override whose effective identity equals — and continues to equal — the base identity).
+
+### AF
+
+No production logic changed for the reload path itself. `cmd/apifrontend/main.go`'s previously-anonymous config-watcher callback was extracted into a named `configReloadCallback(cfg *config.Config) func([]byte) error` purely to make the following invariant independently testable: parsing and validating a candidate config (for CM-02 audit/drift-detection purposes) never mutates the live `*config.Config` passed to `startConfigWatcher`, regardless of what fields the candidate changes. `TestConfigReloadNeverMutatesLiveConfig`-equivalent coverage lives in `cmd/apifrontend/reload_identity_test.go`.
+
+### Deployment note: who actually restarts on an LLM identity change today
+
+This DD changes *what a config-file edit alone can do* — it does not, by itself, restart any pod. Whether an LLM identity change reaches a running KA pod at all depends on the deployment path:
+
+- **Kubernaut Operator**: already computes a hash of the `llm-runtime` ConfigMap's contents and stamps it into the Deployment's pod template annotations (`internal/controller/kubernaut_controller.go`), forcing a rolling restart on *any* change to that ConfigMap — LLM identity or tuning field alike. No operator change was needed for this DD; operator-managed deployments were already restart-on-change before and after.
+- **Helm chart (no operator)**: the chart renders the ConfigMap but does not itself trigger a restart on ConfigMap content changes — this is a standard Helm limitation, not specific to Kubernaut, and intentionally out of this DD's scope to change (the chart's job ends at rendering resources; restart-on-change is a deployment-topology concern).
+- **GitOps (e.g. ArgoCD) managing the Helm chart or raw manifests directly**: same as the raw-Helm case — ArgoCD syncs the ConfigMap but does not restart pods on its own. Teams in this position who want automatic restarts on `llm-runtime` ConfigMap changes should use [`stakater/Reloader`](https://github.com/stakater/Reloader) (annotation-based restart triggers), with an ArgoCD `ignoreDifferences` rule for the pod-template annotation Reloader adds, to avoid ArgoCD reporting perpetual drift. This is documented as an external-tool recommendation in the configuration-reference docs, not implemented in the chart itself.
+
+## Consequences
+
+### Positive
+- Closes the cross-provider signature-replay risk at the source (identity can't drift underneath in-flight or future reasoning-block validation logic) rather than requiring permanent downstream defensive checks.
+- Matches operator intuition: "which model is this pod running" is now a boot-time fact, consistent for the process lifetime, improving audit trail trustworthiness (SOC2 CC8.1 reconstruction can name the actual model without cross-referencing hot-reload history).
+- All non-identity hot-reload behavior (the vast majority of real-world tuning use cases) is fully preserved — this is a narrow, targeted restriction, not a hot-reload regression.
+- AF required no production behavior change (was already compliant); the investigation converted an implicit invariant into an explicit, tested one.
+
+### Negative
+- Any operator relying on live cross-provider/model `phaseModels` swaps (undetected in production use, only present in now-corrected documentation examples) must restart the pod going forward.
+- Helm-only and GitOps-managed deployments (without the Operator or an equivalent restart-trigger like Reloader) will silently keep running the old identity if an operator edits `llm-runtime.yaml`'s `model`/`provider`/phase-override identity fields expecting immediate effect — mitigated by documentation, not code, per this DD's Deployment Note.
+- A pre-existing, narrower micro-race in `DefaultPhaseResolver.ResolvePhase` (client/model-name/runtime-params fetched via three separate calls rather than one atomic snapshot) was identified during this investigation. It was out of scope for this DD (unrelated to identity locking specifically) but has since been fixed under [#1610](https://github.com/jordigilh/kubernaut/issues/1610): `SwappableClient.Pin()` now captures all three under one lock acquisition, and both `DefaultPhaseResolver.ResolvePhase` and `Investigator.resolveForPhase`'s legacy branch use it.
+
+---
+
+**Document Control**:
+- **Created**: 2026-07-06
+- **Version**: 1.0
+- **Status**: Approved & Implemented

--- a/docs/requirements/BR-HAPI-199-configmap-hot-reload.md
+++ b/docs/requirements/BR-HAPI-199-configmap-hot-reload.md
@@ -1,12 +1,36 @@
 # BR-HAPI-199: ConfigMap Hot-Reload for HolmesGPT API
 
 ## Status
-**✅ IMPLEMENTED** (V1.0)
+**⚠️ SUPERSEDED** — see note below
 **Created**: 2025-12-06
-**Last Updated**: 2025-12-07
-**Implemented**: 2025-12-07
+**Last Updated**: 2026-07-06 (superseded)
+**Implemented**: 2025-12-07 (for the Python "HolmesGPT API" PoC described below, not the current Go implementation)
 
 ---
+
+> **SUPERSEDED (2026-07-06)**: This BR describes a Python-based "HolmesGPT API"
+> service (`kubernaut-agent/poc/hot_reload_poc.py`, `watchdog` dependency,
+> `DD-HAPI-004`) that was a pre-Go-rewrite proof of concept. It does not
+> describe the current Kubernaut Agent (KA, `cmd/kubernautagent`), which is
+> implemented in Go per [DD-HAPI-019](../architecture/decisions/DD-HAPI-019-go-rewrite-design).
+>
+> Specifically, the "Fields Supporting Hot-Reload" table below claiming
+> `llm.model` and `llm.provider` are both hot-reloadable (✅) is **incorrect**
+> for the current Go implementation: as of
+> [#1599](https://github.com/jordigilh/kubernaut/issues/1599) /
+> [DD-LLM-008](../architecture/decisions/DD-LLM-008-restart-required-llm-identity-lock.md),
+> LLM identity (`provider` + `model`, at both base and per-phase-override level)
+> requires a process restart to change — only `endpoint`, `apiKeyFile`,
+> `temperature`, `maxRetries`, `timeoutSeconds`, and `customHeaders` are
+> hot-reloadable. `llm.provider` was, in fact, never hot-reloadable in the Go
+> implementation even before #1599 (KA's `LLMRuntimeConfig` has no `Provider`
+> field at all).
+>
+> The authoritative source for KA's current hot-reload behavior is
+> [`docs/services/kubernaut-agent/configuration-reference.md`](../services/kubernaut-agent/configuration-reference.md).
+> This document is retained for historical reference only and MUST NOT be used
+> to answer "is X hot-reloadable in KA" — recall/query tools should prefer the
+> configuration-reference doc and DD-LLM-008 for that question.
 
 ## Business Context
 

--- a/docs/services/apifrontend/configuration-reference.md
+++ b/docs/services/apifrontend/configuration-reference.md
@@ -1,0 +1,106 @@
+# API Frontend configuration reference
+
+Narrowly-scoped reference for API Frontend (AF, `cmd/apifrontend`) configuration
+and hot-reload behavior, written specifically to document the restart-required
+LLM identity rule ([#1599](https://github.com/jordigilh/kubernaut/issues/1599) /
+[DD-LLM-008](../architecture/decisions/DD-LLM-008-restart-required-llm-identity-lock.md))
+for this service. AF did not previously have a configuration-reference doc; this
+is not (yet) an exhaustive field-by-field reference the way
+[kubernaut-agent/configuration-reference.md](../kubernaut-agent/configuration-reference.md)
+is — it covers the config file, the config-drift-detection watcher, and the
+LLM-identity-relevant fields specifically.
+
+Derived from:
+
+- `pkg/apifrontend/config/config.go` (`Config` struct, `DefaultConfig`, `Load`, `Validate`, `ResolveDefaults`)
+- `cmd/apifrontend/main.go` (`configReloadCallback`, `startConfigWatcher`)
+- `charts/kubernaut/templates/apifrontend/apifrontend.yaml`
+
+## 1. Configuration file
+
+Unlike Kubernaut Agent (KA), AF has a **single** configuration file — there is
+no separate hot-reloadable LLM runtime file.
+
+| Item | Detail |
+|------|--------|
+| Path | `/etc/apifrontend/config.yaml` (constant `configPath` in `cmd/apifrontend/main.go`; no CLI flag override) |
+| Format | YAML |
+| Reload | **Restart required for every field, including LLM identity** — see §2 |
+
+## 2. Config-drift-detection watcher is validate-only, not hot-apply
+
+AF does run a `config.FileWatcher` on `configPath` (`startConfigWatcher`,
+wired for CM-02 config-drift-detection + audit trail purposes), but — unlike
+KA's `llm-runtime.yaml` watcher, which actively swaps a live `llm.SwappableClient`
+— AF's watcher callback (`configReloadCallback`) only **parses and validates**
+the candidate file content. It builds a fresh, disposable `config.Config` value
+from the candidate YAML, runs `ResolveDefaults()` + `Validate()` against it for
+audit-trail/drift-detection purposes, and then discards it — the result is
+never assigned back into the live `*config.Config` the running process is using,
+and no client (LLM or otherwise) is rebuilt from it.
+
+**Practical consequence: every field in AF's config, not just LLM identity, is
+restart-only.** This was true before #1599 and required no production
+behavior change to remain true — #1599 added `TestAPIFrontendCmdReloadIdentity`
+(`cmd/apifrontend/reload_identity_test.go`) as regression coverage proving this
+invariant specifically for `agent.llm.provider`/`.model` and
+`severityTriage.llm.provider`/`.model`, so a future change to
+`configReloadCallback` that started wiring live-apply couldn't silently
+reintroduce the cross-provider identity risk DD-LLM-008 describes.
+
+## 3. LLM-identity-relevant fields
+
+AF has two independent LLM configurations, both static (config-file, restart-only):
+
+| YAML path | Go field | Purpose |
+|-----------|----------|---------|
+| `agent.llm` | `Config.Agent.LLM` (`types.LLMConfig`) | Primary LLM client used by AF's agent-facing tooling (`launcher.NewModelFromConfig`, built once at startup in `cmd/apifrontend/mcp_a2a_handlers.go`). |
+| `severityTriage.llm` | `Config.SeverityTriage.LLM` (`*types.LLMConfig`, nilable — feature is entirely optional) | Severity-triage LLM client, only constructed when `severityTriage.enabled` is true and `llm` is non-nil. |
+
+Both are `types.LLMConfig` (`pkg/shared/types/llm.go`) — the same struct type KA's static `ai.llm` uses. Key sub-fields relevant to identity:
+
+| YAML key | Description |
+|----------|-------------|
+| `provider` | `openai`, `anthropic`, `vertex_ai`, `openai_compatible`, etc. Empty `provider` on `agent.llm` means "LLM not configured" (`LLMConfig.Validate` returns nil early) — not every AF deployment configures an LLM at all. |
+| `model` | Model id for the provider. |
+| `endpoint`, `apiKeyFile`, `azureApiVersion`, `vertexProject`, `vertexLocation`, `bedrockRegion`, `oauth2.*` | Same semantics as KA's `ai.llm` — see [kubernaut-agent/configuration-reference.md §4.1](../kubernaut-agent/configuration-reference.md#41-aillm-static) for the shared struct's field reference. |
+
+Since **nothing** in AF hot-reloads (§2), there is no separate "identity vs.
+tuning" distinction to make here the way there is for KA's `phaseModels` (KA
+§6.1) — every field above, identity or not, requires a restart to change. The
+distinction only matters for KA, which has an actual hot-swap mechanism to
+guard.
+
+## 4. Helm mapping
+
+Source: `charts/kubernaut/templates/apifrontend/apifrontend.yaml`.
+
+As of this writing, the chart renders `agent.kaBaseURL`, `agent.dsBearerTokenFile`,
+and `severityTriage.cacheTTLSeconds`/`.llmConfidence`, but does **not** render
+`agent.llm.*` or `severityTriage.llm.*` — AF's LLM configuration (when used) is
+not currently exposed via primary Helm values and must be supplied via a
+ConfigMap patch/overlay or chart fork. This is an accurate description of the
+current chart, not a statement that it should stay this way; if `agent.llm`
+gains first-class Helm support in the future, cross-reference this file and
+DD-LLM-008 when documenting it.
+
+## 5. Deployment topology and restart triggers
+
+Since every AF config field (LLM identity included) requires a restart to take
+effect, the question "will my ConfigMap edit actually reach the running pod"
+depends entirely on deployment topology — identical concern and identical
+guidance to KA's (see
+[kubernaut-agent/configuration-reference.md §13](../kubernaut-agent/configuration-reference.md#13-deployment-topology-and-restart-triggers-for-llm-identity-changes)):
+
+| Deployment path | Restarts on `config.yaml` ConfigMap change? |
+|------------------|:---:|
+| Kubernaut Operator | ✅ Yes — hashes ConfigMap contents into pod template annotations |
+| Helm chart only (no operator) | ❌ No — manual `kubectl rollout restart` needed |
+| GitOps (e.g. ArgoCD) | ❌ No by default — use [`stakater/Reloader`](https://github.com/stakater/Reloader) if you want automatic restarts on ConfigMap change |
+
+---
+
+Treat this reference as authoritative for AF's LLM-identity restart semantics.
+For everything else in AF's configuration surface (auth, RBAC, rate limiting,
+fleet, session, etc.), read `pkg/apifrontend/config/config.go` directly until a
+full field-by-field reference exists for this service.

--- a/docs/services/kubernaut-agent/configuration-reference.md
+++ b/docs/services/kubernaut-agent/configuration-reference.md
@@ -17,7 +17,16 @@ Configuration is split into two files plus optional CLI overrides:
 | Layer | Reload | Purpose |
 |-------|--------|---------|
 | Static YAML (`Config`) | Requires process restart | Runtime, AI (except hot LLM knobs), integrations |
-| LLM runtime YAML (`LLMRuntimeConfig`) | File watcher reload | Model, endpoint, API key placeholder, tuning, custom headers |
+| LLM runtime YAML (`LLMRuntimeConfig`) | File watcher reload, **except LLM identity** | Endpoint, API key placeholder, tuning, custom headers, per-phase overrides — see §6 |
+
+> **LLM identity (`model`, and `phaseModels.<phase>.provider`/`.model`) requires a
+> process restart to change** — [#1599](https://github.com/jordigilh/kubernaut/issues/1599) /
+> [DD-LLM-008](../../architecture/decisions/DD-LLM-008-restart-required-llm-identity-lock.md).
+> A hot-reload attempt that changes identity is rejected in full (the whole
+> candidate reload, including any otherwise-safe tuning changes in the same
+> payload) and the previous configuration keeps running. See §6 for the full
+> field-by-field breakdown and §13 for the operational implications of this
+> across deployment topologies (Operator, Helm-only, GitOps).
 
 CLI flags only select paths or override the main HTTP listen socket; they do not replace the YAML surface.
 
@@ -207,15 +216,67 @@ Top-level YAML (not nested under `runtime`/`ai` in file). Mapped by `LLMRuntimeC
 
 | YAML key | Type | Default | Validation / behavior | Description |
 |----------|------|---------|------------------------|-------------|
-| `model` | string | (empty) | **Required** | Model id for the provider. |
+| `model` | string | (empty) | **Required**; **immutable after boot — see below** | Model id for the provider. |
 | `endpoint` | string | (empty) | Required for non-standard providers (see section 5.1) | API base / proxy URL. |
 | `apiKey` | string | (empty) | If empty, resolved from credential files (section 5.2) | Inline key material (sensitive). |
 | `temperature` | float64 | `0` if omitted | None in `Validate` | Passed to `RuntimeParams`. **Omitted YAML fields decode as Go zero values** (`0`); they are **not** merged with `DefaultLLMRuntime()` in `LoadLLMRuntime`. |
 | `maxRetries` | int | `0` if omitted | None in `Validate` | Retry attempts = `maxAttempts = 1 + maxRetries`; if `maxAttempts < 1` it is clamped to `1` in chat helper. |
 | `timeoutSeconds` | int | `0` if omitted | None | If `<= 0`, per-chat wrapper does not add `context.WithTimeout` (relies on parent context). The `anthropicfamily`/`openai` clients still use a **120s** default HTTP client timeout when a custom transport stack is built. |
 | `customHeaders` | array | `nil` | Each entry validated; see below | Extra outbound headers on LLM HTTP stack. |
+| `phaseModels` | map of `LLMOverrideConfig`, keyed by phase name | `nil` | See §6.1 | Per-phase LLM overrides (#1470). Identity fields (`provider`, `model`) within an override are subject to the same restart-required rule as base `model` — see §6.1. |
 
-### 6.1 `customHeaders[]`
+**`model` is immutable after process start** ([#1599](https://github.com/jordigilh/kubernaut/issues/1599) /
+[DD-LLM-008](../../architecture/decisions/DD-LLM-008-restart-required-llm-identity-lock.md)):
+`ai.llm.provider` (static config) combined with runtime `model` form the LLM's
+"identity". A hot-reload attempt where the new `model` differs from the model
+the process booted with is rejected in full — the reload callback returns an
+error, the FileWatcher keeps the previous configuration running, and no field
+in that reload payload is applied (not even otherwise-safe tuning changes
+bundled in the same file). This is enforced against the boot-time snapshot,
+not the most-recently-accepted reload — since accepted reloads can never
+actually change `model`, these are equivalent in practice. To change the
+model or provider, edit the config and restart the pod (see §13 for how that
+restart is triggered, or isn't, depending on deployment topology).
+
+### 6.1 `phaseModels.<phase>` (per-phase LLM override, #1470)
+
+Each key under `phaseModels` must be a valid phase name (`workflow_discovery`,
+`rca`, `validation`, ...). The value is an `LLMOverrideConfig` — the same
+struct type used by `ai.alignmentCheck.llm` (§7.1), but here it lives in the
+**hot-reloadable** runtime file, not the static one.
+
+| YAML key | Type | Default | Description |
+|----------|------|---------|-------------|
+| `provider` | string | (empty) | Overrides base `ai.llm.provider` for this phase when non-empty. **Identity field — restart required to change, see below.** |
+| `model` | string | (empty) | Overrides base runtime `model` for this phase when non-empty. **Identity field — restart required to change, see below.** |
+| `endpoint` | string | (empty) | Overrides base runtime `endpoint` for this phase when non-empty. Hot-reloadable. |
+| `apiKeyFile` | string | (empty) | Overrides base `apiKeyFile` for this phase when non-empty. Hot-reloadable. |
+| `azureApiVersion` | string | (empty) | Overrides static Azure API version for this phase when non-empty (#1600). Hot-reloadable. |
+| `vertexProject` | string | (empty) | Overrides static Vertex project for this phase when non-empty. Hot-reloadable. |
+| `vertexLocation` | string | (empty) | Overrides static Vertex location for this phase when non-empty. Hot-reloadable. |
+| `bedrockRegion` | string | (empty) | Reserved (#1582) — not currently consumed. |
+
+An override's *effective identity* is `provider` (falling back to base
+`ai.llm.provider` when empty) + `model` (falling back to base runtime `model`
+when empty) — not the literal override fields. Per #1599 / DD-LLM-008, a
+hot-reload is rejected if it would change any phase's effective identity,
+whether that's because:
+
+- an **existing** phase override's `provider`/`model` changed,
+- a **new** phase override is added whose effective identity differs from
+  base (e.g. adding `phaseModels.rca.model: claude-sonnet` when the base
+  model is `gpt-4o`), or
+- an **existing** phase override is **removed** and falling back to base
+  would change that phase's effective identity (e.g. removing an override
+  that pinned `rca` to a different provider than base).
+
+Adding, tuning, or removing a phase override is accepted whenever doing so
+does **not** change that phase's effective identity — for example, adding a
+new override that only sets `endpoint` (inheriting the base model/provider),
+or removing an override that only ever set `endpoint` (so removal falls back
+to the same effective identity it already had).
+
+### 6.2 `customHeaders[]`
 
 | Field | Type | Sources | Validation | Description |
 |-------|------|---------|------------|-------------|
@@ -231,6 +292,8 @@ Reload failures leave the previously swapped client in place; reload rejects emp
 ## 7. Alignment checker
 
 YAML path: `ai.alignmentCheck`
+
+**Static configuration — not hot-reloadable.** Unlike `phaseModels` (§6.1), `ai.alignmentCheck` (including its optional `llm` override) lives entirely in the static config file and is read once at startup. There is no restart-required *identity lock* to reason about here specifically because nothing in this section is ever hot-swapped in the first place — changing anything under `ai.alignmentCheck`, including its shadow-model override, always requires a process restart.
 
 When `enabled` is true and `llm` is nil, startup logs **error-level** diagnostics that shadow traffic shares the primary instrumented LLM client ( contention risk ). When `enabled` is true and dedicated shadow client creation fails (non-nil `ai.alignmentCheck.llm` configured but client build fails), the **process exits** (fail-closed).
 
@@ -373,6 +436,18 @@ Store in Kubernetes **Secrets** (or equivalent vault-backed mounts), never in pl
 | Summarizer never runs | `ai.summarizer.threshold <= 0` disables it without validation error. |
 | Startup exit with alignment enabled | Process exits when `alignmentCheck` is enabled **and** a dedicated shadow LLM fails to construct when `alignmentCheck.llm` is configured; sharing primary client when `llm` nil does **not** exit. |
 | Custom header validation fails | `secretKeyRef` env unset at startup or multiple of `value`/`secretKeyRef`/`filePath` set.
+
+## 13. Deployment topology and restart triggers for LLM identity changes
+
+Per §1 and §6, changing `ai.llm.provider` (static) or `model`/`phaseModels.<phase>.provider`/`phaseModels.<phase>.model` (runtime) requires a **pod restart** — a hot-reload attempt that changes any of these is rejected outright (#1599 / DD-LLM-008). Editing the ConfigMap alone does **not** restart anything; whether an edit actually reaches a running pod depends entirely on how kubernaut-agent is deployed:
+
+| Deployment path | Restarts on `llm-runtime` ConfigMap change? | Notes |
+|------------------|:---:|-------|
+| **Kubernaut Operator** | ✅ Yes, automatically | The operator hashes the `llm-runtime` ConfigMap's contents and stamps the hash into the Deployment's pod template annotations, forcing a rolling restart on *any* change to that ConfigMap — identity or tuning field alike. No action needed; this was already the behavior before #1599 and required no operator change. |
+| **Helm chart only (no operator)** | ❌ No | Helm renders the ConfigMap but does not itself trigger a restart when its contents change on a subsequent `helm upgrade` — this is a standard Helm limitation, not specific to this chart. If you need `model`/`provider`/phase-identity changes to take effect, you must manually restart the deployment (`kubectl rollout restart deployment/<name>`) after upgrading. |
+| **GitOps (e.g. ArgoCD) managing the Helm chart or raw manifests** | ❌ No, by default | Same limitation as raw Helm — GitOps tooling syncs the ConfigMap but does not restart pods on its own. If you want identity changes (or any config change) to restart the pod automatically, use [`stakater/Reloader`](https://github.com/stakater/Reloader) with an annotation on the Deployment (e.g. `configmap.reloader.stakater.com/reload: "kubernaut-agent-llm-runtime"`). When using ArgoCD, also add an `ignoreDifferences` rule for the pod-template annotation Reloader injects, so ArgoCD doesn't report perpetual drift against the last-applied manifest. |
+
+This table is a deployment-topology reference, not a promise this chart implements restart-on-change itself outside the Operator path — the Helm chart's responsibility ends at rendering the ConfigMap/Deployment; triggering a restart on a subsequent content change is a deployment-topology concern that the tools above already solve well, and duplicating that logic in the chart was deliberately avoided (see DD-LLM-008's Deployment Note for the alternatives considered).
 
 ## Appendix A: TLS trust precedence (independent stacks)
 

--- a/docs/testing/783-sdk-config-hotreload/TEST_PLAN.md
+++ b/docs/testing/783-sdk-config-hotreload/TEST_PLAN.md
@@ -3,15 +3,28 @@
 **Issue**: [#783](https://github.com/jordigilh/kubernaut/issues/783)
 **Service**: Kubernaut Agent (KA)
 **Date**: 2026-04-15
-**Status**: Active
+**Status**: Active — amended 2026-07-06 for [#1599](https://github.com/jordigilh/kubernaut/issues/1599) / [DD-LLM-008](../../architecture/decisions/DD-LLM-008-restart-required-llm-identity-lock.md) (see below)
+
+> **2026-07-06 amendment**: `model` moved from "In Scope" to "Out of Scope" per #1599 —
+> LLM identity (provider+model, base and per-phase) now requires a restart to change.
+> The BR table below was also corrected: the original `BR-AI-029` and unqualified
+> `BR-CFG-005`/`BR-PERF-008` citations pointed at the wrong requirement (or an
+> ambiguous, colliding BR ID — multiple unrelated requirements docs reuse the same
+> ID); see the source-file-qualified citations below. This plan otherwise still
+> describes the credential/transport-focused fields (`provider`, `oauth2.*`) that
+> were already out of scope before #1599 for unrelated reasons.
 
 ## Business Requirements
 
-| BR ID | Description | Hot-Reload Relevance |
-|-------|-------------|---------------------|
-| BR-CFG-005 | Hot-reload configuration where safe | Primary driver: SDK LLM config must reload without pod restart |
-| BR-PERF-008 | Hot-reload must apply within 10 seconds | FileWatcher debounce (200ms) + client build must complete within budget |
-| BR-AI-029 | Zero-downtime policy updates | Model/endpoint changes must not interrupt in-flight investigations |
+`BR-CFG-005` and `BR-PERF-008` are reused, unrelated IDs across multiple
+`docs/requirements/*.md` files — citations below are qualified with the source
+file to disambiguate.
+
+| BR ID | Source | Description | Hot-Reload Relevance |
+|-------|--------|-------------|---------------------|
+| BR-CFG-005 | `docs/requirements/09_SHARED_UTILITIES_COMMON.md` | MUST implement configuration hot-reloading where safe | Primary driver: SDK LLM config must reload without pod restart, for the fields that are actually safe to reload (see #1599 amendment above for what "safe" now excludes) |
+| BR-PERF-008 | `docs/requirements/09_SHARED_UTILITIES_COMMON.md` | Hot-reload operations MUST complete within 10 seconds | FileWatcher debounce (200ms) + client build must complete within budget |
+| BR-PERF-015 | `docs/requirements/10_AI_CONTEXT_ORCHESTRATION.md` | Dynamic toolset reconfiguration MUST not interrupt ongoing investigations | Closest existing analog for "config changes must not interrupt in-flight investigations" — written about toolset reconfiguration specifically; applied here by the same principle to LLM client hot-swap (implemented via per-phase client pinning, #783/#1470). The original citation (`BR-AI-029`, Rego/OPA zero-downtime policy updates) was unrelated to LLM hot-reload and has been replaced. |
 
 ## Scope
 
@@ -19,7 +32,6 @@
 
 | Field | Merge Semantic | Risk Level |
 |-------|---------------|------------|
-| `model` | Gap-fill | Low |
 | `endpoint` | Gap-fill | Low |
 | `api_key` | Gap-fill | Medium (credential rotation) |
 | `vertex_project` | Gap-fill | Low |
@@ -33,7 +45,9 @@
 
 | Field | Reason |
 |-------|--------|
-| `provider` | Changes entire construction path, transport stack, credential model |
+| `model` (base and `phaseModels` overrides) | **#1599 / DD-LLM-008**: LLM identity (provider+model) is immutable after process start — a hot-swap risks replaying one provider's opaque reasoning signature against a different provider/model that never issued it. Was previously "In Scope" (gap-fill) before this amendment. |
+| `phaseModels.<phase>.provider` | Same as above — phase-level provider is part of that phase's identity |
+| `provider` (base) | Changes entire construction path, transport stack, credential model (already immutable pre-#1599: `LLMRuntimeConfig` has no base `Provider` field) |
 | `oauth2.token_url` | Credential redirect attack surface (M5) |
 | `oauth2.client_id` | Credential exfiltration risk |
 | `oauth2.client_secret` | Credential exfiltration risk |
@@ -72,7 +86,7 @@
 | UT-KA-783-RC-004 | Reload rejects OAuth2 token_url change | `reload_callback_test.go` |
 | UT-KA-783-RC-005 | Reload rejects OAuth2 client_id change | `reload_callback_test.go` |
 | UT-KA-783-RC-006 | Reload rejects OAuth2 client_secret change | `reload_callback_test.go` |
-| UT-KA-783-RC-007 | Reload accepts model change | `reload_callback_test.go` |
+| UT-KA-783-RC-007 | Reload rejects model change, requires restart (amended per #1599; was "accepts model change" before this DD) | `reload_callback_783_test.go` |
 | UT-KA-783-RC-008 | Reload accepts endpoint change | `reload_callback_test.go` |
 | UT-KA-783-RC-009 | Reload accepts api_key change | `reload_callback_test.go` |
 | UT-KA-783-RC-010 | Reload accepts OAuth2 scopes change | `reload_callback_test.go` |
@@ -99,8 +113,9 @@
 
 1. Live config is NEVER mutated before validation succeeds
 2. Provider changes are ALWAYS rejected
-3. OAuth2 credential changes are ALWAYS rejected
-4. Empty/whitespace SDK content is ALWAYS rejected
-5. In-flight investigations complete with pinned client
-6. Old clients are explicitly closed after swap
-7. Structured reload events are emitted for every attempt
+3. Model changes are ALWAYS rejected (base and per-phase-override identity; amended per #1599 — was previously accepted)
+4. OAuth2 credential changes are ALWAYS rejected
+5. Empty/whitespace SDK content is ALWAYS rejected
+6. In-flight investigations complete with pinned client
+7. Old clients are explicitly closed after swap
+8. Structured reload events are emitted for every attempt

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -225,6 +225,11 @@ func (inv *Investigator) auditLog() logr.Logger {
 // the given investigation phase. When a PhaseClientResolver is configured, it
 // delegates to the resolver (which may return a phase-specific client).
 // Otherwise, falls back to the legacy Swappable + PinDecorator pattern.
+//
+// The legacy branch captures client/model/params via a single
+// SwappableClient.Pin() call so the three describe the same Swap version —
+// calling Snapshot/ModelName/RuntimeParameters separately would risk a torn
+// read if a hot-reload landed between calls (#1610).
 func (inv *Investigator) resolveForPhase(phase katypes.Phase) (llm.Client, string, llm.RuntimeParams) {
 	if inv.phaseResolver != nil {
 		return inv.phaseResolver.ResolvePhase(phase)
@@ -233,17 +238,17 @@ func (inv *Investigator) resolveForPhase(phase katypes.Phase) (llm.Client, strin
 	modelName := inv.modelName
 	var runtimeParams llm.RuntimeParams
 	if inv.swappable != nil {
-		pinned := inv.swappable.Snapshot()
+		snap := inv.swappable.Pin()
 		if inv.pinDecorator != nil {
-			client = inv.pinDecorator(pinned)
+			client = inv.pinDecorator(snap.Client)
 			if client == nil {
-				client = llm.NewInstrumentedClient(pinned)
+				client = llm.NewInstrumentedClient(snap.Client)
 			}
 		} else {
-			client = llm.NewInstrumentedClient(pinned)
+			client = llm.NewInstrumentedClient(snap.Client)
 		}
-		modelName = inv.swappable.ModelName()
-		runtimeParams = inv.swappable.RuntimeParameters()
+		modelName = snap.ModelName
+		runtimeParams = snap.RuntimeParams
 	}
 	return client, modelName, runtimeParams
 }

--- a/internal/kubernautagent/investigator/phase_resolver.go
+++ b/internal/kubernautagent/investigator/phase_resolver.go
@@ -60,6 +60,12 @@ func NewDefaultPhaseResolver(
 // If a phase-specific SwappableClient exists, it is used; otherwise the
 // default is used. The returned client is a snapshot that is unaffected by
 // subsequent hot-reload swaps.
+//
+// The client, model name, and runtime params are captured via a single
+// SwappableClient.Pin() call so the three are guaranteed to describe the
+// same Swap version — calling Snapshot/ModelName/RuntimeParameters
+// separately would risk a torn read if a hot-reload landed between calls
+// (#1610).
 func (r *DefaultPhaseResolver) ResolvePhase(phase katypes.Phase) (llm.Client, string, llm.RuntimeParams) {
 	r.mu.RLock()
 	sw, ok := r.phaseSwappables[phase]
@@ -69,20 +75,18 @@ func (r *DefaultPhaseResolver) ResolvePhase(phase katypes.Phase) (llm.Client, st
 		sw = r.defaultSwappable
 	}
 
-	pinned := sw.Snapshot()
-	modelName := sw.ModelName()
-	params := sw.RuntimeParameters()
+	snap := sw.Pin()
 
 	var client llm.Client
 	if r.pinDecorator != nil {
-		client = r.pinDecorator(pinned)
+		client = r.pinDecorator(snap.Client)
 		if client == nil {
-			client = llm.NewInstrumentedClient(pinned)
+			client = llm.NewInstrumentedClient(snap.Client)
 		}
 	} else {
-		client = llm.NewInstrumentedClient(pinned)
+		client = llm.NewInstrumentedClient(snap.Client)
 	}
-	return client, modelName, params
+	return client, snap.ModelName, snap.RuntimeParams
 }
 
 // SetPhaseSwappable adds or replaces a phase-specific SwappableClient.

--- a/pkg/kubernautagent/llm/swappable_client.go
+++ b/pkg/kubernautagent/llm/swappable_client.go
@@ -38,6 +38,10 @@ const oldClientCloseTimeout = 5 * time.Second
 //     so it never blocks callers.
 //   - Snapshot returns a bare llm.Client pinned at the current moment;
 //     subsequent Swap calls do not affect outstanding snapshots.
+//   - Pin (#1610) atomically captures Client+ModelName+RuntimeParams under
+//     one lock acquisition; callers needing more than one of these values
+//     together should use Pin rather than calling Snapshot/ModelName/
+//     RuntimeParameters separately, which can observe a torn combination.
 // RuntimeParams holds LLM runtime parameters that can be hot-reloaded
 // alongside the client. Investigator reads these at the start of each
 // investigation to pin values for the duration.
@@ -125,6 +129,38 @@ func (sc *SwappableClient) Snapshot() Client {
 	c := sc.inner
 	sc.mu.RUnlock()
 	return c
+}
+
+// PinnedSnapshot is an atomically-captured, mutually consistent view of a
+// SwappableClient's client, model name, and runtime params at a single
+// point in time. All three fields are guaranteed to come from the same
+// Swap "version" — see Pin.
+type PinnedSnapshot struct {
+	Client        Client
+	ModelName     string
+	RuntimeParams RuntimeParams
+}
+
+// Pin atomically captures the client, model name, and runtime params under
+// a single lock acquisition, so the three are guaranteed to describe the
+// same Swap version.
+//
+// Prefer Pin over calling Snapshot, ModelName, and RuntimeParameters
+// separately when a caller needs more than one of these values to jointly
+// describe the same point in time (e.g. resolving the client to pin for the
+// duration of an investigation phase, #1610): each of those three methods
+// takes/releases the lock independently, so a Swap landing between two
+// calls can return a torn combination (e.g. the pre-swap Client paired with
+// the post-swap RuntimeParams). Every individual field read is race-free
+// under go test -race — only the cross-field combination is at risk.
+func (sc *SwappableClient) Pin() PinnedSnapshot {
+	sc.mu.RLock()
+	defer sc.mu.RUnlock()
+	return PinnedSnapshot{
+		Client:        sc.inner,
+		ModelName:     sc.modelName,
+		RuntimeParams: sc.runtimeParams,
+	}
 }
 
 // ModelName returns the model name associated with the current inner client.

--- a/pkg/kubernautagent/llm/swappable_client_1610_test.go
+++ b/pkg/kubernautagent/llm/swappable_client_1610_test.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package llm_test
+
+import (
+	"strconv"
+	"sync"
+	"sync/atomic"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+)
+
+var _ = Describe("SwappableClient.Pin — atomic client+model+params snapshot (#1610)", func() {
+
+	Describe("UT-KA-1610-001: Pin never observes a torn read across concurrent Swap", func() {
+		It("should return a Client/ModelName/RuntimeParams triple from the same Swap version every time", func() {
+			const iterations = 5000
+
+			original := &recordingClient{id: "0"}
+			sc, err := llm.NewSwappableClient(original, "model-0", llm.RuntimeParams{Temperature: 0})
+			Expect(err).NotTo(HaveOccurred())
+
+			var mismatches atomic.Int64
+			var wg sync.WaitGroup
+			stop := make(chan struct{})
+
+			// Writer: swaps in a new client/model/params triple on every
+			// iteration, each uniquely identifiable by index.
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer close(stop)
+				for i := 1; i <= iterations; i++ {
+					id := strconv.Itoa(i)
+					_ = sc.Swap(&recordingClient{id: id}, "model-"+id, llm.RuntimeParams{Temperature: float64(i)})
+				}
+			}()
+
+			// Readers: repeatedly Pin() and verify the returned triple is
+			// internally consistent (ModelName/RuntimeParams describe the
+			// exact same Swap version as the returned Client).
+			for w := 0; w < 8; w++ {
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					for {
+						select {
+						case <-stop:
+							return
+						default:
+						}
+						snap := sc.Pin()
+						rc, ok := snap.Client.(*recordingClient)
+						if !ok {
+							mismatches.Add(1)
+							continue
+						}
+						idx, convErr := strconv.Atoi(rc.id)
+						if convErr != nil {
+							mismatches.Add(1)
+							continue
+						}
+						if snap.ModelName != "model-"+rc.id || snap.RuntimeParams.Temperature != float64(idx) {
+							mismatches.Add(1)
+						}
+					}
+				}()
+			}
+
+			wg.Wait()
+			Expect(mismatches.Load()).To(BeZero(),
+				"Pin() must return a mutually consistent (Client, ModelName, RuntimeParams) triple even under concurrent Swap")
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Closes #1599. Also fixes #1610 (found during #1599 preflight, tracked and
fixed as a separate follow-up).

- **#1599**: KA's hot-reload path silently accepted `model` changes (base
  and per-phase-override), and cross-provider `phaseModels` overrides were
  demonstrated as a supported example in docs. This risks replaying one
  provider's opaque reasoning signature (e.g. Anthropic's thinking-block
  `Signature` bytes) against a different provider/model that never issued
  it. `llmRuntimeReloadCallback` now validates candidate reloads
  atomically: any base or per-phase identity change (provider+model)
  rejects the *entire* candidate payload — including any otherwise-safe
  tuning changes bundled in the same reload — and requires a process
  restart. AF was investigated and confirmed already restart-only for
  every config field (no live-swap mechanism exists there at all), so no
  AF production code changed; a regression test proves this.
- **#1610**: `DefaultPhaseResolver.ResolvePhase` and
  `Investigator.resolveForPhase`'s legacy branch fetched a phase's client,
  model name, and runtime params via three independent
  `SwappableClient` lock acquisitions, which could return a torn
  combination if a hot-reload landed mid-sequence. Added
  `SwappableClient.Pin()`, capturing all three under one lock, and
  switched both call sites to use it.

## What changed

- `cmd/kubernautagent/llm_builder.go`: `llmRuntimeReloadCallback` now takes
  a frozen `bootRuntime` snapshot and enforces the identity lock via
  `parseAndAuthorizeReload`/`validatePhaseIdentity` before applying any
  reload.
- `cmd/kubernautagent/bootstrap.go`, `main.go`: thread `bootRuntime` through
  to the reload callback; `wireHotReload` refactored to a params struct
  (was at the 8-param anti-pattern limit).
- `cmd/kubernautagent/reload_callback_783_test.go`,
  `reload_callback_1470_test.go`: rewritten to assert rejection of base and
  per-phase identity changes (previously asserted acceptance).
- `cmd/apifrontend/main.go`, new `reload_identity_test.go`: regression test
  proving AF's `configReloadCallback` validates but never mutates live
  config.
- `pkg/kubernautagent/llm/swappable_client.go`: new `Pin()` atomic snapshot
  + regression stress test (`swappable_client_1610_test.go`) proving no
  torn reads under concurrent `Swap`.
- `internal/kubernautagent/investigator/{phase_resolver,investigator}.go`:
  use `Pin()` instead of three separate calls.
- Docs: new `DD-LLM-008` design decision record; `BR-HAPI-199` marked
  superseded (described a pre-Go-rewrite Python PoC, incorrectly claiming
  `model`/`provider` are hot-reloadable); `783` `TEST_PLAN.md` BR citations
  corrected; KA `configuration-reference.md` updated (model immutability,
  `phaseModels` identity rules); new AF `configuration-reference.md`
  (AF had none previously); both gain a deployment-topology section
  (Operator/Helm/GitOps restart triggers, referencing stakater/Reloader
  for GitOps rather than reimplementing it).

## Out of scope

- Azure AD/Entra Bearer-token auth, cross-repo `kubernaut-operator`/
  `kubernaut-docs` issues for this change were filed separately (see
  #1599 discussion).

## Test plan

- [x] `go build ./...`
- [x] `golangci-lint run` on all touched packages — 0 issues
- [x] `go test -race` on `pkg/kubernautagent/...`, `internal/kubernautagent/...`,
      `cmd/kubernautagent/...`, `cmd/apifrontend/...` — all pass
- [x] New `#1610` stress test confirmed to catch the bug (8176 mismatches)
      when `Pin()` was temporarily reimplemented as three separate calls,
      before reverting to the atomic fix

Made with [Cursor](https://cursor.com)