### PR TITLE
feat(apifrontend): add OpenAI-compatible severity triage LLM support (#1618)

### DIFF
--- a/cmd/apifrontend/backend_deps.go
+++ b/cmd/apifrontend/backend_deps.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/ds"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/handler"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/metrics"
 	prom "github.com/jordigilh/kubernaut/pkg/apifrontend/prometheus"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/resilience"
@@ -41,6 +42,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/fleet/readiness"
 	"github.com/jordigilh/kubernaut/pkg/fleet/registry"
 	"github.com/jordigilh/kubernaut/pkg/shared/hotreload"
+	"github.com/jordigilh/kubernaut/pkg/shared/llm/openaicompat"
 	"github.com/jordigilh/kubernaut/pkg/shared/types"
 )
 
@@ -581,6 +583,8 @@ func adaptFleetReaderFactory(rf fleet.ReaderFactory) tools.ResourceReaderFactory
 //   - vertex_ai + other model → GenAITriager (Google GenAI SDK)
 //   - gemini → GenAITriager (Gemini API)
 //   - anthropic → AnthropicTriager (direct Anthropic API)
+//   - openai / openai_compatible → OpenAICompatibleTriager (shared openaicompat
+//     client — OpenAI, Azure OpenAI, vLLM, Ollama, LlamaStack, self-hosted; #1618)
 func newLLMTriagerFromConfig(ctx context.Context, llmCfg types.LLMConfig, logger logr.Logger) (severity.LLMTriager, error) {
 	switch llmCfg.Provider {
 	case types.LLMProviderVertexAI:
@@ -592,6 +596,8 @@ func newLLMTriagerFromConfig(ctx context.Context, llmCfg types.LLMConfig, logger
 		return newGenAITriagerForGemini(ctx, llmCfg, logger)
 	case types.LLMProviderAnthropic:
 		return newAnthropicTriagerDirect(ctx, llmCfg, logger)
+	case types.LLMProviderOpenAI, types.LLMProviderOpenAICompatible:
+		return newOpenAICompatibleTriager(llmCfg, logger)
 	default:
 		return nil, fmt.Errorf("unsupported triage LLM provider: %q", llmCfg.Provider)
 	}
@@ -654,6 +660,33 @@ func newAnthropicTriagerDirect(_ context.Context, llmCfg types.LLMConfig, logger
 		return nil, fmt.Errorf("anthropic direct client: %w", err)
 	}
 	return severity.NewAnthropicTriager(severity.AnthropicTriagerConfig{
+		Client: client,
+		Model:  llmCfg.Model,
+		Logger: logger,
+	}), nil
+}
+
+// newOpenAICompatibleTriager builds an LLMTriager backed by the shared
+// openaicompat client (#1618), reusing the same TLS/OAuth2/custom-header/
+// circuit-breaker transport chain as AF's main-agent OpenAI-compatible
+// model (launcher.BuildLLMHTTPClient) so severity triage gets identical
+// resilience/auth behavior to the agent it triages for.
+func newOpenAICompatibleTriager(llmCfg types.LLMConfig, logger logr.Logger) (severity.LLMTriager, error) {
+	httpClient, err := launcher.BuildLLMHTTPClient(llmCfg)
+	if err != nil {
+		return nil, fmt.Errorf("build HTTP client: %w", err)
+	}
+
+	var opts []openaicompat.Option
+	if httpClient != nil {
+		opts = append(opts, openaicompat.WithHTTPClient(httpClient))
+	}
+	if llmCfg.AzureAPIVersion != "" {
+		opts = append(opts, openaicompat.WithAzureAPIVersion(llmCfg.AzureAPIVersion))
+	}
+
+	client := openaicompat.New(llmCfg.Model, llmCfg.Endpoint, llmCfg.APIKey, opts...)
+	return severity.NewOpenAICompatibleTriager(severity.OpenAICompatibleTriagerConfig{
 		Client: client,
 		Model:  llmCfg.Model,
 		Logger: logger,

--- a/cmd/apifrontend/main_wiring_test.go
+++ b/cmd/apifrontend/main_wiring_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/ratelimit"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/resilience"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/session"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/severity"
 	"github.com/jordigilh/kubernaut/pkg/shared/types"
 )
 
@@ -1780,7 +1781,10 @@ func TestTriageConfigResolution_ExplicitOverridesAgent(t *testing.T) {
 
 func TestNewLLMTriagerFromConfig_RejectsUnsupportedProvider(t *testing.T) {
 	logger := logr.Discard()
-	cfg := types.LLMConfig{Provider: "openai", Model: "gpt-4"}
+	// "azure" alone (without provider: openai + AzureAPIVersion) isn't a
+	// recognized provider value in its own right — genuinely unsupported,
+	// unlike "openai"/"openai_compatible" which are now routed (#1618).
+	cfg := types.LLMConfig{Provider: "azure", Model: "gpt-4"}
 
 	_, err := newLLMTriagerFromConfig(context.Background(), cfg, logger)
 	if err == nil {
@@ -1788,5 +1792,33 @@ func TestNewLLMTriagerFromConfig_RejectsUnsupportedProvider(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unsupported") {
 		t.Errorf("expected 'unsupported' in error, got: %v", err)
+	}
+}
+
+// TestNewLLMTriagerFromConfig_AcceptsOpenAICompatible proves #1618's fix:
+// severity triage no longer errors at startup for openai/openai_compatible
+// providers, closing the gap that made AF's severity-triage feature
+// unusable in fully local/air-gapped deployments (ADR-002's stated goal)
+// even though the main agent already supports these providers.
+func TestNewLLMTriagerFromConfig_AcceptsOpenAICompatible(t *testing.T) {
+	logger := logr.Discard()
+
+	for _, provider := range []string{types.LLMProviderOpenAI, types.LLMProviderOpenAICompatible} {
+		cfg := types.LLMConfig{
+			Provider: provider,
+			Model:    "openai/gpt-oss-120b",
+			Endpoint: "http://localhost:8000",
+		}
+
+		triager, err := newLLMTriagerFromConfig(context.Background(), cfg, logger)
+		if err != nil {
+			t.Fatalf("IT-AF-1618-001: provider %q: expected no error, got: %v", provider, err)
+		}
+		if triager == nil {
+			t.Fatalf("IT-AF-1618-001: provider %q: expected non-nil triager", provider)
+		}
+		if _, ok := triager.(*severity.OpenAICompatibleTriager); !ok {
+			t.Errorf("IT-AF-1618-001: provider %q: expected *severity.OpenAICompatibleTriager, got %T", provider, triager)
+		}
 	}
 }

--- a/docs/development/getting-started/setup/LLM_SETUP_GUIDE.md
+++ b/docs/development/getting-started/setup/LLM_SETUP_GUIDE.md
@@ -1,5 +1,18 @@
 # LLM Integration Setup Guide
 
+> **⚠️ SUPERSEDED for KA/AF (v1.5.2+)**: the `SLM_*` environment-variable
+> scheme and `localai`/`ramalama` provider names below describe a
+> pre-microservices-architecture setup (a monolithic `kubernaut` binary) and
+> do not apply to the current Kubernaut Agent (`cmd/kubernautagent`) or API
+> Frontend (`cmd/apifrontend`) services. For running KA and/or AF locally
+> against a self-hosted OpenAI-compatible model (vLLM, Ollama, LlamaStack),
+> see
+> [`LOCAL_SELF_HOSTED_LLM_v1.5.2.md`](LOCAL_SELF_HOSTED_LLM_v1.5.2.md)
+> (v1.5.2) or
+> [`docs/services/kubernaut-agent/configuration-reference.md`](../../../services/kubernaut-agent/configuration-reference.md)
+> / [`docs/services/apifrontend/configuration-reference.md`](../../../services/apifrontend/configuration-reference.md)
+> (1.6.0/`main`). This document is retained for historical reference only.
+
 ## 🚀 Quick Start for Local LLM (192.168.1.169:8080)
 
 ### Option 1: Environment Variables (Recommended)

--- a/docs/development/getting-started/setup/LOCAL_SELF_HOSTED_LLM_v1.5.2.md
+++ b/docs/development/getting-started/setup/LOCAL_SELF_HOSTED_LLM_v1.5.2.md
@@ -201,11 +201,67 @@ Notes:
 
 ## 5. Operational recommendations for the pilot
 
-- **Raise the AA auto-approval confidence threshold** (`rego.confidenceThreshold`,
-  default `0.8`) for the duration of the pilot — e.g. `0.92` — to compensate
-  for a weaker/self-hosted model's typically higher hallucination rate and
-  lower agentic/tool-use reliability relative to a frontier hosted model.
-  Relax it only after comparing outcomes against your existing baseline.
+### On the auto-approval confidence threshold: don't trust a number you haven't measured
+
+The Rego approval policy's `confidence_threshold` (`rego.confidenceThreshold`,
+default `0.8`) is, in practice, **the only gate standing between an LLM's
+remediation suggestion and unattended execution** — approval-required actions
+aside (sensitive resource kinds, missing remediation target,
+infrastructure-provisioning actions), it's the sole confidence-based control
+(`pkg/aianalysis/testdata/policies/approval.rego`: `is_high_confidence if {
+input.confidence >= confidence_threshold }`). It is worth understanding
+exactly what that number is before leaning on it as a pilot safety lever:
+
+- `confidence` is **entirely LLM self-report** — a byproduct of the model
+  narrating its own uncertainty in the RCA prompt's "Pre-Submit Adversarial
+  Due Diligence" step ("Start at 1.0 and list each factor that reduced it...":
+  `internal/kubernautagent/prompt/templates/incident_investigation.tmpl`).
+  There is no log-prob-based score, no independent verifier, no
+  self-consistency/ensemble check, and no historical calibration curve behind
+  it — just the model grading its own homework.
+- The JSON schema enforces that the calibration field is *present* as a
+  string (`internal/kubernautagent/parser/schema.go`), not that it's truthful
+  or substantive. A model can satisfy the schema with a generic placeholder
+  sentence while still reporting `confidence: 0.95`.
+- Raising the threshold (e.g. to `0.92`) only filters cases where the model
+  is self-aware enough to flag its own gaps. It does **nothing** for a
+  confidently wrong RCA — a hallucination the model sincerely (if
+  miscalibrated-ly) believes is correct — which is the more dangerous class
+  of error precisely because it clears any threshold you pick. Worse, the
+  same weak agentic reliability that motivates using a higher threshold in
+  the first place (missed evidence, premature investigation abort per
+  [#1613](https://github.com/jordigilh/kubernaut/issues/1613), truncated
+  output silently accepted per
+  [#1614](https://github.com/jordigilh/kubernaut/issues/1614)) is exactly
+  what undermines the model's ability to *recognize* those same gaps when
+  self-scoring its confidence. Leaning on self-reported confidence to
+  compensate for unreliable self-assessment is circular.
+- **Kubernaut has no eval harness that runs candidate models against its own
+  demo scenarios to measure RCA accuracy or confidence calibration.** Demo
+  scenarios exist as a specification
+  (`docs/requirements/BR-PLATFORM-002-demo-scenario-specification.md`), but
+  nothing today replays them against a candidate model and compares
+  self-reported confidence to human-verified correctness. Without that, any
+  specific threshold value — `0.8`, `0.92`, or otherwise — is a guess, not a
+  measurement, for any given model.
+
+**Recommendation**: don't tune the threshold as your primary mitigation for
+this pilot. Instead:
+
+- Treat **100% human review** as the default for the pilot's duration,
+  independent of whatever `confidence` the model reports — the threshold
+  should not be trusted to do this job until it's been validated.
+- If/when an eval harness against Kubernaut's own demo scenarios exists,
+  use it to measure the model's actual confidence-vs-correctness calibration
+  first, and only then decide whether any threshold value buys real
+  precision — and what that value should be. (Tracked:
+  [#1622](https://github.com/jordigilh/kubernaut/issues/1622).)
+- Relax to threshold-based auto-approval only after that comparison shows
+  the model's self-reported confidence is a meaningfully predictive signal
+  for your workload, not before.
+
+### Other recommendations
+
 - **Validate tool-calling end-to-end through each service's actual adapter**
   (not just a raw `curl` to vLLM) before trusting the pilot — see §2.
 - **Don't rely on hot-reload to swap models** on KA — restart manually (§3).

--- a/docs/development/getting-started/setup/LOCAL_SELF_HOSTED_LLM_v1.5.2.md
+++ b/docs/development/getting-started/setup/LOCAL_SELF_HOSTED_LLM_v1.5.2.md
@@ -1,0 +1,246 @@
+# Running KA + AF locally against a self-hosted OpenAI-compatible LLM (v1.5.2)
+
+**Applies to**: `v1.5.2` only. Kubernaut Agent's (KA) LLM client stack changed
+materially in 1.6.0 (`langchaingo` removal, shared `openaicompat` client,
+[DD-LLM-008](../../../architecture/decisions/DD-LLM-008-restart-required-llm-identity-lock.md)
+identity lock, [#1604](https://github.com/jordigilh/kubernaut/issues/1604)
+reasoning-effort knob) — none of that exists at this tag. If you're running
+`main`/1.6.0+, this doc's *architecture* section doesn't apply to you (though
+the vLLM server-side recommendations still do); check
+[`configuration-reference.md`](../../../services/kubernaut-agent/configuration-reference.md)
+instead.
+
+This doc is for operators/contributors who want to point a locally-running
+KA and/or AF at a self-hosted, OpenAI-API-compatible model server (vLLM,
+Ollama, LlamaStack, etc.) instead of a hosted provider (Anthropic, OpenAI,
+Vertex AI, Gemini). It consolidates findings from a real pilot exercise
+(vLLM serving `gpt-oss-120b`), but the configuration guidance applies to any
+self-hosted OpenAI-compatible model of similar or lower agentic capability
+than a frontier hosted model.
+
+> If you just want a stale-doc pointer: this supersedes the "Quick Start for
+> Local LLM" section of [`LLM_SETUP_GUIDE.md`](LLM_SETUP_GUIDE.md), which
+> describes a pre-microservices-architecture `SLM_*` env var scheme that no
+> longer applies to KA or AF.
+
+---
+
+## 1. Architecture — KA and AF use *different* LLM client stacks at v1.5.2
+
+This is the single most important thing to understand before configuring
+either service — they don't share code here, and their capabilities differ:
+
+| | KA (`cmd/kubernautagent`) | AF main agent (`cmd/apifrontend`, A2A) | AF severity triage (`cmd/apifrontend`) |
+|---|---|---|---|
+| Client library | `tmc/langchaingo` (`pkg/kubernautagent/llm/langchaingo/adapter.go`) | in-house ADK adapter (`pkg/apifrontend/launcher/openai/adapter.go`) | Google GenAI SDK / Anthropic SDK only |
+| Self-hosted OpenAI-compatible endpoint support | Yes — `provider: openai` + `endpoint` | Yes — `provider: openai` or `openai_compatible` + `endpoint` | **No** — provider switch only recognizes `vertex_ai`, `gemini`, `anthropic`; anything else errors at startup |
+| Retry on transient errors | Only on a non-streaming fallback path production doesn't use in practice | None | N/A (not usable) |
+| Resilience | None beyond `maxRetries` (see caveat in §3) | `circuitBreaker` (open/half-open/closed), applied to the transport | N/A |
+| Reasoning-token capture (`reasoning_content`) | Not implemented — silently dropped | Not implemented | N/A |
+| `tool_choice` forcing | Not implemented | Not implemented | N/A |
+
+**Practical consequence**: if you're running fully local/self-hosted with no
+cloud LLM credentials at all, **AF's severity-triage feature cannot use your
+self-hosted model** and will fail to start if `severityTriage.enabled: true`
+with a non-`vertex_ai`/`gemini`/`anthropic` provider. Either set
+`severityTriage.enabled: false`, or point `severityTriage.llm` at a real
+cloud credential separately from `agent.llm` (the two are independently
+configurable — `severityTriage.llm` falls back to `agent.llm` only if unset,
+per `triageLLMSource` in `cmd/apifrontend/main.go`). This is a tracked gap,
+not a deliberate design decision — see
+[#1618](https://github.com/jordigilh/kubernaut/issues/1618) — and is present
+on `main` too, not just this release.
+
+---
+
+## 2. vLLM (or equivalent) server setup
+
+Independent of Kubernaut's version. Example for `gpt-oss-120b`:
+
+```bash
+vllm serve openai/gpt-oss-120b \
+  --tool-call-parser openai \
+  --reasoning-parser openai_gptoss \
+  --enable-auto-tool-choice \
+  --default-chat-template-kwargs '{"reasoning_effort": "high"}' \
+  --max-model-len 131072
+```
+
+- `--default-chat-template-kwargs` sets the server-side default reasoning
+  effort. Neither KA nor AF sends a `reasoning_effort` request parameter at
+  v1.5.2 (see §5), so this is the *only* way to control it — set it once at
+  the server, not per-request.
+- Verify `--reasoning-parser`/`--tool-call-parser` flag names against your
+  installed vLLM version; they've changed across releases and gpt-oss
+  tool-calling had multiple correctness bugs fixed through v0.10.2+. Pin a
+  recent, tested version.
+- Test your actual tool set through KA's `langchaingo` adapter and AF's
+  in-house adapter directly before trusting a pilot — both are independent,
+  simpler HTTP-mapping layers than a raw `curl` against vLLM, and each could
+  mishandle gpt-oss-specific response quirks differently.
+
+---
+
+## 3. KA configuration (`config.yaml` + `llm-runtime.yaml`)
+
+### Static config (`config.yaml`)
+
+```yaml
+ai:
+  llm:
+    provider: openai        # not "openai_compatible" — that value doesn't exist in KA at v1.5.2
+    model: openai/gpt-oss-120b
+    endpoint: http://<vllm-host>:8000   # langchaingo adapter appends /v1 itself
+  investigation:
+    maxTurns: 50             # default 40 — see §6 risk #1613/#1615 trade-off before raising further
+  safety:
+    anomaly:
+      maxToolCallsPerTool: 15   # default 10 — soft limit, safe to raise
+      maxTotalToolCalls: 45     # default 30 — HARD limit (see §6), give real headroom
+      maxRepeatedFailures: 4    # default 3 — soft limit, safe to raise
+```
+
+### Hot-reloadable runtime config (`llm-runtime.yaml`)
+
+```yaml
+model: openai/gpt-oss-120b
+endpoint: http://<vllm-host>:8000
+apiKey: EMPTY          # plaintext field at v1.5.2 (no apiKeyFile) — vLLM usually ignores it
+temperature: 0.3       # lower than the 0.7 default — reduces variance given weaker agentic reliability
+timeoutSeconds: 300    # up from 120s default — see caveat below, err high
+maxRetries: 3          # default 3 — see caveat below, mostly moot in production
+```
+
+**Caveats specific to what these fields actually do at v1.5.2** (verified
+against the `v1.5.2` tag directly, not assumed from `main`):
+
+- `apiKey` is **inline plaintext in the YAML** at this version — there is no
+  `apiKeyFile` indirection for KA's runtime config (that's a later addition).
+- `maxRetries`/backoff only applies to `ChatWithParams`
+  (`pkg/kubernautagent/llm/chat_helpers.go`), a non-streaming fallback path
+  the production interactive investigation loop doesn't call. The path it
+  *does* call (`Investigator.chatOrStream` → `client.StreamChat`) has a
+  single timeout and **no retry at all** — a transient error or timeout
+  aborts the whole investigation immediately. Set `timeoutSeconds`
+  generously; there's no safety net if you guess too low. (Tracked for a
+  fix in 1.6.0: [#1612](https://github.com/jordigilh/kubernaut/issues/1612).)
+- `maxTotalToolCalls` hits a **hard abort with no chance for the model to
+  summarize** what it already found. Raising the ceiling is your only lever
+  today. (Tracked: [#1613](https://github.com/jordigilh/kubernaut/issues/1613).)
+- A truncated (`finish_reason=length`) response gets exactly one escalated
+  retry (`2× completion_tokens`, capped at 16384); if truncated again, the
+  partial/possibly-empty content is silently accepted as final. Reasoning
+  models at high effort are more likely to double-truncate than a plain
+  chat model. (Tracked: [#1614](https://github.com/jordigilh/kubernaut/issues/1614).)
+- Conversation history is never trimmed/summarized across turns — a long,
+  many-turn investigation can silently exceed a smaller-context model's
+  window with no detection. Balance `maxTurns` against this: raising it to
+  avoid premature give-up (per the point above) increases exposure here.
+  (Tracked: [#1615](https://github.com/jordigilh/kubernaut/issues/1615).)
+- No reasoning-effort config knob exists at v1.5.2 either way (that's the
+  1.6.0-era [#1604](https://github.com/jordigilh/kubernaut/issues/1604)
+  feature, and even there it doesn't yet recognize gpt-oss's model name —
+  see [#1604](https://github.com/jordigilh/kubernaut/issues/1604) follow-on
+  discussion). Effort is controlled entirely at the vLLM server (§2).
+- `langchaingo`'s response parsing silently drops any `reasoning_content`
+  field a self-hosted reasoning model returns — you get **zero visibility**
+  into the model's chain-of-thought anywhere in KA's investigation
+  transcript, logs, or audit trace on this version.
+- `provider`/`model` changes via hot-reload of `llm-runtime.yaml` take
+  effect **live, with no restart requirement or identity-consistency check**
+  (the [#1599](https://github.com/jordigilh/kubernaut/issues/1599)/
+  [DD-LLM-008](../../../architecture/decisions/DD-LLM-008-restart-required-llm-identity-lock.md)
+  protection is 1.6.0-only). Treat "restart after changing the model" as a
+  manual operational discipline for this version, not something the
+  software enforces.
+
+---
+
+## 4. AF configuration (`config.yaml`)
+
+```yaml
+agent:
+  llm:
+    provider: openai_compatible
+    model: openai/gpt-oss-120b
+    endpoint: http://<vllm-host>:8000
+    apiKeyFile: /path/to/dummy-key-file   # AF uses file-based apiKeyFile, unlike KA's inline apiKey
+    timeoutSeconds: 300
+    circuitBreaker:
+      enabled: true       # disabled by default — enable it, since it's AF's only resilience mechanism here
+      maxRequests: 5
+      interval: 60s
+      timeout: 30s
+      failureThreshold: 3
+
+severityTriage:
+  enabled: false   # openai_compatible is NOT supported for severity triage — see §1 and #1618
+  # If you need severity triage locally, either leave it disabled, or set an
+  # explicit severityTriage.llm block pointing at a real vertex_ai/gemini/anthropic
+  # credential — it does not have to match agent.llm. This is a known gap
+  # (https://github.com/jordigilh/kubernaut/issues/1618), not a documented
+  # design decision — AF's own ADR-002 states local-model support for
+  # air-gapped deployments as an explicit goal, so this is expected to close
+  # eventually. Tracked on `main` first; backport to release branches is a
+  # separate decision.
+```
+
+Notes:
+
+- Changes to `agent.llm` are **restart-required by design** at v1.5.2 —
+  there's no hot-reload watcher for AF's config at all (consistent with AF's
+  overall restart-only posture, unrelated to gpt-oss specifically).
+- AF's `circuitBreaker` is the one piece of LLM-call resilience either
+  service has at this version — there's no retry logic in the in-house
+  `openai` adapter itself. It's worth enabling explicitly for a pilot since
+  it defaults to `enabled: false`.
+- Like KA, AF's adapter doesn't send `reasoning_effort` or `tool_choice` —
+  same vLLM server-side workaround from §2 applies.
+
+---
+
+## 5. Operational recommendations for the pilot
+
+- **Raise the AA auto-approval confidence threshold** (`rego.confidenceThreshold`,
+  default `0.8`) for the duration of the pilot — e.g. `0.92` — to compensate
+  for a weaker/self-hosted model's typically higher hallucination rate and
+  lower agentic/tool-use reliability relative to a frontier hosted model.
+  Relax it only after comparing outcomes against your existing baseline.
+- **Validate tool-calling end-to-end through each service's actual adapter**
+  (not just a raw `curl` to vLLM) before trusting the pilot — see §2.
+- **Don't rely on hot-reload to swap models** on KA — restart manually (§3).
+- Expect **no visibility into the model's reasoning trace** on this version
+  (§3) — if RCA quality is hard to diagnose, that's a concrete argument for
+  upgrading to 1.6.0 rather than trying to backport reasoning capture, which
+  was built as a unit with the client-library replacement.
+
+---
+
+## 6. Known gaps tracked for 1.6.0 (not backported to v1.5.2)
+
+| Issue | Gap | Generic beyond gpt-oss/vLLM? |
+|---|---|---|
+| [#1612](https://github.com/jordigilh/kubernaut/issues/1612) | No retry on LLM call errors/timeouts in KA's streaming/interactive path | Yes — any provider, any hosting mechanism |
+| [#1613](https://github.com/jordigilh/kubernaut/issues/1613) | `maxTotalToolCalls` hard-aborts with no wrap-up turn | Yes — any less tool-call-efficient model |
+| [#1614](https://github.com/jordigilh/kubernaut/issues/1614) | Second `max_tokens` truncation silently accepted as final content | Yes — any verbose/reasoning-heavy model |
+| [#1615](https://github.com/jordigilh/kubernaut/issues/1615) | No context-window/history trimming for long investigations | Yes — any smaller-context or high-verbosity model |
+| [#1616](https://github.com/jordigilh/kubernaut/issues/1616) | `phaseModels` doesn't support per-phase reasoning/effort overrides | 1.6.0-only feature gap (reasoning config doesn't exist at v1.5.2 at all) |
+| [#1618](https://github.com/jordigilh/kubernaut/issues/1618) | AF severity triage doesn't support `openai`/`openai_compatible` provider | Yes — present on both v1.5.2 and `main`; not backend-version-specific |
+
+#1612-#1616 are scoped to `main`/1.6.0 — none apply as "fixes" to v1.5.2,
+since the underlying code (`openaicompat` client, reasoning config) doesn't
+exist at this tag. #1618 is different: it's a gap in AF's severity-triage
+provider dispatch that exists identically on both v1.5.2 and `main`, so a
+fix there is a real candidate for backporting once it lands. They're listed
+here so pilot operators know these failure modes are recognized and being
+addressed upstream, not silently ignored.
+
+---
+
+## Related documents
+
+- [`docs/services/kubernaut-agent/configuration-reference.md`](../../../services/kubernaut-agent/configuration-reference.md) — authoritative KA config reference (1.6.0/`main`)
+- [`docs/services/apifrontend/configuration-reference.md`](../../../services/apifrontend/configuration-reference.md) — authoritative AF config reference (1.6.0/`main`)
+- [DD-LLM-004](../../../architecture/decisions/DD-LLM-004-langchaingo-removal-generalized-clients.md) — why `langchaingo` was removed in 1.6.0
+- [DD-LLM-005](../../../architecture/decisions/DD-LLM-005-model-aware-reasoning-support.md) — model-aware reasoning support design (BR-AI-086)
+- [DD-LLM-008](../../../architecture/decisions/DD-LLM-008-restart-required-llm-identity-lock.md) — restart-required LLM identity lock (1.6.0-only)

--- a/pkg/apifrontend/launcher/export_test.go
+++ b/pkg/apifrontend/launcher/export_test.go
@@ -52,11 +52,6 @@ func BuildTransportChainForTest(cfg types.LLMConfig) (http.RoundTripper, error) 
 	return buildTransportChain(cfg)
 }
 
-// BuildLLMHTTPClientForTest exports buildLLMHTTPClient for unit testing.
-func BuildLLMHTTPClientForTest(cfg types.LLMConfig) (*http.Client, error) {
-	return buildLLMHTTPClient(cfg)
-}
-
 // EnsureTrailingParagraphBreakForTest exports ensureTrailingParagraphBreak for unit testing.
 func EnsureTrailingParagraphBreakForTest(s string) string {
 	return ensureTrailingParagraphBreak(s)

--- a/pkg/apifrontend/launcher/model.go
+++ b/pkg/apifrontend/launcher/model.go
@@ -98,7 +98,7 @@ func newGeminiModel(ctx context.Context, cfg types.LLMConfig) (model.LLM, error)
 		}
 	}
 
-	httpClient, err := buildLLMHTTPClient(cfg)
+	httpClient, err := BuildLLMHTTPClient(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("build HTTP client: %w", err)
 	}
@@ -120,10 +120,14 @@ func newAnthropicModel(ctx context.Context, cfg types.LLMConfig) (model.LLM, err
 	return adkanthropic.NewModel(ctx, anthropic.Model(cfg.Model), adkCfg)
 }
 
-// buildLLMHTTPClient constructs an HTTP client with the transport chain
+// BuildLLMHTTPClient constructs an HTTP client with the transport chain
 // (TLS CA, OAuth2, custom headers, circuit breaker) when any auth/resilience
-// options are configured. Returns (nil, nil) when no custom transport is needed.
-func buildLLMHTTPClient(cfg types.LLMConfig) (*http.Client, error) {
+// options are configured. Returns (nil, nil) when no custom transport is
+// needed. Exported (rather than kept package-private) because it's reused
+// by cmd/apifrontend's OpenAI-compatible severity-triage wiring (#1618), in
+// addition to this package's own OpenAI-compatible/Gemini model
+// construction — not just a testing-only need.
+func BuildLLMHTTPClient(cfg types.LLMConfig) (*http.Client, error) {
 	rt, err := buildTransportChain(cfg)
 	if err != nil {
 		return nil, err
@@ -146,11 +150,11 @@ func buildLLMHTTPClient(cfg types.LLMConfig) (*http.Client, error) {
 // Returns (nil, nil) when no custom transport is needed.
 //
 // Issue #1342: This transport chain is applied to the Gemini provider (via
-// buildLLMHTTPClient). Vertex AI and Anthropic providers cannot receive a custom
+// BuildLLMHTTPClient). Vertex AI and Anthropic providers cannot receive a custom
 // transport yet because the ADK wrapper (adk-anthropic-go) does not expose HTTP
 // client injection. An upstream PR adding BaseTransport to Config is pending;
 // once merged, newVertexAIModel and newAnthropicModel should call
-// buildLLMHTTPClient. The AF validation gate for these providers has been
+// BuildLLMHTTPClient. The AF validation gate for these providers has been
 // removed (Phase 3) to allow transport config in preparation.
 func buildTransportChain(cfg types.LLMConfig) (http.RoundTripper, error) {
 	base := http.DefaultTransport
@@ -204,7 +208,7 @@ func buildTransportChain(cfg types.LLMConfig) (http.RoundTripper, error) {
 func newOpenAICompatibleModel(cfg types.LLMConfig) (model.LLM, error) {
 	var opts []openaimodel.Option
 
-	httpClient, err := buildLLMHTTPClient(cfg)
+	httpClient, err := BuildLLMHTTPClient(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("build HTTP client: %w", err)
 	}

--- a/pkg/apifrontend/launcher/transport_chain_test.go
+++ b/pkg/apifrontend/launcher/transport_chain_test.go
@@ -170,7 +170,7 @@ var _ = Describe("Transport Chain", func() {
 				Model:    "gemini-2.0-flash",
 				APIKey:   "test-key",
 			}
-			client, err := launcher.BuildLLMHTTPClientForTest(cfg)
+			client, err := launcher.BuildLLMHTTPClient(cfg)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(client).To(BeNil())
 		})
@@ -187,7 +187,7 @@ var _ = Describe("Transport Chain", func() {
 				TLSCaFile:      caFile,
 				TimeoutSeconds: 60,
 			}
-			client, err := launcher.BuildLLMHTTPClientForTest(cfg)
+			client, err := launcher.BuildLLMHTTPClient(cfg)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(client).NotTo(BeNil())
 			Expect(client.Timeout).To(Equal(60 * time.Second))
@@ -204,7 +204,7 @@ var _ = Describe("Transport Chain", func() {
 				APIKey:    "test-key",
 				TLSCaFile: caFile,
 			}
-			client, err := launcher.BuildLLMHTTPClientForTest(cfg)
+			client, err := launcher.BuildLLMHTTPClient(cfg)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(client).NotTo(BeNil())
 			Expect(client.Timeout).To(Equal(time.Duration(types.DefaultLLMTimeoutSeconds) * time.Second))

--- a/pkg/apifrontend/severity/openai_compatible.go
+++ b/pkg/apifrontend/severity/openai_compatible.go
@@ -1,0 +1,104 @@
+package severity
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/go-logr/logr"
+
+	prom "github.com/jordigilh/kubernaut/pkg/apifrontend/prometheus"
+	"github.com/jordigilh/kubernaut/pkg/shared/llm/openaicompat"
+)
+
+// ChatClient abstracts a single non-streaming Chat Completions call for
+// testability, mirroring ContentGenerator's role for GenAITriager.
+// *openaicompat.Client satisfies this directly.
+type ChatClient interface {
+	Chat(ctx context.Context, req openaicompat.Request) (*openaicompat.Response, error)
+}
+
+// OpenAICompatibleTriager implements LLMTriager against any OpenAI Chat
+// Completions-compatible endpoint (OpenAI, Azure OpenAI, vLLM, Ollama,
+// LlamaStack, self-hosted/custom) via the shared openaicompat client
+// (#1618). Unlike GenAITriager/AnthropicTriager, there is no vendor SDK
+// here — openaicompat.Client already speaks the wire protocol directly.
+type OpenAICompatibleTriager struct {
+	client ChatClient
+	model  string
+	logger logr.Logger
+}
+
+// OpenAICompatibleTriagerConfig holds construction parameters for
+// OpenAICompatibleTriager. Exactly one of Client or ChatClient must be set:
+// Client is the production path (a real *openaicompat.Client), ChatClient
+// is the test-injection seam.
+type OpenAICompatibleTriagerConfig struct {
+	Client     *openaicompat.Client
+	ChatClient ChatClient
+	Model      string
+	Logger     logr.Logger
+}
+
+// NewOpenAICompatibleTriager creates a production LLMTriager backed by an
+// OpenAI-compatible endpoint. Panics if neither Client nor ChatClient is
+// set, matching NewGenAITriager's fail-fast-on-misconfiguration contract.
+func NewOpenAICompatibleTriager(cfg OpenAICompatibleTriagerConfig) *OpenAICompatibleTriager {
+	client := cfg.ChatClient
+	if client == nil {
+		if cfg.Client == nil {
+			panic("NewOpenAICompatibleTriager: Client or ChatClient must not be nil")
+		}
+		client = cfg.Client
+	}
+	if cfg.Logger.GetSink() == nil {
+		cfg.Logger = logr.Discard()
+	}
+	return &OpenAICompatibleTriager{
+		client: client,
+		model:  cfg.Model,
+		logger: cfg.Logger,
+	}
+}
+
+// TriageWithRules classifies severity using LLM with matched rule context.
+func (o *OpenAICompatibleTriager) TriageWithRules(ctx context.Context, rules []prom.Rule, input TriageInput) (TriageResult, error) {
+	prompt := BuildTriagePrompt(input, rules)
+	return o.classify(ctx, prompt)
+}
+
+// TriagePure classifies severity using LLM without rule context (pure fallback).
+func (o *OpenAICompatibleTriager) TriagePure(ctx context.Context, input TriageInput) (TriageResult, error) {
+	prompt := BuildTriagePrompt(input, nil)
+	return o.classify(ctx, prompt)
+}
+
+func (o *OpenAICompatibleTriager) classify(ctx context.Context, prompt string) (TriageResult, error) {
+	req := openaicompat.Request{
+		Model:    o.model,
+		Messages: []openaicompat.Message{{Role: "user", Content: prompt}},
+	}
+	resp, err := o.client.Chat(ctx, req)
+	if err != nil {
+		return TriageResult{}, fmt.Errorf("LLM call failed: %w", err)
+	}
+	if resp == nil {
+		return TriageResult{}, fmt.Errorf("LLM returned nil response")
+	}
+
+	text := strings.TrimSpace(resp.Message.Content)
+	if text == "" {
+		return TriageResult{}, fmt.Errorf("LLM returned empty response")
+	}
+
+	sev := NormalizeSeverity(text)
+	confidence := 1.0
+	if !ValidateSeverity(strings.TrimSpace(strings.ToLower(text))) {
+		confidence = 0.5
+	}
+
+	return TriageResult{
+		Severity:   sev,
+		Confidence: confidence,
+	}, nil
+}

--- a/pkg/apifrontend/severity/openai_compatible_test.go
+++ b/pkg/apifrontend/severity/openai_compatible_test.go
@@ -1,0 +1,139 @@
+package severity_test
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/severity"
+	"github.com/jordigilh/kubernaut/pkg/shared/llm/openaicompat"
+)
+
+// fakeChatClient is a test double for severity.ChatClient, mirroring the
+// existing promptCaptureLLM/mockLLM pattern used for GenAITriager in
+// llm_test.go.
+type fakeChatClient struct {
+	resp        *openaicompat.Response
+	err         error
+	capturedReq openaicompat.Request
+}
+
+func (f *fakeChatClient) Chat(_ context.Context, req openaicompat.Request) (*openaicompat.Response, error) {
+	f.capturedReq = req
+	return f.resp, f.err
+}
+
+var _ = Describe("OpenAICompatibleTriager", func() {
+	var defaultInput severity.TriageInput
+
+	BeforeEach(func() {
+		defaultInput = severity.TriageInput{
+			Namespace:   "prod",
+			Kind:        "Deployment",
+			Name:        "web-api",
+			Description: "High error rate",
+		}
+	})
+
+	Describe("UT-AF-1618-001: Construction", func() {
+		It("panics with nil ChatClient", func() {
+			Expect(func() {
+				severity.NewOpenAICompatibleTriager(severity.OpenAICompatibleTriagerConfig{})
+			}).To(Panic())
+		})
+	})
+
+	Describe("UT-AF-1618-002: TriagePure", func() {
+		It("sends the triage prompt as a single user message tagged with the configured model", func() {
+			fake := &fakeChatClient{
+				resp: &openaicompat.Response{Message: openaicompat.Message{Content: "critical"}},
+			}
+			triager := severity.NewOpenAICompatibleTriager(severity.OpenAICompatibleTriagerConfig{
+				ChatClient: fake,
+				Model:      "openai/gpt-oss-120b",
+			})
+
+			result, err := triager.TriagePure(context.Background(), defaultInput)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Severity).To(Equal("critical"))
+			Expect(result.Confidence).To(Equal(1.0))
+			Expect(fake.capturedReq.Model).To(Equal("openai/gpt-oss-120b"))
+			Expect(fake.capturedReq.Messages).To(HaveLen(1))
+			Expect(fake.capturedReq.Messages[0].Role).To(Equal("user"))
+			Expect(fake.capturedReq.Messages[0].Content).To(ContainSubstring("web-api"))
+		})
+	})
+
+	Describe("UT-AF-1618-003: TriageWithRules", func() {
+		It("returns the classified severity from the response", func() {
+			fake := &fakeChatClient{
+				resp: &openaicompat.Response{Message: openaicompat.Message{Content: "warning"}},
+			}
+			triager := severity.NewOpenAICompatibleTriager(severity.OpenAICompatibleTriagerConfig{
+				ChatClient: fake,
+				Model:      "openai/gpt-oss-120b",
+			})
+
+			result, err := triager.TriageWithRules(context.Background(), nil, defaultInput)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Severity).To(Equal("warning"))
+		})
+	})
+
+	Describe("UT-AF-1618-004: Response validation", func() {
+		It("returns an error when the chat call fails", func() {
+			fake := &fakeChatClient{err: errors.New("connection refused")}
+			triager := severity.NewOpenAICompatibleTriager(severity.OpenAICompatibleTriagerConfig{
+				ChatClient: fake,
+				Model:      "openai/gpt-oss-120b",
+			})
+
+			_, err := triager.TriagePure(context.Background(), defaultInput)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("connection refused"))
+		})
+
+		It("returns an error when the response is nil", func() {
+			fake := &fakeChatClient{resp: nil}
+			triager := severity.NewOpenAICompatibleTriager(severity.OpenAICompatibleTriagerConfig{
+				ChatClient: fake,
+				Model:      "openai/gpt-oss-120b",
+			})
+
+			_, err := triager.TriagePure(context.Background(), defaultInput)
+
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("returns an error when the response content is empty", func() {
+			fake := &fakeChatClient{resp: &openaicompat.Response{Message: openaicompat.Message{Content: ""}}}
+			triager := severity.NewOpenAICompatibleTriager(severity.OpenAICompatibleTriagerConfig{
+				ChatClient: fake,
+				Model:      "openai/gpt-oss-120b",
+			})
+
+			_, err := triager.TriagePure(context.Background(), defaultInput)
+
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("degrades confidence to 0.5 when the model's text isn't a recognized severity", func() {
+			fake := &fakeChatClient{resp: &openaicompat.Response{Message: openaicompat.Message{Content: "not sure, maybe bad?"}}}
+			triager := severity.NewOpenAICompatibleTriager(severity.OpenAICompatibleTriagerConfig{
+				ChatClient: fake,
+				Model:      "openai/gpt-oss-120b",
+			})
+
+			result, err := triager.TriagePure(context.Background(), defaultInput)
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Severity).To(Equal("warning")) // NormalizeSeverity default
+			Expect(result.Confidence).To(Equal(0.5))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- Adds an `openai`/`openai_compatible` case to `newLLMTriagerFromConfig` (`cmd/apifrontend/backend_deps.go`), backed by a new `severity.OpenAICompatibleTriager` that reuses the shared `openaicompat` client.
- Exports `launcher.BuildLLMHTTPClient` (previously package-private `buildLLMHTTPClient`) so severity triage reuses the exact same TLS/OAuth2/custom-header/circuit-breaker transport chain as AF's main-agent OpenAI-compatible model, instead of duplicating it.
- Adds a local/self-hosted LLM setup guide (`docs/development/getting-started/setup/LOCAL_SELF_HOSTED_LLM_v1.5.2.md`) documenting the manual/E2E-adjacent validation step against a real vLLM/Ollama instance.

Closes #1618.

## Test plan

- `TestNewLLMTriagerFromConfig_AcceptsOpenAICompatible` (`cmd/apifrontend/main_wiring_test.go`): proves `openai`/`openai_compatible` providers now dispatch to a working `*severity.OpenAICompatibleTriager` instead of erroring at startup.
- `pkg/apifrontend/severity/openai_compatible_test.go` (UT-AF-1618-001..004): construction, `TriagePure`/`TriageWithRules` request shape and response parsing, and error/edge-case handling (chat failure, nil response, empty content, unrecognized severity text) against a fake `ChatClient`, mirroring the existing `GenAITriager` test pattern.
- No vendor-specific sub-dispatch needed (plain switch case, unlike `vertex_ai`).

Made with [Cursor](https://cursor.com)