### PR TITLE
fix(kubernautagent): propagate accumulated tool-call history in RCA and workflow-discovery phases on main (#1936)

### DIFF
--- a/docs/testing/1936/TEST_PLAN.md
+++ b/docs/testing/1936/TEST_PLAN.md
@@ -1,0 +1,105 @@
+# Test Plan: Message-Staleness Fix — Combined `main` Port (RCA + Workflow-Discovery + Alignment Rendering)
+
+**Issue**: [#1936](https://github.com/jordigilh/kubernaut/issues/1936) (`main`) — combined port of [#1935](https://github.com/jordigilh/kubernaut/issues/1935)/[#1939](https://github.com/jordigilh/kubernaut/pull/1939) (RCA phase, `release/v1.5`) and [#1945](https://github.com/jordigilh/kubernaut/issues/1945)/[#1947](https://github.com/jordigilh/kubernaut/pull/1947) (Workflow-Discovery phase, `release/v1.5`)
+**Authority**: BR-AUDIT-005 v2.0 (`docs/requirements/11_SECURITY_ACCESS_CONTROL.md`)
+**Branch**: `fix/1936-message-propagation-main-port` (off `main`)
+**Created**: 2026-08-05
+**Status**: Draft — implementation in progress
+
+---
+
+## 1. Purpose
+
+`release/v1.5` shipped two fast-follow fixes for the same underlying defect class ("message-staleness": `runLLMLoop`'s accumulated tool-call history never reaching the caller that built its initial `[system, user]` message slice):
+
+- **#1939** (RCA phase): `runRCA`'s `messages` was never reassigned from `runLLMLoop`'s result, starving `sameKindValidationGate`, `apiVersionValidationGate`, `retryRCASubmit`, and `alignment.NotifyRCAComplete`'s shadow-agent grounding review of real tool-call evidence.
+- **#1947** (Workflow-Discovery phase): the identical bug in `runWorkflowSelection` — `retryWorkflowSubmit` (both call sites) and the self-correction closure's `messages` all read a stale `[system, user]`-only slice.
+
+Direct triage of `main`'s current source (`internal/kubernautagent/investigator/investigator_rca.go`, `investigator_loop.go`, `investigator_workflow_selection.go`, `internal/kubernautagent/alignment/grounding.go`) confirms `main` shares the identical defect shape in **both** phases, compounded by one structural difference: `main`'s `LoopResult` types (`SubmitResult`, `SubmitWithWorkflowResult`, `SubmitNoWorkflowResult`, `TextResult`) carry **no `Messages` field at all** — only `CancelledResult` does. `release/v1.5` had already added `Messages` to `SubmitResult`/`TextResult` as part of #1939, so #1945's fix only needed to extend 2 more cases; `main`'s port must add the field to all 4 non-terminal `LoopResult` types from scratch.
+
+### Confirmed via direct source read (line-accurate, `origin/main`)
+
+- `investigator_loop.go:293` — `processToolCalls` calls `sentinelResult(tc, resp.Message.Reasoning)`; `sentinelResult` (`investigator.go:138`) builds `SubmitResult`/`SubmitWithWorkflowResult`/`SubmitNoWorkflowResult` with `Content`+`Reasoning` only — no message history threaded through.
+- `investigator_loop.go:132` — the final-turn `TextResult{Content: ..., Reasoning: ...}` literal (no tool calls, loop terminates) also carries no message history.
+- `investigator_rca.go:54` — `alignment.NotifyRCAComplete(ctx, messages)` reads `runRCA`'s never-reassigned local `messages`; `retryRCASubmit` (line 63), `sameKindValidationGate` (line 93), `apiVersionValidationGate` (line 112) all read the same stale variable downstream of that one point.
+- `investigator_workflow_selection.go:65-70` — `runWorkflowSelection`'s top-level `runLLMLoop` result flows into `handleWorkflowSelectionLoopResult`, `workflowSelectionRetryOrHumanReview` (`retryWorkflowSubmit`'s two call sites: line 78 and inside the `TextResult` case at line 178), and `selfCorrectWorkflowSelection` (line 119) — all via the same never-reassigned `messages`.
+- `investigator_workflow_selection.go:294-301` — `runSelfCorrectionAttempt`'s nested `runLLMLoop` call (line 297) feeds `classifySelfCorrectionLoopResult` (line 301) via `state.messages`, itself never reassigned from the nested loop's result.
+- `internal/kubernautagent/alignment/grounding.go:167-183` — `renderConversation` renders only `msg.Content`; `main`'s `llm.Message` already carries `Reasoning *llm.ReasoningBlock` (BR-AI-086/#1580's `anthropicfamily` capture-and-replay), so once propagation is fixed, the shadow LLM would still never see the model's thinking text without this one-line addition.
+
+### Confirmed NOT needed on `main` (scope exclusions, per #1936 triage comments)
+
+- **Root cause #1 (dropped-thinking-block)**: `main`'s `anthropicfamily` client already implements correct capture/replay under BR-AI-086/#1580 — the `vertexanthropic`-specific defect that motivated `release/v1.5`'s separate `Reasoning`-field-on-response fix does not exist on `main`.
+- **Console `ThinkingPanel` gap**: `main` already has a dedicated, fully-wired channel (`emitReasoningContentEvent` → `session.EventTypeReasoningContentDelta` → `ka_investigate_bridge.go` → `launcher.EmitReasoningContentSafe`, #1635/DD-LLM-009) — no `reasoning_delta`-field-overload workaround needed, unlike `release/v1.5`.
+- **Contradiction canary**: explicitly dropped per #1935/#1936 decision — this fix targets the confirmed, reproduced defect only.
+
+## 2. Fix Design
+
+Mirrors the already-shipped `release/v1.5` pattern (both #1939 and #1947), adapted to `main`'s current type shapes:
+
+### 2a. `internal/kubernautagent/investigator/investigator.go`
+- Add `Messages []llm.Message` to `SubmitResult`, `SubmitWithWorkflowResult`, `SubmitNoWorkflowResult`, `TextResult` (additive fields; confirmed via repo-wide grep that every existing construction site — production and test — uses named-field literals, so this is non-breaking).
+- Change `sentinelResult`'s signature to `sentinelResult(tc llm.ToolCall, reasoning *llm.ReasoningBlock, messages []llm.Message) LoopResult`, threading `messages` (the pre-this-turn accumulated history — i.e. every prior fully-paired assistant/tool turn, excluding the sentinel call itself, matching `release/v1.5`'s established "exclude the dangling tool_use" contract) into each of the three constructed results.
+- Add a `loopResultMessages(r LoopResult) []llm.Message` helper (does not exist on `main` yet) with a type switch covering `*SubmitResult`, `*TextResult`, `*SubmitWithWorkflowResult`, `*SubmitNoWorkflowResult` (all four return `v.Messages`); `default` (Cancelled/Exhausted) returns `nil`.
+
+### 2b. `internal/kubernautagent/investigator/investigator_loop.go`
+- `processToolCalls`'s sentinel-detection call site (line 293): `sentinelResult(tc, resp.Message.Reasoning, messages)` — `messages` is the parameter already in scope (the pre-turn accumulated history passed into `processToolCalls`).
+- `runLoopTurn`'s final-turn `TextResult` literal (line 132): add `Messages: messages`.
+
+### 2c. `internal/kubernautagent/investigator/investigator_rca.go`
+- In `runRCA`, immediately after `loopRes, err := inv.runLLMLoop(...)` returns (line 49) and before `alignment.NotifyRCAComplete(ctx, messages)` (line 54): `if extended := loopResultMessages(loopRes); len(extended) > 0 { messages = extended }`. This single point feeds `alignment.NotifyRCAComplete`, `retryRCASubmit` (line 63), `sameKindValidationGate` (line 93), and `apiVersionValidationGate` (line 112) — all downstream reads of the same variable.
+
+### 2d. `internal/kubernautagent/investigator/investigator_workflow_selection.go`
+- In `runWorkflowSelection`, immediately after `loopRes, err := inv.runLLMLoop(...)` returns (line 65) and before `handleWorkflowSelectionLoopResult` (line 70): same reassignment pattern. Feeds `workflowSelectionRetryOrHumanReview`/`retryWorkflowSubmit` (both the line-78 and line-178 call sites) and `selfCorrectWorkflowSelection` (line 119).
+- In `runSelfCorrectionAttempt`, immediately after `corrLoopRes, corrErr := inv.runLLMLoop(ctx, state.messages, ...)` returns (line 297) and before `classifySelfCorrectionLoopResult` (line 301): `if extended := loopResultMessages(corrLoopRes); len(extended) > 0 { state.messages = extended }`. Because `state` is a pointer shared across `validator.SelfCorrect`'s repeated `correctionFn` invocations, this persists correctly across up to `maxSelfCorrectionAttempts` attempts.
+
+### 2e. `internal/kubernautagent/alignment/grounding.go`
+- `renderConversation` (line 167): render `msg.Reasoning.Text` alongside `msg.Content` when present (one-line addition, identical to the fix already shipped on `release/v1.5` via #1939).
+
+No signature changes to `runLLMLoop`, `LLMInvocationContext`, `retryRCASubmit`, `retryWorkflowSubmit`, `selfCorrectionState`, or `validator.SelfCorrect`'s contract — this is a pure data-flow correction plus one new field-per-type and one new helper, using existing plumbing throughout.
+
+## 3. FedRAMP / SOC2 Control Mapping
+
+| Control | Title | Relevance |
+|---|---|---|
+| **AU-3** | Content of Audit Records | `emitLLMRequestAudit`/`emitRetryAudit`/gate audit events compute `prompt_length`/`prompt_preview`/full `messages` from the same stale variables fixed here — today those audit records misrepresent what was actually sent to the LLM in both phases. IT-KA-1936-004/005/007/008 assert the audit-visible prompt now reflects real tool-call evidence. |
+| **CC7.2** | Internal Controls (Decision Audit Trails) | The same-kind and apiVersion validation gates, and the workflow-discovery self-correction loop, are decision-audit-trail mechanisms; IT-KA-1936-004/005/008 prove their retry decisions are now made with complete context, not a stale approximation. |
+| **CC8.1** | Audit Completeness / RR Reconstruction (BR-AUDIT-005 v2.0) | IT-KA-1936-004/005/007/008/009 assert that LLM calls underlying a gate retry, parse-retry, self-correction attempt, or shadow-agent grounding review are reconstructable with the tool evidence that actually informed them — closing the same class of gap #1935/#1945 closed on `release/v1.5`, now on `main`. |
+
+## 4. Pyramid Invariant — Test Scenario Inventory
+
+| ID | Tier | Business-Level Behavior Description | Control / BR | Test File |
+|---|---|---|---|---|
+| UT-KA-1936-001 | Unit | `sentinelResult` populates `.Messages` on `*SubmitResult`/`*SubmitWithWorkflowResult`/`*SubmitNoWorkflowResult` from its `messages` parameter (currently has no `messages` parameter at all) | #1935/#1945 root cause #2 (main port) | `internal/kubernautagent/investigator/investigator_message_propagation_1936_test.go` |
+| UT-KA-1936-002 | Unit | `runLoopTurn`'s final-turn `TextResult` carries `.Messages` (the accumulated history at the point the LLM responds with plain text and no tool call) | same | `internal/kubernautagent/investigator/investigator_message_propagation_1936_test.go` |
+| UT-KA-1936-003 | Unit | `loopResultMessages` returns `.Messages` for all four of `*SubmitResult`/`*TextResult`/`*SubmitWithWorkflowResult`/`*SubmitNoWorkflowResult`; returns `nil` for `*CancelledResult`/`*ExhaustedResult` (unchanged, handled separately by their own callers) | same | `internal/kubernautagent/investigator/investigator_message_propagation_1936_test.go` |
+| IT-KA-1936-004 | Integration | `sameKindValidationGate`'s retry request (captured via mock `llm.Client`), through the real `Investigate()` production path, includes the earlier `kubectl_describe` tool_use/tool_result pair | AU-3, CC7.2, CC8.1 | `internal/kubernautagent/investigator/gate_history_propagation_1936_test.go` |
+| IT-KA-1936-005 | Integration | `apiVersionValidationGate`'s retry request includes the earlier `kubectl_describe` tool_use/tool_result pair, through the same production path | AU-3, CC7.2, CC8.1 | `internal/kubernautagent/investigator/gate_history_propagation_1936_test.go` |
+| IT-KA-1936-006 | Integration | Shadow agent's grounding request (via `alignment.NotifyRCAComplete` → `Observer` → `Evaluator`) includes both the earlier tool-call history and the model's `Reasoning.Text`, through the real `Investigate()` path with a real `Observer`/`Evaluator` pair | AU-3, CC8.1 | `internal/kubernautagent/investigator/alignment_grounding_propagation_1936_test.go` |
+| IT-KA-1936-007 | Integration | `retryWorkflowSubmit`'s retry request includes the earlier `list_available_actions` tool_use/tool_result pair, through the real `Investigate()` production path, when the LLM's first workflow-discovery response is unparseable text | AU-3, CC8.1 | `internal/kubernautagent/investigator/workflow_history_propagation_1936_test.go` |
+| IT-KA-1936-008 | Integration | Across two self-correction attempts (catalog-validation failure on a hallucinated `workflow_id`), the second attempt's request includes the first attempt's own nested-loop tool-call turn (`list_workflows`), not just the top-level `[system, user]` + correction messages | AU-3, CC7.2, CC8.1 | `internal/kubernautagent/investigator/workflow_history_propagation_1936_test.go` |
+
+**Note on file split**: UT-KA-1936-001/002/003 require white-box access to unexported `sentinelResult`/`loopResultMessages`/`runLoopTurn` and live in `package investigator`. IT-KA-1936-004 through 008 exercise the real `Investigate()` production entry point and live in `package investigator_test`, reusing the `gateMockLLMClient`/`gateRecordingAuditStore`/`gateK8sClient`/`gateDSClient`/`gateWfToolResp`/`stubCatalogFetcher` helpers already established on `main` (`apiversion_gate_test.go`, `wiring_test.go`) — this is the same shared harness `release/v1.5`'s #1935/#1945 fixes used, confirmed present and API-identical on `main` by direct source read. This mirrors the split already established by #1935 (UT-006/007 vs. IT-008/009/010) and #1945 (UT-001a/001b vs. IT-002/003).
+
+### Tier Skip Rationale — E2E
+
+Same rationale as `docs/testing/1935/TEST_PLAN.md` Section 4 and `docs/testing/1945/TEST_PLAN.md`'s Tier Skip Rationale: this is wiring-level data-flow correctness (does the right history reach the right retry/grounding call), which the Pyramid Invariant assigns to IT, not E2E. No existing E2E scenario asserts on internal message-history content; E2E proves journey completion, not this. Not filed as a gap since it mirrors the already-accepted precedent from both parent fixes.
+
+## 5. Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | Test ID |
+|---|---|---|---|
+| `Messages` field added to `SubmitResult`/`SubmitWithWorkflowResult`/`SubmitNoWorkflowResult`/`TextResult`; `sentinelResult` threads it through | `runLLMLoop` (both phases) | `internal/kubernautagent/investigator/investigator.go`, `investigator_loop.go` | UT-KA-1936-001, UT-KA-1936-002 |
+| `loopResultMessages` helper (new) | `runRCA`, `runWorkflowSelection`, `runSelfCorrectionAttempt` | `internal/kubernautagent/investigator/investigator.go` | UT-KA-1936-003 |
+| `runRCA` reassigns `messages` from top-level loop result before gates/retry/alignment notify | `runRCA` | `internal/kubernautagent/investigator/investigator_rca.go` | IT-KA-1936-004, IT-KA-1936-005, IT-KA-1936-006 |
+| `runWorkflowSelection` reassigns `messages` from top-level loop result before `retryWorkflowSubmit`/self-correction | `runWorkflowSelection` | `internal/kubernautagent/investigator/investigator_workflow_selection.go` | IT-KA-1936-007 |
+| `runSelfCorrectionAttempt` reassigns `state.messages` from each nested loop result | `selfCorrectWorkflowSelection` → `runSelfCorrectionAttempt` | `internal/kubernautagent/investigator/investigator_workflow_selection.go` | IT-KA-1936-008 |
+| `renderConversation` renders `msg.Reasoning.Text` | `alignment.NotifyRCAComplete` → `Observer.StartGroundingReview` → `Evaluator.EvaluateGrounding` | `internal/kubernautagent/alignment/grounding.go` | IT-KA-1936-006 |
+
+## 6. Out of Scope / Tracked Separately
+
+- Root cause #1 (dropped-thinking-block) and the console `ThinkingPanel` gap — both confirmed not applicable to `main` (see Section 1).
+- The tool-access-contradiction canary — explicitly dropped per user decision on #1935/#1936; this fix targets only the confirmed, reproduced message-propagation defect.
+
+## 7. Final Results
+
+_To be filled in after implementation and verification (build/lint/test pass)._

--- a/internal/kubernautagent/alignment/grounding.go
+++ b/internal/kubernautagent/alignment/grounding.go
@@ -167,6 +167,14 @@ func (e *Evaluator) finalizeGroundingObservation(ctx context.Context, obs Ground
 func renderConversation(messages []llm.Message, maxTokens int) string {
 	var b strings.Builder
 	for i, msg := range messages {
+		// #1935/#1936 (BR-AI-086, FedRAMP CC7.2): the model's reasoning/
+		// thinking text lives in a separate field from Content — without
+		// rendering it, the shadow agent's grounding review never saw the
+		// reasoning that anchored an assistant turn's tool_use decisions,
+		// even after the conversation itself stopped being stale.
+		if msg.Reasoning != nil && msg.Reasoning.Text != "" {
+			fmt.Fprintf(&b, "[%s:thinking] %s\n", msg.Role, msg.Reasoning.Text)
+		}
 		fmt.Fprintf(&b, "[%s] %s\n", msg.Role, msg.Content)
 		if i < len(messages)-1 {
 			b.WriteString("---\n")

--- a/internal/kubernautagent/investigator/alignment_grounding_propagation_1936_test.go
+++ b/internal/kubernautagent/investigator/alignment_grounding_propagation_1936_test.go
@@ -1,0 +1,183 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	"context"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/alignment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// shadowCapturingClient1936 is a minimal llm.Client for the shadow/grounding
+// evaluator that records the rendered content of every request it receives,
+// so specs can inspect exactly what the shadow agent saw.
+type shadowCapturingClient1936 struct {
+	mu    sync.Mutex
+	calls []string
+}
+
+func (c *shadowCapturingClient1936) Close() error { return nil }
+
+func (c *shadowCapturingClient1936) StreamChat(ctx context.Context, req llm.ChatRequest, _ func(llm.ChatStreamEvent) error) (llm.ChatResponse, error) {
+	return c.Chat(ctx, req)
+}
+
+func (c *shadowCapturingClient1936) Chat(_ context.Context, req llm.ChatRequest) (llm.ChatResponse, error) {
+	var b strings.Builder
+	for _, m := range req.Messages {
+		b.WriteString(m.Content)
+	}
+	c.mu.Lock()
+	c.calls = append(c.calls, b.String())
+	c.mu.Unlock()
+	return llm.ChatResponse{Message: llm.Message{Role: "assistant", Content: `{"grounded":true,"explanation":"clean"}`}}, nil
+}
+
+func (c *shadowCapturingClient1936) allCalls() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]string, len(c.calls))
+	copy(out, c.calls)
+	return out
+}
+
+// #1936 (main port of #1935 root cause #2, extended to the shadow/alignment
+// agent; BR-AUDIT-005 v2.0, FedRAMP CC7.2/CC8.1): the same message-staleness
+// bug that starves sameKindValidationGate/apiVersionValidationGate of
+// tool-call history also starves alignment.NotifyRCAComplete's full-context
+// grounding review -- the shadow agent's core defense against
+// prompt-injection/hallucination has been evaluating an almost-empty
+// [system, user] conversation regardless of how many tools were actually
+// called. Additionally, renderConversation on main only renders msg.Content,
+// so even once propagation is fixed the shadow LLM would still never see
+// the model's Reasoning.Text (BR-AI-086) without the accompanying one-line
+// fix to grounding.go. This spec drives a real Investigator through its
+// real production wiring (Investigate -> runRCA -> alignment.NotifyRCAComplete
+// -> Observer.StartGroundingReview -> Evaluator.EvaluateGrounding) with a
+// real Observer/Evaluator pair and proves the shadow LLM's request actually
+// contains both.
+var _ = Describe("#1936 (alignment): grounding review must see real tool-call history and thinking text", func() {
+
+	Describe("IT-KA-1936-006: shadow agent's grounding request includes tool-call history and Reasoning text", func() {
+		It("renders the earlier kubectl_describe tool_use/tool_result pair and the thinking-block text into the grounding LLM request", func() {
+			primaryClient := &gateMockLLMClient{
+				responses: []llm.ChatResponse{
+					// Turn 1: real tool call, with a thinking block attached (Sonnet-5-style).
+					{
+						Message: llm.Message{
+							Role:      "assistant",
+							Content:   "Investigating...",
+							Reasoning: &llm.ReasoningBlock{Text: "UNIQUE_REASONING_MARKER_1936"},
+						},
+						ToolCalls: []llm.ToolCall{
+							{ID: "tc_1", Name: "kubectl_describe", Arguments: `{"kind":"Pod","name":"api-server-xyz","namespace":"production"}`},
+						},
+					},
+					// Turn 2: submit_result.
+					{Message: llm.Message{Role: "assistant", Content: `{
+						"rca_summary":"Pod OOMKilled",
+						"confidence":0.85,
+						"remediation_target":{"kind":"Deployment","name":"api-server","namespace":"production","api_version":"apps/v1"}
+					}`}},
+					gateWfToolResp(`{"workflow_id":"increase-memory-limit","confidence":0.9}`),
+				},
+			}
+
+			shadowClient := &shadowCapturingClient1936{}
+			evaluator := alignment.NewEvaluator(shadowClient, alignment.EvaluatorConfig{
+				Timeout:       2 * time.Second,
+				MaxStepTokens: 2000,
+				MaxRetries:    1,
+				// The real investigation system prompt (rendered by
+				// prompt.Builder) is several KB — a small budget here would
+				// truncate renderConversation before reaching the tool-call
+				// turns this spec asserts on, which is a test artifact, not
+				// the behavior under test.
+				MaxConversationTokens: 200000,
+			}, "You are a grounding reviewer.")
+			obs, err := alignment.NewObserver(evaluator,
+				alignment.WithCorrelationID("corr-1936-006"),
+				alignment.WithObserverLogger(logr.Discard()),
+				alignment.WithGroundingEnabled(true),
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			auditStore := &gateRecordingAuditStore{}
+			builder, _ := prompt.NewBuilder()
+			enricher := enrichment.NewEnricher(&gateK8sClient{}, &gateDSClient{}, auditStore, logr.Discard())
+
+			// investigator.New (not newTestInvestigator): a nil
+			// CatalogFetcher makes workflow-discovery fail closed
+			// immediately after the RCA phase under test, matching
+			// #1935's alignment_grounding_propagation_1935_test.go
+			// precedent.
+			inv := investigator.New(investigator.Config{
+				Client: primaryClient, Builder: builder, ResultParser: parser.NewResultParser(),
+				Enricher: enricher, AuditStore: auditStore, Logger: logr.Discard(),
+				MaxTurns: 15, PhaseTools: investigator.DefaultPhaseToolMap(),
+			})
+
+			signal := katypes.SignalContext{
+				ResourceKind: "Pod",
+				ResourceName: "api-server-xyz",
+				Name:         "api-server-xyz",
+				Namespace:    "production",
+				Severity:     "critical",
+				Message:      "Pod OOMKilled repeatedly",
+			}
+
+			ctx := alignment.WithObserver(context.Background(), obs)
+			_, err = inv.Investigate(ctx, signal)
+			Expect(err).NotTo(HaveOccurred())
+
+			waitRes := obs.WaitForCompletion(5 * time.Second)
+			Expect(waitRes.Complete).To(BeTrue(), "IT-KA-1936-006: grounding review must complete before assertions")
+
+			calls := shadowClient.allCalls()
+			Expect(calls).NotTo(BeEmpty())
+
+			var groundingCall string
+			for _, c := range calls {
+				if strings.Contains(c, "[tool]") {
+					groundingCall = c
+					break
+				}
+			}
+			Expect(groundingCall).NotTo(BeEmpty(),
+				"IT-KA-1936-006: the grounding review's rendered conversation must include a \"[tool]\" turn "+
+					"from the earlier kubectl_describe call (#1935/#1936 root cause #2, extended to alignment)")
+			Expect(groundingCall).To(ContainSubstring("kubectl_describe"),
+				"IT-KA-1936-006: grounding review must include the actual tool name that was called")
+			Expect(groundingCall).To(ContainSubstring("UNIQUE_REASONING_MARKER_1936"),
+				"IT-KA-1936-006: grounding review must include the model's thinking-block text (BR-AI-086), "+
+					"not just Content — renderConversation must render Reasoning too")
+		})
+	})
+})

--- a/internal/kubernautagent/investigator/gate_history_propagation_1936_test.go
+++ b/internal/kubernautagent/investigator/gate_history_propagation_1936_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// #1936 (main port of #1935 root cause #2, BR-AUDIT-005 v2.0, FedRAMP
+// AU-3/CC7.2/CC8.1): before this fix, sameKindValidationGate/
+// apiVersionValidationGate always received a stale [system, user]-only
+// history regardless of how many tools were called earlier in the same RCA
+// turn, because runLLMLoop never returned its accumulated messages to
+// runRCA and none of main's LoopResult types carried a Messages field at
+// all. These specs prove the wiring fix end to end through the real
+// Investigate() production path: the gate's actual retry request (captured
+// via the mock LLM client) must include the prior tool-call/tool-result
+// turns.
+var _ = Describe("#1936: validation-gate retries must include real tool-call history", func() {
+
+	var (
+		logger     logr.Logger
+		auditStore *gateRecordingAuditStore
+		mockClient *gateMockLLMClient
+		builder    *prompt.Builder
+		rp         *parser.ResultParser
+		enricher   *enrichment.Enricher
+		phaseTools katypes.PhaseToolMap
+	)
+
+	BeforeEach(func() {
+		logger = logr.Discard()
+		auditStore = &gateRecordingAuditStore{}
+		mockClient = &gateMockLLMClient{}
+		builder, _ = prompt.NewBuilder()
+		rp = parser.NewResultParser()
+		enricher = enrichment.NewEnricher(&gateK8sClient{}, &gateDSClient{}, auditStore, logger)
+		phaseTools = investigator.DefaultPhaseToolMap()
+	})
+
+	// toolCallMessages inspects a captured llm.ChatRequest for tool-call/
+	// tool-result turns matching the given tool name.
+	toolCallMessages := func(req llm.ChatRequest, toolName string) (sawCall, sawResult bool) {
+		for _, msg := range req.Messages {
+			for _, tc := range msg.ToolCalls {
+				if tc.Name == toolName {
+					sawCall = true
+				}
+			}
+			if msg.Role == "tool" && msg.ToolName == toolName {
+				sawResult = true
+			}
+		}
+		return sawCall, sawResult
+	}
+
+	Describe("IT-KA-1936-004: sameKindValidationGate retry includes prior tool-call turns", func() {
+		It("sends the earlier kubectl_describe tool_use/tool_result pair as part of the gate retry request", func() {
+			signal := katypes.SignalContext{
+				ResourceKind: "Pod",
+				ResourceName: "api-server-xyz",
+				Name:         "api-server-xyz",
+				Namespace:    "production",
+				Severity:     "critical",
+				Message:      "Pod OOMKilled repeatedly",
+			}
+
+			mockClient.responses = []llm.ChatResponse{
+				// Turn 1: real tool call before the LLM submits its RCA result.
+				{
+					Message: llm.Message{Role: "assistant", Content: "Investigating..."},
+					ToolCalls: []llm.ToolCall{
+						{ID: "tc_1", Name: "kubectl_describe", Arguments: `{"kind":"Pod","name":"api-server-xyz","namespace":"production"}`},
+					},
+				},
+				// Turn 2: submit_result — same-kind gate fires (target.Kind == signal.ResourceKind == "Pod").
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Pod OOMKilled",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Pod","name":"api-server-xyz","namespace":"production"}
+				}`}},
+				// Turn 3: gate retry — LLM re-targets the parent Deployment.
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Deployment memory limit too low",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Deployment","name":"api-server","namespace":"production","api_version":"apps/v1"}
+				}`}},
+				gateWfToolResp(`{"workflow_id":"increase-memory-limit","confidence":0.9}`),
+			}
+
+			// investigator.New (not newTestInvestigator) deliberately: a nil
+			// CatalogFetcher makes the post-RCA workflow-discovery phase
+			// fail closed immediately (#1677 hardening) without consuming
+			// any further mock responses, keeping this spec isolated to the
+			// RCA-phase gate retry under test (matches #1935's
+			// gate_history_propagation_1935_test.go precedent).
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			_, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(mockClient.calls)).To(BeNumerically(">=", 3),
+				"IT-KA-1936-004: expected at least tool-call turn + submit + gate-retry LLM calls")
+			gateRetryReq := mockClient.calls[2]
+
+			sawCall, sawResult := toolCallMessages(gateRetryReq, "kubectl_describe")
+			Expect(sawCall).To(BeTrue(),
+				"IT-KA-1936-004: same-kind gate retry must include the earlier kubectl_describe tool_use turn (#1935/#1936 root cause #2)")
+			Expect(sawResult).To(BeTrue(),
+				"IT-KA-1936-004: same-kind gate retry must include the paired tool_result turn (#1935/#1936 root cause #2)")
+		})
+	})
+
+	Describe("IT-KA-1936-005: apiVersionValidationGate retry includes prior tool-call turns", func() {
+		It("sends the earlier kubectl_describe tool_use/tool_result pair as part of the gate retry request", func() {
+			mapper := newAmbiguousSubscriptionMapper()
+			signal := katypes.SignalContext{
+				ResourceKind: "Pod",
+				ResourceName: "etcd-operator-xyz",
+				Name:         "etcd-operator-xyz",
+				Namespace:    "demo-operator",
+				Severity:     "critical",
+				Message:      "RBAC denial on wrong API group",
+			}
+
+			mockClient.responses = []llm.ChatResponse{
+				// Turn 1: real tool call before the LLM submits its RCA result.
+				{
+					Message: llm.Message{Role: "assistant", Content: "Investigating..."},
+					ToolCalls: []llm.ToolCall{
+						{ID: "tc_1", Name: "kubectl_describe", Arguments: `{"kind":"Subscription","name":"etcd","namespace":"demo-operator"}`},
+					},
+				},
+				// Turn 2: submit_result — apiVersion gate fires (ambiguous kind, no api_version).
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Subscription etcd needs restart",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Subscription","name":"etcd","namespace":"demo-operator"}
+				}`}},
+				// Turn 3: gate retry — LLM provides api_version.
+				{Message: llm.Message{Role: "assistant", Content: `{
+					"rca_summary":"Subscription etcd needs restart",
+					"confidence":0.85,
+					"remediation_target":{"kind":"Subscription","name":"etcd","namespace":"demo-operator","api_version":"operators.coreos.com/v1alpha1"}
+				}`}},
+				gateWfToolResp(`{"workflow_id":"restart-sub","confidence":0.9}`),
+			}
+
+			resolver := investigator.NewMapperScopeResolver(mapper)
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools, ScopeResolver: resolver,
+			})
+
+			_, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(mockClient.calls)).To(BeNumerically(">=", 3),
+				"IT-KA-1936-005: expected at least tool-call turn + submit + gate-retry LLM calls")
+			gateRetryReq := mockClient.calls[2]
+
+			sawCall, sawResult := toolCallMessages(gateRetryReq, "kubectl_describe")
+			Expect(sawCall).To(BeTrue(),
+				"IT-KA-1936-005: apiVersion gate retry must include the earlier kubectl_describe tool_use turn (#1935/#1936 root cause #2)")
+			Expect(sawResult).To(BeTrue(),
+				"IT-KA-1936-005: apiVersion gate retry must include the paired tool_result turn (#1935/#1936 root cause #2)")
+		})
+	})
+})

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -73,9 +73,14 @@ type LoopResult interface {
 // SubmitResult is returned when the LLM calls the generic submit_result tool
 // (RCA phase). Reasoning carries the winning turn's thinking block, when the
 // LLM's reasoning capability was enabled (BR-AI-086 AC6) — nil otherwise.
+// Messages carries the fully-paired assistant/tool turns accumulated by
+// runLLMLoop BEFORE this final (still-unpaired) submit_result call — see
+// sentinelResult's doc comment for why the final call itself is excluded
+// (#1935/#1936 root cause #2).
 type SubmitResult struct {
 	Content   string
 	Reasoning *llm.ReasoningBlock
+	Messages  []llm.Message
 }
 
 func (*SubmitResult) loopResult() {}
@@ -84,6 +89,7 @@ func (*SubmitResult) loopResult() {}
 type SubmitWithWorkflowResult struct {
 	Content   string
 	Reasoning *llm.ReasoningBlock
+	Messages  []llm.Message
 }
 
 func (*SubmitWithWorkflowResult) loopResult() {}
@@ -92,14 +98,18 @@ func (*SubmitWithWorkflowResult) loopResult() {}
 type SubmitNoWorkflowResult struct {
 	Content   string
 	Reasoning *llm.ReasoningBlock
+	Messages  []llm.Message
 }
 
 func (*SubmitNoWorkflowResult) loopResult() {}
 
 // TextResult is returned when the LLM responds with plain text (no tool call).
+// Messages carries the fully-paired assistant/tool turns accumulated by
+// runLLMLoop prior to this final text turn (#1935/#1936 root cause #2).
 type TextResult struct {
 	Content   string
 	Reasoning *llm.ReasoningBlock
+	Messages  []llm.Message
 }
 
 func (*TextResult) loopResult() {}
@@ -131,18 +141,43 @@ type CancelledResult struct {
 
 func (*CancelledResult) loopResult() {}
 
+// loopResultMessages extracts the accumulated message history from a
+// LoopResult, for the concrete types that carry one (#1935/#1936 root cause
+// #2). CancelledResult and ExhaustedResult are handled separately by their
+// own callers (cancellation snapshot / abort path) and return nil here.
+func loopResultMessages(r LoopResult) []llm.Message {
+	switch v := r.(type) {
+	case *SubmitResult:
+		return v.Messages
+	case *TextResult:
+		return v.Messages
+	case *SubmitWithWorkflowResult:
+		return v.Messages
+	case *SubmitNoWorkflowResult:
+		return v.Messages
+	default:
+		return nil
+	}
+}
+
 // sentinelResult maps a sentinel tool call to its LoopResult type, attaching
 // the reasoning block (if any) from the turn whose response produced tc, so
 // reasoning captured at the LLM-client layer (BR-AI-086 AC1-3) reaches the
-// InvestigationResult that gets built from the sentinel's Content.
-func sentinelResult(tc llm.ToolCall, reasoning *llm.ReasoningBlock) LoopResult {
+// InvestigationResult that gets built from the sentinel's Content. messages
+// is the history accumulated so far — i.e. every PRIOR, fully-paired
+// assistant(tool_use)/tool(tool_result) turn, NOT including the sentinel
+// call itself (tc). Deliberately excluding the sentinel call avoids ever
+// replaying a dangling, unpaired tool_use block to the LLM on a later
+// retry — the sentinel is consumed here, never executed as a real tool, so
+// it has no matching tool_result (#1935/#1936 root cause #2).
+func sentinelResult(tc llm.ToolCall, reasoning *llm.ReasoningBlock, messages []llm.Message) LoopResult {
 	switch tc.Name {
 	case SubmitResultToolName:
-		return &SubmitResult{Content: tc.Arguments, Reasoning: reasoning}
+		return &SubmitResult{Content: tc.Arguments, Reasoning: reasoning, Messages: messages}
 	case SubmitResultWithWorkflowToolName:
-		return &SubmitWithWorkflowResult{Content: tc.Arguments, Reasoning: reasoning}
+		return &SubmitWithWorkflowResult{Content: tc.Arguments, Reasoning: reasoning, Messages: messages}
 	case SubmitResultNoWorkflowToolName:
-		return &SubmitNoWorkflowResult{Content: tc.Arguments, Reasoning: reasoning}
+		return &SubmitNoWorkflowResult{Content: tc.Arguments, Reasoning: reasoning, Messages: messages}
 	default:
 		return nil
 	}

--- a/internal/kubernautagent/investigator/investigator_loop.go
+++ b/internal/kubernautagent/investigator/investigator_loop.go
@@ -129,7 +129,7 @@ func (inv *Investigator) runLoopTurn(ctx context.Context, state *loopTurnState, 
 		return &ExhaustedResult{Reason: "output truncated after retry"}, messages, true, nil
 	}
 
-	return &TextResult{Content: resp.Message.Content, Reasoning: resp.Message.Reasoning}, messages, true, nil
+	return &TextResult{Content: resp.Message.Content, Reasoning: resp.Message.Reasoning, Messages: messages}, messages, true, nil
 }
 
 // doLLMCall builds the per-turn chat request (using state.maxTokens for any
@@ -290,7 +290,7 @@ func (inv *Investigator) emitLLMResponseAudit(ctx context.Context, correlationID
 // total tool-call budget is now exhausted.
 func (inv *Investigator) processToolCalls(ctx context.Context, messages []llm.Message, resp llm.ChatResponse, turn int, phase string, correlationID string) (newMessages []llm.Message, sentinel LoopResult, budgetExhausted bool) {
 	for _, tc := range resp.ToolCalls {
-		if sr := sentinelResult(tc, resp.Message.Reasoning); sr != nil {
+		if sr := sentinelResult(tc, resp.Message.Reasoning, messages); sr != nil {
 			inv.logger.Info("sentinel detected",
 				"tool", tc.Name,
 				"phase", phase,

--- a/internal/kubernautagent/investigator/investigator_message_propagation_1936_test.go
+++ b/internal/kubernautagent/investigator/investigator_message_propagation_1936_test.go
@@ -1,0 +1,201 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// White-box (package investigator, not investigator_test) because
+// sentinelResult/loopResultMessages/runLoopTurn are intentionally
+// unexported. #1936 ports #1935/PR #1939 (RCA phase) and #1945/PR #1947
+// (workflow-discovery phase) from release/v1.5 to main. Unlike v1.5, main's
+// LoopResult types (SubmitResult/SubmitWithWorkflowResult/
+// SubmitNoWorkflowResult/TextResult) carry NO Messages field at all before
+// this fix -- only CancelledResult does -- so runRCA's and
+// runWorkflowSelection's gates, parse-retries, self-correction loop, and
+// the alignment shadow-agent grounding review all operate on a stale
+// [system, user]-only history today, regardless of model or how many tools
+// actually ran. Confirmed via direct source read of origin/main (see
+// docs/testing/1936/TEST_PLAN.md Section 1).
+
+var _ = Describe("#1936: sentinelResult and loopResultMessages must propagate accumulated message history", func() {
+
+	accumulated := []llm.Message{
+		{Role: "system", Content: "system prompt"},
+		{Role: "user", Content: "Investigate: critical api-server in prod"},
+		{Role: "assistant", Content: "Investigating...", ToolCalls: []llm.ToolCall{
+			{ID: "tc_1", Name: "kubectl_describe", Arguments: `{"kind":"Pod","name":"api-server"}`},
+		}},
+		{Role: "tool", Content: `{"status":"OOMKilled"}`, ToolCallID: "tc_1", ToolName: "kubectl_describe"},
+	}
+
+	Describe("UT-KA-1936-001: sentinelResult populates Messages on all three sentinel types", func() {
+		DescribeTable("returns a LoopResult carrying the accumulated history, not just Content/Reasoning",
+			func(toolName string, assertType func(LoopResult) []llm.Message) {
+				reasoning := &llm.ReasoningBlock{Text: "thinking..."}
+				tc := llm.ToolCall{ID: "tc_final", Name: toolName, Arguments: `{"confidence":0.9}`}
+
+				result := sentinelResult(tc, reasoning, accumulated)
+				Expect(result).NotTo(BeNil())
+
+				got := assertType(result)
+				Expect(got).NotTo(BeEmpty(),
+					"UT-KA-1936-001: sentinelResult must populate Messages from its messages parameter, "+
+						"not leave it as a zero-value nil slice (#1935/#1945 root cause #2, main port)")
+				Expect(got).To(Equal(accumulated))
+			},
+			Entry("submit_result -> SubmitResult", SubmitResultToolName, func(r LoopResult) []llm.Message {
+				sr, ok := r.(*SubmitResult)
+				Expect(ok).To(BeTrue(), "expected *SubmitResult")
+				return sr.Messages
+			}),
+			Entry("submit_result_with_workflow -> SubmitWithWorkflowResult", SubmitResultWithWorkflowToolName, func(r LoopResult) []llm.Message {
+				sr, ok := r.(*SubmitWithWorkflowResult)
+				Expect(ok).To(BeTrue(), "expected *SubmitWithWorkflowResult")
+				return sr.Messages
+			}),
+			Entry("submit_result_no_workflow -> SubmitNoWorkflowResult", SubmitResultNoWorkflowToolName, func(r LoopResult) []llm.Message {
+				sr, ok := r.(*SubmitNoWorkflowResult)
+				Expect(ok).To(BeTrue(), "expected *SubmitNoWorkflowResult")
+				return sr.Messages
+			}),
+		)
+	})
+
+	Describe("UT-KA-1936-003: loopResultMessages covers all four message-carrying LoopResult types", func() {
+		It("returns SubmitResult.Messages", func() {
+			got := loopResultMessages(&SubmitResult{Content: "x", Messages: accumulated})
+			Expect(got).To(Equal(accumulated))
+		})
+		It("returns TextResult.Messages", func() {
+			got := loopResultMessages(&TextResult{Content: "x", Messages: accumulated})
+			Expect(got).To(Equal(accumulated))
+		})
+		It("returns SubmitWithWorkflowResult.Messages", func() {
+			got := loopResultMessages(&SubmitWithWorkflowResult{Content: "x", Messages: accumulated})
+			Expect(got).To(Equal(accumulated))
+		})
+		It("returns SubmitNoWorkflowResult.Messages", func() {
+			got := loopResultMessages(&SubmitNoWorkflowResult{Content: "x", Messages: accumulated})
+			Expect(got).To(Equal(accumulated))
+		})
+		It("returns nil for CancelledResult (handled separately by its own callers)", func() {
+			got := loopResultMessages(&CancelledResult{Messages: accumulated})
+			Expect(got).To(BeNil(),
+				"UT-KA-1936-003: CancelledResult's Messages is read directly by cancellation-snapshot "+
+					"callers, not via loopResultMessages -- this must remain nil to avoid masking that contract")
+		})
+		It("returns nil for ExhaustedResult (carries no message history)", func() {
+			got := loopResultMessages(&ExhaustedResult{Reason: "max turns exhausted"})
+			Expect(got).To(BeNil())
+		})
+	})
+})
+
+// msgPropNopAuditStore discards audit events; only runLLMLoop's Messages
+// propagation is under test here, not audit persistence.
+type msgPropNopAuditStore struct{}
+
+func (msgPropNopAuditStore) StoreAudit(_ context.Context, _ *audit.AuditEvent) error { return nil }
+
+// msgPropMockClient is a minimal llm.Client that returns pre-configured
+// responses in order, driving runLLMLoop through one or more turns.
+type msgPropMockClient struct {
+	responses []llm.ChatResponse
+	callIdx   int
+}
+
+func (m *msgPropMockClient) Close() error { return nil }
+
+func (m *msgPropMockClient) StreamChat(ctx context.Context, req llm.ChatRequest, _ func(llm.ChatStreamEvent) error) (llm.ChatResponse, error) {
+	return m.Chat(ctx, req)
+}
+
+func (m *msgPropMockClient) Chat(_ context.Context, _ llm.ChatRequest) (llm.ChatResponse, error) {
+	if m.callIdx < len(m.responses) {
+		resp := m.responses[m.callIdx]
+		m.callIdx++
+		return resp, nil
+	}
+	return llm.ChatResponse{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"fallback"}`}}, nil
+}
+
+func newMsgPropTestInvestigator(client llm.Client) *Investigator {
+	return New(Config{
+		Client:     client,
+		Logger:     logr.Discard(),
+		MaxTurns:   10,
+		PhaseTools: DefaultPhaseToolMap(),
+		AuditStore: msgPropNopAuditStore{},
+	})
+}
+
+var _ = Describe("#1936: runLoopTurn's final TextResult must carry accumulated message history", func() {
+
+	Describe("UT-KA-1936-002: TextResult carries prior tool-call/tool-result turns", func() {
+		It("populates Messages when the final response is plain text with no tool call", func() {
+			client := &msgPropMockClient{
+				responses: []llm.ChatResponse{
+					{
+						Message: llm.Message{Role: "assistant", Content: "Investigating..."},
+						ToolCalls: []llm.ToolCall{
+							{ID: "tc_1", Name: "kubectl_logs", Arguments: `{"name":"api-server","namespace":"prod"}`},
+						},
+					},
+					{
+						Message: llm.Message{Role: "assistant", Content: "Plain-text analysis with no tool call."},
+					},
+				},
+			}
+			inv := newMsgPropTestInvestigator(client)
+
+			initial := []llm.Message{
+				{Role: "system", Content: "system prompt"},
+				{Role: "user", Content: "Investigate: critical api-server in prod"},
+			}
+			res, err := inv.runLLMLoop(context.Background(), initial, katypes.PhaseRCA, LLMInvocationContext{
+				CorrelationID: "corr-1936-002",
+				Client:        client,
+				ModelName:     "test-model",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			tr, ok := res.(*TextResult)
+			Expect(ok).To(BeTrue(), "expected a TextResult when the LLM responds with plain text and no tool call")
+
+			Expect(tr.Messages).NotTo(BeEmpty(),
+				"UT-KA-1936-002: TextResult.Messages must carry the accumulated history (#1935/#1945 root cause #2, main port)")
+
+			var sawToolResult bool
+			for _, msg := range tr.Messages {
+				if msg.Role == "tool" && msg.ToolName == "kubectl_logs" {
+					sawToolResult = true
+				}
+			}
+			Expect(sawToolResult).To(BeTrue(), "UT-KA-1936-002: Messages must include the earlier kubectl_logs tool_result turn")
+		})
+	})
+})

--- a/internal/kubernautagent/investigator/investigator_rca.go
+++ b/internal/kubernautagent/investigator/investigator_rca.go
@@ -50,6 +50,14 @@ func (inv *Investigator) runRCA(ctx context.Context, signal katypes.SignalContex
 	if err != nil {
 		return nil, err
 	}
+	// #1935/#1936 root cause #2: runLLMLoop's accumulated tool-call history
+	// must flow back into messages before it feeds alignment.NotifyRCAComplete,
+	// retryRCASubmit, sameKindValidationGate, and apiVersionValidationGate
+	// below — otherwise all four operate on a stale [system, user]-only slice
+	// regardless of how many tools actually ran.
+	if extended := loopResultMessages(loopRes); len(extended) > 0 {
+		messages = extended
+	}
 
 	alignment.NotifyRCAComplete(ctx, messages)
 

--- a/internal/kubernautagent/investigator/investigator_workflow_selection.go
+++ b/internal/kubernautagent/investigator/investigator_workflow_selection.go
@@ -66,6 +66,16 @@ func (inv *Investigator) runWorkflowSelection(ctx context.Context, signal katype
 	if err != nil {
 		return nil, err
 	}
+	// #1935/#1936 root cause #2 (workflow-discovery extension, #1945):
+	// runLLMLoop's accumulated tool-call history must flow back into
+	// messages before it feeds handleWorkflowSelectionLoopResult (and, via
+	// it, retryWorkflowSubmit's two call sites and selfCorrectWorkflowSelection
+	// below) — otherwise every retry/self-correction attempt operates on a
+	// stale [system, user]-only slice regardless of how many
+	// list_available_actions/list_workflows calls actually ran.
+	if extended := loopResultMessages(loopRes); len(extended) > 0 {
+		messages = extended
+	}
 
 	content, early := inv.handleWorkflowSelectionLoopResult(ctx, loopRes, rcaSummary, messages, llmCtx)
 	if early != nil {
@@ -297,6 +307,15 @@ func (inv *Investigator) runSelfCorrectionAttempt(ctx context.Context, r *katype
 	corrLoopRes, corrErr := inv.runLLMLoop(ctx, state.messages, katypes.PhaseWorkflowDiscovery, llmCtx)
 	if corrErr != nil {
 		return nil, corrErr
+	}
+	// #1945 (main port #1936): the nested loop's accumulated tool-call
+	// history must flow back into state.messages before the next
+	// self-correction attempt's request is built from it — otherwise
+	// attempt N+1 is missing every tool call made during attempt N's own
+	// nested loop (list_workflows, etc.), independent of the top-level
+	// reassignment in runWorkflowSelection above.
+	if extended := loopResultMessages(corrLoopRes); len(extended) > 0 {
+		state.messages = extended
 	}
 	return inv.classifySelfCorrectionLoopResult(corrLoopRes, r, state, rcaSummary)
 }

--- a/internal/kubernautagent/investigator/workflow_history_propagation_1936_test.go
+++ b/internal/kubernautagent/investigator/workflow_history_propagation_1936_test.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// #1936 (main port of #1935 root cause #2, workflow-discovery extension
+// #1945; BR-AUDIT-005 v2.0, FedRAMP AU-3/CC7.2/CC8.1): runWorkflowSelection's
+// local `messages` variable is never reassigned from runLLMLoop's result,
+// so retryWorkflowSubmit and the self-correction closure both operate on a
+// stale [system, user]-only history regardless of how many workflow-
+// discovery tools (list_available_actions, list_workflows) the LLM actually
+// called. These specs prove the wiring fix end to end through the real
+// Investigate() production path, reusing the gateMockLLMClient/
+// gateRecordingAuditStore/gateK8sClient/gateDSClient/stubCatalogFetcher
+// helpers already established on main (apiversion_gate_test.go,
+// wiring_test.go).
+var _ = Describe("#1936: workflow-discovery retries must include real tool-call history", func() {
+
+	var (
+		logger     logr.Logger
+		auditStore *gateRecordingAuditStore
+		mockClient *gateMockLLMClient
+		builder    *prompt.Builder
+		rp         *parser.ResultParser
+		enricher   *enrichment.Enricher
+		phaseTools katypes.PhaseToolMap
+		signal     katypes.SignalContext
+	)
+
+	BeforeEach(func() {
+		logger = logr.Discard()
+		auditStore = &gateRecordingAuditStore{}
+		mockClient = &gateMockLLMClient{}
+		builder, _ = prompt.NewBuilder()
+		rp = parser.NewResultParser()
+		enricher = enrichment.NewEnricher(&gateK8sClient{}, &gateDSClient{}, auditStore, logger)
+		phaseTools = investigator.DefaultPhaseToolMap()
+		signal = katypes.SignalContext{
+			ResourceKind: "Pod",
+			ResourceName: "api-server-xyz",
+			Name:         "api-server-xyz",
+			Namespace:    "production",
+			Severity:     "critical",
+			Message:      "Pod OOMKilled repeatedly",
+		}
+	})
+
+	// wfToolCallMessages inspects a captured llm.ChatRequest for tool-call/
+	// tool-result turns matching the given tool name (mirrors
+	// gate_history_propagation_1936_test.go's toolCallMessages helper).
+	wfToolCallMessages := func(req llm.ChatRequest, toolName string) (sawCall, sawResult bool) {
+		for _, msg := range req.Messages {
+			for _, tc := range msg.ToolCalls {
+				if tc.Name == toolName {
+					sawCall = true
+				}
+			}
+			if msg.Role == "tool" && msg.ToolName == toolName {
+				sawResult = true
+			}
+		}
+		return sawCall, sawResult
+	}
+
+	Describe("IT-KA-1936-007: retryWorkflowSubmit retry includes prior tool-call turns", func() {
+		It("sends the earlier list_available_actions tool_use/tool_result pair as part of the retry request", func() {
+			mockClient.responses = []llm.ChatResponse{
+				// Turn 0 (RCA phase): parseable, no tool calls needed.
+				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"Pod OOMKilled","confidence":0.85}`}},
+				// Turn 1 (workflow-discovery, top-level loop turn 0): real tool call.
+				{
+					Message: llm.Message{Role: "assistant", Content: "Checking available actions..."},
+					ToolCalls: []llm.ToolCall{
+						{ID: "tc_1", Name: "list_available_actions", Arguments: `{}`},
+					},
+				},
+				// Turn 2 (workflow-discovery, top-level loop turn 1): unparseable
+				// plain text final response — triggers retryWorkflowSubmit.
+				{Message: llm.Message{Role: "assistant", Content: "I could not determine a matching workflow from the available actions."}},
+				// Turn 3: the actual parse-retry LLM call under test.
+				gateWfToolResp(`{"workflow_id":"restart-pod","confidence":0.9}`),
+			}
+
+			// investigator.New (not newTestInvestigator): a nil
+			// CatalogFetcher makes the final selection fail closed after
+			// the retry under test has already been captured, isolating
+			// this spec to the retryWorkflowSubmit history-propagation
+			// behavior (matches #1945's precedent).
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+			})
+
+			_, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(len(mockClient.calls)).To(BeNumerically(">=", 4),
+				"IT-KA-1936-007: expected RCA + WD tool-call turn + WD final text turn + parse-retry LLM calls")
+			retryReq := mockClient.calls[3]
+
+			sawCall, sawResult := wfToolCallMessages(retryReq, "list_available_actions")
+			Expect(sawCall).To(BeTrue(),
+				"IT-KA-1936-007: workflow-discovery parse-retry must include the earlier list_available_actions tool_use turn (#1936)")
+			Expect(sawResult).To(BeTrue(),
+				"IT-KA-1936-007: workflow-discovery parse-retry must include the paired tool_result turn (#1936)")
+		})
+	})
+
+	Describe("IT-KA-1936-008: self-correction second attempt includes first attempt's nested tool-call turn", func() {
+		It("sends the first correction attempt's own list_workflows tool_use/tool_result pair as part of the second attempt's request", func() {
+			mockClient.responses = []llm.ChatResponse{
+				// Turn 0 (RCA phase): parseable, no tool calls needed.
+				{Message: llm.Message{Role: "assistant", Content: `{"rca_summary":"Pod OOMKilled","confidence":0.85}`}},
+				// Turn 1 (workflow-discovery, top-level loop turn 0): LLM
+				// immediately submits a hallucinated workflow_id — parses
+				// fine but fails catalog validation, triggering self-correction
+				// attempt 1.
+				gateWfToolResp(`{"workflow_id":"invalid-wf","confidence":0.7}`),
+				// Turn 2 (self-correction attempt 1, nested loop turn 0): real
+				// tool call made DURING the correction attempt itself.
+				{
+					Message: llm.Message{Role: "assistant", Content: "Let me check the workflow catalog again..."},
+					ToolCalls: []llm.ToolCall{
+						{ID: "tc_wf_list", Name: "list_workflows", Arguments: `{}`},
+					},
+				},
+				// Turn 3 (self-correction attempt 1, nested loop turn 1): still
+				// invalid — attempt 1 fails validation too, triggering attempt 2.
+				gateWfToolResp(`{"workflow_id":"invalid-wf-2","confidence":0.7}`),
+				// Turn 4: self-correction attempt 2's request — the one under
+				// test. Resolves to a valid workflow so SelfCorrect terminates.
+				gateWfToolResp(`{"workflow_id":"valid-wf","confidence":0.9}`),
+			}
+
+			validator := parser.NewValidator([]string{"valid-wf"})
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: rp,
+				Enricher: enricher, AuditStore: auditStore, Logger: logger,
+				MaxTurns: 15, PhaseTools: phaseTools,
+				Pipeline: investigator.Pipeline{
+					CatalogFetcher: &stubCatalogFetcher{validator: validator},
+				},
+			})
+
+			result, err := inv.Investigate(context.Background(), signal)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.WorkflowID).To(Equal("valid-wf"), "self-correction must converge on the valid workflow")
+
+			Expect(len(mockClient.calls)).To(BeNumerically(">=", 5),
+				"IT-KA-1936-008: expected RCA + top-level submit + 2 self-correction attempts (1 nested tool-call turn + 3 submit turns)")
+			secondAttemptReq := mockClient.calls[4]
+
+			sawCall, sawResult := wfToolCallMessages(secondAttemptReq, "list_workflows")
+			Expect(sawCall).To(BeTrue(),
+				"IT-KA-1936-008: self-correction attempt 2's request must include attempt 1's own list_workflows tool_use turn (#1936), "+
+					"not just the top-level [system, user] + correction messages")
+			Expect(sawResult).To(BeTrue(),
+				"IT-KA-1936-008: self-correction attempt 2's request must include the paired tool_result turn (#1936)")
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Ports the message-staleness fix to `main`, which was originally split across two `release/v1.5` PRs:

- #1939 (#1935) — RCA phase (`runRCA`)
- #1947 (#1945) — Workflow-discovery phase (`runWorkflowSelection` + self-correction)

`main`'s `LoopResult` types (`SubmitResult`, `TextResult`, `SubmitWithWorkflowResult`, `SubmitNoWorkflowResult`) lacked a `Messages` field entirely, so this is a from-scratch application of the same fix shape rather than a straight cherry-pick:

- Add `Messages []llm.Message` to all four `LoopResult` types; thread `messages` through `sentinelResult`.
- Add `loopResultMessages()` covering all four message-carrying types (plus `CancelledResult`/`ExhaustedResult`).
- Reassign `messages` from the loop result immediately after every `runLLMLoop` call that previously kept a stale local copy: `runRCA`, `runWorkflowSelection`'s top-level call, and the self-correction closure's nested call.
- `alignment.renderConversation` now renders `msg.Reasoning.Text` alongside `msg.Content`, so the shadow agent's grounding review sees the same thinking text the console now displays (parity with the #1935 fix).

Without this, validation-gate retries, workflow-discovery retries, and self-correction attempts on `main` silently drop every tool-call turn the LLM made — the retry/self-correction LLM request only ever contains `[system, user]` plus a correction message, never the intervening tool calls. This also means the `audit.StoreBestEffort` records computed from that same stale slice (AU-3) and remediation-request reconstruction (CC8.1, BR-AUDIT-005 v2.0) misrepresent what was actually sent to the LLM.

Closes #1936.

## Test plan

Full IEEE-829-hybrid test plan: `docs/testing/1936/TEST_PLAN.md`.

- UT-KA-1936-001/002/003 (unit): `sentinelResult` populates `Messages` on all three sentinel types; `runLoopTurn`'s final `TextResult` carries prior tool-call turns; `loopResultMessages` covers all six `LoopResult` types.
- IT-KA-1936-004/005 (integration): `sameKindValidationGate`/`apiVersionValidationGate` retries include prior tool-call turns, through the real `Investigate` -> `runRCA` -> `runLLMLoop` -> gate-retry path.
- IT-KA-1936-006 (integration): shadow agent's grounding request includes tool-call history and `Reasoning.Text`.
- IT-KA-1936-007/008 (integration): `retryWorkflowSubmit` retry and the second self-correction attempt include prior tool-call turns.

Validated via:
- [x] `make test` — all 12 service unit suites pass (0 failures), including `internal/kubernautagent/...`
- [x] `go build ./...`
- [x] `golangci-lint run --timeout=5m` — 0 new issues (19 pre-existing issues, all in unrelated `docs/spikes`/`scripts/validation`/`hack` files, confirmed unchanged via `git stash`)
- [x] `make lint-rules` sub-targets — pre-existing baseline violations only (1770/1770 identical with changes stashed vs. applied for `lint-test-patterns`; orphaned-type and non-BDD findings for `lint-business-integration`/`lint-tdd-compliance` all outside `kubernautagent`; `lint-openapi-crd-drift` failure is pre-existing and unrelated to any CRD/OpenAPI file touched here)

Made with [Cursor](https://cursor.com)