### PR TITLE
docs: rewrite ADR-055/ADR-056 against Go KA implementation (Issue #1806 PR3b-4)

### DIFF
--- a/docs/architecture/decisions/ADR-055-llm-driven-context-enrichment.md
+++ b/docs/architecture/decisions/ADR-055-llm-driven-context-enrichment.md
@@ -1,12 +1,10 @@
-# ADR-055: LLM-Driven Context Enrichment (Post-RCA)
+# ADR-055: Post-RCA Context Enrichment (Target-Scoped, Not Signal-Scoped)
 
 **Status**: ACCEPTED
 **Decision Date**: 2026-02-12
-**Version**: 1.5
-**Confidence**: 92%
+**Version**: 2.0 (Go rewrite)
+**Confidence**: 90%
 **Applies To**: Kubernaut Agent (KA), AIAnalysis Controller, SignalProcessing
-
-> **Note (2026-08-01, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: "HAPI" throughout this document refers to what is now Kubernaut Agent (KA) — the Go-native successor to the retired Python HolmesGPT-API. The `DD-HAPI-017` cross-reference below has been updated to its current `DD-KA-017` equivalent. The rest of this document's body (tool names, `session_state` mechanism, Python-era phase descriptions) has not been fully rewritten against the Go implementation; treat [DD-KA-006](DD-KA-006-remediation-target-in-rca.md), [DD-KA-016](DD-KA-016-remediation-history-context.md), and [DD-KA-017](DD-KA-017-three-step-workflow-discovery-integration.md) as authoritative wherever this document's body conflicts with them.
 
 ---
 
@@ -14,26 +12,22 @@
 
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
-| 1.0 | 2026-02-12 | Architecture Team | Initial proposal: move context enrichment (owner chain, spec hash, remediation history) from pre-LLM computation to post-RCA tool-driven flow. |
-| 1.1 | 2026-02-12 | Architecture Team | Address 8 triage gaps: replace `target_in_owner_chain` with `remediation_target` Rego input (§2, ADR-055), preserve `ExtractRootCauseAnalysis` (§3), enforce `remediationTarget` as required LLM response field (§4), clarify CRD deprecation (§5), clarify `current_spec_hash` scope (§6), document new owner-chain resolution + RBAC expansion (§7), update latency estimate (§8). [Deprecated - Issue #180: Recovery flow reference removed] *(§4 "required LLM response field" for target identity superseded by BR-496 v2 / DD-KA-006 v2.0: KA owns `remediationTarget` via K8s-verified owner-chain injection, `InjectRemediationTarget`.)* |
-| 1.3 | 2026-02-24 | Architecture Team | **Issue #188 (DD-EM-003)**: Renamed `resolveEffectivenessTarget` to `resolveDualTargets` throughout. The function now returns `*creator.DualTarget{Signal, Remediation}` with explicit dual-target semantics. Updated compatibility table and data quality section. |
-| 1.2 | 2026-02-12 | Architecture Team | Refine tool return contract: `get_resource_context` returns only `root_owner` and `remediation_history` to the LLM. Owner chain traversal and spec hash computation are internal implementation details not exposed in the tool response. Update prompt Phase 3b accordingly. See also ADR-056 for DetectedLabels relocation. |
-| 1.4 | 2026-03-24 | Architecture Team | **Issue #524**: Namespaced tool renamed to `get_namespaced_resource_context`; added `get_cluster_resource_context` for cluster-scoped targets (Node, PV, etc.). Both tools registered in the `resource_context` toolset. `resource_scope` (`namespaced` / `cluster`) stored in `session_state`. Canonical `TARGET_RESOURCE_*` injection is conditional on workflow schema declarations; former validator Step 0 (mandatory canonical declarations) removed. |
-| 1.5 | 2026-03-25 | Architecture Team | **Issue #529**: Three-phase RCA architecture. Context enrichment moves from LLM-driven tool call to HAPI-driven `EnrichmentService` (Phase 2). LLM provides `affectedResource` in Phase 1; HAPI resolves owner chain, detects labels, and fetches history for the resolved root owner. Enrichment context sent to LLM in Phase 3 for informed workflow selection. Resource context tools no longer write `root_owner` or `detected_labels` to `session_state`; `EnrichmentService` is the sole authoritative source. BR-HAPI-262 (history verification enforcement) dropped — HAPI always provides verified history. BR-HAPI-260 (dedicated history tool) dropped — existing resource context tools already return history; EnrichmentService provides authoritative history in Phase 2. Resource context tools remain available as optional Phase 1 informational tools (label detection still returns `detected_infrastructure` to LLM but no longer writes to `session_state`). See BR-HAPI-261, BR-HAPI-264. |
+| 1.0–1.5 | 2026-02-12 to 2026-03-25 | Architecture Team | Historical evolution under the Python-era implementation: proposed moving context enrichment from pre-LLM computation to an LLM-driven tool call (`get_namespaced_resource_context` / `get_cluster_resource_context`), then to a `HAPI`-internal `EnrichmentService` (Issue #529). Superseded by v2.0 below; see git history for the original entries. |
+| 2.0 | 2026-08-02 | — | Rewritten against the Go KA implementation as part of [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806). **Key correction**: the decision this ADR records — compute owner-chain/spec-hash/history context for the RCA-identified target, not the pre-RCA signal source — is unchanged and confirmed implemented. But the *mechanism* is not what v1.0–v1.4 decided: KA does not wait for the LLM to call a resource-context tool. `Investigator.resolveEnrichment` (`internal/kubernautagent/investigator/investigator.go`) runs automatically once the RCA target is resolved (`ResolveEnrichmentTarget`), calling `enrichment.Enricher.Enrich` (`internal/kubernautagent/enrichment/enricher.go`) unconditionally, for every investigation. The `get_namespaced_resource_context`/`get_cluster_resource_context` LLM tools (`internal/kubernautagent/tools/custom/resource_context.go`) still exist and remain registered, but are not the primary or sole trigger — enrichment happens whether or not the LLM calls them. Replaced the Python "Changes Required" migration-plan tables (file paths under `kubernaut-agent/src/...py`, already executed and merged long ago) with a pointer to the current Go implementation and to [DD-KA-016](DD-KA-016-remediation-history-context.md)/[DD-KA-017](DD-KA-017-three-step-workflow-discovery-integration.md), which are authoritative for current mechanics. Corrected the Rego input field name from the originally-proposed `affected_resource` to the actual implemented `remediation_target` (`pkg/aianalysis/rego/evaluator.go`). Renamed `HAPI` → Kubernaut Agent (KA) throughout. |
 
 ---
 
 ## Context & Problem
 
-### Current Architecture (Pre-Computation Model)
+### Original Architecture (Pre-Computation Model, Retired)
 
-The current pipeline pre-collects context **before** the LLM performs Root Cause Analysis (RCA):
+Before this decision, the pipeline pre-collected context **before** the LLM performed Root Cause Analysis (RCA), computed from the **signal source** resource:
 
 ```
-Signal -> SP enriches with OwnerChain
-  -> RO copies OwnerChain to AIAnalysis.Spec.EnrichmentResults
-  -> AIAnalysis Controller passes OwnerChain to HAPI request (Issue #97)
-  -> HAPI pre-computes BEFORE LLM invocation:
+Signal -> SignalProcessing enriches with OwnerChain (of the signal source)
+  -> RemediationOrchestrator copies OwnerChain to AIAnalysis.Spec.EnrichmentResults
+  -> AIAnalysis Controller passes OwnerChain to KA's predecessor
+  -> Pre-computes BEFORE LLM invocation:
       1. resolve_root_owner(owner_chain) -> root owner
       2. compute_spec_hash(root_owner) -> SHA-256 hash
       3. fetch_remediation_history(root_owner, spec_hash) -> history context
@@ -41,343 +35,76 @@ Signal -> SP enriches with OwnerChain
   -> LLM selects workflow based on pre-computed context
 ```
 
-This applies to the **incident flow** (`extensions/incident/llm_integration.py`). [Deprecated - Issue #180: Recovery flow reference removed]
+### Problems That Motivated the Change (still the reason this decision holds)
 
-### Problems
-
-1. **Wrong resource context**: The owner chain and spec hash are computed from the **signal source** (e.g., the crashing Pod), not the **actual root cause target** (e.g., a misconfigured ConfigMap, an HPA with wrong thresholds, or a Deployment with missing resource limits). The LLM may identify a completely different resource as the root cause.
-
-2. **Context pollution**: The LLM receives remediation history for the signal source resource, which may be irrelevant to the actual root cause. This consumes context window and can bias the LLM's reasoning.
-
-3. **Wasted computation**: If the owner chain resolution or spec hash computation fails (e.g., the `ImportError: No module named 'utils.canonical_hash'` observed in CI), the data is empty anyway. The LLM proceeds without it, proving the pre-computation is not essential for RCA.
-
-4. **Owner chain only for Pods**: SignalProcessing only computes owner chains for Pod signals. Deployment, StatefulSet, DaemonSet, Node, and Service signals have empty owner chains, making the entire propagation path a no-op for most signal types.
-
-5. **Unnecessary data propagation**: The owner chain traverses three CRD boundaries (SP -> RO -> AIAnalysis -> HAPI) purely to enable a pre-computation that targets the wrong resource.
+1. **Wrong resource context**: The owner chain and spec hash were computed from the **signal source** (e.g., the crashing Pod), not the **actual root cause target** (e.g., a misconfigured ConfigMap, an HPA with wrong thresholds, or a Deployment with missing resource limits). The LLM may identify a completely different resource as the root cause.
+2. **Context pollution**: Pre-computed history for the signal source resource may be irrelevant to the actual root cause, consuming context window and biasing the LLM's reasoning.
+3. **Wasted computation**: If the pre-computed owner chain or spec hash was empty or wrong, the LLM proceeded without it anyway — the pre-computation was not essential for RCA to begin with.
+4. **Owner chain only for Pods**: SignalProcessing only computed owner chains for Pod signals; Deployment, StatefulSet, DaemonSet, Node, and Service signals had empty owner chains.
+5. **Unnecessary data propagation**: The owner chain traversed three CRD boundaries (SP → RO → AIAnalysis → KA's predecessor) purely to enable a pre-computation that targeted the wrong resource.
 
 ### Business Requirements Affected
 
-- **DD-KA-016**: Remediation history context (enhanced, not broken)
+- **DD-KA-016**: Remediation history context (enhanced, not broken, by this decision)
 - **BR-AI-023**: Investigation audit trail (unchanged)
-- **Issue #97**: Owner chain / AffectedResource / SpecHash (superseded by this ADR)
-- **DD-KA-017**: Three-step workflow discovery (enhanced, tools execute in correct order)
+- **DD-KA-017**: Three-step workflow discovery (enhanced — label/history context now scoped to the correct target)
 
 ---
 
 ## Decision
 
-### Move to LLM-Driven, Post-RCA Context Enrichment
+**Compute owner-chain, spec-hash, and remediation-history context for the RCA-identified target, not the pre-RCA signal source — automatically, once KA resolves that target.**
 
-Replace the pre-computation model with a three-phase, tool-driven flow where the LLM controls when and for which resource context is collected:
+### Current Implementation (Go KA)
 
 ```
-Signal -> AIAnalysis Controller passes signal context to HAPI
-  -> HAPI invokes LLM with signal context only (no pre-computed enrichment)
-  -> Phase 1 (RCA): LLM analyzes signal, identifies root cause and affected resource
-  -> Phase 2 (Context): LLM calls get_namespaced_resource_context or get_cluster_resource_context (from the resource_context toolset) for the RCA target
-      -> Tool internally:
-         1. Traverses K8s ownerReferences for identified target
-         2. Identifies root managing resource (e.g., Pod -> Deployment)
-         3. Computes spec hash for root owner
-         4. Queries DataStorage for remediation history (root owner + spec hash)
-      -> Returns to LLM: root_owner identity + remediation_history only
-         (owner chain and spec hash are internal, not exposed)
-  -> Phase 3 (Workflow): LLM calls 3-step workflow discovery (DD-KA-017)
-      -> list_available_actions(action_type)
-      -> list_workflows(action_type, filters)
-      -> get_workflow(workflow_id) with parameter mapping
-  -> LLM returns complete result: RCA + affected resource + workflow recommendation
+Signal -> AIAnalysis Controller passes signal context to KA
+  -> KA invokes LLM with signal context only (no pre-computed enrichment)
+  -> Phase 1 (RCA): LLM analyzes the signal and returns a structured result
+     including a remediation target (kind/name/namespace), parsed by
+     internal/kubernautagent/parser
+  -> KA resolves the enrichment target: ResolveEnrichmentTarget prefers the
+     LLM's RCA-identified target, falling back to the signal resource only
+     if the LLM didn't provide one (internal/kubernautagent/investigator/investigator.go)
+  -> KA automatically enriches for that target (no LLM tool call required):
+     Investigator.resolveEnrichment -> enrichment.Enricher.Enrich
+       1. Traverses K8s ownerReferences for the resolved target
+       2. Identifies the root managing resource (e.g., Pod -> Deployment)
+       3. Computes the spec hash for the root owner (DD-EM-002)
+       4. Queries DataStorage for target-scoped remediation history (DD-KA-016)
+       5. Detects 12 infrastructure characteristics for the root owner (DD-KA-018)
+  -> Phase 2 (Workflow): LLM uses the three-step workflow discovery protocol
+     (DD-KA-017), informed by the enrichment result rendered into the prompt
+  -> KA returns the complete result: RCA + remediation target + workflow
+     recommendation
 ```
 
-This flow applies to the incident path.
+This is KA's single, unified investigation flow (there is no separate incident/recovery split in Go KA).
+
+**A secondary path also exists**: `get_namespaced_resource_context` / `get_cluster_resource_context` are still registered as LLM-callable tools (used by the interactive MCP mode's `select_workflow` pre-selection hook, and available to the autonomous flow's LLM). Calling them re-runs the same `Enricher.Enrich` logic for a target the LLM specifies. They are not a prerequisite for enrichment — the automatic path above always runs regardless of whether the LLM calls them.
 
 ### Key Design Principles
 
-1. **The LLM identifies the target resource, not pre-computation**. The `affectedResource` in the result is a required, first-class RCA output, not derived from a pre-computed owner chain.
+1. **The LLM identifies the target resource, not pre-computation.** The RCA-time remediation target is a first-class output of RCA, not derived from a pre-computed owner chain of the signal source.
 
-2. **`affectedResource` is a required field in the LLM response contract**. The response validator (3-attempt self-correction loop) rejects responses that omit it, the same way it enforces `severity`, `summary`, and `selected_workflow`. If the LLM omits `affectedResource`, the validator returns an error and the LLM retries with the signal context (which includes the target resource) as fallback.
+2. **Target identity is K8s-verified, not blindly trusted from the LLM.** Per [DD-KA-006](DD-KA-006-remediation-target-in-rca.md) v2.0, KA injects `TARGET_RESOURCE_*` workflow parameters from a K8s-verified owner chain (`InjectRemediationTarget`) as `kaManagedParams`, which are never stripped regardless of workflow schema declaration. This superseded the original v1.0–v1.4 design of a strictly-required, unconstrained LLM response field enforced by a hard validator failure — the LLM's stated target is a strong input, but KA's own K8s lookups are the final authority for what gets injected into the workflow.
 
-3. **Context is fetched for the right resource at the right time**. The spec hash and remediation history describe the resource that will actually be remediated.
+3. **Context is fetched for the right resource at the right time.** The spec hash and remediation history describe the resource that will actually be remediated, computed automatically once that resource is known — not the signal source, and not gated on an explicit LLM request.
 
-4. **Tool-driven, not pipeline-driven**. The LLM requests what it needs through tool calls. If the RCA determines no context enrichment is needed (e.g., the root cause is a misconfiguration that doesn't need history), it can skip the tool call entirely.
+4. **Automatic, not solely tool-driven.** Enrichment runs unconditionally for every investigation once the RCA target is resolved. This is a deliberate correction from the original v1.0–v1.4 decision (LLM must call a resource-context tool to trigger enrichment): making it automatic guarantees every investigation has correct target-scoped context, rather than depending on the LLM choosing to call a tool. The LLM-callable tools remain available as a secondary path (e.g., for the interactive MCP mode, or mid-investigation re-scoping).
 
-5. **`affected_resource` replaces `target_in_owner_chain` in Rego policy input**. Instead of a boolean about chain membership, the Rego evaluator exposes the LLM-identified target resource (kind, name, namespace) as structured input. This enables granular, per-kind approval policies (e.g., "require approval for Node remediations in production") rather than the opaque `not target_validated` gate.
-
----
-
-## Changes Required
-
-### Phase 1: Revert Issue #97 Pre-Computation Path
-
-#### HAPI (Python) -- Incident Flow
-
-| File | Change | Rationale |
-|------|--------|-----------|
-| `kubernaut-agent/src/extensions/incident/llm_integration.py` | Remove pre-LLM root owner resolution, spec hash computation, remediation history fetch via root owner, and Phase C `affectedResource` population (~lines 227-278, 593-608) | Pre-computation targets wrong resource |
-| `kubernaut-agent/src/extensions/incident/result_parser.py` | Remove `target_in_owner_chain` from `parse_and_validate_investigation_result`. Remove `is_target_in_owner_chain()` function. | Replaced by `affected_resource` Rego input |
-| `kubernaut-agent/src/clients/k8s_client.py` | Remove `resolve_root_owner()` function. Keep `compute_spec_hash()` (reused by new tool). | `resolve_root_owner` was a trivial list[-1]; new tool traverses K8s API instead |
-| `kubernaut-agent/tests/unit/test_k8s_client_owner_resolution.py` | Remove tests for `resolve_root_owner()` | Function removed |
-
-#### AIAnalysis Controller (Go)
-
-| File | Change | Rationale |
-|------|--------|-----------|
-| `pkg/aianalysis/handlers/request_builder.go` (lines 296-306) | Remove OwnerChain -> HAPI request mapping | OwnerChain no longer passed to HAPI |
-| `pkg/aianalysis/handlers/response_processor.go` | **No changes**. `ExtractRootCauseAnalysis` stays as-is -- it correctly extracts `affectedResource` from the LLM's RCA JSON response. The centralization (dedup of 5 handler methods) is valuable. | Only the Python-side Phase C fallback is removed; the Go-side extraction of whatever the LLM returns is correct |
-| `api/aianalysis/v1alpha1/aianalysis_types.go` | Remove `TargetInOwnerChain *bool` from AIAnalysis status. Add deprecation comment to `EnrichmentResults.OwnerChain` field: `// Deprecated: ADR-055 - no longer populated for HAPI. Scheduled for removal in v2 API.` | `target_in_owner_chain` concept removed; CRD OwnerChain field removal deferred to v2 |
-
-#### Rego Policy and Evaluator
-
-| File | Change | Rationale |
-|------|--------|-----------|
-| `pkg/aianalysis/rego/evaluator.go` | Remove `TargetInOwnerChain bool` from `RegoInput`. Add `AffectedResource` struct (Kind, Name, Namespace) to `RegoInput`. Populate from `analysis.Status.RootCauseAnalysis.AffectedResource`. | Replaces boolean with structured data |
-| `pkg/aianalysis/handlers/analyzing.go` | Remove `TargetInOwnerChain` mapping (~lines 353-356). Add `AffectedResource` mapping from `analysis.Status.RootCauseAnalysis.AffectedResource`. | Feeds new Rego input |
-| `config/rego/aianalysis/approval.rego` | Replace `target_validated` / `not target_validated` rules with `affected_resource`-based rules. See example below. | Enables granular per-kind policies |
-
-**New Rego policy pattern:**
-
-```rego
-# Old (removed):
-# target_validated if { input.target_in_owner_chain == true }
-# require_approval if { is_production; not target_validated }
-
-# New: Granular affected_resource policies
-# Operators can write kind-specific rules
-
-# Node remediations in production always require approval
-require_approval if {
-    is_production
-    input.affected_resource.kind == "Node"
-}
-
-# StatefulSet remediations in production require approval
-require_approval if {
-    is_production
-    input.affected_resource.kind == "StatefulSet"
-}
-
-# Risk factor: production + sensitive resource kinds
-risk_factors contains {"score": 80, "reason": "Production environment with sensitive resource kind - requires manual approval"} if {
-    is_production
-    input.affected_resource.kind == "Node"
-}
-
-risk_factors contains {"score": 60, "reason": "Production environment with stateful resource - requires manual approval"} if {
-    is_production
-    input.affected_resource.kind == "StatefulSet"
-}
-```
-
-#### RemediationOrchestrator (Go)
-
-| File | Change | Rationale |
-|------|--------|-----------|
-| `pkg/remediationorchestrator/creator/aianalysis.go` | `buildEnrichmentResults()` can stop copying `OwnerChain` to AIAnalysis spec | No downstream consumer needs it for HAPI |
-
-#### SignalProcessing (Go)
-
-| File | Change | Rationale |
-|------|--------|-----------|
-| No changes | SP owner chain enrichment stays -- it serves SP's own purposes (label detection, HPA detection, Rego evaluation) | Owner chain computation in SP is not affected |
-
-### Phase 2: Add HAPI Resource Context Tools (`resource_context` Toolset)
-
-#### Tools: `get_namespaced_resource_context` and `get_cluster_resource_context`
-
-```python
-class GetNamespacedResourceContextTool:
-    """Fetch remediation context for a namespace-scoped RCA target.
-
-    Internally traverses K8s ownerReferences, computes spec hash,
-    and queries remediation history. Returns only the root owner
-    identity and history -- chain traversal and hash are internal.
-    Stores resource_scope='namespaced' in session_state.
-
-    Returns to LLM:
-    - root_owner: The root managing resource (kind, name, namespace)
-    - remediation_history: Past remediation attempts for that resource
-    """
-
-    def execute(self, kind: str, name: str, namespace: str) -> ResourceContext:
-        # 1. (Internal) Traverse K8s ownerReferences to find root owner
-        owner_chain = k8s_client.resolve_owner_chain(kind, name, namespace)
-
-        # 2. (Internal) Determine root owner (last in chain, or resource itself)
-        root_owner = owner_chain[-1] if owner_chain else {
-            "kind": kind, "name": name, "namespace": namespace
-        }
-
-        # 3. (Internal) Compute spec hash of root owner
-        spec_hash = k8s_client.compute_spec_hash(
-            root_owner["kind"], root_owner["name"], namespace
-        )
-
-        # 4. (Internal) Fetch remediation history for root owner + spec hash
-        history = remediation_history_client.fetch(root_owner, spec_hash)
-
-        # Return only what the LLM needs
-        return ResourceContext(
-            root_owner=root_owner,
-            remediation_history=history,
-        )
-```
-
-`get_cluster_resource_context` is the sibling tool for **cluster-scoped** RCA targets (e.g. Node, PersistentVolume): it resolves context without a namespace, sets `resource_scope='cluster'` in `session_state`, and follows the same internal pattern (spec hash + remediation history for the resolved target).
-
-#### New Function: `resolve_owner_chain`
-
-This is a **new function** in `k8s_client.py`, not a refactor of `resolve_root_owner()`. It traverses K8s `ownerReferences` from scratch:
-
-```python
-async def resolve_owner_chain(
-    self, kind: str, name: str, namespace: str, max_depth: int = 5
-) -> List[Dict[str, str]]:
-    """Traverse K8s ownerReferences to build the ownership chain.
-
-    Starting from the given resource, follows metadata.ownerReferences
-    (controller: true) upward until no more owners are found or max_depth
-    is reached.
-
-    Returns list of owner entries (excluding the source resource).
-    Example for a Pod owned by a Deployment:
-        [{"kind": "ReplicaSet", "name": "api-7d8f9c6b5", "namespace": "prod"},
-         {"kind": "Deployment", "name": "api", "namespace": "prod"}]
-    """
-    chain = []
-    current_kind, current_name = kind, name
-    for _ in range(max_depth):
-        resource = await self._get_resource(current_kind, current_name, namespace)
-        if resource is None:
-            break
-        owner_refs = resource.get("metadata", {}).get("ownerReferences", [])
-        controller_owner = next(
-            (ref for ref in owner_refs if ref.get("controller") is True), None
-        )
-        if controller_owner is None:
-            break
-        entry = {
-            "kind": controller_owner["kind"],
-            "name": controller_owner["name"],
-            "namespace": namespace,
-        }
-        chain.append(entry)
-        current_kind = controller_owner["kind"]
-        current_name = controller_owner["name"]
-    return chain
-```
-
-#### RBAC Expansion
-
-The resource context tools need to read `ownerReferences` on resources during chain traversal AND read `.spec` for hash computation (plus cluster-scoped `get` where applicable for `get_cluster_resource_context`). The RBAC manifest must be expanded:
-
-```yaml
-# deploy/kubernaut-agent/03-rbac.yaml
-rules:
-  # Existing: read events
-  - apiGroups: [""]
-    resources: ["events"]
-    verbs: ["get", "list"]
-
-  # ADR-055: Read ownerReferences for chain traversal + read spec for hash
-  - apiGroups: [""]
-    resources: ["pods"]
-    verbs: ["get"]
-  - apiGroups: ["apps"]
-    resources: ["deployments", "statefulsets", "daemonsets", "replicasets"]
-    verbs: ["get"]
-```
-
-Note: `replicasets` added (needed for Pod -> ReplicaSet traversal). `pods` added (needed for starting traversal from a Pod resource to read its `ownerReferences`).
-
-#### Tool Registration
-
-Both tools are registered on the **`resource_context` toolset** (`ResourceContextToolset` in `kubernaut-agent/src/toolsets/resource_context.py`), which is attached in the incident flow alongside the existing DD-HAPI-017 workflow discovery tools. The LLM sees `get_namespaced_resource_context` and `get_cluster_resource_context` as distinct tool names and must choose the one that matches the RCA target’s scope (Issue #524).
-
-#### Updated Prompt Flow
-
-> **Note (BR-496 v2, DD-KA-006 v2.0):** Stored remediation target identity is derived by KA from the K8s-verified owner chain (`InjectRemediationTarget`), not taken as an unconstrained required LLM field. `TARGET_RESOURCE_*` workflow params are unconditionally injected and preserved (`kaManagedParams`), regardless of workflow schema declaration. The numbered steps below reflect the original ADR-055 prompt contract where they still apply.
-
-The HAPI system prompt instructs the LLM:
-
-1. **First**: Analyze the signal context and perform root cause analysis. Identify the root cause and the affected resource. The `affectedResource` field is **required** in your response.
-2. **Then**: Call `get_namespaced_resource_context` (namespace-scoped target) or `get_cluster_resource_context` (cluster-scoped target) with the appropriate arguments. The tool returns: (a) `root_owner` -- the root managing resource (e.g., a Pod's Deployment); use this as your `affectedResource`; (b) `remediation_history` -- past remediations for that resource. Owner chain traversal and spec hash computation are internal to the tool.
-3. **Finally**: Use the three-step workflow discovery (DD-HAPI-017) to select the appropriate remediation workflow, informed by the remediation history.
-
-#### Response Validation
-
-> **Note (BR-496 v2, DD-KA-006 v2.0):** Target resource identity for downstream consumers is injected from the K8s-verified owner chain. KA unconditionally injects `TARGET_RESOURCE_NAME` / `TARGET_RESOURCE_KIND` / `TARGET_RESOURCE_NAMESPACE` (and `TARGET_RESOURCE_API_VERSION` when known) as `kaManagedParams`, which are never stripped regardless of workflow schema declaration. The following still describes the original validator expectation for LLM RCA output shape where `affectedResource` was LLM-supplied.
-
-The `WorkflowResponseValidator` (3-attempt self-correction loop) is updated to validate that `affectedResource` is present in the RCA output. If the LLM omits it, the validator returns:
-
-```
-"missing required field: root_cause_analysis.affectedResource (kind, name required; namespace required for namespace-scoped resources, omit for cluster-scoped)"
-```
-
-The LLM retries with the signal context (which includes the target resource kind/name) available to produce the field. This is the same validation pattern used for `severity`, `summary`, and `selected_workflow`.
-
-### Phase 3: Clean Up Result Structure
-
-#### Remove from HAPI Request
-
-| Field | Action |
-|-------|--------|
-| `enrichment_results.ownerChain` | Remove from request schema -- HAPI resolves it via tool |
-| `enrichment_results.currentSpecHash` | Remove -- computed by tool for correct resource |
-
-#### Keep in HAPI Response
-
-| Field | Source | Notes |
-|-------|--------|-------|
-| `affected_resource` | LLM RCA output (Phase 1) | Required field, enforced by response validator |
-| `root_cause_analysis` | LLM RCA output (Phase 1) | Unchanged |
-| `recommended_workflow` | LLM workflow selection (Phase 3) | Based on correct context |
-
-#### `current_spec_hash` Scope
-
-The `current_spec_hash` computed by the resource context tools (`get_namespaced_resource_context` / `get_cluster_resource_context`) is used **within the HAPI session only** -- for the remediation history lookup (DataStorage query). It is NOT surfaced in the HAPI response.
-
-The Go-side `CapturePreRemediationHash` in the RO reconciler independently computes the spec hash from the K8s API at workflow execution time. This is correct: the RO captures the hash at the moment of remediation, not from a potentially stale HAPI response. No changes needed to the RO hash computation.
-
-#### Remove `target_in_owner_chain`
-
-Removed from:
-- HAPI response (`result_parser.py` -- incident parse function)
-- `is_target_in_owner_chain()` function in `result_parser.py`
-- AIAnalysis CRD status (`TargetInOwnerChain *bool`)
-- Rego evaluator input (`RegoInput` struct)
-- Rego approval policy (`target_validated` rules)
-- Analyzing handler (`TargetInOwnerChain` mapping)
-
-Replaced by: `affected_resource` (kind, name, namespace) as Rego input for granular policy rules.
-
----
-
-## Impact on Issue #97
-
-Issue #97 introduced these capabilities:
-
-| Capability | Issue #97 Implementation | ADR-055 Impact |
-|------------|--------------------------|----------------|
-| **Owner chain propagation** (SP -> AIAnalysis -> HAPI) | `request_builder.go` maps OwnerChain to HAPI request | **SUPERSEDED**: Remove mapping. HAPI resolves owner chain via tool call for the correct resource. |
-| **Spec hash computation** | `k8s_client.py` computes hash pre-LLM from signal source's root owner | **SUPERSEDED**: `compute_spec_hash()` preserved, invoked by tool for the RCA-identified target. |
-| **`affectedResource` population** | Derived from pre-computed root owner in `llm_integration.py` Phase C | **SUPERSEDED**: LLM identifies affected resource directly during RCA. Enforced as required field via response validator. |
-| **`ExtractRootCauseAnalysis` centralization** | `response_processor.go` helper deduplicating 5 handler methods | **RETAINED**: Centralization is valuable. The Go-side extraction of `affectedResource` from the RCA JSON is correct regardless of how the LLM populates it. |
-| **`resolveDualTargets`** | `reconciler.go` uses `AffectedResource` for EA targeting (DD-EM-003) | **RETAINED + RENAMED**: Renamed from `resolveEffectivenessTarget` in Issue #188. Now returns `*creator.DualTarget{Signal, Remediation}` with explicit dual-target semantics. The `AffectedResource` field is populated by the LLM directly rather than by HAPI's Phase C fallback. |
-| **RBAC for apps/v1** | `03-rbac.yaml` grants read access for spec hash | **RETAINED + EXPANDED**: Still needed for the resource context tools. Expanded to include `replicasets` and `pods` for owner chain traversal (and cluster-scoped reads as required for `get_cluster_resource_context`). |
-| **`target_in_owner_chain` validation** | `result_parser.py` checks RCA target against pre-computed chain | **REPLACED**: Removed. `affected_resource` exposed as structured Rego input for granular per-kind approval policies. |
+5. **`remediation_target` is structured Rego policy input.** Instead of a boolean about owner-chain membership, the Rego evaluator (`pkg/aianalysis/rego/evaluator.go`) exposes the RCA-identified/K8s-verified target resource (kind, name, namespace) as `remediation_target` — enabling granular, per-kind approval policies (e.g., "require approval for Node remediations in production"). The field name is `remediation_target`, not the originally-proposed `affected_resource` — it was renamed during implementation to align with DD-KA-006's `remediationTarget` terminology.
 
 ---
 
 ## Advantages
 
-1. **Accuracy**: Context is collected for the resource the LLM actually identified as the root cause, not the signal source.
-2. **Efficiency**: No wasted computation when owner chain is empty (non-Pod signals) or when the LLM identifies a different target.
-3. **Simpler data flow**: Eliminates the SP -> RO -> AIAnalysis -> HAPI propagation of owner chain data across three service boundaries.
+1. **Accuracy**: Context is collected for the resource actually identified as the root cause, not the signal source.
+2. **Efficiency**: No wasted computation when the owner chain is empty (non-Pod signals) or when the LLM identifies a different target.
+3. **Simpler data flow**: Eliminates the SP → RO → AIAnalysis → KA propagation of owner chain data across three service boundaries.
 4. **Cleaner LLM context**: RCA reasoning is not biased by pre-loaded remediation history for potentially the wrong resource.
-5. **Agentic pattern**: Aligns with modern LLM tool-use patterns where the agent drives information gathering based on its analysis.
-6. **Graceful degradation**: If `get_namespaced_resource_context` / `get_cluster_resource_context` fails (K8s API unavailable, RBAC issues), the LLM can still complete RCA and workflow selection without historical context, and it can reason about the failure explicitly.
-7. **Better Rego policies**: `affected_resource` (kind, name, namespace) as Rego input enables granular, per-kind approval rules -- strictly more powerful than the previous boolean `target_in_owner_chain`.
-8. **Enforced data quality** *(superseded for identity — BR-496 v2 / DD-KA-006 v2.0: KA injects `remediationTarget` from the K8s-verified owner chain)*: `affectedResource` as a required response field with validation was intended to ensure downstream consumers (`resolveDualTargets` (DD-EM-003), WFE creator, audit trail) always have the target resource.
+5. **Guaranteed correctness over agentic optionality**: Making enrichment automatic (rather than purely LLM-tool-driven) removes the risk of an investigation completing without target-scoped context because the LLM didn't think to ask for it.
+6. **Better Rego policies**: `remediation_target` (kind, name, namespace) as Rego input enables granular, per-kind approval rules — strictly more powerful than a boolean owner-chain-membership flag.
 
 ---
 
@@ -385,19 +112,19 @@ Issue #97 introduced these capabilities:
 
 | Risk | Likelihood | Impact | Mitigation |
 |------|-----------|--------|------------|
-| Additional latency from tool call round-trip | Medium | Low | Session-based async flow handles multi-turn interactions. Tool performs 3 sequential K8s/DS calls (~1-5s total). Spec hash + history fetch can be parallelized once root owner is known. |
-| Owner-chain re-enrichment may hard-fail after retry exhaustion | Low | Medium | KA retries owner-chain resolution before giving up. **BR-496 v2 (DD-KA-006 v2.0)**: If owner-chain re-enrichment hard-fails, KA flags `needs_human_review=true` with `human_review_reason=rca_incomplete` (`internal/kubernautagent/investigator/investigator_discovery.go`). |
-| LLM omits `affectedResource` from RCA | Low | Low | `affectedResource` enforced as required field by response validator (3-attempt self-correction loop). Same pattern as `severity`, `summary`. |
-| LLM identifies wrong target, fetches wrong context | Low | Low | Same risk exists today (pre-computed context may also be for wrong resource). The new flow is strictly better because the LLM can correct itself. **BR-496 v2 (DD-KA-006 v2.0)**: Stored target identity follows the K8s-verified owner chain via KA's `InjectRemediationTarget`, not a mismatch-driven human review path. |
-| Rego policy breakage during migration | Medium | High | Rego input schema update (`target_in_owner_chain` → `affected_resource`) must be atomic. Test with existing E2E approval tests. See BR-AI-085-005 for default-deny safety pattern. |
+| Additional latency from automatic enrichment on every investigation | Low | Low | `Enricher.Enrich` performs a small number of sequential K8s/DataStorage calls; K8s client caching and DD-KA-016's indexed queries keep this bounded. |
+| Owner-chain re-enrichment fails (RBAC, timeout, API unavailable) | Low | Medium | KA retries owner-chain resolution before giving up. Per BR-496 v2 / DD-KA-006 v2.0, if it hard-fails, KA sets `needs_human_review=true` with `human_review_reason=rca_incomplete` (`internal/kubernautagent/investigator/investigator_discovery.go`). |
+| LLM identifies the wrong target, so KA enriches the wrong resource | Low | Low | Same risk existed under the pre-computation model. KA's automatic enrichment is strictly better because it targets the LLM's RCA output rather than a fixed pre-RCA guess, and target identity is ultimately K8s-verified (DD-KA-006) before being injected into workflow parameters. |
+| Rego policy input schema drift | Low | Medium | `remediation_target` is a stable, tested field on `RegoInput` (`pkg/aianalysis/rego/evaluator.go`); covered by existing approval-policy tests. |
 
 ---
 
-## References
+## Related Decisions
 
-- **DD-KA-017**: Three-step workflow discovery integration
-- **DD-KA-016**: Remediation history context via spec-hash matching
-- **Issue #97**: Owner chain / AffectedResource / SpecHash (superseded)
-- **DD-WORKFLOW-001 v1.7-1.8**: Owner chain schema and validation
-- **DD-EM-002**: Canonical spec hash computation
-- **BR-AI-085**: Rego Policy Input Schema for Approval Decisions (includes default-deny safety pattern)
+- **[DD-KA-006](DD-KA-006-remediation-target-in-rca.md)**: Remediation target identity — K8s-verified owner-chain injection, the current authority for how target identity flows into workflow execution.
+- **[DD-KA-016](DD-KA-016-remediation-history-context.md)**: Remediation history context via target-scoped, spec-hash-matched queries — the current authority for the history-fetch mechanics referenced above.
+- **[DD-KA-017](DD-KA-017-three-step-workflow-discovery-integration.md)**: Three-step workflow discovery — the current authority for how enrichment results (labels, history) reach the LLM during workflow selection.
+- **[DD-KA-018](DD-KA-018-detected-labels-detection-specification.md)**: DetectedLabels detection specification — the current authority for the 12 infrastructure characteristics computed during enrichment.
+- **[ADR-056](ADR-056-post-rca-label-computation.md)**: Post-RCA label computation — extends this decision's target-scoping principle to DetectedLabels.
+- **[DD-EM-002](DD-EM-002-canonical-spec-hash.md)**: Canonical spec hash computation.
+- **BR-AI-085**: Rego Policy Input Schema for Approval Decisions (includes default-deny safety pattern).

--- a/docs/architecture/decisions/ADR-056-post-rca-label-computation.md
+++ b/docs/architecture/decisions/ADR-056-post-rca-label-computation.md
@@ -1,12 +1,10 @@
-# ADR-056: Post-RCA Label Computation Relocation
+# ADR-056: Post-RCA Label Computation (Target-Scoped, Not Signal-Scoped)
 
 **Status**: ACCEPTED
 **Decision Date**: 2026-02-12
-**Version**: 1.7
-**Confidence**: 96%
+**Version**: 2.0 (Go rewrite)
+**Confidence**: 94%
 **Applies To**: SignalProcessing, Kubernaut Agent (KA), AIAnalysis Controller, Data Storage
-
-> **Note (2026-08-01, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: Cross-references to DD-HAPI-017/018 below have been updated to their current DD-KA-017/018 equivalents. The remaining body text (change history, "session_state" mechanism, Python file paths) still describes the pre-Go-rewrite implementation and has not yet been fully rewritten against `internal/kubernautagent/enrichment/label_detector.go` — treat DD-KA-018 as authoritative for current detection behavior, and DD-KA-017 for the current tool/label-injection mechanism, wherever this document's body conflicts with them.
 
 ---
 
@@ -14,14 +12,8 @@
 
 | Version | Date | Author | Changes |
 |---------|------|--------|---------|
-| 1.0 | 2026-02-12 | Architecture Team | Initial decision: relocate label computation from SP to HAPI post-RCA. Labels are HAPI-internal, not returned to LLM. |
-| 1.1 | 2026-02-12 | Architecture Team | Add DD-HAPI-018 cross-reference. Increase confidence to 96%. |
-| 1.2 | 2026-02-12 | Architecture Team | Align with DD-HAPI-017 v1.2 flow enforcement. Clarify session state wiring. |
-| 1.3 | 2026-02-20 | Architecture Team | Surface detected labels to LLM as read-only `cluster_context` in `list_available_actions` response. Labels remain HAPI-computed and are NOT LLM-managed parameters. The change gives the LLM explicit infrastructure context for informed action type selection (e.g., GitOps-managed, HPA-enabled). See DD-HAPI-017 v1.3, BR-HAPI-017-007. |
-| 1.4 | 2026-02-20 | Architecture Team | Phase 1 implementation: move label detection from `workflow_discovery.py` (signal source) into the `resource_context` toolset (`get_namespaced_resource_context` for namespaced RCA targets; cluster-scoped targets use `get_cluster_resource_context`). Add conditional `detected_infrastructure` response for one-shot LLM reassessment when active labels exist. Second call on the appropriate tool resolves new target context but skips label re-detection. See DD-HAPI-017 v1.4, BR-HAPI-017-008. |
-| 1.5 | 2026-03-12 | Architecture Team | Status changed from PROPOSED to ACCEPTED. Implementation verified complete: label detection in resource context tools, session-state propagation, `failedDetections` stripping all operational. Dead code (`should_include_detected_labels()`) tracked as tech debt (#345). |
-| 1.6 | 2026-03-24 | Architecture Team | **Issue #524**: Document tool split — `get_namespaced_resource_context` and `get_cluster_resource_context` in the `resource_context` toolset; `resource_scope` in `session_state`. Narrative and diagrams updated from legacy `get_resource_context` name. |
-| 1.7 | 2026-03-25 | Architecture Team | **Issue #529**: Label detection moves from `resource_context` tools to `EnrichmentService` (Phase 2 of three-phase RCA). Labels are now detected for the K8s-verified root owner resolved by HAPI (not the resource the LLM investigated via the tool). `_detect_labels_if_needed` removed from `resource_context.py`; `_build_k8s_context` extracted to shared utility. Labels provided to LLM via enrichment prompt in Phase 3, not via tool response. `session_state["detected_labels"]` no longer written by resource context tools. See BR-HAPI-264. |
+| 1.0–1.7 | 2026-02-12 to 2026-03-25 | Architecture Team | Historical evolution under the Python-era implementation: relocated label computation from SignalProcessing to a `HAPI`-internal step, added a read-only `cluster_context` surfaced in the `list_available_actions` tool response, added a one-shot `detected_infrastructure` field on the resource-context tool response for RCA reassessment, then moved detection into a `HAPI`-internal `EnrichmentService` (Issue #529). Superseded by v2.0 below; see git history for the original entries. |
+| 2.0 | 2026-08-02 | — | Rewritten against the Go KA implementation as part of [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806). **Key correction**: the decision this ADR records — compute infrastructure labels for the RCA-identified target's root owner, not the pre-RCA signal source — is unchanged and confirmed implemented (`internal/kubernautagent/enrichment/label_detector.go`). But the delivery mechanism the Python-era design built (a read-only `cluster_context` tool-response field plus a one-shot `detected_infrastructure` reassessment field) was **not carried into the Go rewrite** — neither string appears anywhere in `internal/kubernautagent/`. The actual Go mechanism is simpler: labels are (1) rendered directly into the investigation prompt (`internal/kubernautagent/prompt/builder.go`) and (2) propagated via `SignalContext.DetectedLabelsJSON` on `context.Context` to filter workflow-discovery queries (`internal/kubernautagent/tools/custom/tools.go`) — not a shared mutable `session_state` dict. Replaced the Python "Changes Required" migration-plan tables with a pointer to the current Go implementation and to [DD-KA-018](DD-KA-018-detected-labels-detection-specification.md) (label count corrected from 7–9 to the current 12 characteristics) and [DD-KA-017](DD-KA-017-three-step-workflow-discovery-integration.md). Renamed `HAPI` → Kubernaut Agent (KA) throughout. |
 
 ---
 
@@ -29,13 +21,13 @@
 
 ### Background: ADR-055 Exposed a Deeper Gap
 
-ADR-055 moved context enrichment (owner chain resolution, spec hash, remediation history) from pre-LLM computation to LLM-driven post-RCA tool calls in the `resource_context` toolset (`get_namespaced_resource_context` for namespaced targets; `get_cluster_resource_context` for cluster-scoped targets such as Node or PV). This correctly addresses the "wrong resource context" problem for those three data points.
+[ADR-055](ADR-055-llm-driven-context-enrichment.md) moved owner-chain resolution, spec hash, and remediation history from pre-RCA signal-source computation to post-RCA target-scoped computation. That correctly addressed the "wrong resource context" problem for those three data points.
 
-However, ADR-055 did not address **DetectedLabels**, which suffer from the same fundamental flaw: they are computed at **signal time** for the **signal source resource** by SignalProcessing, then propagated downstream to HAPI for workflow discovery and LLM prompt context.
+It did not, at the time, address **DetectedLabels**, which suffer from the same flaw: they were computed at **signal time** for the **signal source resource** by SignalProcessing, then propagated downstream for workflow discovery and LLM prompt context.
 
 ### The Stale Labels Problem
 
-When the LLM's RCA identifies a resource different from the signal source, the DetectedLabels computed by SP are **stale and potentially misleading**:
+When the LLM's RCA identifies a resource different from the signal source, DetectedLabels computed for the signal source are **stale and potentially misleading**:
 
 ```
 Signal: Pod "api-xyz" in namespace "prod" crashes
@@ -55,183 +47,67 @@ Workflow discovery receives SP's DetectedLabels:
   - Result: Returns Deployment-oriented workflows instead of Node remediation workflows
 ```
 
-This is not an edge case. RCA routinely pivots to a different resource:
-
-| Signal Source | RCA Target | SP Labels Valid? |
-|--------------|------------|-----------------|
-| Pod crash | Deployment misconfiguration (in owner chain) | Yes |
-| Pod OOMKill | Container resource limits on Deployment | Yes |
-| Pod CrashLoopBackOff | Bad ConfigMap mount | No |
-| Pod crash | Node memory pressure | No |
-| Service latency | Upstream dependency failure | No |
-| Pod eviction | PVC storage class issue | No |
-
-Conservative estimate: ~30-40% of RCA results identify a resource outside the signal source's owner chain.
-
-### Current Data Flow
-
-```
-SignalProcessing                  AIAnalysis              HAPI
-+-----------------------+         +----------+           +----------------------+
-| 1. Compute OwnerChain |         |          |           |                      |
-| 2. Detect labels      |-------->| Copy to  |---------->| prompt_builder:      |
-|    (signal source)    |  enrich | AIA spec |   request |   cluster context    |
-| 3. Store in SP status |  results|          |           |   filter instructions|
-+-----------------------+         +----------+           |                      |
-                                                         | workflow_discovery:  |
-                                                         |   detected_labels    |
-                                                         |   query param        |
-                                                         +----------------------+
-```
-
-SP computes labels for the **signal source** at signal time. These flow through three CRD boundaries (SP -> RO -> AIAnalysis -> HAPI) and are used for:
-
-1. **LLM Prompt Context** (`prompt_builder.py`): `build_cluster_context_section()` converts labels to natural language (e.g., "This namespace is managed by GitOps (argocd)")
-2. **Workflow Discovery Filtering** (`workflow_discovery.py`): Labels passed as `detected_labels` query parameter to Data Storage
-3. **Workflow Search Scoring** (`search.go`): Labels used for boost/penalty scoring in POST search
-
-### Evidence of the Gap in Existing Code
-
-The gap was anticipated but never resolved:
-
-- **`should_include_detected_labels()`** in `kubernaut-agent/src/toolsets/workflow_discovery.py` (line 152): A guard function that checks whether the RCA target matches the signal source before including DetectedLabels. It is **defined but never called** -- the exact guard for this gap was written but never wired into the workflow discovery flow.
-
-- **Data Storage discovery SQL** in `pkg/datastorage/repository/workflow/discovery.go`: `detected_labels` are parsed from the request but **not used in the discovery SQL queries** -- they only participate in boost/penalty scoring in the separate POST search flow. This means the three-step discovery path (list actions -> list workflows -> get workflow) already operates without label filtering.
+This is not an edge case — RCA routinely identifies a resource outside the signal source's owner chain (Pod crash → Node memory pressure; Pod eviction → PVC storage class issue; Service latency → upstream dependency failure).
 
 ### Business Requirements Affected
 
-- **BR-SP-101**: DetectedLabels auto-detection (8 characteristics) -- scope changes from pipeline-wide to SP-internal
-- **BR-SP-103**: FailedDetections tracking -- stays within SP
-- **BR-HAPI-194**: Honor `failedDetections` in workflow filtering -- moves to HAPI-computed labels
-- **BR-KA-250/252**: DetectedLabels integration with Data Storage -- labels now computed by HAPI
-- **DD-WORKFLOW-001 v1.7/v2.1/v2.2**: DetectedLabels schema and validation -- architectural relocation
+- **BR-SP-101**: DetectedLabels auto-detection — scope is SP-internal (signal classification only)
+- **BR-SP-103**: FailedDetections tracking — stays within SP
+- **BR-KA-264/265**: Post-RCA label detection and use in workflow discovery
 
 ---
 
 ## Decision
 
-### Relocate Label Computation from SignalProcessing to HAPI (Post-RCA, Internal)
+### Relocate Label Computation from SignalProcessing to KA (Post-RCA, Automatic)
 
-Move label detection from signal time (SP) to post-RCA time (HAPI), aligned with the actual remediation target resource identified by the LLM. Labels are computed by HAPI and used for three purposes: (1) transparently injected into DataStorage workflow discovery queries as filter criteria, (2) **surfaced read-only to the LLM** as `cluster_context` in the `list_available_actions` tool response (v1.3), and (3) **conditionally returned in the `get_namespaced_resource_context` / `get_cluster_resource_context` response** (whichever applies to the target scope) as `detected_infrastructure` when active labels exist, enabling the LLM to reassess its RCA strategy before workflow selection (v1.4). The LLM does not manage or pass labels as parameters -- they are computed once (one-shot) and injected into responses for reasoning context only.
+Compute infrastructure labels for the **resolved root owner of the RCA-identified target**, not the signal source — as part of the same automatic enrichment pass ADR-055 introduced, not a separate LLM-triggered step.
 
-### Foundational Principle: Impact vs. Target
+### Foundational Principle: Impact vs. Target (unchanged)
 
-The architecture separates two fundamentally different classification scopes:
+- **Impact-scoped (SignalProcessing, pre-RCA)**: Business classification — environment, priority, severity, business unit. These describe the **business impact of the signal** and remain correct regardless of what RCA identifies as the root cause.
+- **Target-scoped (KA, post-RCA)**: DetectedLabels — stateful, hpaManaged, helmManaged, pdbProtected, GitOps-managed, service mesh, CNV/KubeVirt characteristics, etc. These describe **operational properties of the remediation target** and can only be answered correctly for the actual target RCA identifies.
 
-- **Impact-scoped (SP, pre-RCA)**: Business classification -- environment, priority, severity, business unit. These describe the **business impact of the signal**: which service is affected, in which environment, how urgent is it. These are valid at signal time and remain correct regardless of what the RCA identifies as the root cause. A Pod crash in production is P0 whether the fix targets a Pod, a Deployment, or a Node.
+SignalProcessing owns impact classification. KA owns target properties. Neither crosses into the other's domain.
 
-- **Target-scoped (HAPI, post-RCA)**: DetectedLabels -- stateful, hpaManaged, helmManaged, pdbProtected, etc. These describe **operational properties of the remediation target**: what constraints apply to the resource we are about to fix. These can only be answered correctly for the actual target identified by RCA.
-
-SP owns impact classification. HAPI owns target properties. Neither crosses into the other's domain.
-
-### Proposed Architecture
+### Current Implementation (Go KA)
 
 ```
-SignalProcessing                  AIAnalysis              HAPI
-+-----------------------+         +----------+           +-----------------------------------+
-| Business classif.:    |         |          |           | 1. LLM performs RCA               |
-|  - environment        |         | Signal   |           | 2. LLM calls                      |
-|  - priority           |         | context  |---------->|    get_namespaced_resource_context()|
-|  - severity           |         | only     |  request  |    or get_cluster_resource_context() |
-|                       |         |          |           |    for RCA target (by scope)       |
-|  - business unit      |         | (no      |           | 3. Tool internally:                |
-|                       |         |  labels  |           |    - Resolves owner chain          |
-| DetectedLabels:       |         |  or      |           |    - Computes spec hash            |
-|  (SP-internal only)   |         |  owner   |           |    - Fetches history               |
-|  for audit/classify   |         |  chain)  |           |    - Computes labels (one-shot)    |
-+-----------------------+         +----------+           |    - Stores labels in session state|
-                                                         |    Returns to LLM:                 |
-                                                         |      root_owner + history          |
-                                                         |      + detected_infrastructure     |
-                                                         |        (only if active labels)     |
-                                                         |                                    |
-                                                         | 3a. (v1.4) If active labels:       |
-                                                         |    LLM reassesses RCA strategy.    |
-                                                         |    May call the appropriate        |
-                                                         |    resource_context tool again     |
-                                                         |    (get_namespaced_* or get_cluster|
-                                                         |    _*; root_owner + history only,  |
-                                                         |    no label re-detection).         |
-                                                         |                                    |
-                                                         | 4. LLM calls list_available_actions|
-                                                         |    HAPI injects stored labels into |
-                                                         |    DataStorage query AND returns   |
-                                                         |    them as read-only cluster_context|
-                                                         |    in tool response (v1.3)         |
-                                                         |                                    |
-                                                         | 5. LLM calls list_workflows        |
-                                                         |    HAPI transparently injects      |
-                                                         |    stored labels into DS query     |
-                                                         +-----------------------------------+
+SignalProcessing              AIAnalysis           Kubernaut Agent (KA)
++----------------------+      +----------+         +--------------------------+
+| Business classif.:   |      |          |         | 1. LLM performs RCA      |
+|  - environment       |      | Signal   |-------->| 2. KA resolves enrichment|
+|  - priority          |      | context  | request |    target (ADR-055)      |
+|  - severity          |      | only     |         | 3. Enricher.Enrich runs  |
+|  - business unit     |      | (no      |         |    automatically:         |
+|                      |      |  labels  |         |    - owner chain, spec    |
+| DetectedLabels:      |      |  or      |         |      hash, history        |
+|  (SP-internal only)  |      |  owner   |         |    - LabelDetector:       |
+|  for its own audit/  |      |  chain)  |         |      12 characteristics   |
+|  classification      |      |          |         |      for the root owner   |
++----------------------+      +----------+         | 4. Labels rendered into   |
+                                                    |    investigation prompt   |
+                                                    | 5. Labels propagated via  |
+                                                    |    SignalContext.         |
+                                                    |    DetectedLabelsJSON to  |
+                                                    |    filter list_workflows/ |
+                                                    |    list_available_actions |
+                                                    +--------------------------+
 ```
 
 ### Key Design Principles
 
-1. **Impact vs. target separation.** Business classification (SP) describes signal impact and is stable across RCA outcomes. DetectedLabels (HAPI) describe the remediation target and must be computed post-RCA for the correct resource.
+1. **Impact vs. target separation** (unchanged). Business classification (SignalProcessing) describes signal impact and is stable across RCA outcomes. DetectedLabels (KA) describe the remediation target and are computed post-RCA for the correct resource.
 
-2. **DetectedLabels are HAPI-computed, read-only to the LLM.** Labels are computed by HAPI during the applicable `resource_context` tool call (`get_namespaced_resource_context` or `get_cluster_resource_context`, post-RCA) and stored in session state. They are **not passed as tool parameters** (the LLM cannot set or override them). HAPI transparently injects them into workflow discovery queries as filter criteria. **v1.3**: Labels are also surfaced to the LLM as a read-only `cluster_context` section in the `list_available_actions` tool response, giving the LLM explicit infrastructure context (e.g., "this is ArgoCD-managed") for informed action type selection. **v1.4**: When active labels are detected, they are also returned in that tool's response as `detected_infrastructure`, enabling the LLM to reassess its RCA strategy (e.g., realizing that a GitOps-managed resource should be remediated via commit revert rather than direct patch). This is a **one-shot** mechanism: labels are computed on the first resource-context tool call only; subsequent calls for revised targets resolve root_owner + history but skip label re-detection. The LLM's tool interface remains simple -- no label parameters, no risk of label hallucination -- but the LLM can now reason about detected infrastructure characteristics at both RCA reassessment time (via `detected_infrastructure`) and workflow selection time (via `cluster_context`).
+2. **DetectedLabels are KA-computed and delivered two ways, both read-only to the LLM.** Labels are computed once per investigation, during the same automatic enrichment pass that resolves owner chain/spec hash/history (ADR-055) — not via a separate LLM tool call, and not stored in a shared mutable dict. They reach the LLM through: (a) direct rendering into the investigation prompt (`internal/kubernautagent/prompt/builder.go`, e.g. "Detected labels: hpaManaged=true, helmManaged=true"), giving the LLM infrastructure context during RCA and workflow-selection reasoning; and (b) transparent injection as filter criteria into `list_available_actions`/`list_workflows` catalog queries via `SignalContext.DetectedLabelsJSON` (`internal/kubernautagent/tools/custom/tools.go`). The LLM never passes labels as a tool parameter and cannot override them. **Simplified from the original Python-era design**: the earlier read-only `cluster_context` tool-response field and the one-shot `detected_infrastructure` RCA-reassessment field were not carried into the Go rewrite — direct prompt rendering replaced both.
 
-3. **Workflow discovery `list_workflows` drops the `detected_labels` parameter.** The LLM calls `list_workflows(action_type)` and HAPI internally applies the stored labels as filter criteria. This is completely transparent from the LLM's perspective.
+3. **Workflow discovery tools take no label parameter.** The LLM calls `list_workflows(action_type)` with no `detected_labels` argument; KA applies the stored labels as filter criteria internally. This is unchanged from the original decision.
 
-4. **SP keeps its own labels for internal purposes.** SP still computes labels for signal classification, audit events (`HasOwnerChain`, `OwnerChainLength`), and internal detection. These do not leave SP.
+4. **SignalProcessing keeps its own labels for internal purposes.** SP still computes labels for signal classification and its own audit events. These do not leave SP.
 
-5. **The `resource_context` toolset (`get_namespaced_resource_context` / `get_cluster_resource_context`) is the single source of truth for target context.** ADR-055 already made these tools the source for owner chain, spec hash, and remediation history. Adding label detection completes the picture.
+5. **KA's enrichment pass (ADR-055) is the single source of truth for target context, including labels.** Owner chain, spec hash, remediation history, and DetectedLabels are all resolved together, for the same RCA-identified target, in the same automatic pass — not four independently-triggered lookups.
 
-6. **CustomLabels (Rego-extracted) stay as-is.** Customer-defined Rego policies extract labels from the signal source resource. These are a customer extension point and should be designed for impact/signal-scoped properties (team, cost-center, service-tier) rather than resource-specific mechanics. Guidance will be documented. Moving customer Rego execution to HAPI post-RCA is a potential future iteration but out of scope for this decision.
-
-7. **No backwards compatibility required.** The system has not been released. All changes are forward-only.
-
----
-
-## Changes Required
-
-### Phase 1: Extend `resource_context` Tools with Label Detection and One-Shot Reassessment
-
-| File | Change | Rationale |
-|------|--------|-----------|
-| `kubernaut-agent/src/toolsets/resource_context.py` | Add label detection logic to the namespaced and cluster resource context tool implementations (`_invoke_async()`). After resolving owner chain (when applicable), detect: gitOpsManaged, pdbProtected, hpaEnabled, stateful, helmManaged, networkIsolated, serviceMesh. **Store labels in session state** and `resource_scope`. **v1.4**: Conditionally include `detected_infrastructure` in response when any label is active (boolean `true` or non-empty string). Omit when all defaults or on second call (one-shot: session_state sentinel prevents re-detection). Update tool `additional_instructions` for reassessment guidance. | Labels computed for the actual RCA target. Active labels surfaced for LLM reassessment before workflow selection. |
-| `kubernaut-agent/src/toolsets/workflow_discovery.py` | Remove `_ensure_detected_labels()`, `_compute_labels_async()`, `_build_k8s_context()`. Remove `k8s_client`, `resource_name`, `resource_namespace` params. Discovery tools now read labels exclusively from session_state (populated by `get_namespaced_resource_context` / `get_cluster_resource_context`). | Eliminates signal-source label computation. Labels come from RCA target via session_state. |
-| `kubernaut-agent/src/extensions/llm_config.py` | Wire `session_state` through `register_resource_context_toolset()`. Remove `k8s_client`, `resource_name`, `resource_namespace` from `register_workflow_discovery_toolset()`. | Session state shared between both toolsets. |
-| `kubernaut-agent/src/extensions/incident/llm_integration.py` | Pass `session_state` to resource context toolset. Remove K8s client and resource identity passing to workflow discovery. | Wiring change. |
-| `kubernaut-agent/src/extensions/recovery/llm_integration.py` | Same changes as incident flow. | Wiring change. |
-| `kubernaut-agent/src/clients/k8s_client.py` | No changes -- ADR-056 K8s extensions (list_pdbs, list_hpas, list_network_policies, get_namespace_metadata) already implemented. | Already done. |
-| `deploy/kubernaut-agent/service-rbac.yaml` | No changes -- `kubernaut-agent-investigator` ClusterRole already has PDB, HPA, NetworkPolicy RBAC. | Already done. |
-| `kubernaut-agent/tests/unit/test_resource_context_session_state.py` | Rewrite 9 tests (UT-HAPI-056-034 through 042) for label detection in resource context. Add 3 reassessment tests (UT-HAPI-056-090 through 092). | TDD: test each label detection and reassessment path |
-
-### Phase 2: Remove Label and OwnerChain Propagation from Pipeline
-
-| File | Change | Rationale |
-|------|--------|-----------|
-| `pkg/shared/types/enrichment.go` | Remove `OwnerChain []OwnerChainEntry` field from `EnrichmentResults` (**ADR-055: removed**). Keep `OwnerChainEntry` type (used by SP internally). | OwnerChain no longer propagated; SP uses its own CRD type |
-| `pkg/shared/types/enrichment.go` | Remove `DetectedLabels *DetectedLabels` field from `EnrichmentResults` (**ADR-056: removed, now in PostRCAContext**). Keep `DetectedLabels` type (used by SP internally). | Labels no longer propagated; SP uses them internally |
-| `pkg/remediationorchestrator/creator/aianalysis.go` | Remove `buildEnrichmentResults` OwnerChain copy logic and DetectedLabels copy logic | No longer propagated to AIAnalysis |
-| `pkg/aianalysis/handlers/request_builder.go` | Remove DetectedLabels mapping to HAPI request (OwnerChain mapping already removed by ADR-055) | HAPI computes its own labels |
-| `api/signalprocessing/v1alpha1/signalprocessing_types.go` | Keep `OwnerChain` in `KubernetesContext` (SP-internal) | SP still needs it for its own label detection |
-| `pkg/shared/types/zz_generated.deepcopy.go` | Regenerate with `controller-gen` after type changes | DeepCopy must match updated types |
-
-### Phase 3: Transparent Label Injection in Workflow Discovery
-
-| File | Change | Rationale |
-|------|--------|-----------|
-| `kubernaut-agent/src/toolsets/workflow_discovery.py` | Remove `should_include_detected_labels()` function. Remove `detected_labels` from `list_workflows` tool parameter schema. Update toolset to read labels from session state (stored by the `resource_context` tools) and inject them transparently into DataStorage queries. LLM calls `list_workflows(action_type)` with no label parameters. **v1.3 (BR-HAPI-017-007)**: In `ListAvailableActionsTool._invoke()`, after receiving the DS response, inject a `cluster_context` section containing the detected labels (with `failedDetections` stripped) and a natural-language note. This surfaces infrastructure context to the LLM for informed action type selection without making labels a tool parameter. | Labels are HAPI-computed; the LLM receives them as read-only context but cannot set or override them. Guard function no longer needed -- labels always match target. |
-| `kubernaut-agent/src/extensions/incident/prompt_builder.py` | Remove `build_cluster_context_section()` DetectedLabels rendering from LLM prompt. Labels are no longer provided as static prompt context -- they are surfaced dynamically via `cluster_context` in the `list_available_actions` tool response (v1.3). | Labels arrive at the right time (post-RCA, during workflow discovery) rather than at prompt construction time (pre-RCA) |
-| `kubernaut-agent/src/extensions/llm_config.py` | Update `register_workflow_discovery_toolset()` to not pass `detected_labels` from enrichment results. Toolset reads from session state instead. | Labels come from internal state, not request |
-
-### Phase 4: Update SP Internal Label Flow
-
-| File | Change | Rationale |
-|------|--------|-----------|
-| `internal/controller/signalprocessing/signalprocessing_controller.go` | Keep `detectLabels()` but store result in SP-specific status field instead of shared `EnrichmentResults` | Labels stay internal to SP |
-| `pkg/signalprocessing/audit/client.go` | Update audit to read labels from SP's internal field | Audit still captures label detection results |
-| `pkg/signalprocessing/detection/labels.go` | No changes -- label detection logic stays in SP for internal use | SP still detects labels for signal classification |
-
-### Phase 5: Cleanup
-
-| File | Change | Rationale |
-|------|--------|-----------|
-| `pkg/shared/types/enrichment.go` | Evaluate whether `EnrichmentResults` struct is still needed. If only `KubernetesContext` and `CustomLabels` remain, consider simplifying. | Reduce unnecessary abstraction |
-| `api/openapi/data-storage-v1.yaml` | Update OpenAPI spec if `detected_labels` parameter semantics change | API contract alignment |
-| Test files across `test/unit/`, `test/integration/`, `test/e2e/` | Update all tests that reference propagated OwnerChain or DetectedLabels | Test alignment with new architecture |
+6. **No backwards compatibility required.** Carried forward from the original decision; still true.
 
 ---
 
@@ -239,88 +115,61 @@ SignalProcessing                  AIAnalysis              HAPI
 
 ### Positive
 
-1. **Accurate workflow discovery**: Labels always describe the resource being remediated, not the signal source. Workflow selection matches the actual target.
-
-2. **Simpler LLM interface with informed context at two decision points**: The LLM does not manage DetectedLabels as tool parameters -- `list_workflows` drops the `detected_labels` parameter. Fewer tool parameters means less hallucination risk and simpler prompt engineering. **v1.3**: The LLM receives detected labels as read-only `cluster_context` in the `list_available_actions` response, enabling explicit reasoning about infrastructure characteristics during workflow selection. **v1.4**: The LLM also receives labels as `detected_infrastructure` in the `get_namespaced_resource_context` / `get_cluster_resource_context` response (when active), enabling RCA reassessment before workflow discovery (e.g., realizing that a GitOps-managed resource needs a commit revert, not a direct patch).
-
-3. **Simpler pipeline**: Removes OwnerChain and DetectedLabels propagation across three CRD boundaries (SP -> RO -> AIAnalysis -> HAPI). Fewer moving parts, fewer conversion points.
-
-4. **Clean separation of concerns**: SP owns business classification (impact-scoped, stable). HAPI owns target properties (resource-scoped, post-RCA). Each component classifies what it has visibility into.
-
-5. **Eliminates dead code**: `should_include_detected_labels()` and the unused discovery SQL label filtering become unnecessary.
-
-6. **Consistent with ADR-055**: Completes the architectural shift started by ADR-055. All target-specific context (owner chain, spec hash, history, labels) is now computed post-RCA for the actual target.
-
-7. **SP simplification**: SP's enrichment results become lighter. SP still performs label detection for its own audit and classification needs, but the results don't need serialization into shared types.
+1. **Accurate workflow discovery**: Labels always describe the resource being remediated, not the signal source.
+2. **Simpler LLM interface**: `list_workflows` takes no label parameter — fewer parameters, less hallucination risk.
+3. **Simpler pipeline**: Removes DetectedLabels propagation across CRD boundaries (SP → RO → AIAnalysis → KA); KA computes them directly against the K8s API for its resolved target.
+4. **Clean separation of concerns**: SignalProcessing owns business classification (impact-scoped, stable); KA owns target properties (resource-scoped, post-RCA).
+5. **Consistent with ADR-055**: Completes the architectural shift — all target-specific context (owner chain, spec hash, history, labels) is computed together, post-RCA, for the actual target.
+6. **Simpler than originally designed**: The Go implementation dropped the Python-era `cluster_context`/`detected_infrastructure` two-field delivery split in favor of straightforward prompt rendering, with no loss of the underlying guarantee (labels always describe the correct target).
 
 ### Negative
 
-1. **Additional K8s API calls at RCA time**: Label detection requires API calls (PDB lookup, HPA lookup, NetworkPolicy list, annotation inspection) during HAPI tool execution. Estimated ~5-8 additional API calls per investigation. Mitigated by K8s client caching.
-
-2. **Label detection logic duplication**: SP's original Go label detection (`pkg/signalprocessing/detection/labels.go`) was removed per this ADR; KA's `internal/kubernautagent/enrichment/label_detector.go` is now the sole implementation. **Mitigated by [DD-KA-018](DD-KA-018-detected-labels-detection-specification.md)**: the authoritative detection specification, kept in sync with the Go implementation.
-
-3. **Increased HAPI RBAC surface**: HAPI's ServiceAccount needs additional RBAC permissions for PDB, HPA, and NetworkPolicy resources.
-
-4. **Larger refactor scope**: Changes touch SP, AIAnalysis, RO, HAPI, Data Storage, and shared types. Requires careful phased execution.
+1. **Additional K8s API calls at RCA time**: Label detection (PDB, HPA, NetworkPolicy, ResourceQuota, CNV/KubeVirt lookups) runs as part of every investigation's enrichment pass. Mitigated by K8s client caching within `Enricher`.
+2. **Increased KA RBAC surface**: KA's ServiceAccount needs read access for PDBs, HPAs, NetworkPolicies, ResourceQuotas, and (for CNV/KubeVirt detections) VirtualMachine-related resources.
+3. **Single Go implementation, single point of specification drift risk**: `internal/kubernautagent/enrichment/label_detector.go` is the sole implementation (SignalProcessing's original Go label detector was retired per this ADR). Mitigated by [DD-KA-018](DD-KA-018-detected-labels-detection-specification.md), the authoritative detection specification kept in sync with the Go source.
 
 ---
 
 ## Alternatives Considered
 
-### Alternative A: Wire in `should_include_detected_labels()` Guard
+### Alternative A: Guard-Based Exclusion
 
-Keep SP-computed labels but activate the existing guard function to exclude them when RCA diverges from signal source.
+Keep SignalProcessing-computed labels but exclude them whenever RCA diverges from the signal source.
 
-**Rejected because**:
-- Only solves the "wrong labels" problem by exclusion (no labels at all), not by providing correct labels for the target
-- Workflow discovery would operate with no label context for ~30-40% of investigations
-- The guard function's owner chain dependency creates a circular problem (needs the chain to validate labels, but the chain describes the wrong resource)
+**Rejected because**: solves "wrong labels" only by removing labels entirely for ~30-40% of investigations where RCA diverges from the signal source — workflow discovery would then operate with no label context at all for those cases.
 
-### Alternative B: LLM-Driven Natural Language Filtering (No Labels)
+### Alternative B: LLM-Driven Natural-Language Filtering (No Structured Labels)
 
-Remove structured label filtering entirely. Let the LLM describe what it needs in natural language when calling workflow discovery.
+Remove structured label filtering; let the LLM describe infrastructure constraints in natural language.
 
-**Deferred because**:
-- Less deterministic -- harder to test and validate
-- Safety guardrails (Rego) benefit from structured label data (e.g., "require approval for stateful workload operations")
-- Could be revisited as the LLM-driven architecture matures
-- May be the right long-term direction but premature for v1.0
+**Deferred because**: less deterministic and harder to test; Rego-based safety guardrails benefit from structured label data (e.g., "require approval for stateful workload operations"). May be revisited as the architecture matures, but not adopted for V1.0.
 
-### Alternative C: SP Re-enriches After RCA
+### Alternative C: SignalProcessing Re-enriches After RCA
 
-After the LLM identifies the root cause, trigger a second SP enrichment pass for the RCA target resource.
+Trigger a second SignalProcessing enrichment pass for the RCA-identified target.
 
-**Rejected because**:
-- Adds round-trip latency (HAPI -> Controller -> SP -> Controller -> HAPI)
-- Architecturally backwards -- moves more work into the pipeline instead of simplifying it
-- The LLM already has direct K8s API access via `get_namespaced_resource_context` and `get_cluster_resource_context`
+**Rejected because**: adds a round-trip (KA → Controller → SP → Controller → KA) for something KA can compute directly against the K8s API in one pass, as part of the same enrichment step that already resolves owner chain and spec hash.
 
 ---
 
 ## Related Decisions
 
-- **[ADR-055](ADR-055-llm-driven-context-enrichment.md)**: LLM-Driven Context Enrichment (Post-RCA) -- prerequisite; established the `resource_context` toolset and post-RCA pattern (`get_namespaced_resource_context` / `get_cluster_resource_context` per Issue #524)
-- **[DD-KA-018 v2.0](DD-KA-018-detected-labels-detection-specification.md)**: DetectedLabels Detection Specification -- authoritative detection contract, now covering 12 characteristics (the original 7-9, plus 4 CNV/KubeVirt additions). Historically a cross-language SP/HAPI contract; KA (Go) is now the sole implementation.
-- **[DD-KA-017 v2.0](DD-KA-017-three-step-workflow-discovery-integration.md)**: Three-Step Workflow Discovery Integration -- the LLM-facing tool contract (`list_available_actions`/`list_workflows`/`get_workflow`) built on top of KA's own workflow catalog (see DD-WORKFLOW-019 for the DS→KA ownership move).
-- **DD-WORKFLOW-001 v1.7/v2.1/v2.2**: DetectedLabels schema and validation framework
-- **DD-CONTRACT-002**: Enrichment results schema -- will be updated to remove propagated fields
-- **BR-SP-101**: DetectedLabels auto-detection -- scope narrows to SP-internal
-- **BR-HAPI-194**: Honor failedDetections -- relocates to HAPI-computed labels
-- **BR-KA-250/252**: DetectedLabels in workflow search -- source changes from SP to HAPI
-- **Issue #102**: Implementation tracking issue
-- **Issue #132**: GitOps causality evidence chain and CRD safety guardrails -- identified during Phase 1 implementation
+- **[ADR-055](ADR-055-llm-driven-context-enrichment.md)**: Post-RCA Context Enrichment — prerequisite; established the automatic, target-scoped enrichment pass this decision's label computation is now part of.
+- **[DD-KA-018](DD-KA-018-detected-labels-detection-specification.md) v2.0**: DetectedLabels Detection Specification — authoritative detection contract, 12 characteristics, ground truth for `label_detector.go`.
+- **[DD-KA-017](DD-KA-017-three-step-workflow-discovery-integration.md) v2.0**: Three-Step Workflow Discovery Integration — authoritative for how labels reach workflow-discovery filtering via `SignalContext.DetectedLabelsJSON`.
+- **DD-WORKFLOW-001**: DetectedLabels schema and validation framework.
+- **BR-SP-101**: DetectedLabels auto-detection — scope is SP-internal.
+- **BR-KA-264/265**: DetectedLabels detection and use in workflow discovery.
 
 ---
 
 ## Confidence Assessment
 
-**Confidence: 96%** (up from 90% in v1.1)
+**Confidence: 94%**
 
-| Risk | v1.1 | v1.2 | Mitigation |
-|------|------|------|------------|
-| Label detection parity between SP (Go) and KA (Go) | 5% | ~1% | Both implementations are Go; DD-KA-018 remains the formal specification. Cross-language parity risk no longer applies now that HAPI's Python implementation has been fully retired. |
-| Label injection into workflow discovery | 5% | ~1% | KA propagates detected labels via `SignalContext.DetectedLabelsJSON` (request-context value, not a shared mutable dict) — see DD-KA-017. |
+| Risk | Assessment |
+|------|-----------|
+| Label detection specification drift | Low. Single Go implementation (`label_detector.go`); DD-KA-018 is the formal specification kept in sync with source, both dated 2026-08-01. |
+| RBAC configuration gaps | Low-Medium. KA's ServiceAccount needs PDB/HPA/NetworkPolicy/ResourceQuota/CNV-VM RBAC; missing grants surface as `FailedDetections` entries rather than silent wrong data (fail-observable, not fail-silent). |
 
-**Residual gap (4%)**:
-- Python K8s client behavioral differences (~2%): Label selector matching, error types, and timeout behavior differ between Go's controller-runtime and Python's `kubernetes` client. Mitigated by conformance test vectors.
-- RBAC configuration for HAPI (~2%): HAPI's ServiceAccount needs PDB, HPA, and NetworkPolicy RBAC. If not granted, all API-based detections fail via FailedDetections. Mitigated by Helm chart RBAC templates.
+**Residual gap (6%)**: The read-only `cluster_context`/`detected_infrastructure` reassessment mechanism the Python-era design specified was not reimplemented in Go (see v2.0 changelog). This ADR treats that as an intentional simplification confirmed by the current implementation, not a gap to close — but it is called out here in case a future iteration wants the one-shot RCA-reassessment capability back.


### PR DESCRIPTION
## Summary

PR3b-4 of [#1806](https://github.com/jordigilh/kubernaut/issues/1806): rewrites `ADR-055-llm-driven-context-enrichment.md` and `ADR-056-post-rca-label-computation.md`, the two files in the "self-declared-stale" Group E of the PR3b triage.

Both ADRs already carried a 2026-08-01 note saying their body (Python-era mechanics) hadn't been fully rewritten against the Go implementation, deferring to `DD-KA-016`/`DD-KA-017`/`DD-KA-018`. Verified those three docs are accurate (all rewritten 2026-08-01 as part of this same issue) before using them as ground truth, then found the mechanism itself — not just the Python↔Go terminology — had changed:

- **ADR-055**: originally decided the LLM must call a resource-context tool (`get_namespaced_resource_context`/`get_cluster_resource_context`) to trigger context enrichment. That's not what's implemented: `Investigator.resolveEnrichment` → `Enricher.Enrich` (`internal/kubernautagent/{investigator,enrichment}`) runs **automatically** once RCA resolves a target, for every investigation. The tools still exist and are registered but are a secondary path, not the trigger. Also corrected the Rego input field name (`remediation_target`, not the originally-proposed `affected_resource` — confirmed via `pkg/aianalysis/rego/evaluator.go` and the existing `ADR-055-ADDENDUM-001` rename record).
- **ADR-056**: the Python-era design's label-delivery mechanism (a read-only `cluster_context` tool-response field, plus a one-shot `detected_infrastructure` RCA-reassessment field) was never carried into the Go rewrite — verified neither string exists anywhere under `internal/kubernautagent/`. The actual mechanism is simpler: labels are rendered directly into the investigation prompt (`internal/kubernautagent/prompt/builder.go`) and propagated via `SignalContext.DetectedLabelsJSON` to filter workflow-discovery queries — not a shared mutable `session_state` dict.

The underlying decision rationale both ADRs are built on — compute owner-chain/spec-hash/history/labels for the RCA-identified target, not the pre-RCA signal source — is unchanged and confirmed still implemented exactly as intended. Kept that rationale, consequences, and alternatives-considered sections; collapsed the (already-executed, historical) Python migration-plan tables into short pointers at the real Go source and the DD-KA-016/017/018 authorities; swapped remaining HAPI → Kubernaut Agent (KA) terminology.

## Test plan

- [x] Verified the automatic (non-tool-driven) enrichment mechanism against `internal/kubernautagent/investigator/investigator.go` (`resolveEnrichment`, `ResolveEnrichmentTarget`) and `internal/kubernautagent/enrichment/enricher.go`.
- [x] Verified `get_namespaced_resource_context`/`get_cluster_resource_context` are still registered (`cmd/kubernautagent/toolregistry.go`) but not a hard prerequisite (confirmed against `DD-KA-017`'s own text).
- [x] Verified `cluster_context`/`detected_infrastructure` do not exist anywhere in `internal/kubernautagent/` (grep, zero matches) before removing that mechanism from ADR-056's description.
- [x] Verified label rendering into the prompt (`internal/kubernautagent/prompt/builder.go`) and discovery-query filtering (`internal/kubernautagent/tools/custom/tools.go`) as the actual current mechanism.
- [x] Verified the Rego `remediation_target` field name against `pkg/aianalysis/rego/evaluator.go` and cross-checked against `ADR-055-ADDENDUM-001-remediation-target-rename.md`.
- [x] Confirmed all new cross-reference links (`DD-KA-006/016/017/018`, `DD-EM-002`) resolve to existing files.
- [x] Docs-only change; no code touched.
