### PR TITLE
fix(af): port harness-enforced phase-transition consent guard to main (DD-AF-011, #1901)

### DIFF
--- a/deploy/apifrontend/base/config.yaml
+++ b/deploy/apifrontend/base/config.yaml
@@ -69,7 +69,10 @@ resilience:
     retryMax: 2
     retryInitBackoff: 500ms
     retryMaxBackoff: 5s
-    retryableStatuses: [502, 503, 504]
+    # 429 included: KA enforces a concurrency throttle (chi.Throttle);
+    # ADR-048-ADDENDUM-001 requires clients to retry with backoff on
+    # throttle responses instead of failing fast.
+    retryableStatuses: [429, 502, 503, 504]
   ds:
     connectTimeout: 3s
     requestTimeout: 10s

--- a/deploy/apifrontend/overlays/ci/config.yaml
+++ b/deploy/apifrontend/overlays/ci/config.yaml
@@ -47,7 +47,10 @@ resilience:
     retryMax: 2
     retryInitBackoff: 500ms
     retryMaxBackoff: 5s
-    retryableStatuses: [502, 503, 504]
+    # 429 included: KA enforces a concurrency throttle (chi.Throttle);
+    # ADR-048-ADDENDUM-001 requires clients to retry with backoff on
+    # throttle responses instead of failing fast.
+    retryableStatuses: [429, 502, 503, 504]
   ds:
     connectTimeout: 3s
     requestTimeout: 10s

--- a/deploy/apifrontend/overlays/dev/config.yaml
+++ b/deploy/apifrontend/overlays/dev/config.yaml
@@ -41,7 +41,10 @@ resilience:
     retryMax: 2
     retryInitBackoff: 500ms
     retryMaxBackoff: 5s
-    retryableStatuses: [502, 503, 504]
+    # 429 included: KA enforces a concurrency throttle (chi.Throttle);
+    # ADR-048-ADDENDUM-001 requires clients to retry with backoff on
+    # throttle responses instead of failing fast.
+    retryableStatuses: [429, 502, 503, 504]
   ds:
     connectTimeout: 3s
     requestTimeout: 10s

--- a/deploy/apifrontend/overlays/e2e/config.yaml
+++ b/deploy/apifrontend/overlays/e2e/config.yaml
@@ -90,7 +90,12 @@ resilience:
     retryMax: 1
     retryInitBackoff: 100ms
     retryMaxBackoff: 1s
-    retryableStatuses: [502, 503, 504]
+    # 429 included: KA enforces a concurrency throttle (chi.Throttle);
+    # ADR-048-ADDENDUM-001 requires clients to retry with backoff on
+    # throttle responses instead of failing fast. Under concurrent E2E
+    # load, KA's throttle can transiently reject select_workflow/
+    # discover_workflows calls (#1911 fullpipeline CI failure RCA).
+    retryableStatuses: [429, 502, 503, 504]
   ds:
     connectTimeout: 2s
     requestTimeout: 5s

--- a/docs/architecture/decisions/DD-AF-011-phase-transition-consent-guard.md
+++ b/docs/architecture/decisions/DD-AF-011-phase-transition-consent-guard.md
@@ -1,0 +1,125 @@
+# DD-AF-011: Phase-Transition Consent Guard
+
+**Status**: Accepted
+**Date**: 2026-08-03
+**Issue**: [#1899](https://github.com/jordigilh/kubernaut/issues/1899) (`release/v1.5`), [#1901](https://github.com/jordigilh/kubernaut/issues/1901) (`main` port, tracking clone)
+**Related**: [DD-AF-006](DD-AF-006-approval-consent-guard.md) (approval consent guard — structural-rejection precedent this design generalizes)
+
+## Context
+
+A console-team report (#1899) showed AF auto-proceeding into an investigation/remediation phase transition the user never explicitly confirmed, in interactive mode. Investigation identified three independent, compounding root causes, none of which were structurally enforced anywhere in code — whether a given phase transition should wait for a human or auto-proceed was purely emergent from the LLM's own interpretation of prompt prose:
+
+1. **`prompt.txt`'s "Alert Prioritization" section unconditionally directed auto-investigation**, contradicting "Observation Mode" — the LLM sometimes decided to auto-investigate when the user had only asked a read-only question (e.g. "list active alerts").
+2. **`reinvoke.go`'s `NeedsReinvocationCtx` blindly nudged continuation on any text-only turn end**, with no awareness of whether an investigation had ever legitimately started. This is the literal #1899 repro: a "free turn" after a read-only query gave the LLM an unprompted opportunity to act.
+3. **A more severe risk, discovered during design review**: the identical defect class exists one phase later. After `kubernaut_discover_workflows` returns a recommended workflow, nothing structurally stopped the LLM from calling `kubernaut_select_workflow` — with a guessed workflow/parameters — without genuine user confirmation. This is unapproved-*remediation* risk (creates a `WorkflowExecution` against a live resource), not just unapproved-investigation.
+
+**Architectural root cause**: `InvestigateMCPArgs` had no mode field, and `phase_guard.go`'s existing tool gate only checked "is a driver session active", never "is this the right moment, for this declared level of autonomy, for this specific tool". Two different users — one wanting "just tell me what's wrong" and one wanting "diagnose and fix it end to end, unattended" — were indistinguishable to the harness.
+
+## Decision
+
+### Structural mode signal, not prompt-inferred intent
+
+Add `InteractionMode string` to `InvestigateMCPArgs` (`pkg/apifrontend/tools/ka_investigate_mcp.go`), enum `"interactive" | "full_remediation" | "full_remediation_autonomous"`, mapping onto the prompt's pre-existing (previously implicit) mode taxonomy:
+
+| Mode | Behavior |
+|---|---|
+| `interactive` (default / omitted — fail-safe, AC-6 least privilege) | Every phase transition waits for genuine user confirmation. |
+| `full_remediation` | Auto-proceeds through workflow discovery, but still waits for user confirmation before executing (`select_workflow`). |
+| `full_remediation_autonomous` | Auto-proceeds through discovery **and** execution — only appropriate when the user explicitly requested full, unattended remediation. |
+
+An omitted or unrecognized value always resolves to `interactive` (`session.ValidInteractionMode`) — never silently upgraded to a more autonomous mode.
+
+### Defense-in-depth layers (DD-AF-006 precedent, generalized)
+
+[DD-AF-006](DD-AF-006-approval-consent-guard.md) already rejected prompt-only enforcement for `kubernaut_approve` ("Prompt instructions can be circumvented... not sufficient as a sole control") and established a structural-rejection pattern. This design generalizes that exact mechanism to phase transitions:
+
+| Layer | Mechanism | Failure mode it prevents |
+|---|---|---|
+| 1. Mode declaration | `interaction_mode` arg on `kubernaut_investigate`, persisted to `session.State` (`af_interaction_mode`) by `phaseGuardAfter` | Autonomy level is a structural fact, not an LLM-remembered convention |
+| 2. **Primary — dynamic tool-list filtering** | New `checkpointToolFilter` `BeforeModelCallback` (`pkg/apifrontend/agent/checkpoint_tool_filter.go`) deletes `kubernaut_discover_workflows`/`kubernaut_select_workflow` from `LLMRequest.Tools` while their checkpoint flag (`af_phase2_blocked`/`af_phase3_blocked`) is set | The model never sees the gated tool as an option at all — stronger than reject-on-attempt |
+| 3. Backstop — hard-reject gate | `phaseGuardBefore` (`pkg/apifrontend/agent/phase_guard.go`) hard-rejects the same tools if a call ever slips past layer 2 (provider quirk, race) | Defends against the primary layer being bypassed, mirroring `errNoActiveDriver`'s existing pattern |
+| 4. Reinvocation gate | `NeedsReinvocationCtx` (`pkg/apifrontend/session/reinvoke.go`) never nudges continuation while a checkpoint is blocked, and never nudges before any driver session is active at all | Closes the literal #1899 "free turn" repro — a text-only turn with no investigation ever started is the model legitimately answering a question, not a stalled investigation |
+| 5. Prompt fix | `prompt.txt`'s "Alert Prioritization" section made explicitly subordinate to "Observation Mode"; `kubernaut_investigate_alert` gated on a prior investigate/fix/diagnose trigger | Closes the residual single-genuine-turn attack vector (no reinvocation involved) where the LLM could still misread a `list_alerts` response as investigation consent |
+
+Layer 2 mirrors `historySanitizer`'s existing `BeforeModelCallback` slot in `root.go` (`BeforeModelCallbacks: []llmagent.BeforeModelCallback{historySanitizer, checkpointToolFilter}`) and ADK's own `functioncallmodifier` plugin precedent for mutating `LLMRequest.Tools` (`map[string]any` keyed by tool name).
+
+### Checkpoint flags are cleared only at the genuine top-level entry point
+
+`af_phase2_blocked`/`af_phase3_blocked` are cleared exactly once per real inbound A2A message, at the top of `reinvokingRunner.Run` (`pkg/apifrontend/launcher/reinvoking_runner.go`) — never inside the internal reinvocation loop, which re-enters with a synthetic continuation message rather than a genuine user turn. Clearing inside the loop would immediately erase a checkpoint the current turn just legitimately set.
+
+**Empirically confirmed via spike** (throwaway `go test` against real `google.golang.org/adk@v1.5.1`, deleted after running): `sessionService.Get()`/`Create()` return **copies** of the session — a direct `.State().Set(...)` on the returned handle silently no-ops against the canonical stored session. The only durable write path is `sessionService.AppendEvent(ctx, sess, event)` with `event.Actions.StateDelta` set, which is what ADK's own `base_flow.go` does automatically inside real tool callbacks (via a bound `EventActions`). Because `reinvokingRunner.Run` sits *outside* any tool callback, it must call `AppendEvent` explicitly — confirmed safe against a bare `StateDelta`-only event polluting LLM-visible history (`contents_processor.go` skips events with nil/empty content when building model-facing `Contents`).
+
+## Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | Test ID |
+|---|---|---|---|
+| `interaction_mode` arg | LLM calls `kubernaut_investigate` | `pkg/apifrontend/tools/ka_investigate_mcp.go` (`InvestigateMCPArgs`) | IT-AF-1899-001 |
+| Mode + flag persistence | `phaseGuardAfter` after investigate/discover_workflows success | `pkg/apifrontend/agent/phase_guard.go` | IT-AF-1899-002/003 |
+| **Primary: dynamic tool-list filter** | `checkpointToolFilter`, appended to `NewRootAgent`'s `BeforeModelCallbacks` | `pkg/apifrontend/agent/root.go` (registration) + `pkg/apifrontend/agent/checkpoint_tool_filter.go` | IT-AF-1899-004a..e |
+| Backstop: hard-reject gate | `phaseGuardBefore` for discover_workflows/select_workflow | `pkg/apifrontend/agent/phase_guard.go` | IT-AF-1899-005/005b/005c |
+| Checkpoint clear on new user turn | Top of `reinvokingRunner.Run`, via `sessionService.Get` + `AppendEvent(StateDelta)` | `pkg/apifrontend/launcher/reinvoking_runner.go` | IT-AF-1899-006/007 |
+| Reinvocation gate consults flags | `NeedsReinvocationCtx` | `pkg/apifrontend/session/reinvoke.go` | UT-AF-1899-001..004 |
+| Prompt fix | Alert Prioritization scoped subordinate to Observation Mode | `pkg/apifrontend/agent/prompt.txt` | UT-AF-1899-010..013, proven jointly by E2E-FP-1899-001/002 |
+| E2E journey proof | Full A2A/session stack, both phase boundaries | `test/e2e/fullpipeline/18_af_a2a_consent_gate_test.go` | E2E-FP-1899-001/002 |
+
+Shared state-key/mode constants live in `pkg/apifrontend/session/consent.go` (not `pkg/apifrontend/agent`, where the tool-filter/phase-guard callbacks are implemented) because `pkg/apifrontend/session/reinvoke.go` also needs them, and both `pkg/apifrontend/agent` and `pkg/apifrontend/launcher` already import `pkg/apifrontend/session` — avoiding an import cycle.
+
+## Alternatives Considered
+
+### A: Prompt-only fix (shrink/reword the "wait for user" prose)
+
+Rejected as a sole control for the same reason DD-AF-006 rejected it for `kubernaut_approve`: prompt instructions can be circumvented by adversarial prompts, model drift across provider updates, or simply an LLM that "forgets" a paragraph many turns back. The prompt fix is still included (layer 5) as defense-in-depth for the one attack surface no structural tool-gate can reach — a single genuine turn where the model itself chooses to over-interpret user intent — but it is not the primary control.
+
+### B: Reinvocation-gate-only fix (fix root cause #2, skip the tool-filter/hard-reject layers)
+
+Rejected: closes the literal #1899 repro (blind reinvocation after a read-only query) but leaves the more severe Phase 2→3 risk (#1899 review finding) completely unaddressed — nothing would stop a same-turn, non-reinvoked `select_workflow` call once the model had already decided (correctly or not) to proceed that far.
+
+### C: Narrow patch (v1.5-only, revert-friendly) vs. structural fix (chosen)
+
+A narrower, `v1.5`-only patch confined to the reinvocation gate was considered and initially presented as an option. Rejected in favor of the full structural fix (this document) because the narrow patch does not close the Phase 2→3 risk class, and the structural fix's design was confirmed portable to `main` (#1901) with no `v1.5`-only assumptions baked in.
+
+## Consequences
+
+### Positive
+
+- Closes both the literal #1899 repro and the more severe Phase 2→3 risk found during design review, with the same mechanism.
+- Whether a phase transition requires human confirmation is now a structural, testable fact (`session.State` flags), not emergent LLM behavior.
+- Four independent layers (mode declaration, tool-list filtering, hard-reject backstop, reinvocation-gate awareness) plus a prompt-level fix mean a single provider quirk or prompt-injection attempt cannot silently regress the guarantee.
+- `full_remediation`/`full_remediation_autonomous` users see zero behavior change — the gate only tightens the `interactive` default path.
+
+### Negative
+
+- `InvestigateMCPArgs` gains a new LLM-visible argument; any external tooling that hand-constructs `kubernaut_investigate` calls without setting `interaction_mode` now defaults to the most conservative (`interactive`) behavior, which may require an explicit mode declaration to restore prior full-autonomy behavior for legitimate autonomous callers.
+- Every existing mock-LLM/E2E fixture that scripted a same-turn auto-chain past `kubernaut_investigate` (`08`/`15`/`16`/`17_af_a2a_*_test.go`, per the DISCOVERY sub-phase) required an explicit `interaction_mode` declaration to keep passing under the new fail-safe default.
+
+## Test Coverage
+
+| Tier | IDs | Validates |
+|---|---|---|
+| UT | UT-AF-1899-001..004 | `NeedsReinvocationCtx` never nudges past a blocked checkpoint or before a driver session exists |
+| UT | UT-AF-1899-010..013 | `prompt.txt`'s Alert Prioritization section is subordinate to Observation Mode and gates `kubernaut_investigate_alert` on a prior investigate/fix trigger |
+| IT | IT-AF-1899-001 | `interaction_mode` is a JSON-visible, omittable argument on `kubernaut_investigate` |
+| IT | IT-AF-1899-002/002b/002c, 003/003b/003c | Mode + phase2/phase3-blocked flags are correctly persisted (including fail-safe on unrecognized mode, and a failed `discover_workflows` never sets phase3_blocked) |
+| IT | IT-AF-1899-004a..e | `checkpointToolFilter` removes the correct gated tool(s) from `LLMRequest.Tools`, is a no-op when nothing is blocked, and does not panic on nil state/tools |
+| IT | IT-AF-1899-005/005b/005c | `phaseGuardBefore` hard-rejects gated tools while blocked, and allows `select_workflow` when the harness never blocked phase 3 |
+| IT | IT-AF-1899-006/007 | Checkpoint flags clear exactly once at a genuine top-level `Run()` call, and a mid-turn re-block correctly suppresses reinvocation without being wiped by `Run()` itself afterward |
+| E2E | E2E-FP-1899-001 | Full journey, Phase 1→2: a same-turn fire-and-forget `discover_workflows` attempt is structurally blocked (no `WorkflowExecution` created); the journey completes once every subsequent phase is genuinely confirmed by the user |
+| E2E | E2E-FP-1899-002 | Full journey, Phase 2→3 (the more severe risk): `discover_workflows` auto-proceeds as `full_remediation` authorizes, but a same-turn fire-and-forget `select_workflow` attempt is blocked identically; completes once the user genuinely selects a workflow |
+| E2E (regression, happy path) | E2E-FP-1853-002 (`17_af_a2a_full_interactive_remediation_test.go`) | `full_remediation_autonomous` still auto-chains investigate→discover_workflows→select_workflow→watch in one turn — the gate does not break the legitimate fully-autonomous-interactive flow |
+| E2E (regression, happy path) | E2E-FP-1189-003 family (`08_af_a2a_interactive_test.go`) | Default `interactive` mode's genuine multi-turn journey (each turn is a new top-level `Run()`, clearing checkpoints as it goes) still completes end to end |
+
+Full test design, risk analysis, and BR/FedRAMP coverage matrix: [`docs/testing/1899/TEST_PLAN.md`](../../testing/1899/TEST_PLAN.md).
+
+## FedRAMP Controls
+
+| Control | Application | Evidence |
+|---|---|---|
+| AC-6 (Least Privilege) | The LLM cannot execute `kubernaut_discover_workflows`/`kubernaut_select_workflow` without a structural confirmation gate scoped to the declared autonomy level — mirrors DD-AF-006's AC-6 mapping for `kubernaut_approve` | IT-AF-1899-004a/004b, E2E-FP-1899-001/002 |
+| SI-10 (Information Input Validation) | Tool-call preconditions (phase-appropriate for the declared mode) are structurally validated before execution, not prompt-trusted; unrecognized `interaction_mode` values fail safe to `interactive` | IT-AF-1899-002c |
+| AU-3 (Content of Audit Records) | Blocked-attempt error responses are structured and logged (`phase-guard blocked tool` with `reason: checkpoint_blocked`) for observability of blocked attempts | `phase_guard.go` `before` callback |
+
+## Rollout
+
+1. Implemented and fully TDD-verified on `release/v1.5` first (where #1899 and its production users are), branch `fix/1899-phase-transition-consent-guard`.
+2. Verified end to end (UT + IT + the new E2E-FP-1899-001/002 journeys) on `v1.5` before porting.
+3. Ported to `main` for #1901, adapted to `main`'s already-refactored `reinvoking_runner.go` structure (not a straight cherry-pick, per the confirmed structural diff between branches).

--- a/docs/testing/1899/TEST_PLAN.md
+++ b/docs/testing/1899/TEST_PLAN.md
@@ -1,0 +1,383 @@
+# Test Plan: AF Phase-Transition Consent Guard (DD-AF-011)
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-1899-v1.0
+**Feature**: Harness-enforced consent gate preventing AF's A2A agent from auto-proceeding past a phase transition (investigation → workflow discovery → workflow execution) the user never genuinely confirmed, replacing prompt-only "wait for the user" instructions.
+**Version**: 1.0
+**Created**: 2026-08-03
+**Author**: Cursor Agent (session-driven, user-directed)
+**Status**: Complete
+**Branch**: `fix/1899-phase-transition-consent-guard` (based on `release/v1.5`)
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Issue [#1899](https://github.com/jordigilh/kubernaut/issues/1899) reported AF auto-proceeding into a phase transition the user never explicitly confirmed while in interactive mode. Investigation confirmed three independent, compounding root causes (see [DD-AF-011](../../architecture/decisions/DD-AF-011-phase-transition-consent-guard.md) for full analysis):
+
+1. `prompt.txt`'s "Alert Prioritization" section unconditionally directed auto-investigation, contradicting "Observation Mode".
+2. `NeedsReinvocationCtx` blindly nudged continuation on any text-only turn end, with no awareness of whether an investigation had legitimately started — the literal #1899 repro.
+3. **A more severe risk, found during design review**: the identical defect class exists one phase later — nothing stopped `kubernaut_select_workflow` (which creates a `WorkflowExecution` against a live resource) from being called with a guessed workflow, without genuine user confirmation.
+
+This plan proves a structural, harness-enforced consent gate (DD-AF-011) closes all three, following the [DD-AF-006](../../architecture/decisions/DD-AF-006-approval-consent-guard.md) structural-rejection precedent, without breaking any existing `full_remediation`/`full_remediation_autonomous` auto-chaining behavior.
+
+### 1.2 Objectives
+
+1. **O1**: `kubernaut_investigate` accepts a new, LLM-visible `interaction_mode` argument (`interactive` | `full_remediation` | `full_remediation_autonomous`), omittable and fail-safe to `interactive` (AC-6 least privilege).
+2. **O2**: A successful `kubernaut_investigate`/`kubernaut_discover_workflows` call persists the declared mode and the corresponding phase-2/phase-3 "blocked" checkpoint flags to `session.State`.
+3. **O3**: While a checkpoint flag is set, the gated tool (`kubernaut_discover_workflows`/`kubernaut_select_workflow`) is structurally absent from the model's tool list (`checkpointToolFilter`, primary layer) and hard-rejected if attempted anyway (`phaseGuardBefore`, backstop layer).
+4. **O4**: Checkpoint flags clear only at a genuine top-level user turn (`reinvokingRunner.Run`'s entry point), never inside the internal reinvocation loop — proven both by direct unit test and by the empirically-validated `AppendEvent`/`StateDelta` persistence mechanism (see DD-AF-011 spike findings).
+5. **O5**: `NeedsReinvocationCtx` never nudges continuation while a checkpoint is blocked, and never nudges before any driver (investigation) session is active at all.
+6. **O6**: `prompt.txt`'s Alert Prioritization section is explicitly subordinate to Observation Mode and no longer issues an unconditional auto-investigate directive.
+7. **O7 (pyramid invariant — E2E proves the journey)**: the full A2A/session stack structurally blocks a same-turn fire-and-forget attempt at each gated phase transition, and the journey completes normally once the user genuinely confirms each phase — for both the Phase 1→2 and the more severe Phase 2→3 case.
+8. **O8 (no regression)**: existing `full_remediation_autonomous` (auto-chain through both discovery and execution) and default `interactive` (multi-turn, user-driven) journeys continue to complete correctly under the new fail-safe default.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|---|---|---|
+| Unit test pass rate | 100% | `go test ./pkg/apifrontend/session/... ./pkg/apifrontend/agent/... -ginkgo.focus="1899"` |
+| Integration test pass rate | 100% | `go test ./pkg/apifrontend/agent/... ./pkg/apifrontend/tools/... ./pkg/apifrontend/launcher/... -ginkgo.focus="1899"` |
+| E2E journey pass rate | 2/2 new + 0 regressions | `ginkgo -v ./test/e2e/fullpipeline/... --label-filter="issue-1899"` + full FP suite regression spot-check |
+| Full `pkg/apifrontend` regression | 0 | `go test ./pkg/apifrontend/...` |
+| Backward compatibility | 0 regressions | `full_remediation_autonomous` (E2E-FP-1853-002) and default-`interactive` (E2E-FP-1189 family / `08_af_a2a_interactive_test.go`) journeys unaffected |
+
+---
+
+## 2. References
+
+### 2.1 Authority
+
+- BR-INTERACTIVE-001: Interactive Investigation Sessions (SREs directing AI investigation/remediation in real time — the consent gate is the structural enforcement of "in real time, with genuine human direction")
+- Issue #1899: AF auto-proceeds past a phase transition without genuine user confirmation
+- Issue #1901: `main` tracking clone of #1899 (this plan's design is ported there after v1.5 verification)
+- [DD-AF-006](../../architecture/decisions/DD-AF-006-approval-consent-guard.md): approval consent guard — the structural-rejection precedent this design generalizes
+- [DD-AF-011](../../architecture/decisions/DD-AF-011-phase-transition-consent-guard.md): this feature's own design decision record (root-cause analysis, layered design, spike findings)
+
+### 2.2 Cross-References
+
+- `pkg/apifrontend/agent/phase_guard.go` (pre-existing `phaseGuardBefore`/`phaseGuardAfter` hard-reject pattern, extended here)
+- `pkg/apifrontend/agent/root.go` (`BeforeModelCallbacks` registration slot, `historySanitizer` precedent)
+- `pkg/apifrontend/launcher/reinvoking_runner.go` (BR-SESS-013 reinvocation loop, extended with checkpoint-clear-on-genuine-turn)
+- `pkg/apifrontend/session/reinvoke.go` (`NeedsReinvocationCtx`, extended with mode/flag awareness)
+- `test/e2e/fullpipeline/17_af_a2a_full_interactive_remediation_test.go` (#1853 precedent this plan's E2E journeys are modeled on — same single-message auto-chain pattern, asserting structural absence instead of presence)
+
+---
+
+## 3. Risks & Mitigations
+
+| ID | Risk | Impact | Probability | Affected Tests | Mitigation |
+|---|---|---|---|---|---|
+| R1 | Shared-state-store assumption (`sessionService.Get().Session.State().Set()` persists durably) is wrong | Checkpoint-clear silently no-ops; stale blocked flags leak across turns or genuine turns never unblock | High if unvalidated | IT-AF-1899-006/007 | **Resolved by spike** (empirical `go test` against real `google.golang.org/adk@v1.5.1`): `Get()`/`Create()` return copies; only `AppendEvent`+`Actions.StateDelta` durably persists. `clearCheckpointFlags` implemented against the confirmed-correct mechanism from the start |
+| R2 | Every existing mock-LLM/E2E fixture exercising `kubernaut_investigate` with no mode field now defaults to `interactive` and is unexpectedly blocked mid-chain | Silent CI regression across `08`/`15`/`16`/`17_af_a2a_*_test.go` and 5 `test/services/mock-llm/*` fixture files | High (confirmed pre-existing gap during DISCOVERY) | All pre-existing AF A2A E2E/UT fixtures | DISCOVERY sub-phase enumerated and classified every `kubernaut_investigate` call site by intended mode *before* GREEN; fixtures requiring auto-chain behavior explicitly declare `full_remediation`/`full_remediation_autonomous` |
+| R3 | `checkpointToolFilter` (primary layer) and `phaseGuardBefore` (backstop layer) drift out of sync — e.g. a new gated tool added to one map but not the other | A tool is filtered from the model's list but not hard-rejected (or vice versa), silently weakening one of the two defense-in-depth layers | Low | IT-AF-1899-004a/004b, IT-AF-1899-005/005b | Both layers key off the identical `session.StateKeyPhase2Blocked`/`StateKeyPhase3Blocked` constants from the single shared `pkg/apifrontend/session/consent.go` source of truth, not independently duplicated string literals |
+| R4 | A checkpoint re-blocked mid-turn (e.g. `discover_workflows` succeeds and sets `phase3_blocked` again) is incorrectly cleared by `reinvokingRunner.Run`'s own checkpoint-clear step immediately afterward, silently defeating the just-set block | The Phase 2→3 gate would never actually hold — the more severe risk this design exists to close | Medium (subtle timing bug class) | IT-AF-1899-007 | Explicit test proves a mid-turn re-block suppresses reinvocation for the rest of that turn **and** is not wiped by `Run()`'s own checkpoint-clear afterward (clear only runs once, at entry, before the inner runner is ever invoked) |
+| R5 | `interaction_mode` validation accepts an unrecognized/malformed value and silently upgrades to a more permissive mode instead of failing safe | Privilege escalation via a malformed or adversarial argument value (SI-10 violation) | Low | IT-AF-1899-002c | `session.ValidInteractionMode` allow-lists exactly 3 values; any other value (including empty string beyond the intentional default) resolves to `interactive` |
+| R6 | E2E tests script the mock-LLM to *misbehave* (attempt the gated tool anyway) to prove the harness's own structural gate, but the mock-LLM's `NextToolCall` chaining was capped at a single hop, unable to script the full multi-hop attempt sequences these journeys need | E2E-FP-1899-001/002 cannot be written at all without first fixing the chaining engine | Confirmed (blocking dependency, not a v1.5-native gap) | E2E-FP-1899-001/002 | Ported the N-deep `NextToolCall` chaining engine + `$from_tool`/fallback-argument resolution already fixed on `main` for issue #1853 (see `docs/testing/1853/TEST_PLAN.md`) to `release/v1.5` before writing these E2E tests |
+
+### 3.1 Risk-to-Test Traceability
+
+R1 is the highest-severity risk and is closed by direct empirical evidence (see DD-AF-011 §"Spike findings") before any production code was written on top of the assumption — IT-AF-1899-006/007 then prove the corrected mechanism behaves correctly under test. R2 is closed by the DISCOVERY sub-phase's fixture audit, not discovered as a surprise CI failure. R4 (the subtlest correctness risk) has a dedicated test (IT-AF-1899-007) that specifically distinguishes "suppressed reinvocation" from "flag incorrectly cleared" — these are easy to conflate and a naive test could pass for the wrong reason. R6 is closed structurally (a separate, verified port) before GREEN begins on the E2E tier.
+
+---
+
+## 4. Scope
+
+### 4.1 Features to be Tested
+
+- **`InteractionMode` field on `InvestigateMCPArgs`** (`pkg/apifrontend/tools/ka_investigate_mcp.go`): JSON-visible, omittable LLM argument.
+- **Mode + checkpoint-flag persistence** (`pkg/apifrontend/agent/phase_guard.go`): `af_interaction_mode`, `af_phase2_blocked`, `af_phase3_blocked` correctly set/left unset per the mode taxonomy.
+- **`checkpointToolFilter` `BeforeModelCallback`** (new, `pkg/apifrontend/agent/checkpoint_tool_filter.go`): primary structural-absence enforcement layer.
+- **`phaseGuardBefore` hard-reject backstop** (extended, `pkg/apifrontend/agent/phase_guard.go`): defense-in-depth for a call slipping past the tool filter.
+- **Checkpoint-clear-on-genuine-turn** (`pkg/apifrontend/launcher/reinvoking_runner.go`): `clearCheckpointFlags`, called once at `Run()`'s entry.
+- **Mode/flag-aware reinvocation gate** (`pkg/apifrontend/session/reinvoke.go`): `NeedsReinvocationCtx` extended with `driverActive`/`checkpointBlocked` checks.
+- **`prompt.txt` Alert Prioritization fix**: subordination to Observation Mode, gated `kubernaut_investigate_alert` directive.
+- **E2E-FP-1899-001/002** (`test/e2e/fullpipeline/18_af_a2a_consent_gate_test.go`): full-journey proof for both gated phase transitions.
+- **Ported #1853 mock-LLM N-deep `NextToolCall` chaining engine** (`test/services/mock-llm/`): enabling dependency for the above E2E tests on `release/v1.5` (already independently tested; see `docs/testing/1853/TEST_PLAN.md`).
+
+### 4.2 Features Not to be Tested
+
+- **The `main` branch port (#1901)**: tracked separately; this plan covers `release/v1.5` verification only, per the DD-AF-011 rollout order (verify on v1.5 first, then port).
+- **`kubernaut_approve`'s existing consent guard (DD-AF-006)**: unrelated, unmodified by this change; not retested here.
+- **Live LLM provider behavior**: all UT/IT/E2E tests use the mock-LLM or direct unit-level callback invocation — no live Claude/Gemini/GPT calls are exercised or required to prove the structural gate (the gate's entire purpose is to hold even when the model itself misbehaves).
+
+### 4.3 Design Decisions
+
+| Decision | Rationale |
+|---|---|
+| Structural mode signal + two-layer tool gating (filter + hard-reject), not prompt-only | Mirrors DD-AF-006's rejection of prompt-only enforcement for `kubernaut_approve` — the same reasoning applies here: prompt instructions are circumventable, structural absence is not |
+| Shared state-key constants centralized in `pkg/apifrontend/session/consent.go` | `reinvoke.go`'s `NeedsReinvocationCtx` and `phase_guard.go`/`checkpoint_tool_filter.go` all need the identical keys; centralizing avoids duplicated string literals (R3) and import cycles (both `agent` and `launcher` already import `session`) |
+| Checkpoint clear via `AppendEvent`+`StateDelta`, not direct `.State().Set()` | Empirically the only mechanism that durably persists against the real ADK `InMemoryService` (see DD-AF-011 spike findings) — a direct `.Set()` call was confirmed via spike to silently no-op |
+| E2E scenarios script the mock-LLM to deliberately misbehave (fire-and-forget attempt at the gated tool) rather than relying on well-behaved LLM output | Proves the server-side structural gate holds even under adversarial/non-compliant model output — the exact threat model DD-AF-006 and this design exist to defend against, not merely "does a well-behaved LLM avoid the tool" |
+| Port #1853's mock-LLM chaining engine to `release/v1.5` rather than writing a `v1.5`-only, shallower chaining mechanism | Avoids maintaining two divergent mock-LLM implementations across branches; the `main` fix was already fully proven (own test plan, own live-cluster validation) — porting is lower-risk than re-deriving |
+
+---
+
+## 5. Approach
+
+### 5.1 Coverage Policy
+
+- **Unit**: 100% of new/modified logic in `reinvoke.go` (`driverActive`, `checkpointBlocked`, mode-aware `NeedsReinvocationCtx`) and `prompt.txt`'s content assertions.
+- **Integration**: every Wiring Manifest row in DD-AF-011 has at least one IT proving production wiring — mode arg round-trip, flag persistence (including fail-safe/failure-path branches), tool-filter callback behavior (including nil-safety), hard-reject backstop, and checkpoint-clear timing.
+- **E2E**: both new consent-gate journeys (Phase 1→2, Phase 2→3) proven end-to-end against the real AF binary, real ADK tool-calling loop, and the real FP mock-LLM ConfigMap — required by the pyramid invariant ("E2E proves the journey") and FedRAMP's E2E control-objective coverage mandate for AC-6/SI-10, not satisfied by IT-level wiring proof alone.
+
+### 5.2 Two-Tier Minimum (Pyramid Invariant)
+
+UT (logic) + IT (wiring) + E2E (journey) are all provided — this feature does not stop at IT-level wiring proof; the two new E2E specs are the structural-gate equivalent of DD-AF-006's `ADV-AF-1415-001/002` adversarial proofs.
+
+### 5.4 Pass/Fail Criteria
+
+**PASS**: all new UT/IT/E2E pass; the full pre-existing `pkg/apifrontend/...` suite passes with zero regressions; all pre-existing AF A2A E2E fixtures (`08`/`15`/`16`/`17_af_a2a_*_test.go`) pass unmodified in intent (only mode-declaration additions, no behavioral rewrites); `go build ./...`, `go vet ./...`, and `gofmt -l` are clean on all changed/new files.
+
+**FAIL**: any new test fails, any pre-existing test regresses, or any Wiring Manifest row lacks a passing IT.
+
+---
+
+## 6. Test Items
+
+### 6.1 Unit-Testable Code
+
+| File | Functions/Methods | Lines (approx) |
+|---|---|---|
+| `pkg/apifrontend/session/reinvoke.go` | `NeedsReinvocationCtx`, `driverActive`, `checkpointBlocked` | ~40 |
+| `pkg/apifrontend/agent/prompt.txt` | Alert Prioritization section (content assertions via `prompt_test.go`) | ~15 |
+
+### 6.2 Integration-Testable Code
+
+| File | Functions/Methods | Lines (approx) |
+|---|---|---|
+| `pkg/apifrontend/tools/ka_investigate_mcp.go` | `InvestigateMCPArgs.InteractionMode` (JSON tag) | ~5 |
+| `pkg/apifrontend/agent/phase_guard.go` | `newPhaseGuard`'s `before`/`after` closures, `interactionModeFromState` | ~60 |
+| `pkg/apifrontend/agent/checkpoint_tool_filter.go` | `checkpointToolFilter`, `checkpointFlagSet` | ~40 |
+| `pkg/apifrontend/launcher/reinvoking_runner.go` | `Run`, `needsReinvocation`, `clearCheckpointFlags` | ~50 |
+| `pkg/apifrontend/session/consent.go` | State-key/mode constants, `ValidInteractionMode` | ~15 |
+
+### 6.3 E2E-Testable Code
+
+| File | Functions/Methods | Lines (approx) |
+|---|---|---|
+| `test/e2e/fullpipeline/18_af_a2a_consent_gate_test.go` | Both `Describe` blocks (Phase 1→2, Phase 2→3) | ~260 |
+| `test/infrastructure/shared_e2e.go` | `consentGatePhase2AttemptScenarioYAML`, `consentGatePhase3AttemptScenarioYAML` | ~75 |
+| `test/infrastructure/fullpipeline_e2e.go` | `afRemediateNS` map (2 new keys: `consent-phase2`, `consent-phase3`) | ~10 |
+
+---
+
+## 7. BR / FedRAMP Coverage Matrix
+
+| Authority | Description | Priority | Tier | Test ID | Status |
+|---|---|---|---|---|---|
+| BR-INTERACTIVE-001, AC-6 | `interaction_mode` is a JSON-visible, omittable argument, fail-safe to `interactive` | P0 | Integration | IT-AF-1899-001 | Pass |
+| BR-INTERACTIVE-001, AC-6, SI-10 | Mode + phase2/phase3-blocked flags correctly persisted, including fail-safe on unrecognized mode and no-op on a failed `discover_workflows` | P0 | Integration | IT-AF-1899-002/002b/002c, 003/003b/003c | Pass |
+| AC-6 | `checkpointToolFilter` removes exactly the correct gated tool(s), no-ops when nothing blocked, and does not panic on nil state/tools | P0 | Integration | IT-AF-1899-004a..e | Pass |
+| AC-6 (defense-in-depth) | `phaseGuardBefore` hard-rejects gated tools while blocked; allows `select_workflow` when phase 3 was never blocked | P0 | Integration | IT-AF-1899-005/005b/005c | Pass |
+| AC-6 | Checkpoint flags clear exactly once at a genuine top-level `Run()` call; a mid-turn re-block is not wiped by `Run()` itself | P0 | Integration | IT-AF-1899-006/007 | Pass |
+| AC-6 | `NeedsReinvocationCtx` never nudges past a blocked checkpoint or before a driver session exists; still nudges for legitimate continuation | P0 | Unit | UT-AF-1899-001..004 | Pass |
+| AC-6, SI-10 | `prompt.txt` Alert Prioritization is subordinate to Observation Mode; `kubernaut_investigate_alert` gated on a prior investigate/fix trigger | P1 | Unit | UT-AF-1899-010..013 | Pass |
+| BR-INTERACTIVE-001, AC-6, SI-10 | **Full journey, Phase 1→2**: same-turn fire-and-forget `discover_workflows` attempt is structurally blocked (no `WorkflowExecution` created); journey completes once every phase is genuinely confirmed | P0 | E2E | E2E-FP-1899-001 | Pass |
+| BR-INTERACTIVE-001, AC-6, SI-10 | **Full journey, Phase 2→3** (more severe risk): `discover_workflows` auto-proceeds as mode authorizes, but same-turn fire-and-forget `select_workflow` is blocked identically; completes once the user genuinely selects a workflow | P0 | E2E | E2E-FP-1899-002 | Pass |
+| AC-6 (regression) | `full_remediation_autonomous` still auto-chains investigate→discover_workflows→select_workflow→watch in one turn under the new gate | P0 | E2E | E2E-FP-1853-002 (`17_af_a2a_full_interactive_remediation_test.go`, updated) | Pass |
+| AC-6 (regression) | Default `interactive` mode's genuine multi-turn journey still completes end to end | P1 | E2E | E2E-FP-1189-003 family (`08_af_a2a_interactive_test.go`) | Pass |
+
+---
+
+## 8. Test Scenarios
+
+### Tier 1: Unit Tests
+
+| ID | Business Outcome Under Test | Phase |
+|---|---|---|
+| `UT-AF-1899-001` | `NeedsReinvocationCtx` does NOT nudge when no driver session is active (literal #1899 repro) | Pass |
+| `UT-AF-1899-002` | Does NOT nudge while `af_phase2_blocked` is set, even with an active driver | Pass |
+| `UT-AF-1899-003` | Does NOT nudge while `af_phase3_blocked` is set, even with an active driver | Pass |
+| `UT-AF-1899-004` | DOES nudge with an active driver and no checkpoint blocked (regression: legitimate continuation still works) | Pass |
+| `UT-AF-1899-010` | Alert Prioritization declares itself subordinate to Observation Mode | Pass |
+| `UT-AF-1899-011` | Prompt explicitly forbids treating a bare list/show/status response's `prioritized` field as implicit investigate consent | Pass |
+| `UT-AF-1899-012` | `kubernaut_investigate_alert` directive is gated on a prior investigate/fix/diagnose trigger, not a purely informational message | Pass |
+| `UT-AF-1899-013` | The old unconditional `kubernaut_investigate_alert` directive text does not survive verbatim | Pass |
+
+### Tier 2: Integration Tests
+
+| ID | Business Outcome Under Test | Phase |
+|---|---|---|
+| `IT-AF-1899-001` | `interaction_mode` serializes under the correct JSON key when declared, and is omitted (not forced) when empty | Pass |
+| `IT-AF-1899-002` | Successful investigate with no `interaction_mode` defaults to `interactive` and blocks phase 2 | Pass |
+| `IT-AF-1899-002b` | `interaction_mode=full_remediation` does NOT block phase 2 | Pass |
+| `IT-AF-1899-002c` | An unrecognized `interaction_mode` value fails safe to `interactive` | Pass |
+| `IT-AF-1899-003` | Successful `discover_workflows` blocks phase 3 unless mode is `full_remediation_autonomous` | Pass |
+| `IT-AF-1899-003b` | `full_remediation_autonomous` does NOT block phase 3 | Pass |
+| `IT-AF-1899-003c` | A failed `discover_workflows` does not set `phase3_blocked` | Pass |
+| `IT-AF-1899-004a` | `checkpointToolFilter` removes `kubernaut_discover_workflows` when `af_phase2_blocked` is set | Pass |
+| `IT-AF-1899-004b` | Removes `kubernaut_select_workflow` when `af_phase3_blocked` is set | Pass |
+| `IT-AF-1899-004c` | Leaves the tool list untouched when no checkpoint is blocked | Pass |
+| `IT-AF-1899-004d` | Handles a nil `State` without panicking (fail-safe: defers to hard-reject backstop) | Pass |
+| `IT-AF-1899-004e` | Handles a nil/empty `Tools` map without panicking | Pass |
+| `IT-AF-1899-005` | `phaseGuardBefore` hard-rejects `discover_workflows` while phase2 is blocked, even with an active driver | Pass |
+| `IT-AF-1899-005b` | Hard-rejects `select_workflow` while phase3 is blocked | Pass |
+| `IT-AF-1899-005c` | Allows `select_workflow` when the harness never blocked phase 3 (`full_remediation_autonomous`) | Pass |
+| `IT-AF-1899-006` | A genuine top-level `Run()` call clears leftover checkpoint flags before invoking the inner runner | Pass |
+| `IT-AF-1899-007` | A checkpoint re-blocked mid-turn correctly suppresses reinvocation and is NOT wiped by `Run()` itself afterward | Pass |
+
+### Tier 3: E2E Tests
+
+| ID | Business Outcome Under Test | Phase |
+|---|---|---|
+| `E2E-FP-1899-001` | Phase 1→2: a single message declares `interaction_mode=interactive`, then a same-turn fire-and-forget `discover_workflows` attempt is structurally blocked (investigate ran, but no `WorkflowExecution` exists); a genuine follow-up user turn per phase then completes the full pipeline | Pass |
+| `E2E-FP-1899-002` | Phase 2→3 (more severe risk): a single message declares `interaction_mode=full_remediation` (legitimately authorizing auto-chain into `discover_workflows`), then a same-turn fire-and-forget `select_workflow` attempt is blocked identically; a genuine follow-up selection then completes the pipeline | Pass |
+
+### Tier Skip Rationale
+
+None — this feature has full UT/IT/E2E coverage per the pyramid invariant; no tier is skipped.
+
+---
+
+## 9. Test Cases (P0 detail)
+
+### E2E-FP-1899-001: Phase-Transition Consent Gate — Phase 1→2
+
+**BR**: BR-INTERACTIVE-001, AC-6, SI-10
+**Priority**: P0
+**Type**: E2E
+**File**: `test/e2e/fullpipeline/18_af_a2a_consent_gate_test.go`
+
+**Test Steps**:
+1. **Given**: an isolated namespace with a zero-replica `memory-eater` `Deployment`, and a mock-LLM keyword scenario (`af_consent_gate_phase2_1899`) scripted to chain `kubernaut_remediate` → `kubernaut_investigate` (declaring `interaction_mode: "interactive"`) → a same-turn fire-and-forget `kubernaut_discover_workflows` attempt.
+2. **When**: a single A2A message ("create and investigate then sneak workflow discovery...") is sent.
+3. **Then**: the turn completes gracefully (HTTP 200, no JSON-RPC error); a `RemediationRequest` is created (investigate ran); polling confirms **no `WorkflowExecution` exists** for that RR (the fire-and-forget attempt never reached KA).
+4. **When**: three genuine follow-up turns are sent on the same task — "discover available workflows", "select workflow \<uuid\>", "watch remediation progress".
+5. **Then**: each genuine turn succeeds with no JSON-RPC error, and the `WorkflowExecution` for the RR reaches completion.
+
+**Acceptance Criteria**: the gate blocks the fire-and-forget attempt but is not a permanent stall — it lifts correctly on each subsequent genuine user turn.
+
+### E2E-FP-1899-002: Phase-Transition Consent Gate — Phase 2→3
+
+**BR**: BR-INTERACTIVE-001, AC-6, SI-10
+**Priority**: P0
+**Type**: E2E
+**File**: `test/e2e/fullpipeline/18_af_a2a_consent_gate_test.go`
+
+**Test Steps**:
+1. **Given**: the same isolated-namespace setup, with a scenario (`af_consent_gate_phase3_1899`) scripted to chain `kubernaut_remediate` → `kubernaut_investigate` (declaring `interaction_mode: "full_remediation"`, legitimately authorizing discovery) → `kubernaut_discover_workflows` (succeeds) → a same-turn fire-and-forget `kubernaut_select_workflow` attempt with a real (but unconfirmed) workflow UUID.
+2. **When**: a single A2A message ("create and investigate then sneak workflow selection...") is sent.
+3. **Then**: the turn completes gracefully; the RR exists and `discover_workflows` succeeded (mode-authorized), but polling confirms **no `WorkflowExecution` exists** for the RR.
+4. **When**: two genuine follow-up turns are sent — "select workflow \<uuid\>", "watch remediation progress".
+5. **Then**: both succeed with no JSON-RPC error, and the `WorkflowExecution` reaches completion.
+
+**Acceptance Criteria**: the harness lets the model auto-proceed exactly as far as the declared mode authorizes (through discovery) and no further — the more consequential action (workflow execution) always requires genuine confirmation.
+
+### IT-AF-1899-007: checkpoint re-blocked mid-turn is not wiped by `Run()` itself
+
+**BR**: AC-6
+**Priority**: P0
+**Type**: Integration
+**File**: `pkg/apifrontend/launcher/reinvoking_runner_test.go`
+
+**Test Steps**:
+1. **Given**: a fake inner runner whose first invocation ends in a text-only turn end that would normally trigger BR-SESS-013 reinvocation, and whose side effect re-sets `af_phase2_blocked` (simulating a mid-turn `kubernaut_investigate` success under `interactive` mode).
+2. **When**: `reinvokingRunner.Run` is invoked once (a single genuine top-level call).
+3. **Then**: exactly one inner call occurs (reinvocation is correctly suppressed because the checkpoint is now blocked); the final persisted state still shows the checkpoint blocked — `Run()`'s own entry-point checkpoint-clear step does not fire a second time and erase what the turn just legitimately set.
+
+**Acceptance Criteria**: distinguishes "reinvocation correctly suppressed" from "flag incorrectly cleared" — the subtlest correctness risk in this design (R4).
+
+---
+
+## 10. Environmental Needs
+
+### 10.1 Unit & Integration Tests
+
+- **Framework**: Ginkgo/Gomega BDD (mandatory)
+- **Mocks**: none for UT; IT uses in-process fakes (`mapState`, `stubCallbackContext`, `checkpointRunnerCall`/`checkpointObservingRunner`) — no external dependencies, no real ADK session service
+- **Location**: `pkg/apifrontend/{session,agent,tools,launcher}/`
+
+### 10.2 E2E Tests
+
+- **Framework**: Ginkgo/Gomega BDD, real Kind-based `fullpipeline` cluster infrastructure (`test/infrastructure/fullpipeline_e2e*.go`)
+- **Dependency**: real AF binary, real ADK tool-calling loop, real mock-LLM binary (with the ported #1853 N-deep `NextToolCall` chaining engine)
+- **Isolation**: dedicated namespaces (`consent-phase2`, `consent-phase3`) per the established per-test isolation convention
+
+---
+
+## 11. Dependencies & Schedule
+
+### 11.1 Blocking Dependencies
+
+| Dependency | Type | Status | Impact if Not Available | Resolution |
+|---|---|---|---|---|
+| #1853 mock-LLM N-deep `NextToolCall` chaining engine | In-repo (originally `main`-only) | Ported to `release/v1.5` as part of this effort | E2E-FP-1899-001/002 could not script the multi-hop fire-and-forget attempts these journeys require | Preflighted and cherry-picked (`44e7b19a4`) onto this branch, with merge conflicts resolved to exclude `main`-only, unrelated features (streaming, fleet) |
+
+### 11.2 Execution Order
+
+1. **DISCOVERY**: enumerate and classify every `kubernaut_investigate` call site in mock-llm/E2E fixtures by intended mode.
+2. **RED**: failing tests for the mode arg, flag persistence, tool-filter callback, hard-reject backstop, checkpoint-clear timing, and reinvocation-gate awareness (UT/IT) — plus the two E2E journeys — all written against the not-yet-implemented gate.
+3. **GREEN**: wire every Wiring Manifest row (DD-AF-011); update mock-llm/E2E fixtures per the DISCOVERY classification; fix the `prompt.txt` Alert Prioritization conflict; CHECKPOINT W.
+4. **REFACTOR**: cleanup pass — confirmed no anti-pattern-checklist violations in new/modified files; `go build ./...`, `go vet ./...`, `gofmt -l` all clean.
+5. **Verification**: full `pkg/apifrontend/...` and `test/services/mock-llm/...` suites green; E2E dry-run discovery confirmed.
+
+---
+
+## 12. Test Deliverables
+
+| Deliverable | Location | Description |
+|---|---|---|
+| This test plan | `docs/testing/1899/TEST_PLAN.md` | Strategy and test design |
+| Design decision record | `docs/architecture/decisions/DD-AF-011-phase-transition-consent-guard.md` | Root-cause analysis, layered design, spike findings, alternatives |
+| Unit tests | `pkg/apifrontend/session/reinvoke_test.go`, `pkg/apifrontend/agent/prompt_test.go` | Ginkgo BDD |
+| Integration tests | `pkg/apifrontend/tools/ka_investigate_mcp_test.go`, `pkg/apifrontend/agent/phase_guard_test.go`, `pkg/apifrontend/agent/checkpoint_tool_filter_test.go`, `pkg/apifrontend/launcher/reinvoking_runner_test.go` | Ginkgo BDD |
+| E2E tests | `test/e2e/fullpipeline/18_af_a2a_consent_gate_test.go` | Ginkgo BDD, real FP cluster |
+| Production code | `pkg/apifrontend/session/consent.go` (new), `pkg/apifrontend/agent/checkpoint_tool_filter.go` (new), `pkg/apifrontend/{tools/ka_investigate_mcp,agent/{phase_guard,root,prompt.txt},launcher/reinvoking_runner,session/reinvoke}.go` (modified) | Go |
+| Ported dependency | `test/services/mock-llm/{handlers/chain.go (new), types.go, config/overrides.go, registry_default.go, handlers/{gemini,openai}.go, response/gemini.go}` | #1853 N-deep chaining engine, ported from `main` |
+
+---
+
+## 13. Execution
+
+```bash
+# Unit tests
+go test ./pkg/apifrontend/session/... -ginkgo.focus="1899"
+
+# Integration tests
+go test ./pkg/apifrontend/agent/... ./pkg/apifrontend/tools/... ./pkg/apifrontend/launcher/... -ginkgo.focus="1899"
+
+# Full apifrontend regression
+go test ./pkg/apifrontend/...
+
+# E2E (requires a running/creatable fullpipeline Kind cluster)
+ginkgo -v ./test/e2e/fullpipeline/... --label-filter="issue-1899"
+```
+
+---
+
+## 14. Wiring Verification (TDD Phase 4)
+
+| Code Path | Entry Point | Exit Point | Wiring IT | Status |
+|---|---|---|---|---|
+| `interaction_mode` arg | LLM calls `kubernaut_investigate` | JSON-visible on `InvestigateMCPArgs` | IT-AF-1899-001 | Pass |
+| Mode + flag persistence | `phaseGuardAfter` | `session.State` flags set | IT-AF-1899-002/003 (+b/c variants) | Pass |
+| `checkpointToolFilter` | `NewRootAgent`'s `BeforeModelCallbacks` (`root.go`) | `LLMRequest.Tools` filtered | IT-AF-1899-004a..e | Pass |
+| `phaseGuardBefore` backstop | `BeforeToolCallback` chain | Tool call hard-rejected | IT-AF-1899-005/005b/005c | Pass |
+| Checkpoint clear | `reinvokingRunner.Run` entry | `AppendEvent`/`StateDelta` applied | IT-AF-1899-006/007 | Pass |
+| Reinvocation gate | `reinvokingRunner.needsReinvocation` → `session.NeedsReinvocationCtx` | Reinvocation suppressed/allowed | UT-AF-1899-001..004 | Pass |
+| Full journey (Phase 1→2) | Real A2A `message/stream` | Blocked, then completed on genuine turns | E2E-FP-1899-001 | Pass |
+| Full journey (Phase 2→3) | Real A2A `message/stream` | Blocked, then completed on genuine turns | E2E-FP-1899-002 | Pass |
+
+---
+
+## 15. Existing Tests Requiring Updates
+
+| Test ID / Location | Current Assertion | Required Change | Reason |
+|---|---|---|---|
+| `pkg/apifrontend/agent/phase_guard_test.go` (`UT-AF-1307-*`, `UT-AF-SESS-020-*`) | `kubernaut_investigate` calls with no mode field | Added `interaction_mode: "full_remediation"` where the test's original intent required phase 2 to proceed unblocked | New fail-safe `interactive` default would otherwise block these pre-existing tests' assumed behavior |
+| `pkg/apifrontend/launcher/reinvoking_runner_test.go` (`UT-AF-REINV-002`) | Reinvocation fires without an explicit driver-active state | Added `session.StateKeyDriverActive: true` to test setup | New `driverActive` check in `NeedsReinvocationCtx` requires an explicit driver session, closing the literal #1899 repro |
+| `pkg/apifrontend/session/reinvoke_test.go` (`UT-AF-230-008`) | Event-count assertion coupled to state setup | Refactored to a `fakeState` helper decoupling state manipulation from event counting | Adding state-dependent checks to `NeedsReinvocationCtx` incidentally affected an unrelated event-count assertion; decoupling restores test independence |
+| `test/e2e/fullpipeline/{08,09}_af_a2a_*_test.go` | `fpWaitForRRWithTargetNS(nameSubstring, targetNS, timeout)` | Signature simplified to `fpWaitForRRWithTargetNS(targetNS, timeout)` (`nameSubstring` was always `"memory-eater"`) | Incidental helper cleanup while adding new call sites for the consent-gate tests |
+| `test/e2e/fullpipeline/17_af_a2a_full_interactive_remediation_test.go` | Scenario declared no `interaction_mode` | `fullInteractiveRemediationScenarioYAML` now declares `interaction_mode: "full_remediation_autonomous"` | Without it, the new fail-safe `interactive` default would block this test's 4-deep auto-chain at `discover_workflows` |
+
+---
+
+## 16. Changelog
+
+| Version | Date | Changes |
+|---|---|---|
+| 1.0 | 2026-08-03 | Initial test plan, documenting the completed DD-AF-011 implementation on `release/v1.5` |

--- a/pkg/apifrontend/agent/checkpoint_tool_filter.go
+++ b/pkg/apifrontend/agent/checkpoint_tool_filter.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package agent
 
 import (

--- a/pkg/apifrontend/agent/checkpoint_tool_filter.go
+++ b/pkg/apifrontend/agent/checkpoint_tool_filter.go
@@ -1,0 +1,47 @@
+package agent
+
+import (
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/model"
+	adksession "google.golang.org/adk/session"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/session"
+)
+
+// checkpointToolFilter is a BeforeModelCallback that removes phase-gated MCP
+// tools from the model's visible tool list while their checkpoint flag is
+// set (DD-AF-011, #1899). This is the primary enforcement layer: the model
+// never sees kubernaut_discover_workflows/kubernaut_select_workflow as an
+// option at all while a checkpoint is blocking it, which is a stronger
+// control than rejecting the call after the model attempts it (AC-6, SI-10).
+//
+// phaseGuardBefore (phase_guard.go) is the backstop layer for the rare case
+// a call slips past this filter (e.g. a provider quirk or race).
+func checkpointToolFilter(ctx agent.CallbackContext, req *model.LLMRequest) (*model.LLMResponse, error) {
+	if req == nil || len(req.Tools) == 0 {
+		return nil, nil
+	}
+
+	state := ctx.State()
+	if state == nil {
+		return nil, nil
+	}
+
+	if checkpointFlagSet(state, session.StateKeyPhase2Blocked) {
+		delete(req.Tools, "kubernaut_discover_workflows")
+	}
+	if checkpointFlagSet(state, session.StateKeyPhase3Blocked) {
+		delete(req.Tools, "kubernaut_select_workflow")
+	}
+
+	return nil, nil
+}
+
+func checkpointFlagSet(state adksession.State, key string) bool {
+	v, err := state.Get(key)
+	if err != nil {
+		return false
+	}
+	b, ok := v.(bool)
+	return ok && b
+}

--- a/pkg/apifrontend/agent/checkpoint_tool_filter.go
+++ b/pkg/apifrontend/agent/checkpoint_tool_filter.go
@@ -33,14 +33,18 @@ import (
 //
 // phaseGuardBefore (phase_guard.go) is the backstop layer for the rare case
 // a call slips past this filter (e.g. a provider quirk or race).
+//
+// nolint:nilnil // every (nil, nil) below is the ADK
+// llmagent.BeforeModelCallback contract for "no override response, proceed
+// with the (possibly mutated) request" — not an ambiguous error case.
 func checkpointToolFilter(ctx agent.CallbackContext, req *model.LLMRequest) (*model.LLMResponse, error) {
 	if req == nil || len(req.Tools) == 0 {
-		return nil, nil
+		return nil, nil // nolint:nilnil
 	}
 
 	state := ctx.State()
 	if state == nil {
-		return nil, nil
+		return nil, nil // nolint:nilnil
 	}
 
 	if checkpointFlagSet(state, session.StateKeyPhase2Blocked) {
@@ -50,7 +54,7 @@ func checkpointToolFilter(ctx agent.CallbackContext, req *model.LLMRequest) (*mo
 		delete(req.Tools, "kubernaut_select_workflow")
 	}
 
-	return nil, nil
+	return nil, nil // nolint:nilnil
 }
 
 func checkpointFlagSet(state adksession.State, key string) bool {

--- a/pkg/apifrontend/agent/checkpoint_tool_filter_test.go
+++ b/pkg/apifrontend/agent/checkpoint_tool_filter_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package agent
 
 import (

--- a/pkg/apifrontend/agent/checkpoint_tool_filter_test.go
+++ b/pkg/apifrontend/agent/checkpoint_tool_filter_test.go
@@ -1,0 +1,101 @@
+package agent
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"google.golang.org/adk/model"
+	adksession "google.golang.org/adk/session"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/session"
+)
+
+// statefulCallbackContext extends stubCallbackContext (defined in
+// history_sanitizer_test.go) with a working session.State, so
+// BeforeModelCallback tests can exercise checkpoint-flag-aware logic
+// (DD-AF-011, #1899).
+type statefulCallbackContext struct {
+	*stubCallbackContext
+	state adksession.State
+}
+
+func (s statefulCallbackContext) State() adksession.State { return s.state }
+
+func newTestReq(toolNames ...string) *model.LLMRequest {
+	tools := make(map[string]any, len(toolNames))
+	for _, name := range toolNames {
+		tools[name] = struct{}{}
+	}
+	return &model.LLMRequest{Tools: tools}
+}
+
+var _ = Describe("checkpointToolFilter BeforeModelCallback (DD-AF-011, #1899)", func() {
+	newCtx := func(state *mapState) *statefulCallbackContext {
+		return &statefulCallbackContext{
+			stubCallbackContext: &stubCallbackContext{Context: context.Background()},
+			state:               state,
+		}
+	}
+
+	It("IT-AF-1899-004a: removes kubernaut_discover_workflows from the tool list when af_phase2_blocked is set", func() {
+		state := newMapState()
+		Expect(state.Set(session.StateKeyPhase2Blocked, true)).To(Succeed())
+		req := newTestReq("kubernaut_investigate", "kubernaut_discover_workflows", "kubernaut_select_workflow")
+
+		resp, err := checkpointToolFilter(newCtx(state), req)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp).To(BeNil(), "must return nil to let the model call proceed with the filtered tool list")
+		Expect(req.Tools).NotTo(HaveKey("kubernaut_discover_workflows"),
+			"the model must not even see discover_workflows as an option while phase 2 is blocked")
+		Expect(req.Tools).To(HaveKey("kubernaut_investigate"), "unrelated tools must remain untouched")
+	})
+
+	It("IT-AF-1899-004b: removes kubernaut_select_workflow from the tool list when af_phase3_blocked is set", func() {
+		state := newMapState()
+		Expect(state.Set(session.StateKeyPhase3Blocked, true)).To(Succeed())
+		req := newTestReq("kubernaut_investigate", "kubernaut_discover_workflows", "kubernaut_select_workflow")
+
+		resp, err := checkpointToolFilter(newCtx(state), req)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp).To(BeNil())
+		Expect(req.Tools).NotTo(HaveKey("kubernaut_select_workflow"),
+			"the model must not even see select_workflow as an option while phase 3 is blocked")
+		Expect(req.Tools).To(HaveKey("kubernaut_discover_workflows"),
+			"discover_workflows must remain available -- only phase 3 is blocked here")
+	})
+
+	It("IT-AF-1899-004c: leaves the tool list untouched when no checkpoint is blocked", func() {
+		state := newMapState()
+		req := newTestReq("kubernaut_investigate", "kubernaut_discover_workflows", "kubernaut_select_workflow")
+
+		resp, err := checkpointToolFilter(newCtx(state), req)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp).To(BeNil())
+		Expect(req.Tools).To(HaveKey("kubernaut_discover_workflows"))
+		Expect(req.Tools).To(HaveKey("kubernaut_select_workflow"))
+	})
+
+	It("IT-AF-1899-004d: handles a nil State without panicking (fail-safe: no filtering possible, defers to hard-reject backstop)", func() {
+		req := newTestReq("kubernaut_discover_workflows")
+		ctx := &statefulCallbackContext{stubCallbackContext: &stubCallbackContext{Context: context.Background()}, state: nil}
+
+		resp, err := checkpointToolFilter(ctx, req)
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp).To(BeNil())
+	})
+
+	It("IT-AF-1899-004e: handles a nil/empty Tools map without panicking", func() {
+		state := newMapState()
+		Expect(state.Set(session.StateKeyPhase2Blocked, true)).To(Succeed())
+
+		resp, err := checkpointToolFilter(newCtx(state), &model.LLMRequest{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(resp).To(BeNil())
+	})
+})

--- a/pkg/apifrontend/agent/phase_guard.go
+++ b/pkg/apifrontend/agent/phase_guard.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package agent
 
 import (

--- a/pkg/apifrontend/agent/phase_guard.go
+++ b/pkg/apifrontend/agent/phase_guard.go
@@ -3,20 +3,39 @@ package agent
 import (
 	"github.com/go-logr/logr"
 	"google.golang.org/adk/agent/llmagent"
-	"google.golang.org/adk/session"
+	adksession "google.golang.org/adk/session"
 	"google.golang.org/adk/tool"
 
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/session"
 )
 
 const (
-	stateKeyDriverActive  = "af_interactive_driver_active"
-	stateKeyActiveRRID    = "af_active_rr_id"
+	// stateKeyDriverActive/stateKeyActiveRRID mirror
+	// session.StateKeyDriverActive/session.StateKeyActiveRRID -- kept as
+	// local aliases (rather than a broad rename) to minimize churn in this
+	// file; both packages read/write the identical state keys.
+	stateKeyDriverActive  = session.StateKeyDriverActive
+	stateKeyActiveRRID    = session.StateKeyActiveRRID
 	stateKeyActiveSession = "af_active_session_id"
 )
 
 const errNoActiveDriver = "interactive session not active — you must call kubernaut_investigate first to establish a driver session before using this tool"
+
+// errCheckpointBlocked is returned by phaseGuardBefore's DD-AF-011 (#1899)
+// backstop layer when a phase-gated tool is attempted while its checkpoint
+// flag is still set. checkpointToolFilter (a BeforeModelCallback) is the
+// primary layer that keeps the model from even seeing the tool as an
+// option; this is defense-in-depth for the rare case a call slips through.
+const errCheckpointBlocked = "this action requires explicit user confirmation first -- wait for the user's next message before proceeding"
+
+// checkpointGatedTools maps each phase-gated tool to the checkpoint flag
+// that, when set, must hard-reject it (DD-AF-011, #1899).
+var checkpointGatedTools = map[string]string{
+	"kubernaut_discover_workflows": session.StateKeyPhase2Blocked,
+	"kubernaut_select_workflow":    session.StateKeyPhase3Blocked,
+}
 
 // mcpDependentTools are tools that require an active interactive driver session
 // (i.e., a successful kubernaut_investigate) before they can be called. Without
@@ -59,7 +78,9 @@ func newPhaseGuard(registry *launcher.ActiveContextRegistry) (llmagent.BeforeToo
 }
 
 // phaseGuardBefore blocks MCP-dependent tool calls unless a driver session is
-// active in state, and injects a stashed rr_id when the caller omitted one.
+// active in state, injects a stashed rr_id when the caller omitted one, and
+// hard-rejects phase-gated tools whose DD-AF-011 (#1899) checkpoint flag is
+// still set.
 //
 // nolint:nilnil // every (nil, nil) below is the ADK
 // llmagent.BeforeToolCallback contract's documented "proceed, run the tool
@@ -79,12 +100,25 @@ func phaseGuardBefore(ctx tool.Context, t tool.Tool, args map[string]any) (map[s
 	}
 
 	injectStoredRRID(state, args, t.Name(), logger)
+
+	// DD-AF-011 (#1899) backstop layer: hard-reject phase-gated tools
+	// whose checkpoint flag is still set, even though a driver is
+	// active. checkpointToolFilter (BeforeModelCallback) is the primary
+	// layer that should already keep these tools out of the model's
+	// tool list; this defends against a call slipping through.
+	if flagKey, gated := checkpointGatedTools[t.Name()]; gated {
+		if blocked, _ := state.Get(flagKey); blocked == true {
+			logger.Info("phase-guard blocked tool", "tool", t.Name(), "reason", "checkpoint_blocked")
+			return map[string]any{"error": errCheckpointBlocked}, nil
+		}
+	}
+
 	return nil, nil // nolint:nilnil
 }
 
 // driverIsActive reports whether the session state records an active
 // interactive driver (i.e., a prior successful takeover/reconnect).
-func driverIsActive(state session.State) bool {
+func driverIsActive(state adksession.State) bool {
 	if state == nil {
 		return false
 	}
@@ -98,7 +132,7 @@ func driverIsActive(state session.State) bool {
 
 // injectStoredRRID fills args["rr_id"] from session state when the caller
 // did not supply one, so MCP-dependent tools can omit it after takeover.
-func injectStoredRRID(state session.State, args map[string]any, toolName string, logger logr.Logger) {
+func injectStoredRRID(state adksession.State, args map[string]any, toolName string, logger logr.Logger) {
 	if args == nil || state == nil {
 		return
 	}
@@ -120,10 +154,16 @@ func injectStoredRRID(state session.State, args map[string]any, toolName string,
 // phaseGuardAfter records successful driver-entry/session-terminal tool calls
 // into session state and, when registry is non-nil, keeps the
 // ActiveContextRegistry in sync for multi-turn session continuity (BR-SESS-020).
+// DD-AF-011 (#1899): also persists the interaction_mode signal and phase2/3
+// checkpoint flags after kubernaut_investigate/kubernaut_discover_workflows.
 func phaseGuardAfter(registry *launcher.ActiveContextRegistry, ctx tool.Context, t tool.Tool, inputArgs, resp map[string]any, callErr error) (map[string]any, error) {
 	toolName := t.Name()
 	isEntry := driverEntryTools[toolName]
 	isTerminal := sessionTerminalTools[toolName]
+	// DD-AF-011 (#1899): discover_workflows is neither a driver-entry nor
+	// a session-terminal tool, but its success still needs to persist
+	// the phase-3 checkpoint flag.
+	isDiscoverWorkflows := toolName == "kubernaut_discover_workflows"
 	isSuccess := toolCallSucceeded(callErr, resp)
 
 	// Refresh idle timer for any successful tool call to keep the
@@ -132,12 +172,20 @@ func phaseGuardAfter(registry *launcher.ActiveContextRegistry, ctx tool.Context,
 		refreshActiveContext(registry, ctx)
 	}
 
-	if (!isEntry && !isTerminal) || !isSuccess {
+	if !isEntry && !isTerminal && !isDiscoverWorkflows {
+		return resp, callErr
+	}
+	if !isSuccess {
+		return resp, callErr
+	}
+
+	if isDiscoverWorkflows {
+		recordDiscoverWorkflowsCheckpoint(ctx)
 		return resp, callErr
 	}
 
 	if isEntry {
-		recordDriverEntryState(ctx, inputArgs, resp)
+		recordDriverEntryState(ctx, toolName, inputArgs, resp)
 	}
 	syncActiveContextRegistry(registry, ctx, isEntry, isTerminal)
 
@@ -162,9 +210,32 @@ func refreshActiveContext(registry *launcher.ActiveContextRegistry, ctx tool.Con
 	}
 }
 
+// recordDiscoverWorkflowsCheckpoint persists the DD-AF-011 (#1899) phase-3
+// checkpoint flag after a successful kubernaut_discover_workflows call:
+// blocked unless the session's interaction_mode is
+// full_remediation_autonomous, in which case the harness may auto-chain
+// straight into kubernaut_select_workflow within the same turn.
+func recordDiscoverWorkflowsCheckpoint(ctx tool.Context) {
+	state := ctx.State()
+	if state == nil {
+		return
+	}
+	logger := logr.FromContextOrDiscard(ctx)
+	mode := interactionModeFromState(state)
+	blocked := mode != session.InteractionModeFullRemediationAutonomous
+	if err := state.Set(session.StateKeyPhase3Blocked, blocked); err != nil {
+		logger.Error(err, "phase-guard failed to persist phase3_blocked state")
+	}
+}
+
 // recordDriverEntryState persists driver-active flag, rr_id, and session_id
-// into session state after a successful driver-entry tool call (investigate/reconnect).
-func recordDriverEntryState(ctx tool.Context, inputArgs, resp map[string]any) {
+// into session state after a successful driver-entry tool call
+// (investigate/reconnect). DD-AF-011 (#1899): for kubernaut_investigate
+// specifically, also persists the interaction_mode signal and the
+// phase2_blocked checkpoint flag it implies — kubernaut_reconnect resumes an
+// already-established session and leaves any prior mode/checkpoint state
+// untouched.
+func recordDriverEntryState(ctx tool.Context, toolName string, inputArgs, resp map[string]any) {
 	state := ctx.State()
 	if state == nil {
 		return
@@ -185,13 +256,37 @@ func recordDriverEntryState(ctx tool.Context, inputArgs, resp map[string]any) {
 			logger.Error(err, "phase-guard failed to store session_id in state")
 		}
 	}
+
+	if toolName == "kubernaut_investigate" {
+		recordInteractionMode(state, inputArgs, logger)
+	}
+}
+
+// recordInteractionMode persists the DD-AF-011 (#1899) interaction_mode
+// declared on a successful kubernaut_investigate call (failing safe to
+// interactive when omitted/invalid, AC-6/SI-10) and the phase2_blocked
+// checkpoint flag it implies.
+func recordInteractionMode(state adksession.State, inputArgs map[string]any, logger logr.Logger) {
+	mode := session.InteractionModeInteractive
+	if inputArgs != nil {
+		if raw, ok := inputArgs["interaction_mode"].(string); ok && session.ValidInteractionMode(raw) {
+			mode = raw
+		}
+	}
+	if err := state.Set(session.StateKeyInteractionMode, mode); err != nil {
+		logger.Error(err, "phase-guard failed to persist interaction mode")
+	}
+	blocked := mode == session.InteractionModeInteractive
+	if err := state.Set(session.StateKeyPhase2Blocked, blocked); err != nil {
+		logger.Error(err, "phase-guard failed to persist phase2_blocked state")
+	}
 }
 
 // storeActiveRRID resolves the RR ID for a driver-entry tool call, preferring
 // the value in resp (kubernaut_investigate returns it) and falling back to
 // inputArgs (kubernaut_reconnect takes it as input but does not echo it in
 // the response), then persists it into session state.
-func storeActiveRRID(state session.State, resp, inputArgs map[string]any, logger logr.Logger) {
+func storeActiveRRID(state adksession.State, resp, inputArgs map[string]any, logger logr.Logger) {
 	rrID, ok := resp["rr_id"].(string)
 	if !ok || rrID == "" {
 		if inputArgs == nil {
@@ -223,6 +318,24 @@ func syncActiveContextRegistry(registry *launcher.ActiveContextRegistry, ctx too
 	case isTerminal:
 		registry.Clear(identity.Username)
 	}
+}
+
+// interactionModeFromState reads the DD-AF-011 (#1899) interaction mode
+// persisted by a prior kubernaut_investigate success, failing safe to
+// InteractionModeInteractive when unset or invalid (AC-6, SI-10).
+func interactionModeFromState(state adksession.State) string {
+	if state == nil {
+		return session.InteractionModeInteractive
+	}
+	v, err := state.Get(session.StateKeyInteractionMode)
+	if err != nil {
+		return session.InteractionModeInteractive
+	}
+	s, ok := v.(string)
+	if !ok || !session.ValidInteractionMode(s) {
+		return session.InteractionModeInteractive
+	}
+	return s
 }
 
 // NewPhaseGuardForTest exports the phase guard without registry for unit testing.

--- a/pkg/apifrontend/agent/phase_guard_test.go
+++ b/pkg/apifrontend/agent/phase_guard_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package agent
 
 import (

--- a/pkg/apifrontend/agent/phase_guard_test.go
+++ b/pkg/apifrontend/agent/phase_guard_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/session"
 )
 
 // statefulToolContext extends fakeToolContext with a working session.State
@@ -65,10 +66,10 @@ func (m *mapState) All() iter.Seq2[string, any] {
 
 var _ = Describe("Phase Guard (#1307)", func() {
 	var (
-		state    *mapState
-		toolCtx  tool.Context
-		before   func(tool.Context, tool.Tool, map[string]any) (map[string]any, error)
-		after    func(tool.Context, tool.Tool, map[string]any, map[string]any, error) (map[string]any, error)
+		state   *mapState
+		toolCtx tool.Context
+		before  func(tool.Context, tool.Tool, map[string]any) (map[string]any, error)
+		after   func(tool.Context, tool.Tool, map[string]any, map[string]any, error) (map[string]any, error)
 	)
 
 	BeforeEach(func() {
@@ -115,7 +116,11 @@ var _ = Describe("Phase Guard (#1307)", func() {
 	)
 
 	It("UT-AF-1307-010: after investigate succeeds, discover_workflows is allowed", func() {
-		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+		// DD-AF-011 (#1899): declares full_remediation so the new consent
+		// gate doesn't block phase 2 -- this test exercises driver-active
+		// gating, not the consent gate itself (see phase_guard_test.go's
+		// "DD-AF-011" Describe block for that coverage).
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, map[string]any{"interaction_mode": "full_remediation"}, map[string]any{
 			"session_id": "sess-001", "status": "active",
 		}, nil)
 
@@ -135,8 +140,10 @@ var _ = Describe("Phase Guard (#1307)", func() {
 	})
 
 	It("UT-AF-1307-013: after investigate succeeds, discover_workflows is allowed", func() {
-		// Simulate successful investigation via AfterToolCallback
-		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+		// Simulate successful investigation via AfterToolCallback.
+		// DD-AF-011 (#1899): declares full_remediation to bypass the new
+		// consent gate, since this test is about driver-active gating.
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, map[string]any{"interaction_mode": "full_remediation"}, map[string]any{
 			"session_id": "sess-inv-001", "status": "completed",
 		}, nil)
 
@@ -182,8 +189,10 @@ var _ = Describe("Phase Guard (#1307)", func() {
 	})
 
 	It("UT-AF-1307-021: before callback injects rr_id from state when LLM omits it", func() {
-		// Simulate successful investigation storing rr_id
-		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+		// Simulate successful investigation storing rr_id.
+		// DD-AF-011 (#1899): declares full_remediation to bypass the new
+		// consent gate, since this test is about rr_id injection.
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, map[string]any{"interaction_mode": "full_remediation"}, map[string]any{
 			"session_id": "sess-rr-021", "rr_id": "rr-inject-me", "status": "completed",
 		}, nil)
 
@@ -197,8 +206,10 @@ var _ = Describe("Phase Guard (#1307)", func() {
 	})
 
 	It("UT-AF-1307-022: LLM-provided rr_id is NOT overwritten by state injection", func() {
-		// Store one rr_id in state
-		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+		// Store one rr_id in state.
+		// DD-AF-011 (#1899): declares full_remediation to bypass the new
+		// consent gate, since this test is about rr_id precedence.
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, map[string]any{"interaction_mode": "full_remediation"}, map[string]any{
 			"session_id": "sess-rr-022", "rr_id": "rr-stale-state", "status": "completed",
 		}, nil)
 
@@ -270,6 +281,131 @@ var _ = Describe("Phase Guard (#1307)", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(stored).To(Equal("rr-response-new"),
 			"response rr_id must take priority over input args rr_id")
+	})
+
+	// --- DD-AF-011 (#1899): phase-transition consent gate ---
+
+	It("IT-AF-1899-002: successful investigate with no interaction_mode defaults to interactive and blocks phase 2", func() {
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+			"session_id": "sess-1899-a", "rr_id": "rr-1899-a", "status": "completed",
+		}, nil)
+
+		mode, err := state.Get(session.StateKeyInteractionMode)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mode).To(Equal(session.InteractionModeInteractive),
+			"fail-safe default: an omitted interaction_mode must resolve to interactive (AC-6)")
+
+		blocked, err := state.Get(session.StateKeyPhase2Blocked)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(blocked).To(Equal(true),
+			"interactive mode must block phase 2 (discover_workflows) until a genuine user turn")
+	})
+
+	It("IT-AF-1899-002b: successful investigate with interaction_mode=full_remediation does NOT block phase 2", func() {
+		inputArgs := map[string]any{"interaction_mode": "full_remediation"}
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, inputArgs, map[string]any{
+			"session_id": "sess-1899-b", "rr_id": "rr-1899-b", "status": "completed",
+		}, nil)
+
+		blocked, err := state.Get(session.StateKeyPhase2Blocked)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(blocked).To(Equal(false),
+			"full_remediation must auto-proceed through workflow discovery")
+	})
+
+	It("IT-AF-1899-002c: an unrecognized interaction_mode value fails safe to interactive", func() {
+		inputArgs := map[string]any{"interaction_mode": "definitely-not-a-real-mode"}
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, inputArgs, map[string]any{
+			"session_id": "sess-1899-c", "rr_id": "rr-1899-c", "status": "completed",
+		}, nil)
+
+		mode, err := state.Get(session.StateKeyInteractionMode)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mode).To(Equal(session.InteractionModeInteractive),
+			"SI-10: an invalid mode value must never grant MORE autonomy than the safest default")
+	})
+
+	It("IT-AF-1899-003: successful discover_workflows blocks phase 3 unless mode is full_remediation_autonomous", func() {
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, map[string]any{"interaction_mode": "full_remediation"}, map[string]any{
+			"session_id": "sess-1899-d", "rr_id": "rr-1899-d", "status": "completed",
+		}, nil)
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_discover_workflows"}, nil, map[string]any{
+			"workflows": []any{"wf-1"},
+		}, nil)
+
+		blocked, err := state.Get(session.StateKeyPhase3Blocked)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(blocked).To(Equal(true),
+			"full_remediation must still wait for genuine user confirmation before executing a workflow")
+	})
+
+	It("IT-AF-1899-003b: full_remediation_autonomous does NOT block phase 3", func() {
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, map[string]any{"interaction_mode": "full_remediation_autonomous"}, map[string]any{
+			"session_id": "sess-1899-e", "rr_id": "rr-1899-e", "status": "completed",
+		}, nil)
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_discover_workflows"}, nil, map[string]any{
+			"workflows": []any{"wf-1"},
+		}, nil)
+
+		blocked, err := state.Get(session.StateKeyPhase3Blocked)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(blocked).To(Equal(false),
+			"full_remediation_autonomous must auto-proceed through workflow selection")
+	})
+
+	It("IT-AF-1899-003c: a failed discover_workflows does not set phase3_blocked", func() {
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+			"session_id": "sess-1899-f", "rr_id": "rr-1899-f", "status": "completed",
+		}, nil)
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_discover_workflows"}, nil, map[string]any{
+			"error": "discovery failed",
+		}, nil)
+
+		_, err := state.Get(session.StateKeyPhase3Blocked)
+		Expect(err).To(MatchError(adksession.ErrStateKeyNotExist),
+			"a failed discover_workflows must not set a checkpoint — nothing succeeded to gate yet")
+	})
+
+	It("IT-AF-1899-005: before hard-rejects discover_workflows while phase2 is blocked, even with an active driver", func() {
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+			"session_id": "sess-1899-g", "rr_id": "rr-1899-g", "status": "completed",
+		}, nil)
+
+		result, err := before(toolCtx, fakeTool{name: "kubernaut_discover_workflows"}, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).NotTo(BeNil(),
+			"discover_workflows must be hard-rejected while phase 2 is blocked, even though a driver is active")
+		errMsg, ok := result["error"].(string)
+		Expect(ok).To(BeTrue())
+		Expect(errMsg).To(ContainSubstring("wait"),
+			"error must guide the LLM to wait for the user, not retry")
+	})
+
+	It("IT-AF-1899-005b: before hard-rejects select_workflow while phase3 is blocked", func() {
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, map[string]any{"interaction_mode": "full_remediation"}, map[string]any{
+			"session_id": "sess-1899-h", "rr_id": "rr-1899-h", "status": "completed",
+		}, nil)
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_discover_workflows"}, nil, map[string]any{
+			"workflows": []any{"wf-1"},
+		}, nil)
+
+		result, err := before(toolCtx, fakeTool{name: "kubernaut_select_workflow"}, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).NotTo(BeNil(),
+			"select_workflow must be hard-rejected while phase 3 is blocked")
+	})
+
+	It("IT-AF-1899-005c: select_workflow is allowed when the harness never blocked phase 3 (full_remediation_autonomous)", func() {
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, map[string]any{"interaction_mode": "full_remediation_autonomous"}, map[string]any{
+			"session_id": "sess-1899-i", "rr_id": "rr-1899-i", "status": "completed",
+		}, nil)
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_discover_workflows"}, nil, map[string]any{
+			"workflows": []any{"wf-1"},
+		}, nil)
+
+		result, err := before(toolCtx, fakeTool{name: "kubernaut_select_workflow"}, nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeNil(), "select_workflow must be allowed when the harness never blocked phase 3")
 	})
 })
 
@@ -362,7 +498,9 @@ var _ = Describe("Phase Guard — ActiveContextRegistry Integration (BR-SESS-020
 
 	It("UT-AF-SESS-020-025: No-op when registry is nil (backward compat)", func() {
 		beforeNil, afterNil := NewPhaseGuardWithRegistryForTest(nil)
-		_, _ = afterNil(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+		// DD-AF-011 (#1899): declares full_remediation to bypass the new
+		// consent gate, since this test is about registry backward-compat.
+		_, _ = afterNil(toolCtx, fakeTool{name: "kubernaut_investigate"}, map[string]any{"interaction_mode": "full_remediation"}, map[string]any{
 			"session_id": "ka-sess-001", "rr_id": "rr-123",
 		}, nil)
 

--- a/pkg/apifrontend/agent/prompt.txt
+++ b/pkg/apifrontend/agent/prompt.txt
@@ -198,14 +198,16 @@ NOTE: kubernaut_approve is NOT available to you. Approval and rejection actions 
 
 ## Alert Prioritization
 
+SUBORDINATE TO THE DECISION ALGORITHM AND OBSERVATION MODE (#1899): everything in this section only applies once you have already decided, per the Decision Algorithm above, that the user wants an alert investigated or remediated. It never overrides Observation Mode's consent gate. A bare "list"/"show"/"status" request is answered by `list_alerts` alone — full stop. Do NOT treat a `prioritized` field in that response as an implicit instruction to investigate anything; the user must explicitly ask before any alert is investigated or remediated.
+
 When `list_alerts` returns a `prioritized` field, the `alerts[]` array is sorted by priority (highest severity first, FIFO tiebreak). The `prioritized` indices reference positions in this array:
-- `selected_index`: Index of the highest-severity, longest-firing alert. Investigate this one.
+- `selected_index`: Index of the highest-severity, longest-firing alert. This is the one to investigate, but ONLY once the user has asked you to investigate/fix/diagnose.
 - `tied_indices`: Indices of other alerts at the same severity as selected. In interactive mode, present these to the user for confirmation. In autonomous mode, proceed with selected.
 - `also_active_start`: Index where lower-severity alerts begin (context only).
 
 If `truncated` is true, use `total_count` to know how many alerts exist beyond the returned set. Use filters (namespace, severity, state) to narrow results rather than retrying.
 
-Always use `kubernaut_investigate_alert` with `alerts[selected_index]` unless the user explicitly picks a different one from `tied_indices`.
+ONLY when the user's message already matched the Interactive/Autonomous/Full-Interactive-Remediation triggers above (not a bare "list"/"show"/"status" request): use `kubernaut_investigate_alert` with `alerts[selected_index]` unless the user explicitly picks a different one from `tied_indices`. If the user's message was purely informational, do NOT call `kubernaut_investigate_alert` — wait for their explicit follow-up request instead.
 
 ## Output Style
 Do NOT use emoji in your responses. Use plain text formatting only.

--- a/pkg/apifrontend/agent/prompt.txt
+++ b/pkg/apifrontend/agent/prompt.txt
@@ -48,7 +48,7 @@ Behavior: Create the remediation request and confirm. The pipeline handles inves
 ### Full Interactive Remediation (investigate AND fix with user oversight)
 Triggered by: "investigate and fix", "diagnose and remediate", "look into and fix", or when the user explicitly wants to see findings before choosing a workflow.
 Tool: Call `kubernaut_investigate` with namespace/kind/name or rr_id.
-Behavior: Proceed through the full Phase 1 → 2 → 3 → 4 flow. In interactive mode, pause after Phase 1 for user input. In autonomous-interactive mode (user said "fix" but context implies oversight), select the highest-confidence workflow automatically.
+Behavior: Proceed through the full Phase 1 → 2 → 3 → 4 flow. In interactive mode, pause after Phase 1 for user input — omit interaction_mode on this call (the fail-safe default already pauses correctly). In autonomous-interactive mode (user said "fix" but context implies oversight), select the highest-confidence workflow automatically — you MUST set interaction_mode: "full_remediation_autonomous" on this kubernaut_investigate call, or the phase-transition consent gate will block workflow discovery/selection waiting for a user turn that will never come (#1899).
 
 ### Observation Mode (read-only)
 Triggered by: "show me", "list", "status", "check", "what's the status of"

--- a/pkg/apifrontend/agent/prompt_test.go
+++ b/pkg/apifrontend/agent/prompt_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package agent_test
 
 import (

--- a/pkg/apifrontend/agent/prompt_test.go
+++ b/pkg/apifrontend/agent/prompt_test.go
@@ -566,3 +566,47 @@ var _ = Describe("Prompt — Alert Prioritization Consent Gate (#1899)", func() 
 			"#1899: the unconditional (unqualified) directive must not survive verbatim adjacent to the next section")
 	})
 })
+
+// =============================================================================
+// DD-AF-011 (#1899): Full Interactive Remediation must declare interaction_mode
+//
+// The harness-enforced phase-transition consent gate fails safe to
+// "interactive" whenever kubernaut_investigate's interaction_mode argument
+// is omitted or unrecognized. Before this fix, "Full Interactive
+// Remediation"'s autonomous-interactive sub-case (line: "select the
+// highest-confidence workflow automatically") told the LLM to auto-proceed
+// through discover_workflows/select_workflow, but never instructed it to
+// declare interaction_mode: full_remediation_autonomous on the triggering
+// kubernaut_investigate call. Once the consent gate went live, that
+// omission would have silently regressed the autonomous-interactive flow:
+// the gate would always fail-safe-block discover_workflows waiting for a
+// user turn that, in this mode, is never coming -- turning "investigate
+// and fix" (with oversight-implying context) into a permanent stall. This
+// closes that gap with an explicit instruction, verified textually here
+// (a live-LLM behavioral guarantee is out of scope for a prompt-content
+// test, consistent with every other prompt.txt directive in this suite).
+// =============================================================================
+
+var _ = Describe("Prompt — Full Interactive Remediation declares interaction_mode (#1899)", func() {
+	var instruction string
+
+	BeforeEach(func() {
+		cfg := agentpkg.DefaultTestConfig()
+		instruction = cfg.Instruction
+	})
+
+	It("UT-AF-1899-014: AC-6/SI-10 autonomous-interactive sub-case instructs declaring full_remediation_autonomous", func() {
+		Expect(instruction).To(ContainSubstring(`interaction_mode: "full_remediation_autonomous"`),
+			"#1899: without this explicit instruction, the consent gate's fail-safe interactive default would permanently stall the autonomous-interactive flow at discover_workflows, waiting for a user turn that never comes")
+	})
+
+	It("UT-AF-1899-015: prompt explains WHY the mode must be declared, not just what value to use", func() {
+		Expect(instruction).To(ContainSubstring("consent gate will block workflow discovery/selection"),
+			"#1899: the instruction must explain the consequence of omitting interaction_mode, not just state the value, so the directive survives future prompt edits/summarization with its rationale intact")
+	})
+
+	It("UT-AF-1899-016: interactive sub-case explicitly notes interaction_mode is omitted (fail-safe default applies)", func() {
+		Expect(instruction).To(ContainSubstring(`omit interaction_mode`),
+			"#1899: the interactive sub-case should explicitly note it relies on the fail-safe default, disambiguating it from the autonomous-interactive sub-case's explicit declaration")
+	})
+})

--- a/pkg/apifrontend/agent/prompt_test.go
+++ b/pkg/apifrontend/agent/prompt_test.go
@@ -523,3 +523,46 @@ var _ = Describe("Prompt #1430 / BR-KA-200: No-action exception in Phase 1 CRITI
 			"#1430 / AU-3: prompt must document empty options list for no-action scenario")
 	})
 })
+
+// =============================================================================
+// Issue #1899: Alert Prioritization must not override the Observation Mode
+// consent gate. Live-repro'd on a shared cluster: a bare "list active alerts"
+// query caused the LLM to autonomously call kubernaut_investigate_alert with
+// zero user consent, because the unconditional "Always use
+// kubernaut_investigate_alert..." directive had no gate on user intent/mode.
+// This is a defense-in-depth textual fix alongside the harness-enforced
+// consent guard (DD-AF-011): even within a single genuine turn (no
+// reinvocation involved), the prompt must not let Alert Prioritization
+// override Observation Mode's "unless the user EXPLICITLY requests it" rule.
+// =============================================================================
+
+var _ = Describe("Prompt — Alert Prioritization Consent Gate (#1899)", func() {
+	var instruction string
+
+	BeforeEach(func() {
+		cfg := agentpkg.DefaultTestConfig()
+		instruction = cfg.Instruction
+	})
+
+	It("UT-AF-1899-010: AC-6/SI-10 Alert Prioritization declares itself subordinate to Observation Mode", func() {
+		Expect(instruction).To(ContainSubstring("SUBORDINATE TO THE DECISION ALGORITHM AND OBSERVATION MODE"),
+			"#1899: Alert Prioritization must explicitly state it never overrides the consent gate")
+	})
+
+	It("UT-AF-1899-011: AC-6 prompt explicitly forbids treating a bare list/show/status as an implicit investigate request", func() {
+		Expect(instruction).To(ContainSubstring("Do NOT treat a `prioritized` field in that response as an implicit instruction to investigate anything"),
+			"#1899: a list_alerts response's prioritized field must not be read as investigation consent")
+	})
+
+	It("UT-AF-1899-012: AC-6/SI-10 kubernaut_investigate_alert directive is gated on a prior investigate/fix/diagnose trigger", func() {
+		Expect(instruction).To(ContainSubstring("ONLY when the user's message already matched the Interactive/Autonomous/Full-Interactive-Remediation triggers above"),
+			"#1899: kubernaut_investigate_alert must only fire once the user's intent already matched an investigate/fix trigger, not a bare list/show/status query")
+		Expect(instruction).To(ContainSubstring("If the user's message was purely informational, do NOT call `kubernaut_investigate_alert`"),
+			"#1899: prompt must explicitly forbid investigate_alert on purely informational messages")
+	})
+
+	It("UT-AF-1899-013: AC-6 prompt does not contain the old unconditional investigate_alert directive", func() {
+		Expect(instruction).NotTo(ContainSubstring("Always use `kubernaut_investigate_alert` with `alerts[selected_index]` unless the user explicitly picks a different one from `tied_indices`.\n\n## Output Style"),
+			"#1899: the unconditional (unqualified) directive must not survive verbatim adjacent to the next section")
+	})
+})

--- a/pkg/apifrontend/agent/root.go
+++ b/pkg/apifrontend/agent/root.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package agent
 
 import (

--- a/pkg/apifrontend/agent/root.go
+++ b/pkg/apifrontend/agent/root.go
@@ -72,7 +72,7 @@ func NewRootAgent(cfg AgentConfig, opts ...Option) (agent.Agent, []tool.Tool, er
 		Tools:                allTools,
 		Instruction:          cfg.Instruction,
 		InstructionProvider:  cfg.InstructionProvider,
-		BeforeModelCallbacks: []llmagent.BeforeModelCallback{historySanitizer},
+		BeforeModelCallbacks: []llmagent.BeforeModelCallback{historySanitizer, checkpointToolFilter},
 		BeforeToolCallbacks:  beforeCallbacks,
 		AfterToolCallbacks:   []llmagent.AfterToolCallback{afterMetrics, afterAudit, afterPhase, afterLog},
 	})

--- a/pkg/apifrontend/config/config.go
+++ b/pkg/apifrontend/config/config.go
@@ -5,6 +5,7 @@ package config
 
 import (
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -299,7 +300,11 @@ func defaultResilienceConfig() ResilienceConfig {
 			RetryMax:           2,
 			RetryInitBackoff:   500 * time.Millisecond,
 			RetryMaxBackoff:    5 * time.Second,
-			RetryableStatuses:  []int{502, 503, 504},
+			// 429 (Too Many Requests) is included because KA enforces a
+			// concurrency throttle (chi.Throttle); ADR-048-ADDENDUM-001
+			// requires clients to retry with backoff on throttle responses
+			// rather than fail fast.
+			RetryableStatuses: []int{http.StatusTooManyRequests, 502, 503, 504},
 		},
 		DS: DependencyConfig{
 			ConnectTimeout:     3 * time.Second,

--- a/pkg/apifrontend/launcher/reinvoking_runner.go
+++ b/pkg/apifrontend/launcher/reinvoking_runner.go
@@ -71,6 +71,14 @@ func newReinvokingRunner(inner adka2a.Runner, sessionService adksession.Service,
 // until every reinvocation has genuinely finished.
 func (r *reinvokingRunner) Run(ctx context.Context, userID, sessionID string, msg *genai.Content, cfg agent.RunConfig) iter.Seq2[*adksession.Event, error] {
 	return func(yield func(*adksession.Event, error) bool) {
+		// DD-AF-011 (#1899): clear any leftover phase checkpoint flags
+		// exactly once, here, at the genuine top-level entry point for a
+		// real inbound A2A message. This must NOT run inside the
+		// reinvocation loop below (which re-enters r.inner.Run with a
+		// synthetic message, not a real user turn) -- doing so would
+		// immediately erase a checkpoint the current turn just set.
+		r.clearCheckpointFlags(ctx, userID, sessionID)
+
 		currentMsg := msg
 		reinvokeCount := 0
 		for {
@@ -124,7 +132,50 @@ func (r *reinvokingRunner) needsReinvocation(ctx context.Context, userID, sessio
 	if resp == nil || resp.Session == nil {
 		return false
 	}
-	return session.NeedsReinvocationCtx(ctx, isv1alpha1.SessionPhaseActive, resp.Session.Events(), reinvokeCount)
+	return session.NeedsReinvocationCtx(ctx, isv1alpha1.SessionPhaseActive, resp.Session.Events(), resp.Session.State(), reinvokeCount)
+}
+
+// clearCheckpointFlags clears any DD-AF-011 (#1899) phase checkpoint flags
+// left over from a prior turn, so a genuine new user message always starts
+// with a clean slate for phase-transition consent. Per the empirically
+// confirmed spike findings (see the #1899 plan), a direct
+// sessionService.Get(...).Session.State().Set(...) call would silently no-op
+// against the real ADK InMemoryService -- Get()/Create() return copies, and
+// only AppendEvent applying Event.Actions.StateDelta durably persists to the
+// canonical stored session. This mirrors exactly what ADK's own base_flow.go
+// does automatically inside real tool callbacks; reinvokingRunner sits
+// outside any tool callback, so it must do this explicitly.
+//
+// A session-fetch failure (e.g. first-ever turn, session not yet created) is
+// logged and treated as "nothing to clear" -- fail safe, never block the
+// turn on this best-effort cleanup.
+func (r *reinvokingRunner) clearCheckpointFlags(ctx context.Context, userID, sessionID string) {
+	resp, getErr := r.sessionService.Get(ctx, &adksession.GetRequest{
+		AppName:   r.appName,
+		UserID:    userID,
+		SessionID: sessionID,
+	})
+	if getErr != nil || resp == nil || resp.Session == nil {
+		return
+	}
+
+	state := resp.Session.State()
+	phase2, _ := state.Get(session.StateKeyPhase2Blocked)
+	phase3, _ := state.Get(session.StateKeyPhase3Blocked)
+	if phase2 != true && phase3 != true {
+		return
+	}
+
+	event := adksession.NewEvent("checkpoint-clear")
+	event.Actions.StateDelta = map[string]any{
+		session.StateKeyPhase2Blocked: false,
+		session.StateKeyPhase3Blocked: false,
+	}
+	if appendErr := r.sessionService.AppendEvent(ctx, resp.Session, event); appendErr != nil {
+		r.logger.Error(appendErr, "failed to clear checkpoint flags for new user turn",
+			"session_id", sessionID,
+		)
+	}
 }
 
 // plainRunnerAdapter adapts a real *runner.Runner (whose Run method has an

--- a/pkg/apifrontend/launcher/reinvoking_runner_test.go
+++ b/pkg/apifrontend/launcher/reinvoking_runner_test.go
@@ -78,10 +78,16 @@ func toolCallModelEvent(invocationID string) *adksession.Event {
 var _ = Describe("reinvokingRunner (BR-SESS-013, issue #1776)", func() {
 	It("UT-AF-REINV-002: Run() re-invokes when last event has no tool call (session Active, count < Max)", func() {
 		sessionSvc := adksession.InMemoryService()
-		_, err := sessionSvc.Create(context.Background(), &adksession.CreateRequest{
+		createResp, err := sessionSvc.Create(context.Background(), &adksession.CreateRequest{
 			AppName: "test-app", UserID: "user-1", SessionID: "sess-1",
 		})
 		Expect(err).NotTo(HaveOccurred())
+		// DD-AF-011 (#1899): reinvocation now also requires an active driver
+		// session in state -- this test represents a genuinely stalled
+		// mid-investigation continuation, so declare one.
+		driverEvt := adksession.NewEvent("setup")
+		driverEvt.Actions.StateDelta = map[string]any{session.StateKeyDriverActive: true}
+		Expect(sessionSvc.AppendEvent(context.Background(), createResp.Session, driverEvt)).To(Succeed())
 
 		fake := &scriptedRunner{
 			sessionSvc: sessionSvc,
@@ -127,5 +133,157 @@ var _ = Describe("reinvokingRunner (BR-SESS-013, issue #1776)", func() {
 		Expect(fake.calls).To(HaveLen(1),
 			"Run() must NOT re-invoke the inner runner when the last event already contains a tool call")
 		Expect(events).To(HaveLen(1))
+	})
+})
+
+// checkpointRunnerCall records the DD-AF-011 (#1899) checkpoint-flag values
+// observed in session state at the moment a given inner Run() call started,
+// so tests can prove exactly when (and how often) clearing happened.
+type checkpointRunnerCall struct {
+	phase2AtEntry any
+	phase3AtEntry any
+}
+
+// checkpointObservingRunner is a fake inner Runner that records the
+// checkpoint-flag state visible at the start of each call, optionally
+// applying a scripted mid-call state mutation (sideEffects) before yielding
+// its response event -- used to simulate a tool call (e.g. a re-triggered
+// kubernaut_investigate) re-blocking a checkpoint within the same genuine
+// top-level turn.
+type checkpointObservingRunner struct {
+	sessionSvc  adksession.Service
+	appName     string
+	responses   []*adksession.Event
+	sideEffects map[int]map[string]any
+	calls       []checkpointRunnerCall
+}
+
+func (r *checkpointObservingRunner) Run(ctx context.Context, userID, sessionID string, _ *genai.Content, _ agent.RunConfig) iter.Seq2[*adksession.Event, error] {
+	callIdx := len(r.calls)
+	return func(yield func(*adksession.Event, error) bool) {
+		resp, err := r.sessionSvc.Get(ctx, &adksession.GetRequest{AppName: r.appName, UserID: userID, SessionID: sessionID})
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		p2, _ := resp.Session.State().Get(session.StateKeyPhase2Blocked)
+		p3, _ := resp.Session.State().Get(session.StateKeyPhase3Blocked)
+		r.calls = append(r.calls, checkpointRunnerCall{phase2AtEntry: p2, phase3AtEntry: p3})
+
+		if delta, ok := r.sideEffects[callIdx]; ok {
+			effect := adksession.NewEvent("side-effect")
+			effect.Actions.StateDelta = delta
+			if appendErr := r.sessionSvc.AppendEvent(ctx, resp.Session, effect); appendErr != nil {
+				yield(nil, appendErr)
+				return
+			}
+		}
+
+		if callIdx >= len(r.responses) {
+			return
+		}
+		refreshed, err := r.sessionSvc.Get(ctx, &adksession.GetRequest{AppName: r.appName, UserID: userID, SessionID: sessionID})
+		if err != nil {
+			yield(nil, err)
+			return
+		}
+		event := r.responses[callIdx]
+		if appendErr := r.sessionSvc.AppendEvent(ctx, refreshed.Session, event); appendErr != nil {
+			yield(nil, appendErr)
+			return
+		}
+		yield(event, nil)
+	}
+}
+
+var _ = Describe("reinvokingRunner checkpoint-flag clearing (DD-AF-011, #1899)", func() {
+	const appName = "test-app"
+
+	It("IT-AF-1899-006: a genuine top-level Run() call clears leftover checkpoint flags before invoking the inner runner", func() {
+		ctx := context.Background()
+		sessionSvc := adksession.InMemoryService()
+		createResp, err := sessionSvc.Create(ctx, &adksession.CreateRequest{
+			AppName: appName, UserID: "user-1", SessionID: "sess-ckpt-1",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Simulate leftover blocked checkpoints from a prior turn (e.g. the
+		// user asked a question mid-investigation and never confirmed).
+		leftover := adksession.NewEvent("leftover")
+		leftover.Actions.StateDelta = map[string]any{
+			session.StateKeyPhase2Blocked: true,
+			session.StateKeyPhase3Blocked: true,
+		}
+		Expect(sessionSvc.AppendEvent(ctx, createResp.Session, leftover)).To(Succeed())
+
+		fake := &checkpointObservingRunner{
+			sessionSvc: sessionSvc,
+			appName:    appName,
+			responses:  []*adksession.Event{toolCallModelEvent("inv-1")},
+		}
+		rr := launcher.NewReinvokingRunnerForTest(fake, sessionSvc, appName, logr.Discard())
+
+		for _, runErr := range rr.Run(ctx, "user-1", "sess-ckpt-1", genai.NewContentFromText("go ahead", genai.RoleUser), agent.RunConfig{}) {
+			Expect(runErr).NotTo(HaveOccurred())
+		}
+
+		Expect(fake.calls).To(HaveLen(1))
+		Expect(fake.calls[0].phase2AtEntry).To(Equal(false),
+			"a genuine top-level user turn must clear af_phase2_blocked before the inner runner is ever invoked")
+		Expect(fake.calls[0].phase3AtEntry).To(Equal(false),
+			"a genuine top-level user turn must clear af_phase3_blocked before the inner runner is ever invoked")
+	})
+
+	It("IT-AF-1899-007: a checkpoint re-blocked mid-turn correctly suppresses reinvocation and is NOT wiped by Run() itself afterward", func() {
+		ctx := context.Background()
+		sessionSvc := adksession.InMemoryService()
+		createResp, err := sessionSvc.Create(ctx, &adksession.CreateRequest{
+			AppName: appName, UserID: "user-1", SessionID: "sess-ckpt-2",
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		leftover := adksession.NewEvent("leftover")
+		leftover.Actions.StateDelta = map[string]any{
+			session.StateKeyPhase2Blocked: true,
+			session.StateKeyDriverActive:  true,
+		}
+		Expect(sessionSvc.AppendEvent(ctx, createResp.Session, leftover)).To(Succeed())
+
+		fake := &checkpointObservingRunner{
+			sessionSvc: sessionSvc,
+			appName:    appName,
+			// call 0 re-blocks phase2 mid-turn (as phaseGuardAfter would
+			// after an in-turn kubernaut_investigate) and ends with a
+			// text-only event (no tool call). Per DD-AF-011 (#1899), a
+			// blocked checkpoint must ALSO suppress reinvocation itself
+			// (never nudge past a gate the harness just put up) -- so this
+			// call is expected to be the ONLY inner call for this turn.
+			sideEffects: map[int]map[string]any{
+				0: {session.StateKeyPhase2Blocked: true},
+			},
+			responses: []*adksession.Event{
+				textOnlyModelEvent("inv-1", "let me think about that"),
+				toolCallModelEvent("inv-2"),
+			},
+		}
+		rr := launcher.NewReinvokingRunnerForTest(fake, sessionSvc, appName, logr.Discard())
+
+		for _, runErr := range rr.Run(ctx, "user-1", "sess-ckpt-2", genai.NewContentFromText("go ahead", genai.RoleUser), agent.RunConfig{}) {
+			Expect(runErr).NotTo(HaveOccurred())
+		}
+
+		Expect(fake.calls).To(HaveLen(1),
+			"a checkpoint re-blocked mid-turn must suppress reinvocation for the rest of THIS turn -- "+
+				"the model must wait for the user, not be nudged again")
+		Expect(fake.calls[0].phase2AtEntry).To(Equal(false),
+			"the genuine top-level call must see the leftover checkpoint cleared before it runs")
+
+		getResp, err := sessionSvc.Get(ctx, &adksession.GetRequest{AppName: appName, UserID: "user-1", SessionID: "sess-ckpt-2"})
+		Expect(err).NotTo(HaveOccurred())
+		final, err := getResp.Session.State().Get(session.StateKeyPhase2Blocked)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(final).To(Equal(true),
+			"Run() must NOT clear the checkpoint flag a second time after correctly deciding not to reinvoke -- "+
+				"clearCheckpointFlags only runs once, at genuine top-level entry, never mid-loop")
 	})
 })

--- a/pkg/apifrontend/launcher/reinvoking_runner_test.go
+++ b/pkg/apifrontend/launcher/reinvoking_runner_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package launcher_test
 
 import (

--- a/pkg/apifrontend/session/consent.go
+++ b/pkg/apifrontend/session/consent.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package session
 
 // DD-AF-011 (#1899): Phase-Transition Consent Guard.

--- a/pkg/apifrontend/session/consent.go
+++ b/pkg/apifrontend/session/consent.go
@@ -1,0 +1,65 @@
+package session
+
+// DD-AF-011 (#1899): Phase-Transition Consent Guard.
+//
+// These constants define the harness-enforced consent gate's session.State
+// backchannel: a structural signal for which interaction mode the LLM
+// declared on kubernaut_investigate, and which phase transitions the
+// harness has gated pending genuine user confirmation. They live in this
+// package (rather than pkg/apifrontend/agent, where the tool-filter and
+// phase-guard callbacks that read/write them are implemented) because
+// pkg/apifrontend/session/reinvoke.go's NeedsReinvocationCtx also needs
+// them, and both pkg/apifrontend/agent and pkg/apifrontend/launcher already
+// import this package -- avoiding an import cycle.
+const (
+	// StateKeyDriverActive records whether an interactive driver session
+	// (a successful kubernaut_investigate or kubernaut_reconnect) is active.
+	// Mirrors pkg/apifrontend/agent/phase_guard.go's pre-existing
+	// af_interactive_driver_active key.
+	StateKeyDriverActive = "af_interactive_driver_active"
+
+	// StateKeyActiveRRID records the RemediationRequest ID established by
+	// the active driver session. Mirrors phase_guard.go's pre-existing
+	// af_active_rr_id key.
+	StateKeyActiveRRID = "af_active_rr_id"
+
+	// StateKeyInteractionMode records the interaction_mode declared on the
+	// most recent successful kubernaut_investigate call.
+	StateKeyInteractionMode = "af_interaction_mode"
+
+	// StateKeyPhase2Blocked is set true after a successful
+	// kubernaut_investigate when the declared (or defaulted) interaction
+	// mode requires waiting for genuine user confirmation before
+	// kubernaut_discover_workflows may run.
+	StateKeyPhase2Blocked = "af_phase2_blocked"
+
+	// StateKeyPhase3Blocked is set true after a successful
+	// kubernaut_discover_workflows when the declared interaction mode
+	// requires waiting for genuine user confirmation before
+	// kubernaut_select_workflow may run.
+	StateKeyPhase3Blocked = "af_phase3_blocked"
+)
+
+// Interaction mode values for InteractionMode / StateKeyInteractionMode.
+//
+// InteractionModeInteractive is the fail-safe default (AC-6 least
+// privilege): every phase transition waits for genuine user confirmation.
+// Any unrecognized/invalid value provided by the LLM must resolve to this
+// mode, never to a more autonomous one (SI-10).
+const (
+	InteractionModeInteractive               = "interactive"
+	InteractionModeFullRemediation           = "full_remediation"
+	InteractionModeFullRemediationAutonomous = "full_remediation_autonomous"
+)
+
+// ValidInteractionMode reports whether mode is one of the recognized
+// InteractionMode* values. Callers must fail safe to
+// InteractionModeInteractive when this returns false.
+func ValidInteractionMode(mode string) bool {
+	switch mode {
+	case InteractionModeInteractive, InteractionModeFullRemediation, InteractionModeFullRemediationAutonomous:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/apifrontend/session/reinvoke.go
+++ b/pkg/apifrontend/session/reinvoke.go
@@ -22,21 +22,28 @@ const (
 )
 
 // NeedsReinvocation determines whether the agent should be re-invoked based
-// on session phase, event history, and reinvocation count. Returns true when:
+// on session phase, event history, state, and reinvocation count. Returns
+// true when:
 //  1. Phase is Active (not Disconnected, not terminal)
 //  2. Events are non-empty
 //  3. Last event has no FunctionCall parts (text-only turn end)
 //  4. reinvokeCount < MaxReinvocations
+//  5. An interactive driver session is active in state (DD-AF-011, #1899:
+//     a text-only turn with no investigation ever started is the model
+//     legitimately answering a question, not a stalled investigation)
+//  6. No phase-2/phase-3 checkpoint is blocked in state (DD-AF-011, #1899:
+//     reinvocation must never nudge the model past a consent gate the
+//     harness deliberately put up)
 //
 // Wired into StreamingExecutor.Execute via WithReinvocation option.
-func NeedsReinvocation(phase v1alpha1.SessionPhase, events adksession.Events, reinvokeCount int) bool {
-	return NeedsReinvocationCtx(context.Background(), phase, events, reinvokeCount)
+func NeedsReinvocation(phase v1alpha1.SessionPhase, events adksession.Events, state adksession.State, reinvokeCount int) bool {
+	return NeedsReinvocationCtx(context.Background(), phase, events, state, reinvokeCount)
 }
 
 // NeedsReinvocationCtx is the context-aware variant of NeedsReinvocation.
 // Returns false when ctx is cancelled, preventing ghost re-invocation cascades
 // that fail immediately with "context canceled" (#1435).
-func NeedsReinvocationCtx(ctx context.Context, phase v1alpha1.SessionPhase, events adksession.Events, reinvokeCount int) bool {
+func NeedsReinvocationCtx(ctx context.Context, phase v1alpha1.SessionPhase, events adksession.Events, state adksession.State, reinvokeCount int) bool {
 	if ctx.Err() != nil {
 		return false
 	}
@@ -51,7 +58,53 @@ func NeedsReinvocationCtx(ctx context.Context, phase v1alpha1.SessionPhase, even
 	}
 
 	last := events.At(events.Len() - 1)
-	return !hasToolCall(last)
+	if hasToolCall(last) {
+		return false
+	}
+
+	if !driverActive(state) {
+		return false
+	}
+	if checkpointBlocked(state) {
+		return false
+	}
+
+	return true
+}
+
+// driverActive reports whether an interactive driver session (a successful
+// kubernaut_investigate/kubernaut_reconnect) is recorded in state. A nil or
+// unreadable state fails safe to "no driver" -- never nudge.
+func driverActive(state adksession.State) bool {
+	if state == nil {
+		return false
+	}
+	v, err := state.Get(StateKeyDriverActive)
+	if err != nil {
+		return false
+	}
+	b, ok := v.(bool)
+	return ok && b
+}
+
+// checkpointBlocked reports whether either DD-AF-011 (#1899) phase
+// checkpoint is currently blocking, i.e. the harness is waiting for genuine
+// user confirmation before the next phase transition.
+func checkpointBlocked(state adksession.State) bool {
+	if state == nil {
+		return false
+	}
+	if v, err := state.Get(StateKeyPhase2Blocked); err == nil {
+		if b, ok := v.(bool); ok && b {
+			return true
+		}
+	}
+	if v, err := state.Get(StateKeyPhase3Blocked); err == nil {
+		if b, ok := v.(bool); ok && b {
+			return true
+		}
+	}
+	return false
 }
 
 // SyntheticMessage returns a user-role content message used to prompt the

--- a/pkg/apifrontend/session/reinvoke.go
+++ b/pkg/apifrontend/session/reinvoke.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package session
 
 import (

--- a/pkg/apifrontend/session/reinvoke_test.go
+++ b/pkg/apifrontend/session/reinvoke_test.go
@@ -2,6 +2,7 @@ package session_test
 
 import (
 	"context"
+	"iter"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -17,6 +18,47 @@ import (
 const (
 	agent = "agent"
 )
+
+// fakeState is a minimal, self-contained adksession.State implementation
+// (deliberately independent of the real adksession.InMemoryService) used to
+// control DD-AF-011 (#1899) checkpoint/mode flags without the side effect of
+// polluting the Events() count -- setting state via a real session's
+// AppendEvent would itself append an event, defeating "does not trigger with
+// empty events"-style tests.
+type fakeState struct {
+	data map[string]any
+}
+
+func newFakeState(flags map[string]any) *fakeState {
+	data := make(map[string]any, len(flags))
+	for k, v := range flags {
+		data[k] = v
+	}
+	return &fakeState{data: data}
+}
+
+func (f *fakeState) Get(key string) (any, error) {
+	v, ok := f.data[key]
+	if !ok {
+		return nil, adksession.ErrStateKeyNotExist
+	}
+	return v, nil
+}
+
+func (f *fakeState) Set(key string, value any) error {
+	f.data[key] = value
+	return nil
+}
+
+func (f *fakeState) All() iter.Seq2[string, any] {
+	return func(yield func(string, any) bool) {
+		for k, v := range f.data {
+			if !yield(k, v) {
+				return
+			}
+		}
+	}
+}
 
 var _ = Describe("Re-invocation Fallback", func() {
 	ctx := context.Background()
@@ -39,6 +81,14 @@ var _ = Describe("Re-invocation Fallback", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 		return getResp.Session.Events()
+	}
+
+	// activeDriverState is the DD-AF-011 baseline for "mid-investigation, no
+	// checkpoint gate active" -- the scenario all the pre-#1899 tests were
+	// written against, now made explicit since driver-active is a mandatory
+	// precondition for reinvocation.
+	activeDriverState := func() adksession.State {
+		return newFakeState(map[string]any{session.StateKeyDriverActive: true})
 	}
 
 	textEvent := func() *adksession.Event {
@@ -67,19 +117,19 @@ var _ = Describe("Re-invocation Fallback", func() {
 
 	It("UT-AF-230-001: detects text-only turn end during active investigation", func() {
 		events := getEvents(textEvent())
-		result := session.NeedsReinvocation(v1alpha1.SessionPhaseActive, events, 0)
+		result := session.NeedsReinvocation(v1alpha1.SessionPhaseActive, events, activeDriverState(), 0)
 		Expect(result).To(BeTrue())
 	})
 
 	It("UT-AF-230-002: does not trigger with tool calls", func() {
 		events := getEvents(toolCallEvent())
-		result := session.NeedsReinvocation(v1alpha1.SessionPhaseActive, events, 0)
+		result := session.NeedsReinvocation(v1alpha1.SessionPhaseActive, events, activeDriverState(), 0)
 		Expect(result).To(BeFalse())
 	})
 
 	It("UT-AF-230-003: does not trigger when terminal", func() {
 		events := getEvents(textEvent())
-		result := session.NeedsReinvocation(v1alpha1.SessionPhaseCompleted, events, 0)
+		result := session.NeedsReinvocation(v1alpha1.SessionPhaseCompleted, events, activeDriverState(), 0)
 		Expect(result).To(BeFalse())
 	})
 
@@ -93,25 +143,25 @@ var _ = Describe("Re-invocation Fallback", func() {
 
 	It("UT-AF-230-005: tracks reinvocation count", func() {
 		events := getEvents(textEvent())
-		result := session.NeedsReinvocation(v1alpha1.SessionPhaseActive, events, 1)
+		result := session.NeedsReinvocation(v1alpha1.SessionPhaseActive, events, activeDriverState(), 1)
 		Expect(result).To(BeTrue())
 	})
 
 	It("UT-AF-230-006: stops after max reinvocations", func() {
 		events := getEvents(textEvent())
-		result := session.NeedsReinvocation(v1alpha1.SessionPhaseActive, events, session.MaxReinvocations)
+		result := session.NeedsReinvocation(v1alpha1.SessionPhaseActive, events, activeDriverState(), session.MaxReinvocations)
 		Expect(result).To(BeFalse())
 	})
 
 	It("UT-AF-230-007: does not trigger when Disconnected", func() {
 		events := getEvents(textEvent())
-		result := session.NeedsReinvocation(v1alpha1.SessionPhaseDisconnected, events, 0)
+		result := session.NeedsReinvocation(v1alpha1.SessionPhaseDisconnected, events, activeDriverState(), 0)
 		Expect(result).To(BeFalse())
 	})
 
 	It("UT-AF-230-008: does not trigger with empty events", func() {
 		events := getEvents()
-		result := session.NeedsReinvocation(v1alpha1.SessionPhaseActive, events, 0)
+		result := session.NeedsReinvocation(v1alpha1.SessionPhaseActive, events, activeDriverState(), 0)
 		Expect(result).To(BeFalse())
 	})
 
@@ -119,15 +169,56 @@ var _ = Describe("Re-invocation Fallback", func() {
 		events := getEvents(textEvent())
 		cancelledCtx, cancel := context.WithCancel(ctx)
 		cancel()
-		result := session.NeedsReinvocationCtx(cancelledCtx, v1alpha1.SessionPhaseActive, events, 0)
+		result := session.NeedsReinvocationCtx(cancelledCtx, v1alpha1.SessionPhaseActive, events, activeDriverState(), 0)
 		Expect(result).To(BeFalse(),
 			"#1435: re-invocation must not fire when context is already cancelled")
 	})
 
 	It("UT-AF-1435-011: triggers normally when context is active", func() {
 		events := getEvents(textEvent())
-		result := session.NeedsReinvocationCtx(ctx, v1alpha1.SessionPhaseActive, events, 0)
+		result := session.NeedsReinvocationCtx(ctx, v1alpha1.SessionPhaseActive, events, activeDriverState(), 0)
 		Expect(result).To(BeTrue(),
 			"re-invocation should still fire when context is healthy")
+	})
+
+	// --- DD-AF-011 (#1899): mode/flag-aware reinvocation gate ---
+
+	It("UT-AF-1899-001: does NOT nudge when no driver session is active (literal #1899 repro)", func() {
+		// No af_interactive_driver_active flag at all -- e.g. the user asked
+		// a plain question and the model answered in Observation Mode. There
+		// was never an investigation to "continue".
+		events := getEvents(textEvent())
+		result := session.NeedsReinvocation(v1alpha1.SessionPhaseActive, events, nil, 0)
+		Expect(result).To(BeFalse(),
+			"#1899: reinvocation must never nudge investigation into existence when none was ever requested")
+	})
+
+	It("UT-AF-1899-002: does NOT nudge while af_phase2_blocked is set, even with an active driver", func() {
+		events := getEvents(textEvent())
+		state := newFakeState(map[string]any{
+			session.StateKeyDriverActive:  true,
+			session.StateKeyPhase2Blocked: true,
+		})
+		result := session.NeedsReinvocation(v1alpha1.SessionPhaseActive, events, state, 0)
+		Expect(result).To(BeFalse(),
+			"reinvocation must not push the model past a phase-2 checkpoint the harness deliberately gated")
+	})
+
+	It("UT-AF-1899-003: does NOT nudge while af_phase3_blocked is set, even with an active driver", func() {
+		events := getEvents(textEvent())
+		state := newFakeState(map[string]any{
+			session.StateKeyDriverActive:  true,
+			session.StateKeyPhase3Blocked: true,
+		})
+		result := session.NeedsReinvocation(v1alpha1.SessionPhaseActive, events, state, 0)
+		Expect(result).To(BeFalse(),
+			"reinvocation must not push the model past a phase-3 checkpoint the harness deliberately gated")
+	})
+
+	It("UT-AF-1899-004: DOES nudge with an active driver and no checkpoint blocked (regression: legitimate continuation still works)", func() {
+		events := getEvents(textEvent())
+		result := session.NeedsReinvocation(v1alpha1.SessionPhaseActive, events, activeDriverState(), 0)
+		Expect(result).To(BeTrue(),
+			"a genuinely stalled mid-investigation turn (driver active, no checkpoint gate) must still be nudged")
 	})
 })

--- a/pkg/apifrontend/session/reinvoke_test.go
+++ b/pkg/apifrontend/session/reinvoke_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package session_test
 
 import (

--- a/pkg/apifrontend/tools/ka_investigate_mcp.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp.go
@@ -94,6 +94,18 @@ type InvestigateMCPArgs struct {
 	// the rr_id takeover path, since the cluster identity is read back from
 	// the existing RR object instead). Empty for the local hub cluster.
 	ClusterID string `json:"cluster_id,omitempty"`
+
+	// InteractionMode declares how much autonomy the harness should grant
+	// for phase transitions following this investigation (DD-AF-011,
+	// #1899). One of "interactive" (default when omitted -- wait for
+	// genuine user confirmation before discover_workflows/select_workflow),
+	// "full_remediation" (auto-proceed to workflow discovery, but still
+	// wait for user confirmation before executing a workflow), or
+	// "full_remediation_autonomous" (auto-proceed through both discovery
+	// and execution -- only use this when the user explicitly requested
+	// full, unattended remediation). An omitted or unrecognized value fails
+	// safe to "interactive" (AC-6 least privilege, SI-10 input validation).
+	InteractionMode string `json:"interaction_mode,omitempty" jsonschema:"one of interactive (default), full_remediation, full_remediation_autonomous -- declares how much autonomy to grant for post-investigation phase transitions"`
 }
 
 // InvestigateMCPResult is the output of the MCP investigate tool.

--- a/pkg/apifrontend/tools/ka_investigate_mcp_test.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp_test.go
@@ -217,6 +217,36 @@ var _ = Describe("HandleInvestigationMCP — #1326 BR-MCP-002 non-blocking MCP i
 	})
 })
 
+var _ = Describe("DD-AF-011 (#1899): InteractionMode field on InvestigateMCPArgs", func() {
+
+	Describe("IT-AF-1899-001: interaction_mode is a JSON-visible argument on kubernaut_investigate", func() {
+		It("should serialize a declared mode under the interaction_mode key", func() {
+			args := tools.InvestigateMCPArgs{
+				RRID:            "rr-1899-001",
+				InteractionMode: "full_remediation_autonomous",
+			}
+			b, err := json.Marshal(args)
+			Expect(err).NotTo(HaveOccurred())
+
+			var decoded map[string]any
+			Expect(json.Unmarshal(b, &decoded)).To(Succeed())
+			Expect(decoded["interaction_mode"]).To(Equal("full_remediation_autonomous"),
+				"the LLM-visible JSON key must be interaction_mode so the ADK tool schema exposes it")
+		})
+
+		It("should omit interaction_mode from JSON when left empty (fail-safe default is implicit)", func() {
+			args := tools.InvestigateMCPArgs{RRID: "rr-1899-002"}
+			b, err := json.Marshal(args)
+			Expect(err).NotTo(HaveOccurred())
+
+			var decoded map[string]any
+			Expect(json.Unmarshal(b, &decoded)).To(Succeed())
+			Expect(decoded).NotTo(HaveKey("interaction_mode"),
+				"an omitted mode must not force the LLM to always specify one")
+		})
+	})
+})
+
 var _ = Describe("formatEventForUser — #1326 BR-MCP-008 event filtering", func() {
 
 	Describe("UT-AF-1326-040: reasoning_delta events produce text", func() {

--- a/test/e2e/fullpipeline/08_af_a2a_interactive_test.go
+++ b/test/e2e/fullpipeline/08_af_a2a_interactive_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fullpipeline
 
 import (

--- a/test/e2e/fullpipeline/09_af_cross_namespace_test.go
+++ b/test/e2e/fullpipeline/09_af_cross_namespace_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fullpipeline
 
 import (

--- a/test/e2e/fullpipeline/16_af_a2a_combined_investigate_test.go
+++ b/test/e2e/fullpipeline/16_af_a2a_combined_investigate_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fullpipeline
 
 import (

--- a/test/e2e/fullpipeline/17_af_a2a_full_interactive_remediation_test.go
+++ b/test/e2e/fullpipeline/17_af_a2a_full_interactive_remediation_test.go
@@ -32,6 +32,18 @@ import (
 // test anywhere in the suite to exercise a NextToolCall chain deeper than 2
 // tool calls, proving the #1853 N-deep chaining fix end to end against the
 // real AF binary.
+//
+// DD-AF-011 (#1899) happy-path coverage: fullInteractiveRemediationScenarioYAML
+// (test/infrastructure/shared_e2e.go) declares interaction_mode:
+// "full_remediation_autonomous" on the kubernaut_investigate call, which is
+// what authorizes the harness-enforced phase-transition consent gate
+// (checkpointToolFilter + phaseGuardBefore) to let this same-turn auto-chain
+// reach kubernaut_select_workflow/kubernaut_watch at all -- without it, the
+// gate's fail-safe "interactive" default would block discover_workflows and
+// this test would fail the same way E2E-FP-1899-001/002 prove a fire-and-
+// forget attempt is blocked. This test is therefore the E2E happy-path
+// regression proof for full_remediation_autonomous under the consent gate,
+// complementing the negative-path proofs in 18_af_a2a_consent_gate_test.go.
 var _ = Describe("AF A2A Full Interactive Remediation Full Pipeline [E2E-FP-1853-002]", Label("fp", "af", "a2a", "interactive", "issue-1853"), func() {
 
 	It("should auto-chain investigate -> discover_workflows -> select_workflow -> watch from a single combined message, with no manual pause", NodeTimeout(8*time.Minute), func(_ SpecContext) {

--- a/test/e2e/fullpipeline/17_af_a2a_full_interactive_remediation_test.go
+++ b/test/e2e/fullpipeline/17_af_a2a_full_interactive_remediation_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fullpipeline
 
 import (

--- a/test/e2e/fullpipeline/18_af_a2a_consent_gate_test.go
+++ b/test/e2e/fullpipeline/18_af_a2a_consent_gate_test.go
@@ -166,7 +166,12 @@ var _ = Describe("AF A2A Phase-Transition Consent Gate — Phase 1->2 [E2E-FP-18
 		GinkgoWriter.Printf("  Turn 4 — watch OK\n")
 
 		By("Verifying the journey completed once every phase was genuinely confirmed")
-		fpWaitForWEComplete(rrName, 60*time.Second)
+		// 5m matches the identical investigate->discover->select->execute->watch
+		// chain in 07_af_a2a_autonomous_test.go / 17_af_a2a_full_interactive_remediation_test.go:
+		// full-pipeline completion after the final "watch" turn routinely takes
+		// well over 60s under CI load (observed 90-190s for equivalent specs in
+		// the same run), so a 60s post-watch confirmation window is too tight.
+		fpWaitForWEComplete(rrName, 5*time.Minute)
 		GinkgoWriter.Printf("  Full pipeline completed for %s after the consent gate lifted on genuine turns\n", rrName)
 	})
 })
@@ -288,7 +293,12 @@ var _ = Describe("AF A2A Phase-Transition Consent Gate — Phase 2->3 [E2E-FP-18
 		GinkgoWriter.Printf("  Turn 3 — watch OK\n")
 
 		By("Verifying the journey completed once the user genuinely confirmed workflow selection")
-		fpWaitForWEComplete(rrName, 60*time.Second)
+		// 5m matches the identical investigate->discover->select->execute->watch
+		// chain in 07_af_a2a_autonomous_test.go / 17_af_a2a_full_interactive_remediation_test.go:
+		// full-pipeline completion after the final "watch" turn routinely takes
+		// well over 60s under CI load (observed 90-190s for equivalent specs in
+		// the same run), so a 60s post-watch confirmation window is too tight.
+		fpWaitForWEComplete(rrName, 5*time.Minute)
 		GinkgoWriter.Printf("  Full pipeline completed for %s after the consent gate lifted on the genuine turn\n", rrName)
 	})
 })

--- a/test/e2e/fullpipeline/18_af_a2a_consent_gate_test.go
+++ b/test/e2e/fullpipeline/18_af_a2a_consent_gate_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fullpipeline
 
 import (

--- a/test/e2e/fullpipeline/18_af_a2a_consent_gate_test.go
+++ b/test/e2e/fullpipeline/18_af_a2a_consent_gate_test.go
@@ -151,7 +151,14 @@ var _ = Describe("AF A2A Phase-Transition Consent Gate — Phase 1->2 [E2E-FP-18
 		GinkgoWriter.Printf("  Turn 2 — discover workflows OK (gate lifted on genuine user turn)\n")
 
 		By("Turn 3 (genuine): user explicitly selects a workflow — phase 2->3 gate must also lift on its own genuine turn")
-		body = fpA2ATasksSendWithContext("fp-cg2-3", turn1CtxID, taskID, "select workflow oomkill-increase-memory-v1")
+		// #1899: "select the discovered workflow" (af_select_discovered_workflow_1899)
+		// resolves to the real seeded catalog UUID, unlike the shared
+		// af_select_workflow scenario's "select workflow ..." phrase, whose
+		// hardcoded human-readable literal fails kubernaut_select_workflow's
+		// strict UUID comparison (issue #1834 upstream, confirmed via
+		// must-gather RCA) -- that failure was masking this test's own
+		// consent-gate PASS behind an unrelated invalid_workflow error.
+		body = fpA2ATasksSendWithContext("fp-cg2-3", turn1CtxID, taskID, "select the discovered workflow")
 		resp3, err := fpA2AInvokeWithTimeout(body, 90*time.Second)
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = resp3.Body.Close() }()
@@ -283,7 +290,10 @@ var _ = Describe("AF A2A Phase-Transition Consent Gate — Phase 2->3 [E2E-FP-18
 		// E2E-FP-1899-001 above -- kubernaut_investigate (and the
 		// mode-authorized discover_workflows auto-chain) ran inside Turn 1
 		// itself, so their state only exists in turn1CtxID's ADK session.
-		body = fpA2ATasksSendWithContext("fp-cg3-2", turn1CtxID, taskID, "select workflow oomkill-increase-memory-v1")
+		// "select the discovered workflow" (not "select workflow ...") for
+		// the same af_select_discovered_workflow_1899/#1834 reason as
+		// E2E-FP-1899-001's Turn 3 above.
+		body = fpA2ATasksSendWithContext("fp-cg3-2", turn1CtxID, taskID, "select the discovered workflow")
 		resp2, err := fpA2AInvokeWithTimeout(body, 90*time.Second)
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = resp2.Body.Close() }()

--- a/test/e2e/fullpipeline/18_af_a2a_consent_gate_test.go
+++ b/test/e2e/fullpipeline/18_af_a2a_consent_gate_test.go
@@ -1,0 +1,278 @@
+package fullpipeline
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// E2E-FP-1899-001: AF A2A Phase-Transition Consent Gate — Phase 1->2
+// (DD-AF-011, issue #1899). A single combined message declares
+// interaction_mode=interactive on kubernaut_investigate, then scripts a
+// same-turn fire-and-forget attempt at kubernaut_discover_workflows with no
+// intervening genuine user message -- the literal #1899 repro (the console
+// team observed AF silently discarding session-scoped parameters and
+// auto-proceeding past a phase boundary the user never confirmed).
+//
+// This proves the structural (harness-enforced) gate end to end: even
+// though the scripted mock-LLM "misbehaves" and emits the discover_workflows
+// call anyway (regardless of what tools are advertised), checkpointToolFilter
+// (BeforeModelCallback) and phaseGuardBefore's hard-reject backstop
+// (BeforeToolCallback) block it, so no WorkflowExecution is ever created
+// from the single turn. It then proves the gate is not a permanent stall:
+// once the user genuinely confirms each subsequent phase (interactive mode
+// gates every transition, mirroring E2E-FP-1189-003's turn-per-phase
+// design), the journey completes to a WorkflowExecution.
+var _ = Describe("AF A2A Phase-Transition Consent Gate — Phase 1->2 [E2E-FP-1899-001]", Label("fp", "af", "a2a", "interactive", "issue-1899"), func() {
+
+	It("should block a same-turn fire-and-forget discover_workflows attempt, then complete once the user genuinely confirms each phase", NodeTimeout(8*time.Minute), func(_ SpecContext) {
+		targetNS := fpRemediateNS["consent-phase2"]
+		Expect(targetNS).NotTo(BeEmpty(), "consent-phase2 namespace must be set by SynchronizedBeforeSuite")
+
+		By("Verifying AF is reachable")
+		resp, err := afHTTPClient.Get(afBaseURL + "/healthz")
+		if err != nil || resp.StatusCode == http.StatusBadGateway || resp.StatusCode == http.StatusServiceUnavailable {
+			Skip("AF not reachable in FP cluster — skipping E2E-FP-1899-001")
+		}
+		_ = resp.Body.Close()
+
+		By("Ensuring managed target namespace exists for the consent-gate phase2 RR")
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: targetNS,
+				Labels: map[string]string{
+					"kubernaut.ai/managed":     "true",
+					"kubernaut.ai/environment": "staging",
+				},
+			},
+		}
+		if err := k8sClient.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
+			Expect(err).NotTo(HaveOccurred(), "Failed to create namespace %s", targetNS)
+		}
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(context.Background(), ns, &client.DeleteOptions{})
+		})
+
+		By("Deploying zero-replica target Deployment in isolated namespace")
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "memory-eater",
+				Namespace: targetNS,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr.To[int32](0),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "memory-eater"},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": "memory-eater"},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "app",
+							Image: "busybox:1.36",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+							},
+						}},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+
+		By("Turn 1 (single message): declare interactive mode, then fire-and-forget attempt discover_workflows in the same turn")
+		body := fpA2ATasksSend("fp-cg2-1",
+			"create and investigate then sneak workflow discovery for deployment memory-eater")
+		resp, err = fpA2AInvokeWithTimeout(body, 180*time.Second)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp.Body.Close() }()
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		rpc, parseErr := fpParseRPC(resp)
+		Expect(parseErr).NotTo(HaveOccurred())
+		Expect(rpc.Error).To(BeNil(), "blocked turn should still complete gracefully, not return a JSON-RPC error")
+		task, taskErr := fpExtractTask(rpc.Result)
+		Expect(taskErr).NotTo(HaveOccurred())
+		taskID := task.ID
+		Expect(taskID).NotTo(BeEmpty(), "A2A task ID must not be empty")
+		GinkgoWriter.Printf("  Turn 1 (blocked attempt) — task: %s (state: %s)\n", taskID, task.Status.State)
+
+		By("Verifying investigate ran (RR exists) but the fire-and-forget discover_workflows attempt never reached KA")
+		rrName := fpWaitForRRWithTargetNS(targetNS, 60*time.Second)
+		Expect(rrName).NotTo(BeEmpty())
+		fpAssertNoWEForRR(rrName)
+		GinkgoWriter.Printf("  Confirmed: no WorkflowExecution exists for %s after the blocked same-turn attempt\n", rrName)
+
+		By("Turn 2 (genuine): user explicitly asks to discover workflows — phase 1->2 gate must now lift")
+		body = fpA2ATasksSendWithTask("fp-cg2-2", taskID, "discover available workflows")
+		resp2, err := fpA2AInvokeWithTimeout(body, 90*time.Second)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp2.Body.Close() }()
+		Expect(resp2.StatusCode).To(Equal(http.StatusOK))
+		rpc, parseErr = fpParseRPC(resp2)
+		Expect(parseErr).NotTo(HaveOccurred())
+		Expect(rpc.Error).To(BeNil(), "Turn 2 (genuine discover_workflows) should not return a JSON-RPC error")
+		GinkgoWriter.Printf("  Turn 2 — discover workflows OK (gate lifted on genuine user turn)\n")
+
+		By("Turn 3 (genuine): user explicitly selects a workflow — phase 2->3 gate must also lift on its own genuine turn")
+		body = fpA2ATasksSendWithTask("fp-cg2-3", taskID, "select workflow oomkill-increase-memory-v1")
+		resp3, err := fpA2AInvokeWithTimeout(body, 90*time.Second)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp3.Body.Close() }()
+		Expect(resp3.StatusCode).To(Equal(http.StatusOK))
+		rpc, parseErr = fpParseRPC(resp3)
+		Expect(parseErr).NotTo(HaveOccurred())
+		Expect(rpc.Error).To(BeNil(), "Turn 3 (genuine select_workflow) should not return a JSON-RPC error")
+		GinkgoWriter.Printf("  Turn 3 — select workflow OK\n")
+
+		By("Turn 4 (genuine): watch remediation progress to completion")
+		body = fpA2ATasksSendWithTask("fp-cg2-4", taskID, "watch remediation progress")
+		resp4, err := fpA2AInvokeWithTimeout(body, 300*time.Second)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp4.Body.Close() }()
+		Expect(resp4.StatusCode).To(Equal(http.StatusOK))
+		rpc, parseErr = fpParseRPC(resp4)
+		Expect(parseErr).NotTo(HaveOccurred())
+		Expect(rpc.Error).To(BeNil(), "Turn 4 (genuine watch) should not return a JSON-RPC error")
+		GinkgoWriter.Printf("  Turn 4 — watch OK\n")
+
+		By("Verifying the journey completed once every phase was genuinely confirmed")
+		fpWaitForWEComplete(rrName, 60*time.Second)
+		GinkgoWriter.Printf("  Full pipeline completed for %s after the consent gate lifted on genuine turns\n", rrName)
+	})
+})
+
+// E2E-FP-1899-002: AF A2A Phase-Transition Consent Gate — Phase 2->3
+// (DD-AF-011, issue #1899, the more severe newly-discovered risk). A single
+// combined message declares interaction_mode=full_remediation on
+// kubernaut_investigate (legitimately authorizing the auto-chain into
+// kubernaut_discover_workflows), then scripts a same-turn fire-and-forget
+// attempt at kubernaut_select_workflow with a guessed workflow -- no user
+// confirmation. Selecting and executing a workflow is the more consequential
+// action (it creates a WorkflowExecution and begins remediating a live
+// resource), so this is the sharper edge of the #1899 risk: the harness must
+// let the model auto-proceed exactly as far as the declared mode authorizes
+// (through discovery) and no further.
+var _ = Describe("AF A2A Phase-Transition Consent Gate — Phase 2->3 [E2E-FP-1899-002]", Label("fp", "af", "a2a", "interactive", "issue-1899"), func() {
+
+	It("should auto-chain through discover_workflows but block a same-turn fire-and-forget select_workflow attempt, then complete once the user genuinely confirms", NodeTimeout(8*time.Minute), func(_ SpecContext) {
+		targetNS := fpRemediateNS["consent-phase3"]
+		Expect(targetNS).NotTo(BeEmpty(), "consent-phase3 namespace must be set by SynchronizedBeforeSuite")
+
+		By("Verifying AF is reachable")
+		resp, err := afHTTPClient.Get(afBaseURL + "/healthz")
+		if err != nil || resp.StatusCode == http.StatusBadGateway || resp.StatusCode == http.StatusServiceUnavailable {
+			Skip("AF not reachable in FP cluster — skipping E2E-FP-1899-002")
+		}
+		_ = resp.Body.Close()
+
+		By("Ensuring managed target namespace exists for the consent-gate phase3 RR")
+		ns := &corev1.Namespace{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: targetNS,
+				Labels: map[string]string{
+					"kubernaut.ai/managed":     "true",
+					"kubernaut.ai/environment": "staging",
+				},
+			},
+		}
+		if err := k8sClient.Create(ctx, ns); err != nil && !apierrors.IsAlreadyExists(err) {
+			Expect(err).NotTo(HaveOccurred(), "Failed to create namespace %s", targetNS)
+		}
+		DeferCleanup(func() {
+			_ = k8sClient.Delete(context.Background(), ns, &client.DeleteOptions{})
+		})
+
+		By("Deploying zero-replica target Deployment in isolated namespace")
+		dep := &appsv1.Deployment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "memory-eater",
+				Namespace: targetNS,
+			},
+			Spec: appsv1.DeploymentSpec{
+				Replicas: ptr.To[int32](0),
+				Selector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"app": "memory-eater"},
+				},
+				Template: corev1.PodTemplateSpec{
+					ObjectMeta: metav1.ObjectMeta{
+						Labels: map[string]string{"app": "memory-eater"},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{{
+							Name:  "app",
+							Image: "busybox:1.36",
+							Resources: corev1.ResourceRequirements{
+								Limits: corev1.ResourceList{
+									corev1.ResourceMemory: resource.MustParse("64Mi"),
+								},
+							},
+						}},
+					},
+				},
+			},
+		}
+		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
+
+		By("Turn 1 (single message): declare full_remediation mode (authorizes discovery), then fire-and-forget attempt select_workflow in the same turn")
+		body := fpA2ATasksSend("fp-cg3-1",
+			"create and investigate then sneak workflow selection for deployment memory-eater")
+		resp, err = fpA2AInvokeWithTimeout(body, 180*time.Second)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp.Body.Close() }()
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+		rpc, parseErr := fpParseRPC(resp)
+		Expect(parseErr).NotTo(HaveOccurred())
+		Expect(rpc.Error).To(BeNil(), "blocked turn should still complete gracefully, not return a JSON-RPC error")
+		task, taskErr := fpExtractTask(rpc.Result)
+		Expect(taskErr).NotTo(HaveOccurred())
+		taskID := task.ID
+		Expect(taskID).NotTo(BeEmpty(), "A2A task ID must not be empty")
+		GinkgoWriter.Printf("  Turn 1 (blocked attempt) — task: %s (state: %s)\n", taskID, task.Status.State)
+
+		By("Verifying investigate+discover_workflows ran (mode-authorized) but the fire-and-forget select_workflow attempt never created a WorkflowExecution")
+		rrName := fpWaitForRRWithTargetNS(targetNS, 60*time.Second)
+		Expect(rrName).NotTo(BeEmpty())
+		fpAssertNoWEForRR(rrName)
+		GinkgoWriter.Printf("  Confirmed: no WorkflowExecution exists for %s after the blocked same-turn attempt\n", rrName)
+
+		By("Turn 2 (genuine): user explicitly selects a workflow — phase 2->3 gate must now lift")
+		body = fpA2ATasksSendWithTask("fp-cg3-2", taskID, "select workflow oomkill-increase-memory-v1")
+		resp2, err := fpA2AInvokeWithTimeout(body, 90*time.Second)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp2.Body.Close() }()
+		Expect(resp2.StatusCode).To(Equal(http.StatusOK))
+		rpc, parseErr = fpParseRPC(resp2)
+		Expect(parseErr).NotTo(HaveOccurred())
+		Expect(rpc.Error).To(BeNil(), "Turn 2 (genuine select_workflow) should not return a JSON-RPC error")
+		GinkgoWriter.Printf("  Turn 2 — select workflow OK (gate lifted on genuine user turn)\n")
+
+		By("Turn 3 (genuine): watch remediation progress to completion")
+		body = fpA2ATasksSendWithTask("fp-cg3-3", taskID, "watch remediation progress")
+		resp3, err := fpA2AInvokeWithTimeout(body, 300*time.Second)
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp3.Body.Close() }()
+		Expect(resp3.StatusCode).To(Equal(http.StatusOK))
+		rpc, parseErr = fpParseRPC(resp3)
+		Expect(parseErr).NotTo(HaveOccurred())
+		Expect(rpc.Error).To(BeNil(), "Turn 3 (genuine watch) should not return a JSON-RPC error")
+		GinkgoWriter.Printf("  Turn 3 — watch OK\n")
+
+		By("Verifying the journey completed once the user genuinely confirmed workflow selection")
+		fpWaitForWEComplete(rrName, 60*time.Second)
+		GinkgoWriter.Printf("  Full pipeline completed for %s after the consent gate lifted on the genuine turn\n", rrName)
+	})
+})

--- a/test/e2e/fullpipeline/18_af_a2a_consent_gate_test.go
+++ b/test/e2e/fullpipeline/18_af_a2a_consent_gate_test.go
@@ -111,6 +111,7 @@ var _ = Describe("AF A2A Phase-Transition Consent Gate — Phase 1->2 [E2E-FP-18
 		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
 
 		By("Turn 1 (single message): declare interactive mode, then fire-and-forget attempt discover_workflows in the same turn")
+		const turn1CtxID = "ctx-fp-cg2-1"
 		body := fpA2ATasksSend("fp-cg2-1",
 			"create and investigate then sneak workflow discovery for deployment memory-eater")
 		resp, err = fpA2AInvokeWithTimeout(body, 180*time.Second)
@@ -133,7 +134,13 @@ var _ = Describe("AF A2A Phase-Transition Consent Gate — Phase 1->2 [E2E-FP-18
 		GinkgoWriter.Printf("  Confirmed: no WorkflowExecution exists for %s after the blocked same-turn attempt\n", rrName)
 
 		By("Turn 2 (genuine): user explicitly asks to discover workflows — phase 1->2 gate must now lift")
-		body = fpA2ATasksSendWithTask("fp-cg2-2", taskID, "discover available workflows")
+		// #1899: pin to Turn 1's own session context (not a "ctx-"+taskID
+		// derivation) -- kubernaut_investigate ran inside Turn 1 itself, so
+		// the af_interactive_driver_active state it set only exists in
+		// turn1CtxID's ADK session. fpA2ATasksSendWithTask would land here
+		// in a brand-new empty session and get wrongly hard-rejected with
+		// "no_active_driver" (confirmed via must-gather RCA).
+		body = fpA2ATasksSendWithContext("fp-cg2-2", turn1CtxID, taskID, "discover available workflows")
 		resp2, err := fpA2AInvokeWithTimeout(body, 90*time.Second)
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = resp2.Body.Close() }()
@@ -144,7 +151,7 @@ var _ = Describe("AF A2A Phase-Transition Consent Gate — Phase 1->2 [E2E-FP-18
 		GinkgoWriter.Printf("  Turn 2 — discover workflows OK (gate lifted on genuine user turn)\n")
 
 		By("Turn 3 (genuine): user explicitly selects a workflow — phase 2->3 gate must also lift on its own genuine turn")
-		body = fpA2ATasksSendWithTask("fp-cg2-3", taskID, "select workflow oomkill-increase-memory-v1")
+		body = fpA2ATasksSendWithContext("fp-cg2-3", turn1CtxID, taskID, "select workflow oomkill-increase-memory-v1")
 		resp3, err := fpA2AInvokeWithTimeout(body, 90*time.Second)
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = resp3.Body.Close() }()
@@ -155,7 +162,7 @@ var _ = Describe("AF A2A Phase-Transition Consent Gate — Phase 1->2 [E2E-FP-18
 		GinkgoWriter.Printf("  Turn 3 — select workflow OK\n")
 
 		By("Turn 4 (genuine): watch remediation progress to completion")
-		body = fpA2ATasksSendWithTask("fp-cg2-4", taskID, "watch remediation progress")
+		body = fpA2ATasksSendWithContext("fp-cg2-4", turn1CtxID, taskID, "watch remediation progress")
 		resp4, err := fpA2AInvokeWithTimeout(body, 300*time.Second)
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = resp4.Body.Close() }()
@@ -249,6 +256,7 @@ var _ = Describe("AF A2A Phase-Transition Consent Gate — Phase 2->3 [E2E-FP-18
 		Expect(k8sClient.Create(ctx, dep)).To(Succeed())
 
 		By("Turn 1 (single message): declare full_remediation mode (authorizes discovery), then fire-and-forget attempt select_workflow in the same turn")
+		const turn1CtxID = "ctx-fp-cg3-1"
 		body := fpA2ATasksSend("fp-cg3-1",
 			"create and investigate then sneak workflow selection for deployment memory-eater")
 		resp, err = fpA2AInvokeWithTimeout(body, 180*time.Second)
@@ -271,7 +279,11 @@ var _ = Describe("AF A2A Phase-Transition Consent Gate — Phase 2->3 [E2E-FP-18
 		GinkgoWriter.Printf("  Confirmed: no WorkflowExecution exists for %s after the blocked same-turn attempt\n", rrName)
 
 		By("Turn 2 (genuine): user explicitly selects a workflow — phase 2->3 gate must now lift")
-		body = fpA2ATasksSendWithTask("fp-cg3-2", taskID, "select workflow oomkill-increase-memory-v1")
+		// #1899: pin to Turn 1's own session context, same rationale as
+		// E2E-FP-1899-001 above -- kubernaut_investigate (and the
+		// mode-authorized discover_workflows auto-chain) ran inside Turn 1
+		// itself, so their state only exists in turn1CtxID's ADK session.
+		body = fpA2ATasksSendWithContext("fp-cg3-2", turn1CtxID, taskID, "select workflow oomkill-increase-memory-v1")
 		resp2, err := fpA2AInvokeWithTimeout(body, 90*time.Second)
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = resp2.Body.Close() }()
@@ -282,7 +294,7 @@ var _ = Describe("AF A2A Phase-Transition Consent Gate — Phase 2->3 [E2E-FP-18
 		GinkgoWriter.Printf("  Turn 2 — select workflow OK (gate lifted on genuine user turn)\n")
 
 		By("Turn 3 (genuine): watch remediation progress to completion")
-		body = fpA2ATasksSendWithTask("fp-cg3-3", taskID, "watch remediation progress")
+		body = fpA2ATasksSendWithContext("fp-cg3-3", turn1CtxID, taskID, "watch remediation progress")
 		resp3, err := fpA2AInvokeWithTimeout(body, 300*time.Second)
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = resp3.Body.Close() }()

--- a/test/e2e/fullpipeline/af_helpers_test.go
+++ b/test/e2e/fullpipeline/af_helpers_test.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package fullpipeline
 
 import (

--- a/test/e2e/fullpipeline/af_helpers_test.go
+++ b/test/e2e/fullpipeline/af_helpers_test.go
@@ -84,6 +84,16 @@ func fpA2ATasksSend(id, text string) string {
 // fpA2ATasksSendWithTask continues an existing A2A task by including taskId.
 // Includes a contextId derived from the taskId to prevent the SessionInterceptor
 // from overriding to a stale session.
+//
+// This is safe for multi-turn tests whose driver-establishing kubernaut_investigate
+// call happens on Turn 2+ (e.g. 07/08/09/17): every fpA2ATasksSendWithTask call for
+// the same taskID derives the identical "ctx-"+taskID session, so ADK session state
+// (af_interactive_driver_active, etc.) set on Turn 2 is visible on Turn 3+. It is NOT
+// safe when Turn 1 itself (via fpA2ATasksSend, whose contextId is "ctx-"+id, NOT
+// "ctx-"+taskID) already ran kubernaut_investigate -- Turn 2's derived "ctx-"+taskID
+// session is a brand-new, empty ADK session that never saw that state, so a
+// driver-gated tool call on Turn 2 is wrongly hard-rejected with "no_active_driver"
+// (issue #1899 E2E tests: use fpA2ATasksSendWithContext instead in that case).
 func fpA2ATasksSendWithTask(id, taskID, text string) string {
 	return fpBuildJSONRPC(id, "message/send", map[string]interface{}{
 		"id": taskID,
@@ -112,6 +122,30 @@ func fpA2AMessageStreamWithContext(id, contextID, text string) string {
 		"message": map[string]interface{}{
 			"messageId": "msg-" + id,
 			"contextId": contextID,
+			"role":      "user",
+			"parts": []map[string]interface{}{
+				{"kind": "text", "text": text},
+			},
+		},
+	})
+}
+
+// fpA2ATasksSendWithContext continues an existing A2A task like
+// fpA2ATasksSendWithTask, but pins contextId to the caller-supplied ctxID
+// instead of deriving one from taskID. Use this when Turn 1's own message
+// (sent via fpA2ATasksSend, whose session context is "ctx-"+turn1ID) already
+// ran a driver-establishing tool (kubernaut_investigate) chained together
+// with other tool calls in that SAME turn: subsequent genuine turns must
+// keep landing in that exact ADK session (ctxID = "ctx-"+turn1ID) to see the
+// af_interactive_driver_active / af_phase*_blocked / interaction_mode state
+// Turn 1 persisted, rather than a fresh "ctx-"+taskID session that never saw
+// it (issue #1899).
+func fpA2ATasksSendWithContext(id, ctxID, taskID, text string) string {
+	return fpBuildJSONRPC(id, "message/send", map[string]interface{}{
+		"id": taskID,
+		"message": map[string]interface{}{
+			"messageId": "msg-" + id,
+			"contextId": ctxID,
 			"role":      "user",
 			"parts": []map[string]interface{}{
 				{"kind": "text", "text": text},

--- a/test/infrastructure/fullpipeline_e2e.go
+++ b/test/infrastructure/fullpipeline_e2e.go
@@ -454,6 +454,18 @@ func SetupFullPipelineInfrastructure(ctx context.Context, clusterName, kubeconfi
 		// through discover_workflows -> select_workflow -> watch with no
 		// pause for manual workflow selection.
 		"full-interactive": fmt.Sprintf("fp-full-%s", uuid.New().String()[:8]),
+		// consent-phase2: dedicated namespace for E2E-FP-1899-001 (DD-AF-011,
+		// issue #1899 Phase 1->2 consent gate): a single message declares
+		// interaction_mode=interactive on kubernaut_investigate then attempts
+		// a same-turn fire-and-forget kubernaut_discover_workflows -- the
+		// structural gate must block it until a genuine follow-up turn.
+		"consent-phase2": fmt.Sprintf("fp-cg2-%s", uuid.New().String()[:8]),
+		// consent-phase3: dedicated namespace for E2E-FP-1899-002 (DD-AF-011,
+		// issue #1899 Phase 2->3 consent gate): a single message declares
+		// interaction_mode=full_remediation (authorizing discover_workflows
+		// to auto-chain) then attempts a same-turn fire-and-forget
+		// kubernaut_select_workflow -- the gate must block only the 3rd hop.
+		"consent-phase3": fmt.Sprintf("fp-cg3-%s", uuid.New().String()[:8]),
 	}
 	_, _ = fmt.Fprintln(writer, "  📌 AF remediate namespaces:")
 	for key, ns := range afRemediateNS {

--- a/test/infrastructure/shared_e2e.go
+++ b/test/infrastructure/shared_e2e.go
@@ -373,6 +373,15 @@ func combinedRemediateInvestigateScenarioYAML(ns string) string {
 // nested recommended.workflow_id field, so the LLM "reads" the recommended
 // workflow the same way afSelectWorkflowID already does for the manual-select
 // scenario below. Returns "" if ns is empty.
+//
+// interaction_mode=full_remediation_autonomous (DD-AF-011, issue #1899) is
+// declared on the investigate call so the harness-enforced phase-transition
+// consent gate authorizes this same-turn auto-chain all the way through
+// select_workflow -- without it, the gate's fail-safe default (interactive)
+// would block kubernaut_discover_workflows and this scenario's 4-deep chain
+// would never reach kubernaut_watch. This doubles as the E2E happy-path
+// regression proof that full_remediation_autonomous still auto-chains
+// correctly under the consent gate (E2E-FP-1899 coverage matrix).
 func fullInteractiveRemediationScenarioYAML(ns, selectWorkflowID string) string {
 	if ns == "" {
 		return ""
@@ -387,6 +396,7 @@ func fullInteractiveRemediationScenarioYAML(ns, selectWorkflowID string) string 
             kind: "Deployment"
             name: "memory-eater"
             api_version: "apps/v1"
+            interaction_mode: "full_remediation_autonomous"
         next_tool_call:
           name: "kubernaut_discover_workflows"
           arguments:
@@ -400,6 +410,104 @@ func fullInteractiveRemediationScenarioYAML(ns, selectWorkflowID string) string 
               name: "kubernaut_watch"
               arguments:
                 name: "$from_tool:kubernaut_investigate:rr_id"
+`, ns, selectWorkflowID)
+}
+
+// consentGatePhase2AttemptScenarioYAML returns a keyword scenario for
+// E2E-FP-1899-001 (DD-AF-011, issue #1899 Phase 1->2 consent gate): a single
+// message chains kubernaut_remediate -> kubernaut_investigate (declaring
+// interaction_mode=interactive explicitly) -> a same-turn fire-and-forget
+// attempt at kubernaut_discover_workflows with no intervening genuine user
+// message -- the literal #1899 repro. The real AF/A2A stack must
+// structurally block the 3rd hop (checkpointToolFilter removes the tool
+// from the model's tool list; phaseGuardBefore hard-rejects it as a
+// defense-in-depth backstop even though this scripted mock-LLM "misbehaves"
+// and attempts the call anyway), so no WorkflowExecution is ever created
+// from this single turn.
+//
+// Starting from kubernaut_remediate (rather than kubernaut_investigate
+// directly, as fullInteractiveRemediationScenarioYAML above does) is
+// deliberate: it puts a kubernaut_remediate response in the conversation
+// history, which the existing af_discover_workflows/af_select_workflow/
+// af_watch keyword scenarios below require to resolve their own
+// $from_tool:kubernaut_remediate:rr_id argument -- letting the test's
+// genuine follow-up turns (proving the journey completes once the user
+// actually confirms) reuse those scenarios exactly as 08's multi-turn
+// interactive flow already does, with zero further new scenarios. Returns
+// "" if ns is empty.
+func consentGatePhase2AttemptScenarioYAML(ns string) string {
+	if ns == "" {
+		return ""
+	}
+	return fmt.Sprintf(`      - name: "af_consent_gate_phase2_1899"
+        keywords: ["create and investigate then sneak workflow discovery"]
+        match_last_only: true
+        tool_call:
+          name: "kubernaut_remediate"
+          arguments:
+            namespace: "%s"
+            kind: "Deployment"
+            name: "memory-eater"
+            api_version: "apps/v1"
+            description: "FP E2E consent-gate phase2 attempt request (#1899)"
+        next_tool_call:
+          name: "kubernaut_investigate"
+          arguments:
+            rr_id: "$from_tool:kubernaut_remediate:rr_id"
+            interaction_mode: "interactive"
+          next_tool_call:
+            name: "kubernaut_discover_workflows"
+            arguments:
+              rr_id: "$from_tool:kubernaut_remediate:rr_id"
+`, ns)
+}
+
+// consentGatePhase3AttemptScenarioYAML returns a keyword scenario for
+// E2E-FP-1899-002 (DD-AF-011, issue #1899 Phase 2->3 consent gate, the more
+// severe newly-discovered risk): a single message chains kubernaut_remediate
+// -> kubernaut_investigate (declaring interaction_mode=full_remediation,
+// legitimately authorizing the auto-chain into kubernaut_discover_workflows)
+// -> kubernaut_discover_workflows (succeeds) -> a same-turn fire-and-forget
+// attempt at kubernaut_select_workflow with a guessed workflow -- no user
+// confirmation. The gate must let the 3rd hop through (discover_workflows
+// succeeds, mode authorizes it) but block the 4th (select_workflow), so no
+// WorkflowExecution is ever created from this single turn. selectWorkflowID
+// must be the real seeded catalog UUID (see resolveWorkflowUUID) so that IF
+// the consent gate's defense-in-depth were to fail, the scripted call would
+// otherwise have succeeded -- an invalid placeholder ID would mask a gate
+// failure behind an unrelated invalid_workflow validation error, producing
+// a false-negative test. Starts from kubernaut_remediate for the same
+// $from_tool resolution reason as consentGatePhase2AttemptScenarioYAML
+// above. Returns "" if ns is empty.
+func consentGatePhase3AttemptScenarioYAML(ns, selectWorkflowID string) string {
+	if ns == "" {
+		return ""
+	}
+	return fmt.Sprintf(`      - name: "af_consent_gate_phase3_1899"
+        keywords: ["create and investigate then sneak workflow selection"]
+        match_last_only: true
+        tool_call:
+          name: "kubernaut_remediate"
+          arguments:
+            namespace: "%s"
+            kind: "Deployment"
+            name: "memory-eater"
+            api_version: "apps/v1"
+            description: "FP E2E consent-gate phase3 attempt request (#1899)"
+        next_tool_call:
+          name: "kubernaut_investigate"
+          arguments:
+            rr_id: "$from_tool:kubernaut_remediate:rr_id"
+            interaction_mode: "full_remediation"
+          next_tool_call:
+            name: "kubernaut_discover_workflows"
+            arguments:
+              rr_id: "$from_tool:kubernaut_remediate:rr_id"
+            next_tool_call:
+              name: "kubernaut_select_workflow"
+              arguments:
+                rr_id: "$from_tool:kubernaut_remediate:rr_id"
+                workflow_id: "%s"
 `, ns, selectWorkflowID)
 }
 
@@ -529,14 +637,16 @@ func DeployMockLLMInNamespace(ctx context.Context, namespace, kubeconfigPath, im
 	// invalid_workflow (silently, unless the caller strictly asserts on
 	// tool-call success) -- root cause of the E2E-FP-1189-005 Turn 5 stall.
 	afSelectWorkflowID := resolveWorkflowUUID(workflowUUIDs, "oomkill-increase-memory-v1")
-	// #1853 mode 2/3 scenarios are registered before af_investigate below:
-	// both keywords contain the substring "investigate", and mock-llm's
-	// registry breaks confidence ties (all keyword_scenarios score 1.0) by
-	// registration order, so these must come first to win over the bare
-	// "investigate" keyword.
+	// #1853 mode 2/3 and #1899 consent-gate scenarios are registered before
+	// af_investigate below: all of their keywords contain the substring
+	// "investigate", and mock-llm's registry breaks confidence ties (all
+	// keyword_scenarios score 1.0) by registration order, so these must
+	// come first to win over the bare "investigate" keyword.
 	afKeywordYAML := "keyword_scenarios:\n" + remediateScenarios +
 		combinedRemediateInvestigateScenarioYAML(afRemediateNS["combined-investigate"]) +
 		fullInteractiveRemediationScenarioYAML(afRemediateNS["full-interactive"], afSelectWorkflowID) +
+		consentGatePhase2AttemptScenarioYAML(afRemediateNS["consent-phase2"]) +
+		consentGatePhase3AttemptScenarioYAML(afRemediateNS["consent-phase3"], afSelectWorkflowID) +
 		`      - name: "af_investigate"
         keywords: ["start investigation", "investigate", "begin investigation"]
         match_last_only: true

--- a/test/infrastructure/shared_e2e.go
+++ b/test/infrastructure/shared_e2e.go
@@ -677,6 +677,25 @@ func DeployMockLLMInNamespace(ctx context.Context, namespace, kubeconfigPath, im
           arguments:
             rr_id: "$from_tool:kubernaut_remediate:rr_id"
             workflow_id: "` + afSelectWorkflowID + `"
+      # af_select_discovered_workflow_1899 exists alongside af_select_workflow
+      # above (distinct keyword, same resolved UUID) so the #1899 consent-gate
+      # E2E tests have a dedicated, self-documenting keyword ("select the
+      # discovered workflow") for their genuine follow-up select_workflow
+      # turn, independent of whether af_select_workflow's own keyword phrase
+      # ever changes. Confirmed via must-gather RCA on release/v1.5 (where
+      # af_select_workflow still used a hardcoded human-readable literal,
+      # issue #1834): an unresolved workflow_id fails kubernaut_select_workflow
+      # with invalid_workflow, which would mask the consent gate's own PASS
+      # behind an unrelated downstream error.
+      - name: "af_select_discovered_workflow_1899"
+        keywords: ["select the discovered workflow"]
+        match_last_only: true
+        repeat_tool_call: true
+        tool_call:
+          name: "kubernaut_select_workflow"
+          arguments:
+            rr_id: "$from_tool:kubernaut_remediate:rr_id"
+            workflow_id: "` + afSelectWorkflowID + `"
       - name: "af_watch"
         keywords: ["watch remediation", "watch pipeline", "watch progress"]
         match_last_only: true


### PR DESCRIPTION
## Summary

Ports the #1899 phase-transition consent guard (DD-AF-011) from `release/v1.5` (merged in #1910) to `main`, closing #1901.

AF could auto-proceed into an investigation/remediation phase transition the user never explicitly confirmed. This adds a structural, testable consent gate — not emergent LLM prompt-following — across two phase boundaries (investigate→discover_workflows, discover_workflows→select_workflow), with defense-in-depth layers:

1. **Mode declaration** — new `interaction_mode` arg (`interactive` | `full_remediation` | `full_remediation_autonomous`) on `kubernaut_investigate`, persisted to session state. Omitted/unrecognized values fail safe to `interactive`.
2. **Primary — dynamic tool-list filtering** (`checkpointToolFilter`) — removes gated tools from the model's visible tool list while a checkpoint flag is set, so the model never sees them as an option.
3. **Backstop — hard-reject gate** (`phaseGuardBefore`) — rejects the same tools if a call ever slips past layer 2.
4. **Reinvocation gate** (`NeedsReinvocationCtx`) — never nudges continuation while blocked or before any driver session is active, closing the literal #1899 "free turn after a read-only query" repro.
5. **Prompt fix** — `prompt.txt`'s "Alert Prioritization" section is now explicitly subordinate to "Observation Mode".

Full design rationale, alternatives considered, and FedRAMP control mapping: [`docs/architecture/decisions/DD-AF-011-phase-transition-consent-guard.md`](docs/architecture/decisions/DD-AF-011-phase-transition-consent-guard.md). Test plan: [`docs/testing/1899/TEST_PLAN.md`](docs/testing/1899/TEST_PLAN.md).

## Port notes (not a straight cherry-pick)

`main` and `release/v1.5` had diverged (`main`'s `phase_guard.go`/`root.go`/`reinvoking_runner.go` were independently refactored, and `main` already had its own fix for #1834's workflow-UUID and #1853's mock-LLM N-deep `NextToolCall` chaining). Each commit was cherry-picked individually and manually reconciled against `main`'s current structure:

- `pkg/apifrontend/agent/phase_guard.go` / `root.go`: merged the v1.5 consent-guard logic into `main`'s already-refactored function structure (ADK import aliasing, existing audit helpers preserved).
- `pkg/apifrontend/tools/ka_investigate_mcp.go`: merged `InteractionMode` alongside `main`'s existing `ClusterID` field.
- `test/infrastructure/{fullpipeline_e2e.go,shared_e2e.go}`: combined `main`'s existing namespaces/mock-LLM scenarios with the new consent-gate ones; added `af_select_discovered_workflow_1899` scenario (redundant on `main`, since #1834's UUID fix already landed independently here, but kept for parity with the ported E2E tests' keyword phrasing).
- `test/e2e/fullpipeline/17_af_a2a_full_interactive_remediation_test.go`: add/add conflict, resolved by keeping `main`'s existing test and layering in the DD-AF-011 happy-path documentation.
- Fixed a `nilnil` lint gap in `checkpoint_tool_filter.go` (present in the original v1.5 file too) by adding the `//nolint:nilnil` annotation this package already uses consistently for ADK `BeforeModelCallback`s.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean on all touched packages (`pkg/apifrontend/{agent,session,launcher,tools}`, `test/{e2e/fullpipeline,infrastructure}`)
- [x] `go test ./pkg/apifrontend/...` — all packages pass
- [x] `go test ./test/services/mock-llm/...` — no regressions
- [x] Ephemeral YAML-sanity check confirmed the merged mock-LLM keyword-scenario YAML parses correctly (17 scenarios)
- [x] Verified none of the files touched in this PR are part of the pre-existing repo-wide `gofmt` drift


Made with [Cursor](https://cursor.com)