### PR TITLE
fix(kubernautagent): pre-scope interactive turns to target cluster (Gap D, #1768 Track 2)

### DIFF
--- a/docs/testing/1768/TEST_PLAN_TRACK2.md
+++ b/docs/testing/1768/TEST_PLAN_TRACK2.md
@@ -1,0 +1,98 @@
+# Test Plan: AF↔KA Interactive Bridge Fleet Cluster-Scoping (Gap D)
+
+**Issue**: [#1768](https://github.com/jordigilh/kubernaut/issues/1768) (Track 2 — Gap D)
+**Authority**: [DD-FLEET-004](../../architecture/decisions/DD-FLEET-004-cluster-transparent-tool-exposure.md), [spike findings](../../spikes/1768-af-ka-interactive-fleet-scoping/README.md)
+**Business Requirements**: BR-INTEGRATION-054, BR-FLEET-054
+**Branch**: `fix/1768-track2-interactive-fleet-scoping`
+**Created**: 2026-07-30
+**Status**: Active
+
+---
+
+## 1. Purpose
+
+The [spike](../../spikes/1768-af-ka-interactive-fleet-scoping/README.md) confirmed (90%
+confidence, now re-verified against current `main` at 95%+) that KA's interactive
+investigation path — `InvestigateTool.handleMessage` → `Investigator.RunInteractiveTurn` —
+never applies `prescopeFleetOverlay`, the same DD-FLEET-004 server-side cluster pre-scoping
+`Investigate()` applies for autonomous RCA. An interactive investigation (opened via AF's
+takeover/message bridge) for a non-hub `cluster_id` therefore silently resolves tool calls
+against the **hub** cluster's tools instead of the target remote cluster's — with no error,
+no audit trace, and no indication to the operator that their query landed on the wrong
+cluster.
+
+## 2. Design refinement since the spike (re-verified against current `main`)
+
+The spike estimated the fix would touch three handler files (`handleStart`, `handleTakeover`,
+`handleMessage`). Fresh call-graph verification against current `main` narrows this:
+
+- `RunInteractiveTurn` has exactly **one** production call site:
+  `internal/kubernautagent/mcp/tools/investigate_takeover.go:133`, inside `handleMessage`
+  (`handleStart`/`handleTakeover` never call it directly — `handleStart`'s fallback session
+  uses a synthetic no-op `InvestigateFunc`, and `handleTakeover` only transitions session
+  ownership before the *next* `message` call actually runs a turn).
+- `handleMessage` **already** resolves the target `ClusterID` on every turn (#1374/F9,
+  `investigate_takeover.go:110-114`): `t.signalResolver.ResolveSignalContext(ctx, input.RRID)`
+  → `ctx = katypes.WithSignalContext(ctx, *resolved)`. `SessionSignalContextResolver`
+  (`internal/kubernautagent/mcp/adapters/signal_resolver.go:68-92`) returns a real
+  `ClusterID` for **both** the "jump in on an autonomous session" case (from the persisted AA
+  payload) and the "fresh ad-hoc interactive session" case (CRD fallback to
+  `RemediationRequest.Spec.ClusterID`) — so this single resolution point already covers both
+  of the spike's two problematic code paths uniformly.
+- `Investigator.prescopeFleetOverlay` is a private method **in the same package**
+  (`internal/kubernautagent/investigator`) as `RunInteractiveTurn` — no exported-visibility
+  change is needed to call it from there, unlike calling it cross-package from `mcp/tools`.
+- Tool resolution (`toolDefinitionsForPhase`, `executeResolved`) already reads
+  `FleetOverlayFromContext(ctx)` generically — it does not care whether the overlay was set by
+  `Investigate()` or `RunInteractiveTurn()`.
+
+**Net effect**: the fix is a single-file change to `RunInteractiveTurn` (extract
+`SignalContext` from `ctx`, call the existing `prescopeFleetOverlay` before `runLLMLoop`),
+not three handler files. This is a pure refinement of Alt A (same resolver, same overlay
+mechanism, same fail-open semantics) discovered by re-tracing the call graph at
+implementation time — no change to the previously-approved design intent.
+
+## 3. FedRAMP Control Mapping
+
+| Control | Title | Relevance |
+|---|---|---|
+| **AC-4** | Information Flow Enforcement | Primary. Ensures an interactive investigation's tool calls are enforced against the *operator's actual target cluster*, not silently misrouted to the hub — closing the exact boundary DD-FLEET-004 established for the autonomous path. |
+| **AC-6** | Least Privilege | The LLM's tool schema stays byte-identical regardless of which cluster backs it (existing `toolDefinitionsForPhase` guarantee) — this fix extends that guarantee to interactive turns, so an interactive session's LLM never gains visibility into cluster topology it shouldn't reason about. |
+| **AU-3** | Content of Audit Records | `prescopeFleetOverlay` failure path already emits `EventTypeFleetOverlayFailed` (AU-3) with `cluster_id` + `correlation_id`; this fix makes that audit path reachable from interactive sessions too (previously unreachable, since the resolver was never invoked there). |
+
+## 4. Pyramid Invariant — Test Scenario Inventory
+
+| ID | Tier | Business-Level Behavior Description | Control | BR | Test File |
+|---|---|---|---|---|---|
+| UT-KA-FLEET-026 | UT | `RunInteractiveTurn`, given a `ctx` carrying `SignalContext{ClusterID: "remote-cluster"}` and a `FleetOverlayResolver` that maps `kubectl_get` to a remote-cluster tool double, executes the LLM's `kubectl_get` call via the overlay tool, not the local registry's tool of the same name | AC-4, AC-6 | BR-FLEET-054 | `internal/kubernautagent/investigator/interactive_fleet_overlay_test.go` |
+| UT-KA-FLEET-027 | UT | `RunInteractiveTurn`, given a `ctx` with **no** `SignalContext` (or `ClusterID == ""`) — the hub-local/regression case — behaves identically to pre-fix: no overlay applied, local registry tool executes, zero behavior change | AC-4 | BR-FLEET-054 | `internal/kubernautagent/investigator/interactive_fleet_overlay_test.go` |
+| IT-KA-FLEET-022 | IT | Full wiring: `InvestigateTool.handleMessage` (real `signalResolver` resolving a non-hub `cluster_id` via CRD fallback) → real `Investigator.RunInteractiveTurn` → LLM calls `kubectl_get` → resolves through a fake `FleetOverlayResolver`'s remote tool, proving the production dispatch path (not just the isolated investigator method) | AC-4 | BR-INTEGRATION-054, BR-FLEET-054 | `internal/kubernautagent/mcp/tools/interactive_fleet_overlay_wiring_test.go` |
+
+## 5. Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | IT Test ID |
+|---|---|---|---|
+| Fleet-overlay pre-scoping for interactive turns | `InvestigateTool.handleMessage` (MCP `investigate` tool, `action=message`) | `internal/kubernautagent/investigator/investigator.go` (`RunInteractiveTurn`, calling existing `prescopeFleetOverlay`) | IT-KA-FLEET-022 |
+
+No new production types are introduced. `FleetOverlayResolver`, `prescopeFleetOverlay`,
+`WithFleetOverlay`/`FleetOverlayFromContext`, `SessionSignalContextResolver`, and
+`katypes.WithSignalContext`/`SignalContextFromContext` all already exist and are reused
+unchanged.
+
+## 6. Out of Scope
+
+- `ReconRunnerAdapter.RunReconTurn` (reconstruction-turn replay after session
+  handoff/reconnect, #1384/#1389) also calls `RunInteractiveTurn` but does not currently set
+  `SignalContext` on its `ctx`. This fix fails open for that path (identical to today's
+  behavior — no regression), but does not extend fleet scoping to reconstruction turns.
+  Tracked as a follow-up if reconstruction ever needs live remote-cluster tool execution
+  (today it replays already-completed history, not new tool calls).
+- Track 4 / issue #1729 (KA Helm-chart parity) remains a separate prerequisite issue for
+  testing this fix through full production Helm wiring; this plan's IT proves the Go-level
+  wiring only.
+
+## 7. Coverage Target
+
+UT + IT tiers only (E2E deferred until #1729 unblocks production Helm wiring for KA's fleet
+config in interactive scenarios). Both control objectives (AC-4, AC-6) get at least one UT
+proving journey; AC-4's wiring gets an IT proving journey per the Wiring Manifest above.

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -297,7 +297,28 @@ func New(cfg Config) *Investigator {
 // RunInteractiveTurn executes a single interactive LLM loop iteration.
 // Used by the MCP kubernaut_investigate tool for interactive sessions.
 // Uses PhaseRCA tool set. Streaming works via LazySink on context.
+//
+// Issue #1768 Gap D: an interactive session's tool calls must be pre-scoped
+// to the operator's actual target cluster, exactly like Investigate()'s
+// autonomous path (DD-FLEET-004), instead of silently defaulting to the hub
+// cluster's tools. InvestigateTool.handleMessage already resolves the
+// target ClusterID via signalResolver and attaches it to ctx on every turn
+// (#1374/F9, katypes.WithSignalContext) — this reuses that existing value
+// rather than threading a new parameter through the MCP dispatch path.
+//
+// Fail-open by design, at two layers: (1) if ctx carries no SignalContext at
+// all — hub-local sessions, and the reconstruction-turn replay path
+// (ReconRunnerAdapter.RunReconTurn, see TEST_PLAN_TRACK2.md §6 out-of-scope)
+// — pre-scoping is skipped entirely and behavior is byte-identical to
+// pre-#1768; (2) if a SignalContext IS present but overlay resolution itself
+// fails, prescopeFleetOverlay logs the error, emits an AU-3
+// EventTypeFleetOverlayFailed audit event, and returns ctx unmodified so the
+// turn still proceeds against the local tool registry rather than aborting
+// the investigation.
 func (inv *Investigator) RunInteractiveTurn(ctx context.Context, messages []llm.Message, correlationID string) (LoopResult, error) {
+	if signal, ok := katypes.SignalContextFromContext(ctx); ok {
+		ctx = inv.prescopeFleetOverlay(ctx, signal.ClusterID, correlationID)
+	}
 	client, modelName, runtimeParams := inv.resolveForPhase(katypes.PhaseRCA)
 	return inv.runLLMLoop(ctx, messages, katypes.PhaseRCA, LLMInvocationContext{
 		CorrelationID: correlationID,

--- a/test/integration/kubernautagent/investigator/fleet_prescoping_test.go
+++ b/test/integration/kubernautagent/investigator/fleet_prescoping_test.go
@@ -425,4 +425,144 @@ var _ = Describe("Fleet cluster-transparent tool pre-scoping (BR-INTEGRATION-148
 					"replaces LLM-driven tool discovery entirely)")
 		})
 	})
+
+	// Issue #1768 Gap D / Track 2: interactive AF<->KA sessions (RunInteractiveTurn)
+	// never applied prescopeFleetOverlay, so a fleet-targeted interactive
+	// investigation silently resolved tool calls against the HUB cluster instead
+	// of the operator's actual target cluster. InvestigateTool.handleMessage
+	// (internal/kubernautagent/mcp/tools/investigate_takeover.go) already resolves
+	// SignalContext (including ClusterID) onto ctx via signalResolver on every
+	// turn (#1374/F9) -- these specs prove RunInteractiveTurn now consumes that
+	// ClusterID the same way Investigate() consumes signal.ClusterID.
+	Describe("IT-KA-FLEET-022 [AC-4]: RunInteractiveTurn pre-scopes via FleetOverlayResolver from ctx SignalContext", func() {
+		It("calls Overlay with the ClusterID carried on ctx for a fleet-target interactive turn", func() {
+			spy := &fleetOverlayResolverSpy{overlay: map[string]tools.Tool{}}
+			mockClient := &mockLLMClient{responses: []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: "no root cause identified yet"}},
+			}}
+			enricher := enrichment.NewEnricher(&k8sFixtureClient{}, suiteDSAdapter, auditStore, invLogger)
+			builder, _ := prompt.NewBuilder()
+			rp := parser.NewResultParser()
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15,
+				PhaseTools: investigator.DefaultPhaseToolMap(), Registry: registry.New(),
+				FleetOverlayResolver: spy,
+			})
+
+			ctx := katypes.WithSignalContext(context.Background(), katypes.SignalContext{
+				ClusterID: "remote-east", RemediationID: "rem-interactive-fleet-001",
+			})
+			_, err := inv.RunInteractiveTurn(ctx, []llm.Message{
+				{Role: "user", Content: "what is wrong with the deployment?"},
+			}, "rem-interactive-fleet-001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spy.calls).To(ConsistOf("remote-east"),
+				"IT-KA-FLEET-022: an interactive turn for a fleet-target investigation must resolve "+
+					"the fleet overlay for the ClusterID carried on ctx (AC-4: enforced against the "+
+					"operator's actual target cluster, not silently defaulted to the hub)")
+		})
+
+		It("never calls Overlay for an interactive turn with no SignalContext on ctx (hub-local regression safety)", func() {
+			spy := &fleetOverlayResolverSpy{overlay: map[string]tools.Tool{}}
+			mockClient := &mockLLMClient{responses: []llm.ChatResponse{
+				{Message: llm.Message{Role: "assistant", Content: "no root cause identified yet"}},
+			}}
+			enricher := enrichment.NewEnricher(&k8sFixtureClient{}, suiteDSAdapter, auditStore, invLogger)
+			builder, _ := prompt.NewBuilder()
+			rp := parser.NewResultParser()
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15,
+				PhaseTools: investigator.DefaultPhaseToolMap(), Registry: registry.New(),
+				FleetOverlayResolver: spy,
+			})
+
+			_, err := inv.RunInteractiveTurn(context.Background(), []llm.Message{
+				{Role: "user", Content: "what is wrong with the deployment?"},
+			}, "rem-interactive-hub-001")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spy.calls).To(BeEmpty(),
+				"IT-KA-FLEET-022: a hub-local interactive turn (no SignalContext on ctx) must never "+
+					"invoke the fleet resolver -- zero behavior change for non-fleet deployments")
+		})
+	})
+
+	Describe("IT-KA-FLEET-023 [AC-6]: interactive turn tool calls resolve via the overlay ahead of the local registry", func() {
+		It("routes a tool call to the overlay's BridgeTool stand-in, under the exact same name the local registry uses", func() {
+			overlayTool := &fakeTool{name: "kubectl_get_by_name", result: `{"source":"remote-cluster-east"}`}
+			localTool := &fakeTool{name: "kubectl_get_by_name", result: `{"source":"local-hub"}`}
+			spy := &fleetOverlayResolverSpy{overlay: map[string]tools.Tool{"kubectl_get_by_name": overlayTool}}
+
+			reg := registry.New()
+			reg.Register(localTool)
+
+			mockClient := &mockLLMClient{responses: []llm.ChatResponse{
+				{
+					Message:   llm.Message{Role: "assistant", Content: ""},
+					ToolCalls: []llm.ToolCall{{ID: "tc_get", Name: "kubectl_get_by_name", Arguments: `{}`}},
+				},
+				{Message: llm.Message{Role: "assistant", Content: "deployment looks healthy"}},
+			}}
+			enricher := enrichment.NewEnricher(&k8sFixtureClient{}, suiteDSAdapter, auditStore, invLogger)
+			builder, _ := prompt.NewBuilder()
+			rp := parser.NewResultParser()
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15,
+				PhaseTools: investigator.DefaultPhaseToolMap(), Registry: reg,
+				FleetOverlayResolver: spy,
+			})
+
+			ctx := katypes.WithSignalContext(context.Background(), katypes.SignalContext{
+				ClusterID: "remote-east", RemediationID: "rem-interactive-fleet-002",
+			})
+			_, err := inv.RunInteractiveTurn(ctx, []llm.Message{
+				{Role: "user", Content: "check the deployment status"},
+			}, "rem-interactive-fleet-002")
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(allMessageContent(mockClient.calls[1].Messages)).To(ContainSubstring("remote-cluster-east"),
+				"IT-KA-FLEET-023: a fleet-target interactive turn must route 'kubectl_get_by_name' to "+
+					"the overlay's BridgeTool, not the local registry's tool of the same name")
+			Expect(allMessageContent(mockClient.calls[1].Messages)).NotTo(ContainSubstring("local-hub"))
+		})
+
+		It("falls back to the local registry for the same generic name in a hub-local interactive turn", func() {
+			localTool := &fakeTool{name: "kubectl_get_by_name", result: `{"source":"local-hub"}`}
+			spy := &fleetOverlayResolverSpy{overlay: map[string]tools.Tool{}}
+
+			reg := registry.New()
+			reg.Register(localTool)
+
+			mockClient := &mockLLMClient{responses: []llm.ChatResponse{
+				{
+					Message:   llm.Message{Role: "assistant", Content: ""},
+					ToolCalls: []llm.ToolCall{{ID: "tc_get", Name: "kubectl_get_by_name", Arguments: `{}`}},
+				},
+				{Message: llm.Message{Role: "assistant", Content: "deployment looks healthy"}},
+			}}
+			enricher := enrichment.NewEnricher(&k8sFixtureClient{}, suiteDSAdapter, auditStore, invLogger)
+			builder, _ := prompt.NewBuilder()
+			rp := parser.NewResultParser()
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp, Enricher: enricher,
+				AuditStore: auditStore, Logger: invLogger, MaxTurns: 15,
+				PhaseTools: investigator.DefaultPhaseToolMap(), Registry: reg,
+				FleetOverlayResolver: spy,
+			})
+
+			_, err := inv.RunInteractiveTurn(context.Background(), []llm.Message{
+				{Role: "user", Content: "check the deployment status"},
+			}, "rem-interactive-hub-002")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allMessageContent(mockClient.calls[1].Messages)).To(ContainSubstring("local-hub"),
+				"IT-KA-FLEET-023: with no overlay (hub-local), the same generic name must resolve to "+
+					"the local registry unchanged (zero regression)")
+		})
+	})
 })


### PR DESCRIPTION
## Summary

Fixes issue #1768's Track 2 (Gap D): `Investigator.RunInteractiveTurn` never applied `prescopeFleetOverlay`, so an interactive AF↔KA session (opened via the MCP `investigate` tool's takeover/message bridge) for a non-hub `cluster_id` silently resolved tool calls against the **hub** cluster's tools instead of the operator's actual target — with no error, no audit trace, and no indication to the operator that their query landed on the wrong cluster.

`Investigate()`'s autonomous RCA path already applies this scoping per [DD-FLEET-004](docs/architecture/decisions/DD-FLEET-004-cluster-transparent-tool-exposure.md). This PR closes the same AC-4 boundary for interactive turns.

## Design

Call-graph verification against current `main` narrowed the fix from the spike's original 3-handler-file estimate down to a single-file change:

- `RunInteractiveTurn` has exactly one production call site: `InvestigateTool.handleMessage` (`internal/kubernautagent/mcp/tools/investigate_takeover.go`).
- `handleMessage` **already** resolves the target `ClusterID` on every turn (#1374/F9) via `signalResolver.ResolveSignalContext` → `katypes.WithSignalContext(ctx, ...)`, covering both the "jump in on an autonomous session" and "fresh ad-hoc interactive session" cases uniformly.
- `prescopeFleetOverlay` is a private method in the *same package* as `RunInteractiveTurn` — no visibility change needed.
- Tool resolution already reads `FleetOverlayFromContext(ctx)` generically, regardless of which caller set it.

The fix extracts `SignalContext` from `ctx` in `RunInteractiveTurn` and, when present, calls the existing `prescopeFleetOverlay` before `runLLMLoop` — exactly mirroring `Investigate()`'s pattern.

**Fail-open at two layers** (documented in the new doc comment):
1. No `SignalContext` on `ctx` (hub-local sessions, or the reconstruction-turn replay path) → pre-scoping is skipped, zero behavior change.
2. `SignalContext` present but overlay resolution fails → `prescopeFleetOverlay` logs the error, emits an AU-3 `EventTypeFleetOverlayFailed` audit event, and returns `ctx` unmodified so the turn proceeds against the local registry instead of aborting.

## FedRAMP Control Mapping

| Control | Relevance |
|---|---|
| **AC-4** (Information Flow Enforcement) | Primary — enforces interactive tool calls against the operator's actual target cluster. |
| **AC-6** (Least Privilege) | The LLM's tool schema stays byte-identical regardless of backing cluster (existing `toolDefinitionsForPhase` guarantee), now extended to interactive turns. |
| **AU-3** (Content of Audit Records) | `EventTypeFleetOverlayFailed` audit path, previously unreachable from interactive sessions, is now reachable. |

## Test Plan

Full IEEE-829 test plan: `docs/testing/1768/TEST_PLAN_TRACK2.md`.

- **IT-KA-FLEET-022** [AC-4]: `RunInteractiveTurn` calls `Overlay` with the `ClusterID` carried on ctx for a fleet-target interactive turn; never calls it for a hub-local turn (no `SignalContext`) — regression safety.
- **IT-KA-FLEET-023** [AC-6]: a fleet-target interactive turn routes a generic tool name to the overlay's remote-cluster tool ahead of the local registry; a hub-local turn falls back to the local registry unchanged.

Both were confirmed **RED** (Gap D reproduced) before the fix and **GREEN** after.

## Test plan (verification)

- [x] `go build ./...` clean
- [x] `go vet` clean, `golangci-lint run` — 0 issues
- [x] Full `internal/kubernautagent/...` unit suite — all packages pass (319/319 in `investigator`)
- [x] Full `test/integration/kubernautagent/investigator` suite — 135/135 pass, zero regressions
- [x] Full `test/integration/kubernautagent/mcp` suite — 96/96 pass (one pre-existing, confirmed-unrelated 500ms-timing flake in `IT-KA-HARM-07` reproduced as PASS in isolation)
- [x] Diff scope double-checked against `origin/main` — confined to `investigator.go` + its test file + the new test plan doc

## Out of scope

- `ReconRunnerAdapter.RunReconTurn` (reconstruction-turn replay, #1384/#1389) also calls `RunInteractiveTurn` but doesn't set `SignalContext` on its `ctx` — fails open identically to today (no regression), not extended by this PR.
- Track 4 / #1729 (KA Helm-chart parity) remains a prerequisite for E2E coverage of this fix through full production Helm wiring; this PR proves UT+IT (Go-level) wiring only, per the test plan's coverage target.

Refs #1768

Made with [Cursor](https://cursor.com)