### PR TITLE
fix(ka): make LLM temperature optional, omitted unless configured (#1749)

### DIFF
--- a/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
+++ b/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
@@ -316,7 +316,14 @@ data:
   llm-runtime.yaml: |
     model: {{ .Values.kubernautAgent.llm.model | quote }}
     endpoint: {{ .Values.kubernautAgent.llm.endpoint | default "" | quote }}
-    temperature: {{ .Values.kubernautAgent.llm.temperature | default 0.7 }}
+    {{- /* #1749: only render temperature when explicitly set. Some models
+       (e.g. claude-opus-4-8) reject the parameter outright with a 400 if
+       it is present at all — omit it by default rather than forcing 0.7.
+       hasKey (not a truthy `if`) so an explicit `temperature: 0` still
+       renders (BR-HAPI-199 — explicit zero must still be sent). */}}
+    {{- if hasKey .Values.kubernautAgent.llm "temperature" }}
+    temperature: {{ .Values.kubernautAgent.llm.temperature }}
+    {{- end }}
     maxRetries: {{ .Values.kubernautAgent.llm.maxRetries | default 3 }}
     timeoutSeconds: {{ .Values.kubernautAgent.llm.timeoutSeconds | default 120 }}
 ---

--- a/charts/kubernaut/tests/kubernaut-agent-llm-runtime_test.yaml
+++ b/charts/kubernaut/tests/kubernaut-agent-llm-runtime_test.yaml
@@ -1,0 +1,55 @@
+suite: kubernaut-agent-llm-runtime ConfigMap — optional temperature (#1749)
+templates:
+  - templates/kubernaut-agent/kubernaut-agent.yaml
+set:
+  signalprocessing:
+    policies:
+      existingConfigMap: dummy
+  aianalysis:
+    policies:
+      existingConfigMap: dummy
+  kubernautAgent:
+    llm:
+      provider: anthropic
+      model: claude-opus-4-8
+tests:
+  - it: omits the temperature key entirely when not set in values (default install)
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-agent-llm-runtime
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - notMatchRegex:
+          path: data["llm-runtime.yaml"]
+          pattern: "temperature:"
+
+  - it: renders the temperature key when explicitly set to a non-zero value
+    set:
+      kubernautAgent:
+        llm:
+          provider: anthropic
+          model: claude-opus-4-8
+          temperature: 0.7
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-agent-llm-runtime
+    asserts:
+      - matchRegex:
+          path: data["llm-runtime.yaml"]
+          pattern: "temperature: 0\\.7"
+
+  - it: renders the temperature key when explicitly set to 0 (BR-HAPI-199 — explicit zero must still be sent)
+    set:
+      kubernautAgent:
+        llm:
+          provider: anthropic
+          model: claude-opus-4-8
+          temperature: 0
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-agent-llm-runtime
+    asserts:
+      - matchRegex:
+          path: data["llm-runtime.yaml"]
+          pattern: "temperature: 0"

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -765,7 +765,7 @@
             "tlsCaFile": { "type": "string", "default": "", "description": "Path to PEM CA cert for internal LLM endpoints behind private CA. Static — requires pod restart." },
             "model": { "type": "string", "default": "", "description": "LLM model name (gpt-4o, claude-sonnet-4-20250514). Hot-reloadable." },
             "endpoint": { "type": "string", "default": "", "description": "LLM endpoint URL. Hot-reloadable." },
-            "temperature": { "type": "number", "default": 0.7, "description": "LLM sampling temperature. Hot-reloadable." },
+            "temperature": { "type": "number", "description": "LLM sampling temperature. Hot-reloadable. Omitted by default (#1749) — some models (e.g. claude-opus-4-8) reject this parameter outright with a 400 if set at all. Only set this if your model supports it." },
             "maxRetries": { "type": "integer", "default": 3, "description": "Max retries for LLM requests. Hot-reloadable." },
             "timeoutSeconds": { "type": "integer", "default": 120, "description": "LLM request timeout in seconds. Hot-reloadable." },
             "oauth2": {

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -398,7 +398,11 @@ kubernautAgent:
     # -- LLM runtime fields (hot-reloadable via kubernaut-agent-llm-runtime ConfigMap).
     model: ""      # e.g., "gpt-4o", "claude-sonnet-4-20250514"
     endpoint: ""   # e.g., "http://llm-gateway:8080/v1"
-    temperature: 0.7
+    # -- Sampling temperature. Omitted by default (#1749): some models
+    # (e.g. claude-opus-4-8) reject this parameter outright with a 400 if
+    # it is present at all. Uncomment and set an explicit value only if
+    # your model supports it.
+    # temperature: 0.7
     maxRetries: 3
     timeoutSeconds: 120
     # -- OAuth2 client credentials grant for enterprise LLM gateway authentication.

--- a/internal/kubernautagent/config/config.go
+++ b/internal/kubernautagent/config/config.go
@@ -71,16 +71,16 @@ type IntegrationsConfig struct {
 
 // LLMConfig holds static LLM provider settings that require a pod restart to change.
 type LLMConfig struct {
-	Provider        string              `yaml:"provider"`
-	AzureAPIVersion string              `yaml:"azureApiVersion"`
-	VertexProject   string              `yaml:"vertexProject"`
-	VertexLocation  string              `yaml:"vertexLocation"`
-	BedrockRegion   string              `yaml:"bedrockRegion"`
-	TLSCaFile       string              `yaml:"tlsCaFile,omitempty"`
-	TLSCertFile     string              `yaml:"tlsCertFile,omitempty"`
-	TLSKeyFile      string              `yaml:"tlsKeyFile,omitempty"`
-	OAuth2          OAuth2Config        `yaml:"oauth2,omitempty"`
-	CircuitBreaker  CircuitBreakerCfg   `yaml:"circuitBreaker,omitempty"`
+	Provider        string            `yaml:"provider"`
+	AzureAPIVersion string            `yaml:"azureApiVersion"`
+	VertexProject   string            `yaml:"vertexProject"`
+	VertexLocation  string            `yaml:"vertexLocation"`
+	BedrockRegion   string            `yaml:"bedrockRegion"`
+	TLSCaFile       string            `yaml:"tlsCaFile,omitempty"`
+	TLSCertFile     string            `yaml:"tlsCertFile,omitempty"`
+	TLSKeyFile      string            `yaml:"tlsKeyFile,omitempty"`
+	OAuth2          OAuth2Config      `yaml:"oauth2,omitempty"`
+	CircuitBreaker  CircuitBreakerCfg `yaml:"circuitBreaker,omitempty"`
 }
 
 // CircuitBreakerCfg configures the gobreaker circuit breaker for HTTP clients.
@@ -98,13 +98,19 @@ type CircuitBreakerCfg struct {
 // This struct maps to a separate ConfigMap (kubernaut-agent-llm-runtime) watched by
 // the FileWatcher.
 type LLMRuntimeConfig struct {
-	Model          string                       `yaml:"model"`
-	Endpoint       string                       `yaml:"endpoint"`
-	APIKey         string                       `yaml:"apiKey"`
-	Temperature    float64                      `yaml:"temperature"`
-	MaxRetries     int                          `yaml:"maxRetries"`
-	TimeoutSeconds int                          `yaml:"timeoutSeconds"`
-	CustomHeaders  []pkgconfig.HeaderDefinition `yaml:"customHeaders,omitempty"`
+	Model    string `yaml:"model"`
+	Endpoint string `yaml:"endpoint"`
+	APIKey   string `yaml:"apiKey"`
+	// Temperature is a pointer so "not configured" (nil, key absent from
+	// YAML) can be distinguished from "explicitly configured as 0"
+	// (BR-HAPI-199, #1749). Some models (e.g. claude-opus-4-8) reject the
+	// temperature parameter outright with a 400 if it is present at all,
+	// so it must be omitted from the wire request rather than defaulted to
+	// a numeric value when the operator never set it.
+	Temperature    *float64                      `yaml:"temperature,omitempty"`
+	MaxRetries     int                           `yaml:"maxRetries"`
+	TimeoutSeconds int                           `yaml:"timeoutSeconds"`
+	CustomHeaders  []pkgconfig.HeaderDefinition  `yaml:"customHeaders,omitempty"`
 	PhaseModels    map[string]*LLMOverrideConfig `yaml:"phaseModels,omitempty"`
 }
 
@@ -153,6 +159,9 @@ func (r *LLMRuntimeConfig) EffectivePhaseConfig(phase string, baseLLM LLMConfig,
 	}
 	if override.APIKey != "" {
 		runtimeOut.APIKey = override.APIKey
+	}
+	if override.Temperature != nil {
+		runtimeOut.Temperature = override.Temperature
 	}
 	return staticOut, runtimeOut
 }
@@ -240,8 +249,8 @@ type RateLimitConfig struct {
 }
 
 type SessionConfig struct {
-	TTL                        time.Duration `yaml:"ttl"`
-	MaxConcurrentInvestigations int          `yaml:"maxConcurrentInvestigations"`
+	TTL                         time.Duration `yaml:"ttl"`
+	MaxConcurrentInvestigations int           `yaml:"maxConcurrentInvestigations"`
 }
 
 type AuditConfig struct {
@@ -263,14 +272,14 @@ type MCPConfig struct {
 // When Enabled=true, KA exposes an SSE-based MCP endpoint for user-driven
 // investigations. Feature is gated off by default.
 type InteractiveConfig struct {
-	Enabled                bool                `yaml:"enabled"`
-	SessionTTL             time.Duration       `yaml:"sessionTTL"`
-	InactivityTimeout      time.Duration       `yaml:"inactivityTimeout"`
-	MaxConcurrentSessions  int                 `yaml:"maxConcurrentSessions"`
-	RateLimitPerUser       int                 `yaml:"rateLimitPerUser"`
-	MaxAnalyzingTimeout    time.Duration       `yaml:"maxAnalyzingTimeout"`
-	DisconnectGracePeriod  time.Duration       `yaml:"disconnectGracePeriod"`
-	JWTProviders []JWTProviderConfig `yaml:"jwtProviders,omitempty"`
+	Enabled               bool                `yaml:"enabled"`
+	SessionTTL            time.Duration       `yaml:"sessionTTL"`
+	InactivityTimeout     time.Duration       `yaml:"inactivityTimeout"`
+	MaxConcurrentSessions int                 `yaml:"maxConcurrentSessions"`
+	RateLimitPerUser      int                 `yaml:"rateLimitPerUser"`
+	MaxAnalyzingTimeout   time.Duration       `yaml:"maxAnalyzingTimeout"`
+	DisconnectGracePeriod time.Duration       `yaml:"disconnectGracePeriod"`
+	JWTProviders          []JWTProviderConfig `yaml:"jwtProviders,omitempty"`
 
 	// MCPKeepAlive is the server-side ping interval for MCP sessions (#1387).
 	// Keeps SSE streams alive through OCP router idle timeouts.
@@ -435,14 +444,14 @@ const (
 
 // AlignmentCheckConfig holds settings for the shadow agent alignment checker (#601).
 type AlignmentCheckConfig struct {
-	Enabled        bool                 `yaml:"enabled"`
-	Mode           AlignmentMode        `yaml:"mode"`
-	LLM            *LLMOverrideConfig   `yaml:"llm"`
-	Timeout        time.Duration        `yaml:"timeout"`
-	MaxStepTokens  int                  `yaml:"maxStepTokens"`
-	MaxRetries     int                  `yaml:"maxRetries"`
-	VerdictTimeout time.Duration        `yaml:"verdictTimeout"`
-	Canary         CanaryConfig         `yaml:"canary"`
+	Enabled         bool                  `yaml:"enabled"`
+	Mode            AlignmentMode         `yaml:"mode"`
+	LLM             *LLMOverrideConfig    `yaml:"llm"`
+	Timeout         time.Duration         `yaml:"timeout"`
+	MaxStepTokens   int                   `yaml:"maxStepTokens"`
+	MaxRetries      int                   `yaml:"maxRetries"`
+	VerdictTimeout  time.Duration         `yaml:"verdictTimeout"`
+	Canary          CanaryConfig          `yaml:"canary"`
 	GroundingReview GroundingReviewConfig `yaml:"groundingReview"`
 }
 
@@ -472,6 +481,10 @@ type LLMOverrideConfig struct {
 	VertexProject   string `yaml:"vertexProject"`
 	VertexLocation  string `yaml:"vertexLocation"`
 	BedrockRegion   string `yaml:"bedrockRegion"`
+	// Temperature overrides the base/phase temperature (#1749). Nil means
+	// "inherit the base value unchanged" — not "force omission" — mirroring
+	// LLMRuntimeConfig.Temperature's pointer semantics.
+	Temperature *float64 `yaml:"temperature,omitempty"`
 }
 
 // EffectiveLLM returns a merged set of static + runtime fields for the
@@ -505,6 +518,9 @@ func (c *AlignmentCheckConfig) EffectiveLLM(base LLMConfig, runtime LLMRuntimeCo
 	}
 	if c.LLM.APIKey != "" {
 		runtimeOut.APIKey = c.LLM.APIKey
+	}
+	if c.LLM.Temperature != nil {
+		runtimeOut.Temperature = c.LLM.Temperature
 	}
 	return staticOut, runtimeOut
 }
@@ -551,7 +567,8 @@ func (r *LLMRuntimeConfig) Validate(provider string) error {
 		if override == nil || (override.Provider == "" && override.Endpoint == "" &&
 			override.Model == "" && override.APIKey == "" &&
 			override.AzureAPIVersion == "" && override.VertexProject == "" &&
-			override.VertexLocation == "" && override.BedrockRegion == "") {
+			override.VertexLocation == "" && override.BedrockRegion == "" &&
+			override.Temperature == nil) {
 			return fmt.Errorf("phaseModels[%q]: at least one override field must be set", phase)
 		}
 	}
@@ -692,10 +709,10 @@ func DefaultConfig() *Config {
 		Runtime: RuntimeConfig{
 			Logging: internalconfig.DefaultLoggingConfig(),
 			Server: ServerConfig{
-			Address: "0.0.0.0", Port: 8443, HealthAddr: ":8081", MetricsAddr: ":9090",
-			DisableProfiling:      true,
-			DisableAdminEndpoints: true,
-			MaxConcurrentRequests: 100,
+				Address: "0.0.0.0", Port: 8443, HealthAddr: ":8081", MetricsAddr: ":9090",
+				DisableProfiling:      true,
+				DisableAdminEndpoints: true,
+				MaxConcurrentRequests: 100,
 				RateLimit: RateLimitConfig{
 					RequestsPerSecond: 5,
 					Burst:             10,
@@ -737,11 +754,11 @@ func DefaultConfig() *Config {
 				},
 			},
 			Safety: SafetyConfig{
-			Sanitization: SanitizationConfig{
-				InjectionPatternsEnabled: true,
-				CredentialScrubEnabled:   true,
-				SecretRedactionEnabled:   true,
-			},
+				Sanitization: SanitizationConfig{
+					InjectionPatternsEnabled: true,
+					CredentialScrubEnabled:   true,
+					SecretRedactionEnabled:   true,
+				},
 				Anomaly: AnomalyConfig{
 					MaxToolCallsPerTool: 10,
 					MaxTotalToolCalls:   30,
@@ -757,9 +774,13 @@ func DefaultConfig() *Config {
 }
 
 // DefaultLLMRuntime returns an LLMRuntimeConfig with sensible production defaults.
+//
+// Temperature is deliberately left nil (#1749): not every model/provider
+// accepts the parameter (e.g. claude-opus-4-8 rejects it with a 400), so
+// the safe default is to omit it from the wire request entirely unless an
+// operator explicitly configures one for their model.
 func DefaultLLMRuntime() *LLMRuntimeConfig {
 	return &LLMRuntimeConfig{
-		Temperature:    0.7,
 		MaxRetries:     3,
 		TimeoutSeconds: 120,
 	}

--- a/internal/kubernautagent/config/config_1470_test.go
+++ b/internal/kubernautagent/config/config_1470_test.go
@@ -21,6 +21,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/config"
+	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("Per-Phase LLM Model Routing — #1470", func() {
@@ -112,13 +113,80 @@ phaseModels:
 				},
 			}
 			baseLLM := config.LLMConfig{Provider: "openai"}
-			baseRT := config.LLMRuntimeConfig{Model: "base-model", Endpoint: "http://base", Temperature: 0.7}
+			baseRT := config.LLMRuntimeConfig{Model: "base-model", Endpoint: "http://base", Temperature: ptr.To(0.7)}
 
 			outLLM, outRT := rt.EffectivePhaseConfig("workflow_discovery", baseLLM, baseRT)
 			Expect(outLLM.Provider).To(Equal("openai"), "provider should be preserved")
 			Expect(outRT.Model).To(Equal("fast-model"), "model should be overridden")
 			Expect(outRT.Endpoint).To(Equal("http://base"), "endpoint should be preserved")
-			Expect(outRT.Temperature).To(Equal(0.7), "temperature should be preserved")
+			Expect(outRT.Temperature).NotTo(BeNil(), "temperature should be preserved")
+			Expect(*outRT.Temperature).To(Equal(0.7), "temperature should be preserved")
+		})
+	})
+
+	Describe("UT-AI-1749-001: EffectivePhaseConfig merges a per-phase temperature override", func() {
+		It("should use the override's temperature when the phase sets one", func() {
+			rt := &config.LLMRuntimeConfig{
+				Model: "default-model",
+				PhaseModels: map[string]*config.LLMOverrideConfig{
+					"rca": {Temperature: ptr.To(0.2)},
+				},
+			}
+			baseLLM := config.LLMConfig{Provider: "anthropic"}
+			baseRT := config.LLMRuntimeConfig{Model: "claude-opus-4-8", Temperature: ptr.To(0.7)}
+
+			_, outRT := rt.EffectivePhaseConfig("rca", baseLLM, baseRT)
+			Expect(outRT.Temperature).NotTo(BeNil())
+			Expect(*outRT.Temperature).To(Equal(0.2), "phase override temperature should win over base")
+		})
+	})
+
+	Describe("UT-AI-1749-002: EffectivePhaseConfig inherits base temperature when the override is silent on it", func() {
+		It("should keep the base temperature when the phase override does not set one", func() {
+			rt := &config.LLMRuntimeConfig{
+				Model: "default-model",
+				PhaseModels: map[string]*config.LLMOverrideConfig{
+					"workflow_discovery": {Model: "fast-model"}, // no Temperature override
+				},
+			}
+			baseLLM := config.LLMConfig{Provider: "anthropic"}
+			baseRT := config.LLMRuntimeConfig{Model: "claude-opus-4-8", Temperature: ptr.To(0.7)}
+
+			_, outRT := rt.EffectivePhaseConfig("workflow_discovery", baseLLM, baseRT)
+			Expect(outRT.Temperature).NotTo(BeNil())
+			Expect(*outRT.Temperature).To(Equal(0.7), "base temperature must be inherited when override is silent")
+		})
+	})
+
+	Describe("UT-AI-1749-003: EffectivePhaseConfig inherits a nil base temperature (not coerced to 0)", func() {
+		It("should keep temperature nil when neither base nor override set one", func() {
+			rt := &config.LLMRuntimeConfig{
+				Model: "default-model",
+				PhaseModels: map[string]*config.LLMOverrideConfig{
+					"rca": {Model: "fast-model"},
+				},
+			}
+			baseLLM := config.LLMConfig{Provider: "anthropic"}
+			baseRT := config.LLMRuntimeConfig{Model: "claude-opus-4-8"} // Temperature unset (nil)
+
+			_, outRT := rt.EffectivePhaseConfig("rca", baseLLM, baseRT)
+			Expect(outRT.Temperature).To(BeNil(),
+				"omitted base temperature must stay nil through the phase merge — must not be coerced to 0")
+		})
+	})
+
+	Describe("UT-AI-1749-004 (SI-10): Validate accepts a temperature-only phase override", func() {
+		It("should not reject an override whose only set field is Temperature", func() {
+			rt := &config.LLMRuntimeConfig{
+				Model:    "test-model",
+				Endpoint: "http://localhost",
+				PhaseModels: map[string]*config.LLMOverrideConfig{
+					"rca": {Temperature: ptr.To(0.2)},
+				},
+			}
+			err := rt.Validate("openai")
+			Expect(err).NotTo(HaveOccurred(),
+				"a phase override that only sets Temperature must be treated as non-empty")
 		})
 	})
 

--- a/internal/kubernautagent/config/config_684_test.go
+++ b/internal/kubernautagent/config/config_684_test.go
@@ -105,7 +105,19 @@ temperature: 0.7
 `)
 			rt, err := config.LoadLLMRuntime(rtYAML)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(rt.Temperature).To(BeNumerically("~", 0.7, 0.001))
+			Expect(rt.Temperature).NotTo(BeNil(), "temperature was explicitly set in YAML and must be parsed")
+			Expect(*rt.Temperature).To(BeNumerically("~", 0.7, 0.001))
+		})
+
+		It("UT-KA-1749-006: leaves temperature nil when omitted from runtime config YAML", func() {
+			rtYAML := []byte(`
+model: "claude-opus-4-8"
+`)
+			rt, err := config.LoadLLMRuntime(rtYAML)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rt.Temperature).To(BeNil(),
+				"omitting temperature from the ConfigMap YAML must leave it unset (nil), not default it to a "+
+					"numeric value — fixes claude-opus-4-8 400 'temperature is deprecated for this model'")
 		})
 
 		It("UT-KA-684-006: parses maxRetries and timeoutSeconds from runtime config", func() {
@@ -132,7 +144,8 @@ timeoutSeconds: 60
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rt.Model).To(Equal("claude-sonnet-4-20250514"))
 			Expect(rt.Endpoint).To(Equal("http://localhost:11434/v1"))
-			Expect(rt.Temperature).To(BeNumerically("~", 0.5, 0.001))
+			Expect(rt.Temperature).NotTo(BeNil(), "temperature was explicitly set in YAML and must be parsed")
+			Expect(*rt.Temperature).To(BeNumerically("~", 0.5, 0.001))
 			Expect(rt.MaxRetries).To(Equal(5))
 			Expect(rt.TimeoutSeconds).To(Equal(60))
 		})

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -198,10 +198,10 @@ type Investigator struct {
 	pipeline      Pipeline
 	modelName     string
 	scopeResolver ScopeResolver
-	swappable      *llm.SwappableClient
-	metrics        *metrics.Metrics
-	pinDecorator   func(llm.Client) llm.Client
-	phaseResolver  PhaseClientResolver
+	swappable     *llm.SwappableClient
+	metrics       *metrics.Metrics
+	pinDecorator  func(llm.Client) llm.Client
+	phaseResolver PhaseClientResolver
 }
 
 func (inv *Investigator) auditLog() logr.Logger {
@@ -256,10 +256,10 @@ func New(cfg Config) *Investigator {
 		pipeline:      pipeline,
 		modelName:     cfg.ModelName,
 		scopeResolver: cfg.ScopeResolver,
-		swappable:      cfg.Swappable,
-		metrics:        cfg.Metrics,
-		pinDecorator:   cfg.PinDecorator,
-		phaseResolver:  cfg.PhaseResolver,
+		swappable:     cfg.Swappable,
+		metrics:       cfg.Metrics,
+		pinDecorator:  cfg.PinDecorator,
+		phaseResolver: cfg.PhaseResolver,
 	}
 }
 
@@ -913,7 +913,6 @@ CRITICAL: root_cause_analysis must be a JSON object, NOT a string. Do NOT wrap i
 	return nil
 }
 
-
 func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katypes.SignalContext, rcaSummary string, enrichData *prompt.EnrichmentData, p1Ctx *prompt.Phase1Data, tokens *TokenAccumulator, correlationID string, client llm.Client, modelName string, runtimeParams llm.RuntimeParams) (result *katypes.InvestigationResult, retErr error) {
 	// Apply signal label overrides (target_resource_kind / target_resource_name)
 	// before attaching to context. This ensures workflow discovery tools
@@ -1449,8 +1448,10 @@ func (inv *Investigator) chatOrStream(ctx context.Context, client llm.Client, re
 		"diag_dropped", diagSendDrop.Load(),
 		"diag_nil", diagSinkNil.Load())
 
-	temp := runtimeParams.Temperature
-	req.Options.Temperature = &temp
+	// #1749: shared with ChatWithParams's non-streaming path — see
+	// llm.ApplyTemperature's doc comment for why this was pulled out into
+	// one function.
+	llm.ApplyTemperature(&req.Options, runtimeParams)
 
 	bo := llm.ResolveRetryBackoff(runtimeParams)
 	maxAttempts := llm.ResolveMaxAttempts(runtimeParams)

--- a/internal/kubernautagent/investigator/stream_events_test.go
+++ b/internal/kubernautagent/investigator/stream_events_test.go
@@ -19,6 +19,7 @@ package investigator_test
 import (
 	"context"
 	"encoding/json"
+
 	"github.com/go-logr/logr"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -30,9 +31,34 @@ import (
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
-	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+	"k8s.io/utils/ptr"
 )
+
+// streamTestInvestigatorWithParams builds an Investigator whose LLM client is
+// wrapped in a SwappableClient carrying the given RuntimeParams, so tests can
+// control what chatOrStream sees (mirrors streamTestInvestigator, but exposes
+// the runtime-params-driven, Swappable+PinDecorator resolution path that
+// chatOrStream's streaming branch runs through in production).
+func streamTestInvestigatorWithParams(client llm.Client, params llm.RuntimeParams) *investigator.Investigator {
+	logger := logr.Discard()
+	builder, _ := prompt.NewBuilder()
+	rp := parser.NewResultParser()
+	enricher := enrichment.NewEnricher(nopK8sClient{}, nopDSClient{}, audit.NopAuditStore{}, logger)
+	swappable, err := llm.NewSwappableClient(client, "test-model", params)
+	Expect(err).NotTo(HaveOccurred())
+	return investigator.New(investigator.Config{
+		Swappable:    swappable,
+		Builder:      builder,
+		ResultParser: rp,
+		Enricher:     enricher,
+		AuditStore:   audit.NopAuditStore{},
+		Logger:       logger,
+		MaxTurns:     15,
+		PhaseTools:   investigator.DefaultPhaseToolMap(),
+	})
+}
 
 func streamTestInvestigator(client llm.Client) *investigator.Investigator {
 	logger := logr.Discard()
@@ -367,6 +393,73 @@ var _ = Describe("Kubernaut Agent Investigator Stream Events — #823 PR4", func
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(BeNil())
 			Expect(result.RCASummary).NotTo(BeEmpty())
+		})
+	})
+
+	Describe("UT-KA-1749-003: chatOrStream (streaming path) omits temperature when not configured", func() {
+		It("should leave Options.Temperature nil on the streamed request when RuntimeParams.Temperature is nil", func() {
+			eventCh := make(chan session.InvestigationEvent, 64)
+			ctx := session.WithEventSink(context.Background(), eventCh)
+
+			mockClient := &cancelAwareMockClient{
+				responses: []llm.ChatResponse{
+					{
+						Message: llm.Message{
+							Role:    "assistant",
+							Content: `{"rca_summary":"pod OOM killed","confidence":0.9}`,
+						},
+						Usage: llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+					},
+				},
+			}
+
+			// Temperature intentionally left nil (not configured) — this is the
+			// streaming path (chatOrStream, sink != nil), an independent code
+			// path from the non-streaming ChatWithParams (#1749).
+			inv := streamTestInvestigatorWithParams(mockClient, llm.RuntimeParams{})
+			go func() {
+				_, _ = inv.Investigate(ctx, streamSignal)
+				close(eventCh)
+			}()
+			collectEvents(eventCh)
+
+			Expect(mockClient.calls).NotTo(BeEmpty())
+			for i, call := range mockClient.calls {
+				Expect(call.Options.Temperature).To(BeNil(),
+					"call %d: chatOrStream must omit temperature from the streamed request when not "+
+						"explicitly configured (fixes claude-opus-4-8 400 'temperature is deprecated for this model')", i)
+			}
+		})
+	})
+
+	Describe("UT-KA-1749-004 (BR-HAPI-199): chatOrStream still sends an explicit temperature of 0", func() {
+		It("should set Options.Temperature to 0 on the streamed request when explicitly configured as 0.0", func() {
+			eventCh := make(chan session.InvestigationEvent, 64)
+			ctx := session.WithEventSink(context.Background(), eventCh)
+
+			mockClient := &cancelAwareMockClient{
+				responses: []llm.ChatResponse{
+					{
+						Message: llm.Message{
+							Role:    "assistant",
+							Content: `{"rca_summary":"pod OOM killed","confidence":0.9}`,
+						},
+						Usage: llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+					},
+				},
+			}
+
+			inv := streamTestInvestigatorWithParams(mockClient, llm.RuntimeParams{Temperature: ptr.To(0.0)})
+			go func() {
+				_, _ = inv.Investigate(ctx, streamSignal)
+				close(eventCh)
+			}()
+			collectEvents(eventCh)
+
+			Expect(mockClient.calls).NotTo(BeEmpty())
+			Expect(mockClient.calls[0].Options.Temperature).NotTo(BeNil(),
+				"an explicit temperature of 0 must still be sent on the streamed request — BR-HAPI-199")
+			Expect(*mockClient.calls[0].Options.Temperature).To(Equal(0.0))
 		})
 	})
 })

--- a/pkg/kubernautagent/llm/chat_helpers.go
+++ b/pkg/kubernautagent/llm/chat_helpers.go
@@ -158,6 +158,23 @@ func IsNonRetryableHTTPStatus(code int) bool {
 	}
 }
 
+// ApplyTemperature copies params.Temperature onto opts only when it is
+// explicitly configured (non-nil). Some models (e.g. claude-opus-4-8)
+// reject the temperature parameter outright with a 400 if it is present
+// on the wire request at all, regardless of value — so "not configured"
+// must mean "omitted", not "defaulted to a numeric value" (#1749).
+//
+// Exported because both non-streaming (ChatWithParams, below) and
+// streaming (investigator.chatOrStream) call paths need it — a previous
+// version of this logic was duplicated inline in both places, which is
+// exactly how the #1749 bug ended up with two independent, easy-to-miss
+// fix sites instead of one.
+func ApplyTemperature(opts *ChatOptions, params RuntimeParams) {
+	if params.Temperature != nil {
+		opts.Temperature = params.Temperature
+	}
+}
+
 // ChatWithParams wraps a Client.Chat call, injecting runtime parameters
 // (temperature, timeout, retries) from the hot-reloadable LLM config.
 // Each attempt gets a fresh context timeout; the timeout is cancelled
@@ -166,8 +183,7 @@ func IsNonRetryableHTTPStatus(code int) bool {
 // and fail fast on errors an adapter has classified as non-retryable
 // (#1585) instead of consuming the full retry budget.
 func ChatWithParams(ctx context.Context, client Client, req ChatRequest, params RuntimeParams) (ChatResponse, error) {
-	temp := params.Temperature
-	req.Options.Temperature = &temp
+	ApplyTemperature(&req.Options, params)
 
 	bo := ResolveRetryBackoff(params)
 	maxAttempts := ResolveMaxAttempts(params)

--- a/pkg/kubernautagent/llm/chat_with_params_test.go
+++ b/pkg/kubernautagent/llm/chat_with_params_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 	"github.com/jordigilh/kubernaut/pkg/shared/backoff"
+	"k8s.io/utils/ptr"
 )
 
 var fastBackoff = &backoff.Config{
@@ -98,7 +99,7 @@ var _ = Describe("ChatWithParams — BUG-1/BUG-3 fixes", func() {
 			}}
 
 			params := llm.RuntimeParams{
-				Temperature:    0.7,
+				Temperature:    ptr.To(0.7),
 				TimeoutSeconds: 5,
 			}
 			req := llm.ChatRequest{
@@ -121,7 +122,7 @@ var _ = Describe("ChatWithParams — BUG-1/BUG-3 fixes", func() {
 			}}
 
 			params := llm.RuntimeParams{
-				Temperature: 0.7,
+				Temperature: ptr.To(0.7),
 			}
 			req := llm.ChatRequest{
 				Messages: []llm.Message{{Role: "user", Content: "test"}},
@@ -132,10 +133,55 @@ var _ = Describe("ChatWithParams — BUG-1/BUG-3 fixes", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(mock.capturedReq.Options.Temperature).NotTo(BeNil(),
-				"Temperature must be set by ChatWithParams")
+				"Temperature must be set by ChatWithParams when configured")
 			Expect(*mock.capturedReq.Options.Temperature).To(BeNumerically("~", 0.7, 0.001))
 			Expect(mock.capturedReq.Options.JSONMode).To(BeTrue(),
 				"other options must be preserved")
+		})
+	})
+
+	Describe("UT-KA-1749-001: omits temperature from the wire request when not configured", func() {
+		It("should leave Options.Temperature nil when RuntimeParams.Temperature is nil", func() {
+			mock := &capturingClient{resp: llm.ChatResponse{
+				Message: llm.Message{Role: "assistant", Content: "ok"},
+			}}
+
+			params := llm.RuntimeParams{
+				Temperature: nil, // not configured — must not be sent to the provider
+			}
+			req := llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "test"}},
+			}
+
+			_, err := llm.ChatWithParams(context.Background(), mock, req, params)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mock.capturedReq.Options.Temperature).To(BeNil(),
+				"temperature must be omitted from the request when not explicitly configured "+
+					"(fixes claude-opus-4-8 400 'temperature is deprecated for this model')")
+		})
+	})
+
+	Describe("UT-KA-1749-002 (BR-HAPI-199): still sends an explicit temperature of 0", func() {
+		It("should set Options.Temperature to 0 when RuntimeParams.Temperature is an explicit pointer to 0.0", func() {
+			mock := &capturingClient{resp: llm.ChatResponse{
+				Message: llm.Message{Role: "assistant", Content: "ok"},
+			}}
+
+			params := llm.RuntimeParams{
+				Temperature: ptr.To(0.0), // explicitly configured as zero, not "unset"
+			}
+			req := llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "test"}},
+			}
+
+			_, err := llm.ChatWithParams(context.Background(), mock, req, params)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mock.capturedReq.Options.Temperature).NotTo(BeNil(),
+				"an explicit temperature of 0 must still be sent — BR-HAPI-199 requires "+
+					"deterministic output to be an explicit configuration, not confused with 'unset'")
+			Expect(*mock.capturedReq.Options.Temperature).To(Equal(0.0))
 		})
 	})
 
@@ -146,7 +192,7 @@ var _ = Describe("ChatWithParams — BUG-1/BUG-3 fixes", func() {
 			}}
 
 			params := llm.RuntimeParams{
-				Temperature:    0.5,
+				Temperature:    ptr.To(0.5),
 				TimeoutSeconds: 0,
 			}
 			req := llm.ChatRequest{
@@ -168,7 +214,7 @@ var _ = Describe("ChatWithParams — BUG-1/BUG-3 fixes", func() {
 				successResp: llm.ChatResponse{Message: llm.Message{Role: "assistant", Content: "ok"}},
 			}
 			params := llm.RuntimeParams{
-				Temperature:  0.7,
+				Temperature:  ptr.To(0.7),
 				MaxRetries:   maxRetries,
 				RetryBackoff: fastBackoff,
 			}
@@ -208,7 +254,7 @@ var _ = Describe("ChatWithParams — BUG-1/BUG-3 fixes", func() {
 				Multiplier: 2.0, JitterPercent: 0,
 			}
 			params := llm.RuntimeParams{
-				Temperature:  0.7,
+				Temperature:  ptr.To(0.7),
 				MaxRetries:   5,
 				RetryBackoff: slowBackoff,
 			}

--- a/pkg/kubernautagent/llm/classify_1585_test.go
+++ b/pkg/kubernautagent/llm/classify_1585_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	"k8s.io/utils/ptr"
 )
 
 // Issue #1585: ChatWithParams retries on any non-nil error for the full
@@ -88,7 +89,7 @@ var _ = Describe("LLM error classification — #1585", func() {
 		It("makes exactly one call, consuming none of the retry budget", func() {
 			mock := &nonRetryableErrorClient{err: llm.MarkNonRetryable(errors.New("401: invalid api key"))}
 			params := llm.RuntimeParams{
-				Temperature:  0.7,
+				Temperature:  ptr.To(0.7),
 				MaxRetries:   5,
 				RetryBackoff: fastBackoff,
 			}

--- a/pkg/kubernautagent/llm/swappable_client.go
+++ b/pkg/kubernautagent/llm/swappable_client.go
@@ -38,11 +38,18 @@ const oldClientCloseTimeout = 5 * time.Second
 //     so it never blocks callers.
 //   - Snapshot returns a bare llm.Client pinned at the current moment;
 //     subsequent Swap calls do not affect outstanding snapshots.
+//
 // RuntimeParams holds LLM runtime parameters that can be hot-reloaded
 // alongside the client. Investigator reads these at the start of each
 // investigation to pin values for the duration.
+//
+// Temperature is a pointer so "not configured" (nil) can be distinguished
+// from "explicitly configured as 0" (BR-HAPI-199, #1749). Some models
+// (e.g. claude-opus-4-8) reject the temperature parameter outright with a
+// 400 if it is present at all, so it must be omitted from the wire request
+// rather than defaulted to a numeric value when the operator never set it.
 type RuntimeParams struct {
-	Temperature    float64
+	Temperature    *float64
 	TimeoutSeconds int
 	MaxRetries     int
 	// RetryBackoff overrides the default backoff config for ChatWithParams retries.

--- a/pkg/kubernautagent/tools/summarizer/summarizer.go
+++ b/pkg/kubernautagent/tools/summarizer/summarizer.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools"
-	"k8s.io/utils/ptr"
 )
 
 // Summarizer uses a secondary LLM call to shorten tool output that exceeds
@@ -84,12 +83,15 @@ func (s *Summarizer) MaybeSummarize(ctx context.Context, toolName string, result
 		)
 	}
 
+	// #1749: no Temperature is set here. This call shares the base LLM
+	// client/model with the rest of the agent, so it cannot assume the
+	// configured model supports the parameter at all (e.g. claude-opus-4-8
+	// rejects it outright with a 400) — omitting it entirely is safe for
+	// every provider, and summarization has no BR-HAPI-199-style
+	// determinism requirement that would justify forcing 0.
 	resp, err := s.llmClient.Chat(ctx, llm.ChatRequest{
 		Messages: []llm.Message{
 			{Role: "user", Content: prompt},
-		},
-		Options: llm.ChatOptions{
-			Temperature: ptr.To(0.0),
 		},
 	})
 	if err != nil {
@@ -124,7 +126,7 @@ type wrappedTool struct {
 	summarizer *Summarizer
 }
 
-func (w *wrappedTool) Name() string               { return w.inner.Name() }
+func (w *wrappedTool) Name() string                { return w.inner.Name() }
 func (w *wrappedTool) Description() string         { return w.inner.Description() }
 func (w *wrappedTool) Parameters() json.RawMessage { return w.inner.Parameters() }
 

--- a/pkg/kubernautagent/tools/summarizer/summarizer_test.go
+++ b/pkg/kubernautagent/tools/summarizer/summarizer_test.go
@@ -40,10 +40,12 @@ type stubTool struct {
 	output string
 }
 
-func (s *stubTool) Name() string                                                    { return s.name }
-func (s *stubTool) Description() string                                             { return "stub desc" }
-func (s *stubTool) Parameters() json.RawMessage                                     { return json.RawMessage(`{}`) }
-func (s *stubTool) Execute(_ context.Context, _ json.RawMessage) (string, error)    { return s.output, nil }
+func (s *stubTool) Name() string                { return s.name }
+func (s *stubTool) Description() string         { return "stub desc" }
+func (s *stubTool) Parameters() json.RawMessage { return json.RawMessage(`{}`) }
+func (s *stubTool) Execute(_ context.Context, _ json.RawMessage) (string, error) {
+	return s.output, nil
+}
 
 var _ = Describe("Kubernaut Agent Summarizer Unit — #433", func() {
 
@@ -167,6 +169,23 @@ var _ = Describe("Kubernaut Agent Summarizer Unit — #433", func() {
 			prompt := fake.calls[0].Messages[0].Content
 			Expect(prompt).To(ContainSubstring(moderateOutput),
 				"full output should be in prompt when below maxInputSize")
+		})
+	})
+
+	Describe("UT-KA-1749-005: MaybeSummarize does not send a temperature parameter", func() {
+		It("should leave Options.Temperature nil on the summarization LLM call", func() {
+			fake := &fakeLLM{response: "summarized output"}
+			s := summarizer.New(fake, 100)
+
+			longOutput := strings.Repeat("data ", 50) // 250 chars
+			_, err := s.MaybeSummarize(context.Background(), "kubectl_logs", longOutput)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(fake.calls).To(HaveLen(1))
+			Expect(fake.calls[0].Options.Temperature).To(BeNil(),
+				"the summarizer must not hardcode a temperature — it shares the base LLM client/model "+
+					"with the rest of the agent and must not depend on that model supporting the "+
+					"parameter (fixes claude-opus-4-8 400 'temperature is deprecated for this model')")
 		})
 	})
 


### PR DESCRIPTION
## Summary

Kubernaut Agent unconditionally sent a `temperature` parameter on every LLM
request. `claude-opus-4-8` rejects that parameter outright with an HTTP 400
("temperature is deprecated for this model"), which surfaced to customers as
a generic `internal_error: Internal service error` during workflow discovery
(the specific 400 is redacted by `ErrorBoundary` before reaching the console).

This makes `temperature` optional end-to-end: omitted from the wire request
unless explicitly configured, while still honoring an explicit `0`
(BR-HAPI-199 — deterministic output must be an explicit choice, not confused
with "unset").

Fixes #1749.

## Business Requirement

`BR-HAPI-199` — temperature=0 must be sendable as an explicit, deterministic
configuration; this PR preserves that while fixing the "always sent" defect
that breaks models which don't support the parameter at all.

## Changes

- `pkg/kubernautagent/llm`: `RuntimeParams.Temperature` → `*float64`; new
  shared `llm.ApplyTemperature()` helper used by both LLM call sites
  (previously duplicated inline — this bug had two independent fix sites
  because of that duplication)
- `internal/kubernautagent/investigator`: `chatOrStream` (streaming path,
  the likely actual customer-facing call path for this incident) now calls
  `llm.ApplyTemperature` instead of unconditionally setting the field
- `internal/kubernautagent/config`: `LLMRuntimeConfig.Temperature` →
  `*float64`; `LLMOverrideConfig` gains a `Temperature` field for per-phase
  overrides; `EffectivePhaseConfig`/`AlignmentCheckConfig` merges and
  `Validate()` updated accordingly; `DefaultLLMRuntime()` leaves it nil
- `pkg/kubernautagent/tools/summarizer`: dropped the hardcoded
  `Temperature: ptr.To(0.0)` bypass entirely (an independent 400 source)
- `charts/kubernaut`: `kubernaut-agent-llm-runtime` ConfigMap only renders
  `temperature` when the key is present in values (`hasKey`, not a truthy
  `if`, so an explicit `0` still renders); `values.yaml` default commented
  out; `values.schema.json` default removed
- New Helm unittest suite (`kubernaut-agent-llm-runtime_test.yaml`) proving
  omit-by-default, explicit-`0.7`, and explicit-`0` rendering

`cmd/kubernautagent/main.go` and `llm_builder.go` needed **no changes** —
they already passed the runtime-config pointer straight through.

Tracked follow-ups (recorded in #1749, out of scope for this PR):
- Port the identical fix to `main`/`v1.6` (in progress)
- `kubernaut-operator` issue to make the CRD's equivalent field optional
  and avoid rendering it when unset in the CR

## Test Plan

- [x] Unit tests pass (`go test ./pkg/kubernautagent/llm/... ./internal/kubernautagent/config/... ./internal/kubernautagent/investigator/... ./pkg/kubernautagent/tools/summarizer/... ./cmd/kubernautagent/...`)
- [x] Integration tests pass (`test/integration/kubernautagent/config`)
- [x] `go build ./...` succeeds
- [x] `go vet ./...` succeeds
- [x] `golangci-lint run` passes (0 issues on changed packages)
- [x] `helm unittest charts/kubernaut` passes (new + existing suites)
- [x] Manually verified `helm template` output for omitted / explicit-0.7 / explicit-0 cases

## Checklist

- [x] Tests written following TDD (RED-GREEN-REFACTOR)
- [x] All errors handled and logged
- [x] Documentation updated (if applicable) — N/A, no user-facing docs affected
- [x] No breaking changes (or documented in description) — behavior change: fresh installs that never set `kubernautAgent.llm.temperature` will no longer send `temperature: 0.7` by default. Existing deployments that already set the value explicitly (in values or a custom ConfigMap) are unaffected.
