### PR TITLE
fix(apifrontend): remove internal acronym leaks from interactive-investigation status messages (#1916)

### DIFF
--- a/docs/tests/1916/TEST_PLAN.md
+++ b/docs/tests/1916/TEST_PLAN.md
@@ -1,0 +1,154 @@
+# Test Plan: Interactive-Investigation Status Messages Leak Internal Acronyms
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-1916
+**Feature**: Three hardcoded `launcher.EmitStatusSafe` status/warning strings in `HandleInvestigationMCPWithRegistry` leak internal service acronyms (`KA`, `AA`) and CRD name (`IS CRD`) to the console user, bypassing the harness's own documented no-internal-names constraint.
+**Version**: 1.0
+**Created**: 2026-08-04
+**Author**: AI Agent
+**Status**: Implemented (UT verified locally; full `apifrontend` unit suite + `-race` + lint clean)
+**Branch**: `fix/1916-af-status-message-acronym-leak`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+GitHub issue #1916 reports that three Go-harness literals in
+`pkg/apifrontend/tools/ka_investigate_mcp.go` are emitted verbatim to the
+console chat UI as status lines during an interactive investigation:
+
+- `"Investigation session ready, connecting to KA..."` (line 327)
+- `"Interactive session acknowledged by AA, starting investigation..."` (line 340)
+- `"Warning: IS CRD creation failed (%s), investigation continues"` (line 406)
+
+`KA` (Kubernaut Agent), `AA` (the AIAnalysis controller/reconciler), and
+`IS CRD` (the InvestigationSession custom resource) are internal service and
+CRD names that mean nothing to a console user, and are explicitly forbidden by
+`pkg/apifrontend/agent/prompt.txt`'s `## Behavioral Constraints` item 1:
+*"Never reference internal system names (RemediationRequest, AIAnalysis,
+SignalProcessing, KA, CRD, etcd) in responses."* That constraint governs only
+LLM-generated text; these three strings are Go harness literals and bypass it
+entirely.
+
+### 1.2 Objectives
+
+1. **No internal-name leakage**: all three status/warning strings emitted by
+   `HandleInvestigationMCPWithRegistry` are reworded to drop the internal
+   service/CRD names while preserving their informational intent.
+2. **Behavioral proof, not string inspection**: tests exercise the real
+   production entry point (`HandleInvestigationMCPWithRegistry`, wired to the
+   `kubernaut_investigate` MCP tool) via the existing `launcher.WithEventBridge`
+   test harness, and assert on the text actually emitted on the A2A event
+   channel — not on the source literal directly.
+3. **No regression**: the underlying redacted-error content in the line-406
+   warning (via `security.RedactError`) is unchanged; only the wrapper text
+   changes.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./pkg/apifrontend/tools/... -run "UT-AF-1916" -v -count=1` |
+| Regression pass rate (pre-existing) | 100% | `ka_investigate_wiring_test.go` / `ka_investigate_mcp_test.go` suites unchanged (`make test-unit-apifrontend`) |
+| Build/Lint | Clean | `go build ./...`, `golangci-lint run` |
+
+---
+
+## 2. References
+
+### 2.1 Authority
+
+- Issue #1916: AF interactive-investigation status messages leak internal
+  acronyms (KA, AA, IS CRD) to the console user.
+- `pkg/apifrontend/agent/prompt.txt`, `## Behavioral Constraints` item 1 — the
+  product's own documented no-internal-names constraint (enforced today only
+  for LLM output, via `UT-AF-131-004` in `pkg/apifrontend/agent/prompt_test.go`).
+- No standalone `BR-XXX` requirement exists for "console status text must not
+  leak internal names" (`BR-INTERACTIVE.md`, `BR-INTERACTIVE-010.md` checked).
+  Following the established convention for pure bug fixes in this repo
+  (issues #1922, #1440, #1928), this fix is anchored to **Issue #1916** and
+  the FedRAMP control below rather than an unbacked BR-XXX.
+
+### 2.2 FedRAMP Controls
+
+| Control | Intent | Application | Test ID |
+|---------|--------|-------------|---------|
+| SI-11 (Error Handling) | Error/status messages do not leak information that could reveal system architecture to an unauthorized viewer | The three console status/warning strings emitted during interactive investigation must not reference internal service acronyms (`KA`, `AA`) or CRD names (`IS CRD`) | UT-AF-1916-001, UT-AF-1916-002, UT-AF-1916-003 |
+
+This is the same control family already used in this codebase for this exact
+class of "message must not leak X" bug (`docs/tests/1293/TEST_PLAN_INTERACTIVE_INVESTIGATION.md`
+line 91, `pkg/apifrontend/session/deferred_crd_test.go:538`,
+`pkg/datastorage/server/response/rfc7807.go:90`).
+
+---
+
+## 3. Scope
+
+### 3.1 In Scope
+
+| Area | Description |
+|------|--------------|
+| `HandleInvestigationMCPWithRegistry` status text | Reword the three literals at lines 327, 340, 406 of `pkg/apifrontend/tools/ka_investigate_mcp.go` |
+
+### 3.2 Out of Scope
+
+- Any change to `security.RedactError` or the redaction logic applied to the
+  underlying hook error (unaffected — only the wrapper text changes).
+- Any change to `prompt.txt`'s LLM-facing constraint (already correct; this
+  fix closes the harness-side gap it does not cover).
+- Any new wiring, component, or CRD — this is a literal-text-only fix inside
+  an already-wired, already-integration-tested function.
+
+---
+
+## 4. Test Scenarios (Unit — behavioral, via production entry point)
+
+All three scenarios call `tools.HandleInvestigationMCPWithRegistry` directly
+(the same function registered as the `kubernaut_investigate` MCP tool) with
+`launcher.WithEventBridge` installed, and assert on the `*a2a.TaskStatusUpdateEvent`
+text actually emitted — proving the fix through the real dispatch path rather
+than a static string check.
+
+| ID | FedRAMP | Business Behavior Verified | Acceptance Criteria | Status |
+|----|---------|------------------------------|----------------------|--------|
+| UT-AF-1916-001 | SI-11 | "Session ready" status (triggered when `HandleAwaitSession` finds a ready KA session for the RR via a pre-populated `AIAnalysis.Status.KASession.ID`) omits the `KA` acronym | Emitted status text does not contain `"KA"`; matches the new friendly wording | Implemented — PASS |
+| UT-AF-1916-002 | SI-11 | "Session acknowledged" status (triggered when `AwaitISPhaseActive` finds an `InvestigationSession` CRD with `Status.Phase == Active` for the RR) omits the `AA` acronym | Emitted status text does not contain `"AA"`; matches the new friendly wording | Implemented — PASS |
+| UT-AF-1916-003 | SI-11 | "Session tracking failed" warning (triggered when the `onStarted` `SessionStartedHook` returns an error) omits the `IS CRD` reference while still surfacing the redacted underlying error | Emitted warning text does not contain `"IS CRD"`; still contains the redacted hook error substring | Implemented — PASS |
+
+**Test file**: `pkg/apifrontend/tools/status_message_leak_1916_test.go`
+
+---
+
+## 5. Wiring Manifest
+
+Not applicable — no new component, handler, or callback is introduced. All
+three fixes are literal-string edits inside the existing, already-wired
+`HandleInvestigationMCPWithRegistry` function. Its production entry point
+(`kubernaut_investigate` MCP tool registration) and wiring are already proven
+by pre-existing tests (`WIRE-SESSION-001/002/003`, `WIRE-C01`, `WIRE-W04` in
+`ka_investigate_wiring_test.go`), which are unaffected by this change (per
+2.1 above, they carry no direct dependency on the three literals under fix).
+
+---
+
+## 6. TDD Execution Phases
+
+| Phase | Type | Scope | Tests |
+|-------|------|-------|-------|
+| 1 | RED | Add 3 failing tests asserting the new (not-yet-implemented) friendly wording | UT-AF-1916-001..003 |
+| 2 | GREEN | Reword the 3 literals in `ka_investigate_mcp.go` | All Phase 1 tests pass; no regression in existing `tools_test` suite |
+| 3 | REFACTOR | Extract literals to named constants; re-audit new wording for leaks; lint/build | All tests remain green |
+
+---
+
+## 7. Execution
+
+```bash
+go build ./...
+go test ./pkg/apifrontend/tools/... -run "UT-AF-1916" -v -count=1
+make test-unit-apifrontend
+golangci-lint run --timeout=5m ./pkg/apifrontend/...
+```

--- a/pkg/apifrontend/tools/ka_investigate_mcp.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp.go
@@ -48,6 +48,18 @@ import (
 // Short because the phase transition should follow almost immediately after AA submits.
 const isPhaseActivePollTimeout = 5 * time.Second
 
+// Status/warning text emitted during the interactive-investigation await
+// loop (#1916, SI-11). Deliberately omits internal service acronyms (KA, AA)
+// and CRD names (IS CRD) — console users must never see internal system
+// architecture, per pkg/apifrontend/agent/prompt.txt's Behavioral Constraints
+// item 1. That constraint only governs LLM-generated text; these are Go
+// harness literals, so they must independently avoid the same leakage.
+const (
+	statusSessionReadyText        = "Investigation session ready, connecting..."
+	statusSessionAcknowledgedText = "Interactive session created, starting investigation..."
+	warnSessionTrackingFailedFmt  = "Warning: session tracking setup failed (%s), investigation continues"
+)
+
 type rrIDContextKey struct{}
 
 // WithRRID attaches the remediation request ID to the context so that
@@ -324,7 +336,7 @@ func HandleInvestigationMCPWithRegistry(ctx context.Context, mcpClient ka.MCPCli
 		checkCancel()
 		if awaitErr == nil && awaitResult.Status == "ready" {
 			kaSessionID = awaitResult.SessionID
-			_ = launcher.EmitStatusSafe(ctx, "Investigation session ready, connecting to KA...")
+			_ = launcher.EmitStatusSafe(ctx, statusSessionReadyText)
 		}
 
 		// Wait for the IS CRD phase to become Active — AA sets this after
@@ -337,7 +349,7 @@ func HandleInvestigationMCPWithRegistry(ctx context.Context, mcpClient ka.MCPCli
 		}
 		isCtx, isCancel := context.WithTimeout(ctx, isPhaseTimeout)
 		if AwaitISPhaseActive(isCtx, client, namespace, args.RRID) {
-			_ = launcher.EmitStatusSafe(ctx, "Interactive session acknowledged by AA, starting investigation...")
+			_ = launcher.EmitStatusSafe(ctx, statusSessionAcknowledgedText)
 		}
 		isCancel()
 	}
@@ -403,7 +415,7 @@ func HandleInvestigationMCPWithRegistry(ctx context.Context, mcpClient ka.MCPCli
 				"session_id", result.SessionID,
 				"namespace", namespace,
 			)
-			_ = launcher.EmitStatusSafe(ctx, fmt.Sprintf("Warning: IS CRD creation failed (%s), investigation continues", security.RedactError(hookErr)))
+			_ = launcher.EmitStatusSafe(ctx, fmt.Sprintf(warnSessionTrackingFailedFmt, security.RedactError(hookErr)))
 		}
 	}
 

--- a/pkg/apifrontend/tools/status_message_leak_1916_test.go
+++ b/pkg/apifrontend/tools/status_message_leak_1916_test.go
@@ -1,0 +1,211 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/a2aproject/a2a-go/a2a"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	aiav1alpha1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
+	isv1alpha1 "github.com/jordigilh/kubernaut/api/investigationsession/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+)
+
+// statusLeak1916Scheme registers both AIAnalysis (session-ready check) and
+// InvestigationSession (IS-phase-active check) so a single fake client can
+// drive either await path independently, without requiring both to be
+// registered in each of the package's other single-purpose test schemes.
+func statusLeak1916Scheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = aiav1alpha1.AddToScheme(s)
+	_ = isv1alpha1.AddToScheme(s)
+	return s
+}
+
+func newStatusLeak1916Client(objects ...crclient.Object) crclient.Client {
+	return fake.NewClientBuilder().
+		WithScheme(statusLeak1916Scheme()).
+		WithObjects(objects...).
+		WithStatusSubresource(objects...).
+		Build()
+}
+
+// statusTextsFrom extracts the text of every TaskStatusUpdateEvent captured
+// by a bridgeQueue, in emission order.
+func statusTextsFrom(queue *bridgeQueue) []string {
+	var texts []string
+	for _, evt := range queue.Events() {
+		se, ok := evt.(*a2a.TaskStatusUpdateEvent)
+		if !ok {
+			continue
+		}
+		if se.Status.Message == nil || len(se.Status.Message.Parts) == 0 {
+			continue
+		}
+		if tp, ok := se.Status.Message.Parts[0].(a2a.TextPart); ok {
+			texts = append(texts, tp.Text)
+		}
+	}
+	return texts
+}
+
+var _ = Describe("Interactive investigation status messages — no internal-name leakage (#1916)", func() {
+
+	It("UT-AF-1916-001 [SI-11]: session-ready status omits internal acronym KA", func() {
+		tc := newStatusLeak1916Client(newTypedAIAnalysisWithSession("rr-1916-001", "sess-1916-001"))
+
+		mockMCP := &ka.MockMCPClient{
+			StartInvestigationFn: func(_ context.Context, _ ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+				return &ka.StartInvestigationResult{
+					SessionID: "sess-1916-001",
+					Status:    "started",
+					Events:    nil,
+					Closer:    func() {},
+				}, nil
+			},
+		}
+
+		queue := &bridgeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-1916-001", "ctx-1916-001", nil)
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		_, err := tools.HandleInvestigationMCPWithRegistry(
+			ctx, mockMCP, tc, "kubernaut-system",
+			tools.InvestigateMCPArgs{RRID: "rr-1916-001"},
+			nil, nil, nil, true, nil, "alice", nil, nil,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		texts := statusTextsFrom(queue)
+		var readyText string
+		for _, t := range texts {
+			if strings.HasPrefix(t, "Investigation session ready") {
+				readyText = t
+				break
+			}
+		}
+		Expect(readyText).NotTo(BeEmpty(), "expected a session-ready status event, got: %v", texts)
+		Expect(readyText).To(Equal("Investigation session ready, connecting..."),
+			"SI-11: session-ready status must not reference the internal KA acronym")
+		Expect(readyText).NotTo(ContainSubstring("KA"))
+	})
+
+	It("UT-AF-1916-002 [SI-11]: session-acknowledged status omits internal acronym AA", func() {
+		origTimeout := tools.AwaitSessionTimeout
+		tools.AwaitSessionTimeout = 10 * time.Millisecond
+		defer func() { tools.AwaitSessionTimeout = origTimeout }()
+
+		// Deliberately no AIAnalysis-with-session object: isolates the
+		// IS-phase-active path (line ~340) from the session-ready path
+		// (line ~327) covered by UT-AF-1916-001.
+		tc := newStatusLeak1916Client(newTypedIS("kubernaut-system", "isess-1916-002", "rr-1916-002", isv1alpha1.SessionPhaseActive))
+
+		mockMCP := &ka.MockMCPClient{
+			StartInvestigationFn: func(_ context.Context, _ ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+				return &ka.StartInvestigationResult{
+					SessionID: "sess-1916-002",
+					Status:    "started",
+					Events:    nil,
+					Closer:    func() {},
+				}, nil
+			},
+		}
+
+		queue := &bridgeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-1916-002", "ctx-1916-002", nil)
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		_, err := tools.HandleInvestigationMCPWithRegistry(
+			ctx, mockMCP, tc, "kubernaut-system",
+			tools.InvestigateMCPArgs{RRID: "rr-1916-002"},
+			nil, nil, nil, true, nil, "alice", nil, nil,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		texts := statusTextsFrom(queue)
+		var ackText string
+		for _, t := range texts {
+			if strings.HasPrefix(t, "Interactive session") {
+				ackText = t
+				break
+			}
+		}
+		Expect(ackText).NotTo(BeEmpty(), "expected a session-acknowledged status event, got: %v", texts)
+		Expect(ackText).To(Equal("Interactive session created, starting investigation..."),
+			"SI-11: session-acknowledged status must not reference the internal AA acronym")
+		Expect(ackText).NotTo(ContainSubstring("AA"))
+	})
+
+	It("UT-AF-1916-003 [SI-11]: session-tracking-failed warning omits internal CRD name IS CRD", func() {
+		mockMCP := &ka.MockMCPClient{
+			StartInvestigationFn: func(_ context.Context, _ ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+				return &ka.StartInvestigationResult{
+					SessionID: "sess-1916-003",
+					Status:    "started",
+					Events:    nil,
+					Closer:    func() {},
+				}, nil
+			},
+		}
+
+		onStarted := func(_ context.Context, _ string, _ string, _ string) error {
+			return fmt.Errorf("boom: hook failed")
+		}
+
+		queue := &bridgeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-1916-003", "ctx-1916-003", nil)
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		// No K8s client needed: with client=nil, the await-session /
+		// IS-phase-active block (guarded by "client != nil") is skipped,
+		// isolating this test to the onStarted-hook-error path only.
+		_, err := tools.HandleInvestigationMCPWithRegistry(
+			ctx, mockMCP, nil, "kubernaut-system",
+			tools.InvestigateMCPArgs{RRID: "rr-1916-003"},
+			nil, nil, onStarted, true, nil, "alice", nil, nil,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		texts := statusTextsFrom(queue)
+		var warnText string
+		for _, t := range texts {
+			if strings.HasPrefix(t, "Warning:") {
+				warnText = t
+				break
+			}
+		}
+		Expect(warnText).NotTo(BeEmpty(), "expected a warning status event, got: %v", texts)
+		Expect(warnText).To(Equal("Warning: session tracking setup failed (boom: hook failed), investigation continues"),
+			"SI-11: session-tracking-failed warning must not reference the internal IS CRD name, but must retain the underlying error")
+		Expect(warnText).NotTo(ContainSubstring("IS CRD"))
+	})
+})


### PR DESCRIPTION
## Summary

Closes #1916.

Three hardcoded `launcher.EmitStatusSafe` status/warning strings in `HandleInvestigationMCPWithRegistry` rendered internal service acronyms (`KA`, `AA`) and a CRD name (`IS CRD`) directly to the console user, bypassing the harness's own documented no-internal-names behavioral constraint (`pkg/apifrontend/agent/prompt.txt`), which only governs LLM-generated text — these three strings are Go harness literals and bypassed it entirely.

- `"Investigation session ready, connecting to KA..."` → `"Investigation session ready, connecting..."`
- `"Interactive session acknowledged by AA, starting investigation..."` → `"Interactive session created, starting investigation..."`
- `"Warning: IS CRD creation failed (%s), investigation continues"` → `"Warning: session tracking setup failed (%s), investigation continues"`

The three literals are extracted to named constants (`statusSessionReadyText`, `statusSessionAcknowledgedText`, `warnSessionTrackingFailedFmt`) so future prompt-safety audits are a single-place check.

## FedRAMP control

SI-11 (Error Handling): status/warning messages emitted to the console must not leak internal service names, controller acronyms, or CRD kinds that could reveal system architecture. See `docs/tests/1916/TEST_PLAN.md`.

## Tests

Added `UT-AF-1916-001..003`, which call `HandleInvestigationMCPWithRegistry` directly — the production entry point wired to the `kubernaut_investigate` MCP tool — via `launcher.WithEventBridge`, and assert on the emitted status/warning text. This proves the fix through the real dispatch path rather than a static string check. No wiring manifest is required: no new component, handler, or callback is introduced.

`security.RedactError` and all pre-existing `ka_investigate_wiring_test.go` / `ka_investigate_mcp_test.go` coverage are unaffected (verified: no other test depends on the old literal text).

## Test plan

- [x] RED: 3 new tests failed against unfixed code; 565 pre-existing tests in `pkg/apifrontend/tools` stayed green
- [x] GREEN: `make test-unit-apifrontend` — all 24 suites passed (568/568 specs in `tools`), composite coverage 82.7%
- [x] REFACTOR: extracted named constants, re-audited replacement wording for new leaks, `go build ./...` clean, `golangci-lint run` — 0 issues, `-race` clean

Made with [Cursor](https://cursor.com)