### PR TITLE
fix(kubernautagent): propagate accumulated tool-call history in workflow-discovery phase (#1945)

### DIFF
--- a/docs/testing/1945/TEST_PLAN.md
+++ b/docs/testing/1945/TEST_PLAN.md
@@ -1,0 +1,73 @@
+# Test Plan: Workflow-Discovery Phase Message-Staleness Fix (v1.5 fast-follow)
+
+**Issue**: [#1945](https://github.com/jordigilh/kubernaut/issues/1945) (`release/v1.5`), expands scope of [#1936](https://github.com/jordigilh/kubernaut/issues/1936) (`main`)
+**Authority**: BR-AUDIT-005 v2.0 (`docs/requirements/11_SECURITY_ACCESS_CONTROL.md`)
+**Branch**: `fix/1945-workflow-discovery-message-staleness` (off `release/v1.5`)
+**Created**: 2026-08-05
+**Status**: Draft — implementation in progress
+
+---
+
+## 1. Purpose
+
+Issue #1935/PR #1939 fixed the messages-staleness bug (`runLLMLoop`'s accumulated tool-call history never reaching the caller) **only for the RCA phase** (`runRCA`). Direct triage of the current `release/v1.5` source shows the identical bug is still live in the **Workflow-Discovery phase** (`runWorkflowSelection`).
+
+### Root cause (confirmed via source triage): workflow-discovery retries never see tool-call history
+
+`runWorkflowSelection` (`internal/kubernautagent/investigator/investigator.go`) builds a local `messages := []llm.Message{system, user}` and passes it to `runLLMLoop`. Unlike `runRCA` (already fixed), `runWorkflowSelection` **never reassigns `messages` from the loop's result** — `retryWorkflowSubmit`'s `history` argument (both call sites: the `TextResult` unparseable-text branch and the post-parse-error branch) and the self-correction closure's `messages` (reused across up to `maxSelfCorrectionAttempts` attempts) all keep reading the stale `[system, user]`-only slice, missing every `list_available_actions`/`list_workflows` tool call the LLM actually made.
+
+The read-side helper introduced by #1939 only handles half of the `LoopResult` types it needs to — `SubmitWithWorkflowResult`/`SubmitNoWorkflowResult` (the two workflow-discovery sentinel types) already carry a populated `.Messages` field via `sentinelResult`, but `loopResultMessages` silently returns `nil` for both (`default` case), so even a caller that *did* read it back would get nothing for these two types.
+
+This has two independent effects, exercised by two independent fixes below:
+
+1. **Top-level propagation**: after the *first* `runLLMLoop` call in `runWorkflowSelection` returns, its accumulated messages must flow into `messages` before `retryWorkflowSubmit`'s two call sites.
+2. **Self-correction closure propagation**: after *each* nested `runLLMLoop` call inside `selfCorrectWorkflowSelection`'s `correctionFn` closure, its accumulated messages must flow into the closure-captured `messages` before the *next* correction attempt's request is built — otherwise even attempt 2+ requests are missing tool calls made during attempt 1's own nested loop, independent of whatever the top-level fix already captured.
+
+## 2. Fix Design
+
+Mirror the already-shipped, already-tested `runRCA`/`loopResultMessages` fix exactly — no new types, no new abstractions:
+
+- `internal/kubernautagent/investigator/investigator.go`:
+  - Extend `loopResultMessages(r LoopResult) []llm.Message`'s type switch with `case *SubmitWithWorkflowResult` / `case *SubmitNoWorkflowResult`, both returning `v.Messages`.
+  - In `runWorkflowSelection`, immediately after the top-level `runLLMLoop` call returns (before the result-type switch), reassign: `if extended := loopResultMessages(loopRes); len(extended) > 0 { messages = extended }`. This single fix point feeds **both** `retryWorkflowSubmit` call sites (the `TextResult`-branch call and the post-parse-error call), since both read the same `messages` variable.
+  - In the self-correction `correctionFn` closure (inside `runWorkflowSelection`), immediately after its nested `runLLMLoop` call returns (before the closure's own result-type switch), the same reassignment: `if extended := loopResultMessages(corrLoopRes); len(extended) > 0 { messages = extended }`. Because `messages` is a free variable captured by reference from the enclosing `runWorkflowSelection` scope, this persists across attempts — attempt N+1's request is built from attempt N's reassigned value.
+
+No signature changes to `retryWorkflowSubmit`, `loopResultMessages`'s callers, or `SelfCorrect`'s contract — this is a pure data-flow correction using existing plumbing.
+
+## 3. FedRAMP / SOC2 Control Mapping
+
+| Control | Title | Relevance |
+|---|---|---|
+| **AU-3** | Content of Audit Records | `retryWorkflowSubmit`'s and the self-correction loop's `audit.StoreBestEffort` calls compute `prompt_length`/`prompt_preview` from the same stale `history`/`messages` — today those audit records themselves misrepresent what was actually sent to the LLM during workflow discovery. IT-KA-1945-002/003 assert the audit-visible prompt now reflects real tool-call evidence. |
+| **CC8.1** | Audit Completeness / RR Reconstruction (BR-AUDIT-005 v2.0) | IT-KA-1945-002/003 assert the workflow-discovery LLM calls underlying a parse-retry or self-correction attempt are reconstructable with the tool evidence that informed them — closing the same class of gap #1935's RCA-phase fix closed, for the workflow-selection phase. |
+
+## 4. Pyramid Invariant — Test Scenario Inventory
+
+| ID | Tier | Business-Level Behavior Description | Control / BR | Test File |
+|---|---|---|---|---|
+| UT-KA-1945-001 | Unit | `loopResultMessages` returns the accumulated `.Messages` for `*SubmitWithWorkflowResult` and `*SubmitNoWorkflowResult` (currently silently returns `nil` for both) | #1935 root cause #2 (workflow-discovery extension) | `internal/kubernautagent/investigator/investigator_workflow_history_propagation_1945_test.go` |
+| IT-KA-1945-002 | Integration | `retryWorkflowSubmit`'s retry request (captured via mock `llm.Client`) includes the earlier `list_available_actions` tool_use/tool_result pair, through the real `Investigate` -> `runWorkflowSelection` -> `runLLMLoop` -> `retryWorkflowSubmit` production path, when the LLM's first workflow-discovery response is unparseable text | AU-3, CC8.1 | `internal/kubernautagent/investigator/workflow_history_propagation_1945_test.go` |
+| IT-KA-1945-003 | Integration | Across two self-correction attempts (catalog-validation failure on a hallucinated `workflow_id`), the second attempt's request includes the first attempt's own nested-loop tool-call turn (`list_workflows`), not just the top-level `[system, user]` + correction messages — proving the closure's own nested reassignment, distinct from the top-level one | AU-3, CC8.1 | `internal/kubernautagent/investigator/workflow_history_propagation_1945_test.go` |
+
+**Note on file split**: UT-KA-1945-001 requires white-box access to the unexported `loopResultMessages` function and lives in `package investigator` (mirroring `investigator_loop_messages_1935_test.go`'s established pattern). IT-KA-1945-002/003 exercise the real `Investigate()` production entry point and live in `package investigator_test` (mirroring `gate_history_propagation_1935_test.go`, reusing its `gateMockLLMClient`/`gateRecordingAuditStore`/`gateK8sClient`/`gateDSClient`/`gateWfToolResp` helpers), consistent with the split already established by #1935's own UT-006/007 vs. IT-008/009.
+
+### Tier Skip Rationale — E2E
+
+Same rationale as `docs/testing/1935/TEST_PLAN.md` Section 4: this is wiring-level data-flow correctness (does the right history reach the right retry call), which the Pyramid Invariant assigns to IT, not E2E. No existing E2E scenario asserts on internal message-history content; E2E proves journey completion, not this. Not filed as a gap since it mirrors the already-accepted precedent from the parent fix (#1935).
+
+## 5. Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | Test ID |
+|---|---|---|---|
+| `loopResultMessages` extended for workflow-discovery sentinel types | `runLLMLoop` (workflow-discovery phase) | `internal/kubernautagent/investigator/investigator.go` | UT-KA-1945-001 |
+| `runWorkflowSelection` reassigns `messages` from top-level loop result before `retryWorkflowSubmit`/self-correction | `runWorkflowSelection` | `internal/kubernautagent/investigator/investigator.go` | IT-KA-1945-002 |
+| Self-correction closure reassigns `messages` from each nested loop result | `selfCorrectWorkflowSelection`'s `correctionFn` (the closure defined inline in `runWorkflowSelection`) | `internal/kubernautagent/investigator/investigator.go` | IT-KA-1945-003 |
+
+## 6. Out of Scope / Tracked Separately
+
+- **`main` (#1936)**: confirmed to share the same defect shape in both the RCA and Workflow-Discovery phases, compounded by `main` currently lacking `Messages` fields on any `LoopResult` type. Scope expansion tracked via comment on #1936; the combined port (RCA + workflow-discovery + alignment rendering) happens as Phase 2, after this fix merges into `release/v1.5`.
+- Alignment/grounding rendering fix (`renderConversation` rendering `msg.Reasoning.Text`) — already shipped for `release/v1.5` via #1939; no analogous gap exists for workflow-discovery since `alignment.NotifyRCAComplete` is only called once, for the RCA phase.
+
+## 7. Final Results
+
+_To be filled in after implementation and verification (build/lint/test pass)._

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -143,11 +143,20 @@ func (*CancelledResult) loopResult() {}
 // LoopResult, for the concrete types that carry one (#1935 root cause #2).
 // CancelledResult and ExhaustedResult are handled separately by their
 // callers (cancellation snapshot / abort path) and return nil here.
+// #1945: extended to also cover the workflow-discovery phase's sentinel
+// types (SubmitWithWorkflowResult/SubmitNoWorkflowResult) — sentinelResult
+// already populates their Messages field, but until this fix that data was
+// silently discarded by the default case, mirroring the same gap #1935
+// fixed for SubmitResult/TextResult in the RCA phase.
 func loopResultMessages(r LoopResult) []llm.Message {
 	switch v := r.(type) {
 	case *SubmitResult:
 		return v.Messages
 	case *TextResult:
+		return v.Messages
+	case *SubmitWithWorkflowResult:
+		return v.Messages
+	case *SubmitNoWorkflowResult:
 		return v.Messages
 	default:
 		return nil
@@ -1029,6 +1038,17 @@ func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katype
 		return nil, err
 	}
 
+	// #1945 (workflow-discovery extension of #1935 root cause #2): runLLMLoop
+	// accumulates tool-call/tool-result turns in its OWN local `messages`
+	// slice as the investigation progresses, but this variable stayed frozen
+	// at its initial [system, user] value for the rest of runWorkflowSelection
+	// regardless of how many tools were actually called. Reassigning it here
+	// fixes both retryWorkflowSubmit call sites below (the TextResult-branch
+	// call and the post-parse-error call), since both read this same variable.
+	if extended := loopResultMessages(loopRes); len(extended) > 0 {
+		messages = extended
+	}
+
 	var content string
 	switch r := loopRes.(type) {
 	case *CancelledResult:
@@ -1154,6 +1174,18 @@ func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katype
 			if corrErr != nil {
 				return nil, corrErr
 			}
+
+			// #1945: the closure's own nested runLLMLoop call needs the same
+			// reassignment as the top-level one above — otherwise tool calls
+			// made DURING this correction attempt (e.g. a re-check of
+			// list_workflows) are lost before the NEXT attempt's request is
+			// built, even though the top-level fix already ran once. messages
+			// is captured by reference from the enclosing runWorkflowSelection
+			// scope, so this persists across attempts.
+			if extended := loopResultMessages(corrLoopRes); len(extended) > 0 {
+				messages = extended
+			}
+
 			switch cr := corrLoopRes.(type) {
 			case *CancelledResult:
 				return nil, context.Canceled

--- a/internal/kubernautagent/investigator/investigator_workflow_history_propagation_1945_test.go
+++ b/internal/kubernautagent/investigator/investigator_workflow_history_propagation_1945_test.go
@@ -1,0 +1,78 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+)
+
+// White-box (package investigator, not investigator_test) because
+// loopResultMessages is intentionally unexported. #1935/PR #1939 fixed
+// runRCA's consumption of this helper but only extended its type switch to
+// cover *SubmitResult/*TextResult (the RCA-phase sentinel/text results) —
+// *SubmitWithWorkflowResult and *SubmitNoWorkflowResult (the
+// workflow-discovery phase's sentinel types) fall through to the `default:
+// return nil` branch despite `sentinelResult` already populating their
+// Messages field. This is the read-side half of #1945's fix; the write-side
+// (runWorkflowSelection actually reassigning `messages` from this helper)
+// is proven by IT-KA-1945-002/003 in workflow_history_propagation_1945_test.go.
+var _ = Describe("#1945: loopResultMessages must cover workflow-discovery sentinel types", func() {
+
+	accumulated := []llm.Message{
+		{Role: "system", Content: "system prompt"},
+		{Role: "user", Content: "RCA findings: ...\n\nSelect the appropriate remediation workflow."},
+		{Role: "assistant", Content: "Checking available actions...", ToolCalls: []llm.ToolCall{
+			{ID: "tc_1", Name: "list_available_actions", Arguments: "{}"},
+		}},
+		{Role: "tool", Content: `{"actions":["restart-pod"]}`, ToolCallID: "tc_1", ToolName: "list_available_actions"},
+	}
+
+	Describe("UT-KA-1945-001a: SubmitWithWorkflowResult carries prior tool-call/tool-result turns", func() {
+		It("returns the accumulated Messages instead of nil", func() {
+			r := &SubmitWithWorkflowResult{
+				Content:  `{"workflow_id":"restart-pod","confidence":0.9}`,
+				Messages: accumulated,
+			}
+
+			got := loopResultMessages(r)
+
+			Expect(got).NotTo(BeEmpty(),
+				"UT-KA-1945-001a: loopResultMessages must return SubmitWithWorkflowResult.Messages, "+
+					"not silently fall through to the default nil case (#1935 root cause #2, workflow-discovery extension)")
+			Expect(got).To(Equal(accumulated))
+		})
+	})
+
+	Describe("UT-KA-1945-001b: SubmitNoWorkflowResult carries prior tool-call/tool-result turns", func() {
+		It("returns the accumulated Messages instead of nil", func() {
+			r := &SubmitNoWorkflowResult{
+				Content:  `{"reasoning":"no workflow matches"}`,
+				Messages: accumulated,
+			}
+
+			got := loopResultMessages(r)
+
+			Expect(got).NotTo(BeEmpty(),
+				"UT-KA-1945-001b: loopResultMessages must return SubmitNoWorkflowResult.Messages, "+
+					"not silently fall through to the default nil case (#1935 root cause #2, workflow-discovery extension)")
+			Expect(got).To(Equal(accumulated))
+		})
+	})
+})

--- a/internal/kubernautagent/investigator/workflow_history_propagation_1945_test.go
+++ b/internal/kubernautagent/investigator/workflow_history_propagation_1945_test.go
@@ -1,0 +1,185 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// #1935 root cause #2, workflow-discovery extension (#1945, BR-AUDIT-005
+// v2.0, FedRAMP AU-3/CC8.1): PR #1939 fixed runRCA's consumption of
+// runLLMLoop's accumulated messages but left runWorkflowSelection
+// unchanged — its local `messages` variable is never reassigned from the
+// loop's result, so retryWorkflowSubmit and the self-correction closure
+// both operate on a stale [system, user]-only history regardless of how
+// many workflow-discovery tools (list_available_actions, list_workflows)
+// the LLM actually called. These specs prove the wiring fix end to end
+// through the real Investigate() production path, reusing the
+// gateMockLLMClient/gateRecordingAuditStore/gateK8sClient/gateDSClient
+// helpers established by gate_history_propagation_1935_test.go.
+var _ = Describe("#1945: workflow-discovery retries must include real tool-call history", func() {
+
+	var (
+		logger     logr.Logger
+		auditStore *gateRecordingAuditStore
+		mockClient *gateMockLLMClient
+		builder    *prompt.Builder
+		rp         *parser.ResultParser
+		enricher   *enrichment.Enricher
+		phaseTools katypes.PhaseToolMap
+		signal     katypes.SignalContext
+	)
+
+	BeforeEach(func() {
+		logger = logr.Discard()
+		auditStore = &gateRecordingAuditStore{}
+		mockClient = &gateMockLLMClient{}
+		builder, _ = prompt.NewBuilder()
+		rp = parser.NewResultParser()
+		enricher = enrichment.NewEnricher(&gateK8sClient{}, &gateDSClient{}, auditStore, logger)
+		phaseTools = investigator.DefaultPhaseToolMap()
+		signal = katypes.SignalContext{
+			ResourceKind: "Pod",
+			ResourceName: "api-server-xyz",
+			Name:         "api-server-xyz",
+			Namespace:    "production",
+			Severity:     "critical",
+			Message:      "Pod OOMKilled repeatedly",
+		}
+	})
+
+	// wfToolCallMessages inspects a captured llm.ChatRequest for tool-call/
+	// tool-result turns matching the given tool name (mirrors
+	// gate_history_propagation_1935_test.go's toolCallMessages helper).
+	wfToolCallMessages := func(req llm.ChatRequest, toolName string) (sawCall, sawResult bool) {
+		for _, msg := range req.Messages {
+			for _, tc := range msg.ToolCalls {
+				if tc.Name == toolName {
+					sawCall = true
+				}
+			}
+			if msg.Role == "tool" && msg.ToolName == toolName {
+				sawResult = true
+			}
+		}
+		return sawCall, sawResult
+	}
+
+	Describe("IT-KA-1945-002: retryWorkflowSubmit retry includes prior tool-call turns", func() {
+		It("sends the earlier list_available_actions tool_use/tool_result pair as part of the retry request", func() {
+			mockClient.responses = []llm.ChatResponse{
+				// Turn 0 (RCA phase): parseable, no tool calls needed.
+				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"Pod OOMKilled","confidence":0.85}`}},
+				// Turn 1 (workflow-discovery, top-level loop turn 0): real tool call.
+				{
+					Message: llm.Message{Role: "assistant", Content: "Checking available actions..."},
+					ToolCalls: []llm.ToolCall{
+						{ID: "tc_1", Name: "list_available_actions", Arguments: `{}`},
+					},
+				},
+				// Turn 2 (workflow-discovery, top-level loop turn 1): unparseable
+				// plain text final response — triggers retryWorkflowSubmit.
+				{Message: llm.Message{Role: "assistant", Content: "I could not determine a matching workflow from the available actions."}},
+				// Turn 3: the actual parse-retry LLM call under test.
+				gateWfToolResp(`{"workflow_id":"restart-pod","confidence":0.9}`),
+			}
+
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			_, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(mockClient.calls)).To(BeNumerically(">=", 4),
+				"IT-KA-1945-002: expected RCA + WD tool-call turn + WD final text turn + parse-retry LLM calls")
+			retryReq := mockClient.calls[3]
+
+			sawCall, sawResult := wfToolCallMessages(retryReq, "list_available_actions")
+			Expect(sawCall).To(BeTrue(),
+				"IT-KA-1945-002: workflow-discovery parse-retry must include the earlier list_available_actions tool_use turn (#1945)")
+			Expect(sawResult).To(BeTrue(),
+				"IT-KA-1945-002: workflow-discovery parse-retry must include the paired tool_result turn (#1945)")
+		})
+	})
+
+	Describe("IT-KA-1945-003: self-correction second attempt includes first attempt's nested tool-call turn", func() {
+		It("sends the first correction attempt's own list_workflows tool_use/tool_result pair as part of the second attempt's request", func() {
+			mockClient.responses = []llm.ChatResponse{
+				// Turn 0 (RCA phase): parseable, no tool calls needed.
+				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"Pod OOMKilled","confidence":0.85}`}},
+				// Turn 1 (workflow-discovery, top-level loop turn 0): LLM
+				// immediately submits a hallucinated workflow_id — parses
+				// fine but fails catalog validation, triggering self-correction
+				// attempt 1.
+				gateWfToolResp(`{"workflow_id":"invalid-wf","confidence":0.7}`),
+				// Turn 2 (self-correction attempt 1, nested loop turn 0): real
+				// tool call made DURING the correction attempt itself.
+				{
+					Message: llm.Message{Role: "assistant", Content: "Let me check the workflow catalog again..."},
+					ToolCalls: []llm.ToolCall{
+						{ID: "tc_wf_list", Name: "list_workflows", Arguments: `{}`},
+					},
+				},
+				// Turn 3 (self-correction attempt 1, nested loop turn 1): still
+				// invalid — attempt 1 fails validation too, triggering attempt 2.
+				gateWfToolResp(`{"workflow_id":"invalid-wf-2","confidence":0.7}`),
+				// Turn 4: self-correction attempt 2's request — the one under
+				// test. Resolves to a valid workflow so SelfCorrect terminates.
+				gateWfToolResp(`{"workflow_id":"valid-wf","confidence":0.9}`),
+			}
+
+			validator := parser.NewValidator([]string{"valid-wf"})
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+				Pipeline: investigator.Pipeline{
+					CatalogFetcher: &staticFetcher{validator: validator},
+				},
+			})
+
+			result, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.WorkflowID).To(Equal("valid-wf"), "self-correction must converge on the valid workflow")
+
+			Expect(len(mockClient.calls)).To(BeNumerically(">=", 5),
+				"IT-KA-1945-003: expected RCA + top-level submit + 2 self-correction attempts (1 nested tool-call turn + 3 submit turns)")
+			secondAttemptReq := mockClient.calls[4]
+
+			sawCall, sawResult := wfToolCallMessages(secondAttemptReq, "list_workflows")
+			Expect(sawCall).To(BeTrue(),
+				"IT-KA-1945-003: self-correction attempt 2's request must include attempt 1's own list_workflows tool_use turn (#1945), "+
+					"not just the top-level [system, user] + correction messages")
+			Expect(sawResult).To(BeTrue(),
+				"IT-KA-1945-003: self-correction attempt 2's request must include the paired tool_result turn (#1945)")
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Fixes #1945 — a fast-follow gap left behind by #1939 (which fixed the messages-staleness bug for the RCA phase only).

- `runWorkflowSelection`'s local `messages` variable was never reassigned from `runLLMLoop`'s result, so `retryWorkflowSubmit` (both call sites) and the self-correction closure kept reading a stale `[system, user]`-only history regardless of how many `list_available_actions`/`list_workflows` tool calls the LLM actually made during workflow discovery.
- `loopResultMessages` only handled the RCA-phase sentinel types (`SubmitResult`/`TextResult`); the workflow-discovery sentinel types (`SubmitWithWorkflowResult`/`SubmitNoWorkflowResult`) already carried a populated `.Messages` field but fell through to `nil`.

Mirrors the already-shipped, already-tested `runRCA`/`loopResultMessages` fix exactly — no new types, no new abstractions:

1. Extended `loopResultMessages`'s type switch to cover the two workflow-discovery sentinel types.
2. Reassign `messages` from the top-level loop result immediately after the first `runLLMLoop` call, before either `retryWorkflowSubmit` call site or the self-correction block reads it.
3. Reassign `messages` again inside the self-correction closure after each nested `runLLMLoop` call — otherwise attempt N+1's request would still be missing tool calls made during attempt N's own nested loop, independent of the top-level fix.

## FedRAMP / SOC2 control mapping

- **AU-3** (Content of Audit Records): the retry/self-correction audit events' `prompt_length`/`prompt_preview` now reflect what was actually sent to the LLM.
- **CC8.1** (Audit Completeness / BR-AUDIT-005 v2.0): workflow-discovery LLM calls underlying a parse-retry or self-correction attempt are now reconstructable with the tool evidence that informed them.

See `docs/testing/1945/TEST_PLAN.md` for the full pyramid-invariant test inventory and control mapping.

## Test plan

- [x] UT-KA-1945-001: `loopResultMessages` returns `.Messages` for `*SubmitWithWorkflowResult`/`*SubmitNoWorkflowResult` (RED confirmed failing pre-fix, GREEN post-fix)
- [x] IT-KA-1945-002: `retryWorkflowSubmit`'s retry request includes the earlier `list_available_actions` tool_use/tool_result pair, through the real `Investigate` production path
- [x] IT-KA-1945-003: self-correction attempt 2's request includes attempt 1's own nested `list_workflows` tool-call turn, proving the closure's own reassignment (distinct from the top-level one)
- [x] Full `investigator` package suite green (265/265 specs), no regressions
- [x] `go build ./...`, `golangci-lint run` clean on touched package
- [x] `make lint-rules` sub-target violation counts confirmed byte-for-byte identical before/after this change (pre-existing, unrelated repo-wide baseline issues, verified via `git stash` diff)

## Related

- #1935 / #1939 (parent fix — RCA phase only)
- #1936 (`main`/v1.6 port — scope expanded via comment to cover both phases plus this fix)

Made with [Cursor](https://cursor.com)