### PR TITLE
test(effectivenessmonitor): fix CI flake in UT-EM-DAR-004 timing margin

### DIFF
--- a/pkg/effectivenessmonitor/deadline_aware_requeue_test.go
+++ b/pkg/effectivenessmonitor/deadline_aware_requeue_test.go
@@ -239,13 +239,26 @@ var _ = Describe("Deadline-Aware Requeue (BR-EM-007, Issue #591)", func() {
 	// When remaining time is already at or below the safety margin, the
 	// requeue must not be pushed past the deadline (no negative/zero-clamped
 	// surprises) — it falls back to firing at the remaining time exactly.
+	//
+	// CI flake fix: `remaining` must stay comfortably below
+	// requeueDeadlineSafetyMargin (2s in production) to exercise the
+	// fallback branch, but comfortably above the wall-clock time the
+	// reconciler's full pass (hash/health/alert/metrics checks + fake
+	// client round-trips) actually takes. Previously 500ms — too tight
+	// under a loaded CI runner: `time.Now()` is captured here at seed
+	// time, but the deadline is re-evaluated deep inside Reconcile() via
+	// TimeUntilExpired, which clamps any elapsed-past-deadline duration to
+	// exactly 0 and short-circuits into completion (RequeueAfter=0),
+	// failing the ">0" assertion below even though the requeue-capping
+	// logic itself is correct. 1.5s leaves 3x the original margin while
+	// still exercising the same fallback branch (1.5s < 2s margin).
 	// ========================================
 	It("UT-EM-DAR-004: should fall back to the remaining time when it is already below the safety margin", func() {
 		s := buildScheme()
 		ns := testNs
 		name := "ea-dar-004"
 
-		remaining := 500 * time.Millisecond
+		remaining := 1500 * time.Millisecond
 		deadline := time.Now().Add(remaining)
 		ea := seedAssessingEA(name, deadline)
 		r := makeReconciler(s, ea)


### PR DESCRIPTION
## Summary

Fixes a CI flake on `main` in `Unit Tests (effectivenessmonitor)`, discovered in the post-merge pipeline for PR #1703 (`fix/1701-health-assessed-decay-race`, run [29822313900](https://github.com/jordigilh/kubernaut/actions/runs/29822313900)).

## Root cause

`UT-EM-DAR-004` (`pkg/effectivenessmonitor/deadline_aware_requeue_test.go`) seeds an `EffectivenessAssessment` with a `ValidityDeadline` **500ms** in the future, then asserts `result.RequeueAfter > 0` after a full `Reconcile()` pass (hash check + live health probe + alert check + metrics check, each a fake-client round-trip).

`TimeUntilExpired()` (`pkg/effectivenessmonitor/validity/validity.go`) clamps any elapsed-past-deadline duration to exactly `0`. If the reconcile's wall-clock time exceeds the 500ms budget before reaching the expiry check, the EA is treated as already expired and short-circuits into completion with `RequeueAfter=0` — failing the `>0` assertion.

This is a **test-timing-budget flake**, not a defect in `capRequeueAtDeadline`'s fallback logic itself — the same assertions pass reliably once given enough headroom (see Verification below).

**CI failure**:
```
[FAILED] Behavior: requeue must stay positive even when almost no validity time remains
Expected
    <time.Duration>: 0
to be >
    <int>: 0
```

## Fix

Widen the seeded remaining time in `UT-EM-DAR-004` from 500ms → 1.5s. This:
- Stays below `requeueDeadlineSafetyMargin` (2s in production), so the intended fallback branch is still exercised
- Gives 3x the original headroom for the reconciler's fake-client round-trips to complete before the deadline check runs

No production code changes.

## Evidence the original budget was too tight

A local run of this package's full suite (398 specs across 3 sub-suites) shows individual specs elsewhere in this same package occasionally taking 800-1000ms on this machine alone (e.g. `target_resources_test.go` pod/hash resolution specs) — before accounting for the additional CPU contention of ~20 services' unit-test jobs running concurrently in CI.

## Verification

- Ran the Deadline-Aware Requeue specs 8x sequentially — all pass
- Full `effectivenessmonitor` unit suite: 398 specs, 0 failures
- `golangci-lint run ./pkg/effectivenessmonitor/...`: 0 issues
- `go build ./pkg/effectivenessmonitor/... ./internal/controller/effectivenessmonitor/...`: pass
