### PR TITLE
Backport #1916 AF status message acronym leak fix to main

### DIFF
--- a/docs/tests/1937/TEST_PLAN.md
+++ b/docs/tests/1937/TEST_PLAN.md
@@ -1,0 +1,160 @@
+# Test Plan: Interactive-Investigation Status Messages Leak Internal Acronyms (main port)
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-1937
+**Feature**: `main` port of #1916's fix — three hardcoded `launcher.EmitStatusSafe` status/warning strings in the interactive-investigation flow leak internal service acronyms (`KA`, `AA`) and CRD name (`IS CRD`) to the console user.
+**Version**: 1.0
+**Created**: 2026-08-04
+**Author**: AI Agent
+**Status**: Implemented
+**Branch**: `backport/1916-af-status-message-acronym-leak-main`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+This is the `main` port of the fix for GitHub issue #1916, originally found
+and fixed against `release/v1.5` (#1932). This is tracked by #1937 (reverse
+of the usual v1.5-first sequencing note only in the sense that this bug was
+found on `release/v1.5` first — the port direction is the same as
+#1912→#1913, #1915→#1917, #1918→#1924: implement on `release/v1.5`, then
+port to `main`).
+
+The bug predates neither branch — the same three literals exist unchanged on
+both `release/v1.5` and `main`, carried forward by `main`'s later refactor of
+`HandleInvestigationMCPWithRegistry` into smaller helper functions
+(`resolveInvestigationRR`, `signalInteractiveSession`,
+`awaitInvestigationReady`, `startKAInvestigation`,
+`finalizeInvestigationStart`) taking a `*InvestigateConfig` struct, instead
+of `release/v1.5`'s single function with 13 positional parameters:
+
+- `awaitInvestigationReady` (main, `ka_investigate_mcp.go:474`):
+  `"Investigation session ready, connecting to KA..."`
+- `awaitInvestigationReady` (main, `ka_investigate_mcp.go:487`):
+  `"Interactive session acknowledged by AA, starting investigation..."`
+- `finalizeInvestigationStart` (main, `ka_investigate_mcp.go:568`):
+  `"Warning: IS CRD creation failed (%s), investigation continues"`
+
+Same behavioral constraint applies: `pkg/apifrontend/agent/prompt.txt`'s
+`## Behavioral Constraints` item 1 forbids internal names in LLM-generated
+text; these are Go harness literals and bypass it entirely, identically to
+`release/v1.5`.
+
+### 1.2 Objectives
+
+Identical to #1916's objectives on `release/v1.5` (`docs/tests/1916/TEST_PLAN.md`),
+re-verified against `main`'s refactored code shape:
+
+1. **No internal-name leakage**: all three status/warning strings emitted
+   during the await-and-finalize sequence are reworded identically to the
+   `release/v1.5` fix.
+2. **Behavioral proof, not string inspection**: tests exercise the real
+   production entry point (`HandleInvestigationMCPWithRegistry`, still wired
+   to the `kubernaut_investigate` MCP tool on `main`) via
+   `launcher.WithEventBridge`, asserting on the text actually emitted.
+3. **No regression**: `security.RedactError`'s redaction of the underlying
+   hook error is unchanged; only the wrapper text changes.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./pkg/apifrontend/tools/... -run "UT-AF-1916" -v -count=1` |
+| Regression pass rate (pre-existing) | 100% | `ka_investigate_wiring_test.go` / `ka_investigate_mcp_test.go` suites unchanged (`make test-unit-apifrontend`) |
+| Build/Lint | Clean | `go build ./...`, `golangci-lint run` |
+
+---
+
+## 2. References
+
+### 2.1 Authority
+
+- Issue #1916: original bug report (`release/v1.5`).
+- PR #1932: `release/v1.5` implementation.
+- Issue #1937: `main` port tracking issue and divergence analysis (this plan).
+- `pkg/apifrontend/agent/prompt.txt`, `## Behavioral Constraints` item 1.
+
+### 2.2 FedRAMP Controls
+
+| Control | Intent | Application | Test ID |
+|---------|--------|-------------|---------|
+| SI-11 (Error Handling) | Error/status messages do not leak information that could reveal system architecture to an unauthorized viewer | The three console status/warning strings emitted during interactive investigation must not reference internal service acronyms (`KA`, `AA`) or CRD names (`IS CRD`) | UT-AF-1916-001, UT-AF-1916-002, UT-AF-1916-003 |
+
+---
+
+## 3. Scope
+
+### 3.1 In Scope
+
+| Area | Description |
+|------|--------------|
+| `awaitInvestigationReady` status text | Reword the two literals at `pkg/apifrontend/tools/ka_investigate_mcp.go:474,487` (main line numbers) |
+| `finalizeInvestigationStart` warning text | Reword the literal at `pkg/apifrontend/tools/ka_investigate_mcp.go:568` (main line numbers) |
+
+### 3.2 Out of Scope
+
+- Any change to `security.RedactError` or the redaction logic.
+- Any change to `prompt.txt`'s LLM-facing constraint.
+- Any new wiring, component, or CRD.
+- `finalizeInvestigationStart`'s server-side `logr...Error(hookErr, "IS CRD creation failed after investigate", ...)` log line — this is a structured log, not console-emitted user-facing text, so it is not in scope for this console-leak fix.
+
+---
+
+## 4. Test Scenarios (Unit — behavioral, via production entry point)
+
+All three scenarios call `tools.HandleInvestigationMCPWithRegistry` directly
+with `launcher.WithEventBridge` installed, and assert on the
+`*a2a.TaskStatusUpdateEvent` text actually emitted. Adapted from
+`release/v1.5`'s test to `main`'s `&tools.InvestigateConfig{...}` call
+signature (`ctx, cfg *InvestigateConfig, args, blocking, username`) instead
+of 13 positional parameters, following the existing
+`UT-AF-WIRE-SESSION-001/002` pattern already on `main`
+(`ka_investigate_wiring_test.go`). `newTypedIS` also drops the namespace
+parameter on `main` (hardcoded to `"kubernaut-system"` internally) —
+`newTypedAIAnalysisWithSession`, `bridgeQueue`, and
+`launcher.WithEventBridge` port unchanged.
+
+| ID | FedRAMP | Business Behavior Verified | Acceptance Criteria | Status |
+|----|---------|------------------------------|----------------------|--------|
+| UT-AF-1916-001 | SI-11 | "Session ready" status (triggered when `HandleAwaitSession` finds a ready KA session for the RR via a pre-populated `AIAnalysis.Status.KASession.ID`) omits the `KA` acronym | Emitted status text does not contain `"KA"`; matches the new friendly wording | Implemented — PASS |
+| UT-AF-1916-002 | SI-11 | "Session acknowledged" status (triggered when `AwaitISPhaseActive` finds an `InvestigationSession` CRD with `Status.Phase == Active` for the RR) omits the `AA` acronym | Emitted status text does not contain `"AA"`; matches the new friendly wording | Implemented — PASS |
+| UT-AF-1916-003 | SI-11 | "Session tracking failed" warning (triggered when the `onStarted` `SessionStartedHook` returns an error) omits the `IS CRD` reference while still surfacing the redacted underlying error | Emitted warning text does not contain `"IS CRD"`; still contains the redacted hook error substring | Implemented — PASS |
+
+**Test file**: `pkg/apifrontend/tools/status_message_leak_1916_test.go`
+
+---
+
+## 5. Wiring Manifest
+
+Not applicable — no new component, handler, or callback is introduced. All
+three fixes are literal-string edits inside the existing, already-wired
+`awaitInvestigationReady`/`finalizeInvestigationStart` helpers, called from
+`HandleInvestigationMCPWithRegistry` (production entry point:
+`kubernaut_investigate` MCP tool registration, unchanged by this fix). Their
+wiring is already proven by pre-existing tests
+(`UT-AF-WIRE-SESSION-001/002/003` in `ka_investigate_wiring_test.go`), which
+are unaffected by this change.
+
+---
+
+## 6. TDD Execution Phases
+
+| Phase | Type | Scope | Tests |
+|-------|------|-------|-------|
+| 1 | RED | Port the 3 tests, adapted to `main`'s `&InvestigateConfig{}` call signature and `newTypedIS` arity; confirm failure against unfixed `main` code | UT-AF-1916-001..003 |
+| 2 | GREEN | Reword the 3 literals inside `awaitInvestigationReady`/`finalizeInvestigationStart` in `ka_investigate_mcp.go` | All Phase 1 tests pass; no regression in existing `tools_test` suite |
+| 3 | REFACTOR | Re-audit new wording for leaks; lint/build/race | All tests remain green |
+
+---
+
+## 7. Execution
+
+```bash
+go build ./...
+go test ./pkg/apifrontend/tools/... -run "UT-AF-1916" -v -count=1
+make test-unit-apifrontend
+golangci-lint run --timeout=5m ./pkg/apifrontend/...
+```

--- a/pkg/apifrontend/tools/ka_investigate_mcp.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp.go
@@ -47,6 +47,18 @@ import (
 // Short because the phase transition should follow almost immediately after AA submits.
 const isPhaseActivePollTimeout = 5 * time.Second
 
+// Status/warning text emitted during the interactive-investigation await
+// loop (#1916, SI-11). Deliberately omits internal service acronyms (KA, AA)
+// and CRD names (IS CRD) — console users must never see internal system
+// architecture, per pkg/apifrontend/agent/prompt.txt's Behavioral Constraints
+// item 1. That constraint only governs LLM-generated text; these are Go
+// harness literals, so they must independently avoid the same leakage.
+const (
+	statusSessionReadyText        = "Investigation session ready, connecting..."
+	statusSessionAcknowledgedText = "Interactive session created, starting investigation..."
+	warnSessionTrackingFailedFmt  = "Warning: session tracking setup failed (%s), investigation continues"
+)
+
 type rrIDContextKey struct{}
 
 // WithRRID attaches the remediation request ID to the context so that
@@ -471,7 +483,7 @@ func awaitInvestigationReady(ctx context.Context, cfg *InvestigateConfig, rrID, 
 	var kaSessionID string
 	if awaitErr == nil && awaitResult.Status == "ready" {
 		kaSessionID = awaitResult.SessionID
-		_ = launcher.EmitStatusSafe(ctx, "Investigation session ready, connecting to KA...")
+		_ = launcher.EmitStatusSafe(ctx, statusSessionReadyText)
 	}
 
 	// Wait for the IS CRD phase to become Active — AA sets this after
@@ -484,7 +496,7 @@ func awaitInvestigationReady(ctx context.Context, cfg *InvestigateConfig, rrID, 
 	}
 	isCtx, isCancel := context.WithTimeout(ctx, isPhaseTimeout)
 	if AwaitISPhaseActive(isCtx, cfg.Client, cfg.Namespace, rrID) {
-		_ = launcher.EmitStatusSafe(ctx, "Interactive session acknowledged by AA, starting investigation...")
+		_ = launcher.EmitStatusSafe(ctx, statusSessionAcknowledgedText)
 	}
 	isCancel()
 
@@ -565,7 +577,7 @@ func finalizeInvestigationStart(ctx context.Context, cfg *InvestigateConfig, rrI
 				"session_id", result.SessionID,
 				"namespace", cfg.Namespace,
 			)
-			_ = launcher.EmitStatusSafe(ctx, fmt.Sprintf("Warning: IS CRD creation failed (%s), investigation continues", security.RedactError(hookErr)))
+			_ = launcher.EmitStatusSafe(ctx, fmt.Sprintf(warnSessionTrackingFailedFmt, security.RedactError(hookErr)))
 		}
 	}
 

--- a/pkg/apifrontend/tools/status_message_leak_1916_test.go
+++ b/pkg/apifrontend/tools/status_message_leak_1916_test.go
@@ -1,0 +1,221 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/a2aproject/a2a-go/a2a"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	aiav1alpha1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
+	isv1alpha1 "github.com/jordigilh/kubernaut/api/investigationsession/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+)
+
+// statusLeak1916Scheme registers both AIAnalysis (session-ready check) and
+// InvestigationSession (IS-phase-active check) so a single fake client can
+// drive either await path independently, without requiring both to be
+// registered in each of the package's other single-purpose test schemes.
+func statusLeak1916Scheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = aiav1alpha1.AddToScheme(s)
+	_ = isv1alpha1.AddToScheme(s)
+	return s
+}
+
+func newStatusLeak1916Client(objects ...crclient.Object) crclient.Client {
+	return fake.NewClientBuilder().
+		WithScheme(statusLeak1916Scheme()).
+		WithObjects(objects...).
+		WithStatusSubresource(objects...).
+		Build()
+}
+
+// statusTextsFrom extracts the text of every TaskStatusUpdateEvent captured
+// by a bridgeQueue, in emission order.
+func statusTextsFrom(queue *bridgeQueue) []string {
+	var texts []string
+	for _, evt := range queue.Events() {
+		se, ok := evt.(*a2a.TaskStatusUpdateEvent)
+		if !ok {
+			continue
+		}
+		if se.Status.Message == nil || len(se.Status.Message.Parts) == 0 {
+			continue
+		}
+		if tp, ok := se.Status.Message.Parts[0].(a2a.TextPart); ok {
+			texts = append(texts, tp.Text)
+		}
+	}
+	return texts
+}
+
+var _ = Describe("Interactive investigation status messages — no internal-name leakage (#1916)", func() {
+
+	It("UT-AF-1916-001 [SI-11]: session-ready status omits internal acronym KA", func() {
+		tc := newStatusLeak1916Client(newTypedAIAnalysisWithSession("rr-1916-001", "sess-1916-001"))
+
+		mockMCP := &ka.MockMCPClient{
+			StartInvestigationFn: func(_ context.Context, _ ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+				return &ka.StartInvestigationResult{
+					SessionID: "sess-1916-001",
+					Status:    "started",
+					Events:    nil,
+					Closer:    func() {},
+				}, nil
+			},
+		}
+
+		queue := &bridgeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-1916-001", "ctx-1916-001", nil)
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		_, err := tools.HandleInvestigationMCPWithRegistry(
+			ctx, &tools.InvestigateConfig{
+				MCPClient: mockMCP,
+				Client:    tc,
+				Namespace: "kubernaut-system",
+			}, tools.InvestigateMCPArgs{RRID: "rr-1916-001"},
+			true, "alice",
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		texts := statusTextsFrom(queue)
+		var readyText string
+		for _, t := range texts {
+			if strings.HasPrefix(t, "Investigation session ready") {
+				readyText = t
+				break
+			}
+		}
+		Expect(readyText).NotTo(BeEmpty(), "expected a session-ready status event, got: %v", texts)
+		Expect(readyText).To(Equal("Investigation session ready, connecting..."),
+			"SI-11: session-ready status must not reference the internal KA acronym")
+		Expect(readyText).NotTo(ContainSubstring("KA"))
+	})
+
+	It("UT-AF-1916-002 [SI-11]: session-acknowledged status omits internal acronym AA", func() {
+		origTimeout := tools.AwaitSessionTimeout
+		tools.AwaitSessionTimeout = 10 * time.Millisecond
+		defer func() { tools.AwaitSessionTimeout = origTimeout }()
+
+		// Deliberately no AIAnalysis-with-session object: isolates the
+		// IS-phase-active path from the session-ready path covered by
+		// UT-AF-1916-001.
+		tc := newStatusLeak1916Client(newTypedIS("isess-1916-002", "rr-1916-002", isv1alpha1.SessionPhaseActive))
+
+		mockMCP := &ka.MockMCPClient{
+			StartInvestigationFn: func(_ context.Context, _ ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+				return &ka.StartInvestigationResult{
+					SessionID: "sess-1916-002",
+					Status:    "started",
+					Events:    nil,
+					Closer:    func() {},
+				}, nil
+			},
+		}
+
+		queue := &bridgeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-1916-002", "ctx-1916-002", nil)
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		_, err := tools.HandleInvestigationMCPWithRegistry(
+			ctx, &tools.InvestigateConfig{
+				MCPClient: mockMCP,
+				Client:    tc,
+				Namespace: "kubernaut-system",
+			}, tools.InvestigateMCPArgs{RRID: "rr-1916-002"},
+			true, "alice",
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		texts := statusTextsFrom(queue)
+		var ackText string
+		for _, t := range texts {
+			if strings.HasPrefix(t, "Interactive session") {
+				ackText = t
+				break
+			}
+		}
+		Expect(ackText).NotTo(BeEmpty(), "expected a session-acknowledged status event, got: %v", texts)
+		Expect(ackText).To(Equal("Interactive session created, starting investigation..."),
+			"SI-11: session-acknowledged status must not reference the internal AA acronym")
+		Expect(ackText).NotTo(ContainSubstring("AA"))
+	})
+
+	It("UT-AF-1916-003 [SI-11]: session-tracking-failed warning omits internal CRD name IS CRD", func() {
+		mockMCP := &ka.MockMCPClient{
+			StartInvestigationFn: func(_ context.Context, _ ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+				return &ka.StartInvestigationResult{
+					SessionID: "sess-1916-003",
+					Status:    "started",
+					Events:    nil,
+					Closer:    func() {},
+				}, nil
+			},
+		}
+
+		onStarted := func(_ context.Context, _ string, _ string, _ string) error {
+			return fmt.Errorf("boom: hook failed")
+		}
+
+		queue := &bridgeQueue{}
+		ctx := launcher.WithEventBridge(context.Background(), queue, "task-1916-003", "ctx-1916-003", nil)
+		ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		defer cancel()
+
+		// No K8s client needed: with Client=nil, the await-session /
+		// IS-phase-active block (guarded by "cfg.Client != nil") is
+		// skipped, isolating this test to the onStarted-hook-error path
+		// only.
+		_, err := tools.HandleInvestigationMCPWithRegistry(
+			ctx, &tools.InvestigateConfig{
+				MCPClient: mockMCP,
+				Namespace: "kubernaut-system",
+				OnStarted: onStarted,
+			}, tools.InvestigateMCPArgs{RRID: "rr-1916-003"},
+			true, "alice",
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		texts := statusTextsFrom(queue)
+		var warnText string
+		for _, t := range texts {
+			if strings.HasPrefix(t, "Warning:") {
+				warnText = t
+				break
+			}
+		}
+		Expect(warnText).NotTo(BeEmpty(), "expected a warning status event, got: %v", texts)
+		Expect(warnText).To(Equal("Warning: session tracking setup failed (boom: hook failed), investigation continues"),
+			"SI-11: session-tracking-failed warning must not reference the internal IS CRD name, but must retain the underlying error")
+		Expect(warnText).NotTo(ContainSubstring("IS CRD"))
+	})
+})


### PR DESCRIPTION
## Summary

Closes #1937. Backports #1916's fix (merged to `release/v1.5` via #1932) to `main`, following the same v1.5-first-then-main sequencing as #1912→#1913, #1915→#1917, #1918→#1924.

Three hardcoded `launcher.EmitStatusSafe` status/warning strings rendered internal service acronyms (`KA`, `AA`) and a CRD name (`IS CRD`) directly to the console user, bypassing the harness's own documented no-internal-names behavioral constraint (`pkg/apifrontend/agent/prompt.txt`), which only governs LLM-generated text.

- `"Investigation session ready, connecting to KA..."` → `"Investigation session ready, connecting..."`
- `"Interactive session acknowledged by AA, starting investigation..."` → `"Interactive session created, starting investigation..."`
- `"Warning: IS CRD creation failed (%s), investigation continues"` → `"Warning: session tracking setup failed (%s), investigation continues"`

### Not a straight cherry-pick

`main` had already split `HandleInvestigationMCPWithRegistry` into smaller helpers (`resolveInvestigationRR`, `signalInteractiveSession`, `awaitInvestigationReady`, `startKAInvestigation`, `finalizeInvestigationStart`) taking a `*InvestigateConfig` struct, instead of `release/v1.5`'s single function with 13 positional parameters. The production string values and the three extracted named constants (`statusSessionReadyText`, `statusSessionAcknowledgedText`, `warnSessionTrackingFailedFmt`) are otherwise byte-for-byte identical to the `release/v1.5` fix — only the surrounding function boundaries differ.

The test file needed the same kind of adaptation: `UT-AF-1916-001..003` are ported to call `HandleInvestigationMCPWithRegistry(ctx, &tools.InvestigateConfig{...}, args, blocking, username)` (main's signature) instead of the 13-positional-arg call, following the existing `UT-AF-WIRE-SESSION-001/002` pattern already on `main`. `newTypedIS` also drops the namespace parameter on `main` (hardcoded internally). `newTypedAIAnalysisWithSession`, `bridgeQueue`, and `launcher.WithEventBridge` ported unchanged.

## FedRAMP control

SI-11 (Error Handling), same as #1916/#1932. See `docs/tests/1937/TEST_PLAN.md`.

## Test plan

- [x] RED: 3 ported tests failed against unfixed `main` code; 641 pre-existing specs in `pkg/apifrontend/tools` stayed green
- [x] GREEN: `make test-unit-apifrontend` — all 25 suites passed, composite coverage 79.6%
- [x] REFACTOR: re-audited replacement wording for new leaks (none found), `go build ./...` clean, `golangci-lint run` — 0 issues, `-race` clean

## Depends on

- #1916 / #1932 (already merged to `release/v1.5`)

Made with [Cursor](https://cursor.com)