### PR TITLE
fix(workflowexecution): eliminate duplicate terminal audit writes on conflict retries (#1597)

### DIFF
--- a/docs/architecture/decisions/DD-WE-009-terminal-audit-ordering.md
+++ b/docs/architecture/decisions/DD-WE-009-terminal-audit-ordering.md
@@ -1,0 +1,247 @@
+# DD-WE-009: Terminal Audit Write Ordering (Duplicate Audit Fix)
+
+**Version**: 1.0
+**Date**: 2026-07-07
+**Status**: APPROVED
+**Author**: WorkflowExecution Team
+**Reviewers**: Platform Team
+
+---
+
+## Context
+
+`MarkCompleted`, `MarkFailed`, and `markFailedInternal` (the shared core of
+`MarkFailedWithReason`/`MarkFailedAsDeduplicated`) each perform a terminal phase
+transition via `StatusManager.AtomicStatusUpdate`, which wraps the caller's closure in
+`k8sretry.RetryOnConflict`:
+
+```go
+func (m *Manager) AtomicStatusUpdate(ctx context.Context, wfe *workflowexecutionv1alpha1.WorkflowExecution, updateFunc func() error) error {
+    return k8sretry.RetryOnConflict(k8sretry.DefaultRetry, func() error {
+        if err := m.client.Get(ctx, client.ObjectKeyFromObject(wfe), wfe); err != nil { // refetch
+            return fmt.Errorf("failed to refetch WorkflowExecution: %w", err)
+        }
+        if err := updateFunc(); err != nil { // caller's closure
+            return fmt.Errorf("failed to apply status updates: %w", err)
+        }
+        if err := m.client.Status().Update(ctx, wfe); err != nil { // may return a conflict
+            return fmt.Errorf("failed to atomically update status: %w", err)
+        }
+        return nil
+    })
+}
+```
+
+Prior to this decision, the three transition helpers (`applyCompletedTransition`,
+`applyFailedStatusTransition`, and `markFailedInternal`'s inline closure) called the
+`AuditManager.RecordWorkflow{Completed,Failed}` audit write and set the `AuditRecorded`
+condition **inside** this closure. Because `RetryOnConflict` re-runs the **entire**
+closure — refetch, phase transition, and audit call — on every optimistic-lock conflict,
+a single logical terminal transition that hit even one conflict produced **N audit
+events for N closure executions**, not one. This is [issue #1597](https://github.com/jordigilh/kubernaut/issues/1597),
+originally surfaced as a follow-up item from
+[DD-WE-008](./DD-WE-008-job-resource-governance-transient-failure-tolerance.md)'s Related
+Documents section during its own audit-completeness preflight.
+
+This directly violates BR-AUDIT-005 / SOC2 CC8.1 ("complete remediation request
+reconstruction from audit traces alone" — a duplicate `workflow.completed` event makes
+the audit trail internally inconsistent, not just noisy) and ADR-032's "No Audit Loss"
+mandate (which is about under-recording, but an over-recording duplicate is an equally
+real trace-integrity defect).
+
+### Why This Wasn't Already Caught
+
+Every other WorkflowExecution unit/integration test exercises the happy path (a fake
+client with no injected conflicts), where `RetryOnConflict`'s closure runs exactly once
+and the bug is invisible. The `AuditRecorded` condition's own integration tests
+(`test/integration/workflowexecution/conditions_integration_test.go`) assert via
+`Eventually(...)` that the condition eventually reaches `True`/`False` — they never
+assert *how many times* the underlying audit write occurred, so they pass regardless of
+this bug.
+
+### Precedent Elsewhere in the Codebase
+
+AIAnalysis and SignalProcessing controllers already record their terminal audit events
+**after** their own `AtomicStatusUpdate` closures return (with idempotency guards
+tracked as `AA-BUG-001`/`SP-BUG-ENRICHMENT-001`), establishing "audit outside the
+retryable closure" as the codebase convention this decision brings WorkflowExecution
+into alignment with.
+
+---
+
+## Decision
+
+Extract the audit-write + `AuditRecorded`-condition-setting logic into a new
+`recordTerminalAudit` helper, called by `MarkCompleted`, `MarkFailed`, and
+`markFailedInternal` **after** their respective primary `AtomicStatusUpdate` has
+durably committed the phase transition — not from inside its closure.
+
+```go
+func (r *WorkflowExecutionReconciler) recordTerminalAudit(
+    ctx context.Context,
+    wfe *workflowexecutionv1alpha1.WorkflowExecution,
+    eventName string,
+    auditFn func(ctx context.Context, wfe *workflowexecutionv1alpha1.WorkflowExecution) error,
+    logger logr.Logger,
+) {
+    succeeded, reason, message := true, weconditions.ReasonAuditSucceeded,
+        fmt.Sprintf("Audit event %s recorded to DataStorage", eventName)
+    if err := auditFn(ctx, wfe); err != nil {
+        succeeded, reason, message = false, weconditions.ReasonAuditFailed,
+            fmt.Sprintf("Failed to record audit event: %v", err)
+    }
+    if err := r.StatusManager.AtomicStatusUpdate(ctx, wfe, func() error {
+        weconditions.SetAuditRecorded(wfe, succeeded, reason, message)
+        return nil
+    }); err != nil {
+        logger.Error(err, "Failed to persist AuditRecorded condition", "event", eventName)
+    }
+}
+```
+
+The audit call itself now executes exactly once per logical transition, regardless of
+how many conflicts the primary `AtomicStatusUpdate` absorbs. The `AuditRecorded`
+condition outcome is then persisted via a **second**, small, idempotent
+`AtomicStatusUpdate` call that only touches that one condition — itself safe to retry
+on conflict, because setting the same condition value twice is a no-op.
+
+This does **not** conflict with [DD-PERF-001](./DD-PERF-001-atomic-status-updates-mandate.md)'s
+atomic-status-update mandate: that mandate targets consolidating multiple **status
+field** writes (phase, counters, timestamps, conditions) that change together as part
+of one state transition into a single API call. It does not require bundling an
+external side effect (a network call to DataStorage) into that same retryable unit —
+doing so is precisely what caused this bug, since network calls are not safe to
+silently re-execute inside a K8s-API-conflict retry loop.
+
+### Cost
+
+One extra `Status().Update()` API call per terminal transition (for the
+`AuditRecorded`-only follow-up), versus the single combined call before this fix. This
+is a fixed, small cost (no loop, no per-conflict multiplication) and is the trade-off
+this decision makes in exchange for audit-count correctness.
+
+---
+
+## Alternatives Considered
+
+### Option A: Move audit outside the closure (Selected)
+
+Described above. Matches the established AIAnalysis/SignalProcessing precedent.
+**Pros**: Audit written exactly once; no schema/API changes; minimal blast radius (one
+file). **Cons**: One extra API call per terminal transition; the `AuditRecorded`
+condition is no longer set atomically with the phase transition (closes in a
+follow-up write instead) — acceptable because existing consumers of that condition
+already poll via `Eventually`, not via same-call atomicity.
+
+### Option B: Client-side idempotency key / dedup on the audit event
+
+Generate a stable idempotency key (e.g. hash of `wfe.UID` + phase + generation) and have
+DataStorage deduplicate on it server-side.
+**Cons**: `event_id` in the audit API is server-generated (`pkg/workflowexecution/audit/manager.go`
+never sets it), so there is no existing request field to carry a client-supplied
+idempotency key. Implementing this would require an OpenAPI schema change to
+`data-storage-v1.yaml`, DataStorage-side dedup logic, and an ogen-client regen — a
+cross-service change disproportionate to this bug's scope.
+**Decision**: Rejected — same conclusion the DD-WE-008 follow-up note already
+anticipated ("needs its own design review"); Option A fixes the bug without touching
+DataStorage at all.
+
+### Option C: In-memory guard flag inside the closure
+
+Set a local `bool` before the first audit call and skip re-recording on closure re-runs.
+**Cons**: The closure is a fresh function value captured by `RetryOnConflict`, but the
+`wfe` object it mutates is **refetched** from the API server at the top of every retry
+(`m.client.Get(...)`), which does not carry any local-only guard state — a package-level
+or captured-variable guard would work only because the closure itself persists across
+retries in the same `RetryOnConflict` call, but this conflates "retry-loop-local
+memory" with "durable state," which is fragile and non-obvious to future maintainers
+compared to Option A's structural fix. Also does not match the existing
+AIAnalysis/SignalProcessing precedent.
+**Decision**: Rejected in favor of the clearer, precedent-aligned Option A.
+
+---
+
+## Validation (Spike Findings)
+
+Two spikes were run against real code (not just static reasoning) before implementation:
+
+1. **Conflict-injection technique**: a `fake.NewClientBuilder()` with
+   `WithInterceptorFuncs(interceptor.Funcs{SubResourceUpdate: ...})` that returns exactly
+   one `apierrors.NewConflict(...)` on the first `Status().Update()` call, then delegates
+   normally. Confirmed this reliably forces `RetryOnConflict` to re-run the closure a
+   second time.
+2. **Bug reproduction**: run against the pre-fix code, the audit-event count scaled 1:1
+   with closure re-executions (2 events for 1 logical completion with one injected
+   conflict) — reproducing #1597 exactly.
+3. **Fix validation**: run against the `recordTerminalAudit`-based fix, the audit-event
+   count stayed at exactly 1 regardless of conflicts injected on either the primary or
+   the follow-up `AtomicStatusUpdate` call, with zero regressions across the full
+   existing `pkg/workflowexecution/...` unit suite and the
+   `test/integration/workflowexecution/...` suite (108/108 passing, including the
+   `AuditRecorded`-condition-count assertions in
+   `conditions_integration_test.go`/`job_lifecycle_integration_test.go`).
+
+These findings are now permanently captured as regression tests `UT-WE-1597-001`
+(`MarkCompleted`), `UT-WE-1597-002` (`MarkFailed`), and `UT-WE-1597-003`
+(`MarkFailedWithReason`) in `pkg/workflowexecution/controller_test.go`.
+
+---
+
+## Affected Components
+
+| Component | Change |
+|---|---|
+| `internal/controller/workflowexecution/workflowexecution_status_marking.go` | New `recordTerminalAudit` helper; `MarkCompleted`/`MarkFailed`/`markFailedInternal` call it after their primary `AtomicStatusUpdate`; audit-recording code removed from `applyCompletedTransition`/`applyFailedStatusTransition`/`markFailedInternal`'s closure |
+| `pkg/workflowexecution/controller_test.go` | New `Describe("Issue #1597: ...")` block: `UT-WE-1597-001/002/003` conflict-injection regression tests |
+
+**Explicitly NOT touched**: `pkg/workflowexecution/audit/manager.go` (audit payload
+construction unchanged), `pkg/workflowexecution/status/manager.go` (`AtomicStatusUpdate`
+itself unchanged — this decision changes how callers use it, not its implementation),
+DataStorage OpenAPI schema/ogen-client (Option B rejected).
+
+---
+
+## Consequences
+
+### Positive
+
+1. `workflow.completed`/`workflow.failed` audit events are recorded exactly once per
+   logical terminal transition, regardless of K8s API optimistic-lock conflicts —
+   closes the BR-AUDIT-005/SOC2 CC8.1 trace-integrity gap.
+2. Brings WorkflowExecution's terminal-audit ordering in line with the existing
+   AIAnalysis/SignalProcessing precedent, reducing the number of distinct patterns for
+   the same architectural concern across controllers.
+3. No schema, API, or cross-service changes required.
+
+### Negative
+
+1. One extra `Status().Update()` call per terminal transition (the `AuditRecorded`-only
+   follow-up) versus the single combined call before this fix.
+2. The `AuditRecorded` condition is no longer guaranteed to reach the API server in the
+   same call as the phase transition — a caller reading `wfe.Status` between the two
+   writes could observe the terminal phase with `AuditRecorded` still absent/stale.
+   Accepted because existing consumers already poll for eventual consistency
+   (`Eventually` in integration tests), not same-call atomicity.
+
+### Neutral
+
+1. `DD-PERF-001`'s atomic-status-update mandate is unaffected — this decision only
+   changes what happens *outside* that pattern (the audit side effect), not the
+   pattern itself.
+
+---
+
+## Related Documents
+
+- [DD-PERF-001: Atomic Status Updates Mandate](./DD-PERF-001-atomic-status-updates-mandate.md) — the pattern this decision does not conflict with (targets status-field consolidation, not audit-call bundling)
+- [DD-WE-008: Job Resource Governance and Transient-Failure Tolerance](./DD-WE-008-job-resource-governance-transient-failure-tolerance.md) — originating follow-up note ("`RetryOnConflict`-wraps-audit-call ordering gap") that led to this decision
+- BR-AUDIT-005 v2.0 (root audit business requirement, defined in `AGENTS.md`) — audit completeness/reconstruction mandate this decision protects
+- [Issue #1597](https://github.com/jordigilh/kubernaut/issues/1597) — originating issue
+
+---
+
+## Document Maintenance
+
+| Date | Version | Changes |
+|---|---|---|
+| 2026-07-07 | 1.0 | Initial decision and implementation |

--- a/internal/controller/workflowexecution/workflowexecution_status_marking.go
+++ b/internal/controller/workflowexecution/workflowexecution_status_marking.go
@@ -111,11 +111,18 @@ func (r *WorkflowExecutionReconciler) MarkCompleted(ctx context.Context, wfe *wo
 	// AFTER: 1 atomic API call (50% reduction)
 	// ========================================
 	if err := r.StatusManager.AtomicStatusUpdate(ctx, wfe, func() error {
-		return r.applyCompletedTransition(ctx, wfe, completionTime, durationVal, summary, logger)
+		return r.applyCompletedTransition(wfe, completionTime, durationVal, summary)
 	}); err != nil {
 		logger.Error(err, "Failed to atomically update status to Completed")
 		return ctrl.Result{}, err
 	}
+
+	// Issue #1597: audit recorded exactly once, AFTER the phase-transition
+	// AtomicStatusUpdate above has durably committed. Previously this call
+	// lived inside that closure and re-fired on every RetryOnConflict retry,
+	// producing duplicate workflow.completed audit events for one logical
+	// completion. See DD-WE-009.
+	r.recordTerminalAudit(ctx, wfe, "workflow.completed", r.AuditManager.RecordWorkflowCompleted, logger)
 
 	// Day 7: Record metrics (BR-WE-008)
 	// DD-METRICS-001: Use injected metrics instead of global function
@@ -169,12 +176,15 @@ func completionTimeAndDuration(wfe *workflowexecutionv1alpha1.WorkflowExecution,
 
 // applyCompletedTransition is the AtomicStatusUpdate callback body for
 // MarkCompleted: transitions the phase to Completed (P0: Phase State
-// Machine), persists completion time/duration/ExecutionStatus, sets the
-// TektonPipelineComplete/Ready conditions (BR-WE-006, Issue #79 Phase 7b),
-// and records the workflow.completed audit event (BR-WE-005, ADR-032).
+// Machine), persists completion time/duration/ExecutionStatus, and sets the
+// TektonPipelineComplete/Ready conditions (BR-WE-006, Issue #79 Phase 7b).
 // Extracted from MarkCompleted (Wave 6 6e-ii GREEN: funlen remediation) —
-// pure code motion, no behavior change.
-func (r *WorkflowExecutionReconciler) applyCompletedTransition(ctx context.Context, wfe *workflowexecutionv1alpha1.WorkflowExecution, completionTime *metav1.Time, durationVal *metav1.Duration, summary []*workflowexecutionv1alpha1.ExecutionStatusSummary, logger logr.Logger) error {
+// pure code motion, no behavior change. Issue #1597: the workflow.completed
+// audit event is recorded by the caller (MarkCompleted) via
+// recordTerminalAudit AFTER this closure commits, not inside it — see
+// DD-WE-009 for why bundling audit into the retryable closure caused
+// duplicate audit writes on conflict retries.
+func (r *WorkflowExecutionReconciler) applyCompletedTransition(wfe *workflowexecutionv1alpha1.WorkflowExecution, completionTime *metav1.Time, durationVal *metav1.Duration, summary []*workflowexecutionv1alpha1.ExecutionStatusSummary) error {
 	if err := r.PhaseManager.TransitionTo(wfe, wephase.Completed); err != nil {
 		return fmt.Errorf("failed to transition to Completed: %w", err)
 	}
@@ -194,18 +204,6 @@ func (r *WorkflowExecutionReconciler) applyCompletedTransition(ctx context.Conte
 
 	// Issue #79 Phase 7b: Set Ready condition on terminal transitions
 	weconditions.SetReady(wfe, true, weconditions.ReasonReady, "Workflow execution completed")
-
-	// Day 8: Record audit event for workflow completion (BR-WE-005, ADR-032)
-	if err := r.AuditManager.RecordWorkflowCompleted(ctx, wfe); err != nil {
-		logger.V(1).Info("Failed to record workflow.completed audit event", "error", err)
-		weconditions.SetAuditRecorded(wfe, false,
-			weconditions.ReasonAuditFailed,
-			fmt.Sprintf("Failed to record audit event: %v", err))
-	} else {
-		weconditions.SetAuditRecorded(wfe, true,
-			weconditions.ReasonAuditSucceeded,
-			"Audit event workflow.completed recorded to DataStorage")
-	}
 
 	return nil
 }
@@ -251,11 +249,16 @@ func (r *WorkflowExecutionReconciler) MarkFailed(ctx context.Context, wfe *workf
 		summary:        summary,
 	}
 	if err := r.StatusManager.AtomicStatusUpdate(ctx, wfe, func() error {
-		return r.applyFailedStatusTransition(ctx, wfe, failedTransition, logger)
+		return r.applyFailedStatusTransition(wfe, failedTransition)
 	}); err != nil {
 		logger.Error(err, "Failed to atomically update status to Failed")
 		return ctrl.Result{}, err
 	}
+
+	// Issue #1597: audit recorded exactly once, AFTER the phase-transition
+	// AtomicStatusUpdate above has durably committed (see MarkCompleted /
+	// DD-WE-009 for the full rationale).
+	r.recordTerminalAudit(ctx, wfe, "workflow.failed", r.AuditManager.RecordWorkflowFailed, logger)
 
 	// Day 7: Record metrics (BR-WE-008)
 	// DD-METRICS-001: Use injected metrics instead of global function
@@ -361,13 +364,14 @@ type failedStatusTransition struct {
 
 // applyFailedStatusTransition is the AtomicStatusUpdate callback body for
 // MarkFailed: transitions the phase to Failed (P0: Phase State Machine),
-// persists completion time/duration/FailureDetails/ExecutionStatus, sets the
-// TektonPipelineComplete/Ready conditions (BR-WE-006, Issue #79 Phase 7b),
-// and records the workflow.failed audit event (BR-WE-005, ADR-032, P3:
-// Audit Manager pattern). Extracted from MarkFailed (Wave 6 6e-ii GREEN:
-// funlen/gocyclo/gocognit remediation) — pure code motion, no behavior
-// change.
-func (r *WorkflowExecutionReconciler) applyFailedStatusTransition(ctx context.Context, wfe *workflowexecutionv1alpha1.WorkflowExecution, t failedStatusTransition, logger logr.Logger) error {
+// persists completion time/duration/FailureDetails/ExecutionStatus, and sets
+// the TektonPipelineComplete/Ready conditions (BR-WE-006, Issue #79 Phase
+// 7b). Extracted from MarkFailed (Wave 6 6e-ii GREEN: funlen/gocyclo/gocognit
+// remediation) — pure code motion, no behavior change. Issue #1597: the
+// workflow.failed audit event is recorded by the caller (MarkFailed) via
+// recordTerminalAudit AFTER this closure commits, not inside it (see
+// DD-WE-009).
+func (r *WorkflowExecutionReconciler) applyFailedStatusTransition(wfe *workflowexecutionv1alpha1.WorkflowExecution, t failedStatusTransition) error {
 	if err := r.PhaseManager.TransitionTo(wfe, wephase.Failed); err != nil {
 		return fmt.Errorf("failed to transition to Failed: %w", err)
 	}
@@ -386,19 +390,6 @@ func (r *WorkflowExecutionReconciler) applyFailedStatusTransition(ctx context.Co
 
 	// Issue #79 Phase 7b: Set Ready condition on terminal transitions
 	weconditions.SetReady(wfe, false, weconditions.ReasonNotReady, "Workflow execution failed")
-
-	// Day 8: Record audit event for workflow failure (BR-WE-005, ADR-032)
-	// Uses Audit Manager (P3: Audit Manager pattern)
-	if err := r.AuditManager.RecordWorkflowFailed(ctx, wfe); err != nil {
-		logger.V(1).Info("Failed to record workflow.failed audit event", "error", err)
-		weconditions.SetAuditRecorded(wfe, false,
-			weconditions.ReasonAuditFailed,
-			fmt.Sprintf("Failed to record audit event: %v", err))
-	} else {
-		weconditions.SetAuditRecorded(wfe, true,
-			weconditions.ReasonAuditSucceeded,
-			"Audit event workflow.failed recorded to DataStorage")
-	}
 
 	return nil
 }
@@ -479,9 +470,14 @@ func (r *WorkflowExecutionReconciler) MarkFailedAsDeduplicated(ctx context.Conte
 
 // markFailedInternal is the shared core for MarkFailedWithReason and
 // MarkFailedAsDeduplicated. It performs the AtomicStatusUpdate with phase
-// transition, completion time, failure details, conditions, audit, and metrics.
+// transition, completion time, failure details, conditions, and metrics.
 // The optional extraUpdates callback runs inside the atomic closure to set
 // method-specific fields (e.g., DeduplicatedBy for the M5 constraint).
+// Issue #1597: the workflow.failed audit event is recorded via
+// recordTerminalAudit AFTER the AtomicStatusUpdate below commits, not inside
+// its closure (see DD-WE-009) — audit calls inside a RetryOnConflict closure
+// re-fire on every conflict-triggered retry, producing duplicate audit
+// writes for one logical transition.
 func (r *WorkflowExecutionReconciler) markFailedInternal(
 	ctx context.Context,
 	wfe *workflowexecutionv1alpha1.WorkflowExecution,
@@ -507,27 +503,51 @@ func (r *WorkflowExecutionReconciler) markFailedInternal(
 		weconditions.SetExecutionCreated(wfe, false, conditionReason, conditionMessage)
 		weconditions.SetReady(wfe, false, weconditions.ReasonNotReady, "Workflow execution failed")
 
-		if err := r.AuditManager.RecordWorkflowFailed(ctx, wfe); err != nil {
-			logger.V(1).Info("Failed to record workflow.failed audit event", "error", err)
-			weconditions.SetAuditRecorded(wfe, false,
-				weconditions.ReasonAuditFailed,
-				fmt.Sprintf("Failed to record audit event: %v", err))
-		} else {
-			weconditions.SetAuditRecorded(wfe, true,
-				weconditions.ReasonAuditSucceeded,
-				"Audit event workflow.failed recorded to DataStorage")
-		}
-
 		return nil
 	}); err != nil {
 		logger.Error(err, "Failed to atomically update status to Failed")
 		return err
 	}
 
+	r.recordTerminalAudit(ctx, wfe, "workflow.failed", r.AuditManager.RecordWorkflowFailed, logger)
+
 	if r.Metrics != nil {
 		r.Metrics.RecordWorkflowFailure(0)
 	}
 	return nil
+}
+
+// recordTerminalAudit (Issue #1597) records a terminal-transition audit
+// event exactly once, AFTER the caller's primary AtomicStatusUpdate has
+// durably committed the phase transition, then persists the outcome via a
+// second, idempotent AtomicStatusUpdate that only touches the AuditRecorded
+// condition. This replaces the prior pattern of calling auditFn and setting
+// AuditRecorded INSIDE the primary AtomicStatusUpdate's RetryOnConflict
+// closure, which re-ran the audit call on every conflict-triggered retry —
+// producing duplicate audit writes for a single logical transition. See
+// DD-WE-009 and DD-PERF-001 (the atomic-status-update mandate targets status
+// *field* consolidation, not audit-call bundling).
+func (r *WorkflowExecutionReconciler) recordTerminalAudit(
+	ctx context.Context,
+	wfe *workflowexecutionv1alpha1.WorkflowExecution,
+	eventName string,
+	auditFn func(ctx context.Context, wfe *workflowexecutionv1alpha1.WorkflowExecution) error,
+	logger logr.Logger,
+) {
+	succeeded, reason, message := true, weconditions.ReasonAuditSucceeded,
+		fmt.Sprintf("Audit event %s recorded to DataStorage", eventName)
+	if err := auditFn(ctx, wfe); err != nil {
+		logger.V(1).Info(fmt.Sprintf("Failed to record %s audit event", eventName), "error", err)
+		succeeded, reason, message = false, weconditions.ReasonAuditFailed,
+			fmt.Sprintf("Failed to record audit event: %v", err)
+	}
+
+	if err := r.StatusManager.AtomicStatusUpdate(ctx, wfe, func() error {
+		weconditions.SetAuditRecorded(wfe, succeeded, reason, message)
+		return nil
+	}); err != nil {
+		logger.Error(err, "Failed to persist AuditRecorded condition", "event", eventName)
+	}
 }
 
 // ========================================

--- a/pkg/workflowexecution/controller_test.go
+++ b/pkg/workflowexecution/controller_test.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -31,13 +32,16 @@ import (
 	tektonv1 "github.com/tektoncd/pipeline/pkg/apis/pipeline/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"knative.dev/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	workflowexecutionv1alpha1 "github.com/jordigilh/kubernaut/api/workflowexecution/v1alpha1"
@@ -1179,6 +1183,202 @@ var _ = Describe("WorkflowExecution Controller", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(result.RequeueAfter).To(Equal(1*time.Minute),
 				"MarkFailed must schedule RequeueAfter so ReconcileTerminal runs to release the lock (#375)")
+		})
+	})
+
+	// ========================================
+	// Issue #1597: duplicate audit writes on RetryOnConflict retries
+	//
+	// Root cause: MarkCompleted/MarkFailed/MarkFailedWithReason recorded the
+	// terminal audit event INSIDE the AtomicStatusUpdate closure. When
+	// Status().Update() hit an optimistic-lock conflict, RetryOnConflict
+	// re-ran the ENTIRE closure — including the audit call — producing one
+	// duplicate audit write per retry for a single logical transition.
+	//
+	// Fix (DD-WE-009): audit is now recorded by recordTerminalAudit AFTER the
+	// primary AtomicStatusUpdate durably commits, then the AuditRecorded
+	// condition outcome is persisted via a second, idempotent
+	// AtomicStatusUpdate. These tests inject exactly one conflict on the
+	// FIRST Status().Update() call (via interceptor.Funcs) to prove the
+	// audit event count stays at 1 regardless of retries.
+	// ========================================
+	Describe("Issue #1597: terminal audit recorded exactly once despite conflict retries", func() {
+		// newConflictOnFirstAttemptClient builds a fake client whose FIRST
+		// Status().Update() call fails with a conflict (simulating a
+		// concurrent writer winning the race), then succeeds on every
+		// subsequent call. Returns the client and a counter of total
+		// SubResourceUpdate attempts observed.
+		newConflictOnFirstAttemptClient := func(objs ...client.Object) (client.Client, *int32) {
+			var attempts int32
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objs...).
+				WithStatusSubresource(objs...).
+				WithInterceptorFuncs(interceptor.Funcs{
+					SubResourceUpdate: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+						if atomic.AddInt32(&attempts, 1) == 1 {
+							return apierrors.NewConflict(
+								schema.GroupResource{Group: "workflowexecution.kubernaut.ai", Resource: "workflowexecutions"},
+								obj.GetName(),
+								fmt.Errorf("simulated concurrent status write"),
+							)
+						}
+						return c.Status().Update(ctx, obj, opts...)
+					},
+				}).
+				Build()
+			return fakeClient, &attempts
+		}
+
+		It("UT-WE-1597-001: MarkCompleted records exactly one workflow.completed audit event despite a conflict retry", func() {
+			startTime := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+			wfe := &workflowexecutionv1alpha1.WorkflowExecution{
+				ObjectMeta: metav1.ObjectMeta{Name: "wfe-1597-completed", Namespace: "default"},
+				Spec: workflowexecutionv1alpha1.WorkflowExecutionSpec{
+					TargetResource: "default/deployment/app-1597",
+					WorkflowRef: workflowexecutionv1alpha1.WorkflowRef{
+						WorkflowID:      "restart-deployment",
+						ExecutionBundle: "ghcr.io/kubernaut/workflows/restart:v1.0.0",
+					},
+				},
+				Status: workflowexecutionv1alpha1.WorkflowExecutionStatus{
+					Phase:     workflowexecutionv1alpha1.PhaseRunning,
+					StartTime: &startTime,
+				},
+			}
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      weexecutor.ExecutionResourceName(wfe.Spec.TargetResource),
+					Namespace: "kubernaut-workflows",
+				},
+			}
+
+			fakeClient, attempts := newConflictOnFirstAttemptClient(wfe)
+			auditStore := &mockAuditStore{events: make([]*ogenclient.AuditEventRequest, 0)}
+			reconciler := &workflowexecution.WorkflowExecutionReconciler{
+				Client:             fakeClient,
+				Scheme:             scheme,
+				Recorder:           recorder,
+				ExecutionNamespace: "kubernaut-workflows",
+				AuditStore:         auditStore,
+				StatusManager:      status.NewManager(fakeClient),
+				AuditManager:       audit.NewManager(auditStore, logr.Discard()),
+			}
+
+			_, err := reconciler.MarkCompleted(ctx, wfe, pr)
+			Expect(err).ToNot(HaveOccurred(), "RetryOnConflict must absorb the injected conflict and succeed")
+			Expect(atomic.LoadInt32(attempts)).To(BeNumerically(">=", 2),
+				"the injected conflict must have forced at least one retry")
+
+			Expect(auditStore.events).To(HaveLen(1),
+				"exactly one workflow.completed audit event must be recorded despite the conflict retry")
+
+			var updated workflowexecutionv1alpha1.WorkflowExecution
+			Expect(reconciler.Get(ctx, client.ObjectKeyFromObject(wfe), &updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(workflowexecutionv1alpha1.PhaseCompleted))
+			cond := meta.FindStatusCondition(updated.Status.Conditions, "AuditRecorded")
+			Expect(cond).ToNot(BeNil(), "AuditRecorded condition must be persisted")
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+		})
+
+		It("UT-WE-1597-002: MarkFailed records exactly one workflow.failed audit event despite a conflict retry", func() {
+			startTime := metav1.NewTime(time.Now().Add(-45 * time.Second))
+			wfe := &workflowexecutionv1alpha1.WorkflowExecution{
+				ObjectMeta: metav1.ObjectMeta{Name: "wfe-1597-failed", Namespace: "default"},
+				Spec: workflowexecutionv1alpha1.WorkflowExecutionSpec{
+					TargetResource: "default/deployment/failing-app-1597",
+					WorkflowRef: workflowexecutionv1alpha1.WorkflowRef{
+						WorkflowID:      "restart-deployment",
+						ExecutionBundle: "ghcr.io/kubernaut/workflows/restart:v1.0.0",
+					},
+				},
+				Status: workflowexecutionv1alpha1.WorkflowExecutionStatus{
+					Phase:     workflowexecutionv1alpha1.PhaseRunning,
+					StartTime: &startTime,
+				},
+			}
+			pr := &tektonv1.PipelineRun{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      weexecutor.ExecutionResourceName(wfe.Spec.TargetResource),
+					Namespace: "kubernaut-workflows",
+				},
+			}
+			pr.Status.SetCondition(&apis.Condition{
+				Type:    apis.ConditionSucceeded,
+				Status:  corev1.ConditionFalse,
+				Reason:  "Failed",
+				Message: "Task 'apply-memory-increase' failed: permission denied",
+			})
+
+			fakeClient, attempts := newConflictOnFirstAttemptClient(wfe)
+			auditStore := &mockAuditStore{events: make([]*ogenclient.AuditEventRequest, 0)}
+			reconciler := &workflowexecution.WorkflowExecutionReconciler{
+				Client:             fakeClient,
+				Scheme:             scheme,
+				Recorder:           recorder,
+				ExecutionNamespace: "kubernaut-workflows",
+				AuditStore:         auditStore,
+				StatusManager:      status.NewManager(fakeClient),
+				AuditManager:       audit.NewManager(auditStore, logr.Discard()),
+			}
+
+			_, err := reconciler.MarkFailed(ctx, wfe, pr)
+			Expect(err).ToNot(HaveOccurred(), "RetryOnConflict must absorb the injected conflict and succeed")
+			Expect(atomic.LoadInt32(attempts)).To(BeNumerically(">=", 2),
+				"the injected conflict must have forced at least one retry")
+
+			Expect(auditStore.events).To(HaveLen(1),
+				"exactly one workflow.failed audit event must be recorded despite the conflict retry")
+
+			var updated workflowexecutionv1alpha1.WorkflowExecution
+			Expect(reconciler.Get(ctx, client.ObjectKeyFromObject(wfe), &updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(workflowexecutionv1alpha1.PhaseFailed))
+			cond := meta.FindStatusCondition(updated.Status.Conditions, "AuditRecorded")
+			Expect(cond).ToNot(BeNil(), "AuditRecorded condition must be persisted")
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
+		})
+
+		It("UT-WE-1597-003: MarkFailedWithReason records exactly one workflow.failed audit event despite a conflict retry", func() {
+			wfe := &workflowexecutionv1alpha1.WorkflowExecution{
+				ObjectMeta: metav1.ObjectMeta{Name: "wfe-1597-preexec-failed", Namespace: "default"},
+				Spec: workflowexecutionv1alpha1.WorkflowExecutionSpec{
+					TargetResource: "default/deployment/quota-app-1597",
+					WorkflowRef: workflowexecutionv1alpha1.WorkflowRef{
+						WorkflowID:      "restart-deployment",
+						ExecutionBundle: "ghcr.io/kubernaut/workflows/restart:v1.0.0",
+					},
+				},
+				Status: workflowexecutionv1alpha1.WorkflowExecutionStatus{
+					Phase: workflowexecutionv1alpha1.PhasePending,
+				},
+			}
+
+			fakeClient, attempts := newConflictOnFirstAttemptClient(wfe)
+			auditStore := &mockAuditStore{events: make([]*ogenclient.AuditEventRequest, 0)}
+			reconciler := &workflowexecution.WorkflowExecutionReconciler{
+				Client:             fakeClient,
+				Scheme:             scheme,
+				Recorder:           recorder,
+				ExecutionNamespace: "kubernaut-workflows",
+				AuditStore:         auditStore,
+				StatusManager:      status.NewManager(fakeClient),
+				AuditManager:       audit.NewManager(auditStore, logr.Discard()),
+			}
+
+			err := reconciler.MarkFailedWithReason(ctx, wfe, "QuotaExceeded", "namespace quota exceeded")
+			Expect(err).ToNot(HaveOccurred(), "RetryOnConflict must absorb the injected conflict and succeed")
+			Expect(atomic.LoadInt32(attempts)).To(BeNumerically(">=", 2),
+				"the injected conflict must have forced at least one retry")
+
+			Expect(auditStore.events).To(HaveLen(1),
+				"exactly one workflow.failed audit event must be recorded despite the conflict retry")
+
+			var updated workflowexecutionv1alpha1.WorkflowExecution
+			Expect(reconciler.Get(ctx, client.ObjectKeyFromObject(wfe), &updated)).To(Succeed())
+			Expect(updated.Status.Phase).To(Equal(workflowexecutionv1alpha1.PhaseFailed))
+			cond := meta.FindStatusCondition(updated.Status.Conditions, "AuditRecorded")
+			Expect(cond).ToNot(BeNil(), "AuditRecorded condition must be persisted")
+			Expect(cond.Status).To(Equal(metav1.ConditionTrue))
 		})
 	})
 


### PR DESCRIPTION
## Summary

- `MarkCompleted`/`MarkFailed`/`MarkFailedWithReason` recorded the terminal audit event (`workflow.completed`/`workflow.failed`) **inside** the `AtomicStatusUpdate` closure. Since `RetryOnConflict` re-runs the entire closure on every optimistic-lock conflict, a single logical transition that hit even one conflict produced duplicate audit events — violating BR-AUDIT-005/SOC2 CC8.1 trace integrity.
- Extracted the audit write + `AuditRecorded` condition into a new `recordTerminalAudit` helper, called **after** the primary `AtomicStatusUpdate` durably commits (not from inside its retryable closure), aligning WorkflowExecution with the existing AIAnalysis/SignalProcessing precedent.
- Adds `DD-WE-009` documenting the decision, rejected alternatives, and spike validation.

Closes #1597.

## Test plan

- [x] `UT-WE-1597-001/002/003`: new conflict-injection regression tests (via `interceptor.Funcs`) proving exactly one audit event is recorded per logical transition despite a forced `Status().Update()` conflict, for `MarkCompleted`, `MarkFailed`, and `MarkFailedWithReason` respectively.
- [x] Verified RED: all 3 tests fail against the pre-fix code (audit count scales with conflict retries).
- [x] Verified GREEN: all 3 tests pass against the fix.
- [x] Full unit suite (`pkg/workflowexecution/...`, `internal/controller/workflowexecution/...`) — pass, zero regressions.
- [x] Full integration suite (`make test-integration-workflowexecution`) — 108/108 pass, including `AuditRecorded`-condition assertions in `conditions_integration_test.go`/`job_lifecycle_integration_test.go`.
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` — clean.

Made with [Cursor](https://cursor.com)