### PR TITLE
fix(kubernautagent): buffer investigation events before Subscribe to close #1811 race (v1.5 backport)

### DIFF
--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -1515,16 +1515,13 @@ func (inv *Investigator) chatOrStream(ctx context.Context, client llm.Client, re
 	return resp, err
 }
 
-// emitToSink sends an InvestigationEvent to the context-carried event sink
-// using non-blocking send semantics. If the sink is nil (no subscriber) or
-// the channel buffer is full, the event is silently dropped. This ensures
+// emitToSink sends an InvestigationEvent through the context-carried
+// LazySink. If no channel is attached yet, the event is buffered for replay
+// once a subscriber connects (#1811) rather than silently dropped; if the
+// active channel's buffer is full, it is dropped as before. This ensures
 // the investigation loop is never blocked by a slow SSE consumer.
 func emitToSink(ctx context.Context, eventType string, turn int, phase string, data map[string]interface{}) {
-	sink := session.EventSinkFromContext(ctx)
-	if sink == nil {
-		diagSinkNil.Add(1)
-		return
-	}
+	sinkPresent := session.EventSinkFromContext(ctx) != nil
 	var raw json.RawMessage
 	if data != nil {
 		var err error
@@ -1539,9 +1536,11 @@ func emitToSink(ctx context.Context, eventType string, turn int, phase string, d
 		Phase: phase,
 		Data:  raw,
 	}
-	select {
-	case sink <- event:
+	switch {
+	case session.EmitEvent(ctx, event):
 		diagSendOK.Add(1)
+	case !sinkPresent:
+		diagSinkNil.Add(1)
 	default:
 		diagSendDrop.Add(1)
 	}

--- a/internal/kubernautagent/mcp/tools/late_subscribe_replay_1811_it_test.go
+++ b/internal/kubernautagent/mcp/tools/late_subscribe_replay_1811_it_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+	mcptools "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// IT-KA-1811-001 exercises the exact production dispatch path for #1811 — the
+// real InvestigateTool.Handle (action=start) and InvestigateTool.SubscribeEvents,
+// wired to a real *session.Manager as autoMgr (matching cmd/kubernautagent's
+// production wiring), not the session package's internal Manager/LazySink API
+// directly. This proves the wiring point, complementing session package's
+// UT-KA-1811-002/003 which prove the LazySink buffering logic itself.
+//
+// Scenario: AA submits an investigation non-interactively via
+// Manager.StartInvestigation (mirrors AA's real submission path, outside the
+// kubernaut_investigate MCP tool). The investigation resolves fast enough
+// that AF's kubernaut_investigate action=start call reaches
+// upgradeOrCreateInteractiveSession -> autoMgr.UpgradeToInteractive while the
+// goroutine is still running -- then the goroutine's InteractiveHold observes
+// the upgrade and returns. Before the #1811 fix, every event emitted during
+// that window (by session.EmitEvent, matching investigator.emitToSink and
+// manager.go's emitCompleteEvent) was silently dropped because
+// wireInvestigationEventBridge's tool.SubscribeEvents() call — which always
+// runs strictly after handleStart returns — activated the LazySink too late.
+var _ = Describe("Fix #1811 — Late-Subscribe Event Replay IT (Pyramid Invariant: wiring proof)", func() {
+
+	Describe("IT-KA-1811-001: kubernaut_investigate action=start upgrade-in-place replays buffered events on SubscribeEvents", func() {
+		It("delivers RCA-phase events and the terminal complete event through the real InvestigateTool + session.Manager wiring", func() {
+			mgr := session.NewManager(session.NewStore(30*time.Minute), logr.Discard(), audit.NopAuditStore{}, nil)
+
+			rrID := "rr-it-1811-001"
+			readyForUpgrade := make(chan struct{})
+			upgradeApplied := make(chan struct{})
+			investigationDone := make(chan struct{})
+
+			// Mirrors AA's real submission path: a non-interactive
+			// StartInvestigation call outside the kubernaut_investigate MCP
+			// tool entirely (AA does not call this tool).
+			autoSessionID, err := mgr.StartInvestigation(context.Background(),
+				func(ctx context.Context) (*katypes.InvestigationResult, error) {
+					defer close(investigationDone)
+
+					// Mirrors investigator.emitToSink's RCA-phase progress
+					// events, emitted before anyone has subscribed.
+					session.EmitEvent(ctx, session.InvestigationEvent{
+						Type: session.EventTypeReasoningDelta, Turn: 0, Phase: "rca",
+					})
+
+					// Mirrors the exact CI-observed ordering: AF's
+					// kubernaut_investigate reaches the real
+					// upgradeOrCreateInteractiveSession -> UpgradeToInteractive
+					// call while this goroutine is still running (status is
+					// still StatusRunning, so the upgrade succeeds in-place),
+					// and only afterward does the InteractiveHold check below
+					// observe the flag and short-circuit.
+					close(readyForUpgrade)
+					<-upgradeApplied
+
+					return &katypes.InvestigationResult{
+						RCASummary:      "CrashLoopBackOff: container exits with code 137",
+						InteractiveHold: session.InteractiveUpgradeFromContext(ctx),
+					}, nil
+				},
+				map[string]string{"remediation_id": rrID},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			// Real InvestigateTool wired exactly as production wires it
+			// (cmd/kubernautagent passes the same *session.Manager for both
+			// autoMgr and the HTTP completer).
+			sessionMgr := &mockSessionManager{
+				takeoverSession: &mcpinternal.InteractiveSession{
+					SessionID:     "mcp-sess-it-1811-001",
+					CorrelationID: rrID,
+					ActingUser:    mcpinternal.UserInfo{Username: "sre-user"},
+				},
+			}
+			tool := mcptools.NewInvestigateTool(sessionMgr, &mockInvestigatorRunner{}, &mockContextReconstructor{}, mgr,
+				mcptools.WithHTTPCompleter(mgr))
+
+			By("AF's kubernaut_investigate action=start reaches the real upgrade-in-place path while the goroutine is still mid-RCA-turn")
+			Eventually(readyForUpgrade, 2*time.Second).Should(BeClosed())
+			startOut, startErr := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   rrID,
+				Action: mcptools.ActionStart,
+			}, mcpinternal.UserInfo{Username: "sre-user"})
+			Expect(startErr).NotTo(HaveOccurred())
+			Expect(startOut.InvestigationSessionID).To(Equal(autoSessionID),
+				"handleStart must upgrade the existing autonomous session in-place, not create a fresh fallback session")
+			close(upgradeApplied)
+
+			Eventually(investigationDone, 2*time.Second).Should(BeClosed())
+			Eventually(func() session.Status {
+				sess, _ := mgr.GetSession(autoSessionID)
+				if sess == nil {
+					return ""
+				}
+				return sess.Status
+			}, 2*time.Second).Should(Equal(session.StatusUserDriving),
+				"InteractiveHold must land the session in StatusUserDriving (non-terminal, channel kept open for a later Subscribe)")
+
+			By("registration.go's wireInvestigationEventBridge subscribes strictly after handleStart returns — by which point the race above has already happened")
+			eventCh, subErr := tool.SubscribeEvents(context.Background(), startOut.InvestigationSessionID)
+			Expect(subErr).NotTo(HaveOccurred())
+			Expect(eventCh).NotTo(BeNil())
+
+			var received []session.InvestigationEvent
+			Eventually(func() []session.InvestigationEvent {
+				for {
+					select {
+					case evt := <-eventCh:
+						received = append(received, evt)
+					default:
+						return received
+					}
+				}
+			}, 2*time.Second).Should(HaveLen(2),
+				"IT-KA-1811-001: both the buffered RCA event and the terminal complete event must be replayed to the late subscriber")
+			Expect(received[0].Type).To(Equal(session.EventTypeReasoningDelta))
+			Expect(received[1].Type).To(Equal(session.EventTypeComplete))
+		})
+	})
+})

--- a/internal/kubernautagent/session/event_sink.go
+++ b/internal/kubernautagent/session/event_sink.go
@@ -26,19 +26,46 @@ type eventSinkKey struct{}
 type sessionIDKey struct{}
 type actingUserKey struct{}
 
+// lazySinkBufferCap bounds the number of events LazySink buffers before a
+// channel is attached. Matches eventChannelBuffer (manager.go) so a full
+// replay never overflows the newly-activated channel (#1811).
+const lazySinkBufferCap = 64
+
 // LazySink holds a channel reference that can be set after the context is
 // created. This allows Subscribe to attach the event sink lazily while the
 // investigation goroutine's context is already in flight.
+//
+// #1811: before a channel is attached, Emit buffers events (bounded,
+// oldest-evicted) instead of silently dropping them. Set replays the
+// buffer to the newly-activated channel so a late Subscribe (e.g. AF's
+// kubernaut_investigate racing an autonomous investigation's fast
+// InteractiveHold completion) still delivers everything emitted so far.
 type LazySink struct {
-	mu sync.RWMutex
-	ch chan<- InvestigationEvent
+	mu     sync.RWMutex
+	ch     chan<- InvestigationEvent
+	buffer []InvestigationEvent
 }
 
-// Set assigns the channel. Safe for concurrent use.
+// Set assigns the channel and replays any buffered events (oldest-first,
+// non-blocking) accumulated while no channel was attached. Safe for
+// concurrent use.
 func (ls *LazySink) Set(ch chan<- InvestigationEvent) {
 	ls.mu.Lock()
+	defer ls.mu.Unlock()
 	ls.ch = ch
-	ls.mu.Unlock()
+	if ch == nil || len(ls.buffer) == 0 {
+		return
+	}
+	for _, evt := range ls.buffer {
+		select {
+		case ch <- evt:
+		default:
+			// Newly-created channel is already full (unexpected given it's
+			// sized to eventChannelBuffer >= lazySinkBufferCap) — stop
+			// replay rather than block session activation.
+		}
+	}
+	ls.buffer = nil
 }
 
 // Get returns the channel, or nil if not yet set.
@@ -46,6 +73,29 @@ func (ls *LazySink) Get() chan<- InvestigationEvent {
 	ls.mu.RLock()
 	defer ls.mu.RUnlock()
 	return ls.ch
+}
+
+// Emit sends event to the active channel (non-blocking), or buffers it
+// (bounded, oldest-evicted) if no channel is attached yet. Returns true if
+// the event was sent to an active channel, false if buffered or dropped
+// (channel full). Callers that need to distinguish "buffered for later
+// replay" from "dropped, channel full" should check Get() != nil first.
+func (ls *LazySink) Emit(event InvestigationEvent) bool {
+	ls.mu.Lock()
+	defer ls.mu.Unlock()
+	if ls.ch == nil {
+		ls.buffer = append(ls.buffer, event)
+		if len(ls.buffer) > lazySinkBufferCap {
+			ls.buffer = ls.buffer[len(ls.buffer)-lazySinkBufferCap:]
+		}
+		return false
+	}
+	select {
+	case ls.ch <- event:
+		return true
+	default:
+		return false
+	}
 }
 
 // WithLazySink returns a derived context carrying a LazySink.
@@ -71,6 +121,18 @@ func EventSinkFromContext(ctx context.Context) chan<- InvestigationEvent {
 		return nil
 	}
 	return ls.Get()
+}
+
+// EmitEvent sends event through the LazySink attached to ctx (if any),
+// buffering it for later replay if no channel is attached yet (#1811).
+// Returns false if there is no LazySink on ctx, if the event was buffered,
+// or if the active channel's buffer is full.
+func EmitEvent(ctx context.Context, event InvestigationEvent) bool {
+	ls, ok := ctx.Value(eventSinkKey{}).(*LazySink)
+	if !ok || ls == nil {
+		return false
+	}
+	return ls.Emit(event)
 }
 
 // WithSessionID returns a derived context carrying the session ID so that

--- a/internal/kubernautagent/session/event_sink_test.go
+++ b/internal/kubernautagent/session/event_sink_test.go
@@ -85,6 +85,62 @@ var _ = Describe("Session ID Context Helpers — BR-AUDIT-070", func() {
 	})
 })
 
+var _ = Describe("LazySink Buffered Replay — #1811", func() {
+
+	Describe("UT-KA-1811-001: Emit buffers events when no channel is attached", func() {
+		It("buffers events emitted before Set() and replays them in order once a channel is attached", func() {
+			ls := &session.LazySink{}
+
+			sent := ls.Emit(session.InvestigationEvent{Type: session.EventTypeReasoningDelta, Turn: 0})
+			Expect(sent).To(BeFalse(), "no channel attached yet — Emit must not report a live send")
+
+			sent = ls.Emit(session.InvestigationEvent{Type: session.EventTypeToolCallStart, Turn: 0})
+			Expect(sent).To(BeFalse())
+
+			ch := make(chan session.InvestigationEvent, 8)
+			ls.Set(ch)
+
+			Expect(ch).To(Receive(HaveField("Type", session.EventTypeReasoningDelta)),
+				"buffered event 1 must be replayed first (order preserved)")
+			Expect(ch).To(Receive(HaveField("Type", session.EventTypeToolCallStart)),
+				"buffered event 2 must be replayed second")
+		})
+
+		It("delivers events emitted after Set() immediately, without needing another Set() call", func() {
+			ls := &session.LazySink{}
+			ch := make(chan session.InvestigationEvent, 8)
+			ls.Set(ch)
+
+			sent := ls.Emit(session.InvestigationEvent{Type: session.EventTypeComplete})
+			Expect(sent).To(BeTrue(), "channel already attached — Emit must report a live send")
+			Expect(ch).To(Receive(HaveField("Type", session.EventTypeComplete)))
+		})
+
+		It("bounds the buffer so an autonomous investigation that is never subscribed to cannot grow unbounded", func() {
+			ls := &session.LazySink{}
+			const overCapacity = 200
+			for i := 0; i < overCapacity; i++ {
+				ls.Emit(session.InvestigationEvent{Type: session.EventTypeTokenDelta, Turn: i})
+			}
+
+			ch := make(chan session.InvestigationEvent, overCapacity)
+			ls.Set(ch)
+			close(ch)
+
+			var replayed int
+			var lastTurn int
+			for evt := range ch {
+				replayed++
+				lastTurn = evt.Turn
+			}
+			Expect(replayed).To(BeNumerically("<", overCapacity),
+				"buffer must be capped — not every emitted event can be retained")
+			Expect(lastTurn).To(Equal(overCapacity-1),
+				"oldest events are evicted first — the most recent event must survive")
+		})
+	})
+})
+
 var _ = Describe("Interactive Upgrade Context Helpers — #1390", func() {
 
 	Describe("UT-KA-1390-005 [SC-24]: InteractiveUpgradeFromContext returns false when no flag in context", func() {

--- a/internal/kubernautagent/session/late_subscribe_replay_1811_test.go
+++ b/internal/kubernautagent/session/late_subscribe_replay_1811_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package session_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// Reproduces the exact #1811 ordering: AA submits non-interactively via
+// StartInvestigation (not the "pending" StartInteractiveSession path), the
+// investigation resolves fast enough to hit an InteractiveHold short-circuit
+// (mirrors investigator.checkRCAEarlyReturn) and return *before* AF's
+// kubernaut_investigate call reaches UpgradeToInteractive+Subscribe. Prior to
+// the #1811 fix, every event emitted during that window was silently dropped
+// because LazySink had no memory of emissions that occurred before a channel
+// was attached.
+var _ = Describe("Late-Subscribe Event Replay — AA/AF Interactive-Upgrade Race (#1811)", func() {
+
+	var (
+		store  *session.Store
+		mgr    *session.Manager
+		logger logr.Logger
+	)
+
+	BeforeEach(func() {
+		logger = logr.Discard()
+		store = session.NewStore(10*time.Minute, session.WithLogger(logger))
+		mgr = session.NewManager(store, logger, nil, nil)
+	})
+
+	Describe("UT-KA-1811-002: buffered events survive a late Subscribe after in-place upgrade", func() {
+		It("delivers the RCA-phase events and the terminal complete event to a subscriber that joins after the goroutine already finished", func() {
+			investigationDone := make(chan struct{})
+			readyForUpgrade := make(chan struct{})
+			upgradeApplied := make(chan struct{})
+
+			id, err := mgr.StartInvestigation(context.Background(),
+				func(ctx context.Context) (*katypes.InvestigationResult, error) {
+					defer close(investigationDone)
+
+					// Simulate the RCA phase emitting a couple of progress
+					// events, exactly as investigator.go's emitToSink does —
+					// via the context-carried sink, before anyone has
+					// subscribed (sink is nil at this point).
+					session.EmitEvent(ctx, session.InvestigationEvent{
+						Type: session.EventTypeReasoningDelta, Turn: 0, Phase: "rca",
+					})
+					session.EmitEvent(ctx, session.InvestigationEvent{
+						Type: session.EventTypeToolCallStart, Turn: 0, Phase: "rca",
+					})
+
+					// Mirrors the exact CI-observed ordering: AF's
+					// kubernaut_investigate reaches UpgradeToInteractive
+					// *while the goroutine is still running* (status is
+					// still StatusRunning, so the upgrade succeeds), and
+					// only afterward does investigator.checkRCAEarlyReturn's
+					// InteractiveUpgradeFromContext(ctx) check observe the
+					// flag and short-circuit with InteractiveHold.
+					close(readyForUpgrade)
+					<-upgradeApplied
+
+					return &katypes.InvestigationResult{
+						RCASummary:      "CrashLoopBackOff: container exits with code 137",
+						InteractiveHold: session.InteractiveUpgradeFromContext(ctx),
+					}, nil
+				},
+				map[string]string{"remediation_id": "rr-1811-001"},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			// AF's kubernaut_investigate arrives while the goroutine is
+			// still mid-RCA-turn: upgrade-in-place succeeds (session is
+			// still StatusRunning), exactly as observed in the CI logs.
+			Eventually(readyForUpgrade, 2*time.Second).Should(BeClosed())
+			Expect(mgr.UpgradeToInteractive(id, "sre-user", []string{"sre"})).To(Succeed())
+			close(upgradeApplied)
+
+			Eventually(investigationDone, 2*time.Second).Should(BeClosed())
+			Eventually(func() session.Status {
+				sess, _ := store.Get(id)
+				return sess.Status
+			}, 2*time.Second).Should(Equal(session.StatusUserDriving),
+				"InteractiveHold must land the session in StatusUserDriving (non-terminal, channel kept open)")
+
+			// registration.go's Subscribe wiring runs after handleStart
+			// returns — by which point, in the race, the goroutine has
+			// already emitted (and dropped, pre-fix) everything above.
+			eventCh, subErr := mgr.Subscribe(context.Background(), id)
+			Expect(subErr).NotTo(HaveOccurred())
+
+			var received []session.InvestigationEvent
+			Eventually(func() int {
+				for {
+					select {
+					case evt, ok := <-eventCh:
+						if !ok {
+							return len(received)
+						}
+						received = append(received, evt)
+					default:
+						return len(received)
+					}
+				}
+			}, 2*time.Second).Should(BeNumerically(">=", 3),
+				"the 2 buffered RCA events plus the terminal complete event must all be replayed")
+
+			Expect(received[0].Type).To(Equal(session.EventTypeReasoningDelta))
+			Expect(received[1].Type).To(Equal(session.EventTypeToolCallStart))
+			Expect(received[2].Type).To(Equal(session.EventTypeComplete),
+				"emitCompleteEvent's terminal event must also survive the buffering/replay path")
+			Expect(string(received[2].Data)).To(ContainSubstring("CrashLoopBackOff"),
+				"the replayed complete event must carry the real RCA content, not an empty placeholder")
+		})
+	})
+
+	Describe("UT-KA-1811-003: already-working case (sink active before emission) is unaffected", func() {
+		It("delivers events live with no duplication when Subscribe happens before the goroutine emits", func() {
+			pendingID, err := mgr.StartInteractiveSession(context.Background(),
+				func(ctx context.Context) (*katypes.InvestigationResult, error) {
+					session.EmitEvent(ctx, session.InvestigationEvent{Type: session.EventTypeReasoningDelta, Turn: 0})
+					return &katypes.InvestigationResult{RCASummary: "ok"}, nil
+				},
+				map[string]string{"remediation_id": "rr-1811-002"},
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mgr.LaunchDeferredInvestigation(pendingID)).To(Succeed())
+
+			eventCh, subErr := mgr.Subscribe(context.Background(), pendingID)
+			Expect(subErr).NotTo(HaveOccurred())
+
+			var received []session.InvestigationEvent
+			for evt := range eventCh {
+				received = append(received, evt)
+			}
+
+			Expect(received).To(HaveLen(2), "exactly the 1 live event + 1 complete event — no duplicate replay")
+			Expect(received[0].Type).To(Equal(session.EventTypeReasoningDelta))
+			Expect(received[1].Type).To(Equal(session.EventTypeComplete))
+		})
+	})
+})

--- a/internal/kubernautagent/session/manager.go
+++ b/internal/kubernautagent/session/manager.go
@@ -909,14 +909,10 @@ func (m *Manager) emitCompleteEvent(id string, result *katypes.InvestigationResu
 	if sink == nil {
 		return
 	}
-	ch := sink.Get()
-	if ch == nil {
-		return
-	}
-	select {
-	case ch <- InvestigationEvent{Type: EventTypeComplete, Data: MarshalRCASubset(result)}:
-	default:
-	}
+	// #1811: route through Emit (not Get()+manual send) so this terminal
+	// event is buffered and replayed if no one has subscribed yet — e.g. an
+	// InteractiveHold completion that races ahead of AF's kubernaut_investigate.
+	sink.Emit(InvestigationEvent{Type: EventTypeComplete, Data: MarshalRCASubset(result)})
 }
 
 // EmitSessionEndedByRR emits a terminal InvestigationEvent with the given
@@ -951,17 +947,20 @@ func (m *Manager) emitTerminalEvent(id, reason string) {
 			"session_id", id, "reason", reason)
 		return
 	}
-	ch := sink.Get()
-	if ch == nil {
-		m.logger.V(1).Info("emitTerminalEvent: sink channel is nil",
-			"session_id", id, "reason", reason)
-		return
-	}
-	select {
-	case ch <- InvestigationEvent{Type: EventTypeSessionEnded, Phase: reason}:
-	default:
-		m.logger.Info("terminal event dropped: channel full",
-			"session_id", id, "reason", reason)
+	// #1811: route through Emit so a not-yet-subscribed observer still gets
+	// this terminal event replayed once it does Subscribe, instead of it
+	// being silently and permanently lost. hadChannel distinguishes
+	// "buffered for later replay" (no active subscriber yet) from the
+	// pre-existing "channel full" drop case for accurate SI-4 logging.
+	hadChannel := sink.Get() != nil
+	if sent := sink.Emit(InvestigationEvent{Type: EventTypeSessionEnded, Phase: reason}); !sent {
+		if hadChannel {
+			m.logger.Info("terminal event dropped: channel full",
+				"session_id", id, "reason", reason)
+		} else {
+			m.logger.V(1).Info("terminal event buffered for replay: no active subscriber yet",
+				"session_id", id, "reason", reason)
+		}
 	}
 }
 

--- a/internal/kubernautagent/session/terminal_event_1438_test.go
+++ b/internal/kubernautagent/session/terminal_event_1438_test.go
@@ -51,6 +51,14 @@ var _ = Describe("Terminal event before session release (#1438)", func() {
 			ch, err := mgr.Subscribe(context.Background(), id)
 			Expect(err).NotTo(HaveOccurred())
 
+			// #1811: the InteractiveHold completion's own EventTypeComplete
+			// was emitted before this late Subscribe and is now correctly
+			// replayed (previously silently lost) — drain it first so this
+			// test can assert on the session_ended event specifically.
+			var completeEvt session.InvestigationEvent
+			Eventually(ch, 2*time.Second).Should(Receive(&completeEvt))
+			Expect(completeEvt.Type).To(Equal(session.EventTypeComplete))
+
 			mgr.EmitSessionEndedByRR("rr-1438-001", "inactivity_timeout")
 
 			var evt session.InvestigationEvent
@@ -88,6 +96,13 @@ var _ = Describe("Terminal event before session release (#1438)", func() {
 
 			ch, err := mgr.Subscribe(context.Background(), id)
 			Expect(err).NotTo(HaveOccurred())
+
+			// #1811: drain the InteractiveHold completion's replayed
+			// EventTypeComplete (previously silently lost pre-#1811 fix)
+			// before asserting on the absence of a session_ended event below.
+			var completeEvt session.InvestigationEvent
+			Eventually(ch, 2*time.Second).Should(Receive(&completeEvt))
+			Expect(completeEvt.Type).To(Equal(session.EventTypeComplete))
 
 			err = mgr.CompleteUserDriving(id, &katypes.InvestigationResult{WorkflowID: "wf-done"})
 			Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
## Summary

Backport of #1811's fix (main-branch PR #1816) to `release/v1.5`.

- Same architecture, same bug: `LazySink.Get()` returns `nil` until a channel is attached via `Subscribe`, so any event emitted by an autonomous investigation that completes fast enough to hit `InteractiveHold` before AF's `kubernaut_investigate` call reaches `UpgradeToInteractive`+`Subscribe` was silently and permanently dropped.
- Adds `LazySink.Emit` (buffers events, bounded at `eventChannelBuffer`=64, when no channel is attached yet) and a context-based `session.EmitEvent` helper. `LazySink.Set` now replays the buffer to a newly-activated channel.
- Routes `investigator.emitToSink` and `manager.go`'s `emitCompleteEvent`/`emitTerminalEvent` through this buffering path instead of the previous "`Get()` then manual `select`" pattern that had no memory of pre-`Subscribe` emissions.

`v1.5` has a different (pre-#1390-refactor) file layout than `main` — `launchInvestigation`, `emitCompleteEvent`, `emitTerminalEvent`, and `FindByRemediationID`/`FindPendingByRemediationID` all live in one `session/manager.go`, and `emitToSink` lives in `investigator/investigator.go` rather than a split `investigator_loop.go` — but the `LazySink`/`InteractiveHold` architecture and the race itself are identical, confirmed during #1811 triage on `v1.5`.

## Test plan

See [`docs/testing/1811/TEST_PLAN.md`](https://github.com/jordigilh/kubernaut/blob/main/docs/testing/1811/TEST_PLAN.md) on `main` for the full root cause, fix design, and FedRAMP mapping (SI-4, AU-3) — same analysis applies here; test IDs preserved for traceability:

| ID | Tier | Description |
|---|---|---|
| UT-KA-1811-001 | Unit | `LazySink.Emit` buffers events (bounded, oldest-evicted) when no channel is attached, and `Set` replays them in order — `event_sink_test.go` |
| UT-KA-1811-002 | Unit | Reproduces the exact race: `StartInvestigation` → in-place `UpgradeToInteractive` while still running → `InteractiveHold` completion → late `Subscribe` still delivers everything — `late_subscribe_replay_1811_test.go` (new) |
| UT-KA-1811-003 | Unit | Regression guard: already-working case (sink active before emission) is unaffected — `late_subscribe_replay_1811_test.go` (new) |
| IT-KA-1811-001 | Integration | Real `InvestigateTool.Handle`(action=start)/`SubscribeEvents` wiring, proving the production dispatch path — `late_subscribe_replay_1811_it_test.go` (new) |
| UT-KA-1438-001/002 | Unit (updated) | Updated to drain the now-correctly-replayed `EventTypeComplete` event before asserting on `session_ended` |

## Validation

- `go build ./...` — clean
- `go vet ./...` — clean
- `golangci-lint run` (session/investigator/mcp-tools packages) — 0 issues
- Full `internal/kubernautagent/...` unit suite — all packages pass, 0 regressions

## Note

`v1.5` does not need the follow-up E2E hardening revert from main's PR #1816 — `E2E-FP-1189-005` does not exist on this branch. The newly-discovered orphaned-RCA race ([#1818](https://github.com/jordigilh/kubernaut/issues/1818), found while hardening that E2E test on `main`) has **not** been triaged against `v1.5` yet — tracked separately as a follow-up.

Closes #1811 (v1.5 track)

Made with [Cursor](https://cursor.com)