### PR TITLE
fix(kubernautagent): tool-budget MCPError code + per-investigation anomaly isolation (#1889, #1892) [main port]

### DIFF
--- a/charts/kubernaut/templates/_generated_defaults.tpl
+++ b/charts/kubernaut/templates/_generated_defaults.tpl
@@ -270,6 +270,10 @@ hooks:
         image: docker.io/bitnami/kubectl:latest@sha256:6e2cdb22d6ab7264ea198c717f555e30536b54029d26c8781b9f25f78951b564
 kubernautAgent:
     additionalClusterRoleBindings: []
+    ai:
+        safety:
+            anomaly:
+                maxTotalToolCalls: 30
     alignmentCheck:
         enabled: false
         llmProfileRef: ""

--- a/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
+++ b/charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml
@@ -159,6 +159,9 @@ ai:
 {{- end }}
   investigation:
     maxTurns: 40
+    safety:
+      anomaly:
+        maxTotalToolCalls: {{ $v.ai.safety.anomaly.maxTotalToolCalls }}
 {{- if .Values.kubernautAgent.alignmentCheck.enabled }}
   alignmentCheck:
     enabled: true

--- a/charts/kubernaut/tests/kubernaut_agent_anomaly_config_test.yaml
+++ b/charts/kubernaut/tests/kubernaut_agent_anomaly_config_test.yaml
@@ -1,0 +1,51 @@
+suite: "kubernaut-agent ConfigMap — anomaly detector maxTotalToolCalls (#1892)"
+templates:
+  - templates/kubernaut-agent/kubernaut-agent.yaml
+set:
+  signalprocessing:
+    policies:
+      existingConfigMap: dummy
+  aianalysis:
+    policies:
+      existingConfigMap: dummy
+  global:
+    llmProfiles:
+      primary:
+        provider: anthropic
+        model: claude-opus-4
+        credentialsSecretName: llm-credentials-primary
+  kubernautAgent:
+    llmProfileRef: primary
+tests:
+  - it: "HT-KA-1892-001a — renders the default of 30 when maxTotalToolCalls is not overridden"
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-agent-config
+    asserts:
+      - isKind:
+          of: ConfigMap
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "maxTotalToolCalls: 30"
+
+  - it: "HT-KA-1892-001b — renders an operator-supplied override value"
+    set:
+      global:
+        llmProfiles:
+          primary:
+            provider: anthropic
+            model: claude-opus-4
+            credentialsSecretName: llm-credentials-primary
+      kubernautAgent:
+        llmProfileRef: primary
+        ai:
+          safety:
+            anomaly:
+              maxTotalToolCalls: 75
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-agent-config
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "maxTotalToolCalls: 75"

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -2021,6 +2021,33 @@
             }
           }
         },
+        "ai": {
+          "type": "object",
+          "description": "AI investigation behavior and safety guardrails.",
+          "additionalProperties": false,
+          "properties": {
+            "safety": {
+              "type": "object",
+              "description": "Guardrails that constrain AI tool-calling behavior.",
+              "additionalProperties": false,
+              "properties": {
+                "anomaly": {
+                  "type": "object",
+                  "description": "I7 anomaly detector (DD-KA-019-003): aborts an investigation that exhibits runaway tool-calling behavior.",
+                  "additionalProperties": false,
+                  "properties": {
+                    "maxTotalToolCalls": {
+                      "type": "integer",
+                      "default": 30,
+                      "minimum": 1,
+                      "description": "Maximum total tool calls allowed per investigation phase before the investigation aborts as budget-exhausted (surfaces as MCPError code tool_budget_exhausted for interactive sessions)."
+                    }
+                  }
+                }
+              }
+            }
+          }
+        },
         "interactive": {
           "type": "object",
           "description": "MCP interactive mode (#703): enables human-in-the-loop investigation sessions.",

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -490,6 +490,16 @@ kubernautAgent:
   # -- Shadow agent alignment check (#601): parallel audit for prompt injection detection.
   alignmentCheck:
     enabled: false
+  # -- AI investigation behavior and safety guardrails.
+  ai:
+    safety:
+      anomaly:
+        # -- Maximum total tool calls allowed per investigation phase before the
+        # investigation aborts as budget-exhausted (I7 anomaly detector,
+        # DD-KA-019-003). Raise this if legitimate investigations are hitting
+        # the ceiling; for interactive sessions this surfaces as the MCPError
+        # code tool_budget_exhausted (#1889).
+        maxTotalToolCalls: 30
   # -- Multi-cluster fleet configuration (BR-FLEET-054, ADR-068, issue #1729).
   # Gated by global.fleet.enabled (Issue #1707) -- when true and
   # global.fleet.mcpGatewayEndpoint/mcpGatewayType are set, KA's investigator

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -162,6 +162,11 @@ func startAPIServer(ctx context.Context, p apiServerStartParams) (httpServer *ht
 
 	p.store.StartCleanupLoop(ctx, p.cfg.Runtime.Session.TTL/2)
 
+	// #1892: sweep idle per-investigation AnomalyDetector entries so a
+	// correlationID whose investigation never reaches a clean exit path
+	// (crash, cancellation, client disconnect) does not leak memory forever.
+	p.inv.StartAnomalyDetectorCleanupLoop(ctx, 30*time.Minute, investigator.DefaultAnomalyDetectorTTL)
+
 	// Route setup (including the JWKS pre-warm inside newAuthMiddleware) has
 	// completed by this point; only the network bind remains. Mark the API
 	// server ready now so /readyz does not report ready any earlier than this.

--- a/docs/generated/helm-values-reference.md
+++ b/docs/generated/helm-values-reference.md
@@ -344,6 +344,7 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 |-----------|------|--------------|---------|----------|
 | `additionalClusterRoleBindings` | array of string | Issue #1069 (DD-GATEWAY-018): names of pre-existing ClusterRoles to bind to the Kubernaut Agent ServiceAccount, generalizing kubernaut-operator's equivalent KA-only mechanism to the Helm chart, for resource kinds not already covered by its investigator ClusterRole. | `[]` | No |
 | `affinity` | object | Kubernetes affinity rules | `` | No |
+| `ai.safety.anomaly.maxTotalToolCalls` | integer | Maximum total tool calls allowed per investigation phase before the investigation aborts as budget-exhausted (surfaces as MCPError code tool_budget_exhausted for interactive sessions). | `30` | No |
 | `alignmentCheck.enabled` | boolean | Enable the shadow alignment agent. | `false` | No |
 | `alignmentCheck.llmProfileRef` | string | DD-PLATFORM-007: name of an entry in global.llmProfiles for a dedicated alignment-check shadow-agent LLM. Empty (default) inherits kubernautAgent.llmProfileRef's resolved profile, reusing the investigation LLM. Replaces the old alignmentCheck.llm.* block, whose apiKey field never had any effect (the Kubernaut Agent binary only reads apiKeyFile -- see kubernaut#1726 for the same class of bug). | `""` | No |
 | `alignmentCheck.maxStepTokens` | integer | Max evaluator response tokens per step. | `500` | No |

--- a/docs/tests/1889/TEST_PLAN.md
+++ b/docs/tests/1889/TEST_PLAN.md
@@ -1,0 +1,131 @@
+# Test Plan: Tool-budget MCPError code + per-investigation AnomalyDetector isolation + Helm value (#1889, #1892) — `main`/v1.6 port
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-1889-1892-main-v1.0
+**Version**: 1.0
+**Created**: 2026-08-03
+**Author**: AI Assistant
+**Status**: Implemented
+**Branch**: `fix/1889-1892-tool-budget-isolation-main` (targets `main`)
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This is the `main`/v1.6 port of the fix originally designed, TDD'd, and CI-validated on
+`release/v1.5` in [PR #1895](https://github.com/jordigilh/kubernaut/pull/1895) (branch
+`fix/1889-1892-tool-budget-isolation`). Per project policy, `release/v1.5` is fixed first (it
+ships to customers); this document tracks the follow-up port to `main` once `main`'s
+independently-refactored codebase structure was re-verified against the same design.
+
+The v1.5 PR's design rationale, alternatives analysis, and full test case descriptions are not
+repeated here — see `docs/tests/1889/TEST_PLAN.md` on `release/v1.5` (PR #1895) for that. This
+document records only what differs in the port: `main`'s file layout, and confirmation that every
+call site enumerated in the original plan has a `main`-side equivalent.
+
+Three issues, one PR (same combined-PR rationale as #1895: CI runner capacity, ~30min/PR):
+
+1. **#1889 gap 1**: `ErrCodeToolBudgetExhausted` MCPError code, so an interactive session hitting
+   the I7 anomaly detector's tool-call budget surfaces a diagnosable `tool_budget_exhausted` code
+   instead of being redacted to a generic `internal_error` by `ErrorBoundary`.
+2. **#1892**: Per-investigation `AnomalyDetector` isolation. `main`, like `release/v1.5`, shares one
+   pod-wide `AnomalyDetector` (`inv.pipeline.AnomalyDetector`) across every concurrent
+   investigation; one investigation's phase-transition `Reset()` silently zeroed every other
+   in-flight investigation's tool-call budget on the same KA pod.
+3. **Helm value**: expose `maxTotalToolCalls` as `kubernautAgent.ai.safety.anomaly.maxTotalToolCalls`
+   (Go-side `cfg.AI.Safety.Anomaly.MaxTotalToolCalls` already existed on `main`; only the Helm
+   chart lacked a way to set it — the template hardcoded `investigation.maxTurns: 40` with no
+   `safety` block at all).
+
+### 1.2 Codebase-structure differences from the `release/v1.5` port (confirmed by direct inspection)
+
+| Aspect | `release/v1.5` | `main` |
+|---|---|---|
+| `ExhaustedResult`/`runLLMLoop`/`processToolCalls` location | `investigator.go` (inline) | `investigator.go` (types) + `investigator_loop.go` (loop logic) — refactored into a separate file |
+| `ReasonToolBudgetExhausted` | added as a `const` in `investigator.go` | same: added as a `const` next to `ExhaustedResult`'s definition in `investigator.go` |
+| `executeTool` signature | took `(ctx, name, args)`, no correlationID (pre-fix) | same starting shape: took `(ctx, name, args)`, no correlationID (pre-fix) — both needed the same `correlationID` parameter added |
+| `investigate.go` / `investigate_takeover.go` wrap site | `investigate.go:656` `"interactive turn failed: %w"` | `investigate_takeover.go:131` `"interactive turn failed: %w"` — same wrap text, different filename |
+| Helm `values.yaml`/`values.schema.json` structure | `kubernautAgent.llm.*` literal block | `kubernautAgent.llmProfileRef` + `global.llmProfiles` (DD-PLATFORM-007) — chart restructured independently of this fix; the new `kubernautAgent.ai.safety.anomaly.maxTotalToolCalls` leaf is unaffected by this and inserted the same way |
+| `docs/tests/`, `docs/architecture/decisions/DD-K8S-001*` | present (from this same work) | did not exist on `main` prior to this port (created fresh here) |
+
+All other call sites (`Investigate()`, `runWorkflowDiscoveryPhase()`,
+`RunWorkflowDiscoveryFromRCA()`, `processToolCalls()`, `cmd/kubernautagent/main.go`'s
+`store.StartCleanupLoop` neighbor) matched the `release/v1.5` shape exactly, confirmed by direct
+read of each file before editing (CHECKPOINT A).
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit/Integration test pass rate | 100% | `make test-unit-kubernautagent` |
+| Helm chart test pass rate | 100%, 0 regressions | `make test-helm` (436 tests across 45 suites) |
+| Backward compatibility | 0 regressions | Full `make test-unit-kubernautagent` suite (109 specs / 34 Ginkgo suites) |
+| Build/lint | Clean | `go build ./...`, `golangci-lint run` on changed packages |
+
+---
+
+## 2. References
+
+- [PR #1895](https://github.com/jordigilh/kubernaut/pull/1895) — original `release/v1.5` implementation (design authority)
+- `docs/tests/1889/TEST_PLAN.md` on `release/v1.5` — full design rationale, alternatives, and per-test-case detail
+- Issue #1889, Issue #1892
+
+---
+
+## 3. Test Items (`main`-specific file paths)
+
+| File | Change |
+|------|--------|
+| `internal/kubernautagent/mcp/tools/errors.go` | Added `ErrCodeToolBudgetExhausted` |
+| `internal/kubernautagent/mcp/tools/errors_test.go` | **New**. `IT-KA-1889-001` + `ErrorBoundary` unit tests |
+| `internal/kubernautagent/mcp/adapters/adapters.go` | `ExtractContent` returns `ErrCodeToolBudgetExhausted` for `ReasonToolBudgetExhausted` |
+| `internal/kubernautagent/investigator/investigator.go` | Added `ReasonToolBudgetExhausted` const; added `anomalyScope` field + wiring in `New()`; `Investigate()`/`runWorkflowDiscoveryPhase()` use `anomalyDetectorFor(correlationID)` |
+| `internal/kubernautagent/investigator/investigator_loop.go` | `processToolCalls` uses `anomalyDetectorFor(correlationID).TotalExceeded()`; passes `correlationID` to `executeTool`; uses `ReasonToolBudgetExhausted` constant |
+| `internal/kubernautagent/investigator/investigator_tools.go` | `executeTool` takes `correlationID`, uses `anomalyDetectorFor(correlationID)` |
+| `internal/kubernautagent/investigator/investigator_discovery.go` | `RunWorkflowDiscoveryFromRCA` uses `anomalyDetectorFor(correlationID).Reset()` |
+| `internal/kubernautagent/investigator/anomaly.go` | Added `Clone()` |
+| `internal/kubernautagent/investigator/investigator_anomaly_scope.go` | **New**. `anomalyScope`, `anomalyDetectorFor`, `pruneAnomalyDetectors`, `StartAnomalyDetectorCleanupLoop`, `DefaultAnomalyDetectorTTL` |
+| `internal/kubernautagent/investigator/investigator_anomaly_scope_test.go` | **New**. `UT-KA-1892-002/003`, `IT-KA-1892-001` |
+| `cmd/kubernautagent/main.go` | Wired `p.inv.StartAnomalyDetectorCleanupLoop` next to `p.store.StartCleanupLoop` |
+| `charts/kubernaut/values.yaml` | Added `kubernautAgent.ai.safety.anomaly.maxTotalToolCalls: 30` |
+| `charts/kubernaut/values.schema.json` | Added schema for `kubernautAgent.ai.safety.anomaly.maxTotalToolCalls` |
+| `charts/kubernaut/templates/kubernaut-agent/kubernaut-agent.yaml` | Templates `investigation.safety.anomaly.maxTotalToolCalls` from `$v.ai.safety.anomaly.maxTotalToolCalls` |
+| `charts/kubernaut/tests/kubernaut_agent_anomaly_config_test.yaml` | **New**. `HT-KA-1892-001a/b` — default + override rendering |
+
+---
+
+## 4. BR Coverage Matrix
+
+| Reference | Description | Priority | Tier | Test ID | Status |
+|-----------|--------------|----------|------|---------|--------|
+| #1889 | Tool budget exhaustion surfaces as `tool_budget_exhausted`, not `internal_error` | P1 | Unit+Integration | IT-KA-1889-001 | Pass |
+| #1892 | Per-correlationID `AnomalyDetector` memoization | P1 | Unit | UT-KA-1892-003 | Pass |
+| #1892 | Concurrent investigations never observe each other's `Reset()`/counters | P1 | Integration | IT-KA-1892-001 | Pass |
+| #1892 | Idle per-investigation detector entries are pruned by TTL sweep | P2 | Unit | UT-KA-1892-002 | Pass |
+| Helm | `maxTotalToolCalls` renders default (30) and operator override | P2 | Helm-unittest | HT-KA-1892-001a/b | Pass |
+
+---
+
+## 5. Execution Evidence
+
+```bash
+go build ./...                                        # clean
+go vet ./internal/kubernautagent/... ./cmd/kubernautagent/...   # clean
+golangci-lint run --timeout=5m \
+  ./internal/kubernautagent/investigator/... \
+  ./internal/kubernautagent/mcp/... \
+  ./cmd/kubernautagent/...                             # 0 issues
+make test-unit-kubernautagent                          # 109 Passed, 0 Failed (34 suites)
+make test-helm                                         # 436 Passed, 0 Failed (45 suites)
+```
+
+---
+
+## 6. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-08-03 | Initial port of PR #1895 to `main`. All tests pass; build/vet/lint clean. Opened as a draft PR pending console-team validation of the `release/v1.5` fix in production. |

--- a/internal/kubernautagent/investigator/anomaly.go
+++ b/internal/kubernautagent/investigator/anomaly.go
@@ -183,6 +183,17 @@ func (d *AnomalyDetector) Reset() {
 	d.failureTracker = make(map[string]int)
 }
 
+// Clone returns a new AnomalyDetector with the same config and suspicious
+// patterns but freshly zeroed counters. Used to give each concurrent
+// investigation its own isolated budget instance (#1892) instead of sharing
+// a single pod-wide detector, whose Reset()/counter mutations would
+// otherwise silently corrupt other in-flight investigations.
+func (d *AnomalyDetector) Clone() *AnomalyDetector {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return NewAnomalyDetector(d.config, d.suspiciousPatterns)
+}
+
 func (d *AnomalyDetector) checkSuspiciousArgs(name string, args json.RawMessage) AnomalyResult {
 	if len(d.suspiciousPatterns) == 0 || len(args) == 0 {
 		return AnomalyResult{Allowed: true}

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -104,6 +104,14 @@ type TextResult struct {
 
 func (*TextResult) loopResult() {}
 
+// ReasonToolBudgetExhausted is the ExhaustedResult.Reason value set when the
+// AnomalyDetector's total tool-call budget trips mid-investigation. Exported
+// as a named constant (rather than a bare string literal) so
+// adapters.ExtractContent can match on it precisely to surface
+// tools.ErrCodeToolBudgetExhausted instead of a generic internal error
+// (#1889 gap 1).
+const ReasonToolBudgetExhausted = "tool budget exhausted"
+
 // ExhaustedResult is returned when the loop exhausts maxTurns, tool budget,
 // or the truncation-retry escalation (#1614: the escalated retry is ALSO
 // truncated). Reason distinguishes the cases for observability (#770).
@@ -227,6 +235,12 @@ type Investigator struct {
 	// shared across all concurrent investigations, so this must never be
 	// mutated post-New (DD-FLEET-004 preflight finding).
 	fleetOverlayResolver FleetOverlayResolver
+	// anomalyScope hands out a per-correlationID AnomalyDetector clone so
+	// concurrent investigations sharing this Investigator never corrupt each
+	// other's tool-call budgets (#1892). pipeline.AnomalyDetector remains the
+	// config template; production code must go through anomalyDetectorFor
+	// rather than pipeline.AnomalyDetector directly.
+	anomalyScope *anomalyScope
 }
 
 func (inv *Investigator) auditLog() logr.Logger {
@@ -291,6 +305,10 @@ func New(cfg Config) *Investigator {
 		pinDecorator:         cfg.PinDecorator,
 		phaseResolver:        cfg.PhaseResolver,
 		fleetOverlayResolver: cfg.FleetOverlayResolver,
+		anomalyScope: &anomalyScope{
+			template: pipeline.AnomalyDetector,
+			entries:  make(map[string]*anomalyDetectorEntry),
+		},
 	}
 }
 
@@ -380,14 +398,18 @@ func (inv *Investigator) Investigate(ctx context.Context, signal katypes.SignalC
 	ctx = inv.prescopeFleetOverlay(ctx, signal.ClusterID, signal.RemediationID)
 
 	defer inv.startDiagSummary(ctx)()
-	inv.pipeline.AnomalyDetector.Reset()
+
+	// #1892: correlationID must be resolved before the first Reset() so the
+	// per-investigation AnomalyDetector (not the shared config template) is
+	// the one reset here.
+	correlationID := signal.RemediationID
+	inv.anomalyDetectorFor(correlationID).Reset()
 
 	// #783 + #1470: Pin client per phase. Each phase resolves its own client,
 	// model name, and runtime params. Subsequent hot-reload swaps do not
 	// affect in-flight work.
 	rcaClient, rcaModelName, rcaRuntimeParams := inv.resolveForPhase(katypes.PhaseRCA)
 
-	correlationID := signal.RemediationID
 	enrichmentCache := make(map[string]*enrichment.EnrichmentResult)
 
 	signalKind, signalName, signalNS := ResolveEnrichmentTarget(signal, nil)
@@ -453,7 +475,7 @@ func (inv *Investigator) runWorkflowDiscoveryPhase(ctx context.Context, p workfl
 	promptEnrichment := toPromptEnrichment(enrichData)
 	workflowSignal = inv.enrichWorkflowSignalForDiscovery(workflowSignal, p.Signal, p.RCAResult, enrichData, p.CorrelationID)
 
-	inv.pipeline.AnomalyDetector.Reset()
+	inv.anomalyDetectorFor(p.CorrelationID).Reset()
 
 	wfClient, wfModelName, wfRuntimeParams := inv.resolveForPhase(katypes.PhaseWorkflowDiscovery)
 

--- a/internal/kubernautagent/investigator/investigator_anomaly_scope.go
+++ b/internal/kubernautagent/investigator/investigator_anomaly_scope.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// DefaultAnomalyDetectorTTL bounds how long a per-investigation AnomalyDetector
+// entry may sit idle before StartAnomalyDetectorCleanupLoop reclaims it.
+// Investigations normally complete in minutes; 2h gives ample margin for
+// slow interactive sessions while still bounding worst-case memory growth
+// when a correlationID's investigation ends without a clean exit path
+// (crash, cancellation, client disconnect).
+const DefaultAnomalyDetectorTTL = 2 * time.Hour
+
+// anomalyDetectorEntry tracks a per-investigation AnomalyDetector alongside
+// the last time it was accessed, so the TTL sweep can identify abandoned
+// entries without depending on any investigation exit path firing (#1892).
+type anomalyDetectorEntry struct {
+	detector   *AnomalyDetector
+	lastAccess time.Time
+}
+
+// anomalyScope holds one isolated AnomalyDetector per investigation
+// (keyed by correlation ID), cloned from a shared config template. This
+// replaces the pre-#1892 design where every concurrent investigation on a
+// KA pod shared a single AnomalyDetector, so one investigation's Reset()
+// (fired at RCA->workflow-discovery phase transitions) could silently zero
+// another in-flight investigation's tool-call budgets.
+type anomalyScope struct {
+	mu       sync.Mutex
+	template *AnomalyDetector
+	entries  map[string]*anomalyDetectorEntry
+}
+
+// anomalyDetectorFor returns the AnomalyDetector scoped to correlationID,
+// creating one (cloned from the shared config template) on first access.
+// Safe for concurrent use. An empty correlationID falls back to the shared
+// template detector directly: this should not happen on any production call
+// path (correlationID is always signal.RemediationID or an explicit
+// parameter), but failing open to a single detector is safer than panicking
+// or silently creating an unbounded number of ""-keyed entries.
+func (inv *Investigator) anomalyDetectorFor(correlationID string) *AnomalyDetector {
+	if correlationID == "" {
+		return inv.anomalyScope.template
+	}
+
+	inv.anomalyScope.mu.Lock()
+	defer inv.anomalyScope.mu.Unlock()
+
+	entry, ok := inv.anomalyScope.entries[correlationID]
+	if !ok {
+		entry = &anomalyDetectorEntry{detector: inv.anomalyScope.template.Clone()}
+		inv.anomalyScope.entries[correlationID] = entry
+	}
+	entry.lastAccess = time.Now()
+	return entry.detector
+}
+
+// pruneAnomalyDetectors removes entries whose lastAccess predates
+// time.Now()-maxAge, and returns the number of entries removed.
+func (inv *Investigator) pruneAnomalyDetectors(maxAge time.Duration) int {
+	cutoff := time.Now().Add(-maxAge)
+
+	inv.anomalyScope.mu.Lock()
+	defer inv.anomalyScope.mu.Unlock()
+
+	removed := 0
+	for id, entry := range inv.anomalyScope.entries {
+		if entry.lastAccess.Before(cutoff) {
+			delete(inv.anomalyScope.entries, id)
+			removed++
+		}
+	}
+	return removed
+}
+
+// StartAnomalyDetectorCleanupLoop periodically prunes per-investigation
+// AnomalyDetector entries idle longer than maxAge, until ctx is cancelled.
+// Mirrors session.Store.StartCleanupLoop's background-sweep pattern (#1892).
+func (inv *Investigator) StartAnomalyDetectorCleanupLoop(ctx context.Context, interval, maxAge time.Duration) {
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case <-ticker.C:
+				removed := inv.pruneAnomalyDetectors(maxAge)
+				if removed > 0 {
+					inv.logger.V(1).Info("pruned idle per-investigation anomaly detectors",
+						"removed", removed, "max_age", maxAge)
+				}
+			}
+		}
+	}()
+}

--- a/internal/kubernautagent/investigator/investigator_anomaly_scope_test.go
+++ b/internal/kubernautagent/investigator/investigator_anomaly_scope_test.go
@@ -1,0 +1,126 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+// White-box (package investigator, not investigator_test) because these
+// specs exercise anomalyDetectorFor and pruneAnomalyDetectors directly,
+// which are intentionally unexported: they are Investigator-internal
+// multiplexing/lifecycle concerns, not part of the public API (#1892
+// design decision: keep counting logic (AnomalyDetector) and
+// multiplexing/lifecycle (this file) separately testable).
+
+func newScopeTestInvestigator(cfg AnomalyConfig) *Investigator {
+	return New(Config{
+		Logger: logr.Discard(),
+		Pipeline: Pipeline{
+			AnomalyDetector: NewAnomalyDetector(cfg, nil),
+		},
+	})
+}
+
+var _ = Describe("Kubernaut Agent Investigator anomaly detector scoping (#1892)", func() {
+
+	Describe("UT-KA-1892-003: anomalyDetectorFor memoizes per correlationID", func() {
+		It("returns the same instance for repeated lookups of one correlationID and a distinct instance for another", func() {
+			inv := newScopeTestInvestigator(AnomalyConfig{MaxToolCallsPerTool: 10, MaxTotalToolCalls: 100, MaxRepeatedFailures: 10})
+
+			a1 := inv.anomalyDetectorFor("rr-a")
+			a2 := inv.anomalyDetectorFor("rr-a")
+			Expect(a1).To(BeIdenticalTo(a2),
+				"repeated lookups for the same correlationID must resolve to the same detector instance")
+
+			b1 := inv.anomalyDetectorFor("rr-b")
+			Expect(b1).NotTo(BeIdenticalTo(a1),
+				"a different correlationID must resolve to a distinct detector instance")
+		})
+	})
+
+	Describe("IT-KA-1892-001: concurrent investigations never observe each other's Reset()/counters (#1892)", func() {
+		It("keeps rr-b's per-tool counter exhausted despite a concurrent Reset()/CheckToolCall storm on rr-a", func() {
+			cfg := AnomalyConfig{MaxToolCallsPerTool: 2, MaxTotalToolCalls: 100, MaxRepeatedFailures: 100}
+			inv := newScopeTestInvestigator(cfg)
+
+			detA := inv.anomalyDetectorFor("rr-a")
+			detB := inv.anomalyDetectorFor("rr-b")
+			Expect(detA).NotTo(BeIdenticalTo(detB), "rr-a and rr-b must get distinct detector instances")
+
+			args := json.RawMessage(`{}`)
+			// rr-b consumes its full per-tool budget (2) for kubectl_describe up front.
+			Expect(detB.CheckToolCall("kubectl_describe", args).Allowed).To(BeTrue())
+			Expect(detB.CheckToolCall("kubectl_describe", args).Allowed).To(BeTrue())
+
+			// Concurrently hammer rr-a's detector with Reset() and CheckToolCall,
+			// simulating rr-a's own phase-transition Reset() firing while rr-b is
+			// mid-flight on the same KA pod. Against the pre-fix pod-wide singleton
+			// this would reset/mutate rr-b's shared counters too.
+			var wg sync.WaitGroup
+			wg.Add(2)
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+				for i := 0; i < 50; i++ {
+					inv.anomalyDetectorFor("rr-a").Reset()
+				}
+			}()
+			go func() {
+				defer GinkgoRecover()
+				defer wg.Done()
+				for i := 0; i < 50; i++ {
+					inv.anomalyDetectorFor("rr-a").CheckToolCall("kubectl_describe", args)
+				}
+			}()
+			wg.Wait()
+
+			// rr-b's per-tool budget for kubectl_describe must still read as
+			// exhausted, unaffected by any of rr-a's concurrent Reset() calls.
+			result := detB.CheckToolCall("kubectl_describe", args)
+			Expect(result.Allowed).To(BeFalse(),
+				"rr-b's own per-tool budget must remain exhausted; a shared singleton would have been reset by rr-a's concurrent Reset() calls")
+			Expect(result.Reason).To(ContainSubstring("per-tool"))
+		})
+	})
+
+	Describe("UT-KA-1892-002: pruneAnomalyDetectors removes idle entries and keeps recently-touched ones", func() {
+		It("evicts only entries whose lastAccess predates the cutoff", func() {
+			inv := newScopeTestInvestigator(DefaultAnomalyConfig())
+
+			staleA := inv.anomalyDetectorFor("stale-a")
+			time.Sleep(20 * time.Millisecond)
+			freshC := inv.anomalyDetectorFor("fresh-c")
+
+			removed := inv.pruneAnomalyDetectors(10 * time.Millisecond)
+			Expect(removed).To(Equal(1), "only the idle entry older than the cutoff should be pruned")
+
+			// A pruned correlationID gets a brand-new clone on next access.
+			Expect(inv.anomalyDetectorFor("stale-a")).NotTo(BeIdenticalTo(staleA),
+				"stale-a should have been evicted and re-created fresh on next access")
+			// A recently-touched entry survives the sweep untouched.
+			Expect(inv.anomalyDetectorFor("fresh-c")).To(BeIdenticalTo(freshC),
+				"fresh-c was touched after the cutoff and must not be pruned")
+		})
+	})
+})

--- a/internal/kubernautagent/investigator/investigator_discovery.go
+++ b/internal/kubernautagent/investigator/investigator_discovery.go
@@ -43,7 +43,7 @@ func (inv *Investigator) RunWorkflowDiscoveryFromRCA(ctx context.Context, signal
 	rcaCopy := *rcaResult
 	rcaResult = &rcaCopy
 
-	inv.pipeline.AnomalyDetector.Reset()
+	inv.anomalyDetectorFor(correlationID).Reset()
 
 	inv.autoResolveRCATargetAPIVersion(rcaResult, correlationID)
 

--- a/internal/kubernautagent/investigator/investigator_loop.go
+++ b/internal/kubernautagent/investigator/investigator_loop.go
@@ -111,7 +111,7 @@ func (inv *Investigator) runLoopTurn(ctx context.Context, state *loopTurnState, 
 			return sentinel, toolMessages, true, nil
 		}
 		if budgetExhausted {
-			return &ExhaustedResult{Reason: "tool budget exhausted"}, toolMessages, true, nil
+			return &ExhaustedResult{Reason: ReasonToolBudgetExhausted}, toolMessages, true, nil
 		}
 		return nil, toolMessages, false, nil
 	}
@@ -311,7 +311,7 @@ func (inv *Investigator) processToolCalls(ctx context.Context, messages []llm.Me
 			"tool_index": i,
 		})
 		g.Go(func() error {
-			toolResults[i] = inv.executeTool(ctx, tc.Name, json.RawMessage(tc.Arguments))
+			toolResults[i] = inv.executeTool(ctx, tc.Name, json.RawMessage(tc.Arguments), correlationID)
 			return nil
 		})
 	}
@@ -342,7 +342,7 @@ func (inv *Investigator) processToolCalls(ctx context.Context, messages []llm.Me
 		})
 	}
 
-	budgetExhausted = inv.pipeline.AnomalyDetector.TotalExceeded()
+	budgetExhausted = inv.anomalyDetectorFor(correlationID).TotalExceeded()
 	return messages, nil, budgetExhausted
 }
 

--- a/internal/kubernautagent/investigator/investigator_tools.go
+++ b/internal/kubernautagent/investigator/investigator_tools.go
@@ -270,12 +270,14 @@ func (inv *Investigator) executeResolved(ctx context.Context, name string, args 
 	return result, err
 }
 
-func (inv *Investigator) executeTool(ctx context.Context, name string, args json.RawMessage) string {
+func (inv *Investigator) executeTool(ctx context.Context, name string, args json.RawMessage, correlationID string) string {
 	if inv.registry == nil {
 		return toolErrorJSON("no registry configured for tool " + name)
 	}
 
-	if ar := inv.pipeline.AnomalyDetector.CheckToolCall(name, args); !ar.Allowed {
+	detector := inv.anomalyDetectorFor(correlationID)
+
+	if ar := detector.CheckToolCall(name, args); !ar.Allowed {
 		inv.logger.Info("anomaly detector rejected tool call",
 			"tool", name,
 			"reason", ar.Reason,
@@ -288,7 +290,7 @@ func (inv *Investigator) executeTool(ctx context.Context, name string, args json
 		inv.logger.Error(err, "tool execution failed",
 			"tool", name,
 		)
-		if ar := inv.pipeline.AnomalyDetector.RecordFailure(name, args); !ar.Allowed {
+		if ar := detector.RecordFailure(name, args); !ar.Allowed {
 			errResult := toolErrorJSON(ar.Reason)
 			alignment.SubmitToolStep(ctx, name, errResult)
 			return errResult

--- a/internal/kubernautagent/mcp/adapters/adapters.go
+++ b/internal/kubernautagent/mcp/adapters/adapters.go
@@ -73,6 +73,9 @@ func ExtractContent(result investigator.LoopResult) (string, error) {
 	case *investigator.SubmitNoWorkflowResult:
 		return r.Content, nil
 	case *investigator.ExhaustedResult:
+		if r.Reason == investigator.ReasonToolBudgetExhausted {
+			return "", fmt.Errorf("investigation exhausted: %w", tools.ErrCodeToolBudgetExhausted)
+		}
 		return "", fmt.Errorf("investigation exhausted: %s", r.Reason)
 	case *investigator.CancelledResult:
 		return "", fmt.Errorf("investigation cancelled at turn %d", r.Turn)

--- a/internal/kubernautagent/mcp/tools/errors.go
+++ b/internal/kubernautagent/mcp/tools/errors.go
@@ -111,6 +111,16 @@ var (
 		Code:    "not_driver",
 		Message: "Caller is not the active driver for this session",
 	}
+	// ErrCodeToolBudgetExhausted is returned when the AnomalyDetector's
+	// total tool-call budget trips mid-investigation (#1889 gap 1). Before
+	// this fix, ExtractContent wrapped ExhaustedResult{Reason:
+	// ReasonToolBudgetExhausted} in a plain fmt.Errorf, which ErrorBoundary
+	// then redacted to the generic ErrCodeInternalError — leaving the MCP
+	// client unable to distinguish "hit a real safety limit" from "server bug".
+	ErrCodeToolBudgetExhausted = &MCPError{
+		Code:    "tool_budget_exhausted",
+		Message: "Investigation exceeded the maximum number of tool calls allowed",
+	}
 )
 
 // ErrorBoundary wraps a tool handler error: if the error is already an MCPError

--- a/internal/kubernautagent/mcp/tools/errors_test.go
+++ b/internal/kubernautagent/mcp/tools/errors_test.go
@@ -1,0 +1,70 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools_test
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/adapters"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ErrorBoundary", func() {
+	Describe("known MCPError codes pass through unchanged", func() {
+		It("returns the same *MCPError when the handler error already is one", func() {
+			err := tools.ErrorBoundary(logr.Discard(), "kubernaut_investigate", tools.ErrCodeRateLimited)
+			Expect(err).To(Equal(tools.ErrCodeRateLimited))
+		})
+	})
+
+	Describe("unknown errors are redacted to internal_error (H3/SEC-5)", func() {
+		It("replaces a raw, non-MCPError with the generic internal error", func() {
+			err := tools.ErrorBoundary(logr.Discard(), "kubernaut_investigate", fmt.Errorf("some internal detail: db timeout"))
+			Expect(err).To(Equal(tools.ErrCodeInternalError))
+		})
+	})
+
+	Describe("IT-KA-1889-001: tool budget exhaustion survives the full production wrap chain (#1889 gap 1)", func() {
+		It("reaches ErrorBoundary as tool_budget_exhausted, not internal_error, through the exact wraps production applies", func() {
+			// Step 1: adapters.ExtractContent, exactly as InvestigatorRunnerAdapter.RunInteractiveTurn calls it.
+			_, extractErr := adapters.ExtractContent(&investigator.ExhaustedResult{Reason: investigator.ReasonToolBudgetExhausted})
+			Expect(extractErr).To(HaveOccurred())
+
+			// Step 2: the investigateTakeoverTool.handleMessage wrap
+			// (investigate_takeover.go:131): fmt.Errorf("interactive turn
+			// failed: %w", err).
+			turnErr := fmt.Errorf("interactive turn failed: %w", extractErr)
+
+			// Step 3: the registration.go dispatch wrap that every kubernaut_investigate
+			// tool call passes through.
+			boundaryErr := tools.ErrorBoundary(logr.Discard(), "kubernaut_investigate", turnErr)
+
+			var mcpErr *tools.MCPError
+			Expect(errors.As(boundaryErr, &mcpErr)).To(BeTrue(),
+				"tool budget exhaustion must survive both wrap layers as a typed MCPError, not be redacted to internal_error")
+			Expect(mcpErr.Code).To(Equal("tool_budget_exhausted"))
+			Expect(boundaryErr).NotTo(Equal(tools.ErrCodeInternalError),
+				"this is exactly the #1889 regression: redaction to a generic, undiagnosable error")
+		})
+	})
+})


### PR DESCRIPTION
## Summary

`main`/v1.6 port of #1895 (`release/v1.5`), held in **draft** until the console team validates the `release/v1.5` fix in production. Do not merge until that validation completes.

- **#1889 gap 1**: `AnomalyDetector` budget exhaustion now surfaces to MCP clients as `tool_budget_exhausted`, a typed `MCPError`, instead of being redacted by `ErrorBoundary` to a generic `internal_error`.
- **#1892**: Each concurrent investigation now gets its own cloned `AnomalyDetector` (keyed by correlation ID, TTL-swept), fixing a real bug where one investigation's phase-transition `Reset()` silently zeroed every other in-flight investigation's tool-call budget on the same KA pod (previously a single pod-wide singleton).
- **Helm**: `kubernautAgent.ai.safety.anomaly.maxTotalToolCalls` is now a configurable Helm value (was hardcoded, no way to raise the ceiling without a code change).

`main`'s `internal/kubernautagent/investigator` package and Helm chart have diverged structurally from `release/v1.5` (refactored `investigator_loop.go`, `llmProfileRef`/`global.llmProfiles` instead of `kubernautAgent.llm.*`, etc.) — this is a fresh, independently-verified implementation of the same design against `main`'s current layout, not a cherry-pick. See `docs/tests/1889/TEST_PLAN.md` for the structural diff table confirmed during the port.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet` clean on changed packages
- [x] `golangci-lint run` — 0 issues on changed packages
- [x] `make test-unit-kubernautagent` — 109 Passed, 0 Failed (34 suites)
- [x] `make test-helm` — 436 Passed, 0 Failed (45 suites, including 2 new cases for the Helm value)
- [ ] **Blocking for merge**: console team confirms the `release/v1.5` fix (#1895) works in practice

Refs: #1889, #1892

Made with [Cursor](https://cursor.com)