### PR TITLE
fix(workflowexecution): fail closed on remote ClusterID for Ansible engine (#1761)

### DIFF
--- a/docs/architecture/decisions/ADR-068-fleet-federation-architecture.md
+++ b/docs/architecture/decisions/ADR-068-fleet-federation-architecture.md
@@ -4,7 +4,7 @@
 **Date**: 2026-06-19
 **Deciders**: Architecture Team
 **Context**: Multi-cluster federation requires coordinated architecture across GW, KA, RO, WE, and a new FMC Writer service (#54)
-**Related**: ADR-064 (MCP Gateway - deferred), ADR-065 (ClusterID on RR), ADR-067 (KA MCP Dynamic Tool Discovery), DD-FLEET-004 (Cluster-Transparent Tool Exposure — supersedes decision #11's LLM-facing discovery tools)
+**Related**: ADR-064 (MCP Gateway - deferred), ADR-065 (ClusterID on RR), ADR-067 (KA MCP Dynamic Tool Discovery), DD-FLEET-004 (Cluster-Transparent Tool Exposure — supersedes decision #11's LLM-facing discovery tools), DD-FLEET-005 (Ansible Engine Not Supported for Fleet Execution — amends decision #9 and Alternative H)
 
 ## Context
 
@@ -155,6 +155,7 @@ business logic.
 8. **Gateway CRDs as source of truth** (not ConfigMap): The gateway's native CRDs (`MCPRoute`/`Backend` for EAIGW, `MCPServerRegistration` for Kuadrant) are the authoritative registry of MCP backends. Kubernaut is a **read-only consumer** — it watches but never creates or modifies these CRDs. The control plane (ACM, Rancher, GitOps) owns their lifecycle.
 
 9. **MCP Gateway as unified chokepoint for all remote cluster access** (not separate auth paths per backend type): All Kubernaut services that interact with remote clusters — GW, KA, RO, SP, AF, EM (read-only), FMC (metadata sync), and WE (remediation execution) — access remote clusters exclusively through the MCP Gateway. The K8s MCP Server and AAP MCP Server are both registered as backends behind the same gateway. This eliminates the need for service-specific credential management (e.g., separate AAP bearer token injection). Auth is enforced at two layers: (a) the gateway validates caller credentials via its native auth model (OAuth + CEL for EAIGW, Authorino + OPA for Kuadrant), and (b) each MCP Server authenticates against its own local APIs using its own ServiceAccount. No per-cluster SA tokens are maintained by Kubernaut services.
+   > **Amended by [DD-FLEET-005](DD-FLEET-005-ansible-engine-not-supported-for-remote-execution.md) (2026-07-30)**: live validation against a real Kuadrant gateway found `MCPServerRegistration.credentialRef` is discovery-only and is **not** injected into actual `tools/call` requests, so the AAP-MCP-Server-as-backend design described here does not work for WE's Ansible engine as-is. WE's Ansible engine does not use this chokepoint for remote clusters; it fails closed instead (see DD-FLEET-005). The chokepoint principle itself remains correct and unaffected for K8s MCP backends (Job/Tekton engines, all other services).
 
 10. **Gateway-agnostic business logic** (not per-gateway code paths): Services that need to call MCP tools on a remote cluster use the `GatewayDiscoverer` interface (decision #11) to discover clusters and tools. The only gateway-aware components are the `GatewayDiscoverer` implementations and the cluster registry in FMC (`pkg/fleet/registry/`). All other services — GW, SP, WE, KA, RO, AF, EM — are fully gateway-agnostic.
 
@@ -263,6 +264,7 @@ business logic.
 - -: Separate credential management and rotation for AAP tokens outside the gateway
 - -: AAP MCP backends are treated differently from K8s MCP backends, violating the unified chokepoint principle
 - **Deferred**: AAP MCP Server is now registered as a standard `Backend` behind the MCP Gateway, same as K8s MCP Servers. The gateway handles routing to both. WE calls tools through the gateway without knowing whether the backend is K8s-native or AAP. If AAP MCP requires its own auth, the `MCPRoute.backendRefs[].securityPolicy` handles upstream credential injection — Kubernaut services are not involved.
+- **Superseded (2026-07-30, [DD-FLEET-005](DD-FLEET-005-ansible-engine-not-supported-for-remote-execution.md))**: this mitigation does not hold for the Kuadrant gateway implementation actually in use — live testing confirmed per-call credential injection for non-K8s backends does not work (see DD-FLEET-005 Option 1 findings). Combined with a second, independent blocker (no credential-delete tool in the AAP MCP Server's API surface), the Ansible engine does not use the MCP Gateway for remote clusters at all; it fails closed on any non-empty `ClusterID` instead. This does not reopen Alternative H for K8s MCP backends — the chokepoint principle remains sound there.
 
 ## Consequences
 
@@ -383,6 +385,7 @@ for the full method and results.
 | SP Enrichment | SP remote cluster enrichment via MCP Gateway (BR-INTEGRATION-054) | Complete |
 | RO Fleet Scope | RO scope routing via FederatedScopeChecker (BR-FLEET-054) | Complete |
 | WE Fleet Routing | WE JobExecutor.IsCompleted ClusterID propagation (BR-FLEET-054) | Complete |
+| WE Ansible Fleet Routing | WE AnsibleExecutor remote (ClusterID != "") execution — evaluated, not pursued; fails closed instead (DD-FLEET-005) | Not Pursued (#1761) |
 | EM Fleet Routing | EM target-read routing via ReaderFactory (BR-FLEET-054) | Complete |
 | AF Fleet Routing | AF kubectl_get/kubectl_list ResourceReader abstraction + list_clusters tool (BR-FLEET-054) | Complete |
 | Fleet Readiness Gate | Fail-closed, pod-wide `/readyz` for runtime Fleet dependency unreachability across all 7 services (#1553) | Complete |

--- a/docs/architecture/decisions/DD-FLEET-005-ansible-engine-not-supported-for-remote-execution.md
+++ b/docs/architecture/decisions/DD-FLEET-005-ansible-engine-not-supported-for-remote-execution.md
@@ -3,7 +3,9 @@
 ## Status
 
 **Approved**: 2026-07-30
-**Confidence**: 95%
+**Confidence**: 97% (raised from 95% on 2026-07-30 after Phase 3 closed the one
+open question about whether a machine-to-machine AAP auth path could avoid Option 1's
+gateway-credential blocker — see Validation Results Phase 3)
 **Milestone**: v1.6
 **Related Issue**: #1761
 
@@ -50,10 +52,23 @@ gateway instead of raw AWX REST.
   `tools/list` introspection against a real AAP 2.7 instance)
 
 **Cons**:
-- **No `credentials_destroy` tool exists anywhere in the 101-tool surface.** Confirmed by
-  exhaustively checking every toolset's `tools/list` output. Kubernaut's ephemeral AWX
-  credential cleanup (`cleanupEphemeralCredentials`, BR-WE-015) has no MCP equivalent —
-  ephemeral credentials would accumulate in AAP indefinitely.
+- **No `credentials_destroy` tool is exposed by any default toolset in the deployed
+  101-tool surface.** Confirmed by exhaustively checking every toolset's `tools/list`
+  output. Kubernaut's ephemeral AWX credential cleanup (`cleanupEphemeralCredentials`,
+  BR-WE-015) has no MCP equivalent today — ephemeral credentials would accumulate in AAP
+  indefinitely. **Root-caused (2026-07-30) as a toolset-curation gap, not a capability
+  gap**: the AAP Controller API underlying the MCP server does support
+  `DELETE /api/v2/credentials/{id}/` (`credentials_destroy`, confirmed present in the
+  OpenAPI schema bundled in
+  [`ansible/aap-mcp-server`](https://github.com/ansible/aap-mcp-server)`/data/controller-schema.json`)
+  — it is simply never included in any of the server's default toolset definitions
+  (`aap-mcp.sample.yaml` includes `credential_types_destroy`, i.e. delete a credential
+  *type*, but never `credentials_destroy`, delete a credential *instance*, in any
+  toolset, including `security_compliance`). The server supports fully custom toolset
+  configs, so this is technically addressable via configuration or an upstream PR — as
+  of this writing, no issue or PR in that 4-issue repo tracks it. This does not change
+  the verdict below: it does not resolve Option 1's second, independent blocker (gateway
+  auth), and no fix has actually landed.
 - **`MCPServerRegistration.credentialRef` is discovery-only, never injected into actual
   `tools/call` requests** — confirmed two ways against a real, live Kuadrant gateway
   (v0.7.1): (a) the CRD's own field docs state this explicitly; (b) empirically, calling
@@ -64,6 +79,26 @@ gateway instead of raw AWX REST.
 - ADR-068's own stated mitigation for this exact risk (Alternative H: *"the
   `MCPRoute.backendRefs[].securityPolicy` handles upstream credential injection"*) does
   not hold for the Kuadrant gateway this repo actually uses — confirmed live, not assumed.
+- **Fixing the `credentialRef` injection bug alone would not be enough — confirmed
+  2026-07-30 by inspecting AAP's own auth surface directly**, not by inference from
+  Kuadrant's side. `GET /api/gateway/v1/authenticator_plugins/` against the live AAP 2.7
+  instance lists all 11 supported authenticator plugin types (`azuread`, `github` +4
+  variants, `google_oauth2`, `keycloak`, `ldap`, `local`, `oidc`, `radius`, `saml`,
+  `tacacs`). The `keycloak` and `oidc` plugins — the only two capable of trusting
+  kubernaut's existing fleet identity provider — are both built on `python-social-auth`
+  and require `AUTHORIZATION_URL`/`CALLBACK_URL`/`RESPONSE_TYPE=code` in their
+  configuration schema: a browser-redirect login flow, not a machine-to-machine
+  JWT-bearer grant (RFC 7523) or resource-server-style JWT validation. A headless
+  controller like `WorkflowExecution` cannot complete a redirect-based login on its own.
+  This is the structural reason Option 2 and Option 1 behave so differently under the
+  *same* gateway: Kubernetes API servers natively validate OIDC-federated identities as
+  resource servers on every request (observed directly in this spike — the fleet
+  identity mapped to `keycloak:service-account-kubernaut-fleet-read` for RBAC purposes,
+  no redirect involved); AAP has no equivalent mode behind any of its 11 auth plugins.
+  Even a bug-free `credentialRef` injection could therefore only ever forward a static,
+  pre-provisioned AAP credential (OAuth Application or Personal Access Token) per
+  registration — the same per-cluster raw-credential-vending shape already rejected as
+  Option 3, just relocated into a Kuadrant CRD field instead of kubernaut's own code.
 
 **Confidence in rejecting**: high — both blockers reproduced against real, live
 components (real AAP 2.7, real Kuadrant gateway, real Keycloak token exchange), not
@@ -206,13 +241,19 @@ path.
 
 ## Validation Results
 
-Both alternatives were validated against real, live infrastructure across two spike
+Both alternatives were validated against real, live infrastructure across three spike
 phases:
 
 - **Phase 1**: A real `AnsibleAutomationPlatform` v2.7 aggregate CR was stood up on a live
   OCP dev cluster (controller + MCP enabled), subscription activated via the real
   Gateway API, and the combined `/mcp` endpoint's `tools/list` introspected directly
-  (101 real tools across 6 toolsets). The `credentials_destroy` gap was found here.
+  (101 real tools across 6 toolsets). The `credentials_destroy` gap was found here, then
+  root-caused (2026-07-30) against the upstream
+  [`ansible/aap-mcp-server`](https://github.com/ansible/aap-mcp-server) repo's own bundled
+  OpenAPI schema (`data/controller-schema.json`) and sample toolset config
+  (`aap-mcp.sample.yaml`) — confirmed as a toolset-curation omission, not a missing AAP
+  API capability (see Option 1 Cons above). Checked that repo's issue/PR history (4
+  issues total, none related) — no existing tracking.
 - **Phase 2**: Used this repo's own CI-validated `PRESERVE_E2E_CLUSTER=true make
   test-e2e-fleetmetadatacache-kuadrant` automation to stand up a real, isolated Kind
   cluster with a live Keycloak + Istio + Kuadrant MCP Gateway + `kube-mcp-server` stack.
@@ -221,6 +262,15 @@ phases:
   (`resources_create_or_update`/`resources_get`/`resources_delete`, all PASS). Option 1's
   AAP MCP Server was registered as a second live backend on the same gateway
   (`credentialRef`-based registration, discovery PASS, all `tools/call` FAIL with `500`).
+- **Phase 3** (2026-07-30, after the Kind clusters were torn down): re-verified against
+  the still-live OCP AAP 2.7 instance whether the Phase 2 gateway-auth blocker could be
+  closed by any AAP-side mechanism rather than a Kuadrant fix. Queried
+  `GET /api/gateway/v1/authenticator_plugins/` directly (all 11 plugin types + full
+  configuration schemas) and `GET /api/gateway/v1/authenticators/` (confirmed only
+  "Local Database Authenticator" configured, `ALLOW_OAUTH2_FOR_EXTERNAL_USERS: false` —
+  no external IdP wired in at all today). Result: no plugin supports machine-to-machine
+  JWT exchange; see Option 1 Cons for the full finding. This closes the residual
+  uncertainty flagged when this DD was first drafted.
 - Upstream evidence: [awx-resource-operator#130](https://github.com/ansible/awx-resource-operator/issues/130),
   [#164](https://github.com/ansible/awx-resource-operator/issues/164), and
   [PR #124](https://github.com/ansible/awx-resource-operator/pull/124) (root cause).
@@ -245,13 +295,20 @@ fixed without kubernaut's knowledge between this decision and its next review.
 **When to Revisit**:
 - If [awx-resource-operator#130](https://github.com/ansible/awx-resource-operator/issues/130)
   is fixed upstream **and** `AnsibleCredential` is promoted out of Tech Preview
-- If the Kuadrant `mcp-gateway` project adds per-call credential injection for non-K8s
-  backends (would close Option 1's auth blocker; the `credentials_destroy` gap would
-  still need a separate upstream fix)
+- If **both** of the following land upstream — fixing either alone is not sufficient,
+  confirmed 2026-07-30: (a) the Kuadrant `mcp-gateway` project adds per-call credential
+  injection for non-K8s backends, **and** (b) AAP's platform gateway adds a
+  machine-to-machine JWT-bearer/resource-server auth mode capable of validating an
+  externally-federated identity per-call (no such mode exists in any of AAP's 11
+  authenticator plugins today — all are interactive, redirect-based). A
+  `credentials_destroy` tool would also still need to be added to a toolset, via custom
+  config or an upstream PR to `ansible/aap-mcp-server` — a smaller, independently
+  actionable fix, not blocked on either of the above.
 - If a genuine, prioritized business requirement for fleet-Ansible remediation emerges —
-  per direct guidance, escalate the two upstream gaps to the Ansible/AAP team directly
-  rather than re-attempting a kubernaut-side workaround, since both root causes are
-  upstream defects, not architecture gaps on kubernaut's side
+  per direct guidance, escalate the gateway-auth and JWT-federation gaps to the
+  Kuadrant/Ansible teams directly rather than re-attempting a kubernaut-side workaround,
+  since these root causes are upstream defects/gaps, not architecture gaps on
+  kubernaut's side
 
 **Success Metrics**:
 - `AnsibleExecutor.Create` returns a clear, actionable error (never a silent

--- a/docs/architecture/decisions/DD-FLEET-005-ansible-engine-not-supported-for-remote-execution.md
+++ b/docs/architecture/decisions/DD-FLEET-005-ansible-engine-not-supported-for-remote-execution.md
@@ -4,7 +4,7 @@
 
 **Approved**: 2026-07-30
 **Confidence**: 95%
-**Milestone**: v1.5
+**Milestone**: v1.6
 **Related Issue**: #1761
 
 ## Context & Problem
@@ -140,7 +140,7 @@ not a simpler one.
 ## Decision
 
 **Neither remote-execution option is adopted.** The Ansible/AAP engine is **not
-supported** for fleet (`Spec.ClusterID != ""`) `WorkflowExecution` in v1.5.
+supported** for fleet (`Spec.ClusterID != ""`) `WorkflowExecution` in v1.6.
 `AnsibleExecutor.Create` fails closed with a clear, actionable error whenever
 `wfe.Spec.ClusterID != ""` — this is exactly the "safe minimum" fallback issue #1761
 itself proposed if a real remote path proved infeasible. Local/hub execution via
@@ -194,7 +194,7 @@ path.
   ongoing test/support burden for a fraction of full parity
 
 **Negative**:
-- Remote/fleet clusters cannot use the Ansible/AAP engine at all in v1.5 — workflows
+- Remote/fleet clusters cannot use the Ansible/AAP engine at all in v1.6 — workflows
   targeting a managed/remote cluster must use the Job or Tekton engine instead
 - If a genuine business need for fleet-Ansible remediation emerges, it is blocked on
   upstream fixes outside kubernaut's control (see Review & Evolution)

--- a/docs/architecture/decisions/DD-FLEET-005-ansible-engine-not-supported-for-remote-execution.md
+++ b/docs/architecture/decisions/DD-FLEET-005-ansible-engine-not-supported-for-remote-execution.md
@@ -84,25 +84,64 @@ gateway instead of raw AWX REST.
   Kuadrant's side. `GET /api/gateway/v1/authenticator_plugins/` against the live AAP 2.7
   instance lists all 11 supported authenticator plugin types (`azuread`, `github` +4
   variants, `google_oauth2`, `keycloak`, `ldap`, `local`, `oidc`, `radius`, `saml`,
-  `tacacs`). The `keycloak` and `oidc` plugins — the only two capable of trusting
-  kubernaut's existing fleet identity provider — are both built on `python-social-auth`
-  and require `AUTHORIZATION_URL`/`CALLBACK_URL`/`RESPONSE_TYPE=code` in their
-  configuration schema: a browser-redirect login flow, not a machine-to-machine
-  JWT-bearer grant (RFC 7523) or resource-server-style JWT validation. A headless
-  controller like `WorkflowExecution` cannot complete a redirect-based login on its own.
-  This is the structural reason Option 2 and Option 1 behave so differently under the
-  *same* gateway: Kubernetes API servers natively validate OIDC-federated identities as
-  resource servers on every request (observed directly in this spike — the fleet
-  identity mapped to `keycloak:service-account-kubernaut-fleet-read` for RBAC purposes,
-  no redirect involved); AAP has no equivalent mode behind any of its 11 auth plugins.
-  Even a bug-free `credentialRef` injection could therefore only ever forward a static,
-  pre-provisioned AAP credential (OAuth Application or Personal Access Token) per
-  registration — the same per-cluster raw-credential-vending shape already rejected as
-  Option 3, just relocated into a Kuadrant CRD field instead of kubernaut's own code.
+  `tacacs`) — none support machine-to-machine JWT exchange. See
+  [Root Cause](#root-cause-why-aap-cannot-accept-a-keycloak-issued-token-for-api-authorization)
+  below for the full mechanism and why this isn't fixable by a PR to Kuadrant, the AAP
+  MCP Server, or anything on kubernaut's side.
 
 **Confidence in rejecting**: high — both blockers reproduced against real, live
 components (real AAP 2.7, real Kuadrant gateway, real Keycloak token exchange), not
 simulated.
+
+#### Root Cause: Why AAP Cannot Accept a Keycloak-Issued Token for API Authorization
+
+This is not a Kuadrant bug, not a kubernaut gap, and not something addressable by
+contributing a PR to `ansible/aap-mcp-server` or the Kuadrant `mcp-gateway` project —
+unlike the two toolset/injection issues above, it is architectural, on AAP's own side,
+and independent of both. Fixing either or both of those two issues would not unblock
+Option 1 without this also being fixed:
+
+- AAP's platform gateway is a Django + Django REST Framework application using
+  `django-oauth-toolkit` (DOT) as its OAuth2 provider. DOT's token model is
+  **stateful and database-backed**: an issued access token is an opaque string
+  persisted as an `AccessToken` row, linked by foreign key to a local Django `User`
+  row. Authenticating a request means a **database lookup** — "does this token value
+  exist, is it unexpired, which `User` does it point to?" — not cryptographic
+  signature verification against an issuer's public key.
+- Every downstream permission check, audit record, and ownership relationship in AAP
+  (RBAC, `created_by`/`modified_by` attribution, Organization/Team membership) is a
+  foreign key to that same local `User` row. A cryptographically valid Keycloak JWT
+  has no such row behind it — AAP's authorization stack has nothing to attach it to.
+- Creating that row (JIT-provisioning) is precisely what the interactive `keycloak`/
+  `oidc` authenticator plugins' login pipeline does the first time a given external
+  identity logs in (per Red Hat's own SSO docs: *"if this is your first time logging
+  in with this SSO method, platform gateway creates a user linked to your... user"*).
+  This is not a side effect of requiring a browser — it **is** the mechanism, and it
+  has no headless equivalent: there is no supported API that performs this
+  resolve-or-create step outside the interactive login view.
+- Keycloak **is** already meaningfully delegated to for interactive users today — it
+  handles authentication and can drive AAP Team/Role assignment via the
+  `GROUPS_CLAIM` mapping at login time. What's missing is specifically a
+  **stateless, per-call** path for headless/machine callers: nothing in AAP's request
+  authentication stack validates a live, externally-issued JWT signature on an
+  ordinary API call the way a JWT-bearer resource server would.
+- **This is a design choice, not a limitation of OAuth2/OIDC itself.** Contrast with
+  Kubernetes' own API server, which implements OIDC authentication in a genuinely
+  stateless, claims-based way (`--oidc-issuer-url`): a JWT's `sub`/`groups` claims map
+  directly to RBAC subjects, with **no persisted "User" object required anywhere**.
+  This is exactly why Option 2 (creating `tower.ansible.com` CRDs through the
+  K8s-native `kube-mcp-server`) worked cleanly in this same spike — the fleet
+  identity resolved live to `keycloak:service-account-kubernaut-fleet-read` for RBAC
+  purposes, no login ceremony, no local row required — while Option 1 (AAP's own API)
+  structurally cannot work the same way, independent of any Kuadrant-side fix.
+- **Practical consequence**: fixing Kuadrant's `credentialRef` injection bug alone
+  would not unlock Option 1. Even a bug-free Kuadrant could only ever forward a
+  static, pre-provisioned AAP credential (OAuth Application or Personal Access
+  Token) configured on the `MCPServerRegistration` — never one dynamically derived
+  from the caller's actual Keycloak identity — because AAP has no mechanism to accept
+  the latter at all. That reintroduces the same per-cluster raw-credential-vending
+  shape already rejected as Option 3, just relocated into a Kuadrant CRD field
+  instead of kubernaut's own code.
 
 ---
 
@@ -300,7 +339,9 @@ fixed without kubernaut's knowledge between this decision and its next review.
   injection for non-K8s backends, **and** (b) AAP's platform gateway adds a
   machine-to-machine JWT-bearer/resource-server auth mode capable of validating an
   externally-federated identity per-call (no such mode exists in any of AAP's 11
-  authenticator plugins today — all are interactive, redirect-based). A
+  authenticator plugins today — all are interactive, redirect-based; see
+  [Root Cause](#root-cause-why-aap-cannot-accept-a-keycloak-issued-token-for-api-authorization)
+  for why this is an AAP-side architectural gap, not a Kuadrant one). A
   `credentials_destroy` tool would also still need to be added to a toolset, via custom
   config or an upstream PR to `ansible/aap-mcp-server` — a smaller, independently
   actionable fix, not blocked on either of the above.

--- a/docs/architecture/decisions/DD-FLEET-005-ansible-engine-not-supported-for-remote-execution.md
+++ b/docs/architecture/decisions/DD-FLEET-005-ansible-engine-not-supported-for-remote-execution.md
@@ -1,0 +1,259 @@
+# DD-FLEET-005: Ansible/AAP Engine Not Supported for Fleet (Remote) WorkflowExecution
+
+## Status
+
+**Approved**: 2026-07-30
+**Confidence**: 95%
+**Milestone**: v1.5
+**Related Issue**: #1761
+
+## Context & Problem
+
+`AnsibleExecutor` (`pkg/workflowexecution/executor/ansible.go`) has zero `ClusterID`
+awareness. Unlike `JobExecutor`/`TektonExecutor`, which route through
+`ClientFactory.ClientFor(ctx, wfe.Spec.ClusterID)` to reach a remote cluster via the
+fleet MCP Gateway, `AnsibleExecutor` unconditionally calls the hub's own local AWX/AAP
+instance via `AWXHTTPClient`, and `injectK8sCredential` unconditionally injects the
+**hub's own** in-cluster K8s credentials (`ReadInClusterCredentials()`) as the AWX
+credential used by `kubernetes.core` playbook modules.
+
+The practical effect: a `WorkflowExecution` with a non-empty `Spec.ClusterID` (targeting
+a remote/managed cluster) using the `ansible` engine does not fail — it silently
+executes the playbook against the **hub cluster**, using the hub's own K8s API
+credentials, while the operator believes it targeted the remote cluster. Issue #1761
+flagged this as a correctness/safety bug and proposed, as a safe minimum fallback,
+failing closed on any non-empty `ClusterID` if a real remote-execution path proved
+infeasible.
+
+ADR-068 (Decision #9, and Alternative H) had already designed for a fix: register the
+AAP MCP Server as a `Backend`/`MCPServerRegistration` behind the same unified MCP
+Gateway used for K8s remote access, eliminating the need for AAP-specific credential
+handling. This was never implemented. Two candidate implementations of that fix — plus
+one CRD-based alternative discovered mid-spike — were evaluated against **real, live
+infrastructure** (not documentation or assumptions).
+
+## Alternatives Considered
+
+### Option 1: AAP MCP Server as a fleet backend (the ADR-068-designed approach)
+
+**Approach**: Register the AAP MCP Server (GA since AAP 2.7, June 2026) as a second
+backend behind the same Kuadrant/EAIGW gateway already used for K8s remote access, per
+ADR-068 Decision #9. `AnsibleExecutor` would call `job_management` toolset tools
+(`job_templates_launch_create`, `jobs_retrieve`, `jobs_cancel_create`, etc.) through the
+gateway instead of raw AWX REST.
+
+**Pros**:
+- Matches the already-approved ADR-068 architecture exactly — no new design needed
+- GA component, not experimental — 101 tools discovered correctly with proper
+  `aap_cluster_`-style prefixing once registered
+- Direct 1:1 tool mapping for the job-launch/status/cancel path (confirmed via live
+  `tools/list` introspection against a real AAP 2.7 instance)
+
+**Cons**:
+- **No `credentials_destroy` tool exists anywhere in the 101-tool surface.** Confirmed by
+  exhaustively checking every toolset's `tools/list` output. Kubernaut's ephemeral AWX
+  credential cleanup (`cleanupEphemeralCredentials`, BR-WE-015) has no MCP equivalent —
+  ephemeral credentials would accumulate in AAP indefinitely.
+- **`MCPServerRegistration.credentialRef` is discovery-only, never injected into actual
+  `tools/call` requests** — confirmed two ways against a real, live Kuadrant gateway
+  (v0.7.1): (a) the CRD's own field docs state this explicitly; (b) empirically, calling
+  a harmless read tool through the gateway returned `500: ... server returned 4xx for
+  initialize POST`, traced to the broker forwarding the caller's Keycloak JWT (which AAP
+  does not understand) instead of the registration's own credential. Every real
+  `tools/call` to an AAP-backed tool fails authentication.
+- ADR-068's own stated mitigation for this exact risk (Alternative H: *"the
+  `MCPRoute.backendRefs[].securityPolicy` handles upstream credential injection"*) does
+  not hold for the Kuadrant gateway this repo actually uses — confirmed live, not assumed.
+
+**Confidence in rejecting**: high — both blockers reproduced against real, live
+components (real AAP 2.7, real Kuadrant gateway, real Keycloak token exchange), not
+simulated.
+
+---
+
+### Option 2: `tower.ansible.com` Resource Operator CRDs via the existing K8s MCP server
+
+**Approach**: Use the AAP Operator's bundled Resource Operator, which provides
+`AnsibleJob`/`AnsibleCredential`/`JobTemplate` CRDs. `AnsibleExecutor` would create these
+CRs through the **same generic K8s CRUD tools** (`resources_get/list/create_or_update/delete`)
+already used by `JobExecutor`/`TektonExecutor` for remote clusters — no new gateway
+plumbing, no new tool-prefix discovery.
+
+**Pros**:
+- Reuses proven `ClientFactory`/K8s-MCP plumbing verbatim — zero new code in
+  `pkg/fleet/mcpclient`
+- Job launch (`AnsibleJob`, GA component) and K8s-credential injection (via the
+  dedicated, proper secret-ref field `AnsibleCredential.spec.kubernetes_bearer_token_secret`)
+  both fully validated live through a real Kuadrant gateway with **zero blockers**
+- Credential deletion works via ordinary `resources_delete` — the exact capability
+  missing from Option 1
+
+**Cons**:
+- `AnsibleCredential` is explicitly marked "(Tech Preview)" in its own live CRD schema
+  (`AnsibleJob`/`JobTemplate` carry no such marker)
+- ~55x latency overhead per launch (runner-pod-per-job: pod scheduling + image pull +
+  REST polling) vs. sub-second direct REST/MCP calls — measured on a trivial job
+  template; real playbooks would differ but the mechanism-level overhead is structural
+- **Fatal for generic secrets**: the only field available for non-K8s/non-SSH credential
+  shapes — `spec.inputs`, exactly what arbitrary `dependencies.secrets` injection needs —
+  is (a) a **plaintext string, not a secret-ref** (unlike every other field on this CRD),
+  a real AC-4/AU-3 audit-trail regression since today's direct-REST/MCP flow never
+  persists secret bytes in any object; and (b) **functionally broken, independent of the
+  compliance concern**, per the upstream repo
+  ([`github.com/ansible/awx-resource-operator`](https://github.com/ansible/awx-resource-operator),
+  which its own README states is "maintained by the Red Hat Ansible Team" — the AAP
+  Operator bundle ships this identical project, not a separately-patched fork):
+  - [Issue #130](https://github.com/ansible/awx-resource-operator/issues/130) (open since
+    2023-06-30, still open): the `inputs` field never reaches the underlying
+    `awx.awx.credential` call. Root cause confirmed by a contributor:
+    [PR #124](https://github.com/ansible/awx-resource-operator/pull/124) (merged
+    2023-04-25) renamed the internal variable `inputs` -> `credential_inputs` everywhere
+    except `roles/credential/templates/job_definition.yml.j2`, which still looks for the
+    old name. The value is silently dropped.
+  - [Issue #164](https://github.com/ansible/awx-resource-operator/issues/164) (open since
+    2024-08-27): confirms this is systemic, not isolated — every credential type has its
+    own hardcoded, narrow field allow-list (e.g. SSH only exposes `ssh_key_data`/
+    `username`, not even `ssh_key_unlock`). There is no generic key-value passthrough
+    anywhere in this operator.
+
+**Confidence in rejecting the generic-secrets sub-case**: very high — reproduced findings
+plus two independently-filed, still-open upstream issues spanning 2023-2024 with no fix
+merged as of 2026-07.
+
+---
+
+### Option 3 (rejected pre-spike): Make `AWXHTTPClient` itself `ClusterID`-aware
+
+**Approach**: Resolve a target cluster's raw host/bearer-token/CA and hand it directly to
+today's AWX REST client instead of routing through MCP at all.
+
+**Cons**: Requires inventing a raw-per-cluster-credential-vending mechanism that
+contradicts ADR-068 Decision #9's explicit security posture (*"No per-cluster SA tokens
+are maintained by Kubernaut services"*) and Alternative H's rejection of exactly this
+shape of solution. No such mechanism exists anywhere in the codebase
+(`pkg/fleet/registry.ClusterInfo` holds only `ID`/`MCPEndpoint`/`ToolPrefix`/`Labels`,
+never credentials).
+
+**Confidence in rejecting**: high — would be a larger, contradictory architectural change,
+not a simpler one.
+
+## Decision
+
+**Neither remote-execution option is adopted.** The Ansible/AAP engine is **not
+supported** for fleet (`Spec.ClusterID != ""`) `WorkflowExecution` in v1.5.
+`AnsibleExecutor.Create` fails closed with a clear, actionable error whenever
+`wfe.Spec.ClusterID != ""` — this is exactly the "safe minimum" fallback issue #1761
+itself proposed if a real remote path proved infeasible. Local/hub execution via
+`AWXHTTPClient` is completely unchanged — zero regression risk to the proven, working
+path.
+
+**Rationale**:
+
+1. **A clean binary cut beats partial/conditional engine support.** Option 2's core
+   capability (job launch + K8s-credential injection) has zero confirmed blockers, so a
+   *scoped* remote-Ansible capability (support job launch + K8s-credential injection,
+   fail closed only for workflows that also declare `dependencies.secrets`) was
+   seriously considered. It was rejected: it would force operators to reason about which
+   workflows are "remote-Ansible-safe" based on their secret-injection needs — a support
+   burden and footgun risk judged worse than a single, predictable rule. An engine is
+   either fully supported on a given `ClusterID`, or it is not; mixing engines per
+   workflow capability need is the wrong UX to hand operators.
+2. **Neither Red Hat-supported path is actually a distinct, better-maintained
+   alternative to the other.** The Resource Operator shipped inside the AAP Operator
+   bundle is the *identical* open-source `ansible/awx-resource-operator` project, not a
+   separately-patched downstream fork — confirmed via the repo's own README and matching
+   field-for-field CRD documentation across the community and Red Hat product docs. The
+   AAP MCP Server (Option 1) is a genuinely distinct, newer component, but carries its
+   own two independent, live-confirmed blockers.
+3. **Both alternatives were validated against real, live infrastructure**, not
+   documentation or assumptions — see [Validation Results](#validation-results).
+
+## Implementation
+
+- `AnsibleExecutor.Create` returns an error immediately when `wfe.Spec.ClusterID != ""`,
+  before any AWX/AAP interaction — mirrors the existing `localClientFactory.ClientFor`
+  fail-closed pattern in `pkg/workflowexecution/executor/client_factory.go:63-68` (used by
+  non-fleet deployments for Job/Tekton), for consistency of error shape across engines.
+- Error message must name the engine, the requested `ClusterID`, and point at this DD for
+  the "why" (avoids a bare/unexplained rejection).
+- No changes to `GetStatus`/`Cleanup` behavior beyond what naturally follows from `Create`
+  never having launched a remote job (there is no remote `ExecutionRef` to poll or clean
+  up).
+- No changes to local/hub (`ClusterID == ""`) behavior anywhere in `ansible.go`.
+
+## Consequences
+
+**Positive**:
+- Closes issue #1761's actual safety concern (silent wrong-cluster execution) with a
+  minimal, low-risk code change instead of a multi-day implementation
+- Zero regression to local/hub Ansible execution — today's proven `AWXHTTPClient` path is
+  untouched
+- Avoids taking a compliance-sensitive execution path (SOC2/FedRAMP AC-4/AU-3 in scope,
+  per AGENTS.md) into production dependency on two Tech-Preview-or-worse components
+- Avoids maintaining a partially-capable remote-Ansible code path that would need its own
+  ongoing test/support burden for a fraction of full parity
+
+**Negative**:
+- Remote/fleet clusters cannot use the Ansible/AAP engine at all in v1.5 — workflows
+  targeting a managed/remote cluster must use the Job or Tekton engine instead
+- If a genuine business need for fleet-Ansible remediation emerges, it is blocked on
+  upstream fixes outside kubernaut's control (see Review & Evolution)
+
+**Neutral**:
+- `docs/spikes/multi-cluster-mcp-write/spike-aap-mcp-server.md`'s previously-open item
+  ("Gateway credential injection") is now closed with a definitive NO, not left
+  unresolved
+
+## Validation Results
+
+Both alternatives were validated against real, live infrastructure across two spike
+phases:
+
+- **Phase 1**: A real `AnsibleAutomationPlatform` v2.7 aggregate CR was stood up on a live
+  OCP dev cluster (controller + MCP enabled), subscription activated via the real
+  Gateway API, and the combined `/mcp` endpoint's `tools/list` introspected directly
+  (101 real tools across 6 toolsets). The `credentials_destroy` gap was found here.
+- **Phase 2**: Used this repo's own CI-validated `PRESERVE_E2E_CLUSTER=true make
+  test-e2e-fleetmetadatacache-kuadrant` automation to stand up a real, isolated Kind
+  cluster with a live Keycloak + Istio + Kuadrant MCP Gateway + `kube-mcp-server` stack.
+  Option 2's `AnsibleJob`/`AnsibleCredential` CRDs (extracted from the real AAP 2.7
+  install) were applied and exercised through the real gateway
+  (`resources_create_or_update`/`resources_get`/`resources_delete`, all PASS). Option 1's
+  AAP MCP Server was registered as a second live backend on the same gateway
+  (`credentialRef`-based registration, discovery PASS, all `tools/call` FAIL with `500`).
+- Upstream evidence: [awx-resource-operator#130](https://github.com/ansible/awx-resource-operator/issues/130),
+  [#164](https://github.com/ansible/awx-resource-operator/issues/164), and
+  [PR #124](https://github.com/ansible/awx-resource-operator/pull/124) (root cause).
+
+**Residual 5%**: (a) the dev cluster's loopback-only topology (`local-cluster` only)
+still caps how conclusively genuinely-remote-cluster behavior for Option 1/2's *working*
+parts was proven, though the Kind `fmc-e2e`/`fmc-e2e-remote` split is a closer
+approximation than the OCP cluster alone; (b) upstream GitHub issues can theoretically be
+fixed without kubernaut's knowledge between this decision and its next review.
+
+## Related Decisions
+
+- **Amends**: [ADR-068](ADR-068-fleet-federation-architecture.md) — Decision #9 and
+  Alternative H's assumption that the AAP MCP Server would be registered as a fleet
+  backend is retired *for the Ansible engine specifically*. The unified-gateway
+  chokepoint principle itself is unaffected and remains correct for K8s MCP backends
+  (Job/Tekton engines).
+- **Resolves**: Issue #1761 (via fail-closed, not via full remote support)
+
+## Review & Evolution
+
+**When to Revisit**:
+- If [awx-resource-operator#130](https://github.com/ansible/awx-resource-operator/issues/130)
+  is fixed upstream **and** `AnsibleCredential` is promoted out of Tech Preview
+- If the Kuadrant `mcp-gateway` project adds per-call credential injection for non-K8s
+  backends (would close Option 1's auth blocker; the `credentials_destroy` gap would
+  still need a separate upstream fix)
+- If a genuine, prioritized business requirement for fleet-Ansible remediation emerges —
+  per direct guidance, escalate the two upstream gaps to the Ansible/AAP team directly
+  rather than re-attempting a kubernaut-side workaround, since both root causes are
+  upstream defects, not architecture gaps on kubernaut's side
+
+**Success Metrics**:
+- `AnsibleExecutor.Create` returns a clear, actionable error (never a silent
+  hub-execution) for any `wfe.Spec.ClusterID != ""`
+- Zero behavior change for `wfe.Spec.ClusterID == ""`

--- a/pkg/workflowexecution/ansible_executor_test.go
+++ b/pkg/workflowexecution/ansible_executor_test.go
@@ -326,6 +326,53 @@ var _ = Describe("AnsibleExecutor (BR-WE-015)", func() {
 		})
 	})
 
+	Context("ClusterID fail-closed (#1761, DD-FLEET-005)", func() {
+		It("UT-WE-1761-001: should fail closed and never contact AWX when ClusterID targets a remote cluster", func() {
+			var awxCalled bool
+			awxClient.findTemplateByNameFn = func(_ context.Context, _ string) (int, error) {
+				awxCalled = true
+				return 99, nil
+			}
+			awxClient.launchFunc = func(_ context.Context, _ int, _ map[string]interface{}) (int, error) {
+				awxCalled = true
+				return 42, nil
+			}
+
+			engineConfig, _ := json.Marshal(map[string]interface{}{
+				"playbookPath":    "playbooks/restart.yml",
+				"jobTemplateName": "restart-pod",
+			})
+			wfe := newAnsibleWFE("remote-wfe", "default", engineConfig, nil)
+			wfe.Spec.ClusterID = "remote-cluster-1"
+
+			_, err := ansibleExec.Create(ctx, wfe, "default", executor.CreateOptions{})
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("remote-cluster-1"), "error should name the rejected cluster")
+			Expect(err.Error()).To(ContainSubstring("ansible"), "error should name the engine that rejected the request")
+			Expect(awxCalled).To(BeFalse(), "AWX must never be contacted for a remote ClusterID -- DD-FLEET-005 fails closed before any AWX interaction")
+		})
+
+		It("UT-WE-1761-002: should execute normally when ClusterID is empty (local/hub, unchanged behavior)", func() {
+			awxClient.findTemplateByNameFn = func(_ context.Context, _ string) (int, error) {
+				return 99, nil
+			}
+			awxClient.launchFunc = func(_ context.Context, _ int, _ map[string]interface{}) (int, error) {
+				return 42, nil
+			}
+
+			engineConfig, _ := json.Marshal(map[string]interface{}{
+				"playbookPath":    "playbooks/restart.yml",
+				"jobTemplateName": "restart-pod",
+			})
+			wfe := newAnsibleWFE("local-wfe", "default", engineConfig, nil)
+			Expect(wfe.Spec.ClusterID).To(BeEmpty(), "sanity check: local/hub WFEs have no ClusterID set")
+
+			result, err := ansibleExec.Create(ctx, wfe, "default", executor.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+			Expect(result.ResourceName).To(ContainSubstring("awx-job-"))
+		})
+	})
+
 	Context("GetStatus", func() {
 		It("UT-WE-015-002: should map all 7 AWX states to correct WFE phases", func() {
 			testCases := []struct {

--- a/pkg/workflowexecution/executor/ansible.go
+++ b/pkg/workflowexecution/executor/ansible.go
@@ -231,6 +231,19 @@ func (a *AnsibleExecutor) Create(
 	namespace string,
 	opts CreateOptions,
 ) (*CreateResult, error) {
+	// DD-FLEET-005 (#1761): the ansible engine does not support remote (fleet)
+	// execution. Live spikes against both candidate remote paths (AAP MCP
+	// Server, tower.ansible.com Resource Operator CRDs) each surfaced
+	// independent, confirmed blockers -- see DD-FLEET-005 for the full
+	// evidence and rationale. Fail closed here, before any AWX/AAP
+	// interaction, rather than silently executing against the hub cluster.
+	if wfe.Spec.ClusterID != "" {
+		return nil, fmt.Errorf(
+			"ansible engine does not support remote execution: cannot target cluster %q (see DD-FLEET-005)",
+			wfe.Spec.ClusterID,
+		)
+	}
+
 	cfg, err := a.parseEngineConfig(wfe)
 	if err != nil {
 		return nil, fmt.Errorf("parse ansible engineConfig: %w", err)


### PR DESCRIPTION
## Summary

- `AnsibleExecutor.Create` ignored `WorkflowExecution.Spec.ClusterID`, silently executing fleet remediation against the **hub** cluster instead of the intended remote target -- unlike `JobExecutor`/`TektonExecutor`, which already route through `ClientFactory` correctly.
- A live spike evaluated two candidate remote-execution paths for the Ansible engine:
  1. **AAP MCP Server as a fleet backend** (the design ADR-068 Decision #9 originally assumed) -- blocked by two independent, live-confirmed issues: no credential-delete tool anywhere in its API surface, and the gateway's `credentialRef` is discovery-only, never injected into actual `tools/call` requests.
  2. **`tower.ansible.com` Resource Operator CRDs** via the existing K8s MCP server -- job launch + K8s-credential injection validated live with zero blockers, but the only field for generic/non-K8s secrets (`AnsibleCredential.spec.inputs`) is both a compliance regression (plaintext-in-spec) *and* a confirmed, currently-unfixed upstream bug ([awx-resource-operator#130](https://github.com/ansible/awx-resource-operator/issues/130), [#164](https://github.com/ansible/awx-resource-operator/issues/164)).
- Neither option is adopted. Per [DD-FLEET-005](docs/architecture/decisions/DD-FLEET-005-ansible-engine-not-supported-for-remote-execution.md), the Ansible/AAP engine is not supported for fleet (remote) `WorkflowExecution` -- `AnsibleExecutor.Create` now fails closed with a clear error for any non-empty `ClusterID`, before any AWX/AAP interaction. This is the safe-minimum fallback the issue itself proposed as step 1 of its suggested fix.
- Local/hub execution (`ClusterID == ""`) is completely unchanged.
- Amends [ADR-068](docs/architecture/decisions/ADR-068-fleet-federation-architecture.md) (Decision #9, Alternative H, Implementation Status table) to reflect this.

## Test plan

- [x] `UT-WE-1761-001`: `Create` fails closed and never contacts AWX when `ClusterID` targets a remote cluster
- [x] `UT-WE-1761-002`: `Create` executes normally when `ClusterID` is empty (local/hub, unchanged behavior)
- [x] `go build ./...` passes
- [x] `go test ./pkg/workflowexecution/...` and `./internal/controller/workflowexecution/...` pass (zero regressions)
- [x] `golangci-lint run` -- 0 issues on touched packages

Resolves #1761 (will close on merge, per the pre-agreed disposition).

Made with [Cursor](https://cursor.com)