### PR TITLE
fix(e2e/fleet): widen CrashLoopBackOff wait timeout 2m->4m in E2E-FLEET-014

### DIFF
--- a/test/e2e/fleet/14_crashloop_cross_cluster_fix_test.go
+++ b/test/e2e/fleet/14_crashloop_cross_cluster_fix_test.go
@@ -62,6 +62,15 @@ var _ = Describe("E2E-FLEET-014 [AC-3, AC-4, SI-4]: CrashLoop config fix perform
 		})
 
 		By("Step 1b: Waiting for the real CrashLoopBackOff on the remote cluster...")
+		// Timeout widened from 2m to 4m (CI runs 29234664178, 29458356036): must-gather
+		// events on the shared single-node "fleet-e2e-remote" Kind cluster show a
+		// node-wide ~90-100s gap between image-pull-complete and the kubelet's first
+		// container Started event under concurrent parallel-spec load (this test races
+		// E2E-FLEET-015's OOMKill deployment and the suite-wide memory-eater fixture for
+		// the same node's CPU). Reaching CrashLoopBackOff needs a full start->crash->
+		// backoff cycle after that delay, which left near-zero margin in a fixed 2m
+		// budget. E2E-FLEET-015 tolerates the same delay because it also accepts an
+		// earlier OOMKilled termination-state signal, not just CrashLoopBackOff.
 		Eventually(func() bool {
 			pods := &corev1.PodList{}
 			if err := remoteK8sClient.List(ctx, pods, client.InNamespace(namespace),
@@ -78,7 +87,7 @@ var _ = Describe("E2E-FLEET-014 [AC-3, AC-4, SI-4]: CrashLoop config fix perform
 				}
 			}
 			return false
-		}, 2*time.Minute, 2*time.Second).Should(BeTrue(), "crashloop-app should reach CrashLoopBackOff on the remote cluster")
+		}, 4*time.Minute, 2*time.Second).Should(BeTrue(), "crashloop-app should reach CrashLoopBackOff on the remote cluster")
 
 		By("Step 2: Sending synthetic cluster-tagged alert to Gateway (AC-4, no real event-exporter bridge)")
 		payload := buildPrometheusAlertWithCluster("KubePodCrashLooping", namespace, "high",


### PR DESCRIPTION
## Root cause

E2E-FLEET-014 (`test/e2e/fleet/14_crashloop_cross_cluster_fix_test.go:81`) intermittently times out waiting for `crashloop-app` to reach `Waiting.Reason == "CrashLoopBackOff"` on the remote cluster, with a fixed 2-minute `Eventually()` budget.

Confirmed via must-gather from two independent, unrelated CI failures:
- Run [29234664178](https://github.com/jordigilh/kubernaut/actions/runs/29234664178) (`main`, PR #1664, 2026-07-13)
- Run [29458356036](https://github.com/jordigilh/kubernaut/actions/runs/29458356036/job/87497643265) (dependabot PR #1670, 2026-07-15)

Both show the identical signature: same test, same file:line, ~120.0s timeout, `31 Passed | 1 Failed`.

must-gather `events.txt` from both runs shows a node-wide ~90-100s gap between image-pull-complete and the kubelet's first container `Started` event on the shared single-node `fleet-e2e-remote` Kind cluster -- affecting *multiple* concurrently-scheduled pods (`crashloop-app` **and** the unrelated suite-wide `memory-eater` fixture), not something specific to this test's image/spec. The fleet suite runs with `--procs=$(nproc)` (parallel Ginkgo specs), so E2E-FLEET-014 (`crashloop-app`), E2E-FLEET-015 (`memory-eater-oom-cc`), and the suite-wide `memory-eater` fixture all land on the same node within seconds of each other, competing for CPU.

E2E-FLEET-014's assertion requires a full start->crash->backoff cycle to observe `CrashLoopBackOff`, which is more timing-sensitive than E2E-FLEET-015's check (which also accepts an earlier `OOMKilled` termination-state signal) -- explaining why 014 times out under this contention while 015 does not.

Not a code regression: neither failing run's diff touches this test's code path (run 29458356036's PR was a pure `go.mod`/`go.sum` dependency bump with zero overlap with this Deployment's lifecycle).

## Fix

Widen the `Eventually()` timeout from 2m to 4m to absorb the observed node-start latency, without weakening the assertion itself (still requires genuine `CrashLoopBackOff`).

## Validation
- `go build ./test/e2e/fleet/...` passes
- `go vet ./test/e2e/fleet/...` passes

Confidence: ~92%, grounded in two independent CI runs reproducing the identical failure signature and identical must-gather timing anomaly.

Made with [Cursor](https://cursor.com)