### PR TITLE
fix(af): simplify ParseRARID to bare-name-only, matching ParseRRID

### DIFF
--- a/docs/tests/1493/TEST_PLAN.md
+++ b/docs/tests/1493/TEST_PLAN.md
@@ -7,6 +7,8 @@
 **Status**: Approved
 **Business Requirement**: BR-API-1493
 
+> **⚠️ Superseded in part by [#1959](https://github.com/jordigilh/kubernaut/issues/1959)**: the `namespace/name` tolerance in `ParseRARID` (`UT-AF-1493-002`) and the `approval_request_name` namespace prefix in `BuildPhaseMetadata` (added by a sibling commit for #1492) were found to be redundant per **ADR-057** (all RARs live in the controller namespace) and inconsistent with the `ParseRRID` bare-name-only precedent (`2bfd24c31`). See `docs/tests/1959/TEST_PLAN.md` for the correction. The bare-name acceptance fix below remains valid and is preserved.
+
 ---
 
 ## 1. Purpose

--- a/docs/tests/1959/TEST_PLAN.md
+++ b/docs/tests/1959/TEST_PLAN.md
@@ -1,0 +1,95 @@
+# Test Plan: Simplify ParseRARID to Bare-Name-Only (Issue #1959)
+
+**Service**: apifrontend
+**Version**: 1.0
+**Created**: 2026-08-06
+**Author**: AI Assistant
+**Status**: Approved
+**Business Requirement**: BR-API-1493 (amends #1493)
+
+---
+
+## 1. Purpose
+
+Remove the redundant `namespace/name` tolerance from `ParseRARID` and the
+redundant namespace prefix from `BuildPhaseMetadata`'s `approval_request_name`,
+so `rar_id` handling matches the bare-name-only precedent already established
+for `rr_id` (`ParseRRID`, `2bfd24c31`).
+
+## 2. Background
+
+`#1493` (`c083673f5`) fixed a real bug (tool rejected bare RAR names) but also
+added `namespace/name` tolerance "for backward compatibility." A sibling
+commit (`cdbdf2452`, #1492) bundled in a change making `BuildPhaseMetadata`
+emit `approval_request_name` as `namespace/name` "for defense-in-depth."
+
+Per **ADR-057** (CRD Namespace Consolidation), every `RemediationApprovalRequest`
+is always created in the single controller namespace — there is no legitimate
+scenario where a RAR's namespace differs from `controllerNS`. The
+`namespace/name` branch in `ParseRARID` therefore could never resolve
+anything the bare-name branch (using the injected, trusted `controllerNS`)
+couldn't already resolve, and it introduced a minor trust-boundary
+inconsistency: it used the caller-supplied namespace segment instead of the
+injected `controllerNS`.
+
+The kubernaut-console `ChatContainer.tsx` passes `approval_request_name`
+through to `rar_id` verbatim (no parsing), so this change requires **no
+console-side update** — see jordigilh/kubernaut-console#57 for the console's
+own, unrelated follow-up (error-type differentiation in the graceful
+degradation card).
+
+## 3. Objectives
+
+- `ParseRARID` becomes structurally identical to `ParseRRID`: bare-name-only,
+  namespace always sourced from the injected argument
+- `BuildPhaseMetadata` emits `approval_request_name` as a bare name
+- Preserve the legitimate bare-name-acceptance fix from #1493
+- No regressions in existing approval request flows; no console changes
+
+## 4. Scope
+
+### In Scope
+
+- `ParseRARID` (`helpers.go`): drop the `namespace/name` split branch
+- `BuildPhaseMetadata` (`status_types.go`): revert `approval_request_name` to
+  bare name (only this one line from `cdbdf2452`/#1492 — its unrelated
+  Kind/Name `target` display format change is untouched)
+- Adversarial tests proving a `rar_id` containing `/` is now rejected as an
+  invalid K8s resource name rather than reinterpreted as `namespace/name`
+
+### Out of Scope
+
+- Console-side changes (none required)
+- `cdbdf2452`'s Kind/Name display format work (unrelated, stays as-is)
+
+## 5. BR Coverage Matrix
+
+| BR ID | Description | Priority | Test Type | Test ID | Status |
+|-------|-------------|----------|-----------|---------|--------|
+| BR-API-1493 | `ParseRARID`: bare name resolution (unchanged) | P0 | Unit | UT-AF-1493-001 | Pass |
+| BR-API-1493 | `ParseRARID`: rar_id with slash is NOT split (name-only) | P0 | Unit | UT-AF-1959-002 | Pass |
+| BR-API-1493 | `ParseRARID`: fallback to explicit ns+name (unchanged) | P1 | Unit | UT-AF-1493-003 | Pass |
+| BR-API-1493 | `ParseRARID`: error on empty inputs (unchanged) | P1 | Unit | UT-AF-1493-004 | Pass |
+| BR-API-1493 | Metadata `approval_request_name` is bare name | P0 | Unit | UT-AF-1959-001 | Pass |
+| BR-API-1493 | Bare name holds regardless of RR namespace | P1 | Unit | UT-AF-1959-002 (handler) | Pass |
+| BR-API-1493 | Handler resolves bare rar_id shorthand | P0 | Unit | UT-AF-1959-003 | Pass |
+| BR-API-1493 | rar_id with embedded namespace no longer overrides injected namespace | P0 | Adversarial | ADV-AF-1959-006 | Pass |
+
+## 6. Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | Test ID |
+|---|---|---|---|
+| `ParseRARID` (simplified) | `HandleGetApprovalRequest` | `crd_tools.go` | UT-AF-1959-003 |
+| `BuildPhaseMetadata` (bare name) | SSE status subscription | `status_types.go` | UT-AF-1959-001 |
+
+## 7. Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| A production caller relied on `namespace/name` shorthand | Confirmed only producer was `BuildPhaseMetadata` (being fixed) and the console passes values through verbatim (confirmed by reading `ChatContainer.tsx`) — no other producer exists |
+| release/v1.5 divergence | `release/v1.5` never received `cdbdf2452`'s metadata change, so only needs the `ParseRARID` simplification (tracked separately) |
+
+## 8. Environment
+
+- Unit tests: `go test ./pkg/apifrontend/...`
+- `go build ./...` clean

--- a/pkg/apifrontend/handler/status_types.go
+++ b/pkg/apifrontend/handler/status_types.go
@@ -95,8 +95,11 @@ func addPhaseSpecificMetadata(meta map[string]any, rr *remediationv1.Remediation
 	case remediationv1.PhaseBlocked:
 		addBlockedPhaseMetadata(meta, rr)
 	case remediationv1.PhaseAwaitingApproval:
-		rarName := fmt.Sprintf("rar-%s", rr.Name)
-		meta["approval_request_name"] = rr.Namespace + "/" + rarName
+		// #1959: bare name only — every RAR lives in the controller namespace
+		// (ADR-057), so a namespace prefix here is redundant. ParseRARID
+		// resolves rar_id the same way ParseRRID resolves rr_id: namespace
+		// always comes from the injected controllerNS, never from the ID.
+		meta["approval_request_name"] = fmt.Sprintf("rar-%s", rr.Name)
 	case remediationv1.PhaseCompleted:
 		if rr.Status.Outcome != "" {
 			meta["outcome"] = rr.Status.Outcome

--- a/pkg/apifrontend/handler/status_types_test.go
+++ b/pkg/apifrontend/handler/status_types_test.go
@@ -78,7 +78,7 @@ var _ = Describe("BuildPhaseMetadata", func() {
 		Expect(meta).To(HaveKey("block_message"))
 	})
 
-	It("UT-AF-1493-006 (was UT-AF-1460-008a): AwaitingApproval phase returns approval_request_name with namespace prefix", func() {
+	It("UT-AF-1959-001 (was UT-AF-1460-008a/UT-AF-1493-006): AwaitingApproval phase returns bare approval_request_name", func() {
 		rr := &remediationv1.RemediationRequest{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "rr-approval-test",
@@ -90,10 +90,13 @@ var _ = Describe("BuildPhaseMetadata", func() {
 		}
 		meta := handler.BuildPhaseMetadata(rr, nil)
 		Expect(meta).To(HaveKey("approval_request_name"))
-		Expect(meta["approval_request_name"]).To(Equal("kubernaut-system/rar-rr-approval-test"))
+		Expect(meta["approval_request_name"]).To(Equal("rar-rr-approval-test"),
+			"#1959: approval_request_name is always a bare name — every RAR lives in the "+
+				"controller namespace per ADR-057, so a namespace prefix here is redundant and "+
+				"the console (which passes this straight through as rar_id) never needs it")
 	})
 
-	It("IT-AF-1493-002: namespace prefix flows through BuildPhaseMetadata for AwaitingApproval", func() {
+	It("UT-AF-1959-002: approval_request_name stays bare regardless of RR namespace", func() {
 		rr := &remediationv1.RemediationRequest{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "rr-payment-fix",
@@ -105,7 +108,8 @@ var _ = Describe("BuildPhaseMetadata", func() {
 		}
 		meta := handler.BuildPhaseMetadata(rr, nil)
 		Expect(meta).To(HaveKey("approval_request_name"))
-		Expect(meta["approval_request_name"]).To(Equal("payments/rar-rr-payment-fix"))
+		Expect(meta["approval_request_name"]).To(Equal("rar-rr-payment-fix"),
+			"no namespace prefix regardless of which namespace the RR CRD happens to live in")
 	})
 
 	It("UT-AF-1468-001: metadata contains investigation identity fields from RR spec (AU-3)", func() {

--- a/pkg/apifrontend/tools/helpers.go
+++ b/pkg/apifrontend/tools/helpers.go
@@ -53,15 +53,13 @@ func ParseRRID(rrID, namespace, name string) (ns, n string, err error) {
 	return namespace, name, nil
 }
 
-// ParseRARID resolves rar_id to namespace and name. It accepts both bare names
-// (paired with the injected namespace) and "namespace/name" format for backward
-// compatibility. If rarID is empty, the explicit namespace and name arguments
-// are used as fallback.
+// ParseRARID resolves rar_id to namespace and name. The rar_id is always a
+// plain resource name (no namespace prefix) — per ADR-057, every RAR lives in
+// the controller namespace, so the namespace always comes from the injected
+// argument, never from rar_id content (#1959). If rarID is empty, the
+// explicit namespace and name arguments are used as fallback.
 func ParseRARID(rarID, namespace, name string) (ns, n string, err error) {
 	if rarID != "" {
-		if parts := strings.SplitN(rarID, "/", 2); len(parts) == 2 && parts[0] != "" && parts[1] != "" {
-			return parts[0], parts[1], nil
-		}
 		return namespace, rarID, nil
 	}
 	if name == "" {
@@ -69,7 +67,6 @@ func ParseRARID(rarID, namespace, name string) (ns, n string, err error) {
 	}
 	return namespace, name, nil
 }
-
 
 // ToUserFriendlyError translates K8s API errors into user-friendly messages.
 // Internal details (namespace paths, resource versions, field paths) are not exposed.

--- a/pkg/apifrontend/tools/helpers_test.go
+++ b/pkg/apifrontend/tools/helpers_test.go
@@ -88,7 +88,7 @@ var _ = Describe("ParseRRID — name-only rr_id format (#E2E-FIX)", func() {
 	})
 })
 
-var _ = Describe("ParseRARID — tolerant rar_id parser (#1493)", func() {
+var _ = Describe("ParseRARID — name-only rar_id format (#1959)", func() {
 
 	Describe("UT-AF-1493-001: bare name resolves with injected namespace", func() {
 		It("should pair bare rar_id with the explicit namespace argument", func() {
@@ -99,12 +99,15 @@ var _ = Describe("ParseRARID — tolerant rar_id parser (#1493)", func() {
 		})
 	})
 
-	Describe("UT-AF-1493-002: namespace/name format is accepted and split", func() {
-		It("should split on slash when rar_id contains namespace/name", func() {
+	Describe("UT-AF-1959-002: rar_id containing slash is passed through as name (no split)", func() {
+		It("should NOT split on slash — rar_id is always the full name, namespace always from controllerNS", func() {
 			ns, name, err := tools.ParseRARID("payments/rar-oom-1", "injected-ns", "")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(ns).To(Equal("payments"))
-			Expect(name).To(Equal("rar-oom-1"))
+			Expect(name).To(Equal("payments/rar-oom-1"),
+				"ParseRARID must not split; all RARs live in the controller namespace per ADR-057, "+
+					"so a namespace segment embedded in rar_id can never be legitimate and must not "+
+					"override the trusted, injected namespace")
+			Expect(ns).To(Equal("injected-ns"))
 		})
 	})
 

--- a/pkg/apifrontend/tools/kubernaut_approval_adversarial_test.go
+++ b/pkg/apifrontend/tools/kubernaut_approval_adversarial_test.go
@@ -208,16 +208,21 @@ var _ = Describe("ADVERSARIAL: kubernaut_get_approval_request", func() {
 			Expect(err.Error()).To(ContainSubstring("invalid input"))
 		})
 
-		It("ADV-AF-109-006: simultaneous rar_id and namespace/name - rar_id takes precedence", func() {
+		It("ADV-AF-1959-006 (was ADV-AF-109-006): rar_id with an embedded namespace no longer silently overrides the injected namespace", func() {
+			// #1959: previously, a slash in rar_id was split and the resulting
+			// namespace segment SILENTLY replaced the trusted, injected
+			// controllerNS — letting caller-supplied input override the trust
+			// boundary. Now rar_id is always a literal resource name (no
+			// split), so "payments/rar-oom-1" is rejected as an invalid K8s
+			// resource name rather than being reinterpreted as namespace/name.
 			tc := newTypedFakeClient(newTypedDetailedRAR("payments", "rar-oom-1"))
-			result, err := tools.HandleGetApprovalRequest(ctx, tc, tools.GetApprovalRequestArgs{
+			_, err := tools.HandleGetApprovalRequest(ctx, tc, tools.GetApprovalRequestArgs{
 				RARID:     "payments/rar-oom-1",
 				Namespace: "other-ns",
 				Name:      "other-name",
 			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Namespace).To(Equal("payments"))
-			Expect(result.Name).To(Equal("rar-oom-1"))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid input"))
 		})
 	})
 

--- a/pkg/apifrontend/tools/kubernaut_get_approval_request_test.go
+++ b/pkg/apifrontend/tools/kubernaut_get_approval_request_test.go
@@ -39,10 +39,11 @@ var _ = Describe("kubernaut_get_approval_request", func() {
 		Expect(result.Expired).To(BeFalse())
 	})
 
-	It("UT-AF-109-002: returns full RAR detail by rar_id shorthand", func() {
+	It("UT-AF-1959-003 (was UT-AF-109-002): returns full RAR detail by bare rar_id shorthand", func() {
 		tc := newTypedFakeClient(newTypedDetailedRAR("payments", "rar-oom-1"))
 		result, err := tools.HandleGetApprovalRequest(ctx, tc, tools.GetApprovalRequestArgs{
-			RARID: "payments/rar-oom-1",
+			RARID:     "rar-oom-1",
+			Namespace: "payments",
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.Name).To(Equal("rar-oom-1"))


### PR DESCRIPTION
## Summary

Simplifies `ParseRARID` to bare-name-only, removing the redundant `namespace/name` tolerance added by #1493, and reverts the namespace prefix that a sibling commit (`cdbdf2452`, #1492) bundled into `BuildPhaseMetadata`'s `approval_request_name`.

## Why

Per **ADR-057** (CRD Namespace Consolidation), every `RemediationApprovalRequest` is always created in the single controller namespace (`controllerNS`) — there is no legitimate scenario where a RAR's namespace differs from it. `ParseRRID` already established the bare-name-only pattern for `rr_id` (`2bfd24c31`, pre-dating #1493) for this exact reason. `ParseRARID`'s `namespace/name` branch could never resolve anything the bare-name branch (using the trusted, injected `controllerNS`) couldn't already resolve — and it introduced a minor trust-boundary inconsistency: it used the **caller-supplied** namespace segment instead of the injected `controllerNS`.

## What's kept vs. changed

`cdbdf2452` (#1492) is otherwise unrelated and legitimate (Kind/Name display formatting for the `target` field) — only its bundled `approval_request_name` line is reverted here.

- **Kept**: `ParseRARID` name (clearer than the old `ParseResourceID`), bare-name acceptance (the real #1493 bug fix), all of #1492's Kind/Name display work
- **Changed**: `ParseRARID` drops the `strings.SplitN` branch (bare-name-only, matches `ParseRRID`); `BuildPhaseMetadata`'s `approval_request_name` reverts to a bare name

## No console-side change required

`kubernaut-console`'s `ChatContainer.tsx` passes `approval_request_name` through to `rar_id` **verbatim** — no parsing/splitting logic on its end. It was always format-agnostic, so this is a drop-in change requiring no coordinated release. See [jordigilh/kubernaut-console#57](https://github.com/jordigilh/kubernaut-console/issues/57) for the console's own, unrelated follow-up (distinguishing permission-denied from bad-request errors in the approval graceful-degradation card).

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/apifrontend/...` — all green
- [x] Adversarial test updated: `rar_id` containing a namespace-like prefix (e.g. `"payments/rar-oom-1"`) is now rejected as an invalid K8s resource name rather than silently reinterpreted as `namespace/name` (closes the trust-boundary gap)
- [x] `gofmt` clean on all changed files

Closes #1959

## Related

- #1493 (original fix, now simplified — bare-name acceptance preserved)
- #1492 (unrelated Kind/Name display fix; only its bundled `approval_request_name` line is reverted)
- #1957 / #1958 (release/v1.5 backport of #1493 that surfaced this re-analysis)
- ADR-057 (CRD Namespace Consolidation)

Made with [Cursor](https://cursor.com)