### PR TITLE
fix(ci): align crun/podman fix with main's approach (Issue #1769)

### DIFF
--- a/.github/actions/install-podman/action.yml
+++ b/.github/actions/install-podman/action.yml
@@ -1,0 +1,52 @@
+name: Install Podman (crun-pinned)
+description: >
+  Installs podman via apt, then replaces the runner's bundled crun binary
+  with a pinned release known to be compatible with podman's generated OCI
+  Runtime Spec configs (Issue #1769). GitHub's ubuntu-24.04 runner images
+  ship a crun version older than 1.14.3, which rejects podman-generated
+  container configs with "Error: OCI runtime error: crun: unknown version
+  specified" -- a deterministic version-compatibility bug, not a transient
+  flake: it reproduces on every `podman run`/`kind create cluster` call
+  that hits it, on that exact podman+crun pairing, until crun is upgraded.
+  See https://github.com/containers/podman/issues/27272 (root cause: crun
+  rejects OCI Runtime Spec v1.2.1 configs below v1.14.3) and
+  https://github.com/containers/crun/releases/tag/1.14.3 (fix version).
+
+inputs:
+  crun-version:
+    description: Pinned crun release to install (must be >= 1.14.3).
+    required: false
+    default: '1.28'
+
+runs:
+  using: composite
+  steps:
+    - name: Install podman
+      shell: bash
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y podman
+
+    - name: Pin crun >= 1.14.3 (Issue #1769)
+      shell: bash
+      run: |
+        CRUN_VERSION="${{ inputs.crun-version }}"
+        ARCH=$(dpkg --print-architecture)
+        case "$ARCH" in
+          amd64) CRUN_ARCH="linux-amd64" ;;
+          arm64) CRUN_ARCH="linux-arm64" ;;
+          *) echo "Unsupported architecture for crun pin: $ARCH"; exit 1 ;;
+        esac
+
+        echo "Runner-provided crun: $(crun --version 2>&1 | head -1 || echo 'not found')"
+
+        curl -fsSL -o /tmp/crun \
+          "https://github.com/containers/crun/releases/download/${CRUN_VERSION}/crun-${CRUN_VERSION}-${CRUN_ARCH}"
+        chmod +x /tmp/crun
+        sudo mv /tmp/crun /usr/bin/crun
+
+        echo "Pinned crun: $(crun --version | head -1)"
+
+    - name: Print podman version
+      shell: bash
+      run: podman --version

--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -503,20 +503,7 @@ jobs:
       - name: Generate OpenAPI specs
         run: make generate
       - name: Install Podman
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y podman
-      # crun pin (#1784): the ubuntu-latest runner image's preinstalled crun
-      # predates 1.14.3 and cannot parse the OCI Runtime Spec v1.2.1
-      # config.json that current Podman generates, failing every container
-      # start with "OCI runtime error: crun: unknown version specified"
-      # (https://github.com/containers/podman/issues/27272, resolved in
-      # crun v1.14.3). apt's crun lags behind apt's podman, so pin explicitly.
-      - name: Pin crun >= 1.14.3 (podman/crun OCI spec compat)
-        run: |
-          sudo curl -fL "https://github.com/containers/crun/releases/download/1.14.3/crun-1.14.3-linux-amd64" -o /usr/bin/crun
-          sudo chmod +x /usr/bin/crun
-          crun --version
+        uses: ./.github/actions/install-podman
       - name: Setup envtest (K8s test binaries)
         run: |
           go install sigs.k8s.io/controller-runtime/tools/setup-envtest@release-0.23
@@ -696,21 +683,7 @@ jobs:
       - name: Generate OpenAPI specs
         run: make generate
       - name: Install Podman
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y podman
-      # crun pin (#1784): the ubuntu-latest runner image's preinstalled crun
-      # predates 1.14.3 and cannot parse the OCI Runtime Spec v1.2.1
-      # config.json that current Podman generates, failing every container
-      # start (including Kind's own control-plane container) with
-      # "OCI runtime error: crun: unknown version specified"
-      # (https://github.com/containers/podman/issues/27272, resolved in
-      # crun v1.14.3). apt's crun lags behind apt's podman, so pin explicitly.
-      - name: Pin crun >= 1.14.3 (podman/crun OCI spec compat)
-        run: |
-          sudo curl -fL "https://github.com/containers/crun/releases/download/1.14.3/crun-1.14.3-linux-amd64" -o /usr/bin/crun
-          sudo chmod +x /usr/bin/crun
-          crun --version
+        uses: ./.github/actions/install-podman
       - name: Login to GitHub Container Registry (for image pulls)
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | podman login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -929,23 +902,7 @@ jobs:
           echo "PASS: values.schema.json is consistent with values.yaml"
 
       - name: Install Podman
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y podman
-          podman --version
-
-      # crun pin (#1784): the ubuntu-latest runner image's preinstalled crun
-      # predates 1.14.3 and cannot parse the OCI Runtime Spec v1.2.1
-      # config.json that current Podman generates, failing every container
-      # start (including Kind's own control-plane container) with
-      # "OCI runtime error: crun: unknown version specified"
-      # (https://github.com/containers/podman/issues/27272, resolved in
-      # crun v1.14.3). apt's crun lags behind apt's podman, so pin explicitly.
-      - name: Pin crun >= 1.14.3 (podman/crun OCI spec compat)
-        run: |
-          sudo curl -fL "https://github.com/containers/crun/releases/download/1.14.3/crun-1.14.3-linux-amd64" -o /usr/bin/crun
-          sudo chmod +x /usr/bin/crun
-          crun --version
+        uses: ./.github/actions/install-podman
 
       - name: Install Kind
         run: |
@@ -957,7 +914,35 @@ jobs:
 
       - name: Create Kind cluster
         run: |
-          kind create cluster --name "$KIND_CLUSTER_NAME" --wait 120s
+          # Issue #1769: GitHub-hosted runners intermittently resolve a
+          # podman/crun combination where the OCI runtime rejects the
+          # container config ("crun: unknown version specified"), failing
+          # `kind create cluster` with exit status 126 while starting the
+          # control-plane container. This is a transient runner-side
+          # container-runtime issue, not a config problem -- Kind already
+          # tears down the partially-created node before returning, so a
+          # bare retry of the whole invocation is safe. Mirrors the same
+          # fix applied to the Go E2E harness (test/infrastructure/
+          # kind_cluster_helpers.go's retryTransientKindRuntimeError).
+          max_attempts=3
+          attempt=1
+          while true; do
+            echo "🔧 kind create cluster attempt ${attempt}/${max_attempts}"
+            if output=$(kind create cluster --name "$KIND_CLUSTER_NAME" --wait 120s 2>&1); then
+              echo "${output}"
+              break
+            fi
+            echo "${output}"
+            if [ "${attempt}" -ge "${max_attempts}" ] || ! echo "${output}" | grep -qiE "crun: unknown version specified|OCI runtime error"; then
+              echo "❌ kind create cluster failed (attempt ${attempt}/${max_attempts}) -- not a known-transient error, giving up."
+              exit 1
+            fi
+            backoff=$(( attempt * 5 ))
+            echo "⚠️  Transient container-runtime error detected (attempt ${attempt}/${max_attempts}), retrying in ${backoff}s..."
+            sleep "${backoff}"
+            attempt=$(( attempt + 1 ))
+          done
+
           kubectl cluster-info
           kubectl get nodes -o wide
 

--- a/.github/workflows/e2e-test-template.yml
+++ b/.github/workflows/e2e-test-template.yml
@@ -66,23 +66,7 @@ jobs:
           kind version
 
       - name: Install Podman
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y podman
-          podman --version
-
-      # crun pin (#1784): the ubuntu-latest runner image's preinstalled crun
-      # predates 1.14.3 and cannot parse the OCI Runtime Spec v1.2.1
-      # config.json that current Podman generates, failing every container
-      # start (including Kind's own control-plane container) with
-      # "OCI runtime error: crun: unknown version specified"
-      # (https://github.com/containers/podman/issues/27272, resolved in
-      # crun v1.14.3). apt's crun lags behind apt's podman, so pin explicitly.
-      - name: Pin crun >= 1.14.3 (podman/crun OCI spec compat)
-        run: |
-          sudo curl -fL "https://github.com/containers/crun/releases/download/1.14.3/crun-1.14.3-linux-amd64" -o /usr/bin/crun
-          sudo chmod +x /usr/bin/crun
-          crun --version
+        uses: ./.github/actions/install-podman
 
       # ========================================
       # Run E2E Tests (with retry)

--- a/.github/workflows/helm-smoke-test.yml
+++ b/.github/workflows/helm-smoke-test.yml
@@ -38,23 +38,7 @@ jobs:
           go-version: '1.26.5'
 
       - name: Install Podman
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y podman
-          podman --version
-
-      # crun pin (#1784): the ubuntu-latest runner image's preinstalled crun
-      # predates 1.14.3 and cannot parse the OCI Runtime Spec v1.2.1
-      # config.json that current Podman generates, failing every container
-      # start (including Kind's own control-plane container) with
-      # "OCI runtime error: crun: unknown version specified"
-      # (https://github.com/containers/podman/issues/27272, resolved in
-      # crun v1.14.3). apt's crun lags behind apt's podman, so pin explicitly.
-      - name: Pin crun >= 1.14.3 (podman/crun OCI spec compat)
-        run: |
-          sudo curl -fL "https://github.com/containers/crun/releases/download/1.14.3/crun-1.14.3-linux-amd64" -o /usr/bin/crun
-          sudo chmod +x /usr/bin/crun
-          crun --version
+        uses: ./.github/actions/install-podman
 
       - name: Install Kind
         run: |

--- a/.github/workflows/integration-test-template.yml
+++ b/.github/workflows/integration-test-template.yml
@@ -46,23 +46,7 @@ jobs:
       # ========================================
       - name: Install Podman
         if: inputs.infrastructure == 'podman'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y podman
-          podman --version
-
-      # crun pin (#1784): the ubuntu-latest runner image's preinstalled crun
-      # predates 1.14.3 and cannot parse the OCI Runtime Spec v1.2.1
-      # config.json that current Podman generates, failing every container
-      # start with "OCI runtime error: crun: unknown version specified"
-      # (https://github.com/containers/podman/issues/27272, resolved in
-      # crun v1.14.3). apt's crun lags behind apt's podman, so pin explicitly.
-      - name: Pin crun >= 1.14.3 (podman/crun OCI spec compat)
-        if: inputs.infrastructure == 'podman'
-        run: |
-          sudo curl -fL "https://github.com/containers/crun/releases/download/1.14.3/crun-1.14.3-linux-amd64" -o /usr/bin/crun
-          sudo chmod +x /usr/bin/crun
-          crun --version
+        uses: ./.github/actions/install-podman
 
       - name: Install Kind v0.30.0
         if: inputs.infrastructure == 'kind'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -358,23 +358,7 @@ jobs:
           cache: true
 
       - name: Install Podman
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y podman
-          podman --version
-
-      # crun pin (#1784): the ubuntu-latest runner image's preinstalled crun
-      # predates 1.14.3 and cannot parse the OCI Runtime Spec v1.2.1
-      # config.json that current Podman generates, failing every container
-      # start (including Kind's own control-plane container) with
-      # "OCI runtime error: crun: unknown version specified"
-      # (https://github.com/containers/podman/issues/27272, resolved in
-      # crun v1.14.3). apt's crun lags behind apt's podman, so pin explicitly.
-      - name: Pin crun >= 1.14.3 (podman/crun OCI spec compat)
-        run: |
-          sudo curl -fL "https://github.com/containers/crun/releases/download/1.14.3/crun-1.14.3-linux-amd64" -o /usr/bin/crun
-          sudo chmod +x /usr/bin/crun
-          crun --version
+        uses: ./.github/actions/install-podman
 
       - name: Install Kind
         run: |

--- a/test/infrastructure/kind_cluster_helpers.go
+++ b/test/infrastructure/kind_cluster_helpers.go
@@ -25,6 +25,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // minKindVersionMajor, minKindVersionMinor define the minimum supported Kind
@@ -92,6 +93,68 @@ type ExtraMount struct {
 	HostPath      string
 	ContainerPath string
 	ReadOnly      bool
+}
+
+// kindCreateClusterMaxAttempts caps retries for `kind create cluster` when it
+// fails with a known-transient container-runtime error (Issue #1769).
+//
+// GitHub-hosted runners intermittently install a podman/crun combination where
+// the OCI runtime rejects the generated container config ("crun: unknown
+// version specified"), causing `kind create cluster` to fail with exit status
+// 126 while starting the control-plane container. This is a transient
+// container-runtime hiccup on the runner -- not a Kind config, kubeconfig, or
+// application-code problem -- and Kind itself already tears down the
+// partially-created node ("Deleted nodes: [...]") before returning, so retrying
+// the whole `kind create cluster` invocation from scratch is safe.
+const kindCreateClusterMaxAttempts = 3
+
+// transientKindRuntimeErrorPatterns are substrings of `kind create cluster`
+// output that indicate a transient container-runtime failure worth retrying,
+// as opposed to a genuine config/environment problem that would just fail
+// identically on every attempt.
+var transientKindRuntimeErrorPatterns = []string{
+	"crun: unknown version specified",
+	"OCI runtime error",
+}
+
+// isTransientKindRuntimeError reports whether kind's combined output matches a
+// known-transient container-runtime failure signature.
+func isTransientKindRuntimeError(output string) bool {
+	for _, pattern := range transientKindRuntimeErrorPatterns {
+		if strings.Contains(output, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// retryTransientKindRuntimeError runs runOnce (a `kind create cluster`
+// invocation) up to kindCreateClusterMaxAttempts times, retrying only when
+// runOnce fails AND its captured output matches a known-transient
+// container-runtime error (see isTransientKindRuntimeError). Any other
+// failure (bad config, missing binary, etc.) returns immediately on the first
+// attempt, since retrying would just reproduce the same error.
+func retryTransientKindRuntimeError(writer io.Writer, runOnce func() (output string, err error)) error {
+	const label = "kind create cluster"
+	var lastErr error
+	for attempt := 1; attempt <= kindCreateClusterMaxAttempts; attempt++ {
+		output, err := runOnce()
+		if err == nil {
+			if attempt > 1 {
+				_, _ = fmt.Fprintf(writer, "   ✅ %s succeeded on attempt %d/%d\n", label, attempt, kindCreateClusterMaxAttempts)
+			}
+			return nil
+		}
+		lastErr = err
+		if attempt >= kindCreateClusterMaxAttempts || !isTransientKindRuntimeError(output) {
+			return lastErr
+		}
+		backoff := time.Duration(attempt) * 5 * time.Second
+		_, _ = fmt.Fprintf(writer, "   ⚠️  %s hit a transient container-runtime error (attempt %d/%d), retrying in %v: %v\n",
+			label, attempt, kindCreateClusterMaxAttempts, backoff, err)
+		time.Sleep(backoff)
+	}
+	return lastErr
 }
 
 // CreateKindClusterWithExtraMounts creates a Kind cluster with dynamically added extraMounts
@@ -194,15 +257,19 @@ func CreateKindClusterWithExtraMounts(
 		_, _ = fmt.Fprintf(writer, "      %s → %s%s\n", mount.HostPath, mount.ContainerPath, readOnlyStr)
 	}
 
-	// 7. Create Kind cluster
-	cmd := exec.Command("kind", "create", "cluster",
-		"--name", clusterName,
-		"--config", tmpConfig.Name(),
-		"--kubeconfig", kubeconfigPath)
-	cmd.Stdout = writer
-	cmd.Stderr = writer
-
-	if err := cmd.Run(); err != nil {
+	// 7. Create Kind cluster (Issue #1769: retry on transient runtime errors)
+	err = retryTransientKindRuntimeError(writer, func() (string, error) {
+		var captured strings.Builder
+		cmd := exec.Command("kind", "create", "cluster",
+			"--name", clusterName,
+			"--config", tmpConfig.Name(),
+			"--kubeconfig", kubeconfigPath)
+		cmd.Stdout = io.MultiWriter(writer, &captured)
+		cmd.Stderr = io.MultiWriter(writer, &captured)
+		runErr := cmd.Run()
+		return captured.String(), runErr
+	})
+	if err != nil {
 		return fmt.Errorf("kind create cluster failed: %w", err)
 	}
 
@@ -399,27 +466,32 @@ func CreateKindClusterWithConfig(opts KindClusterOptions, writer io.Writer) erro
 		waitTimeout = "60s"
 	}
 
-	cmd := exec.Command("kind", "create", "cluster",
-		"--name", opts.ClusterName,
-		"--config", absoluteConfigPath,
-		"--kubeconfig", opts.KubeconfigPath,
-		"--wait", waitTimeout)
+	// 9. Create cluster (Issue #1769: retry on transient runtime errors)
+	err = retryTransientKindRuntimeError(writer, func() (string, error) {
+		var captured strings.Builder
+		cmd := exec.Command("kind", "create", "cluster",
+			"--name", opts.ClusterName,
+			"--config", absoluteConfigPath,
+			"--kubeconfig", opts.KubeconfigPath,
+			"--wait", waitTimeout)
 
-	cmd.Stdout = writer
-	cmd.Stderr = writer
+		cmd.Stdout = io.MultiWriter(writer, &captured)
+		cmd.Stderr = io.MultiWriter(writer, &captured)
 
-	// 7. Set working directory to project root if requested (for ./coverdata resolution)
-	if opts.ProjectRootAsWorkingDir {
-		cmd.Dir = workspaceRoot
-	}
+		// 7. Set working directory to project root if requested (for ./coverdata resolution)
+		if opts.ProjectRootAsWorkingDir {
+			cmd.Dir = workspaceRoot
+		}
 
-	// 8. Set Podman provider if requested
-	if opts.UsePodman {
-		cmd.Env = append(os.Environ(), "KIND_EXPERIMENTAL_PROVIDER=podman")
-	}
+		// 8. Set Podman provider if requested
+		if opts.UsePodman {
+			cmd.Env = append(os.Environ(), "KIND_EXPERIMENTAL_PROVIDER=podman")
+		}
 
-	// 9. Create cluster
-	if err := cmd.Run(); err != nil {
+		runErr := cmd.Run()
+		return captured.String(), runErr
+	})
+	if err != nil {
 		return fmt.Errorf("kind create cluster failed: %w", err)
 	}
 

--- a/test/infrastructure/workflowexecution_e2e_hybrid.go
+++ b/test/infrastructure/workflowexecution_e2e_hybrid.go
@@ -186,15 +186,20 @@ func SetupWorkflowExecutionInfrastructureHybridWithCoverage(ctx context.Context,
 		return fmt.Errorf("failed to find Kind config: %w", err)
 	}
 
-	// Create Kind cluster
-	createCmd := exec.Command("kind", "create", "cluster",
-		"--name", clusterName,
-		"--config", configPath,
-		"--kubeconfig", kubeconfigPath,
-	)
-	createCmd.Stdout = writer
-	createCmd.Stderr = writer
-	if err := createCmd.Run(); err != nil {
+	// Create Kind cluster (Issue #1769: retry on transient runtime errors)
+	err = retryTransientKindRuntimeError(writer, func() (string, error) {
+		var captured strings.Builder
+		createCmd := exec.Command("kind", "create", "cluster",
+			"--name", clusterName,
+			"--config", configPath,
+			"--kubeconfig", kubeconfigPath,
+		)
+		createCmd.Stdout = io.MultiWriter(writer, &captured)
+		createCmd.Stderr = io.MultiWriter(writer, &captured)
+		runErr := createCmd.Run()
+		return captured.String(), runErr
+	})
+	if err != nil {
 		return fmt.Errorf("failed to create Kind cluster: %w", err)
 	}
 

--- a/test/infrastructure/workflowexecution_parallel.go
+++ b/test/infrastructure/workflowexecution_parallel.go
@@ -82,14 +82,20 @@ func CreateWorkflowExecutionClusterParallel(clusterName, kubeconfigPath string, 
 	// ═══════════════════════════════════════════════════════════════════════
 	_, _ = fmt.Fprintf(output, "\n📦 PHASE 1: Creating Kind cluster...\n")
 
-	createCmd := exec.Command("kind", "create", "cluster",
-		"--name", clusterName,
-		"--config", configPath,
-		"--kubeconfig", kubeconfigPath,
-	)
-	createCmd.Stdout = output
-	createCmd.Stderr = output
-	if err := createCmd.Run(); err != nil {
+	// Issue #1769: retry on transient container-runtime errors.
+	err = retryTransientKindRuntimeError(output, func() (string, error) {
+		var captured strings.Builder
+		createCmd := exec.Command("kind", "create", "cluster",
+			"--name", clusterName,
+			"--config", configPath,
+			"--kubeconfig", kubeconfigPath,
+		)
+		createCmd.Stdout = io.MultiWriter(output, &captured)
+		createCmd.Stderr = io.MultiWriter(output, &captured)
+		runErr := createCmd.Run()
+		return captured.String(), runErr
+	})
+	if err != nil {
 		return fmt.Errorf("failed to create Kind cluster: %w", err)
 	}
 	_, _ = fmt.Fprintf(output, "✅ Kind cluster created\n")


### PR DESCRIPTION
## Summary

release/v1.5's crun/podman fix (#1785) and `main`'s fix for the identical underlying problem ([Issue #1769](https://github.com/jordigilh/kubernaut/issues/1769), closed) had diverged into two different implementations of the same fix — which the project explicitly wants to avoid ("only implementation details should differ due to refactoring, not different approaches based on version").

**release/v1.5 (#1785, this PR replaces it):** an inline "Pin crun >= 1.14.3" step duplicated across 5 workflow files, no retry safety net.

**main (Issue #1769):** a reusable `install-podman` composite action (pins crun to `1.28`, comfortably above the `1.14.3` minimum) *plus* a defense-in-depth retry wrapper — both in `ci-pipeline.yml`'s inline Kind-cluster-creation step and in the Go E2E test harness (`retryTransientKindRuntimeError`) — for the rare case a runner still resolves an incompatible pairing despite the pin.

This PR replaces release/v1.5's inline pin with main's approach verbatim (same composite action content, same crun version, same retry logic), adapting only what's required by main's own unrelated context-plumbing refactor that release/v1.5 doesn't have (the retry helper uses `exec.Command` instead of `exec.CommandContext`, since release/v1.5's `test/infrastructure` helpers don't thread `context.Context`).

## Changes

- New `.github/actions/install-podman` composite action (copied from `main`), replacing 8 inline "Pin crun >= 1.14.3" step duplicates across `ci-pipeline.yml`, `e2e-test-template.yml`, `helm-smoke-test.yml`, `integration-test-template.yml`, and `release.yml`.
- `ci-pipeline.yml`'s inline "Create Kind cluster" step (Helm smoke test job) now retries up to 3x on a detected transient container-runtime error, mirroring `main`'s scope exactly (the separate `helm-smoke-test.yml`/`release.yml` "Create Kind cluster" steps are left as single-attempt, matching what `main` currently does there too).
- `test/infrastructure/kind_cluster_helpers.go` gains `retryTransientKindRuntimeError`/`isTransientKindRuntimeError`, wired into both `CreateKindClusterWithExtraMounts` and `CreateKindClusterWithConfig`.
- `workflowexecution_e2e_hybrid.go` and `workflowexecution_parallel.go`'s own direct `kind create cluster` calls are wrapped with the same retry.

## Note on issue tracking

[#1784](https://github.com/jordigilh/kubernaut/issues/1784) (opened independently for this same problem before this alignment work discovered #1769 already existed and was closed via main) is a duplicate. Left open — closing it is left to the user's discretion.

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./test/infrastructure/...` clean
- [x] `golangci-lint run ./test/infrastructure/...` — 0 issues
- [x] `go test ./test/infrastructure/...` — no regressions
- [x] All 6 modified/added YAML files validated with `yaml.safe_load`
- [ ] CI green on this PR (validates the composite action + retry wrapper actually resolve the flake in practice)

Made with [Cursor](https://cursor.com)