### PR TITLE
fix(e2e): scope AF investigate grounding to a dedicated fixture, not default/nginx

### DIFF
--- a/deploy/apifrontend/overlays/e2e/mock-llm.yaml
+++ b/deploy/apifrontend/overlays/e2e/mock-llm.yaml
@@ -99,8 +99,14 @@ data:
           name: "kubernaut_investigate"
           arguments:
             api_version: "v1"
-            namespace: "default"
-            name: "nginx"
+            # #1839: dedicated namespace/name (not "default"/"nginx") so this
+            # fixture's synthetic grounding alert (AFInvestigateGrounding,
+            # apifrontend_prometheus_e2e.go) can only ever match this exact
+            # target -- generic names would let it silently backstop any
+            # future scenario that forgets to add its own Prometheus
+            # grounding.
+            namespace: "af-investigate-e2e"
+            name: "af-investigate-target"
             kind: "Pod"
 
       - name: "af_investigate"
@@ -109,8 +115,8 @@ data:
         tool_call:
           name: "kubernaut_investigate"
           arguments:
-            namespace: "default"
-            name: "nginx"
+            namespace: "af-investigate-e2e"
+            name: "af-investigate-target"
             kind: "Pod"
 
       - name: "af_investigate_resume"

--- a/test/e2e/apifrontend/alert_prioritization_e2e_test.go
+++ b/test/e2e/apifrontend/alert_prioritization_e2e_test.go
@@ -57,8 +57,10 @@ var _ = Describe("Alert Prioritization E2E — #1412", Ordered, Label("e2e", "al
 		ctx, cancel := context.WithTimeout(context.Background(), 90*time.Second)
 		defer cancel()
 
+		// #1839: HighCPU's target lives in "sev-tier1-ns", not "default" --
+		// see apifrontend_prometheus_e2e.go's SeverityTriageAlertRulesYAML doc.
 		Expect(kinfra.AFInjectOTLPMetrics(ctx, promURL, "e2e_cpu_usage_percent", 95, map[string]string{
-			"namespace": "default", "kind": "Deployment", "name": "test-firing-target",
+			"namespace": "sev-tier1-ns", "kind": "Deployment", "name": "test-firing-target",
 		})).To(Succeed(), "CPU metric re-injection for alert prioritization")
 
 		Eventually(func() error {
@@ -80,7 +82,7 @@ var _ = Describe("Alert Prioritization E2E — #1412", Ordered, Label("e2e", "al
 	It("E2E-AF-1412-001: list_alerts returns prioritized result with critical as Selected over warning and info", func() {
 		callBody := buildJSONRPC("e2e-1412-001", "tools/call", map[string]interface{}{
 			"name":      "kubernaut_list_alerts",
-			"arguments": map[string]interface{}{"namespace": "default"},
+			"arguments": map[string]interface{}{"namespace": "sev-tier1-ns"},
 		})
 		raw, code, err := mcpPOST(sreToken, mcpSessionID, callBody)
 		Expect(err).NotTo(HaveOccurred())
@@ -116,12 +118,12 @@ var _ = Describe("Alert Prioritization E2E — #1412", Ordered, Label("e2e", "al
 	})
 
 	It("E2E-AF-1412-002: tied critical alerts both appear in response (Selected + Tied)", func() {
-		// This test requires 2+ critical alerts firing in the default namespace.
+		// This test requires 2+ critical alerts firing in the sev-tier1-ns namespace.
 		// The E2E infrastructure fires a single HighCPU critical alert, so Tied will be empty.
 		// Validates structural correctness: tool returns valid response with Selected populated.
 		callBody := buildJSONRPC("e2e-1412-002", "tools/call", map[string]interface{}{
 			"name":      "kubernaut_list_alerts",
-			"arguments": map[string]interface{}{"namespace": "default"},
+			"arguments": map[string]interface{}{"namespace": "sev-tier1-ns"},
 		})
 		raw, code, err := mcpPOST(sreToken, mcpSessionID, callBody)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/apifrontend/e2e_suite_test.go
+++ b/test/e2e/apifrontend/e2e_suite_test.go
@@ -76,11 +76,15 @@ var _ = SynchronizedBeforeSuite(
 				To(Succeed(), "Prometheus must become ready within 90s")
 
 			_, _ = fmt.Fprintln(GinkgoWriter, "  Injecting OTLP metrics for severity triage alerts...")
+			// #1839: dedicated namespaces (not "default") so these fixtures
+			// cannot accidentally backstop an unrelated test that shares the
+			// "default" namespace but forgot to configure its own grounding
+			// (see apifrontend_prometheus_e2e.go's SeverityTriageAlertRulesYAML).
 			Expect(kinfra.AFInjectOTLPMetrics(ctx, promURL, "e2e_cpu_usage_percent", 95, map[string]string{
-				"namespace": "default", "kind": "Deployment", "name": "test-firing-target",
+				"namespace": "sev-tier1-ns", "kind": "Deployment", "name": "test-firing-target",
 			})).To(Succeed(), "CPU metric injection must succeed")
 			Expect(kinfra.AFInjectOTLPMetrics(ctx, promURL, "e2e_memory_usage_percent", 90, map[string]string{
-				"namespace": "default", "kind": "Deployment", "name": "test-pending-target",
+				"namespace": "sev-tier15-ns", "kind": "Deployment", "name": "test-pending-target",
 			})).To(Succeed(), "Memory metric injection must succeed")
 
 			// NOTE: e2e_disk_usage_percent is NOT injected here — injected at test

--- a/test/e2e/apifrontend/severity_triage_test.go
+++ b/test/e2e/apifrontend/severity_triage_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Severity Triage Pipeline (G12)", Label("e2e", "phase4", "g12")
 		Expect(err).NotTo(HaveOccurred(), "SRE DEX token")
 		Expect(authToken).NotTo(BeEmpty())
 
-		for _, nsName := range []string{"sev-tier2-ns", "no-data-ns", "no-rules-ns"} {
+		for _, nsName := range []string{"sev-tier1-ns", "sev-tier15-ns", "sev-tier2-ns", "no-data-ns", "no-rules-ns", "sev-userhint-ns"} {
 			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
 			err = k8sClient.Create(context.Background(), ns)
 			if err != nil && !apierrors.IsAlreadyExists(err) {
@@ -97,7 +97,7 @@ var _ = Describe("Severity Triage Pipeline (G12)", Label("e2e", "phase4", "g12")
 		}
 		ctx := context.Background()
 		Expect(injectMetricForTier2(ctx, promURL, "e2e_cpu_usage_percent", 95, map[string]string{
-			"namespace": "default", "kind": "Deployment", "name": "test-firing-target",
+			"namespace": "sev-tier1-ns", "kind": "Deployment", "name": "test-firing-target",
 		})).To(Succeed(), "CPU metric re-injection must succeed for Tier 1")
 
 		Eventually(func() error {
@@ -105,15 +105,15 @@ var _ = Describe("Severity Triage Pipeline (G12)", Label("e2e", "phase4", "g12")
 		}, 60*time.Second, 2*time.Second).Should(Succeed(),
 			"HighCPU alert must be firing before RR creation")
 
-		a2aCreateRRAndWait("default", "test-firing-target", "")
-		rr := findRRByTarget("default", "test-firing-target")
+		a2aCreateRRAndWait("sev-tier1-ns", "test-firing-target", "")
+		rr := findRRByTarget("sev-tier1-ns", "test-firing-target")
 		Expect(rr.Spec.Severity).To(Equal("critical"), "spec.severity")
 		Expect(rr.Spec.SignalLabels).To(HaveKeyWithValue("severity_source", "firing_alert"))
 	})
 
 	It("TC-E2E-SEV-02: Tier 1.5 — Pending alert", func() {
-		a2aCreateRRAndWait("default", "test-pending-target", "")
-		rr := findRRByTarget("default", "test-pending-target")
+		a2aCreateRRAndWait("sev-tier15-ns", "test-pending-target", "")
+		rr := findRRByTarget("sev-tier15-ns", "test-pending-target")
 		Expect(rr.Spec.Severity).NotTo(BeEmpty(), "severity must be set by triage pipeline")
 		src := rr.Spec.SignalLabels["severity_source"]
 		Expect(src).To(BeElementOf(
@@ -238,8 +238,16 @@ var _ = Describe("Severity Triage Pipeline (G12)", Label("e2e", "phase4", "g12")
 	})
 
 	It("TC-E2E-SEV-06: User severity hint does not bypass triage pipeline", func() {
-		a2aCreateRRAndWait("default", "test-user-severity-bypass", " with severity low")
-		rr := findRRByTarget("default", "test-user-severity-bypass")
+		// #1839: dedicated namespace/rule (UserSeverityHintGrounding in
+		// apifrontend_prometheus_e2e.go), not "default". This fixture used
+		// to have no rule of its own and silently passed only by riding
+		// HighCPU's namespace-level fallback via their shared "default"
+		// namespace -- the same hidden cross-test coupling diagnosed for
+		// the AF investigate fixture (#1865). A dedicated namespace+rule
+		// makes this test's grounding self-contained and immune to any
+		// other fixture's alert state.
+		a2aCreateRRAndWait("sev-userhint-ns", "test-user-severity-bypass", " with severity low")
+		rr := findRRByTarget("sev-userhint-ns", "test-user-severity-bypass")
 		Expect(rr.Spec.Severity).NotTo(BeEmpty(), "severity must be set by triage pipeline")
 		Expect(rr.Spec.SignalLabels).To(HaveKey("severity_source"),
 			"triage pipeline must set severity_source even when user supplies a hint")

--- a/test/infrastructure/apifrontend_prometheus_e2e.go
+++ b/test/infrastructure/apifrontend_prometheus_e2e.go
@@ -216,28 +216,46 @@ func AFInjectOTLPMetrics(ctx context.Context, prometheusURL, metricName string, 
 //   - DiskPressure: for:0s + metric injected -> inactive then evaluates live data (tier 2)
 //   - NetworkLatency: query matches no-data-ns target but no metric exists -> inactive no data (tier 2.5)
 //   - AFInvestigateGrounding: for:0s + vector(1) (never stale) -> tier 1, grounds
-//     the mock-LLM's "default/Pod/nginx" investigate fixture (see below)
+//     the mock-LLM's dedicated "af-investigate-e2e/Pod/af-investigate-target"
+//     investigate fixture (see below)
 //
 // PromQL expressions include label selectors for namespace/kind/name because the
 // triage pipeline's Tier 1.5 and Tier 2 use ExtractLabelMatchers(query)
 // + MatchesResource to correlate rules with the target resource.
 //
 // #1839 RCA: deploy/apifrontend/overlays/e2e/mock-llm.yaml's "af_investigate"/
-// "af_progressive_investigate"/"af_investigate_resume" scenarios all target a
-// fixed namespace="default",kind="Pod",name="nginx" via kubernaut_investigate,
-// which (like kubernaut_remediate) now runs through the fail-closed severity
-// triage pipeline. Before Tier 3 was removed, an ungrounded call like this
-// silently fell back to the pure-LLM tier and always "succeeded". Without a
-// resource-specific rule, these calls degraded to Triager's namespace-level
-// correlation fallback (any firing alert sharing namespace="default", e.g.
-// HighCPU) — which is timing-dependent: HighCPU's injected OTLP metric goes
-// Prometheus-stale (default 5m) if not re-injected, so tests running late in
-// a parallel E2E suite intermittently lost that accidental grounding and
-// failed with ErrSeverityUndetermined (see progressive_flow_e2e_test.go
-// E2E-AF-1408-001). vector(1) has no underlying series to go stale, so this
-// rule fires deterministically for the whole suite lifetime and grounds the
-// resource directly (Tier 1, resource-exact match) instead of leaning on an
-// unrelated fixture's namespace-level spillover.
+// "af_progressive_investigate"/"af_investigate_resume" scenarios target a
+// fixed resource via kubernaut_investigate, which (like kubernaut_remediate)
+// now runs through the fail-closed severity triage pipeline. Before Tier 3
+// was removed, an ungrounded call like this silently fell back to the
+// pure-LLM tier and always "succeeded". The fixture originally used
+// namespace="default",kind="Pod",name="nginx" with no dedicated rule, so
+// calls degraded to Triager's namespace-level correlation fallback (any
+// firing alert sharing namespace="default", e.g. HighCPU) — which is
+// timing-dependent: HighCPU's injected OTLP metric goes Prometheus-stale
+// (default 5m) if not re-injected, so tests running late in a parallel E2E
+// suite intermittently lost that accidental grounding and failed with
+// ErrSeverityUndetermined (see progressive_flow_e2e_test.go E2E-AF-1408-001).
+//
+// AFInvestigateGrounding's expr (vector(1) > 0) has no underlying series, so
+// it can never go stale and fires deterministically for the whole suite
+// lifetime. Its target was also moved off the shared "default" namespace and
+// generic "nginx" name onto a dedicated namespace="af-investigate-e2e",
+// name="af-investigate-target": labelsOverlap (severity/triage.go) matches
+// resource-level correlation on kind+name only (namespace is intentionally
+// excluded there), and Tier 1 additionally falls back to a namespace-level
+// match against ANY resource sharing an alert's namespace when no
+// resource-exact match exists. A rule keyed to "default"/"nginx" — both
+// generic, easily-reused placeholder values — would silently backstop any
+// *future* scenario that targets the same generic name/namespace without
+// configuring its own grounding, defeating the whole point of removing
+// Tier 3 (a mis-configured new scenario should fail loudly with
+// ErrSeverityUndetermined, not silently inherit an unrelated fixture's
+// severity). A dedicated namespace+name closes both correlation paths to
+// exactly this one fixture, matching the existing convention of
+// test-firing-target/test-pending-target/test-inactive-target/
+// test-nodata-target below (each unique enough that no other scenario would
+// plausibly collide with it).
 const SeverityTriageAlertRulesYAML = `
 groups:
   - name: e2e-severity-triage
@@ -281,9 +299,9 @@ groups:
         labels:
           severity: warning
           source: prometheus
-          namespace: default
+          namespace: af-investigate-e2e
           kind: Pod
-          name: nginx
+          name: af-investigate-target
         annotations:
-          summary: "Synthetic grounding alert for AF investigate E2E fixture (default/Pod/nginx, #1839)"
+          summary: "Synthetic grounding alert for AF investigate E2E fixture (dedicated namespace/name, #1839)"
 `

--- a/test/infrastructure/apifrontend_prometheus_e2e.go
+++ b/test/infrastructure/apifrontend_prometheus_e2e.go
@@ -218,6 +218,25 @@ func AFInjectOTLPMetrics(ctx context.Context, prometheusURL, metricName string, 
 //   - AFInvestigateGrounding: for:0s + vector(1) (never stale) -> tier 1, grounds
 //     the mock-LLM's dedicated "af-investigate-e2e/Pod/af-investigate-target"
 //     investigate fixture (see below)
+//   - UserSeverityHintGrounding: for:0s + vector(1) (never stale) -> tier 1,
+//     grounds severity_triage_test.go's TC-E2E-SEV-06 "user hint does not
+//     bypass triage" fixture (dedicated namespace="sev-userhint-ns",
+//     kind=Deployment, name="test-user-severity-bypass")
+//
+// #1839 follow-up (no fixtures in "default"): HighCPU and HighMemory used to
+// target namespace="default" (unlike DiskPressure/NetworkLatency, which
+// already used dedicated sev-tier2-ns/no-data-ns namespaces). "default" is
+// the one namespace every test can use without any setup, which is exactly
+// why it kept attracting *unintentional* consumers: severity_triage_test.go's
+// TC-E2E-SEV-06 ("test-user-severity-bypass") had no rule of its own and was
+// silently passing only because it shared namespace="default" with HighCPU,
+// riding Tier 1's namespace-level fallback (bestAlertMatch in
+// severity/triage.go) -- the same hidden-coupling failure mode diagnosed
+// below for the (now-fixed) AF investigate fixture. HighCPU/HighMemory were
+// moved to their own dedicated namespaces (sev-tier1-ns/sev-tier15-ns) --
+// matching the sev-tier2-ns/no-data-ns convention -- specifically so
+// "default" no longer groups multiple fixtures together and cannot silently
+// backstop a future test that forgets to configure its own grounding.
 //
 // PromQL expressions include label selectors for namespace/kind/name because the
 // triage pipeline's Tier 1.5 and Tier 2 use ExtractLabelMatchers(query)
@@ -262,7 +281,7 @@ groups:
     interval: 5s
     rules:
       - alert: HighCPU
-        expr: e2e_cpu_usage_percent{namespace="default",kind="Deployment",name="test-firing-target"} > 90
+        expr: e2e_cpu_usage_percent{namespace="sev-tier1-ns",kind="Deployment",name="test-firing-target"} > 90
         for: 0s
         labels:
           severity: critical
@@ -270,7 +289,7 @@ groups:
         annotations:
           summary: "CPU usage is critically high"
       - alert: HighMemory
-        expr: e2e_memory_usage_percent{namespace="default",kind="Deployment",name="test-pending-target"} > 85
+        expr: e2e_memory_usage_percent{namespace="sev-tier15-ns",kind="Deployment",name="test-pending-target"} > 85
         for: 1h
         labels:
           severity: high
@@ -304,4 +323,15 @@ groups:
           name: af-investigate-target
         annotations:
           summary: "Synthetic grounding alert for AF investigate E2E fixture (dedicated namespace/name, #1839)"
+      - alert: UserSeverityHintGrounding
+        expr: vector(1) > 0
+        for: 0s
+        labels:
+          severity: warning
+          source: prometheus
+          namespace: sev-userhint-ns
+          kind: Deployment
+          name: test-user-severity-bypass
+        annotations:
+          summary: "Synthetic grounding alert for TC-E2E-SEV-06 (dedicated namespace/name, #1839)"
 `


### PR DESCRIPTION
## Summary

Post-merge follow-up to #1857. The `AFInvestigateGrounding` Prometheus rule added there used `namespace=default,kind=Pod,name=nginx` labels, which turned out to be an accidental catch-all rather than a narrowly-scoped fixture grounding.

`severity/triage.go`'s Tier 1 correlation has two paths that both widen this rule's blast radius beyond the intended single fixture:

- `labelsOverlap()` explicitly excludes `"namespace"` from its key-overlap comparison (only `kind`+`name` are compared), so the rule would resource-match **any** future scenario using `kind=Pod,name=nginx` in **any** namespace.
- `bestAlertMatch()`'s namespace-level fallback grounds **any other resource** sharing the alert's `namespace` label when no resource-exact match exists, so with `namespace=default` the rule would also silently backstop any other resource in the (generic, easily-reused) `"default"` namespace.

Either path would let a future mis-configured scenario (one that forgets to add its own Prometheus grounding) silently inherit this fixture's `"warning"` severity instead of failing closed with `ErrSeverityUndetermined` — exactly the failure mode #1839 removed Tier 3 to prevent, reintroduced through a test fixture.

## Fix

Move the `af_investigate`/`af_progressive_investigate` mock-LLM scenarios (and the grounding rule's labels) off the generic `default`/`nginx` onto a dedicated `namespace=af-investigate-e2e`, `name=af-investigate-target` — both values unique enough that no other scenario would plausibly collide with them, matching the existing `test-firing-target`/`test-pending-target`/`test-inactive-target`/`test-nodata-target` convention already used by the sibling severity-triage-tier rules.

## Test plan

- [x] `go build ./test/infrastructure/...`
- [x] `go vet ./test/infrastructure/...`
- [x] `golangci-lint run ./test/infrastructure/...` — 0 issues
- [ ] CI: `E2E (apifrontend)` green (exercises the `af_investigate`/`af_progressive_investigate`/`af_investigate_resume` scenarios via `E2E-AF-1408-001` and related tests)

Made with [Cursor](https://cursor.com)