### PR TITLE
ci: extend Dependabot to cover the release/v1.5 maintenance branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,8 @@
 version: 2
 updates:
+  # ============================================================
+  # main (default branch)
+  # ============================================================
   - package-ecosystem: gomod
     directory: /
     schedule:
@@ -56,6 +59,82 @@ updates:
       - docker
     commit-message:
       prefix: "docker"
+    groups:
+      all-docker:
+        patterns:
+          - "*"
+
+  # ============================================================
+  # release/v1.5 (active maintenance branch)
+  #
+  # Dependabot's `target-branch` does not support wildcards/globs
+  # (https://github.com/dependabot/dependabot-core/issues/6890 -- still
+  # open), so each actively maintained release/* branch needs its own
+  # explicit block per ecosystem; it cannot be expressed as a single
+  # `release/**` pattern like the CI workflows use. Also note: any
+  # ecosystem block with a non-default target-branch is excluded from
+  # Dependabot's security-update PRs -- those always target the default
+  # branch (main) regardless of this config.
+  #
+  # Process: see "Dependabot on Maintenance Branches" in
+  # docs/development/release/RELEASE_GUIDE.md for adding/removing these
+  # blocks as release branches are cut/retired.
+  # ============================================================
+  - package-ecosystem: gomod
+    target-branch: release/v1.5
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - security
+    commit-message:
+      prefix: "deps(v1.5)"
+    ignore:
+      - dependency-name: "k8s.io/*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "sigs.k8s.io/*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+    groups:
+      all-go-deps:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    target-branch: release/v1.5
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ci
+    commit-message:
+      prefix: "ci(v1.5)"
+    groups:
+      all-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: docker
+    target-branch: release/v1.5
+    directories:
+      - "/docker"
+      - "/cmd/**"
+      - "/test/**"
+      - "/docs/architecture/spikes/**"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - docker
+    commit-message:
+      prefix: "docker(v1.5)"
     groups:
       all-docker:
         patterns:

--- a/docs/development/release/RELEASE_GUIDE.md
+++ b/docs/development/release/RELEASE_GUIDE.md
@@ -281,6 +281,30 @@ git push -u origin release/vX.Y
 If `release/vX.Y` already exists (from a previous patch), skip this step and
 pull it instead: `git checkout release/vX.Y && git pull origin release/vX.Y`.
 
+### Step 1a: Add Dependabot coverage (first patch only)
+
+Dependabot's `target-branch` option does not support wildcards
+([dependabot/dependabot-core#6890](https://github.com/dependabot/dependabot-core/issues/6890)
+is still open), so `.github/dependabot.yml` cannot express "all `release/**`
+branches" the way `ci-pipeline.yml`/`codeql.yml` do. Each actively maintained
+maintenance branch needs its own explicit `updates:` block per ecosystem
+(gomod, github-actions, docker).
+
+When you create a new `release/vX.Y` maintenance branch (Step 1 above), add
+three new blocks to `.github/dependabot.yml` — copy the existing
+`release/v1.5` blocks and change `target-branch` and the commit-message
+suffix to match the new branch (e.g. `deps(vX.Y)`).
+
+When a maintenance branch stops receiving patches (superseded by a newer
+minor, or end-of-support), remove its three blocks from `dependabot.yml` in
+the same PR that declares it retired — leaving stale blocks around just
+generates PRs against a branch nobody merges.
+
+Note: any `updates:` entry with a non-default `target-branch` is excluded
+from Dependabot's security-update PRs (those always target the default
+branch, `main`), so maintenance branches only get scheduled version updates
+via this config, not the separate security-alert flow.
+
 ### Step 2: Create the fix branch from the maintenance branch
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds explicit `gomod`/`github-actions`/`docker` Dependabot `updates:` blocks targeting `release/v1.5`, so this actively maintained release branch gets the same weekly dependency update coverage as `main`.
- Documents the add/remove process for these blocks in `docs/development/release/RELEASE_GUIDE.md`'s hotfix workflow (new "Step 1a: Add Dependabot coverage").

## Why per-branch blocks instead of a `release/**` pattern

The CI workflows (`ci-pipeline.yml`, `codeql.yml`) already use a `release/**` glob for their branch triggers, but Dependabot's `target-branch` option has no wildcard/glob support ([dependabot/dependabot-core#6890](https://github.com/dependabot/dependabot-core/issues/6890), still open). Each actively maintained maintenance branch needs its own explicit block per ecosystem — this PR adds that for `release/v1.5` only (the current active maintenance branch; older `release/**` branches are frozen/historical and were intentionally excluded per discussion).

Note: entries with a non-default `target-branch` are excluded from Dependabot's security-update PRs (those always target `main`), so `release/v1.5` gets scheduled version updates via this config but not the separate security-alert flow — called out in the RELEASE_GUIDE.md addition.

## Test plan

- [x] Validated `.github/dependabot.yml` is well-formed YAML (`python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"`) and produces 6 `updates` entries (3 for `main`, 3 for `release/v1.5`).
- [ ] After merge, confirm Dependabot's next scheduled run (Monday) opens PRs against `release/v1.5` for each ecosystem with outdated dependencies.

Made with [Cursor](https://cursor.com)