### PR TITLE
fix(test-infra): bump fullpipeline E2E KA rateLimitPerUser 20->40 (#1853)

### DIFF
--- a/test/infrastructure/apifrontend_e2e.go
+++ b/test/infrastructure/apifrontend_e2e.go
@@ -713,7 +713,7 @@ func afPatchKAJWTAudience(ctx context.Context, kubeconfigPath, namespace string,
         username: "email"
         groups: "groups"`
 
-	anchor := "rateLimitPerUser: 20"
+	anchor := "rateLimitPerUser: 40" // keep in sync with test/infrastructure/kubernautagent.go
 	if !strings.Contains(currentConfig, anchor) {
 		return fmt.Errorf("cannot find anchor %q in KA config", anchor)
 	}

--- a/test/infrastructure/kubernautagent.go
+++ b/test/infrastructure/kubernautagent.go
@@ -945,7 +945,16 @@ data:
       sessionTTL: "5m"
       inactivityTimeout: "2m"
       maxConcurrentSessions: 10
-      rateLimitPerUser: 20
+      # #1737 bumped this 10->20 after full-suite E2E parallelism alone
+      # (no application-level concurrency) tripped the per-user token
+      # bucket. #1853's new full-pipeline interactive tests add further
+      # concurrent MCP session churn under the same shared e2e-user-sre
+      # identity (confirmed via must-gather RCA: concurrent
+      # discover_workflows/select_workflow calls rejected 429 "Too Many
+      # Requests" during MCP session (re)establishment) -- bumped again
+      # 20->40 for headroom. Keep in sync with the anchor string in
+      # afPatchKAJWTAudience (test/infrastructure/apifrontend_e2e.go).
+      rateLimitPerUser: 40
 %s
 ---
 apiVersion: v1


### PR DESCRIPTION
## Summary

- PR #1884's `E2E-FP-1853-002` run intermittently failed 429 "Too Many Requests" while `kubernaut_discover_workflows`/`kubernaut_select_workflow` (re)established an MCP session to KA — root-caused via must-gather RCA to KA's per-user token-bucket limiter (`internal/kubernautagent/server/user_ratelimit.go`, SEC-02) being shared across multiple concurrent fullpipeline specs that all authenticate as the same `e2e-user-sre` test identity.
- Same class of false positive as #1737 (which bumped this 10->20); #1853's new 4-deep interactive-chain test adds enough further concurrent MCP session churn to need more headroom. Bumped 20->40.
- Kept the anchor string in `apifrontend_e2e.go`'s `afPatchKAJWTAudience` in sync with the new value (it does a string-match patch against the KA ConfigMap).

## Root cause evidence

```
{"tool": "kubernaut_discover_workflows", "error": "...MCP connect: calling \"initialize\": rejected by transport: sending \"initialize\": Too Many Requests"}
{"tool": "kubernaut_select_workflow", "error": "...MCP connect: rejected by transport: sending \"notifications/initialized\": Too Many Requests"}
```

Not a regression from #1869, and not a defect in #1853's `NextToolCall` chaining fix itself (independently live-validated pre-merge, see #1853's comment history) — confirmed the original failure self-healed on a bare job rerun with no code changes.

Full findings also posted on #1853.

## Test plan

- [x] `go build ./test/infrastructure/...`
- [ ] CI: `E2E (fullpipeline)` passes (validates the bump under real concurrent load)

Made with [Cursor](https://cursor.com)