### PR TITLE
Close out #1827, #1855, #1796: AF RBAC drift fix, ACL/approve E2E gaps, mode docs, LLM client ADR

### DIFF
--- a/deploy/apifrontend/overlays/e2e/e2e-user-rbac.yaml
+++ b/deploy/apifrontend/overlays/e2e/e2e-user-rbac.yaml
@@ -2,6 +2,32 @@
 # ADR-022: All AF K8s operations (MCP bridge and A2A) use AF's ServiceAccount.
 # E2E users do not need CRD permissions for kubernaut_* tools at runtime.
 # These grants remain for E2E test fixture setup (admin kubectl).
+#
+# Removed 2026-08-04 (#1827 persona ACL-matrix E2E, incident found in CI on
+# PR #1914): this file used to also carry a broad "MCP tool authorization"
+# rule (kubernaut.ai/tools, verb=use) listing ~25 resourceNames, bound to
+# sre/ai-orchestrator/observability/remediation-approver via the
+# ClusterRoleBindings below. Because Kubernetes RBAC is additive (a SAR
+# Allowed=true from ANY matching ClusterRole/Binding wins), that block
+# silently granted every one of those 4 groups access to tools far beyond
+# what charts/kubernaut/values.yaml's apifrontend.config.rbac.personas
+# actually authorizes for them -- e.g. ai-orchestrator could call
+# kubernaut_get_effectiveness, kubernaut_get_audit_trail, kubernaut_approve,
+# etc. even though its persona entry never lists them. This defeated the
+# exact per-persona least-privilege model persona_acl_matrix_test.go
+# (TC-E2E-ACL-001) exists to prove, and went undetected because no prior
+# test asserted a *negative* (denied) case for those (persona, tool) pairs
+# through AF's real /mcp endpoint using a genuine Dex-issued token.
+#
+# The block was removed rather than reconciled with values.yaml because it
+# had already drifted from it (e.g. "kubernaut_list_alerts" here vs.
+# "list_alerts" in values.yaml's persona lists -- see the compat grant
+# below) and duplicated authority PersonaToolClusterRolesYAML already
+# derives correctly from values.yaml (afDeployE2ERBAC applies both). Removal
+# impact was verified by grepping every kubernaut_* raw MCP tool call in
+# test/e2e/apifrontend for the persona token used; the only dependency found
+# was sre's alert_prioritization_e2e_test.go calls to "kubernaut_list_alerts"
+# -- preserved narrowly below instead of restoring the full broad grant.
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -30,36 +56,6 @@ rules:
   - apiGroups: ["batch"]
     resources: ["jobs", "cronjobs"]
     verbs: ["get"]
-  # MCP tool authorization (SAR verb: "use" on kubernaut.ai/tools)
-  - apiGroups: ["kubernaut.ai"]
-    resources: ["tools"]
-    resourceNames:
-      - kubernaut_discover_workflows
-      - kubernaut_investigate
-      - kubernaut_select_workflow
-      - kubernaut_present_decision
-      - kubernaut_message
-      - kubernaut_complete
-      - kubernaut_cancel
-      - kubernaut_status
-      - kubernaut_reconnect
-      - kubernaut_remediate
-      - kubernaut_check_existing_remediation
-      - kubernaut_cancel_remediation
-      - kubernaut_watch
-      - kubernaut_approve
-      - kubernaut_list_remediations
-      - kubernaut_get_remediation
-      - kubernaut_list_workflows
-      - kubernaut_get_remediation_history
-      - kubernaut_get_effectiveness
-      - kubernaut_get_audit_trail
-      - kubernaut_list_alerts
-      - kubernaut_complete_no_action
-      - kubernaut_list_approval_requests
-      - kubernaut_get_approval_request
-      - kubernaut_await_session
-    verbs: ["use"]
   # kubernaut_remediate / kubernaut_check_existing_remediation / kubernaut_cancel_remediation / kubernaut_watch
   - apiGroups: ["kubernaut.ai"]
     resources: ["remediationrequests"]
@@ -128,4 +124,38 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: e2e-user-k8s-tools
+  apiGroup: rbac.authorization.k8s.io
+---
+# Narrow compat grant for sre only: values.yaml's sre persona list carries
+# "list_alerts" (the internal name AF's own ADK agent uses for the A2A tool
+# -- pkg/apifrontend/agent/root.go), but the raw /mcp endpoint registers the
+# same capability under a different resourceName, "kubernaut_list_alerts"
+# (pkg/apifrontend/handler/mcp_bridge.go, mcptools.go). This pre-existing
+# naming mismatch means PersonaToolClusterRolesYAML (which derives strictly
+# from values.yaml) cannot itself authorize sre's direct-MCP
+# alert_prioritization_e2e_test.go calls. Scoped to sre + this single
+# resourceName only -- see the removal note above for why the broader grant
+# this replaced was deleted rather than kept for all 4 groups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: e2e-sre-list-alerts-compat
+rules:
+  - apiGroups: ["kubernaut.ai"]
+    resources: ["tools"]
+    resourceNames:
+      - kubernaut_list_alerts
+    verbs: ["use"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: e2e-sre-list-alerts-compat
+subjects:
+  - kind: Group
+    name: sre
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: e2e-sre-list-alerts-compat
   apiGroup: rbac.authorization.k8s.io

--- a/docs/architecture/decisions/DD-LLM-011-retain-anthropicfamily-reject-agenticclaude.md
+++ b/docs/architecture/decisions/DD-LLM-011-retain-anthropicfamily-reject-agenticclaude.md
@@ -1,0 +1,79 @@
+# DD-LLM-011: Retain `anthropicfamily` on Direct `anthropic-sdk-go` — Reject `eino-ext`'s `agenticclaude`
+
+**Status**: ✅ Approved
+**Priority**: P3 (evaluation of an existing, working, non-forced component — no code change)
+**Owner**: KubernautAgent Team
+**Scope**: `pkg/kubernautagent/llm/anthropicfamily` (evaluated, unchanged), `cmd/kubernautagent/llm_builder.go` (evaluated, unchanged)
+**Related**: [DD-LLM-007](./DD-LLM-007-af-ka-anthropic-client-divergence.md) (AF/KA Anthropic client divergence boundary), [DD-LLM-010](./DD-LLM-010-eino-agenticgemini-for-ka-gemini-client.md) (eino-ext adoption precedent for KA's Gemini client, which deferred this exact evaluation), [DD-KA-019-001](./DD-KA-019-go-rewrite-design/DD-KA-019-001-framework-selection.md) (Framework Isolation Pattern), [DD-LLM-006](./DD-LLM-006-bedrock-dual-client-routing.md) (Bedrock dual-client routing), [BR-AI-086](../../requirements/BR-AI-086-llm-reasoning-token-support.md), Issue #1796, #1778
+
+---
+
+## Context & Problem
+
+DD-LLM-010 adopted `cloudwego/eino-ext`'s `components/model/agenticgemini` for KA's new native Gemini client (`pkg/kubernautagent/llm/geminifamily`, #1778), bringing `cloudwego/eino` and `cloudwego/eino-ext` into KA's `go.mod` for the first time. That DD explicitly deferred — not decided — a follow-up question it raised itself: `eino-ext` also ships a `components/model/agenticclaude` component (Claude/Anthropic, the same `eino/schema.AgenticMessage` contract as `agenticgemini`), and now that `eino` is already a dependency, should KA's existing `anthropicfamily.Client` (built directly on `anthropic-sdk-go`, ~300 LOC of hand-written protocol logic) be replaced by a thin wrapper over `agenticclaude`, the way `geminifamily` wraps `agenticgemini`?
+
+Unlike DD-LLM-010's Gemini decision, this is **not forced by a capability gap** — `anthropicfamily` is working, tested code on KA's primary/most-used LLM path (native `provider: anthropic` and `provider: vertex_ai` when the configured model is Claude, both dispatched from `cmd/kubernautagent/llm_builder.go`'s `buildLLMClientFromConfig`). The only premise that changed since DD-LLM-007 rejected Anthropic-client unification is dependency cost: `eino` is now "reuse an existing dependency" rather than "add a new one." This DD re-runs the alternatives analysis under that changed premise, as DD-LLM-010 committed to do.
+
+### Alternatives Considered
+
+#### Alternative A — Retain `anthropicfamily.Client` unchanged, built directly on `anthropic-sdk-go` (chosen)
+
+- **Pros**: Zero regression risk to a working, tested capability (see Discovery Spike Findings below — `agenticclaude` currently regresses on three fronts). No new adapter-layer risk introduced to KA's primary LLM path. `anthropicfamily`'s explicit design intent (`client.go:17-44`) and its "zero ADK coupling" characterization — the evidence DD-LLM-007's Alternative C relies on to justify AF/KA divergence — remain completely unaffected, since nothing about `anthropicfamily` changes.
+- **Cons**: `anthropicfamily` remains a second hand-maintained Anthropic protocol adapter (alongside AF's `adk-anthropic-go`), each independently exposed to upstream `anthropic-sdk-go` API changes. No native AWS Bedrock-for-Claude path (see below).
+
+#### Alternative B — Replace `anthropicfamily.Client` with a thin wrapper over `eino-ext`'s `agenticclaude` (rejected)
+
+- **Pros**: Reuses an already-present dependency (`eino` core, pinned at the exact version `agenticclaude` needs — zero eino-core version delta) rather than adding one. Would establish a uniform "thin adapter over eino-ext" pattern across both of KA's Google/Anthropic clients (mirroring `geminifamily`). `agenticclaude` supports Function Tools, Deferred Tools, and Server Tools (web search/fetch/code exec) — broader tool-call surface than `anthropicfamily` currently implements. Gains native AWS Bedrock support (`Config.ByBedrock`) that `anthropicfamily` currently lacks and has deferred to #1582 (DD-LLM-006).
+- **Cons** (confirmed by direct inspection of `agenticclaude`'s source on `cloudwego/eino-ext@main`, not assumption):
+  1. **`agenticclaude` silently drops `RedactedThinkingBlock` on incoming responses** (`convertor.go:601-603`: explicitly discards it rather than mapping it to a field). `anthropicfamily` captures and replays redacted thinking blocks today (`client.go:511-516`, `432-444`), proven by `UT-KA-1580-108`/`UT-KA-1580-111`. Adopting `agenticclaude` as-is would be a **regression** in a tested, working capability, not parity.
+  2. **No per-call thinking override.** `agenticclaude`'s `Thinking` config is fixed at `Model` construction (`model.go:469-471`, `184`) with no `model.Option` equivalent in `claudeOptions` (`option.go`). `anthropicfamily` supports both a construction-time default (`WithReasoning`) *and* a per-call override that wins (`client.go:106-118`, `309-319`), proven by `UT-KA-1578-203`. This is a second regression relative to today's tested behavior.
+  3. **No `output_config.effort` support for Claude.** A repo-wide `grep -rn -i "outputconfig|output_config|effort"` across all of `agenticclaude`'s source returns exactly two hits, both in `model.go`'s `ExtraFields` doc comment — a generic, provider-agnostic example (`"reasoning_effort": "high"` against a hypothetical model `"o1"`, i.e. an OpenAI reasoning-model example, not a Claude-specific feature). There is no dedicated `Effort`/`OutputConfig` field on `Config`/`claudeOptions` the way `anthropicfamily.Client.buildParams` sets `params.OutputConfig.Effort` directly (`client.go:316-317`, BR-AI-086's #1604 unified `Effort` knob — see DD-LLM-007's Update note). `agenticclaude`'s `ExtraFields`/`WithExtraFields` top-level JSON-merge escape hatch is an untested, unverified bridging path for reproducing this — it would need its own discovery spike before being relied on, not assumed to work identically to a first-class field.
+  4. **No built-in error classification.** `agenticclaude.Generate`/`.Stream` only wrap errors with `fmt.Errorf("...: %w", err)` (`model.go:342`, `387`) — no retryable/non-retryable typing. Since `%w` preserves the unwrap chain, a wrapping adapter could still reimplement `anthropicfamily.classifyErr`'s `errors.As(err, &anthropic.Error{})` logic today (`client.go:274-286`) — meaning adopting `agenticclaude` would **not** reduce KA's hand-written surface for this concern at all; it would need to be rewritten, not inherited.
+  5. Net LOC/complexity reduction is smaller than DD-LLM-010's Gemini case: `geminifamily`'s own precedent (`conv.go`) shows `eino-ext` adoption does not eliminate the KA-type ↔ eino-type translation layer, only the wire-protocol/HTTP-transport layer `anthropicfamily` already gets for free from `anthropic-sdk-go` directly. The marginal benefit here is materially smaller than for Gemini, where KA had *no* existing client at all.
+
+### Discovery Spike Findings (`agenticclaude`, verified against `cloudwego/eino-ext@main`)
+
+Verified by direct source inspection (`convertor.go`, `model.go`, `option.go`, `event_convertor.go`) and `go list -m -versions`, not documentation claims alone:
+
+- **Regression #1 — dropped `RedactedThinkingBlock`**: `convertor.go:601-603` explicitly discards redacted thinking content (`// Drop redacted thinking block; return nil, nil`) instead of mapping it to `schema.Reasoning`.
+- **Regression #2 — no per-call thinking override**: `Thinking` is `Model`-construction-scoped only (`model.go:469-471`); `claudeOptions` (`option.go`) has no per-call equivalent.
+- **Regression #3 — no `effort`/`output_config` support**: zero matches for `outputconfig|output_config|effort` across the entire component source.
+- **Not a regression — error classification**: `agenticclaude` has none (`model.go:342`, `387`, plain `fmt.Errorf` wraps); a replacement adapter would have to write this logic itself either way, same cost as today.
+- **Advantage — native Bedrock support**: `Config.ByBedrock` (`model.go:147-173`, `261-279`), which `anthropicfamily` lacks (tracked separately under #1582/DD-LLM-006).
+- **Advantage — no unexported-contract coupling**: unlike `geminifamily`'s `ThoughtSignature` workaround (DD-LLM-010's Discovery Spike Findings), `agenticclaude` uses the **public** `schema.Reasoning.Signature`/`.Text` fields directly (`convertor.go:284`, `589-591`) — so *if* the three regressions above were fixed upstream, adopting it would not require reproducing an unversioned private-key hack the way `geminifamily` did.
+- Tool-call round-tripping and streaming (including thinking-delta and signature-delta streaming, `event_convertor.go:119-123`) are at parity or broader than `anthropicfamily`.
+
+### Decision
+
+**Alternative A** — retain `anthropicfamily.Client` unchanged, built directly on `anthropic-sdk-go`. Do **not** adopt `eino-ext`'s `agenticclaude` at this time. `anthropicfamily` has no forcing bug or capability gap; `agenticclaude` currently has three confirmed regressions against `anthropicfamily`'s existing, tested behavior (dropped redacted-thinking blocks, no per-call thinking override, no effort-dial support) that would have to be accepted or separately worked around to adopt it. The dependency-footprint argument that motivated re-opening this question (eino is now "reuse" not "add") does not, by itself, outweigh those regressions.
+
+**DD-LLM-007 is not revised.** Its Alternative C evidence — that `anthropicfamily` has "zero ADK coupling" and is cheap to maintain independently of AF's `adk-anthropic-go` — remains entirely accurate, since this decision leaves `anthropicfamily`'s internals untouched. The AF/KA Anthropic-client divergence boundary DD-LLM-007 establishes is unaffected by this evaluation either way.
+
+**Revisit conditions** (not a blocking commitment, just the trigger that would make re-evaluation worthwhile): if `eino-ext` closes the redacted-thinking-block gap, adds a per-call thinking override, and adds `effort`/`output_config` support upstream, the cost/benefit shifts materially and this DD should be re-opened. Separately, if AWS Bedrock support for Claude becomes an actual forcing requirement, evaluate extending DD-LLM-006's existing Bedrock dual-client-routing pattern first, as a more narrowly-scoped fix than a full client replacement.
+
+## Consequences
+
+### Positive
+- Avoids adopting a regression into a working, tested, BR-AI-086-relevant capability (redacted-thinking replay, per-call thinking override, effort dial) for no forcing reason.
+- No new dependency surface added to KA's primary/most-used LLM path (`eino`/`eino-ext` remain scoped to `geminifamily` only, per DD-LLM-010's original intent).
+- DD-LLM-007's AF/KA divergence boundary and its supporting evidence remain valid with zero required updates.
+- Closes issue #1796 with a documented, evidence-based decision instead of leaving the question open indefinitely.
+
+### Negative
+- `anthropicfamily` remains a second hand-maintained Anthropic protocol adapter (alongside AF's `adk-anthropic-go`), each ~300 LOC, independently exposed to `anthropic-sdk-go` API/behavior changes.
+- No native Bedrock-for-Claude path from this decision; if ever prioritized, tracked separately under #1582/DD-LLM-006.
+- This decision is time-bound to `agenticclaude`'s current state (`cloudwego/eino-ext@main`, evaluated 2026-08-03); it should be revisited, not treated as permanent, if the upstream gaps close.
+
+## Related Decisions
+- **Builds on**: DD-LLM-010 (which deferred this exact evaluation to #1796), DD-KA-019-001 (Framework Isolation Pattern)
+- **Reaffirms**: DD-LLM-007 (AF/KA Anthropic client divergence boundary — unaffected, since `anthropicfamily`'s internals are unchanged by this decision)
+- **Contrasts with**: DD-LLM-010, where eino-ext adoption *was* the right call for KA's Gemini client — that decision closed an actual capability gap (KA had zero native Gemini client); here, `anthropicfamily` has no capability gap, and the eino-ext alternative currently regresses on three fronts
+- **Related to**: DD-LLM-006 (Bedrock dual-client routing — the narrower path to Bedrock-for-Claude support if that ever becomes a forcing requirement, instead of a full client replacement)
+- **Referenced by**: #1796 (closes this issue)
+
+---
+
+**Document Control**:
+- **Created**: 2026-08-03
+- **Version**: 1.0
+- **Status**: Approved

--- a/docs/requirements/BR-INTERACTIVE.md
+++ b/docs/requirements/BR-INTERACTIVE.md
@@ -200,6 +200,43 @@ See [docs/mcp/discover-workflows-contract.md](../mcp/discover-workflows-contract
 
 ---
 
+## BR-INTERACTIVE-011: AF Remediation Mode Selection and Full Interactive Remediation
+
+**Business Requirement ID**: BR-INTERACTIVE-011
+**Priority**: P1
+**Status**: Implemented
+**GitHub Issue**: [#1855](https://github.com/jordigilh/kubernaut/issues/1855)
+
+### Business Need
+
+AF's ADK agent (`pkg/apifrontend/agent/prompt.txt`) selects between three distinct remediation modes purely from LLM judgment of user phrasing, with no explicit mode parameter or API contract. Two of the three modes (autonomous, interactive) were already formalized by BR-INTERACTIVE-001..010 and covered by tests; the third mode -- "Full Interactive Remediation" -- streams the same RCA transparency as interactive mode but then auto-selects the highest-confidence workflow and proceeds to execution without pausing for user selection. This mode existed in production and had E2E coverage (`E2E-FP-1853-002`, #1853) but no business-requirement record of its trigger phrasing, decision algorithm, or success criteria, leaving operators and future contributors with no authoritative reference for how mode selection works or why mode 3 is safe to auto-select.
+
+### Mode Selection Decision Algorithm
+
+AF's agent selects a mode per user turn based on phrasing alone (no session state, no explicit mode flag):
+
+| Mode | Trigger phrasing (examples) | Tool sequence | Pauses for user? |
+|------|------------------------------|----------------|-------------------|
+| 1. Autonomous | "fix", "remediate", "address", "resolve", "heal" (alone, no oversight implied) | `kubernaut_remediate` only | No — pipeline (AA/RO/WFE) handles investigation and workflow selection autonomously after RR creation |
+| 2. Interactive | "investigate", "what's wrong with", "diagnose", "look into" (alone) | `kubernaut_investigate` → **stop** | Yes — after RCA (Phase 1), waits for the user to explicitly drive `kubernaut_discover_workflows` → `kubernaut_select_workflow` → `kubernaut_watch` |
+| 3. Full Interactive Remediation | "investigate and fix", "diagnose and remediate", "look into and fix", or combined intent implying both transparency and completion | `kubernaut_investigate` → `kubernaut_discover_workflows` → `kubernaut_select_workflow` → `kubernaut_watch` (no pause) | No — same RCA transparency as mode 2, but auto-selects the highest-confidence workflow and proceeds straight through to a terminal state |
+
+Modes 2 and 3 share identical Phase 1 (RCA) behavior; the only branch point is whether the agent pauses after presenting findings (mode 2) or immediately proceeds to workflow discovery/selection/execution using the highest-confidence recommendation (mode 3). This mirrors `prompt.txt`'s own framing: "In interactive mode: STOP here and wait for user selection" vs. mode 3's "select the highest-confidence workflow automatically."
+
+### Success Criteria
+
+1. `prompt.txt` documents all three modes with explicit trigger-phrase lists, distinguishable by an LLM without ambiguity between mode 1 (single-verb fix intent) and mode 3 (combined investigate+fix intent)
+2. Mode 3 streams full Phase 1 (RCA) transparency to the user/A2A artifact before any workflow action is taken — parity with mode 2's transparency, not a shortcut that hides reasoning
+3. Mode 3 never pauses between Phase 1 and Phase 4 (execution) — no manual tool call is required from the user once mode 3 is triggered
+4. Mode 3 selects the workflow discovery result's highest-confidence recommendation, not an arbitrary or first-listed option
+5. Mode selection is re-evaluated per user turn from phrasing alone; there is no persistent "mode" field on RR/AIAnalysis/IS that could desynchronize from the agent's actual behavior
+
+### Contract Reference
+
+Behavioral proof: `test/e2e/fullpipeline/17_af_a2a_full_interactive_remediation_test.go` (`E2E-FP-1853-002`, #1853) drives mode 3 end-to-end (zero manual turns, terminal `WorkflowExecution`) using the `af_full_interactive_remediation_1853` mock-llm scenario (`test/infrastructure/shared_e2e.go`). Sibling mode-2 coverage: `test/e2e/fullpipeline/16_af_a2a_combined_investigate_test.go` (`E2E-FP-1853-001`). Mode 1 coverage: `E2E-FP-1189-002` (#1332). See `docs/testing/1853/TEST_PLAN.md` for the full test rationale.
+
+---
+
 ## Traceability Matrix
 
 | BR ID | PR | Checkpoint | Test Tier |
@@ -213,3 +250,4 @@ See [docs/mcp/discover-workflows-contract.md](../mcp/discover-workflows-contract
 | BR-INTERACTIVE-007 | PR1 | CP-1 | Unit |
 | BR-INTERACTIVE-008 | PR2 + PR6 | CP-2 + CP-5 | Unit + E2E |
 | BR-INTERACTIVE-009 | #1169 | — | Unit + IT + E2E |
+| BR-INTERACTIVE-011 | #1853 | — | E2E (`E2E-FP-1853-001`, `E2E-FP-1853-002`) |

--- a/docs/services/apifrontend/design/ARCHITECTURE.md
+++ b/docs/services/apifrontend/design/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # kubernaut-apifrontend Architecture Design Document
 
-**Version:** 1.1
+**Version:** 1.2
 **Status:** Accepted
-**Last Updated:** 2026-05-10
+**Last Updated:** 2026-08-03 (added Section 3.0 Operational Modes, BR-INTERACTIVE-011, #1855)
 
 ---
 
@@ -288,6 +288,24 @@ type SessionStore interface {
 ---
 
 ## 3. Data Flow
+
+### 3.0 Operational Modes
+
+AF's ADK agent selects one of three remediation modes per user turn, purely from
+phrasing in `pkg/apifrontend/agent/prompt.txt` -- there is no explicit mode
+parameter or session-level mode field.
+
+| Mode | Trigger phrasing | Behavior | BR |
+|------|-------------------|----------|-----|
+| Autonomous | "fix", "remediate", "heal" (alone) | `kubernaut_remediate` only; pipeline (AA/RO/WFE) investigates and selects a workflow with no further AF/LLM involvement | [BR-INTERACTIVE-001](../../../requirements/BR-INTERACTIVE.md#br-interactive-001-interactive-investigation-sessions) |
+| Interactive | "investigate", "diagnose", "look into" (alone) | `kubernaut_investigate` → RCA streamed to user → **stop and wait** for the user to drive discovery/selection/watch | [BR-INTERACTIVE-004](../../../requirements/BR-INTERACTIVE.md#br-interactive-004-dynamic-takeover-of-autonomous-investigations), [BR-INTERACTIVE-010](../../../requirements/BR-INTERACTIVE-010.md) |
+| Full Interactive Remediation | "investigate and fix", "diagnose and remediate" (combined) | Same RCA transparency as Interactive, but auto-selects the highest-confidence workflow and proceeds straight through to execution with no pause | [BR-INTERACTIVE-011](../../../requirements/BR-INTERACTIVE.md#br-interactive-011-af-remediation-mode-selection-and-full-interactive-remediation) |
+
+See BR-INTERACTIVE-011 for the full decision algorithm and success criteria.
+Flow 1 below illustrates the Interactive-mode "yield to user" path (`alt User
+accepts and selects workflow`); Full Interactive Remediation follows the same
+Phase 1-2 steps but takes that branch automatically without a `tasks/send`
+round-trip from the user.
 
 ### Flow 1: NL Query → Triage → RR Creation → Investigation → User Decision
 

--- a/test/e2e/apifrontend/persona_acl_matrix_test.go
+++ b/test/e2e/apifrontend/persona_acl_matrix_test.go
@@ -1,0 +1,185 @@
+package e2e_test
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	kinfra "github.com/jordigilh/kubernaut/test/infrastructure"
+)
+
+// persona ACL-matrix E2E coverage (#1827).
+//
+// Prior E2E coverage exercised individual persona/tool pairs (e.g.
+// TC-E2E-RAR-03 proves sre may kubernaut_approve, E2E-AF-WP-003 proves cicd
+// may not kubernaut_discover_workflows), but no test confirmed the full
+// values.yaml apifrontend.config.rbac.personas matrix is actually enforced
+// end-to-end through AF's real SAR-backed Authorizer (pkg/apifrontend/auth/sar.go)
+// for more than one or two personas/tools at a time.
+//
+// This suite derives its expectations directly from values.yaml (via
+// kinfra.LoadPersonaToolsFromValuesYAML, the same source of truth
+// PersonaToolClusterRolesYAML renders from -- see UT-INFRA-RBAC-002) rather
+// than hand-declaring a second "expected" table that could itself drift, as
+// happened to the AF-only E2E suite's RBAC bootstrap (2026-08-03 incident).
+//
+// probeTools is a small set of read-only, side-effect-free tools chosen
+// because their persona coverage in values.yaml varies (granted to some
+// personas, not others), so each one yields both positive and negative
+// cases across the 6 personas without needing per-tool scenario data setup.
+var probeTools = []string{
+	"kubernaut_get_effectiveness",
+	"kubernaut_list_workflows",
+	"kubernaut_get_audit_trail",
+	"kubernaut_list_approval_requests",
+	"kubernaut_get_remediation_history",
+}
+
+// probeArgs returns harmless, always-optional-or-fake arguments for a probe
+// tool so the call reaches AF's RBAC check and (if allowed) executes without
+// tripping input validation first. The exact result content doesn't matter --
+// only whether AF's response is an RBAC denial.
+func probeArgs(tool string) map[string]interface{} {
+	switch tool {
+	case "kubernaut_get_audit_trail":
+		return map[string]interface{}{"rr_id": "e2e-acl-matrix-probe"}
+	default:
+		return map[string]interface{}{}
+	}
+}
+
+// personaSession caches one Dex JWT + MCP session per persona so the 5 probe
+// tools for that persona share a single auth round-trip instead of each
+// re-authenticating from scratch (see cachedPersonaSession's doc comment).
+type personaSession struct {
+	token     string
+	sessionID string
+}
+
+// cachedPersonaSession lazily authenticates and opens an MCP session for
+// persona, memoizing the result in cache for reuse across every probeTools
+// entry for that persona.
+//
+// Fix for CI incident (2026-08-03, run against PR adding this suite): the
+// original version called fetchDEXTokenForPersona + initMCPSession fresh in
+// every one of the 30 (persona x tool) DescribeTable entries. Ginkgo
+// distributes DescribeTable entries as independent specs across
+// --procs=12, so this suite alone could put up to 30 concurrent fresh Dex
+// authentications on the single Dex pod's single Kind hostPort -> NodePort
+// path (already a known contention point per issue #1807, mitigated there
+// with a 4-attempt retry+backoff for the *existing*, smaller call volume).
+// That existing mitigation was not sized for this suite's 5x-larger burst:
+// the run saw sustained "connection reset by peer"/EOF errors on
+// https://localhost:5556/dex/token cascading into unrelated specs (in other
+// files, running concurrently) also failing to obtain their own tokens, and
+// the suite hit its 18-minute Ginkgo timeout with 81 failures.
+//
+// Caching one token+session per persona (in an Ordered container below, so
+// this map is never accessed concurrently) cuts this suite's own Dex/MCP
+// auth round-trips from 30 to 6 -- back in line with the per-suite load the
+// #1807 retry logic was actually designed to absorb.
+func cachedPersonaSession(cache map[string]personaSession, persona string) (personaSession, error) {
+	if sess, ok := cache[persona]; ok {
+		return sess, nil
+	}
+	tok, err := fetchDEXTokenForPersona(persona)
+	if err != nil {
+		return personaSession{}, fmt.Errorf("fetch token for %s: %w", persona, err)
+	}
+	sid, err := initMCPSession(tok)
+	if err != nil {
+		return personaSession{}, fmt.Errorf("init MCP session for %s: %w", persona, err)
+	}
+	sess := personaSession{token: tok, sessionID: sid}
+	cache[persona] = sess
+	return sess, nil
+}
+
+// callProbeTool invokes the probe tool using an already-authenticated
+// persona session, reporting whether AF's RBAC layer denied it.
+func callProbeTool(sess personaSession, persona, tool string) (text string, denied bool, err error) {
+	body := buildJSONRPC(fmt.Sprintf("acl-%s-%s", persona, tool), "tools/call", map[string]interface{}{
+		"name":      tool,
+		"arguments": probeArgs(tool),
+	})
+	raw, code, err := mcpPOST(sess.token, sess.sessionID, body)
+	if err != nil {
+		return "", false, err
+	}
+	if code >= 400 {
+		return string(raw), true, nil
+	}
+
+	text, toolIsError, err := parseMCPToolPayload(unwrapSSEDataLine(raw))
+	if err != nil {
+		return text, false, err
+	}
+	denied = toolIsError && strings.Contains(strings.ToLower(text), "permission denied")
+	return text, denied, nil
+}
+
+// Ordered: forces all specs in this container to run sequentially on a
+// single Ginkgo process (never parallelized against each other), which is
+// what makes the sequential, unsynchronized tokenCache map below safe and
+// also caps this suite's own Dex load to one in-flight auth at a time --
+// see cachedPersonaSession's doc comment for the incident this fixes.
+var _ = Describe("Persona ACL matrix enforcement (#1827)", Ordered, Label("e2e", "phase2", "rbac"), func() {
+	var (
+		personaTools map[string][]string
+		tokenCache   map[string]personaSession
+	)
+
+	BeforeAll(func() {
+		var err error
+		personaTools, err = kinfra.LoadPersonaToolsFromValuesYAML()
+		Expect(err).NotTo(HaveOccurred(), "values.yaml apifrontend.config.rbac.personas must be parseable")
+		Expect(personaTools).NotTo(BeEmpty())
+		tokenCache = make(map[string]personaSession, len(e2ePersonas))
+	})
+
+	// Sorted persona names so table entries are generated deterministically.
+	personaNames := make([]string, 0, len(e2ePersonas))
+	for name := range e2ePersonas {
+		personaNames = append(personaNames, name)
+	}
+	sort.Strings(personaNames)
+
+	entries := []TableEntry{}
+	for _, persona := range personaNames {
+		for _, tool := range probeTools {
+			entries = append(entries, Entry(fmt.Sprintf("%s x %s", persona, tool), persona, tool))
+		}
+	}
+
+	DescribeTable("AF grants or denies each probe tool exactly as values.yaml declares",
+		func(persona, tool string) {
+			tools, ok := personaTools[persona]
+			Expect(ok).To(BeTrue(), "values.yaml apifrontend.config.rbac.personas must define persona %q", persona)
+			allowed := false
+			for _, t := range tools {
+				if t == tool {
+					allowed = true
+					break
+				}
+			}
+
+			sess, err := cachedPersonaSession(tokenCache, persona)
+			Expect(err).NotTo(HaveOccurred(), "authentication for persona %s should not fail", persona)
+
+			text, denied, err := callProbeTool(sess, persona, tool)
+			Expect(err).NotTo(HaveOccurred(), "probe call for %s/%s should not error at the transport level", persona, tool)
+
+			if allowed {
+				Expect(denied).To(BeFalse(),
+					"persona %q has %q in values.yaml but AF's /mcp endpoint denied it: %s", persona, tool, text)
+			} else {
+				Expect(denied).To(BeTrue(),
+					"persona %q lacks %q in values.yaml but AF's /mcp endpoint allowed it: %s", persona, tool, text)
+			}
+		},
+		entries,
+	)
+})

--- a/test/e2e/apifrontend/rr_lifecycle_test.go
+++ b/test/e2e/apifrontend/rr_lifecycle_test.go
@@ -239,4 +239,53 @@ var _ = Describe("RAR Flow (G5)", Label("e2e", "phase2", "g5"), func() {
 		Expect(toolErr).To(BeFalse(), "SRE should be allowed to approve: %s", atext)
 		Expect(strings.ToLower(atext)).To(ContainSubstring("approved"))
 	})
+
+	// TC-E2E-RAR-04 (#1827): kubernaut_approve's "Approved" path is covered
+	// by RAR-01/03 above, but the "Rejected" decision was never exercised
+	// end-to-end through AF's own /mcp endpoint (only unit-tested directly
+	// against tools.HandleApprove, see kubernaut_approve_test.go) -- so a
+	// wire-level regression in the Decision="Rejected" branch (MCP argument
+	// marshaling, RBAC, or RAR status patch) had no E2E signal.
+	It("TC-E2E-RAR-04: kubernaut_approve Rejected path succeeds via AF /mcp", func() {
+		const rrName = "e2e-rr-rar04"
+		Expect(createRR(rrNamespace, rrName, "test-deploy-rar04")).To(Succeed())
+		DeferCleanup(func() { deleteRR(rrNamespace, rrName) })
+
+		approverTok, err := fetchDEXTokenForPersona("remediation-approver")
+		Expect(err).NotTo(HaveOccurred())
+		approverSession, err := initMCPSession(approverTok)
+		Expect(err).NotTo(HaveOccurred())
+
+		rarName := "e2e-rar-g5-04"
+		Expect(k8sClient.Create(context.Background(), buildRAR(rrNamespace, rarName, rrName))).To(Succeed())
+		DeferCleanup(func() {
+			rar := &remediationv1alpha1.RemediationApprovalRequest{
+				ObjectMeta: metav1.ObjectMeta{Name: rarName, Namespace: rrNamespace},
+			}
+			_ = client.IgnoreNotFound(k8sClient.Delete(context.Background(), rar))
+		})
+
+		rejBody := buildJSONRPC("g5-04-reject", "tools/call", map[string]interface{}{
+			"name": "kubernaut_approve",
+			"arguments": map[string]interface{}{
+				"rar_name": rarName,
+				"decision": "Rejected",
+				"reason":   "E2E G5 rejection (#1827)",
+			},
+		})
+		rraw, rcode, err := mcpPOST(approverTok, approverSession, rejBody)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(rcode).To(BeNumerically("<", 400))
+		rtext, toolErr, rperr := parseMCPToolPayload(unwrapSSEDataLine(rraw))
+		Expect(rperr).NotTo(HaveOccurred())
+		Expect(toolErr).To(BeFalse(), "reject should succeed (not a tool-level error): %s", rtext)
+		Expect(strings.ToLower(rtext)).To(ContainSubstring("rejected"))
+
+		By("the RAR's status.decision is persisted as Rejected")
+		rar := &remediationv1alpha1.RemediationApprovalRequest{}
+		Expect(k8sClient.Get(context.Background(), client.ObjectKey{
+			Namespace: rrNamespace, Name: rarName,
+		}, rar)).To(Succeed())
+		Expect(string(rar.Status.Decision)).To(Equal("Rejected"))
+	})
 })

--- a/test/infrastructure/apifrontend_e2e.go
+++ b/test/infrastructure/apifrontend_e2e.go
@@ -41,6 +41,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -574,54 +576,47 @@ spec:
 	return kubectlApplyStdinAF(ctx, kubeconfigPath, manifest, writer)
 }
 
+// personaOrder is the fixed, deterministic rendering order for the 6
+// per-persona ClusterRoles/ClusterRoleBindings PersonaToolClusterRolesYAML
+// generates. Must match afPersonaGroupNames (fullpipeline_e2e_helm.go) and
+// charts/kubernaut/values.yaml's apifrontend.config.rbac.personas keys.
+var personaOrder = []string{
+	"sre", "ai-orchestrator", "cicd", "observability", "l3-audit", "remediation-approver",
+}
+
 // PersonaToolClusterRolesYAML generates the 6 per-persona ClusterRoles (with
-// kubernaut.ai/tools verb=use resourceNames) and 6 ClusterRoleBindings (mapping
-// DEX OIDC groups to the ClusterRoles). Mirrors the Helm chart template that
-// generates kubernaut-tool-{persona} ClusterRoles from values.yaml personas.
+// kubernaut.ai/tools verb=use resourceNames) and 6 ClusterRoleBindings
+// (mapping DEX OIDC groups to the ClusterRoles).
 //
-// Used by both AF E2E and full-pipeline E2E deployments.
-func PersonaToolClusterRolesYAML() string {
-	type persona struct {
-		name  string
-		tools []string
-	}
-	personas := []persona{
-		{"sre", []string{
-			"kubernaut_list_remediations", "kubernaut_get_remediation", "kubernaut_approve",
-			"kubernaut_cancel_remediation", "kubernaut_watch", "kubernaut_investigate",
-			"kubernaut_discover_workflows", "kubernaut_select_workflow",
-			"kubernaut_present_decision", "kubernaut_list_workflows", "kubernaut_get_remediation_history",
-			"kubernaut_get_effectiveness", "kubernaut_get_audit_trail",
-			"kubectl_get", "kubectl_list", "kubectl_list_events",
-			"kubernaut_check_existing_remediation", "kubernaut_remediate",
-		}},
-		{"ai-orchestrator", []string{
-			"kubernaut_list_remediations", "kubernaut_get_remediation", "kubernaut_approve",
-			"kubernaut_cancel_remediation", "kubernaut_watch", "kubernaut_investigate",
-			"kubernaut_discover_workflows", "kubernaut_select_workflow",
-			"kubernaut_present_decision",
-			"kubectl_get", "kubectl_list", "kubectl_list_events",
-			"kubernaut_check_existing_remediation", "kubernaut_remediate",
-		}},
-		{"cicd", []string{
-			"kubernaut_list_remediations", "kubernaut_get_remediation", "kubernaut_watch",
-		}},
-		{"observability", []string{
-			"kubernaut_list_remediations", "kubernaut_get_remediation", "kubernaut_watch",
-			"kubernaut_get_effectiveness", "kubernaut_list_workflows",
-			"kubectl_get", "kubectl_list", "kubectl_list_events",
-		}},
-		{"l3-audit", []string{
-			"kubernaut_list_remediations", "kubernaut_get_remediation", "kubernaut_list_workflows",
-			"kubernaut_get_remediation_history", "kubernaut_get_effectiveness", "kubernaut_get_audit_trail",
-		}},
-		{"remediation-approver", []string{
-			"kubernaut_approve", "kubernaut_list_remediations", "kubernaut_get_remediation", "kubernaut_watch",
-		}},
+// Tool lists are derived directly from charts/kubernaut/values.yaml's
+// apifrontend.config.rbac.personas (via LoadPersonaToolsFromValuesYAML)
+// rather than hand-copied literals. This function used to embed its own
+// copy of each persona's tool list; that copy silently drifted out of sync
+// for 5 of 6 personas as values.yaml gained tools across #1367/#1372/#1869
+// with zero build/lint signal, breaking test/e2e/apifrontend's
+// E2E-KA-1418-001/002 (kubernaut_complete_no_action as sre) on SAR denial
+// (incident found 2026-08-03, regression-pinned by
+// UT-INFRA-RBAC-002 in rbac_parity_test.go). Deriving from values.yaml
+// eliminates this whole class of drift permanently.
+//
+// Used by AF-only E2E deployments (see afDeployE2ERBAC). Full-pipeline E2E
+// does not call this: it deploys the real chart via `helm install` and only
+// adds the ClusterRoleBindings (see bindAFPersonaToolClusterRoles,
+// fullpipeline_e2e_helm.go), so it was never subject to this drift.
+func PersonaToolClusterRolesYAML() (string, error) {
+	personaTools, err := LoadPersonaToolsFromValuesYAML()
+	if err != nil {
+		return "", fmt.Errorf("failed to load persona tool RBAC from values.yaml: %w", err)
 	}
 
 	var b strings.Builder
-	for _, p := range personas {
+	for _, name := range personaOrder {
+		tools, ok := personaTools[name]
+		if !ok {
+			return "", fmt.Errorf(
+				"persona %q (afPersonaGroupNames) not found in values.yaml apifrontend.config.rbac.personas", name)
+		}
+
 		fmt.Fprintf(&b, `---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -632,8 +627,8 @@ rules:
     resources: ["tools"]
     verbs: ["use"]
     resourceNames:
-`, p.name)
-		for _, t := range p.tools {
+`, name)
+		for _, t := range tools {
 			fmt.Fprintf(&b, "      - %q\n", t)
 		}
 
@@ -650,10 +645,40 @@ subjects:
   - kind: Group
     name: %s
     apiGroup: rbac.authorization.k8s.io
-`, p.name, p.name, p.name)
+`, name, name, name)
 	}
 
-	return b.String()
+	return b.String(), nil
+}
+
+// LoadPersonaToolsFromValuesYAML reads charts/kubernaut/values.yaml and
+// returns apifrontend.config.rbac.personas as persona name -> tool list --
+// the single source of truth PersonaToolClusterRolesYAML renders from.
+// Exported for reuse by test/e2e/apifrontend's persona ACL-matrix test
+// (#1827), so that test asserts against the same source of truth instead
+// of re-declaring a third hand-copied tool list.
+func LoadPersonaToolsFromValuesYAML() (map[string][]string, error) {
+	path := filepath.Join(getProjectRoot(), "charts", "kubernaut", "values.yaml")
+	data, err := os.ReadFile(path) //nolint:gosec // G304: known project path
+	if err != nil {
+		return nil, fmt.Errorf("failed to read values.yaml: %w", err)
+	}
+	var parsed struct {
+		APIFrontend struct {
+			Config struct {
+				RBAC struct {
+					Personas map[string][]string `yaml:"personas"`
+				} `yaml:"rbac"`
+			} `yaml:"config"`
+		} `yaml:"apifrontend"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		return nil, fmt.Errorf("failed to parse values.yaml: %w", err)
+	}
+	if len(parsed.APIFrontend.Config.RBAC.Personas) == 0 {
+		return nil, fmt.Errorf("values.yaml apifrontend.config.rbac.personas is empty or missing")
+	}
+	return parsed.APIFrontend.Config.RBAC.Personas, nil
 }
 
 // ============================================================================
@@ -793,7 +818,10 @@ metadata:
 		return fmt.Errorf("failed to deploy AF RBAC from base: %w", err)
 	}
 
-	personaToolRBAC := PersonaToolClusterRolesYAML()
+	personaToolRBAC, err := PersonaToolClusterRolesYAML()
+	if err != nil {
+		return fmt.Errorf("failed to generate persona tool ClusterRoles: %w", err)
+	}
 	if err := kubectlApplyStdinAF(ctx, kubeconfigPath, personaToolRBAC, writer); err != nil {
 		return fmt.Errorf("failed to deploy persona tool ClusterRoles: %w", err)
 	}

--- a/test/infrastructure/rbac_parity_test.go
+++ b/test/infrastructure/rbac_parity_test.go
@@ -28,6 +28,16 @@ import (
 	"k8s.io/apimachinery/pkg/util/yaml"
 )
 
+// afPersonaGroupNamesForParity mirrors afPersonaGroupNames
+// (fullpipeline_e2e_helm.go) -- the fixed, rarely-changing list of persona
+// group names AF's SAR authorization recognizes. Duplicated here (rather
+// than importing afPersonaGroupNames directly) only to keep this parity
+// test decoupled from an unrelated file's private variable; both must stay
+// in sync with charts/kubernaut/values.yaml's apifrontend.config.rbac.personas keys.
+var afPersonaGroupNamesForParity = []string{
+	"sre", "ai-orchestrator", "cicd", "observability", "l3-audit", "remediation-approver",
+}
+
 // parseClusterRoleRules reads a multi-document YAML file and returns the rules
 // for the named ClusterRole. Returns nil if not found.
 func parseClusterRoleRules(path, name string) ([]rbacv1.PolicyRule, error) {
@@ -35,6 +45,13 @@ func parseClusterRoleRules(path, name string) ([]rbacv1.PolicyRule, error) {
 	if err != nil {
 		return nil, err
 	}
+	return parseClusterRoleRulesFromYAML(data, name)
+}
+
+// parseClusterRoleRulesFromYAML is parseClusterRoleRules' shared core, split
+// out so callers already holding in-memory multi-document YAML (e.g.
+// PersonaToolClusterRolesYAML's generated output) don't need a scratch file.
+func parseClusterRoleRulesFromYAML(data []byte, name string) ([]rbacv1.PolicyRule, error) {
 	for _, doc := range strings.Split(string(data), "---") {
 		doc = strings.TrimSpace(doc)
 		if doc == "" || !strings.Contains(doc, "kind: ClusterRole") {
@@ -130,6 +147,86 @@ var _ = Describe("AF RBAC parity (UT-INFRA-RBAC-001)", func() {
 			"AC-6: least privilege — AF's takeover-path client.Get() fetch requires the 'get' verb on remediationrequests")
 	})
 })
+
+// UT-INFRA-RBAC-002: Structural parity test for PersonaToolClusterRolesYAML.
+//
+// Incident (2026-08-03): #1869/#1884 added kubernaut_get_approval_request and
+// kubernaut_complete_no_action to the sre persona in values.yaml (plus other
+// tools added over #1367/#1372's history for other personas), but
+// PersonaToolClusterRolesYAML's hand-copied tool-list literals silently
+// drifted out of sync for 5 of 6 personas -- with zero build/lint signal,
+// because both sides compiled and ran fine independently. This left
+// test/e2e/apifrontend/interactive_wiring_e2e_test.go's E2E-KA-1418-001/002
+// (which call kubernaut_complete_no_action as the sre persona through AF's
+// real /mcp endpoint) failing on SAR denial in that suite's Kind cluster,
+// even though the same calls work correctly in the fullpipeline E2E suite
+// (which binds ClusterRoleBindings to the chart's own Helm-rendered
+// ClusterRoles instead of a second hand-copied list -- see
+// bindAFPersonaToolClusterRoles's doc comment, fullpipeline_e2e_helm.go).
+//
+// This test pins PersonaToolClusterRolesYAML's generated tool set to exactly
+// match values.yaml's apifrontend.config.rbac.personas (via
+// LoadPersonaToolsFromValuesYAML), so any future persona/tool change that
+// isn't reflected in both places fails CI instead of silently breaking the
+// AF-only E2E suite.
+var _ = Describe("AF persona tool RBAC parity (UT-INFRA-RBAC-002)", func() {
+	var (
+		personaTools  map[string][]string
+		generatedYAML string
+	)
+
+	BeforeEach(func() {
+		var err error
+		personaTools, err = LoadPersonaToolsFromValuesYAML()
+		Expect(err).NotTo(HaveOccurred(), "values.yaml apifrontend.config.rbac.personas must be parseable")
+		Expect(personaTools).NotTo(BeEmpty(), "values.yaml must define at least one persona")
+
+		generatedYAML, err = PersonaToolClusterRolesYAML()
+		Expect(err).NotTo(HaveOccurred(), "PersonaToolClusterRolesYAML must succeed")
+	})
+
+	DescribeTable("generated ClusterRole tool set matches values.yaml persona",
+		func(persona string) {
+			expectedTools, ok := personaTools[persona]
+			Expect(ok).To(BeTrue(), "values.yaml apifrontend.config.rbac.personas must define persona %q", persona)
+
+			rules, err := parseClusterRoleRulesFromYAML([]byte(generatedYAML), "kubernaut-tool-"+persona)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(rules).NotTo(BeEmpty(), "generated ClusterRole kubernaut-tool-%s must have rules", persona)
+
+			var actualTools []string
+			for _, r := range rules {
+				actualTools = append(actualTools, r.ResourceNames...)
+			}
+			Expect(actualTools).To(ConsistOf(toAnySlice(expectedTools)...),
+				"kubernaut-tool-%s ClusterRole tool set drifted from values.yaml apifrontend.config.rbac.personas.%s -- "+
+					"PersonaToolClusterRolesYAML must derive from values.yaml, not a hand-copied literal", persona, persona)
+		},
+		Entry("sre", "sre"),
+		Entry("ai-orchestrator", "ai-orchestrator"),
+		Entry("cicd", "cicd"),
+		Entry("observability", "observability"),
+		Entry("l3-audit", "l3-audit"),
+		Entry("remediation-approver", "remediation-approver"),
+	)
+
+	It("covers every persona group name AF's SAR authorization recognizes", func() {
+		for _, name := range afPersonaGroupNamesForParity {
+			Expect(personaTools).To(HaveKey(name),
+				"values.yaml apifrontend.config.rbac.personas must define persona %q referenced by afPersonaGroupNames", name)
+		}
+	})
+})
+
+// toAnySlice adapts a []string to []interface{} for Gomega's ConsistOf,
+// which needs variadic interface{} elements rather than a typed slice.
+func toAnySlice(s []string) []interface{} {
+	out := make([]interface{}, len(s))
+	for i, v := range s {
+		out[i] = v
+	}
+	return out
+}
 
 var _ = Describe("IT-AF-1460-021: StatusHandler production wiring", func() {
 	It("StatusHandler is constructed in cmd/apifrontend/main.go", func() {


### PR DESCRIPTION
## Summary

Follow-up work from PR #1894, addressing the 3 issues scoped for after that merge, plus a live regression found while investigating #1827.

- **Regression fix (fix-first)**: `test/infrastructure/apifrontend_e2e.go`'s `PersonaToolClusterRolesYAML()` had a hand-copied per-persona tool list that silently drifted out of sync with `charts/kubernaut/values.yaml` for 5 of 6 personas (across #1367/#1372/#1869, zero build/lint signal). Now derives directly from `values.yaml` via `LoadPersonaToolsFromValuesYAML`, pinned by new `UT-INFRA-RBAC-002`.
- **#1827** ("AF's own /mcp endpoint has zero E2E coverage"): triaged — most of the surface already has E2E coverage. Added the 2 genuine gaps: `kubernaut_approve`'s Rejected path (`TC-E2E-RAR-04`) and a persona ACL matrix proving `values.yaml` RBAC is enforced end-to-end (`TC-E2E-ACL-001`), Ordered + token/session-cached to avoid overloading Dex (#1807).
- **#1855** (AF remediation mode selection docs): added `BR-INTERACTIVE-011` documenting the 3-mode decision algorithm (autonomous / interactive / full interactive remediation) and cross-referenced it from `ARCHITECTURE.md`.
- **#1796** (evaluate `agenticclaude` as `anthropicfamily.Client` replacement): discovery spike found confirmed regressions (dropped `RedactedThinkingBlock`, no per-call thinking override, no `effort` support, no built-in error classification) with no forcing bug to justify them. Documented in `DD-LLM-011`, reaffirming DD-LLM-007; **do not adopt**.

## Test plan

- [x] `go build ./...`
- [x] `go vet` on changed packages
- [x] `golangci-lint run` on changed packages (0 issues)
- [x] `UT-INFRA-RBAC-002` (new regression test) passes locally, confirms the drift fix
- [ ] CI: `E2E (apifrontend)` — local Kind-based runs were blocked by local-machine infra issues (Podman VM disk exhaustion from repeated image rebuilds, Dex pod overload from the new ACL-matrix test's concurrent auth — since fixed with `Ordered` + per-persona token caching) rather than any test-logic failure; relying on CI's dedicated runners for a clean signal
- [ ] CI: `E2E (fleet)`, `E2E (fullpipeline)` — no production code touched by this PR; included for regression coverage

Closes #1796. Addresses #1827, #1855 (docs-only issues to be closed manually after CI confirms).

Made with [Cursor](https://cursor.com)