### PR TITLE
docs(ids): rename BR-AA-HAPI-064 and AA-HAPI-001 to KA equivalents (code, generated clients, CRD schemas, docs)

### DIFF
--- a/api/aianalysis/v1alpha1/aianalysis_types.go
+++ b/api/aianalysis/v1alpha1/aianalysis_types.go
@@ -495,7 +495,7 @@ type AIAnalysisStatus struct {
 	ConsecutiveFailures int32 `json:"consecutiveFailures,omitempty"`
 
 	// ========================================
-	// INVESTIGATION SESSION (BR-AA-HAPI-064)
+	// INVESTIGATION SESSION (BR-AA-KA-064)
 	// Tracks the async submit/poll session with Kubernaut Agent
 	// ========================================
 	// KASession tracks the async KA session for submit/poll pattern
@@ -545,8 +545,8 @@ type PostRCAContext struct {
 }
 
 // KASession tracks the async Kubernaut Agent session lifecycle.
-// BR-AA-HAPI-064.4: AA controller session tracking
-// BR-AA-HAPI-064.5: Session regeneration on 404 (KA restart)
+// BR-AA-KA-064.4: AA controller session tracking
+// BR-AA-KA-064.5: Session regeneration on 404 (KA restart)
 // Renamed from InvestigationSession to avoid CRD name collision with
 // the root InvestigationSession type in api/investigationsession/v1alpha1/.
 type KASession struct {
@@ -566,7 +566,7 @@ type KASession struct {
 	// +optional
 	CreatedAt *metav1.Time `json:"createdAt,omitempty"`
 	// PollCount tracks the number of poll attempts for observability
-	// BR-AA-HAPI-064.8: Constant 15s poll interval (configurable 1s–5m)
+	// BR-AA-KA-064.8: Constant 15s poll interval (configurable 1s–5m)
 	// +kubebuilder:validation:Minimum=0
 	// +optional
 	PollCount int32 `json:"pollCount,omitempty"`

--- a/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
@@ -731,7 +731,7 @@ spec:
               humanReviewReason:
                 description: |-
                   Reason why human review needed (when NeedsHumanReview=true)
-                  BR-HAPI-197: Maps to KA's human_review_reason enum values
+                  BR-KA-197: Maps to KA's human_review_reason enum values
                   BR-AI-601: alignment_check_failed added for shadow agent alignment verdicts
                 enum:
                 - workflow_not_found
@@ -857,11 +857,11 @@ spec:
               needsHumanReview:
                 description: |-
                   ========================================
-                  HUMAN REVIEW SIGNALING (BR-HAPI-197)
+                  HUMAN REVIEW SIGNALING (BR-KA-197)
                   Set by Kubernaut Agent when AI cannot produce reliable result
                   ========================================
                   True if human review required (KA decision: RCA incomplete/unreliable)
-                  BR-HAPI-197: Triggers NotificationRequest creation in RO
+                  BR-KA-197: Triggers NotificationRequest creation in RO
                   BR-496 v2: Set when root_owner missing (rca_incomplete) or validation/confidence issues.
                 type: boolean
               observedGeneration:

--- a/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
@@ -794,7 +794,7 @@ spec:
               investigationSession:
                 description: |-
                   ========================================
-                  INVESTIGATION SESSION (BR-AA-HAPI-064)
+                  INVESTIGATION SESSION (BR-AA-KA-064)
                   Tracks the async submit/poll session with Kubernaut Agent
                   ========================================
                   KASession tracks the async KA session for submit/poll pattern
@@ -834,7 +834,7 @@ spec:
                   pollCount:
                     description: |-
                       PollCount tracks the number of poll attempts for observability
-                      BR-AA-HAPI-064.8: Constant 15s poll interval (configurable 1s–5m)
+                      BR-AA-KA-064.8: Constant 15s poll interval (configurable 1s–5m)
                     format: int32
                     minimum: 0
                     type: integer

--- a/charts/kubernaut/crds/kubernaut.ai_notificationrequests.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_notificationrequests.yaml
@@ -187,7 +187,7 @@ spec:
                         type: boolean
                       humanReviewReason:
                         description: HumanReviewReason from Kubernaut Agent when needs_human_review=true
-                          (BR-HAPI-197).
+                          (BR-KA-197).
                         type: string
                       reason:
                         description: Reason is the high-level failure reason (e.g.,

--- a/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
@@ -731,7 +731,7 @@ spec:
               humanReviewReason:
                 description: |-
                   Reason why human review needed (when NeedsHumanReview=true)
-                  BR-HAPI-197: Maps to KA's human_review_reason enum values
+                  BR-KA-197: Maps to KA's human_review_reason enum values
                   BR-AI-601: alignment_check_failed added for shadow agent alignment verdicts
                 enum:
                 - workflow_not_found
@@ -857,11 +857,11 @@ spec:
               needsHumanReview:
                 description: |-
                   ========================================
-                  HUMAN REVIEW SIGNALING (BR-HAPI-197)
+                  HUMAN REVIEW SIGNALING (BR-KA-197)
                   Set by Kubernaut Agent when AI cannot produce reliable result
                   ========================================
                   True if human review required (KA decision: RCA incomplete/unreliable)
-                  BR-HAPI-197: Triggers NotificationRequest creation in RO
+                  BR-KA-197: Triggers NotificationRequest creation in RO
                   BR-496 v2: Set when root_owner missing (rca_incomplete) or validation/confidence issues.
                 type: boolean
               observedGeneration:

--- a/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
@@ -794,7 +794,7 @@ spec:
               investigationSession:
                 description: |-
                   ========================================
-                  INVESTIGATION SESSION (BR-AA-HAPI-064)
+                  INVESTIGATION SESSION (BR-AA-KA-064)
                   Tracks the async submit/poll session with Kubernaut Agent
                   ========================================
                   KASession tracks the async KA session for submit/poll pattern
@@ -834,7 +834,7 @@ spec:
                   pollCount:
                     description: |-
                       PollCount tracks the number of poll attempts for observability
-                      BR-AA-HAPI-064.8: Constant 15s poll interval (configurable 1s–5m)
+                      BR-AA-KA-064.8: Constant 15s poll interval (configurable 1s–5m)
                     format: int32
                     minimum: 0
                     type: integer

--- a/charts/kubernaut/files/crds/kubernaut.ai_notificationrequests.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_notificationrequests.yaml
@@ -187,7 +187,7 @@ spec:
                         type: boolean
                       humanReviewReason:
                         description: HumanReviewReason from Kubernaut Agent when needs_human_review=true
-                          (BR-HAPI-197).
+                          (BR-KA-197).
                         type: string
                       reason:
                         description: Reason is the high-level failure reason (e.g.,

--- a/cmd/aianalysis/main.go
+++ b/cmd/aianalysis/main.go
@@ -203,7 +203,7 @@ type aiAnalysisClients struct {
 // main()'s original fail-fast behavior. Rego hot-reloader and audit store
 // cleanup remain the caller's responsibility during graceful shutdown.
 func wireAIAnalysisClients(ctx context.Context, cfg *config.Config) *aiAnalysisClients {
-	// BR-AA-HAPI-064: HTTP client timeout for session submit/poll/result calls.
+	// BR-AA-KA-064: HTTP client timeout for session submit/poll/result calls.
 	setupLog.Info("Creating Kubernaut Agent client",
 		"url", cfg.Agent.URL,
 		"timeout", cfg.Agent.Timeout,
@@ -294,8 +294,8 @@ func setupAIAnalysisReconciler(mgr ctrl.Manager, cfg *config.Config, controllerN
 	isPhaseUpdater := handlers.NewK8sISPhaseUpdater(mgr.GetClient(), controllerNS)
 	investigatingHandler := handlers.NewInvestigatingHandler(clients.agentClient, controllerLog, aianalysisMetrics, clients.auditClient,
 		handlers.WithRecorder(eventRecorder),                            // DD-EVENT-001: Session lifecycle events
-		handlers.WithSessionMode(),                                      // BR-AA-HAPI-064: Async submit/poll/result flow
-		handlers.WithSessionPollInterval(cfg.Agent.SessionPollInterval), // BR-AA-HAPI-064.8: From config
+		handlers.WithSessionMode(),                                      // BR-AA-KA-064: Async submit/poll/result flow
+		handlers.WithSessionPollInterval(cfg.Agent.SessionPollInterval), // BR-AA-KA-064.8: From config
 		handlers.WithInvestigationSessionChecker(isChecker),             // BR-INTERACTIVE-010: IS CRD awareness
 		handlers.WithISPhaseUpdater(isPhaseUpdater))                     // BR-INTERACTIVE-010: Set IS Active after submit
 	analyzingHandler := handlers.NewAnalyzingHandler(clients.regoEvaluator, controllerLog, aianalysisMetrics, clients.auditClient).

--- a/cmd/aianalysis/main.go
+++ b/cmd/aianalysis/main.go
@@ -277,7 +277,7 @@ func wireAIAnalysisClients(ctx context.Context, cfg *config.Config) *aiAnalysisC
 
 // setupAIAnalysisReconciler creates the metrics collector (DD-METRICS-001),
 // the Investigating/Analyzing phase handlers (BR-AI-007, BR-AI-012), the
-// atomic status manager (DD-PERF-001, AA-HAPI-001), and wires the
+// atomic status manager (DD-PERF-001, AA-KA-001), and wires the
 // AIAnalysisReconciler into mgr. Also registers the healthz/readyz checks,
 // including the cache-sync-aware readyz check that prevents premature
 // reconciliation before controller watches are established. Exits the
@@ -302,9 +302,9 @@ func setupAIAnalysisReconciler(mgr ctrl.Manager, cfg *config.Config, controllerN
 		WithConfidenceThreshold(cfg.Rego.ConfidenceThreshold) // #225: operator-configurable threshold
 
 	// DD-PERF-001: Atomic status updates reduce K8s API calls by 50-75%.
-	// AA-HAPI-001: Pass APIReader to bypass cache for fresh refetches.
+	// AA-KA-001: Pass APIReader to bypass cache for fresh refetches.
 	statusManager := aistatus.NewManager(mgr.GetClient(), mgr.GetAPIReader())
-	setupLog.Info("AIAnalysis status manager initialized (DD-PERF-001 + AA-HAPI-001)")
+	setupLog.Info("AIAnalysis status manager initialized (DD-PERF-001 + AA-KA-001)")
 
 	aaReconciler := &aianalysis.AIAnalysisReconciler{
 		Client:           mgr.GetClient(),

--- a/config/aianalysis.yaml
+++ b/config/aianalysis.yaml
@@ -12,13 +12,13 @@ controller:
   leaderElectionId: aianalysis.kubernaut.ai
 
 # ========================================
-# HOLMESGPT-API CONNECTIVITY (BR-AI-007, BR-AA-HAPI-064)
+# HOLMESGPT-API CONNECTIVITY (BR-AI-007, BR-AA-KA-064)
 # ========================================
 holmesgpt:
   url: https://kubernaut-agent:8443
   # LLM RCA + 3-step workflow discovery can take 2-3 min with real Vertex AI
   timeout: 180s
-  # BR-AA-HAPI-064.8: Constant interval between session status polls.
+  # BR-AA-KA-064.8: Constant interval between session status polls.
   # Polling is normal async behavior, not error recovery.
   sessionPollInterval: 15s
 

--- a/config/crd/bases/kubernaut.ai_aianalyses.yaml
+++ b/config/crd/bases/kubernaut.ai_aianalyses.yaml
@@ -731,7 +731,7 @@ spec:
               humanReviewReason:
                 description: |-
                   Reason why human review needed (when NeedsHumanReview=true)
-                  BR-HAPI-197: Maps to KA's human_review_reason enum values
+                  BR-KA-197: Maps to KA's human_review_reason enum values
                   BR-AI-601: alignment_check_failed added for shadow agent alignment verdicts
                 enum:
                 - workflow_not_found
@@ -857,11 +857,11 @@ spec:
               needsHumanReview:
                 description: |-
                   ========================================
-                  HUMAN REVIEW SIGNALING (BR-HAPI-197)
+                  HUMAN REVIEW SIGNALING (BR-KA-197)
                   Set by Kubernaut Agent when AI cannot produce reliable result
                   ========================================
                   True if human review required (KA decision: RCA incomplete/unreliable)
-                  BR-HAPI-197: Triggers NotificationRequest creation in RO
+                  BR-KA-197: Triggers NotificationRequest creation in RO
                   BR-496 v2: Set when root_owner missing (rca_incomplete) or validation/confidence issues.
                 type: boolean
               observedGeneration:

--- a/config/crd/bases/kubernaut.ai_aianalyses.yaml
+++ b/config/crd/bases/kubernaut.ai_aianalyses.yaml
@@ -794,7 +794,7 @@ spec:
               investigationSession:
                 description: |-
                   ========================================
-                  INVESTIGATION SESSION (BR-AA-HAPI-064)
+                  INVESTIGATION SESSION (BR-AA-KA-064)
                   Tracks the async submit/poll session with Kubernaut Agent
                   ========================================
                   KASession tracks the async KA session for submit/poll pattern
@@ -834,7 +834,7 @@ spec:
                   pollCount:
                     description: |-
                       PollCount tracks the number of poll attempts for observability
-                      BR-AA-HAPI-064.8: Constant 15s poll interval (configurable 1s–5m)
+                      BR-AA-KA-064.8: Constant 15s poll interval (configurable 1s–5m)
                     format: int32
                     minimum: 0
                     type: integer

--- a/config/crd/bases/kubernaut.ai_notificationrequests.yaml
+++ b/config/crd/bases/kubernaut.ai_notificationrequests.yaml
@@ -187,7 +187,7 @@ spec:
                         type: boolean
                       humanReviewReason:
                         description: HumanReviewReason from Kubernaut Agent when needs_human_review=true
-                          (BR-HAPI-197).
+                          (BR-KA-197).
                         type: string
                       reason:
                         description: Reason is the high-level failure reason (e.g.,

--- a/docs/architecture/KUBERNAUT_CRD_ARCHITECTURE.md
+++ b/docs/architecture/KUBERNAUT_CRD_ARCHITECTURE.md
@@ -127,7 +127,7 @@ Kubernaut is an AI-powered Kubernetes remediation platform built on a **microser
 **CRD**: `AIAnalysis` (`kubernaut.ai/v1alpha1`)
 
 **Responsibilities**:
-- Submit an investigation to Kubernaut Agent **asynchronously** — `SubmitInvestigation()` returns a `session_id`; the controller then polls via `PollSession()` until a terminal state, then calls `GetSessionResult()` (`pkg/agentclient`, [BR-AA-HAPI-064](../requirements/)) — KA has **no** synchronous "analyze and return" endpoint
+- Submit an investigation to Kubernaut Agent **asynchronously** — `SubmitInvestigation()` returns a `session_id`; the controller then polls via `PollSession()` until a terminal state, then calls `GetSessionResult()` (`pkg/agentclient`, [BR-AA-KA-064](../requirements/)) — KA has **no** synchronous "analyze and return" endpoint
 - Evaluate the investigation result against a Rego policy (`pkg/aianalysis/rego/evaluator.go`, [BR-AI-011](../requirements/), [BR-AI-014](../requirements/) graceful degradation) to produce a `PolicyDecision`: `Approved`, `ManualReviewRequired`, `Denied`, or `DegradedMode`
 - Detect and reject hallucinated or invalid AI responses
 

--- a/docs/architecture/KUBERNAUT_SERVICE_CATALOG.md
+++ b/docs/architecture/KUBERNAUT_SERVICE_CATALOG.md
@@ -122,7 +122,7 @@ CRD controller (`cmd/aianalysis`) — API `8080`, health `8081`, metrics `9090`
 #### **V1.0 Implementation Scope**
 - **🎯 Focus**: Kubernaut Agent (KA) integration via **async submit/poll** (`pkg/agentclient`) — never a single synchronous call
 - **🔐 Approval Gating**: Rego policy evaluation (`pkg/aianalysis/rego/evaluator.go`) determines whether a `RemediationApprovalRequest` is required before WorkflowExecution proceeds
-- **🔄 Historical naming note**: [BR-AA-HAPI-064](../requirements/BR-AA-HAPI-064-session-based-pull-design.md) — the `HAPI` token in this BR ID is a legacy naming artifact; the requirement itself describes the current session-based **pull** (poll) design against Kubernaut Agent
+- **🔄 Historical naming note**: [BR-AA-KA-064](../requirements/BR-AA-KA-064-session-based-pull-design.md) — the `HAPI` token in this BR ID is a legacy naming artifact; the requirement itself describes the current session-based **pull** (poll) design against Kubernaut Agent
 
 #### **Business Requirements**
 - **Primary**: BR-AI-001 to BR-AI-088 (see e.g. [BR-AI-085](../requirements/BR-AI-085-rego-policy-input-schema.md) Rego policy input schema, [BR-AI-088](../requirements/BR-AI-088-configurable-confidence-thresholds.md) configurable confidence thresholds)

--- a/docs/architecture/KUBERNAUT_SERVICE_CATALOG.md
+++ b/docs/architecture/KUBERNAUT_SERVICE_CATALOG.md
@@ -122,7 +122,7 @@ CRD controller (`cmd/aianalysis`) — API `8080`, health `8081`, metrics `9090`
 #### **V1.0 Implementation Scope**
 - **🎯 Focus**: Kubernaut Agent (KA) integration via **async submit/poll** (`pkg/agentclient`) — never a single synchronous call
 - **🔐 Approval Gating**: Rego policy evaluation (`pkg/aianalysis/rego/evaluator.go`) determines whether a `RemediationApprovalRequest` is required before WorkflowExecution proceeds
-- **🔄 Historical naming note**: [BR-AA-KA-064](../requirements/BR-AA-KA-064-session-based-pull-design.md) — the `HAPI` token in this BR ID is a legacy naming artifact; the requirement itself describes the current session-based **pull** (poll) design against Kubernaut Agent
+- **🔄 Session design**: [BR-AA-KA-064](../requirements/BR-AA-KA-064-session-based-pull-design.md) (renamed from `BR-AA-HAPI-064` — legacy `HAPI` token removed, Issue #1886) describes the current session-based **pull** (poll) design against Kubernaut Agent
 
 #### **Business Requirements**
 - **Primary**: BR-AI-001 to BR-AI-088 (see e.g. [BR-AI-085](../requirements/BR-AI-085-rego-policy-input-schema.md) Rego policy input schema, [BR-AI-088](../requirements/BR-AI-088-configurable-confidence-thresholds.md) configurable confidence thresholds)

--- a/docs/architecture/decisions/ADR-019-aianalysis-error-classification-retry-strategy.md
+++ b/docs/architecture/decisions/ADR-019-aianalysis-error-classification-retry-strategy.md
@@ -78,7 +78,7 @@ every error from a KA call into one of:
 | `Transient` | HTTP 5xx, unknown status | ✅ Yes | 5xx: No; unknown: Yes |
 | `Timeout` | `context.DeadlineExceeded`, `net.Error.Timeout()` | ✅ Yes | ❌ No |
 | `Network` | DNS failure, connection refused, generic `net.Error` | ✅ Yes | DNS/refused: Yes; generic: No |
-| `SessionLost` | 404 on session poll (BR-AA-HAPI-064.5) | Session regeneration, not standard retry | — |
+| `SessionLost` | 404 on session poll (BR-AA-KA-064.5) | Session regeneration, not standard retry | — |
 | `Permanent` (caller cancel) | `context.Canceled` | ❌ No | ❌ No |
 
 ### Retry Schedule (Exponential Backoff, Actual)

--- a/docs/architecture/decisions/ADR-045-aianalysis-ka-service-contract.md
+++ b/docs/architecture/decisions/ADR-045-aianalysis-ka-service-contract.md
@@ -82,7 +82,7 @@ mTLS" as originally specified).
 (`pkg/aianalysis/handlers/investigating.go`), which submits then polls at
 `h.sessionPollInterval` until `completed`/`failed`.
 
-**Business/Design authority**: `BR-KA-002` (analyze endpoint), `BR-AA-HAPI-064.1`/`.3` (async
+**Business/Design authority**: `BR-KA-002` (analyze endpoint), `BR-AA-KA-064.1`/`.3` (async
 submit/result), `DD-AUTH-006` (user attribution for LLM cost tracking) — cited directly in the
 OpenAPI spec's endpoint descriptions.
 

--- a/docs/architecture/decisions/DD-AUDIT-003-service-audit-trace-requirements.md
+++ b/docs/architecture/decisions/DD-AUDIT-003-service-audit-trace-requirements.md
@@ -309,7 +309,7 @@ Kubernaut consists of 12 microservices with different responsibilities. Not all 
 | `aianalysis.analysis.failed` | AI analysis failed (KA timeout, invalid response, etc.) | **P0** |
 | `aianalysis.phase.transition` | AIAnalysis phase state machine transition | P0 |
 | `aianalysis.aiagent.call` | Call to Kubernaut Agent (KA) recorded (endpoint, HTTP status, duration) | P0 |
-| `aianalysis.aiagent.submit` / `.result` / `.session_lost` | Async submit/poll/result session lifecycle with KA (BR-AA-HAPI-064) | P0 |
+| `aianalysis.aiagent.submit` / `.result` / `.session_lost` | Async submit/poll/result session lifecycle with KA (BR-AA-KA-064) | P0 |
 | `aianalysis.approval.decision` | Manual approval decision recorded | P0 |
 | `aianalysis.rego.evaluation` | Rego policy evaluation result | P0 |
 | `aianalysis.error.occurred` | Structured error event | P0 |

--- a/docs/architecture/decisions/DD-EVENT-001-controller-event-registry.md
+++ b/docs/architecture/decisions/DD-EVENT-001-controller-event-registry.md
@@ -106,7 +106,7 @@ Each controller has a dedicated K8s Event Observability BR:
 | BR-ORCH-095 | RemediationOrchestrator | K8s Event Observability (DD-EVENT-001) |
 | BR-EM-095 | EffectivenessMonitor | K8s Event Observability (DD-EVENT-001) |
 
-Events tied to existing BRs (e.g., session events under BR-AA-HAPI-064) use the existing BR number for test IDs.
+Events tied to existing BRs (e.g., session events under BR-AA-KA-064) use the existing BR number for test IDs.
 
 ---
 
@@ -127,7 +127,7 @@ Events tied to existing BRs (e.g., session events under BR-AA-HAPI-064) use the 
 | `EventReasonSessionRegenerationExceeded` | `SessionRegenerationExceeded` | Warning | P2 | Max session regenerations (5) exceeded, transitioning to Failed | Implemented (v1.1) |
 | `EventReasonPhaseTransition` | `PhaseTransition` | Normal | P3 | Any intermediate phase transition (shared constant) | Planned (v1.1) |
 
-**Note**: Session events (SessionCreated, SessionLost, SessionRegenerationExceeded) were originally delegated to the Issue #64 team but have been implemented by the current team via `WithRecorder` functional option on `InvestigatingHandler`. See BR-AA-HAPI-064.6 and `docs/testing/BR-AA-HAPI-064/session_based_pull_test_plan_v1.0.md`.
+**Note**: Session events (SessionCreated, SessionLost, SessionRegenerationExceeded) were originally delegated to the Issue #64 team but have been implemented by the current team via `WithRecorder` functional option on `InvestigatingHandler`. See BR-AA-KA-064.6 and `docs/testing/BR-AA-KA-064/session_based_pull_test_plan_v1.0.md`.
 
 ### WorkflowExecution Controller
 
@@ -352,7 +352,7 @@ Per-controller issues with TDD methodology (RED-GREEN-REFACTOR):
 | Controller | Issue | Events to Add | BR | Owner |
 |---|---|---|---|---|
 | AA | #72 | 6 (excl. 3 session events) | BR-AA-095 | Current team |
-| AA (session) | #73 | 3 (SessionCreated, SessionLost, SessionRegenerationExceeded) | BR-AA-HAPI-064.6 | Current team (originally delegated to Issue #64 team) |
+| AA (session) | #73 | 3 (SessionCreated, SessionLost, SessionRegenerationExceeded) | BR-AA-KA-064.6 | Current team (originally delegated to Issue #64 team) |
 | WE | TBD | 5 | BR-WE-095 | Current team |
 | SP | TBD | 5 | BR-SP-095 | Current team |
 | NT | TBD | 6 | BR-NT-095 | Current team |
@@ -427,7 +427,7 @@ Define unique constants for each intermediate transition (e.g., `EventReasonPend
 - **DD-CONTROLLER-001**: Observed generation idempotency pattern (related controller design)
 - **DD-TEST-006**: Test plan policy and test ID convention (`{TestType}-{ServiceCode}-{BR#}-{Sequence}`)
 - **Issue #64**: AA-HAPI session-based pull design (owns session event implementation)
-- **BR-AA-HAPI-064.6**: Session regeneration cap event (test plan: `docs/testing/BR-AA-HAPI-064/`)
+- **BR-AA-KA-064.6**: Session regeneration cap event (test plan: `docs/testing/BR-AA-KA-064/`)
 
 ## Test Plans
 

--- a/docs/requirements/BR-AA-KA-064-session-based-pull-design.md
+++ b/docs/requirements/BR-AA-KA-064-session-based-pull-design.md
@@ -1,4 +1,4 @@
-# BR-AA-HAPI-064: Session-Based Pull Design for AA-KA Communication
+# BR-AA-KA-064: Session-Based Pull Design for AA-KA Communication
 
 **Status**: APPROVED
 **Version**: 1.1
@@ -23,16 +23,16 @@ The current architecture has the AA controller make a blocking HTTP call to KA's
 
 ## Requirements
 
-### BR-AA-HAPI-064.1: Async Submit Endpoint
+### BR-AA-KA-064.1: Async Submit Endpoint
 KA MUST accept investigation requests and return a session identifier immediately (HTTP 202 Accepted) without waiting for LLM completion.
 
-### BR-AA-HAPI-064.2: Session Status Polling
+### BR-AA-KA-064.2: Session Status Polling
 KA MUST provide an endpoint to check investigation session status (pending, investigating, completed, failed).
 
-### BR-AA-HAPI-064.3: Session Result Retrieval
+### BR-AA-KA-064.3: Session Result Retrieval
 KA MUST provide an endpoint to retrieve the completed investigation result by session ID.
 
-### BR-AA-HAPI-064.4: AA Controller Session Tracking (InvestigationSession)
+### BR-AA-KA-064.4: AA Controller Session Tracking (InvestigationSession)
 The AA controller MUST store session state in the AIAnalysis CRD status using an `InvestigationSession` sub-structure:
 
 ```go
@@ -44,20 +44,20 @@ type InvestigationSession struct {
 }
 ```
 
-### BR-AA-HAPI-064.5: Session Regeneration on KA Restart
+### BR-AA-KA-064.5: Session Regeneration on KA Restart
 When a poll returns 404 (session not found, typically due to KA restart), the AA controller MUST:
 1. Increment `InvestigationSession.Generation`
 2. Clear `InvestigationSession.ID`
 3. Resubmit the investigation request to get a new session
 4. Update `InvestigationSession.CreatedAt`
 
-### BR-AA-HAPI-064.6: Session Regeneration Cap
+### BR-AA-KA-064.6: Session Regeneration Cap
 The AA controller MUST cap session regenerations at 5. After 5 regenerations, the AA MUST transition to Failed with:
 - `SubReason: "SessionRegenerationExceeded"`
 - Escalation notification to operators
 - Warning K8s Event per DD-EVENT-001
 
-### BR-AA-HAPI-064.7: InvestigationSessionReady Condition
+### BR-AA-KA-064.7: InvestigationSessionReady Condition
 The AA controller MUST maintain an `InvestigationSessionReady` Condition on the AIAnalysis CRD:
 - True/SessionCreated when a new session is submitted
 - True/SessionActive when polls succeed
@@ -65,15 +65,15 @@ The AA controller MUST maintain an `InvestigationSessionReady` Condition on the 
 - True/SessionRegenerated when resubmit after loss succeeds
 - False/SessionRegenerationExceeded when cap is exceeded
 
-### BR-AA-HAPI-064.8: Polling with Controller-Runtime Requeue
+### BR-AA-KA-064.8: Polling with Controller-Runtime Requeue
 The AA controller MUST use controller-runtime `RequeueAfter` for polling, not blocking waits. A constant poll interval of 15s is used (configurable via `--session-poll-interval` flag or `WithSessionPollInterval` option). The original recommended backoff (10s, 20s, 30s) was replaced with a constant interval for simplicity and predictable load patterns.
 
-### BR-AA-HAPI-064.9: Recovery Flow Support
+### BR-AA-KA-064.9: Recovery Flow Support
 ~~The same async pattern MUST apply to recovery investigations (`/api/v1/recovery/analyze`).~~
 
 **DEPRECATED for v1.0**: Recovery investigations are deprecated. Instead, when a remediation is ineffective, the alert re-fires through the Gateway and the existing AI analysis results (from the prior Effectiveness Assessment) are included in the KA prompt context. The RO routing engine has logic to prevent this from becoming an endless cycle. Recovery flow may be revisited in future versions.
 
-### BR-AA-HAPI-064.10: Timeout Removal
+### BR-AA-KA-064.10: Timeout Removal
 Once the async design is validated, the 10-minute hardcoded timeout workaround in `cmd/aianalysis/main.go` MUST be removed. All HTTP calls become short-lived (~30s timeout).
 
 ---
@@ -106,8 +106,8 @@ Once the async design is validated, the 10-minute hardcoded timeout workaround i
 ## Changelog
 
 ### v1.1 (2026-03-04)
-- BR-AA-HAPI-064.8: Updated to reflect constant 15s poll interval design decision (replaces 10s/20s/30s backoff)
-- BR-AA-HAPI-064.9: Marked recovery flow as deprecated for v1.0 (alert re-fire through Gateway replaces dedicated recovery endpoint)
+- BR-AA-KA-064.8: Updated to reflect constant 15s poll interval design decision (replaces 10s/20s/30s backoff)
+- BR-AA-KA-064.9: Marked recovery flow as deprecated for v1.0 (alert re-fire through Gateway replaces dedicated recovery endpoint)
 
 ### v1.0 (2026-02-09)
 - Initial version based on GitHub issue #64 analysis

--- a/docs/services/crd-controllers/02-aianalysis/controller-implementation.md
+++ b/docs/services/crd-controllers/02-aianalysis/controller-implementation.md
@@ -10,7 +10,7 @@
 
 | Version | Date | Changes | Reference |
 |---------|------|---------|-----------|
-| v3.0 | 2026-08-02 | **#1806 CORRECTION**: Full rewrite, superseding the v2.0 STALE banner. Fixed the package structure to match the real code (`internal/controller/aianalysis/` for the reconciler, `pkg/aianalysis/handlers/` for phase logic, `pkg/agentclient` for the KA client — not `pkg/ai/holmesgpt` / `internal/controller/aianalysis/holmesgpt`, which do not exist); replaced the fictional `HolmesGPTClient holmesgpt.Client` reconciler field and single synchronous `Investigate()` call with the real async submit/poll/result session flow (`AgentClientInterface.SubmitInvestigation`/`PollSession`/`GetSessionResult`, BR-AA-HAPI-064); replaced the 60s/5s hardcoded phase timeouts with the real `DefaultSessionPollInterval` (15s) and `DefaultMaxInvestigationDuration` (25m) wall-clock cap; corrected `AIApprovalRequest` references to `RemediationApprovalRequest` | #1806, BR-AA-HAPI-064 |
+| v3.0 | 2026-08-02 | **#1806 CORRECTION**: Full rewrite, superseding the v2.0 STALE banner. Fixed the package structure to match the real code (`internal/controller/aianalysis/` for the reconciler, `pkg/aianalysis/handlers/` for phase logic, `pkg/agentclient` for the KA client — not `pkg/ai/holmesgpt` / `internal/controller/aianalysis/holmesgpt`, which do not exist); replaced the fictional `HolmesGPTClient holmesgpt.Client` reconciler field and single synchronous `Investigate()` call with the real async submit/poll/result session flow (`AgentClientInterface.SubmitInvestigation`/`PollSession`/`GetSessionResult`, BR-AA-KA-064); replaced the 60s/5s hardcoded phase timeouts with the real `DefaultSessionPollInterval` (15s) and `DefaultMaxInvestigationDuration` (25m) wall-clock cap; corrected `AIApprovalRequest` references to `RemediationApprovalRequest` | #1806, BR-AA-KA-064 |
 | v2.0 | 2025-11-30 | **REGENERATED**: Fixed SignalProcessing naming; Removed legacy phases (recommending→analyzing); Removed HolmesGPTConfig/InvestigationScope; Added DetectedLabels/CustomLabels/OwnerChain; V1.0 4-phase flow | DD-WORKFLOW-001 v1.8, DD-RECOVERY-002 |
 | v1.1 | 2025-10-16 | Added self-documenting JSON format | DD-HOLMESGPT-009 |
 | v1.0 | 2025-10-15 | Initial specification | - |
@@ -36,7 +36,7 @@ pkg/aianalysis/
 ├── rego/evaluator.go            # Rego policy evaluation (BR-AI-011)
 └── handlers/
     ├── interfaces.go            # AgentClientInterface, AuditClientInterface, RegoEvaluatorInterface
-    ├── constants.go             # Retry/backoff + session constants (BR-AA-HAPI-064)
+    ├── constants.go             # Retry/backoff + session constants (BR-AA-KA-064)
     ├── investigating.go         # InvestigatingHandler: async submit/poll/result session flow
     ├── analyzing.go             # AnalyzingHandler: Rego policy evaluation
     ├── request_builder.go       # Builds agentclient.IncidentRequest from AIAnalysis spec
@@ -124,7 +124,7 @@ type AgentClientInterface interface {
     // Legacy synchronous method (being deprecated)
     Investigate(ctx context.Context, req *agentclient.IncidentRequest) (*agentclient.IncidentResponse, error)
 
-    // Async session methods (BR-AA-HAPI-064) — the real, current flow
+    // Async session methods (BR-AA-KA-064) — the real, current flow
     SubmitInvestigation(ctx context.Context, req *agentclient.IncidentRequest) (string, error)
     PollSession(ctx context.Context, sessionID string) (*agentclient.SessionStatusResult, error)
     GetSessionResult(ctx context.Context, sessionID string) (*agentclient.IncidentResponse, error)
@@ -255,7 +255,7 @@ func (r *AIAnalysisReconciler) reconcilePending(ctx context.Context, analysis *a
 }
 ```
 
-### Investigating Phase — Async Submit/Poll/Result (BR-AA-HAPI-064)
+### Investigating Phase — Async Submit/Poll/Result (BR-AA-KA-064)
 
 Unlike a single synchronous HTTP call, the Investigating phase is a **non-blocking session state machine** driven by `InvestigatingHandler.Handle` (`pkg/aianalysis/handlers/investigating.go`). Each reconcile either submits, polls, or fetches the result — it never blocks the reconcile loop waiting on Kubernaut Agent (KA):
 
@@ -288,7 +288,7 @@ func (h *InvestigatingHandler) handleSessionPoll(ctx context.Context, analysis *
     session := analysis.Status.KASession
     status, err := h.kaClient.PollSession(ctx, session.ID) // GET /api/v1/incident/session/{id}
     if err != nil {
-        return h.handleSessionPollError(ctx, analysis, err) // 404 -> session regeneration (BR-AA-HAPI-064.5)
+        return h.handleSessionPollError(ctx, analysis, err) // 404 -> session regeneration (BR-AA-KA-064.5)
     }
 
     switch status.Status {
@@ -414,9 +414,9 @@ func (r *AIAnalysisReconciler) SetupWithManager(mgr ctrl.Manager) error {
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
 | **4-Phase Flow** | Pending → Investigating → Analyzing → Completed | "Approving" phase moved to RO (creates `RemediationApprovalRequest`) |
-| **Async Session Model** | Submit/poll/result, not a blocking synchronous call | Non-blocking reconciles; investigations can take minutes without holding a goroutine or HTTP connection open (BR-AA-HAPI-064) |
+| **Async Session Model** | Submit/poll/result, not a blocking synchronous call | Non-blocking reconciles; investigations can take minutes without holding a goroutine or HTTP connection open (BR-AA-KA-064) |
 | **25-Minute Wall-Clock Cap** | `DefaultMaxInvestigationDuration`, checked every poll | Bounds resource consumption from a stuck/slow KA session, including interactive takeover (#1078) |
-| **Session Regeneration** | On 404 from `PollSession`/`GetSessionResult`, clear session ID and resubmit (capped at 5 regenerations) | Recovers from KA restarts without failing the whole investigation (BR-AA-HAPI-064.5/.6) |
+| **Session Regeneration** | On 404 from `PollSession`/`GetSessionResult`, clear session ID and resubmit (capped at 5 regenerations) | Recovers from KA restarts without failing the whole investigation (BR-AA-KA-064.5/.6) |
 | **No HolmesGPTConfig / InvestigationScope** | Removed | V1.0 uses a single Kubernaut Agent (KA) provider; KA decides investigation scope dynamically |
 | **approvalRequired flag** | V1.0 signaling; RO creates `RemediationApprovalRequest` | No approval orchestration logic inside AIAnalysis itself |
 

--- a/docs/services/crd-controllers/02-aianalysis/crd-schema.md
+++ b/docs/services/crd-controllers/02-aianalysis/crd-schema.md
@@ -30,7 +30,7 @@
 | **ADR-055** | `OwnerChain`/`CustomLabels` moved onto `EnrichmentResults.KubernetesContext`; the LLM's `RemediationTarget` (RCA output) replaced the old `target_in_owner_chain` boolean |
 | **Issue #113** | `KubernetesContext` restructured to a lean, classification-focused shape (`Namespace`, `Workload`, `OwnerChain`, `CustomLabels`) — no more per-kind `PodDetails`/`DeploymentDetails` in the enrichment input |
 | **Issue #1661 / DD-WORKFLOW-018** | `SelectedWorkflow` embeds `sharedtypes.WorkflowSnapshot` (the same type `WorkflowExecution.Spec.WorkflowRef` uses) so the two can never drift; write-once via CEL once `selectedAt` is set |
-| **BR-AA-HAPI-064** | Async submit/poll/result session pattern with KA; `status.investigationSession` (Go type `KASession`) tracks it |
+| **BR-AA-KA-064** | Async submit/poll/result session pattern with KA; `status.investigationSession` (Go type `KASession`) tracks it |
 | **DD-INTERACTIVE-002** | Any RemediationRequest is takeover-capable; `status.interactiveSession` is observability-only |
 | **ADR-040** | `RemediationApprovalRequest` (not `AIApprovalRequest`) is the CRD RemediationOrchestrator creates for manual approval — implemented today, not deferred |
 | **Issue #180** | The `DD-RECOVERY-002` recovery-attempt fields (`isRecoveryAttempt`, `previousExecutions`, etc.) were removed from the spec entirely, not merely deprecated in place |
@@ -376,7 +376,7 @@ The v2.0–v2.7 versions of this document described `IsRecoveryAttempt`, `Recove
 removed, not merely deprecated-in-place. `AIAnalysisSpec` has no recovery-related fields at all
 today (see [AIAnalysisSpec](#aianalysisspec) above).
 
-Per BR-AA-HAPI-064.9: when a remediation is ineffective, the alert re-fires through the Gateway
+Per BR-AA-KA-064.9: when a remediation is ineffective, the alert re-fires through the Gateway
 as a new signal, and prior AI analysis / Effectiveness Assessment results are surfaced to KA as
 prompt context — there is no dedicated "recovery AIAnalysis" spec shape in V1.0. If this changes,
 DD-RECOVERY-002/003 will need to be revisited and this section updated with the real fields.
@@ -462,7 +462,7 @@ type AIAnalysisStatus struct {
     // +optional
     ConsecutiveFailures int32 `json:"consecutiveFailures,omitempty"`
 
-    // Async KA submit/poll session tracking (BR-AA-HAPI-064)
+    // Async KA submit/poll session tracking (BR-AA-KA-064)
     // +optional
     KASession *KASession `json:"investigationSession,omitempty"`
 
@@ -625,7 +625,7 @@ type AlternativeApproach struct {
 ### KASession, InteractiveSessionInfo, PostRCAContext
 
 ```go
-// KASession tracks the async KA session lifecycle (BR-AA-HAPI-064.4/.5; the JSON tag is
+// KASession tracks the async KA session lifecycle (BR-AA-KA-064.4/.5; the JSON tag is
 // still "investigationSession" — renamed from InvestigationSession only at the Go type
 // level to avoid colliding with the unrelated root InvestigationSession CRD).
 type KASession struct {
@@ -637,7 +637,7 @@ type KASession struct {
     LastPolled *metav1.Time `json:"lastPolled,omitempty"`
     // +optional
     CreatedAt *metav1.Time `json:"createdAt,omitempty"`
-    // BR-AA-HAPI-064.8: constant 15s poll interval (configurable 1s–5m)
+    // BR-AA-KA-064.8: constant 15s poll interval (configurable 1s–5m)
     // +optional
     PollCount int32 `json:"pollCount,omitempty"`
     // #1390: after 3 consecutive 409s the session is regenerated

--- a/docs/services/crd-controllers/02-aianalysis/integration-points.md
+++ b/docs/services/crd-controllers/02-aianalysis/integration-points.md
@@ -169,7 +169,7 @@ type AgentClientInterface interface {
     // Legacy synchronous method (being deprecated) — internally does submit→poll→result
     Investigate(ctx context.Context, req *agentclient.IncidentRequest) (*agentclient.IncidentResponse, error)
 
-    // Async session methods (BR-AA-HAPI-064) — what the controller actually uses
+    // Async session methods (BR-AA-KA-064) — what the controller actually uses
     SubmitInvestigation(ctx context.Context, req *agentclient.IncidentRequest) (string, error)
     PollSession(ctx context.Context, sessionID string) (*agentclient.SessionStatusResult, error)
     GetSessionResult(ctx context.Context, sessionID string) (*agentclient.IncidentResponse, error)
@@ -179,7 +179,7 @@ type AgentClientInterface interface {
 }
 ```
 
-### Endpoints (async session API, BR-AA-HAPI-064)
+### Endpoints (async session API, BR-AA-KA-064)
 
 | Endpoint | Method | Purpose |
 |----------|--------|---------|
@@ -190,7 +190,7 @@ type AgentClientInterface interface {
 | `https://kubernaut-agent:8443/health` | GET | Health check |
 
 There is no `POST /api/v1/recovery/analyze` endpoint and no separate "recovery" request shape —
-per BR-AA-HAPI-064.9, an ineffective remediation re-fires as a new signal through the Gateway
+per BR-AA-KA-064.9, an ineffective remediation re-fires as a new signal through the Gateway
 instead of triggering a dedicated recovery call.
 
 ### Async Submit → Poll → Result Flow
@@ -300,7 +300,7 @@ distinct from a fixed "3 attempts, 1s/2s/4s" table:
 |---|---|---|---|
 | `401` | `Authentication` | No | Alerts |
 | `403` | `Authorization` | No | Alerts |
-| `404` on poll | `SessionLost` (not `Configuration`) | Triggers session regeneration, not a standard retry | BR-AA-HAPI-064.5 |
+| `404` on poll | `SessionLost` (not `Configuration`) | Triggers session regeneration, not a standard retry | BR-AA-KA-064.5 |
 | `404` elsewhere | `Configuration` | No | Alerts |
 | `422` / `400` | `Permanent` | No | Alerts |
 | `429` | `RateLimit` | Yes | 2× base delay, no alert |

--- a/docs/services/crd-controllers/02-aianalysis/metrics-slos.md
+++ b/docs/services/crd-controllers/02-aianalysis/metrics-slos.md
@@ -10,7 +10,7 @@
 
 | Version | Date | Changes |
 |---------|------|---------|
-| v3.0 | 2026-08-02 | **#1806 CORRECTION**: Full rewrite. Rebuilt the metrics table, dashboard, alerts, and queries around the 4 metrics that actually exist in [`pkg/aianalysis/metrics/metrics.go`](../../../../pkg/aianalysis/metrics/metrics.go) (`aianalysis_rego_evaluations_total`, `aianalysis_approval_decisions_total`, `aianalysis_confidence_score_distribution`, `aianalysis_failures_total`). Removed all `aianalysis_holmesgpt_*`, `aianalysis_investigation_*`, and `aianalysis_workflow_*` metrics — none of these exist in code (client-side KA call metrics were intentionally removed; see Scope Note below). Replaced the 60-second-sync-call latency SLOs with SLOs grounded in the real async submit/poll/result session model (25-minute wall-clock cap, BR-AA-HAPI-064) |
+| v3.0 | 2026-08-02 | **#1806 CORRECTION**: Full rewrite. Rebuilt the metrics table, dashboard, alerts, and queries around the 4 metrics that actually exist in [`pkg/aianalysis/metrics/metrics.go`](../../../../pkg/aianalysis/metrics/metrics.go) (`aianalysis_rego_evaluations_total`, `aianalysis_approval_decisions_total`, `aianalysis_confidence_score_distribution`, `aianalysis_failures_total`). Removed all `aianalysis_holmesgpt_*`, `aianalysis_investigation_*`, and `aianalysis_workflow_*` metrics — none of these exist in code (client-side KA call metrics were intentionally removed; see Scope Note below). Replaced the 60-second-sync-call latency SLOs with SLOs grounded in the real async submit/poll/result session model (25-minute wall-clock cap, BR-AA-KA-064) |
 | v2.0 | 2025-11-30 | V1.0 ALIGNMENT: Updated approval metrics to signaling pattern (no AIApprovalRequest CRD); Added DetectedLabels/CustomLabels metrics; Updated phase names |
 | v1.0 | 2025-10-15 | Initial specification |
 
@@ -39,7 +39,7 @@ If you need per-investigation timing, use `AIAnalysis.status.investigationTime` 
 | **Auto-Approval Rate** | `approval_decisions{decision="auto_approved"} / approval_decisions_total` | 40-60% | Rego policy effectiveness (BR-AI-059) |
 | **AI Confidence (Avg)** | `avg(aianalysis_confidence_score_distribution)` | ≥0.80 | High-quality workflow selection (BR-AI-OBSERVABILITY-004) |
 | **Failure Rate** | `sum(rate(aianalysis_failures_total[1h]))` | Trend-monitored (no fleet-wide fixed target — depends on cluster alert volume) | Overall investigation health (BR-KA-197) |
-| **TransientError Share** | `failures{reason="TransientError"} / failures_total` | Trend-monitored | Async KA session health — covers both retry-exhaustion and the 25-minute session timeout cap (#1078, BR-AA-HAPI-064) |
+| **TransientError Share** | `failures{reason="TransientError"} / failures_total` | Trend-monitored | Async KA session health — covers both retry-exhaustion and the 25-minute session timeout cap (#1078, BR-AA-KA-064) |
 
 > **Note on denominators**: There is no "total investigations started" counter (client-side KA call counters were deliberately removed — see Scope Note). `aianalysis_confidence_score_distribution`'s sample count and `aianalysis_failures_total`'s sum are the closest available proxies for "successful" vs. "failed" investigation volume respectively (see `recordPhaseMetrics` in `internal/controller/aianalysis/metrics_recorder.go`), so ratio SLIs above use each metric family's own total as the denominator rather than a global count.
 
@@ -257,7 +257,7 @@ groups:
       summary: "AIAnalysis failure rate elevated"
       description: "{{ $value }} failures/hour across all reasons — inspect `sum by (reason, sub_reason) (aianalysis_failures_total)` for the dominant cause"
 
-  # Async session health: Transient/timeout failures (#1078, BR-AA-HAPI-064)
+  # Async session health: Transient/timeout failures (#1078, BR-AA-KA-064)
   - alert: AIAnalysisTransientFailuresElevated
     expr: |
       sum(rate(aianalysis_failures_total{reason="TransientError"}[1h])) > 2

--- a/docs/services/crd-controllers/02-aianalysis/overview.md
+++ b/docs/services/crd-controllers/02-aianalysis/overview.md
@@ -10,7 +10,7 @@
 
 | Version | Date | Changes | Reference |
 |---------|------|---------|-----------|
-| v3.0 | 2026-08-02 | **#1806 CORRECTION**: Full rewrite. Replaced the synchronous "single HTTP call to HolmesGPT-API" architecture with the real async submit/poll/result session model against Kubernaut Agent (KA); fixed the Go client package reference (`pkg/agentclient`, not `pkg/clients/holmesgpt/`); corrected the Input Contract (`DetectedLabels`/`CustomLabels`/`OwnerChain` are NOT part of `spec.analysisRequest` — `DetectedLabels` are KA-computed *after* RCA and returned as an output in `status.postRCAContext`, per ADR-056); removed the recovery-attempt input fields (`isRecoveryAttempt`/`previousExecutions` do not exist on the current CRD spec — recovery-via-resubmission was deprecated, Issue #180); corrected the Output Contract to match `RootCauseAnalysis`/`RemediationTarget`/`SelectedWorkflow` (`WorkflowSnapshot`-embedded, no bare `containerImage` field); replaced `AIApprovalRequest` (never implemented) with the real `RemediationApprovalRequest` CRD | #1806, ADR-056, BR-AA-HAPI-064 |
+| v3.0 | 2026-08-02 | **#1806 CORRECTION**: Full rewrite. Replaced the synchronous "single HTTP call to HolmesGPT-API" architecture with the real async submit/poll/result session model against Kubernaut Agent (KA); fixed the Go client package reference (`pkg/agentclient`, not `pkg/clients/holmesgpt/`); corrected the Input Contract (`DetectedLabels`/`CustomLabels`/`OwnerChain` are NOT part of `spec.analysisRequest` — `DetectedLabels` are KA-computed *after* RCA and returned as an output in `status.postRCAContext`, per ADR-056); removed the recovery-attempt input fields (`isRecoveryAttempt`/`previousExecutions` do not exist on the current CRD spec — recovery-via-resubmission was deprecated, Issue #180); corrected the Output Contract to match `RootCauseAnalysis`/`RemediationTarget`/`SelectedWorkflow` (`WorkflowSnapshot`-embedded, no bare `containerImage` field); replaced `AIApprovalRequest` (never implemented) with the real `RemediationApprovalRequest` CRD | #1806, ADR-056, BR-AA-KA-064 |
 | v2.0 | 2025-11-30 | **REGENERATED**: Complete rewrite for V1.0 scope; Fixed RemediationProcessing→SignalProcessing; Added DetectedLabels/CustomLabels/OwnerChain; Removed "Approving" phase; Updated ports per DD-TEST-001 | DD-WORKFLOW-001 v1.8, DD-RECOVERY-002 |
 | v1.1 | 2025-10-20 | Added V1.0 approval notification integration | ADR-018 |
 | v1.0 | 2025-10-15 | Initial design specification | - |
@@ -23,7 +23,7 @@
 
 **Core Responsibilities**:
 1. **Receive enrichment data from SignalProcessing** (via Remediation Orchestrator)
-2. **Submit an investigation to Kubernaut Agent (KA)** asynchronously, then poll the session until it completes (BR-AA-HAPI-064)
+2. **Submit an investigation to Kubernaut Agent (KA)** asynchronously, then poll the session until it completes (BR-AA-KA-064)
 3. **Evaluate Rego approval policies** for automated vs. manual approval
 4. **Provide structured output** for WorkflowExecution creation
 
@@ -35,7 +35,7 @@
 
 | Capability | Description | Reference |
 |------------|-------------|-----------|
-| **Kubernaut Agent (KA) Integration** | Single AI provider, accessed via an async submit/poll/result session (not a single synchronous call) | BR-AI-001, BR-AA-HAPI-064 |
+| **Kubernaut Agent (KA) Integration** | Single AI provider, accessed via an async submit/poll/result session (not a single synchronous call) | BR-AI-001, BR-AA-KA-064 |
 | **Workflow Selection** | Select from predefined workflow catalog; catalog resolution happens inside KA | BR-AI-075, BR-KA-250 |
 | **Rego Approval Policies** | Auto-approve or flag for manual review | BR-AI-028 |
 | **Interactive Takeover** | A human operator can take over an in-progress session via MCP (`user_driving` state); the 25-minute session cap still applies | DD-INTERACTIVE-002, BR-INTERACTIVE-001 |
@@ -211,7 +211,7 @@ status:
   approvalRequired: true
   approvalReason: "Confidence below 80% threshold (72% < 80%)"
 
-  # Async session tracking (BR-AA-HAPI-064)
+  # Async session tracking (BR-AA-KA-064)
   investigationSession:
     id: "sess-abc123"
     generation: 0
@@ -271,7 +271,7 @@ RemediationRequest (root orchestrator)
 | **Investigation & Analysis** | 12 | BR-AI-001 to BR-AI-023 |
 | **Workflow Selection** | 2 | BR-AI-075, BR-AI-076 |
 | **Approval Policies** | 4 | BR-AI-028 to BR-AI-030 |
-| **Async Session Management** | 4 | BR-AA-HAPI-064 (submit/poll/result, session regeneration) |
+| **Async Session Management** | 4 | BR-AA-KA-064 (submit/poll/result, session regeneration) |
 | **Kubernaut Agent (KA) Integration** | 5 | BR-KA-250 to BR-HAPI-252 |
 | **Validation & Hallucination** | 4 | BR-AI-023 (catalog validation) |
 

--- a/docs/services/crd-controllers/02-aianalysis/reconciliation-phases.md
+++ b/docs/services/crd-controllers/02-aianalysis/reconciliation-phases.md
@@ -10,7 +10,7 @@
 
 | Version | Date | Changes | Reference |
 |---------|------|---------|-----------|
-| **v2.3** | 2026-08-02 | **#1806 CORRECTION**: Fixed the remaining stale sections not covered by the prior validation-focused pass (#1847): Phase 2 (Investigating) rewritten from a single 60s synchronous HolmesGPT-API call to the real async submit/poll/result session flow against Kubernaut Agent (KA) with a 25-minute wall-clock cap (BR-AA-HAPI-064); corrected the Phase Overview table/diagram, Phase Timeout Configuration section, Rego policy input/output examples (`require_approval`/`reason`, not `AUTO_APPROVE`/`MANUAL_APPROVAL_REQUIRED`), Recovery Attempts section (`isRecoveryAttempt`/`previousExecutions` do not exist on the current CRD spec), and the Metrics section (the referenced `kubernaut_aianalysis_phase_duration_seconds` metric does not exist; see `metrics-slos.md` for the real 4 metrics) | #1806, BR-AA-HAPI-064 |
+| **v2.3** | 2026-08-02 | **#1806 CORRECTION**: Fixed the remaining stale sections not covered by the prior validation-focused pass (#1847): Phase 2 (Investigating) rewritten from a single 60s synchronous HolmesGPT-API call to the real async submit/poll/result session flow against Kubernaut Agent (KA) with a 25-minute wall-clock cap (BR-AA-KA-064); corrected the Phase Overview table/diagram, Phase Timeout Configuration section, Rego policy input/output examples (`require_approval`/`reason`, not `AUTO_APPROVE`/`MANUAL_APPROVAL_REQUIRED`), Recovery Attempts section (`isRecoveryAttempt`/`previousExecutions` do not exist on the current CRD spec), and the Metrics section (the referenced `kubernaut_aianalysis_phase_duration_seconds` metric does not exist; see `metrics-slos.md` for the real 4 metrics) | #1806, BR-AA-KA-064 |
 | **v2.2** | 2025-12-09 | **V1.0 COMPLIANCE AUDIT**: (1) Timeout should be `spec.TimeoutConfig` not annotation (pending RO clarification); (2) Recovery attempts must use `/api/v1/recovery/analyze` endpoint (pending HAPI confirmation); (3) Recovery fields must be passed to HAPI | `NOTICE_AIANALYSIS_V1_COMPLIANCE_GAPS.md`, `REQUEST_RO_TIMEOUT_PASSTHROUGH_CLARIFICATION.md` (both docs/handoff/, deleted in the repo-wide non-authoritative docs purge) |
 | v2.1 | 2025-12-06 | **BR-KA-197**: Added `SubReason` field for granular failure tracking; Removed `Recommending` from Phase enum; Added failure taxonomy | BR-KA-197, DD-HAPI-002 v1.2 |
 | v2.0 | 2025-11-30 | **REGENERATED**: Removed "Approving" phase (V1.0); Removed BR-AI-051-053 (dependency validation); Simplified to 4-phase flow; Added DetectedLabels/CustomLabels handling | DD-RECOVERY-002, BR_MAPPING v1.2 |
@@ -89,7 +89,7 @@ status:
 
 ## Phase 2: Investigating
 
-**Purpose**: AI-powered investigation via **Kubernaut Agent (KA)**, using an async submit/poll/result session (BR-AA-HAPI-064) — **not** a single synchronous HTTP call.
+**Purpose**: AI-powered investigation via **Kubernaut Agent (KA)**, using an async submit/poll/result session (BR-AA-KA-064) — **not** a single synchronous HTTP call.
 
 **Timeout**: 25 minutes wall-clock cap on the whole session (`DefaultMaxInvestigationDuration` in `pkg/aianalysis/handlers/constants.go`, configurable via `WithMaxInvestigationDuration(d time.Duration)` on the `InvestigatingHandler`) — not a per-call timeout.
 
@@ -137,14 +137,14 @@ If the wall-clock session age exceeds `DefaultMaxInvestigationDuration` (25 minu
 
 ### Session Regeneration on 404
 
-If `PollSession` returns `404` (KA restarted and lost session state), the handler clears `status.kaSession.id` and re-submits a new investigation from scratch (BR-AA-HAPI-064.5) rather than failing immediately.
+If `PollSession` returns `404` (KA restarted and lost session state), the handler clears `status.kaSession.id` and re-submits a new investigation from scratch (BR-AA-KA-064.5) rather than failing immediately.
 
 ### Error Handling
 
 | Error | Action | Retry |
 |-------|--------|-------|
 | Kubernaut Agent (KA) unavailable | Retry with exponential backoff | Yes (transient) |
-| `PollSession` returns 404 (session lost) | Clear session ID, re-submit | Yes (BR-AA-HAPI-064.5) |
+| `PollSession` returns 404 (session lost) | Clear session ID, re-submit | Yes (BR-AA-KA-064.5) |
 | 25-minute wall-clock cap exceeded | Mark as `Failed` | No |
 | Invalid/malformed KA response | Mark as `Failed` | No |
 
@@ -398,7 +398,7 @@ status:
 > `AIAnalysisSpec` (`api/aianalysis/v1alpha1/aianalysis_types.go`), **none of these fields
 > exist** — there is no recovery-attempt input contract on the CRD spec today. The recovery/retry
 > flow design (`DD-RECOVERY-002`) was archived/deleted when the recovery flow itself was
-> deprecated (Issue #180) — recovery now flows through Gateway re-fire (BR-AA-HAPI-064.9), not a
+> deprecated (Issue #180) — recovery now flows through Gateway re-fire (BR-AA-KA-064.9), not a
 > dedicated AIAnalysis spec field. If/when a recovery-attempt input contract ships, it should be
 > documented here against the real spec fields rather than the illustrative example below.
 

--- a/docs/testing/BR-AA-KA-064/session_based_pull_test_plan_v1.0.md
+++ b/docs/testing/BR-AA-KA-064/session_based_pull_test_plan_v1.0.md
@@ -1,20 +1,20 @@
-# V1.0 Test Plan: BR-AA-HAPI-064 Session-Based Pull Design
+# V1.0 Test Plan: BR-AA-KA-064 Session-Based Pull Design
 
 **Version**: 1.0.0
 **Created**: 2026-02-09
 **Status**: APPROVED
-**Purpose**: TDD test plan for session-based asynchronous AA-HAPI communication
+**Purpose**: TDD test plan for session-based asynchronous AA-KA communication
 
 ---
 
 ## Overview
 
-This test plan covers the full TDD implementation of BR-AA-HAPI-064 (Session-Based Pull Design),
+This test plan covers the full TDD implementation of BR-AA-KA-064 (Session-Based Pull Design),
 which replaces the synchronous blocking HTTP call between AA and HAPI with an asynchronous
 submit/poll pattern using session IDs.
 
 **Reference Documents**:
-- [BR-AA-HAPI-064](../../../docs/requirements/BR-AA-HAPI-064-session-based-pull-design.md)
+- [BR-AA-KA-064](../../../docs/requirements/BR-AA-KA-064-session-based-pull-design.md)
 - [DD-AA-HAPI-064](../../../docs/architecture/decisions/DD-AA-HAPI-064-session-based-pull-design.md)
 - [DD-EVENT-001](../../../docs/architecture/decisions/DD-EVENT-001-controller-event-registry.md)
 - [TESTING_GUIDELINES.md](../../development/business-requirements/TESTING_GUIDELINES.md)
@@ -50,13 +50,13 @@ Per [TESTING_GUIDELINES.md](../../development/business-requirements/TESTING_GUID
 
 This test plan covers:
 
-- AA controller submit/poll/result handler logic (incident only; recovery deprecated for v1.0 per BR-AA-HAPI-064.9)
+- AA controller submit/poll/result handler logic (incident only; recovery deprecated for v1.0 per BR-AA-KA-064.9)
 - HAPI session manager lifecycle and async endpoints (incident only; recovery deprecated for v1.0)
 - `InvestigationSession` CRD tracking, `InvestigationSessionReady` Condition, K8s Events
 - Session regeneration (404 detection, Generation counter, cap at 5)
 - Audit trace validation with **exact** counts at integration tier
 - Mock LLM session endpoint support for CI/CD
-- Service-specific E2E with async AA-HAPI communication
+- Service-specific E2E with async AA-KA communication
 
 **Out of Scope**:
 
@@ -67,7 +67,7 @@ This test plan covers:
 ### Design Decision: Async-First Endpoints (No Backward Compatibility)
 
 **Decision date**: 2026-02-11
-**Context**: BR-AA-HAPI-064 replaces synchronous blocking HTTP calls between AA and HAPI with an
+**Context**: BR-AA-KA-064 replaces synchronous blocking HTTP calls between AA and HAPI with an
 asynchronous submit/poll/result pattern. Both HAPI endpoints (`POST /api/v1/incident/analyze` and
 `POST /api/v1/recovery/analyze`) are modified to return HTTP 202 Accepted with a `session_id`
 instead of HTTP 200 with the full synchronous response.
@@ -135,7 +135,7 @@ request lifecycle, so the submit → get-result pattern works without polling or
 ### 1.1 Incident Submit Flow
 
 - **UT-AA-064-001**: Submit investigation when InvestigationSession is nil
-  - BR: BR-AA-HAPI-064.1, BR-AA-HAPI-064.4, BR-AA-HAPI-064.7
+  - BR: BR-AA-KA-064.1, BR-AA-KA-064.4, BR-AA-KA-064.7
   - Business Outcome: Controller creates a HAPI session and records it in CRD status
   - Given: AIAnalysis with nil InvestigationSession, Phase=Investigating
   - When: `Handle()` called
@@ -145,7 +145,7 @@ request lifecycle, so the submit → get-result pattern works without polling or
     - Result: `RequeueAfter: 10s` (non-blocking return)
     - Audit side effect: `auditClientSpy` recorded exactly 1 `holmesgpt.submit` event with sessionID
 - **UT-AA-064-002**: Submit investigation after session regeneration (ID cleared, Generation preserved)
-  - BR: BR-AA-HAPI-064.5
+  - BR: BR-AA-KA-064.5
   - Business Outcome: After a session loss, AA resubmits while preserving the regeneration count
   - Given: AIAnalysis with `InvestigationSession{ID: "", Generation: 2}`
   - When: `Handle()` called
@@ -156,7 +156,7 @@ request lifecycle, so the submit → get-result pattern works without polling or
 ### 1.2 Incident Poll Flow
 
 - **UT-AA-064-003**: Poll session -- status "pending", controller requeues
-  - BR: BR-AA-HAPI-064.2, BR-AA-HAPI-064.8
+  - BR: BR-AA-KA-064.2, BR-AA-KA-064.8
   - Business Outcome: AA waits for HAPI to complete investigation without blocking
   - Given: InvestigationSession with valid ID
   - When: `PollSession()` returns `{status: "pending"}`
@@ -165,7 +165,7 @@ request lifecycle, so the submit → get-result pattern works without polling or
     - Condition: Reason=`SessionActive`
     - Result: `RequeueAfter: 10s` (first poll interval)
 - **UT-AA-064-004**: Poll session -- status "investigating", backoff increases
-  - BR: BR-AA-HAPI-064.2, BR-AA-HAPI-064.8
+  - BR: BR-AA-KA-064.2, BR-AA-KA-064.8
   - Business Outcome: AA uses increasing backoff to avoid overloading HAPI
   - Given: InvestigationSession with valid ID, second consecutive poll
   - When: `PollSession()` returns `{status: "investigating"}`
@@ -173,7 +173,7 @@ request lifecycle, so the submit → get-result pattern works without polling or
     - CRD status: `LastPolled` updated
     - Result: `RequeueAfter: 20s` (second poll backoff)
 - **UT-AA-064-005**: Poll session -- status "completed", result fetched and processed
-  - BR: BR-AA-HAPI-064.3
+  - BR: BR-AA-KA-064.3
   - Business Outcome: AA retrieves the completed investigation and advances to policy analysis
   - Given: InvestigationSession with valid ID
   - When: `PollSession()` returns `{status: "completed"}`, `GetSessionResult()` returns `IncidentResponse` with workflow
@@ -181,14 +181,14 @@ request lifecycle, so the submit → get-result pattern works without polling or
     - CRD status: Phase transitions to `Analyzing`, SelectedWorkflow populated
     - Audit side effect: `auditClientSpy` recorded exactly 1 `holmesgpt.result` event with `investigationTime > 0`
 - **UT-AA-064-006**: Poll session -- status "failed", investigation terminates
-  - BR: BR-AA-HAPI-064.2
+  - BR: BR-AA-KA-064.2
   - Business Outcome: HAPI-side failure is surfaced to operators via CRD status
   - Given: InvestigationSession with valid ID
   - When: `PollSession()` returns `{status: "failed", error: "LLM provider error"}`
   - Then:
     - CRD status: Phase=`Failed`, error details in Message/Reason
 - **UT-AA-064-007**: Polling backoff caps at 30s
-  - BR: BR-AA-HAPI-064.8
+  - BR: BR-AA-KA-064.8
   - Business Outcome: Polling frequency stabilizes to avoid unnecessary API load
   - Given: Consecutive polls (1st, 2nd, 3rd, 4th)
   - Then: RequeueAfter values are 10s, 20s, 30s, 30s respectively (capped)
@@ -196,7 +196,7 @@ request lifecycle, so the submit → get-result pattern works without polling or
 ### 1.3 Session Lost and Regeneration
 
 - **UT-AA-064-008**: Session lost (404) -- first regeneration
-  - BR: BR-AA-HAPI-064.5
+  - BR: BR-AA-KA-064.5
   - Business Outcome: AA self-heals after HAPI restart by resubmitting investigation
   - Given: `InvestigationSession{ID: "session-1", Generation: 0}`
   - When: `PollSession()` returns 404
@@ -206,7 +206,7 @@ request lifecycle, so the submit → get-result pattern works without polling or
     - Result: `RequeueAfter: 0` (immediate resubmit)
     - Audit side effect: `auditClientSpy` recorded exactly 1 `holmesgpt.session_lost` event with `generation=1`
 - **UT-AA-064-009**: Session lost -- multiple regenerations under cap
-  - BR: BR-AA-HAPI-064.5
+  - BR: BR-AA-KA-064.5
   - Business Outcome: AA continues self-healing up to the regeneration limit
   - Given: `InvestigationSession{Generation: 3}`
   - When: `PollSession()` returns 404
@@ -214,7 +214,7 @@ request lifecycle, so the submit → get-result pattern works without polling or
     - CRD status: Generation=4, ID cleared
     - Result: `RequeueAfter: 0` (immediate resubmit, not failed)
 - **UT-AA-064-010**: Regeneration cap exceeded -- investigation fails with escalation
-  - BR: BR-AA-HAPI-064.6, DD-EVENT-001
+  - BR: BR-AA-KA-064.6, DD-EVENT-001
   - Business Outcome: After 5 failed session regenerations, AA escalates to operators via CRD status, K8s Warning Event, and escalation notification
   - Given: `InvestigationSession{Generation: 4}`
   - When: `PollSession()` returns 404 (incrementing Generation to 5)
@@ -249,15 +249,15 @@ request lifecycle, so the submit → get-result pattern works without polling or
 ### 1.5 Client Configuration Correctness
 
 - **UT-AA-064-014**: Async client constructor sets 30s timeout (not 10m workaround)
-  - BR: BR-AA-HAPI-064.10
-  - Business Outcome: All AA-HAPI HTTP calls are short-lived; the 10-minute blocking workaround is removed
+  - BR: BR-AA-KA-064.10
+  - Business Outcome: All AA-KA HTTP calls are short-lived; the 10-minute blocking workaround is removed
   - Given: `NewHolmesGPTClient()` constructed with async config
   - Then: `client.HTTPClient.Timeout == 30 * time.Second` (config value assertion, runs in milliseconds)
 
 ### 1.6 Recovery Submit/Poll Flow (Dedicated)
 
 - **UT-AA-064-015**: Recovery submit routes to recovery endpoint
-  - BR: BR-AA-HAPI-064.9
+  - BR: BR-AA-KA-064.9
   - Business Outcome: Recovery investigations use the dedicated recovery endpoint, not the incident endpoint
   - Given: AIAnalysis with `IsRecoveryAttempt=true`, nil InvestigationSession
   - When: `Handle()` called
@@ -265,14 +265,14 @@ request lifecycle, so the submit → get-result pattern works without polling or
     - `SubmitRecoveryInvestigation()` called (NOT `SubmitInvestigation`)
     - CRD status: InvestigationSession populated with session ID
 - **UT-AA-064-016**: Recovery poll completed -- recovery result fetched and processed
-  - BR: BR-AA-HAPI-064.9, BR-AA-HAPI-064.3
+  - BR: BR-AA-KA-064.9, BR-AA-KA-064.3
   - Business Outcome: Recovery investigation results are correctly processed through the recovery response path
   - Given: Recovery session with status=completed
   - When: `GetRecoverySessionResult()` returns RecoveryResponse
   - Then:
     - CRD status: Phase transitions correctly, RecoveryStatus populated
 - **UT-AA-064-017**: Recovery session lost -- same regeneration cap applies
-  - BR: BR-AA-HAPI-064.9, BR-AA-HAPI-064.5
+  - BR: BR-AA-KA-064.9, BR-AA-KA-064.5
   - Business Outcome: Recovery investigations have the same resilience guarantees as incident investigations
   - Given: Recovery session, `PollSession()` returns 404
   - Then: Same regeneration flow (Generation increment, cap at 5, escalation on exceed)
@@ -361,10 +361,10 @@ request lifecycle, so the submit → get-result pattern works without polling or
 
 ### 2.5 HTTP Endpoints (Recovery -- Dedicated)
 
-> **DEPRECATED for v1.0** (BR-AA-HAPI-064.9): Recovery endpoints are deprecated. These test scenarios are deferred until recovery is revisited.
+> **DEPRECATED for v1.0** (BR-AA-KA-064.9): Recovery endpoints are deprecated. These test scenarios are deferred until recovery is revisited.
 
 - **UT-HAPI-064-016**: ~~`POST /api/v1/recovery/analyze` returns 202 with session_id~~
-  - BR: BR-AA-HAPI-064.9
+  - BR: BR-AA-KA-064.9
   - Business Outcome: Recovery investigations use the same async pattern as incident investigations
   - Given: Valid RecoveryRequest body
   - Then: HTTP 202 Accepted, `{"session_id": "uuid"}`
@@ -392,7 +392,7 @@ request lifecycle, so the submit → get-result pattern works without polling or
 ### 3.1 Incident Flow + Audit Trace Validation
 
 - **IT-AA-064-001**: Full submit/poll/result happy path with real HAPI
-  - BR: BR-AA-HAPI-064.1, .2, .3, .4
+  - BR: BR-AA-KA-064.1, .2, .3, .4
   - Business Outcome: AA controller drives a complete async investigation lifecycle via CRD reconciliation
   - Given: envtest cluster, real HAPI (Mock LLM), AA controller running
   - When: AIAnalysis CRD created with Phase=Investigating
@@ -413,7 +413,7 @@ request lifecycle, so the submit → get-result pattern works without polling or
     - **Total AA events**: exactly 6
     - Each event validated: `correlationId`, `eventCategory="analysis"`, `eventAction`, `eventOutcome` per ADR-034
 - **IT-AA-064-003**: Session regeneration via simulated HAPI restart
-  - BR: BR-AA-HAPI-064.5, .7
+  - BR: BR-AA-KA-064.5, .7
   - Business Outcome: HAPI restart is transparent to the remediation pipeline -- controller self-heals and completes
   - Given: Session created, then Mock HAPI returns 404 for first poll (simulating restart), then normal on resubmit
   - Then:
@@ -432,7 +432,7 @@ request lifecycle, so the submit → get-result pattern works without polling or
     - `aianalysis.analysis.completed`: exactly 1
     - **Total AA events**: exactly 8
 - **IT-AA-064-005**: Audit trace exact counts -- regeneration cap exceeded (5 losses)
-  - BR: BR-AA-HAPI-064.6, BR-AUDIT-005
+  - BR: BR-AA-KA-064.6, BR-AUDIT-005
   - Business Outcome: Persistent HAPI instability failure path is fully auditable
   - Given: Mock HAPI returns 404 for every poll (5 consecutive losses)
   - Then: `countEventsByType` **exact** assertions:
@@ -443,7 +443,7 @@ request lifecycle, so the submit → get-result pattern works without polling or
     - **Total AA events**: exactly 11
     - CRD: Phase=Failed, SubReason="SessionRegenerationExceeded"
 - **IT-AA-064-006**: InvestigationSessionReady Condition lifecycle
-  - BR: BR-AA-HAPI-064.7
+  - BR: BR-AA-KA-064.7
   - Business Outcome: Operators can observe session health via standard K8s Conditions
   - Given: Full cycle with one session loss and regeneration
   - Then: Condition transitions verified at each stage:
@@ -454,16 +454,16 @@ request lifecycle, so the submit → get-result pattern works without polling or
 
 ### 3.2 Recovery Flow + Audit Trace Validation (Dedicated)
 
-> **DEPRECATED for v1.0** (BR-AA-HAPI-064.9): Recovery investigations are deprecated. These integration test scenarios are deferred.
+> **DEPRECATED for v1.0** (BR-AA-KA-064.9): Recovery investigations are deprecated. These integration test scenarios are deferred.
 
 - **IT-AA-064-007**: ~~Recovery submit/poll/result happy path~~
-  - BR: BR-AA-HAPI-064.9
+  - BR: BR-AA-KA-064.9
   - Business Outcome: Recovery investigations complete successfully using the async pattern
   - Given: AIAnalysis CRD with `IsRecoveryAttempt=true`
   - When: Controller reconciles
   - Then: Calls recovery endpoints (`/api/v1/recovery/analyze`, `/recovery/session/{id}`, `/recovery/session/{id}/result`), Phase reaches Completed
 - **IT-AA-064-008**: Recovery audit trace exact counts
-  - BR: BR-AA-HAPI-064.9, BR-AUDIT-005
+  - BR: BR-AA-KA-064.9, BR-AUDIT-005
   - Business Outcome: Recovery investigations produce the same audit completeness as incident investigations
   - Given: Full recovery submit/poll/result cycle
   - Then: `countEventsByType` **exact** assertions:
@@ -475,10 +475,10 @@ request lifecycle, so the submit → get-result pattern works without polling or
 
 CRD Events team completed issues #71-#73. These integration tests validate session lifecycle K8s events emitted by the InvestigatingHandler (via `WithRecorder`).
 
-**Location**: `test/integration/aianalysis/events_test.go` (within BR-AA-HAPI-064 session context)
+**Location**: `test/integration/aianalysis/events_test.go` (within BR-AA-KA-064 session context)
 
 - **IT-AA-064-01a**: SessionCreated on happy path
-  - BR: BR-AA-HAPI-064, DD-EVENT-001
+  - BR: BR-AA-KA-064, DD-EVENT-001
   - Business Outcome: Operators can observe that a HAPI session was created via K8s Events
   - Given: AIAnalysis CRD created, controller reconciles with `WithSessionMode()`
   - Then: Normal event with reason=`SessionCreated` emitted, message contains "session created"
@@ -506,7 +506,7 @@ CRD Events team completed issues #71-#73. These integration tests validate sessi
 ### 4.1 Incident Session Flow
 
 - **IT-HAPI-064-001**: Submit + poll + result via business logic
-  - BR: BR-AA-HAPI-064.1, .2, .3
+  - BR: BR-AA-KA-064.1, .2, .3
   - Business Outcome: HAPI processes an investigation asynchronously and produces a complete result
   - Given: Running HAPI with Mock LLM
   - When: Call `analyze_incident()` async (new session-based flow)
@@ -534,15 +534,15 @@ CRD Events team completed issues #71-#73. These integration tests validate sessi
 
 ### 4.2 Recovery Session Flow (Dedicated)
 
-> **DEPRECATED for v1.0** (BR-AA-HAPI-064.9): Recovery session endpoints are deprecated. These integration test scenarios are deferred.
+> **DEPRECATED for v1.0** (BR-AA-KA-064.9): Recovery session endpoints are deprecated. These integration test scenarios are deferred.
 
 - **IT-HAPI-064-005**: ~~Recovery submit + poll + result~~
-  - BR: BR-AA-HAPI-064.9
+  - BR: BR-AA-KA-064.9
   - Business Outcome: Recovery investigations work end-to-end through the async session pattern
   - Given: RecoveryRequest submitted
   - Then: Session created, background task calls recovery logic, result retrievable via recovery endpoint
 - **IT-HAPI-064-006**: Recovery session audit events emitted with exact counts
-  - BR: BR-AA-HAPI-064.9, BR-AUDIT-005
+  - BR: BR-AA-KA-064.9, BR-AUDIT-005
   - Business Outcome: Recovery audit trail is as complete as incident audit trail
   - Given: Full recovery session lifecycle
   - Then: After `audit_store.flush()`, **exact** assertions:
@@ -564,7 +564,7 @@ CRD Events team completed issues #71-#73. These integration tests validate sessi
 **Existing pattern reference**: `test/e2e/aianalysis/03_full_flow_test.go`, `test/e2e/aianalysis/suite_test.go`
 
 - **E2E-AA-064-001**: AA async submit/poll/result flow (incident)
-  - BR: BR-AA-HAPI-064.1 through .8
+  - BR: BR-AA-KA-064.1 through .8
   - Business Outcome: AA controller completes an async investigation in a real K8s environment
   - Given: Kind cluster with AA controller, DS, HAPI, Mock LLM deployed. No other controllers.
   - When: Test creates AIAnalysis CRD directly (no RO/Gateway)
@@ -585,62 +585,62 @@ CRD Events team completed issues #71-#73. These integration tests validate sessi
 #### Incident Session Endpoints (6 scenarios)
 
 - **E2E-HAPI-064-001**: Incident submit/poll/result for CrashLoopBackOff (happy path)
-  - BR: BR-AA-HAPI-064.1, .2, .3
+  - BR: BR-AA-KA-064.1, .2, .3
   - Business Outcome: Standard CrashLoopBackOff signal produces confident recommendation via async session
   - Endpoints: POST /incident/analyze (202), GET /incident/session/{id}, GET /incident/session/{id}/result
   - Assertions: session_id non-empty, status=completed, confidence ~0.88, needs_human_review=false
   - **Status**: Implemented
 - **E2E-HAPI-064-002**: Incident submit/poll/result for OOMKilled (happy path)
-  - BR: BR-AA-HAPI-064.1, .2, .3
+  - BR: BR-AA-KA-064.1, .2, .3
   - Business Outcome: OOMKilled signal produces confident recommendation via async session
   - Assertions: confidence ~0.88, needs_human_review=false
   - **Status**: Implemented
 - **E2E-HAPI-064-003**: No workflow found via session (MOCK_NO_WORKFLOW_FOUND)
-  - BR: BR-AA-HAPI-064.1, BR-HAPI-197
+  - BR: BR-AA-KA-064.1, BR-HAPI-197
   - Business Outcome: Escalation to human review with clear reason via session flow
   - Assertions: needs_human_review=true, human_review_reason=NoMatchingWorkflows, confidence=0, selected_workflow=nil
   - **Status**: Implemented
 - **E2E-HAPI-064-004**: Low confidence via session (MOCK_LOW_CONFIDENCE)
-  - BR: BR-AA-HAPI-064.1, BR-HAPI-197
+  - BR: BR-AA-KA-064.1, BR-HAPI-197
   - Business Outcome: Low-confidence recommendation returned for AA threshold evaluation
   - Assertions: needs_human_review=false (HAPI doesn't enforce thresholds), confidence <0.5, alternative_workflows present
   - **Status**: Implemented
 - **E2E-HAPI-064-005**: Max retries exhausted via session (MOCK_MAX_RETRIES_EXHAUSTED)
-  - BR: BR-AA-HAPI-064.1, BR-HAPI-197
+  - BR: BR-AA-KA-064.1, BR-HAPI-197
   - Business Outcome: Complete validation history for debugging after max retries
   - Assertions: needs_human_review=true, human_review_reason=LlmParsingError, 3 validation attempts, sequential attempt numbers
   - **Status**: Implemented
 - **E2E-HAPI-064-006**: Session status transitions observable during investigation
-  - BR: BR-AA-HAPI-064.2
+  - BR: BR-AA-KA-064.2
   - Business Outcome: Session status is queryable and reaches terminal state
   - Assertions: "completed" status observed (intermediate states may not be observable with Mock LLM speed)
   - **Status**: Implemented
 
 #### Recovery Session Endpoints (3 scenarios)
 
-> **DEPRECATED for v1.0** (BR-AA-HAPI-064.9): Recovery session E2E scenarios are deprecated and deferred.
+> **DEPRECATED for v1.0** (BR-AA-KA-064.9): Recovery session E2E scenarios are deprecated and deferred.
 
 - **E2E-HAPI-064-007**: ~~Recovery submit/poll/result happy path~~
-  - BR: BR-AA-HAPI-064.9
+  - BR: BR-AA-KA-064.9
   - Business Outcome: Recovery session endpoints work identically to incident endpoints
   - Endpoints: POST /recovery/analyze (202), GET /incident/session/{id}, GET /recovery/session/{id}/result
   - Assertions: can_recover=true, selected_workflow present, confidence ~0.85
   - **Status**: Implemented
 - **E2E-HAPI-064-008**: Recovery not reproducible via session (MOCK_NOT_REPRODUCIBLE)
-  - BR: BR-AA-HAPI-064.9, BR-HAPI-212
+  - BR: BR-AA-KA-064.9, BR-HAPI-212
   - Business Outcome: When issue self-resolved, recovery indicates no action needed
   - Assertions: can_recover=false, needs_human_review=false, selected_workflow=null, confidence ~0.85
   - **Status**: Implemented
 - **E2E-HAPI-064-009**: No recovery workflow found via session (MOCK_NO_WORKFLOW_FOUND)
-  - BR: BR-AA-HAPI-064.9, BR-HAPI-197
+  - BR: BR-AA-KA-064.9, BR-HAPI-197
   - Business Outcome: Escalation to human review when no recovery workflow available
   - Assertions: can_recover=true, needs_human_review=true, human_review_reason=NoMatchingWorkflows
   - **Status**: Implemented
 
 #### Complete Lifecycle (1 scenario)
 
-- **E2E-HAPI-064-010**: ~~Full incident then recovery via session endpoints~~ **DEPRECATED for v1.0** (BR-AA-HAPI-064.9)
-  - BR: BR-AA-HAPI-064.1, .9
+- **E2E-HAPI-064-010**: ~~Full incident then recovery via session endpoints~~ **DEPRECATED for v1.0** (BR-AA-KA-064.9)
+  - BR: BR-AA-KA-064.1, .9
   - ~~Business Outcome: End-to-end incident → recovery lifecycle using session endpoints~~
   - ~~Flow: Submit incident → poll → result → simulate failure → submit recovery → poll → result~~
   - ~~Assertions: both sessions complete, session IDs distinct, recovery selects workflow~~
@@ -649,12 +649,12 @@ CRD Events team completed issues #71-#73. These integration tests validate sessi
 #### Session Error Handling (2 scenarios)
 
 - **E2E-HAPI-064-011**: Poll non-existent session returns 404
-  - BR: BR-AA-HAPI-064.2, BR-AA-HAPI-064.5
+  - BR: BR-AA-KA-064.2, BR-AA-KA-064.5
   - Business Outcome: Invalid session IDs return clear HTTP 404 errors
   - Assertions: APIError with StatusCode=404
   - **Status**: Implemented
 - **E2E-HAPI-064-012**: Result for non-existent session returns 404
-  - BR: BR-AA-HAPI-064.3
+  - BR: BR-AA-KA-064.3
   - Business Outcome: Result retrieval for invalid sessions returns clear HTTP 404 errors
   - Assertions: APIError with StatusCode=404
   - **Status**: Implemented
@@ -719,16 +719,16 @@ Mock LLM itself does not need session endpoints (HAPI manages sessions internall
 
 | BR Requirement                              | Unit Scenarios                  | Integration Scenarios                | E2E Scenarios |
 | ------------------------------------------- | ------------------------------- | ------------------------------------ | ------------- |
-| BR-AA-HAPI-064.1 (Async Submit)             | AA-001, 002, 015                | AA-001, 007                          | AA-001        |
-| BR-AA-HAPI-064.2 (Session Polling)          | AA-003, 004, 005, 006, 007      | AA-001, 006                          | AA-001        |
-| BR-AA-HAPI-064.3 (Result Retrieval)         | AA-005, 016                     | AA-001, 007                          | AA-001        |
-| BR-AA-HAPI-064.4 (InvestigationSession CRD) | AA-001, 002                     | AA-001                               | AA-001        |
-| BR-AA-HAPI-064.5 (Regeneration)             | AA-002, 008, 009, 017           | AA-003, 004                          | -             |
-| BR-AA-HAPI-064.6 (Regeneration Cap)         | AA-010                          | AA-005                               | -             |
-| BR-AA-HAPI-064.7 (Condition)                | AA-001                          | AA-006                               | -             |
-| BR-AA-HAPI-064.8 (Requeue Backoff)          | AA-003, 004, 007                | AA-001                               | AA-001        |
-| BR-AA-HAPI-064.9 (Recovery)                 | AA-015, 016, 017                | AA-007, 008                          | AA-003        |
-| BR-AA-HAPI-064.10 (Timeout Removal)         | AA-014                          | -                                    | AA-001        |
+| BR-AA-KA-064.1 (Async Submit)             | AA-001, 002, 015                | AA-001, 007                          | AA-001        |
+| BR-AA-KA-064.2 (Session Polling)          | AA-003, 004, 005, 006, 007      | AA-001, 006                          | AA-001        |
+| BR-AA-KA-064.3 (Result Retrieval)         | AA-005, 016                     | AA-001, 007                          | AA-001        |
+| BR-AA-KA-064.4 (InvestigationSession CRD) | AA-001, 002                     | AA-001                               | AA-001        |
+| BR-AA-KA-064.5 (Regeneration)             | AA-002, 008, 009, 017           | AA-003, 004                          | -             |
+| BR-AA-KA-064.6 (Regeneration Cap)         | AA-010                          | AA-005                               | -             |
+| BR-AA-KA-064.7 (Condition)                | AA-001                          | AA-006                               | -             |
+| BR-AA-KA-064.8 (Requeue Backoff)          | AA-003, 004, 007                | AA-001                               | AA-001        |
+| BR-AA-KA-064.9 (Recovery)                 | AA-015, 016, 017                | AA-007, 008                          | AA-003        |
+| BR-AA-KA-064.10 (Timeout Removal)         | AA-014                          | -                                    | AA-001        |
 | BR-AUDIT-005 (Audit Traces)                 | AA-001, 005, 008 (side effects) | AA-002, 004, 005, 008; HAPI-003, 006 | AA-002        |
 
 ---
@@ -759,7 +759,7 @@ Mock LLM itself does not need session endpoints (HAPI manages sessions internall
 
 ## References
 
-- [BR-AA-HAPI-064](../../../docs/requirements/BR-AA-HAPI-064-session-based-pull-design.md)
+- [BR-AA-KA-064](../../../docs/requirements/BR-AA-KA-064-session-based-pull-design.md)
 - [DD-AA-HAPI-064](../../../docs/architecture/decisions/DD-AA-HAPI-064-session-based-pull-design.md)
 - [DD-EVENT-001](../../../docs/architecture/decisions/DD-EVENT-001-controller-event-registry.md)
 - [TESTING_GUIDELINES.md](../../development/business-requirements/TESTING_GUIDELINES.md)

--- a/docs/testing/DD-EVENT-001/TP-EVENT-AA.md
+++ b/docs/testing/DD-EVENT-001/TP-EVENT-AA.md
@@ -6,7 +6,7 @@
 **Author**: AI Assistant
 **Status**: Draft
 **Issue**: #72 (our events), #73 (session events, implemented)
-**BR**: BR-AA-095, BR-AA-HAPI-064.6 (session events)
+**BR**: BR-AA-095, BR-AA-KA-064.6 (session events)
 **DD**: DD-EVENT-001 v1.1
 
 ---
@@ -59,9 +59,9 @@
 | BR-AA-095 | Happy path event trail | Integration | IT-AA-095-01 | ⏸️ Pending |
 | BR-AA-095 | Investigation failure event trail | Integration | IT-AA-095-02 | ⏸️ Pending |
 | BR-AA-095 | Human review event trail | Integration | IT-AA-095-03 | ⏸️ Pending |
-| BR-AA-HAPI-064 | SessionCreated on happy path | Integration | IT-AA-064-01a | ✅ Implemented |
-| BR-AA-HAPI-064 | SessionLost on stale session (404) | Integration | IT-AA-064-01b | ✅ Implemented |
-| BR-AA-HAPI-064.6 | SessionRegenerationExceeded on cap | Integration | IT-AA-064-01c | ✅ Implemented |
+| BR-AA-KA-064 | SessionCreated on happy path | Integration | IT-AA-064-01a | ✅ Implemented |
+| BR-AA-KA-064 | SessionLost on stale session (404) | Integration | IT-AA-064-01b | ✅ Implemented |
+| BR-AA-KA-064.6 | SessionRegenerationExceeded on cap | Integration | IT-AA-064-01c | ✅ Implemented |
 
 ---
 
@@ -226,7 +226,7 @@
 
 ## 5. Session Event Tests (Implemented)
 
-Originally delegated to the Issue #64 team, these tests were implemented by the current team. They map to BR-AA-HAPI-064.6 and the existing test plan at `docs/testing/BR-AA-HAPI-064/session_based_pull_test_plan_v1.0.md`.
+Originally delegated to the Issue #64 team, these tests were implemented by the current team. They map to BR-AA-KA-064.6 and the existing test plan at `docs/testing/BR-AA-KA-064/session_based_pull_test_plan_v1.0.md`.
 
 ### Unit Tests
 
@@ -246,7 +246,7 @@ Originally delegated to the Issue #64 team, these tests were implemented by the 
 | IT-AA-064-01b | SessionLost + SessionCreated | Stale session (404) triggers Warning + regeneration with new SessionCreated | Implemented |
 | IT-AA-064-01c | SessionLost + SessionRegenerationExceeded | Cap reached: Warning events emitted, AA transitions to Failed | Implemented |
 
-**File**: `test/integration/aianalysis/events_test.go` (within BR-AA-HAPI-064 session context)
+**File**: `test/integration/aianalysis/events_test.go` (within BR-AA-KA-064 session context)
 
 ---
 

--- a/docs/tests/1351/TEST_PLAN.md
+++ b/docs/tests/1351/TEST_PLAN.md
@@ -156,13 +156,13 @@ E2E proves journey --> Interactive takeover → select_workflow → AA poll → 
 | UT-AA-1351-001 | BR-ORCH-027 AC-1 | CP-10 | `handleSessionPollUserDriving` enforces `maxInvestigationDuration` | `PhaseFailed` after 25m even in `user_driving` |
 | UT-AA-1351-002 | BR-ORCH-027 | CP-10 | `user_driving` timeout sets `Reason`, `SubReason`, and `SetInvestigationComplete` | All terminal fields populated consistently |
 | UT-AA-1351-003 | BR-AI-009 | CP-10 | `ConsecutiveFailures` reset to 0 on successful poll | Intermittent errors don't accumulate across successes |
-| UT-AA-1351-004 | BR-AA-HAPI-064.5 | CP-10 | `GetSessionResult` 404 triggers session regeneration (like poll 404) | `handleSessionLost` called, not `handleError` |
+| UT-AA-1351-004 | BR-AA-KA-064.5 | CP-10 | `GetSessionResult` 404 triggers session regeneration (like poll 404) | `handleSessionLost` called, not `handleError` |
 | UT-AA-1351-005 | BR-INTERACTIVE-010 SC-7.2 | SI-2 | `handleSessionPollCancelled` requeues on IS check error | Transient API error → `RequeueAfter` (not terminal) |
 | UT-AA-1351-006 | BR-ORCH-028 | SI-2 | AA communicates timeout cap to RO-compatible boundary | `maxInvestigationDuration` wired from config |
 | UT-AA-1351-007 | BR-AI-009 | SI-2 | `InvestigationTime > 0` with `Phase=Investigating` triggers recovery (not skip) | Handler requeues or re-evaluates instead of returning empty |
 | UT-AA-1351-008 | BR-HAPI-197 | AU-2 | `handleSessionPollFailed` sets `Reason=InvestigationFailed` and `SubReason` | No stale retry metadata on terminal status |
 | UT-AA-1351-009 | BR-ORCH-027 | SI-2 | Timeout path calls `SetInvestigationComplete(false, ...)` | `InvestigationComplete` condition consistent with `PhaseFailed` |
-| UT-AA-1351-010 | BR-AA-HAPI-064 | CP-10 | 409 on `GetSessionResult` has bounded retry (cap at N attempts) | Does not re-poll indefinitely; fails after cap |
+| UT-AA-1351-010 | BR-AA-KA-064 | CP-10 | 409 on `GetSessionResult` has bounded retry (cap at N attempts) | Does not re-poll indefinitely; fails after cap |
 | UT-AA-1351-011 | DD-EVENT-001 | AU-2 | `user_driving` event emission rate-limited (not every 15s) | Max 1 event per 5-minute window (or similar) |
 
 ### 5.3 AF Tier 1: Unit Tests — Prove Logic

--- a/docs/tests/433/TP-433-PARITY.md
+++ b/docs/tests/433/TP-433-PARITY.md
@@ -102,7 +102,7 @@ TP-433 (119 scenarios) covers the Go Kubernaut Agent rewrite core: engine, inves
 
 ### 4.2 Features Not to be Tested
 
-- **Session HTTP semantics** (BR-AA-HAPI-064): E2E-tier per TESTING_GUIDELINES; existing E2E-KA-433-003..005 cover 202/404/409
+- **Session HTTP semantics** (BR-AA-KA-064): E2E-tier per TESTING_GUIDELINES; existing E2E-KA-433-003..005 cover 202/404/409
 - **Workflow security gate** (BR-HAPI-017-003): Tested in Data Storage ITs (`IT-DS-017-*`); KA delegates to DS
 - **Three-step discovery pagination** (BR-HAPI-017-001): Tested in DS ITs; KA tools forward to DS
 - **Conversation continuity** (BR-HAPI-263): Two-invocation architecture is intentional -- Phase 3 starts fresh with injected RCA summary per `phase3_workflow_selection.tmpl` header

--- a/internal/config/aianalysis/config.go
+++ b/internal/config/aianalysis/config.go
@@ -64,7 +64,7 @@ type AgentConfig struct {
 	Timeout time.Duration `yaml:"timeout"`
 
 	// SessionPollInterval is the constant interval between session status polls.
-	// BR-AA-HAPI-064.8: Polling is normal async behavior, not error recovery.
+	// BR-AA-KA-064.8: Polling is normal async behavior, not error recovery.
 	// Default: 15s. Range: [1s, 5m].
 	SessionPollInterval time.Duration `yaml:"sessionPollInterval"`
 }

--- a/internal/controller/aianalysis/aianalysis_controller.go
+++ b/internal/controller/aianalysis/aianalysis_controller.go
@@ -139,7 +139,7 @@ func (r *AIAnalysisReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
 
-	// AA-HAPI-001: Log reconcile state for debugging duplicate call issues
+	// AA-KA-001: Log reconcile state for debugging duplicate call issues
 	log.V(1).Info("Reconcile state",
 		"phase", analysis.Status.Phase,
 		"generation", analysis.Generation,

--- a/internal/controller/aianalysis/phase_handlers.go
+++ b/internal/controller/aianalysis/phase_handlers.go
@@ -146,7 +146,7 @@ func (r *AIAnalysisReconciler) runInvestigatingHandler(ctx context.Context, anal
 
 	// AA-BUG-009: Enhanced idempotency - skip handler if phase already changed OR already executed
 	if outcome.phaseBefore != PhaseInvestigating {
-		log.Info("AA-HAPI-001: Phase already changed, skipping handler",
+		log.Info("AA-KA-001: Phase already changed, skipping handler",
 			"expected", PhaseInvestigating, "actual", outcome.phaseBefore,
 			"observedGeneration", analysis.Status.ObservedGeneration)
 		outcome.handlerExecuted = false
@@ -156,7 +156,7 @@ func (r *AIAnalysisReconciler) runInvestigatingHandler(ctx context.Context, anal
 	if analysis.Status.InvestigationTime > 0 {
 		hasActiveSession := analysis.Status.KASession != nil && analysis.Status.KASession.ID != ""
 		if !hasActiveSession {
-			log.Info("AA-HAPI-001: Handler already executed, skipping duplicate call",
+			log.Info("AA-KA-001: Handler already executed, skipping duplicate call",
 				"investigationTime", analysis.Status.InvestigationTime,
 				"phase", outcome.phaseBefore)
 			outcome.handlerExecuted = false

--- a/internal/kubernautagent/api/openapi.json
+++ b/internal/kubernautagent/api/openapi.json
@@ -12,7 +12,7 @@
           "Incident Analysis"
         ],
         "summary": "Incident Analyze Endpoint",
-        "description": "Submit incident analysis request (async session-based pattern).\n\nBusiness Requirement: BR-KA-002 (Incident analysis endpoint)\nBusiness Requirement: BR-AA-HAPI-064.1 (Async submit returns session ID)\nDesign Decision: DD-AUTH-006 (User attribution for LLM cost tracking)\n\nCalled by: AIAnalysis Controller via SubmitInvestigation()\n\nReturns HTTP 202 Accepted with {\"session_id\": \"<uuid>\"}.\nThe investigation runs as a background task. Poll via GET /incident/session/{id}.",
+        "description": "Submit incident analysis request (async session-based pattern).\n\nBusiness Requirement: BR-KA-002 (Incident analysis endpoint)\nBusiness Requirement: BR-AA-KA-064.1 (Async submit returns session ID)\nDesign Decision: DD-AUTH-006 (User attribution for LLM cost tracking)\n\nCalled by: AIAnalysis Controller via SubmitInvestigation()\n\nReturns HTTP 202 Accepted with {\"session_id\": \"<uuid>\"}.\nThe investigation runs as a background task. Poll via GET /incident/session/{id}.",
         "operationId": "incident_analyze_endpoint_api_v1_incident_analyze_post",
         "requestBody": {
           "content": {
@@ -369,7 +369,7 @@
           "Incident Analysis"
         ],
         "summary": "Incident Session Status Endpoint",
-        "description": "Poll session status. BR-AA-HAPI-064.2.",
+        "description": "Poll session status. BR-AA-KA-064.2.",
         "operationId": "incident_session_status_endpoint_api_v1_incident_session__session_id__get",
         "parameters": [
           {
@@ -432,7 +432,7 @@
           "Incident Analysis"
         ],
         "summary": "Incident Session Result Endpoint",
-        "description": "Retrieve completed investigation result. BR-AA-HAPI-064.3.",
+        "description": "Retrieve completed investigation result. BR-AA-KA-064.3.",
         "operationId": "incident_session_result_endpoint_api_v1_incident_session__session_id__result_get",
         "parameters": [
           {

--- a/pkg/agentclient/client.go
+++ b/pkg/agentclient/client.go
@@ -125,7 +125,7 @@ func NewKubernautAgentClientWithTransport(cfg Config, transport http.RoundTrippe
 //   - *IncidentResponse: Successful response with AI analysis
 //   - *APIError: HTTP error (4xx, 5xx)
 func (c *KubernautAgentClient) Investigate(ctx context.Context, req *IncidentRequest) (*IncidentResponse, error) {
-	// BR-AA-HAPI-064: KA endpoints are async-only (202 Accepted).
+	// BR-AA-KA-064: KA endpoints are async-only (202 Accepted).
 	// This sync wrapper internally does submit -> poll -> get result,
 	// providing backward-compatible API for callers that don't need
 	// explicit session management (e.g., integration tests, one-shot callers).
@@ -147,7 +147,7 @@ func (c *KubernautAgentClient) Investigate(ctx context.Context, req *IncidentReq
 // The poll interval is 1s, bounded by the ctx deadline. Transient 429 (rate-limited)
 // responses are retried with a 2s back-off rather than failing immediately.
 //
-// BR-AA-HAPI-064: Internal helper for sync-over-async wrapping.
+// BR-AA-KA-064: Internal helper for sync-over-async wrapping.
 func (c *KubernautAgentClient) awaitSession(ctx context.Context, sessionID string) error {
 	for {
 		result, err := c.PollSession(ctx, sessionID)
@@ -178,7 +178,7 @@ func (c *KubernautAgentClient) awaitSession(ctx context.Context, sessionID strin
 }
 
 // ========================================
-// SESSION TYPES (BR-AA-HAPI-064)
+// SESSION TYPES (BR-AA-KA-064)
 // ========================================
 
 // SessionStatusResult represents the status of an investigation session.
@@ -201,12 +201,12 @@ type SessionStatusResult struct {
 }
 
 // ========================================
-// ASYNC SESSION METHODS (BR-AA-HAPI-064)
+// ASYNC SESSION METHODS (BR-AA-KA-064)
 // DD-KA-003: All session methods now use the generated OpenAPI client.
 // ========================================
 
 // SubmitInvestigation submits an incident investigation request and returns a session ID.
-// BR-AA-HAPI-064.1: POST /api/v1/incident/analyze returns 202 with session_id
+// BR-AA-KA-064.1: POST /api/v1/incident/analyze returns 202 with session_id
 // DD-KA-003: Delegates to generated client for OTel tracing and type-safe dispatch.
 func (c *KubernautAgentClient) SubmitInvestigation(ctx context.Context, req *IncidentRequest) (string, error) {
 	res, err := c.client.IncidentAnalyzeEndpointAPIV1IncidentAnalyzePost(ctx, req)
@@ -237,8 +237,8 @@ func (c *KubernautAgentClient) SubmitInvestigation(ctx context.Context, req *Inc
 }
 
 // PollSession polls the status of an investigation session.
-// BR-AA-HAPI-064.2: GET /api/v1/incident/session/{id}
-// Returns *APIError{StatusCode: 404} when session not found (BR-AA-HAPI-064.5 regeneration trigger).
+// BR-AA-KA-064.2: GET /api/v1/incident/session/{id}
+// Returns *APIError{StatusCode: 404} when session not found (BR-AA-KA-064.5 regeneration trigger).
 func (c *KubernautAgentClient) PollSession(ctx context.Context, sessionID string) (*SessionStatusResult, error) {
 	res, err := c.client.IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet(ctx,
 		IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetParams{SessionID: sessionID})
@@ -268,7 +268,7 @@ func (c *KubernautAgentClient) PollSession(ctx context.Context, sessionID string
 }
 
 // GetSessionResult retrieves the result of a completed incident investigation session.
-// BR-AA-HAPI-064.3: GET /api/v1/incident/session/{id}/result
+// BR-AA-KA-064.3: GET /api/v1/incident/session/{id}/result
 func (c *KubernautAgentClient) GetSessionResult(ctx context.Context, sessionID string) (*IncidentResponse, error) {
 	res, err := c.client.IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGet(ctx,
 		IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetParams{SessionID: sessionID})

--- a/pkg/agentclient/oas_client_gen.go
+++ b/pkg/agentclient/oas_client_gen.go
@@ -38,7 +38,7 @@ type Invoker interface {
 	//
 	// Submit incident analysis request (async session-based pattern).
 	// Business Requirement: BR-KA-002 (Incident analysis endpoint)
-	// Business Requirement: BR-AA-HAPI-064.1 (Async submit returns session ID)
+	// Business Requirement: BR-AA-KA-064.1 (Async submit returns session ID)
 	// Design Decision: DD-AUTH-006 (User attribution for LLM cost tracking)
 	// Called by: AIAnalysis Controller via SubmitInvestigation()
 	// Returns HTTP 202 Accepted with {"session_id": "<uuid>"}.
@@ -48,13 +48,13 @@ type Invoker interface {
 	IncidentAnalyzeEndpointAPIV1IncidentAnalyzePost(ctx context.Context, request *IncidentRequest) (IncidentAnalyzeEndpointAPIV1IncidentAnalyzePostRes, error)
 	// IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGet invokes incident_session_result_endpoint_api_v1_incident_session__session_id__result_get operation.
 	//
-	// Retrieve completed investigation result. BR-AA-HAPI-064.3.
+	// Retrieve completed investigation result. BR-AA-KA-064.3.
 	//
 	// GET /api/v1/incident/session/{session_id}/result
 	IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGet(ctx context.Context, params IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetParams) (IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetRes, error)
 	// IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet invokes incident_session_status_endpoint_api_v1_incident_session__session_id__get operation.
 	//
-	// Poll session status. BR-AA-HAPI-064.2.
+	// Poll session status. BR-AA-KA-064.2.
 	//
 	// GET /api/v1/incident/session/{session_id}
 	IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet(ctx context.Context, params IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetParams) (IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetRes, error)
@@ -211,7 +211,7 @@ func (c *Client) sendCancelSessionAPIV1IncidentSessionSessionIDCancelPost(ctx co
 //
 // Submit incident analysis request (async session-based pattern).
 // Business Requirement: BR-KA-002 (Incident analysis endpoint)
-// Business Requirement: BR-AA-HAPI-064.1 (Async submit returns session ID)
+// Business Requirement: BR-AA-KA-064.1 (Async submit returns session ID)
 // Design Decision: DD-AUTH-006 (User attribution for LLM cost tracking)
 // Called by: AIAnalysis Controller via SubmitInvestigation()
 // Returns HTTP 202 Accepted with {"session_id": "<uuid>"}.
@@ -292,7 +292,7 @@ func (c *Client) sendIncidentAnalyzeEndpointAPIV1IncidentAnalyzePost(ctx context
 
 // IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGet invokes incident_session_result_endpoint_api_v1_incident_session__session_id__result_get operation.
 //
-// Retrieve completed investigation result. BR-AA-HAPI-064.3.
+// Retrieve completed investigation result. BR-AA-KA-064.3.
 //
 // GET /api/v1/incident/session/{session_id}/result
 func (c *Client) IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGet(ctx context.Context, params IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetParams) (IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetRes, error) {
@@ -385,7 +385,7 @@ func (c *Client) sendIncidentSessionResultEndpointAPIV1IncidentSessionSessionIDR
 
 // IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet invokes incident_session_status_endpoint_api_v1_incident_session__session_id__get operation.
 //
-// Poll session status. BR-AA-HAPI-064.2.
+// Poll session status. BR-AA-KA-064.2.
 //
 // GET /api/v1/incident/session/{session_id}
 func (c *Client) IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet(ctx context.Context, params IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetParams) (IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetRes, error) {

--- a/pkg/agentclient/oas_handlers_gen.go
+++ b/pkg/agentclient/oas_handlers_gen.go
@@ -181,7 +181,7 @@ func (s *Server) handleCancelSessionAPIV1IncidentSessionSessionIDCancelPostReque
 //
 // Submit incident analysis request (async session-based pattern).
 // Business Requirement: BR-KA-002 (Incident analysis endpoint)
-// Business Requirement: BR-AA-HAPI-064.1 (Async submit returns session ID)
+// Business Requirement: BR-AA-KA-064.1 (Async submit returns session ID)
 // Design Decision: DD-AUTH-006 (User attribution for LLM cost tracking)
 // Called by: AIAnalysis Controller via SubmitInvestigation()
 // Returns HTTP 202 Accepted with {"session_id": "<uuid>"}.
@@ -328,7 +328,7 @@ func (s *Server) handleIncidentAnalyzeEndpointAPIV1IncidentAnalyzePostRequest(ar
 
 // handleIncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetRequest handles incident_session_result_endpoint_api_v1_incident_session__session_id__result_get operation.
 //
-// Retrieve completed investigation result. BR-AA-HAPI-064.3.
+// Retrieve completed investigation result. BR-AA-KA-064.3.
 //
 // GET /api/v1/incident/session/{session_id}/result
 func (s *Server) handleIncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {
@@ -471,7 +471,7 @@ func (s *Server) handleIncidentSessionResultEndpointAPIV1IncidentSessionSessionI
 
 // handleIncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetRequest handles incident_session_status_endpoint_api_v1_incident_session__session_id__get operation.
 //
-// Poll session status. BR-AA-HAPI-064.2.
+// Poll session status. BR-AA-KA-064.2.
 //
 // GET /api/v1/incident/session/{session_id}
 func (s *Server) handleIncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetRequest(args [1]string, argsEscaped bool, w http.ResponseWriter, r *http.Request) {

--- a/pkg/agentclient/oas_server_gen.go
+++ b/pkg/agentclient/oas_server_gen.go
@@ -19,7 +19,7 @@ type Handler interface {
 	//
 	// Submit incident analysis request (async session-based pattern).
 	// Business Requirement: BR-KA-002 (Incident analysis endpoint)
-	// Business Requirement: BR-AA-HAPI-064.1 (Async submit returns session ID)
+	// Business Requirement: BR-AA-KA-064.1 (Async submit returns session ID)
 	// Design Decision: DD-AUTH-006 (User attribution for LLM cost tracking)
 	// Called by: AIAnalysis Controller via SubmitInvestigation()
 	// Returns HTTP 202 Accepted with {"session_id": "<uuid>"}.
@@ -29,13 +29,13 @@ type Handler interface {
 	IncidentAnalyzeEndpointAPIV1IncidentAnalyzePost(ctx context.Context, req *IncidentRequest) (IncidentAnalyzeEndpointAPIV1IncidentAnalyzePostRes, error)
 	// IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGet implements incident_session_result_endpoint_api_v1_incident_session__session_id__result_get operation.
 	//
-	// Retrieve completed investigation result. BR-AA-HAPI-064.3.
+	// Retrieve completed investigation result. BR-AA-KA-064.3.
 	//
 	// GET /api/v1/incident/session/{session_id}/result
 	IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGet(ctx context.Context, params IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetParams) (IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetRes, error)
 	// IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet implements incident_session_status_endpoint_api_v1_incident_session__session_id__get operation.
 	//
-	// Poll session status. BR-AA-HAPI-064.2.
+	// Poll session status. BR-AA-KA-064.2.
 	//
 	// GET /api/v1/incident/session/{session_id}
 	IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet(ctx context.Context, params IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetParams) (IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetRes, error)

--- a/pkg/agentclient/oas_unimplemented_gen.go
+++ b/pkg/agentclient/oas_unimplemented_gen.go
@@ -27,7 +27,7 @@ func (UnimplementedHandler) CancelSessionAPIV1IncidentSessionSessionIDCancelPost
 //
 // Submit incident analysis request (async session-based pattern).
 // Business Requirement: BR-KA-002 (Incident analysis endpoint)
-// Business Requirement: BR-AA-HAPI-064.1 (Async submit returns session ID)
+// Business Requirement: BR-AA-KA-064.1 (Async submit returns session ID)
 // Design Decision: DD-AUTH-006 (User attribution for LLM cost tracking)
 // Called by: AIAnalysis Controller via SubmitInvestigation()
 // Returns HTTP 202 Accepted with {"session_id": "<uuid>"}.
@@ -40,7 +40,7 @@ func (UnimplementedHandler) IncidentAnalyzeEndpointAPIV1IncidentAnalyzePost(ctx 
 
 // IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGet implements incident_session_result_endpoint_api_v1_incident_session__session_id__result_get operation.
 //
-// Retrieve completed investigation result. BR-AA-HAPI-064.3.
+// Retrieve completed investigation result. BR-AA-KA-064.3.
 //
 // GET /api/v1/incident/session/{session_id}/result
 func (UnimplementedHandler) IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGet(ctx context.Context, params IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetParams) (r IncidentSessionResultEndpointAPIV1IncidentSessionSessionIDResultGetRes, _ error) {
@@ -49,7 +49,7 @@ func (UnimplementedHandler) IncidentSessionResultEndpointAPIV1IncidentSessionSes
 
 // IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet implements incident_session_status_endpoint_api_v1_incident_session__session_id__get operation.
 //
-// Poll session status. BR-AA-HAPI-064.2.
+// Poll session status. BR-AA-KA-064.2.
 //
 // GET /api/v1/incident/session/{session_id}
 func (UnimplementedHandler) IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGet(ctx context.Context, params IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetParams) (r IncidentSessionStatusEndpointAPIV1IncidentSessionSessionIDGetRes, _ error) {

--- a/pkg/aianalysis/agentclient_session_test.go
+++ b/pkg/aianalysis/agentclient_session_test.go
@@ -29,9 +29,9 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/agentclient"
 )
 
-// BR-AA-HAPI-064: Session-based async pull communication unit tests for AgentClient.
+// BR-AA-KA-064: Session-based async pull communication unit tests for AgentClient.
 // These tests verify the HTTP-level behavior of the 5 session methods using httptest.NewServer.
-var _ = Describe("AgentClient Session Methods [BR-AA-HAPI-064]", func() {
+var _ = Describe("AgentClient Session Methods [BR-AA-KA-064]", func() {
 	var (
 		mockServer *httptest.Server
 		hgClient   *agentclient.KubernautAgentClient

--- a/pkg/aianalysis/agentclient_test.go
+++ b/pkg/aianalysis/agentclient_test.go
@@ -54,7 +54,7 @@ var _ = Describe("AgentClient", func() {
 
 	Describe("Investigate", func() {
 		// BR-AI-006: Successful API call (via session flow)
-		// BR-AA-HAPI-064: Investigate() wraps submit -> poll -> result internally
+		// BR-AA-KA-064: Investigate() wraps submit -> poll -> result internally
 		Context("with successful response", func() {
 			BeforeEach(func() {
 				mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -195,7 +195,7 @@ var _ = Describe("AgentClient", func() {
 			})
 		})
 
-		// BR-AA-HAPI-064: awaitSession returns error when session fails server-side
+		// BR-AA-KA-064: awaitSession returns error when session fails server-side
 		Context("with session that fails during investigation", func() {
 			BeforeEach(func() {
 				mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -238,7 +238,7 @@ var _ = Describe("AgentClient", func() {
 			})
 		})
 
-		// BR-AA-HAPI-064: awaitSession respects context cancellation
+		// BR-AA-KA-064: awaitSession respects context cancellation
 		Context("with context cancelled during polling", func() {
 			BeforeEach(func() {
 				mockServer = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/aianalysis/audit/audit.go
+++ b/pkg/aianalysis/audit/audit.go
@@ -43,7 +43,7 @@ const (
 	EventTypeRegoEvaluation    = "aianalysis.rego.evaluation"
 	EventTypeError             = "aianalysis.error.occurred"
 
-	// Session audit event types (BR-AA-HAPI-064)
+	// Session audit event types (BR-AA-KA-064)
 	EventTypeAIAgentSubmit      = "aianalysis.aiagent.submit"
 	EventTypeAIAgentResult      = "aianalysis.aiagent.result"
 	EventTypeAIAgentSessionLost = "aianalysis.aiagent.session_lost"
@@ -443,12 +443,12 @@ func determineNeedsHumanReview(analysis *aianalysisv1.AIAnalysis) bool {
 }
 
 // ========================================
-// SESSION AUDIT METHODS (BR-AA-HAPI-064)
+// SESSION AUDIT METHODS (BR-AA-KA-064)
 // Stubs for async submit/poll audit events - implementation in GREEN phase
 // ========================================
 
 // RecordAIAgentSubmit records an async KA submit event with session ID.
-// BR-AA-HAPI-064: Audit trail for session creation
+// BR-AA-KA-064: Audit trail for session creation
 func (c *AuditClient) RecordAIAgentSubmit(ctx context.Context, analysis *aianalysisv1.AIAnalysis, sessionID string) {
 	payload := ogenclient.AIAnalysisAIAgentCallPayload{
 		Endpoint:       "session_submit",
@@ -473,7 +473,7 @@ func (c *AuditClient) RecordAIAgentSubmit(ctx context.Context, analysis *aianaly
 }
 
 // RecordAIAgentResult records an async KA result retrieval with investigation time.
-// BR-AA-HAPI-064: Audit trail for result retrieval.
+// BR-AA-KA-064: Audit trail for result retrieval.
 //
 // For backward compatibility with existing audit tests (DD-AUDIT-003), this also
 // emits an EventTypeAIAgentCall event, which is the sync-era equivalent of
@@ -508,7 +508,7 @@ func (c *AuditClient) RecordAIAgentResult(ctx context.Context, analysis *aianaly
 }
 
 // RecordAIAgentSessionLost records a session lost event with generation count.
-// BR-AA-HAPI-064: Audit trail for session regeneration
+// BR-AA-KA-064: Audit trail for session regeneration
 func (c *AuditClient) RecordAIAgentSessionLost(ctx context.Context, analysis *aianalysisv1.AIAnalysis, generation int32) {
 	payload := ogenclient.AIAnalysisAIAgentCallPayload{
 		Endpoint:       "session_lost",

--- a/pkg/aianalysis/conditions.go
+++ b/pkg/aianalysis/conditions.go
@@ -41,7 +41,7 @@ const (
 	ConditionApprovalRequired = "ApprovalRequired"
 
 	// ConditionInvestigationSessionReady indicates the KA session health
-	// BR-AA-HAPI-064.7: Operators can observe session health via standard K8s Conditions
+	// BR-AA-KA-064.7: Operators can observe session health via standard K8s Conditions
 	ConditionInvestigationSessionReady = "InvestigationSessionReady"
 )
 
@@ -95,7 +95,7 @@ const (
 	ReasonPolicyRequiresApproval = "PolicyRequiresApproval"
 
 	// ========================================
-	// Session-related reasons (BR-AA-HAPI-064)
+	// Session-related reasons (BR-AA-KA-064)
 	// ========================================
 
 	// ReasonSessionCreated - KA session was created successfully
@@ -182,7 +182,7 @@ func SetApprovalRequired(analysis *aianalysisv1.AIAnalysis, required bool, reaso
 }
 
 // SetInvestigationSessionReady sets the InvestigationSessionReady condition
-// BR-AA-HAPI-064.7: Operators can observe session health via standard K8s Conditions
+// BR-AA-KA-064.7: Operators can observe session health via standard K8s Conditions
 func SetInvestigationSessionReady(analysis *aianalysisv1.AIAnalysis, ready bool, reason, message string) {
 	status := metav1.ConditionTrue
 	if !ready {

--- a/pkg/aianalysis/config_test.go
+++ b/pkg/aianalysis/config_test.go
@@ -31,7 +31,7 @@ import (
 // CONFIG VALIDATION UNIT TESTS
 // ========================================
 //
-// Business Requirement: BR-AI-007, BR-AI-012, BR-AA-HAPI-064
+// Business Requirement: BR-AI-007, BR-AI-012, BR-AA-KA-064
 // ADR-030: Service Configuration Management
 //
 // Purpose: Validate that AIAnalysis Config.Validate() correctly rejects
@@ -133,13 +133,13 @@ var _ = Describe("AIAnalysis Config - Unit Tests", Label("config", "validation",
 			Expect(cfg.Validate()).To(MatchError(ContainSubstring("agent.timeout")))
 		})
 
-		It("BR-AA-HAPI-064: should reject session poll interval below 1s", func() {
+		It("BR-AA-KA-064: should reject session poll interval below 1s", func() {
 			cfg := config.DefaultConfig()
 			cfg.Agent.SessionPollInterval = 0
 			Expect(cfg.Validate()).To(MatchError(ContainSubstring("sessionPollInterval")))
 		})
 
-		It("BR-AA-HAPI-064: should reject session poll interval above 5m", func() {
+		It("BR-AA-KA-064: should reject session poll interval above 5m", func() {
 			cfg := config.DefaultConfig()
 			cfg.Agent.SessionPollInterval = 10 * time.Minute
 			Expect(cfg.Validate()).To(MatchError(ContainSubstring("sessionPollInterval")))

--- a/pkg/aianalysis/handlers/constants.go
+++ b/pkg/aianalysis/handlers/constants.go
@@ -57,14 +57,14 @@ const (
 )
 
 // ========================================
-// SESSION CONFIGURATION (BR-AA-HAPI-064)
+// SESSION CONFIGURATION (BR-AA-KA-064)
 // Async submit/poll session management
 // ========================================
 
 const (
 	// MaxSessionRegenerations is the maximum number of session regenerations
 	// before the investigation fails with SessionRegenerationExceeded.
-	// BR-AA-HAPI-064.6: Cap at 5 regenerations
+	// BR-AA-KA-064.6: Cap at 5 regenerations
 	MaxSessionRegenerations int32 = 5
 
 	// MaxConsecutiveGetResultErrors is the maximum number of consecutive 409 errors
@@ -73,7 +73,7 @@ const (
 	MaxConsecutiveGetResultErrors int32 = 3
 
 	// DefaultSessionPollInterval is the constant polling interval for session status checks.
-	// BR-AA-HAPI-064.8: Polling is not error recovery -- KA is healthy, just not done yet.
+	// BR-AA-KA-064.8: Polling is not error recovery -- KA is healthy, just not done yet.
 	// A constant interval is simpler, predictable, and sufficient for async LLM investigations.
 	// Configurable via WithSessionPollInterval option or --session-poll-interval flag.
 	DefaultSessionPollInterval = 15 * time.Second

--- a/pkg/aianalysis/handlers/error_classifier.go
+++ b/pkg/aianalysis/handlers/error_classifier.go
@@ -70,7 +70,7 @@ const (
 	ErrorTypePermanent ErrorType = "Permanent"
 
 	// ErrorTypeSessionLost indicates KA session was lost (404 on poll)
-	// BR-AA-HAPI-064.5: Triggers session regeneration, not standard retry
+	// BR-AA-KA-064.5: Triggers session regeneration, not standard retry
 	ErrorTypeSessionLost ErrorType = "SessionLost"
 )
 

--- a/pkg/aianalysis/handlers/interfaces.go
+++ b/pkg/aianalysis/handlers/interfaces.go
@@ -39,14 +39,14 @@ import (
 //
 // Methods:
 // - Investigate: (Legacy sync) Analyzes incidents via /incident/analyze endpoint
-// - SubmitInvestigation: (Async) Submits investigation, returns session ID (BR-AA-HAPI-064.1)
-// - PollSession: (Async) Polls session status (BR-AA-HAPI-064.2)
-// - GetSessionResult: (Async) Retrieves incident investigation result (BR-AA-HAPI-064.3)
+// - SubmitInvestigation: (Async) Submits investigation, returns session ID (BR-AA-KA-064.1)
+// - PollSession: (Async) Polls session status (BR-AA-KA-064.2)
+// - GetSessionResult: (Async) Retrieves incident investigation result (BR-AA-KA-064.3)
 type AgentClientInterface interface {
 	// Legacy synchronous methods (will be deprecated)
 	Investigate(ctx context.Context, req *agentclient.IncidentRequest) (*agentclient.IncidentResponse, error)
 
-	// Async session methods (BR-AA-HAPI-064)
+	// Async session methods (BR-AA-KA-064)
 	SubmitInvestigation(ctx context.Context, req *agentclient.IncidentRequest) (string, error)
 	PollSession(ctx context.Context, sessionID string) (*agentclient.SessionStatusResult, error)
 	GetSessionResult(ctx context.Context, sessionID string) (*agentclient.IncidentResponse, error)
@@ -66,9 +66,9 @@ type AgentClientInterface interface {
 // Methods:
 // - RecordAIAgentCall: Records AI agent API calls with status and duration
 // - RecordPhaseTransition: Records phase transition events (DD-AUDIT-003)
-// - RecordAIAgentSubmit: Records async AI agent submit event (BR-AA-HAPI-064)
-// - RecordAIAgentResult: Records async AI agent result retrieval event (BR-AA-HAPI-064)
-// - RecordAIAgentSessionLost: Records session lost event (BR-AA-HAPI-064)
+// - RecordAIAgentSubmit: Records async AI agent submit event (BR-AA-KA-064)
+// - RecordAIAgentResult: Records async AI agent result retrieval event (BR-AA-KA-064)
+// - RecordAIAgentSessionLost: Records session lost event (BR-AA-KA-064)
 type AuditClientInterface interface {
 	RecordAIAgentCall(ctx context.Context, analysis *aianalysisv1.AIAnalysis, endpoint string, statusCode int, durationMs int)
 	RecordPhaseTransition(ctx context.Context, analysis *aianalysisv1.AIAnalysis, from, to string)
@@ -78,7 +78,7 @@ type AuditClientInterface interface {
 	RecordAnalysisComplete(ctx context.Context, analysis *aianalysisv1.AIAnalysis)
 
 	// ========================================
-	// Session audit methods (BR-AA-HAPI-064)
+	// Session audit methods (BR-AA-KA-064)
 	// ========================================
 
 	// RecordAIAgentSubmit records an async AI agent submit event with session ID

--- a/pkg/aianalysis/handlers/investigating.go
+++ b/pkg/aianalysis/handlers/investigating.go
@@ -46,7 +46,7 @@ import (
 // BR-AI-007: Call KA and process response
 // BR-AI-009: Retry transient errors with exponential backoff
 // BR-AI-010: Fail immediately on permanent errors
-// BR-AA-HAPI-064: Async session-based submit/poll/result flow
+// BR-AA-KA-064: Async session-based submit/poll/result flow
 // Refactoring P1.1: Uses ResponseProcessor for response handling
 // Refactoring P1.2: Uses RequestBuilder for request construction
 // Refactoring P2.1: Uses ErrorClassifier for error classification and retry logic
@@ -58,8 +58,8 @@ type InvestigatingHandler struct {
 	processor                *ResponseProcessor          // P1.1: Response processing logic
 	builder                  *RequestBuilder             // P1.2: Request construction logic
 	errorClassifier          *ErrorClassifier            // P2.1: Error classification and retry logic
-	useSessionMode           bool                        // BR-AA-HAPI-064: Enable async session-based flow
-	sessionPollInterval      time.Duration               // BR-AA-HAPI-064.8: Constant interval between session polls
+	useSessionMode           bool                        // BR-AA-KA-064: Enable async session-based flow
+	sessionPollInterval      time.Duration               // BR-AA-KA-064.8: Constant interval between session polls
 	maxInvestigationDuration time.Duration               // #1078: Wall-clock cap on investigation before PhaseFailed
 	recorder                 record.EventRecorder        // DD-EVENT-001: K8s event recorder for session lifecycle events
 	isChecker                InvestigationSessionChecker // BR-INTERACTIVE-010: Check IS CRD before submit
@@ -69,7 +69,7 @@ type InvestigatingHandler struct {
 // InvestigatingHandlerOption is a functional option for InvestigatingHandler configuration.
 type InvestigatingHandlerOption func(*InvestigatingHandler)
 
-// WithSessionMode enables the async session-based submit/poll/result flow (BR-AA-HAPI-064).
+// WithSessionMode enables the async session-based submit/poll/result flow (BR-AA-KA-064).
 // When enabled, the handler uses SubmitInvestigation/PollSession/GetSessionResult
 // instead of the legacy synchronous Investigate method.
 func WithSessionMode() InvestigatingHandlerOption {
@@ -87,7 +87,7 @@ func WithRecorder(r record.EventRecorder) InvestigatingHandlerOption {
 }
 
 // WithSessionPollInterval sets the constant interval between session status polls.
-// BR-AA-HAPI-064.8: Polling is normal async behavior, not error recovery, so a constant
+// BR-AA-KA-064.8: Polling is normal async behavior, not error recovery, so a constant
 // interval is used instead of exponential backoff. Default: DefaultSessionPollInterval (15s).
 func WithSessionPollInterval(d time.Duration) InvestigatingHandlerOption {
 	return func(h *InvestigatingHandler) {
@@ -128,7 +128,7 @@ func WithISPhaseUpdater(updater ISPhaseUpdater) InvestigatingHandlerOption {
 // Refactoring P1.1: Initializes ResponseProcessor
 // Refactoring P1.2: Initializes RequestBuilder
 // Refactoring P2.1: Initializes ErrorClassifier with configurable backoff parameters
-// BR-AA-HAPI-064: Accepts functional options (e.g., WithSessionMode())
+// BR-AA-KA-064: Accepts functional options (e.g., WithSessionMode())
 func NewInvestigatingHandler(hgClient AgentClientInterface, log logr.Logger, m *metrics.Metrics, auditClient AuditClientInterface, opts ...InvestigatingHandlerOption) *InvestigatingHandler {
 	if m == nil {
 		panic("metrics cannot be nil: metrics are mandatory for observability")
@@ -142,7 +142,7 @@ func NewInvestigatingHandler(hgClient AgentClientInterface, log logr.Logger, m *
 		metrics:                  m,
 		auditClient:              auditClient,
 		log:                      handlerLog,
-		sessionPollInterval:      DefaultSessionPollInterval,      // BR-AA-HAPI-064.8: Constant poll interval
+		sessionPollInterval:      DefaultSessionPollInterval,      // BR-AA-KA-064.8: Constant poll interval
 		maxInvestigationDuration: DefaultMaxInvestigationDuration, // #1078: Wall-clock cap
 		processor:                NewResponseProcessor(log, m, auditClient),
 		builder:                  NewRequestBuilder(log),
@@ -156,7 +156,7 @@ func NewInvestigatingHandler(hgClient AgentClientInterface, log logr.Logger, m *
 
 // Handle processes the Investigating phase
 // BR-AI-007: Call KA and update status
-// BR-AA-HAPI-064: Async session-based flow when useSessionMode=true
+// BR-AA-KA-064: Async session-based flow when useSessionMode=true
 func (h *InvestigatingHandler) Handle(ctx context.Context, analysis *aianalysisv1.AIAnalysis) (ctrl.Result, error) {
 	h.log.Info("Processing Investigating phase",
 		"name", analysis.Name,
@@ -166,7 +166,7 @@ func (h *InvestigatingHandler) Handle(ctx context.Context, analysis *aianalysisv
 	// AA-HAPI-001: Idempotency is handled at controller level (phase_handlers.go:125-130)
 	// via AtomicStatusUpdate callback with APIReader refetch. No handler-level check needed.
 
-	// BR-AA-HAPI-064: Use async session-based flow when enabled
+	// BR-AA-KA-064: Use async session-based flow when enabled
 	if h.useSessionMode {
 		return h.handleSessionBased(ctx, analysis)
 	}
@@ -380,12 +380,12 @@ func mapErrorTypeToSubReason(errorType ErrorType) string {
 }
 
 // ========================================
-// SESSION-BASED FLOW (BR-AA-HAPI-064)
+// SESSION-BASED FLOW (BR-AA-KA-064)
 // Async submit/poll/result pattern for KA communication
 // ========================================
 
 // handleSessionBased routes the session-based flow based on InvestigationSession state.
-// BR-AA-HAPI-064: Non-blocking communication with KA via submit/poll/result
+// BR-AA-KA-064: Non-blocking communication with KA via submit/poll/result
 func (h *InvestigatingHandler) handleSessionBased(ctx context.Context, analysis *aianalysisv1.AIAnalysis) (ctrl.Result, error) {
 	session := analysis.Status.KASession
 
@@ -459,8 +459,8 @@ func (h *InvestigatingHandler) checkISMismatchAndCancel(ctx context.Context, ana
 }
 
 // handleSessionSubmit submits a new investigation to KA and records the session ID.
-// BR-AA-HAPI-064.1: Submit returns session ID for subsequent polling
-// BR-AA-HAPI-064.9: Submit incident investigation to KA
+// BR-AA-KA-064.1: Submit returns session ID for subsequent polling
+// BR-AA-KA-064.9: Submit incident investigation to KA
 func (h *InvestigatingHandler) handleSessionSubmit(ctx context.Context, analysis *aianalysisv1.AIAnalysis) (ctrl.Result, error) {
 	// Detect if this is a regeneration (session exists but ID was cleared after 404)
 	isRegeneration := analysis.Status.KASession != nil &&
@@ -602,7 +602,7 @@ func (h *InvestigatingHandler) finalizeSessionSubmit(ctx context.Context, analys
 }
 
 // handleSessionPoll polls the status of an active KA session.
-// BR-AA-HAPI-064.2: Poll session status (pending/investigating/completed/failed)
+// BR-AA-KA-064.2: Poll session status (pending/investigating/completed/failed)
 //
 // Poll-tracking status writes (PollCount, LastPolled) are filtered by the
 // informer predicate (aiAnalysisUpdatePredicate) so they don't trigger
@@ -738,7 +738,7 @@ func (h *InvestigatingHandler) handleSessionPollUserDriving(ctx context.Context,
 }
 
 // handleSessionPollPending handles poll results where investigation is still in progress.
-// BR-AA-HAPI-064.8: Constant poll interval (not backoff -- polling is normal async behavior).
+// BR-AA-KA-064.8: Constant poll interval (not backoff -- polling is normal async behavior).
 //
 // Updates PollCount and LastPolled in the CRD status for observability.
 // The aiAnalysisUpdatePredicate filters PollCount/LastPolled-only status writes
@@ -765,7 +765,7 @@ func (h *InvestigatingHandler) handleSessionPollPending(ctx context.Context, ana
 }
 
 // handleSessionPollCompleted handles poll results where investigation has completed.
-// BR-AA-HAPI-064.3: Fetch result and process through ResponseProcessor
+// BR-AA-KA-064.3: Fetch result and process through ResponseProcessor
 func (h *InvestigatingHandler) handleSessionPollCompleted(ctx context.Context, analysis *aianalysisv1.AIAnalysis) (ctrl.Result, error) {
 	session := analysis.Status.KASession
 
@@ -833,7 +833,7 @@ func (h *InvestigatingHandler) handleSessionIncidentResult(ctx context.Context, 
 }
 
 // handleSessionPollFailed handles poll results where investigation has failed on KA side.
-// BR-AA-HAPI-064: Surface KA-side failure to operators via CRD status
+// BR-AA-KA-064: Surface KA-side failure to operators via CRD status
 // AA-MED-1: Ensure Reason and SubReason are set for structured failure reporting.
 func (h *InvestigatingHandler) handleSessionPollFailed(ctx context.Context, analysis *aianalysisv1.AIAnalysis, status *agentclient.SessionStatusResult) (ctrl.Result, error) {
 	session := analysis.Status.KASession
@@ -956,7 +956,7 @@ func (h *InvestigatingHandler) handleCancellationTakeover(ctx context.Context, a
 }
 
 // handleSessionPollError handles errors during session polling (e.g., 404 session lost).
-// BR-AA-HAPI-064.5: 404 triggers session regeneration, not standard retry
+// BR-AA-KA-064.5: 404 triggers session regeneration, not standard retry
 func (h *InvestigatingHandler) handleSessionPollError(ctx context.Context, analysis *aianalysisv1.AIAnalysis, err error) (ctrl.Result, error) {
 	// Check for 404 (session lost) - triggers regeneration logic
 	var apiErr *agentclient.APIError
@@ -969,8 +969,8 @@ func (h *InvestigatingHandler) handleSessionPollError(ctx context.Context, analy
 }
 
 // handleSessionLost handles session loss (404 on poll) with regeneration logic.
-// BR-AA-HAPI-064.5: Increment generation, clear ID, requeue for re-submit
-// BR-AA-HAPI-064.6: Fail with SessionRegenerationExceeded if cap reached
+// BR-AA-KA-064.5: Increment generation, clear ID, requeue for re-submit
+// BR-AA-KA-064.6: Fail with SessionRegenerationExceeded if cap reached
 func (h *InvestigatingHandler) handleSessionLost(ctx context.Context, analysis *aianalysisv1.AIAnalysis) (ctrl.Result, error) {
 	session := analysis.Status.KASession
 	session.Generation++
@@ -992,7 +992,7 @@ func (h *InvestigatingHandler) handleSessionLost(ctx context.Context, analysis *
 			fmt.Sprintf("KA session lost (generation %d), attempting regeneration", session.Generation))
 	}
 
-	// BR-AA-HAPI-064.6: Check if regeneration cap exceeded
+	// BR-AA-KA-064.6: Check if regeneration cap exceeded
 	if session.Generation >= MaxSessionRegenerations {
 		h.log.Info("Session regeneration cap exceeded",
 			"generation", session.Generation,
@@ -1035,7 +1035,7 @@ func (h *InvestigatingHandler) handleSessionLost(ctx context.Context, analysis *
 }
 
 // handleSessionGetResultError handles errors when fetching the session result.
-// BR-AA-HAPI-064: 409 Conflict tracked with consecutive error counter (#1390)
+// BR-AA-KA-064: 409 Conflict tracked with consecutive error counter (#1390)
 // AA-HIGH-1: 404 triggers session regeneration (same as poll 404)
 func (h *InvestigatingHandler) handleSessionGetResultError(ctx context.Context, analysis *aianalysisv1.AIAnalysis, err error) (ctrl.Result, error) {
 	var apiErr *agentclient.APIError

--- a/pkg/aianalysis/handlers/investigating.go
+++ b/pkg/aianalysis/handlers/investigating.go
@@ -163,7 +163,7 @@ func (h *InvestigatingHandler) Handle(ctx context.Context, analysis *aianalysisv
 		"sessionMode", h.useSessionMode,
 	)
 
-	// AA-HAPI-001: Idempotency is handled at controller level (phase_handlers.go:125-130)
+	// AA-KA-001: Idempotency is handled at controller level (phase_handlers.go:125-130)
 	// via AtomicStatusUpdate callback with APIReader refetch. No handler-level check needed.
 
 	// BR-AA-KA-064: Use async session-based flow when enabled
@@ -194,7 +194,7 @@ func (h *InvestigatingHandler) Handle(ctx context.Context, analysis *aianalysisv
 		return h.handleError(ctx, analysis, err)
 	}
 
-	// AA-HAPI-001: Set ObservedGeneration immediately after successful KA call
+	// AA-KA-001: Set ObservedGeneration immediately after successful KA call
 	// This prevents duplicate KA calls when controller reconciles before status persists
 	// DD-CONTROLLER-001 v3.0 Pattern C: Set before phase transition
 	analysis.Status.ObservedGeneration = analysis.Generation

--- a/pkg/aianalysis/investigating_handler_session_test.go
+++ b/pkg/aianalysis/investigating_handler_session_test.go
@@ -39,9 +39,9 @@ import (
 )
 
 // ========================================
-// BR-AA-HAPI-064: Session-Based Pull Design Unit Tests
+// BR-AA-KA-064: Session-Based Pull Design Unit Tests
 //
-// Test Plan: docs/testing/BR-AA-HAPI-064/session_based_pull_test_plan_v1.0.md
+// Test Plan: docs/testing/BR-AA-KA-064/session_based_pull_test_plan_v1.0.md
 //
 // These tests validate the async submit/poll/result flow between
 // AA controller and KA using session IDs.
@@ -107,7 +107,7 @@ func (s *sessionAuditSpy) RecordAIAgentSessionLost(ctx context.Context, analysis
 // Test Suite
 // ========================================
 
-var _ = Describe("InvestigatingHandler Session-Based Pull (BR-AA-HAPI-064)", func() {
+var _ = Describe("InvestigatingHandler Session-Based Pull (BR-AA-KA-064)", func() {
 	var (
 		handler    *handlers.InvestigatingHandler
 		mockClient *mocks.MockAgentClient
@@ -245,7 +245,7 @@ var _ = Describe("InvestigatingHandler Session-Based Pull (BR-AA-HAPI-064)", fun
 	// ========================================
 	Describe("Session Poll Flow", func() {
 		// UT-AA-064-003: Poll session -- status "pending"
-		// BR-AA-HAPI-064.8: Constant poll interval (not backoff). Polling is normal
+		// BR-AA-KA-064.8: Constant poll interval (not backoff). Polling is normal
 		// async behavior, not error recovery. Interval is configurable (default 15s).
 		Context("UT-AA-064-003: Poll session -- status pending, controller requeues", func() {
 			It("should update LastPolled and PollCount, requeue at constant interval", func() {
@@ -263,13 +263,13 @@ var _ = Describe("InvestigatingHandler Session-Based Pull (BR-AA-HAPI-064)", fun
 				Expect(err).NotTo(HaveOccurred())
 				Expect(analysis.Status.KASession.LastPolled).NotTo(BeNil(), "LastPolled should be updated")
 				Expect(analysis.Status.KASession.PollCount).To(Equal(int32(1)), "PollCount should be incremented to 1")
-				// BR-AA-HAPI-064.8: Constant interval, default 15s
+				// BR-AA-KA-064.8: Constant interval, default 15s
 				Expect(result.RequeueAfter).To(Equal(handlers.DefaultSessionPollInterval), "First poll should requeue at constant interval (15s)")
 			})
 		})
 
 		// UT-AA-064-004: Poll session -- status "investigating", same constant interval
-		// BR-AA-HAPI-064.8: Constant poll interval regardless of PollCount.
+		// BR-AA-KA-064.8: Constant poll interval regardless of PollCount.
 		Context("UT-AA-064-004: Poll session -- investigating, constant interval", func() {
 			It("should use same constant interval for second consecutive poll", func() {
 				analysis := createSessionTestAnalysis()
@@ -287,7 +287,7 @@ var _ = Describe("InvestigatingHandler Session-Based Pull (BR-AA-HAPI-064)", fun
 				result, err := handler.Handle(ctx, analysis)
 
 				Expect(err).NotTo(HaveOccurred())
-				// BR-AA-HAPI-064.8: Constant interval, same as first poll
+				// BR-AA-KA-064.8: Constant interval, same as first poll
 				Expect(result.RequeueAfter).To(Equal(handlers.DefaultSessionPollInterval), "Second poll should use same constant interval (15s)")
 			})
 		})
@@ -364,7 +364,7 @@ var _ = Describe("InvestigatingHandler Session-Based Pull (BR-AA-HAPI-064)", fun
 		})
 
 		// UT-AA-064-007: Polling interval is constant across all polls
-		// BR-AA-HAPI-064.8: Constant interval -- polling is not error recovery.
+		// BR-AA-KA-064.8: Constant interval -- polling is not error recovery.
 		// Every poll uses the same configured interval regardless of PollCount.
 		Context("UT-AA-064-007: Polling interval is constant across all polls", func() {
 			It("should use the same constant interval for every poll", func() {
@@ -385,7 +385,7 @@ var _ = Describe("InvestigatingHandler Session-Based Pull (BR-AA-HAPI-064)", fun
 					intervals = append(intervals, result.RequeueAfter)
 				}
 
-				// BR-AA-HAPI-064.8: All polls use the same constant interval
+				// BR-AA-KA-064.8: All polls use the same constant interval
 				Expect(intervals).To(HaveLen(4))
 				for i, interval := range intervals {
 					Expect(interval).To(Equal(handlers.DefaultSessionPollInterval),
@@ -561,7 +561,7 @@ var _ = Describe("InvestigatingHandler Session-Based Pull (BR-AA-HAPI-064)", fun
 				result, err := handler.Handle(ctx, analysis)
 
 				Expect(err).NotTo(HaveOccurred())
-				// BR-AA-HAPI-064.8: Re-poll at standard constant interval (not backoff)
+				// BR-AA-KA-064.8: Re-poll at standard constant interval (not backoff)
 				Expect(result.RequeueAfter).To(Equal(handlers.DefaultSessionPollInterval), "409 should re-poll at standard session poll interval (15s)")
 				// Phase should NOT be Failed
 				Expect(analysis.Status.Phase).NotTo(Equal(aianalysis.PhaseFailed), "Should NOT fail on 409 (transient)")
@@ -739,7 +739,7 @@ var _ = Describe("InvestigatingHandler Session-Based Pull (BR-AA-HAPI-064)", fun
 					Timeout: 30 * time.Second,
 				}
 
-				// BR-AA-HAPI-064.10: Timeout removal - verify config value
+				// BR-AA-KA-064.10: Timeout removal - verify config value
 				Expect(cfg.Timeout).To(Equal(30*time.Second), "Async client should use 30s timeout, not 10m workaround")
 			})
 		})

--- a/pkg/aianalysis/investigating_handler_test.go
+++ b/pkg/aianalysis/investigating_handler_test.go
@@ -58,7 +58,7 @@ func (n *noopAuditClient) RecordAnalysisComplete(ctx context.Context, analysis *
 	// No-op: Unit tests don't need audit recording
 }
 
-// BR-AA-HAPI-064: Session audit no-ops
+// BR-AA-KA-064: Session audit no-ops
 func (n *noopAuditClient) RecordAIAgentSubmit(ctx context.Context, analysis *aianalysisv1.AIAnalysis, sessionID string) {
 }
 
@@ -99,7 +99,7 @@ func (s *auditClientSpy) RecordAnalysisComplete(ctx context.Context, analysis *a
 	// Not tracked in spy for Gap #7 tests
 }
 
-// BR-AA-HAPI-064: Session audit spy methods
+// BR-AA-KA-064: Session audit spy methods
 func (s *auditClientSpy) RecordAIAgentSubmit(ctx context.Context, analysis *aianalysisv1.AIAnalysis, sessionID string) {
 	// Not tracked in spy for Gap #7 tests
 }

--- a/pkg/aianalysis/status/manager.go
+++ b/pkg/aianalysis/status/manager.go
@@ -17,7 +17,7 @@ import (
 // This manager reduces K8s API calls by consolidating multiple status field updates
 // into a single atomic operation, improving performance and reducing race conditions.
 //
-// AA-HAPI-001 Fix: Uses APIReader for cache-bypassed refetch to prevent stale reads
+// AA-KA-001 Fix: Uses APIReader for cache-bypassed refetch to prevent stale reads
 type Manager struct {
 	client    client.Client
 	apiReader client.Reader // Direct API server access (no cache)
@@ -61,7 +61,7 @@ func (m *Manager) AtomicStatusUpdate(
 ) error {
 	return k8sretry.RetryOnConflict(k8sretry.DefaultRetry, func() error {
 		// 1. Refetch to get latest resourceVersion (optimistic locking)
-		// AA-HAPI-001: Use APIReader to bypass cache and get FRESH data
+		// AA-KA-001: Use APIReader to bypass cache and get FRESH data
 		// This prevents duplicate KA calls when cache is stale after status write
 		if err := m.apiReader.Get(ctx, client.ObjectKeyFromObject(analysis), analysis); err != nil {
 		return fmt.Errorf("failed to refetch AIAnalysis: %w", err)
@@ -96,7 +96,7 @@ func (m *Manager) UpdatePhase(
 ) error {
 	return k8sretry.RetryOnConflict(k8sretry.DefaultRetry, func() error {
 		// 1. Refetch to get latest resourceVersion
-		// AA-HAPI-001: Use APIReader to bypass cache
+		// AA-KA-001: Use APIReader to bypass cache
 		if err := m.apiReader.Get(ctx, client.ObjectKeyFromObject(analysis), analysis); err != nil {
 			return fmt.Errorf("failed to refetch AIAnalysis: %w", err)
 		}

--- a/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
@@ -731,7 +731,7 @@ spec:
               humanReviewReason:
                 description: |-
                   Reason why human review needed (when NeedsHumanReview=true)
-                  BR-HAPI-197: Maps to KA's human_review_reason enum values
+                  BR-KA-197: Maps to KA's human_review_reason enum values
                   BR-AI-601: alignment_check_failed added for shadow agent alignment verdicts
                 enum:
                 - workflow_not_found
@@ -857,11 +857,11 @@ spec:
               needsHumanReview:
                 description: |-
                   ========================================
-                  HUMAN REVIEW SIGNALING (BR-HAPI-197)
+                  HUMAN REVIEW SIGNALING (BR-KA-197)
                   Set by Kubernaut Agent when AI cannot produce reliable result
                   ========================================
                   True if human review required (KA decision: RCA incomplete/unreliable)
-                  BR-HAPI-197: Triggers NotificationRequest creation in RO
+                  BR-KA-197: Triggers NotificationRequest creation in RO
                   BR-496 v2: Set when root_owner missing (rca_incomplete) or validation/confidence issues.
                 type: boolean
               observedGeneration:

--- a/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
@@ -794,7 +794,7 @@ spec:
               investigationSession:
                 description: |-
                   ========================================
-                  INVESTIGATION SESSION (BR-AA-HAPI-064)
+                  INVESTIGATION SESSION (BR-AA-KA-064)
                   Tracks the async submit/poll session with Kubernaut Agent
                   ========================================
                   KASession tracks the async KA session for submit/poll pattern
@@ -834,7 +834,7 @@ spec:
                   pollCount:
                     description: |-
                       PollCount tracks the number of poll attempts for observability
-                      BR-AA-HAPI-064.8: Constant 15s poll interval (configurable 1s–5m)
+                      BR-AA-KA-064.8: Constant 15s poll interval (configurable 1s–5m)
                     format: int32
                     minimum: 0
                     type: integer

--- a/pkg/shared/assets/crds/kubernaut.ai_notificationrequests.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_notificationrequests.yaml
@@ -187,7 +187,7 @@ spec:
                         type: boolean
                       humanReviewReason:
                         description: HumanReviewReason from Kubernaut Agent when needs_human_review=true
-                          (BR-HAPI-197).
+                          (BR-KA-197).
                         type: string
                       reason:
                         description: Reason is the high-level failure reason (e.g.,

--- a/test/e2e/aianalysis/08_session_async_flow_test.go
+++ b/test/e2e/aianalysis/08_session_async_flow_test.go
@@ -30,9 +30,9 @@ import (
 )
 
 // Session-Based Async Flow E2E Tests
-// Test Plan: docs/testing/BR-AA-HAPI-064/session_based_pull_test_plan_v1.0.md
+// Test Plan: docs/testing/BR-AA-KA-064/session_based_pull_test_plan_v1.0.md
 // Scenario: E2E-AA-064-001
-// Business Requirements: BR-AA-HAPI-064.1 through .8
+// Business Requirements: BR-AA-KA-064.1 through .8
 //
 // Purpose: Validate that the AA controller completes a full async investigation
 // lifecycle (submit -> poll -> result) in a real K8s environment with deployed KA.
@@ -84,7 +84,7 @@ var _ = Describe("E2E-AA-064: Session-Based Async Flow", Label("e2e", "session",
 			// ========================================
 			// Scenario ID: E2E-AA-064-001
 			// Business Outcome: AA controller completes an async investigation in a real K8s environment
-			// BR: BR-AA-HAPI-064.1 through .8
+			// BR: BR-AA-KA-064.1 through .8
 			// Flow: AA submits to KA (202) -> polls session -> fetches result -> completes analysis
 
 			defer func() { _ = k8sClient.Delete(ctx, analysis) }()
@@ -101,7 +101,7 @@ var _ = Describe("E2E-AA-064: Session-Based Async Flow", Label("e2e", "session",
 			By("Verifying InvestigationSession was populated during async flow")
 			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), analysis)).To(Succeed())
 
-			// BR-AA-HAPI-064.4: InvestigationSession tracking
+			// BR-AA-KA-064.4: InvestigationSession tracking
 			session := analysis.Status.KASession
 			Expect(session).NotTo(BeNil(), "InvestigationSession must be populated in CRD status")
 			// Session ID should be set (from KA's 202 response)

--- a/test/e2e/kubernautagent/audit_pipeline_test.go
+++ b/test/e2e/kubernautagent/audit_pipeline_test.go
@@ -92,7 +92,7 @@ var _ = Describe("E2E-KA Audit Pipeline", Label("e2e", "ka", "audit"), func() {
 			}
 
 			// ========================================
-			// ACT: Call KA incident analysis via session client (BR-AA-HAPI-064)
+			// ACT: Call KA incident analysis via session client (BR-AA-KA-064)
 			// ========================================
 			_, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")
@@ -177,7 +177,7 @@ var _ = Describe("E2E-KA Audit Pipeline", Label("e2e", "ka", "audit"), func() {
 			}
 
 			// ========================================
-			// ACT (BR-AA-HAPI-064: async session flow)
+			// ACT (BR-AA-KA-064: async session flow)
 			// ========================================
 			_, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")
@@ -259,7 +259,7 @@ var _ = Describe("E2E-KA Audit Pipeline", Label("e2e", "ka", "audit"), func() {
 			}
 
 			// ========================================
-			// ACT: Call KA (triggers validation) (BR-AA-HAPI-064: async session flow)
+			// ACT: Call KA (triggers validation) (BR-AA-KA-064: async session flow)
 			// ========================================
 			_, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")
@@ -341,7 +341,7 @@ var _ = Describe("E2E-KA Audit Pipeline", Label("e2e", "ka", "audit"), func() {
 			}
 
 			// ========================================
-			// ACT (BR-AA-HAPI-064: async session flow)
+			// ACT (BR-AA-KA-064: async session flow)
 			// ========================================
 			_, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")

--- a/test/e2e/kubernautagent/incident_analysis_test.go
+++ b/test/e2e/kubernautagent/incident_analysis_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/ogenx"
 )
 
-// BR-AA-HAPI-064: Success-path tests migrated from ogen direct client (sync 200) to
+// BR-AA-KA-064: Success-path tests migrated from ogen direct client (sync 200) to
 // sessionClient.Investigate() (async submit/poll/result wrapper) because KA
 // endpoints are now async-only (202 Accepted).
 // Error-path tests (E2E-KA-007, 008) retain the ogen client for strict
@@ -71,7 +71,7 @@ var _ = Describe("E2E-KA Incident Analysis", Label("e2e", "ka", "incident"), fun
 			}
 
 			// ========================================
-			// ACT: Call KA incident analysis via session client (BR-AA-HAPI-064)
+			// ACT: Call KA incident analysis via session client (BR-AA-KA-064)
 			// ========================================
 			incidentResp, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")
@@ -132,7 +132,7 @@ var _ = Describe("E2E-KA Incident Analysis", Label("e2e", "ka", "incident"), fun
 			}
 
 			// ========================================
-			// ACT (BR-AA-HAPI-064: async session flow)
+			// ACT (BR-AA-KA-064: async session flow)
 			// ========================================
 			incidentResp, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")
@@ -188,7 +188,7 @@ var _ = Describe("E2E-KA Incident Analysis", Label("e2e", "ka", "incident"), fun
 			}
 
 			// ========================================
-			// ACT (BR-AA-HAPI-064: async session flow)
+			// ACT (BR-AA-KA-064: async session flow)
 			// ========================================
 			incidentResp, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")
@@ -258,7 +258,7 @@ var _ = Describe("E2E-KA Incident Analysis", Label("e2e", "ka", "incident"), fun
 			}
 
 			// ========================================
-			// ACT (BR-AA-HAPI-064: async session flow)
+			// ACT (BR-AA-KA-064: async session flow)
 			// ========================================
 			incidentResp, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")
@@ -314,7 +314,7 @@ var _ = Describe("E2E-KA Incident Analysis", Label("e2e", "ka", "incident"), fun
 			}
 
 			// ========================================
-			// ACT (BR-AA-HAPI-064: async session flow)
+			// ACT (BR-AA-KA-064: async session flow)
 			// ========================================
 			incidentResp, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")
@@ -370,7 +370,7 @@ var _ = Describe("E2E-KA Incident Analysis", Label("e2e", "ka", "incident"), fun
 			}
 
 			// ========================================
-			// ACT (BR-AA-HAPI-064: async session flow)
+			// ACT (BR-AA-KA-064: async session flow)
 			// ========================================
 			incidentResp, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")

--- a/test/e2e/kubernautagent/param_validation_e2e_test.go
+++ b/test/e2e/kubernautagent/param_validation_e2e_test.go
@@ -65,7 +65,7 @@ var _ = Describe("E2E-KA Parameter Validation Self-Correction (#1170)", Label("e
 			}
 
 			// ========================================
-			// ACT (BR-AA-HAPI-064: async session flow)
+			// ACT (BR-AA-KA-064: async session flow)
 			// ========================================
 			incidentResp, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")

--- a/test/e2e/kubernautagent/proactive_signal_mode_test.go
+++ b/test/e2e/kubernautagent/proactive_signal_mode_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/agentclient"
 )
 
-// BR-AA-HAPI-064: All success-path tests migrated from ogen direct client (sync 200) to
+// BR-AA-KA-064: All success-path tests migrated from ogen direct client (sync 200) to
 // sessionClient.Investigate() (async submit/poll/result wrapper) because KA
 // endpoints are now async-only (202 Accepted).
 
@@ -80,7 +80,7 @@ var _ = Describe("E2E-KA-084: Proactive Signal Mode Investigation", Label("e2e",
 			)
 
 			// ========================================
-			// ACT: Call KA incident analysis endpoint (BR-AA-HAPI-064: async session flow)
+			// ACT: Call KA incident analysis endpoint (BR-AA-KA-064: async session flow)
 			// ========================================
 			incidentResp, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")
@@ -161,7 +161,7 @@ var _ = Describe("E2E-KA-084: Proactive Signal Mode Investigation", Label("e2e",
 			)
 
 			// ========================================
-			// ACT: Call KA incident analysis endpoint (BR-AA-HAPI-064: async session flow)
+			// ACT: Call KA incident analysis endpoint (BR-AA-KA-064: async session flow)
 			// ========================================
 			incidentResp, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")
@@ -216,7 +216,7 @@ var _ = Describe("E2E-KA-084: Proactive Signal Mode Investigation", Label("e2e",
 			// signal_mode intentionally NOT set — defaults to reactive
 
 			// ========================================
-			// ACT: Call KA incident analysis endpoint (BR-AA-HAPI-064: async session flow)
+			// ACT: Call KA incident analysis endpoint (BR-AA-KA-064: async session flow)
 			// ========================================
 			incidentResp, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")

--- a/test/e2e/kubernautagent/session_endpoints_test.go
+++ b/test/e2e/kubernautagent/session_endpoints_test.go
@@ -28,10 +28,10 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/agentclient"
 )
 
-// Session-Based Endpoint E2E Tests (BR-AA-HAPI-064)
-// Test Plan: docs/testing/BR-AA-HAPI-064/session_based_pull_test_plan_v1.0.md
+// Session-Based Endpoint E2E Tests (BR-AA-KA-064)
+// Test Plan: docs/testing/BR-AA-KA-064/session_based_pull_test_plan_v1.0.md
 // Scenarios: E2E-KA-064-001 through E2E-KA-064-012
-// Business Requirements: BR-AA-HAPI-064.1 through .9
+// Business Requirements: BR-AA-KA-064.1 through .9
 //
 // Purpose: Validate all KA session REST API endpoints with realistic business outcomes.
 // These tests exercise the async submit/poll/result pattern using raw session endpoints.
@@ -58,7 +58,7 @@ var _ = Describe("E2E-KA-064: Session-Based Endpoints", Label("e2e", "ka", "sess
 			// ========================================
 			// Scenario ID: E2E-KA-064-001
 			// Business Outcome: Standard CrashLoopBackOff signal produces confident recommendation via async session
-			// BR: BR-AA-HAPI-064.1, .2, .3
+			// BR: BR-AA-KA-064.1, .2, .3
 			// Endpoints: POST /incident/analyze, GET /incident/session/{id}, GET /incident/session/{id}/result
 
 			// ========================================
@@ -131,7 +131,7 @@ var _ = Describe("E2E-KA-064: Session-Based Endpoints", Label("e2e", "ka", "sess
 			// ========================================
 			// Scenario ID: E2E-KA-064-002
 			// Business Outcome: OOMKilled signal type produces confident workflow recommendation via async session
-			// BR: BR-AA-HAPI-064.1, .2, .3
+			// BR: BR-AA-KA-064.1, .2, .3
 
 			// ========================================
 			// ARRANGE
@@ -195,7 +195,7 @@ var _ = Describe("E2E-KA-064: Session-Based Endpoints", Label("e2e", "ka", "sess
 			// ========================================
 			// Scenario ID: E2E-KA-064-003
 			// Business Outcome: MOCK_NO_WORKFLOW_FOUND escalates to human review via session flow
-			// BR: BR-AA-HAPI-064.1, BR-KA-197
+			// BR: BR-AA-KA-064.1, BR-KA-197
 
 			// ========================================
 			// ARRANGE
@@ -261,7 +261,7 @@ var _ = Describe("E2E-KA-064: Session-Based Endpoints", Label("e2e", "ka", "sess
 			// ========================================
 			// Scenario ID: E2E-KA-064-004
 			// Business Outcome: MOCK_LOW_CONFIDENCE returns low-confidence recommendation for AA to evaluate
-			// BR: BR-AA-HAPI-064.1, BR-KA-197
+			// BR: BR-AA-KA-064.1, BR-KA-197
 
 			// ========================================
 			// ARRANGE
@@ -323,7 +323,7 @@ var _ = Describe("E2E-KA-064: Session-Based Endpoints", Label("e2e", "ka", "sess
 			// ========================================
 			// Scenario ID: E2E-KA-064-005
 			// Business Outcome: MOCK_MAX_RETRIES_EXHAUSTED returns complete validation history for debugging
-			// BR: BR-AA-HAPI-064.1, BR-KA-197
+			// BR: BR-AA-KA-064.1, BR-KA-197
 
 			// ========================================
 			// ARRANGE
@@ -398,7 +398,7 @@ var _ = Describe("E2E-KA-064: Session-Based Endpoints", Label("e2e", "ka", "sess
 			// ========================================
 			// Scenario ID: E2E-KA-064-006
 			// Business Outcome: Session status is queryable and reaches terminal state
-			// BR: BR-AA-HAPI-064.2
+			// BR: BR-AA-KA-064.2
 
 			// ========================================
 			// ARRANGE
@@ -465,7 +465,7 @@ var _ = Describe("E2E-KA-064: Session-Based Endpoints", Label("e2e", "ka", "sess
 			// ========================================
 			// Scenario ID: E2E-KA-064-011
 			// Business Outcome: Invalid session IDs return clear errors (404)
-			// BR: BR-AA-HAPI-064.2, BR-AA-HAPI-064.5
+			// BR: BR-AA-KA-064.2, BR-AA-KA-064.5
 
 			// ========================================
 			// ARRANGE: Use a fabricated UUID that doesn't exist
@@ -490,7 +490,7 @@ var _ = Describe("E2E-KA-064: Session-Based Endpoints", Label("e2e", "ka", "sess
 			Expect(apiErr.StatusCode).To(Equal(http.StatusNotFound),
 				"Non-existent session should return HTTP 404")
 
-			// BUSINESS IMPACT: AA controller detects session loss and triggers regeneration (BR-AA-HAPI-064.5)
+			// BUSINESS IMPACT: AA controller detects session loss and triggers regeneration (BR-AA-KA-064.5)
 		})
 
 		It("E2E-KA-064-012: Result for non-existent session returns error", func() {
@@ -499,7 +499,7 @@ var _ = Describe("E2E-KA-064: Session-Based Endpoints", Label("e2e", "ka", "sess
 			// ========================================
 			// Scenario ID: E2E-KA-064-012
 			// Business Outcome: Result retrieval for invalid sessions returns clear errors
-			// BR: BR-AA-HAPI-064.3
+			// BR: BR-AA-KA-064.3
 
 			// ========================================
 			// ARRANGE: Use a fabricated UUID that doesn't exist

--- a/test/e2e/kubernautagent/three_step_discovery_test.go
+++ b/test/e2e/kubernautagent/three_step_discovery_test.go
@@ -85,7 +85,7 @@ var _ = Describe("E2E-KA-017: Three-Step Workflow Discovery", Label("e2e", "ka",
 			}
 
 			// ========================================
-			// ACT (BR-AA-HAPI-064: async session flow)
+			// ACT (BR-AA-KA-064: async session flow)
 			// ========================================
 			incidentResp, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis should succeed with three-step discovery")

--- a/test/e2e/kubernautagent/workflow_catalog_test.go
+++ b/test/e2e/kubernautagent/workflow_catalog_test.go
@@ -33,7 +33,7 @@ import (
 // NOTE: These tests validate the workflow catalog tool (used by KA internally for LLM-driven workflow search).
 // The workflow catalog is not a direct HTTP endpoint, but is invoked as part of incident analysis.
 //
-// BR-AA-HAPI-064: All success-path tests migrated from ogen direct client (sync 200) to
+// BR-AA-KA-064: All success-path tests migrated from ogen direct client (sync 200) to
 // sessionClient.Investigate() (async submit/poll/result wrapper) because KA
 // endpoints are now async-only (202 Accepted).
 
@@ -72,7 +72,7 @@ var _ = Describe("E2E-KA Workflow Catalog", Label("e2e", "ka", "catalog"), func(
 
 			// ========================================
 			// ACT: Call KA (which internally uses workflow catalog)
-			// (BR-AA-HAPI-064: async session flow)
+			// (BR-AA-KA-064: async session flow)
 			// ========================================
 			incidentResp, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")
@@ -120,7 +120,7 @@ var _ = Describe("E2E-KA Workflow Catalog", Label("e2e", "ka", "catalog"), func(
 			}
 
 			// ========================================
-			// ACT (BR-AA-HAPI-064: async session flow)
+			// ACT (BR-AA-KA-064: async session flow)
 			// ========================================
 			_, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")
@@ -167,7 +167,7 @@ var _ = Describe("E2E-KA Workflow Catalog", Label("e2e", "ka", "catalog"), func(
 			ClusterName:       "e2e-test",
 		}
 			// ========================================
-			// ACT (BR-AA-HAPI-064: async session flow)
+			// ACT (BR-AA-KA-064: async session flow)
 			// ========================================
 			incidentResp, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA should handle empty workflow results gracefully")
@@ -213,7 +213,7 @@ var _ = Describe("E2E-KA Workflow Catalog", Label("e2e", "ka", "catalog"), func(
 				ClusterName:       "e2e-test",
 			}
 			// ========================================
-			// ACT (BR-AA-HAPI-064: async session flow)
+			// ACT (BR-AA-KA-064: async session flow)
 			// ========================================
 			incidentResp, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")
@@ -261,7 +261,7 @@ var _ = Describe("E2E-KA Workflow Catalog", Label("e2e", "ka", "catalog"), func(
 				ClusterName:       "e2e-test",
 			}
 			// ========================================
-			// ACT (BR-AA-HAPI-064: async session flow)
+			// ACT (BR-AA-KA-064: async session flow)
 			// ========================================
 			_, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")
@@ -313,7 +313,7 @@ var _ = Describe("E2E-KA Workflow Catalog", Label("e2e", "ka", "catalog"), func(
 			}
 			// ========================================
 			// ACT: Simulate LLM completing RCA for OOMKilled
-			// (BR-AA-HAPI-064: async session flow)
+			// (BR-AA-KA-064: async session flow)
 			// ========================================
 			incidentResp, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")
@@ -360,7 +360,7 @@ var _ = Describe("E2E-KA Workflow Catalog", Label("e2e", "ka", "catalog"), func(
 				ClusterName:       "e2e-test",
 			}
 			// ========================================
-			// ACT (BR-AA-HAPI-064: async session flow)
+			// ACT (BR-AA-KA-064: async session flow)
 			// ========================================
 			incidentResp, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")
@@ -407,7 +407,7 @@ var _ = Describe("E2E-KA Workflow Catalog", Label("e2e", "ka", "catalog"), func(
 			ClusterName:       "e2e-test",
 		}
 			// ========================================
-			// ACT (BR-AA-HAPI-064: async session flow)
+			// ACT (BR-AA-KA-064: async session flow)
 			// ========================================
 			respObj, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA should handle empty workflow results gracefully")
@@ -455,7 +455,7 @@ var _ = Describe("E2E-KA Workflow Catalog", Label("e2e", "ka", "catalog"), func(
 				ClusterName:       "e2e-test",
 			}
 			// ========================================
-			// ACT (BR-AA-HAPI-064: async session flow)
+			// ACT (BR-AA-KA-064: async session flow)
 			// ========================================
 			_, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")
@@ -499,7 +499,7 @@ var _ = Describe("E2E-KA Workflow Catalog", Label("e2e", "ka", "catalog"), func(
 				ClusterName:       "e2e-test",
 			}
 			// ========================================
-			// ACT (BR-AA-HAPI-064: async session flow)
+			// ACT (BR-AA-KA-064: async session flow)
 			// ========================================
 			_, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")
@@ -543,7 +543,7 @@ var _ = Describe("E2E-KA Workflow Catalog", Label("e2e", "ka", "catalog"), func(
 				ClusterName:       "e2e-test",
 			}
 			// ========================================
-			// ACT (BR-AA-HAPI-064: async session flow)
+			// ACT (BR-AA-KA-064: async session flow)
 			// ========================================
 			_, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")
@@ -587,7 +587,7 @@ var _ = Describe("E2E-KA Workflow Catalog", Label("e2e", "ka", "catalog"), func(
 				ClusterName:       "e2e-test",
 			}
 			// ========================================
-			// ACT (BR-AA-HAPI-064: async session flow)
+			// ACT (BR-AA-KA-064: async session flow)
 			// ========================================
 			_, err := sessionClient.Investigate(ctx, req)
 			Expect(err).ToNot(HaveOccurred(), "KA incident analysis API call should succeed")

--- a/test/integration/aianalysis/audit_flow_integration_test.go
+++ b/test/integration/aianalysis/audit_flow_integration_test.go
@@ -389,8 +389,8 @@ var _ = Describe("AIAnalysis Controller Audit Flow Integration - BR-AI-050", Lab
 			//
 			// AIAnalysis Controller events (9):
 			// - 3 phase transitions (Pending→Investigating→Analyzing→Completed)
-			// - 1 AI agent submit (aiagent.submit — session creation, BR-AA-HAPI-064)
-			// - 1 AI agent result (aiagent.result — session result retrieval, BR-AA-HAPI-064)
+			// - 1 AI agent submit (aiagent.submit — session creation, BR-AA-KA-064)
+			// - 1 AI agent result (aiagent.result — session result retrieval, BR-AA-KA-064)
 			// - 1 AI agent API call metadata (aiagent.call — backward compat from RecordAIAgentResult)
 			// - 1 Rego evaluation (policy check)
 			// - 1 Approval decision (auto-approval or manual review)
@@ -400,7 +400,7 @@ var _ = Describe("AIAnalysis Controller Audit Flow Integration - BR-AI-050", Lab
 			//       are EXCLUDED from this test. KA integration tests validate those separately.
 			//       This test focuses ONLY on AIAnalysis controller audit behavior.
 			//
-			// Total: 9 AIAnalysis events (deterministic per DD-AIANALYSIS-005 v1.x + BR-AA-HAPI-064 session audit)
+			// Total: 9 AIAnalysis events (deterministic per DD-AIANALYSIS-005 v1.x + BR-AA-KA-064 session audit)
 			// Breakdown: 3 phase transitions + 3 AI agent events (submit+result+call) + 1 Rego + 1 approval + 1 completion
 			Expect(len(events)).To(Equal(9),
 				"AIAnalysis workflow generates exactly 9 audit events: 3 phase transitions + 3 AI agent (submit+result+call) + 1 Rego + 1 approval + 1 completion")

--- a/test/integration/aianalysis/events_test.go
+++ b/test/integration/aianalysis/events_test.go
@@ -285,7 +285,7 @@ var _ = Describe("AIAnalysis K8s Event Observability (DD-EVENT-001, BR-AA-095)",
 	})
 
 	// ========================================
-	// BR-AA-HAPI-064: Session Lifecycle Event Tests
+	// BR-AA-KA-064: Session Lifecycle Event Tests
 	// CRD Events team handoff (issues #71-#73 completed)
 	// ========================================
 

--- a/test/integration/aianalysis/suite_test.go
+++ b/test/integration/aianalysis/suite_test.go
@@ -819,7 +819,7 @@ timeoutSeconds: 120
 	isPhaseUpdater := handlers.NewK8sISPhaseUpdater(k8sManager.GetClient(), controllerNS)
 	investigatingHandler := handlers.NewInvestigatingHandler(realAgentClient, ctrl.Log.WithName("investigating-handler"), testMetrics, auditClient,
 		handlers.WithRecorder(eventRecorder),                  // DD-EVENT-001: Session lifecycle events
-		handlers.WithSessionMode(),                            // BR-AA-HAPI-064: Async submit/poll/result flow
+		handlers.WithSessionMode(),                            // BR-AA-KA-064: Async submit/poll/result flow
 		handlers.WithSessionPollInterval(2*time.Second),       // Fast polling for tests (production default: 15s)
 		handlers.WithInvestigationSessionChecker(isChecker),   // BR-INTERACTIVE-010: IS CRD awareness
 		handlers.WithISPhaseUpdater(isPhaseUpdater))           // BR-INTERACTIVE-010: Set IS Active after submit

--- a/test/integration/aianalysis/suite_test.go
+++ b/test/integration/aianalysis/suite_test.go
@@ -838,7 +838,7 @@ timeoutSeconds: 120
 		Scheme:           k8sManager.GetScheme(),
 		Recorder:         eventRecorder,
 		Log:              ctrl.Log.WithName("aianalysis-controller"),
-		StatusManager:    status.NewManager(k8sManager.GetClient(), k8sManager.GetAPIReader()), // DD-PERF-001 + AA-HAPI-001: Cache-bypassed refetch
+		StatusManager:    status.NewManager(k8sManager.GetClient(), k8sManager.GetAPIReader()), // DD-PERF-001 + AA-KA-001: Cache-bypassed refetch
 		AnalyzingHandler: analyzingHandler,
 		AuditClient:      auditClient,
 	}

--- a/test/shared/mocks/agentclient.go
+++ b/test/shared/mocks/agentclient.go
@@ -29,7 +29,7 @@ import (
 // MockAgentClient is a mock implementation of AgentClientInterface for unit tests.
 // Now uses generated types from KA OpenAPI spec for type-safe testing.
 // BR-AI-006: Mock for API call testing
-// BR-AA-HAPI-064: Extended with async session methods
+// BR-AA-KA-064: Extended with async session methods
 type MockAgentClient struct {
 	// InvestigateFunc allows tests to customize the Investigate behavior
 	InvestigateFunc func(ctx context.Context, req *agentclient.IncidentRequest) (*agentclient.IncidentResponse, error)
@@ -47,7 +47,7 @@ type MockAgentClient struct {
 	Err error
 
 	// ========================================
-	// Async session fields (BR-AA-HAPI-064)
+	// Async session fields (BR-AA-KA-064)
 	// ========================================
 
 	// SubmitInvestigationFunc allows tests to customize SubmitInvestigation behavior
@@ -217,7 +217,7 @@ func (m *MockAgentClient) WithFullResponse(
 }
 
 // ========================================
-// Async Session Methods (BR-AA-HAPI-064)
+// Async Session Methods (BR-AA-KA-064)
 // ========================================
 
 // SubmitInvestigation implements AgentClientInterface for async submit.
@@ -293,7 +293,7 @@ func (m *MockAgentClient) CancelSession(_ context.Context, _ string) error {
 }
 
 // ========================================
-// Async Session Test Helpers (BR-AA-HAPI-064)
+// Async Session Test Helpers (BR-AA-KA-064)
 // ========================================
 
 // WithSessionSubmitResponse configures the mock to return a specific session ID on submit.


### PR DESCRIPTION
## Summary

Closes #1886. Closes #1903.

Renames two legacy HAPI-naming ID patterns to their KA equivalents, consistent with the HAPI->KA rename completed in #1806/#1829. Both were excluded from #1829's mechanical sweep for the same reason: larger blast radius than a plain text substitution.

Consolidated into a single PR (per direction) to avoid extra CI/resource overhead from splitting closely-related renames across multiple small PRs.

**Target IDs confirmed** (both mechanical `HAPI`->`KA` substring swaps, zero collisions verified before implementing):
- `BR-AA-HAPI-064` -> `BR-AA-KA-064` (consistent with the existing `BR-AA-001/010/020/095` numbering family)
- `AA-HAPI-001` -> `AA-KA-001` (no `BR-` prefix added — matches the original's informal style; it has no corresponding `docs/requirements/` file)

### Commits (low-risk to high-risk)

1. **`fix(crds): regenerate CRD manifests to sync BR-HAPI-197 rename from #1829`** — Pre-existing, unrelated drift discovered during preflight: #1829 renamed `BR-HAPI-197`->`BR-KA-197` in Go source comments but the checked-in CRD YAMLs (`config/crd/bases` + 3 synced copies, `kubernaut.ai_aianalyses.yaml` + `kubernaut.ai_notificationrequests.yaml`) were never regenerated. Fixed via `make manifests` (no manual edits).
2. **`docs(ids): rename BR-AA-HAPI-064 to BR-AA-KA-064 (source of truth)`** — Updates `internal/kubernautagent/api/openapi.json` (ogen source spec) and `api/aianalysis/v1alpha1/aianalysis_types.go` (controller-gen source doc-comments).
3. **`docs(ids): rename BR-AA-HAPI-064 to BR-AA-KA-064 (regenerated artifacts)`** — Regenerates the 4 `pkg/agentclient/oas_*_gen.go` files (`make generate-agentclient`) and the 4 `kubernaut.ai_aianalyses.yaml` copies (`make manifests`) from the updated source of truth. No manual edits. `go build`/`go vet` verified clean.
4. **`docs(ids): rename BR-AA-HAPI-064 to BR-AA-KA-064 (remaining Go + docs)`** — Mechanical text sweep across the remaining 42 files (Go comments, Ginkgo test descriptions, architecture/requirements docs). Same pattern as #1829.
5. **`docs(ids): rename BR-AA-HAPI-064 requirements doc and test-plan folder`** — `git mv` for the canonical requirements doc and the test-plan folder (filenames embed the ID), plus 2 spot-fixes for now-stale prose found while verifying inbound links.
6. **`docs(ids): rename AA-HAPI-001 to AA-KA-001 (Issue #1903)`** — Mechanical sweep of 12 occurrences across 6 files (Go comments/log strings only — no CRD or generated-code exposure).

### Verification

- Full-repo `git grep -c "BR-AA-HAPI-064"` and `git grep -c "AA-HAPI-001"` -> 0 matches for both
- `go build ./...` and `go vet ./...` clean
- `golangci-lint run` on all touched packages: 0 issues
- `make test-unit-aianalysis`: 462/462 specs passed (452 `pkg/aianalysis` + 10 `internal/controller/aianalysis`) — re-verified after each sweep
- Diff-reviewed every regenerated file (ogen client, CRD YAMLs) to confirm the diff is *only* the intended ID rename, no unintended codegen drift

### Known gap (not this PR's fault)

`make test-integration-aianalysis` could not be completed in the local sandbox: `SynchronizedBeforeSuite` builds DataStorage/KubernautAgent container images as a test dependency, and the local Podman VM (fixed 93GB disk) ran out of space during the Go module download/build step on two separate attempts (before and after a `podman system prune` that reclaimed ~50GB). This is an environment resource constraint, not a code issue — the failure occurs in `BeforeSuite` before any `aianalysis`-specific spec runs, so it gives no signal either way about this change's correctness. Recommend CI (which has proper build resources) confirm integration tests pass before merge.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run` on touched packages
- [x] `make test-unit-aianalysis` (462/462 passed, re-verified after each sweep)
- [x] Full-repo re-grep for zero remaining `BR-AA-HAPI-064` / `AA-HAPI-001` matches
- [x] Diff-review of all regenerated/generated files
- [ ] `make test-integration-aianalysis` — blocked locally by Podman VM disk space; needs CI confirmation