### PR TITLE
fix(ci): pin crun>=1.14.3 to fix podman OCI spec v1.2.1 incompatibility (#1784)

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -506,6 +506,17 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y podman
+      # crun pin (#1784): the ubuntu-latest runner image's preinstalled crun
+      # predates 1.14.3 and cannot parse the OCI Runtime Spec v1.2.1
+      # config.json that current Podman generates, failing every container
+      # start with "OCI runtime error: crun: unknown version specified"
+      # (https://github.com/containers/podman/issues/27272, resolved in
+      # crun v1.14.3). apt's crun lags behind apt's podman, so pin explicitly.
+      - name: Pin crun >= 1.14.3 (podman/crun OCI spec compat)
+        run: |
+          sudo curl -fL "https://github.com/containers/crun/releases/download/1.14.3/crun-1.14.3-linux-amd64" -o /usr/bin/crun
+          sudo chmod +x /usr/bin/crun
+          crun --version
       - name: Setup envtest (K8s test binaries)
         run: |
           go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.23
@@ -688,6 +699,18 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y podman
+      # crun pin (#1784): the ubuntu-latest runner image's preinstalled crun
+      # predates 1.14.3 and cannot parse the OCI Runtime Spec v1.2.1
+      # config.json that current Podman generates, failing every container
+      # start (including Kind's own control-plane container) with
+      # "OCI runtime error: crun: unknown version specified"
+      # (https://github.com/containers/podman/issues/27272, resolved in
+      # crun v1.14.3). apt's crun lags behind apt's podman, so pin explicitly.
+      - name: Pin crun >= 1.14.3 (podman/crun OCI spec compat)
+        run: |
+          sudo curl -fL "https://github.com/containers/crun/releases/download/1.14.3/crun-1.14.3-linux-amd64" -o /usr/bin/crun
+          sudo chmod +x /usr/bin/crun
+          crun --version
       - name: Login to GitHub Container Registry (for image pulls)
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -910,6 +933,19 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y podman
           podman --version
+
+      # crun pin (#1784): the ubuntu-latest runner image's preinstalled crun
+      # predates 1.14.3 and cannot parse the OCI Runtime Spec v1.2.1
+      # config.json that current Podman generates, failing every container
+      # start (including Kind's own control-plane container) with
+      # "OCI runtime error: crun: unknown version specified"
+      # (https://github.com/containers/podman/issues/27272, resolved in
+      # crun v1.14.3). apt's crun lags behind apt's podman, so pin explicitly.
+      - name: Pin crun >= 1.14.3 (podman/crun OCI spec compat)
+        run: |
+          sudo curl -fL "https://github.com/containers/crun/releases/download/1.14.3/crun-1.14.3-linux-amd64" -o /usr/bin/crun
+          sudo chmod +x /usr/bin/crun
+          crun --version
 
       - name: Install Kind
         run: |

--- a/.github/workflows/e2e-test-template.yml
+++ b/.github/workflows/e2e-test-template.yml
@@ -71,6 +71,19 @@ jobs:
           sudo apt-get install -y podman
           podman --version
 
+      # crun pin (#1784): the ubuntu-latest runner image's preinstalled crun
+      # predates 1.14.3 and cannot parse the OCI Runtime Spec v1.2.1
+      # config.json that current Podman generates, failing every container
+      # start (including Kind's own control-plane container) with
+      # "OCI runtime error: crun: unknown version specified"
+      # (https://github.com/containers/podman/issues/27272, resolved in
+      # crun v1.14.3). apt's crun lags behind apt's podman, so pin explicitly.
+      - name: Pin crun >= 1.14.3 (podman/crun OCI spec compat)
+        run: |
+          sudo curl -fL "https://github.com/containers/crun/releases/download/1.14.3/crun-1.14.3-linux-amd64" -o /usr/bin/crun
+          sudo chmod +x /usr/bin/crun
+          crun --version
+
       # ========================================
       # Run E2E Tests (with retry)
       # ========================================

--- a/.github/workflows/helm-smoke-test.yml
+++ b/.github/workflows/helm-smoke-test.yml
@@ -43,6 +43,19 @@ jobs:
           sudo apt-get install -y podman
           podman --version
 
+      # crun pin (#1784): the ubuntu-latest runner image's preinstalled crun
+      # predates 1.14.3 and cannot parse the OCI Runtime Spec v1.2.1
+      # config.json that current Podman generates, failing every container
+      # start (including Kind's own control-plane container) with
+      # "OCI runtime error: crun: unknown version specified"
+      # (https://github.com/containers/podman/issues/27272, resolved in
+      # crun v1.14.3). apt's crun lags behind apt's podman, so pin explicitly.
+      - name: Pin crun >= 1.14.3 (podman/crun OCI spec compat)
+        run: |
+          sudo curl -fL "https://github.com/containers/crun/releases/download/1.14.3/crun-1.14.3-linux-amd64" -o /usr/bin/crun
+          sudo chmod +x /usr/bin/crun
+          crun --version
+
       - name: Install Kind
         run: |
           KIND_VERSION="v0.30.0"

--- a/.github/workflows/integration-test-template.yml
+++ b/.github/workflows/integration-test-template.yml
@@ -51,6 +51,19 @@ jobs:
           sudo apt-get install -y podman
           podman --version
 
+      # crun pin (#1784): the ubuntu-latest runner image's preinstalled crun
+      # predates 1.14.3 and cannot parse the OCI Runtime Spec v1.2.1
+      # config.json that current Podman generates, failing every container
+      # start with "OCI runtime error: crun: unknown version specified"
+      # (https://github.com/containers/podman/issues/27272, resolved in
+      # crun v1.14.3). apt's crun lags behind apt's podman, so pin explicitly.
+      - name: Pin crun >= 1.14.3 (podman/crun OCI spec compat)
+        if: inputs.infrastructure == 'podman'
+        run: |
+          sudo curl -fL "https://github.com/containers/crun/releases/download/1.14.3/crun-1.14.3-linux-amd64" -o /usr/bin/crun
+          sudo chmod +x /usr/bin/crun
+          crun --version
+
       - name: Install Kind v0.30.0
         if: inputs.infrastructure == 'kind'
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -363,6 +363,19 @@ jobs:
           sudo apt-get install -y podman
           podman --version
 
+      # crun pin (#1784): the ubuntu-latest runner image's preinstalled crun
+      # predates 1.14.3 and cannot parse the OCI Runtime Spec v1.2.1
+      # config.json that current Podman generates, failing every container
+      # start (including Kind's own control-plane container) with
+      # "OCI runtime error: crun: unknown version specified"
+      # (https://github.com/containers/podman/issues/27272, resolved in
+      # crun v1.14.3). apt's crun lags behind apt's podman, so pin explicitly.
+      - name: Pin crun >= 1.14.3 (podman/crun OCI spec compat)
+        run: |
+          sudo curl -fL "https://github.com/containers/crun/releases/download/1.14.3/crun-1.14.3-linux-amd64" -o /usr/bin/crun
+          sudo chmod +x /usr/bin/crun
+          crun --version
+
       - name: Install Kind
         run: |
           KIND_VERSION="v0.30.0"


### PR DESCRIPTION
## Root cause

Multiple `Integration (*)`, `E2E (*)`, and `Helm Smoke Tests (Kind)` jobs were intermittently
failing with:

```
Error: OCI runtime error: crun: unknown version specified
```

RCA (must-gather job logs across PRs #1779, #1780, #1781 — different service each time)
traced this to a confirmed upstream Podman/crun incompatibility:
https://github.com/containers/podman/issues/27272. The `ubuntu-latest` runner image's
preinstalled `crun` predates v1.14.3 and cannot parse the OCI Runtime Spec v1.2.1
`config.json` that current Podman generates, so every container start (PostgreSQL, Kind
control-plane) fails outright — regardless of which service's suite happens to start a
container first. This is why a different job appeared to fail on each PR.

## Fix

Pin `crun` to the documented minimum working version (v1.14.3) by downloading the static
binary from the official `containers/crun` GitHub release right after installing Podman, in
every workflow job that installs Podman:

- `.github/workflows/ci-pipeline.yml` (Integration matrix, E2E matrix, Helm Smoke Tests — 3 occurrences)
- `.github/workflows/helm-smoke-test.yml`
- `.github/workflows/release.yml`
- `.github/workflows/integration-test-template.yml` / `e2e-test-template.yml` (currently
  unreferenced reusable workflows — fixed for consistency)

Tracked in #1784.

## Verification

- Root cause confirmed via must-gather job logs on 3 independent branches, all showing the
  identical `crun: unknown version specified` error against different container-starting
  steps (Postgres for Integration suites, Kind control-plane for E2E suites).
- `crun-1.14.3-linux-amd64` binary verified to download and execute locally (`file` reports a
  valid statically-linked ELF x86-64 executable).
- All 5 edited workflow YAML files validated with `python3 -c "import yaml; yaml.safe_load(...)"`.

## Test plan

- [ ] CI green on this PR (Integration/E2E/Helm Smoke Tests no longer hit the crun error)

Made with [Cursor](https://cursor.com)