### PR TITLE
fix: bump google.golang.org/grpc to v1.82.1 (GHSA-hrxh-6v49-42gf)

### DIFF
--- a/docker/db-migrate.Dockerfile
+++ b/docker/db-migrate.Dockerfile
@@ -26,6 +26,7 @@ RUN GOMODCACHE=$(mktemp -d) && \
     go get github.com/pressly/goose/v3/cmd/goose@v3.27.1 && \
     go get golang.org/x/crypto@v0.53.0 && \
     go get golang.org/x/net@v0.56.0 && \
+    go get google.golang.org/grpc@v1.82.1 && \
     go build -o /go/bin/goose github.com/pressly/goose/v3/cmd/goose
 
 FROM registry.access.redhat.com/ubi10/ubi-minimal:latest@sha256:af74bce19b9ab6446362310c9d18ffb4671ac11b2a4d36263047d9f57a653d80 AS production

--- a/go.mod
+++ b/go.mod
@@ -212,7 +212,7 @@ require (
 	google.golang.org/api v0.279.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260615183401-62b3387ff324 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260610212136-7ab31c22f7ad // indirect
-	google.golang.org/grpc v1.81.1 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -570,8 +570,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260615183401-62b3387ff324 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260615183401-62b3387ff324/go.mod h1:Z4WJ5pJOYWFWcHEQUelD5QaZDknIQkpIL/+fyJOT9+A=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260610212136-7ab31c22f7ad h1:45WmJvIV6C2+O/jjLkPUH+F3aOj/1miDoU2DD0+NWbg=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260610212136-7ab31c22f7ad/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.1 h1:VnnIIZ88UzOOKLukQi+ImGz8O1Wdp8nAGGnvOfEIWQQ=
-google.golang.org/grpc v1.81.1/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af h1:+5/Sw3GsDNlEmu7TfklWKPdQ0Ykja5VEmq2i817+jbI=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary

- Trivy's CVE scan fails CI (`Build (apifrontend|kubernautagent|workflowexecution)/*`, `Build Infra (db-migrate)`, cascading to `Test Suite Summary`/`Merge Gate`) on a HIGH severity finding: `google.golang.org/grpc@v1.81.1` (or `v1.80.0` for db-migrate) is vulnerable per [GHSA-hrxh-6v49-42gf](https://github.com/advisories/GHSA-hrxh-6v49-42gf) (gRPC-Go xDS RBAC and HTTP/2 vulnerabilities), fixed upstream in `v1.82.1`.
- This is a pre-existing, repo-wide issue on `main` — it surfaced while reviewing an unrelated PR (#1709) that happened to trigger these specific build jobs. It blocks any PR touching those services/binaries until fixed.
- Two separate fixes needed, since the vulnerable grpc dependency is pulled in via two independent module graphs:
  1. **Root module** (`go.mod`): grpc is already a direct top-level pin there (resolved via MVS from `kubernetes-mcp-server`, `open-policy-agent/opa`, `prometheus`, `tektoncd/pipeline`, OTel gRPC exporters), so a plain `go get google.golang.org/grpc@v1.82.1 && go mod tidy` is sufficient. Affects `apifrontend`, `kubernautagent`, `workflowexecution`.
  2. **`docker/db-migrate.Dockerfile`**: builds `goose` in an isolated `go mod init tmp` module, entirely separate from the root `go.mod`. Goose's YDB dialect driver (`ydb-platform/ydb-go-genproto`) transitively pulls `grpc@v1.80.0`. Added an explicit `go get google.golang.org/grpc@v1.82.1` in the builder stage, following the existing pattern used for the `golang.org/x/crypto`/`golang.org/x/net` pins there.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `make test-unit-apifrontend` — 24 suites, 0 failures
- [x] `make test-unit-workflowexecution` — 5 suites, 0 failures
- [x] `make test-unit-kubernautagent` — 31 suites, 0 failures
- [x] Rebuilt the `apifrontend` binary locally and confirmed via `go version -m` (same buildinfo source Trivy's `gobinary` analyzer reads) that `google.golang.org/grpc v1.82.1` is now linked, resolving the advisory.
- [x] Reproduced the exact `go mod init tmp` / `go get` / `go build` sequence from `db-migrate.Dockerfile` locally and confirmed via `go version -m` that the resulting `goose` binary links `grpc v1.82.1`. Full container build was blocked locally by a pre-existing podman machine UID/GID namespace issue (unrelated to this change); CI will provide the authoritative image-level Trivy confirmation.