### PR TITLE
fix(fleet): mcpclient connect timeout + feat(apifrontend): enforce console-access gate (#1934, #1919)

### DIFF
--- a/charts/kubernaut/templates/apifrontend/apifrontend.yaml
+++ b/charts/kubernaut/templates/apifrontend/apifrontend.yaml
@@ -458,6 +458,42 @@ rules:
       {{- end }}
 {{- end }}
 ---
+# #1919 (AC-3/AC-6): coarse-grained console-access gate, deliberately a
+# separate, independently-auditable grant from the per-tool ClusterRoles
+# above (not derived from them) -- operators grant "console access" and
+# "tool access" as two explicit steps. Enforced server-side at every
+# tool-invocation site (checkRBAC/newRBACGuard), not just the advisory
+# GET /a2a/access endpoint.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubernaut-console-access
+  labels:
+    kubernaut.ai/component: console-authorization
+    {{- include "kubernaut.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["kubernaut.ai"]
+    resources: ["console"]
+    verbs: ["use"]
+{{- range .Values.apifrontend.config.rbac.consoleAccessGroups }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernaut-console-access-{{ . }}
+  labels:
+    kubernaut.ai/component: console-authorization
+    {{- include "kubernaut.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubernaut-console-access
+subjects:
+  - kind: Group
+    name: {{ . }}
+    apiGroup: rbac.authorization.k8s.io
+{{- end }}
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/kubernaut/tests/console_access_rbac_test.yaml
+++ b/charts/kubernaut/tests/console_access_rbac_test.yaml
@@ -1,0 +1,107 @@
+suite: console access RBAC gate (#1919)
+templates:
+  - templates/apifrontend/apifrontend.yaml
+set:
+  postgresql:
+    auth:
+      existingSecret: dummy
+  valkey:
+    existingSecret: dummy
+  global:
+    llmProfiles:
+      primary:
+        provider: openai
+        model: gpt-4
+        credentialsSecretName: llm-credentials-primary
+  kubernautAgent:
+    llmProfileRef: primary
+tests:
+  # ---------------------------------------------------------------------
+  # IT-HELM-1919-001: the coarse-grained ClusterRole exists and grants
+  # exactly kubernaut.ai/console use, distinct from the per-tool
+  # kubernaut-tool-* ClusterRoles (#1919, AC-3/AC-6).
+  # ---------------------------------------------------------------------
+  - it: "IT-HELM-1919-001: kubernaut-console-access ClusterRole grants kubernaut.ai/console use"
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-console-access
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - contains:
+          path: rules[0].resources
+          content: console
+      - contains:
+          path: rules[0].verbs
+          content: use
+      - contains:
+          path: rules[0].apiGroups
+          content: kubernaut.ai
+
+  # ---------------------------------------------------------------------
+  # IT-HELM-1919-002: default consoleAccessGroups produces a
+  # ClusterRoleBinding per group, bound to the console-access ClusterRole.
+  # ---------------------------------------------------------------------
+  - it: "IT-HELM-1919-002: sre is bound to kubernaut-console-access by default"
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-console-access-sre
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: roleRef.name
+          value: kubernaut-console-access
+      - equal:
+          path: subjects[0].kind
+          value: Group
+      - equal:
+          path: subjects[0].name
+          value: sre
+
+  - it: "IT-HELM-1919-002b: cicd (not a default console-access group) has no ClusterRoleBinding rendered"
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-console-access-cicd
+      skipEmptyTemplates: true
+    asserts:
+      - hasDocuments:
+          count: 0
+          filterAware: true
+
+  # ---------------------------------------------------------------------
+  # IT-HELM-1919-003: an empty consoleAccessGroups list is empty-safe --
+  # the ClusterRole still renders, but zero ClusterRoleBindings do.
+  # ---------------------------------------------------------------------
+  - it: "IT-HELM-1919-003: empty consoleAccessGroups renders the ClusterRole but no bindings"
+    template: templates/apifrontend/apifrontend.yaml
+    set:
+      apifrontend:
+        config:
+          rbac:
+            consoleAccessGroups: []
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-console-access
+    asserts:
+      - isKind:
+          of: ClusterRole
+
+  - it: "IT-HELM-1919-003b: empty consoleAccessGroups renders no kubernaut-console-access-sre binding"
+    template: templates/apifrontend/apifrontend.yaml
+    set:
+      apifrontend:
+        config:
+          rbac:
+            consoleAccessGroups: []
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-console-access-sre
+      skipEmptyTemplates: true
+    asserts:
+      - hasDocuments:
+          count: 0
+          filterAware: true

--- a/charts/kubernaut/tests/console_access_rbac_test.yaml
+++ b/charts/kubernaut/tests/console_access_rbac_test.yaml
@@ -61,16 +61,28 @@ tests:
           path: subjects[0].name
           value: sre
 
-  - it: "IT-HELM-1919-002b: cicd (not a default console-access group) has no ClusterRoleBinding rendered"
+  - it: "IT-HELM-1919-002b: a group not listed in consoleAccessGroups has no ClusterRoleBinding rendered"
     template: templates/apifrontend/apifrontend.yaml
     documentSelector:
       path: metadata.name
-      value: kubernaut-console-access-cicd
+      value: kubernaut-console-access-guest
       skipEmptyTemplates: true
     asserts:
       - hasDocuments:
           count: 0
           filterAware: true
+
+  - it: "IT-HELM-1919-002c: cicd and l3-audit (automation/audit personas) are also bound by default, per #1919's non-goal of weakening existing per-tool grants"
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-console-access-cicd
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: roleRef.name
+          value: kubernaut-console-access
 
   # ---------------------------------------------------------------------
   # IT-HELM-1919-003: an empty consoleAccessGroups list is empty-safe --

--- a/charts/kubernaut/tests/fleet_registry_rbac_test.yaml
+++ b/charts/kubernaut/tests/fleet_registry_rbac_test.yaml
@@ -369,9 +369,17 @@ tests:
         fleet:
           namespace: team-a
     template: templates/apifrontend/apifrontend.yaml
+    # #1919 added a second, unconditional ClusterRole (kubernaut-console-access)
+    # to this template that `personas: null` (suite-level set above) cannot
+    # clear, so neither `path: kind, value: ClusterRole` (2 ClusterRoles) nor
+    # `path: metadata.name, value: apifrontend` (shared by the ServiceAccount/
+    # ConfigMap/ClusterRoleBinding/RoleBinding/Service/Deployment in this same
+    # template) is unique anymore. rules[0].resources[0] is: the fleet-registry
+    # ClusterRole's first rule is always investigationsessions, vs.
+    # kubernaut-console-access's only rule being resources=["console"].
     documentSelector:
-      path: kind
-      value: ClusterRole
+      path: rules[0].resources[0]
+      value: investigationsessions
     asserts:
       - notContains:
           path: rules
@@ -390,9 +398,11 @@ tests:
         fleet:
           namespace: ""
     template: templates/apifrontend/apifrontend.yaml
+    # #1919: see IT-HELM-020-007b comment above -- select by rules[0].resources[0]
+    # to disambiguate from the also-unconditional kubernaut-console-access ClusterRole.
     documentSelector:
-      path: kind
-      value: ClusterRole
+      path: rules[0].resources[0]
+      value: investigationsessions
     asserts:
       - contains:
           path: rules

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -2894,6 +2894,13 @@
                       "type": "string"
                     }
                   }
+                },
+                "consoleAccessGroups": {
+                  "type": "array",
+                  "description": "OIDC groups granted the coarse-grained kubernaut-console-access ClusterRole (kubernaut.ai/console, verb=use), a separate grant from the per-tool personas above (#1919)",
+                  "items": {
+                    "type": "string"
+                  }
                 }
               }
             }

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -953,6 +953,21 @@ apifrontend:
           - kubernaut_get_remediation
           - kubernaut_watch
           - kubernaut_await_session
+      # -- #1919 (AC-3/AC-6): OIDC groups granted the coarse-grained
+      # kubernaut-console-access ClusterRole (kubernaut.ai/console, verb=use).
+      # A deliberately separate, independently-auditable grant from the
+      # per-tool `personas` above -- NOT derived from them, so an operator
+      # must explicitly opt a group into console/chat access even if that
+      # group already has tool grants. Enforced both by the advisory
+      # GET /a2a/access endpoint and, more importantly, server-side inside
+      # every tool-call path (checkRBAC/newRBACGuard), so a client that never
+      # calls /a2a/access still cannot bypass the gate. Defaults to the same
+      # groups the E2E RBAC already grants tool access to; edit freely.
+      consoleAccessGroups:
+        - sre
+        - ai-orchestrator
+        - observability
+        - remediation-approver
   resources:
     requests:
       memory: 64Mi

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -955,18 +955,23 @@ apifrontend:
           - kubernaut_await_session
       # -- #1919 (AC-3/AC-6): OIDC groups granted the coarse-grained
       # kubernaut-console-access ClusterRole (kubernaut.ai/console, verb=use).
-      # A deliberately separate, independently-auditable grant from the
-      # per-tool `personas` above -- NOT derived from them, so an operator
-      # must explicitly opt a group into console/chat access even if that
-      # group already has tool grants. Enforced both by the advisory
-      # GET /a2a/access endpoint and, more importantly, server-side inside
-      # every tool-call path (checkRBAC/newRBACGuard), so a client that never
-      # calls /a2a/access still cannot bypass the gate. Defaults to the same
-      # groups the E2E RBAC already grants tool access to; edit freely.
+      # A separate, independently-auditable grant from the per-tool
+      # `personas` above -- NOT rendered *from* them (an operator can revoke
+      # console access from a group without touching its tool grants) -- but
+      # defaulted to *every* group listed in `personas`, per the issue's own
+      # guidance ("bind it to the same groups that get any tool access") and
+      # its explicit non-goal of weakening existing per-tool grants: checkRBAC
+      # and newRBACGuard enforce this gate on *every* tool call (not just
+      # console-UI ones, to close the direct-/mcp-or-/a2a-invoke bypass), so a
+      # persona/group omitted here would silently lose all its `personas`
+      # tool access too. Edit freely -- e.g. remove a group here to make it
+      # console-access-only.
       consoleAccessGroups:
         - sre
         - ai-orchestrator
+        - cicd
         - observability
+        - l3-audit
         - remediation-approver
   resources:
     requests:

--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -676,19 +676,31 @@ func buildRouterConfig(p routerBuildParams) (handler.RouterConfig, http.Handler,
 		statusHandler = handler.NewStatusHandler(p.HDeps.Backends.TypedClient(), cfg.Session.Namespace, logger)
 	}
 
+	// #1919: GET /a2a/access is only registered when the configured
+	// Authorizer also implements ConsoleAuthorizer. Production always
+	// constructs *auth.SARChecker (see buildSARClient), which satisfies both
+	// interfaces at compile time (sar.go's `var _ auth.ConsoleAuthorizer =
+	// (*SARChecker)(nil)`); the assertion only ever fails for a
+	// ToolAuthorizer-only test double.
+	var consoleAccessHandler http.Handler
+	if ca, ok := p.HDeps.Authorizer.(auth.ConsoleAuthorizer); ok {
+		consoleAccessHandler = handler.NewConsoleAccessHandler(ca, p.HDeps.Auditor, logger)
+	}
+
 	routerCfg := handler.RouterConfig{
-		MetricsRegistry:    metricsReg,
-		Logger:             logger,
-		A2AHandler:         p.A2AHandler,
-		MCPHandler:         p.MCPHandler,
-		AgentCardHandler:   p.AgentCardHandler,
-		AuthMiddleware:     p.AuthMiddleware,
-		PreAuthMiddleware:  p.PreAuthMW,
-		PostAuthMiddleware: p.PostAuthMW,
-		ReadyChecker:       handler.AllReady(func() bool { return !p.Draining.Load() }, p.DepsReady, p.AuthReady, sessInfra.Healthy.Load),
-		SSETracker:         buildSSETracker(cfg, metricsReg),
-		StatusHandler:      statusHandler,
-		Draining:           p.Draining,
+		MetricsRegistry:      metricsReg,
+		Logger:               logger,
+		A2AHandler:           p.A2AHandler,
+		MCPHandler:           p.MCPHandler,
+		AgentCardHandler:     p.AgentCardHandler,
+		AuthMiddleware:       p.AuthMiddleware,
+		PreAuthMiddleware:    p.PreAuthMW,
+		PostAuthMiddleware:   p.PostAuthMW,
+		ReadyChecker:         handler.AllReady(func() bool { return !p.Draining.Load() }, p.DepsReady, p.AuthReady, sessInfra.Healthy.Load),
+		SSETracker:           buildSSETracker(cfg, metricsReg),
+		StatusHandler:        statusHandler,
+		ConsoleAccessHandler: consoleAccessHandler,
+		Draining:             p.Draining,
 	}
 	router, err := handler.NewRouter(routerCfg)
 	if err != nil {

--- a/cmd/apifrontend/main_wiring_test.go
+++ b/cmd/apifrontend/main_wiring_test.go
@@ -904,6 +904,21 @@ func (a *allowAllToolAuthorizer) Check(_ context.Context, _ string, _ []string, 
 	return true, nil
 }
 
+// dualToolConsoleAuthorizer implements both auth.ToolAuthorizer and
+// auth.ConsoleAuthorizer, mirroring the shape *auth.SARChecker has in
+// production -- used to prove buildRouterConfig (#1919) wires
+// RouterConfig.ConsoleAccessHandler whenever the configured Authorizer
+// supports the optional ConsoleAuthorizer capability.
+type dualToolConsoleAuthorizer struct{}
+
+func (d *dualToolConsoleAuthorizer) Check(_ context.Context, _ string, _ []string, _ string) (bool, error) {
+	return true, nil
+}
+
+func (d *dualToolConsoleAuthorizer) CheckConsoleAccess(_ context.Context, _ string, _ []string) (bool, error) {
+	return true, nil
+}
+
 type noopAuditor struct{}
 
 func (n *noopAuditor) Emit(_ context.Context, _ *audit.Event) {}
@@ -1824,5 +1839,82 @@ func TestNewLLMTriagerFromConfig_AcceptsOpenAICompatible(t *testing.T) {
 		if _, ok := triager.(*severity.OpenAICompatibleTriager); !ok {
 			t.Errorf("IT-AF-1618-001: provider %q: expected *severity.OpenAICompatibleTriager, got %T", provider, triager)
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #1919: buildRouterConfig wires RouterConfig.ConsoleAccessHandler whenever
+// the configured Authorizer also implements auth.ConsoleAuthorizer, and
+// leaves it nil otherwise (e.g. a ToolAuthorizer-only test double) --
+// proving the Wiring Manifest's "RouterConfig.ConsoleAccessHandler" row:
+// production entry point is buildRouterConfig, called from
+// buildRouterAndServers in run().
+// ---------------------------------------------------------------------------
+
+func testRouterBuildParams(authorizer auth.ToolAuthorizer) routerBuildParams {
+	healthy := &atomic.Bool{}
+	healthy.Store(true)
+	draining := &atomic.Bool{}
+	return routerBuildParams{
+		HDeps: &handlerDeps{
+			Cfg:        &config.Config{},
+			Backends:   testBackendDeps(),
+			SessInfra:  &sessionInfra{Healthy: healthy, StopFunc: func() {}},
+			MetricsReg: metrics.NewRegistry(),
+			Authorizer: authorizer,
+			Auditor:    &noopAuditor{},
+			Logger:     logr.Discard(),
+		},
+		MCPHandler:       http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
+		DepsReady:        func() bool { return true },
+		AgentCardHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
+		A2AHandler:       http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
+		AuthMiddleware:   func(next http.Handler) http.Handler { return next },
+		AuthReady:        func() bool { return true },
+		Draining:         draining,
+	}
+}
+
+func TestBuildRouterConfig_ConsoleAccessHandler_WiredWhenAuthorizerSupportsIt(t *testing.T) {
+	t.Parallel()
+
+	routerCfg, _, err := buildRouterConfig(testRouterBuildParams(&dualToolConsoleAuthorizer{}))
+	if err != nil {
+		t.Fatalf("IT-AF-1919-W01: unexpected error: %v", err)
+	}
+	if routerCfg.ConsoleAccessHandler == nil {
+		t.Fatal("IT-AF-1919-W01: ConsoleAccessHandler must be wired when Authorizer implements ConsoleAuthorizer")
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/a2a/access", http.NoBody)
+	req = req.WithContext(auth.WithUserIdentity(req.Context(), &auth.UserIdentity{Username: "u", Groups: []string{"sre"}}))
+	rec := httptest.NewRecorder()
+	routerCfg.ConsoleAccessHandler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Errorf("IT-AF-1919-W01: expected 200 from wired ConsoleAccessHandler, got %d", rec.Code)
+	}
+}
+
+func TestBuildRouterConfig_ConsoleAccessHandler_NilWhenAuthorizerDoesNotSupportIt(t *testing.T) {
+	t.Parallel()
+
+	routerCfg, _, err := buildRouterConfig(testRouterBuildParams(&allowAllToolAuthorizer{}))
+	if err != nil {
+		t.Fatalf("IT-AF-1919-W02: unexpected error: %v", err)
+	}
+	if routerCfg.ConsoleAccessHandler != nil {
+		t.Fatal("IT-AF-1919-W02: ConsoleAccessHandler must be nil when Authorizer does not implement ConsoleAuthorizer")
+	}
+
+	router, err := handler.NewRouter(routerCfg)
+	if err != nil {
+		t.Fatalf("IT-AF-1919-W02: unexpected router construction error: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/a2a/access", http.NoBody)
+	req.Header.Set("Authorization", "Bearer test-token")
+	rec := httptest.NewRecorder()
+	router.ServeHTTP(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("IT-AF-1919-W02: expected 404 for unregistered /a2a/access route, got %d", rec.Code)
 	}
 }

--- a/deploy/apifrontend/overlays/e2e/e2e-user-rbac.yaml
+++ b/deploy/apifrontend/overlays/e2e/e2e-user-rbac.yaml
@@ -70,13 +70,6 @@ rules:
   - apiGroups: ["kubernaut.ai"]
     resources: ["remediationapprovalrequests/status"]
     verbs: ["get", "update", "patch"]
-  # #1919: coarse-grained console-access gate, now enforced server-side at
-  # every tool-invocation site (checkRBAC/newRBACGuard), not just the
-  # advisory GET /a2a/access endpoint -- E2E users need this grant or every
-  # existing MCP/A2A tool-call E2E test would start failing the new check.
-  - apiGroups: ["kubernaut.ai"]
-    resources: ["console"]
-    verbs: ["use"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
@@ -98,39 +91,6 @@ metadata:
 subjects:
   - kind: Group
     name: ai-orchestrator
-    apiGroup: rbac.authorization.k8s.io
-roleRef:
-  kind: ClusterRole
-  name: e2e-user-k8s-tools
-  apiGroup: rbac.authorization.k8s.io
----
-# cicd and l3-audit bindings below exist solely for the kubernaut.ai/console
-# use grant added above (#1919): PersonaToolClusterRolesYAML already grants
-# both groups their per-tool kubernaut.ai/tools rights from values.yaml, but
-# has no notion of the coarser console-access resource, so without these
-# bindings both personas would fail every values.yaml-granted tool call once
-# checkRBAC/newRBACGuard started enforcing kubernaut.ai/console use on every
-# call (regression caught by persona_acl_matrix_test.go, CI on PR #1940).
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: e2e-cicd-k8s-tools
-subjects:
-  - kind: Group
-    name: cicd
-    apiGroup: rbac.authorization.k8s.io
-roleRef:
-  kind: ClusterRole
-  name: e2e-user-k8s-tools
-  apiGroup: rbac.authorization.k8s.io
----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
-metadata:
-  name: e2e-l3-audit-k8s-tools
-subjects:
-  - kind: Group
-    name: l3-audit
     apiGroup: rbac.authorization.k8s.io
 roleRef:
   kind: ClusterRole
@@ -164,6 +124,110 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: e2e-user-k8s-tools
+  apiGroup: rbac.authorization.k8s.io
+---
+# #1919: coarse-grained console-access gate (kubernaut.ai/console, verb=use),
+# now enforced server-side at every tool-invocation site
+# (checkRBAC/newRBACGuard), not just the advisory GET /a2a/access endpoint --
+# E2E personas need this grant or every existing MCP/A2A tool-call E2E test
+# would fail the new check. Deliberately a SEPARATE ClusterRole from
+# e2e-user-k8s-tools (not one more rule added to it): SARChecker.checkSAR
+# (pkg/apifrontend/auth/sar.go) never sets ResourceAttributes.Namespace, so
+# this is always a cluster-scoped check -- a namespace-scoped RoleBinding
+# (like observability's e2e-observability-k8s-tools below, intentionally
+# namespace-scoped to prove K8s RBAC namespace restriction for *those*
+# unrelated pods/events/deployments/etc. rules) can never satisfy it.
+# Mixing the two into one ClusterRole silently broke observability's console
+# access the first time this was tried (RCA'd via CI must-gather on PR
+# #1940) -- every persona below gets an unconditional ClusterRoleBinding
+# instead, matching the "every persona with a tool grant needs console
+# access too" default applied to charts/kubernaut/values.yaml's
+# consoleAccessGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: e2e-console-access
+rules:
+  - apiGroups: ["kubernaut.ai"]
+    resources: ["console"]
+    verbs: ["use"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: e2e-sre-console-access
+subjects:
+  - kind: Group
+    name: sre
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: e2e-console-access
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: e2e-ai-orchestrator-console-access
+subjects:
+  - kind: Group
+    name: ai-orchestrator
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: e2e-console-access
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: e2e-cicd-console-access
+subjects:
+  - kind: Group
+    name: cicd
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: e2e-console-access
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: e2e-observability-console-access
+subjects:
+  - kind: Group
+    name: observability
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: e2e-console-access
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: e2e-l3-audit-console-access
+subjects:
+  - kind: Group
+    name: l3-audit
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: e2e-console-access
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: e2e-remediation-approver-console-access
+subjects:
+  - kind: Group
+    name: remediation-approver
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: e2e-console-access
   apiGroup: rbac.authorization.k8s.io
 ---
 # Narrow compat grant for sre only: values.yaml's sre persona list carries

--- a/deploy/apifrontend/overlays/e2e/e2e-user-rbac.yaml
+++ b/deploy/apifrontend/overlays/e2e/e2e-user-rbac.yaml
@@ -104,6 +104,39 @@ roleRef:
   name: e2e-user-k8s-tools
   apiGroup: rbac.authorization.k8s.io
 ---
+# cicd and l3-audit bindings below exist solely for the kubernaut.ai/console
+# use grant added above (#1919): PersonaToolClusterRolesYAML already grants
+# both groups their per-tool kubernaut.ai/tools rights from values.yaml, but
+# has no notion of the coarser console-access resource, so without these
+# bindings both personas would fail every values.yaml-granted tool call once
+# checkRBAC/newRBACGuard started enforcing kubernaut.ai/console use on every
+# call (regression caught by persona_acl_matrix_test.go, CI on PR #1940).
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: e2e-cicd-k8s-tools
+subjects:
+  - kind: Group
+    name: cicd
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: e2e-user-k8s-tools
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: e2e-l3-audit-k8s-tools
+subjects:
+  - kind: Group
+    name: l3-audit
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: e2e-user-k8s-tools
+  apiGroup: rbac.authorization.k8s.io
+---
 # Observability group uses a namespace-scoped RoleBinding (not ClusterRoleBinding)
 # to verify that K8s RBAC correctly restricts access to specific namespaces.
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/apifrontend/overlays/e2e/e2e-user-rbac.yaml
+++ b/deploy/apifrontend/overlays/e2e/e2e-user-rbac.yaml
@@ -70,6 +70,13 @@ rules:
   - apiGroups: ["kubernaut.ai"]
     resources: ["remediationapprovalrequests/status"]
     verbs: ["get", "update", "patch"]
+  # #1919: coarse-grained console-access gate, now enforced server-side at
+  # every tool-invocation site (checkRBAC/newRBACGuard), not just the
+  # advisory GET /a2a/access endpoint -- E2E users need this grant or every
+  # existing MCP/A2A tool-call E2E test would start failing the new check.
+  - apiGroups: ["kubernaut.ai"]
+    resources: ["console"]
+    verbs: ["use"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/docs/generated/helm-values-reference.md
+++ b/docs/generated/helm-values-reference.md
@@ -57,6 +57,7 @@ Auto-generated from `charts/kubernaut/values.schema.json` by `hack/gen-helm-conf
 | `config.rateLimit.maxConcurrentSessions` | integer |  | `50` | No |
 | `config.rateLimit.toolCallsPerMinute` | integer |  | `600` | No |
 | `config.rateLimit.userRequestsPerSec` | integer |  | `100` | No |
+| `config.rbac.consoleAccessGroups` | array of string | OIDC groups granted the coarse-grained kubernaut-console-access ClusterRole (kubernaut.ai/console, verb=use), a separate grant from the per-tool personas above (#1919) | `` | No |
 | `config.rbac.personas` | map[string]object | Map of persona name to list of allowed tool names for SAR-based authorization | `` | No |
 | `config.rbac.sarCacheTTL` | string | TTL for SubjectAccessReview cache entries | `"30s"` | No |
 | `config.resilience.prometheus.connectTimeout` | string | Go time.Duration string (e.g. "30s", "5m", "1h30m") | `"5s"` | No |

--- a/docs/tests/1919/TEST_PLAN.md
+++ b/docs/tests/1919/TEST_PLAN.md
@@ -1,0 +1,236 @@
+# Test Plan: Coarse-Grained Console Access Authorization Gate (AF Backend)
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-1919
+**Feature**: A new `kubernaut.ai/console` `use` SubjectAccessReview grant, checked
+(a) via a new lightweight `GET /a2a/access` pre-flight endpoint for UX purposes,
+and (b) — the actual security fix — enforced server-side inside both existing
+tool-invocation paths (`checkRBAC` for `/mcp`, `newRBACGuard` for `/a2a/invoke`)
+so console access is a real security boundary, not merely a UI-advisory check
+a non-conforming client could bypass.
+**Version**: 1.0
+**Created**: 2026-08-04
+**Author**: AI Agent
+**Status**: Draft
+**Branch**: `feat/1919-1934-console-gate-connect-timeout`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Issue #1919 proposes gating console UI rendering on a dedicated coarse-grained
+authorization role, separate from per-tool RBAC, so operators can grant
+"console access" and "tool access" as two explicit, separately-auditable
+steps. The issue's own 3-part proposal spans a new AF endpoint, RBAC
+convention/manifests, and `kubernaut-console` frontend gating
+(`jordigilh/kubernaut-console#48`, a different repo — explicitly out of scope
+here).
+
+During planning, a critical architectural gap was identified and resolved
+before implementation began: an advisory-only `GET /a2a/access` endpoint does
+not close the loop — a client that never calls it (curl, a script, a
+non-conforming frontend build) could invoke `/mcp` or `/a2a/invoke` directly
+and only ever be checked against `kubernaut.ai/tools`, never
+`kubernaut.ai/console`. This defeats the issue's own "two explicit,
+separately-auditable steps" premise for any non-browser client. The design
+was therefore extended (session discussion, not a re-scope) to also enforce
+`kubernaut.ai/console` `use` at both pre-existing tool-invocation
+enforcement points, `checkRBAC` and `newRBACGuard`, making the new endpoint a
+UX convenience layered on top of a real, unbypassable server-side gate.
+
+### 1.2 Objectives
+
+1. **New `SARChecker` capability**: `CheckConsoleAccess(ctx, user, groups)`
+   checks `kubernaut.ai/console` `use` (a coarse-grained, unnamed resource,
+   distinct from the existing per-tool `kubernaut.ai/tools` check), sharing
+   the existing SAR-call + cache infrastructure via an extracted `checkSAR`
+   helper.
+2. **New endpoint**: `GET /a2a/access` returns `200` when the caller's
+   identity has console access, `403` (RFC 7807) otherwise. Sits behind the
+   same `AuthMiddleware`/`PostAuthMiddleware` tier as the existing
+   authenticated routes — no new unauthenticated surface.
+3. **Real server-side enforcement (the actual fix)**: `checkRBAC` (`/mcp`)
+   and `newRBACGuard` (`/a2a/invoke`'s tool-calling loop) both additionally
+   deny a tool call when the configured authorizer implements
+   `ConsoleAuthorizer` and denies console access — even when the specific
+   tool being called would otherwise be allowed. Proven by real HTTP/runner
+   round trips that **never call `/a2a/access`**, demonstrating the bypass is
+   closed, not merely that the new endpoint itself works.
+4. **Zero-touch backward compatibility**: the enforcement is implemented as
+   an optional-interface type-assertion on the existing `Authorizer`
+   field/param (no new required field, no signature change), so the ~50
+   pre-existing test doubles (`allowAllAuthorizer`, `mapAuthorizer`,
+   `mockAuthorizerImpl`, etc.) that don't implement `ConsoleAuthorizer`
+   continue to exercise the unchanged, per-tool-only code path.
+5. **Production correctness guaranteed at compile time**: `var _
+   auth.ConsoleAuthorizer = (*SARChecker)(nil)` ensures the single
+   production `*SARChecker` instance — wired to both `MCPBridgeConfig.Authorizer`
+   and `agent.AgentConfig.Authorizer` from the same `cmd/apifrontend/main.go`
+   construction site — always satisfies `ConsoleAuthorizer`, so the "skip"
+   branch can only ever be taken by test doubles.
+6. **RBAC manifests are CI-gated, not just manually inspected**: a new
+   `kubernaut-console-access` `ClusterRole`/`ClusterRoleBinding` pair,
+   validated by new cases in the existing CI-gated `helm-unittest` suite
+   (`charts/kubernaut/tests/`, per `DD-PLATFORM-005`).
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `go test ./pkg/apifrontend/... -run "UT-AF-1919" -v -count=1` |
+| Integration test pass rate | 100% | `go test ./pkg/apifrontend/... -run "IT-AF-1919" -v -count=1` |
+| Helm-unittest pass rate | 100% | `make test-helm` (or `helm unittest charts/kubernaut`) |
+| Regression pass rate (pre-existing) | 100% | Full `pkg/apifrontend/...` suite unchanged |
+| Build/Lint | Clean | `go build ./...`, `golangci-lint run` |
+
+---
+
+## 2. References
+
+### 2.1 Authority
+
+- Issue #1919: this feature request (backend scope only).
+- `jordigilh/kubernaut-console#48`: companion frontend issue (separate repo,
+  out of scope; will be informed of the actual chosen path once this merges).
+- ADR-021 / ADR-022: existing SAR-based `kubernaut.ai/tools` authorization
+  model this feature extends by one coarse-grained resource.
+- `docs/architecture/decisions/DD-PLATFORM-005-helm-unittest-ci-integration.md`:
+  authority for using `charts/kubernaut/tests/*.yaml` (not manual `helm
+  template`) for RBAC manifest validation.
+
+### 2.2 FedRAMP Controls
+
+| Control | Intent | Application | Test ID |
+|---------|--------|-------------|---------|
+| AC-3 (Access Enforcement) | The system enforces approved authorizations for logical access | `kubernaut.ai/console` `use` gates both the new endpoint and, critically, both existing tool-invocation paths | UT-AF-1919-001..002, 006, 008; IT-AF-1919-001, 002, 005, 006 |
+| AC-6 (Least Privilege) | Users/processes are granted only the access necessary | Console access is a separate, explicit grant from per-tool access — not derived/implied from any tool grant | UT-AF-1919-006..009; RBAC manifest design (§3.1) |
+| AU-12 (Audit Generation) | The system generates audit records for security-relevant events | Console-access denial at the endpoint and at both enforcement sites emits `audit.EventAuthAccessDenied` | IT-AF-1919-003; UT-AF-1919-008 |
+
+---
+
+## 3. Scope
+
+### 3.1 In Scope
+
+| Area | Description |
+|------|--------------|
+| `pkg/apifrontend/auth/sar.go` | `checkSAR` extraction, `CheckConsoleAccess`, `ConsoleAuthorizer` interface, compile-time assertion |
+| `pkg/apifrontend/handler/console_access.go` (new) | `NewConsoleAccessHandler` |
+| `pkg/apifrontend/handler/router.go`, `cmd/apifrontend/main.go` | `GET /a2a/access` route + wiring |
+| `pkg/apifrontend/handler/mcp_bridge.go` (`checkRBAC`) | Console-access type-assertion enforcement for `/mcp` |
+| `pkg/apifrontend/agent/root.go` (`newRBACGuard`) | Console-access type-assertion enforcement for `/a2a/invoke` |
+| `charts/kubernaut/templates/apifrontend/apifrontend.yaml`, `charts/kubernaut/values.yaml` | New `kubernaut-console-access` ClusterRole/Binding + `consoleAccessGroups` values key |
+| `deploy/apifrontend/overlays/e2e/e2e-user-rbac.yaml` | E2E RBAC grant so E2E users keep passing the new gate |
+| `charts/kubernaut/tests/console_access_rbac_test.yaml` (new) | Helm-unittest coverage for the new manifests |
+
+### 3.2 Out of Scope
+
+- `kubernaut-console` frontend gating (`jordigilh/kubernaut-console#48`) — separate repo.
+- `ResilienceConfig.TokenRefreshTimeout` being dead/unwired (unrelated #1934-adjacent finding) — not touched.
+- Any change to `ADR-022`'s "AF SA does all K8s I/O" model — this is just
+  another `subjectaccessreviews create` call by the existing AF ServiceAccount.
+- Any change to the existing `ToolAuthorizer`/`Check` contract or its ~50
+  existing call sites — the new capability is strictly additive.
+
+---
+
+## 4. Test Scenarios
+
+### 4.1 Unit — `SARChecker.CheckConsoleAccess` (`pkg/apifrontend/auth/sar_test.go`)
+
+| ID | FedRAMP | Business Behavior Verified | Acceptance Criteria | Status |
+|----|---------|------------------------------|----------------------|--------|
+| UT-AF-1919-001 | AC-3 | `CheckConsoleAccess` returns `true` when the SAR reactor allows `kubernaut.ai/console` `use` | `(true, nil)` returned | Pending |
+| UT-AF-1919-002 | AC-3 | `CheckConsoleAccess` returns `false` when SAR denies | `(false, nil)` returned | Pending |
+| UT-AF-1919-003 | AC-3 | Fail-closed on empty user | `(false, err)` returned, no SAR call made | Pending |
+| UT-AF-1919-004 | AC-3 | Fail-closed on SAR API error | `(false, err)` returned | Pending |
+| UT-AF-1919-005 | AC-3 | Constructed `SubjectAccessReview` has the correct shape | `Verb=use, Group=kubernaut.ai, Resource=console, Name=""` | Pending |
+
+### 4.2 Unit — `checkRBAC` enforcement (`pkg/apifrontend/handler/mcp_bridge_test.go`)
+
+New `dualAuthorizer{toolAllowed, consoleAllowed bool}` double implementing both `ToolAuthorizer` and `ConsoleAuthorizer`.
+
+| ID | FedRAMP | Business Behavior Verified | Acceptance Criteria | Status |
+|----|---------|------------------------------|----------------------|--------|
+| UT-AF-1919-006 | AC-3, AC-6 | `checkRBAC` denies the tool call when the authorizer implements `ConsoleAuthorizer` and denies console access, even though the per-tool check would allow that tool | Real MCP tool call via `handler.NewMCPHandler` returns an error result containing "console" | Pending |
+| UT-AF-1919-007 | AC-3 | `checkRBAC` behavior is unchanged when the configured authorizer does **not** implement `ConsoleAuthorizer` | Tool call succeeds exactly as the pre-existing `allowAllAuthorizer`-based tests already prove — zero-touch confirmed | Pending |
+
+### 4.3 Unit — `newRBACGuard` enforcement (`pkg/apifrontend/agent/root_test.go`)
+
+Same `dualAuthorizer` double (agent-package-local copy, mirroring the existing per-package `mockAuthorizerImpl` duplication convention already in this codebase).
+
+| ID | FedRAMP | Business Behavior Verified | Acceptance Criteria | Status |
+|----|---------|------------------------------|----------------------|--------|
+| UT-AF-1919-008 | AC-3, AU-12 | `newRBACGuard` denies the tool call when console access is denied even though the per-tool check would allow it; emits audit event with `reason=console_access_denied` | `NewRBACGuardForTest` direct invocation returns `{"error": ...}` containing "console"; spy auditor captures one `EventAuthAccessDenied` event with `Detail["reason"]=="console_access_denied"` | Pending |
+| UT-AF-1919-009 | AC-3 | `newRBACGuard` behavior is unchanged when the configured authorizer does not implement `ConsoleAuthorizer` | Existing `mockAuthorizerImpl`-based tests (UT-AF-1221-020/021, UT-AF-1332-080/081) continue to pass unmodified — zero-touch confirmed | Pending |
+
+### 4.4 Integration — `GET /a2a/access` (new `pkg/apifrontend/handler/console_access_test.go`)
+
+Real `handler.NewRouter` + real middleware chain + fake `ConsoleAuthorizer`, mirroring `handler_test.go`'s router-level harness.
+
+| ID | FedRAMP | Business Behavior Verified | Acceptance Criteria | Status |
+|----|---------|------------------------------|----------------------|--------|
+| IT-AF-1919-001 | AC-3 | `GET /a2a/access` with a valid identity + allowed console access returns `200` | HTTP 200 | Pending |
+| IT-AF-1919-002 | AC-3 | Returns `403` (RFC 7807 `application/problem+json`) when console access is denied | HTTP 403, `Content-Type: application/problem+json` | Pending |
+| IT-AF-1919-003 | AU-12 | Denial emits `audit.EventAuthAccessDenied` with `Detail["endpoint"]=="console"` | Spy auditor captures the event | Pending |
+| IT-AF-1919-004 | IA-2 | Request with no identity in context returns `401` (route sits behind `AuthMiddleware`, not a new unauthenticated hole) | HTTP 401 | Pending |
+
+### 4.5 Integration — bypass-closure proof (the actual security fix)
+
+Real router/agent dispatch, **`/a2a/access` is never called** — proves a
+client that skips the pre-flight endpoint entirely still cannot bypass the
+console gate.
+
+| ID | FedRAMP | Business Behavior Verified | Acceptance Criteria | Status |
+|----|---------|------------------------------|----------------------|--------|
+| IT-AF-1919-005 | AC-3 | Real `POST /mcp` tool-call request, console access denied but tool access allowed, `/a2a/access` never called — the tool call is still denied | Error result mentioning console access denial | Pending |
+| IT-AF-1919-006 | AC-3 | Real ADK `runner.Run` dispatch (same `newRBACGuard`-as-`BeforeToolCallback` wiring shape `NewRootAgent` uses) with an LLM that decides to call a tool, console denied/tool allowed, `/a2a/access` never called — the tool call is denied | Function response contains the console-denial error, mirroring the existing `IT-AF-1221-020/021` harness convention in this file | Pending |
+
+### 4.6 Helm-unittest — RBAC manifests (new `charts/kubernaut/tests/console_access_rbac_test.yaml`)
+
+Mirrors `persona_rbac_approval_gate_test.yaml`'s `documentSelector`-on-`metadata.name` pattern.
+
+| ID | Business Behavior Verified | Acceptance Criteria | Status |
+|----|------------------------------|----------------------|--------|
+| IT-HELM-1919-001 | `kubernaut-console-access` ClusterRole is rendered with the correct rule | `isKind: ClusterRole`, `rules[0].resources` contains `console`, `rules[0].verbs` contains `use` | Pending |
+| IT-HELM-1919-002 | A `ClusterRoleBinding` is rendered per configured group | `isKind: ClusterRoleBinding`, `subjects[0].name` equals the configured group | Pending |
+| IT-HELM-1919-003 | Empty `consoleAccessGroups` renders no bindings (loop is empty-safe) | No matching `ClusterRoleBinding` document | Pending |
+
+---
+
+## 5. Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | IT/UT Test ID |
+|---|---|---|---|
+| `SARChecker.CheckConsoleAccess` / `checkSAR` | `handleConsoleAccess` handler | `pkg/apifrontend/auth/sar.go` | IT-AF-1919-001/002 |
+| `NewConsoleAccessHandler` | `GET /a2a/access` route | `pkg/apifrontend/handler/console_access.go` (new) | IT-AF-1919-001..004 |
+| `RouterConfig.ConsoleAccessHandler` | `cmd/apifrontend/main.go` `RouterConfig` construction | `pkg/apifrontend/handler/router.go` | IT-AF-1919-001..004 |
+| `checkRBAC` console-access enforcement (type-assertion on `cfg.Authorizer`) | `wrapTool` MCP tool dispatch (`cmd/apifrontend/main.go` -> `buildMCPHandler` -> `sarChecker` as `Authorizer`) | `pkg/apifrontend/handler/mcp_bridge.go` | IT-AF-1919-005, UT-AF-1919-006/007 |
+| `newRBACGuard` console-access enforcement (type-assertion on `authorizer`) | agent `BeforeToolCallback` chain (`cmd/apifrontend/main.go` -> `agent.AgentConfig` -> `sarChecker` as `Authorizer`) | `pkg/apifrontend/agent/root.go` | IT-AF-1919-006, UT-AF-1919-008/009 |
+| `var _ auth.ConsoleAuthorizer = (*SARChecker)(nil)` | compile-time guarantee, no runtime entry point | `pkg/apifrontend/auth/sar.go` | build (compile failure = test failure) |
+| `kubernaut-console-access` ClusterRole/Binding | Helm chart render + E2E overlay | `charts/kubernaut/templates/apifrontend/apifrontend.yaml`, `deploy/apifrontend/overlays/e2e/e2e-user-rbac.yaml` | IT-HELM-1919-001..003 |
+
+---
+
+## 6. TDD Execution Phases
+
+| Phase | Type | Scope | Tests |
+|-------|------|-------|-------|
+| 1 | RED | Add all UT/IT test cases against unfixed code; confirm they fail (compile failure for new symbols, or assertion failure for behavior) | UT-AF-1919-001..009, IT-AF-1919-001..006, IT-HELM-1919-001..003 |
+| 2 | GREEN | `checkSAR`/`CheckConsoleAccess`/`ConsoleAuthorizer` + compile-time assertion; `NewConsoleAccessHandler`; router/main.go wiring; `checkRBAC`/`newRBACGuard` type-assertion enforcement; Helm manifests + values | All Phase 1 tests pass; no regression in existing `pkg/apifrontend/...` suite |
+| 3 | REFACTOR | Lint/build/race for `pkg/apifrontend`; `helm template`/`helm unittest` validation | All tests remain green |
+
+---
+
+## 7. Execution
+
+```bash
+go build ./...
+go test ./pkg/apifrontend/... -run "UT-AF-1919|IT-AF-1919" -v -count=1
+go test ./pkg/apifrontend/... -count=1
+golangci-lint run --timeout=5m ./pkg/apifrontend/...
+helm unittest charts/kubernaut -f 'tests/console_access_rbac_test.yaml'
+```

--- a/docs/tests/1934/TEST_PLAN.md
+++ b/docs/tests/1934/TEST_PLAN.md
@@ -1,0 +1,149 @@
+# Test Plan: Fleet MCP Client `connectWithBackoff`/`doReconnect` Block Forever on a Hung Handshake
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-1934
+**Feature**: Bound each MCP connect attempt inside `pkg/fleet/mcpclient`'s
+backoff/reconnect loop with a per-attempt timeout, so a single hung handshake
+cannot block startup or reconnection forever.
+**Version**: 1.0
+**Created**: 2026-08-04
+**Author**: AI Agent
+**Status**: Draft
+**Branch**: `feat/1919-1934-console-gate-connect-timeout`
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+`connectWithBackoff` (`pkg/fleet/mcpclient/resilience.go`, inside
+`wait.ExponentialBackoff`'s closure) and `doReconnect`
+(`pkg/fleet/mcpclient/resilience.go`) both call `New(ctx, rc.endpoint,
+rc.opts...)` using the caller's raw `ctx`. `New()`
+(`pkg/fleet/mcpclient/client.go`) performs a single blocking
+`mcpClient.Connect(ctx, transport, nil)` with no internal bound of its own.
+
+Every production caller of `NewResilient`/`Reconnect` (8 `cmd/*/main.go`
+sites) passes a signal-cancel-only context (`context.Background()` wrapped in
+`signal.NotifyContext`/`ctrl.SetupSignalHandler`) — never a context with a
+deadline. Issue #1933 reproduced a hung handshake against a non-conformant
+fake server: a single such hang blocks the entire backoff loop, and thus
+service startup (or a lazy reconnect), forever — silently defeating
+`MaxElapsedTime`/`MaxInterval`, which exist specifically to bound total
+retry duration.
+
+### 1.2 Objectives
+
+1. **Bounded connect attempts**: each individual `New()` call inside
+   `connectWithBackoff` and `doReconnect` is bounded by a new
+   `ResilienceConfig.ConnectTimeout`, independent of whether the caller's
+   context carries a deadline.
+2. **Behavioral proof, not implementation inspection**: tests exercise the
+   real `NewResilient`/`Reconnect` entry points against a fake MCP server
+   that never responds to `initialize`, with `context.Background()` (no
+   caller deadline) — proving the bound is enforced internally, not merely
+   inherited from the caller.
+3. **No regression**: existing backoff/retry/reconnect behavior
+   (`UT-FLEET-RES-002/003/007`) is unaffected when connections succeed
+   within `ConnectTimeout`.
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| Unit test pass rate | 100% | `make test-unit` (`pkg/fleet/mcpclient/...`) |
+| Regression pass rate (pre-existing) | 100% | `UT-FLEET-RES-001..005,007` unchanged |
+| Build/Lint | Clean | `go build ./...`, `golangci-lint run` |
+
+---
+
+## 2. References
+
+### 2.1 Authority
+
+- Issue #1934: this bug report.
+- Issue #1933: original hang reproduction that motivated this fix.
+- `pkg/fleet/readiness/probers.go` (`MCPClientProber.Probe`): pre-existing
+  `context.WithTimeout(ctx, timeout)` idiom this fix mirrors, one layer up.
+- `pkg/fleet/fmc/http_client.go`: second pre-existing instance of the same
+  idiom.
+- BR-INTEGRATION-065 (governing `pkg/fleet/mcpclient`, per
+  `docs/testing/BR-INTEGRATION-054/TEST_PLAN.md`).
+
+### 2.2 FedRAMP Controls
+
+| Control | Intent | Application | Test ID |
+|---------|--------|-------------|---------|
+| CP-10 (Information System Recovery and Reconstitution) | The system must be able to retry and recover from failed dependencies within a bounded time | Bounding each connect attempt is what allows the backoff loop to actually recover/retry rather than being stuck indefinitely on one hung attempt | UT-FLEET-RES-008, UT-FLEET-RES-009 |
+
+---
+
+## 3. Scope
+
+### 3.1 In Scope
+
+| Area | Description |
+|------|--------------|
+| `ResilienceConfig` | Add `ConnectTimeout time.Duration` field, default 30s in `DefaultResilienceConfig()` |
+| `connectWithBackoff` | Wrap the per-attempt `New(ctx, ...)` call with `context.WithTimeout(ctx, rc.config.ConnectTimeout)` |
+| `doReconnect` | Same treatment around its single `New(ctx, ...)` call |
+
+### 3.2 Out of Scope
+
+- `ResilienceConfig.TokenRefreshTimeout` being dead/unwired (pre-existing,
+  unrelated gap discovered during preflight) — not touched here.
+- Any change to `New()`/`Client` in `client.go` itself — the fix bounds the
+  *caller's* context passed into `New()`, not `New()`'s internals.
+- Any change to the backoff schedule (`InitialInterval`/`MaxInterval`/`MaxElapsedTime`)
+  itself.
+
+---
+
+## 4. Test Scenarios (Unit — behavioral, via production entry points)
+
+Both scenarios reuse the existing `newFakeMCPServer(onInitialize func(...))`
+hook (already used by `UT-FLEET-RES-003/007`) with an `onInitialize` that
+never writes a response — simulating the exact #1933-class hang — and call
+the real `NewResilient`/`Reconnect` production entry points with
+`context.Background()` (no caller-supplied deadline), proving the bound is
+enforced internally rather than inherited.
+
+| ID | FedRAMP | Business Behavior Verified | Acceptance Criteria | Status |
+|----|---------|------------------------------|----------------------|--------|
+| UT-FLEET-RES-008 | CP-10 | `NewResilient` against a hanging fake server, with a short test `ConnectTimeout`/`MaxElapsedTime` and a caller context with no deadline, returns instead of hanging | Call returns (with an error) within a bounded wall-clock margin (not the full test timeout); error indicates a connect failure, not a test hang | Pending |
+| UT-FLEET-RES-009 | CP-10 | `Reconnect` against a hanging fake server, with a caller context with no deadline, returns instead of hanging | `doReconnect`'s own bound fires even though the caller supplies no deadline (today it only avoids hanging by accident, because the sole caller `probers.go` happens to wrap its own timeout) | Pending |
+
+**Test file**: `pkg/fleet/mcpclient/resilience_test.go`
+
+---
+
+## 5. Wiring Manifest
+
+Not applicable — no new component/handler/entry point. `ResilienceConfig`,
+`connectWithBackoff`, and `doReconnect` are already-wired, already
+production-exercised code (8 `cmd/*/main.go` call sites via
+`NewResilient`/`Reconnect`); only their internal per-attempt timeout
+behavior changes.
+
+---
+
+## 6. TDD Execution Phases
+
+| Phase | Type | Scope | Tests |
+|-------|------|-------|-------|
+| 1 | RED | Add `UT-FLEET-RES-008/009` against unfixed code; confirm they fail (hang/timeout at the test level) | UT-FLEET-RES-008, UT-FLEET-RES-009 |
+| 2 | GREEN | Add `ConnectTimeout` to `ResilienceConfig`; wrap the `New()` calls in `connectWithBackoff` and `doReconnect` with `context.WithTimeout` | Both new tests pass; no regression in `UT-FLEET-RES-001..005,007` |
+| 3 | REFACTOR | Lint/build/race for `pkg/fleet/mcpclient` | All tests remain green |
+
+---
+
+## 7. Execution
+
+```bash
+go build ./...
+go test ./pkg/fleet/mcpclient/... -run "UT-FLEET-RES-00(8|9)" -v -count=1
+make test-unit
+golangci-lint run --timeout=5m ./pkg/fleet/mcpclient/...
+```

--- a/pkg/apifrontend/agent/root.go
+++ b/pkg/apifrontend/agent/root.go
@@ -254,61 +254,90 @@ func NewRBACGuardForTest(authorizer auth.ToolAuthorizer, auditor audit.Emitter) 
 	return newRBACGuard(authorizer, auditor)
 }
 
+// denyRBACGuard emits an EventAuthAccessDenied audit event (AU-12, if auditor
+// is non-nil) and logs the denial, mirroring denyRBAC's contract in
+// mcp_bridge.go for the A2A tool-calling path. userID may be empty (no
+// identity yet resolved).
+func denyRBACGuard(ctx tool.Context, auditor audit.Emitter, toolName, userID, reason string, groups []string, logErr error) {
+	logger := logr.FromContextOrDiscard(ctx)
+	if logErr != nil {
+		logger.Error(logErr, "rbac-guard denied tool", "tool", toolName, "user", userID, "reason", reason)
+	} else {
+		logger.Info("rbac-guard denied tool", "tool", toolName, "user", userID, "reason", reason)
+	}
+	if auditor == nil {
+		return
+	}
+	detail := map[string]string{
+		"tool_name": toolName,
+		"endpoint":  "a2a",
+	}
+	if reason != "" {
+		detail["reason"] = reason
+	}
+	if groups != nil {
+		detail["groups"] = strings.Join(groups, ",")
+	}
+	auditor.Emit(ctx, &audit.Event{
+		Type:   audit.EventAuthAccessDenied,
+		UserID: userID,
+		Detail: detail,
+	})
+}
+
+// checkConsoleAccessGuard enforces the #1919 (AC-3, AC-6) coarse-grained
+// console-access gate for the A2A tool-calling path: a separate, coarser gate
+// than per-tool authorization, enforced here (not just at the advisory
+// GET /a2a/access endpoint) so a client driving the A2A tool-calling loop
+// directly cannot bypass it. Optional-interface type-assertion: authorizers
+// that don't implement ConsoleAuthorizer (all pre-existing test doubles) skip
+// this check unchanged (result == nil, ok == true). Returns the guard's
+// terminal result (non-nil) when access is denied or the check errors.
+func checkConsoleAccessGuard(ctx tool.Context, authorizer auth.ToolAuthorizer, auditor audit.Emitter, identity *auth.UserIdentity, toolName string) (result map[string]any, ok bool) {
+	ca, isConsoleAuthorizer := authorizer.(auth.ConsoleAuthorizer)
+	if !isConsoleAuthorizer {
+		return nil, true
+	}
+
+	consoleAllowed, cErr := ca.CheckConsoleAccess(ctx, identity.Username, identity.Groups)
+	if cErr != nil {
+		denyRBACGuard(ctx, auditor, toolName, identity.Username, "console_authorizer_error", identity.Groups, cErr)
+		return map[string]any{"error": "authorization check failed: console access"}, false
+	}
+	if !consoleAllowed {
+		denyRBACGuard(ctx, auditor, toolName, identity.Username, "console_access_denied", identity.Groups, nil)
+		return map[string]any{"error": "forbidden: no console access"}, false
+	}
+	return nil, true
+}
+
 // newRBACGuard returns a BeforeToolCallback that enforces RBAC via SAR.
 // Fail-closed: if no identity, authorizer error, or denial, the tool call is rejected.
 // Denied attempts are emitted as audit events for FedRAMP SI-4 compliance.
 func newRBACGuard(authorizer auth.ToolAuthorizer, auditor audit.Emitter) llmagent.BeforeToolCallback {
 	return func(ctx tool.Context, t tool.Tool, _ map[string]any) (map[string]any, error) {
+		toolName := t.Name()
+
 		identity := auth.UserIdentityFromContext(ctx)
 		if identity == nil {
-			logr.FromContextOrDiscard(ctx).Info("rbac-guard denied tool", "tool", t.Name(), "reason", "no_identity_in_context")
-			if auditor != nil {
-				auditor.Emit(ctx, &audit.Event{
-					Type: audit.EventAuthAccessDenied,
-					Detail: map[string]string{
-						"tool_name": t.Name(),
-						"endpoint":  "a2a",
-						"reason":    "no_identity_in_context",
-					},
-				})
-			}
+			denyRBACGuard(ctx, auditor, toolName, "", "no_identity_in_context", nil, nil)
 			return map[string]any{"error": "unauthorized: no identity in context"}, nil
 		}
 
-		toolName := t.Name()
+		if result, ok := checkConsoleAccessGuard(ctx, authorizer, auditor, identity, toolName); !ok {
+			return result, nil
+		}
+
 		allowed, err := authorizer.Check(ctx, identity.Username, identity.Groups, toolName)
 		if err != nil {
-			logr.FromContextOrDiscard(ctx).Error(err, "rbac-guard denied tool", "tool", toolName, "user", identity.Username, "reason", "authorizer_error")
-			if auditor != nil {
-				auditor.Emit(ctx, &audit.Event{
-					Type:   audit.EventAuthAccessDenied,
-					UserID: identity.Username,
-					Detail: map[string]string{
-						"tool_name": toolName,
-						"endpoint":  "a2a",
-						"reason":    "authorizer_error",
-						"groups":    strings.Join(identity.Groups, ","),
-					},
-				})
-			}
+			denyRBACGuard(ctx, auditor, toolName, identity.Username, "authorizer_error", identity.Groups, err)
 			return map[string]any{"error": "authorization check failed"}, nil
 		}
 		if allowed {
 			return nil, nil
 		}
 
-		if auditor != nil {
-			auditor.Emit(ctx, &audit.Event{
-				Type:   audit.EventAuthAccessDenied,
-				UserID: identity.Username,
-				Detail: map[string]string{
-					"tool_name": toolName,
-					"endpoint":  "a2a",
-					"groups":    strings.Join(identity.Groups, ","),
-				},
-			})
-		}
-
+		denyRBACGuard(ctx, auditor, toolName, identity.Username, "", identity.Groups, nil)
 		return map[string]any{"error": fmt.Sprintf("forbidden: role does not grant access to tool %q", toolName)}, nil
 	}
 }

--- a/pkg/apifrontend/agent/root_test.go
+++ b/pkg/apifrontend/agent/root_test.go
@@ -99,6 +99,22 @@ func (m *mockAuthorizerImpl) Check(_ context.Context, _ string, _ []string, _ st
 	return m.allow, m.err
 }
 
+// dualAuthorizer implements both auth.ToolAuthorizer and auth.ConsoleAuthorizer
+// with independently controllable outcomes, for testing #1919's console-access
+// enforcement layered on top of the pre-existing per-tool check in newRBACGuard.
+type dualAuthorizer struct {
+	toolAllowed    bool
+	consoleAllowed bool
+}
+
+func (d *dualAuthorizer) Check(_ context.Context, _ string, _ []string, _ string) (bool, error) {
+	return d.toolAllowed, nil
+}
+
+func (d *dualAuthorizer) CheckConsoleAccess(_ context.Context, _ string, _ []string) (bool, error) {
+	return d.consoleAllowed, nil
+}
+
 var _ = Describe("Root Agent", func() {
 	Describe("NewRootAgent", func() {
 		It("UT-AF-100-001: returns configured agent with model", func() {
@@ -261,8 +277,8 @@ var _ = Describe("Root Agent", func() {
 			callCount  atomic.Int32
 		}
 
-		newMockToolCallLLM := func(targetTool string) *mockToolCallLLM {
-			return &mockToolCallLLM{targetTool: targetTool}
+		newMockToolCallLLM := func() *mockToolCallLLM {
+			return &mockToolCallLLM{targetTool: "af_test_tool"}
 		}
 
 		buildToolCallLLMName := func(_ *mockToolCallLLM) string { return "mock-tool-call-llm" }
@@ -355,7 +371,7 @@ var _ = Describe("Root Agent", func() {
 		}
 
 		It("IT-AF-1221-020: allowed identity -> tool executes via runner.Run", func() {
-			mockLLM := newMockToolCallLLM("af_test_tool")
+			mockLLM := newMockToolCallLLM()
 			r, _ := buildRunner(mockLLM, &mockAuthorizerImpl{allow: true})
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
@@ -371,7 +387,7 @@ var _ = Describe("Root Agent", func() {
 		})
 
 		It("IT-AF-1221-021: denied identity -> tool blocked with forbidden", func() {
-			mockLLM := newMockToolCallLLM("af_test_tool")
+			mockLLM := newMockToolCallLLM()
 			r, _ := buildRunner(mockLLM, &mockAuthorizerImpl{allow: false})
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
@@ -384,12 +400,27 @@ var _ = Describe("Root Agent", func() {
 		})
 
 		It("IT-AF-1221-022: no identity in context -> denied with unauthorized", func() {
-			mockLLM := newMockToolCallLLM("af_test_tool")
+			mockLLM := newMockToolCallLLM()
 			r, _ := buildRunner(mockLLM, &mockAuthorizerImpl{allow: true})
 
 			// No identity injected — context.Background() without WithUserIdentity
 			result := runAgent(r, context.Background())
 			Expect(result).To(ContainSubstring("unauthorized"))
+		})
+
+		It("IT-AF-1919-006 [AC-3]: console access denied blocks the tool call via runner.Run even though the tool would be allowed (bypass-closure proof: /a2a/access is never called)", func() {
+			mockLLM := newMockToolCallLLM()
+			r, _ := buildRunner(mockLLM, &dualAuthorizer{toolAllowed: true, consoleAllowed: false})
+
+			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+				Username: "sre-user@example.com",
+				Groups:   []string{"sre"},
+			})
+
+			result := runAgent(r, ctx)
+			Expect(result).To(ContainSubstring("console"),
+				"AC-3: a client that never calls GET /a2a/access must still be denied at the tool-call site "+
+					"when console access is denied, even though the per-tool check would allow the call")
 		})
 
 		It("UT-AF-1332-080: RBAC denial emits EventAuthAccessDenied audit event (SI-4)", func() {
@@ -450,6 +481,61 @@ var _ = Describe("Root Agent", func() {
 			Expect(ev.Type).To(Equal(audit.EventAuthAccessDenied))
 			Expect(ev.Detail["reason"]).To(Equal("no_identity_in_context"))
 			Expect(ev.Detail["tool_name"]).To(Equal("kubernaut_remediate"))
+		})
+
+		It("UT-AF-1919-008 [AC-3, AU-12]: denies when console access is denied even though the tool would be allowed, and audits reason=console_access_denied", func() {
+			spyAuditor := &spyAuditEmitter{}
+			guard := agentpkg.NewRBACGuardForTest(&dualAuthorizer{toolAllowed: true, consoleAllowed: false}, spyAuditor)
+
+			testTool, err := functiontool.New(functiontool.Config{
+				Name:        "kubernaut_investigate",
+				Description: "test tool for #1919 console gate",
+			}, func(_ tool.Context, _ struct{}) (struct{}, error) {
+				return struct{}{}, nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			baseCtx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+				Username: "sre-user@example.com",
+				Groups:   []string{"sre"},
+			})
+			ctx := mockToolCtx{Context: baseCtx, callID: "console-gate-008"}
+
+			result, err := guard(ctx, testTool, map[string]any{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(HaveKey("error"))
+			Expect(result["error"]).To(ContainSubstring("console"),
+				"AC-3: denial must be attributable to the console-access gate, not the (allowed) per-tool check")
+
+			Expect(spyAuditor.events).To(HaveLen(1), "AU-12: console-access denial must emit exactly one audit event")
+			ev := spyAuditor.events[0]
+			Expect(ev.Type).To(Equal(audit.EventAuthAccessDenied))
+			Expect(ev.UserID).To(Equal("sre-user@example.com"))
+			Expect(ev.Detail["reason"]).To(Equal("console_access_denied"))
+			Expect(ev.Detail["tool_name"]).To(Equal("kubernaut_investigate"))
+		})
+
+		It("UT-AF-1919-009 [AC-3]: unchanged when the authorizer does not implement ConsoleAuthorizer", func() {
+			guard := agentpkg.NewRBACGuardForTest(&mockAuthorizerImpl{allow: true}, nil)
+
+			testTool, err := functiontool.New(functiontool.Config{
+				Name:        "kubernaut_investigate",
+				Description: "test tool for #1919 zero-touch fallback",
+			}, func(_ tool.Context, _ struct{}) (struct{}, error) {
+				return struct{}{}, nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			baseCtx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+				Username: "sre-user@example.com",
+				Groups:   []string{"sre"},
+			})
+			ctx := mockToolCtx{Context: baseCtx, callID: "console-gate-009"}
+
+			result, err := guard(ctx, testTool, map[string]any{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNil(),
+				"AC-3: an authorizer that doesn't implement ConsoleAuthorizer must fall through to the unchanged per-tool-only check (nil result = proceed)")
 		})
 	})
 

--- a/pkg/apifrontend/auth/sar.go
+++ b/pkg/apifrontend/auth/sar.go
@@ -22,6 +22,20 @@ type ToolAuthorizer interface {
 	Check(ctx context.Context, user string, groups []string, toolName string) (bool, error)
 }
 
+// ConsoleAuthorizer checks whether a user is authorized to access the
+// kubernaut console/chat UI at all -- a coarse-grained gate independent of
+// (and enforced in addition to) any per-tool ToolAuthorizer.Check result
+// (#1919, AC-3/AC-6). Implementations must be safe for concurrent use.
+//
+// This is an optional capability: callers holding a ToolAuthorizer type-assert
+// for ConsoleAuthorizer and skip the console check when the concrete
+// authorizer doesn't implement it, so existing ToolAuthorizer-only test
+// doubles need no changes (see checkRBAC in mcp_bridge.go and newRBACGuard in
+// agent/root.go).
+type ConsoleAuthorizer interface {
+	CheckConsoleAccess(ctx context.Context, user string, groups []string) (bool, error)
+}
+
 type cacheEntry struct {
 	allowed   bool
 	expiresAt time.Time
@@ -81,14 +95,33 @@ func (s *SARChecker) evictExpired(interval time.Duration) {
 // by performing a Kubernetes SubjectAccessReview against the kubernaut.ai/tools resource.
 // Results are cached for the configured TTL. Errors are never cached (retried on next call).
 func (s *SARChecker) Check(ctx context.Context, user string, groups []string, toolName string) (bool, error) {
-	if user == "" {
-		return false, fmt.Errorf("user must not be empty")
-	}
 	if toolName == "" {
 		return false, fmt.Errorf("tool name must not be empty")
 	}
+	return s.checkSAR(ctx, user, groups, "tools", toolName)
+}
 
-	key := cacheKey(user, groups, toolName)
+// CheckConsoleAccess verifies whether the given user (with groups) holds the
+// coarse-grained, unnamed "console" grant (#1919, AC-3/AC-6) -- a separate,
+// independently-auditable authorization step from any per-tool grant. It
+// performs a Kubernetes SubjectAccessReview against the kubernaut.ai/console
+// resource (verb=use, no resourceName). Results are cached for the
+// configured TTL, in the same cache but keyed distinctly from Check's
+// "tools" entries so the two never collide.
+func (s *SARChecker) CheckConsoleAccess(ctx context.Context, user string, groups []string) (bool, error) {
+	return s.checkSAR(ctx, user, groups, "console", "")
+}
+
+// checkSAR is the shared SAR-call-plus-cache implementation behind both
+// Check (resource="tools", name=toolName) and CheckConsoleAccess
+// (resource="console", name=""). Fail-closed: empty user or any API error
+// returns (false, err).
+func (s *SARChecker) checkSAR(ctx context.Context, user string, groups []string, resource, name string) (bool, error) {
+	if user == "" {
+		return false, fmt.Errorf("user must not be empty")
+	}
+
+	key := cacheKey(user, groups, resource, name)
 
 	s.mu.RLock()
 	if entry, ok := s.cache[key]; ok && time.Now().Before(entry.expiresAt) {
@@ -104,15 +137,15 @@ func (s *SARChecker) Check(ctx context.Context, user string, groups []string, to
 			ResourceAttributes: &authorizationv1.ResourceAttributes{
 				Verb:     "use",
 				Group:    "kubernaut.ai",
-				Resource: "tools",
-				Name:     toolName,
+				Resource: resource,
+				Name:     name,
 			},
 		},
 	}
 
 	result, err := s.client.AuthorizationV1().SubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
 	if err != nil {
-		s.logger.Error(err, "SAR API call failed", "user", user, "tool", toolName)
+		s.logger.Error(err, "SAR API call failed", "user", user, "resource", resource, "name", name)
 		return false, fmt.Errorf("SAR authorization check failed: %w", err)
 	}
 
@@ -126,19 +159,20 @@ func (s *SARChecker) Check(ctx context.Context, user string, groups []string, to
 	s.mu.Unlock()
 
 	if !allowed {
-		s.logger.V(1).Info("SAR denied tool access", "user", user, "tool", toolName, "groups", groups)
+		s.logger.V(1).Info("SAR denied access", "user", user, "resource", resource, "name", name, "groups", groups)
 	}
 
 	return allowed, nil
 }
 
-func cacheKey(user string, groups []string, toolName string) string {
+func cacheKey(user string, groups []string, resource, name string) string {
 	sorted := make([]string, len(groups))
 	copy(sorted, groups)
 	sort.Strings(sorted)
-	raw := user + "\x00" + strings.Join(sorted, "\x00") + "\x00" + toolName
+	raw := user + "\x00" + strings.Join(sorted, "\x00") + "\x00" + resource + "\x00" + name
 	h := sha256.Sum256([]byte(raw))
 	return hex.EncodeToString(h[:])
 }
 
 var _ ToolAuthorizer = (*SARChecker)(nil)
+var _ ConsoleAuthorizer = (*SARChecker)(nil)

--- a/pkg/apifrontend/auth/sar_test.go
+++ b/pkg/apifrontend/auth/sar_test.go
@@ -198,4 +198,86 @@ var _ = Describe("SARChecker", func() {
 			Expect(allowed).To(BeFalse(), "AC 5: fail-closed on invalid input")
 		})
 	})
+
+	Describe("UT-AF-1919-001: CheckConsoleAccess allowed [AC-3]", func() {
+		It("should return true when SAR allows kubernaut.ai/console use", func() {
+			fakeK8s.PrependReactor("create", "subjectaccessreviews", allowAll)
+			checker = auth.NewSARChecker(fakeK8s, 30*time.Second, logr.Discard())
+
+			allowed, err := checker.CheckConsoleAccess(ctx, "alice", []string{"sre"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allowed).To(BeTrue(), "AC-3: console access should be granted when SAR allows")
+		})
+	})
+
+	Describe("UT-AF-1919-002: CheckConsoleAccess denied [AC-3]", func() {
+		It("should return false when SAR denies kubernaut.ai/console use", func() {
+			fakeK8s.PrependReactor("create", "subjectaccessreviews", denyAll)
+			checker = auth.NewSARChecker(fakeK8s, 30*time.Second, logr.Discard())
+
+			allowed, err := checker.CheckConsoleAccess(ctx, "viewer", []string{"observability"})
+			Expect(err).NotTo(HaveOccurred(), "AC-3: denial is not an error")
+			Expect(allowed).To(BeFalse(), "AC-3: console access should be denied when SAR denies")
+		})
+	})
+
+	Describe("UT-AF-1919-003: CheckConsoleAccess fail-closed on empty user [AC-3]", func() {
+		It("should reject empty user as input validation", func() {
+			checker = auth.NewSARChecker(fakeK8s, 30*time.Second, logr.Discard())
+
+			allowed, err := checker.CheckConsoleAccess(ctx, "", []string{"sre"})
+			Expect(err).To(HaveOccurred(), "AC-3: empty user must be rejected")
+			Expect(allowed).To(BeFalse(), "AC-3: fail-closed on invalid input")
+		})
+	})
+
+	Describe("UT-AF-1919-004: CheckConsoleAccess fail-closed on SAR API error [AC-3]", func() {
+		It("should return false and an error when SAR API fails", func() {
+			fakeK8s.PrependReactor("create", "subjectaccessreviews", failAll)
+			checker = auth.NewSARChecker(fakeK8s, 30*time.Second, logr.Discard())
+
+			allowed, err := checker.CheckConsoleAccess(ctx, "alice", []string{"sre"})
+			Expect(err).To(HaveOccurred(), "AC-3: API error should be propagated")
+			Expect(allowed).To(BeFalse(), "AC-3: fail-closed — API error must deny access")
+		})
+	})
+
+	Describe("UT-AF-1919-005: CheckConsoleAccess SAR request shape [AC-3]", func() {
+		It("should build a SAR for the coarse-grained console resource, not a named tool", func() {
+			fakeK8s.PrependReactor("create", "subjectaccessreviews", allowAll)
+			checker = auth.NewSARChecker(fakeK8s, 30*time.Second, logr.Discard())
+
+			_, err := checker.CheckConsoleAccess(ctx, "alice@corp.com", []string{"sre", "system:authenticated"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(lastSAR).NotTo(BeNil(), "AC-3: SAR request should have been captured")
+			Expect(lastSAR.Spec.User).To(Equal("alice@corp.com"))
+			Expect(lastSAR.Spec.Groups).To(ConsistOf("sre", "system:authenticated"))
+			Expect(lastSAR.Spec.ResourceAttributes).NotTo(BeNil())
+			Expect(lastSAR.Spec.ResourceAttributes.Verb).To(Equal("use"), "verb must be 'use'")
+			Expect(lastSAR.Spec.ResourceAttributes.Group).To(Equal("kubernaut.ai"), "apiGroup must be 'kubernaut.ai'")
+			Expect(lastSAR.Spec.ResourceAttributes.Resource).To(Equal("console"), "resource must be 'console', distinct from 'tools'")
+			Expect(lastSAR.Spec.ResourceAttributes.Name).To(Equal(""), "console access is a coarse-grained, unnamed resource")
+		})
+	})
+
+	Describe("UT-AF-1919: tools and console SAR cache entries do not collide", func() {
+		It("should call the SAR API separately for Check(tools) and CheckConsoleAccess even with identical user/groups", func() {
+			callCount := atomic.Int32{}
+			fakeK8s.PrependReactor("create", "subjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				callCount.Add(1)
+				createAction := action.(k8stesting.CreateAction)
+				sar := createAction.GetObject().(*authorizationv1.SubjectAccessReview)
+				sar.Status = authorizationv1.SubjectAccessReviewStatus{Allowed: true}
+				return true, sar, nil
+			})
+			checker = auth.NewSARChecker(fakeK8s, 30*time.Second, logr.Discard())
+
+			_, _ = checker.Check(ctx, "alice", []string{"sre"}, "kubernaut_approve")
+			_, _ = checker.CheckConsoleAccess(ctx, "alice", []string{"sre"})
+
+			Expect(callCount.Load()).To(Equal(int32(2)),
+				"AC-3: tools and console checks for the same user/groups must be cached independently")
+		})
+	})
 })

--- a/pkg/apifrontend/handler/console_access.go
+++ b/pkg/apifrontend/handler/console_access.go
@@ -1,0 +1,75 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/go-logr/logr"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/audit"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/httputil"
+)
+
+// consoleAccessHandler serves GET /a2a/access (#1919): a lightweight,
+// pre-flight check the console/chat client can call once at load time to
+// decide whether to render its UI at all, backed by the same
+// kubernaut.ai/console SAR grant that checkRBAC and newRBACGuard also
+// enforce directly at every tool-call site (this endpoint is advisory only
+// -- it is not itself the security boundary, see #1919 design notes).
+type consoleAccessHandler struct {
+	checker auth.ConsoleAuthorizer
+	auditor audit.Emitter
+	logger  logr.Logger
+}
+
+// NewConsoleAccessHandler constructs the GET /a2a/access handler. auditor
+// may be nil (no audit emission); logger may be the zero value (discarded).
+func NewConsoleAccessHandler(checker auth.ConsoleAuthorizer, auditor audit.Emitter, logger logr.Logger) http.Handler {
+	if logger.GetSink() == nil {
+		logger = logr.Discard()
+	}
+	return &consoleAccessHandler{
+		checker: checker,
+		auditor: auditor,
+		logger:  logger.WithName("console-access"),
+	}
+}
+
+func (h *consoleAccessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user := auth.UserIdentityFromContext(ctx)
+	if user == nil {
+		httputil.WriteProblem(w, http.StatusUnauthorized, "Unauthorized", "authentication required")
+		return
+	}
+
+	allowed, err := h.checker.CheckConsoleAccess(ctx, user.Username, user.Groups)
+	if err != nil {
+		h.logger.Error(err, "console access check failed", "user", user.Username)
+		h.deny(ctx, w, user, "console_authorizer_error")
+		return
+	}
+	if !allowed {
+		h.deny(ctx, w, user, "console_access_denied")
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// deny emits an EventAuthAccessDenied audit event (AU-12) and writes the
+// RFC 7807 403 response, mirroring checkRBAC's denyRBAC (mcp_bridge.go).
+func (h *consoleAccessHandler) deny(ctx context.Context, w http.ResponseWriter, user *auth.UserIdentity, reason string) {
+	if h.auditor != nil {
+		h.auditor.Emit(ctx, &audit.Event{
+			Type:   audit.EventAuthAccessDenied,
+			UserID: user.Username,
+			Detail: map[string]string{
+				"endpoint": "console",
+				"reason":   reason,
+			},
+		})
+	}
+	httputil.WriteProblem(w, http.StatusForbidden, "Forbidden", "not authorized to access the console")
+}

--- a/pkg/apifrontend/handler/console_access_test.go
+++ b/pkg/apifrontend/handler/console_access_test.go
@@ -1,0 +1,218 @@
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/audit"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/handler"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/metrics"
+)
+
+// fakeConsoleAuthorizer implements auth.ConsoleAuthorizer for the GET
+// /a2a/access IT tests, independent of the concrete SARChecker.
+type fakeConsoleAuthorizer struct {
+	allow bool
+	err   error
+}
+
+func (f *fakeConsoleAuthorizer) CheckConsoleAccess(_ context.Context, _ string, _ []string) (bool, error) {
+	return f.allow, f.err
+}
+
+// consoleTestUser is the identity injected by the fake AuthMiddleware used
+// throughout this file's IT tests once a bearer token is present.
+var consoleTestUser = &auth.UserIdentity{Username: "sre-user@example.com", Groups: []string{"sre"}}
+
+// fakeIdentityAuthMiddleware mirrors the production AuthMiddleware's
+// contract (401 without a bearer token, auth.UserIdentity injected into
+// context otherwise) without exercising real JWT validation -- that is
+// already covered by pkg/apifrontend/auth's own test suite. This lets these
+// tests exercise the real handler.NewRouter + real route wiring +
+// checkRBAC/console-access-handler logic.
+func fakeIdentityAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		ctx := auth.WithUserIdentity(r.Context(), consoleTestUser)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+var _ = Describe("Console Access Endpoint (#1919)", func() {
+	var (
+		metricsReg     *metrics.Registry
+		consoleAuditor *fakeAuditor
+		newRouterWith  func(checker auth.ConsoleAuthorizer) http.Handler
+	)
+
+	BeforeEach(func() {
+		metricsReg = metrics.NewRegistry()
+		consoleAuditor = &fakeAuditor{}
+		newRouterWith = func(checker auth.ConsoleAuthorizer) http.Handler {
+			router, err := handler.NewRouter(handler.RouterConfig{
+				MetricsRegistry:      metricsReg,
+				A2AHandler:           http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
+				MCPHandler:           http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
+				AgentCardHandler:     http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
+				ConsoleAccessHandler: handler.NewConsoleAccessHandler(checker, consoleAuditor, logr.Discard()),
+				AuthMiddleware:       fakeIdentityAuthMiddleware,
+				ReadyChecker:         func() bool { return true },
+			})
+			Expect(err).NotTo(HaveOccurred())
+			return router
+		}
+	})
+
+	It("IT-AF-1919-001 [AC-3]: GET /a2a/access returns 200 when console access is allowed", func() {
+		router := newRouterWith(&fakeConsoleAuthorizer{allow: true})
+		req := httptest.NewRequest(http.MethodGet, "/a2a/access", http.NoBody)
+		req.Header.Set("Authorization", "Bearer test-token")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+	})
+
+	It("IT-AF-1919-002 [AC-3]: GET /a2a/access returns 403 problem+json when console access is denied", func() {
+		router := newRouterWith(&fakeConsoleAuthorizer{allow: false})
+		req := httptest.NewRequest(http.MethodGet, "/a2a/access", http.NoBody)
+		req.Header.Set("Authorization", "Bearer test-token")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		Expect(rec.Code).To(Equal(http.StatusForbidden))
+		Expect(rec.Header().Get("Content-Type")).To(Equal("application/problem+json"))
+	})
+
+	It("IT-AF-1919-003 [AU-12]: denial emits an EventAuthAccessDenied audit event with endpoint=console", func() {
+		router := newRouterWith(&fakeConsoleAuthorizer{allow: false})
+		req := httptest.NewRequest(http.MethodGet, "/a2a/access", http.NoBody)
+		req.Header.Set("Authorization", "Bearer test-token")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		Eventually(consoleAuditor.Events).Should(HaveLen(1))
+		ev := consoleAuditor.Events()[0]
+		Expect(ev.Type).To(Equal(audit.EventAuthAccessDenied))
+		Expect(ev.UserID).To(Equal(consoleTestUser.Username))
+		Expect(ev.Detail["endpoint"]).To(Equal("console"))
+	})
+
+	It("IT-AF-1919-004 [IA-2]: GET /a2a/access returns 401 without a bearer token (route sits behind AuthMiddleware)", func() {
+		router := newRouterWith(&fakeConsoleAuthorizer{allow: true})
+		req := httptest.NewRequest(http.MethodGet, "/a2a/access", http.NoBody)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		Expect(rec.Code).To(Equal(http.StatusUnauthorized))
+	})
+
+	It("IT-AF-1919-005 [AC-3]: bypass-closure -- real POST /mcp tool call is denied when console access is denied but tool access is allowed, without ever calling GET /a2a/access", func() {
+		fakeK8s := newFakeDynamicClient()
+		bridgeAuditor := &fakeAuditor{}
+		mcpCfg := handler.MCPConfig{
+			ServerName:    "kubernaut-apifrontend",
+			ServerVersion: "v0.1.0-test",
+			Enabled:       true,
+			Bridge: &handler.MCPBridgeConfig{
+				K8sClient:          fakeK8s,
+				TypedClient:        newBridgeTypedClient(),
+				Namespace:          "default",
+				Authorizer:         &dualAuthorizer{toolAllowed: true, consoleAllowed: false},
+				Auditor:            bridgeAuditor,
+				Metrics:            newBridgeMetrics(),
+				ToolTimeout:        2 * time.Second,
+				MaxConcurrentTools: 5,
+			},
+		}
+		mcpHandler, err := handler.NewMCPHandler(mcpCfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		router, err := handler.NewRouter(handler.RouterConfig{
+			MetricsRegistry:  metricsReg,
+			A2AHandler:       http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
+			MCPHandler:       mcpHandler,
+			AgentCardHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
+			AuthMiddleware:   fakeIdentityAuthMiddleware,
+			ReadyChecker:     func() bool { return true },
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// No request to GET /a2a/access is ever made -- proves a client that
+		// never calls the advisory endpoint cannot bypass the console gate
+		// by going straight to POST /mcp through the real production router.
+		sid := mcpInitializeThroughRouter(router)
+		status, respBody := mcpCallToolThroughRouter(router, sid, kubernautListRemediations, map[string]any{})
+		Expect(status).To(Equal(http.StatusOK), "MCP transport itself succeeds; denial is inside the tool result")
+		Expect(isErrorResult(respBody)).To(BeTrue(),
+			"AC-3: a client that never calls GET /a2a/access must still be denied via the real router + checkRBAC")
+		Expect(extractTextContent(respBody)).To(ContainSubstring("console"))
+	})
+})
+
+// mcpInitializeThroughRouter and mcpCallToolThroughRouter mirror
+// mcpInitialize/mcpCallTool (mcp_bridge_test.go) but drive identity via the
+// fakeIdentityAuthMiddleware bearer-token contract (Authorization header)
+// instead of injecting it directly into the request context, since the
+// handler under test here is the full production router, not the bare MCP
+// handler.
+func mcpInitializeThroughRouter(h http.Handler) string {
+	initReq := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-03-26",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test-client", "version": "1.0"},
+		},
+	}
+	rec := mcpPostThroughRouter(h, "", initReq)
+	Expect(rec.Code).To(Equal(http.StatusOK))
+	sessionID := rec.Header().Get("Mcp-Session-Id")
+	Expect(sessionID).NotTo(BeEmpty())
+
+	notif := map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "notifications/initialized",
+	}
+	mcpPostThroughRouter(h, sessionID, notif)
+	return sessionID
+}
+
+func mcpCallToolThroughRouter(h http.Handler, sessionID, toolName string, args map[string]any) (status int, body string) {
+	callReq := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      toolName,
+			"arguments": args,
+		},
+	}
+	rec := mcpPostThroughRouter(h, sessionID, callReq)
+	return rec.Code, rec.Body.String()
+}
+
+func mcpPostThroughRouter(h http.Handler, sessionID string, body any) *httptest.ResponseRecorder {
+	data, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Authorization", "Bearer test-token")
+	if sessionID != "" {
+		req.Header.Set("Mcp-Session-Id", sessionID)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}

--- a/pkg/apifrontend/handler/mcp_bridge.go
+++ b/pkg/apifrontend/handler/mcp_bridge.go
@@ -585,6 +585,22 @@ func checkRBAC(ctx context.Context, cfg *MCPBridgeConfig, toolName string) error
 		return fmt.Errorf("permission denied: no authorizer configured")
 	}
 
+	// #1919 (AC-3, AC-6): console access is a separate, coarser-grained gate
+	// than per-tool authorization, enforced here (not just at the advisory
+	// GET /a2a/access endpoint) so a client that never calls that endpoint
+	// cannot bypass it. Optional-interface type-assertion: authorizers that
+	// don't implement ConsoleAuthorizer (all pre-existing test doubles) skip
+	// this check and fall through to the per-tool check unchanged.
+	if ca, ok := cfg.Authorizer.(auth.ConsoleAuthorizer); ok {
+		consoleAllowed, cErr := ca.CheckConsoleAccess(ctx, user.Username, user.Groups)
+		if cErr != nil {
+			return fmt.Errorf("permission denied: console access check failed: %w", cErr)
+		}
+		if !consoleAllowed {
+			return fmt.Errorf("permission denied: no console access")
+		}
+	}
+
 	allowed, err := cfg.Authorizer.Check(ctx, user.Username, user.Groups, toolName)
 	if err != nil {
 		return fmt.Errorf("permission denied: authorization check failed for %s: %w", toolName, err)

--- a/pkg/apifrontend/handler/mcp_bridge_test.go
+++ b/pkg/apifrontend/handler/mcp_bridge_test.go
@@ -49,6 +49,22 @@ func (a *allowAllAuthorizer) Check(_ context.Context, _ string, _ []string, _ st
 	return true, nil
 }
 
+// dualAuthorizer implements both auth.ToolAuthorizer and auth.ConsoleAuthorizer
+// with independently controllable outcomes, for testing #1919's console-access
+// enforcement layered on top of the pre-existing per-tool check.
+type dualAuthorizer struct {
+	toolAllowed    bool
+	consoleAllowed bool
+}
+
+func (d *dualAuthorizer) Check(_ context.Context, _ string, _ []string, _ string) (bool, error) {
+	return d.toolAllowed, nil
+}
+
+func (d *dualAuthorizer) CheckConsoleAccess(_ context.Context, _ string, _ []string) (bool, error) {
+	return d.consoleAllowed, nil
+}
+
 // mapAuthorizer is a ToolAuthorizer mock that uses a role-to-tools map for decisions.
 type mapAuthorizer struct {
 	roles map[string][]string
@@ -930,6 +946,64 @@ var _ = Describe("MCP Bridge - Tier 2: Security", Label("tier2", "bridge"), func
 			Expect(isErrorResult(body)).To(BeTrue())
 			text := extractTextContent(body)
 			Expect(text).To(ContainSubstring("permission denied"))
+		})
+
+		It("UT-AF-1919-006 [AC-3, AC-6]: checkRBAC denies when console access is denied even though the tool would be allowed", func() {
+			cfg := handler.MCPConfig{
+				ServerName:    "kubernaut-apifrontend",
+				ServerVersion: "v0.1.0-test",
+				Enabled:       true,
+				Bridge: &handler.MCPBridgeConfig{
+					K8sClient:   fakeK8s,
+					TypedClient: newBridgeTypedClient(),
+					Namespace:   "default",
+
+					Authorizer:         &dualAuthorizer{toolAllowed: true, consoleAllowed: false},
+					Auditor:            auditor,
+					Metrics:            metrics,
+					ToolTimeout:        2 * time.Second,
+					MaxConcurrentTools: 5,
+				},
+			}
+			h, err := handler.NewMCPHandler(cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			user := &auth.UserIdentity{Username: "operator", Groups: []string{"sre"}, Issuer: "test"}
+			sid := mcpInitialize(h, user)
+
+			_, body := mcpCallTool(h, sid, kubernautListRemediations, map[string]any{}, user)
+			Expect(isErrorResult(body)).To(BeTrue(),
+				"AC-3: console access denial must block the tool call even though the per-tool check allows it")
+			text := extractTextContent(body)
+			Expect(text).To(ContainSubstring("console"))
+		})
+
+		It("UT-AF-1919-007 [AC-3]: checkRBAC is unchanged when the authorizer does not implement ConsoleAuthorizer", func() {
+			cfg := handler.MCPConfig{
+				ServerName:    "kubernaut-apifrontend",
+				ServerVersion: "v0.1.0-test",
+				Enabled:       true,
+				Bridge: &handler.MCPBridgeConfig{
+					K8sClient:   fakeK8s,
+					TypedClient: newBridgeTypedClient(),
+					Namespace:   "default",
+
+					Authorizer:         &allowAllAuthorizer{},
+					Auditor:            auditor,
+					Metrics:            metrics,
+					ToolTimeout:        2 * time.Second,
+					MaxConcurrentTools: 5,
+				},
+			}
+			h, err := handler.NewMCPHandler(cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			user := &auth.UserIdentity{Username: "operator", Groups: []string{"sre"}, Issuer: "test"}
+			sid := mcpInitialize(h, user)
+
+			_, body := mcpCallTool(h, sid, kubernautListRemediations, map[string]any{}, user)
+			Expect(isErrorResult(body)).To(BeFalse(),
+				"AC-3: an authorizer that doesn't implement ConsoleAuthorizer must fall through to the unchanged per-tool-only check")
 		})
 
 		It("UT-AF-B-029: wildcard * grants access to all tools", func() {

--- a/pkg/apifrontend/handler/router.go
+++ b/pkg/apifrontend/handler/router.go
@@ -28,7 +28,11 @@ type RouterConfig struct {
 	MaxPayloadBytes    int64
 	SSETracker         *streaming.ConnectionTracker
 	StatusHandler      http.Handler
-	Draining           *atomic.Bool
+	// ConsoleAccessHandler serves GET /a2a/access (#1919), an advisory
+	// pre-flight check for the console/chat client. Registered only when
+	// non-nil, same authenticated middleware tier as StatusHandler.
+	ConsoleAccessHandler http.Handler
+	Draining             *atomic.Bool
 }
 
 func (c *RouterConfig) validate() error {
@@ -117,6 +121,18 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) { //nolint:gocritic // hu
 			statusChain = cfg.PreAuthMiddleware(statusChain)
 		}
 		mux.Handle("POST /a2a/status", statusChain)
+	}
+
+	if cfg.ConsoleAccessHandler != nil {
+		innerConsoleAccess := writeDeadlineMiddleware(cfg.ConsoleAccessHandler)
+		if cfg.PostAuthMiddleware != nil {
+			innerConsoleAccess = cfg.PostAuthMiddleware(innerConsoleAccess)
+		}
+		consoleAccessChain := cfg.AuthMiddleware(innerConsoleAccess)
+		if cfg.PreAuthMiddleware != nil {
+			consoleAccessChain = cfg.PreAuthMiddleware(consoleAccessChain)
+		}
+		mux.Handle("GET /a2a/access", consoleAccessChain)
 	}
 
 	recoverLogger := cfg.Logger

--- a/pkg/fleet/mcpclient/resilience.go
+++ b/pkg/fleet/mcpclient/resilience.go
@@ -47,6 +47,13 @@ type ResilienceConfig struct {
 	MaxElapsedTime time.Duration
 	// TokenRefreshTimeout bounds OAuth2 token refresh HTTP calls.
 	TokenRefreshTimeout time.Duration
+	// ConnectTimeout bounds each individual MCP connect attempt made by
+	// connectWithBackoff and doReconnect, independent of whether the
+	// caller's context carries a deadline. Without this, a single hung
+	// handshake (issue #1934) blocks the entire backoff loop -- and thus
+	// service startup or reconnection -- forever, silently defeating
+	// MaxElapsedTime/MaxInterval.
+	ConnectTimeout time.Duration
 }
 
 // DefaultResilienceConfig returns production-ready defaults per Phase 6 plan.
@@ -56,6 +63,9 @@ func DefaultResilienceConfig() ResilienceConfig {
 		MaxInterval:         30 * time.Second,
 		MaxElapsedTime:      5 * time.Minute,
 		TokenRefreshTimeout: 10 * time.Second,
+		// Matches MaxInterval: a single attempt should never take longer
+		// than the max backoff interval we'd otherwise wait between attempts.
+		ConnectTimeout: 30 * time.Second,
 	}
 }
 
@@ -187,7 +197,9 @@ func (rc *ResilientClient) connectWithBackoff(ctx context.Context) error {
 		default:
 		}
 
-		c, connErr := New(ctx, rc.endpoint, rc.opts...)
+		attemptCtx, cancel := context.WithTimeout(ctx, rc.config.ConnectTimeout)
+		defer cancel()
+		c, connErr := New(attemptCtx, rc.endpoint, rc.opts...)
 		if connErr != nil {
 			lastErr = connErr
 			rc.logger.V(1).Info("Connection attempt failed, retrying",
@@ -244,7 +256,9 @@ func (rc *ResilientClient) doReconnect(ctx context.Context) error {
 		_ = old.Close()
 	}
 
-	c, err := New(ctx, rc.endpoint, rc.opts...)
+	attemptCtx, cancel := context.WithTimeout(ctx, rc.config.ConnectTimeout)
+	defer cancel()
+	c, err := New(attemptCtx, rc.endpoint, rc.opts...)
 	if err != nil {
 		rc.logger.Error(err, "Reconnection failed")
 		return err

--- a/pkg/fleet/mcpclient/resilience_test.go
+++ b/pkg/fleet/mcpclient/resilience_test.go
@@ -48,7 +48,7 @@ import (
 // The standalone SSE stream (GET) and session teardown (DELETE) are
 // tolerated with spec-permitted non-2xx responses, matching how a
 // stateless real-world MCP Gateway would answer them.
-func newFakeMCPServer(onInitialize func(w http.ResponseWriter, id json.RawMessage)) *httptest.Server {
+func newFakeMCPServer(onInitialize func(w http.ResponseWriter, r *http.Request, id json.RawMessage)) *httptest.Server {
 	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.Method {
 		case http.MethodGet:
@@ -73,7 +73,7 @@ func newFakeMCPServer(onInitialize func(w http.ResponseWriter, id json.RawMessag
 		case "notifications/initialized", "notifications/cancelled":
 			w.WriteHeader(http.StatusAccepted)
 		case "initialize":
-			onInitialize(w, req.ID)
+			onInitialize(w, r, req.ID)
 		default:
 			w.WriteHeader(http.StatusNotImplemented)
 		}
@@ -186,7 +186,7 @@ var _ = Describe("MCP Client Resilience (Phase 6)", func() {
 		It("should retry with exponential backoff until success", func() {
 			var attempts atomic.Int32
 
-			server := newFakeMCPServer(func(w http.ResponseWriter, id json.RawMessage) {
+			server := newFakeMCPServer(func(w http.ResponseWriter, _ *http.Request, id json.RawMessage) {
 				count := attempts.Add(1)
 				if count < 3 {
 					w.WriteHeader(http.StatusServiceUnavailable)
@@ -247,7 +247,7 @@ var _ = Describe("MCP Client Resilience (Phase 6)", func() {
 	Context("UT-FLEET-RES-007 [readiness gate Wave 0]: Concurrent Reconnect() calls deduplicate", func() {
 		It("collapses overlapping Reconnect() calls into a single MCP handshake instead of racing (prevents leaked connections when a periodic readiness prober and the lazy reconnect-on-error path call Reconnect concurrently)", func() {
 			var handshakeCount atomic.Int32
-			server := newFakeMCPServer(func(w http.ResponseWriter, id json.RawMessage) {
+			server := newFakeMCPServer(func(w http.ResponseWriter, _ *http.Request, id json.RawMessage) {
 				handshakeCount.Add(1)
 				// Widen the overlap window so all concurrent Reconnect() callers
 				// below arrive before any single handshake completes.
@@ -324,6 +324,86 @@ var _ = Describe("MCP Client Resilience (Phase 6)", func() {
 			Expect(os.WriteFile(secretFile, []byte("rotated"), 0o600)).To(Succeed())
 
 			time.Sleep(500 * time.Millisecond)
+		})
+	})
+
+	Context("UT-FLEET-RES-008 [CP-10]: connectWithBackoff bounds each attempt independently of caller deadline", func() {
+		It("returns instead of hanging forever when the server never responds to initialize (#1933-class hang)", func() {
+			// Never write an "initialize" response until the client gives up on
+			// its per-attempt deadline (post-fix) or a generous safety-net
+			// duration (pre-fix, proving the missing bound) -- whichever comes
+			// first, so the fake handler doesn't leak past the test.
+			server := newFakeMCPServer(func(_ http.ResponseWriter, r *http.Request, _ json.RawMessage) {
+				select {
+				case <-r.Context().Done():
+				case <-time.After(3 * time.Second):
+				}
+			})
+			defer server.Close()
+
+			cfg := mcpclient.DefaultResilienceConfig()
+			cfg.ConnectTimeout = 150 * time.Millisecond
+			cfg.InitialInterval = 50 * time.Millisecond
+			cfg.MaxInterval = 50 * time.Millisecond
+			cfg.MaxElapsedTime = 150 * time.Millisecond
+
+			done := make(chan error, 1)
+			go func() {
+				_, err := mcpclient.NewResilient(context.Background(), server.URL+"/mcp", cfg, logger)
+				done <- err
+			}()
+
+			select {
+			case err := <-done:
+				Expect(err).To(HaveOccurred(),
+					"NewResilient should give up after exhausting bounded attempts against a permanently hanging server")
+			case <-time.After(1500 * time.Millisecond):
+				Fail("NewResilient did not return within 1.5s: a single hung connect attempt is blocking the " +
+					"entire backoff loop (issue #1934) instead of being bounded by ConnectTimeout")
+			}
+		})
+	})
+
+	Context("UT-FLEET-RES-009 [CP-10]: doReconnect bounds its attempt independently of caller deadline", func() {
+		It("returns instead of hanging forever when the server hangs on reconnect (#1933-class hang)", func() {
+			var attempts atomic.Int32
+			server := newFakeMCPServer(func(w http.ResponseWriter, r *http.Request, id json.RawMessage) {
+				if attempts.Add(1) == 1 {
+					// Initial connect (inside NewResilient below) succeeds immediately.
+					writeMCPInitializeResult(w, id)
+					return
+				}
+				// Every subsequent handshake (the Reconnect() under test) hangs.
+				select {
+				case <-r.Context().Done():
+				case <-time.After(3 * time.Second):
+				}
+			})
+			defer server.Close()
+
+			cfg := mcpclient.DefaultResilienceConfig()
+			cfg.ConnectTimeout = 150 * time.Millisecond
+			cfg.InitialInterval = 50 * time.Millisecond
+			cfg.MaxInterval = 50 * time.Millisecond
+			cfg.MaxElapsedTime = 500 * time.Millisecond
+
+			rc, err := mcpclient.NewResilient(context.Background(), server.URL+"/mcp", cfg, logger)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rc.Ready()).To(BeTrue())
+
+			done := make(chan error, 1)
+			go func() {
+				done <- rc.Reconnect(context.Background())
+			}()
+
+			select {
+			case err := <-done:
+				Expect(err).To(HaveOccurred(),
+					"Reconnect should fail promptly when the server hangs on the handshake, instead of blocking forever")
+			case <-time.After(1 * time.Second):
+				Fail("Reconnect did not return within 1s: doReconnect's single connect attempt has no bound " +
+					"when the caller supplies no deadline (issue #1934)")
+			}
 		})
 	})
 })


### PR DESCRIPTION
## Summary

Two independent fixes bundled per triage request, both scoped to `pkg/fleet/mcpclient` and `pkg/apifrontend`:

**#1934 -- mcpclient connect timeout (FedRAMP CP-10)**
- `connectWithBackoff`/`doReconnect` could hang indefinitely on a slow/unresponsive MCP Gateway since `mcp.NewClient`'s handshake had no deadline, stalling resilience retries instead of backing off.
- Added `ResilienceConfig.ConnectTimeout`, wrapping each connection attempt in `context.WithTimeout`.

**#1919 -- console-access authorization gate (AC-3, AC-6, AU-12)**
- The issue proposed an advisory `GET /api/v1/console/access` pre-flight endpoint. During planning we identified that an advisory-only endpoint doesn't close the bypass: a client that never calls it (going straight to `POST /mcp` or the A2A tool-calling loop) would never be checked.
- Endpoint path changed to `GET /a2a/access` to match AF's existing flat-route convention (`/a2a/invoke`, `/mcp`) instead of introducing a new `/api/v1` prefix.
- **The real fix**: `kubernaut.ai/console` (verb=`use`) is now enforced server-side at every tool-invocation site -- `checkRBAC` (MCP path, `pkg/apifrontend/handler/mcp_bridge.go`) and `newRBACGuard` (A2A path, `pkg/apifrontend/agent/root.go`) -- not just at the advisory endpoint. A client that never calls `GET /a2a/access` is still denied.
- New `auth.ConsoleAuthorizer` interface + `SARChecker.CheckConsoleAccess`, using an optional-interface pattern (type-assertion) so the ~50 pre-existing `ToolAuthorizer`-only test doubles needed no changes.
- New `kubernaut-console-access` ClusterRole/ClusterRoleBindings in the Helm chart, bound per `apifrontend.config.rbac.consoleAccessGroups`.
- **Bonus fix**: found and fixed a pre-existing chart bug where the per-persona `kubernaut-tool-*` ClusterRoles' `rules:` block rendered nested one level too deep inside `metadata:` (silently dropped by the K8s API, granting zero rules in a real cluster) -- surfaced only by a raw structural YAML check, since the existing helm-unittest assertions are document-relative and still resolved "correctly" against the buggy document.

## Test plan

- [x] `docs/tests/1934/TEST_PLAN.md`, `docs/tests/1919/TEST_PLAN.md`
- [x] `go build ./...`
- [x] `go test ./pkg/apifrontend/... ./cmd/apifrontend/... ./pkg/fleet/mcpclient/... -race` -- all green
- [x] `golangci-lint run` on touched packages -- 0 issues
- [x] `helm unittest charts/kubernaut/` -- 459/459 passing (includes new `console_access_rbac_test.yaml` + fixed `fleet_registry_rbac_test.yaml`)
- [x] `helm lint` + full `helm template` render validated as well-formed YAML (165 documents)
- [x] Bypass-closure IT (`IT-AF-1919-005`): a real `POST /mcp` tool call through the full production router is denied when console access is denied but tool access is allowed, without the test ever calling `GET /a2a/access`

Closes #1934, closes #1919

Made with [Cursor](https://cursor.com)