### PR TITLE
feat(apifrontend): thread cluster_id into AF RRContext and A2A events (#1409)

### DIFF
--- a/docs/architecture/decisions/ADR-065-fleet-cluster-identity-on-rr.md
+++ b/docs/architecture/decisions/ADR-065-fleet-cluster-identity-on-rr.md
@@ -116,7 +116,13 @@ type RemediationRequestSpec struct {
 | GW CRD population | CRDCreator.Create() | pkg/gateway/processing/crd_creator.go | IT-GW-FLEET-001 |
 | GW cluster-aware fingerprint | CalculateClusterAwareFingerprint | pkg/gateway/types/fingerprint.go | IT-GW-FLEET-002 |
 | KA SignalContext population | ResolveSignalContext() | internal/kubernautagent/mcp/adapters/signal_resolver.go | IT-KA-FLEET-001 |
-| AF RR creation | CreateRR tool | pkg/apifrontend/tools/af_create_rr.go | IT-AF-FLEET (pending) |
+| AF RR creation (cluster_id LLM arg) | HandleCreateRR / HandleInvestigateAlert / HandleRemediate / HandleInvestigationMCP | pkg/apifrontend/tools/{af_create_rr,af_investigate_alert,ka_remediate,ka_investigate_mcp}.go | IT-AF-1409-001..005 |
+| AF cluster-aware dedup | HandleCheckExistingRR (rrFingerprintWithCluster) | pkg/apifrontend/tools/af_check_existing_rr.go | UT-AF-1409-005/005b/005c, IT-AF-1409-006 |
+| AF takeover context reconstruction | resolveInvestigationRR / setTakeoverRRContext | pkg/apifrontend/tools/ka_investigate_mcp.go | UT-AF-1409-011/012/013 |
+| AF EventBridge RRContext.ClusterID | RRContext / mergeRRContext / RRContextSafe | pkg/apifrontend/launcher/event_bridge.go | UT-AF-1409-001/001b/001c/001d/002 |
+| AF investigation_summary artifact | emitDecisionEvent | pkg/apifrontend/launcher/part_converter.go | UT-AF-1409-006/006b/006c, IT-AF-1409-009 |
+| AF execution_progress artifact | BuildProgressSnapshot / crd_tools_watch.go | pkg/apifrontend/tools/execution_progress.go | UT-AF-1409-007/008, IT-AF-1409-007/007b |
+| AF Console context banner (full journey) | A2A `message/send` -> investigation_summary DataPart | test/e2e/fullpipeline/10_af_fleet_cluster_id_test.go | E2E-AF-1409-001 |
 
 ---
 
@@ -138,6 +144,7 @@ type RemediationRequestSpec struct {
 | IT-GW-FLEET-003 | Backward compat (empty clusterID when no cluster label) | PASS |
 | IT-KA-FLEET-001 | Fleet tools visible in RCA phase after AppendFleetToolsToRCA | PASS |
 | IT-KA-FLEET-002 | Empty fleet tools do not corrupt phase map | PASS |
+| UT/IT/E2E-AF-1409-* | AF cluster_id threading: RRContext, dedup, takeover reconstruction, investigation_summary/execution_progress artifacts, Console banner journey — see [docs/tests/1409/TEST_PLAN.md](../../tests/1409/TEST_PLAN.md) | PASS (full pyramid: 13 UT, 10 IT, 1 E2E — E2E verified against a live Kind cluster) |
 
 ---
 

--- a/docs/tests/1409/TEST_PLAN.md
+++ b/docs/tests/1409/TEST_PLAN.md
@@ -1,0 +1,521 @@
+# Test Plan: Fleet `cluster_id` on AF RR-Creating Tools + Context Propagation
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-1409-v1.0
+**Feature**: Thread `cluster_id` as an LLM-facing input on AF's RR-creating tools
+(`kubernaut_investigate_alert`, `kubernaut_investigate`, `kubernaut_remediate`), read it
+back into `EventBridge.RRContext`, and propagate it into `investigation_summary` and
+`execution_progress` A2A artifacts for Console multi-cluster context banners. Folds in
+two related correctness fixes discovered during preflight (#1423 takeover-path context
+gap, cluster-unaware dedup fingerprint in `kubernaut_check_existing_remediation`).
+**Version**: 1.0
+**Created**: 2026-07-08
+**Author**: AI Agent
+**Status**: Draft
+**Branch**: `feat/1409-af-cluster-id-events`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Issue #1409 asks for Console context banners to show which cluster a remediation is
+running against in multi-cluster (fleet) deployments. ADR-065 already added
+`ClusterID`/`ClusterName` to `RemediationRequestSpec` and wired Gateway to populate them
+from Thanos `external_labels`, but reserved AF's side as `IT-AF-FLEET (pending)`. Preflight
+for this plan found that AF's *internal* `CreateRRArgs`/`buildRRObject` already thread
+`ClusterID` into the RR spec, but no LLM-facing tool exposes `cluster_id` as an argument,
+so it is never actually set outside of Gateway-created RRs. Separately, `CreateRRResult`
+does not return `ClusterID`, so even AF-created RRs can't populate `RRContext` for the
+Console banner. This plan closes both gaps and the two related correctness issues below.
+
+### 1.2 Objectives
+
+1. **Write-side correctness**: `kubernaut_investigate_alert`, `kubernaut_investigate`, and
+   `kubernaut_remediate` accept an optional `cluster_id` argument and persist it to
+   `RemediationRequestSpec.ClusterID` on creation.
+2. **Read-back correctness**: `EventBridge.RRContext` carries `ClusterID`, and every status
+   event and the `investigation_summary`/`execution_progress` artifacts include `cluster_id`
+   in their metadata/payload once available.
+3. **Takeover-path correctness (#1423 gap)**: `kubernaut_investigate`'s `rr_id`-only
+   (takeover) branch fetches the full `RemediationRequest` object and populates all
+   available `RRContext` fields (namespace, kind, target, alert_name, cluster_id), not just
+   `rr_id`, with graceful degradation if the fetch fails.
+4. **Dedup correctness**: `kubernaut_check_existing_remediation` uses the same cluster-aware
+   fingerprint as `HandleCreateRR` (`rrFingerprintWithCluster`), so a resource with the same
+   namespace/kind/name on two different clusters is not incorrectly reported as a duplicate.
+5. **Backward compatibility**: local-hub (single-cluster) callers that omit `cluster_id`
+   see byte-identical behavior to today (empty-string cluster ID, existing fingerprints
+   unchanged — proven by `CalculateClusterAwareFingerprint("", ...)` already used by
+   `rrFingerprint`).
+6. **Wiring proof (Pyramid Invariant)**: `cluster_id` set via any of the three tools is
+   observable end-to-end in the SSE `investigation_summary` artifact, not just in an
+   in-memory struct field.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|---|---|---|
+| Unit test pass rate | 100% | `go test ./pkg/apifrontend/launcher/... ./pkg/apifrontend/tools/... ./pkg/apifrontend/validate/...` |
+| Integration test pass rate | 100% | `go test ./test/integration/apifrontend/...` |
+| Unit-testable code coverage | >=80% | `go tool cover` on modified files listed in Section 6.1 |
+| Backward compatibility | 0 regressions | Existing AF unit/integration suites pass unmodified |
+| E2E proof | 1 passing scenario | `cluster_id` reaches SSE `investigation_summary` artifact |
+
+### 1.4 FedRAMP / SOC2 Control Mapping
+
+> Every test in this plan verifies a business-level compliance behavior, not just a
+> technical implementation detail. Each test ID in Section 8/9 carries a bracketed
+> control tag, e.g. `UT-AF-1409-005 [AC-4]`, tying the test to the specific NIST 800-53
+> (FedRAMP) or SOC2 control it satisfies. SOC2 criteria are added only where they
+> genuinely apply alongside the more precise FedRAMP mapping (dual-mapping policy) —
+> not force-fit onto every row.
+
+| Control | Framework | Requirement | Satisfied By |
+|---|---|---|---|
+| AU-3 | FedRAMP (NIST 800-53) | Content of audit records: structured event payloads carry correct actor/cluster attribution | UT-AF-1409-003, UT-AF-1409-004, UT-AF-1409-007, UT-AF-1409-008, IT-AF-1409-001/002/003/007, E2E-AF-1409-001 |
+| SI-4 | FedRAMP (NIST 800-53) | System monitoring: cross-cluster signal correlation via `ClusterID` (mirrors ADR-065's own AU-3/SI-4 mapping for this field) | UT-AF-1409-001, IT-AF-1409-001/002/003/007, E2E-AF-1409-001 |
+| AC-4 | FedRAMP (NIST 800-53) | Information flow enforcement: cluster-scoped dedup fingerprint prevents remediation-state conflation across cluster boundaries | UT-AF-1409-005, IT-AF-1409-006 |
+| SI-10 | FedRAMP (NIST 800-53) | Input validation: caller-supplied context takes precedence over server-merged fields; `cluster_id` is length-bounded | UT-AF-1409-002, UT-AF-1409-006, UT-AF-1409-009 |
+| AC-6 | FedRAMP (NIST 800-53) | Least privilege: takeover-path fetch relies on a `get`-only RBAC grant, no broader access | IT-AF-1409-008 |
+| SI-17 | FedRAMP (NIST 800-53) | Fail-safe procedures: takeover-path fetch degrades gracefully instead of failing closed on the whole session | IT-AF-1409-005 |
+| AU-2 | FedRAMP (NIST 800-53) | Audit events: takeover-path fetch failures are logged, never silently swallowed | IT-AF-1409-005 |
+| CC8.1 | SOC2 | Complete remediation request reconstruction from audit/artifact traces alone (BR-AUDIT-005) | IT-AF-1409-004, E2E-AF-1409-001 |
+
+Updated tallies after closing the tier-skip and dead-code gaps below: AU-3 additionally covered by UT-AF-1409-010, IT-AF-1409-009; SI-10 additionally covered by IT-AF-1409-009, IT-AF-1409-010.
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- BR-FLEET-001: Fleet remediation requires cluster identity on every RR
+- BR-INTEGRATION-065: Multi-cluster signal routing and scope gating
+- [ADR-065](../../architecture/decisions/ADR-065-fleet-cluster-identity-on-rr.md): Fleet Cluster Identity on RR — reserves `IT-AF-FLEET (pending)` for this work
+- Issue [#1409](https://github.com/jordigilh/kubernaut/issues/1409): Console cluster context banner
+- Issue #1423 (referenced): takeover-path Console banner context gap
+- Issue #54: Multi-cluster remediation tracking
+
+### 2.2 Cross-References
+
+- [Wiring Verification](../../../.cursor/rules/10-wiring-verification.mdc)
+- [Testing Strategy](../../../.cursor/rules/03-testing-strategy.mdc)
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|-----------------|------------|
+| R1 | Adding `cluster_id` to `CheckExistingRRArgs` changes the fingerprint used by an already-shipped tool, silently breaking existing (single-cluster) dedup behavior | High — duplicate RRs created, or false-positive dedup | Low | UT-AF-1409-005, IT-AF-1409-006 | `CalculateClusterAwareFingerprint("", ...)` is proven backward-compatible (empty clusterID produces the pre-existing 3-field fingerprint format); regression-tested explicitly |
+| R2 | Takeover-path `client.Get()` fetch (#1423 fix) fails (RR deleted mid-session, RBAC denial) and blanks the whole banner instead of degrading gracefully | Medium — Console banner regression for takeover sessions | Low | IT-AF-1409-005 | Get failure is logged (AU-2) and falls back to the pre-existing `rr_id`-only `RRContext`, never panics or blocks the tool response |
+| R3 | RBAC: AF's ServiceAccount lacks `get` on `remediationrequests` for the takeover fetch | High — takeover path fetch always fails | Low (confirmed via preflight) | IT-AF-1409-008 | `deploy/apifrontend/base/02-rbac.yaml` already grants `get` on `remediationrequests`; regression test pins this |
+| R4 | `mergeRRContext`/`emitDecisionEvent` metadata key collision: caller-supplied `cluster_id` in a `FunctionCall` overwritten or dropped | Low — Console shows stale/wrong cluster | Low | UT-AF-1409-002, UT-AF-1409-006 | Follows the existing `mergeRRContext` precedence rule (caller keys win, SI-10) already proven for `rr_id`/`namespace`/etc. |
+| R5 | `ClusterID` format/source is documented inconsistently across `remediationrequest_types.go`, ADR-065, and `af_create_rr.go` (confirmed pre-existing doc drift, not introduced by this change) | Low — confusing tool description for the LLM | N/A | N/A | Out of scope for this PR; new tool descriptions kept format-agnostic (mirrors `kubectl_get` convention) rather than compounding the drift |
+
+### 3.1 Risk-to-Test Traceability
+
+R1-R3 are High/Medium impact and each has a dedicated regression test (UT-AF-1409-005,
+IT-AF-1409-005/006/008). R4 and R5 are Low impact; R4 has unit coverage, R5 is a
+documented non-goal.
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **`EventBridge.RRContext`** (`pkg/apifrontend/launcher/event_bridge.go`): `ClusterID` field
+  added, merged into status-event metadata via `mergeRRContext`.
+- **`CreateRRResult`** (`pkg/apifrontend/tools/af_create_rr.go`): `ClusterID` returned to
+  callers on both the create path (`buildRRObject`/`createOrReuseRR`) and the
+  dedup/reuse path (`checkExistingRRByFingerprint`/`CheckExistingRRResult`).
+- **`kubernaut_investigate_alert`** (`pkg/apifrontend/tools/af_investigate_alert.go`):
+  `cluster_id` accepted as LLM input, wired to `CreateRRArgs.ClusterID` and
+  `SetRRContextSafe`.
+- **`kubernaut_remediate`** (`pkg/apifrontend/tools/ka_remediate.go`): same wiring.
+- **`kubernaut_investigate`** (`pkg/apifrontend/tools/ka_investigate_mcp.go`): same wiring
+  on the create path; takeover (`rr_id`-only) path gains a `client.Get()` fetch that
+  populates full `RRContext` with graceful degradation.
+- **`kubernaut_check_existing_remediation`** (`pkg/apifrontend/tools/af_check_existing_rr.go`):
+  `cluster_id` accepted, cluster-aware fingerprint used for dedup lookups.
+- **`emitDecisionEvent`** (`pkg/apifrontend/launcher/part_converter.go`): merges
+  `cluster_id` into the `investigation_summary` `DataPart` via a new thread-safe
+  `EventBridge` accessor.
+- **`BuildProgressSnapshot`** (`pkg/apifrontend/tools/execution_progress.go`) and its call
+  site in `crd_tools_watch.go`: `cluster_id` added to the `execution_progress` payload,
+  sourced from the live `RemediationRequest` object.
+- **`validate.ClusterID`** (`pkg/apifrontend/validate/k8s.go`, new function): optional,
+  `MaxLength=253` input validation (SI-10).
+
+### 4.2 Features Not to be Tested
+
+- **`cluster_name`**: explicitly excluded from this change (deprecated field, not unique,
+  slated for removal — user decision).
+- **Gateway-side cluster extraction** (`pkg/gateway/adapters/prometheus_adapter.go`):
+  already covered by `IT-GW-FLEET-001/002/003` (ADR-065, PASS). Not re-tested here.
+- **RO/notification-side cluster consumption**: out of scope, separate ADR-065 migration
+  item.
+- **`ClusterID` format/source documentation inconsistency**: pre-existing, tracked as a
+  documentation cleanup, not a test gap.
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Add `cluster_id` only, not `cluster_name`, to all new LLM-facing args | `cluster_name` is non-unique and slated for removal; adding it now would create a feature dependent on a deprecated field |
+| Fold #1423 takeover-path gap and dedup-fingerprint correctness fix into this PR rather than filing separately | Both are pre-existing technical debt that this change would otherwise silently make worse (dedup) or leave stale (Console banner never populated on takeover) |
+| No new `DD-XXX` design decision record | This is an incremental extension of an existing, already-approved pattern (ADR-065 anticipated exactly this AF-side write path); no new architectural pattern introduced |
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+- **Unit**: >=80% of unit-testable logic (fingerprint selection, `mergeRRContext`,
+  `BuildProgressSnapshot`, `validate.ClusterID`).
+- **Integration**: 100% of wiring points in the manifest below (Section 14), each proven
+  through the real tool-handler-to-CRD-to-EventBridge path (no mocks on `pkg/` business
+  logic; fake `client.Client` for K8s per existing AF IT convention).
+- **E2E**: one proving journey (`cluster_id` reaches the SSE artifact), per Pyramid
+  Invariant — this is an extension of an existing tool, not a new subsystem, so a single
+  E2E scenario is sufficient rather than a full new E2E suite.
+
+### 5.2 Two-Tier Minimum
+
+Every objective in Section 1.2 is covered by at least UT + IT (see BR Coverage Matrix,
+Section 7).
+
+### 5.3 Pass/Fail Criteria
+
+**PASS**: all P0 tests pass, coverage targets met (Section 1.3), zero regressions in
+existing AF unit/integration suites (`af_create_rr_test.go`,
+`af_check_existing_rr_test.go`, `event_bridge_test.go`, `ka_investigate_mcp_test.go`).
+
+**FAIL**: any P0 test fails, any existing passing test regresses, or coverage drops below
+80% on any modified file's tier.
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `pkg/apifrontend/launcher/event_bridge.go` | `RRContext`, `mergeRRContext`, `RRContext()`/`RRContextSafe` (new accessors) | ~25 |
+| `pkg/apifrontend/tools/af_create_rr.go` | `createOrReuseRR`, `checkExistingRRByFingerprint`, `CreateRRResult` | ~15 |
+| `pkg/apifrontend/tools/af_check_existing_rr.go` | `HandleCheckExistingRR`, `CheckExistingRRArgs/Result` | ~15 |
+| `pkg/apifrontend/tools/execution_progress.go` | `BuildProgressSnapshot` | ~10 |
+| `pkg/apifrontend/launcher/part_converter.go` | `emitDecisionEvent` | ~10 |
+| `pkg/apifrontend/validate/k8s.go` | `ClusterID` (new) | ~10 |
+| `pkg/apifrontend/tools/ka_investigate_mcp.go` | `resolveInvestigationRR` takeover-fetch decision logic (success/failure/degrade), driven directly via `HandleInvestigationMCPWithRegistry` with a fake `client.Client` and mock MCP client (no MCP SDK/HTTP transport — same convention as the existing `UT-AF-1326-*` cases in `ka_investigate_mcp_test.go`) | ~15 |
+
+### 6.2 Integration-Testable Code
+
+| File | Functions/Methods | Lines (approx) |
+|------|-------------------|-----------------|
+| `pkg/apifrontend/tools/af_investigate_alert.go` | `InvestigateAlertArgs`, `HandleInvestigateAlert` | ~10 |
+| `pkg/apifrontend/tools/ka_remediate.go` | `RemediateArgs`, `HandleRemediate` | ~10 |
+| `pkg/apifrontend/tools/ka_investigate_mcp.go` | `InvestigateMCPArgs`, `resolveInvestigationRR` (takeover fetch, wiring proof through the real registered-tool dispatch path) | ~30 |
+| `pkg/apifrontend/tools/crd_tools_watch.go` | `handleRREvent` (`BuildProgressSnapshot` call site) | ~5 |
+| `deploy/apifrontend/base/02-rbac.yaml` | ClusterRole `get` on `remediationrequests` | N/A (config regression) |
+
+### 6.3 Version Identification
+
+| Item | Version/Commit | Notes |
+|------|----------------|-------|
+| Code under test | `feat/1409-af-cluster-id-events` HEAD | Branched from `origin/main` at `908672b71` |
+| Dependency: ADR-065 | Merged | `CreateRRArgs.ClusterID`/`buildRRObject` already implemented |
+
+---
+
+## 7. BR Coverage Matrix
+
+| BR ID | Description | Control | Priority | Tier | Test ID | Status |
+|-------|-------------|---------|----------|------|---------|--------|
+| BR-FLEET-001 | RRContext structurally carries ClusterID for cross-cluster correlation | SI-4 | P0 | Unit | UT-AF-1409-001 | Passing |
+| BR-FLEET-001 | mergeRRContext honors caller-supplied precedence over server-set cluster_id | SI-10 | P0 | Unit | UT-AF-1409-002 | Passing |
+| BR-FLEET-001 | CreateRRResult attributes correct cluster provenance on the create path | AU-3 | P0 | Unit | UT-AF-1409-003 | Passing |
+| BR-FLEET-001 | CreateRRResult attributes correct cluster provenance on the dedup/reuse path | AU-3 | P1 | Unit | UT-AF-1409-004 | Passing |
+| BR-INTEGRATION-065 | Cluster-aware fingerprint enforces information-flow isolation between clusters | AC-4 | P0 | Unit | UT-AF-1409-005 | Passing |
+| BR-FLEET-001 | investigation_summary artifact honors caller precedence for cluster_id | SI-10 | P0 | Unit | UT-AF-1409-006 | Passing |
+| BR-FLEET-001 | execution_progress payload carries correct cluster attribution | AU-3 | P0 | Unit | UT-AF-1409-007 | Passing |
+| BR-FLEET-001 | execution_progress omits cluster_id for local-hub RRs (no false attribution) | AU-3 | P1 | Unit | UT-AF-1409-008 | Passing |
+| BR-INTEGRATION-065 | validate.ClusterID enforces length-bounded input validation on LLM-supplied cluster_id | SI-10 | P1 | Unit | UT-AF-1409-009 | Passing |
+| BR-AUDIT-005 | emitCreateRRAudit attributes cluster_id in the Detail map for AF-originated fleet RRs | AU-3 | P1 | Unit | UT-AF-1409-010 | Passing |
+| BR-FLEET-001 | Takeover path's context-reconstruction decision logic populates full context from a successful fetch | AU-3, CC8.1 | P0 | Unit | UT-AF-1409-011 | Passing |
+| BR-FLEET-001 | Takeover path's context-reconstruction decision logic degrades to partial context on fetch failure, without erroring the tool call | SI-17, AU-2 | P1 | Unit | UT-AF-1409-012 | Passing |
+| BR-FLEET-001 | kubernaut_investigate_alert correctly attributes and correlates cluster identity end-to-end | AU-3, SI-4 | P0 | Integration | IT-AF-1409-001 | Passing |
+| BR-FLEET-001 | kubernaut_remediate correctly attributes and correlates cluster identity end-to-end | AU-3, SI-4 | P0 | Integration | IT-AF-1409-002 | Passing |
+| BR-FLEET-001 | kubernaut_investigate (create) correctly attributes and correlates cluster identity end-to-end | AU-3, SI-4 | P0 | Integration | IT-AF-1409-003 | Passing |
+| BR-FLEET-001 | Takeover path reconstructs complete remediation context from the RR alone (#1423) | AU-3, CC8.1 | P0 | Integration | IT-AF-1409-004 | Passing |
+| BR-FLEET-001 | Takeover path fails safe (degrades, doesn't fail closed) on fetch failure, failure is audited | SI-17, AU-2 | P1 | Integration | IT-AF-1409-005 | Passing |
+| BR-INTEGRATION-065 | check_existing_remediation enforces cluster-scoped information-flow isolation in dedup | AC-4 | P0 | Integration | IT-AF-1409-006 | Passing |
+| BR-FLEET-001 | execution_progress artifact carries correct cluster attribution end-to-end via watch loop | AU-3, SI-4 | P1 | Integration | IT-AF-1409-007 | Passing |
+| BR-INTEGRATION-065 | AF ServiceAccount holds least-privilege (get-only) access for the takeover fetch | AC-6 | P1 | Integration | IT-AF-1409-008 | Passing |
+| BR-FLEET-001 | emitDecisionEvent wiring proves cluster_id reaches the investigation_summary DataPart (IT tier, not just E2E) | SI-10, AU-3 | P0 | Integration | IT-AF-1409-009 | Passing |
+| BR-INTEGRATION-065 | validate.ClusterID is actually wired into the tool boundary, not dead code | SI-10 | P1 | Integration | IT-AF-1409-010 | Passing |
+| BR-FLEET-001 | Cluster identity is reconstructable end-to-end from the SSE-visible artifact alone | AU-3, SI-4, CC8.1 | P0 | E2E | E2E-AF-1409-001 | Passing |
+
+---
+
+## 8. Test Scenarios
+
+### Tier 1: Unit Tests
+
+| ID | Business Outcome Under Test | Phase |
+|----|------------------------------|-------|
+| UT-AF-1409-001 [SI-4] | `RRContext` structurally carries `ClusterID` so downstream status events can support cross-cluster signal correlation, not just single-cluster tracking | Passing |
+| UT-AF-1409-002 [SI-10] | `mergeRRContext` merges server-set `cluster_id` into event metadata but never overwrites a caller-supplied value — caller-provided context always takes precedence over merged defaults | Passing |
+| UT-AF-1409-003 [AU-3] | `createOrReuseRR`'s create branch attributes the newly created RR's audit-visible cluster identity (`CreateRRResult.ClusterID`) correctly to the cluster the caller specified | Passing |
+| UT-AF-1409-004 [AU-3] | `createOrReuseRR`'s existing-RR (dedup) branch attributes cluster identity from the *actual* existing RR object, not the caller's args — preventing a race from misattributing audit provenance to the wrong cluster | Passing |
+| UT-AF-1409-005 [AC-4] | Cluster-aware fingerprinting enforces information-flow isolation between clusters: a `cluster_id="a"` lookup never matches state fingerprinted under `cluster_id="b"` for the same namespace/kind/name, preventing remediation-state conflation across cluster boundaries (regression proving R1 is closed) | Passing |
+| UT-AF-1409-006 [SI-10] | `emitDecisionEvent` merges `cluster_id` into the `investigation_summary` DataPart from `RRContext`, but never overwrites a caller-supplied `cluster_id` already present in the decision payload — caller precedence enforced at the artifact layer too | Passing |
+| UT-AF-1409-007 [AU-3] | `execution_progress` payload carries correct cluster attribution (`cluster_id`) whenever the RR being watched has one, so Console audit/observability views are cluster-attributable | Passing |
+| UT-AF-1409-008 [AU-3] | `execution_progress` omits the `cluster_id` key entirely for local-hub RRs, avoiding false cluster attribution (empty-string noise) in audit-visible payloads for single-cluster deployments | Passing |
+| UT-AF-1409-009 [SI-10] | `validate.ClusterID` enforces length-bounded input validation on the LLM-supplied `cluster_id`, rejecting oversized values before they reach the RR spec or any downstream event payload | Passing |
+| UT-AF-1409-010 [AU-3] | `emitCreateRRAudit` includes `cluster_id` in the audit `Detail` map for both the RR-created and RR-deduplicated events, so AF-originated fleet RRs are cluster-attributable in the audit trail exactly like Gateway-originated ones | Passing |
+| UT-AF-1409-011 [AU-3, CC8.1] | `resolveInvestigationRR`'s takeover (`rr_id`-only) branch, driven directly against a fake `client.Client` seeded with a `RemediationRequest`, populates the *complete* context (namespace, kind, target, alert_name, cluster_id) from the fetched object — the pure decision logic, independent of the real MCP/HTTP transport that IT-AF-1409-004 additionally proves is wired | Passing |
+| UT-AF-1409-012 [SI-17, AU-2] | `resolveInvestigationRR`'s takeover branch, driven against a fake `client.Client` returning a not-found error, degrades to the partial (`rr_id`-only) context instead of failing the tool call, and logs the fetch failure — the pure decision logic for the fail-safe path IT-AF-1409-005 additionally proves is wired | Passing |
+
+### Tier Skip Rationale
+
+- **Unit tests for `af_investigate_alert.go`/`ka_remediate.go`/`ka_investigate_mcp.go` call-site wiring**: no dedicated UT is written for the `cluster_id` argument -> `CreateRRArgs.ClusterID` -> `SetRRContextSafe` plumbing in these three files. This is a single-field pass-through with no branching logic (zero decision points), so there is no business logic for a UT to exercise beyond what IT-AF-1409-001/002/003 already covers end to end. The wiring is proven at the IT tier instead (Two-Tier Minimum satisfied via IT + the transitively-exercised UT-AF-1409-003/004 for the fields it passes through).
+- **Unit tests for `deploy/apifrontend/base/02-rbac.yaml`**: static RBAC YAML has no unit-testable logic; IT-AF-1409-008 is the sole tier for this row (RBAC config assertions are not unit-testable by definition).
+
+### Tier 2: Integration Tests
+
+| ID | Business Outcome Under Test | Phase |
+|----|------------------------------|-------|
+| IT-AF-1409-001 [AU-3, SI-4] | `kubernaut_investigate_alert` with `cluster_id` produces an RR and a status-event stream that are both correctly and consistently attributed to that cluster end-to-end, enabling cross-cluster correlation. Also asserts, via the existing `fakeAuditor` pattern (`pkg/apifrontend/handler/mcp_bridge_integration_test.go`), that the emitted `audit.Event.Detail["cluster_id"]` matches the supplied value — this is the actual IT-tier proof for the audit-Detail-map row (Section 14), replacing the unverified "transitively exercised" claim from the prior revision | Passing |
+| IT-AF-1409-002 [AU-3, SI-4] | `kubernaut_remediate` with `cluster_id` produces the same correct end-to-end cluster attribution as IT-AF-1409-001 | Passing |
+| IT-AF-1409-003 [AU-3, SI-4] | `kubernaut_investigate`'s create path with `cluster_id` produces the same correct end-to-end cluster attribution as IT-AF-1409-001 | Passing |
+| IT-AF-1409-004 [AU-3, CC8.1] | A takeover session (`rr_id` only) reconstructs the *complete* remediation context — namespace, kind, target, alert name, and cluster identity — from the RR alone, proving audit-trail reconstruction is possible without the original creating session (closes the #1423 gap) | Passing |
+| IT-AF-1409-005 [SI-17, AU-2] | A takeover session against a deleted/inaccessible RR fails safe: it degrades to a partial (rr_id-only) context instead of failing the whole tool call, and the fetch failure is logged rather than silently swallowed | Passing |
+| IT-AF-1409-006 [AC-4] | `kubernaut_check_existing_remediation` enforces cluster-scoped information-flow isolation: a live, non-terminal remediation on one cluster is never reported as covering an identically-named target on a different cluster | Passing |
+| IT-AF-1409-007 [AU-3, SI-4] | The watch loop's `execution_progress` artifact is correctly attributed to the live RR's cluster identity end-to-end, not just at the unit level | Passing |
+| IT-AF-1409-008 [AC-6] | AF's ServiceAccount holds only `get` (not `list`/`watch`/`delete`) on `remediationrequests` at the RBAC layer, satisfying least-privilege for the new takeover-path fetch | Passing |
+| IT-AF-1409-009 [SI-10, AU-3] | `emitDecisionEvent`, driven directly against a real `EventBridge` and a fake `eventqueue.Writer` (no full E2E harness), correctly writes `cluster_id` into the `investigation_summary` DataPart — proving the wiring point itself, independent of the full journey E2E-AF-1409-001 covers | Passing |
+| IT-AF-1409-010 [SI-10] | An oversized `cluster_id` (>253 chars) supplied to `kubernaut_investigate_alert` and to `kubernaut_check_existing_remediation` is rejected at the tool boundary before it reaches the RR spec or any fingerprint computation, proving `validate.ClusterID` is actually wired into both validation paths (not dead code) | Passing |
+
+### Tier 3: E2E Tests
+
+| ID | Business Outcome Under Test | Phase |
+|----|------------------------------|-------|
+| E2E-AF-1409-001 [AU-3, SI-4, CC8.1] | A `cluster_id` supplied to `kubernaut_remediate` is fully reconstructable from the SSE-visible `investigation_summary` artifact alone via `RRContext` auto-fill (not LLM-supplied precedence, which UT-AF-1409-006b already covers), proving the complete chain from tool argument to Console-visible, audit-grade artifact (SOC2 CC8.1 reconstruction proof). Verified against a live Kind cluster (`test-e2e-fullpipeline` infra): `Ran 1 of 29 Specs`, `1 Passed \| 0 Failed`. | Passing |
+
+---
+
+## 9. Test Cases (P0 detail)
+
+### UT-AF-1409-005 [AC-4]: Cluster-aware dedup fingerprint enforces information-flow isolation
+
+**BR**: BR-INTEGRATION-065
+**Control**: AC-4 (Information flow enforcement, NIST 800-53/FedRAMP)
+**Priority**: P0
+**Type**: Unit
+**File**: `pkg/apifrontend/tools/af_check_existing_rr_test.go`
+
+**Test Steps**:
+1. **Given**: two `RemediationRequest`s exist for the same namespace/kind/name, one with
+   `spec.clusterID="cluster-a"`, one with `spec.clusterID="cluster-b"`, both non-terminal.
+2. **When**: `HandleCheckExistingRR` is called with `args.ClusterID="cluster-a"`.
+3. **Then**: it returns the `cluster-a` RR's `rr_id`, never the `cluster-b` RR's.
+
+**Acceptance Criteria**: cluster-aware fingerprint matches only the intended cluster's RR;
+omitting `cluster_id` (empty string) preserves today's pre-#1409 single-cluster behavior.
+
+### IT-AF-1409-004 [AU-3, CC8.1]: Takeover path reconstructs complete remediation context
+
+**BR**: BR-FLEET-001
+**Control**: AU-3 (Content of audit records); SOC2 CC8.1 (complete reconstruction from traces alone, BR-AUDIT-005)
+**Priority**: P0
+**Type**: Integration
+**File**: `test/integration/apifrontend/ka_investigate_mcp_test.go`
+
+**Test Steps**:
+1. **Given**: a `RemediationRequest` exists with `spec.clusterID="cluster-a"`,
+   `spec.targetResource={Namespace: "ns1", Kind: "Deployment", Name: "app1"}`, non-terminal.
+2. **When**: `kubernaut_investigate` is called with only `rr_id` set (no namespace/kind/name).
+3. **Then**: the resulting `EventBridge.RRContext` has `Namespace="ns1"`, `Kind="Deployment"`,
+   `Target="app1"`, `ClusterID="cluster-a"` — not just `RRID`.
+
+**Acceptance Criteria**: proves the #1423 Console-banner gap on takeover sessions is closed.
+
+---
+
+## 10. Environmental Needs
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory), matching existing `pkg/apifrontend/tools`
+  and `pkg/apifrontend/launcher` suites.
+- **Unit**: no external dependencies; `fake.NewClientBuilder()` for any K8s object access.
+- **Integration**: `fake.NewClientBuilder()`-backed `client.Client` (existing AF IT
+  convention — real business logic, faked K8s API per Mock Strategy in AGENTS.md).
+- **E2E**: existing `test/e2e/fullpipeline` harness (already exercises `investigate_alert`
+  through a real AF process; extend, don't duplicate).
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Blocking Dependencies
+
+None. ADR-065's CRD schema and Gateway-side wiring are already merged.
+
+### 11.2 Execution Order (per-component RED->GREEN cycles, per AGENTS.md's Wiring-First TDD Sequence)
+
+> **Sequencing correction**: an earlier revision of this section described one
+> "big-bang" RED phase (write all 20 tests up front) followed by one "big-bang" GREEN
+> phase (implement everything). That does not match AGENTS.md's actual Wiring-First TDD
+> Sequence, which pairs RED and GREEN *per component/wiring-point*:
+>
+> ```
+> RED: Write IT test calling component through production entry point -> fails
+>      Write UT test for component logic -> fails
+> GREEN: Wire component in production code -> IT passes
+>        Implement component logic -> UT passes
+> REFACTOR: Clean up
+> ```
+>
+> REFACTOR is a single shared step at the end, not per-component, because the
+> triplicated `RRContext`-from-`CreateRRResult` construction it removes only becomes
+> visible once all three create-path call sites already exist from earlier cycles.
+> CHECKPOINT W gates the *exit* of the last RED->GREEN cycle — per AGENTS.md, "GREEN is
+> NOT complete until both UT and IT pass" — it is not a step performed after REFACTOR.
+> REFACTOR only starts once every IT below is green. A second, lightweight re-run of the
+> full suite after REFACTOR (Post-Refactor Validation) confirms REFACTOR didn't regress
+> the wiring — it is a safety-net check, not the first proof of wiring.
+
+1. **Phase 1 (RED->GREEN cycles)** — ~6h, 12 cycles in dependency order: for each
+   component below, write its failing UT/IT first, confirm it fails against current
+   code, then write the minimal implementation to turn it green before moving to the
+   next component. No sophisticated logic in these cycles — minimal field additions and
+   wiring only.
+   1. `RRContext.ClusterID` + `mergeRRContext` — UT-AF-1409-001/002 (`event_bridge.go`)
+   2. `CreateRRResult.ClusterID` populated on create/dedup branches — UT-AF-1409-003/004 (`af_create_rr.go`)
+   3. `cluster_id` in both `emitCreateRRAudit` `Detail` maps — UT-AF-1409-010 (`af_create_rr.go`; missing entirely from the initial draft — code with no RED test)
+   4. `CheckExistingRRArgs/Result.ClusterID` + `rrFingerprintWithCluster` switch — UT-AF-1409-005, IT-AF-1409-006 (`af_check_existing_rr.go`)
+   5. `cluster_id` arg on `InvestigateAlertArgs`, wired to `CreateRRArgs`/`SetRRContextSafe` — IT-AF-1409-001 (`af_investigate_alert.go`)
+   6. `cluster_id` arg on `RemediateArgs`, same wiring — IT-AF-1409-002 (`ka_remediate.go`)
+   7. `cluster_id` arg on `InvestigateMCPArgs`, create-path wiring — IT-AF-1409-003 (`ka_investigate_mcp.go`)
+   8. Takeover `rr_id`-only branch: `client.Get` + graceful degradation, full `RRContext` — IT-AF-1409-004/005 (`ka_investigate_mcp.go`)
+   9. `cluster_id` merged into `investigation_summary` via `emitDecisionEvent` + new `EventBridge` accessor — UT-AF-1409-006, IT-AF-1409-009 (`part_converter.go`; previously skipped straight from UT to E2E, violating the Pyramid Invariant)
+   10. `BuildProgressSnapshot` signature extension + `crd_tools_watch.go` call site — UT-AF-1409-007/008, IT-AF-1409-007 (`execution_progress.go`)
+   11. `validate.ClusterID` (optional, `MaxLength=253`) wired into `validateCreateRRArgs` and `HandleCheckExistingRR` — UT-AF-1409-009 (unit), IT-AF-1409-010 (proves enforcement at the tool boundary, not just unit-tested in isolation)
+   12. RBAC regression pin (expected to pass immediately — locks current state, not new GREEN code) — IT-AF-1409-008
+
+   No new `cmd/` wiring is required for any of these — all three tools are already
+   registered in `cmd/apifrontend`; this extends existing registered tools' argument
+   schemas.
+2. **CHECKPOINT W (GREEN exit gate)** — ~0.25h: after all 12 cycles, confirm every row
+   in the Section 14 Wiring Manifest has a passing IT exercising the real
+   tool-to-CRD-to-EventBridge path — GREEN is not declared done until this is true,
+   including IT-AF-1409-009 (decision artifact) and IT-AF-1409-010 (validation wiring),
+   not just the UTs for those two rows.
+3. **Phase 3 (REFACTOR)** — ~1.5h: extract a shared "populate RRContext from
+   CreateRRResult" helper used by the three call sites (`af_investigate_alert.go`,
+   `ka_remediate.go`, `ka_investigate_mcp.go`) to avoid triplicated `SetRRContextSafe`
+   construction; apply Go Anti-Pattern Checklist. **Post-Refactor Validation (mandatory
+   precondition for calling REFACTOR complete)**: `go build ./...`, re-run every UT/IT
+   from Phase 1 and confirm all still pass, `grep` for any stale field/type names left
+   behind by the extraction.
+4. **Phase 4 (Wiring re-confirmation)** — ~0.5h: re-check the Section 14 manifest after
+   REFACTOR to confirm the extraction didn't silently break a wiring path (this is a
+   safety-net re-check; the first proof of wiring already happened at CHECKPOINT W above).
+5. **Phase 5 (E2E)** — ~1h: extend `test/e2e/fullpipeline` with E2E-AF-1409-001 — the
+   full-journey confirmation, distinct from (and downstream of) IT-AF-1409-009's
+   wiring-level proof.
+
+**Total estimate**: ~9.5h (~1.2 dev days) — unchanged from the prior revision; this is a
+sequencing fix, not a scope change.
+
+---
+
+## 12. Test Deliverables
+
+| Deliverable | Location | Description |
+|-------------|----------|--------------|
+| This test plan | `docs/tests/1409/TEST_PLAN.md` | Strategy and test design |
+| Unit tests | `pkg/apifrontend/launcher/event_bridge_test.go`, `pkg/apifrontend/tools/af_create_rr_test.go`, `af_check_existing_rr_test.go`, `execution_progress_test.go`, `part_converter_test.go`, `validate/k8s_test.go` | Ginkgo BDD specs |
+| Integration tests | `test/integration/apifrontend/*_test.go` | Ginkgo BDD specs |
+| E2E test | `test/e2e/fullpipeline/*_test.go` | Ginkgo BDD spec |
+| ADR-065 update | `docs/architecture/decisions/ADR-065-fleet-cluster-identity-on-rr.md` | Replace `IT-AF-FLEET (pending)` row with concrete `IT-AF-1409-001..008` |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests
+go test ./pkg/apifrontend/launcher/... ./pkg/apifrontend/tools/... ./pkg/apifrontend/validate/... -ginkgo.v
+
+# Integration tests
+go test ./test/integration/apifrontend/... -ginkgo.v -ginkgo.focus="1409"
+
+# E2E
+go test ./test/e2e/fullpipeline/... -ginkgo.focus="1409"
+
+# Coverage
+go test ./pkg/apifrontend/... -coverprofile=coverage.out
+go tool cover -func=coverage.out
+```
+
+---
+
+## 14. Wiring Verification (checked at CHECKPOINT W / GREEN exit; re-confirmed at Phase 4 post-REFACTOR)
+
+| Code Path | Entry Point | Exit Point | Control | Wiring IT | Status |
+|-----------|-------------|------------|---------|-----------|--------|
+| `cluster_id` arg -> `CreateRRArgs.ClusterID` -> `buildRRObject` | `kubernaut_investigate_alert` | RR `spec.clusterID` | AU-3, SI-4 | IT-AF-1409-001 | Passing |
+| `cluster_id` arg -> `CreateRRArgs.ClusterID` -> `buildRRObject` | `kubernaut_remediate` | RR `spec.clusterID` | AU-3, SI-4 | IT-AF-1409-002 | Passing |
+| `cluster_id` arg -> `CreateRRArgs.ClusterID` -> `buildRRObject` | `kubernaut_investigate` (create) | RR `spec.clusterID` | AU-3, SI-4 | IT-AF-1409-003 | Passing |
+| `CreateRRResult.ClusterID` -> `SetRRContextSafe` | all three create-path tools | `EventBridge.RRContext` | AU-3, SI-4 | IT-AF-1409-001/002/003 | Passing |
+| `rr_id`-only takeover (success) -> `client.Get` -> full `RRContext` | `kubernaut_investigate` (takeover) | `EventBridge.RRContext` | AU-3, CC8.1 | IT-AF-1409-004 | Passing |
+| `rr_id`-only takeover (fetch failure) -> graceful degradation | `kubernaut_investigate` (takeover) | partial `RRContext` + logged failure | SI-17, AU-2 | IT-AF-1409-005 | Passing |
+| `RRContext.ClusterID` -> `emitDecisionEvent` | `kubernaut_present_decision` FunctionCall | `investigation_summary` DataPart (SSE) | SI-10, AU-3 | IT-AF-1409-009 (wiring), E2E-AF-1409-001 (journey) | Passing |
+| RR `spec.clusterID` -> `BuildProgressSnapshot` | `handleRREvent` watch loop | `execution_progress` DataPart (SSE) | AU-3, SI-4 | IT-AF-1409-007 | Passing |
+| `cluster_id` arg -> cluster-aware fingerprint | `kubernaut_check_existing_remediation` | dedup lookup result | AC-4 | IT-AF-1409-006 | Passing |
+| ClusterRole `get` on `remediationrequests` | AF ServiceAccount | takeover `client.Get` call | AC-6 | IT-AF-1409-008 | Passing |
+| `args.ClusterID` -> `validate.ClusterID` | `validateCreateRRArgs`, `HandleCheckExistingRR` | rejected/accepted before RR spec or fingerprint | SI-10 | IT-AF-1409-010 | Passing |
+| `args.ClusterID` -> `emitCreateRRAudit` Detail map | `createOrReuseRR` (both branches) | `audit.Event.Detail["cluster_id"]` | AU-3 | IT-AF-1409-001 (extended to assert via `fakeAuditor`; see Section 8 note — previously only UT-AF-1409-010, which was an unverified "transitively exercised" claim found and closed on audit) | Passing |
+
+**Unit tests do NOT count as wiring proof.** All 12 rows above are proven by integration
+or E2E tests that traverse the real tool-handler-to-CRD-to-EventBridge stack; UT-AF-1409-010
+still exists as the unit-level proof of the `Detail` map construction logic itself, but the
+row above is no longer proven by UT alone.
+
+**Note on `mergeRRContext`'s own wiring (not a manifest row)**: `mergeRRContext`'s only
+production callers are `emitStatusEventWithMeta` and `emitKeepaliveEvent`
+(`event_bridge.go:244,291`), both pre-existing and already exercised by AF's existing status-event
+test suites. Adding `ClusterID` to its field map is additive to an already-proven wiring path, not
+a new wiring point, so UT-AF-1409-001/002 alone is sufficient here without a dedicated new IT.
+
+---
+
+## 15. Existing Tests Requiring Updates
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|---------------------|---------------------|-------------------|--------|
+| `af_check_existing_rr_test.go` (existing cases) | Calls `HandleCheckExistingRR` without `ClusterID` | None — `ClusterID` is `omitempty`; empty string preserves `rrFingerprint("", ...)` equivalence | Backward compatibility, not a behavior change |
+| `docs/architecture/decisions/ADR-065-fleet-cluster-identity-on-rr.md` Wiring Manifest (line 119) | `IT-AF-FLEET (pending)` | Replace with `IT-AF-1409-001` (primary AF RR-creation wiring proof) | This plan implements the row ADR-065 reserved |
+
+---
+
+## 16. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-07-08 | Initial test plan |
+| 1.1 | 2026-07-08 | Added Section 1.4 FedRAMP/SOC2 Control Mapping table; rewrote every test scenario (Sections 7, 8, 9, 14) to carry a bracketed control tag and a business-level compliance description instead of a technical-implementation description, per project methodology (mandatory for all test plans and implementation plans, not just this one) |
+| 1.2 | 2026-07-08 | Closed three Pyramid Invariant / TDD gaps found on audit: (1) added UT-AF-1409-010 for the previously-untested `emitCreateRRAudit` Detail-map change; (2) added IT-AF-1409-009 so `emitDecisionEvent` wiring is proven at the IT tier instead of only via E2E; (3) added IT-AF-1409-010 and wired `validate.ClusterID` into `validateCreateRRArgs`/`HandleCheckExistingRR` so it isn't dead code; (4) documented the Tier Skip Rationale for the three call-site tools' UT skip; (5) corrected Section 11.2 so CHECKPOINT W gates GREEN's exit, not a step after REFACTOR |
+| 1.3 | 2026-07-08 | Rewrote Section 11.2: replaced the "big-bang" RED-all-then-GREEN-all sequencing with AGENTS.md's actual Wiring-First TDD Sequence (RED->GREEN paired per component, 12 cycles in dependency order, single shared REFACTOR at the end since the triplicated-helper duplication is only visible once all three create-path call sites exist). Retitled Section 14 to clarify the Wiring Manifest is checked twice — first at CHECKPOINT W (GREEN's exit gate), then re-confirmed at the post-REFACTOR phase — not solely "TDD Phase 4" as previously mislabeled. The implementation plan's todos were restructured the same way. |
+| 1.4 | 2026-07-08 | Pyramid Invariant re-audit against the real codebase (not just this plan's own claims) found two gaps: (1) the audit-Detail-map manifest row claimed "transitively exercised by IT-AF-1409-001/002/003" but none of those IT descriptions actually asserted on the audit trail — confirmed a `fakeAuditor` capture pattern already exists in `pkg/apifrontend/handler/mcp_bridge_integration_test.go`, so extended IT-AF-1409-001's scope to assert `audit.Event.Detail["cluster_id"]`, closing the row's contradiction with this section's own "unit tests do NOT count as wiring proof" rule; (2) the Wiring Manifest was missing a dedicated row for IT-AF-1409-005 (the fail-safe/degradation branch, distinct from IT-AF-1409-004's happy path) even though it's a listed P1 test — added it. Manifest is now 12 rows, all IT/E2E-proven. Also documented (as a non-gap, verified via grep of `mergeRRContext`'s actual call sites) why `mergeRRContext`'s own field addition doesn't need a new dedicated IT: its callers are pre-existing, already-wired production code. |
+| 1.5 | 2026-07-08 | Follow-up Pyramid Invariant audit (triggered by a direct "do you guarantee the pyramid invariant" question) cross-checked all 12 Wiring Manifest rows against Sections 6-9 line by line. Found one documentation inconsistency: `resolveInvestigationRR`'s takeover-fetch rows (IT-AF-1409-004/005) have no UT and, unlike the other two skipped-UT rows (call-site wiring, RBAC YAML), had no documented Tier Skip Rationale explaining why. Added a third Tier Skip Rationale bullet (Section 8) explaining the skip is consistent with the project's Mock Strategy — `client.Get()` against a `RemediationRequest` is Kubernetes-API-backed and therefore fake-client-driven (Integration tier) by definition, with no separable pure-logic branch to extract into a UT without an artificial split. No coverage gap was found (all 12 rows remain IT/E2E-proven); this closes a documentation-completeness gap only. |
+| 1.6 | 2026-07-08 | Corrected v1.5's conclusion after re-recall confirmed a stronger, no-exceptions project rule: "100% business logic unit test coverage for all implementations, with no exceptions" — and that this codebase already treats direct-handler-call tests with fake/mock dependencies (including a fake `client.Client`) as legitimate Unit tests, reserving Integration for tests that go through the real MCP SDK/HTTP transport (evidenced by `ka_investigate_mcp_test.go`'s existing `UT-AF-1326-*` cases, which call `HandleInvestigationMCP` directly with a mock MCP client). Reverted the v1.5 Tier Skip Rationale bullet and added UT-AF-1409-011 (success reconstruction) and UT-AF-1409-012 (fail-safe degradation) as genuine Unit tests of `resolveInvestigationRR`'s takeover-fetch decision logic, driven directly (bypassing MCP transport) against a fake `client.Client`. IT-AF-1409-004/005 remain unchanged as the IT-tier wiring proof through the real registered-tool dispatch path. Added a new `RRContext()`/`RRContextSafe` accessor pair (Section 6.1) needed for these UTs (and reused internally by `emitDecisionEvent`) to read back the bridge's context from outside `pkg/apifrontend/launcher`. |
+| 1.7 | 2026-07-09 | CHECKPOINT W executed against the real codebase (not just this plan's claims): found that IT-AF-1409-001/002/003/004/005/006 were documented as the Wiring Manifest's proof rows but had never actually been written — only their UT-tier siblings (UT-AF-1409-003/004/005/005b/005c/011/012/013) existed. Closed the gap by adding all six as new `It` specs driven through the real registered-tool dispatch path (`HandleInvestigateAlert`, `HandleRemediate`, `HandleInvestigationMCPWithRegistry` with a mock MCP client, `HandleCheckExistingRR`), asserting on the created RR's `spec.clusterID`, the `audit.Event.Detail["cluster_id"]` via the existing `auditRecorder`, and the A2A status-event metadata via the existing `bridgeQueue` pattern. All 620+ specs in `pkg/apifrontend/tools` and the full `pkg/apifrontend/...` module pass with zero regressions. All 12 Wiring Manifest rows (Section 14) now show `Passing` except the one row whose E2E leg (`E2E-AF-1409-001`) is intentionally deferred to the E2E phase. Also added `IT-AF-1409-008` to `test/infrastructure/rbac_parity_test.go` (Cycle 12), regression-pinning the pre-existing `get` grant on `remediationrequests`. Sections 7 and 8 updated from `Pending` to `Passing` for every test ID now implemented and green. |
+| 1.8 | 2026-07-09 | E2E-AF-1409-001 written and run against a live Kind cluster (user explicitly asked "why not live cluster to test? can't you spawn a kind cluster?" — answer: yes, and it surfaced two real bugs). RCA via must-gather on two failed live runs found: (1) a genuine infra issue (`no space left on device` in the Podman VM — resolved via `podman system prune -af --volumes`, unrelated to this change); (2) a pre-existing, unrelated latent bug in `test/services/mock-llm`'s `NextToolCall` chaining (`handlers/gemini.go`): unlike the sibling `RepeatToolCall` path, `NextToolCall` had no "fire once" guard, so `match_last_only` kept re-matching the same scenario and the mock-LLM re-emitted the chained tool call on every ADK reasoning round-trip — an unbounded loop (confirmed in must-gather: same scenario firing every ~0.5s for 60+ seconds). Fixed at the source by adding `response.HasFunctionResponseNamed(contents, name)` (scans *all* conversation history, not just the last turn, unlike the existing `LastContentIsFunctionResponse`) and gating `NextToolCall` on it in `handlers/gemini.go`; this is a mock-LLM infrastructure fix with no production-code impact, verified against the existing `UT-ML-1407-*` regression suite (all still green) before re-running the E2E test. A second must-gather cycle (after the loop fix) found a third, narrower bug: the mock scenario's chained `kubernaut_present_decision` call was (a) incorrectly passing `cluster_id` as a tool argument — `kubernaut_present_decision`'s schema has no such property, so ADK's schema validation rejected the call before its handler ever ran — and (b) missing the schema-required `session_id` field. Both defeated the very RRContext-auto-fill path the test targets. Fixed by removing `cluster_id` from the scenario's `kubernaut_present_decision` arguments (letting `emitDecisionEvent`'s auto-fill populate it from `RRContext`, per cycle 9) and adding a `session_id` placeholder value (uninspected by `HandlePresentDecision`, only schema-validated). Confidence gate: preflight (root-caused via must-gather logs, not guesswork) plus a full mock-llm regression run (`go test ./test/services/mock-llm/...`, all green including OpenAI's unaffected, already-guarded `NextToolCall` path) raised confidence above 90% before the fix was applied, per the monitoring protocol. E2E-AF-1409-001 now passes against a live Kind cluster: `Ran 1 of 29 Specs in 1000.537 seconds` / `1 Passed \| 0 Failed \| 0 Pending \| 28 Skipped`. Sections 7, 8, and 14 updated from `Pending`/`IT Passing / E2E Pending` to `Passing`. ADR-065's Wiring Manifest and Test Plan Reference updated to close out the `IT-AF-FLEET (pending)` placeholder row and reference the full #1409 pyramid. |

--- a/pkg/apifrontend/launcher/event_bridge.go
+++ b/pkg/apifrontend/launcher/event_bridge.go
@@ -79,6 +79,10 @@ type RRContext struct {
 	Target    string `json:"target"`
 	AlertName string `json:"alert_name"`
 	Phase     string `json:"phase"`
+	// ClusterID is the fleet cluster identifier (ADR-065). Empty for local-hub
+	// (single-cluster) RRs, in which case it is omitted from event metadata
+	// entirely (#1409, SI-10: no false attribution via empty-string noise).
+	ClusterID string `json:"cluster_id,omitempty"`
 }
 
 // EventBridge enables tool handlers to emit progressive A2A events directly to
@@ -139,6 +143,7 @@ func (b *EventBridge) mergeRRContext(meta map[string]any) map[string]any {
 		"target":     b.rrCtx.Target,
 		"alert_name": b.rrCtx.AlertName,
 		"phase":      b.rrCtx.Phase,
+		"cluster_id": b.rrCtx.ClusterID,
 	}
 	for k, v := range fields {
 		if v == "" {
@@ -159,6 +164,32 @@ func SetRRContextSafe(ctx context.Context, rc *RRContext) {
 		return
 	}
 	bridge.SetRRContext(rc)
+}
+
+// RRContext returns a copy of the bridge's stored RR context, or nil if
+// SetRRContext has not been called. Thread-safe: protected by the bridge
+// mutex. Used by artifact producers (e.g. emitDecisionEvent) and callers
+// outside this package that need to read back server-sourced fields such
+// as ClusterID (#1409) without a data race on the underlying pointer.
+func (b *EventBridge) RRContext() *RRContext {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	if b.rrCtx == nil {
+		return nil
+	}
+	rc := *b.rrCtx
+	return &rc
+}
+
+// RRContextSafe is a nil-safe helper that returns a copy of the RR context
+// stored on the EventBridge in ctx. Returns nil when no bridge is present or
+// no context has been set yet.
+func RRContextSafe(ctx context.Context) *RRContext {
+	bridge := EventBridgeFromContext(ctx)
+	if bridge == nil {
+		return nil
+	}
+	return bridge.RRContext()
 }
 
 // UpdatePhaseSafe updates the phase on the EventBridge from context. Nil-safe.

--- a/pkg/apifrontend/launcher/event_bridge_test.go
+++ b/pkg/apifrontend/launcher/event_bridge_test.go
@@ -1255,3 +1255,83 @@ var _ = Describe("RR Context Enrichment — #1423 (AU-3, SI-4, SC-7)", func() {
 		})
 	})
 })
+
+// Fleet cluster_id propagation — #1409 (SI-4, SI-10, AU-3).
+var _ = Describe("RR Context Fleet cluster_id — #1409 (SI-4, SI-10, AU-3)", func() {
+
+	Describe("RRContext.ClusterID structural carry (SI-4: cross-cluster correlation)", func() {
+		It("UT-AF-1409-001: RRContext carries ClusterID through to status event metadata", func() {
+			queue := &fakeQueue{}
+			ctx := launcher.WithEventBridge(context.Background(), queue, "task-1409-001", "ctx-1409-001", nil)
+			bridge := launcher.EventBridgeFromContext(ctx)
+
+			bridge.SetRRContext(&launcher.RRContext{
+				RRID:      "rr-fleet-001",
+				Namespace: "demo-gateway",
+				ClusterID: "cluster-east-1",
+				Phase:     "Investigating",
+			})
+
+			Expect(bridge.EmitStatus(ctx, "Investigation starting...")).To(Succeed())
+			Expect(queue.events).To(HaveLen(1))
+
+			evt := queue.events[0].(*a2a.TaskStatusUpdateEvent)
+			Expect(evt.Metadata).To(HaveKeyWithValue("cluster_id", "cluster-east-1"),
+				"SI-4: cluster_id enables cross-cluster signal correlation in fleet deployments")
+
+			rc := launcher.RRContextSafe(ctx)
+			Expect(rc).NotTo(BeNil())
+			Expect(rc.ClusterID).To(Equal("cluster-east-1"),
+				"RRContextSafe must round-trip ClusterID for downstream artifact consumers (e.g. emitDecisionEvent)")
+		})
+
+		It("UT-AF-1409-001b: status events omit cluster_id entirely for local-hub RRs (no false attribution)", func() {
+			queue := &fakeQueue{}
+			ctx := launcher.WithEventBridge(context.Background(), queue, "task-1409-001b", "ctx-1409-001b", nil)
+			bridge := launcher.EventBridgeFromContext(ctx)
+
+			bridge.SetRRContext(&launcher.RRContext{RRID: "rr-local-001", Phase: "Investigating"})
+			Expect(bridge.EmitStatus(ctx, "Investigation starting...")).To(Succeed())
+
+			evt := queue.events[0].(*a2a.TaskStatusUpdateEvent)
+			Expect(evt.Metadata).NotTo(HaveKey("cluster_id"),
+				"SI-10: empty-string cluster_id must not appear as noise for single-cluster deployments")
+		})
+	})
+
+	Describe("mergeRRContext caller precedence for cluster_id (SI-10: server-sourced authority)", func() {
+		It("UT-AF-1409-002: caller-supplied cluster_id metadata takes precedence over RR context", func() {
+			queue := &fakeQueue{}
+			ctx := launcher.WithEventBridge(context.Background(), queue, "task-1409-002", "ctx-1409-002", nil)
+			bridge := launcher.EventBridgeFromContext(ctx)
+
+			bridge.SetRRContext(&launcher.RRContext{
+				RRID:      "rr-fleet-002",
+				ClusterID: "cluster-from-context",
+				Phase:     "Investigating",
+			})
+
+			callerMeta := map[string]any{
+				"type":       launcher.MetaTypeStatus,
+				"cluster_id": "cluster-from-caller",
+			}
+			Expect(bridge.EmitStatusWithMeta(ctx, "Caller-scoped update", callerMeta)).To(Succeed())
+
+			evt := queue.events[0].(*a2a.TaskStatusUpdateEvent)
+			Expect(evt.Metadata).To(HaveKeyWithValue("cluster_id", "cluster-from-caller"),
+				"SI-10: caller-provided cluster_id always takes precedence over merged defaults")
+		})
+	})
+
+	Describe("RRContextSafe nil-safety (SC-7: boundary protection)", func() {
+		It("UT-AF-1409-001c: RRContextSafe returns nil when no bridge is present in context", func() {
+			Expect(launcher.RRContextSafe(context.Background())).To(BeNil())
+		})
+
+		It("UT-AF-1409-001d: RRContextSafe returns nil when a bridge is present but SetRRContext was never called", func() {
+			queue := &fakeQueue{}
+			ctx := launcher.WithEventBridge(context.Background(), queue, "task-1409-001d", "ctx-1409-001d", nil)
+			Expect(launcher.RRContextSafe(ctx)).To(BeNil())
+		})
+	})
+})

--- a/pkg/apifrontend/launcher/part_converter.go
+++ b/pkg/apifrontend/launcher/part_converter.go
@@ -396,6 +396,14 @@ func emitDecisionEvent(ctx context.Context, bridge *EventBridge, fc *genai.Funct
 		data = map[string]any{}
 	}
 
+	// SI-10: caller-supplied cluster_id (already present in the LLM-produced
+	// payload) takes precedence over the server-side RRContext value.
+	if rc := bridge.RRContext(); rc != nil && rc.ClusterID != "" {
+		if _, exists := data["cluster_id"]; !exists {
+			data["cluster_id"] = rc.ClusterID
+		}
+	}
+
 	summary, _ := data["summary"].(string)
 	if summary == "" {
 		summary = "Remediation decision"

--- a/pkg/apifrontend/launcher/part_converter_test.go
+++ b/pkg/apifrontend/launcher/part_converter_test.go
@@ -2041,3 +2041,92 @@ var _ = Describe("Event-aware text routing (#1410)", func() {
 		})
 	})
 })
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// #1409: Fleet cluster_id propagation into investigation_summary artifact
+// ═══════════════════════════════════════════════════════════════════════════════
+
+var _ = Describe("Fleet cluster_id propagation into investigation_summary (#1409)", func() {
+	var convert launcher.PartConverterFunc
+
+	BeforeEach(func() {
+		convert = launcher.BuildPartConverterForTest()
+	})
+
+	decisionPart := func(args map[string]any) *genai.Part {
+		return &genai.Part{
+			FunctionCall: &genai.FunctionCall{
+				Name: "kubernaut_present_decision",
+				Args: args,
+			},
+		}
+	}
+
+	It("UT-AF-1409-006: emitDecisionEvent merges cluster_id from RRContext into the investigation_summary DataPart", func() {
+		queue, ctx := partConverterBridgeCtx()
+		launcher.SetRRContextSafe(ctx, &launcher.RRContext{RRID: "rr-1409-006", ClusterID: "cluster-fleet-a"})
+
+		part := decisionPart(map[string]any{
+			"session_id": "sess-1409-006",
+			"summary":    "OOMKill detected",
+			"rca":        map[string]any{"severity": "critical", "confidence": 0.9, "explanation": "memory limit exceeded"},
+			"options":    []any{},
+		})
+		result, err := convert(ctx, nil, part)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeNil())
+
+		Expect(queue.events).To(HaveLen(1))
+		artifactEvt, ok := queue.events[0].(*a2a.TaskArtifactUpdateEvent)
+		Expect(ok).To(BeTrue())
+		dp, ok := artifactEvt.Artifact.Parts[0].(a2a.DataPart)
+		Expect(ok).To(BeTrue())
+		Expect(dp.Data).To(HaveKeyWithValue("cluster_id", "cluster-fleet-a"),
+			"AU-3: investigation_summary DataPart must carry cluster_id from RRContext for Console multi-cluster banners")
+	})
+
+	It("UT-AF-1409-006b: emitDecisionEvent never overwrites a caller-supplied cluster_id (SI-10 precedence)", func() {
+		queue, ctx := partConverterBridgeCtx()
+		launcher.SetRRContextSafe(ctx, &launcher.RRContext{RRID: "rr-1409-006b", ClusterID: "cluster-server-side"})
+
+		part := decisionPart(map[string]any{
+			"session_id": "sess-1409-006b",
+			"summary":    "OOMKill detected",
+			"rca":        map[string]any{"severity": "critical", "confidence": 0.9, "explanation": "memory limit exceeded"},
+			"options":    []any{},
+			"cluster_id": "cluster-caller-supplied",
+		})
+		_, err := convert(ctx, nil, part)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(queue.events).To(HaveLen(1))
+		artifactEvt, ok := queue.events[0].(*a2a.TaskArtifactUpdateEvent)
+		Expect(ok).To(BeTrue())
+		dp, ok := artifactEvt.Artifact.Parts[0].(a2a.DataPart)
+		Expect(ok).To(BeTrue())
+		Expect(dp.Data).To(HaveKeyWithValue("cluster_id", "cluster-caller-supplied"),
+			"SI-10: caller-supplied cluster_id in the decision payload must take precedence over RRContext")
+	})
+
+	It("UT-AF-1409-006c: emitDecisionEvent omits cluster_id when RRContext has none (local-hub RR)", func() {
+		queue, ctx := partConverterBridgeCtx()
+		launcher.SetRRContextSafe(ctx, &launcher.RRContext{RRID: "rr-1409-006c"})
+
+		part := decisionPart(map[string]any{
+			"session_id": "sess-1409-006c",
+			"summary":    "OOMKill detected",
+			"rca":        map[string]any{"severity": "critical", "confidence": 0.9, "explanation": "memory limit exceeded"},
+			"options":    []any{},
+		})
+		_, err := convert(ctx, nil, part)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(queue.events).To(HaveLen(1))
+		artifactEvt, ok := queue.events[0].(*a2a.TaskArtifactUpdateEvent)
+		Expect(ok).To(BeTrue())
+		dp, ok := artifactEvt.Artifact.Parts[0].(a2a.DataPart)
+		Expect(ok).To(BeTrue())
+		Expect(dp.Data).NotTo(HaveKey("cluster_id"),
+			"AU-3: local-hub RRs (no ClusterID) must not inject a false empty cluster_id attribution")
+	})
+})

--- a/pkg/apifrontend/launcher/schemas/execution_progress.v1.schema.json
+++ b/pkg/apifrontend/launcher/schemas/execution_progress.v1.schema.json
@@ -26,6 +26,10 @@
     "completed_at": {
       "type": "string",
       "format": "date-time"
+    },
+    "cluster_id": {
+      "type": "string",
+      "description": "Fleet cluster identifier for the RemediationRequest, when applicable (ADR-065)."
     }
   },
   "additionalProperties": true

--- a/pkg/apifrontend/launcher/schemas/investigation_summary.v1.schema.json
+++ b/pkg/apifrontend/launcher/schemas/investigation_summary.v1.schema.json
@@ -12,6 +12,10 @@
     "rr_id": {
       "type": "string"
     },
+    "cluster_id": {
+      "type": "string",
+      "description": "Fleet cluster identifier for the RemediationRequest, when applicable (ADR-065)."
+    },
     "summary": {
       "type": "string"
     },

--- a/pkg/apifrontend/launcher/streaming_it_test.go
+++ b/pkg/apifrontend/launcher/streaming_it_test.go
@@ -215,6 +215,43 @@ var _ = Describe("IT-AF-1399: A2A Streaming Pipeline Wiring", func() {
 		})
 	})
 
+	Describe("Fleet cluster_id propagation (#1409)", func() {
+		It("IT-AF-1409-009: cluster_id reaches the investigation_summary DataPart through the streaming pipeline", func() {
+			convert := launcher.BuildStreamingPartConverterForTest()
+			part := &genai.Part{
+				FunctionCall: &genai.FunctionCall{
+					Name: "kubernaut_present_decision",
+					Args: map[string]any{
+						"session_id": "sess-it-1409-009",
+						"summary":    "Disk pressure detected",
+						"rca":        map[string]any{"severity": "high", "confidence": 0.85, "explanation": "disk full"},
+						"options":    []any{map[string]any{"workflow_id": "wf-1", "name": "Evict Pod"}},
+					},
+				},
+			}
+			queue := &fakeQueue{}
+			ctx := launcher.WithEventBridge(context.Background(), queue, "task-it-1409-009", "ctx-it-1409-009", nil)
+			launcher.SetRRContextSafe(ctx, &launcher.RRContext{RRID: "rr-it-1409-009", ClusterID: "cluster-fleet-it"})
+
+			result, err := convert(ctx, nil, part)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNil())
+
+			Expect(queue.events).To(HaveLen(1))
+			artifactEvt, ok := queue.events[0].(*a2a.TaskArtifactUpdateEvent)
+			Expect(ok).To(BeTrue(), "AU-3: decision must emit TaskArtifactUpdateEvent")
+
+			dp, ok := artifactEvt.Artifact.Parts[0].(a2a.DataPart)
+			Expect(ok).To(BeTrue())
+			Expect(dp.Data).To(HaveKeyWithValue("cluster_id", "cluster-fleet-it"),
+				"SI-10, AU-3: cluster_id must reach the investigation_summary DataPart through the wired streaming pipeline")
+
+			err = launcher.ValidatePayloadForTest("investigation_summary", dp.Data)
+			Expect(err).NotTo(HaveOccurred(),
+				"SI-10: emitted DataPart.Data with cluster_id must still pass schema validation")
+		})
+	})
+
 	Describe("outputMetaTools routing preserved", func() {
 		It("IT-AF-1399-005: kubernaut_watch FunctionResponse still uses status type", func() {
 			convert := launcher.BuildPartConverterForTest()

--- a/pkg/apifrontend/tools/af_check_existing_rr.go
+++ b/pkg/apifrontend/tools/af_check_existing_rr.go
@@ -19,6 +19,10 @@ type CheckExistingRRArgs struct {
 	Namespace string `json:"namespace"`
 	Kind      string `json:"kind"`
 	Name      string `json:"name"`
+	// ClusterID scopes the dedup fingerprint to a specific fleet cluster
+	// (#1409, AC-4). Empty string preserves pre-#1409 local-hub matching
+	// behavior for backward compatibility.
+	ClusterID string `json:"cluster_id,omitempty"`
 }
 
 // CheckExistingRRResult is the output of kubernaut_check_existing_remediation.
@@ -27,6 +31,8 @@ type CheckExistingRRResult struct {
 	RRID     string `json:"rr_id,omitempty"`
 	Phase    string `json:"phase,omitempty"`
 	Severity string `json:"severity,omitempty"`
+	// ClusterID attributes the existing RR to its cluster of origin (#1409).
+	ClusterID string `json:"cluster_id,omitempty"`
 }
 
 // HandleCheckExistingRR checks whether a non-terminal RemediationRequest already
@@ -53,8 +59,11 @@ func HandleCheckExistingRR(ctx context.Context, client crclient.Client, controll
 	if args.Name == "" {
 		return CheckExistingRRResult{}, fmt.Errorf("%w: name must not be empty", ErrInvalidInput)
 	}
+	if err := validate.ClusterID(args.ClusterID); err != nil {
+		return CheckExistingRRResult{}, fmt.Errorf("%w: %w", ErrInvalidInput, err)
+	}
 
-	fingerprint := rrFingerprint(args.Namespace, args.Kind, args.Name)
+	fingerprint := rrFingerprintWithCluster(args.ClusterID, args.Namespace, args.Kind, args.Name)
 
 	var list remediationv1.RemediationRequestList
 	if err := client.List(ctx, &list, crclient.InNamespace(controllerNS)); err != nil {
@@ -69,9 +78,10 @@ func HandleCheckExistingRR(ctx context.Context, client crclient.Client, controll
 		phase := string(item.Status.OverallPhase)
 		if !IsTerminalPhase(phase) {
 			return CheckExistingRRResult{
-				Exists: true,
-				RRID:   item.Name,
-				Phase:  phase,
+				Exists:    true,
+				RRID:      item.Name,
+				Phase:     phase,
+				ClusterID: item.Spec.ClusterID,
 			}, nil
 		}
 	}

--- a/pkg/apifrontend/tools/af_check_existing_rr_test.go
+++ b/pkg/apifrontend/tools/af_check_existing_rr_test.go
@@ -2,6 +2,7 @@ package tools_test
 
 import (
 	"context"
+	"strings"
 	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -121,6 +122,95 @@ var _ = Describe("kubernaut_check_existing_remediation", func() {
 			}()
 		}
 		wg.Wait()
+	})
+
+	Describe("Cluster-aware dedup fingerprinting (#1409, AC-4: information-flow isolation)", func() {
+		It("UT-AF-1409-005: a cluster_id=\"a\" lookup never matches state fingerprinted under cluster_id=\"b\"", func() {
+			rrA := newTypedRRWithFingerprint("prod", "rr-cluster-a", "Executing", "Deployment", "web")
+			rrA.Spec.ClusterID = "cluster-a"
+			rrA.Spec.SignalFingerprint = gwtypes.CalculateClusterAwareFingerprint("cluster-a", gwtypes.ResourceIdentifier{
+				Namespace: "prod", Kind: "Deployment", Name: "web",
+			})
+			client := newTypedFakeClient(rrA)
+
+			result, err := tools.HandleCheckExistingRR(context.Background(), client, "prod", tools.CheckExistingRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web", ClusterID: "cluster-b",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Exists).To(BeFalse(),
+				"AC-4: cluster-b's dedup check must not match cluster-a's remediation state (no cross-cluster conflation)")
+		})
+
+		It("UT-AF-1409-005b: a cluster_id=\"a\" lookup matches state fingerprinted under the same cluster_id", func() {
+			rrA := newTypedRRWithFingerprint("prod", "rr-cluster-a", "Executing", "Deployment", "web")
+			rrA.Spec.ClusterID = "cluster-a"
+			rrA.Spec.SignalFingerprint = gwtypes.CalculateClusterAwareFingerprint("cluster-a", gwtypes.ResourceIdentifier{
+				Namespace: "prod", Kind: "Deployment", Name: "web",
+			})
+			client := newTypedFakeClient(rrA)
+
+			result, err := tools.HandleCheckExistingRR(context.Background(), client, "prod", tools.CheckExistingRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web", ClusterID: "cluster-a",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Exists).To(BeTrue())
+			Expect(result.RRID).To(Equal("rr-cluster-a"))
+			Expect(result.ClusterID).To(Equal("cluster-a"))
+		})
+
+		It("UT-AF-1409-005c: empty cluster_id (local hub) preserves pre-#1409 backward-compatible matching", func() {
+			rr := newTypedRRWithFingerprint("prod", "rr-local", "Executing", "Deployment", "web")
+			client := newTypedFakeClient(rr)
+
+			result, err := tools.HandleCheckExistingRR(context.Background(), client, "prod", tools.CheckExistingRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Exists).To(BeTrue())
+		})
+
+		// IT-AF-1409-006 is the Wiring Manifest's designated proof for the
+		// "cluster_id arg -> cluster-aware fingerprint -> dedup lookup result"
+		// row. It calls HandleCheckExistingRR directly because that IS the
+		// kubernaut_check_existing_remediation tool's production entry point
+		// (NewCheckExistingRemediationTool's functiontool closure is a
+		// zero-logic pass-through, same as the neighboring UT-AF-1409-005/005b
+		// tests and IT-AF-1409-010 below) — there is no additional MCP/HTTP
+		// transport layer to cross for this internal (ADK-only, non-MCP) tool.
+		It("IT-AF-1409-006: AC-4 — kubernaut_check_existing_remediation enforces cluster-scoped information-flow isolation end-to-end", func() {
+			rrEast := newTypedRRWithFingerprint("prod", "rr-east-006", "Executing", "Deployment", "web")
+			rrEast.Spec.ClusterID = "cluster-east-006"
+			rrEast.Spec.SignalFingerprint = gwtypes.CalculateClusterAwareFingerprint("cluster-east-006", gwtypes.ResourceIdentifier{
+				Namespace: "prod", Kind: "Deployment", Name: "web",
+			})
+			client := newTypedFakeClient(rrEast)
+
+			sameClusterResult, err := tools.HandleCheckExistingRR(context.Background(), client, "prod", tools.CheckExistingRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web", ClusterID: "cluster-east-006",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sameClusterResult.Exists).To(BeTrue(),
+				"AC-4: a live, non-terminal remediation must be found when checked from its own cluster")
+			Expect(sameClusterResult.ClusterID).To(Equal("cluster-east-006"))
+
+			differentClusterResult, err := tools.HandleCheckExistingRR(context.Background(), client, "prod", tools.CheckExistingRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web", ClusterID: "cluster-west-006",
+			})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(differentClusterResult.Exists).To(BeFalse(),
+				"AC-4: a live, non-terminal remediation on cluster-east must never be reported as covering an identically-named target checked from cluster-west (no cross-cluster conflation)")
+		})
+
+		It("IT-AF-1409-010: SI-10 — oversized cluster_id rejected at the kubernaut_check_existing_remediation tool boundary before fingerprint computation", func() {
+			client := newTypedFakeClient()
+
+			_, err := tools.HandleCheckExistingRR(context.Background(), client, "prod", tools.CheckExistingRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web", ClusterID: strings.Repeat("a", 254),
+			})
+			Expect(err).To(HaveOccurred(),
+				"SI-10: validate.ClusterID must be wired into HandleCheckExistingRR, not dead code")
+			Expect(err.Error()).To(ContainSubstring("cluster_id"))
+		})
 	})
 
 	It("UT-AF-052-048: mismatched fingerprint not reported as existing", func() {

--- a/pkg/apifrontend/tools/af_create_rr.go
+++ b/pkg/apifrontend/tools/af_create_rr.go
@@ -67,6 +67,11 @@ type CreateRRResult struct {
 	Severity       string `json:"severity,omitempty"`
 	SeveritySource string `json:"severity_source,omitempty"`
 	SignalName     string `json:"signal_name,omitempty"`
+	// ClusterID attributes the returned RR to its cluster of origin (#1409,
+	// AU-3). On the create branch this echoes args.ClusterID; on the dedup
+	// branch it is read from the *existing* RR object (not the caller's
+	// args) to avoid misattributing audit provenance under a create race.
+	ClusterID string `json:"cluster_id,omitempty"`
 }
 
 // rrCreateGroup provides singleflight deduplication per fingerprint.
@@ -76,10 +81,6 @@ type CreateRRResult struct {
 // and the check_existing_rr safety net prevents duplicate CRDs regardless.
 // Note: parallel tests with the same fingerprint may share flights (by design).
 var rrCreateGroup singleflight.Group
-
-func rrFingerprint(namespace, kind, name string) string {
-	return rrFingerprintWithCluster("", namespace, kind, name)
-}
 
 // rrFingerprintWithCluster generates a dedup fingerprint that includes the cluster
 // context. Delegates to gwtypes.CalculateClusterAwareFingerprint to ensure GW and
@@ -108,10 +109,11 @@ func checkExistingRRByFingerprint(ctx context.Context, client crclient.Client, c
 		phase := string(item.Status.OverallPhase)
 		if !IsTerminalPhase(phase) {
 			return CheckExistingRRResult{
-				Exists:   true,
-				RRID:     item.Name,
-				Phase:    phase,
-				Severity: item.Spec.Severity,
+				Exists:    true,
+				RRID:      item.Name,
+				Phase:     phase,
+				Severity:  item.Spec.Severity,
+				ClusterID: item.Spec.ClusterID,
 			}, nil
 		}
 	}
@@ -190,6 +192,9 @@ func validateCreateRRArgs(d *ToolDeps, args *CreateRRArgs) error {
 			return fmt.Errorf("%w: %w", ErrInvalidInput, err)
 		}
 	}
+	if err := validate.ClusterID(args.ClusterID); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidInput, err)
+	}
 	return nil
 }
 
@@ -243,6 +248,7 @@ func createOrReuseRR(ctx context.Context, d *ToolDeps, req createRRRequest) (*Cr
 			Message:       fmt.Sprintf("RemediationRequest already exists (%s)", existing.Phase),
 			AlreadyExists: true,
 			Severity:      existing.Severity,
+			ClusterID:     existing.ClusterID,
 		}, nil
 	}
 
@@ -255,6 +261,7 @@ func createOrReuseRR(ctx context.Context, d *ToolDeps, req createRRRequest) (*Cr
 		RRID:       rrObj.Name,
 		Message:    fmt.Sprintf("RemediationRequest created for %s/%s by %s", req.Args.Kind, req.Args.Name, req.Username),
 		SignalName: req.SignalName,
+		ClusterID:  req.Args.ClusterID,
 	}
 	if req.TriageResult != nil {
 		out.Severity = req.TriageResult.Severity
@@ -325,6 +332,7 @@ func emitCreateRRAudit(ctx context.Context, d *ToolDeps, args *CreateRRArgs, use
 				"kind":        args.Kind,
 				"name":        args.Name,
 				"existing_rr": res.RRID,
+				"cluster_id":  res.ClusterID,
 			},
 		})
 		return
@@ -334,11 +342,12 @@ func emitCreateRRAudit(ctx context.Context, d *ToolDeps, args *CreateRRArgs, use
 		UserID:      username,
 		ClusterName: args.ClusterName,
 		Detail: map[string]string{
-			"namespace": d.ControllerNS,
-			"kind":      args.Kind,
-			"name":      args.Name,
-			"rr_id":     res.RRID,
-			"severity":  resolvedSeverity,
+			"namespace":  d.ControllerNS,
+			"kind":       args.Kind,
+			"name":       args.Name,
+			"rr_id":      res.RRID,
+			"severity":   resolvedSeverity,
+			"cluster_id": res.ClusterID,
 		},
 	})
 }

--- a/pkg/apifrontend/tools/af_create_rr_test.go
+++ b/pkg/apifrontend/tools/af_create_rr_test.go
@@ -20,6 +20,7 @@ import (
 	prom "github.com/jordigilh/kubernaut/pkg/apifrontend/prometheus"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/severity"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+	gwtypes "github.com/jordigilh/kubernaut/pkg/gateway/types"
 )
 
 type noopPromClient struct{}
@@ -665,6 +666,44 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 		})
 	})
 
+	Describe("CreateRRResult.ClusterID provenance (#1409, AU-3: audit-visible cluster attribution)", func() {
+		It("UT-AF-1409-003: create branch attributes CreateRRResult.ClusterID to the caller-specified cluster", func() {
+			tc := newTypedFakeClient()
+			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
+				Client:       tc,
+				ControllerNS: "kubernaut-system",
+			}, &tools.CreateRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "nginx",
+				Description: "test", APIVersion: "apps/v1", ClusterID: "cluster-east-1",
+			}, "user")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.AlreadyExists).To(BeFalse())
+			Expect(result.ClusterID).To(Equal("cluster-east-1"),
+				"AU-3: CreateRRResult must attribute the newly created RR's cluster identity so callers can populate RRContext")
+		})
+
+		It("UT-AF-1409-004: dedup branch attributes ClusterID from the actual existing RR, not the caller's args", func() {
+			existing := newTypedRRWithFingerprint("prod", "rr-deploy-web-existing", "Executing", "Deployment", "web")
+			existing.Spec.ClusterID = "cluster-original"
+			existing.Spec.SignalFingerprint = gwtypes.CalculateClusterAwareFingerprint("cluster-original", gwtypes.ResourceIdentifier{
+				Namespace: "prod", Kind: "Deployment", Name: "web",
+			})
+			tc := newTypedFakeClient(existing)
+
+			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
+				Client:       tc,
+				ControllerNS: "prod",
+			}, &tools.CreateRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web",
+				Description: "race", APIVersion: "apps/v1", ClusterID: "cluster-original",
+			}, "user")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.AlreadyExists).To(BeTrue())
+			Expect(result.ClusterID).To(Equal("cluster-original"),
+				"AU-3: dedup branch must attribute cluster identity from the actual existing RR object to prevent a race from misattributing audit provenance")
+		})
+	})
+
 	Describe("Audit trail (CHAR-AF-1532)", func() {
 		It("emits EventRRCreated with severity detail on first creation", func() {
 			tc := newTypedFakeClient()
@@ -712,6 +751,49 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 			Expect(ev.Type).To(Equal(audit.EventRRDeduplicated))
 			Expect(ev.UserID).To(Equal("bob"))
 			Expect(ev.Detail["existing_rr"]).To(Equal(result.RRID))
+		})
+
+		It("UT-AF-1409-010: EventRRCreated Detail map includes cluster_id for fleet-originated RRs", func() {
+			tc := newTypedFakeClient()
+			rec := &auditRecorder{}
+
+			_, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
+				Client:       tc,
+				ControllerNS: "kubernaut-system",
+				Auditor:      rec,
+			}, &tools.CreateRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web",
+				Description: "fleet audit", APIVersion: "apps/v1", ClusterID: "cluster-east-1",
+			}, "alice")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(rec.events).To(HaveLen(1))
+			Expect(rec.events[0].Detail["cluster_id"]).To(Equal("cluster-east-1"),
+				"AU-3: AF-originated fleet RRs must be cluster-attributable in the audit trail, matching Gateway-originated ones")
+		})
+
+		It("UT-AF-1409-010b: EventRRDeduplicated Detail map includes cluster_id for fleet-originated RRs", func() {
+			existing := newTypedRRWithFingerprint("prod", "rr-deploy-web-existing", "Executing", "Deployment", "web")
+			existing.Spec.ClusterID = "cluster-east-1"
+			existing.Spec.SignalFingerprint = gwtypes.CalculateClusterAwareFingerprint("cluster-east-1", gwtypes.ResourceIdentifier{
+				Namespace: "prod", Kind: "Deployment", Name: "web",
+			})
+			tc := newTypedFakeClient(existing)
+			rec := &auditRecorder{}
+
+			_, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
+				Client:       tc,
+				ControllerNS: "prod",
+				Auditor:      rec,
+			}, &tools.CreateRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web",
+				Description: "fleet audit dedup", APIVersion: "apps/v1", ClusterID: "cluster-east-1",
+			}, "bob")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(rec.events).To(HaveLen(1))
+			Expect(rec.events[0].Detail["cluster_id"]).To(Equal("cluster-east-1"),
+				"AU-3: dedup audit event must also attribute cluster_id")
 		})
 
 		It("does not panic and creates the RR when no Auditor is configured", func() {

--- a/pkg/apifrontend/tools/af_investigate_alert.go
+++ b/pkg/apifrontend/tools/af_investigate_alert.go
@@ -19,7 +19,6 @@ import (
 	apiprom "github.com/jordigilh/kubernaut/pkg/apifrontend/prometheus"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/severity"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/validate"
-	"github.com/jordigilh/kubernaut/pkg/remediationrequest"
 )
 
 // AlertISSignaler creates an InvestigationSession CRD to signal interactive
@@ -57,6 +56,9 @@ type InvestigateAlertArgs struct {
 	Kind       string `json:"kind"`
 	Name       string `json:"name"`
 	Namespace  string `json:"namespace,omitempty"`
+	// ClusterID identifies the fleet cluster the target resource lives on
+	// (#1409, ADR-065). Empty for the local hub cluster.
+	ClusterID string `json:"cluster_id,omitempty"`
 }
 
 // InvestigateAlertResult is the output of kubernaut_investigate_alert.
@@ -122,6 +124,7 @@ func HandleInvestigateAlert(
 		ClusterScoped:      clusterScoped,
 		Description:        fmt.Sprintf("Alert-driven investigation: %s", args.AlertName),
 		SignalNameOverride: args.AlertName,
+		ClusterID:          args.ClusterID,
 	}
 
 	result, err := HandleCreateRR(ctx, &ToolDeps{Client: cfg.Client, DynClient: cfg.DynClient, ControllerNS: cfg.ControllerNS, Triager: cfg.Triager, Auditor: cfg.Auditor}, createArgs, username)
@@ -131,14 +134,7 @@ func HandleInvestigateAlert(
 
 	signalInteractiveIfConfigured(ctx, cfg.Signaler, result.RRID, username)
 
-	launcher.SetRRContextSafe(ctx, &launcher.RRContext{
-		RRID:      result.RRID,
-		Namespace: args.Namespace,
-		Kind:      args.Kind,
-		Target:    remediationrequest.FormatResourceDisplay(args.Kind, args.Name),
-		AlertName: args.AlertName,
-		Phase:     "Investigating",
-	})
+	launcher.SetRRContextSafe(ctx, newlyCreatedRRContext(result.RRID, args.Namespace, args.Kind, args.Name, args.AlertName, result.ClusterID))
 
 	return InvestigateAlertResult{
 		RRID:           result.RRID,
@@ -216,7 +212,7 @@ func resolveInvestigateAlertScope(ctx context.Context, mapper meta.RESTMapper, a
 }
 
 // validateAlertIfConfigured checks alertName exists in Prometheus when
-// promClient is configured (graceful degradation when nil — validation is
+// promClient is configured (graceful degradation when nil, validation is
 // skipped and alertValidated is reported false).
 func validateAlertIfConfigured(ctx context.Context, promClient apiprom.Client, alertName string, incFailure func(string)) (bool, error) {
 	if promClient == nil {
@@ -303,6 +299,8 @@ func NewInvestigateAlertTool(cfg InvestigateAlertConfig) (tool.Tool, error) {
 		Description: "Create an investigation for a specific Prometheus alert targeting a Kubernetes resource. " +
 			"Provide alert_name (the Prometheus alert name), api_version, kind, and name of the target resource. " +
 			"For namespaced resources, also provide namespace. " +
+			"For fleet (multi-cluster) deployments, also provide cluster_id to identify which cluster the " +
+			"resource lives on; omit for the local hub cluster. " +
 			"The backend validates the alert exists and creates a RemediationRequest.",
 	}, func(ctx tool.Context, args InvestigateAlertArgs) (InvestigateAlertResult, error) {
 		return HandleInvestigateAlert(ctx, cfg, &args, usernameFromContext(ctx))

--- a/pkg/apifrontend/tools/af_investigate_alert_test.go
+++ b/pkg/apifrontend/tools/af_investigate_alert_test.go
@@ -345,6 +345,21 @@ var _ = Describe("kubernaut_investigate_alert (#1372)", func() {
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("alert_name"))
 		})
+
+		It("IT-AF-1409-010: SI-10 — oversized cluster_id rejected at the kubernaut_investigate_alert tool boundary before reaching the RR spec", func() {
+			_, err := tools.HandleInvestigateAlert(context.Background(), baseCfg(),
+				&tools.InvestigateAlertArgs{
+					AlertName:  "KubePodCrashLooping",
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "web",
+					Namespace:  "prod",
+					ClusterID:  fmt.Sprintf("%0254d", 0),
+				}, "user")
+			Expect(err).To(HaveOccurred(),
+				"SI-10: validate.ClusterID must be wired into the kubernaut_investigate_alert tool boundary, not dead code")
+			Expect(err.Error()).To(ContainSubstring("cluster_id"))
+		})
 	})
 
 	Describe("Metrics wiring (UT-AF-1372-050..051)", func() {
@@ -519,6 +534,58 @@ var _ = Describe("kubernaut_investigate_alert (#1372)", func() {
 			}
 			Expect(found).To(BeTrue(),
 				"AU-3: status events after HandleInvestigateAlert must carry rr_id from RR context")
+		})
+	})
+
+	Describe("Fleet cluster_id end-to-end wiring (#1409)", func() {
+		It("IT-AF-1409-001: AU-3, SI-4 — kubernaut_investigate_alert correctly attributes and correlates cluster identity end-to-end", func() {
+			tc := newTypedFakeClient()
+			rec := &auditRecorder{}
+			q := &bridgeQueue{}
+			ctx := launcher.WithEventBridge(context.Background(), q, a2a.NewTaskID(), "ctx-it-1409-001", nil)
+
+			result, err := tools.HandleInvestigateAlert(ctx, tools.InvestigateAlertConfig{
+				Client:       tc,
+				ControllerNS: "kubernaut-system",
+				Auditor:      rec,
+			}, &tools.InvestigateAlertArgs{
+				AlertName:  "KubePodCrashLooping",
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "web",
+				Namespace:  "prod",
+				ClusterID:  "cluster-fleet-it-001",
+			}, "user")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RRID).NotTo(BeEmpty())
+
+			created := verifyTypedRR(tc, "kubernaut-system", extractRRName(result.RRID))
+			Expect(created.Spec.ClusterID).To(Equal("cluster-fleet-it-001"),
+				"AU-3, SI-4: cluster_id must reach the RR spec for cross-cluster correlation")
+
+			var auditSaw bool
+			for _, e := range rec.events {
+				if e.Detail["cluster_id"] == "cluster-fleet-it-001" {
+					auditSaw = true
+					break
+				}
+			}
+			Expect(auditSaw).To(BeTrue(),
+				"AU-3: emitCreateRRAudit's Detail map must attribute cluster_id for the AF-originated fleet RR")
+
+			Expect(launcher.EmitStatusSafe(ctx, "post-alert-investigate status")).To(Succeed())
+			var eventSaw bool
+			for _, evt := range q.Events() {
+				statusEvt, ok := evt.(*a2a.TaskStatusUpdateEvent)
+				if !ok || statusEvt.Metadata == nil {
+					continue
+				}
+				if statusEvt.Metadata["cluster_id"] == "cluster-fleet-it-001" {
+					eventSaw = true
+				}
+			}
+			Expect(eventSaw).To(BeTrue(),
+				"AU-3, SI-4: A2A status events must carry cluster_id from RRContext for Console cross-cluster correlation")
 		})
 	})
 })

--- a/pkg/apifrontend/tools/crd_tools_watch.go
+++ b/pkg/apifrontend/tools/crd_tools_watch.go
@@ -235,7 +235,7 @@ func (s *watchLoopState) handleRREvent(ctx, watchCtx context.Context, deps watch
 			progressMeta["stabilization_window"] = timing.StabilizationWindow
 		}
 	}
-	snapshot := BuildProgressSnapshot(phase, deps.Args.Name, s.startedAt, completedAt)
+	snapshot := BuildProgressSnapshot(phase, deps.Args.Name, s.startedAt, completedAt, rrObj.Spec.ClusterID)
 	_ = launcher.EmitArtifactSafe(ctx, snapshot, fmt.Sprintf("Progress: %s", phase), progressMeta)
 
 	if IsTerminalPhase(phase) {

--- a/pkg/apifrontend/tools/execution_progress.go
+++ b/pkg/apifrontend/tools/execution_progress.go
@@ -16,7 +16,9 @@ import (
 
 // BuildProgressSnapshot constructs the structured payload for an execution_progress
 // artifact event. The returned map is suitable for use as an a2a.DataPart.Data field.
-func BuildProgressSnapshot(currentPhase, rrName, startedAt, completedAt string) map[string]any {
+// clusterID is omitted entirely when empty (AU-3: avoids false attribution for
+// local-hub RemediationRequests that have no fleet cluster identity).
+func BuildProgressSnapshot(currentPhase, rrName, startedAt, completedAt, clusterID string) map[string]any {
 	payload := map[string]any{
 		"type":           "execution_progress",
 		"schema_version": "1.0",
@@ -26,6 +28,9 @@ func BuildProgressSnapshot(currentPhase, rrName, startedAt, completedAt string) 
 	}
 	if completedAt != "" {
 		payload["completed_at"] = completedAt
+	}
+	if clusterID != "" {
+		payload["cluster_id"] = clusterID
 	}
 	return payload
 }

--- a/pkg/apifrontend/tools/execution_progress_test.go
+++ b/pkg/apifrontend/tools/execution_progress_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Execution Progress Artifacts (#1403)", func() {
 	Describe("BuildProgressSnapshot — UT-AF-1403-001..003", func() {
 		DescribeTable("constructs correct payload",
 			func(phase, rrName, startedAt, completedAt string, expectCompletedAt bool) {
-				snapshot := tools.BuildProgressSnapshot(phase, rrName, startedAt, completedAt)
+				snapshot := tools.BuildProgressSnapshot(phase, rrName, startedAt, completedAt, "")
 				Expect(snapshot).NotTo(BeNil())
 				Expect(snapshot["type"]).To(Equal("execution_progress"))
 				Expect(snapshot["schema_version"]).To(Equal("1.0"))
@@ -38,6 +38,20 @@ var _ = Describe("Execution Progress Artifacts (#1403)", func() {
 			Entry("UT-AF-1403-002: terminal phase with completed_at", "Completed", "rr-abc123", "2026-06-11T10:00:00Z", "2026-06-11T10:05:00Z", true),
 			Entry("UT-AF-1403-003: non-terminal phase omits completed_at", "Analyzing", "rr-def456", "2026-06-11T09:30:00Z", "", false),
 		)
+	})
+
+	Describe("BuildProgressSnapshot cluster attribution — UT-AF-1409-007/008", func() {
+		It("UT-AF-1409-007: AU-3 — carries cluster_id when the RR being watched has one", func() {
+			snapshot := tools.BuildProgressSnapshot("Executing", "rr-fleet-001", "2026-06-11T10:00:00Z", "", "cluster-fleet-b")
+			Expect(snapshot).To(HaveKeyWithValue("cluster_id", "cluster-fleet-b"),
+				"AU-3: execution_progress must carry cluster attribution for Console multi-cluster context")
+		})
+
+		It("UT-AF-1409-008: AU-3 — omits cluster_id entirely for local-hub RRs (no false attribution)", func() {
+			snapshot := tools.BuildProgressSnapshot("Executing", "rr-local-001", "2026-06-11T10:00:00Z", "", "")
+			Expect(snapshot).NotTo(HaveKey("cluster_id"),
+				"AU-3: local-hub RRs must not carry an empty-string cluster_id (false attribution noise)")
+		})
 	})
 
 	Describe("FetchStabilizationWindow (typed client) — UT-AF-1403-004..005", func() {
@@ -317,7 +331,7 @@ var _ = Describe("Execution Progress Artifacts (#1403)", func() {
 
 	Describe("Progress artifact DataPart JSON structure — UT-AF-1403-011", func() {
 		It("UT-AF-1403-011: DataPart payload is JSON-serializable with expected fields", func() {
-			snapshot := tools.BuildProgressSnapshot("Verifying", "rr-xyz789", "2026-06-11T10:00:00Z", "")
+			snapshot := tools.BuildProgressSnapshot("Verifying", "rr-xyz789", "2026-06-11T10:00:00Z", "", "")
 			data, err := json.Marshal(snapshot)
 			Expect(err).NotTo(HaveOccurred())
 

--- a/pkg/apifrontend/tools/export_test.go
+++ b/pkg/apifrontend/tools/export_test.go
@@ -5,3 +5,10 @@ var IsStatusEvent = isStatusEvent
 
 // MapReasonToPhase exposes mapReasonToPhase for external test packages.
 var MapReasonToPhase = mapReasonToPhase
+
+// ResolveInvestigationRR exposes resolveInvestigationRR for external test
+// packages, so its takeover-fetch decision logic (#1409) can be unit-tested
+// directly without going through the full HandleInvestigationMCPWithRegistry
+// await/signal machinery (which requires a real MCP/HTTP transport to test
+// meaningfully — that wiring is proven separately at the IT tier).
+var ResolveInvestigationRR = resolveInvestigationRR

--- a/pkg/apifrontend/tools/helpers.go
+++ b/pkg/apifrontend/tools/helpers.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
+	"github.com/jordigilh/kubernaut/pkg/remediationrequest"
 )
 
 // AuditableInput is an opt-in interface that tool argument types can implement
@@ -101,6 +104,27 @@ func buildForbiddenMsg(msg string) string {
 		return fmt.Sprintf("you lack access to %s -- contact your cluster administrator for RBAC permissions", action)
 	}
 	return "you lack access to this resource -- contact your cluster administrator for RBAC permissions"
+}
+
+// newlyCreatedRRContext builds the EventBridge RRContext seeded immediately
+// after a new RemediationRequest is created (#1409, #1423). It is shared by
+// the three create-path tools (kubernaut_investigate_alert, kubernaut_remediate,
+// kubernaut_investigate's create branch), which previously each constructed
+// an identical launcher.RRContext literal inline. Phase is always
+// "Investigating" here since this only runs immediately after a fresh
+// creation — the takeover (rr_id-only) path has its own distinct source
+// (a fetched RemediationRequest, not a CreateRRResult) and is not a
+// candidate for this helper.
+func newlyCreatedRRContext(rrID, namespace, kind, name, alertName, clusterID string) *launcher.RRContext {
+	return &launcher.RRContext{
+		RRID:      rrID,
+		Namespace: namespace,
+		Kind:      kind,
+		Target:    remediationrequest.FormatResourceDisplay(kind, name),
+		AlertName: alertName,
+		Phase:     "Investigating",
+		ClusterID: clusterID,
+	}
 }
 
 // IsTerminalPhase returns true if the given RR phase is terminal.

--- a/pkg/apifrontend/tools/ka_investigate_mcp.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp.go
@@ -30,6 +30,7 @@ import (
 	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
 	aiav1alpha1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
 
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/audit"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
@@ -88,6 +89,11 @@ type InvestigateMCPArgs struct {
 	Namespace  string `json:"namespace,omitempty"`
 	Kind       string `json:"kind,omitempty"`
 	Name       string `json:"name,omitempty"`
+	// ClusterID identifies the fleet cluster the target resource lives on
+	// (#1409, ADR-065). Only meaningful when creating a new RR (ignored for
+	// the rr_id takeover path, since the cluster identity is read back from
+	// the existing RR object instead). Empty for the local hub cluster.
+	ClusterID string `json:"cluster_id,omitempty"`
 }
 
 // InvestigateMCPResult is the output of the MCP investigate tool.
@@ -268,17 +274,49 @@ func resolveInvestigationRR(ctx context.Context, cfg *InvestigateConfig, args *I
 		return "", fmt.Errorf("rr_id is required for MCP investigation")
 	}
 
-	// For the existing-RR path (rr_id provided as input), set minimal RR context.
-	// Resource metadata may not be available without a K8s read; rr_id + phase
-	// is sufficient for Console escape-hatch buttons (#1423).
+	// For the existing-RR path (rr_id provided as input, i.e. a takeover of
+	// an autonomous investigation), attempt to fetch the full RemediationRequest
+	// to reconstruct complete context for Console banner population (#1423,
+	// #1409). Falls back to minimal rr_id+phase context if the fetch is
+	// unavailable or fails (SI-17: fail-safe degradation, not fail-closed —
+	// a takeover session must still proceed even when the RR can't be read).
 	if !hasResourceArgs {
-		launcher.SetRRContextSafe(ctx, &launcher.RRContext{
-			RRID:  args.RRID,
-			Phase: "Investigating",
-		})
+		setTakeoverRRContext(ctx, cfg, args.RRID)
 	}
 
 	return rrSeverity, nil
+}
+
+// setTakeoverRRContext seeds the EventBridge RR context for the takeover
+// (rr_id-only) path. On success, reconstructs the complete context
+// (namespace, kind, target, alert_name, cluster_id) from the fetched RR
+// object, closing the #1423 gap where takeover sessions previously carried
+// only rr_id+phase. On any failure (no client/namespace configured, or the
+// fetch itself errors), degrades to the minimal rr_id+phase context instead
+// of failing the tool call (SI-17, AU-2: failure is logged, not silent).
+func setTakeoverRRContext(ctx context.Context, cfg *InvestigateConfig, rrID string) {
+	if cfg.Client != nil && cfg.Namespace != "" {
+		var rr remediationv1.RemediationRequest
+		err := cfg.Client.Get(ctx, crclient.ObjectKey{Namespace: cfg.Namespace, Name: rrID}, &rr)
+		if err == nil {
+			launcher.SetRRContextSafe(ctx, &launcher.RRContext{
+				RRID:      rrID,
+				Namespace: rr.Spec.TargetResource.Namespace,
+				Kind:      rr.Spec.TargetResource.Kind,
+				Target:    remediationrequest.FormatResourceDisplay(rr.Spec.TargetResource.Kind, rr.Spec.TargetResource.Name),
+				AlertName: rr.Spec.SignalName,
+				Phase:     "Investigating",
+				ClusterID: rr.Spec.ClusterID,
+			})
+			return
+		}
+		logr.FromContextOrDiscard(ctx).Info("takeover RR context fetch failed, degrading to minimal context",
+			"rr_id", rrID, "error", err)
+	}
+	launcher.SetRRContextSafe(ctx, &launcher.RRContext{
+		RRID:  rrID,
+		Phase: "Investigating",
+	})
 }
 
 // createRRForInvestigation creates a new RemediationRequest from
@@ -312,6 +350,7 @@ func createRRForInvestigation(ctx context.Context, cfg *InvestigateConfig, args 
 		Name:          args.Name,
 		APIVersion:    args.APIVersion,
 		ClusterScoped: clusterScoped,
+		ClusterID:     args.ClusterID,
 	}
 	createUser := ""
 	if identity != nil {
@@ -323,14 +362,7 @@ func createRRForInvestigation(ctx context.Context, cfg *InvestigateConfig, args 
 	}
 	args.RRID = result.RRID
 
-	launcher.SetRRContextSafe(ctx, &launcher.RRContext{
-		RRID:      result.RRID,
-		Namespace: args.Namespace,
-		Kind:      args.Kind,
-		Target:    remediationrequest.FormatResourceDisplay(args.Kind, args.Name),
-		AlertName: result.SignalName,
-		Phase:     "Investigating",
-	})
+	launcher.SetRRContextSafe(ctx, newlyCreatedRRContext(result.RRID, args.Namespace, args.Kind, args.Name, result.SignalName, result.ClusterID))
 
 	return result.Severity, nil
 }
@@ -669,6 +701,9 @@ func NewInvestigateMCPTool(cfg *InvestigateConfig, mapper meta.RESTMapper) (tool
 			"Provide rr_id to resume an existing investigation, or " +
 			"api_version/kind/name (and optional namespace for namespaced resources) " +
 			"to create a new investigation. " +
+			"For fleet (multi-cluster) deployments, also provide cluster_id when creating a new " +
+			"investigation to identify which cluster the resource lives on; omit for the local hub cluster " +
+			"(ignored when resuming via rr_id, since cluster identity is read from the existing request). " +
 			"This tool blocks until the investigation completes and returns " +
 			"the root-cause analysis summary. Live progress events stream " +
 			"to the user automatically while the investigation runs.",

--- a/pkg/apifrontend/tools/ka_investigate_mcp_test.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp_test.go
@@ -27,8 +27,13 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
 
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/audit"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
@@ -1318,6 +1323,269 @@ var _ = Describe("HandleInvestigationMCPWithRegistry — session ID forwarding (
 			Expect(recorder.events[0].Detail["ka_correlation_id"]).To(Equal("ka-confirmed-1452-006"),
 				"AU-3: audit event must reference the KA-confirmed session ID for traceability")
 		})
+	})
+})
+
+// Takeover RR context reconstruction — #1409, #1423 (AU-3, CC8.1, SI-17, AU-2).
+// Exercises resolveInvestigationRR's business logic directly (via the
+// ResolveInvestigationRR export), bypassing HandleInvestigationMCPWithRegistry's
+// await/signal machinery — that wiring is proven separately at the IT tier
+// (IT-AF-1409-004/005) through the real registered-tool dispatch path.
+var _ = Describe("Takeover RR context reconstruction — #1409, #1423 (AU-3, CC8.1, SI-17, AU-2)", func() {
+	It("UT-AF-1409-011: successful fetch populates the complete context (namespace, kind, target, alert_name, cluster_id)", func() {
+		rr := &remediationv1.RemediationRequest{
+			ObjectMeta: objMeta("kubernaut-system", "rr-takeover-011"),
+			Spec: remediationv1.RemediationRequestSpec{
+				SignalName: "PodCrashLooping",
+				ClusterID:  "cluster-east-1",
+				TargetResource: remediationv1.ResourceIdentifier{
+					Kind:      "Deployment",
+					Name:      "web",
+					Namespace: "prod",
+				},
+			},
+		}
+		tc := newTypedFakeClient(rr)
+
+		queue := &bridgeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-1409-011", "ctx-1409-011", nil)
+
+		_, err := tools.ResolveInvestigationRR(ctx, &tools.InvestigateConfig{
+			Client:    tc,
+			Namespace: "kubernaut-system",
+		}, &tools.InvestigateMCPArgs{RRID: "rr-takeover-011"})
+		Expect(err).NotTo(HaveOccurred())
+
+		rc := launcher.RRContextSafe(ctx)
+		Expect(rc).NotTo(BeNil())
+		Expect(rc.RRID).To(Equal("rr-takeover-011"))
+		Expect(rc.Namespace).To(Equal("prod"),
+			"AU-3: takeover must reconstruct the workload namespace from the fetched RR")
+		Expect(rc.Kind).To(Equal("Deployment"))
+		Expect(rc.Target).To(Equal("Deployment/web"))
+		Expect(rc.AlertName).To(Equal("PodCrashLooping"))
+		Expect(rc.ClusterID).To(Equal("cluster-east-1"),
+			"CC8.1: cluster identity must be reconstructable from the RR alone (closes #1423 gap)")
+		Expect(rc.Phase).To(Equal("Investigating"))
+	})
+
+	It("UT-AF-1409-012: fetch failure degrades to minimal (rr_id + phase) context instead of failing the call", func() {
+		tc := newTypedFakeClientWithGetInterceptor(func(_ context.Context, key crclient.ObjectKey, _ crclient.Object, _ ...crclient.GetOption) error {
+			return apierrors.NewNotFound(schema.GroupResource{Group: "remediation.kubernaut.ai", Resource: "remediationrequests"}, key.Name)
+		})
+
+		queue := &bridgeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-1409-012", "ctx-1409-012", nil)
+
+		_, err := tools.ResolveInvestigationRR(ctx, &tools.InvestigateConfig{
+			Client:    tc,
+			Namespace: "kubernaut-system",
+		}, &tools.InvestigateMCPArgs{RRID: "rr-takeover-012"})
+		Expect(err).NotTo(HaveOccurred(),
+			"SI-17: takeover must fail safe (degrade), not fail closed, when the RR fetch errors")
+
+		rc := launcher.RRContextSafe(ctx)
+		Expect(rc).NotTo(BeNil())
+		Expect(rc.RRID).To(Equal("rr-takeover-012"))
+		Expect(rc.Phase).To(Equal("Investigating"))
+		Expect(rc.Namespace).To(BeEmpty(), "degraded context must not fabricate fields it couldn't fetch")
+		Expect(rc.ClusterID).To(BeEmpty())
+	})
+
+	It("UT-AF-1409-013: no client configured (MCP-bridge-only setup) preserves pre-#1423 minimal context (backward compat)", func() {
+		queue := &bridgeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-1409-013", "ctx-1409-013", nil)
+
+		_, err := tools.ResolveInvestigationRR(ctx, &tools.InvestigateConfig{
+			Namespace: "kubernaut-system",
+		}, &tools.InvestigateMCPArgs{RRID: "rr-takeover-013"})
+		Expect(err).NotTo(HaveOccurred())
+
+		rc := launcher.RRContextSafe(ctx)
+		Expect(rc).NotTo(BeNil())
+		Expect(rc.RRID).To(Equal("rr-takeover-013"))
+		Expect(rc.Phase).To(Equal("Investigating"))
+		Expect(rc.Namespace).To(BeEmpty())
+	})
+})
+
+// Fleet cluster_id end-to-end wiring — #1409 (AU-3, SI-4, CC8.1, SI-17, AU-2).
+// Unlike the UT-AF-1409-011/012/013 tests above (which exercise
+// resolveInvestigationRR's decision logic directly via the export), these
+// drive the real registered-tool dispatch path (HandleInvestigationMCPWithRegistry),
+// proving the create-path and takeover-path wiring end to end.
+var _ = Describe("HandleInvestigationMCPWithRegistry — fleet cluster_id wiring (#1409)", func() {
+	closedEventsMCP := func() *ka.MockMCPClient {
+		eventCh := make(chan ka.InvestigationEvent)
+		close(eventCh)
+		return &ka.MockMCPClient{
+			StartInvestigationFn: func(_ context.Context, args ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+				return &ka.StartInvestigationResult{
+					SessionID: "sess-" + args.RRID,
+					Status:    "started",
+					Events:    eventCh,
+					Closer:    func() {},
+				}, nil
+			},
+		}
+	}
+
+	It("IT-AF-1409-003: AU-3, SI-4 — kubernaut_investigate's create path correctly attributes and correlates cluster identity end-to-end", func() {
+		origTimeout := tools.AwaitSessionTimeout
+		tools.AwaitSessionTimeout = 10 * time.Millisecond
+		defer func() { tools.AwaitSessionTimeout = origTimeout }()
+
+		tc := newTypedClientForInvestigate()
+		queue := &bridgeQueue{}
+		ctx := launcher.WithEventBridge(
+			auth.WithUserIdentity(context.Background(), &auth.UserIdentity{Username: "alice", Groups: []string{"sre"}}),
+			queue, "task-1409-003", "ctx-1409-003", nil,
+		)
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+
+		result, err := tools.HandleInvestigationMCPWithRegistry(
+			ctx, &tools.InvestigateConfig{
+				MCPClient: closedEventsMCP(),
+				Client:    tc,
+				Namespace: "kubernaut-system",
+			}, tools.InvestigateMCPArgs{
+				APIVersion: "apps/v1",
+				Namespace:  "prod",
+				Kind:       "Deployment",
+				Name:       "web-1409-003",
+				ClusterID:  "cluster-fleet-it-003",
+			},
+			true, "alice",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RRID).NotTo(BeEmpty())
+
+		created := verifyTypedRR(tc, "kubernaut-system", result.RRID)
+		Expect(created.Spec.ClusterID).To(Equal("cluster-fleet-it-003"),
+			"AU-3, SI-4: cluster_id must reach the RR spec for cross-cluster correlation")
+
+		var eventSaw bool
+		for _, evt := range queue.Events() {
+			statusEvt, ok := evt.(*a2a.TaskStatusUpdateEvent)
+			if !ok || statusEvt.Metadata == nil {
+				continue
+			}
+			if statusEvt.Metadata["cluster_id"] == "cluster-fleet-it-003" {
+				eventSaw = true
+			}
+		}
+		Expect(eventSaw).To(BeTrue(),
+			"AU-3, SI-4: A2A status events must carry cluster_id from RRContext for Console cross-cluster correlation")
+	})
+
+	It("IT-AF-1409-004: AU-3, CC8.1 — takeover session (rr_id only) reconstructs complete remediation context from the RR alone, end-to-end", func() {
+		origTimeout := tools.AwaitSessionTimeout
+		tools.AwaitSessionTimeout = 10 * time.Millisecond
+		defer func() { tools.AwaitSessionTimeout = origTimeout }()
+
+		rr := &remediationv1.RemediationRequest{
+			ObjectMeta: objMeta("kubernaut-system", "rr-takeover-it-004"),
+			Spec: remediationv1.RemediationRequestSpec{
+				SignalName: "PodCrashLooping",
+				ClusterID:  "cluster-fleet-it-004",
+				TargetResource: remediationv1.ResourceIdentifier{
+					Kind:      "Deployment",
+					Name:      "web",
+					Namespace: "prod",
+				},
+			},
+		}
+		tc := newTypedClientForInvestigate(rr)
+		queue := &bridgeQueue{}
+		ctx := launcher.WithEventBridge(
+			auth.WithUserIdentity(context.Background(), &auth.UserIdentity{Username: "alice", Groups: []string{"sre"}}),
+			queue, "task-1409-004", "ctx-1409-004", nil,
+		)
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+
+		result, err := tools.HandleInvestigationMCPWithRegistry(
+			ctx, &tools.InvestigateConfig{
+				MCPClient: closedEventsMCP(),
+				Client:    tc,
+				Namespace: "kubernaut-system",
+			}, tools.InvestigateMCPArgs{RRID: "rr-takeover-it-004"},
+			true, "alice",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RRID).To(Equal("rr-takeover-it-004"))
+
+		// The takeover path itself emits no automatic status/artifact event
+		// (no RR creation -> no severity-triage fallback RCA). Emit one
+		// explicitly, mirroring UT-AF-1423-020/030's established pattern, to
+		// surface the RRContext HandleInvestigationMCPWithRegistry set on the
+		// EventBridge during the call.
+		Expect(launcher.EmitStatusSafe(ctx, "post-investigate-takeover status")).To(Succeed())
+
+		var meta map[string]any
+		for _, evt := range queue.Events() {
+			statusEvt, ok := evt.(*a2a.TaskStatusUpdateEvent)
+			if !ok || statusEvt.Metadata == nil {
+				continue
+			}
+			if rrid, ok := statusEvt.Metadata["rr_id"].(string); ok && rrid == "rr-takeover-it-004" {
+				meta = statusEvt.Metadata
+				break
+			}
+		}
+		Expect(meta).NotTo(BeNil(), "AU-3: at least one status event must carry the takeover session's rr_id")
+		Expect(meta["namespace"]).To(Equal("prod"))
+		Expect(meta["kind"]).To(Equal("Deployment"))
+		Expect(meta["target"]).To(Equal("Deployment/web"))
+		Expect(meta["alert_name"]).To(Equal("PodCrashLooping"))
+		Expect(meta["cluster_id"]).To(Equal("cluster-fleet-it-004"),
+			"CC8.1: complete remediation context, including cluster identity, must be reconstructable from the RR alone (closes #1423 gap)")
+	})
+
+	It("IT-AF-1409-005: SI-17, AU-2 — takeover session against an inaccessible RR fails safe (degrades) instead of failing the whole tool call", func() {
+		origTimeout := tools.AwaitSessionTimeout
+		tools.AwaitSessionTimeout = 10 * time.Millisecond
+		defer func() { tools.AwaitSessionTimeout = origTimeout }()
+
+		tc := newTypedFakeClientWithGetInterceptor(func(_ context.Context, key crclient.ObjectKey, _ crclient.Object, _ ...crclient.GetOption) error {
+			return apierrors.NewNotFound(schema.GroupResource{Group: "remediation.kubernaut.ai", Resource: "remediationrequests"}, key.Name)
+		})
+		queue := &bridgeQueue{}
+		ctx := launcher.WithEventBridge(
+			auth.WithUserIdentity(context.Background(), &auth.UserIdentity{Username: "alice", Groups: []string{"sre"}}),
+			queue, "task-1409-005", "ctx-1409-005", nil,
+		)
+		ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+		defer cancel()
+
+		result, err := tools.HandleInvestigationMCPWithRegistry(
+			ctx, &tools.InvestigateConfig{
+				MCPClient: closedEventsMCP(),
+				Client:    tc,
+				Namespace: "kubernaut-system",
+			}, tools.InvestigateMCPArgs{RRID: "rr-takeover-it-005"},
+			true, "alice",
+		)
+		Expect(err).NotTo(HaveOccurred(),
+			"SI-17: a takeover session must proceed (fail safe) even when the RR context fetch fails, not fail closed on the whole tool call")
+		Expect(result.RRID).To(Equal("rr-takeover-it-005"))
+
+		Expect(launcher.EmitStatusSafe(ctx, "post-investigate-takeover status")).To(Succeed())
+
+		var meta map[string]any
+		for _, evt := range queue.Events() {
+			statusEvt, ok := evt.(*a2a.TaskStatusUpdateEvent)
+			if !ok || statusEvt.Metadata == nil {
+				continue
+			}
+			if rrid, ok := statusEvt.Metadata["rr_id"].(string); ok && rrid == "rr-takeover-it-005" {
+				meta = statusEvt.Metadata
+				break
+			}
+		}
+		Expect(meta).NotTo(BeNil(), "degraded takeover context must still carry rr_id for correlation")
+		Expect(meta["cluster_id"]).To(BeNil(), "degraded context must not fabricate cluster_id it couldn't fetch")
 	})
 })
 

--- a/pkg/apifrontend/tools/ka_remediate.go
+++ b/pkg/apifrontend/tools/ka_remediate.go
@@ -14,7 +14,6 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/severity"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/validate"
-	"github.com/jordigilh/kubernaut/pkg/remediationrequest"
 )
 
 // RemediateArgs defines the LLM-supplied input for kubernaut_remediate.
@@ -28,6 +27,9 @@ type RemediateArgs struct {
 	// APIVersion is the Kubernetes API group/version (e.g., "apps/v1", "v1").
 	// Required when providing namespace/kind/name (#1372).
 	APIVersion string `json:"api_version"`
+	// ClusterID identifies the fleet cluster the target resource lives on
+	// (#1409, ADR-065). Empty for the local hub cluster.
+	ClusterID string `json:"cluster_id,omitempty"`
 }
 
 // RemediateResult is the output of kubernaut_remediate.
@@ -38,6 +40,10 @@ type RemediateResult struct {
 	Severity       string `json:"severity,omitempty"`
 	SeveritySource string `json:"severity_source,omitempty"`
 	SignalName     string `json:"signal_name,omitempty"`
+	// ClusterID attributes the RR to its cluster of origin (#1409). Kept as
+	// the trailing field, matching CreateRRResult's field order, so the
+	// RemediateResult(result) conversion below stays valid.
+	ClusterID string `json:"cluster_id,omitempty"`
 }
 
 // HandleRemediate creates a RemediationRequest CRD without creating an
@@ -68,6 +74,7 @@ func HandleRemediate(ctx context.Context, d *ToolDeps, args *RemediateArgs, user
 			RRID:          rr.Name,
 			Message:       fmt.Sprintf("RemediationRequest already exists (%s)", rr.Status.OverallPhase),
 			AlreadyExists: true,
+			ClusterID:     rr.Spec.ClusterID,
 		}, nil
 	}
 
@@ -82,6 +89,7 @@ func HandleRemediate(ctx context.Context, d *ToolDeps, args *RemediateArgs, user
 		Description:   args.Description,
 		APIVersion:    args.APIVersion,
 		ClusterScoped: args.Namespace == "",
+		ClusterID:     args.ClusterID,
 	}
 
 	result, err := HandleCreateRR(ctx, d, createArgs, username)
@@ -89,14 +97,7 @@ func HandleRemediate(ctx context.Context, d *ToolDeps, args *RemediateArgs, user
 		return RemediateResult{}, err
 	}
 
-	launcher.SetRRContextSafe(ctx, &launcher.RRContext{
-		RRID:      result.RRID,
-		Namespace: args.Namespace,
-		Kind:      args.Kind,
-		Target:    remediationrequest.FormatResourceDisplay(args.Kind, args.Name),
-		AlertName: result.SignalName,
-		Phase:     "Investigating",
-	})
+	launcher.SetRRContextSafe(ctx, newlyCreatedRRContext(result.RRID, args.Namespace, args.Kind, args.Name, result.SignalName, result.ClusterID))
 
 	return RemediateResult(result), nil
 }
@@ -114,7 +115,9 @@ func NewRemediateTool(client crclient.Client, dynClient dynamic.Interface, contr
 	}
 	return functiontool.New(functiontool.Config{
 		Name:        "kubernaut_remediate",
-		Description: "Create a RemediationRequest for autonomous remediation. Use when fixing issues without interactive investigation. The pipeline will analyze and remediate automatically.",
+		Description: "Create a RemediationRequest for autonomous remediation. Use when fixing issues without interactive investigation. " +
+			"The pipeline will analyze and remediate automatically. " +
+			"For fleet (multi-cluster) deployments, also provide cluster_id to identify which cluster the resource lives on; omit for the local hub cluster.",
 	}, func(ctx tool.Context, args RemediateArgs) (RemediateResult, error) {
 		return HandleRemediate(ctx, d, &args, usernameFromContext(ctx))
 	})

--- a/pkg/apifrontend/tools/ka_remediate_test.go
+++ b/pkg/apifrontend/tools/ka_remediate_test.go
@@ -202,4 +202,56 @@ var _ = Describe("kubernaut_remediate (#1332 Intent-Based Tool Redesign)", func(
 				"AU-3: status events after HandleRemediate must carry rr_id from RR context")
 		})
 	})
+
+	Describe("Fleet cluster_id end-to-end wiring (#1409)", func() {
+		It("IT-AF-1409-002: AU-3, SI-4 — kubernaut_remediate correctly attributes and correlates cluster identity end-to-end", func() {
+			tc := newTypedFakeClient()
+			rec := &auditRecorder{}
+			q := &bridgeQueue{}
+			ctx := launcher.WithEventBridge(context.Background(), q, a2a.NewTaskID(), "ctx-it-1409-002", nil)
+
+			result, err := tools.HandleRemediate(ctx, &tools.ToolDeps{
+				Client:       tc,
+				ControllerNS: "kubernaut-system",
+				Auditor:      rec,
+			}, &tools.RemediateArgs{
+				Namespace:  "prod",
+				Kind:       "Deployment",
+				Name:       "web-fleet",
+				APIVersion: "apps/v1",
+				ClusterID:  "cluster-fleet-it-002",
+			}, "user")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RRID).NotTo(BeEmpty())
+			Expect(result.ClusterID).To(Equal("cluster-fleet-it-002"))
+
+			created := verifyTypedRR(tc, "kubernaut-system", extractRRName(result.RRID))
+			Expect(created.Spec.ClusterID).To(Equal("cluster-fleet-it-002"),
+				"AU-3, SI-4: cluster_id must reach the RR spec for cross-cluster correlation")
+
+			var auditSaw bool
+			for _, e := range rec.events {
+				if e.Detail["cluster_id"] == "cluster-fleet-it-002" {
+					auditSaw = true
+					break
+				}
+			}
+			Expect(auditSaw).To(BeTrue(),
+				"AU-3: emitCreateRRAudit's Detail map must attribute cluster_id for the AF-originated fleet RR")
+
+			Expect(launcher.EmitStatusSafe(ctx, "post-remediate status")).To(Succeed())
+			var eventSaw bool
+			for _, evt := range q.Events() {
+				statusEvt, ok := evt.(*a2a.TaskStatusUpdateEvent)
+				if !ok || statusEvt.Metadata == nil {
+					continue
+				}
+				if statusEvt.Metadata["cluster_id"] == "cluster-fleet-it-002" {
+					eventSaw = true
+				}
+			}
+			Expect(eventSaw).To(BeTrue(),
+				"AU-3, SI-4: A2A status events must carry cluster_id from RRContext for Console cross-cluster correlation")
+		})
+	})
 })

--- a/pkg/apifrontend/tools/kubernaut_watch_test.go
+++ b/pkg/apifrontend/tools/kubernaut_watch_test.go
@@ -699,3 +699,84 @@ var _ = Describe("verification_step events in HandleWatch — #1427", func() {
 			"AU-3: alert_check in_progress detail must include signal name for audit traceability")
 	})
 })
+
+var _ = Describe("Fleet cluster_id in execution_progress — IT-AF-1409-007 (#1409)", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("IT-AF-1409-007: AU-3, SI-4 — execution_progress artifact carries cluster_id from the live RR through the watch loop", func() {
+		rr := newTypedRR("payments", "rr-fleet-1", "Pending")
+		rr.Spec.ClusterID = "cluster-fleet-it-007"
+		wc := newWatchClient(rr)
+
+		queue := &bridgeQueue{}
+		ctx = launcher.WithEventBridge(ctx, queue, "task-it-1409-007", "ctx-it-1409-007", nil)
+
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			updateRRPhase(ctx, wc, "payments", "rr-fleet-1", "Executing")
+			time.Sleep(50 * time.Millisecond)
+			updateRRTerminal(ctx, wc, "payments", "rr-fleet-1", "Completed", "success", "done")
+		}()
+
+		result, err := tools.HandleWatch(ctx, wc, tools.WatchArgs{Namespace: "payments", Name: "rr-fleet-1"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Status).To(Equal("completed"))
+
+		events := queue.Events()
+		var sawClusterID bool
+		for _, evt := range events {
+			artifactEvt, ok := evt.(*a2a.TaskArtifactUpdateEvent)
+			if !ok {
+				continue
+			}
+			for _, part := range artifactEvt.Artifact.Parts {
+				dp, ok := part.(a2a.DataPart)
+				if !ok {
+					continue
+				}
+				if dp.Data["cluster_id"] == "cluster-fleet-it-007" {
+					sawClusterID = true
+				}
+			}
+		}
+		Expect(sawClusterID).To(BeTrue(),
+			"AU-3, SI-4: execution_progress artifact must carry cluster_id from the live RemediationRequest through the wired watch loop")
+	})
+
+	It("IT-AF-1409-007b: AU-3 — execution_progress artifact omits cluster_id for local-hub RRs", func() {
+		rr := newTypedRR("payments", "rr-local-1", "Pending")
+		wc := newWatchClient(rr)
+
+		queue := &bridgeQueue{}
+		ctx = launcher.WithEventBridge(ctx, queue, "task-it-1409-007b", "ctx-it-1409-007b", nil)
+
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			updateRRTerminal(ctx, wc, "payments", "rr-local-1", "Completed", "success", "done")
+		}()
+
+		result, err := tools.HandleWatch(ctx, wc, tools.WatchArgs{Namespace: "payments", Name: "rr-local-1"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Status).To(Equal("completed"))
+
+		events := queue.Events()
+		for _, evt := range events {
+			artifactEvt, ok := evt.(*a2a.TaskArtifactUpdateEvent)
+			if !ok {
+				continue
+			}
+			for _, part := range artifactEvt.Artifact.Parts {
+				dp, ok := part.(a2a.DataPart)
+				if !ok {
+					continue
+				}
+				Expect(dp.Data).NotTo(HaveKey("cluster_id"),
+					"AU-3: local-hub RRs must not carry a false-attribution cluster_id in execution_progress")
+			}
+		}
+	})
+})

--- a/pkg/apifrontend/validate/k8s.go
+++ b/pkg/apifrontend/validate/k8s.go
@@ -148,6 +148,20 @@ func LabelValue(v string) error {
 	return nil
 }
 
+// MaxClusterIDLen is the maximum length for a fleet cluster identifier (ADR-065).
+const MaxClusterIDLen = 253
+
+// ClusterID validates an optional fleet cluster identifier (ADR-065). Empty is
+// valid (single-cluster/local-hub deployments carry no cluster attribution).
+// Format is intentionally not further constrained here (ADR-065 documents a
+// pre-existing format inconsistency across producers, out of scope for this fix).
+func ClusterID(clusterID string) error {
+	if len(clusterID) > MaxClusterIDLen {
+		return fmt.Errorf("cluster_id %q exceeds max length %d", clusterID, MaxClusterIDLen)
+	}
+	return nil
+}
+
 // MaxEscalationReasonLen is the maximum allowed length for an escalation reason.
 const MaxEscalationReasonLen = 1024
 

--- a/pkg/apifrontend/validate/k8s_test.go
+++ b/pkg/apifrontend/validate/k8s_test.go
@@ -225,3 +225,24 @@ var _ = Describe("EscalationReason validation (UT-VALIDATE-1418)", func() {
 		Entry("empty string", "", "whitespace-only"),
 	)
 })
+
+var _ = Describe("ClusterID (UT-AF-1409-009)", func() {
+	DescribeTable("UT-AF-1409-009: valid cluster_id values accepted (optional, length-bounded)",
+		func(clusterID string) {
+			Expect(validate.ClusterID(clusterID)).To(Succeed())
+		},
+		Entry("empty (optional field, no cluster attribution)", ""),
+		Entry("simple identifier", "cluster-fleet-a"),
+		Entry("exactly 253 chars", strings.Repeat("a", 253)),
+	)
+
+	DescribeTable("UT-AF-1409-009b: oversized cluster_id rejected [SI-10]",
+		func(clusterID string, substr string) {
+			err := validate.ClusterID(clusterID)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring(substr))
+		},
+		Entry("254 chars (over max)", strings.Repeat("a", 254), "exceeds max length"),
+		Entry("way over max", strings.Repeat("a", 1000), "exceeds max length"),
+	)
+})

--- a/test/e2e/fullpipeline/10_af_fleet_cluster_id_test.go
+++ b/test/e2e/fullpipeline/10_af_fleet_cluster_id_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package fullpipeline
+
+import (
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
+	gwtypes "github.com/jordigilh/kubernaut/pkg/gateway/types"
+)
+
+// E2E-AF-1409-001: AU-3, CC8.1 — Fleet cluster_id survives the full AF ADK
+// round-trip (LLM-supplied arg -> RR spec -> RRContext -> emitDecisionEvent)
+// and is reconstructable from the SSE-visible investigation_summary artifact
+// alone, closing the Console multi-cluster context-banner gap (#1409, ADR-065).
+//
+// Single-turn design (one message/send call): the "fleet cluster
+// remediation" keyword matches a dedicated mock-LLM scenario
+// (test/infrastructure/shared_e2e.go) that emits kubernaut_remediate with
+// cluster_id="cluster-fleet-e2e-1409" (creates the RR), chained via
+// NextToolCall into kubernaut_present_decision with NO cluster_id of its
+// own. This deliberately exercises emitDecisionEvent's RRContext auto-fill
+// path (part_converter.go, cycle 9) rather than LLM-supplied precedence
+// (already covered by UT-AF-1409-006b) — proving cluster_id survives purely
+// through AF's server-side RRContext plumbing, the same path a real
+// takeover session would use.
+//
+// Single-turn is required here, not two separate message/send calls:
+// RRContext lives on the per-request EventBridge (WithEventBridge is called
+// fresh for every incoming request — see event_bridge.go/launcher.go), so a
+// second, separate HTTP request to the same task would start with no
+// RRContext at all and the auto-fill this test targets would never trigger.
+// A two-turn variant was tried and confirmed this via must-gather (turn 2's
+// investigation_summary artifact carried a nil cluster_id).
+//
+// The single-turn NextToolCall chain in turn was found to infinite-loop on
+// first attempt: NextToolCall had no "fire once" guard, and because
+// match_last_only keeps matching the same scenario, mock-llm kept
+// re-emitting kubernaut_present_decision on every ADK reasoning round-trip
+// until the client-side timeout (confirmed via must-gather: mock-llm log
+// showed the scenario firing every ~0.5s for 60+ seconds). Fixed at the
+// source (response.HasFunctionResponseNamed guard added to
+// test/services/mock-llm, #1409): NextToolCall now stops firing once its
+// own target tool has already responded anywhere in the conversation
+// history. Verified against a live Kind cluster (test-e2e-fullpipeline
+// infra) in the authoring environment after the fix.
+var _ = Describe("AF Fleet cluster_id Artifact Propagation [E2E-AF-1409-001]", Label("fp", "af", "fleet", "issue-1409"), func() {
+
+	It("should propagate LLM-supplied cluster_id through RRContext into the investigation_summary artifact", func() {
+		fleetNS := fpRemediateNS["fleet"]
+		Expect(fleetNS).NotTo(BeEmpty(), "fleet namespace must be set by SynchronizedBeforeSuite")
+
+		By("Verifying AF is reachable")
+		resp, err := afHTTPClient.Get(afBaseURL + "/healthz")
+		if err != nil || resp.StatusCode == http.StatusBadGateway || resp.StatusCode == http.StatusServiceUnavailable {
+			Skip("AF not reachable in FP cluster — skipping E2E-AF-1409-001")
+		}
+		_ = resp.Body.Close()
+
+		By("Sending single-turn A2A message: kubernaut_remediate(cluster_id) -> kubernaut_present_decision")
+		body := fpA2ATasksSend("fp-fleet-1409-1", "fleet cluster remediation")
+		resp, err = fpA2AInvokeWithTimeout(body, 60*time.Second)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp.Body.Close() }()
+		Expect(resp.StatusCode).To(Equal(http.StatusOK), "A2A message/send should return 200")
+
+		rpc, parseErr := fpParseRPC(resp)
+		Expect(parseErr).NotTo(HaveOccurred())
+		Expect(rpc.Error).To(BeNil(), "A2A should not return a JSON-RPC error")
+
+		task, taskErr := fpExtractTask(rpc.Result)
+		Expect(taskErr).NotTo(HaveOccurred())
+		Expect(task.ID).NotTo(BeEmpty(), "A2A task ID must not be empty")
+		GinkgoWriter.Printf("  E2E-AF-1409-001 task: %s (state: %s)\n", task.ID, task.Status.State)
+
+		By("Verifying the RR spec carries cluster_id (AU-3, SI-4: LLM arg -> RR spec)")
+		// Cluster-aware fingerprint (#1409): createOrReuseRR computes
+		// rrFingerprintWithCluster(args.ClusterID, ...) — must match here, or this
+		// RR (created with cluster_id="cluster-fleet-e2e-1409") is invisible to the
+		// cluster-blind rrFingerprint("", ...) helper used by other FP scenarios.
+		fp := gwtypes.CalculateClusterAwareFingerprint("cluster-fleet-e2e-1409", gwtypes.ResourceIdentifier{
+			Namespace: fleetNS,
+			Kind:      "Deployment",
+			Name:      "memory-eater",
+		})
+		rrName := fpWaitForRRByFingerprint(fp, 60*time.Second)
+		Expect(rrName).NotTo(BeEmpty())
+
+		var rr remediationv1.RemediationRequest
+		Expect(apiReader.Get(ctx, client.ObjectKey{Namespace: namespace, Name: rrName}, &rr)).To(Succeed())
+		Expect(rr.Spec.ClusterID).To(Equal("cluster-fleet-e2e-1409"),
+			"AU-3, SI-4: cluster_id must reach the RR spec for cross-cluster correlation")
+
+		By("Verifying the investigation_summary artifact carries cluster_id (CC8.1: reconstructable from artifact alone)")
+		art := fpFindArtifactBySchema(task, "investigation_summary")
+		Expect(art).NotTo(BeNil(),
+			"CC8.1: a kubernaut_present_decision call must produce an investigation_summary artifact on the completed Task")
+
+		data := fpArtifactData(art)
+		Expect(data).NotTo(BeNil(), "investigation_summary artifact must carry a DataPart")
+		Expect(data["cluster_id"]).To(Equal("cluster-fleet-e2e-1409"),
+			"CC8.1: cluster_id must be reconstructable from the investigation_summary artifact alone via RRContext auto-fill "+
+				"(emitDecisionEvent, part_converter.go) — the LLM's kubernaut_present_decision call itself carried no cluster_id")
+		GinkgoWriter.Printf("  E2E-AF-1409-001: investigation_summary artifact cluster_id=%v\n", data["cluster_id"])
+	})
+})

--- a/test/e2e/fullpipeline/af_helpers_test.go
+++ b/test/e2e/fullpipeline/af_helpers_test.go
@@ -88,6 +88,49 @@ type fpA2ATaskResult struct {
 		State   string          `json:"state"`
 		Message json.RawMessage `json:"message,omitempty"`
 	} `json:"status"`
+	// Artifacts carries structured DataPart payloads (e.g. investigation_summary,
+	// execution_progress) accumulated on the Task during synchronous message/send
+	// invocation. Used by E2E-AF-1409-001 (#1409) to prove cluster_id reaches the
+	// SSE-visible artifact end-to-end without requiring a live SSE stream.
+	Artifacts []fpA2AArtifact `json:"artifacts,omitempty"`
+}
+
+type fpA2AArtifact struct {
+	ID       string              `json:"artifactId"`
+	Name     string              `json:"name,omitempty"`
+	Metadata map[string]any      `json:"metadata,omitempty"`
+	Parts    []fpA2AArtifactPart `json:"parts"`
+}
+
+type fpA2AArtifactPart struct {
+	Kind string         `json:"kind"`
+	Data map[string]any `json:"data,omitempty"`
+	Text string         `json:"text,omitempty"`
+}
+
+// fpFindArtifactBySchema returns the first artifact in the task whose metadata
+// "schema" field matches the given value (e.g. "investigation_summary"), or nil.
+func fpFindArtifactBySchema(task fpA2ATaskResult, schema string) *fpA2AArtifact {
+	for i := range task.Artifacts {
+		if s, _ := task.Artifacts[i].Metadata["schema"].(string); s == schema {
+			return &task.Artifacts[i]
+		}
+	}
+	return nil
+}
+
+// fpArtifactData returns the merged data map of the first DataPart in the
+// artifact, or nil if the artifact has no DataPart.
+func fpArtifactData(art *fpA2AArtifact) map[string]any {
+	if art == nil {
+		return nil
+	}
+	for _, p := range art.Parts {
+		if p.Kind == "data" && p.Data != nil {
+			return p.Data
+		}
+	}
+	return nil
 }
 
 // fpA2AInvoke sends a JSON-RPC request to POST /a2a/invoke.
@@ -425,4 +468,3 @@ func fpPostSignalToGateway(reason, podName, podNamespace string) string {
 		"Gateway response must include remediationRequestName for signal %q", reason)
 	return rrName
 }
-

--- a/test/infrastructure/fullpipeline_e2e.go
+++ b/test/infrastructure/fullpipeline_e2e.go
@@ -409,6 +409,11 @@ func SetupFullPipelineInfrastructure(ctx context.Context, clusterName, kubeconfi
 	afRemediateNS = map[string]string{
 		"autonomous":  fmt.Sprintf("fp-auto-%s", uuid.New().String()[:8]),
 		"interactive": fmt.Sprintf("fp-int-%s", uuid.New().String()[:8]),
+		// fleet: dedicated namespace for E2E-AF-1409-001 (#1409 ADR-065), which
+		// exercises kubernaut_remediate with a fleet cluster_id argument chained
+		// into kubernaut_present_decision to prove cluster_id reaches the
+		// SSE-visible investigation_summary artifact end-to-end.
+		"fleet": fmt.Sprintf("fp-fleet-%s", uuid.New().String()[:8]),
 	}
 	_, _ = fmt.Fprintln(writer, "  📌 AF remediate namespaces:")
 	for key, ns := range afRemediateNS {
@@ -1263,11 +1268,11 @@ func waitForFullPipelineServicesReady(ctx context.Context, namespace, kubeconfig
 		"kubernaut-agent",
 		"gateway",
 		"event-exporter",
-		"mock-slack",    // Accepts Slack webhook POSTs so notifications reach terminal phase
-		"prometheus",    // ADR-EM-001: Prometheus for EM metric comparison
-		"alertmanager",  // ADR-EM-001: AlertManager for EM alert resolution
-		"apifrontend",   // Issue #1189: AF as FP signal source
-		"dex",           // Issue #1189: OIDC provider for AF authentication
+		"mock-slack",   // Accepts Slack webhook POSTs so notifications reach terminal phase
+		"prometheus",   // ADR-EM-001: Prometheus for EM metric comparison
+		"alertmanager", // ADR-EM-001: AlertManager for EM alert resolution
+		"apifrontend",  // Issue #1189: AF as FP signal source
+		"dex",          // Issue #1189: OIDC provider for AF authentication
 	}
 	if !skipMockLLM() {
 		deployments = append(deployments, "mock-llm")

--- a/test/infrastructure/rbac_parity_test.go
+++ b/test/infrastructure/rbac_parity_test.go
@@ -110,6 +110,25 @@ var _ = Describe("AF RBAC parity (UT-INFRA-RBAC-001)", func() {
 		Entry("SAR",                 "authorization.k8s.io", "subjectaccessreviews",    []string{"create"}),
 		Entry("token reviews",       "authentication.k8s.io", "tokenreviews",           []string{"create"}),
 	)
+
+	// IT-AF-1409-008 [AC-6]: #1409's takeover-path context-reconstruction fetch
+	// (ka_investigate_mcp.go's resolveInvestigationRR) relies on a client.Get()
+	// against RemediationRequest. This regression-pins that the ClusterRole
+	// already grants "get" (least privilege — no broader verb is required for
+	// the new fetch), so a future RBAC edit that narrows this rule fails CI
+	// before it breaks the takeover-path Console banner in production.
+	It("IT-AF-1409-008: AC-6 — ClusterRole grants get (not list/watch/delete) on remediationrequests for the takeover-path fetch", func() {
+		var rrRule *rbacv1.PolicyRule
+		for i := range rules {
+			if slices.Contains(rules[i].APIGroups, "kubernaut.ai") && slices.Contains(rules[i].Resources, "remediationrequests") {
+				rrRule = &rules[i]
+				break
+			}
+		}
+		Expect(rrRule).NotTo(BeNil(), "02-rbac.yaml must contain a rule for kubernaut.ai/remediationrequests")
+		Expect(rrRule.Verbs).To(ContainElement("get"),
+			"AC-6: least privilege — AF's takeover-path client.Get() fetch requires the 'get' verb on remediationrequests")
+	})
 })
 
 var _ = Describe("IT-AF-1460-021: StatusHandler production wiring", func() {

--- a/test/infrastructure/shared_e2e.go
+++ b/test/infrastructure/shared_e2e.go
@@ -163,6 +163,65 @@ subjects:
 	return nil
 }
 
+// fleetClusterIDScenarioYAML returns a keyword_scenarios YAML fragment for
+// E2E-AF-1409-001 (#1409, ADR-065): a single-turn conversation where
+// kubernaut_remediate (LLM-supplied cluster_id, creates the RR) is chained
+// via NextToolCall into kubernaut_present_decision (no cluster_id of its
+// own) — so the test can assert cluster_id reaches the SSE-visible
+// investigation_summary artifact purely via RRContext auto-fill (RR spec ->
+// RRContext -> emitDecisionEvent). Single-turn (one HTTP request) is
+// required here: RRContext lives on the per-request EventBridge
+// (WithEventBridge is called fresh per message/send call), so a second,
+// separate HTTP request would start with no RRContext at all and the
+// auto-fill this test exercises would never trigger.
+//
+// NextToolCall has no "fire once" guard by default, and because
+// match_last_only keeps matching this same scenario, mock-llm would
+// otherwise re-emit kubernaut_present_decision on every subsequent ADK
+// reasoning round-trip — an unbounded loop confirmed via must-gather
+// (mock-llm log showed the same scenario firing every ~0.5s for 60+ seconds
+// before the client-side timeout). Fixed at the source
+// (response.HasFunctionResponseNamed guard in handlers/gemini.go, #1409):
+// NextToolCall now stops firing once its own target tool has already
+// responded anywhere in the conversation history.
+//
+// session_id is required by PresentDecisionArgs' JSON schema (ka_tools.go)
+// even though HandlePresentDecision does not validate its value — any
+// non-empty string satisfies ADK's generated schema.
+//
+// Returns "" when fleetNS is empty (KA/AA suites that don't pass a "fleet"
+// key in afRemediateNS), so this is a no-op for suites that don't need it.
+func fleetClusterIDScenarioYAML(fleetNS string) string {
+	if fleetNS == "" {
+		return ""
+	}
+	return fmt.Sprintf(`      - name: "af_remediate_fleet_1409"
+        keywords: ["fleet cluster remediation"]
+        match_last_only: true
+        tool_call:
+          name: "kubernaut_remediate"
+          arguments:
+            namespace: "%s"
+            kind: "Deployment"
+            name: "memory-eater"
+            api_version: "apps/v1"
+            description: "FP E2E fleet cluster_id remediation request (#1409)"
+            cluster_id: "cluster-fleet-e2e-1409"
+        next_tool_call:
+          name: "kubernaut_present_decision"
+          arguments:
+            session_id: "fleet-1409-session"
+            summary: "Fleet investigation complete: memory-eater pod crash loop due to OOM."
+            rca:
+              severity: "warning"
+              confidence: 0.8
+              target: "Deployment/memory-eater"
+              tool_calls_count: 1
+              llm_turns: 1
+            options: []
+`, fleetNS)
+}
+
 // DeployMockLLMInNamespace deploys the Go Mock LLM service to a Kind namespace.
 // Uses ClusterIP for internal access only (no NodePort needed for E2E).
 //
@@ -279,7 +338,7 @@ func DeployMockLLMInNamespace(ctx context.Context, namespace, kubeconfigPath, im
           name: "kubernaut_watch"
           arguments:
             name: "$from_tool:kubernaut_remediate:rr_id"
-`
+` + fleetClusterIDScenarioYAML(afRemediateNS["fleet"])
 
 	configMap := fmt.Sprintf(`apiVersion: v1
 kind: ConfigMap

--- a/test/services/mock-llm/handlers/gemini.go
+++ b/test/services/mock-llm/handlers/gemini.go
@@ -173,7 +173,15 @@ func (h *handler) handleGeminiToolResponse(
 	// NextToolCall: when the initial tool has been called (FunctionResponse
 	// present) and a chained next_tool_call is configured, emit it. This
 	// simulates the LLM auto-proceeding to a second tool in the same session.
-	if hasFunctionResults && cfg.NextToolCall != nil {
+	//
+	// Guard against infinite NextToolCall loops (#1409): fire at most once —
+	// stop once NextToolCall's own target tool has already responded anywhere
+	// in history. Without this, the ADK reasoning loop keeps calling back
+	// after NextToolCall's FunctionResponse is appended, and this handler
+	// would re-fire the same NextToolCall forever (see HasFunctionResponseNamed
+	// doc for the confirmed failure mode).
+	nextToolAlreadyFired := cfg.NextToolCall != nil && response.HasFunctionResponseNamed(contents, cfg.NextToolCall.Name)
+	if hasFunctionResults && cfg.NextToolCall != nil && !nextToolAlreadyFired {
 		h.trackToolCall(cfg.NextToolCall.Name)
 		writeJSON(w, http.StatusOK, response.BuildGeminiToolCallResponse(cfg.NextToolCall.Name, scenarios.MockScenarioConfig{
 			ToolCallName: cfg.NextToolCall.Name,

--- a/test/services/mock-llm/response/gemini.go
+++ b/test/services/mock-llm/response/gemini.go
@@ -198,6 +198,26 @@ func LastContentIsFunctionResponse(contents []GeminiContent) bool {
 	return false
 }
 
+// HasFunctionResponseNamed scans all Gemini contents (not just the last entry)
+// for a FunctionResponse matching the given tool name. Used to guard
+// NextToolCall chaining (#1409): unlike LastContentIsFunctionResponse (which
+// only looks at the most recent turn), NextToolCall must stop firing once its
+// own target tool has responded ANYWHERE in history, even though the ADK
+// reasoning loop keeps appending new (non-matching) content afterward —
+// otherwise the same NextToolCall re-fires every subsequent round-trip,
+// producing an unbounded loop (confirmed via must-gather: scenario firing
+// every ~0.5s for 60+ seconds before the client-side timeout).
+func HasFunctionResponseNamed(contents []GeminiContent, name string) bool {
+	for _, c := range contents {
+		for _, p := range c.Parts {
+			if p.FunctionResponse != nil && p.FunctionResponse.Name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // ExtractFieldFromFunctionResponse scans Gemini contents for a FunctionResponse
 // with the given tool name and extracts a top-level string field from its JSON
 // response object. Returns empty string if not found.


### PR DESCRIPTION
## Summary

Closes #1409 by threading `RemediationRequest.Spec.ClusterID` into AF's `RRContext` and downstream A2A event payloads (`investigation_summary`, `execution_progress`), so Console can display multi-cluster context banners for AF-originated remediation sessions.

- **`cluster_id` on RR-creating tools**: `kubernaut_investigate_alert`, `kubernaut_investigate`, and `kubernaut_remediate` accept an optional `cluster_id` LLM-facing argument, threaded into the created RR's spec, audit trail (`Detail["cluster_id"]`), and `RRContext`.
- **Cluster-aware dedup**: `kubernaut_check_existing_remediation` now fingerprints with `rrFingerprintWithCluster`, closing an information-flow isolation gap (AC-4) where identically-named targets on different clusters could conflate remediation state.
- **Takeover context reconstruction (#1423)**: the `rr_id`-only takeover path in `ka_investigate_mcp.go` now fetches the full `RemediationRequest` to populate complete `RRContext` (namespace, kind, target, alert_name, cluster_id), instead of leaving Console banners blank. Fails safe (degrades to partial context, logs the failure) on fetch errors.
- **`RRContext.ClusterID`** merges into `investigation_summary` (`emitDecisionEvent`) and `execution_progress` (`BuildProgressSnapshot`) DataParts, with caller-supplied `cluster_id` always taking precedence over the merged default.
- **`validate.ClusterID`** enforces length-bound input validation, wired into both the create and dedup tool boundaries.
- **Bonus fix**: found and fixed an unrelated, pre-existing infinite-loop bug in `test/services/mock-llm`'s `NextToolCall` chaining (no "fire once" guard, unlike the sibling `RepeatToolCall` path) while authoring the E2E test against a live Kind cluster.

## Test plan

Full test pyramid — see [`docs/tests/1409/TEST_PLAN.md`](docs/tests/1409/TEST_PLAN.md) for the complete IEEE 829-2008 hybrid plan with FedRAMP/SOC2 control mapping (AU-2, AU-3, AC-4, AC-6, SI-4, SI-10, SI-17, CC8.1).

- [x] 13 Unit tests (`UT-AF-1409-*`) — `RRContext`/`RRContextSafe` accessors, `CreateRRResult`/`CheckExistingRR` cluster attribution, cluster-aware dedup isolation, artifact cluster_id merge/precedence, takeover reconstruction (success + degradation), `validate.ClusterID`
- [x] 10 Integration tests (`IT-AF-1409-*`) — end-to-end wiring through the real registered-tool dispatch path for all three create-path tools, takeover happy/fail-safe paths, dedup isolation, watch-loop `execution_progress` attribution, RBAC least-privilege, oversized-input rejection
- [x] 1 E2E test (`E2E-AF-1409-001`) — verified against a live Kind cluster (`Ran 1 of 29 Specs`, `1 Passed | 0 Failed`): `cluster_id` survives the full AF ADK round-trip and is reconstructable from the SSE-visible `investigation_summary` artifact alone (SOC2 CC8.1)
- [x] `go build ./...`, `golangci-lint run` (0 issues) on all changed packages
- [x] Full regression: `pkg/apifrontend/...`, `test/services/mock-llm/...`, `test/infrastructure/...` all green, zero regressions
- [x] ADR-065's Wiring Manifest updated, closing the `IT-AF-FLEET (pending)` placeholder row


Made with [Cursor](https://cursor.com)