### PR TITLE
fix(kubernautagent): session-completion signal propagation for interactive sessions (#1654)

### DIFF
--- a/cmd/kubernautagent/routes.go
+++ b/cmd/kubernautagent/routes.go
@@ -727,6 +727,7 @@ func buildMCPTools(d mcpToolsDeps) (*mcptools.InvestigateTool, *mcptools.SelectW
 		mcptools.WithLogger(d.logger.WithName("select-workflow")),
 		mcptools.WithHTTPSessionCompleter(d.autoMgr),
 		mcptools.WithMutexProvider(investigateTool),
+		mcptools.WithSelectWorkflowTimeoutTracker(d.timeoutMgr),
 	}
 	if d.enricher != nil {
 		swOpts = append(swOpts, mcptools.WithEnrichmentRunner(d.enricher))
@@ -738,6 +739,7 @@ func buildMCPTools(d mcpToolsDeps) (*mcptools.InvestigateTool, *mcptools.SelectW
 		mcptools.WithCompleteNoActionLogger(d.logger.WithName("complete-no-action")),
 		mcptools.WithCompleteNoActionHTTPCompleter(d.autoMgr),
 		mcptools.WithCompleteNoActionMutexProvider(investigateTool),
+		mcptools.WithCompleteNoActionTimeoutTracker(d.timeoutMgr),
 	)
 
 	return investigateTool, selectWfTool, completeNoActionTool

--- a/cmd/kubernautagent/routes_completenoaction_timeout_wiring_1654_test.go
+++ b/cmd/kubernautagent/routes_completenoaction_timeout_wiring_1654_test.go
@@ -1,0 +1,178 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	coordinationv1 "k8s.io/api/coordination/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+	mcpadapters "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/adapters"
+	mcptools "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+	dsmodels "github.com/jordigilh/kubernaut/pkg/datastorage/models"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+	wfclient "github.com/jordigilh/kubernaut/pkg/workflowexecution/client"
+)
+
+// ============================================================================
+// #1654: CompleteNoActionTool / SelectWorkflowTool inactivity-timer wiring.
+//
+// buildMCPTools must wire each tool that can terminate an interactive session
+// (complete_no_action, select_workflow) with the shared TimeoutManager so the
+// tool can cancel the session's inactivity timer on completion. Without this
+// wiring, the timer fires ~InactivityTimeout later regardless of the session
+// already being terminal, producing spurious "failed to release expired
+// session" errors and an incorrect "inactivity_timeout" audit/terminal event
+// for a session that actually ended for a different reason.
+// ============================================================================
+
+// stubWorkflowQuerier implements wfclient.WorkflowQuerier, returning a fixed
+// catalog entry for ResolveWorkflowCatalogMetadata (the only method
+// WorkflowCatalogAdapter.GetWorkflowByID calls) and failing every other
+// method (unused by select_workflow's catalog-lookup path).
+type stubWorkflowQuerier struct{}
+
+func (stubWorkflowQuerier) GetWorkflowDependencies(_ context.Context, _ string) (*dsmodels.WorkflowDependencies, error) {
+	return nil, fmt.Errorf("not used by this test")
+}
+
+func (stubWorkflowQuerier) GetWorkflowEngineConfig(_ context.Context, _ string) (json.RawMessage, error) {
+	return nil, fmt.Errorf("not used by this test")
+}
+
+func (stubWorkflowQuerier) GetWorkflowExecutionEngine(_ context.Context, _ string) (string, string, error) {
+	return "", "", fmt.Errorf("not used by this test")
+}
+
+func (stubWorkflowQuerier) GetWorkflowExecutionBundle(_ context.Context, _ string) (string, string, error) {
+	return "", "", fmt.Errorf("not used by this test")
+}
+
+func (stubWorkflowQuerier) ResolveWorkflowCatalogMetadata(_ context.Context, _ string) (*wfclient.WorkflowCatalogMetadata, error) {
+	return &wfclient.WorkflowCatalogMetadata{
+		WorkflowName:    "restart-pod",
+		ExecutionEngine: "argo",
+		ExecutionBundle: "oci://example/restart-pod:v1",
+	}, nil
+}
+
+func (stubWorkflowQuerier) GetWorkflowSchemaMetadata(_ context.Context, _ string) (*wfclient.SchemaMetadata, error) {
+	return nil, fmt.Errorf("not used by this test")
+}
+
+func newMCPTestLeaseSessionManager() *mcpinternal.LeaseSessionManager {
+	scheme := runtime.NewScheme()
+	if err := coordinationv1.AddToScheme(scheme); err != nil {
+		panic(err)
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).Build()
+	return mcpinternal.NewLeaseSessionManagerConcrete(fakeClient, "kubernaut-system", logr.Discard())
+}
+
+var _ = Describe("buildMCPTools — interactive-session inactivity-timer wiring (#1654)", func() {
+
+	It("IT-KA-1654-001: complete_no_action stops the inactivity timer for the session it completes", func() {
+		leaseMgr := newMCPTestLeaseSessionManager()
+		autoMgr := newMCPTestAutoMgr()
+
+		expired := make(chan string, 1)
+		timeoutMgr := mcpinternal.NewTimeoutManager(30*time.Millisecond, nil, func(sessionID string) {
+			expired <- sessionID
+		})
+		defer timeoutMgr.StopAll()
+
+		_, _, completeNoActionTool := buildMCPTools(mcpToolsDeps{
+			leaseMgr:     leaseMgr,
+			autoMgr:      autoMgr,
+			agentMetrics: newMCPTestAgentMetrics(),
+			timeoutMgr:   timeoutMgr,
+			auditStore:   audit.NopAuditStore{},
+			logger:       logr.Discard(),
+		})
+
+		user := mcpinternal.UserInfo{Username: "alice"}
+		driver, err := leaseMgr.Takeover(context.Background(), "rr-1654-001", user)
+		Expect(err).NotTo(HaveOccurred())
+
+		timeoutMgr.StartTracking(driver.SessionID, func(string) {})
+
+		_, err = completeNoActionTool.Handle(context.Background(), mcptools.CompleteNoActionInput{RRID: "rr-1654-001"}, user)
+		Expect(err).NotTo(HaveOccurred())
+
+		Consistently(expired, 120*time.Millisecond, 10*time.Millisecond).ShouldNot(Receive(),
+			"IT-KA-1654-001: complete_no_action must stop the inactivity timer via the production-wired "+
+				"timeoutTracker; if this fires, WithCompleteNoActionTimeoutTracker is not wired into "+
+				"buildMCPTools' construction of CompleteNoActionTool")
+	})
+
+	It("IT-KA-1654-002: select_workflow stops the inactivity timer for the session it completes", func() {
+		leaseMgr := newMCPTestLeaseSessionManager()
+		autoMgr := newMCPTestAutoMgr()
+
+		expired := make(chan string, 1)
+		timeoutMgr := mcpinternal.NewTimeoutManager(30*time.Millisecond, nil, func(sessionID string) {
+			expired <- sessionID
+		})
+		defer timeoutMgr.StopAll()
+
+		catalogAdapter := mcpadapters.NewWorkflowCatalogAdapter(stubWorkflowQuerier{})
+
+		_, selectWfTool, _ := buildMCPTools(mcpToolsDeps{
+			leaseMgr:       leaseMgr,
+			autoMgr:        autoMgr,
+			agentMetrics:   newMCPTestAgentMetrics(),
+			timeoutMgr:     timeoutMgr,
+			auditStore:     audit.NopAuditStore{},
+			logger:         logr.Discard(),
+			catalogAdapter: catalogAdapter,
+		})
+
+		user := mcpinternal.UserInfo{Username: "alice"}
+		driver, err := leaseMgr.Takeover(context.Background(), "rr-1654-002", user)
+		Expect(err).NotTo(HaveOccurred())
+		driver.DiscoveryResult = &mcpinternal.WorkflowDiscoveryResult{
+			Recommended: &mcpinternal.DiscoveredWorkflow{WorkflowID: "wf-1654"},
+		}
+		driver.RCAResult = &katypes.InvestigationResult{
+			RCASummary: "OOM on api-server pod",
+			Confidence: 0.9,
+		}
+
+		timeoutMgr.StartTracking(driver.SessionID, func(string) {})
+
+		_, err = selectWfTool.Handle(context.Background(), mcptools.SelectWorkflowInput{
+			RRID:       "rr-1654-002",
+			WorkflowID: "wf-1654",
+		}, user)
+		Expect(err).NotTo(HaveOccurred())
+
+		Consistently(expired, 120*time.Millisecond, 10*time.Millisecond).ShouldNot(Receive(),
+			"IT-KA-1654-002: select_workflow must stop the inactivity timer via the production-wired "+
+				"timeoutTracker; if this fires, SelectWorkflowTool has no way to cancel it (missing "+
+				"WithSelectWorkflowTimeoutTracker wiring)")
+	})
+})

--- a/docs/tests/1440/TEST_PLAN.md
+++ b/docs/tests/1440/TEST_PLAN.md
@@ -209,7 +209,7 @@ Applied during each TDD REFACTOR phase.
 |-----------------------------------------|----------|--------------------------------------------------------------|
 | AutonomousSessionManager interface change breaks mocks | Medium | Minimal extension; update all implementors in same PR      |
 | Signal resolver thin context for MCP-only sessions | Low | RR CRD fallback sufficient for interactive; enrichment happens in KA investigator |
-| Race between MCP start and AA submit (duplicate sessions) | Low | LeaseSessionManager enforces one driver; GetLatest* picks newest |
+| Race between MCP start and AA submit (duplicate sessions) | Low | LeaseSessionManager enforces one driver; GetLatest* picks newest. **Revised (2026-07, #1654):** the driver-uniqueness guarantee is MCP-lease-scoped only — it does not prevent two `session.Manager` (HTTP-side) sessions with the same `remediation_id` metadata (a fallback session from MCP `action=start` alongside AA's own autonomous investigation session). `E2E-FP-1456-001` RCA found this materializes in practice: completion logic that stopped at the first matching session left the sibling non-terminal. Fixed by making `ForceCompleteByRemediationID` complete every non-terminal sibling and `CompleteHTTPSession` always attempt both completion paths — see [#1654](https://github.com/jordigilh/kubernaut/issues/1654). |
 | E2E flakiness in Kind cluster           | Medium   | `Eventually()` with generous timeouts; fallback to IT level  |
 
 ## 14. Status

--- a/internal/kubernautagent/mcp/tools/cancel_lifecycle_test.go
+++ b/internal/kubernautagent/mcp/tools/cancel_lifecycle_test.go
@@ -21,13 +21,28 @@ import (
 	"sync"
 
 	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
 	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
 	mcptools "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
 	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 )
+
+// jsonLogCapture captures funcr.NewJSON log records for substring assertions
+// on error/warning output without depending on exact structured formatting.
+type jsonLogCapture struct {
+	mu    sync.Mutex
+	lines []string
+}
+
+func (c *jsonLogCapture) capture(obj string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.lines = append(c.lines, obj)
+}
 
 var _ = Describe("#1351 KA Session Lifecycle — handleCancel HTTP bridge", func() {
 
@@ -169,14 +184,63 @@ var _ = Describe("UT-KA-1351-004: SessionClosedHandler disconnect resolves HTTP 
 	})
 })
 
+// #1654: E2E-FP-1456-001 RCA found that a duplicate session sharing the same
+// remediation_id (MCP action=start fallback session alongside AA's own
+// autonomous investigation session) is left non-terminal when
+// CompleteHTTPSession only calls CompleteUserDriving for the one match found
+// by FindUserDrivingByRemediationID. AA may be polling the OTHER
+// (non-user_driving) sibling session, which never gets force-completed
+// because the previous either/or branching short-circuited on the first
+// match. CompleteHTTPSession must always attempt BOTH completion paths so
+// every sibling session sharing the remediation_id is resolved.
+var _ = Describe("#1654: CompleteHTTPSession completes ALL sibling sessions, not just the first match", func() {
+	It("should call ForceCompleteByRemediationID even when a user_driving session was found and completed", func() {
+		completer := &cancelLifecycleHTTPCompleter{
+			foundID: "http-sess-dual-001",
+			found:   true,
+		}
+		logger := logr.Discard()
+
+		mcptools.CompleteHTTPSession(completer, "rr-dual-001", nil, logger, "select_workflow")
+
+		completedID, _ := completer.getCompleted()
+		Expect(completedID).To(Equal("http-sess-dual-001"),
+			"CompleteHTTPSession must still complete the user_driving session it found")
+		Expect(completer.forceCompleteCalled()).To(BeTrue(),
+			"CompleteHTTPSession must ALSO call ForceCompleteByRemediationID to resolve any sibling "+
+				"session sharing the same remediation_id that AA might be polling instead (#1654)")
+	})
+
+	It("should not report a critical failure when the user_driving path succeeds and force-complete finds no sibling (ErrSessionNotFound)", func() {
+		completer := &cancelLifecycleHTTPCompleter{
+			foundID:            "http-sess-dual-002",
+			found:              true,
+			forceCompleteError: session.ErrSessionNotFound,
+		}
+		capture := &jsonLogCapture{}
+		logger := funcr.NewJSON(capture.capture, funcr.Options{})
+
+		mcptools.CompleteHTTPSession(completer, "rr-dual-002", nil, logger, "select_workflow")
+
+		completedID, _ := completer.getCompleted()
+		Expect(completedID).To(Equal("http-sess-dual-002"))
+		for _, line := range capture.lines {
+			Expect(line).NotTo(ContainSubstring("CRITICAL"),
+				"a successful user_driving completion must not be reported as a critical failure "+
+					"just because there was no sibling session left to force-complete (#1654)")
+		}
+	})
+})
+
 // cancelLifecycleHTTPCompleter tracks calls for lifecycle test assertions.
 type cancelLifecycleHTTPCompleter struct {
-	mu                    sync.Mutex
-	foundID               string
-	found                 bool
-	completedID           string
-	completedResult       *katypes.InvestigationResult
+	mu                     sync.Mutex
+	foundID                string
+	found                  bool
+	completedID            string
+	completedResult        *katypes.InvestigationResult
 	forceCompleteWasCalled bool
+	forceCompleteError     error
 }
 
 func (c *cancelLifecycleHTTPCompleter) FindUserDrivingByRemediationID(_ string) (string, bool) {
@@ -197,6 +261,9 @@ func (c *cancelLifecycleHTTPCompleter) ForceCompleteByRemediationID(_ string, re
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	c.forceCompleteWasCalled = true
+	if c.forceCompleteError != nil {
+		return c.forceCompleteError
+	}
 	c.completedResult = result
 	return nil
 }
@@ -234,4 +301,3 @@ func (t *mockTimeoutTracker) stoppedSessionID() string {
 	defer t.mu.Unlock()
 	return t.sessionID
 }
-

--- a/internal/kubernautagent/mcp/tools/select_workflow.go
+++ b/internal/kubernautagent/mcp/tools/select_workflow.go
@@ -147,6 +147,7 @@ type SelectWorkflowTool struct {
 	sessions          mcpinternal.SessionManager
 	httpCompleter     HTTPSessionCompleter
 	mutexProvider     SessionMutexProvider
+	timeoutTracker    TimeoutTracker
 	preSelectionHooks []PreSelectionHook
 	logger            logr.Logger
 }
@@ -176,6 +177,20 @@ func WithMutexProvider(provider SessionMutexProvider) SelectWorkflowOption {
 func WithLogger(logger logr.Logger) SelectWorkflowOption {
 	return func(t *SelectWorkflowTool) {
 		t.logger = logger
+	}
+}
+
+// WithSelectWorkflowTimeoutTracker sets the inactivity-timeout tracker so
+// select_workflow can cancel the session's timer on completion (#1654), the
+// same way complete_no_action and investigate(cancel) already do. Without
+// this, a session terminated by workflow selection keeps its inactivity
+// timer running until it fires ~InactivityTimeout later against an
+// already-terminal session.
+func WithSelectWorkflowTimeoutTracker(tt TimeoutTracker) SelectWorkflowOption {
+	return func(t *SelectWorkflowTool) {
+		if tt != nil {
+			t.timeoutTracker = tt
+		}
 	}
 }
 
@@ -227,6 +242,14 @@ func (t *SelectWorkflowTool) Handle(ctx context.Context, input SelectWorkflowInp
 	workflow, err := t.catalog.GetWorkflowByID(ctx, input.WorkflowID)
 	if err != nil {
 		return SelectWorkflowOutput{}, fmt.Errorf("workflow catalog lookup failed: %w", err)
+	}
+
+	// #1654: stop the inactivity timer synchronously (not deferred to the
+	// completion goroutine below) — the session is terminating regardless of
+	// whether an HTTP completer is wired, so the timer must not be left
+	// running to fire later against an already-terminal session.
+	if t.timeoutTracker != nil {
+		t.timeoutTracker.StopTracking(driver.SessionID)
 	}
 
 	// Auto-complete: build final InvestigationResult from RCA + selected workflow,

--- a/internal/kubernautagent/mcp/tools/select_workflow_test.go
+++ b/internal/kubernautagent/mcp/tools/select_workflow_test.go
@@ -491,6 +491,75 @@ var _ = Describe("kubernaut_select_workflow — discovery gating & auto-complete
 			}).WithTimeout(2 * time.Second).WithPolling(50 * time.Millisecond).Should(Succeed())
 		})
 	})
+
+	// #1654: select_workflow terminates the interactive session (same as
+	// complete_no_action, see UT-KA-1351-005), so it must cancel the
+	// session's inactivity timer the same way. Before this fix, only
+	// InvestigateTool/CompleteNoActionTool called StopTracking; select_workflow
+	// had no way to, since it never received a TimeoutTracker at all — the
+	// inactivity timer kept running after a successful selection and fired
+	// ~InactivityTimeout later against an already-terminal session.
+	Describe("UT-KA-1654-D-001: select_workflow calls StopTracking on completion", func() {
+		It("should stop the timeout tracker synchronously before returning", func() {
+			wfID := "wf-stoptrack"
+			catalog := &mockWorkflowCatalog{
+				workflow: &mcptools.CatalogWorkflow{WorkflowID: wfID, WorkflowName: "restart-pod"},
+			}
+			completer := &mockHTTPCompleter{foundID: "http-sess-002", found: true}
+			tracker := &mockTimeoutTracker{}
+			sessions := &mockSessionManager{
+				isActive: true,
+				getDriverResult: &mcpinternal.InteractiveSession{
+					SessionID:       "sess-stoptrack-001",
+					CorrelationID:   "rr-stoptrack-001",
+					ActingUser:      mcpinternal.UserInfo{Username: "alice"},
+					RCAResult:       &katypes.InvestigationResult{RCASummary: "OOM crash", Confidence: 0.9},
+					DiscoveryResult: discoveryWithWorkflow(wfID),
+				},
+			}
+
+			tool := mcptools.NewSelectWorkflowTool(catalog, sessions,
+				mcptools.WithHTTPSessionCompleter(completer),
+				mcptools.WithSelectWorkflowTimeoutTracker(tracker),
+			)
+			output, err := tool.Handle(context.Background(), mcptools.SelectWorkflowInput{
+				RRID:       "rr-stoptrack-001",
+				WorkflowID: wfID,
+			}, mcpinternal.UserInfo{Username: "alice"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output.Status).To(Equal("workflow_selected"))
+
+			// StopTracking must run synchronously within Handle (not deferred to
+			// the async completion goroutine), so no Eventually() is needed here.
+			Expect(tracker.stoppedSessionID()).To(Equal("sess-stoptrack-001"),
+				"select_workflow must call StopTracking on completion (#1654)")
+		})
+
+		It("should be a no-op when no tracker is configured (backward compatible)", func() {
+			wfID := "wf-notracker"
+			catalog := &mockWorkflowCatalog{
+				workflow: &mcptools.CatalogWorkflow{WorkflowID: wfID, WorkflowName: "restart-pod"},
+			}
+			sessions := &mockSessionManager{
+				isActive: true,
+				getDriverResult: &mcpinternal.InteractiveSession{
+					SessionID:       "sess-notracker-001",
+					CorrelationID:   "rr-notracker-001",
+					ActingUser:      mcpinternal.UserInfo{Username: "alice"},
+					RCAResult:       &katypes.InvestigationResult{RCASummary: "OOM crash", Confidence: 0.9},
+					DiscoveryResult: discoveryWithWorkflow(wfID),
+				},
+			}
+
+			tool := mcptools.NewSelectWorkflowTool(catalog, sessions)
+			output, err := tool.Handle(context.Background(), mcptools.SelectWorkflowInput{
+				RRID:       "rr-notracker-001",
+				WorkflowID: wfID,
+			}, mcpinternal.UserInfo{Username: "alice"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output.Status).To(Equal("workflow_selected"))
+		})
+	})
 })
 
 var _ = Describe("kubernaut_select_workflow — helper functions", func() {

--- a/internal/kubernautagent/mcp/tools/session_teardown.go
+++ b/internal/kubernautagent/mcp/tools/session_teardown.go
@@ -17,27 +17,56 @@ limitations under the License.
 package tools
 
 import (
+	"errors"
+
 	"github.com/go-logr/logr"
 
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
 	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 )
 
 // CompleteHTTPSession bridges the MCP session lifecycle event to the HTTP session
-// store that the AA controller polls. It attempts FindUserDriving first, falling
-// back to ForceComplete when the session is not in user_driving status.
+// store that the AA controller polls.
+//
+// #1654: duplicate sessions can share the same remediation_id — e.g. an MCP
+// action=start fallback session created before AA's own autonomous
+// investigation session for the same rrID transitions out of Running. AA
+// polls its own session, which may not be the one FindUserDrivingByRemediationID
+// finds. Completing only the first match left the sibling session stuck
+// non-terminal (its inactivity timer was the only thing that would eventually
+// resolve it, minutes later). CompleteHTTPSession therefore always attempts
+// BOTH completion paths — CompleteUserDriving for the user_driving match (if
+// any) AND ForceCompleteByRemediationID for every other non-terminal sibling
+// — so no session sharing the remediation_id is left behind. A critical error
+// is logged only when NEITHER path actually completed anything, since
+// ErrSessionNotFound from the force-complete path is the expected/common case
+// once the user_driving session already resolved every session that existed.
 // Exported for use by cmd/kubernautagent/main.go (timeout/disconnect handlers).
 func CompleteHTTPSession(completer HTTPSessionCompleter, rrID string, result *katypes.InvestigationResult, logger logr.Logger, action string) {
 	if completer == nil {
 		return
 	}
-	httpSessionID, found := completer.FindUserDrivingByRemediationID(rrID)
-	if found {
+
+	var userDrivingCompleted bool
+	if httpSessionID, found := completer.FindUserDrivingByRemediationID(rrID); found {
 		if err := completer.CompleteUserDriving(httpSessionID, result); err != nil {
-			logger.Error(err, "CRITICAL: failed to complete HTTP session — AA will not receive result",
+			logger.Error(err, "failed to complete user_driving HTTP session",
 				"action", action, "rr_id", rrID, "http_session_id", httpSessionID)
+		} else {
+			userDrivingCompleted = true
 		}
-	} else if err := completer.ForceCompleteByRemediationID(rrID, result); err != nil {
-		logger.Error(err, "CRITICAL: both completion paths failed — AA will not receive result",
-			"action", action, "rr_id", rrID)
+	}
+
+	forceCompleteErr := completer.ForceCompleteByRemediationID(rrID, result)
+	forceCompleted := forceCompleteErr == nil
+
+	if !userDrivingCompleted && !forceCompleted {
+		if errors.Is(forceCompleteErr, session.ErrSessionNotFound) {
+			logger.Error(forceCompleteErr, "CRITICAL: no session found for either completion path — AA will not receive result",
+				"action", action, "rr_id", rrID)
+		} else {
+			logger.Error(forceCompleteErr, "CRITICAL: both completion paths failed — AA will not receive result",
+				"action", action, "rr_id", rrID)
+		}
 	}
 }

--- a/internal/kubernautagent/session/force_complete_1654_test.go
+++ b/internal/kubernautagent/session/force_complete_1654_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// ============================================================================
+// #1654: ForceCompleteByRemediationID must complete ALL non-terminal sibling
+// sessions sharing the same remediation_id, not just the first one found.
+//
+// Root cause (E2E-FP-1456-001 RCA): MCP action=start (SC-24) can create a
+// fallback interactive session for an rrID before AA's own autonomous
+// investigation session for the same rrID transitions out of Running. Both
+// sessions carry the same remediation_id metadata. When complete_no_action /
+// select_workflow later force-completes "the" session for that rrID, only
+// the first match in map iteration order was completed — leaving the other
+// (the one AA is actually polling) stuck non-terminal until its own
+// inactivity timer eventually fires minutes later.
+// ============================================================================
+
+var _ = Describe("session.Manager.ForceCompleteByRemediationID — #1654 sibling-session completion", func() {
+
+	Describe("UT-KA-1654-B-001: completes every non-terminal session sharing the remediation_id", func() {
+		It("should transition both sibling sessions to Completed, not just the first", func() {
+			store := session.NewStore(30 * time.Minute)
+			mgr := session.NewManager(store, logr.Discard(), nil, nil)
+
+			doneA := make(chan struct{})
+			idA, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				<-ctx.Done()
+				close(doneA)
+				return nil, ctx.Err()
+			}, map[string]string{"remediation_id": "rr-1654-b-001", "mode": "interactive_fallback"})
+			Expect(err).NotTo(HaveOccurred())
+
+			doneB := make(chan struct{})
+			idB, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				<-ctx.Done()
+				close(doneB)
+				return nil, ctx.Err()
+			}, map[string]string{"remediation_id": "rr-1654-b-001"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				s, _ := mgr.GetSession(idA)
+				if s == nil {
+					return ""
+				}
+				return s.Status
+			}, 2*time.Second, 20*time.Millisecond).Should(Equal(session.StatusRunning))
+			Eventually(func() session.Status {
+				s, _ := mgr.GetSession(idB)
+				if s == nil {
+					return ""
+				}
+				return s.Status
+			}, 2*time.Second, 20*time.Millisecond).Should(Equal(session.StatusRunning))
+
+			result := &katypes.InvestigationResult{RCASummary: "operator closed with no action"}
+			Expect(mgr.ForceCompleteByRemediationID("rr-1654-b-001", result)).To(Succeed())
+
+			sessA, errA := mgr.GetSession(idA)
+			Expect(errA).NotTo(HaveOccurred())
+			Expect(sessA.Status).To(Equal(session.StatusCompleted),
+				"IT must complete BOTH sibling sessions sharing rr-1654-b-001, not just the first match (#1654)")
+
+			sessB, errB := mgr.GetSession(idB)
+			Expect(errB).NotTo(HaveOccurred())
+			Expect(sessB.Status).To(Equal(session.StatusCompleted),
+				"IT must complete BOTH sibling sessions sharing rr-1654-b-001, not just the first match (#1654)")
+		})
+
+		It("should return ErrSessionNotFound when no non-terminal session matches", func() {
+			store := session.NewStore(30 * time.Minute)
+			mgr := session.NewManager(store, logr.Discard(), nil, nil)
+
+			err := mgr.ForceCompleteByRemediationID("rr-1654-b-nonexistent", nil)
+			Expect(err).To(MatchError(session.ErrSessionNotFound))
+		})
+	})
+
+	Describe("UT-KA-1654-B-002: emits a SessionCompleted audit event per completed session (SOC2 CC8.1)", func() {
+		It("should emit one EventTypeSessionCompleted event for each sibling session force-completed", func() {
+			store := session.NewStore(30 * time.Minute)
+			auditSpy := &spyAuditStore{}
+			mgr := session.NewManager(store, logr.Discard(), auditSpy, nil)
+
+			idA, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}, map[string]string{"remediation_id": "rr-1654-b-002"})
+			Expect(err).NotTo(HaveOccurred())
+
+			idB, err := mgr.StartInvestigation(context.Background(), func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				<-ctx.Done()
+				return nil, ctx.Err()
+			}, map[string]string{"remediation_id": "rr-1654-b-002"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				s, _ := mgr.GetSession(idA)
+				if s == nil {
+					return ""
+				}
+				return s.Status
+			}, 2*time.Second, 20*time.Millisecond).Should(Equal(session.StatusRunning))
+			Eventually(func() session.Status {
+				s, _ := mgr.GetSession(idB)
+				if s == nil {
+					return ""
+				}
+				return s.Status
+			}, 2*time.Second, 20*time.Millisecond).Should(Equal(session.StatusRunning))
+
+			Expect(mgr.ForceCompleteByRemediationID("rr-1654-b-002", nil)).To(Succeed())
+
+			events := auditSpy.Events()
+			completedIDs := map[string]bool{}
+			for _, e := range events {
+				if e.EventType == audit.EventTypeSessionCompleted && e.CorrelationID == "rr-1654-b-002" {
+					completedIDs[e.SessionID] = true
+				}
+			}
+			Expect(completedIDs).To(HaveKey(idA),
+				"ForceCompleteByRemediationID must emit a SessionCompleted audit event for every completed session (#1654, SOC2 CC8.1)")
+			Expect(completedIDs).To(HaveKey(idB),
+				"ForceCompleteByRemediationID must emit a SessionCompleted audit event for every completed session (#1654, SOC2 CC8.1)")
+		})
+	})
+})

--- a/internal/kubernautagent/session/manager_query.go
+++ b/internal/kubernautagent/session/manager_query.go
@@ -321,37 +321,63 @@ func (m *Manager) GetSessionLazySink(id string) (*LazySink, bool) {
 	return sess.lazySink, true
 }
 
-// ForceCompleteByRemediationID locates any session (Running, UserDriving, or
-// Completed) matching the given remediation ID and forces it to StatusCompleted
-// with the provided result. Cancels the investigation goroutine if still running.
+// ForceCompleteByRemediationID locates every non-terminal session (Running,
+// Pending, or UserDriving) matching the given remediation ID and forces each
+// one to StatusCompleted with the provided result, cancelling its
+// investigation goroutine if still running.
 //
 // This is the fallback path for MCP tools (complete_no_action, action:complete,
 // select_workflow) when TransitionToUserDriving was not called or failed because
 // the autonomous investigation started after MCP session acquisition, or had
 // already completed before takeover.
+//
+// #1654: iterates over ALL matching non-terminal sessions rather than
+// returning after the first. Duplicate sessions for the same remediation_id
+// can coexist (e.g. an MCP action=start fallback session alongside AA's own
+// autonomous investigation session) — completing only the first one found
+// left the other stuck non-terminal, with AA (or the inactivity timer)
+// waiting on a session that would never transition. Returns
+// ErrSessionNotFound only when no non-terminal session matched at all.
 func (m *Manager) ForceCompleteByRemediationID(rrID string, result *katypes.InvestigationResult) error {
 	m.store.mu.Lock()
-	for _, sess := range m.store.sessions {
-		if sess.Metadata["remediation_id"] == rrID && !IsTerminal(sess.Status) {
-			prevStatus := sess.Status
-			if sess.cancel != nil {
-				sess.cancel()
-			}
-			sess.Status = StatusCompleted
-			if result != nil {
-				sess.Result = result
-			}
-			sess.lazySink.Set(nil)
-			if sess.eventChan != nil {
-				close(sess.eventChan)
-				sess.eventChan = nil
-			}
-			m.store.mu.Unlock()
-			m.logger.Info("Force-completed session by remediation ID",
-				"remediation_id", rrID, "previous_status", string(prevStatus))
-			return nil
+	type completedSession struct {
+		id            string
+		prevStatus    Status
+		correlationID string
+	}
+	var completed []completedSession
+	for id, sess := range m.store.sessions {
+		if sess.Metadata["remediation_id"] != rrID || IsTerminal(sess.Status) {
+			continue
 		}
+		prevStatus := sess.Status
+		if sess.cancel != nil {
+			sess.cancel()
+		}
+		sess.Status = StatusCompleted
+		if result != nil {
+			sess.Result = result
+		}
+		sess.lazySink.Set(nil)
+		if sess.eventChan != nil {
+			close(sess.eventChan)
+			sess.eventChan = nil
+		}
+		completed = append(completed, completedSession{id: id, prevStatus: prevStatus, correlationID: rrID})
 	}
 	m.store.mu.Unlock()
-	return ErrSessionNotFound
+
+	if len(completed) == 0 {
+		return ErrSessionNotFound
+	}
+
+	for _, c := range completed {
+		m.logger.Info("Force-completed session by remediation ID",
+			"remediation_id", rrID, "session_id", c.id, "previous_status", string(c.prevStatus))
+		m.emitSessionEvent(context.Background(), sessionEventParams{
+			EventType: audit.EventTypeSessionCompleted, Action: audit.ActionSessionCompleted,
+			Outcome: audit.OutcomeSuccess, SessionID: c.id, CorrelationID: c.correlationID,
+		}, nil, "completion_mode", "force_complete", "previous_status", string(c.prevStatus))
+	}
+	return nil
 }

--- a/test/services/mock-llm/cmd/mock-llm/main.go
+++ b/test/services/mock-llm/cmd/mock-llm/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+	http://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -49,9 +49,16 @@ func main() {
 	router := handlers.NewFullRouterWithMetrics(registry, cfg.ForceText, cfg.Mode, cfg.RecordHeaders, nil, m, overrides)
 
 	srv := &http.Server{
-		Handler:      router,
-		ReadTimeout:  30 * time.Second,
-		WriteTimeout: 30 * time.Second,
+		Handler:     router,
+		ReadTimeout: 30 * time.Second,
+		// #1654: must stay strictly greater than the largest scenario-injected
+		// per-turn delay (e.g. scenario_slow_investigation.go's
+		// SecondTurnDelay=30s) plus response-write overhead. At exactly 30s the
+		// two raced: net/http aborted the in-flight write right as the delayed
+		// handler finished, so KA's client saw an EOF instead of the intended
+		// slow-but-successful response, masking the real E2E-FP-1456-001
+		// session-completion bug behind an unrelated infra timing collision.
+		WriteTimeout: 60 * time.Second,
 		IdleTimeout:  120 * time.Second,
 	}
 


### PR DESCRIPTION
## Summary

Root-cause fix for the session-completion propagation bug uncovered while investigating `E2E-FP-1456-001` flakiness during PR #1652 (#1651). Scoped out of #1651 per explicit request and fixed here as its own TDD effort, closing #1654.

Three independent, compounding bugs were found and fixed:

- **Fix A — missing wiring**: `buildMCPTools` never passed the shared `TimeoutManager` into `CompleteNoActionTool` (`WithCompleteNoActionTimeoutTracker` existed but was never called). A completed session's inactivity timer kept running and could fire minutes later against an already-terminal session.
- **Fix D — missing capability**: `SelectWorkflowTool` had no way to receive a `TimeoutTracker` at all (no field, no option). Added `WithSelectWorkflowTimeoutTracker`, wired it, and call `StopTracking` synchronously in `Handle` before the async completion goroutine.
- **Fix B — the actual root cause**: MCP `action=start` (SC-24) can create a fallback interactive session for an `rrID` before AA's own autonomous investigation session for the *same* `rrID` leaves `Running`. Both share `remediation_id` metadata in `session.Manager`'s store. `CompleteHTTPSession`/`ForceCompleteByRemediationID` only ever resolved the first match, leaving the sibling session — the one AA was actually polling — stuck non-terminal until its own inactivity timer eventually fired ~2 minutes later. Now `ForceCompleteByRemediationID` completes *every* non-terminal sibling (emitting a `SessionCompleted` audit event per session — this path previously had zero audit trace, a SOC2 CC8.1 gap), and `CompleteHTTPSession` always attempts both completion paths.
- **Fix C — test-infra collision**: `mock-llm`'s `WriteTimeout` (30s) exactly equaled `scenario_slow_investigation.go`'s `SecondTurnDelay` (30s), so the delayed response could race the write deadline and surface as an EOF to KA's client — a second, independent way for the same E2E test to reach `Failed`, easily confused with the real bug above. Raised to 60s with an explanatory comment.

## Wiring Manifest

| Component | Production Entry Point | Wiring Code Location | IT/UT Test ID |
|---|---|---|---|
| `CompleteNoActionTool.timeoutTracker` | `buildMCPTools` | `cmd/kubernautagent/routes.go` | IT-KA-1654-001 |
| `SelectWorkflowTool.timeoutTracker` | `buildMCPTools` | `cmd/kubernautagent/routes.go` | IT-KA-1654-002, UT-KA-1654-D-001/002 |
| `ForceCompleteByRemediationID` sibling sweep | `session.Manager` | `internal/kubernautagent/session/manager_query.go` | UT-KA-1654-B-001/002 |
| `CompleteHTTPSession` dual-path | `mcptools` | `internal/kubernautagent/mcp/tools/session_teardown.go` | new #1654 tests in `cancel_lifecycle_test.go` |

## Test plan

- [x] New IT tests (`cmd/kubernautagent`) exercise the real `buildMCPTools` production wiring path with a real `TimeoutManager` for both `complete_no_action` and `select_workflow`.
- [x] New UT tests (`mcp/tools`, `session`) prove the underlying logic (StopTracking call, sibling-session completion loop, audit emission, dual-path completion).
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` — all clean.
- [x] `go test ./internal/kubernautagent/...` and `./cmd/kubernautagent/...` — all green.
- [ ] Full `fullpipeline` E2E suite (including `E2E-FP-1456-001`) — will be validated by CI on this PR; not run locally due to envtest/DataStorage/mock-llm stack startup cost.

Closes #1654.

Made with [Cursor](https://cursor.com)