### PR TITLE
[DO NOT MERGE] diag(#1949): step-level tracing for response-loss re-repro

### DIFF
--- a/internal/kubernautagent/mcp/tools/investigate.go
+++ b/internal/kubernautagent/mcp/tools/investigate.go
@@ -848,6 +848,16 @@ func (t *InvestigateTool) handleReconnect(input InvestigateInput, user mcpintern
 }
 
 func (t *InvestigateTool) handleDiscoverWorkflows(ctx context.Context, input InvestigateInput, user mcpinternal.UserInfo) (InvestigateOutput, error) {
+	// #1949 retest diagnostics: bracket every step from RunWorkflowDiscovery
+	// returning through the final return with elapsed-time markers. The
+	// 2026-08-06 retest showed KA's own business logic (LLM loop, catalog
+	// validation) completing normally but the tool-call response never
+	// reaching AF — this narrows down whether that gap is inside this
+	// handler (post-loop) or in response delivery after it returns.
+	// Temporary instrumentation for the #1949 follow-up investigation; safe
+	// to remove once the exact drop point is confirmed.
+	handlerStart := time.Now()
+
 	mu := t.getSessionMutex(input.RRID)
 	mu.Lock()
 	defer mu.Unlock()
@@ -977,6 +987,12 @@ func (t *InvestigateTool) handleDiscoverWorkflows(ctx context.Context, input Inv
 	if err != nil {
 		return InvestigateOutput{}, fmt.Errorf("workflow discovery failed: %w", err)
 	}
+	t.logger.Info("discover_workflows: RunWorkflowDiscovery returned",
+		"rr_id", input.RRID,
+		"session_id", sess.SessionID,
+		"workflow_id", workflowResult.WorkflowID,
+		"human_review_needed", workflowResult.HumanReviewNeeded,
+		"elapsed_since_handler_start", time.Since(handlerStart).String())
 
 	// Step 5: Store results on the interactive session.
 	sess.RCAResult = rcaResult
@@ -1008,19 +1024,35 @@ func (t *InvestigateTool) handleDiscoverWorkflows(ctx context.Context, input Inv
 	}
 
 	// Enrich workflow names from catalog.
+	enrichStart := time.Now()
 	t.enrichDiscoveryNames(ctx, sess.DiscoveryResult)
+	t.logger.Info("discover_workflows: enrichDiscoveryNames completed",
+		"rr_id", input.RRID,
+		"session_id", sess.SessionID,
+		"enrich_duration", time.Since(enrichStart).String(),
+		"elapsed_since_handler_start", time.Since(handlerStart).String())
 
 	// Reset inactivity timer after the LLM calls complete.
 	t.sessions.TouchActivity(input.RRID)
 	if t.timeoutTracker != nil {
 		t.timeoutTracker.ResetInactivity(sess.SessionID)
 	}
+	t.logger.Info("discover_workflows: post-completion inactivity timer reset",
+		"rr_id", input.RRID,
+		"session_id", sess.SessionID,
+		"elapsed_since_handler_start", time.Since(handlerStart).String())
 
 	// Build the JSON response for the user.
 	discoveryJSON, err := json.Marshal(sess.DiscoveryResult)
 	if err != nil {
 		return InvestigateOutput{}, fmt.Errorf("marshal discovery result: %w", err)
 	}
+
+	t.logger.Info("discover_workflows: returning response to caller",
+		"rr_id", input.RRID,
+		"session_id", sess.SessionID,
+		"response_bytes", len(discoveryJSON),
+		"elapsed_since_handler_start", time.Since(handlerStart).String())
 
 	return InvestigateOutput{
 		SessionID: sess.SessionID,
@@ -1085,12 +1117,18 @@ func (t *InvestigateTool) resolveWorkflowName(ctx context.Context, workflowID st
 	if workflowID == "" {
 		return ""
 	}
+	// #1949 retest diagnostics: log the catalog HTTP round-trip duration.
+	// Temporary instrumentation for the #1949 follow-up investigation.
+	lookupStart := time.Now()
 	wf, err := t.catalog.GetWorkflowByID(ctx, workflowID)
+	lookupDuration := time.Since(lookupStart)
 	if err != nil {
 		t.logger.V(1).Info("catalog lookup failed for workflow name enrichment",
-			"workflow_id", workflowID, "error", err)
+			"workflow_id", workflowID, "error", err, "lookup_duration", lookupDuration.String())
 		return ""
 	}
+	t.logger.Info("discover_workflows: catalog lookup for name enrichment completed",
+		"workflow_id", workflowID, "lookup_duration", lookupDuration.String())
 	return wf.WorkflowName
 }
 


### PR DESCRIPTION
## Purpose

**This PR is a throwaway diagnostic build — do not merge.** It exists solely to
get CI to build and push an image tagged `pr-<this PR number>` for QE to
pull and re-run the #1949 repro scenario, per the request in
https://github.com/jordigilh/kubernaut/issues/1949#issuecomment-5199395443.

## Background

The 2026-08-06 retest showed the original #1949 fix (#1951) is not regressed:
KA's own business logic for the hung session (LLM loop, catalog validation)
completed in well under a second (`01:19:15`), yet the console/AF still
observed a ~10 minute hang before any response reached it. This points to
the `discover_workflows` tool-call response being computed successfully
inside KA but lost somewhere in the transport/session-reuse layer *after*
KA's handler logic finishes — a different bug class than the original
missing-timeout hang.

## What this adds

Structured `Info`-level log lines (with elapsed-time markers, all
prefixed `discover_workflows:`) bracketing every step of
`handleDiscoverWorkflows` from `RunWorkflowDiscovery` returning through
the final response marshal, plus the catalog `GetWorkflowByID` round-trip
duration in `resolveWorkflowName`:

1. Immediately after `RunWorkflowDiscovery` returns (workflow_id, elapsed)
2. Immediately after `enrichDiscoveryNames` completes (enrich duration, elapsed)
3. Immediately after the post-completion `ResetInactivity` call (elapsed)
4. Immediately before returning the marshaled JSON response (response size, elapsed)
5. Around each catalog `GetWorkflowByID` call (lookup duration)

These markers make it possible to confirm from KA logs alone whether the
handler returned promptly (supporting the transport/session-layer-loss
hypothesis) or stalled internally at one of these steps (which would
point back at KA).

## Requested QE action

Re-run the repro scenario against this build with:
- KA logs captured (these new step-level markers)
- A simultaneous AF-side goroutine dump taken while the session appears hung

so we can pinpoint exactly where the response is lost before scoping a fix.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./internal/kubernautagent/mcp/tools/...`
- [x] `go test ./internal/kubernautagent/mcp/tools/...` (all existing tests pass, no behavior change)
- [x] `golangci-lint run` on the changed package (0 issues)
- [ ] QE re-repro with this image + AF-side goroutine dump

No new tests added — this is temporary logging instrumentation, not a
behavioral fix, so it is exempt from the TDD/pyramid-invariant gates that
apply to functional changes.

Made with [Cursor](https://cursor.com)