### PR TITLE
docs(1806): verify+correct Group J HAPI/HolmesGPT refs (connectivity/deployment cluster)

### DIFF
--- a/docs/architecture/EFFECTIVENESS_MONITOR_RESTART_RECOVERY_FLOWS.md
+++ b/docs/architecture/EFFECTIVENESS_MONITOR_RESTART_RECOVERY_FLOWS.md
@@ -177,6 +177,10 @@ func (r *EffectivenessMonitorReconciler) performAssessment(
     basicScore := r.calculateBasicEffectiveness(metricsBefore, metricsAfter)
 
     // Decision: Call AI?
+    // ⚠️ CORRECTED (2026-08-02, Issue #1806): the AI-analysis branch below (shouldCallAI /
+    // holmesgptClient.PostExecutionAnalyze) is illustrative pseudocode, not real Go code — neither symbol exists
+    // in source, and the actual `internal/controller/effectivenessmonitor` implementation does not call out to
+    // Kubernaut Agent (KA) (formerly "HolmesGPT") for post-execution analysis. Preserved as historical design intent.
     if r.shouldCallAI(assessment, basicScore) {
         aiAnalysis := r.holmesgptClient.PostExecutionAnalyze(ctx, &PostExecRequest{
             ExecutionID:         assessment.TraceID,

--- a/docs/architecture/HEARTBEAT_MONITORING_DESIGN.md
+++ b/docs/architecture/HEARTBEAT_MONITORING_DESIGN.md
@@ -5,6 +5,14 @@
 **Status**: Implementation Plan
 **Purpose**: Design heartbeat monitoring for 20B+ model availability with automatic rule-based fallback
 
+> **⚠️ HISTORICAL (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: This was an
+> implementation *plan* (Status above) and there is no `heartbeat_monitor`/`HeartbeatMonitor` component in current
+> Go source — it does not appear to have been built. Additionally, the `context_api`/`holmesgpt_api` monitor-service
+> choice below is stale: **HolmesGPT** was renamed **Kubernaut Agent (KA)** in the Go rewrite (v1.3, issue
+> [#433](https://github.com/jordigilh/kubernaut/issues/433)), and **Context API** was deprecated and folded into
+> Data Storage per [DD-CONTEXT-006](decisions/DD-CONTEXT-006-CONTEXT-API-DEPRECATION.md) — neither exists as
+> described here. Preserved below as historical design record only.
+
 ---
 
 ## 🎯 **System Overview**
@@ -249,7 +257,7 @@ type HeartbeatMetrics struct {
 # Heartbeat monitoring configuration
 heartbeat:
   enabled: true                    # Enable heartbeat monitoring
-  monitor_service: "context_api"   # context_api or holmesgpt_api
+  monitor_service: "context_api"   # context_api (deprecated, DD-CONTEXT-006) or holmesgpt_api (renamed Kubernaut Agent (KA), issue #433) — historical, see banner above
   check_interval: "30s"           # Health check frequency
   failure_threshold: 3            # Failures before failover
   healthy_threshold: 2            # Successes before recovery

--- a/docs/architecture/MICROSERVICES_COMMUNICATION_ARCHITECTURE.md
+++ b/docs/architecture/MICROSERVICES_COMMUNICATION_ARCHITECTURE.md
@@ -25,6 +25,22 @@
 
 ---
 
+> **⚠️ HISTORICAL (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: This document
+> describes a pre-CRD, sequential-HTTP-call "10-service" design (`webhook-service`, `ai-service`,
+> `workflow-engine-service`, `executor-service`, `storage-service`, `intelligence-service`, `monitor-service`,
+> `context-api-service`, `notification-service`) that predates — and does not reflect — Kubernaut's current
+> CRD-controller architecture. See [Kubernaut Service Catalog](KUBERNAUT_SERVICE_CATALOG.md) for the
+> authoritative current 12-service decomposition. Two corrections specific to this issue: (1) **HolmesGPT** was
+> rewritten in Go and renamed **Kubernaut Agent (KA)** in v1.3 (issue
+> [#433](https://github.com/jordigilh/kubernaut/issues/433)); it runs as a first-class Kubernaut service
+> (`cmd/kubernautagent/`, real ports: API `8443`, health `8081`, metrics `9090`), not as an external tool behind
+> a `context-service`. (2) **Context API** (`context-service`/`context-api-service` below) was deprecated and
+> folded into Data Storage per [DD-CONTEXT-006](decisions/DD-CONTEXT-006-CONTEXT-API-DEPRECATION.md); it no
+> longer exists as a running service. The remaining service list/ports/flows below are preserved as historical
+> record and have not been otherwise re-verified against current source.
+
+---
+
 ## 1. Overview
 
 This document defines the communication patterns and protocols between Kubernaut's **approved 10-service microservices architecture**, establishing clear service boundaries, data flow, and integration patterns for the distributed architecture following Single Responsibility Principle compliance.
@@ -100,7 +116,7 @@ Services:
     Port: 8091 (HTTP), 9091 (metrics), 8191 (health)
     Image: quay.io/jordigilh/context-service:v1.0.0
     Dependencies: [notification-service]
-    External: [HolmesGPT, External AI]
+    External: [Kubernaut Agent (KA), External AI]  # formerly "HolmesGPT" — see banner above
 
   notification-service:
     Purpose: Multi-Channel Notifications Only
@@ -115,7 +131,7 @@ Services:
 ```mermaid
 graph TB
     ALM[AlertManager] --> WH[webhook-service:8080]
-    HGP[HolmesGPT] --> CA[context-api-service:8091]
+    KA["Kubernaut Agent (KA)<br/>formerly HolmesGPT"] --> CA[context-api-service:8091]
 
     WH --> AI[ai-service:8093]
     WH --> WE[workflow-engine-service:8092]
@@ -230,7 +246,9 @@ Response:
 
 ### 3.2 Context API Service Communication
 
-#### 3.2.1 HolmesGPT Integration
+#### 3.2.1 HolmesGPT Integration — HISTORICAL, see banner above
+> HolmesGPT was rewritten in Go and renamed Kubernaut Agent (KA) in v1.3; Context API was deprecated per
+> DD-CONTEXT-006. This flow is preserved unmodified as a historical record.
 
 **Current Implementation**: HTTP REST API (already implemented)
 **Target Architecture**: Enhanced with service mesh integration

--- a/docs/architecture/PRODUCTION_MONITORING.md
+++ b/docs/architecture/PRODUCTION_MONITORING.md
@@ -190,6 +190,14 @@ spec:
 ### Key Performance Indicators (KPIs)
 
 **Business KPIs:**
+
+> **⚠️ CORRECTED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: The metric
+> names in this subsection (KPIs below) are illustrative examples and do not match actual emitted Prometheus
+> metric names — none of `kubernaut_alerts_processed_total`, `kubernaut_investigation_confidence_score`, etc. exist
+> in source. Real Kubernaut Agent (KA) metrics use the `aiagent_` prefix (e.g. `aiagent_http_rate_limited_total`;
+> see `internal/kubernautagent/metrics/metrics.go`). The `service="holmesgpt"` label below has been renamed to
+> `service="kubernaut-agent"` for terminology accuracy only; this does not make the examples real metrics.
+
 ```prometheus
 # Alert processing performance
 kubernaut_alerts_processed_total{status="success"} 1250
@@ -197,9 +205,9 @@ kubernaut_alerts_processed_total{status="filtered"} 85
 kubernaut_alerts_filtered_ratio 0.064
 
 # Investigation accuracy and confidence
-kubernaut_investigation_confidence_score{service="holmesgpt"} 0.87
+kubernaut_investigation_confidence_score{service="kubernaut-agent"} 0.87
 kubernaut_investigation_confidence_score{service="llm"} 0.82
-kubernaut_investigation_accuracy_rate{service="holmesgpt"} 0.91
+kubernaut_investigation_accuracy_rate{service="kubernaut-agent"} 0.91
 
 # Action execution success
 kubernaut_actions_executed_total{action="scale_deployment",status="success"} 145
@@ -220,7 +228,7 @@ kubernaut_cache_operations_total{operation="hit",cache_type="context"} 1967
 kubernaut_cache_operations_total{operation="miss",cache_type="context"} 374
 
 # Service Health
-kubernaut_service_availability_ratio{service="holmesgpt"} 0.997
+kubernaut_service_availability_ratio{service="kubernaut-agent"} 0.997
 kubernaut_service_availability_ratio{service="llm"} 0.995
 kubernaut_service_availability_ratio{service="context_api"} 0.999
 ```
@@ -305,7 +313,7 @@ func (p *Processor) ProcessAlert(alert types.Alert) error {
 │ ┌─────────────────┐     ┌─────────────────┐     ┌─────────────┐ │
 │ │ Context         │     │ KA              │     │ Action      │ │
 │ │ Enrichment      │     │ Investigation   │     │ Executor    │ │
-│ │ (Span: context) │     │ (Span: holmes)  │     │ (Span: exec)│ │
+│ │ (Span: context) │     │ (Span: ka)      │     │ (Span: exec)│ │
 │ └─────────────────┘     └─────────────────┘     └─────────────┘ │
 │                                                                 │
 │ All spans share Trace ID: abc123                               │

--- a/docs/architecture/SERVICE_CONNECTIVITY_SPECIFICATION.md
+++ b/docs/architecture/SERVICE_CONNECTIVITY_SPECIFICATION.md
@@ -7,6 +7,22 @@
 
 ---
 
+> **⚠️ HISTORICAL (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: This document
+> predates Kubernaut's CRD-controller architecture and describes an earlier, sequential-HTTP-call design
+> (`Remediation Processor`, `Workflow Orchestrator`, `K8s Executor`, `Intelligence Service`, etc.) that was never
+> built as specified here. The current production architecture is 12 CRD-controller/stateless services — see
+> [Kubernaut Service Catalog](KUBERNAUT_SERVICE_CATALOG.md) for the authoritative decomposition. Two corrections
+> specific to this issue: (1) **HolmesGPT** (the "External AI & Investigation Tools" integration below) was
+> rewritten in Go and renamed **Kubernaut Agent (KA)** in v1.3 (issue [#433](https://github.com/jordigilh/kubernaut/issues/433));
+> it is now a first-class Kubernaut service (`cmd/kubernautagent/`), not an external tool consumed via a
+> "Context API Service". (2) **Context API** (referenced throughout this document as the HolmesGPT-facing
+> service) was deprecated and folded into Data Storage per
+> [DD-CONTEXT-006](decisions/DD-CONTEXT-006-CONTEXT-API-DEPRECATION.md); it no longer exists as a running service.
+> The rest of this document's service list/ports/flows is preserved as-is for historical reference and has not
+> been otherwise re-verified against current source.
+
+---
+
 ## 🎯 **PURPOSE**
 
 This document defines the **approved service connectivity patterns** for Kubernaut's microservices architecture, providing detailed justification for each service connection and integration pattern based on business requirements.
@@ -134,7 +150,12 @@ This document defines the **approved service connectivity patterns** for Kuberna
 
 ### **External AI & Investigation Tools**
 
-#### **HolmesGPT Integration**
+#### **HolmesGPT Integration** — HISTORICAL, see banner above
+> As of v1.3, HolmesGPT was rewritten in Go and renamed **Kubernaut Agent (KA)**; it runs as a first-class
+> Kubernaut service (real ports: API `8443`, health `8081`, metrics `9090` — see
+> `charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml`), not as an externally-integrated tool behind
+> a "Context API Service" (deprecated, DD-CONTEXT-006). The entry below is preserved unmodified as a historical
+> record of the original (never-built-as-specified) design.
 - **Connected Service**: 🌐 Context API Service
 - **Protocol**: HTTPS REST API
 - **Endpoint**: `http://holmesgpt-service:8090/api/v1/`

--- a/docs/architecture/TROUBLESHOOTING_GUIDE.md
+++ b/docs/architecture/TROUBLESHOOTING_GUIDE.md
@@ -199,7 +199,12 @@ kubectl scale statefulset/redis --replicas=3 -n kubernaut-system
 
 ---
 
-### **Context API Service**
+### **Context API Service** — HISTORICAL
+> **⚠️ HISTORICAL (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: Context API
+> was deprecated and its functionality folded into Data Storage per
+> [DD-CONTEXT-006](decisions/DD-CONTEXT-006-CONTEXT-API-DEPRECATION.md); it does not exist as a standalone running
+> service today. Table/index names below (`incident_embeddings`, etc.) are illustrative and not verified against
+> current Data Storage schema. Preserved as historical troubleshooting record.
 
 #### **Issue: Vector Search Timeout**
 
@@ -259,7 +264,9 @@ Investigation rate limit exceeded (5/min)
 **Resolution**:
 ```bash
 # Check current rate
-curl http://kubernaut-agent:9090/metrics | grep holmesgpt_rate_limit_exceeded_total
+# CORRECTED (2026-08-02, Issue #1806): real metric name is aiagent_http_rate_limited_total
+# (internal/kubernautagent/metrics/metrics.go); "holmesgpt_rate_limit_exceeded_total" never existed.
+curl http://kubernaut-agent:9090/metrics | grep aiagent_http_rate_limited_total
 
 # Option 1: Increase rate limit (config)
 # Edit ConfigMap to increase from 5/min to 10/min
@@ -413,6 +420,8 @@ histogram_quantile(0.95, rate(contextapi_http_request_duration_seconds_bucket[5m
 
 ```bash
 # Test connectivity between services
+# NOTE (2026-08-02, Issue #1806): context-api is deprecated (DD-CONTEXT-006), folded into Data Storage.
+# Substitute the current data-storage service/port for this check.
 kubectl exec -n kubernaut-system gateway-{pod} -- curl -s http://context-api:8080/healthz
 
 # Check DNS resolution
@@ -478,6 +487,8 @@ kubectl get componentstatuses
 kubectl get pods -n kube-system
 
 # Step 3: Restart all Kubernaut services in order
+# NOTE (2026-08-02, Issue #1806): `context-api` below is deprecated (DD-CONTEXT-006, folded into data-storage)
+# and should be dropped from this list; kept here as historical context for the restart ordering.
 kubectl rollout restart statefulset/postgresql -n kubernaut-system
 kubectl rollout restart statefulset/redis -n kubernaut-system
 sleep 30

--- a/docs/architecture/references/visual-diagrams-master.md
+++ b/docs/architecture/references/visual-diagrams-master.md
@@ -111,19 +111,30 @@ stateDiagram-v2
 
 ## 02-aianalysis/ Diagrams
 
+> **⚠️ HISTORICAL (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: This entire
+> section predates the Go rewrite of HolmesGPT into **Kubernaut Agent (KA)** (v1.3, issue
+> [#433](https://github.com/jordigilh/kubernaut/issues/433)) and describes an API/CRD shape that was never built as
+> shown: a synchronous `POST /api/v1/investigate` call (the real KA API is async/session-based:
+> `POST /api/v1/incident/analyze` → poll `GET .../session/{id}` → `GET .../session/{id}/result`), and a standalone
+> `AIApprovalRequest` CRD (no such CRD was ever built — approval is signaled via `RemediationApprovalRequest`).
+> For accurate, current diagrams and integration details, see
+> [AI Analysis Service — Kubernaut Agent (KA) Integration & Approval Policies](../../services/crd-controllers/02-aianalysis/ka-approval.md).
+> Diagrams below are preserved unmodified as historical record except for HolmesGPT terminology, which is renamed
+> for readability.
+
 ### Architecture Diagram
 ```mermaid
 graph TB
     subgraph "AI Analysis Service"
         AIA[AIAnalysis CRD]
         Controller[AIAnalysisReconciler]
-        HolmesAPI[HolmesGPT API Client]
+        KAClient[Kubernaut Agent -KA- API Client]
         RegoEngine[Rego Policy Engine]
         HistoricalDB[Historical Success Rate]
     end
 
     subgraph "External Services"
-        HolmesGPT[HolmesGPT-API Service<br/>Port 8090]
+        KA[Kubernaut Agent -KA- Service<br/>formerly HolmesGPT-API]
         AR[RemediationRequest CRD<br/>Parent]
         Notification[Notification Service<br/>Port 8080]
     end
@@ -139,8 +150,8 @@ graph TB
 
     AR -->|Creates & Owns| AIA
     Controller -->|Watches| AIA
-    Controller -->|Investigate Alert| HolmesAPI
-    HolmesAPI -->|AI Analysis| HolmesGPT
+    Controller -->|Investigate Alert| KAClient
+    KAClient -->|AI Analysis| KA
     Controller -->|Load Policy| CM
     Controller -->|Evaluate Policy| RegoEngine
     Controller -->|Search Similar| VectorDB
@@ -163,7 +174,7 @@ sequenceDiagram
     participant AR as RemediationRequest
     participant AIA as AIAnalysis CRD
     participant Ctrl as AIAnalysis<br/>Reconciler
-    participant HG as HolmesGPT-API
+    participant HG as Kubernaut Agent (KA)<br/>formerly HolmesGPT-API
     participant Rego as Rego Engine
     participant App as AIApprovalRequest<br/>CRD
     participant Not as Notification<br/>Service
@@ -218,7 +229,7 @@ stateDiagram-v2
     [*] --> Pending
     Pending --> Validating: Reconcile triggered
     Validating --> Investigating: Alert data valid
-    Investigating --> Approving: HolmesGPT analysis complete
+    Investigating --> Approving: Kubernaut Agent (KA) analysis complete
     Approving --> Approved: Auto-approve OR manual approve
     Approving --> Rejected: Manual rejection
     Approved --> Ready: Workflow definition prepared
@@ -227,7 +238,7 @@ stateDiagram-v2
     Failed --> [*]: Manual intervention required
 
     note right of Investigating
-        HolmesGPT AI analysis
+        Kubernaut Agent (KA) AI analysis
         Generate recommendations
         Confidence >80%
         Timeout: 60s

--- a/docs/development/e2e-testing/README.md
+++ b/docs/development/e2e-testing/README.md
@@ -2,6 +2,16 @@
 
 This directory contains configurations and guides for Kubernaut's end-to-end testing infrastructure, primarily using **Kind (Kubernetes in Docker)** for lightweight, fast testing.
 
+> **⚠️ CORRECTED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: Two corrections
+> while verifying this doc. (1) **HolmesGPT** was rewritten in Go and renamed **Kubernaut Agent (KA)** in v1.3
+> (issue [#433](https://github.com/jordigilh/kubernaut/issues/433)); references below are renamed accordingly.
+> (2) Several commands referenced below do not exist in the current repo — there is no bare `make test-e2e`,
+> `setup-test-e2e`, or `cleanup-test-e2e` target, no `run-e2e-tests.sh`/`run-use-case-N.sh` scripts, and no
+> `deploy/holmesgpt-deployment.yaml`. The actual current E2E entry points are per-service Makefile targets, e.g.
+> `make test-e2e-kubernautagent`, `make test-e2e-fullpipeline`, `make test-e2e-fleet` (see `Makefile` for the full
+> list via `grep '^test-e2e' Makefile`). The Kind/hybrid/bare-metal narrative below is preserved as historical
+> context and has not been otherwise re-verified against current source.
+
 ## 🎯 **Primary Testing Platform: Kind**
 
 **Recommended Platform:** Kind (Kubernetes in Docker)
@@ -111,15 +121,15 @@ sudo ./cleanup-e2e-environment-root.sh
 
 **Architecture Overview:**
 - 🖥️ **Kubernetes Cluster**: Remote host (helios08)
-- 🤖 **HolmesGPT Container**: Custom REST API container (localhost:8090 or in-cluster)
+- 🤖 **Kubernaut Agent (KA) Container** (formerly "HolmesGPT Container"): Custom REST API container (localhost:8090 or in-cluster)
 - 🔧 **Kubernaut**: Local machine (manages remote cluster)
 - 🧪 **Tests**: Local machine
 - 📊 **Vector DB**: Local machine (PostgreSQL)
 
 **Network Topology:**
 - Local machine → Remote cluster ✅
-- Local machine → HolmesGPT Container ✅
-- Remote cluster → HolmesGPT ⚙️ (configurable: local or in-cluster deployment)
+- Local machine → Kubernaut Agent (KA) Container ✅
+- Remote cluster → Kubernaut Agent (KA) ⚙️ (configurable: local or in-cluster deployment)
 
 ```bash
 # Navigate to e2e testing directory
@@ -131,11 +141,13 @@ make deploy-cluster-remote-only
 # 2. Setup local Kubernaut to connect to remote cluster
 make setup-local-hybrid
 
-# 3. Deploy HolmesGPT container
+# 3. Deploy Kubernaut Agent (KA) container (formerly "HolmesGPT container")
 # Option A: Local deployment
 docker run -d -p 8090:8090 kubernaut/kubernaut-agent:latest
 
 # Option B: In-cluster deployment
+# NOTE: deploy/holmesgpt-deployment.yaml does not exist in the current repo; use the Helm chart instead
+# (charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml)
 oc apply -f deploy/holmesgpt-deployment.yaml
 
 # 4. Validate hybrid network topology
@@ -434,7 +446,7 @@ The complete E2E environment includes everything needed for Kubernaut testing:
 #### **Top 10 E2E Use Cases**
 1. **AI-Driven Pod Resource Exhaustion Recovery**
 2. **Multi-Node Failure with Workload Migration**
-3. **HolmesGPT Investigation Pipeline Under Load**
+3. **Kubernaut Agent (KA) Investigation Pipeline Under Load** (formerly "HolmesGPT Investigation Pipeline Under Load")
 4. **Network Partition Recovery with Service Mesh**
 5. **Storage Failure with Vector Database Persistence**
 6. **AI Model Timeout Cascade with Fallback Logic**
@@ -455,7 +467,7 @@ The complete E2E environment includes everything needed for Kubernaut testing:
 
 # Run individual use cases
 ./run-use-case-1.sh             # Resource exhaustion recovery
-./run-use-case-3.sh             # HolmesGPT investigation
+./run-use-case-3.sh             # Kubernaut Agent (KA) investigation, formerly "HolmesGPT investigation"
 ./run-use-case-9.sh             # Security incident response
 ```
 

--- a/docs/development/getting-started/setup/DEPLOYMENT.md
+++ b/docs/development/getting-started/setup/DEPLOYMENT.md
@@ -1,5 +1,14 @@
 # Deployment Guide
 
+> **⚠️ CORRECTED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: This guide
+> predates the Go rewrite of HolmesGPT into **Kubernaut Agent (KA)** (v1.3, issue
+> [#433](https://github.com/jordigilh/kubernaut/issues/433)) and the move to Helm-based production deployment.
+> References to "HolmesGPT service"/`holmesgpt-service` below have been renamed to Kubernaut Agent (KA) for
+> terminology accuracy, but the env vars, Docker Compose flow, and manual `kubectl apply -f k8s/` steps described
+> here do not reflect the current deployment path. For current production deployment, use the Helm chart at
+> `charts/kubernaut/` (see `charts/kubernaut/README.md`); KA's real ports are API `8443`, health `8081`, metrics
+> `9090` (`charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml`), not `8090` as shown below.
+
 ## Prerequisites
 
 - Kubernetes cluster with RBAC enabled
@@ -35,7 +44,7 @@ make bootstrap-dev-compose
 
 Access (legacy):
 - Go service: http://localhost:8080
-- HolmesGPT service: http://localhost:8090
+- HolmesGPT service (now Kubernaut Agent (KA)): http://localhost:8090
 - LocalAI endpoint: http://192.168.1.169:8080 (if configured)
 
 ### 3. Kubernetes (Production)
@@ -44,7 +53,7 @@ Access (legacy):
 # Create namespace
 kubectl create namespace kubernaut
 
-# Create secrets
+# Create secrets (legacy secret name; predates Kubernaut Agent (KA) rewrite)
 kubectl create secret generic holmesgpt-secrets \
   --from-literal=openai-api-key=your_api_key \
   -n kubernaut
@@ -58,6 +67,9 @@ kubectl apply -f k8s/ -n kubernaut
 ### Go Service Environment Variables
 
 ```env
+# Legacy env vars for the pre-rewrite "HolmesGPT" service, now Kubernaut Agent (KA); current KA
+# configuration is via a mounted config file, not these env vars — see
+# charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
 AI_SERVICES_HOLMESGPT_ENABLED=true
 AI_SERVICES_HOLMESGPT_ENDPOINT=http://holmesgpt-service:8090
 POSTGRES_HOST=postgres-service
@@ -70,30 +82,30 @@ POSTGRES_PASSWORD=secretpassword
 
 ### Minimum
 
-- Go Service: 256Mi memory, 200m CPU (includes HolmesGPT client)
-- HolmesGPT Service: 512Mi memory, 200m CPU
+- Go Service: 256Mi memory, 200m CPU (includes Kubernaut Agent (KA) client)
+- Kubernaut Agent (KA) (formerly "HolmesGPT Service"): 512Mi memory, 200m CPU
 
 ### Recommended Production
 
-- Go Service: 1Gi memory, 500m CPU, 3 replicas (includes HolmesGPT client)
-- HolmesGPT Service: 2Gi memory, 500m CPU, 2 replicas
+- Go Service: 1Gi memory, 500m CPU, 3 replicas (includes Kubernaut Agent (KA) client)
+- Kubernaut Agent (KA) (formerly "HolmesGPT Service"): 2Gi memory, 500m CPU, 2 replicas
 
 ## Monitoring
 
 ### Health Checks
 
 ```bash
-# Go service health (includes HolmesGPT connectivity)
+# Go service health (includes Kubernaut Agent (KA) connectivity)
 curl http://localhost:8080/health
 
-# HolmesGPT service health
+# Kubernaut Agent (KA) health (formerly "HolmesGPT service health"; legacy port shown, current KA health port is 8081)
 curl http://localhost:8090/health
 ```
 
 ### Metrics
 
 Prometheus metrics available at:
-- Go service: http://localhost:8080/metrics (includes HolmesGPT integration metrics)
+- Go service: http://localhost:8080/metrics (includes Kubernaut Agent (KA) integration metrics)
 
 ## Security
 
@@ -133,35 +145,35 @@ spec:
   - to: []
     ports:
     - protocol: TCP
-      port: 8090  # HolmesGPT Service
+      port: 8090  # Kubernaut Agent (KA), formerly "HolmesGPT Service"; legacy port shown, current KA API port is 8443
 ```
 
 ## Troubleshooting
 
 ### Common Issues
 
-**HolmesGPT service fails to start:**
-- Check HolmesGPT container configuration
+**Kubernaut Agent (KA) fails to start** (formerly "HolmesGPT service fails to start"):
+- Check the KA container configuration
 - Verify LLM provider connectivity
 - Review startup logs for validation errors
 
-**Go service can't connect to HolmesGPT:**
-- Verify HolmesGPT service is running and healthy
+**Go service can't connect to Kubernaut Agent (KA)** (formerly "...to HolmesGPT"):
+- Verify KA is running and healthy
 - Check network connectivity between services
-- Confirm HolmesGPT service URL configuration
+- Confirm KA service URL configuration
 
 **High latency:**
-- Optimize HolmesGPT configuration
-- Increase HolmesGPT service replicas
+- Optimize Kubernaut Agent (KA) configuration
+- Increase KA replicas
 - Optimize LLM provider settings (model, max_tokens)
 
 ### Log Analysis
 
 ```bash
-# Go service logs (includes HolmesGPT integration)
+# Go service logs (includes Kubernaut Agent (KA) integration)
 kubectl logs -f deployment/kubernaut -n kubernaut
 
-# HolmesGPT service logs
+# Kubernaut Agent (KA) logs (formerly "HolmesGPT service logs"; legacy deployment name shown)
 kubectl logs -f deployment/holmesgpt-service -n kubernaut
 
 # Filter for errors

--- a/docs/services/crd-controllers/05-remediationorchestrator/data-handling-architecture.md
+++ b/docs/services/crd-controllers/05-remediationorchestrator/data-handling-architecture.md
@@ -2,9 +2,11 @@
 
 ### Overview
 
-**Architectural Principle**: Remediation Coordinator provides targeting data only (~8KB). HolmesGPT fetches logs/metrics dynamically using built-in toolsets.
+**Architectural Principle**: Remediation Coordinator provides targeting data only (~8KB). Kubernaut Agent (KA)
+(formerly "HolmesGPT" — renamed in the Go rewrite, v1.3, issue [#433](https://github.com/jordigilh/kubernaut/issues/433))
+fetches logs/metrics dynamically using built-in tools.
 
-**Why This Matters**: Understanding this pattern ensures compliance with Kubernetes etcd limits and provides fresh data for HolmesGPT investigations.
+**Why This Matters**: Understanding this pattern ensures compliance with Kubernetes etcd limits and provides fresh data for KA investigations.
 
 ---
 
@@ -17,13 +19,15 @@
 
 **Data Freshness**:
 - Logs stored in CRDs become stale immediately
-- HolmesGPT needs real-time data for accurate investigations
+- Kubernaut Agent (KA) needs real-time data for accurate investigations
 - Kubernetes API provides fresh pod logs on demand
 
-**HolmesGPT Design**:
-- Built-in toolsets fetch data from live sources
-- `kubernetes` toolset: Pod logs, events, kubectl describe
-- `prometheus` toolset: Metrics queries, PromQL generation
+**Kubernaut Agent (KA) Design**:
+- Built-in tools fetch data from live sources (see `pkg/kubernautagent/tools/` — `k8s`, `logs`, `prometheus`,
+  `alertmanager`; full list in
+  [AI Analysis Service — KA Toolsets](../02-aianalysis/ka-approval.md#ka-toolsets))
+- `k8s`/`logs` tools: Pod logs, events, resource describe
+- `prometheus` tool: Metrics queries, PromQL generation
 
 ---
 
@@ -40,7 +44,7 @@ spec:
       severity: "critical"
       environment: "production"
 
-      # Resource targeting for HolmesGPT
+      # Resource targeting for Kubernaut Agent (KA)
       namespace: "production-app"
       resourceKind: "Pod"
       resourceName: "web-app-789"
@@ -66,28 +70,31 @@ spec:
 ```
 
 **What Is NOT Stored**:
-- ❌ Pod logs (HolmesGPT `kubernetes` toolset fetches)
-- ❌ Metrics data (HolmesGPT `prometheus` toolset fetches)
-- ❌ Events (HolmesGPT fetches dynamically)
-- ❌ kubectl describe output (HolmesGPT generates)
+- ❌ Pod logs (KA `k8s`/`logs` tools fetch)
+- ❌ Metrics data (KA `prometheus` tool fetches)
+- ❌ Events (KA fetches dynamically)
+- ❌ kubectl describe output (KA generates on demand)
 
 ---
 
-### How HolmesGPT Uses Targeting Data
+### How Kubernaut Agent (KA) Uses Targeting Data
 
-**AIAnalysis Controller → HolmesGPT-API**:
+**AIAnalysis Controller → Kubernaut Agent (KA) REST API** (via `pkg/agentclient`, OpenAPI-generated):
 
-```python
-# HolmesGPT uses targeting data to fetch fresh logs/metrics
-holmes_client.investigate(
-    namespace="production-app",      # From SignalContext
-    resource_name="web-app-789",     # From SignalContext
-    # HolmesGPT toolsets automatically:
-    # 1. kubectl logs -n production-app web-app-789 --tail 500
-    # 2. kubectl describe pod web-app-789 -n production-app
-    # 3. kubectl get events -n production-app
-    # 4. promql: container_memory_usage_bytes{pod="web-app-789"}
-)
+> **⚠️ CORRECTED (2026-08-02, [Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806))**: The snippet
+> below is illustrative pseudocode only — it does not reflect a real Go API. The actual integration is the
+> AIAnalysis controller calling KA's REST API through the generated `pkg/agentclient` client; see
+> `test/integration/aianalysis/agentclient_integration_test.go` for the real call pattern and
+> [AI Analysis Service — KA Toolsets](../02-aianalysis/ka-approval.md#ka-toolsets) for KA's tool implementation.
+
+```text
+# Conceptual flow — KA uses targeting data to fetch fresh logs/metrics:
+#   1. AIAnalysis controller calls KA's investigation API with namespace/resource_name (from SignalContext)
+#   2. KA's built-in tools automatically:
+#      - fetch pod logs (tail ~500 lines)
+#      - describe the target resource
+#      - list recent events in the namespace
+#      - query Prometheus (e.g. container_memory_usage_bytes{pod="web-app-789"})
 ```
 
 **Result**: Fresh, real-time data for investigation (not stale CRD snapshots)
@@ -109,7 +116,7 @@ kubernetesContext:
     namespace:
       type: string
       maxLength: 63  # RFC 1123 DNS label
-      description: "Target namespace for HolmesGPT investigation"
+      description: "Target namespace for Kubernaut Agent (KA) investigation"
     resourceKind:
       type: string
       maxLength: 100  # Kubernetes resource kind max
@@ -118,7 +125,7 @@ kubernetesContext:
     resourceName:
       type: string
       maxLength: 253  # RFC 1123 DNS subdomain
-      description: "Resource name for HolmesGPT targeting"
+      description: "Resource name for Kubernaut Agent (KA) targeting"
     labels:
       type: object
       maxProperties: 20
@@ -190,7 +197,7 @@ func (r *RemediationRequestReconciler) createAIAnalysis(
                     Environment:       alertProcessing.Status.EnrichedSignal.Environment,
                     BusinessPriority:  alertProcessing.Status.EnrichedSignal.BusinessPriority,
 
-                    // Resource targeting for HolmesGPT toolsets
+                    // Resource targeting for Kubernaut Agent (KA) tools
                     Namespace:    alertProcessing.Status.EnrichedSignal.Namespace,
                     ResourceKind: alertProcessing.Status.EnrichedSignal.ResourceKind,
                     ResourceName: alertProcessing.Status.EnrichedSignal.ResourceName,
@@ -310,11 +317,10 @@ All field constraints match Kubernetes object specifications:
 
 ### Reference
 
-For detailed HolmesGPT toolset capabilities and CRD schemas:
+For detailed Kubernaut Agent (KA) tool capabilities and CRD schemas:
 - [SignalProcessing CRD Schema](../../design/CRD/02_REMEDIATION_PROCESSING_CRD.md)
 - [AIAnalysis CRD Schema](../02-aianalysis/crd-schema.md)
-- [AI Analysis Service Spec - HolmesGPT Toolsets](./02-ai-analysis.md#holmesgpt-toolsets--dynamic-data-fetching)
-- [HolmesGPT Official Documentation](https://github.com/robusta-dev/holmesgpt)
+- [AI Analysis Service Spec - KA Toolsets](../02-aianalysis/ka-approval.md#ka-toolsets)
 
 ---
 

--- a/docs/services/crd-controllers/05-remediationorchestrator/integration-points.md
+++ b/docs/services/crd-controllers/05-remediationorchestrator/integration-points.md
@@ -201,9 +201,12 @@ func (r *RemediationRequestReconciler) createAIAnalysis(
                         IncludeHistoricalPatterns: true,
                     },
                 },
-                // HolmesGPTConfig is populated by AIAnalysis controller from system defaults
-                // Remediation Coordinator only provides business data (targeting info, enriched context)
-                // See AIAnalysis service spec for Kubernaut Agent configuration management
+                // Kubernaut Agent (KA) investigation/tool configuration is NOT part of this spec — it is
+                // owned and applied by the AIAnalysis controller / KA itself, not by Remediation Coordinator.
+                // Remediation Coordinator only provides business data (targeting info, enriched context).
+                // NOTE (2026-08-02, Issue #1806): this comment previously referenced a `HolmesGPTConfig` field,
+                // which does not exist in the current AIAnalysis API (api/aianalysis/) — no equivalent
+                // per-request config field exists today; corrected to avoid citing a fictional field.
             },
         }
 


### PR DESCRIPTION
## Summary

Group J of the HAPI/HolmesGPT → Kubernaut Agent (KA) rename effort ([Issue #1806](https://github.com/jordigilh/kubernaut/issues/1806)): the deployment/connectivity/communications-architecture cluster. Unlike the mechanical-rename groups, these files needed ground-truth verification against current source (`internal/kubernautagent/`, `pkg/agentclient/`, `api/aianalysis/`, decision docs) before rewriting — several contained substantive architectural inaccuracies beyond terminology.

## Files changed

| File | What was done |
|---|---|
| `docs/architecture/SERVICE_CONNECTIVITY_SPECIFICATION.md` | **Historical banner** — describes a pre-CRD, sequential-HTTP-call design never built as specified. Clarified HolmesGPT→KA rename + Context API deprecation (DD-CONTEXT-006), pointed to `KUBERNAUT_SERVICE_CATALOG.md`. |
| `docs/architecture/MICROSERVICES_COMMUNICATION_ARCHITECTURE.md` | **Historical banner** — same pre-CRD "10-service" design issue. Renamed HolmesGPT mermaid nodes/labels for terminology consistency within preserved historical diagrams. |
| `docs/services/crd-controllers/05-remediationorchestrator/data-handling-architecture.md` | **Verified + rewritten** — core "targeting data only, KA fetches dynamically" principle confirmed accurate against `pkg/kubernautagent/tools/*` and `ka-approval.md`. Renamed HolmesGPT→KA, replaced fictional Python `holmes_client.investigate()` pseudocode with a corrected note (real path: AIAnalysis → KA via `pkg/agentclient`), fixed a dead link. |
| `docs/services/crd-controllers/05-remediationorchestrator/integration-points.md` | **Corrected** — comment cited a fictional `HolmesGPTConfig` field (doesn't exist in `api/aianalysis/`); replaced with an accurate description. |
| `docs/architecture/references/visual-diagrams-master.md` | **Section-scoped historical note** — the `02-aianalysis` diagrams show a synchronous `POST /api/v1/investigate` call and a standalone `AIApprovalRequest` CRD, neither ever built (real KA API is async/session-based; approval uses `RemediationApprovalRequest`). Pointed to `ka-approval.md`; renamed HolmesGPT mermaid nodes for consistency. |
| `docs/architecture/PRODUCTION_MONITORING.md` | **Corrected** — none of the example KPI metric names exist in source; added a note plus renamed `service="holmesgpt"` → `service="kubernaut-agent"` and fixed a stale `Span: holmes` → `Span: ka` trace label. Pointed to real `aiagent_*` metric prefix. |
| `docs/architecture/HEARTBEAT_MONITORING_DESIGN.md` | **Historical banner** — confirmed `heartbeat_monitor`/`HeartbeatMonitor` was never implemented (doc's own Status was "Implementation Plan"). Corrected the `context_api`/`holmesgpt_api` config comment. |
| `docs/architecture/EFFECTIVENESS_MONITOR_RESTART_RECOVERY_FLOWS.md` | **Corrected** — confirmed `holmesgptClient.PostExecutionAnalyze`/`EffectivenessMonitorReconciler` are fictional (real controller `internal/controller/effectivenessmonitor` has no AI-analysis call). Added inline correction note. |
| `docs/architecture/TROUBLESHOOTING_GUIDE.md` | **Corrected** — fixed a fictional `holmesgpt_rate_limit_exceeded_total` metric to the real `aiagent_http_rate_limited_total`. Added historical note to the "Context API Service" section (deprecated per DD-CONTEXT-006) and flagged two other stale live-looking `context-api` references. |
| `docs/development/e2e-testing/README.md` | **Corrected** — renamed HolmesGPT→KA throughout. Flagged that several referenced commands don't exist in the current repo (no bare `make test-e2e`, no `run-e2e-tests.sh`/`run-use-case-N.sh`, no `deploy/holmesgpt-deployment.yaml`); pointed to real per-service `make test-e2e-<service>` targets. |
| `docs/development/getting-started/setup/DEPLOYMENT.md` | **Corrected** — top-of-doc note (predates KA rewrite + Helm deployment; real KA ports 8443/8081/9090). Renamed HolmesGPT→KA in prose; left literal legacy identifiers (env vars, secret/deployment names, port 8090) unchanged with inline notes rather than fabricating unverified current equivalents. |

## Deferred / out of scope items — resolution

- ~~`APPROVED_MICROSERVICES_ARCHITECTURE.md` and `SERVICE_DEPENDENCY_MAP.md` — still have live-tense HolmesGPT/HAPI mentions~~ — **Checked, no action needed.** Both were already fully corrected in earlier #1806 passes. Remaining `HolmesGPT` text in `APPROVED_MICROSERVICES_ARCHITECTURE.md` is intentional historical framing ("never reached GA, replaced by KA"); in `SERVICE_DEPENDENCY_MAP.md` it's only internal Mermaid node *IDs* (invisible to readers) — the rendered labels already say "Kubernaut Agent (KA)".
- `docs/services/crd-controllers/05-remediationorchestrator/integration-points.md` inconsistently uses both `SignalProcessing` (current, correct) and `RemediationProcessing`/`processingv1` (dead — verified no such package/type exists anywhere in `api/`) for the same CRD. Unrelated to HolmesGPT/HAPI, so not fixed here — **filed as [Issue #1879](https://github.com/jordigilh/kubernaut/issues/1879)** with exact line numbers and a suggested fix.
- Files under `docs/tests/`, `docs/testing/`, `docs/test/`, `docs/requirements/`, and `docs/architecture/decisions/DD-*`/`ADR-*` were intentionally skipped per scope (other already-planned groups / directory-wide convention).
- `BR-EXTERNAL-001` and other BR IDs left as-is (no verified `BR-KA-*`/`BR-AI-*` renamed equivalent found) — deferred to issue [#1829](https://github.com/jordigilh/kubernaut/issues/1829) per project convention.

## Test plan

Docs-only change. No code/build impact.

- [x] `grep -rn "HolmesGPT\|HAPI"` on each touched file confirms all remaining hits are intentional (historical citations, correction notes, or preserved historical content covered by banners)
- [x] Verified claims against source: `internal/kubernautagent/metrics/metrics.go` (real metric names), `pkg/kubernautagent/tools/*` + `docs/services/crd-controllers/02-aianalysis/ka-approval.md` (KA tool/API architecture), `api/aianalysis/` (no `HolmesGPTConfig` field), `internal/controller/effectivenessmonitor` (no AI-analysis call), `charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml` (real KA ports), `docs/architecture/decisions/DD-CONTEXT-006-CONTEXT-API-DEPRECATION.md` (Context API deprecation)
- [x] No dead links introduced; one pre-existing dead link fixed (`data-handling-architecture.md`)

🤖 Generated with [Cursor](https://cursor.com)

Made with [Cursor](https://cursor.com)