### PR TITLE
docs(1806): Group G — fix compliance-critical audit doc contradictions

### DIFF
--- a/docs/architecture/decisions/DD-AUDIT-001-V1-V2-VERSIONING-STRATEGY.md
+++ b/docs/architecture/decisions/DD-AUDIT-001-V1-V2-VERSIONING-STRATEGY.md
@@ -54,7 +54,7 @@ After 24h:
 func (r *AIAnalysisReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
     // 1. Update CRD status (real-time operator visibility)
     aiAnalysis.Status.Phase = "Completed"
-    aiAnalysis.Status.HolmesGPTResults = results
+    aiAnalysis.Status.AIAgentResults = results // illustrative; see SelectedWorkflow/RootCauseAnalysis in api/aianalysis/v1alpha1
     aiAnalysis.Status.ApprovalDecision = "approved"
     if err := r.Status().Update(ctx, aiAnalysis); err != nil {
         return ctrl.Result{}, err

--- a/docs/architecture/decisions/DD-AUDIT-003-service-audit-trace-requirements.md
+++ b/docs/architecture/decisions/DD-AUDIT-003-service-audit-trace-requirements.md
@@ -66,7 +66,7 @@
 - **Note**: Typed OpenAPI payloads deferred to follow-up DataStorage schema update; events use untyped `event_data` JSONB fallback
 
 **Recent Changes** (v1.8 - March 25, 2026):
-- **HolmesGPT API Service**: Added 2 Phase 2 enrichment audit events per Issue #533:
+- **Kubernaut Agent (KA) Service**: Added 2 Phase 2 enrichment audit events per Issue #533:
   - `aiagent.enrichment.completed` — Phase 2 enrichment succeeded (root_owner resolved, labels detected, history fetched)
   - `aiagent.enrichment.failed` — Phase 2 enrichment failed after retry exhaustion (captures reason, detail, affected_resource)
 - **Authority**: BR-AUDIT-005 v2.0 (SOC2 CC8.1), #533, #529 (three-phase RCA architecture)
@@ -213,12 +213,21 @@ Kubernaut consists of 12 microservices with different responsibilities. Not all 
 
 ### **Service Inventory**
 
+> **⚠️ HISTORICAL SNAPSHOT (corrected [#1806](https://github.com/jordigilh/kubernaut/issues/1806))**:
+> This inventory and the "Decision" breakdown below are the **original v1.0 (Nov 2025) snapshot** —
+> "HolmesGPT API Service" (item 5) refers to the pre-Go-rewrite Python service, and the "12 services"
+> / "9 out of 12" counts predate KA's P0 reclassification, Fleet Metadata Cache, API Frontend, and
+> other services added since. **For the current, authoritative 14-service breakdown, see the
+> [Summary Table](#-summary-table) below** — do not use this section's counts. Kept here only as a
+> record of the original decision rationale (criteria weighting, industry-standard framing), which
+> is still broadly valid even though the specific service list is outdated.
+
 **Stateless Services** (8):
 1. Gateway Service
 2. Data Storage Service
 3. Auth Webhook Service
 4. Context API Service
-5. HolmesGPT API Service
+5. HolmesGPT API Service (pre-rewrite; see Kubernaut Agent (KA), now P0 MUST — §11 below)
 6. Dynamic Toolset Service
 7. Notification Service
 8. Effectiveness Monitor Service
@@ -231,14 +240,14 @@ Kubernaut consists of 12 microservices with different responsibilities. Not all 
 
 ---
 
-## ✅ **Decision**
+## ✅ **Decision** (Historical v1.0 Snapshot — see note above)
 
-**APPROVED**: **9 out of 12 services** generate audit traces
+**APPROVED** (as of v1.0, Nov 2025): **9 out of 12 services** generate audit traces
 
-**Breakdown**:
+**Breakdown** (v1.0, historical — superseded by the current 14-service Summary Table below):
 - ✅ **7 services MUST** (P0): Gateway, AI Analysis, Remediation Execution, Notification, Data Storage, Auth Webhook, Effectiveness Monitor
 - ✅ **2 services SHOULD** (P1): Signal Processing, Remediation Orchestrator
-- ⚠️ **3 services NO audit**: Context API, HolmesGPT API, Dynamic Toolset
+- ⚠️ **2 services NO audit** (v1.0): Context API, Dynamic Toolset — HolmesGPT API was also NO-audit at v1.0 but is corrected to P0 MUST as of v1.3 (Kubernaut Agent); see §11 below
 
 **Rationale**:
 1. **Compliance Alignment**: P0 services meet SOC 2, ISO 27001, GDPR requirements
@@ -250,7 +259,7 @@ Kubernaut consists of 12 microservices with different responsibilities. Not all 
 
 ## 📊 **Service-by-Service Analysis**
 
-### **P0: MUST Generate Audit Traces (7 Services)**
+### **P0: MUST Generate Audit Traces (7 services listed below, #1-7; Kubernaut Agent (KA) is also P0 MUST but is listed as #11 further down for numbering-stability reasons — see correction note there)**
 
 ---
 
@@ -281,31 +290,44 @@ Kubernaut consists of 12 microservices with different responsibilities. Not all 
 **Rationale**:
 - ✅ **Business-Critical**: AI recommendations drive remediation actions
 - ✅ **Compliance**: AI decision-making requires audit trail (AI Act, SOC 2)
-- ✅ **External Interactions**: Calls HolmesGPT API (external LLM)
+- ✅ **External Interactions**: Calls Kubernaut Agent (KA), which in turn calls the external LLM
 - ✅ **State Changes**: Updates `AIAnalysis` CRD with recommendations
 - ✅ **Debugging Value**: Critical for understanding AI decisions
 - ✅ **Cost Tracking**: LLM API costs need monitoring
 
 **Audit Events**:
 
+> **⚠️ CORRECTED (2026-08-02, [#1806](https://github.com/jordigilh/kubernaut/issues/1806))**: The
+> hyphenated `ai-analysis.*` event types below (an early, pre-implementation naming draft) do not
+> exist anywhere in the codebase — verified via `grep -rn "ai-analysis\." pkg/aianalysis/`, zero
+> matches. The real event types are the unhyphenated `aianalysis.*` ones, defined in
+> `pkg/aianalysis/audit/audit.go`. Table replaced with the real event set below.
+
 | Event Type | Description | Priority |
 |------------|-------------|----------|
-| `ai-analysis.investigation.started` | AI investigation started | P0 |
-| `ai-analysis.llm.request_sent` | LLM API request sent | P0 |
-| `ai-analysis.llm.response_received` | LLM API response received | P0 |
-| `ai-analysis.recommendation.generated` | Remediation recommendation generated | P0 |
-| `ai-analysis.crd.updated` | AIAnalysis CRD updated | P0 |
-| `ai-analysis.llm.request_failed` | LLM API request failed | P0 |
-| `aianalysis.analysis.completed` | AI analysis completed with full Holmes response (SOC2) | **P0** |
-| `aianalysis.analysis.failed` | AI analysis failed (Holmes API timeout, invalid response, etc.) | **P0** |
+| `aianalysis.analysis.completed` | AI analysis completed with full KA response (SOC2 reconstruction, DD-AUDIT-004) | **P0** |
+| `aianalysis.analysis.failed` | AI analysis failed (KA timeout, invalid response, etc.) | **P0** |
+| `aianalysis.phase.transition` | AIAnalysis phase state machine transition | P0 |
+| `aianalysis.aiagent.call` | Call to Kubernaut Agent (KA) recorded (endpoint, HTTP status, duration) | P0 |
+| `aianalysis.aiagent.submit` / `.result` / `.session_lost` | Async submit/poll/result session lifecycle with KA (BR-AA-HAPI-064) | P0 |
+| `aianalysis.approval.decision` | Manual approval decision recorded | P0 |
+| `aianalysis.rego.evaluation` | Rego policy evaluation result | P0 |
+| `aianalysis.error.occurred` | Structured error event | P0 |
 
 **SOC2 Compliance Event** (v1.3 - January 2026):
 - **Event**: `aianalysis.analysis.completed`
-- **Purpose**: Single event capturing complete `provider_data` for RR reconstruction (DD-AUDIT-004)
-- **Distinction**: Complements existing granular `ai-analysis.*` events for operational visibility
-- **Naming**: No hyphen (`aianalysis` not `ai-analysis`) to match SOC2 test plan convention
+- **Purpose**: Single event capturing complete analysis outcome for RR reconstruction (DD-AUDIT-004)
+- **Distinction**: Complements the other granular `aianalysis.*` events above for operational visibility
+- **Naming**: No hyphen (`aianalysis`) to match SOC2 test plan convention
 - **Required By**: BR-AUDIT-005 v2.0 (100% RR CRD reconstruction accuracy)
-- **Event Data Fields**:
+- **Event Data Fields**: real payload is `AIAnalysisAuditPayload` / `AnalysisCompletePayload`
+  (`pkg/aianalysis/audit/audit.go`, DD-AUDIT-004) — fields are `Phase`, `ApprovalRequired`,
+  `ApprovalReason`, `DegradedMode`, `WarningsCount`, `Confidence`, `WorkflowID`,
+  `TargetInOwnerChain`, `Reason`, `SubReason`. The illustrative JSON below is **stale**
+  (corrected [#1806](https://github.com/jordigilh/kubernaut/issues/1806)): there is no
+  `provider_data`/`provider` wrapper or `analysis_id` field in the real payload — that shape
+  predates the actual DD-AUDIT-004 V2.0 implementation. Kept only as a historical illustration
+  of the original design intent, not the real schema:
   ```json
   {
     "provider_data": {
@@ -543,7 +565,7 @@ Kubernaut consists of 12 microservices with different responsibilities. Not all 
 
 ---
 
-### **NO Audit Traces Needed (3 Services)**
+### **NO Audit Traces Needed (3 of the 4 services below — #11 Kubernaut Agent is P0 MUST, corrected [#1806](https://github.com/jordigilh/kubernaut/issues/1806); kept in this section only to preserve stable numbering with the Related Decisions/cross-links below)**
 
 ---
 
@@ -629,27 +651,42 @@ context_api:
 
 ---
 
-#### 11. HolmesGPT API Service ❌
+#### 11. Kubernaut Agent (KA) Service ✅
 
-**Status**: ⚠️ **NO** audit traces needed (delegated to AI Analysis Controller)
+> **⚠️ CORRECTED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: This
+> subsection previously described the pre-Go-rewrite HolmesGPT API as a thin, stateless **proxy** with
+> **NO audit traces needed**, on the theory that the caller (AI Analysis Controller) was solely
+> responsible for auditing LLM interactions. That was already contradicted elsewhere in this very
+> document — the Summary Table (below) and the "[v1.3 Update: Kubernaut Agent Audit
+> Traces](#v13-update-kubernaut-agent-audit-traces)" section both correctly classify this service as
+> **P0 MUST**, and the "[KA Narrative vs Table Inconsistency](#ka-narrative-vs-table-inconsistency)"
+> note further down only checked the narrative-vs-table wording, not this subsection's stronger
+> "NO audit" verdict — so the contradiction survived multiple correction passes. Verified against
+> `internal/kubernautagent/audit/` (`emitter.go`, `ds_buffered_store.go`): KA is **not** a passive
+> proxy — it directly generates and buffers its own `aiagent.*` audit events (LLM requests/responses,
+> tool calls, workflow-validation attempts, response completion/failure, enrichment) and ships them to
+> Data Storage via `BufferedDSAuditStore`. The rationale and "Industry Precedent" framing below is
+> retained only as a historical record of the pre-rewrite design; it no longer reflects reality and
+> MUST NOT be used to justify skipping audit review for this service.
 
-**Rationale**:
-- ❌ **Wrapper Service**: Thin wrapper around HolmesGPT SDK
-- ❌ **No State Changes**: Only proxies requests to external LLM
-- ❌ **Audit Responsibility**: AI Analysis Controller audits LLM interactions
-- ✅ **Alternative**: Application logs + metrics sufficient
+**Status**: ✅ **MUST** audit traces (self-generated, not delegated)
 
-**Why No Audit Traces**:
-- HolmesGPT API is a **proxy** (like an API gateway)
-- Audit responsibility belongs to the **caller** (AI Analysis Controller)
-- Industry standard: Proxy services don't duplicate audit traces
+**Rationale** (current, v1.3+):
+- ✅ **Direct Emitter**: KA generates its own `aiagent.*` audit events for every LLM interaction, tool call, and workflow-selection validation attempt (`internal/kubernautagent/audit/emitter.go`)
+- ✅ **Compliance-Critical**: LLM investigation outcomes and workflow-selection decisions are exactly the kind of AI-driven decision audit trail SOC2 CC7.2 and BR-AUDIT-005 require
+- ✅ **Async, Non-Blocking**: Uses `BufferedDSAuditStore` (`internal/kubernautagent/audit/ds_buffered_store.go`) to ship events to Data Storage without blocking the investigation critical path
+- See the [`AUDIT_EVENT_CATALOG.md`](../../services/stateless/kubernaut-agent/security/AUDIT_EVENT_CATALOG.md) for the complete, current, actively-maintained event catalog (37 event types as of v2.5)
 
-**Alternative Observability**:
+**Historical Rationale (pre-v1.3, HolmesGPT API era — no longer accurate, kept for context only)**:
+- ~~Wrapper Service: Thin wrapper around HolmesGPT SDK~~
+- ~~No State Changes: Only proxies requests to external LLM~~
+- ~~Audit Responsibility: AI Analysis Controller audits LLM interactions~~
+- ~~HolmesGPT API is a proxy (like an API gateway); audit responsibility belongs to the caller~~
+
+**Alternative Observability** (still valid, in addition to audit events):
 - ✅ Application logs (request/response logging)
-- ✅ Prometheus metrics (LLM latency, error rate)
+- ✅ Prometheus metrics (LLM latency, error rate — see `PROMETHEUS_ALERTRULES.md`)
 - ✅ OpenTelemetry traces (distributed tracing)
-
-**Industry Precedent**: AWS API Gateway (not audited), Nginx reverse proxy (not audited)
 
 ---
 
@@ -658,9 +695,9 @@ context_api:
 **Status**: ⚠️ **NO** audit traces needed
 
 **Rationale**:
-- ❌ **Configuration Service**: Only serves HolmesGPT toolset configuration
+- ❌ **Configuration Service**: Only serves toolset configuration to Kubernaut Agent (KA)
 - ❌ **Read-Only**: No state changes (configuration is static)
-- ❌ **No External Interactions**: Internal service (called by HolmesGPT API)
+- ❌ **No External Interactions**: Internal service (called by Kubernaut Agent)
 - ❌ **No Compliance Requirements**: Configuration reads don't require audit trail
 - ✅ **Alternative**: Application logs sufficient
 
@@ -719,7 +756,7 @@ context_api:
 | **Signal Processing Controller** | ✅ **SHOULD** | P1 | Operational visibility (enrichment) |
 | **Remediation Orchestrator Controller** | ✅ **SHOULD** | P1 | Operational visibility (coordination) |
 | **Context API Service** | ❌ **NO** | N/A | Read-only, no state changes |
-| **HolmesGPT API Service** | ✅ **MUST** | P0 | LLM interactions and investigation outcomes (DD-AUDIT-005, BR-AUDIT-005). Emits `aiagent.*` events: `aiagent.llm.request`, `aiagent.llm.response`, `aiagent.llm.tool_call`, `aiagent.workflow.validation_attempt`, `aiagent.response.complete`, `aiagent.response.failed`, `aiagent.enrichment.completed`, `aiagent.enrichment.failed` |
+| **Kubernaut Agent (KA) Service** (renamed from HolmesGPT API, v1.3) | ✅ **MUST** | P0 | LLM interactions and investigation outcomes (DD-AUDIT-005, BR-AUDIT-005). Emits `aiagent.*` events: `aiagent.llm.request`, `aiagent.llm.response`, `aiagent.llm.tool_call`, `aiagent.workflow.validation_attempt`, `aiagent.response.complete`, `aiagent.response.failed`, `aiagent.enrichment.completed`, `aiagent.enrichment.failed` |
 | **Dynamic Toolset Service** | ❌ **NO** | N/A | Configuration, read-only |
 | **Fleet Metadata Cache Service** | ❌ **NO** | N/A | Read-only scope cache, not a chain participant (Issue #54, ADR-068) |
 
@@ -729,7 +766,16 @@ context_api:
 
 ## 🎯 **Implementation Priority**
 
-### Phase 1: P0 Services (MUST) - 8 Services
+> **⚠️ HISTORICAL ROADMAP (corrected [#1806](https://github.com/jordigilh/kubernaut/issues/1806))**:
+> This "Implementation Priority" phasing predates Kubernaut Agent (KA)'s P0 reclassification (v1.3)
+> and Fleet Metadata Cache's addition (v2.3) — Phase 1 below is missing KA (should be 9 services, not
+> 8) and Phase 3 wrongly lists "HolmesGPT API Service" among the no-audit services (corrected inline
+> below); FMC isn't listed in either phase (it's NO-audit per the Summary Table's §13, added after
+> this roadmap was written). All audit implementation work described here already shipped — this
+> section is a historical rollout plan, not a current TODO list. See the Summary Table above for the
+> current, authoritative per-service MUST/SHOULD/NO breakdown.
+
+### Phase 1: P0 Services (MUST) - 8 Services (historical; now 9 with Kubernaut Agent (KA))
 
 **Timeline**: Sprint 1-2 (2 weeks)
 
@@ -768,12 +814,13 @@ context_api:
 
 ---
 
-### Phase 3: No Audit Traces - 3 Services
+### Phase 3: No Audit Traces - 2 Services (historical: originally 3, HolmesGPT API moved to Phase 1 as Kubernaut Agent (KA) at v1.3)
 
 **Services**:
 1. Context API Service (application logs only)
-2. HolmesGPT API Service (application logs only)
-3. Dynamic Toolset Service (application logs only)
+2. Dynamic Toolset Service (application logs only)
+
+(Fleet Metadata Cache is also NO-audit, added v2.3 — see Summary Table §13; not listed here as this roadmap predates it.)
 
 **Effort**: 0 hours (no audit implementation needed)
 
@@ -833,7 +880,7 @@ context_api:
 | Kubernaut Service | Industry Equivalent | Audited? | Rationale |
 |-------------------|---------------------|----------|-----------|
 | Context API Service | AWS S3 GET | ❌ No | Read-only operations not audited |
-| HolmesGPT API Service | AWS API Gateway | ✅ Yes | Per DD-AUDIT-005: emits `aiagent.*` events for LLM interactions, tool calls, and investigation outcomes (provider perspective). Updated from v1.0 which incorrectly classified HAPI as proxy-only. |
+| Kubernaut Agent (KA) Service (renamed from HolmesGPT API, v1.3) | AWS API Gateway | ✅ Yes | Per DD-AUDIT-005: emits `aiagent.*` events for LLM interactions, tool calls, and investigation outcomes (provider perspective). Updated from v1.0 which incorrectly classified it as proxy-only. |
 | Dynamic Toolset Service | Kubernetes ConfigMap | ❌ No | Configuration reads not audited |
 
 **Key Insight**: Industry standard is to audit **state-changing operations** and **external interactions**, NOT read-only or configuration operations.
@@ -974,7 +1021,9 @@ The reconstruction pipeline (`pkg/datastorage/reconstruction/`) MUST:
 
 ### KA Narrative vs Table Inconsistency
 
-DD-AUDIT-003 v2.0 narrative describes KA as P0 MUST (via the `aiagent` category, v1.3 update). The summary table at Section "Summary Table" correctly lists HolmesGPT API Service as P0 MUST with `aiagent.*` events emitted by KA (per v1.3 clarification). No action needed -- the naming reflects the KA Go rewrite (v1.3).
+DD-AUDIT-003 v2.0 narrative describes KA as P0 MUST (via the `aiagent` category, v1.3 update). The summary table at Section "Summary Table" correctly lists Kubernaut Agent (KA) Service as P0 MUST with `aiagent.*` events emitted by KA (per v1.3 clarification).
+
+**Correction (2026-08-02, [#1806](https://github.com/jordigilh/kubernaut/issues/1806))**: This note's original "No action needed" conclusion only checked the narrative-vs-table wording — it missed that §11 ("HolmesGPT API Service ❌") still had a full "NO audit traces needed" verdict and rationale, directly contradicting the Summary Table it claims to agree with. §11, the Service Inventory / Decision section, the "SOC2 Compliance Event" JSON sample, and the "Implementation Priority" Phase 1/3 roadmap have all now been corrected in place (see their own inline notes). Action **was** needed; it is done as of this pass.
 
 ## API Frontend (AF) Event Catalog
 

--- a/docs/architecture/decisions/DD-AUDIT-005-hybrid-provider-data-capture.md
+++ b/docs/architecture/decisions/DD-AUDIT-005-hybrid-provider-data-capture.md
@@ -2,36 +2,43 @@
 
 **Status**: Approved
 **Created**: January 5, 2026
-**Author**: AI Analysis + HolmesAPI Integration Team
+**Author**: AI Analysis + Kubernaut Agent Integration Team
 **Business Requirement**: BR-AUDIT-005 v2.0 (Gap #4 - AI Provider Data)
 **Related Documents**:
 - [SOC2 Audit Test Plan](../../development/SOC2/SOC2_AUDIT_RR_RECONSTRUCTION_TEST_PLAN.md)
-- [DD-AUDIT-002: Audit Shared Library Design](./DD-AUDIT-002-audit-shared-library.md)
+- [DD-AUDIT-002: Audit Shared Library Design](./DD-AUDIT-002-audit-shared-library-design.md)
 - [DD-AUDIT-003: Service Audit Trace Requirements](./DD-AUDIT-003-service-audit-trace-requirements.md)
+
+> **Note (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: This
+> decision was originally written (Jan 2026) when the provider service was named HolmesGPT API
+> (HAPI). It was renamed **Kubernaut Agent (KA)** in the v1.3 Go rewrite ([#433](https://github.com/jordigilh/kubernaut/issues/433));
+> terminology below has been updated to KA throughout. The decision's substance — hybrid
+> provider (`aiagent.*`) + consumer (`aianalysis.*`) audit events — is unchanged and still
+> current; see the "v1.3 Update" section for what changed in practice.
 
 ---
 
 ## Context
 
-For SOC2 Type II compliance and RemediationRequest (RR) reconstruction, we need to capture complete AI provider response data in audit trails. The AI Analysis service depends on HolmesGPT API (HAPI) for root cause analysis and workflow recommendations.
+For SOC2 Type II compliance and RemediationRequest (RR) reconstruction, we need to capture complete AI provider response data in audit trails. The AI Analysis service depends on Kubernaut Agent (KA) for root cause analysis and workflow recommendations.
 
 **Problem**: Where should the audit event for AI provider data be emitted?
 - **Option A**: AI Analysis Controller only (consumer captures response)
-- **Option B**: HolmesAPI only (provider captures response)
+- **Option B**: Kubernaut Agent (KA) only (provider captures response)
 - **Option C**: BOTH services (hybrid approach)
 
 ---
 
 ## Decision
 
-**We will use a HYBRID approach where BOTH HolmesAPI and AI Analysis Controller emit audit events.**
+**We will use a HYBRID approach where BOTH Kubernaut Agent (KA) and AI Analysis Controller emit audit events.**
 
 ### Event Distribution
 
 | Service | Event Type | Purpose | Content |
 |---------|-----------|---------|---------|
-| **HolmesAPI** | `aiagent.response.complete` | Provider perspective (success) | Full `IncidentResponse` structure |
-| **HolmesAPI** | `aiagent.response.failed` | Provider perspective (failure) | Error message, failure phase, duration (#442, SOC2 CC8.1) |
+| **Kubernaut Agent (KA)** | `aiagent.response.complete` | Provider perspective (success) | Full `IncidentResponse` structure |
+| **Kubernaut Agent (KA)** | `aiagent.response.failed` | Provider perspective (failure) | Error message, failure phase, duration (#442, SOC2 CC8.1) |
 | **AI Analysis** | `aianalysis.analysis.completed` | Consumer perspective | `provider_response_summary` + business context |
 
 ---
@@ -42,7 +49,7 @@ For SOC2 Type II compliance and RemediationRequest (RR) reconstruction, we need 
 
 **SOC2 Principle**: Multiple independent audit sources provide stronger compliance evidence than a single source.
 
-1. **Provider Audit (HAPI)**:
+1. **Provider Audit (KA)**:
    - ✅ Captures response **at the source** (API endpoint)
    - ✅ Complete `IncidentResponse` structure with all fields
    - ✅ Independent of consumer processing
@@ -56,7 +63,7 @@ For SOC2 Type II compliance and RemediationRequest (RR) reconstruction, we need 
 
 ### Single Source of Truth
 
-**HAPI owns the complete API response data** - AA references it by summary.
+**KA owns the complete API response data** - AA references it by summary.
 
 ```sql
 -- Full provider response (authoritative)
@@ -89,24 +96,24 @@ WHERE event_type = 'aianalysis.analysis.completed'
 
 **Cons**:
 - ❌ AA must store full response in CRD status (increases CRD size)
-- ❌ No independent verification of HAPI → AA data transfer
-- ❌ Duplicates HAPI data in AA service
+- ❌ No independent verification of KA → AA data transfer
+- ❌ Duplicates KA data in AA service
 - ❌ Single point of failure for audit capture
 
 **Verdict**: ⛔ **REJECTED** - Violates single source of truth principle
 
 ---
 
-#### Option B: HAPI Only (Provider Captures)
+#### Option B: KA Only (Provider Captures)
 
 **Pros**:
-- ✅ Single source of truth (HAPI owns response)
+- ✅ Single source of truth (KA owns response)
 - ✅ No CRD status bloat
-- ✅ Easy implementation (HAPI audit already exists)
+- ✅ Easy implementation (KA audit already exists)
 
 **Cons**:
 - ❌ No AA business context (phase, approval, degraded mode)
-- ❌ Requires 2 queries for RR reconstruction (HAPI + AA events)
+- ❌ Requires 2 queries for RR reconstruction (KA + AA events)
 - ❌ Can't prove AA received the response
 
 **Verdict**: ⚠️ **INSUFFICIENT** - Missing critical business context
@@ -132,23 +139,31 @@ WHERE event_type = 'aianalysis.analysis.completed'
 
 ## Implementation
 
-### HolmesAPI Changes
+### Kubernaut Agent (KA) Changes
 
-**File**: `kubernaut-agent/src/audit/events.py`
+> **Historical note**: The code below is illustrative pseudocode from the original (Jan 2026)
+> decision, written when KA was still the pre-rewrite Python service (`kubernaut-agent/src/...`
+> paths, `def`/snake_case). It predates the v1.3 Go rewrite ([#433](https://github.com/jordigilh/kubernaut/issues/433))
+> and was never a literal source file — `HAPIResponseEventData` / `HAPIResponseFailedEventData`
+> were never real types in the codebase. It's kept to show the original design intent (per-event
+> Pydantic-style models); the actual current Go payload types live in
+> `pkg/kubernautagent/audit/` and `pkg/aianalysis/audit/audit.go`.
+
+**File** (historical, pre-rewrite): `kubernaut-agent/src/audit/events.py`
 
 ```python
-def create_hapi_response_complete_event(
+def create_ka_response_complete_event(
     incident_id: str,
     remediation_id: str,
     response_data: Dict[str, Any]  # Full IncidentResponse
 ) -> Dict[str, Any]:
     """
-    Create Holmes API response completion audit event
+    Create Kubernaut Agent response completion audit event
 
     BR-AUDIT-005 Gap #4: Capture complete API response for SOC2 audit trail
-    DD-AUDIT-005: Provider perspective audit (HAPI owns response data)
+    DD-AUDIT-005: Provider perspective audit (KA owns response data)
     """
-    event_data_model = HAPIResponseEventData(
+    event_data_model = KAResponseEventData(
         event_id=str(uuid.uuid4()),
         incident_id=incident_id,
         response_data=response_data  # Full IncidentResponse
@@ -163,7 +178,7 @@ def create_hapi_response_complete_event(
     )
 ```
 
-**File**: `kubernaut-agent/src/audit/events.py` (failure path, added in #442)
+**File** (historical, pre-rewrite): `kubernaut-agent/src/audit/events.py` (failure path, added in #442)
 
 ```python
 def create_aiagent_response_failed_event(
@@ -174,12 +189,12 @@ def create_aiagent_response_failed_event(
     duration_seconds: Optional[float] = None,
 ) -> AuditEventRequest:
     """
-    Create audit event for a failed HAPI investigation.
+    Create audit event for a failed KA investigation.
 
     SOC2 CC8.1: Failed investigations MUST have an audit trail.
     DD-AUDIT-005: Provider perspective failure audit.
     """
-    event_data_model = HAPIResponseFailedEventData(
+    event_data_model = KAResponseFailedEventData(
         event_type="aiagent.response.failed",
         event_id=str(uuid.uuid4()),
         incident_id=incident_id,
@@ -196,7 +211,7 @@ def create_aiagent_response_failed_event(
     )
 ```
 
-**File**: `kubernaut-agent/src/extensions/incident/endpoint.py`
+**File** (historical, pre-rewrite): `kubernaut-agent/src/extensions/incident/endpoint.py`
 
 ```python
 @router.post("/incident/analyze")
@@ -205,7 +220,7 @@ async def incident_analyze_endpoint(request: IncidentRequest) -> IncidentRespons
 
     # DD-AUDIT-005: Capture complete response for audit trail (provider perspective)
     audit_store = get_audit_store()
-    audit_store.store_audit(create_hapi_response_complete_event(
+    audit_store.store_audit(create_ka_response_complete_event(
         incident_id=request.incident_id,
         remediation_id=request.remediation_id,
         response_data=result.model_dump()
@@ -216,7 +231,7 @@ async def incident_analyze_endpoint(request: IncidentRequest) -> IncidentRespons
 
 The endpoint also wraps `analyze_incident` in a `try/except` to emit `aiagent.response.failed` on exception, capturing `error_message`, `phase`, and `duration_seconds` before re-raising (#442).
 
-**Effort**: ~15 minutes
+**Effort**: ~15 minutes (historical; superseded by the Go rewrite's `pkg/kubernautagent/audit/` implementation)
 
 ---
 
@@ -304,7 +319,7 @@ func (c *AuditClient) RecordAnalysisComplete(ctx context.Context, analysis *aian
 **File**: `test/integration/aianalysis/audit_provider_data_integration_test.go`
 
 ```go
-It("should capture Holmes response in BOTH HAPI and AA audit events", func() {
+It("should capture Holmes response in BOTH KA and AA audit events", func() {
     // Create AIAnalysis CRD
     aiAnalysis := createTestAIAnalysis()
     err := k8sClient.Create(ctx, aiAnalysis)
@@ -319,12 +334,12 @@ It("should capture Holmes response in BOTH HAPI and AA audit events", func() {
 
     correlationID := aiAnalysis.Spec.RemediationID
 
-    // Verify HAPI audit event (provider perspective)
-    hapiEvents := waitForAuditEvents(correlationID, "aiagent.response.complete", 1)
-    hapiEventData := hapiEvents[0].EventData.(map[string]interface{})
-    Expect(hapiEventData).To(HaveKey("response_data"))
+    // Verify KA audit event (provider perspective)
+    kaEvents := waitForAuditEvents(correlationID, "aiagent.response.complete", 1)
+    kaEventData := kaEvents[0].EventData.(map[string]interface{})
+    Expect(kaEventData).To(HaveKey("response_data"))
 
-    responseData := hapiEventData["response_data"].(map[string]interface{})
+    responseData := kaEventData["response_data"].(map[string]interface{})
     Expect(responseData).To(HaveKey("root_cause_analysis"))
     Expect(responseData).To(HaveKey("selected_workflow"))
     Expect(responseData).To(HaveKey("alternative_workflows"))
@@ -338,7 +353,7 @@ It("should capture Holmes response in BOTH HAPI and AA audit events", func() {
     Expect(summary).To(HaveKey("analysis_preview"))
     Expect(summary).To(HaveKey("selected_workflow_id"))
 
-    // Verify AA business context (not in HAPI event)
+    // Verify AA business context (not in KA event)
     Expect(aaEventData).To(HaveKey("phase"))
     Expect(aaEventData).To(HaveKey("approval_required"))
     Expect(aaEventData).To(HaveKey("degraded_mode"))
@@ -357,7 +372,7 @@ It("should capture Holmes response in BOTH HAPI and AA audit events", func() {
 
 | Audit Aspect | Single Event | Hybrid Events |
 |--------------|-------------|---------------|
-| **Provider Data Integrity** | ⚠️ Unverified | ✅ HAPI event proves source |
+| **Provider Data Integrity** | ⚠️ Unverified | ✅ KA event proves source |
 | **Consumer Processing** | ⚠️ Assumed | ✅ AA event proves receipt |
 | **Data Transfer Validation** | ❌ No proof | ✅ Both events prove transfer |
 | **Debugging** | 🔴 Limited context | ✅ Full provider + consumer views |
@@ -391,9 +406,9 @@ It("should capture Holmes response in BOTH HAPI and AA audit events", func() {
 
 1. ✅ **Enhanced SOC2 Compliance**: Multiple independent audit sources
 2. ✅ **Easier Debugging**: Both provider and consumer perspectives available
-3. ✅ **Single Source of Truth**: HAPI owns complete response data
+3. ✅ **Single Source of Truth**: KA owns complete response data
 4. ✅ **Business Context**: AA provides phase, approval, degraded mode info
-5. ✅ **Data Transfer Validation**: Can prove HAPI → AA data integrity
+5. ✅ **Data Transfer Validation**: Can prove KA → AA data integrity
 
 ### Negative
 
@@ -413,7 +428,7 @@ It("should capture Holmes response in BOTH HAPI and AA audit events", func() {
 
 If storage cost becomes a concern in the future, we can:
 
-1. **Compress HAPI response_data** using gzip before storing
+1. **Compress KA response_data** using gzip before storing
 2. **Archive old audit events** to cold storage after 90 days
 3. **Sample audit events** for non-production environments
 
@@ -457,9 +472,9 @@ Starting in v1.3 ([issue #433](https://github.com/jordigilh/kubernaut/issues/433
 
 ## Related Decisions
 
-- [DD-AUDIT-002: Audit Shared Library Design](./DD-AUDIT-002-audit-shared-library.md)
+- [DD-AUDIT-002: Audit Shared Library Design](./DD-AUDIT-002-audit-shared-library-design.md)
 - [DD-AUDIT-003: Service Audit Trace Requirements](./DD-AUDIT-003-service-audit-trace-requirements.md)
-- [DD-AUDIT-004: Structured Event Data Standards](./DD-AUDIT-004-structured-event-data-standards.md)
+- [DD-AUDIT-004: Structured Types for Audit Event Payloads](./DD-AUDIT-004-structured-types-for-audit-event-payloads.md)
 
 ---
 
@@ -467,6 +482,6 @@ Starting in v1.3 ([issue #433](https://github.com/jordigilh/kubernaut/issues/433
 
 - [BR-AUDIT-005 v2.0: Audit Event Gaps for RR Reconstruction](../../requirements/11_SECURITY_ACCESS_CONTROL.md)
 - [SOC2 Audit Test Plan v2.1.0](../../development/SOC2/SOC2_AUDIT_RR_RECONSTRUCTION_TEST_PLAN.md)
-- [ADR-034: Unified Audit Table Design](./ADR-034-unified-audit-table.md)
+- [ADR-034: Unified Audit Table Design](./ADR-034-unified-audit-table-design.md)
 - [ADR-038: Asynchronous Buffered Audit Trace Ingestion](./ADR-038-async-buffered-audit-ingestion.md)
 


### PR DESCRIPTION
## Summary

Part of #1806. Verifies and rewrites the compliance-critical audit decision docs (Group G: DD-AUDIT-003/005/001) against actual source code, correcting real contradictions found beyond simple HAPI→KA renaming.

- **DD-AUDIT-003-service-audit-trace-requirements.md**: Fixed a real internal contradiction — the Summary Table and v1.3 update section correctly list Kubernaut Agent (KA, renamed from HAPI) as a P0 MUST audit emitter, but §11 "HolmesGPT API Service" still had a full "NO audit traces needed" verdict/rationale from before the Go rewrite. Rewrote §11 to ✅ MUST with a `CORRECTED` banner, verified against `internal/kubernautagent/audit/emitter.go`. Replaced the fictional `ai-analysis.*` event table with the real event types from `pkg/aianalysis/audit/audit.go`. Fixed the stale SOC2 JSON sample (a `provider_data`/`provider` wrapper that never existed in the real `AIAnalysisAuditPayload`). Annotated the historical Service Inventory / Decision / Implementation Priority sections as v1.0-era snapshots that predate KA's P0 reclassification and Fleet Metadata Cache.
- **DD-AUDIT-005-hybrid-provider-data-capture.md**: Renamed HolmesAPI/HAPI → Kubernaut Agent (KA) throughout this still-valid hybrid provider/consumer audit decision. Fixed three broken relative links (DD-AUDIT-002, DD-AUDIT-004, ADR-034 had all been renamed since this doc was written). Flagged the Python implementation section as historical/illustrative pseudocode (the `HAPIResponseEventData` types were never real code).
- **DD-AUDIT-001-V1-V2-VERSIONING-STRATEGY.md**: Fixed an illustrative pseudocode field reference (`HolmesGPTResults` → `AIAgentResults`) with a pointer to the real `AIAnalysis` status fields.

## Test plan

- [x] Verified no remaining unintentional HAPI/HolmesGPT references in the three files (`grep` confirms all remaining hits are historical citations or my own correction notes)
- [x] Cross-checked event names/payloads against `pkg/aianalysis/audit/audit.go` and `internal/kubernautagent/audit/emitter.go`
- [x] Verified all corrected relative links resolve to real files
- Docs-only change; no build/lint/test impact

Made with [Cursor](https://cursor.com)