### PR TITLE
fix: RCA follow-up for E2E-FLEET-014 flake — must-gather cluster collision + dead WFE.FailureReason field

### DIFF
--- a/internal/controller/workflowexecution/workflowexecution_status_marking.go
+++ b/internal/controller/workflowexecution/workflowexecution_status_marking.go
@@ -379,6 +379,15 @@ func (r *WorkflowExecutionReconciler) applyFailedStatusTransition(wfe *workflowe
 	wfe.Status.CompletionTime = t.completionTime
 	wfe.Status.Duration = t.durationVal
 	wfe.Status.FailureDetails = t.failureDetails
+	// Issue #1690 RCA follow-up: mirror onto the flat top-level field too --
+	// RO's executing_handler.go and E2E scenario assertions read
+	// Status.FailureReason directly rather than Status.FailureDetails.Reason,
+	// and it was never populated on this path, silently blanking out
+	// user-facing failure messaging for every in-execution (job/tekton)
+	// failure.
+	if t.failureDetails != nil {
+		wfe.Status.FailureReason = t.failureDetails.Reason
+	}
 
 	// Issue #118 Gap 4: persist ExecutionStatus inside callback (survives refetch)
 	if len(t.summary) > 0 && t.summary[0] != nil {
@@ -495,6 +504,11 @@ func (r *WorkflowExecutionReconciler) markFailedInternal(
 
 		wfe.Status.CompletionTime = now
 		wfe.Status.FailureDetails = failureDetails
+		// Issue #1690 RCA follow-up: see applyFailedStatusTransition's comment --
+		// mirror onto the flat top-level field for the pre-execution path too.
+		if failureDetails != nil {
+			wfe.Status.FailureReason = failureDetails.Reason
+		}
 
 		if extraUpdates != nil {
 			extraUpdates()

--- a/pkg/workflowexecution/controller_test.go
+++ b/pkg/workflowexecution/controller_test.go
@@ -1104,6 +1104,26 @@ var _ = Describe("WorkflowExecution Controller", func() {
 			Expect(updated.Status.FailureDetails).To(And(Not(BeNil()), HaveField("Message", Not(BeEmpty()))))
 		})
 
+		// Issue #1690 RCA follow-up: Status.FailureReason (the flat, top-level
+		// field read directly by RO's executing_handler.go and by E2E scenario
+		// assertions) was never populated by the in-execution MarkFailed path --
+		// only Status.FailureDetails.Reason (the nested struct) was set. This
+		// silently blanked out RO's user-facing failure messaging and made E2E
+		// failure diagnostics ("reached Failed phase (reason: )") useless for
+		// every job/tekton execution failure, not just pre-execution ones.
+		It("should populate the top-level FailureReason field to match FailureDetails.Reason", func() {
+			_, err := reconciler.MarkFailed(ctx, wfe, pr)
+			Expect(err).ToNot(HaveOccurred())
+
+			var updated workflowexecutionv1alpha1.WorkflowExecution
+			err = reconciler.Get(ctx, client.ObjectKeyFromObject(wfe), &updated)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(updated.Status.FailureReason).ToNot(BeEmpty(),
+				"top-level FailureReason must be populated so RO and E2E consumers reading it directly see the real reason")
+			Expect(updated.Status.FailureReason).To(Equal(updated.Status.FailureDetails.Reason),
+				"top-level FailureReason must mirror FailureDetails.Reason")
+		})
+
 		It("should set CompletionTime", func() {
 			_, err := reconciler.MarkFailed(ctx, wfe, pr)
 			Expect(err).ToNot(HaveOccurred())
@@ -4887,6 +4907,12 @@ var _ = Describe("WorkflowExecution Controller", func() {
 				Expect(wfe.Status.FailureDetails).To(And(Not(BeNil()), HaveField("Reason", Equal(
 					workflowexecutionv1alpha1.FailureReasonOOMKilled))))
 				Expect(wfe.Status.FailureDetails.WasExecutionFailure).To(BeFalse())
+
+				// Issue #1690 RCA follow-up: the pre-execution path
+				// (markFailedInternal) must also mirror the reason onto the
+				// flat top-level field, same as the in-execution MarkFailed path.
+				Expect(wfe.Status.FailureReason).To(Equal(workflowexecutionv1alpha1.FailureReasonOOMKilled),
+					"top-level FailureReason must be populated on the pre-execution failure path too")
 
 				// And: Audit event should be emitted
 				Eventually(func() bool {

--- a/test/e2e/fleet/suite_test.go
+++ b/test/e2e/fleet/suite_test.go
@@ -589,6 +589,11 @@ var _ = SynchronizedAfterSuite(
 			}
 			if remoteKubeconfigPath != "" {
 				infrastructure.MustGatherPodLogs(remoteClusterName, remoteKubeconfigPath, "kubernaut-system", "fleet", GinkgoWriter)
+				// Issue #1690 RCA follow-up: the job execution engine can route
+				// the K8s Job to the remote cluster (BR-FLEET-054), so its Job/
+				// Pod/Event diagnostics can live in the remote cluster's
+				// "kubernaut-workflows" namespace, not just the primary's.
+				infrastructure.MustGatherPodLogs(remoteClusterName, remoteKubeconfigPath, "kubernaut-workflows", "fleet", GinkgoWriter)
 			}
 		}
 

--- a/test/infrastructure/datastorage.go
+++ b/test/infrastructure/datastorage.go
@@ -137,13 +137,33 @@ func ResolveAnyFailure(clusterName string, setupFailed, anyTestFailed bool, writ
 // - namespace: Kubernetes namespace to collect logs from (e.g., "kubernaut-system")
 // - serviceName: Service name for directory naming (e.g., "fullpipeline", "aianalysis")
 // - writer: Output writer for logging
+// mustGatherDirPath builds the on-disk directory a single MustGatherPodLogs
+// call writes into.
+//
+// Issue #1690 RCA follow-up: this MUST include clusterName. Multi-cluster
+// E2E suites (fleet, fleetmetadatacache, fleetmetadatacache/eaigw) call
+// MustGatherPodLogs once per cluster with the *same* serviceName and the
+// *same* namespace ("kubernaut-system" exists on both the primary and the
+// remote cluster) -- only clusterName differs between the calls. Without it
+// in the path, the second cluster's call silently overwrote the first
+// cluster's namespace-level files (events.txt, jobs.txt, jobs_describe.txt,
+// pod_status.txt/json -- everything except per-pod log files, which happen
+// to not collide because pod names differ). This is exactly what destroyed
+// the primary cluster's WorkflowFailed event during the RCA for the
+// E2E-FLEET-014 BackoffLimitExceeded flake: the event was captured, then
+// clobbered by the remote cluster's must-gather pass moments later in the
+// same run.
+func mustGatherDirPath(serviceName, clusterName, namespace string) string {
+	return fmt.Sprintf("/tmp/kubernaut-must-gather/%s/%s/%s", serviceName, clusterName, namespace)
+}
+
 func MustGatherPodLogs(clusterName, kubeconfigPath, namespace, serviceName string, writer io.Writer) {
 	_, _ = fmt.Fprintf(writer, "═══════════════════════════════════════════════════════════\n")
 	_, _ = fmt.Fprintf(writer, "📋 MUST-GATHER: Collecting pod logs via kubectl\n")
 	_, _ = fmt.Fprintf(writer, "   Cluster: %s | Namespace: %s | Service: %s\n", clusterName, namespace, serviceName)
 	_, _ = fmt.Fprintf(writer, "═══════════════════════════════════════════════════════════\n\n")
 
-	mustGatherDir := fmt.Sprintf("/tmp/kubernaut-must-gather/%s/%s", serviceName, namespace)
+	mustGatherDir := mustGatherDirPath(serviceName, clusterName, namespace)
 	if err := os.MkdirAll(mustGatherDir, 0755); err != nil {
 		_, _ = fmt.Fprintf(writer, "❌ Failed to create must-gather directory %s: %v\n", mustGatherDir, err)
 		return

--- a/test/infrastructure/datastorage_test.go
+++ b/test/infrastructure/datastorage_test.go
@@ -1,0 +1,50 @@
+/*
+Copyright 2025 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package infrastructure
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// Issue #1690 RCA follow-up: multi-cluster E2E suites (fleet,
+// fleetmetadatacache, fleetmetadatacache/eaigw) call MustGatherPodLogs once
+// per cluster with the same serviceName+namespace pair (e.g. both the
+// primary and remote cluster have a "kubernaut-system" namespace) -- only
+// clusterName differs. mustGatherDirPath must produce a distinct directory
+// per cluster or the second call's must-gather pass silently overwrites the
+// first cluster's namespace-level diagnostic files.
+var _ = Describe("mustGatherDirPath", func() {
+	DescribeTable("directory path construction",
+		func(serviceName, clusterName, namespace, expected string) {
+			Expect(mustGatherDirPath(serviceName, clusterName, namespace)).To(Equal(expected))
+		},
+		Entry("UT-INFRA-MG-001: primary cluster",
+			"fleet", "fleet-e2e", "kubernaut-system",
+			"/tmp/kubernaut-must-gather/fleet/fleet-e2e/kubernaut-system"),
+		Entry("UT-INFRA-MG-002: remote cluster, same service+namespace as primary",
+			"fleet", "fleet-e2e-remote", "kubernaut-system",
+			"/tmp/kubernaut-must-gather/fleet/fleet-e2e-remote/kubernaut-system"),
+	)
+
+	It("UT-INFRA-MG-003: produces distinct paths for two clusters sharing serviceName and namespace", func() {
+		primary := mustGatherDirPath("fleet", "fleet-e2e", "kubernaut-system")
+		remote := mustGatherDirPath("fleet", "fleet-e2e-remote", "kubernaut-system")
+		Expect(primary).ToNot(Equal(remote),
+			"distinct clusters must never collide onto the same must-gather directory, or the second cluster's collection silently destroys the first cluster's diagnostic files (events.txt, jobs.txt, pod_status.*)")
+	})
+})


### PR DESCRIPTION
## Summary

Follow-up from triaging the intermittent `E2E-FLEET-014` `BackoffLimitExceeded` flake in PR #1690 (see #1692 for the full RCA). Neither of these bugs caused the flake, but both blocked diagnosing it — this PR fixes both so a future recurrence is actually diagnosable.

## Changes

1. **Must-gather cluster-name collision** (`test/infrastructure/datastorage.go`): `MustGatherPodLogs`'s output directory was built from `serviceName/namespace` only, omitting `clusterName`. Every multi-cluster E2E suite (fleet, fleetmetadatacache, fleetmetadatacache/eaigw) calls it once per cluster with the *same* `serviceName`+`namespace` (both primary and remote clusters have a `kubernaut-system` namespace) — so the second cluster's call silently overwrote the first cluster's `events.txt`/`jobs.txt`/`jobs_describe.txt`/`pod_status.*`. This is exactly what destroyed the primary cluster's `WorkflowFailed` K8s Event during the #1692 RCA. Extracted the path construction into a testable `mustGatherDirPath` helper and included `clusterName` in it.

2. **Dead `WorkflowExecution.Status.FailureReason` field** (`internal/controller/workflowexecution/workflowexecution_status_marking.go`): the flat top-level field — read directly by RO's `executing_handler.go` for user-facing failure messaging, and by E2E scenario assertions — was never populated by `MarkFailed`/`MarkFailedWithReason`; only the nested `Status.FailureDetails.Reason` was set. This silently blanked out RO's failure messaging *and* made E2E failure diagnostics (`"reached Failed phase (reason: )"`) useless for every in-execution failure. Now mirrored from `FailureDetails.Reason` on both the in-execution (`applyFailedStatusTransition`) and pre-execution (`markFailedInternal`) paths.

3. **Missing remote-cluster `kubernaut-workflows` must-gather call** (`test/e2e/fleet/suite_test.go`): the fleet suite only gathered the primary cluster's `kubernaut-workflows` namespace; since job-engine executions can route to the remote cluster (BR-FLEET-054), the remote cluster's Job/Pod/Event data was never collected at all.

## Testing (TDD)

- RED: added `should populate the top-level FailureReason field to match FailureDetails.Reason` (MarkFailed) and extended the `CTRL-FAIL-01: OOMKilled enum test` (MarkFailedWithReason) in `pkg/workflowexecution/controller_test.go` — both failed against the old code (empty string).
- GREEN: the two-line mirror fix in both status-marking paths makes both pass.
- New `test/infrastructure/datastorage_test.go` unit-tests `mustGatherDirPath` directly (`UT-INFRA-MG-001..003`), including an explicit "two clusters sharing serviceName+namespace must not collide" assertion — the exact scenario that destroyed the RCA evidence.

## Verification

- `go build ./...`, `go vet ./...` clean.
- `go test ./pkg/workflowexecution/... ./internal/controller/workflowexecution/... ./internal/controller/remediationorchestrator/... ./test/infrastructure/...` — all green.
- `golangci-lint run` on all changed files — 0 issues.

## Related

- #1692 (RCA tracking issue, left open pending recurrence with these fixed diagnostics)
- #1690 (the PR whose flaky rerun triggered this investigation)

Made with [Cursor](https://cursor.com)