### PR TITLE
fix(ci): bump v1.5 golangci-lint timeout 5m->10m to match main

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -110,7 +110,11 @@ jobs:
     needs: [detect-changes]
     if: needs.detect-changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 8
+    # Bumped from 8 to match main's 15: golangci-lint's own --timeout is now
+    # 10m (see .golangci.yml), so the enclosing job needs enough headroom for
+    # that plus checkout/setup-go/generate/validate-embed steps that run
+    # before it.
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -146,7 +150,7 @@ jobs:
         uses: golangci/golangci-lint-action@v9
         with:
           version: v2.9.0
-          args: cmd/... pkg/... internal/... test/...
+          args: --timeout=10m cmd/... pkg/... internal/... test/...
           only-new-issues: true
 
       - name: Dependency vulnerability scan (govulncheck)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -4,7 +4,12 @@
 version: "2"
 
 run:
-  timeout: 5m
+  # Bumped from 5m: as of 2026-08, `golangci-lint run` against the full
+  # cmd/... pkg/... internal/... test/... tree routinely completes right at
+  # or just over the old 5m ceiling (observed 304s/"0 issues" immediately
+  # followed by a timeout failure on PRs #1821 and #1824's CI, previously
+  # misdiagnosed as a transient CI infra flake). Matches `main`'s value.
+  timeout: 10m
   tests: true
 
 linters:


### PR DESCRIPTION
## Summary

\`release/v1.5\`'s \`Lint (Go Services)\` CI job has been intermittently failing with a golangci-lint internal timeout, previously (mis)diagnosed twice as a transient CI infrastructure flake while triaging #1821 and #1824 -- both showed the identical signature:

\`\`\`
0 issues.

level=error msg="Timeout exceeded: try increasing it by passing --timeout option"

##[error]golangci-lint exit with code 4
Ran golangci-lint in 304608ms
\`\`\`

**Root cause**: \`release/v1.5\`'s \`.golangci.yml\` still has \`run.timeout: 5m\` (never bumped, unlike \`main\` which is at \`10m\`), and its CI workflow's \`golangci-lint-action\` \`args\` never pass a \`--timeout\` override either (\`main\`'s does: \`--timeout=10m\`). As the codebase has grown, a full \`golangci-lint run\` against \`cmd/... pkg/... internal/... test/...\` on \`v1.5\` now routinely completes right at or just over the old 5-minute ceiling -- lint itself finishes ("0 issues.") but golangci-lint's own internal deadline fires within the same instant, so the job fails nondeterministically depending on runner load/cache warmth.

Confirmed locally: a full run against this branch's current tree, with a warm cache and \`--timeout=10m\`, completes cleanly in ~52s. CI runners are slower/more contended, which is why this borderline case surfaces there and not locally.

## Changes

- \`.golangci.yml\`: \`run.timeout\` \`5m\` → \`10m\` (matches \`main\`)
- \`.github/workflows/ci-pipeline.yml\`:
  - \`lint-go\` job \`timeout-minutes\` \`8\` → \`15\` (matches \`main\`; needed headroom now that golangci-lint's own timeout is 10m, plus the checkout/setup-go/generate/validate-embed steps that run before it)
  - Pass \`--timeout=10m\` explicitly to \`golangci-lint-action\`'s \`args\` as defense-in-depth (matches \`main\`'s pattern), rather than relying solely on the config file value

No production code changes -- CI configuration only.

## Test plan

- [x] \`golangci-lint config verify\` -- passes
- [x] \`golangci-lint run --timeout=10m cmd/... pkg/... internal/... test/...\` locally -- 0 issues, ~52s
- [x] \`go build ./...\` -- passes
- [x] YAML syntax validated for both modified files
- [ ] CI: \`Lint (Go Services)\` job on this PR itself (self-validating)

Made with [Cursor](https://cursor.com)