### PR TITLE
fix: namespace-scoped RBAC for fleet ClusterRegistry CRD watch (#1686, BR-RBAC-020)

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -280,7 +280,12 @@ jobs:
           version: latest
 
       - name: Install helm-unittest plugin
-        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.1
+        # --verify=false: azure/setup-helm's "latest" now resolves to Helm v4,
+        # which added plugin provenance verification and refuses to install a
+        # plugin whose source doesn't publish it ("plugin source does not
+        # support verification") unless explicitly opted out. helm-unittest's
+        # releases aren't signed, so this is required, not optional.
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.1 --verify=false
 
       - name: Run helm-unittest specs
         run: helm unittest charts/kubernaut/

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -255,6 +255,36 @@ jobs:
           path: licenses.csv
           retention-days: 90
 
+  # DD-PLATFORM-005 (motivated by #1686/BR-RBAC-020): dedicated fast
+  # fail-fast gate for chart template changes, distinct from helm-smoke-test
+  # (Stage 2+, needs built images and a live Kind cluster, ~30-45min).
+  # helm-unittest asserts specific rendered output (RBAC rule shape,
+  # conditional resources) offline in seconds -- runs in Stage 1 alongside
+  # lint-go/unit-tests instead of waiting on build-images, so a broken
+  # template fails CI in ~1min instead of ~30min.
+  helm-unittest:
+    name: Helm Chart Unit Tests (helm-unittest)
+    needs: [detect-changes]
+    if: needs.detect-changes.outputs.code_changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          submodules: true
+
+      - name: Install Helm
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5.0.1
+        with:
+          version: latest
+
+      - name: Install helm-unittest plugin
+        run: helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.1
+
+      - name: Run helm-unittest specs
+        run: helm unittest charts/kubernaut/
+
   unit-tests:
     name: Unit Tests (${{ matrix.service }})
     needs: [detect-changes]
@@ -1673,7 +1703,7 @@ jobs:
   # ========================================
   summary:
     name: Test Suite Summary
-    needs: [detect-changes, lint-go, unit-tests, build-images, build-infra-images, integration-tests, e2e-tests, helm-smoke-test]
+    needs: [detect-changes, lint-go, unit-tests, build-images, build-infra-images, integration-tests, e2e-tests, helm-unittest, helm-smoke-test]
     if: always() && needs.detect-changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -1946,6 +1976,20 @@ jobs:
             exit 1
           fi
 
+          # Check for Helm chart unit tests (helm-unittest, #1686)
+          if [ "${{ needs.helm-unittest.result }}" == "failure" ]; then
+            echo ""
+            echo "❌ Helm chart unit tests failed - check charts/kubernaut/tests/*.yaml"
+            exit 1
+          elif [ "${{ needs.helm-unittest.result }}" == "skipped" ]; then
+            echo ""
+            echo "⏭️  Helm chart unit tests skipped (dependencies failed)"
+          elif [ "${{ needs.helm-unittest.result }}" == "cancelled" ]; then
+            echo ""
+            echo "⚠️  Helm chart unit tests cancelled"
+            exit 1
+          fi
+
           # Check for Helm smoke test (handle skipped if dependencies failed)
           if [ "${{ needs.helm-smoke-test.result }}" == "failure" ]; then
             echo ""
@@ -1964,6 +2008,7 @@ jobs:
           echo ""
           if [ "${{ needs.integration-tests.result }}" == "success" ] && \
              [ "${{ needs.e2e-tests.result }}" == "success" ] && \
+             [ "${{ needs.helm-unittest.result }}" == "success" ] && \
              [ "${{ needs.helm-smoke-test.result }}" == "success" ]; then
             echo "✅ All tests passed!"
             exit 0
@@ -1985,7 +2030,7 @@ jobs:
     if: always()
     needs: [detect-changes, lint-go, license-scan, unit-tests, build-images,
             build-infra-images,
-            integration-tests, e2e-tests, helm-smoke-test, summary]
+            integration-tests, e2e-tests, helm-unittest, helm-smoke-test, summary]
     runs-on: ubuntu-latest
     steps:
       - name: Evaluate CI results
@@ -2005,6 +2050,7 @@ jobs:
           echo "  build-infra:          ${{ needs.build-infra-images.result }}"
           echo "  integration-tests:    ${{ needs.integration-tests.result }}"
           echo "  e2e-tests:            ${{ needs.e2e-tests.result }}"
+          echo "  helm-unittest:        ${{ needs.helm-unittest.result }}"
           echo "  helm-smoke-test:      ${{ needs.helm-smoke-test.result }}"
           echo "  summary:              ${{ needs.summary.result }}"
           echo ""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -747,6 +747,7 @@ golangci-lint run --timeout=5m
 make test                          # Unit tests
 make test-integration-[service]    # Integration tests
 make test-e2e-[service]           # E2E tests
+make test-helm                    # Helm chart unit tests (helm-unittest, charts/kubernaut/tests/)
 
 # Validation
 make lint-test-patterns           # Test anti-patterns

--- a/Makefile
+++ b/Makefile
@@ -230,9 +230,9 @@ lint: golangci-lint ## Run golangci-lint
 	$(GOLANGCI_LINT) run cmd/... pkg/... internal/... test/...
 
 .PHONY: test-helm
-test-helm: ## Run helm-unittest specs for charts/kubernaut (requires the helm-unittest plugin: helm plugin install https://github.com/helm-unittest/helm-unittest)
+test-helm: ## Run helm-unittest specs for charts/kubernaut (requires the helm-unittest plugin: helm plugin install https://github.com/helm-unittest/helm-unittest --verify=false)
 	@command -v helm >/dev/null 2>&1 || { echo "❌ helm not found; install Helm first"; exit 1; }
-	@helm plugin list 2>/dev/null | grep -q unittest || { echo "❌ helm-unittest plugin not installed; run: helm plugin install https://github.com/helm-unittest/helm-unittest"; exit 1; }
+	@helm plugin list 2>/dev/null | grep -q unittest || { echo "❌ helm-unittest plugin not installed; run: helm plugin install https://github.com/helm-unittest/helm-unittest --verify=false"; exit 1; }
 	helm unittest charts/kubernaut/
 
 .PHONY: clean

--- a/Makefile
+++ b/Makefile
@@ -229,6 +229,12 @@ vet: ## Run go vet against code
 lint: golangci-lint ## Run golangci-lint
 	$(GOLANGCI_LINT) run cmd/... pkg/... internal/... test/...
 
+.PHONY: test-helm
+test-helm: ## Run helm-unittest specs for charts/kubernaut (requires the helm-unittest plugin: helm plugin install https://github.com/helm-unittest/helm-unittest)
+	@command -v helm >/dev/null 2>&1 || { echo "❌ helm not found; install Helm first"; exit 1; }
+	@helm plugin list 2>/dev/null | grep -q unittest || { echo "❌ helm-unittest plugin not installed; run: helm plugin install https://github.com/helm-unittest/helm-unittest"; exit 1; }
+	helm unittest charts/kubernaut/
+
 .PHONY: clean
 clean: ## Clean build artifacts
 	@echo "Cleaning Go artifacts..."

--- a/charts/kubernaut/templates/_helpers.tpl
+++ b/charts/kubernaut/templates/_helpers.tpl
@@ -466,6 +466,77 @@ subjects:
 {{- end }}
 
 {{/*
+Render a namespace-scoped Role + RoleBinding granting a fleet
+ClusterRegistry's CRD watch (MCPServerRegistration for kuadrant;
+Backend/MCPRoute for eaigw), used in place of the equivalent cluster-wide
+ClusterRole rule whenever a service's fleet namespace-scoping knob
+(<service>.fleet.namespace / fleetmetadatacache.namespace) is set (#1686,
+BR-RBAC-020). Each rule is opted in independently via a bool so the exact
+rule content (apiGroups/resources/verbs) matches the ClusterRole variant it
+replaces verbatim -- callers copy the same literal rule block used in their
+own ClusterRole rather than re-typing it, so the two RBAC kinds cannot drift
+apart.
+Params:
+  name                    - resource name prefix (e.g. "apifrontend")
+  serviceAccount          - ServiceAccount name to bind (usually == name)
+  namespace               - namespace to scope the watch/RBAC to
+  appLabels               - pre-rendered "app identifying" label line(s),
+                             e.g. "app: apifrontend" or FMC's two-line
+                             app.kubernetes.io/name+component convention
+  mcpServerRegistrations  - bool: grant mcp.kuadrant.io/mcpserverregistrations
+  kuadrantGateways        - bool: grant gateway.networking.k8s.io/gateways+httproutes (FMC only)
+  eaigwBackends           - bool: grant gateway.envoyproxy.io/backends + aigateway.envoyproxy.io/mcproutes
+  Release, labels         - as in kubernaut.nsRoleForSecrets above
+Usage: {{ include "kubernaut.fleet.registryNsRBAC" (dict "name" "apifrontend" "serviceAccount" "apifrontend" "namespace" $ns "appLabels" "app: apifrontend" "mcpServerRegistrations" true "Release" .Release "labels" (include "kubernaut.labels" .)) }}
+*/}}
+{{- define "kubernaut.fleet.registryNsRBAC" -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .name }}-fleet-registry
+  namespace: {{ .namespace }}
+  labels:
+    {{- .appLabels | nindent 4 }}
+    {{- .labels | nindent 4 }}
+rules:
+  {{- if .mcpServerRegistrations }}
+  - apiGroups: ["mcp.kuadrant.io"]
+    resources: ["mcpserverregistrations"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .kuadrantGateways }}
+  - apiGroups: ["gateway.networking.k8s.io"]
+    resources: ["gateways", "httproutes"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+  {{- if .eaigwBackends }}
+  - apiGroups: ["gateway.envoyproxy.io"]
+    resources: ["backends"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["aigateway.envoyproxy.io"]
+    resources: ["mcproutes"]
+    verbs: ["get", "list", "watch"]
+  {{- end }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .name }}-fleet-registry-binding
+  namespace: {{ .namespace }}
+  labels:
+    {{- .appLabels | nindent 4 }}
+    {{- .labels | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ .name }}-fleet-registry
+subjects:
+  - kind: ServiceAccount
+    name: {{ .serviceAccount }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}
+
+{{/*
 Render affinity and topologySpreadConstraints for a component pod spec.
 DD-PLATFORM-004: injects a default soft (preferred, weight 100) pod
 anti-affinity spreading replicas across nodes by the given matchLabels,

--- a/charts/kubernaut/templates/apifrontend/apifrontend.yaml
+++ b/charts/kubernaut/templates/apifrontend/apifrontend.yaml
@@ -77,7 +77,14 @@ rules:
   - apiGroups: ["authentication.k8s.io"]
     resources: ["tokenreviews"]
     verbs: ["create"]
-  {{- if eq $apifrontendFleetPreamble.config.mcpGatewayType "kuadrant" }}
+  {{- /*
+  #1686 (BR-RBAC-020): the mcpserverregistrations rule is only granted
+  cluster-wide here when no namespace scope is configured. When
+  apifrontend.fleet.namespace is set, the identical rule is granted instead
+  via a namespace-scoped Role/RoleBinding below, matching what the
+  ClusterRegistry informer actually watches (least privilege).
+  */}}
+  {{- if and (eq $apifrontendFleetPreamble.config.mcpGatewayType "kuadrant") (not .Values.apifrontend.fleet.namespace) }}
   # BR-FLEET-054: AF's ClusterRegistry watches MCPServerRegistration CRs
   # directly via a dynamic informer when the Kuadrant MCP Gateway is used.
   - apiGroups: ["mcp.kuadrant.io"]
@@ -100,6 +107,12 @@ subjects:
   - kind: ServiceAccount
     name: apifrontend
     namespace: {{ .Release.Namespace }}
+{{- if and (eq $apifrontendFleetPreamble.config.mcpGatewayType "kuadrant") .Values.apifrontend.fleet.namespace }}
+---
+# #1686 (BR-RBAC-020): namespace-scoped equivalent of the ClusterRole rule
+# above, granted instead of it when apifrontend.fleet.namespace is set.
+{{ include "kubernaut.fleet.registryNsRBAC" (dict "name" "apifrontend" "serviceAccount" "apifrontend" "namespace" .Values.apifrontend.fleet.namespace "appLabels" "app: apifrontend" "mcpServerRegistrations" true "Release" .Release "labels" (include "kubernaut.labels" .)) }}
+{{- end }}
 ---
 # RoleBinding granting AF SA access to KA service (trusted intermediary, #1287)
 apiVersion: rbac.authorization.k8s.io/v1

--- a/charts/kubernaut/templates/effectivenessmonitor/effectivenessmonitor.yaml
+++ b/charts/kubernaut/templates/effectivenessmonitor/effectivenessmonitor.yaml
@@ -127,7 +127,14 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  {{- if eq $effectivenessmonitorFleetPreamble.config.mcpGatewayType "kuadrant" }}
+  {{- /*
+  #1686 (BR-RBAC-020): the mcpserverregistrations rule is only granted
+  cluster-wide here when no namespace scope is configured. When
+  effectivenessmonitor.fleet.namespace is set, the identical rule is
+  granted instead via a namespace-scoped Role/RoleBinding below, matching
+  what the ClusterRegistry informer actually watches (least privilege).
+  */}}
+  {{- if and (eq $effectivenessmonitorFleetPreamble.config.mcpGatewayType "kuadrant") (not .Values.effectivenessmonitor.fleet.namespace) }}
   # BR-FLEET-054: EM's ClusterRegistry watches MCPServerRegistration CRs
   # directly via a dynamic informer when the Kuadrant MCP Gateway is used.
   - apiGroups: ["mcp.kuadrant.io"]
@@ -149,6 +156,12 @@ subjects:
   - kind: ServiceAccount
     name: effectivenessmonitor-controller
     namespace: {{ .Release.Namespace }}
+{{- if and (eq $effectivenessmonitorFleetPreamble.config.mcpGatewayType "kuadrant") .Values.effectivenessmonitor.fleet.namespace }}
+---
+# #1686 (BR-RBAC-020): namespace-scoped equivalent of the ClusterRole rule
+# above, granted instead of it when effectivenessmonitor.fleet.namespace is set.
+{{ include "kubernaut.fleet.registryNsRBAC" (dict "name" "effectivenessmonitor" "serviceAccount" "effectivenessmonitor-controller" "namespace" .Values.effectivenessmonitor.fleet.namespace "appLabels" "app: effectivenessmonitor-controller" "mcpServerRegistrations" true "Release" .Release "labels" (include "kubernaut.labels" .)) }}
+{{- end }}
 ---
 # Issue #545: Bind to built-in view ClusterRole for broad read access to CRDs
 # (cert-manager, Istio, etc.) needed for post-remediation hash capture (DD-EM-002).

--- a/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
+++ b/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
@@ -139,6 +139,15 @@ metadata:
     app.kubernetes.io/name: fleetmetadatacache
     app.kubernetes.io/component: fleet-metadata-cache
     {{- include "kubernaut.labels" . | nindent 4 }}
+{{- /*
+#1686 (BR-RBAC-020): FMC's ClusterRole exists solely to grant its
+ClusterRegistry's CRD watch (there is no other rule in this ClusterRole),
+so when fleetmetadatacache.namespace scopes that watch to one namespace, the
+ClusterRole/ClusterRoleBinding are skipped entirely in favor of the
+namespace-scoped Role/RoleBinding below (least privilege) instead of
+rendering a redundant empty ClusterRole.
+*/}}
+{{- if not .Values.fleetmetadatacache.namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -179,6 +188,12 @@ subjects:
   - kind: ServiceAccount
     name: fleetmetadatacache
     namespace: {{ .Release.Namespace }}
+{{- else }}
+---
+# #1686 (BR-RBAC-020): namespace-scoped equivalent of the ClusterRole rules
+# above, granted instead of them when fleetmetadatacache.namespace is set.
+{{ include "kubernaut.fleet.registryNsRBAC" (dict "name" "fleetmetadatacache" "serviceAccount" "fleetmetadatacache" "namespace" .Values.fleetmetadatacache.namespace "appLabels" "app.kubernetes.io/name: fleetmetadatacache" "mcpServerRegistrations" (eq .Values.fleetmetadatacache.gatewayType "kuadrant") "kuadrantGateways" (eq .Values.fleetmetadatacache.gatewayType "kuadrant") "eaigwBackends" (ne .Values.fleetmetadatacache.gatewayType "kuadrant") "Release" .Release "labels" (include "kubernaut.labels" .)) }}
+{{- end }}
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/charts/kubernaut/templates/signalprocessing/signalprocessing.yaml
+++ b/charts/kubernaut/templates/signalprocessing/signalprocessing.yaml
@@ -139,7 +139,14 @@ rules:
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  {{- if eq $signalprocessingFleetPreamble.config.mcpGatewayType "kuadrant" }}
+  {{- /*
+  #1686 (BR-RBAC-020): the mcpserverregistrations rule is only granted
+  cluster-wide here when no namespace scope is configured. When
+  signalprocessing.fleet.namespace is set, the identical rule is granted
+  instead via a namespace-scoped Role/RoleBinding below, matching what the
+  ClusterRegistry informer actually watches (least privilege).
+  */}}
+  {{- if and (eq $signalprocessingFleetPreamble.config.mcpGatewayType "kuadrant") (not .Values.signalprocessing.fleet.namespace) }}
   # BR-FLEET-003 (#1511): SP's ClusterRegistry watches MCPServerRegistration
   # CRs directly via a dynamic informer to evaluate the `cluster`
   # classification dimension when the Kuadrant MCP Gateway is used.
@@ -162,6 +169,12 @@ subjects:
   - kind: ServiceAccount
     name: signalprocessing-controller
     namespace: {{ .Release.Namespace }}
+{{- if and (eq $signalprocessingFleetPreamble.config.mcpGatewayType "kuadrant") .Values.signalprocessing.fleet.namespace }}
+---
+# #1686 (BR-RBAC-020): namespace-scoped equivalent of the ClusterRole rule
+# above, granted instead of it when signalprocessing.fleet.namespace is set.
+{{ include "kubernaut.fleet.registryNsRBAC" (dict "name" "signalprocessing" "serviceAccount" "signalprocessing-controller" "namespace" .Values.signalprocessing.fleet.namespace "appLabels" "app: signalprocessing-controller" "mcpServerRegistrations" true "Release" .Release "labels" (include "kubernaut.labels" .)) }}
+{{- end }}
 ---
 # Role: namespace-scoped access to configmaps and secrets (#229)
 {{ include "kubernaut.nsRoleForSecrets" (dict "name" "signalprocessing" "serviceAccount" "signalprocessing-controller" "Release" .Release "labels" (include "kubernaut.labels" .)) }}

--- a/charts/kubernaut/tests/fleet_registry_rbac_test.yaml
+++ b/charts/kubernaut/tests/fleet_registry_rbac_test.yaml
@@ -1,0 +1,470 @@
+suite: Fleet ClusterRegistry RBAC least-privilege split (#1686, BR-RBAC-020)
+templates:
+  - templates/signalprocessing/signalprocessing.yaml
+  - templates/fleetmetadatacache/fleetmetadatacache.yaml
+  - templates/apifrontend/apifrontend.yaml
+  - templates/effectivenessmonitor/effectivenessmonitor.yaml
+set:
+  postgresql:
+    auth:
+      existingSecret: dummy
+  valkey:
+    existingSecret: dummy
+  kubernautAgent:
+    llm:
+      provider: openai
+      model: gpt-4
+  signalprocessing:
+    policies:
+      existingConfigMap: test-cm
+  aianalysis:
+    policies:
+      existingConfigMap: test-cm
+  # values.yaml ships a default "sre" persona, which renders a second,
+  # unrelated ClusterRole (kubernaut-tool-sre) for SAR-based tool
+  # authorization. Cleared once here (suite-level) rather than in every AF
+  # test case below, so the `documentSelector: {path: kind, value:
+  # ClusterRole}` used by the AF tests stays unambiguous (exactly one
+  # ClusterRole document) without repeating this override per test.
+  apifrontend:
+    config:
+      rbac:
+        personas: null
+tests:
+  # ---------------------------------------------------------------------
+  # SP (IT-HELM-020-001/002)
+  # ---------------------------------------------------------------------
+  - it: "IT-HELM-020-001: SP namespace-scoped Role replaces the ClusterRole rule when namespace is set"
+    set:
+      signalprocessing:
+        fleet:
+          mcpGatewayType: kuadrant
+          namespace: team-a
+    template: templates/signalprocessing/signalprocessing.yaml
+    documentSelector:
+      path: metadata.name
+      value: signalprocessing-fleet-registry
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.namespace
+          value: team-a
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["mcp.kuadrant.io"]
+            resources: ["mcpserverregistrations"]
+            verbs: ["get", "list", "watch"]
+
+  - it: "IT-HELM-020-001b: SP ClusterRole does NOT contain the fleet rule when namespace is set"
+    set:
+      signalprocessing:
+        fleet:
+          mcpGatewayType: kuadrant
+          namespace: team-a
+    template: templates/signalprocessing/signalprocessing.yaml
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["mcp.kuadrant.io"]
+            resources: ["mcpserverregistrations"]
+            verbs: ["get", "list", "watch"]
+
+  - it: "IT-HELM-020-002: SP retains the ClusterRole rule when namespace is unset (regression guard)"
+    set:
+      signalprocessing:
+        fleet:
+          mcpGatewayType: kuadrant
+          namespace: ""
+    template: templates/signalprocessing/signalprocessing.yaml
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["mcp.kuadrant.io"]
+            resources: ["mcpserverregistrations"]
+            verbs: ["get", "list", "watch"]
+
+  - it: "IT-HELM-020-002b: SP does not render a Role for the fleet registry when namespace is unset"
+    set:
+      signalprocessing:
+        fleet:
+          mcpGatewayType: kuadrant
+          namespace: ""
+    template: templates/signalprocessing/signalprocessing.yaml
+    documentSelector:
+      path: metadata.name
+      value: signalprocessing-fleet-registry
+      skipEmptyTemplates: true
+    asserts:
+      - hasDocuments:
+          count: 0
+          filterAware: true
+
+  # ---------------------------------------------------------------------
+  # FMC — kuadrant branch (IT-HELM-020-003/004)
+  # ---------------------------------------------------------------------
+  - it: "IT-HELM-020-003: FMC (kuadrant) namespace-scoped Role replaces the ClusterRole rules when namespace is set"
+    set:
+      fleetmetadatacache:
+        enabled: true
+        mcpGatewayEndpoint: "http://mcp.example.com"
+        gatewayType: kuadrant
+        namespace: team-a
+        oauth2:
+          tokenURL: "http://oauth.example.com"
+          credentialsSecretRef: "fmc-creds"
+    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.namespace
+          value: team-a
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["mcp.kuadrant.io"]
+            resources: ["mcpserverregistrations"]
+            verbs: ["get", "list", "watch"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["gateway.networking.k8s.io"]
+            resources: ["gateways", "httproutes"]
+            verbs: ["get", "list", "watch"]
+
+  - it: "IT-HELM-020-003b: FMC ClusterRole/ClusterRoleBinding are not rendered at all when namespace is set (kuadrant)"
+    set:
+      fleetmetadatacache:
+        enabled: true
+        mcpGatewayEndpoint: "http://mcp.example.com"
+        gatewayType: kuadrant
+        namespace: team-a
+        oauth2:
+          tokenURL: "http://oauth.example.com"
+          credentialsSecretRef: "fmc-creds"
+    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
+    documentSelector:
+      path: kind
+      value: ClusterRole
+      skipEmptyTemplates: true
+    asserts:
+      - hasDocuments:
+          count: 0
+          filterAware: true
+
+  - it: "IT-HELM-020-004: FMC (kuadrant) retains the ClusterRole rules when namespace is unset (regression guard)"
+    set:
+      fleetmetadatacache:
+        enabled: true
+        mcpGatewayEndpoint: "http://mcp.example.com"
+        gatewayType: kuadrant
+        namespace: ""
+        oauth2:
+          tokenURL: "http://oauth.example.com"
+          credentialsSecretRef: "fmc-creds"
+    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["mcp.kuadrant.io"]
+            resources: ["mcpserverregistrations"]
+            verbs: ["get", "list", "watch"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["gateway.networking.k8s.io"]
+            resources: ["gateways", "httproutes"]
+            verbs: ["get", "list", "watch"]
+
+  - it: "IT-HELM-020-004b: FMC does not render a Role for the fleet registry when namespace is unset"
+    set:
+      fleetmetadatacache:
+        enabled: true
+        mcpGatewayEndpoint: "http://mcp.example.com"
+        gatewayType: kuadrant
+        namespace: ""
+        oauth2:
+          tokenURL: "http://oauth.example.com"
+          credentialsSecretRef: "fmc-creds"
+    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
+    documentSelector:
+      path: metadata.name
+      value: fleetmetadatacache-fleet-registry
+      skipEmptyTemplates: true
+    asserts:
+      - hasDocuments:
+          count: 0
+          filterAware: true
+
+  # ---------------------------------------------------------------------
+  # FMC — eaigw branch (IT-HELM-020-005/006)
+  # ---------------------------------------------------------------------
+  - it: "IT-HELM-020-005: FMC (eaigw) namespace-scoped Role replaces the ClusterRole rules when namespace is set"
+    set:
+      fleetmetadatacache:
+        enabled: true
+        mcpGatewayEndpoint: "http://mcp.example.com"
+        gatewayType: eaigw
+        namespace: team-a
+        oauth2:
+          tokenURL: "http://oauth.example.com"
+          credentialsSecretRef: "fmc-creds"
+    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.namespace
+          value: team-a
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["gateway.envoyproxy.io"]
+            resources: ["backends"]
+            verbs: ["get", "list", "watch"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["aigateway.envoyproxy.io"]
+            resources: ["mcproutes"]
+            verbs: ["get", "list", "watch"]
+
+  - it: "IT-HELM-020-005b: FMC ClusterRole/ClusterRoleBinding are not rendered at all when namespace is set (eaigw)"
+    set:
+      fleetmetadatacache:
+        enabled: true
+        mcpGatewayEndpoint: "http://mcp.example.com"
+        gatewayType: eaigw
+        namespace: team-a
+        oauth2:
+          tokenURL: "http://oauth.example.com"
+          credentialsSecretRef: "fmc-creds"
+    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
+    documentSelector:
+      path: kind
+      value: ClusterRole
+      skipEmptyTemplates: true
+    asserts:
+      - hasDocuments:
+          count: 0
+          filterAware: true
+
+  - it: "IT-HELM-020-006: FMC (eaigw) retains the ClusterRole rules when namespace is unset (regression guard)"
+    set:
+      fleetmetadatacache:
+        enabled: true
+        mcpGatewayEndpoint: "http://mcp.example.com"
+        gatewayType: eaigw
+        namespace: ""
+        oauth2:
+          tokenURL: "http://oauth.example.com"
+          credentialsSecretRef: "fmc-creds"
+    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["gateway.envoyproxy.io"]
+            resources: ["backends"]
+            verbs: ["get", "list", "watch"]
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["aigateway.envoyproxy.io"]
+            resources: ["mcproutes"]
+            verbs: ["get", "list", "watch"]
+
+  # ---------------------------------------------------------------------
+  # AF (IT-HELM-020-007/008)
+  # ---------------------------------------------------------------------
+  - it: "IT-HELM-020-007: AF namespace-scoped Role replaces the ClusterRole rule when namespace is set"
+    set:
+      apifrontend:
+        fleet:
+          enabled: true
+          mcpGatewayEndpoint: "http://mcp.example.com"
+          mcpGatewayType: kuadrant
+          namespace: team-a
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.namespace
+          value: team-a
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["mcp.kuadrant.io"]
+            resources: ["mcpserverregistrations"]
+            verbs: ["get", "list", "watch"]
+
+  - it: "IT-HELM-020-007b: AF ClusterRole does NOT contain the fleet rule when namespace is set"
+    set:
+      apifrontend:
+        fleet:
+          enabled: true
+          mcpGatewayEndpoint: "http://mcp.example.com"
+          mcpGatewayType: kuadrant
+          namespace: team-a
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["mcp.kuadrant.io"]
+            resources: ["mcpserverregistrations"]
+            verbs: ["get", "list", "watch"]
+
+  - it: "IT-HELM-020-008: AF retains the ClusterRole rule when namespace is unset (regression guard)"
+    set:
+      apifrontend:
+        fleet:
+          enabled: true
+          mcpGatewayEndpoint: "http://mcp.example.com"
+          mcpGatewayType: kuadrant
+          namespace: ""
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["mcp.kuadrant.io"]
+            resources: ["mcpserverregistrations"]
+            verbs: ["get", "list", "watch"]
+
+  - it: "IT-HELM-020-008b: AF does not render a Role for the fleet registry when namespace is unset"
+    set:
+      apifrontend:
+        fleet:
+          enabled: true
+          mcpGatewayEndpoint: "http://mcp.example.com"
+          mcpGatewayType: kuadrant
+          namespace: ""
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: metadata.name
+      value: apifrontend-fleet-registry
+      skipEmptyTemplates: true
+    asserts:
+      - hasDocuments:
+          count: 0
+          filterAware: true
+
+  # ---------------------------------------------------------------------
+  # EM (IT-HELM-020-009/010)
+  # ---------------------------------------------------------------------
+  - it: "IT-HELM-020-009: EM namespace-scoped Role replaces the ClusterRole rule when namespace is set"
+    set:
+      effectivenessmonitor:
+        fleet:
+          enabled: true
+          mcpGatewayEndpoint: "http://mcp.example.com"
+          mcpGatewayType: kuadrant
+          namespace: team-a
+    template: templates/effectivenessmonitor/effectivenessmonitor.yaml
+    documentSelector:
+      path: kind
+      value: Role
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.namespace
+          value: team-a
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["mcp.kuadrant.io"]
+            resources: ["mcpserverregistrations"]
+            verbs: ["get", "list", "watch"]
+
+  - it: "IT-HELM-020-009b: EM ClusterRole does NOT contain the fleet rule when namespace is set"
+    set:
+      effectivenessmonitor:
+        fleet:
+          enabled: true
+          mcpGatewayEndpoint: "http://mcp.example.com"
+          mcpGatewayType: kuadrant
+          namespace: team-a
+    template: templates/effectivenessmonitor/effectivenessmonitor.yaml
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - notContains:
+          path: rules
+          content:
+            apiGroups: ["mcp.kuadrant.io"]
+            resources: ["mcpserverregistrations"]
+            verbs: ["get", "list", "watch"]
+
+  - it: "IT-HELM-020-010: EM retains the ClusterRole rule when namespace is unset (regression guard)"
+    set:
+      effectivenessmonitor:
+        fleet:
+          enabled: true
+          mcpGatewayEndpoint: "http://mcp.example.com"
+          mcpGatewayType: kuadrant
+          namespace: ""
+    template: templates/effectivenessmonitor/effectivenessmonitor.yaml
+    documentSelector:
+      path: kind
+      value: ClusterRole
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: ["mcp.kuadrant.io"]
+            resources: ["mcpserverregistrations"]
+            verbs: ["get", "list", "watch"]
+
+  - it: "IT-HELM-020-010b: EM does not render a Role for the fleet registry when namespace is unset"
+    set:
+      effectivenessmonitor:
+        fleet:
+          enabled: true
+          mcpGatewayEndpoint: "http://mcp.example.com"
+          mcpGatewayType: kuadrant
+          namespace: ""
+    template: templates/effectivenessmonitor/effectivenessmonitor.yaml
+    documentSelector:
+      path: metadata.name
+      value: effectivenessmonitor-fleet-registry
+      skipEmptyTemplates: true
+    asserts:
+      - hasDocuments:
+          count: 0
+          filterAware: true

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -898,6 +898,7 @@
             "enabled": { "type": "boolean", "default": false },
             "mcpGatewayEndpoint": { "type": "string", "default": "", "description": "MCP Gateway endpoint URL for remote cluster reads. Optional; falls back to global.fleet.mcpGatewayEndpoint when unset" },
             "mcpGatewayType": { "type": "string", "default": "", "description": "MCP Gateway type: eaigw or kuadrant. Falls back to global.fleet.mcpGatewayType when unset" },
+            "namespace": { "type": "string", "default": "", "description": "Restricts the ClusterRegistry CRD watch to a single namespace instead of cluster-wide (BR-RBAC-020, #1686). Empty (default) watches all namespaces and grants cluster-wide RBAC" },
             "tlsCAFile": { "type": "string", "default": "", "description": "Path to a CA bundle for verifying the MCP Gateway's TLS certificate. Falls back to global.fleet.tlsCAFile, then to the shared inter-service CA, when unset" },
             "oauth2": { "$ref": "#/definitions/fleetOAuth2" }
           }
@@ -1211,6 +1212,7 @@
             "enabled": { "type": "boolean", "default": false },
             "mcpGatewayEndpoint": { "type": "string", "default": "", "description": "MCP Gateway endpoint URL for remote cluster reads. Optional; falls back to global.fleet.mcpGatewayEndpoint when unset" },
             "mcpGatewayType": { "type": "string", "default": "", "description": "MCP Gateway type: eaigw or kuadrant. Falls back to global.fleet.mcpGatewayType when unset" },
+            "namespace": { "type": "string", "default": "", "description": "Restricts the ClusterRegistry CRD watch to a single namespace instead of cluster-wide (BR-RBAC-020, #1686). Empty (default) watches all namespaces and grants cluster-wide RBAC" },
             "tlsCAFile": { "type": "string", "default": "", "description": "Path to a CA bundle for verifying the MCP Gateway's TLS certificate. Falls back to global.fleet.tlsCAFile, then to the shared inter-service CA, when unset" },
             "oauth2": { "$ref": "#/definitions/fleetOAuth2" }
           }

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -505,6 +505,10 @@ effectivenessmonitor:
     # -- Optional: falls back to global.fleet.mcpGatewayEndpoint when unset.
     mcpGatewayEndpoint: ""  # e.g., "http://envoy-ai-gateway.kubernaut-system.svc:8080/mcp"
     mcpGatewayType: ""      # "eaigw" or "kuadrant"; falls back to global.fleet.mcpGatewayType when unset
+    # -- Restricts the ClusterRegistry CRD watch to a single namespace instead of
+    # cluster-wide (BR-RBAC-020, #1686). Empty (default) watches all namespaces and
+    # grants cluster-wide RBAC, matching pre-#1686 behavior.
+    namespace: ""
     # -- Path to a CA bundle for verifying the MCP Gateway's TLS certificate. Falls
     # back to global.fleet.tlsCAFile, then to the shared inter-service CA already
     # mounted at /etc/tls-ca/ca.crt, when unset.
@@ -938,6 +942,10 @@ apifrontend:
     # -- Optional: falls back to global.fleet.mcpGatewayEndpoint when unset.
     mcpGatewayEndpoint: ""  # e.g., "http://envoy-ai-gateway.kubernaut-system.svc:8080/mcp"
     mcpGatewayType: ""      # "eaigw" or "kuadrant"; falls back to global.fleet.mcpGatewayType when unset
+    # -- Restricts the ClusterRegistry CRD watch to a single namespace instead of
+    # cluster-wide (BR-RBAC-020, #1686). Empty (default) watches all namespaces and
+    # grants cluster-wide RBAC, matching pre-#1686 behavior.
+    namespace: ""
     # -- Path to a CA bundle for verifying the MCP Gateway's TLS certificate. Falls
     # back to global.fleet.tlsCAFile, then to the shared inter-service CA already
     # mounted at /etc/tls-ca/ca.crt, when unset.

--- a/cmd/apifrontend/backend_deps.go
+++ b/cmd/apifrontend/backend_deps.go
@@ -517,7 +517,10 @@ func buildFleetReaderDeps(ctx context.Context, cfg *config.Config, deps *backend
 	clusterRegistry, err := registry.NewClusterRegistry(
 		cfg.Fleet.EffectiveMCPGatewayType(),
 		deps.k8sDynClient,
-		registry.RegistryConfig{},
+		// #1686/BR-RBAC-020: thread Fleet.Namespace through so the watch (and
+		// the RBAC granted to match it) can be scoped to a single namespace
+		// instead of always defaulting to cluster-wide.
+		registry.RegistryConfig{Namespace: cfg.Fleet.Namespace},
 		registry.NewMetrics(),
 		fleetLog,
 	)

--- a/cmd/apifrontend/fleet_wiring_test.go
+++ b/cmd/apifrontend/fleet_wiring_test.go
@@ -172,6 +172,65 @@ func TestBuildFleetReaderDeps_EnabledUnreachableEndpoint_DegradesGracefully(t *t
 	t.Cleanup(deps.fleetReadinessGate.Stop)
 }
 
+// TestBuildFleetReaderDeps_Enabled_WithNamespace_ScopesClusterRegistryWatch is
+// IT-AF-020-001 (#1686, BR-RBAC-020): proves cmd/apifrontend threads
+// Config.Fleet.Namespace into registry.RegistryConfig instead of always
+// passing registry.RegistryConfig{} — the previously-hardcoded gap that
+// forced a cluster-wide watch (and matching cluster-wide RBAC) even when an
+// operator configured a namespace scope. Asserted via the fake dynamic
+// client's recorded actions: EAIGWRegistry's informer factory
+// (NewFilteredDynamicSharedInformerFactory) issues its list/watch calls
+// against whatever namespace RegistryConfig.Namespace carries.
+func TestBuildFleetReaderDeps_Enabled_WithNamespace_ScopesClusterRegistryWatch(t *testing.T) {
+	t.Parallel()
+
+	gw := mockgw.NewMockGateway()
+	t.Cleanup(gw.Close)
+
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), backendGVRListKinds)
+
+	deps := &backendDeps{k8sDynClient: dynClient}
+	cfg := &config.Config{}
+	cfg.Fleet.Enabled = true
+	cfg.Fleet.MCPGatewayEndpoint = gw.URL()
+	cfg.Fleet.MCPGatewayType = registry.GatewayEAIGW
+	cfg.Fleet.Namespace = "team-a"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	err := buildFleetReaderDeps(ctx, cfg, deps, logr.Discard())
+	if err != nil {
+		t.Fatalf("IT-AF-020-001: unexpected error wiring fleet reader deps: %v", err)
+	}
+	if fc := deps.FleetResilientClient(); fc != nil {
+		defer func() { _ = fc.Close() }()
+	}
+	if deps.fleetReadinessGate != nil {
+		defer deps.fleetReadinessGate.Stop()
+	}
+
+	if deps.FleetClusterRegistry == nil {
+		t.Fatal("IT-AF-020-001: FleetClusterRegistry must be wired when fleet is enabled")
+	}
+
+	scoped := false
+	for _, action := range dynClient.Actions() {
+		if action.GetResource() != registry.BackendGVR {
+			continue
+		}
+		if action.GetNamespace() == "team-a" {
+			scoped = true
+			break
+		}
+	}
+	if !scoped {
+		t.Error("IT-AF-020-001: Config.Fleet.Namespace must thread into registry.RegistryConfig.Namespace — " +
+			"expected the ClusterRegistry's informer to List/Watch backends.gateway.envoyproxy.io scoped to " +
+			"namespace \"team-a\", but no such namespaced action was recorded (BR-RBAC-020, #1686)")
+	}
+}
+
 // stubFleetClusterRegistry is a minimal registry.ClusterRegistry for testing
 // AgentConfig threading without a live MCP Gateway or CRD watcher.
 type stubFleetClusterRegistry struct{}

--- a/cmd/effectivenessmonitor/fleet_wiring_test.go
+++ b/cmd/effectivenessmonitor/fleet_wiring_test.go
@@ -119,6 +119,60 @@ func TestBuildFleetReaderFactory_Enabled_WiresReaderFactory(t *testing.T) {
 	}
 }
 
+// TestBuildFleetReaderFactory_Enabled_WithNamespace_ScopesClusterRegistryWatch
+// is IT-EM-020-001 (#1686, BR-RBAC-020): proves cmd/effectivenessmonitor
+// threads Config.Fleet.Namespace into registry.RegistryConfig instead of
+// always passing registry.RegistryConfig{} — the previously-hardcoded gap
+// that forced a cluster-wide watch (and matching cluster-wide RBAC) even
+// when an operator configured a namespace scope. Asserted via the fake
+// dynamic client's recorded actions: EAIGWRegistry's informer factory
+// (NewFilteredDynamicSharedInformerFactory) issues its list/watch calls
+// against whatever namespace RegistryConfig.Namespace carries.
+func TestBuildFleetReaderFactory_Enabled_WithNamespace_ScopesClusterRegistryWatch(t *testing.T) {
+	t.Parallel()
+
+	gw := mockgw.NewMockGateway()
+	t.Cleanup(gw.Close)
+
+	localClient := crfake.NewClientBuilder().WithScheme(runtime.NewScheme()).Build()
+	dynClient := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), backendGVRListKinds)
+	cfg := config.DefaultConfig()
+	cfg.Fleet.Enabled = true
+	cfg.Fleet.MCPGatewayEndpoint = gw.URL()
+	cfg.Fleet.MCPGatewayType = registry.GatewayEAIGW
+	cfg.Fleet.Namespace = "team-a"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	rf, fc, err := buildFleetReaderFactory(ctx, localClient, dynClient, cfg, logr.Discard())
+	if err != nil {
+		t.Fatalf("IT-EM-020-001: unexpected error wiring fleet reader factory: %v", err)
+	}
+	if fc != nil {
+		t.Cleanup(func() { _ = fc.Close() })
+	}
+	if rf == nil {
+		t.Fatal("IT-EM-020-001: fleet.ReaderFactory must be wired when fleet is enabled")
+	}
+
+	scoped := false
+	for _, action := range dynClient.Actions() {
+		if action.GetResource() != registry.BackendGVR {
+			continue
+		}
+		if action.GetNamespace() == "team-a" {
+			scoped = true
+			break
+		}
+	}
+	if !scoped {
+		t.Error("IT-EM-020-001: Config.Fleet.Namespace must thread into registry.RegistryConfig.Namespace — " +
+			"expected the ClusterRegistry's informer to List/Watch backends.gateway.envoyproxy.io scoped to " +
+			"namespace \"team-a\", but no such namespaced action was recorded (BR-RBAC-020, #1686)")
+	}
+}
+
 // TestBuildFleetReaderFactory_EnabledUnreachableEndpoint_DegradesGracefully
 // pins the fail-open contract for an unreachable Fleet MCP Gateway endpoint
 // at the ReaderFactory/error level (mirrors GW's

--- a/cmd/effectivenessmonitor/main.go
+++ b/cmd/effectivenessmonitor/main.go
@@ -486,7 +486,10 @@ func buildFleetReaderFactory(ctx context.Context, localClient client.Client, dyn
 	clusterRegistry, err := registry.NewClusterRegistry(
 		cfg.Fleet.EffectiveMCPGatewayType(),
 		dynClient,
-		registry.RegistryConfig{},
+		// #1686/BR-RBAC-020: thread Fleet.Namespace through so the watch (and
+		// the RBAC granted to match it) can be scoped to a single namespace
+		// instead of always defaulting to cluster-wide.
+		registry.RegistryConfig{Namespace: cfg.Fleet.Namespace},
 		registry.NewMetrics(),
 		fleetLog,
 	)

--- a/docs/architecture/decisions/DD-PLATFORM-005-helm-unittest-ci-integration.md
+++ b/docs/architecture/decisions/DD-PLATFORM-005-helm-unittest-ci-integration.md
@@ -1,0 +1,162 @@
+# DD-PLATFORM-005: helm-unittest as a Dedicated Fast-Fail CI Gate
+
+**Date**: July 23, 2026
+**Status**: ✅ **APPROVED**
+**Confidence**: 92%
+**Last Reviewed**: July 23, 2026
+**Related**: Issue #1686 (Fleet ClusterRegistry RBAC least-privilege split, BR-RBAC-020),
+`charts/kubernaut/tests/` (pre-existing `helm-unittest` specs, previously never run in CI)
+
+---
+
+## 🎯 **DECISION**
+
+**`helm-unittest` is wired into `ci-pipeline.yml` as its own job (`helm-unittest`),
+scheduled in Stage 1 alongside `lint-go`/`license-scan`/`unit-tests` (depends only
+on `detect-changes`), rather than folded into the existing `helm-smoke-test` job
+or left unintegrated.** A `make test-helm` target is added for local parity.
+
+---
+
+## 📊 **Context & Problem**
+
+`charts/kubernaut/tests/*.yaml` already contained 8 `helm-unittest` suites (81
+test cases) covering RBAC conditionals, TLS mode branching, sync-wave ordering,
+and default-hardening behavior — an established, working pattern in this repo.
+None of it ran in CI: `ci-pipeline.yml` had no `helm unittest` invocation
+anywhere. The only chart validation gate was `helm-smoke-test`, which installs
+the full chart into a live Kind cluster and asserts pods come up healthy —
+useful for catching install-time failures, but unable to assert *specific*
+rendered output (e.g. "does this ClusterRole contain rule X when value Y is
+set") the way `helm-unittest`'s `contains`/`notContains`/`documentSelector`
+assertions can.
+
+Implementing #1686 (BR-RBAC-020: namespace-scoped RBAC instead of unconditional
+cluster-wide grants) needed exactly this kind of assertion — "the ClusterRole
+does NOT contain rule X, and a namespace-scoped Role DOES" — which motivated
+finally wiring the existing `helm-unittest` specs into CI rather than relying
+solely on manual `helm template | grep` verification.
+
+---
+
+## 🔍 **Alternatives Considered**
+
+### **Option A: Dedicated `helm-unittest` job in Stage 1** ✅ **CHOSEN**
+
+**Approach**: New job depending only on `detect-changes`, running in parallel
+with `lint-go`/`unit-tests` (~1 minute: checkout + `helm plugin install` +
+`helm unittest`). Wired into `summary` and `merge-gate` `needs:` lists.
+
+**Pros**:
+- ✅ Fails fast (~1 min) on a broken template, long before the ~30-45 min
+  `helm-smoke-test` (which needs `build-images` + a live Kind cluster) would
+  ever catch the same defect
+- ✅ No new infra dependency (no cluster, no built images) — pure offline
+  chart rendering + assertion
+- ✅ Assertion granularity `helm-smoke-test` cannot match (specific rule
+  presence/absence, conditional resource counts) without turning the smoke
+  test into an unmaintainable pile of `kubectl get -o yaml | grep`
+
+**Cons**:
+- ❌ One more job in an already-long pipeline (mitigated: ~1 min, runs in
+  parallel with existing Stage 1 jobs, adds ~0 min to total wall-clock time)
+
+**Confidence**: 92% (approved)
+
+---
+
+### **Option B: Fold into `helm-smoke-test`**
+
+**Approach**: Add a `helm unittest charts/kubernaut/` step inside the existing
+`helm-smoke-test` job, before the `helm install` steps.
+
+**Pros**:
+- ✅ No new job in the pipeline's job graph
+
+**Cons**:
+- ❌ `helm-smoke-test` needs `build-images`/`build-infra-images` first (Stage
+  2+) — a pure-template bug would only surface after waiting on image builds,
+  losing the fast-fail benefit that's the whole point of a unit-test tier
+- ❌ `helm-smoke-test` already runs a `tls_mode` matrix (`hook`,
+  `cert-manager`) at 30-45 min each; conflating "assert rendered YAML shape"
+  with "assert the chart installs and pods become healthy" mixes two
+  different test tiers (unit vs. integration) into one job, working against
+  the same Pyramid Invariant principle this project applies to Go tests
+
+**Confidence**: N/A (rejected)
+
+---
+
+### **Option C: Leave unintegrated (status quo)**
+
+**Approach**: Keep `helm-unittest` specs as a local-only, `make`-less,
+CI-less convenience never enforced on PRs.
+
+**Pros**:
+- ✅ Zero pipeline changes
+
+**Cons**:
+- ❌ 81 pre-existing test cases (now 100 with #1686's additions) provide no
+  actual regression protection — anyone can merge a chart change that
+  silently breaks them, since nothing runs them
+- ❌ Directly contradicts the reason `helm-unittest` specs were written in
+  the first place (RBAC/TLS-mode/sync-wave regression guards)
+
+**Confidence**: N/A (rejected — this was literally the pre-#1686 status quo
+being fixed)
+
+---
+
+## Decision
+
+**APPROVED: Option A** — dedicated Stage-1 `helm-unittest` job.
+
+**Rationale**:
+1. **Fast-fail economics**: a chart template regression should fail in ~1
+   minute, not ~30-45 minutes behind image builds and a live cluster
+2. **Tier separation**: `helm-unittest` (offline, rendered-YAML assertions) and
+   `helm-smoke-test` (live cluster, install/health) are different test tiers
+   with different failure modes worth keeping distinguishable in CI output
+3. **Zero net wall-clock cost**: runs in parallel with existing Stage 1 jobs,
+   which are already the pipeline's critical-path floor
+
+---
+
+## Implementation
+
+**Primary Implementation Files**:
+- `.github/workflows/ci-pipeline.yml` — new `helm-unittest` job (Stage 1,
+  `needs: [detect-changes]`); added to `summary` and `merge-gate` `needs:`
+  lists and status-reporting steps
+- `Makefile` — new `test-helm` target (local parity, guards on the plugin
+  being installed)
+- `charts/kubernaut/tests/fleet_registry_rbac_test.yaml` — first suite
+  written expecting to run in CI (19 cases, #1686/BR-RBAC-020)
+
+**Pinned versions**: `helm-unittest` plugin `v1.1.1` (latest tag at time of
+writing); `azure/setup-helm` reuses the same pinned SHA already used by
+`helm-smoke-test` for consistency.
+
+### Consequences
+
+**Positive**:
+- ✅ 100 `helm-unittest` cases now enforced on every PR touching
+  `charts/**`/`Makefile`/`.github/workflows/**` (per existing
+  `detect-changes` filters — no filter changes needed)
+- ✅ Local dev parity via `make test-helm`
+
+**Negative**:
+- ⚠️ One more required check in `merge-gate`'s `needs:` list — **Mitigation**:
+  negligible wall-clock cost (parallel, ~1 min); `merge-gate`'s existing
+  generic `contains(needs.*.result, 'failure')` check needed no new logic
+
+**Neutral**:
+- 🔄 Establishes the pattern for future chart-behavior assertions to land as
+  `helm-unittest` specs (enforced) rather than only `helm-smoke-test`
+  installs (which can't assert specific rendered content) or ad hoc manual
+  `helm template` checks (which aren't enforced at all)
+
+### Related Decisions
+- **Builds On**: pre-existing `charts/kubernaut/tests/*.yaml` suites (never
+  previously CI-enforced)
+- **Supports**: BR-RBAC-020 (#1686)

--- a/docs/testing/1686/TEST_PLAN.md
+++ b/docs/testing/1686/TEST_PLAN.md
@@ -248,7 +248,7 @@ pre-fix output for any of the 4 charts.
 ## 10. Environmental Needs
 
 - **Unit/Integration**: Ginkgo/Gomega BDD (mandatory), `go test`, no external infra.
-- **Helm**: `helm` CLI + `helm-unittest` plugin (`helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.1`), no cluster needed.
+- **Helm**: `helm` CLI + `helm-unittest` plugin (`helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.1 --verify=false` — `--verify=false` is required on Helm v4+, which added plugin signature verification that helm-unittest's unsigned releases don't satisfy), no cluster needed.
 
 ---
 

--- a/docs/testing/1686/TEST_PLAN.md
+++ b/docs/testing/1686/TEST_PLAN.md
@@ -1,0 +1,310 @@
+# Test Plan: Fleet ClusterRegistry RBAC Least-Privilege Split
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-1686-v1.0
+**Feature**: Namespace-scoped `Role`/`RoleBinding` instead of a cluster-wide `ClusterRole` rule for
+the fleet `ClusterRegistry` CRD watch, whenever the watch itself is scoped to a single namespace,
+across SignalProcessing (SP), FleetMetadataCache (FMC), APIFrontend (AF), and EffectivenessMonitor (EM).
+**Version**: 1.0
+**Created**: 2026-07-23
+**Author**: AI Agent (Cursor)
+**Status**: ✅ Complete — all tests passing, implementation merged to branch
+**Branch**: `fix/1686-fleet-registry-rbac-least-privilege`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+SP/FMC/AF/EM each construct a `pkg/fleet/registry.ClusterRegistry` that watches MCP Gateway CRDs
+(`MCPServerRegistration` for Kuadrant; `Backend`/`MCPRoute` for Envoy AI Gateway) to discover
+fleet-managed clusters. The registry supports scoping this watch to a single namespace
+(`RegistryConfig.Namespace`), but the Helm chart always grants a cluster-wide `ClusterRole` rule for
+these CRDs regardless of whether the namespace scoping knob is set — an avoidable least-privilege
+violation (FedRAMP AC-6/CM-6). This test plan proves: (a) the two previously-hardcoded config paths
+(AF, EM) now thread `Namespace` through to `RegistryConfig`, and (b) all four Helm charts render a
+namespace-scoped `Role`+`RoleBinding` instead of the cluster-wide rule whenever a namespace is
+configured, with zero behavior change when it is not (backward compatibility).
+
+### 1.2 Objectives
+
+1. **Go wiring**: `fleet.FleetConfig.Namespace` (new field) flows into `registry.RegistryConfig.Namespace`
+   for both AF and EM, matching the pattern SP/FMC already have.
+2. **RBAC split**: For each of SP/FMC/AF/EM, the fleet CRD watch rule is granted via a namespace-scoped
+   `Role`+`RoleBinding` when a namespace is configured, and via the existing cluster-wide `ClusterRole`
+   rule when it is not (default, unchanged for current deployments).
+3. **Backward compatibility**: default (`namespace` unset) rendering is byte-for-byte unchanged from
+   pre-fix output for all 4 charts.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./pkg/fleet/...` |
+| Integration test pass rate | 100% | `go test ./cmd/apifrontend/... ./cmd/effectivenessmonitor/...` |
+| Helm-unittest pass rate | 100% | `helm unittest charts/kubernaut/` |
+| Backward compatibility | 0 regressions | Existing `helm-unittest`/`helm-smoke-test` suites pass unmodified |
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- BR-RBAC-020: "MUST implement least-privilege access by default" (`docs/requirements/11_SECURITY_ACCESS_CONTROL.md`)
+- FedRAMP AC-6 (Least Privilege), CM-6 (Configuration Settings)
+- Issue #1686: Fleet ClusterRegistry RBAC: cluster-wide ClusterRole granted even when `namespace`
+  scopes the watch to one namespace
+- Prior art (same class of fix): `jordigilh/kubernaut-operator#223` (ADR-068 fleet triage,
+  `mcpGatewayNamespace`)
+- DD-PLATFORM-004 (chart default hardening): establishes `helm-unittest` as the chart's unit-test
+  convention this plan extends
+
+### 2.2 Cross-References
+
+- [Testing Strategy](../../.cursor/rules/03-testing-strategy.mdc)
+- `charts/kubernaut/tests/tls_mode_test.yaml` — existing precedent for conditional-RBAC helm-unittest specs
+- `charts/kubernaut/templates/_helpers.tpl` (`kubernaut.nsRoleForSecrets`) — existing precedent for a
+  namespace-scoped `Role`/`RoleBinding` named template
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | RBAC split accidentally breaks default (namespace-unset) deployments by omitting the `ClusterRole` rule | High — fleet classification silently stops working for existing installs | Low | `IT-HELM-020-002/004/006/008` (regression guards) | Explicit "namespace empty" test case per service asserting the `ClusterRole` rule is still present |
+| R2 | Namespace-scoped `Role`/`RoleBinding` omits a required verb/resource present in the `ClusterRole` variant | Medium — ClusterRegistry watch fails with Forbidden in namespace-scoped mode | Low | `IT-HELM-020-001/003/005/007` | Assert exact rule content (apiGroups/resources/verbs) matches the `ClusterRole` variant it replaces |
+| R3 | AF/EM's shared `fleet.FleetConfig.Namespace` field addition silently breaks GW/RO (also embed `FleetConfig`) | Low — GW/RO never call `NewClusterRegistry` directly | Low | `UT-FLEET-020-001` | Additive `omitempty` field; existing `FleetConfig` UT suite (`pkg/fleet/fleet_test.go`) re-run as regression guard |
+
+### 3.1 Risk-to-Test Traceability
+
+All three risks (R1–R3) have a directly mapped test; no coverage gaps.
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **`fleet.FleetConfig`** (`pkg/fleet/config.go`): new `Namespace` field YAML round-trip.
+- **AF fleet wiring** (`cmd/apifrontend/backend_deps.go: buildFleetReaderDeps`): `Namespace` threads
+  into `registry.RegistryConfig`.
+- **EM fleet wiring** (`cmd/effectivenessmonitor/main.go: buildFleetReaderFactory`): `Namespace`
+  threads into `registry.RegistryConfig`.
+- **Helm RBAC rendering** (4 templates: `signalprocessing.yaml`, `fleetmetadatacache.yaml`,
+  `apifrontend.yaml`, `effectivenessmonitor.yaml`): namespace-scoped `Role`/`RoleBinding` vs.
+  cluster-wide `ClusterRole` rule, gated on the relevant `*.fleet.namespace` (or `*.namespace` for FMC)
+  value.
+
+### 4.2 Features Not to be Tested
+
+- The `ClusterRegistry`/informer's own namespace-scoped List/Watch behavior (`pkg/fleet/registry`) —
+  already implemented and tested prior to #1686; this plan only proves the RBAC *granted* matches
+  what the watch actually *needs*.
+- CI wiring of `helm-unittest` itself (new job, Makefile target) — verified by the CI run on this PR,
+  not a Ginkgo/helm-unittest test.
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Add `Namespace` to the *shared* `fleet.FleetConfig` (not a new AF/EM-local struct) | Matches the struct's existing purpose (shared by GW/RO/AF/EM); avoids duplicating SP's local-struct pattern for two more services; additive `omitempty` field is a no-op for GW/RO, which never call `NewClusterRegistry` |
+| New `kubernaut.fleet.registryNsRBAC` Helm helper (not 4 inline copies) | Mirrors the existing `kubernaut.nsRoleForSecrets` DRY pattern already used in this chart |
+| helm-unittest (not a Go-based `os/exec helm template` harness) | Already the chart's established unit-test convention (DD-PLATFORM-001..004); avoids introducing a second, competing test mechanism |
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+- **Unit**: `pkg/fleet/config.go`'s new field — pure data, covered by YAML round-trip UT.
+- **Integration**: AF/EM wiring — proven via existing `buildFleetReaderDeps`/`buildFleetReaderFactory`
+  IT harnesses (fake dynamic client + mock MCP gateway), extended with a `Namespace`-set case.
+- **Helm (requirements-based, not line-coverage)**: all 4 templates' RBAC rendering, both branches
+  (namespace set / unset) — proven via `helm-unittest` `documentSelector`+`contains`/`notContains`
+  assertions, mirroring `tls_mode_test.yaml`'s existing style.
+
+### 5.2 Two-Tier Minimum
+
+Go wiring (AF/EM): UT (field round-trip) + IT (wiring through production entry point). Helm RBAC:
+covered by `helm-unittest` only — there is no meaningful "unit" tier below chart-template rendering,
+and no live-cluster E2E tier is warranted for a pure RBAC-shape change (the existing Kind-based
+`helm-smoke-test.yml` already proves the chart installs cleanly with the changed templates as a
+regression net, not a new test written for this issue).
+
+### 5.4 Pass/Fail Criteria
+
+**PASS**: all UT/IT/helm-unittest cases below pass; `helm lint --strict` clean; existing
+`helm-smoke-test.yml` and `helm-unittest` suites (pre-existing specs) remain green (no regressions).
+
+**FAIL**: any new or existing test regresses, or default (namespace-unset) rendering differs from
+pre-fix output for any of the 4 charts.
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code
+
+| File | Functions/Methods | Lines (approx) |
+|------|--------------------|-----------------|
+| `pkg/fleet/config.go` | `FleetConfig` (new `Namespace` field) | ~5 |
+
+### 6.2 Integration-Testable Code
+
+| File | Functions/Methods | Lines (approx) |
+|------|--------------------|-----------------|
+| `cmd/apifrontend/backend_deps.go` | `buildFleetReaderDeps` | ~3 (call-site change) |
+| `cmd/effectivenessmonitor/main.go` | `buildFleetReaderFactory` | ~3 (call-site change) |
+| `charts/kubernaut/templates/_helpers.tpl` | `kubernaut.fleet.registryNsRBAC` | ~20 (new helper) |
+| `charts/kubernaut/templates/signalprocessing/signalprocessing.yaml` | ClusterRole/Role split | ~15 |
+| `charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml` | ClusterRole/Role split (2 branches) | ~25 |
+| `charts/kubernaut/templates/apifrontend/apifrontend.yaml` | ClusterRole/Role split | ~15 |
+| `charts/kubernaut/templates/effectivenessmonitor/effectivenessmonitor.yaml` | ClusterRole/Role split | ~15 |
+
+---
+
+## 7. BR Coverage Matrix
+
+| BR ID | Description | Priority | Tier | Test ID | Status |
+|-------|-------------|----------|------|---------|--------|
+| BR-RBAC-020 | Namespace field round-trips through FleetConfig | P1 | Unit | UT-FLEET-020-001 | ✅ Pass |
+| BR-RBAC-020 | AF wires Config.Fleet.Namespace into ClusterRegistry | P0 | Integration | IT-AF-020-001 | ✅ Pass |
+| BR-RBAC-020 | EM wires Config.Fleet.Namespace into ClusterRegistry | P0 | Integration | IT-EM-020-001 | ✅ Pass |
+| BR-RBAC-020 | SP grants namespace-scoped Role instead of ClusterRole rule when namespace set | P0 | Helm | IT-HELM-020-001 | ✅ Pass |
+| BR-RBAC-020 | SP retains ClusterRole rule when namespace unset (regression guard) | P0 | Helm | IT-HELM-020-002 | ✅ Pass |
+| BR-RBAC-020 | FMC (kuadrant) grants namespace-scoped Role when namespace set | P0 | Helm | IT-HELM-020-003 | ✅ Pass |
+| BR-RBAC-020 | FMC (kuadrant) retains ClusterRole rule when namespace unset | P0 | Helm | IT-HELM-020-004 | ✅ Pass |
+| BR-RBAC-020 | FMC (eaigw) grants namespace-scoped Role when namespace set | P0 | Helm | IT-HELM-020-005 | ✅ Pass |
+| BR-RBAC-020 | FMC (eaigw) retains ClusterRole rule when namespace unset | P0 | Helm | IT-HELM-020-006 | ✅ Pass |
+| BR-RBAC-020 | AF grants namespace-scoped Role when namespace set | P0 | Helm | IT-HELM-020-007 | ✅ Pass |
+| BR-RBAC-020 | AF retains ClusterRole rule when namespace unset | P0 | Helm | IT-HELM-020-008 | ✅ Pass |
+| BR-RBAC-020 | EM grants namespace-scoped Role when namespace set | P0 | Helm | IT-HELM-020-009 | ✅ Pass |
+| BR-RBAC-020 | EM retains ClusterRole rule when namespace unset | P0 | Helm | IT-HELM-020-010 | ✅ Pass |
+
+---
+
+## 8. Test Scenarios
+
+### Tier 1: Unit Tests
+
+| ID | Business Outcome Under Test | Phase |
+|----|------------------------------|-------|
+| `UT-FLEET-020-001` | `FleetConfig.Namespace` set via YAML `namespace:` key is readable on the struct; empty when omitted | ✅ Pass |
+
+### Tier 2: Integration Tests
+
+| ID | Business Outcome Under Test | Phase |
+|----|------------------------------|-------|
+| `IT-AF-020-001` | Setting `cfg.Fleet.Namespace` and calling `buildFleetReaderDeps` results in a `ClusterRegistry` constructed with that namespace (proven via the fake dynamic client's list call being namespace-scoped) | ✅ Pass |
+| `IT-EM-020-001` | Same proof for `buildFleetReaderFactory` | ✅ Pass |
+
+### Tier 3: Helm Chart Tests (helm-unittest)
+
+| ID | Business Outcome Under Test | Phase |
+|----|------------------------------|-------|
+| `IT-HELM-020-001` | SP: `signalprocessing.fleet.namespace` set + `mcpGatewayType=kuadrant` → namespace-scoped `Role`/`RoleBinding` rendered with the `mcpserverregistrations` rule; `ClusterRole` does NOT contain it | ✅ Pass |
+| `IT-HELM-020-002` | SP: `namespace` unset → `ClusterRole` contains the rule; no `Role` rendered (regression guard) | ✅ Pass |
+| `IT-HELM-020-003` | FMC: `namespace` set + `gatewayType=kuadrant` → `Role` rendered with `mcpserverregistrations`+`gateways`+`httproutes` rules | ✅ Pass |
+| `IT-HELM-020-004` | FMC: `namespace` unset + `gatewayType=kuadrant` → `ClusterRole` contains the rules; no `Role` (regression guard) | ✅ Pass |
+| `IT-HELM-020-005` | FMC: `namespace` set + `gatewayType=eaigw` → `Role` rendered with `backends`+`mcproutes` rules | ✅ Pass |
+| `IT-HELM-020-006` | FMC: `namespace` unset + `gatewayType=eaigw` → `ClusterRole` contains the rules; no `Role` (regression guard) | ✅ Pass |
+| `IT-HELM-020-007` | AF: `apifrontend.fleet.namespace` set + kuadrant → `Role` rendered | ✅ Pass |
+| `IT-HELM-020-008` | AF: `namespace` unset → `ClusterRole` contains the rule (regression guard) | ✅ Pass |
+| `IT-HELM-020-009` | EM: `effectivenessmonitor.fleet.namespace` set + kuadrant → `Role` rendered | ✅ Pass |
+| `IT-HELM-020-010` | EM: `namespace` unset → `ClusterRole` contains the rule (regression guard) | ✅ Pass |
+
+### Tier Skip Rationale
+
+- **E2E**: not applicable — this is a static RBAC-shape change with no runtime behavior to exercise
+  beyond what `helm-smoke-test.yml` (pre-existing, unmodified) already covers by installing the chart.
+
+---
+
+## 9. Test Cases (P0 detail)
+
+### IT-HELM-020-001: SP namespace-scoped Role replaces ClusterRole rule
+
+**BR**: BR-RBAC-020
+**Priority**: P0
+**Type**: Helm (helm-unittest)
+**File**: `charts/kubernaut/tests/fleet_registry_rbac_test.yaml`
+
+**Test Steps**:
+1. **Given**: `signalprocessing.fleet.mcpGatewayType=kuadrant`, `signalprocessing.fleet.namespace=team-a`
+2. **When**: rendering `templates/signalprocessing/signalprocessing.yaml`
+3. **Then**: a `Role`+`RoleBinding` named for the SP fleet registry exist in namespace `team-a` granting
+   `mcp.kuadrant.io/mcpserverregistrations` get/list/watch, bound to `signalprocessing-controller`; the
+   `ClusterRole` document does NOT contain that rule.
+
+**Acceptance Criteria**: exact rule parity with the pre-fix `ClusterRole` rule (no verb/resource drift).
+
+---
+
+## 10. Environmental Needs
+
+- **Unit/Integration**: Ginkgo/Gomega BDD (mandatory), `go test`, no external infra.
+- **Helm**: `helm` CLI + `helm-unittest` plugin (`helm plugin install https://github.com/helm-unittest/helm-unittest --version v1.1.1`), no cluster needed.
+
+---
+
+## 11. Dependencies & Schedule
+
+No blocking dependencies. Execution order: RED (failing UT/IT/helm-unittest) → GREEN (Go wiring +
+Helm template split, CI wiring) → REFACTOR (dedupe/naming pass, `go build`/`helm lint` as safety net).
+
+---
+
+## 12. Test Deliverables
+
+| Deliverable | Location |
+|-------------|----------|
+| This test plan | `docs/testing/1686/TEST_PLAN.md` |
+| Unit test | `pkg/fleet/fleet_test.go` |
+| Integration tests | `cmd/apifrontend/fleet_wiring_test.go`, `cmd/effectivenessmonitor/fleet_wiring_test.go` |
+| Helm-unittest suite | `charts/kubernaut/tests/fleet_registry_rbac_test.yaml` |
+| CI wiring | `.github/workflows/ci-pipeline.yml` (`helm-unittest` job), `Makefile` (`test-helm` target) |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit + Integration
+go test ./pkg/fleet/... -run TestFleet
+go test ./cmd/apifrontend/... -run TestBuildFleetReaderDeps
+go test ./cmd/effectivenessmonitor/... -run TestBuildFleetReaderFactory
+
+# Helm
+helm unittest charts/kubernaut/ --file 'tests/fleet_registry_rbac_test.yaml'
+helm lint charts/kubernaut/ --strict --set global.image.tag=test ...
+```
+
+---
+
+## 14. Wiring Verification (TDD Phase 4)
+
+| Code Path | Entry Point | Exit Point | Wiring IT | Status |
+|-----------|-------------|------------|-----------|--------|
+| `fleet.FleetConfig.Namespace` → `registry.RegistryConfig.Namespace` (AF) | `cmd/apifrontend/main.go` startup | `buildFleetReaderDeps` → `registry.NewClusterRegistry` | `IT-AF-020-001` | ✅ Pass |
+| `fleet.FleetConfig.Namespace` → `registry.RegistryConfig.Namespace` (EM) | `cmd/effectivenessmonitor/main.go` startup | `buildFleetReaderFactory` → `registry.NewClusterRegistry` | `IT-EM-020-001` | ✅ Pass |
+
+---
+
+## 15. Existing Tests Requiring Updates
+
+None — this is purely additive (new field, new helper, new conditional branch); no existing test
+asserts the *absence* of namespace scoping in a way that would break.
+
+---
+
+## 16. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-07-23 | Initial test plan |
+| 1.1 | 2026-07-23 | Implementation complete. All UT/IT/helm-unittest cases pass (100/100 `helm unittest charts/kubernaut/`, including the 81 pre-existing cases as a regression check). `helm lint --strict` clean. Actual test IDs in code differ slightly from this plan's placeholders: `UT-FLEET-020-001` was implemented as four scenarios `UT-FLEET-CFG-080..083` in `pkg/fleet/fleet_test.go` (settable/round-trip/omitempty/Validate-optional), following that file's existing per-field numbering convention rather than introducing a new `020` block. `IT-AF-020-001`/`IT-EM-020-001` and `IT-HELM-020-001..010` match this plan's IDs exactly. `helm-unittest` CI wiring is additionally documented in [DD-PLATFORM-005](../../architecture/decisions/DD-PLATFORM-005-helm-unittest-ci-integration.md) (dedicated Stage-1 job vs. folding into `helm-smoke-test`). A follow-up tech-debt issue (#1719) was filed for the pre-existing, unrelated drift across 3 divergent fleet-config struct shapes discovered during preflight — explicitly out of scope for this fix. |

--- a/pkg/fleet/config.go
+++ b/pkg/fleet/config.go
@@ -78,6 +78,18 @@ type FleetConfig struct {
 	// or "kuadrant" (Kuadrant MCP Gateway). Defaults to "eaigw" when empty.
 	MCPGatewayType MCPGatewayType `yaml:"mcpGatewayType,omitempty"`
 
+	// Namespace restricts the ClusterRegistry's CRD watch (MCPServerRegistration
+	// for kuadrant; Backend/MCPRoute for eaigw) to a single namespace instead of
+	// watching cluster-wide. Threaded into registry.RegistryConfig.Namespace by
+	// callers that construct a ClusterRegistry directly (AF, EM). Empty (the
+	// default) preserves the pre-existing cluster-wide watch behavior. Mirrors
+	// the field SP/FMC already expose locally (pkg/signalprocessing/config,
+	// MCPGatewayConfig below); least-privilege RBAC (BR-RBAC-020, #1686) is only
+	// possible when this is set, since the Helm chart narrows the granted
+	// Role/RoleBinding to match whatever namespace this carries.
+	// +optional
+	Namespace string `yaml:"namespace,omitempty"`
+
 	// TLSCAFile is the path to the CA certificate bundle for verifying TLS connections
 	// to the fleet backend (ACM Search, FMC). When set, the ACM client uses this CA
 	// instead of InsecureSkipVerify. Typically mounted from the service-ca operator.

--- a/pkg/fleet/fleet_test.go
+++ b/pkg/fleet/fleet_test.go
@@ -205,6 +205,71 @@ var _ = Describe("FleetConfig.TokenPath — acm backend bearer-token requirement
 	})
 })
 
+// Issue #1686 (BR-RBAC-020, FedRAMP AC-6/CM-6): AF and EM each construct a
+// registry.ClusterRegistry directly (cmd/apifrontend/backend_deps.go,
+// cmd/effectivenessmonitor/main.go) to watch MCP Gateway CRDs for cluster
+// discovery, but FleetConfig had no Namespace field — unlike SP's local
+// FleetConfig (pkg/signalprocessing/config), which already supports scoping
+// that watch to a single namespace. Without it, AF/EM always passed
+// registry.RegistryConfig{} (Namespace unset), forcing a cluster-wide watch
+// even when an operator wanted to restrict it — and the Helm chart granted
+// cluster-wide RBAC unconditionally to match. This Describe block locks in
+// the field's presence and YAML round-trip so a future refactor cannot
+// silently drop it again (mirrors the UT-FLEET-CFG-050/051 TLSCAFile block
+// above).
+var _ = Describe("FleetConfig.Namespace (#1686, BR-RBAC-020)", func() {
+	It("UT-FLEET-CFG-080 [AC-6,CM-6]: Namespace is settable and defaults to empty (cluster-wide watch)", func() {
+		cfg := fleet.FleetConfig{
+			Enabled:            true,
+			MCPGatewayEndpoint: "http://gw:8080/mcp",
+			MCPGatewayType:     fleet.GatewayKuadrant,
+		}
+		Expect(cfg.Namespace).To(BeEmpty(),
+			"zero-value Namespace must mean watch-all (no behavior change for existing deployments)")
+
+		cfg.Namespace = "team-a"
+		Expect(cfg.Namespace).To(Equal("team-a"))
+	})
+
+	It("UT-FLEET-CFG-081 [AC-6,CM-6]: Namespace survives a YAML round-trip via the namespace key", func() {
+		cfg := fleet.FleetConfig{
+			Enabled:            true,
+			MCPGatewayEndpoint: "http://gw:8080/mcp",
+			MCPGatewayType:     fleet.GatewayKuadrant,
+			Namespace:          "team-a",
+		}
+		data, err := yaml.Marshal(cfg)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(data)).To(ContainSubstring("namespace: team-a"))
+
+		var roundTripped fleet.FleetConfig
+		Expect(yaml.Unmarshal(data, &roundTripped)).To(Succeed())
+		Expect(roundTripped.Namespace).To(Equal(cfg.Namespace))
+	})
+
+	It("UT-FLEET-CFG-082 [AC-6,CM-6]: Namespace is omitted from marshaled YAML when empty (omitempty)", func() {
+		cfg := fleet.FleetConfig{
+			Enabled:            true,
+			MCPGatewayEndpoint: "http://gw:8080/mcp",
+			MCPGatewayType:     fleet.GatewayKuadrant,
+		}
+		data, err := yaml.Marshal(cfg)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(string(data)).ToNot(ContainSubstring("namespace:"),
+			"empty Namespace must not render a namespace: key (omitempty)")
+	})
+
+	It("UT-FLEET-CFG-083 [AC-6,CM-6]: Validate does not require Namespace when fleet is enabled", func() {
+		cfg := fleet.FleetConfig{
+			Enabled:            true,
+			MCPGatewayEndpoint: "http://gw:8080/mcp",
+			MCPGatewayType:     fleet.GatewayKuadrant,
+		}
+		Expect(cfg.Validate()).ToNot(HaveOccurred(),
+			"Namespace is an optional least-privilege scoping knob, not a required field")
+	})
+})
+
 var _ = Describe("FleetConfig MCPGatewayType (MCP Gateway Adapter)", func() {
 	It("UT-FLEET-CFG-030 [CM-6]: Validate accepts valid MCPGatewayType eaigw", func() {
 		cfg := fleet.FleetConfig{


### PR DESCRIPTION
## Summary

`SignalProcessing`, `FleetMetadataCache`, `APIFrontend`, and `EffectivenessMonitor` each construct a
`registry.ClusterRegistry` that watches MCP Gateway CRDs (`MCPServerRegistration` for kuadrant;
`Backend`/`MCPRoute` for eaigw) to discover fleet-managed clusters. The registry supports scoping this
watch to a single namespace, but the Helm chart always granted a **cluster-wide `ClusterRole`** rule for
these CRDs regardless of whether that scoping knob was actually set — an avoidable least-privilege
violation (FedRAMP AC-6/CM-6, BR-RBAC-020).

Fixes #1686.

## Changes

1. **Go wiring** (`pkg/fleet/config.go`, `cmd/apifrontend/backend_deps.go`,
   `cmd/effectivenessmonitor/main.go`): `fleet.FleetConfig` gains a `Namespace` field; AF/EM now thread
   `cfg.Fleet.Namespace` into `registry.RegistryConfig` instead of always passing `RegistryConfig{}`
   (they previously had **no way at all** to scope the watch down).

2. **Helm RBAC split** (new `kubernaut.fleet.registryNsRBAC` helper + all 4 service templates): grants a
   namespace-scoped `Role`+`RoleBinding` instead of the cluster-wide `ClusterRole` rule whenever a
   namespace is configured. Exact same rule content either way — only the RBAC kind/scope changes.
   - SP/AF/EM: default (namespace-unset) rendering is byte-for-byte unchanged.
   - FMC: its `ClusterRole` exists *solely* for this CRD watch, so it's skipped entirely (both
     gateway-type branches) rather than left with an empty `rules: []`. FMC's default
     `namespace` was already `"kubernaut-system"` (non-empty) — so **its default install now correctly
     tightens to a namespace-scoped `Role`**, which is the actual fix, not a side effect.
   - `apifrontend.fleet.namespace` / `effectivenessmonitor.fleet.namespace` added to `values.yaml` +
     `values.schema.json` (previously not exposed at all).

3. **CI**: `helm-unittest` (81 pre-existing specs, never run in CI) is now wired in as a dedicated
   Stage-1 job (`needs: [detect-changes]` only, ~1min, parallel with `lint-go`/`unit-tests`) rather than
   folded into the ~30-45min `helm-smoke-test`. `make test-helm` for local parity. See
   [DD-PLATFORM-005](docs/architecture/decisions/DD-PLATFORM-005-helm-unittest-ci-integration.md) for
   alternatives considered.

## Tests

- `UT-FLEET-CFG-080..083` (`pkg/fleet/fleet_test.go`)
- `IT-AF-020-001` / `IT-EM-020-001` (`cmd/apifrontend`, `cmd/effectivenessmonitor` — proven via fake
  dynamic client recorded-action namespace assertions)
- `IT-HELM-020-001..010` (`charts/kubernaut/tests/fleet_registry_rbac_test.yaml`, 19 cases: both gateway
  types × both namespace states × all 4 services)
- Full `helm unittest charts/kubernaut/`: **100/100 passing** (81 pre-existing + 19 new, zero regressions)
- `go build ./...`, `go vet`, `golangci-lint`: clean
- `helm lint charts/kubernaut/ --strict`: clean

Full IEEE-829 test plan: `docs/testing/1686/TEST_PLAN.md`

## Follow-up (filed separately, not blocking this PR)

Preflight for this fix found 3 structurally-different fleet-config shapes across services
(`fleet.FleetConfig` vs. SP/WE/KA's private `FleetConfig` copies vs. `fleet.MCPGatewayConfig`), which is
organic drift, not a deliberate design. Tracked as tech-debt in #1719 — explicitly scoped out of this PR.
