### PR TITLE
docs(readme): update roadmap and release links to v1.5.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Kubernaut closes the loop from Kubernetes alert to automated remediation. It ope
 <p align="center">
   <a href="https://jordigilh.github.io/kubernaut-docs/"><strong>Full Documentation</strong></a> &nbsp;·&nbsp;
   <a href="https://github.com/jordigilh/kubernaut-demo-scenarios"><strong>Demo Scenarios</strong></a> &nbsp;·&nbsp;
-  <a href="https://github.com/jordigilh/kubernaut/releases/tag/v1.5.2"><strong>Latest Release (v1.5.2)</strong></a>
+  <a href="https://github.com/jordigilh/kubernaut/releases/tag/v1.5.3"><strong>Latest Release (v1.5.3)</strong></a>
 </p>
 
 ---
@@ -84,11 +84,12 @@ Kubernaut bridges that gap. It uses an LLM agent that investigates the actual ro
 
 ## Roadmap
 
-### v1.5.2 — OpenAI Adapter & Severity Model ([released](https://github.com/jordigilh/kubernaut/releases/tag/v1.5.2))
+### v1.5.3 — OpenAI Adapter & Severity Model ([released](https://github.com/jordigilh/kubernaut/releases/tag/v1.5.3))
 
 - **OpenAI-compatible LLM adapter** — In-house adapter for OpenAI-compatible endpoints (LlamaStack, vLLM, Ollama, Azure OpenAI) with mTLS transport chain injection, streaming, and tool call support ([#1487](https://github.com/jordigilh/kubernaut/pull/1487), BR-INTEGRATION-1254)
 - **4-level severity model** — Replaced `medium`/`low` with `warning`/`info` across CRDs, APIs, policies, and prompts ([#1484](https://github.com/jordigilh/kubernaut/pull/1484), ADR-066)
 - **Cluster-scoped resource fixes** — Dynamic scope resolution for namespace handling in KA investigate, AF, and Effectiveness Monitor ([#1480](https://github.com/jordigilh/kubernaut/pull/1480))
+- **v1.5.3 patch** — Removed a DataStorage pre-flight registry check that unconditionally blocked valid `execution.bundle` registrations against self-signed or credential-required private registries ([#1642](https://github.com/jordigilh/kubernaut/issues/1642))
 
 ### v1.6 — Fleet Remediation & ITSM (next)
 
@@ -117,12 +118,12 @@ Verify any image before you pull it:
 
 ```bash
 # Verify the signature (keyless, tied to this repo's release workflow)
-cosign verify quay.io/kubernaut-ai/gateway:v1.5.2 \
+cosign verify quay.io/kubernaut-ai/gateway:v1.5.3 \
   --certificate-identity-regexp "https://github.com/jordigilh/kubernaut/.github/workflows/release.yml@.*" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"
 
 # Verify the SLSA build provenance attestation
-cosign verify-attestation quay.io/kubernaut-ai/gateway:v1.5.2 \
+cosign verify-attestation quay.io/kubernaut-ai/gateway:v1.5.3 \
   --type slsaprovenance \
   --certificate-identity-regexp "https://github.com/jordigilh/kubernaut/.github/workflows/release.yml@.*" \
   --certificate-oidc-issuer "https://token.actions.githubusercontent.com"


### PR DESCRIPTION
## Summary

- README's "Latest Release" link, Roadmap section header/link, and cosign verify examples were still pointing at v1.5.2, even though v1.5.3 was released 2026-07-08.
- Bumps all three to v1.5.3 and adds a roadmap bullet for the v1.5.3 patch fix (#1642 — removed the DataStorage pre-flight registry check that blocked valid `execution.bundle` registrations against self-signed/credential-required registries), consistent with how prior patch-only releases are folded into the preceding minor release's roadmap entry.

## Test plan

- [x] Docs-only change; verified no other `v1.5.2` references remain in README.md
- [x] No linter errors

Made with [Cursor](https://cursor.com)