### PR TITLE
fix(apifrontend): backport console-access gate to release/v1.5 (#1919, #1941)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Kubernaut will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Security
+
+- **Coarse-grained console-access authorization gate (#1919, #1941, AC-3/AC-6/AU-12)** — Adds a new `kubernaut.ai/console` "use" SubjectAccessReview grant, enforced server-side at both existing AF tool-invocation paths (`/mcp` and `/a2a/invoke`), in addition to the pre-existing per-tool `kubernaut.ai/tools` check. Also adds an advisory `GET /a2a/access` pre-flight endpoint for UI clients. **Operator action may be required**: the chart's new `apifrontend.config.rbac.consoleAccessGroups` value defaults to all six built-in personas (`sre`, `ai-orchestrator`, `cicd`, `observability`, `l3-audit`, `remediation-approver`), so deployments using only those default persona group names need no changes. If you configured a custom group under `apifrontend.config.rbac.personas` (or renamed/replaced the defaults), you must add that same group name to `apifrontend.config.rbac.consoleAccessGroups`, or users in that group will have **every** AF tool call denied after upgrading, even though their existing per-tool grants are unchanged. `helm install`/`helm upgrade` now prints an `NOTES.txt` warning listing any `personas` group missing from `consoleAccessGroups` to catch this case at deploy time.
+
 ## [1.5.5] - 2026-07-28
 
 ### Fixed

--- a/charts/kubernaut/templates/NOTES.txt
+++ b/charts/kubernaut/templates/NOTES.txt
@@ -83,6 +83,32 @@ configured Prometheus in the agent's config.yaml (tools.prometheus.url).
 No additional SDK config changes are needed for Prometheus access.
 
 {{- end }}
+{{- if .Values.apifrontend.enabled }}
+{{- $personas := .Values.apifrontend.config.rbac.personas | default dict }}
+{{- $consoleGroups := .Values.apifrontend.config.rbac.consoleAccessGroups | default list }}
+{{- $missingConsoleAccess := list }}
+{{- range $persona, $tools := $personas }}
+{{- if not (has $persona $consoleGroups) }}
+{{- $missingConsoleAccess = append $missingConsoleAccess $persona }}
+{{- end }}
+{{- end }}
+{{- if $missingConsoleAccess }}
+=== RBAC WARNING: console-access gate (#1919) ===
+
+apifrontend.config.rbac.personas group(s) below have per-tool RBAC grants but
+are NOT listed in apifrontend.config.rbac.consoleAccessGroups:
+
+{{- range $missingConsoleAccess }}
+  - {{ . }}
+{{- end }}
+
+Every AF tool call (/mcp and /a2a/invoke) additionally requires the
+coarse-grained kubernaut.ai/console "use" grant. Users in the group(s) above
+will have ALL tool calls denied until you add them to consoleAccessGroups,
+even though their per-tool grants above remain intact and unchanged.
+
+{{- end }}
+{{- end }}
 === Monitoring ===
 
 Kubernaut is designed to work with kube-prometheus-stack.

--- a/charts/kubernaut/templates/apifrontend/apifrontend.yaml
+++ b/charts/kubernaut/templates/apifrontend/apifrontend.yaml
@@ -174,7 +174,6 @@ kind: ClusterRole
 metadata:
   name: kubernaut-tool-{{ $persona }}
   labels:
-    app.kubernetes.io/part-of: kubernaut
     kubernaut.ai/component: tool-authorization
     {{- include "kubernaut.labels" $ | nindent 4 }}
 rules:
@@ -185,6 +184,42 @@ rules:
       {{- range $tools }}
       - {{ . }}
       {{- end }}
+{{- end }}
+---
+# #1919 (AC-3/AC-6): coarse-grained console-access gate, deliberately a
+# separate, independently-auditable grant from the per-tool ClusterRoles
+# above (not derived from them) -- operators grant "console access" and
+# "tool access" as two explicit steps. Enforced server-side at every
+# tool-invocation site (checkRBAC/newRBACGuard), not just the advisory
+# GET /a2a/access endpoint.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubernaut-console-access
+  labels:
+    kubernaut.ai/component: console-authorization
+    {{- include "kubernaut.labels" . | nindent 4 }}
+rules:
+  - apiGroups: ["kubernaut.ai"]
+    resources: ["console"]
+    verbs: ["use"]
+{{- range .Values.apifrontend.config.rbac.consoleAccessGroups }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: kubernaut-console-access-{{ . }}
+  labels:
+    kubernaut.ai/component: console-authorization
+    {{- include "kubernaut.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: kubernaut-console-access
+subjects:
+  - kind: Group
+    name: {{ . }}
+    apiGroup: rbac.authorization.k8s.io
 {{- end }}
 ---
 apiVersion: apps/v1

--- a/charts/kubernaut/tests/console_access_rbac_test.yaml
+++ b/charts/kubernaut/tests/console_access_rbac_test.yaml
@@ -1,0 +1,122 @@
+suite: console access RBAC gate (#1919)
+templates:
+  - templates/apifrontend/apifrontend.yaml
+set:
+  postgresql:
+    auth:
+      existingSecret: dummy
+  valkey:
+    existingSecret: dummy
+  signalprocessing:
+    policies:
+      existingConfigMap: dummy
+  aianalysis:
+    policies:
+      existingConfigMap: dummy
+  kubernautAgent:
+    llm:
+      provider: openai
+      model: gpt-4o
+      credentialsSecretName: dummy
+tests:
+  # ---------------------------------------------------------------------
+  # IT-HELM-1919-001: the coarse-grained ClusterRole exists and grants
+  # exactly kubernaut.ai/console use, distinct from the per-tool
+  # kubernaut-tool-* ClusterRoles (#1919, AC-3/AC-6).
+  # ---------------------------------------------------------------------
+  - it: "IT-HELM-1919-001: kubernaut-console-access ClusterRole grants kubernaut.ai/console use"
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-console-access
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - contains:
+          path: rules[0].resources
+          content: console
+      - contains:
+          path: rules[0].verbs
+          content: use
+      - contains:
+          path: rules[0].apiGroups
+          content: kubernaut.ai
+
+  # ---------------------------------------------------------------------
+  # IT-HELM-1919-002: default consoleAccessGroups produces a
+  # ClusterRoleBinding per group, bound to the console-access ClusterRole.
+  # ---------------------------------------------------------------------
+  - it: "IT-HELM-1919-002: sre is bound to kubernaut-console-access by default"
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-console-access-sre
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: roleRef.name
+          value: kubernaut-console-access
+      - equal:
+          path: subjects[0].kind
+          value: Group
+      - equal:
+          path: subjects[0].name
+          value: sre
+
+  - it: "IT-HELM-1919-002b: a group not listed in consoleAccessGroups has no ClusterRoleBinding rendered"
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-console-access-guest
+      skipEmptyTemplates: true
+    asserts:
+      - hasDocuments:
+          count: 0
+          filterAware: true
+
+  - it: "IT-HELM-1919-002c: cicd and l3-audit (automation/audit personas) are also bound by default, per #1919's non-goal of weakening existing per-tool grants"
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-console-access-cicd
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: roleRef.name
+          value: kubernaut-console-access
+
+  # ---------------------------------------------------------------------
+  # IT-HELM-1919-003: an empty consoleAccessGroups list is empty-safe --
+  # the ClusterRole still renders, but zero ClusterRoleBindings do.
+  # ---------------------------------------------------------------------
+  - it: "IT-HELM-1919-003: empty consoleAccessGroups renders the ClusterRole but no bindings"
+    template: templates/apifrontend/apifrontend.yaml
+    set:
+      apifrontend:
+        config:
+          rbac:
+            consoleAccessGroups: []
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-console-access
+    asserts:
+      - isKind:
+          of: ClusterRole
+
+  - it: "IT-HELM-1919-003b: empty consoleAccessGroups renders no kubernaut-console-access-sre binding"
+    template: templates/apifrontend/apifrontend.yaml
+    set:
+      apifrontend:
+        config:
+          rbac:
+            consoleAccessGroups: []
+    documentSelector:
+      path: metadata.name
+      value: kubernaut-console-access-sre
+      skipEmptyTemplates: true
+    asserts:
+      - hasDocuments:
+          count: 0
+          filterAware: true

--- a/charts/kubernaut/values.schema.json
+++ b/charts/kubernaut/values.schema.json
@@ -1085,6 +1085,11 @@
                     "type": "array",
                     "items": { "type": "string" }
                   }
+                },
+                "consoleAccessGroups": {
+                  "type": "array",
+                  "description": "OIDC groups granted the coarse-grained kubernaut-console-access ClusterRole (kubernaut.ai/console, verb=use), a separate grant from the per-tool personas above (#1919)",
+                  "items": { "type": "string" }
                 }
               }
             }

--- a/charts/kubernaut/values.yaml
+++ b/charts/kubernaut/values.yaml
@@ -748,6 +748,18 @@ apifrontend:
           - kubernaut_get_remediation
           - kubernaut_watch
           - kubernaut_await_session
+      # #1919 (AC-3/AC-6): groups granted the coarse-grained console-access
+      # gate (kubernaut.ai/console, verb=use) -- a separate, independently
+      # auditable grant from the per-tool personas above. All 6 personas are
+      # included by default so every persona that has tool access also has
+      # console access out of the box.
+      consoleAccessGroups:
+        - sre
+        - ai-orchestrator
+        - cicd
+        - observability
+        - l3-audit
+        - remediation-approver
   resources:
     requests:
       memory: 64Mi

--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -284,20 +284,28 @@ func run() int {
 		statusHandler = handler.NewStatusHandler(deps.TypedClient(), cfg.Session.Namespace, logger)
 	}
 
+	// #1919: GET /a2a/access is an advisory pre-flight check for the
+	// console/chat client, backed by the same *auth.SARChecker used for
+	// per-tool authorization elsewhere in this file. sarChecker satisfies
+	// auth.ConsoleAuthorizer at compile time (see sar.go's
+	// `var _ auth.ConsoleAuthorizer = (*SARChecker)(nil)`).
+	consoleAccessHandler := handler.NewConsoleAccessHandler(sarChecker, auditor, logger)
+
 	draining := &atomic.Bool{}
 	routerCfg := handler.RouterConfig{
-		MetricsRegistry:    metricsReg,
-		Logger:             logger,
-		A2AHandler:         a2aHandler,
-		MCPHandler:         mcpHandler,
-		AgentCardHandler:   agentCardHandler,
-		AuthMiddleware:     authMiddleware,
-		PreAuthMiddleware:  preAuthMW,
-		PostAuthMiddleware: postAuthMW,
-		ReadyChecker:       handler.AllReady(func() bool { return !draining.Load() }, depsReady, authReady, sessInfra.Healthy.Load),
-		SSETracker:         buildSSETracker(cfg, metricsReg),
-		StatusHandler:      statusHandler,
-		Draining:           draining,
+		MetricsRegistry:      metricsReg,
+		Logger:               logger,
+		A2AHandler:           a2aHandler,
+		MCPHandler:           mcpHandler,
+		AgentCardHandler:     agentCardHandler,
+		AuthMiddleware:       authMiddleware,
+		PreAuthMiddleware:    preAuthMW,
+		PostAuthMiddleware:   postAuthMW,
+		ReadyChecker:         handler.AllReady(func() bool { return !draining.Load() }, depsReady, authReady, sessInfra.Healthy.Load),
+		SSETracker:           buildSSETracker(cfg, metricsReg),
+		StatusHandler:        statusHandler,
+		ConsoleAccessHandler: consoleAccessHandler,
+		Draining:             draining,
 	}
 	router, err := handler.NewRouter(routerCfg)
 	if err != nil {

--- a/deploy/apifrontend/overlays/e2e/e2e-user-rbac.yaml
+++ b/deploy/apifrontend/overlays/e2e/e2e-user-rbac.yaml
@@ -129,3 +129,107 @@ roleRef:
   kind: ClusterRole
   name: e2e-user-k8s-tools
   apiGroup: rbac.authorization.k8s.io
+---
+# #1919: coarse-grained console-access gate (kubernaut.ai/console, verb=use),
+# now enforced server-side at every tool-invocation site
+# (checkRBAC/newRBACGuard), not just the advisory GET /a2a/access endpoint --
+# E2E personas need this grant or every existing MCP/A2A tool-call E2E test
+# would fail the new check. Deliberately a SEPARATE ClusterRole from
+# e2e-user-k8s-tools (not one more rule added to it): SARChecker.checkSAR
+# (pkg/apifrontend/auth/sar.go) never sets ResourceAttributes.Namespace, so
+# this is always a cluster-scoped check -- a namespace-scoped RoleBinding
+# (like observability's e2e-observability-k8s-tools above, intentionally
+# namespace-scoped to prove K8s RBAC namespace restriction for *those*
+# unrelated pods/events/deployments/etc. rules) can never satisfy it.
+# Mixing the two into one ClusterRole silently broke observability's console
+# access the first time this was tried (RCA'd via CI must-gather on PR
+# #1940) -- every persona below gets an unconditional ClusterRoleBinding
+# instead, matching the "every persona with a tool grant needs console
+# access too" default applied to charts/kubernaut/values.yaml's
+# consoleAccessGroups.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: e2e-console-access
+rules:
+  - apiGroups: ["kubernaut.ai"]
+    resources: ["console"]
+    verbs: ["use"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: e2e-sre-console-access
+subjects:
+  - kind: Group
+    name: sre
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: e2e-console-access
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: e2e-ai-orchestrator-console-access
+subjects:
+  - kind: Group
+    name: ai-orchestrator
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: e2e-console-access
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: e2e-cicd-console-access
+subjects:
+  - kind: Group
+    name: cicd
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: e2e-console-access
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: e2e-observability-console-access
+subjects:
+  - kind: Group
+    name: observability
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: e2e-console-access
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: e2e-l3-audit-console-access
+subjects:
+  - kind: Group
+    name: l3-audit
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: e2e-console-access
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: e2e-remediation-approver-console-access
+subjects:
+  - kind: Group
+    name: remediation-approver
+    apiGroup: rbac.authorization.k8s.io
+roleRef:
+  kind: ClusterRole
+  name: e2e-console-access
+  apiGroup: rbac.authorization.k8s.io

--- a/docs/tests/1919/TEST_PLAN.md
+++ b/docs/tests/1919/TEST_PLAN.md
@@ -56,6 +56,22 @@ a cherry-pick. Two notable adaptations from the original `main` implementation:
    (and the `mcpclient` resilience code #1934 fixed) does not exist on
    `release/v1.5` — it was introduced on `main` after `release/v1.5` branched.
    See #1941 for the confirmation.
+4. **Operator-facing upgrade risk not addressed by the original `main`
+   implementation, added here**: because `consoleAccessGroups` is a separate,
+   independently-maintained values key rather than being derived from
+   `apifrontend.config.rbac.personas`'s keys, an operator who configured a
+   custom persona group (or replaced the default six) would, after
+   upgrading, silently have every AF tool call denied for that group --
+   even though its per-tool grants are unchanged -- with no clear signal
+   beyond a `forbidden: no console access` error. `main`'s PR #1940 did not
+   add any warning for this. Added a `charts/kubernaut/templates/NOTES.txt`
+   hint (printed on `helm install`/`helm upgrade`) that diffs `personas`
+   keys against `consoleAccessGroups` and lists any gap, plus a
+   `CHANGELOG.md` entry under `[Unreleased]` documenting the required
+   operator action. Verified manually via `helm install --dry-run` (helm-unittest
+   does not render `NOTES.txt`) with both default values (no warning) and a
+   `--set apifrontend.config.rbac.personas.custom-team[0]=...` override (warning
+   correctly lists the ungranted group).
 
 Everything else below mirrors the original `main` test plan's intent,
 re-verified against `release/v1.5`'s actual code.

--- a/docs/tests/1919/TEST_PLAN.md
+++ b/docs/tests/1919/TEST_PLAN.md
@@ -1,0 +1,289 @@
+# Test Plan: Coarse-Grained Console Access Authorization Gate (AF Backend) — `release/v1.5` Backport
+
+> **Template Version**: 2.0 — Hybrid IEEE 829-2008 + Kubernaut
+
+**Test Plan Identifier**: TP-1919
+**Feature**: A new `kubernaut.ai/console` `use` SubjectAccessReview grant, checked
+(a) via a new lightweight `GET /a2a/access` pre-flight endpoint for UX purposes,
+and (b) — the actual security fix — enforced server-side inside both existing
+tool-invocation paths (`checkRBAC` for `/mcp`, `newRBACGuard` for `/a2a/invoke`)
+so console access is a real security boundary, not merely a UI-advisory check
+a non-conforming client could bypass.
+**Version**: 1.0
+**Created**: 2026-08-05
+**Author**: AI Agent
+**Status**: Complete
+**Branch**: `fix/1941-console-access-gate-v1.5`
+
+---
+
+## 0. Backport Provenance
+
+This is a `release/v1.5` backport of the fix originally implemented against
+`main` for issue [#1919](https://github.com/jordigilh/kubernaut/issues/1919)
+(merged via [PR #1940](https://github.com/jordigilh/kubernaut/pull/1940)),
+tracked by backport issue
+[#1941](https://github.com/jordigilh/kubernaut/issues/1941). `main` and
+`release/v1.5` had diverged significantly in the affected files (`mcp_bridge.go`,
+`root.go`, `apifrontend.yaml`, `main.go` all carry unrelated `main`-only
+refactors from later issues — #1366, #1496, #1677, #1718, #1737, #1790,
+#1801, #1827, #1923, DD-PLATFORM-006/008), so this was a manual, surgical
+re-application of the #1919 diff onto `release/v1.5`'s actual code shape, not
+a cherry-pick. Two notable adaptations from the original `main` implementation:
+
+1. **No `buildRouterConfig`/`routerBuildParams` extraction on `release/v1.5`**:
+   `main`'s `TestBuildRouterConfig_ConsoleAccessHandler_*` wiring unit tests
+   target a function-extraction refactor that predates #1919 on `main` but
+   does not exist on `release/v1.5` (router construction is inline in `run()`
+   here). Porting those two tests verbatim was not possible without
+   introducing an out-of-scope refactor. Wiring is instead proven by (a) grep
+   evidence that `cmd/apifrontend/main.go` constructs
+   `handler.NewConsoleAccessHandler(sarChecker, ...)` and passes it to
+   `RouterConfig.ConsoleAccessHandler`, and (b) the IT-AF-1919-001..005 tests
+   in `console_access_test.go`, which exercise the real
+   `handler.NewRouter` dispatch path end-to-end.
+2. **Pre-existing chart label duplication bug fixed as a prerequisite**: the
+   `kubernaut-tool-{{ $persona }}` ClusterRole template on `release/v1.5` set
+   `app.kubernetes.io/part-of: kubernaut` both explicitly and via the
+   `kubernaut.labels` helper (which already emits it), producing a duplicate
+   YAML mapping key. `helm template`'s plain-text renderer never caught this,
+   but the `helm-unittest` plugin's strict YAML decode does, and it blocked
+   every test targeting `templates/apifrontend/apifrontend.yaml` — including
+   the new `console_access_rbac_test.yaml` added here. Fixed by removing the
+   redundant explicit label (no behavior change; `kubernaut.labels` already
+   provides it).
+3. **#1934 (mcpclient connect timeout) is explicitly out of scope**: `pkg/fleet`
+   (and the `mcpclient` resilience code #1934 fixed) does not exist on
+   `release/v1.5` — it was introduced on `main` after `release/v1.5` branched.
+   See #1941 for the confirmation.
+
+Everything else below mirrors the original `main` test plan's intent,
+re-verified against `release/v1.5`'s actual code.
+
+---
+
+## 1. Introduction
+
+### 1.1 Purpose
+
+Issue #1919 proposes gating console UI rendering on a dedicated coarse-grained
+authorization role, separate from per-tool RBAC, so operators can grant
+"console access" and "tool access" as two explicit, separately-auditable
+steps. The issue's own 3-part proposal spans a new AF endpoint, RBAC
+convention/manifests, and `kubernaut-console` frontend gating
+(`jordigilh/kubernaut-console#48`, a different repo — explicitly out of scope
+here).
+
+During the original `main` implementation's planning, a critical architectural
+gap was identified and resolved before implementation began: an advisory-only
+`GET /a2a/access` endpoint does not close the loop — a client that never calls
+it (curl, a script, a non-conforming frontend build) could invoke `/mcp` or
+`/a2a/invoke` directly and only ever be checked against `kubernaut.ai/tools`,
+never `kubernaut.ai/console`. This defeats the issue's own "two explicit,
+separately-auditable steps" premise for any non-browser client. The design was
+therefore extended to also enforce `kubernaut.ai/console` `use` at both
+pre-existing tool-invocation enforcement points, `checkRBAC` and
+`newRBACGuard`, making the new endpoint a UX convenience layered on top of a
+real, unbypassable server-side gate. This backport carries that same design
+onto `release/v1.5`.
+
+### 1.2 Objectives
+
+1. **New `SARChecker` capability**: `CheckConsoleAccess(ctx, user, groups)`
+   checks `kubernaut.ai/console` `use` (a coarse-grained, unnamed resource,
+   distinct from the existing per-tool `kubernaut.ai/tools` check), sharing
+   the existing SAR-call + cache infrastructure via an extracted `checkSAR`
+   helper.
+2. **New endpoint**: `GET /a2a/access` returns `200` when the caller's
+   identity has console access, `403` (RFC 7807) otherwise. Sits behind the
+   same `AuthMiddleware`/`PostAuthMiddleware` tier as the existing
+   authenticated routes — no new unauthenticated surface.
+3. **Real server-side enforcement (the actual fix)**: `checkRBAC` (`/mcp`)
+   and `newRBACGuard` (`/a2a/invoke`'s tool-calling loop) both additionally
+   deny a tool call when the configured authorizer implements
+   `ConsoleAuthorizer` and denies console access — even when the specific
+   tool being called would otherwise be allowed. Proven by real HTTP/runner
+   round trips that **never call `/a2a/access`**, demonstrating the bypass is
+   closed, not merely that the new endpoint itself works.
+4. **Zero-touch backward compatibility**: the enforcement is implemented as
+   an optional-interface type-assertion on the existing `Authorizer`
+   field/param (no new required field, no signature change), so pre-existing
+   test doubles (`allowAllAuthorizer`, `mapAuthorizer`, `mockAuthorizerImpl`,
+   etc.) that don't implement `ConsoleAuthorizer` continue to exercise the
+   unchanged, per-tool-only code path.
+5. **Production correctness guaranteed at compile time**: `var _
+   auth.ConsoleAuthorizer = (*SARChecker)(nil)` ensures the single
+   production `*SARChecker` instance — wired to both `MCPBridgeConfig.Authorizer`
+   and `agent.AgentConfig.Authorizer` from the same `cmd/apifrontend/main.go`
+   construction site — always satisfies `ConsoleAuthorizer`, so the "skip"
+   branch can only ever be taken by test doubles.
+6. **RBAC manifests are CI-gated, not just manually inspected**: a new
+   `kubernaut-console-access` `ClusterRole`/`ClusterRoleBinding` pair,
+   validated by new cases in the existing CI-gated `helm-unittest` suite
+   (`charts/kubernaut/tests/`, per `DD-PLATFORM-005`).
+
+### 1.3 Success Metrics
+
+| Metric | Target | Measurement | Result |
+|--------|--------|-------------|--------|
+| Unit test pass rate | 100% | `go test ./pkg/apifrontend/... -run "UT-AF-1919" -v -count=1` | 100% |
+| Integration test pass rate | 100% | `go test ./pkg/apifrontend/... -run "IT-AF-1919" -v -count=1` | 100% |
+| Helm-unittest pass rate | 100% | `helm unittest charts/kubernaut` | 100% |
+| Regression pass rate (pre-existing) | 100% | Full `pkg/apifrontend/...` suite unchanged | 100% |
+| Build/Lint | Clean | `go build ./...`, `golangci-lint run` | Clean |
+
+---
+
+## 2. References
+
+### 2.1 Authority
+
+- Issue #1919: original feature request (backend scope only).
+- Issue #1941: this `release/v1.5` backport's tracking issue.
+- PR #1940: original `main` implementation.
+- `jordigilh/kubernaut-console#48`: companion frontend issue (separate repo,
+  out of scope).
+- ADR-021 / ADR-022: existing SAR-based `kubernaut.ai/tools` authorization
+  model this feature extends by one coarse-grained resource.
+- `docs/architecture/decisions/DD-PLATFORM-005-helm-unittest-ci-integration.md`:
+  authority for using `charts/kubernaut/tests/*.yaml` (not manual `helm
+  template`) for RBAC manifest validation.
+
+### 2.2 FedRAMP Controls
+
+| Control | Intent | Application | Test ID |
+|---------|--------|-------------|---------|
+| AC-3 (Access Enforcement) | The system enforces approved authorizations for logical access | `kubernaut.ai/console` `use` gates both the new endpoint and, critically, both existing tool-invocation paths | UT-AF-1919-001..002, 006, 008; IT-AF-1919-001, 002, 005, 006 |
+| AC-6 (Least Privilege) | Users/processes are granted only the access necessary | Console access is a separate, explicit grant from per-tool access — not derived/implied from any tool grant | UT-AF-1919-006..009; RBAC manifest design (§3.1) |
+| AU-12 (Audit Generation) | The system generates audit records for security-relevant events | Console-access denial at the endpoint and at both enforcement sites emits `audit.EventAuthAccessDenied` | IT-AF-1919-003; UT-AF-1919-008 |
+
+---
+
+## 3. Scope
+
+### 3.1 In Scope
+
+| Area | Description |
+|------|--------------|
+| `pkg/apifrontend/auth/sar.go` | `checkSAR` extraction, `CheckConsoleAccess`, `ConsoleAuthorizer` interface, compile-time assertion |
+| `pkg/apifrontend/handler/console_access.go` (new) | `NewConsoleAccessHandler` |
+| `pkg/apifrontend/handler/router.go`, `cmd/apifrontend/main.go` | `GET /a2a/access` route + wiring |
+| `pkg/apifrontend/handler/mcp_bridge.go` (`checkRBAC`) | Console-access type-assertion enforcement for `/mcp` |
+| `pkg/apifrontend/agent/root.go` (`newRBACGuard`) | Console-access type-assertion enforcement for `/a2a/invoke` |
+| `charts/kubernaut/templates/apifrontend/apifrontend.yaml`, `charts/kubernaut/values.yaml`, `charts/kubernaut/values.schema.json` | New `kubernaut-console-access` ClusterRole/Binding + `consoleAccessGroups` values key (all 6 personas by default) |
+| `deploy/apifrontend/overlays/e2e/e2e-user-rbac.yaml` | Dedicated cluster-scoped `e2e-console-access` ClusterRole/Bindings so E2E users keep passing the new gate |
+| `charts/kubernaut/tests/console_access_rbac_test.yaml` (new) | Helm-unittest coverage for the new manifests |
+
+### 3.2 Out of Scope
+
+- `kubernaut-console` frontend gating (`jordigilh/kubernaut-console#48`) — separate repo.
+- Issue #1934 (mcpclient connect timeout) — `pkg/fleet` does not exist on
+  `release/v1.5`; confirmed not applicable in issue #1941.
+- Any `main`-only refactor unrelated to #1919 (function extractions for
+  #1366/#1496/#1677/#1718/#1737/#1790/#1801/#1827/#1923,
+  DD-PLATFORM-006/008) — deliberately not carried over; this backport is
+  scoped to the #1919 security fix only.
+- Any change to `ADR-022`'s "AF SA does all K8s I/O" model — this is just
+  another `subjectaccessreviews create` call by the existing AF ServiceAccount.
+- Any change to the existing `ToolAuthorizer`/`Check` contract or its
+  existing call sites — the new capability is strictly additive.
+
+---
+
+## 4. Test Scenarios
+
+### 4.1 Unit — `SARChecker.CheckConsoleAccess` (`pkg/apifrontend/auth/sar_test.go`)
+
+| ID | FedRAMP | Business Behavior Verified | Acceptance Criteria | Status |
+|----|---------|------------------------------|----------------------|--------|
+| UT-AF-1919-001 | AC-3 | `CheckConsoleAccess` returns `true` when the SAR reactor allows `kubernaut.ai/console` `use` | `(true, nil)` returned | Passed |
+| UT-AF-1919-002 | AC-3 | `CheckConsoleAccess` returns `false` when SAR denies | `(false, nil)` returned | Passed |
+| UT-AF-1919-003 | AC-3 | Fail-closed on empty user | `(false, err)` returned, no SAR call made | Passed |
+| UT-AF-1919-004 | AC-3 | Fail-closed on SAR API error | `(false, err)` returned | Passed |
+| UT-AF-1919-005 | AC-3 | Constructed `SubjectAccessReview` has the correct shape | `Verb=use, Group=kubernaut.ai, Resource=console, Name=""` | Passed |
+
+### 4.2 Unit — `checkRBAC` enforcement (`pkg/apifrontend/handler/mcp_bridge_test.go`)
+
+New `dualAuthorizer{toolAllowed, consoleAllowed bool}` double implementing both `ToolAuthorizer` and `ConsoleAuthorizer`.
+
+| ID | FedRAMP | Business Behavior Verified | Acceptance Criteria | Status |
+|----|---------|------------------------------|----------------------|--------|
+| UT-AF-1919-006 | AC-3, AC-6 | `checkRBAC` denies the tool call when the authorizer implements `ConsoleAuthorizer` and denies console access, even though the per-tool check would allow that tool | Real MCP tool call via `handler.NewMCPHandler` returns an error result containing "console" | Passed |
+| UT-AF-1919-007 | AC-3 | `checkRBAC` behavior is unchanged when the configured authorizer does **not** implement `ConsoleAuthorizer` | Tool call succeeds exactly as the pre-existing `allowAllAuthorizer`-based tests already prove — zero-touch confirmed | Passed |
+
+### 4.3 Unit — `newRBACGuard` enforcement (`pkg/apifrontend/agent/root_test.go`)
+
+Same `dualAuthorizer` double (agent-package-local copy, mirroring the existing per-package `mockAuthorizerImpl` duplication convention already in this codebase).
+
+| ID | FedRAMP | Business Behavior Verified | Acceptance Criteria | Status |
+|----|---------|------------------------------|----------------------|--------|
+| UT-AF-1919-008 | AC-3, AU-12 | `newRBACGuard` denies the tool call when console access is denied even though the per-tool check would allow it; emits audit event with `reason=console_access_denied` | `NewRBACGuardForTest` direct invocation returns `{"error": ...}` containing "console"; spy auditor captures one `EventAuthAccessDenied` event with `Detail["reason"]=="console_access_denied"` | Passed |
+| UT-AF-1919-009 | AC-3 | `newRBACGuard` behavior is unchanged when the configured authorizer does not implement `ConsoleAuthorizer` | Existing `mockAuthorizerImpl`-based tests (UT-AF-1221-020/021, UT-AF-1332-080/081) continue to pass unmodified — zero-touch confirmed | Passed |
+
+### 4.4 Integration — `GET /a2a/access` (new `pkg/apifrontend/handler/console_access_test.go`)
+
+Real `handler.NewRouter` + real middleware chain + fake `ConsoleAuthorizer`, mirroring `handler_test.go`'s router-level harness.
+
+| ID | FedRAMP | Business Behavior Verified | Acceptance Criteria | Status |
+|----|---------|------------------------------|----------------------|--------|
+| IT-AF-1919-001 | AC-3 | `GET /a2a/access` with a valid identity + allowed console access returns `200` | HTTP 200 | Passed |
+| IT-AF-1919-002 | AC-3 | Returns `403` (RFC 7807 `application/problem+json`) when console access is denied | HTTP 403, `Content-Type: application/problem+json` | Passed |
+| IT-AF-1919-003 | AU-12 | Denial emits `audit.EventAuthAccessDenied` with `Detail["endpoint"]=="console"` | Spy auditor captures the event | Passed |
+| IT-AF-1919-004 | IA-2 | Request with no identity in context returns `401` (route sits behind `AuthMiddleware`, not a new unauthenticated hole) | HTTP 401 | Passed |
+
+### 4.5 Integration — bypass-closure proof (the actual security fix)
+
+Real router/agent dispatch, **`/a2a/access` is never called** — proves a
+client that skips the pre-flight endpoint entirely still cannot bypass the
+console gate.
+
+| ID | FedRAMP | Business Behavior Verified | Acceptance Criteria | Status |
+|----|---------|------------------------------|----------------------|--------|
+| IT-AF-1919-005 | AC-3 | Real `POST /mcp` tool-call request, console access denied but tool access allowed, `/a2a/access` never called — the tool call is still denied | Error result mentioning console access denial | Passed |
+| IT-AF-1919-006 | AC-3 | Real ADK `runner.Run` dispatch (same `newRBACGuard`-as-`BeforeToolCallback` wiring shape `NewRootAgent` uses) with an LLM that decides to call a tool, console denied/tool allowed, `/a2a/access` never called — the tool call is denied | Function response contains the console-denial error, mirroring the existing `IT-AF-1221-020/021` harness convention in this file | Passed |
+
+### 4.6 Helm-unittest — RBAC manifests (new `charts/kubernaut/tests/console_access_rbac_test.yaml`)
+
+| ID | Business Behavior Verified | Acceptance Criteria | Status |
+|----|------------------------------|----------------------|--------|
+| IT-HELM-1919-001 | `kubernaut-console-access` ClusterRole is rendered with the correct rule | `isKind: ClusterRole`, `rules[0].resources` contains `console`, `rules[0].verbs` contains `use` | Passed |
+| IT-HELM-1919-002 / 002b / 002c | A `ClusterRoleBinding` is rendered per configured group; ungranted groups get none; `cicd`/`l3-audit` are bound by default | `isKind: ClusterRoleBinding`, `subjects[0].name` equals the configured group | Passed |
+| IT-HELM-1919-003 / 003b | Empty `consoleAccessGroups` renders the ClusterRole but no bindings (loop is empty-safe) | ClusterRole renders; no matching `ClusterRoleBinding` document | Passed |
+
+---
+
+## 5. Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | IT/UT Test ID |
+|---|---|---|---|
+| `SARChecker.CheckConsoleAccess` / `checkSAR` | `consoleAccessHandler.ServeHTTP` | `pkg/apifrontend/auth/sar.go` | IT-AF-1919-001/002 |
+| `NewConsoleAccessHandler` | `GET /a2a/access` route | `pkg/apifrontend/handler/console_access.go` (new) | IT-AF-1919-001..004 |
+| `RouterConfig.ConsoleAccessHandler` | `cmd/apifrontend/main.go` inline `RouterConfig` construction (no `buildRouterConfig` extraction on `release/v1.5`) | `pkg/apifrontend/handler/router.go` | IT-AF-1919-001..004 (via real `handler.NewRouter`) |
+| `checkRBAC` console-access enforcement (type-assertion on `cfg.Authorizer`) | MCP tool dispatch (`cmd/apifrontend/main.go` -> `sarChecker` as `Authorizer` in `MCPBridgeConfig`) | `pkg/apifrontend/handler/mcp_bridge.go` | IT-AF-1919-005, UT-AF-1919-006/007 |
+| `newRBACGuard` console-access enforcement (type-assertion on `authorizer`) | agent `BeforeToolCallback` chain (`cmd/apifrontend/main.go` -> `agent.AgentConfig` -> `sarChecker` as `Authorizer`) | `pkg/apifrontend/agent/root.go` | IT-AF-1919-006, UT-AF-1919-008/009 |
+| `var _ auth.ConsoleAuthorizer = (*SARChecker)(nil)` | compile-time guarantee, no runtime entry point | `pkg/apifrontend/auth/sar.go` | build (compile failure = test failure) |
+| `kubernaut-console-access` ClusterRole/Binding | Helm chart render + E2E overlay | `charts/kubernaut/templates/apifrontend/apifrontend.yaml`, `deploy/apifrontend/overlays/e2e/e2e-user-rbac.yaml` | IT-HELM-1919-001..003 |
+
+---
+
+## 6. TDD Execution Phases
+
+| Phase | Type | Scope | Result |
+|-------|------|-------|--------|
+| 1 | RED (equivalent) | Confirmed `pkg/fleet`/`buildRouterConfig` absence and pre-#1919 code shape on `release/v1.5` via a temporary `git worktree` diff against the original `main` implementation | Confirmed gap exists |
+| 2 | GREEN | `checkSAR`/`CheckConsoleAccess`/`ConsoleAuthorizer` + compile-time assertion; `NewConsoleAccessHandler`; router/main.go wiring; `checkRBAC`/`newRBACGuard` type-assertion enforcement; Helm manifests + values; E2E RBAC overlay; fixed a pre-existing chart label-duplication bug blocking helm-unittest | All tests above pass; no regression in existing `pkg/apifrontend/...` suite |
+| 3 | REFACTOR | Lint/build/race for `pkg/apifrontend`; `helm lint --strict`/`helm unittest` validation | All tests remain green |
+
+---
+
+## 7. Execution
+
+```bash
+go build ./...
+go test ./pkg/apifrontend/... -run "UT-AF-1919|IT-AF-1919" -v -count=1
+go test ./pkg/apifrontend/... -count=1
+go test ./pkg/apifrontend/... -race -count=1
+golangci-lint run --timeout=5m ./pkg/apifrontend/...
+helm lint charts/kubernaut/ --strict --set global.image.tag=schema-check --set postgresql.auth.existingSecret=lint-placeholder --set datastorage.dbExistingSecret=lint-placeholder --set valkey.existingSecret=lint-placeholder --set kubernautAgent.llm.provider=openai --set kubernautAgent.llm.model=gpt-4o --set kubernautAgent.llm.credentialsSecretName=lint-placeholder
+helm unittest charts/kubernaut
+```

--- a/pkg/apifrontend/agent/root.go
+++ b/pkg/apifrontend/agent/root.go
@@ -208,57 +208,87 @@ func NewRBACGuardForTest(authorizer auth.ToolAuthorizer, auditor audit.Emitter) 
 // newRBACGuard returns a BeforeToolCallback that enforces RBAC via SAR.
 // Fail-closed: if no identity, authorizer error, or denial, the tool call is rejected.
 // Denied attempts are emitted as audit events for FedRAMP SI-4 compliance.
+// denyRBACGuard emits an EventAuthAccessDenied audit event (AU-12, if auditor
+// is non-nil) and logs the denial, mirroring denyRBAC's contract in
+// mcp_bridge.go for the A2A tool-calling path. userID may be empty (no
+// identity yet resolved).
+func denyRBACGuard(ctx tool.Context, auditor audit.Emitter, toolName, userID, reason string, groups []string, logErr error) {
+	logger := logr.FromContextOrDiscard(ctx)
+	if logErr != nil {
+		logger.Error(logErr, "rbac-guard denied tool", "tool", toolName, "user", userID, "reason", reason)
+	} else {
+		logger.Info("rbac-guard denied tool", "tool", toolName, "user", userID, "reason", reason)
+	}
+	if auditor == nil {
+		return
+	}
+	detail := map[string]string{
+		"tool_name": toolName,
+		"endpoint":  "a2a",
+	}
+	if reason != "" {
+		detail["reason"] = reason
+	}
+	if groups != nil {
+		detail["groups"] = strings.Join(groups, ",")
+	}
+	auditor.Emit(ctx, &audit.Event{
+		Type:   audit.EventAuthAccessDenied,
+		UserID: userID,
+		Detail: detail,
+	})
+}
+
+// checkConsoleAccessGuard enforces the #1919 (AC-3, AC-6) coarse-grained
+// console-access gate for the A2A tool-calling path: a separate, coarser gate
+// than per-tool authorization, enforced here (not just at the advisory
+// GET /a2a/access endpoint) so a client driving the A2A tool-calling loop
+// directly cannot bypass it. Optional-interface type-assertion: authorizers
+// that don't implement ConsoleAuthorizer (all pre-existing test doubles) skip
+// this check unchanged (result == nil, ok == true). Returns the guard's
+// terminal result (non-nil) when access is denied or the check errors.
+func checkConsoleAccessGuard(ctx tool.Context, authorizer auth.ToolAuthorizer, auditor audit.Emitter, identity *auth.UserIdentity, toolName string) (result map[string]any, ok bool) {
+	ca, isConsoleAuthorizer := authorizer.(auth.ConsoleAuthorizer)
+	if !isConsoleAuthorizer {
+		return nil, true
+	}
+
+	consoleAllowed, cErr := ca.CheckConsoleAccess(ctx, identity.Username, identity.Groups)
+	if cErr != nil {
+		denyRBACGuard(ctx, auditor, toolName, identity.Username, "console_authorizer_error", identity.Groups, cErr)
+		return map[string]any{"error": "authorization check failed: console access"}, false
+	}
+	if !consoleAllowed {
+		denyRBACGuard(ctx, auditor, toolName, identity.Username, "console_access_denied", identity.Groups, nil)
+		return map[string]any{"error": "forbidden: no console access"}, false
+	}
+	return nil, true
+}
+
 func newRBACGuard(authorizer auth.ToolAuthorizer, auditor audit.Emitter) llmagent.BeforeToolCallback {
 	return func(ctx tool.Context, t tool.Tool, _ map[string]any) (map[string]any, error) {
+		toolName := t.Name()
+
 		identity := auth.UserIdentityFromContext(ctx)
 		if identity == nil {
-			logr.FromContextOrDiscard(ctx).Info("rbac-guard denied tool", "tool", t.Name(), "reason", "no_identity_in_context")
-			if auditor != nil {
-				auditor.Emit(ctx, &audit.Event{
-					Type: audit.EventAuthAccessDenied,
-					Detail: map[string]string{
-						"tool_name": t.Name(),
-						"endpoint":  "a2a",
-						"reason":    "no_identity_in_context",
-					},
-				})
-			}
+			denyRBACGuard(ctx, auditor, toolName, "", "no_identity_in_context", nil, nil)
 			return map[string]any{"error": "unauthorized: no identity in context"}, nil
 		}
 
-		toolName := t.Name()
+		if result, ok := checkConsoleAccessGuard(ctx, authorizer, auditor, identity, toolName); !ok {
+			return result, nil
+		}
+
 		allowed, err := authorizer.Check(ctx, identity.Username, identity.Groups, toolName)
 		if err != nil {
-			logr.FromContextOrDiscard(ctx).Error(err, "rbac-guard denied tool", "tool", toolName, "user", identity.Username, "reason", "authorizer_error")
-			if auditor != nil {
-				auditor.Emit(ctx, &audit.Event{
-					Type:   audit.EventAuthAccessDenied,
-					UserID: identity.Username,
-					Detail: map[string]string{
-						"tool_name": toolName,
-						"endpoint":  "a2a",
-						"reason":    "authorizer_error",
-						"groups":    strings.Join(identity.Groups, ","),
-					},
-				})
-			}
+			denyRBACGuard(ctx, auditor, toolName, identity.Username, "authorizer_error", identity.Groups, err)
 			return map[string]any{"error": "authorization check failed"}, nil
 		}
 		if allowed {
 			return nil, nil
 		}
 
-		if auditor != nil {
-			auditor.Emit(ctx, &audit.Event{
-				Type:   audit.EventAuthAccessDenied,
-				UserID: identity.Username,
-				Detail: map[string]string{
-					"tool_name": toolName,
-					"endpoint":  "a2a",
-					"groups":    strings.Join(identity.Groups, ","),
-				},
-			})
-		}
+		denyRBACGuard(ctx, auditor, toolName, identity.Username, "", identity.Groups, nil)
 
 		return map[string]any{"error": fmt.Sprintf("forbidden: role does not grant access to tool %q", toolName)}, nil
 	}

--- a/pkg/apifrontend/agent/root_test.go
+++ b/pkg/apifrontend/agent/root_test.go
@@ -83,6 +83,22 @@ func (m *mockAuthorizerImpl) Check(_ context.Context, _ string, _ []string, _ st
 	return m.allow, m.err
 }
 
+// dualAuthorizer implements both auth.ToolAuthorizer and auth.ConsoleAuthorizer
+// with independently controllable outcomes, for testing #1919's console-access
+// enforcement layered on top of the pre-existing per-tool check in newRBACGuard.
+type dualAuthorizer struct {
+	toolAllowed    bool
+	consoleAllowed bool
+}
+
+func (d *dualAuthorizer) Check(_ context.Context, _ string, _ []string, _ string) (bool, error) {
+	return d.toolAllowed, nil
+}
+
+func (d *dualAuthorizer) CheckConsoleAccess(_ context.Context, _ string, _ []string) (bool, error) {
+	return d.consoleAllowed, nil
+}
+
 var _ = Describe("Root Agent", func() {
 	Describe("NewRootAgent", func() {
 		It("UT-AF-100-001: returns configured agent with model", func() {
@@ -245,8 +261,8 @@ var _ = Describe("Root Agent", func() {
 			callCount  atomic.Int32
 		}
 
-		newMockToolCallLLM := func(targetTool string) *mockToolCallLLM {
-			return &mockToolCallLLM{targetTool: targetTool}
+		newMockToolCallLLM := func() *mockToolCallLLM {
+			return &mockToolCallLLM{targetTool: "af_test_tool"}
 		}
 
 		buildToolCallLLMName := func(_ *mockToolCallLLM) string { return "mock-tool-call-llm" }
@@ -339,7 +355,7 @@ var _ = Describe("Root Agent", func() {
 		}
 
 		It("IT-AF-1221-020: allowed identity -> tool executes via runner.Run", func() {
-			mockLLM := newMockToolCallLLM("af_test_tool")
+			mockLLM := newMockToolCallLLM()
 			r, _ := buildRunner(mockLLM, &mockAuthorizerImpl{allow: true})
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
@@ -355,7 +371,7 @@ var _ = Describe("Root Agent", func() {
 		})
 
 		It("IT-AF-1221-021: denied identity -> tool blocked with forbidden", func() {
-			mockLLM := newMockToolCallLLM("af_test_tool")
+			mockLLM := newMockToolCallLLM()
 			r, _ := buildRunner(mockLLM, &mockAuthorizerImpl{allow: false})
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
@@ -368,12 +384,27 @@ var _ = Describe("Root Agent", func() {
 		})
 
 		It("IT-AF-1221-022: no identity in context -> denied with unauthorized", func() {
-			mockLLM := newMockToolCallLLM("af_test_tool")
+			mockLLM := newMockToolCallLLM()
 			r, _ := buildRunner(mockLLM, &mockAuthorizerImpl{allow: true})
 
 			// No identity injected — context.Background() without WithUserIdentity
 			result := runAgent(r, context.Background())
 			Expect(result).To(ContainSubstring("unauthorized"))
+		})
+
+		It("IT-AF-1919-006 [AC-3]: console access denied blocks the tool call via runner.Run even though the tool would be allowed (bypass-closure proof: /a2a/access is never called)", func() {
+			mockLLM := newMockToolCallLLM()
+			r, _ := buildRunner(mockLLM, &dualAuthorizer{toolAllowed: true, consoleAllowed: false})
+
+			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+				Username: "sre-user@example.com",
+				Groups:   []string{"sre"},
+			})
+
+			result := runAgent(r, ctx)
+			Expect(result).To(ContainSubstring("console"),
+				"AC-3: a client that never calls GET /a2a/access must still be denied at the tool-call site "+
+					"when console access is denied, even though the per-tool check would allow the call")
 		})
 
 		It("UT-AF-1332-080: RBAC denial emits EventAuthAccessDenied audit event (SI-4)", func() {
@@ -434,6 +465,61 @@ var _ = Describe("Root Agent", func() {
 			Expect(ev.Type).To(Equal(audit.EventAuthAccessDenied))
 			Expect(ev.Detail["reason"]).To(Equal("no_identity_in_context"))
 			Expect(ev.Detail["tool_name"]).To(Equal("kubernaut_remediate"))
+		})
+
+		It("UT-AF-1919-008 [AC-3, AU-12]: denies when console access is denied even though the tool would be allowed, and audits reason=console_access_denied", func() {
+			spyAuditor := &spyAuditEmitter{}
+			guard := agentpkg.NewRBACGuardForTest(&dualAuthorizer{toolAllowed: true, consoleAllowed: false}, spyAuditor)
+
+			testTool, err := functiontool.New(functiontool.Config{
+				Name:        "kubernaut_investigate",
+				Description: "test tool for #1919 console gate",
+			}, func(_ tool.Context, _ struct{}) (struct{}, error) {
+				return struct{}{}, nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			baseCtx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+				Username: "sre-user@example.com",
+				Groups:   []string{"sre"},
+			})
+			ctx := mockToolCtx{Context: baseCtx, callID: "console-gate-008"}
+
+			result, err := guard(ctx, testTool, map[string]any{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(HaveKey("error"))
+			Expect(result["error"]).To(ContainSubstring("console"),
+				"AC-3: denial must be attributable to the console-access gate, not the (allowed) per-tool check")
+
+			Expect(spyAuditor.events).To(HaveLen(1), "AU-12: console-access denial must emit exactly one audit event")
+			ev := spyAuditor.events[0]
+			Expect(ev.Type).To(Equal(audit.EventAuthAccessDenied))
+			Expect(ev.UserID).To(Equal("sre-user@example.com"))
+			Expect(ev.Detail["reason"]).To(Equal("console_access_denied"))
+			Expect(ev.Detail["tool_name"]).To(Equal("kubernaut_investigate"))
+		})
+
+		It("UT-AF-1919-009 [AC-3]: unchanged when the authorizer does not implement ConsoleAuthorizer", func() {
+			guard := agentpkg.NewRBACGuardForTest(&mockAuthorizerImpl{allow: true}, nil)
+
+			testTool, err := functiontool.New(functiontool.Config{
+				Name:        "kubernaut_investigate",
+				Description: "test tool for #1919 zero-touch fallback",
+			}, func(_ tool.Context, _ struct{}) (struct{}, error) {
+				return struct{}{}, nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			baseCtx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+				Username: "sre-user@example.com",
+				Groups:   []string{"sre"},
+			})
+			ctx := mockToolCtx{Context: baseCtx, callID: "console-gate-009"}
+
+			result, err := guard(ctx, testTool, map[string]any{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNil(),
+				"AC-3: an authorizer that doesn't implement ConsoleAuthorizer must fall through to the unchanged per-tool-only check (nil result = proceed)")
 		})
 	})
 

--- a/pkg/apifrontend/auth/sar.go
+++ b/pkg/apifrontend/auth/sar.go
@@ -22,6 +22,20 @@ type ToolAuthorizer interface {
 	Check(ctx context.Context, user string, groups []string, toolName string) (bool, error)
 }
 
+// ConsoleAuthorizer checks whether a user is authorized to access the
+// kubernaut console/chat UI at all -- a coarse-grained gate independent of
+// (and enforced in addition to) any per-tool ToolAuthorizer.Check result
+// (#1919, AC-3/AC-6). Implementations must be safe for concurrent use.
+//
+// This is an optional capability: callers holding a ToolAuthorizer type-assert
+// for ConsoleAuthorizer and skip the console check when the concrete
+// authorizer doesn't implement it, so existing ToolAuthorizer-only test
+// doubles need no changes (see checkRBAC in mcp_bridge.go and newRBACGuard in
+// agent/root.go).
+type ConsoleAuthorizer interface {
+	CheckConsoleAccess(ctx context.Context, user string, groups []string) (bool, error)
+}
+
 type cacheEntry struct {
 	allowed   bool
 	expiresAt time.Time
@@ -81,14 +95,33 @@ func (s *SARChecker) evictExpired(interval time.Duration) {
 // by performing a Kubernetes SubjectAccessReview against the kubernaut.ai/tools resource.
 // Results are cached for the configured TTL. Errors are never cached (retried on next call).
 func (s *SARChecker) Check(ctx context.Context, user string, groups []string, toolName string) (bool, error) {
-	if user == "" {
-		return false, fmt.Errorf("user must not be empty")
-	}
 	if toolName == "" {
 		return false, fmt.Errorf("tool name must not be empty")
 	}
+	return s.checkSAR(ctx, user, groups, "tools", toolName)
+}
 
-	key := cacheKey(user, groups, toolName)
+// CheckConsoleAccess verifies whether the given user (with groups) holds the
+// coarse-grained, unnamed "console" grant (#1919, AC-3/AC-6) -- a separate,
+// independently-auditable authorization step from any per-tool grant. It
+// performs a Kubernetes SubjectAccessReview against the kubernaut.ai/console
+// resource (verb=use, no resourceName). Results are cached for the
+// configured TTL, in the same cache but keyed distinctly from Check's
+// "tools" entries so the two never collide.
+func (s *SARChecker) CheckConsoleAccess(ctx context.Context, user string, groups []string) (bool, error) {
+	return s.checkSAR(ctx, user, groups, "console", "")
+}
+
+// checkSAR is the shared SAR-call-plus-cache implementation behind both
+// Check (resource="tools", name=toolName) and CheckConsoleAccess
+// (resource="console", name=""). Fail-closed: empty user or any API error
+// returns (false, err).
+func (s *SARChecker) checkSAR(ctx context.Context, user string, groups []string, resource, name string) (bool, error) {
+	if user == "" {
+		return false, fmt.Errorf("user must not be empty")
+	}
+
+	key := cacheKey(user, groups, resource, name)
 
 	s.mu.RLock()
 	if entry, ok := s.cache[key]; ok && time.Now().Before(entry.expiresAt) {
@@ -104,15 +137,15 @@ func (s *SARChecker) Check(ctx context.Context, user string, groups []string, to
 			ResourceAttributes: &authorizationv1.ResourceAttributes{
 				Verb:     "use",
 				Group:    "kubernaut.ai",
-				Resource: "tools",
-				Name:     toolName,
+				Resource: resource,
+				Name:     name,
 			},
 		},
 	}
 
 	result, err := s.client.AuthorizationV1().SubjectAccessReviews().Create(ctx, sar, metav1.CreateOptions{})
 	if err != nil {
-		s.logger.Error(err, "SAR API call failed", "user", user, "tool", toolName)
+		s.logger.Error(err, "SAR API call failed", "user", user, "resource", resource, "name", name)
 		return false, fmt.Errorf("SAR authorization check failed: %w", err)
 	}
 
@@ -126,19 +159,20 @@ func (s *SARChecker) Check(ctx context.Context, user string, groups []string, to
 	s.mu.Unlock()
 
 	if !allowed {
-		s.logger.V(1).Info("SAR denied tool access", "user", user, "tool", toolName, "groups", groups)
+		s.logger.V(1).Info("SAR denied access", "user", user, "resource", resource, "name", name, "groups", groups)
 	}
 
 	return allowed, nil
 }
 
-func cacheKey(user string, groups []string, toolName string) string {
+func cacheKey(user string, groups []string, resource, name string) string {
 	sorted := make([]string, len(groups))
 	copy(sorted, groups)
 	sort.Strings(sorted)
-	raw := user + "\x00" + strings.Join(sorted, "\x00") + "\x00" + toolName
+	raw := user + "\x00" + strings.Join(sorted, "\x00") + "\x00" + resource + "\x00" + name
 	h := sha256.Sum256([]byte(raw))
 	return hex.EncodeToString(h[:])
 }
 
 var _ ToolAuthorizer = (*SARChecker)(nil)
+var _ ConsoleAuthorizer = (*SARChecker)(nil)

--- a/pkg/apifrontend/auth/sar_test.go
+++ b/pkg/apifrontend/auth/sar_test.go
@@ -19,13 +19,14 @@ import (
 
 var _ = Describe("SARChecker", func() {
 	var (
-		ctx       context.Context
-		fakeK8s   *k8sfake.Clientset
-		checker   *auth.SARChecker
-		sarCalls  atomic.Int32
-		lastSAR   *authorizationv1.SubjectAccessReview
+		ctx      context.Context
+		fakeK8s  *k8sfake.Clientset
+		checker  *auth.SARChecker
+		sarCalls atomic.Int32
+		lastSAR  *authorizationv1.SubjectAccessReview
 	)
 
+	//nolint:unparam // must match k8stesting.ReactionFunc signature required by PrependReactor
 	allowAll := func(action k8stesting.Action) (bool, runtime.Object, error) {
 		sarCalls.Add(1)
 		createAction := action.(k8stesting.CreateAction)
@@ -35,6 +36,7 @@ var _ = Describe("SARChecker", func() {
 		return true, sar, nil
 	}
 
+	//nolint:unparam // must match k8stesting.ReactionFunc signature required by PrependReactor
 	denyAll := func(action k8stesting.Action) (bool, runtime.Object, error) {
 		sarCalls.Add(1)
 		createAction := action.(k8stesting.CreateAction)
@@ -44,7 +46,8 @@ var _ = Describe("SARChecker", func() {
 		return true, sar, nil
 	}
 
-	failAll := func(action k8stesting.Action) (bool, runtime.Object, error) {
+	//nolint:unparam // action unused and runtime.Object always nil, but must match k8stesting.ReactionFunc signature required by PrependReactor
+	failAll := func(_ k8stesting.Action) (bool, runtime.Object, error) {
 		sarCalls.Add(1)
 		return true, nil, errors.New("api server unreachable")
 	}
@@ -193,6 +196,88 @@ var _ = Describe("SARChecker", func() {
 			allowed, err := checker.Check(ctx, "alice", []string{"sre"}, "")
 			Expect(err).To(HaveOccurred(), "AC 5: empty tool name must be rejected")
 			Expect(allowed).To(BeFalse(), "AC 5: fail-closed on invalid input")
+		})
+	})
+
+	Describe("UT-AF-1919-001: CheckConsoleAccess allowed [AC-3]", func() {
+		It("should return true when SAR allows kubernaut.ai/console use", func() {
+			fakeK8s.PrependReactor("create", "subjectaccessreviews", allowAll)
+			checker = auth.NewSARChecker(fakeK8s, 30*time.Second, logr.Discard())
+
+			allowed, err := checker.CheckConsoleAccess(ctx, "alice", []string{"sre"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(allowed).To(BeTrue(), "AC-3: console access should be granted when SAR allows")
+		})
+	})
+
+	Describe("UT-AF-1919-002: CheckConsoleAccess denied [AC-3]", func() {
+		It("should return false when SAR denies kubernaut.ai/console use", func() {
+			fakeK8s.PrependReactor("create", "subjectaccessreviews", denyAll)
+			checker = auth.NewSARChecker(fakeK8s, 30*time.Second, logr.Discard())
+
+			allowed, err := checker.CheckConsoleAccess(ctx, "viewer", []string{"observability"})
+			Expect(err).NotTo(HaveOccurred(), "AC-3: denial is not an error")
+			Expect(allowed).To(BeFalse(), "AC-3: console access should be denied when SAR denies")
+		})
+	})
+
+	Describe("UT-AF-1919-003: CheckConsoleAccess fail-closed on empty user [AC-3]", func() {
+		It("should reject empty user as input validation", func() {
+			checker = auth.NewSARChecker(fakeK8s, 30*time.Second, logr.Discard())
+
+			allowed, err := checker.CheckConsoleAccess(ctx, "", []string{"sre"})
+			Expect(err).To(HaveOccurred(), "AC-3: empty user must be rejected")
+			Expect(allowed).To(BeFalse(), "AC-3: fail-closed on invalid input")
+		})
+	})
+
+	Describe("UT-AF-1919-004: CheckConsoleAccess fail-closed on SAR API error [AC-3]", func() {
+		It("should return false and an error when SAR API fails", func() {
+			fakeK8s.PrependReactor("create", "subjectaccessreviews", failAll)
+			checker = auth.NewSARChecker(fakeK8s, 30*time.Second, logr.Discard())
+
+			allowed, err := checker.CheckConsoleAccess(ctx, "alice", []string{"sre"})
+			Expect(err).To(HaveOccurred(), "AC-3: API error should be propagated")
+			Expect(allowed).To(BeFalse(), "AC-3: fail-closed — API error must deny access")
+		})
+	})
+
+	Describe("UT-AF-1919-005: CheckConsoleAccess SAR request shape [AC-3]", func() {
+		It("should build a SAR for the coarse-grained console resource, not a named tool", func() {
+			fakeK8s.PrependReactor("create", "subjectaccessreviews", allowAll)
+			checker = auth.NewSARChecker(fakeK8s, 30*time.Second, logr.Discard())
+
+			_, err := checker.CheckConsoleAccess(ctx, "alice@corp.com", []string{"sre", "system:authenticated"})
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(lastSAR).NotTo(BeNil(), "AC-3: SAR request should have been captured")
+			Expect(lastSAR.Spec.User).To(Equal("alice@corp.com"))
+			Expect(lastSAR.Spec.Groups).To(ConsistOf("sre", "system:authenticated"))
+			Expect(lastSAR.Spec.ResourceAttributes).NotTo(BeNil())
+			Expect(lastSAR.Spec.ResourceAttributes.Verb).To(Equal("use"), "verb must be 'use'")
+			Expect(lastSAR.Spec.ResourceAttributes.Group).To(Equal("kubernaut.ai"), "apiGroup must be 'kubernaut.ai'")
+			Expect(lastSAR.Spec.ResourceAttributes.Resource).To(Equal("console"), "resource must be 'console', distinct from 'tools'")
+			Expect(lastSAR.Spec.ResourceAttributes.Name).To(Equal(""), "console access is a coarse-grained, unnamed resource")
+		})
+	})
+
+	Describe("UT-AF-1919: tools and console SAR cache entries do not collide", func() {
+		It("should call the SAR API separately for Check(tools) and CheckConsoleAccess even with identical user/groups", func() {
+			callCount := atomic.Int32{}
+			fakeK8s.PrependReactor("create", "subjectaccessreviews", func(action k8stesting.Action) (bool, runtime.Object, error) {
+				callCount.Add(1)
+				createAction := action.(k8stesting.CreateAction)
+				sar := createAction.GetObject().(*authorizationv1.SubjectAccessReview)
+				sar.Status = authorizationv1.SubjectAccessReviewStatus{Allowed: true}
+				return true, sar, nil
+			})
+			checker = auth.NewSARChecker(fakeK8s, 30*time.Second, logr.Discard())
+
+			_, _ = checker.Check(ctx, "alice", []string{"sre"}, "kubernaut_approve")
+			_, _ = checker.CheckConsoleAccess(ctx, "alice", []string{"sre"})
+
+			Expect(callCount.Load()).To(Equal(int32(2)),
+				"AC-3: tools and console checks for the same user/groups must be cached independently")
 		})
 	})
 })

--- a/pkg/apifrontend/handler/console_access.go
+++ b/pkg/apifrontend/handler/console_access.go
@@ -1,0 +1,75 @@
+package handler
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/go-logr/logr"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/audit"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/httputil"
+)
+
+// consoleAccessHandler serves GET /a2a/access (#1919): a lightweight,
+// pre-flight check the console/chat client can call once at load time to
+// decide whether to render its UI at all, backed by the same
+// kubernaut.ai/console SAR grant that checkRBAC and newRBACGuard also
+// enforce directly at every tool-call site (this endpoint is advisory only
+// -- it is not itself the security boundary, see #1919 design notes).
+type consoleAccessHandler struct {
+	checker auth.ConsoleAuthorizer
+	auditor audit.Emitter
+	logger  logr.Logger
+}
+
+// NewConsoleAccessHandler constructs the GET /a2a/access handler. auditor
+// may be nil (no audit emission); logger may be the zero value (discarded).
+func NewConsoleAccessHandler(checker auth.ConsoleAuthorizer, auditor audit.Emitter, logger logr.Logger) http.Handler {
+	if logger.GetSink() == nil {
+		logger = logr.Discard()
+	}
+	return &consoleAccessHandler{
+		checker: checker,
+		auditor: auditor,
+		logger:  logger.WithName("console-access"),
+	}
+}
+
+func (h *consoleAccessHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	user := auth.UserIdentityFromContext(ctx)
+	if user == nil {
+		httputil.WriteProblem(w, http.StatusUnauthorized, "Unauthorized", "authentication required")
+		return
+	}
+
+	allowed, err := h.checker.CheckConsoleAccess(ctx, user.Username, user.Groups)
+	if err != nil {
+		h.logger.Error(err, "console access check failed", "user", user.Username)
+		h.deny(ctx, w, user, "console_authorizer_error")
+		return
+	}
+	if !allowed {
+		h.deny(ctx, w, user, "console_access_denied")
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+// deny emits an EventAuthAccessDenied audit event (AU-12) and writes the
+// RFC 7807 403 response, mirroring checkRBAC's denyRBAC (mcp_bridge.go).
+func (h *consoleAccessHandler) deny(ctx context.Context, w http.ResponseWriter, user *auth.UserIdentity, reason string) {
+	if h.auditor != nil {
+		h.auditor.Emit(ctx, &audit.Event{
+			Type:   audit.EventAuthAccessDenied,
+			UserID: user.Username,
+			Detail: map[string]string{
+				"endpoint": "console",
+				"reason":   reason,
+			},
+		})
+	}
+	httputil.WriteProblem(w, http.StatusForbidden, "Forbidden", "not authorized to access the console")
+}

--- a/pkg/apifrontend/handler/console_access_test.go
+++ b/pkg/apifrontend/handler/console_access_test.go
@@ -1,0 +1,218 @@
+package handler_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/audit"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/handler"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/metrics"
+)
+
+// fakeConsoleAuthorizer implements auth.ConsoleAuthorizer for the GET
+// /a2a/access IT tests, independent of the concrete SARChecker.
+type fakeConsoleAuthorizer struct {
+	allow bool
+	err   error
+}
+
+func (f *fakeConsoleAuthorizer) CheckConsoleAccess(_ context.Context, _ string, _ []string) (bool, error) {
+	return f.allow, f.err
+}
+
+// consoleTestUser is the identity injected by the fake AuthMiddleware used
+// throughout this file's IT tests once a bearer token is present.
+var consoleTestUser = &auth.UserIdentity{Username: "sre-user@example.com", Groups: []string{"sre"}}
+
+// fakeIdentityAuthMiddleware mirrors the production AuthMiddleware's
+// contract (401 without a bearer token, auth.UserIdentity injected into
+// context otherwise) without exercising real JWT validation -- that is
+// already covered by pkg/apifrontend/auth's own test suite. This lets these
+// tests exercise the real handler.NewRouter + real route wiring +
+// checkRBAC/console-access-handler logic.
+func fakeIdentityAuthMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") == "" {
+			http.Error(w, "unauthorized", http.StatusUnauthorized)
+			return
+		}
+		ctx := auth.WithUserIdentity(r.Context(), consoleTestUser)
+		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+var _ = Describe("Console Access Endpoint (#1919)", func() {
+	var (
+		metricsReg     *metrics.Registry
+		consoleAuditor *fakeAuditor
+		newRouterWith  func(checker auth.ConsoleAuthorizer) http.Handler
+	)
+
+	BeforeEach(func() {
+		metricsReg = metrics.NewRegistry()
+		consoleAuditor = &fakeAuditor{}
+		newRouterWith = func(checker auth.ConsoleAuthorizer) http.Handler {
+			router, err := handler.NewRouter(handler.RouterConfig{
+				MetricsRegistry:      metricsReg,
+				A2AHandler:           http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
+				MCPHandler:           http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
+				AgentCardHandler:     http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
+				ConsoleAccessHandler: handler.NewConsoleAccessHandler(checker, consoleAuditor, logr.Discard()),
+				AuthMiddleware:       fakeIdentityAuthMiddleware,
+				ReadyChecker:         func() bool { return true },
+			})
+			Expect(err).NotTo(HaveOccurred())
+			return router
+		}
+	})
+
+	It("IT-AF-1919-001 [AC-3]: GET /a2a/access returns 200 when console access is allowed", func() {
+		router := newRouterWith(&fakeConsoleAuthorizer{allow: true})
+		req := httptest.NewRequest(http.MethodGet, "/a2a/access", http.NoBody)
+		req.Header.Set("Authorization", "Bearer test-token")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		Expect(rec.Code).To(Equal(http.StatusOK))
+	})
+
+	It("IT-AF-1919-002 [AC-3]: GET /a2a/access returns 403 problem+json when console access is denied", func() {
+		router := newRouterWith(&fakeConsoleAuthorizer{allow: false})
+		req := httptest.NewRequest(http.MethodGet, "/a2a/access", http.NoBody)
+		req.Header.Set("Authorization", "Bearer test-token")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		Expect(rec.Code).To(Equal(http.StatusForbidden))
+		Expect(rec.Header().Get("Content-Type")).To(Equal("application/problem+json"))
+	})
+
+	It("IT-AF-1919-003 [AU-12]: denial emits an EventAuthAccessDenied audit event with endpoint=console", func() {
+		router := newRouterWith(&fakeConsoleAuthorizer{allow: false})
+		req := httptest.NewRequest(http.MethodGet, "/a2a/access", http.NoBody)
+		req.Header.Set("Authorization", "Bearer test-token")
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+
+		Eventually(consoleAuditor.Events).Should(HaveLen(1))
+		ev := consoleAuditor.Events()[0]
+		Expect(ev.Type).To(Equal(audit.EventAuthAccessDenied))
+		Expect(ev.UserID).To(Equal(consoleTestUser.Username))
+		Expect(ev.Detail["endpoint"]).To(Equal("console"))
+	})
+
+	It("IT-AF-1919-004 [IA-2]: GET /a2a/access returns 401 without a bearer token (route sits behind AuthMiddleware)", func() {
+		router := newRouterWith(&fakeConsoleAuthorizer{allow: true})
+		req := httptest.NewRequest(http.MethodGet, "/a2a/access", http.NoBody)
+		rec := httptest.NewRecorder()
+		router.ServeHTTP(rec, req)
+		Expect(rec.Code).To(Equal(http.StatusUnauthorized))
+	})
+
+	It("IT-AF-1919-005 [AC-3]: bypass-closure -- real POST /mcp tool call is denied when console access is denied but tool access is allowed, without ever calling GET /a2a/access", func() {
+		fakeK8s := newFakeDynamicClient()
+		bridgeAuditor := &fakeAuditor{}
+		mcpCfg := handler.MCPConfig{
+			ServerName:    "kubernaut-apifrontend",
+			ServerVersion: "v0.1.0-test",
+			Enabled:       true,
+			Bridge: &handler.MCPBridgeConfig{
+				K8sClient:          fakeK8s,
+				TypedClient:        newBridgeTypedClient(),
+				Namespace:          "default",
+				Authorizer:         &dualAuthorizer{toolAllowed: true, consoleAllowed: false},
+				Auditor:            bridgeAuditor,
+				Metrics:            newBridgeMetrics(),
+				ToolTimeout:        2 * time.Second,
+				MaxConcurrentTools: 5,
+			},
+		}
+		mcpHandler, err := handler.NewMCPHandler(mcpCfg)
+		Expect(err).NotTo(HaveOccurred())
+
+		router, err := handler.NewRouter(handler.RouterConfig{
+			MetricsRegistry:  metricsReg,
+			A2AHandler:       http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
+			MCPHandler:       mcpHandler,
+			AgentCardHandler: http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) }),
+			AuthMiddleware:   fakeIdentityAuthMiddleware,
+			ReadyChecker:     func() bool { return true },
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// No request to GET /a2a/access is ever made -- proves a client that
+		// never calls the advisory endpoint cannot bypass the console gate
+		// by going straight to POST /mcp through the real production router.
+		sid := mcpInitializeThroughRouter(router)
+		status, respBody := mcpCallToolThroughRouter(router, sid, "kubernaut_list_remediations", map[string]any{})
+		Expect(status).To(Equal(http.StatusOK), "MCP transport itself succeeds; denial is inside the tool result")
+		Expect(isErrorResult(respBody)).To(BeTrue(),
+			"AC-3: a client that never calls GET /a2a/access must still be denied via the real router + checkRBAC")
+		Expect(extractTextContent(respBody)).To(ContainSubstring("console"))
+	})
+})
+
+// mcpInitializeThroughRouter and mcpCallToolThroughRouter mirror
+// mcpInitialize/mcpCallTool (mcp_bridge_test.go) but drive identity via the
+// fakeIdentityAuthMiddleware bearer-token contract (Authorization header)
+// instead of injecting it directly into the request context, since the
+// handler under test here is the full production router, not the bare MCP
+// handler.
+func mcpInitializeThroughRouter(h http.Handler) string {
+	initReq := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2025-03-26",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "test-client", "version": "1.0"},
+		},
+	}
+	rec := mcpPostThroughRouter(h, "", initReq)
+	Expect(rec.Code).To(Equal(http.StatusOK))
+	sessionID := rec.Header().Get("Mcp-Session-Id")
+	Expect(sessionID).NotTo(BeEmpty())
+
+	notif := map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "notifications/initialized",
+	}
+	mcpPostThroughRouter(h, sessionID, notif)
+	return sessionID
+}
+
+func mcpCallToolThroughRouter(h http.Handler, sessionID, toolName string, args map[string]any) (status int, body string) {
+	callReq := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      2,
+		"method":  "tools/call",
+		"params": map[string]any{
+			"name":      toolName,
+			"arguments": args,
+		},
+	}
+	rec := mcpPostThroughRouter(h, sessionID, callReq)
+	return rec.Code, rec.Body.String()
+}
+
+func mcpPostThroughRouter(h http.Handler, sessionID string, body any) *httptest.ResponseRecorder {
+	data, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/mcp", bytes.NewReader(data))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json, text/event-stream")
+	req.Header.Set("Authorization", "Bearer test-token")
+	if sessionID != "" {
+		req.Header.Set("Mcp-Session-Id", sessionID)
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	return rec
+}

--- a/pkg/apifrontend/handler/mcp_bridge.go
+++ b/pkg/apifrontend/handler/mcp_bridge.go
@@ -505,6 +505,22 @@ func checkRBAC(ctx context.Context, cfg *MCPBridgeConfig, toolName string) error
 		return fmt.Errorf("permission denied: no authorizer configured")
 	}
 
+	// #1919 (AC-3, AC-6): console access is a separate, coarser-grained gate
+	// than per-tool authorization, enforced here (not just at the advisory
+	// GET /a2a/access endpoint) so a client that never calls that endpoint
+	// cannot bypass it. Optional-interface type-assertion: authorizers that
+	// don't implement ConsoleAuthorizer (all pre-existing test doubles) skip
+	// this check and fall through to the per-tool check unchanged.
+	if ca, ok := cfg.Authorizer.(auth.ConsoleAuthorizer); ok {
+		consoleAllowed, cErr := ca.CheckConsoleAccess(ctx, user.Username, user.Groups)
+		if cErr != nil {
+			return fmt.Errorf("permission denied: console access check failed: %w", cErr)
+		}
+		if !consoleAllowed {
+			return fmt.Errorf("permission denied: no console access")
+		}
+	}
+
 	allowed, err := cfg.Authorizer.Check(ctx, user.Username, user.Groups, toolName)
 	if err != nil {
 		return fmt.Errorf("permission denied: authorization check failed for %s: %w", toolName, err)

--- a/pkg/apifrontend/handler/mcp_bridge_test.go
+++ b/pkg/apifrontend/handler/mcp_bridge_test.go
@@ -44,6 +44,22 @@ func (a *allowAllAuthorizer) Check(_ context.Context, _ string, _ []string, _ st
 	return true, nil
 }
 
+// dualAuthorizer implements both auth.ToolAuthorizer and auth.ConsoleAuthorizer
+// with independently controllable outcomes, for testing #1919's console-access
+// enforcement layered on top of the pre-existing per-tool check.
+type dualAuthorizer struct {
+	toolAllowed    bool
+	consoleAllowed bool
+}
+
+func (d *dualAuthorizer) Check(_ context.Context, _ string, _ []string, _ string) (bool, error) {
+	return d.toolAllowed, nil
+}
+
+func (d *dualAuthorizer) CheckConsoleAccess(_ context.Context, _ string, _ []string) (bool, error) {
+	return d.consoleAllowed, nil
+}
+
 // mapAuthorizer is a ToolAuthorizer mock that uses a role-to-tools map for decisions.
 type mapAuthorizer struct {
 	roles map[string][]string
@@ -923,6 +939,64 @@ var _ = Describe("MCP Bridge - Tier 2: Security", Label("tier2", "bridge"), func
 			Expect(isErrorResult(body)).To(BeTrue())
 			text := extractTextContent(body)
 			Expect(text).To(ContainSubstring("permission denied"))
+		})
+
+		It("UT-AF-1919-006 [AC-3, AC-6]: checkRBAC denies when console access is denied even though the tool would be allowed", func() {
+			cfg := handler.MCPConfig{
+				ServerName:    "kubernaut-apifrontend",
+				ServerVersion: "v0.1.0-test",
+				Enabled:       true,
+				Bridge: &handler.MCPBridgeConfig{
+					K8sClient:   fakeK8s,
+					TypedClient: newBridgeTypedClient(),
+					Namespace:   "default",
+
+					Authorizer:         &dualAuthorizer{toolAllowed: true, consoleAllowed: false},
+					Auditor:            auditor,
+					Metrics:            metrics,
+					ToolTimeout:        2 * time.Second,
+					MaxConcurrentTools: 5,
+				},
+			}
+			h, err := handler.NewMCPHandler(cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			user := &auth.UserIdentity{Username: "operator", Groups: []string{"sre"}, Issuer: "test"}
+			sid := mcpInitialize(h, user)
+
+			_, body := mcpCallTool(h, sid, "kubernaut_list_remediations", map[string]any{}, user)
+			Expect(isErrorResult(body)).To(BeTrue(),
+				"AC-3: console access denial must block the tool call even though the per-tool check allows it")
+			text := extractTextContent(body)
+			Expect(text).To(ContainSubstring("console"))
+		})
+
+		It("UT-AF-1919-007 [AC-3]: checkRBAC is unchanged when the authorizer does not implement ConsoleAuthorizer", func() {
+			cfg := handler.MCPConfig{
+				ServerName:    "kubernaut-apifrontend",
+				ServerVersion: "v0.1.0-test",
+				Enabled:       true,
+				Bridge: &handler.MCPBridgeConfig{
+					K8sClient:   fakeK8s,
+					TypedClient: newBridgeTypedClient(),
+					Namespace:   "default",
+
+					Authorizer:         &allowAllAuthorizer{},
+					Auditor:            auditor,
+					Metrics:            metrics,
+					ToolTimeout:        2 * time.Second,
+					MaxConcurrentTools: 5,
+				},
+			}
+			h, err := handler.NewMCPHandler(cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			user := &auth.UserIdentity{Username: "operator", Groups: []string{"sre"}, Issuer: "test"}
+			sid := mcpInitialize(h, user)
+
+			_, body := mcpCallTool(h, sid, "kubernaut_list_remediations", map[string]any{}, user)
+			Expect(isErrorResult(body)).To(BeFalse(),
+				"AC-3: an authorizer that doesn't implement ConsoleAuthorizer must fall through to the unchanged per-tool-only check")
 		})
 
 		It("UT-AF-B-029: wildcard * grants access to all tools", func() {

--- a/pkg/apifrontend/handler/router.go
+++ b/pkg/apifrontend/handler/router.go
@@ -28,7 +28,11 @@ type RouterConfig struct {
 	MaxPayloadBytes    int64
 	SSETracker         *streaming.ConnectionTracker
 	StatusHandler      http.Handler
-	Draining           *atomic.Bool
+	// ConsoleAccessHandler serves GET /a2a/access (#1919), an advisory
+	// pre-flight check for the console/chat client. Registered only when
+	// non-nil, same authenticated middleware tier as StatusHandler.
+	ConsoleAccessHandler http.Handler
+	Draining             *atomic.Bool
 }
 
 func (c *RouterConfig) validate() error {
@@ -112,6 +116,18 @@ func NewRouter(cfg RouterConfig) (http.Handler, error) { //nolint:gocritic // hu
 			statusChain = cfg.PreAuthMiddleware(statusChain)
 		}
 		mux.Handle("POST /a2a/status", statusChain)
+	}
+
+	if cfg.ConsoleAccessHandler != nil {
+		innerConsoleAccess := writeDeadlineMiddleware(cfg.ConsoleAccessHandler)
+		if cfg.PostAuthMiddleware != nil {
+			innerConsoleAccess = cfg.PostAuthMiddleware(innerConsoleAccess)
+		}
+		consoleAccessChain := cfg.AuthMiddleware(innerConsoleAccess)
+		if cfg.PreAuthMiddleware != nil {
+			consoleAccessChain = cfg.PreAuthMiddleware(consoleAccessChain)
+		}
+		mux.Handle("GET /a2a/access", consoleAccessChain)
 	}
 
 	recoverLogger := cfg.Logger


### PR DESCRIPTION
## Summary

Backports the console-access authorization gate from `main` (issue #1919, PR #1940) to `release/v1.5`, tracked by #1941.

- Adds `SARChecker.CheckConsoleAccess` / `ConsoleAuthorizer`, checking a new coarse-grained `kubernaut.ai/console` `use` SAR grant, separate from the existing per-tool `kubernaut.ai/tools` check (AC-6: least privilege — "console access" and "tool access" are two explicit, independently-auditable grants).
- **The actual security fix**: enforces this gate server-side at both existing tool-invocation paths — `checkRBAC` (`/mcp`) and `newRBACGuard` (`/a2a/invoke`'s tool-calling loop) — so a client that never calls the advisory endpoint below cannot bypass it (AC-3).
- Adds `GET /a2a/access`, a lightweight authenticated pre-flight endpoint the console/chat client can call once to decide whether to render its UI, backed by the same grant. Denials emit `audit.EventAuthAccessDenied` (AU-12).
- Adds the `kubernaut-console-access` Helm RBAC manifests (ClusterRole + one ClusterRoleBinding per group in the new `consoleAccessGroups` values key, defaulted to all six personas) and CI-gated helm-unittest coverage.
- Ports the E2E RBAC overlay with a dedicated, cluster-scoped `e2e-console-access` ClusterRole/Bindings (kept separate from the namespace-scoped `e2e-user-k8s-tools` binding used to prove K8s namespace restriction, per the RCA on the original PR #1940).
- Fixes a pre-existing chart bug found along the way: `app.kubernetes.io/part-of: kubernaut` was set both explicitly and via the `kubernaut.labels` helper on the `kubernaut-tool-*` ClusterRoles, producing a duplicate YAML key that only `helm-unittest`'s strict decode (not `helm template`) caught.

`main` and `release/v1.5` had diverged significantly in the affected files, so this is a surgical re-application of the #1919 diff onto `release/v1.5`'s actual code shape, not a cherry-pick. See `docs/tests/1919/TEST_PLAN.md` §0 for the full list of adaptations (notably: #1934/mcpclient timeout is out of scope here since `pkg/fleet` doesn't exist on this branch).

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/apifrontend/... ./cmd/apifrontend/... -count=1` (full regression, all green)
- [x] `go test ./pkg/apifrontend/auth/... ./pkg/apifrontend/handler/... ./pkg/apifrontend/agent/... -race -count=1`
- [x] `golangci-lint run ./pkg/apifrontend/... ./cmd/apifrontend/...` — 0 issues
- [x] `helm lint charts/kubernaut/ --strict` — clean
- [x] `helm unittest charts/kubernaut` — 18/18 passed (incl. 6 new console-access RBAC cases)
- [x] New unit/integration tests: UT-AF-1919-001..009, IT-AF-1919-001..006, IT-HELM-1919-001..003 — all passing, including the bypass-closure proof (`/a2a/access` never called, tool call still denied)


Made with [Cursor](https://cursor.com)