### PR TITLE
fix(main): backport #1772, #1775, #1777 fixes from release/v1.5 wave

### DIFF
--- a/internal/kubernautagent/investigator/investigator_gates.go
+++ b/internal/kubernautagent/investigator/investigator_gates.go
@@ -127,7 +127,7 @@ func (inv *Investigator) retryForSameKind(ctx context.Context, result *katypes.I
 	// hardcoded 0/"" that misrepresented every gate retry as an empty
 	// request.
 	gateEvent.Data["prompt_length"] = totalPromptLength(retryMessages)
-	gateEvent.Data["prompt_preview"] = lastUserMessage(retryMessages, 500)
+	gateEvent.Data["prompt_preview"] = lastUserMessage(retryMessages)
 	audit.StoreBestEffort(ctx, inv.auditStore, gateEvent, inv.auditLog())
 
 	resp, err := llm.ChatWithParams(ctx, client, llm.ChatRequest{
@@ -307,7 +307,7 @@ func (inv *Investigator) retryForAPIVersion(ctx context.Context, p retryForAPIVe
 	// hardcoded 0/"" that misrepresented every gate retry as an empty
 	// request.
 	gateEvent.Data["prompt_length"] = totalPromptLength(retryMessages)
-	gateEvent.Data["prompt_preview"] = lastUserMessage(retryMessages, 500)
+	gateEvent.Data["prompt_preview"] = lastUserMessage(retryMessages)
 	audit.StoreBestEffort(ctx, inv.auditStore, gateEvent, inv.auditLog())
 
 	resp, retryErr := llm.ChatWithParams(ctx, client, llm.ChatRequest{

--- a/internal/kubernautagent/investigator/investigator_gates.go
+++ b/internal/kubernautagent/investigator/investigator_gates.go
@@ -81,18 +81,18 @@ func (inv *Investigator) sameKindValidationGate(
 		"signal_resource_kind", signal.ResourceKind,
 		"correlation_id", correlationID)
 
+	// #1777 (BR-AUDIT-005, FedRAMP AU-3): prompt_length/prompt_preview are
+	// populated in retryForSameKind, once the actual retry prompt exists —
+	// see the audit.StoreBestEffort call there for why.
 	gateEvent := audit.NewEvent(audit.EventTypeLLMRequest, correlationID)
 	gateEvent.EventAction = audit.ActionSameKindGate
 	gateEvent.EventOutcome = audit.OutcomeSuccess
 	gateEvent.Data["model"] = modelName
-	gateEvent.Data["prompt_length"] = 0
-	gateEvent.Data["prompt_preview"] = ""
 	gateEvent.Data["signal_resource_kind"] = signal.ResourceKind
 	gateEvent.Data["target_kind"] = result.RemediationTarget.Kind
 	gateEvent.Data["target_name"] = result.RemediationTarget.Name
-	audit.StoreBestEffort(ctx, inv.auditStore, gateEvent, inv.auditLog())
 
-	return inv.retryForSameKind(ctx, result, history, llmCtx)
+	return inv.retryForSameKind(ctx, result, history, llmCtx, gateEvent)
 }
 
 // sameKindCorrectionMessage builds the LLM correction message asking it to
@@ -116,12 +116,22 @@ func sameKindCorrectionMessage(targetKind string) string {
 // the retry response. Falls back to the original result at every failure
 // point: LLM error, empty response, parse error, or a retry result that
 // lost the remediation target.
-func (inv *Investigator) retryForSameKind(ctx context.Context, result *katypes.InvestigationResult, history []llm.Message, llmCtx LLMInvocationContext) *katypes.InvestigationResult {
+func (inv *Investigator) retryForSameKind(ctx context.Context, result *katypes.InvestigationResult, history []llm.Message, llmCtx LLMInvocationContext, gateEvent *audit.AuditEvent) *katypes.InvestigationResult {
 	tokens, correlationID, client, runtimeParams := llmCtx.Tokens, llmCtx.CorrelationID, llmCtx.Client, llmCtx.RuntimeParams
 	correctionMsg := sameKindCorrectionMessage(result.RemediationTarget.Kind)
+	retryMessages := appendCorrectionMessage(history, correctionMsg)
+
+	// #1777 (BR-AUDIT-005, FedRAMP AU-3): the audit event must reflect the
+	// retry prompt actually sent to the LLM. Populating these fields before
+	// retryMessages exists forced prompt_length/prompt_preview to a
+	// hardcoded 0/"" that misrepresented every gate retry as an empty
+	// request.
+	gateEvent.Data["prompt_length"] = totalPromptLength(retryMessages)
+	gateEvent.Data["prompt_preview"] = lastUserMessage(retryMessages, 500)
+	audit.StoreBestEffort(ctx, inv.auditStore, gateEvent, inv.auditLog())
 
 	resp, err := llm.ChatWithParams(ctx, client, llm.ChatRequest{
-		Messages: appendCorrectionMessage(history, correctionMsg),
+		Messages: retryMessages,
 		Tools:    submitOnlyRCATools(),
 		Options:  llm.ChatOptions{JSONMode: true, OutputSchema: parser.RCAResultSchema()},
 	}, runtimeParams)
@@ -209,15 +219,15 @@ func (inv *Investigator) apiVersionValidationGate(
 	inv.logger.Info("apiVersionValidationGate triggered: ambiguous kind missing api_version",
 		"kind", kind, "conflicting_groups", groupList, "correlation_id", correlationID)
 
+	// #1777 (BR-AUDIT-005, FedRAMP AU-3): prompt_length/prompt_preview are
+	// populated in retryForAPIVersion, once the actual retry prompt exists —
+	// see the audit.StoreBestEffort call there for why.
 	gateEvent := audit.NewEvent(audit.EventTypeLLMRequest, correlationID)
 	gateEvent.EventAction = audit.ActionAPIVersionGate
 	gateEvent.EventOutcome = audit.OutcomeSuccess
 	gateEvent.Data["model"] = modelName
-	gateEvent.Data["prompt_length"] = 0
-	gateEvent.Data["prompt_preview"] = ""
 	gateEvent.Data["ambiguous_kind"] = kind
 	gateEvent.Data["conflicting_groups"] = groupList
-	audit.StoreBestEffort(ctx, inv.auditStore, gateEvent, inv.auditLog())
 
 	return inv.retryForAPIVersion(ctx, retryForAPIVersionParams{
 		Result: result, History: history, Client: client, RuntimeParams: runtimeParams, Tokens: tokens,
@@ -289,9 +299,19 @@ func (inv *Investigator) retryForAPIVersion(ctx context.Context, p retryForAPIVe
 			`API group the target %s/%s belongs to.`,
 		kind, groupList, kind, result.RemediationTarget.Name,
 	)
+	retryMessages := appendCorrectionMessage(history, correctionMsg)
+
+	// #1777 (BR-AUDIT-005, FedRAMP AU-3): the audit event must reflect the
+	// retry prompt actually sent to the LLM. Populating these fields before
+	// retryMessages exists forced prompt_length/prompt_preview to a
+	// hardcoded 0/"" that misrepresented every gate retry as an empty
+	// request.
+	gateEvent.Data["prompt_length"] = totalPromptLength(retryMessages)
+	gateEvent.Data["prompt_preview"] = lastUserMessage(retryMessages, 500)
+	audit.StoreBestEffort(ctx, inv.auditStore, gateEvent, inv.auditLog())
 
 	resp, retryErr := llm.ChatWithParams(ctx, client, llm.ChatRequest{
-		Messages: appendCorrectionMessage(history, correctionMsg),
+		Messages: retryMessages,
 		Tools:    submitOnlyRCATools(),
 		Options:  llm.ChatOptions{JSONMode: true, OutputSchema: parser.RCAResultSchema()},
 	}, runtimeParams)

--- a/internal/kubernautagent/investigator/investigator_gates_audit_test.go
+++ b/internal/kubernautagent/investigator/investigator_gates_audit_test.go
@@ -1,0 +1,177 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// #1777 (BR-AUDIT-005 / FedRAMP AU-3): sameKindValidationGate and
+// apiVersionValidationGate both send a real corrective retry prompt to the
+// LLM (a full re-transmission of history + a correction message), but the
+// audit event they emit BEFORE building that retry hardcodes
+// prompt_length=0/prompt_preview="" regardless of what is actually sent.
+// This breaks SOC2 CC8.1 audit-trace reconstruction: the trail claims an
+// empty prompt was sent when a real, non-trivial corrective prompt was.
+var _ = Describe("#1777: validation-gate audit events must reflect the real retry prompt", func() {
+
+	var (
+		logger     logr.Logger
+		auditStore *gateRecordingAuditStore
+		mockClient *gateMockLLMClient
+		builder    *prompt.Builder
+		rp         *parser.ResultParser
+		enricher   *enrichment.Enricher
+		phaseTools katypes.PhaseToolMap
+	)
+
+	BeforeEach(func() {
+		logger = logr.Discard()
+		auditStore = &gateRecordingAuditStore{}
+		mockClient = &gateMockLLMClient{}
+		builder, _ = prompt.NewBuilder()
+		rp = parser.NewResultParser()
+		enricher = enrichment.NewEnricher(&gateK8sClient{}, &gateDSClient{}, auditStore, logger)
+		phaseTools = investigator.DefaultPhaseToolMap()
+	})
+
+	Describe("UT-KA-1777-001: apiVersionValidationGate audit event carries the real retry prompt", func() {
+		It("should populate prompt_length/prompt_preview from the actual retryMessages, not 0/\"\" (BR-AUDIT-005, FedRAMP AU-3)", func() {
+			mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{
+				{Group: "operators.coreos.com", Version: "v1alpha1"},
+				{Group: "messaging.knative.dev", Version: "v1"},
+			})
+			mapper.Add(schema.GroupVersionKind{Group: "operators.coreos.com", Version: "v1alpha1", Kind: "Subscription"}, meta.RESTScopeNamespace)
+			mapper.Add(schema.GroupVersionKind{Group: "messaging.knative.dev", Version: "v1", Kind: "Subscription"}, meta.RESTScopeNamespace)
+
+			signal := katypes.SignalContext{
+				ResourceKind: "Pod",
+				ResourceName: "etcd-operator-xyz",
+				Name:         "etcd-operator-xyz",
+				Namespace:    "demo-operator",
+				Severity:     "critical",
+				Message:      "RBAC denial on wrong API group",
+			}
+
+			mockClient.responses = []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Subscription etcd needs restart",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Subscription","name":"etcd","namespace":"demo-operator"}
+				}`}},
+				// Gate retry: LLM provides api_version
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Subscription etcd needs restart",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Subscription","name":"etcd","namespace":"demo-operator","api_version":"operators.coreos.com/v1alpha1"}
+				}`}},
+				gateWfToolResp(`{"workflow_id":"restart-sub","confidence":0.9}`),
+			}
+
+			resolver := investigator.NewMapperScopeResolver(mapper)
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools, ScopeResolver: resolver,
+			})
+
+			_, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+
+			gateEvents := auditStore.eventsByAction(audit.ActionAPIVersionGate)
+			Expect(gateEvents).NotTo(BeEmpty(), "UT-KA-1777-001: gate must emit an audit event")
+			ev := gateEvents[0]
+
+			Expect(ev.Data["prompt_length"]).To(BeNumerically(">", 0),
+				"UT-KA-1777-001: gate sends a real corrective prompt to the LLM — the audit trail "+
+					"must reflect that, not a hardcoded 0 (SOC2 CC8.1 reconstruction)")
+			preview, ok := ev.Data["prompt_preview"].(string)
+			Expect(ok).To(BeTrue())
+			Expect(preview).NotTo(BeEmpty(),
+				"UT-KA-1777-001: prompt_preview must carry the actual correction message, not \"\"")
+			Expect(preview).To(ContainSubstring("api_version"),
+				"UT-KA-1777-001: prompt_preview must reflect the real correction message content")
+		})
+	})
+
+	Describe("UT-KA-1777-002: sameKindValidationGate audit event carries the real retry prompt", func() {
+		It("should populate prompt_length/prompt_preview from the actual retryMessages, not 0/\"\" (BR-AUDIT-005, FedRAMP AU-3)", func() {
+			signal := katypes.SignalContext{
+				ResourceKind: "Pod",
+				ResourceName: "api-server-xyz",
+				Name:         "api-server-xyz",
+				Namespace:    "production",
+				Severity:     "critical",
+				Message:      "Pod OOMKilled repeatedly",
+			}
+
+			mockClient.responses = []llm.ChatResponse{
+				// Same-kind gate fires: RemediationTarget.Kind ("Pod") == signal.ResourceKind ("Pod")
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Pod OOMKilled",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Pod","name":"api-server-xyz","namespace":"production"}
+				}`}},
+				// Gate retry: LLM re-targets the parent Deployment
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Deployment memory limit too low",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Deployment","name":"api-server","namespace":"production","api_version":"apps/v1"}
+				}`}},
+				gateWfToolResp(`{"workflow_id":"increase-memory-limit","confidence":0.9}`),
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			_, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+
+			gateEvents := auditStore.eventsByAction(audit.ActionSameKindGate)
+			Expect(gateEvents).NotTo(BeEmpty(), "UT-KA-1777-002: gate must emit an audit event")
+			ev := gateEvents[0]
+
+			Expect(ev.Data["prompt_length"]).To(BeNumerically(">", 0),
+				"UT-KA-1777-002: gate sends a real corrective prompt to the LLM — the audit trail "+
+					"must reflect that, not a hardcoded 0 (SOC2 CC8.1 reconstruction)")
+			preview, ok := ev.Data["prompt_preview"].(string)
+			Expect(ok).To(BeTrue())
+			Expect(preview).NotTo(BeEmpty(),
+				"UT-KA-1777-002: prompt_preview must carry the actual correction message, not \"\"")
+			Expect(preview).To(ContainSubstring("same resource kind"),
+				"UT-KA-1777-002: prompt_preview must reflect the real correction message content")
+		})
+	})
+})

--- a/internal/kubernautagent/investigator/investigator_loop.go
+++ b/internal/kubernautagent/investigator/investigator_loop.go
@@ -247,7 +247,7 @@ func (inv *Investigator) emitLLMRequestAudit(ctx context.Context, correlationID,
 	reqEvent.EventOutcome = audit.OutcomeSuccess
 	reqEvent.Data["model"] = modelName
 	reqEvent.Data["prompt_length"] = totalPromptLength(messages)
-	reqEvent.Data["prompt_preview"] = lastUserMessage(messages, 500)
+	reqEvent.Data["prompt_preview"] = lastUserMessage(messages)
 	reqEvent.Data["toolsets_enabled"] = toolNames(toolDefs)
 	reqEvent.Data["messages"] = messagesToAuditFormat(messages)
 	audit.StoreBestEffort(ctx, inv.auditStore, reqEvent, inv.auditLog())

--- a/internal/kubernautagent/investigator/investigator_tools.go
+++ b/internal/kubernautagent/investigator/investigator_tools.go
@@ -51,10 +51,17 @@ func totalPromptLength(messages []llm.Message) int {
 	return total
 }
 
-func lastUserMessage(messages []llm.Message, maxLen int) string {
+// lastUserMessagePreviewLen is the fixed truncation length for audit
+// prompt_preview fields derived from the last user message. Every caller of
+// lastUserMessage uses this same length (unlike truncatePreview's other call
+// sites, which vary), so it is hardcoded here rather than threaded as a
+// parameter (100 Go Mistakes: unparam).
+const lastUserMessagePreviewLen = 500
+
+func lastUserMessage(messages []llm.Message) string {
 	for i := len(messages) - 1; i >= 0; i-- {
 		if messages[i].Role == "user" {
-			return truncatePreview(messages[i].Content, maxLen)
+			return truncatePreview(messages[i].Content, lastUserMessagePreviewLen)
 		}
 	}
 	return ""
@@ -110,7 +117,7 @@ func (inv *Investigator) emitRetryAudit(ctx context.Context, p retryAuditParams)
 	retryEvent.EventOutcome = audit.OutcomeSuccess
 	retryEvent.Data["model"] = p.modelName
 	retryEvent.Data["prompt_length"] = totalPromptLength(p.messages)
-	retryEvent.Data["prompt_preview"] = lastUserMessage(p.messages, 500)
+	retryEvent.Data["prompt_preview"] = lastUserMessage(p.messages)
 	retryEvent.Data["retry_attempt"] = p.attempt
 	retryEvent.Data["retry_max"] = p.maxAttempts
 	retryEvent.Data["phase"] = string(p.phase)

--- a/pkg/apifrontend/tools/kubectl_get.go
+++ b/pkg/apifrontend/tools/kubectl_get.go
@@ -73,10 +73,22 @@ func HandleKubectlGet(ctx context.Context, reader ResourceReader, mapper meta.RE
 // resolveGVRAndGVK maps a Kind string to both GroupVersionResource and
 // GroupVersionKind using the static table in pkg/shared/k8s. Both are
 // needed: GVR for dynamic.Interface and GVK for client.Reader dispatch.
+//
+// #1772: the plural must come from the RESTMapper (which reflects the API
+// server's actual resource naming) whenever one is available. Falling back
+// straight to meta.UnsafeGuessKindToResource's naive kind-lowercase+"s"
+// heuristic mis-pluralizes irregular kinds (e.g. Ingress -> "ingresss"),
+// causing kubectl_get to look up the wrong resource and return a false
+// "not found".
 func resolveGVRAndGVK(mapper meta.RESTMapper, kind string) (schema.GroupVersionResource, schema.GroupVersionKind, error) {
 	gvk, err := sharedK8s.ResolveGVKForKind(mapper, kind)
 	if err != nil {
 		return schema.GroupVersionResource{}, schema.GroupVersionKind{}, err
+	}
+	if mapper != nil {
+		if mapping, mErr := mapper.RESTMapping(gvk.GroupKind(), gvk.Version); mErr == nil {
+			return mapping.Resource, gvk, nil
+		}
 	}
 	plural, _ := meta.UnsafeGuessKindToResource(gvk)
 	return plural, gvk, nil

--- a/pkg/apifrontend/tools/kubectl_get_test.go
+++ b/pkg/apifrontend/tools/kubectl_get_test.go
@@ -6,6 +6,8 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -238,5 +240,69 @@ var _ = Describe("kubectl_get", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.Kind).To(Equal("Endpoints"))
 		Expect(result.Object).To(HaveKey("subsets"))
+	})
+
+	// UT-AF-1772-001/002 (BR-AI, SI-10 input validation / correctness):
+	// resolveGVRAndGVK must use the discovery-backed RESTMapper's real plural
+	// instead of meta.UnsafeGuessKindToResource's naive heuristic, which
+	// mis-pluralizes irregular Kinds (e.g. "AIAnalysis" -> "aianalysises"
+	// instead of the real "aianalyses") and surfaces as a misleading
+	// RBAC/403 error (#1772).
+	It("UT-AF-1772-001: resolves the discovery-backed plural for an irregular Kind (AIAnalysis)", func() {
+		mapper := meta.NewDefaultRESTMapper([]schema.GroupVersion{
+			{Group: "kubernaut.ai", Version: "v1alpha1"},
+		})
+		aiaGVK := schema.GroupVersionKind{Group: "kubernaut.ai", Version: "v1alpha1", Kind: "AIAnalysis"}
+		aiaGVR := schema.GroupVersionResource{Group: "kubernaut.ai", Version: "v1alpha1", Resource: "aianalyses"}
+		mapper.AddSpecific(aiaGVK, aiaGVR, aiaGVR, meta.RESTScopeNamespace)
+
+		gvrs := map[schema.GroupVersionResource]string{
+			aiaGVR: "AIAnalysisList",
+		}
+		scheme := runtime.NewScheme()
+		// The fake tracker's Add() always places seed objects under
+		// meta.UnsafeGuessKindToResource's plural, which would silently make
+		// this test pass against the *buggy* resolveGVRAndGVK too (both sides
+		// guessing "aianalysises"). Bypass that by seeding via an explicit
+		// Create call under the real, discovery-correct GVR instead.
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, gvrs)
+		aia := &unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "kubernaut.ai/v1alpha1",
+				"kind":       "AIAnalysis",
+				"metadata": map[string]interface{}{
+					"name":      "rr-123-analysis",
+					"namespace": "prod",
+				},
+			},
+		}
+		_, err := client.Resource(aiaGVR).Namespace("prod").Create(context.Background(), aia, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
+
+		result, err := tools.HandleKubectlGet(context.Background(), &tools.DynamicResourceReader{Client: client}, mapper, tools.KubectlGetArgs{
+			Kind:      "AIAnalysis",
+			Name:      "rr-123-analysis",
+			Namespace: "prod",
+		})
+		Expect(err).NotTo(HaveOccurred(),
+			"kubectl_get must resolve AIAnalysis's real discovery-backed plural (aianalyses), "+
+				"not the naive guess (aianalysises), which would 404 and be misreported as an RBAC error")
+		Expect(result.Kind).To(Equal("AIAnalysis"))
+		Expect(result.Name).To(Equal("rr-123-analysis"))
+	})
+
+	It("UT-AF-1772-002: falls back to the naive plural guess when mapper is nil", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, kubectlGVRs,
+			newUnstructuredService("prod", "web-svc", "10.0.0.1"),
+		)
+
+		result, err := tools.HandleKubectlGet(context.Background(), &tools.DynamicResourceReader{Client: client}, nil, tools.KubectlGetArgs{
+			Kind:      "Service",
+			Name:      "web-svc",
+			Namespace: "prod",
+		})
+		Expect(err).NotTo(HaveOccurred(), "regular Kinds must still resolve when no RESTMapper is available")
+		Expect(result.Kind).To(Equal("Service"))
 	})
 })

--- a/pkg/kubernautagent/llm/anthropicfamily/client.go
+++ b/pkg/kubernautagent/llm/anthropicfamily/client.go
@@ -659,6 +659,14 @@ func extractTextDelta(event anthropic.MessageStreamEventUnion) (string, bool) {
 	if event.Delta.Text != "" {
 		return event.Delta.Text, true
 	}
+	// #1775: extended/interleaved thinking (Claude's thinking: {type: "enabled"}
+	// param) streams its content as thinking_delta events, populating
+	// event.Delta.Thinking rather than event.Delta.Text. Without this branch,
+	// that content is silently dropped from the token_delta sink the moment
+	// extended thinking is enabled on a request.
+	if event.Delta.Thinking != "" {
+		return event.Delta.Thinking, true
+	}
 	return "", false
 }
 

--- a/pkg/kubernautagent/llm/anthropicfamily/stream_chat_1775_test.go
+++ b/pkg/kubernautagent/llm/anthropicfamily/stream_chat_1775_test.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package anthropicfamily_test
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/anthropics/anthropic-sdk-go/option"
+
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm/anthropicfamily"
+)
+
+// thinkingBlockSSE is a real Anthropic Messages API streaming response
+// containing a thinking_delta content block, in the exact
+// "event: <type>\ndata: <json>\n\n" wire format the SDK's SSE decoder
+// expects (mirrors anthropic-sdk-go's own message_test.go "thinking block"
+// fixture).
+const thinkingBlockSSE = `event: message_start
+data: {"type":"message_start","message":{"id":"msg_thinking","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[],"stop_reason":null,"stop_sequence":null,"usage":{"input_tokens":50,"output_tokens":0}}}
+
+event: content_block_start
+data: {"type":"content_block_start","index":0,"content_block":{"type":"thinking","thinking":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":0,"delta":{"type":"thinking_delta","thinking":"investigating pod crash..."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":0}
+
+event: content_block_start
+data: {"type":"content_block_start","index":1,"content_block":{"type":"text","text":""}}
+
+event: content_block_delta
+data: {"type":"content_block_delta","index":1,"delta":{"type":"text_delta","text":"The pod is OOMKilled."}}
+
+event: content_block_stop
+data: {"type":"content_block_stop","index":1}
+
+event: message_delta
+data: {"type":"message_delta","delta":{"stop_reason":"end_turn","stop_sequence":null},"usage":{"output_tokens":10}}
+
+event: message_stop
+data: {"type":"message_stop"}
+
+`
+
+// IT-VA-1775-001 (BR-AI-086 live reasoning narration): proves the fix closes
+// the loop end-to-end through the real Anthropic SSE wire format and
+// StreamChat's actual callback dispatch, not just the extractTextDelta unit
+// in isolation. Regression target: #1775 — thinking_delta content silently
+// dropped from the token_delta stream.
+var _ = Describe("StreamChat — #1775 thinking_delta wire contract", func() {
+	It("IT-VA-1775-001: delivers thinking_delta content to the callback alongside text_delta", func() {
+		tokenSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"access_token":"fake-token","token_type":"Bearer","expires_in":3600}`))
+		}))
+		defer tokenSrv.Close()
+		fakeCreds := generateFakeServiceAccountJSONWithTokenURL(tokenSrv.URL)
+
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "text/event-stream")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(thinkingBlockSSE))
+		}))
+		defer server.Close()
+
+		client, err := anthropicfamily.New(context.Background(),
+			"claude-sonnet-4-6", fakeCreds, "my-project", "us-central1",
+			anthropicfamily.WithSDKOptions(option.WithBaseURL(server.URL)),
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		var deltas []string
+		_, err = client.StreamChat(context.Background(), llm.ChatRequest{
+			Messages: []llm.Message{{Role: "user", Content: "Why is the pod crashing?"}},
+		}, func(evt llm.ChatStreamEvent) error {
+			if evt.Delta != "" {
+				deltas = append(deltas, evt.Delta)
+			}
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		joined := strings.Join(deltas, "")
+		Expect(joined).To(ContainSubstring("investigating pod crash..."),
+			"thinking_delta content must reach the callback; a missing Delta.Thinking check "+
+				"means extended-thinking output is silently dropped from the live console panel (#1775)")
+		Expect(joined).To(ContainSubstring("The pod is OOMKilled."),
+			"text_delta content must keep working alongside thinking_delta (no regression)")
+	})
+})

--- a/pkg/kubernautagent/llm/anthropicfamily/text_delta_test.go
+++ b/pkg/kubernautagent/llm/anthropicfamily/text_delta_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package anthropicfamily
+
+import (
+	"github.com/anthropics/anthropic-sdk-go"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// UT-VA-1775-001..004 (BR-AI-086 live reasoning narration): extractTextDelta
+// must surface extended-thinking content (thinking_delta events), not just
+// regular text_delta events. #1775: prior to this fix, event.Delta.Thinking
+// was never read, so any thinking_delta stream event was silently dropped —
+// zero visible output in the console's live panel the moment extended
+// thinking is enabled on a request.
+var _ = Describe("extractTextDelta — #1775", func() {
+	It("UT-VA-1775-001: extracts thinking_delta content", func() {
+		event := anthropic.MessageStreamEventUnion{
+			Type: "content_block_delta",
+			Delta: anthropic.MessageStreamEventUnionDelta{
+				Type:     "thinking_delta",
+				Thinking: "investigating pod crash...",
+			},
+		}
+		delta, ok := extractTextDelta(event)
+		Expect(ok).To(BeTrue(), "thinking_delta events must be extracted, not silently dropped")
+		Expect(delta).To(Equal("investigating pod crash..."))
+	})
+
+	It("UT-VA-1775-002: text_delta still extracts as before (no regression)", func() {
+		event := anthropic.MessageStreamEventUnion{
+			Type: "content_block_delta",
+			Delta: anthropic.MessageStreamEventUnionDelta{
+				Type: "text_delta",
+				Text: "hello",
+			},
+		}
+		delta, ok := extractTextDelta(event)
+		Expect(ok).To(BeTrue())
+		Expect(delta).To(Equal("hello"))
+	})
+
+	It("UT-VA-1775-003: non-content_block_delta events return false", func() {
+		event := anthropic.MessageStreamEventUnion{Type: "message_stop"}
+		_, ok := extractTextDelta(event)
+		Expect(ok).To(BeFalse())
+	})
+
+	It("UT-VA-1775-004: content_block_delta with neither text nor thinking returns false", func() {
+		event := anthropic.MessageStreamEventUnion{
+			Type: "content_block_delta",
+			Delta: anthropic.MessageStreamEventUnionDelta{
+				Type:        "input_json_delta",
+				PartialJSON: `{"kind":`,
+			},
+		}
+		_, ok := extractTextDelta(event)
+		Expect(ok).To(BeFalse())
+	})
+})


### PR DESCRIPTION
## Summary

Backports 3 of the 5 fixes from release/v1.5's consolidated bugfix wave (#1779) to `main`, adapted to main's current (diverged) code structure. main has moved on since the v1.5 branch cut — `resolveGVR` → `resolveGVRAndGVK`, `vertexanthropic` → `anthropicfamily`, and the validation gates now thread an `LLMInvocationContext` struct — so each fix is re-implemented against that structure rather than cherry-picked.

- **#1772**: `kubectl_get`'s `resolveGVRAndGVK` now prefers the RESTMapper's discovery-backed plural over `meta.UnsafeGuessKindToResource`'s naive heuristic, which mis-pluralizes irregular Kinds (e.g. `AIAnalysis` → `aianalysises` instead of `aianalyses`), surfacing as a misleading RBAC/403 error.
- **#1775**: `anthropicfamily`'s `extractTextDelta` now also reads `event.Delta.Thinking`, so extended-thinking (`thinking_delta`) stream events are no longer silently dropped from the live console panel.
- **#1777**: `sameKindValidationGate`/`apiVersionValidationGate` now populate their audit event's `prompt_length`/`prompt_preview` from the actual retry prompt sent to the LLM (once it's built), instead of a hardcoded `0`/`""` — closes a SOC2 CC8.1 audit-reconstruction gap (BR-AUDIT-005, FedRAMP AU-3).

**Not backported** (already fixed on `main`, confirmed via source inspection):
- #1771 — fixed via #1634 (reasoning_delta field already renamed to `"text"`)
- #1773 — `SpecHash` validation/wiring for remediation history already present

## Test plan
- [x] `go build ./...` passes
- [x] Unit tests ported/adapted per fix: `kubectl_get_test.go` (UT-AF-1772-001/002), `text_delta_test.go` + `stream_chat_1775_test.go` (UT-VA-1775-001..004, IT-VA-1775-001), `investigator_gates_audit_test.go` (UT-KA-1777-001/002)
- [x] Full package suites green with no regressions: `internal/kubernautagent/investigator`, `pkg/apifrontend/tools`, `pkg/kubernautagent/llm/anthropicfamily`
- [ ] CI green on this PR

Made with [Cursor](https://cursor.com)