### PR TITLE
docs: correct Group I workflow-catalog/MCP-discovery docs against DD-WORKFLOW-019 (Issue #1806)

### DIFF
--- a/docs/architecture/decisions/ADR-021-workflow-dependency-cycle-detection.md
+++ b/docs/architecture/decisions/ADR-021-workflow-dependency-cycle-detection.md
@@ -1,15 +1,36 @@
 # ADR-021: Workflow Dependency Cycle Detection & Validation
 
-**Status**: ✅ **APPROVED**  
+**Status**: 🗄️ **SUPERSEDED / NEVER IMPLEMENTED** — see note below  
 **Date**: 2025-10-17  
-**Related**: ADR-020 (Parallel Execution Limits)  
-**Confidence**: 90%
+**Related**: ADR-020 (Parallel Execution Limits), [DD-WORKFLOW-016](DD-WORKFLOW-016-action-type-workflow-indexing.md) (current: predefined workflow catalog), [DD-WORKFLOW-017](DD-WORKFLOW-017-workflow-lifecycle-component-interactions.md), [DD-WORKFLOW-019](DD-WORKFLOW-019-ka-owned-workflow-discovery.md)  
+**Confidence**: 90% (original design confidence for an approach later superseded before implementation)
 
----
+> **SUPERSEDED / NEVER IMPLEMENTED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**:
+> This entire document — not just this opening note — describes a dynamic, per-incident
+> workflow-generation model: the agent emits an arbitrary multi-step JSON graph of recommendations with
+> inter-step `dependencies`, and a cycle-detection validator protects against the agent generating an
+> invalid (circular) graph. That model was superseded **before implementation** by the predefined
+> workflow-catalog approach (DD-WORKFLOW-016/017/019): Kubernaut Agent (KA) selects one existing,
+> pre-registered `RemediationWorkflow` from the catalog via the three-step discovery protocol
+> (`list_available_actions` -> `list_workflows` -> `get_workflow`) rather than generating a novel
+> multi-step dependency graph per incident. A cataloged workflow's internal steps (e.g. a Tekton
+> `PipelineRun`'s task graph) are authored and validated by the workflow's own execution engine at
+> registration time, not dynamically emitted by the LLM per remediation — so there is no
+> agent-generated, cross-step dependency graph for a Go validator to check for cycles in the shipped
+> architecture.
+>
+> Confirmed via repo-wide search of `pkg/` and `internal/`: `dependency_validator.go`,
+> `ValidateDependencyGraph`, `GetExecutionOrder`, `processHolmesGPTRecommendations`, and the Prometheus
+> metrics/alerts named below (`aianalysis_dependency_validation_total`,
+> `aianalysis_dependency_cycles_detected_total`, `HighDependencyCycleRate`) do not exist anywhere in the
+> codebase, in this or any other form — this was never built, in whole or in part, under any name. The
+> companion enhancement proposal, `ADR-021-AI-DRIVEN-CYCLE-CORRECTION-ASSESSMENT.md`, describes the same
+> unbuilt architecture and is equally historical (out of scope for this correction pass, not edited
+> here). This document is retained in full below for historical/design-archaeology context only — do not
+> use any part of it, including the code, metrics, or Business Requirements (BR-AI-066 through
+> BR-AI-070) below, to understand current KA or AIAnalysis behavior.
 
 ## Context & Problem
-
-> **⚠️ STALE (flagged [#1806](https://github.com/jordigilh/kubernaut/issues/1806), not corrected here)**: This ADR describes a dynamic, per-incident workflow-generation model (the agent emits arbitrary multi-step JSON recommendations with inter-step dependencies) that has since been superseded by a predefined workflow catalog approach — the agent now selects an existing cataloged workflow rather than generating novel dependency graphs. The dependency-cycle-detection code described here (`dependency_validator.go`, `ValidateDependencyGraph`, `processHolmesGPTRecommendations`) does not exist in the current codebase.
 
 Kubernaut Agent (KA) generates multi-step workflows with dependencies in **self-documenting JSON format**:
 

--- a/docs/architecture/decisions/ADR-055-ADDENDUM-001-remediation-target-rename.md
+++ b/docs/architecture/decisions/ADR-055-ADDENDUM-001-remediation-target-rename.md
@@ -5,6 +5,22 @@
 **Issue**: #542  
 **Parent ADR**: ADR-055 (LLM-Driven Context Enrichment)
 
+> **Historical Context (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**:
+> Layer 1 below documents PR #543 as it landed in March 2026, against the **pre-Go-rewrite Python**
+> `kubernaut-agent`/HAPI implementation (`prompt_builder.py`, `result_parser.py`, `llm_integration.py`,
+> `enrichment_service.py`, and a "HolmesGPT OAS client"). None of those Python files exist in the
+> repository today — `kubernaut-agent`/HolmesGPT API was rewritten in Go as **Kubernaut Agent (KA)** per
+> [DD-KA-019](DD-KA-019-go-rewrite-design/DD-KA-019-go-rewrite-design.md) (approved 2026-03-04, the same
+> day as this addendum). The underlying decision this addendum records — renaming the semantically
+> ambiguous `affectedResource` to the clearer `remediationTarget` — remains valid and is confirmed still
+> implemented today: `RemediationTarget` is a live type in
+> `api/aianalysis/v1alpha1/aianalysis_types.go` (line 630), and the Rego evaluator
+> (`pkg/aianalysis/rego/evaluator.go`, lines 115/286) still exposes it under the `remediation_target` JSON
+> key exactly as Layer 2 below describes — confirmed by [ADR-055 v2.0](ADR-055-llm-driven-context-enrichment.md)'s
+> own description of `remediation_target` as "structured Rego policy input". Layer 2 (Go CRD & Consumers)
+> is therefore accurate as current-state documentation, not just history; only Layer 1 (Python) is
+> obsolete.
+
 ## Context
 
 Issue #542 identified that the field name `affectedResource` was semantically ambiguous.

--- a/docs/architecture/decisions/DD-WORKFLOW-002-MCP-WORKFLOW-CATALOG-ARCHITECTURE.md
+++ b/docs/architecture/decisions/DD-WORKFLOW-002-MCP-WORKFLOW-CATALOG-ARCHITECTURE.md
@@ -1,14 +1,35 @@
 # DD-WORKFLOW-002: MCP Workflow Catalog Architecture
 
-> **SUPERSEDED** by [DD-WORKFLOW-016](./DD-WORKFLOW-016-action-type-workflow-indexing.md) (Action-Type Workflow Catalog Indexing, February 2026).
+> **SUPERSEDED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: This
+> Nov 2025 proposal describes a **Python** HolmesGPT API calling a standalone **Embedding Service (MCP
+> Server)** that generates 384-dim sentence-transformer embeddings and posts a single
+> `search_workflow_catalog` semantic-search tool call to a Data Storage `POST /api/v1/workflows/search`
+> pgvector endpoint — none of which reflects the shipped architecture. The standalone Embedding Service
+> was never built; HolmesGPT API was rewritten in Go as **Kubernaut Agent (KA)**; and the single
+> semantic-search tool was first replaced by a three-step, `action_type`-taxonomy-based discovery
+> protocol (`list_available_actions` -> `list_workflows` -> `get_workflow`, DD-WORKFLOW-016, Feb 2026),
+> which has since been relocated again: that three-step protocol's discovery/scoring logic now runs
+> **in-process inside KA** against an informer-backed cache of `RemediationWorkflow`/`ActionType` CRDs
+> (confirmed via `internal/kubernautagent/workflowcatalog/discovery.go`,
+> `internal/kubernautagent/workflowcatalog/cache_filter.go`), not any Data Storage REST/MCP endpoint or
+> PostgreSQL/pgvector store (both retired as dead code — no `pgvector`/embedding reference remains
+> anywhere in the KA discovery path). See [DD-WORKFLOW-019](DD-WORKFLOW-019-ka-owned-workflow-discovery.md)
+> for the current discovery-ownership design and
+> [DD-WORKFLOW-017](DD-WORKFLOW-017-workflow-lifecycle-component-interactions.md) for the current
+> end-to-end lifecycle (registration -> discovery -> execution -> management). This document — including
+> the Feb-2026 correction note directly below, which remains accurate about the discovery *protocol
+> shape* but not about *where* it now runs — is retained for historical context only; do not use it to
+> understand the current architecture.
+
+> **SUPERSEDED (intermediate correction, Feb 2026)** by [DD-WORKFLOW-016](./DD-WORKFLOW-016-action-type-workflow-indexing.md) (Action-Type Workflow Catalog Indexing).
 >
-> DD-WORKFLOW-016 replaces the single `search_workflow_catalog` tool with a three-step discovery protocol (`list_available_actions`, `list_workflows`, `get_workflow`). The `signal_type`-based querying, semantic search with pgvector embeddings, and Embedding Service architecture defined in this document are no longer valid. The `action_type` taxonomy (DD-WORKFLOW-016) replaces `signal_type` as the primary catalog indexing key. Refer to DD-WORKFLOW-016 for the current Kubernaut Agent (KA) toolset and DS endpoint design.
+> DD-WORKFLOW-016 replaces the single `search_workflow_catalog` tool with a three-step discovery protocol (`list_available_actions`, `list_workflows`, `get_workflow`). The `signal_type`-based querying, semantic search with pgvector embeddings, and Embedding Service architecture defined in this document are no longer valid. The `action_type` taxonomy (DD-WORKFLOW-016) replaces `signal_type` as the primary catalog indexing key. **Update (2026-08-02)**: refer to DD-WORKFLOW-019 and DD-WORKFLOW-017 — not this note's original DD-WORKFLOW-016-only pointer — for the current Kubernaut Agent (KA) toolset and endpoint design, since discovery ownership itself moved from Data Storage to KA after this note was written.
 
 **Date**: November 14, 2025
-**Status**: **SUPERSEDED** by DD-WORKFLOW-016
+**Status**: 🗄️ **SUPERSEDED** — see notes above (originally by DD-WORKFLOW-016, Feb 2026; discovery ownership further superseded by DD-WORKFLOW-019, Jul 2026)
 **Deciders**: Architecture Team
-**Version**: 3.3
-**Related**: DD-WORKFLOW-012 (Workflow Immutability), ADR-034 (Unified Audit Table), DD-WORKFLOW-014 (Workflow Selection Audit Trail), DD-CONTRACT-001 (AIAnalysis ↔ WorkflowExecution Alignment)
+**Version**: 3.4
+**Related**: DD-WORKFLOW-012 (Workflow Immutability), ADR-034 (Unified Audit Table), DD-WORKFLOW-014 (Workflow Selection Audit Trail), DD-CONTRACT-001 (AIAnalysis ↔ WorkflowExecution Alignment), [DD-WORKFLOW-019](DD-WORKFLOW-019-ka-owned-workflow-discovery.md) (current discovery-ownership design), [DD-WORKFLOW-017](DD-WORKFLOW-017-workflow-lifecycle-component-interactions.md) (current end-to-end lifecycle)
 
 ---
 
@@ -28,6 +49,15 @@
 ---
 
 ## Changelog
+
+### Version 3.4 (2026-08-02) — Issue #1806 correction
+- **Correction pass**: Added a dated SUPERSEDED banner (matching DD-WORKFLOW-010's style) above the
+  existing Feb-2026 DD-WORKFLOW-016 correction note, clarifying that discovery/scoring ownership has
+  moved a second time — from Data Storage (DD-WORKFLOW-016) to an in-process KA cache
+  (DD-WORKFLOW-019) — and that the standalone Embedding Service and Python HolmesGPT API described in
+  this document's body were never built in that form. Verified via grep: no `pgvector`/embedding
+  reference remains in `internal/kubernautagent/workflowcatalog/`. No body content removed; retained
+  below as historical reference only.
 
 ### Version 3.3 (2025-11-30)
 - **BREAKING**: Standardized all filter field names to **snake_case** for consistency

--- a/docs/architecture/decisions/DD-WORKFLOW-004-deterministic-query-construction.md
+++ b/docs/architecture/decisions/DD-WORKFLOW-004-deterministic-query-construction.md
@@ -1,9 +1,32 @@
 # DD-WORKFLOW-004: Deterministic Query Construction for Workflow Search
 
 **Date**: November 22, 2025
-**Status**: ✅ **APPROVED**
-**Confidence**: 98%
+**Status**: 🗄️ **SUPERSEDED** — see note below
+**Confidence**: 98% (original assessment of the now-superseded design)
 **Purpose**: Define the query construction strategy for workflow catalog search - deterministic vs. LLM-based approach.
+
+> **SUPERSEDED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: This
+> Nov 2025 decision addressed how to build a free-text `query` string (e.g. `"OOMKilled critical memory
+> leak java heap"`) for a Data Storage `POST /api/v1/workflows/search` **pgvector semantic-search**
+> endpoint — deterministic string formatting (this doc's Option B) vs. a second LLM call (Option A). That
+> entire premise never shipped. Per the current, verified architecture
+> ([DD-WORKFLOW-016](DD-WORKFLOW-016-action-type-workflow-indexing.md),
+> [DD-WORKFLOW-017](DD-WORKFLOW-017-workflow-lifecycle-component-interactions.md),
+> [DD-WORKFLOW-019](DD-WORKFLOW-019-ka-owned-workflow-discovery.md)), there is no free-text query to
+> construct — deterministically or via LLM — at all: Kubernaut Agent (KA) discovers workflows through a
+> three-step protocol (`list_available_actions` -> `list_workflows` -> `get_workflow`) that passes the
+> already-structured signal-context fields (`severity`, `component`, `environment`, `priority`,
+> `custom_labels`, `detected_labels`) directly as exact-match/hard filters — no query string, no
+> embedding generation, and no pgvector similarity search exist anywhere in the current discovery path
+> (confirmed via grep: zero `pgvector`/embedding references in `internal/kubernautagent/workflowcatalog/`).
+> The LLM instead reads rendered, human-readable action-type and workflow descriptions across the three
+> steps and reasons about the best fit directly — replacing "which query text produces the best semantic
+> match" with "which cataloged workflow's description best fits the RCA". The Python
+> `construct_workflow_search_query()` / Go `QueryBuilder` code below, and the "Next Steps" implementing
+> them, were never built and are obsolete. This document is retained for historical context (the
+> underlying "avoid a second LLM call when the first call's output is already sufficient" reasoning
+> remains a valid general engineering principle) — do not use it to understand the current discovery
+> mechanism.
 
 ---
 
@@ -569,6 +592,7 @@ else:
 
 | Version | Date | Changes |
 |---------|------|---------|
+| 1.1 | 2026-08-02 | **[Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806) correction**: Marked SUPERSEDED. The pgvector semantic-search `query`-string premise this doc addresses never shipped; the real discovery protocol (DD-WORKFLOW-016/017/019) uses structured filter parameters with no query construction step at all. No body content removed; retained as historical reference. |
 | 1.0 | 2025-11-22 | Initial version: Deterministic query construction decision |
 
 ---

--- a/docs/architecture/decisions/DD-WORKFLOW-008-version-roadmap.md
+++ b/docs/architecture/decisions/DD-WORKFLOW-008-version-roadmap.md
@@ -1,8 +1,21 @@
 # DD-WORKFLOW-008: Workflow Feature Roadmap
 
 **Date**: 2025-11-15
-**Status**: Planning
+**Status**: Planning (historical — see [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806) note below)
 **Related**: DD-WORKFLOW-012 (Workflow Immutability)
+
+> **PARTIAL CORRECTION (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**:
+> This is a Nov-2025 forward-looking roadmap; treat version-by-version claims accordingly. The v1.0
+> baseline's "semantic search REST API (`GET /api/v1/playbooks/search`)" and pgvector architecture were
+> later built as described here, then fully retired by [DD-WORKFLOW-018](DD-WORKFLOW-018-etcd-single-source-of-truth.md)/[DD-WORKFLOW-019](DD-WORKFLOW-019-ka-owned-workflow-discovery.md)
+> — the catalog is now etcd-backed (`RemediationWorkflow`/`ActionType` CRDs) with label-based, non-semantic
+> discovery owned in-process by Kubernaut Agent (KA), not a Data Storage REST search endpoint. The v1.1
+> "CRD-based management" vision was realized, but via a different mechanism than described here (a
+> `RemediationWorkflow` CRD + AuthWebhook admission bridge, per [DD-WORKFLOW-017](DD-WORKFLOW-017-workflow-lifecycle-component-interactions.md)/[ADR-058](ADR-058-webhook-driven-workflow-registration.md),
+> not a standalone "Workflow Registry Controller" reconciling CRDs against a database). The v2.0
+> "HolmesGPT Replacement Evaluation" question is now **RESOLVED** — see the inline note on that section
+> below. This document is retained as a historical planning record; do not use the v1.0/v1.1 architecture
+> descriptions to understand the current system.
 
 ---
 
@@ -125,11 +138,18 @@
 
 #### Strategic Evaluations Required
 
-**1. HolmesGPT Replacement Evaluation** 🔍 **REQUIRES DETAILED ANALYSIS**
+**1. HolmesGPT Replacement Evaluation** 🔍 **REQUIRES DETAILED ANALYSIS** — ✅ **RESOLVED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**
+> **Resolution**: This "build vs. continue with HolmesGPT" question was decided and implemented. See
+> [DD-KA-019](DD-KA-019-go-rewrite-design/DD-KA-019-go-rewrite-design.md) (approved 2026-03-04): HolmesGPT
+> was replaced with a Kubernaut-owned Go rewrite, **Kubernaut Agent (KA)**, isolating the LLM framework
+> behind a small adapter interface (~60 LOC) so Kubernaut owns the agentic loop, tool execution, and LLM
+> providers directly, and eliminating shell-based tool execution (`subprocess.run(shell=True)`) entirely.
+> The analysis items below (compatibility risk, maintenance burden, migration path) were the actual inputs
+> to that decision — retained here for historical record, not as an open question.
 - **Problem**: HolmesGPT not designed as REST API service, causing dependency risks
 - **Proposal**: Replace with custom kubernaut agent
 - **Timeline**: After v1.1 release
-- **Decision Needed**: Build vs. continue with HolmesGPT
+- **Decision Needed**: ~~Build vs. continue with HolmesGPT~~ Resolved: built (DD-KA-019)
 - **Analysis Required**:
   - Compatibility risks with HolmesGPT SDK evolution
   - Maintenance burden of forked/wrapped HolmesGPT
@@ -137,7 +157,14 @@
   - Migration path from v1.x to v2.0
   - Impact on existing integrations
 
-**2. Toolset Integration Strategy Evaluation** 🔍 **REQUIRES DETAILED ANALYSIS**
+**2. Toolset Integration Strategy Evaluation** 🔍 **REQUIRES DETAILED ANALYSIS** — largely resolved, see note
+> **Note (2026-08-02, #1806)**: Also decided, per [DD-KA-019-002](DD-KA-019-go-rewrite-design/DD-KA-019-002-toolset-implementation.md)
+> (approved 2026-03-04): Kubernetes and Prometheus toolsets use Go bindings called directly in-process
+> (`client-go`, `net/http`), i.e. closer to this section's "Option A" than "Option B" for those two
+> toolsets specifically — not a blanket resolution of every tool integration decision (DD-KA-019-002 v1.1
+> also documents an MCP Tool Provider skeleton for other use cases). Not verified against every toolset
+> added since; treat the specific comparison items below as historical input rather than an open
+> question for K8s/Prometheus.
 - **Problem**: Two approaches for exposing tools to LLM
   - **Option A**: Embed tools directly in container (e.g., kubectl in kubernaut-agent image)
   - **Option B**: Expose tools via MCP (current MVP approach)

--- a/docs/architecture/decisions/DD-WORKFLOW-013-scoring-field-population.md
+++ b/docs/architecture/decisions/DD-WORKFLOW-013-scoring-field-population.md
@@ -1,10 +1,30 @@
 # DD-WORKFLOW-013: Scoring Field Population and Data Flow
 
 **Date**: 2025-11-27
-**Status**: ✅ **APPROVED**
-**Version**: 1.0
+**Status**: ⚠️ **PARTIALLY SUPERSEDED** — see correction notice below
+**Version**: 1.1
 **Authority**: Technical Reference
-**Related**: DD-WORKFLOW-004 (Hybrid Scoring), DD-WORKFLOW-012 (Immutability), DD-WORKFLOW-002 (MCP Architecture)
+**Related**: DD-WORKFLOW-004 (Hybrid Scoring — superseded), DD-WORKFLOW-012 (Immutability), DD-WORKFLOW-002 (MCP Architecture — superseded), [DD-WORKFLOW-016](DD-WORKFLOW-016-action-type-workflow-indexing.md) (current scoring authority), [DD-WORKFLOW-019](DD-WORKFLOW-019-ka-owned-workflow-discovery.md) (current ownership)
+
+---
+
+## 📋 Changelog
+
+| Version | Date | Author | Changes |
+|---------|------|--------|---------|
+| 1.1 | 2026-08-02 | Architecture Team (#1806 correction) | **Partial correction pass**: this is not a blanket-supersede case. The scoring *concept* (a numeric field used internally for sorting, kept out of the LLM's view) survives; the specific transport ("HolmesGPT API → Data Storage Service" as two separate network hops) and the specific formula (pgvector `base_similarity` + SQL-computed `label_boost`/`label_penalty`) do not. See "⚠️ Reading This Document" below for the full breakdown, verified against `internal/kubernautagent/workflowcatalog/cache_filter.go` and `pkg/datastorage/models/workflow.go`. | [#1806](https://github.com/jordigilh/kubernaut/issues/1806) |
+| 1.0 | 2025-11-27 | Architecture Team | Initial version. | — |
+
+---
+
+## ⚠️ Reading This Document (2026-08-02 Correction Notice)
+
+This document was written against the Nov-2025 Python HolmesGPT-API / PostgreSQL-pgvector architecture. Treat it accordingly:
+
+- **What is still current**: `final_score` still exists, is still computed once per discovery call, still drives `ORDER BY final_score DESC` (now a Go in-memory sort, not SQL), and is still stripped before rendering results to the LLM — the general "keep a scoring breakdown internally, hide the score itself from the LLM" pattern this document argues for is directionally correct. Per [DD-WORKFLOW-016](DD-WORKFLOW-016-action-type-workflow-indexing.md) (`final_score -- Internal: used by KA for sorting, stripped before LLM rendering`), the LLM today sees **zero** score fields at all (not even a minimal `confidence`) — the current design goes further than this document's "PROPOSED (minimal): only `confidence`" conclusion, stripping scores entirely rather than reducing them to one field.
+- **What is superseded (actor/transport)**: Step 1/2 below describe "LLM Query → HolmesGPT API → Data Storage Service" as two separate Python/Go services connected over HTTP (`kubernaut-agent/src/toolsets/workflow_catalog.py` calling `POST http://data-storage:8080/api/v1/workflows/search`). Per [DD-WORKFLOW-019](DD-WORKFLOW-019-ka-owned-workflow-discovery.md), that Python file and that Data Storage REST search endpoint are both retired dead code — discovery is a single in-process call from Kubernaut Agent (KA, Go) into its own informer-backed cache (`internal/kubernautagent/workflowcatalog/discovery.go`'s `ListWorkflowsByActionType` / `discovery_cache.go`'s `filterAndScoreCachedWorkflows`), with no second service and no network hop for this step.
+- **What is superseded (formula)**: Steps 3-4 describe a PostgreSQL SQL query computing `base_similarity` from pgvector cosine similarity (`1 - (embedding <=> $1)`), plus SQL `CASE`-statement `label_boost`/`label_penalty`. There is no embedding and no `base_similarity` field anywhere in the current implementation (confirmed via grep: zero `pgvector`/embedding references in `internal/kubernautagent/workflowcatalog/`). The real, current formula lives in `internal/kubernautagent/workflowcatalog/cache_filter.go`'s `finalScore(detectedBoost, customBoost, penalty)`: `(5.0 + detectedBoost + customBoost - penalty) / 10.0`, capped at 1.0 — a label-match/conflict scoring model with a flat 0.5 baseline (no semantic component at all), computed in Go over the informer cache rather than in SQL.
+- **What partially survives as a shared type**: `pkg/datastorage/models/workflow.go`'s `WorkflowSearchResult` struct (fields `Confidence`, `LabelBoost`, `LabelPenalty`, `FinalScore`, `Rank`, ~lines 355-420) still exists and is explicitly annotated in-code as implementing **"DD-WORKFLOW-004 v1.5 (Label-Only Scoring with Wildcard Weighting)"** — i.e. a *label-only, no-embedding* scoring model. This confirms DD-WORKFLOW-004 itself was silently revised past v1.0 (semantic pgvector query construction, its own document text never updated to reflect this) all the way to a label-only v1.5 design before KA took ownership; this document's Step 3/4 SQL, however, reflects neither v1.0 nor v1.5 exactly.
 
 ---
 
@@ -286,7 +306,7 @@ LLM Response (Minimal)
 
 ---
 
-**Status**: ✅ **APPROVED**
-**Confidence**: 95%
-**Implementation**: Keep all fields in Go, expose only `confidence` to LLM
+**Status**: ⚠️ **PARTIALLY SUPERSEDED** (2026-08-02, #1806) — the "keep detail internal, hide score from LLM" principle holds; the transport (single in-process KA call, not HolmesGPT-API-to-Data-Storage HTTP) and formula (label-only, no pgvector `base_similarity`) do not. See correction notice near the top of this document.
+**Confidence**: 95% (original, pre-correction assessment)
+**Implementation (current)**: `internal/kubernautagent/workflowcatalog/cache_filter.go`'s `finalScore` computes the score in Go over the informer cache; the LLM sees no score field at all (not even `confidence`) per DD-WORKFLOW-016.
 


### PR DESCRIPTION
## Summary

Group I of the HAPI/HolmesGPT documentation-accuracy sweep for #1806: workflow catalog / MCP discovery architecture docs that described the standalone "Embedding Service (MCP Server)" + pgvector semantic-search design as current, when it was actually superseded — first by [DD-WORKFLOW-016](https://github.com/jordigilh/kubernaut/blob/main/docs/architecture/decisions/DD-WORKFLOW-016-action-type-workflow-indexing.md)'s three-step discovery protocol, then by [DD-WORKFLOW-019](https://github.com/jordigilh/kubernaut/blob/main/docs/architecture/decisions/DD-WORKFLOW-019-ka-owned-workflow-discovery.md)'s KA-owned, in-process, informer-cache discovery (no separate MCP embedding service, no Data Storage search endpoint). Each fix below preserves the original document body as historical reference below a correction banner/note — nothing was deleted.

## Changes

- **`DD-WORKFLOW-002-MCP-WORKFLOW-CATALOG-ARCHITECTURE.md`**: this doc already had a Feb-2026 "SUPERSEDED by DD-WORKFLOW-016" banner, but that banner itself was stale (DD-WORKFLOW-016's DS-hosted ownership model was superseded again by DD-WORKFLOW-019). Added a new dated SUPERSEDED banner (matching `DD-WORKFLOW-010`'s style) above it, pointing to DD-WORKFLOW-019/017 as current, and added a changelog entry.
- **`DD-WORKFLOW-004-deterministic-query-construction.md`**: added a full SUPERSEDED banner. The pgvector free-text `query` string this doc builds (deterministic-vs-LLM debate) was never shipped — the real three-step protocol passes structured signal-context filters directly, with no query-construction step at all (verified: zero `pgvector`/embedding references remain in `internal/kubernautagent/workflowcatalog/`).
- **`DD-WORKFLOW-008-version-roadmap.md`**: the "HolmesGPT Replacement Evaluation 🔍 REQUIRES DETAILED ANALYSIS" section presented the Go-rewrite decision as open. Marked **RESOLVED** inline, pointing to [DD-KA-019](https://github.com/jordigilh/kubernaut/blob/main/docs/architecture/decisions/DD-KA-019-go-rewrite-design/DD-KA-019-go-rewrite-design.md) (approved 2026-03-04). Also noted the adjacent "Toolset Integration Strategy Evaluation" is largely resolved per DD-KA-019-002 (K8s/Prometheus tools use direct Go bindings), and added a roadmap-wide historical caveat for the v1.0 pgvector/semantic-search baseline and the v1.1 CRD-registration mechanism (both later built differently than described here).
- **`DD-WORKFLOW-013-scoring-field-population.md`**: **partial correction**, not a blanket supersede (DD-EFFECTIVENESS-001 style). The "compute a score internally, hide it from the LLM" principle survives (and the current design goes further — the LLM sees *zero* score fields, not even `confidence`). What's dead: the actor/transport (`HolmesGPT API -> Data Storage Service` as two HTTP-connected services) and the formula (pgvector `base_similarity` + SQL `CASE`-statement boost/penalty). Verified the real, current formula against `internal/kubernautagent/workflowcatalog/cache_filter.go`'s `finalScore()` — `(5.0 + detectedBoost + customBoost - penalty) / 10.0`, a label-only model with no semantic component — and confirmed `pkg/datastorage/models/workflow.go`'s `WorkflowSearchResult` struct still exists, annotated in-code as "DD-WORKFLOW-004 v1.5 (Label-Only Scoring)".
- **`ADR-055-ADDENDUM-001-remediation-target-rename.md`**: added a brief "Historical Context" note (not a full banner) — Layer 1 (Python `prompt_builder.py`/`result_parser.py`/etc., the "HolmesGPT OAS client") is dead post-Go-rewrite ([DD-KA-019](https://github.com/jordigilh/kubernaut/blob/main/docs/architecture/decisions/DD-KA-019-go-rewrite-design/DD-KA-019-go-rewrite-design.md)); Layer 2 (Go CRD type, Rego field rename) verified still live today (`api/aianalysis/v1alpha1/aianalysis_types.go:630`, `pkg/aianalysis/rego/evaluator.go:115,286`).
- **`ADR-021-workflow-dependency-cycle-detection.md`**: this doc already had a narrow STALE caveat on just the opening section, while the rest of the body continued describing the dead architecture in the present tense. Extended it into a full-document SUPERSEDED/NEVER IMPLEMENTED banner after confirming via repo-wide grep of `pkg/` and `internal/` that `dependency_validator.go`, `ValidateDependencyGraph`, `GetExecutionOrder`, and `processHolmesGPTRecommendations` were never built in any form — the per-incident dynamic dependency-graph model was superseded before implementation by the predefined workflow-catalog approach.

## Test plan

- [x] Docs-only change; no Go files touched, `go build ./...` unaffected.
- [x] Every factual correction verified against real source: `internal/kubernautagent/workflowcatalog/discovery.go`, `discovery_cache.go`, `cache_filter.go` (scoring formula, discovery ownership); `pkg/datastorage/models/workflow.go` (still-live `WorkflowSearchResult` fields); `api/aianalysis/v1alpha1/aianalysis_types.go` and `pkg/aianalysis/rego/evaluator.go` (`RemediationTarget` still live); repo-wide grep of `pkg/`/`internal/` confirming zero hits for `dependency_validator.go`/`ValidateDependencyGraph`/`processHolmesGPTRecommendations` and zero `pgvector`/embedding references in the KA discovery path.
- [x] Confirmed no body content was deleted — all six files retain their original text below the new/updated correction banners.

Part of #1806 (Group I: workflow catalog / MCP discovery architecture).

Made with [Cursor](https://cursor.com)