### PR TITLE
fix(security): pin golang.org/x/text in db-migrate goose builder (#1763, CVE-2026-56852)

### DIFF
--- a/docker/db-migrate.Dockerfile
+++ b/docker/db-migrate.Dockerfile
@@ -20,12 +20,20 @@ FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi10/go-toolset:10.2 
 USER root
 ARG TARGETARCH
 ENV CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH}
+# golang.org/x/text pin (#1763, CVE-2026-56852, norm.Iter infinite loop,
+# fixed in v0.39.0): this isolated `go mod init tmp` module doesn't see the
+# main project's go.mod, so its x/text bump doesn't reach goose's build.
+# `go mod graph` confirms x/text is pulled in transitively (via the grpc/
+# crypto/net pins below); pin explicitly to the same version already used
+# in the main project's go.mod, following the same precedent as the
+# x/crypto/x/net/grpc pins already in this file.
 RUN GOMODCACHE=$(mktemp -d) && \
     cd "$GOMODCACHE" && \
     go mod init tmp && \
     go get github.com/pressly/goose/v3/cmd/goose@v3.27.1 && \
     go get golang.org/x/crypto@v0.53.0 && \
     go get golang.org/x/net@v0.56.0 && \
+    go get golang.org/x/text@v0.40.0 && \
     go get google.golang.org/grpc@v1.82.1 && \
     go build -o /go/bin/goose github.com/pressly/goose/v3/cmd/goose
 


### PR DESCRIPTION
## Summary

`Build & Push (db-migrate)`'s Trivy scan is failing on every open PR targeting `release/v1.5` (confirmed on #1779, #1780) with a HIGH severity finding in the bundled `goose` binary:

```
golang.org/x/text  CVE-2026-56852  HIGH  fixed  v0.38.0 -> 0.39.0
"A norm.Iter can enter an infinite loop when handling input containing ..."
https://avd.aquasec.com/nvd/cve-2026-56852
```

This CVE and fix are not new — issue #1763 already covered it and it was fixed on `main` (merged via #1760). It was never backported to `release/v1.5`, whose `docker/db-migrate.Dockerfile` was still several security-pin commits behind `main`'s (last touched by the `grpc` pin, commit `c8d936101`).

## Root cause

`db-migrate`'s `goose` binary is built from an isolated `go mod init tmp` module inside the Dockerfile — not this repo's own `go.mod`/`go.sum`. So the repo-wide `golang.org/x/text` bump to `v0.40.0` (already in `go.mod`) never reaches that isolated build; it needs its own explicit `go get` pin, same root cause as the existing `x/crypto`/`x/net`/`grpc` pins already in this file.

## Fix

Add `go get golang.org/x/text@v0.40.0` to the `goose-builder` stage, pinned to the same version already used by the main project's `go.mod`, following the exact established pattern for the other pins in this file.

Scoped narrowly to just this CVE fix — `main` also separately did a larger postgres-only driver-exclusion refactor and base-image digest-pinning for this file; those are out of scope here and can be backported separately if desired.

## Test plan

- [x] Replicated the Dockerfile's exact `go get`/`go build` chain locally in an isolated temp module
- [x] `go list -m golang.org/x/text` confirms resolution to `v0.40.0`
- [x] `go version -m` on the built `goose` binary confirms `golang.org/x/text v0.40.0` is actually linked in (not just resolved but unused)
- [ ] CI: `Build & Push (db-migrate)` Trivy scan should now pass (this is exactly the check this PR fixes)

No Go unit tests apply — this is a Dockerfile dependency pin, consistent with how the prior `x/crypto`/`x/net`/`grpc` pins in this same file were fixed (infra/CVE change, not business logic).

Made with [Cursor](https://cursor.com)