### PR TITLE
fix(must-gather): bump kubectl to v1.36.2 to resolve CVEs

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -516,6 +516,7 @@ jobs:
           exit-code: 1
           severity: CRITICAL,HIGH
           ignore-unfixed: true
+          version: v0.72.0
 
       - name: Save image to tarball
         run: |
@@ -627,6 +628,7 @@ jobs:
           exit-code: 1
           severity: CRITICAL,HIGH
           ignore-unfixed: true
+          version: v0.72.0
 
       - name: Save image to tarball
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,6 +379,7 @@ jobs:
           exit-code: 1
           severity: CRITICAL,HIGH
           ignore-unfixed: true
+          version: v0.72.0
           # DD-PLATFORM-003: time-bound exceptions for must-gather's kubectl CVEs
           # with no fix available yet in any published kubectl release.
           trivyignores: ${{ matrix.service == 'must-gather' && 'cmd/must-gather/.trivyignore' || '' }}
@@ -432,6 +433,7 @@ jobs:
           exit-code: 1
           severity: CRITICAL,HIGH
           ignore-unfixed: true
+          version: v0.72.0
           # DD-PLATFORM-003: time-bound exceptions for must-gather's kubectl CVEs
           # with no fix available yet in any published kubectl release.
           trivyignores: ${{ matrix.service == 'must-gather' && 'cmd/must-gather/.trivyignore' || '' }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -368,6 +368,9 @@ jobs:
           - must-gather
           - db-migrate
     steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
       - name: Scan for CVEs (Trivy)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -376,6 +379,9 @@ jobs:
           exit-code: 1
           severity: CRITICAL,HIGH
           ignore-unfixed: true
+          # DD-PLATFORM-003: time-bound exceptions for must-gather's kubectl CVEs
+          # with no fix available yet in any published kubectl release.
+          trivyignores: ${{ matrix.service == 'must-gather' && 'cmd/must-gather/.trivyignore' || '' }}
 
       - name: Generate SBOM (CycloneDX)
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
@@ -415,6 +421,9 @@ jobs:
           - must-gather
           - db-migrate
     steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
       - name: Scan for CVEs (Trivy)
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
@@ -423,6 +432,9 @@ jobs:
           exit-code: 1
           severity: CRITICAL,HIGH
           ignore-unfixed: true
+          # DD-PLATFORM-003: time-bound exceptions for must-gather's kubectl CVEs
+          # with no fix available yet in any published kubectl release.
+          trivyignores: ${{ matrix.service == 'must-gather' && 'cmd/must-gather/.trivyignore' || '' }}
 
       - name: Generate SBOM (CycloneDX)
         uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0

--- a/cmd/must-gather/.trivyignore
+++ b/cmd/must-gather/.trivyignore
@@ -1,0 +1,32 @@
+# Trivy vulnerability exceptions for the must-gather image
+#
+# DD-PLATFORM-003: kubectl was bumped v1.31.0 -> v1.36.2 (Issue #1663), which
+# resolved 18 of 23 CVEs flagged in GH Actions run 29058480982 (job
+# 86711219020), including the sole CRITICAL. The 5 entries below have no fix
+# available in ANY currently published kubectl release: Kubernetes has not
+# yet adopted the golang.org/x/net >= 0.55.0 or Go >= 1.25.12/1.26.5 patch
+# versions that carry the actual upstream fix (verified 2026-07-13 against
+# kubectl v1.31.14 through v1.36.2, the latest stable, and kubernetes/kubernetes
+# @master). Time-bound (exp:) so this resurfaces in CI for re-triage instead
+# of silently suppressing indefinitely. Tracked in Issue #1662.
+#
+# Re-run before the expiration date:
+#   1. Check if a newer kubectl release ships golang.org/x/net >= 0.55.0 and
+#      Go >= 1.25.12/1.26.5 (`go version -m` on the released binary).
+#   2. If yes: bump cmd/must-gather/Dockerfile and remove these entries.
+#   3. If no: re-verify no fix exists yet and extend the expiration date.
+
+# golang.org/x/net/html: Arbitrary code execution via Cross-Site Scripting (fixed 0.55.0; kubectl v1.36.2 ships 0.49.0)
+CVE-2026-25681 exp:2026-10-11
+
+# golang.org/x/net/html: Cross-Site Scripting via HTML parsing bypass (fixed 0.55.0; kubectl v1.36.2 ships 0.49.0)
+CVE-2026-27136 exp:2026-10-11
+
+# net/http/internal/http2 (vendored in x/net): DoS via malformed SETTINGS_MAX_FRAME_SIZE frame (fixed 0.53.0; kubectl v1.36.2 ships 0.49.0)
+CVE-2026-33814 exp:2026-10-11
+
+# golang.org/x/net/idna: Privilege escalation via incorrect Punycode label processing (fixed 0.55.0; kubectl v1.36.2 ships 0.49.0)
+CVE-2026-39821 exp:2026-10-11
+
+# stdlib os.Root: Symlink following vulnerability allows directory traversal (fixed 1.25.12/1.26.5; kubectl v1.36.2 built with Go 1.26.4)
+CVE-2026-39822 exp:2026-10-11

--- a/cmd/must-gather/Dockerfile
+++ b/cmd/must-gather/Dockerfile
@@ -26,10 +26,13 @@ LABEL maintainer="Kubernaut Platform Team" \
 # UBI Standard already includes: tar, gzip, findutils, util-linux, coreutils
 # Only install additional tools we need
 
-# Install kubectl (Kubernetes 1.31 - compatible with Kubernetes 1.30-1.32)
+# Install kubectl (client v1.36.2 - Issue #1663: bumped from v1.31.0 to pick up
+# upstream CVE fixes; validated against server versions 1.30-1.32 via kind-cluster
+# spike since v1.36 is outside kubectl's official +/-1 minor version-skew window
+# for those older API servers -- see DD-PLATFORM-003)
 # Use TARGETARCH to download correct architecture binary
 ARG TARGETARCH
-RUN curl -LO "https://dl.k8s.io/release/v1.31.0/bin/linux/${TARGETARCH}/kubectl" && \
+RUN curl -LO "https://dl.k8s.io/release/v1.36.2/bin/linux/${TARGETARCH}/kubectl" && \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/kubectl
 

--- a/docs/architecture/decisions/DD-PLATFORM-003-must-gather-kubectl-version-policy.md
+++ b/docs/architecture/decisions/DD-PLATFORM-003-must-gather-kubectl-version-policy.md
@@ -1,0 +1,182 @@
+# DD-PLATFORM-003: Must-Gather kubectl Version Bump Policy (CVE Remediation)
+
+**Date**: July 13, 2026
+**Status**: ✅ **APPROVED**
+**Confidence**: 90%
+**Last Reviewed**: July 13, 2026
+**Related**: Issue #1663 (Trivy security scan blocking `v1.6.0-rc1` release), Issue #1662 (follow-up to re-triage residual CVEs before exception expiration), Issue #1315 (Trivy/SBOM release gate), `cmd/must-gather/Dockerfile`
+
+---
+
+## 🎯 **DECISION**
+
+**Bump the `kubectl` binary bundled in the `must-gather` image from `v1.31.0`
+to the latest published release (`v1.36.2`) to resolve the majority of the
+23 CVEs (1 CRITICAL, 22 HIGH) flagged by the release pipeline's Trivy scan
+(GitHub Actions run 29058480982, job 86711219020), even though this exceeds
+kubectl's officially documented +/-1 minor version-skew support window for
+the image's stated target server versions (1.30-1.32). Compatibility was
+validated empirically via a kind-cluster spike (see below) before approval.
+The small number of CVEs with no available fix in any current kubectl
+release (because upstream Kubernetes has not yet adopted the necessary
+`golang.org/x/net`/Go-toolchain patch versions) are suppressed via a
+time-bound `.trivyignore` exception that expires and resurfaces the finding
+for re-triage.**
+
+---
+
+## 📊 **Context & Problem**
+
+The `v1.6.0-rc1` release pipeline's Trivy scan of the `must-gather` image
+failed with `exit-code: 1` because `/usr/local/bin/kubectl` (a prebuilt
+binary downloaded from `dl.k8s.io` in `cmd/must-gather/Dockerfile`) reported
+23 fixable CVEs:
+
+- 1 **CRITICAL**: `CVE-2025-68121` (`crypto/tls` certificate validation, Go stdlib)
+- 22 **HIGH**: `golang.org/x/net` (4), `golang.org/x/oauth2` (1),
+  `github.com/moby/spdystream` (1), Go stdlib (16 more)
+
+### Investigation
+
+Downloaded and inspected (`go version -m`) every currently published kubectl
+release from `v1.31.14` (latest 1.31.x patch) through `v1.36.2` (latest
+stable overall, and even `kubernetes/kubernetes@master`, unreleased). Finding:
+**no published kubectl release fully resolves all 23 CVEs** — upstream
+Kubernetes has not yet picked up `golang.org/x/net >= 0.55.0` (needed for
+4 CVEs) or a Go toolchain >= 1.25.12/1.26.5 (needed for 1 CVE;
+`v1.36.2` ships Go 1.26.4). `v1.36.2` is the best currently achievable target,
+resolving 18 of 23 CVEs (including the sole CRITICAL).
+
+## Alternatives Considered
+
+### Alternative A: Build kubectl from source with force-patched transitive deps
+
+**Approach**: Multi-stage Docker build; a small Go module requiring
+`k8s.io/kubectl@v0.31.14` (preserving v1.31 client behavior) with
+`golang.org/x/net`, `golang.org/x/oauth2`, and `github.com/moby/spdystream`
+force-upgraded past their fixed versions via `go get`, compiled with Go
+1.26.5. Validated via local spike — builds and runs successfully, resolves
+100% of the 23 CVEs while keeping the documented 1.30-1.32 skew window.
+
+**Pros**:
+- ✅ Resolves all 23 CVEs immediately, no residual exceptions
+- ✅ Preserves official kubectl version-skew compatibility (client stays v1.31.x)
+
+**Cons**:
+- ❌ New build pattern (Go builder stage) for an otherwise Bash-only image
+- ❌ Ships dependency combinations upstream Kubernetes has never tested/released
+- ❌ Ongoing maintenance burden to keep force-pinned versions current
+
+**Confidence**: 85% (rejected — user preferred simpler approach + explicit tracking over a bespoke unreleased dependency combination)
+
+---
+
+### Alternative B: Bump to latest published kubectl release + kind-validate + time-bound exception (CHOSEN)
+
+**Approach**: Change one line in the Dockerfile (`v1.31.0` → `v1.36.2`).
+Validate empirically against kind clusters running the documented supported
+server versions (1.30, 1.31, 1.32) by diffing every kubectl invocation
+pattern used by `cmd/must-gather/collectors/*.sh` between the old and new
+client. Suppress the small number of CVEs with no available upstream fix via
+a `.trivyignore` file with an explicit expiration date so the exception
+resurfaces for re-triage rather than being silently permanent.
+
+**Pros**:
+- ✅ Minimal, easily reviewable Dockerfile change
+- ✅ Resolves 18/23 CVEs (100% of CRITICAL) using only released, upstream-tested artifacts
+- ✅ Empirically validated (not just policy-assumed) against all 3 documented server versions
+- ✅ Residual risk is time-boxed and self-resurfacing, not permanently hidden
+
+**Cons**:
+- ❌ Exceeds kubectl's official +/-1 minor version-skew policy for servers 1.30-1.32 (mitigated by empirical validation, not just wishful skipping)
+- ❌ Leaves 5 CVEs technically "fixed upstream but unavailable in kubectl" until Kubernetes ships a newer patch release
+
+**Confidence**: 90% (approved by user)
+
+---
+
+### Alternative C: Keep `v1.31.0`, blanket-ignore all 23 CVEs pending upstream fix
+
+**Approach**: No Dockerfile change; suppress the whole Trivy finding set for `must-gather`.
+
+**Pros**:
+- ✅ Zero engineering effort
+
+**Cons**:
+- ❌ Leaves the sole CRITICAL CVE (and 17 other HIGH CVEs that DO have a fix already published upstream) unresolved for no reason — a real regression in security posture with a trivial available fix
+- ❌ Sets a bad precedent of reaching for suppression before exhausting available upstream fixes
+
+**Confidence**: 20% (rejected)
+
+---
+
+## Decision
+
+**APPROVED: Alternative B**
+
+**Rationale**:
+1. **Best available fix, no invented dependency graph**: Resolves the CRITICAL CVE and 17 of 22 HIGH CVEs using only an artifact Kubernetes itself has built, tested, and released — no bespoke/unreleased dependency combination to maintain.
+2. **Empirically validated, not policy-assumed**: A kind-cluster spike executed every kubectl invocation pattern from all 6 must-gather collectors against live 1.30/1.31/1.32 API servers with both the old (v1.31.0) and new (v1.36.2) client and diffed the results. Zero return-code mismatches and zero functional output differences across all 3 versions; only cosmetic differences (client version banner, a `describe pod`/`describe node` label/format tweak) were observed.
+3. **Residual risk is bounded and self-resurfacing**: The 5 CVEs with no available kubectl release fix are suppressed via `.trivyignore` entries with an explicit `exp:` expiration date (90 days), so the CI gate re-fails automatically for re-triage instead of the exception being silently permanent.
+
+**Key Insight**: Kubectl's documented n-1/n+1 version-skew policy is a
+*support* boundary, not a hard compatibility wall for the specific,
+narrow set of read-only `get`/`describe`/`logs`/`top`/`api-resources`
+operations must-gather performs. Empirical validation against the exact
+command surface in use is a stronger signal than the general policy for
+this specific tool.
+
+### Implementation
+
+**Primary Implementation Files**:
+- `cmd/must-gather/Dockerfile` — kubectl download version bumped `v1.31.0` → `v1.36.2`
+- `cmd/must-gather/.trivyignore` — time-bound exceptions for the 5 CVEs with no available upstream fix
+- `.github/workflows/release.yml` — `trivyignores` input wired into both `security-scan-amd64`/`security-scan-arm64` Trivy steps for the `must-gather` matrix entry
+
+**Validation performed** (not shipped as automated CI — see Consequences):
+- kind clusters `v1.30.8`, `v1.31.9`, `v1.32.8` (kindest/node images)
+- Representative resources per collector: namespaces, a CRD + CR instance, a
+  Deployment/pod with logs, RBAC (Role/RoleBinding/ClusterRole/ClusterRoleBinding),
+  PVC, Service, NetworkPolicy, Ingress, ConfigMap, webhook configs
+- Every `kubectl` invocation pattern from `collectors/*.sh` executed with both
+  `kubectl-baseline` (v1.31.0) and `kubectl-candidate` (v1.36.2) clients,
+  diffed after normalizing volatile fields (timestamps, UIDs, resourceVersions)
+
+### Consequences
+
+**Positive**:
+- ✅ Release pipeline's Trivy gate passes with a real, verified reduction in exposure (23 → 5 CVEs, CRITICAL eliminated)
+- ✅ No new build pattern/technology introduced into an otherwise simple Bash image
+
+**Negative**:
+- ⚠️ 5 CVEs remain unresolved until Kubernetes ships a release with `golang.org/x/net >= 0.55.0` and Go >= 1.25.12/1.26.5 — **Mitigation**: time-bound `.trivyignore` (90-day expiration) + tracking issue filed to revisit
+- ⚠️ kind-cluster compatibility validation was a manual, one-time spike, not an automated regression test — **Mitigation**: documented here for future re-validation; consider promoting to a CI job if kubectl is bumped again before 1.30-1.32 support is dropped
+
+**Neutral**:
+- 🔄 Future kubectl bumps for this image should repeat the kind-cluster validation spike documented here, especially if the target server-version range changes
+
+### Validation Results
+
+**Confidence Assessment Progression**:
+- Initial assessment (before investigation): 60% — assumed a simple version bump would fully resolve the scan
+- After dependency/toolchain investigation: 75% — confirmed no release fully resolves all CVEs, several alternatives viable
+- After kind-cluster spike (3 versions, zero functional diffs): 90% — empirical evidence supports the skew-policy exception
+
+**Key Validation Points**:
+- ✅ `go version -m` inspection of actual released kubectl binaries (not just `go.mod`, which can diverge from `replace` directives) confirmed exact embedded dependency versions for v1.31.0 through v1.36.2
+- ✅ kind-cluster diff spike: 0 RC mismatches, 0 functional output diffs across 1.30/1.31/1.32
+- ✅ Local Trivy scan of the rebuilt image (see PR) confirms exactly the expected 5 residual CVEs
+
+### Related Decisions
+- **Builds On**: Issue #1315 (Trivy/SBOM release gate introduction)
+
+### Review & Evolution
+
+**When to Revisit**:
+- When the `.trivyignore` 90-day exception expires (tracking issue filed)
+- If Kubernetes ships a kubectl release with `golang.org/x/net >= 0.55.0` and Go >= 1.25.12/1.26.5 sooner (re-run this spike, drop the exception early)
+- If the documented minimum supported server version for must-gather changes (re-run the kind-cluster validation spike against the new range)
+
+**Success Metrics**:
+- Trivy scan for `must-gather`: 0 CRITICAL, <=5 time-bound-exception HIGH (target: 0 once upstream catches up)
+- No user-reported must-gather functional regressions against clusters in the 1.30-1.32 range post-release


### PR DESCRIPTION
## Summary

- Bumps the `kubectl` binary bundled in the `must-gather` image from `v1.31.0` to `v1.36.2`, resolving 18 of the 23 CVEs (1 CRITICAL, 22 HIGH) flagged by the release pipeline's Trivy scan (run [29058480982](https://github.com/jordigilh/kubernaut/actions/runs/29058480982/job/86711219020)), including the sole CRITICAL. Fixes #1663.
- Validates compatibility empirically: every `kubectl` invocation pattern used by `cmd/must-gather/collectors/*.sh` was run against live kind clusters for all three documented supported server versions (1.30/1.31/1.32) with both the old and new client, diffed end-to-end -- zero return-code mismatches, zero functional output differences.
- The 5 residual CVEs (no fix available in *any* currently published kubectl release -- verified against every release from v1.31.14 through v1.36.2) are suppressed via a time-bound `cmd/must-gather/.trivyignore` (90-day `exp:` expiration), wired into the release pipeline's Trivy step for `must-gather` only, so the exception resurfaces automatically for re-triage. Follow-up tracked in #1662.
- Documents the full alternatives analysis (build-from-source vs. bump-latest vs. ignore-all) and validation evidence in [DD-PLATFORM-003](docs/architecture/decisions/DD-PLATFORM-003-must-gather-kubectl-version-policy.md).
- Also pins the Trivy scanner itself to its latest release (`v0.72.0`) across all 4 scan steps in `release.yml`/`ci-pipeline.yml` -- the action wrapper was already at its latest release but was implicitly floating on Trivy CLI v0.70.0 as its default.

## Test plan

- [x] `make test` (45/45 bats tests) passing against a locally built image with kubectl v1.36.2
- [x] kind-cluster regression spike: kubectl v1.31.0 vs v1.36.2 diffed across every collector command pattern on k8s 1.30.8 / 1.31.9 / 1.32.8 -- 0 RC mismatches, 0 functional diffs (only cosmetic client-version-banner / `describe` label differences)
- [x] Local Trivy scan (v0.72.0) of the rebuilt image confirms exactly the expected 5 residual CVEs, and confirms `.trivyignore` suppresses them (and correctly resurfaces them once the `exp:` date is simulated as past)
- [x] `cmd/must-gather/Makefile lint` (shellcheck) -- no new warnings introduced
- [ ] CI: release-pipeline Trivy gate passes for `must-gather` (this PR doesn't trigger `release.yml`, which is tag-triggered only -- will be exercised at the next release tag)

Made with [Cursor](https://cursor.com)