### PR TITLE
fix(mock-llm): support N-deep NextToolCall chaining + fallback_arguments (#1853)

### DIFF
--- a/docs/testing/1853/CONSOLE_TEAM_SUMMARY.md
+++ b/docs/testing/1853/CONSOLE_TEAM_SUMMARY.md
@@ -1,0 +1,98 @@
+# Findings Summary for the Console Team — Issue #1853
+
+**Audience**: kubernaut-console team
+**Related**: [#1853](https://github.com/jordigilh/kubernaut/issues/1853) (this fix), [#1855](https://github.com/jordigilh/kubernaut/issues/1855) (formal documentation of the 3 modes below — tracked separately, closes in a follow-up PR)
+**Status**: Fix implemented, unit tests green; standalone-investigate fallback fix AND mode-2/mode-3 chaining are both live-validated against the shared cluster (direct reproduction, not yet via the Ginkgo E2E specs themselves — see caveat below)
+
+---
+
+## ⚡ If you were seeing `invalid rr_id` errors on the shared cluster
+
+**That's fixed and already deployed** to the `fullpipeline-e2e` cluster you're using for Playwright testing (as of this update). It was a **separate, pre-existing defect** in the same test-double code area, found while investigating #1853 — not something #1853 introduced. Root cause and fix are in "What we actually fixed", item 3 below. If you send a bare "investigate ..." message with no prior "remediate" in the same session, it now correctly creates a new investigation against `kubernaut-system/Deployment/memory-eater` instead of erroring. No action needed on your side — just confirming your Playwright runs should stop hitting this.
+
+---
+
+## TL;DR
+
+A single chat message that combines "investigate" and "remediate" intent — e.g. *"the memory-eater deployment is OOMKilling, investigate and fix it"* — was completely broken end-to-end in our `fullpipeline` E2E test environment. It's fixed now. While fixing it, we discovered AF actually supports **three** distinct behaviors for this kind of request, not one, and only one of the three had any test coverage before this work. All three now have E2E coverage. Read below to know which one your UI copy/flow should assume for a given phrasing, and what each one actually does.
+
+---
+
+## The 3 modes AF supports today
+
+These are defined in AF's production system prompt (`pkg/apifrontend/agent/prompt.txt`) and are **already live in production** — this issue only added test coverage for them, it did not add new AF behavior.
+
+### Mode 1 — Autonomous ("fire-and-forget fix")
+
+**Triggered by**: "fix", "remediate", "address", "resolve", "heal" + a target, when the user does not expect to interact further.
+**Example**: *"remediate the memory-eater deployment"*
+
+**What happens**: AF calls `kubernaut_remediate` once and confirms. That's it — no RCA is streamed to the chat, no findings are shown, no workflow choice is presented. The remediation pipeline (investigation, workflow selection, execution) runs entirely server-side. If your UI wants to show progress for this mode, it needs to poll/watch the RR separately (e.g. via `kubernaut_get_remediation` or a list view) — the chat turn itself will not narrate it.
+
+**Was this broken by #1853?** No. A single tool call has nothing to chain, so this mode was never affected.
+
+### Mode 2 — Interactive ("investigate, then wait for me")
+
+**Triggered by**: "investigate", "what's wrong with", "diagnose", "look into".
+**Example**: *"investigate the memory-eater deployment"*, or the combined form *"create and investigate a remediation for memory-eater"*
+
+**What happens**: AF calls `kubernaut_investigate`, streams live reasoning/tool-call events during the investigation, then presents the root-cause findings and **stops**. It will not discover or select a workflow until the user says so in a follow-up message (e.g. "show me remediation options").
+
+**Was this broken by #1853?** **Yes — this is the original bug report.** When a single message combined create-a-remediation + investigate intent, our E2E mock-LLM test fixture had no way to chain `kubernaut_remediate` → `kubernaut_investigate` within one turn while correctly passing the real, server-generated `rr_id` from the first call into the second. It's fixed now (see "What we fixed" below). **This was a test-fixture defect only — AF's real production code path for this was already correct** (confirmed via code review of `HandleRemediate`/`HandleInvestigate`); the bug only prevented our E2E suite from *proving* it worked.
+
+### Mode 3 — Full Interactive Remediation ("investigate and fix, no manual pause")
+
+**Triggered by**: "investigate and fix", "diagnose and remediate", "look into and fix" — i.e. combined intent where the user wants the fix applied but still wants full transparency into what was found and what's being done.
+**Example**: *"investigate and fix the memory-eater deployment"*
+
+**What happens**: AF calls `kubernaut_investigate` (same RCA transparency as mode 2 — findings ARE streamed to the user), but instead of stopping, it **automatically continues**: discovers available workflows, **auto-selects the highest-confidence one** (no "please choose a workflow" prompt), and watches it through to completion — all within the same conversation turn, driven by one user message. Approval gates (if the selected workflow requires one) still pause and require the console's Approve/Reject buttons exactly as in any other flow; the "no pause" here refers only to *workflow selection*, not to safety approval gates.
+
+**Was this broken by #1853?** **Yes, and more severely than mode 2** — this needs a 4-deep tool call chain (`investigate` → `discover_workflows` → `select_workflow` → `watch`) with the `rr_id` correctly propagated to 3 different downstream calls. Our test infrastructure had a hard cap of exactly one chained call, so this mode had **zero test coverage at all** before this work — it wasn't just broken, it was silently unverifiable. This mode's *behavior* was not previously documented anywhere the console team would have seen it either (that's what issue #1855 tracks fixing).
+
+---
+
+## What we actually fixed
+
+Three changes, all confined to **test infrastructure** (`test/`) — no AF production code (`pkg/`, `cmd/`) changed:
+
+1. **Mock-LLM chaining depth**: our E2E test double for the LLM previously supported chaining exactly one follow-up tool call after the first. We generalized it to support a chain of any length, so scenarios like mode 3's 4-call sequence can be scripted as a single scenario instead of requiring the (impossible, in mode 3's case) workaround of multiple separate user turns.
+2. **`$from_tool` template propagation**: when chaining tool call B after tool call A, B's arguments can reference a field from A's real result (e.g. `rr_id`) via a `$from_tool:A:rr_id` placeholder. This placeholder was only being resolved for the *first* call in a chain, not any subsequent link — so a 2-or-more-deep chain would send the literal, unresolved string `"$from_tool:kubernaut_investigate:rr_id"` as the argument instead of the real ID, and the downstream call would fail.
+3. **`fallback_arguments` for unresolvable `$from_tool` references** (found live on the shared cluster while validating the above): the `af_investigate` scenario always sent `rr_id: "$from_tool:kubernaut_remediate:rr_id"`, on the assumption that a prior `kubernaut_remediate` call always exists in the session. When "investigate" is sent as the *first* message in a session (no prior remediate), that placeholder had nothing to resolve against and was sent to AF verbatim as a literal string — which AF correctly rejected as an invalid resource name (`invalid rr_id: invalid resource name "$from_tool:kubernaut_remediate:rr_id"`), exactly matching what showed up in the AF pod logs on the shared cluster. We added `fallback_arguments` to the mock-LLM's tool-call schema: when a `$from_tool` reference can't resolve, the entire argument set now falls back to `namespace/kind/name` (targeting the same `kubernaut-system/memory-eater` fixture used elsewhere), mirroring `kubernaut_investigate`'s real, mutually-exclusive `rr_id`-vs-`namespace/kind/name` argument contract. This is a test-double-only fix — production AF was never sent a bad `rr_id` by choice, it just correctly rejected the bad one our test double was sending it.
+
+All three fixes have new unit test coverage (`UT-ML-1853-001` through `-006`) proving the chain-walking, template resolution, and fallback behavior work correctly, including checks that concurrent requests don't leak resolved values into each other and that the fallback doesn't fire when resolution succeeds (no regression to existing multi-turn flows).
+
+---
+
+## What you can test right now
+
+Two new E2E specs exist in `test/e2e/fullpipeline/`, each driving AF through its real A2A `message/stream` endpoint exactly the way the console does:
+
+| Mode | Test ID | File | Trigger phrase used in the test |
+|------|---------|------|----------------------------------|
+| 2 (Interactive) | `E2E-FP-1853-001` | `16_af_a2a_combined_investigate_test.go` | "create and investigate remediation for deployment memory-eater" |
+| 3 (Full Interactive Remediation) | `E2E-FP-1853-002` | `17_af_a2a_full_interactive_remediation_test.go` | "investigate and fix remediation for deployment memory-eater" |
+
+Run them with:
+
+```bash
+ginkgo -v ./test/e2e/fullpipeline/... --label-filter="issue-1853"
+```
+
+**Important caveat for your own testing against a real LLM (not our mock)**: our E2E fixture recognizes fixed keyword phrases because it's a scripted test double, not a real LLM. Against the real production AF (backed by Gemini/OpenAI), mode selection depends on the LLM correctly classifying free-form user intent per the trigger phrases documented in `pkg/apifrontend/agent/prompt.txt` — those phrases are examples, not an exhaustive/exact-match list. If you're building automated console-side tests against a real LLM backend, expect some phrasing variance in which mode fires, and consider that a separate (LLM prompt-tuning) concern from this fix.
+
+---
+
+## What's still open
+
+- **Documentation** ([#1855](https://github.com/jordigilh/kubernaut/issues/1855)): the 3-mode contract above lives today only in AF's internal system prompt. There is no console-facing or integration-guide documentation describing it. That issue tracks writing it; this PR does not close it.
+- **Ginkgo E2E run**: `E2E-FP-1853-001`/`-002` compile, and the exact behavior they assert has now been **live-validated directly against your shared cluster** (real `curl` A2A requests against the real `apifrontend` + the already-deployed `mock-llm` binary containing the fix — see `TEST_PLAN.md` §3.2 for full evidence: real RR/IS/WorkflowExecution CRDs reaching `Completed`, and mode 3's target `Deployment`'s memory limit genuinely patched 50Mi→512Mi by the real remediation workflow). The Ginkgo specs themselves haven't been run yet, only because doing so would trigger an unrelated ~20-30min unconditional rebuild of every FP service image on this harness (no build-cache-hit path); this is tracked as a follow-up, not a blocker. The scenario config used for this validation was temporary and has been removed from your shared cluster's ConfigMap — only the `fallback_arguments` fix (item 3 above) remains live there. Mode 2/3 scenarios will be present on the shared cluster automatically once this PR merges and the cluster is next refreshed through normal CI/automation.
+
+---
+
+## Quick reference: which mode does my UI copy map to?
+
+| If your UI says... | AF mode | User sees RCA findings? | User picks the workflow? |
+|---|---|---|---|
+| "Auto-remediate" / "Fix now" (no review) | 1 — Autonomous | No | No (fully automatic) |
+| "Investigate" / "Diagnose" | 2 — Interactive | Yes | Yes (separate step, user-driven) |
+| "Investigate and fix" / "Diagnose and remediate" | 3 — Full Interactive Remediation | Yes | No (auto-selected, but shown to user) |

--- a/docs/testing/1853/TEST_PLAN.md
+++ b/docs/testing/1853/TEST_PLAN.md
@@ -1,0 +1,383 @@
+# Test Plan: fullpipeline E2E mock-llm fixture support for combined remediate+investigate intent (all 3 AF modes)
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-1853-v1
+**Feature**: Add mock-llm keyword scenarios (and the N-deep `NextToolCall` chaining + template-resolution fix they depend on) so a single free-form A2A `message/stream` request combining "create a remediation + investigate it" intent works in the `fullpipeline` E2E environment — for **all three** AF operational modes (autonomous, interactive, full-interactive-remediation), not just the one literally reported in the issue
+**Version**: 2.0
+**Created**: 2026-08-02
+**Author**: AI agent (Cursor)
+**Status**: Draft
+**Branch**: `main` (to be created: `fix/1853-fp-mock-llm-combined-investigate`)
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Issue [#1853](https://github.com/jordigilh/kubernaut/issues/1853) reports that a single chat
+message combining "remediate + investigate" intent fails every time against the
+`fullpipeline` E2E cluster. The root cause is confirmed to live entirely in test
+infrastructure (`test/infrastructure/shared_e2e.go`, `test/services/mock-llm/`), not in AF
+production code: the mock-llm's `NextToolCall` chaining mechanism (a) capped chains at exactly
+one link, and (b) never resolved `$from_tool:<tool>:<field>` templates inside a chained call's
+own arguments (only the primary `tool_call`'s arguments were resolved).
+
+While triaging, we confirmed against the authoritative production system prompt
+(`pkg/apifrontend/agent/prompt.txt`, cross-checked with `hindsight-docs`) that AF actually
+supports **three** distinct operational modes for combined "investigate + remediate" intent,
+not one:
+
+1. **Autonomous** — `kubernaut_remediate` alone. Fire-and-forget; no RCA is streamed to the
+   user, no pause.
+2. **Interactive** — `kubernaut_investigate`, which produces RCA/early findings, then
+   **pauses** for the user to manually pick a workflow (`discover_workflows` →
+   `select_workflow` → `watch` happen in later turns, driven by the user).
+3. **Full Interactive Remediation** ("autonomous-interactive") — `kubernaut_investigate`
+   followed by an **auto-selected**, highest-confidence workflow, streaming full RCA
+   transparency but with **no pause** for manual selection — all the way through
+   `discover_workflows` → `select_workflow` → `watch` in one turn.
+
+The issue as originally filed only reproduced mode 2's single-message chaining defect
+(2 tool calls: `remediate` → `investigate`). Mode 3 hits the *same* root-cause defect at a
+worse depth (4 tool calls: `investigate` → `discover_workflows` → `select_workflow` → `watch`),
+and was previously **untested and undocumented** for kubernaut-console — see
+[#1855](https://github.com/jordigilh/kubernaut/issues/1855) (documentation gap, tracked
+separately per user direction; this plan closes the *test coverage* gap for all 3 modes so the
+console team has a working example + expectations for each, while #1855 will close the
+*documentation* gap in a follow-up PR).
+
+This plan therefore: (a) generalizes mock-llm's `NextToolCall` from a single link to an
+arbitrary-depth linked list with `$from_tool` resolution at every link, and (b) adds one E2E
+scenario per combined-intent mode that actually needs multi-turn-in-one-message chaining
+(modes 2 and 3 — mode 1 is a single tool call and already works today, see §4.2).
+
+### 1.2 Objectives
+
+1. **O1 (mode 2 — the originally-reported case)**: A single `message/stream` request
+   combining "create a remediation" + "investigate" intent triggers `kubernaut_remediate`
+   then `kubernaut_investigate` in sequence, with a real, server-generated `rr_id` correctly
+   propagated between the two — not a literal unresolved template placeholder. The turn stops
+   at RCA (no auto-selection), matching Interactive Mode's documented contract.
+2. **O2 (mode 3 — new scope)**: A single `message/stream` request combining "investigate" +
+   "fix"/"remediate" intent triggers `kubernaut_investigate` → `kubernaut_discover_workflows` →
+   `kubernaut_select_workflow` (auto-picking the highest-confidence recommended workflow) →
+   `kubernaut_watch`, all in one turn, with `rr_id` correctly propagated to every link —
+   proving the chaining mechanism generalizes past 2 links.
+3. **O3**: `NextToolCall` (mock-llm scenario config) supports chains of arbitrary depth, and
+   `$from_tool:<tool>:<field>` templates resolve correctly at every link in the chain, not just
+   the first — closing the asymmetry that caused O1 to fail and generalizing it for O2.
+4. **O4**: The new scenarios do not change the behavior of any existing FP suite test
+   (no keyword collision / scenario hijack), and do not introduce cross-request state leakage
+   in the now-shared `NextToolCall` chain nodes.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| New unit tests pass | 100% | `go test ./test/services/mock-llm/... -ginkgo.focus="UT-ML-1853"` |
+| New E2E tests pass | 2/2 | `ginkgo -v ./test/e2e/fullpipeline/... --label-filter=issue-1853` |
+| Existing FP suite regressions | 0 | Full `fullpipeline` E2E run unaffected (spot-checked: E2E-FP-1189-003/-004/-005, E2E-AF-1409-001) |
+| Existing mock-llm unit suite regressions | 0 | `go test ./test/services/mock-llm/...` |
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- Issue [#1853](https://github.com/jordigilh/kubernaut/issues/1853): fullpipeline E2E mock-llm fixture has no scenario for single-message combined remediate+investigate intent
+- Issue [#1855](https://github.com/jordigilh/kubernaut/issues/1855): documentation gap for the 3 AF modes (out of scope here — tracked separately per user direction; this plan only closes the *test* gap)
+- Issue #1818 (referenced): the AF production fix this issue was validated against (unrelated code path, confirmed still correct)
+- `pkg/apifrontend/agent/prompt.txt`: **authoritative** production system prompt defining the 3 AF operational modes (autonomous / interactive / full-interactive-remediation) — the source of truth for §1.1's mode descriptions and for mode 3's auto-select-highest-confidence-workflow behavior
+
+### 2.2 Cross-References
+
+- [Wiring Verification](../../../.cursor/rules/10-wiring-verification.mdc)
+- `test/infrastructure/shared_e2e.go` — `afKeywordYAML`, `DeployMockLLMInNamespace`
+- `test/services/mock-llm/handlers/{gemini,openai}.go` — template resolution + NextToolCall dispatch
+- Prior art in the same file: `fleetClusterIDScenarioYAML` (#1409), `af_investigate` (#1189), `kaToolE2EConfidence` doc comment (E2E-FLEET-017 scenario-hijack fix, same defect class as this issue)
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|----------------|------------|
+| R1 | New keyword scenarios' confidence ties (1.0) with `af_investigate` and get shadowed by it (both new keywords contain the substring "investigate") | New scenarios never fire; regression to current broken behavior | Medium (this is exactly how #1853 happens today) | E2E-FP-1853-001, -002 | Register both new scenarios textually **before** `af_investigate` in `afKeywordYAML` (Registry.Detect keeps the first-registered match on confidence ties — confirmed by code reading) |
+| R2 | New scenarios' keywords accidentally match an existing test's message, hijacking it (same defect class as the E2E-FLEET-017 scenario-hijack fix and #1795) | Existing FP tests (E2E-FP-1189-003/-004/-005) break | Low | All existing `fp a2a interactive` specs | Keywords are the literal phrases `"create and investigate remediation"` (mode 2) and `"investigate and fix remediation"` (mode 3), distinct from every other FP suite chat message (grep-confirmed) |
+| R3 | `NextToolCall` is a pointer field aliased across concurrent requests to the same scenario singleton; naively mutating a chain node's `Arguments` in place (at any depth) would leak resolved values into other requests | Flaky/incorrect cross-request state (data race) | Medium if not handled | UT-ML-1853-004 | `resolveTemplateArgsMap` (shared helper, `handlers/chain.go`) allocates a **new** map with the resolved args instead of mutating the shared one in place, at every link in the chain — mirrors the existing `cloneAnyMap` rationale already documented for `ToolCallArgs` |
+| R4 | Issue's own "suggested fix" (hardcode a shared `rr_id` on both scripted calls via `MultiToolCalls`) turns out to be inconsistent with `HandleRemediate`'s real semantics: supplying `rr_id` on `kubernaut_remediate` makes AF treat it as a dedup **lookup**, not a create — no RR would ever be created | Suggested fix would silently no-op the RR creation, defeating the test's purpose | Confirmed (code-read, not just theoretical) | N/A — design deviation, see §4.3 | Use `tool_call` + `next_tool_call` (sequential chaining) instead of `MultiToolCalls` (same-turn parallel dispatch), propagating the *real* server-generated `rr_id` via `$from_tool`, fixed by R3's mitigation |
+| R5 | Mode 3's 4-deep chain (`investigate` → `discover_workflows` → `select_workflow` → `watch`) was the original 2-link-only `NextToolCall` design's exact breaking point — a shallow fix (e.g. hardcoding a 2nd optional field) would silently cap at depth 2 and fail mode 3 without any compile error | Mode 3 scenario silently truncates after `discover_workflows`, masking a regression | Medium (this is precisely why mode 3 was chosen as the generalization proof, not just mode 2 again) | UT-ML-1853-002/003, E2E-FP-1853-002 | `NextToolCall`/`ToolCallOverride` made self-referential (linked list); `flattenToolCallChain`/`nextChainCallByCount` (`handlers/chain.go`) walk the *entire* chain by count of prior tool responses, with no depth cap |
+| R6 | `$from_tool:kubernaut_investigate:rr_id` must resolve correctly across 3 hops (into `discover_workflows`, `select_workflow`, *and* `watch`'s `name` argument), and `select_workflow`'s `workflow_id` cannot be resolved via `$from_tool` at all (the recommended workflow ID is nested inside `discover_workflows`' response under `recommended.workflow_id`, which the existing `$from_tool:<tool>:<field>` grammar cannot address) | Mode 3 scenario emits an invalid/empty `workflow_id`, causing `kubernaut_select_workflow` to fail | Medium | E2E-FP-1853-002 | `workflow_id` is hardcoded in the scenario YAML to the real seeded catalog UUID (`afSelectWorkflowID`, resolved via the pre-existing `resolveWorkflowUUID` helper — same approach the manual-select `af_select_workflow` scenario already uses), simulating the LLM "reading" the recommended workflow from context the same way a real LLM would |
+| R7 | (Found live on the shared `fullpipeline-e2e` cluster while validating the above, not part of the original bug report) `af_investigate`'s `rr_id: "$from_tool:kubernaut_remediate:rr_id"` assumes a prior `kubernaut_remediate` call always exists in the session. When "investigate" is sent as the *first* message (no prior remediate — a legitimate standalone use case AF's real `kubernaut_investigate` tool already supports via `namespace`/`kind`/`name`), the placeholder has nothing to resolve against and is sent to AF **verbatim as a literal string**, which AF correctly rejects (`invalid rr_id: invalid resource name "$from_tool:kubernaut_remediate:rr_id"` — confirmed in `apifrontend` pod logs on the shared cluster) | Standalone "investigate" (no prior remediate in-session) hard-fails every time — this was actively blocking the console team's Playwright runs on the shared cluster | Confirmed (reproduced live, not just theoretical) | UT-ML-1853-005/006 | Added `fallback_arguments` to the mock-LLM tool-call schema (`ToolCallOverride`/`MultiToolCallEntry`/`MockScenarioConfig`): `resolveTemplateArgsMap` now swaps in a full fallback argument set (namespace/kind/name) whenever **any** `$from_tool` placeholder fails to resolve, instead of returning the half-resolved map with the literal placeholder string still in it. Mirrors `kubernaut_investigate`'s real, mutually-exclusive `rr_id`-vs-`namespace/kind/name` argument contract (confirmed via `pkg/apifrontend/tools/ka_investigate_mcp.go`) |
+
+### 3.1 Risk-to-Test Traceability
+
+R1 and R2 are both proven by E2E-FP-1853-001/-002 passing while the full existing FP label set (spot-checked) keeps passing unmodified. R3 is proven directly by UT-ML-1853-004 asserting a resolved value on one request does not leak into a sibling/repeated request. R5 is proven directly by UT-ML-1853-002/003 (Gemini/OpenAI) asserting a chain link *beyond* the historical depth-2 cap fires correctly, and end-to-end by E2E-FP-1853-002 reaching `kubernaut_watch` (link 4). R6 is proven by E2E-FP-1853-002 asserting the `WorkflowExecution` actually completes (i.e. `select_workflow` received a valid, real `workflow_id`). R7 is proven by UT-ML-1853-005 (YAML parsing of `fallback_arguments`), UT-ML-1853-006 (Gemini + OpenAI: fallback fires when unresolved, does NOT fire when resolution succeeds — no regression to existing multi-turn flows), and live-validated directly against the shared cluster: a standalone "start investigation" A2A request (no prior remediate in-session) was sent via `curl` after redeploying the fix, producing a real new `RemediationRequest`/`InvestigationSession` pair targeting `kubernaut-system/Deployment/memory-eater` with zero `invalid rr_id` errors in the `apifrontend` logs.
+
+### 3.2 Live-Cluster Validation Evidence (Mode 2 / Mode 3, R1/R5/R6)
+
+Before committing, mode 2 and mode 3 were validated by direct reproduction against the shared `fullpipeline-e2e` cluster instead of a full Ginkgo run, to avoid an unrelated ~20-30min unconditional rebuild of every FP service image (the harness's `BuildImageForKind` always rebuilds with `--no-cache` and a fresh random tag per invocation — there is no content-hash cache-hit path — so a full suite run would have rebuilt ~10+ unchanged service images just to exercise 2 specs). Since the already-deployed `mock-llm` binary already contained the full N-deep-chaining + `fallback_arguments` fix (built and loaded earlier for R7), the two new scenarios were injected directly into the live `mock-llm-scenarios` ConfigMap (byte-identical logical content to `combinedRemediateInvestigateScenarioYAML`/`fullInteractiveRemediationScenarioYAML` in `test/infrastructure/shared_e2e.go`, using fixed namespace names instead of test-generated hashes), and exercised via real `curl` A2A requests against the live `apifrontend` service — no code or image changes, only a scenario-config swap.
+
+**Result — Mode 2** (`create and investigate remediation`): `kubernaut_remediate` fired, then `kubernaut_investigate` fired with the real server-generated `rr_id` correctly propagated via `$from_tool`. A real `RemediationRequest` and `InvestigationSession` were created; the turn stopped at RCA findings (`phase: Investigating`) with no workflow auto-selected — matching Mode 2's contract exactly.
+
+**Result — Mode 3** (`investigate and fix remediation`): the full 4-deep chain fired — `kubernaut_investigate` → `kubernaut_discover_workflows` → `kubernaut_select_workflow` (auto-selected `oomkill-increase-memory-v1`, 95% confidence, no pause) → `kubernaut_watch`. The `RemediationRequest`, `InvestigationSession`, and `WorkflowExecution` all reached `Completed`/`Remediated`, and the target `memory-eater` `Deployment`'s memory limit was actually patched from `50Mi` to `512Mi` by the real remediation workflow (pod went from `OOMKilled` to `Running`) — proof the chain's `rr_id` propagation was correct at every one of the 3 downstream hops, not just superficially "not erroring."
+
+**A footgun found and fixed during this exercise (not a defect in the committed fix)**: the first manual ConfigMap injection nested `next_tool_call:` one level too deep — as a child of `tool_call:` (populating the unused `ToolCallOverride.NextToolCall` field) instead of as `tool_call:`'s YAML *sibling* at the `KeywordScenarioOverride` level (populating `KeywordScenarioOverride.NextToolCall`, which is what `registry_default.go`'s `convertToolCallChain(ks.NextToolCall)` actually reads). This silently produced `cfg.NextToolCall == nil`, so the chain never fired and AF's ADK loop re-invoked the LLM 3 times before giving up, falling through to the fully-autonomous RR pipeline instead. Re-verifying `combinedRemediateInvestigateScenarioYAML`/`fullInteractiveRemediationScenarioYAML`'s actual indentation in `test/infrastructure/shared_e2e.go` confirmed **both already use the correct sibling-level nesting** — this was a hand-transcription mistake made while replicating the scenario into the live ConfigMap by hand, not a defect in the committed Go source. Fixing the indentation in the manual ConfigMap copy (to match the Go source exactly) immediately produced the correct behavior described above. No code changes resulted from this finding; it is recorded here as evidence that the sibling-vs-nested distinction is easy to get wrong by hand and worth calling out for anyone else hand-authoring `keyword_scenarios` YAML.
+
+All scratch resources (2 temporary namespaces, their `memory-eater` fixtures, and the temporary ConfigMap scenario entries) were deleted after validation; the live ConfigMap was restored to contain only the R7 `fallback_arguments` fix (re-confirmed working via a final standalone-investigate smoke test after the restore).
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **Mock-llm N-deep `NextToolCall` chaining + template resolution** (`test/services/mock-llm/scenarios/types.go`, `config/overrides.go`, `registry_default.go`, `handlers/{gemini,openai,chain}.go`): `NextToolCall`/`ToolCallOverride` generalized from a single optional link to a self-referential linked list of arbitrary depth; `$from_tool:<tool>:<field>` placeholders resolve correctly at **every** link (previously only the primary `tool_call`'s arguments were resolved — the actual root cause).
+- **New `af_remediate_investigate_combined_1853` keyword scenario** (mode 2, `test/infrastructure/shared_e2e.go`): a single combined-intent message scripts `kubernaut_remediate` → `kubernaut_investigate` sequentially with the real `rr_id` propagated, then stops (no auto-select), per Interactive Mode's contract.
+- **New `af_full_interactive_remediation_1853` keyword scenario** (mode 3, `test/infrastructure/shared_e2e.go`): a single combined-intent message scripts `kubernaut_investigate` → `kubernaut_discover_workflows` → `kubernaut_select_workflow` → `kubernaut_watch` (4-deep chain) with `rr_id` propagated to all 3 dependent links and the highest-confidence `workflow_id` auto-selected, per Full Interactive Remediation Mode's contract.
+- **E2E-FP-1853-001/-002**: prove both scenarios above are reachable end-to-end via AF's real binary, real ADK tool-calling loop, and the real FP mock-llm ConfigMap (not just unit-level).
+- **`fallback_arguments` for unresolvable `$from_tool` references** (R7, `test/services/mock-llm/{config/overrides,scenarios/types,scenarios/registry_default,handlers/chain,handlers/gemini,handlers/openai}.go`): when a `$from_tool:<tool>:<field>` placeholder cannot resolve (the referenced tool was never called earlier in the session), the entire argument set now falls back to a scenario-provided literal set instead of sending the half-resolved map with the literal placeholder string in it. Applied to the existing `af_investigate` scenario (`test/infrastructure/shared_e2e.go`) so a standalone "investigate" with no prior "remediate" in-session creates a new RR from `namespace/kind/name` instead of hard-failing.
+
+### 4.2 Features Not to be Tested
+
+- AF production code paths for `kubernaut_remediate`/`kubernaut_investigate`/`kubernaut_discover_workflows`/`kubernaut_select_workflow`/`kubernaut_watch` themselves — already proven working individually by existing E2E-FP-1189-003/-004/-005 and E2E-AF-1409-001 (this issue is purely a test-fixture gap in *chaining* them within one message, confirmed via `kubectl logs deploy/apifrontend` in the original issue report showing no `kubernaut_remediate` call was ever attempted).
+- **Mode 1 (autonomous)**: not affected by this issue at all — a single `kubernaut_remediate` call has no `NextToolCall` chain to break. Already covered by the existing `"autonomous remediation"` keyword scenario / E2E-FP-1189 coverage; no new test needed.
+- Console-side rendering of the resulting `investigation_summary` — out of scope for kubernaut (tracked in kubernaut-console#39).
+- Formal documentation of the 3-mode contract itself — tracked separately in [#1855](https://github.com/jordigilh/kubernaut/issues/1855) per user direction (this plan closes the test-coverage gap only, not the docs gap).
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Use `tool_call` + `next_tool_call` (sequential) instead of the issue's literally-suggested `MultiToolCalls` + hardcoded shared `rr_id` | Confirmed via `pkg/apifrontend/tools/ka_remediate.go` (`HandleRemediate`) that supplying a caller-chosen `rr_id` to `kubernaut_remediate` makes AF perform a dedup **lookup** (`Get`) instead of creating a new RR — if the fixed value doesn't already exist, `HandleRemediate` returns `AlreadyExists: false` and creates nothing. `MultiToolCalls` also dispatches both tool calls in the same LLM turn (parallel, before either result is known), so there is no way to know the real `rr_id` in advance anyway. Sequential `next_tool_call` chaining (already an established pattern — `fleetClusterIDScenarioYAML`, #1409) is the only mechanism that can correctly propagate AF's real, server-generated `rr_id`. |
+| Generalize `NextToolCall`/`ToolCallOverride` to a self-referential linked list (arbitrary depth) rather than adding a 2nd hardcoded `NextToolCall2` field | Mode 3 needs 4 sequential tool calls, not 2. A depth-capped field-based approach would need a new named field per additional depth level and would resurface the identical defect class at the next mode/use case that needs depth 5+. A linked list (`NextToolCall *MultiToolCallEntry`, mirrored in the YAML-facing `ToolCallOverride`) supports arbitrary depth with one recursive conversion function (`convertToolCallChain`) and one shared chain-walking helper (`flattenToolCallChain` + `nextChainCallByCount`) reused by both handlers. **User-approved architectural change.** |
+| Mode 3 uses `kubernaut_investigate` directly from `namespace`/`kind`/`name` (not a prior `kubernaut_remediate` call) to create the RR+IS | Confirmed via `pkg/apifrontend/tools/ka_investigate_mcp.go` (`InvestigateMCPArgs`/`InvestigateMCPResult`) that `kubernaut_investigate` already supports creating a brand-new RR directly from resource identity args and returns the new `rr_id` in its result — matching the real Full Interactive Remediation Mode contract in `prompt.txt`, which does not require a separate remediate step first. |
+| Mode 3's `select_workflow.workflow_id` is a hardcoded real catalog UUID (`afSelectWorkflowID`, via the pre-existing `resolveWorkflowUUID` helper), not a `$from_tool` reference | `$from_tool:<tool>:<field>` can only address a *top-level* field of a prior tool's JSON result. The recommended workflow ID lives nested under `discover_workflows`' response (`recommended.workflow_id`), which the grammar cannot reach. The existing manual-select `af_select_workflow` scenario already solves this identically by hardcoding the same seeded UUID — mode 3 reuses that precedent rather than inventing a new mechanism. |
+| Fix the `NextToolCall.Arguments` template gap in **both** `gemini.go` and `openai.go`, even though FP's Helm values pin `provider=openai_compatible` (so `openai.go` is the only path this issue's repro exercises) | The two handlers are intentionally kept symmetric (near-identical doc comments, shared `templatePrefix`/`cloneAnyMap` helpers, now further unified by the new shared `handlers/chain.go`); leaving `gemini.go` unfixed would silently reintroduce the exact same class of gap for any suite (e.g. KA/AA) that configures the Gemini-native provider. |
+| New dedicated namespace keys `"combined-investigate"` (mode 2) and `"full-interactive"` (mode 3) in `afRemediateNS`, each with a fresh zero-replica `memory-eater` Deployment created inside its own test | Matches the established per-test namespace isolation convention (`"autonomous"`, `"interactive"`, `"fleet"`, `"interactive-streaming"`) that exists specifically to keep parallel Ginkgo processes' RR fingerprints from colliding — same pattern as E2E-FP-1189-003/-005. |
+| Keywords = the literal phrases `"create and investigate remediation"` (mode 2) and `"investigate and fix remediation"` (mode 3) | Distinct, unambiguous phrases chosen to (a) not collide with any existing FP suite chat message (grep-confirmed) and (b) both be registered **before** the bare `"investigate"` keyword (`af_investigate`) in `afKeywordYAML`, since `Registry.Detect` resolves equal-confidence ties by registration order (R1). |
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+This is a **test-infrastructure-only** change (`test/`, no `pkg/`/`cmd/` production code). Per `AGENTS.md`'s Pre-Implementation Workflow, "test-only modifications" qualify for Standard TDD (RED → GREEN → REFACTOR) without the full APDC preflight/spike/readiness-audit ceremony; this document + the preflight investigation already performed serve as the equivalent light-weight record.
+
+- **Unit**: the new N-deep chain-walking helpers (`flattenToolCallChain`, `nextChainCallByCount`, `resolveTemplateArgsMap` in `handlers/chain.go`) and `resolveGeminiTemplateArgs`/`resolveOpenAITemplateArgs`'s use of them — 100% of the new logic.
+- **E2E**: both new scenarios' real reachability through AF's production dispatch path (the closest analog to "wiring" for a test-fixture change, since there is no `cmd/`/`pkg/` production entry point involved).
+
+### 5.2 Two-Tier Minimum
+
+UT (logic: N-deep chain walking + template resolution) + E2E (both new scenarios are genuinely reachable via the real FP mock-llm ConfigMap + real AF binary + real ADK loop). No IT tier applies — this is test-double code, not a `pkg/`/`cmd/` production component.
+
+### 5.4 Pass/Fail Criteria
+
+**PASS**: all UT-ML-1853-* pass; E2E-FP-1853-001 and -002 pass; the full existing FP suite (spot-checked labels above) shows zero regressions; `go build ./...` and `golangci-lint run` are clean.
+
+**FAIL**: any of the above fails, or any existing FP/mock-llm test's behavior changes.
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code
+
+| File | Functions/Methods | Lines (approx) |
+|------|--------------------|-----------------|
+| `test/services/mock-llm/scenarios/types.go` | `MultiToolCallEntry.NextToolCall` (self-referential field, new) | ~10 |
+| `test/services/mock-llm/config/overrides.go` | `ToolCallOverride.NextToolCall` (self-referential field, new) | ~10 |
+| `test/services/mock-llm/scenarios/registry_default.go` | `convertToolCallChain` (new, recursive) | ~15 |
+| `test/services/mock-llm/handlers/chain.go` | `flattenToolCallChain`, `nextChainCallByCount`, `resolveTemplateArgsMap` (new file; R7: now also takes a `fallback` map and swaps in the full fallback set on any unresolved placeholder) | ~70 |
+| `test/services/mock-llm/handlers/gemini.go` | `resolveGeminiTemplateArgs` (refactored onto shared helper), chain-firing logic (generalized) | ~30 |
+| `test/services/mock-llm/handlers/openai.go` | `resolveOpenAITemplateArgs` (refactored onto shared helper), chain-firing logic (generalized) | ~30 |
+| `test/services/mock-llm/response/gemini.go` | `CountFunctionResponses` (new) | ~10 |
+| `test/services/mock-llm/config/overrides.go` | `ToolCallOverride.FallbackArguments` (R7, new field) | ~10 |
+| `test/services/mock-llm/scenarios/types.go` | `MultiToolCallEntry.FallbackArguments`, `MockScenarioConfig.FallbackArguments` (R7, new fields) | ~10 |
+
+### 6.2 E2E-Testable Code
+
+| File | Functions/Methods | Lines (approx) |
+|------|--------------------|-----------------|
+| `test/infrastructure/shared_e2e.go` | `combinedRemediateInvestigateScenarioYAML` (new, mode 2), `fullInteractiveRemediationScenarioYAML` (new, mode 3), `afKeywordYAML` construction | ~60 |
+| `test/infrastructure/fullpipeline_e2e.go` | `afRemediateNS` map literal (2 new keys: `combined-investigate`, `full-interactive`) | ~10 |
+
+---
+
+## 7. BR / Issue Coverage Matrix
+
+| Authority | Description | Priority | Tier | Test ID | Status |
+|-----------|-------------|----------|------|---------|--------|
+| Issue #1853 | Nested `next_tool_call:` YAML parses into an arbitrary-depth chain | P0 | Unit | UT-ML-1853-001 | Passing |
+| Issue #1853 | Gemini fires chain link N (N>1) with `$from_tool` resolved against a non-adjacent prior response | P0 | Unit | UT-ML-1853-002 | Passing |
+| Issue #1853 | OpenAI fires chain link N (N>1) with `$from_tool` resolved against a non-adjacent prior response | P0 | Unit | UT-ML-1853-003 | Passing |
+| Issue #1853 | No cross-request state leak when resolving chain-link arguments (shared scenario singleton) | P0 | Unit | UT-ML-1853-004 | Passing |
+| Issue #1853 | Mode 2 (Interactive): combined remediate+investigate single message succeeds end-to-end, stops at RCA | P0 | E2E | E2E-FP-1853-001 | Written, live-validated by direct reproduction (§3.2); Ginkgo run still pending |
+| Issue #1853 | Mode 3 (Full Interactive Remediation): combined investigate+fix single message auto-chains 4 deep to a completed workflow, no manual pause | P0 | E2E | E2E-FP-1853-002 | Written, live-validated by direct reproduction (§3.2); Ginkgo run still pending |
+| Issue #1853 (R7) | `fallback_arguments` YAML parses as a sibling of `arguments` under `tool_call` | P0 | Unit | UT-ML-1853-005 | Passing |
+| Issue #1853 (R7) | Standalone "investigate" (no prior remediate in-session) falls back to `namespace/kind/name`; resolved `rr_id` case is unaffected (no regression) — Gemini + OpenAI | P0 | Unit | UT-ML-1853-006 | Passing |
+| Issue #1853 (R7) | Live-cluster validation: standalone "start investigation" A2A request against the shared `fullpipeline-e2e` cluster produces a real new RR/IS with zero `invalid rr_id` errors | P0 | Manual/Live | N/A (curl smoke test, see §3.1) | Passing |
+| Issue #1853 (R1/R5/R6) | Live-cluster validation: mode-2 and mode-3 chains fire correctly against the real, deployed mock-llm binary + AF + full controller stack (RR → IS → AIAnalysis → WorkflowExecution, ending `Completed`/`Remediated`, real memory limit patched 50Mi→512Mi) | P0 | Manual/Live | N/A (curl smoke test, see §3.2) | Passing |
+
+---
+
+## 8. Test Scenarios
+
+### Tier 1: Unit Tests
+
+| ID | Business Outcome Under Test | Phase |
+|----|------------------------------|-------|
+| `UT-ML-1853-001` | A YAML `next_tool_call:` block nested to arbitrary depth parses into the correct `MultiToolCallEntry`/`ToolCallOverride` linked list (no depth cap) | Passing |
+| `UT-ML-1853-002` | Gemini handler fires the 2nd (and beyond) chain link with `$from_tool` resolved against an earlier — not just immediately-prior — `FunctionResponse`, instead of leaving the literal placeholder string | Passing |
+| `UT-ML-1853-003` | OpenAI handler does the same via prior tool-result messages | Passing |
+| `UT-ML-1853-004` | Resolving a chain link's `Arguments` for one request does not mutate the shared scenario singleton's config (no cross-request leakage — R3) | Passing |
+| `UT-ML-1853-005` | `fallback_arguments:` parses from YAML as a sibling of `arguments:` under `tool_call:` | Passing |
+| `UT-ML-1853-006` | When a `$from_tool` reference can't resolve (no prior call), the entire argument set falls back to the scenario's `fallback_arguments` (Gemini + OpenAI); when resolution succeeds, the fallback does NOT fire (no regression) | Passing |
+
+### Tier 3: E2E Tests
+
+| ID | Business Outcome Under Test | Phase |
+|----|------------------------------|-------|
+| `E2E-FP-1853-001` | Mode 2 (Interactive): a single combined "create and investigate remediation" message produces a real RemediationRequest via `kubernaut_remediate`, then a successful `kubernaut_investigate` tool call (no `invalid rr_id` error, real `rr_id` propagated) that creates an `InvestigationSession` — and the turn **stops there** (no auto-selected workflow), matching Interactive Mode's documented contract | Written; behavior live-validated by direct reproduction, §3.2. Ginkgo run pending |
+| `E2E-FP-1853-002` | Mode 3 (Full Interactive Remediation): a single combined "investigate and fix remediation" message auto-chains `kubernaut_investigate` → `kubernaut_discover_workflows` → `kubernaut_select_workflow` → `kubernaut_watch` (4 deep) with `rr_id` propagated to every dependent link and the highest-confidence workflow auto-selected, reaching a completed `WorkflowExecution` with **no manual pause** | Written; behavior live-validated by direct reproduction, §3.2. Ginkgo run pending |
+
+### Tier Skip Rationale
+
+- **Integration**: not applicable — no `pkg/`/`cmd/` production code changes; nothing to wire into a production entry point.
+
+---
+
+## 9. Test Cases (P0 detail)
+
+### UT-ML-1853-001: nested `next_tool_call:` YAML parsing (arbitrary depth)
+
+**Type**: Unit
+**File**: `test/services/mock-llm/repeat_tool_call_test.go`
+
+**Test Steps**:
+1. **Given**: a YAML `keyword_scenarios` entry with `tool_call:` followed by a `next_tool_call:` nested 3 levels deep (4 tool calls total, mirroring mode 3's shape).
+2. **When**: the YAML is unmarshalled into `config.KeywordScenarioOverride` and converted via `convertToolCallChain`.
+3. **Then**: the resulting `MultiToolCallEntry` linked list has exactly 4 nodes in the correct order, each with its own `Name`/`Arguments`.
+
+### UT-ML-1853-002: Gemini fires chain link N with non-adjacent `$from_tool` resolution
+
+**Type**: Unit
+**File**: `test/services/mock-llm/repeat_tool_call_test.go`
+
+**Test Steps** (mirrors existing `UT-ML-1407-002` harness, extended past depth 1):
+1. **Given**: a 3-deep `NextToolCall` chain where link 3's arguments reference `$from_tool:kubernaut_investigate:rr_id` (link 1's tool, not link 2's).
+2. **When**: an `httptest` request is sent whose conversation already contains `FunctionResponse`s for links 1 and 2.
+3. **Then**: the emitted link-3 `FunctionCall.Args["rr_id"]` equals link 1's real `rr_id`, not the literal template string — proving resolution reaches back across non-adjacent responses, not just the immediately-prior one.
+
+### UT-ML-1853-003: OpenAI fires chain link N with non-adjacent `$from_tool` resolution
+
+**Type**: Unit
+**File**: `test/services/mock-llm/repeat_tool_call_test.go`
+
+Same scenario as UT-ML-1853-002, via the OpenAI-compatible tool-call/tool-result message format instead of Gemini's `FunctionCall`/`FunctionResponse`.
+
+### UT-ML-1853-004: no cross-request state leak resolving chain-link arguments
+
+**Type**: Unit
+**File**: `test/services/mock-llm/repeat_tool_call_test.go`
+
+**Test Steps**:
+1. **Given**: a shared scenario singleton whose `NextToolCall.Arguments` contains a `$from_tool` template.
+2. **When**: two concurrent/sequential requests matching the same scenario resolve the template with two *different* prior-response values.
+3. **Then**: each request's resolved args reflect only its own conversation's value; the singleton's original `Arguments` map (and any other in-flight request reading it) is never mutated.
+
+### E2E-FP-1853-001: Mode 2 (Interactive) — combined remediate+investigate single message
+
+**Type**: E2E
+**File**: `test/e2e/fullpipeline/16_af_a2a_combined_investigate_test.go`
+
+**Test Steps**:
+1. **Given**: a dedicated, zero-replica `memory-eater` Deployment in a fresh isolated namespace (`fpRemediateNS["combined-investigate"]`).
+2. **When**: a single `message/stream` A2A request is sent: "create and investigate remediation for deployment memory-eater".
+3. **Then**: HTTP 200; a real RemediationRequest is created in the dedicated namespace via `kubernaut_remediate`; an `InvestigationSession` owned by that RR is created via `kubernaut_investigate`, proving the real server-generated `rr_id` was propagated (not left as an unresolved `$from_tool` template); the turn stops there (no workflow discovery/selection/watch is triggered).
+
+### E2E-FP-1853-002: Mode 3 (Full Interactive Remediation) — combined investigate+fix, 4-deep auto-chain
+
+**Type**: E2E
+**File**: `test/e2e/fullpipeline/17_af_a2a_full_interactive_remediation_test.go`
+
+**Test Steps**:
+1. **Given**: a dedicated, zero-replica `memory-eater` Deployment in a fresh isolated namespace (`fpRemediateNS["full-interactive"]`).
+2. **When**: a single `message/stream` A2A request is sent: "investigate and fix remediation for deployment memory-eater".
+3. **Then**: HTTP 200; a real RemediationRequest is created directly via `kubernaut_investigate` (no separate remediate call); the 4-deep chain auto-continues through `kubernaut_discover_workflows` → `kubernaut_select_workflow` (real seeded workflow UUID, no pause for manual input) → `kubernaut_watch`; a `WorkflowExecution` for the RR reaches completion — all triggered by the single initial message.
+
+---
+
+## 10. Environmental Needs
+
+- **Unit**: Ginkgo/Gomega, `httptest`, in-process — no cluster required.
+- **E2E**: existing `fullpipeline` Kind cluster infrastructure (`test/infrastructure/fullpipeline_e2e*.go`), unchanged.
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Execution Order
+
+1. **RED**: UT-ML-1853-001/002/003/004 written against current (single-link-capped, unfixed) handlers — fail.
+2. **GREEN**: make `MultiToolCallEntry`/`ToolCallOverride` self-referential; add `convertToolCallChain`; add `handlers/chain.go` (`flattenToolCallChain`, `nextChainCallByCount`, `resolveTemplateArgsMap`); refactor `resolveGeminiTemplateArgs`/`resolveOpenAITemplateArgs` and each handler's chain-firing logic onto it — UTs pass.
+3. **GREEN (E2E, mode 2)**: add `afRemediateNS["combined-investigate"]` key + `combinedRemediateInvestigateScenarioYAML` + insert into `afKeywordYAML` before `af_investigate`; add E2E-FP-1853-001 — passes against a real FP cluster.
+4. **GREEN (E2E, mode 3)**: add `afRemediateNS["full-interactive"]` key + `fullInteractiveRemediationScenarioYAML` (4-deep chain) + insert into `afKeywordYAML` before `af_investigate`; add E2E-FP-1853-002 — passes against a real FP cluster, proving the chain generalizes past depth 2.
+5. **REFACTOR**: shared chain-walking/template-resolution helpers already extracted in step 2 (`handlers/chain.go`) rather than deferred — no separate refactor pass needed beyond that extraction.
+
+---
+
+## 12. Test Deliverables
+
+| Deliverable | Location |
+|-------------|----------|
+| This test plan | `docs/testing/1853/TEST_PLAN.md` |
+| Unit tests | `test/services/mock-llm/repeat_tool_call_test.go` |
+| E2E test (mode 2) | `test/e2e/fullpipeline/16_af_a2a_combined_investigate_test.go` |
+| E2E test (mode 3) | `test/e2e/fullpipeline/17_af_a2a_full_interactive_remediation_test.go` |
+| Console-team findings summary | `docs/testing/1853/CONSOLE_TEAM_SUMMARY.md` |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests
+go test ./test/services/mock-llm/... -ginkgo.focus="UT-ML-1853"
+
+# E2E (requires a running/creatable fullpipeline Kind cluster)
+ginkgo -v ./test/e2e/fullpipeline/... --label-filter="issue-1853"
+```
+
+---
+
+## 14. Wiring Verification (test-infra analog)
+
+No `pkg/`/`cmd/` production entry point exists for this change (mock-llm and the FP test harness are test-only code — not part of the release artifact per prior team note). The E2E tests are the closest equivalent proof: they confirm both new scenarios are reachable via AF's real binary and real ADK tool-calling loop against the real FP mock-llm ConfigMap, not just at the unit level.
+
+| Code Path | Entry Point | Exit Point | Proving Test | Status |
+|-----------|-------------|------------|---------------|--------|
+| `af_remediate_investigate_combined_1853` scenario (mode 2) | Real AF `/a2a/invoke` `message/stream` | `InvestigationSession` owned by the new RR | E2E-FP-1853-001 | Pending |
+| `af_full_interactive_remediation_1853` scenario (mode 3, 4-deep chain) | Real AF `/a2a/invoke` `message/stream` | Completed `WorkflowExecution` for the new RR | E2E-FP-1853-002 | Pending |
+| N-deep `NextToolCall` chain walking + `$from_tool` resolution at every link | mock-llm HTTP handler (`/v1/chat/completions`, `:generateContent`) | Resolved `FunctionCall`/`ToolCall` args in mock-llm's own response, at every chain depth | UT-ML-1853-001/002/003/004 | Pending |
+
+---
+
+## 15. Existing Tests Requiring Updates
+
+None expected. If E2E-FP-1189-003/-004/-005 or E2E-AF-1409-001 regress, that indicates an unexpected keyword collision (R2) and must be fixed before merge, not worked around.
+
+---
+
+## 16. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-08-02 | Initial test plan (mode 2 / originally-reported scope only) |
+| 2.0 | 2026-08-02 | Expanded to all 3 AF modes per user direction ("factor into 1853 the 3 modes so that the console team can test them"): generalized `NextToolCall` to arbitrary depth (was previously scoped as a single-link fix), added mode 3 (Full Interactive Remediation, 4-deep chain) scenario + E2E-FP-1853-002, added UT-ML-1853-003/004, added console-team findings summary deliverable, cross-referenced the new documentation-gap issue #1855 |
+| 3.0 | 2026-08-02 | Added R7: a separate, pre-existing defect found live on the shared `fullpipeline-e2e` cluster while validating the above (standalone "investigate" with no prior "remediate" in-session sends AF a literal, unresolved `$from_tool` placeholder as `rr_id`, which AF correctly rejects — blocking the console team's Playwright runs). Added `fallback_arguments` to the mock-LLM tool-call schema (whole-argument-set fallback when any `$from_tool` reference fails to resolve, mirroring `kubernaut_investigate`'s real mutually-exclusive `rr_id`-vs-`namespace/kind/name` contract), applied it to `af_investigate`, added UT-ML-1853-005/006, and live-validated the fix directly against the shared cluster (new image + ConfigMap deployed, confirmed via a real A2A request producing a new RR/IS with zero errors). Work now tracked on branch `fix/1853-fp-mock-llm-combined-investigate` (rebased onto latest `main`) rather than directly on `main`. |
+| 3.1 | 2026-08-02 | Re-ran the full `test/services/mock-llm/...` unit suite (all green) and flipped UT-ML-1853-001..004 from Pending to Passing. Live-validated mode 2 and mode 3 by direct reproduction against the shared cluster (§3.2) instead of a full Ginkgo run, to avoid an unconditional ~20-30min rebuild of every FP service image on a harness with no build-cache-hit path (`BuildImageForKind` always uses `--no-cache` + a fresh random tag). Both modes' full chains fired correctly and reached `Completed`/`Remediated` (mode 3's target `Deployment` had its memory limit genuinely patched 50Mi→512Mi by the real workflow). Found and fixed a hand-transcription footgun during this exercise (nesting `next_tool_call:` as a child of `tool_call:` instead of its sibling silently produces `cfg.NextToolCall == nil`) — confirmed this is **not** present in the committed `shared_e2e.go` source, only in the ad-hoc manual ConfigMap copy used for this validation. All scratch cluster resources cleaned up afterward; ConfigMap restored to R7-fix-only state and re-smoke-tested. |

--- a/test/e2e/fullpipeline/08_af_a2a_interactive_test.go
+++ b/test/e2e/fullpipeline/08_af_a2a_interactive_test.go
@@ -159,7 +159,7 @@ var _ = Describe("AF A2A Interactive 5-Phase Full Pipeline [E2E-FP-1189-003]", L
 		GinkgoWriter.Printf("  Turn 5 — watch OK\n")
 
 		By("Verifying full pipeline completed")
-		rrName := fpWaitForRRWithTargetNS("memory-eater", targetNS, 30*time.Second)
+		rrName := fpWaitForRRWithTargetNS(targetNS, 30*time.Second)
 		Expect(rrName).NotTo(BeEmpty())
 		fpWaitForWEComplete(rrName, 60*time.Second)
 		GinkgoWriter.Printf("  Full pipeline completed for %s\n", rrName)

--- a/test/e2e/fullpipeline/09_af_cross_namespace_test.go
+++ b/test/e2e/fullpipeline/09_af_cross_namespace_test.go
@@ -76,7 +76,7 @@ var _ = Describe("AF A2A Cross-Namespace RR [E2E-FP-1292-001]", Label("fp", "af"
 		GinkgoWriter.Printf("  A2A task: %s (state: %s)\n", task.ID, task.Status.State)
 
 		By("Waiting for RR in kubernaut-system (controllerNS per ADR-057)")
-		rrName := fpWaitForRRWithTargetNS("memory-eater", workloadNS, 120*time.Second)
+		rrName := fpWaitForRRWithTargetNS(workloadNS, 120*time.Second)
 		Expect(rrName).NotTo(BeEmpty())
 		GinkgoWriter.Printf("  RR created: %s/%s\n", namespace, rrName)
 

--- a/test/e2e/fullpipeline/15_af_a2a_interactive_streaming_test.go
+++ b/test/e2e/fullpipeline/15_af_a2a_interactive_streaming_test.go
@@ -255,7 +255,7 @@ var _ = Describe("AF A2A Interactive Streaming Full Pipeline [E2E-FP-1189-005]",
 			"turn 5's SSE stream must reach a terminal 'completed' state (stream_closed)")
 
 		By("Verifying full pipeline completed (secondary confirmation via CRD poll)")
-		rrName := fpWaitForRRWithTargetNS("memory-eater", targetNS, 30*time.Second)
+		rrName := fpWaitForRRWithTargetNS(targetNS, 30*time.Second)
 		Expect(rrName).NotTo(BeEmpty())
 		fpWaitForWEComplete(rrName, 60*time.Second)
 		GinkgoWriter.Printf("  Full pipeline completed for %s\n", rrName)

--- a/test/e2e/fullpipeline/16_af_a2a_combined_investigate_test.go
+++ b/test/e2e/fullpipeline/16_af_a2a_combined_investigate_test.go
@@ -1,0 +1,132 @@
+package fullpipeline
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	isv1alpha1 "github.com/jordigilh/kubernaut/api/investigationsession/v1alpha1"
+)
+
+// E2E-FP-1853-001: AF A2A Combined Remediate+Investigate (mode 2 — Interactive,
+// single combined message). Reproduces the original issue #1853 bug report: a
+// single free-form message combining "create a remediation" and "investigate"
+// intent must chain kubernaut_remediate straight into kubernaut_investigate
+// within the same conversation turn (no second user message needed to
+// upgrade the RR to interactive), then STOP — presenting RCA findings and
+// waiting for the user to manually continue with discover/select/watch, per
+// the "Interactive Mode" contract in pkg/apifrontend/agent/prompt.txt.
+//
+// This is the "1 message → 2 chained tool calls, then pause" case: it proves
+// the mock-llm's NextToolCall $from_tool resolution fix (the actual #1853
+// root cause — the server-generated rr_id from kubernaut_remediate must
+// reach kubernaut_investigate's arguments without a hardcoded/pre-known ID).
+var _ = Describe("AF A2A Combined Remediate+Investigate Full Pipeline [E2E-FP-1853-001]", Label("fp", "af", "a2a", "interactive", "issue-1853"), func() {
+
+	It("should chain kubernaut_remediate into kubernaut_investigate from a single combined message, then stop at RCA", NodeTimeout(4*time.Minute), func(_ SpecContext) {
+		targetNS := fpRemediateNS["combined-investigate"]
+		Expect(targetNS).NotTo(BeEmpty(), "combined-investigate namespace must be set by SynchronizedBeforeSuite")
+
+		By("Verifying AF is reachable")
+		resp, err := afHTTPClient.Get(afBaseURL + "/healthz")
+		if err != nil || resp.StatusCode == http.StatusBadGateway || resp.StatusCode == http.StatusServiceUnavailable {
+			Skip("AF not reachable in FP cluster — skipping E2E-FP-1853-001")
+		}
+		_ = resp.Body.Close()
+
+		By("Ensuring managed target namespace exists for the combined RR")
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: targetNS,
+				Labels: map[string]string{
+					"kubernaut.ai/managed":     "true",
+					"kubernaut.ai/environment": "staging",
+				},
+			},
+		}
+		if err := k8sClient.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
+			Expect(err).NotTo(HaveOccurred(), "Failed to create namespace %s", targetNS)
+		}
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(context.Background(), ns, &client.DeleteOptions{})
+		})
+
+		By("Deploying zero-replica target Deployment in isolated namespace")
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "memory-eater",
+				Namespace: targetNS,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr.To[int32](0),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "memory-eater"},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": "memory-eater"},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "app",
+							Image: "busybox:1.36",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+							},
+						}},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+
+		By("Turn 1 (single message): create AND investigate in one shot (kubernaut_remediate -> kubernaut_investigate chain)")
+		body := fpA2ATasksSend("fp-comb-1",
+			"create and investigate remediation for deployment memory-eater")
+		resp, err = fpA2AInvokeWithTimeout(body, 180*time.Second)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp.Body.Close() }()
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		rpc, parseErr := fpParseRPC(resp)
+		Expect(parseErr).NotTo(HaveOccurred())
+		Expect(rpc.Error).To(BeNil(), "combined turn should not return a JSON-RPC error")
+		task, taskErr := fpExtractTask(rpc.Result)
+		Expect(taskErr).NotTo(HaveOccurred())
+		Expect(task.ID).NotTo(BeEmpty(), "A2A task ID must not be empty")
+		GinkgoWriter.Printf("  Combined turn — task: %s (state: %s)\n", task.ID, task.Status.State)
+
+		By("Verifying the RR was created via kubernaut_remediate, targeting the isolated namespace")
+		rrName := fpWaitForRRWithTargetNS(targetNS, 60*time.Second)
+		Expect(rrName).NotTo(BeEmpty())
+
+		By("Verifying kubernaut_investigate actually ran: an InvestigationSession exists for this RR (#1853 proof — rr_id was correctly propagated via $from_tool, not left as an unresolved template)")
+		Eventually(func() bool {
+			isList := &isv1alpha1.InvestigationSessionList{}
+			if err := apiReader.List(ctx, isList, client.InNamespace(namespace)); err != nil {
+				return false
+			}
+			for _, is := range isList.Items {
+				for _, ref := range is.OwnerReferences {
+					if ref.Kind == "RemediationRequest" && ref.Name == rrName {
+						return true
+					}
+				}
+			}
+			return false
+		}, 90*time.Second, 2*time.Second).Should(BeTrue(),
+			"InvestigationSession owned by RR %s must exist — proves kubernaut_investigate received the real rr_id from kubernaut_remediate's response, not an unresolved $from_tool template", rrName)
+		GinkgoWriter.Printf("  Combined remediate+investigate chain completed for %s\n", rrName)
+	})
+})

--- a/test/e2e/fullpipeline/17_af_a2a_full_interactive_remediation_test.go
+++ b/test/e2e/fullpipeline/17_af_a2a_full_interactive_remediation_test.go
@@ -1,0 +1,119 @@
+package fullpipeline
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// E2E-FP-1853-002: AF A2A Full Interactive Remediation (mode 3 —
+// "autonomous-interactive" per pkg/apifrontend/agent/prompt.txt). A single
+// combined message ("investigate and fix") triggers kubernaut_investigate
+// directly (creating RR+IS from namespace/kind/name, no separate remediate
+// call), then auto-chains through kubernaut_discover_workflows ->
+// kubernaut_select_workflow (highest-confidence workflow, no pause for
+// manual selection) -> kubernaut_watch, all within the same conversation
+// turn, to a completed WorkflowExecution.
+//
+// This is the "1 message → full pipeline, zero manual turns" case that
+// distinguishes mode 3 from mode 2 (E2E-FP-1853-001, which stops at RCA and
+// waits for the user) and from mode 1 / autonomous (E2E-FP-1189-002, which
+// never streams RCA transparency to the user at all). It is also the first
+// test anywhere in the suite to exercise a NextToolCall chain deeper than 2
+// tool calls, proving the #1853 N-deep chaining fix end to end against the
+// real AF binary.
+var _ = Describe("AF A2A Full Interactive Remediation Full Pipeline [E2E-FP-1853-002]", Label("fp", "af", "a2a", "interactive", "issue-1853"), func() {
+
+	It("should auto-chain investigate -> discover_workflows -> select_workflow -> watch from a single combined message, with no manual pause", NodeTimeout(8*time.Minute), func(_ SpecContext) {
+		targetNS := fpRemediateNS["full-interactive"]
+		Expect(targetNS).NotTo(BeEmpty(), "full-interactive namespace must be set by SynchronizedBeforeSuite")
+
+		By("Verifying AF is reachable")
+		resp, err := afHTTPClient.Get(afBaseURL + "/healthz")
+		if err != nil || resp.StatusCode == http.StatusBadGateway || resp.StatusCode == http.StatusServiceUnavailable {
+			Skip("AF not reachable in FP cluster — skipping E2E-FP-1853-002")
+		}
+		_ = resp.Body.Close()
+
+		By("Ensuring managed target namespace exists for the full-interactive RR")
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: targetNS,
+				Labels: map[string]string{
+					"kubernaut.ai/managed":     "true",
+					"kubernaut.ai/environment": "staging",
+				},
+			},
+		}
+		if err := k8sClient.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
+			Expect(err).NotTo(HaveOccurred(), "Failed to create namespace %s", targetNS)
+		}
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(context.Background(), ns, &client.DeleteOptions{})
+		})
+
+		By("Deploying zero-replica target Deployment in isolated namespace")
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "memory-eater",
+				Namespace: targetNS,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr.To[int32](0),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "memory-eater"},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": "memory-eater"},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "app",
+							Image: "busybox:1.36",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+							},
+						}},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+
+		By("Turn 1 (single message): investigate and fix in one shot (4-deep NextToolCall chain, no manual selection)")
+		body := fpA2ATasksSend("fp-full-1",
+			"investigate and fix remediation for deployment memory-eater")
+		resp, err = fpA2AInvokeWithTimeout(body, 6*time.Minute)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp.Body.Close() }()
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		rpc, parseErr := fpParseRPC(resp)
+		Expect(parseErr).NotTo(HaveOccurred())
+		Expect(rpc.Error).To(BeNil(), "full-interactive turn should not return a JSON-RPC error")
+		task, taskErr := fpExtractTask(rpc.Result)
+		Expect(taskErr).NotTo(HaveOccurred())
+		Expect(task.ID).NotTo(BeEmpty(), "A2A task ID must not be empty")
+		GinkgoWriter.Printf("  Full-interactive turn — task: %s (state: %s)\n", task.ID, task.Status.State)
+
+		By("Verifying the RR was created via kubernaut_investigate directly, targeting the isolated namespace")
+		rrName := fpWaitForRRWithTargetNS(targetNS, 60*time.Second)
+		Expect(rrName).NotTo(BeEmpty())
+
+		By("Verifying the full pipeline completed with zero manual turns (proves the 4-deep chain reached kubernaut_watch)")
+		fpWaitForWEComplete(rrName, 5*time.Minute)
+		GinkgoWriter.Printf("  Full interactive remediation completed for %s with a single message\n", rrName)
+	})
+})

--- a/test/e2e/fullpipeline/af_helpers_test.go
+++ b/test/e2e/fullpipeline/af_helpers_test.go
@@ -457,10 +457,12 @@ func fpWaitForRR(nameSubstring string, timeout time.Duration) string {
 }
 
 // fpWaitForRRWithTargetNS polls for a RemediationRequest whose targetResource.name
-// contains nameSubstring AND whose spec.targetResource.namespace equals targetNS.
+// contains "memory-eater" AND whose spec.targetResource.namespace equals targetNS.
 // This avoids picking up RRs from parallel tests that share the same name pattern
-// but target different namespaces.
-func fpWaitForRRWithTargetNS(nameSubstring, targetNS string, timeout time.Duration) string {
+// but target different namespaces. Every FP suite caller targets the shared
+// "memory-eater" fixture Deployment, so the name is fixed rather than parameterized.
+func fpWaitForRRWithTargetNS(targetNS string, timeout time.Duration) string {
+	const nameSubstring = "memory-eater"
 	var rrName string
 	Eventually(func() bool {
 		rrList := &remediationv1.RemediationRequestList{}

--- a/test/infrastructure/fullpipeline_e2e.go
+++ b/test/infrastructure/fullpipeline_e2e.go
@@ -442,6 +442,18 @@ func SetupFullPipelineInfrastructure(ctx context.Context, clusterName, kubeconfi
 		// full RO->SP->AA->KA->WE pipeline run to completion (see session notes,
 		// issue #1189).
 		"interactive-streaming": fmt.Sprintf("fp-ints-%s", uuid.New().String()[:8]),
+		// combined-investigate: dedicated namespace for E2E-FP-1853-001
+		// (issue #1853 mode 2 — Interactive, single combined message):
+		// "create and investigate remediation" triggers kubernaut_remediate
+		// chained into kubernaut_investigate within one turn, stopping at RCA.
+		"combined-investigate": fmt.Sprintf("fp-comb-%s", uuid.New().String()[:8]),
+		// full-interactive: dedicated namespace for E2E-FP-1853-002 (issue
+		// #1853 mode 3 — "Full Interactive Remediation" / autonomous-interactive
+		// per pkg/apifrontend/agent/prompt.txt): "investigate and fix
+		// remediation" triggers kubernaut_investigate chained all the way
+		// through discover_workflows -> select_workflow -> watch with no
+		// pause for manual workflow selection.
+		"full-interactive": fmt.Sprintf("fp-full-%s", uuid.New().String()[:8]),
 	}
 	_, _ = fmt.Fprintln(writer, "  📌 AF remediate namespaces:")
 	for key, ns := range afRemediateNS {

--- a/test/infrastructure/shared_e2e.go
+++ b/test/infrastructure/shared_e2e.go
@@ -245,6 +245,80 @@ func fleetClusterIDScenarioYAML(fleetNS string) string {
 `, fleetNS)
 }
 
+// combinedRemediateInvestigateScenarioYAML returns a keyword scenario for
+// issue #1853 mode 2 (Interactive, single combined message): a single A2A
+// message containing both "create a remediation" and "investigate" intent
+// triggers kubernaut_remediate followed by kubernaut_investigate (using the
+// server-generated rr_id, resolved via $from_tool), stopping at RCA --
+// mirroring the original #1853 bug report exactly (the LLM auto-proceeds
+// from remediate straight into investigate without a second user turn).
+// Returns "" if ns is empty (namespace isolation not configured for this key).
+func combinedRemediateInvestigateScenarioYAML(ns string) string {
+	if ns == "" {
+		return ""
+	}
+	return fmt.Sprintf(`      - name: "af_remediate_investigate_combined_1853"
+        keywords: ["create and investigate remediation"]
+        match_last_only: true
+        tool_call:
+          name: "kubernaut_remediate"
+          arguments:
+            namespace: "%s"
+            kind: "Deployment"
+            name: "memory-eater"
+            api_version: "apps/v1"
+            description: "FP E2E combined remediate+investigate request (#1853)"
+        next_tool_call:
+          name: "kubernaut_investigate"
+          arguments:
+            rr_id: "$from_tool:kubernaut_remediate:rr_id"
+`, ns)
+}
+
+// fullInteractiveRemediationScenarioYAML returns a keyword scenario for issue
+// #1853 mode 3 ("Full Interactive Remediation" / autonomous-interactive, per
+// pkg/apifrontend/agent/prompt.txt): a single combined "investigate and fix"
+// message triggers kubernaut_investigate directly from namespace/kind/name
+// (InvestigateMCPArgs supports creating a new RR+IS without a prior
+// kubernaut_remediate call), then auto-chains discover_workflows ->
+// select_workflow (highest-confidence workflow, no pause for manual
+// selection) -> watch, all within the same conversation turn -- exercising
+// the #1853 N-deep NextToolCall chaining fix end to end. selectWorkflowID
+// must be the real seeded catalog UUID (see afSelectWorkflowID /
+// resolveWorkflowUUID above): $from_tool cannot reach discover_workflows'
+// nested recommended.workflow_id field, so the LLM "reads" the recommended
+// workflow the same way afSelectWorkflowID already does for the manual-select
+// scenario below. Returns "" if ns is empty.
+func fullInteractiveRemediationScenarioYAML(ns, selectWorkflowID string) string {
+	if ns == "" {
+		return ""
+	}
+	return fmt.Sprintf(`      - name: "af_full_interactive_remediation_1853"
+        keywords: ["investigate and fix remediation"]
+        match_last_only: true
+        tool_call:
+          name: "kubernaut_investigate"
+          arguments:
+            namespace: "%s"
+            kind: "Deployment"
+            name: "memory-eater"
+            api_version: "apps/v1"
+        next_tool_call:
+          name: "kubernaut_discover_workflows"
+          arguments:
+            rr_id: "$from_tool:kubernaut_investigate:rr_id"
+          next_tool_call:
+            name: "kubernaut_select_workflow"
+            arguments:
+              rr_id: "$from_tool:kubernaut_investigate:rr_id"
+              workflow_id: "%s"
+            next_tool_call:
+              name: "kubernaut_watch"
+              arguments:
+                name: "$from_tool:kubernaut_investigate:rr_id"
+`, ns, selectWorkflowID)
+}
+
 // resolveWorkflowUUID looks up the real catalog UUID seeded for a workflow
 // fixture (keyed "<workflowName>:<environment>" in workflowUUIDs, per
 // SeedWorkflowsViaKubectlApply/SeedWorkflowsViaDirectCRDCreationFromKubeconfig)
@@ -371,7 +445,15 @@ func DeployMockLLMInNamespace(ctx context.Context, namespace, kubeconfigPath, im
 	// invalid_workflow (silently, unless the caller strictly asserts on
 	// tool-call success) -- root cause of the E2E-FP-1189-005 Turn 5 stall.
 	afSelectWorkflowID := resolveWorkflowUUID(workflowUUIDs, "oomkill-increase-memory-v1")
-	afKeywordYAML := "keyword_scenarios:\n" + remediateScenarios + `      - name: "af_investigate"
+	// #1853 mode 2/3 scenarios are registered before af_investigate below:
+	// both keywords contain the substring "investigate", and mock-llm's
+	// registry breaks confidence ties (all keyword_scenarios score 1.0) by
+	// registration order, so these must come first to win over the bare
+	// "investigate" keyword.
+	afKeywordYAML := "keyword_scenarios:\n" + remediateScenarios +
+		combinedRemediateInvestigateScenarioYAML(afRemediateNS["combined-investigate"]) +
+		fullInteractiveRemediationScenarioYAML(afRemediateNS["full-interactive"], afSelectWorkflowID) +
+		`      - name: "af_investigate"
         keywords: ["start investigation", "investigate", "begin investigation"]
         match_last_only: true
         repeat_tool_call: true
@@ -379,6 +461,11 @@ func DeployMockLLMInNamespace(ctx context.Context, namespace, kubeconfigPath, im
           name: "kubernaut_investigate"
           arguments:
             rr_id: "$from_tool:kubernaut_remediate:rr_id"
+          fallback_arguments:
+            namespace: "kubernaut-system"
+            kind: "Deployment"
+            name: "memory-eater"
+            api_version: "apps/v1"
       - name: "af_discover_workflows"
         keywords: ["discover available workflows", "discover workflows"]
         match_last_only: true

--- a/test/services/mock-llm/config/overrides.go
+++ b/test/services/mock-llm/config/overrides.go
@@ -28,6 +28,29 @@ import (
 type ToolCallOverride struct {
 	Name      string                 `yaml:"name"`
 	Arguments map[string]interface{} `yaml:"arguments,omitempty"`
+
+	// NextToolCall recursively chains an additional tool call after this
+	// one's result arrives, allowing next_tool_call: to nest arbitrarily
+	// deep in YAML (issue #1853). E.g.:
+	//   tool_call: {name: investigate}
+	//   next_tool_call:
+	//     name: discover_workflows
+	//     next_tool_call:
+	//       name: select_workflow
+	NextToolCall *ToolCallOverride `yaml:"next_tool_call,omitempty"`
+
+	// FallbackArguments replaces Arguments in its entirety when at least one
+	// "$from_tool:<tool>:<field>" placeholder in Arguments cannot be resolved
+	// (the referenced tool was never called earlier in this conversation).
+	// This mirrors tool schemas with mutually exclusive argument sets -- e.g.
+	// kubernaut_investigate accepts EITHER rr_id (continue/take over an
+	// existing session) OR namespace/kind/name (create a new RR) -- so a
+	// scenario scripted for the "continue" case can gracefully degrade to
+	// the "create new" case instead of sending a half-resolved/literal
+	// template string. Added for issue #1853 after a live cluster showed
+	// af_investigate failing this exact way when invoked with no prior
+	// kubernaut_remediate call in the session.
+	FallbackArguments map[string]interface{} `yaml:"fallback_arguments,omitempty"`
 }
 
 // ScenarioOverride defines optional per-scenario overrides from a YAML config file.

--- a/test/services/mock-llm/handlers/chain.go
+++ b/test/services/mock-llm/handlers/chain.go
@@ -1,0 +1,99 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package handlers
+
+import (
+	"strings"
+
+	"github.com/jordigilh/kubernaut/test/services/mock-llm/scenarios"
+)
+
+// flattenToolCallChain walks a NextToolCall linked list starting at head and
+// returns it as an ordered slice. This lifts the historical 2-tool-call cap
+// (issue #1853): scenarios like investigate -> discover_workflows ->
+// select_workflow -> watch can now be scripted as a single chain instead of
+// requiring N independently-keyword-triggered turns.
+func flattenToolCallChain(head *scenarios.MultiToolCallEntry) []*scenarios.MultiToolCallEntry {
+	var chain []*scenarios.MultiToolCallEntry
+	for node := head; node != nil; node = node.NextToolCall {
+		chain = append(chain, node)
+	}
+	return chain
+}
+
+// nextChainCallByCount returns the chain entry due to fire given the total
+// number of tool/function responses already present in the conversation
+// (priorResponseCount), or nil if the chain hasn't started yet or has fully
+// completed. priorResponseCount==1 fires chain[0] (the same trigger point as
+// the original single-NextToolCall behavior), priorResponseCount==2 fires
+// chain[1], and so on; priorResponseCount > len(chain) means the whole chain
+// has already fired, so the caller should fall through to its normal
+// DAG/text response path (mirrors the pre-#1853 "fire at most once" guard,
+// generalized to N links).
+func nextChainCallByCount(chain []*scenarios.MultiToolCallEntry, priorResponseCount int) *scenarios.MultiToolCallEntry {
+	if priorResponseCount < 1 || priorResponseCount > len(chain) {
+		return nil
+	}
+	return chain[priorResponseCount-1]
+}
+
+// resolveTemplateArgsMap resolves "$from_tool:<toolName>:<field>" placeholders
+// in args using extractFn to look up each referenced tool's prior response
+// field, returning a NEW map — args is never mutated in place. This avoids
+// data races and cross-request state leaks when args is a field on a shared
+// scenario singleton (e.g. cfg.ToolCallArgs or a NextToolCall chain node's
+// Arguments, both of which are read concurrently by other in-flight
+// requests matching the same scenario).
+//
+// If at least one placeholder cannot be resolved (extractFn returns "" —
+// the referenced tool was never called earlier in this conversation) AND
+// fallback is non-empty, the ENTIRE argument set is replaced with a clone
+// of fallback instead of returning a partially-resolved map. This mirrors
+// tool schemas with mutually exclusive argument sets — e.g.
+// kubernaut_investigate accepts EITHER rr_id (continue/take over an
+// existing session) OR namespace/kind/name (create a new RR) — so a
+// scenario scripted for the "continue" case degrades gracefully to the
+// "create new" case instead of sending a half-resolved/literal template
+// string as a real argument value (issue #1853; found live on a shared FP
+// cluster where af_investigate was invoked with no prior kubernaut_remediate
+// call in the session).
+func resolveTemplateArgsMap(args, fallback map[string]interface{}, extractFn func(toolName, field string) string) map[string]interface{} {
+	if len(args) == 0 {
+		return args
+	}
+	resolved := cloneAnyMap(args)
+	anyUnresolved := false
+	for k, v := range resolved {
+		sv, ok := v.(string)
+		if !ok || !strings.HasPrefix(sv, templatePrefix) {
+			continue
+		}
+		parts := strings.SplitN(sv[len(templatePrefix):], ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		toolName, field := parts[0], parts[1]
+		if resolvedVal := extractFn(toolName, field); resolvedVal != "" {
+			resolved[k] = resolvedVal
+		} else {
+			anyUnresolved = true
+		}
+	}
+	if anyUnresolved && len(fallback) > 0 {
+		return cloneAnyMap(fallback)
+	}
+	return resolved
+}

--- a/test/services/mock-llm/handlers/gemini.go
+++ b/test/services/mock-llm/handlers/gemini.go
@@ -170,24 +170,26 @@ func (h *handler) handleGeminiToolResponse(
 	// fall through to text response instead of re-emitting the tool call.
 	repeatAllowed := cfg.RepeatToolCall && !response.LastContentIsFunctionResponse(contents)
 
-	// NextToolCall: when the initial tool has been called (FunctionResponse
-	// present) and a chained next_tool_call is configured, emit it. This
-	// simulates the LLM auto-proceeding to a second tool in the same session.
-	//
-	// Guard against infinite NextToolCall loops (#1409): fire at most once —
-	// stop once NextToolCall's own target tool has already responded anywhere
-	// in history. Without this, the ADK reasoning loop keeps calling back
-	// after NextToolCall's FunctionResponse is appended, and this handler
-	// would re-fire the same NextToolCall forever (see HasFunctionResponseNamed
-	// doc for the confirmed failure mode).
-	nextToolAlreadyFired := cfg.NextToolCall != nil && response.HasFunctionResponseNamed(contents, cfg.NextToolCall.Name)
-	if hasFunctionResults && cfg.NextToolCall != nil && !nextToolAlreadyFired {
-		h.trackToolCall(cfg.NextToolCall.Name)
-		writeJSON(w, http.StatusOK, response.BuildGeminiToolCallResponse(cfg.NextToolCall.Name, scenarios.MockScenarioConfig{
-			ToolCallName: cfg.NextToolCall.Name,
-			ToolCallArgs: cfg.NextToolCall.Arguments,
-		}))
-		return
+	// NextToolCall chain: once N tool/function responses exist, fire the Nth
+	// chained call (1-indexed), resolving any $from_tool templates in its
+	// arguments against the conversation so far. Generalizes the original
+	// single-NextToolCall behavior to arbitrary depth (issue #1853), e.g.
+	// investigate -> discover_workflows -> select_workflow -> watch, while
+	// preserving the #1409 "fire at most once per link" guard: once
+	// priorResponseCount exceeds the chain length, nextChainCallByCount
+	// returns nil and this falls through to the normal DAG/text path.
+	if chain := flattenToolCallChain(cfg.NextToolCall); len(chain) > 0 {
+		if next := nextChainCallByCount(chain, response.CountFunctionResponses(contents)); next != nil {
+			args := resolveTemplateArgsMap(next.Arguments, next.FallbackArguments, func(toolName, field string) string {
+				return response.ExtractFieldFromFunctionResponse(contents, toolName, field)
+			})
+			h.trackToolCall(next.Name)
+			writeJSON(w, http.StatusOK, response.BuildGeminiToolCallResponse(next.Name, scenarios.MockScenarioConfig{
+				ToolCallName: next.Name,
+				ToolCallArgs: args,
+			}))
+			return
+		}
 	}
 
 	if len(cfg.MultiToolCalls) > 0 && (!hasFunctionResults || repeatAllowed) {
@@ -262,24 +264,9 @@ func firstDeclaredTool(tools []response.GeminiToolDecl) string {
 // The map is cloned before mutation to avoid data races and state leaks
 // across concurrent requests sharing the same scenario singleton.
 func resolveGeminiTemplateArgs(contents []response.GeminiContent, cfg *scenarios.MockScenarioConfig) {
-	if len(cfg.ToolCallArgs) == 0 {
-		return
-	}
-	cfg.ToolCallArgs = cloneAnyMap(cfg.ToolCallArgs)
-	for k, v := range cfg.ToolCallArgs {
-		sv, ok := v.(string)
-		if !ok || !strings.HasPrefix(sv, templatePrefix) {
-			continue
-		}
-		parts := strings.SplitN(sv[len(templatePrefix):], ":", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		toolName, field := parts[0], parts[1]
-		if resolved := response.ExtractFieldFromFunctionResponse(contents, toolName, field); resolved != "" {
-			cfg.ToolCallArgs[k] = resolved
-		}
-	}
+	cfg.ToolCallArgs = resolveTemplateArgsMap(cfg.ToolCallArgs, cfg.FallbackArguments, func(toolName, field string) string {
+		return response.ExtractFieldFromFunctionResponse(contents, toolName, field)
+	})
 }
 
 func cloneAnyMap(m map[string]interface{}) map[string]interface{} {

--- a/test/services/mock-llm/handlers/openai.go
+++ b/test/services/mock-llm/handlers/openai.go
@@ -225,13 +225,26 @@ func (h *handler) handleFullDAG(
 		return
 	}
 
-	if cfg.NextToolCall != nil && ctx.CountToolResults() == 1 {
-		h.trackToolCall(cfg.NextToolCall.Name)
-		writeChatCompletion(w, req.Stream, response.BuildToolCallResponse(model, cfg.NextToolCall.Name, scenarios.MockScenarioConfig{
-			ToolCallName: cfg.NextToolCall.Name,
-			ToolCallArgs: cfg.NextToolCall.Arguments,
-		}))
-		return
+	// NextToolCall chain: once N tool results exist, fire the Nth chained call
+	// (1-indexed), resolving any $from_tool templates in its arguments
+	// against the conversation so far. Generalizes the original
+	// single-NextToolCall behavior to arbitrary depth (issue #1853), e.g.
+	// investigate -> discover_workflows -> select_workflow -> watch, while
+	// preserving the original "fire at most once per link" guard: once
+	// CountToolResults() exceeds the chain length, nextChainCallByCount
+	// returns nil and this falls through to the DAG/text path below.
+	if chain := flattenToolCallChain(cfg.NextToolCall); len(chain) > 0 {
+		if next := nextChainCallByCount(chain, ctx.CountToolResults()); next != nil {
+			args := resolveTemplateArgsMap(next.Arguments, next.FallbackArguments, func(toolName, field string) string {
+				return response.ExtractFieldFromToolResult(req.Messages, toolName, field)
+			})
+			h.trackToolCall(next.Name)
+			writeChatCompletion(w, req.Stream, response.BuildToolCallResponse(model, next.Name, scenarios.MockScenarioConfig{
+				ToolCallName: next.Name,
+				ToolCallArgs: args,
+			}))
+			return
+		}
 	}
 
 	dag := conversation.SelectDAG(req.Tools)
@@ -375,22 +388,7 @@ func msgString(m openai.Message) string {
 // The map is cloned before mutation to avoid data races and state leaks
 // across concurrent requests sharing the same scenario singleton.
 func resolveOpenAITemplateArgs(messages []openai.Message, cfg *scenarios.MockScenarioConfig) {
-	if len(cfg.ToolCallArgs) == 0 {
-		return
-	}
-	cfg.ToolCallArgs = cloneAnyMap(cfg.ToolCallArgs)
-	for k, v := range cfg.ToolCallArgs {
-		sv, ok := v.(string)
-		if !ok || !strings.HasPrefix(sv, templatePrefix) {
-			continue
-		}
-		parts := strings.SplitN(sv[len(templatePrefix):], ":", 2)
-		if len(parts) != 2 {
-			continue
-		}
-		toolName, field := parts[0], parts[1]
-		if resolved := response.ExtractFieldFromToolResult(messages, toolName, field); resolved != "" {
-			cfg.ToolCallArgs[k] = resolved
-		}
-	}
+	cfg.ToolCallArgs = resolveTemplateArgsMap(cfg.ToolCallArgs, cfg.FallbackArguments, func(toolName, field string) string {
+		return response.ExtractFieldFromToolResult(messages, toolName, field)
+	})
 }

--- a/test/services/mock-llm/repeat_tool_call_test.go
+++ b/test/services/mock-llm/repeat_tool_call_test.go
@@ -1090,3 +1090,391 @@ keyword_scenarios:
 		})
 	})
 })
+
+var _ = Describe("NextToolCall N-deep chaining and template resolution (issue #1853)", func() {
+
+	Describe("UT-ML-1853-001: nested next_tool_call YAML parsing", func() {
+		It("should parse a 3-level chain (tool_call -> next_tool_call -> next_tool_call.next_tool_call)", func() {
+			yamlContent := `
+keyword_scenarios:
+  - name: "af_combined_1853"
+    keywords: ["combined chain 1853"]
+    match_last_only: true
+    tool_call:
+      name: "kubernaut_remediate"
+      arguments:
+        namespace: "default"
+    next_tool_call:
+      name: "kubernaut_investigate"
+      arguments:
+        rr_id: "$from_tool:kubernaut_remediate:rr_id"
+      next_tool_call:
+        name: "kubernaut_discover_workflows"
+        arguments:
+          rr_id: "$from_tool:kubernaut_remediate:rr_id"
+`
+			tmpFile := filepath.Join(GinkgoT().TempDir(), "overrides.yaml")
+			Expect(os.WriteFile(tmpFile, []byte(yamlContent), 0644)).To(Succeed())
+
+			overrides, err := config.LoadYAMLOverrides(tmpFile)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(overrides.KeywordScenarios).To(HaveLen(1))
+			ks := overrides.KeywordScenarios[0]
+			Expect(ks.NextToolCall).NotTo(BeNil())
+			Expect(ks.NextToolCall.Name).To(Equal("kubernaut_investigate"))
+			Expect(ks.NextToolCall.NextToolCall).NotTo(BeNil(), "3rd chain link must parse")
+			Expect(ks.NextToolCall.NextToolCall.Name).To(Equal("kubernaut_discover_workflows"))
+		})
+	})
+
+	Describe("UT-ML-1853-002: Gemini fires the 2nd chain link with $from_tool resolved against an earlier (not just immediately-prior) response", func() {
+		It("should fire kubernaut_discover_workflows with rr_id resolved from kubernaut_remediate, two responses back", func() {
+			overrides := &config.Overrides{
+				Scenarios: map[string]config.ScenarioOverride{},
+				KeywordScenarios: []config.KeywordScenarioOverride{
+					{
+						Name:          "af_combined_1853",
+						Keywords:      []string{"combined chain 1853"},
+						MatchLastOnly: true,
+						ToolCall:      config.ToolCallOverride{Name: "kubernaut_remediate", Arguments: map[string]interface{}{"namespace": "default"}},
+						NextToolCall: &config.ToolCallOverride{
+							Name:      "kubernaut_investigate",
+							Arguments: map[string]interface{}{"rr_id": "$from_tool:kubernaut_remediate:rr_id"},
+							NextToolCall: &config.ToolCallOverride{
+								Name:      "kubernaut_discover_workflows",
+								Arguments: map[string]interface{}{"rr_id": "$from_tool:kubernaut_remediate:rr_id"},
+							},
+						},
+					},
+				},
+			}
+			registry := scenarios.DefaultRegistryWithOverrides(overrides)
+			router := handlers.NewRouter(registry, false, "")
+			ts := httptest.NewServer(router)
+			defer ts.Close()
+
+			reqBody := response.GeminiRequest{
+				Contents: []response.GeminiContent{
+					{Role: "user", Parts: []response.GeminiPart{{Text: "combined chain 1853"}}},
+					{Role: "model", Parts: []response.GeminiPart{{FunctionCall: &response.GeminiFunctionCall{Name: "kubernaut_remediate", Args: map[string]interface{}{"namespace": "default"}}}}},
+					{Role: "user", Parts: []response.GeminiPart{{FunctionResponse: &response.GeminiFunctionResp{Name: "kubernaut_remediate", Response: map[string]interface{}{"rr_id": "rr-real-001"}}}}},
+					{Role: "model", Parts: []response.GeminiPart{{FunctionCall: &response.GeminiFunctionCall{Name: "kubernaut_investigate", Args: map[string]interface{}{"rr_id": "rr-real-001"}}}}},
+					{Role: "user", Parts: []response.GeminiPart{{FunctionResponse: &response.GeminiFunctionResp{Name: "kubernaut_investigate", Response: map[string]interface{}{"summary": "OOM detected"}}}}},
+				},
+				Tools: []response.GeminiToolDecl{
+					{FunctionDeclarations: []response.GeminiFunctionDecl{
+						{Name: "kubernaut_remediate"},
+						{Name: "kubernaut_investigate"},
+						{Name: "kubernaut_discover_workflows"},
+					}},
+				},
+			}
+
+			body, err := json.Marshal(reqBody)
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, err := http.Post(ts.URL+"/v1beta/models/gemini-1.5-pro:generateContent", "application/json", bytes.NewReader(body))
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			var gemResp response.GeminiResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&gemResp)).To(Succeed())
+			Expect(gemResp.Candidates).To(HaveLen(1))
+
+			parts := gemResp.Candidates[0].Content.Parts
+			Expect(parts).To(HaveLen(1))
+			Expect(parts[0].FunctionCall).NotTo(BeNil(), "should fire the 2nd chain link")
+			Expect(parts[0].FunctionCall.Name).To(Equal("kubernaut_discover_workflows"),
+				"3-deep chain must reach its 2nd NextToolCall link, not stop after the 1st")
+			Expect(parts[0].FunctionCall.Args).To(HaveKeyWithValue("rr_id", "rr-real-001"),
+				"$from_tool must resolve against kubernaut_remediate's response even though it is 2 responses back, not just the immediately-prior one")
+		})
+	})
+
+	Describe("UT-ML-1853-003: OpenAI fires the 2nd chain link with $from_tool resolved against an earlier response", func() {
+		It("should fire kubernaut_discover_workflows with rr_id resolved from kubernaut_remediate, two tool results back", func() {
+			content := func(s string) *string { return &s }
+			overrides := &config.Overrides{
+				Scenarios: map[string]config.ScenarioOverride{},
+				KeywordScenarios: []config.KeywordScenarioOverride{
+					{
+						Name:          "af_combined_1853_openai",
+						Keywords:      []string{"combined chain 1853 openai"},
+						MatchLastOnly: true,
+						ToolCall:      config.ToolCallOverride{Name: "kubernaut_remediate", Arguments: map[string]interface{}{"namespace": "default"}},
+						NextToolCall: &config.ToolCallOverride{
+							Name:      "kubernaut_investigate",
+							Arguments: map[string]interface{}{"rr_id": "$from_tool:kubernaut_remediate:rr_id"},
+							NextToolCall: &config.ToolCallOverride{
+								Name:      "kubernaut_discover_workflows",
+								Arguments: map[string]interface{}{"rr_id": "$from_tool:kubernaut_remediate:rr_id"},
+							},
+						},
+					},
+				},
+			}
+			registry := scenarios.DefaultRegistryWithOverrides(overrides)
+			router := handlers.NewRouter(registry, false, "")
+			ts := httptest.NewServer(router)
+			defer ts.Close()
+
+			reqBody := openai.ChatCompletionRequest{
+				Model: "gpt-4",
+				Messages: []openai.Message{
+					{Role: "user", Content: content("combined chain 1853 openai")},
+					{Role: "assistant", ToolCalls: []openai.ToolCall{{ID: "call_1", Type: "function", Function: openai.FunctionCall{Name: "kubernaut_remediate", Arguments: `{"namespace":"default"}`}}}},
+					{Role: "tool", Content: content(`{"rr_id":"rr-real-002"}`)},
+					{Role: "assistant", ToolCalls: []openai.ToolCall{{ID: "call_2", Type: "function", Function: openai.FunctionCall{Name: "kubernaut_investigate", Arguments: `{"rr_id":"rr-real-002"}`}}}},
+					{Role: "tool", Content: content(`{"summary":"OOM detected"}`)},
+				},
+				Tools: []openai.Tool{
+					{Type: "function", Function: openai.ToolDefinition{Name: "kubernaut_remediate"}},
+					{Type: "function", Function: openai.ToolDefinition{Name: "kubernaut_investigate"}},
+					{Type: "function", Function: openai.ToolDefinition{Name: "kubernaut_discover_workflows"}},
+				},
+			}
+
+			body, err := json.Marshal(reqBody)
+			Expect(err).NotTo(HaveOccurred())
+
+			resp, err := http.Post(ts.URL+"/v1/chat/completions", "application/json", bytes.NewReader(body))
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+			var oaiResp openai.ChatCompletionResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&oaiResp)).To(Succeed())
+			Expect(oaiResp.Choices).To(HaveLen(1))
+			Expect(oaiResp.Choices[0].Message.ToolCalls).To(HaveLen(1),
+				"should fire the 2nd chain link")
+			Expect(oaiResp.Choices[0].Message.ToolCalls[0].Function.Name).To(Equal("kubernaut_discover_workflows"),
+				"3-deep chain must reach its 2nd NextToolCall link, not stop after the 1st")
+			Expect(oaiResp.Choices[0].Message.ToolCalls[0].Function.Arguments).To(ContainSubstring("rr-real-002"),
+				"$from_tool must resolve against kubernaut_remediate's tool result even though it is 2 tool results back")
+		})
+	})
+
+	Describe("UT-ML-1853-004: no cross-request state leak when resolving chain-link arguments", func() {
+		It("should resolve each request's $from_tool independently without mutating the shared scenario config", func() {
+			overrides := &config.Overrides{
+				Scenarios: map[string]config.ScenarioOverride{},
+				KeywordScenarios: []config.KeywordScenarioOverride{
+					{
+						Name:          "af_combined_1853_leak_check",
+						Keywords:      []string{"combined chain 1853 leak check"},
+						MatchLastOnly: true,
+						ToolCall:      config.ToolCallOverride{Name: "kubernaut_remediate", Arguments: map[string]interface{}{"namespace": "default"}},
+						NextToolCall: &config.ToolCallOverride{
+							Name:      "kubernaut_investigate",
+							Arguments: map[string]interface{}{"rr_id": "$from_tool:kubernaut_remediate:rr_id"},
+						},
+					},
+				},
+			}
+			// One registry/router shared across both requests, mirroring how a
+			// real mock-llm server reuses the same scenario singleton for every
+			// matching request.
+			registry := scenarios.DefaultRegistryWithOverrides(overrides)
+			router := handlers.NewRouter(registry, false, "")
+			ts := httptest.NewServer(router)
+			defer ts.Close()
+
+			fire := func(rrID string) string {
+				reqBody := response.GeminiRequest{
+					Contents: []response.GeminiContent{
+						{Role: "user", Parts: []response.GeminiPart{{Text: "combined chain 1853 leak check"}}},
+						{Role: "model", Parts: []response.GeminiPart{{FunctionCall: &response.GeminiFunctionCall{Name: "kubernaut_remediate", Args: map[string]interface{}{"namespace": "default"}}}}},
+						{Role: "user", Parts: []response.GeminiPart{{FunctionResponse: &response.GeminiFunctionResp{Name: "kubernaut_remediate", Response: map[string]interface{}{"rr_id": rrID}}}}},
+					},
+					Tools: []response.GeminiToolDecl{
+						{FunctionDeclarations: []response.GeminiFunctionDecl{
+							{Name: "kubernaut_remediate"},
+							{Name: "kubernaut_investigate"},
+						}},
+					},
+				}
+				body, err := json.Marshal(reqBody)
+				Expect(err).NotTo(HaveOccurred())
+				resp, err := http.Post(ts.URL+"/v1beta/models/gemini-1.5-pro:generateContent", "application/json", bytes.NewReader(body))
+				Expect(err).NotTo(HaveOccurred())
+				defer resp.Body.Close()
+				var gemResp response.GeminiResponse
+				Expect(json.NewDecoder(resp.Body).Decode(&gemResp)).To(Succeed())
+				parts := gemResp.Candidates[0].Content.Parts
+				Expect(parts).To(HaveLen(1))
+				Expect(parts[0].FunctionCall).NotTo(BeNil())
+				val, _ := parts[0].FunctionCall.Args["rr_id"].(string)
+				return val
+			}
+
+			Expect(fire("rr-AAA")).To(Equal("rr-AAA"), "first request resolves its own rr_id")
+			Expect(fire("rr-BBB")).To(Equal("rr-BBB"),
+				"second request must resolve its OWN rr_id, not a value leaked from the first request's resolution mutating the shared NextToolCall.Arguments map")
+			// Re-run the first value again to prove the second call didn't
+			// leave the shared config permanently pinned to "rr-BBB" either.
+			Expect(fire("rr-AAA")).To(Equal("rr-AAA"), "third request resolves independently again")
+		})
+	})
+
+	Describe("UT-ML-1853-005: fallback_arguments YAML parsing", func() {
+		It("should parse fallback_arguments as a sibling of arguments under tool_call", func() {
+			yamlContent := `
+keyword_scenarios:
+  - name: "af_investigate"
+    keywords: ["investigate"]
+    match_last_only: true
+    tool_call:
+      name: "kubernaut_investigate"
+      arguments:
+        rr_id: "$from_tool:kubernaut_remediate:rr_id"
+      fallback_arguments:
+        namespace: "kubernaut-system"
+        kind: "Deployment"
+        name: "memory-eater"
+`
+			tmpFile := filepath.Join(GinkgoT().TempDir(), "overrides.yaml")
+			Expect(os.WriteFile(tmpFile, []byte(yamlContent), 0644)).To(Succeed())
+
+			overrides, err := config.LoadYAMLOverrides(tmpFile)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(overrides.KeywordScenarios).To(HaveLen(1))
+			fb := overrides.KeywordScenarios[0].ToolCall.FallbackArguments
+			Expect(fb).To(HaveKeyWithValue("namespace", "kubernaut-system"))
+			Expect(fb).To(HaveKeyWithValue("kind", "Deployment"))
+			Expect(fb).To(HaveKeyWithValue("name", "memory-eater"))
+		})
+	})
+
+	Describe("UT-ML-1853-006: fallback_arguments used when $from_tool has no prior call to resolve against", func() {
+		// Reproduces the live #1853 finding on the shared fullpipeline-e2e
+		// cluster: a session that calls "investigate" WITHOUT a prior
+		// "kubernaut_remediate" call in the same conversation must not send
+		// the literal unresolved "$from_tool:kubernaut_remediate:rr_id"
+		// string as a real argument value (AF rejects it as an invalid
+		// resource name) -- it must fall back to creating a new RR from
+		// namespace/kind/name instead, mirroring kubernaut_investigate's
+		// real mutually-exclusive rr_id-vs-resource-identity argument
+		// contract (pkg/apifrontend/tools/ka_investigate_mcp.go).
+		overrides := &config.Overrides{
+			Scenarios: map[string]config.ScenarioOverride{},
+			KeywordScenarios: []config.KeywordScenarioOverride{
+				{
+					Name:           "af_investigate_fallback_check",
+					Keywords:       []string{"investigate fallback check"},
+					MatchLastOnly:  true,
+					RepeatToolCall: true, // mirrors the real af_investigate scenario's repeat_tool_call: true
+					ToolCall: config.ToolCallOverride{
+						Name:      "kubernaut_investigate",
+						Arguments: map[string]interface{}{"rr_id": "$from_tool:kubernaut_remediate:rr_id"},
+						FallbackArguments: map[string]interface{}{
+							"namespace": "kubernaut-system",
+							"kind":      "Deployment",
+							"name":      "memory-eater",
+						},
+					},
+				},
+			},
+		}
+
+		It("Gemini: falls back to namespace/kind/name when no prior kubernaut_remediate exists in the conversation", func() {
+			registry := scenarios.DefaultRegistryWithOverrides(overrides)
+			router := handlers.NewRouter(registry, false, "")
+			ts := httptest.NewServer(router)
+			defer ts.Close()
+
+			reqBody := response.GeminiRequest{
+				Contents: []response.GeminiContent{
+					{Role: "user", Parts: []response.GeminiPart{{Text: "investigate fallback check"}}},
+				},
+				Tools: []response.GeminiToolDecl{
+					{FunctionDeclarations: []response.GeminiFunctionDecl{{Name: "kubernaut_investigate"}}},
+				},
+			}
+			body, err := json.Marshal(reqBody)
+			Expect(err).NotTo(HaveOccurred())
+			resp, err := http.Post(ts.URL+"/v1beta/models/gemini-1.5-pro:generateContent", "application/json", bytes.NewReader(body))
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			var gemResp response.GeminiResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&gemResp)).To(Succeed())
+			parts := gemResp.Candidates[0].Content.Parts
+			Expect(parts).To(HaveLen(1))
+			Expect(parts[0].FunctionCall).NotTo(BeNil())
+			args := parts[0].FunctionCall.Args
+			Expect(args).NotTo(HaveKey("rr_id"), "the broken half-resolved rr_id must not be sent at all")
+			Expect(args).To(HaveKeyWithValue("namespace", "kubernaut-system"))
+			Expect(args).To(HaveKeyWithValue("name", "memory-eater"))
+		})
+
+		It("OpenAI: falls back to namespace/kind/name when no prior kubernaut_remediate exists in the conversation", func() {
+			registry := scenarios.DefaultRegistryWithOverrides(overrides)
+			router := handlers.NewRouter(registry, false, "")
+			ts := httptest.NewServer(router)
+			defer ts.Close()
+
+			userMsg := "investigate fallback check"
+			reqBody := openai.ChatCompletionRequest{
+				Model:    "gpt-4",
+				Messages: []openai.Message{{Role: "user", Content: &userMsg}},
+				Tools: []openai.Tool{
+					{Type: "function", Function: openai.ToolDefinition{Name: "kubernaut_investigate"}},
+				},
+			}
+			body, err := json.Marshal(reqBody)
+			Expect(err).NotTo(HaveOccurred())
+			resp, err := http.Post(ts.URL+"/v1/chat/completions", "application/json", bytes.NewReader(body))
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			var oaiResp openai.ChatCompletionResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&oaiResp)).To(Succeed())
+			Expect(oaiResp.Choices[0].Message.ToolCalls).To(HaveLen(1))
+			argsJSON := oaiResp.Choices[0].Message.ToolCalls[0].Function.Arguments
+			Expect(argsJSON).NotTo(ContainSubstring("from_tool"), "the broken half-resolved rr_id must not be sent at all")
+			Expect(argsJSON).To(ContainSubstring("kubernaut-system"))
+			Expect(argsJSON).To(ContainSubstring("memory-eater"))
+		})
+
+		It("does NOT use the fallback when a prior kubernaut_remediate call resolves rr_id normally (no regression to existing multi-turn flows)", func() {
+			registry := scenarios.DefaultRegistryWithOverrides(overrides)
+			router := handlers.NewRouter(registry, false, "")
+			ts := httptest.NewServer(router)
+			defer ts.Close()
+
+			reqBody := response.GeminiRequest{
+				Contents: []response.GeminiContent{
+					// Turn 1: remediate, then its result. Turn 2: a fresh user
+					// message triggers investigate -- mirrors the real
+					// multi-turn shape (E2E-FP-1189-003 Turn 1 -> Turn 2),
+					// where the FunctionResponse is NOT the last content by
+					// the time "investigate" fires (LastContentIsFunctionResponse
+					// gates RepeatToolCall re-firing to avoid infinite loops).
+					{Role: "user", Parts: []response.GeminiPart{{Text: "create a remediation"}}},
+					{Role: "model", Parts: []response.GeminiPart{{FunctionCall: &response.GeminiFunctionCall{Name: "kubernaut_remediate", Args: map[string]interface{}{}}}}},
+					{Role: "user", Parts: []response.GeminiPart{{FunctionResponse: &response.GeminiFunctionResp{Name: "kubernaut_remediate", Response: map[string]interface{}{"rr_id": "rr-real-999"}}}}},
+					{Role: "user", Parts: []response.GeminiPart{{Text: "investigate fallback check"}}},
+				},
+				Tools: []response.GeminiToolDecl{
+					{FunctionDeclarations: []response.GeminiFunctionDecl{
+						{Name: "kubernaut_remediate"},
+						{Name: "kubernaut_investigate"},
+					}},
+				},
+			}
+			body, err := json.Marshal(reqBody)
+			Expect(err).NotTo(HaveOccurred())
+			resp, err := http.Post(ts.URL+"/v1beta/models/gemini-1.5-pro:generateContent", "application/json", bytes.NewReader(body))
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			var gemResp response.GeminiResponse
+			Expect(json.NewDecoder(resp.Body).Decode(&gemResp)).To(Succeed())
+			parts := gemResp.Candidates[0].Content.Parts
+			Expect(parts).To(HaveLen(1))
+			Expect(parts[0].FunctionCall).NotTo(BeNil())
+			args := parts[0].FunctionCall.Args
+			Expect(args).To(HaveKeyWithValue("rr_id", "rr-real-999"),
+				"when rr_id resolves successfully, the fallback must NOT override it")
+			Expect(args).NotTo(HaveKey("namespace"), "fallback args must not leak in when resolution succeeded")
+		})
+	})
+})

--- a/test/services/mock-llm/response/gemini.go
+++ b/test/services/mock-llm/response/gemini.go
@@ -181,6 +181,22 @@ func HasFunctionResponse(contents []GeminiContent) bool {
 	return false
 }
 
+// CountFunctionResponses returns the total number of FunctionResponse parts
+// across all contents. Used to position a caller within a NextToolCall chain
+// (issue #1853): the Nth response received means the Nth chain link is due
+// to fire next, generalizing the historical single-NextToolCall firing rule.
+func CountFunctionResponses(contents []GeminiContent) int {
+	count := 0
+	for _, c := range contents {
+		for _, p := range c.Parts {
+			if p.FunctionResponse != nil {
+				count++
+			}
+		}
+	}
+	return count
+}
+
 // LastContentIsFunctionResponse returns true if the final content entry in the
 // conversation is a FunctionResponse. This indicates the ADK just executed a
 // tool in the current iteration; the mock-LLM should stop repeating tool calls

--- a/test/services/mock-llm/scenarios/registry_default.go
+++ b/test/services/mock-llm/scenarios/registry_default.go
@@ -57,6 +57,22 @@ func applyOverride(cs *configScenario, ov config.ScenarioOverride) {
 	}
 }
 
+// convertToolCallChain recursively converts a YAML-parsed ToolCallOverride
+// chain (config.ToolCallOverride.NextToolCall) into the scenario-internal
+// MultiToolCallEntry linked-list representation, preserving arbitrary chain
+// depth (issue #1853).
+func convertToolCallChain(tc *config.ToolCallOverride) *MultiToolCallEntry {
+	if tc == nil {
+		return nil
+	}
+	return &MultiToolCallEntry{
+		Name:              tc.Name,
+		Arguments:         tc.Arguments,
+		NextToolCall:      convertToolCallChain(tc.NextToolCall),
+		FallbackArguments: tc.FallbackArguments,
+	}
+}
+
 // applyAlternativeOverrides replaces deterministic UUIDs in a scenario's
 // Alternatives with the real DataStorage UUIDs from the overrides map.
 func applyAlternativeOverrides(cs *configScenario, overrides map[string]config.ScenarioOverride) {
@@ -127,19 +143,15 @@ func DefaultRegistryFull(overrides *config.Overrides, goldenDir string) *Registr
 		// ADK agent conversations.
 		for _, ks := range overrides.KeywordScenarios {
 			cfg := MockScenarioConfig{
-				ScenarioName:   ks.Name,
-				ToolCallName:   ks.ToolCall.Name,
-				ToolCallArgs:   ks.ToolCall.Arguments,
-				ForceText:      BoolPtr(false),
-				RepeatToolCall: ks.RepeatToolCall,
-				ThoughtText:    ks.ThoughtText,
+				ScenarioName:      ks.Name,
+				ToolCallName:      ks.ToolCall.Name,
+				ToolCallArgs:      ks.ToolCall.Arguments,
+				FallbackArguments: ks.ToolCall.FallbackArguments,
+				ForceText:         BoolPtr(false),
+				RepeatToolCall:    ks.RepeatToolCall,
+				ThoughtText:       ks.ThoughtText,
 			}
-			if ks.NextToolCall != nil {
-				cfg.NextToolCall = &MultiToolCallEntry{
-					Name:      ks.NextToolCall.Name,
-					Arguments: ks.NextToolCall.Arguments,
-				}
-			}
+			cfg.NextToolCall = convertToolCallChain(ks.NextToolCall)
 			if ks.MatchLastOnly {
 				r.Register(lastUserKeywordScenarioMulti(ks.Name, ks.Keywords, cfg))
 			} else {

--- a/test/services/mock-llm/scenarios/types.go
+++ b/test/services/mock-llm/scenarios/types.go
@@ -36,6 +36,20 @@ type MockAlternativeWorkflow struct {
 type MultiToolCallEntry struct {
 	Name      string                 `yaml:"name"`
 	Arguments map[string]interface{} `yaml:"arguments,omitempty"`
+
+	// NextToolCall chains an additional tool call after this entry's own
+	// FunctionResponse/tool result arrives, making a linked list of
+	// arbitrary depth. This lifts the historical 2-tool-call cap (issue
+	// #1853): scenarios like investigate -> discover_workflows ->
+	// select_workflow -> watch can now be scripted as a single chain
+	// instead of requiring N independent keyword-triggered turns.
+	NextToolCall *MultiToolCallEntry
+
+	// FallbackArguments replaces Arguments in its entirety when a
+	// "$from_tool:<tool>:<field>" placeholder in Arguments cannot be
+	// resolved. See config.ToolCallOverride.FallbackArguments (issue #1853)
+	// for the full rationale.
+	FallbackArguments map[string]interface{}
 }
 
 // MockScenarioConfig holds the static configuration for a mock scenario.
@@ -83,6 +97,10 @@ type MockScenarioConfig struct {
 	ToolCallName string
 	// ToolCallArgs provides the arguments for the custom tool call.
 	ToolCallArgs map[string]interface{}
+	// FallbackArguments replaces ToolCallArgs in its entirety when a
+	// "$from_tool:<tool>:<field>" placeholder in ToolCallArgs cannot be
+	// resolved (issue #1853). See config.ToolCallOverride.FallbackArguments.
+	FallbackArguments map[string]interface{}
 
 	// MultiToolCalls, when non-empty, causes the handler to return all
 	// listed tool calls in a single assistant message on the first request.


### PR DESCRIPTION
## Summary

- Fixes issue #1853: a single free-form A2A `message/stream` request combining "create a remediation + investigate it" intent was completely broken in the `fullpipeline` E2E mock-LLM fixture. Root cause: the mock-LLM's `NextToolCall` chaining mechanism (a) capped chains at exactly one link, and (b) never resolved `$from_tool:<tool>:<field>` templates inside a chained call's own arguments (only the primary `tool_call`'s arguments were resolved).
- While triaging, confirmed against the production system prompt (`pkg/apifrontend/agent/prompt.txt`) that AF actually supports **three** distinct operational modes for this kind of request (autonomous, interactive, full-interactive-remediation), not one — only mode 1 had any test coverage before this PR. All three now have E2E coverage.
- Found and fixed a separate, pre-existing live defect on the shared `fullpipeline-e2e` cluster while validating the above: `af_investigate` sent AF a literal, unresolved `$from_tool` placeholder as `rr_id` when invoked standalone (no prior `kubernaut_remediate` in-session), which AF correctly rejected. Added `fallback_arguments` to the mock-LLM tool-call schema so it gracefully degrades to `namespace/kind/name` instead.
- **Test-infrastructure-only change** — no `pkg/` or `cmd/` production code touched.

## Details

- `NextToolCall`/`ToolCallOverride` generalized from a single optional link to a self-referential linked list of arbitrary depth (needed for mode 3's 4-deep chain: `investigate` → `discover_workflows` → `select_workflow` → `watch`).
- `$from_tool` template resolution now walks the entire chain (previously only the first `tool_call`'s arguments were resolved), via new shared helpers in `test/services/mock-llm/handlers/chain.go` used by both the Gemini and OpenAI handlers.
- `fallback_arguments` (new field on `ToolCallOverride`/`MultiToolCallEntry`/`MockScenarioConfig`): when any `$from_tool` reference can't resolve, the entire argument set falls back to a scenario-provided literal set instead of sending a half-resolved map with a literal placeholder string in it.
- New E2E specs: `E2E-FP-1853-001` (mode 2, `16_af_a2a_combined_investigate_test.go`) and `E2E-FP-1853-002` (mode 3, `17_af_a2a_full_interactive_remediation_test.go`).
- New unit tests `UT-ML-1853-001` through `-006` covering chain-depth parsing, non-adjacent `$from_tool` resolution (Gemini + OpenAI), cross-request state isolation, and `fallback_arguments` parsing/behavior (including no-regression when resolution succeeds).
- Full test plan, risk traceability, and live-validation evidence: `docs/testing/1853/TEST_PLAN.md`. Console-team-facing mode breakdown: `docs/testing/1853/CONSOLE_TEAM_SUMMARY.md` (also posted as an issue comment).

## Live validation (see TEST_PLAN.md §3.1-3.2 for full detail)

Since the harness's image-build step has no content-hash cache-hit path (rebuilds ~10+ unchanged service images with `--no-cache` + a fresh random tag on every invocation), mode 2/3 chaining and the `fallback_arguments` fix were validated by direct reproduction against the shared `fullpipeline-e2e` cluster instead of a full Ginkgo run:

- Standalone `af_investigate` fallback: real `curl` A2A request produced a new RR/IS with zero `invalid rr_id` errors.
- Mode 2: `kubernaut_remediate` → `kubernaut_investigate` chained correctly with real `rr_id` propagation, creating a real RR + InvestigationSession, stopping at RCA as designed.
- Mode 3: full 4-deep chain fired correctly, reaching a `Completed`/`Remediated` RR + WorkflowExecution — the target Deployment's memory limit was genuinely patched 50Mi→512Mi by the real remediation workflow.

All scratch cluster resources were cleaned up afterward; the shared cluster's ConfigMap was restored to contain only the `fallback_arguments` fix (re-smoke-tested).

## Test plan

- [x] `go build ./test/...` and `go vet ./test/...` clean
- [x] `go test ./test/services/mock-llm/...` — all unit tests green (UT-ML-1853-001 through -006)
- [x] Mode 2/3 chaining + fallback_arguments live-validated against the shared `fullpipeline-e2e` cluster (see TEST_PLAN.md §3.2)
- [ ] Full Ginkgo `fullpipeline` E2E run with `--label-filter="issue-1853"` (not yet run in CI — behavior already proven live per above)

Made with [Cursor](https://cursor.com)