### PR TITLE
fix(apifrontend): backport #1658 -- prevent raw tool-call arg leak when alert tools are disabled (v1.5)

### DIFF
--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -945,9 +945,14 @@ func buildA2AHandler(ctx context.Context, cfg *config.Config, deps *backendDeps,
 
 	activeCtxRegistry := launcher.NewActiveContextRegistry(launcher.DefaultRegistryTTL, launcher.DefaultRegistryIdleTimeout)
 
+	// #1658: alertToolsEnabled must mirror the same cfg.PromClient != nil gate
+	// NewRootAgent uses to decide whether to register list_alerts/get_alert_details/
+	// kubernaut_investigate_alert, so the prompt never advertises tools that
+	// aren't actually callable.
+	alertToolsEnabled := deps.PromClient != nil
 	rootAgent, _, err := agentpkg.NewRootAgent(agentpkg.AgentConfig{
-		Instruction:           agentpkg.BuildInstruction(cfg.Session.Namespace),
-		InstructionProvider:   agentpkg.NewInstructionProvider(cfg.Session.Namespace),
+		Instruction:           agentpkg.BuildInstruction(cfg.Session.Namespace, alertToolsEnabled),
+		InstructionProvider:   agentpkg.NewInstructionProvider(cfg.Session.Namespace, alertToolsEnabled),
 		LLMModel:              llmModel,
 		Namespace:             cfg.Session.Namespace,
 		K8sClient:             deps.K8sClient(),

--- a/docs/testing/1658/TEST_PLAN.md
+++ b/docs/testing/1658/TEST_PLAN.md
@@ -1,0 +1,114 @@
+# Test Plan: AF Raw Tool-Call Arg Leak on Unavailable Alert Tools
+
+**Issue**: [#1658](https://github.com/jordigilh/kubernaut/issues/1658)
+**Business Requirements**: BR-AI-023 (detect/handle AI hallucinations or invalid responses), BR-AI-024 (graceful degradation when a dependency is unavailable)
+**Branch**: `fix/1658-af-tool-error-leak` (originally against `main`); this copy backported verbatim to `release/v1.5` on `fix/1658-backport-v1.5` — same root cause and fix present on both branches, only `main`'s fleet-federation `ResourceReader` abstraction (`DynamicResourceReader`) is absent on v1.5, so `UT-AF-1658-020` calls `HandleKubectlList` with the raw `dynamic.Interface` there instead.
+**Created**: 2026-08-01
+**Status**: Complete — all scenarios in Section 3 pass
+
+---
+
+## 1. Purpose
+
+When `severityTriage.enabled: false` (`cfg.PromClient == nil`), API Frontend does not
+register `list_alerts`/`get_alert_details`/`kubernaut_investigate_alert` (gated in
+`pkg/apifrontend/agent/root.go`'s `buildToolList` on `cfg.PromClient != nil`). The system
+prompt (`pkg/apifrontend/agent/prompt.go`'s `BuildInstruction`), however, unconditionally
+advertised these tools regardless of whether they were actually registered. If a user then
+asked to "list active alerts", the LLM had no purpose-built alert tool available in its
+function-calling schema and fell back to the generic `kubectl_list` tool, guessing
+`kind: "Alert"` (not a real Kubernetes/Kubernaut resource kind). The tool call failed
+(`ErrInvalidInput: cannot resolve GVK for kind "Alert"`), and instead of explaining the
+failure in natural language, the model's next-turn text echoed the raw tool-call arguments
+back to the user as the final chat response.
+
+### Root cause (confirmed via code read, not just issue inference)
+
+Two independent gaps, both required to fully close this class of bug:
+
+1. **Prompt/registration mismatch** (`pkg/apifrontend/agent/prompt.go`): `BuildInstruction`
+   took only a `namespace` parameter and had no way to know whether `alertToolConstructors`
+   (`root.go:183`) were actually included in the tool list passed to the LLM. The model was
+   told alert tools exist unconditionally, so a confused/weak model would attempt to use them
+   via the closest available substitute (`kubectl_list`) rather than saying they're
+   unavailable.
+2. **No generic tool-error-to-natural-language mandate**: the existing
+   `## Structured Artifact Contract (#1408)` directive in `prompt.txt` only mandates
+   `present_decision`-based failure handling for `kubernaut_investigate`/
+   `kubernaut_discover_workflows` — it does not cover generic observation-tool failures like
+   `kubectl_list`/`kubectl_get`. Nothing told the model it must never surface raw tool-call
+   arguments/JSON as its final answer for *any* tool.
+
+Kubernaut's own error-plumbing (`pkg/apifrontend/launcher/part_converter.go`'s
+`toolErrorPart`, #1302) already correctly routes tool-error `FunctionResponse`s to the
+reasoning/thinking stream, never as a definitive artifact, and the ADK agent loop always
+re-invokes the LLM after a tool error (never bypasses it). The leak was therefore not a
+plumbing bypass — it was the LLM's own next-turn text, produced with no guardrail against
+restating/echoing a failed call's arguments, passing through untouched as genuine assistant
+text.
+
+## 2. Fix Design
+
+1. **Conditional prompt content** (`pkg/apifrontend/agent/prompt.go`): `BuildInstruction`
+   and `NewInstructionProvider` take a new `alertToolsEnabled bool` parameter, threaded from
+   the same `cfg.PromClient != nil` check used by `buildToolList` (wired at the single
+   production call site, `cmd/apifrontend/mcp_a2a_handlers.go`'s `buildRootAgentConfig`).
+   When `false`, the appended "Tool Usage Rules" section omits `list_alerts`/
+   `get_alert_details`/`kubernaut_investigate_alert` from the tool list and observation
+   permission line, and instead explicitly states these tools are unavailable, that "Alert"
+   is not a Kubernetes resource kind, and that the model should explain unavailability rather
+   than guess. The immutable embedded `prompt.txt` base is untouched (SC-7) — this is
+   additive, per-deployment guidance exactly like the existing namespace/CRD-type context.
+2. **Generic tool-failure mandate** (`pkg/apifrontend/agent/prompt.txt`): added
+   `## Behavioral Constraints` item 5 — any tool error MUST be explained in natural language;
+   raw tool-call arguments/JSON/error objects must never be surfaced verbatim. This is
+   deliberately broader than the existing `present_decision`-scoped mandate (#1408, item 3 of
+   the Structured Artifact Contract) since it must cover every tool, not just the two
+   investigation-flow tools that already funnel through a structured artifact.
+3. **Test coverage gap closed**: `kubectl_list` had no test for an unresolvable `Kind` (the
+   exact failure mode in this issue), unlike its `kubectl_get` sibling
+   (`UT-AF-1230-009`). Added `UT-AF-1658-020` mirroring that pattern with `Kind: "Alert"`.
+
+Out of scope (not needed once 1-2 above close the root cause, and avoids unnecessary
+special-casing): a `kubectl_list`/`kubectl_get` runtime guard for well-known "looks like it
+should exist but doesn't" kind guesses (issue's suggested fix #3). The unresolved-kind error
+message (`cannot resolve GVK for kind "Alert"`) already gives the LLM enough signal once it
+is also told (via fix 1) that alert tools are unavailable and (via fix 2) that it must
+explain tool failures rather than echo them.
+
+## 3. Pyramid Invariant — Test Scenario Inventory
+
+| ID | Tier | Business-Level Behavior Description | BR | Test File |
+|---|---|---|---|---|
+| UT-AF-1658-001 | Unit | `alertToolsEnabled=true` preserves existing behavior: prompt advertises `list_alerts`/`get_alert_details`/`kubernaut_investigate_alert` | BR-AI-024 | `pkg/apifrontend/agent/prompt_test.go` |
+| UT-AF-1658-002 | Unit | `alertToolsEnabled=false` omits alert tools from the observation-tool permission line and the Prometheus/Thanos usage guidance | BR-AI-024 | `pkg/apifrontend/agent/prompt_test.go` |
+| UT-AF-1658-003 | Unit | `alertToolsEnabled=false` explicitly states alert querying is unavailable in this deployment | BR-AI-024 | `pkg/apifrontend/agent/prompt_test.go` |
+| UT-AF-1658-004 | Unit | `alertToolsEnabled=false` instructs the model not to guess a `kubectl_list`/`kubectl_get` kind (e.g. `"Alert"`) for alert queries | BR-AI-023 | `pkg/apifrontend/agent/prompt_test.go` |
+| UT-AF-1658-005 | Unit | `alertToolsEnabled=false` still contains the immutable core prompt (SC-7 regression guard) | BR-AI-024 | `pkg/apifrontend/agent/prompt_test.go` |
+| UT-AF-1658-010 | Unit | Base embedded prompt mandates a natural-language explanation for any tool error and forbids surfacing raw tool-call arguments | BR-AI-023 | `pkg/apifrontend/agent/prompt_test.go` |
+| UT-AF-1658-020 | Unit | `kubectl_list` with an unresolvable, guessed non-K8s kind (e.g. `"Alert"`) returns an `invalid input` error (closes prior coverage gap relative to `kubectl_get`'s `UT-AF-1230-009`) | BR-AI-023 | `pkg/apifrontend/tools/kubectl_list_test.go` |
+
+### Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | Test ID |
+|---|---|---|---|
+| `alertToolsEnabled` conditioning | `cmd/apifrontend/main.go` startup (A2A handler construction) | `cmd/apifrontend/mcp_a2a_handlers.go`'s `buildRootAgentConfig`, threading `d.Backends.PromClient != nil` into both `BuildInstruction` and `NewInstructionProvider` | Existing `IT-AF-1367-*`/`IT-AF-1372-*` (root.go tool-registration gating, unchanged) prove the same `PromClient` gate; UT-AF-1658-001..005 prove the prompt side matches it |
+
+No new production components — this makes an existing config-derived tool-registration gate
+also drive the prompt content that describes those tools, and adds a missing general
+error-handling directive to the existing prompt.
+
+## 4. Final Results
+
+All scenarios pass locally against `origin/main` (`go build ./...`, `go vet ./...`,
+`golangci-lint run` all clean):
+
+| ID | Result |
+|---|---|
+| UT-AF-1658-001..005, 010 | PASS |
+| UT-AF-1658-020 | PASS |
+| Full `pkg/apifrontend/agent` suite (167 specs) | PASS (0 regressions) |
+| Full `pkg/apifrontend/tools` suite (632 specs) | PASS (0 regressions) |
+| Full `pkg/apifrontend/...` suite | PASS (0 regressions) |
+| `go build ./...`, `go vet ./...` | PASS |
+| `golangci-lint run` (changed packages) | 0 issues |

--- a/pkg/apifrontend/agent/prompt.go
+++ b/pkg/apifrontend/agent/prompt.go
@@ -45,7 +45,17 @@ func defaultInstruction() string {
 // BuildInstruction constructs the full agent instruction by appending deployment
 // context (namespace, CRD types) to the immutable embedded prompt. The core prompt
 // is never modified — this function only appends (SC-7 boundary protection).
-func BuildInstruction(namespace string) string {
+//
+// alertToolsEnabled reflects whether list_alerts/get_alert_details/
+// kubernaut_investigate_alert are actually registered in the tool list (gated
+// on cfg.PromClient != nil — see agentpkg.buildToolList). When false, the
+// appended guidance omits those tools from the observation permission list and
+// explicitly tells the model alert querying is unavailable, rather than
+// silently advertising tools it cannot call. This closes the gap where the
+// model, told alert tools exist but unable to invoke them, would fall back to
+// guessing an invalid kubectl_list kind (e.g. "Alert") and leak the raw,
+// failed tool-call arguments back to the user (#1658).
+func BuildInstruction(namespace string, alertToolsEnabled bool) string {
 	if namespace == "" {
 		namespace = "default"
 	}
@@ -62,15 +72,27 @@ func BuildInstruction(namespace string) string {
 	sb.WriteString("SignalProcessing, EffectivenessAssessment, WorkflowExecution, ActionType, NotificationRequest\n")
 	sb.WriteString("\n## Tool Usage Rules\n")
 	sb.WriteString("- For investigation and remediation, always use kubernaut MCP tools (kubernaut_investigate, ")
-	sb.WriteString("kubernaut_investigate_alert, kubernaut_remediate, kubernaut_discover_workflows, ")
+	if alertToolsEnabled {
+		sb.WriteString("kubernaut_investigate_alert, ")
+	}
+	sb.WriteString("kubernaut_remediate, kubernaut_discover_workflows, ")
 	sb.WriteString("kubernaut_select_workflow, kubernaut_watch). ")
 	sb.WriteString("NEVER use kubectl tools directly for investigation or remediation actions.\n")
-	sb.WriteString("- kubectl_get, kubectl_list, kubectl_list_events, list_alerts, and get_alert_details are permitted ONLY for observation (reading cluster state).\n")
-	sb.WriteString("- list_alerts and get_alert_details query Prometheus/Thanos for currently firing or pending alerts. ")
-	sb.WriteString("Use them for preflight investigation context before delegating to kubernaut_investigate or kubernaut_investigate_alert.\n")
-	sb.WriteString("- kubernaut_investigate_alert: use when you know the specific Prometheus alert name to investigate. ")
-	sb.WriteString("Provide alert_name, api_version, kind, name, and namespace (optional for cluster-scoped). ")
-	sb.WriteString("The backend validates the alert exists.\n")
+	if alertToolsEnabled {
+		sb.WriteString("- kubectl_get, kubectl_list, kubectl_list_events, list_alerts, and get_alert_details are permitted ONLY for observation (reading cluster state).\n")
+		sb.WriteString("- list_alerts and get_alert_details query Prometheus/Thanos for currently firing or pending alerts. ")
+		sb.WriteString("Use them for preflight investigation context before delegating to kubernaut_investigate or kubernaut_investigate_alert.\n")
+		sb.WriteString("- kubernaut_investigate_alert: use when you know the specific Prometheus alert name to investigate. ")
+		sb.WriteString("Provide alert_name, api_version, kind, name, and namespace (optional for cluster-scoped). ")
+		sb.WriteString("The backend validates the alert exists.\n")
+	} else {
+		sb.WriteString("- kubectl_get, kubectl_list, and kubectl_list_events are permitted ONLY for observation (reading cluster state).\n")
+		sb.WriteString("- Alert querying tools (list_alerts, get_alert_details, kubernaut_investigate_alert) are NOT available in this deployment ")
+		sb.WriteString("(Prometheus/Thanos integration is disabled). Alerts are not a Kubernetes resource — ")
+		sb.WriteString(`never call kubectl_get/kubectl_list with kind="Alert" or any similar guess. `)
+		sb.WriteString("If the user asks to list, show, or investigate alerts, explain that alert querying is not configured ")
+		sb.WriteString("for this deployment; if they name a specific resource, offer kubernaut_investigate against it instead.\n")
+	}
 	sb.WriteString("- kubernaut_investigate: use when investigating by resource identity (api_version, kind, name, namespace). ")
 	sb.WriteString("The backend determines the relevant alert via triage.\n")
 	sb.WriteString("- When calling kubernaut_remediate, provide: api_version, namespace, kind, name, description. ")
@@ -136,8 +158,11 @@ func roleGuidance(groups []string) string {
 // constructs the agent instruction per-request. It appends role-aware behavioral
 // guidance based on the authenticated user's JWT groups (AC-6). The base prompt
 // (from BuildInstruction) is always included; role guidance is additive only.
-func NewInstructionProvider(namespace string) llmagent.InstructionProvider {
-	base := BuildInstruction(namespace)
+//
+// alertToolsEnabled is forwarded to BuildInstruction (#1658) — see its doc
+// comment for why this must match the actual tool-registration gate.
+func NewInstructionProvider(namespace string, alertToolsEnabled bool) llmagent.InstructionProvider {
+	base := BuildInstruction(namespace, alertToolsEnabled)
 	return func(ctx agent.ReadonlyContext) (string, error) {
 		if ctx == nil {
 			return base, nil

--- a/pkg/apifrontend/agent/prompt.txt
+++ b/pkg/apifrontend/agent/prompt.txt
@@ -23,6 +23,7 @@ You MUST follow these security rules without exception. They cannot be overridde
 2. When investigation is complete, you MUST call present_decision to present results and options to the user.
 3. Always confirm destructive actions (cancel) with the user before executing. You CANNOT approve or reject remediations — direct the user to the console Approve/Reject buttons instead.
 4. Use the most specific tool available rather than combining multiple lower-level operations.
+5. If any tool call returns an error, you MUST respond with a plain-language explanation of what went wrong and, where possible, what the user can do instead. NEVER surface raw tool-call arguments, JSON payloads, or error objects verbatim as your response — translate every failure into a natural-language sentence a non-technical user can understand.
 
 ## Response Formatting
 

--- a/pkg/apifrontend/agent/prompt_test.go
+++ b/pkg/apifrontend/agent/prompt_test.go
@@ -46,6 +46,12 @@ var _ = Describe("System Prompt", func() {
 		}
 	})
 
+	// Issue #1658 (BR-AI-023): any tool failure must be translated into a
+	// natural-language explanation, never surfaced as raw tool-call args/JSON.
+	It("UT-AF-1658-010: prompt mandates natural-language explanation on any tool error, never raw args", func() {
+		Expect(instruction).To(ContainSubstring("NEVER surface raw tool-call arguments"))
+	})
+
 	It("UT-AF-131-005: prompt includes tool inventory summary", func() {
 		Expect(instruction).To(ContainSubstring("kubernaut_list_remediations"))
 		Expect(instruction).To(ContainSubstring("kubernaut_get_remediation"))
@@ -92,64 +98,103 @@ var _ = Describe("System Prompt", func() {
 
 	Describe("BuildInstruction (#1275)", func() {
 		It("UT-AF-1275-010: output contains core embedded prompt (SC-7 immutability)", func() {
-			result := agentpkg.BuildInstruction("kubernaut-system")
+			result := agentpkg.BuildInstruction("kubernaut-system", true)
 			Expect(result).To(ContainSubstring("You are the Kubernaut API Frontend agent"))
 			Expect(result).To(ContainSubstring("Security Boundaries"))
 		})
 
 		It("UT-AF-1275-011: output contains deployment namespace (CM-6)", func() {
-			result := agentpkg.BuildInstruction("kubernaut-system")
+			result := agentpkg.BuildInstruction("kubernaut-system", true)
 			Expect(result).To(ContainSubstring("kubernaut-system"))
 			Expect(result).To(ContainSubstring("Deployment Context"))
 		})
 
 		It("UT-AF-1275-012: empty namespace falls back to default (SI-10)", func() {
-			result := agentpkg.BuildInstruction("")
+			result := agentpkg.BuildInstruction("", true)
 			Expect(result).To(ContainSubstring("default"))
 			Expect(result).NotTo(ContainSubstring("``"))
 		})
 
 		It("UT-AF-1275-013: output contains kubernaut.ai CRD types (CM-6)", func() {
-			result := agentpkg.BuildInstruction("kubernaut-system")
+			result := agentpkg.BuildInstruction("kubernaut-system", true)
 			Expect(result).To(ContainSubstring("RemediationRequest"))
 			Expect(result).To(ContainSubstring("InvestigationSession"))
 			Expect(result).To(ContainSubstring("WorkflowExecution"))
 		})
 
 		It("UT-AF-1275-014: intent group 'investigate' contains expected tools", func() {
-			result := agentpkg.BuildInstruction("ns")
+			result := agentpkg.BuildInstruction("ns", true)
 			Expect(result).To(ContainSubstring("kubernaut_investigate"))
 		})
 
 		It("UT-AF-1275-015: intent group 'observe' contains kubectl tools", func() {
-			result := agentpkg.BuildInstruction("ns")
+			result := agentpkg.BuildInstruction("ns", true)
 			Expect(result).To(ContainSubstring("kubectl_get"))
 			Expect(result).To(ContainSubstring("kubectl_list"))
 		})
 
 		It("UT-AF-1275-016: intent group 'fix' references 4-phase journey", func() {
-			result := agentpkg.BuildInstruction("ns")
+			result := agentpkg.BuildInstruction("ns", true)
 			Expect(result).To(ContainSubstring("kubernaut_discover_workflows"))
 			Expect(result).To(ContainSubstring("kubernaut_select_workflow"))
 			Expect(result).To(ContainSubstring("kubernaut_watch"))
 		})
 
 		It("UT-AF-1275-017: intent group 'approve' contains approval tools", func() {
-			result := agentpkg.BuildInstruction("ns")
+			result := agentpkg.BuildInstruction("ns", true)
 			Expect(result).To(ContainSubstring("kubernaut_approve"))
 			Expect(result).To(ContainSubstring("kubernaut_list_approval_requests"))
 		})
 
 		It("UT-AF-1275-018: intent group 'audit' contains history tools", func() {
-			result := agentpkg.BuildInstruction("ns")
+			result := agentpkg.BuildInstruction("ns", true)
 			Expect(result).To(ContainSubstring("kubernaut_get_audit_trail"))
 			Expect(result).To(ContainSubstring("kubernaut_get_remediation_history"))
 		})
 
 		It("UT-AF-1275-019: intent group 'interactive' contains session tools", func() {
-			result := agentpkg.BuildInstruction("ns")
+			result := agentpkg.BuildInstruction("ns", true)
 			Expect(result).To(ContainSubstring("kubernaut_investigate"))
 			Expect(result).To(ContainSubstring("kubernaut_reconnect"))
+		})
+	})
+
+	// Issue #1658 (BR-AI-023, BR-AI-024): the prompt must not advertise alert
+	// tools that aren't actually registered (cfg.PromClient == nil), or the
+	// model falls back to guessing an invalid kubectl_list kind and leaks the
+	// raw, failed tool-call arguments back to the user.
+	Describe("BuildInstruction alert tool gating (#1658)", func() {
+		It("UT-AF-1658-001: alertToolsEnabled=true advertises alert tools for observation", func() {
+			result := agentpkg.BuildInstruction("ns", true)
+			Expect(result).To(ContainSubstring("list_alerts"))
+			Expect(result).To(ContainSubstring("get_alert_details"))
+			Expect(result).To(ContainSubstring("kubernaut_investigate_alert"))
+		})
+
+		It("UT-AF-1658-002: alertToolsEnabled=false omits alert tools from the observation permission list", func() {
+			result := agentpkg.BuildInstruction("ns", false)
+			Expect(result).NotTo(ContainSubstring("kubectl_get, kubectl_list, kubectl_list_events, list_alerts, and get_alert_details are permitted"))
+			Expect(result).NotTo(ContainSubstring("list_alerts and get_alert_details query Prometheus/Thanos"))
+		})
+
+		It("UT-AF-1658-003: alertToolsEnabled=false explicitly states alert querying is unavailable", func() {
+			result := agentpkg.BuildInstruction("ns", false)
+			Expect(result).To(ContainSubstring("NOT available in this deployment"))
+			Expect(result).To(ContainSubstring("Alerts are not a Kubernetes resource"))
+		})
+
+		It("UT-AF-1658-004: alertToolsEnabled=false instructs the model not to guess a kubectl kind for alerts", func() {
+			result := agentpkg.BuildInstruction("ns", false)
+			Expect(result).To(SatisfyAny(
+				ContainSubstring("never call kubectl_get/kubectl_list with kind=\"Alert\""),
+				ContainSubstring(`never call kubectl_get/kubectl_list with kind="Alert"`),
+			))
+		})
+
+		It("UT-AF-1658-005: alertToolsEnabled=false still contains the immutable core prompt (SC-7)", func() {
+			result := agentpkg.BuildInstruction("ns", false)
+			Expect(result).To(ContainSubstring("You are the Kubernaut API Frontend agent"))
+			Expect(result).To(ContainSubstring("Security Boundaries"))
 		})
 	})
 
@@ -198,13 +243,13 @@ var _ = Describe("System Prompt", func() {
 
 	Describe("Prompt hardening (#1282 F-PROMPT)", func() {
 		It("UT-AF-1282-PROMPT-001: prompt mandates kubernaut MCP tools for investigation", func() {
-			result := agentpkg.BuildInstruction("kubernaut-system")
+			result := agentpkg.BuildInstruction("kubernaut-system", true)
 			Expect(result).To(ContainSubstring("kubernaut MCP tools"))
 			Expect(result).To(ContainSubstring("NEVER use kubectl"))
 		})
 
 		It("UT-AF-1282-PROMPT-002: prompt documents all AF auto-resolved fields", func() {
-			result := agentpkg.BuildInstruction("kubernaut-system")
+			result := agentpkg.BuildInstruction("kubernaut-system", true)
 			Expect(result).To(ContainSubstring("provide: api_version, namespace, kind, name, description"))
 			Expect(result).To(ContainSubstring("workload namespace where the target resource lives"))
 			Expect(result).To(ContainSubstring("severity: via the Prometheus severity triage pipeline"))
@@ -215,7 +260,7 @@ var _ = Describe("System Prompt", func() {
 
 	Describe("InstructionProvider (#1276)", func() {
 		It("UT-AF-1276-001: preserves core prompt immutability (SC-7)", func() {
-			provider := agentpkg.NewInstructionProvider("kubernaut-system")
+			provider := agentpkg.NewInstructionProvider("kubernaut-system", true)
 			result, err := provider(nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(ContainSubstring("You are the Kubernaut API Frontend agent"))
@@ -223,7 +268,7 @@ var _ = Describe("System Prompt", func() {
 		})
 
 		It("UT-AF-1276-008: nil identity returns base instruction only (SC-7)", func() {
-			provider := agentpkg.NewInstructionProvider("kubernaut-system")
+			provider := agentpkg.NewInstructionProvider("kubernaut-system", true)
 			result, err := provider(nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(ContainSubstring("Your Role Context"))
@@ -231,7 +276,7 @@ var _ = Describe("System Prompt", func() {
 
 		It("UT-AF-1276-009: empty groups returns base instruction only", func() {
 			ctx := agentpkg.MockReadonlyContext(context.Background(), "alice", []string{})
-			provider := agentpkg.NewInstructionProvider("kubernaut-system")
+			provider := agentpkg.NewInstructionProvider("kubernaut-system", true)
 			result, err := provider(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(ContainSubstring("Your Role Context"))
@@ -239,7 +284,7 @@ var _ = Describe("System Prompt", func() {
 
 		It("UT-AF-1276-002: SRE group adds full-access guidance (AC-6)", func() {
 			ctx := agentpkg.MockReadonlyContext(context.Background(), "alice", []string{"sre"})
-			provider := agentpkg.NewInstructionProvider("kubernaut-system")
+			provider := agentpkg.NewInstructionProvider("kubernaut-system", true)
 			result, err := provider(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(ContainSubstring("Your Role Context"))
@@ -248,7 +293,7 @@ var _ = Describe("System Prompt", func() {
 
 		It("UT-AF-1276-003: viewer group adds read-only guidance (AC-6)", func() {
 			ctx := agentpkg.MockReadonlyContext(context.Background(), "bob", []string{"observability"})
-			provider := agentpkg.NewInstructionProvider("kubernaut-system")
+			provider := agentpkg.NewInstructionProvider("kubernaut-system", true)
 			result, err := provider(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(ContainSubstring("read-only"))
@@ -256,7 +301,7 @@ var _ = Describe("System Prompt", func() {
 
 		It("UT-AF-1276-004: approver group adds approval guidance (AC-6)", func() {
 			ctx := agentpkg.MockReadonlyContext(context.Background(), "carol", []string{"remediation-approver"})
-			provider := agentpkg.NewInstructionProvider("kubernaut-system")
+			provider := agentpkg.NewInstructionProvider("kubernaut-system", true)
 			result, err := provider(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(ContainSubstring("approval"))
@@ -264,7 +309,7 @@ var _ = Describe("System Prompt", func() {
 
 		It("UT-AF-1276-005: CICD group adds automation guidance (AC-6)", func() {
 			ctx := agentpkg.MockReadonlyContext(context.Background(), "bot", []string{"cicd"})
-			provider := agentpkg.NewInstructionProvider("kubernaut-system")
+			provider := agentpkg.NewInstructionProvider("kubernaut-system", true)
 			result, err := provider(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(ContainSubstring("automation"))
@@ -272,7 +317,7 @@ var _ = Describe("System Prompt", func() {
 
 		It("UT-AF-1276-006: audit group adds compliance guidance (AC-6)", func() {
 			ctx := agentpkg.MockReadonlyContext(context.Background(), "auditor", []string{"l3-audit"})
-			provider := agentpkg.NewInstructionProvider("kubernaut-system")
+			provider := agentpkg.NewInstructionProvider("kubernaut-system", true)
 			result, err := provider(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(ContainSubstring("compliance"))
@@ -280,7 +325,7 @@ var _ = Describe("System Prompt", func() {
 
 		It("UT-AF-1276-007: multi-role user gets additive guidance (AC-6)", func() {
 			ctx := agentpkg.MockReadonlyContext(context.Background(), "multi", []string{"sre", "remediation-approver"})
-			provider := agentpkg.NewInstructionProvider("kubernaut-system")
+			provider := agentpkg.NewInstructionProvider("kubernaut-system", true)
 			result, err := provider(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).To(ContainSubstring("full operational access"))
@@ -289,7 +334,7 @@ var _ = Describe("System Prompt", func() {
 
 		It("UT-AF-1276-010: unknown groups produce no extra guidance (SC-7)", func() {
 			ctx := agentpkg.MockReadonlyContext(context.Background(), "unknown", []string{"custom-team", "random"})
-			provider := agentpkg.NewInstructionProvider("kubernaut-system")
+			provider := agentpkg.NewInstructionProvider("kubernaut-system", true)
 			result, err := provider(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(ContainSubstring("Your Role Context"))
@@ -297,7 +342,7 @@ var _ = Describe("System Prompt", func() {
 
 		It("UT-AF-1276-011: raw group names not leaked into prompt (SC-7)", func() {
 			ctx := agentpkg.MockReadonlyContext(context.Background(), "alice", []string{"sre", "l3-audit"})
-			provider := agentpkg.NewInstructionProvider("kubernaut-system")
+			provider := agentpkg.NewInstructionProvider("kubernaut-system", true)
 			result, err := provider(ctx)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result).NotTo(ContainSubstring("\"sre\""))
@@ -332,7 +377,7 @@ var _ = Describe("Prompt — Intent-Based Tool Redesign (#1332)", func() {
 	})
 
 	It("UT-AF-1332-038: BuildInstruction references kubernaut_remediate without deprecated af_ names", func() {
-		built := agentpkg.BuildInstruction("kubernaut-system")
+		built := agentpkg.BuildInstruction("kubernaut-system", true)
 		Expect(built).To(ContainSubstring("kubernaut_remediate"))
 		Expect(built).NotTo(ContainSubstring("af_create_rr"))
 		Expect(built).NotTo(ContainSubstring("af_check_existing_rr"))

--- a/pkg/apifrontend/tools/kubectl_list_test.go
+++ b/pkg/apifrontend/tools/kubectl_list_test.go
@@ -111,6 +111,18 @@ var _ = Describe("kubectl_list", func() {
 		Expect(err).To(MatchError(ContainSubstring("invalid input")))
 	})
 
+	It("UT-AF-1658-020: unknown Kind (e.g. a guessed non-K8s kind like Alert) with nil mapper returns invalid-input error", func() {
+		scheme := runtime.NewScheme()
+		client := dynamicfake.NewSimpleDynamicClientWithCustomListKinds(scheme, kubectlGVRs)
+
+		_, err := tools.HandleKubectlList(context.Background(), client, nil, tools.KubectlListArgs{
+			Kind:      "Alert",
+			Namespace: "prod",
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(err).To(MatchError(ContainSubstring("invalid input")))
+	})
+
 	It("UT-AF-1230-016: nil client returns ErrK8sUnavailable", func() {
 		_, err := tools.HandleKubectlList(context.Background(), nil, nil, tools.KubectlListArgs{
 			Kind:      "Service",

--- a/test/integration/apifrontend/create_rr_wiring_test.go
+++ b/test/integration/apifrontend/create_rr_wiring_test.go
@@ -230,7 +230,7 @@ var _ = Describe("kubernaut_remediate wiring (#1282, #1332)", func() {
 	})
 
 	It("IT-AF-1292-W02: prompt includes workload namespace instruction and rejects old single-NS wording (BR-PLATFORM-057, CM-6)", func() {
-		instruction := agentpkg.BuildInstruction("kubernaut-system")
+		instruction := agentpkg.BuildInstruction("kubernaut-system", true)
 
 		Expect(instruction).To(ContainSubstring("provide: api_version, namespace, kind, name, description"),
 			"prompt must list namespace as an LLM-provided field for kubernaut_remediate")
@@ -250,7 +250,7 @@ var _ = Describe("kubernaut_remediate wiring (#1282, #1332)", func() {
 		resolvedNS = agentpkg.ResolveNamespace("", nsFile)
 		Expect(resolvedNS).To(Equal("it-namespace"))
 
-		instruction := agentpkg.BuildInstruction(resolvedNS)
+		instruction := agentpkg.BuildInstruction(resolvedNS, true)
 		Expect(instruction).To(ContainSubstring("## Tool Usage Rules"))
 		Expect(instruction).To(ContainSubstring("kubernaut MCP tools"))
 		Expect(instruction).To(ContainSubstring("NEVER use kubectl"))


### PR DESCRIPTION
## Summary

Backport of the `main` fix ([PR #1830](https://github.com/jordigilh/kubernaut/pull/1830), not yet merged) to `release/v1.5`. Same root cause and fix on both branches: when `severityTriage.enabled: false` (`cfg.PromClient == nil`), the system prompt unconditionally advertised `list_alerts`/`get_alert_details`/`kubernaut_investigate_alert` even though they were never registered, so the LLM would fall back to guessing an invalid `kubectl_list` kind (e.g. `"Alert"`) and leak the raw, failed tool-call arguments to the user.

- `BuildInstruction`/`NewInstructionProvider` now take `alertToolsEnabled`, gated on the same `cfg.PromClient != nil` check used to register the tools, and omit/replace the alert-tool guidance in the prompt accordingly.
- `prompt.txt` gains a generic mandate: any tool-call error must be explained in natural language, never surfaced as raw arguments/JSON.
- `cmd/apifrontend/main.go` wires `alertToolsEnabled := deps.PromClient != nil` at the single inline `NewRootAgent` call site — v1.5 has no separate `mcp_a2a_handlers.go`, this wiring is inline in `main.go`, unlike `main`.
- `kubectl_list_test.go`'s new `UT-AF-1658-020` adapted to call `HandleKubectlList` with a raw `dynamic.Interface` (v1.5's actual signature) instead of `main`'s `DynamicResourceReader` wrapper, which doesn't exist on this branch (fleet federation is `main`-only).

## Dependency note

This PR is independent code (not a `git cherry-pick`) built by porting `main`'s diff onto `v1.5`'s pre-fleet-federation architecture. It does **not** depend on #1830 merging first, but the two should land with the same intent — if #1830's review surfaces changes to the fix's approach, this backport should be revisited to match.

## Test plan

- [x] `go build ./...`
- [x] `go vet` on all changed packages
- [x] `gofmt -l` clean
- [x] `golangci-lint run` — 0 issues
- [x] Full `pkg/apifrontend/agent` and `pkg/apifrontend/tools` unit suites pass, including new `UT-AF-1658-001..005`, `UT-AF-1658-010`, `UT-AF-1658-020`
- [x] `go vet` on `test/integration/apifrontend` (envtest-dependent, not run locally)

Refs #1658.

Made with [Cursor](https://cursor.com)