### PR TITLE
docs: rewrite Group D - workflow/playbook-as-separate-MCP-service docs (#1806)

### DIFF
--- a/docs/architecture/decisions/DD-CONTRACT-001-aianalysis-workflowexecution-alignment.md
+++ b/docs/architecture/decisions/DD-CONTRACT-001-aianalysis-workflowexecution-alignment.md
@@ -1,9 +1,24 @@
 # DD-CONTRACT-001: AIAnalysis ↔ WorkflowExecution Contract Alignment
 
-**Status**: ✅ Approved
-**Version**: 1.2
-**Date**: 2025-11-28
-**Confidence**: 98%
+**Status**: ✅ Approved (core contract shape); ⚠️ **catalog-resolution mechanism corrected in v2.0**
+**Version**: 2.0
+**Date**: 2025-11-28 (v1.2); 2026-08-02 (v2.0 correction, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))
+**Confidence**: 95%
+
+> **v2.0 correction note**: This v1.2 document (Nov 2025) predates the current implementation and got one
+> load-bearing detail wrong: it describes **"HolmesGPT-API"** resolving `workflow_id → containerImage` via a
+> **Data Storage MCP search** during RCA. Neither exists today. The service is **Kubernaut Agent (KA)**, a
+> native-Go rewrite, and KA owns workflow discovery **in-process** against `RemediationWorkflow`/`ActionType`
+> CRDs (informer-backed cache, no HTTP/MCP call to Data Storage for this) — see
+> [DD-WORKFLOW-019](DD-WORKFLOW-019-ka-owned-workflow-discovery.md) (authoritative, "Implemented" as of July
+> 2026). The CRD field named `containerImage`/`containerDigest` below was also generalized and renamed to
+> `executionBundle`/`executionBundleDigest` (Issue #1661 Change 11-12) once WorkflowExecution grew three
+> execution engines (Tekton, native `batchv1.Job`, Ansible/AWX) instead of only Tekton. The remaining sections
+> — the overall CRD contract shape, the RO pass-through principle, and the approval-orchestration flow — remain
+> directionally correct and are corrected in place below rather than rewritten from scratch. For the
+> `approvalRequired` vs. `needsHumanReview` two-flag decision logic (added after this document's v1.x), see
+> [DD-CONTRACT-002](DD-CONTRACT-002-service-integration-contracts.md#contract-2-aianalysis--ro-status-output),
+> which is kept as the single authority for that split to avoid duplicating it here.
 
 ---
 
@@ -53,139 +68,101 @@ Align all CRD schemas with ADR-041 and ADR-043.
 
 ### 1. AIAnalysis CRD Status
 
-**Updated Schema**:
-```go
-// pkg/api/aianalysis/v1alpha1/types.go
-package v1alpha1
+**Real schema** (`api/aianalysis/v1alpha1/aianalysis_types.go`, API group `kubernaut.ai/v1alpha1` —
+corrected from v1.2's `pkg/api/aianalysis/v1alpha1/types.go` / `kubernaut.io`; simplified/illustrative, see
+source for the complete field list):
 
-import (
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
+```go
+// api/aianalysis/v1alpha1/aianalysis_types.go
+package v1alpha1
 
 // AIAnalysisStatus defines the observed state of AIAnalysis
 type AIAnalysisStatus struct {
-    // Phase tracks current analysis stage
-    // NOTE: AIAnalysis does NOT have "Approving" phase - it completes with approvalRequired=true
-    // RemediationOrchestrator handles the approval orchestration (ADR-040)
-    // +kubebuilder:validation:Enum=Pending;Investigating;Analyzing;Completed;Failed
+    // Phase tracks current analysis stage (no "Approving"/"Recommending" phase -
+    // simplified 4-phase flow; RO handles approval orchestration, ADR-040)
     Phase string `json:"phase"`
 
-    // PhaseTransitions records timestamps for each phase
-    PhaseTransitions map[string]metav1.Time `json:"phaseTransitions,omitempty"`
+    // RootCauseAnalysis contains RCA findings, including the LLM-determined
+    // RemediationTarget (BR-KA-212) -- may differ from the signal's source resource
+    RootCauseAnalysis *RootCauseAnalysis `json:"rootCauseAnalysis,omitempty"`
 
-    // InvestigationResult contains HolmesGPT investigation findings
-    InvestigationResult *InvestigationResult `json:"investigationResult,omitempty"`
-
-    // SelectedWorkflow contains the LLM-selected workflow (per ADR-041)
-    // Populated after successful investigation and analysis
+    // SelectedWorkflow contains the AI-selected workflow (DD-CONTRACT-002)
+    // Immutable once SelectedAt is populated (Issue #1661, DD-WORKFLOW-018)
     SelectedWorkflow *SelectedWorkflow `json:"selectedWorkflow,omitempty"`
 
-    // AlternativeWorkflows contains backup options (per ADR-041)
+    // AlternativeWorkflows are informational only (context for approval decisions),
+    // never used for automatic execution
     AlternativeWorkflows []AlternativeWorkflow `json:"alternativeWorkflows,omitempty"`
 
-    // ApprovalRequired indicates if manual approval is needed
-    // Triggers RemediationOrchestrator to create RemediationApprovalRequest (ADR-040)
-    ApprovalRequired bool `json:"approvalRequired,omitempty"`
+    // ApprovalRequired: Rego policy decision -- AI HAS an answer, policy requires approval
+    ApprovalRequired bool `json:"approvalRequired"`
 
-    // ApprovalReason explains why approval is required
-    ApprovalReason string `json:"approvalReason,omitempty"`
+    // NeedsHumanReview: KA decision -- AI CAN'T answer (rca_incomplete,
+    // no_matching_workflows, low_confidence). See DD-CONTRACT-002 for the
+    // full two-flag decision logic.
+    NeedsHumanReview bool `json:"needsHumanReview"`
 
     // WorkflowExecutionRef references the created WorkflowExecution CRD
     WorkflowExecutionRef *ObjectReference `json:"workflowExecutionRef,omitempty"`
-
-    // Conditions provide detailed status information
-    Conditions []metav1.Condition `json:"conditions,omitempty"`
 }
 
-// SelectedWorkflow represents the LLM's workflow selection (per ADR-041)
-// NOTE: containerImage and containerDigest are resolved by HolmesGPT-API during MCP search
-// RO passes these through to WorkflowExecution (no separate catalog lookup needed)
+// RootCauseAnalysis contains detailed RCA results
+type RootCauseAnalysis struct {
+    Summary             string             `json:"summary"`
+    SignalType          string             `json:"signalType"`
+    ContributingFactors []string           `json:"contributingFactors,omitempty"`
+    // RemediationTarget: the resource the LLM determined should actually be
+    // remediated (BR-KA-212) -- e.g. signal came from a Pod, target is its Deployment
+    RemediationTarget   *RemediationTarget `json:"remediationTarget,omitempty"`
+}
+
+// SelectedWorkflow contains the AI-selected workflow for execution (DD-CONTRACT-002)
 type SelectedWorkflow struct {
-    // WorkflowID is the catalog lookup key
-    // +kubebuilder:validation:Required
-    WorkflowID string `json:"workflowId"`
+    // WorkflowSnapshot is the catalog-resolved execution snapshot, inline-embedded
+    // so its field list can never drift from WorkflowExecution.Spec.WorkflowRef,
+    // which embeds the identical type (Issue #1661 Change 12, DD-WORKFLOW-018).
+    // Fields: WorkflowID, WorkflowName, ActionType, Version, ExecutionBundle
+    // (OCI bundle ref -- renamed from "containerImage" once WorkflowExecution grew
+    // 3 execution engines: Tekton/Job/Ansible), ExecutionBundleDigest, ExecutionEngine,
+    // EngineConfig, ServiceAccountName, Dependencies, Resources, DeclaredParameterNames.
+    sharedtypes.WorkflowSnapshot `json:",inline"`
 
-    // Version of the selected workflow
-    Version string `json:"version,omitempty"`
-
-    // ContainerImage is the OCI bundle reference (resolved by HolmesGPT-API from catalog)
-    // +kubebuilder:validation:Required
-    ContainerImage string `json:"containerImage"`
-
-    // ContainerDigest for audit trail and reproducibility (resolved by HolmesGPT-API)
-    ContainerDigest string `json:"containerDigest,omitempty"`
-
-    // Confidence score from MCP search (0.0-1.0)
-    // +kubebuilder:validation:Minimum=0
-    // +kubebuilder:validation:Maximum=1
-    Confidence float64 `json:"confidence"`
-
-    // Parameters populated by LLM based on RCA (per DD-WORKFLOW-003)
-    // Keys are UPPER_SNAKE_CASE per Tekton convention
-    Parameters map[string]string `json:"parameters"`
-
-    // Rationale explains why this workflow was selected
-    Rationale string `json:"rationale"`
-}
-
-// AlternativeWorkflow represents backup workflow options
-type AlternativeWorkflow struct {
-    WorkflowID string  `json:"workflowId"`
-    Version    string  `json:"version,omitempty"`
-    Confidence float64 `json:"confidence"`
-    Rationale  string  `json:"rationale,omitempty"`
+    Confidence float64           `json:"confidence"`
+    // Parameters: UPPER_SNAKE_CASE keys per DD-WORKFLOW-003
+    Parameters map[string]string `json:"parameters,omitempty"`
+    Rationale  string            `json:"rationale"`
 }
 ```
 
 ### 2. WorkflowExecution CRD Spec
 
-**Updated Schema**:
-```go
-// pkg/api/workflowexecution/v1alpha1/types.go
-package v1alpha1
+**Real schema** (`api/workflowexecution/v1alpha1/workflowexecution_types.go`):
 
-import (
-    corev1 "k8s.io/api/core/v1"
-    metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-)
+```go
+// api/workflowexecution/v1alpha1/workflowexecution_types.go
+package v1alpha1
 
 // WorkflowExecutionSpec defines the desired state of WorkflowExecution
 type WorkflowExecutionSpec struct {
-    // RemediationRequestRef references the parent RemediationRequest CRD
     RemediationRequestRef corev1.ObjectReference `json:"remediationRequestRef"`
 
-    // WorkflowRef contains the workflow catalog reference
-    // Resolved from AIAnalysis.Status.SelectedWorkflow
+    // WorkflowRef: catalog-resolved reference, copied verbatim from
+    // AIAnalysis.Status.SelectedWorkflow by RemediationOrchestrator (PASS THROUGH,
+    // no re-fetch from DataStorage/KA catalog -- Issue #1661 Change 11d/11e)
     WorkflowRef WorkflowRef `json:"workflowRef"`
 
-    // Parameters from LLM selection (per DD-WORKFLOW-003)
-    // Keys are UPPER_SNAKE_CASE for Tekton PipelineRun params
     Parameters map[string]string `json:"parameters"`
-
-    // Confidence score from LLM (for audit trail)
-    Confidence float64 `json:"confidence"`
-
-    // Rationale from LLM (for audit trail)
-    Rationale string `json:"rationale,omitempty"`
-
-    // ExecutionStrategy specifies how to execute the workflow
-    ExecutionStrategy ExecutionStrategy `json:"executionStrategy"`
+    Confidence float64           `json:"confidence"`
+    Rationale  string            `json:"rationale,omitempty"`
 }
 
-// WorkflowRef contains catalog-resolved workflow reference
+// WorkflowRef is nothing but an inline embed of the same sharedtypes.WorkflowSnapshot
+// type embedded in AIAnalysis.Status.SelectedWorkflow -- sharing one Go/CRD-schema type
+// between both CRDs makes it structurally impossible for their field lists to drift
+// (Issue #1661 Change 12). There is no separate "ContainerImage"/"ContainerDigest" pair
+// here; ExecutionBundle/ExecutionBundleDigest live on the embedded WorkflowSnapshot.
 type WorkflowRef struct {
-    // WorkflowID is the catalog lookup key
-    WorkflowID string `json:"workflowId"`
-
-    // Version of the workflow
-    Version string `json:"version"`
-
-    // ContainerImage resolved from workflow catalog (Data Storage API)
-    // OCI bundle reference for Tekton PipelineRun
-    ContainerImage string `json:"containerImage"`
-
-    // ContainerDigest for audit trail and reproducibility
-    ContainerDigest string `json:"containerDigest,omitempty"`
+    sharedtypes.WorkflowSnapshot `json:",inline"`
 }
 ```
 
@@ -196,41 +173,46 @@ type WorkflowRef struct {
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                         COMPLETE DATA FLOW                               │
-│                  (HolmesGPT-API resolves containerImage)                 │
+│    (KA resolves ExecutionBundle via its own in-process workflow         │
+│     discovery -- DD-WORKFLOW-019 -- NOT a Data Storage MCP search)      │
 ├─────────────────────────────────────────────────────────────────────────┤
 │                                                                         │
 │  ┌──────────────────────┐                                               │
 │  │  AIAnalysis CRD      │                                               │
-│  │  spec.analysisReq    │──────► HolmesGPT-API                          │
+│  │  (async submit)      │──────► Kubernaut Agent (KA)                   │
 │  └──────────────────────┘              │                                │
 │                                        │                                │
 │                          ┌─────────────┴─────────────┐                  │
 │                          │                           │                  │
 │                          ▼                           ▼                  │
 │               ┌─────────────────────┐    ┌─────────────────────┐        │
-│               │ Data Storage API    │    │ LLM Provider        │        │
-│               │ (MCP Workflow Search)│    │ (Workflow Selection)│        │
-│               │ Returns:            │    │ Returns:            │        │
-│               │ - workflow_id       │    │ - workflow_id       │        │
-│               │ - container_image   │    │ - parameters        │        │
-│               │ - container_digest  │    │ - confidence        │        │
+│               │ KA in-process       │    │ LLM Provider        │        │
+│               │ workflowcatalog     │    │ (Workflow Selection)│        │
+│               │ (informer cache on  │    │ Returns:            │        │
+│               │  RemediationWorkflow│    │ - workflow_id       │        │
+│               │  /ActionType CRDs)  │    │ - parameters        │        │
+│               │ Returns:            │    │ - confidence        │        │
+│               │ - workflowId        │    │                     │        │
+│               │ - executionBundle   │    │                     │        │
 │               └──────────┬──────────┘    └──────────┬──────────┘        │
 │                          │                           │                  │
 │                          └─────────────┬─────────────┘                  │
 │                                        │                                │
-│                          HolmesGPT-API combines both                    │
+│                                KA combines both                         │
 │                                        ▼                                │
 │  ┌──────────────────────────────────────────────────────────────┐       │
-│  │  AIAnalysis.Status.SelectedWorkflow                          │       │
-│  │  ├── workflowId: "oomkill-increase-memory"                   │       │
+│  │  AIAnalysis.Status.SelectedWorkflow (WorkflowSnapshot-embed) │       │
+│  │  ├── workflowId: "<DS-assigned UUID>"                        │       │
+│  │  ├── workflowName: "oomkill-increase-memory"                 │       │
 │  │  ├── version: "1.0.0"                                        │       │
-│  │  ├── containerImage: "quay.io/kubernaut/oomkill:v1.0.0"     │  ◄── RESOLVED BY HolmesGPT-API
-│  │  ├── containerDigest: "sha256:abc123..."                     │  ◄── RESOLVED BY HolmesGPT-API
+│  │  ├── executionBundle: "quay.io/kubernaut/oomkill:v1.0.0"    │  ◄── RESOLVED BY KA (in-process)
+│  │  ├── executionBundleDigest: "sha256:abc123..."               │  ◄── RESOLVED BY KA (in-process)
+│  │  ├── executionEngine: "tekton"                               │       │
 │  │  ├── confidence: 0.95                                        │       │
 │  │  ├── parameters:                                             │       │
 │  │  │     NAMESPACE: "production"                               │       │
 │  │  │     DEPLOYMENT_NAME: "payment-service"                    │       │
-│  │  └── rationale: "MCP search matched OOMKilled signal..."     │       │
+│  │  └── rationale: "Discovery protocol matched OOMKilled..."    │       │
 │  └────────────────────────┬─────────────────────────────────────┘       │
 │                           │                                             │
 │                           │ RemediationOrchestrator watches             │
@@ -238,22 +220,19 @@ type WorkflowRef struct {
 │                           ▼                                             │
 │  ┌──────────────────────────────────────────────────────────────┐       │
 │  │  WorkflowExecution.Spec (RO passes through from AIAnalysis)  │       │
-│  │  ├── workflowRef:                                            │       │
-│  │  │     workflowId: "oomkill-increase-memory"                 │       │
-│  │  │     version: "1.0.0"                                      │       │
-│  │  │     containerImage: "quay.io/kubernaut/oomkill:v1.0.0"   │  ◄── PASS THROUGH
-│  │  │     containerDigest: "sha256:abc123..."                   │  ◄── PASS THROUGH
+│  │  ├── workflowRef: (identical WorkflowSnapshot fields)        │  ◄── PASS THROUGH
 │  │  ├── parameters:                                             │       │
 │  │  │     NAMESPACE: "production"                               │       │
 │  │  │     DEPLOYMENT_NAME: "payment-service"                    │       │
 │  │  ├── confidence: 0.95                                        │       │
-│  │  └── rationale: "MCP search matched..."                      │       │
+│  │  └── rationale: "Discovery protocol matched..."              │       │
 │  └────────────────────────┬─────────────────────────────────────┘       │
 │                           │                                             │
 │                           │ WorkflowExecution Controller                │
 │                           ▼                                             │
 │  ┌──────────────────────────────────────────────────────────────┐       │
-│  │  Tekton PipelineRun                                          │       │
+│  │  Tekton PipelineRun (or batchv1.Job / AWX Job, per          │       │
+│  │  executionEngine -- ADR-024, ADR-044)                        │       │
 │  │  ├── pipelineRef:                                            │       │
 │  │  │     resolver: bundles                                     │       │
 │  │  │     params:                                               │       │
@@ -269,82 +248,65 @@ type WorkflowRef struct {
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
+**Note**: KA's workflow discovery is a 3-step in-process protocol (`ListActions` →
+`ListWorkflowsByActionType` → `GetWorkflowWithContextFilters`/`GetByID`, DD-WORKFLOW-016/DD-KA-017)
+against its own informer-backed cache of `RemediationWorkflow`/`ActionType` CRDs — there is no MCP
+tool call or HTTP request to Data Storage for this. Data Storage's `/api/v1/workflows*` REST surface
+was retired as dead code once KA became the sole consumer (DD-WORKFLOW-019 v2.0, Phase 2g).
+
 ---
 
 ## Service Responsibilities
 
 | Service | Responsibility |
 |---------|----------------|
-| **AIAnalysis Controller** | Calls HolmesGPT-API, stores `SelectedWorkflow` (including containerImage) in status |
-| **HolmesGPT-API** | Queries catalog for MCP search, calls LLM, **resolves workflow_id → containerImage** |
+| **AIAnalysis Controller** | Submits investigation to KA (async submit/poll/result), stores `SelectedWorkflow` (including `executionBundle`) in status |
+| **Kubernaut Agent (KA)** | Runs in-process workflow discovery against its own `RemediationWorkflow`/`ActionType` CRD cache, calls LLM, **resolves workflowId → executionBundle** (DD-WORKFLOW-019) |
 | **RemediationOrchestrator** | Watches AIAnalysis, orchestrates approval flow, **passes through** to WorkflowExecution |
 | **Notification Controller** | Delivers approval notifications via Alertmanager routing (DD-NOTIFICATION-001) |
 | **RemediationApprovalRequest Controller** | Manages approval lifecycle, timeout expiration (ADR-040) |
-| **Data Storage Service** | Provides `/api/v1/workflows/search` for MCP (queried by HolmesGPT-API) |
-| **WorkflowExecution Controller** | Uses `WorkflowRef.ContainerImage` to create Tekton PipelineRun |
+| **Data Storage / AuthWebhook** | Own the `RemediationWorkflow`/`ActionType` CRD catalog data (etcd-backed); **do not** serve a search/MCP endpoint for it — retired (DD-WORKFLOW-019 v2.0 Phase 2g) |
+| **WorkflowExecution Controller** | Uses `WorkflowRef.ExecutionBundle` to create the PipelineRun/Job/AWX run per `ExecutionEngine` |
 
-### Key Design Decision (Approved 2025-11-28)
+### Key Design Decision (Approved 2025-11-28; mechanism corrected 2026-08-02)
 
-**HolmesGPT-API resolves `workflow_id → containerImage`** during MCP search. RO does NOT call the catalog - it passes through the resolved values from AIAnalysis.status.
+**KA resolves `workflowId → executionBundle`** via its own in-process discovery cache. RO does NOT call the catalog — it passes through the resolved values from AIAnalysis.status.
 
 **Rationale**:
-1. HolmesGPT-API already queries catalog for MCP search - it has the data
-2. Immutable workflows mean containerImage never changes for a given workflow_id+version
-3. Simpler RO - no catalog client needed
+1. KA already runs the discovery protocol during investigation — it has the data
+2. Immutable workflows mean `executionBundle` never changes for a given `workflowId`+version
+3. Simpler RO — no catalog client needed
 4. Industry alignment (Temporal, Step Functions resolve at definition time)
 
 ---
 
 ## RO Pass-Through Logic
 
-**RemediationOrchestrator** passes through the resolved workflow from AIAnalysis (no catalog lookup):
+**RemediationOrchestrator** passes through the resolved workflow from AIAnalysis (no catalog lookup) —
+see `pkg/remediationorchestrator/creator/workflowexecution.go` (`WorkflowExecutionCreator`) for the real
+implementation. Simplified illustration of the pass-through:
 
 ```go
-// pkg/remediationorchestrator/reconciler.go
-package remediationorchestrator
+// pkg/remediationorchestrator/creator/workflowexecution.go (illustrative excerpt)
+func (c *WorkflowExecutionCreator) buildSpec(
+    aiAnalysis *aianalysisv1.AIAnalysis,
+) workflowexecutionv1.WorkflowExecutionSpec {
+    sw := aiAnalysis.Status.SelectedWorkflow // *SelectedWorkflow, embeds sharedtypes.WorkflowSnapshot
 
-import (
-    "context"
-
-    kubernautv1alpha1 "github.com/jordigilh/kubernaut/api/v1alpha1"
-    ctrl "sigs.k8s.io/controller-runtime"
-)
-
-func (r *Reconciler) createWorkflowExecution(
-    ctx context.Context,
-    aiAnalysis *kubernautv1alpha1.AIAnalysis,
-    remediationRequest *kubernautv1alpha1.RemediationRequest,
-) error {
-    // Pass through - no catalog lookup needed
-    // HolmesGPT-API already resolved containerImage during MCP search
-    wfe := &kubernautv1alpha1.WorkflowExecution{
-        ObjectMeta: ctrl.ObjectMeta{
-            Name:      fmt.Sprintf("workflow-%s", remediationRequest.Name),
-            Namespace: remediationRequest.Namespace,
-            OwnerReferences: []metav1.OwnerReference{
-                *metav1.NewControllerRef(remediationRequest, kubernautv1alpha1.GroupVersion.WithKind("RemediationRequest")),
-            },
+    return workflowexecutionv1.WorkflowExecutionSpec{
+        WorkflowRef: workflowexecutionv1.WorkflowRef{
+            WorkflowSnapshot: sw.WorkflowSnapshot, // PASS THROUGH -- identical embedded type, no re-fetch
         },
-        Spec: kubernautv1alpha1.WorkflowExecutionSpec{
-            RemediationRequestRef: corev1.ObjectReference{
-                Name:      remediationRequest.Name,
-                Namespace: remediationRequest.Namespace,
-            },
-            WorkflowRef: kubernautv1alpha1.WorkflowRef{
-                WorkflowID:      aiAnalysis.Status.SelectedWorkflow.WorkflowID,
-                Version:         aiAnalysis.Status.SelectedWorkflow.Version,
-                ContainerImage:  aiAnalysis.Status.SelectedWorkflow.ContainerImage,  // PASS THROUGH
-                ContainerDigest: aiAnalysis.Status.SelectedWorkflow.ContainerDigest, // PASS THROUGH
-            },
-            Parameters: aiAnalysis.Status.SelectedWorkflow.Parameters, // PASS THROUGH
-            Confidence: aiAnalysis.Status.SelectedWorkflow.Confidence,
-            Rationale:  aiAnalysis.Status.SelectedWorkflow.Rationale,
-        },
+        Parameters: sw.Parameters, // PASS THROUGH
+        Confidence: sw.Confidence,
+        Rationale:  sw.Rationale,
     }
-
-    return r.Create(ctx, wfe)
 }
 ```
+
+`validateSelectedWorkflow` (same file) enforces BR-ORCH-025's precondition: a missing/invalid
+`selectedWorkflow` marks the `RemediationRequest` `Failed` rather than creating an incomplete
+`WorkflowExecution`.
 
 ---
 
@@ -352,32 +314,29 @@ func (r *Reconciler) createWorkflowExecution(
 
 ### Key Principle: AIAnalysis Completes, RO Orchestrates
 
-**AIAnalysis does NOT stay in "Approving" phase.** It completes its analysis and signals approval is needed via `approvalRequired: true`. The RemediationOrchestrator is responsible for orchestrating the approval workflow.
+**AIAnalysis does NOT stay in "Approving" phase.** It completes its analysis (4-phase flow, no
+"Approving"/"Recommending" phase) and signals one of two independent flags — see
+[DD-CONTRACT-002](DD-CONTRACT-002-service-integration-contracts.md#contract-2-aianalysis--ro-status-output)
+for the authoritative two-flag (`approvalRequired` vs. `needsHumanReview`) decision logic. The
+RemediationOrchestrator is responsible for orchestrating whichever flow those flags trigger.
 
-### AIAnalysis Completion (Low Confidence)
-
-When `AIAnalysis.Status.SelectedWorkflow.Confidence < 0.80`:
+### AIAnalysis Completion (Approval Required Example)
 
 ```yaml
-# AIAnalysis.Status after low-confidence selection
+# AIAnalysis.Status after a selection that clears KA's own workflow-confidence
+# floor but trips AIAnalysis's Rego approval-threshold policy (BR-AI-088, default 80%)
 # NOTE: phase = "Completed", NOT "Approving"
 status:
   phase: Completed              # ← AIAnalysis is DONE with its work
   selectedWorkflow:
-    workflowId: "oomkill-increase-memory"
-    confidence: 0.65            # Below 80% threshold
+    workflowId: "<DS-assigned UUID>"
+    workflowName: "oomkill-increase-memory"
+    confidence: 0.72            # Below the Rego policy's approval threshold
     parameters:
       NAMESPACE: "production"
-  approvalRequired: true        # ← Signal for RO to orchestrate approval
-  approvalReason: "Confidence 65% below 80% threshold"
-  approvalContext:              # ← Rich context for operator decision
-    investigationSummary: "Memory leak detected..."
-    evidenceCollected:
-      - "OOMKilled events in last 24h"
-      - "Memory growth 50MB/hour"
-    alternativesConsidered:
-      - workflowId: "oomkill-restart-pods"
-        confidence: 0.45
+  approvalRequired: true        # ← Rego decision: AI HAS an answer, policy requires approval
+  needsHumanReview: false       # ← KA decision: AI COULD answer (contrast with DD-CONTRACT-002)
+  whyApprovalRequired: "confidence 0.72 below Rego policy threshold 0.80"
 ```
 
 ### RemediationOrchestrator Approval Flow
@@ -436,32 +395,34 @@ When RO detects `AIAnalysis.Status.approvalRequired == true`:
 
 | Document | Relationship |
 |----------|--------------|
+| **DD-WORKFLOW-019** | KA-owned workflow discovery (authoritative for *who* resolves `workflowId → executionBundle` and *how* — corrects this document's v1.2 "HolmesGPT-API + Data Storage MCP search" claim) |
+| **DD-CONTRACT-002** | Service Integration Contracts (authoritative for the `approvalRequired`/`needsHumanReview` two-flag decision logic) |
 | **ADR-041** | LLM Response Contract (authoritative for `selected_workflow` format) |
 | **ADR-043** | Workflow Schema Definition (authoritative for catalog schema) |
 | **ADR-040** | RemediationApprovalRequest Architecture (approval lifecycle) |
 | **ADR-017** | NotificationRequest Creator (RO creates notifications) |
 | **ADR-018** | Approval Notification Integration (rich approval context) |
+| **ADR-024**, **ADR-044** | WorkflowExecution's 3 execution engines (Tekton/Job/Ansible) and engine delegation |
 | **DD-NOTIFICATION-001** | Alertmanager Routing Reuse (notification channel routing) |
 | **DD-TIMEOUT-001** | Global Remediation Timeout (approval timeout: 15m default) |
 | **DD-WORKFLOW-003** | Parameterized Actions (UPPER_SNAKE_CASE parameters) |
-| **DD-WORKFLOW-005** | Automated Schema Extraction (V1.0/V1.1 registration) |
-| **BR-AI-075** | Workflow Selection Output Format |
-| **BR-AI-076** | Approval Context for Low Confidence |
+| **DD-WORKFLOW-018** | Etcd single source of truth; introduces the shared `WorkflowSnapshot` type this document now describes |
 | **BR-ORCH-025** | Catalog Lookup Before WorkflowExecution |
-| **BR-ORCH-026** | Approval Orchestration |
+| **BR-KA-212** | RCA-determined `RemediationTarget` |
 
 ---
 
-## Migration Impact
+## Migration Impact (Historical — v1.0, completed)
+
+The table below documents the original v1.0 migration (Nov 2025); it is retained for historical
+context and is **not** an open work item. All rows completed long before this v2.0 correction pass.
 
 | File | Change Required |
 |------|-----------------|
-| `api/aianalysis/v1alpha1/types.go` | Replace `Recommendations` with `SelectedWorkflow` |
-| `api/workflowexecution/v1alpha1/types.go` | Add `WorkflowRef`, simplify `WorkflowDefinition` |
+| `api/aianalysis/v1alpha1/aianalysis_types.go` | Replace `Recommendations` with `SelectedWorkflow` |
+| `api/workflowexecution/v1alpha1/workflowexecution_types.go` | Add `WorkflowRef`, simplify `WorkflowDefinition` |
 | `docs/services/crd-controllers/02-aianalysis/crd-schema.md` | Update examples |
 | `docs/services/crd-controllers/03-workflowexecution/crd-schema.md` | Update examples |
-| AIAnalysis implementation plan | Update to use new schema |
-| WorkflowExecution implementation plan | Update to use `WorkflowRef` |
 
 ---
 
@@ -469,11 +430,10 @@ When RO detects `AIAnalysis.Status.approvalRequired == true`:
 
 | Aspect | Confidence | Rationale |
 |--------|------------|-----------|
-| **ADR-041 alignment** | 98% | LLM contract tested and working |
-| **Catalog integration** | 95% | DD-WORKFLOW-005 + ADR-043 define clear schema |
-| **Approval integration** | 99% | ADR-040 already approved and well-designed |
-| **Parameter format** | 95% | DD-WORKFLOW-003 defines UPPER_SNAKE_CASE |
-| **Overall** | 95% | Strong foundation, clear contracts |
+| **CRD contract shape (WorkflowSnapshot embed)** | 95% | Verified directly against current Go source (`api/aianalysis/v1alpha1`, `api/workflowexecution/v1alpha1`, `pkg/shared/types/workflow_snapshot.go`) |
+| **Catalog-resolution mechanism (KA in-process, DD-WORKFLOW-019)** | 98% | DD-WORKFLOW-019 v2.0 status is "Implemented"; retirement of DS's `/api/v1/workflows*` confirmed by an E2E test (`04_workflow_endpoints_retired_test.go`) |
+| **Approval integration** | 90% | Two-flag split (`approvalRequired`/`needsHumanReview`) confirmed in source; precise Rego threshold values not re-verified in this pass — see DD-CONTRACT-002 |
+| **Overall** | 95% | Core contract shape and catalog-resolution ownership corrected against source; some illustrative Go snippets simplified for readability rather than reproduced verbatim |
 
 ---
 
@@ -481,6 +441,7 @@ When RO detects `AIAnalysis.Status.approvalRequired == true`:
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 2.0 | 2026-08-02 | **Correction** ([Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806)): Renamed HolmesGPT-API → Kubernaut Agent (KA) throughout. Corrected catalog-resolution mechanism: KA resolves `workflowId → executionBundle` via its own in-process discovery cache (DD-WORKFLOW-019), not a Data Storage MCP search — that endpoint was retired as dead code. Fixed API group `kubernaut.io` → `kubernaut.ai`. Replaced `ContainerImage`/`ContainerDigest` field names with the real `ExecutionBundle`/`ExecutionBundleDigest` (generalized for 3 execution engines: Tekton/Job/Ansible). Corrected `SelectedWorkflow`/`WorkflowRef` Go samples to reflect the real shared `sharedtypes.WorkflowSnapshot` embed. Pointed to DD-CONTRACT-002 for the up-to-date `approvalRequired`/`needsHumanReview` two-flag logic rather than duplicating a now-superseded single-flag description. Marked the v1.0 migration table historical. |
 | 1.2 | 2025-11-28 | **BREAKING**: HolmesGPT-API now resolves `workflow_id → containerImage` during MCP search. Added `containerImage` and `containerDigest` to `SelectedWorkflow`. RO no longer calls catalog - passes through from AIAnalysis. Updated data flow diagram. Removed catalog client code. |
 | 1.1 | 2025-11-28 | **Approval flow clarification**: AIAnalysis completes with `approvalRequired: true`, RO orchestrates approval (creates NotificationRequest + RemediationApprovalRequest). Removed "Approving" phase from AIAnalysis. Added approval flow diagram and service responsibilities. |
 | 1.0 | 2025-11-28 | Initial DD: AIAnalysis ↔ WorkflowExecution contract alignment |

--- a/docs/architecture/decisions/DD-CONTRACT-002-service-integration-contracts.md
+++ b/docs/architecture/decisions/DD-CONTRACT-002-service-integration-contracts.md
@@ -1,11 +1,22 @@
 # DD-CONTRACT-002: Service Integration Contracts
 
 **Status**: ✅ Approved
-**Version**: 1.2
-**Date**: 2025-12-01
-**Confidence**: 98%
+**Version**: 1.3
+**Date**: 2025-12-01 (v1.2); 2026-08-02 (v1.3 correction, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))
+**Confidence**: 95%
 
-> **Note (2026-08-01, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: The `BR-HAPI-*` IDs and human-review contract language in "Contract 2" have been corrected to `BR-KA-*` / `remediationTarget` to match [DD-KA-006](DD-KA-006-remediation-target-in-rca.md). **"Contract 3: HolmesGPT-API → Data Storage (MCP Workflow Search)" below has NOT been rewritten** — it still describes HolmesGPT-API calling Data Storage's MCP endpoint for workflow search during RCA. Per [DD-WORKFLOW-019](DD-WORKFLOW-019-ka-owned-workflow-discovery.md), workflow discovery ownership moved from Data Storage to KA's in-process catalog (`internal/kubernautagent/workflowcatalog`); KA no longer calls Data Storage's MCP search endpoint for this purpose. Treat DD-WORKFLOW-019 as authoritative for the current workflow-discovery data flow; Contract 3 here is retained for historical context pending a full rewrite.
+> **v1.3 correction note (2026-08-02)**: Following up on the 2026-08-01 partial pass noted below, this
+> revision finishes the job: **Contract 3 is rewritten** to reflect [DD-WORKFLOW-019](DD-WORKFLOW-019-ka-owned-workflow-discovery.md)
+> (KA owns workflow discovery in-process; the Data Storage MCP search endpoint it used to describe is
+> retired dead code), and all remaining "HolmesGPT-API" references throughout Contracts 1/4/5/6, the
+> data-flow summary table, and the validation checklist are renamed to **Kubernaut Agent (KA)**. The
+> obsolete "HolmesGPT-API Amendment Required" section (a v1.0 TODO that was completed and shipped long
+> ago, in a different shape — `executionBundle`/`executionBundleDigest`, not `container_image`/`container_digest`)
+> is removed. The `kubernaut.io` API group used in Contract 1/4 YAML samples is corrected to `kubernaut.ai`.
+>
+> **2026-08-01 note (partial pass, retained for history)**: The `BR-HAPI-*` IDs and human-review contract
+> language in "Contract 2" have been corrected to `BR-KA-*` / `remediationTarget` to match
+> [DD-KA-006](DD-KA-006-remediation-target-in-rca.md).
 
 ---
 
@@ -26,7 +37,7 @@ This document defines the **authoritative API contracts** between AIAnalysis, Re
 │  │     RO      │ ───────────────► │ AIAnalysis  │                           │
 │  └─────────────┘                  └──────┬──────┘                           │
 │        │                                 │                                  │
-│        │ watches                         │ calls HolmesGPT-API              │
+│        │ watches                         │ calls Kubernaut Agent (KA)       │
 │        │ status                          │ updates status                   │
 │        │                                 ▼                                  │
 │        │                          ┌──────────────┐                          │
@@ -40,8 +51,8 @@ This document defines the **authoritative API contracts** between AIAnalysis, Re
 │        │   waits for approval decision                                      │
 │        │                                                                    │
 │        │ THEN (if approved or no approval needed):                          │
-│        │   reads containerImage from AIAnalysis.status.selectedWorkflow     │
-│        │   (NO catalog lookup - HolmesGPT-API resolved during MCP search)   │
+│        │   reads executionBundle from AIAnalysis.status.selectedWorkflow    │
+│        │   (NO catalog lookup - KA resolved it via its own in-process cache)│
 │        │                                                                    │
 │        ▼                                                                    │
 │  ┌─────────────┐     creates      ┌──────────────────┐                      │
@@ -71,13 +82,13 @@ This document defines the **authoritative API contracts** between AIAnalysis, Re
 ### What RO Creates
 
 ```yaml
-apiVersion: kubernaut.io/v1alpha1
+apiVersion: kubernaut.ai/v1alpha1
 kind: AIAnalysis
 metadata:
   name: aianalysis-<remediation-id>
   namespace: kubernaut-system
   ownerReferences:
-    - apiVersion: kubernaut.io/v1alpha1
+    - apiVersion: kubernaut.ai/v1alpha1
       kind: RemediationRequest
       name: <remediation-request-name>
       uid: <remediation-request-uid>
@@ -140,19 +151,22 @@ status:
   humanReviewReason: string        # Why review needed (when needsHumanReview=true)
 
   # REQUIRED (when phase=Completed): Selected workflow
-  # NOTE: containerImage resolved by KA during workflow catalog lookup (DD-WORKFLOW-019)
+  # NOTE: executionBundle resolved by KA's own in-process discovery cache, NOT a
+  # Data Storage MCP search (DD-WORKFLOW-019) -- see Contract 3 below
   selectedWorkflow:
-    workflowId: string       # Catalog lookup key (e.g., "oomkill-increase-memory")
-    version: string          # Workflow version (e.g., "1.0.0")
-    containerImage: string   # OCI bundle (resolved by KA)
-    containerDigest: string  # For audit trail (resolved by KA)
-    confidence: float64      # 0.0-1.0
-    parameters:              # map[string]string - UPPER_SNAKE_CASE keys
+    workflowId: string           # Catalog lookup key (DS-assigned UUID)
+    workflowName: string         # Human-readable name (e.g., "oomkill-increase-memory")
+    version: string               # Workflow version (e.g., "1.0.0")
+    executionBundle: string      # OCI bundle ref (resolved by KA; renamed from "containerImage")
+    executionBundleDigest: string # For audit trail (resolved by KA)
+    executionEngine: string      # "tekton" | "job" | "ansible" (ADR-024, ADR-044)
+    confidence: float64          # 0.0-1.0
+    parameters:                  # map[string]string - UPPER_SNAKE_CASE keys
       NAMESPACE: string
       DEPLOYMENT_NAME: string
       # ... other workflow-specific params
-    rationale: string        # Why this workflow was selected
-    actionType: string       # DD-WORKFLOW-016 taxonomy (e.g., "ScaleReplicas", "RestartPod")
+    rationale: string            # Why this workflow was selected
+    actionType: string           # DD-WORKFLOW-016 taxonomy (e.g., "ScaleReplicas", "RestartPod")
 
   # REQUIRED: Approval signal (from AIAnalysis Rego policies)
   # Set by AIAnalysis when policy requires approval for high-risk remediation
@@ -180,11 +194,11 @@ status:
 |-------|------|----------|------------|
 | `status.phase` | string | ✅ | One of: Pending, Investigating, Analyzing, Completed, Failed |
 | `status.needsHumanReview` | bool | ✅ | KA decision: AI can't answer (BR-KA-197, BR-KA-212) |
-| `status.humanReviewReason` | string | ✅ (when needsHumanReview=true) | Why review needed (e.g., "rca_incomplete", "workflow_not_found") |
+| `status.humanReviewReason` | string | ✅ (when needsHumanReview=true) | One of `rca_incomplete`, `no_matching_workflows`, `low_confidence` (real enum, `api/aianalysis/v1alpha1/aianalysis_types.go`) |
 | `status.selectedWorkflow.workflowId` | string | ✅ (when Completed) | Valid workflow identifier |
 | `status.selectedWorkflow.version` | string | ✅ (when Completed) | Semantic version |
-| `status.selectedWorkflow.containerImage` | string | ✅ (when Completed) | OCI bundle reference (from KA's workflow catalog) |
-| `status.selectedWorkflow.containerDigest` | string | ✅ (when Completed) | Image digest (from KA's workflow catalog) |
+| `status.selectedWorkflow.executionBundle` | string | ✅ (when Completed) | OCI bundle reference (from KA's in-process discovery cache) |
+| `status.selectedWorkflow.executionBundleDigest` | string | ✅ (when Completed) | Bundle digest (from KA's in-process discovery cache) |
 | `status.selectedWorkflow.confidence` | float64 | ✅ (when Completed) | 0.0 to 1.0 |
 | `status.selectedWorkflow.parameters` | map[string]string | ✅ (when Completed) | UPPER_SNAKE_CASE keys |
 | `status.selectedWorkflow.actionType` | string | ✅ (when Completed) | DD-WORKFLOW-016 taxonomy (e.g., "ScaleReplicas") |
@@ -222,69 +236,55 @@ func (r *Reconciler) handleAIAnalysisCompleted(ctx context.Context, aiAnalysis *
 
 ---
 
-## Contract 3: HolmesGPT-API → Data Storage (MCP Workflow Search)
+## Contract 3: KA's In-Process Workflow Discovery (DD-WORKFLOW-019)
 
-**NOTE**: This contract is between HolmesGPT-API and Data Storage, NOT RO.
-RO does not call Data Storage for workflow resolution (DD-CONTRACT-001 v1.2).
+**NOTE**: There is no HTTP/MCP contract here — that is precisely what this rewrite corrects. The
+v1.2 version of this section described `HolmesGPT-API` calling `POST /api/v1/workflows/search` on
+Data Storage. Neither exists today:
 
-### API Call (by HolmesGPT-API during MCP search)
+- The service is **Kubernaut Agent (KA)**, a native-Go rewrite of the old Python HolmesGPT-API.
+- Data Storage's `/api/v1/workflows*` REST surface was **retired as dead code** once KA became the
+  sole production consumer of the discovery protocol (DD-WORKFLOW-019 v2.0, Issue #1677 Phase 2g).
+  Its retirement is proven by `test/e2e/datastorage/04_workflow_endpoints_retired_test.go`.
+- Workflow catalog data itself still lives outside KA — as `RemediationWorkflow`/`ActionType` CRDs
+  (etcd-backed, reconciled by `authwebhook`) — but KA reads it directly via its own
+  `controller-runtime` informer cache (`internal/kubernautagent/tools/custom/tools.go`,
+  `internal/kubernautagent/workflowcatalog`), not through any other service's API.
 
+### KA's 3-step in-process discovery protocol (DD-WORKFLOW-016 / DD-KA-017)
+
+No network call — this is a Go function call chain against KA's own cache:
+
+```go
+// internal/kubernautagent/tools/custom/tools.go (illustrative — see source for exact signatures)
+actions := catalog.ListActions(ctx, filters)                          // step 1
+workflows := catalog.ListWorkflowsByActionType(ctx, actionType, ctx2)  // step 2
+workflow := catalog.GetWorkflowWithContextFilters(ctx, workflowID, filters) // step 3 (or GetByID)
 ```
-POST /api/v1/workflows/search
-```
 
-### Request
-
-```json
-{
-  "query": "OOMKilled memory limit exceeded",
-  "labels": {
-    "signal_type": "OOMKilled",
-    "severity": "critical"
-  },
-  "limit": 5
-}
-```
-
-### Response
-
-```json
-{
-  "workflows": [
-    {
-      "workflow_id": "oomkill-increase-memory",
-      "version": "1.0.0",
-      "container_image": "quay.io/kubernaut/workflow-oomkill:v1.0.0",
-      "container_digest": "sha256:abc123def456...",
-      "parameters": [
-        {"name": "NAMESPACE", "type": "string", "required": true},
-        {"name": "DEPLOYMENT_NAME", "type": "string", "required": true}
-      ],
-      "labels": {
-        "signal_type": "OOMKilled",
-        "severity": "critical"
-      },
-      "similarity_score": 0.95
-    }
-  ]
-}
-```
+`workflow` is a `sharedtypes.WorkflowSnapshot` (`WorkflowID`, `WorkflowName`, `ActionType`, `Version`,
+`ExecutionBundle`, `ExecutionBundleDigest`, `ExecutionEngine`, `EngineConfig`, `ServiceAccountName`,
+`Dependencies`, `Resources`, `DeclaredParameterNames`) — the same type embedded in both
+`AIAnalysis.Status.SelectedWorkflow` and `WorkflowExecution.Spec.WorkflowRef` (see DD-CONTRACT-001 v2.0).
+KA includes this snapshot (plus LLM-selected `parameters`/`confidence`/`rationale`) when it returns the
+investigation result to the AIAnalysis controller via its async `GetSessionResult()` API
+(`pkg/agentclient`) — not via any Data Storage response.
 
 ### Contract Guarantees
 
-| Field | Type | Required | HolmesGPT-API Extracts |
-|-------|------|----------|------------------------|
-| `container_image` | string | ✅ | Included in AIAnalysis.status.selectedWorkflow |
-| `container_digest` | string | ✅ | Included in AIAnalysis.status.selectedWorkflow |
-| `parameters` | array | ✅ | Used to validate LLM-selected parameters |
+| Field | Type | Required | KA Extracts From |
+|-------|------|----------|-------------------|
+| `executionBundle` | string | ✅ | Its own informer-cached `RemediationWorkflow` CRD, not an HTTP response |
+| `executionBundleDigest` | string | ✅ | Same |
+| `dependencies`/`resources`/`declaredParameterNames` | array/map | ✅ | Same — catalog-authoritative, validated by KA before returning (Issue #1661 Change 11a) |
 
-### Error Handling (by HolmesGPT-API)
+### Error Handling (by KA)
 
-| Status | Meaning | HolmesGPT-API Action |
-|--------|---------|----------------------|
-| 200 | Found | Select best match, include in response |
-| 404 | No matches | Return error to AIAnalysis controller |
-| 5xx | Server error | Retry with backoff |
+| Condition | Meaning | KA Action |
+|-----------|---------|-----------|
+| Found | Match in cache | Select best match, include in response |
+| No matches | `ListWorkflowsByActionType`/`GetByID` returns empty | Set `AIAnalysis.Status.NeedsHumanReview=true`, `HumanReviewReason="no_matching_workflows"` |
+| Cache not yet synced | Informer hasn't completed initial `List`/`Watch` | KA blocks on `WaitForCacheSync` at startup — not a per-request failure mode |
 
 ---
 
@@ -293,48 +293,56 @@ POST /api/v1/workflows/search
 ### What RO Creates
 
 ```yaml
-apiVersion: kubernaut.io/v1alpha1
+apiVersion: kubernaut.ai/v1alpha1
 kind: WorkflowExecution
 metadata:
   name: workflow-<remediation-id>
   namespace: kubernaut-system
   ownerReferences:
-    - apiVersion: kubernaut.io/v1alpha1
+    - apiVersion: kubernaut.ai/v1alpha1
       kind: RemediationRequest
       name: <remediation-request-name>
       uid: <remediation-request-uid>
       controller: true
   labels:
-    kubernaut.io/remediation-request: <remediation-request-name>
-    kubernaut.io/workflow-id: <workflow-id>
+    kubernaut.ai/remediation-request: <remediation-request-name>
+    kubernaut.ai/workflow-id: <workflow-id>
 spec:
   # REQUIRED: Parent reference
   remediationRequestRef:
     name: string
     namespace: string
-    apiVersion: kubernaut.io/v1alpha1
+    apiVersion: kubernaut.ai/v1alpha1
     kind: RemediationRequest
 
-  # REQUIRED: Workflow reference (PASS THROUGH from AIAnalysis)
+  # REQUIRED: Workflow reference (PASS THROUGH from AIAnalysis -- identical
+  # embedded sharedtypes.WorkflowSnapshot type, no re-fetch from KA/DataStorage)
   workflowRef:
-    workflowId: string        # From AIAnalysis.status.selectedWorkflow.workflowId
-    version: string           # From AIAnalysis.status.selectedWorkflow.version
-    containerImage: string    # PASS THROUGH from AIAnalysis.status.selectedWorkflow.containerImage
-    containerDigest: string   # PASS THROUGH from AIAnalysis.status.selectedWorkflow.containerDigest
+    workflowId: string            # From AIAnalysis.status.selectedWorkflow.workflowId
+    workflowName: string          # From AIAnalysis.status.selectedWorkflow.workflowName
+    version: string                # From AIAnalysis.status.selectedWorkflow.version
+    executionBundle: string       # PASS THROUGH from AIAnalysis.status.selectedWorkflow.executionBundle
+    executionBundleDigest: string # PASS THROUGH from AIAnalysis.status.selectedWorkflow.executionBundleDigest
+    executionEngine: string       # PASS THROUGH -- "tekton" | "job" | "ansible"
 
-  # REQUIRED: Parameters from LLM
+  # REQUIRED: Resource lock target (DD-WE-001), format "namespace/kind/name"
+  targetResource: string
+
+  # OPTIONAL: Remote-cluster execution via MCP Gateway (BR-FLEET-054); empty = local/hub cluster
+  clusterID: string
+
+  # OPTIONAL: Parameters from LLM
   parameters:                 # map[string]string - copied from AIAnalysis
     NAMESPACE: string
     DEPLOYMENT_NAME: string
 
-  # REQUIRED: Audit trail
+  # OPTIONAL: Audit trail
   confidence: float64         # From AIAnalysis.status.selectedWorkflow.confidence
   rationale: string           # From AIAnalysis.status.selectedWorkflow.rationale
 
-  # OPTIONAL: Execution config
+  # OPTIONAL: Execution config (ServiceAccountName instead lives on workflowRef -- Issue #1661 Change 11c/11f)
   executionConfig:
-    timeout: duration         # Default: 30m
-    serviceAccountName: string # Per-workflow SA (DD-WE-005 v2.0); if absent, K8s namespace default
+    timeout: duration          # Tekton PipelineRun timeout; default: RemediationRequest global timeout or 30m
 ```
 
 ### Contract Guarantees
@@ -343,19 +351,20 @@ spec:
 |-------|------|----------|--------|
 | `spec.workflowRef.workflowId` | string | ✅ | AIAnalysis.status.selectedWorkflow.workflowId |
 | `spec.workflowRef.version` | string | ✅ | AIAnalysis.status.selectedWorkflow.version |
-| `spec.workflowRef.containerImage` | string | ✅ | AIAnalysis.status.selectedWorkflow.containerImage (PASS THROUGH) |
-| `spec.workflowRef.containerDigest` | string | ✅ | AIAnalysis.status.selectedWorkflow.containerDigest (PASS THROUGH) |
+| `spec.workflowRef.executionBundle` | string | ✅ | AIAnalysis.status.selectedWorkflow.executionBundle (PASS THROUGH) |
+| `spec.workflowRef.executionBundleDigest` | string | ✅ | AIAnalysis.status.selectedWorkflow.executionBundleDigest (PASS THROUGH) |
 | `spec.parameters` | map[string]string | ✅ | AIAnalysis.status.selectedWorkflow.parameters |
 | `spec.confidence` | float64 | ✅ | AIAnalysis.status.selectedWorkflow.confidence |
 
-### Key Design Decision (DD-CONTRACT-001 v1.2)
+### Key Design Decision (DD-CONTRACT-001 v2.0, DD-WORKFLOW-019)
 
 ```
 ✅ CORRECT: RO passes through all fields from AIAnalysis.status.selectedWorkflow
-            HolmesGPT-API already resolved containerImage during MCP search
+            KA already resolved executionBundle via its own in-process discovery cache
 ```
 
-RO does NOT call Data Storage API. HolmesGPT-API resolves `workflow_id → container_image` during MCP search and includes it in the AIAnalysis status.
+RO does NOT call Data Storage API. KA resolves `workflowId → executionBundle` via its own
+in-process discovery cache (DD-WORKFLOW-019) and includes it in the AIAnalysis status.
 
 ---
 
@@ -431,22 +440,22 @@ metadata:
   name: <workflow-execution-name>-run
   namespace: kubernaut-system
   ownerReferences:
-    - apiVersion: kubernaut.io/v1alpha1
+    - apiVersion: kubernaut.ai/v1alpha1
       kind: WorkflowExecution
       name: <workflow-execution-name>
       uid: <workflow-execution-uid>
       controller: true
   labels:
-    kubernaut.io/workflow-execution: <workflow-execution-name>
-    kubernaut.io/workflow-id: <workflow-id>
+    kubernaut.ai/workflow-execution: <workflow-execution-name>
+    kubernaut.ai/workflow-id: <workflow-id>
 spec:
   pipelineRef:
     resolver: bundles
     params:
       - name: bundle
-        value: <containerImage>  # From spec.workflowRef.containerImage
+        value: <executionBundle>  # From spec.workflowRef.executionBundle
       - name: name
-        value: <workflowId>      # From spec.workflowRef.workflowId
+        value: <workflowId>       # From spec.workflowRef.workflowId
 
   params:                        # Copied from spec.parameters
     - name: NAMESPACE
@@ -458,17 +467,22 @@ spec:
     pipeline: <timeout>          # From spec.executionConfig.timeout
 
   taskRunTemplate:
-    serviceAccountName: <sa>     # From spec.executionConfig.serviceAccountName
+    serviceAccountName: <sa>     # From spec.workflowRef.serviceAccountName (Issue #1661 Change 11c/11f -- NOT executionConfig)
 ```
+
+**Note**: This is the Tekton-engine path only. When `spec.workflowRef.executionEngine` is `job` or
+`ansible`, WorkflowExecution creates a native `batchv1.Job` or an AWX Job Template run instead
+(ADR-024, ADR-044) — the PipelineRun shape above does not apply.
 
 ### Contract Guarantees
 
 | PipelineRun Field | Source |
 |-------------------|--------|
-| `spec.pipelineRef.params[bundle].value` | `WorkflowExecution.spec.workflowRef.containerImage` |
+| `spec.pipelineRef.params[bundle].value` | `WorkflowExecution.spec.workflowRef.executionBundle` |
 | `spec.pipelineRef.params[name].value` | `WorkflowExecution.spec.workflowRef.workflowId` |
 | `spec.params` | `WorkflowExecution.spec.parameters` |
 | `spec.timeouts.pipeline` | `WorkflowExecution.spec.executionConfig.timeout` |
+| `spec.taskRunTemplate.serviceAccountName` | `WorkflowExecution.spec.workflowRef.serviceAccountName` |
 
 ---
 
@@ -477,15 +491,15 @@ spec:
 | Step | Source | Destination | Data Transferred |
 |------|--------|-------------|------------------|
 | 1 | RO | AIAnalysis.spec | remediationRequestRef, signalContext |
-| 2 | AIAnalysis Controller | HolmesGPT-API | analysisRequest |
-| 3 | HolmesGPT-API | Data Storage API | MCP workflow search |
-| 4 | Data Storage API | HolmesGPT-API | workflows (incl. containerImage, containerDigest) |
-| 5 | HolmesGPT-API | LLM | prompt with workflow options |
-| 6 | LLM | HolmesGPT-API | selected workflow_id + parameters |
-| 7 | HolmesGPT-API | AIAnalysis.status | selectedWorkflow (workflowId, actionType, containerImage, params, confidence) |
+| 2 | AIAnalysis Controller | Kubernaut Agent (KA) | analysisRequest (async `SubmitInvestigation()`) |
+| 3 | KA | its own in-process cache (`RemediationWorkflow`/`ActionType` CRDs) | 3-step discovery protocol (DD-WORKFLOW-019) — no network hop |
+| 4 | KA | LLM | prompt with workflow options |
+| 5 | LLM | KA | selected workflowId + parameters |
+| 6 | AIAnalysis Controller | KA | poll/result (`GetSessionResult()`, `pkg/agentclient`) |
+| 7 | KA | AIAnalysis.status | selectedWorkflow (WorkflowSnapshot: workflowId, actionType, executionBundle, params, confidence) |
 | 8 | RO | WorkflowExecution.spec | workflowRef (PASS THROUGH), parameters |
-| 9 | WorkflowExecution | PipelineRun.spec | bundle, params |
-| 10 | Tekton | PipelineRun.status | Succeeded/Failed |
+| 9 | WorkflowExecution | PipelineRun/Job/AWX run spec | bundle, params (per `executionEngine`) |
+| 10 | Tekton/K8s/AWX | WorkflowExecution (watched) | Succeeded/Failed |
 | 11 | WorkflowExecution | WorkflowExecution.status | phase, failureReason |
 | 12 | RO | RemediationRequest.status | overallPhase |
 
@@ -495,31 +509,29 @@ spec:
 
 Before implementing any service, verify:
 
-### HolmesGPT-API (Amended Requirement)
-- [ ] Queries Data Storage API for MCP workflow search
-- [ ] Includes `containerImage` and `containerDigest` in response to AIAnalysis
-- [ ] Returns complete workflow info (not just workflow_id)
+### Kubernaut Agent (KA)
+- [ ] Runs the 3-step discovery protocol against its own informer-cached `RemediationWorkflow`/`ActionType` CRDs (DD-WORKFLOW-019) — does **not** call a Data Storage search endpoint
+- [ ] Includes `executionBundle` and `executionBundleDigest` in the `WorkflowSnapshot` returned to AIAnalysis
+- [ ] Returns complete workflow info (not just `workflowId`) — `WorkflowName`/`ActionType`/`Dependencies`/`Resources`/`DeclaredParameterNames` too
 
 ### AIAnalysis Controller
-- [ ] Receives `containerImage` and `containerDigest` from HolmesGPT-API
-- [ ] Populates `status.selectedWorkflow.containerImage` (from HolmesGPT-API)
-- [ ] Populates `status.selectedWorkflow.containerDigest` (from HolmesGPT-API)
+- [ ] Populates `status.selectedWorkflow` (embedded `WorkflowSnapshot`) from KA's session result
 - [ ] Populates `status.selectedWorkflow.parameters` with UPPER_SNAKE_CASE keys
-- [ ] Sets `status.approvalRequired = true` when confidence < 0.80
+- [ ] Sets `status.approvalRequired = true` per the Rego policy decision (not a hardcoded threshold in this contract — see BR-AI-088)
+- [ ] Sets `status.needsHumanReview = true` when KA can't answer (`rca_incomplete`/`no_matching_workflows`/`low_confidence`)
 - [ ] Sets `status.phase = Completed` (never "Approving")
 
 ### RemediationOrchestrator
-- [ ] Does NOT call Data Storage API for workflow resolution
-- [ ] Passes through `containerImage` from AIAnalysis.status.selectedWorkflow
-- [ ] Passes through `containerDigest` from AIAnalysis.status.selectedWorkflow
+- [ ] Does NOT call Data Storage or KA for workflow resolution
+- [ ] Passes through the embedded `WorkflowSnapshot` from AIAnalysis.status.selectedWorkflow unchanged
 - [ ] Copies `parameters` from AIAnalysis to WorkflowExecution unchanged
 - [ ] Handles approval flow before creating WorkflowExecution
 
 ### WorkflowExecution Controller
-- [ ] Creates PipelineRun with `resolver: bundles`
-- [ ] Passes `containerImage` as bundle parameter
-- [ ] Passes all `parameters` as PipelineRun params
-- [ ] Does NOT orchestrate steps (Tekton does)
+- [ ] Dispatches to the engine named in `spec.workflowRef.executionEngine` (Tekton `PipelineRef` with `resolver: bundles`, native `batchv1.Job`, or AWX Job Template)
+- [ ] Passes `executionBundle` as the appropriate engine-specific image/bundle reference
+- [ ] Passes all `parameters` as engine-specific params/env
+- [ ] Does NOT orchestrate steps (the engine does)
 
 ---
 
@@ -527,45 +539,12 @@ Before implementing any service, verify:
 
 | Document | Purpose |
 |----------|---------|
-| **DD-CONTRACT-001 v1.2** | AIAnalysis ↔ WorkflowExecution schema alignment (containerImage resolution) |
+| **DD-CONTRACT-001 v2.0** | AIAnalysis ↔ WorkflowExecution schema alignment (`executionBundle` resolution, `WorkflowSnapshot` embed) |
+| **DD-WORKFLOW-019** | KA-owned workflow discovery (authoritative for Contract 3's in-process mechanism) |
 | **ADR-041** | LLM Response Contract (selectedWorkflow format) |
 | **ADR-043** | Workflow Schema Definition (catalog format) |
-| **ADR-044** | Engine Delegation (Tekton handles steps) |
+| **ADR-024**, **ADR-044** | 3 execution engines (Tekton/Job/Ansible), engine delegation |
 | **DD-WORKFLOW-003** | Parameter naming (UPPER_SNAKE_CASE) |
-
----
-
-## HolmesGPT-API Amendment Required
-
-**TODO**: HolmesGPT-API must be amended to include `container_image` and `container_digest` in its response to AIAnalysis.
-
-### Current Response (Pre-Amendment)
-```json
-{
-  "selected_workflow": {
-    "workflow_id": "oomkill-increase-memory",
-    "confidence": 0.95,
-    "parameters": {...}
-  }
-}
-```
-
-### Required Response (Post-Amendment)
-```json
-{
-  "selected_workflow": {
-    "workflow_id": "oomkill-increase-memory",
-    "version": "1.0.0",
-    "container_image": "quay.io/kubernaut/workflow-oomkill:v1.0.0",
-    "container_digest": "sha256:abc123...",
-    "confidence": 0.95,
-    "parameters": {...},
-    "rationale": "..."
-  }
-}
-```
-
-**Implementation Effort**: ~2-4 hours (HolmesGPT-API already queries catalog for MCP search)
 
 ---
 
@@ -573,6 +552,7 @@ Before implementing any service, verify:
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 1.3 | 2026-08-02 | **Correction** ([Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806)): Rewrote Contract 3 to describe KA's real in-process discovery protocol (DD-WORKFLOW-019) instead of a Data Storage MCP search endpoint that was retired as dead code. Renamed remaining HolmesGPT-API → Kubernaut Agent (KA) references throughout Contracts 1/4/5/6, the data-flow summary, and the validation checklist. Fixed `kubernaut.io` → `kubernaut.ai` API group. Replaced `containerImage`/`containerDigest` with the real `executionBundle`/`executionBundleDigest` (`sharedtypes.WorkflowSnapshot`). Removed the obsolete "HolmesGPT-API Amendment Required" section (its TODO shipped long ago, in this different field shape). Corrected Contract 4/6 to note the 3 execution engines (Tekton/Job/Ansible), not just Tekton. |
 | 1.2 | 2025-12-01 | Fixed internal inconsistencies: Updated integration diagram and Contract 4 to consistently state RO passes through containerImage from AIAnalysis.status (no catalog lookup). Removed stale "FROM CATALOG LOOKUP" comments. |
 | 1.1 | 2025-11-28 | Updated contracts for HolmesGPT-API containerImage resolution (DD-CONTRACT-001 v1.2). RO no longer calls Data Storage. Added HolmesGPT-API amendment requirement. |
 | 1.0 | 2025-11-28 | Initial authoritative integration contracts |

--- a/docs/architecture/decisions/DD-WORKFLOW-010-mcp-integration-confidence.md
+++ b/docs/architecture/decisions/DD-WORKFLOW-010-mcp-integration-confidence.md
@@ -1,9 +1,20 @@
 # DD-WORKFLOW-010: MCP Workflow Catalog Integration in HolmesGPT API - Confidence Assessment
 
-**Date**: 2025-11-15  
-**Status**: ✅ Approved  
-**Target Version**: v1.0 (MVP)  
+**Date**: 2025-11-15
+**Status**: 🗄️ **SUPERSEDED** — see note below
+**Target Version**: v1.0 (MVP)
 **Related**: DD-WORKFLOW-008, DD-WORKFLOW-009, DD-EMBEDDING-001, DD-STORAGE-008
+
+> **SUPERSEDED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: This
+> Nov 2025 proposal describes a **Python** `kubernaut-agent`, a temporary Mock MCP Server, a semantic
+> `/api/v1/playbooks/search` REST endpoint on Data Storage, and a planned separate Embedding Service —
+> none of which reflect the shipped architecture. `kubernaut-agent`/HolmesGPT-API was rewritten in Go as
+> **Kubernaut Agent (KA)**; the Mock MCP Server and the standalone Embedding Service were never built;
+> and workflow catalog search moved to KA's own **in-process** discovery protocol against
+> `RemediationWorkflow`/`ActionType` CRDs, not any Data Storage REST/MCP endpoint (which was retired as
+> dead code). See [DD-WORKFLOW-019](DD-WORKFLOW-019-ka-owned-workflow-discovery.md) for the authoritative,
+> implemented design. This document is retained for historical context only — do not use it to understand
+> the current architecture.
 
 ---
 

--- a/docs/architecture/decisions/DD-WORKFLOW-LLM-ARCHITECTURE-CONFIDENCE-ASSESSMENT.md
+++ b/docs/architecture/decisions/DD-WORKFLOW-LLM-ARCHITECTURE-CONFIDENCE-ASSESSMENT.md
@@ -4,6 +4,15 @@
 **Assessment Type**: Architecture Confidence Review
 **Scope**: Complete LLM investigation workflow
 **Reviewer**: AI Architecture Assistant
+**Status**: 🗄️ **SUPERSEDED** — see note below
+
+> **SUPERSEDED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: This Nov
+> 2025 assessment reviews a Python `HolmesGPT API` calling a standalone **Embedding Service MCP**, neither
+> of which was built as described. `HolmesGPT-API` was rewritten in Go as **Kubernaut Agent (KA)**; the
+> separate Embedding Service MCP component was never built; and workflow catalog resolution moved to KA's
+> own in-process discovery protocol (see [DD-WORKFLOW-019](DD-WORKFLOW-019-ka-owned-workflow-discovery.md),
+> authoritative and implemented). This document is retained for historical context only — its confidence
+> scores and risk assessments do not describe the shipped system.
 
 ---
 

--- a/docs/requirements/10_AI_CONTEXT_ORCHESTRATION.md
+++ b/docs/requirements/10_AI_CONTEXT_ORCHESTRATION.md
@@ -2,8 +2,17 @@
 
 **Document Version**: 1.0
 **Date**: January 2025
-**Status**: Business Requirements Specification
+**Status**: 🗄️ **SUPERSEDED** — see note below
 **Module**: AI Context Orchestration (`pkg/ai/holmesgpt/`, `pkg/api/context/`)
+
+> **SUPERSEDED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: This Jan
+> 2025 spec describes a standalone **Context API service** (`pkg/api/context/`) and a Python
+> **HolmesGPT** with pluggable toolsets, providing "historical intelligence" as a distinct service from
+> real-time investigation. That standalone service was deprecated and removed; its capabilities were
+> absorbed into Data Storage, and HolmesGPT-API was rewritten in Go as **Kubernaut Agent (KA)**. See
+> [DD-CONTEXT-006](../architecture/decisions/DD-CONTEXT-006-CONTEXT-API-DEPRECATION.md) for the
+> authoritative deprecation decision. This document is retained for historical context only — the
+> `BR-CONTEXT-*` requirements below do not describe a live, separately-deployed service.
 
 ---
 


### PR DESCRIPTION
## Summary

Part of #1806 (PR3b-5d). Rewrites the 5 remaining Group D files describing "workflow/playbook catalog hosted as a separate MCP/Embedding service" — an architecture that was never fully built as specified, or has since been superseded by KA's own in-process discovery cache ([DD-WORKFLOW-019](https://github.com/jordigilh/kubernaut/blob/main/docs/architecture/decisions/DD-WORKFLOW-019-ka-owned-workflow-discovery.md)).

- **`DD-CONTRACT-001-aianalysis-workflowexecution-alignment.md`** (v1.2 → v2.0): Rewrote the AIAnalysis/WorkflowExecution CRD contract against real Go source (`api/aianalysis/v1alpha1`, `api/workflowexecution/v1alpha1`, `pkg/shared/types/workflow_snapshot.go`). Corrected `kubernaut.io` → `kubernaut.ai`, `containerImage`/`containerDigest` → `executionBundle`/`executionBundleDigest` (`sharedtypes.WorkflowSnapshot` embed), and the catalog-resolution mechanism (KA in-process, not HolmesGPT-API + Data Storage MCP search). Rewrote the RO pass-through code sample and the approval-flow example, pointing to DD-CONTRACT-002 for the up-to-date two-flag (`approvalRequired`/`needsHumanReview`) logic instead of duplicating a superseded single-flag description.
- **`DD-CONTRACT-002-service-integration-contracts.md`** (v1.2 → v1.3): Finished a prior partial pass. Rewrote Contract 3 end-to-end to describe KA's real 3-step in-process discovery protocol instead of a `POST /api/v1/workflows/search` Data Storage MCP endpoint that was retired as dead code. Renamed remaining HolmesGPT-API references throughout Contracts 1/4/5/6, the data-flow summary table, and the validation checklist. Fixed the API group and `containerImage`/`containerDigest` field names. Removed the obsolete "HolmesGPT-API Amendment Required" TODO section (shipped long ago, in a different field shape). Noted the 3 execution engines (Tekton/Job/Ansible) instead of assuming Tekton-only.
- **`DD-WORKFLOW-010-mcp-integration-confidence.md`**, **`DD-WORKFLOW-LLM-ARCHITECTURE-CONFIDENCE-ASSESSMENT.md`**, **`docs/requirements/10_AI_CONTEXT_ORCHESTRATION.md`**: marked `SUPERSEDED` with pointers to DD-WORKFLOW-019 / DD-CONTEXT-006. Each describes a Python-era component (Mock MCP Server, standalone Embedding Service, standalone Context API service) that was never built as specified or has since been removed. Retained verbatim as historical record rather than rewritten, per this issue's established convention for docs describing dead/never-built architecture.

## Test plan

- [x] Docs-only change; no code/build impact
- [x] Verified no unintentional `HolmesGPT`/`HAPI`/`containerImage`/`kubernaut.io` references remain in the 5 touched files (remaining hits are historical changelog entries / explanatory correction notes)
- [x] Cross-checked field names and API group against current Go source (`api/aianalysis/v1alpha1`, `api/workflowexecution/v1alpha1`, `pkg/shared/types/workflow_snapshot.go`)
- [x] Verified `DD-CONTEXT-006`/`DD-WORKFLOW-019` link targets exist

Made with [Cursor](https://cursor.com)