### PR TITLE
feat(helm): default anti-affinity + PDB on by default (PR B, DD-PLATFORM-004)

### DIFF
--- a/charts/kubernaut/README.md
+++ b/charts/kubernaut/README.md
@@ -626,9 +626,25 @@ All controllers accept: `replicas`, `resources`, `pdb.{enabled,minAvailable,maxU
 `containerSecurityContext`, `affinity`, `topologySpreadConstraints`, `pdb`, `nodeSelector`,
 `tolerations`) — previously these two services were missing wiring for the pod-hardening and
 scheduling helpers that every other service already used, even though the schema and values
-already implied they were supported. `pdb.enabled` defaults to `false` for both, matching every
-other service; set `apifrontend.pdb.enabled=true` / `fleetmetadatacache.pdb.enabled=true` (plus
-`minAvailable`/`maxUnavailable`) to opt in.
+already implied they were supported.
+
+#### Default anti-affinity and PDB (DD-PLATFORM-004)
+
+Every service that renders a Deployment gets a default **soft** (preferred, not required)
+pod anti-affinity spreading its replicas across nodes, and `pdb.enabled` defaults to
+`true` (`maxUnavailable: 1`) for every service in `templates/pdb.yaml` — matching the
+Kubernaut Operator's defaults. Both are safe with the chart's default `replicas: 1`: a
+preferred anti-affinity term is a no-op with no peer replica to avoid, and
+`maxUnavailable: 1` (never `minAvailable`) always permits the sole pod to be voluntarily
+evicted (e.g. `kubectl drain`) rather than blocking it. Override per-service via
+`<service>.affinity` (deep-merged with the default: a sibling key like `nodeAffinity`
+merges in alongside the default `podAntiAffinity`; to fully replace the default
+anti-affinity term itself, provide your own **non-empty**
+`podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution` list — an *empty*
+list or `null` is treated as unset and the default silently wins back, see
+DD-PLATFORM-004) and `<service>.pdb.enabled=false` to opt out of the PDB entirely.
+`console`'s and `fleetmetadatacache`'s PDBs still only render when the service itself
+is enabled.
 
 ### Kubernaut Agent Security Hardening (BR-PLATFORM-005)
 

--- a/charts/kubernaut/templates/_helpers.tpl
+++ b/charts/kubernaut/templates/_helpers.tpl
@@ -407,15 +407,23 @@ subjects:
 {{- end }}
 
 {{/*
-Render optional affinity and topologySpreadConstraints for a component pod spec.
-Usage: {{ include "kubernaut.affinity" .Values.gateway | nindent 6 }}
+Render affinity and topologySpreadConstraints for a component pod spec.
+DD-PLATFORM-004: injects a default soft (preferred, weight 100) pod
+anti-affinity spreading replicas across nodes by the given matchLabels,
+merged with any user-supplied .affinity override — user values win on
+conflicting keys, sibling keys (e.g. nodeAffinity, or an explicit empty
+preferredDuringSchedulingIgnoredDuringExecution: [] to opt out) merge
+additively. Ported from the Kubernaut Operator's preferredPodAntiAffinity
+(kubernaut-operator/internal/resources/deployments.go).
+Usage: {{ include "kubernaut.affinity" (dict "component" .Values.gateway "matchLabels" (dict "app" "gateway")) | nindent 6 }}
 */}}
 {{- define "kubernaut.affinity" -}}
-{{- with .affinity }}
+{{- $component := .component -}}
+{{- $defaultAntiAffinity := dict "podAntiAffinity" (dict "preferredDuringSchedulingIgnoredDuringExecution" (list (dict "weight" 100 "podAffinityTerm" (dict "topologyKey" "kubernetes.io/hostname" "labelSelector" (dict "matchLabels" .matchLabels))))) -}}
+{{- $userAffinity := $component.affinity | default dict -}}
 affinity:
-  {{- toYaml . | nindent 2 }}
-{{- end }}
-{{- with .topologySpreadConstraints }}
+  {{- toYaml (merge $userAffinity $defaultAntiAffinity) | nindent 2 }}
+{{- with $component.topologySpreadConstraints }}
 topologySpreadConstraints:
   {{- toYaml . | nindent 2 }}
 {{- end }}

--- a/charts/kubernaut/templates/aianalysis/aianalysis.yaml
+++ b/charts/kubernaut/templates/aianalysis/aianalysis.yaml
@@ -173,7 +173,7 @@ spec:
       {{- include "kubernaut.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- include "kubernaut.podSecurityContext" .Values.aianalysis | nindent 8 }}
-      {{- include "kubernaut.affinity" .Values.aianalysis | nindent 6 }}
+      {{- include "kubernaut.affinity" (dict "component" .Values.aianalysis "matchLabels" (dict "app" "aianalysis-controller")) | nindent 6 }}
       {{- include "kubernaut.scheduling" (dict "component" .Values.aianalysis "global" .Values.global) | nindent 6 }}
       containers:
         - name: aianalysis

--- a/charts/kubernaut/templates/apifrontend/apifrontend.yaml
+++ b/charts/kubernaut/templates/apifrontend/apifrontend.yaml
@@ -257,7 +257,7 @@ spec:
       {{- include "kubernaut.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- include "kubernaut.podSecurityContext" .Values.apifrontend | nindent 8 }}
-      {{- include "kubernaut.affinity" .Values.apifrontend | nindent 6 }}
+      {{- include "kubernaut.affinity" (dict "component" .Values.apifrontend "matchLabels" (dict "app" "apifrontend")) | nindent 6 }}
       {{- include "kubernaut.scheduling" (dict "component" .Values.apifrontend "global" .Values.global) | nindent 6 }}
       containers:
         - name: apifrontend

--- a/charts/kubernaut/templates/authwebhook/authwebhook.yaml
+++ b/charts/kubernaut/templates/authwebhook/authwebhook.yaml
@@ -116,7 +116,7 @@ spec:
       {{- include "kubernaut.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- include "kubernaut.podSecurityContext" .Values.authwebhook | nindent 8 }}
-      {{- include "kubernaut.affinity" .Values.authwebhook | nindent 6 }}
+      {{- include "kubernaut.affinity" (dict "component" .Values.authwebhook "matchLabels" (dict "app" "authwebhook")) | nindent 6 }}
       {{- include "kubernaut.scheduling" (dict "component" .Values.authwebhook "global" .Values.global) | nindent 6 }}
       {{- if eq .Values.tls.mode "hook" }}
       initContainers:

--- a/charts/kubernaut/templates/console/console.yaml
+++ b/charts/kubernaut/templates/console/console.yaml
@@ -115,7 +115,7 @@ spec:
       automountServiceAccountToken: false
       securityContext:
         {{- include "kubernaut.podSecurityContext" .Values.console | nindent 8 }}
-      {{- include "kubernaut.affinity" .Values.console | nindent 6 }}
+      {{- include "kubernaut.affinity" (dict "component" .Values.console "matchLabels" (dict "app" "console")) | nindent 6 }}
       {{- include "kubernaut.scheduling" (dict "component" .Values.console "global" .Values.global) | nindent 6 }}
       containers:
         - name: oauth2-proxy

--- a/charts/kubernaut/templates/datastorage/datastorage.yaml
+++ b/charts/kubernaut/templates/datastorage/datastorage.yaml
@@ -105,7 +105,7 @@ spec:
       {{- include "kubernaut.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- include "kubernaut.podSecurityContext" .Values.datastorage | nindent 8 }}
-      {{- include "kubernaut.affinity" .Values.datastorage | nindent 6 }}
+      {{- include "kubernaut.affinity" (dict "component" .Values.datastorage "matchLabels" (dict "app" "datastorage")) | nindent 6 }}
       {{- include "kubernaut.scheduling" (dict "component" .Values.datastorage "global" .Values.global) | nindent 6 }}
       terminationGracePeriodSeconds: 90
       initContainers:

--- a/charts/kubernaut/templates/effectivenessmonitor/effectivenessmonitor.yaml
+++ b/charts/kubernaut/templates/effectivenessmonitor/effectivenessmonitor.yaml
@@ -194,7 +194,7 @@ spec:
       {{- include "kubernaut.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- include "kubernaut.podSecurityContext" .Values.effectivenessmonitor | nindent 8 }}
-      {{- include "kubernaut.affinity" .Values.effectivenessmonitor | nindent 6 }}
+      {{- include "kubernaut.affinity" (dict "component" .Values.effectivenessmonitor "matchLabels" (dict "app" "effectivenessmonitor-controller")) | nindent 6 }}
       {{- include "kubernaut.scheduling" (dict "component" .Values.effectivenessmonitor "global" .Values.global) | nindent 6 }}
       containers:
         - name: controller

--- a/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
+++ b/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
@@ -62,7 +62,7 @@ spec:
       {{- include "kubernaut.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- include "kubernaut.podSecurityContext" .Values.fleetmetadatacache | nindent 8 }}
-      {{- include "kubernaut.affinity" .Values.fleetmetadatacache | nindent 6 }}
+      {{- include "kubernaut.affinity" (dict "component" .Values.fleetmetadatacache "matchLabels" (dict "app.kubernetes.io/name" "fleetmetadatacache")) | nindent 6 }}
       {{- include "kubernaut.scheduling" (dict "component" .Values.fleetmetadatacache "global" .Values.global) | nindent 6 }}
       containers:
         - name: fleetmetadatacache

--- a/charts/kubernaut/templates/gateway/gateway.yaml
+++ b/charts/kubernaut/templates/gateway/gateway.yaml
@@ -192,7 +192,7 @@ spec:
       {{- include "kubernaut.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- include "kubernaut.podSecurityContext" .Values.gateway | nindent 8 }}
-      {{- include "kubernaut.affinity" .Values.gateway | nindent 6 }}
+      {{- include "kubernaut.affinity" (dict "component" .Values.gateway "matchLabels" (dict "app" "gateway")) | nindent 6 }}
       {{- include "kubernaut.scheduling" (dict "component" .Values.gateway "global" .Values.global) | nindent 6 }}
       containers:
         - name: gateway

--- a/charts/kubernaut/templates/infrastructure/postgresql.yaml
+++ b/charts/kubernaut/templates/infrastructure/postgresql.yaml
@@ -62,7 +62,7 @@ spec:
       {{- $pscOverride := .Values.postgresql.podSecurityContext | default dict }}
       securityContext:
         {{- toYaml (merge $pscOverride $pscDefaults) | nindent 8 }}
-      {{- include "kubernaut.affinity" .Values.postgresql | nindent 6 }}
+      {{- include "kubernaut.affinity" (dict "component" .Values.postgresql "matchLabels" (dict "app" "postgresql")) | nindent 6 }}
       {{- include "kubernaut.scheduling" (dict "component" .Values.postgresql "global" .Values.global) | nindent 6 }}
       containers:
         - name: postgresql

--- a/charts/kubernaut/templates/infrastructure/valkey.yaml
+++ b/charts/kubernaut/templates/infrastructure/valkey.yaml
@@ -62,7 +62,7 @@ spec:
       {{- $pscOverride := .Values.valkey.podSecurityContext | default dict }}
       securityContext:
         {{- toYaml (merge $pscOverride $pscDefaults) | nindent 8 }}
-      {{- include "kubernaut.affinity" .Values.valkey | nindent 6 }}
+      {{- include "kubernaut.affinity" (dict "component" .Values.valkey "matchLabels" (dict "app" "valkey")) | nindent 6 }}
       {{- include "kubernaut.scheduling" (dict "component" .Values.valkey "global" .Values.global) | nindent 6 }}
       containers:
         - name: valkey

--- a/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
+++ b/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
@@ -372,7 +372,7 @@ spec:
       {{- include "kubernaut.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- include "kubernaut.podSecurityContext" .Values.kubernautAgent | nindent 8 }}
-      {{- include "kubernaut.affinity" .Values.kubernautAgent | nindent 6 }}
+      {{- include "kubernaut.affinity" (dict "component" .Values.kubernautAgent "matchLabels" (dict "app" "kubernaut-agent")) | nindent 6 }}
       {{- include "kubernaut.scheduling" (dict "component" .Values.kubernautAgent "global" .Values.global) | nindent 6 }}
       containers:
         - name: kubernaut-agent

--- a/charts/kubernaut/templates/notification/notification.yaml
+++ b/charts/kubernaut/templates/notification/notification.yaml
@@ -153,7 +153,7 @@ spec:
       {{- include "kubernaut.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- include "kubernaut.podSecurityContext" .Values.notification | nindent 8 }}
-      {{- include "kubernaut.affinity" .Values.notification | nindent 6 }}
+      {{- include "kubernaut.affinity" (dict "component" .Values.notification "matchLabels" (dict "app" "notification-controller")) | nindent 6 }}
       {{- include "kubernaut.scheduling" (dict "component" .Values.notification "global" .Values.global) | nindent 6 }}
       containers:
         - name: manager

--- a/charts/kubernaut/templates/remediationorchestrator/remediationorchestrator.yaml
+++ b/charts/kubernaut/templates/remediationorchestrator/remediationorchestrator.yaml
@@ -249,7 +249,7 @@ spec:
       {{- include "kubernaut.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- include "kubernaut.podSecurityContext" .Values.remediationorchestrator | nindent 8 }}
-      {{- include "kubernaut.affinity" .Values.remediationorchestrator | nindent 6 }}
+      {{- include "kubernaut.affinity" (dict "component" .Values.remediationorchestrator "matchLabels" (dict "app" "remediationorchestrator-controller")) | nindent 6 }}
       {{- include "kubernaut.scheduling" (dict "component" .Values.remediationorchestrator "global" .Values.global) | nindent 6 }}
       containers:
         - name: remediationorchestrator-controller

--- a/charts/kubernaut/templates/signalprocessing/signalprocessing.yaml
+++ b/charts/kubernaut/templates/signalprocessing/signalprocessing.yaml
@@ -193,7 +193,7 @@ spec:
       {{- include "kubernaut.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- include "kubernaut.podSecurityContext" .Values.signalprocessing | nindent 8 }}
-      {{- include "kubernaut.affinity" .Values.signalprocessing | nindent 6 }}
+      {{- include "kubernaut.affinity" (dict "component" .Values.signalprocessing "matchLabels" (dict "app" "signalprocessing-controller")) | nindent 6 }}
       {{- include "kubernaut.scheduling" (dict "component" .Values.signalprocessing "global" .Values.global) | nindent 6 }}
       containers:
         - name: signalprocessing-controller

--- a/charts/kubernaut/templates/workflowexecution/workflowexecution.yaml
+++ b/charts/kubernaut/templates/workflowexecution/workflowexecution.yaml
@@ -239,7 +239,7 @@ spec:
       {{- include "kubernaut.imagePullSecrets" . | nindent 6 }}
       securityContext:
         {{- include "kubernaut.podSecurityContext" .Values.workflowexecution | nindent 8 }}
-      {{- include "kubernaut.affinity" .Values.workflowexecution | nindent 6 }}
+      {{- include "kubernaut.affinity" (dict "component" .Values.workflowexecution "matchLabels" (dict "app" "workflowexecution-controller")) | nindent 6 }}
       {{- include "kubernaut.scheduling" (dict "component" .Values.workflowexecution "global" .Values.global) | nindent 6 }}
       {{- if and .Values.workflowexecution.config.ansible .Values.workflowexecution.config.ansible.caCertSecretRef }}
       # BR-PLATFORM-005 (Kubernaut Operator parity): combine the inter-service CA

--- a/charts/kubernaut/tests/apifrontend_fmc_hardening_test.yaml
+++ b/charts/kubernaut/tests/apifrontend_fmc_hardening_test.yaml
@@ -180,9 +180,43 @@ tests:
         pdb:
           enabled: true
           maxUnavailable: 1
-      # datastorage.pdb defaults to enabled=true; disable it here so the only
-      # PDB that could possibly render is the (guarded) fleetmetadatacache one.
+      # DD-PLATFORM-004: pdb.enabled defaults to true for every other service;
+      # disable them all here so the only PDB that could possibly render is
+      # the (guarded) fleetmetadatacache one.
+      gateway:
+        pdb:
+          enabled: false
       datastorage:
+        pdb:
+          enabled: false
+      aianalysis:
+        pdb:
+          enabled: false
+      signalprocessing:
+        pdb:
+          enabled: false
+      remediationorchestrator:
+        pdb:
+          enabled: false
+      workflowexecution:
+        pdb:
+          enabled: false
+      notification:
+        pdb:
+          enabled: false
+      effectivenessmonitor:
+        pdb:
+          enabled: false
+      kubernautAgent:
+        pdb:
+          enabled: false
+      authwebhook:
+        pdb:
+          enabled: false
+      apifrontend:
+        pdb:
+          enabled: false
+      console:
         pdb:
           enabled: false
     asserts:

--- a/charts/kubernaut/tests/default_hardening_test.yaml
+++ b/charts/kubernaut/tests/default_hardening_test.yaml
@@ -1,0 +1,172 @@
+suite: default anti-affinity and PDB (DD-PLATFORM-004)
+templates:
+  - templates/gateway/gateway.yaml
+  - templates/datastorage/datastorage.yaml
+  - templates/fleetmetadatacache/fleetmetadatacache.yaml
+  - templates/pdb.yaml
+set:
+  postgresql:
+    auth:
+      existingSecret: dummy
+  valkey:
+    existingSecret: dummy
+  kubernautAgent:
+    llm:
+      provider: openai
+      model: gpt-4
+  signalprocessing:
+    policies:
+      existingConfigMap: test-cm
+  aianalysis:
+    policies:
+      existingConfigMap: test-cm
+tests:
+  - it: "gateway Deployment gets default soft pod anti-affinity keyed on its own selector"
+    template: templates/gateway/gateway.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
+          value: 100
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey
+          value: kubernetes.io/hostname
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels.app
+          value: gateway
+
+  - it: "fleetmetadatacache Deployment's default anti-affinity uses its app.kubernetes.io/name selector scheme"
+    set:
+      fleetmetadatacache:
+        enabled: true
+        mcpGatewayEndpoint: "http://mcp.example.com"
+        oauth2:
+          tokenURL: "http://oauth.example.com"
+          credentialsSecretRef: "fmc-creds"
+    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels["app.kubernetes.io/name"]
+          value: fleetmetadatacache
+
+  - it: "user-supplied affinity (e.g. nodeAffinity) merges additively with the default anti-affinity, not replacing it"
+    set:
+      gateway:
+        affinity:
+          nodeAffinity:
+            requiredDuringSchedulingIgnoredDuringExecution:
+              nodeSelectorTerms:
+                - matchExpressions:
+                    - key: disktype
+                      operator: In
+                      values: ["ssd"]
+    template: templates/gateway/gateway.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key
+          value: disktype
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
+          value: 100
+
+  - it: "user can fully replace the default anti-affinity with a non-empty override (merge keeps a non-zero user value, not the default)"
+    set:
+      gateway:
+        affinity:
+          podAntiAffinity:
+            preferredDuringSchedulingIgnoredDuringExecution:
+              - weight: 1
+                podAffinityTerm:
+                  topologyKey: kubernetes.io/hostname
+                  labelSelector:
+                    matchLabels:
+                      app: something-else
+    template: templates/gateway/gateway.yaml
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
+          value: 1
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.labelSelector.matchLabels.app
+          value: something-else
+      - lengthEqual:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution
+          count: 1
+
+  - it: "gateway PDB is enabled by default with maxUnavailable: 1 (no minAvailable)"
+    documentSelector:
+      path: metadata.name
+      value: gateway
+    template: templates/pdb.yaml
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable
+
+  - it: "datastorage PDB defaults to maxUnavailable: 1, not minAvailable (regression guard for the pre-existing PodDisruptionBudgetAtLimit bug)"
+    documentSelector:
+      path: metadata.name
+      value: datastorage
+    template: templates/pdb.yaml
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - notExists:
+          path: spec.minAvailable
+
+  - it: "PDB can still be opted out of per-service"
+    set:
+      gateway:
+        pdb:
+          enabled: false
+      datastorage:
+        pdb:
+          enabled: false
+      aianalysis:
+        pdb:
+          enabled: false
+      signalprocessing:
+        pdb:
+          enabled: false
+      remediationorchestrator:
+        pdb:
+          enabled: false
+      workflowexecution:
+        pdb:
+          enabled: false
+      notification:
+        pdb:
+          enabled: false
+      effectivenessmonitor:
+        pdb:
+          enabled: false
+      kubernautAgent:
+        pdb:
+          enabled: false
+      authwebhook:
+        pdb:
+          enabled: false
+      apifrontend:
+        pdb:
+          enabled: false
+      console:
+        pdb:
+          enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/pdb.yaml

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -93,11 +93,11 @@
       "additionalProperties": { "type": "string" }
     },
     "pdb": {
-      "description": "PodDisruptionBudget configuration",
+      "description": "PodDisruptionBudget configuration. DD-PLATFORM-004: enabled by default (maxUnavailable: 1) for all services that render a PDB (see templates/pdb.yaml); minAvailable is intentionally not the default because it blocks all voluntary disruption at replicas=1 (PodDisruptionBudgetAtLimit).",
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "enabled": { "type": "boolean", "default": false },
+        "enabled": { "type": "boolean", "default": true },
         "minAvailable": { "oneOf": [{ "type": "integer" }, { "type": "string" }] },
         "maxUnavailable": { "oneOf": [{ "type": "integer" }, { "type": "string" }] }
       }

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -88,9 +88,9 @@ tls:
 gateway:
   replicas: 1
   pdb:
-    enabled: false
+    enabled: true
     # minAvailable: 1
-    # maxUnavailable: ""
+    maxUnavailable: 1
   logging:
     level: "INFO"
   config:
@@ -195,8 +195,8 @@ datastorage:
     memoryTarget: 80
   pdb:
     enabled: true
-    minAvailable: 1
-    # maxUnavailable: ""
+    # minAvailable: 1
+    maxUnavailable: 1
   logging:
     level: "INFO"
   dbExistingSecret: ""  # DEPRECATED: db-secrets.yaml is now in postgresql-secret. Set only for BYO PostgreSQL with a separate DataStorage secret.
@@ -263,9 +263,9 @@ datastorage:
 aianalysis:
   replicas: 1
   pdb:
-    enabled: false
+    enabled: true
     # minAvailable: 1
-    # maxUnavailable: ""
+    maxUnavailable: 1
   logging:
     level: "INFO"
   rego:
@@ -289,9 +289,9 @@ aianalysis:
 signalprocessing:
   replicas: 1
   pdb:
-    enabled: false
+    enabled: true
     # minAvailable: 1
-    # maxUnavailable: ""
+    maxUnavailable: 1
   logging:
     level: "INFO"
   # -- Unified Rego policy externalization (ADR-060, #415).
@@ -340,9 +340,9 @@ signalprocessing:
 remediationorchestrator:
   replicas: 1
   pdb:
-    enabled: false
+    enabled: true
     # minAvailable: 1
-    # maxUnavailable: ""
+    maxUnavailable: 1
   logging:
     level: "INFO"
   resources:
@@ -419,9 +419,9 @@ workflowexecution:
   workflowNamespace: kubernaut-workflows  # namespace for Job/PipelineRun execution
   replicas: 1
   pdb:
-    enabled: false
+    enabled: true
     # minAvailable: 1
-    # maxUnavailable: ""
+    maxUnavailable: 1
   logging:
     level: "INFO"
   config:
@@ -452,9 +452,9 @@ workflowexecution:
 notification:
   replicas: 1
   pdb:
-    enabled: false
+    enabled: true
     # minAvailable: 1
-    # maxUnavailable: ""
+    maxUnavailable: 1
   logging:
     level: "INFO"
   # -- Slack quickstart shortcut.
@@ -485,9 +485,9 @@ notification:
 effectivenessmonitor:
   replicas: 1
   pdb:
-    enabled: false
+    enabled: true
     # minAvailable: 1
-    # maxUnavailable: ""
+    maxUnavailable: 1
   logging:
     level: "INFO"
   config:
@@ -556,9 +556,9 @@ kubernautAgent:
     #       username: "preferred_username"
     #       groups: "groups"
   pdb:
-    enabled: false
+    enabled: true
     # minAvailable: 1
-    # maxUnavailable: ""
+    maxUnavailable: 1
   logging:
     level: "INFO"
   resources:
@@ -640,9 +640,9 @@ kubernautAgent:
 authwebhook:
   replicas: 1
   pdb:
-    enabled: false
+    enabled: true
     # minAvailable: 1
-    # maxUnavailable: ""
+    maxUnavailable: 1
   logging:
     level: "INFO"
   resources:
@@ -710,9 +710,9 @@ fleetmetadatacache:
   enabled: false
   replicas: 1
   pdb:
-    enabled: false
+    enabled: true
     # minAvailable: 1
-    # maxUnavailable: ""
+    maxUnavailable: 1
   image:
     repository: quay.io/kubernaut-ai/fleetmetadatacache
     tag: v1.6.0
@@ -875,9 +875,9 @@ apifrontend:
   enabled: true
   replicas: 1
   pdb:
-    enabled: false
+    enabled: true
     # minAvailable: 1
-    # maxUnavailable: ""
+    maxUnavailable: 1
   # -- HorizontalPodAutoscaler (BR-PLATFORM-003, Issue #1589). autoscaling/v2 is a stable core
   # API — no CRD gate needed, unlike ServiceMonitor/PrometheusRule. Ported from the Kubernaut
   # Operator's APIFrontendHPA (kubernaut-operator/internal/resources/hpa.go).
@@ -1057,9 +1057,9 @@ console:
   enabled: false
   replicas: 1
   pdb:
-    enabled: false
+    enabled: true
     # minAvailable: 1
-    # maxUnavailable: ""
+    maxUnavailable: 1
   auth:
     # -- Pre-created Secret with keys: client-id, client-secret, cookie-secret
     # (generate cookie-secret with: openssl rand -base64 32 | head -c 32 | base64).

--- a/docs/architecture/decisions/DD-PLATFORM-004-chart-default-hardening.md
+++ b/docs/architecture/decisions/DD-PLATFORM-004-chart-default-hardening.md
@@ -1,0 +1,178 @@
+# DD-PLATFORM-004: Anti-Affinity and PDB Enabled by Default
+
+**Date**: July 8, 2026
+**Status**: ✅ **APPROVED**
+**Confidence**: 96%
+**Last Reviewed**: July 8, 2026
+**Related**: Issue #1617 (Helm chart GitOps/ArgoCD operational readiness), Kubernaut Operator
+(`kubernaut-operator/internal/resources/deployments.go`, `pdb.go`), PR A (apifrontend/
+fleetmetadatacache hardening gaps)
+
+---
+
+## 🎯 **DECISION**
+
+**Every Kubernaut Helm chart service that renders a Deployment SHALL get a
+default soft (preferred, weight 100) pod anti-affinity spreading its
+replicas across nodes by its own selector labels, and `pdb.enabled` SHALL
+default to `true` with `maxUnavailable: 1` for every service already
+covered by `templates/pdb.yaml`. Both remain fully overridable per-service
+via `values.yaml`.**
+
+Both defaults are additive, soft, and safe at `replicas: 1` (the chart's
+default everywhere): a `preferred` (not `required`) anti-affinity term never
+blocks scheduling when there's no other replica to avoid, and
+`maxUnavailable: 1` (never `minAvailable`) always permits a single-replica
+pod to be voluntarily evicted rather than paradoxically blocking it forever.
+
+---
+
+## 📊 **Context & Problem**
+
+Auditing the Helm chart against the Kubernaut Operator's defaults
+(`kubernaut-operator/internal/resources/deployments.go`,
+`preferredPodAntiAffinity`; `pdb.go`, `PodDisruptionBudgets`) found the
+Operator ships **unconditional** soft anti-affinity and a PDB
+(`MaxUnavailable: 1`) for every component, while the Helm chart shipped both
+as opt-in, `enabled: false` (or the field didn't exist in some cases before
+PR A). This is a meaningful operational-readiness gap: a chart deployed with
+defaults has no protection against a single `kubectl drain` or a
+co-scheduling accident taking out every replica of a service at once —
+exactly the class of incident PDBs and anti-affinity exist to prevent — and
+it's inconsistent with the Operator installation path that's supposed to be
+at parity.
+
+A **secondary, pre-existing bug** was found in `values.yaml` while making
+this change: `datastorage.pdb` already defaulted to `enabled: true`, but
+used `minAvailable: 1` rather than `maxUnavailable: 1`. With
+`datastorage.replicas: 1` (the default), `minAvailable: 1` means "at least 1
+of 1 must remain available" — i.e. **zero voluntary disruptions are ever
+permitted** (`PodDisruptionBudgetAtLimit`), which silently blocks
+`kubectl drain`, cluster-autoscaler node consolidation, and rolling
+node upgrades indefinitely for that pod. This is exactly the failure mode
+the Kubernaut Operator's own PDB test explicitly guards against:
+
+```go
+// kubernaut-operator/internal/resources/pdb_test.go
+Expect(pdb.Spec.MinAvailable).To(BeNil(),
+  "PDB %q should not have MinAvailable set (causes PodDisruptionBudgetAtLimit with 1 replica)", pdb.Name)
+```
+
+This DD's new uniform default (`maxUnavailable: 1`, never `minAvailable`)
+fixes that latent bug as part of the same change, rather than leaving one
+service on the broken pattern while introducing the correct one everywhere
+else.
+
+---
+
+## 🔍 **Alternatives Considered**
+
+### **Option A: Match the Operator — enable both, unconditionally, via helper defaults** ✅ **CHOSEN**
+
+Change the `kubernaut.affinity` helper to inject a default
+`podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution` term
+(`weight: 100`, `topologyKey: kubernetes.io/hostname`, `matchLabels` = the
+component's own pod selector labels), deep-merged with any user-supplied
+`<service>.affinity` override via Sprig's `merge` (user keys win; sibling
+keys merge additively — validated in a scratch-chart spike). Flip
+`pdb.enabled` to `true` and set `maxUnavailable: 1` as the shipped default
+for every one of the 13 services in `templates/pdb.yaml`'s loop.
+
+- ✅ Matches the Operator's proven, already-in-production defaults —
+  closes the parity gap this refactor pass is explicitly chasing.
+- ✅ Safe at `replicas: 1`: `preferred` anti-affinity is a no-op with no
+  peer replica to avoid; `maxUnavailable: 1` always permits eviction of the
+  sole pod (unlike `minAvailable: 1`, see above).
+- ✅ Fully overridable: a user can still set `<service>.affinity` to
+  anything, and `<service>.pdb.enabled=false` to opt out of the PDB
+  entirely, exactly as before.
+- ⚠️ **Known limitation, accepted**: the merge (Sprig `merge`, backed by
+  `mergo`) treats an empty list or `null` as an unset zero-value, so an
+  explicit `podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution:
+  []` override does **not** suppress the default term — mergo falls back to
+  the default's non-zero list regardless (verified via an isolated spike).
+  A user who wants genuinely different anti-affinity behavior must supply
+  their own **non-empty** `preferredDuringSchedulingIgnoredDuringExecution`
+  list, which *does* fully replace the default (also verified). This is
+  accepted rather than worked around because the default term is `preferred`
+  (soft) and therefore never blocks scheduling — there is no scenario where
+  a user's inability to fully null it out causes a deployment failure, only
+  a harmless, ignorable scheduler preference.
+- ✅ Fixes the pre-existing `datastorage` `minAvailable`/`maxUnavailable`
+  inconsistency as a natural side effect of unifying on one pattern.
+- ➖ Behavior change for existing installs that `helm upgrade` without
+  pinning these values explicitly (mitigated: both changes are soft/
+  best-effort at the replica counts the chart ships by default, and are
+  exactly what the Operator path already does).
+
+### **Option B: New explicit global toggle (`global.hardening.antiAffinityEnabled` / `.pdbEnabled`)** ❌ REJECTED
+
+Add a chart-wide switch defaulting to `true`, with per-service overrides
+layered on top.
+
+- ❌ Adds a new configuration axis and merge-precedence rules
+  (global-vs-per-service) for something the existing per-service
+  `<service>.affinity` / `<service>.pdb.enabled` fields already fully
+  express — pure added complexity with no behavioral benefit over Option A.
+- ❌ Diverges further from the Operator, which has no such global toggle
+  either.
+
+### **Option C: Leave both opt-in, only fix the `datastorage` `minAvailable` bug** ❌ REJECTED
+
+Minimal fix: just correct `datastorage.pdb` to use `maxUnavailable: 1`, and
+leave every other service (plus anti-affinity for all 15) untouched.
+
+- ❌ Doesn't close the actual gap this refactor pass set out to address
+  (Operator parity, operational readiness by default) — leaves 12 more
+  services with no PDB and every service with no anti-affinity by default.
+- ➖ Lowest risk / smallest diff, but was rejected because the risk of
+  Option A is already minimal (soft/best-effort, matches an existing
+  production reference implementation) and the operational upside
+  (protecting every default install, not just users who discover and flip
+  these settings) is significant.
+
+---
+
+## ✅ **Consequences**
+
+- `charts/kubernaut/templates/_helpers.tpl`: `kubernaut.affinity` signature
+  changed from `(include "kubernaut.affinity" .Values.<service>)` to
+  `(include "kubernaut.affinity" (dict "component" .Values.<service>
+  "matchLabels" (dict "app" "<name>")))`, injecting the default
+  `preferredDuringSchedulingIgnoredDuringExecution` anti-affinity term
+  merged with any user override.
+- All 15 call sites (13 pre-existing + `apifrontend`/`fleetmetadatacache`
+  from PR A) updated to pass their own component's actual pod-selector
+  `matchLabels` (`app: <name>` for 14 services; `app.kubernetes.io/name:
+  fleetmetadatacache` for the one service using that selector scheme).
+- `charts/kubernaut/values.yaml`: `pdb.enabled` flipped from `false` to
+  `true`, and `maxUnavailable: 1` (previously commented out) uncommented,
+  for all 12 services that previously had `pdb.enabled: false`.
+  `datastorage.pdb` changed from `minAvailable: 1` to `maxUnavailable: 1`
+  (bugfix, see Context above). `console`'s and `fleetmetadatacache`'s PDBs
+  still only actually render when the service itself is enabled (existing
+  `pdb.yaml` guard, unchanged).
+- `charts/kubernaut/values.schema.json`: `#/definitions/pdb.properties.
+  enabled.default` changed from `false` to `true` to match.
+- No change to `postgresql`/`valkey`: they already had `kubernaut.affinity`
+  wired (now also gain the default anti-affinity), but are intentionally
+  **not** added to `templates/pdb.yaml`'s loop by this DD — they're
+  typically deployed as a single, disable-and-bring-your-own-infra
+  component (`postgresql.enabled` / `valkey.enabled`), and a PDB was not
+  part of the Operator-parity gap identified for this pass. Can be
+  revisited separately if needed.
+- `helm-unittest` extended to cover: default anti-affinity rendering (and
+  merge behavior with a user override) for a representative sample of
+  services, default PDB `maxUnavailable: 1` rendering, and the
+  `datastorage` `minAvailable`→`maxUnavailable` regression guard.
+- Validated: `helm lint` and `helm template` clean across all three
+  `tls.mode` values; full `helm-unittest` suite green.
+
+## 🔗 Related Decisions
+
+- PR A (apifrontend/fleetmetadatacache hardening gaps): added the
+  `kubernaut.affinity` / `pdb` wiring to these two services that this DD's
+  helper-signature change and default flip then apply to, alongside every
+  other service.
+- Issue #1617: umbrella GitOps/ArgoCD operational readiness work this
+  chart-refactor pass (PRs A/B/C) is part of.

--- a/docs/architecture/decisions/README.md
+++ b/docs/architecture/decisions/README.md
@@ -104,6 +104,7 @@
 | DD-PLATFORM-001 | [cert-manager Inter-Service mTLS Auto-Provisioning](./DD-PLATFORM-001-cert-manager-interservice-mtls.md) | Helm chart (all services) | ✅ Approved | 2026-07-07 | Dedicated internal CA closes SC-8 gap for cert-manager mode |
 | DD-PLATFORM-002 | [Fix ArgoCD PostSync/Health Deadlock for post-install Hook Jobs](./DD-PLATFORM-002-argocd-postsync-health-deadlock.md) | Helm chart (db-migration, interservice-ca-sync) | ✅ Approved | 2026-07-07 | argocd.argoproj.io/hook: Sync override breaks PostSync/health circular dependency |
 | DD-PLATFORM-003 | [Infra-First ArgoCD Sync Wave (Phased Deployment)](./DD-PLATFORM-003-argocd-infra-first-sync-wave.md) | Helm chart (PostgreSQL, Valkey, DataStorage, certs, hook Jobs) | ✅ Approved | 2026-07-07 | sync-wave "-1" for infra/certs/DataStorage reduces CI contention and closes TLS-cert mount race |
+| DD-PLATFORM-004 | [Anti-Affinity and PDB Enabled by Default](./DD-PLATFORM-004-chart-default-hardening.md) | Helm chart (all services) | ✅ Approved | 2026-07-08 | Soft anti-affinity + PDB (maxUnavailable: 1) on by default, matching Kubernaut Operator parity |
 
 **Note**: DD-* prefix is used for detailed design decisions with comprehensive alternatives analysis, implementation strategy, and validation plans. ADR-* prefix is used for architectural records.
 


### PR DESCRIPTION
## Summary

Second of a three-PR sequence (A/B/C) closing chart-refactor/hardening gaps found while
auditing the Helm chart against the Kubernaut Operator's defaults. **Stacked on #1625**
(base branch `feature/1617-gitops-cicd-smoke-tests`, which already includes PR A's
`apifrontend`/`fleetmetadatacache` hardening) since this PR updates the `kubernaut.affinity`
helper's call sites, including the two added by PR A — rebase/merge order: #1625 first, then
this PR.

Closes the remaining Operator-parity gap: the Kubernaut Operator ships **unconditional** soft
pod anti-affinity and a PDB (`maxUnavailable: 1`) for every component
(`kubernaut-operator/internal/resources/deployments.go`, `pdb.go`); the Helm chart shipped
both as opt-in (`enabled: false`, or missing entirely pre-PR-A).

See **[DD-PLATFORM-004](docs/architecture/decisions/DD-PLATFORM-004-chart-default-hardening.md)**
for the full alternatives analysis and a known, accepted limitation.

## Changes

- **`kubernaut.affinity` helper** (`_helpers.tpl`): now injects a default soft
  (`preferred`, weight 100) pod anti-affinity term — `topologyKey:
  kubernetes.io/hostname`, `matchLabels` = the component's own pod-selector labels —
  deep-merged (Sprig `merge`) with any user-supplied `<service>.affinity` override. User
  keys win on conflict; sibling keys (e.g. `nodeAffinity`) merge in additively. Signature
  changed from `(include "kubernaut.affinity" .Values.<service>)` to `(include
  "kubernaut.affinity" (dict "component" .Values.<service> "matchLabels" (dict "app"
  "<name>")))`.
- **All 15 call sites** (13 pre-existing + `apifrontend`/`fleetmetadatacache` from PR A)
  updated to pass their actual pod-selector `matchLabels` (`app: <name>` for 14 services;
  `app.kubernetes.io/name: fleetmetadatacache` for the one service using that scheme —
  verified against each Deployment's real `spec.selector.matchLabels`, not assumed).
- **`values.yaml`**: `pdb.enabled` flipped `false` → `true` with `maxUnavailable: 1`
  (previously commented out) for the 12 services that had it disabled.
- **Bugfix**: `datastorage.pdb` was already `enabled: true` by default, but used
  `minAvailable: 1`. With `datastorage.replicas: 1`, that means **zero voluntary
  disruptions are ever permitted** (`PodDisruptionBudgetAtLimit`) — silently blocking
  `kubectl drain` / cluster-autoscaler / node upgrades indefinitely. Changed to
  `maxUnavailable: 1`, matching the Operator's own explicit test guard against this exact
  failure mode (`pdb_test.go`: `"PDB should not have MinAvailable set (causes
  PodDisruptionBudgetAtLimit with 1 replica)"`).
- **`values.schema.json`**: `#/definitions/pdb.properties.enabled.default` changed
  `false` → `true` to match.
- **New DD-PLATFORM-004** documents the decision and a known, accepted limitation found
  during testing: an explicit empty-list or `null` override of the default anti-affinity
  term is silently discarded by `mergo` (treated as an unset zero-value, so the default
  wins back) — a full override requires the user to supply their own **non-empty**
  `preferredDuringSchedulingIgnoredDuringExecution` list, which does correctly replace the
  default. Accepted rather than worked around because the injected term is `preferred`
  (soft) and therefore never blocks scheduling regardless.
- **README**: "Common Controller Parameters" section updated with the new defaults and
  override/opt-out mechanics.
- **`tests/default_hardening_test.yaml`** (new, 7 tests): default anti-affinity rendering
  for both selector schemes (`app` / `app.kubernetes.io/name`), merge-with-user-`nodeAffinity`
  behavior, full-replacement override behavior, default PDB `maxUnavailable: 1` (including a
  `datastorage` regression guard for the `minAvailable` bug above), and per-service PDB
  opt-out.
- Updated PR A's existing test (`apifrontend_fmc_hardening_test.yaml`) for the new
  PDB-enabled-by-default baseline (it previously assumed all PDBs were disabled by default).

## Test plan

- [x] `helm lint` (default `tls.mode`)
- [x] `helm template` across all three `tls.mode` values (`hook`, `cert-manager`, `manual`)
  — clean render, no errors
- [x] `python -m json.tool values.schema.json` — valid JSON
- [x] Full `helm-unittest` suite: **68/68 passing** (61 from #1625 + 7 new)
- [x] Isolated scratch-chart spike confirming the exact `merge`/`mergo` semantics for: no
  override, empty-list override (fails to opt out — documented as a known limitation),
  sibling-key override (merges in), and non-empty full-replacement override (works)
- [x] Verified each of the 15 `matchLabels` values against the corresponding Deployment's
  actual `spec.selector.matchLabels` (not assumed from naming convention)

Made with [Cursor](https://cursor.com)