### PR TITLE
fix(af): bound pooled MCP tool calls and Claude/Vertex-Claude LLM calls with client-side timeouts

### DIFF
--- a/pkg/apifrontend/launcher/export_test.go
+++ b/pkg/apifrontend/launcher/export_test.go
@@ -3,9 +3,11 @@ package launcher
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/a2aproject/a2a-go/a2a"
 	"github.com/go-logr/logr"
+	"google.golang.org/adk/model"
 	"google.golang.org/adk/server/adka2a"
 	"google.golang.org/adk/session"
 	"google.golang.org/genai"
@@ -100,4 +102,30 @@ func EmitArtifactForTest(ctx context.Context, data map[string]any, textFallback 
 // ValidatePayloadForTest exports ValidatePayload for testing.
 func ValidatePayloadForTest(schemaName string, data map[string]any) error {
 	return ValidatePayload(schemaName, data)
+}
+
+// IsTimeoutWrappedForTest reports whether m is a *timeoutModel (the #1955
+// decorator applied by newAnthropicModel/newVertexAnthropicModel) and, if
+// so, its configured timeout. Lets black-box (launcher_test) specs prove
+// the decorator is wired into NewModelFromConfig's real construction sites
+// without exposing timeoutModel itself.
+func IsTimeoutWrappedForTest(m model.LLM) (time.Duration, bool) {
+	tm, ok := m.(*timeoutModel)
+	if !ok {
+		return 0, false
+	}
+	return tm.timeout, true
+}
+
+// UnwrapTimeoutForTest peels off the #1955 timeoutModel decorator (if
+// present) and returns the underlying provider-specific model.LLM
+// unchanged otherwise. Lets pre-existing dispatch-regression specs (e.g.
+// IT-AF-1792-002) keep asserting on the concrete provider type via
+// fmt.Sprintf("%T", ...) without being coupled to whether that provider
+// also happens to be timeout-wrapped.
+func UnwrapTimeoutForTest(m model.LLM) model.LLM {
+	if tm, ok := m.(*timeoutModel); ok {
+		return tm.inner
+	}
+	return m
 }

--- a/pkg/apifrontend/launcher/model.go
+++ b/pkg/apifrontend/launcher/model.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"iter"
 	"net/http"
 	"os"
 	"strings"
@@ -118,7 +119,11 @@ func newVertexAnthropicModel(ctx context.Context, cfg types.LLMConfig) (m model.
 	if cfg.Endpoint != "" {
 		adkCfg.BaseURL = cfg.Endpoint
 	}
-	return adkanthropic.NewModel(ctx, cfg.Model, adkCfg)
+	llm, err := adkanthropic.NewModel(ctx, cfg.Model, adkCfg)
+	if err != nil {
+		return nil, err
+	}
+	return wrapWithTimeout(llm, cfg), nil
 }
 
 // newVertexGeminiModel constructs an ADK model.LLM for a Gemini model
@@ -257,7 +262,54 @@ func newAnthropicModel(ctx context.Context, cfg types.LLMConfig) (model.LLM, err
 	if cfg.Endpoint != "" {
 		adkCfg.BaseURL = cfg.Endpoint
 	}
-	return adkanthropic.NewModel(ctx, cfg.Model, adkCfg)
+	llm, err := adkanthropic.NewModel(ctx, cfg.Model, adkCfg)
+	if err != nil {
+		return nil, err
+	}
+	return wrapWithTimeout(llm, cfg), nil
+}
+
+// timeoutModel wraps a model.LLM so every GenerateContent call is bounded
+// by a context deadline, working around adk-anthropic-go not exposing
+// HTTP client injection (#1342) — the only two providers (direct Anthropic
+// API and Vertex-hosted Claude) still missing any client-side timeout
+// after #1955's audit. The deadline is applied to the ctx that flows into
+// the (lazily-evaluated) returned iterator, so it bounds the real,
+// deferred SDK call — adk-anthropic-go's own GenerateContent/generateStream
+// return closures that don't touch the network until ranged over, and
+// anthropic-sdk-go builds its HTTP request via http.NewRequestWithContext,
+// which binds connect, header-read, and body/SSE read to ctx — not just
+// this function's own (instant) return.
+type timeoutModel struct {
+	inner   model.LLM
+	timeout time.Duration
+}
+
+func (m *timeoutModel) Name() string { return m.inner.Name() }
+
+func (m *timeoutModel) GenerateContent(ctx context.Context, req *model.LLMRequest, stream bool) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) {
+		callCtx, cancel := context.WithTimeout(ctx, m.timeout)
+		defer cancel()
+		for resp, err := range m.inner.GenerateContent(callCtx, req, stream) {
+			if !yield(resp, err) {
+				return
+			}
+		}
+	}
+}
+
+// wrapWithTimeout resolves the configured LLM call timeout (falling back
+// to DefaultLLMTimeoutSeconds, mirroring BuildLLMHTTPClient's identical
+// resolution for the Gemini/OpenAI-compatible/Vertex-Gemini paths) and
+// wraps inner with a timeoutModel enforcing it at the context layer
+// instead of the HTTP client layer.
+func wrapWithTimeout(inner model.LLM, cfg types.LLMConfig) model.LLM {
+	timeout := time.Duration(types.DefaultLLMTimeoutSeconds) * time.Second
+	if cfg.TimeoutSeconds > 0 {
+		timeout = time.Duration(cfg.TimeoutSeconds) * time.Second
+	}
+	return &timeoutModel{inner: inner, timeout: timeout}
 }
 
 // BuildLLMHTTPClient constructs an HTTP client with the transport chain

--- a/pkg/apifrontend/launcher/model_test.go
+++ b/pkg/apifrontend/launcher/model_test.go
@@ -102,7 +102,13 @@ var _ = Describe("Model Factory", func() {
 				return
 			}
 			Expect(m).NotTo(BeNil())
-			Expect(fmt.Sprintf("%T", m)).To(ContainSubstring("anthropic"))
+			// #1955 now wraps the Anthropic/Vertex-Anthropic construction
+			// sites in a *launcher.timeoutModel decorator, so unwrap it
+			// before asserting on the underlying provider's concrete type —
+			// this spec's job is the dispatch (anthropic vs. gemini), not
+			// the timeout wiring (covered separately by
+			// model_timeout_1955_test.go's IT-AF-1955-004).
+			Expect(fmt.Sprintf("%T", launcher.UnwrapTimeoutForTest(m))).To(ContainSubstring("anthropic"))
 		})
 
 		// IT-AF-1792-005: vertex_ai + an unrecognized model family. Found

--- a/pkg/apifrontend/launcher/model_timeout_1955_internal_test.go
+++ b/pkg/apifrontend/launcher/model_timeout_1955_internal_test.go
@@ -1,0 +1,105 @@
+package launcher
+
+import (
+	"context"
+	"errors"
+	"iter"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"google.golang.org/adk/model"
+
+	"github.com/jordigilh/kubernaut/pkg/shared/types"
+)
+
+// hangingLLM is a model.LLM fake whose GenerateContent blocks until the
+// ctx it receives ends, then yields the resulting error — used to prove
+// wrapWithTimeout's decorator actually bounds the call (#1955), not just
+// that it resolves the right duration.
+type hangingLLM struct {
+	name string
+}
+
+func (m *hangingLLM) Name() string { return m.name }
+
+func (m *hangingLLM) GenerateContent(ctx context.Context, _ *model.LLMRequest, _ bool) iter.Seq2[*model.LLMResponse, error] {
+	return func(yield func(*model.LLMResponse, error) bool) {
+		<-ctx.Done()
+		yield(nil, ctx.Err())
+	}
+}
+
+// awaitGenerateContent ranges over seq in a goroutine and fails the spec
+// fast if it doesn't terminate within bound, instead of letting a
+// regression (no timeout enforced) hang the whole suite.
+func awaitGenerateContent(bound time.Duration, seq iter.Seq2[*model.LLMResponse, error]) error {
+	done := make(chan error, 1)
+	go func() {
+		var lastErr error
+		for _, err := range seq {
+			lastErr = err
+		}
+		done <- lastErr
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(bound):
+		Fail("GenerateContent did not return within the safety bound — #1955 timeout not enforced")
+		return nil
+	}
+}
+
+var _ = Describe("timeoutModel decorator (#1955, BR-AI-1955)", func() {
+	It("UT-AF-1955-001: resolves and enforces the DefaultLLMTimeoutSeconds fallback when cfg.TimeoutSeconds is unset", func() {
+		inner := &hangingLLM{name: "claude-test"}
+		wrapped := wrapWithTimeout(inner, types.LLMConfig{})
+
+		tm, ok := wrapped.(*timeoutModel)
+		Expect(ok).To(BeTrue())
+		Expect(tm.timeout).To(Equal(time.Duration(types.DefaultLLMTimeoutSeconds) * time.Second))
+
+		// Shrink the resolved timeout directly (white-box, same package) so
+		// this spec doesn't have to wait out the real 120s default in order
+		// to prove enforcement — the resolution branch above already
+		// confirmed 120s is what production code would have picked.
+		tm.timeout = 10 * time.Millisecond
+
+		err := awaitGenerateContent(2*time.Second, wrapped.GenerateContent(context.Background(), &model.LLMRequest{}, false))
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, context.DeadlineExceeded)).To(BeTrue())
+	})
+
+	It("UT-AF-1955-002: resolves and enforces an explicit cfg.TimeoutSeconds instead of the default", func() {
+		inner := &hangingLLM{name: "claude-test"}
+		wrapped := wrapWithTimeout(inner, types.LLMConfig{TimeoutSeconds: 45})
+
+		tm, ok := wrapped.(*timeoutModel)
+		Expect(ok).To(BeTrue())
+		Expect(tm.timeout).To(Equal(45 * time.Second))
+
+		tm.timeout = 10 * time.Millisecond
+
+		err := awaitGenerateContent(2*time.Second, wrapped.GenerateContent(context.Background(), &model.LLMRequest{}, false))
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, context.DeadlineExceeded)).To(BeTrue())
+	})
+
+	It("streaming calls (stream=true) are bounded the same way as non-streaming", func() {
+		inner := &hangingLLM{name: "claude-test"}
+		wrapped := &timeoutModel{inner: inner, timeout: 10 * time.Millisecond}
+
+		err := awaitGenerateContent(2*time.Second, wrapped.GenerateContent(context.Background(), &model.LLMRequest{}, true))
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, context.DeadlineExceeded)).To(BeTrue())
+	})
+
+	It("Name() passes through to the wrapped inner model", func() {
+		inner := &hangingLLM{name: "claude-passthrough"}
+		wrapped := wrapWithTimeout(inner, types.LLMConfig{})
+		Expect(wrapped.Name()).To(Equal("claude-passthrough"))
+	})
+})

--- a/pkg/apifrontend/launcher/model_timeout_1955_test.go
+++ b/pkg/apifrontend/launcher/model_timeout_1955_test.go
@@ -1,0 +1,66 @@
+package launcher_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
+	"github.com/jordigilh/kubernaut/pkg/shared/types"
+)
+
+// Claude/Vertex-Claude LLM call timeout wiring (#1955, BR-AI-1955).
+//
+// These drive the real, exported production entry point
+// (launcher.NewModelFromConfig, the same call cmd/apifrontend makes) rather
+// than the unexported wrapWithTimeout/timeoutModel directly — proving the
+// decorator is actually applied at the two real construction sites
+// (newAnthropicModel, newVertexAnthropicModel), not just that the
+// decorator's own logic works in isolation (covered separately by
+// model_timeout_1955_internal_test.go's white-box specs).
+var _ = Describe("Claude/Vertex-Claude LLM call timeout wiring (#1955, BR-AI-1955)", func() {
+	Describe("NewModelFromConfig", func() {
+		It("IT-AF-1955-003: wraps a direct-API anthropic model with the timeout decorator", func() {
+			cfg := types.LLMConfig{
+				Provider:       types.LLMProviderAnthropic,
+				Model:          "claude-sonnet-4-20250514",
+				APIKey:         "sk-ant-test-key",
+				TimeoutSeconds: 45,
+			}
+			m, err := launcher.NewModelFromConfig(context.Background(), cfg)
+			Expect(err).NotTo(HaveOccurred())
+
+			timeout, wrapped := launcher.IsTimeoutWrappedForTest(m)
+			Expect(wrapped).To(BeTrue(), "newAnthropicModel must wrap its result with the #1955 timeout decorator")
+			Expect(timeout).To(Equal(45 * time.Second))
+		})
+
+		// IT-AF-1955-004: vertex_ai + a claude-* model, which main dispatches
+		// (via newVertexAIModel's types.IsAnthropicModel check, #1778/#1792)
+		// to newVertexAnthropicModel specifically — the vertex_ai + gemini-*
+		// path (newVertexGeminiModel) already has its own timeout via
+		// httpClient.Timeout and is untouched by this fix. Construction
+		// requires ambient GCP ADC, which this environment may or may not
+		// have — soft-checked exactly like this package's pre-existing
+		// IT-AF-1792-002 (model_test.go), since either outcome still proves
+		// the fix as long as a successful construction is wrapped.
+		It("IT-AF-1955-004: wraps a Vertex-hosted claude model with the timeout decorator when construction succeeds", func() {
+			cfg := types.LLMConfig{
+				Provider:       types.LLMProviderVertexAI,
+				Model:          "claude-sonnet-4-20250514",
+				VertexProject:  "test-project",
+				VertexLocation: "us-central1",
+			}
+			m, err := launcher.NewModelFromConfig(context.Background(), cfg)
+			if err != nil {
+				Expect(err.Error()).To(ContainSubstring("GCP ADC unavailable"))
+				return
+			}
+			timeout, wrapped := launcher.IsTimeoutWrappedForTest(m)
+			Expect(wrapped).To(BeTrue(), "newVertexAnthropicModel must wrap its result with the #1955 timeout decorator")
+			Expect(timeout).To(Equal(time.Duration(types.DefaultLLMTimeoutSeconds) * time.Second))
+		})
+	})
+})

--- a/pkg/apifrontend/tools/ka_interactive.go
+++ b/pkg/apifrontend/tools/ka_interactive.go
@@ -45,7 +45,9 @@ func invokeInteractiveAction(ctx context.Context, mcpClient ka.MCPClient, action
 		}
 	}
 
-	result, err := mcpClient.InvokeAction(ctx, ka.InvokeActionArgs{
+	toolCtx, cancel := context.WithTimeout(ctx, PooledToolCallTimeout)
+	defer cancel()
+	result, err := mcpClient.InvokeAction(toolCtx, ka.InvokeActionArgs{
 		RRID:    args.RRID,
 		Action:  action,
 		Message: args.Message,

--- a/pkg/apifrontend/tools/ka_tools.go
+++ b/pkg/apifrontend/tools/ka_tools.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"slices"
+	"time"
 
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
@@ -15,6 +16,18 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/validate"
 	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
 )
+
+// PooledToolCallTimeout bounds a single pooled-session KA MCP call
+// (discover_workflows, select_workflow, message, complete, cancel,
+// status, reconnect). Without it, a lost/stuck response on a reused
+// session blocks the caller indefinitely (#1954) — the caller's raw ctx
+// was previously passed straight through with no deadline. 60s covers
+// discover_workflows's legitimate LLM-bound latency (observed 14-25s in
+// KA) with headroom, while staying well under KA's own inactivity
+// backstop (#1949/#1951/#1952). A var, not a const, so tests can shrink
+// it to verify real end-to-end timeout enforcement in milliseconds,
+// mirroring AwaitSessionTimeout's test-override pattern (crd_tools_session.go).
+var PooledToolCallTimeout = 60 * time.Second
 
 // WorkflowParameter describes a single input parameter for a workflow.
 type WorkflowParameter struct {
@@ -72,7 +85,9 @@ func HandleDiscoverWorkflows(ctx context.Context, mcpClient ka.MCPClient, args D
 		return DiscoverWorkflowsResult{}, fmt.Errorf("workflow discovery is not available: MCP client not configured")
 	}
 
-	kaResult, err := mcpClient.DiscoverWorkflows(ctx, ka.DiscoverWorkflowsArgs{
+	toolCtx, cancel := context.WithTimeout(ctx, PooledToolCallTimeout)
+	defer cancel()
+	kaResult, err := mcpClient.DiscoverWorkflows(toolCtx, ka.DiscoverWorkflowsArgs{
 		RRID:       args.RRID,
 		WorkflowID: args.WorkflowID,
 		Kind:       args.Kind,
@@ -247,7 +262,9 @@ func HandleSelectWorkflow(ctx context.Context, mcpClient ka.MCPClient, args Sele
 	if mcpClient == nil {
 		return SelectWorkflowResult{}, fmt.Errorf("workflow selection is not available: MCP client not configured")
 	}
-	result, err := mcpClient.SelectWorkflow(ctx, ka.SelectWorkflowArgs{
+	toolCtx, cancel := context.WithTimeout(ctx, PooledToolCallTimeout)
+	defer cancel()
+	result, err := mcpClient.SelectWorkflow(toolCtx, ka.SelectWorkflowArgs{
 		RRID:       args.RRID,
 		WorkflowID: args.WorkflowID,
 		Kind:       args.Kind,

--- a/pkg/apifrontend/tools/pooled_tool_timeout_1954_test.go
+++ b/pkg/apifrontend/tools/pooled_tool_timeout_1954_test.go
@@ -1,0 +1,181 @@
+package tools_test
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+)
+
+// hangingPoolSession is a ka.PoolSession fake whose CallTool blocks until
+// the caller's ctx ends, then returns ctx.Err() — reproducing #1954's
+// "MCP response lost on a reused pooled session" symptom, where only a
+// caller-side deadline (not the server) can ever unblock the call.
+type hangingPoolSession struct {
+	mu     sync.Mutex
+	closed bool
+}
+
+func (s *hangingPoolSession) CallTool(ctx context.Context, _ *mcp.CallToolParams) (*mcp.CallToolResult, error) {
+	<-ctx.Done()
+	return nil, ctx.Err()
+}
+
+func (s *hangingPoolSession) Ping(_ context.Context, _ *mcp.PingParams) error { return nil }
+
+func (s *hangingPoolSession) Close() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.closed = true
+	return nil
+}
+
+func identityCtxFor1954(username string) context.Context {
+	return auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+		Username: username,
+		Groups:   []string{"sre"},
+	})
+}
+
+// specSafetyBound is comfortably longer than tools.PooledToolCallTimeout's
+// shrunk-for-test value (20ms) but short enough to fail RED-phase specs
+// fast instead of hanging the suite.
+const specSafetyBound = 2 * time.Second
+
+// awaitWithSafetyBound runs fn in a goroutine and fails the spec fast if it
+// doesn't complete within specSafetyBound, instead of letting a regression
+// (no timeout applied anywhere in the chain) hang the whole suite until the
+// outer `go test` process timeout.
+func awaitWithSafetyBound(fn func()) {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		fn()
+	}()
+	select {
+	case <-done:
+	case <-time.After(specSafetyBound):
+		Fail("operation did not return within the safety bound — #1954 timeout not enforced")
+	}
+}
+
+var _ = Describe("Pooled MCP tool-call timeout (#1954, BR-INTERACTIVE-010)", func() {
+	var origTimeout time.Duration
+
+	BeforeEach(func() {
+		origTimeout = tools.PooledToolCallTimeout
+		tools.PooledToolCallTimeout = 20 * time.Millisecond
+	})
+
+	AfterEach(func() {
+		tools.PooledToolCallTimeout = origTimeout
+	})
+
+	Describe("HandleDiscoverWorkflows", func() {
+		It("UT-AF-1954-001: returns instead of hanging when the pooled MCP call never responds", func() {
+			mockMCP := &ka.MockMCPClient{
+				DiscoverWorkflowsFn: func(ctx context.Context, _ ka.DiscoverWorkflowsArgs) (*ka.DiscoverWorkflowsResult, error) {
+					<-ctx.Done()
+					return nil, ctx.Err()
+				},
+			}
+
+			var result tools.DiscoverWorkflowsResult
+			var err error
+			awaitWithSafetyBound(func() {
+				result, err = tools.HandleDiscoverWorkflows(context.Background(), mockMCP, tools.DiscoverWorkflowsArgs{})
+			})
+
+			// HandleDiscoverWorkflows deliberately downgrades a deadline/cancel
+			// error to an empty-but-successful result (pre-existing graceful
+			// degradation, left unchanged by #1954's fix) — what matters here
+			// is that it returns at all within the safety bound above.
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Count).To(Equal(0))
+		})
+	})
+
+	Describe("HandleSelectWorkflow", func() {
+		It("UT-AF-1954-002: returns an error instead of hanging when the pooled MCP call never responds", func() {
+			mockMCP := &ka.MockMCPClient{
+				SelectWorkflowFn: func(ctx context.Context, _ ka.SelectWorkflowArgs) (*ka.SelectWorkflowResult, error) {
+					<-ctx.Done()
+					return nil, ctx.Err()
+				},
+			}
+
+			var err error
+			awaitWithSafetyBound(func() {
+				_, err = tools.HandleSelectWorkflow(context.Background(), mockMCP, tools.SelectWorkflowArgs{
+					RRID:       "pay/rr-1954",
+					WorkflowID: "wf-restart",
+				}, nil)
+			})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("selecting workflow"))
+		})
+	})
+
+	Describe("invokeInteractiveAction (via HandleMessage)", func() {
+		It("UT-AF-1954-003: returns an error instead of hanging when the pooled MCP call never responds", func() {
+			mockMCP := &ka.MockMCPClient{
+				InvokeActionFn: func(ctx context.Context, _ ka.InvokeActionArgs) (*ka.InvokeActionResult, error) {
+					<-ctx.Done()
+					return nil, ctx.Err()
+				},
+			}
+
+			var err error
+			awaitWithSafetyBound(func() {
+				_, err = tools.HandleMessage(context.Background(), mockMCP, tools.InteractiveActionArgs{
+					RRID:    "rr-prod-1954",
+					Message: "still there?",
+				}, nil)
+			})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("message"))
+		})
+	})
+
+	// IT-AF-1954-004 exercises the real production wiring end to end:
+	// HandleDiscoverWorkflows -> the real ka.PooledMCPClient -> the real
+	// ka.KASessionPool -> only the actual network boundary, PoolSession,
+	// is faked. A mock at the ka.MCPClient layer (the three specs above)
+	// only proves the handler applies a deadline to its own ctx argument;
+	// this is the one that proves that deadline actually propagates
+	// through the real pool/session plumbing far enough to cancel a
+	// genuinely stuck call — the gap that would have let #1954 through.
+	Describe("IT-AF-1954-004: real PooledMCPClient/KASessionPool wiring", func() {
+		It("bounds a stuck pooled-session CallTool through the real production chain", func() {
+			pool := ka.NewKASessionPool(ka.PoolConfig{
+				Factory: func(_ context.Context) (ka.PoolSession, error) {
+					return &hangingPoolSession{}, nil
+				},
+				MaxEntries: 10,
+				Logger:     logr.Discard(),
+			})
+			pooledClient := ka.NewPooledMCPClient(pool, logr.Discard())
+
+			var result tools.DiscoverWorkflowsResult
+			var err error
+			awaitWithSafetyBound(func() {
+				result, err = tools.HandleDiscoverWorkflows(identityCtxFor1954("alice"), pooledClient, tools.DiscoverWorkflowsArgs{
+					RRID: "pay/rr-1954-it",
+				})
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Count).To(Equal(0))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

`main` port of #1960, which fixed these two issues on `release/v1.5` — confirmed working by the console team's live retest there. Same fix, adapted to `main`'s slightly different `newVertexAIModel` dispatch (it splits Claude/Gemini vertex_ai construction into separate `newVertexAnthropicModel`/`newVertexGeminiModel` functions, added by #1778/#1792, whereas v1.5 has a single `newVertexAIModel` handling Claude only).

- **#1964** (main-tracking clone of #1954, `release/v1.5` original — fixed, validated, closed): none of AF's ADK-facing interactive tool handlers (`discover_workflows`, `select_workflow`, `message`, `complete`, `cancel`, `status`, `reconnect`) bound their call to the pooled KA MCP client with any deadline, so a lost/stuck response on a reused session blocked the caller indefinitely. Adds `PooledToolCallTimeout` (60s) and wraps the three call sites in `ka_tools.go`/`ka_interactive.go`.

- **#1956** (main-tracking clone of #1955, `release/v1.5` original — fixed, validated, closed): AF's own agent-loop LLM call to Claude (direct Anthropic API or Vertex AI) had no bound anywhere, since `adk-anthropic-go` doesn't expose HTTP client injection (#1342). Adds a `timeoutModel` decorator around `model.LLM` that applies `cfg.TimeoutSeconds` (falling back to `DefaultLLMTimeoutSeconds`) at the context layer, applied in `newAnthropicModel`/`newVertexAnthropicModel`. `main`'s Vertex-hosted-Gemini path (`newVertexGeminiModel`, #1778/#1792/#1801) is unaffected — it already sets `httpClient.Timeout` explicitly.

## Pyramid invariant

Both fixes are proven end-to-end, not just in isolation:
- `IT-AF-1954-004` drives `HandleDiscoverWorkflows` through the real `PooledMCPClient`/`KASessionPool` with only the network-facing `PoolSession` boundary faked.
- `IT-AF-1955-003`/`004` drive the real `NewModelFromConfig` construction sites (the same entry point `cmd/apifrontend` uses) and assert the `timeoutModel` decorator is actually wired in — not just that the decorator's own logic works (covered separately by the white-box `UT-AF-1955-*` specs).

(Test IDs keep the original `-1954-`/`-1955-` suffixes from the `release/v1.5` PR for traceability back to the shared fix design, even though the tracking issues on this branch are #1964/#1956.)

## Incidental fix

Porting #1955/#1956 exposed a pre-existing `main`-only regression: `IT-AF-1792-002` asserted on `model.LLM`'s concrete type name via `%T` to prove `vertex_ai`+claude still dispatches to the Anthropic constructor (#1792) — the new `timeoutModel` wrapper changes that type name. Added `UnwrapTimeoutForTest` to peel the decorator off before that assertion, preserving the original dispatch-regression check.

## Test plan

- [x] `go build ./...`
- [x] `golangci-lint run --timeout=5m ./pkg/apifrontend/...` — 0 issues
- [x] `go vet ./...`
- [x] Full `pkg/apifrontend` suite passes, including the pre-existing `IT-AF-1792-*` dispatch specs after the `UnwrapTimeoutForTest` fix
- [x] New specs verified individually via `-ginkgo.focus` before the full-suite run: 4/4 `#1954`-derived specs, 6/6 `#1955`-derived specs
- [x] Full CI green (all Build/Lint/Unit/Integration/E2E/Helm-smoke jobs pass)

Refs #1964, #1956 (this PR's tracking issues); #1954, #1955 (release/v1.5 originals, closed)