### PR TITLE
fix(datastorage,workflowexecution): remove execution.bundle pre-flight registry check; extend Job-engine image-pull observability

### DIFF
--- a/docs/architecture/decisions/ADR-060-parallel-workflow-validation.md
+++ b/docs/architecture/decisions/ADR-060-parallel-workflow-validation.md
@@ -1,21 +1,30 @@
 # ADR-060: Parallel Workflow Validation
 
 **Date**: May 9, 2026
-**Status**: Approved
+**Status**: Superseded — Pattern 1 (typed-result-slot parallelism) retired by Issue #1642; see [Update: Post-#1481/#1642](#update-post-1481-1642) below
 **Version**: 1.0
-**Authority**: AUTHORITATIVE for workflow registration validation concurrency patterns
+**Authority**: AUTHORITATIVE for workflow registration validation concurrency patterns (historical — Pattern 2 remains active for `ValidateDependencies` callers outside registration)
 **Related**: DD-WE-006 (Schema-Declared Dependencies), DD-WORKFLOW-016 (Action Type Taxonomy), ADR-058 (Webhook-Driven Registration), BR-STORAGE-014 (Workflow Catalog Management)
 **GitHub Issue**: [#1070](https://github.com/jordigilh/kubernaut/issues/1070)
 
 ---
 
+## Update: Post-#1481/#1642
+
+Both of the two checks this ADR parallelized alongside action-type taxonomy have since been removed from `HandleCreateWorkflow`:
+
+- **Issue #1481** removed step 5c, schema-declared dependency existence validation (`ValidateDependencies`). Kubernetes now validates dependency existence exclusively at runtime when the WorkflowExecution's Job/PipelineRun attempts to mount the volume/workspace (BR-WORKFLOW-008).
+- **Issue #1642** removed step 5b, execution bundle existence validation (`ValidateBundleExists`). A pre-flight registry check running from the DataStorage pod's own network/credential context cannot validate self-signed or credential-required private registries reachable only by the actual workflow execution environment, so the check unconditionally blocked otherwise-valid registrations. Kubernetes now fails fast at Job/PipelineRun image-pull time instead, extending the same BR-WORKFLOW-008 pattern.
+
+With only the action-type taxonomy check remaining, Pattern 1 (typed-result-slot + `sync.WaitGroup`) no longer parallelizes anything and has been collapsed back into a direct sequential call in `validateExternalChecks`. The historical context below (Context, Decision, Consequences, Alternatives) is preserved for reference but no longer describes the current implementation of `HandleCreateWorkflow`. Pattern 2 (`errgroup` inside `ValidateDependencies`) remains relevant wherever that validator is still invoked outside the registration path.
+
 ## Context
 
-`HandleCreateWorkflow` performs three independent external validation checks during workflow registration:
+`HandleCreateWorkflow` performed three independent external validation checks during workflow registration:
 
 1. **Action-type taxonomy** (PostgreSQL query via `ActionTypeExists`)
-2. **Execution bundle existence** (OCI registry HEAD via `ValidateBundleExists`)
-3. **Schema-declared dependencies** (Kubernetes API GETs via `ValidateDependencies`)
+2. **Execution bundle existence** (OCI registry HEAD via `ValidateBundleExists`) — removed, Issue #1642
+3. **Schema-declared dependencies** (Kubernetes API GETs via `ValidateDependencies`) — removed, Issue #1481
 
 Prior to this change, these checks ran sequentially. Each call could take 50-500ms depending on backend latency, making worst-case registration latency the sum of all three (up to 1.5s+). Since the checks are independent, parallelization reduces wall-clock time to the duration of the slowest check.
 
@@ -48,7 +57,7 @@ A 10-second `context.WithTimeout` wraps the entire `validateExternalChecks` call
 
 - Registration latency reduced from sum-of-three to max-of-three (typically 30-60% improvement)
 - Per-phase Prometheus histograms (`datastorage_workflow_validation_duration_seconds`) provide observability into individual backend latencies
-- Error priority contract is preserved and locked by unit tests (UT-WF-1070-001 through 005)
+- Error priority contract was preserved and locked by unit tests (UT-WF-1070-001, -002, -004; -003 was removed with the bundle-not-found error type it covered — Issue #1642)
 
 ### Negative
 

--- a/docs/architecture/decisions/DD-WORKFLOW-017-workflow-lifecycle-component-interactions.md
+++ b/docs/architecture/decisions/DD-WORKFLOW-017-workflow-lifecycle-component-interactions.md
@@ -728,7 +728,7 @@ This DD **supersedes**:
 - **Priority**: P0 (blocking for DD-004 compliance)
 - **Description**: All HTTP error responses (4xx, 5xx) from workflow registration and lifecycle management endpoints MUST use RFC 7807 Problem Details format per DD-004. Each error response must include the `type` URI (`https://kubernaut.ai/problems/{error-type}`), `title`, `detail`, `status`, and `instance` fields, with `Content-Type: application/problem+json`.
 - **Acceptance Criteria**:
-  - All validation errors (400, 409, 422, 502) during registration use RFC 7807 format with domain-specific error types (e.g., `unknown-action-type`, `duplicate-workflow`, `schema-not-found`, `image-pull-failed`)
+  - All validation errors (400, 409, 422, 502) during registration use RFC 7807 format with domain-specific error types (e.g., `unknown-action-type`, `duplicate-workflow`, `schema-not-found`)
   - Invalid lifecycle transitions return 409 with error type `invalid-transition` and actionable `detail` text
   - Missing mandatory `reason` field on lifecycle PATCH endpoints returns 400 with error type `validation-error`
   - `Content-Type: application/problem+json` header is set on all error responses

--- a/docs/testing/299/TEST_PLAN.md
+++ b/docs/testing/299/TEST_PLAN.md
@@ -35,7 +35,7 @@
 - Phase 1 (#292) format migration (covered by [Phase 1 Test Plan](../292/TEST_PLAN.md))
 - Seed-workflows Helm Job migration to CRD manifests (deferred, Step 8)
 - AW integration tests with real Kind cluster (deferred to E2E)
-- OCI bundle validation (`ValidateBundleExists`) -- unchanged, still uses OCI puller
+- OCI bundle validation (`ValidateBundleExists`) -- unchanged at the time of this plan, still used the OCI puller; **removed by Issue #1642** (pre-flight registry existence check could not validate self-signed/credential-required private registries)
 
 ### Design Decisions
 

--- a/docs/testing/DD-WORKFLOW-017/execution_bundle_test_plan_v1.0.md
+++ b/docs/testing/DD-WORKFLOW-017/execution_bundle_test_plan_v1.0.md
@@ -645,60 +645,20 @@ makeCreateRequest := func(schemaImage string) *http.Request {
 
 ---
 
-### UT-WF-017-013: Reject OCI registration when execution.bundle image does not exist in registry
+### UT-WF-017-013: REMOVED (Issue #1642)
 
-- **BR**: BR-WORKFLOW-017-001 (Validation #10), DD-WORKFLOW-017 (Error handling), Issue #89
-- **Business Outcome**: The OCI registration pipeline provides early feedback when `execution.bundle` references an image that does not exist in the container registry, preventing workflows from being registered that will fail at execution time with `ImagePullBackOff`
-- **Preconditions**:
-  - `MockImagePullerWithFailingExists` configured: `Pull()` succeeds (schema extraction works), `Exists()` returns error (bundle image not found)
-  - Handler wired with mock extractor, no DB (nil repository)
-- **Given**:
-  - Mock OCI puller returns a valid schema image (all fields pass validation including `execution.bundle` format)
-  - `puller.Exists()` returns an error simulating a missing image in the registry
-  - HTTP request: `POST /api/v1/workflows` with body `{"schemaImage": "quay.io/kubernaut/schemas/exec-bundle-test:v1.0.0"}`
-- **When**: `handler.HandleCreateWorkflow(rr, req)` is called
-- **Then**:
-  - `rr.Code` is `400` (Bad Request) -- bundle existence check failed
-  - Response body is RFC 7807 JSON with:
-    - `"type"`: `"https://kubernaut.ai/problems/bundle-not-found"`
-    - `"detail"`: contains `"execution.bundle"` -- identifies the problem as bundle-related
-  - `Content-Type` header is `application/problem+json`
-- **Exit Criteria**:
-  - HTTP 400 is returned (not 500 or 502)
-  - RFC 7807 `type` field is `bundle-not-found` (distinct from `validation-error`)
-  - `detail` field contains enough information for the operator to identify the unreachable bundle
-  - The handler does NOT proceed to DB insertion
-- **Mock Requirement**:
-  - New mock type `MockImagePullerWithFailingExists` that extends `MockImagePuller` (Pull succeeds) but overrides `Exists()` to return an error. This mock is required because the existing `MockImagePuller.Exists()` always returns nil and `FailingMockImagePuller.Pull()` always fails (preventing schema extraction from succeeding).
-- **Implementation Hint**:
-  ```go
-  It("UT-WF-017-013: should reject OCI registration when execution.bundle image does not exist in registry", func() {
-      puller := oci.NewMockImagePullerWithFailingExists(
-          validDigestOnlyBundleSchemaYAML,
-          fmt.Errorf("MANIFEST_UNKNOWN: manifest unknown"),
-      )
-      handler := newHandlerWithMockExtractor(puller)
-      req := makeCreateRequest("quay.io/kubernaut/schemas/exec-bundle-test:v1.0.0")
-      rr := httptest.NewRecorder()
-
-      handler.HandleCreateWorkflow(rr, req)
-
-      Expect(rr.Code).To(Equal(http.StatusBadRequest),
-          "non-existent execution.bundle must be rejected with 400")
-      Expect(rr.Header().Get("Content-Type")).To(ContainSubstring("application/problem+json"))
-
-      var problem map[string]interface{}
-      Expect(json.Unmarshal(rr.Body.Bytes(), &problem)).To(Succeed())
-      Expect(problem["type"]).To(Equal("https://kubernaut.ai/problems/bundle-not-found"),
-          "RFC 7807 type must be bundle-not-found")
-      Expect(problem["detail"]).To(ContainSubstring("execution.bundle"),
-          "RFC 7807 detail must reference the bundle")
-  })
-  ```
-- **Anti-Pattern Warnings**:
-  - Do not use `FailingMockImagePuller` -- it fails on `Pull()` too, preventing schema extraction from succeeding
-  - Do not confuse this with `validation-error` (format validation) -- this is a `bundle-not-found` (existence check)
-  - Do not skip RFC 7807 body assertions -- the error type distinguishes this from other 400 errors
+> **Superseded by Issue #1642.** This test scenario, and the pre-flight
+> `execution.bundle` registry existence check (`ValidateBundleExists` /
+> `ImagePuller.Exists`) it exercised, have been removed. The check ran from
+> the DataStorage pod's own network/credential context, which cannot
+> validate self-signed or credential-required private registries reachable
+> only by the actual workflow execution environment — this unconditionally
+> blocked otherwise-valid registrations rather than only catching real typos.
+> Kubernetes now fails fast at Job/PipelineRun image-pull time instead
+> (`ImagePullBackOff`), extending the same BR-WORKFLOW-008 runtime
+> observability pattern already used for schema-declared dependency
+> mounting (Issue #1481). The `bundle-not-found` RFC 7807 error type no
+> longer exists.
 
 ---
 
@@ -717,7 +677,7 @@ makeCreateRequest := func(schemaImage string) *http.Request {
 | UT-WF-017-010 | Valid registration accepted | Positive | RED (passes) | BR-WORKFLOW-004, DD-WORKFLOW-017 |
 | UT-WF-017-011 | Tag-only bundle registration rejected | Negative | RED (fails) | BR-WORKFLOW-004, Issue #89 |
 | UT-WF-017-012 | Missing execution registration rejected | Negative | RED (fails) | BR-WORKFLOW-004, Issue #89 |
-| UT-WF-017-013 | Bundle image not found in registry | Negative | RED (fails) | BR-WORKFLOW-017-001 #10, Issue #89 |
+| UT-WF-017-013 | ~~Bundle image not found in registry~~ | Removed | N/A | Superseded by Issue #1642 |
 
 ---
 

--- a/pkg/datastorage/execution_bundle_validation_test.go
+++ b/pkg/datastorage/execution_bundle_validation_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 
@@ -260,29 +259,14 @@ var _ = Describe("UT-DS/WF-017: Execution Bundle Validation", func() {
 				"error detail must indicate schema validation failure")
 		})
 
-		It("UT-WF-017-013: should reject inline registration when execution.bundle image does not exist in registry", func() {
-			puller := oci.NewMockImagePullerWithFailingExists(
-				validDigestOnlyBundleSchemaYAML,
-				fmt.Errorf("MANIFEST_UNKNOWN: manifest unknown"),
-			)
-			handler := newHandlerWithMockExtractor(puller)
-			req := makeInlineCreateRequest(validDigestOnlyBundleSchemaYAML)
-			rr := httptest.NewRecorder()
-
-			handler.HandleCreateWorkflow(rr, req)
-
-			Expect(rr.Code).To(Equal(http.StatusBadRequest),
-				"non-existent execution.bundle must be rejected with 400")
-			Expect(rr.Header().Get("Content-Type")).To(ContainSubstring("application/problem+json"),
-				"error response must use RFC 7807 content type")
-
-			var problem map[string]interface{}
-			Expect(json.Unmarshal(rr.Body.Bytes(), &problem)).To(Succeed(),
-				"response body must be valid RFC 7807 JSON")
-			Expect(problem["type"]).To(Equal("https://kubernaut.ai/problems/bundle-not-found"),
-				"RFC 7807 type must be bundle-not-found")
-			Expect(problem["detail"]).To(ContainSubstring("execution.bundle"),
-				"error detail must reference the bundle field")
-		})
+		// UT-WF-017-013 ("should reject inline registration when execution.bundle
+		// image does not exist in registry") was removed by Issue #1642: the
+		// pre-flight registry existence check ran from the DataStorage pod's own
+		// network/credential context, which cannot validate self-signed or
+		// credential-required private registries reachable only by the actual
+		// workflow execution environment — this unconditionally blocked valid
+		// registrations. Kubernetes now fails fast at Job/PipelineRun image-pull
+		// time instead (BR-WORKFLOW-008), mirroring the precedent set by Issue
+		// #1481 for schema-declared dependency existence checks.
 	})
 })

--- a/pkg/datastorage/oci/extractor.go
+++ b/pkg/datastorage/oci/extractor.go
@@ -105,13 +105,6 @@ func (e *SchemaExtractor) ExtractFromImage(ctx context.Context, imageRef string)
 	}, nil
 }
 
-// ValidateBundleExists checks that the execution.bundle image reference exists in the registry.
-// Called after schema extraction to provide early feedback on typos or missing images
-// rather than failing at workflow execution time.
-func (e *SchemaExtractor) ValidateBundleExists(ctx context.Context, bundleRef string) error {
-	return e.puller.Exists(ctx, bundleRef)
-}
-
 // findFileInImage searches all layers of an OCI image for the given file path.
 // Returns the file content as a string, or an error if not found.
 func findFileInImage(img v1.Image, filePath string) (string, error) {

--- a/pkg/datastorage/oci/mock_puller.go
+++ b/pkg/datastorage/oci/mock_puller.go
@@ -50,11 +50,6 @@ func NewMockImagePuller(schemaContent string) *MockImagePuller {
 	return &MockImagePuller{schemaContent: schemaContent}
 }
 
-// Exists always succeeds for mock images.
-func (m *MockImagePuller) Exists(_ context.Context, _ string) error {
-	return nil
-}
-
 // Pull returns an in-memory OCI image with /workflow-schema.yaml.
 func (m *MockImagePuller) Pull(_ context.Context, ref string) (v1.Image, string, error) {
 	img := empty.Image
@@ -84,29 +79,6 @@ func (m *MockImagePuller) Pull(_ context.Context, ref string) (v1.Image, string,
 	return img, digest.String(), nil
 }
 
-// MockImagePullerWithFailingExists implements ImagePuller where Pull() succeeds
-// (schema extraction works) but Exists() returns an error (bundle image not found).
-// This enables testing the handler's bundle-not-found error path (Step 5c) without
-// failing at the schema extraction stage (Step 4).
-type MockImagePullerWithFailingExists struct {
-	*MockImagePuller
-	existsErr error
-}
-
-// NewMockImagePullerWithFailingExists creates a mock where Pull returns a valid
-// image containing the given schema content, but Exists returns the given error.
-func NewMockImagePullerWithFailingExists(schemaContent string, existsErr error) *MockImagePullerWithFailingExists {
-	return &MockImagePullerWithFailingExists{
-		MockImagePuller: NewMockImagePuller(schemaContent),
-		existsErr:       existsErr,
-	}
-}
-
-// Exists returns the configured error, simulating a missing bundle image.
-func (m *MockImagePullerWithFailingExists) Exists(_ context.Context, _ string) error {
-	return m.existsErr
-}
-
 // FailingMockImagePuller implements ImagePuller and always returns an error.
 type FailingMockImagePuller struct {
 	errMsg string
@@ -115,11 +87,6 @@ type FailingMockImagePuller struct {
 // NewFailingMockImagePuller creates a mock puller that always fails with the given message.
 func NewFailingMockImagePuller(errMsg string) *FailingMockImagePuller {
 	return &FailingMockImagePuller{errMsg: errMsg}
-}
-
-// Exists always returns an error for the failing mock.
-func (m *FailingMockImagePuller) Exists(_ context.Context, ref string) error {
-	return fmt.Errorf("image %q not found in registry: %s", ref, m.errMsg)
 }
 
 // Pull always returns an error.

--- a/pkg/datastorage/oci/puller.go
+++ b/pkg/datastorage/oci/puller.go
@@ -44,11 +44,6 @@ type ImagePuller interface {
 	// Pull retrieves an OCI image by reference (e.g., "quay.io/org/workflow:v1.0.0").
 	// Returns the image and its SHA-256 digest.
 	Pull(ctx context.Context, ref string) (v1.Image, string, error)
-
-	// Exists checks whether an OCI image manifest exists at the given reference.
-	// Uses a HEAD request — lightweight, does not download layers.
-	// Returns nil if the manifest exists, or an error describing why it doesn't.
-	Exists(ctx context.Context, ref string) error
 }
 
 // CraneImagePuller implements ImagePuller using google/go-containerregistry (crane).
@@ -87,20 +82,4 @@ func (p *CraneImagePuller) Pull(ctx context.Context, ref string) (v1.Image, stri
 	p.logger.V(1).Info("OCI image pulled successfully", "ref", ref, "digest", digestStr)
 
 	return img, digestStr, nil
-}
-
-// Exists checks whether an OCI image manifest exists at the given reference.
-// Uses crane.Head for a lightweight manifest existence check without downloading layers.
-func (p *CraneImagePuller) Exists(ctx context.Context, ref string) error {
-	p.logger.V(1).Info("Checking OCI image existence", "ref", ref)
-
-	opts := append([]crane.Option{crane.WithContext(ctx)}, p.opts...)
-
-	_, err := crane.Head(ref, opts...)
-	if err != nil {
-		return fmt.Errorf("image %q not found in registry: %w", ref, err)
-	}
-
-	p.logger.V(1).Info("OCI image exists", "ref", ref)
-	return nil
 }

--- a/pkg/datastorage/server/handler.go
+++ b/pkg/datastorage/server/handler.go
@@ -84,7 +84,7 @@ type Handler struct {
 	workflowIntegrityRepo   WorkflowContentIntegrityRepository // BR-WORKFLOW-006: Content hash integrity checking
 	actionTypeValidator     ActionTypeValidator                // GAP-4: DD-WORKFLOW-016 taxonomy validation
 	auditStore              audit.AuditStore                  // BR-AUDIT-023: Workflow search audit
-	schemaExtractor         *oci.SchemaExtractor              // DD-WE-006: OCI bundle validation (ValidateBundleExists)
+	schemaExtractor         *oci.SchemaExtractor              // DD-WORKFLOW-017: OCI image schema extraction; not currently invoked by any handler (Issue #1642 removed its last caller, ValidateBundleExists)
 	remediationHistoryRepo  RemediationHistoryQuerier         // BR-HAPI-016: Remediation history context (DD-HAPI-016 v1.1)
 	actionTypeRepo          *actiontyperepo.Repository        // BR-WORKFLOW-007: ActionType CRD lifecycle
 }
@@ -141,8 +141,10 @@ func WithAuditStore(store audit.AuditStore) HandlerOption {
 	}
 }
 
-// WithSchemaExtractor sets the OCI schema extractor for bundle validation
-// DD-WE-006: ValidateBundleExists uses OCI puller to verify execution bundles
+// WithSchemaExtractor sets the OCI schema extractor.
+// DD-WORKFLOW-017: retained for OCI-based schema extraction; not currently
+// invoked by any handler (Issue #1642 removed its last caller,
+// ValidateBundleExists — the execution.bundle pre-flight existence check).
 func WithSchemaExtractor(extractor *oci.SchemaExtractor) HandlerOption {
 	return func(h *Handler) {
 		h.schemaExtractor = extractor

--- a/pkg/datastorage/server/workflow_create_handlers.go
+++ b/pkg/datastorage/server/workflow_create_handlers.go
@@ -22,7 +22,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"sync"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -87,10 +86,8 @@ func (h *Handler) HandleCreateWorkflow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Validate external checks in parallel (Issue #1070)
-	// Typed-result-slot pattern: each check writes to its own error slot,
-	// then we check slots in priority order so callers always see the same
-	// RFC 7807 error type regardless of goroutine completion order.
+	// Validate external checks (action-type taxonomy — Issue #1642 removed
+	// the last other check, execution.bundle image existence).
 	if err := h.validateExternalChecks(r.Context(), workflow); err != nil {
 		err.writeTo(w, h.logger)
 		return
@@ -291,115 +288,56 @@ func (ve *validationError) writeTo(w http.ResponseWriter, logger logr.Logger) {
 	response.WriteRFC7807Error(w, ve.status, ve.errorType, ve.title, ve.detail, logger)
 }
 
-// validateExternalChecks runs Steps 5a–5b (action-type, bundle-exists)
-// in parallel and returns the highest-priority error, preserving the
-// original sequential error contract.
+// validateExternalChecks runs Step 5a (action-type taxonomy) and returns
+// its error, if any.
 //
-// A 10-second timeout budget bounds the total wall-clock time for all
-// external calls, preventing a degraded backend from consuming the
-// entire server WriteTimeout.
-//
-// Issue #1070: Typed-result-slot pattern — each goroutine writes to its
-// own slot; after all goroutines complete we check slots in priority order.
+// A 10-second timeout budget bounds the external call, preventing a
+// degraded backend from consuming the entire server WriteTimeout.
 //
 // Issue #1481: Step 5c (schema-declared dependency existence check,
 // DD-WE-006) was removed — Kubernetes now validates dependency existence
 // exclusively at runtime when the WorkflowExecution's Job/PipelineRun
 // attempts to mount the volume/workspace (BR-WORKFLOW-008).
+//
+// Issue #1642: Step 5b (execution.bundle image existence check) was
+// removed — the same pre-flight/runtime context mismatch applies: a check
+// running from the DataStorage pod's own network/credential context cannot
+// validate self-signed or credential-required private registries reachable
+// only by the actual workflow execution environment, which unconditionally
+// blocked valid registrations. Kubernetes now fails fast at Job/PipelineRun
+// image-pull time instead, extending the same BR-WORKFLOW-008 pattern.
+//
+// With only one external check remaining, Issue #1070's typed-result-slot/
+// goroutine pattern (built for running multiple checks in parallel) no
+// longer serves a purpose and has been collapsed back into a direct
+// sequential call.
 func (h *Handler) validateExternalChecks(
 	ctx context.Context,
 	workflow *models.RemediationWorkflow,
 ) *validationError {
-	const (
-		slotActionType = iota
-		slotBundle
-		slotCount
-
-		validationTimeout = 10 * time.Second
-	)
+	const validationTimeout = 10 * time.Second
 
 	ctx, cancel := context.WithTimeout(ctx, validationTimeout)
 	defer cancel()
 
-	var (
-		slots [slotCount]*validationError
-		mu    sync.Mutex
-		wg    sync.WaitGroup
-	)
-
-	totalStart := time.Now()
-
-	setSlot := func(idx int, ve *validationError) {
-		mu.Lock()
-		slots[idx] = ve
-		mu.Unlock()
+	if h.actionTypeValidator == nil {
+		return nil
 	}
 
-	h.launchExternalValidationGoroutines(ctx, &wg, workflow, setSlot, validationSlots{
-		actionType: slotActionType,
-		bundle:     slotBundle,
-	})
-
-	wg.Wait()
-
-	// Return the highest-priority error (lowest slot index).
-	for _, slot := range slots {
-		if slot != nil {
-			dsmetrics.WorkflowValidationDuration.WithLabelValues("total", "error").Observe(time.Since(totalStart).Seconds())
-			return slot
-		}
+	totalStart := time.Now()
+	ve := h.validateActionType(ctx, workflow)
+	if ve != nil {
+		dsmetrics.WorkflowValidationDuration.WithLabelValues("total", "error").Observe(time.Since(totalStart).Seconds())
+		return ve
 	}
 	dsmetrics.WorkflowValidationDuration.WithLabelValues("total", "ok").Observe(time.Since(totalStart).Seconds())
 	return nil
 }
 
-// validationSlots groups the typed-result-slot indices (Issue #1070) used by
-// launchExternalValidationGoroutines, so the function stays within the
-// 7-argument limit (100go.co anti-pattern: functions with 8+ parameters).
-type validationSlots struct {
-	actionType int
-	bundle     int
-}
-
-// launchExternalValidationGoroutines fires steps 5a-5b of validateExternalChecks
-// (action-type, bundle-exists) as parallel goroutines against wg, each
-// reporting into its typed result slot via setSlot. Extracted from
-// validateExternalChecks (Wave 6 6f GREEN: funlen remediation) — pure code
-// motion, no behavior change.
-func (h *Handler) launchExternalValidationGoroutines(
-	ctx context.Context,
-	wg *sync.WaitGroup,
-	workflow *models.RemediationWorkflow,
-	setSlot func(idx int, ve *validationError),
-	slots validationSlots,
-) {
-	// 5a: Validate action_type against taxonomy (GAP-4, DD-WORKFLOW-016)
-	if h.actionTypeValidator != nil {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			h.validateActionTypeSlot(ctx, workflow, func(ve *validationError) { setSlot(slots.actionType, ve) })
-		}()
-	}
-
-	// 5b: Validate execution bundle image exists in the registry (skip for ansible — Git repo)
-	if workflow.ExecutionBundle != nil && *workflow.ExecutionBundle != "" &&
-		workflow.ExecutionEngine != models.ExecutionEngineAnsible && h.schemaExtractor != nil {
-		bundleRef := *workflow.ExecutionBundle
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			h.validateBundleExistsSlot(ctx, bundleRef, func(ve *validationError) { setSlot(slots.bundle, ve) })
-		}()
-	}
-}
-
-// validateActionTypeSlot implements step 5a of validateExternalChecks:
-// validate workflow.ActionType against the action-type taxonomy
-// (GAP-4, DD-WORKFLOW-016), reporting the result via setSlot. Extracted
-// from validateExternalChecks (Wave 6 6f GREEN: funlen remediation) — pure
-// code motion, no behavior change.
-func (h *Handler) validateActionTypeSlot(ctx context.Context, workflow *models.RemediationWorkflow, setSlot func(*validationError)) {
+// validateActionType implements step 5a of validateExternalChecks: validate
+// workflow.ActionType against the action-type taxonomy (GAP-4,
+// DD-WORKFLOW-016).
+func (h *Handler) validateActionType(ctx context.Context, workflow *models.RemediationWorkflow) *validationError {
 	start := time.Now()
 	exists, err := h.actionTypeValidator.ActionTypeExists(ctx, workflow.ActionType)
 	if err != nil {
@@ -407,48 +345,24 @@ func (h *Handler) validateActionTypeSlot(ctx context.Context, workflow *models.R
 		h.logger.Error(err, "Failed to validate action_type against taxonomy",
 			"action_type", workflow.ActionType,
 		)
-		setSlot(&validationError{
+		return &validationError{
 			status:    http.StatusInternalServerError,
 			errorType: "internal-error",
 			title:     "Internal Server Error",
 			detail:    "Failed to validate action type",
-		})
-		return
+		}
 	}
 	if !exists {
 		dsmetrics.WorkflowValidationDuration.WithLabelValues("action_type", "error").Observe(time.Since(start).Seconds())
-		setSlot(&validationError{
+		return &validationError{
 			status:    http.StatusBadRequest,
 			errorType: "validation-error",
 			title:     "Validation Error",
 			detail:    fmt.Sprintf("action_type '%s' is not in the action type taxonomy (DD-WORKFLOW-016)", workflow.ActionType),
-		})
-		return
+		}
 	}
 	dsmetrics.WorkflowValidationDuration.WithLabelValues("action_type", "ok").Observe(time.Since(start).Seconds())
-}
-
-// validateBundleExistsSlot implements step 5b of validateExternalChecks:
-// validate that the execution bundle image resolves in the registry,
-// reporting the result via setSlot. Extracted from validateExternalChecks
-// (Wave 6 6f GREEN: funlen remediation) — pure code motion, no behavior
-// change.
-func (h *Handler) validateBundleExistsSlot(ctx context.Context, bundleRef string, setSlot func(*validationError)) {
-	start := time.Now()
-	if err := h.schemaExtractor.ValidateBundleExists(ctx, bundleRef); err != nil {
-		dsmetrics.WorkflowValidationDuration.WithLabelValues("bundle_exists", "error").Observe(time.Since(start).Seconds())
-		h.logger.Error(err, "Execution bundle image not found in registry",
-			"execution_bundle", bundleRef,
-		)
-		setSlot(&validationError{
-			status:    http.StatusBadRequest,
-			errorType: "bundle-not-found",
-			title:     "Execution Bundle Not Found",
-			detail:    "execution.bundle image could not be resolved; verify the image reference is correct",
-		})
-		return
-	}
-	dsmetrics.WorkflowValidationDuration.WithLabelValues("bundle_exists", "ok").Observe(time.Since(start).Seconds())
+	return nil
 }
 
 // contentIntegrityError is returned when an active workflow with the same

--- a/pkg/datastorage/workflow_validation_priority_test.go
+++ b/pkg/datastorage/workflow_validation_priority_test.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 
@@ -45,12 +44,18 @@ import (
 // Validation order (as defined in HandleCreateWorkflow):
 //   Step 3:  Schema validation         → type = validation-error
 //   Step 5a: Action-type taxonomy      → type = validation-error
-//   Step 5b: Bundle-exists (OCI)       → type = bundle-not-found
 //
 // Issue #1481: Step 5c (dependency validation) was removed — schema-declared
 // dependencies are no longer checked for existence at registration time;
 // Kubernetes validates them at runtime when the WorkflowExecution's Job/
 // PipelineRun attempts to mount the volume/workspace (BR-WORKFLOW-008).
+//
+// Issue #1642: Step 5b (bundle-exists, OCI) was removed — a pre-flight
+// registry check from the DataStorage pod's own network/credential context
+// cannot validate self-signed or credential-required private registries
+// reachable only by the actual workflow execution environment. Kubernetes
+// now fails fast at Job/PipelineRun image-pull time instead, extending the
+// same BR-WORKFLOW-008 observability pattern.
 //
 // These tests wire all remaining validators so every step *would* fail,
 // then assert only the highest-priority error is returned.
@@ -97,8 +102,8 @@ var _ = Describe("Issue #1070: HandleCreateWorkflow Validation Error Priority", 
 
 		It("UT-WF-1070-001: schema validation error beats all downstream failures", func() {
 			schemaYAML := validSchemaForPriorityTests()
-			failingPuller := oci.NewMockImagePullerWithFailingExists(schemaYAML, fmt.Errorf("bundle not found"))
-			extractor := oci.NewSchemaExtractor(failingPuller, schema.NewParser())
+			puller := oci.NewMockImagePuller(schemaYAML)
+			extractor := oci.NewSchemaExtractor(puller, schema.NewParser())
 
 			handler := server.NewHandler(
 				server.WithActionTypeValidator(rejectingActionTypeValidator()),
@@ -116,10 +121,10 @@ var _ = Describe("Issue #1070: HandleCreateWorkflow Validation Error Priority", 
 				"Schema validation must be the first error, regardless of downstream failures")
 		})
 
-		It("UT-WF-1070-002: action-type error beats bundle-not-found", func() {
+		It("UT-WF-1070-002: action-type error surfaces when schema is valid", func() {
 			schemaYAML := validSchemaForPriorityTests()
-			failingPuller := oci.NewMockImagePullerWithFailingExists(schemaYAML, fmt.Errorf("bundle not found"))
-			extractor := oci.NewSchemaExtractor(failingPuller, schema.NewParser())
+			puller := oci.NewMockImagePuller(schemaYAML)
+			extractor := oci.NewSchemaExtractor(puller, schema.NewParser())
 
 			handler := server.NewHandler(
 				server.WithActionTypeValidator(rejectingActionTypeValidator()),
@@ -134,37 +139,15 @@ var _ = Describe("Issue #1070: HandleCreateWorkflow Validation Error Priority", 
 			Expect(rr.Code).To(Equal(http.StatusBadRequest))
 			problem := parseRFC7807(rr)
 			Expect(problem["type"]).To(Equal("https://kubernaut.ai/problems/validation-error"),
-				"Action-type rejection must take priority over bundle-not-found errors")
+				"Action-type rejection must surface as a validation error")
 			Expect(problem["detail"]).To(ContainSubstring("action_type"),
 				"Error detail should mention action_type")
 		})
 
-		It("UT-WF-1070-003: bundle-not-found surfaces when no higher-priority failures exist", func() {
-			schemaYAML := validSchemaForPriorityTests()
-			failingPuller := oci.NewMockImagePullerWithFailingExists(schemaYAML, fmt.Errorf("bundle image not in registry"))
-			extractor := oci.NewSchemaExtractor(failingPuller, schema.NewParser())
-
-			acceptingValidator := &mockActionTypeValidator{
-				existsFn: func(_ context.Context, _ string) (bool, error) {
-					return true, nil
-				},
-			}
-
-			handler := server.NewHandler(
-				server.WithActionTypeValidator(acceptingValidator),
-				server.WithSchemaExtractor(extractor),
-			)
-
-			req := makeRequest(schemaYAML)
-			rr := httptest.NewRecorder()
-
-			handler.HandleCreateWorkflow(rr, req)
-
-			Expect(rr.Code).To(Equal(http.StatusBadRequest))
-			problem := parseRFC7807(rr)
-			Expect(problem["type"]).To(Equal("https://kubernaut.ai/problems/bundle-not-found"),
-				"Bundle-not-found should surface when action-type passes")
-		})
+		// UT-WF-1070-003 ("bundle-not-found surfaces when no higher-priority
+		// failures exist") was removed by Issue #1642 along with the
+		// bundle-exists pre-flight check itself — there is no longer a
+		// bundle-not-found error type to surface at registration time.
 
 		It("UT-WF-1070-004: all validations pass — no error returned", func() {
 			schemaYAML := validSchemaForPriorityTests()

--- a/pkg/workflowexecution/executor/job.go
+++ b/pkg/workflowexecution/executor/job.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"time"
 
 	batchv1 "k8s.io/api/batch/v1"
@@ -53,6 +54,37 @@ const (
 var podMountFailureReasons = map[string]bool{
 	"FailedMount":                true,
 	"CreateContainerConfigError": true,
+}
+
+// imagePullFailureReasons are the kubelet Event reasons that MAY indicate a
+// container image could not be pulled (Issue #1645, BR-WORKFLOW-008),
+// mirroring the Tekton engine's existing ImagePullBackOff message
+// classification (internal/controller/workflowexecution/failure_analysis.go).
+//
+// Unlike podMountFailureReasons, a reason match alone is not sufficient:
+// kubelet reuses the generic "Failed" and "BackOff" reasons for many
+// unrelated container lifecycle events (e.g. liveness probe failures,
+// CrashLoopBackOff), so isImagePullFailureEvent also checks the message text.
+var imagePullFailureReasons = map[string]bool{
+	"Failed":  true,
+	"BackOff": true,
+}
+
+// isImagePullFailureEvent reports whether evt is a kubelet Event describing
+// a container image-pull failure, as opposed to some other cause of the
+// generic "Failed"/"BackOff" reason. Real kubelet image-pull events always
+// mention "pull image" in the detailed message (e.g. `Failed to pull image
+// "x": rpc error: ...`) or, for the terser retry-summary variant, "Error:
+// ErrImagePull" / "Error: ImagePullBackOff" (see
+// k8s.io/kubernetes/pkg/kubelet/images).
+func isImagePullFailureEvent(evt corev1.Event) bool {
+	if !imagePullFailureReasons[evt.Reason] {
+		return false
+	}
+	messageLower := strings.ToLower(evt.Message)
+	return strings.Contains(messageLower, "pull image") ||
+		strings.Contains(messageLower, "errimagepull") ||
+		strings.Contains(messageLower, "imagepullbackoff")
 }
 
 // JobExecutor implements the Executor interface for Kubernetes Jobs.
@@ -184,11 +216,12 @@ func (j *JobExecutor) GetStatus(ctx context.Context, wfe *workflowexecutionv1alp
 const jobPodNameSuffixLength = 5
 
 // enrichFailureMessage inspects Events involving the failed Job's Pod(s) for
-// a FailedMount or CreateContainerConfigError reason and, if found, returns
+// a FailedMount/CreateContainerConfigError reason (missing Secret/ConfigMap
+// dependency, #1481) or an image-pull failure (#1645) and, if found, returns
 // its message in place of the generic Job condition message
 // (BR-WORKFLOW-008). Since dependency existence is no longer pre-flight
-// validated (#1481), this is the only place the specific missing
-// Secret/ConfigMap name surfaces.
+// validated (#1481) and, as of #1642, neither is execution.bundle image
+// existence, this is the only place either specific failure detail surfaces.
 //
 // Deliberately does NOT list the Job's Pods first: Kubernetes' job-controller
 // deletes a Job's active Pods as soon as ActiveDeadlineSeconds is exceeded —
@@ -215,7 +248,7 @@ func (j *JobExecutor) enrichFailureMessage(ctx context.Context, c ExecutorClient
 		if evt.InvolvedObject.Kind != "Pod" || !isJobPodName(evt.InvolvedObject.Name, podNamePrefix) {
 			continue
 		}
-		if podMountFailureReasons[evt.Reason] {
+		if podMountFailureReasons[evt.Reason] || isImagePullFailureEvent(evt) {
 			return evt.Message
 		}
 	}

--- a/pkg/workflowexecution/executor/job_test.go
+++ b/pkg/workflowexecution/executor/job_test.go
@@ -632,6 +632,143 @@ var _ = Describe("UT-WE-054-JOB: JobExecutor", func() {
 				"should preserve the generic Job condition message when no enriching Pod event is found")
 		})
 
+		// Issue #1645 / BR-WORKFLOW-008: extends the Job engine's runtime
+		// observability (already present for dependency-mount failures, see
+		// UT-WE-054-JOB-018 above) to container image-pull failures, mirroring
+		// the Tekton engine's existing ImagePullBackOff message classification
+		// (internal/controller/workflowexecution/failure_analysis.go). This
+		// gap is more relevant since Issue #1642 removed the DataStorage
+		// pre-flight execution.bundle registry existence check -- bad/
+		// unreachable bundle references now always surface here at runtime.
+		It("UT-WE-054-JOB-028 [BR-WORKFLOW-008]: should enrich Failed message with the kubelet's detailed image-pull-failure event", func() {
+			jobName := executor.ExecutionResourceName("default/deployment/bad-image")
+			job := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: namespace},
+				Status: batchv1.JobStatus{
+					Failed: 1,
+					Conditions: []batchv1.JobCondition{
+						{
+							Type:    batchv1.JobFailed,
+							Status:  corev1.ConditionTrue,
+							Reason:  "DeadlineExceeded",
+							Message: "Job was active longer than specified deadline",
+						},
+					},
+				},
+			}
+			evt := &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{Name: "evt-errimagepull", Namespace: namespace},
+				InvolvedObject: corev1.ObjectReference{
+					Kind:      "Pod",
+					Name:      jobName + "-x7k2m",
+					Namespace: namespace,
+				},
+				// Real kubelet event: Reason is the generic "Failed" -- the
+				// specific detail lives in the message (see
+				// pkg/kubelet/images/image_manager.go upstream).
+				Reason:  "Failed",
+				Message: `Failed to pull image "quay.io/kubernaut/bad-bundle:v1": rpc error: code = NotFound desc = manifest unknown`,
+				Type:    corev1.EventTypeWarning,
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(job, evt).Build()
+			factory := &mockClientFactory{client: fakeClient}
+			je := executor.NewJobExecutorWithFactory(factory)
+
+			wfe := newTestWFE("wfe-bad-image", "default/deployment/bad-image", "")
+			wfe.Status.ExecutionRef = &corev1.LocalObjectReference{Name: jobName}
+
+			result, err := je.GetStatus(ctx, wfe, namespace)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Phase).To(Equal(workflowexecutionv1alpha1.PhaseFailed))
+			Expect(result.Message).To(ContainSubstring("manifest unknown"),
+				"BR-WORKFLOW-008: message should be enriched with the specific image-pull failure detail from the Pod event")
+		})
+
+		It("UT-WE-054-JOB-029 [BR-WORKFLOW-008]: should enrich Failed message with a terse 'Error: ImagePullBackOff' event when no detailed event exists", func() {
+			jobName := executor.ExecutionResourceName("default/deployment/backoff-image")
+			job := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: namespace},
+				Status: batchv1.JobStatus{
+					Failed: 1,
+					Conditions: []batchv1.JobCondition{
+						{
+							Type:    batchv1.JobFailed,
+							Status:  corev1.ConditionTrue,
+							Reason:  "DeadlineExceeded",
+							Message: "Job was active longer than specified deadline",
+						},
+					},
+				},
+			}
+			evt := &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{Name: "evt-imagepullbackoff", Namespace: namespace},
+				InvolvedObject: corev1.ObjectReference{
+					Kind:      "Pod",
+					Name:      jobName + "-x7k2m",
+					Namespace: namespace,
+				},
+				Reason:  "Failed",
+				Message: "Error: ImagePullBackOff",
+				Type:    corev1.EventTypeWarning,
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(job, evt).Build()
+			factory := &mockClientFactory{client: fakeClient}
+			je := executor.NewJobExecutorWithFactory(factory)
+
+			wfe := newTestWFE("wfe-backoff-image", "default/deployment/backoff-image", "")
+			wfe.Status.ExecutionRef = &corev1.LocalObjectReference{Name: jobName}
+
+			result, err := je.GetStatus(ctx, wfe, namespace)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Phase).To(Equal(workflowexecutionv1alpha1.PhaseFailed))
+			Expect(result.Message).To(ContainSubstring("ImagePullBackOff"),
+				"BR-WORKFLOW-008: message should be enriched even from the terse image-pull-backoff event variant")
+		})
+
+		It("UT-WE-054-JOB-030 [BR-WORKFLOW-008]: should NOT misclassify an unrelated 'Failed' Pod event as an image-pull failure", func() {
+			jobName := executor.ExecutionResourceName("default/deployment/probe-failure")
+			job := &batchv1.Job{
+				ObjectMeta: metav1.ObjectMeta{Name: jobName, Namespace: namespace},
+				Status: batchv1.JobStatus{
+					Failed: 1,
+					Conditions: []batchv1.JobCondition{
+						{
+							Type:    batchv1.JobFailed,
+							Status:  corev1.ConditionTrue,
+							Reason:  "BackoffLimitExceeded",
+							Message: "Job has reached the specified backoff limit",
+						},
+					},
+				},
+			}
+			// kubelet reuses the generic "Failed" reason for many unrelated
+			// container lifecycle events (e.g. liveness probe failures) --
+			// this must NOT be misread as an image-pull failure.
+			evt := &corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{Name: "evt-probe-failed", Namespace: namespace},
+				InvolvedObject: corev1.ObjectReference{
+					Kind:      "Pod",
+					Name:      jobName + "-x7k2m",
+					Namespace: namespace,
+				},
+				Reason:  "Failed",
+				Message: "Liveness probe failed: HTTP probe failed with statuscode: 500",
+				Type:    corev1.EventTypeWarning,
+			}
+			fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(job, evt).Build()
+			factory := &mockClientFactory{client: fakeClient}
+			je := executor.NewJobExecutorWithFactory(factory)
+
+			wfe := newTestWFE("wfe-probe-failure", "default/deployment/probe-failure", "")
+			wfe.Status.ExecutionRef = &corev1.LocalObjectReference{Name: jobName}
+
+			result, err := je.GetStatus(ctx, wfe, namespace)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.Phase).To(Equal(workflowexecutionv1alpha1.PhaseFailed))
+			Expect(result.Message).To(Equal("Job has reached the specified backoff limit"),
+				"an unrelated 'Failed' event (e.g. probe failure) must not be misclassified as an image-pull failure")
+		})
+
 		It("UT-WE-054-JOB-007: should return Running when Job has no terminal condition", func() {
 			jobName := executor.ExecutionResourceName("default/deployment/running")
 			completions := int32(1)

--- a/test/integration/workflowexecution/dependency_resolution_integration_test.go
+++ b/test/integration/workflowexecution/dependency_resolution_integration_test.go
@@ -172,6 +172,31 @@ var _ = Describe("DD-WE-006: Dependency Resolution", Label("integration", "dd-we
 				"BR-WORKFLOW-008: failure message should name the missing resource from the Pod's FailedMount event")
 		})
 
+		It("IT-WE-1645-001 [BR-WORKFLOW-008]: should enrich the Failed message from the Pod's image-pull-failure event", func() {
+			wfe := createUniqueJobWFE("depres-1645-001", "default/deployment/dep-test-1645-001")
+			Expect(k8sClient.Create(ctx, wfe)).To(Succeed())
+			defer cleanupJobWFE(wfe)
+
+			job, err := waitForJobCreation(wfe.Name, 15*time.Second)
+			Expect(err).ToNot(HaveOccurred(), "Job should be created")
+
+			// EnvTest has no kubelet/job-controller: simulate the kubelet-emitted
+			// image-pull-failure Pod event + terminal JobFailed condition a real
+			// cluster would produce for an unreachable/nonexistent bundle image
+			// (Issue #1642 removed the DataStorage pre-flight check that used to
+			// catch some of these earlier, at registration time).
+			const badImageMessage = `Failed to pull image "quay.io/kubernaut/nonexistent-1645:v1": rpc error: code = NotFound desc = manifest unknown`
+			Expect(simulateJobFailureWithMissingDependency(job, "Failed", badImageMessage)).To(Succeed())
+
+			failedWFE, err := waitForWFEPhase(wfe.Name, wfe.Namespace, "Failed", 15*time.Second)
+			Expect(err).ToNot(HaveOccurred(), "WFE should reach Failed once the Job reaches a terminal JobFailed condition")
+
+			Expect(failedWFE.Status.Phase).To(Equal(workflowexecutionv1alpha1.PhaseFailed))
+			Expect(failedWFE.Status.FailureDetails).ToNot(BeNil())
+			Expect(failedWFE.Status.FailureDetails.Message).To(ContainSubstring("manifest unknown"),
+				"BR-WORKFLOW-008: failure message should surface the specific image-pull failure detail from the Pod event")
+		})
+
 		It("IT-WE-006-005: should create Job without dependency volumes when querier returns nil", func() {
 			testWorkflowQuerier.Deps = nil
 


### PR DESCRIPTION
## Summary

- Closes #1642: removes the DataStorage pre-flight `execution.bundle` OCI registry existence check (`ValidateBundleExists` / `ImagePuller.Exists`). The check ran from the DataStorage pod's own network/credential context and could not validate self-signed or credential-required private registries reachable only by the actual workflow execution environment, unconditionally blocking otherwise-valid registrations.
- Closes #1645 (filed as part of this triage): extends the Job execution engine's `enrichFailureMessage` (BR-WORKFLOW-008) to also classify kubelet image-pull-failure Pod events, mirroring the Tekton engine's existing `ImagePullBackOff` message classification. This gap is more relevant now that the pre-flight bundle check above is gone -- bad/unreachable bundle references for Job-engine workflows now always surface here at runtime instead.

## Changes

**Issue #1642 (DataStorage)**
- Removed `ImagePuller.Exists`, `SchemaExtractor.ValidateBundleExists`, and their mocks (`MockImagePullerWithFailingExists`) as dead code.
- Collapsed `validateExternalChecks`'s typed-result-slot/goroutine parallelism (Issue #1070) back into a direct sequential call now that only the action-type taxonomy check remains.
- Updated/removed the unit tests that locked in the old `bundle-not-found` behavior (`UT-WF-017-013`, `UT-WF-1070-003`); rewrote `UT-WF-1070-001/002` to no longer depend on the removed mock.
- Docs: `ADR-060` marked superseded for Pattern 1 (with a "Post-#1481/#1642" update section), `DD-WORKFLOW-017`'s stale `image-pull-failed` registration-error example dropped, and the relevant test-plan docs annotated.

**Issue #1645 (WorkflowExecution / Job engine)**
- `enrichFailureMessage` now also detects kubelet image-pull-failure events. Since kubelet reuses the generic `Failed`/`BackOff` reasons for many unrelated container lifecycle events, message-text matching (`pull image` / `ErrImagePull` / `ImagePullBackOff`) is required in addition to the reason, unlike the existing `podMountFailureReasons` check.
- Added `UT-WE-054-JOB-028/029/030` (including a negative test guarding against misclassifying an unrelated `Failed` event, e.g. a liveness-probe failure) and `IT-WE-1645-001` proving the end-to-end enrichment path through the real reconciler + envtest.

## Test plan

- [x] `go build ./...`
- [x] `golangci-lint run` on all touched packages -- 0 issues
- [x] `go vet ./...`
- [x] `go test ./pkg/datastorage/...` -- all pass
- [x] `go test ./pkg/workflowexecution/...` -- all pass (50/50 specs in `executor`, including new UT-WE-054-JOB-028/029/030)
- [x] Targeted integration run: `IT-WE-1481-001` (regression) and `IT-WE-1645-001` (new) both pass against real envtest
- [x] Repo-wide grep sweep for dangling references to removed symbols (`ValidateBundleExists`, `MockImagePullerWithFailingExists`, `bundle-not-found`) -- none in production code

## Notes for reviewers

- `Handler.schemaExtractor` / `WithSchemaExtractor` now have no remaining production caller in `pkg/datastorage/server` (their only use, `ValidateBundleExists`, is removed). Left in place as-is since `SchemaExtractor.ExtractFromImage` (OCI-based schema extraction) is out of scope for this PR; comments updated to flag this for future cleanup rather than silently expanding scope.
- The v1.5.3 hotfix backport to a new `release/v1.5` maintenance branch (discussed separately) is **not** included in this PR and will be handled as a follow-up hand-port once this lands on `main`, per prior discussion (v1.5.2's codebase predates #1481 and the `workflow_create_handlers.go` split, so a direct cherry-pick isn't feasible).

Made with [Cursor](https://cursor.com)