### PR TITLE
fix(af): backport #1493 — accept bare RAR names in kubernaut_get_approval_request

### DIFF
--- a/docs/tests/1493/TEST_PLAN.md
+++ b/docs/tests/1493/TEST_PLAN.md
@@ -1,0 +1,117 @@
+# Test Plan: Fix RAR Resource ID Format Mismatch (Issue #1493)
+
+**Service**: apifrontend
+**Version**: 1.0
+**Created**: 2026-06-24
+**Author**: AI Assistant
+**Status**: Approved
+**Business Requirement**: BR-API-1493
+
+---
+
+## 1. Purpose
+
+Validate that the `kubernaut_get_approval_request` MCP tool accepts bare RAR names
+(as emitted by status subscription metadata) and that `BuildPhaseMetadata` emits
+`approval_request_name` in `namespace/name` format for defense-in-depth.
+
+## 2. Objectives
+
+- Fix the semantic contract mismatch between metadata producer and tool consumer
+- Maintain backward compatibility with `namespace/name` format in `rar_id`
+- Ensure no regressions in existing approval request flows
+
+## 3. Success Metrics
+
+- All UT, IT tests pass
+- Existing `UT-AF-109-*` tests remain green (backward compatibility)
+- Existing `E2E-AF-1398-*` tests remain green (approval event journey)
+- `go build ./...` clean, `golangci-lint` clean
+
+## 4. Scope
+
+### In Scope
+
+- `ParseRARID` function: tolerant parser accepting bare names and `namespace/name`
+- `HandleGetApprovalRequest`: wiring to use `ParseRARID`
+- `BuildPhaseMetadata`: emit `namespace/name` in `approval_request_name`
+- Removal of unused `ParseResourceID`
+
+### Out of Scope
+
+- Console-side changes (`kubernaut-console` repo)
+- E2E test additions (existing `E2E-AF-1398-001` covers the journey)
+
+## 5. FedRAMP / SOC2 Control Mapping
+
+| Control | Relevance | Verification |
+|---------|-----------|--------------|
+| AU-3 (Audit Content) | `approval_request_name` metadata used in audit trails | UT-AF-1493-006 verifies namespace prefix for traceability |
+| SC-7 (Boundary Protection) | Server-side namespace injection prevents client namespace spoofing | IT-AF-1493-001 proves injected namespace is used |
+| SI-4 (System Monitoring) | Status events carry correct resource identifiers | IT-AF-1493-002 proves namespace/name in metadata |
+
+## 6. BR Coverage Matrix
+
+| BR ID | Description | Priority | Test Type | Test ID | Status |
+|-------|-------------|----------|-----------|---------|--------|
+| BR-API-1493 | ParseRARID: bare name resolution | P0 | Unit | UT-AF-1493-001 | Pending |
+| BR-API-1493 | ParseRARID: namespace/name passthrough | P0 | Unit | UT-AF-1493-002 | Pending |
+| BR-API-1493 | ParseRARID: fallback to explicit ns+name | P1 | Unit | UT-AF-1493-003 | Pending |
+| BR-API-1493 | ParseRARID: error on empty inputs | P1 | Unit | UT-AF-1493-004 | Pending |
+| BR-API-1493 | Handler accepts bare rar_id | P0 | Unit | UT-AF-1493-005 | Pending |
+| BR-API-1493 | Metadata includes namespace prefix | P0 | Unit | UT-AF-1493-006 | Pending |
+| BR-API-1493 | Bare rar_id wired through handler to K8s | P0 | Integration | IT-AF-1493-001 | Pending |
+| BR-API-1493 | Namespace prefix in BuildPhaseMetadata | P0 | Integration | IT-AF-1493-002 | Pending |
+
+## 7. Test Scenarios
+
+### 7.1 Happy Path Tests
+
+| Test ID | Description | Input | Expected Output |
+|---------|-------------|-------|-----------------|
+| UT-AF-1493-001 | Bare RAR name resolves with injected namespace | `rarID="rar-oom-1"`, `ns="payments"` | `("payments", "rar-oom-1", nil)` |
+| UT-AF-1493-002 | namespace/name format passes through | `rarID="payments/rar-oom-1"` | `("payments", "rar-oom-1", nil)` |
+| UT-AF-1493-003 | Empty rar_id uses explicit fallback | `rarID=""`, `ns="pay"`, `name="rar-1"` | `("pay", "rar-1", nil)` |
+| UT-AF-1493-005 | Handler returns full RAR with bare rar_id | `RARID="rar-oom-1"`, `Namespace="payments"` | Full RAR result |
+| IT-AF-1493-001 | Bare rar_id dispatches through handler to K8s | Same as UT-AF-1493-005 via production path | Full RAR result |
+
+### 7.2 Error Handling Tests
+
+| Test ID | Description | Input | Expected Output |
+|---------|-------------|-------|-----------------|
+| UT-AF-1493-004 | Empty rar_id + empty name | `rarID=""`, `name=""` | Error: "name is required" |
+
+### 7.3 Metadata Tests
+
+| Test ID | Description | Input | Expected Output |
+|---------|-------------|-------|-----------------|
+| UT-AF-1493-006 | AwaitingApproval emits namespace/name | RR with `Namespace="kubernaut-system"` | `"kubernaut-system/rar-<name>"` |
+| IT-AF-1493-002 | Namespace prefix flows through status path | Same RR through BuildPhaseMetadata | `"kubernaut-system/rar-<name>"` |
+
+## 8. Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | IT Test ID |
+|-----------|----------------------|---------------------|------------|
+| `ParseRARID` | `HandleGetApprovalRequest` | `crd_tools.go:341` | IT-AF-1493-001 |
+| `BuildPhaseMetadata` ns prefix | SSE status subscription | `status_types.go:116` | IT-AF-1493-002 |
+
+## 9. TDD Execution Order
+
+1. **Cycle 1** (UT): `ParseRARID` logic in `helpers_test.go`
+2. **Cycle 2** (IT+Wire): `HandleGetApprovalRequest` wiring in `kubernaut_get_approval_request_test.go`
+3. **Cycle 3** (UT+IT): `BuildPhaseMetadata` namespace prefix in `status_types_test.go`
+4. **Refactor**: Remove `ParseResourceID`, update `UT-AF-109-008`
+
+## 10. Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| Console expects bare `approval_request_name` | Option C (tolerant tool) ensures bare names still work even if console hasn't updated |
+| Other tools may use `ParseResourceID` in future | Confirmed zero callers; removal prevents future misuse |
+| E2E `E2E-AF-1398-001` may assert on bare name | Check test assertions; update if needed |
+
+## 11. Environment
+
+- Unit tests: `go test ./pkg/apifrontend/...`
+- Integration tests: `go test ./pkg/apifrontend/...` (same package, uses `fake.NewClientBuilder`)
+- E2E: existing `test/e2e/apifrontend/structured_approval_e2e_test.go`

--- a/pkg/apifrontend/tools/crd_tools.go
+++ b/pkg/apifrontend/tools/crd_tools.go
@@ -338,7 +338,7 @@ func HandleGetApprovalRequest(ctx context.Context, client crclient.Client, args 
 		return GetApprovalRequestResult{}, ErrK8sUnavailable
 	}
 
-	ns, name, err := ParseResourceID(args.RARID, args.Namespace, args.Name)
+	ns, name, err := ParseRARID(args.RARID, args.Namespace, args.Name)
 	if err != nil {
 		return GetApprovalRequestResult{}, err
 	}

--- a/pkg/apifrontend/tools/helpers.go
+++ b/pkg/apifrontend/tools/helpers.go
@@ -50,21 +50,23 @@ func ParseRRID(rrID, namespace, name string) (ns, n string, err error) {
 	return namespace, name, nil
 }
 
-// ParseResourceID parses a resource ID shorthand (namespace/name) into its components.
-// If resourceID is empty, namespace and name are returned as-is.
-func ParseResourceID(resourceID, namespace, name string) (ns, n string, err error) {
-	if resourceID != "" {
-		parts := strings.SplitN(resourceID, "/", 2)
-		if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-			return "", "", fmt.Errorf("invalid resource_id format %q: expected namespace/name", resourceID)
+// ParseRARID resolves rar_id to namespace and name. It accepts both bare names
+// (paired with the injected namespace) and "namespace/name" format for backward
+// compatibility. If rarID is empty, the explicit namespace and name arguments
+// are used as fallback.
+func ParseRARID(rarID, namespace, name string) (ns, n string, err error) {
+	if rarID != "" {
+		if parts := strings.SplitN(rarID, "/", 2); len(parts) == 2 && parts[0] != "" && parts[1] != "" {
+			return parts[0], parts[1], nil
 		}
-		return parts[0], parts[1], nil
+		return namespace, rarID, nil
 	}
-	if namespace == "" || name == "" {
-		return "", "", fmt.Errorf("namespace and name are required when resource_id is not provided")
+	if name == "" {
+		return "", "", fmt.Errorf("name is required when rar_id is not provided")
 	}
 	return namespace, name, nil
 }
+
 
 // ToUserFriendlyError translates K8s API errors into user-friendly messages.
 // Internal details (namespace paths, resource versions, field paths) are not exposed.

--- a/pkg/apifrontend/tools/helpers_test.go
+++ b/pkg/apifrontend/tools/helpers_test.go
@@ -88,6 +88,44 @@ var _ = Describe("ParseRRID — name-only rr_id format (#E2E-FIX)", func() {
 	})
 })
 
+var _ = Describe("ParseRARID — tolerant rar_id parser (#1493)", func() {
+
+	Describe("UT-AF-1493-001: bare name resolves with injected namespace", func() {
+		It("should pair bare rar_id with the explicit namespace argument", func() {
+			ns, name, err := tools.ParseRARID("rar-oom-1", "payments", "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ns).To(Equal("payments"))
+			Expect(name).To(Equal("rar-oom-1"))
+		})
+	})
+
+	Describe("UT-AF-1493-002: namespace/name format is accepted and split", func() {
+		It("should split on slash when rar_id contains namespace/name", func() {
+			ns, name, err := tools.ParseRARID("payments/rar-oom-1", "injected-ns", "")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ns).To(Equal("payments"))
+			Expect(name).To(Equal("rar-oom-1"))
+		})
+	})
+
+	Describe("UT-AF-1493-003: empty rar_id falls back to explicit namespace + name", func() {
+		It("should use explicit args when rar_id is empty", func() {
+			ns, name, err := tools.ParseRARID("", "pay", "rar-fallback-1")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(ns).To(Equal("pay"))
+			Expect(name).To(Equal("rar-fallback-1"))
+		})
+	})
+
+	Describe("UT-AF-1493-004: empty rar_id + empty name returns error", func() {
+		It("should require name when rar_id is not provided", func() {
+			_, _, err := tools.ParseRARID("", "ns", "")
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("name is required"))
+		})
+	})
+})
+
 var _ = Describe("IsTerminalPhase", func() {
 	DescribeTable("UT-AF-TERM-001: classifies phases correctly",
 		func(phase string, expected bool) {

--- a/pkg/apifrontend/tools/kubernaut_get_approval_request_test.go
+++ b/pkg/apifrontend/tools/kubernaut_get_approval_request_test.go
@@ -105,7 +105,7 @@ var _ = Describe("kubernaut_get_approval_request", func() {
 		Expect(err.Error()).To(ContainSubstring("invalid input"))
 	})
 
-	It("UT-AF-109-008: invalid rar_id format returns error", func() {
+	It("UT-AF-109-008: bare rar_id without namespace returns not-found (no matching RAR)", func() {
 		tc := newTypedFakeClient()
 		_, err := tools.HandleGetApprovalRequest(ctx, tc, tools.GetApprovalRequestArgs{
 			RARID: "bad-format-no-slash",
@@ -128,6 +128,31 @@ var _ = Describe("kubernaut_get_approval_request", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.RecommendedWorkflow.Name).To(Equal("oomkill-increase-memory-v1"))
 		Expect(result.RecommendedWorkflow.Version).To(Equal("1.0.0"))
+	})
+
+	It("UT-AF-1493-005: returns full RAR detail with bare rar_id and injected namespace", func() {
+		tc := newTypedFakeClient(newTypedDetailedRAR("payments", "rar-oom-1"))
+		result, err := tools.HandleGetApprovalRequest(ctx, tc, tools.GetApprovalRequestArgs{
+			RARID:     "rar-oom-1",
+			Namespace: "payments",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Name).To(Equal("rar-oom-1"))
+		Expect(result.Namespace).To(Equal("payments"))
+		Expect(result.RemediationRequest).To(Equal("rr-oom-1"))
+	})
+
+	It("IT-AF-1493-001: bare rar_id dispatches through handler to K8s lookup", func() {
+		tc := newTypedFakeClient(newTypedDetailedRAR("payments", "rar-oom-1"))
+		result, err := tools.HandleGetApprovalRequest(ctx, tc, tools.GetApprovalRequestArgs{
+			RARID:     "rar-oom-1",
+			Namespace: "payments",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Name).To(Equal("rar-oom-1"))
+		Expect(result.Namespace).To(Equal("payments"))
+		Expect(result.Confidence).To(BeNumerically("~", 0.72, 0.001))
+		Expect(result.EvidenceCollected).To(HaveLen(2))
 	})
 
 	Context("ADVERSARIAL tests", func() {


### PR DESCRIPTION
## Summary

Backports `c083673f5` (#1493) to `release/v1.5`. That fix was merged to `main` on 2026-06-25 but never ported to `release/v1.5`, leaving the strict, pre-fix `ParseResourceID` live on this branch.

- Adds `ParseRARID`, a tolerant parser that accepts both bare RAR names (paired with the injected namespace) and `namespace/name` format
- Replaces the strict `ParseResourceID` (which required `namespace/name` and rejected bare names) at its single call site in `HandleGetApprovalRequest`
- Removes `ParseResourceID` (zero remaining callers on `release/v1.5`, confirmed via `git grep`)
- Carries the original BR-API-1493 test plan and unit tests unmodified

Closes #1957

## Root cause

`release/v1.5`'s `kubernaut_get_approval_request` MCP tool rejects bare RAR names like `rar-rr-6d620a1e06da-97638681` with `invalid resource_id format ... expected namespace/name`, even though status-subscription metadata emits bare names. This is currently causing kubernaut-console's `approval-gate.spec.ts` "approve path" and "decline path" E2E tests to fail with a 100% hit rate, and had been briefly misattributed to a recurrence of the (already-fixed) #278/#1869 RBAC gap before being traced to this unported fix.

## Verification performed

- Confirmed `c083673f5` is not an ancestor of `origin/release/v1.5` prior to this PR
- Confirmed `release/v1.5` had exactly one caller of `ParseResourceID` (`crd_tools.go`), matching main's post-fix "zero remaining callers" state — safe removal
- Dry-run cherry-picked in an isolated worktree first: applied with zero conflicts
- `go build ./pkg/apifrontend/...` — clean
- `go test ./pkg/apifrontend/tools/...` — all pass

## Test plan

- [x] `go build ./pkg/apifrontend/...`
- [x] `go test ./pkg/apifrontend/tools/...` (includes ported `ParseRARID` unit tests and `kubernaut_get_approval_request` tests)
- [ ] Re-run kubernaut-console `approval-gate.spec.ts` against this branch to confirm the E2E failure is resolved


Made with [Cursor](https://cursor.com)