### PR TITLE
fix(security): pin golang.org/x/text in db-migrate's goose build to resolve CVE-2026-56852

### DIFF
--- a/docker/db-migrate.Dockerfile
+++ b/docker/db-migrate.Dockerfile
@@ -39,10 +39,18 @@ ENV CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH}
 # (compiled unconditionally by the core goose library, not gated by a
 # cmd/goose build tag) but is SQLite-based with no grpc/CVE-prone transitive
 # dependencies, so it's left as-is rather than chasing further.
+#
+# golang.org/x/text pin: unlike x/net/x/crypto/grpc above, this one can't be
+# removed by excluding drivers -- it's pulled in by github.com/jackc/pgx/v5,
+# the postgres driver we actually keep (`go mod graph` confirms; `go version -m`
+# on the built binary confirms it's actually linked in, not just resolved).
+# Pin to the same version used in the main project's go.mod to resolve
+# CVE-2026-56852 (golang.org/x/text < v0.39.0, norm.Iter infinite loop).
 RUN GOMODCACHE=$(mktemp -d) && \
     cd "$GOMODCACHE" && \
     go mod init tmp && \
     go get github.com/pressly/goose/v3/cmd/goose@v3.27.2 && \
+    go get golang.org/x/text@v0.40.0 && \
     go build -tags 'no_clickhouse no_mssql no_mysql no_sqlite3 no_turso no_vertica no_ydb' \
       -o /go/bin/goose github.com/pressly/goose/v3/cmd/goose
 


### PR DESCRIPTION
## Summary

Trivy's CVE scan on the `db-migrate` image flags `usr/local/bin/goose` with a HIGH severity finding — `golang.org/x/text v0.37.0`, fixed in `v0.39.0` (CVE-2026-56852: a `norm.Iter` infinite loop on crafted input). Surfaced by CI on [PR #1755's `db-migrate` image scan](https://github.com/jordigilh/kubernaut/actions/runs/30447754522/job/90562564974).

## Root cause

`db-migrate`'s `goose` binary is built from an isolated temp `go.mod` (not this repo's `go.mod`/`go.sum`), so the module-graph `x/text` version used by the main project never reaches it.

Unlike the `x/net`/`x/crypto`/`grpc` CVEs previously resolved here by excluding unused `goose` drivers (ydb/mssql/mysql/etc. via build tags — see git history), `x/text` can't be dropped that way: `go mod graph` shows it's pulled in by `github.com/jackc/pgx/v5`, the **postgres** driver kubernaut actually keeps. `go version -m` on the built binary confirms it's actually linked in, not just resolved-but-unused.

## Fix

Adds an explicit `go get golang.org/x/text@v0.40.0` pin in the goose-builder stage, following the existing `x/crypto`/`x/net`/`grpc` precedent in this Dockerfile. Pinned to `v0.40.0` — the same version already used in the main project's `go.mod` — for consistency.

## Validation

- Replicated the Dockerfile's exact `go get` + `go build` sequence (including the postgres-only build tags) in an isolated temp module locally.
- Before fix: `go version -m` on the built `goose` binary shows `golang.org/x/text v0.37.0` linked in (vulnerable).
- After fix: `go version -m` shows `golang.org/x/text v0.40.0` linked in; `x/net`/`x/crypto`/`grpc` remain absent from the binary (unaffected by this change).
- `go build ./...` for the full repo — clean (this change only touches `docker/db-migrate.Dockerfile`).

## Follow-up

PR #1755 is based on an older `main` (pre-goose-v3.27.2 driver-stripping optimization) and is what surfaced this CVE. Once this merges, PR #1755's branch should merge/rebase `main` to pick up the fix.

Co-authored-by: Cursor <cursoragent@cursor.com>

Made with [Cursor](https://cursor.com)