### PR TITLE
fix(kubernautagent): use peak-concurrency, not wall-clock, to prove IT-KA-970-001 parallelism (#1552 v1.5 backport)

### DIFF
--- a/test/integration/kubernautagent/investigator/investigator_parallel_test.go
+++ b/test/integration/kubernautagent/investigator/investigator_parallel_test.go
@@ -28,6 +28,7 @@ type delayedFakeTool struct {
 	result    string
 	delay     time.Duration
 	active    *atomic.Int32
+	peak      *atomic.Int32
 	execCount *atomic.Int32
 }
 
@@ -36,8 +37,16 @@ func (f *delayedFakeTool) Description() string         { return "delayed fake " 
 func (f *delayedFakeTool) Parameters() json.RawMessage { return nil }
 func (f *delayedFakeTool) Execute(ctx context.Context, _ json.RawMessage) (string, error) {
 	if f.active != nil {
-		f.active.Add(1)
+		cur := f.active.Add(1)
 		defer f.active.Add(-1)
+		if f.peak != nil {
+			for {
+				p := f.peak.Load()
+				if cur <= p || f.peak.CompareAndSwap(p, cur) {
+					break
+				}
+			}
+		}
 	}
 	if f.execCount != nil {
 		f.execCount.Add(1)
@@ -110,10 +119,12 @@ var _ = Describe("BR-PERFORMANCE-970: Parallel Tool Execution in runLLMLoop", fu
 			const toolDelay = 100 * time.Millisecond
 			const numTools = 4
 
+			active := &atomic.Int32{}
+			peak := &atomic.Int32{}
 			reg := registry.New()
 			toolNames := []string{"kubectl_describe", "kubectl_events", "kubectl_logs", "kubectl_get_by_name"}
 			for _, tn := range toolNames {
-				reg.Register(&delayedFakeTool{name: tn, result: fmt.Sprintf(`{"tool":"%s","status":"ok"}`, tn), delay: toolDelay})
+				reg.Register(&delayedFakeTool{name: tn, result: fmt.Sprintf(`{"tool":"%s","status":"ok"}`, tn), delay: toolDelay, active: active, peak: peak})
 			}
 
 			toolCalls := make([]llm.ToolCall, numTools)
@@ -149,9 +160,27 @@ var _ = Describe("BR-PERFORMANCE-970: Parallel Tool Execution in runLLMLoop", fu
 			elapsed := time.Since(start)
 			Expect(err).NotTo(HaveOccurred())
 
-			sequentialBaseline := time.Duration(numTools) * toolDelay
-			Expect(elapsed).To(BeNumerically("<", time.Duration(float64(sequentialBaseline)*0.6)),
-				"parallel execution should complete in < 60%% of sequential baseline (%v); got %v", sequentialBaseline, elapsed)
+			// PRIMARY proof of parallelism (#1552): peak concurrent active tool
+			// executions is a deterministic structural signal, unlike wall-clock
+			// timing. A tight elapsed-vs-sequential-baseline assertion is
+			// intrinsically flaky on shared CI runners -- this exact check was
+			// already loosened once (0.6x -> 1.0x sequential baseline on main,
+			// commit 7c4c14d3b) and still failed at 941ms and 852ms against the
+			// 800ms (1.0x) ceiling despite genuinely parallel dispatch. If
+			// dispatch ever regressed to sequential, peak would deterministically
+			// be 1, not a value that only sometimes drifts past a timing
+			// threshold.
+			Expect(peak.Load()).To(Equal(int32(numTools)),
+				"all %d tool calls should have been in flight concurrently at some point, proving genuine parallel dispatch rather than a sequential fallback", numTools)
+
+			// SECONDARY sanity ceiling: guards against a true hang, not tuned to
+			// prove speed. Anchored to a single tool's delay plus a large fixed
+			// margin (not a multiple of numTools) so CI scheduling jitter can
+			// never trip it; a real sequential-fallback regression would still
+			// be caught above by the peak-concurrency assertion.
+			sanityCeiling := toolDelay + 5*time.Second
+			Expect(elapsed).To(BeNumerically("<", sanityCeiling),
+				"parallel execution took %v, exceeding the generous sanity ceiling of %v -- possible hang", elapsed, sanityCeiling)
 
 			// Verify message ordering: the 2nd LLM call's messages should end with
 			// tool results in declaration order (tc_0, tc_1, tc_2, tc_3)


### PR DESCRIPTION
## Summary

Backports the fix for #1552 from `main` (cherry-picked from `ce4602ee0`) to `release/v1.5`. `release/v1.5` still had the original `elapsed < 0.6 * sequentialBaseline` hard wall-clock assertion (pre-dating `main`'s intermediate loosening to `1.0x` in `7c4c14d3b`), which is intrinsically flaky on shared CI runners per the issue's documented history (flaked twice already on `main` even after loosening).

Replaces the timing-based assertion with the same fix already merged to `main`:
- **PRIMARY proof of parallelism**: assert peak concurrent active tool executions (`peak.Load() == numTools`) — a deterministic structural signal that a real sequential-dispatch regression would still catch (peak would be 1).
- **SECONDARY sanity ceiling**: `elapsed < toolDelay + 5s`, a fixed margin anchored to a single tool's delay (not scaled by `numTools`), loose enough that CI scheduling jitter can never trip it — only guards against a true hang.

`toolDelay` remains `100ms` on this branch (unchanged, not touched by this fix), so the sanity ceiling here is `5.1s`.

## Test plan

- [x] `IT-KA-970-001/002/003` (`test/integration/kubernautagent/investigator/investigator_parallel_test.go`) — all 3 pass locally
- [x] Full `investigator` integration suite (117 specs) — PASS, 0 regressions
- [x] `go build ./...`, `go vet` on the package — PASS
- [x] `golangci-lint run` on the package — 0 issues

Related: #1552

🤖 Generated with [Cursor](https://cursor.com)

Made with [Cursor](https://cursor.com)