### PR TITLE
fix(helm): scope hook ClusterRole RBAC to tls.mode and auto-provision datastorage-signing-cert

### DIFF
--- a/charts/kubernaut/README.md
+++ b/charts/kubernaut/README.md
@@ -527,6 +527,20 @@ cluster's other known peers.
 | `tls.mode` | `hook` (self-signed), `cert-manager` (production), or `manual` | `hook` |
 | `tls.certManager.issuerRef.name` | Issuer/ClusterIssuer name. When mode=cert-manager and left empty, auto-selected via `lookup` if exactly one exists in the cluster (real `helm install`/`upgrade` only); required if rendering via `helm template`/GitOps or if multiple issuers exist | `""` |
 
+> **`datastorage-signing-cert` prerequisite** (#334): DataStorage signs audit exports with an
+> RSA 2048 key for tamper-evidence (AU-9) and **fails to start with no fallback** if this key is
+> missing. In `tls.mode=cert-manager`, the chart auto-provisions it via a `Certificate` resource
+> (same as `authwebhook-tls`) — no action needed. In `tls.mode=manual`, you must create it
+> yourself before installing:
+>
+> ```bash
+> openssl genrsa -out /tmp/signing-tls.key 2048
+> openssl req -new -x509 -days 365 -key /tmp/signing-tls.key \
+>   -out /tmp/signing-tls.crt -subj "/CN=datastorage-signing-cert"
+> kubectl create secret tls datastorage-signing-cert \
+>   --cert=/tmp/signing-tls.crt --key=/tmp/signing-tls.key -n kubernaut-system
+> ```
+
 ### NetworkPolicies
 
 | Parameter | Description | Default |

--- a/charts/kubernaut/templates/NOTES.txt
+++ b/charts/kubernaut/templates/NOTES.txt
@@ -89,7 +89,8 @@ Certificates are automatically renewed during upgrade if they expire within 30 d
 {{- else if eq .Values.tls.mode "cert-manager" }}
 TLS mode: cert-manager (certificates managed by cert-manager).
 The authwebhook-cert Certificate resource provisions the authwebhook-tls Secret.
-cert-manager handles renewal automatically.
+The datastorage-signing-cert Certificate resource provisions DataStorage's AU-9
+audit-signing key (#334). cert-manager handles renewal automatically for both.
 {{- else if eq .Values.tls.mode "manual" }}
 TLS mode: manual (user-managed certificates).
 You must create the authwebhook-tls Secret (type kubernetes.io/tls) and patch the
@@ -102,6 +103,16 @@ MutatingWebhookConfiguration and ValidatingWebhookConfiguration with the CA bund
 
    kubectl patch mutatingwebhookconfigurations authwebhook-mutating --type=json \
      -p "[{\"op\":\"add\",\"path\":\"/webhooks/0/clientConfig/caBundle\",\"value\":\"${CA_B64}\"}]"
+
+You must also create the datastorage-signing-cert Secret (type kubernetes.io/tls,
+RSA 2048 key) for DataStorage's AU-9 audit-signing key -- DataStorage fails to
+start without it, with no fallback (#334):
+
+   openssl genrsa -out /tmp/signing-tls.key 2048
+   openssl req -new -x509 -days 365 -key /tmp/signing-tls.key \
+     -out /tmp/signing-tls.crt -subj "/CN=datastorage-signing-cert"
+   kubectl create secret tls datastorage-signing-cert \
+     --cert=/tmp/signing-tls.crt --key=/tmp/signing-tls.key -n {{ .Release.Namespace }}
 {{- end }}
 
 === Uninstalling ===

--- a/charts/kubernaut/templates/datastorage/certificate.yaml
+++ b/charts/kubernaut/templates/datastorage/certificate.yaml
@@ -1,0 +1,28 @@
+{{- if eq .Values.tls.mode "cert-manager" }}
+# #334: datastorage-signing-cert is DataStorage's AU-9 audit-signing key
+# (pkg/cert.Signer), not a network-facing TLS cert -- no dnsNames needed,
+# just a stable RSA keypair signed by the configured issuer. Mirrors what the
+# hook-mode tls-cert-gen Job creates via
+# `openssl req -x509 -subj "/CN=datastorage-signing-cert"`. Without this,
+# tls.mode=cert-manager never provisions the secret and DataStorage's
+# loadSigningCertificate fails hard (no fallback, by AU-9 design).
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: datastorage-signing-cert
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "kubernaut.labels" . | nindent 4 }}
+spec:
+  secretName: datastorage-signing-cert
+  duration: 8760h   # 365 days
+  renewBefore: 720h  # 30 days
+  privateKey:
+    algorithm: RSA
+    size: 2048
+  issuerRef:
+    name: {{ include "kubernaut.tls.issuerName" . }}
+    kind: {{ .Values.tls.certManager.issuerRef.kind }}
+    group: {{ .Values.tls.certManager.issuerRef.group }}
+  commonName: datastorage-signing-cert
+{{- end }}

--- a/charts/kubernaut/templates/hooks/tls-cert-job.yaml
+++ b/charts/kubernaut/templates/hooks/tls-cert-job.yaml
@@ -373,9 +373,18 @@ metadata:
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation
 rules:
+  # #334: webhook-cleanup (pre-delete) runs in every tls.mode, so delete must
+  # stay unconditional. get/patch are only used by tls-cabundle-patch, which
+  # only exists in hook mode -- granting them in cert-manager/manual mode
+  # would be unused, least-privilege-violating access.
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
-    verbs: ["get", "patch", "delete"]
+    verbs: ["delete"]
+  {{- if eq .Values.tls.mode "hook" }}
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+    verbs: ["get", "patch"]
+  {{- end }}
   # #521: CRD upgrade hook needs SSA permissions on CRDs.
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]

--- a/charts/kubernaut/tests/tls_mode_test.yaml
+++ b/charts/kubernaut/tests/tls_mode_test.yaml
@@ -1,0 +1,177 @@
+suite: TLS mode conditional RBAC and Certificate resources (#334)
+templates:
+  - templates/hooks/tls-cert-job.yaml
+  - templates/authwebhook/certificate.yaml
+  - templates/datastorage/certificate.yaml
+set:
+  postgresql:
+    auth:
+      existingSecret: dummy
+  valkey:
+    existingSecret: dummy
+  kubernautAgent:
+    llm:
+      provider: openai
+      model: gpt-4
+  # kubernaut.tls.issuerName requires an explicit issuerRef.name when there is
+  # no live cluster access to auto-discover an Issuer/ClusterIssuer (helm
+  # template / helm-unittest / GitOps rendering all fall into this path).
+  tls:
+    certManager:
+      issuerRef:
+        name: test-issuer
+tests:
+  - it: "hook mode: kubernaut-hook-role grants delete unconditionally"
+    set:
+      tls:
+        mode: hook
+    template: templates/hooks/tls-cert-job.yaml
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["admissionregistration.k8s.io"]
+            resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+            verbs: ["delete"]
+
+  - it: "hook mode: kubernaut-hook-role also grants get+patch (tls-cabundle-patch needs it)"
+    set:
+      tls:
+        mode: hook
+    template: templates/hooks/tls-cert-job.yaml
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["admissionregistration.k8s.io"]
+            resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+            verbs: ["get", "patch"]
+
+  - it: "hook mode: kubernaut-hook-role still grants CRD SSA permissions (regression guard)"
+    set:
+      tls:
+        mode: hook
+    template: templates/hooks/tls-cert-job.yaml
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["apiextensions.k8s.io"]
+            resources: ["customresourcedefinitions"]
+            verbs: ["get", "list", "create", "update", "patch"]
+
+  - it: "cert-manager mode: kubernaut-hook-role does NOT grant get/patch on webhook configs (#334)"
+    set:
+      tls:
+        mode: cert-manager
+    template: templates/hooks/tls-cert-job.yaml
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["admissionregistration.k8s.io"]
+            resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+            verbs: ["delete"]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["admissionregistration.k8s.io"]
+            resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+            verbs: ["get", "patch"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["apiextensions.k8s.io"]
+            resources: ["customresourcedefinitions"]
+            verbs: ["get", "list", "create", "update", "patch"]
+
+  - it: "manual mode: kubernaut-hook-role does NOT grant get/patch on webhook configs (#334)"
+    set:
+      tls:
+        mode: manual
+    template: templates/hooks/tls-cert-job.yaml
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["admissionregistration.k8s.io"]
+            resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+            verbs: ["delete"]
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["admissionregistration.k8s.io"]
+            resources: ["mutatingwebhookconfigurations", "validatingwebhookconfigurations"]
+            verbs: ["get", "patch"]
+
+  - it: "cert-manager mode: datastorage-signing-cert Certificate is auto-provisioned"
+    set:
+      tls:
+        mode: cert-manager
+    template: templates/datastorage/certificate.yaml
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: spec.secretName
+          value: datastorage-signing-cert
+      - equal:
+          path: spec.privateKey.algorithm
+          value: RSA
+      - equal:
+          path: spec.privateKey.size
+          value: 2048
+
+  - it: "cert-manager mode: authwebhook-cert Certificate still renders (regression guard)"
+    set:
+      tls:
+        mode: cert-manager
+    template: templates/authwebhook/certificate.yaml
+    documentSelector:
+      path: metadata.name
+      value: authwebhook-cert
+    asserts:
+      - isKind:
+          of: Certificate
+      - equal:
+          path: spec.secretName
+          value: authwebhook-tls
+
+  - it: "hook mode: no Certificate resources rendered (hook Job manages certs instead)"
+    set:
+      tls:
+        mode: hook
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/authwebhook/certificate.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/datastorage/certificate.yaml
+
+  - it: "manual mode: no Certificate resources rendered (user-managed)"
+    set:
+      tls:
+        mode: manual
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/authwebhook/certificate.yaml
+      - hasDocuments:
+          count: 0
+        template: templates/datastorage/certificate.yaml

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -49,8 +49,12 @@ fullnameOverride: ""
 #                  No external dependencies. Certs are stored in authwebhook-tls Secret.
 #   cert-manager - Certificates managed by cert-manager (recommended for production).
 #                  Requires cert-manager installed and an Issuer/ClusterIssuer configured.
+#                  Also auto-provisions DataStorage's AU-9 audit-signing key
+#                  (datastorage-signing-cert Certificate/Secret) -- #334.
 #   manual       - User-managed certificates. The chart creates no TLS resources or hooks.
-#                  The user must create the authwebhook-tls Secret and patch webhook caBundle.
+#                  The user must create the authwebhook-tls Secret and patch webhook caBundle,
+#                  AND create the datastorage-signing-cert Secret (type kubernetes.io/tls,
+#                  RSA 2048) -- DataStorage fails to start without it, no fallback (#334).
 #                  Suitable for service meshes, external PKI, or CI environments.
 tls:
   mode: hook  # "hook", "cert-manager", or "manual"


### PR DESCRIPTION
## Summary

- Splits the `admissionregistration.k8s.io` rule in `kubernaut-hook-role` so `get`/`patch` (needed only by `tls-cabundle-patch`) are gated on `tls.mode=hook`, while `delete` (needed by `webhook-cleanup` in every mode) stays unconditional.
- Auto-provisions DataStorage's AU-9 audit-signing key (`datastorage-signing-cert`) via a `cert-manager.io/v1 Certificate` (mirrors `authwebhook-cert`) when `tls.mode=cert-manager`. Previously this secret was never created outside `tls.mode=hook`, permanently blocking DataStorage startup (no fallback, by AU-9 design). Documented as a manual prerequisite for `tls.mode=manual`.
- Both fixes were empirically validated against a live Kind + ArgoCD (stable) + cert-manager v1.20.3 deployment, in addition to new `helm-unittest` coverage. See #1617 for the full GitOps-readiness spike writeup.

Fixes #334. Contributes to #1617.

## Test plan

- [x] New `charts/kubernaut/tests/tls_mode_test.yaml`: 9 `helm-unittest` cases covering RBAC scoping (hook/cert-manager/manual) and `Certificate` rendering, all passing.
- [x] Full existing `helm-unittest` suite still passing (16/16).
- [x] `helm lint` clean.
- [x] `helm template` clean for all 3 `tls.mode` values.
- [x] Live validation: deployed via ArgoCD against a Kind cluster with cert-manager; confirmed `kubectl get clusterrole kubernaut-hook-role` has no `get`/`patch` on webhook configs in `cert-manager` mode; confirmed DataStorage pod progresses past the previously-permanent `secret "datastorage-signing-cert" not found` mount failure and reaches `Running`.

Made with [Cursor](https://cursor.com)