### PR TITLE
fix(effectivenessmonitor): assess cluster-scoped Node/PersistentVolume targets (#193)

### DIFF
--- a/api/openapi/data-storage-v1.yaml
+++ b/api/openapi/data-storage-v1.yaml
@@ -5060,6 +5060,8 @@ components:
             Only present for effectiveness.metrics.assessed events.
             Phase A (V1.0): cpu_before/cpu_after populated. Other fields nullable pending
             Phase B metrics assessor expansion (additional PromQL queries).
+            Cluster-scoped fields (node_*, pv_*) populated for Node/PersistentVolume
+            targets only (Issue #193, DD-EM-005 v1.1); null for namespace-scoped targets.
           properties:
             cpu_before:
               type: number
@@ -5113,6 +5115,68 @@ components:
               format: double
               nullable: true
               description: Request throughput (requests/second) after remediation
+            node_not_ready_before:
+              type: number
+              format: double
+              nullable: true
+              description: |
+                Node Ready condition status=false flag before remediation (1=not ready, 0=ready).
+                Cluster-scoped (Issue #193, DD-EM-005).
+            node_not_ready_after:
+              type: number
+              format: double
+              nullable: true
+              description: Node Ready condition status=false flag after remediation (1=not ready, 0=ready). Cluster-scoped (Issue #193, DD-EM-005).
+            node_memory_pressure_before:
+              type: number
+              format: double
+              nullable: true
+              description: Node MemoryPressure condition flag before remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+            node_memory_pressure_after:
+              type: number
+              format: double
+              nullable: true
+              description: Node MemoryPressure condition flag after remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+            node_disk_pressure_before:
+              type: number
+              format: double
+              nullable: true
+              description: Node DiskPressure condition flag before remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+            node_disk_pressure_after:
+              type: number
+              format: double
+              nullable: true
+              description: Node DiskPressure condition flag after remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+            pv_phase_failed_before:
+              type: number
+              format: double
+              nullable: true
+              description: PersistentVolume Failed phase flag before remediation (1=failed, 0=not failed). Cluster-scoped (Issue #193, DD-EM-005).
+            pv_phase_failed_after:
+              type: number
+              format: double
+              nullable: true
+              description: PersistentVolume Failed phase flag after remediation (1=failed, 0=not failed). Cluster-scoped (Issue #193, DD-EM-005).
+            pv_phase_pending_before:
+              type: number
+              format: double
+              nullable: true
+              description: PersistentVolume Pending phase flag before remediation (1=pending, 0=not pending). Cluster-scoped (Issue #193, DD-EM-005).
+            pv_phase_pending_after:
+              type: number
+              format: double
+              nullable: true
+              description: PersistentVolume Pending phase flag after remediation (1=pending, 0=not pending). Cluster-scoped (Issue #193, DD-EM-005).
+            pv_usage_ratio_before:
+              type: number
+              format: double
+              nullable: true
+              description: PersistentVolume used/capacity usage ratio before remediation (0.0-1.0+). Cluster-scoped (Issue #193, DD-EM-005).
+            pv_usage_ratio_after:
+              type: number
+              format: double
+              nullable: true
+              description: PersistentVolume used/capacity usage ratio after remediation (0.0-1.0+). Cluster-scoped (Issue #193, DD-EM-005).
 
         alert_resolution:
           type: object
@@ -6856,6 +6920,64 @@ components:
           format: double
           description: Error rate after remediation (0.0-1.0)
           example: 0.019
+        throughputBeforeRps:
+          type: number
+          format: double
+          description: Request throughput (requests/second) before remediation
+          example: 150.0
+        throughputAfterRps:
+          type: number
+          format: double
+          description: Request throughput (requests/second) after remediation
+          example: 148.0
+        nodeNotReadyBefore:
+          type: number
+          format: double
+          description: Node Ready condition status=false flag before remediation (1=not ready, 0=ready). Cluster-scoped (Issue #193, DD-EM-005).
+        nodeNotReadyAfter:
+          type: number
+          format: double
+          description: Node Ready condition status=false flag after remediation (1=not ready, 0=ready). Cluster-scoped (Issue #193, DD-EM-005).
+        nodeMemoryPressureBefore:
+          type: number
+          format: double
+          description: Node MemoryPressure condition flag before remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+        nodeMemoryPressureAfter:
+          type: number
+          format: double
+          description: Node MemoryPressure condition flag after remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+        nodeDiskPressureBefore:
+          type: number
+          format: double
+          description: Node DiskPressure condition flag before remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+        nodeDiskPressureAfter:
+          type: number
+          format: double
+          description: Node DiskPressure condition flag after remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+        pvPhaseFailedBefore:
+          type: number
+          format: double
+          description: PersistentVolume Failed phase flag before remediation (1=failed, 0=not failed). Cluster-scoped (Issue #193, DD-EM-005).
+        pvPhaseFailedAfter:
+          type: number
+          format: double
+          description: PersistentVolume Failed phase flag after remediation (1=failed, 0=not failed). Cluster-scoped (Issue #193, DD-EM-005).
+        pvPhasePendingBefore:
+          type: number
+          format: double
+          description: PersistentVolume Pending phase flag before remediation (1=pending, 0=not pending). Cluster-scoped (Issue #193, DD-EM-005).
+        pvPhasePendingAfter:
+          type: number
+          format: double
+          description: PersistentVolume Pending phase flag after remediation (1=pending, 0=not pending). Cluster-scoped (Issue #193, DD-EM-005).
+        pvUsageRatioBefore:
+          type: number
+          format: double
+          description: PersistentVolume used/capacity usage ratio before remediation (0.0-1.0+). Cluster-scoped (Issue #193, DD-EM-005).
+        pvUsageRatioAfter:
+          type: number
+          format: double
+          description: PersistentVolume used/capacity usage ratio after remediation (0.0-1.0+). Cluster-scoped (Issue #193, DD-EM-005).
 
     # ========================================
     # ActionType Taxonomy (BR-WORKFLOW-007)

--- a/docs/architecture/DESIGN_DECISIONS.md
+++ b/docs/architecture/DESIGN_DECISIONS.md
@@ -100,6 +100,7 @@
 | DD-PLAYBOOK-001 | Mandatory Playbook Label Schema (7 Labels) | ✅ Approved | 2025-11-14 | [DD-PLAYBOOK-001-mandatory-label-schema.md](decisions/DD-PLAYBOOK-001-mandatory-label-schema.md) |
 | DD-PLAYBOOK-002 | MCP Playbook Catalog Architecture | ✅ Approved | 2025-11-14 | [DD-PLAYBOOK-002-MCP-PLAYBOOK-CATALOG-ARCHITECTURE.md](decisions/DD-PLAYBOOK-002-MCP-PLAYBOOK-CATALOG-ARCHITECTURE.md) |
 | DD-INFRA-001 | ConfigMap Hot-Reload Pattern (Shared Infrastructure) | ✅ Approved | 2025-12-06 | [DD-INFRA-001-configmap-hotreload-pattern.md](decisions/DD-INFRA-001-configmap-hotreload-pattern.md) |
+| DD-EM-005 | Cluster-Scoped Metrics and Alert Assessment (Node, PersistentVolume) | ✅ Approved | 2026-07-07 | [DD-EM-005-cluster-scoped-metrics-alert-assessment.md](decisions/DD-EM-005-cluster-scoped-metrics-alert-assessment.md) |
 | DD-WE-001 | Resource Locking Safety (Prevent Parallel Workflows) | ✅ Approved | 2025-12-01 | [DD-WE-001-resource-locking-safety.md](decisions/DD-WE-001-resource-locking-safety.md) |
 | DD-WE-002 | Dedicated Execution Namespace | ✅ Approved | 2025-12-01 | [DD-WE-002-dedicated-execution-namespace.md](decisions/DD-WE-002-dedicated-execution-namespace.md) |
 | DD-WE-003 | Resource Lock Persistence (Deterministic PipelineRun Name) | ✅ Approved | 2025-12-01 | [DD-WE-003-resource-lock-persistence.md](decisions/DD-WE-003-resource-lock-persistence.md) |

--- a/docs/architecture/decisions/DD-EM-005-cluster-scoped-metrics-alert-assessment.md
+++ b/docs/architecture/decisions/DD-EM-005-cluster-scoped-metrics-alert-assessment.md
@@ -1,0 +1,255 @@
+# DD-EM-005: Cluster-Scoped Metrics and Alert Assessment (Node, PersistentVolume)
+
+**Version**: 1.1
+**Date**: 2026-07-07
+**Status**: ✅ APPROVED
+**Author**: EffectivenessMonitor Team
+
+---
+
+## Context
+
+Issue #193: `assessMetrics()` and `assessAlert()` produce no meaningful signal for cluster-scoped
+`SignalTarget` kinds (`Node`, `PersistentVolume`, i.e. `Namespace == ""`).
+
+**Metrics side**: `assessMetrics()` always calls `buildMetricQuerySpecs(ns)`, which builds 5 PromQL
+queries filtered by `namespace="%s"`. When `ns == ""` (cluster-scoped), every query matches zero
+series, `comparisons` is empty, and the component is unconditionally marked
+`Assessed=false, Details="no metric data available for comparison"`
+(`internal/controller/effectivenessmonitor/assess_components.go:253-256`).
+
+**Alert side**: `assessAlert()` builds an `alert.AlertContext{AlertName, Namespace}` — `AlertLabels`
+is never populated in production code. `buildMatchers()`
+(`pkg/effectivenessmonitor/alert/alert.go:126-138`) already loops over `AlertLabels` to add precise
+matchers and already omits the namespace matcher when empty, but since `AlertLabels` is always nil,
+cluster-scoped alert resolution degrades to alertname-only matching — unable to distinguish
+`Node/worker-1` firing `KubeNodeNotReady` from `Node/worker-2` firing the same alert.
+
+### Why a ConfigMap was initially considered, and rejected
+
+The issue's own example PromQL assumed Prometheus queries for cluster-scoped resources are
+inherently non-deterministic across environments, implying a per-environment configurable
+query template (`MetricTemplates` ConfigMap) would be required.
+
+A due-diligence spike (live queries against a real OCP cluster's `openshift-monitoring` stack,
+cross-checked against upstream documentation) found this assumption incorrect for the metrics
+this issue targets:
+
+- `kube_node_status_condition` and `kube_persistentvolume_status_phase` /
+  `kube_persistentvolume_capacity_bytes` (from `kube-state-metrics`) are K8s-API-driven, not
+  subject to scrape-relabeling variance, and keyed deterministically by `node=`/`persistentvolume=`
+  matching the resource's `.metadata.name` exactly.
+- These metrics and the labels they carry are documented `STABLE` in the upstream
+  [`kubernetes/kube-state-metrics`](https://github.com/kubernetes/kube-state-metrics/blob/main/docs/metrics/storage/persistentvolume-metrics.md)
+  project — the same unmodified binary vendored by both OCP's `cluster-monitoring-operator` and
+  vanilla-k8s's `kube-prometheus-stack` Helm chart. Not an OCP-specific behavior.
+- The issue's own example query (assuming PV name == PVC name) was structurally incorrect; the
+  correct PV-usage query requires a `label_replace`-based join between `kubelet_volume_stats_used_bytes`
+  (PVC-keyed) and `kube_persistentvolume_claim_ref` (PV-keyed) — verified live end-to-end.
+
+Because the required queries are deterministic and vendor-neutral, a ConfigMap-driven
+`MetricTemplates` schema would add config surface (new YAML schema, ADR-030 3-layer wiring, CRD
+growth) to solve a problem that doesn't exist for the Node/PersistentVolume kinds in scope.
+
+### Why no new AlertManager-side code or config was needed
+
+`AlertContext.AlertLabels` (`pkg/effectivenessmonitor/alert/alert.go:43`) already exists and
+`buildMatchers()` already consumes it correctly — it is simply never populated by
+`assessAlert()` today. Confirmed empirically (live `ALERTS{alertstate="firing"}` query) that
+firing Prometheus alert instances inherit ALL labels from the underlying PromQL query result,
+not just the alerting rule's static `labels:` block — so a `KubeNodeNotReady` alert (whose query
+is `kube_node_status_condition{...} == 0`) carries `node=<name>` at fire time. This is standard
+Prometheus alerting-rule behavior (not OCP-specific): confirmed the `KubeNodeNotReady`,
+`KubePersistentVolumeFillingUp`, `KubePersistentVolumeErrors` rules originate from
+`kubernetes-monitoring/kubernetes-mixin`, the vendor-neutral rule set used by both OCP and
+`kube-prometheus-stack`.
+
+---
+
+## Decision
+
+**Add deterministic, hardcoded Go query builders and a Kind-to-label-key mapping — no new
+config, CRD fields, or AlertManager-side code.**
+
+### Metrics: Kind-dispatch in `assessMetrics()`
+
+When `ea.Spec.SignalTarget.Namespace == ""`, dispatch on `ea.Spec.SignalTarget.Kind`:
+
+- `"Node"` → `buildNodeMetricQuerySpecs(name)`: `kube_node_status_condition` for `Ready`
+  (inverted: `status="false"`), `MemoryPressure`, `DiskPressure` (all `LowerIsBetter: true`).
+- `"PersistentVolume"` → `buildPVMetricQuerySpecs(name)`: `kube_persistentvolume_status_phase`
+  for `Failed`/`Pending` (`LowerIsBetter: true`), plus the verified usage-join ratio.
+- Any other cluster-scoped `Kind` → unchanged existing fallback (`Assessed=false`,
+  `"no metric data available for comparison"`).
+- Namespace-scoped path (`ns != ""`) is completely unchanged — still calls
+  `buildMetricQuerySpecs(ns)`.
+
+This mirrors the existing pattern: the 5 namespace-scoped queries are themselves hardcoded,
+non-configurable Go functions, not YAML config.
+
+### Alert: `AlertLabels` population in `assessAlert()`
+
+A new `clusterScopedAlertLabelKey(kind string) (string, bool)` maps `"Node"` → `"node"` and
+`"PersistentVolume"` → `"persistentvolume"` (the exact `kube-state-metrics` / kubernetes-mixin
+label keys verified live). When `ea.Spec.SignalTarget.Namespace == ""` and the Kind is
+recognized, `assessAlert()` sets `alertCtx.AlertLabels = map[string]string{labelKey: name}`
+before calling the existing (unchanged) `alertScorer.Score()`. `buildMatchers()` in
+`pkg/effectivenessmonitor/alert/alert.go` requires no changes — it already iterates
+`AlertLabels` into precise matchers.
+
+### No changes required to:
+
+- `cmd/effectivenessmonitor/main.go` (no new wiring)
+- `internal/config/effectivenessmonitor/config.go` (no new config fields)
+- Any CRD type (`EffectivenessAssessment` schema unchanged)
+- `pkg/effectivenessmonitor/alert/alert.go` (extension point already existed)
+
+---
+
+## Considered Alternatives
+
+| Approach | Why Discarded |
+|---|---|
+| ConfigMap-driven `MetricTemplates` per Kind (original proposal) | Solves a non-existent problem: the required Node/PV metrics are deterministic and vendor-neutral (verified live + upstream docs); adds YAML schema, ADR-030 wiring, and maintenance burden with no accuracy benefit |
+| New `alertLabelKey` config field per Kind | `AlertContext.AlertLabels` already exists and is already consumed correctly by `buildMatchers()` — the actual gap was that production code never populated it, not that the matching mechanism was insufficient |
+| `node_exporter`-based Node CPU/memory as the primary metric source | `node_exporter`'s `instance` label format (hostname vs IP vs custom) varies by scrape-config relabeling across environments — genuinely non-deterministic. `kube_node_status_condition` avoids this by being K8s-API-driven |
+| Treat cAdvisor's `node`-labeled `container_cpu_usage_seconds_total` as load-bearing for Node CPU | Verified present on this cluster's kube-prometheus-stack setup, but relabeling-config-dependent (not guaranteed identical across every chart's kubelet ServiceMonitor) — kept as optional/best-effort only, protected by the existing per-query `Available=false` graceful-skip |
+
+---
+
+## Consequences
+
+### Positive
+
+- Zero new config surface: no ConfigMap, CRD field, or `cmd/` wiring changes
+- Reuses an existing, already-tested extension point (`AlertContext.AlertLabels`) instead of
+  building new AlertManager-matching logic
+- Deterministic, vendor-neutral metrics — verified to work identically on OCP and vanilla
+  Kubernetes + `kube-prometheus-stack`
+- `SignalTarget.Kind` propagation for Node/PersistentVolume already works today (Gateway's
+  `APIResourceRegistry.LabelToKind` dynamic K8s API discovery, pre-existing/tested) — no upstream
+  changes needed
+- No regression risk to the namespace-scoped path or the `#639` golden-string test suite (neither
+  is touched)
+
+### Negative
+
+- `buildNodeMetricQuerySpecs`/`buildPVMetricQuerySpecs` are Kind-specific and not extensible to
+  arbitrary future cluster-scoped kinds without additional code (acceptable: issue #193 scopes
+  to Node + PersistentVolume only; a future cluster-scoped kind would need its own builder,
+  matching how the namespace-scoped builder is also not generically extensible)
+- `clusterScopedAlertLabelKey` is a small static map, not derived from live API discovery like
+  Gateway's `LabelToKind` — acceptable because the label key needed here (matching
+  `kube-state-metrics` output label names) is a narrower, different concern than Gateway's
+  Kind-detection problem
+
+### Risks
+
+- `kube_persistentvolume_claim_ref` join depends on the label names `name`/`claim_namespace` —
+  confirmed live and matches the upstream `kube-state-metrics` docs (`STABLE`), but not
+  exhaustively tested against every KSM version in the wild
+  - **Mitigation**: code comment citing the verified upstream schema; existing per-query
+    `Available=false` graceful-skip means an unexpected schema change degrades to "no data"
+    rather than an incorrect score
+- Assumes `kube-state-metrics` is deployed alongside Prometheus (near-universal default in
+  `kube-prometheus-stack` and OCP, but a technically separate component from bare Prometheus)
+  - **Mitigation**: already-existing graceful degradation handles absence the same as any other
+    missing metric today; no crash, no incorrect data
+
+---
+
+## v1.1 Addendum: Audit `metric_deltas` Extension (SOC2 CC8.1, FedRAMP AU-3)
+
+### Gap found
+
+v1.0 fixed `Score` computation for Node/PersistentVolume targets (via the query builders and
+`AlertLabels` above), but the `effectiveness.metrics.assessed` audit event's `metric_deltas`
+sub-object remained **empty** for these Kinds: `populateMetricsAssessResult`
+(`internal/controller/effectivenessmonitor/assess_components.go`) only recognized the 5
+namespace-scoped `metricQuerySpec.Name` values (`cpu_utilization`, `memory_utilization`,
+`http_request_duration_p95_ms`, `http_error_rate`, `http_throughput_rps`), so the 6 new
+cluster-scoped query names introduced in v1.0 (`kube_node_status_condition_ready`,
+`..._memorypressure`, `..._diskpressure`, `kube_persistentvolume_status_phase_failed`,
+`..._pending`, `kubelet_volume_stats_used_bytes_ratio`) fell through with no mapping.
+
+This is a gap against:
+
+- **SOC2 CC8.1** (complete audit-trail reconstruction): a Node/PV remediation's audit trail could
+  not be reconstructed with the same metric-level detail as a namespace-scoped remediation.
+- **FedRAMP AU-3** (structured content of audit records): the audit record's `metric_deltas`
+  sub-object silently omitted data that was actually queried and available.
+
+Decision and full pipeline design discussed in
+[issue #193 comment](https://github.com/jordigilh/kubernaut/issues/193#issuecomment-4908176229).
+
+### Fix: additive named field pairs (Proposal A), full pipeline
+
+Added 6 new before/after field pairs to both the raw audit schema
+(`EffectivenessAssessmentAuditPayloadMetricDeltas`, nullable `OptNilFloat64`) and the DataStorage
+projection schema (`RemediationMetricDeltas`, `OptFloat64`) in `api/openapi/data-storage-v1.yaml`:
+`node_not_ready_{before,after}`, `node_memory_pressure_{before,after}`,
+`node_disk_pressure_{before,after}`, `pv_phase_failed_{before,after}`,
+`pv_phase_pending_{before,after}`, `pv_usage_ratio_{before,after}`.
+
+Wired end-to-end through all 3 services, mirroring the exact precedent of commit `21e592475`
+(the original Phase A -> Phase B metric_deltas field extension):
+
+`metricQuerySpec.Name` (EM) -> `populateMetricsAssessResult` -> `metricsAssessResult` struct ->
+`emitMetricsEvent` -> `MetricsAssessedData` / `RecordMetricsAssessed` (EM audit) -> `metric_deltas`
+audit table column -> `mapMetricDeltas` (DataStorage) -> `RemediationMetricDeltas` projection ->
+`ds_adapter.go mapMetricDeltas` (Kubernaut Agent) -> `enrichment.MetricDeltas` DTO ->
+`FormatMetricDeltas` (LLM prompt text).
+
+**Opportunistic backfill**: while tracing the pipeline, found `throughput_before_rps`/
+`throughput_after_rps` had been present in the raw audit payload and EM producer since
+`21e592475`, but were never propagated to `RemediationMetricDeltas`, `enrichment.MetricDeltas`,
+or `FormatMetricDeltas`. Backfilled in the same change (flagged separately in the issue comment
+as pre-existing and unrelated to #193, but touching the same files/functions).
+
+Rejected alternative: a generic `entries: [{name, before, after}]` array structure (Proposal B) —
+would have required a breaking migration of all 5 existing Phase A/B fields to avoid two
+audit-record shapes co-existing, with no accuracy or extensibility benefit over the additive
+named-pair pattern already proven twice in this codebase (Phase A->B, and now this v1.1 extension).
+
+### Control mapping
+
+| Control | Requirement | How this change satisfies it |
+|---|---|---|
+| SOC2 CC8.1 | Complete audit-trail reconstruction | `effectiveness.metrics.assessed` events for Node/PV targets now carry the same metric-level detail as namespace-scoped targets; proven end-to-end by `IT-EM-193-001/002` querying the audit trail back via `QueryAuditEvents` and asserting `metric_deltas` content |
+| FedRAMP AU-3 | Structured content of audit records | New fields follow the existing typed-sub-object OpenAPI schema pattern (`OptNilFloat64`), not an untyped/free-form extension |
+| FedRAMP AU-2 | Audit events capture the actions that were actually taken/observed | Fields are populated only when the corresponding PromQL query succeeds (`Available=true`); absent/failed queries leave the field unset rather than a misleading zero value |
+
+### Wiring manifest (v1.1 addendum)
+
+| Component | Production Entry Point | Test ID |
+|---|---|---|
+| `metric_deltas` / `RemediationMetricDeltas` schemas (+6 pairs, +throughput backfill) | `api/openapi/data-storage-v1.yaml` | `make gen-diff` (CI gate) |
+| `populateMetricsAssessResult` (+6 switch cases) | `assess_components.go` | UT-EM-193-008..010 |
+| `MetricsAssessedData` / `RecordMetricsAssessed` (+6 Opt-wraps) | `pkg/effectivenessmonitor/audit/manager.go` | UT-EM-AM-013..016 |
+| `emitMetricsEvent` (+6 passthrough) | `internal/controller/effectivenessmonitor/events.go` | IT-EM-193-001/002 (extended, asserts real audit-trail content via `QueryAuditEvents`) |
+| `mapMetricDeltas` (DataStorage, +6 + throughput) | `pkg/datastorage/server/remediation_history_logic.go` | UT-RH-LOGIC-025/026 |
+| `enrichment.MetricDeltas` DTO + `ds_adapter.go mapMetricDeltas` (+6 + throughput) | `internal/kubernautagent/enrichment/` | UT-KA-433W-014 |
+| `FormatMetricDeltas` (+6 + throughput rendering) | `internal/kubernautagent/prompt/history.go` | UT-KA-433-HP-003 (extended) |
+
+---
+
+## Related Decisions
+
+- **DD-EM-003**: Dual-target assessment — noted cluster-scoped resources as a "neutral
+  consequence" where namespace-scoped queries "operate at cluster scope when namespace is
+  empty"; DD-EM-005 corrects this — an empty namespace does not make the existing
+  namespace-filtered PromQL queries operate at cluster scope, it makes them match zero series.
+- **BR-EM-002**: Alert resolution check via AlertManager API — extended to cluster-scoped targets
+- **BR-EM-003**: Prometheus metric comparison — extended to cluster-scoped targets
+- **Issue #193**: EM cluster-scoped resource assessment gap (this decision's origin)
+- **Issue #639**: EM metrics query golden-string tests — confirmed unaffected (only asserts
+  against the untouched namespace-scoped `buildMetricQuerySpecs`)
+
+---
+
+## Document Maintenance
+
+| Date | Version | Changes |
+|------|---------|---------|
+| 2026-07-07 | 1.0 | Initial decision: Kind-dispatch metric query builders + `AlertLabels` population for cluster-scoped (Node, PersistentVolume) targets. No new config/CRD surface. |
+| 2026-07-07 | 1.1 | Audit `metric_deltas` extension: 6 new field pairs for cluster-scoped Node/PersistentVolume metrics, wired full-pipeline (EM -> DataStorage -> Kubernaut Agent), closing a SOC2 CC8.1 / FedRAMP AU-3 audit-completeness gap. Opportunistic backfill of a pre-existing `throughput_before_rps`/`after_rps` propagation gap in the same files. |

--- a/docs/architecture/decisions/DD-EM-005-cluster-scoped-metrics-alert-assessment.md
+++ b/docs/architecture/decisions/DD-EM-005-cluster-scoped-metrics-alert-assessment.md
@@ -1,6 +1,6 @@
 # DD-EM-005: Cluster-Scoped Metrics and Alert Assessment (Node, PersistentVolume)
 
-**Version**: 1.1
+**Version**: 1.2
 **Date**: 2026-07-07
 **Status**: ✅ APPROVED
 **Author**: EffectivenessMonitor Team
@@ -218,6 +218,7 @@ named-pair pattern already proven twice in this codebase (Phase A->B, and now th
 | SOC2 CC8.1 | Complete audit-trail reconstruction | `effectiveness.metrics.assessed` events for Node/PV targets now carry the same metric-level detail as namespace-scoped targets; proven end-to-end by `IT-EM-193-001/002` querying the audit trail back via `QueryAuditEvents` and asserting `metric_deltas` content |
 | FedRAMP AU-3 | Structured content of audit records | New fields follow the existing typed-sub-object OpenAPI schema pattern (`OptNilFloat64`), not an untyped/free-form extension |
 | FedRAMP AU-2 | Audit events capture the actions that were actually taken/observed | Fields are populated only when the corresponding PromQL query succeeds (`Available=true`); absent/failed queries leave the field unset rather than a misleading zero value |
+| BR-HAPI-016 | Audit data usably reaches LLM remediation-history context, not just the audit store | The v1.1 UTs (`UT-RH-LOGIC-025/026`, `UT-KA-433W-014`) proved per-layer mapping in isolation only; v1.2 closes the pyramid-invariant gap by extending the pre-existing real-DS `IT-KA-433-ENR-008` to prove these fields survive the actual EM->DS->KA HTTP wire |
 
 ### Wiring manifest (v1.1 addendum)
 
@@ -227,8 +228,8 @@ named-pair pattern already proven twice in this codebase (Phase A->B, and now th
 | `populateMetricsAssessResult` (+6 switch cases) | `assess_components.go` | UT-EM-193-008..010 |
 | `MetricsAssessedData` / `RecordMetricsAssessed` (+6 Opt-wraps) | `pkg/effectivenessmonitor/audit/manager.go` | UT-EM-AM-013..016 |
 | `emitMetricsEvent` (+6 passthrough) | `internal/controller/effectivenessmonitor/events.go` | IT-EM-193-001/002 (extended, asserts real audit-trail content via `QueryAuditEvents`) |
-| `mapMetricDeltas` (DataStorage, +6 + throughput) | `pkg/datastorage/server/remediation_history_logic.go` | UT-RH-LOGIC-025/026 |
-| `enrichment.MetricDeltas` DTO + `ds_adapter.go mapMetricDeltas` (+6 + throughput) | `internal/kubernautagent/enrichment/` | UT-KA-433W-014 |
+| `mapMetricDeltas` (DataStorage, +6 + throughput) | `pkg/datastorage/server/remediation_history_logic.go` | UT-RH-LOGIC-025/026; IT-KA-433-ENR-008 (extended, exercises this function via a real HTTP round-trip) |
+| `enrichment.MetricDeltas` DTO + `ds_adapter.go mapMetricDeltas` (+6 + throughput) | `internal/kubernautagent/enrichment/` | UT-KA-433W-014; IT-KA-433-ENR-008 (extended, real DS+HTTP wiring proof) |
 | `FormatMetricDeltas` (+6 + throughput rendering) | `internal/kubernautagent/prompt/history.go` | UT-KA-433-HP-003 (extended) |
 
 ---
@@ -253,3 +254,4 @@ named-pair pattern already proven twice in this codebase (Phase A->B, and now th
 |------|---------|---------|
 | 2026-07-07 | 1.0 | Initial decision: Kind-dispatch metric query builders + `AlertLabels` population for cluster-scoped (Node, PersistentVolume) targets. No new config/CRD surface. |
 | 2026-07-07 | 1.1 | Audit `metric_deltas` extension: 6 new field pairs for cluster-scoped Node/PersistentVolume metrics, wired full-pipeline (EM -> DataStorage -> Kubernaut Agent), closing a SOC2 CC8.1 / FedRAMP AU-3 audit-completeness gap. Opportunistic backfill of a pre-existing `throughput_before_rps`/`after_rps` propagation gap in the same files. |
+| 2026-07-07 | 1.2 | Pyramid invariant closure: v1.1's DataStorage/Kubernaut-Agent wiring points had only isolated per-layer UT coverage (`UT-RH-LOGIC-025/026`, `UT-KA-433W-014`), no IT proving the real EM->DS->KA wire. Extended the pre-existing real-DS `IT-KA-433-ENR-008` (already the authoritative wiring proof for Phase A `metric_deltas` fields) to also seed/assert the v1.1 fields, closing the gap without adding a new test suite. |

--- a/docs/testing/193/TEST_PLAN.md
+++ b/docs/testing/193/TEST_PLAN.md
@@ -1,0 +1,379 @@
+# Test Plan: EM Cluster-Scoped Resource Assessment (Node, PersistentVolume)
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-193-v1.1
+**Feature**: `EffectivenessMonitor.assessMetrics()`/`assessAlert()` produce meaningful,
+deterministic assessment signal for cluster-scoped `SignalTarget` kinds (`Node`,
+`PersistentVolume`) instead of unconditionally reporting "no metric data available."
+v1.1 adds: the `effectiveness.metrics.assessed` audit event's `metric_deltas` sub-object is
+populated for these same cluster-scoped targets (SOC2 CC8.1 / FedRAMP AU-3 audit-completeness
+gap fix), propagated full-pipeline through DataStorage and Kubernaut Agent.
+**Version**: 1.1
+**Created**: 2026-07-07
+**Author**: EffectivenessMonitor Team
+**Status**: Active
+**Branch**: `feature/issue-193-em-cluster-scoped-fix`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Today, every `EffectivenessAssessment` whose `SignalTarget.Kind` is cluster-scoped (`Node`,
+`PersistentVolume`, i.e. `Namespace == ""`) gets `MetricsAssessed=false` on every single
+reconciliation, and alert resolution degrades to alertname-only matching (unable to
+distinguish `Node/worker-1` from `Node/worker-2` firing the same alert). This test plan
+proves the fix: deterministic, `kube-state-metrics`-backed PromQL query builders for
+Node/PersistentVolume metrics, and population of the pre-existing
+`alert.AlertContext.AlertLabels` extension point for precise AlertManager matching.
+
+### 1.2 Objectives
+
+1. **Metrics dispatch**: `assessMetrics()` produces `MetricsAssessed=true` with a
+   correctly-directioned score for `Kind=Node` and `Kind=PersistentVolume` targets, using
+   query builders that are unit-testable in isolation from Prometheus I/O.
+2. **Alert precision**: `assessAlert()` populates `AlertContext.AlertLabels` with the
+   Kind-appropriate label key/value for cluster-scoped targets, verified end-to-end by
+   inspecting the actual AlertManager filter matchers sent over HTTP.
+3. **Zero regression**: The existing namespace-scoped metrics path (`buildMetricQuerySpecs`,
+   issue #639 golden-string suite) and the existing alert/health/hash test suites are
+   provably untouched.
+4. **Documented behavior change**: `isAlertDecay`'s currently-unreachable-for-cluster-scoped
+   guard clause (`MetricsAssessed` was always `false`) becomes reachable; this is captured as
+   an explicit test, not a silent side effect.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./internal/controller/effectivenessmonitor/...` |
+| Integration test pass rate | 100% | `ginkgo ./test/integration/effectivenessmonitor/...` |
+| Backward compatibility | 0 regressions | #639 golden-string suite + existing EM UT/IT suites pass unmodified |
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- `BR-EM-002`: Alert resolution check via AlertManager API — extended by this issue
+- `BR-EM-003`: Prometheus metric comparison — extended by this issue
+- [DD-EM-005](../../architecture/decisions/DD-EM-005-cluster-scoped-metrics-alert-assessment.md): Cluster-Scoped Metrics and Alert Assessment
+- [DD-EM-003](../../architecture/decisions/DD-EM-003-dual-target-assessment.md): Dual-Target Effectiveness Assessment (defines `SignalTarget`/`TargetResource`)
+- Issue #193: EM cluster-scoped resource assessment gap (this test plan's origin)
+- Issue #639: EM metrics query golden-string tests (regression scope)
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../../.cursor/rules/03-testing-strategy.mdc)
+- [AGENTS.md](../../../AGENTS.md) — TDD workflow, Pyramid Invariant
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | `kube_persistentvolume_claim_ref` join label names (`name`/`claim_namespace`) differ on some KSM versions | PV usage-ratio query silently returns no data | Low | UT-EM-193-002, IT-EM-193-002 | Query is one of several independent metrics (graceful per-query degradation via existing `Available=false` path); code comment cites the verified upstream-`STABLE` schema |
+| R2 | `isAlertDecay`'s `MetricsAssessed` guard becomes reachable for cluster-scoped targets for the first time, exposing a previously-dormant code path to new inputs | Alert-decay detection could misfire for Node/PV if the guard's assumptions don't hold at cluster scope | Low | UT-EM-193-006, UT-EM-193-007 (decay-test) | Explicit tests document the exact interaction (healthy + stable hash + regressed metrics → decay suppressed; same but improved metrics → decay detected, control case) |
+| R3 | Kind-dispatch branch added to `assessMetrics`/`assessAlert` regresses the unchanged namespace-scoped path | Existing EAs for namespaced targets stop being assessed correctly | Low | Regression: full existing EM UT/IT suite, #639 golden-string suite | Dispatch is gated strictly on `Namespace == ""`; namespace-scoped branch is unmodified code, not just unmodified behavior |
+
+### 3.1 Risk-to-Test Traceability
+
+All three risks (R1–R3) have direct test coverage as listed above; none are open gaps.
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **`buildNodeMetricQuerySpecs`** (`internal/controller/effectivenessmonitor/assess_components.go`): Node condition-based PromQL query specs (Ready, MemoryPressure, DiskPressure)
+- **`buildPVMetricQuerySpecs`** (same file): PersistentVolume phase + usage-join PromQL query specs
+- **`clusterScopedAlertLabelKey`** (same file): Kind → `kube-state-metrics` label key mapping
+- **`assessMetrics` Kind-dispatch branch** (same file): routes cluster-scoped targets to the new builders
+- **`assessAlert` `AlertLabels` population** (same file): wires the mapping into `alert.AlertContext`
+- **`isAlertDecay`** (same file): interaction with now-reachable cluster-scoped `MetricsAssessed`
+
+### 4.2 Features Not to be Tested
+
+- `pkg/effectivenessmonitor/alert/alert.go` `buildMatchers()`: unchanged, already covered by existing #269 test suite; this plan only proves the caller now populates `AlertLabels`
+- Namespace-scoped `buildMetricQuerySpecs`: unchanged; covered by existing #639 golden-string suite (verified as regression, not re-specified here)
+- Gateway's `SignalTarget.Kind` propagation for Node/PV: pre-existing, already-tested code (confirmed by due-diligence spike, not modified by this issue)
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Hardcoded Go query builders, no ConfigMap | Node/PV metrics are deterministic and vendor-neutral (see DD-EM-005); a config schema would add surface for a non-existent problem |
+| Reuse existing `AlertContext.AlertLabels`, no new AlertManager code | Extension point already existed and was already consumed correctly by `buildMatchers()`; only the population was missing |
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+- **Unit**: 100% of the new pure-logic functions (`buildNodeMetricQuerySpecs`, `buildPVMetricQuerySpecs`, `clusterScopedAlertLabelKey`)
+- **Integration**: 100% of the new wiring points (Kind-dispatch in `assessMetrics`, `AlertLabels` population in `assessAlert`) — see Wiring Manifest in the implementation plan
+
+### 5.2 Two-Tier Minimum
+
+Every new code path has both a UT (pure logic, isolated) and an IT (real dispatch path through the reconciler, real envtest CRD, httptest Prometheus/AlertManager mocks).
+
+### 5.3 Business Outcome Quality Bar
+
+Tests assert on business outcomes (`MetricsAssessed`, `MetricsScore` direction, AlertManager filter matcher content) — not internal call counts or implementation details.
+
+### 5.4 Pass/Fail Criteria
+
+**PASS**: All UT/IT scenarios below pass; #639 golden-string suite and full existing EM UT/IT suite pass unmodified.
+
+**FAIL**: Any new scenario fails, or any existing EM test regresses.
+
+### 5.5 Suspension & Resumption Criteria
+
+**Suspend** if `go build ./...` fails. **Resume** once the build is green.
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code (pure logic, no I/O)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `internal/controller/effectivenessmonitor/assess_components.go` | `buildNodeMetricQuerySpecs`, `buildPVMetricQuerySpecs`, `clusterScopedAlertLabelKey`, `isAlertDecay` (pure logic, no I/O — the interaction with cluster-scoped `MetricsAssessed` is proven by UT, not IT) | ~40 |
+
+### 6.2 Integration-Testable Code (I/O, wiring, cross-component)
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `internal/controller/effectivenessmonitor/assess_components.go` | `assessMetrics` Kind-dispatch, `assessAlert` `AlertLabels` population | ~20 |
+
+### 6.3 Version Identification
+
+| Item | Version/Commit | Notes |
+|------|----------------|-------|
+| Code under test | `feature/issue-193-em-cluster-scoped-fix` HEAD | Branched from `origin/main` |
+
+---
+
+## 7. BR Coverage Matrix
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-EM-003 | Prometheus metric comparison (extended: cluster-scoped) | P1 | Unit | UT-EM-193-001, UT-EM-193-002 | Pending |
+| BR-EM-003 | Prometheus metric comparison (extended: cluster-scoped) | P1 | Integration | IT-EM-193-001, IT-EM-193-002 | Pending |
+| BR-EM-002 | Alert resolution check (extended: cluster-scoped precision) | P1 | Unit | UT-EM-193-003, UT-EM-193-004, UT-EM-193-005 | Pending |
+| BR-EM-002 | Alert resolution check (extended: cluster-scoped precision) | P1 | Integration | IT-EM-193-003 | Pending |
+| BR-EM-012 | Alert decay detection (interaction with now-reachable cluster-scoped metrics) | P2 | Unit | UT-EM-193-006, UT-EM-193-007 | Pending |
+| BR-AUDIT-005, BR-EM-003 | Audit `metric_deltas` completeness for cluster-scoped targets (SOC2 CC8.1, FedRAMP AU-2/AU-3) | P1 | Unit | UT-EM-193-008..010, UT-EM-AM-013..016, UT-RH-LOGIC-025/026, UT-KA-433W-014 | Done |
+| BR-AUDIT-005, BR-EM-003 | Audit `metric_deltas` completeness for cluster-scoped targets (SOC2 CC8.1, FedRAMP AU-2/AU-3) | P1 | Integration | IT-EM-193-001, IT-EM-193-002 (extended) | Done |
+
+---
+
+## 8. Test Scenarios
+
+### Test ID Naming Convention
+
+Format: `{TIER}-EM-193-{SEQUENCE}` (issue-number-keyed, matching existing EM precedent
+e.g. `UT-EM-269-NNN`, `IT-EM-MC-NNN`).
+
+### Tier 1: Unit Tests
+
+**Testable code scope**: `internal/controller/effectivenessmonitor/assess_components.go` new pure functions
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-EM-193-001` | `buildNodeMetricQuerySpecs` produces Ready/MemoryPressure/DiskPressure PromQL specs, all `LowerIsBetter=true` | Pending |
+| `UT-EM-193-002` | `buildPVMetricQuerySpecs` produces Failed/Pending phase specs (`LowerIsBetter=true`) and the usage-join ratio spec | Pending |
+| `UT-EM-193-003` | `clusterScopedAlertLabelKey("Node")` returns `("node", true)` | Pending |
+| `UT-EM-193-004` | `clusterScopedAlertLabelKey("PersistentVolume")` returns `("persistentvolume", true)` | Pending |
+| `UT-EM-193-005` | `clusterScopedAlertLabelKey("SomeUnknownKind")` returns `("", false)` | Pending |
+| `UT-EM-193-006` | `isAlertDecay`: Node target, healthy + hash-stable + real metrics regression (`MetricsScore<=0`, newly reachable at cluster scope) → returns `false` | Pending |
+| `UT-EM-193-007` | `isAlertDecay`: Node target, healthy + hash-stable + metrics improved, alert still firing → returns `true` (decay detected, control case) | Pending |
+
+### Tier 2: Integration Tests
+
+**Testable code scope**: `assessMetrics`/`assessAlert` dispatch through the real reconciler, envtest CRD, httptest Prometheus/AlertManager mocks
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `IT-EM-193-001` | EA with `SignalTarget.Kind=Node`, `Namespace=""` → `MetricsAssessed=true` with a correctly-directioned score, using mock Prometheus data. Extended (v1.1): the `effectiveness.metrics.assessed` audit event's `metric_deltas` sub-object carries the Node fields, verified by querying the real audit trail back via `QueryAuditEvents` | Done |
+| `IT-EM-193-002` | EA with `SignalTarget.Kind=PersistentVolume`, `Namespace=""` → `MetricsAssessed=true` with a correctly-directioned score. Extended (v1.1): `metric_deltas` carries the PV fields, verified via `QueryAuditEvents` | Done |
+| `IT-EM-193-003` | EA with `SignalTarget.Kind=Node`, `Namespace=""` → the AlertManager request's `filter` query params include `node="<name>"` | Pending |
+
+### Tier 1b/1c: Unit Tests — Audit `metric_deltas` Extension (v1.1, DD-EM-005 addendum)
+
+**Testable code scope**: EM producer mapping, EM audit DTO, DataStorage projection, Kubernaut Agent enrichment/prompt
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `UT-EM-193-008` | `populateMetricsAssessResult` maps the 3 Node condition query names into `NodeNotReadyBefore/After`, `NodeMemoryPressureBefore/After`, `NodeDiskPressureBefore/After` | Done |
+| `UT-EM-193-009` | `populateMetricsAssessResult` maps the 3 PersistentVolume query names into `PVPhaseFailedBefore/After`, `PVPhasePendingBefore/After`, `PVUsageRatioBefore/After` | Done |
+| `UT-EM-193-010` | `populateMetricsAssessResult` leaves cluster-scoped fields nil when the query is unavailable (graceful degradation) | Done |
+| `UT-EM-AM-013` | `RecordMetricsAssessed` sets the 3 Node condition `metric_deltas` fields when populated | Done |
+| `UT-EM-AM-014` | `RecordMetricsAssessed` sets the 3 PersistentVolume `metric_deltas` fields when populated | Done |
+| `UT-EM-AM-015` | `RecordMetricsAssessed` leaves cluster-scoped fields unset for namespace-scoped assessments | Done |
+| `UT-EM-AM-016` | `RecordMetricsAssessed` does not clobber Phase A/B fields when cluster-scoped fields are also present | Done |
+| `UT-RH-LOGIC-025` | DataStorage `mapMetricDeltas` maps the 6 cluster-scoped fields and backfills `throughput_before_rps`/`after_rps` into `RemediationMetricDeltas` | Done |
+| `UT-RH-LOGIC-026` | DataStorage `mapMetricDeltas` leaves cluster-scoped/throughput fields unset when absent (namespace-scoped, Phase A/B only) | Done |
+| `UT-KA-433W-014` | Kubernaut Agent `ds_adapter.go mapMetricDeltas` maps throughput + cluster-scoped fields into `enrichment.MetricDeltas`, and leaves them nil when absent | Done |
+| `UT-KA-433-HP-003` (extended) | `FormatMetricDeltas` renders throughput and cluster-scoped Node/PV pairs as human-readable LLM prompt text | Done |
+
+### Tier Skip Rationale
+
+- **E2E**: Not added for this issue — the fix is fully exercised by UT+IT against real
+  `kube-state-metrics`-shaped PromQL (verified live during due diligence, not re-verified in
+  CI) and real AlertManager matcher construction. No new E2E-only behavior is introduced.
+
+---
+
+## 9. Test Cases (P0/P1 detail)
+
+### UT-EM-193-001: buildNodeMetricQuerySpecs
+
+**BR**: BR-EM-003
+**Priority**: P1
+**Type**: Unit
+**File**: `internal/controller/effectivenessmonitor/cluster_scoped_metrics_test.go`
+
+**Test Steps**:
+1. **Given**: a Node name `"worker-1"`
+2. **When**: `buildNodeMetricQuerySpecs("worker-1")` is called
+3. **Then**: the returned specs' `Query` strings contain `kube_node_status_condition` with
+   `node="worker-1"` for `Ready`/`MemoryPressure`/`DiskPressure`, and all have
+   `LowerIsBetter=true`
+
+**Acceptance Criteria**: PromQL substrings match the verified spike queries; direction is correct (a firing "not ready"/"pressure" condition is 1, so lower is better after remediation).
+
+### UT-EM-193-002: buildPVMetricQuerySpecs
+
+**BR**: BR-EM-003
+**Priority**: P1
+**Type**: Unit
+**File**: `internal/controller/effectivenessmonitor/cluster_scoped_metrics_test.go`
+
+**Test Steps**:
+1. **Given**: a PersistentVolume name `"pvc-abc123"`
+2. **When**: `buildPVMetricQuerySpecs("pvc-abc123")` is called
+3. **Then**: returned specs include `kube_persistentvolume_status_phase{...phase="Failed"...}`
+   and `...phase="Pending"...` (both `LowerIsBetter=true`), plus the usage-join ratio query
+   containing `kube_persistentvolume_claim_ref{persistentvolume="pvc-abc123"}`
+
+### IT-EM-193-001/002: Cluster-scoped metrics dispatch
+
+**BR**: BR-EM-003
+**Priority**: P1
+**Type**: Integration
+**File**: `test/integration/effectivenessmonitor/cluster_scoped_193_integration_test.go`
+
+**Test Steps**:
+1. **Given**: mock Prometheus configured with a 2-sample matrix response (improvement)
+2. **When**: an EA is created with `SignalTarget.Kind=Node` (or `PersistentVolume`) and empty `Namespace`
+3. **Then**: the EA eventually reaches `Completed` with `Status.Components.MetricsAssessed=true` and a non-nil `MetricsScore`
+
+### IT-EM-193-003: Cluster-scoped alert matcher precision
+
+**BR**: BR-EM-002
+**Priority**: P1
+**Type**: Integration
+**File**: `test/integration/effectivenessmonitor/cluster_scoped_193_integration_test.go`
+
+**Test Steps**:
+1. **Given**: mock AlertManager configured with no active alerts
+2. **When**: an EA is created with `SignalTarget.Kind=Node`, `Name="worker-1"`, empty `Namespace`
+3. **Then**: `mockAM.GetRequestLog()` contains a request to `/api/v2/alerts` whose `filter` query
+   values include `node="worker-1"`
+
+**Dependencies**: None beyond the shared EM integration suite fixtures (`mockProm`, `mockAM`, `k8sClient`).
+
+---
+
+## 10. Environmental Needs
+
+### 10.1 Unit Tests
+
+- **Framework**: Ginkgo/Gomega BDD
+- **Mocks**: None — pure function tests, no external dependencies
+- **Location**: `internal/controller/effectivenessmonitor/` (white-box, `package controller`)
+
+### 10.2 Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD with envtest
+- **Mocks**: httptest Prometheus + AlertManager mocks (per existing suite convention — external services only)
+- **Location**: `test/integration/effectivenessmonitor/`
+
+### 10.4 Tools & Versions
+
+| Tool | Minimum Version | Purpose |
+|------|-----------------|---------|
+| Go | per `go.mod` | Build and test |
+| Ginkgo CLI | v2.x | Test runner |
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Blocking Dependencies
+
+None — all upstream propagation (`SignalTarget.Kind` for Node/PV) is pre-existing, already-tested code (confirmed by due-diligence spike).
+
+### 11.2 Execution Order
+
+1. **Phase 1 (RED)**: UT-EM-193-001..005, then IT-EM-193-001..004 — all fail (functions/dispatch don't exist yet)
+2. **Phase 2 (GREEN)**: Minimal implementation of the 3 new functions + Kind-dispatch wiring in `assessMetrics`/`assessAlert` — CHECKPOINT W
+3. **Phase 3 (REFACTOR)**: Dedup shared query-spec construction, flatten dispatch conditional, enrich fallback message
+4. **Phase 4 (Post-Refactor Validation)**: `go build`, `go test`, stale-symbol grep
+5. **Phase 5**: Regression — #639 golden-string suite + full existing EM UT/IT suite
+
+---
+
+## 12. Test Deliverables
+
+| Deliverable | Location | Description |
+|-------------|----------|--------------|
+| This test plan | `docs/testing/193/TEST_PLAN.md` | Strategy and test design |
+| Unit test suite | `internal/controller/effectivenessmonitor/cluster_scoped_metrics_test.go` | Ginkgo BDD, UT-EM-193-001..005 |
+| Integration test suite | `test/integration/effectivenessmonitor/cluster_scoped_193_integration_test.go` | Ginkgo BDD, IT-EM-193-001..004 |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests
+go test ./internal/controller/effectivenessmonitor/... -run TestEffectivenessMonitor -v
+
+# Integration tests (requires podman/envtest toolchain)
+make test-integration-effectivenessmonitor
+```
+
+---
+
+## 14. Wiring Verification (TDD Phase 4)
+
+| Code Path | Entry Point | Exit Point | Wiring IT | Status |
+|-----------|-------------|------------|-----------|--------|
+| `buildNodeMetricQuerySpecs` | `assessMetrics` Kind-dispatch | `MetricsAssessed`/`MetricsScore` on EA status | IT-EM-193-001 | Pending |
+| `buildPVMetricQuerySpecs` | `assessMetrics` Kind-dispatch | `MetricsAssessed`/`MetricsScore` on EA status | IT-EM-193-002 | Pending |
+| `clusterScopedAlertLabelKey` | `assessAlert` `AlertContext` population | AlertManager `filter` query params | IT-EM-193-003 | Pending |
+
+---
+
+## 15. Existing Tests Requiring Updates
+
+None. The namespace-scoped path (`buildMetricQuerySpecs`, #639 golden-string suite) and
+`pkg/effectivenessmonitor/alert/alert.go` are unmodified.
+
+---
+
+## 16. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-07-07 | Initial test plan for issue #193 |
+| 1.1 | 2026-07-07 | Added audit `metric_deltas` extension coverage (DD-EM-005 v1.1 addendum): UT-EM-193-008..010, UT-EM-AM-013..016, UT-RH-LOGIC-025/026, UT-KA-433W-014, extended UT-KA-433-HP-003 and IT-EM-193-001/002. Closes a SOC2 CC8.1 / FedRAMP AU-3 audit-completeness gap for Node/PersistentVolume targets. |

--- a/docs/testing/193/TEST_PLAN.md
+++ b/docs/testing/193/TEST_PLAN.md
@@ -2,14 +2,17 @@
 
 > **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
 
-**Test Plan Identifier**: TP-193-v1.1
+**Test Plan Identifier**: TP-193-v1.2
 **Feature**: `EffectivenessMonitor.assessMetrics()`/`assessAlert()` produce meaningful,
 deterministic assessment signal for cluster-scoped `SignalTarget` kinds (`Node`,
 `PersistentVolume`) instead of unconditionally reporting "no metric data available."
 v1.1 adds: the `effectiveness.metrics.assessed` audit event's `metric_deltas` sub-object is
 populated for these same cluster-scoped targets (SOC2 CC8.1 / FedRAMP AU-3 audit-completeness
 gap fix), propagated full-pipeline through DataStorage and Kubernaut Agent.
-**Version**: 1.1
+v1.2 adds: pyramid-invariant closure — extends the pre-existing real-DataStorage,
+real-HTTP `IT-KA-433-ENR-008` to prove the v1.1 fields survive the actual EM->DS->KA
+wire (not just per-layer UT mapping in isolation).
+**Version**: 1.2
 **Created**: 2026-07-07
 **Author**: EffectivenessMonitor Team
 **Status**: Active
@@ -172,6 +175,7 @@ Tests assert on business outcomes (`MetricsAssessed`, `MetricsScore` direction, 
 | BR-EM-012 | Alert decay detection (interaction with now-reachable cluster-scoped metrics) | P2 | Unit | UT-EM-193-006, UT-EM-193-007 | Pending |
 | BR-AUDIT-005, BR-EM-003 | Audit `metric_deltas` completeness for cluster-scoped targets (SOC2 CC8.1, FedRAMP AU-2/AU-3) | P1 | Unit | UT-EM-193-008..010, UT-EM-AM-013..016, UT-RH-LOGIC-025/026, UT-KA-433W-014 | Done |
 | BR-AUDIT-005, BR-EM-003 | Audit `metric_deltas` completeness for cluster-scoped targets (SOC2 CC8.1, FedRAMP AU-2/AU-3) | P1 | Integration | IT-EM-193-001, IT-EM-193-002 (extended) | Done |
+| BR-HAPI-016 | Cluster-scoped/throughput `metric_deltas` fields survive the full EM->DS->KA production wire (not just isolated per-layer UT mapping) | P1 | Integration | IT-KA-433-ENR-008 (extended) | Done |
 
 ---
 
@@ -223,6 +227,25 @@ e.g. `UT-EM-269-NNN`, `IT-EM-MC-NNN`).
 | `UT-RH-LOGIC-026` | DataStorage `mapMetricDeltas` leaves cluster-scoped/throughput fields unset when absent (namespace-scoped, Phase A/B only) | Done |
 | `UT-KA-433W-014` | Kubernaut Agent `ds_adapter.go mapMetricDeltas` maps throughput + cluster-scoped fields into `enrichment.MetricDeltas`, and leaves them nil when absent | Done |
 | `UT-KA-433-HP-003` (extended) | `FormatMetricDeltas` renders throughput and cluster-scoped Node/PV pairs as human-readable LLM prompt text | Done |
+
+### Tier 2b: Integration Tests — Pyramid Invariant Closure (v1.2)
+
+**Testable code scope**: full EM->DataStorage->Kubernaut Agent wire (real PostgreSQL + real
+DataStorage HTTP server + real KA enrichment client, per `test/integration/kubernautagent/enrichment/suite_test.go`)
+
+The v1.1 UTs above (`UT-RH-LOGIC-025/026`, `UT-KA-433W-014`) each prove correct field mapping
+in isolation at their own layer, calling the real business-logic function directly with
+in-memory fixtures. Per the pyramid invariant ("a component with only UT coverage is
+prototyped, not implemented"), that is necessary but not sufficient: it does not prove the two
+layers are actually wired together end-to-end (DS's HTTP serialization of the new fields, and
+KA's HTTP client correctly deserializing them). `IT-KA-433-ENR-008` already existed as the
+authoritative real-DS, real-HTTP wiring proof for the Phase A `metric_deltas` fields
+(`cpu_before`/`after`, `memory_before`/`after`); it was extended to seed and assert the v1.1
+cluster-scoped + throughput fields through the same real wire.
+
+| ID | Business Outcome Under Test | Phase |
+|----|----------------------------|-------|
+| `IT-KA-433-ENR-008` (extended) | Cluster-scoped (Node/PV) + throughput `metric_deltas` fields seeded as a raw `audit_events` row survive a real HTTP round-trip through DataStorage's `CorrelateTier1Chain`/`mapMetricDeltas` and KA's `ds_adapter.go mapMetricDeltas` into `enrichment.MetricDeltas`, unchanged | Done |
 
 ### Tier Skip Rationale
 
@@ -377,3 +400,4 @@ None. The namespace-scoped path (`buildMetricQuerySpecs`, #639 golden-string sui
 |---------|------|---------|
 | 1.0 | 2026-07-07 | Initial test plan for issue #193 |
 | 1.1 | 2026-07-07 | Added audit `metric_deltas` extension coverage (DD-EM-005 v1.1 addendum): UT-EM-193-008..010, UT-EM-AM-013..016, UT-RH-LOGIC-025/026, UT-KA-433W-014, extended UT-KA-433-HP-003 and IT-EM-193-001/002. Closes a SOC2 CC8.1 / FedRAMP AU-3 audit-completeness gap for Node/PersistentVolume targets. |
+| 1.2 | 2026-07-07 | Pyramid invariant closure: extended the pre-existing real-DS `IT-KA-433-ENR-008` with the v1.1 cluster-scoped/throughput fields, proving they survive the real EM->DS->KA HTTP wire, not just isolated per-layer UT mapping. |

--- a/internal/controller/effectivenessmonitor/assess_components.go
+++ b/internal/controller/effectivenessmonitor/assess_components.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -124,6 +125,16 @@ func (r *Reconciler) assessAlert(ctx context.Context, reader client.Reader, ea *
 		Namespace: ea.Spec.SignalTarget.Namespace,
 	}
 
+	// Issue #193, DD-EM-005: for cluster-scoped targets (empty Namespace), populate
+	// AlertLabels so buildMatchers() scopes the AlertManager query to the specific
+	// resource (e.g. node="worker-1"), instead of degrading to alertname-only
+	// matching that cannot distinguish "Node A" from "Node B" firing the same alert.
+	if ea.Spec.SignalTarget.Namespace == "" {
+		if labelKey, ok := clusterScopedAlertLabelKey(ea.Spec.SignalTarget.Kind); ok {
+			alertCtx.AlertLabels = map[string]string{labelKey: ea.Spec.SignalTarget.Name}
+		}
+	}
+
 	// #269: Resolve active pod names from SignalTarget so the scorer can filter
 	// out stale alerts for pods deleted during rolling restarts.
 	if podNames := r.listActivePodNames(ctx, reader, ea.Spec.SignalTarget); podNames != nil {
@@ -197,6 +208,20 @@ type metricsAssessResult struct {
 	ErrorRateAfter      *float64
 	ThroughputBeforeRPS *float64
 	ThroughputAfterRPS  *float64
+	// Cluster-scoped fields (Issue #193, DD-EM-005 v1.1): populated only for
+	// Node/PersistentVolume targets, nil for namespace-scoped assessments.
+	NodeNotReadyBefore       *float64
+	NodeNotReadyAfter        *float64
+	NodeMemoryPressureBefore *float64
+	NodeMemoryPressureAfter  *float64
+	NodeDiskPressureBefore   *float64
+	NodeDiskPressureAfter    *float64
+	PVPhaseFailedBefore      *float64
+	PVPhaseFailedAfter       *float64
+	PVPhasePendingBefore     *float64
+	PVPhasePendingAfter      *float64
+	PVUsageRatioBefore       *float64
+	PVUsageRatioAfter        *float64
 }
 
 // metricQuerySpec defines a PromQL query for a single metric type.
@@ -222,13 +247,13 @@ type metricQueryResult struct {
 // (graceful degradation). The score is the average of all available metric improvements.
 func (r *Reconciler) assessMetrics(ctx context.Context, ea *eav1.EffectivenessAssessment) metricsAssessResult {
 	logger := log.FromContext(ctx)
-	ns := ea.Spec.SignalTarget.Namespace
+	target := ea.Spec.SignalTarget
 
 	start := ea.CreationTimestamp.Add(-r.Config.PrometheusLookback)
 	end := time.Now()
 	step := 1 * time.Second
 
-	queries := buildMetricQuerySpecs(ns)
+	queries := buildMetricQuerySpecsForTarget(target)
 
 	queryResults := make([]metricQueryResult, len(queries))
 	for i, spec := range queries {
@@ -252,7 +277,7 @@ func (r *Reconciler) assessMetrics(ctx context.Context, ea *eav1.EffectivenessAs
 	}
 	if len(comparisons) == 0 {
 		result.Assessed = false
-		result.Details = "no metric data available for comparison"
+		result.Details = fmt.Sprintf("no metric data available for comparison (kind=%s, namespace=%q)", target.Kind, target.Namespace)
 		return metricsAssessResult{Component: result}
 	}
 
@@ -268,6 +293,25 @@ func (r *Reconciler) assessMetrics(ctx context.Context, ea *eav1.EffectivenessAs
 	mr := metricsAssessResult{Component: result}
 	populateMetricsAssessResult(&mr, queryResults)
 	return mr
+}
+
+// buildMetricQuerySpecsForTarget dispatches to the correct query-spec builder
+// for target: the namespace-scoped 5-metric set when a namespace is present,
+// or a Kind-specific cluster-scoped builder when it is empty (Issue #193,
+// DD-EM-005). An unrecognized cluster-scoped Kind returns an empty slice,
+// which assessMetrics reports via its "no metric data available" fallback.
+func buildMetricQuerySpecsForTarget(target eav1.TargetResource) []metricQuerySpec {
+	if target.Namespace != "" {
+		return buildMetricQuerySpecs(target.Namespace)
+	}
+	switch target.Kind {
+	case "Node":
+		return buildNodeMetricQuerySpecs(target.Name)
+	case "PersistentVolume":
+		return buildPVMetricQuerySpecs(target.Name)
+	default:
+		return nil
+	}
 }
 
 // buildMetricQuerySpecs returns the 5 independent PromQL queries (CPU,
@@ -304,6 +348,89 @@ func buildMetricQuerySpecs(ns string) []metricQuerySpec {
 	}
 }
 
+// buildKSMFlagQuerySpec builds a metricQuerySpec for a kube-state-metrics
+// "badness flag" series: a metric scoped to a resource by resourceLabel="resourceName",
+// plus any additional label matchers (e.g. condition/phase), where a value of
+// 1 means the resource is in a bad state and 0 means it isn't -- so every
+// spec built this way is LowerIsBetter. Shared by buildNodeMetricQuerySpecs
+// (Node conditions) and buildPVMetricQuerySpecs (PV phases) to eliminate the
+// duplicated Sprintf/struct-literal boilerplate between them (Issue #193
+// REFACTOR).
+func buildKSMFlagQuerySpec(specName, metric, resourceLabel, resourceName string, extraMatchers ...string) metricQuerySpec {
+	matchers := append([]string{fmt.Sprintf(`%s="%s"`, resourceLabel, resourceName)}, extraMatchers...)
+	return metricQuerySpec{
+		Name:          specName,
+		Query:         fmt.Sprintf(`%s{%s}`, metric, strings.Join(matchers, ",")),
+		LowerIsBetter: true,
+	}
+}
+
+// buildNodeMetricQuerySpecs returns deterministic, kube-state-metrics-backed
+// PromQL query specs for a cluster-scoped Node target (Issue #193, DD-EM-005).
+// Each query tracks a "badness" condition (1 = bad, 0 = good), so all three
+// are LowerIsBetter: a firing NotReady/MemoryPressure/DiskPressure condition
+// resolving after remediation is an improvement.
+func buildNodeMetricQuerySpecs(name string) []metricQuerySpec {
+	const metric = "kube_node_status_condition"
+	return []metricQuerySpec{
+		buildKSMFlagQuerySpec("kube_node_status_condition_ready", metric, "node", name,
+			`condition="Ready"`, `status="false"`),
+		buildKSMFlagQuerySpec("kube_node_status_condition_memorypressure", metric, "node", name,
+			`condition="MemoryPressure"`, `status="true"`),
+		buildKSMFlagQuerySpec("kube_node_status_condition_diskpressure", metric, "node", name,
+			`condition="DiskPressure"`, `status="true"`),
+	}
+}
+
+// buildPVMetricQuerySpecs returns deterministic, kube-state-metrics-backed
+// PromQL query specs for a cluster-scoped PersistentVolume target (Issue #193,
+// DD-EM-005). Failed/Pending phase flags are "badness" conditions
+// (LowerIsBetter). The usage ratio joins kubelet_volume_stats_used_bytes
+// (PVC-keyed) to kube_persistentvolume_claim_ref (PV-keyed) via label_replace,
+// then divides by kube_persistentvolume_capacity_bytes -- verified live
+// end-to-end against a real cluster; label names (persistentvolume,
+// claim_namespace, name) are STABLE per the upstream kube-state-metrics docs.
+// The usage ratio doesn't fit the single-metric "flag" shape above (it's a
+// two-metric join), so it remains a standalone literal.
+func buildPVMetricQuerySpecs(name string) []metricQuerySpec {
+	return []metricQuerySpec{
+		buildKSMFlagQuerySpec("kube_persistentvolume_status_phase_failed", "kube_persistentvolume_status_phase", "persistentvolume", name,
+			`phase="Failed"`),
+		buildKSMFlagQuerySpec("kube_persistentvolume_status_phase_pending", "kube_persistentvolume_status_phase", "persistentvolume", name,
+			`phase="Pending"`),
+		{
+			Name: "kubelet_volume_stats_used_bytes_ratio",
+			Query: fmt.Sprintf(
+				`(kubelet_volume_stats_used_bytes `+
+					`* on(namespace, persistentvolumeclaim) group_left(persistentvolume) `+
+					`label_replace(label_replace(kube_persistentvolume_claim_ref{persistentvolume="%s"}, `+
+					`"namespace", "$1", "claim_namespace", "(.*)"), `+
+					`"persistentvolumeclaim", "$1", "name", "(.*)")) `+
+					`/ on(persistentvolume) group_left() kube_persistentvolume_capacity_bytes{persistentvolume="%s"}`,
+				name, name),
+			LowerIsBetter: true,
+		},
+	}
+}
+
+// clusterScopedAlertLabelKey maps a cluster-scoped SignalTarget Kind to the
+// label key that kube-state-metrics/kubernetes-mixin alerting rules carry for
+// that resource type in AlertManager (Issue #193, DD-EM-005). Verified live:
+// firing alert instances inherit ALL labels from the underlying PromQL query
+// result, so a KubeNodeNotReady alert (query: kube_node_status_condition{...})
+// carries a "node" label at fire time. ok=false for any Kind without a known
+// mapping (assessAlert falls back to alertname-only matching, same as today).
+func clusterScopedAlertLabelKey(kind string) (string, bool) {
+	switch kind {
+	case "Node":
+		return "node", true
+	case "PersistentVolume":
+		return "persistentvolume", true
+	default:
+		return "", false
+	}
+}
+
 // populateMetricsAssessResult fills mr's before/after fields from the
 // available query results, keyed by metric name. Extracted from
 // assessMetrics (Wave 6 6a GREEN: funlen remediation) — pure code motion,
@@ -329,6 +456,24 @@ func populateMetricsAssessResult(mr *metricsAssessResult, queryResults []metricQ
 		case "http_throughput_rps":
 			mr.ThroughputBeforeRPS = &qr.PreValue
 			mr.ThroughputAfterRPS = &qr.PostValue
+		case "kube_node_status_condition_ready":
+			mr.NodeNotReadyBefore = &qr.PreValue
+			mr.NodeNotReadyAfter = &qr.PostValue
+		case "kube_node_status_condition_memorypressure":
+			mr.NodeMemoryPressureBefore = &qr.PreValue
+			mr.NodeMemoryPressureAfter = &qr.PostValue
+		case "kube_node_status_condition_diskpressure":
+			mr.NodeDiskPressureBefore = &qr.PreValue
+			mr.NodeDiskPressureAfter = &qr.PostValue
+		case "kube_persistentvolume_status_phase_failed":
+			mr.PVPhaseFailedBefore = &qr.PreValue
+			mr.PVPhaseFailedAfter = &qr.PostValue
+		case "kube_persistentvolume_status_phase_pending":
+			mr.PVPhasePendingBefore = &qr.PreValue
+			mr.PVPhasePendingAfter = &qr.PostValue
+		case "kubelet_volume_stats_used_bytes_ratio":
+			mr.PVUsageRatioBefore = &qr.PreValue
+			mr.PVUsageRatioAfter = &qr.PostValue
 		}
 	}
 }

--- a/internal/controller/effectivenessmonitor/cluster_scoped_metrics_test.go
+++ b/internal/controller/effectivenessmonitor/cluster_scoped_metrics_test.go
@@ -1,0 +1,174 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck // Ginkgo DSL convention
+	. "github.com/onsi/gomega"    //nolint:staticcheck // Gomega DSL convention
+)
+
+// Issue #193 / DD-EM-005: EM cluster-scoped resource assessment.
+//
+// buildNodeMetricQuerySpecs and buildPVMetricQuerySpecs are the deterministic,
+// kube-state-metrics-backed PromQL query builders for cluster-scoped targets
+// (Node, PersistentVolume). clusterScopedAlertLabelKey maps a cluster-scoped
+// Kind to the label key AlertManager alerts carry for that resource, so
+// assessAlert can populate alert.AlertContext.AlertLabels for precise matching.
+var _ = Describe("cluster-scoped metric/alert-label builders (BR-EM-003, BR-EM-002, DD-EM-005)", func() {
+
+	// UT-EM-193-001
+	Describe("buildNodeMetricQuerySpecs", func() {
+		It("produces Ready/MemoryPressure/DiskPressure PromQL specs keyed by node name, all LowerIsBetter", func() {
+			specs := buildNodeMetricQuerySpecs("worker-1")
+
+			Expect(specs).To(HaveLen(3))
+			for _, s := range specs {
+				Expect(s.LowerIsBetter).To(BeTrue(),
+					"a firing Node condition (NotReady/MemoryPressure/DiskPressure) is 1, so lower is better after remediation")
+				Expect(s.Query).To(ContainSubstring(`node="worker-1"`))
+				Expect(s.Query).To(ContainSubstring("kube_node_status_condition"))
+			}
+
+			names := make([]string, len(specs))
+			for i, s := range specs {
+				names[i] = s.Name
+			}
+			Expect(names).To(ConsistOf(
+				"kube_node_status_condition_ready",
+				"kube_node_status_condition_memorypressure",
+				"kube_node_status_condition_diskpressure",
+			))
+		})
+	})
+
+	// UT-EM-193-002
+	Describe("buildPVMetricQuerySpecs", func() {
+		It("produces Failed/Pending phase specs and a usage-join ratio spec keyed by PV name", func() {
+			specs := buildPVMetricQuerySpecs("pvc-abc123")
+
+			Expect(specs).To(HaveLen(3))
+
+			byName := make(map[string]metricQuerySpec, len(specs))
+			for _, s := range specs {
+				byName[s.Name] = s
+			}
+
+			Expect(byName).To(HaveKey("kube_persistentvolume_status_phase_failed"))
+			Expect(byName["kube_persistentvolume_status_phase_failed"].LowerIsBetter).To(BeTrue())
+			Expect(byName["kube_persistentvolume_status_phase_failed"].Query).To(ContainSubstring(`persistentvolume="pvc-abc123"`))
+			Expect(byName["kube_persistentvolume_status_phase_failed"].Query).To(ContainSubstring(`phase="Failed"`))
+
+			Expect(byName).To(HaveKey("kube_persistentvolume_status_phase_pending"))
+			Expect(byName["kube_persistentvolume_status_phase_pending"].LowerIsBetter).To(BeTrue())
+			Expect(byName["kube_persistentvolume_status_phase_pending"].Query).To(ContainSubstring(`phase="Pending"`))
+
+			Expect(byName).To(HaveKey("kubelet_volume_stats_used_bytes_ratio"))
+			usageSpec := byName["kubelet_volume_stats_used_bytes_ratio"]
+			Expect(usageSpec.LowerIsBetter).To(BeTrue())
+			Expect(usageSpec.Query).To(ContainSubstring("kubelet_volume_stats_used_bytes"))
+			Expect(usageSpec.Query).To(ContainSubstring(`kube_persistentvolume_claim_ref{persistentvolume="pvc-abc123"}`))
+		})
+	})
+
+	// UT-EM-193-003, UT-EM-193-004, UT-EM-193-005
+	Describe("clusterScopedAlertLabelKey", func() {
+		It("maps Node to the kube-state-metrics 'node' label key", func() {
+			key, ok := clusterScopedAlertLabelKey("Node")
+			Expect(ok).To(BeTrue())
+			Expect(key).To(Equal("node"))
+		})
+
+		It("maps PersistentVolume to the kube-state-metrics 'persistentvolume' label key", func() {
+			key, ok := clusterScopedAlertLabelKey("PersistentVolume")
+			Expect(ok).To(BeTrue())
+			Expect(key).To(Equal("persistentvolume"))
+		})
+
+		It("returns ok=false for an unrecognized cluster-scoped Kind", func() {
+			key, ok := clusterScopedAlertLabelKey("SomeUnknownKind")
+			Expect(ok).To(BeFalse())
+			Expect(key).To(BeEmpty())
+		})
+	})
+
+	// UT-EM-193-008, UT-EM-193-009, UT-EM-193-010
+	// populateMetricsAssessResult must map the 6 new cluster-scoped
+	// metricQuerySpec.Name values into metricsAssessResult fields so the
+	// effectiveness.metrics.assessed audit event's metric_deltas sub-object
+	// is populated for Node/PersistentVolume assessments (Issue #193 audit
+	// gap, DD-EM-005 v1.1).
+	Describe("populateMetricsAssessResult (cluster-scoped mapping)", func() {
+		It("UT-EM-193-008: maps Node condition query results into Node*  fields", func() {
+			mr := &metricsAssessResult{}
+			results := []metricQueryResult{
+				{Spec: metricQuerySpec{Name: "kube_node_status_condition_ready"}, PreValue: 1.0, PostValue: 0.0, Available: true},
+				{Spec: metricQuerySpec{Name: "kube_node_status_condition_memorypressure"}, PreValue: 1.0, PostValue: 0.0, Available: true},
+				{Spec: metricQuerySpec{Name: "kube_node_status_condition_diskpressure"}, PreValue: 0.0, PostValue: 0.0, Available: true},
+			}
+
+			populateMetricsAssessResult(mr, results)
+
+			Expect(mr.NodeNotReadyBefore).ToNot(BeNil())
+			Expect(*mr.NodeNotReadyBefore).To(BeNumerically("~", 1.0, 0.001))
+			Expect(mr.NodeNotReadyAfter).ToNot(BeNil())
+			Expect(*mr.NodeNotReadyAfter).To(BeNumerically("~", 0.0, 0.001))
+
+			Expect(mr.NodeMemoryPressureBefore).ToNot(BeNil())
+			Expect(*mr.NodeMemoryPressureBefore).To(BeNumerically("~", 1.0, 0.001))
+			Expect(mr.NodeMemoryPressureAfter).ToNot(BeNil())
+
+			Expect(mr.NodeDiskPressureBefore).ToNot(BeNil())
+			Expect(mr.NodeDiskPressureAfter).ToNot(BeNil())
+		})
+
+		It("UT-EM-193-009: maps PersistentVolume phase/usage query results into PV* fields", func() {
+			mr := &metricsAssessResult{}
+			results := []metricQueryResult{
+				{Spec: metricQuerySpec{Name: "kube_persistentvolume_status_phase_failed"}, PreValue: 1.0, PostValue: 0.0, Available: true},
+				{Spec: metricQuerySpec{Name: "kube_persistentvolume_status_phase_pending"}, PreValue: 0.0, PostValue: 0.0, Available: true},
+				{Spec: metricQuerySpec{Name: "kubelet_volume_stats_used_bytes_ratio"}, PreValue: 0.95, PostValue: 0.60, Available: true},
+			}
+
+			populateMetricsAssessResult(mr, results)
+
+			Expect(mr.PVPhaseFailedBefore).ToNot(BeNil())
+			Expect(*mr.PVPhaseFailedBefore).To(BeNumerically("~", 1.0, 0.001))
+			Expect(mr.PVPhaseFailedAfter).ToNot(BeNil())
+			Expect(*mr.PVPhaseFailedAfter).To(BeNumerically("~", 0.0, 0.001))
+
+			Expect(mr.PVPhasePendingBefore).ToNot(BeNil())
+			Expect(mr.PVPhasePendingAfter).ToNot(BeNil())
+
+			Expect(mr.PVUsageRatioBefore).ToNot(BeNil())
+			Expect(*mr.PVUsageRatioBefore).To(BeNumerically("~", 0.95, 0.001))
+			Expect(mr.PVUsageRatioAfter).ToNot(BeNil())
+			Expect(*mr.PVUsageRatioAfter).To(BeNumerically("~", 0.60, 0.001))
+		})
+
+		It("UT-EM-193-010: leaves cluster-scoped fields nil when the query is unavailable (graceful degradation)", func() {
+			mr := &metricsAssessResult{}
+			results := []metricQueryResult{
+				{Spec: metricQuerySpec{Name: "kube_node_status_condition_ready"}, Available: false},
+			}
+
+			populateMetricsAssessResult(mr, results)
+
+			Expect(mr.NodeNotReadyBefore).To(BeNil())
+			Expect(mr.NodeNotReadyAfter).To(BeNil())
+		})
+	})
+})

--- a/internal/controller/effectivenessmonitor/events.go
+++ b/internal/controller/effectivenessmonitor/events.go
@@ -156,6 +156,19 @@ func (r *Reconciler) emitMetricsEvent(ctx context.Context, ea *eav1.Effectivenes
 			ErrorRateAfter:      mr.ErrorRateAfter,
 			ThroughputBeforeRPS: mr.ThroughputBeforeRPS,
 			ThroughputAfterRPS:  mr.ThroughputAfterRPS,
+
+			NodeNotReadyBefore:       mr.NodeNotReadyBefore,
+			NodeNotReadyAfter:        mr.NodeNotReadyAfter,
+			NodeMemoryPressureBefore: mr.NodeMemoryPressureBefore,
+			NodeMemoryPressureAfter:  mr.NodeMemoryPressureAfter,
+			NodeDiskPressureBefore:   mr.NodeDiskPressureBefore,
+			NodeDiskPressureAfter:    mr.NodeDiskPressureAfter,
+			PVPhaseFailedBefore:      mr.PVPhaseFailedBefore,
+			PVPhaseFailedAfter:       mr.PVPhaseFailedAfter,
+			PVPhasePendingBefore:     mr.PVPhasePendingBefore,
+			PVPhasePendingAfter:      mr.PVPhasePendingAfter,
+			PVUsageRatioBefore:       mr.PVUsageRatioBefore,
+			PVUsageRatioAfter:        mr.PVUsageRatioAfter,
 		})
 	})
 }

--- a/internal/controller/effectivenessmonitor/isalertdecay_193_test.go
+++ b/internal/controller/effectivenessmonitor/isalertdecay_193_test.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+import (
+	. "github.com/onsi/ginkgo/v2" //nolint:staticcheck // Ginkgo DSL convention
+	. "github.com/onsi/gomega"    //nolint:staticcheck // Gomega DSL convention
+
+	eav1 "github.com/jordigilh/kubernaut/api/effectivenessassessment/v1alpha1"
+	emtypes "github.com/jordigilh/kubernaut/pkg/effectivenessmonitor/types"
+)
+
+// UT-EM-193-006 (Issue #193, DD-EM-005): isAlertDecay interaction with
+// now-reachable cluster-scoped metrics.
+//
+// Before this issue, ea.Status.Components.MetricsAssessed was unconditionally
+// false for every cluster-scoped (Node/PersistentVolume) target, so
+// isAlertDecay's "metrics regressed" guard clause
+// (MetricsAssessed && MetricsScore<=0 -> return false) was dead code for
+// those targets -- it could never evaluate true. Now that assessMetrics
+// dispatches to buildNodeMetricQuerySpecs/buildPVMetricQuerySpecs for
+// cluster-scoped Kinds, MetricsAssessed can become true for a Node target,
+// making this guard reachable for the first time. This test documents that
+// the guard behaves correctly once reachable: a healthy, spec-stable Node
+// with a real metrics regression must NOT be misclassified as Prometheus
+// alert decay.
+var _ = Describe("isAlertDecay: cluster-scoped metrics reachability (Issue #193, BR-EM-012)", func() {
+	It("returns false for a Node target that is healthy and hash-stable but has a real metrics regression", func() {
+		r := &Reconciler{}
+
+		healthScore := 1.0
+		metricsScore := 0.0 // regressed/no-improvement, <= 0.0
+		ea := &eav1.EffectivenessAssessment{
+			Spec: eav1.EffectivenessAssessmentSpec{
+				SignalTarget: eav1.TargetResource{
+					Kind: "Node",
+					Name: "worker-1",
+					// Namespace intentionally empty: cluster-scoped target.
+				},
+			},
+			Status: eav1.EffectivenessAssessmentStatus{
+				Components: eav1.EAComponents{
+					HealthAssessed: true,
+					HealthScore:    &healthScore,
+					HashComputed:   true,
+					// Newly reachable for a Node target as of this issue:
+					// previously MetricsAssessed was always false at cluster scope.
+					MetricsAssessed: true,
+					MetricsScore:    &metricsScore,
+				},
+			},
+		}
+
+		alertScore := 0.0 // alert still firing
+		ar := alertAssessResult{
+			Component: emtypes.ComponentResult{
+				Component: emtypes.ComponentAlert,
+				Assessed:  true,
+				Score:     &alertScore,
+			},
+		}
+
+		Expect(r.isAlertDecay(ea, ar)).To(BeFalse(),
+			"a real metrics regression (MetricsScore<=0) on a cluster-scoped target must suppress alert-decay "+
+				"classification, not just on namespace-scoped targets -- the guard must be reachable and correct "+
+				"now that Kind=Node can produce MetricsAssessed=true")
+	})
+
+	It("returns true for a Node target that is healthy, hash-stable, and has no metrics regression (decay detected)", func() {
+		r := &Reconciler{}
+
+		healthScore := 1.0
+		metricsScore := 0.6 // improved, > 0.0
+		ea := &eav1.EffectivenessAssessment{
+			Spec: eav1.EffectivenessAssessmentSpec{
+				SignalTarget: eav1.TargetResource{
+					Kind: "Node",
+					Name: "worker-1",
+				},
+			},
+			Status: eav1.EffectivenessAssessmentStatus{
+				Components: eav1.EAComponents{
+					HealthAssessed:  true,
+					HealthScore:     &healthScore,
+					HashComputed:    true,
+					MetricsAssessed: true,
+					MetricsScore:    &metricsScore,
+				},
+			},
+		}
+
+		alertScore := 0.0 // alert still firing despite health/metrics improvement
+		ar := alertAssessResult{
+			Component: emtypes.ComponentResult{
+				Component: emtypes.ComponentAlert,
+				Assessed:  true,
+				Score:     &alertScore,
+			},
+		}
+
+		Expect(r.isAlertDecay(ea, ar)).To(BeTrue(),
+			"a healthy, stable, metrics-improved Node target with a still-firing alert is the intended "+
+				"Prometheus-alert-decay case (Issue #369, BR-EM-012), now reachable at cluster scope too")
+	})
+})

--- a/internal/kubernautagent/enrichment/ds_adapter.go
+++ b/internal/kubernautagent/enrichment/ds_adapter.go
@@ -247,5 +247,71 @@ func mapMetricDeltas(md ogenclient.RemediationMetricDeltas) *MetricDeltas {
 		v := md.ErrorRateAfter.Value
 		result.ErrorRateAfter = &v
 	}
+	populateClusterScopedAndThroughputDeltas(result, md)
 	return result
+}
+
+// populateClusterScopedAndThroughputDeltas maps the throughput backfill and
+// the 6 cluster-scoped Node/PersistentVolume fields (Issue #193, DD-EM-005
+// v1.1) from the ogen-generated RemediationMetricDeltas into result. Extracted
+// from mapMetricDeltas to keep that function within the project's
+// line-length convention -- pure code motion alongside the new field
+// mappings, no behavior change to the existing fields mapped above.
+func populateClusterScopedAndThroughputDeltas(result *MetricDeltas, md ogenclient.RemediationMetricDeltas) {
+	if md.ThroughputBeforeRps.Set {
+		v := md.ThroughputBeforeRps.Value
+		result.ThroughputBeforeRps = &v
+	}
+	if md.ThroughputAfterRps.Set {
+		v := md.ThroughputAfterRps.Value
+		result.ThroughputAfterRps = &v
+	}
+	if md.NodeNotReadyBefore.Set {
+		v := md.NodeNotReadyBefore.Value
+		result.NodeNotReadyBefore = &v
+	}
+	if md.NodeNotReadyAfter.Set {
+		v := md.NodeNotReadyAfter.Value
+		result.NodeNotReadyAfter = &v
+	}
+	if md.NodeMemoryPressureBefore.Set {
+		v := md.NodeMemoryPressureBefore.Value
+		result.NodeMemoryPressureBefore = &v
+	}
+	if md.NodeMemoryPressureAfter.Set {
+		v := md.NodeMemoryPressureAfter.Value
+		result.NodeMemoryPressureAfter = &v
+	}
+	if md.NodeDiskPressureBefore.Set {
+		v := md.NodeDiskPressureBefore.Value
+		result.NodeDiskPressureBefore = &v
+	}
+	if md.NodeDiskPressureAfter.Set {
+		v := md.NodeDiskPressureAfter.Value
+		result.NodeDiskPressureAfter = &v
+	}
+	if md.PvPhaseFailedBefore.Set {
+		v := md.PvPhaseFailedBefore.Value
+		result.PvPhaseFailedBefore = &v
+	}
+	if md.PvPhaseFailedAfter.Set {
+		v := md.PvPhaseFailedAfter.Value
+		result.PvPhaseFailedAfter = &v
+	}
+	if md.PvPhasePendingBefore.Set {
+		v := md.PvPhasePendingBefore.Value
+		result.PvPhasePendingBefore = &v
+	}
+	if md.PvPhasePendingAfter.Set {
+		v := md.PvPhasePendingAfter.Value
+		result.PvPhasePendingAfter = &v
+	}
+	if md.PvUsageRatioBefore.Set {
+		v := md.PvUsageRatioBefore.Value
+		result.PvUsageRatioBefore = &v
+	}
+	if md.PvUsageRatioAfter.Set {
+		v := md.PvUsageRatioAfter.Value
+		result.PvUsageRatioAfter = &v
+	}
 }

--- a/internal/kubernautagent/enrichment/ds_adapter_test.go
+++ b/internal/kubernautagent/enrichment/ds_adapter_test.go
@@ -126,6 +126,85 @@ var _ = Describe("DataStorage Adapter — TP-433-WIR Phase 1a", func() {
 		})
 	})
 
+	Describe("UT-KA-433W-014: DS adapter maps cluster-scoped and throughput metric_deltas fields (Issue #193, DD-EM-005 v1.1)", func() {
+		It("should map throughput and Node/PersistentVolume fields into enrichment.MetricDeltas", func() {
+			client := &stubDSClient{
+				response: &ogenclient.RemediationHistoryContext{
+					TargetResource: "cluster/Node/worker-1",
+					Tier1: ogenclient.RemediationHistoryTier1{
+						Chain: []ogenclient.RemediationHistoryEntry{
+							{
+								RemediationUID: "wf-node-recovery-001",
+								CompletedAt:    time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC),
+								MetricDeltas: ogenclient.NewOptRemediationMetricDeltas(ogenclient.RemediationMetricDeltas{
+									ThroughputBeforeRps:      ogenclient.NewOptFloat64(120.0),
+									ThroughputAfterRps:       ogenclient.NewOptFloat64(150.0),
+									NodeNotReadyBefore:       ogenclient.NewOptFloat64(1.0),
+									NodeNotReadyAfter:        ogenclient.NewOptFloat64(0.0),
+									NodeMemoryPressureBefore: ogenclient.NewOptFloat64(1.0),
+									NodeMemoryPressureAfter:  ogenclient.NewOptFloat64(0.0),
+									NodeDiskPressureBefore:   ogenclient.NewOptFloat64(0.0),
+									NodeDiskPressureAfter:    ogenclient.NewOptFloat64(0.0),
+									PvPhaseFailedBefore:      ogenclient.NewOptFloat64(1.0),
+									PvPhaseFailedAfter:       ogenclient.NewOptFloat64(0.0),
+									PvPhasePendingBefore:     ogenclient.NewOptFloat64(0.0),
+									PvPhasePendingAfter:      ogenclient.NewOptFloat64(0.0),
+									PvUsageRatioBefore:       ogenclient.NewOptFloat64(0.95),
+									PvUsageRatioAfter:        ogenclient.NewOptFloat64(0.60),
+								}),
+							},
+						},
+					},
+				},
+			}
+
+			adapter := enrichment.NewDSAdapter(client)
+			result, err := adapter.GetRemediationHistory(context.Background(), "Node", "worker-1", "", "abc123")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Tier1).To(HaveLen(1))
+			md := result.Tier1[0].MetricDeltas
+			Expect(md).NotTo(BeNil())
+
+			Expect(*md.ThroughputBeforeRps).To(BeNumerically("~", 120.0))
+			Expect(*md.ThroughputAfterRps).To(BeNumerically("~", 150.0))
+			Expect(*md.NodeNotReadyBefore).To(BeNumerically("~", 1.0))
+			Expect(*md.NodeNotReadyAfter).To(BeNumerically("~", 0.0))
+			Expect(*md.NodeMemoryPressureBefore).To(BeNumerically("~", 1.0))
+			Expect(*md.NodeDiskPressureBefore).To(BeNumerically("~", 0.0))
+			Expect(*md.PvPhaseFailedBefore).To(BeNumerically("~", 1.0))
+			Expect(*md.PvPhasePendingBefore).To(BeNumerically("~", 0.0))
+			Expect(*md.PvUsageRatioBefore).To(BeNumerically("~", 0.95))
+			Expect(*md.PvUsageRatioAfter).To(BeNumerically("~", 0.60))
+		})
+
+		It("should leave cluster-scoped and throughput fields nil when absent (namespace-scoped target)", func() {
+			client := &stubDSClient{
+				response: &ogenclient.RemediationHistoryContext{
+					Tier1: ogenclient.RemediationHistoryTier1{
+						Chain: []ogenclient.RemediationHistoryEntry{
+							{
+								RemediationUID: "wf-ns-001",
+								CompletedAt:    time.Date(2026, 3, 1, 10, 0, 0, 0, time.UTC),
+								MetricDeltas: ogenclient.NewOptRemediationMetricDeltas(ogenclient.RemediationMetricDeltas{
+									CpuBefore: ogenclient.NewOptFloat64(0.85),
+									CpuAfter:  ogenclient.NewOptFloat64(0.45),
+								}),
+							},
+						},
+					},
+				},
+			}
+
+			adapter := enrichment.NewDSAdapter(client)
+			result, err := adapter.GetRemediationHistory(context.Background(), "Deployment", "api-server", "default", "abc123")
+			Expect(err).NotTo(HaveOccurred())
+			md := result.Tier1[0].MetricDeltas
+			Expect(md.ThroughputBeforeRps).To(BeNil())
+			Expect(md.NodeNotReadyBefore).To(BeNil())
+			Expect(md.PvUsageRatioBefore).To(BeNil())
+		})
+	})
+
 	Describe("UT-KA-433W-002: DS adapter returns empty result for empty DS history", func() {
 		It("should return empty Tier1/Tier2 slices, not nil", func() {
 			client := &stubDSClient{

--- a/internal/kubernautagent/enrichment/enricher.go
+++ b/internal/kubernautagent/enrichment/enricher.go
@@ -127,6 +127,25 @@ type MetricDeltas struct {
 	LatencyP95AfterMs  *float64 `json:"latency_p95_after_ms,omitempty"`
 	ErrorRateBefore    *float64 `json:"error_rate_before,omitempty"`
 	ErrorRateAfter     *float64 `json:"error_rate_after,omitempty"`
+	// ThroughputBeforeRps/After backfill a pre-existing gap: present in the raw
+	// EM audit event and DS's RemediationMetricDeltas since 21e592475, but never
+	// propagated to this domain type until now.
+	ThroughputBeforeRps *float64 `json:"throughput_before_rps,omitempty"`
+	ThroughputAfterRps  *float64 `json:"throughput_after_rps,omitempty"`
+	// Cluster-scoped fields (Issue #193, DD-EM-005 v1.1): populated only when
+	// the source remediation targeted a Node or PersistentVolume.
+	NodeNotReadyBefore       *float64 `json:"node_not_ready_before,omitempty"`
+	NodeNotReadyAfter        *float64 `json:"node_not_ready_after,omitempty"`
+	NodeMemoryPressureBefore *float64 `json:"node_memory_pressure_before,omitempty"`
+	NodeMemoryPressureAfter  *float64 `json:"node_memory_pressure_after,omitempty"`
+	NodeDiskPressureBefore   *float64 `json:"node_disk_pressure_before,omitempty"`
+	NodeDiskPressureAfter    *float64 `json:"node_disk_pressure_after,omitempty"`
+	PvPhaseFailedBefore      *float64 `json:"pv_phase_failed_before,omitempty"`
+	PvPhaseFailedAfter       *float64 `json:"pv_phase_failed_after,omitempty"`
+	PvPhasePendingBefore     *float64 `json:"pv_phase_pending_before,omitempty"`
+	PvPhasePendingAfter      *float64 `json:"pv_phase_pending_after,omitempty"`
+	PvUsageRatioBefore       *float64 `json:"pv_usage_ratio_before,omitempty"`
+	PvUsageRatioAfter        *float64 `json:"pv_usage_ratio_after,omitempty"`
 }
 
 // RetryConfig controls retry behavior for infrastructure calls in Enrich().

--- a/internal/kubernautagent/prompt/history.go
+++ b/internal/kubernautagent/prompt/history.go
@@ -331,10 +331,43 @@ func FormatMetricDeltas(md *enrichment.MetricDeltas) string {
 	if md.ErrorRateBefore != nil && md.ErrorRateAfter != nil {
 		parts = append(parts, fmt.Sprintf("error_rate: %.4f -> %.4f", *md.ErrorRateBefore, *md.ErrorRateAfter))
 	}
+	parts = append(parts, formatClusterScopedAndThroughputDeltas(md)...)
 	if len(parts) == 0 {
 		return "N/A"
 	}
 	return strings.Join(parts, ", ")
+}
+
+// formatClusterScopedAndThroughputDeltas renders the throughput backfill and
+// the 6 cluster-scoped Node/PersistentVolume metric_deltas fields (Issue
+// #193, DD-EM-005 v1.1) as human-readable before->after pairs for the LLM
+// prompt. Extracted from FormatMetricDeltas to keep that function within the
+// project's line-length convention -- pure code motion alongside the new
+// field mappings, no behavior change to the existing fields formatted above.
+func formatClusterScopedAndThroughputDeltas(md *enrichment.MetricDeltas) []string {
+	var parts []string
+	if md.ThroughputBeforeRps != nil && md.ThroughputAfterRps != nil {
+		parts = append(parts, fmt.Sprintf("throughput: %.1f -> %.1f rps", *md.ThroughputBeforeRps, *md.ThroughputAfterRps))
+	}
+	if md.NodeNotReadyBefore != nil && md.NodeNotReadyAfter != nil {
+		parts = append(parts, fmt.Sprintf("node_not_ready: %.0f -> %.0f", *md.NodeNotReadyBefore, *md.NodeNotReadyAfter))
+	}
+	if md.NodeMemoryPressureBefore != nil && md.NodeMemoryPressureAfter != nil {
+		parts = append(parts, fmt.Sprintf("node_memory_pressure: %.0f -> %.0f", *md.NodeMemoryPressureBefore, *md.NodeMemoryPressureAfter))
+	}
+	if md.NodeDiskPressureBefore != nil && md.NodeDiskPressureAfter != nil {
+		parts = append(parts, fmt.Sprintf("node_disk_pressure: %.0f -> %.0f", *md.NodeDiskPressureBefore, *md.NodeDiskPressureAfter))
+	}
+	if md.PvPhaseFailedBefore != nil && md.PvPhaseFailedAfter != nil {
+		parts = append(parts, fmt.Sprintf("pv_phase_failed: %.0f -> %.0f", *md.PvPhaseFailedBefore, *md.PvPhaseFailedAfter))
+	}
+	if md.PvPhasePendingBefore != nil && md.PvPhasePendingAfter != nil {
+		parts = append(parts, fmt.Sprintf("pv_phase_pending: %.0f -> %.0f", *md.PvPhasePendingBefore, *md.PvPhasePendingAfter))
+	}
+	if md.PvUsageRatioBefore != nil && md.PvUsageRatioAfter != nil {
+		parts = append(parts, fmt.Sprintf("pv_usage_ratio: %.2f -> %.2f", *md.PvUsageRatioBefore, *md.PvUsageRatioAfter))
+	}
+	return parts
 }
 
 // DetectDecliningEffectiveness groups Tier1 entries by actionType and checks

--- a/internal/kubernautagent/prompt/history_test.go
+++ b/internal/kubernautagent/prompt/history_test.go
@@ -96,6 +96,33 @@ var _ = Describe("Remediation History Prompt Builder — KA Parity (#433)", func
 		It("should return N/A for nil metric deltas", func() {
 			Expect(prompt.FormatMetricDeltas(nil)).To(Equal("N/A"))
 		})
+
+		It("should format throughput and cluster-scoped Node/PV pairs (Issue #193, DD-EM-005 v1.1)", func() {
+			md := &enrichment.MetricDeltas{
+				ThroughputBeforeRps:      floatPtr(120.0),
+				ThroughputAfterRps:       floatPtr(150.0),
+				NodeNotReadyBefore:       floatPtr(1.0),
+				NodeNotReadyAfter:        floatPtr(0.0),
+				NodeMemoryPressureBefore: floatPtr(1.0),
+				NodeMemoryPressureAfter:  floatPtr(0.0),
+				NodeDiskPressureBefore:   floatPtr(0.0),
+				NodeDiskPressureAfter:    floatPtr(0.0),
+				PvPhaseFailedBefore:      floatPtr(1.0),
+				PvPhaseFailedAfter:       floatPtr(0.0),
+				PvPhasePendingBefore:     floatPtr(0.0),
+				PvPhasePendingAfter:      floatPtr(0.0),
+				PvUsageRatioBefore:       floatPtr(0.95),
+				PvUsageRatioAfter:        floatPtr(0.60),
+			}
+			result := prompt.FormatMetricDeltas(md)
+			Expect(result).To(ContainSubstring("throughput: 120.0 -> 150.0 rps"))
+			Expect(result).To(ContainSubstring("node_not_ready: 1 -> 0"))
+			Expect(result).To(ContainSubstring("node_memory_pressure: 1 -> 0"))
+			Expect(result).To(ContainSubstring("node_disk_pressure: 0 -> 0"))
+			Expect(result).To(ContainSubstring("pv_phase_failed: 1 -> 0"))
+			Expect(result).To(ContainSubstring("pv_phase_pending: 0 -> 0"))
+			Expect(result).To(ContainSubstring("pv_usage_ratio: 0.95 -> 0.60"))
+		})
 	})
 
 	Describe("UT-KA-433-HP-004: FormatTier1Entry — normal entry", func() {

--- a/pkg/audit/openapi_spec_data.yaml
+++ b/pkg/audit/openapi_spec_data.yaml
@@ -5060,6 +5060,8 @@ components:
             Only present for effectiveness.metrics.assessed events.
             Phase A (V1.0): cpu_before/cpu_after populated. Other fields nullable pending
             Phase B metrics assessor expansion (additional PromQL queries).
+            Cluster-scoped fields (node_*, pv_*) populated for Node/PersistentVolume
+            targets only (Issue #193, DD-EM-005 v1.1); null for namespace-scoped targets.
           properties:
             cpu_before:
               type: number
@@ -5113,6 +5115,68 @@ components:
               format: double
               nullable: true
               description: Request throughput (requests/second) after remediation
+            node_not_ready_before:
+              type: number
+              format: double
+              nullable: true
+              description: |
+                Node Ready condition status=false flag before remediation (1=not ready, 0=ready).
+                Cluster-scoped (Issue #193, DD-EM-005).
+            node_not_ready_after:
+              type: number
+              format: double
+              nullable: true
+              description: Node Ready condition status=false flag after remediation (1=not ready, 0=ready). Cluster-scoped (Issue #193, DD-EM-005).
+            node_memory_pressure_before:
+              type: number
+              format: double
+              nullable: true
+              description: Node MemoryPressure condition flag before remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+            node_memory_pressure_after:
+              type: number
+              format: double
+              nullable: true
+              description: Node MemoryPressure condition flag after remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+            node_disk_pressure_before:
+              type: number
+              format: double
+              nullable: true
+              description: Node DiskPressure condition flag before remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+            node_disk_pressure_after:
+              type: number
+              format: double
+              nullable: true
+              description: Node DiskPressure condition flag after remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+            pv_phase_failed_before:
+              type: number
+              format: double
+              nullable: true
+              description: PersistentVolume Failed phase flag before remediation (1=failed, 0=not failed). Cluster-scoped (Issue #193, DD-EM-005).
+            pv_phase_failed_after:
+              type: number
+              format: double
+              nullable: true
+              description: PersistentVolume Failed phase flag after remediation (1=failed, 0=not failed). Cluster-scoped (Issue #193, DD-EM-005).
+            pv_phase_pending_before:
+              type: number
+              format: double
+              nullable: true
+              description: PersistentVolume Pending phase flag before remediation (1=pending, 0=not pending). Cluster-scoped (Issue #193, DD-EM-005).
+            pv_phase_pending_after:
+              type: number
+              format: double
+              nullable: true
+              description: PersistentVolume Pending phase flag after remediation (1=pending, 0=not pending). Cluster-scoped (Issue #193, DD-EM-005).
+            pv_usage_ratio_before:
+              type: number
+              format: double
+              nullable: true
+              description: PersistentVolume used/capacity usage ratio before remediation (0.0-1.0+). Cluster-scoped (Issue #193, DD-EM-005).
+            pv_usage_ratio_after:
+              type: number
+              format: double
+              nullable: true
+              description: PersistentVolume used/capacity usage ratio after remediation (0.0-1.0+). Cluster-scoped (Issue #193, DD-EM-005).
 
         alert_resolution:
           type: object
@@ -6856,6 +6920,64 @@ components:
           format: double
           description: Error rate after remediation (0.0-1.0)
           example: 0.019
+        throughputBeforeRps:
+          type: number
+          format: double
+          description: Request throughput (requests/second) before remediation
+          example: 150.0
+        throughputAfterRps:
+          type: number
+          format: double
+          description: Request throughput (requests/second) after remediation
+          example: 148.0
+        nodeNotReadyBefore:
+          type: number
+          format: double
+          description: Node Ready condition status=false flag before remediation (1=not ready, 0=ready). Cluster-scoped (Issue #193, DD-EM-005).
+        nodeNotReadyAfter:
+          type: number
+          format: double
+          description: Node Ready condition status=false flag after remediation (1=not ready, 0=ready). Cluster-scoped (Issue #193, DD-EM-005).
+        nodeMemoryPressureBefore:
+          type: number
+          format: double
+          description: Node MemoryPressure condition flag before remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+        nodeMemoryPressureAfter:
+          type: number
+          format: double
+          description: Node MemoryPressure condition flag after remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+        nodeDiskPressureBefore:
+          type: number
+          format: double
+          description: Node DiskPressure condition flag before remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+        nodeDiskPressureAfter:
+          type: number
+          format: double
+          description: Node DiskPressure condition flag after remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+        pvPhaseFailedBefore:
+          type: number
+          format: double
+          description: PersistentVolume Failed phase flag before remediation (1=failed, 0=not failed). Cluster-scoped (Issue #193, DD-EM-005).
+        pvPhaseFailedAfter:
+          type: number
+          format: double
+          description: PersistentVolume Failed phase flag after remediation (1=failed, 0=not failed). Cluster-scoped (Issue #193, DD-EM-005).
+        pvPhasePendingBefore:
+          type: number
+          format: double
+          description: PersistentVolume Pending phase flag before remediation (1=pending, 0=not pending). Cluster-scoped (Issue #193, DD-EM-005).
+        pvPhasePendingAfter:
+          type: number
+          format: double
+          description: PersistentVolume Pending phase flag after remediation (1=pending, 0=not pending). Cluster-scoped (Issue #193, DD-EM-005).
+        pvUsageRatioBefore:
+          type: number
+          format: double
+          description: PersistentVolume used/capacity usage ratio before remediation (0.0-1.0+). Cluster-scoped (Issue #193, DD-EM-005).
+        pvUsageRatioAfter:
+          type: number
+          format: double
+          description: PersistentVolume used/capacity usage ratio after remediation (0.0-1.0+). Cluster-scoped (Issue #193, DD-EM-005).
 
     # ========================================
     # ActionType Taxonomy (BR-WORKFLOW-007)

--- a/pkg/datastorage/ogen-client/oas_json_gen.go
+++ b/pkg/datastorage/ogen-client/oas_json_gen.go
@@ -30584,19 +30584,103 @@ func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) encodeFields(e *jx.Enc
 			s.ThroughputAfterRps.Encode(e)
 		}
 	}
+	{
+		if s.NodeNotReadyBefore.Set {
+			e.FieldStart("node_not_ready_before")
+			s.NodeNotReadyBefore.Encode(e)
+		}
+	}
+	{
+		if s.NodeNotReadyAfter.Set {
+			e.FieldStart("node_not_ready_after")
+			s.NodeNotReadyAfter.Encode(e)
+		}
+	}
+	{
+		if s.NodeMemoryPressureBefore.Set {
+			e.FieldStart("node_memory_pressure_before")
+			s.NodeMemoryPressureBefore.Encode(e)
+		}
+	}
+	{
+		if s.NodeMemoryPressureAfter.Set {
+			e.FieldStart("node_memory_pressure_after")
+			s.NodeMemoryPressureAfter.Encode(e)
+		}
+	}
+	{
+		if s.NodeDiskPressureBefore.Set {
+			e.FieldStart("node_disk_pressure_before")
+			s.NodeDiskPressureBefore.Encode(e)
+		}
+	}
+	{
+		if s.NodeDiskPressureAfter.Set {
+			e.FieldStart("node_disk_pressure_after")
+			s.NodeDiskPressureAfter.Encode(e)
+		}
+	}
+	{
+		if s.PvPhaseFailedBefore.Set {
+			e.FieldStart("pv_phase_failed_before")
+			s.PvPhaseFailedBefore.Encode(e)
+		}
+	}
+	{
+		if s.PvPhaseFailedAfter.Set {
+			e.FieldStart("pv_phase_failed_after")
+			s.PvPhaseFailedAfter.Encode(e)
+		}
+	}
+	{
+		if s.PvPhasePendingBefore.Set {
+			e.FieldStart("pv_phase_pending_before")
+			s.PvPhasePendingBefore.Encode(e)
+		}
+	}
+	{
+		if s.PvPhasePendingAfter.Set {
+			e.FieldStart("pv_phase_pending_after")
+			s.PvPhasePendingAfter.Encode(e)
+		}
+	}
+	{
+		if s.PvUsageRatioBefore.Set {
+			e.FieldStart("pv_usage_ratio_before")
+			s.PvUsageRatioBefore.Encode(e)
+		}
+	}
+	{
+		if s.PvUsageRatioAfter.Set {
+			e.FieldStart("pv_usage_ratio_after")
+			s.PvUsageRatioAfter.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfEffectivenessAssessmentAuditPayloadMetricDeltas = [10]string{
-	0: "cpu_before",
-	1: "cpu_after",
-	2: "memory_before",
-	3: "memory_after",
-	4: "latency_p95_before_ms",
-	5: "latency_p95_after_ms",
-	6: "error_rate_before",
-	7: "error_rate_after",
-	8: "throughput_before_rps",
-	9: "throughput_after_rps",
+var jsonFieldsNameOfEffectivenessAssessmentAuditPayloadMetricDeltas = [22]string{
+	0:  "cpu_before",
+	1:  "cpu_after",
+	2:  "memory_before",
+	3:  "memory_after",
+	4:  "latency_p95_before_ms",
+	5:  "latency_p95_after_ms",
+	6:  "error_rate_before",
+	7:  "error_rate_after",
+	8:  "throughput_before_rps",
+	9:  "throughput_after_rps",
+	10: "node_not_ready_before",
+	11: "node_not_ready_after",
+	12: "node_memory_pressure_before",
+	13: "node_memory_pressure_after",
+	14: "node_disk_pressure_before",
+	15: "node_disk_pressure_after",
+	16: "pv_phase_failed_before",
+	17: "pv_phase_failed_after",
+	18: "pv_phase_pending_before",
+	19: "pv_phase_pending_after",
+	20: "pv_usage_ratio_before",
+	21: "pv_usage_ratio_after",
 }
 
 // Decode decodes EffectivenessAssessmentAuditPayloadMetricDeltas from json.
@@ -30706,6 +30790,126 @@ func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) Decode(d *jx.Decoder) 
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"throughput_after_rps\"")
+			}
+		case "node_not_ready_before":
+			if err := func() error {
+				s.NodeNotReadyBefore.Reset()
+				if err := s.NodeNotReadyBefore.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"node_not_ready_before\"")
+			}
+		case "node_not_ready_after":
+			if err := func() error {
+				s.NodeNotReadyAfter.Reset()
+				if err := s.NodeNotReadyAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"node_not_ready_after\"")
+			}
+		case "node_memory_pressure_before":
+			if err := func() error {
+				s.NodeMemoryPressureBefore.Reset()
+				if err := s.NodeMemoryPressureBefore.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"node_memory_pressure_before\"")
+			}
+		case "node_memory_pressure_after":
+			if err := func() error {
+				s.NodeMemoryPressureAfter.Reset()
+				if err := s.NodeMemoryPressureAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"node_memory_pressure_after\"")
+			}
+		case "node_disk_pressure_before":
+			if err := func() error {
+				s.NodeDiskPressureBefore.Reset()
+				if err := s.NodeDiskPressureBefore.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"node_disk_pressure_before\"")
+			}
+		case "node_disk_pressure_after":
+			if err := func() error {
+				s.NodeDiskPressureAfter.Reset()
+				if err := s.NodeDiskPressureAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"node_disk_pressure_after\"")
+			}
+		case "pv_phase_failed_before":
+			if err := func() error {
+				s.PvPhaseFailedBefore.Reset()
+				if err := s.PvPhaseFailedBefore.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"pv_phase_failed_before\"")
+			}
+		case "pv_phase_failed_after":
+			if err := func() error {
+				s.PvPhaseFailedAfter.Reset()
+				if err := s.PvPhaseFailedAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"pv_phase_failed_after\"")
+			}
+		case "pv_phase_pending_before":
+			if err := func() error {
+				s.PvPhasePendingBefore.Reset()
+				if err := s.PvPhasePendingBefore.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"pv_phase_pending_before\"")
+			}
+		case "pv_phase_pending_after":
+			if err := func() error {
+				s.PvPhasePendingAfter.Reset()
+				if err := s.PvPhasePendingAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"pv_phase_pending_after\"")
+			}
+		case "pv_usage_ratio_before":
+			if err := func() error {
+				s.PvUsageRatioBefore.Reset()
+				if err := s.PvUsageRatioBefore.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"pv_usage_ratio_before\"")
+			}
+		case "pv_usage_ratio_after":
+			if err := func() error {
+				s.PvUsageRatioAfter.Reset()
+				if err := s.PvUsageRatioAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"pv_usage_ratio_after\"")
 			}
 		default:
 			return d.Skip()
@@ -44707,17 +44911,115 @@ func (s *RemediationMetricDeltas) encodeFields(e *jx.Encoder) {
 			s.ErrorRateAfter.Encode(e)
 		}
 	}
+	{
+		if s.ThroughputBeforeRps.Set {
+			e.FieldStart("throughputBeforeRps")
+			s.ThroughputBeforeRps.Encode(e)
+		}
+	}
+	{
+		if s.ThroughputAfterRps.Set {
+			e.FieldStart("throughputAfterRps")
+			s.ThroughputAfterRps.Encode(e)
+		}
+	}
+	{
+		if s.NodeNotReadyBefore.Set {
+			e.FieldStart("nodeNotReadyBefore")
+			s.NodeNotReadyBefore.Encode(e)
+		}
+	}
+	{
+		if s.NodeNotReadyAfter.Set {
+			e.FieldStart("nodeNotReadyAfter")
+			s.NodeNotReadyAfter.Encode(e)
+		}
+	}
+	{
+		if s.NodeMemoryPressureBefore.Set {
+			e.FieldStart("nodeMemoryPressureBefore")
+			s.NodeMemoryPressureBefore.Encode(e)
+		}
+	}
+	{
+		if s.NodeMemoryPressureAfter.Set {
+			e.FieldStart("nodeMemoryPressureAfter")
+			s.NodeMemoryPressureAfter.Encode(e)
+		}
+	}
+	{
+		if s.NodeDiskPressureBefore.Set {
+			e.FieldStart("nodeDiskPressureBefore")
+			s.NodeDiskPressureBefore.Encode(e)
+		}
+	}
+	{
+		if s.NodeDiskPressureAfter.Set {
+			e.FieldStart("nodeDiskPressureAfter")
+			s.NodeDiskPressureAfter.Encode(e)
+		}
+	}
+	{
+		if s.PvPhaseFailedBefore.Set {
+			e.FieldStart("pvPhaseFailedBefore")
+			s.PvPhaseFailedBefore.Encode(e)
+		}
+	}
+	{
+		if s.PvPhaseFailedAfter.Set {
+			e.FieldStart("pvPhaseFailedAfter")
+			s.PvPhaseFailedAfter.Encode(e)
+		}
+	}
+	{
+		if s.PvPhasePendingBefore.Set {
+			e.FieldStart("pvPhasePendingBefore")
+			s.PvPhasePendingBefore.Encode(e)
+		}
+	}
+	{
+		if s.PvPhasePendingAfter.Set {
+			e.FieldStart("pvPhasePendingAfter")
+			s.PvPhasePendingAfter.Encode(e)
+		}
+	}
+	{
+		if s.PvUsageRatioBefore.Set {
+			e.FieldStart("pvUsageRatioBefore")
+			s.PvUsageRatioBefore.Encode(e)
+		}
+	}
+	{
+		if s.PvUsageRatioAfter.Set {
+			e.FieldStart("pvUsageRatioAfter")
+			s.PvUsageRatioAfter.Encode(e)
+		}
+	}
 }
 
-var jsonFieldsNameOfRemediationMetricDeltas = [8]string{
-	0: "cpuBefore",
-	1: "cpuAfter",
-	2: "memoryBefore",
-	3: "memoryAfter",
-	4: "latencyP95BeforeMs",
-	5: "latencyP95AfterMs",
-	6: "errorRateBefore",
-	7: "errorRateAfter",
+var jsonFieldsNameOfRemediationMetricDeltas = [22]string{
+	0:  "cpuBefore",
+	1:  "cpuAfter",
+	2:  "memoryBefore",
+	3:  "memoryAfter",
+	4:  "latencyP95BeforeMs",
+	5:  "latencyP95AfterMs",
+	6:  "errorRateBefore",
+	7:  "errorRateAfter",
+	8:  "throughputBeforeRps",
+	9:  "throughputAfterRps",
+	10: "nodeNotReadyBefore",
+	11: "nodeNotReadyAfter",
+	12: "nodeMemoryPressureBefore",
+	13: "nodeMemoryPressureAfter",
+	14: "nodeDiskPressureBefore",
+	15: "nodeDiskPressureAfter",
+	16: "pvPhaseFailedBefore",
+	17: "pvPhaseFailedAfter",
+	18: "pvPhasePendingBefore",
+	19: "pvPhasePendingAfter",
+	20: "pvUsageRatioBefore",
+	21: "pvUsageRatioAfter",
 }
 
 // Decode decodes RemediationMetricDeltas from json.
@@ -44807,6 +45109,146 @@ func (s *RemediationMetricDeltas) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"errorRateAfter\"")
+			}
+		case "throughputBeforeRps":
+			if err := func() error {
+				s.ThroughputBeforeRps.Reset()
+				if err := s.ThroughputBeforeRps.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"throughputBeforeRps\"")
+			}
+		case "throughputAfterRps":
+			if err := func() error {
+				s.ThroughputAfterRps.Reset()
+				if err := s.ThroughputAfterRps.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"throughputAfterRps\"")
+			}
+		case "nodeNotReadyBefore":
+			if err := func() error {
+				s.NodeNotReadyBefore.Reset()
+				if err := s.NodeNotReadyBefore.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"nodeNotReadyBefore\"")
+			}
+		case "nodeNotReadyAfter":
+			if err := func() error {
+				s.NodeNotReadyAfter.Reset()
+				if err := s.NodeNotReadyAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"nodeNotReadyAfter\"")
+			}
+		case "nodeMemoryPressureBefore":
+			if err := func() error {
+				s.NodeMemoryPressureBefore.Reset()
+				if err := s.NodeMemoryPressureBefore.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"nodeMemoryPressureBefore\"")
+			}
+		case "nodeMemoryPressureAfter":
+			if err := func() error {
+				s.NodeMemoryPressureAfter.Reset()
+				if err := s.NodeMemoryPressureAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"nodeMemoryPressureAfter\"")
+			}
+		case "nodeDiskPressureBefore":
+			if err := func() error {
+				s.NodeDiskPressureBefore.Reset()
+				if err := s.NodeDiskPressureBefore.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"nodeDiskPressureBefore\"")
+			}
+		case "nodeDiskPressureAfter":
+			if err := func() error {
+				s.NodeDiskPressureAfter.Reset()
+				if err := s.NodeDiskPressureAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"nodeDiskPressureAfter\"")
+			}
+		case "pvPhaseFailedBefore":
+			if err := func() error {
+				s.PvPhaseFailedBefore.Reset()
+				if err := s.PvPhaseFailedBefore.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"pvPhaseFailedBefore\"")
+			}
+		case "pvPhaseFailedAfter":
+			if err := func() error {
+				s.PvPhaseFailedAfter.Reset()
+				if err := s.PvPhaseFailedAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"pvPhaseFailedAfter\"")
+			}
+		case "pvPhasePendingBefore":
+			if err := func() error {
+				s.PvPhasePendingBefore.Reset()
+				if err := s.PvPhasePendingBefore.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"pvPhasePendingBefore\"")
+			}
+		case "pvPhasePendingAfter":
+			if err := func() error {
+				s.PvPhasePendingAfter.Reset()
+				if err := s.PvPhasePendingAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"pvPhasePendingAfter\"")
+			}
+		case "pvUsageRatioBefore":
+			if err := func() error {
+				s.PvUsageRatioBefore.Reset()
+				if err := s.PvUsageRatioBefore.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"pvUsageRatioBefore\"")
+			}
+		case "pvUsageRatioAfter":
+			if err := func() error {
+				s.PvUsageRatioAfter.Reset()
+				if err := s.PvUsageRatioAfter.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"pvUsageRatioAfter\"")
 			}
 		default:
 			return d.Skip()

--- a/pkg/datastorage/ogen-client/oas_schemas_gen.go
+++ b/pkg/datastorage/ogen-client/oas_schemas_gen.go
@@ -16960,6 +16960,8 @@ type EffectivenessAssessmentAuditPayload struct {
 	// Only present for effectiveness.metrics.assessed events.
 	// Phase A (V1.0): cpu_before/cpu_after populated. Other fields nullable pending
 	// Phase B metrics assessor expansion (additional PromQL queries).
+	// Cluster-scoped fields (node_*, pv_*) populated for Node/PersistentVolume
+	// targets only (Issue #193, DD-EM-005 v1.1); null for namespace-scoped targets.
 	MetricDeltas OptEffectivenessAssessmentAuditPayloadMetricDeltas `json:"metric_deltas"`
 	// Structured alert resolution check results from AlertManager.
 	// Only present for effectiveness.alert.assessed events.
@@ -17570,6 +17572,8 @@ func (s *EffectivenessAssessmentAuditPayloadHealthChecks) SetPendingCount(val Op
 // Only present for effectiveness.metrics.assessed events.
 // Phase A (V1.0): cpu_before/cpu_after populated. Other fields nullable pending
 // Phase B metrics assessor expansion (additional PromQL queries).
+// Cluster-scoped fields (node_*, pv_*) populated for Node/PersistentVolume
+// targets only (Issue #193, DD-EM-005 v1.1); null for namespace-scoped targets.
 type EffectivenessAssessmentAuditPayloadMetricDeltas struct {
 	// CPU utilization before remediation (earliest sample in query range).
 	CPUBefore OptNilFloat64 `json:"cpu_before"`
@@ -17591,6 +17595,36 @@ type EffectivenessAssessmentAuditPayloadMetricDeltas struct {
 	ThroughputBeforeRps OptNilFloat64 `json:"throughput_before_rps"`
 	// Request throughput (requests/second) after remediation.
 	ThroughputAfterRps OptNilFloat64 `json:"throughput_after_rps"`
+	// Node Ready condition status=false flag before remediation (1=not ready, 0=ready).
+	// Cluster-scoped (Issue #193, DD-EM-005).
+	NodeNotReadyBefore OptNilFloat64 `json:"node_not_ready_before"`
+	// Node Ready condition status=false flag after remediation (1=not ready, 0=ready). Cluster-scoped
+	// (Issue.
+	NodeNotReadyAfter OptNilFloat64 `json:"node_not_ready_after"`
+	// Node MemoryPressure condition flag before remediation (1=pressure, 0=none). Cluster-scoped (Issue.
+	NodeMemoryPressureBefore OptNilFloat64 `json:"node_memory_pressure_before"`
+	// Node MemoryPressure condition flag after remediation (1=pressure, 0=none). Cluster-scoped (Issue.
+	NodeMemoryPressureAfter OptNilFloat64 `json:"node_memory_pressure_after"`
+	// Node DiskPressure condition flag before remediation (1=pressure, 0=none). Cluster-scoped (Issue.
+	NodeDiskPressureBefore OptNilFloat64 `json:"node_disk_pressure_before"`
+	// Node DiskPressure condition flag after remediation (1=pressure, 0=none). Cluster-scoped (Issue.
+	NodeDiskPressureAfter OptNilFloat64 `json:"node_disk_pressure_after"`
+	// PersistentVolume Failed phase flag before remediation (1=failed, 0=not failed). Cluster-scoped
+	// (Issue.
+	PvPhaseFailedBefore OptNilFloat64 `json:"pv_phase_failed_before"`
+	// PersistentVolume Failed phase flag after remediation (1=failed, 0=not failed). Cluster-scoped
+	// (Issue.
+	PvPhaseFailedAfter OptNilFloat64 `json:"pv_phase_failed_after"`
+	// PersistentVolume Pending phase flag before remediation (1=pending, 0=not pending). Cluster-scoped
+	// (Issue.
+	PvPhasePendingBefore OptNilFloat64 `json:"pv_phase_pending_before"`
+	// PersistentVolume Pending phase flag after remediation (1=pending, 0=not pending). Cluster-scoped
+	// (Issue.
+	PvPhasePendingAfter OptNilFloat64 `json:"pv_phase_pending_after"`
+	// PersistentVolume used/capacity usage ratio before remediation (0.0-1.0+). Cluster-scoped (Issue.
+	PvUsageRatioBefore OptNilFloat64 `json:"pv_usage_ratio_before"`
+	// PersistentVolume used/capacity usage ratio after remediation (0.0-1.0+). Cluster-scoped (Issue.
+	PvUsageRatioAfter OptNilFloat64 `json:"pv_usage_ratio_after"`
 }
 
 // GetCPUBefore returns the value of CPUBefore.
@@ -17643,6 +17677,66 @@ func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) GetThroughputAfterRps(
 	return s.ThroughputAfterRps
 }
 
+// GetNodeNotReadyBefore returns the value of NodeNotReadyBefore.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) GetNodeNotReadyBefore() OptNilFloat64 {
+	return s.NodeNotReadyBefore
+}
+
+// GetNodeNotReadyAfter returns the value of NodeNotReadyAfter.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) GetNodeNotReadyAfter() OptNilFloat64 {
+	return s.NodeNotReadyAfter
+}
+
+// GetNodeMemoryPressureBefore returns the value of NodeMemoryPressureBefore.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) GetNodeMemoryPressureBefore() OptNilFloat64 {
+	return s.NodeMemoryPressureBefore
+}
+
+// GetNodeMemoryPressureAfter returns the value of NodeMemoryPressureAfter.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) GetNodeMemoryPressureAfter() OptNilFloat64 {
+	return s.NodeMemoryPressureAfter
+}
+
+// GetNodeDiskPressureBefore returns the value of NodeDiskPressureBefore.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) GetNodeDiskPressureBefore() OptNilFloat64 {
+	return s.NodeDiskPressureBefore
+}
+
+// GetNodeDiskPressureAfter returns the value of NodeDiskPressureAfter.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) GetNodeDiskPressureAfter() OptNilFloat64 {
+	return s.NodeDiskPressureAfter
+}
+
+// GetPvPhaseFailedBefore returns the value of PvPhaseFailedBefore.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) GetPvPhaseFailedBefore() OptNilFloat64 {
+	return s.PvPhaseFailedBefore
+}
+
+// GetPvPhaseFailedAfter returns the value of PvPhaseFailedAfter.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) GetPvPhaseFailedAfter() OptNilFloat64 {
+	return s.PvPhaseFailedAfter
+}
+
+// GetPvPhasePendingBefore returns the value of PvPhasePendingBefore.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) GetPvPhasePendingBefore() OptNilFloat64 {
+	return s.PvPhasePendingBefore
+}
+
+// GetPvPhasePendingAfter returns the value of PvPhasePendingAfter.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) GetPvPhasePendingAfter() OptNilFloat64 {
+	return s.PvPhasePendingAfter
+}
+
+// GetPvUsageRatioBefore returns the value of PvUsageRatioBefore.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) GetPvUsageRatioBefore() OptNilFloat64 {
+	return s.PvUsageRatioBefore
+}
+
+// GetPvUsageRatioAfter returns the value of PvUsageRatioAfter.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) GetPvUsageRatioAfter() OptNilFloat64 {
+	return s.PvUsageRatioAfter
+}
+
 // SetCPUBefore sets the value of CPUBefore.
 func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) SetCPUBefore(val OptNilFloat64) {
 	s.CPUBefore = val
@@ -17691,6 +17785,66 @@ func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) SetThroughputBeforeRps
 // SetThroughputAfterRps sets the value of ThroughputAfterRps.
 func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) SetThroughputAfterRps(val OptNilFloat64) {
 	s.ThroughputAfterRps = val
+}
+
+// SetNodeNotReadyBefore sets the value of NodeNotReadyBefore.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) SetNodeNotReadyBefore(val OptNilFloat64) {
+	s.NodeNotReadyBefore = val
+}
+
+// SetNodeNotReadyAfter sets the value of NodeNotReadyAfter.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) SetNodeNotReadyAfter(val OptNilFloat64) {
+	s.NodeNotReadyAfter = val
+}
+
+// SetNodeMemoryPressureBefore sets the value of NodeMemoryPressureBefore.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) SetNodeMemoryPressureBefore(val OptNilFloat64) {
+	s.NodeMemoryPressureBefore = val
+}
+
+// SetNodeMemoryPressureAfter sets the value of NodeMemoryPressureAfter.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) SetNodeMemoryPressureAfter(val OptNilFloat64) {
+	s.NodeMemoryPressureAfter = val
+}
+
+// SetNodeDiskPressureBefore sets the value of NodeDiskPressureBefore.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) SetNodeDiskPressureBefore(val OptNilFloat64) {
+	s.NodeDiskPressureBefore = val
+}
+
+// SetNodeDiskPressureAfter sets the value of NodeDiskPressureAfter.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) SetNodeDiskPressureAfter(val OptNilFloat64) {
+	s.NodeDiskPressureAfter = val
+}
+
+// SetPvPhaseFailedBefore sets the value of PvPhaseFailedBefore.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) SetPvPhaseFailedBefore(val OptNilFloat64) {
+	s.PvPhaseFailedBefore = val
+}
+
+// SetPvPhaseFailedAfter sets the value of PvPhaseFailedAfter.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) SetPvPhaseFailedAfter(val OptNilFloat64) {
+	s.PvPhaseFailedAfter = val
+}
+
+// SetPvPhasePendingBefore sets the value of PvPhasePendingBefore.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) SetPvPhasePendingBefore(val OptNilFloat64) {
+	s.PvPhasePendingBefore = val
+}
+
+// SetPvPhasePendingAfter sets the value of PvPhasePendingAfter.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) SetPvPhasePendingAfter(val OptNilFloat64) {
+	s.PvPhasePendingAfter = val
+}
+
+// SetPvUsageRatioBefore sets the value of PvUsageRatioBefore.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) SetPvUsageRatioBefore(val OptNilFloat64) {
+	s.PvUsageRatioBefore = val
+}
+
+// SetPvUsageRatioAfter sets the value of PvUsageRatioAfter.
+func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) SetPvUsageRatioAfter(val OptNilFloat64) {
+	s.PvUsageRatioAfter = val
 }
 
 // Individual component assessment scores.
@@ -28142,6 +28296,40 @@ type RemediationMetricDeltas struct {
 	ErrorRateBefore OptFloat64 `json:"errorRateBefore"`
 	// Error rate after remediation (0.0-1.0).
 	ErrorRateAfter OptFloat64 `json:"errorRateAfter"`
+	// Request throughput (requests/second) before remediation.
+	ThroughputBeforeRps OptFloat64 `json:"throughputBeforeRps"`
+	// Request throughput (requests/second) after remediation.
+	ThroughputAfterRps OptFloat64 `json:"throughputAfterRps"`
+	// Node Ready condition status=false flag before remediation (1=not ready, 0=ready). Cluster-scoped
+	// (Issue.
+	NodeNotReadyBefore OptFloat64 `json:"nodeNotReadyBefore"`
+	// Node Ready condition status=false flag after remediation (1=not ready, 0=ready). Cluster-scoped
+	// (Issue.
+	NodeNotReadyAfter OptFloat64 `json:"nodeNotReadyAfter"`
+	// Node MemoryPressure condition flag before remediation (1=pressure, 0=none). Cluster-scoped (Issue.
+	NodeMemoryPressureBefore OptFloat64 `json:"nodeMemoryPressureBefore"`
+	// Node MemoryPressure condition flag after remediation (1=pressure, 0=none). Cluster-scoped (Issue.
+	NodeMemoryPressureAfter OptFloat64 `json:"nodeMemoryPressureAfter"`
+	// Node DiskPressure condition flag before remediation (1=pressure, 0=none). Cluster-scoped (Issue.
+	NodeDiskPressureBefore OptFloat64 `json:"nodeDiskPressureBefore"`
+	// Node DiskPressure condition flag after remediation (1=pressure, 0=none). Cluster-scoped (Issue.
+	NodeDiskPressureAfter OptFloat64 `json:"nodeDiskPressureAfter"`
+	// PersistentVolume Failed phase flag before remediation (1=failed, 0=not failed). Cluster-scoped
+	// (Issue.
+	PvPhaseFailedBefore OptFloat64 `json:"pvPhaseFailedBefore"`
+	// PersistentVolume Failed phase flag after remediation (1=failed, 0=not failed). Cluster-scoped
+	// (Issue.
+	PvPhaseFailedAfter OptFloat64 `json:"pvPhaseFailedAfter"`
+	// PersistentVolume Pending phase flag before remediation (1=pending, 0=not pending). Cluster-scoped
+	// (Issue.
+	PvPhasePendingBefore OptFloat64 `json:"pvPhasePendingBefore"`
+	// PersistentVolume Pending phase flag after remediation (1=pending, 0=not pending). Cluster-scoped
+	// (Issue.
+	PvPhasePendingAfter OptFloat64 `json:"pvPhasePendingAfter"`
+	// PersistentVolume used/capacity usage ratio before remediation (0.0-1.0+). Cluster-scoped (Issue.
+	PvUsageRatioBefore OptFloat64 `json:"pvUsageRatioBefore"`
+	// PersistentVolume used/capacity usage ratio after remediation (0.0-1.0+). Cluster-scoped (Issue.
+	PvUsageRatioAfter OptFloat64 `json:"pvUsageRatioAfter"`
 }
 
 // GetCpuBefore returns the value of CpuBefore.
@@ -28184,6 +28372,76 @@ func (s *RemediationMetricDeltas) GetErrorRateAfter() OptFloat64 {
 	return s.ErrorRateAfter
 }
 
+// GetThroughputBeforeRps returns the value of ThroughputBeforeRps.
+func (s *RemediationMetricDeltas) GetThroughputBeforeRps() OptFloat64 {
+	return s.ThroughputBeforeRps
+}
+
+// GetThroughputAfterRps returns the value of ThroughputAfterRps.
+func (s *RemediationMetricDeltas) GetThroughputAfterRps() OptFloat64 {
+	return s.ThroughputAfterRps
+}
+
+// GetNodeNotReadyBefore returns the value of NodeNotReadyBefore.
+func (s *RemediationMetricDeltas) GetNodeNotReadyBefore() OptFloat64 {
+	return s.NodeNotReadyBefore
+}
+
+// GetNodeNotReadyAfter returns the value of NodeNotReadyAfter.
+func (s *RemediationMetricDeltas) GetNodeNotReadyAfter() OptFloat64 {
+	return s.NodeNotReadyAfter
+}
+
+// GetNodeMemoryPressureBefore returns the value of NodeMemoryPressureBefore.
+func (s *RemediationMetricDeltas) GetNodeMemoryPressureBefore() OptFloat64 {
+	return s.NodeMemoryPressureBefore
+}
+
+// GetNodeMemoryPressureAfter returns the value of NodeMemoryPressureAfter.
+func (s *RemediationMetricDeltas) GetNodeMemoryPressureAfter() OptFloat64 {
+	return s.NodeMemoryPressureAfter
+}
+
+// GetNodeDiskPressureBefore returns the value of NodeDiskPressureBefore.
+func (s *RemediationMetricDeltas) GetNodeDiskPressureBefore() OptFloat64 {
+	return s.NodeDiskPressureBefore
+}
+
+// GetNodeDiskPressureAfter returns the value of NodeDiskPressureAfter.
+func (s *RemediationMetricDeltas) GetNodeDiskPressureAfter() OptFloat64 {
+	return s.NodeDiskPressureAfter
+}
+
+// GetPvPhaseFailedBefore returns the value of PvPhaseFailedBefore.
+func (s *RemediationMetricDeltas) GetPvPhaseFailedBefore() OptFloat64 {
+	return s.PvPhaseFailedBefore
+}
+
+// GetPvPhaseFailedAfter returns the value of PvPhaseFailedAfter.
+func (s *RemediationMetricDeltas) GetPvPhaseFailedAfter() OptFloat64 {
+	return s.PvPhaseFailedAfter
+}
+
+// GetPvPhasePendingBefore returns the value of PvPhasePendingBefore.
+func (s *RemediationMetricDeltas) GetPvPhasePendingBefore() OptFloat64 {
+	return s.PvPhasePendingBefore
+}
+
+// GetPvPhasePendingAfter returns the value of PvPhasePendingAfter.
+func (s *RemediationMetricDeltas) GetPvPhasePendingAfter() OptFloat64 {
+	return s.PvPhasePendingAfter
+}
+
+// GetPvUsageRatioBefore returns the value of PvUsageRatioBefore.
+func (s *RemediationMetricDeltas) GetPvUsageRatioBefore() OptFloat64 {
+	return s.PvUsageRatioBefore
+}
+
+// GetPvUsageRatioAfter returns the value of PvUsageRatioAfter.
+func (s *RemediationMetricDeltas) GetPvUsageRatioAfter() OptFloat64 {
+	return s.PvUsageRatioAfter
+}
+
 // SetCpuBefore sets the value of CpuBefore.
 func (s *RemediationMetricDeltas) SetCpuBefore(val OptFloat64) {
 	s.CpuBefore = val
@@ -28222,6 +28480,76 @@ func (s *RemediationMetricDeltas) SetErrorRateBefore(val OptFloat64) {
 // SetErrorRateAfter sets the value of ErrorRateAfter.
 func (s *RemediationMetricDeltas) SetErrorRateAfter(val OptFloat64) {
 	s.ErrorRateAfter = val
+}
+
+// SetThroughputBeforeRps sets the value of ThroughputBeforeRps.
+func (s *RemediationMetricDeltas) SetThroughputBeforeRps(val OptFloat64) {
+	s.ThroughputBeforeRps = val
+}
+
+// SetThroughputAfterRps sets the value of ThroughputAfterRps.
+func (s *RemediationMetricDeltas) SetThroughputAfterRps(val OptFloat64) {
+	s.ThroughputAfterRps = val
+}
+
+// SetNodeNotReadyBefore sets the value of NodeNotReadyBefore.
+func (s *RemediationMetricDeltas) SetNodeNotReadyBefore(val OptFloat64) {
+	s.NodeNotReadyBefore = val
+}
+
+// SetNodeNotReadyAfter sets the value of NodeNotReadyAfter.
+func (s *RemediationMetricDeltas) SetNodeNotReadyAfter(val OptFloat64) {
+	s.NodeNotReadyAfter = val
+}
+
+// SetNodeMemoryPressureBefore sets the value of NodeMemoryPressureBefore.
+func (s *RemediationMetricDeltas) SetNodeMemoryPressureBefore(val OptFloat64) {
+	s.NodeMemoryPressureBefore = val
+}
+
+// SetNodeMemoryPressureAfter sets the value of NodeMemoryPressureAfter.
+func (s *RemediationMetricDeltas) SetNodeMemoryPressureAfter(val OptFloat64) {
+	s.NodeMemoryPressureAfter = val
+}
+
+// SetNodeDiskPressureBefore sets the value of NodeDiskPressureBefore.
+func (s *RemediationMetricDeltas) SetNodeDiskPressureBefore(val OptFloat64) {
+	s.NodeDiskPressureBefore = val
+}
+
+// SetNodeDiskPressureAfter sets the value of NodeDiskPressureAfter.
+func (s *RemediationMetricDeltas) SetNodeDiskPressureAfter(val OptFloat64) {
+	s.NodeDiskPressureAfter = val
+}
+
+// SetPvPhaseFailedBefore sets the value of PvPhaseFailedBefore.
+func (s *RemediationMetricDeltas) SetPvPhaseFailedBefore(val OptFloat64) {
+	s.PvPhaseFailedBefore = val
+}
+
+// SetPvPhaseFailedAfter sets the value of PvPhaseFailedAfter.
+func (s *RemediationMetricDeltas) SetPvPhaseFailedAfter(val OptFloat64) {
+	s.PvPhaseFailedAfter = val
+}
+
+// SetPvPhasePendingBefore sets the value of PvPhasePendingBefore.
+func (s *RemediationMetricDeltas) SetPvPhasePendingBefore(val OptFloat64) {
+	s.PvPhasePendingBefore = val
+}
+
+// SetPvPhasePendingAfter sets the value of PvPhasePendingAfter.
+func (s *RemediationMetricDeltas) SetPvPhasePendingAfter(val OptFloat64) {
+	s.PvPhasePendingAfter = val
+}
+
+// SetPvUsageRatioBefore sets the value of PvUsageRatioBefore.
+func (s *RemediationMetricDeltas) SetPvUsageRatioBefore(val OptFloat64) {
+	s.PvUsageRatioBefore = val
+}
+
+// SetPvUsageRatioAfter sets the value of PvUsageRatioAfter.
+func (s *RemediationMetricDeltas) SetPvUsageRatioAfter(val OptFloat64) {
+	s.PvUsageRatioAfter = val
 }
 
 // Type-safe audit event payload for RemediationOrchestrator (lifecycle.started, lifecycle.created,

--- a/pkg/datastorage/ogen-client/oas_validators_gen.go
+++ b/pkg/datastorage/ogen-client/oas_validators_gen.go
@@ -5254,6 +5254,222 @@ func (s *EffectivenessAssessmentAuditPayloadMetricDeltas) Validate() error {
 			Error: err,
 		})
 	}
+	if err := func() error {
+		if value, ok := s.NodeNotReadyBefore.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "node_not_ready_before",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.NodeNotReadyAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "node_not_ready_after",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.NodeMemoryPressureBefore.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "node_memory_pressure_before",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.NodeMemoryPressureAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "node_memory_pressure_after",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.NodeDiskPressureBefore.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "node_disk_pressure_before",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.NodeDiskPressureAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "node_disk_pressure_after",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.PvPhaseFailedBefore.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "pv_phase_failed_before",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.PvPhaseFailedAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "pv_phase_failed_after",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.PvPhasePendingBefore.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "pv_phase_pending_before",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.PvPhasePendingAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "pv_phase_pending_after",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.PvUsageRatioBefore.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "pv_usage_ratio_before",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.PvUsageRatioAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "pv_usage_ratio_after",
+			Error: err,
+		})
+	}
 	if len(failures) > 0 {
 		return &validate.Error{Fields: failures}
 	}
@@ -7877,6 +8093,258 @@ func (s *RemediationMetricDeltas) Validate() error {
 	}(); err != nil {
 		failures = append(failures, validate.FieldError{
 			Name:  "errorRateAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.ThroughputBeforeRps.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "throughputBeforeRps",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.ThroughputAfterRps.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "throughputAfterRps",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.NodeNotReadyBefore.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "nodeNotReadyBefore",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.NodeNotReadyAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "nodeNotReadyAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.NodeMemoryPressureBefore.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "nodeMemoryPressureBefore",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.NodeMemoryPressureAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "nodeMemoryPressureAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.NodeDiskPressureBefore.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "nodeDiskPressureBefore",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.NodeDiskPressureAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "nodeDiskPressureAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.PvPhaseFailedBefore.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "pvPhaseFailedBefore",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.PvPhaseFailedAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "pvPhaseFailedAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.PvPhasePendingBefore.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "pvPhasePendingBefore",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.PvPhasePendingAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "pvPhasePendingAfter",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.PvUsageRatioBefore.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "pvUsageRatioBefore",
+			Error: err,
+		})
+	}
+	if err := func() error {
+		if value, ok := s.PvUsageRatioAfter.Get(); ok {
+			if err := func() error {
+				if err := (validate.Float{}).Validate(float64(value)); err != nil {
+					return errors.Wrap(err, "float")
+				}
+				return nil
+			}(); err != nil {
+				return err
+			}
+		}
+		return nil
+	}(); err != nil {
+		failures = append(failures, validate.FieldError{
+			Name:  "pvUsageRatioAfter",
 			Error: err,
 		})
 	}

--- a/pkg/datastorage/remediation_history_logic_test.go
+++ b/pkg/datastorage/remediation_history_logic_test.go
@@ -203,6 +203,96 @@ var _ = Describe("Remediation History Correlation Logic (DD-HAPI-016 v1.1)", fun
 			Expect(entry.MetricDeltas.Value.CpuAfter.Value).To(BeNumerically("~", 0.45, 0.001))
 		})
 
+		// ========================================
+		// Cluster-scoped metric_deltas fields + throughput backfill
+		// (Issue #193 audit gap, DD-EM-005 v1.1)
+		// ========================================
+		It("UT-RH-LOGIC-025: should map cluster-scoped Node/PV metric_deltas fields and backfill throughput", func() {
+			roEvents := []repository.RawAuditRow{
+				makeROEvent("rr-cluster-001", "sha256:pre123", "success", "alert", "fp-node-001", "restart", fixedTime),
+			}
+			emEvents := map[string][]*server.EffectivenessEvent{
+				"rr-cluster-001": {
+					{
+						EventData: map[string]interface{}{
+							"event_type": "effectiveness.metrics.assessed",
+							"assessed":   true,
+							"score":      0.9,
+							"details":    "Node conditions and PV usage improved",
+							"metric_deltas": map[string]interface{}{
+								"throughput_before_rps":       120.0,
+								"throughput_after_rps":        150.0,
+								"node_not_ready_before":       1.0,
+								"node_not_ready_after":        0.0,
+								"node_memory_pressure_before": 1.0,
+								"node_memory_pressure_after":  0.0,
+								"node_disk_pressure_before":   0.0,
+								"node_disk_pressure_after":    0.0,
+								"pv_phase_failed_before":      1.0,
+								"pv_phase_failed_after":       0.0,
+								"pv_phase_pending_before":     0.0,
+								"pv_phase_pending_after":      0.0,
+								"pv_usage_ratio_before":       0.95,
+								"pv_usage_ratio_after":        0.60,
+							},
+						},
+					},
+				},
+			}
+
+			entries := server.CorrelateTier1Chain(roEvents, emEvents, "sha256:current")
+
+			Expect(entries).To(HaveLen(1))
+			md := entries[0].MetricDeltas
+			Expect(md.Set).To(BeTrue())
+
+			Expect(md.Value.ThroughputBeforeRps.Set).To(BeTrue(), "throughput_before_rps backfill")
+			Expect(md.Value.ThroughputBeforeRps.Value).To(BeNumerically("~", 120.0, 0.001))
+			Expect(md.Value.ThroughputAfterRps.Set).To(BeTrue())
+			Expect(md.Value.ThroughputAfterRps.Value).To(BeNumerically("~", 150.0, 0.001))
+
+			Expect(md.Value.NodeNotReadyBefore.Set).To(BeTrue())
+			Expect(md.Value.NodeNotReadyBefore.Value).To(BeNumerically("~", 1.0, 0.001))
+			Expect(md.Value.NodeNotReadyAfter.Set).To(BeTrue())
+			Expect(md.Value.NodeMemoryPressureBefore.Set).To(BeTrue())
+			Expect(md.Value.NodeMemoryPressureAfter.Set).To(BeTrue())
+			Expect(md.Value.NodeDiskPressureBefore.Set).To(BeTrue())
+			Expect(md.Value.NodeDiskPressureAfter.Set).To(BeTrue())
+
+			Expect(md.Value.PvPhaseFailedBefore.Set).To(BeTrue())
+			Expect(md.Value.PvPhaseFailedBefore.Value).To(BeNumerically("~", 1.0, 0.001))
+			Expect(md.Value.PvPhaseFailedAfter.Set).To(BeTrue())
+			Expect(md.Value.PvPhasePendingBefore.Set).To(BeTrue())
+			Expect(md.Value.PvPhasePendingAfter.Set).To(BeTrue())
+			Expect(md.Value.PvUsageRatioBefore.Set).To(BeTrue())
+			Expect(md.Value.PvUsageRatioBefore.Value).To(BeNumerically("~", 0.95, 0.001))
+			Expect(md.Value.PvUsageRatioAfter.Set).To(BeTrue())
+			Expect(md.Value.PvUsageRatioAfter.Value).To(BeNumerically("~", 0.60, 0.001))
+		})
+
+		It("UT-RH-LOGIC-026: should leave cluster-scoped and throughput fields unset when absent (namespace-scoped, Phase A/B only)", func() {
+			roEvents := []repository.RawAuditRow{
+				makeROEvent("rr-cluster-002", "sha256:pre456", "success", "alert", "fp-ns-001", "restart", fixedTime),
+			}
+			emEvents := map[string][]*server.EffectivenessEvent{
+				"rr-cluster-002": makeFullEMEvents(), // only cpu_before/cpu_after present
+			}
+
+			entries := server.CorrelateTier1Chain(roEvents, emEvents, "sha256:current")
+
+			Expect(entries).To(HaveLen(1))
+			md := entries[0].MetricDeltas.Value
+
+			Expect(md.ThroughputBeforeRps.Set).To(BeFalse())
+			Expect(md.ThroughputAfterRps.Set).To(BeFalse())
+			Expect(md.NodeNotReadyBefore.Set).To(BeFalse())
+			Expect(md.NodeMemoryPressureBefore.Set).To(BeFalse())
+			Expect(md.NodeDiskPressureBefore.Set).To(BeFalse())
+			Expect(md.PvPhaseFailedBefore.Set).To(BeFalse())
+			Expect(md.PvPhasePendingBefore.Set).To(BeFalse())
+			Expect(md.PvUsageRatioBefore.Set).To(BeFalse())
+		})
+
 		It("UT-RH-LOGIC-006: should build entry with nil effectiveness when no EM data", func() {
 			roEvents := []repository.RawAuditRow{
 				makeROEvent("rr-002", "sha256:pre789", "success", "alert", "fp-002", "restart", fixedTime),

--- a/pkg/datastorage/server/middleware/openapi_spec_data.yaml
+++ b/pkg/datastorage/server/middleware/openapi_spec_data.yaml
@@ -5060,6 +5060,8 @@ components:
             Only present for effectiveness.metrics.assessed events.
             Phase A (V1.0): cpu_before/cpu_after populated. Other fields nullable pending
             Phase B metrics assessor expansion (additional PromQL queries).
+            Cluster-scoped fields (node_*, pv_*) populated for Node/PersistentVolume
+            targets only (Issue #193, DD-EM-005 v1.1); null for namespace-scoped targets.
           properties:
             cpu_before:
               type: number
@@ -5113,6 +5115,68 @@ components:
               format: double
               nullable: true
               description: Request throughput (requests/second) after remediation
+            node_not_ready_before:
+              type: number
+              format: double
+              nullable: true
+              description: |
+                Node Ready condition status=false flag before remediation (1=not ready, 0=ready).
+                Cluster-scoped (Issue #193, DD-EM-005).
+            node_not_ready_after:
+              type: number
+              format: double
+              nullable: true
+              description: Node Ready condition status=false flag after remediation (1=not ready, 0=ready). Cluster-scoped (Issue #193, DD-EM-005).
+            node_memory_pressure_before:
+              type: number
+              format: double
+              nullable: true
+              description: Node MemoryPressure condition flag before remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+            node_memory_pressure_after:
+              type: number
+              format: double
+              nullable: true
+              description: Node MemoryPressure condition flag after remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+            node_disk_pressure_before:
+              type: number
+              format: double
+              nullable: true
+              description: Node DiskPressure condition flag before remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+            node_disk_pressure_after:
+              type: number
+              format: double
+              nullable: true
+              description: Node DiskPressure condition flag after remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+            pv_phase_failed_before:
+              type: number
+              format: double
+              nullable: true
+              description: PersistentVolume Failed phase flag before remediation (1=failed, 0=not failed). Cluster-scoped (Issue #193, DD-EM-005).
+            pv_phase_failed_after:
+              type: number
+              format: double
+              nullable: true
+              description: PersistentVolume Failed phase flag after remediation (1=failed, 0=not failed). Cluster-scoped (Issue #193, DD-EM-005).
+            pv_phase_pending_before:
+              type: number
+              format: double
+              nullable: true
+              description: PersistentVolume Pending phase flag before remediation (1=pending, 0=not pending). Cluster-scoped (Issue #193, DD-EM-005).
+            pv_phase_pending_after:
+              type: number
+              format: double
+              nullable: true
+              description: PersistentVolume Pending phase flag after remediation (1=pending, 0=not pending). Cluster-scoped (Issue #193, DD-EM-005).
+            pv_usage_ratio_before:
+              type: number
+              format: double
+              nullable: true
+              description: PersistentVolume used/capacity usage ratio before remediation (0.0-1.0+). Cluster-scoped (Issue #193, DD-EM-005).
+            pv_usage_ratio_after:
+              type: number
+              format: double
+              nullable: true
+              description: PersistentVolume used/capacity usage ratio after remediation (0.0-1.0+). Cluster-scoped (Issue #193, DD-EM-005).
 
         alert_resolution:
           type: object
@@ -6856,6 +6920,64 @@ components:
           format: double
           description: Error rate after remediation (0.0-1.0)
           example: 0.019
+        throughputBeforeRps:
+          type: number
+          format: double
+          description: Request throughput (requests/second) before remediation
+          example: 150.0
+        throughputAfterRps:
+          type: number
+          format: double
+          description: Request throughput (requests/second) after remediation
+          example: 148.0
+        nodeNotReadyBefore:
+          type: number
+          format: double
+          description: Node Ready condition status=false flag before remediation (1=not ready, 0=ready). Cluster-scoped (Issue #193, DD-EM-005).
+        nodeNotReadyAfter:
+          type: number
+          format: double
+          description: Node Ready condition status=false flag after remediation (1=not ready, 0=ready). Cluster-scoped (Issue #193, DD-EM-005).
+        nodeMemoryPressureBefore:
+          type: number
+          format: double
+          description: Node MemoryPressure condition flag before remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+        nodeMemoryPressureAfter:
+          type: number
+          format: double
+          description: Node MemoryPressure condition flag after remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+        nodeDiskPressureBefore:
+          type: number
+          format: double
+          description: Node DiskPressure condition flag before remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+        nodeDiskPressureAfter:
+          type: number
+          format: double
+          description: Node DiskPressure condition flag after remediation (1=pressure, 0=none). Cluster-scoped (Issue #193, DD-EM-005).
+        pvPhaseFailedBefore:
+          type: number
+          format: double
+          description: PersistentVolume Failed phase flag before remediation (1=failed, 0=not failed). Cluster-scoped (Issue #193, DD-EM-005).
+        pvPhaseFailedAfter:
+          type: number
+          format: double
+          description: PersistentVolume Failed phase flag after remediation (1=failed, 0=not failed). Cluster-scoped (Issue #193, DD-EM-005).
+        pvPhasePendingBefore:
+          type: number
+          format: double
+          description: PersistentVolume Pending phase flag before remediation (1=pending, 0=not pending). Cluster-scoped (Issue #193, DD-EM-005).
+        pvPhasePendingAfter:
+          type: number
+          format: double
+          description: PersistentVolume Pending phase flag after remediation (1=pending, 0=not pending). Cluster-scoped (Issue #193, DD-EM-005).
+        pvUsageRatioBefore:
+          type: number
+          format: double
+          description: PersistentVolume used/capacity usage ratio before remediation (0.0-1.0+). Cluster-scoped (Issue #193, DD-EM-005).
+        pvUsageRatioAfter:
+          type: number
+          format: double
+          description: PersistentVolume used/capacity usage ratio after remediation (0.0-1.0+). Cluster-scoped (Issue #193, DD-EM-005).
 
     # ========================================
     # ActionType Taxonomy (BR-WORKFLOW-007)

--- a/pkg/datastorage/server/remediation_history_logic.go
+++ b/pkg/datastorage/server/remediation_history_logic.go
@@ -123,9 +123,10 @@ func mapHealthChecks(eventData map[string]interface{}) api.OptRemediationHealthC
 // effectiveness.metrics.assessed event's data.
 //
 // DD-HAPI-016 v1.1: metric_deltas provides before/after pairs for CPU, memory,
-// latency p95, and error rate. Currently only CPU is populated by the EM team;
-// remaining metrics fields are optional and absent until additional PromQL
-// queries are implemented.
+// latency p95, error rate, and throughput. DD-EM-005 v1.1 (Issue #193) adds
+// cluster-scoped Node/PersistentVolume fields, populated only when the source
+// EffectivenessAssessment targets a Node or PersistentVolume; all fields are
+// optional and absent until the corresponding PromQL query succeeds.
 func mapMetricDeltas(eventData map[string]interface{}) api.OptRemediationMetricDeltas {
 	mdMap, ok := eventData["metric_deltas"].(map[string]interface{})
 	if !ok {
@@ -157,7 +158,60 @@ func mapMetricDeltas(eventData map[string]interface{}) api.OptRemediationMetricD
 	if v, ok := mdMap["error_rate_after"].(float64); ok {
 		md.ErrorRateAfter = api.OptFloat64{Value: v, Set: true}
 	}
+	populateClusterScopedAndThroughputDeltas(&md, mdMap)
 	return api.OptRemediationMetricDeltas{Value: md, Set: true}
+}
+
+// populateClusterScopedAndThroughputDeltas maps the throughput backfill
+// (present in the raw event since 21e592475, never propagated downstream)
+// and the 6 cluster-scoped Node/PersistentVolume metric_deltas fields
+// (Issue #193 audit gap, DD-EM-005 v1.1) from the raw event map into md.
+// Extracted from mapMetricDeltas to keep that function within the project's
+// line-length convention -- pure code motion alongside the new field
+// mappings, no behavior change to the existing fields mapped above.
+func populateClusterScopedAndThroughputDeltas(md *api.RemediationMetricDeltas, mdMap map[string]interface{}) {
+	if v, ok := mdMap["throughput_before_rps"].(float64); ok {
+		md.ThroughputBeforeRps = api.OptFloat64{Value: v, Set: true}
+	}
+	if v, ok := mdMap["throughput_after_rps"].(float64); ok {
+		md.ThroughputAfterRps = api.OptFloat64{Value: v, Set: true}
+	}
+	if v, ok := mdMap["node_not_ready_before"].(float64); ok {
+		md.NodeNotReadyBefore = api.OptFloat64{Value: v, Set: true}
+	}
+	if v, ok := mdMap["node_not_ready_after"].(float64); ok {
+		md.NodeNotReadyAfter = api.OptFloat64{Value: v, Set: true}
+	}
+	if v, ok := mdMap["node_memory_pressure_before"].(float64); ok {
+		md.NodeMemoryPressureBefore = api.OptFloat64{Value: v, Set: true}
+	}
+	if v, ok := mdMap["node_memory_pressure_after"].(float64); ok {
+		md.NodeMemoryPressureAfter = api.OptFloat64{Value: v, Set: true}
+	}
+	if v, ok := mdMap["node_disk_pressure_before"].(float64); ok {
+		md.NodeDiskPressureBefore = api.OptFloat64{Value: v, Set: true}
+	}
+	if v, ok := mdMap["node_disk_pressure_after"].(float64); ok {
+		md.NodeDiskPressureAfter = api.OptFloat64{Value: v, Set: true}
+	}
+	if v, ok := mdMap["pv_phase_failed_before"].(float64); ok {
+		md.PvPhaseFailedBefore = api.OptFloat64{Value: v, Set: true}
+	}
+	if v, ok := mdMap["pv_phase_failed_after"].(float64); ok {
+		md.PvPhaseFailedAfter = api.OptFloat64{Value: v, Set: true}
+	}
+	if v, ok := mdMap["pv_phase_pending_before"].(float64); ok {
+		md.PvPhasePendingBefore = api.OptFloat64{Value: v, Set: true}
+	}
+	if v, ok := mdMap["pv_phase_pending_after"].(float64); ok {
+		md.PvPhasePendingAfter = api.OptFloat64{Value: v, Set: true}
+	}
+	if v, ok := mdMap["pv_usage_ratio_before"].(float64); ok {
+		md.PvUsageRatioBefore = api.OptFloat64{Value: v, Set: true}
+	}
+	if v, ok := mdMap["pv_usage_ratio_after"].(float64); ok {
+		md.PvUsageRatioAfter = api.OptFloat64{Value: v, Set: true}
+	}
 }
 
 // mapAlertResolution extracts signalResolved from the alert_resolution typed

--- a/pkg/effectivenessmonitor/audit/manager.go
+++ b/pkg/effectivenessmonitor/audit/manager.go
@@ -248,6 +248,21 @@ type MetricsAssessedData struct {
 	ThroughputBeforeRPS *float64
 	// ThroughputAfterRPS is the request throughput (req/s) after remediation (nil if unavailable).
 	ThroughputAfterRPS *float64
+
+	// Cluster-scoped fields (Issue #193, DD-EM-005 v1.1): populated only for
+	// Node/PersistentVolume SignalTarget.Kind, nil for namespace-scoped assessments.
+	NodeNotReadyBefore       *float64
+	NodeNotReadyAfter        *float64
+	NodeMemoryPressureBefore *float64
+	NodeMemoryPressureAfter  *float64
+	NodeDiskPressureBefore   *float64
+	NodeDiskPressureAfter    *float64
+	PVPhaseFailedBefore      *float64
+	PVPhaseFailedAfter       *float64
+	PVPhasePendingBefore     *float64
+	PVPhasePendingAfter      *float64
+	PVUsageRatioBefore       *float64
+	PVUsageRatioAfter        *float64
 }
 
 // RecordHealthAssessed records the effectiveness.health.assessed audit event with
@@ -418,9 +433,55 @@ func (m *Manager) RecordMetricsAssessed(ctx context.Context, ea *eav1.Effectiven
 	if metricsData.ThroughputAfterRPS != nil {
 		md.ThroughputAfterRps = ogenclient.NewOptNilFloat64(*metricsData.ThroughputAfterRPS)
 	}
+	populateClusterScopedMetricDeltas(&md, metricsData)
 	payload.MetricDeltas = ogenclient.NewOptEffectivenessAssessmentAuditPayloadMetricDeltas(md)
 
 	return m.storeEvent(ctx, cfg, ea, payload, result)
+}
+
+// populateClusterScopedMetricDeltas Opt-wraps the cluster-scoped (Node,
+// PersistentVolume) metric_deltas fields from metricsData into md. Extracted
+// from RecordMetricsAssessed (Issue #193, DD-EM-005 v1.1) to keep the
+// function within the project's line-length convention -- pure code motion
+// alongside the new field mappings, no behavior change to the existing
+// namespace-scoped fields above.
+func populateClusterScopedMetricDeltas(md *ogenclient.EffectivenessAssessmentAuditPayloadMetricDeltas, metricsData MetricsAssessedData) {
+	if metricsData.NodeNotReadyBefore != nil {
+		md.NodeNotReadyBefore = ogenclient.NewOptNilFloat64(*metricsData.NodeNotReadyBefore)
+	}
+	if metricsData.NodeNotReadyAfter != nil {
+		md.NodeNotReadyAfter = ogenclient.NewOptNilFloat64(*metricsData.NodeNotReadyAfter)
+	}
+	if metricsData.NodeMemoryPressureBefore != nil {
+		md.NodeMemoryPressureBefore = ogenclient.NewOptNilFloat64(*metricsData.NodeMemoryPressureBefore)
+	}
+	if metricsData.NodeMemoryPressureAfter != nil {
+		md.NodeMemoryPressureAfter = ogenclient.NewOptNilFloat64(*metricsData.NodeMemoryPressureAfter)
+	}
+	if metricsData.NodeDiskPressureBefore != nil {
+		md.NodeDiskPressureBefore = ogenclient.NewOptNilFloat64(*metricsData.NodeDiskPressureBefore)
+	}
+	if metricsData.NodeDiskPressureAfter != nil {
+		md.NodeDiskPressureAfter = ogenclient.NewOptNilFloat64(*metricsData.NodeDiskPressureAfter)
+	}
+	if metricsData.PVPhaseFailedBefore != nil {
+		md.PvPhaseFailedBefore = ogenclient.NewOptNilFloat64(*metricsData.PVPhaseFailedBefore)
+	}
+	if metricsData.PVPhaseFailedAfter != nil {
+		md.PvPhaseFailedAfter = ogenclient.NewOptNilFloat64(*metricsData.PVPhaseFailedAfter)
+	}
+	if metricsData.PVPhasePendingBefore != nil {
+		md.PvPhasePendingBefore = ogenclient.NewOptNilFloat64(*metricsData.PVPhasePendingBefore)
+	}
+	if metricsData.PVPhasePendingAfter != nil {
+		md.PvPhasePendingAfter = ogenclient.NewOptNilFloat64(*metricsData.PVPhasePendingAfter)
+	}
+	if metricsData.PVUsageRatioBefore != nil {
+		md.PvUsageRatioBefore = ogenclient.NewOptNilFloat64(*metricsData.PVUsageRatioBefore)
+	}
+	if metricsData.PVUsageRatioAfter != nil {
+		md.PvUsageRatioAfter = ogenclient.NewOptNilFloat64(*metricsData.PVUsageRatioAfter)
+	}
 }
 
 // buildBasePayload constructs the common payload fields shared by all component events.

--- a/pkg/effectivenessmonitor/audit_manager_test.go
+++ b/pkg/effectivenessmonitor/audit_manager_test.go
@@ -397,16 +397,20 @@ var _ = Describe("Audit Manager — Typed Sub-Objects (DD-017 v2.5)", func() {
 			latAfter := 80.0
 			errBefore := 0.05
 			errAfter := 0.01
+			throughputBefore := 120.0
+			throughputAfter := 180.0
 
 			metricsData := audit.MetricsAssessedData{
-				CPUBefore:          &cpuBefore,
-				CPUAfter:           &cpuAfter,
-				MemoryBefore:       &memBefore,
-				MemoryAfter:        &memAfter,
-				LatencyP95BeforeMs: &latBefore,
-				LatencyP95AfterMs:  &latAfter,
-				ErrorRateBefore:    &errBefore,
-				ErrorRateAfter:     &errAfter,
+				CPUBefore:           &cpuBefore,
+				CPUAfter:            &cpuAfter,
+				MemoryBefore:        &memBefore,
+				MemoryAfter:         &memAfter,
+				LatencyP95BeforeMs:  &latBefore,
+				LatencyP95AfterMs:   &latAfter,
+				ErrorRateBefore:     &errBefore,
+				ErrorRateAfter:      &errAfter,
+				ThroughputBeforeRPS: &throughputBefore,
+				ThroughputAfterRPS:  &throughputAfter,
 			}
 
 			err := mgr.RecordMetricsAssessed(ctx, ea, result, metricsData)
@@ -437,6 +441,11 @@ var _ = Describe("Audit Manager — Typed Sub-Objects (DD-017 v2.5)", func() {
 			Expect(md.ErrorRateBefore.Value).To(BeNumerically("~", 0.05, 0.001))
 			Expect(md.ErrorRateAfter.Set).To(BeTrue())
 			Expect(md.ErrorRateAfter.Value).To(BeNumerically("~", 0.01, 0.001))
+
+			Expect(md.ThroughputBeforeRps.Set).To(BeTrue())
+			Expect(md.ThroughputBeforeRps.Value).To(BeNumerically("~", 120.0, 0.001))
+			Expect(md.ThroughputAfterRps.Set).To(BeTrue())
+			Expect(md.ThroughputAfterRps.Value).To(BeNumerically("~", 180.0, 0.001))
 		})
 
 		It("UT-EM-AM-011: should leave Phase B fields unset when only CPU available (partial query)", func() {
@@ -472,6 +481,167 @@ var _ = Describe("Audit Manager — Typed Sub-Objects (DD-017 v2.5)", func() {
 			Expect(md.LatencyP95AfterMs.Set).To(BeFalse())
 			Expect(md.ErrorRateBefore.Set).To(BeFalse())
 			Expect(md.ErrorRateAfter.Set).To(BeFalse())
+			Expect(md.ThroughputBeforeRps.Set).To(BeFalse())
+			Expect(md.ThroughputAfterRps.Set).To(BeFalse())
+		})
+
+		// ========================================
+		// Cluster-scoped metric_deltas fields (Issue #193, DD-EM-005 v1.1)
+		// ========================================
+
+		It("UT-EM-AM-013: should set Node condition metric_deltas fields when provided", func() {
+			score := 0.75
+			result := types.ComponentResult{
+				Component: types.ComponentMetrics,
+				Assessed:  true,
+				Score:     &score,
+				Details:   "Node conditions improved",
+			}
+
+			notReadyBefore, notReadyAfter := 1.0, 0.0
+			memPressureBefore, memPressureAfter := 1.0, 0.0
+			diskPressureBefore, diskPressureAfter := 0.0, 0.0
+
+			metricsData := audit.MetricsAssessedData{
+				NodeNotReadyBefore:       &notReadyBefore,
+				NodeNotReadyAfter:        &notReadyAfter,
+				NodeMemoryPressureBefore: &memPressureBefore,
+				NodeMemoryPressureAfter:  &memPressureAfter,
+				NodeDiskPressureBefore:   &diskPressureBefore,
+				NodeDiskPressureAfter:    &diskPressureAfter,
+			}
+
+			err := mgr.RecordMetricsAssessed(ctx, ea, result, metricsData)
+			Expect(err).ToNot(HaveOccurred())
+
+			payload := extractPayload(spy.lastEvent)
+			Expect(payload.MetricDeltas.Set).To(BeTrue())
+			md := payload.MetricDeltas.Value
+
+			Expect(md.NodeNotReadyBefore.Set).To(BeTrue())
+			Expect(md.NodeNotReadyBefore.Value).To(BeNumerically("~", 1.0, 0.001))
+			Expect(md.NodeNotReadyAfter.Set).To(BeTrue())
+			Expect(md.NodeNotReadyAfter.Value).To(BeNumerically("~", 0.0, 0.001))
+
+			Expect(md.NodeMemoryPressureBefore.Set).To(BeTrue())
+			Expect(md.NodeMemoryPressureBefore.Value).To(BeNumerically("~", 1.0, 0.001))
+			Expect(md.NodeMemoryPressureAfter.Set).To(BeTrue())
+			Expect(md.NodeMemoryPressureAfter.Value).To(BeNumerically("~", 0.0, 0.001))
+
+			Expect(md.NodeDiskPressureBefore.Set).To(BeTrue())
+			Expect(md.NodeDiskPressureBefore.Value).To(BeNumerically("~", 0.0, 0.001))
+			Expect(md.NodeDiskPressureAfter.Set).To(BeTrue())
+			Expect(md.NodeDiskPressureAfter.Value).To(BeNumerically("~", 0.0, 0.001))
+		})
+
+		It("UT-EM-AM-014: should set PersistentVolume phase/usage metric_deltas fields when provided", func() {
+			score := 0.9
+			result := types.ComponentResult{
+				Component: types.ComponentMetrics,
+				Assessed:  true,
+				Score:     &score,
+				Details:   "PV phase and usage improved",
+			}
+
+			phaseFailedBefore, phaseFailedAfter := 1.0, 0.0
+			phasePendingBefore, phasePendingAfter := 0.0, 0.0
+			usageRatioBefore, usageRatioAfter := 0.95, 0.60
+
+			metricsData := audit.MetricsAssessedData{
+				PVPhaseFailedBefore:  &phaseFailedBefore,
+				PVPhaseFailedAfter:   &phaseFailedAfter,
+				PVPhasePendingBefore: &phasePendingBefore,
+				PVPhasePendingAfter:  &phasePendingAfter,
+				PVUsageRatioBefore:   &usageRatioBefore,
+				PVUsageRatioAfter:    &usageRatioAfter,
+			}
+
+			err := mgr.RecordMetricsAssessed(ctx, ea, result, metricsData)
+			Expect(err).ToNot(HaveOccurred())
+
+			payload := extractPayload(spy.lastEvent)
+			Expect(payload.MetricDeltas.Set).To(BeTrue())
+			md := payload.MetricDeltas.Value
+
+			Expect(md.PvPhaseFailedBefore.Set).To(BeTrue())
+			Expect(md.PvPhaseFailedBefore.Value).To(BeNumerically("~", 1.0, 0.001))
+			Expect(md.PvPhaseFailedAfter.Set).To(BeTrue())
+			Expect(md.PvPhaseFailedAfter.Value).To(BeNumerically("~", 0.0, 0.001))
+
+			Expect(md.PvPhasePendingBefore.Set).To(BeTrue())
+			Expect(md.PvPhasePendingAfter.Set).To(BeTrue())
+
+			Expect(md.PvUsageRatioBefore.Set).To(BeTrue())
+			Expect(md.PvUsageRatioBefore.Value).To(BeNumerically("~", 0.95, 0.001))
+			Expect(md.PvUsageRatioAfter.Set).To(BeTrue())
+			Expect(md.PvUsageRatioAfter.Value).To(BeNumerically("~", 0.60, 0.001))
+		})
+
+		It("UT-EM-AM-015: should leave cluster-scoped fields unset for namespace-scoped assessments", func() {
+			score := 0.85
+			result := types.ComponentResult{
+				Component: types.ComponentMetrics,
+				Assessed:  true,
+				Score:     &score,
+			}
+
+			cpuBefore, cpuAfter := 0.8, 0.3
+			metricsData := audit.MetricsAssessedData{
+				CPUBefore: &cpuBefore,
+				CPUAfter:  &cpuAfter,
+				// Cluster-scoped fields intentionally nil (namespace-scoped target)
+			}
+
+			err := mgr.RecordMetricsAssessed(ctx, ea, result, metricsData)
+			Expect(err).ToNot(HaveOccurred())
+
+			payload := extractPayload(spy.lastEvent)
+			md := payload.MetricDeltas.Value
+
+			Expect(md.CPUBefore.Set).To(BeTrue())
+
+			Expect(md.NodeNotReadyBefore.Set).To(BeFalse(), "node_not_ready_before should not be set for namespace-scoped targets")
+			Expect(md.NodeNotReadyAfter.Set).To(BeFalse())
+			Expect(md.NodeMemoryPressureBefore.Set).To(BeFalse())
+			Expect(md.NodeMemoryPressureAfter.Set).To(BeFalse())
+			Expect(md.NodeDiskPressureBefore.Set).To(BeFalse())
+			Expect(md.NodeDiskPressureAfter.Set).To(BeFalse())
+			Expect(md.PvPhaseFailedBefore.Set).To(BeFalse())
+			Expect(md.PvPhaseFailedAfter.Set).To(BeFalse())
+			Expect(md.PvPhasePendingBefore.Set).To(BeFalse())
+			Expect(md.PvPhasePendingAfter.Set).To(BeFalse())
+			Expect(md.PvUsageRatioBefore.Set).To(BeFalse())
+			Expect(md.PvUsageRatioAfter.Set).To(BeFalse())
+		})
+
+		It("UT-EM-AM-016: should not clobber Phase A/B fields when cluster-scoped fields are also present", func() {
+			score := 0.7
+			result := types.ComponentResult{
+				Component: types.ComponentMetrics,
+				Assessed:  true,
+				Score:     &score,
+			}
+
+			cpuBefore, cpuAfter := 0.8, 0.3
+			notReadyBefore, notReadyAfter := 1.0, 0.0
+
+			metricsData := audit.MetricsAssessedData{
+				CPUBefore:          &cpuBefore,
+				CPUAfter:           &cpuAfter,
+				NodeNotReadyBefore: &notReadyBefore,
+				NodeNotReadyAfter:  &notReadyAfter,
+			}
+
+			err := mgr.RecordMetricsAssessed(ctx, ea, result, metricsData)
+			Expect(err).ToNot(HaveOccurred())
+
+			payload := extractPayload(spy.lastEvent)
+			md := payload.MetricDeltas.Value
+
+			Expect(md.CPUBefore.Set).To(BeTrue())
+			Expect(md.CPUBefore.Value).To(BeNumerically("~", 0.8, 0.001))
+			Expect(md.NodeNotReadyBefore.Set).To(BeTrue())
+			Expect(md.NodeNotReadyBefore.Value).To(BeNumerically("~", 1.0, 0.001))
 		})
 	})
 })

--- a/test/integration/effectivenessmonitor/cluster_scoped_193_integration_test.go
+++ b/test/integration/effectivenessmonitor/cluster_scoped_193_integration_test.go
@@ -1,0 +1,240 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package effectivenessmonitor
+
+import (
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	eav1 "github.com/jordigilh/kubernaut/api/effectivenessassessment/v1alpha1"
+	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+	"github.com/jordigilh/kubernaut/test/infrastructure"
+)
+
+// fetchMetricsAssessedPayload queries the audit trail for the
+// effectiveness.metrics.assessed event matching correlationID and returns
+// its typed metric_deltas sub-object. Used to prove the audit event content
+// (not just Score/MetricsAssessed) is populated for cluster-scoped targets
+// (Issue #193 audit gap, DD-EM-005 v1.1).
+func fetchMetricsAssessedPayload(correlationID string) ogenclient.EffectivenessAssessmentAuditPayloadMetricDeltas {
+	var event *ogenclient.AuditEvent
+	Eventually(func() bool {
+		resp, err := dsClients.OpenAPIClient.QueryAuditEvents(ctx, ogenclient.QueryAuditEventsParams{
+			CorrelationID: ogenclient.NewOptString(correlationID),
+			Limit:         ogenclient.NewOptInt(100),
+		})
+		if err != nil {
+			GinkgoWriter.Printf("Audit query error: %v\n", err)
+			return false
+		}
+		for i := range resp.Data {
+			if resp.Data[i].EventType == "effectiveness.metrics.assessed" {
+				event = &resp.Data[i]
+				return true
+			}
+		}
+		return false
+	}, 30*time.Second, 2*time.Second).Should(BeTrue(),
+		"effectiveness.metrics.assessed event must exist in audit trail")
+
+	payload, ok := event.EventData.GetEffectivenessAssessmentAuditPayload()
+	Expect(ok).To(BeTrue(), "Event data must be EffectivenessAssessmentAuditPayload")
+	Expect(payload.MetricDeltas.Set).To(BeTrue(), "metric_deltas sub-object must be set")
+	return payload.MetricDeltas.Value
+}
+
+// promQuerySent reports whether any query_range request logged so far carried
+// a "query" param containing substr. The mock's canned response ignores query
+// content, so this is the only reliable way to prove which PromQL the
+// reconciler actually dispatched (i.e. that Kind-dispatch routed to the new
+// cluster-scoped builders, not the namespace-scoped ones).
+func promQuerySent(substr string) bool {
+	for _, req := range mockProm.GetRequestLog() {
+		if req.Path != "/api/v1/query_range" {
+			continue
+		}
+		for _, q := range req.Query["query"] {
+			if strings.Contains(q, substr) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// createClusterScopedEA creates an EA CRD for a cluster-scoped target (Node,
+// PersistentVolume) — SignalTarget/RemediationTarget both carry an empty
+// Namespace, mirroring how the Remediation Orchestrator populates these
+// fields for Kind=Node/PersistentVolume today (Issue #193, DD-EM-005).
+func createClusterScopedEA(name, correlationID, kind, resourceName string) *eav1.EffectivenessAssessment {
+	target := eav1.TargetResource{
+		Kind: kind,
+		Name: resourceName,
+		// Namespace intentionally empty: cluster-scoped resource.
+	}
+	ea := &eav1.EffectivenessAssessment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: eav1.EffectivenessAssessmentSpec{
+			CorrelationID:           correlationID,
+			RemediationRequestPhase: "Completed",
+			SignalTarget:            target,
+			RemediationTarget:       target,
+			Config: eav1.EAConfig{
+				StabilizationWindow: metav1.Duration{Duration: 1 * time.Second},
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, ea)).To(Succeed())
+	GinkgoWriter.Printf("✅ Created cluster-scoped EffectivenessAssessment: %s/%s (Kind=%s, Name=%s)\n",
+		ea.Namespace, ea.Name, kind, resourceName)
+	return ea
+}
+
+var _ = Describe("Cluster-Scoped Resource Assessment Integration (Issue #193, BR-EM-002, BR-EM-003, DD-EM-005)", func() {
+
+	BeforeEach(func() {
+		// Restore mock Prometheus/AlertManager to known-good defaults before each test,
+		// since other Describe blocks in this suite mutate shared package-level mocks.
+		now := float64(time.Now().Unix())
+		preRemediationTime := now - 60
+		mockProm.SetQueryRangeHandler(nil)
+		mockProm.SetQueryRangeResponse(infrastructure.NewPromMatrixResponse(
+			map[string]string{"__name__": "kube_node_status_condition"},
+			[][]interface{}{
+				{preRemediationTime, "1.000000"}, // pre-remediation: condition firing (e.g. NotReady=1)
+				{now, "0.000000"},                // post-remediation: condition cleared (improvement)
+			},
+		))
+		mockAM.SetAlertsResponse([]infrastructure.AMAlert{})
+		mockAM.ResetRequestLog()
+		mockProm.ResetRequestLog()
+	})
+
+	// ========================================
+	// IT-EM-193-001: Kind=Node metrics dispatch -> MetricsAssessed=true
+	// ========================================
+	It("IT-EM-193-001: should assess metrics for a cluster-scoped Node target", func() {
+		ea := createClusterScopedEA("ea-193-node-mc", "rr-193-node-mc", "Node", "worker-1")
+
+		fetchedEA := &eav1.EffectivenessAssessment{}
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: ea.Name, Namespace: ea.Namespace,
+			}, fetchedEA)).To(Succeed())
+			g.Expect(fetchedEA.Status.Phase).To(Equal(eav1.PhaseCompleted))
+		}, timeout, interval).Should(Succeed())
+
+		Expect(fetchedEA.Status.Components.MetricsAssessed).To(BeTrue(),
+			"Node targets must be assessed via kube_node_status_condition, not the namespace-scoped queries")
+		Expect(fetchedEA.Status.Components.MetricsScore).NotTo(BeNil())
+		Expect(*fetchedEA.Status.Components.MetricsScore).To(BeNumerically(">", 0.0),
+			"condition cleared (1 -> 0) should score as improvement for a LowerIsBetter metric")
+
+		By("Verifying the reconciler actually dispatched the Node-scoped PromQL, not the namespace-scoped fallback")
+		Expect(promQuerySent(`node="worker-1"`)).To(BeTrue(),
+			"assessMetrics must dispatch to buildNodeMetricQuerySpecs for Kind=Node, which queries by node label")
+		Expect(promQuerySent(`namespace=""`)).To(BeFalse(),
+			"the namespace-scoped query builder (which produces an empty namespace filter) must not be used for Kind=Node")
+
+		By("Verifying the effectiveness.metrics.assessed audit event's metric_deltas sub-object is populated (audit gap fix, DD-EM-005 v1.1)")
+		Expect(auditStore.Flush(ctx)).To(Succeed())
+		md := fetchMetricsAssessedPayload("rr-193-node-mc")
+		Expect(md.NodeNotReadyBefore.Set).To(BeTrue(), "node_not_ready_before must be populated for Kind=Node")
+		Expect(md.NodeNotReadyBefore.Value).To(BeNumerically("~", 1.0, 0.001))
+		Expect(md.NodeNotReadyAfter.Set).To(BeTrue())
+		Expect(md.NodeNotReadyAfter.Value).To(BeNumerically("~", 0.0, 0.001))
+		Expect(md.NodeMemoryPressureBefore.Set).To(BeTrue())
+		Expect(md.NodeDiskPressureBefore.Set).To(BeTrue())
+	})
+
+	// ========================================
+	// IT-EM-193-002: Kind=PersistentVolume metrics dispatch -> MetricsAssessed=true
+	// ========================================
+	It("IT-EM-193-002: should assess metrics for a cluster-scoped PersistentVolume target", func() {
+		ea := createClusterScopedEA("ea-193-pv-mc", "rr-193-pv-mc", "PersistentVolume", "pvc-abc123")
+
+		fetchedEA := &eav1.EffectivenessAssessment{}
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: ea.Name, Namespace: ea.Namespace,
+			}, fetchedEA)).To(Succeed())
+			g.Expect(fetchedEA.Status.Phase).To(Equal(eav1.PhaseCompleted))
+		}, timeout, interval).Should(Succeed())
+
+		Expect(fetchedEA.Status.Components.MetricsAssessed).To(BeTrue(),
+			"PersistentVolume targets must be assessed via kube_persistentvolume_* queries, not the namespace-scoped queries")
+		Expect(fetchedEA.Status.Components.MetricsScore).NotTo(BeNil())
+
+		By("Verifying the reconciler actually dispatched the PV-scoped PromQL, not the namespace-scoped fallback")
+		Expect(promQuerySent(`persistentvolume="pvc-abc123"`)).To(BeTrue(),
+			"assessMetrics must dispatch to buildPVMetricQuerySpecs for Kind=PersistentVolume, which queries by persistentvolume label")
+		Expect(promQuerySent(`namespace=""`)).To(BeFalse(),
+			"the namespace-scoped query builder (which produces an empty namespace filter) must not be used for Kind=PersistentVolume")
+
+		By("Verifying the effectiveness.metrics.assessed audit event's metric_deltas sub-object is populated (audit gap fix, DD-EM-005 v1.1)")
+		Expect(auditStore.Flush(ctx)).To(Succeed())
+		md := fetchMetricsAssessedPayload("rr-193-pv-mc")
+		Expect(md.PvPhaseFailedBefore.Set).To(BeTrue(), "pv_phase_failed_before must be populated for Kind=PersistentVolume")
+		Expect(md.PvPhaseFailedAfter.Set).To(BeTrue())
+		Expect(md.PvPhasePendingBefore.Set).To(BeTrue())
+		Expect(md.PvUsageRatioBefore.Set).To(BeTrue())
+		Expect(md.PvUsageRatioBefore.Value).To(BeNumerically("~", 1.0, 0.001))
+	})
+
+	// ========================================
+	// IT-EM-193-003: Kind=Node alert matcher precision -> AlertLabels populated
+	// ========================================
+	It("IT-EM-193-003: should scope AlertManager matchers to the specific Node via AlertLabels", func() {
+		ea := createClusterScopedEA("ea-193-node-alert", "rr-193-node-alert", "Node", "worker-1")
+
+		fetchedEA := &eav1.EffectivenessAssessment{}
+		Eventually(func(g Gomega) {
+			g.Expect(k8sClient.Get(ctx, types.NamespacedName{
+				Name: ea.Name, Namespace: ea.Namespace,
+			}, fetchedEA)).To(Succeed())
+			g.Expect(fetchedEA.Status.Phase).To(Equal(eav1.PhaseCompleted))
+		}, timeout, interval).Should(Succeed())
+
+		Expect(fetchedEA.Status.Components.AlertAssessed).To(BeTrue())
+
+		By("Verifying the AlertManager request carried a node-specific matcher")
+		requests := mockAM.GetRequestLog()
+		found := false
+		for _, req := range requests {
+			if req.Path != "/api/v2/alerts" {
+				continue
+			}
+			for _, f := range req.Query["filter"] {
+				if f == `node="worker-1"` {
+					found = true
+				}
+			}
+		}
+		Expect(found).To(BeTrue(),
+			"assessAlert must populate AlertContext.AlertLabels so buildMatchers emits a node=\"worker-1\" filter, "+
+				"distinguishing this Node from any other Node firing the same alertname")
+	})
+})

--- a/test/integration/kubernautagent/enrichment/enrichment_real_ds_test.go
+++ b/test/integration/kubernautagent/enrichment/enrichment_real_ds_test.go
@@ -474,6 +474,23 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 						"cpu_after":     0.45,
 						"memory_before": 512.0,
 						"memory_after":  256.0,
+						// Cluster-scoped + throughput fields (Issue #193, DD-EM-005 v1.1):
+						// proves the full EM -> DS -> KA wiring for these fields, not just
+						// isolated per-layer unit coverage.
+						"throughput_before_rps":       120.0,
+						"throughput_after_rps":        150.0,
+						"node_not_ready_before":       1.0,
+						"node_not_ready_after":        0.0,
+						"node_memory_pressure_before": 1.0,
+						"node_memory_pressure_after":  0.0,
+						"node_disk_pressure_before":   0.0,
+						"node_disk_pressure_after":    0.0,
+						"pv_phase_failed_before":      1.0,
+						"pv_phase_failed_after":       0.0,
+						"pv_phase_pending_before":     0.0,
+						"pv_phase_pending_after":      0.0,
+						"pv_usage_ratio_before":       0.95,
+						"pv_usage_ratio_after":        0.60,
 					},
 				}, now.Add(3*time.Minute))
 
@@ -507,6 +524,24 @@ var _ = Describe("Kubernaut Agent Enrichment — Real DS + Real K8s (#433)", Lab
 			Expect(*entry.MetricDeltas.CpuAfter).To(BeNumerically("~", 0.45, 0.001))
 			Expect(*entry.MetricDeltas.MemoryBefore).To(BeNumerically("~", 512.0, 0.1))
 			Expect(*entry.MetricDeltas.MemoryAfter).To(BeNumerically("~", 256.0, 0.1))
+
+			By("Asserting cluster-scoped + throughput MetricDeltas propagation (Issue #193, DD-EM-005 v1.1) -- proves the full EM->DS->KA wiring for these fields")
+			Expect(entry.MetricDeltas.ThroughputBeforeRps).ToNot(BeNil())
+			Expect(*entry.MetricDeltas.ThroughputBeforeRps).To(BeNumerically("~", 120.0, 0.001))
+			Expect(entry.MetricDeltas.ThroughputAfterRps).ToNot(BeNil())
+			Expect(*entry.MetricDeltas.ThroughputAfterRps).To(BeNumerically("~", 150.0, 0.001))
+			Expect(entry.MetricDeltas.NodeNotReadyBefore).ToNot(BeNil())
+			Expect(*entry.MetricDeltas.NodeNotReadyBefore).To(BeNumerically("~", 1.0, 0.001))
+			Expect(entry.MetricDeltas.NodeNotReadyAfter).ToNot(BeNil())
+			Expect(entry.MetricDeltas.NodeMemoryPressureBefore).ToNot(BeNil())
+			Expect(entry.MetricDeltas.NodeDiskPressureBefore).ToNot(BeNil())
+			Expect(entry.MetricDeltas.PvPhaseFailedBefore).ToNot(BeNil())
+			Expect(*entry.MetricDeltas.PvPhaseFailedBefore).To(BeNumerically("~", 1.0, 0.001))
+			Expect(entry.MetricDeltas.PvPhasePendingBefore).ToNot(BeNil())
+			Expect(entry.MetricDeltas.PvUsageRatioBefore).ToNot(BeNil())
+			Expect(*entry.MetricDeltas.PvUsageRatioBefore).To(BeNumerically("~", 0.95, 0.001))
+			Expect(entry.MetricDeltas.PvUsageRatioAfter).ToNot(BeNil())
+			Expect(*entry.MetricDeltas.PvUsageRatioAfter).To(BeNumerically("~", 0.60, 0.001))
 
 			By("Asserting SignalResolved propagation from alert.assessed")
 			Expect(entry.SignalResolved).To(HaveValue(BeTrue()))


### PR DESCRIPTION
## Summary

`EffectivenessMonitor.assessMetrics()`/`assessAlert()` previously issued only namespace-scoped PromQL and unconditionally reported "no metric data available" for cluster-scoped `SignalTarget` kinds (`Node`, `PersistentVolume`), and alert resolution had no precise per-target matching for these kinds. This PR fixes both, and closes an audit-completeness gap found while verifying the fix.

- **Kind-dispatch metric query builders**: Node/PersistentVolume targets now query `kube-state-metrics` (deterministic, K8s-API-driven) instead of the hardcoded namespace-scoped queries used for workload targets.
- **`AlertLabels` population** for cluster-scoped targets so AlertManager resolution can match precisely instead of falling back to broad/no matching.
- **Audit `metric_deltas` extension** (SOC2 CC8.1 / FedRAMP AU-2/AU-3): the `effectiveness.metrics.assessed` audit event's `metric_deltas` sub-object was silently empty for cluster-scoped targets even after the fix above, because the audit DTOs/schema only had namespace-scoped field names. Extended the OpenAPI schema, EM producer, DataStorage correlation, and Kubernaut Agent enrichment/prompt formatting -- full pipeline (EM -> DataStorage -> Kubernaut Agent) -- with 6 new field pairs. Opportunistically backfilled a pre-existing, unrelated gap in the same files: `throughput_before_rps`/`after_rps` was present in the raw audit payload but never propagated downstream.
- **Pyramid-invariant closure**: the audit extension's DataStorage/Kubernaut-Agent wiring points initially had only isolated per-layer UT coverage. Closed by extending the pre-existing real-PostgreSQL, real-DataStorage-HTTP-server `IT-KA-433-ENR-008` to prove the new fields survive the actual EM->DS->KA wire.

No new ConfigMap/CRD surface: query construction is hardcoded per Kind in Go, following the precedent of existing namespace-scoped query builders (see DD-EM-005 for the rejected generic-config alternative and why).

Closes #193.

## Design decisions

- `docs/architecture/decisions/DD-EM-005-cluster-scoped-metrics-alert-assessment.md` (v1.2): full design rationale, rejected alternatives, SOC2/FedRAMP control mapping, wiring manifest.
- `docs/testing/193/TEST_PLAN.md` (v1.2): IEEE-829 test plan, BR coverage matrix (BR-EM-002, BR-EM-003, BR-EM-012, BR-AUDIT-005, BR-HAPI-016).

## Test plan

- **Unit**: UT-EM-193-001..010, UT-EM-AM-013..016, UT-RH-LOGIC-025/026, UT-KA-433W-014, extended UT-KA-433-HP-003.
- **Integration**:
  - `IT-EM-193-001/002`: EA with `SignalTarget.Kind=Node`/`PersistentVolume`, `Namespace=""` against mock Prometheus/AlertManager -> correctly-directioned `MetricsAssessed` score; extended to assert the real, persisted `effectiveness.metrics.assessed` audit event's `metric_deltas` content via `QueryAuditEvents`.
  - `IT-KA-433-ENR-008` (extended): cluster-scoped + throughput `metric_deltas` fields survive a real HTTP round-trip through DataStorage's correlation logic and Kubernaut Agent's enrichment client.
- All affected unit and integration suites re-run clean post-rebase: EM (114+3 specs), KA enrichment (10/10 specs), DataStorage remediation-history (9 specs).

## Commit structure

Six logically-grouped, independently-buildable commits (schema -> EM producer -> DataStorage -> Kubernaut Agent -> integration test -> docs), plus one follow-up commit closing the pyramid-invariant gap found during self-review.

Made with [Cursor](https://cursor.com)