### PR TITLE
docs(platform-006): mark DD-PLATFORM-006/BR-PLATFORM-007 status Implemented

### DIFF
--- a/docs/architecture/decisions/DD-PLATFORM-006-helm-chart-configuration-surface-reduction.md
+++ b/docs/architecture/decisions/DD-PLATFORM-006-helm-chart-configuration-surface-reduction.md
@@ -1,7 +1,8 @@
 # DD-PLATFORM-006: Helm Chart Configuration Surface Reduction
 
-**Status**: 🟡 **PROPOSED** (pending user approval)
-**Decision Date**: TBD (on approval)
+**Status**: ✅ **IMPLEMENTED** (merged via [PR #1790](https://github.com/jordigilh/kubernaut/pull/1790))
+**Decision Date**: 2026-07-31 (merge date; Decision Area 14's materialized-defaults generator
+remains deferred to its own follow-up PR — see Status section below)
 **Version**: 5.11 (Decision Area 13 addendum, round-16 RCA: FMC was a third Go Valkey client missed
 by this Decision Area's original DataStorage/APIFrontend-only census — fixed with the identical
 `sharedtls.BuildTLSConfig` pattern, mandatory-on per DataStorage's shape rather than the replay
@@ -1111,7 +1112,12 @@ further user review — made explicit, in both the hint text and a new Consequen
 is a genuine accepted cost to remediation quality/confidence, not merely an invisible
 nice-to-have)
 **Last Updated**: 2026-07-31
-**Status**: 🟡 Proposed — awaiting user approval. Field-census recount and file/line-reference
+**Status**: ✅ Implemented — merged to `main` via [PR #1790](https://github.com/jordigilh/kubernaut/pull/1790)
+(merge commit `80daf42f7`), tracking issue [#1743](https://github.com/jordigilh/kubernaut/issues/1743)
+closed. All CI suites (unit, integration, helm-unittest, E2E fullpipeline, E2E fleet) green on the
+merge commit. Decision Area 14's materialized-defaults generator (234 fields) remains deferred to
+PR9, tracked as an explicit follow-up rather than blocking this DD's Decision Areas 1-13/15-17.
+Field-census recount and file/line-reference
 verification against `main` post-PR #1755 completed (Decision Area 12) — no Decision Area's
 chosen alternative changed. Decision Area 4's Fleet overlay approach reversed from a shipped
 `values-fleet.yaml` file to fields folded into the user's own `values.yaml`, after identifying it

--- a/docs/requirements/BR-PLATFORM-007-helm-chart-minimal-onboarding.md
+++ b/docs/requirements/BR-PLATFORM-007-helm-chart-minimal-onboarding.md
@@ -4,7 +4,8 @@
 **Category**: Platform
 **Priority**: P2
 **Target Version**: V1.5
-**Status**: 🟡 Proposed
+**Status**: ✅ Implemented (merged via [PR #1790](https://github.com/jordigilh/kubernaut/pull/1790),
+2026-07-31)
 **Date**: 2026-07-25 (lean reconstruction 2026-07-29 — see Document Note below)
 
 ---
@@ -102,7 +103,11 @@ security/stability-relevant opt-out gaps identified during this effort.
 - **FR-11**: Require `apifrontend.enabled=true` whenever `kubernautAgent.interactive.enabled=true`
   (APIFrontend is currently the sole consumer of KubernautAgent's interactive MCP endpoint), and
   whenever `console.enabled=true` (Console's nginx sidecar has no other backend).
-- **FR-12**: Add a `values-fleet.yaml` overlay covering Fleet-Federation-specific fields.
+- **FR-12**: ~~Add a `values-fleet.yaml` overlay covering Fleet-Federation-specific fields.~~
+  Superseded during implementation (DD-PLATFORM-006 Decision Area 4): a shipped overlay file is
+  unreachable via `-f` for a pure-OCI/airgapped install without a `helm pull --untar` step first,
+  so Fleet-specific fields are instead documented inline in the README/generated values reference
+  for the user's own `values.yaml`, with no shipped overlay file.
 
 ---
 
@@ -131,5 +136,8 @@ security/stability-relevant opt-out gaps identified during this effort.
 
 ---
 
-**Document Status**: 🟡 Proposed
+**Document Status**: ✅ Implemented — merged to `main` via
+[PR #1790](https://github.com/jordigilh/kubernaut/pull/1790), tracking issue
+[#1743](https://github.com/jordigilh/kubernaut/issues/1743) closed. FR-12 superseded per the note
+above; all other Functional Requirements implemented as designed in DD-PLATFORM-006.
 **Priority**: P2


### PR DESCRIPTION
## Summary

- Post-merge follow-up to #1790 (closes #1743): updates the status headers/footers of
  `DD-PLATFORM-006` and `BR-PLATFORM-007` from Proposed to Implemented now that the full
  implementation has merged to `main` with all CI suites green.
- Notes Decision Area 14's materialized-defaults generator (234 fields) remains explicitly
  deferred to its own follow-up PR, so it isn't miscounted as part of this DD's closed scope.
- Marks BR-PLATFORM-007's FR-12 (`values-fleet.yaml` overlay) as superseded, per
  DD-PLATFORM-006 Decision Area 4's reversal to inline README/generated-reference
  documentation instead of a shipped overlay file (a shipped overlay is unreachable via `-f`
  for pure-OCI/airgapped installs without a `helm pull --untar` step first).

## Test plan

- Docs-only change; no code/behavior affected.
- Verified both files render correctly and cross-reference the correct PR/issue/commit.

Closes #1743

Made with [Cursor](https://cursor.com)