### PR TITLE
fix(fleet): resolve gateway-agnostic tool prefix in KA overlay (#1756)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,11 @@ SERVICES := $(filter-out README.md must-gather, $(notdir $(wildcard cmd/*)))
 # Result: aianalysis apifrontend authwebhook datastorage effectivenessmonitor gateway kubernautagent notification remediationorchestrator signalprocessing workflowexecution
 # Note: must-gather is a bash tool, built separately via cmd/must-gather/Makefile
 
+# COMMA: literal comma for use inside $(if ...) expressions building
+# comma-separated --coverpkg lists (a bare "," inside $(if ...) would be
+# parsed as an argument separator, not a literal character).
+COMMA := ,
+
 # Test configuration
 # Dynamically detect CPU cores (works on Linux and macOS)
 # Linux (GitHub Actions): nproc
@@ -253,50 +258,63 @@ ensure-coverage-dirs: ## Ensure coverage directories exist for all test tiers, p
 
 # Unit Tests
 .PHONY: test-unit-%
+# cmd/$* is included whenever it exists (true for every real SERVICES entry;
+# guarded via $(wildcard ...) so ad-hoc invocations against a non-service
+# pkg/ directory, e.g. `make test-unit-fleet`, keep working unchanged) --
+# closes a gap where cmd/<service>'s own Ginkgo suites (main-package wiring
+# code, white-box tests needing same-package access) were never executed by
+# any make target or CI job. See Issue #1756 discussion.
 test-unit-%: ginkgo ensure-coverage-dirs ## Run unit tests for specified service (e.g., make test-unit-gateway)
 	@echo "════════════════════════════════════════════════════════════════════════"
 	@echo "🧪 $* - Unit Tests ($(TEST_PROCS) procs)"
 	@echo "════════════════════════════════════════════════════════════════════════"
-	@$(GINKGO) -v $(RACE_FLAG) --timeout=$(TEST_TIMEOUT_UNIT) --procs=$(TEST_PROCS) --coverprofile=coverage_unit_$*.out --covermode=atomic --coverpkg=github.com/jordigilh/kubernaut/pkg/$*/...,github.com/jordigilh/kubernaut/internal/controller/$*/... ./pkg/$*/... ./internal/controller/$*/...
+	@$(GINKGO) -v $(RACE_FLAG) --timeout=$(TEST_TIMEOUT_UNIT) --procs=$(TEST_PROCS) --coverprofile=coverage_unit_$*.out --covermode=atomic --coverpkg=github.com/jordigilh/kubernaut/pkg/$*/...,github.com/jordigilh/kubernaut/internal/controller/$*/...$(if $(wildcard cmd/$*),$(COMMA)github.com/jordigilh/kubernaut/cmd/$*/...) ./pkg/$*/... ./internal/controller/$*/...$(if $(wildcard cmd/$*), ./cmd/$*/...)
 	@if [ -f coverage_unit_$*.out ]; then \
 		echo ""; \
 		echo "📊 Coverage report generated: coverage_unit_$*.out"; \
 		go tool cover -func=coverage_unit_$*.out | grep total || echo "No coverage data"; \
 	fi
 
-# Kubernaut Agent unit tests: internal code lives at internal/kubernautagent/ (not internal/controller/)
+# Kubernaut Agent unit tests: internal code lives at internal/kubernautagent/ (not internal/controller/).
+# cmd/kubernautagent/... is included (Issue #1756): its 20+ file Ginkgo suite
+# (main-package wiring, e.g. toolregistry.go's gatewayOverlayResolver) had no
+# make target or CI job executing it at all.
 .PHONY: test-unit-kubernautagent
-test-unit-kubernautagent: ginkgo ensure-coverage-dirs ## Run kubernaut agent unit tests (coverpkg: pkg + internal/kubernautagent)
+test-unit-kubernautagent: ginkgo ensure-coverage-dirs ## Run kubernaut agent unit tests (coverpkg: pkg + internal/kubernautagent + cmd/kubernautagent)
 	@echo "════════════════════════════════════════════════════════════════════════"
 	@echo "🧪 kubernautagent - Unit Tests ($(TEST_PROCS) procs)"
 	@echo "════════════════════════════════════════════════════════════════════════"
-	@$(GINKGO) -v --race --timeout=$(TEST_TIMEOUT_UNIT) --procs=$(TEST_PROCS) --coverprofile=coverage_unit_kubernautagent.out --covermode=atomic --coverpkg=github.com/jordigilh/kubernaut/pkg/kubernautagent/...,github.com/jordigilh/kubernaut/internal/kubernautagent/... ./pkg/kubernautagent/... ./internal/kubernautagent/...
+	@$(GINKGO) -v --race --timeout=$(TEST_TIMEOUT_UNIT) --procs=$(TEST_PROCS) --coverprofile=coverage_unit_kubernautagent.out --covermode=atomic --coverpkg=github.com/jordigilh/kubernaut/pkg/kubernautagent/...,github.com/jordigilh/kubernaut/internal/kubernautagent/...,github.com/jordigilh/kubernaut/cmd/kubernautagent/... ./pkg/kubernautagent/... ./internal/kubernautagent/... ./cmd/kubernautagent/...
 	@if [ -f coverage_unit_kubernautagent.out ]; then \
 		echo ""; \
 		echo "📊 Coverage report generated: coverage_unit_kubernautagent.out"; \
 		go tool cover -func=coverage_unit_kubernautagent.out | grep total || echo "No coverage data"; \
 	fi
 
-# Gateway unit tests: no internal/controller/gateway/ exists, use pkg-only coverpkg
+# Gateway unit tests: no internal/controller/gateway/ exists, use pkg-only coverpkg.
+# cmd/gateway/... is included (Issue #1756 Makefile-gap fix): see the
+# test-unit-kubernautagent comment above for why this matters.
 .PHONY: test-unit-gateway
-test-unit-gateway: ginkgo ensure-coverage-dirs ## Run gateway unit tests (coverpkg: pkg/gateway only)
+test-unit-gateway: ginkgo ensure-coverage-dirs ## Run gateway unit tests (coverpkg: pkg/gateway + cmd/gateway)
 	@echo "════════════════════════════════════════════════════════════════════════"
 	@echo "🧪 gateway - Unit Tests ($(TEST_PROCS) procs)"
 	@echo "════════════════════════════════════════════════════════════════════════"
-	@$(GINKGO) -v $(RACE_FLAG) --timeout=$(TEST_TIMEOUT_UNIT) --procs=$(TEST_PROCS) --coverprofile=coverage_unit_gateway.out --covermode=atomic --coverpkg=github.com/jordigilh/kubernaut/pkg/gateway/... ./pkg/gateway/...
+	@$(GINKGO) -v $(RACE_FLAG) --timeout=$(TEST_TIMEOUT_UNIT) --procs=$(TEST_PROCS) --coverprofile=coverage_unit_gateway.out --covermode=atomic --coverpkg=github.com/jordigilh/kubernaut/pkg/gateway/...,github.com/jordigilh/kubernaut/cmd/gateway/... ./pkg/gateway/... ./cmd/gateway/...
 	@if [ -f coverage_unit_gateway.out ]; then \
 		echo ""; \
 		echo "📊 Coverage report generated: coverage_unit_gateway.out"; \
 		go tool cover -func=coverage_unit_gateway.out | grep total || echo "No coverage data"; \
 	fi
 
-# Fleet Metadata Cache unit tests: code lives at pkg/fleet/fmc/
+# Fleet Metadata Cache unit tests: code lives at pkg/fleet/fmc/.
+# cmd/fleetmetadatacache/... is included (Issue #1756 Makefile-gap fix): see
+# the test-unit-kubernautagent comment above for why this matters.
 .PHONY: test-unit-fleetmetadatacache
-test-unit-fleetmetadatacache: ginkgo ensure-coverage-dirs ## Run Fleet Metadata Cache unit tests (coverpkg: pkg/fleet/fmc)
+test-unit-fleetmetadatacache: ginkgo ensure-coverage-dirs ## Run Fleet Metadata Cache unit tests (coverpkg: pkg/fleet/fmc + cmd/fleetmetadatacache)
 	@echo "════════════════════════════════════════════════════════════════════════"
 	@echo "🧪 fleetmetadatacache - Unit Tests ($(TEST_PROCS) procs)"
 	@echo "════════════════════════════════════════════════════════════════════════"
-	@$(GINKGO) -v $(RACE_FLAG) --timeout=$(TEST_TIMEOUT_UNIT) --procs=$(TEST_PROCS) --coverprofile=coverage_unit_fleetmetadatacache.out --covermode=atomic --coverpkg=github.com/jordigilh/kubernaut/pkg/fleet/fmc/... ./pkg/fleet/fmc/...
+	@$(GINKGO) -v $(RACE_FLAG) --timeout=$(TEST_TIMEOUT_UNIT) --procs=$(TEST_PROCS) --coverprofile=coverage_unit_fleetmetadatacache.out --covermode=atomic --coverpkg=github.com/jordigilh/kubernaut/pkg/fleet/fmc/...,github.com/jordigilh/kubernaut/cmd/fleetmetadatacache/... ./pkg/fleet/fmc/... ./cmd/fleetmetadatacache/...
 	@if [ -f coverage_unit_fleetmetadatacache.out ]; then \
 		echo ""; \
 		echo "📊 Coverage report generated: coverage_unit_fleetmetadatacache.out"; \
@@ -325,7 +343,7 @@ test-unit-datastorage: ginkgo ensure-coverage-dirs ## Run datastorage unit tests
 	@echo "════════════════════════════════════════════════════════════════════════"
 	@echo "🧪 datastorage - Unit Tests ($(TEST_PROCS) procs) [coverage: hand-written code only]"
 	@echo "════════════════════════════════════════════════════════════════════════"
-	@$(GINKGO) -v $(RACE_FLAG) --timeout=$(TEST_TIMEOUT_UNIT) --procs=$(TEST_PROCS) --coverprofile=coverage_unit_datastorage.out --covermode=atomic --output-dir=. --coverpkg=$(DATASTORAGE_COVERPKG) ./pkg/datastorage/...
+	@$(GINKGO) -v $(RACE_FLAG) --timeout=$(TEST_TIMEOUT_UNIT) --procs=$(TEST_PROCS) --coverprofile=coverage_unit_datastorage.out --covermode=atomic --output-dir=. --coverpkg=$(DATASTORAGE_COVERPKG),github.com/jordigilh/kubernaut/cmd/datastorage/... ./pkg/datastorage/... ./cmd/datastorage/...
 	@if [ -f coverage_unit_datastorage.out ]; then \
 		echo ""; \
 		echo "📊 Coverage report generated: coverage_unit_datastorage.out"; \
@@ -767,12 +785,15 @@ test-e2e-kubernautagent: ginkgo ensure-coverage-dirs generate-agentclient ## Run
 
 ##@ Special Cases - Authentication Webhook
 
+# cmd/authwebhook/... has no test files today but is included for
+# consistency/future-proofing (Issue #1756 Makefile-gap fix): if tests are
+# added there later, they run automatically without another Makefile edit.
 .PHONY: test-unit-authwebhook
 test-unit-authwebhook: ginkgo ensure-coverage-dirs ## Run authentication webhook unit tests
 	@echo "════════════════════════════════════════════════════════════════════════"
 	@echo "🧪 Authentication Webhook - Unit Tests ($(TEST_PROCS) procs)"
 	@echo "════════════════════════════════════════════════════════════════════════"
-	@$(GINKGO) -v $(RACE_FLAG) --timeout=$(TEST_TIMEOUT_UNIT) --procs=$(TEST_PROCS) --coverprofile=coverage_unit_authwebhook.out --covermode=atomic --coverpkg=github.com/jordigilh/kubernaut/pkg/authwebhook/... ./pkg/authwebhook/...
+	@$(GINKGO) -v $(RACE_FLAG) --timeout=$(TEST_TIMEOUT_UNIT) --procs=$(TEST_PROCS) --coverprofile=coverage_unit_authwebhook.out --covermode=atomic --coverpkg=github.com/jordigilh/kubernaut/pkg/authwebhook/...,github.com/jordigilh/kubernaut/cmd/authwebhook/... ./pkg/authwebhook/... ./cmd/authwebhook/...
 	@if [ -f coverage_unit_authwebhook.out ]; then \
 		echo ""; \
 		echo "📊 Coverage report generated: coverage_unit_authwebhook.out"; \

--- a/cmd/kubernautagent/toolregistry.go
+++ b/cmd/kubernautagent/toolregistry.go
@@ -192,12 +192,25 @@ func (r *gatewayOverlayResolver) Overlay(ctx context.Context, clusterID string) 
 		if err != nil {
 			return nil, fmt.Errorf("discover tools for cluster %q: %w", clusterID, err)
 		}
+		names := make([]string, len(defs))
+		for i, def := range defs {
+			names[i] = def.Name
+		}
+		// EAIGW names carry a "{clusterID}__" wire prefix; Kuadrant names
+		// carry whatever admin-set MCPServerRegistration.spec.prefix the
+		// cluster was registered with, which is NOT guaranteed to follow the
+		// "{clusterID}__" shape (Issue #1756). PrefixFromToolNames matches
+		// gateway-agnostically against the discovered names themselves
+		// rather than assuming either convention, so both gateway types
+		// resolve correctly without KA needing to know which one it's
+		// talking to.
+		prefix, prefixErr := fleetclient.PrefixFromToolNames(clusterID, names)
+		if prefixErr != nil {
+			return nil, fmt.Errorf("resolve tool prefix for cluster %q: %w", clusterID, prefixErr)
+		}
 		overlay := make(map[string]tools.Tool, len(defs))
 		for _, def := range defs {
-			// EAIGW names carry a "{clusterID}__" wire prefix; Kuadrant names
-			// (post select_tools) are already bare. TrimPrefix is a no-op for
-			// the latter, so this line handles both gateway types uniformly.
-			genericName := strings.TrimPrefix(def.Name, clusterID+"__")
+			genericName := strings.TrimPrefix(def.Name, prefix)
 			bridge := fleetclient.NewBridgeTool(def, clusterID, r.session)
 			overlay[genericName] = &genericNameTool{inner: bridge, name: genericName}
 		}

--- a/cmd/kubernautagent/toolregistry_kuadrant_prefix_test.go
+++ b/cmd/kubernautagent/toolregistry_kuadrant_prefix_test.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/fleet/mcpclient"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools"
+)
+
+// fixedDiscoverer implements mcpclient.GatewayDiscoverer, returning a fixed
+// set of ToolDefinitions for one clusterID regardless of which gateway wire
+// convention those definitions carry -- lets a single test double drive both
+// EAIGW-style and Kuadrant-style prefix scenarios against the real
+// gatewayOverlayResolver.
+type fixedDiscoverer struct {
+	clusterID string
+	defs      []mcpclient.ToolDefinition
+}
+
+func (d *fixedDiscoverer) ListClusters(_ context.Context, _ string) ([]mcpclient.ClusterInfo, error) {
+	return nil, nil
+}
+
+func (d *fixedDiscoverer) ToolsForCluster(_ context.Context, clusterID string) ([]mcpclient.ToolDefinition, error) {
+	if clusterID != d.clusterID {
+		return nil, nil
+	}
+	return d.defs, nil
+}
+
+// capturingSession implements mcpclient.Session, recording the tool name
+// each CallTool invocation used. This lets a test assert that the wire call
+// reaches the gateway under the tool's ORIGINAL, gateway-prefixed name even
+// though the LLM only ever sees the generic one (DD-FLEET-004).
+type capturingSession struct {
+	lastToolName string
+}
+
+func (s *capturingSession) CallTool(_ context.Context, params *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+	s.lastToolName = params.Name
+	return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: "ok"}}}, nil
+}
+
+// UT-KA-FLEET-024/025 [AC-4]: gatewayOverlayResolver.Overlay() must generic-ize
+// a cluster's discovered tool names identically regardless of which gateway
+// wire convention produced them (Issue #1756). Overlay()'s generic-name
+// computation must never leak the wire prefix into the LLM-facing tool
+// identity, and must never leave the wire identity used for the real gateway
+// call ambiguous -- both are AC-4 (information flow enforcement) properties:
+// an incorrect generic key here means an investigation's tool calls silently
+// resolve against the wrong cluster boundary instead of erroring.
+//
+// These tests call the real, unexported gatewayOverlayResolver.Overlay()
+// directly (not a re-derivation living in another package, which is exactly
+// how issue #1756 went undetected) with only the GatewayDiscoverer/Session
+// external dependencies faked, per the project's mock-external-only policy.
+var _ = Describe("gatewayOverlayResolver.Overlay prefix resolution across gateway conventions (DD-FLEET-004, BR-INTEGRATION-054, BR-INTEGRATION-1489) [AC-4]", func() {
+	DescribeTable("generic-izes the tool name regardless of the gateway's wire prefix convention",
+		func(clusterID, wireName string) {
+			session := &capturingSession{}
+			disc := &fixedDiscoverer{
+				clusterID: clusterID,
+				defs:      []mcpclient.ToolDefinition{{Name: wireName}},
+			}
+			resolver := &gatewayOverlayResolver{discoverer: disc, session: session}
+
+			overlay, err := resolver.Overlay(context.Background(), clusterID)
+			Expect(err).ToNot(HaveOccurred())
+
+			tool, found := overlay["resources_get"]
+			Expect(found).To(BeTrue(),
+				"DD-FLEET-004/AC-4: the LLM must see this cluster's tool under the generic name "+
+					"'resources_get', regardless of the gateway's wire prefix convention -- got keys %v", toolKeys(overlay))
+			Expect(tool.Name()).To(Equal("resources_get"))
+
+			_, execErr := tool.Execute(context.Background(), json.RawMessage(`{}`))
+			Expect(execErr).ToNot(HaveOccurred())
+			Expect(session.lastToolName).To(Equal(wireName),
+				"AC-4: the wire call must reach the gateway using the cluster's original prefixed "+
+					"name even though the LLM only ever named the generic tool")
+		},
+		Entry("UT-KA-FLEET-024 [AC-4]: EAIGW convention ({clusterID}__resources_get)",
+			"cluster-a", "cluster-a__resources_get"),
+		Entry("UT-KA-FLEET-025 [AC-4]: Kuadrant convention (admin-set spec.prefix, NOT {clusterID}__)",
+			"prod-east", "prod_east_resources_get"),
+	)
+})
+
+func toolKeys(overlay map[string]tools.Tool) []string {
+	keys := make([]string, 0, len(overlay))
+	for k := range overlay {
+		keys = append(keys, k)
+	}
+	return keys
+}

--- a/docs/testing/1756/TEST_PLAN.md
+++ b/docs/testing/1756/TEST_PLAN.md
@@ -1,0 +1,99 @@
+# Test Plan: Fleet Tool Overlay Gateway-Agnostic Prefix Resolution
+
+**Issue**: #1756
+**Authority**: [DD-FLEET-004](../../architecture/decisions/DD-FLEET-004-cluster-transparent-tool-exposure.md), [ADR-068](../../architecture/decisions/ADR-068-fleet-federation-architecture.md) decision #10/#11
+**Business Requirements**: BR-INTEGRATION-054, BR-INTEGRATION-1489
+**Branch**: `fix/1756-kuadrant-tool-prefix`
+**Created**: 2026-07-28
+**Status**: Active
+
+---
+
+## 1. Purpose
+
+`gatewayOverlayResolver.Overlay()` (`cmd/kubernautagent/toolregistry.go`) computes the
+LLM-facing "generic" tool name by unconditionally stripping the EAIGW convention
+(`"{clusterID}__"`). For Kuadrant, whose `MCPServerRegistration.spec.prefix` is a free-text,
+admin-set value that does not follow that convention (e.g. `prod-east` → `prod_east_`), the
+strip is a no-op: the remote tool is never offered to the LLM under its generic name, and the
+LLM silently falls back to the hub-local tool of the same name — an incorrect-cluster data
+correctness defect for RCA, not merely a missed optimization.
+
+This is a business acceptance criterion failure, not just a code defect: DD-FLEET-004 commits
+to "the LLM's tool schema for a fleet-target investigation is byte-identical to a hub-local
+investigation's" and "the LLM can never request tools for a cluster other than the one it was
+asked to investigate." Every test below asserts one of these two business-level outcomes
+directly (map key identity, wire wire-name identity) — not the internal string-manipulation
+mechanism — so the tests remain valid even if the extraction algorithm changes later.
+
+## 2. FedRAMP Control Mapping
+
+| Control | Title | Relevance |
+|---|---|---|
+| **AC-4** | Information Flow Enforcement | Primary control. The defect is a cross-cluster information-flow-enforcement failure: an investigation's tool calls must be enforced to the intended target-cluster boundary; on failure they must error, never silently resolve against a different (hub) boundary. Directly analogous to `E2E-FMC-054-015`'s cross-cluster isolation assertion in `docs/testing/BR-INTEGRATION-054/TEST_PLAN.md`. |
+| **AC-6** | Least Privilege | Secondary. DD-FLEET-004's own stated guarantee ("the LLM can never request tools for a cluster other than the one it was asked to investigate") is the least-privilege property this defect silently violates by substituting wrong-cluster data instead of failing closed. |
+
+## 3. Pyramid Invariant — Test Scenario Inventory
+
+Per the pyramid invariant, no single tier is sufficient: UT proves the extraction logic is
+correct in isolation, the same-package UT proves the *actual* production `Overlay()` method
+(not a re-derivation, which is exactly how #1756 went undetected) is wired to that logic
+correctly for both gateway conventions, IT proves it against a real MCP protocol round trip,
+and the journey test proves the full `Investigator.Investigate()` path end-to-end.
+
+| ID | Tier | Business-Level Behavior Description | Control | BR | Test File |
+|---|---|---|---|---|---|
+| UT-MCP-TN-101..106 | UT | `PrefixFromToolNames` derives the correct gateway-specific wire prefix from a list of discovered tool names for both EAIGW (`{clusterID}__`) and Kuadrant (admin-set, non-`{clusterID}__`) conventions, and errors (not panics/guesses) when no tool name matches the cluster | AC-4 | BR-INTEGRATION-054 | `pkg/fleet/mcpclient/discover_test.go` |
+| UT-KA-FLEET-024/025 | UT | The real, unexported `gatewayOverlayResolver.Overlay()` generic-izes a cluster's discovered tool name identically regardless of gateway convention: the LLM sees the tool under the same generic key (`resources_get`) whether the wire name is `cluster-a__resources_get` (EAIGW) or `prod_east_resources_get` (Kuadrant), and the wire call still reaches the gateway under the tool's original prefixed name | AC-4 | BR-INTEGRATION-054, BR-INTEGRATION-1489 | `cmd/kubernautagent/toolregistry_kuadrant_prefix_test.go` |
+| IT-KA-FLEET-010 (revised) | IT | The exported `fleetclient.PrefixFromToolNames` helper correctly derives a Kuadrant cluster's wire prefix from tool names discovered via a **real** two-phase `discover_tools`/`select_tools`/`ListTools` MCP protocol round trip against the mock gateway (no hardcoded literal prefix duplicated in test code) | AC-4 | BR-INTEGRATION-054 | `test/integration/kubernautagent/fleet/fleet_wiring_test.go` |
+| E2E-KA-FLEET-002 (new) | "E2E" (journey, per this repo's existing DD-FLEET-004 labeling of `fleet_e2e_journey_test.go`) | KA's full `Investigator.Investigate()` -> LLM -> gateway journey resolves and executes a remote-cluster tool correctly when the fleet gateway is Kuadrant (non-bare prefix convention), matching the existing EAIGW-only `E2E-KA-FLEET-001` journey | AC-4 | BR-INTEGRATION-054, BR-INTEGRATION-1489 | `test/integration/kubernautagent/investigator/fleet_e2e_journey_test.go` |
+
+## 4. Why the Existing Suite Missed This (Coverage Gap Being Closed)
+
+- `E2E-KA-FLEET-001` is the only test driving KA's real `Investigator.Investigate()` through
+  the fleet overlay end-to-end, but it only exercises EAIGW, where the buggy formula is
+  correct by construction.
+- `IT-KA-FLEET-010` configured a non-bare Kuadrant prefix but re-derived the trim step with
+  the literal correct answer (`strings.TrimPrefix(def.Name, "prod_east_")`) instead of calling
+  the production formula, so it could never detect the mismatch.
+- No test previously called the real `gatewayOverlayResolver.Overlay()` with a non-`{clusterID}__`
+  prefix at all.
+
+This plan closes all three gaps: `UT-KA-FLEET-024/025` calls the real production method
+directly; `IT-KA-FLEET-010` is fixed to call the real exported helper against real protocol
+traffic instead of a hardcoded literal; `E2E-KA-FLEET-002` extends the one real journey test
+to a Kuadrant scenario.
+
+### 4.1 A fourth, orthogonal gap: `cmd/*` unit suites were never executed by CI
+
+While adding `UT-KA-FLEET-024/025` (a same-package unit test calling the real, unexported
+`gatewayOverlayResolver.Overlay()` directly), discovered that `make test-unit-kubernautagent`
+listed only `./pkg/kubernautagent/... ./internal/kubernautagent/...` — `./cmd/kubernautagent/...`
+was never in any make target's package list, so its entire 20+ file Ginkgo suite (96 specs,
+including the pre-existing `toolregistry_test.go`, `toolregistry_overlay_singleflight_test.go`,
+etc.) had **zero** make target or CI job executing it, ever. `.github/workflows/ci-pipeline.yml`'s
+unit-test matrix job runs exactly `make test-unit-${{ matrix.service }}` per service, so this was
+a silent, repo-wide CI blind spot, not just a kubernautagent-specific one: the same audit found
+5 more services (`gateway`, `fleetmetadatacache`, `datastorage`, `apifrontend` via the generic
+`test-unit-%` pattern rule, plus `authwebhook` with no `cmd/` tests yet) with a `cmd/<service>`
+Ginkgo/`testing.T` suite that was similarly never run. Fixed in the `Makefile`: the generic
+`test-unit-%` pattern rule and all 5 dedicated per-service targets now conditionally include
+`./cmd/$*/...` (via `$(wildcard cmd/$*)`, so non-service ad hoc invocations are unaffected), and
+all 12 CI-matrix services were re-run locally via their `make test-unit-*` target to confirm zero
+regressions. Without this fix, `UT-KA-FLEET-024/025` above would have caught the bug locally but
+never run in CI at all.
+
+## 5. Coverage Targets
+
+| Tier | Target |
+|---|---|
+| Unit | 100% of `PrefixFromToolNames` branches (match, no-match, empty input) |
+| Integration | 100% wiring proof for this fix (`IT-KA-FLEET-010` uses the real exported helper against real MCP protocol traffic) |
+| Journey | Both gateway conventions (EAIGW `E2E-KA-FLEET-001`, Kuadrant `E2E-KA-FLEET-002`) exercise the identical `Investigator.Investigate()` production path |
+
+## 6. References
+
+- Issue #1756
+- [DD-FLEET-004: Cluster-Transparent Tool Exposure](../../architecture/decisions/DD-FLEET-004-cluster-transparent-tool-exposure.md)
+- [ADR-068: Fleet Federation Architecture](../../architecture/decisions/ADR-068-fleet-federation-architecture.md)
+- [BR-INTEGRATION-054 Test Plan](../BR-INTEGRATION-054/TEST_PLAN.md) (AC-4 precedent: `E2E-FMC-054-015` cross-cluster isolation)

--- a/pkg/fleet/mcpclient/discover.go
+++ b/pkg/fleet/mcpclient/discover.go
@@ -28,11 +28,8 @@ import (
 // the gateway-specific prefix for a given cluster by matching the cluster ID
 // against discovered tool names.
 //
-// The matching is gateway-agnostic: it normalizes both the cluster ID and tool
-// names (replacing hyphens with underscores) and checks whether any tool starts
-// with the normalized cluster ID and ends with a known base tool name. The
-// prefix returned is the original (un-normalized) substring before the base
-// tool name, preserving whatever separator the gateway uses.
+// The matching itself is gateway-agnostic and delegates to PrefixFromToolNames;
+// see that function's doc comment for the extraction algorithm.
 //
 // Authority: ADR-068 decision #10 (gateway-agnostic business logic), Issue #54
 func DiscoverToolPrefix(ctx context.Context, session *mcp.ClientSession, clusterID string) (string, error) {
@@ -41,27 +38,63 @@ func DiscoverToolPrefix(ctx context.Context, session *mcp.ClientSession, cluster
 		return "", fmt.Errorf("list tools from MCP Gateway: %w", err)
 	}
 
+	names := make([]string, len(result.Tools))
+	for i, tool := range result.Tools {
+		names[i] = tool.Name
+	}
+
+	prefix, err := PrefixFromToolNames(clusterID, names)
+	if err != nil {
+		return "", fmt.Errorf("in MCP Gateway tools/list response: %w", err)
+	}
+	return prefix, nil
+}
+
+// PrefixFromToolNames finds the gateway-specific wire prefix for a given
+// cluster by matching the cluster ID against an already-discovered list of
+// tool names.
+//
+// The matching is gateway-agnostic: it normalizes both the cluster ID and each
+// tool name (replacing hyphens with underscores) and checks whether the name
+// starts with the normalized cluster ID and ends with a known base tool name.
+// The prefix returned is the original (un-normalized) substring before the
+// base tool name, preserving whatever separator the gateway uses -- this
+// covers both EAIGW's "{clusterID}__" convention and Kuadrant's admin-set
+// MCPServerRegistration.spec.prefix, which is not required to follow the
+// "{clusterID}__" shape at all (Issue #1756).
+//
+// Operating on a plain name slice (rather than a live *mcp.ClientSession, as
+// DiscoverToolPrefix does) lets callers that already hold discovered tool
+// definitions -- e.g. cmd/kubernautagent's gatewayOverlayResolver.Overlay(),
+// which gets them from GatewayDiscoverer.ToolsForCluster() -- reuse this exact
+// extraction logic without an extra ListTools() round trip and without
+// duplicating (and silently drifting from) it, which is exactly how #1756
+// went undetected.
+//
+// Authority: ADR-068 decision #10 (gateway-agnostic business logic),
+// DD-FLEET-004, BR-INTEGRATION-054, BR-INTEGRATION-1489, Issue #1756.
+func PrefixFromToolNames(clusterID string, names []string) (string, error) {
 	normalized := strings.ReplaceAll(clusterID, "-", "_")
 
-	for _, tool := range result.Tools {
-		name := strings.ReplaceAll(tool.Name, "-", "_")
-		if !strings.HasPrefix(name, normalized) {
+	for _, name := range names {
+		normalizedName := strings.ReplaceAll(name, "-", "_")
+		if !strings.HasPrefix(normalizedName, normalized) {
 			continue
 		}
 		for _, suffix := range knownToolSuffixes {
-			if strings.HasSuffix(name, suffix) {
-				prefix := tool.Name[:len(tool.Name)-len(suffix)]
+			if strings.HasSuffix(normalizedName, suffix) {
+				prefix := name[:len(name)-len(suffix)]
 				return prefix, nil
 			}
 		}
 	}
 
-	return "", fmt.Errorf("no tools found for cluster %q in MCP Gateway tools/list response", clusterID)
+	return "", fmt.Errorf("no tools found for cluster %q among %d discovered tool names", clusterID, len(names))
 }
 
 // knownToolSuffixes are the base tool names from kubernetes-mcp-server that
-// DiscoverToolPrefix uses as anchors to extract the cluster prefix from
-// gateway-prefixed tool names.
+// PrefixFromToolNames (and, transitively, DiscoverToolPrefix) uses as anchors
+// to extract the cluster prefix from gateway-prefixed tool names.
 var knownToolSuffixes = []string{
 	ToolGet,
 	ToolList,

--- a/pkg/fleet/mcpclient/discover_test.go
+++ b/pkg/fleet/mcpclient/discover_test.go
@@ -135,3 +135,54 @@ var _ = Describe("DiscoverToolPrefix (BR-INTEGRATION-054, ADR-068 #10)", func() 
 		Expect(err.Error()).To(ContainSubstring("no tools found for cluster"))
 	})
 })
+
+// PrefixFromToolNames is DiscoverToolPrefix's pure extraction logic, operating
+// on an already-discovered slice of tool names rather than a live MCP
+// session. Extracted for issue #1756: gatewayOverlayResolver.Overlay()
+// (cmd/kubernautagent) needs the exact same gateway-agnostic matching against
+// names it already has from ToolsForCluster(), without an extra ListTools()
+// round trip and without duplicating (and silently drifting from) this logic.
+//
+// Authority: ADR-068 decision #10 (gateway-agnostic business logic),
+// DD-FLEET-004, BR-INTEGRATION-054, BR-INTEGRATION-1489, Issue #1756.
+var _ = Describe("PrefixFromToolNames (BR-INTEGRATION-054, BR-INTEGRATION-1489, ADR-068 #10) [AC-4]", func() {
+	DescribeTable("derives the gateway-specific prefix from an already-discovered tool name list",
+		func(clusterID string, names []string, expectedPrefix string) {
+			prefix, err := mcpclient.PrefixFromToolNames(clusterID, names)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(prefix).To(Equal(expectedPrefix))
+		},
+
+		Entry("UT-MCP-TN-101 [AC-4]: EAIGW convention (cluster-a -> cluster-a__)",
+			"cluster-a",
+			[]string{"cluster-a__resources_get", "cluster-a__resources_list"},
+			"cluster-a__",
+		),
+		Entry("UT-MCP-TN-102 [AC-4]: Kuadrant convention (cluster-a -> cluster_a_)",
+			"cluster-a",
+			[]string{"cluster_a_resources_get", "cluster_a_resources_list"},
+			"cluster_a_",
+		),
+		Entry("UT-MCP-TN-103 [AC-4]: Kuadrant multi-segment prefix (prod-east -> prod_east_)",
+			"prod-east",
+			[]string{"prod_east_resources_get"},
+			"prod_east_",
+		),
+		Entry("UT-MCP-TN-104 [AC-4]: mixed tool list -- only the target cluster's own tools match (AC-4 cross-cluster isolation)",
+			"prod-east",
+			[]string{"prod_west_resources_get", "prod_east_resources_list"},
+			"prod_east_",
+		),
+	)
+
+	It("UT-MCP-TN-105 [AC-4]: returns an error (never a wrong-cluster guess) when no name matches the cluster ID", func() {
+		_, err := mcpclient.PrefixFromToolNames("nonexistent", []string{"cluster-a__resources_get"})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no tools found for cluster"))
+	})
+
+	It("UT-MCP-TN-106 [AC-4]: returns an error for an empty name list", func() {
+		_, err := mcpclient.PrefixFromToolNames("cluster-a", nil)
+		Expect(err).To(HaveOccurred())
+	})
+})

--- a/test/integration/kubernautagent/fleet/fleet_wiring_test.go
+++ b/test/integration/kubernautagent/fleet/fleet_wiring_test.go
@@ -397,9 +397,26 @@ var _ = Describe("Fleet Wiring Integration Tests (BR-INTEGRATION-065)", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(defs).ToNot(BeEmpty())
 
+			// AC-4/Issue #1756: derive the wire prefix via the same
+			// gateway-agnostic PrefixFromToolNames helper production code
+			// uses (cmd/kubernautagent's gatewayOverlayResolver.Overlay()),
+			// instead of a hardcoded "prod_east_" literal that can silently
+			// drift from Kuadrant's actual (admin-set, non-{clusterID}__)
+			// MCPServerRegistration.spec.prefix convention. This proves the
+			// helper's extraction against real discover_tools/select_tools/
+			// ListTools MCP protocol traffic, not just a mocked table.
+			names := make([]string, len(defs))
+			for i, def := range defs {
+				names[i] = def.Name
+			}
+			prefix, err := mcpclient.PrefixFromToolNames("prod-east", names)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(prefix).To(Equal("prod_east_"),
+				"sanity check: the mock gateway's configured Prefix must round-trip through real discovery")
+
 			reg := toolregistry.New()
 			for _, def := range defs {
-				generic := strings.TrimPrefix(def.Name, "prod_east_")
+				generic := strings.TrimPrefix(def.Name, prefix)
 				bridge := mcpclient.NewBridgeTool(def, "prod-east", session)
 				reg.Register(&fleetGenericNameTool{inner: bridge, name: generic})
 			}

--- a/test/integration/kubernautagent/investigator/fleet_e2e_journey_test.go
+++ b/test/integration/kubernautagent/investigator/fleet_e2e_journey_test.go
@@ -61,9 +61,24 @@ const fleetE2EMarker = "kubernaut-fleet-e2e-remote-marker-1732"
 // (test/integration/kubernautagent/fleet/fleet_wiring_test.go); duplicated
 // here because the production type is unexported and this package cannot
 // import cmd/kubernautagent (a main package).
+//
+// wirePrefix is threaded in explicitly by each test rather than derived via
+// fleetclient.PrefixFromToolNames: this resolver's job is to prove
+// Investigator.Investigate() correctly CONSUMES an overlay (map key identity
+// + wire-name preservation) through a real MCP session end to end -- not to
+// re-derive the wire prefix, which is already proven against the real
+// production helper by UT-MCP-TN-* (pkg/fleet/mcpclient), UT-KA-FLEET-024/025
+// (cmd/kubernautagent, calling the real unexported gatewayOverlayResolver.
+// Overlay() directly), and IT-KA-FLEET-010 (real discover_tools/select_tools
+// protocol round trip). Each test sets wirePrefix to exactly what it
+// configured its own mock gateway with, so the mapping stays visible and
+// auditable in the same file rather than silently duplicating (and risking
+// drift from) the derivation formula -- the exact anti-pattern Issue #1756
+// found in the pre-fix IT-KA-FLEET-010.
 type fleetE2EOverlayResolver struct {
 	discoverer fleetclient.GatewayDiscoverer
 	session    fleetclient.Session
+	wirePrefix string
 }
 
 func (r *fleetE2EOverlayResolver) Overlay(ctx context.Context, clusterID string) (map[string]tools.Tool, error) {
@@ -73,11 +88,38 @@ func (r *fleetE2EOverlayResolver) Overlay(ctx context.Context, clusterID string)
 	}
 	overlay := make(map[string]tools.Tool, len(defs))
 	for _, def := range defs {
-		generic := strings.TrimPrefix(def.Name, clusterID+"__")
+		generic := strings.TrimPrefix(def.Name, r.wirePrefix)
 		bridge := fleetclient.NewBridgeTool(def, clusterID, r.session)
 		overlay[generic] = &fleetE2EGenericNameTool{inner: bridge, name: generic}
 	}
 	return overlay, nil
+}
+
+// fleetE2EFixedDiscoverer implements fleetclient.GatewayDiscoverer, returning
+// a fixed set of ToolDefinitions for one clusterID. Used by the Kuadrant
+// journey scenario (E2E-KA-FLEET-002) in place of the real KuadrantDiscoverer:
+// that discoverer's ToolsForCluster() requires the discover_tools/select_tools
+// meta-tools (mockgw.WithDiscoverableTools), which only support the 4 fixed
+// kube-mcp-server tool base names -- IT-KA-FLEET-010 already proves that real
+// two-phase protocol round trip against the real KuadrantDiscoverer. This
+// journey test's distinct job is proving Investigator.Investigate() reaches
+// the remote gateway under a non-"{clusterID}__" wire prefix end to end, so a
+// fixed discoverer stands in for the discovery step while the actual
+// mcp.CallTool wire dispatch below still goes through a real MCP session.
+type fleetE2EFixedDiscoverer struct {
+	clusterID string
+	defs      []fleetclient.ToolDefinition
+}
+
+func (d *fleetE2EFixedDiscoverer) ListClusters(_ context.Context, _ string) ([]fleetclient.ClusterInfo, error) {
+	return nil, nil
+}
+
+func (d *fleetE2EFixedDiscoverer) ToolsForCluster(_ context.Context, clusterID string) ([]fleetclient.ToolDefinition, error) {
+	if clusterID != d.clusterID {
+		return nil, nil
+	}
+	return d.defs, nil
 }
 
 // fleetE2EGenericNameTool locally mirrors cmd/kubernautagent's unexported
@@ -133,6 +175,54 @@ func (fleetE2EScenario) ConfigForContext(ctx *scenarios.DetectionContext) scenar
 	}
 	return scenarios.MockScenarioConfig{
 		ScenarioName: "fleet_e2e_journey_1732",
+		ToolCallName: "kubectl_get_by_name",
+		ToolCallArgs: map[string]interface{}{
+			"kind": "Pod", "name": "api-server-abc", "namespace": "production",
+		},
+		ForceText: scenarios.BoolPtr(false),
+	}
+}
+
+// fleetE2EKuadrantMarker is fleetE2EMarker's counterpart for the Kuadrant
+// journey scenario (E2E-KA-FLEET-002, Issue #1756): a distinctive string
+// embedded in the mock gateway's tool result so the mock-LLM scenario can
+// detect whether the remote tool has already executed.
+const fleetE2EKuadrantMarker = "kubernaut-fleet-e2e-remote-marker-1756"
+
+// fleetE2EKuadrantScenario mirrors fleetE2EScenario for the Kuadrant
+// convention journey (Issue #1756 regression guard): same turn-dependent
+// tool-call-then-RCA-text shape, targeting cluster prod-east under a
+// Kuadrant-style admin-set prefix ("prod_east_") instead of EAIGW's
+// "{clusterID}__".
+type fleetE2EKuadrantScenario struct{}
+
+func (fleetE2EKuadrantScenario) Name() string { return "fleet_e2e_journey_kuadrant_1756" }
+func (fleetE2EKuadrantScenario) Metadata() scenarios.ScenarioMetadata {
+	return scenarios.ScenarioMetadata{Name: "fleet_e2e_journey_kuadrant_1756", Description: "E2E-KA-FLEET-002"}
+}
+func (fleetE2EKuadrantScenario) DAG() *conversation.DAG { return nil }
+func (fleetE2EKuadrantScenario) Match(ctx *scenarios.DetectionContext) (bool, float64) {
+	if strings.Contains(ctx.Content, "fleetkuadranttransparencyprobe") {
+		return true, 1.0
+	}
+	return false, 0
+}
+func (fleetE2EKuadrantScenario) ConfigForContext(ctx *scenarios.DetectionContext) scenarios.MockScenarioConfig {
+	if strings.Contains(ctx.AllText, fleetE2EKuadrantMarker) {
+		actionable := true
+		return scenarios.MockScenarioConfig{
+			ScenarioName:         "fleet_e2e_journey_kuadrant_1756",
+			SignalName:           "FleetKuadrantTransparencyProbe",
+			Severity:             "critical",
+			RootCause:            "remote pod api-server-abc confirmed OOMKilled via a fleet-transparent tool call routed to Kuadrant cluster prod-east",
+			InvestigationOutcome: "actionable",
+			IsActionable:         &actionable,
+			Confidence:           0.9,
+			ForceText:            scenarios.BoolPtr(true),
+		}
+	}
+	return scenarios.MockScenarioConfig{
+		ScenarioName: "fleet_e2e_journey_kuadrant_1756",
 		ToolCallName: "kubectl_get_by_name",
 		ToolCallArgs: map[string]interface{}{
 			"kind": "Pod", "name": "api-server-abc", "namespace": "production",
@@ -204,7 +294,7 @@ var _ = Describe("Fleet cluster-transparent tool exposure — full journey (BR-I
 				MaxTurns:             5,
 				PhaseTools:           investigator.DefaultPhaseToolMap(),
 				Registry:             reg,
-				FleetOverlayResolver: &fleetE2EOverlayResolver{discoverer: disc, session: session},
+				FleetOverlayResolver: &fleetE2EOverlayResolver{discoverer: disc, session: session, wirePrefix: "remote-east__"},
 			})
 
 			signal := katypes.SignalContext{
@@ -234,6 +324,112 @@ var _ = Describe("Fleet cluster-transparent tool exposure — full journey (BR-I
 				"DD-FLEET-004: the LLM only ever named the generic tool 'kubectl_get_by_name', "+
 					"yet the wire call must reach cluster remote-east's own prefixed tool -- proving "+
 					"cluster-transparent resolution end to end through a real MCP client/session, not a mock")
+
+			Expect(result.RCASummary).NotTo(ContainSubstring("local-hub"),
+				"the hub-local fakeTool registered under the same generic name must never execute "+
+					"for a fleet-target investigation")
+		})
+	})
+
+	Describe("E2E-KA-FLEET-002 [AC-4]: a real mock-LLM issues a tool call under a generic name during a Kuadrant fleet-target investigation, and it reaches the remote cluster via the cluster's admin-set (non-\"{clusterID}__\") prefix", func() {
+		It("routes kubectl_get_by_name to the prod-east mock gateway via the fleet overlay under Kuadrant's prefix convention, never the hub-local tool (Issue #1756 regression guard)", func() {
+			// --- Remote cluster side: mock MCP gateway exposing exactly one
+			// wire-prefixed tool for cluster "prod-east", using a Kuadrant-
+			// style admin-set prefix ("prod_east_") that does NOT follow
+			// EAIGW's "{clusterID}__" convention -- exactly the shape of
+			// prefix Issue #1756 found gatewayOverlayResolver.Overlay()
+			// mis-resolving. ---
+			inputSchema := json.RawMessage(`{"type":"object","properties":{"kind":{"type":"string"},"name":{"type":"string"},"namespace":{"type":"string"}},"required":["kind","name"]}`)
+			gw := mockgw.NewMockGateway(mockgw.WithTool(
+				"prod_east_kubectl_get_by_name",
+				"Get a Kubernetes resource by name from the remote cluster",
+				inputSchema,
+				func(_ context.Context, _ *mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+					text := fmt.Sprintf(`{"marker":%q,"cluster":"prod-east","kind":"Pod","name":"api-server-abc","namespace":"production","status":"OOMKilled"}`, fleetE2EKuadrantMarker)
+					return &mcp.CallToolResult{Content: []mcp.Content{&mcp.TextContent{Text: text}}}, nil
+				},
+			))
+			defer gw.Close()
+
+			mcpC, err := fleetclient.New(context.Background(), gw.URL())
+			Expect(err).NotTo(HaveOccurred())
+			defer mcpC.Close()
+			session := mcpC.Session()
+
+			// See fleetE2EFixedDiscoverer's doc comment: stands in for
+			// KuadrantDiscoverer's discover_tools/select_tools round trip
+			// (already proven for real by IT-KA-FLEET-010), so this test can
+			// focus on proving Investigator.Investigate() itself resolves
+			// and executes correctly under a non-"{clusterID}__" prefix.
+			disc := &fleetE2EFixedDiscoverer{
+				clusterID: "prod-east",
+				defs: []fleetclient.ToolDefinition{{
+					Name:        "prod_east_kubectl_get_by_name",
+					Description: "Get a Kubernetes resource by name from the remote cluster",
+					InputSchema: inputSchema,
+				}},
+			}
+
+			// --- Mock LLM side: a real HTTP server serving the hand-rolled
+			// turn-aware scenario above. ---
+			reg2 := scenarios.NewRegistry()
+			reg2.Register(fleetE2EKuadrantScenario{})
+			llmServer := httptest.NewServer(handlers.NewRouter(reg2, false, ""))
+			defer llmServer.Close()
+
+			llmClient := kaopenai.New("test-model", llmServer.URL, "test-key")
+			sw, err := llm.NewSwappableClient(llmClient, "test-model")
+			Expect(err).NotTo(HaveOccurred())
+
+			builder, err := prompt.NewBuilder()
+			Expect(err).NotTo(HaveOccurred())
+
+			// --- Hub-local side: a local registry with a fakeTool under the
+			// SAME generic name the remote overlay will also use (see
+			// E2E-KA-FLEET-001's identical comment above for why). ---
+			reg := registry.New()
+			reg.Register(&fakeTool{name: "kubectl_get_by_name", result: `{"source":"local-hub","warning":"must never be reached for a fleet-target investigation"}`})
+
+			auditStore := newCapturingAuditStore(suiteAuditStore)
+
+			inv := investigator.New(investigator.Config{
+				PhaseResolver:        investigator.NewDefaultPhaseResolver(sw, nil),
+				Builder:              builder,
+				ResultParser:         parser.NewResultParser(),
+				AuditStore:           auditStore,
+				Logger:               logr.Discard(),
+				MaxTurns:             5,
+				PhaseTools:           investigator.DefaultPhaseToolMap(),
+				Registry:             reg,
+				FleetOverlayResolver: &fleetE2EOverlayResolver{discoverer: disc, session: session, wirePrefix: "prod_east_"},
+			})
+
+			signal := katypes.SignalContext{
+				Name:          "FleetKuadrantTransparencyProbe",
+				Namespace:     "production",
+				Severity:      "critical",
+				Message:       "OOMKilled",
+				ClusterID:     "prod-east",
+				ResourceKind:  "Pod",
+				ResourceName:  "api-server-abc",
+				RemediationID: "rem-e2e-fleet-kuadrant-1756",
+				// Interactive: RCA-only short-circuit, mirroring E2E-KA-FLEET-001.
+				Interactive: true,
+			}
+
+			result, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred(),
+				"E2E-KA-FLEET-002: a Kuadrant fleet-target investigation through a real mock-LLM + real mock MCP gateway must complete without error")
+			Expect(result).NotTo(BeNil())
+
+			calls := gw.CallLog()
+			Expect(calls).To(HaveLen(1),
+				"the remote mock gateway must receive exactly one real MCP tool call")
+			Expect(calls[0].ToolName).To(Equal("prod_east_kubectl_get_by_name"),
+				"Issue #1756 regression guard (AC-4): the LLM only ever named the generic tool 'kubectl_get_by_name', "+
+					"yet the wire call must reach cluster prod-east's Kuadrant-prefixed tool ('prod_east_', NOT the "+
+					"buggy '{clusterID}__' assumption) -- proving cluster-transparent resolution end to end under a "+
+					"real, non-EAIGW gateway wire convention")
 
 			Expect(result.RCASummary).NotTo(ContainSubstring("local-hub"),
 				"the hub-local fakeTool registered under the same generic name must never execute "+


### PR DESCRIPTION
## Summary

`gatewayOverlayResolver.Overlay()` (`cmd/kubernautagent/toolregistry.go`) unconditionally stripped EAIGW's `"{clusterID}__"` convention when computing the LLM-facing generic tool name. For Kuadrant, whose `MCPServerRegistration.spec.prefix` is a free-text, admin-set value that does not follow that convention (e.g. `prod-east` → `prod_east_`), the strip was a no-op: the remote tool was never offered to the LLM under its generic name, so the LLM silently fell back to the hub-local tool of the same name — an incorrect-cluster data-correctness defect for RCA (AC-4 information flow enforcement), not merely a missed optimization.

## Fix

Extracted `DiscoverToolPrefix`'s existing gateway-agnostic prefix-matching logic (`pkg/fleet/mcpclient`) into a pure `PrefixFromToolNames(clusterID, names)` helper, operating on an already-discovered name slice instead of a live MCP session. `gatewayOverlayResolver.Overlay()` now calls this helper instead of hardcoding the EAIGW shape, resolving both gateway conventions correctly without KA needing to know which one it's talking to.

## Test plan (pyramid invariant)

Full test plan: [`docs/testing/1756/TEST_PLAN.md`](docs/testing/1756/TEST_PLAN.md)

| Tier | Test IDs | What it proves |
|---|---|---|
| UT | `UT-MCP-TN-101..106` | `PrefixFromToolNames` derives the correct prefix for EAIGW, Kuadrant (incl. multi-segment), cross-cluster isolation; errors on no-match/empty input |
| UT | `UT-KA-FLEET-024/025` | The **real, unexported** `gatewayOverlayResolver.Overlay()` — not a re-derivation, which is exactly how this defect went undetected — generic-izes tool names identically for both conventions |
| IT | `IT-KA-FLEET-010` (revised) | Now derives the expected prefix via the real helper against a real `discover_tools`/`select_tools` protocol round trip, instead of a hardcoded `"prod_east_"` literal that could silently drift |
| E2E (journey) | `E2E-KA-FLEET-002` (new) | Kuadrant-convention counterpart to the existing EAIGW-only `E2E-KA-FLEET-001`, proving the full `Investigator.Investigate()` → LLM → gateway journey end-to-end |

FedRAMP control mapping: **AC-4** (Information Flow Enforcement, primary), **AC-6** (Least Privilege, secondary).

## Unrelated but discovered CI gap (also fixed here)

While adding `UT-KA-FLEET-024/025`, discovered that **no make target ever included `cmd/<service>/...`** in any `test-unit-*` invocation. `.github/workflows/ci-pipeline.yml`'s unit-test matrix runs exactly `make test-unit-${{ matrix.service }}` per service, so this was silently skipping real, pre-existing test suites in `cmd/` across **5 services** (`kubernautagent` — 96 specs across 20+ files, `gateway`, `fleetmetadatacache`, `datastorage`, `apifrontend`), not just kubernautagent.

Fixed by conditionally including `./cmd/$*/...` in the generic `test-unit-%` pattern rule and all 5 affected dedicated targets (guarded by `$(wildcard cmd/$*)` so non-service ad hoc invocations, e.g. `make test-unit-fleet`, are unaffected). `authwebhook` was also updated for consistency/future-proofing (no `cmd/` tests exist yet).

**Verified**: re-ran all 12 CI-matrix services' `make test-unit-*` targets locally — zero regressions, all suites green.

## Validation

- `go build ./...` — clean
- `go vet ./...` — clean
- `make test-unit-kubernautagent` — 96/96 specs pass
- `make test-unit-{gateway,fleetmetadatacache,datastorage,authwebhook,apifrontend,effectivenessmonitor,notification,remediationorchestrator,signalprocessing,workflowexecution,aianalysis}` — all pass
- `ginkgo ./test/integration/kubernautagent/{fleet,investigator}/...` (the two packages touched) — 131/131 specs pass, including `IT-KA-FLEET-010`, `E2E-KA-FLEET-001`, `E2E-KA-FLEET-002`

Fixes #1756
