### PR TITLE
docs: rewrite/supersede Group F misc HAPI/HolmesGPT stale samples (Issue #1806 PR3b-5f)

### DIFF
--- a/docs/architecture/DYNAMIC_TOOLSET_CONFIGURATION_ARCHITECTURE.md
+++ b/docs/architecture/DYNAMIC_TOOLSET_CONFIGURATION_ARCHITECTURE.md
@@ -2,9 +2,19 @@
 
 **Document Version**: 2.0
 **Date**: January 2025
-**Status**: Architecture Design Specification - **APPROVED**
+**Status**: 🗄️ **SUPERSEDED** — see note below
 **Module**: Dynamic Toolset Configuration (`pkg/ai/holmesgpt/`, `pkg/platform/k8s/`, `pkg/api/context/`)
 **Update**: File-based ConfigMap polling with reconciliation
+
+> **SUPERSEDED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: The
+> Dynamic Toolset Service designed in detail below was **deferred to V2.0 and never built** —
+> see [DD-016](decisions/DD-016-dynamic-toolset-v2-deferral.md) (authoritative deferral decision,
+> 2025-11-21). None of the Go paths (`pkg/ai/holmesgpt/dynamic_toolset_manager.go`) or Python paths
+> (`docker/kubernaut-agent/src/services/toolset_config_service.py`) referenced below exist in the
+> codebase; `HolmesGPT-API`/`kubernaut-agent` was subsequently rewritten in Go as **Kubernaut Agent
+> (KA)**, which instead ships with built-in Prometheus-only toolset logic (no separate discovery
+> service, no ConfigMap reconciliation loop). This document is retained for historical/design-reference
+> context only — do not use it to understand the current toolset configuration mechanism.
 
 ---
 

--- a/docs/architecture/PROMETHEUS_ALERTRULES.md
+++ b/docs/architecture/PROMETHEUS_ALERTRULES.md
@@ -1,9 +1,17 @@
 # Prometheus AlertRules for Kubernaut Services
 
-**Version**: 1.0
-**Last Updated**: October 6, 2025
-**Status**: ✅ Authoritative Reference
+**Version**: 1.1
+**Last Updated**: August 2, 2026
+**Status**: ⚠️ Partially Verified Reference — see [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806) note below
 **Scope**: All 11 Kubernaut V1 Services + Infrastructure
+
+> **Note (2026-08-02)**: The Kubernaut Agent (formerly "HolmesGPT API") and AI Analysis alert
+> sections were corrected against real metric names in `pkg/kubernautagent/llm/instrumented_client.go`
+> and `pkg/aianalysis/metrics/metrics.go` — see inline notes in those sections. The Kubernetes
+> Executor section remains deprecated per ADR-025. All other alert groups (Infrastructure, Service
+> Availability, Performance, Gateway, Remediation Orchestrator, Workflow Execution, Notification,
+> Business Logic) have not been re-verified against current metric exports in this pass and should
+> not be assumed authoritative without checking the relevant service's `metrics.go`.
 
 ---
 
@@ -660,6 +668,17 @@ spec:
 
 ### AI Analysis Alerts
 
+> **Note (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: The
+> `AIAnalysisHolmesGPTUnavailable` alert below was corrected to use a real metric (see inline comment).
+> The other three alerts in this group (`ai_analysis_investigation_errors_total`,
+> `ai_analysis_investigations_total`, `ai_analysis_investigation_duration_seconds_bucket`,
+> `ai_analysis_low_confidence_total`, `ai_analysis_completed_total`) reference metrics that do not
+> exist in `pkg/aianalysis/metrics/metrics.go` (current exports: `aianalysis_rego_evaluations_total`,
+> `aianalysis_approval_decisions_total`, `aianalysis_confidence_score_distribution`,
+> `aianalysis_failures_total`). This predates the Go implementation and is a metrics-naming gap
+> unrelated to the HAPI→KA rename; left as-is pending a dedicated metrics audit issue rather than
+> guessing at replacements out of scope for this rename pass.
+
 ```yaml
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
@@ -675,17 +694,20 @@ spec:
     interval: 30s
     rules:
 
-    # HolmesGPT unavailable
-    - alert: AIAnalysisHolmesGPTUnavailable
-      expr: ai_analysis_holmesgpt_availability == 0
+    # Kubernaut Agent (KA) call failures
+    # Corrected (2026-08-02, #1806): the original "holmesgpt_availability" gauge never existed.
+    # AIAnalysis has no direct availability probe for KA; the closest real signal is the
+    # APIError/AgentAPICallFailed reason on aianalysis_failures_total (pkg/aianalysis/metrics/metrics.go).
+    - alert: AIAnalysisAgentAPICallFailures
+      expr: increase(aianalysis_failures_total{reason="APIError", sub_reason="AgentAPICallFailed"}[5m]) > 0
       for: 5m
       labels:
         severity: warning
         service: ai-analysis
       annotations:
-        summary: "HolmesGPT API is unavailable"
-        description: "AI Analysis cannot reach HolmesGPT at {{ $labels.endpoint }}. AI investigations are failing."
-        runbook_url: https://docs.kubernaut.io/runbooks/ai-analysis/holmesgpt-unavailable
+        summary: "AI Analysis cannot reach Kubernaut Agent (KA)"
+        description: "AIAnalysis recorded {{ $value }} failed calls to Kubernaut Agent in the last 5m. AI investigations are failing."
+        runbook_url: https://docs.kubernaut.io/runbooks/ai-analysis/agent-api-call-failures
 
     # High investigation failures
     - alert: AIAnalysisHighInvestigationFailureRate
@@ -840,7 +862,14 @@ spec:
 
 ---
 
-### HolmesGPT API Alerts
+### Kubernaut Agent (KA) Alerts
+
+> **Corrected (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: Renamed
+> from "HolmesGPT API"; metric names below corrected against the real, currently-shipped metrics in
+> `pkg/kubernautagent/llm/instrumented_client.go` (`aiagent_api_llm_requests_total{status}`,
+> `aiagent_api_llm_request_duration_seconds`, `aiagent_api_llm_tokens_total{type}`). These metrics carry
+> no `provider` label, so `{{ $labels.provider }}` annotations below were removed rather than left
+> pointing at a nonexistent label.
 
 ```yaml
 apiVersion: monitoring.coreos.com/v1
@@ -858,51 +887,51 @@ spec:
     rules:
 
     # Service down
-    - alert: HolmesGPTAPIDown
+    - alert: KubernautAgentDown
       expr: up{job="kubernaut-agent"} == 0
       for: 2m
       labels:
         severity: warning
         service: kubernaut-agent
       annotations:
-        summary: "HolmesGPT API is down"
-        description: "HolmesGPT API has been down for more than 2 minutes. AI investigations will fail."
+        summary: "Kubernaut Agent is down"
+        description: "Kubernaut Agent has been down for more than 2 minutes. AI investigations will fail."
         runbook_url: https://docs.kubernaut.io/runbooks/kubernaut-agent/service-down
 
     # High LLM latency
-    - alert: HolmesGPTAPIHighLLMLatency
-      expr: histogram_quantile(0.95, rate(holmesgpt_llm_request_duration_seconds_bucket[5m])) > 30
+    - alert: KubernautAgentHighLLMLatency
+      expr: histogram_quantile(0.95, rate(aiagent_api_llm_request_duration_seconds_bucket[5m])) > 30
       for: 10m
       labels:
         severity: warning
         service: kubernaut-agent
       annotations:
-        summary: "HolmesGPT LLM requests are slow"
-        description: "95th percentile LLM request time is {{ $value }}s for provider {{ $labels.provider }}."
+        summary: "Kubernaut Agent LLM requests are slow"
+        description: "95th percentile LLM request time is {{ $value }}s."
         runbook_url: https://docs.kubernaut.io/runbooks/kubernaut-agent/high-llm-latency
 
-    # LLM provider errors
-    - alert: HolmesGPTAPILLMProviderErrors
-      expr: rate(holmesgpt_llm_errors_total[5m]) / rate(holmesgpt_llm_requests_total[5m]) > 0.1
+    # LLM errors
+    - alert: KubernautAgentLLMErrors
+      expr: rate(aiagent_api_llm_requests_total{status="error"}[5m]) / rate(aiagent_api_llm_requests_total[5m]) > 0.1
       for: 5m
       labels:
         severity: warning
         service: kubernaut-agent
       annotations:
-        summary: "LLM provider {{ $labels.provider }} has high error rate"
-        description: "{{ $value | humanizePercentage }} of requests to {{ $labels.provider }} are failing."
+        summary: "Kubernaut Agent has a high LLM request error rate"
+        description: "{{ $value | humanizePercentage }} of LLM requests are failing."
         runbook_url: https://docs.kubernaut.io/runbooks/kubernaut-agent/llm-provider-errors
 
     # High token usage
-    - alert: HolmesGPTAPIHighTokenUsage
-      expr: rate(holmesgpt_tokens_used_total[1h]) > 1000000
+    - alert: KubernautAgentHighTokenUsage
+      expr: rate(aiagent_api_llm_tokens_total[1h]) > 1000000
       for: 1h
       labels:
         severity: info
         service: kubernaut-agent
       annotations:
         summary: "High LLM token usage"
-        description: "Using {{ $value }} tokens per hour for provider {{ $labels.provider }}. Review usage and costs."
+        description: "Using {{ $value }} tokens per hour (type={{ $labels.type }}). Review usage and costs."
         runbook_url: https://docs.kubernaut.io/runbooks/kubernaut-agent/high-token-usage
 ```
 
@@ -1229,7 +1258,7 @@ curl -X POST https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK \
 | **Workflow Execution** | 3 | Workflow-specific |
 | ~~**Kubernetes Executor**~~ (DEPRECATED - ADR-025) | 4 | Executor-specific |
 | **Notification Service** | 3 | Notification-specific |
-| **HolmesGPT API** | 4 | HolmesGPT-specific |
+| **Kubernaut Agent (KA)** | 4 | KA-specific |
 | **Business Logic** | 3 | Platform-wide |
 | **Total** | **58** | **All services + infrastructure** |
 
@@ -1267,7 +1296,31 @@ curl -X POST https://hooks.slack.com/services/YOUR/SLACK/WEBHOOK \
 
 ---
 
-**Document Status**: ✅ Complete
-**Last Updated**: October 6, 2025
+## Changelog
+
+### v1.1 (2026-08-02) — HAPI→KA correction pass ([Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))
+
+- Renamed "HolmesGPT API Alerts" section to "Kubernaut Agent (KA) Alerts"; renamed
+  `HolmesGPTAPIDown`/`HolmesGPTAPIHighLLMLatency`/`HolmesGPTAPILLMProviderErrors`/`HolmesGPTAPIHighTokenUsage`
+  to `KubernautAgentDown`/`KubernautAgentHighLLMLatency`/`KubernautAgentLLMErrors`/`KubernautAgentHighTokenUsage`.
+- Corrected LLM metric names from fictional `holmesgpt_*` names to the real, currently-shipped
+  `aiagent_api_llm_requests_total{status}`, `aiagent_api_llm_request_duration_seconds`, and
+  `aiagent_api_llm_tokens_total{type}` (source: `pkg/kubernautagent/llm/instrumented_client.go`).
+  Removed `{{ $labels.provider }}` annotations since these metrics carry no provider label.
+- Replaced `AIAnalysisHolmesGPTUnavailable` (`ai_analysis_holmesgpt_availability`, a metric that
+  never existed) with `AIAnalysisAgentAPICallFailures`, based on the real
+  `aianalysis_failures_total{reason="APIError",sub_reason="AgentAPICallFailed"}` counter
+  (source: `pkg/aianalysis/metrics/metrics.go`).
+- Flagged (but did not fix, out of scope for this rename pass) that the remaining three AI Analysis
+  alerts reference metric names not present in `pkg/aianalysis/metrics/metrics.go` — tracked as a
+  follow-up metrics-audit item, not a HAPI-naming issue.
+- Updated the Summary/Alert Coverage table row from "HolmesGPT API" to "Kubernaut Agent (KA)".
+- Downgraded document status from "Authoritative Reference" to "Partially Verified Reference"
+  pending a full metrics audit of the remaining alert groups.
+
+---
+
+**Document Status**: ⚠️ Partially Verified (see Changelog)
+**Last Updated**: August 2, 2026
 **Maintainer**: Kubernaut Architecture Team
-**Version**: 1.0
+**Version**: 1.1

--- a/docs/architecture/decisions/ADR-050-configuration-validation-strategy.md
+++ b/docs/architecture/decisions/ADR-050-configuration-validation-strategy.md
@@ -40,7 +40,7 @@ func (e *Evaluator) Evaluate(ctx context.Context, ...) {
 **Scope**: All configuration types across all services:
 - **Rego Policies**: SignalProcessing, AIAnalysis, WorkflowExecution
 - **YAML ConfigMaps**: Gateway (rate limits), WorkflowExecution (playbooks)
-- **JSON Settings**: HolmesGPT-API (LLM configurations)
+- **YAML Settings**: Kubernaut Agent (LLM configurations)
 - **Environment Variables**: All services (ports, timeouts, feature flags)
 - **Certificate Files**: Data Storage (TLS certificates)
 
@@ -301,7 +301,7 @@ All services MUST meet these requirements:
 ### ⚠️ Partial Compliance
 | Service | Config Type | Startup Validation | Hot-Reload | Caching | Notes |
 |---|---|---|---|---|---|
-| **HolmesGPT-API** | YAML (LLM config) | ✅ | ✅ | ❌ | Python FileWatcher (DD-HAPI-004) |
+| **Kubernaut Agent (KA)** | YAML (LLM config) | ✅ | ✅ | ❌ | Go `FileWatcher` on `kubernaut-agent-llm-runtime` ConfigMap (`internal/kubernautagent/config/config_types.go`) |
 
 ### ❌ Non-Compliant Services (V1.0 Fix Required)
 | Service | Config Type | Startup Validation | Hot-Reload | Caching | Gap |
@@ -457,7 +457,7 @@ func main() {
 **Existing Services**:
 - SignalProcessing: Already compliant (no changes needed)
 - AIAnalysis: Requires V1.0 fix (DD-AIANALYSIS-002)
-- HolmesGPT-API: Python implementation compliant (DD-HAPI-004)
+- Kubernaut Agent (KA): Go implementation compliant (`internal/kubernautagent/config/config_types.go` `FileWatcher`; formerly a Python implementation cited as "DD-HAPI-004", which was never formalized as an actual design-decision doc)
 
 ### Risk Assessment
 | Risk | Likelihood | Impact | Mitigation |
@@ -481,7 +481,9 @@ func main() {
 
 ### Child Decisions (Service-Specific)
 - **DD-AIANALYSIS-002**: Rego Policy Startup Validation (AIAnalysis implementation)
-- **DD-HAPI-004**: ConfigMap Hot-Reload (HolmesGPT-API Python implementation)
+- ~~**DD-HAPI-004**~~: ConfigMap Hot-Reload — cited here as the design authority for KA's (formerly
+  HolmesGPT-API's) hot-reload, but no such doc was ever formalized; the live implementation is
+  `internal/kubernautagent/config/config_types.go`'s `FileWatcher` on the `kubernaut-agent-llm-runtime` ConfigMap
 - **DD-SP-XXX**: (Implicit - SignalProcessing already compliant)
 
 ### Related Decisions
@@ -528,10 +530,10 @@ go test ./pkg/service -bench BenchmarkEvaluate
 - **Library**: `pkg/shared/hotreload/file_watcher.go`
 - **Main Entry**: `cmd/signalprocessing/main.go:240-252`
 
-### Python Service (YAML Config)
-- **Reference**: `kubernaut-agent/src/config/hot_reload.py`
-- **Library**: `watchdog` (Python equivalent of fsnotify)
-- **Design**: DD-HAPI-004
+### Kubernaut Agent (KA, Go) Service (YAML Config)
+- **Reference**: `internal/kubernautagent/config/config_types.go` (`LLMRuntimeConfig`, `FileWatcher`)
+- **Note**: formerly a Python service using the `watchdog` library (`kubernaut-agent/src/config/hot_reload.py`,
+  now removed); rewritten in Go as part of the HolmesGPT-API → Kubernaut Agent migration
 
 ### Test Examples
 - **Unit Tests**: `pkg/signalprocessing/rego/engine_test.go`

--- a/docs/architecture/decisions/DD-CICD-001-optimized-parallel-test-strategy.md
+++ b/docs/architecture/decisions/DD-CICD-001-optimized-parallel-test-strategy.md
@@ -1,9 +1,19 @@
 # DD-CICD-001: Optimized Parallel Test Strategy for 8 Services
 
 **Date**: December 15, 2025
-**Status**: ✅ **PROPOSED** - Ready for Approval
+**Status**: 🗄️ **SUPERSEDED BY EVENTS** — see note below
 **Priority**: **HIGH** - CI/CD Optimization
 **Impact**: Reduces total CI/CD time from ~120 minutes to ~35 minutes (71% improvement)
+
+> **SUPERSEDED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: This
+> Dec 2025 proposal targeted an 8-service CI matrix (including a Python `holmesgpt`/HAPI service with a
+> separate `unit-python-service` job). The real `.github/workflows/ci-pipeline.yml` has since grown to a
+> 12-service Go matrix (`signalprocessing, aianalysis, authwebhook, workflowexecution,
+> remediationorchestrator, notification, gateway, datastorage, effectivenessmonitor, kubernautagent,
+> apifrontend, fleetmetadatacache`) — `holmesgpt` was rewritten in Go and renamed to `kubernautagent`,
+> and there is no longer a separate Python unit-test job. Whether the specific tiering/parallelism
+> strategy below was adopted as designed is not reflected here; treat `.github/workflows/ci-pipeline.yml`
+> as the current source of truth for actual CI structure. Retained for historical context only.
 
 ---
 

--- a/docs/architecture/decisions/DD-E2E-001-parallel-image-builds.md
+++ b/docs/architecture/decisions/DD-E2E-001-parallel-image-builds.md
@@ -49,7 +49,7 @@ func deployDataStorage(clusterName, kubeconfigPath string, writer io.Writer) err
     deployManifest()
 }
 
-func deployHolmesGPTAPI(...) {
+func DeployKubernautAgentOnly(...) {
     buildImage()  // ← Waits for previous build
     loadToKind()
     deployManifest()
@@ -153,10 +153,10 @@ go func() {
     buildResults <- imageBuildResult{"datastorage", "kubernaut-datastorage:latest", err}
 }()
 
-// Build HolmesGPT-API image (parallel)
+// Build Kubernaut Agent (KA) image (parallel)
 go func() {
-    err := buildImageOnly("HolmesGPT-API", "localhost/kubernaut-kubernaut-agent:latest",
-        "kubernaut-agent/Dockerfile", projectRoot, writer)
+    err := buildImageOnly("Kubernaut Agent", "localhost/kubernaut-kubernaut-agent:latest",
+        "docker/kubernautagent.Dockerfile", projectRoot, writer)
     buildResults <- imageBuildResult{"kubernaut-agent", "kubernaut-kubernaut-agent:latest", err}
 }()
 
@@ -192,9 +192,9 @@ if err := deployDataStorageOnly(clusterName, kubeconfigPath, builtImages["datast
     return fmt.Errorf("failed to deploy Data Storage: %w", err)
 }
 
-fmt.Fprintln(writer, "🤖 Deploying HolmesGPT-API...")
-if err := deployHolmesGPTAPIOnly(clusterName, kubeconfigPath, builtImages["kubernaut-agent"], writer); err != nil {
-    return fmt.Errorf("failed to deploy HolmesGPT-API: %w", err)
+fmt.Fprintln(writer, "🤖 Deploying Kubernaut Agent...")
+if err := DeployKubernautAgentOnly(ctx, clusterName, kubeconfigPath, namespace, builtImages["kubernaut-agent"], enableJWT, writer); err != nil {
+    return fmt.Errorf("failed to deploy Kubernaut Agent: %w", err)
 }
 
 fmt.Fprintln(writer, "🧠 Deploying AIAnalysis controller...")

--- a/docs/architecture/decisions/DD-INTEGRATION-001-local-image-builds.md
+++ b/docs/architecture/decisions/DD-INTEGRATION-001-local-image-builds.md
@@ -422,7 +422,7 @@ def start_infrastructure() -> bool:
 
     # Start services via compose (Python manages the process)
     result = subprocess.run(
-        [compose_cmd, "-f", "docker-compose.workflow-catalog.yml", "-p", "hapi-integration", "up", "-d"],
+        [compose_cmd, "-f", "docker-compose.workflow-catalog.yml", "-p", "kubernautagent-integration", "up", "-d"],
         cwd=script_dir,
         capture_output=True,
         timeout=180
@@ -448,7 +448,7 @@ def integration_infrastructure():
         pytest.fail(
             "REQUIRED: Infrastructure not running.\\n"
             "  Per TESTING_GUIDELINES.md: Tests MUST Fail, NEVER Skip\\n"
-            "  Start it with: make test-integration-holmesgpt"
+            "  Start it with: make test-integration-kubernautagent"
         )
 
     # Set environment variables for service clients

--- a/docs/architecture/decisions/DD-TEST-001-QUICK-REFERENCE.md
+++ b/docs/architecture/decisions/DD-TEST-001-QUICK-REFERENCE.md
@@ -36,18 +36,30 @@
 | **WorkflowExecution** | 8085 | 30085 | 30185 |
 | **Notification** | 8086 | 30086 | 30186 |
 | **Toolset** | 8087 | 30087 | 30187 |
-| **HolmesGPT API** | 8088 | 30088 | 30188 |
+| **Kubernaut Agent (KA)** | 8088 | 30088 | 30188* |
+
+\* *Per the real `test/infrastructure/kind-kubernautagent-config.yaml`, 30188/28088 is KA's **health**
+NodePort; KA's metrics NodePort is actually 30988 (host 9088) — this table's "Metrics NodePort" column
+heading does not hold for the KA row. Not corrected further here (out of scope for this pass); treat
+the Kind config YAML as ground truth over this table for exact port semantics.*
 
 ---
 
-## 🐍 HolmesGPT API E2E Dependencies (Dedicated Kind Cluster)
+## 🤖 Kubernaut Agent (KA) E2E Dependencies (Dedicated Kind Cluster)
+
+> **Corrected (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: The
+> pgvector-backed workflow catalog storage and standalone Embedding Service below were **retired**
+> (`33c2053a3`, `eb5185b73` — see [DD-CONTRACT-002](DD-CONTRACT-002-service-integration-contracts.md)
+> changelog). KA's real E2E Kind config (`test/infrastructure/kind-kubernautagent-config.yaml`) has no
+> dedicated pgvector/embedding ports — it shares generic PostgreSQL (30439) and Redis (30387) NodePorts
+> instead of the dedicated 5488/8188/6388 below. Table retained for historical reference only.
 
 | Dependency | Host Port | NodePort | Purpose |
 |------------|-----------|----------|---------|
-| PostgreSQL + pgvector | 5488 | 30488 | Workflow catalog storage |
-| Embedding Service | 8188 | 30288 | Vector embeddings |
+| ~~PostgreSQL + pgvector~~ | ~~5488~~ | ~~30488~~ | ~~Workflow catalog storage~~ — retired |
+| ~~Embedding Service~~ | ~~8188~~ | ~~30288~~ | ~~Vector embeddings~~ — retired |
 | Data Storage | 8089 | 30089 | Audit trail, catalog API |
-| Redis | 6388 | 30388 | Data Storage DLQ |
+| ~~Redis~~ | ~~6388~~ | ~~30388~~ | ~~Data Storage DLQ~~ — superseded by shared Redis NodePort 30387 |
 
 ---
 
@@ -79,13 +91,12 @@ API: http://localhost:28090
 Embedding: http://localhost:28000
 ```
 
-### **"I'm working on HolmesGPT API E2E tests"**
+### **"I'm working on Kubernaut Agent (KA) E2E tests"**
 ```
-HolmesGPT API: http://localhost:8088
+Kubernaut Agent: http://localhost:8088
 Data Storage: http://localhost:8089
-PostgreSQL: localhost:5488
-Embedding: http://localhost:8188
-Redis: localhost:6388
+PostgreSQL: localhost:30439   # shared, not a dedicated KA port
+Redis: localhost:30387        # shared, not a dedicated KA port
 ```
 
 ### **"I'm working on Gateway integration tests"**
@@ -103,27 +114,26 @@ Data Storage: http://localhost:18091
 # Check if ports are available
 lsof -i :15433  # Data Storage PostgreSQL (integration)
 lsof -i :18090  # Data Storage API (integration)
-lsof -i :8088   # HolmesGPT API (Kind E2E)
+lsof -i :8088   # Kubernaut Agent (Kind E2E)
 
 # Connect to test databases
 psql -h localhost -p 15433 -U postgres -d kubernaut  # Integration
 psql -h localhost -p 25433 -U postgres -d kubernaut  # E2E
-psql -h localhost -p 5488 -U slm_user -d action_history  # HAPI E2E
 
 # Connect to test Redis
 redis-cli -h localhost -p 16379  # Data Storage integration
 redis-cli -h localhost -p 16380  # Gateway integration
-redis-cli -h localhost -p 6388   # HAPI E2E
 
 # Test API health
 curl http://localhost:18090/health  # Data Storage integration
 curl http://localhost:18080/health  # Gateway integration
-curl http://localhost:8088/health   # HAPI E2E (Kind)
-curl http://localhost:8089/health   # Data Storage E2E (HAPI Kind)
+curl http://localhost:8088/health   # Kubernaut Agent E2E (Kind)
+curl http://localhost:8089/health   # Data Storage E2E (KA Kind cluster)
 
-# Kind cluster management (HAPI)
-kind get clusters | grep holmesgpt
-kind delete cluster --name holmesgpt-e2e
+# Kind cluster management (KA) -- exact cluster name is set by the test setup helper
+# in test/infrastructure/kubernautagent.go; check `kind get clusters` output to confirm
+kind get clusters
+kind delete cluster --name <ka-e2e-cluster-name-from-above>
 ```
 
 ---

--- a/docs/architecture/decisions/DD-WORKFLOW-003-parameterized-actions.md
+++ b/docs/architecture/decisions/DD-WORKFLOW-003-parameterized-actions.md
@@ -1,15 +1,21 @@
 # DD-WORKFLOW-003: Parameterized Remediation Actions
 
 **Status**: Approved  
-**Version**: 2.3  
+**Version**: 2.4  
 **Created**: 2025-11-15  
-**Updated**: 2026-03-04  
+**Updated**: 2026-08-02  
 **Target Release**: v1.1  
 **Related**: BR-WORKFLOW-001, DD-WORKFLOW-001, BR-496
 
 ---
 
 ## Changelog
+
+### Version 2.4 (2026-08-02)
+**Changes** ([Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806)):
+- ✅ Renamed HAPI → Kubernaut Agent (KA) throughout (mechanical rename, same feature, verified live against `internal/kubernautagent/parser/validator.go`)
+- ✅ Corrected the "Current Tekton Pipeline Execution Model" diagram: real service names (SignalProcessing/AIAnalysis/RemediationOrchestrator/WorkflowExecution controllers), KA's in-process workflow discovery (DD-WORKFLOW-019, not MCP catalog search), and the 3 execution engines (Tekton/Job/Ansible, ADR-024/044) instead of Tekton-only
+- ✅ Marked the Nov 2025 "Implementation Roadmap" phase list historical
 
 ### Version 2.3 (2026-03-04)
 **Changes**:
@@ -210,21 +216,23 @@ The LLM selects a specific remediation workflow and populates its required param
 }
 ```
 
-### HAPI-Managed Canonical Parameters (BR-496 v2)
+### KA-Managed Canonical Parameters (BR-496 v2)
 
-Three parameters are **HAPI-managed** — their values are injected by HAPI from the K8s-verified `root_owner`, not provided by the LLM:
+Three parameters are **KA-managed** — their values are injected by Kubernaut Agent (KA, formerly
+HolmesGPT-API/HAPI) from the K8s-verified `root_owner`, not provided by the LLM:
 
 - **`TARGET_RESOURCE_NAME`**: Name of the root managing resource (e.g., "payment-api")
 - **`TARGET_RESOURCE_KIND`**: Kind of the root managing resource (e.g., "Deployment")
 - **`TARGET_RESOURCE_NAMESPACE`**: Namespace of the root managing resource (omitted for cluster-scoped resources)
 
-**Workflow Schema Contract**: All workflow schemas **MUST** declare these three parameters. The `WorkflowResponseValidator` Step 0 rejects schemas that omit them.
+**Workflow Schema Contract**: All workflow schemas **MUST** declare these three parameters. KA's
+schema validator (`internal/kubernautagent/parser/validator.go`) rejects schemas that omit them.
 
-**Schema Stripping**: When `get_workflow` returns the workflow schema to the LLM, these three parameters are stripped from the response. This prevents the LLM from seeing or populating values that HAPI will overwrite.
+**Schema Stripping**: When `get_workflow` returns the workflow schema to the LLM, these three parameters are stripped from the response. This prevents the LLM from seeing or populating values that KA will overwrite.
 
-**Operational Parameters**: All other parameters (e.g., `MEMORY_LIMIT_NEW`, `SCALE_TARGET_REPLICAS`) remain LLM-provided. HAPI does not manage or validate these — the LLM populates them based on its investigation.
+**Operational Parameters**: All other parameters (e.g., `MEMORY_LIMIT_NEW`, `SCALE_TARGET_REPLICAS`) remain LLM-provided. KA does not manage or validate these — the LLM populates them based on its investigation.
 
-**Example — Combined HAPI-managed + LLM-provided parameters**:
+**Example — Combined KA-managed + LLM-provided parameters**:
 ```json
 {
   "parameters": {
@@ -236,7 +244,7 @@ Three parameters are **HAPI-managed** — their values are injected by HAPI from
 }
 ```
 
-In this example, the first three are injected by HAPI; `MEMORY_LIMIT_NEW` is provided by the LLM.
+In this example, the first three are injected by KA; `MEMORY_LIMIT_NEW` is provided by the LLM.
 
 ---
 
@@ -246,9 +254,9 @@ In this example, the first three are injected by HAPI; `MEMORY_LIMIT_NEW` is pro
 ┌─────────────────────────────────────────────────────────────┐
 │                    AI Analysis Service                       │
 │  1. Receives incident                                        │
-│  2. Calls HolmesGPT API for RCA                             │
+│  2. Calls Kubernaut Agent (KA) for RCA                       │
 │  3. LLM performs RCA (NO workflow pre-fetch to avoid contamination)
-│  4. LLM calls MCP tools to search playbooks AFTER RCA
+│  4. LLM calls KA's in-process discovery tools to search workflows AFTER RCA (DD-WORKFLOW-019)
 └───────────────────────┬─────────────────────────────────────┘
                         │
                         │ Creates PipelineRun with parameters
@@ -320,7 +328,12 @@ In this example, the first three are injected by HAPI; `MEMORY_LIMIT_NEW` is pro
 **Implementation Note**: Rollback parameters will be included in the LLM's JSON response as an optional field within each strategy.
 ---
 
-## Implementation Roadmap (Revised)
+## Implementation Roadmap (Revised) (Historical — v1.1 rollout plan, completed)
+
+> The phases below describe the original Nov 2025 rollout plan, including now-superseded components
+> (Mock MCP Server, "HolmesGPT API" naming). Retained for historical context; see the [KA-Managed
+> Canonical Parameters](#ka-managed-canonical-parameters-br-496-v2) section above for the current,
+> shipped mechanism.
 
 ### Phase 1 (v1.1) - Parameter Schema + LLM Integration
 **Duration**: 2-3 weeks
@@ -471,7 +484,6 @@ This is **superior** to building a custom execution engine because:
 Based on the authoritative [Kubernaut Architecture Overview](../../KUBERNAUT_ARCHITECTURE_OVERVIEW.md):
 
 ```
-```
 ┌─────────────────┐
 │ Signal Source   │  Prometheus, K8s Events
 │ (Alert/Event)   │
@@ -484,35 +496,36 @@ Based on the authoritative [Kubernaut Architecture Overview](../../KUBERNAUT_ARC
          │
          ▼
 ┌─────────────────┐
-│   Processor     │  Signal lifecycle + environment classification
+│ SignalProcessing│  Signal lifecycle + environment classification
+│  Controller     │
 └────────┬────────┘
          │
          ▼
 ┌─────────────────┐
-│  AI Analysis    │  HolmesGPT-Only integration
-│     Engine      │
+│  AIAnalysis     │  Async submit/poll/result session with KA
+│  Controller     │
 └────────┬────────┘
          │
          ▼
 ┌─────────────────┐
-│  HolmesGPT-API  │  Investigation & RCA
-│                 │  • Calls MCP workflow catalog search
-│                 │  • Returns recommendations with parameters
+│ Kubernaut Agent │  Investigation & RCA
+│      (KA)       │  • In-process workflow discovery (DD-WORKFLOW-019, no MCP call)
+│                 │  • Returns selectedWorkflow with parameters
 └────────┬────────┘
          │
          ▼
 ┌─────────────────┐
-│ Remediation     │  Orchestration & coordination
-│ Execution Engine│  • Parses LLM recommendations
-│ (CRD Controller)│  • Validates workflow parameters
-│                 │  • Creates Tekton PipelineRuns
+│ Remediation-    │  Orchestration & coordination
+│ Orchestrator    │  • Reads AIAnalysis.status.selectedWorkflow
+│ (RO Controller) │  • Passes through executionBundle/parameters (no re-validation)
+│                 │  • Creates WorkflowExecution CRD
 └────────┬────────┘
          │
          ▼
 ┌─────────────────┐
-│ Tekton Pipelines│  Kubernetes-native execution
-│  (PipelineRun)  │  • Runs workflow container images
-│                 │  • Injects parameters as env vars
+│ WorkflowExecution│ Dispatches by executionEngine
+│   Controller    │  • Tekton PipelineRun / batchv1.Job / AWX (ADR-024, ADR-044)
+│                 │  • Injects parameters as env vars/params
 └────────┬────────┘
          │
          ▼
@@ -524,10 +537,10 @@ Based on the authoritative [Kubernaut Architecture Overview](../../KUBERNAUT_ARC
 ```
 
 **Key Architectural Principles:**
-- **Investigation vs Execution Separation**: HolmesGPT investigates (NO execution), Tekton executes
-- **Remediation Execution Engine Coordination**: Parses recommendations, validates actions, coordinates execution
-- **Tekton PipelineRuns**: Kubernetes-native execution of workflow containers
-- **Parameter Flow**: LLM → Remediation Execution Engine → Tekton PipelineRun → Container Environment
+- **Investigation vs Execution Separation**: KA investigates (NO execution), the execution engine (Tekton/Job/Ansible) executes
+- **RO Pass-Through**: RO does not re-validate or re-resolve — it passes through KA's already-resolved `selectedWorkflow` (DD-CONTRACT-001)
+- **Multiple Execution Engines**: WorkflowExecution dispatches to Tekton, native `batchv1.Job`, or Ansible/AWX per `executionEngine` (ADR-024, ADR-044) — not Tekton-only
+- **Parameter Flow**: LLM → KA → AIAnalysis.status → RO (pass-through) → WorkflowExecution.spec → execution engine → Container Environment
 
 
 ### Workflow Design Pattern: Single Remediation Per Playbook
@@ -1010,7 +1023,7 @@ echo "Final replicas: ${FINAL_REPLICAS}"
 ### Success Metrics
 
 **Business Value**:
-- 40% reduction in validation complexity (Remediation Execution Engine + HolmesGPT-API)
+- 40% reduction in validation complexity (WorkflowExecution Controller + Kubernaut Agent (KA))
 - 25% reduction in LLM prompt tokens (simpler parameter schemas)
 - 60% improvement in audit trail granularity (Data Storage Service)
 - 30% reduction in container testing burden

--- a/docs/development/e2e-testing/GETTING_STARTED.md
+++ b/docs/development/e2e-testing/GETTING_STARTED.md
@@ -1,8 +1,27 @@
 # Getting Started with Kubernaut E2E Testing
 
-**Status**: Feature Complete (Testing Phase)
+**Status**: 🔄 SUPERSEDED — see notice below
 **Current Phase**: Unit, Integration, and E2E Test Implementation
-**Deployment Model**: Hybrid Architecture (Recommended)
+**Deployment Model**: Hybrid Architecture (historical proposal, never adopted)
+
+---
+
+## ⚠️ **SUPERSEDED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**
+
+This document (and the rest of `docs/development/e2e-testing/`) describes a January 2025 proposal for
+a **remote bare-metal hybrid architecture** (dedicated RHEL host, e.g. `helios08`, reached over SSH,
+with a standalone "HolmesGPT REST API" container on `localhost:8090`). None of the `make` targets
+referenced below (`configure-e2e-remote`, `deploy-cluster-remote-only`, `setup-local-hybrid`,
+`test-e2e-hybrid`, `status-hybrid`, `validate-hybrid-topology`, `cleanup-hybrid`) exist in the
+repository's `Makefile` — this deployment model was never adopted.
+
+**What actually ships today**: per-service E2E suites in `test/e2e/<service>/` (Ginkgo, against a local
+Kind cluster), run via `make test-e2e-<service>` (e.g. `make test-e2e-kubernautagent`,
+`make test-e2e-fullpipeline`, `make test-e2e-fleet`) — see the root `Makefile` (`test-e2e-%` target)
+and `docs/development/testing/KA_E2E_TEST_PLAN.md` for the Kubernaut Agent (KA) suite specifically.
+There is no separate "HolmesGPT REST API" service; KA is a single Go binary/container.
+
+Kept below for historical reference only; do not follow these instructions.
 
 ---
 

--- a/docs/development/testing/KA_E2E_TEST_PLAN.md
+++ b/docs/development/testing/KA_E2E_TEST_PLAN.md
@@ -234,7 +234,7 @@ This test plan documents all 48 E2E test scenarios from the Python test suite to
 
 #### E2E-KA-L007: Invalid Request Returns Error
 
-**Business Requirement**: BR-HAPI-200
+**Business Requirement**: BR-KA-200
 
 **Business Outcome**: Invalid requests rejected with clear error messages
 
@@ -444,7 +444,7 @@ This test plan documents all 48 E2E test scenarios from the Python test suite to
 
 #### E2E-KA-L018: Recovery Rejects Invalid Attempt Number
 
-**Business Requirement**: BR-HAPI-200
+**Business Requirement**: BR-KA-200
 
 **Business Outcome**: Invalid recovery attempt numbers rejected (must be >= 1)
 
@@ -824,7 +824,7 @@ This test plan documents all 48 E2E test scenarios from the Python test suite to
 **Implementation Notes**:
 ```go
 // IncidentRequest uses plain strings (not OptString as of ogen v1.0+)
-req := &hapiclient.IncidentRequest{
+req := &agentclient.IncidentRequest{
     IncidentID:        "test-audit-045",
     RemediationID:     remediationID,
     SignalName:        "OOMKilled",  // Issue #166: was SignalType
@@ -1510,21 +1510,21 @@ var _ = Describe("E2E-KA-L001: No Workflow Found Returns Human Review", Label("e
     Context("BR-KA-197: Human review scenarios", func() {
         It("should return needs_human_review when no matching workflow exists", func() {
             // Arrange: Create request with MOCK_NO_WORKFLOW_FOUND
-            req := &hapiogen.IncidentRequest{
-                IncidentID:     hapiogen.NewOptString("test-edge-001"),
-                RemediationID:  hapiogen.NewOptString("test-rem-001"),
-                SignalName:     hapiogen.NewOptString("MOCK_NO_WORKFLOW_FOUND"),  // Issue #166
-                Severity:       hapiogen.NewOptString("high"),
-                SignalSource:   hapiogen.NewOptString("prometheus"),
+            req := &agentclient.IncidentRequest{
+                IncidentID:     agentclient.NewOptString("test-edge-001"),
+                RemediationID:  agentclient.NewOptString("test-rem-001"),
+                SignalName:     agentclient.NewOptString("MOCK_NO_WORKFLOW_FOUND"),  // Issue #166
+                Severity:       agentclient.NewOptString("high"),
+                SignalSource:   agentclient.NewOptString("prometheus"),
                 // ... other required fields
             }
             
             // Act: Call KA
-            resp, err := hapiClient.IncidentAnalyzeEndpointAPIV1IncidentAnalyzePost(ctx, req)
+            resp, err := hgClient.IncidentAnalyzeEndpointAPIV1IncidentAnalyzePost(ctx, req)
             Expect(err).ToNot(HaveOccurred())
             
             // Assert: Business outcome validation
-            incidentResp, ok := resp.(*hapiogen.IncidentResponse)
+            incidentResp, ok := resp.(*agentclient.IncidentResponse)
             Expect(ok).To(BeTrue(), "Expected IncidentResponse type")
             
             // BEHAVIOR: Human review required
@@ -1704,11 +1704,11 @@ IncidentRequest{
 RecoveryRequest{
     IncidentID:            "test-013",                                    // plain string
     RemediationID:         "test-rem-013",                                // plain string
-    SignalName:            hapiclient.NewOptNilString("CrashLoopBackOff"), // OptNilString (Issue #166)
-    Severity:              hapiclient.NewOptNilString("high"),             // OptNilString
-    IsRecoveryAttempt:     hapiclient.NewOptBool(true),                    // OptBool
-    RecoveryAttemptNumber: hapiclient.NewOptNilInt(2),                     // OptNilInt
-    PreviousExecution:     hapiclient.NewOptNilPreviousExecution(...),     // OptNilPreviousExecution
+    SignalName:            agentclient.NewOptNilString("CrashLoopBackOff"), // OptNilString (Issue #166)
+    Severity:              agentclient.NewOptNilString("high"),             // OptNilString
+    IsRecoveryAttempt:     agentclient.NewOptBool(true),                    // OptBool
+    RecoveryAttemptNumber: agentclient.NewOptNilInt(2),                     // OptNilInt
+    PreviousExecution:     agentclient.NewOptNilPreviousExecution(...),     // OptNilPreviousExecution
 }
 ```
 
@@ -1752,7 +1752,7 @@ PreviousExecution{
         FailureStep: "apply-fix",
         ErrorOutput: "kubectl apply failed",
     },
-    NaturalLanguageSummary: hapiclient.NewOptNilString("Workflow failed at step apply-fix"),
+    NaturalLanguageSummary: agentclient.NewOptNilString("Workflow failed at step apply-fix"),
 }
 ```
 
@@ -2298,6 +2298,6 @@ Migration complete when:
 
 - **Python Test Suite**: `kubernaut-agent/tests/e2e/`
 - **Go Test Suite Target**: `test/e2e/kubernaut-agent/`
-- **Infrastructure**: `test/infrastructure/holmesgpt_api.go`
-- **Migration Plan**: `.cursor/plans/hapi_e2e_go_migration_*.plan.md`
+- **Infrastructure**: `test/infrastructure/kubernautagent.go` (renamed from `holmesgpt_api.go` during the Go rewrite)
+- **Migration Plan**: historical — the Python→Go migration plan referenced here no longer exists under `.cursor/plans/`; the migration itself completed and is reflected in this test plan's `E2E-KA-L{SEQUENCE}` scenarios
 - **Template**: `V1_0_SERVICE_MATURITY_TEST_PLAN_TEMPLATE.md`

--- a/docs/requirements/02_AI_MACHINE_LEARNING.md
+++ b/docs/requirements/02_AI_MACHINE_LEARNING.md
@@ -11,6 +11,7 @@
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 1.2 | 2026-08-02 | **Correction** ([Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806)): BR-AI-075 corrected — `executionBundle` (not `containerImage`) resolved by KA's in-process discovery cache (DD-WORKFLOW-019), not an MCP search. BR-AI-076 corrected to Rego policy decision language. Marked BR-AI-080–083 (Recovery Flow) `DEPRECATED` per the authoritative note already in `02-aianalysis/BUSINESS_REQUIREMENTS.md` — never implemented, `DD-RECOVERY-002`/`003` no longer exist, and the ID range was reused for graceful-shutdown requirements. |
 | 1.1 | 2025-11-30 | Added BR-AI-075-076 (Workflow Selection), BR-AI-080-083 (Recovery Flow) |
 | 1.0 | 2025-01-15 | Initial version |
 
@@ -161,42 +162,48 @@ The AI & Machine Learning components provide intelligent decision-making capabil
 > **Added**: v1.1 (2025-11-30) - Formalizes workflow selection output requirements per DD-CONTRACT-001
 
 - **BR-AI-075**: MUST produce structured workflow selection output per ADR-041 LLM contract
-  - **Output Fields**: `workflowId` (UUID from catalog), `containerImage` (OCI reference), `parameters` (map)
-  - **Catalog Integration**: Selected workflow MUST exist in Data Storage workflow catalog
-  - **Container Resolution**: Kubernaut Agent (KA) resolves `workflowId` → `containerImage` during MCP search
+  - **Output Fields**: `workflowId` (UUID from catalog), `executionBundle` (OCI reference — renamed
+    from `containerImage`, DD-CONTRACT-001 v2.0), `parameters` (map)
+  - **Catalog Integration**: Selected workflow MUST exist in the `RemediationWorkflow`/`ActionType` CRD catalog
+  - **Bundle Resolution**: Kubernaut Agent (KA) resolves `workflowId` → `executionBundle` via its own
+    in-process discovery cache (DD-WORKFLOW-019) — **not** an MCP/Data Storage search
   - **Parameter Validation**: Parameters MUST conform to workflow's parameter schema
-  - **Reference**: DD-CONTRACT-001 v1.2, DD-WORKFLOW-002 v3.3
-- **BR-AI-076**: MUST provide rich approval context when confidence is below threshold (<80%)
+  - **Reference**: DD-CONTRACT-001 v2.0, DD-WORKFLOW-019
+- **BR-AI-076**: MUST provide rich approval context when policy requires approval
   - **Approval Context Fields**: `investigationSummary`, `rootCauseEvidence`, `recommendationRationale`, `riskAssessment`
-  - **Threshold**: Auto-approval only when confidence ≥80%, otherwise `approvalRequired=true`
-  - **V1.0 Flow**: AIAnalysis sets flag, Remediation Orchestrator triggers notification
-  - **V1.1 Flow**: Creates `RemediationApprovalRequest` CRD for approval workflow
-  - **Reference**: ADR-040, ADR-018
+  - **Threshold**: Rego policy decision (default 80%, operator-configurable — see [Issue #1828](https://github.com/jordigilh/kubernaut/issues/1828)), sets `approvalRequired=true` when not met
+  - **Flow**: AIAnalysis sets `approvalRequired`, RemediationOrchestrator orchestrates notification + `RemediationApprovalRequest` CRD (ADR-040)
+  - **Reference**: ADR-040, ADR-018, DD-CONTRACT-002
 
-### 2.8 Recovery Flow
+### 2.8 Recovery Flow ⚠️ DEPRECATED (2026-03)
 
-> **Added**: v1.1 (2025-11-30) - Formalizes recovery attempt handling per DD-RECOVERY-002
+> **Deprecation Notice (2026-03)**: This section (BR-AI-080 through BR-AI-083, added v1.1 2025-11-30
+> against a since-deleted `DD-RECOVERY-002`/`DD-RECOVERY-003`) was **deprecated and never implemented as
+> described**. Recovery was superseded by the Effectiveness Monitor (EM) service, which handles
+> post-remediation assessment instead — see the authoritative deprecation note in
+> [`02-aianalysis/BUSINESS_REQUIREMENTS.md`](../services/crd-controllers/02-aianalysis/BUSINESS_REQUIREMENTS.md#category-4-recovery-flow-️-deprecated-2026-03).
+> The spec fields referenced below (`isRecoveryAttempt`, `recoveryAttemptNumber`, `previousExecutions`)
+> were never added to the `AIAnalysis` CRD. **Note**: the `BR-AI-080`–`BR-AI-083` ID range was later
+> reused for an unrelated, actually-implemented requirement — AIAnalysis graceful shutdown (SIGTERM
+> handling, in-flight completion, audit buffer flush) — see `pkg/aianalysis/controller_shutdown_test.go`
+> and `cmd/aianalysis/main.go`. Retained below for historical context only.
 
-- **BR-AI-080**: MUST support recovery analysis for failed WorkflowExecution attempts
+- **BR-AI-080** *(deprecated)*: MUST support recovery analysis for failed WorkflowExecution attempts
   - **Trigger**: Remediation Orchestrator creates new AIAnalysis CRD with `isRecoveryAttempt=true`
   - **Attempt Tracking**: `recoveryAttemptNumber` increments for each retry (1, 2, 3, ...)
   - **Max Attempts**: Configurable via annotation (default: 3)
-  - **Reference**: DD-RECOVERY-002
-- **BR-AI-081**: MUST accept and utilize previous execution context for recovery analysis
+- **BR-AI-081** *(deprecated)*: MUST accept and utilize previous execution context for recovery analysis
   - **Input**: `previousExecutions` array containing ALL prior attempt contexts
-  - **Context Fields**: `workflowId`, `containerImage`, `failureReason`, `failurePhase`, `kubernetesReason`
+  - **Context Fields**: `workflowId`, `executionBundle`, `failureReason`, `failurePhase`, `kubernetesReason`
   - **Purpose**: Enable LLM to learn from failures and avoid repeating mistakes
-  - **Reference**: DD-RECOVERY-003
-- **BR-AI-082**: MUST call Kubernaut Agent (KA) recovery endpoint for failed workflow analysis
-  - **Endpoint**: `POST /api/v1/recovery/analyze`
+- **BR-AI-082** *(deprecated)*: MUST call Kubernaut Agent (KA) recovery endpoint for failed workflow analysis
+  - **Endpoint**: `POST /api/v1/recovery/analyze` (never implemented; no such endpoint exists on KA)
   - **Payload**: Original context + failure context + Kubernetes reason codes
   - **Response**: New workflow recommendation avoiding previous failure causes
-  - **Reference**: DD-RECOVERY-003, BR-HAPI-RECOVERY-001
-- **BR-AI-083**: MUST reuse original enrichment data without re-enriching for recovery attempts
+- **BR-AI-083** *(deprecated)*: MUST reuse original enrichment data without re-enriching for recovery attempts
   - **Source**: `spec.enrichmentResults` copied from original SignalProcessing CRD
   - **Rationale**: Signal context hasn't changed; re-enriching wastes resources
   - **Optimization**: Skip SignalProcessing reconciliation for recovery AIAnalysis CRDs
-  - **Reference**: DD-RECOVERY-002
 
 ---
 


### PR DESCRIPTION
## Summary

Final content group (PR3b-5f) of the HAPI→Kubernaut Agent (KA) documentation consolidation tracked in #1806. Fixes the last 12 miscellaneous one-off files that the mechanical terminology sweeps (PR3b-2 #1849, PR3b-3 #1850) flagged as needing individual judgment (stale service names, fictional metrics, or superseded architecture).

## Changes

- **`docs/requirements/02_AI_MACHINE_LEARNING.md`**: corrected BR-AI-075/076 to reflect `executionBundle` and KA's in-process workflow discovery; added a DEPRECATED banner to the never-implemented Recovery Flow (BR-AI-080..083).
- **`docs/architecture/DYNAMIC_TOOLSET_CONFIGURATION_ARCHITECTURE.md`**: marked SUPERSEDED — the feature was deferred to V2.0 per DD-016 and never built as described.
- **`docs/development/testing/KA_E2E_TEST_PLAN.md`**: corrected client package/infra paths; renamed the now-dangling `BR-HAPI-200` references to `BR-KA-200` (the canonical requirement doc was already renamed in an earlier PR, leaving these as broken cross-references).
- **`docs/architecture/decisions/DD-WORKFLOW-003-parameterized-actions.md`**: renamed HAPI→KA, updated the architecture diagram, marked the Nov 2025 rollout plan historical.
- **`docs/architecture/decisions/DD-E2E-001-parallel-image-builds.md`**: corrected Go function/Dockerfile references.
- **`docs/architecture/decisions/DD-CICD-001-optimized-parallel-test-strategy.md`**: marked SUPERSEDED — the proposed 8-service Python CI matrix was never built; real CI is a 12-service Go matrix.
- **`docs/architecture/decisions/DD-TEST-001-QUICK-REFERENCE.md`**: renamed "HolmesGPT API" → "Kubernaut Agent (KA)", corrected the port table and Kind cluster commands.
- **`docs/architecture/decisions/ADR-050-configuration-validation-strategy.md`**: renamed HolmesGPT-API → KA, documented the real Go `FileWatcher` implementation, deprecated the never-formalized `DD-HAPI-004` reference.
- **`docs/architecture/PROMETHEUS_ALERTRULES.md`**: renamed the Kubernaut Agent alert group and its LLM metric names to match what's actually exported (`pkg/kubernautagent/llm/instrumented_client.go`); replaced the fictional `AIAnalysisHolmesGPTUnavailable` alert with one based on the real `aianalysis_failures_total{reason="APIError"}` counter (`pkg/aianalysis/metrics/metrics.go`); flagged — but explicitly left out of scope for a dedicated metrics-audit issue — unrelated pre-existing drift in the other three AI Analysis alerts (they reference metric names that don't exist in the current Go implementation, unrelated to the HAPI rename).
- **`docs/architecture/decisions/DD-INTEGRATION-001-local-image-builds.md`**: corrected a stale compose project name and make target inside already-superseded example code.
- **`docs/development/e2e-testing/GETTING_STARTED.md`**: marked SUPERSEDED — the remote bare-metal hybrid architecture (dedicated RHEL host over SSH, standalone "HolmesGPT REST API" container) it describes was never adopted; pointed readers to the real Kind-cluster-based `test/e2e/<service>` suites.
- `docs/architecture/RATE_LIMITING_STANDARD.md` needed no changes — its earlier flagged references were already resolved by the PR3b-2/3 sweep.

## Test plan

- [x] Docs-only change; no code/build/test impact.
- [x] Verified remaining `HolmesGPT|HAPI` hits in each touched file are intentional historical/corrective references (inside SUPERSEDED banners or explanatory "formerly X" notes), not live prose.
- [x] Cross-checked all newly-cited metric names, Makefile targets, and source paths against actual Go source (`pkg/kubernautagent/llm/instrumented_client.go`, `pkg/aianalysis/metrics/metrics.go`, root `Makefile`, `test/e2e/*`).

Part of #1806. This closes out the last content group (Group F); a final zero-HAPI-references verification pass across all of `docs/` remains before closing the issue.

Made with [Cursor](https://cursor.com)