### PR TITLE
fix(helm): split CRD-bundling ConfigMap per-CRD to fix GitOps client-side-apply size limit

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -1391,13 +1391,6 @@ jobs:
             destination:
               server: https://kubernetes.default.svc
               namespace: ${GITOPS_NAMESPACE}
-            # #1617 spike finding: the chart's bundled-CRDs ConfigMap (consumed by the
-            # crd-upgrade hook) is large enough that ArgoCD's default client-side apply
-            # fails with "metadata.annotations: Too long: may not be more than 262144
-            # bytes". ServerSideApply is required at the Application level.
-            syncPolicy:
-              syncOptions:
-                - ServerSideApply=true
           EOF
           argocd app list
 

--- a/charts/kubernaut/templates/hooks/crd-upgrade-job.yaml
+++ b/charts/kubernaut/templates/hooks/crd-upgrade-job.yaml
@@ -2,23 +2,34 @@
 # This pre-upgrade hook applies CRDs via server-side apply so schema changes
 # (field additions, removals, default changes) take effect on upgrade.
 # See: https://helm.sh/docs/chart_best_practices/custom_resource_definitions/
+#
+# #1641: one ConfigMap per CRD file, not a single bundled ConfigMap. A single
+# ConfigMap holding all 10 CRDs' full YAML is ~288 KB, which exceeds the
+# 262144-byte Kubernetes annotation-size limit once GitOps tools (ArgoCD,
+# Flux) or plain `kubectl apply` store it in the client-side-apply
+# `kubectl.kubernetes.io/last-applied-configuration` annotation for 3-way
+# merge diffing. The largest individual CRD is ~62 KB, leaving ~4x headroom
+# per ConfigMap -- fixing the root cause (object size) instead of an
+# ArgoCD-only `ServerSideApply` sync-option workaround (which wouldn't help
+# Flux users). The Job's own cluster-side apply already uses
+# `kubectl apply --server-side`; this is unrelated to that.
+{{- range $path, $_ := .Files.Glob "files/crds/*.yaml" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "kubernaut.fullname" . }}-crd-manifests
-  namespace: {{ .Release.Namespace }}
+  name: {{ include "kubernaut.fullname" $ }}-crd-{{ $path | base | trimPrefix "kubernaut.ai_" | trimSuffix ".yaml" }}
+  namespace: {{ $.Release.Namespace }}
   labels:
-    {{- include "kubernaut.labels" . | nindent 4 }}
+    {{- include "kubernaut.labels" $ | nindent 4 }}
   annotations:
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-3"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 data:
-  {{- range $path, $_ := .Files.Glob "files/crds/*.yaml" }}
   {{ $path | base }}: |
     {{- $.Files.Get $path | nindent 4 }}
-  {{- end }}
 ---
+{{- end }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -46,8 +57,17 @@ spec:
       {{- include "kubernaut.scheduling" (dict "component" .Values.hooks "global" .Values.global) | nindent 6 }}
       volumes:
         - name: crds
-          configMap:
-            name: {{ include "kubernaut.fullname" . }}-crd-manifests
+          # #1641: projected volume merging one configMap source per CRD ConfigMap
+          # (see the ConfigMap block above). Each ConfigMap has exactly one
+          # uniquely-named data key (the original CRD filename), so this merges
+          # flatly into /crds with no collisions -- the hook script's
+          # `for f in /crds/*.yaml` loop below is unaffected.
+          projected:
+            sources:
+              {{- range $path, $_ := .Files.Glob "files/crds/*.yaml" }}
+              - configMap:
+                  name: {{ include "kubernaut.fullname" $ }}-crd-{{ $path | base | trimPrefix "kubernaut.ai_" | trimSuffix ".yaml" }}
+              {{- end }}
       containers:
         - name: apply-crds
           # Reuses the shared kubectl image from hooks.tlsCerts.image

--- a/charts/kubernaut/tests/crd_manifests_split_test.yaml
+++ b/charts/kubernaut/tests/crd_manifests_split_test.yaml
@@ -1,0 +1,87 @@
+suite: CRD manifests split per-CRD to fix GitOps client-side-apply size limit (#1641)
+templates:
+  - templates/hooks/crd-upgrade-job.yaml
+set:
+  postgresql:
+    auth:
+      existingSecret: dummy
+  valkey:
+    existingSecret: dummy
+  kubernautAgent:
+    llm:
+      provider: openai
+      model: gpt-4
+tests:
+  # hasDocuments counts all documents in the template's rendered output; it
+  # does not apply documentSelector filtering (verified empirically -- see
+  # PR description). 10 per-CRD ConfigMaps + 1 Job = 11, vs. the pre-fix
+  # 1 bundled ConfigMap + 1 Job = 2. The per-field assertions below (which DO
+  # apply the selector) independently confirm the 10 matched documents are
+  # actually ConfigMaps with the expected shape.
+  - it: "renders 10 separate per-CRD ConfigMaps plus the Job (was 1 ConfigMap + 1 Job = 2 documents)"
+    asserts:
+      - hasDocuments:
+          count: 11
+
+  - it: "each per-CRD ConfigMap carries the pre-upgrade hook annotations"
+    documentSelector:
+      path: kind
+      value: ConfigMap
+      matchMany: true
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: pre-upgrade
+      - equal:
+          path: metadata.annotations["helm.sh/hook-weight"]
+          value: "-3"
+      - equal:
+          path: metadata.annotations["helm.sh/hook-delete-policy"]
+          value: before-hook-creation,hook-succeeded
+
+  - it: "each per-CRD ConfigMap's data is non-empty (one CRD manifest embedded)"
+    documentSelector:
+      path: kind
+      value: ConfigMap
+      matchMany: true
+    asserts:
+      - notEqual:
+          path: data
+          value: {}
+
+  - it: "the crd-upgrade Job mounts CRDs via a projected volume with one source per CRD"
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: crds
+      - isNull:
+          path: spec.template.spec.volumes[0].configMap
+      - isNotNull:
+          path: spec.template.spec.volumes[0].projected
+      - lengthEqual:
+          path: spec.template.spec.volumes[0].projected.sources
+          count: 10
+
+  - it: "the crd-upgrade Job's volume mount path and read-only flag are unchanged"
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].mountPath
+          value: /crds
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].readOnly
+          value: true
+
+  - it: "the Job's kubectl apply loop and RBAC wait script are unchanged (only the volume source changed)"
+    documentSelector:
+      path: kind
+      value: Job
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: "kubectl apply --server-side --force-conflicts -f"


### PR DESCRIPTION
## Summary

Closes #1641, closes #1617 (split out of #1617's "New gap found" spike finding; this was the last of the 4 suggested next steps on #1617, so this PR completes it too).

- The chart's `crd-upgrade` pre-upgrade hook bundled all 10 CRDs' full YAML into a **single** ConfigMap (~288 KB combined; largest CRD alone, `kubernaut.ai_aianalyses.yaml`, is ~62 KB). That fits under etcd's 1 MiB object limit, but breaks **client-side apply** — the default sync mechanism for ArgoCD, Flux, and plain `kubectl apply` — which stores a full copy of the object in the `kubectl.kubernetes.io/last-applied-configuration` annotation for 3-way-merge diffing, capped at 262144 total annotation bytes:
  ```
  metadata.annotations: Too long: may not be more than 262144 bytes
  ```
- Fixed by splitting into **one ConfigMap per CRD** (`{{ fullname }}-crd-<plural>`, sanitized from the source filename to satisfy DNS-1123 subdomain naming — the raw filename contains `_`/`.` which aren't valid), and switching the Job's `crds` volume from a single `configMap` source to a `projected` volume with one `configMap` source per CRD. Since each ConfigMap has exactly one uniquely-named data key (the original filename), they merge flatly under the same `/crds` mount path — **zero changes** to the hook script's `for f in /crds/*.yaml` loop or to the Job's own cluster-side `kubectl apply --server-side --force-conflicts` loop.
- **Why split instead of the `ServerSideApply` sync-option annotation** (the fallback #1617 originally proposed, and what's live in CI today as a stopgap): that annotation is ArgoCD-specific — Flux has no equivalent, so it would leave Flux users with the same failure. Splitting fixes the actual root cause (object size), working identically under ArgoCD, Flux, and plain `kubectl`/`helm upgrade`, with no GitOps-tool-specific configuration required from chart consumers.
- Removed the now-unnecessary `syncOptions: [ServerSideApply=true]` workaround from the CI GitOps smoke test's ArgoCD `Application` manifest (`ci-pipeline.yml`), so that job's ArgoCD sync now empirically proves the fix works via **default** client-side apply — per #1641's acceptance criteria ("no `ServerSideApply` sync-option annotation required").

## Validation

- `helm-unittest`: 74/74 passing (68 pre-existing + 6 new in `charts/kubernaut/tests/crd_manifests_split_test.yaml`) — covers document count, per-ConfigMap hook annotations, non-empty data, the Job's `projected` volume shape (10 sources, no `configMap` volume), unchanged mount path/readOnly, and unchanged `kubectl apply` command.
- `helm lint` clean for all three `tls.mode` values (`hook`, `cert-manager`, `manual`).
- `helm template` rendered and measured: the largest per-CRD ConfigMap (`aianalyses`) is **~70 KB — 26.7% of the 262144-byte limit**, comfortably within the ~4x headroom the issue predicted; all 10 ConfigMaps render with correct, DNS-1123-valid names and the Job's projected volume lists all 10 by name.
- CI: the existing `helm-smoke-test` job's `cert-manager` matrix leg (added in #1625) exercises this fix live against a real Kind + ArgoCD cluster — will confirm green in this PR's checks.

## Test plan

- [x] `helm unittest charts/kubernaut/` passes (74/74)
- [x] `helm lint` clean for `hook`/`cert-manager`/`manual`
- [x] `helm template` + size measurement confirms all 10 ConfigMaps are well under the 262144-byte limit
- [ ] CI: `helm-smoke-test` (`cert-manager` leg, ArgoCD GitOps validation) green with the `ServerSideApply` workaround removed

Made with [Cursor](https://cursor.com)
