### PR TITLE
fix(af): simplify ParseRARID to bare-name-only, matching ParseRRID (release/v1.5)

### DIFF
--- a/docs/tests/1493/TEST_PLAN.md
+++ b/docs/tests/1493/TEST_PLAN.md
@@ -7,6 +7,8 @@
 **Status**: Approved
 **Business Requirement**: BR-API-1493
 
+> **⚠️ Superseded in part by [#1959](https://github.com/jordigilh/kubernaut/issues/1959)**: the `namespace/name` tolerance in `ParseRARID` (`UT-AF-1493-002`) was found to be redundant per **ADR-057** (all RARs live in the controller namespace) and inconsistent with the `ParseRRID` bare-name-only precedent (`2bfd24c31`). See `docs/tests/1959/TEST_PLAN.md` for the correction. The bare-name acceptance fix below remains valid and is preserved. (Note: `release/v1.5` never received the namespace-prefix metadata change from #1492, so only the `ParseRARID` simplification applies here.)
+
 ---
 
 ## 1. Purpose

--- a/docs/tests/1959/TEST_PLAN.md
+++ b/docs/tests/1959/TEST_PLAN.md
@@ -1,0 +1,76 @@
+# Test Plan: Simplify ParseRARID to Bare-Name-Only (Issue #1959)
+
+**Service**: apifrontend
+**Version**: 1.0 (release/v1.5 port)
+**Created**: 2026-08-06
+**Author**: AI Assistant
+**Status**: Approved
+**Business Requirement**: BR-API-1493 (amends #1493)
+
+---
+
+## 1. Purpose
+
+Remove the redundant `namespace/name` tolerance from `ParseRARID`, so
+`rar_id` handling matches the bare-name-only precedent already established
+for `rr_id` (`ParseRRID`, `2bfd24c31`).
+
+## 2. Background
+
+This is the `release/v1.5` port of the `main` fix. `release/v1.5` received
+`#1493`'s `ParseRARID` (via #1957/#1958) but never received the sibling
+commit (`cdbdf2452`, #1492) that added a namespace prefix to
+`BuildPhaseMetadata`'s `approval_request_name` — so on `release/v1.5`,
+`BuildPhaseMetadata` already emits a bare name and needs no change. Only
+`ParseRARID` needs simplifying here.
+
+Per **ADR-057** (CRD Namespace Consolidation), every `RemediationApprovalRequest`
+is always created in the single controller namespace — there is no legitimate
+scenario where a RAR's namespace differs from `controllerNS`. The
+`namespace/name` branch in `ParseRARID` therefore could never resolve
+anything the bare-name branch (using the injected, trusted `controllerNS`)
+couldn't already resolve, and it introduced a minor trust-boundary
+inconsistency: it used the caller-supplied namespace segment instead of the
+injected `controllerNS`.
+
+## 3. Objectives
+
+- `ParseRARID` becomes structurally identical to `ParseRRID`: bare-name-only,
+  namespace always sourced from the injected argument
+- Preserve the legitimate bare-name-acceptance fix from #1493
+- No regressions in existing approval request flows; no console changes
+
+## 4. Scope
+
+### In Scope
+
+- `ParseRARID` (`helpers.go`): drop the `namespace/name` split branch
+- Adversarial tests proving a `rar_id` containing `/` is now rejected as an
+  invalid K8s resource name rather than reinterpreted as `namespace/name`
+
+### Out of Scope
+
+- `BuildPhaseMetadata` (already bare name on this branch — no change needed)
+- Console-side changes (none required)
+
+## 5. BR Coverage Matrix
+
+| BR ID | Description | Priority | Test Type | Test ID | Status |
+|-------|-------------|----------|-----------|---------|--------|
+| BR-API-1493 | `ParseRARID`: bare name resolution (unchanged) | P0 | Unit | UT-AF-1493-001 | Pass |
+| BR-API-1493 | `ParseRARID`: rar_id with slash is NOT split (name-only) | P0 | Unit | UT-AF-1959-002 | Pass |
+| BR-API-1493 | `ParseRARID`: fallback to explicit ns+name (unchanged) | P1 | Unit | UT-AF-1493-003 | Pass |
+| BR-API-1493 | `ParseRARID`: error on empty inputs (unchanged) | P1 | Unit | UT-AF-1493-004 | Pass |
+| BR-API-1493 | Handler resolves bare rar_id shorthand | P0 | Unit | UT-AF-1959-003 | Pass |
+| BR-API-1493 | rar_id with embedded namespace no longer overrides injected namespace | P0 | Adversarial | ADV-AF-1959-006 | Pass |
+
+## 6. Risks
+
+| Risk | Mitigation |
+|------|-----------|
+| A production caller relied on `namespace/name` shorthand | Confirmed only producer was `BuildPhaseMetadata` (already bare on this branch) and the console passes values through verbatim — no other producer exists |
+
+## 7. Environment
+
+- Unit tests: `go test ./pkg/apifrontend/...`
+- `go build ./...` clean

--- a/pkg/apifrontend/tools/helpers.go
+++ b/pkg/apifrontend/tools/helpers.go
@@ -50,15 +50,13 @@ func ParseRRID(rrID, namespace, name string) (ns, n string, err error) {
 	return namespace, name, nil
 }
 
-// ParseRARID resolves rar_id to namespace and name. It accepts both bare names
-// (paired with the injected namespace) and "namespace/name" format for backward
-// compatibility. If rarID is empty, the explicit namespace and name arguments
-// are used as fallback.
+// ParseRARID resolves rar_id to namespace and name. The rar_id is always a
+// plain resource name (no namespace prefix) — per ADR-057, every RAR lives in
+// the controller namespace, so the namespace always comes from the injected
+// argument, never from rar_id content (#1959). If rarID is empty, the
+// explicit namespace and name arguments are used as fallback.
 func ParseRARID(rarID, namespace, name string) (ns, n string, err error) {
 	if rarID != "" {
-		if parts := strings.SplitN(rarID, "/", 2); len(parts) == 2 && parts[0] != "" && parts[1] != "" {
-			return parts[0], parts[1], nil
-		}
 		return namespace, rarID, nil
 	}
 	if name == "" {
@@ -66,7 +64,6 @@ func ParseRARID(rarID, namespace, name string) (ns, n string, err error) {
 	}
 	return namespace, name, nil
 }
-
 
 // ToUserFriendlyError translates K8s API errors into user-friendly messages.
 // Internal details (namespace paths, resource versions, field paths) are not exposed.

--- a/pkg/apifrontend/tools/helpers_test.go
+++ b/pkg/apifrontend/tools/helpers_test.go
@@ -88,7 +88,7 @@ var _ = Describe("ParseRRID — name-only rr_id format (#E2E-FIX)", func() {
 	})
 })
 
-var _ = Describe("ParseRARID — tolerant rar_id parser (#1493)", func() {
+var _ = Describe("ParseRARID — name-only rar_id format (#1959)", func() {
 
 	Describe("UT-AF-1493-001: bare name resolves with injected namespace", func() {
 		It("should pair bare rar_id with the explicit namespace argument", func() {
@@ -99,12 +99,15 @@ var _ = Describe("ParseRARID — tolerant rar_id parser (#1493)", func() {
 		})
 	})
 
-	Describe("UT-AF-1493-002: namespace/name format is accepted and split", func() {
-		It("should split on slash when rar_id contains namespace/name", func() {
+	Describe("UT-AF-1959-002: rar_id containing slash is passed through as name (no split)", func() {
+		It("should NOT split on slash — rar_id is always the full name, namespace always from controllerNS", func() {
 			ns, name, err := tools.ParseRARID("payments/rar-oom-1", "injected-ns", "")
 			Expect(err).NotTo(HaveOccurred())
-			Expect(ns).To(Equal("payments"))
-			Expect(name).To(Equal("rar-oom-1"))
+			Expect(name).To(Equal("payments/rar-oom-1"),
+				"ParseRARID must not split; all RARs live in the controller namespace per ADR-057, "+
+					"so a namespace segment embedded in rar_id can never be legitimate and must not "+
+					"override the trusted, injected namespace")
+			Expect(ns).To(Equal("injected-ns"))
 		})
 	})
 

--- a/pkg/apifrontend/tools/kubernaut_approval_adversarial_test.go
+++ b/pkg/apifrontend/tools/kubernaut_approval_adversarial_test.go
@@ -208,16 +208,21 @@ var _ = Describe("ADVERSARIAL: kubernaut_get_approval_request", func() {
 			Expect(err.Error()).To(ContainSubstring("invalid input"))
 		})
 
-		It("ADV-AF-109-006: simultaneous rar_id and namespace/name - rar_id takes precedence", func() {
+		It("ADV-AF-1959-006 (was ADV-AF-109-006): rar_id with an embedded namespace no longer silently overrides the injected namespace", func() {
+			// #1959: previously, a slash in rar_id was split and the resulting
+			// namespace segment SILENTLY replaced the trusted, injected
+			// controllerNS — letting caller-supplied input override the trust
+			// boundary. Now rar_id is always a literal resource name (no
+			// split), so "payments/rar-oom-1" is rejected as an invalid K8s
+			// resource name rather than being reinterpreted as namespace/name.
 			tc := newTypedFakeClient(newTypedDetailedRAR("payments", "rar-oom-1"))
-			result, err := tools.HandleGetApprovalRequest(ctx, tc, tools.GetApprovalRequestArgs{
+			_, err := tools.HandleGetApprovalRequest(ctx, tc, tools.GetApprovalRequestArgs{
 				RARID:     "payments/rar-oom-1",
 				Namespace: "other-ns",
 				Name:      "other-name",
 			})
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Namespace).To(Equal("payments"))
-			Expect(result.Name).To(Equal("rar-oom-1"))
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("invalid input"))
 		})
 	})
 

--- a/pkg/apifrontend/tools/kubernaut_get_approval_request_test.go
+++ b/pkg/apifrontend/tools/kubernaut_get_approval_request_test.go
@@ -39,10 +39,11 @@ var _ = Describe("kubernaut_get_approval_request", func() {
 		Expect(result.Expired).To(BeFalse())
 	})
 
-	It("UT-AF-109-002: returns full RAR detail by rar_id shorthand", func() {
+	It("UT-AF-1959-003 (was UT-AF-109-002): returns full RAR detail by bare rar_id shorthand", func() {
 		tc := newTypedFakeClient(newTypedDetailedRAR("payments", "rar-oom-1"))
 		result, err := tools.HandleGetApprovalRequest(ctx, tc, tools.GetApprovalRequestArgs{
-			RARID: "payments/rar-oom-1",
+			RARID:     "rar-oom-1",
+			Namespace: "payments",
 		})
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result.Name).To(Equal("rar-oom-1"))


### PR DESCRIPTION
## Summary

`release/v1.5` port of #1961 (the `main` fix). Simplifies `ParseRARID` to bare-name-only, removing the redundant `namespace/name` tolerance added by #1493's backport (#1957/#1958).

## Why this branch is different from the main PR

`release/v1.5` received `#1493`'s `ParseRARID` fix (via #1957/#1958) but **never received #1492's** sibling commit that added a namespace prefix to `BuildPhaseMetadata`'s `approval_request_name`. So on this branch, `BuildPhaseMetadata` already emits a bare name — **no metadata change needed here**, only the `ParseRARID` simplification.

## Why

Per **ADR-057** (CRD Namespace Consolidation), every `RemediationApprovalRequest` is always created in the single controller namespace (`controllerNS`). `ParseRRID` already established the bare-name-only pattern for `rr_id` (`2bfd24c31`) for this exact reason. `ParseRARID`'s `namespace/name` branch could never resolve anything the bare-name branch couldn't already resolve, and it used the **caller-supplied** namespace segment instead of the injected, trusted `controllerNS`.

## No console-side change required

Same as the `main` PR — `kubernaut-console`'s `ChatContainer.tsx` passes `approval_request_name` through to `rar_id` verbatim, no parsing. See [jordigilh/kubernaut-console#57](https://github.com/jordigilh/kubernaut-console/issues/57) for the console's own, unrelated follow-up.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/apifrontend/...` — all green
- [x] Adversarial test updated: `rar_id` containing a namespace-like prefix is now rejected as an invalid K8s resource name rather than silently reinterpreted as `namespace/name`
- [x] `gofmt` clean

Closes #1959

## Related

- #1961 (the `main` fix this ports)
- #1957 / #1958 (the backport that surfaced this re-analysis)
- ADR-057 (CRD Namespace Consolidation)

Made with [Cursor](https://cursor.com)