### PR TITLE
docs(charts): warn operators when consoleAccessGroups omits a personas group (#1919, #1943)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Misleading `vertex_ai` + Gemini chart docs/examples (#1793)** — `charts/kubernaut`'s README and values examples suggested `gemini-2.5-pro` worked under `provider: vertex_ai` when it did not; now genuinely supported and covered by Helm + Go wiring tests.
 - **`GOOGLE_APPLICATION_CREDENTIALS` no longer statically declared in API Frontend's Deployment (#1801)** — This credential-adjacent env var was previously rendered as a static `env:` entry whenever `provider: vertex_ai` was configured, visible via `kubectl get pod -o yaml` to anyone with pod-read RBAC. It's now injected in-process at construction time (`pkg/apifrontend/launcher.InjectAmbientGoogleCredentials`) only for the model families whose SDK has no explicit-credentials-bytes option, matching Kubernaut Agent's and the HolmesGPT API predecessor's precedent. API Frontend's Gemini-on-Vertex path now authenticates with explicit credential bytes end-to-end, touching zero env vars.
 
+### Security
+
+- **`consoleAccessGroups` upgrade-safety warning (#1919, #1943, AC-3/AC-6)** — PR #1940 added a coarse-grained `kubernaut.ai/console` "use" SAR grant, enforced server-side at both AF tool-invocation paths (`/mcp` and `/a2a/invoke`) in addition to the pre-existing per-tool `kubernaut.ai/tools` check, defaulting `apifrontend.config.rbac.consoleAccessGroups` to all six built-in personas. Since `consoleAccessGroups` is a separate, independently-maintained values key rather than being derived from `apifrontend.config.rbac.personas`'s keys, an operator who configured a custom persona group (or replaced the defaults) would silently have every AF tool call denied for that group after upgrading, even though its per-tool grants are unchanged. `helm install`/`helm upgrade` now prints a `NOTES.txt` warning listing any `personas` group missing from `consoleAccessGroups` to catch this at deploy time.
+
 ## [1.5.2] - 2026-06-24
 
 ### Added

--- a/charts/kubernaut/templates/NOTES.txt
+++ b/charts/kubernaut/templates/NOTES.txt
@@ -77,6 +77,40 @@ own opt-in Ingress posture, BR-PLATFORM-009). To reach it, either:
   kubectl port-forward -n {{ .Release.Namespace }} svc/console 4180:4180
 
 {{- end }}
+{{- /*
+DD-PLATFORM-006 Decision Area 14: reads apifrontend's own merged value
+(schema default true, once apifrontend.enabled is removed from values.yaml),
+not a raw .Values.apifrontend.enabled, which would incorrectly skip this
+warning for any user relying on the schema's default -- see console.yaml's
+identical guard for the same rationale.
+*/}}
+{{- $afNotesV := include "kubernaut.mergedValues" (dict "root" $ "service" "apifrontend") | fromYaml }}
+{{- if $afNotesV.enabled }}
+{{- $personas := .Values.apifrontend.config.rbac.personas | default dict }}
+{{- $consoleGroups := .Values.apifrontend.config.rbac.consoleAccessGroups | default list }}
+{{- $missingConsoleAccess := list }}
+{{- range $persona, $tools := $personas }}
+{{- if not (has $persona $consoleGroups) }}
+{{- $missingConsoleAccess = append $missingConsoleAccess $persona }}
+{{- end }}
+{{- end }}
+{{- if $missingConsoleAccess }}
+=== RBAC WARNING: console-access gate (#1919) ===
+
+apifrontend.config.rbac.personas group(s) below have per-tool RBAC grants but
+are NOT listed in apifrontend.config.rbac.consoleAccessGroups:
+
+{{- range $missingConsoleAccess }}
+  - {{ . }}
+{{- end }}
+
+Every AF tool call (/mcp and /a2a/invoke) additionally requires the
+coarse-grained kubernaut.ai/console "use" grant. Users in the group(s) above
+will have ALL tool calls denied until you add them to consoleAccessGroups,
+even though their per-tool grants above remain intact and unchanged.
+
+{{- end }}
+{{- end }}
 === Monitoring ===
 
 Kubernaut is designed to work with kube-prometheus-stack.

--- a/charts/kubernaut/tests/console_access_notes_hint_test.yaml
+++ b/charts/kubernaut/tests/console_access_notes_hint_test.yaml
@@ -1,0 +1,74 @@
+suite: "#1919/#1943: NOTES.txt warns when a personas group is missing from consoleAccessGroups"
+templates:
+  - templates/NOTES.txt
+set:
+  postgresql:
+    auth:
+      existingSecret: dummy
+  valkey:
+    existingSecret: dummy
+  global:
+    llmProfiles:
+      primary:
+        provider: openai
+        model: gpt-4
+        credentialsSecretName: llm-credentials-primary
+  kubernautAgent:
+    llmProfileRef: primary
+  signalprocessing:
+    policies:
+      existingConfigMap: test-cm
+  aianalysis:
+    policies:
+      existingConfigMap: test-cm
+tests:
+  - it: "default values (all 6 built-in personas already in consoleAccessGroups): hint is absent"
+    asserts:
+      - notMatchRegexRaw:
+          pattern: "RBAC WARNING: console-access gate"
+
+  - it: "a custom persona group added, consoleAccessGroups left unchanged: hint lists the ungranted group"
+    set:
+      apifrontend:
+        config:
+          rbac:
+            personas:
+              custom-team:
+                - kubernaut_status
+    asserts:
+      - matchRegexRaw:
+          pattern: "RBAC WARNING: console-access gate \\(#1919\\)"
+      - matchRegexRaw:
+          pattern: "- custom-team"
+      - matchRegexRaw:
+          pattern: "ALL tool calls denied until you add them to consoleAccessGroups"
+
+  - it: "a custom persona group added AND added to consoleAccessGroups: hint is absent"
+    set:
+      apifrontend:
+        config:
+          rbac:
+            personas:
+              custom-team:
+                - kubernaut_status
+            consoleAccessGroups:
+              - sre
+              - ai-orchestrator
+              - cicd
+              - observability
+              - l3-audit
+              - remediation-approver
+              - custom-team
+    asserts:
+      - notMatchRegexRaw:
+          pattern: "RBAC WARNING: console-access gate"
+
+  - it: "apifrontend.enabled=false (console also disabled, its dependency): hint is absent regardless of personas/consoleAccessGroups mismatch"
+    set:
+      apifrontend:
+        enabled: false
+      console:
+        enabled: false
+    asserts:
+      - notMatchRegexRaw:
+          pattern: "RBAC WARNING: console-access gate"


### PR DESCRIPTION
## Summary

Closes #1943, the follow-up gap found while backporting #1919 to `release/v1.5` (PR #1942): `apifrontend.config.rbac.consoleAccessGroups` is a separate, independently-maintained values key, not derived from `apifrontend.config.rbac.personas`'s keys. An operator who configures a custom persona group, or replaces the default six, silently has **every** AF tool call denied for that group after upgrading -- even though its per-tool grants are unchanged -- with no signal beyond a generic `forbidden: no console access` error at request time. This is more consequential on `main` than on `release/v1.5`, since the Helm chart is production-supported here (v1.5's chart is operator-only in production).

- Adds a `NOTES.txt` hint, printed on `helm install`/`helm upgrade`, that diffs `apifrontend.config.rbac.personas`'s keys against `apifrontend.config.rbac.consoleAccessGroups` and lists any gap.
- Uses `kubernaut.mergedValues` for the `apifrontend.enabled` check (DD-PLATFORM-006 Decision Area 14) rather than a raw `.Values.apifrontend.enabled` read, which would incorrectly skip the warning for anyone relying on the schema's `default: true` -- same rationale as `console.yaml`'s identical guard.
- Adds a `CHANGELOG.md` entry under `[Unreleased]` documenting the required operator action.
- Adds CI-gated helm-unittest coverage (`console_access_notes_hint_test.yaml`), following the existing `owner_chain_rbac_notes_hint_test.yaml`/`monitoring_notes_hint_test.yaml` NOTES.txt-testing convention.
- Regenerated `docs/generated/helm-values-reference.md` -- no diff, since no `values.schema.json` field changed.

No Go code changes; chart/docs only.

## Test plan

- [x] `helm lint charts/kubernaut/ --strict` -- clean
- [x] `helm unittest charts/kubernaut` -- 464/464 passed (50 suites, incl. the 4 new cases)
- [x] `make generate-helm-config-docs` -- confirmed no drift
- [x] Manual `helm install --dry-run` verification: default values (no warning), a `--set apifrontend.config.rbac.personas.custom-team[0]=...` override (warning correctly lists the ungranted group), `apifrontend.enabled=false` (no warning)

Made with [Cursor](https://cursor.com)