### PR TITLE
fix(kubernautagent): eliminate goroutine-completion race in UT-KA-1390-027 (#1631)

### DIFF
--- a/internal/kubernautagent/session/manager_upgrade_test.go
+++ b/internal/kubernautagent/session/manager_upgrade_test.go
@@ -260,7 +260,18 @@ var _ = Describe("Fix #1390: Jump-In Session Upgrade (BR-INTERACTIVE-004, BR-REL
 
 		Context("UT-KA-1390-027 [SC-24]: store.Update with StatusCompleted + interactiveUpgrade=true forces StatusUserDriving", func() {
 			It("should force user_driving and set InteractiveHold when upgrade flag was set before completion", func() {
+				// Issue #1631: the investigation function must not return until
+				// UpgradeToInteractive has run, otherwise the goroutine can win the
+				// race and call store.Update(StatusCompleted) before the upgrade
+				// flag is set — collapsing this into the UT-KA-1390-029 scenario
+				// (ErrSessionTerminal) instead of exercising the intended
+				// "upgrade before completion" ordering. Same ready/proceed gate
+				// used by UT-KA-1390-008 above.
+				ready := make(chan struct{})
+				proceed := make(chan struct{})
 				id, err := manager.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+					close(ready)
+					<-proceed
 					return &katypes.InvestigationResult{
 						RCASummary:      "Autonomous RCA — investigator did not see upgrade flag",
 						Confidence:      0.9,
@@ -269,7 +280,9 @@ var _ = Describe("Fix #1390: Jump-In Session Upgrade (BR-INTERACTIVE-004, BR-REL
 				}, map[string]string{"remediation_id": "rr-upgrade-027"})
 				Expect(err).NotTo(HaveOccurred())
 
+				<-ready
 				Expect(manager.UpgradeToInteractive(id, "testuser", nil)).To(Succeed())
+				close(proceed)
 
 				Eventually(func() session.Status {
 					s, _ := manager.GetSession(id)


### PR DESCRIPTION
## Summary

Closes #1631.

`UT-KA-1390-027` intermittently failed in CI with `session is in terminal state`. Root cause (full RCA in #1631): this is a **test-synchronization bug**, not a production regression.

- The test's investigation function returned immediately with no synchronization gate.
- `launchInvestigation` (`internal/kubernautagent/session/manager.go:182-205`) synchronously sets `StatusRunning` and spawns the goroutine *before* `StartInvestigation` returns — so with a zero-delay `fn`, the goroutine can call `store.Update(StatusCompleted, ...)` before the test's next statement reaches `UpgradeToInteractive`.
- This is confirmed **not** a production bug: the sibling test `UT-KA-1390-029` (same file) already proves the opposite ordering — "completion wins the race" — is the *intended* behavior, with an explicit comment: `"upgrade on a completed session must fail so handleStart falls back to ForceTransitionToUserDriving"`.

Fix: apply the same `ready`/`proceed` channel-gate synchronization pattern already used by the neighboring `UT-KA-1390-008` test in the same file, guaranteeing `UpgradeToInteractive` runs before the investigation function is allowed to return.

No production code changed.

## Test plan

- [x] `go build ./internal/kubernautagent/...` — clean.
- [x] `go vet ./internal/kubernautagent/session/...` — clean.
- [x] `golangci-lint run ./internal/kubernautagent/session/...` — 0 issues.
- [x] `go test ./internal/kubernautagent/session/... -race -count=1` — full package suite passes.
- [x] `UT-KA-1390-027/028/029` run 30x consecutively with `-race` — 30/30 pass (previously intermittently failed without the fix).

Made with [Cursor](https://cursor.com)