### PR TITLE
feat(helm): close apifrontend/fleetmetadatacache hardening gaps (PR A of chart refactor)

### DIFF
--- a/charts/kubernaut/README.md
+++ b/charts/kubernaut/README.md
@@ -622,6 +622,14 @@ If neither an override nor discovery succeeds, `helm install`/`upgrade` fails wi
 
 All controllers accept: `replicas`, `resources`, `pdb.{enabled,minAvailable,maxUnavailable}`, `podSecurityContext`, `containerSecurityContext`, `nodeSelector`, `tolerations`, `affinity`, `topologySpreadConstraints`.
 
+**APIFrontend** and **FleetMetadataCache** also accept the full set above (`podSecurityContext`,
+`containerSecurityContext`, `affinity`, `topologySpreadConstraints`, `pdb`, `nodeSelector`,
+`tolerations`) — previously these two services were missing wiring for the pod-hardening and
+scheduling helpers that every other service already used, even though the schema and values
+already implied they were supported. `pdb.enabled` defaults to `false` for both, matching every
+other service; set `apifrontend.pdb.enabled=true` / `fleetmetadatacache.pdb.enabled=true` (plus
+`minAvailable`/`maxUnavailable`) to opt in.
+
 ### Kubernaut Agent Security Hardening (BR-PLATFORM-005)
 
 KubernautAgent is the highest-risk component in the mesh — it is LLM-driven and carries the

--- a/charts/kubernaut/templates/apifrontend/apifrontend.yaml
+++ b/charts/kubernaut/templates/apifrontend/apifrontend.yaml
@@ -222,7 +222,6 @@ kind: ClusterRole
 metadata:
   name: kubernaut-tool-{{ $persona }}
   labels:
-    app.kubernetes.io/part-of: kubernaut
     kubernaut.ai/component: tool-authorization
     {{- include "kubernaut.labels" $ | nindent 4 }}
 rules:
@@ -255,10 +254,17 @@ spec:
     spec:
       serviceAccountName: apifrontend
       automountServiceAccountToken: true
+      {{- include "kubernaut.imagePullSecrets" . | nindent 6 }}
+      securityContext:
+        {{- include "kubernaut.podSecurityContext" .Values.apifrontend | nindent 8 }}
+      {{- include "kubernaut.affinity" .Values.apifrontend | nindent 6 }}
+      {{- include "kubernaut.scheduling" (dict "component" .Values.apifrontend "global" .Values.global) | nindent 6 }}
       containers:
         - name: apifrontend
           image: {{ include "kubernaut.image" (dict "service" "apifrontend" "global" .Values.global "appVersion" .Chart.AppVersion) }}
           imagePullPolicy: {{ .Values.global.image.pullPolicy | default "IfNotPresent" }}
+          securityContext:
+            {{- include "kubernaut.containerSecurityContext" .Values.apifrontend | nindent 12 }}
           ports:
             - name: https
               containerPort: {{ .Values.apifrontend.config.server.httpPort | default 8443 }}

--- a/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
+++ b/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
@@ -19,7 +19,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fleetmetadatacache
     app.kubernetes.io/component: fleet-metadata-cache
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "kubernaut.labels" . | nindent 4 }}
 data:
   config.yaml: |
     server:
@@ -46,7 +46,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fleetmetadatacache
     app.kubernetes.io/component: fleet-metadata-cache
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "kubernaut.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.fleetmetadatacache.replicas }}
   selector:
@@ -59,20 +59,17 @@ spec:
         app.kubernetes.io/component: fleet-metadata-cache
     spec:
       serviceAccountName: fleetmetadatacache
+      {{- include "kubernaut.imagePullSecrets" . | nindent 6 }}
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        {{- include "kubernaut.podSecurityContext" .Values.fleetmetadatacache | nindent 8 }}
+      {{- include "kubernaut.affinity" .Values.fleetmetadatacache | nindent 6 }}
+      {{- include "kubernaut.scheduling" (dict "component" .Values.fleetmetadatacache "global" .Values.global) | nindent 6 }}
       containers:
         - name: fleetmetadatacache
           image: "{{ .Values.fleetmetadatacache.image.repository }}:{{ .Values.fleetmetadatacache.image.tag }}"
           imagePullPolicy: {{ .Values.fleetmetadatacache.image.pullPolicy }}
           securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            capabilities:
-              drop:
-                - ALL
+            {{- include "kubernaut.containerSecurityContext" .Values.fleetmetadatacache | nindent 12 }}
           args:
             - "--config=/etc/fleetmetadatacache/config.yaml"
           ports:
@@ -119,7 +116,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fleetmetadatacache
     app.kubernetes.io/component: fleet-metadata-cache
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    {{- include "kubernaut.labels" . | nindent 4 }}
 spec:
   type: ClusterIP
   selector:
@@ -142,6 +139,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fleetmetadatacache
     app.kubernetes.io/component: fleet-metadata-cache
+    {{- include "kubernaut.labels" . | nindent 4 }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -149,6 +147,7 @@ metadata:
   name: fleetmetadatacache
   labels:
     app.kubernetes.io/name: fleetmetadatacache
+    {{- include "kubernaut.labels" . | nindent 4 }}
 rules:
 {{- if eq .Values.fleetmetadatacache.gatewayType "kuadrant" }}
   - apiGroups: ["mcp.kuadrant.io"]
@@ -172,6 +171,7 @@ metadata:
   name: fleetmetadatacache
   labels:
     app.kubernetes.io/name: fleetmetadatacache
+    {{- include "kubernaut.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -189,6 +189,7 @@ metadata:
   labels:
     app.kubernetes.io/name: fleetmetadatacache
     app.kubernetes.io/component: fleet-metadata-cache
+    {{- include "kubernaut.labels" . | nindent 4 }}
 spec:
   podSelector:
     matchLabels:

--- a/charts/kubernaut/templates/pdb.yaml
+++ b/charts/kubernaut/templates/pdb.yaml
@@ -1,18 +1,21 @@
-{{- range $name, $component := dict
-  "gateway" $.Values.gateway
-  "datastorage" $.Values.datastorage
-  "kubernaut-agent" $.Values.kubernautAgent
-  "notification-controller" $.Values.notification
-  "authwebhook" $.Values.authwebhook
-  "signalprocessing-controller" $.Values.signalprocessing
-  "remediationorchestrator-controller" $.Values.remediationorchestrator
-  "workflowexecution-controller" $.Values.workflowexecution
-  "effectivenessmonitor-controller" $.Values.effectivenessmonitor
-  "aianalysis-controller" $.Values.aianalysis
-  "console" $.Values.console
+{{- range $name, $entry := dict
+  "gateway" (dict "values" $.Values.gateway "selectorLabel" "app")
+  "datastorage" (dict "values" $.Values.datastorage "selectorLabel" "app")
+  "kubernaut-agent" (dict "values" $.Values.kubernautAgent "selectorLabel" "app")
+  "notification-controller" (dict "values" $.Values.notification "selectorLabel" "app")
+  "authwebhook" (dict "values" $.Values.authwebhook "selectorLabel" "app")
+  "signalprocessing-controller" (dict "values" $.Values.signalprocessing "selectorLabel" "app")
+  "remediationorchestrator-controller" (dict "values" $.Values.remediationorchestrator "selectorLabel" "app")
+  "workflowexecution-controller" (dict "values" $.Values.workflowexecution "selectorLabel" "app")
+  "effectivenessmonitor-controller" (dict "values" $.Values.effectivenessmonitor "selectorLabel" "app")
+  "aianalysis-controller" (dict "values" $.Values.aianalysis "selectorLabel" "app")
+  "console" (dict "values" $.Values.console "selectorLabel" "app")
+  "apifrontend" (dict "values" $.Values.apifrontend "selectorLabel" "app")
+  "fleetmetadatacache" (dict "values" $.Values.fleetmetadatacache "selectorLabel" "app.kubernetes.io/name")
 }}
-{{/* "console" is opt-in (console.enabled defaults false); skip its PDB entirely when disabled. */}}
-{{- if and $component.pdb $component.pdb.enabled (or (ne $name "console") $component.enabled) }}
+{{- $component := $entry.values }}
+{{/* "console" and "fleetmetadatacache" are opt-in (enabled defaults false); skip their PDB entirely when disabled. */}}
+{{- if and $component.pdb $component.pdb.enabled (or (not (has $name (list "console" "fleetmetadatacache"))) $component.enabled) }}
 ---
 apiVersion: policy/v1
 kind: PodDisruptionBudget
@@ -25,7 +28,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app: {{ $name }}
+      {{ $entry.selectorLabel }}: {{ $name }}
   {{- with $component.pdb.minAvailable }}
   minAvailable: {{ . }}
   {{- end }}

--- a/charts/kubernaut/tests/apifrontend_fmc_hardening_test.yaml
+++ b/charts/kubernaut/tests/apifrontend_fmc_hardening_test.yaml
@@ -1,0 +1,191 @@
+suite: apifrontend/fleetmetadatacache hardening gaps (chart refactor PR A)
+templates:
+  - templates/apifrontend/apifrontend.yaml
+  - templates/fleetmetadatacache/fleetmetadatacache.yaml
+  - templates/pdb.yaml
+set:
+  postgresql:
+    auth:
+      existingSecret: dummy
+  valkey:
+    existingSecret: dummy
+  kubernautAgent:
+    llm:
+      provider: openai
+      model: gpt-4
+  signalprocessing:
+    policies:
+      existingConfigMap: test-cm
+  aianalysis:
+    policies:
+      existingConfigMap: test-cm
+  fleetmetadatacache:
+    enabled: true
+    mcpGatewayEndpoint: "http://mcp.example.com"
+    oauth2:
+      tokenURL: "http://oauth.example.com"
+      credentialsSecretRef: "fmc-creds"
+tests:
+  - it: "apifrontend Deployment gets default pod securityContext"
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+
+  - it: "apifrontend container gets default containerSecurityContext (previously absent)"
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop[0]
+          value: ALL
+
+  - it: "apifrontend imagePullSecrets renders when global.imagePullSecrets is set"
+    set:
+      global:
+        imagePullSecrets:
+          - name: my-pull-secret
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: my-pull-secret
+
+  - it: "apifrontend affinity/scheduling overrides are honored"
+    set:
+      apifrontend:
+        nodeSelector:
+          disktype: ssd
+        tolerations:
+          - key: dedicated
+            operator: Equal
+            value: kubernaut
+            effect: NoSchedule
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.disktype
+          value: ssd
+      - equal:
+          path: spec.template.spec.tolerations[0].key
+          value: dedicated
+
+  - it: "fleetmetadatacache pod/container securityContext rendered output is unchanged (now via helper, not hardcoded)"
+    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.securityContext.seccompProfile.type
+          value: RuntimeDefault
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.allowPrivilegeEscalation
+          value: false
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.capabilities.drop[0]
+          value: ALL
+
+  - it: "fleetmetadatacache selector/matchLabels scheme (app.kubernetes.io/name) is untouched"
+    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: fleetmetadatacache
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: fleetmetadatacache
+
+  - it: "fleetmetadatacache resources gain standard chart labels (helm.sh/chart etc.) without touching selectors"
+    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - exists:
+          path: metadata.labels["helm.sh/chart"]
+      - exists:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+
+  - it: "apifrontend PDB renders with app selector when enabled"
+    set:
+      apifrontend:
+        pdb:
+          enabled: true
+          maxUnavailable: 1
+    template: templates/pdb.yaml
+    documentSelector:
+      path: metadata.name
+      value: apifrontend
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: apifrontend
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+
+  - it: "fleetmetadatacache PDB renders with app.kubernetes.io/name selector when enabled"
+    set:
+      fleetmetadatacache:
+        pdb:
+          enabled: true
+          maxUnavailable: 1
+    template: templates/pdb.yaml
+    documentSelector:
+      path: metadata.name
+      value: fleetmetadatacache
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: fleetmetadatacache
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+
+  - it: "fleetmetadatacache PDB does not render when fleetmetadatacache is disabled, even if pdb.enabled=true"
+    set:
+      fleetmetadatacache:
+        enabled: false
+        pdb:
+          enabled: true
+          maxUnavailable: 1
+      # datastorage.pdb defaults to enabled=true; disable it here so the only
+      # PDB that could possibly render is the (guarded) fleetmetadatacache one.
+      datastorage:
+        pdb:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/pdb.yaml

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -1156,7 +1156,14 @@
             "credentialsSecretRef": { "type": "string", "default": "", "description": "Secret with client-id and client-secret keys (REQUIRED)" }
           }
         },
-        "resources": { "$ref": "#/definitions/resources" }
+        "resources": { "$ref": "#/definitions/resources" },
+        "podSecurityContext": { "$ref": "#/definitions/securityContext" },
+        "containerSecurityContext": { "$ref": "#/definitions/securityContext" },
+        "pdb": { "$ref": "#/definitions/pdb" },
+        "affinity": { "$ref": "#/definitions/affinity" },
+        "topologySpreadConstraints": { "$ref": "#/definitions/topologySpreadConstraints" },
+        "nodeSelector": { "$ref": "#/definitions/nodeSelector" },
+        "tolerations": { "$ref": "#/definitions/tolerations" }
       }
     },
     "apifrontend": {
@@ -1280,6 +1287,11 @@
           }
         },
         "resources": { "$ref": "#/definitions/resources" },
+        "podSecurityContext": { "$ref": "#/definitions/securityContext" },
+        "containerSecurityContext": { "$ref": "#/definitions/securityContext" },
+        "pdb": { "$ref": "#/definitions/pdb" },
+        "affinity": { "$ref": "#/definitions/affinity" },
+        "topologySpreadConstraints": { "$ref": "#/definitions/topologySpreadConstraints" },
         "nodeSelector": { "$ref": "#/definitions/nodeSelector" },
         "tolerations": { "$ref": "#/definitions/tolerations" }
       }

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -709,6 +709,10 @@ valkey:
 fleetmetadatacache:
   enabled: false
   replicas: 1
+  pdb:
+    enabled: false
+    # minAvailable: 1
+    # maxUnavailable: ""
   image:
     repository: quay.io/kubernaut-ai/fleetmetadatacache
     tag: v1.6.0
@@ -870,6 +874,10 @@ networkPolicies:
 apifrontend:
   enabled: true
   replicas: 1
+  pdb:
+    enabled: false
+    # minAvailable: 1
+    # maxUnavailable: ""
   # -- HorizontalPodAutoscaler (BR-PLATFORM-003, Issue #1589). autoscaling/v2 is a stable core
   # API — no CRD gate needed, unlike ServiceMonitor/PrometheusRule. Ported from the Kubernaut
   # Operator's APIFrontendHPA (kubernaut-operator/internal/resources/hpa.go).


### PR DESCRIPTION
## Summary

First of a three-PR sequence (A/B/C) closing chart-refactor/hardening gaps
identified while auditing the Helm chart against the Kubernaut Operator's
defaults (`kubernaut-operator/internal/resources/`). This PR (A) only closes
gaps in two services that were missing wiring every other service already
had — no new default behavior, no opt-in-by-default flips (that's PR B).

`apifrontend` and `fleetmetadatacache` were the only two mesh services
missing:
- `imagePullSecrets`
- `podSecurityContext` / `containerSecurityContext` (fleetmetadatacache had
  these hardcoded inline, not overridable via values)
- `affinity`
- scheduling (`nodeSelector` / `tolerations`) — fleetmetadatacache didn't
  even have these in the schema
- PDB support (`pdb.yaml` only had 11 of the 13 services)

## Changes

- **`apifrontend.yaml`**: wire `kubernaut.imagePullSecrets` /
  `podSecurityContext` / `affinity` / `scheduling` /
  `containerSecurityContext` into the Deployment. The container previously
  had **no** `securityContext` at all.
- **`fleetmetadatacache.yaml`**: replace the hand-rolled, non-overridable
  `securityContext` block with the same helper calls used everywhere else
  in the chart — rendered defaults are **byte-identical** (zero behavior
  change for existing users), just now overridable. Add the same
  affinity/scheduling/imagePullSecrets wiring. Append `kubernaut.labels`
  to all of its resources' `metadata.labels` (its `app.kubernetes.io/name`
  selector scheme is untouched — only non-selector labels changed).
- **`pdb.yaml`**: extend the shared PDB loop to carry a per-component
  selector-label key, so `fleetmetadatacache`'s
  `app.kubernetes.io/name` selector scheme can share the same template as
  every `app: <name>` service. Add `apifrontend` + `fleetmetadatacache`
  entries — `pdb.enabled` defaults to `false` for both, same as every
  other service today.
- **`values.schema.json` / `values.yaml`**: add `podSecurityContext`,
  `containerSecurityContext`, `pdb`, `affinity`,
  `topologySpreadConstraints`, `nodeSelector`, `tolerations` to both
  services (fleetmetadatacache was missing `nodeSelector`/`tolerations`
  entirely, not just the pod-hardening fields).
- **Bugfix (found via new test coverage)**: `apifrontend.yaml`'s
  per-persona `ClusterRole` labels had a hardcoded
  `app.kubernetes.io/part-of: kubernaut` that duplicated the same key
  already emitted by `kubernaut.labels`, producing an invalid duplicate
  YAML mapping key. This is pre-existing on `main` (unrelated to this PR's
  scope) — it was invisible because no `helm-unittest` suite previously
  covered `apifrontend.yaml`. Fixed by dropping the redundant hardcoded
  line.
- **`tests/apifrontend_fmc_hardening_test.yaml`** (new, 10 tests): default
  pod/container security context, `imagePullSecrets` rendering,
  affinity/scheduling overrides, fleetmetadatacache's rendered
  security context being unchanged, label consistency, and PDB
  selector-scheme correctness for both services (including the
  enabled-gate for fleetmetadatacache's PDB).
- **README**: documented that APIFrontend and FleetMetadataCache now
  accept the same common controller parameters as every other service.

## Test plan

- [x] `helm lint` (default `tls.mode`)
- [x] `helm template` across all three `tls.mode` values (`hook`,
  `cert-manager`, `manual`) — clean render, no errors
- [x] `python -m json.tool values.schema.json` — valid JSON
- [x] Full `helm-unittest` suite: **37/37 passing** (27 pre-existing + 10
  new)
- [x] Verified `apifrontend`'s Go binary has no production (non-test) code
  paths writing to disk, before enabling `readOnlyRootFilesystem: true`
  for the first time on that container
- [x] Verified fleetmetadatacache's rendered `securityContext` is
  byte-identical before/after (confirmed via `helm template` diff)

Made with [Cursor](https://cursor.com)