### PR TITLE
test(e2e): remove permanently-skipped E2E-WE-014-005 placeholder

### DIFF
--- a/docs/testing/BR-WE-014/E2E_TEST_PLAN_BR_WE_014.md
+++ b/docs/testing/BR-WE-014/E2E_TEST_PLAN_BR_WE_014.md
@@ -1,6 +1,6 @@
 # E2E Test Plan: BR-WE-014 (Kubernetes Job Execution Backend)
 
-**Version**: 1.1.0
+**Version**: 1.2.0
 **Created**: 2026-02-05
 **Status**: Active
 **Authority**: BR-WE-014 (Kubernetes Job Execution Backend)
@@ -42,7 +42,6 @@ Kubernetes API interactions including Job creation, status monitoring, and clean
 
 | Test ID | Scenario | Gherkin AC | BRs |
 |---------|----------|------------|-----|
-| E2E-WE-014-005 | Invalid executionEngine rejected by API server | AC Scenario 5 | BR-WE-014 |
 | E2E-WE-014-006 | Deterministic Job naming for resource locking | AC Scenario 6 | BR-WE-014, BR-WE-009 |
 | E2E-WE-014-007 | External Job deletion marks WFE as Failed | BR-WE-007 equivalent | BR-WE-014, BR-WE-007 |
 
@@ -53,6 +52,12 @@ Kubernetes API interactions including Job creation, status monitoring, and clean
 | Full platform E2E: OOMKill with Job backend | AC Scenario 8 | Requires all services deployed; deferred to platform E2E suite |
 | RO propagates execution_engine from catalog | AC Scenario 7 | Cross-service; belongs to RO E2E suite |
 | Default executionEngine applied when omitted | AC Scenario 4 | CRD has `+kubebuilder:default=tekton`; covered by existing Tekton tests |
+
+### Superseded
+
+| Test ID | Original Scenario | Gherkin AC | Reason |
+|---------|--------------------|------------|--------|
+| E2E-WE-014-005 | Invalid executionEngine rejected by API server | AC Scenario 5 | `executionEngine` was removed from `WorkflowExecutionSpec`; the CRD-level admission check this test targeted no longer exists. The engine is now resolved at runtime from DataStorage + `ExecutorRegistry`, and rejection of an unsupported engine is proven by `UT-WE-659-002` (`pkg/workflowexecution/controller_events_test.go`) and `IT-WE-015-001` (`test/integration/workflowexecution/ansible_dispatch_integration_test.go`) per the UT-proves-logic / IT-proves-wiring pyramid invariant. No E2E equivalent is required. |
 
 ---
 
@@ -129,16 +134,13 @@ Kubernetes API interactions including Job creation, status monitoring, and clean
 
 ---
 
-### E2E-WE-014-005: Invalid ExecutionEngine CRD Validation
+### E2E-WE-014-005: Superseded (see "Superseded" table above)
 
-**Business Outcome**: Invalid executionEngine values are rejected at API level, preventing misconfigured WFEs.
-
-**Steps**:
-1. Attempt to create WFE with `executionEngine: "ansible"` (invalid enum value)
-2. Assert creation fails with a validation error
-3. Assert no WFE is persisted in the API server
-
-**Pass Criteria**: API server rejects invalid enum value.
+This scenario originally validated CRD-level rejection of an invalid `executionEngine`
+enum value. That field was removed from `WorkflowExecutionSpec`; engine resolution and
+rejection now happen at runtime via DataStorage + `ExecutorRegistry`, and are covered by
+`UT-WE-659-002` and `IT-WE-015-001`. No E2E test exists for this ID -- it is intentionally
+retired rather than kept as a placeholder `Skip()`.
 
 ---
 

--- a/test/e2e/workflowexecution/03_job_backend_test.go
+++ b/test/e2e/workflowexecution/03_job_backend_test.go
@@ -532,14 +532,15 @@ var _ = Describe("WorkflowExecution Job Backend E2E (BR-WE-014)", func() {
 	// P1: Edge Cases and Cross-Cutting Concerns
 	// ========================================
 
-	Context("E2E-WE-014-005: Execution engine resolution (runtime)", func() {
-		It("documents that unsupported engines are validated at runtime, not on the WFE Spec (BR-WE-014)", func() {
-			// ExecutionEngine was removed from WorkflowExecutionSpec; the WE controller resolves the engine
-			// from DataStorage and ExecutorRegistry at runtime. An unsupported engine fails reconciliation
-			// rather than API admission. Exercising that failure path in E2E would require mocking DS.
-			Skip("Unsupported execution engine is validated at runtime via ExecutorRegistry; not exercised in E2E without DataStorage mocks")
-		})
-	})
+	// E2E-WE-014-005 ("Invalid executionEngine rejected by API server") is intentionally
+	// absent: ExecutionEngine was removed from WorkflowExecutionSpec, so the CRD-level
+	// admission scenario this test ID originally covered no longer applies. The
+	// replacement runtime behavior (WE controller rejects an unsupported engine resolved
+	// from DataStorage/ExecutorRegistry) is already proven without a permanent Skip():
+	//   - UT-WE-659-002 (pkg/workflowexecution/controller_events_test.go) proves the logic
+	//   - IT-WE-015-001 (test/integration/workflowexecution/ansible_dispatch_integration_test.go)
+	//     proves the controller wiring via envtest with a real reconciler
+	// See docs/testing/BR-WE-014/E2E_TEST_PLAN_BR_WE_014.md for the updated scope note.
 
 	Context("E2E-WE-014-006: Deterministic Job Naming for Resource Locking", func() {
 		It("should use deterministic Job name based on targetResource (BR-WE-014, BR-WE-009)", func() {


### PR DESCRIPTION
## Summary

Removes a permanently-skipped Ginkgo `It()` in the WorkflowExecution E2E suite, found while monitoring PR #1702's `E2E (workflowexecution)` run — its summary reported `1 Skipped`, which violates AGENTS.md Rule 2 ("Never use `XIt`, `PIt`, or `Skip()` to defer test implementation. Either implement the test... or remove it.").

## Root cause

`E2E-WE-014-005` (`test/e2e/workflowexecution/03_job_backend_test.go`) had an `It()` body that consisted **solely** of `Skip("...")` — it skipped unconditionally, on every run, forever:

```go
It("documents that unsupported engines are validated at runtime, not on the WFE Spec (BR-WE-014)", func() {
	Skip("Unsupported execution engine is validated at runtime via ExecutorRegistry; not exercised in E2E without DataStorage mocks")
})
```

This wasn't a flaky or environment-conditional skip — the original test plan scenario (`E2E-WE-014-005`: "Invalid executionEngine rejected by API server") targeted CRD-level enum validation on a `executionEngine` spec field that has since been **removed** from `WorkflowExecutionSpec`. Engine resolution moved to runtime (DataStorage + `ExecutorRegistry`), so the scenario this test ID was written for is obsolete, not merely unimplemented.

## Why no replacement E2E test is added

The replacement runtime behavior (rejecting an unsupported engine) is already fully proven, satisfying the UT-proves-logic / IT-proves-wiring pyramid invariant:

| Tier | Test | Proves |
|------|------|--------|
| Unit | `UT-WE-659-002` (`pkg/workflowexecution/controller_events_test.go`) | Controller emits `WorkflowValidationFailed` for an unsupported engine |
| Integration | `IT-WE-015-001` (`test/integration/workflowexecution/ansible_dispatch_integration_test.go`) | Real controller (envtest, no mocks) sets `FailureDetails.Reason == "UnsupportedEngine"` |

Fabricating an E2E equivalent would require injecting a fake DataStorage catalog entry with a bogus engine just to re-exercise a check already proven at UT/IT — no new business value, and this isn't a SOC2/FedRAMP control objective requiring an E2E proving journey.

## Changes

- `test/e2e/workflowexecution/03_job_backend_test.go`: removed the dead `Context`/`It`/`Skip` block; replaced with a comment explaining the retirement and pointing to the UT/IT coverage.
- `docs/testing/BR-WE-014/E2E_TEST_PLAN_BR_WE_014.md`: moved `E2E-WE-014-005` out of the active P1 table into a new "Superseded" section with rationale; bumped plan version `1.1.0` → `1.2.0`.

No production code changes.

## Verification

- `go build ./test/...` — pass
- `go vet ./test/e2e/workflowexecution/...` — pass
- Grepped `test/e2e/` for other unconditional `Skip()` calls — confirmed the remaining ones are all behind runtime `if` checks (env vars, reachability probes, tool availability), which is the legitimate use case; this was the only unconditional offender.
