### PR TITLE
fix(shared/k8s): self-heal RESTMapper cache on GVK lookup failure (#1888, #1890) [main port]

### DIFF
--- a/docs/architecture/decisions/DD-K8S-001-restmapper-cache-invalidation-on-lookup-failure.md
+++ b/docs/architecture/decisions/DD-K8S-001-restmapper-cache-invalidation-on-lookup-failure.md
@@ -1,0 +1,251 @@
+# DD-K8S-001: RESTMapper Cache Invalidation on Lookup Failure
+
+## Status
+**✅ Approved** (2026-08-03)
+**Last Reviewed**: 2026-08-03
+**Confidence**: 96%
+
+---
+
+## Context & Problem
+
+**Problem** (Issue #1888, `main`/v1.6 tracking clone [#1890](https://github.com/jordigilh/kubernaut/issues/1890)): AF's `kubectl_get`/`kubectl_list` MCP tools intermittently fail to
+resolve valid CRD kinds (e.g., Red Hat ACM's `search.open-cluster-management.io/Search`) with
+"cannot resolve GVK for kind", even though the CRD is genuinely installed and RBAC-accessible.
+The failure is permanent for the life of the pod — a restart fixes it.
+
+**Root cause** (confirmed against live-cluster testing and the exact vendored
+`k8s.io/client-go@v0.35.7` source, not just generic recollection):
+
+1. `cmd/apifrontend/main.go` constructs `restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(disc))`.
+2. `pkg/shared/k8s/gvk.go`'s `ResolveGVKForKind` fallback calls `mapper.KindsFor(...)` on it for
+   any Kind not in the static table (CRDs, third-party resources).
+3. `DeferredDiscoveryRESTMapper.KindsFor` (client-go source):
+   ```go
+   gvks, err = del.KindsFor(resource)
+   if len(gvks) == 0 && !d.cl.Fresh() {
+       d.Reset()
+       gvks, err = d.KindsFor(resource)
+   }
+   ```
+   The self-heal retry only fires when `!d.cl.Fresh()`.
+4. `memCacheClient.Fresh()` returns `d.cacheValid`, which is set `true` once by `refreshLocked()`
+   on the first successful discovery populate and is **never** invalidated on any timer — only an
+   explicit `Invalidate()`/`Reset()` call flips it back to `false`. There is no periodic TTL
+   anywhere in this client.
+5. `restmapper.GetAPIGroupResources` additionally discards the error from
+   `ServerGroupsAndResources()` whenever `gs`/`rs` come back non-nil — so a single group's
+   transient `*discovery.ErrGroupDiscoveryFailed` during that first populate is silently dropped,
+   with no log line anywhere in the call chain.
+
+**Net effect**: if a CRD's API group is missing from the pod's very first discovery round (a
+transient API-server hiccup, an aggregated-API-server slow to register, or the CRD being
+installed a few seconds after AF's mapper does its first lazy fetch), that Kind is **permanently**
+unresolvable until the pod restarts — the built-in self-heal only exists for the window before the
+first successful populate, never after.
+
+**Blast radius**: confirmed to affect only mappers built via `client-go`'s
+`restmapper.DeferredDiscoveryRESTMapper` directly. RemediationOrchestrator and
+EffectivenessMonitor call `ResolveGVKWithAPIVersion`/`ResolveGVKForKind` with
+`k8sManager.GetRESTMapper()` (controller-runtime's `apiutil.NewDynamicRESTMapper`), a different
+implementation that reactively invalidates per-request on `NoKindMatchError` — not subject to
+this one-shot-`Fresh()` bug. The fix is therefore scoped to `ResolveGVKForKind`'s fallback, the
+only path AF's `kubectl_get`/`kubectl_list` tools use.
+
+**Existing precedent**: `pkg/kubernautagent/tools/k8s/resolver.go` (KA's own dynamic resolver,
+added independently, unrelated code path) already has this exact fix pattern:
+
+```go
+type resettableMapper interface {
+    Reset()
+}
+...
+gvrs, err := r.mapper.ResourcesFor(schema.GroupVersionResource{Resource: resource})
+if err != nil {
+    if rm, ok := r.mapper.(resettableMapper); ok {
+        rm.Reset()
+        gvrs, err = r.mapper.ResourcesFor(schema.GroupVersionResource{Resource: resource})
+    }
+    ...
+}
+```
+
+`gvk.go`'s `ResolveGVKForKind` never got the same treatment.
+
+---
+
+## Alternatives Considered
+
+### Alternative 1: Reactive `Reset()`-on-failure retry ⭐ **SELECTED**
+
+**Approach**: In `ResolveGVKForKind`'s fallback, on `KindsFor` failure/empty result, type-assert
+the mapper to `meta.ResettableRESTMapper` (apimachinery's own interface for exactly this purpose)
+and retry once after `Reset()`.
+
+```go
+gvks, err := mapper.KindsFor(schema.GroupVersionResource{Resource: pluralGVR.Resource})
+if (err != nil || len(gvks) == 0) {
+    if rm, ok := mapper.(meta.ResettableRESTMapper); ok {
+        rm.Reset()
+        gvks, err = mapper.KindsFor(schema.GroupVersionResource{Resource: pluralGVR.Resource})
+    }
+}
+```
+
+**Pros**:
+- ✅ Mirrors an already-shipped, already-accepted pattern in this codebase (`resolver.go`) —
+  zero new design risk
+- ✅ Self-heals on the very next lookup, not after a timer window
+- ✅ Smallest possible diff (~6 lines), no new goroutines, no new config/interval to tune
+- ✅ `apimachinery`'s own `meta.ResettableRESTMapper` doc comment explicitly recommends this
+  check for delegating mappers
+
+**Cons**:
+- ⚠️ A genuinely-invalid/typo'd Kind still costs one extra discovery round-trip per failed
+  lookup (no caching of "this Kind is definitely bad")
+  - **Mitigation**: Same accepted trade-off as the existing `resolver.go` precedent; bounded to
+    exactly one retry, not a loop
+
+**Confidence**: 96% (approved — precedented, minimal, directly addresses the reported symptom)
+
+---
+
+### Alternative 2: Periodic TTL-based `Reset()` background goroutine
+
+**Approach**: Start a background goroutine at mapper-construction time (`cmd/apifrontend/main.go`)
+that calls `mapper.Reset()` on a fixed interval (e.g., every 10 minutes), mirroring the
+`StartAnomalyDetectorCleanupLoop`/`store.StartCleanupLoop` idiom used elsewhere in this codebase
+(#1892).
+
+**Pros**:
+- ✅ Proactively self-heals without waiting for a failed lookup
+- ✅ Consistent with an existing background-sweep idiom in this codebase
+
+**Cons**:
+- ❌ New moving part: an interval to choose and justify (too short = wasted full-discovery
+  refreshes on every AF pod; too long = long recovery window)
+- ❌ Doesn't cover the case of a CRD installed after the pod's first successful discovery *and*
+  before the next lookup attempt if no lookup ever fails to trigger a refresh in between —
+  correctness still ultimately depends on a failed lookup happening at some point
+- ❌ Adds recurring full-discovery-refresh cost (`ServerGroupsAndResources()` across all API
+  groups) independent of actual usage
+
+**Confidence**: 70% (rejected as primary fix — solves a superset of the problem at higher
+ongoing cost, without being strictly necessary given Alternative 1 already self-heals on demand)
+
+---
+
+### Alternative 3: Combined (Alternative 1 + Alternative 2 as defense-in-depth)
+
+**Approach**: Ship the reactive retry now, and separately consider a periodic backstop later if
+telemetry shows kinds still going unresolved for extended periods in production.
+
+**Pros**:
+- ✅ Highest robustness ceiling
+
+**Cons**:
+- ❌ Adds Alternative 2's complexity/cost for a benefit not yet demonstrated to be needed
+- ❌ Scope creep relative to the reported, reproduced bug
+
+**Confidence**: 65% (deferred — revisit only if Alternative 1 proves insufficient in production)
+
+---
+
+## Decision
+
+**APPROVED: Alternative 1** — Reactive `Reset()`-on-failure retry in `ResolveGVKForKind`'s
+fallback, using apimachinery's `meta.ResettableRESTMapper` interface.
+
+**Rationale**:
+1. Directly fixes the reported, reproduced symptom (permanent post-first-miss unresolvability)
+   with the smallest possible change.
+2. Mirrors a pattern already shipped and accepted in this exact codebase
+   (`pkg/kubernautagent/tools/k8s/resolver.go`), eliminating design novelty/risk.
+3. No new background goroutine, interval, or Helm value to introduce, document, and maintain.
+4. Alternative 2/3's extra robustness is not justified without evidence that reactive-only
+   self-heal is insufficient in production; can be revisited later (see Review & Evolution).
+
+---
+
+## Implementation
+
+### Package Location
+
+```
+pkg/shared/k8s/gvk.go          # ResolveGVKForKind fallback (modified)
+pkg/shared/k8s/gvk_test.go     # UT-K8S-1888-* (new)
+```
+
+### Core Change
+
+```go
+if mapper != nil {
+    pluralGVR, _ := meta.UnsafeGuessKindToResource(schema.GroupVersionKind{Kind: kind})
+    resource := schema.GroupVersionResource{Resource: pluralGVR.Resource}
+    gvks, err := mapper.KindsFor(resource)
+    if err != nil || len(gvks) == 0 {
+        // #1888: DeferredDiscoveryRESTMapper's own self-heal only fires once, before its
+        // first successful discovery populate (see DD-K8S-001). A CRD group missing from
+        // that first round stays unresolvable forever without this explicit retry.
+        if rm, ok := mapper.(meta.ResettableRESTMapper); ok {
+            rm.Reset()
+            gvks, err = mapper.KindsFor(resource)
+        }
+    }
+    if err == nil && len(gvks) > 0 {
+        return gvks[0], nil
+    }
+}
+```
+
+---
+
+## Consequences
+
+### Positive
+- ✅ CRD kinds that miss AF's first discovery round now resolve on the very next lookup —
+  no pod restart required
+- ✅ Zero new infrastructure, config, or Helm values
+- ✅ Consistent pattern now exists in both `pkg/shared/k8s/gvk.go` and
+  `pkg/kubernautagent/tools/k8s/resolver.go`
+
+### Negative
+- ⚠️ One extra discovery round-trip per genuinely-failed lookup (typo'd Kind, truly
+  unregistered resource)
+  - **Mitigation**: Bounded to exactly one retry; accepted trade-off already present in
+    `resolver.go`
+
+### Neutral
+- 🔄 `ResolveGVKWithAPIVersion`'s explicit-`apiVersion` path is intentionally left unchanged —
+  its only callers use a different, unaffected RESTMapper implementation (see Context)
+
+---
+
+## Related Documents
+
+| Document | Relationship |
+|----------|--------------|
+| `docs/tests/1888/TEST_PLAN.md` | Test plan for this fix |
+| `pkg/kubernautagent/tools/k8s/resolver.go` | Existing precedent for the same retry pattern |
+| Issue #310 / #1275 / #1040 | Prior `gvk.go` fixes (ambiguity, static-table CRDs, apiVersion disambiguation) |
+| [PR #1896](https://github.com/jordigilh/kubernaut/pull/1896) | `release/v1.5` implementation (design authority for this port) |
+
+---
+
+## Review & Evolution
+
+**When to Revisit**:
+- If production telemetry shows kinds still failing to resolve across multiple consecutive
+  lookups (would indicate Alternative 2/3's proactive backstop is needed)
+- If `client-go` changes `DeferredDiscoveryRESTMapper`'s `Fresh()` semantics in a future version
+
+---
+
+**Last Updated**: August 3, 2026
+
+## Change Log
+
+| Date | Change | Author |
+|------|--------|--------|
+| 2026-08-03 | Initial approval (`release/v1.5`, PR #1896) | AI Assistant |
+| 2026-08-03 | Ported to `main`/v1.6 (issue #1890, this PR) — `pkg/shared/k8s/gvk.go` and `gvk_test.go` were byte-identical to `release/v1.5` at the time of the port, so no design changes were needed | AI Assistant |

--- a/docs/tests/1888/TEST_PLAN.md
+++ b/docs/tests/1888/TEST_PLAN.md
@@ -1,0 +1,92 @@
+# Test Plan: RESTMapper cache self-heals on lookup failure (#1888) — `main`/v1.6 port
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-1888-main-v1.0
+**Version**: 1.0
+**Created**: 2026-08-03
+**Author**: AI Assistant
+**Status**: Implemented
+**Branch**: `fix/1888-1890-restmapper-cache-invalidation-main` (targets `main`)
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This is the `main`/v1.6 port of the fix designed, TDD'd, and CI-validated on `release/v1.5` in
+[PR #1896](https://github.com/jordigilh/kubernaut/pull/1896) (branch
+`fix/1888-restmapper-cache-invalidation`), tracked on `main` by sibling issue
+[#1890](https://github.com/jordigilh/kubernaut/issues/1890). Full root-cause analysis and
+alternatives are documented in
+[DD-K8S-001](../../architecture/decisions/DD-K8S-001-restmapper-cache-invalidation-on-lookup-failure.md),
+ported alongside this test plan — not repeated here.
+
+### 1.2 Codebase-structure comparison (confirmed by direct inspection)
+
+Unlike the #1889/#1892 port (PR #1897), which needed to account for meaningful structural drift
+in `internal/kubernautagent/investigator`, `pkg/shared/k8s/gvk.go` and `gvk_test.go` were found to
+be **byte-identical** between `origin/release/v1.5` (pre-fix) and `origin/main` at the time of this
+port (verified via direct diff before editing, CHECKPOINT A). The `release/v1.5` fix and its full
+test suite were therefore applied to `main` as-is, with no adaptation required beyond copying the
+change.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement | Result |
+|--------|--------|-------------|--------|
+| Unit test pass rate | 100% | `make test-unit-shared-packages` | 37/37 suites passed |
+| `ResolveGVKForKind` line coverage | 100% (new retry branch fully exercised) | `go tool cover -func` on the make target's coverage output | 100.0% |
+| Backward compatibility | 0 regressions | Full `make test-unit-shared-packages` suite | 0 failed |
+| Build/lint | Clean | `go build ./...`, `go vet`, `golangci-lint run` on `pkg/shared/k8s/...` | Clean, 0 issues |
+
+---
+
+## 2. References
+
+- [PR #1896](https://github.com/jordigilh/kubernaut/pull/1896) — original `release/v1.5` implementation (design authority)
+- [DD-K8S-001](../../architecture/decisions/DD-K8S-001-restmapper-cache-invalidation-on-lookup-failure.md) — root cause, alternatives, decision
+- Issue #1888, Issue #1890 (`main`/v1.6 tracking clone)
+
+---
+
+## 3. Test Items
+
+| File | Change |
+|------|--------|
+| `pkg/shared/k8s/gvk.go` | `ResolveGVKForKind` fallback retries once via `Reset()` on `KindsFor` failure/empty result, when the mapper implements `meta.ResettableRESTMapper` |
+| `pkg/shared/k8s/gvk_test.go` | **Extended**. Added `resettableMockMapper`, `alwaysFailingResettableMapper`, and 4 new test cases |
+
+---
+
+## 4. BR Coverage Matrix
+
+| Reference | Description | Priority | Tier | Test ID | Status |
+|-----------|--------------|----------|------|---------|--------|
+| #1888 | Self-heal REST-mapper cache on lookup failure | P1 | Unit | UT-K8S-1888-001 | Pass |
+| #1888 | Retry is bounded to exactly one extra attempt | P2 | Unit | UT-K8S-1888-002 | Pass |
+| #1888 | Error still propagates when retry also fails | P2 | Unit | UT-K8S-1888-003 | Pass |
+| #1888 | Non-resettable mappers are unaffected (no panic/no retry attempted) | P2 | Unit | UT-K8S-1888-004 | Pass |
+
+---
+
+## 5. Execution Evidence
+
+```bash
+go build ./pkg/shared/k8s/...                          # clean
+go vet ./pkg/shared/k8s/...                             # clean
+golangci-lint run --timeout=5m ./pkg/shared/k8s/...     # 0 issues
+make test-unit-shared-packages                          # 37 suites passed, 0 failed
+go tool cover -func=coverage_unit_shared-packages.out | grep gvk.go
+#   pkg/shared/k8s/gvk.go:69   ResolveGVKForKind          100.0%
+#   pkg/shared/k8s/gvk.go:104  ResolveGVKWithAPIVersion   100.0%
+```
+
+---
+
+## 6. Changelog
+
+| Version | Date | Changes |
+|---------|------|---------|
+| 1.0 | 2026-08-03 | Initial port of PR #1896 to `main`. `gvk.go`/`gvk_test.go` were byte-identical to `release/v1.5`'s pre-fix state, so the fix and tests were applied unchanged. All tests pass; build/vet/lint clean. |

--- a/pkg/shared/k8s/gvk.go
+++ b/pkg/shared/k8s/gvk.go
@@ -73,7 +73,21 @@ func ResolveGVKForKind(mapper meta.RESTMapper, kind string) (schema.GroupVersion
 
 	if mapper != nil {
 		pluralGVR, _ := meta.UnsafeGuessKindToResource(schema.GroupVersionKind{Kind: kind})
-		gvks, err := mapper.KindsFor(schema.GroupVersionResource{Resource: pluralGVR.Resource})
+		resource := schema.GroupVersionResource{Resource: pluralGVR.Resource}
+		gvks, err := mapper.KindsFor(resource)
+		if err != nil || len(gvks) == 0 {
+			// #1888: restmapper.DeferredDiscoveryRESTMapper's own self-heal only fires
+			// once, before its first successful discovery populate (its Fresh() gate
+			// becomes permanently true afterward and is never invalidated on a TTL). A
+			// CRD group missing from that first round would otherwise stay unresolvable
+			// for the life of the pod. Retry once via Reset() when the mapper supports it
+			// (see DD-K8S-001), mirroring the existing pattern in
+			// pkg/kubernautagent/tools/k8s/resolver.go.
+			if rm, ok := mapper.(meta.ResettableRESTMapper); ok {
+				rm.Reset()
+				gvks, err = mapper.KindsFor(resource)
+			}
+		}
 		if err == nil && len(gvks) > 0 {
 			return gvks[0], nil
 		}

--- a/pkg/shared/k8s/gvk_test.go
+++ b/pkg/shared/k8s/gvk_test.go
@@ -64,6 +64,42 @@ func (m *mockRESTMapper) ResourceSingularizer(resource string) (string, error) {
 	panic("not implemented")
 }
 
+// resettableMockMapper simulates a restmapper.DeferredDiscoveryRESTMapper whose first
+// KindsFor call misses a CRD group (as if it were absent from the pod's first discovery
+// round — #1888) but resolves correctly once Reset() is called and the lookup retried.
+type resettableMockMapper struct {
+	*mockRESTMapper
+	kindsForCalls    int
+	resetCalls       int
+	postResetResults map[string][]schema.GroupVersionKind
+}
+
+func (m *resettableMockMapper) KindsFor(resource schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	m.kindsForCalls++
+	if m.resetCalls > 0 {
+		if gvks, ok := m.postResetResults[resource.Resource]; ok {
+			return gvks, nil
+		}
+		return nil, &meta.NoResourceMatchError{PartialResource: resource}
+	}
+	return m.mockRESTMapper.KindsFor(resource)
+}
+
+func (m *resettableMockMapper) Reset() {
+	m.resetCalls++
+}
+
+// alwaysFailingResettableMapper simulates a mapper that still cannot resolve a kind even
+// after Reset() — e.g., a genuinely invalid/typo'd Kind, or discovery still down.
+type alwaysFailingResettableMapper struct {
+	*mockRESTMapper
+	resetCalls int
+}
+
+func (m *alwaysFailingResettableMapper) Reset() {
+	m.resetCalls++
+}
+
 var _ = Describe("ResolveGVKForKind (#310)", func() {
 
 	// Mock REST mapper that returns metrics.k8s.io/v1beta1/Node first —
@@ -143,6 +179,61 @@ var _ = Describe("ResolveGVKForKind (#310)", func() {
 
 		It("should return error when kind is unknown and mapper is nil", func() {
 			_, err := k8sutil.ResolveGVKForKind(nil, "NonExistentKind")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("NonExistentKind"))
+		})
+	})
+
+	Context("REST mapper self-heal on lookup failure (#1888)", func() {
+		It("UT-K8S-1888-001: resolves a kind that missed the first discovery round once Reset() retries", func() {
+			mapper := &resettableMockMapper{
+				mockRESTMapper: &mockRESTMapper{},
+				// meta.UnsafeGuessKindToResource("Search") guesses the plural "searchs"
+				// (the naive heuristic doesn't know the real CRD plural is "searches" —
+				// irrelevant here since this mock controls resolution directly).
+				postResetResults: map[string][]schema.GroupVersionKind{
+					"searchs": {{Group: "search.open-cluster-management.io", Version: "v1alpha1", Kind: "Search"}},
+				},
+			}
+
+			gvk, err := k8sutil.ResolveGVKForKind(mapper, "Search")
+
+			Expect(err).NotTo(HaveOccurred(),
+				"a kind missing from the first discovery round must self-heal on retry, not stay permanently unresolvable")
+			Expect(gvk).To(Equal(schema.GroupVersionKind{
+				Group: "search.open-cluster-management.io", Version: "v1alpha1", Kind: "Search",
+			}))
+		})
+
+		It("UT-K8S-1888-002: retries exactly once — Reset() and KindsFor are not called in an unbounded loop", func() {
+			mapper := &resettableMockMapper{
+				mockRESTMapper: &mockRESTMapper{},
+				postResetResults: map[string][]schema.GroupVersionKind{
+					"searchs": {{Group: "search.open-cluster-management.io", Version: "v1alpha1", Kind: "Search"}},
+				},
+			}
+
+			_, err := k8sutil.ResolveGVKForKind(mapper, "Search")
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(mapper.resetCalls).To(Equal(1), "Reset() must be called exactly once on failure, not looped")
+			Expect(mapper.kindsForCalls).To(Equal(2), "KindsFor must be called exactly twice: once before Reset(), once after")
+		})
+
+		It("UT-K8S-1888-003: propagates the original error when the kind is still unresolvable after Reset()", func() {
+			mapper := &alwaysFailingResettableMapper{mockRESTMapper: &mockRESTMapper{}}
+
+			_, err := k8sutil.ResolveGVKForKind(mapper, "TrulyUnknownKind")
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("TrulyUnknownKind"))
+			Expect(mapper.resetCalls).To(Equal(1), "Reset() should still be attempted once even though it doesn't help")
+		})
+
+		It("UT-K8S-1888-004: a mapper without Reset() behaves exactly as before (no retry, no panic)", func() {
+			// metricsMapper (plain mockRESTMapper) does not implement meta.ResettableRESTMapper.
+			_, err := k8sutil.ResolveGVKForKind(metricsMapper, "NonExistentKind")
+
 			Expect(err).To(HaveOccurred())
 			Expect(err.Error()).To(ContainSubstring("NonExistentKind"))
 		})


### PR DESCRIPTION
## Summary

`main`/v1.6 port of [PR #1896](https://github.com/jordigilh/kubernaut/pull/1896), which fixes #1888 on `release/v1.5`. Tracked on `main` by sibling issue #1890.

`ResolveGVKForKind`'s REST-mapper fallback now retries once via `Reset()` when the mapper implements `meta.ResettableRESTMapper`. Without this, a CRD kind missing from AF's very first discovery round (e.g. Red Hat ACM's `search.open-cluster-management.io/Search`) stays permanently unresolvable for the life of the pod — `DeferredDiscoveryRESTMapper`'s own `Fresh()` self-heal gate only fires once, before the first successful discovery populate, and is never invalidated on a timer afterward.

Root cause, alternatives considered, and rationale: [DD-K8S-001](docs/architecture/decisions/DD-K8S-001-restmapper-cache-invalidation-on-lookup-failure.md).

**Port notes**: `pkg/shared/k8s/gvk.go` and `gvk_test.go` were confirmed byte-identical between `release/v1.5` (pre-fix) and `main` before editing, so the v1.5 fix and its full `UT-K8S-1888-*` test suite were applied to `main` unchanged. See `docs/tests/1888/TEST_PLAN.md` for the port-specific test plan.

- `pkg/shared/k8s/gvk.go`: bounded one-retry `Reset()` self-heal in the `ResolveGVKForKind` fallback
- `pkg/shared/k8s/gvk_test.go`: 4 new unit tests (self-heal success, retry-exactly-once, error-still-propagates-after-retry, non-resettable-mapper-unaffected)
- `docs/architecture/decisions/DD-K8S-001-*.md`, `docs/tests/1888/TEST_PLAN.md`: design decision + test plan (ported)

## Status

**Held as draft** pending the same validation gate as #1897: convert to ready-for-review once the `release/v1.5` fix (#1896) is confirmed working (CI is green; awaiting merge approval).

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./pkg/shared/k8s/...` — clean
- [x] `golangci-lint run ./pkg/shared/k8s/...` — 0 issues
- [x] `make test-unit-shared-packages` — 37/37 suites passed
- [x] `ResolveGVKForKind` line coverage 100% (new retry branch fully exercised, confirmed via `go tool cover -func`)

Made with [Cursor](https://cursor.com)