### PR TITLE
docs(1806): correct HAPI/HolmesGPT references in Group K (test infra/container/auth)

### DIFF
--- a/docs/architecture/CRD_SCHEMAS.md
+++ b/docs/architecture/CRD_SCHEMAS.md
@@ -812,6 +812,15 @@ For schemas of CRDs created by Central Controller:
 
 **Purpose**: Temporary file containing schema extensions to be appended to `CRD_SCHEMAS.md`
 
+> **⚠️ CORRECTED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: Beyond
+> the section-level DEPRECATED status above, the `AIAnalysisSpec` Go snippet below (including the
+> `LLMProvider` field and its `holmesgpt` enum value) does not match the current
+> `api/aianalysis/v1alpha1/aianalysis_types.go`, which has no `LLMProvider`/`llmProvider` field at all —
+> Kubernaut Agent (KA) is the sole analysis backend invoked by the AIAnalysis controller today, selected
+> via KA's own runtime LLM profile configuration (`kubernautAgent.llmProfileRef` in
+> `charts/kubernaut/values.yaml`), not a per-CRD enum. Treat this entire extension section as historical;
+> defer to the Go types for the authoritative current schema, as the note below already instructs.
+
 ---
 
 ## 🎯 AIAnalysis CRD

--- a/docs/architecture/ERROR_HANDLING_STANDARD.md
+++ b/docs/architecture/ERROR_HANDLING_STANDARD.md
@@ -769,7 +769,7 @@ Go 1.13 introduced error wrapping with `%w` verb. Always use `%w` to preserve er
 ```go
 // ✅ CORRECT: Use %w to wrap errors
 func (s *AIAnalysisService) analyzeAlert(ctx context.Context, alert *Alert) error {
-    result, err := s.holmesClient.Analyze(ctx, alert)
+    result, err := s.kaClient.Analyze(ctx, alert)
     if err != nil {
         return fmt.Errorf("KA analysis failed: %w", err)
     }
@@ -1008,12 +1008,12 @@ var ServiceTimeouts = map[string]time.Duration{
     "data-storage-write":     10 * time.Second,
     "gateway-webhook":        30 * time.Second,
     "context-api-query":      15 * time.Second,
-    "holmesgpt-analysis":     60 * time.Second,
+    "ka-analysis":            60 * time.Second,
     "notification-send":      30 * time.Second,
     "effectiveness-assess":   45 * time.Second,
 
     // External Service Timeouts
-    "holmesgpt-external":     120 * time.Second,
+    "ka-external":            120 * time.Second,
     "prometheus-query":       30 * time.Second,
     "kubernetes-api":         15 * time.Second,
     "redis-operation":        5 * time.Second,
@@ -1215,12 +1215,12 @@ func (rb *RetryBudget) Remaining() int {
 
 ```go
 // Example: Retry with backoff for upstream service call
-func (s *AIAnalysisService) callHolmesGPT(ctx context.Context, req *AnalysisRequest) (*AnalysisResponse, error) {
+func (s *AIAnalysisService) callKubernautAgent(ctx context.Context, req *AnalysisRequest) (*AnalysisResponse, error) {
     var resp *AnalysisResponse
 
     err := retry.RetryWithBackoff(ctx, retry.NormalRetry, func() error {
         var err error
-        resp, err = s.holmesClient.Analyze(ctx, req)
+        resp, err = s.kaClient.Analyze(ctx, req)
         if err != nil {
             // Classify error to determine if retryable
             if isNetworkError(err) {
@@ -1291,7 +1291,7 @@ type Config struct {
 }
 
 var Configurations = map[string]Config{
-    "holmesgpt-external": {
+    "ka-external": {
         MaxFailures: 5,
         Timeout:     5 * time.Minute, // Longer timeout for external AI
         HalfOpenMax: 1,
@@ -1604,7 +1604,7 @@ type KubernautAgentClient struct {
 }
 
 func NewKubernautAgentClient() *KubernautAgentClient {
-    config := circuitbreaker.Configurations["holmesgpt-external"]
+    config := circuitbreaker.Configurations["ka-external"]
     breaker := circuitbreaker.NewMetricsCircuitBreaker(config, "ai-analysis", "ka")
 
     return &KubernautAgentClient{

--- a/docs/architecture/decisions/ADR-027-multi-architecture-build-strategy.md
+++ b/docs/architecture/decisions/ADR-027-multi-architecture-build-strategy.md
@@ -55,6 +55,13 @@ This pattern affects **all 11+ Kubernaut services** and will impact every develo
 - **Runtime Stage**: `registry.access.redhat.com/ubi10/ubi-minimal:latest`
 
 #### **For Python Services** (e.g., HolmesGPT API)
+
+> **⚠️ CORRECTED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**:
+> "HolmesGPT API" was the pre-rewrite name of what is now Kubernaut Agent (KA), rewritten to native
+> Go per issue #433 (see `docker/kubernautagent.Dockerfile`). No Python-based production service
+> remains in Kubernaut today; this pattern is retained for reference should a future Python-based
+> service be added.
+
 - **Build Stage**: `registry.access.redhat.com/ubi10/python-312:latest`
 - **Runtime Stage**: `registry.access.redhat.com/ubi10/python-312:latest`
 
@@ -422,7 +429,8 @@ build-image:
 
 **Stateless Services**:
 6. gateway-service - Status TBD
-7. **kubernaut-agent-service** - ✅ **Already UBI10 Compliant** (Python UBI10)
+7. **kubernaut-agent-service** - ✅ **Already UBI10 Compliant** (Python UBI10 at time of writing;
+   rewritten to native Go per issue #433 — see `docker/kubernautagent.Dockerfile`, still UBI10-based)
 8. **context-api-service** - ⚠️ **Requires UBI10 Implementation** (new service)
 9. data-storage-service - Status TBD
 10. effectiveness-monitor-service - Status TBD
@@ -564,7 +572,7 @@ build-image:
 |---|---|---|---|---|---|
 | **notification** | alpine/distroless | UBI10 Go + minimal | **P1 - HIGH** | 2-3 hours | Week 2 |
 | **context-api** | N/A (new) | UBI10 Go + minimal | **P1 - HIGH** | 1 hour (doc only) | Day 9 |
-| **kubernaut-agent** | UBI10 Python ✅ | N/A (compliant) | N/A | 0 hours | ✅ Complete |
+| **kubernaut-agent** | UBI10 Python ✅ (at time of writing; now UBI10 Go per issue #433) | N/A (compliant) | N/A | 0 hours | ✅ Complete |
 | **workflow-service** | UBI10 Go ✅ | N/A (compliant) | N/A | 0 hours | ✅ Complete |
 | Other services | TBD | UBI10 (appropriate) | P2-P3 | TBD | Weeks 3-4 |
 

--- a/docs/architecture/decisions/ADR-028-container-registry-policy.md
+++ b/docs/architecture/decisions/ADR-028-container-registry-policy.md
@@ -305,6 +305,12 @@ FROM registry.access.redhat.com/ubi10/ubi:latest
 
 #### **For Python Services** (e.g., HolmesGPT API)
 
+> **⚠️ CORRECTED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**:
+> "HolmesGPT API" was the pre-rewrite name of what is now Kubernaut Agent (KA), rewritten to native
+> Go per issue #433 (see `docker/kubernautagent.Dockerfile`). No Python-based production service
+> remains in Kubernaut today; this pattern is retained for reference should a future Python-based
+> service be added.
+
 **Standard Single-Stage Pattern**:
 
 ```dockerfile

--- a/docs/architecture/decisions/DD-016-dynamic-toolset-v2-deferral.md
+++ b/docs/architecture/decisions/DD-016-dynamic-toolset-v2-deferral.md
@@ -25,7 +25,9 @@ During V1.x development, the **Kubernaut Agent (KA) service architecture** is un
 
 ### Business Requirements Context
 
-**Dynamic Toolset Service Business Requirements**:
+**Dynamic Toolset Service Business Requirements** (BR-HOLMES-XXX IDs kept as-is; no formal BR-KA-XXX
+renumbering exists for these deferred/unimplemented requirements — tracked separately under
+[Issue #1829](https://github.com/jordigilh/kubernaut/issues/1829)):
 - **BR-HOLMES-016**: Dynamic service discovery in Kubernetes cluster
 - **BR-HOLMES-017**: Automatic detection of well-known services
 - **BR-HOLMES-020**: Real-time toolset configuration updates
@@ -239,7 +241,10 @@ When V2.0 expands Kubernaut Agent to identify and integrate with **other observa
 - **MANDATORY**: When V2.0 roadmap includes expanding Kubernaut Agent beyond Prometheus to **multi-service observability** (Grafana, Jaeger, Elasticsearch, custom services)
 - **MANDATORY**: Before V2.0 planning begins (estimated Q3 2025) to assess multi-service discovery requirements
 - **OPTIONAL**: If V1.x users report critical need for automatic multi-service discovery (user feedback loop)
-- **OPTIONAL**: If HolmesGPT SDK significantly changes multi-service toolset configuration approach
+- **OPTIONAL**: If Kubernaut Agent's toolset configuration approach for multi-service discovery changes
+  significantly (this trigger originally referenced the "HolmesGPT SDK"; Kubernaut Agent (KA) was
+  rewritten as a native Go service per issue #433 and no longer depends on that Python SDK — see
+  `internal/kubernautagent/` for the current implementation)
 
 ### Success Metrics (V2.0)
 

--- a/docs/architecture/decisions/DD-AUTH-008-secret-management-kustomize-helm.md
+++ b/docs/architecture/decisions/DD-AUTH-008-secret-management-kustomize-helm.md
@@ -1,9 +1,22 @@
 # DD-AUTH-008: Secret Management Strategy (Kustomize + Helm)
 
 **Date**: January 26, 2026
-**Status**: ✅ **APPROVED** - Authoritative
+**Status**: ✅ **APPROVED** - Authoritative (general pattern) / ⚠️ Worked examples below are stale — see note
 **Authority**: Supersedes inline secret generation approaches
 **Related**: DD-AUTH-007 (OAuth2-Proxy Migration), DD-AUTH-004 (DataStorage OAuth), DD-AUTH-006 (Kubernaut Agent (KA) OAuth)
+
+> **⚠️ CORRECTED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: The
+> worked examples below use DataStorage and "HolmesGPT API" (now Kubernaut Agent (KA)) `ose-oauth-proxy`
+> cookie secrets as their running example. Per [DD-AUTH-011](DD-AUTH-011/DD-AUTH-011-granular-rbac-sar-verb-mapping.md)
+> and [DD-AUTH-014](DD-AUTH-014-middleware-based-sar-authentication.md), **both services have since
+> removed the `ose-oauth-proxy` sidecar** in favor of in-process Go middleware doing TokenReview/
+> SubjectAccessReview directly — confirmed by `charts/kubernaut/templates/datastorage/` and
+> `charts/kubernaut/templates/kubernaut-agent/`, neither of which has an `oauth-proxy` container or
+> `cookie-secret` volume today. The Kustomize-generates/Helm-references **separation-of-concerns
+> principle** this document establishes is still valid and still used elsewhere (e.g., the `console`
+> service's oauth2-proxy cookie-secret, see `charts/kubernaut/values.yaml`) — only the specific
+> DataStorage/KA cookie-secret examples below are now historical. The current values.yaml key for KA
+> is `kubernautAgent` (not `holmesgptApi` as shown below).
 
 ---
 

--- a/docs/architecture/decisions/DD-AUTH-013/DD-AUTH-013-http-status-codes-oauth-proxy.md
+++ b/docs/architecture/decisions/DD-AUTH-013/DD-AUTH-013-http-status-codes-oauth-proxy.md
@@ -5,6 +5,15 @@
 **Version**: 1.0  
 **Authority**: Defines HTTP status codes returned by ose-oauth-proxy sidecar
 
+> **⚠️ CORRECTED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: Since
+> this document was written, [DD-AUTH-014](../DD-AUTH-014-middleware-based-sar-authentication.md) removed
+> the `ose-oauth-proxy` sidecar from both DataStorage and Kubernaut Agent (KA) — they now perform
+> authentication/authorization via in-process Go middleware calling the Kubernetes TokenReview/
+> SubjectAccessReview APIs directly, not a sidecar container. Every "**Source**: `ose-oauth-proxy`
+> sidecar" attribution below should now be read as "in-process auth middleware." The status codes
+> themselves (401/403/400/422/500) and their triggering conditions are unaffected and remain the
+> authoritative reference.
+
 ---
 
 ## 🎯 **OBJECTIVE**

--- a/docs/architecture/decisions/DD-AUTH-013/README.md
+++ b/docs/architecture/decisions/DD-AUTH-013/README.md
@@ -1,8 +1,18 @@
 # DD-AUTH-013: HTTP Status Codes for OAuth-Proxy - Document Index
 
-**Status**: ✅ AUTHORITATIVE  
+**Status**: ✅ AUTHORITATIVE (status codes) / ⚠️ Mechanism corrected — see note below  
 **Last Updated**: January 26, 2026  
 **Category**: Authentication & Authorization
+
+> **⚠️ CORRECTED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: Per
+> [DD-AUTH-014](../DD-AUTH-014-middleware-based-sar-authentication.md) (Phase 2 DataStorage, Phase 3
+> Kubernaut Agent (KA), both ✅ COMPLETE), the `ose-oauth-proxy` **sidecar** described throughout this
+> document has been removed for both DataStorage and KA — confirmed by `charts/kubernaut/templates/`,
+> which has no `oauth-proxy` container for either service today. Both now authenticate/authorize via
+> in-process Go middleware calling the Kubernetes TokenReview/SubjectAccessReview APIs directly. The
+> **401/403/400/422/500 status-code semantics** documented below remain accurate — the middleware
+> returns the same codes for the same failure conditions — only the "`ose-oauth-proxy` sidecar" source
+> attribution is now "in-process auth middleware."
 
 ## Quick Links
 

--- a/docs/architecture/decisions/DD-TEST-001-unique-container-image-tags.md
+++ b/docs/architecture/decisions/DD-TEST-001-unique-container-image-tags.md
@@ -1081,8 +1081,8 @@ When both containers are on the **same podman network**, use container names for
 #### **Correct Configuration**
 ```go
 // test/integration/aianalysis/suite_test.go
-hapiConfig := infrastructure.GenericContainerConfig{
-    Name:    "aianalysis_hapi_test",
+kaConfig := infrastructure.GenericContainerConfig{
+    Name:    "aianalysis_ka_test",
     Network: "aianalysis_test_network", // Same network as DataStorage
     Ports:   map[int]int{8080: 18120},  // container:host
 Env: map[string]string{
@@ -1118,7 +1118,7 @@ Env: map[string]string{
 │  │                │ ✅ Container DNS      │  │
 │  │                │ name:8080             │  │
 │  │  ┌─────────────┴─────────────────┐     │  │
-│  │  │ aianalysis_hapi_test          │     │  │
+│  │  │ aianalysis_ka_test            │     │  │
 │  │  │ - Internal port: 8080         │     │  │
 │  │  │ - Host port: 18120            │     │  │
 │  │  │ - ENV: DATA_STORAGE_URL=      │     │  │
@@ -1184,7 +1184,7 @@ Env: map[string]string{
 #### **Step 1: Verify Container DNS Resolution**
 ```bash
 # From inside KA container, resolve DataStorage container name
-podman exec aianalysis_hapi_test nslookup aianalysis_datastorage_test
+podman exec aianalysis_ka_test nslookup aianalysis_datastorage_test
 
 # Expected output:
 # Server:    10.88.0.1
@@ -1196,7 +1196,7 @@ podman exec aianalysis_hapi_test nslookup aianalysis_datastorage_test
 #### **Step 2: Test Container-to-Container Connectivity**
 ```bash
 # From inside KA container, test DataStorage health endpoint
-podman exec aianalysis_hapi_test curl -v http://aianalysis_datastorage_test:8080/health
+podman exec aianalysis_ka_test curl -v http://aianalysis_datastorage_test:8080/health
 
 # Expected: HTTP 200 with {"status":"healthy",...}
 ```
@@ -1208,7 +1208,7 @@ podman ps --filter "name=aianalysis" --format "{{.Names}}: {{.Ports}}"
 
 # Expected output:
 # aianalysis_datastorage_test: 0.0.0.0:18095->8080/tcp
-# aianalysis_hapi_test: 0.0.0.0:18120->8080/tcp
+# aianalysis_ka_test: 0.0.0.0:18120->8080/tcp
 ```
 
 #### **Step 4: Test Host-to-Container Connectivity**

--- a/docs/architecture/decisions/DD-TEST-010-controller-per-process-architecture.md
+++ b/docs/architecture/decisions/DD-TEST-010-controller-per-process-architecture.md
@@ -156,7 +156,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
     By("Setting up per-process controller with handlers")
     // Create service-specific handlers/dependencies per process
     // Example for AIAnalysis:
-    hapiClient := hgclient.NewHolmesGPTClient(...)
+    kaClient := agentclient.NewKubernautAgentClientWithTransport(...)
     regoEvaluator := rego.NewEvaluator(...)
     investigatingHandler := handlers.NewInvestigatingHandler(...)
     analyzingHandler := handlers.NewAnalyzingHandler(...)
@@ -250,7 +250,7 @@ For each service migrating from single-controller → multi-controller:
 
 **Move to Phase 1 (process 1 only)**:
 - [ ] Keep ONLY infrastructure: `StartDSBootstrap()`
-- [ ] Keep service-specific containers (e.g., HAPI for AIAnalysis)
+- [ ] Keep service-specific containers (e.g., Kubernaut Agent (KA) for AIAnalysis)
 - [ ] Remove: envtest, k8sManager, controller, handlers, metrics
 - [ ] Change `return configBytes` → `return []byte{}`
 
@@ -371,7 +371,7 @@ func(data []byte) {
 - Gateway (no controller, different pattern)
 - DataStorage (no controller, REST API service)
 - AuthWebhook (no controller, webhook service)
-- HolmesGPT-API (Python FastAPI, different pattern)
+- Kubernaut Agent / KA (Go HTTP service, different pattern — formerly "HolmesGPT-API", rewritten to native Go per issue #433)
 
 ---
 


### PR DESCRIPTION
## Summary

Part of #1806. This is "Group K" — the test infrastructure / container build / auth cluster of files. Unlike earlier mechanical-rename groups, these needed verification against actual source (`internal/kubernautagent/`, `pkg/agentclient/`, `docker/kubernautagent.Dockerfile`, `charts/kubernaut/templates/`, `test/integration/aianalysis/suite_test.go`) before rewriting, since several described architecture that has since changed beyond just naming.

### Files corrected

- **`docs/architecture/decisions/DD-TEST-001-unique-container-image-tags.md`**: renamed the stale `aianalysis_hapi_test`/`hapiConfig` container-networking example to `aianalysis_ka_test`/`kaConfig` — confirmed this matches the actual container name in `test/integration/aianalysis/suite_test.go` today.
- **`docs/architecture/decisions/DD-TEST-010-controller-per-process-architecture.md`**: updated the AIAnalysis client pseudo-code to `agentclient.NewKubernautAgentClientWithTransport`, and reworded two prose references (HAPI → KA; "HolmesGPT-API (Python FastAPI)" → "Kubernaut Agent / KA (Go HTTP service)" with a historical aside).
- **`docs/architecture/decisions/DD-AUTH-013/README.md`** and **`DD-AUTH-013-http-status-codes-oauth-proxy.md`**: added CORRECTED notes — [DD-AUTH-014](https://github.com/jordigilh/kubernaut/blob/main/docs/architecture/decisions/DD-AUTH-014-middleware-based-sar-authentication.md) removed the `ose-oauth-proxy` sidecar for both DataStorage and KA in favor of in-process Go middleware; the documented 401/403/etc. status codes and their triggering conditions remain accurate, only the "source: sidecar" attribution is stale. Left the pre-existing "not corrected here" STALE section (Python/FastAPI client paths) untouched, per its own deferral note — didn't want to silently undo an intentional prior deferral.
- **`docs/architecture/decisions/DD-AUTH-008-secret-management-kustomize-helm.md`**: added a CORRECTED note. Confirmed via `charts/kubernaut/templates/{datastorage,kubernaut-agent}/` that neither service has an `oauth-proxy` container or `cookie-secret` volume today, so the worked DataStorage/"HolmesGPT API" cookie-secret example is now historical. The Kustomize+Helm separation-of-concerns *principle* itself is still valid and used elsewhere (e.g. `console`'s oauth2-proxy cookie-secret).
- **`docs/architecture/decisions/ADR-027-multi-architecture-build-strategy.md`** / **`ADR-028-container-registry-policy.md`**: added CORRECTED notes on the "Python Services (e.g., HolmesGPT API)" examples — KA was rewritten to native Go per #433 (`docker/kubernautagent.Dockerfile`); no Python production service remains in Kubernaut today. Also annotated ADR-027's two "kubernaut-agent — Python UBI10 compliant" entries as reflecting the pre-rewrite (Oct 2025) state.
- **`docs/architecture/decisions/DD-016-dynamic-toolset-v2-deferral.md`**: clarified the "HolmesGPT SDK" review-trigger bullet is stale (KA no longer depends on it post-Go-rewrite) and noted the `BR-HOLMES-XXX` IDs are intentionally left as-is, tracked under #1829.
- **`docs/architecture/ERROR_HANDLING_STANDARD.md`**: renamed `holmesClient`/`callHolmesGPT` → `kaClient`/`callKubernautAgent`, and the `holmesgpt-analysis`/`holmesgpt-external` timeout + circuit-breaker map keys → `ka-analysis`/`ka-external` — for consistency with the `KubernautAgentClient` example already present later in the same doc.
- **`docs/architecture/CRD_SCHEMAS.md`**: added a CORRECTED note on the already-`(DEPRECATED - ADR-025)`-labeled AIAnalysis extension section. Confirmed `api/aianalysis/v1alpha1/aianalysis_types.go` has **no** `LLMProvider` field at all today, so the `holmesgpt` enum value in that snippet is fictional/historical, not a live schema to mechanically rename.

### Reviewed, no change needed

- **`docs/architecture/decisions/DD-TEST-001-port-allocation-strategy.md`**: already documents the HAPI→KA rename with an explicit dated changelog entry; remaining HAPI mentions are all in changelog history and are appropriately left as-is.

### Flagged, not fixed here (out of Group K scope)

- `deploy/secrets/kustomization.yaml` and `deploy/secrets/README.md` still describe generating `oauth-proxy` cookie secrets for DataStorage/"HolmesGPT API", but neither service's Helm template has an `oauth-proxy` sidecar anymore — looks like orphaned pre-DD-AUTH-014 infra rather than a docs wording issue. Worth a follow-up cleanup issue.
- `DD-AUTH-014-middleware-based-sar-authentication.md`'s v3.0 changelog entry references "HolmesGPT API"/"HAPI" in dated, historical text — not in Group K's file list, left untouched.
- `BR-HAPI-XXX` / `BR-HOLMES-XXX` business requirement IDs left as-is throughout (no renamed equivalent exists), per #1806 guidance — tracked under #1829.

## Test plan

Docs-only change, no code/behavior affected.
- Ran `grep -rn "HolmesGPT\|HAPI"` (case-insensitive) on every touched file and confirmed all remaining hits are intentional: headings naming the historical term, the CORRECTED notes referencing it, changelog entries, or content inside a pre-existing STALE section deliberately deferred by an earlier pass.
- Cross-checked every technical claim (container names, client constructor names, Helm values keys, Dockerfile paths, Go struct fields) against current source before citing it as current: `internal/kubernautagent/`, `pkg/agentclient/`, `docker/kubernautagent.Dockerfile`, `charts/kubernaut/templates/`, `charts/kubernaut/values.yaml`, `api/aianalysis/v1alpha1/aianalysis_types.go`, `test/integration/aianalysis/suite_test.go`.

Made with [Cursor](https://cursor.com)