### PR TITLE
refactor(nilnil): Issue #1674 — sentinel-error refactor for ambiguous (nil, nil) returns

### DIFF
--- a/internal/controller/remediationorchestrator/analyzing_handler.go
+++ b/internal/controller/remediationorchestrator/analyzing_handler.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -248,7 +249,7 @@ func (h *AnalyzingHandler) handleDirectExecution(ctx context.Context, rr *remedi
 
 	// Routing checks
 	blocked, err := h.callbacks.CheckPostAnalysisConditions(ctx, rr, hashCtx.workflowID, hashCtx.targetResource, hashCtx.preHash, hashCtx.actionType)
-	if err != nil {
+	if err != nil && !errors.Is(err, routing.ErrNotBlocked) {
 		logger.Error(err, "Failed to check routing conditions")
 		return phase.Requeue(config.RequeueGenericError, "routing check failed"), nil
 	}

--- a/internal/controller/remediationorchestrator/awaiting_approval_handler.go
+++ b/internal/controller/remediationorchestrator/awaiting_approval_handler.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -243,7 +244,7 @@ func (h *AwaitingApprovalHandler) capturePostApprovalHash(ctx context.Context, r
 // caller must return (intent, err) immediately.
 func (h *AwaitingApprovalHandler) checkApprovalTargetBusy(ctx context.Context, rr *remediationv1.RemediationRequest, approvalTargetResource string, logger logr.Logger) (phase.TransitionIntent, bool, error) {
 	busyBlock, busyErr := h.callbacks.CheckResourceBusy(ctx, rr, approvalTargetResource)
-	if busyErr != nil {
+	if busyErr != nil && !errors.Is(busyErr, routing.ErrNotBlocked) {
 		logger.Error(busyErr, "Failed to check resource busy (approval path)")
 		return phase.Requeue(config.RequeueGenericError, "resource busy check failed"), true, nil
 	}

--- a/internal/controller/remediationorchestrator/pending_handler.go
+++ b/internal/controller/remediationorchestrator/pending_handler.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -82,7 +83,7 @@ func (h *PendingHandler) Handle(ctx context.Context, rr *remediationv1.Remediati
 	logger.Info("Handling Pending phase - checking routing conditions")
 
 	blocked, err := h.routingEngine.CheckPreAnalysisConditions(ctx, rr)
-	if err != nil {
+	if err != nil && !errors.Is(err, routing.ErrNotBlocked) {
 		logger.Error(err, "Failed to check routing conditions")
 		return phase.Requeue(config.RequeueGenericError, "routing check failed"), nil
 	}

--- a/internal/controller/remediationorchestrator/ro_controller_test_helpers_test.go
+++ b/internal/controller/remediationorchestrator/ro_controller_test_helpers_test.go
@@ -55,19 +55,22 @@ func setupScheme() *runtime.Scheme {
 	return scheme
 }
 
-// MockRoutingEngine is a mock implementation for unit tests
+// MockRoutingEngine is a mock implementation for unit tests.
+//
+// Issue #1674: Check* methods return routing.ErrNotBlocked (not a bare nil
+// error) to match the production RoutingEngine's sentinel-error contract.
 type MockRoutingEngine struct{}
 
 func (m *MockRoutingEngine) CheckPreAnalysisConditions(ctx context.Context, rr *remediationv1.RemediationRequest) (*routing.BlockingCondition, error) {
-	return nil, nil // Always return not blocked for unit tests
+	return nil, routing.ErrNotBlocked // Always return not blocked for unit tests
 }
 
 func (m *MockRoutingEngine) CheckPostAnalysisConditions(ctx context.Context, rr *remediationv1.RemediationRequest, workflowID string, targetResource string, preRemediationSpecHash string, actionType string) (*routing.BlockingCondition, error) {
-	return nil, nil // Always return not blocked for unit tests
+	return nil, routing.ErrNotBlocked // Always return not blocked for unit tests
 }
 
 func (m *MockRoutingEngine) CheckResourceBusy(ctx context.Context, rr *remediationv1.RemediationRequest, targetResource string) (*routing.BlockingCondition, error) {
-	return nil, nil
+	return nil, routing.ErrNotBlocked
 }
 
 func (m *MockRoutingEngine) CheckUnmanagedResource(ctx context.Context, rr *remediationv1.RemediationRequest) *routing.BlockingCondition {

--- a/internal/controller/workflowexecution/workflowexecution_catalog.go
+++ b/internal/controller/workflowexecution/workflowexecution_catalog.go
@@ -22,6 +22,7 @@ package workflowexecution
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
@@ -35,17 +36,18 @@ import (
 // Issue #518: Runtime Execution Engine Resolution
 // ========================================
 
+// ErrAlreadyResolved indicates the WFE's execution engine is already set, so
+// resolveWorkflowCatalog is a no-op (idempotency guard). Issue #1674: typed
+// sentinel replacing the previous ambiguous (nil, nil) return.
+var ErrAlreadyResolved = errors.New("workflow catalog already resolved")
+
 // resolveWorkflowCatalog fetches all workflow metadata from the DS catalog in a
 // single GetWorkflowByID call (Issue #650). Consolidates resolveExecutionEngine,
 // resolveExecutionBundle, resolveDependencies, and GetWorkflowEngineConfig.
-// Idempotent: returns nil immediately if the engine is already resolved.
+// Idempotent: returns ErrAlreadyResolved if the engine is already resolved.
 func (r *WorkflowExecutionReconciler) resolveWorkflowCatalog(ctx context.Context, wfe *workflowexecutionv1alpha1.WorkflowExecution) (*weclient.WorkflowCatalogMetadata, error) {
-	// nolint:nilnil // intentional "already resolved, nothing to do" sentinel,
-	// not an error — already documented above ("Idempotent: returns nil
-	// immediately..."); the sole caller discards the metadata value entirely
-	// and only checks the error (Issue #1546 Tier 2).
 	if wfe.Status.ExecutionEngine != "" {
-		return nil, nil
+		return nil, ErrAlreadyResolved
 	}
 
 	if r.WorkflowQuerier == nil {

--- a/internal/controller/workflowexecution/workflowexecution_catalog_test.go
+++ b/internal/controller/workflowexecution/workflowexecution_catalog_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflowexecution
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	workflowexecutionv1alpha1 "github.com/jordigilh/kubernaut/api/workflowexecution/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/models"
+	weclient "github.com/jordigilh/kubernaut/pkg/workflowexecution/client"
+)
+
+func TestWorkflowExecutionCatalogUnit(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "WorkflowExecution Catalog Unit Suite")
+}
+
+// mockCatalogWorkflowQuerier implements weclient.WorkflowQuerier for testing
+// resolveWorkflowCatalog. Only ResolveWorkflowCatalogMetadata is exercised by
+// this function; the remaining methods are unused stubs required to satisfy
+// the interface.
+type mockCatalogWorkflowQuerier struct {
+	meta *weclient.WorkflowCatalogMetadata
+	err  error
+}
+
+func (m *mockCatalogWorkflowQuerier) GetWorkflowDependencies(context.Context, string) (*models.WorkflowDependencies, error) {
+	panic("not used by resolveWorkflowCatalog")
+}
+
+func (m *mockCatalogWorkflowQuerier) GetWorkflowEngineConfig(context.Context, string) (json.RawMessage, error) {
+	panic("not used by resolveWorkflowCatalog")
+}
+
+func (m *mockCatalogWorkflowQuerier) GetWorkflowExecutionEngine(context.Context, string) (string, string, error) {
+	panic("not used by resolveWorkflowCatalog")
+}
+
+func (m *mockCatalogWorkflowQuerier) GetWorkflowExecutionBundle(context.Context, string) (string, string, error) {
+	panic("not used by resolveWorkflowCatalog")
+}
+
+func (m *mockCatalogWorkflowQuerier) ResolveWorkflowCatalogMetadata(_ context.Context, _ string) (*weclient.WorkflowCatalogMetadata, error) {
+	return m.meta, m.err
+}
+
+func (m *mockCatalogWorkflowQuerier) GetWorkflowSchemaMetadata(context.Context, string) (*weclient.SchemaMetadata, error) {
+	panic("not used by resolveWorkflowCatalog")
+}
+
+// ========================================
+// Issue #1674 (nilnil sentinel-error refactor), Batch 2: resolveWorkflowCatalog
+// previously returned (nil, nil) for the idempotent "already resolved" case,
+// ambiguous with a caller forgetting to check the error. This package had
+// zero unit-test coverage before this change.
+// BR-WE-003 (WorkflowExecution catalog resolution), Issue #650, Issue #518.
+// ========================================
+var _ = Describe("resolveWorkflowCatalog (Issue #1674 Batch 2)", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("UT-WE-1674-001: returns ErrAlreadyResolved when the execution engine is already set", func() {
+		wfe := &workflowexecutionv1alpha1.WorkflowExecution{}
+		wfe.Status.ExecutionEngine = "tekton"
+		r := &WorkflowExecutionReconciler{
+			WorkflowQuerier: &mockCatalogWorkflowQuerier{},
+		}
+
+		meta, err := r.resolveWorkflowCatalog(ctx, wfe)
+
+		Expect(errors.Is(err, ErrAlreadyResolved)).To(BeTrue())
+		Expect(meta).To(BeNil())
+	})
+
+	It("UT-WE-1674-002: resolves engine, service account, and resources from the DS catalog", func() {
+		wfe := &workflowexecutionv1alpha1.WorkflowExecution{}
+		wfe.Spec.WorkflowRef.WorkflowID = "wf-1"
+		r := &WorkflowExecutionReconciler{
+			WorkflowQuerier: &mockCatalogWorkflowQuerier{
+				meta: &weclient.WorkflowCatalogMetadata{
+					ExecutionEngine:    "tekton",
+					WorkflowName:       "restart-pod",
+					ServiceAccountName: "wf-sa",
+				},
+			},
+		}
+
+		meta, err := r.resolveWorkflowCatalog(ctx, wfe)
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(meta).ToNot(BeNil())
+		Expect(wfe.Status.ExecutionEngine).To(Equal("tekton"))
+		Expect(wfe.Status.ServiceAccountName).To(Equal("wf-sa"))
+	})
+})

--- a/internal/controller/workflowexecution/workflowexecution_pending.go
+++ b/internal/controller/workflowexecution/workflowexecution_pending.go
@@ -21,6 +21,7 @@ package workflowexecution
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -213,7 +214,7 @@ func (r *WorkflowExecutionReconciler) resolvePendingSchemaAndEngine(ctx context.
 	// Called BEFORE setting engine from schema so the idempotency guard in
 	// resolveWorkflowCatalog doesn't skip the SA and bundle resolution that
 	// only the catalog provides.
-	if _, catalogErr := r.resolveWorkflowCatalog(ctx, wfe); catalogErr != nil {
+	if _, catalogErr := r.resolveWorkflowCatalog(ctx, wfe); catalogErr != nil && !errors.Is(catalogErr, ErrAlreadyResolved) {
 		logger.Error(catalogErr, "Failed to resolve workflow catalog from DS (non-fatal)")
 	}
 

--- a/internal/kubernautagent/mcp/interfaces.go
+++ b/internal/kubernautagent/mcp/interfaces.go
@@ -144,7 +144,8 @@ type SessionLifecycle interface {
 // sessions. Split out from SessionManager for ISP
 // (GO-ANTIPATTERN-AUDIT-2026-07-01 Wave 0b).
 type SessionQuerier interface {
-	// GetDriver returns the current driver session for an RR, or nil if autonomous.
+	// GetDriver returns the current driver session for an RR, or
+	// ErrSessionNotFound if no interactive session exists (e.g., autonomous mode).
 	GetDriver(rrID string) (*InteractiveSession, error)
 
 	// IsDriverActive returns true if a user is currently driving the given RR.

--- a/internal/kubernautagent/mcp/session_manager.go
+++ b/internal/kubernautagent/mcp/session_manager.go
@@ -344,19 +344,19 @@ func (m *LeaseSessionManager) Release(sessionID string, reason string) error {
 	return nil
 }
 
-// nolint:nilnil // intentional "no active driver" sentinel, not an error —
-// canonical repository/lookup idiom; every caller already guards with
-// `if err != nil || sess == nil` before use (Issue #1546 Tier 2).
+// GetDriver returns the current driver session for rrID, or ErrSessionNotFound
+// if no interactive session exists (e.g., the RR is in autonomous mode).
+// Issue #1674: typed sentinel replaces the previous ambiguous (nil, nil).
 func (m *LeaseSessionManager) GetDriver(rrID string) (*InteractiveSession, error) {
 	raw, ok := m.rrIndex.Load(rrID)
 	if !ok {
-		return nil, nil // nolint:nilnil
+		return nil, ErrSessionNotFound
 	}
 	sessionID := raw.(string)
 
 	raw, ok = m.sessions.Load(sessionID)
 	if !ok {
-		return nil, nil // nolint:nilnil
+		return nil, ErrSessionNotFound
 	}
 	entry := raw.(*sessionEntry)
 

--- a/internal/kubernautagent/mcp/session_manager_test.go
+++ b/internal/kubernautagent/mcp/session_manager_test.go
@@ -128,10 +128,14 @@ var _ = Describe("LeaseSessionManager — #703 BR-INTERACTIVE-002", func() {
 		})
 	})
 
-	Describe("UT-KA-703-I05: GetDriver returns nil when no active session", func() {
-		It("should return nil session when no driver is active", func() {
+	Describe("UT-KA-703-I05: GetDriver returns ErrSessionNotFound when no active session", func() {
+		It("should return ErrSessionNotFound and a nil session when no driver is active", func() {
+			// Issue #1674: GetDriver previously returned (nil, nil), ambiguous
+			// with a caller forgetting to check the error. Every production
+			// caller already guards on `err != nil || sess == nil` (or discards
+			// err entirely), so this sentinel is a pure signature clarification.
 			session, err := mgr.GetDriver("rr-005")
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(MatchError(mcpinternal.ErrSessionNotFound))
 			Expect(session).To(BeNil())
 		})
 	})

--- a/pkg/authwebhook/errors.go
+++ b/pkg/authwebhook/errors.go
@@ -18,6 +18,11 @@ package authwebhook
 
 import "errors"
 
+// ErrActionTypeCRDNotFound indicates no ActionType CRD in the namespace has a
+// spec.name matching the queried action type. Issue #1674: typed sentinel
+// replacing the previous ambiguous (nil, nil) return from findActionTypeKey.
+var ErrActionTypeCRDNotFound = errors.New("ActionType CRD not found")
+
 // PermanentError indicates a non-retryable error from DataStorage.
 // HTTP 400 (validation), 403 (forbidden), 404 (not found) are permanent —
 // retrying will not produce a different result.

--- a/pkg/authwebhook/rw_reconciler.go
+++ b/pkg/authwebhook/rw_reconciler.go
@@ -160,10 +160,9 @@ func (r *RemediationWorkflowReconciler) refreshActionTypeWorkflowCount(ctx conte
 
 	atKey, err := r.findActionTypeKey(ctx, actionType, namespace)
 	if err != nil {
-		logger.Error(err, "Failed to find ActionType CRD", "actionType", actionType)
-		return
-	}
-	if atKey == nil {
+		if !errors.Is(err, ErrActionTypeCRDNotFound) {
+			logger.Error(err, "Failed to find ActionType CRD", "actionType", actionType)
+		}
 		return
 	}
 
@@ -181,7 +180,8 @@ func (r *RemediationWorkflowReconciler) refreshActionTypeWorkflowCount(ctx conte
 	}
 }
 
-// findActionTypeKey locates the ActionType CRD whose spec.name matches actionType.
+// findActionTypeKey locates the ActionType CRD whose spec.name matches
+// actionType. Returns ErrActionTypeCRDNotFound if no match exists.
 func (r *RemediationWorkflowReconciler) findActionTypeKey(ctx context.Context, actionType, namespace string) (*client.ObjectKey, error) {
 	atList := &atv1alpha1.ActionTypeList{}
 	if err := r.List(ctx, atList, client.InNamespace(namespace)); err != nil {
@@ -193,10 +193,7 @@ func (r *RemediationWorkflowReconciler) findActionTypeKey(ctx context.Context, a
 			return &key, nil
 		}
 	}
-	// nolint:nilnil // intentional "not found" sentinel, not an error —
-	// canonical Find* idiom; sole caller already guards with
-	// `if atKey == nil` before use (Issue #1546 Tier 2).
-	return nil, nil
+	return nil, fmt.Errorf("%w: %s", ErrActionTypeCRDNotFound, actionType)
 }
 
 func (r *RemediationWorkflowReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/pkg/authwebhook/rw_reconciler_internal_test.go
+++ b/pkg/authwebhook/rw_reconciler_internal_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package authwebhook
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	atv1alpha1 "github.com/jordigilh/kubernaut/api/actiontype/v1alpha1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+// ========================================
+// Issue #1674 (nilnil sentinel-error refactor), Batch 2: findActionTypeKey is
+// unexported, so its "not found" branch (zero test coverage before this
+// change) is exercised here via an internal (white-box) test file — the
+// package already has precedent for this
+// (remediationapprovalrequest_handler_fuzz_test.go).
+// BR-WORKFLOW-006.
+// ========================================
+var _ = Describe("findActionTypeKey (Issue #1674 Batch 2)", func() {
+	It("UT-AW-1674-001: returns ErrActionTypeCRDNotFound when no ActionType CRD matches the name", func() {
+		s := runtime.NewScheme()
+		Expect(atv1alpha1.AddToScheme(s)).To(Succeed())
+		fakeK8s := fake.NewClientBuilder().WithScheme(s).Build()
+
+		r := &RemediationWorkflowReconciler{Client: fakeK8s}
+
+		key, err := r.findActionTypeKey(context.Background(), "NoSuchAction", "kubernaut-system")
+
+		Expect(errors.Is(err, ErrActionTypeCRDNotFound)).To(BeTrue())
+		Expect(key).To(BeNil())
+	})
+
+	It("UT-AW-1674-002: returns the ObjectKey when an ActionType CRD matches spec.name", func() {
+		s := runtime.NewScheme()
+		Expect(atv1alpha1.AddToScheme(s)).To(Succeed())
+		at := &atv1alpha1.ActionType{}
+		at.SetName("scale-memory-at")
+		at.SetNamespace("kubernaut-system")
+		at.Spec.Name = "ScaleMemory"
+		fakeK8s := fake.NewClientBuilder().WithScheme(s).WithObjects(at).Build()
+
+		r := &RemediationWorkflowReconciler{Client: fakeK8s}
+
+		key, err := r.findActionTypeKey(context.Background(), "ScaleMemory", "kubernaut-system")
+
+		Expect(err).ToNot(HaveOccurred())
+		Expect(key).ToNot(BeNil())
+		Expect(key.Name).To(Equal("scale-memory-at"))
+	})
+})

--- a/pkg/datastorage/actiontype_crud_business_test.go
+++ b/pkg/datastorage/actiontype_crud_business_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastorage_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/jmoiron/sqlx"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kubelog "github.com/jordigilh/kubernaut/pkg/log"
+
+	"github.com/jordigilh/kubernaut/pkg/datastorage/models"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/repository/actiontype"
+)
+
+// ========================================
+// Issue #1674 (nilnil sentinel-error refactor), Batch 1: GetByName previously
+// returned (nil, nil) on sql.ErrNoRows, ambiguous with a caller forgetting to
+// check the error. This package had zero unit-test coverage of GetByName
+// before this batch.
+// BR-WORKFLOW-007 (ActionType CRD lifecycle).
+// ========================================
+var _ = Describe("ActionType CRUD sentinel-error refactor (Issue #1674 Batch 1)", func() {
+	var (
+		mockDB  *sql.DB
+		sqlMock sqlmock.Sqlmock
+		repo    *actiontype.Repository
+		ctx     context.Context
+	)
+
+	BeforeEach(func() {
+		var err error
+		mockDB, sqlMock, err = sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		Expect(err).ToNot(HaveOccurred())
+
+		logger := kubelog.NewLogger(kubelog.DevelopmentOptions())
+		ctx = context.Background()
+
+		sqlxDB := sqlx.NewDb(mockDB, "sqlmock")
+		repo = actiontype.NewRepository(sqlxDB, logger)
+	})
+
+	AfterEach(func() {
+		Expect(sqlMock.ExpectationsWereMet()).To(Succeed())
+		_ = mockDB.Close()
+	})
+
+	Describe("GetByName", func() {
+		It("UT-DS-1674-001: returns ErrActionTypeNotFound when no action type matches the name", func() {
+			// Issue #1674: GetByName must return a typed sentinel instead of the
+			// ambiguous (nil, nil), matching the ErrActionTypeNotFound convention
+			// already used by UpdateDescription/Disable/ForceDisable in this file.
+			sqlMock.ExpectQuery(`SELECT .* FROM action_type_taxonomy WHERE action_type = \$1`).
+				WillReturnError(sql.ErrNoRows)
+
+			at, err := repo.GetByName(ctx, "NoSuchAction")
+
+			Expect(err).To(HaveOccurred(), "Issue #1674: not-found must be a typed error, not (nil, nil)")
+			Expect(errors.Is(err, actiontype.ErrActionTypeNotFound)).To(BeTrue())
+			Expect(at).To(BeNil())
+		})
+
+		It("UT-DS-1674-002: returns the action type when the name matches an existing row", func() {
+			rows := sqlmock.NewRows([]string{
+				"action_type", "description", "status", "disabled_at", "disabled_by", "created_at", "updated_at",
+			}).AddRow(
+				"RestartPod", []byte(`{"what":"restart"}`), "Active", nil, nil, time.Now(), time.Now(),
+			)
+			sqlMock.ExpectQuery(`SELECT .* FROM action_type_taxonomy WHERE action_type = \$1`).
+				WillReturnRows(rows)
+
+			at, err := repo.GetByName(ctx, "RestartPod")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(at).ToNot(BeNil())
+			Expect(at.ActionType).To(Equal("RestartPod"))
+		})
+
+		It("UT-DS-1674-003: propagates a real database error instead of masking it as not-found", func() {
+			sqlMock.ExpectQuery(`SELECT .* FROM action_type_taxonomy WHERE action_type = \$1`).
+				WillReturnError(errors.New("connection refused"))
+
+			at, err := repo.GetByName(ctx, "RestartPod")
+
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, actiontype.ErrActionTypeNotFound)).To(BeFalse(),
+				"a real DB error must not be conflated with the not-found sentinel")
+			Expect(at).To(BeNil())
+		})
+	})
+
+	Describe("Create", func() {
+		It("UT-DS-1674-004: creates a new action type when GetByName returns ErrActionTypeNotFound", func() {
+			// Regression guard: Create's existing-check must tolerate the new
+			// ErrActionTypeNotFound sentinel as "proceed to insert", not treat it
+			// as a fatal lookup failure.
+			sqlMock.ExpectQuery(`SELECT .* FROM action_type_taxonomy WHERE action_type = \$1`).
+				WillReturnError(sql.ErrNoRows)
+			sqlMock.ExpectExec(`INSERT INTO action_type_taxonomy`).
+				WillReturnResult(sqlmock.NewResult(1, 1))
+			rows := sqlmock.NewRows([]string{
+				"action_type", "description", "status", "disabled_at", "disabled_by", "created_at", "updated_at",
+			}).AddRow(
+				"NewAction", []byte(`{"what":"new"}`), "Active", nil, nil, time.Now(), time.Now(),
+			)
+			sqlMock.ExpectQuery(`SELECT .* FROM action_type_taxonomy WHERE action_type = \$1`).
+				WillReturnRows(rows)
+
+			desc := models.ActionTypeDescription{What: "does something new", WhenToUse: "when needed"}
+			result, err := repo.Create(ctx, "NewAction", desc, "tester")
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result).ToNot(BeNil())
+			Expect(result.Status).To(Equal("created"))
+		})
+	})
+})

--- a/pkg/datastorage/engine_config_test.go
+++ b/pkg/datastorage/engine_config_test.go
@@ -18,6 +18,7 @@ package datastorage_test
 
 import (
 	"encoding/json"
+	"errors"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -68,25 +69,27 @@ var _ = Describe("ParseEngineConfig Discriminator [BR-WE-016]", func() {
 	})
 
 	Context("tekton and job engines", func() {
-		It("UT-WE-016-002: should return nil config for engine=tekton", func() {
+		It("UT-WE-016-002: should return ErrNoEngineConfig for engine=tekton", func() {
+			// Issue #1674: tekton/job have no typed engineConfig struct, so this
+			// is now a checkable sentinel instead of an ambiguous (nil, nil).
 			raw := json.RawMessage(`{"someField": "value"}`)
 
 			result, err := models.ParseEngineConfig("tekton", raw)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, models.ErrNoEngineConfig)).To(BeTrue())
 			Expect(result).To(BeNil())
 		})
 
-		It("UT-WE-016-002b: should return nil config for engine=job", func() {
+		It("UT-WE-016-002b: should return ErrNoEngineConfig for engine=job", func() {
 			raw := json.RawMessage(`{"someField": "value"}`)
 
 			result, err := models.ParseEngineConfig("job", raw)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, models.ErrNoEngineConfig)).To(BeTrue())
 			Expect(result).To(BeNil())
 		})
 
-		It("UT-WE-016-002c: should return nil for tekton with empty engineConfig", func() {
+		It("UT-WE-016-002c: should return ErrNoEngineConfig for tekton with empty engineConfig", func() {
 			result, err := models.ParseEngineConfig("tekton", nil)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, models.ErrNoEngineConfig)).To(BeTrue())
 			Expect(result).To(BeNil())
 		})
 	})
@@ -119,9 +122,9 @@ var _ = Describe("ParseEngineConfig Discriminator [BR-WE-016]", func() {
 			Expect(err.Error()).To(ContainSubstring("ansible"))
 		})
 
-		It("UT-WE-016-004c: should return nil for ansible with empty engineConfig", func() {
+		It("UT-WE-016-004c: should return ErrNoEngineConfig for ansible with empty engineConfig", func() {
 			result, err := models.ParseEngineConfig("ansible", nil)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, models.ErrNoEngineConfig)).To(BeTrue())
 			Expect(result).To(BeNil())
 		})
 	})

--- a/pkg/datastorage/models/workflow_schema.go
+++ b/pkg/datastorage/models/workflow_schema.go
@@ -18,6 +18,7 @@ package models
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -25,6 +26,12 @@ import (
 	sharedtypes "github.com/jordigilh/kubernaut/pkg/shared/types"
 	"gopkg.in/yaml.v3"
 )
+
+// ErrNoEngineConfig indicates ParseEngineConfig has no typed engineConfig to
+// return: either raw was empty, or the engine (tekton/job) has no typed
+// engineConfig struct at all. Issue #1674: typed sentinel replacing the
+// previous ambiguous (nil, nil) returns.
+var ErrNoEngineConfig = errors.New("no engineConfig to parse")
 
 // ========================================
 // WORKFLOW SCHEMA MODELS
@@ -291,17 +298,11 @@ type AnsibleEngineConfig struct {
 
 // ParseEngineConfig deserializes raw engineConfig JSON based on the engine discriminator.
 // BR-WE-016: Two-phase unmarshal — read engine first, then unmarshal config.
-// Returns (nil, nil) when raw is empty, regardless of engine.
+// Returns ErrNoEngineConfig when raw is empty, regardless of engine.
 // Returns error for unknown engines or invalid/incomplete ansible config.
 func ParseEngineConfig(engine string, raw json.RawMessage) (any, error) {
-	// nolint:nilnil // intentional "no config" sentinel, not an error —
-	// already documented above ("Returns (nil, nil) when raw is empty").
-	// Both callers (ansible.go, schema/parser.go) only act on the result
-	// when engine=="ansible", where an unexpected nil safely fails the
-	// `parsed.(*AnsibleEngineConfig)` type assertion with a clear error
-	// rather than silently succeeding (Issue #1546 Tier 2).
 	if len(raw) == 0 {
-		return nil, nil
+		return nil, ErrNoEngineConfig
 	}
 	switch engine {
 	case "ansible":
@@ -314,9 +315,8 @@ func ParseEngineConfig(engine string, raw json.RawMessage) (any, error) {
 		}
 		return &cfg, nil
 	case "tekton", "job":
-		// nolint:nilnil // same "no config" sentinel as above — tekton/job
-		// engines don't have a typed engineConfig struct at all.
-		return nil, nil
+		// tekton/job engines don't have a typed engineConfig struct at all.
+		return nil, ErrNoEngineConfig
 	default:
 		return nil, fmt.Errorf("unknown engine %q: cannot parse engineConfig", engine)
 	}

--- a/pkg/datastorage/repository/actiontype/crud.go
+++ b/pkg/datastorage/repository/actiontype/crud.go
@@ -52,7 +52,7 @@ func (r *Repository) Create(ctx context.Context, actionType string, description 
 	}
 
 	existing, err := r.GetByName(ctx, actionType)
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrActionTypeNotFound) {
 		return nil, fmt.Errorf("check existing action type: %w", err)
 	}
 
@@ -95,7 +95,10 @@ func (r *Repository) Create(ctx context.Context, actionType string, description 
 	return &CreateResult{ActionType: created, Status: "created", WasReenabled: false}, nil
 }
 
-// GetByName returns the action type by its PascalCase name, or nil if not found.
+// GetByName returns the action type by its PascalCase name.
+// Returns ErrActionTypeNotFound (wrapped with the queried name) if no
+// matching row exists (Issue #1674: typed sentinel replaces the previous
+// ambiguous (nil, nil) return).
 func (r *Repository) GetByName(ctx context.Context, actionType string) (*models.ActionTypeTaxonomy, error) {
 	var at models.ActionTypeTaxonomy
 	err := r.db.QueryRowxContext(ctx,
@@ -105,11 +108,7 @@ func (r *Repository) GetByName(ctx context.Context, actionType string) (*models.
 	).StructScan(&at)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
-			// nolint:nilnil // intentional "not found" sentinel, not an error —
-			// canonical repository idiom; documented in the GetByName doc
-			// comment above ("or nil if not found"); callers already guard
-			// with `if x != nil` before use (Issue #1546 Tier 2).
-			return nil, nil
+			return nil, fmt.Errorf("%w: %s", ErrActionTypeNotFound, actionType)
 		}
 		return nil, fmt.Errorf("get action type %q: %w", actionType, err)
 	}
@@ -130,9 +129,6 @@ func (r *Repository) UpdateDescription(ctx context.Context, actionType string, n
 	existing, err := r.GetByName(ctx, actionType)
 	if err != nil {
 		return nil, fmt.Errorf("fetch action type for update: %w", err)
-	}
-	if existing == nil {
-		return nil, fmt.Errorf("%w: %s", ErrActionTypeNotFound, actionType)
 	}
 	if existing.Status != models.ActionTypeStatusActive {
 		return nil, fmt.Errorf("%w: %s", ErrActionTypeDisabled, actionType)

--- a/pkg/datastorage/repository/workflow/crud.go
+++ b/pkg/datastorage/repository/workflow/crud.go
@@ -347,8 +347,21 @@ func insertOrReactivateWorkflow(ctx context.Context, tx *sqlx.Tx, newWorkflow *m
 // READ OPERATIONS
 // ========================================
 
+// ErrNotFound is returned by the Get* lookup methods below when no row
+// matches the query. Issue #1674: replaces the ambiguous (nil, nil) return
+// that forced every caller to distinguish "not found" from "real error" by
+// nil-checking the result instead of checking err. Callers should use
+// errors.Is(err, ErrNotFound).
+//
+// DD-WORKFLOW-016: GetWorkflowWithContextFilters (discovery.go) also returns
+// this sentinel for its security gate — it deliberately does not distinguish
+// "workflow doesn't exist" from "workflow exists but doesn't match context
+// filters" to avoid leaking which case occurred to the caller.
+var ErrNotFound = errors.New("workflow not found")
+
 // GetByID retrieves a workflow by UUID (primary key)
 // DD-WORKFLOW-002 v3.0: workflow_id is the sole UUID primary key
+// Returns ErrNotFound (wrapped with the queried ID) if no workflow exists.
 func (r *Repository) GetByID(ctx context.Context, workflowID string) (*models.RemediationWorkflow, error) {
 	query := `
 		SELECT ` + workflowCatalogColumns + ` FROM remediation_workflow_catalog
@@ -358,10 +371,7 @@ func (r *Repository) GetByID(ctx context.Context, workflowID string) (*models.Re
 	var workflow models.RemediationWorkflow
 	err := r.db.GetContext(ctx, &workflow, query, workflowID)
 	if errors.Is(err, sql.ErrNoRows) {
-		// nolint:nilnil // intentional "not found" sentinel, not an error —
-		// canonical repository idiom; all callers already guard with
-		// `if x != nil` before use (Issue #1546 Tier 2).
-		return nil, nil // Not found
+		return nil, fmt.Errorf("%w: %s", ErrNotFound, workflowID)
 	}
 	if err != nil {
 		r.logger.Error(err, "failed to get workflow by ID",
@@ -374,6 +384,7 @@ func (r *Repository) GetByID(ctx context.Context, workflowID string) (*models.Re
 
 // GetByNameAndVersion retrieves a workflow by workflow_name and version
 // DD-WORKFLOW-002 v3.0: workflow_name is the human-readable identifier
+// Returns ErrNotFound (wrapped with name+version) if no workflow exists.
 func (r *Repository) GetByNameAndVersion(ctx context.Context, workflowName, version string) (*models.RemediationWorkflow, error) {
 	query := `
 		SELECT ` + workflowCatalogColumns + ` FROM remediation_workflow_catalog
@@ -383,10 +394,7 @@ func (r *Repository) GetByNameAndVersion(ctx context.Context, workflowName, vers
 	var workflow models.RemediationWorkflow
 	err := r.db.GetContext(ctx, &workflow, query, workflowName, version)
 	if errors.Is(err, sql.ErrNoRows) {
-		// nolint:nilnil // intentional "not found" sentinel, not an error —
-		// canonical repository idiom; all callers already guard with
-		// `if x != nil` before use (Issue #1546 Tier 2).
-		return nil, nil // Not found
+		return nil, fmt.Errorf("%w: %s@%s", ErrNotFound, workflowName, version)
 	}
 	if err != nil {
 		r.logger.Error(err, "failed to get workflow by name and version",
@@ -400,6 +408,7 @@ func (r *Repository) GetByNameAndVersion(ctx context.Context, workflowName, vers
 
 // GetActiveByNameAndVersion retrieves an active workflow by name and version.
 // BR-WORKFLOW-006: Used by content integrity check to detect idempotent re-apply vs supersede.
+// Returns ErrNotFound (wrapped with name+version) if no active workflow exists.
 func (r *Repository) GetActiveByNameAndVersion(ctx context.Context, workflowName, version string) (*models.RemediationWorkflow, error) {
 	query := `
 		SELECT ` + workflowCatalogColumns + ` FROM remediation_workflow_catalog
@@ -409,10 +418,7 @@ func (r *Repository) GetActiveByNameAndVersion(ctx context.Context, workflowName
 	var wf models.RemediationWorkflow
 	err := r.db.GetContext(ctx, &wf, query, workflowName, version)
 	if errors.Is(err, sql.ErrNoRows) {
-		// nolint:nilnil // intentional "not found" sentinel, not an error —
-		// canonical repository idiom; all callers already guard with
-		// `if x != nil` before use (Issue #1546 Tier 2).
-		return nil, nil
+		return nil, fmt.Errorf("%w: %s@%s", ErrNotFound, workflowName, version)
 	}
 	if err != nil {
 		r.logger.Error(err, "failed to get active workflow by name and version",
@@ -425,6 +431,7 @@ func (r *Repository) GetActiveByNameAndVersion(ctx context.Context, workflowName
 // GetLatestDisabledByNameAndVersion retrieves the most recently disabled workflow
 // by name and version. BR-WORKFLOW-006: Used by content integrity check to decide
 // between re-enable (same hash) and create-new (different hash).
+// Returns ErrNotFound (wrapped with name+version) if no disabled workflow exists.
 func (r *Repository) GetLatestDisabledByNameAndVersion(ctx context.Context, workflowName, version string) (*models.RemediationWorkflow, error) {
 	query := `
 		SELECT ` + workflowCatalogColumns + ` FROM remediation_workflow_catalog
@@ -436,10 +443,7 @@ func (r *Repository) GetLatestDisabledByNameAndVersion(ctx context.Context, work
 	var wf models.RemediationWorkflow
 	err := r.db.GetContext(ctx, &wf, query, workflowName, version)
 	if errors.Is(err, sql.ErrNoRows) {
-		// nolint:nilnil // intentional "not found" sentinel, not an error —
-		// canonical repository idiom; all callers already guard with
-		// `if x != nil` before use (Issue #1546 Tier 2).
-		return nil, nil
+		return nil, fmt.Errorf("%w: %s@%s", ErrNotFound, workflowName, version)
 	}
 	if err != nil {
 		r.logger.Error(err, "failed to get disabled workflow by name and version",
@@ -452,6 +456,7 @@ func (r *Repository) GetLatestDisabledByNameAndVersion(ctx context.Context, work
 // GetActiveByWorkflowName retrieves any active workflow entry for a given workflow_name,
 // regardless of version. Issue #371, BR-WORKFLOW-006: Used by handleDuplicateWorkflow
 // for cross-version supersession when a new version of an existing workflow is registered.
+// Returns ErrNotFound (wrapped with the queried name) if no active workflow exists.
 func (r *Repository) GetActiveByWorkflowName(ctx context.Context, workflowName string) (*models.RemediationWorkflow, error) {
 	query := `
 		SELECT ` + workflowCatalogColumns + ` FROM remediation_workflow_catalog
@@ -463,10 +468,7 @@ func (r *Repository) GetActiveByWorkflowName(ctx context.Context, workflowName s
 	var wf models.RemediationWorkflow
 	err := r.db.GetContext(ctx, &wf, query, workflowName)
 	if errors.Is(err, sql.ErrNoRows) {
-		// nolint:nilnil // intentional "not found" sentinel, not an error —
-		// canonical repository idiom; all callers already guard with
-		// `if x != nil` before use (Issue #1546 Tier 2).
-		return nil, nil
+		return nil, fmt.Errorf("%w: %s", ErrNotFound, workflowName)
 	}
 	if err != nil {
 		r.logger.Error(err, "failed to get active workflow by name",
@@ -478,6 +480,8 @@ func (r *Repository) GetActiveByWorkflowName(ctx context.Context, workflowName s
 
 // GetLatestVersion retrieves the latest version of a workflow by workflow_name
 // DD-WORKFLOW-002 v3.0: Uses is_latest_version flag for efficient lookup
+// Returns ErrNotFound (wrapped with the queried name) if no workflow exists.
+// Note: as of Issue #1674, this method has zero production callers.
 func (r *Repository) GetLatestVersion(ctx context.Context, workflowName string) (*models.RemediationWorkflow, error) {
 	query := `
 		SELECT ` + workflowCatalogColumns + ` FROM remediation_workflow_catalog
@@ -487,10 +491,7 @@ func (r *Repository) GetLatestVersion(ctx context.Context, workflowName string) 
 	var workflow models.RemediationWorkflow
 	err := r.db.GetContext(ctx, &workflow, query, workflowName)
 	if errors.Is(err, sql.ErrNoRows) {
-		// nolint:nilnil // intentional "not found" sentinel, not an error —
-		// canonical repository idiom; all callers already guard with
-		// `if x != nil` before use (Issue #1546 Tier 2).
-		return nil, nil // Not found
+		return nil, fmt.Errorf("%w: %s", ErrNotFound, workflowName)
 	}
 	if err != nil {
 		r.logger.Error(err, "failed to get latest workflow version",

--- a/pkg/datastorage/repository/workflow/discovery.go
+++ b/pkg/datastorage/repository/workflow/discovery.go
@@ -253,7 +253,9 @@ func (r *Repository) selectScoredWorkflows(ctx context.Context, whereClause stri
 
 // GetWorkflowWithContextFilters retrieves a workflow by ID with an additional
 // security gate that verifies the workflow matches the provided context filters.
-// Returns nil if the workflow exists but doesn't match the context (security gate).
+// Returns ErrNotFound if the workflow doesn't exist OR exists but doesn't match
+// the context (security gate) — DD-WORKFLOW-016: the two cases are
+// deliberately not distinguished to prevent information leakage.
 // This is Step 3 of the discovery protocol.
 func (r *Repository) GetWorkflowWithContextFilters(ctx context.Context, workflowID string, filters *models.WorkflowDiscoveryFilters) (*models.RemediationWorkflow, error) {
 	// If no context filters, fall back to simple GetByID
@@ -281,12 +283,7 @@ func (r *Repository) GetWorkflowWithContextFilters(ctx context.Context, workflow
 	var wf models.RemediationWorkflow
 	err := r.db.GetContext(ctx, &wf, query, args...)
 	if errors.Is(err, sql.ErrNoRows) {
-		// nolint:nilnil // intentional "not found" sentinel, not an error —
-		// security gate: workflow exists but doesn't match context, or doesn't
-		// exist. We intentionally don't distinguish these cases (DD-WORKFLOW-016:
-		// prevent info leakage). Caller already guards with `if x != nil`
-		// (Issue #1546 Tier 2).
-		return nil, nil
+		return nil, fmt.Errorf("%w: %s", ErrNotFound, workflowID)
 	}
 	if err != nil {
 		r.logger.Error(err, "failed to get workflow with context filters",

--- a/pkg/datastorage/select_narrowing_workflow_test.go
+++ b/pkg/datastorage/select_narrowing_workflow_test.go
@@ -19,6 +19,7 @@ package datastorage_test
 import (
 	"context"
 	"database/sql"
+	"errors"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/jmoiron/sqlx"
@@ -110,7 +111,8 @@ var _ = Describe("Phase 6: SELECT * Narrowing — Workflow Repository (TP-1088-P
 				WillReturnRows(emptyWorkflowRows())
 
 			_, err := repo.GetByID(ctx, "test-uuid")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, workflowrepo.ErrNotFound)).To(BeTrue(),
+				"Issue #1674: an empty result set is expected not-found, not a real error")
 		})
 	})
 
@@ -121,7 +123,8 @@ var _ = Describe("Phase 6: SELECT * Narrowing — Workflow Repository (TP-1088-P
 				WillReturnRows(emptyWorkflowRows())
 
 			_, err := repo.GetByNameAndVersion(ctx, "pod-restart", "v1.0.0")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, workflowrepo.ErrNotFound)).To(BeTrue(),
+				"Issue #1674: an empty result set is expected not-found, not a real error")
 		})
 	})
 
@@ -132,7 +135,8 @@ var _ = Describe("Phase 6: SELECT * Narrowing — Workflow Repository (TP-1088-P
 				WillReturnRows(emptyWorkflowRows())
 
 			_, err := repo.GetActiveByNameAndVersion(ctx, "pod-restart", "v1.0.0")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, workflowrepo.ErrNotFound)).To(BeTrue(),
+				"Issue #1674: an empty result set is expected not-found, not a real error")
 		})
 	})
 
@@ -143,7 +147,8 @@ var _ = Describe("Phase 6: SELECT * Narrowing — Workflow Repository (TP-1088-P
 				WillReturnRows(emptyWorkflowRows())
 
 			_, err := repo.GetLatestDisabledByNameAndVersion(ctx, "pod-restart", "v1.0.0")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, workflowrepo.ErrNotFound)).To(BeTrue(),
+				"Issue #1674: an empty result set is expected not-found, not a real error")
 		})
 	})
 
@@ -154,7 +159,8 @@ var _ = Describe("Phase 6: SELECT * Narrowing — Workflow Repository (TP-1088-P
 				WillReturnRows(emptyWorkflowRows())
 
 			_, err := repo.GetActiveByWorkflowName(ctx, "pod-restart")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, workflowrepo.ErrNotFound)).To(BeTrue(),
+				"Issue #1674: an empty result set is expected not-found, not a real error")
 		})
 	})
 
@@ -165,7 +171,8 @@ var _ = Describe("Phase 6: SELECT * Narrowing — Workflow Repository (TP-1088-P
 				WillReturnRows(emptyWorkflowRows())
 
 			_, err := repo.GetLatestVersion(ctx, "pod-restart")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, workflowrepo.ErrNotFound)).To(BeTrue(),
+				"Issue #1674: an empty result set is expected not-found, not a real error")
 		})
 	})
 
@@ -215,7 +222,8 @@ var _ = Describe("Phase 6: SELECT * Narrowing — Workflow Repository (TP-1088-P
 				WillReturnRows(emptyWorkflowRows())
 
 			_, err := repo.GetWorkflowWithContextFilters(ctx, "test-uuid", nil)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, workflowrepo.ErrNotFound)).To(BeTrue(),
+				"Issue #1674: an empty result set is expected not-found, not a real error")
 		})
 	})
 })

--- a/pkg/datastorage/server/workflow_duplicate_handlers.go
+++ b/pkg/datastorage/server/workflow_duplicate_handlers.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/models"
+	workflowrepo "github.com/jordigilh/kubernaut/pkg/datastorage/repository/workflow"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/schema"
 	deterministicuuid "github.com/jordigilh/kubernaut/pkg/datastorage/uuid"
 )
@@ -68,8 +69,12 @@ func (h *Handler) handleDuplicateWorkflow(ctx context.Context, workflow *models.
 	// re-registering the same CRD content after a PVC wipe recovers the original ID.
 	workflow.WorkflowID = deterministicuuid.DeterministicUUID(incomingHash)
 
+	// Issue #1674: the repo methods below return workflowrepo.ErrNotFound
+	// (not (nil, nil)) when no row matches; that's the expected outcome on
+	// this decision tree's "none" path, not a failure, so it must not be
+	// wrapped and propagated as a real error.
 	active, err := repo.GetActiveByNameAndVersion(ctx, workflow.WorkflowName, workflow.Version)
-	if err != nil {
+	if err != nil && !errors.Is(err, workflowrepo.ErrNotFound) {
 		return nil, fmt.Errorf("lookup active workflow: %w", err)
 	}
 	if active != nil {
@@ -77,7 +82,7 @@ func (h *Handler) handleDuplicateWorkflow(ctx context.Context, workflow *models.
 	}
 
 	disabled, err := repo.GetLatestDisabledByNameAndVersion(ctx, workflow.WorkflowName, workflow.Version)
-	if err != nil {
+	if err != nil && !errors.Is(err, workflowrepo.ErrNotFound) {
 		return nil, fmt.Errorf("lookup disabled workflow: %w", err)
 	}
 	if disabled != nil {
@@ -89,7 +94,7 @@ func (h *Handler) handleDuplicateWorkflow(ctx context.Context, workflow *models.
 	// version upgrade and the old entry must be superseded to enforce single-active
 	// per (workflow_name, action_type).
 	activeAnyVersion, err := repo.GetActiveByWorkflowName(ctx, workflow.WorkflowName)
-	if err != nil {
+	if err != nil && !errors.Is(err, workflowrepo.ErrNotFound) {
 		return nil, fmt.Errorf("lookup active workflow by name: %w", err)
 	}
 	if activeAnyVersion != nil {
@@ -205,7 +210,7 @@ func (h *Handler) retryOnUniqueViolation(ctx context.Context, createErr error, w
 	)
 
 	active, err := h.workflowIntegrityRepo.GetActiveByNameAndVersion(ctx, workflow.WorkflowName, workflow.Version)
-	if err != nil {
+	if err != nil && !errors.Is(err, workflowrepo.ErrNotFound) {
 		h.logger.Error(err, "Retry lookup failed after 23505",
 			"workflow_name", workflow.WorkflowName, "version", workflow.Version)
 		return nil, false
@@ -242,7 +247,7 @@ func (h *Handler) tryReEnableWorkflow(ctx context.Context, workflow *models.Reme
 	}
 
 	existing, err := h.workflowRepo.GetByNameAndVersion(ctx, workflow.WorkflowName, workflow.Version)
-	if err != nil {
+	if err != nil && !errors.Is(err, workflowrepo.ErrNotFound) {
 		return nil, fmt.Errorf("lookup existing workflow: %w", err)
 	}
 	if existing == nil {

--- a/pkg/datastorage/server/workflow_query_handlers.go
+++ b/pkg/datastorage/server/workflow_query_handlers.go
@@ -18,6 +18,7 @@ package server
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strconv"
@@ -28,6 +29,7 @@ import (
 	dsaudit "github.com/jordigilh/kubernaut/pkg/datastorage/audit"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/models"
 	api "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+	workflowrepo "github.com/jordigilh/kubernaut/pkg/datastorage/repository/workflow"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/server/response"
 )
 
@@ -225,6 +227,14 @@ func (h *Handler) HandleGetWorkflowByID(w http.ResponseWriter, r *http.Request) 
 // On any failure it writes the response itself and returns ok=false.
 // Extracted from HandleGetWorkflowByID (Wave 6 6f GREEN: funlen
 // remediation) — pure code motion, no behavior change.
+//
+// Issue #1674: previously checked err.Error() against a hand-built "workflow
+// not found: <id>" string that GetByID/GetWorkflowWithContextFilters never
+// actually produced (they returned (nil, nil) instead) — that branch was
+// dead code, and the real "not found" signal was the nil wf == nil check
+// below. Now that both repo methods return workflowrepo.ErrNotFound, we
+// check the sentinel directly via errors.Is, and the wf == nil check is no
+// longer reachable when err == nil.
 func (h *Handler) fetchWorkflowByIDWithGate(w http.ResponseWriter, r *http.Request, workflowID string, filters *models.WorkflowDiscoveryFilters) (*models.RemediationWorkflow, int64, bool) {
 	// DD-WORKFLOW-016: Use context-filtered query when filters are present (security gate)
 	// GAP-WF-6: Measure query duration for audit payload (DD-WORKFLOW-014 v3.0)
@@ -239,8 +249,14 @@ func (h *Handler) fetchWorkflowByIDWithGate(w http.ResponseWriter, r *http.Reque
 	durationMs := time.Since(startGet).Milliseconds()
 
 	if err != nil {
-		// Check if workflow not found
-		if err.Error() == fmt.Sprintf("workflow not found: %s", workflowID) {
+		// DD-WORKFLOW-016: Return the same 404 for "not found" and "filtered
+		// out by security gate" (prevent info leakage about which case
+		// occurred).
+		if errors.Is(err, workflowrepo.ErrNotFound) {
+			h.logger.Info("Workflow not found or filtered by security gate",
+				"workflow_id", workflowID,
+				"has_context_filters", filters.HasContextFilters(),
+			)
 			response.WriteRFC7807Error(w, http.StatusNotFound, "workflow-not-found", "Not Found",
 				fmt.Sprintf("Workflow not found: %s", workflowID), h.logger)
 			return nil, 0, false
@@ -251,18 +267,6 @@ func (h *Handler) fetchWorkflowByIDWithGate(w http.ResponseWriter, r *http.Reque
 		)
 		response.WriteRFC7807Error(w, http.StatusInternalServerError, "internal-error", "Internal Server Error",
 			"Failed to get workflow", h.logger)
-		return nil, 0, false
-	}
-
-	// Check for nil workflow (not found or security gate filtered out)
-	if wf == nil {
-		h.logger.Info("Workflow not found or filtered by security gate",
-			"workflow_id", workflowID,
-			"has_context_filters", filters.HasContextFilters(),
-		)
-		// DD-WORKFLOW-016: Return same 404 for "not found" and "filtered out" (prevent info leakage)
-		response.WriteRFC7807Error(w, http.StatusNotFound, "workflow-not-found", "Not Found",
-			fmt.Sprintf("Workflow not found: %s", workflowID), h.logger)
 		return nil, 0, false
 	}
 

--- a/pkg/datastorage/server/workflow_update_lifecycle_handlers.go
+++ b/pkg/datastorage/server/workflow_update_lifecycle_handlers.go
@@ -19,6 +19,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -28,6 +29,7 @@ import (
 	dsaudit "github.com/jordigilh/kubernaut/pkg/datastorage/audit"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/models"
 	api "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+	workflowrepo "github.com/jordigilh/kubernaut/pkg/datastorage/repository/workflow"
 	dsmiddleware "github.com/jordigilh/kubernaut/pkg/datastorage/server/middleware"
 	"github.com/jordigilh/kubernaut/pkg/datastorage/server/response"
 )
@@ -62,11 +64,26 @@ func (h *Handler) HandleUpdateWorkflow(w http.ResponseWriter, r *http.Request) {
 
 	workflow, err := h.workflowRepo.GetByID(r.Context(), workflowID)
 	if err != nil {
+		// Issue #1674: previously this branch always returned 404 for ANY
+		// error, including real DB failures — masking outages as "not
+		// found" and, worse, GetByID's old (nil, nil) "not found" contract
+		// meant err was nil here, so this guard never even fired for the
+		// not-found case: workflow stayed nil and reached
+		// applyMutableWorkflowUpdate below, dereferencing workflow.Status
+		// on a nil pointer whenever the request set "status" (panic,
+		// recovered as an HTTP 500). Now that GetByID returns
+		// workflowrepo.ErrNotFound, the two cases are distinguished
+		// correctly.
+		if errors.Is(err, workflowrepo.ErrNotFound) {
+			response.WriteRFC7807Error(w, http.StatusNotFound, "not-found", "Not Found",
+				fmt.Sprintf("Workflow not found: %s", workflowID), h.logger)
+			return
+		}
 		h.logger.Error(err, "Failed to get workflow for update",
 			"workflow_id", workflowID,
 		)
-		response.WriteRFC7807Error(w, http.StatusNotFound, "not-found", "Not Found",
-			fmt.Sprintf("Workflow not found: %s", workflowID), h.logger)
+		response.WriteRFC7807Error(w, http.StatusInternalServerError, "internal-error", "Internal Server Error",
+			"Failed to get workflow", h.logger)
 		return
 	}
 
@@ -286,13 +303,21 @@ func (h *Handler) getWorkflowForLifecycleTransition(w http.ResponseWriter, r *ht
 
 	workflow, err := repo.GetByID(r.Context(), workflowID)
 	if err != nil {
+		if errors.Is(err, workflowrepo.ErrNotFound) {
+			response.WriteRFC7807Error(w, http.StatusNotFound, "not-found", "Not Found",
+				fmt.Sprintf("Workflow not found: %s", workflowID), h.logger)
+			return nil, nil, false
+		}
 		h.logger.Error(err, fmt.Sprintf("Failed to get workflow for %s", opName),
 			"workflow_id", workflowID,
 		)
-		response.WriteRFC7807Error(w, http.StatusNotFound, "not-found", "Not Found",
-			fmt.Sprintf("Workflow not found: %s", workflowID), h.logger)
+		response.WriteRFC7807Error(w, http.StatusInternalServerError, "internal-error", "Internal Server Error",
+			"Failed to get workflow", h.logger)
 		return nil, nil, false
 	}
+	// Defensive: repo is the WorkflowLifecycleRepository interface, and test
+	// doubles (see workflow_lifecycle_handler_test.go) may still return
+	// (nil, nil) directly rather than the workflowrepo.ErrNotFound sentinel.
 	if workflow == nil {
 		response.WriteRFC7807Error(w, http.StatusNotFound, "not-found", "Not Found",
 			fmt.Sprintf("Workflow not found: %s", workflowID), h.logger)

--- a/pkg/datastorage/workflow_content_integrity_test.go
+++ b/pkg/datastorage/workflow_content_integrity_test.go
@@ -53,6 +53,7 @@ type mockWorkflowIntegrityRepo struct {
 	createdWorkflows     []*models.RemediationWorkflow
 	updateStatusCalls    []statusUpdateCall
 	createErr            error
+	getActiveErr         error // Issue #1674: simulates a real DB error from GetActiveByNameAndVersion
 }
 
 type statusUpdateCall struct {
@@ -63,6 +64,9 @@ type statusUpdateCall struct {
 }
 
 func (m *mockWorkflowIntegrityRepo) GetActiveByNameAndVersion(_ context.Context, _, _ string) (*models.RemediationWorkflow, error) {
+	if m.getActiveErr != nil {
+		return nil, m.getActiveErr
+	}
 	return m.activeWorkflow, nil
 }
 
@@ -536,6 +540,30 @@ var _ = Describe("Workflow Content Integrity (BR-WORKFLOW-006)", func() {
 			Expect(json.Unmarshal(rr.Body.Bytes(), &resp)).To(Succeed())
 			Expect(resp["workflowId"]).To(Equal(existingUUID),
 				"Response should return the existing UUID")
+		})
+	})
+
+	// ========================================
+	// UT-DS-1674-009: A real DB error from the lookup must still surface as
+	// a failure, not be swallowed by the workflow.ErrNotFound guard added to
+	// handleDuplicateWorkflow (Issue #1674).
+	// ========================================
+	Describe("UT-DS-1674-009: Real database error during duplicate lookup is not mistaken for not-found", func() {
+		It("should return 500 Internal Server Error, not proceed as if no active workflow existed", func() {
+			mockRepo := &mockWorkflowIntegrityRepo{
+				getActiveErr: fmt.Errorf("connection refused"),
+			}
+
+			handler := newIntegrityHandler(mockRepo)
+			req := makeInlineRequest(integrityBaseYAML)
+			rr := httptest.NewRecorder()
+
+			handler.HandleCreateWorkflow(rr, req)
+
+			Expect(rr.Code).To(Equal(http.StatusInternalServerError),
+				"Issue #1674: a real DB error must not be conflated with workflow.ErrNotFound and treated as 'no active workflow'")
+			Expect(mockRepo.createdWorkflows).To(BeEmpty(),
+				"No workflow should be created when the duplicate-check lookup itself fails")
 		})
 	})
 })

--- a/pkg/datastorage/workflow_crud_business_test.go
+++ b/pkg/datastorage/workflow_crud_business_test.go
@@ -65,17 +65,18 @@ var _ = Describe("Workflow CRUD business-level gap closure (Wave 6 6f)", func() 
 	})
 
 	Describe("GetByID", func() {
-		It("UT-DS-6f-001: returns (nil, nil) — not an error — when no workflow matches the ID", func() {
-			// BR-STORAGE-012: callers (server/workflow_query_handlers.go) distinguish
-			// "not found" (nil, nil -> HTTP 404) from a real DB failure (non-nil error
-			// -> HTTP 500). Conflating the two would either mask outages as 404s or
-			// leak DB errors as "not found".
+		It("UT-DS-6f-001: returns workflow.ErrNotFound — not (nil, nil) — when no workflow matches the ID", func() {
+			// Issue #1674: callers (server/workflow_query_handlers.go) distinguish
+			// "not found" (workflow.ErrNotFound -> HTTP 404) from a real DB failure
+			// (a different non-nil error -> HTTP 500) by checking errors.Is against
+			// the sentinel, rather than nil-checking the result. Conflating the two
+			// would either mask outages as 404s or leak DB errors as "not found".
 			sqlMock.ExpectQuery(`SELECT .* FROM remediation_workflow_catalog WHERE workflow_id = \$1`).
 				WillReturnError(sql.ErrNoRows)
 
 			wf, err := repo.GetByID(ctx, "00000000-0000-0000-0000-000000000000")
 
-			Expect(err).ToNot(HaveOccurred(), "BR-STORAGE-012: not-found must not surface as an error")
+			Expect(errors.Is(err, workflow.ErrNotFound)).To(BeTrue(), "Issue #1674: not-found must be workflow.ErrNotFound")
 			Expect(wf).To(BeNil())
 		})
 

--- a/pkg/datastorage/workflow_notfound_vs_error_handler_test.go
+++ b/pkg/datastorage/workflow_notfound_vs_error_handler_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package datastorage_test
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	"github.com/go-chi/chi/v5"
+	"github.com/jmoiron/sqlx"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kubelog "github.com/jordigilh/kubernaut/pkg/log"
+
+	"github.com/jordigilh/kubernaut/pkg/datastorage/repository"
+	"github.com/jordigilh/kubernaut/pkg/datastorage/server"
+)
+
+// ========================================
+// ISSUE #1674: NOT-FOUND VS REAL-ERROR DISTINCTION
+// ========================================
+// Characterization + regression tests for the two real bugs found while
+// refactoring workflowRepo.GetByID's (nil, nil) "not found" contract to the
+// workflow.ErrNotFound sentinel:
+//
+//  1. HandleUpdateWorkflow (workflow_update_lifecycle_handlers.go): with the
+//     old (nil, nil) contract, `err != nil` never caught the not-found case,
+//     so a nil *models.RemediationWorkflow reached applyMutableWorkflowUpdate
+//     and dereferenced workflow.Status — a nil-pointer panic (recovered as
+//     an HTTP 500) whenever the PATCH body set "status". Now GetByID returns
+//     workflow.ErrNotFound, which is checked before use.
+//  2. fetchWorkflowByIDWithGate (workflow_query_handlers.go): compared
+//     err.Error() against a hand-built "workflow not found: <id>" string
+//     that GetByID/GetWorkflowWithContextFilters never actually produced —
+//     dead code. The real "not found" signal was the `wf == nil` check.
+//     Both handlers also previously collapsed ANY GetByID error (including
+//     real DB outages) into a 404, masking failures. Both are fixed by
+//     checking errors.Is(err, workflow.ErrNotFound) and reserving 500 for
+//     everything else.
+//
+// These tests use a real *repository.WorkflowRepository backed by sqlmock
+// (rather than the interface test doubles in workflow_lifecycle_handler_test.go)
+// because HandleUpdateWorkflow and HandleGetWorkflowByID call through
+// h.workflowRepo, which is concretely typed as *repository.WorkflowRepository.
+// ========================================
+
+var _ = Describe("Issue #1674: workflow not-found vs real-error distinction", func() {
+	var (
+		mockDB  *sql.DB
+		sqlMock sqlmock.Sqlmock
+		repo    *repository.WorkflowRepository
+	)
+
+	BeforeEach(func() {
+		var err error
+		mockDB, sqlMock, err = sqlmock.New(sqlmock.QueryMatcherOption(sqlmock.QueryMatcherRegexp))
+		Expect(err).ToNot(HaveOccurred())
+
+		logger := kubelog.NewLogger(kubelog.DevelopmentOptions())
+		sqlxDB := sqlx.NewDb(mockDB, "sqlmock")
+		repo = repository.NewWorkflowRepository(sqlxDB, logger)
+	})
+
+	AfterEach(func() {
+		Expect(sqlMock.ExpectationsWereMet()).To(Succeed())
+		_ = mockDB.Close()
+	})
+
+	getByIDQuery := `SELECT .* FROM remediation_workflow_catalog WHERE workflow_id = \$1`
+
+	Describe("PATCH /api/v1/workflows/{workflowID} (HandleUpdateWorkflow)", func() {
+		It("UT-DS-1674-005: returns 404, not a nil-deref panic, when the workflow is not found and the request sets status", func() {
+			sqlMock.ExpectQuery(getByIDQuery).WillReturnError(sql.ErrNoRows)
+
+			handler := server.NewHandler(server.WithWorkflowRepository(repo))
+			req := reqWithWorkflowID("", `{"status": "Disabled", "disabledReason": "test"}`)
+			rr := httptest.NewRecorder()
+
+			Expect(func() { handler.HandleUpdateWorkflow(rr, req) }).ToNot(Panic(),
+				"Issue #1674: previously a nil workflow reached applyMutableWorkflowUpdate and panicked on workflow.Status")
+			Expect(rr.Code).To(Equal(http.StatusNotFound))
+		})
+
+		It("UT-DS-1674-006: returns 500, not a misleading 404, when GetByID fails with a real database error", func() {
+			sqlMock.ExpectQuery(getByIDQuery).WillReturnError(errors.New("connection refused"))
+
+			handler := server.NewHandler(server.WithWorkflowRepository(repo))
+			req := reqWithWorkflowID("", `{"status": "Disabled", "disabledReason": "test"}`)
+			rr := httptest.NewRecorder()
+
+			handler.HandleUpdateWorkflow(rr, req)
+
+			Expect(rr.Code).To(Equal(http.StatusInternalServerError),
+				"Issue #1674: a real DB error must not be reported as 404 Not Found")
+		})
+	})
+
+	Describe("GET /api/v1/workflows/{workflowID} (HandleGetWorkflowByID)", func() {
+		getRequest := func() *http.Request {
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/workflows/"+testWorkflowID, nil)
+			rctx := chi.NewRouteContext()
+			rctx.URLParams.Add("workflowID", testWorkflowID)
+			return req.WithContext(context.WithValue(req.Context(), chi.RouteCtxKey, rctx))
+		}
+
+		It("UT-DS-1674-007: returns 404 when the workflow does not exist (dead-code string check removed)", func() {
+			sqlMock.ExpectQuery(getByIDQuery).WillReturnError(sql.ErrNoRows)
+
+			handler := server.NewHandler(server.WithWorkflowRepository(repo))
+			rr := httptest.NewRecorder()
+
+			handler.HandleGetWorkflowByID(rr, getRequest())
+
+			Expect(rr.Code).To(Equal(http.StatusNotFound))
+		})
+
+		It("UT-DS-1674-008: returns 500, not a misleading 404, when GetByID fails with a real database error", func() {
+			sqlMock.ExpectQuery(getByIDQuery).WillReturnError(errors.New("connection refused"))
+
+			handler := server.NewHandler(server.WithWorkflowRepository(repo))
+			rr := httptest.NewRecorder()
+
+			handler.HandleGetWorkflowByID(rr, getRequest())
+
+			Expect(rr.Code).To(Equal(http.StatusInternalServerError),
+				"Issue #1674: a real DB error must not be reported as 404 Not Found")
+		})
+	})
+})

--- a/pkg/gateway/adapters/owner_resolver.go
+++ b/pkg/gateway/adapters/owner_resolver.go
@@ -18,6 +18,7 @@ package adapters
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"time"
@@ -30,6 +31,13 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
+
+// errNoControllerOwner is returned by verifyOwnerViaFallback when the direct
+// API confirms a resource genuinely has no controller owner (as opposed to
+// (nil, nil), which is ambiguous with "an error occurred but was swallowed").
+// Issue #1674. Unexported: consumed only by resolveMissingControllerRef in
+// this file.
+var errNoControllerOwner = errors.New("no controller owner reference found via direct API")
 
 // MaxOwnerChainDepth limits traversal to prevent infinite loops (circular refs).
 // Same constant as pkg/signalprocessing/ownerchain/builder.go:MaxOwnerChainDepth.
@@ -329,7 +337,7 @@ func (r *K8sOwnerResolver) resolveMissingControllerRef(
 	// #284: Trust-but-verify with direct API when the informer cache returns
 	// stale metadata without ownerReferences (race during rollout restarts).
 	verifiedRef, verifyErr := r.verifyOwnerViaFallback(ctx, gvk, key, currentKind, currentName, level)
-	if verifyErr != nil {
+	if verifyErr != nil && !errors.Is(verifyErr, errNoControllerOwner) {
 		return ownerStepResult{err: verifyErr}
 	}
 	if verifiedRef != nil {
@@ -379,10 +387,12 @@ func findControllerOwnerRef(refs []metav1.OwnerReference) *metav1.OwnerReference
 // its ownerReferences before eviction.
 //
 // Returns (ref, nil) when a controller owner was found via the direct API
-// (caller should continue traversal from ref), (nil, nil) when the direct API
-// confirms no controller owner (caller should stop, resource is standalone),
-// or (nil, err) when the resource could not be found via the direct API at
-// all (likely deleted — caller should propagate the error).
+// (caller should continue traversal from ref), (nil, errNoControllerOwner)
+// when the direct API confirms no controller owner (caller should stop,
+// resource is standalone), or (nil, err) for any other err when the resource
+// could not be found via the direct API at all (likely deleted — caller
+// should propagate the error). Callers distinguish the two error cases with
+// errors.Is(err, errNoControllerOwner).
 func (r *K8sOwnerResolver) verifyOwnerViaFallback(
 	ctx context.Context,
 	gvk schema.GroupVersionKind,
@@ -420,15 +430,9 @@ func (r *K8sOwnerResolver) verifyOwnerViaFallback(
 
 	logger.V(1).Info("Verified standalone resource via direct API (no controller owner)",
 		"kind", currentKind, "name", currentName, "level", level)
-	// nolint:nilnil // intentional "confirmed standalone" sentinel, not an error;
-	// the single caller (resolveOwnerStep) already checks verifyErr != nil before
-	// checking verifiedRef != nil, so no ambiguity risk exists today. NOTE: this
-	// #284 trust-but-verify fallback path currently has zero test coverage — a
-	// sentinel-error refactor (recommended by this linter) would be a better
-	// long-term fix, but doing so without first adding characterization tests
-	// would violate the coverage-before-refactor mandate; tracked as a follow-up
-	// rather than folded into Issue #1546 Tier 2's lint-gate scope.
-	return nil, nil
+	// Issue #1674: errNoControllerOwner sentinel replaces the ambiguous
+	// (nil, nil) "confirmed standalone" return.
+	return nil, errNoControllerOwner
 }
 
 // resolveServiceToWorkload traverses Service → spec.selector → Pods to find a

--- a/pkg/remediationorchestrator/locking/owner_ref_test.go
+++ b/pkg/remediationorchestrator/locking/owner_ref_test.go
@@ -18,6 +18,7 @@ package locking_test
 
 import (
 	"context"
+	"errors"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -118,7 +119,7 @@ var _ = Describe("CheckResourceBusy Owner-Ref Self-Detection (BR-ORCH-050)", fun
 
 			// CheckResourceBusy should skip because the WFE belongs to the same RR
 			blocked, err := engine.CheckResourceBusy(ctx, rr, targetResource)
-			Expect(err).NotTo(HaveOccurred())
+			Expect(errors.Is(err, routing.ErrNotBlocked)).To(BeTrue())
 			Expect(blocked).To(BeNil(), "should not be blocked by own WFE (owner UID match)")
 		})
 	})

--- a/pkg/remediationorchestrator/routing/blocking.go
+++ b/pkg/remediationorchestrator/routing/blocking.go
@@ -18,6 +18,7 @@ package routing
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sort"
 	"strings"
@@ -33,6 +34,20 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
+
+// ErrNotBlocked is returned by the Check* family below when no blocking
+// condition applies. Issue #1674: replaces the ambiguous (nil, nil) return
+// that forced callers to distinguish "not blocked" from "a real check
+// failure" by nil-checking the *BlockingCondition result instead of
+// checking err. Callers should use errors.Is(err, ErrNotBlocked).
+var ErrNotBlocked = errors.New("no blocking condition found")
+
+// ErrNoMatch is returned by the Find* family below when no matching
+// RemediationRequest or WorkflowExecution exists. Issue #1674: same
+// rationale as ErrNotBlocked. The Check* functions that call into the
+// Find* family below translate ErrNoMatch into their own ErrNotBlocked
+// contract (e.g. CheckDuplicateInProgress calling FindActiveRRForFingerprint).
+var ErrNoMatch = errors.New("no matching resource found")
 
 // BlockingConditionChecker defines the routing-decision checks that determine
 // whether a RemediationRequest should be blocked. Split out from Engine for
@@ -242,7 +257,7 @@ func (r *RoutingEngine) CheckPreAnalysisConditions(
 	}
 
 	blocked, err := r.CheckDuplicateInProgress(ctx, rr)
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrNotBlocked) {
 		return nil, fmt.Errorf("failed to check duplicate: %w", err)
 	}
 	if blocked != nil {
@@ -253,12 +268,12 @@ func (r *RoutingEngine) CheckPreAnalysisConditions(
 		return blocked, nil
 	}
 
-	// nolint:nilnil // intentional "not blocked" sentinel, not an error: nil
-	// *BlockingCondition + nil error unambiguously means every check passed.
-	// All callers already guard with `if blocked != nil` before use (see
-	// reconcile_loop.go), matching the Check*/Find* helper idiom used
-	// throughout this file (Issue #1546 Tier 2).
-	return nil, nil
+	// Issue #1674: every check passed -- ErrNotBlocked unambiguously means
+	// "no blocking condition found" (see doc comment above). All callers
+	// already guard with `if blocked != nil` before use (see
+	// reconcile_loop.go), and now use errors.Is(err, ErrNotBlocked) instead
+	// of a bare nil check on err.
+	return nil, ErrNotBlocked
 }
 
 // CheckPostAnalysisConditions checks all blocking conditions after AIAnalysis
@@ -301,7 +316,7 @@ func (r *RoutingEngine) CheckPostAnalysisConditions(
 	}
 
 	blocked, err := r.CheckDuplicateInProgress(ctx, rr)
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrNotBlocked) {
 		return nil, fmt.Errorf("failed to check duplicate: %w", err)
 	}
 	if blocked != nil {
@@ -309,7 +324,7 @@ func (r *RoutingEngine) CheckPostAnalysisConditions(
 	}
 
 	blocked, err = r.CheckResourceBusy(ctx, rr, targetResource)
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrNotBlocked) {
 		return nil, fmt.Errorf("failed to check resource lock: %w", err)
 	}
 	if blocked != nil {
@@ -317,7 +332,7 @@ func (r *RoutingEngine) CheckPostAnalysisConditions(
 	}
 
 	blocked, err = r.CheckRecentlyRemediated(ctx, rr, workflowID, targetResource)
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrNotBlocked) {
 		return nil, fmt.Errorf("failed to check recent remediation: %w", err)
 	}
 	if blocked != nil {
@@ -336,8 +351,8 @@ func (r *RoutingEngine) CheckPostAnalysisConditions(
 		}
 	}
 
-	// nolint:nilnil // same "not blocked" sentinel as CheckPreAnalysisConditions above.
-	return nil, nil
+	// Issue #1674: same ErrNotBlocked sentinel as CheckPreAnalysisConditions above.
+	return nil, ErrNotBlocked
 }
 
 // parseTargetResource parses a "namespace/kind/name" or "kind/name" string into TargetResource.
@@ -501,16 +516,16 @@ func (r *RoutingEngine) CheckDuplicateInProgress(
 	// Find active RR with same fingerprint (excluding self)
 	// ADR-057 (#222): Pass TargetResource.Namespace for multi-tenant isolation
 	originalRR, err := r.FindActiveRRForFingerprint(ctx, rr.Namespace, rr.Spec.SignalFingerprint, rr.Name, rr.Spec.TargetResource.Namespace)
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrNoMatch) {
 		return nil, fmt.Errorf("failed to check for duplicate: %w", err)
 	}
 
-	// nolint:nilnil // intentional "not blocked" sentinel (not a duplicate / not
-	// the original), not an error — same file-wide idiom as
-	// CheckPreAnalysisConditions above. Caller (CheckPreAnalysisConditions /
-	// CheckPostAnalysisConditions) already guards with `if blocked != nil`.
-	if originalRR == nil {
-		return nil, nil // Not a duplicate
+	// Issue #1674: ErrNoMatch here means "not a duplicate" for this check's
+	// own contract, so it is translated to ErrNotBlocked. Caller
+	// (CheckPreAnalysisConditions / CheckPostAnalysisConditions) already
+	// guards with `if blocked != nil` before checking err.
+	if errors.Is(err, ErrNoMatch) {
+		return nil, ErrNotBlocked // Not a duplicate
 	}
 
 	// #209: Deterministic tiebreaker — the oldest RR is always the original.
@@ -518,11 +533,11 @@ func (r *RoutingEngine) CheckDuplicateInProgress(
 	// This prevents circular deadlocks (A blocks B, B blocks A).
 	if !rr.CreationTimestamp.IsZero() && !originalRR.CreationTimestamp.IsZero() {
 		if originalRR.CreationTimestamp.After(rr.CreationTimestamp.Time) {
-			return nil, nil // nolint:nilnil // We are older → we are the original
+			return nil, ErrNotBlocked // We are older → we are the original
 		}
 		// Same timestamp: use name as secondary tiebreaker (lexicographic)
 		if originalRR.CreationTimestamp.Time.Equal(rr.CreationTimestamp.Time) && originalRR.Name > rr.Name {
-			return nil, nil // nolint:nilnil // Same time, we sort first → we are the original
+			return nil, ErrNotBlocked // Same time, we sort first → we are the original
 		}
 	}
 
@@ -556,14 +571,13 @@ func (r *RoutingEngine) CheckResourceBusy(
 
 	// Find active WFE for the same target resource
 	activeWFE, err := r.FindActiveWFEForTarget(ctx, targetResourceStr)
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrNoMatch) {
 		return nil, fmt.Errorf("failed to check resource lock: %w", err)
 	}
 
-	// nolint:nilnil // intentional "not blocked" sentinel, not an error — same
-	// file-wide idiom as CheckPreAnalysisConditions above.
-	if activeWFE == nil {
-		return nil, nil // Resource not busy
+	// Issue #1674: ErrNoMatch translated to this check's own ErrNotBlocked contract.
+	if errors.Is(err, ErrNoMatch) {
+		return nil, ErrNotBlocked // Resource not busy
 	}
 
 	// BR-ORCH-050: Skip WFE owned by the requesting RR (self-detection).
@@ -571,7 +585,7 @@ func (r *RoutingEngine) CheckResourceBusy(
 	// should not block itself.
 	for _, ownerRef := range activeWFE.GetOwnerReferences() {
 		if ownerRef.UID == rr.UID {
-			return nil, nil // nolint:nilnil // Our own WFE, not a conflict
+			return nil, ErrNotBlocked // Our own WFE, not a conflict
 		}
 	}
 
@@ -617,14 +631,13 @@ func (r *RoutingEngine) CheckRecentlyRemediated(
 		workflowID, // Pass workflow ID for workflow-specific matching
 		r.config.RecentlyRemediatedCooldown,
 	)
-	if err != nil {
+	if err != nil && !errors.Is(err, ErrNoMatch) {
 		return nil, fmt.Errorf("failed to check recent remediation: %w", err)
 	}
 
-	// nolint:nilnil // intentional "not blocked" sentinel, not an error — same
-	// file-wide idiom as CheckPreAnalysisConditions above.
-	if recentWFE == nil {
-		return nil, nil // No recent remediation
+	// Issue #1674: ErrNoMatch translated to this check's own ErrNotBlocked contract.
+	if errors.Is(err, ErrNoMatch) {
+		return nil, ErrNotBlocked // No recent remediation
 	}
 
 	// Calculate remaining cooldown
@@ -866,7 +879,7 @@ func (r *RoutingEngine) CalculateExponentialBackoff(consecutiveFailures int32) t
 }
 
 // FindActiveRRForFingerprint finds an active (non-terminal) RR with the given fingerprint.
-// Returns the first active RR found, or nil if none exist.
+// Returns the first active RR found, or ErrNoMatch if none exist.
 // Excludes the RR with excludeName (to avoid self-matching).
 //
 // Uses field index on spec.signalFingerprint for O(1) lookup (configured in Day 1).
@@ -925,14 +938,14 @@ func (r *RoutingEngine) FindActiveRRForFingerprint(
 		}
 	}
 
-	// nolint:nilnil // intentional "not found" sentinel, not an error — the
-	// canonical Find* idiom (mirrors client.IgnoreNotFound patterns); callers
-	// already guard with `if x != nil` before use (Issue #1546 Tier 2).
-	return nil, nil // No active duplicate found
+	// Issue #1674: ErrNoMatch is the canonical Find* "not found" sentinel
+	// (mirrors client.IgnoreNotFound patterns); callers use
+	// errors.Is(err, ErrNoMatch) before use.
+	return nil, ErrNoMatch // No active duplicate found
 }
 
 // FindActiveWFEForTarget finds an active (Running phase) WFE for the given target resource.
-// Returns the first running WFE found, or nil if none exist.
+// Returns the first running WFE found, or ErrNoMatch if none exist.
 //
 // Uses field index on spec.targetResource for O(1) lookup (configured in Day 1).
 //
@@ -981,14 +994,13 @@ func (r *RoutingEngine) FindActiveWFEForTarget(
 		}
 	}
 
-	// nolint:nilnil // intentional "not found" sentinel, not an error — same
-	// Find* idiom as FindActiveRRForFingerprint above.
-	return nil, nil // No active WFE found
+	// Issue #1674: same ErrNoMatch idiom as FindActiveRRForFingerprint above.
+	return nil, ErrNoMatch // No active WFE found
 }
 
 // FindRecentCompletedWFE finds the most recent completed WFE for the given
 // target resource and workflow ID, within the cooldown period.
-// Returns the WFE if found within cooldown, or nil if none exist or outside cooldown.
+// Returns the WFE if found within cooldown, or ErrNoMatch if none exist or outside cooldown.
 //
 // Uses field index on spec.targetResource for O(1) lookup (configured in Day 1).
 //
@@ -1048,6 +1060,13 @@ func (r *RoutingEngine) FindRecentCompletedWFE(
 			wfe.Status.CompletionTime.After(mostRecentCompleted.Status.CompletionTime.Time) {
 			mostRecentCompleted = wfe
 		}
+	}
+
+	// Issue #1674: same ErrNoMatch idiom as its Find* siblings above, even
+	// though the nilnil linter never flagged this site (mostRecentCompleted
+	// is a variable, not a literal nil) -- kept consistent for callers.
+	if mostRecentCompleted == nil {
+		return nil, ErrNoMatch
 	}
 
 	return mostRecentCompleted, nil

--- a/pkg/remediationorchestrator/routing/blocking_test.go
+++ b/pkg/remediationorchestrator/routing/blocking_test.go
@@ -18,6 +18,7 @@ package routing_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -311,7 +312,7 @@ var _ = Describe("Routing Engine - Blocking Logic", func() {
 
 			blocked, err := engine.CheckDuplicateInProgress(ctx, incomingRR)
 
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, routing.ErrNotBlocked)).To(BeTrue())
 			Expect(blocked).To(BeNil(),
 				"Tenant-B should NOT be blocked as duplicate of tenant-A's active RR (namespace isolation)")
 		})
@@ -371,7 +372,7 @@ var _ = Describe("Routing Engine - Blocking Logic", func() {
 			// When RR-A is re-reconciled, it should NOT be blocked by RR-B
 			blocked, err := engine.CheckDuplicateInProgress(ctx, rrA)
 
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, routing.ErrNotBlocked)).To(BeTrue())
 			Expect(blocked).To(BeNil(),
 				"Older RR-A should NOT be blocked by newer RR-B — prevents circular deadlock (#209)")
 		})
@@ -492,7 +493,7 @@ var _ = Describe("Routing Engine - Blocking Logic", func() {
 			blocked, err := engine.CheckDuplicateInProgress(ctx, newRR)
 
 			// GREEN: Test should pass
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, routing.ErrNotBlocked)).To(BeTrue())
 			Expect(blocked).To(BeNil()) // Not blocked (original is terminal)
 		})
 
@@ -510,7 +511,7 @@ var _ = Describe("Routing Engine - Blocking Logic", func() {
 			blocked, err := engine.CheckDuplicateInProgress(ctx, rr)
 
 			// GREEN: Test should pass
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, routing.ErrNotBlocked)).To(BeTrue())
 			Expect(blocked).To(BeNil())
 		})
 
@@ -534,7 +535,7 @@ var _ = Describe("Routing Engine - Blocking Logic", func() {
 			blocked, err := engine.CheckDuplicateInProgress(ctx, rr)
 
 			// GREEN: Test should pass
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, routing.ErrNotBlocked)).To(BeTrue())
 			Expect(blocked).To(BeNil()) // Should not block on self
 		})
 
@@ -670,7 +671,7 @@ var _ = Describe("Routing Engine - Blocking Logic", func() {
 			blocked, err := engine.CheckResourceBusy(ctx, rr, "default/pod/nginx-67890")
 
 			// GREEN: Test should pass
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, routing.ErrNotBlocked)).To(BeTrue())
 			Expect(blocked).To(BeNil()) // Not blocked (WFE is terminal)
 		})
 
@@ -692,7 +693,7 @@ var _ = Describe("Routing Engine - Blocking Logic", func() {
 			blocked, err := engine.CheckResourceBusy(ctx, rr, "default/pod/nginx-99999")
 
 			// GREEN: Test should pass
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, routing.ErrNotBlocked)).To(BeTrue())
 			Expect(blocked).To(BeNil())
 		})
 	})
@@ -792,7 +793,7 @@ var _ = Describe("Routing Engine - Blocking Logic", func() {
 			blocked, err := engine.CheckRecentlyRemediated(ctx, rr, "restart-workflow", "default/pod/nginx-old")
 
 			// GREEN: Test should pass
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, routing.ErrNotBlocked)).To(BeTrue())
 			Expect(blocked).To(BeNil()) // Not blocked (cooldown expired)
 		})
 
@@ -899,7 +900,7 @@ var _ = Describe("Routing Engine - Blocking Logic", func() {
 			// Expect NOT blocked - different workflow on same target should be allowed
 			// Per DD-RO-002 Check 4: "If same workflow executed recently for same target"
 			// Since workflow is DIFFERENT, cooldown should NOT apply
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, routing.ErrNotBlocked)).To(BeTrue())
 			Expect(blocked).To(BeNil()) // Not blocked (different workflow)
 		})
 	})
@@ -1005,7 +1006,7 @@ var _ = Describe("Routing Engine - Blocking Logic", func() {
 			// Pass lowercase "deployment" (as the buggy reconciler does on line 955)
 			blocked, err := engine.CheckRecentlyRemediated(ctx, rr, "patch-hpa-v1", "demo-hpa/deployment/api-frontend")
 
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, routing.ErrNotBlocked)).To(BeTrue())
 			Expect(blocked).To(BeNil(),
 				"Bug #203: Lowercase 'deployment' does not match WFE's 'Deployment' -- cooldown bypassed")
 		})
@@ -1213,7 +1214,7 @@ var _ = Describe("Routing Engine - Blocking Logic", func() {
 
 			blocked, err := engine.CheckPreAnalysisConditions(ctx, rr)
 
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, routing.ErrNotBlocked)).To(BeTrue())
 			Expect(blocked).To(BeNil()) // Can proceed to execution
 		})
 	})
@@ -1282,7 +1283,7 @@ var _ = Describe("Routing Engine - Blocking Logic", func() {
 			Expect(fakeClient.Create(ctx, rr)).To(Succeed())
 
 			blocked, err := engine.CheckPreAnalysisConditions(ctx, rr)
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, routing.ErrNotBlocked)).To(BeTrue())
 			Expect(blocked).To(BeNil()) // Not blocked (empty fingerprint doesn't match anything)
 		})
 
@@ -1304,7 +1305,7 @@ var _ = Describe("Routing Engine - Blocking Logic", func() {
 			Expect(fakeClient.Create(ctx, rr)).To(Succeed())
 
 			blocked, err := engine.CheckPostAnalysisConditions(ctx, rr, "", "", "", "")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, routing.ErrNotBlocked)).To(BeTrue())
 			Expect(blocked).To(BeNil()) // Not blocked (empty target doesn't match)
 		})
 
@@ -1386,7 +1387,7 @@ var _ = Describe("Routing Engine - Blocking Logic", func() {
 
 			// Workflow ID from AIAnalysis.Status.SelectedWorkflow.WorkflowID
 			blocked, err := engine.CheckRecentlyRemediated(ctx, rr, "restart-pod", "default/pod/test-pod")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, routing.ErrNotBlocked)).To(BeTrue())
 			Expect(blocked).To(BeNil()) // Not blocked (no CompletionTime = skip)
 		})
 
@@ -1429,7 +1430,7 @@ var _ = Describe("Routing Engine - Blocking Logic", func() {
 
 			// Same workflow ID but outside cooldown window
 			blocked, err := engine.CheckRecentlyRemediated(ctx, rr, "restart-pod", "default/pod/test-pod-old")
-			Expect(err).ToNot(HaveOccurred())
+			Expect(errors.Is(err, routing.ErrNotBlocked)).To(BeTrue())
 			Expect(blocked).To(BeNil()) // Not blocked (cooldown expired)
 		})
 

--- a/pkg/signalprocessing/ownerchain/builder.go
+++ b/pkg/signalprocessing/ownerchain/builder.go
@@ -46,6 +46,7 @@ package ownerchain
 
 import (
 	"context"
+	"errors"
 
 	"github.com/go-logr/logr"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,6 +59,12 @@ import (
 
 // MaxOwnerChainDepth per BR-SP-100: Stop at max depth 5
 const MaxOwnerChainDepth = 5
+
+// ErrNoControllerOwner indicates the fetched resource has no owner reference
+// with controller: true. Issue #1674: typed sentinel replacing the previous
+// ambiguous (nil, nil) return from getControllerOwner — this is the expected
+// "chain complete" signal, not a K8s API error.
+var ErrNoControllerOwner = errors.New("no controller owner reference found")
 
 // Builder constructs the K8s ownership chain.
 // Used for K8s context enrichment in the SignalProcessing pipeline.
@@ -101,16 +108,16 @@ func (b *Builder) Build(ctx context.Context, namespace, kind, name string) ([]si
 
 		ownerRef, err := b.getControllerOwner(ctx, currentNamespace, currentKind, currentName)
 		if err != nil {
+			if errors.Is(err, ErrNoControllerOwner) {
+				b.logger.V(1).Info("No controller owner found, chain complete",
+					"kind", currentKind, "name", currentName)
+				break // No more owners - chain complete
+			}
 			// Log error but return partial chain (graceful degradation)
 			// Per ERROR_HANDLING_PHILOSOPHY.md: Category E - Partial Data
 			b.logger.Info("Error fetching owner, returning partial chain",
 				"error", err, "currentKind", currentKind, "currentName", currentName)
 			break
-		}
-		if ownerRef == nil {
-			b.logger.V(1).Info("No controller owner found, chain complete",
-				"kind", currentKind, "name", currentName)
-			break // No more owners - chain complete
 		}
 		b.logger.V(1).Info("Found controller owner",
 			"ownerKind", ownerRef.Kind, "ownerName", ownerRef.Name)
@@ -141,8 +148,8 @@ func (b *Builder) Build(ctx context.Context, namespace, kind, name string) ([]si
 }
 
 // getControllerOwner fetches a resource and returns its controller owner reference.
-// Returns nil, nil if no controller owner found.
-// Returns nil, error for K8s API errors (RBAC, timeout, not found).
+// Returns ErrNoControllerOwner if no controller owner found.
+// Returns a different error for K8s API errors (RBAC, timeout, not found).
 func (b *Builder) getControllerOwner(ctx context.Context, namespace, kind, name string) (*metav1.OwnerReference, error) {
 	// Check context cancellation first
 	select {
@@ -169,11 +176,7 @@ func (b *Builder) getControllerOwner(ctx context.Context, namespace, kind, name 
 		}
 	}
 
-	// nolint:nilnil // intentional "no controller owner" sentinel, not an
-	// error — already documented above ("Returns nil, nil if no controller
-	// owner found"); sole caller already guards with `if ownerRef == nil`
-	// before use (Issue #1546 Tier 2).
-	return nil, nil // No controller owner
+	return nil, ErrNoControllerOwner
 }
 
 // getGVKForKind returns the GroupVersionKind for a given K8s resource kind.

--- a/pkg/signalprocessing/ownerchain/builder_internal_test.go
+++ b/pkg/signalprocessing/ownerchain/builder_internal_test.go
@@ -1,0 +1,58 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package ownerchain
+
+import (
+	"context"
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	kubelog "github.com/jordigilh/kubernaut/pkg/log"
+)
+
+// ========================================
+// Issue #1674 (nilnil sentinel-error refactor), Batch 2: getControllerOwner is
+// unexported; its "no controller owner" branch is already covered end-to-end
+// through the public Build() API (pkg/signalprocessing/ownerchain_builder_test.go
+// OC-EC-01/OC-EC-04), which continues to pass unchanged after this refactor.
+// This file adds a direct, sentinel-level check on the unexported method.
+// BR-SP-100.
+// ========================================
+var _ = Describe("getControllerOwner (Issue #1674 Batch 2)", func() {
+	It("UT-SP-1674-001: returns ErrNoControllerOwner for a resource with no controller owner reference", func() {
+		s := runtime.NewScheme()
+		Expect(scheme.AddToScheme(s)).To(Succeed())
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: "orphan-pod", Namespace: "default"},
+		}
+		fakeClient := fake.NewClientBuilder().WithScheme(s).WithObjects(pod).Build()
+		b := NewBuilder(fakeClient, kubelog.NewLogger(kubelog.DevelopmentOptions()))
+
+		ref, err := b.getControllerOwner(context.Background(), "default", "Pod", "orphan-pod")
+
+		Expect(errors.Is(err, ErrNoControllerOwner)).To(BeTrue())
+		Expect(ref).To(BeNil())
+	})
+})

--- a/pkg/workflowexecution/client/workflow_querier.go
+++ b/pkg/workflowexecution/client/workflow_querier.go
@@ -20,6 +20,7 @@ package client
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -33,6 +34,12 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/shared/auth"
 	sharedtls "github.com/jordigilh/kubernaut/pkg/shared/tls" // Issue #678: Inter-service TLS
 )
+
+// ErrNoDependencies indicates the workflow catalog entry declares no schema
+// content, and therefore no dependencies to extract. Issue #1674: typed
+// sentinel replacing the previous ambiguous (nil, nil) return from
+// GetWorkflowDependencies.
+var ErrNoDependencies = errors.New("workflow has no dependencies declared")
 
 // WorkflowCatalogMetadata holds all workflow metadata resolved from the DS
 // catalog in a single GetWorkflowByID call (Issue #650). Consolidates what was
@@ -162,7 +169,7 @@ func classifyGetWorkflowResponse(res ogenclient.GetWorkflowByIDRes, workflowID s
 
 // GetWorkflowDependencies fetches the workflow from DS by ID and extracts
 // schema-declared dependencies from the Content field (raw YAML).
-// Returns nil if the workflow has no dependencies declared.
+// Returns ErrNoDependencies if the workflow has no dependencies declared.
 func (q *OgenWorkflowQuerier) GetWorkflowDependencies(ctx context.Context, workflowID string) (*models.WorkflowDependencies, error) {
 	uid, err := uuid.Parse(workflowID)
 	if err != nil {
@@ -182,12 +189,7 @@ func (q *OgenWorkflowQuerier) GetWorkflowDependencies(ctx context.Context, workf
 	}
 
 	if wf.Content == "" {
-		// nolint:nilnil // intentional "no dependencies declared" sentinel,
-		// not an error — already documented above ("Returns nil if the
-		// workflow has no dependencies declared"); the WorkflowQuerier
-		// interface contract makes nil an explicit, documented valid result
-		// (Issue #1546 Tier 2).
-		return nil, nil
+		return nil, ErrNoDependencies
 	}
 
 	parser := schema.NewParser()

--- a/pkg/workflowexecution/workflow_querier_test.go
+++ b/pkg/workflowexecution/workflow_querier_test.go
@@ -19,6 +19,7 @@ package workflowexecution_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -370,6 +371,20 @@ var _ = Describe("OgenWorkflowQuerier (DD-WE-006)", func() {
 				ContainSubstring("internal server error"),
 				ContainSubstring("500"),
 			))
+		})
+
+		It("UT-WE-1674-001: GetWorkflowDependencies returns ErrNoDependencies when the catalog entry declares no content", func() {
+			// Issue #1674: replaces the previous ambiguous (nil, nil) — the
+			// WorkflowQuerier interface now makes "no dependencies declared" an
+			// explicit, checkable sentinel rather than an implicit nil.
+			mock := &mockWorkflowCatalogClient{
+				response: &ogenclient.RemediationWorkflow{Content: ""},
+			}
+			querier := weclient.NewOgenWorkflowQuerier(mock)
+
+			deps, err := querier.GetWorkflowDependencies(ctx, uuid.New().String())
+			Expect(errors.Is(err, weclient.ErrNoDependencies)).To(BeTrue())
+			Expect(deps).To(BeNil())
 		})
 
 		It("UT-WE-658-006: GetWorkflowEngineConfig should classify DS 500 as server error", func() {

--- a/test/integration/datastorage/workflow_discovery_repository_test.go
+++ b/test/integration/datastorage/workflow_discovery_repository_test.go
@@ -18,6 +18,7 @@ package datastorage
 
 import (
 	"crypto/sha256"
+	"errors"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -304,7 +305,7 @@ var _ = Describe("Workflow Discovery Repository Integration Tests", Serial, func
 		// IT-DS-017-001-006: GetWorkflowWithContextFilters -- context mismatch returns nil
 		// ========================================
 		Context("IT-DS-017-001-006: context mismatch returns nil (security gate)", func() {
-			It("should return nil when context filters do not match", func() {
+			It("should return workflow.ErrNotFound when context filters do not match", func() {
 				// Arrange: workflow with severity=critical, environment=production
 				wf := createTestWorkflow("scale-mismatch", "v1.0.0", "ScaleReplicas", "critical", "v1/Pod", "production", "P0", "Active")
 
@@ -317,8 +318,12 @@ var _ = Describe("Workflow Discovery Repository Integration Tests", Serial, func
 				}
 				result, err := workflowRepo.GetWorkflowWithContextFilters(ctx, wf.WorkflowID, filters)
 
-				// Assert: Security gate -- no workflow returned
-				Expect(err).ToNot(HaveOccurred())
+				// Assert: Security gate -- no workflow returned. Issue #1674: the
+				// repository now signals "not found OR filtered out" via the
+				// workflow.ErrNotFound sentinel instead of the ambiguous (nil, nil)
+				// return; the two cases are still deliberately not distinguished
+				// from each other to prevent information leakage (DD-WORKFLOW-016).
+				Expect(errors.Is(err, workflow.ErrNotFound)).To(BeTrue(), "Security gate should surface ErrNotFound for mismatched workflow")
 				Expect(result).To(BeNil(), "Security gate should prevent returning mismatched workflow")
 			})
 		})

--- a/test/integration/kubernautagent/mcp/lease_session_mgr_test.go
+++ b/test/integration/kubernautagent/mcp/lease_session_mgr_test.go
@@ -128,10 +128,13 @@ var _ = Describe("LeaseSessionManager deep IT — BR-INTERACTIVE-005", Label("in
 	})
 
 	Describe("IT-KA-LSM-005: GetDriver returns nil for unknown rrID", func() {
-		It("should return nil session when no driver holds the rrID", func() {
+		It("should return ErrSessionNotFound when no driver holds the rrID", func() {
+			// Issue #1674: GetDriver now signals "no session" via the
+			// ErrSessionNotFound sentinel instead of the ambiguous (nil, nil)
+			// return.
 			mgr := mcpinternal.NewLeaseSessionManagerConcrete(sharedK8sClient, nsName, logger)
 			sess, err := mgr.GetDriver("rr-nobody")
-			Expect(err).NotTo(HaveOccurred())
+			Expect(err).To(MatchError(mcpinternal.ErrSessionNotFound))
 			Expect(sess).To(BeNil())
 		})
 	})


### PR DESCRIPTION
## Summary

Closes #1674.

Replaces ambiguous `(nil, nil)` returns across 10 files with typed sentinel errors, following the existing `ErrActionTypeNotFound` / `ErrSessionNotFound` convention already used elsewhere in the codebase. The `nilnil` linter (enabled for production code in #1679, Issue #1546 Tier 4) flagged the original 27 sites; this PR resolves all of them plus one additional site (`FindRecentCompletedWFE`) included for consistency with its siblings.

## Batches

1. **`actiontype.GetByName` + `session_manager.GetDriver`** — reuse existing `ErrActionTypeNotFound` / `ErrSessionNotFound` sentinels. New sqlmock-based UT file for `actiontype` (previously zero coverage).
2. **Single-caller files** — `rw_reconciler.go` (`ErrActionTypeCRDNotFound`), `ownerchain/builder.go` (`ErrNoControllerOwner`), `workflowexecution_catalog.go` (`ErrAlreadyResolved`, new UT with mock `WorkflowQuerier`), `workflow_querier.go` (`ErrNoDependencies`), `workflow_schema.go` `ParseEngineConfig` (`ErrNoEngineConfig`).
3. **`workflow/crud.go` + `discovery.go`** — new `workflow.ErrNotFound` sentinel across all `Get*` lookup methods. Along the way, found and fixed **two real bugs**:
   - A nil-deref in `HandleUpdateWorkflow` (old `(nil, nil)` contract meant `err != nil` never caught "not found," so a nil workflow reached `applyMutableWorkflowUpdate` and dereferenced `.Status` — recovered as an HTTP 500 by the panic-recovery middleware, but still wrong. Now returns a proper 404.)
   - Dead code in `fetchWorkflowByIDWithGate` (compared `err.Error()` against a hand-built string that was never actually produced).
   Both are covered by new regression tests (`UT-DS-1674-005..009`).
4. **`routing/blocking.go`** — two sentinels per the design decision below: `routing.ErrNotBlocked` (8 `Check*` sites) and `routing.ErrNoMatch` (3 `Find*` sites, including `FindRecentCompletedWFE` which the linter never flagged since it returns a variable, not a literal `nil`). Updated the 3 controller call sites (`pending_handler.go`, `analyzing_handler.go`, `awaiting_approval_handler.go`) and all affected test assertions.
5. **`owner_resolver.go`** (`verifyOwnerViaFallback`, #284 trust-but-verify path) — unexported `errNoControllerOwner` sentinel. Existing coverage (`owner_resolver_k8s_test.go`'s 3 "Trust-but-verify" specs) empirically re-confirmed passing both before and after the change.

### Design decision: sentinel granularity in `routing/blocking.go`

Two families, not one or three:
- `Check*` (`CheckPreAnalysisConditions`, `CheckPostAnalysisConditions`, `CheckDuplicateInProgress`, `CheckResourceBusy`, `CheckRecentlyRemediated`) → `ErrNotBlocked`. All mean the same thing: "no blocking condition found."
- `Find*` (`FindActiveRRForFingerprint`, `FindActiveWFEForTarget`, `FindRecentCompletedWFE`) → `ErrNoMatch`. No caller (in or outside the package) ever disambiguates "no RR" vs "no WFE."

Collapsing to one sentinel would hide the translation point where `Check*` functions convert `ErrNoMatch` → `ErrNotBlocked` for their own contract. Splitting to three buys nothing (no caller needs it).

## Verification

- `go build ./...`, `go vet ./...` — clean.
- `golangci-lint run --timeout=10m cmd/... pkg/... internal/... test/...` (exact CI invocation) — 0 issues.
- `golangci-lint run --enable-only nilnil` on the same scope — 0 issues (down from 27+1 findings).
- `go test ./cmd/... ./pkg/... ./internal/...` — all green, no regressions.
- `pkg/gateway/adapters/owner_resolver_k8s_test.go`'s "Trust-but-verify" specs re-run with `-ginkgo.focus` — 3/3 passing before and after Batch 5.

## Business requirements

BR-WORKFLOW-007, BR-INTERACTIVE-002, BR-STORAGE-014, BR-API-031, BR-ORCH-025, BR-ORCH-036, BR-ORCH-042, BR-GATEWAY-004.

Made with [Cursor](https://cursor.com)