### PR TITLE
fix(fleet): resolve E2E fleet OOMKill + scope-check masking (Issue #54 RCA)

### DIFF
--- a/pkg/fleet/fmc/handler.go
+++ b/pkg/fleet/fmc/handler.go
@@ -108,7 +108,15 @@ func (h *Handler) handleScopeCheck(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		h.logger.Error(err, "scope check failed",
 			"cluster", resource.ClusterID, "kind", resource.Kind, "name", resource.Name)
-		writeJSON(w, ScopeCheckResponse{Managed: false})
+		// Issue #54 fleet E2E RCA (CI run 30464667745): a checker error (e.g.
+		// context canceled/deadline exceeded under FMC resource pressure) is
+		// a failed *check*, not a completed check that determined "not
+		// managed" -- those must not be wire-indistinguishable. 503 lets
+		// HTTPClient (Gateway/RO) retry with backoff instead of the caller
+		// silently, permanently treating a transient blip as a final
+		// unmanaged determination. If retries are exhausted there,
+		// HTTPClient still fails safe to managed=false (SC-7 unchanged).
+		http.Error(w, "scope check temporarily unavailable", http.StatusServiceUnavailable)
 		return
 	}
 

--- a/pkg/fleet/fmc/handler_test.go
+++ b/pkg/fleet/fmc/handler_test.go
@@ -170,14 +170,25 @@ var _ = Describe("FMC HTTP Handler (BR-INTEGRATION-065, ADR-068)", func() {
 			Expect(w.Code).To(Equal(http.StatusMethodNotAllowed))
 		})
 
-		It("UT-FMC-API-007 [SC-7]: cache error falls back to managed=false — boundary conservative under failure", func() {
+		It("UT-FMC-API-007 [SC-7]: cache error returns 503, distinguishable from a genuine managed=false", func() {
+			// Issue #54 fleet E2E RCA (CI run 30464667745): a checker error
+			// (e.g. "context canceled" during FMC's own resource pressure)
+			// used to be silently masked as a normal 200 {"managed":false} --
+			// byte-identical to a genuine "not managed" determination. That
+			// made a transient backend hiccup indistinguishable from a real
+			// scope decision, so callers (Gateway/RO's HTTPClient) had no
+			// signal to retry on. A checker error now surfaces as 503 so the
+			// caller can retry with backoff instead of failing the alert
+			// closed on the very first transient blip; if retries are
+			// exhausted, HTTPClient still falls back to fail-safe
+			// managed=false (SC-7 unchanged), just no longer on transient
+			// failure alone.
 			checker.err = fmt.Errorf("valkey: connection refused")
 
 			w := doGet(mux, "/api/v1/scope/check?cluster=prod-east&group=apps&version=v1&kind=Deployment&namespace=default&name=nginx")
 
-			Expect(w.Code).To(Equal(http.StatusOK))
-			Expect(decodeScopeCheck(w).Managed).To(BeFalse(),
-				"checker errors must fall back to unmanaged (fail-safe)")
+			Expect(w.Code).To(Equal(http.StatusServiceUnavailable),
+				"checker errors must be surfaced distinctly (503), not masked as a final managed=false")
 		})
 
 		It("UT-FMC-API-008 [AC-4]: core group resources (empty group) are queryable", func() {

--- a/pkg/fleet/fmc/http_client.go
+++ b/pkg/fleet/fmc/http_client.go
@@ -24,8 +24,36 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/jordigilh/kubernaut/pkg/shared/backoff"
 	"github.com/jordigilh/kubernaut/pkg/shared/scope"
 )
+
+// Issue #54 fleet E2E RCA (CI run 30464667745): FMC's handler distinguishes
+// a failed check (503 -- e.g. Valkey "context canceled" under resource
+// pressure) from a completed check that determined "not managed" (200).
+// IsManagedResource retries only the former: a small, bounded number of
+// attempts with exponential backoff, wrapped in a hard wall-clock ceiling.
+// This sits on Gateway/RO's synchronous alert-ingestion path, so the ceiling
+// is deliberately short (seconds, not the 45s a test's own outer retry
+// loop might use) -- a transient blip gets a couple of quick retries, but a
+// real outage still fails safe (managed=false, SC-7) promptly rather than
+// stalling the caller.
+const (
+	scopeCheckMaxAttempts  = 3
+	scopeCheckRetryCeiling = 2 * time.Second
+)
+
+// scopeCheckBackoff configures the delay between retry attempts. With
+// BasePeriod=100ms, Multiplier=2, MaxPeriod=500ms: attempt 1 waits ~100ms,
+// attempt 2 waits ~200ms (both ±10% jitter) before the next try; combined
+// with scopeCheckMaxAttempts=3, worst-case pure backoff overhead is ~300ms,
+// well inside scopeCheckRetryCeiling.
+var scopeCheckBackoff = backoff.Config{
+	BasePeriod:    100 * time.Millisecond,
+	MaxPeriod:     500 * time.Millisecond,
+	Multiplier:    2.0,
+	JitterPercent: 10,
+}
 
 // HTTPClient is a scope.ScopeChecker that calls the FMC REST API over HTTP.
 // ADR-068: GW/RO use this client to resolve federated scope instead of connecting
@@ -66,8 +94,38 @@ func NewHTTPClient(baseURL string, opts ...ClientOption) *HTTPClient {
 }
 
 // IsManagedResource checks whether a resource is in-scope by calling FMC's
-// /api/v1/scope/check endpoint. Returns false on any error (fail-safe per SC-7).
+// /api/v1/scope/check endpoint. A transient failure (5xx / transport error)
+// is retried a bounded number of times with backoff (see scopeCheckMaxAttempts,
+// scopeCheckRetryCeiling); a definitive response (200, whether managed true
+// or false) is never retried. All failures ultimately return false, nil
+// (fail-safe per SC-7) -- retries improve resilience to short blips, they
+// never change the fail-closed guarantee on exhaustion.
 func (c *HTTPClient) IsManagedResource(ctx context.Context, r scope.ResourceIdentity) (bool, error) {
+	reqURL := c.buildScopeCheckURL(r)
+
+	ctx, cancel := context.WithTimeout(ctx, scopeCheckRetryCeiling)
+	defer cancel()
+
+	for attempt := int32(1); attempt <= scopeCheckMaxAttempts; attempt++ {
+		managed, final, retryable := c.attemptScopeCheck(ctx, reqURL)
+		if final {
+			return managed, nil
+		}
+		if !retryable || attempt == scopeCheckMaxAttempts {
+			return false, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return false, nil
+		case <-time.After(scopeCheckBackoff.Calculate(attempt)):
+		}
+	}
+	return false, nil
+}
+
+// buildScopeCheckURL constructs the FMC scope-check request URL for a resource.
+func (c *HTTPClient) buildScopeCheckURL(r scope.ResourceIdentity) string {
 	params := url.Values{}
 	params.Set("cluster", r.ClusterID)
 	params.Set("group", r.Group)
@@ -76,29 +134,42 @@ func (c *HTTPClient) IsManagedResource(ctx context.Context, r scope.ResourceIden
 	params.Set("namespace", r.Namespace)
 	params.Set("name", r.Name)
 
-	reqURL := c.baseURL + ScopeCheckPath + "?" + params.Encode()
+	return c.baseURL + ScopeCheckPath + "?" + params.Encode()
+}
 
+// attemptScopeCheck performs a single scope-check HTTP round-trip.
+//
+// final=true means the response is a definitive answer (200 OK, decoded
+// successfully) that must not be retried, regardless of the managed value.
+// retryable=true means the failure looks transient (transport error, or a
+// 5xx indicating FMC's own check failed rather than completed) and is worth
+// a bounded retry. A non-retryable failure (e.g. 4xx, or a malformed 200
+// body) ends the attempt loop immediately, fail-safe.
+func (c *HTTPClient) attemptScopeCheck(ctx context.Context, reqURL string) (managed, final, retryable bool) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, reqURL, nil)
 	if err != nil {
-		return false, nil
+		return false, false, false
 	}
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
-		return false, nil
+		return false, false, true // transport error: transient, worth a retry
 	}
 	defer func() { _ = resp.Body.Close() }()
 
+	if resp.StatusCode >= http.StatusInternalServerError {
+		return false, false, true // 5xx: FMC's check failed (e.g. transient backend error), worth a retry
+	}
 	if resp.StatusCode != http.StatusOK {
-		return false, nil
+		return false, false, false // e.g. 4xx: caller-side problem, not transient -- fail fast
 	}
 
 	var result ScopeCheckResponse
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
-		return false, nil
+		return false, false, false // malformed 200 body: not transient -- fail fast
 	}
 
-	return result.Managed, nil
+	return result.Managed, true, false
 }
 
 // Ping checks connectivity to FMC's API by calling ClustersPath on the same

--- a/pkg/fleet/fmc/http_client_test.go
+++ b/pkg/fleet/fmc/http_client_test.go
@@ -18,8 +18,10 @@ package fmc_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -28,6 +30,24 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/fleet/fmc"
 	"github.com/jordigilh/kubernaut/pkg/shared/scope"
 )
+
+// flakyRoundTripper fails the first failCount requests with a transport-level
+// error (simulating a dropped connection / dial failure), then delegates to
+// the real transport. Used to test IsManagedResource's retry-on-transport-error
+// path deterministically, without relying on real network flakiness.
+type flakyRoundTripper struct {
+	failCount int32
+	attempts  atomic.Int32
+	delegate  http.RoundTripper
+}
+
+func (f *flakyRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	n := f.attempts.Add(1)
+	if n <= f.failCount {
+		return nil, fmt.Errorf("simulated transport error (attempt %d)", n)
+	}
+	return f.delegate.RoundTrip(req)
+}
 
 var _ = Describe("FMC HTTP Client (BR-INTEGRATION-065, ADR-068)", func() {
 	var (
@@ -196,6 +216,143 @@ var _ = Describe("FMC HTTP Client (BR-INTEGRATION-065, ADR-068)", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 			Expect(managed).To(BeTrue())
+		})
+	})
+
+	// Issue #54 fleet E2E RCA (CI run 30464667745): FMC's handler now returns
+	// 503 for a failed check (transient, e.g. context canceled under load),
+	// distinct from a completed check's 200 (managed true or false). These
+	// tests lock in a *bounded* retry-with-backoff on the transient case only
+	// -- the RCA's follow-up requirement that this must not retry forever.
+	Describe("Bounded retry with backoff on transient failures [SC-7, Issue #54]", func() {
+		var requestCount int32
+
+		countingHandler := func(fn func(w http.ResponseWriter, r *http.Request, n int32)) http.HandlerFunc {
+			return func(w http.ResponseWriter, r *http.Request) {
+				n := atomic.AddInt32(&requestCount, 1)
+				fn(w, r, n)
+			}
+		}
+
+		BeforeEach(func() {
+			requestCount = 0
+		})
+
+		It("UT-FMC-HC-013 [SC-7]: retries on 503 and succeeds once FMC recovers, without exhausting all attempts", func() {
+			server = httptest.NewServer(countingHandler(func(w http.ResponseWriter, _ *http.Request, n int32) {
+				if n < 2 {
+					w.WriteHeader(http.StatusServiceUnavailable)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"managed":true}`))
+			}))
+			client = fmc.NewHTTPClient(server.URL)
+
+			managed, err := client.IsManagedResource(context.Background(), scope.ResourceIdentity{
+				ClusterID: "prod-east", Kind: "Deployment", Name: "nginx",
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(managed).To(BeTrue())
+			Expect(atomic.LoadInt32(&requestCount)).To(Equal(int32(2)),
+				"must retry exactly once after the transient 503 before succeeding")
+		})
+
+		It("UT-FMC-HC-014 [SC-7]: retries on a transport error and succeeds once the connection recovers", func() {
+			server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"managed":true}`))
+			}))
+			flaky := &flakyRoundTripper{failCount: 1, delegate: http.DefaultTransport}
+			client = fmc.NewHTTPClient(server.URL, fmc.WithHTTPClient(&http.Client{Transport: flaky}))
+
+			managed, err := client.IsManagedResource(context.Background(), scope.ResourceIdentity{
+				ClusterID: "prod-east", Kind: "Deployment", Name: "nginx",
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(managed).To(BeTrue())
+			Expect(flaky.attempts.Load()).To(Equal(int32(2)),
+				"must retry exactly once after the transient transport error before succeeding")
+		})
+
+		It("UT-FMC-HC-015 [SC-7]: does NOT retry a definitive 200 managed=false response", func() {
+			server = httptest.NewServer(countingHandler(func(w http.ResponseWriter, _ *http.Request, _ int32) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"managed":false}`))
+			}))
+			client = fmc.NewHTTPClient(server.URL)
+
+			managed, err := client.IsManagedResource(context.Background(), scope.ResourceIdentity{
+				ClusterID: "prod-east", Kind: "Deployment", Name: "missing",
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(managed).To(BeFalse())
+			Expect(atomic.LoadInt32(&requestCount)).To(Equal(int32(1)),
+				"a completed check that determined not-managed is a final answer, not a failure to retry")
+		})
+
+		It("UT-FMC-HC-016 [SC-7]: does NOT retry a non-5xx, non-200 status (e.g. 400)", func() {
+			server = httptest.NewServer(countingHandler(func(w http.ResponseWriter, _ *http.Request, _ int32) {
+				w.WriteHeader(http.StatusBadRequest)
+			}))
+			client = fmc.NewHTTPClient(server.URL)
+
+			managed, err := client.IsManagedResource(context.Background(), scope.ResourceIdentity{
+				ClusterID: "prod-east", Kind: "Deployment", Name: "nginx",
+			})
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(managed).To(BeFalse())
+			Expect(atomic.LoadInt32(&requestCount)).To(Equal(int32(1)),
+				"a 4xx is a client-side problem, not a transient backend failure -- must fail fast, not retry")
+		})
+
+		It("UT-FMC-HC-017 [SC-7]: gives up after a bounded number of attempts when 503 persists -- does not retry forever", func() {
+			server = httptest.NewServer(countingHandler(func(w http.ResponseWriter, _ *http.Request, _ int32) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+			}))
+			client = fmc.NewHTTPClient(server.URL)
+
+			start := time.Now()
+			managed, err := client.IsManagedResource(context.Background(), scope.ResourceIdentity{
+				ClusterID: "prod-east", Kind: "Deployment", Name: "nginx",
+			})
+			elapsed := time.Since(start)
+
+			Expect(err).ToNot(HaveOccurred(),
+				"exhausted retries must still fail safe (SC-7), never propagate an error")
+			Expect(managed).To(BeFalse())
+			finalCount := atomic.LoadInt32(&requestCount)
+			Expect(finalCount).To(BeNumerically(">", 1),
+				"must have retried at least once")
+			Expect(finalCount).To(BeNumerically("<=", 3),
+				"must NOT retry forever -- attempts are bounded by a ceiling")
+			Expect(elapsed).To(BeNumerically("<", 3*time.Second),
+				"the bounded retry budget must keep total added latency small on Gateway's synchronous alert-ingestion path")
+		})
+
+		It("UT-FMC-HC-018 [SC-7]: honors a short caller context deadline instead of exhausting its own retry budget", func() {
+			server = httptest.NewServer(countingHandler(func(w http.ResponseWriter, _ *http.Request, _ int32) {
+				w.WriteHeader(http.StatusServiceUnavailable)
+			}))
+			client = fmc.NewHTTPClient(server.URL)
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+			defer cancel()
+
+			start := time.Now()
+			managed, err := client.IsManagedResource(ctx, scope.ResourceIdentity{
+				ClusterID: "prod-east", Kind: "Deployment", Name: "nginx",
+			})
+			elapsed := time.Since(start)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(managed).To(BeFalse())
+			Expect(elapsed).To(BeNumerically("<", 1*time.Second),
+				"a short caller-provided context deadline must cut the retry loop short, not run to its own internal ceiling")
 		})
 	})
 })

--- a/pkg/fleet/mcpclient/client.go
+++ b/pkg/fleet/mcpclient/client.go
@@ -349,11 +349,15 @@ func (c *Client) listResources(ctx context.Context, kind, apiVersion, namespace 
 		return nil, fmt.Errorf("call %s returned error: %s", toolName, ExtractText(result))
 	}
 
+	// A successful call (IsError=false) with no StructuredContent means
+	// kube-mcp-server found zero matching resources for this kind/selector --
+	// not a parse failure. Issue #54 fleet E2E RCA (CI run 30464667745):
+	// treating this as a hard error caused FMC's syncer to log "structuredContent
+	// required but not present in response" on every sync cycle for every
+	// resource kind with zero kubernaut.ai/managed=true matches
+	// (StatefulSet/DaemonSet/Service), for the pod's entire lifetime.
+	// normalizeTableItems(nil, ...) already returns an empty (non-nil) slice.
 	sc := extractStructuredList(result)
-	if sc == nil {
-		return nil, fmt.Errorf("call %s: structuredContent required but not present in response", toolName)
-	}
-
 	return normalizeTableItems(sc, kind, apiVersion), nil
 }
 
@@ -500,4 +504,3 @@ func ExtractText(result *mcp.CallToolResult) string {
 	}
 	return string(data)
 }
-

--- a/pkg/fleet/mcpclient/client_test.go
+++ b/pkg/fleet/mcpclient/client_test.go
@@ -439,5 +439,33 @@ var _ = Describe("ResourceClient (BR-FLEET-002, Phase 0)", func() {
 			Expect(list.Items[0].GetNamespace()).To(Equal("sc-ns"))
 			Expect(list.Items[0].GetLabels()).To(HaveKeyWithValue("app", "structured"))
 		})
+
+		It("IT-FLEET-PARSE-004 [SI-10]: List with a successful, zero-match response (no StructuredContent field) returns an empty list, not an error", func() {
+			// Root cause (Issue #54 fleet E2E RCA, CI run 30464667745): real
+			// kube-mcp-server omits StructuredContent entirely for a
+			// zero-match List call (IsError=false) rather than returning
+			// `{"items": []}`. pkg/fleet/fmc's syncer hit this for every
+			// resource kind with zero kubernaut.ai/managed=true matches
+			// (StatefulSet/DaemonSet/Service), logging "structuredContent
+			// required but not present in response" on every 10s sync cycle
+			// for the pod's entire lifetime -- a successful "nothing matched"
+			// outcome must not be treated as a parse failure.
+			gw = mockgw.NewMockGateway(
+				mockgw.WithMultiCluster("empty-cluster"),
+				mockgw.WithEmptyResourcesList(),
+			)
+
+			c, err := mcpclient.New(ctx, gw.URL(), mcpclient.WithClusterID("empty-cluster"))
+			Expect(err).ToNot(HaveOccurred())
+			defer c.Close()
+
+			list := &unstructured.UnstructuredList{}
+			list.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "StatefulSetList"})
+
+			err = c.List(ctx, list, client.InNamespace("kubernaut-system"))
+			Expect(err).ToNot(HaveOccurred(),
+				"a successful zero-match List response must not surface as an error")
+			Expect(list.Items).To(BeEmpty())
+		})
 	})
 })

--- a/test/infrastructure/fleet_e2e.go
+++ b/test/infrastructure/fleet_e2e.go
@@ -2147,11 +2147,25 @@ spec:
           periodSeconds: 5
         resources:
           requests:
-            memory: "32Mi"
-            cpu: "25m"
-          limits:
             memory: "64Mi"
-            cpu: "100m"
+            cpu: "50m"
+          limits:
+            # Issue #54 fleet E2E RCA (CI run 30464667745): 64Mi/100m was too
+            # tight for FMC's actual workload (TLS/mTLS termination, OAuth2
+            # token refresh, MCP client, concurrent scope-check serving under
+            # ~12 parallel Ginkgo processes). Under load the process couldn't
+            # service its own /healthz probe (default 1s timeout) in time,
+            # kubelet killed+restarted the container (exitCode 137, liveness
+            # probe "context deadline exceeded"), and every scope check
+            # in-flight during that window failed with "context canceled" --
+            # which the (pre-fix) handler indistinguishably reported as
+            # managed=false, causing Gateway to reject alerts as unmanaged.
+            # Raised to match/exceed the production Helm chart's default
+            # (charts/kubernaut/values.yaml fleetmetadatacache.resources:
+            # 128Mi/200m) since this test infra was actually *tighter* than
+            # production.
+            memory: "128Mi"
+            cpu: "200m"
       volumes:
       - name: config
         configMap:

--- a/test/services/mock-mcp-gateway/testutil/server.go
+++ b/test/services/mock-mcp-gateway/testutil/server.go
@@ -65,6 +65,7 @@ type gatewayConfig struct {
 	discoverableClusters         []discoverableCluster
 	structuredContent            []map[string]any
 	allowExternalContainerAccess bool
+	emptyResourcesList           bool
 }
 
 // WithTool registers a static tool on the mock gateway.
@@ -109,6 +110,25 @@ func WithExternalContainerAccess() Option {
 func WithStructuredContent(data []map[string]any) Option {
 	return func(cfg *gatewayConfig) {
 		cfg.structuredContent = data
+	}
+}
+
+// WithEmptyResourcesList configures the mock's resources_list tool to
+// simulate the real kube-mcp-server's observed behavior for a genuinely
+// empty match set: a successful (IsError=false) response that omits the
+// StructuredContent field entirely, rather than returning an empty list.
+//
+// Root cause (Issue #54 fleet E2E RCA, CI run 30464667745): the default mock
+// behavior (and the mock behavior WithStructuredContent produces) always
+// populates StructuredContent, which never matched what real kube-mcp-server
+// does when zero resources match a List call's label selector -- it omits
+// the field rather than returning `{"items": []}`. This option reproduces
+// that divergence so pkg/fleet/mcpclient's handling of a nil StructuredContent
+// on a successful call can be tested against the real-world shape instead of
+// only the mock's previously-idealized always-populated shape.
+func WithEmptyResourcesList() Option {
+	return func(cfg *gatewayConfig) {
+		cfg.emptyResourcesList = true
 	}
 }
 
@@ -327,6 +347,7 @@ func (gw *MockGateway) registerClusterToolsWithPrefix(cluster, prefix string, cf
 
 	listResourcesName := prefix + "resources_list"
 	structuredContent := cfg.structuredContent
+	emptyResourcesList := cfg.emptyResourcesList
 	gw.server.AddTool(&mcp.Tool{
 		Name:        listResourcesName,
 		Description: fmt.Sprintf("List Kubernetes resources from cluster %s", cluster),
@@ -345,6 +366,14 @@ func (gw *MockGateway) registerClusterToolsWithPrefix(cluster, prefix string, cf
 			return &mcp.CallToolResult{
 				Content: []mcp.Content{&mcp.TextContent{Text: `{"error":"apiVersion is required"}`}},
 				IsError: true,
+			}, nil
+		}
+
+		if emptyResourcesList {
+			return &mcp.CallToolResult{
+				Content: []mcp.Content{&mcp.TextContent{Text: "No resources found"}},
+				// StructuredContent deliberately omitted (nil) -- matches
+				// real kube-mcp-server's observed shape for a zero-match List.
 			}, nil
 		}
 


### PR DESCRIPTION
## Summary

Root-cause fix for the intermittent `e2e fleet` failures where 5/32 specs
timed out with the Gateway rejecting alerts as `unmanaged_resource` despite
the target resources carrying `kubernaut.ai/managed=true`.

RCA (CI run [30464667745](https://github.com/jordigilh/kubernaut/actions/runs/30464667745/job/90622847895)):
FleetMetadataCache (FMC) was OOMKilled mid-run (exitCode 137) due to
under-provisioned E2E resource limits, compounded by a regression that made
FMC's syncer hard-fail on every zero-match List call. The combination
produced sustained `context canceled` errors on FMC's `/api/v1/scope/check`
endpoint, which the handler silently masked as a normal, final
`managed=false` -- indistinguishable from a genuine "not managed"
determination, so Gateway rejected in-flight alerts with no way to retry.

Three independent fixes, each with its own commit:

### 1. `test/infrastructure/fleet_e2e.go` -- raise FMC's E2E resource limits
`64Mi/100m -> 128Mi/200m` (limits), matching the production Helm chart
default (`charts/kubernaut/values.yaml`), which the E2E infra had drifted
below.

### 2. `pkg/fleet/mcpclient/client.go` -- stop hard-failing on empty lists
Real `kube-mcp-server` omits `StructuredContent` entirely for a genuinely
empty match set (`IsError=false`) rather than returning `{"items":[]}`.
A prior commit (`1c9416758`) made the field's absence a hard error, so
FMC's syncer logged `structuredContent required but not present in
response` on every sync cycle for every resource kind with zero
`kubernaut.ai/managed=true` matches -- constant background error load
contributing to the resource pressure behind the OOMKill.

### 3. `pkg/fleet/fmc/handler.go` + `http_client.go` -- distinguish failed checks from unmanaged, add bounded retry
- `handler.go`: an internal checker error now returns `503`, distinct from
  a completed check's `200` (managed `true` or `false`) -- previously both
  were wire-identical.
- `http_client.go`: `IsManagedResource` retries only on the transient
  signal (`5xx` / transport error), never on a definitive `200` or `4xx`.
  Bounded: max 3 attempts, exponential backoff (`pkg/shared/backoff`,
  100ms base / 2x / 500ms cap / 10% jitter), hard 2s wall-clock ceiling
  independent of attempt count, and respects a shorter caller context
  deadline. On exhaustion, still fails safe to `(false, nil)` -- the SC-7
  fail-closed guarantee is unchanged, it's just no longer tripped by a
  single transient blip.

## Test plan

- TDD RED->GREEN for all three fixes (new tests: `IT-FLEET-PARSE-004`,
  `UT-FMC-API-007` (updated), `UT-FMC-HC-013..018`)
- `go build ./...`, `go vet`, `golangci-lint run` clean on all changed
  packages
- Full `pkg/fleet/...` suite green (fmc, fmc/config, mcpclient, registry,
  scopecache, readiness, acm, top-level `federated_checker` consumers)

Not run: the container-based `test/integration/fleetmetadatacache` suite
(spins up a real Valkey container) -- it exercises the Valkey-backed happy
path, not the retry/status-code logic that changed here, which is already
covered end-to-end by unit tests using a real `httptest.Server` + real
`http.Client`.

🤖 Generated with [Cursor](https://cursor.com)

Made with [Cursor](https://cursor.com)