### PR TITLE
fix(ka): make LLM temperature optional, omitted unless configured (#1749) [main port]

### DIFF
--- a/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
+++ b/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
@@ -374,7 +374,14 @@ data:
   llm-runtime.yaml: |
     model: {{ $kaProfile.model | quote }}
     endpoint: {{ $kaProfile.endpoint | default "" | quote }}
-    temperature: {{ $kaProfile.temperature | default 0.7 }}
+    {{- /* #1749: only render temperature when explicitly set. Some models
+       (e.g. claude-opus-4-8) reject the parameter outright with a 400 if
+       it is present at all — omit it by default rather than forcing 0.7.
+       hasKey (not a truthy `if`) so an explicit `temperature: 0` still
+       renders (BR-HAPI-199 — explicit zero must still be sent). */}}
+    {{- if hasKey $kaProfile "temperature" }}
+    temperature: {{ $kaProfile.temperature }}
+    {{- end }}
     maxRetries: {{ $kaProfile.maxRetries | default 3 }}
     timeoutSeconds: {{ $kaProfile.timeoutSeconds | default 120 }}
 {{- if $kaPhaseProfiles }}

--- a/charts/kubernaut/tests/llm_profiles_test.yaml
+++ b/charts/kubernaut/tests/llm_profiles_test.yaml
@@ -113,6 +113,34 @@ tests:
           path: data['llm-runtime.yaml']
           pattern: "timeoutSeconds: 90"
 
+  - it: "IT-PLATFORM-LLM-003 (#1749): temperature is omitted entirely when not set on the profile"
+    template: templates/kubernaut-agent/kubernaut-agent.yaml
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-agent-llm-runtime
+    asserts:
+      - notMatchRegex:
+          path: data['llm-runtime.yaml']
+          pattern: "temperature:"
+
+  - it: "IT-PLATFORM-LLM-003 (#1749, BR-HAPI-199): an explicit temperature of 0 still renders"
+    set:
+      global:
+        llmProfiles:
+          primary:
+            provider: anthropic
+            model: claude-opus-4-8
+            credentialsSecretName: llm-credentials-primary
+            temperature: 0
+    template: templates/kubernaut-agent/kubernaut-agent.yaml
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-agent-llm-runtime
+    asserts:
+      - matchRegex:
+          path: data['llm-runtime.yaml']
+          pattern: "temperature: 0"
+
   # -------------------------------------------------------------------------
   # IT-PLATFORM-LLM-004: phaseModels resolves per-phase; unknown phase fails
   # -------------------------------------------------------------------------

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -465,10 +465,9 @@
               },
               "temperature": {
                 "type": "number",
-                "default": 0.7,
                 "minimum": 0,
                 "maximum": 2,
-                "description": "LLM sampling temperature."
+                "description": "LLM sampling temperature. Omitted by default (#1749) -- some models (e.g. claude-opus-4-8) reject this parameter outright with a 400 if it is present at all. Only set this if your model supports it."
               },
               "maxRetries": {
                 "type": "integer",

--- a/cmd/kubernautagent/llm_builder.go
+++ b/cmd/kubernautagent/llm_builder.go
@@ -252,10 +252,11 @@ func mergeLLMConfig(base types.LLMConfig, rt *kaconfig.LLMRuntimeConfig) types.L
 	}
 	merged.TimeoutSeconds = rt.TimeoutSeconds
 	merged.CustomHeaders = rt.CustomHeaders
-	if rt.Temperature != 0 {
-		t := rt.Temperature
-		merged.Temperature = &t
-	}
+	// #1749: rt.Temperature is already *float64 — a direct pointer copy
+	// preserves "not configured" (nil) exactly, unlike the previous
+	// `if rt.Temperature != 0` check, which conflated "unset" with
+	// "explicitly configured as 0" and violated BR-HAPI-199.
+	merged.Temperature = rt.Temperature
 	if rt.MaxRetries != 0 {
 		r := rt.MaxRetries
 		merged.MaxRetries = &r

--- a/cmd/kubernautagent/llm_builder_1749_test.go
+++ b/cmd/kubernautagent/llm_builder_1749_test.go
@@ -1,0 +1,74 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kaconfig "github.com/jordigilh/kubernaut/internal/kubernautagent/config"
+	"github.com/jordigilh/kubernaut/pkg/shared/types"
+	"k8s.io/utils/ptr"
+)
+
+// mergeLLMConfig's Temperature handling — #1749: the previous
+// `if rt.Temperature != 0` check conflated "not configured" with
+// "explicitly configured as 0", violating BR-HAPI-199 and forcing a
+// numeric temperature onto models (e.g. claude-opus-4-8) that reject the
+// parameter outright with a 400. Temperature is now a *float64 all the
+// way through, so mergeLLMConfig copies the pointer directly instead of
+// checking its value.
+var _ = Describe("mergeLLMConfig — temperature pointer semantics (#1749)", func() {
+
+	Describe("UT-KA-1749-007: omits temperature from the merged LLMConfig when not configured", func() {
+		It("should leave merged.Temperature nil when LLMRuntimeConfig.Temperature is nil", func() {
+			merged := mergeLLMConfig(types.LLMConfig{Provider: "anthropic"}, &kaconfig.LLMRuntimeConfig{
+				Model: "claude-opus-4-8",
+			})
+
+			Expect(merged.Temperature).To(BeNil(),
+				"temperature must be omitted from the merged config when not explicitly configured "+
+					"(fixes claude-opus-4-8 400 'temperature is deprecated for this model')")
+		})
+	})
+
+	Describe("UT-KA-1749-008 (BR-HAPI-199): preserves an explicit temperature of 0", func() {
+		It("should set merged.Temperature to 0 when LLMRuntimeConfig.Temperature is an explicit pointer to 0.0", func() {
+			merged := mergeLLMConfig(types.LLMConfig{Provider: "openai"}, &kaconfig.LLMRuntimeConfig{
+				Model:       "gpt-4o",
+				Temperature: ptr.To(0.0),
+			})
+
+			Expect(merged.Temperature).NotTo(BeNil(),
+				"an explicit temperature of 0 must survive the merge — BR-HAPI-199 requires "+
+					"deterministic output to be an explicit configuration, not confused with 'unset'")
+			Expect(*merged.Temperature).To(Equal(0.0))
+		})
+	})
+
+	Describe("UT-KA-1749-009: preserves a non-zero explicit temperature", func() {
+		It("should set merged.Temperature to the configured value", func() {
+			merged := mergeLLMConfig(types.LLMConfig{Provider: "openai"}, &kaconfig.LLMRuntimeConfig{
+				Model:       "gpt-4o",
+				Temperature: ptr.To(0.7),
+			})
+
+			Expect(merged.Temperature).NotTo(BeNil())
+			Expect(*merged.Temperature).To(Equal(0.7))
+		})
+	})
+})

--- a/internal/kubernautagent/config/config.go
+++ b/internal/kubernautagent/config/config.go
@@ -96,7 +96,7 @@ func isEmptyPhaseOverride(override *LLMOverrideConfig) bool {
 		override.Model == "" && override.APIKeyFile == "" &&
 		override.AzureAPIVersion == "" && override.VertexProject == "" &&
 		override.VertexLocation == "" && override.BedrockRegion == "" &&
-		override.Reasoning == nil)
+		override.Reasoning == nil && override.Temperature == nil)
 }
 
 // Validate checks required fields and value constraints for the static config.
@@ -391,9 +391,13 @@ func DefaultConfig() *Config {
 }
 
 // DefaultLLMRuntime returns an LLMRuntimeConfig with sensible production defaults.
+//
+// Temperature is deliberately left nil (#1749): not every model/provider
+// accepts the parameter (e.g. claude-opus-4-8 rejects it with a 400), so
+// the safe default is to omit it from the wire request entirely unless an
+// operator explicitly configures one for their model.
 func DefaultLLMRuntime() *LLMRuntimeConfig {
 	return &LLMRuntimeConfig{
-		Temperature:    0.7,
 		MaxRetries:     3,
 		TimeoutSeconds: 120,
 	}

--- a/internal/kubernautagent/config/config_1470_test.go
+++ b/internal/kubernautagent/config/config_1470_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/config"
 	"github.com/jordigilh/kubernaut/pkg/shared/types"
+	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("Per-Phase LLM Model Routing — #1470", func() {
@@ -113,13 +114,80 @@ phaseModels:
 				},
 			}
 			baseLLM := types.LLMConfig{Provider: "openai"}
-			baseRT := config.LLMRuntimeConfig{Model: "base-model", Endpoint: "http://base", Temperature: 0.7}
+			baseRT := config.LLMRuntimeConfig{Model: "base-model", Endpoint: "http://base", Temperature: ptr.To(0.7)}
 
 			outLLM, outRT := rt.EffectivePhaseConfig("workflow_discovery", baseLLM, baseRT)
 			Expect(outLLM.Provider).To(Equal("openai"), "provider should be preserved")
 			Expect(outRT.Model).To(Equal("fast-model"), "model should be overridden")
 			Expect(outRT.Endpoint).To(Equal("http://base"), "endpoint should be preserved")
-			Expect(outRT.Temperature).To(Equal(0.7), "temperature should be preserved")
+			Expect(outRT.Temperature).NotTo(BeNil(), "temperature should be preserved")
+			Expect(*outRT.Temperature).To(Equal(0.7), "temperature should be preserved")
+		})
+	})
+
+	Describe("UT-AI-1749-001: EffectivePhaseConfig merges a per-phase temperature override", func() {
+		It("should use the override's temperature when the phase sets one", func() {
+			rt := &config.LLMRuntimeConfig{
+				Model: "default-model",
+				PhaseModels: map[string]*config.LLMOverrideConfig{
+					"rca": {Temperature: ptr.To(0.2)},
+				},
+			}
+			baseLLM := types.LLMConfig{Provider: "anthropic"}
+			baseRT := config.LLMRuntimeConfig{Model: "claude-opus-4-8", Temperature: ptr.To(0.7)}
+
+			_, outRT := rt.EffectivePhaseConfig("rca", baseLLM, baseRT)
+			Expect(outRT.Temperature).NotTo(BeNil())
+			Expect(*outRT.Temperature).To(Equal(0.2), "phase override temperature should win over base")
+		})
+	})
+
+	Describe("UT-AI-1749-002: EffectivePhaseConfig inherits base temperature when the override is silent on it", func() {
+		It("should keep the base temperature when the phase override does not set one", func() {
+			rt := &config.LLMRuntimeConfig{
+				Model: "default-model",
+				PhaseModels: map[string]*config.LLMOverrideConfig{
+					"workflow_discovery": {Model: "fast-model"}, // no Temperature override
+				},
+			}
+			baseLLM := types.LLMConfig{Provider: "anthropic"}
+			baseRT := config.LLMRuntimeConfig{Model: "claude-opus-4-8", Temperature: ptr.To(0.7)}
+
+			_, outRT := rt.EffectivePhaseConfig("workflow_discovery", baseLLM, baseRT)
+			Expect(outRT.Temperature).NotTo(BeNil())
+			Expect(*outRT.Temperature).To(Equal(0.7), "base temperature must be inherited when override is silent")
+		})
+	})
+
+	Describe("UT-AI-1749-003: EffectivePhaseConfig inherits a nil base temperature (not coerced to 0)", func() {
+		It("should keep temperature nil when neither base nor override set one", func() {
+			rt := &config.LLMRuntimeConfig{
+				Model: "default-model",
+				PhaseModels: map[string]*config.LLMOverrideConfig{
+					"rca": {Model: "fast-model"},
+				},
+			}
+			baseLLM := types.LLMConfig{Provider: "anthropic"}
+			baseRT := config.LLMRuntimeConfig{Model: "claude-opus-4-8"} // Temperature unset (nil)
+
+			_, outRT := rt.EffectivePhaseConfig("rca", baseLLM, baseRT)
+			Expect(outRT.Temperature).To(BeNil(),
+				"omitted base temperature must stay nil through the phase merge — must not be coerced to 0")
+		})
+	})
+
+	Describe("UT-AI-1749-004 (SI-10): Validate accepts a temperature-only phase override", func() {
+		It("should not reject an override whose only set field is Temperature", func() {
+			rt := &config.LLMRuntimeConfig{
+				Model:    "test-model",
+				Endpoint: "http://localhost",
+				PhaseModels: map[string]*config.LLMOverrideConfig{
+					"rca": {Temperature: ptr.To(0.2)},
+				},
+			}
+			err := rt.Validate("openai")
+			Expect(err).NotTo(HaveOccurred(),
+				"a phase override that only sets Temperature must be treated as non-empty")
 		})
 	})
 

--- a/internal/kubernautagent/config/config_684_test.go
+++ b/internal/kubernautagent/config/config_684_test.go
@@ -105,7 +105,19 @@ temperature: 0.7
 `)
 			rt, err := config.LoadLLMRuntime(rtYAML)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(rt.Temperature).To(BeNumerically("~", 0.7, 0.001))
+			Expect(rt.Temperature).NotTo(BeNil(), "temperature was explicitly set in YAML and must be parsed")
+			Expect(*rt.Temperature).To(BeNumerically("~", 0.7, 0.001))
+		})
+
+		It("UT-KA-1749-006: leaves temperature nil when omitted from runtime config YAML", func() {
+			rtYAML := []byte(`
+model: "claude-opus-4-8"
+`)
+			rt, err := config.LoadLLMRuntime(rtYAML)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rt.Temperature).To(BeNil(),
+				"omitting temperature from the ConfigMap YAML must leave it unset (nil), not default it to a "+
+					"numeric value — fixes claude-opus-4-8 400 'temperature is deprecated for this model'")
 		})
 
 		It("UT-KA-684-006: parses maxRetries and timeoutSeconds from runtime config", func() {
@@ -132,7 +144,8 @@ timeoutSeconds: 60
 			Expect(err).NotTo(HaveOccurred())
 			Expect(rt.Model).To(Equal("claude-sonnet-4-20250514"))
 			Expect(rt.Endpoint).To(Equal("http://localhost:11434/v1"))
-			Expect(rt.Temperature).To(BeNumerically("~", 0.5, 0.001))
+			Expect(rt.Temperature).NotTo(BeNil(), "temperature was explicitly set in YAML and must be parsed")
+			Expect(*rt.Temperature).To(BeNumerically("~", 0.5, 0.001))
 			Expect(rt.MaxRetries).To(Equal(5))
 			Expect(rt.TimeoutSeconds).To(Equal(60))
 		})

--- a/internal/kubernautagent/config/config_types.go
+++ b/internal/kubernautagent/config/config_types.go
@@ -98,10 +98,16 @@ type FleetOAuth2 struct {
 // This struct maps to a separate ConfigMap (kubernaut-agent-llm-runtime) watched by
 // the FileWatcher.
 type LLMRuntimeConfig struct {
-	Model          string                        `yaml:"model"`
-	Endpoint       string                        `yaml:"endpoint"`
-	APIKeyFile     string                        `yaml:"apiKeyFile,omitempty"`
-	Temperature    float64                       `yaml:"temperature"`
+	Model      string `yaml:"model"`
+	Endpoint   string `yaml:"endpoint"`
+	APIKeyFile string `yaml:"apiKeyFile,omitempty"`
+	// Temperature is a pointer so "not configured" (nil, key absent from
+	// YAML) can be distinguished from "explicitly configured as 0"
+	// (BR-HAPI-199, #1749). Some models (e.g. claude-opus-4-8) reject the
+	// temperature parameter outright with a 400 if it is present at all,
+	// so it must be omitted from the wire request rather than defaulted to
+	// a numeric value when the operator never set it.
+	Temperature    *float64                      `yaml:"temperature,omitempty"`
 	MaxRetries     int                           `yaml:"maxRetries"`
 	TimeoutSeconds int                           `yaml:"timeoutSeconds"`
 	CustomHeaders  []types.LLMHeaderDef          `yaml:"customHeaders,omitempty"`
@@ -164,6 +170,9 @@ func (r *LLMRuntimeConfig) EffectivePhaseConfig(phase string, baseLLM types.LLMC
 	}
 	if override.Reasoning != nil {
 		staticOut.Reasoning = override.Reasoning
+	}
+	if override.Temperature != nil {
+		runtimeOut.Temperature = override.Temperature
 	}
 	return staticOut, runtimeOut
 }
@@ -465,6 +474,10 @@ type LLMOverrideConfig struct {
 	// hot-reload changing only this field is not subject to the
 	// restart-required identity lock.
 	Reasoning *types.LLMReasoningConfig `yaml:"reasoning,omitempty"`
+	// Temperature overrides the base/phase temperature (#1749). Nil means
+	// "inherit the base value unchanged" — not "force omission" —
+	// mirroring LLMRuntimeConfig.Temperature's pointer semantics.
+	Temperature *float64 `yaml:"temperature,omitempty"`
 }
 
 // EffectiveLLM returns a merged set of static + runtime fields for the
@@ -507,6 +520,9 @@ func (c *AlignmentCheckConfig) EffectiveLLM(base types.LLMConfig, runtime LLMRun
 	}
 	if c.LLM.Reasoning != nil {
 		staticOut.Reasoning = c.LLM.Reasoning
+	}
+	if c.LLM.Temperature != nil {
+		runtimeOut.Temperature = c.LLM.Temperature
 	}
 	return staticOut, runtimeOut
 }

--- a/internal/kubernautagent/investigator/investigator_loop.go
+++ b/internal/kubernautagent/investigator/investigator_loop.go
@@ -398,8 +398,10 @@ func (inv *Investigator) chatOrStream(ctx context.Context, client llm.Client, re
 		"diag_dropped", diagSendDrop.Load(),
 		"diag_nil", diagSinkNil.Load())
 
-	temp := runtimeParams.Temperature
-	req.Options.Temperature = &temp
+	// #1749: shared with ChatWithParams's non-streaming path — see
+	// llm.ApplyTemperature's doc comment for why this was pulled out into
+	// one function.
+	llm.ApplyTemperature(&req.Options, runtimeParams)
 
 	bo := llm.ResolveRetryBackoff(runtimeParams)
 	maxAttempts := llm.ResolveMaxAttempts(runtimeParams)

--- a/pkg/kubernautagent/llm/chat_helpers.go
+++ b/pkg/kubernautagent/llm/chat_helpers.go
@@ -158,6 +158,23 @@ func IsNonRetryableHTTPStatus(code int) bool {
 	}
 }
 
+// ApplyTemperature copies params.Temperature onto opts only when it is
+// explicitly configured (non-nil). Some models (e.g. claude-opus-4-8)
+// reject the temperature parameter outright with a 400 if it is present
+// on the wire request at all, regardless of value — so "not configured"
+// must mean "omitted", not "defaulted to a numeric value" (#1749).
+//
+// Exported because both non-streaming (ChatWithParams, below) and
+// streaming (investigator's runLLMLoop/chatOrStream-equivalent) call
+// paths need it — a previous version of this logic was duplicated inline
+// in both places, which is exactly how the #1749 bug ended up with two
+// independent, easy-to-miss fix sites instead of one.
+func ApplyTemperature(opts *ChatOptions, params RuntimeParams) {
+	if params.Temperature != nil {
+		opts.Temperature = params.Temperature
+	}
+}
+
 // ChatWithParams wraps a Client.Chat call, injecting runtime parameters
 // (temperature, timeout, retries) from the hot-reloadable LLM config.
 // Each attempt gets a fresh context timeout; the timeout is cancelled
@@ -166,8 +183,7 @@ func IsNonRetryableHTTPStatus(code int) bool {
 // and fail fast on errors an adapter has classified as non-retryable
 // (#1585) instead of consuming the full retry budget.
 func ChatWithParams(ctx context.Context, client Client, req ChatRequest, params RuntimeParams) (ChatResponse, error) {
-	temp := params.Temperature
-	req.Options.Temperature = &temp
+	ApplyTemperature(&req.Options, params)
 
 	bo := ResolveRetryBackoff(params)
 	maxAttempts := ResolveMaxAttempts(params)

--- a/pkg/kubernautagent/llm/chat_with_params_test.go
+++ b/pkg/kubernautagent/llm/chat_with_params_test.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 	"github.com/jordigilh/kubernaut/pkg/shared/backoff"
+	"k8s.io/utils/ptr"
 )
 
 var fastBackoff = &backoff.Config{
@@ -98,7 +99,7 @@ var _ = Describe("ChatWithParams — BUG-1/BUG-3 fixes", func() {
 			}}
 
 			params := llm.RuntimeParams{
-				Temperature:    0.7,
+				Temperature:    ptr.To(0.7),
 				TimeoutSeconds: 5,
 			}
 			req := llm.ChatRequest{
@@ -121,7 +122,7 @@ var _ = Describe("ChatWithParams — BUG-1/BUG-3 fixes", func() {
 			}}
 
 			params := llm.RuntimeParams{
-				Temperature: 0.7,
+				Temperature: ptr.To(0.7),
 			}
 			req := llm.ChatRequest{
 				Messages: []llm.Message{{Role: "user", Content: "test"}},
@@ -139,6 +140,51 @@ var _ = Describe("ChatWithParams — BUG-1/BUG-3 fixes", func() {
 		})
 	})
 
+	Describe("UT-KA-1749-001: omits temperature from the wire request when not configured", func() {
+		It("should leave Options.Temperature nil when RuntimeParams.Temperature is nil", func() {
+			mock := &capturingClient{resp: llm.ChatResponse{
+				Message: llm.Message{Role: "assistant", Content: "ok"},
+			}}
+
+			params := llm.RuntimeParams{
+				Temperature: nil, // not configured — must not be sent to the provider
+			}
+			req := llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "test"}},
+			}
+
+			_, err := llm.ChatWithParams(context.Background(), mock, req, params)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mock.capturedReq.Options.Temperature).To(BeNil(),
+				"temperature must be omitted from the request when not explicitly configured "+
+					"(fixes claude-opus-4-8 400 'temperature is deprecated for this model')")
+		})
+	})
+
+	Describe("UT-KA-1749-002 (BR-HAPI-199): still sends an explicit temperature of 0", func() {
+		It("should set Options.Temperature to 0 when RuntimeParams.Temperature is an explicit pointer to 0.0", func() {
+			mock := &capturingClient{resp: llm.ChatResponse{
+				Message: llm.Message{Role: "assistant", Content: "ok"},
+			}}
+
+			params := llm.RuntimeParams{
+				Temperature: ptr.To(0.0), // explicitly configured as zero, not "unset"
+			}
+			req := llm.ChatRequest{
+				Messages: []llm.Message{{Role: "user", Content: "test"}},
+			}
+
+			_, err := llm.ChatWithParams(context.Background(), mock, req, params)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mock.capturedReq.Options.Temperature).NotTo(BeNil(),
+				"an explicit temperature of 0 must still be sent — BR-HAPI-199 requires "+
+					"deterministic output to be an explicit configuration, not confused with 'unset'")
+			Expect(*mock.capturedReq.Options.Temperature).To(Equal(0.0))
+		})
+	})
+
 	Describe("UT-KA-967-004: no timeout when TimeoutSeconds is 0", func() {
 		It("should not wrap context with timeout", func() {
 			mock := &capturingClient{resp: llm.ChatResponse{
@@ -146,7 +192,7 @@ var _ = Describe("ChatWithParams — BUG-1/BUG-3 fixes", func() {
 			}}
 
 			params := llm.RuntimeParams{
-				Temperature:    0.5,
+				Temperature:    ptr.To(0.5),
 				TimeoutSeconds: 0,
 			}
 			req := llm.ChatRequest{
@@ -168,7 +214,7 @@ var _ = Describe("ChatWithParams — BUG-1/BUG-3 fixes", func() {
 				successResp: llm.ChatResponse{Message: llm.Message{Role: "assistant", Content: "ok"}},
 			}
 			params := llm.RuntimeParams{
-				Temperature:  0.7,
+				Temperature:  ptr.To(0.7),
 				MaxRetries:   maxRetries,
 				RetryBackoff: fastBackoff,
 			}
@@ -208,7 +254,7 @@ var _ = Describe("ChatWithParams — BUG-1/BUG-3 fixes", func() {
 				Multiplier: 2.0, JitterPercent: 0,
 			}
 			params := llm.RuntimeParams{
-				Temperature:  0.7,
+				Temperature:  ptr.To(0.7),
 				MaxRetries:   5,
 				RetryBackoff: slowBackoff,
 			}

--- a/pkg/kubernautagent/llm/classify_1585_test.go
+++ b/pkg/kubernautagent/llm/classify_1585_test.go
@@ -26,6 +26,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	"k8s.io/utils/ptr"
 )
 
 // Issue #1585: ChatWithParams retries on any non-nil error for the full
@@ -88,7 +89,7 @@ var _ = Describe("LLM error classification — #1585", func() {
 		It("makes exactly one call, consuming none of the retry budget", func() {
 			mock := &nonRetryableErrorClient{err: llm.MarkNonRetryable(errors.New("401: invalid api key"))}
 			params := llm.RuntimeParams{
-				Temperature:  0.7,
+				Temperature:  ptr.To(0.7),
 				MaxRetries:   5,
 				RetryBackoff: fastBackoff,
 			}

--- a/pkg/kubernautagent/llm/swappable_client.go
+++ b/pkg/kubernautagent/llm/swappable_client.go
@@ -42,11 +42,18 @@ const oldClientCloseTimeout = 5 * time.Second
 //     one lock acquisition; callers needing more than one of these values
 //     together should use Pin rather than calling Snapshot/ModelName/
 //     RuntimeParameters separately, which can observe a torn combination.
+//
 // RuntimeParams holds LLM runtime parameters that can be hot-reloaded
 // alongside the client. Investigator reads these at the start of each
 // investigation to pin values for the duration.
+//
+// Temperature is a pointer so "not configured" (nil) can be distinguished
+// from "explicitly configured as 0" (BR-HAPI-199, #1749). Some models
+// (e.g. claude-opus-4-8) reject the temperature parameter outright with a
+// 400 if it is present at all, so it must be omitted from the wire request
+// rather than defaulted to a numeric value when the operator never set it.
 type RuntimeParams struct {
-	Temperature    float64
+	Temperature    *float64
 	TimeoutSeconds int
 	MaxRetries     int
 	// RetryBackoff overrides the default backoff config for ChatWithParams retries.

--- a/pkg/kubernautagent/llm/swappable_client_1610_test.go
+++ b/pkg/kubernautagent/llm/swappable_client_1610_test.go
@@ -25,6 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	"k8s.io/utils/ptr"
 )
 
 var _ = Describe("SwappableClient.Pin — atomic client+model+params snapshot (#1610)", func() {
@@ -34,7 +35,7 @@ var _ = Describe("SwappableClient.Pin — atomic client+model+params snapshot (#
 			const iterations = 5000
 
 			original := &recordingClient{id: "0"}
-			sc, err := llm.NewSwappableClient(original, "model-0", llm.RuntimeParams{Temperature: 0})
+			sc, err := llm.NewSwappableClient(original, "model-0", llm.RuntimeParams{Temperature: ptr.To(0.0)})
 			Expect(err).NotTo(HaveOccurred())
 
 			var mismatches atomic.Int64
@@ -49,7 +50,7 @@ var _ = Describe("SwappableClient.Pin — atomic client+model+params snapshot (#
 				defer close(stop)
 				for i := 1; i <= iterations; i++ {
 					id := strconv.Itoa(i)
-					_ = sc.Swap(&recordingClient{id: id}, "model-"+id, llm.RuntimeParams{Temperature: float64(i)})
+					_ = sc.Swap(&recordingClient{id: id}, "model-"+id, llm.RuntimeParams{Temperature: ptr.To(float64(i))})
 				}
 			}()
 
@@ -77,7 +78,9 @@ var _ = Describe("SwappableClient.Pin — atomic client+model+params snapshot (#
 							mismatches.Add(1)
 							continue
 						}
-						if snap.ModelName != "model-"+rc.id || snap.RuntimeParams.Temperature != float64(idx) {
+						if snap.ModelName != "model-"+rc.id ||
+							snap.RuntimeParams.Temperature == nil ||
+							*snap.RuntimeParams.Temperature != float64(idx) {
 							mismatches.Add(1)
 						}
 					}

--- a/pkg/kubernautagent/tools/summarizer/summarizer.go
+++ b/pkg/kubernautagent/tools/summarizer/summarizer.go
@@ -24,7 +24,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools"
-	"k8s.io/utils/ptr"
 )
 
 // Summarizer uses a secondary LLM call to shorten tool output that exceeds
@@ -85,12 +84,15 @@ func (s *Summarizer) MaybeSummarize(ctx context.Context, toolName string, result
 		)
 	}
 
+	// #1749: no Temperature is set here. This call shares the base LLM
+	// client/model with the rest of the agent, so it cannot assume the
+	// configured model supports the parameter at all (e.g. claude-opus-4-8
+	// rejects it outright with a 400) — omitting it entirely is safe for
+	// every provider, and summarization has no BR-HAPI-199-style
+	// determinism requirement that would justify forcing 0.
 	resp, err := s.llmClient.Chat(ctx, llm.ChatRequest{
 		Messages: []llm.Message{
 			{Role: "user", Content: prompt},
-		},
-		Options: llm.ChatOptions{
-			Temperature: ptr.To(0.0),
 		},
 	})
 	if err != nil {
@@ -125,7 +127,7 @@ type wrappedTool struct {
 	summarizer *Summarizer
 }
 
-func (w *wrappedTool) Name() string               { return w.inner.Name() }
+func (w *wrappedTool) Name() string                { return w.inner.Name() }
 func (w *wrappedTool) Description() string         { return w.inner.Description() }
 func (w *wrappedTool) Parameters() json.RawMessage { return w.inner.Parameters() }
 


### PR DESCRIPTION
## Summary

Port of #1750 (release/v1.5 hotfix) to `main`/v1.6.

Kubernaut Agent unconditionally sent a `temperature` parameter on every LLM
request. `claude-opus-4-8` rejects that parameter outright with an HTTP 400
("temperature is deprecated for this model"), which surfaced to customers as
a generic `internal_error: Internal service error` during workflow discovery
(the specific 400 is redacted by `ErrorBoundary` before reaching the console).

This makes `temperature` optional end-to-end: omitted from the wire request
unless explicitly configured, while still honoring an explicit `0`
(BR-HAPI-199 — deterministic output must be an explicit choice, not confused
with "unset").

`main`'s `anthropicfamily` adapter (the anthropic-sdk-go based client) already
guarded on `Temperature != nil` correctly before this PR — the bug was
entirely in the upstream plumbing that populated that pointer even when
unconfigured, same as v1.5's `langchaingo` adapter.

Fixes #1749.

## Business Requirement

`BR-HAPI-199` — temperature=0 must be sendable as an explicit, deterministic
configuration; this PR preserves that while fixing the "always sent" defect
that breaks models which don't support the parameter at all.

## Changes

Identical shape to the v1.5 fix (#1750), adapted to `main`'s file layout:

- `pkg/kubernautagent/llm`: `RuntimeParams.Temperature` → `*float64`; new
  shared `llm.ApplyTemperature()` helper used by both LLM call sites
  (previously duplicated inline — this bug had two independent fix sites
  because of that duplication)
- `internal/kubernautagent/investigator/investigator_loop.go`: `chatOrStream`
  (streaming path) now calls `llm.ApplyTemperature` instead of
  unconditionally setting it
- `internal/kubernautagent/config/config_types.go` + `config.go`:
  `LLMRuntimeConfig.Temperature` → `*float64`; `LLMOverrideConfig` gains a
  `Temperature` field for per-phase overrides; `EffectivePhaseConfig`/
  `AlignmentCheckConfig.EffectiveLLM` merges, `isEmptyPhaseOverride`, and
  `Validate()` updated accordingly; `DefaultLLMRuntime()` leaves it nil
- `cmd/kubernautagent/llm_builder.go`: `mergeLLMConfig`'s naive
  `if rt.Temperature != 0` check — which itself violated BR-HAPI-199 by
  conflating "unset" with "explicitly 0" — is replaced with a direct
  pointer copy (both sides are now `*float64`, so no check is needed at all).
  This was a second, independent BR-HAPI-199 violation discovered during the
  preflight sweep for #1749, fixed here rather than deferred.
- `pkg/kubernautagent/tools/summarizer`: dropped the hardcoded
  `Temperature: ptr.To(0.0)` bypass entirely (an independent 400 source)
- `charts/kubernaut`: `kubernaut-agent-llm-runtime` ConfigMap only renders
  `temperature` when the resolved `llmProfiles` entry has the key
  (`hasKey`, not a truthy `if`, so an explicit `0` still renders);
  `values.schema.json` default removed
- Extended the existing `llm_profiles_test.yaml` Helm unittest suite with
  omit-by-default and explicit-`0` cases for the ConfigMap wiring point

**Explicitly out of scope for this PR** (matches v1.5's scope; recorded in
#1749 as a follow-up): the Helm `phaseModels` override block
(`kubernaut.llm.overrideBlock` in `_helpers.tpl`) does not expose a
per-phase `temperature` override. That helper deliberately mirrors the
Kubernaut Operator's `configmaps.go` field set for `phaseModels` rendering
(documented in the helper's own comment), and extending it is a cross-repo
consistency decision, not a unilateral chart change. The per-phase override
*is* fully supported at the Go/ConfigMap level (`LLMOverrideConfig.Temperature`)
for anyone hand-authoring the ConfigMap directly.

Also tracked as a follow-up in #1749 (not this PR): the `kubernaut-operator`
issue to make the CRD's equivalent field optional and avoid rendering it
when unset in the CR.

## Test Plan

- [x] Unit tests pass (`go test ./pkg/kubernautagent/llm/... ./internal/kubernautagent/config/... ./internal/kubernautagent/investigator/... ./pkg/kubernautagent/tools/summarizer/... ./cmd/kubernautagent/...`)
- [x] `go build ./...` succeeds
- [x] `go vet ./...` succeeds
- [x] `golangci-lint run` passes (0 issues on changed packages)
- [x] `helm unittest charts/kubernaut` passes (177/177, including 2 new + 29 existing in `llm_profiles_test.yaml`)
- [x] Manually verified `helm template` output for omitted / explicit-`0` cases

## Test Plan (checklist continuation)

- [x] Integration tests pass (if applicable) — no dedicated IT suite for this wiring point; covered by the Helm unittest ConfigMap assertions and unit tests exercising the real merge/apply functions
- [x] No new lint errors introduced

## Checklist

- [x] Tests written following TDD (RED-GREEN-REFACTOR)
- [x] All errors handled and logged
- [x] Documentation updated (if applicable) — N/A, no user-facing docs affected
- [x] No breaking changes (or documented in description) — behavior change: fresh installs whose `global.llmProfiles.<name>` never sets `temperature` will no longer send `temperature: 0.7` by default. Existing deployments that already set the value explicitly are unaffected.

## Notes

A pre-existing, unrelated flake was observed during verification and
confirmed **not** caused by this change (reproduces identically on
unmodified `main`, in isolation and under repeated runs):
`cmd/kubernautagent`'s `UT-KA-FLEET-022` (`gatewayOverlayResolver`
singleflight dedup) is timing-sensitive under full-suite load.
