### PR TITLE
fix(k8s): self-heal RESTMapper cache on lookup failure (#1888)

### DIFF
--- a/docs/architecture/DESIGN_DECISIONS.md
+++ b/docs/architecture/DESIGN_DECISIONS.md
@@ -109,6 +109,7 @@
 | DD-TESTING-002 | Integration Test Diagnostics (Must-Gather Pattern) | ✅ Approved | 2026-01-14 | [DD-TESTING-002-integration-test-diagnostics-must-gather.md](decisions/DD-TESTING-002-integration-test-diagnostics-must-gather.md) |
 | DD-AUTH-004 | OpenShift OAuth-Proxy for SOC2 Legal Hold Authentication | ✅ Approved | 2026-01-07 | [DD-AUTH-004-openshift-oauth-proxy-legal-hold.md](decisions/DD-AUTH-004-openshift-oauth-proxy-legal-hold.md) |
 | DD-AUTH-005 | DataStorage Client Authentication Pattern (Authoritative) | ✅ Approved | 2026-01-07 | [DD-AUTH-005-datastorage-client-authentication-pattern.md](decisions/DD-AUTH-005-datastorage-client-authentication-pattern.md) |
+| DD-K8S-001 | RESTMapper Cache Invalidation on Lookup Failure | ✅ Approved | 2026-08-03 | [DD-K8S-001-restmapper-cache-invalidation-on-lookup-failure.md](decisions/DD-K8S-001-restmapper-cache-invalidation-on-lookup-failure.md) |
 
 **Note**: For complete decision details, alternatives considered, implementation guidance, and consequences, see the individual DD-* files in `docs/architecture/decisions/`.
 

--- a/docs/architecture/decisions/DD-K8S-001-restmapper-cache-invalidation-on-lookup-failure.md
+++ b/docs/architecture/decisions/DD-K8S-001-restmapper-cache-invalidation-on-lookup-failure.md
@@ -1,0 +1,249 @@
+# DD-K8S-001: RESTMapper Cache Invalidation on Lookup Failure
+
+## Status
+**✅ Approved** (2026-08-03)
+**Last Reviewed**: 2026-08-03
+**Confidence**: 96%
+
+---
+
+## Context & Problem
+
+**Problem** (Issue #1888): AF's `kubectl_get`/`kubectl_list` MCP tools intermittently fail to
+resolve valid CRD kinds (e.g., Red Hat ACM's `search.open-cluster-management.io/Search`) with
+"cannot resolve GVK for kind", even though the CRD is genuinely installed and RBAC-accessible.
+The failure is permanent for the life of the pod — a restart fixes it.
+
+**Root cause** (confirmed against live-cluster testing and the exact vendored
+`k8s.io/client-go@v0.35.7` source, not just generic recollection):
+
+1. `cmd/apifrontend/main.go` constructs `restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(disc))`.
+2. `pkg/shared/k8s/gvk.go`'s `ResolveGVKForKind` fallback calls `mapper.KindsFor(...)` on it for
+   any Kind not in the static table (CRDs, third-party resources).
+3. `DeferredDiscoveryRESTMapper.KindsFor` (client-go source):
+   ```go
+   gvks, err = del.KindsFor(resource)
+   if len(gvks) == 0 && !d.cl.Fresh() {
+       d.Reset()
+       gvks, err = d.KindsFor(resource)
+   }
+   ```
+   The self-heal retry only fires when `!d.cl.Fresh()`.
+4. `memCacheClient.Fresh()` returns `d.cacheValid`, which is set `true` once by `refreshLocked()`
+   on the first successful discovery populate and is **never** invalidated on any timer — only an
+   explicit `Invalidate()`/`Reset()` call flips it back to `false`. There is no periodic TTL
+   anywhere in this client.
+5. `restmapper.GetAPIGroupResources` additionally discards the error from
+   `ServerGroupsAndResources()` whenever `gs`/`rs` come back non-nil — so a single group's
+   transient `*discovery.ErrGroupDiscoveryFailed` during that first populate is silently dropped,
+   with no log line anywhere in the call chain.
+
+**Net effect**: if a CRD's API group is missing from the pod's very first discovery round (a
+transient API-server hiccup, an aggregated-API-server slow to register, or the CRD being
+installed a few seconds after AF's mapper does its first lazy fetch), that Kind is **permanently**
+unresolvable until the pod restarts — the built-in self-heal only exists for the window before the
+first successful populate, never after.
+
+**Blast radius**: confirmed to affect only mappers built via `client-go`'s
+`restmapper.DeferredDiscoveryRESTMapper` directly. RemediationOrchestrator and
+EffectivenessMonitor call `ResolveGVKWithAPIVersion`/`ResolveGVKForKind` with
+`k8sManager.GetRESTMapper()` (controller-runtime's `apiutil.NewDynamicRESTMapper`), a different
+implementation that reactively invalidates per-request on `NoKindMatchError` — not subject to
+this one-shot-`Fresh()` bug. The fix is therefore scoped to `ResolveGVKForKind`'s fallback, the
+only path AF's `kubectl_get`/`kubectl_list` tools use.
+
+**Existing precedent**: `pkg/kubernautagent/tools/k8s/resolver.go` (KA's own dynamic resolver,
+added independently, unrelated code path) already has this exact fix pattern:
+
+```go
+type resettableMapper interface {
+    Reset()
+}
+...
+gvrs, err := r.mapper.ResourcesFor(schema.GroupVersionResource{Resource: resource})
+if err != nil {
+    if rm, ok := r.mapper.(resettableMapper); ok {
+        rm.Reset()
+        gvrs, err = r.mapper.ResourcesFor(schema.GroupVersionResource{Resource: resource})
+    }
+    ...
+}
+```
+
+`gvk.go`'s `ResolveGVKForKind` never got the same treatment.
+
+---
+
+## Alternatives Considered
+
+### Alternative 1: Reactive `Reset()`-on-failure retry ⭐ **SELECTED**
+
+**Approach**: In `ResolveGVKForKind`'s fallback, on `KindsFor` failure/empty result, type-assert
+the mapper to `meta.ResettableRESTMapper` (apimachinery's own interface for exactly this purpose)
+and retry once after `Reset()`.
+
+```go
+gvks, err := mapper.KindsFor(schema.GroupVersionResource{Resource: pluralGVR.Resource})
+if (err != nil || len(gvks) == 0) {
+    if rm, ok := mapper.(meta.ResettableRESTMapper); ok {
+        rm.Reset()
+        gvks, err = mapper.KindsFor(schema.GroupVersionResource{Resource: pluralGVR.Resource})
+    }
+}
+```
+
+**Pros**:
+- ✅ Mirrors an already-shipped, already-accepted pattern in this codebase (`resolver.go`) —
+  zero new design risk
+- ✅ Self-heals on the very next lookup, not after a timer window
+- ✅ Smallest possible diff (~6 lines), no new goroutines, no new config/interval to tune
+- ✅ `apimachinery`'s own `meta.ResettableRESTMapper` doc comment explicitly recommends this
+  check for delegating mappers
+
+**Cons**:
+- ⚠️ A genuinely-invalid/typo'd Kind still costs one extra discovery round-trip per failed
+  lookup (no caching of "this Kind is definitely bad")
+  - **Mitigation**: Same accepted trade-off as the existing `resolver.go` precedent; bounded to
+    exactly one retry, not a loop
+
+**Confidence**: 96% (approved — precedented, minimal, directly addresses the reported symptom)
+
+---
+
+### Alternative 2: Periodic TTL-based `Reset()` background goroutine
+
+**Approach**: Start a background goroutine at mapper-construction time (`cmd/apifrontend/main.go`)
+that calls `mapper.Reset()` on a fixed interval (e.g., every 10 minutes), mirroring the
+`StartAnomalyDetectorCleanupLoop`/`store.StartCleanupLoop` idiom used elsewhere in this codebase
+(#1892).
+
+**Pros**:
+- ✅ Proactively self-heals without waiting for a failed lookup
+- ✅ Consistent with an existing background-sweep idiom in this codebase
+
+**Cons**:
+- ❌ New moving part: an interval to choose and justify (too short = wasted full-discovery
+  refreshes on every AF pod; too long = long recovery window)
+- ❌ Doesn't cover the case of a CRD installed after the pod's first successful discovery *and*
+  before the next lookup attempt if no lookup ever fails to trigger a refresh in between —
+  correctness still ultimately depends on a failed lookup happening at some point
+- ❌ Adds recurring full-discovery-refresh cost (`ServerGroupsAndResources()` across all API
+  groups) independent of actual usage
+
+**Confidence**: 70% (rejected as primary fix — solves a superset of the problem at higher
+ongoing cost, without being strictly necessary given Alternative 1 already self-heals on demand)
+
+---
+
+### Alternative 3: Combined (Alternative 1 + Alternative 2 as defense-in-depth)
+
+**Approach**: Ship the reactive retry now, and separately consider a periodic backstop later if
+telemetry shows kinds still going unresolved for extended periods in production.
+
+**Pros**:
+- ✅ Highest robustness ceiling
+
+**Cons**:
+- ❌ Adds Alternative 2's complexity/cost for a benefit not yet demonstrated to be needed
+- ❌ Scope creep relative to the reported, reproduced bug
+
+**Confidence**: 65% (deferred — revisit only if Alternative 1 proves insufficient in production)
+
+---
+
+## Decision
+
+**APPROVED: Alternative 1** — Reactive `Reset()`-on-failure retry in `ResolveGVKForKind`'s
+fallback, using apimachinery's `meta.ResettableRESTMapper` interface.
+
+**Rationale**:
+1. Directly fixes the reported, reproduced symptom (permanent post-first-miss unresolvability)
+   with the smallest possible change.
+2. Mirrors a pattern already shipped and accepted in this exact codebase
+   (`pkg/kubernautagent/tools/k8s/resolver.go`), eliminating design novelty/risk.
+3. No new background goroutine, interval, or Helm value to introduce, document, and maintain.
+4. Alternative 2/3's extra robustness is not justified without evidence that reactive-only
+   self-heal is insufficient in production; can be revisited later (see Review & Evolution).
+
+---
+
+## Implementation
+
+### Package Location
+
+```
+pkg/shared/k8s/gvk.go          # ResolveGVKForKind fallback (modified)
+pkg/shared/k8s/gvk_test.go     # UT-K8S-1888-* (new)
+```
+
+### Core Change
+
+```go
+if mapper != nil {
+    pluralGVR, _ := meta.UnsafeGuessKindToResource(schema.GroupVersionKind{Kind: kind})
+    resource := schema.GroupVersionResource{Resource: pluralGVR.Resource}
+    gvks, err := mapper.KindsFor(resource)
+    if err != nil || len(gvks) == 0 {
+        // #1888: DeferredDiscoveryRESTMapper's own self-heal only fires once, before its
+        // first successful discovery populate (see DD-K8S-001). A CRD group missing from
+        // that first round stays unresolvable forever without this explicit retry.
+        if rm, ok := mapper.(meta.ResettableRESTMapper); ok {
+            rm.Reset()
+            gvks, err = mapper.KindsFor(resource)
+        }
+    }
+    if err == nil && len(gvks) > 0 {
+        return gvks[0], nil
+    }
+}
+```
+
+---
+
+## Consequences
+
+### Positive
+- ✅ CRD kinds that miss AF's first discovery round now resolve on the very next lookup —
+  no pod restart required
+- ✅ Zero new infrastructure, config, or Helm values
+- ✅ Consistent pattern now exists in both `pkg/shared/k8s/gvk.go` and
+  `pkg/kubernautagent/tools/k8s/resolver.go`
+
+### Negative
+- ⚠️ One extra discovery round-trip per genuinely-failed lookup (typo'd Kind, truly
+  unregistered resource)
+  - **Mitigation**: Bounded to exactly one retry; accepted trade-off already present in
+    `resolver.go`
+
+### Neutral
+- 🔄 `ResolveGVKWithAPIVersion`'s explicit-`apiVersion` path is intentionally left unchanged —
+  its only callers use a different, unaffected RESTMapper implementation (see Context)
+
+---
+
+## Related Documents
+
+| Document | Relationship |
+|----------|--------------|
+| `docs/tests/1888/TEST_PLAN.md` | Test plan for this fix |
+| `pkg/kubernautagent/tools/k8s/resolver.go` | Existing precedent for the same retry pattern |
+| Issue #310 / #1275 / #1040 | Prior `gvk.go` fixes (ambiguity, static-table CRDs, apiVersion disambiguation) |
+
+---
+
+## Review & Evolution
+
+**When to Revisit**:
+- If production telemetry shows kinds still failing to resolve across multiple consecutive
+  lookups (would indicate Alternative 2/3's proactive backstop is needed)
+- If `client-go` changes `DeferredDiscoveryRESTMapper`'s `Fresh()` semantics in a future version
+
+---
+
+**Last Updated**: August 3, 2026
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-08-03 | Initial approval | AI Assistant |

--- a/docs/tests/1888/TEST_PLAN.md
+++ b/docs/tests/1888/TEST_PLAN.md
@@ -1,0 +1,282 @@
+# Test Plan: RESTMapper cache self-heals on lookup failure (#1888)
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-1888-v1.0
+**Feature**: `ResolveGVKForKind`'s REST-mapper fallback retries once via `Reset()` when a lookup
+fails or comes back empty, so a CRD kind that missed a single discovery round during AF's lazy
+mapper init self-heals on the next lookup instead of staying unresolvable until pod restart.
+**Version**: 1.0
+**Created**: 2026-08-03
+**Author**: AI Assistant
+**Status**: Complete
+**Branch**: `fix/1888-restmapper-cache-invalidation`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Issue #1888: AF's `kubectl_get`/`kubectl_list` MCP tools intermittently fail to resolve valid
+CRD kinds (e.g., ACM's `search.open-cluster-management.io/Search`) with "cannot resolve GVK for
+kind". Root cause (confirmed against live cluster + the exact vendored `k8s.io/client-go@v0.35.7`
+source): `cmd/apifrontend/main.go` builds a `restmapper.NewDeferredDiscoveryRESTMapper` wrapping a
+`memory.MemCacheClient`. That mapper's built-in self-heal (`!d.cl.Fresh()` gate) only fires
+**once**, before the very first successful discovery populate. `memCacheClient.Fresh()` reports
+`cacheValid`, which flips to `true` permanently after the first `refreshLocked()` succeeds and is
+never invalidated on any TTL. If a CRD's API group is missing from that very first discovery
+round (a `*discovery.ErrGroupDiscoveryFailed` for one group, silently discarded by
+`restmapper.GetAPIGroupResources` whenever `gs`/`rs` are non-nil), the Kind is permanently
+unresolvable until the pod restarts.
+
+This test plan covers the fix: `ResolveGVKForKind`'s REST-mapper fallback now retries once via
+`Reset()` on failure/empty result, mirroring the already-shipped `resettableMapper` pattern in
+`pkg/kubernautagent/tools/k8s/resolver.go`.
+
+### 1.2 Objectives
+
+1. **Self-heal proven**: A mapper whose first `KindsFor` call returns no match, but whose
+   second call (post-`Reset()`) returns the correct GVK, causes `ResolveGVKForKind` to succeed —
+   proving the retry path exists and is exercised.
+2. **No regression**: All existing `ResolveGVKForKind`/`ResolveGVKWithAPIVersion` behavior
+   (static-table kinds, ambiguous-Kind disambiguation, nil-mapper handling, genuine not-found
+   errors) is unchanged.
+3. **Scope discipline**: The fix touches only `ResolveGVKForKind`'s fallback — not
+   `ResolveGVKWithAPIVersion`, whose only production callers (RemediationOrchestrator,
+   EffectivenessMonitor) use controller-runtime's `apiutil.NewDynamicRESTMapper`, a different
+   implementation not subject to this bug.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `make test-unit-shared` (or targeted `go test ./pkg/shared/k8s/...` via make) |
+| Backward compatibility | 0 regressions | All pre-existing `gvk_test.go` / `gvk_apiversion_test.go` cases pass unmodified |
+| Retry bounded | No infinite loop / no more than 1 extra discovery round-trip per failed lookup | Code inspection + test asserting `KindsFor` called exactly twice on the failure path |
+
+---
+
+## 2. References
+
+### 2.1 Authority (governing documents)
+
+- Issue #1888: `kubectl_get`/`kubectl_list` fail to resolve GVK for valid CRD kinds
+- [DD-K8S-001](../../architecture/decisions/DD-K8S-001-restmapper-cache-invalidation-on-lookup-failure.md): RESTMapper cache invalidation on lookup failure
+- Precedent: `pkg/kubernautagent/tools/k8s/resolver.go` (`resettableMapper` retry pattern)
+
+### 2.2 Cross-References
+
+- `pkg/shared/k8s/gvk.go` — code under test
+- `pkg/shared/k8s/gvk_test.go` — existing suite, extended here
+- Prior related fix: #1275 (kubernaut.ai CRD static-table kinds), #310 (Node ambiguity), #1040
+  (`ResolveGVKWithAPIVersion` disambiguation)
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|----|------|--------|-------------|-----------------|------------|
+| R1 | Retry fires on every genuinely-invalid Kind, adding a discovery round-trip per bad lookup | Minor extra API-server load on malformed/typo'd Kind requests | Medium | UT-K8S-1888-002 | Bounded to exactly 1 retry (no loop); accepted trade-off, same as the existing `resolver.go` precedent already shipped in this codebase |
+| R2 | Retry masks a persistently-broken mapper (discovery permanently down) behind repeated `Reset()` calls | Wasted work, but no correctness risk — final error is still surfaced | Low | UT-K8S-1888-003 | `Reset()` result is still checked; error propagates normally if the retry also fails |
+| R3 | Fix applied to wrong function (`ResolveGVKWithAPIVersion` instead of/also) | Fix doesn't address the reported bug, or scope creep into reconciler-only code path | Low | UT-K8S-1888-001 | Confirmed via `Grep`: AF's `kubectl_get.go`/`scope_helpers.go` call only `ResolveGVKForKind`; `ResolveGVKWithAPIVersion` callers use a different, unaffected mapper implementation |
+
+### 3.1 Risk-to-Test Traceability
+
+R1/R2 are behavioral trade-offs inherent to the chosen design (DD-K8S-001), not defects;
+UT-K8S-1888-002/003 prove the retry is bounded and errors still propagate correctly.
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **`ResolveGVKForKind` REST-mapper fallback** (`pkg/shared/k8s/gvk.go`): retries once via
+  `Reset()` when the initial `KindsFor` call fails or returns no match, then re-resolves.
+
+### 4.2 Features Not to be Tested
+
+- **`ResolveGVKWithAPIVersion`'s explicit-`apiVersion` path**: out of scope — its only production
+  callers use a RESTMapper implementation (`apiutil.NewDynamicRESTMapper`) not subject to this
+  bug (see DD-K8S-001 §Context for verification).
+- **`restmapper.DeferredDiscoveryRESTMapper` itself**: vendored `client-go` code, not modifiable;
+  this fix works around its one-shot `Fresh()` gate rather than patching it.
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| Reactive `Reset()`-on-failure (not periodic TTL) | Mirrors an already-shipped, precedented pattern (`resolver.go`); smallest diff; self-heals on the very next lookup rather than waiting for a timer. See DD-K8S-001 for full alternatives analysis. |
+| Type-assert to `meta.ResettableRESTMapper` (apimachinery's own interface) rather than a local interface | Avoids a redundant duplicate type; apimachinery's doc comment explicitly recommends this exact check for delegating mappers. |
+| Test IDs reference the issue number (`UT-K8S-1888-*`), not a new BR-XXX doc | Matches established local convention for bug fixes in this file (`UT-K8S-1275-*` for issue #1275) rather than minting a new business requirement document for a defect fix. |
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+- **Unit**: 100% of the new retry branch (both the "retry succeeds" and "retry also fails" paths).
+- **Integration**: N/A — no new wiring; `ResolveGVKForKind` is already called from AF's
+  `kubectl_get.go`/`scope_helpers.go` in production. Existing UT coverage of the shared helper is
+  the correctness proof; no new cross-component wiring is introduced by this fix.
+
+### 5.2 Two-Tier Minimum — Tier Skip Rationale
+
+Integration tier is skipped for this fix: it is a pure-logic change to an already-integrated,
+already-unit-tested helper function with no I/O of its own (the `meta.RESTMapper` it receives is
+already exercised via mocks in the existing suite, matching the file's established test style).
+No new wiring point is introduced (CHECKPOINT W: not applicable — no new component).
+
+### 5.3 Pass/Fail Criteria
+
+**PASS**:
+1. New `UT-K8S-1888-*` tests pass.
+2. All pre-existing tests in `gvk_test.go` and `gvk_apiversion_test.go` continue to pass
+   unmodified.
+3. `go build ./...`, `golangci-lint run`, `go vet ./...` clean.
+
+**FAIL**: any pre-existing test regresses, or the retry loops/recurses unboundedly.
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code
+
+| File | Functions/Methods | Lines (approx) |
+|------|--------------------|-----------------|
+| `pkg/shared/k8s/gvk.go` | `ResolveGVKForKind` (fallback branch) | ~10 (modified) |
+
+### 6.2 Version Identification
+
+| Item | Version/Commit | Notes |
+|------|-----------------|-------|
+| Code under test | `release/v1.5` HEAD (`fix/1888-restmapper-cache-invalidation`) | |
+| `k8s.io/apimachinery` | v0.36.3 (go.mod) | `meta.ResettableRESTMapper` |
+| `k8s.io/client-go` | v0.35.7 (go.mod) | `restmapper.DeferredDiscoveryRESTMapper` (root cause, verified against actual vendored source) |
+
+---
+
+## 7. BR Coverage Matrix
+
+Bug fix to already-implemented, already-integrated functionality; tracked via issue #1888 test
+IDs per local convention (see §4.3), not a new BR document.
+
+| Reference | Description | Priority | Tier | Test ID | Status |
+|-----------|--------------|----------|------|---------|--------|
+| #1888 | Self-heal REST-mapper cache on lookup failure | P1 | Unit | UT-K8S-1888-001 | Pass |
+| #1888 | Retry is bounded to exactly one extra attempt | P2 | Unit | UT-K8S-1888-002 | Pass |
+| #1888 | Error still propagates when retry also fails | P2 | Unit | UT-K8S-1888-003 | Pass |
+| #1888 | Non-resettable mappers are unaffected (no panic/no retry attempted) | P2 | Unit | UT-K8S-1888-004 | Pass |
+
+---
+
+## 8. Test Scenarios
+
+### Tier 1: Unit Tests
+
+**Testable code scope**: `pkg/shared/k8s/gvk.go` — 100% of the new retry branch.
+
+| ID | Business Outcome Under Test | Phase |
+|----|------------------------------|-------|
+| `UT-K8S-1888-001` | A CRD kind that misses the first discovery round resolves successfully on the very next lookup, without requiring a pod restart | Pass |
+| `UT-K8S-1888-002` | The retry fires exactly once per failed lookup (no unbounded loop) | Pass |
+| `UT-K8S-1888-003` | A mapper that still can't resolve the kind after `Reset()` returns the same "cannot resolve GVK" error as before (no silent success, no panic) | Pass |
+| `UT-K8S-1888-004` | A `meta.RESTMapper` that does NOT implement `Reset()` (e.g., `meta.DefaultRESTMapper` used in most existing tests) behaves exactly as before — no retry attempted, no panic from a failed type assertion | Pass |
+
+---
+
+## 9. Test Cases
+
+### UT-K8S-1888-001: Self-heals on next lookup after a missed discovery round
+
+**Priority**: P1
+**Type**: Unit
+**File**: `pkg/shared/k8s/gvk_test.go`
+
+**Test Steps**:
+1. **Given**: A mock `meta.ResettableRESTMapper` whose `KindsFor("customwidgets")` returns
+   `NoResourceMatchError` on the first call (simulating a CRD group missing from the pod's first
+   discovery round), but returns the correct GVK on the second call (simulating the CRD becoming
+   discoverable, e.g. after the operator's cache TTL or a later successful discovery round).
+2. **When**: `ResolveGVKForKind(mapper, "CustomWidget")` is called.
+3. **Then**: It returns the correct GVK with no error, and `Reset()` was called exactly once.
+
+**Acceptance Criteria**: Behavior — resolves without error. Correctness — GVK matches the
+second-call result. Accuracy — `Reset()` invoked exactly once, `KindsFor` invoked exactly twice.
+
+### UT-K8S-1888-002 / 003 / 004
+
+Summarized in §8; implemented as `DescribeTable`/`It` entries alongside UT-K8S-1888-001 in the
+same `Describe("REST mapper self-heal on lookup failure (#1888)")` block.
+
+---
+
+## 10. Environmental Needs
+
+- **Framework**: Ginkgo/Gomega BDD (existing suite convention)
+- **Mocks**: In-package mock `meta.RESTMapper`/`meta.ResettableRESTMapper` implementations only
+  (no external dependencies — this is a pure-logic unit)
+- **Location**: `pkg/shared/k8s/gvk_test.go`
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Blocking Dependencies
+
+None. Independent of PR #1895 (#1889/#1892 fix) — different subsystem (RESTMapper discovery
+caching vs. anomaly-detector isolation), separate branch/PR by design.
+
+### 11.2 Execution Order
+
+1. **RED**: Add `UT-K8S-1888-001..004` with a new resettable mock mapper; confirm they fail
+   against unmodified `gvk.go`.
+2. **GREEN**: Add the `Reset()`-on-failure retry to `ResolveGVKForKind`'s fallback.
+3. **REFACTOR**: Anti-pattern check (naming, error string, retry-bound clarity); N/A if GREEN
+   leaves nothing to clean beyond the minimal retry itself.
+
+---
+
+## 12. Test Deliverables
+
+| Deliverable | Location | Description |
+|-------------|----------|--------------|
+| This test plan | `docs/tests/1888/TEST_PLAN.md` | Strategy and test design |
+| Unit tests | `pkg/shared/k8s/gvk_test.go` | Ginkgo BDD, extended |
+| Design decision | `docs/architecture/decisions/DD-K8S-001-restmapper-cache-invalidation-on-lookup-failure.md` | Alternatives + rationale |
+
+---
+
+## 13. Execution
+
+```bash
+make test-unit-shared   # or the make target covering pkg/shared/...
+```
+
+---
+
+## 14. Wiring Verification
+
+Not applicable — no new component or wiring point. `ResolveGVKForKind` is already called in
+production by `pkg/apifrontend/tools/kubectl_get.go:91` and `pkg/apifrontend/tools/scope_helpers.go:37`.
+This fix changes internal behavior of an already-wired function.
+
+---
+
+## 15. Existing Tests Requiring Updates
+
+None. The fix only adds a new branch that activates on failure/empty-result; all existing
+success-path assertions in `gvk_test.go`/`gvk_apiversion_test.go` are unaffected.
+
+---
+
+## 16. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-08-03 | Initial test plan |
+| 1.1 | 2026-08-03 | RED→GREEN→REFACTOR complete. All 4 new tests (UT-K8S-1888-001..004) pass; full `make test-unit-shared-packages` suite (21 suites) passes with zero regressions; `go build ./...`, `go vet`, and `golangci-lint run` clean. |

--- a/pkg/shared/k8s/gvk.go
+++ b/pkg/shared/k8s/gvk.go
@@ -93,7 +93,21 @@ func ResolveGVKForKind(mapper meta.RESTMapper, kind string) (schema.GroupVersion
 
 	if mapper != nil {
 		pluralGVR, _ := meta.UnsafeGuessKindToResource(schema.GroupVersionKind{Kind: kind})
-		gvks, err := mapper.KindsFor(schema.GroupVersionResource{Resource: pluralGVR.Resource})
+		resource := schema.GroupVersionResource{Resource: pluralGVR.Resource}
+		gvks, err := mapper.KindsFor(resource)
+		if err != nil || len(gvks) == 0 {
+			// #1888: restmapper.DeferredDiscoveryRESTMapper's own self-heal only fires
+			// once, before its first successful discovery populate (its Fresh() gate
+			// becomes permanently true afterward and is never invalidated on a TTL). A
+			// CRD group missing from that first round would otherwise stay unresolvable
+			// for the life of the pod. Retry once via Reset() when the mapper supports it
+			// (see DD-K8S-001), mirroring the existing pattern in
+			// pkg/kubernautagent/tools/k8s/resolver.go.
+			if rm, ok := mapper.(meta.ResettableRESTMapper); ok {
+				rm.Reset()
+				gvks, err = mapper.KindsFor(resource)
+			}
+		}
 		if err == nil && len(gvks) > 0 {
 			return gvks[0], nil
 		}

--- a/pkg/shared/k8s/gvk_test.go
+++ b/pkg/shared/k8s/gvk_test.go
@@ -64,6 +64,42 @@ func (m *mockRESTMapper) ResourceSingularizer(resource string) (string, error) {
 	panic("not implemented")
 }
 
+// resettableMockMapper simulates a restmapper.DeferredDiscoveryRESTMapper whose first
+// KindsFor call misses a CRD group (as if it were absent from the pod's first discovery
+// round — #1888) but resolves correctly once Reset() is called and the lookup retried.
+type resettableMockMapper struct {
+	*mockRESTMapper
+	kindsForCalls    int
+	resetCalls       int
+	postResetResults map[string][]schema.GroupVersionKind
+}
+
+func (m *resettableMockMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	m.kindsForCalls++
+	if m.resetCalls > 0 {
+		if gvks, ok := m.postResetResults[resource.Resource]; ok {
+			return gvks, nil
+		}
+		return nil, &meta.NoResourceMatchError{PartialResource: resource}
+	}
+	return m.mockRESTMapper.KindsFor(resource)
+}
+
+func (m *resettableMockMapper) Reset() {
+	m.resetCalls++
+}
+
+// alwaysFailingResettableMapper simulates a mapper that still cannot resolve a kind even
+// after Reset() — e.g., a genuinely invalid/typo'd Kind, or discovery still down.
+type alwaysFailingResettableMapper struct {
+	*mockRESTMapper
+	resetCalls int
+}
+
+func (m *alwaysFailingResettableMapper) Reset() {
+	m.resetCalls++
+}
+
 var _ = Describe("ResolveGVKForKind (#310)", func() {
 
 	// Mock REST mapper that returns metrics.k8s.io/v1beta1/Node first —
@@ -143,6 +179,61 @@ var _ = Describe("ResolveGVKForKind (#310)", func() {
 
 		It("should return error when kind is unknown and mapper is nil", func() {
 			_, err := k8sutil.ResolveGVKForKind(nil, "NonExistentKind")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("NonExistentKind"))
+		})
+	})
+
+	Context("REST mapper self-heal on lookup failure (#1888)", func() {
+		It("UT-K8S-1888-001: resolves a kind that missed the first discovery round once Reset() retries", func() {
+			mapper := &resettableMockMapper{
+				mockRESTMapper: &mockRESTMapper{},
+				// meta.UnsafeGuessKindToResource("Search") guesses the plural "searchs"
+				// (the naive heuristic doesn't know the real CRD plural is "searches" —
+				// irrelevant here since this mock controls resolution directly).
+				postResetResults: map[string][]schema.GroupVersionKind{
+					"searchs": {{Group: "search.open-cluster-management.io", Version: "v1alpha1", Kind: "Search"}},
+				},
+			}
+
+			gvk, err := k8sutil.ResolveGVKForKind(mapper, "Search")
+
+			Expect(err).NotTo(HaveOccurred(),
+				"a kind missing from the first discovery round must self-heal on retry, not stay permanently unresolvable")
+			Expect(gvk).To(Equal(schema.GroupVersionKind{
+				Group: "search.open-cluster-management.io", Version: "v1alpha1", Kind: "Search",
+			}))
+		})
+
+		It("UT-K8S-1888-002: retries exactly once — Reset() and KindsFor are not called in an unbounded loop", func() {
+			mapper := &resettableMockMapper{
+				mockRESTMapper: &mockRESTMapper{},
+				postResetResults: map[string][]schema.GroupVersionKind{
+					"searchs": {{Group: "search.open-cluster-management.io", Version: "v1alpha1", Kind: "Search"}},
+				},
+			}
+
+			_, err := k8sutil.ResolveGVKForKind(mapper, "Search")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mapper.resetCalls).To(Equal(1), "Reset() must be called exactly once on failure, not looped")
+			Expect(mapper.kindsForCalls).To(Equal(2), "KindsFor must be called exactly twice: once before Reset(), once after")
+		})
+
+		It("UT-K8S-1888-003: propagates the original error when the kind is still unresolvable after Reset()", func() {
+			mapper := &alwaysFailingResettableMapper{mockRESTMapper: &mockRESTMapper{}}
+
+			_, err := k8sutil.ResolveGVKForKind(mapper, "TrulyUnknownKind")
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("TrulyUnknownKind"))
+			Expect(mapper.resetCalls).To(Equal(1), "Reset() should still be attempted once even though it doesn't help")
+		})
+
+		It("UT-K8S-1888-004: a mapper without Reset() behaves exactly as before (no retry, no panic)", func() {
+			// metricsMapper (plain mockRESTMapper) does not implement meta.ResettableRESTMapper.
+			_, err := k8sutil.ResolveGVKForKind(metricsMapper, "NonExistentKind")
+
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("NonExistentKind"))
 		})


### PR DESCRIPTION
## Summary

- `kubectl_get`/`kubectl_list` intermittently failed to resolve valid CRD kinds (e.g. Red Hat ACM's `Search` API) with "cannot resolve GVK for kind", permanently until pod restart.
- Root cause (confirmed against live-cluster testing **and** the exact vendored `k8s.io/client-go@v0.35.7` source, not just recollection): `restmapper.DeferredDiscoveryRESTMapper`'s built-in self-heal only fires once, before its first successful discovery populate — its `Fresh()` gate becomes permanently `true` afterward and is never invalidated on a TTL. A CRD group missing from AF's first discovery round stays unresolvable for the pod's lifetime.
- Fix: `ResolveGVKForKind`'s REST-mapper fallback now retries once via `Reset()` on failure/empty result, mirroring the already-shipped `resettableMapper` pattern in `pkg/kubernautagent/tools/k8s/resolver.go`. See [DD-K8S-001](docs/architecture/decisions/DD-K8S-001-restmapper-cache-invalidation-on-lookup-failure.md) for the full alternatives analysis (reactive retry vs. periodic TTL vs. combined) and why reactive-only was selected.
- Scope confirmed tight: AF's `kubectl_get.go`/`scope_helpers.go` only call `ResolveGVKForKind`. `ResolveGVKWithAPIVersion` (used by RemediationOrchestrator/EffectivenessMonitor) is untouched — those reconcilers use controller-runtime's `apiutil.NewDynamicRESTMapper`, a different implementation not subject to this bug.

Closes #1888.

## Test plan

- [x] RED: added `UT-K8S-1888-001..004` to `pkg/shared/k8s/gvk_test.go` (new resettable mock mapper); confirmed 3 of 4 failed against unmodified code
- [x] GREEN: implemented the `Reset()`-on-failure retry in `pkg/shared/k8s/gvk.go`; all 4 new tests pass
- [x] REFACTOR: removed an unused test field flagged by `golangci-lint`; zero anti-pattern findings
- [x] `make test-unit-shared-packages` — all 21 suites pass, zero regressions
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` — clean
- [x] Full test plan: [docs/tests/1888/TEST_PLAN.md](docs/tests/1888/TEST_PLAN.md)


Made with [Cursor](https://cursor.com)