### PR TITLE
fix(apifrontend): populate causal_chain/tool_calls_count in session_active fallback artifact (v1.5 backport)

### DIFF
--- a/docs/tests/1928/TEST_PLAN.md
+++ b/docs/tests/1928/TEST_PLAN.md
@@ -1,0 +1,110 @@
+# Test Plan: session_active Fallback RCA Card Content Completeness (release/v1.5 backport)
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-1928-v1
+**Feature**: `investigation_summary` fallback artifact carries `causal_chain`/`tool_calls_count` so the Console's RCA card renders on `session_active` — `release/v1.5` port of #1922/#1927
+**Version**: 1.0
+**Created**: 2026-08-04
+**Author**: AI Agent
+**Status**: Implemented (UT/IT verified locally; E2E written and passes lint/build but requires a live E2E cluster — see Section 3.3)
+**Branch**: `fix/1928-v1.5-session-active-fallback-rca-card`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This is the `release/v1.5` backport of the fix for GitHub issue #1922 (`main` implementation: #1927). The bug predates the `release/v1.5` branch cut: when KA rejects a `kubernaut_investigate` call with `session_active` (a second driver contending for an already-driven investigation), AF emits a fallback `investigation_summary` artifact built from severity-triage data alone. That artifact's `rca` object omits `causal_chain` and `tool_calls_count`, so the Console's `hasRCAData` render guard (`AgentBubble.tsx`) never shows the RCA card — the rejected user sees no diagnostic feedback at all, even though AF has honest severity/summary data to show.
+
+See #1928 for the full divergence analysis between `main` and `release/v1.5` that justified treating this as an adapted port rather than a straight cherry-pick.
+
+### 1.2 Objectives
+
+Identical to #1927's objectives (`docs/tests/1922/TEST_PLAN.md` on `main`), re-verified against `release/v1.5`'s code shape:
+
+1. **Content completeness**: the fallback `investigation_summary` artifact's `rca` object includes a non-empty `causal_chain` (and always includes `tool_calls_count`/`llm_turns`, even when zero) so the Console's render guard is satisfied.
+2. **Truthfulness**: the synthetic placeholder never fabricates findings — it states investigation status honestly (AU-3).
+3. **Shape consistency**: the fallback artifact uses the exact same JSON field names as the final `present_decision` artifact (`RCAData`), so Console parsing logic does not need a fallback-specific branch (SI-10).
+4. **Wiring proof**: both callers of the shared helper (`session_active` and KA-produced-no-events fallback) route through the fix.
+5. **Journey proof**: a real rejected concurrent driver (`session_active`, BR-INTERACTIVE-004) actually sees a rendered RCA card end-to-end.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./pkg/apifrontend/tools/... -run "UT-AF-1922" -v -count=1` |
+| Integration test pass rate | 100% | `go test ./pkg/apifrontend/tools/... -run "UT-AF-WIRE-SESSION" -v -count=1` |
+| E2E test pass rate | 100% | `make test-e2e-apifrontend GINKGO_FOCUS="1922"` |
+| Regression pass rate (pre-existing) | 100% | `WIRE-SESSION-001/002`, `WIRE-C01`, `WIRE-W04`, `E2E-AF-1407-*`, `E2E-AF-1408-*` unchanged |
+
+---
+
+## 2. References
+
+### 2.1 Authority
+
+- Issue #1922: session_active fallback RCA card renders blank (original report, `main`)
+- PR #1927: `main` implementation
+- Issue #1928: `release/v1.5` backport tracking issue and divergence analysis
+- `BR-INTERACTIVE-004` (Dynamic Takeover of Autonomous Investigations), success criterion 7: "Single-driver guarantee via K8s Lease (concurrent drivers rejected)" — `docs/requirements/BR-INTERACTIVE.md`
+- `BR-INTERACTIVE-003` (Audit Attribution for Interactive Actions), success criterion 4: "Full conversation reconstruction possible via DS query" — `docs/requirements/BR-INTERACTIVE.md`
+
+### 2.2 FedRAMP Controls
+
+| Control | Intent | Application | Test ID |
+|---------|--------|-------------|---------|
+| AU-3 | Content of audit records | Fallback artifact's `causal_chain`/`summary` truthfully reflect investigation status, never fabricate findings | UT-AF-1922-001 |
+| SI-10 | Information input validation / data integrity | `investigation_summary` schema self-identification stays consistent between fallback and final (`present_decision`) artifacts — identical field names/shapes | UT-AF-1922-002 |
+| SI-4 | Audit classification | `metadata.type=decision` unchanged; fallback remains classified identically to the final decision artifact | UT-AF-WIRE-SESSION-003 |
+| AC-4 (via BR-INTERACTIVE-004) | Information flow enforcement (single-driver rejection) | The rejected caller's `session_active` response still carries a renderable, honest status via the same audit-traceable artifact channel | E2E-AF-1922-001 |
+
+---
+
+## 3. Test Scenarios
+
+### 3.1 Unit Tests (fallback artifact content)
+
+Ported unchanged from `main` — these call `EmitFallbackInvestigationArtifact` directly via `launcher.WithEventBridge`/`bridgeQueue`, with no dependency on `HandleInvestigationMCPWithRegistry`'s signature (identical on both branches).
+
+| ID | Scenario | Expected | Status |
+|----|----------|----------|--------|
+| UT-AF-1922-001 | `EmitFallbackInvestigationArtifact` with empty `CausalChain` | Emitted `rca.causal_chain` is a non-empty, truthful placeholder (no fabricated findings) | Implemented — PASS |
+| UT-AF-1922-002 | `EmitFallbackInvestigationArtifact` with real `CausalChain`/`TotalToolCalls` | Real values pass through unchanged; `tool_calls_count`/`llm_turns` keys always present (even zero) | Implemented — PASS |
+
+### 3.2 Integration Tests
+
+Adapted (not cherry-picked): `release/v1.5` predates the `InvestigateConfig` struct refactor — `HandleInvestigationMCPWithRegistry` takes 13 positional parameters here instead of `main`'s `(ctx, cfg *InvestigateConfig, args, blocking, username)`. The call is rewritten using `release/v1.5`'s own `UT-AF-WIRE-C01` (auto-RR creation via `triager` + mock Prometheus alert, to obtain non-empty `rrSeverity`) combined with `UT-AF-WIRE-SESSION-001/002`'s style (mock `StartInvestigationFn` returning a `session_active` error).
+
+| ID | Scenario | Expected | Status |
+|----|----------|----------|--------|
+| UT-AF-WIRE-SESSION-003 | `HandleInvestigationMCPWithRegistry` with triaged severity + KA `session_active` error | Emitted `TaskArtifactUpdateEvent` (schema=`investigation_summary`) has non-empty `rca.causal_chain` | Implemented — PASS |
+
+### 3.3 E2E Tests
+
+Adapted: `release/v1.5` has no `artifactUpdate` string constant (introduced later on `main`) — this file's own pre-existing #1407/#1408 tests use the literal `"artifact-update"` string, matched here for consistency. The `af_progressive_investigate` mock-LLM scenario (keyword trigger `"progressive investigate"`) and `a2aMessageStream`/`fetchDEXTokenForPersona` helpers already exist unchanged on `release/v1.5`.
+
+| ID | Scenario | Expected | Status |
+|----|----------|----------|--------|
+| E2E-AF-1922-001 | Two concurrent `kubernaut_investigate` calls (real KA) against the same target; second caller receives `session_active` | Second caller's SSE stream contains an `investigation_summary` artifact-update with non-empty `rca.causal_chain` | Implemented — written, builds and lints clean; **not executed** in this session (no live Kind/E2E cluster available locally). Requires `make test-e2e-apifrontend GINKGO_FOCUS="1922"` against a deployed E2E environment (CI or a locally provisioned cluster). |
+
+---
+
+## 4. Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | Test ID |
+|-----------|------------------------|-----------------------|---------|
+| `emitFallbackInvestigationArtifact` (enhanced, pre-existing) | `HandleInvestigationMCPWithRegistry` (session_active branch / no-events-produced branch) | `pkg/apifrontend/tools/ka_investigate_mcp.go` (both call sites, same file — no `ka_investigate_bridge.go` split on `release/v1.5`) | UT-AF-WIRE-SESSION-003 (IT), E2E-AF-1922-001 (E2E) |
+| `EmitFallbackInvestigationArtifact` (new, test-only exported seam) | n/a — test seam, not a production entry point | `pkg/apifrontend/tools/ka_investigate_mcp.go` | UT-AF-1922-001, UT-AF-1922-002 |
+
+---
+
+## 5. Execution
+
+```bash
+go build ./...
+go test ./pkg/apifrontend/tools/... -run "UT-AF-1922" -v -count=1
+go test ./pkg/apifrontend/tools/... -run "UT-AF-WIRE-SESSION" -v -count=1
+make test-e2e-apifrontend GINKGO_FOCUS="1922"
+```

--- a/pkg/apifrontend/tools/ka_investigate_mcp.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp.go
@@ -704,22 +704,52 @@ func emitEarlyRCA(ctx context.Context, rca *InvestigateRCA) {
 	_ = launcher.EmitStructuredMetaSafe(ctx, payload, meta)
 }
 
+// EmitFallbackInvestigationArtifact is the exported entry point for
+// emitFallbackInvestigationArtifact. It is used by unit tests to verify the
+// artifact's content in isolation, without driving the full
+// HandleInvestigationMCPWithRegistry wiring path.
+func EmitFallbackInvestigationArtifact(ctx context.Context, rca *InvestigateRCA, rrID string) {
+	emitFallbackInvestigationArtifact(ctx, rca, rrID)
+}
+
+// fallbackCausalChainPlaceholder is the truthful, non-fabricating
+// causal_chain entry used when a fallback InvestigateRCA carries no real
+// causal chain (severity-triage-only data). It must never describe a
+// specific root cause that was not actually observed (AU-3).
+const fallbackCausalChainPlaceholder = "Full investigation in progress; preliminary severity assessed from resource metadata only"
+
 // emitFallbackInvestigationArtifact emits an artifact-update event with the
 // investigation_summary schema when the KA bridge produced no events but
 // severity triage data is available. This ensures the Console gets a
 // structured artifact even when the KA investigation is slow or unavailable.
-// FedRAMP: SI-10 (data integrity through schema self-identification).
+//
+// The emitted rca object always includes causal_chain/tool_calls_count/
+// llm_turns using the same field names as the final present_decision
+// artifact's RCAData (ka_tools.go), even when rca carries no real causal
+// chain yet: an empty causal_chain leaves the Console's hasRCAData render
+// guard (AgentBubble.tsx) permanently false, silently dropping the fallback
+// message instead of showing a renderable RCA card (#1922).
+// FedRAMP: AU-3 (truthful content, no fabricated findings), SI-10 (data
+// integrity through schema self-identification consistent with the final
+// artifact's shape).
 func emitFallbackInvestigationArtifact(ctx context.Context, rca *InvestigateRCA, rrID string) {
 	if rca == nil {
 		return
+	}
+	causalChain := rca.CausalChain
+	if len(causalChain) == 0 {
+		causalChain = []string{fallbackCausalChainPlaceholder}
 	}
 	data := map[string]any{
 		"session_id": rrID,
 		"summary":    rca.RCASummary,
 		"rca": map[string]any{
-			"explanation": rca.RCASummary,
-			"severity":    rca.Severity,
-			"confidence":  rca.Confidence,
+			"explanation":      rca.RCASummary,
+			"severity":         rca.Severity,
+			"confidence":       rca.Confidence,
+			"causal_chain":     causalChain,
+			"tool_calls_count": rca.TotalToolCalls,
+			"llm_turns":        rca.TotalLLMTurns,
 		},
 	}
 	meta := map[string]any{

--- a/pkg/apifrontend/tools/ka_investigate_wiring_test.go
+++ b/pkg/apifrontend/tools/ka_investigate_wiring_test.go
@@ -228,6 +228,76 @@ var _ = Describe("HandleInvestigationMCPWithRegistry — session_active structur
 			Expect(result.Error).NotTo(BeEmpty(), "Error field must provide actionable guidance")
 			Expect(result.Error).To(ContainSubstring("bob@example.com"), "Error field must include the driver name")
 		})
+
+		It("UT-AF-WIRE-SESSION-003: session_active fallback investigation_summary artifact carries non-empty causal_chain (#1922)", func() {
+			origTimeout := tools.AwaitSessionTimeout
+			tools.AwaitSessionTimeout = 10 * time.Millisecond
+			defer func() { tools.AwaitSessionTimeout = origTimeout }()
+
+			mockProm := &mockPromClientForWiring{
+				alerts: []prom.Alert{
+					{
+						State: "firing",
+						Labels: map[string]string{
+							"alertname": "KubePodCrashLooping",
+							"severity":  "critical",
+							"namespace": "prod",
+							"kind":      "Deployment",
+							"name":      "web-app-1922",
+						},
+					},
+				},
+			}
+			triager := severity.NewTriager(mockProm, &noopLLMForWiring{}, severity.DefaultConfig(), logr.Discard())
+
+			mockMCP := &ka.MockMCPClient{
+				StartInvestigationFn: func(_ context.Context, _ ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+					return nil, fmt.Errorf("kubernaut_investigate start_autonomous: session_active: You already have an active session for this investigation; use action=reconnect to rejoin (map[driver:admin session_id:sess-1922])")
+				},
+			}
+
+			queue := &bridgeQueue{}
+			ctx := launcher.WithEventBridge(
+				auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+					Username: "bob",
+					Groups:   []string{"sre"},
+				}),
+				queue, "task-1922-session", "ctx-1922-session", nil,
+			)
+
+			tc := newTypedClientForInvestigate()
+			result, err := tools.HandleInvestigationMCPWithRegistry(
+				ctx, mockMCP, tc, "kubernaut-system",
+				tools.InvestigateMCPArgs{
+					APIVersion: "apps/v1",
+					Namespace:  "prod",
+					Kind:       "Deployment",
+					Name:       "web-app-1922",
+				},
+				nil, nil, nil, true, nil, "bob", nil, triager,
+			)
+			Expect(err).NotTo(HaveOccurred(), "session_active should not propagate as Go error")
+			Expect(result.Status).To(Equal("session_active"))
+
+			var artifactEvt *a2a.TaskArtifactUpdateEvent
+			for _, evt := range queue.Events() {
+				if art, ok := evt.(*a2a.TaskArtifactUpdateEvent); ok {
+					if schema, _ := art.Artifact.Metadata["schema"].(string); schema == "investigation_summary" {
+						artifactEvt = art
+						break
+					}
+				}
+			}
+			Expect(artifactEvt).NotTo(BeNil(), "session_active must emit an investigation_summary fallback artifact")
+
+			dp, ok := artifactEvt.Artifact.Parts[0].(a2a.DataPart)
+			Expect(ok).To(BeTrue(), "artifact must carry a DataPart")
+			rcaData, ok := dp.Data["rca"].(map[string]any)
+			Expect(ok).To(BeTrue(), "artifact data must include an rca object")
+			causalChain, ok := rcaData["causal_chain"].([]string)
+			Expect(ok).To(BeTrue(), "AU-3/SI-10: rca.causal_chain must be present so the Console's hasRCAData guard renders the RCA card (#1922)")
+			Expect(causalChain).NotTo(BeEmpty(), "AU-3/SI-10: rca.causal_chain must be non-empty so the Console's hasRCAData guard renders the RCA card (#1922)")
+		})
 	})
 })
 
@@ -347,5 +417,91 @@ var _ = Describe("Progressive RCA Emission Wiring — #1407", func() {
 		}
 		Expect(decisionFound).To(BeTrue(),
 			"IT-AF-1407-001: early RCA decision status-update must flow through production EventBridge wiring")
+	})
+})
+
+// =============================================================================
+// Issue #1922 (release/v1.5 backport, #1928): session_active fallback
+// investigation_summary artifact content
+// =============================================================================
+
+var _ = Describe("Fallback Investigation Artifact Content — #1922", func() {
+
+	It("UT-AF-1922-001: AU-3 empty causal_chain is seeded with a truthful placeholder, never fabricated findings", func() {
+		queue := &bridgeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-1922-001", "ctx-1922-001", nil)
+
+		rca := &tools.InvestigateRCA{
+			Severity:   "critical",
+			Confidence: 0.6,
+			RCASummary: "Severity assessed from resource metadata (investigation in progress by admin)",
+		}
+		tools.EmitFallbackInvestigationArtifact(ctx, rca, "rr-1922-001")
+
+		var artifactEvt *a2a.TaskArtifactUpdateEvent
+		for _, evt := range queue.Events() {
+			if art, ok := evt.(*a2a.TaskArtifactUpdateEvent); ok {
+				artifactEvt = art
+				break
+			}
+		}
+		Expect(artifactEvt).NotTo(BeNil(), "fallback artifact must be emitted")
+
+		dp, ok := artifactEvt.Artifact.Parts[0].(a2a.DataPart)
+		Expect(ok).To(BeTrue(), "artifact must carry a DataPart")
+		rcaData, ok := dp.Data["rca"].(map[string]any)
+		Expect(ok).To(BeTrue(), "artifact data must include an rca object")
+		causalChain, ok := rcaData["causal_chain"].([]string)
+		Expect(ok).To(BeTrue(), "rca.causal_chain must be present")
+		Expect(causalChain).NotTo(BeEmpty(),
+			"empty CausalChain input must be seeded with a placeholder so the Console's hasRCAData guard renders the RCA card (#1922)")
+		Expect(causalChain[0]).NotTo(ContainSubstring("OOMKill"),
+			"AU-3: placeholder must not fabricate specific findings that were never observed")
+		Expect(causalChain[0]).To(SatisfyAny(
+			ContainSubstring("progress"),
+			ContainSubstring("pending"),
+		), "AU-3: placeholder must truthfully describe investigation status, not fabricate a root cause")
+	})
+
+	It("UT-AF-1922-002: SI-10 real causal_chain/tool_calls_count pass through unchanged and shape matches present_decision's RCAData", func() {
+		queue := &bridgeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-1922-002", "ctx-1922-002", nil)
+
+		rca := &tools.InvestigateRCA{
+			Severity:       "critical",
+			Confidence:     0.92,
+			CausalChain:    []string{"Memory leak", "OOMKill"},
+			Target:         "Deployment/worker in production",
+			RCASummary:     "OOMKill caused by memory leak",
+			TotalLLMTurns:  17,
+			TotalToolCalls: 19,
+		}
+		tools.EmitFallbackInvestigationArtifact(ctx, rca, "rr-1922-002")
+
+		var artifactEvt *a2a.TaskArtifactUpdateEvent
+		for _, evt := range queue.Events() {
+			if art, ok := evt.(*a2a.TaskArtifactUpdateEvent); ok {
+				artifactEvt = art
+				break
+			}
+		}
+		Expect(artifactEvt).NotTo(BeNil(), "fallback artifact must be emitted")
+
+		dp, ok := artifactEvt.Artifact.Parts[0].(a2a.DataPart)
+		Expect(ok).To(BeTrue(), "artifact must carry a DataPart")
+		rcaData, ok := dp.Data["rca"].(map[string]any)
+		Expect(ok).To(BeTrue(), "artifact data must include an rca object")
+
+		causalChain, ok := rcaData["causal_chain"].([]string)
+		Expect(ok).To(BeTrue(), "rca.causal_chain must be present")
+		Expect(causalChain).To(ConsistOf("Memory leak", "OOMKill"),
+			"real CausalChain must pass through unchanged, not be overwritten by a placeholder")
+
+		Expect(rcaData).To(HaveKey("tool_calls_count"),
+			"SI-10: shape must match present_decision's RCAData field names")
+		Expect(rcaData["tool_calls_count"]).To(Equal(19))
+		Expect(rcaData).To(HaveKey("llm_turns"),
+			"SI-10: shape must match present_decision's RCAData field names")
+		Expect(rcaData["llm_turns"]).To(Equal(17))
 	})
 })

--- a/test/e2e/apifrontend/progressive_flow_e2e_test.go
+++ b/test/e2e/apifrontend/progressive_flow_e2e_test.go
@@ -329,3 +329,165 @@ var _ = Describe("Structured Artifact Contract E2E — #1408", Ordered, Label("e
 			"SI-10: at least one artifact must have metadata schema=investigation_summary with DataPart containing summary")
 	})
 })
+
+// =============================================================================
+// E2E-AF-1922 (release/v1.5 backport, #1928): session_active Fallback RCA
+// Card Content Completeness
+//
+// Proves the rejected-driver journey: two concurrent "progressive investigate"
+// calls; the first caller acquires KA's single-driver session; the second
+// caller's kubernaut_investigate call is rejected with session_active
+// (BR-INTERACTIVE-004) and must still receive a renderable investigation_summary
+// fallback artifact (not a silently-dropped message), because that artifact's
+// rca.causal_chain is what the Console's hasRCAData guard requires to render
+// the RCA card.
+//
+// FedRAMP: AC-4 (information flow enforcement — the rejected caller's session
+// is still observable through the same audit-traceable artifact channel).
+//
+// Mock-LLM scenario: af_progressive_investigate
+// Keyword trigger: "progressive investigate"
+// =============================================================================
+
+var _ = Describe("session_active Fallback RCA Card Content — #1922", Ordered, Label("e2e", "session-active-fallback", "1922"), func() {
+	var sreToken string
+
+	BeforeEach(func() {
+		var err error
+		sreToken, err = fetchDEXTokenForPersona("sre")
+		Expect(err).NotTo(HaveOccurred(), "SRE DEX token required")
+		Expect(sreToken).NotTo(BeEmpty())
+	})
+
+	a2aSSEPost := func(ctx context.Context, body string) (*http.Response, error) {
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, baseURL+"/a2a/invoke", strings.NewReader(body))
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Accept", "text/event-stream")
+		req.Header.Set("Authorization", "Bearer "+sreToken)
+		return httpClient.Do(req)
+	}
+
+	// findFallbackCausalChain scans an SSE response for an artifact-update
+	// event with metadata.schema="investigation_summary" and reports whether
+	// one was found and whether its rca.causal_chain is non-empty.
+	findFallbackCausalChain := func(resp *http.Response) (found, causalChainNonEmpty bool) {
+		sc := bufio.NewScanner(resp.Body)
+		sc.Buffer(make([]byte, 64*1024), 1024*1024)
+
+		for sc.Scan() {
+			line := strings.TrimRight(sc.Text(), "\r")
+			if !strings.HasPrefix(strings.TrimSpace(line), "data:") {
+				continue
+			}
+			data := strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(line), "data:"))
+			if data == "" || !strings.HasPrefix(data, "{") {
+				continue
+			}
+
+			var envelope struct {
+				Result json.RawMessage `json:"result"`
+			}
+			if json.Unmarshal([]byte(data), &envelope) != nil || len(envelope.Result) == 0 {
+				continue
+			}
+
+			var raw map[string]any
+			if json.Unmarshal(envelope.Result, &raw) != nil {
+				continue
+			}
+			// release/v1.5 predates the artifactUpdate string constant
+			// introduced later on main; match this file's own #1407/#1408
+			// convention of comparing against the literal kind string.
+			if kind, _ := raw["kind"].(string); kind != "artifact-update" {
+				continue
+			}
+			artifact, _ := raw["artifact"].(map[string]any)
+			if artifact == nil {
+				continue
+			}
+			meta, _ := artifact["metadata"].(map[string]any)
+			if meta["schema"] != "investigation_summary" {
+				continue
+			}
+			found = true
+
+			parts, _ := artifact["parts"].([]any)
+			for _, p := range parts {
+				part, _ := p.(map[string]any)
+				if part == nil {
+					continue
+				}
+				dpData, _ := part["data"].(map[string]any)
+				if dpData == nil {
+					continue
+				}
+				rcaData, _ := dpData["rca"].(map[string]any)
+				if rcaData == nil {
+					continue
+				}
+				if chain, ok := rcaData["causal_chain"].([]any); ok && len(chain) > 0 {
+					causalChainNonEmpty = true
+				}
+			}
+			if found {
+				break
+			}
+		}
+		return found, causalChainNonEmpty
+	}
+
+	It("E2E-AF-1922-001: AC-4 — rejected concurrent driver's session_active response still carries a renderable RCA card", func() {
+		firstCtx, firstCancel := context.WithTimeout(context.Background(), 4*time.Minute)
+		defer firstCancel()
+
+		firstStarted := make(chan struct{})
+		go func() {
+			defer GinkgoRecover()
+			resp, err := a2aSSEPost(firstCtx, a2aMessageStream("e2e-1922-first", "progressive investigate"))
+			close(firstStarted)
+			if err != nil {
+				return
+			}
+			defer func() { _ = resp.Body.Close() }()
+			// Drain to completion in the background so KA holds the
+			// single-driver session for the duration of the test, exactly
+			// as a real first responder would.
+			sc := bufio.NewScanner(resp.Body)
+			sc.Buffer(make([]byte, 64*1024), 1024*1024)
+			for sc.Scan() { //nolint:revive // drain-only loop, no per-line action needed
+			}
+		}()
+
+		select {
+		case <-firstStarted:
+		case <-time.After(10 * time.Second):
+			Fail("first investigate call did not start streaming within 10s")
+		}
+		// Give the first call time to create/reuse the RR and acquire KA's
+		// single-driver session before the second (contending) call arrives.
+		time.Sleep(3 * time.Second)
+
+		secondCtx, secondCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer secondCancel()
+		resp, err := a2aSSEPost(secondCtx, a2aMessageStream("e2e-1922-second", "progressive investigate"))
+		Expect(err).NotTo(HaveOccurred())
+		defer func() { _ = resp.Body.Close() }()
+		Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+		found, causalChainNonEmpty := findFallbackCausalChain(resp)
+
+		GinkgoWriter.Printf("second (contending) caller: investigation_summary artifact found=%v, causal_chain non-empty=%v\n",
+			found, causalChainNonEmpty)
+
+		By("AC-4: the rejected concurrent driver must still receive an investigation_summary fallback artifact")
+		Expect(found).To(BeTrue(),
+			"second caller (rejected via session_active) must still receive an investigation_summary artifact (#1922)")
+
+		By("AC-4: the fallback artifact's rca.causal_chain must be non-empty so the Console's hasRCAData guard renders the RCA card")
+		Expect(causalChainNonEmpty).To(BeTrue(),
+			"rca.causal_chain must be non-empty for the rejected caller's RCA card to render (#1922)")
+	})
+})


### PR DESCRIPTION
## Summary

Backports #1927 to `release/v1.5`. Closes #1928.

`emitFallbackInvestigationArtifact`'s `rca` object omitted `causal_chain`/`tool_calls_count`/`llm_turns`, so the Console's `hasRCAData` render guard (`AgentBubble.tsx`) stayed permanently false on the `session_active` fallback path — a rejected concurrent driver got no RCA card at all (#1922).

## Adapted, not cherry-picked

`release/v1.5` predates the `InvestigateConfig` struct refactor and the `ka_investigate_bridge.go` split (both introduced later on `main`), so this isn't a straight `git cherry-pick`. See #1928 for the full divergence analysis. Concretely:

- **Production fix**: identical diff to #1927, applied to `ka_investigate_mcp.go` (pre-split location) instead of `ka_investigate_bridge.go`.
- **`UT-AF-1922-001`/`UT-AF-1922-002`**: port unchanged — they call `EmitFallbackInvestigationArtifact` directly via `launcher.WithEventBridge`/`bridgeQueue`, with no dependency on `HandleInvestigationMCPWithRegistry`'s signature.
- **`UT-AF-WIRE-SESSION-003`**: rewritten against this branch's positional-arg `HandleInvestigationMCPWithRegistry(ctx, mcpClient, client, namespace, args, auditor, registry, onStarted, blocking, pool, username, signaler, triager)` signature, following this file's own `UT-AF-WIRE-C01` (triager + mock Prometheus alert for non-empty `rrSeverity`) and `UT-AF-WIRE-SESSION-001/002` (mock `session_active` error) patterns.
- **`E2E-AF-1922-001`**: uses the literal `"artifact-update"` kind string (matching this file's own #1407/#1408 tests) since the `artifactUpdate` constant doesn't exist on this branch yet.
- **Test plan**: `docs/tests/1928/TEST_PLAN.md` documents the above, mirroring `docs/tests/1922/TEST_PLAN.md` on `main`.

## FedRAMP

AU-3 (truthful placeholder, never fabricates findings), SI-10 (shape consistency with `present_decision`'s `RCAData`), AC-4 (rejected driver's session stays observable through the same audit-traceable artifact channel).

## Test plan

- [x] `go build ./...`
- [x] `go vet` (tools + e2e packages)
- [x] `golangci-lint run` — 0 issues
- [x] Full `pkg/apifrontend/tools` suite (565 specs) — PASS, no regressions
- [x] `UT-AF-1922-001`, `UT-AF-1922-002`, `UT-AF-WIRE-SESSION-001/002/003` — PASS
- [ ] `E2E-AF-1922-001` — written, builds/lints clean; requires CI's Kind cluster to execute (no local E2E cluster available in this session)

Made with [Cursor](https://cursor.com)