### PR TITLE
fix(apifrontend): fail fast on unrecognized model family under provider: vertex_ai (#1792 v1.5 backport)

### DIFF
--- a/pkg/apifrontend/launcher/model.go
+++ b/pkg/apifrontend/launcher/model.go
@@ -58,7 +58,28 @@ func NewModelFromConfig(ctx context.Context, cfg config.LLMConfig) (model.LLM, e
 	}
 }
 
+// isVertexAnthropicModel reports whether model names a Claude-family model,
+// the only model family newVertexAIModel can actually construct on this
+// branch. Deliberately kept local rather than imported from
+// pkg/apifrontend/severity.IsAnthropicModel: this is a fail-fast guard
+// only (#1792 v1.5 backport, minimal-risk option), not a step toward
+// sharing detection logic across packages the way main's
+// types.IsAnthropicModel/IsGeminiModel promotion does.
+func isVertexAnthropicModel(model string) bool {
+	return strings.HasPrefix(model, "claude-")
+}
+
+// newVertexAIModel constructs the Vertex AI model client. vertex_ai can
+// host either Claude or Gemini models, but this branch only implements the
+// Claude path (adk-anthropic-go) — unlike main (#1778, #1792), which added
+// a native Vertex-hosted-Gemini client. A non-Claude model name here fails
+// fast with a clear, actionable error instead of silently constructing an
+// Anthropic client that would fail later with a confusing SDK-level error
+// (#1792 v1.5 backport).
 func newVertexAIModel(ctx context.Context, cfg config.LLMConfig) (m model.LLM, err error) {
+	if !isVertexAnthropicModel(cfg.Model) {
+		return nil, fmt.Errorf("vertex_ai: unrecognized model family for model %q (only claude-* models are supported under provider: vertex_ai on this release; use provider: gemini for direct-API Gemini)", cfg.Model)
+	}
 	defer func() {
 		if r := recover(); r != nil {
 			err = fmt.Errorf("vertex_ai: GCP ADC unavailable — set GOOGLE_APPLICATION_CREDENTIALS or provide credentials: %v", r)

--- a/pkg/apifrontend/launcher/model_test.go
+++ b/pkg/apifrontend/launcher/model_test.go
@@ -56,6 +56,24 @@ var _ = Describe("Model Factory", func() {
 			}
 		})
 
+		// IT-AF-1792-005: vertex_ai with an unrecognized (non-Claude) model
+		// family fails fast with a clear, actionable error instead of
+		// silently misconstructing an Anthropic client and failing later
+		// with a confusing SDK-level error. v1.5 fail-fast-only backport of
+		// #1792 -- unlike main, v1.5 does not carry native Vertex-hosted-
+		// Gemini support (tracked separately as a follow-up decision).
+		It("IT-AF-1792-005: vertex_ai with an unrecognized model family fails fast with a clear error", func() {
+			cfg := config.LLMConfig{
+				Provider:       config.LLMProviderVertexAI,
+				Model:          "gemini-2.5-pro",
+				VertexProject:  "test-project",
+				VertexLocation: "us-central1",
+			}
+			_, err := launcher.NewModelFromConfig(context.Background(), cfg)
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("unrecognized model family"))
+		})
+
 		// UT-AF-1254-010: factory dispatches to openai_compatible adapter
 		It("UT-AF-1254-010: constructs openai_compatible model with endpoint", func() {
 			cfg := config.LLMConfig{


### PR DESCRIPTION
## Summary

Minimal-risk backport of #1792 to `release/v1.5`.

- `newVertexAIModel` unconditionally constructed an Anthropic-typed ADK model regardless of the configured model name, so `provider: vertex_ai` with a Gemini model (e.g. `gemini-2.5-pro`) silently misrouted through `adkanthropic.NewModel` and failed later with a confusing SDK-level error instead of a clear one.
- This is the **minimal-risk** backport option, not full parity with `main`'s fix (PR #1797): `main` added a native Vertex-hosted-Gemini client (`credentials.DetectDefault` + `httptransport.NewClient`, promoting `IsAnthropicModel`/`IsGeminiModel` to `pkg/shared/types`), which depends on infrastructure not present on `v1.5` and would add new direct dependencies to a stable release branch.
- `v1.5` instead fails fast with a clear, actionable error identifying the unsupported combination — the "at minimum" option #1792 itself proposed.
- `isVertexAnthropicModel` is deliberately kept local to `pkg/apifrontend/launcher` rather than reusing `pkg/apifrontend/severity.IsAnthropicModel` (which already exists on v1.5 for the unrelated #1404 severity-triage lane): this is a fail-fast guard only, not a step toward cross-package sharing.

Full native Vertex-hosted-Gemini support for v1.5 (if wanted) is a separate, larger follow-up decision — not addressed by this fix.

## Test plan

| ID | Description |
|---|---|
| IT-AF-1792-005 | `vertex_ai` + unrecognized model family fails fast with a clear error (new) |
| UT-AF-1252-004 | `vertex_ai` + Claude model — unaffected (regression guard) |
| UT-AF-1252-002 | `provider: gemini` (direct API) — unaffected (regression guard) |

## Validation

- `go build ./...` — clean
- `go vet ./pkg/apifrontend/... ./cmd/apifrontend/...` — clean
- `golangci-lint run` (launcher package) — 0 issues
- Full `pkg/apifrontend/...` and `cmd/apifrontend/...` suites — all pass, 0 regressions

Closes #1792 (v1.5 track)

Made with [Cursor](https://cursor.com)