### PR TITLE
docs(#1806): correct HolmesGPT/HAPI references in Group H (AIAnalysis/KA client/LLM contracts)

### DIFF
--- a/docs/architecture/RESILIENCE_PATTERNS.md
+++ b/docs/architecture/RESILIENCE_PATTERNS.md
@@ -5,6 +5,16 @@
 This document describes the comprehensive resilience patterns and failure handling mechanisms implemented in the Kubernaut system to ensure high availability, graceful degradation, and robust error recovery.
 
 > **⚠️ STALE (flagged [#1806](https://github.com/jordigilh/kubernaut/issues/1806), not corrected here)**: This document describes an in-process fallback chain (a single `AIServiceIntegrator` with an in-process circuit breaker calling a "Direct LLM Analysis" and "Rule-based Fallback") that does not reflect the current CRD-based microservices architecture, where AIAnalysis is a separate controller with Kubernaut Agent (KA) as the sole V1.0 AI provider (no in-process multi-provider LLM fallback chain).
+>
+> **Additionally verified** (naming/metrics only, architecture correction above still stands): no
+> `CircuitBreaker` type exists anywhere in `pkg/aianalysis` — the real resilience mechanism for KA HTTP
+> calls is a retry-with-backoff transport (`sharedtls.DefaultBaseTransportWithRetry`,
+> `pkg/shared/tls/tls.go`), not a circuit breaker. The pseudocode symbols `investigateWithHolmesGPT`,
+> `ai.holmesGPTClient`, and `ai.holmesGPTCircuitBreaker` below have no current equivalent (there is no
+> `AIServiceIntegrator` type in the codebase). None of the four Prometheus metrics below
+> (`kubernaut_service_availability_ratio`, `kubernaut_fallback_activations_total`,
+> `kubernaut_recovery_time_seconds`, `kubernaut_circuit_breaker_state`) are registered anywhere in the
+> codebase (repo-wide search) — they are illustrative only, not real instrumentation.
 
 ## Business Requirements Addressed
 

--- a/docs/architecture/SAFETY_AWARE_INVESTIGATION_PATTERN.md
+++ b/docs/architecture/SAFETY_AWARE_INVESTIGATION_PATTERN.md
@@ -42,7 +42,11 @@
 **Format**: Self-Documenting JSON (DD-HOLMESGPT-009)
 **Token Efficiency**: ~290 tokens (60% reduction from verbose format)
 **Legend**: ZERO tokens (no legend needed - all keys are self-documenting)
-**Decision Document**: `docs/architecture/decisions/DD-HOLMESGPT-009-Self-Documenting-JSON-Format.md`
+**Decision Document**: ~~`docs/architecture/decisions/DD-HOLMESGPT-009-Self-Documenting-JSON-Format.md`~~ —
+**dead link** (flagged [#1806](https://github.com/jordigilh/kubernaut/issues/1806)): this file does not
+exist and there is no renamed `DD-KA-*` equivalent (verified: no `DD-HOLMESGPT-*` files exist anywhere in
+`docs/architecture/decisions/`, and `DD-KA-001` through `DD-KA-006` are unrelated topics). The
+self-documenting JSON format decision was never re-filed under a new DD number.
 
 ```json
 {
@@ -304,6 +308,16 @@ Provide 2-3 action recommendations ranked by safety and effectiveness.
 
 ## 🔄 **Workflow Integration**
 
+> **⚠️ STALE (flagged [#1806](https://github.com/jordigilh/kubernaut/issues/1806), not corrected here)**:
+> Neither `pkg/processor/context_enrichment.go` nor `pkg/aianalysis/prompt_builder.go` (Step 2 below) exist
+> in the current codebase (verified: no file named `prompt_builder.go` anywhere in the repo). More
+> fundamentally, "Step 2" describes AIAnalysis building the LLM prompt string itself — in the current
+> architecture, AIAnalysis sends a structured `IncidentRequest` to Kubernaut Agent (KA), and KA builds the
+> actual investigation prompt internally (`internal/kubernautagent/prompt/builder.go`). The overall pattern
+> (embed safety/priority context in the investigation request instead of a separate safety endpoint) is
+> still accurate; only the illustrative Go snippets and the "which service builds the prompt" detail below
+> are stale.
+
 ### **Step 1: RemediationProcessor Enrichment**
 
 ```go
@@ -477,7 +491,10 @@ var _ = Describe("Safety-Aware Prompt", func() {
 
 ## 📝 **Design Decisions**
 
-**See**: `docs/architecture/decisions/DD-HOLMESGPT-008-Safety-Aware-Investigation.md`
+**See**: ~~`docs/architecture/decisions/DD-HOLMESGPT-008-Safety-Aware-Investigation.md`~~ — **dead link**
+(flagged [#1806](https://github.com/jordigilh/kubernaut/issues/1806)): this file does not exist and no
+renamed `DD-KA-*` equivalent was filed. This document (`SAFETY_AWARE_INVESTIGATION_PATTERN.md`) is itself
+the only surviving record of that decision.
 
 **Key Decision**: Embed safety context in investigation prompt instead of separate endpoint.
 
@@ -491,7 +508,8 @@ var _ = Describe("Safety-Aware Prompt", func() {
 ## 🔗 **Related Documentation**
 
 - **Architecture**: `docs/architecture/APPROVED_MICROSERVICES_ARCHITECTURE.md`
-- **Decision**: `docs/architecture/decisions/DD-HOLMESGPT-008-Safety-Aware-Investigation.md`
+- **Decision**: ~~`docs/architecture/decisions/DD-HOLMESGPT-008-Safety-Aware-Investigation.md`~~ — dead link,
+  see note under "Design Decisions" above
 - **RemediationProcessor**: `docs/services/stateless/remediation-processor/README.md`
 - **WorkflowExecution**: `docs/services/stateless/workflow-execution/README.md`
 - **Rego Policies**: `config/rego/safety_policies.rego`

--- a/docs/architecture/decisions/ADR-021-AI-DRIVEN-CYCLE-CORRECTION-ASSESSMENT.md
+++ b/docs/architecture/decisions/ADR-021-AI-DRIVEN-CYCLE-CORRECTION-ASSESSMENT.md
@@ -7,6 +7,21 @@
 
 ---
 
+> **⚠️ NEVER BUILT / DEFERRED (flagged [#1806](https://github.com/jordigilh/kubernaut/issues/1806), not
+> corrected here)**: This entire proposal (`ValidateAndCorrectDependencies`, `dependency_validator_ai.go`,
+> `CycleCorrectionAttempts`, `AnalyzeWithCorrection`) was never implemented — repo-wide search finds zero
+> matches for any of these symbols outside this document. Per `BR_MAPPING.md` v1.3 and `DD-AIANALYSIS-005`,
+> BR-AI-071–074 (the BRs this assessment proposes) are deferred to V2.0+, contingent on **dynamic workflow
+> generation** being added at all — a feature that itself was never built. V1.0 uses **predefined,
+> pre-validated workflows from the catalog** (`DD-WORKFLOW-002` v3.3): workflows are validated for cycles
+> (among other things) at *registration* time, not at LLM-selection time, so the premise of this
+> assessment (an LLM generating a workflow DAG that might contain a runtime-discovered cycle) does not
+> apply to the current architecture at all. The "HolmesGPT" naming throughout the pseudocode below
+> (`HolmesGPTRecommendation`, `r.HolmesGPTClient`, `HolmesGPTRequest`) is left unrenamed as historical
+> record of a proposal that predates Kubernaut Agent (KA) and was never built under either name.
+
+---
+
 ## Context & Problem
 
 **Current Approach** (ADR-021): When HolmesGPT generates a workflow with circular dependencies, AIAnalysis controller:

--- a/docs/architecture/decisions/ADR-039-llm-prompt-response-contract.md
+++ b/docs/architecture/decisions/ADR-039-llm-prompt-response-contract.md
@@ -8,6 +8,28 @@
 
 ---
 
+> **⚠️ SUPERSEDED / HISTORICAL (Issue [#1806](https://github.com/jordigilh/kubernaut/issues/1806))**: This
+> document is fully superseded by ADR-041 (see Status line above and Changelog footer) and describes the
+> **pre-Go-rewrite, playbook-based** architecture as it existed on 2025-11-16. It is kept as historical
+> record and intentionally NOT rewritten in place — renaming the actors below would misrepresent what was
+> actually decided at the time. For readers encountering this via search:
+> - **"HolmesGPT API"** (prompt generator) = the pre-rewrite service now called **Kubernaut Agent (KA)**,
+>   implemented today as `internal/kubernautagent/` (Go server) with `pkg/agentclient/` as its
+>   OpenAPI-generated client (verified against `pkg/agentclient/client.go`,
+>   `internal/kubernautagent/investigator/investigator.go`).
+> - **"kubernaut-agent" (Response Parser)**: at the time this ADR was written, this was a *separate*
+>   downstream Python component. Per the Go rewrite (`DD-KA-019`), prompt generation and response parsing
+>   are now both performed in-process by the same Kubernaut Agent (KA) entity — there is no longer a
+>   separate downstream parser.
+> - **"Downstream services (RemediationExecution)"**: `RemediationExecution` does not exist in the current
+>   codebase (verified: no matches under `api/`); the current downstream CRD is `WorkflowExecution`.
+> - This document's **playbook-based** selection contract (`selected_playbook`) was itself replaced by
+>   ADR-041's **workflow-based** selection contract (`selected_workflow`) — see ADR-041 for the current
+>   contract shape.
+> - Note (unrelated to #1806): this file's own heading below says "ADR-038" while the filename says
+>   "ADR-039" — a leftover from the ADR-038→039→040→041 renumbering chain documented in ADR-041's
+>   changelog. Left as-is; out of scope for this terminology sweep.
+
 ## Context
 
 The HolmesGPT API sends prompts to the LLM for Root Cause Analysis (RCA) and remediation playbook selection. The LLM must understand the prompt structure and return a structured JSON response that the system can parse and execute.
@@ -715,6 +737,13 @@ If validation fails, the parser MUST:
 ---
 
 ## Changelog
+
+### Post-2.0 Correction (2026-08, Issue #1806)
+- Added a historical/superseded clarification banner at the top of this document mapping
+  "HolmesGPT API"/"kubernaut-agent" to their current names (Kubernaut Agent (KA),
+  `pkg/agentclient/`, `internal/kubernautagent/`) and noting `RemediationExecution` is now
+  `WorkflowExecution`. Body text left unchanged as historical record (already fully superseded
+  by ADR-041 since 2025).
 
 ### Version 2.0 (2025-11-16) - Major Update
 - **BREAKING**: Added RCA severity assessment (critical, high, medium, low)

--- a/docs/architecture/decisions/DD-AIANALYSIS-001-spec-structure.md
+++ b/docs/architecture/decisions/DD-AIANALYSIS-001-spec-structure.md
@@ -30,6 +30,16 @@
 - Replaced generic `map[string]string` with typed structs
 - Aligned with RemediationRequest and RemediationProcessing data flow
 
+> **⚠️ STALE (flagged [#1806](https://github.com/jordigilh/kubernaut/issues/1806), not corrected here)**: The
+> "Decision" section's `AIAnalysisSpec`/`SignalData` code sample below was never updated to match either (a)
+> this document's own Version 1.1 changelog entry above, which says `LLMProvider`, `LLMModel`, `MaxTokens`,
+> `Temperature`, and `IncludeHistory` were removed, or (b) the real current spec. Verified against
+> `api/aianalysis/v1alpha1/aianalysis_types.go`: the current `AIAnalysisSpec` has `RemediationRequestRef`,
+> `RemediationID`, `AnalysisRequest` (containing `SignalContext SignalContextInput`), and `TimeoutConfig` —
+> there is no `SignalData`, `EnrichedContext`, or any `LLM*` field, and no `"holmesgpt"` enum value anywhere
+> in the CRD types. Rewriting the "Decision" example to match the real, current CRD shape is out of scope
+> for this terminology-only sweep.
+
 ## Context
 
 The current `AIAnalysisSpec` in `api/aianalysis/v1alpha1/aianalysis_types.go` uses a generic `map[string]string` for `SignalContext`, which lacks type safety and proper validation.

--- a/docs/architecture/decisions/DD-AIANALYSIS-004-storm-context-not-exposed.md
+++ b/docs/architecture/decisions/DD-AIANALYSIS-004-storm-context-not-exposed.md
@@ -363,9 +363,11 @@ After determining that storm context has minimal value for LLM RCA (3-6%), the a
 
 ## References
 
-> **⚠️ STALE (flagged [#1806](https://github.com/jordigilh/kubernaut/issues/1806), not corrected here)**: `pkg/aianalysis/client/holmesgpt.go` does not exist in the current codebase.
+> **✅ CORRECTED** ([#1806](https://github.com/jordigilh/kubernaut/issues/1806)): `pkg/aianalysis/client/holmesgpt.go`
+> does not exist in the current codebase; the real KA API contract files are cited below (verified against
+> `pkg/aianalysis/handlers/interfaces.go` and `pkg/agentclient/`).
 
-- **Kubernaut Agent (KA) API Contract**: `pkg/aianalysis/client/holmesgpt.go`
+- **Kubernaut Agent (KA) API Contract**: `pkg/aianalysis/handlers/interfaces.go` (`AgentClientInterface`), `pkg/agentclient/` (ogen-generated client)
 - **AIAnalysis Integration**: `docs/services/crd-controllers/02-aianalysis/integration-points.md`
 - **Gateway Storm Detection**: `docs/services/stateless/gateway-service/overview.md`
 - **Storm Detection Brainstorm**: (internal development reference, removed in v1.0)

--- a/docs/architecture/decisions/DD-AIANALYSIS-005-multiple-analysis-types-deferral.md
+++ b/docs/architecture/decisions/DD-AIANALYSIS-005-multiple-analysis-types-deferral.md
@@ -94,15 +94,20 @@ spec:
 ```go
 AnalysisTypes: []string{"investigation", "workflow-selection"},  // ❌ Expects 2 calls
 
-Expect(eventTypeCounts[aiaudit.EventTypeHolmesGPTCall]).To(Equal(2))  // ❌ Fails
+Expect(eventTypeCounts[aiaudit.EventTypeAIAgentCall]).To(Equal(2))  // ❌ Fails
 ```
 
 **After (Correct)**:
 ```go
 AnalysisTypes: []string{"investigation"},  // ✅ Single type
 
-Expect(eventTypeCounts[aiaudit.EventTypeHolmesGPTCall]).To(Equal(1))  // ✅ Passes
+Expect(eventTypeCounts[aiaudit.EventTypeAIAgentCall]).To(Equal(1))  // ✅ Passes
 ```
+
+> **✅ CORRECTED** ([#1806](https://github.com/jordigilh/kubernaut/issues/1806)): the constant referenced
+> above is `aiaudit.EventTypeAIAgentCall` (value `"aianalysis.aiagent.call"`), not
+> `EventTypeHolmesGPTCall` — verified against `pkg/aianalysis/audit/audit.go`; `EventTypeHolmesGPTCall` does
+> not exist anywhere in the current codebase (repo-wide search).
 
 ### Files Requiring Updates
 
@@ -126,7 +131,7 @@ Expect(eventTypeCounts[aiaudit.EventTypeHolmesGPTCall]).To(Equal(1))  // ✅ Pas
 **Model**: Loop through `AnalysisTypes`, make multiple KA calls
 ```go
 for _, analysisType := range analysis.Spec.AnalysisRequest.AnalysisTypes {
-    // Call HAPI with type-specific request
+    // Call KA with type-specific request
     // Emit separate audit event
     // Aggregate results
 }

--- a/docs/architecture/decisions/DD-LLM-003-mock-first-development-strategy.md
+++ b/docs/architecture/decisions/DD-LLM-003-mock-first-development-strategy.md
@@ -43,6 +43,17 @@ Use mock LLM responses during development, validate with real LLM only for final
 
 ## Implementation
 
+> **⚠️ STALE (flagged [#1806](https://github.com/jordigilh/kubernaut/issues/1806), not corrected here)**: This
+> document predates the Kubernaut Agent Go rewrite (`DD-KA-019`, decided 2026-03-04, ~3 months after this
+> document). `workflow_catalog.py` and the `pytest kubernaut-agent/tests/...` commands below refer to the
+> pre-rewrite Python KA test suite, which no longer exists. The structural analog to "HolmesGPT SDK
+> InvestigationResult" in the current Go codebase is `katypes.InvestigationResult`
+> (`pkg/kubernautagent/types/types.go`, alias `katypes`), produced by `Investigator.Investigate` in
+> `internal/kubernautagent/investigator/investigator.go`. The current mock-LLM test harness is the Go
+> service at `test/services/mock-llm/` (see `test/services/mock-llm/scenarios/`), not a Python mock. The
+> underlying mock-first development principle (this decision) still applies; only the file paths and
+> language are stale.
+
 ### Phase 1: Mock LLM Development (Week 1-2)
 - Use MOCK_WORKFLOWS in workflow_catalog.py (already implemented)
 - Mock LLM responses match HolmesGPT SDK InvestigationResult structure

--- a/docs/architecture/decisions/adr-041-llm-contract/ADR-041-APPENDIX-WORKFLOW-CATALOG-INTEGRATION-TIMELINE.md
+++ b/docs/architecture/decisions/adr-041-llm-contract/ADR-041-APPENDIX-WORKFLOW-CATALOG-INTEGRATION-TIMELINE.md
@@ -526,7 +526,12 @@ tool_executor.get_all_tools_openai_format(model)
 **Architecture Documentation**:
 - ADR-041 Main Document: `docs/architecture/decisions/adr-041-llm-contract/ADR-041-llm-prompt-response-contract.md`
 - Workflow Catalog Architecture: `docs/architecture/decisions/DD-WORKFLOW-002-MCP-WORKFLOW-CATALOG-ARCHITECTURE.md`
-- HolmesGPT API Architecture: `docs/architecture/HOLMESGPT_REST_API_ARCHITECTURE.md`
+- ~~HolmesGPT API Architecture: `docs/architecture/HOLMESGPT_REST_API_ARCHITECTURE.md`~~ — **dead link**
+  (flagged [#1806](https://github.com/jordigilh/kubernaut/issues/1806)): this file does not exist in the
+  current codebase and there is no single renamed replacement. The current Kubernaut Agent (KA) HTTP API
+  is implemented across `internal/kubernautagent/server/` (handlers), `pkg/agentclient/` (OpenAPI-generated
+  client), and `pkg/kubernautagent/` (shared types) — no consolidated architecture doc supersedes this
+  reference.
 
 ---
 

--- a/docs/architecture/decisions/adr-041-llm-contract/ADR-041-llm-prompt-response-contract.md
+++ b/docs/architecture/decisions/adr-041-llm-contract/ADR-041-llm-prompt-response-contract.md
@@ -45,11 +45,28 @@
 ### Version 2.0 (2025-11-16)
 - Previous changelog entries...
 
+### Post-2.7 Correction (2026-08, Issue #1806)
+- Renamed "HolmesGPT API" → "Kubernaut Agent (KA)" in Context and Decision sections (contract actor,
+  now implemented as `internal/kubernautagent/` with `pkg/agentclient/` as its OpenAPI-generated client —
+  verified against `pkg/agentclient/client.go`).
+- Clarified "Response Parser (kubernaut-agent)" — per the Go rewrite (`DD-KA-019`), prompt generation and
+  response parsing are both performed in-process by the same Kubernaut Agent (KA) entity; there is no
+  longer a separate downstream Python parser.
+- Corrected "Downstream services (RemediationExecution)" → "WorkflowExecution" (`RemediationExecution` does
+  not exist anywhere under `api/` in the current codebase; verified by repo-wide search).
+- **Flagged, not corrected**: this document appears to end abruptly after the Section 1 incident-context
+  prompt template (no Response Format, Validation, or Examples sections despite the title/contract scope
+  promising them) before jumping into an embedded "Appendix A" summary. This looks like accidental content
+  loss rather than an intentional trim. Out of scope for this terminology-only sweep — flagging for a
+  separate content-completeness follow-up. The embedded Appendix A debugging log (Nov 18, 2025) is left
+  as-is: it accurately describes the pre-Go-rewrite Python HolmesGPT SDK's toolset-enablement behavior at
+  the time the bug was found, which is historical fact, not a claim about current KA behavior.
+
 ---
 
 ## Context
 
-The HolmesGPT API sends prompts to the LLM for Root Cause Analysis (RCA) and remediation workflow selection. The LLM must understand the prompt structure and return a structured JSON response that the system can parse and execute.
+The Kubernaut Agent (KA) sends prompts to the LLM for Root Cause Analysis (RCA) and remediation workflow selection. The LLM must understand the prompt structure and return a structured JSON response that the system can parse and execute.
 
 ### Problem
 
@@ -74,10 +91,10 @@ Without a single authoritative definition of the prompt/response contract:
 **Create a single authoritative ADR defining the LLM prompt structure and expected response format for workflow selection.**
 
 This ADR serves as the contract between:
-- HolmesGPT API (prompt generator)
+- Kubernaut Agent (KA) (prompt generator)
 - LLM Provider (Claude 4.5 Haiku - current testing model, subject to change)
-- Response Parser (kubernaut-agent)
-- Downstream services (RemediationExecution)
+- Response Parser (Kubernaut Agent (KA), in-process — see Post-2.7 Correction below)
+- Downstream services (WorkflowExecution)
 
 ---
 

--- a/docs/requirements/BR-AI-084-proactive-signal-mode-prompt-strategy.md
+++ b/docs/requirements/BR-AI-084-proactive-signal-mode-prompt-strategy.md
@@ -109,8 +109,8 @@ RO copies sp.Status.SignalMode → aa.Spec.SignalContext.SignalMode
 - [ ] RO `SignalName` source changed from `rr.Spec.SignalName` to `sp.Status.SignalName` (normalized)
 - [ ] AA request builder passes `signalMode` to KA (`pkg/aianalysis/handlers/request_builder.go`)
 - [ ] KA OpenAPI spec includes `signal_mode` in `IncidentRequest`
-- [ ] Go client regenerated (`make generate-holmesgpt-client`)
-- [ ] Python client regenerated
+- [ ] Go client regenerated (`make generate-agentclient`) — corrected from `make generate-holmesgpt-client`, see STALE note below
+- [ ] ~~Python client regenerated~~ — moot, see STALE note below (no Python client in current codebase)
 - [ ] KA prompt switches based on `signal_mode`
 - [ ] Proactive mode allows "no action" as valid LLM outcome
 - [ ] Audit events include `signalMode`
@@ -120,7 +120,19 @@ RO copies sp.Status.SignalMode → aa.Spec.SignalContext.SignalMode
 
 ## Implementation Points
 
-> **⚠️ STALE (flagged [#1806](https://github.com/jordigilh/kubernaut/issues/1806), not corrected here)**: The "Go client regen" row's path (`pkg/holmesgpt/client/oas_schemas_gen.go`) and make target (`make generate-holmesgpt-client`) no longer match the codebase — the generated OpenAPI client now lives under `pkg/agentclient/`.
+> **⚠️ STALE (flagged [#1806](https://github.com/jordigilh/kubernaut/issues/1806), not corrected here)**: The "Go client regen" row's path (`pkg/holmesgpt/client/oas_schemas_gen.go`) and make target (`make generate-holmesgpt-client`) no longer match the codebase — the generated OpenAPI client now lives under `pkg/agentclient/`, and the real make target is `generate-agentclient` (verified against `Makefile`).
+>
+> **Additionally verified**: this entire requirements document predates the Kubernaut Agent Go rewrite
+> (`DD-KA-019`, decided 2026-03-04). The "KA Python model", "KA prompt builder", and "KA LLM integration"
+> rows below (`kubernaut-agent/src/models/incident_models.py`,
+> `kubernaut-agent/src/extensions/incident/prompt_builder.py`,
+> `kubernaut-agent/src/extensions/incident/llm_integration.py`) reference Python paths that do not exist in
+> the current codebase (repo-wide search: no `kubernaut-agent/src/` directory exists). Per
+> `testing-strategy.md`'s BR-AI-084 test results (all "✅ Passed"), R4 (KA prompt strategy switching) was
+> actually implemented in Go at `internal/kubernautagent/prompt/builder.go` (confirmed: this file has a
+> `SignalMode` field and reactive/proactive branching), not as three separate Python files. R3's "Both Go
+> and Python clients MUST be regenerated" and the corresponding Acceptance Criteria checkbox below
+> ("Python client regenerated") are moot — there is no Python client in the current codebase.
 
 | Component | File(s) | Change |
 |---|---|---|


### PR DESCRIPTION
## Summary

Closes out a slice of GitHub issue #1806 (rename stale "HAPI"/"HolmesGPT" doc references to "Kubernaut Agent (KA)" and correct/supersede docs whose architecture description is stale). This PR covers "Group H": 14 files describing AIAnalysis, the KA client, and LLM prompt/response contracts.

Every factual correction below was verified against the current Go source (`pkg/aianalysis/`, `pkg/agentclient/`, `pkg/kubernautagent/`, `internal/kubernautagent/`, `api/aianalysis/v1alpha1/`) — not from memory.

### Per-file summary

| File | Finding / Fix |
|---|---|
| `ADR-039-llm-prompt-response-contract.md` | Fully superseded/historical doc (superseded by ADR-041 since inception). Added a banner mapping "HolmesGPT API"/"kubernaut-agent" to current names (Kubernaut Agent (KA), `pkg/agentclient/`, `internal/kubernautagent/`) and `RemediationExecution` → `WorkflowExecution`. Body left as historical record (matches existing DD-WORKFLOW-010 convention). Noted (not fixed) a pre-existing ADR-038-in-file-ADR-039 title/filename mismatch from the renumbering history. |
| `adr-041-llm-contract/ADR-041-llm-prompt-response-contract.md` | This is the **current, Accepted** contract doc — directly renamed "HolmesGPT API" → "Kubernaut Agent (KA)" in the Context/Decision actor list and `RemediationExecution` → `WorkflowExecution`. Flagged that the document appears to end abruptly after the Section 1 prompt template (missing Response Format/Validation/Examples) — likely accidental content loss; out of scope to author ~500 lines of missing content in a terminology sweep. |
| `adr-041-llm-contract/ADR-041-APPENDIX-...-TIMELINE.md` | Fixed one dead link to non-existent `docs/architecture/HOLMESGPT_REST_API_ARCHITECTURE.md`; noted there's no single consolidated replacement doc. Left the historical Nov 2025 debugging log content (real HolmesGPT SDK behavior at the time) untouched. |
| `DD-LLM-003-mock-first-development-strategy.md` | Flagged as predating the KA Go rewrite (`DD-KA-019`, 2026-03-04): `pytest kubernaut-agent/tests/...` paths no longer exist. Identified the real current analog to "HolmesGPT SDK InvestigationResult" as `katypes.InvestigationResult` (`pkg/kubernautagent/types/types.go`) and the real mock harness as `test/services/mock-llm/`. |
| `DD-AIANALYSIS-004-storm-context-not-exposed.md` | Corrected (not just flagged) a dangling reference to `pkg/aianalysis/client/holmesgpt.go` → the real `AgentClientInterface` (`pkg/aianalysis/handlers/interfaces.go`) + `pkg/agentclient/` (ogen client). |
| `DD-AIANALYSIS-005-multiple-analysis-types-deferral.md` | Corrected two Go test snippets: `aiaudit.EventTypeHolmesGPTCall` → `aiaudit.EventTypeAIAgentCall` (verified against `pkg/aianalysis/audit/audit.go`; old constant doesn't exist anywhere). Renamed `HAPI` → `KA` in a still-relevant V2.0 design-option pseudocode comment. |
| `DD-AIANALYSIS-001-spec-structure.md` | Flagged the "Decision" section's example `AIAnalysisSpec`/`SignalData` code as stale — it contradicts the doc's *own* v1.1 changelog (says `LLMProvider` et al. were removed) and doesn't match the real current CRD (`RemediationRequestRef`, `RemediationID`, `AnalysisRequest{SignalContext}`, `TimeoutConfig` — no `SignalData`/`LLM*`/`"holmesgpt"` enum). |
| `RESILIENCE_PATTERNS.md` | Extended the existing STALE banner: confirmed no `CircuitBreaker` type exists for KA calls (real mechanism is `sharedtls.DefaultBaseTransportWithRetry`); confirmed all 4 cited Prometheus metrics (`kubernaut_service_availability_ratio` etc.) are illustrative only, not real instrumentation. |
| `SAFETY_AWARE_INVESTIGATION_PATTERN.md` | Fixed 3 dead links to non-existent `DD-HOLMESGPT-008`/`DD-HOLMESGPT-009` files (no renamed `DD-KA-*` equivalent exists). Flagged that `pkg/processor/context_enrichment.go` and `pkg/aianalysis/prompt_builder.go` don't exist, and that prompt-building now happens inside KA (`internal/kubernautagent/prompt/builder.go`), not AIAnalysis. |
| `BR_MAPPING.md` | **No change** — already fully corrected/flagged in a prior #1806 pass; verified clean. |
| `testing-strategy.md` | **No change** — already fully corrected/flagged in a prior #1806 pass; verified clean. |
| `finalizers-lifecycle.md` | **No change** — already fully corrected/flagged in a prior #1806 pass; verified clean. |
| `BR-AI-084-proactive-signal-mode-prompt-strategy.md` | Expanded the existing STALE banner: the whole doc predates the Go rewrite — "KA Python model/prompt builder/LLM integration" rows reference nonexistent `kubernaut-agent/src/...` Python paths. Confirmed R4 was actually implemented in Go (`internal/kubernautagent/prompt/builder.go`, has real `SignalMode` branching). Corrected `make generate-holmesgpt-client` → `make generate-agentclient` (verified against `Makefile`) and struck the now-moot "Python client regenerated" acceptance criterion. |
| `ADR-021-AI-DRIVEN-CYCLE-CORRECTION-ASSESSMENT.md` | Flagged the entire proposal as never built (zero matches for `ValidateAndCorrectDependencies`, `dependency_validator_ai.go`, `CycleCorrectionAttempts` outside this doc) and deferred to V2.0+ per `BR_MAPPING.md`/`DD-AIANALYSIS-005`, contingent on dynamic workflow generation (itself never built). V1.0's predefined/pre-validated workflow catalog (`DD-WORKFLOW-002` v3.3) makes the assessment's premise moot. Left "HolmesGPT" naming in the pseudocode as historical record per convention. |

### Judgment calls / things to flag

1. **ADR-041 main doc appears to be missing content** (ends abruptly after the Section 1 prompt template, no Response Format/Validation/Examples sections despite the title promising a full contract). I flagged this but did **not** attempt to author the missing content — that's a much larger undertaking than a terminology/accuracy sweep and risks introducing incorrect contract details without proper review.
2. **ADR-039's own H1 header says "ADR-038"** even though the file is named `ADR-039-...md` — a pre-existing artifact of the ADR-038→039→040→041 renumbering chain (documented in ADR-041's own changelog). Noted but not fixed, since it's a structural/numbering issue orthogonal to the HAPI/KA terminology sweep and touching it risks breaking existing cross-references.
3. For fully-superseded historical docs (ADR-039, ADR-021 assessment), I followed the existing repo convention (see `DD-WORKFLOW-010`) of adding a top clarification banner **without** renaming "HolmesGPT" throughout the historical body text, since doing so would misrepresent what was actually decided/described at the time.

## Test plan

- [x] Docs-only change; no code touched.
- [x] Every rename/correction verified via `Grep`/`Glob` against current Go source (paths cited inline in each banner).
- [ ] CI checks (will confirm shortly after opening PR).

Made with [Cursor](https://cursor.com)