### PR TITLE
fix(1794-backport-v1.5): live SSE complete event never carried RCA data

### DIFF
--- a/internal/kubernautagent/server/handler.go
+++ b/internal/kubernautagent/server/handler.go
@@ -531,11 +531,14 @@ func (h *Handler) terminalSessionSSE(sessionID string) (agentclient.SessionStrea
 		Type:  session.EventTypeComplete,
 		Turn:  0,
 		Phase: "complete",
+		// #1794: use the bounded RCA subset (severity/confidence/rca_summary/...)
+		// rather than a raw dump of sess.Result, which also carries internal
+		// workflow/validation state (workflow_id, validation_attempts_history,
+		// etc.) that must not leak to AF/Console (SI-10). Matches what the live
+		// path (Manager.emitCompleteEvent) now attaches.
 	}
 	if sess.Result != nil {
-		if data, marshalErr := json.Marshal(sess.Result); marshalErr == nil {
-			completeEvent.Data = data
-		}
+		completeEvent.Data = session.MarshalRCASubset(sess.Result)
 	}
 
 	frame, err := json.Marshal(completeEvent)

--- a/internal/kubernautagent/server/stream_handler_test.go
+++ b/internal/kubernautagent/server/stream_handler_test.go
@@ -184,4 +184,42 @@ var _ = Describe("SSE Stream Handler — #823 PR7", func() {
 			Expect(sseData).To(ContainSubstring("terminal result"))
 		})
 	})
+
+	Describe("UT-KA-1794-003: terminal SSE complete event uses the bounded RCA subset, not a raw dump", func() {
+		It("should not leak internal-only InvestigationResult fields (e.g. workflow_id) into the reconnect SSE stream", func() {
+			id, err := mgr.StartInvestigation(context.Background(), func(_ context.Context) (*katypes.InvestigationResult, error) {
+				return &katypes.InvestigationResult{
+					RCASummary: "terminal result",
+					Confidence: 0.95,
+					WorkflowID: "wf-should-not-leak",
+				}, nil
+			}, map[string]string{"remediation_id": "rr-1794-terminal"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(func() session.Status {
+				sess, _ := mgr.GetSession(id)
+				if sess == nil {
+					return session.StatusPending
+				}
+				return sess.Status
+			}, 5*time.Second).Should(Equal(session.StatusCompleted))
+
+			resp, handlerErr := h.SessionStreamAPIV1IncidentSessionSessionIDStreamGet(
+				context.Background(),
+				agentclient.SessionStreamAPIV1IncidentSessionSessionIDStreamGetParams{SessionID: id},
+			)
+			Expect(handlerErr).NotTo(HaveOccurred())
+
+			okResp, ok := resp.(*agentclient.SessionStreamAPIV1IncidentSessionSessionIDStreamGetOK)
+			Expect(ok).To(BeTrue(), "terminal session should return SSE stream with complete event")
+			data, readErr := io.ReadAll(okResp.Data)
+			Expect(readErr).NotTo(HaveOccurred())
+			sseData := string(data)
+			Expect(sseData).To(ContainSubstring("terminal result"),
+				"AF-relevant RCA fields must still be present")
+			Expect(sseData).NotTo(ContainSubstring("wf-should-not-leak"),
+				"SI-10: internal workflow state must not leak into the AF/Console-facing complete event")
+			Expect(sseData).NotTo(ContainSubstring("workflow_id"))
+		})
+	})
 })

--- a/internal/kubernautagent/session/complete_event_rca_1794_test.go
+++ b/internal/kubernautagent/session/complete_event_rca_1794_test.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session_test
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// Issue #1794 (backport from main): the live SSE "complete" event never
+// carried the investigation's RCA result -- only the reconnect/
+// terminalSessionSSE path did, because Manager.runInvestigation emits the
+// complete event before Store.Update persists the result (manager.go), and
+// emitCompleteEvent never received the result to attach in the first place.
+// AF's emitEarlyRCA/emitFallbackInvestigationArtifact key off this event's
+// Data field, so a live-streaming Console user never saw the RCA rendered --
+// an AU-3/SI-4 gap. Root-caused via E2E-FP-1189-005 on main/v1.6.
+var _ = Describe("Live complete event carries RCA data — #1794", func() {
+
+	var (
+		store  *session.Store
+		mgr    *session.Manager
+		logger logr.Logger
+	)
+
+	BeforeEach(func() {
+		logger = logr.Discard()
+		store = session.NewStore(10*time.Minute, session.WithLogger(logger))
+		mgr = session.NewManager(store, logger, nil, nil)
+	})
+
+	Describe("UT-KA-1794-001: live complete event Data is populated from a non-nil result", func() {
+		It("should attach the bounded RCA subset to the live EventTypeComplete event", func() {
+			investigationDone := make(chan struct{})
+
+			pendingID, err := mgr.StartInteractiveSession(context.Background(),
+				func(_ context.Context) (*katypes.InvestigationResult, error) {
+					defer close(investigationDone)
+					return &katypes.InvestigationResult{
+						Severity:   "critical",
+						Confidence: 0.92,
+						RCASummary: "OOMKill caused by memory leak",
+						WorkflowID: "wf-should-not-leak",
+					}, nil
+				},
+				map[string]string{"remediation_id": "rr-1794-001"},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mgr.LaunchDeferredInvestigation(pendingID)).To(Succeed())
+
+			eventCh, subErr := mgr.Subscribe(context.Background(), pendingID)
+			Expect(subErr).NotTo(HaveOccurred())
+
+			Eventually(investigationDone, 5*time.Second).Should(BeClosed())
+
+			var completeEvt *session.InvestigationEvent
+			Eventually(func() *session.InvestigationEvent {
+				select {
+				case evt, ok := <-eventCh:
+					if !ok {
+						return nil
+					}
+					if evt.Type == session.EventTypeComplete {
+						completeEvt = &evt
+					}
+				default:
+				}
+				return completeEvt
+			}, 5*time.Second, 10*time.Millisecond).ShouldNot(BeNil(), "live complete event must be received")
+
+			Expect(completeEvt.Data).NotTo(BeEmpty(),
+				"AU-3/SI-4: the live complete event must carry the RCA result, "+
+					"not an empty Data field -- otherwise a streaming Console user never sees the RCA")
+
+			var parsed map[string]interface{}
+			Expect(json.Unmarshal(completeEvt.Data, &parsed)).To(Succeed())
+			Expect(parsed).To(HaveKeyWithValue("severity", "critical"))
+			Expect(parsed).To(HaveKeyWithValue("rca_summary", "OOMKill caused by memory leak"))
+
+			By("SI-10: verifying the live complete event uses the bounded RCA subset, not a raw dump")
+			Expect(parsed).NotTo(HaveKey("workflow_id"),
+				"internal workflow state must not leak into the AF/Console-facing complete event")
+		})
+	})
+
+	Describe("UT-KA-1794-002: live complete event has empty Data when investigation returns nil result", func() {
+		It("should not populate Data for a nil result (e.g. a failed investigation)", func() {
+			investigationDone := make(chan struct{})
+
+			pendingID, err := mgr.StartInteractiveSession(context.Background(),
+				func(_ context.Context) (*katypes.InvestigationResult, error) {
+					defer close(investigationDone)
+					return nil, nil
+				},
+				map[string]string{"remediation_id": "rr-1794-002"},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mgr.LaunchDeferredInvestigation(pendingID)).To(Succeed())
+
+			eventCh, subErr := mgr.Subscribe(context.Background(), pendingID)
+			Expect(subErr).NotTo(HaveOccurred())
+
+			Eventually(investigationDone, 5*time.Second).Should(BeClosed())
+
+			var completeEvt *session.InvestigationEvent
+			Eventually(func() *session.InvestigationEvent {
+				select {
+				case evt, ok := <-eventCh:
+					if !ok {
+						return nil
+					}
+					if evt.Type == session.EventTypeComplete {
+						completeEvt = &evt
+					}
+				default:
+				}
+				return completeEvt
+			}, 5*time.Second, 10*time.Millisecond).ShouldNot(BeNil(), "live complete event must still be received")
+
+			Expect(completeEvt.Data).To(BeEmpty(), "no RCA data exists to attach for a nil result")
+		})
+	})
+})

--- a/internal/kubernautagent/session/manager.go
+++ b/internal/kubernautagent/session/manager.go
@@ -186,7 +186,7 @@ func (m *Manager) launchInvestigation(ctx context.Context, id string, fn Investi
 		defer m.recoverPanic(id, correlationID)
 
 		result, fnErr := fn(bgCtx)
-		m.emitCompleteEvent(id)
+		m.emitCompleteEvent(id, result)
 		if fnErr != nil {
 			m.logger.Error(fnErr, "investigation failed", "session_id", id)
 			if updateErr := m.store.Update(id, StatusFailed, nil, fnErr); updateErr != nil {
@@ -890,8 +890,14 @@ func (m *Manager) recoverPanic(id, correlationID string) {
 }
 
 // emitCompleteEvent sends an EventTypeComplete to the event sink (if active)
-// to signal the SSE consumer that the investigation has finished.
-func (m *Manager) emitCompleteEvent(id string) {
+// to signal the SSE consumer that the investigation has finished. When result
+// is non-nil, its bounded RCA subset (MarshalRCASubset) is attached as the
+// event's Data so a live-streaming consumer (AF's emitEarlyRCA/
+// emitFallbackInvestigationArtifact) can render the RCA immediately, matching
+// what a reconnecting client already gets from terminalSessionSSE (#1794:
+// previously this always sent an empty-Data event, since it fired before
+// Store.Update persisted the result -- a live Console user never saw the RCA).
+func (m *Manager) emitCompleteEvent(id string, result *katypes.InvestigationResult) {
 	m.store.mu.RLock()
 	sess, ok := m.store.sessions[id]
 	var sink *LazySink
@@ -908,7 +914,7 @@ func (m *Manager) emitCompleteEvent(id string) {
 		return
 	}
 	select {
-	case ch <- InvestigationEvent{Type: EventTypeComplete}:
+	case ch <- InvestigationEvent{Type: EventTypeComplete, Data: MarshalRCASubset(result)}:
 	default:
 	}
 }


### PR DESCRIPTION
## Summary

Backports the #1794 fix from `main`/v1.6 to `release/v1.5`.

- `Manager.emitCompleteEvent` fired the live SSE `EventTypeComplete` event before the investigation result was available, so a live-streaming Console user driving an interactive investigation via SSE never saw the RCA render on completion — only a reconnecting client (`terminalSessionSSE`) got it, since that path reads the already-persisted `sess.Result`.
- Also fixes a related SI-10 data leak in `terminalSessionSSE`, which raw-marshaled the full `session.Result` (including internal-only fields like `workflow_id`) instead of the bounded RCA subset.

Both sites now call the pre-existing `MarshalRCASubset` helper (`rca_event_payload.go`, unchanged) — no new types/components introduced.

**#1795 (AF→KA NetworkPolicy egress gap)**, found alongside #1794 while auditing E2E coverage on `main`, does **not** apply here — `apifrontend`'s Helm chart on `release/v1.5` has no `NetworkPolicy` resource at all yet, so there is nothing to backport for it.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./internal/kubernautagent/...` — clean
- [x] `golangci-lint run ./internal/kubernautagent/session/... ./internal/kubernautagent/server/...` — 0 issues
- [x] New tests added following TDD, RED confirmed before each fix, GREEN after:
  - `UT-KA-1794-001/002` (`session` package, live complete event)
  - `UT-KA-1794-003` (`server` package, terminal/reconnect complete event)
- [x] `go test ./internal/kubernautagent/...` — all packages pass

Made with [Cursor](https://cursor.com)