### PR TITLE
fix(ci): backport crun >=1.14.3 pin + kind-create retries to release/v1.5 (#1769)

### DIFF
--- a/.github/actions/install-podman/action.yml
+++ b/.github/actions/install-podman/action.yml
@@ -1,0 +1,52 @@
+name: Install Podman (crun-pinned)
+description: >
+  Installs podman via apt, then replaces the runner's bundled crun binary
+  with a pinned release known to be compatible with podman's generated OCI
+  Runtime Spec configs (Issue #1769). GitHub's ubuntu-24.04 runner images
+  ship a crun version older than 1.14.3, which rejects podman-generated
+  container configs with "Error: OCI runtime error: crun: unknown version
+  specified" -- a deterministic version-compatibility bug, not a transient
+  flake: it reproduces on every `podman run`/`kind create cluster` call
+  that hits it, on that exact podman+crun pairing, until crun is upgraded.
+  See https://github.com/containers/podman/issues/27272 (root cause: crun
+  rejects OCI Runtime Spec v1.2.1 configs below v1.14.3) and
+  https://github.com/containers/crun/releases/tag/1.14.3 (fix version).
+
+inputs:
+  crun-version:
+    description: Pinned crun release to install (must be >= 1.14.3).
+    required: false
+    default: '1.28'
+
+runs:
+  using: composite
+  steps:
+    - name: Install podman
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y podman
+
+    - name: Pin crun >= 1.14.3 (Issue #1769)
+      shell: bash
+      run: |
+        CRUN_VERSION="${{ inputs.crun-version }}"
+        ARCH=$(dpkg --print-architecture)
+        case "$ARCH" in
+          amd64) CRUN_ARCH="linux-amd64" ;;
+          arm64) CRUN_ARCH="linux-arm64" ;;
+          *) echo "Unsupported architecture for crun pin: $ARCH"; exit 1 ;;
+        esac
+
+        echo "Runner-provided crun: $(crun --version 2>&1 | head -1 || echo 'not found')"
+
+        curl -fsSL -o /tmp/crun \
+          "https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-${CRUN_ARCH}"
+        chmod +x /tmp/crun
+        sudo mv /tmp/crun /usr/bin/crun
+
+        echo "Pinned crun: $(crun --version | head -1)"
+
+    - name: Print podman version
+      shell: bash
+      run: podman --version

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -921,7 +921,35 @@ jobs:
 
       - name: Create Kind cluster
         run: |
-          kind create cluster --name "$KIND_CLUSTER_NAME" --wait 120s
+          # Issue #1769: GitHub-hosted runners intermittently resolve a
+          # podman/crun combination where the OCI runtime rejects the
+          # container config ("crun: unknown version specified"), failing
+          # `kind create cluster` with exit status 126 while starting the
+          # control-plane container. This is a transient runner-side
+          # container-runtime issue, not a config problem -- Kind already
+          # tears down the partially-created node before returning, so a
+          # bare retry of the whole invocation is safe. Mirrors the same
+          # fix applied to the Go E2E harness (test/infrastructure/
+          # kind_cluster_helpers.go's retryTransientKindRuntimeError).
+          max_attempts=3
+          attempt=1
+          while true; do
+            echo "🔧 kind create cluster attempt ${attempt}/${max_attempts}"
+            if output=$(kind create cluster --name "$KIND_CLUSTER_NAME" --wait 120s 2>&1); then
+              echo "${output}"
+              break
+            fi
+            echo "${output}"
+            if [ "${attempt}" -ge "${max_attempts}" ] || ! echo "${output}" | grep -qiE "crun: unknown version specified|OCI runtime error"; then
+              echo "❌ kind create cluster failed (attempt ${attempt}/${max_attempts}) -- not a known-transient error, giving up."
+              exit 1
+            fi
+            backoff=$(( attempt * 5 ))
+            echo "⚠️  Transient container-runtime error detected (attempt ${attempt}/${max_attempts}), retrying in ${backoff}s..."
+            sleep "${backoff}"
+            attempt=$(( attempt + 1 ))
+          done
+
           kubectl cluster-info
           kubectl get nodes -o wide
 

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -503,9 +503,7 @@ jobs:
       - name: Generate OpenAPI specs
         run: make generate
       - name: Install Podman
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y podman
+        uses: ./.github/actions/install-podman
       - name: Setup envtest (K8s test binaries)
         run: |
           go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.23
@@ -685,9 +683,7 @@ jobs:
       - name: Generate OpenAPI specs
         run: make generate
       - name: Install Podman
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y podman
+        uses: ./.github/actions/install-podman
       - name: Login to GitHub Container Registry (for image pulls)
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -906,10 +902,7 @@ jobs:
           echo "PASS: values.schema.json is consistent with values.yaml"
 
       - name: Install Podman
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y podman
-          podman --version
+        uses: ./.github/actions/install-podman
 
       - name: Install Kind
         run: |

--- a/.github/workflows/e2e-test-template.yml
+++ b/.github/workflows/e2e-test-template.yml
@@ -66,10 +66,7 @@ jobs:
           kind version
 
       - name: Install Podman
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y podman
-          podman --version
+        uses: ./.github/actions/install-podman
 
       # ========================================
       # Run E2E Tests (with retry)

--- a/.github/workflows/helm-smoke-test.yml
+++ b/.github/workflows/helm-smoke-test.yml
@@ -38,10 +38,7 @@ jobs:
           go-version: '1.26.5'
 
       - name: Install Podman
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y podman
-          podman --version
+        uses: ./.github/actions/install-podman
 
       - name: Install Kind
         run: |

--- a/.github/workflows/integration-test-template.yml
+++ b/.github/workflows/integration-test-template.yml
@@ -46,10 +46,7 @@ jobs:
       # ========================================
       - name: Install Podman
         if: inputs.infrastructure == 'podman'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y podman
-          podman --version
+        uses: ./.github/actions/install-podman
 
       - name: Install Kind v0.30.0
         if: inputs.infrastructure == 'kind'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,10 +358,7 @@ jobs:
           cache: true
 
       - name: Install Podman
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y podman
-          podman --version
+        uses: ./.github/actions/install-podman
 
       - name: Install Kind
         run: |

--- a/test/infrastructure/kind_cluster_helpers.go
+++ b/test/infrastructure/kind_cluster_helpers.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // minKindVersionMajor, minKindVersionMinor define the minimum supported Kind
@@ -92,6 +93,68 @@ type ExtraMount struct {
 	HostPath      string
 	ContainerPath string
 	ReadOnly      bool
+}
+
+// kindCreateClusterMaxAttempts caps retries for `kind create cluster` when it
+// fails with a known-transient container-runtime error (Issue #1769).
+//
+// GitHub-hosted runners intermittently install a podman/crun combination where
+// the OCI runtime rejects the generated container config ("crun: unknown
+// version specified"), causing `kind create cluster` to fail with exit status
+// 126 while starting the control-plane container. This is a transient
+// container-runtime hiccup on the runner -- not a Kind config, kubeconfig, or
+// application-code problem -- and Kind itself already tears down the
+// partially-created node ("Deleted nodes: [...]") before returning, so retrying
+// the whole `kind create cluster` invocation from scratch is safe.
+const kindCreateClusterMaxAttempts = 3
+
+// transientKindRuntimeErrorPatterns are substrings of `kind create cluster`
+// output that indicate a transient container-runtime failure worth retrying,
+// as opposed to a genuine config/environment problem that would just fail
+// identically on every attempt.
+var transientKindRuntimeErrorPatterns = []string{
+	"crun: unknown version specified",
+	"OCI runtime error",
+}
+
+// isTransientKindRuntimeError reports whether kind's combined output matches a
+// known-transient container-runtime failure signature.
+func isTransientKindRuntimeError(output string) bool {
+	for _, pattern := range transientKindRuntimeErrorPatterns {
+		if strings.Contains(output, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// retryTransientKindRuntimeError runs runOnce (a `kind create cluster`
+// invocation) up to kindCreateClusterMaxAttempts times, retrying only when
+// runOnce fails AND its captured output matches a known-transient
+// container-runtime error (see isTransientKindRuntimeError). Any other
+// failure (bad config, missing binary, etc.) returns immediately on the first
+// attempt, since retrying would just reproduce the same error.
+func retryTransientKindRuntimeError(writer io.Writer, runOnce func() (output string, err error)) error {
+	const label = "kind create cluster"
+	var lastErr error
+	for attempt := 1; attempt <= kindCreateClusterMaxAttempts; attempt++ {
+		output, err := runOnce()
+		if err == nil {
+			if attempt > 1 {
+				_, _ = fmt.Fprintf(writer, "   ✅ %s succeeded on attempt %d/%d\n", label, attempt, kindCreateClusterMaxAttempts)
+			}
+			return nil
+		}
+		lastErr = err
+		if attempt >= kindCreateClusterMaxAttempts || !isTransientKindRuntimeError(output) {
+			return lastErr
+		}
+		backoff := time.Duration(attempt) * 5 * time.Second
+		_, _ = fmt.Fprintf(writer, "   ⚠️  %s hit a transient container-runtime error (attempt %d/%d), retrying in %v: %v\n",
+			label, attempt, kindCreateClusterMaxAttempts, backoff, err)
+		time.Sleep(backoff)
+	}
+	return lastErr
 }
 
 // CreateKindClusterWithExtraMounts creates a Kind cluster with dynamically added extraMounts
@@ -194,15 +257,19 @@ func CreateKindClusterWithExtraMounts(
 		_, _ = fmt.Fprintf(writer, "      %s → %s%s\n", mount.HostPath, mount.ContainerPath, readOnlyStr)
 	}
 
-	// 7. Create Kind cluster
-	cmd := exec.Command("kind", "create", "cluster",
-		"--name", clusterName,
-		"--config", tmpConfig.Name(),
-		"--kubeconfig", kubeconfigPath)
-	cmd.Stdout = writer
-	cmd.Stderr = writer
-
-	if err := cmd.Run(); err != nil {
+	// 7. Create Kind cluster (Issue #1769: retry on transient runtime errors)
+	err = retryTransientKindRuntimeError(writer, func() (string, error) {
+		var captured strings.Builder
+		cmd := exec.Command("kind", "create", "cluster",
+			"--name", clusterName,
+			"--config", tmpConfig.Name(),
+			"--kubeconfig", kubeconfigPath)
+		cmd.Stdout = io.MultiWriter(writer, &captured)
+		cmd.Stderr = io.MultiWriter(writer, &captured)
+		runErr := cmd.Run()
+		return captured.String(), runErr
+	})
+	if err != nil {
 		return fmt.Errorf("kind create cluster failed: %w", err)
 	}
 
@@ -399,27 +466,32 @@ func CreateKindClusterWithConfig(opts KindClusterOptions, writer io.Writer) erro
 		waitTimeout = "60s"
 	}
 
-	cmd := exec.Command("kind", "create", "cluster",
-		"--name", opts.ClusterName,
-		"--config", absoluteConfigPath,
-		"--kubeconfig", opts.KubeconfigPath,
-		"--wait", waitTimeout)
+	// 9. Create cluster (Issue #1769: retry on transient runtime errors)
+	err = retryTransientKindRuntimeError(writer, func() (string, error) {
+		var captured strings.Builder
+		cmd := exec.Command("kind", "create", "cluster",
+			"--name", opts.ClusterName,
+			"--config", absoluteConfigPath,
+			"--kubeconfig", opts.KubeconfigPath,
+			"--wait", waitTimeout)
 
-	cmd.Stdout = writer
-	cmd.Stderr = writer
+		cmd.Stdout = io.MultiWriter(writer, &captured)
+		cmd.Stderr = io.MultiWriter(writer, &captured)
 
-	// 7. Set working directory to project root if requested (for ./coverdata resolution)
-	if opts.ProjectRootAsWorkingDir {
-		cmd.Dir = workspaceRoot
-	}
+		// 7. Set working directory to project root if requested (for ./coverdata resolution)
+		if opts.ProjectRootAsWorkingDir {
+			cmd.Dir = workspaceRoot
+		}
 
-	// 8. Set Podman provider if requested
-	if opts.UsePodman {
-		cmd.Env = append(os.Environ(), "KIND_EXPERIMENTAL_PROVIDER=podman")
-	}
+		// 8. Set Podman provider if requested
+		if opts.UsePodman {
+			cmd.Env = append(os.Environ(), "KIND_EXPERIMENTAL_PROVIDER=podman")
+		}
 
-	// 9. Create cluster
-	if err := cmd.Run(); err != nil {
+		runErr := cmd.Run()
+		return captured.String(), runErr
+	})
+	if err != nil {
 		return fmt.Errorf("kind create cluster failed: %w", err)
 	}
 

--- a/test/infrastructure/workflowexecution_e2e_hybrid.go
+++ b/test/infrastructure/workflowexecution_e2e_hybrid.go
@@ -186,15 +186,20 @@ func SetupWorkflowExecutionInfrastructureHybridWithCoverage(ctx context.Context,
 		return fmt.Errorf("failed to find Kind config: %w", err)
 	}
 
-	// Create Kind cluster
-	createCmd := exec.Command("kind", "create", "cluster",
-		"--name", clusterName,
-		"--config", configPath,
-		"--kubeconfig", kubeconfigPath,
-	)
-	createCmd.Stdout = writer
-	createCmd.Stderr = writer
-	if err := createCmd.Run(); err != nil {
+	// Create Kind cluster (Issue #1769: retry on transient runtime errors)
+	err = retryTransientKindRuntimeError(writer, func() (string, error) {
+		var captured strings.Builder
+		createCmd := exec.CommandContext(ctx, "kind", "create", "cluster",
+			"--name", clusterName,
+			"--config", configPath,
+			"--kubeconfig", kubeconfigPath,
+		)
+		createCmd.Stdout = io.MultiWriter(writer, &captured)
+		createCmd.Stderr = io.MultiWriter(writer, &captured)
+		runErr := createCmd.Run()
+		return captured.String(), runErr
+	})
+	if err != nil {
 		return fmt.Errorf("failed to create Kind cluster: %w", err)
 	}
 

--- a/test/infrastructure/workflowexecution_parallel.go
+++ b/test/infrastructure/workflowexecution_parallel.go
@@ -82,14 +82,20 @@ func CreateWorkflowExecutionClusterParallel(clusterName, kubeconfigPath string, 
 	// ═══════════════════════════════════════════════════════════════════════
 	_, _ = fmt.Fprintf(output, "\n📦 PHASE 1: Creating Kind cluster...\n")
 
-	createCmd := exec.Command("kind", "create", "cluster",
-		"--name", clusterName,
-		"--config", configPath,
-		"--kubeconfig", kubeconfigPath,
-	)
-	createCmd.Stdout = output
-	createCmd.Stderr = output
-	if err := createCmd.Run(); err != nil {
+	// Issue #1769: retry on transient container-runtime errors.
+	err = retryTransientKindRuntimeError(output, func() (string, error) {
+		var captured strings.Builder
+		createCmd := exec.CommandContext(context.Background(), "kind", "create", "cluster",
+			"--name", clusterName,
+			"--config", configPath,
+			"--kubeconfig", kubeconfigPath,
+		)
+		createCmd.Stdout = io.MultiWriter(output, &captured)
+		createCmd.Stderr = io.MultiWriter(output, &captured)
+		runErr := createCmd.Run()
+		return captured.String(), runErr
+	})
+	if err != nil {
 		return fmt.Errorf("failed to create Kind cluster: %w", err)
 	}
 	_, _ = fmt.Fprintf(output, "✅ Kind cluster created\n")


### PR DESCRIPTION
## Summary

Backports the `main`-only fix for issue #1769 ("`Error: OCI runtime error: crun: unknown version specified`") to `release/v1.5`. This is a deterministic podman/crun version-compatibility bug (crun < 1.14.3 rejects podman-generated OCI Runtime Spec v1.2.1 container configs — see [containers/podman#27272](https://github.com/containers/podman/issues/27272), fixed in [crun 1.14.3](https://github.com/containers/crun/releases/tag/1.14.3)), not a transient per-VM flake.

`release/v1.5` never received this fix (it landed on `main` via #1769-related PRs), so every `kind create cluster` step on this branch's CI intermittently fails 126 while starting the control-plane container. Confirmed via must-gather RCA on two unrelated `release/v1.5` CI runs (PR #1781 and PR #1783) — both hit the identical `crun: unknown version specified` signature across 6+ unrelated E2E/Integration jobs (effectivenessmonitor, fullpipeline, kubernautagent, workflowexecution, apifrontend, aianalysis, datastorage, remediationorchestrator, gateway, helm-smoke-test), confirming this is branch-wide CI infrastructure flakiness, not a code defect in either PR.

Cherry-picked from `main` (`534422c03`, `995341930`, `2a83e13cf`), adapted for `release/v1.5`'s divergent structure:
- `test/infrastructure/kind_cluster_helpers.go`/`workflowexecution_*.go`: retry `kind create cluster` up to 3x on the known-transient error signature only (any other failure still fails immediately). `release/v1.5` doesn't carry `main`'s later `context.Context` plumbing for these functions, so the retry wrapper uses `exec.Command` (or the pre-existing `ctx`/`context.Background()` where already available) instead of introducing a new parameter.
- New composite action `.github/actions/install-podman`: installs podman, then pins crun to a release >= 1.14.3 (default `1.28`).
- `ci-pipeline.yml`/`e2e-test-template.yml`/`helm-smoke-test.yml`/`integration-test-template.yml`/`release.yml`: replaced raw `apt-get install -y podman` with the new pinned action; `release/v1.5`'s own registry-based image pull/login flow (distinct from `main`'s artifact-based handoff) is preserved unchanged.
- Dropped `main`-only `fleet-e2e-memory-spike.yml` (doesn't exist on `release/v1.5`) and `main`-only `extraPortMappings`/artifact-loading changes that are out of scope for this fix.

## Validation

- `go build ./...`: clean
- `go vet ./test/infrastructure/...`: clean
- YAML syntax (`python3 -c "import yaml; yaml.safe_load(...)"`) on all 6 modified workflow/action files: OK
- `actionlint`: zero *new* shellcheck findings — diffed against the pre-fix baseline commit, all 29 findings are pre-existing (same script blocks, shifted line numbers only)

## Test plan

- [ ] CI green on this PR (validates the fix end-to-end on `release/v1.5`'s own runners)

Made with [Cursor](https://cursor.com)