### PR TITLE
fix(ka): eliminate UT-KA-FLEET-022 singleflight dedup test flake

### DIFF
--- a/cmd/kubernautagent/toolregistry_overlay_singleflight_test.go
+++ b/cmd/kubernautagent/toolregistry_overlay_singleflight_test.go
@@ -18,8 +18,11 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"runtime"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -83,23 +86,72 @@ var _ = Describe("gatewayOverlayResolver.Overlay singleflight dedup (DD-FLEET-00
 		var wg sync.WaitGroup
 		var successes atomic.Int32
 		wg.Add(concurrency)
-		for i := 0; i < concurrency; i++ {
-			go func() {
-				defer wg.Done()
-				overlay, err := resolver.Overlay(context.Background(), "prod-east")
-				if err == nil && overlay != nil {
-					successes.Add(1)
-				}
-			}()
+
+		call := func() {
+			defer wg.Done()
+			overlay, err := resolver.Overlay(context.Background(), "prod-east")
+			if err == nil && overlay != nil {
+				successes.Add(1)
+			}
 		}
 
-		// Exactly one of the concurrency goroutines is expected to actually
-		// enter ToolsForCluster -- the rest block inside singleflight.Do
-		// itself, never reaching countingDiscoverer at all. Waiting for this
-		// single signal (rather than a fixed sleep) proves the goroutines
-		// were genuinely racing to call Overlay concurrently before any of
-		// them could have returned.
+		// Start the leader alone first and wait for it to actually enter
+		// ToolsForCluster. That proves it is registered as the in-flight
+		// singleflight call for "prod-east" *before* any follower exists,
+		// so every follower spawned below is guaranteed to join this same
+		// call rather than race to start its own.
+		//
+		// #1754: the previous version spawned all `concurrency` goroutines
+		// at once and released the leader as soon as *one* of them entered
+		// -- with no guarantee the other N-1 had reached singleflight.Do
+		// yet. Under scheduler contention from the rest of the suite, a
+		// follower could still be sitting in Go's run queue when the leader
+		// finished and singleflight cleared its in-flight entry, so that
+		// follower started an independent second call. This reproduced
+		// (`callCount == 2`) within a handful of repeated runs under
+		// `-race`.
+		go call()
 		<-disc.entered
+
+		// Now spawn the followers. Each bumps enteredOverlay immediately
+		// before calling Overlay, with no yield point in between, so
+		// spinning until the counter reaches concurrency-1 proves every
+		// follower has reached singleflight.Do -- and therefore joined the
+		// still-blocked leader's in-flight call -- before the leader is
+		// released below. The leader cannot have completed in the
+		// meantime: we haven't closed disc.release yet.
+		var enteredOverlay atomic.Int32
+		for i := 0; i < concurrency-1; i++ {
+			go func() {
+				enteredOverlay.Add(1)
+				call()
+			}()
+		}
+		deadline := time.Now().Add(5 * time.Second)
+		for enteredOverlay.Load() < int32(concurrency-1) {
+			if time.Now().After(deadline) {
+				Fail(fmt.Sprintf("timed out waiting for %d followers to reach Overlay; only %d observed",
+					concurrency-1, enteredOverlay.Load()))
+			}
+			runtime.Gosched()
+		}
+
+		// The counter proves every follower goroutine has been scheduled at
+		// least once and is about to call Overlay, but -- as documented by
+		// golang.org/x/sync/singleflight's own TestDoDupSuppress, which
+		// faces this identical problem and resorts to the same technique
+		// ("time.Sleep(10ms) // let more goroutines enter Do") -- an
+		// atomic signal immediately before a call is not a hard guarantee
+		// that the call has actually happened: Go's runtime can preempt a
+		// goroutine between any two instructions (async, signal-based
+		// preemption since Go 1.14), and this gap is real, not
+		// theoretical -- it reproduced under -race within 2 repeats during
+		// development of this fix. A short settle margin here closes it:
+		// unlike singleflight's own test (which only asserts "more than 0,
+		// fewer than n" calls and so can tolerate the gap), SC-5 requires
+		// asserting exactly one call, so the margin must be more generous.
+		time.Sleep(50 * time.Millisecond)
+
 		close(disc.release)
 		wg.Wait()
 


### PR DESCRIPTION
## Summary

Test-only fix. `gatewayOverlayResolver.Overlay`'s singleflight dedup test
(`UT-KA-FLEET-022`) was intermittently flaky, failing with `callCount == 2`
instead of `1`. Noted (but deliberately not fixed, to keep that PR's diff
focused) as a pre-existing, unrelated issue during #1751's verification.

## Root Cause

The test spawned all 5 concurrent callers at once and released the blocked
leader as soon as *one* of them entered `ToolsForCluster`, with no guarantee
the other 4 had reached `singleflight.Do` yet. Under scheduler contention
(reliably reproducible under `-race` within 2-3 repeats), a follower could
still be sitting in the run queue when the leader completed and singleflight
cleared its in-flight map entry — so that follower started an independent
second call instead of joining the first.

## Fix

1. Start the leader alone first and wait for it to actually enter
   `ToolsForCluster` — this deterministically proves it is registered and
   blocked as the in-flight call before any follower exists.
2. Spawn the followers, each bumping an atomic counter immediately before
   calling `Overlay`, and spin-wait for the counter to confirm all of them
   have been scheduled.
3. Add a bounded settle margin (`time.Sleep(50ms)`) before releasing the
   leader. An atomic signal immediately before a call is not a hard
   guarantee the call has already executed — Go's async, signal-based
   goroutine preemption can land between any two instructions, and this
   reproduced under `-race` even with step 2 alone. This is the same
   technique `golang.org/x/sync/singleflight`'s own `TestDoDupSuppress`
   uses (`time.Sleep(10ms) // let more goroutines enter Do`); a larger
   margin is used here since this test asserts *exactly one* call, a
   stronger invariant than singleflight's own test (which only asserts
   "more than 0, fewer than n").

## Verification

- 500 repeats under `ginkgo -race -repeat` (`UT-KA-FLEET-022`/`023`): 0 failures
  (previously reproduced a failure within 2-3 repeats)
- Full `cmd/kubernautagent` suite: 91/91 passing
- `go build ./...`, `go vet ./...`: clean
- `golangci-lint run ./cmd/kubernautagent/...`: 0 issues

## Business Requirement

N/A — test-only determinism fix, no business logic changed. The test itself
covers `BR-INTEGRATION-1489` (DD-FLEET-004 singleflight dedup), unaffected.

## Checklist

- [x] Tests written following TDD (reproduced the failure first, then fixed)
- [x] No breaking changes
- [x] No new lint errors introduced

Made with [Cursor](https://cursor.com)