### PR TITLE
docs(1806): rewrite Group L - requirements/API-server/data-storage HAPI/HolmesGPT cleanup

### DIFF
--- a/api/openapi/data-storage-v1.yaml
+++ b/api/openapi/data-storage-v1.yaml
@@ -1753,7 +1753,7 @@ components:
             - gateway: Gateway signal and CRD lifecycle events
             - notification: Notification delivery and escalation events
             - analysis: AI analysis, agent calls, and rego evaluation events
-            - aiagent: AI Agent Provider (HolmesGPT API) - autonomous tool-calling agent
+            - aiagent: AI Agent Provider (Kubernaut Agent, KA) - autonomous tool-calling agent
             - signalprocessing: Signal Processing Service
             - workflow: Workflow catalog and discovery events
             - workflowexecution: Workflow execution lifecycle events
@@ -2184,7 +2184,7 @@ components:
               nullable: true
 
     # ========================================
-    # WORKFLOW DISCOVERY SCHEMAS (DD-WORKFLOW-016, DD-HAPI-017)
+    # WORKFLOW DISCOVERY SCHEMAS (DD-WORKFLOW-016, DD-KA-017 formerly DD-HAPI-017)
     # ========================================
     # The three-step discovery protocol's own response types (ActionTypeListResponse,
     # WorkflowDiscoveryResponse, WorkflowDiscoveryEntry, RemediationWorkflow,
@@ -2599,7 +2599,7 @@ components:
         message:
           type: string
           description: Human-readable error description
-          example: "Holmes API request timeout after 30s"
+          example: "Kubernaut Agent (KA) request timeout after 30s"
         code:
           type: string
           description: Machine-readable error classification (ERR_[CATEGORY]_[SPECIFIC])
@@ -2844,7 +2844,7 @@ components:
           type: string
           description: |
             Action type from DD-WORKFLOW-016 taxonomy (e.g., ScaleReplicas, RestartPod).
-            Propagated from AIAnalysis.SelectedWorkflow.ActionType via HAPI three-step discovery.
+            Propagated from AIAnalysis.SelectedWorkflow.ActionType via KA's three-step discovery protocol.
             Used by DS remediation history to populate actionType on entries and summaries.
           example: "ScaleReplicas"
 
@@ -3912,7 +3912,7 @@ components:
           description: |
             Structured health check results from the K8s API assessment.
             Only present for effectiveness.health.assessed events.
-            Enables downstream consumers (DS, HAPI) to extract typed fields
+            Enables downstream consumers (DS, KA) to extract typed fields
             without parsing the human-readable details string.
           properties:
             pod_running:
@@ -4193,13 +4193,13 @@ components:
           description: Updated description
           example: "Updated workflow description"
 
-    # Workflow Discovery Events (DD-HAPI-017, DD-WORKFLOW-014 v3.0)
+    # Workflow Discovery Events (DD-KA-017 formerly DD-HAPI-017, DD-WORKFLOW-014 v3.0)
     WorkflowDiscoveryAuditPayload:
       type: object
       required: [event_type, query, results, search_metadata]
       description: |
         Audit event payload for three-step workflow discovery operations.
-        Authority: DD-HAPI-017 (Three-Step Workflow Discovery Integration)
+        Authority: DD-KA-017 (Three-Step Workflow Discovery Integration, formerly DD-HAPI-017)
         Authority: DD-WORKFLOW-014 v3.0 (Workflow Selection Audit Trail)
         Replaces WorkflowSearchAuditPayload (search endpoint removed).
       properties:
@@ -4431,12 +4431,12 @@ components:
         error_message:
           type: string
           description: Error message
-          example: "HolmesGPT API timeout after 30s"
+          example: "Kubernaut Agent (KA) timeout after 30s"
 
     ProviderResponseSummary:
       type: object
       required: [incident_id, analysis_preview, needs_human_review, warnings_count]
-      description: Summary of Holmes API response from AIAnalysis consumer perspective (BR-AUDIT-005 v2.0 Gap #4)
+      description: Summary of Kubernaut Agent (KA) response from AIAnalysis consumer perspective (BR-AUDIT-005 v2.0 Gap #4)
       properties:
         incident_id:
           type: string
@@ -4455,7 +4455,7 @@ components:
           description: Whether human review is required
         warnings_count:
           type: integer
-          description: Number of warnings from Holmes
+          description: Number of warnings from Kubernaut Agent (KA)
           example: 2
 
     # ========================================
@@ -4550,8 +4550,9 @@ components:
             type: string
 
     # ========================================
-    # HolmesGPT API Event Payloads
-    # From: kubernaut-agent/src/models/audit_models.py
+    # Kubernaut Agent (KA) Event Payloads
+    # From: internal/kubernautagent/audit/ds_payloads.go (rewritten in Go, Issue #433;
+    # formerly kubernaut-agent/src/models/audit_models.py under the pre-rewrite Python HAPI)
     # ========================================
 
     AIAgentResponsePayload:
@@ -4732,7 +4733,7 @@ components:
     IncidentResponseData:
       type: object
       required: [incidentId, analysis, rootCauseAnalysis, confidence, timestamp]
-      description: Complete IncidentResponse structure from HolmesGPT API (DD-AUDIT-004 - strongly typed, no additionalProperties)
+      description: Complete IncidentResponse structure from Kubernaut Agent (KA) (DD-AUDIT-004 - strongly typed, no additionalProperties)
       properties:
         incidentId:
           type: string
@@ -4829,7 +4830,7 @@ components:
               type: string
               description: |
                 Action type from DD-WORKFLOW-016 taxonomy (e.g., ScaleReplicas, RestartPod).
-                Propagated from HAPI three-step discovery protocol.
+                Propagated from KA's three-step discovery protocol.
               example: "ScaleReplicas"
             executionBundle:
               type: string

--- a/docs/README.md
+++ b/docs/README.md
@@ -169,8 +169,8 @@ Comprehensive business requirements for Phase 2 development.
   - **[Alert Tracking Enhancement](requirements/enhancements/ALERT_TRACKING.md)** - End-to-end alert tracking capabilities
   - **[Post-Mortem Tracking](requirements/enhancements/POST_MORTEM_TRACKING.md)** - LLM-generated post-mortem reports
   - **[Workflow Engine Enhancement](requirements/enhancements/WORKFLOW_ENGINE.md)** - Resilient workflow engine capabilities
-  - **[Investigation/Execution Separation](requirements/enhancements/HOLMESGPT_INVESTIGATION_SEPARATION.md)** - Investigation vs execution separation (doc itself still needs a content rewrite against current KA architecture, tracked under #1806)
-  - **[AI Context Orchestration](requirements/enhancements/AI_CONTEXT_ORCHESTRATION.md)** - Dynamic context management enhancements
+  - **[Investigation/Execution Separation](requirements/enhancements/HOLMESGPT_INVESTIGATION_SEPARATION.md)** - Historical Jan 2025 proposal; corrected under #1806 to confirm the core principle is implemented (AIAnalysis+KA for investigation, WorkflowExecution for execution), though the document's specific mechanisms are superseded
+  - **[AI Context Orchestration](requirements/enhancements/AI_CONTEXT_ORCHESTRATION.md)** - 🗄️ Superseded (#1806) — standalone Context API service deprecated, see DD-CONTEXT-006
 
 ### 📊 **Analysis & Research**
 Comprehensive analysis documents and research findings.

--- a/docs/requirements/12_API_SERVER_SERVICES.md
+++ b/docs/requirements/12_API_SERVER_SERVICES.md
@@ -2,8 +2,28 @@
 
 **Document Version**: 1.0
 **Date**: January 2025
-**Status**: Business Requirements Specification
+**Status**: 🗄️ **SUPERSEDED** — see note below
 **Module**: API Server Services (`pkg/api/server/`)
+
+> **SUPERSEDED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: This
+> Jan 2025 document specifies an aspirational `pkg/api/server/` layer — a standalone "Context API
+> Server" for HolmesGPT toolset integration, plus a broad enterprise API gateway (GraphQL, Kong/
+> Ambassador/Istio integration, WebSocket/SSE real-time analytics, HSM-backed mTLS, multi-region
+> disaster recovery, etc.). **`pkg/api/server/` does not exist in the current codebase**, and none of
+> this enterprise-gateway feature set was built as designed.
+>
+> The current equivalent, external-facing API surface is **APIFrontend (AF)** (`pkg/apifrontend/`), a
+> much narrower-scoped gateway for natural-language-driven investigation and `RemediationRequest`
+> creation via the A2A and MCP protocols — see
+> [`docs/services/apifrontend/design/ARCHITECTURE.md`](../services/apifrontend/design/ARCHITECTURE.md)
+> for the authoritative current design. The standalone "Context API Server" concept described in
+> Section 2 below was deprecated and its capabilities absorbed into Data Storage; see
+> [DD-CONTEXT-006](../architecture/decisions/DD-CONTEXT-006-CONTEXT-API-DEPRECATION.md). "HolmesGPT"
+> throughout this document refers to the pre-Go-rewrite architecture — the current equivalent is
+> **Kubernaut Agent (KA)** (`internal/kubernautagent/`, Issue #433). This document is retained for
+> historical context only; none of the `BR-CAPI-*`, `BR-API-*`, `BR-SEC-*`, `BR-PERF-*`, `BR-DOC-*`,
+> `BR-WS-*`, `BR-SSE-*`, `BR-MQ-*`, `BR-RT-*`, `BR-GATE-*`, `BR-STD-*`, `BR-ENT-*`, or `BR-CLOUD-*`
+> requirements below should be treated as describing a live, implemented service.
 
 ---
 

--- a/docs/requirements/BR-GATEWAY-184-target-resource-extraction-priority.md
+++ b/docs/requirements/BR-GATEWAY-184-target-resource-extraction-priority.md
@@ -119,9 +119,14 @@ Gateway MUST use the `job_name` label (not `job`) to identify Kubernetes Job res
 
 The fingerprint formula `SHA256(namespace:kind:name)` will produce different hashes for previously misidentified alerts. This is correct and desired -- the old fingerprints targeted the wrong resource and should not be deduplicated against new, correctly-targeted signals.
 
-### HAPI Prompt (No Changes Required)
+### Kubernaut Agent (KA) Prompt (No Changes Required)
 
-The HAPI prompt builder (`kubernaut-agent/src/extensions/incident/prompt_builder.py`) receives `resource_kind` and `resource_name` from the AA spec and passes them directly to the LLM. The LLM investigates whatever resource it is told about using `kubectl` tools. The prompt output schema already instructs the LLM to trace up OwnerReferences for the `affectedResource` field. No prompt changes are needed -- the fix is fully contained in the Gateway.
+> **CORRECTED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: This
+> section originally referenced the pre-rewrite Python "HAPI" prompt builder. HolmesGPT-API was
+> rewritten in Go as Kubernaut Agent (KA) (Issue #433); the equivalent current component is
+> `internal/kubernautagent/prompt/builder.go`.
+
+The KA prompt builder (`internal/kubernautagent/prompt/builder.go`) receives `resource_kind` and `resource_name` from the AA spec and passes them directly to the LLM. The LLM investigates whatever resource it is told about using `kubectl` tools. The prompt output schema already instructs the LLM to trace up OwnerReferences for the `affectedResource` field. No prompt changes are needed -- the fix is fully contained in the Gateway.
 
 ### Signal Processing, AI Analysis, Workflow Execution
 

--- a/docs/requirements/EXECUTION_INFRASTRUCTURE_CAPABILITIES.md
+++ b/docs/requirements/EXECUTION_INFRASTRUCTURE_CAPABILITIES.md
@@ -2,8 +2,32 @@
 
 **Document Version**: 1.0
 **Date**: January 2025
-**Status**: Architecture Documentation
+**Status**: 🗄️ **SUPERSEDED** — see note below
 **Purpose**: Document existing execution infrastructure that handles all infrastructure changes
+
+> **SUPERSEDED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: This
+> Jan 2025 document describes a pre-CRD-rewrite execution model — a `pkg/workflow/engine/` "Workflow
+> Engine" with a registered `ActionExecutor` interface (`KubernetesActionExecutor`,
+> `MonitoringActionExecutor`, `CustomActionExecutor`) and a separate `pkg/platform/executor/`
+> `ActionRegistry`, invoked from parsed `holmesGPTClient.Investigate()` recommendations. **None of this
+> code exists in the current codebase** (`pkg/workflow/engine/` and `pkg/platform/executor/` were both
+> removed; verified via repo-wide search — zero remaining references).
+>
+> The document's core **architectural principle — investigation is separate from execution — is still
+> true and implemented today**, just via a completely different mechanism:
+> - **Investigation**: the `AIAnalysis` CRD controller (`pkg/aianalysis/`) submits an investigation to
+>   **Kubernaut Agent (KA)** (`internal/kubernautagent/`, the Go rewrite of the former Python
+>   "HolmesGPT-API"/"HAPI", Issue #433) and selects a workflow from the predefined catalog — it does
+>   not execute anything itself. See
+>   [`docs/services/crd-controllers/02-aianalysis/overview.md`](../services/crd-controllers/02-aianalysis/overview.md).
+> - **Execution**: the `WorkflowExecution` CRD controller (`pkg/workflowexecution/`) runs the selected
+>   workflow as a user-provided OCI-bundle container via a Tekton `PipelineRun` (ADR-043, ADR-044) in a
+>   dedicated `kubernaut-workflows` namespace — there is no `ActionExecutor`/`ActionRegistry` interface
+>   or in-process action dispatch. See
+>   [`docs/services/crd-controllers/03-workflowexecution/overview.md`](../services/crd-controllers/03-workflowexecution/overview.md).
+>
+> This document is retained for historical context only. Do not cite the specific interfaces, file
+> paths, or action-type lists below as current.
 
 ---
 

--- a/docs/requirements/enhancements/AI_CONTEXT_ORCHESTRATION.md
+++ b/docs/requirements/enhancements/AI_CONTEXT_ORCHESTRATION.md
@@ -1,9 +1,24 @@
 # AI Context Orchestration - Executive Summary
 
-**Business Requirements Document**: [10_AI_CONTEXT_ORCHESTRATION.md](./10_AI_CONTEXT_ORCHESTRATION.md)
+**Business Requirements Document**: [10_AI_CONTEXT_ORCHESTRATION.md](../10_AI_CONTEXT_ORCHESTRATION.md)
 **Feature Category**: AI & Machine Learning Enhancement
 **Priority**: High
 **Business Impact**: Strategic Platform Evolution
+**Status**: 🗄️ **SUPERSEDED** — see note below
+
+> **SUPERSEDED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: This
+> Jan 2025 executive summary describes a standalone **Context API service** and a Python **HolmesGPT**
+> with pluggable toolsets, providing "historical intelligence" as a distinct service from real-time
+> investigation. That standalone Context API service was deprecated and removed; its capabilities were
+> absorbed into Data Storage, and HolmesGPT-API was rewritten in Go as **Kubernaut Agent (KA)**. See
+> [DD-CONTEXT-006](../../architecture/decisions/DD-CONTEXT-006-CONTEXT-API-DEPRECATION.md) for the
+> authoritative deprecation decision, and the parent
+> [10_AI_CONTEXT_ORCHESTRATION.md](../10_AI_CONTEXT_ORCHESTRATION.md) document (superseded in the same
+> pass) for the corresponding full business-requirements correction. This document is retained for
+> historical context only; the metrics, requirements counts, and architecture diagrams below describe
+> a proposal that was not built as designed. (Also fixed: the "Business Requirements Document" link
+> above was a broken relative path — corrected from `./10_AI_CONTEXT_ORCHESTRATION.md` to
+> `../10_AI_CONTEXT_ORCHESTRATION.md`, since that document lives one directory up.)
 
 ---
 

--- a/docs/requirements/enhancements/HOLMESGPT_INVESTIGATION_SEPARATION.md
+++ b/docs/requirements/enhancements/HOLMESGPT_INVESTIGATION_SEPARATION.md
@@ -1,10 +1,37 @@
-# Kubernaut Agent (KA) Investigation vs Execution Separation - Enhancement Summary
+# Investigation/Execution Separation - Enhancement Summary
 
 **Document Version**: 1.1
 **Date**: January 2025
 **Last Verified**: September 30, 2025
-**Status**: Architecture Enhancement Summary
+**Status**: 🗄️ **HISTORICAL PROPOSAL — Core principle implemented, specific mechanisms superseded** (see note below)
 **Purpose**: Document the comprehensive enhancements made to properly separate KA investigation from infrastructure execution
+
+> **CORRECTED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: This
+> January 2025 document proposed separating "HolmesGPT" investigation from infrastructure execution
+> for the pre-CRD-rewrite architecture. **The underlying principle — AI investigation must not directly
+> execute infrastructure changes — was implemented, and remains true in the current architecture**, but
+> via entirely different, CRD-based mechanisms than this document describes:
+>
+> - **Investigation**: `AIAnalysis` CRD controller (`pkg/aianalysis/`) submits to **Kubernaut Agent
+>   (KA)** (`internal/kubernautagent/`, the Go rewrite of "HolmesGPT-API"/"HAPI", Issue #433) for root
+>   cause analysis and workflow selection from a predefined catalog — investigation-only, no execution.
+>   See [`docs/services/crd-controllers/02-aianalysis/overview.md`](../../services/crd-controllers/02-aianalysis/overview.md).
+> - **Execution**: `WorkflowExecution` CRD controller (`pkg/workflowexecution/`) runs the selected
+>   workflow's OCI bundle via a Tekton `PipelineRun` (ADR-043, ADR-044) — this is the current
+>   equivalent of what this document calls "existing Kubernaut Executors" / the "ActionExecutor
+>   framework". See [`docs/services/crd-controllers/03-workflowexecution/overview.md`](../../services/crd-controllers/03-workflowexecution/overview.md).
+>
+> The **specific technical proposals below are superseded and do not describe current code**:
+> the `BR-HAPI-INVESTIGATION-*`/`BR-WF-HOLMESGPT-*` requirement IDs, the `ActionExecutor`/
+> `KubernetesActionExecutor` framework (see
+> [`EXECUTION_INFRASTRUCTURE_CAPABILITIES.md`](../EXECUTION_INFRASTRUCTURE_CAPABILITIES.md), itself
+> superseded in this same pass), and two of the four referenced files no longer exist:
+> `docs/requirements/13_HOLMESGPT_REST_API_WRAPPER.md` and
+> `docs/architecture/REQUIREMENTS_BASED_ARCHITECTURE_DIAGRAM.md` were both removed in later
+> restructuring with no direct successor (the current requirements/architecture docs for these
+> services are `docs/requirements/04_WORKFLOW_ENGINE_ORCHESTRATION.md` and the per-service docs under
+> `docs/services/crd-controllers/`, linked above). This document is retained for historical context
+> only — do not treat its endpoint list, BR IDs, or file references as current.
 
 ---
 

--- a/docs/services/SERVICE_DOCUMENTATION_GUIDE.md
+++ b/docs/services/SERVICE_DOCUMENTATION_GUIDE.md
@@ -62,9 +62,9 @@
 **Directory**: `docs/services/crd-controllers/02-aianalysis/`
 
 **Key Patterns**:
-- HolmesGPT AI provider integration
+- Kubernaut Agent (KA) AI provider integration
 - Rego policy evaluation (Open Policy Agent)
-- Child CRD management (AIApprovalRequest)
+- Child CRD management (`RemediationApprovalRequest`)
 - Approval workflows (auto vs. manual)
 
 **Special Files**:
@@ -1343,11 +1343,13 @@ Documentation is complete when:
 5. [gateway-service/testing-strategy.md](mdc:docs/services/stateless/gateway-service/testing-strategy.md) - HTTP routing and webhook testing
 
 **Stateless Services** (MEDIUM priority):
-6. [context-api/testing-strategy.md](mdc:docs/services/stateless/context-api/testing-strategy.md) - Query and caching testing
-7. [data-storage/testing-strategy.md](mdc:docs/services/stateless/data-storage/testing-strategy.md) - Vector DB and persistence testing
-8. [kubernaut-agent/testing-strategy.md](mdc:docs/services/stateless/kubernaut-agent/testing-strategy.md) - LLM and prompt testing
-9. [notification-service/testing-strategy.md](mdc:docs/services/stateless/notification-service/testing-strategy.md) - Multi-channel notification testing
-10. [dynamic-toolset/testing-strategy.md](mdc:docs/services/stateless/dynamic-toolset/testing-strategy.md) - Service discovery testing
+<!-- CORRECTED (2026-08-02, Issue #1806): removed dead link to context-api/testing-strategy.md — the
+     standalone Context API service was deprecated and its capabilities absorbed into Data Storage
+     (DD-CONTEXT-006). Query/caching testing now lives under data-storage/testing-strategy.md below. -->
+6. [data-storage/testing-strategy.md](mdc:docs/services/stateless/data-storage/testing-strategy.md) - Vector DB and persistence testing
+7. [kubernaut-agent/testing-strategy.md](mdc:docs/services/stateless/kubernaut-agent/testing-strategy.md) - LLM and prompt testing
+8. [notification-service/testing-strategy.md](mdc:docs/services/stateless/notification-service/testing-strategy.md) - Multi-channel notification testing
+9. [dynamic-toolset/testing-strategy.md](mdc:docs/services/stateless/dynamic-toolset/testing-strategy.md) - Service discovery testing
 
 ### **What Each Service Contains**
 Each service testing strategy includes:
@@ -1370,8 +1372,9 @@ Each service testing strategy includes:
   3. Redundant Coverage (same test at multiple levels)
 
 ### **Key Testing Patterns**
-- **Go Services**: Use Ginkgo `DescribeTable` for state-based testing (10/11 services)
-- **Python Service**: Use `@pytest.mark.parametrize` for parametrized testing (HolmesGPT API)
+- **Go Services**: Use Ginkgo `DescribeTable` for state-based testing (all 12 active services — the former
+  Python HolmesGPT-API was rewritten in Go as Kubernaut Agent (KA), Issue #433, and uses the same Ginkgo
+  pattern as every other service)
 - **Service-Specific Examples**: All examples tailored to each service's domain
 - **Maintainability-First**: Prioritize simplicity and maintainability over exhaustive coverage
 

--- a/docs/services/stateless/data-storage/api-specification.md
+++ b/docs/services/stateless/data-storage/api-specification.md
@@ -632,7 +632,7 @@ trend := current.SuccessRate - previous.SuccessRate
 **Kubernaut Agent (KA)** (Direct Consumer):
 ```go
 // KA calls Data Storage directly
-func (s *HolmesGPTService) GetPlaybookSuccessRate(ctx context.Context, playbookID string) (*SuccessRate, error) {
+func (s *KAService) GetPlaybookSuccessRate(ctx context.Context, playbookID string) (*SuccessRate, error) {
     // Direct call to Data Storage with authentication
     resp, err := s.dataStorageClient.GetMultiDimensionalSuccessRate(ctx, playbookID)
     // Return response

--- a/docs/services/stateless/data-storage/openapi/README.md
+++ b/docs/services/stateless/data-storage/openapi/README.md
@@ -3,6 +3,13 @@
 **Date**: 2025-12-13
 **Status**: 🔴 **DEPRECATED** - This directory is no longer used
 
+> **CORRECTED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: The
+> "Reason for Move" section below is retained as historical context — it correctly describes the
+> pre-rewrite state where the Python HolmesGPT-API ("HAPI") used its own copy of the spec. HAPI was
+> rewritten in Go as **Kubernaut Agent (KA)** (Issue #433) and, like every other Go service, now
+> consumes the single authoritative spec directly. The "Client Generation" section has been rewritten
+> below to describe the current (ogen-based, Go-only) generation flow — there is no Python client.
+
 ---
 
 ## ✅ **AUTHORITATIVE SPEC LOCATION**
@@ -17,10 +24,10 @@ api/openapi/data-storage-v1.yaml
 
 ---
 
-## 📋 **REASON FOR MOVE**
+## 📋 **REASON FOR MOVE (historical)**
 
 **Problem**: Multiple OpenAPI specs caused drift and integration issues:
-- `docs/services/stateless/data-storage/openapi/v3.yaml` (1782 lines) - Used by HAPI
+- `docs/services/stateless/data-storage/openapi/v3.yaml` (1782 lines) - Used by the pre-rewrite Python HolmesGPT-API ("HAPI")
 - `api/openapi/data-storage-v1.yaml` (701 lines) - Used for Go client
 
 **Solution**: Consolidated to single authoritative spec in standard location (`api/openapi/`)
@@ -29,20 +36,14 @@ api/openapi/data-storage-v1.yaml
 
 ## 🚀 **CLIENT GENERATION**
 
-### **Go Client**:
-```bash
-oapi-codegen -package client -generate types,client \
-  -o pkg/datastorage/client/generated.go \
-  api/openapi/data-storage-v1.yaml
-```
+All consumers — including Kubernaut Agent (KA), which was rewritten in Go (Issue #433) and no longer
+has a Python client — generate a single shared Go client from the authoritative spec via `ogen`
+(`pkg/datastorage/ogen-client/gen.go`):
 
-### **Python Client** (HAPI):
 ```bash
-podman run --rm -v ${PWD}:/local:z openapitools/openapi-generator-cli generate \
-  -i /local/api/openapi/data-storage-v1.yaml \
-  -g python \
-  -o /local/kubernaut-agent/src/clients/datastorage \
-  --package-name datastorage_client
+make generate-datastorage-client
+# equivalent to: go generate ./pkg/datastorage/ogen-client/...
+# regenerates pkg/datastorage/ogen-client/oas_*_gen.go from api/openapi/data-storage-v1.yaml
 ```
 
 ---

--- a/pkg/audit/openapi_spec_data.yaml
+++ b/pkg/audit/openapi_spec_data.yaml
@@ -1753,7 +1753,7 @@ components:
             - gateway: Gateway signal and CRD lifecycle events
             - notification: Notification delivery and escalation events
             - analysis: AI analysis, agent calls, and rego evaluation events
-            - aiagent: AI Agent Provider (HolmesGPT API) - autonomous tool-calling agent
+            - aiagent: AI Agent Provider (Kubernaut Agent, KA) - autonomous tool-calling agent
             - signalprocessing: Signal Processing Service
             - workflow: Workflow catalog and discovery events
             - workflowexecution: Workflow execution lifecycle events
@@ -2184,7 +2184,7 @@ components:
               nullable: true
 
     # ========================================
-    # WORKFLOW DISCOVERY SCHEMAS (DD-WORKFLOW-016, DD-HAPI-017)
+    # WORKFLOW DISCOVERY SCHEMAS (DD-WORKFLOW-016, DD-KA-017 formerly DD-HAPI-017)
     # ========================================
     # The three-step discovery protocol's own response types (ActionTypeListResponse,
     # WorkflowDiscoveryResponse, WorkflowDiscoveryEntry, RemediationWorkflow,
@@ -2599,7 +2599,7 @@ components:
         message:
           type: string
           description: Human-readable error description
-          example: "Holmes API request timeout after 30s"
+          example: "Kubernaut Agent (KA) request timeout after 30s"
         code:
           type: string
           description: Machine-readable error classification (ERR_[CATEGORY]_[SPECIFIC])
@@ -2844,7 +2844,7 @@ components:
           type: string
           description: |
             Action type from DD-WORKFLOW-016 taxonomy (e.g., ScaleReplicas, RestartPod).
-            Propagated from AIAnalysis.SelectedWorkflow.ActionType via HAPI three-step discovery.
+            Propagated from AIAnalysis.SelectedWorkflow.ActionType via KA's three-step discovery protocol.
             Used by DS remediation history to populate actionType on entries and summaries.
           example: "ScaleReplicas"
 
@@ -3912,7 +3912,7 @@ components:
           description: |
             Structured health check results from the K8s API assessment.
             Only present for effectiveness.health.assessed events.
-            Enables downstream consumers (DS, HAPI) to extract typed fields
+            Enables downstream consumers (DS, KA) to extract typed fields
             without parsing the human-readable details string.
           properties:
             pod_running:
@@ -4193,13 +4193,13 @@ components:
           description: Updated description
           example: "Updated workflow description"
 
-    # Workflow Discovery Events (DD-HAPI-017, DD-WORKFLOW-014 v3.0)
+    # Workflow Discovery Events (DD-KA-017 formerly DD-HAPI-017, DD-WORKFLOW-014 v3.0)
     WorkflowDiscoveryAuditPayload:
       type: object
       required: [event_type, query, results, search_metadata]
       description: |
         Audit event payload for three-step workflow discovery operations.
-        Authority: DD-HAPI-017 (Three-Step Workflow Discovery Integration)
+        Authority: DD-KA-017 (Three-Step Workflow Discovery Integration, formerly DD-HAPI-017)
         Authority: DD-WORKFLOW-014 v3.0 (Workflow Selection Audit Trail)
         Replaces WorkflowSearchAuditPayload (search endpoint removed).
       properties:
@@ -4431,12 +4431,12 @@ components:
         error_message:
           type: string
           description: Error message
-          example: "HolmesGPT API timeout after 30s"
+          example: "Kubernaut Agent (KA) timeout after 30s"
 
     ProviderResponseSummary:
       type: object
       required: [incident_id, analysis_preview, needs_human_review, warnings_count]
-      description: Summary of Holmes API response from AIAnalysis consumer perspective (BR-AUDIT-005 v2.0 Gap #4)
+      description: Summary of Kubernaut Agent (KA) response from AIAnalysis consumer perspective (BR-AUDIT-005 v2.0 Gap #4)
       properties:
         incident_id:
           type: string
@@ -4455,7 +4455,7 @@ components:
           description: Whether human review is required
         warnings_count:
           type: integer
-          description: Number of warnings from Holmes
+          description: Number of warnings from Kubernaut Agent (KA)
           example: 2
 
     # ========================================
@@ -4550,8 +4550,9 @@ components:
             type: string
 
     # ========================================
-    # HolmesGPT API Event Payloads
-    # From: kubernaut-agent/src/models/audit_models.py
+    # Kubernaut Agent (KA) Event Payloads
+    # From: internal/kubernautagent/audit/ds_payloads.go (rewritten in Go, Issue #433;
+    # formerly kubernaut-agent/src/models/audit_models.py under the pre-rewrite Python HAPI)
     # ========================================
 
     AIAgentResponsePayload:
@@ -4732,7 +4733,7 @@ components:
     IncidentResponseData:
       type: object
       required: [incidentId, analysis, rootCauseAnalysis, confidence, timestamp]
-      description: Complete IncidentResponse structure from HolmesGPT API (DD-AUDIT-004 - strongly typed, no additionalProperties)
+      description: Complete IncidentResponse structure from Kubernaut Agent (KA) (DD-AUDIT-004 - strongly typed, no additionalProperties)
       properties:
         incidentId:
           type: string
@@ -4829,7 +4830,7 @@ components:
               type: string
               description: |
                 Action type from DD-WORKFLOW-016 taxonomy (e.g., ScaleReplicas, RestartPod).
-                Propagated from HAPI three-step discovery protocol.
+                Propagated from KA's three-step discovery protocol.
               example: "ScaleReplicas"
             executionBundle:
               type: string

--- a/pkg/datastorage/ogen-client/oas_schemas_gen.go
+++ b/pkg/datastorage/ogen-client/oas_schemas_gen.go
@@ -7586,7 +7586,7 @@ type AuditEvent struct {
 	// - gateway: Gateway signal and CRD lifecycle events
 	// - notification: Notification delivery and escalation events
 	// - analysis: AI analysis, agent calls, and rego evaluation events
-	// - aiagent: AI Agent Provider (HolmesGPT API) - autonomous tool-calling agent
+	// - aiagent: AI Agent Provider (Kubernaut Agent, KA) - autonomous tool-calling agent
 	// - signalprocessing: Signal Processing Service
 	// - workflow: Workflow catalog and discovery events
 	// - workflowexecution: Workflow execution lifecycle events
@@ -7961,7 +7961,7 @@ func (s *AuditEvent) SetLegalHoldPlacedAt(val OptNilDateTime) {
 // - gateway: Gateway signal and CRD lifecycle events
 // - notification: Notification delivery and escalation events
 // - analysis: AI analysis, agent calls, and rego evaluation events
-// - aiagent: AI Agent Provider (HolmesGPT API) - autonomous tool-calling agent
+// - aiagent: AI Agent Provider (Kubernaut Agent, KA) - autonomous tool-calling agent
 // - signalprocessing: Signal Processing Service
 // - workflow: Workflow catalog and discovery events
 // - workflowexecution: Workflow execution lifecycle events
@@ -11258,7 +11258,7 @@ type AuditEventRequest struct {
 	// - gateway: Gateway signal and CRD lifecycle events
 	// - notification: Notification delivery and escalation events
 	// - analysis: AI analysis, agent calls, and rego evaluation events
-	// - aiagent: AI Agent Provider (HolmesGPT API) - autonomous tool-calling agent
+	// - aiagent: AI Agent Provider (Kubernaut Agent, KA) - autonomous tool-calling agent
 	// - signalprocessing: Signal Processing Service
 	// - workflow: Workflow catalog and discovery events
 	// - workflowexecution: Workflow execution lifecycle events
@@ -11543,7 +11543,7 @@ func (s *AuditEventRequest) SetEventData(val AuditEventRequestEventData) {
 // - gateway: Gateway signal and CRD lifecycle events
 // - notification: Notification delivery and escalation events
 // - analysis: AI analysis, agent calls, and rego evaluation events
-// - aiagent: AI Agent Provider (HolmesGPT API) - autonomous tool-calling agent
+// - aiagent: AI Agent Provider (Kubernaut Agent, KA) - autonomous tool-calling agent
 // - signalprocessing: Signal Processing Service
 // - workflow: Workflow catalog and discovery events
 // - workflowexecution: Workflow execution lifecycle events
@@ -16368,7 +16368,7 @@ type EffectivenessAssessmentAuditPayload struct {
 	HashMatch OptBool `json:"hash_match"`
 	// Structured health check results from the K8s API assessment.
 	// Only present for effectiveness.health.assessed events.
-	// Enables downstream consumers (DS, HAPI) to extract typed fields
+	// Enables downstream consumers (DS, KA) to extract typed fields
 	// without parsing the human-readable details string.
 	HealthChecks OptEffectivenessAssessmentAuditPayloadHealthChecks `json:"health_checks"`
 	// Structured pre/post remediation metric comparison results from Prometheus.
@@ -16880,7 +16880,7 @@ func (s *EffectivenessAssessmentAuditPayloadEventType) UnmarshalText(data []byte
 
 // Structured health check results from the K8s API assessment.
 // Only present for effectiveness.health.assessed events.
-// Enables downstream consumers (DS, HAPI) to extract typed fields
+// Enables downstream consumers (DS, KA) to extract typed fields
 // without parsing the human-readable details string.
 type EffectivenessAssessmentAuditPayloadHealthChecks struct {
 	// Whether at least one pod exists for the target resource.
@@ -18315,7 +18315,7 @@ func (s *HashComparisonData) SetHashMatch(val OptNilBool) {
 	s.HashMatch = val
 }
 
-// Complete IncidentResponse structure from HolmesGPT API (DD-AUDIT-004 - strongly typed, no
+// Complete IncidentResponse structure from Kubernaut Agent (KA) (DD-AUDIT-004 - strongly typed, no
 // additionalProperties).
 // Ref: #/components/schemas/IncidentResponseData
 type IncidentResponseData struct {
@@ -18892,7 +18892,7 @@ func (s *IncidentResponseDataRootCauseAnalysisSeverity) UnmarshalText(data []byt
 type IncidentResponseDataSelectedWorkflow struct {
 	WorkflowId OptString `json:"workflowId"`
 	// Action type from DD-WORKFLOW-016 taxonomy (e.g., ScaleReplicas, RestartPod).
-	// Propagated from HAPI three-step discovery protocol.
+	// Propagated from KA's three-step discovery protocol.
 	ActionType      OptString                                         `json:"actionType"`
 	ExecutionBundle OptString                                         `json:"executionBundle"`
 	Confidence      OptFloat32                                        `json:"confidence"`
@@ -25057,7 +25057,8 @@ type PlaceLegalHoldUnauthorized RFC7807Problem
 
 func (*PlaceLegalHoldUnauthorized) placeLegalHoldRes() {}
 
-// Summary of Holmes API response from AIAnalysis consumer perspective (BR-AUDIT-005 v2.0 Gap.
+// Summary of Kubernaut Agent (KA) response from AIAnalysis consumer perspective (BR-AUDIT-005 v2.0
+// Gap.
 // Ref: #/components/schemas/ProviderResponseSummary
 type ProviderResponseSummary struct {
 	// Incident identifier.
@@ -25068,7 +25069,7 @@ type ProviderResponseSummary struct {
 	SelectedWorkflowID OptString `json:"selected_workflow_id"`
 	// Whether human review is required.
 	NeedsHumanReview bool `json:"needs_human_review"`
-	// Number of warnings from Holmes.
+	// Number of warnings from Kubernaut Agent (KA).
 	WarningsCount int `json:"warnings_count"`
 }
 
@@ -27117,7 +27118,7 @@ type RemediationOrchestratorAuditPayload struct {
 	// Version of the selected workflow.
 	WorkflowVersion OptString `json:"workflow_version"`
 	// Action type from DD-WORKFLOW-016 taxonomy (e.g., ScaleReplicas, RestartPod).
-	// Propagated from AIAnalysis.SelectedWorkflow.ActionType via HAPI three-step discovery.
+	// Propagated from AIAnalysis.SelectedWorkflow.ActionType via KA's three-step discovery protocol.
 	// Used by DS remediation history to populate actionType on entries and summaries.
 	ActionType OptString `json:"action_type"`
 	// Signal type that triggered the remediation (e.g., "alert", "event").
@@ -30692,7 +30693,7 @@ func (s *WorkflowCatalogUpdatedPayload) SetUpdatedFields(val WorkflowCatalogUpda
 }
 
 // Audit event payload for three-step workflow discovery operations.
-// Authority: DD-HAPI-017 (Three-Step Workflow Discovery Integration)
+// Authority: DD-KA-017 (Three-Step Workflow Discovery Integration, formerly DD-HAPI-017)
 // Authority: DD-WORKFLOW-014 v3.0 (Workflow Selection Audit Trail)
 // Replaces WorkflowSearchAuditPayload (search endpoint removed).
 // Ref: #/components/schemas/WorkflowDiscoveryAuditPayload

--- a/pkg/datastorage/server/middleware/openapi_spec_data.yaml
+++ b/pkg/datastorage/server/middleware/openapi_spec_data.yaml
@@ -1753,7 +1753,7 @@ components:
             - gateway: Gateway signal and CRD lifecycle events
             - notification: Notification delivery and escalation events
             - analysis: AI analysis, agent calls, and rego evaluation events
-            - aiagent: AI Agent Provider (HolmesGPT API) - autonomous tool-calling agent
+            - aiagent: AI Agent Provider (Kubernaut Agent, KA) - autonomous tool-calling agent
             - signalprocessing: Signal Processing Service
             - workflow: Workflow catalog and discovery events
             - workflowexecution: Workflow execution lifecycle events
@@ -2184,7 +2184,7 @@ components:
               nullable: true
 
     # ========================================
-    # WORKFLOW DISCOVERY SCHEMAS (DD-WORKFLOW-016, DD-HAPI-017)
+    # WORKFLOW DISCOVERY SCHEMAS (DD-WORKFLOW-016, DD-KA-017 formerly DD-HAPI-017)
     # ========================================
     # The three-step discovery protocol's own response types (ActionTypeListResponse,
     # WorkflowDiscoveryResponse, WorkflowDiscoveryEntry, RemediationWorkflow,
@@ -2599,7 +2599,7 @@ components:
         message:
           type: string
           description: Human-readable error description
-          example: "Holmes API request timeout after 30s"
+          example: "Kubernaut Agent (KA) request timeout after 30s"
         code:
           type: string
           description: Machine-readable error classification (ERR_[CATEGORY]_[SPECIFIC])
@@ -2844,7 +2844,7 @@ components:
           type: string
           description: |
             Action type from DD-WORKFLOW-016 taxonomy (e.g., ScaleReplicas, RestartPod).
-            Propagated from AIAnalysis.SelectedWorkflow.ActionType via HAPI three-step discovery.
+            Propagated from AIAnalysis.SelectedWorkflow.ActionType via KA's three-step discovery protocol.
             Used by DS remediation history to populate actionType on entries and summaries.
           example: "ScaleReplicas"
 
@@ -3912,7 +3912,7 @@ components:
           description: |
             Structured health check results from the K8s API assessment.
             Only present for effectiveness.health.assessed events.
-            Enables downstream consumers (DS, HAPI) to extract typed fields
+            Enables downstream consumers (DS, KA) to extract typed fields
             without parsing the human-readable details string.
           properties:
             pod_running:
@@ -4193,13 +4193,13 @@ components:
           description: Updated description
           example: "Updated workflow description"
 
-    # Workflow Discovery Events (DD-HAPI-017, DD-WORKFLOW-014 v3.0)
+    # Workflow Discovery Events (DD-KA-017 formerly DD-HAPI-017, DD-WORKFLOW-014 v3.0)
     WorkflowDiscoveryAuditPayload:
       type: object
       required: [event_type, query, results, search_metadata]
       description: |
         Audit event payload for three-step workflow discovery operations.
-        Authority: DD-HAPI-017 (Three-Step Workflow Discovery Integration)
+        Authority: DD-KA-017 (Three-Step Workflow Discovery Integration, formerly DD-HAPI-017)
         Authority: DD-WORKFLOW-014 v3.0 (Workflow Selection Audit Trail)
         Replaces WorkflowSearchAuditPayload (search endpoint removed).
       properties:
@@ -4431,12 +4431,12 @@ components:
         error_message:
           type: string
           description: Error message
-          example: "HolmesGPT API timeout after 30s"
+          example: "Kubernaut Agent (KA) timeout after 30s"
 
     ProviderResponseSummary:
       type: object
       required: [incident_id, analysis_preview, needs_human_review, warnings_count]
-      description: Summary of Holmes API response from AIAnalysis consumer perspective (BR-AUDIT-005 v2.0 Gap #4)
+      description: Summary of Kubernaut Agent (KA) response from AIAnalysis consumer perspective (BR-AUDIT-005 v2.0 Gap #4)
       properties:
         incident_id:
           type: string
@@ -4455,7 +4455,7 @@ components:
           description: Whether human review is required
         warnings_count:
           type: integer
-          description: Number of warnings from Holmes
+          description: Number of warnings from Kubernaut Agent (KA)
           example: 2
 
     # ========================================
@@ -4550,8 +4550,9 @@ components:
             type: string
 
     # ========================================
-    # HolmesGPT API Event Payloads
-    # From: kubernaut-agent/src/models/audit_models.py
+    # Kubernaut Agent (KA) Event Payloads
+    # From: internal/kubernautagent/audit/ds_payloads.go (rewritten in Go, Issue #433;
+    # formerly kubernaut-agent/src/models/audit_models.py under the pre-rewrite Python HAPI)
     # ========================================
 
     AIAgentResponsePayload:
@@ -4732,7 +4733,7 @@ components:
     IncidentResponseData:
       type: object
       required: [incidentId, analysis, rootCauseAnalysis, confidence, timestamp]
-      description: Complete IncidentResponse structure from HolmesGPT API (DD-AUDIT-004 - strongly typed, no additionalProperties)
+      description: Complete IncidentResponse structure from Kubernaut Agent (KA) (DD-AUDIT-004 - strongly typed, no additionalProperties)
       properties:
         incidentId:
           type: string
@@ -4829,7 +4830,7 @@ components:
               type: string
               description: |
                 Action type from DD-WORKFLOW-016 taxonomy (e.g., ScaleReplicas, RestartPod).
-                Propagated from HAPI three-step discovery protocol.
+                Propagated from KA's three-step discovery protocol.
               example: "ScaleReplicas"
             executionBundle:
               type: string


### PR DESCRIPTION
## Summary

Group L of [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806) — the requirements/API-server/data-storage cluster. Unlike the mechanical rename groups, these files needed verification against actual current source (Go rewrite of HolmesGPT-API → **Kubernaut Agent (KA)**, Issue #433) before rewriting, since several describe architecture that predates the CRD-based rewrite entirely and is no longer accurate in any form.

### Files corrected

- **`docs/requirements/EXECUTION_INFRASTRUCTURE_CAPABILITIES.md`** — marked `SUPERSEDED`. Entire doc describes a pre-CRD-rewrite `ActionExecutor`/Workflow Engine framework (`pkg/workflow/engine/`, `pkg/platform/executor/`) — confirmed **removed from the codebase** (zero references). Banner points readers to the real current mechanism: `AIAnalysis` + KA for investigation, `WorkflowExecution` + Tekton `PipelineRun` (ADR-043/044) for execution.
- **`docs/requirements/enhancements/HOLMESGPT_INVESTIGATION_SEPARATION.md`** — title changed to "Investigation/Execution Separation" (matches the `docs/README.md` TOC label that anticipated this rewrite). Verified the doc's core principle — AI investigation must not directly execute infrastructure changes — **is implemented today**, just via different CRD-based mechanisms than proposed (evidence cited: `pkg/aianalysis/`, `internal/kubernautagent/`, `pkg/workflowexecution/`). Flagged two dead file references (`13_HOLMESGPT_REST_API_WRAPPER.md`, `REQUIREMENTS_BASED_ARCHITECTURE_DIAGRAM.md` — both removed, no direct successor) and marked the specific `BR-HAPI-*`/`ActionExecutor` proposals as superseded.
- **`docs/requirements/enhancements/AI_CONTEXT_ORCHESTRATION.md`** — marked `SUPERSEDED` to match its sibling `10_AI_CONTEXT_ORCHESTRATION.md` (already corrected in Group D) — the standalone Context API service was deprecated per [DD-CONTEXT-006](https://github.com/jordigilh/kubernaut/blob/main/docs/architecture/decisions/DD-CONTEXT-006-CONTEXT-API-DEPRECATION.md). Also fixed a broken relative link to the sibling doc.
- **`docs/requirements/12_API_SERVER_SERVICES.md`** — marked `SUPERSEDED`. Describes an aspirational `pkg/api/server/` enterprise API gateway (GraphQL, Kong/Istio, HSM, multi-region DR) that was never built — `pkg/api/server/` doesn't exist. Pointed to the real current external API surface, **APIFrontend** (`pkg/apifrontend/`, `docs/services/apifrontend/`).
- **`docs/requirements/BR-GATEWAY-184-target-resource-extraction-priority.md`** — renamed the "HAPI Prompt" section to "Kubernaut Agent (KA) Prompt" and fixed a stale Python source path to the real Go equivalent (`internal/kubernautagent/prompt/builder.go`).
- **`api/openapi/data-storage-v1.yaml`** (the actual Data Storage OpenAPI spec — authoritative per its own README pointer) — renamed HolmesGPT API/Holmes/HAPI mentions to Kubernaut Agent (KA) across schema descriptions/examples; updated `DD-HAPI-017` → `DD-KA-017` (a formally renamed decision doc already exists); fixed a stale Python source-file comment to the real Go path.
- **`docs/services/stateless/data-storage/api-specification.md`** — renamed an illustrative `HolmesGPTService` example type to `KAService`. Verified the doc's own "disabled since V1.0" banner for the multi-dimensional success-rate API already correctly caveats that section's historical status — no change needed there.
- **`docs/services/stateless/data-storage/openapi/README.md`** — corrected the "Client Generation" section, which described a nonexistent `oapi-codegen` Go client path and a Python client for HAPI that no longer exists. Replaced with the real `ogen`-based generation flow (`pkg/datastorage/ogen-client`, `make generate-datastorage-client`), verified against the `Makefile` and `gen.go` generate directive.
- **`docs/services/SERVICE_DOCUMENTATION_GUIDE.md`** — renamed HolmesGPT → Kubernaut Agent (KA); corrected a fictional `AIApprovalRequest` CRD reference to the real `RemediationApprovalRequest`; removed a dead link to the deprecated Context API service's testing-strategy doc; replaced the stale "10/11 Go services + 1 Python service (HolmesGPT API)" split with language reflecting all 12 active services being Go.
- **`docs/README.md`** — updated the two enhancement-doc TOC entries to reflect the corrections above instead of the prior "still needs a content rewrite" placeholder note.

### Explicitly left unchanged (with reasons)

- **`BR-HAPI-*` requirement IDs** and **`DD-HAPI-017`** (where no formally renamed doc exists) — left as-is per the ID-preservation policy; `DD-HAPI-017` → `DD-KA-017` was only applied where a formally renamed decision doc (`DD-KA-017-three-step-workflow-discovery-integration.md`) was confirmed to exist.
- **`docs/services/stateless/data-storage/BUSINESS_REQUIREMENTS.md`** — checked; already substantively corrected by prior PRs (#1843 rewrite, quick-win ID cleanup commits). The two remaining raw "HolmesGPT-API"/"HAPI" strings are inside a historical changelog entry describing a Dec-2025 documentation state, correctly left unrenamed.
- **`docs/requirements/10_AI_CONTEXT_ORCHESTRATION.md`** — already corrected in the prior Group D PR (verified via `git log`); not touched here.
- **`docs/services/crd-controllers/02-aianalysis/overview.md`** — already fully rewritten today (2026-08-02) as part of this same issue; used as an evidence source for this PR's banners, not modified.
- Body prose inside the two `SUPERSEDED` docs (`AI_CONTEXT_ORCHESTRATION.md`, `EXECUTION_INFRASTRUCTURE_CAPABILITIES.md`, `HOLMESGPT_INVESTIGATION_SEPARATION.md`, `12_API_SERVER_SERVICES.md`) retains its original "HolmesGPT" wording below the correction banners — consistent with the established pattern on the already-corrected sibling doc, and with this issue's style guide: genuinely historical content gets a clarifying banner, not a silent rename.

### Out-of-scope items noticed (for separate tracking)

- `docs/requirements/BR-AA-HAPI-064-session-based-pull-design.md`, `docs/requirements/BR-AUDIT-021-030-WORKFLOW-SELECTION-AUDIT-TRAIL.md`, and other `BR-*`/`docs/services/crd-controllers/{02-aianalysis,05-remediationorchestrator,07-effectivenessmonitor}/*` files with HAPI/HolmesGPT hits — not in Group L's explicit scope; several already show signs of being mid-rewrite by concurrent groups.
- `docs/services/stateless/kubernaut-agent/*` (KA's own service docs) and `docs/services/stateless/dynamic-toolset/*` — out of scope, likely owned by a different, KA/toolset-specific group.
- `docs/mcp/discover-workflows-contract.md` — out of scope (MCP-contract-specific group).

## Test plan

Docs-only change — no code, build, or test impact.

- [x] `grep -rn "HolmesGPT\|HAPI"` re-run against every touched file; all remaining hits confirmed intentional (banner explanations or untouched historical body prose)
- [x] All new/edited relative markdown links verified to resolve to real files on disk
- [x] Cross-checked every technical claim (CRD names, package paths, Makefile targets, decision-doc IDs) against actual `pkg/`, `internal/`, `api/`, and `Makefile` source before citing as current

Made with [Cursor](https://cursor.com)