### PR TITLE
fix(af/ka/ro/aa): pprof gate, session hang, phaseGuardAfter, reasoning dedup, RO timeout race, MCP logger, alert mis-correlation, KA finalization gap (#1995/#1997/#2003/#2010/#2011/#2017/#2018/#2019)

### DIFF
--- a/api/aianalysis/v1alpha1/aianalysis_types.go
+++ b/api/aianalysis/v1alpha1/aianalysis_types.go
@@ -334,7 +334,8 @@ type AIAnalysisStatus struct {
 	// SubReason provides specific failure cause within the Reason category
 	// BR-HAPI-197: Maps to needs_human_review triggers from KA
 	// BR-HAPI-200: Added InvestigationInconclusive, ProblemResolved for new investigation outcomes
-	// +kubebuilder:validation:Enum=WorkflowNotFound;ImageMismatch;ParameterValidationFailed;NoMatchingWorkflows;LowConfidence;LLMParsingError;ValidationError;TransientError;PermanentError;InvestigationInconclusive;ProblemResolved;NotActionable;MaxRetriesExceeded;SessionRegenerationExceeded;RcaIncomplete;InvestigationFailed;OperatorEscalation
+	// #2019: Added DecisionExpired for a presented-but-unanswered workflow decision
+	// +kubebuilder:validation:Enum=WorkflowNotFound;ImageMismatch;ParameterValidationFailed;NoMatchingWorkflows;LowConfidence;LLMParsingError;ValidationError;TransientError;PermanentError;InvestigationInconclusive;ProblemResolved;NotActionable;MaxRetriesExceeded;SessionRegenerationExceeded;RcaIncomplete;InvestigationFailed;OperatorEscalation;DecisionExpired
 	// +optional
 	SubReason string `json:"subReason,omitempty"`
 
@@ -387,7 +388,11 @@ type AIAnalysisStatus struct {
 	// Reason why human review needed (when NeedsHumanReview=true)
 	// BR-HAPI-197: Maps to KA's human_review_reason enum values
 	// BR-AI-601: alignment_check_failed added for shadow agent alignment verdicts
-	// +kubebuilder:validation:Enum=workflow_not_found;image_mismatch;parameter_validation_failed;no_matching_workflows;low_confidence;llm_parsing_error;investigation_inconclusive;rca_incomplete;alignment_check_failed;operator_escalation
+	// #2019: decision_expired added -- a workflow was found and presented via
+	// kubernaut_present_decision, but no response arrived before the interactive
+	// session's inactivity timeout. Distinguishes this from no_matching_workflows
+	// so the discovered SelectedWorkflow is preserved instead of discarded.
+	// +kubebuilder:validation:Enum=workflow_not_found;image_mismatch;parameter_validation_failed;no_matching_workflows;low_confidence;llm_parsing_error;investigation_inconclusive;rca_incomplete;alignment_check_failed;operator_escalation;decision_expired
 	// +optional
 	HumanReviewReason string `json:"humanReviewReason,omitempty"`
 

--- a/api/openapi/data-storage-v1.yaml
+++ b/api/openapi/data-storage-v1.yaml
@@ -5839,8 +5839,8 @@ components:
           description: True when AI could not produce reliable result
         humanReviewReason:
           type: string
-          enum: [workflow_not_found, image_mismatch, parameter_validation_failed, no_matching_workflows, low_confidence, llm_parsing_error, investigation_inconclusive, rca_incomplete, alignment_check_failed]
-          description: Structured reason when needsHumanReview=true (BR-HAPI-197, BR-HAPI-200, BR-HAPI-212, BR-AI-601)
+          enum: [workflow_not_found, image_mismatch, parameter_validation_failed, no_matching_workflows, low_confidence, llm_parsing_error, investigation_inconclusive, rca_incomplete, alignment_check_failed, decision_expired]
+          description: Structured reason when needsHumanReview=true (BR-HAPI-197, BR-HAPI-200, BR-HAPI-212, BR-AI-601, #2019)
         warnings:
           type: array
           items:

--- a/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/crds/kubernaut.ai_aianalyses.yaml
@@ -694,6 +694,10 @@ spec:
                   Reason why human review needed (when NeedsHumanReview=true)
                   BR-HAPI-197: Maps to KA's human_review_reason enum values
                   BR-AI-601: alignment_check_failed added for shadow agent alignment verdicts
+                  #2019: decision_expired added -- a workflow was found and presented via
+                  kubernaut_present_decision, but no response arrived before the interactive
+                  session's inactivity timeout. Distinguishes this from no_matching_workflows
+                  so the discovered SelectedWorkflow is preserved instead of discarded.
                 enum:
                 - workflow_not_found
                 - image_mismatch
@@ -705,6 +709,7 @@ spec:
                 - rca_incomplete
                 - alignment_check_failed
                 - operator_escalation
+                - decision_expired
                 type: string
               interactiveSession:
                 description: |-
@@ -1142,6 +1147,7 @@ spec:
                   SubReason provides specific failure cause within the Reason category
                   BR-HAPI-197: Maps to needs_human_review triggers from KA
                   BR-HAPI-200: Added InvestigationInconclusive, ProblemResolved for new investigation outcomes
+                  #2019: Added DecisionExpired for a presented-but-unanswered workflow decision
                 enum:
                 - WorkflowNotFound
                 - ImageMismatch
@@ -1160,6 +1166,7 @@ spec:
                 - RcaIncomplete
                 - InvestigationFailed
                 - OperatorEscalation
+                - DecisionExpired
                 type: string
               totalAnalysisTime:
                 description: TotalAnalysisTime is the total duration of the analysis

--- a/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
+++ b/charts/kubernaut/files/crds/kubernaut.ai_aianalyses.yaml
@@ -694,6 +694,10 @@ spec:
                   Reason why human review needed (when NeedsHumanReview=true)
                   BR-HAPI-197: Maps to KA's human_review_reason enum values
                   BR-AI-601: alignment_check_failed added for shadow agent alignment verdicts
+                  #2019: decision_expired added -- a workflow was found and presented via
+                  kubernaut_present_decision, but no response arrived before the interactive
+                  session's inactivity timeout. Distinguishes this from no_matching_workflows
+                  so the discovered SelectedWorkflow is preserved instead of discarded.
                 enum:
                 - workflow_not_found
                 - image_mismatch
@@ -705,6 +709,7 @@ spec:
                 - rca_incomplete
                 - alignment_check_failed
                 - operator_escalation
+                - decision_expired
                 type: string
               interactiveSession:
                 description: |-
@@ -1142,6 +1147,7 @@ spec:
                   SubReason provides specific failure cause within the Reason category
                   BR-HAPI-197: Maps to needs_human_review triggers from KA
                   BR-HAPI-200: Added InvestigationInconclusive, ProblemResolved for new investigation outcomes
+                  #2019: Added DecisionExpired for a presented-but-unanswered workflow decision
                 enum:
                 - WorkflowNotFound
                 - ImageMismatch
@@ -1160,6 +1166,7 @@ spec:
                 - RcaIncomplete
                 - InvestigationFailed
                 - OperatorEscalation
+                - DecisionExpired
                 type: string
               totalAnalysisTime:
                 description: TotalAnalysisTime is the total duration of the analysis

--- a/cmd/apifrontend/main.go
+++ b/cmd/apifrontend/main.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/http/pprof"
 	"os"
 	"os/signal"
 	"strings"
@@ -326,7 +327,7 @@ func run() int {
 	healthAddr := fmt.Sprintf(":%d", cfg.Server.HealthPort)
 	metricsAddr := fmt.Sprintf(":%d", cfg.Server.MetricsPort)
 
-	healthMux := buildHealthMux(handler.AllReady(depsReady, authReady, sessInfra.Healthy.Load), draining)
+	healthMux := buildHealthMux(handler.AllReady(depsReady, authReady, sessInfra.Healthy.Load), draining, cfg.Server.DisableProfiling)
 	healthServer := &http.Server{
 		Addr:              healthAddr,
 		Handler:           healthMux,
@@ -1294,7 +1295,12 @@ func (t *bearerTokenTransport) RoundTrip(req *http.Request) (*http.Response, err
 
 // buildHealthMux constructs the health server mux with dependency-aware readyz.
 // WIRE-01: /readyz must check depsReady, not just draining.
-func buildHealthMux(depsReady handler.ReadyChecker, draining *atomic.Bool) *http.ServeMux {
+// #1995: pprof handlers are gated on disableProfiling and registered only on
+// this internal health mux (never the externally-reachable API router),
+// mirroring kubernautagent's cmd/kubernautagent/health.go pattern -- this
+// adds zero new network exposure since the health port already carries
+// /healthz and /readyz behind the same NetworkPolicy boundary.
+func buildHealthMux(depsReady handler.ReadyChecker, draining *atomic.Bool, disableProfiling bool) *http.ServeMux {
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -1305,6 +1311,13 @@ func buildHealthMux(depsReady handler.ReadyChecker, draining *atomic.Bool) *http
 		checker = func() bool { return true }
 	}
 	mux.Handle("/readyz", handler.ReadyzHandlerFunc(checker, draining))
+	if !disableProfiling {
+		mux.HandleFunc("/debug/pprof/", pprof.Index)
+		mux.HandleFunc("/debug/pprof/cmdline", pprof.Cmdline)
+		mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+		mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+		mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+	}
 	return mux
 }
 

--- a/cmd/apifrontend/main_wiring_test.go
+++ b/cmd/apifrontend/main_wiring_test.go
@@ -45,7 +45,7 @@ import (
 func TestHealthMuxReadyz_DepsHealthy(t *testing.T) {
 	draining := &atomic.Bool{}
 	depsReady := handler.ReadyChecker(func() bool { return true })
-	mux := buildHealthMux(depsReady, draining)
+	mux := buildHealthMux(depsReady, draining, false)
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", http.NoBody))
@@ -57,7 +57,7 @@ func TestHealthMuxReadyz_DepsHealthy(t *testing.T) {
 func TestHealthMuxReadyz_DepsUnhealthy(t *testing.T) {
 	draining := &atomic.Bool{}
 	depsReady := handler.ReadyChecker(func() bool { return false })
-	mux := buildHealthMux(depsReady, draining)
+	mux := buildHealthMux(depsReady, draining, false)
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", http.NoBody))
@@ -70,7 +70,7 @@ func TestHealthMuxReadyz_Draining(t *testing.T) {
 	draining := &atomic.Bool{}
 	draining.Store(true)
 	depsReady := handler.ReadyChecker(func() bool { return true })
-	mux := buildHealthMux(depsReady, draining)
+	mux := buildHealthMux(depsReady, draining, false)
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", http.NoBody))
@@ -81,7 +81,7 @@ func TestHealthMuxReadyz_Draining(t *testing.T) {
 
 func TestHealthMuxReadyz_NilDepsReady(t *testing.T) {
 	draining := &atomic.Bool{}
-	mux := buildHealthMux(nil, draining)
+	mux := buildHealthMux(nil, draining, false)
 
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/readyz", http.NoBody))
@@ -91,11 +91,67 @@ func TestHealthMuxReadyz_NilDepsReady(t *testing.T) {
 }
 
 func TestHealthMuxHealthz_AlwaysOK(t *testing.T) {
-	mux := buildHealthMux(nil, &atomic.Bool{})
+	mux := buildHealthMux(nil, &atomic.Bool{}, false)
 	rec := httptest.NewRecorder()
 	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/healthz", http.NoBody))
 	if rec.Code != http.StatusOK {
 		t.Errorf("TC-A-01c: healthz should always return 200, got %d", rec.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #1995: pprof/debug-endpoint parity with kubernautagent, gated on the
+// internal health mux only. AC-6/SC-8: pprof must never expand the
+// externally-reachable attack surface -- it shares the health port's
+// existing NetworkPolicy boundary (same as /healthz, /readyz today), and
+// must be entirely absent from the main API router.
+// ---------------------------------------------------------------------------
+
+func TestHealthMuxPprof_EnabledWhenProfilingNotDisabled(t *testing.T) {
+	mux := buildHealthMux(nil, &atomic.Bool{}, false)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/pprof/", http.NoBody))
+	if rec.Code != http.StatusOK {
+		t.Errorf("UT-AF-1995-004: expected 200 from /debug/pprof/ when profiling enabled, got %d", rec.Code)
+	}
+}
+
+func TestHealthMuxPprof_AbsentWhenProfilingDisabled(t *testing.T) {
+	mux := buildHealthMux(nil, &atomic.Bool{}, true)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/debug/pprof/", http.NoBody))
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("UT-AF-1995-005: expected 404 from /debug/pprof/ when DisableProfiling=true, got %d", rec.Code)
+	}
+}
+
+// IT-AF-1995-006 [AC-6, SC-8]: the main externally-reachable API router
+// (handler.NewRouter) must never register /debug/pprof/* regardless of the
+// health mux's profiling setting -- pprof is wired exclusively onto the
+// internal health mux/port (see Wiring Manifest in the #1995 plan).
+func TestMainAPIRouter_NeverRegistersPprof(t *testing.T) {
+	t.Parallel()
+
+	reg := metrics.NewRegistry()
+	stubHandler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) { w.WriteHeader(http.StatusOK) })
+	router, err := handler.NewRouter(handler.RouterConfig{
+		MetricsRegistry:  reg,
+		A2AHandler:       stubHandler,
+		MCPHandler:       stubHandler,
+		AgentCardHandler: stubHandler,
+		AuthMiddleware:   func(h http.Handler) http.Handler { return h },
+		ReadyChecker:     func() bool { return true },
+		Draining:         &atomic.Bool{},
+	})
+	if err != nil {
+		t.Fatalf("IT-AF-1995-006: unexpected error building router config: %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/debug/pprof/", http.NoBody)
+	router.ServeHTTP(rec, req)
+	if rec.Code == http.StatusOK {
+		t.Fatal("IT-AF-1995-006 AC-6/SC-8: main API router must never expose /debug/pprof/ -- pprof must be health-mux-only")
 	}
 }
 

--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -1508,6 +1508,9 @@ func buildMCPHandler(
 		EventStore:     eventStore,
 		KeepAlive:      mcpKeepAlive,
 		SessionTimeout: mcpSessionTimeout,
+		// #2017: without this, go-sdk-internal log/error events (including
+		// OnInternalError, go-sdk#1147/#1153) are silently discarded.
+		Logger: logger.WithName("mcp-sdk"),
 	})
 
 	drainer := mcpkg.NewSessionDrainer(leaseMgr, sessionNotifier, logger.WithName("session-drainer"))

--- a/config/crd/bases/kubernaut.ai_aianalyses.yaml
+++ b/config/crd/bases/kubernaut.ai_aianalyses.yaml
@@ -694,6 +694,10 @@ spec:
                   Reason why human review needed (when NeedsHumanReview=true)
                   BR-HAPI-197: Maps to KA's human_review_reason enum values
                   BR-AI-601: alignment_check_failed added for shadow agent alignment verdicts
+                  #2019: decision_expired added -- a workflow was found and presented via
+                  kubernaut_present_decision, but no response arrived before the interactive
+                  session's inactivity timeout. Distinguishes this from no_matching_workflows
+                  so the discovered SelectedWorkflow is preserved instead of discarded.
                 enum:
                 - workflow_not_found
                 - image_mismatch
@@ -705,6 +709,7 @@ spec:
                 - rca_incomplete
                 - alignment_check_failed
                 - operator_escalation
+                - decision_expired
                 type: string
               interactiveSession:
                 description: |-
@@ -1142,6 +1147,7 @@ spec:
                   SubReason provides specific failure cause within the Reason category
                   BR-HAPI-197: Maps to needs_human_review triggers from KA
                   BR-HAPI-200: Added InvestigationInconclusive, ProblemResolved for new investigation outcomes
+                  #2019: Added DecisionExpired for a presented-but-unanswered workflow decision
                 enum:
                 - WorkflowNotFound
                 - ImageMismatch
@@ -1160,6 +1166,7 @@ spec:
                 - RcaIncomplete
                 - InvestigationFailed
                 - OperatorEscalation
+                - DecisionExpired
                 type: string
               totalAnalysisTime:
                 description: TotalAnalysisTime is the total duration of the analysis

--- a/internal/controller/remediationorchestrator/interactive_timeout_test.go
+++ b/internal/controller/remediationorchestrator/interactive_timeout_test.go
@@ -200,6 +200,87 @@ var _ = Describe("DD-INTERACTIVE-002: Interactive Timeout Extension", func() {
 		})
 	})
 
+	// UT-RO-2011-001: reproduces the live #2011 race — AIAnalysis reaches
+	// Completed (CompletedAt set on InteractiveSession in the same instant)
+	// past the base 10m timeout but within the 45m extension window.
+	// checkPhaseTimeouts recomputes the DD-INTERACTIVE-002 extension fresh on
+	// every reconcile, so it is revoked in the exact same reconcile a
+	// same-tick completion needs it most, discarding a valid, policy-
+	// evaluated AutoApproved remediation decision (BR-ORCH-028; ties to
+	// IR-4/SI-4 -- an incident's remediation decision must survive to the
+	// point of use and phase-timeout logic must not misclassify a completed
+	// analysis as timed out). Live repro: rr-cb4412d9f68c-93dc5fff.
+	Context("UT-RO-2011-001: AIAnalysis Completed races the extension revocation", func() {
+		It("should NOT timeout when AIAnalysis is Completed even though CompletedAt just revoked the extension", func() {
+			startedAt := metav1.NewTime(time.Now().Add(-9 * time.Minute))
+			completedAt := metav1.NewTime(time.Now().Add(-1 * time.Second))
+			ai := aiWithInteractiveSession("ai-race-completed", &startedAt, &completedAt)
+			ai.Status.Phase = "Completed"
+			ai.Status.ApprovalRequired = false
+			ai.Status.SelectedWorkflow = &aianalysisv1.SelectedWorkflow{
+				WorkflowID:      "wf-2011-completed",
+				Version:         "1.0.0",
+				ExecutionBundle: "oci://example/bundle@sha256:deadbeef",
+				Confidence:      0.95,
+			}
+			ai.Status.RootCauseAnalysis = &aianalysisv1.RootCauseAnalysis{
+				RemediationTarget: &aianalysisv1.RemediationTarget{
+					Kind: "Deployment", Name: "target-completed", Namespace: "default",
+				},
+			}
+			// Elapsed 10m47s: past base 10m timeout, well within 45m extension.
+			rr := analyzingRR("rr-race-completed", ai.Name, 10*time.Minute+47*time.Second)
+
+			c := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(rr, ai).
+				WithStatusSubresource(rr, ai).
+				Build()
+
+			reconciler := makeReconciler(c, prodcontroller.TimeoutConfig{})
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: rr.Name, Namespace: rr.Namespace}})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &remediationv1.RemediationRequest{}
+			Expect(c.Get(ctx, types.NamespacedName{Name: rr.Name, Namespace: rr.Namespace}, updated)).To(Succeed())
+			Expect(updated.Status.OverallPhase).NotTo(Equal(remediationv1.PhaseTimedOut),
+				"#2011: a Completed AIAnalysis result must not be discarded by the same-reconcile timeout race")
+		})
+	})
+
+	// UT-RO-2011-002: symmetric case for a Failed AIAnalysis -- AnalyzingHandler.Handle
+	// is equally prepared to finalize a Failed AIAnalysis (handleFailed ->
+	// HandleAIAnalysisStatus), so the same same-tick race must not discard a
+	// Failed result into TimedOut either (BR-ORCH-028).
+	Context("UT-RO-2011-002: AIAnalysis Failed races the extension revocation", func() {
+		It("should NOT timeout when AIAnalysis is Failed even though CompletedAt just revoked the extension", func() {
+			startedAt := metav1.NewTime(time.Now().Add(-9 * time.Minute))
+			completedAt := metav1.NewTime(time.Now().Add(-1 * time.Second))
+			ai := aiWithInteractiveSession("ai-race-failed", &startedAt, &completedAt)
+			ai.Status.Phase = "Failed"
+			ai.Status.Message = "LLM investigation exhausted retries"
+			// Elapsed 10m47s: past base 10m timeout, well within 45m extension.
+			rr := analyzingRR("rr-race-failed", ai.Name, 10*time.Minute+47*time.Second)
+			// handleFailed's manual-review notification path sets an owner
+			// reference on the RR, which requires a non-empty UID (the fake
+			// client does not auto-assign one for pre-supplied objects).
+			rr.UID = types.UID("rr-race-failed-uid")
+
+			c := fake.NewClientBuilder().WithScheme(scheme).
+				WithObjects(rr, ai).
+				WithStatusSubresource(rr, ai).
+				Build()
+
+			reconciler := makeReconciler(c, prodcontroller.TimeoutConfig{})
+			_, err := reconciler.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: rr.Name, Namespace: rr.Namespace}})
+			Expect(err).NotTo(HaveOccurred())
+
+			updated := &remediationv1.RemediationRequest{}
+			Expect(c.Get(ctx, types.NamespacedName{Name: rr.Name, Namespace: rr.Namespace}, updated)).To(Succeed())
+			Expect(updated.Status.OverallPhase).NotTo(Equal(remediationv1.PhaseTimedOut),
+				"#2011: a Failed AIAnalysis result must not be discarded by the same-reconcile timeout race")
+		})
+	})
+
 	// UT-RO-703-004: Per-RR override takes precedence when larger than MaxAnalyzing
 	// BR: BR-ORCH-028 (AC-028-5: per-RR overrides)
 	Context("UT-RO-703-004: Per-RR override larger than MaxAnalyzing wins", func() {

--- a/internal/controller/remediationorchestrator/reconciler.go
+++ b/internal/controller/remediationorchestrator/reconciler.go
@@ -2723,7 +2723,18 @@ func (r *Reconciler) checkPhaseTimeouts(ctx context.Context, rr *remediationv1.R
 
 	// DD-INTERACTIVE-002: Extend Analyzing timeout when interactive session is active
 	if currentPhase == remediationv1.PhaseAnalyzing {
-		phaseTimeout = r.applyInteractiveTimeoutExtension(ctx, rr, phaseTimeout)
+		extended, aiTerminal := r.applyInteractiveTimeoutExtension(ctx, rr, phaseTimeout)
+		if aiTerminal {
+			// #2011: AIAnalysis already reached Completed/Failed. The extension
+			// above is computed fresh from AIAnalysis's *current* state on every
+			// reconcile, so it is revoked in the exact same reconcile that a
+			// same-tick completion needs it most (CompletedAt is set the instant
+			// Phase becomes terminal). Skip the timeout comparison entirely here
+			// and let the Analyzing phase handler (below, same reconcile) consume
+			// the result instead of racing it into TimedOut.
+			return nil
+		}
+		phaseTimeout = extended
 	}
 
 	// Check if phase has exceeded timeout
@@ -2742,12 +2753,14 @@ func (r *Reconciler) checkPhaseTimeouts(ctx context.Context, rr *remediationv1.R
 }
 
 // applyInteractiveTimeoutExtension checks if the associated AIAnalysis has an active
-// interactive session and extends the timeout to MaxAnalyzing if so.
-// Falls back gracefully to the original timeout on AA fetch errors.
-// Reference: DD-INTERACTIVE-002 (dynamic timeout extension)
-func (r *Reconciler) applyInteractiveTimeoutExtension(ctx context.Context, rr *remediationv1.RemediationRequest, defaultTimeout time.Duration) time.Duration {
+// interactive session and extends the timeout to MaxAnalyzing if so. It also reports
+// whether AIAnalysis has already reached a terminal phase (Completed/Failed) via the
+// second return value (#2011) -- see checkPhaseTimeouts's caller for why that matters.
+// Falls back gracefully to the original timeout (and aiTerminal=false) on AA fetch errors.
+// Reference: DD-INTERACTIVE-002 (dynamic timeout extension), #2011
+func (r *Reconciler) applyInteractiveTimeoutExtension(ctx context.Context, rr *remediationv1.RemediationRequest, defaultTimeout time.Duration) (extendedTimeout time.Duration, aiTerminal bool) {
 	if rr.Status.AIAnalysisRef == nil {
-		return defaultTimeout
+		return defaultTimeout, false
 	}
 
 	logger := log.FromContext(ctx)
@@ -2763,11 +2776,21 @@ func (r *Reconciler) applyInteractiveTimeoutExtension(ctx context.Context, rr *r
 	if err := r.client.Get(ctx, key, ai); err != nil {
 		logger.V(1).Info("Failed to fetch AIAnalysis for interactive timeout check, using default",
 			"aiAnalysis", key, "error", err)
-		return defaultTimeout
+		return defaultTimeout, false
+	}
+
+	// #2011: A terminal AIAnalysis (Completed/Failed) is exactly what
+	// AnalyzingHandler.Handle is waiting to consume -- regardless of whether the
+	// interactive-session extension below is still active. Report it so the
+	// caller can skip the timeout comparison entirely rather than risk
+	// discarding a result that exists only because the (now-revoked) extension
+	// gave it the time to finish.
+	if ai.Status.Phase == "Completed" || ai.Status.Phase == "Failed" {
+		return defaultTimeout, true
 	}
 
 	if ai.Status.InteractiveSession == nil {
-		return defaultTimeout
+		return defaultTimeout, false
 	}
 
 	// Active session: StartedAt set, CompletedAt nil
@@ -2779,11 +2802,11 @@ func (r *Reconciler) applyInteractiveTimeoutExtension(ctx context.Context, rr *r
 				"actingUser", ai.Status.InteractiveSession.ActingUser,
 				"defaultTimeout", defaultTimeout,
 				"extendedTimeout", extended)
-			return extended
+			return extended, false
 		}
 	}
 
-	return defaultTimeout
+	return defaultTimeout, false
 }
 
 // handlePhaseTimeout handles phase timeout by transitioning to TimedOut phase.

--- a/internal/kubernautagent/api/openapi.json
+++ b/internal/kubernautagent/api/openapi.json
@@ -1058,10 +1058,11 @@
           "investigation_inconclusive",
           "rca_incomplete",
           "alignment_check_failed",
-          "operator_escalation"
+          "operator_escalation",
+          "decision_expired"
         ],
         "title": "HumanReviewReason",
-        "description": "Structured reason for needs_human_review=true.\n\nBusiness Requirements: BR-HAPI-197, BR-HAPI-200, BR-496, BR-AI-601, BR-WORKFLOW-1418\nDesign Decision: DD-HAPI-002 v1.2, DD-HAPI-006 v1.3, DD-AF-007\n\nAIAnalysis uses this for reliable subReason mapping instead of parsing warnings."
+        "description": "Structured reason for needs_human_review=true.\n\nBusiness Requirements: BR-HAPI-197, BR-HAPI-200, BR-496, BR-AI-601, BR-WORKFLOW-1418\nDesign Decision: DD-HAPI-002 v1.2, DD-HAPI-006 v1.3, DD-AF-007\n\nAIAnalysis uses this for reliable subReason mapping instead of parsing warnings. #2019: decision_expired covers a presented-but-unanswered kubernaut_present_decision that expired via interactive inactivity timeout."
       },
       "IncidentRequest": {
         "properties": {

--- a/internal/kubernautagent/audit/coverage_668_test.go
+++ b/internal/kubernautagent/audit/coverage_668_test.go
@@ -85,6 +85,37 @@ var _ = Describe("Kubernaut Agent audit coverage 668 (BR-HAPI-197 DD-AUDIT-002)"
 			Expect(payload.ResponseData.HumanReviewReason.Value).To(Equal(ogenclient.IncidentResponseDataHumanReviewReasonRcaIncomplete))
 		})
 
+		It("UT-KA-2019-010: maps decision_expired onto the ogen enum value (#2019 audit whitelist)", func() {
+			recorder := &fakeOgenClient{}
+			store := audit.NewDSAuditStore(recorder)
+
+			rd, err := json.Marshal(map[string]interface{}{
+				"rca_summary":         "workflow found and presented, decision not received before timeout",
+				"severity":            "high",
+				"confidence":          0.9,
+				"needs_human_review":  true,
+				"human_review_reason": "decision_expired",
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			event := audit.NewEvent(audit.EventTypeResponseComplete, "corr-hr-decision-expired")
+			event.EventAction = audit.ActionResponseSent
+			event.EventOutcome = audit.OutcomeSuccess
+			event.Data["response_data"] = string(rd)
+			event.Data["total_prompt_tokens"] = 10
+			event.Data["total_completion_tokens"] = 5
+
+			Expect(store.StoreAudit(context.Background(), event)).To(Succeed())
+			req := recorder.calls[0]
+			payload, ok := req.EventData.GetAIAgentResponsePayload()
+			Expect(ok).To(BeTrue())
+			Expect(payload.ResponseData.NeedsHumanReview.Set).To(BeTrue())
+			Expect(payload.ResponseData.NeedsHumanReview.Value).To(BeTrue())
+			Expect(payload.ResponseData.HumanReviewReason.Set).To(BeTrue(),
+				"AU-2/AU-3: decision_expired must not be silently dropped from the audit record (#2019)")
+			Expect(payload.ResponseData.HumanReviewReason.Value).To(Equal(ogenclient.IncidentResponseDataHumanReviewReasonDecisionExpired))
+		})
+
 		It("drops unrecognised human_review_reason strings so OpenAPI validation keeps the event", func() {
 			recorder := &fakeOgenClient{}
 			store := audit.NewDSAuditStore(recorder)

--- a/internal/kubernautagent/audit/ds_store.go
+++ b/internal/kubernautagent/audit/ds_store.go
@@ -788,6 +788,7 @@ var validHumanReviewReasons = map[string]ogenclient.IncidentResponseDataHumanRev
 	"investigation_inconclusive":  ogenclient.IncidentResponseDataHumanReviewReasonInvestigationInconclusive,
 	"rca_incomplete":              ogenclient.IncidentResponseDataHumanReviewReasonRcaIncomplete,
 	"alignment_check_failed": ogenclient.IncidentResponseDataHumanReviewReasonAlignmentCheckFailed,
+	"decision_expired":       ogenclient.IncidentResponseDataHumanReviewReasonDecisionExpired, // #2019
 }
 
 // validHumanReviewReason returns the ogen enum value if the string is a recognised

--- a/internal/kubernautagent/investigator/investigator_tools.go
+++ b/internal/kubernautagent/investigator/investigator_tools.go
@@ -19,12 +19,13 @@ package investigator
 import (
 	"context"
 	"encoding/json"
+	"strings"
 
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/alignment"
-	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/tools/summarizer"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 )
 
 func escalateMaxTokens(completionTokens int) int {
@@ -73,11 +74,23 @@ func truncatePreview(s string, maxLen int) string {
 // calls, because Sonnet 5 puts its narrative in the private, signed thinking
 // block instead of visible Content. Authority: BR-AI-086, FedRAMP CC7.2
 // (#1935 finding #3).
+//
+// #2010: Claude's extended-thinking + tool-use behavior frequently ends the
+// private thinking block with a short one-line plan and then repeats that
+// identical line as the visible Content right before the tool_use block, so
+// Reasoning.Text and Content are genuine, byte-for-byte (or whitespace-only)
+// duplicates on a meaningful fraction of turns. Concatenating both
+// unconditionally in that case produced a single reasoning_delta event whose
+// text was literally "X\n\nX", so the Console's ThinkingPanel showed the
+// same sentence twice separated by a blank line. When the two match (after
+// trimming), only Reasoning.Text is surfaced -- no information is lost
+// since Content is identical modulo whitespace. Authority: BR-AI-086,
+// FedRAMP CC7.2/SI-10.
 func reasoningDeltaText(msg llm.Message) string {
 	if msg.Reasoning == nil || msg.Reasoning.Text == "" {
 		return msg.Content
 	}
-	if msg.Content == "" {
+	if msg.Content == "" || strings.TrimSpace(msg.Content) == strings.TrimSpace(msg.Reasoning.Text) {
 		return msg.Reasoning.Text
 	}
 	return msg.Reasoning.Text + "\n\n" + msg.Content

--- a/internal/kubernautagent/investigator/reasoning_delta_console_1935_test.go
+++ b/internal/kubernautagent/investigator/reasoning_delta_console_1935_test.go
@@ -29,6 +29,8 @@ import (
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
 	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	afka "github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
+	aftools "github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
 	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
 	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
 )
@@ -226,5 +228,79 @@ var _ = Describe("#1935 finding #3: console ThinkingPanel must not go blank on S
 				"IT-KA-1935-014: retryWorkflowSubmit's reasoning_delta event must fall back to Reasoning.Text "+
 					"when the retry turn's Content is empty (#1935 finding #3)")
 		})
+	})
+})
+
+// #2010 (BR-AI-086, FedRAMP CC7.2/SI-10): drives a real Investigator through
+// its real production event-sink wiring with an LLM turn shaped exactly like
+// the live PR #2000 dev-environment observation -- Claude repeats the same
+// one-line plan in both Reasoning.Text and Content immediately before a tool
+// call -- and proves the resulting reasoning_delta event (as it will
+// actually reach the Console via AF's real FormatEventForUser) shows the
+// sentence exactly once, not as a self-duplicated "X\n\nX" entry.
+var _ = Describe("IT-KA-2010-002: reasoning_delta does not self-duplicate identical Reasoning.Text and Content on the wire", func() {
+	It("emits a single, non-duplicated sentence when Claude repeats its plan in both blocks", func() {
+		eventCh := make(chan session.InvestigationEvent, 64)
+		ctx := session.WithEventSink(context.Background(), eventCh)
+
+		duplicateText := "Let me now gather the pod logs and events for complete evidence."
+		mockClient := &cancelAwareMockClient{
+			responses: []llm.ChatResponse{
+				{
+					Message: llm.Message{
+						Role:      "assistant",
+						Content:   duplicateText,
+						Reasoning: &llm.ReasoningBlock{Text: duplicateText},
+					},
+					ToolCalls: []llm.ToolCall{
+						{ID: "tc_1", Name: "kubectl_get_logs", Arguments: `{"kind":"Pod","name":"test","namespace":"default"}`},
+					},
+					Usage: llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+				},
+				{
+					Message: llm.Message{
+						Role:    "assistant",
+						Content: `{"rca_summary":"pod OOM killed","confidence":0.9}`,
+					},
+					Usage: llm.TokenUsage{PromptTokens: 200, CompletionTokens: 100, TotalTokens: 300},
+				},
+			},
+		}
+
+		inv := streamTestInvestigator(mockClient)
+		go func() {
+			_, _ = inv.Investigate(ctx, streamSignal)
+			close(eventCh)
+		}()
+
+		events := collectEvents(eventCh)
+
+		var kaEvent *session.InvestigationEvent
+		for i := range events {
+			if events[i].Type == session.EventTypeReasoningDelta {
+				kaEvent = &events[i]
+				break
+			}
+		}
+		Expect(kaEvent).NotTo(BeNil(), "IT-KA-2010-002: must emit a reasoning_delta event for the turn")
+
+		var data map[string]interface{}
+		Expect(json.Unmarshal(kaEvent.Data, &data)).To(Succeed())
+		text, _ := data["text"].(string)
+		Expect(text).To(Equal(duplicateText),
+			"IT-KA-2010-002: KA's own emitted event must not concatenate identical Reasoning.Text and "+
+				"Content into a self-duplicated entry")
+
+		// Full KA/AF wire-contract proof (mirrors IT-KA-1771-001): the same
+		// wire hop AF actually performs (MCP JSON transport -> ka.InvestigationEvent
+		// -> production FormatEventForUser) must not reintroduce duplication.
+		wireBytes, err := json.Marshal(kaEvent)
+		Expect(err).NotTo(HaveOccurred())
+		var afEvent afka.InvestigationEvent
+		Expect(json.Unmarshal(wireBytes, &afEvent)).To(Succeed())
+		displayText := aftools.FormatEventForUser(afEvent)
+		Expect(displayText).To(Equal(duplicateText),
+			"IT-KA-2010-002: the operator-observable Console text (AF's production FormatEventForUser "+
+				"output) must show the duplicate-prone sentence exactly once")
 	})
 })

--- a/internal/kubernautagent/investigator/reasoning_delta_thinking_1935_test.go
+++ b/internal/kubernautagent/investigator/reasoning_delta_thinking_1935_test.go
@@ -79,3 +79,48 @@ var _ = Describe("UT-KA-1935-011: reasoningDeltaText combines Reasoning.Text wit
 		Expect(reasoningDeltaText(msg)).To(Equal(""))
 	})
 })
+
+// #2010 (BR-AI-086, FedRAMP CC7.2/SI-10): Claude's extended-thinking +
+// tool-use behavior frequently ends the private "thinking" block with a
+// short one-line plan and then repeats that identical line as the visible
+// "text" block immediately before the tool_use block (the same underlying
+// LLM behavior documented for #2006 on main, via DD-LLM-009). Before this
+// fix, reasoningDeltaText's unconditional concatenation produced a single
+// reasoning_delta event whose text was literally "X\n\nX", so the Console's
+// ThinkingPanel showed the same sentence twice, separated by a blank line.
+// Observed live in the PR #2000 dev environment (console-e2e-approval run).
+var _ = Describe("UT-KA-2010-001: reasoningDeltaText does not repeat identical Reasoning.Text and Content", func() {
+	It("returns a single copy when Reasoning.Text and Content are byte-for-byte identical", func() {
+		msg := llm.Message{
+			Role:      "assistant",
+			Content:   "Let me now gather the pod logs and events for complete evidence.",
+			Reasoning: &llm.ReasoningBlock{Text: "Let me now gather the pod logs and events for complete evidence."},
+		}
+		Expect(reasoningDeltaText(msg)).To(Equal("Let me now gather the pod logs and events for complete evidence."),
+			"UT-KA-2010-001: identical Reasoning.Text and Content must not be concatenated into a "+
+				"self-duplicated \"X\\n\\nX\" ThinkingPanel entry")
+	})
+
+	It("returns a single copy when Reasoning.Text and Content differ only by surrounding whitespace", func() {
+		msg := llm.Message{
+			Role:      "assistant",
+			Content:   "  Checking the ConfigMap as well.\n",
+			Reasoning: &llm.ReasoningBlock{Text: "Checking the ConfigMap as well."},
+		}
+		Expect(reasoningDeltaText(msg)).To(Equal("Checking the ConfigMap as well."),
+			"UT-KA-2010-001: a whitespace-only difference is still the same sentence to the operator "+
+				"and must not be shown twice")
+	})
+
+	It("still concatenates when Reasoning.Text and Content genuinely differ (no false-positive suppression)", func() {
+		msg := llm.Message{
+			Role:      "assistant",
+			Content:   "Calling kubectl_describe now.",
+			Reasoning: &llm.ReasoningBlock{Text: "The pod is crash-looping; I should inspect the spec first."},
+		}
+		Expect(reasoningDeltaText(msg)).To(Equal(
+			"The pod is crash-looping; I should inspect the spec first.\n\nCalling kubectl_describe now."),
+			"UT-KA-2010-001: distinct reasoning and content must both still reach the operator, "+
+				"exactly as UT-KA-1935-011 already proves")
+	})
+})

--- a/internal/kubernautagent/mcp/server.go
+++ b/internal/kubernautagent/mcp/server.go
@@ -18,10 +18,12 @@ package mcp
 
 import (
 	"context"
+	"log/slog"
 	"net/http"
 	"sync/atomic"
 	"time"
 
+	"github.com/go-logr/logr"
 	sharedauth "github.com/jordigilh/kubernaut/pkg/shared/auth"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -33,18 +35,36 @@ type MCPServer struct {
 	toolCount atomic.Int32
 }
 
+// MCPServerOption configures optional NewMCPServer behavior. Additive: callers
+// that pass none get the pre-#2017 default (an unset Logger, i.e. go-sdk's
+// discard logger).
+type MCPServerOption func(*mcpsdk.ServerOptions)
+
+// WithMCPLogger threads a logr.Logger into the go-sdk server's ServerOptions
+// via the logr->slog adapter, so SDK-internal log/error events (including
+// OnInternalError -- go-sdk#1147/go-sdk#1153) reach KA's log stream instead
+// of being silently dropped by the SDK's default discard logger (#2016/#2017).
+func WithMCPLogger(logger logr.Logger) MCPServerOption {
+	return func(opts *mcpsdk.ServerOptions) {
+		opts.Logger = slog.New(logr.ToSlogHandler(logger))
+	}
+}
+
 // NewMCPServer creates a new MCP server instance configured for Kubernaut Agent
 // interactive mode. The server starts with zero tools; tools are registered
 // via RegisterTools before the handler is created.
-func NewMCPServer(keepAlive time.Duration) *MCPServer {
+func NewMCPServer(keepAlive time.Duration, options ...MCPServerOption) *MCPServer {
 	impl := &mcpsdk.Implementation{
 		Name:    "kubernaut-agent-interactive",
 		Version: "1.5.0",
 	}
 
-	var opts *mcpsdk.ServerOptions
+	opts := &mcpsdk.ServerOptions{}
 	if keepAlive > 0 {
-		opts = &mcpsdk.ServerOptions{KeepAlive: keepAlive}
+		opts.KeepAlive = keepAlive
+	}
+	for _, option := range options {
+		option(opts)
 	}
 	server := mcpsdk.NewServer(impl, opts)
 
@@ -96,6 +116,10 @@ type MCPDeps struct {
 	// SessionTimeout auto-closes idle MCP HTTP sessions (#1387).
 	// Zero means never.
 	SessionTimeout time.Duration
+	// Logger receives go-sdk-internal log/error events (e.g. OnInternalError)
+	// via the logr->slog adapter. Zero value (unset) preserves the pre-#2017
+	// behavior of a discard logger. #2016/#2017.
+	Logger logr.Logger
 }
 
 // userFromContext extracts the authenticated user identity from the request
@@ -145,7 +169,7 @@ func BootstrapMCP(deps MCPDeps) (http.Handler, *MCPServer) {
 		panic("MCP interactive mode enabled but auth middleware is nil — refusing to start without authentication")
 	}
 
-	srv := NewMCPServer(deps.KeepAlive)
+	srv := NewMCPServer(deps.KeepAlive, WithMCPLogger(deps.Logger))
 	srv.registerTools(deps.Tools)
 
 	var opts *mcpsdk.StreamableHTTPOptions

--- a/internal/kubernautagent/mcp/server_test.go
+++ b/internal/kubernautagent/mcp/server_test.go
@@ -25,8 +25,10 @@ import (
 	"time"
 
 	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 
 	kaconfig "github.com/jordigilh/kubernaut/internal/kubernautagent/config"
 	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
@@ -184,6 +186,49 @@ var _ = Describe("BootstrapMCP Auth Architecture — #895/#896", func() {
 
 			Expect(authCallCount.Load()).To(Equal(int32(0)),
 				"BootstrapMCP must NOT apply auth internally; auth should be applied at router level")
+		})
+	})
+})
+
+// #2016/#2017: without a wired logger, go-sdk's ensureLogger(nil) defaults to
+// a discard *slog.Logger (go-sdk@v1.7.0/mcp/logging.go:104), silently
+// dropping OnInternalError and all other SDK-internal log paths -- this is
+// exactly the diagnosability gap that slowed #1949's triage. Authority:
+// AU-2/AU-3 (Audit Events / Content of Audit Records), SI-4 (System
+// Monitoring) -- no numbered BR exists for this observability enhancement
+// (confirmed absent from docs/requirements/ during planning).
+var _ = Describe("MCP Server Logger Wiring — #2016/#2017", func() {
+
+	Describe("UT-KA-2017-001: WithMCPLogger forwards SDK-internal log/error events", func() {
+		It("should route ServerOptions.Logger.Error calls through to the provided logr.Logger sink", func() {
+			var captured []string
+			captureLogger := funcr.New(func(prefix, args string) {
+				captured = append(captured, args)
+			}, funcr.Options{})
+
+			opts := &mcpsdk.ServerOptions{}
+			mcpinternal.WithMCPLogger(captureLogger)(opts)
+
+			Expect(opts.Logger).NotTo(BeNil(),
+				"WithMCPLogger must set ServerOptions.Logger instead of leaving it nil (go-sdk's discard default)")
+
+			opts.Logger.Error("jsonrpc2 internal error", "error", "simulated write failure")
+			Expect(captured).NotTo(BeEmpty(),
+				"the forwarded slog record must reach the underlying logr.Logger sink, not be silently discarded")
+		})
+	})
+
+	Describe("UT-KA-2017-002: zero-value Logger in MCPDeps remains a safe no-op", func() {
+		It("should not panic when MCPDeps.Logger is the zero value (pre-#2017 default behavior)", func() {
+			Expect(func() {
+				handler, srv := mcpinternal.BootstrapMCP(mcpinternal.MCPDeps{
+					AuthMiddleware: func(next http.Handler) http.Handler { return next },
+					Logger:         logr.Logger{}, // explicit zero value
+				})
+				Expect(handler).NotTo(BeNil())
+				Expect(srv).NotTo(BeNil())
+			}).NotTo(Panic(),
+				"logr.Logger's zero value guards on sink == nil (go-logr@v1.4.4), so BootstrapMCP must tolerate it safely")
 		})
 	})
 })

--- a/internal/kubernautagent/mcp/tools/cancel_lifecycle_test.go
+++ b/internal/kubernautagent/mcp/tools/cancel_lifecycle_test.go
@@ -268,6 +268,8 @@ func (c *cancelLifecycleHTTPCompleter) ForceCompleteByRemediationID(_ string, re
 	return nil
 }
 
+func (c *cancelLifecycleHTTPCompleter) PersistPendingDecisionResult(_ string, _ *katypes.InvestigationResult) {}
+
 func (c *cancelLifecycleHTTPCompleter) getCompleted() (string, *katypes.InvestigationResult) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/kubernautagent/mcp/tools/discover_workflows_no_match_2003_it_test.go
+++ b/internal/kubernautagent/mcp/tools/discover_workflows_no_match_2003_it_test.go
@@ -1,0 +1,158 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools_test
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+	mcptools "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// IT-KA-2003-001 proves the fix through the REAL production dispatch path —
+// InvestigateTool.Handle(action=discover_workflows) — wired to a real
+// session.Manager (not a mock), so EmitSessionEndedByRR's real
+// emitTerminalEvent -> sink.Emit path executes and the terminal event is
+// forwarded by the real EventLogBridge, exactly as it is in production
+// (#1438, AU-3, SI-4). This is what distinguishes it from the UT: the UT
+// proves handleDiscoverWorkflows calls the right mock methods; this IT proves
+// the whole KA-side signal actually reaches the point AF's WatchTerminalEvents
+// is listening at.
+var _ = Describe("IT #2003 — discover_workflows(no_matching_workflows) auto-closes via the real dispatch path", func() {
+
+	It("IT-KA-2003-001 (AU-3, SI-4): session_ended propagates through EventLogBridge promptly, without waiting for inactivity timeout", func() {
+		store := session.NewStore(30 * time.Minute)
+		mgr := session.NewManager(store, logr.Discard(), audit.NopAuditStore{}, nil)
+
+		rrID := "rr-it-2003-001"
+
+		By("Start and launch an interactive session so a stored RCA result exists for rrID")
+		readyCh := make(chan struct{})
+		pendingID, err := mgr.StartInteractiveSession(context.Background(),
+			func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				<-readyCh
+				return &katypes.InvestigationResult{
+					InteractiveHold: true,
+					RCASummary:      "OOM crash on payments-api",
+				}, nil
+			},
+			map[string]string{"remediation_id": rrID},
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(mgr.LaunchDeferredInvestigation(pendingID)).To(Succeed())
+
+		By("Subscribe before releasing the goroutine — activates the LazySink")
+		eventCh, subErr := mgr.Subscribe(context.Background(), pendingID)
+		Expect(subErr).NotTo(HaveOccurred())
+
+		By("Start EventLogBridge (production wiring)")
+		capture := &logCapture{}
+		bridge := mcptools.NewEventLogBridge(eventCh, capture.logFn, logr.Discard(), pendingID)
+		bridgeCtx, bridgeCancel := context.WithCancel(context.Background())
+		defer bridgeCancel()
+		go bridge.Run(bridgeCtx)
+
+		close(readyCh)
+
+		By("Wait for the session to reach StatusUserDriving (RCA stored, ready for discover_workflows)")
+		Eventually(func() session.Status {
+			s, _ := mgr.GetSession(pendingID)
+			if s == nil {
+				return ""
+			}
+			return s.Status
+		}, 5*time.Second).Should(Equal(session.StatusUserDriving))
+
+		Eventually(func() int { return capture.count() }, 3*time.Second).Should(BeNumerically(">=", 1),
+			"drain the EventTypeComplete emitted by the investigation goroutine's exit")
+
+		By("Drive discover_workflows through the real InvestigateTool, mirroring production wiring: " +
+			"autoMgr AND httpCompleter both point at the same session.Manager (cmd/kubernautagent/main.go: WithHTTPCompleter(autoMgr))")
+		leaseSessions := &mockSessionManager{
+			isActive: true,
+			getDriverResult: &mcpinternal.InteractiveSession{
+				SessionID:     "lease-it-2003-001",
+				CorrelationID: rrID,
+				ActingUser:    mcpinternal.UserInfo{Username: "alice"},
+			},
+		}
+		runner := &mockInvestigatorRunner{
+			workflowDiscoveryResult: &katypes.InvestigationResult{
+				RCASummary:        "OOM crash on payments-api",
+				HumanReviewNeeded: true,
+				HumanReviewReason: "no_matching_workflows",
+			},
+		}
+		recon := &mockContextReconstructor{}
+
+		tool := mcptools.NewInvestigateTool(leaseSessions, runner, recon, mgr,
+			mcptools.WithHTTPCompleter(mgr),
+			mcptools.WithWorkflowCatalog(&mockWorkflowCatalog{}),
+		)
+
+		output, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+			RRID:   rrID,
+			Action: mcptools.ActionDiscoverWorkflows,
+		}, mcpinternal.UserInfo{Username: "alice"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output.Status).To(Equal("workflows_discovered"))
+
+		By("Verify EventLogBridge forwarded session_ended promptly (no inactivity-timeout-scale wait)")
+		Eventually(func() string {
+			raw := capture.latest()
+			if raw == nil {
+				return ""
+			}
+			var env struct {
+				EventType string `json:"type"`
+			}
+			_ = json.Unmarshal(raw, &env)
+			return env.EventType
+		}, 3*time.Second).Should(Equal(session.EventTypeSessionEnded))
+
+		var env struct {
+			EventType string `json:"type"`
+			Phase     string `json:"phase"`
+			Seq       int64  `json:"seq"`
+		}
+		Expect(json.Unmarshal(capture.latest(), &env)).To(Succeed())
+		Expect(env.Phase).To(Equal("no_matching_workflows"),
+			"AU-3: terminal event must carry the release reason so AF can map it to a console phase")
+		Expect(env.Seq).To(BeNumerically(">", 0),
+			"SI-4: event must have a positive sequence number for ordering")
+
+		By("Verify the real session actually transitioned to terminal (StatusCompleted), " +
+			"proving production dispatch drove the real session lifecycle, not just a mock call")
+		Eventually(func() session.Status {
+			s, _ := mgr.GetSession(pendingID)
+			if s == nil {
+				return ""
+			}
+			return s.Status
+		}, 3*time.Second).Should(Equal(session.StatusCompleted))
+	})
+})

--- a/internal/kubernautagent/mcp/tools/discover_workflows_no_match_2003_test.go
+++ b/internal/kubernautagent/mcp/tools/discover_workflows_no_match_2003_test.go
@@ -100,12 +100,15 @@ func (m *mockAutoMgrDW2003) getEmitCalls() []emitCall {
 // because this scenario specifically needs to record the completion step
 // into the shared orderRecorder, not just capture the final result value.
 type orderedHTTPCompleter struct {
-	mu          sync.Mutex
-	completedID string
-	completed   *katypes.InvestigationResult
-	found       bool
-	foundID     string
-	order       *orderRecorder
+	mu            sync.Mutex
+	completedID   string
+	completed     *katypes.InvestigationResult
+	found         bool
+	foundID       string
+	order         *orderRecorder
+	pendingID     string
+	pendingResult *katypes.InvestigationResult
+	pendingCalls  int
 }
 
 func (c *orderedHTTPCompleter) FindUserDrivingByRemediationID(_ string) (string, bool) {
@@ -129,10 +132,24 @@ func (c *orderedHTTPCompleter) ForceCompleteByRemediationID(_ string, _ *katypes
 	return nil
 }
 
+func (c *orderedHTTPCompleter) PersistPendingDecisionResult(id string, result *katypes.InvestigationResult) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.pendingID = id
+	c.pendingResult = result
+	c.pendingCalls++
+}
+
 func (c *orderedHTTPCompleter) getCompleted() (string, *katypes.InvestigationResult) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	return c.completedID, c.completed
+}
+
+func (c *orderedHTTPCompleter) getPending() (string, *katypes.InvestigationResult, int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.pendingID, c.pendingResult, c.pendingCalls
 }
 
 var _ = Describe("#2003: discover_workflows auto-closes session on no_matching_workflows", func() {
@@ -247,6 +264,108 @@ var _ = Describe("#2003: discover_workflows auto-closes session on no_matching_w
 				id, _ := sessionMgr.getReleased()
 				g.Expect(id).To(BeEmpty(), "session must remain active for the user to select a workflow")
 			}).WithTimeout(300 * time.Millisecond).WithPolling(50 * time.Millisecond).Should(Succeed())
+		})
+	})
+
+	Describe("UT-KA-2019-004: a found workflow is preserved as a pending decision (in case of inactivity timeout)", func() {
+		It("should call PersistPendingDecisionResult with decision_expired marked and the discovered fields intact", func() {
+			autoMgr := &mockAutoMgrDW2003{
+				rcaResult: &katypes.InvestigationResult{RCASummary: "OOM crash"},
+			}
+			completer := &orderedHTTPCompleter{foundID: "http-sess-2019-004", found: true}
+			sessionMgr := &mockSessionManager{
+				isActive: true,
+				getDriverResult: &mcpinternal.InteractiveSession{
+					SessionID:     "sess-2019-004",
+					CorrelationID: "rr-2019-004",
+					ActingUser:    mcpinternal.UserInfo{Username: "alice"},
+				},
+			}
+			runner := &mockInvestigatorRunner{
+				workflowDiscoveryResult: &katypes.InvestigationResult{
+					RCASummary:        "OOM crash",
+					WorkflowID:        "wf-recommended-2019",
+					Confidence:        0.9,
+					WorkflowRationale: "restart the crashlooping pod",
+				},
+			}
+			recon := &mockContextReconstructor{}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr,
+				mcptools.WithHTTPCompleter(completer),
+				mcptools.WithWorkflowCatalog(&mockWorkflowCatalog{
+					workflow: &mcptools.CatalogWorkflow{WorkflowID: "wf-recommended-2019", WorkflowName: "Mock Workflow"},
+				}),
+			)
+
+			output, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-2019-004",
+				Action: mcptools.ActionDiscoverWorkflows,
+			}, mcpinternal.UserInfo{Username: "alice"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output.Status).To(Equal("workflows_discovered"))
+
+			id, result, calls := completer.getPending()
+			Expect(calls).To(Equal(1), "#2019: a found workflow must be persisted exactly once as a pending decision")
+			Expect(id).To(Equal("http-sess-2019-004"))
+			Expect(result).NotTo(BeNil())
+			Expect(result.WorkflowID).To(Equal("wf-recommended-2019"),
+				"#2019: the discovered workflow identity must survive into the pending-decision preview")
+			Expect(result.WorkflowRationale).To(Equal("restart the crashlooping pod"))
+			Expect(result.HumanReviewNeeded).To(BeTrue())
+			Expect(result.HumanReviewReason).To(Equal(katypes.HumanReviewReasonDecisionExpired),
+				"#2019: the preview must be marked decision_expired so a later inactivity-timeout completion "+
+					"is distinguishable from a genuine no_matching_workflows outcome")
+		})
+	})
+
+	Describe("UT-KA-2019-005: no_matching_workflows does not also persist a pending decision (regression guard)", func() {
+		It("should not call PersistPendingDecisionResult when the outcome is the #2003 auto-close path", func() {
+			order := &orderRecorder{}
+			completer := &orderedHTTPCompleter{foundID: "http-sess-2019-005", found: true, order: order}
+			autoMgr := &mockAutoMgrDW2003{
+				rcaResult: &katypes.InvestigationResult{RCASummary: "OOM crash"},
+				order:     order,
+			}
+			sessionMgr := &mockSessionManager{
+				isActive: true,
+				getDriverResult: &mcpinternal.InteractiveSession{
+					SessionID:     "sess-2019-005",
+					CorrelationID: "rr-2019-005",
+					ActingUser:    mcpinternal.UserInfo{Username: "alice"},
+				},
+			}
+			runner := &mockInvestigatorRunner{
+				workflowDiscoveryResult: &katypes.InvestigationResult{
+					RCASummary:        "OOM crash",
+					HumanReviewNeeded: true,
+					HumanReviewReason: "no_matching_workflows",
+				},
+			}
+			recon := &mockContextReconstructor{}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr,
+				mcptools.WithHTTPCompleter(completer),
+				mcptools.WithWorkflowCatalog(&mockWorkflowCatalog{}),
+			)
+
+			output, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-2019-005",
+				Action: mcptools.ActionDiscoverWorkflows,
+			}, mcpinternal.UserInfo{Username: "alice"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output.Status).To(Equal("workflows_discovered"))
+
+			Eventually(func(g Gomega) {
+				id, result := completer.getCompleted()
+				g.Expect(id).To(Equal("http-sess-2019-005"))
+				g.Expect(result).NotTo(BeNil())
+			}).WithTimeout(2 * time.Second).WithPolling(50 * time.Millisecond).Should(Succeed())
+
+			_, _, calls := completer.getPending()
+			Expect(calls).To(BeZero(),
+				"#2019: the two branches are mutually exclusive -- no_matching_workflows already auto-closes "+
+					"via CompleteHTTPSession, it must not also persist a decision_expired preview")
 		})
 	})
 })

--- a/internal/kubernautagent/mcp/tools/discover_workflows_no_match_2003_test.go
+++ b/internal/kubernautagent/mcp/tools/discover_workflows_no_match_2003_test.go
@@ -1,0 +1,252 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools_test
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+	mcptools "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// orderRecorder captures the relative ordering of the async auto-close steps
+// so tests can assert the #1438 ordering invariant: session_ended must be
+// emitted BEFORE the HTTP session is completed, so EventLogBridge can forward
+// it to AF before the channel closes.
+type orderRecorder struct {
+	mu    sync.Mutex
+	steps []string
+}
+
+func (r *orderRecorder) record(step string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.steps = append(r.steps, step)
+}
+
+func (r *orderRecorder) snapshot() []string {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]string, len(r.steps))
+	copy(out, r.steps)
+	return out
+}
+
+type emitCall struct {
+	RRID, Reason string
+}
+
+// mockAutoMgrDW2003 implements AutonomousSessionManager for #2003 tests. It
+// embeds NopAutonomousManager for the methods this scenario doesn't exercise,
+// and overrides GetLatestRCAResultByRemediationID (to serve a stored RCA
+// without touching the audit-reconstruction fallback) and EmitSessionEndedByRR
+// (to record calls and their ordering).
+type mockAutoMgrDW2003 struct {
+	mcptools.NopAutonomousManager
+	mu        sync.Mutex
+	rcaResult *katypes.InvestigationResult
+	emitCalls []emitCall
+	order     *orderRecorder
+}
+
+func (m *mockAutoMgrDW2003) GetLatestRCAResultByRemediationID(_ string) (*katypes.InvestigationResult, bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.rcaResult != nil {
+		return m.rcaResult, true
+	}
+	return nil, false
+}
+
+func (m *mockAutoMgrDW2003) EmitSessionEndedByRR(rrID, reason string) {
+	m.mu.Lock()
+	m.emitCalls = append(m.emitCalls, emitCall{RRID: rrID, Reason: reason})
+	m.mu.Unlock()
+	if m.order != nil {
+		m.order.record("emit_session_ended")
+	}
+}
+
+func (m *mockAutoMgrDW2003) getEmitCalls() []emitCall {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	out := make([]emitCall, len(m.emitCalls))
+	copy(out, m.emitCalls)
+	return out
+}
+
+// orderedHTTPCompleter is a minimal HTTPSessionCompleter for #2003 ordering
+// assertions — distinct from mockHTTPCompleter (select_workflow_test.go)
+// because this scenario specifically needs to record the completion step
+// into the shared orderRecorder, not just capture the final result value.
+type orderedHTTPCompleter struct {
+	mu          sync.Mutex
+	completedID string
+	completed   *katypes.InvestigationResult
+	found       bool
+	foundID     string
+	order       *orderRecorder
+}
+
+func (c *orderedHTTPCompleter) FindUserDrivingByRemediationID(_ string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.foundID, c.found
+}
+
+func (c *orderedHTTPCompleter) CompleteUserDriving(id string, result *katypes.InvestigationResult) error {
+	c.mu.Lock()
+	c.completedID = id
+	c.completed = result
+	c.mu.Unlock()
+	if c.order != nil {
+		c.order.record("complete_user_driving")
+	}
+	return nil
+}
+
+func (c *orderedHTTPCompleter) ForceCompleteByRemediationID(_ string, _ *katypes.InvestigationResult) error {
+	return nil
+}
+
+func (c *orderedHTTPCompleter) getCompleted() (string, *katypes.InvestigationResult) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.completedID, c.completed
+}
+
+var _ = Describe("#2003: discover_workflows auto-closes session on no_matching_workflows", func() {
+
+	Describe("UT-KA-2003-001: no_matching_workflows emits session_ended before completing (order per #1438)", func() {
+		It("should call EmitSessionEndedByRR before CompleteUserDriving and release the MCP lease", func() {
+			order := &orderRecorder{}
+			completer := &orderedHTTPCompleter{foundID: "http-sess-2003-001", found: true, order: order}
+			autoMgr := &mockAutoMgrDW2003{
+				rcaResult: &katypes.InvestigationResult{RCASummary: "OOM crash", Confidence: 0.4},
+				order:     order,
+			}
+			sessionMgr := &mockSessionManager{
+				isActive: true,
+				getDriverResult: &mcpinternal.InteractiveSession{
+					SessionID:     "sess-2003-001",
+					CorrelationID: "rr-2003-001",
+					ActingUser:    mcpinternal.UserInfo{Username: "alice"},
+				},
+			}
+			runner := &mockInvestigatorRunner{
+				workflowDiscoveryResult: &katypes.InvestigationResult{
+					RCASummary:        "OOM crash",
+					HumanReviewNeeded: true,
+					HumanReviewReason: "no_matching_workflows",
+				},
+			}
+			recon := &mockContextReconstructor{}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr,
+				mcptools.WithHTTPCompleter(completer),
+				mcptools.WithWorkflowCatalog(&mockWorkflowCatalog{}),
+			)
+
+			output, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-2003-001",
+				Action: mcptools.ActionDiscoverWorkflows,
+			}, mcpinternal.UserInfo{Username: "alice"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output.Status).To(Equal("workflows_discovered"),
+				"the discovery response body is unchanged; auto-close is a side effect")
+
+			// Session completion and lease release are deferred to a goroutine so
+			// the MCP response reaches the caller before transport teardown.
+			Eventually(func(g Gomega) {
+				calls := autoMgr.getEmitCalls()
+				g.Expect(calls).To(HaveLen(1))
+				g.Expect(calls[0].RRID).To(Equal("rr-2003-001"))
+				g.Expect(calls[0].Reason).To(Equal("no_matching_workflows"))
+			}).WithTimeout(2 * time.Second).WithPolling(50 * time.Millisecond).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				id, result := completer.getCompleted()
+				g.Expect(id).To(Equal("http-sess-2003-001"))
+				g.Expect(result).NotTo(BeNil())
+			}).WithTimeout(2 * time.Second).WithPolling(50 * time.Millisecond).Should(Succeed())
+
+			Eventually(func(g Gomega) {
+				id, reason := sessionMgr.getReleased()
+				g.Expect(id).To(Equal("sess-2003-001"))
+				g.Expect(reason).To(Equal("no_matching_workflows"))
+			}).WithTimeout(2 * time.Second).WithPolling(50 * time.Millisecond).Should(Succeed())
+
+			Expect(order.snapshot()).To(Equal([]string{"emit_session_ended", "complete_user_driving"}),
+				"#1438: session_ended must be emitted BEFORE the HTTP session completes, "+
+					"so EventLogBridge can forward it to AF before the channel closes (otherwise "+
+					"AF's WatchTerminalEvents, which has no timer-based safety net, never updates "+
+					"the console phase off 'Investigating')")
+		})
+	})
+
+	Describe("UT-KA-2003-002: legitimate discovery results do not auto-close (regression guard)", func() {
+		It("should not emit session_ended or release the session when a workflow was recommended", func() {
+			autoMgr := &mockAutoMgrDW2003{
+				rcaResult: &katypes.InvestigationResult{RCASummary: "OOM crash"},
+			}
+			completer := &orderedHTTPCompleter{foundID: "http-sess-2003-002", found: true}
+			sessionMgr := &mockSessionManager{
+				isActive: true,
+				getDriverResult: &mcpinternal.InteractiveSession{
+					SessionID:     "sess-2003-002",
+					CorrelationID: "rr-2003-002",
+					ActingUser:    mcpinternal.UserInfo{Username: "alice"},
+				},
+			}
+			runner := &mockInvestigatorRunner{
+				workflowDiscoveryResult: &katypes.InvestigationResult{
+					RCASummary: "OOM crash",
+					WorkflowID: "wf-recommended-2003",
+					Confidence: 0.9,
+				},
+			}
+			recon := &mockContextReconstructor{}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr,
+				mcptools.WithHTTPCompleter(completer),
+				mcptools.WithWorkflowCatalog(&mockWorkflowCatalog{
+					workflow: &mcptools.CatalogWorkflow{WorkflowID: "wf-recommended-2003", WorkflowName: "Mock Workflow"},
+				}),
+			)
+
+			output, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-2003-002",
+				Action: mcptools.ActionDiscoverWorkflows,
+			}, mcpinternal.UserInfo{Username: "alice"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(output.Status).To(Equal("workflows_discovered"))
+
+			Consistently(func(g Gomega) {
+				g.Expect(autoMgr.getEmitCalls()).To(BeEmpty(),
+					"a legitimate recommendation must not trigger the no_matching_workflows auto-close")
+				id, _ := sessionMgr.getReleased()
+				g.Expect(id).To(BeEmpty(), "session must remain active for the user to select a workflow")
+			}).WithTimeout(300 * time.Millisecond).WithPolling(50 * time.Millisecond).Should(Succeed())
+		})
+	})
+})

--- a/internal/kubernautagent/mcp/tools/handlestart_robustness_1440_it_test.go
+++ b/internal/kubernautagent/mcp/tools/handlestart_robustness_1440_it_test.go
@@ -78,6 +78,8 @@ func (m *itFallbackAutoMgr) GetSessionLazySink(_ string) (*session.LazySink, boo
 	return nil, false
 }
 
+func (m *itFallbackAutoMgr) EmitSessionEndedByRR(_, _ string) {}
+
 var _ = Describe("Fix #1440 Integration: KA handleStart fallback session creation", func() {
 
 	Describe("IT-KA-1440-010: MCP action=start with no prior session creates interactive session and returns valid session_id (SC-24)", func() {

--- a/internal/kubernautagent/mcp/tools/handlestart_robustness_1440_test.go
+++ b/internal/kubernautagent/mcp/tools/handlestart_robustness_1440_test.go
@@ -139,6 +139,7 @@ func (c *reattachHTTPCompleter) CompleteUserDriving(_ string, _ *katypes.Investi
 func (c *reattachHTTPCompleter) ForceCompleteByRemediationID(_ string, _ *katypes.InvestigationResult) error {
 	return nil
 }
+func (c *reattachHTTPCompleter) PersistPendingDecisionResult(_ string, _ *katypes.InvestigationResult) {}
 
 var _ = Describe("Fix #1440: handleStart robustness — SC-24", func() {
 

--- a/internal/kubernautagent/mcp/tools/handlestart_robustness_1440_test.go
+++ b/internal/kubernautagent/mcp/tools/handlestart_robustness_1440_test.go
@@ -119,6 +119,7 @@ func (m *fallbackAutoMgr) Subscribe(_ context.Context, _ string) (<-chan session
 	return nil, nil
 }
 func (m *fallbackAutoMgr) GetSessionLazySink(_ string) (*session.LazySink, bool) { return nil, false }
+func (m *fallbackAutoMgr) EmitSessionEndedByRR(_, _ string)                      {}
 
 // reattachHTTPCompleter is a minimal HTTPSessionCompleter stub for #1818
 // tests: only FindUserDrivingByRemediationID is exercised by the reattach

--- a/internal/kubernautagent/mcp/tools/interactive_start_test.go
+++ b/internal/kubernautagent/mcp/tools/interactive_start_test.go
@@ -89,6 +89,8 @@ func (m *interactiveAutoMgr) GetSessionLazySink(_ string) (*session.LazySink, bo
 	return nil, false
 }
 
+func (m *interactiveAutoMgr) EmitSessionEndedByRR(_, _ string) {}
+
 var _ = Describe("BR-INTERACTIVE-010: handleStart with pending interactive session — #1293", func() {
 
 	Describe("UT-KA-1293-013: action=start detects pending session and launches deferred investigation", func() {
@@ -467,6 +469,8 @@ func (m *sessionIDTrackingAutoMgr) GetSessionLazySink(_ string) (*session.LazySi
 	return nil, false
 }
 
+func (m *sessionIDTrackingAutoMgr) EmitSessionEndedByRR(_, _ string) {}
+
 // upgradeTrackingAutoMgr tracks calls to UpgradeToInteractive vs TransitionToUserDriving.
 type upgradeTrackingAutoMgr struct {
 	findResult       string
@@ -512,3 +516,5 @@ func (m *upgradeTrackingAutoMgr) Subscribe(_ context.Context, _ string) (<-chan 
 func (m *upgradeTrackingAutoMgr) GetSessionLazySink(_ string) (*session.LazySink, bool) {
 	return nil, false
 }
+
+func (m *upgradeTrackingAutoMgr) EmitSessionEndedByRR(_, _ string) {}

--- a/internal/kubernautagent/mcp/tools/investigate.go
+++ b/internal/kubernautagent/mcp/tools/investigate.go
@@ -78,6 +78,14 @@ type HTTPSessionCompleter interface {
 	FindUserDrivingByRemediationID(rrID string) (string, bool)
 	CompleteUserDriving(id string, result *katypes.InvestigationResult) error
 	ForceCompleteByRemediationID(rrID string, result *katypes.InvestigationResult) error
+
+	// PersistPendingDecisionResult attaches a preview InvestigationResult to a
+	// still-UserDriving session so that a later CompleteUserDriving(id, nil)
+	// -- as invoked by the inactivity-timeout/disconnect handlers -- preserves
+	// the discovered-but-unconfirmed recommendation instead of finalizing as
+	// has_workflow:false (#2019). See session.Store.SetPendingDecisionResult
+	// for the full rationale.
+	PersistPendingDecisionResult(id string, result *katypes.InvestigationResult)
 }
 
 // SessionMutexProvider exposes per-rrID mutexes for concurrency control.
@@ -1067,6 +1075,23 @@ func (t *InvestigateTool) handleDiscoverWorkflows(ctx context.Context, input Inv
 					}
 				}
 			}()
+		}
+	} else if t.httpCompleter != nil {
+		// #2019: a real workflow was found and is about to be presented via
+		// kubernaut_present_decision. Preserve it as a pending-decision preview
+		// BEFORE returning, so that if nothing (human or automation) answers
+		// before the interactive session's inactivity timeout fires,
+		// CompleteHTTPSession's hardcoded nil result (main.go) preserves this
+		// preview instead of silently finalizing as has_workflow:false. If the
+		// user does respond (select_workflow/complete_no_action), that explicit
+		// CompleteUserDriving(id, result) call overwrites this preview with the
+		// confirmed outcome, since Store.CompleteUserDriving only skips the
+		// overwrite when passed a nil result.
+		if httpSessionID, found := t.httpCompleter.FindUserDrivingByRemediationID(input.RRID); found {
+			preview := *workflowResult
+			preview.HumanReviewNeeded = true
+			preview.HumanReviewReason = katypes.HumanReviewReasonDecisionExpired
+			t.httpCompleter.PersistPendingDecisionResult(httpSessionID, &preview)
 		}
 	}
 

--- a/internal/kubernautagent/mcp/tools/investigate.go
+++ b/internal/kubernautagent/mcp/tools/investigate.go
@@ -120,6 +120,13 @@ type AutonomousSessionManager interface {
 	Subscribe(ctx context.Context, id string) (<-chan session.InvestigationEvent, error)
 	// #1384: Get the LazySink for a session so workflow_discovery can stream events.
 	GetSessionLazySink(id string) (*session.LazySink, bool)
+
+	// #2003: Emit a terminal session_ended event for a remediation ID's
+	// user-driving session BEFORE the session completes, so AF's
+	// WatchTerminalEvents (which has no timer-based safety net, #1438) is
+	// notified promptly instead of relying on the 10-minute inactivity
+	// timeout to eventually surface it.
+	EmitSessionEndedByRR(rrID, reason string)
 }
 
 // RRExistenceChecker validates that a RemediationRequest exists before
@@ -199,6 +206,7 @@ func (NopAutonomousManager) Subscribe(context.Context, string) (<-chan session.I
 	return nil, nil
 }
 func (NopAutonomousManager) GetSessionLazySink(string) (*session.LazySink, bool) { return nil, false }
+func (NopAutonomousManager) EmitSessionEndedByRR(string, string)                 {}
 
 // InvestigateTool handles the kubernaut_investigate MCP tool actions:
 // start, message, complete, cancel, takeover, discover_workflows.
@@ -1014,6 +1022,52 @@ func (t *InvestigateTool) handleDiscoverWorkflows(ctx context.Context, input Inv
 	t.sessions.TouchActivity(input.RRID)
 	if t.timeoutTracker != nil {
 		t.timeoutTracker.ResetInactivity(sess.SessionID)
+	}
+
+	// #2003: no_matching_workflows is a terminal outcome — HumanReviewReason
+	// is only ever set to this value on paths that leave WorkflowID and
+	// AlternativeWorkflows empty (investigator.go), so there is nothing left
+	// for the user to browse or select. Without this, the session lingered
+	// until KA's blunt 10-minute inactivity timeout eventually released it,
+	// which was the only thing that emitted session_ended — the terminal
+	// signal AF's WatchTerminalEvents blocks on (no timer-based safety net,
+	// #1438). Mirrors select_workflow.go's auto-close pattern (goroutine
+	// deferred past the MCP response reaching the caller, mutex re-acquired
+	// to avoid a TOCTOU race), but additionally emits session_ended BEFORE
+	// completing — the #1438 ordering that select_workflow's own pattern
+	// omits (safe there only because a workflow's execution start triggers a
+	// separate CRD-phase watch; there is no equivalent for "no match").
+	if workflowResult.HumanReviewNeeded && workflowResult.HumanReviewReason == "no_matching_workflows" {
+		if t.timeoutTracker != nil {
+			t.timeoutTracker.StopTracking(sess.SessionID)
+		}
+		if t.httpCompleter != nil {
+			autoMgr := t.autoMgr
+			completer := t.httpCompleter
+			sessions := t.sessions
+			rrID := input.RRID
+			sessionID := sess.SessionID
+			result := workflowResult
+			logger := t.logger
+			go func() {
+				// KA-HIGH-3: re-acquire the session mutex to prevent TOCTOU
+				// between response delivery and HTTP/lease cleanup.
+				mu := t.getSessionMutex(rrID)
+				mu.Lock()
+				defer mu.Unlock()
+
+				// #1438 ordering: emit BEFORE completing, so EventLogBridge
+				// can forward the terminal event to AF before the channel
+				// closes.
+				autoMgr.EmitSessionEndedByRR(rrID, "no_matching_workflows")
+				CompleteHTTPSession(completer, rrID, result, logger, "no_matching_workflows")
+				if releaseErr := sessions.Release(sessionID, "no_matching_workflows"); releaseErr != nil {
+					if !errors.Is(releaseErr, mcpinternal.ErrSessionNotFound) {
+						logger.Error(releaseErr, "failed to release MCP lease", "session_id", sessionID)
+					}
+				}
+			}()
+		}
 	}
 
 	// Build the JSON response for the user.

--- a/internal/kubernautagent/mcp/tools/select_workflow_test.go
+++ b/internal/kubernautagent/mcp/tools/select_workflow_test.go
@@ -65,6 +65,8 @@ func (m *mockHTTPCompleter) ForceCompleteByRemediationID(_ string, result *katyp
 	return m.completeErr
 }
 
+func (m *mockHTTPCompleter) PersistPendingDecisionResult(_ string, _ *katypes.InvestigationResult) {}
+
 func (m *mockHTTPCompleter) getCompleted() (string, *katypes.InvestigationResult) {
 	m.mu.Lock()
 	defer m.mu.Unlock()

--- a/internal/kubernautagent/mcp/tools/session_handoff_1384_test.go
+++ b/internal/kubernautagent/mcp/tools/session_handoff_1384_test.go
@@ -122,6 +122,8 @@ func (m *mockAutoMgrWithHTTPSession) GetSessionLazySink(_ string) (*session.Lazy
 	return nil, false
 }
 
+func (m *mockAutoMgrWithHTTPSession) EmitSessionEndedByRR(_, _ string) {}
+
 var _ = Describe("Fix #1384 Bug A — Session context propagation (AU-2/AU-3, BR-INTERACTIVE-010 SC-2)", func() {
 
 	Describe("UT-KA-1384-A01: Session context propagated to workflow_discovery (streaming path)", func() {

--- a/internal/kubernautagent/mcp/tools/status_test.go
+++ b/internal/kubernautagent/mcp/tools/status_test.go
@@ -67,6 +67,7 @@ func (m *statusAutoMgr) GetLatestRCAResultByRemediationID(_ string) (*katypes.In
 func (m *statusAutoMgr) StartInvestigation(_ context.Context, _ session.InvestigateFunc, _ map[string]string) (string, error) { return "", nil }
 func (m *statusAutoMgr) Subscribe(_ context.Context, _ string) (<-chan session.InvestigationEvent, error) { return nil, nil }
 func (m *statusAutoMgr) GetSessionLazySink(_ string) (*session.LazySink, bool) { return nil, false }
+func (m *statusAutoMgr) EmitSessionEndedByRR(_, _ string)                      {}
 
 var _ = Describe("action=status — PR4 PROD-01 BR-INTERACTIVE-002", func() {
 

--- a/internal/kubernautagent/mcp/tools/takeover_test.go
+++ b/internal/kubernautagent/mcp/tools/takeover_test.go
@@ -111,6 +111,7 @@ func (m *takeoverAutoMgr) GetLatestRCAResultByRemediationID(_ string) (*katypes.
 func (m *takeoverAutoMgr) StartInvestigation(_ context.Context, _ session.InvestigateFunc, _ map[string]string) (string, error) { return "", nil }
 func (m *takeoverAutoMgr) Subscribe(_ context.Context, _ string) (<-chan session.InvestigationEvent, error) { return nil, nil }
 func (m *takeoverAutoMgr) GetSessionLazySink(_ string) (*session.LazySink, bool) { return nil, false }
+func (m *takeoverAutoMgr) EmitSessionEndedByRR(_, _ string)                      {}
 
 // takeoverSessMgr mocks mcpinternal.SessionManager for takeover tests.
 type takeoverSessMgr struct {

--- a/internal/kubernautagent/server/handler.go
+++ b/internal/kubernautagent/server/handler.go
@@ -856,6 +856,10 @@ func mapHumanReviewReason(reason string) (agentclient.HumanReviewReason, bool) {
 		return agentclient.HumanReviewReasonAlignmentCheckFailed, false
 	case "operator_escalation":
 		return agentclient.HumanReviewReasonOperatorEscalation, false
+	case "decision_expired":
+		// #2019: a workflow was discovered and presented via kubernaut_present_decision,
+		// but no response arrived before the interactive session's inactivity timeout.
+		return agentclient.HumanReviewReasonDecisionExpired, false
 	}
 
 	switch {

--- a/internal/kubernautagent/server/response_mapper_test.go
+++ b/internal/kubernautagent/server/response_mapper_test.go
@@ -256,6 +256,8 @@ var _ = Describe("Response Mapper — #433", func() {
 			{"low_confidence", "low_confidence", "exact match"},
 			{"llm_parsing_error", "llm_parsing_error", "exact match"},
 			{"alignment_check_failed", "alignment_check_failed", "exact match"},
+			{"operator_escalation", "operator_escalation", "exact match"},
+			{"decision_expired", "decision_expired", "exact match (#2019: workflow found and presented, decision unanswered before timeout)"},
 			{"turns exhausted during RCA phase", "rca_incomplete", "contains 'exhausted during RCA'"},
 			{"turns exhausted during workflow selection", "investigation_inconclusive", "contains 'exhausted during workflow selection'"},
 			{"workflow not found in catalog", "workflow_not_found", "contains 'not found' + 'catalog'"},

--- a/internal/kubernautagent/session/manager.go
+++ b/internal/kubernautagent/session/manager.go
@@ -749,6 +749,14 @@ func (m *Manager) GetSignalForRemediation(rrID string) (*katypes.SignalContext, 
 	return nil, ErrSessionNotFound
 }
 
+// PersistPendingDecisionResult exposes Store.SetPendingDecisionResult so
+// discover_workflows (mcp/tools) can preserve a discovered-but-unconfirmed
+// workflow recommendation ahead of a possible inactivity timeout (#2019).
+// See Store.SetPendingDecisionResult for the full rationale.
+func (m *Manager) PersistPendingDecisionResult(id string, result *katypes.InvestigationResult) {
+	m.store.SetPendingDecisionResult(id, result)
+}
+
 // CompleteUserDriving transitions a user-driven session to completed with the
 // given result. This bridges the MCP tool completion path to the HTTP session
 // store so AA's poll mechanism picks up the result.
@@ -770,8 +778,20 @@ func (m *Manager) CompleteUserDriving(id string, result *katypes.InvestigationRe
 		audit.EventTypeSessionCompleted, audit.ActionSessionCompleted,
 		audit.OutcomeSuccess, id, correlationID, nil,
 		"completion_mode", "user_driving")
+	// #2019: read the final state from the session itself (sess.Result), not
+	// the raw result parameter -- when the inactivity-timeout/disconnect
+	// handlers call this with result=nil, Store.CompleteUserDriving preserves
+	// whatever SetPendingDecisionResult already attached, so logging the raw
+	// parameter would misreport an actually-preserved discovery as
+	// has_workflow=false.
+	var hasWorkflow bool
+	var humanReviewReason string
+	if sess != nil && sess.Result != nil {
+		hasWorkflow = sess.Result.WorkflowID != ""
+		humanReviewReason = sess.Result.HumanReviewReason
+	}
 	m.logger.Info("User-driven session completed",
-		"session_id", id, "has_workflow", result != nil && result.WorkflowID != "")
+		"session_id", id, "has_workflow", hasWorkflow, "human_review_reason", humanReviewReason)
 	return nil
 }
 

--- a/internal/kubernautagent/session/manager.go
+++ b/internal/kubernautagent/session/manager.go
@@ -766,11 +766,31 @@ func (m *Manager) CompleteUserDriving(id string, result *katypes.InvestigationRe
 	}
 	m.closeEventChan(id)
 
+	// #2019: hasWorkflow/humanReviewReason must be read from sess.Result under
+	// the same lock acquisition as the sess lookup itself -- sess.Result is
+	// mutated concurrently by Store.SetResult from the investigation goroutine
+	// (see storePartialResult), so reading it after RUnlock() is a genuine
+	// data race (caught by `go test -race`).
 	m.store.mu.RLock()
 	sess := m.store.sessions[id]
 	var correlationID string
-	if sess != nil && sess.Metadata != nil {
-		correlationID = sess.Metadata["remediation_id"]
+	var hasWorkflow bool
+	var humanReviewReason string
+	if sess != nil {
+		if sess.Metadata != nil {
+			correlationID = sess.Metadata["remediation_id"]
+		}
+		// #2019: read the final state from the session itself (sess.Result),
+		// not the raw result parameter -- when the inactivity-timeout/
+		// disconnect handlers call this with result=nil,
+		// Store.CompleteUserDriving preserves whatever
+		// SetPendingDecisionResult already attached, so logging the raw
+		// parameter would misreport an actually-preserved discovery as
+		// has_workflow=false.
+		if sess.Result != nil {
+			hasWorkflow = sess.Result.WorkflowID != ""
+			humanReviewReason = sess.Result.HumanReviewReason
+		}
 	}
 	m.store.mu.RUnlock()
 
@@ -778,18 +798,6 @@ func (m *Manager) CompleteUserDriving(id string, result *katypes.InvestigationRe
 		audit.EventTypeSessionCompleted, audit.ActionSessionCompleted,
 		audit.OutcomeSuccess, id, correlationID, nil,
 		"completion_mode", "user_driving")
-	// #2019: read the final state from the session itself (sess.Result), not
-	// the raw result parameter -- when the inactivity-timeout/disconnect
-	// handlers call this with result=nil, Store.CompleteUserDriving preserves
-	// whatever SetPendingDecisionResult already attached, so logging the raw
-	// parameter would misreport an actually-preserved discovery as
-	// has_workflow=false.
-	var hasWorkflow bool
-	var humanReviewReason string
-	if sess != nil && sess.Result != nil {
-		hasWorkflow = sess.Result.WorkflowID != ""
-		humanReviewReason = sess.Result.HumanReviewReason
-	}
 	m.logger.Info("User-driven session completed",
 		"session_id", id, "has_workflow", hasWorkflow, "human_review_reason", humanReviewReason)
 	return nil

--- a/internal/kubernautagent/session/store.go
+++ b/internal/kubernautagent/session/store.go
@@ -293,6 +293,28 @@ func (s *Store) SetResult(id string, result *katypes.InvestigationResult) {
 	}
 }
 
+// SetPendingDecisionResult attaches a preview InvestigationResult to a
+// UserDriving session, always overwriting any previous value while the
+// session remains UserDriving. Used by discover_workflows to preserve a
+// discovered-but-unconfirmed workflow recommendation so that a later
+// CompleteUserDriving(id, nil) -- as invoked by the inactivity-timeout and
+// disconnect handlers in cmd/kubernautagent/main.go -- preserves it instead
+// of finalizing the session as has_workflow:false (#2019).
+//
+// Unlike SetResult's first-write-wins guard (which protects a #1425
+// cancelled-goroutine race from being clobbered by a later write),
+// SetPendingDecisionResult intentionally always overwrites: discover_workflows
+// may legitimately re-run within the same session, and each run's finding
+// supersedes the previous preview. It is a no-op outside StatusUserDriving so
+// it can never resurrect or corrupt an already-terminal session's result.
+func (s *Store) SetPendingDecisionResult(id string, result *katypes.InvestigationResult) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if sess, ok := s.sessions[id]; ok && sess.Status == StatusUserDriving {
+		sess.Result = result
+	}
+}
+
 // CompleteUserDriving transitions a session from StatusUserDriving to
 // StatusCompleted with the given InvestigationResult. This is the only path
 // that allows a user-driven session to reach completion (Update blocks this

--- a/internal/kubernautagent/session/store_test.go
+++ b/internal/kubernautagent/session/store_test.go
@@ -329,4 +329,68 @@ var _ = Describe("Session Cancellation Infrastructure — #823", func() {
 				"SC-24: second SetResult must be blocked — first-write-wins protects the original result")
 		})
 	})
+
+	Describe("UT-KA-2019-001/002: SetPendingDecisionResult always overwrites on UserDriving, no-ops elsewhere", func() {
+		It("UT-KA-2019-001: overwrites Result on a UserDriving session even when a prior result is already set", func() {
+			store := session.NewStore(30 * time.Minute)
+			id, err := store.Create()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(store.Update(id, session.StatusRunning, nil, nil)).To(Succeed())
+			Expect(store.Update(id, session.StatusUserDriving, nil, nil)).To(Succeed())
+
+			store.SetPendingDecisionResult(id, &katypes.InvestigationResult{WorkflowID: "wf-round-1"})
+			store.SetPendingDecisionResult(id, &katypes.InvestigationResult{WorkflowID: "wf-round-2"})
+
+			sess, err := store.Get(id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sess.Result).NotTo(BeNil())
+			Expect(sess.Result.WorkflowID).To(Equal("wf-round-2"),
+				"#2019: unlike SetResult's first-write-wins guard (#1425, a different concern), "+
+					"SetPendingDecisionResult always overwrites while UserDriving -- discover_workflows may legitimately re-run")
+		})
+
+		It("UT-KA-2019-002: is a no-op on a Completed session (does not resurrect a terminal result)", func() {
+			store := session.NewStore(30 * time.Minute)
+			id, err := store.Create()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(store.Update(id, session.StatusRunning, nil, nil)).To(Succeed())
+			Expect(store.Update(id, session.StatusUserDriving, nil, nil)).To(Succeed())
+			Expect(store.CompleteUserDriving(id, &katypes.InvestigationResult{WorkflowID: "wf-selected"})).To(Succeed())
+
+			store.SetPendingDecisionResult(id, &katypes.InvestigationResult{WorkflowID: "wf-stale-preview"})
+
+			sess, err := store.Get(id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sess.Status).To(Equal(session.StatusCompleted))
+			Expect(sess.Result.WorkflowID).To(Equal("wf-selected"),
+				"#2019: must not overwrite an already-completed session's confirmed result")
+		})
+
+		It("UT-KA-2019-003: composition with CompleteUserDriving(id, nil) preserves the pending preview (the actual #2019 bug-fix mechanism)", func() {
+			store := session.NewStore(30 * time.Minute)
+			id, err := store.Create()
+			Expect(err).NotTo(HaveOccurred())
+			Expect(store.Update(id, session.StatusRunning, nil, nil)).To(Succeed())
+			Expect(store.Update(id, session.StatusUserDriving, nil, nil)).To(Succeed())
+
+			preview := &katypes.InvestigationResult{
+				WorkflowID:        "wf-discovered",
+				HumanReviewNeeded: true,
+				HumanReviewReason: katypes.HumanReviewReasonDecisionExpired,
+			}
+			store.SetPendingDecisionResult(id, preview)
+
+			// Simulates cmd/kubernautagent/main.go's inactivity-timeout/disconnect
+			// handlers, which always call CompleteHTTPSession(..., nil, ...).
+			Expect(store.CompleteUserDriving(id, nil)).To(Succeed())
+
+			sess, err := store.Get(id)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(sess.Status).To(Equal(session.StatusCompleted))
+			Expect(sess.Result).NotTo(BeNil(),
+				"#2019: inactivity-timeout completion with a nil result must preserve the previously discovered workflow, not discard it")
+			Expect(sess.Result.WorkflowID).To(Equal("wf-discovered"))
+			Expect(sess.Result.HumanReviewReason).To(Equal(katypes.HumanReviewReasonDecisionExpired))
+		})
+	})
 })

--- a/pkg/agentclient/oas_json_gen.go
+++ b/pkg/agentclient/oas_json_gen.go
@@ -1490,6 +1490,8 @@ func (s *HumanReviewReason) Decode(d *jx.Decoder) error {
 		*s = HumanReviewReasonAlignmentCheckFailed
 	case HumanReviewReasonOperatorEscalation:
 		*s = HumanReviewReasonOperatorEscalation
+	case HumanReviewReasonDecisionExpired:
+		*s = HumanReviewReasonDecisionExpired
 	default:
 		*s = HumanReviewReason(v)
 	}

--- a/pkg/agentclient/oas_schemas_gen.go
+++ b/pkg/agentclient/oas_schemas_gen.go
@@ -592,7 +592,9 @@ func (*HTTPValidationError) incidentSessionStatusEndpointAPIV1IncidentSessionSes
 // Structured reason for needs_human_review=true.
 // Business Requirements: BR-HAPI-197, BR-HAPI-200, BR-496, BR-AI-601, BR-WORKFLOW-1418
 // Design Decision: DD-HAPI-002 v1.2, DD-HAPI-006 v1.3, DD-AF-007
-// AIAnalysis uses this for reliable subReason mapping instead of parsing warnings.
+// AIAnalysis uses this for reliable subReason mapping instead of parsing warnings. #2019:
+// decision_expired covers a presented-but-unanswered kubernaut_present_decision that expired via
+// interactive inactivity timeout.
 // Ref: #/components/schemas/HumanReviewReason
 type HumanReviewReason string
 
@@ -607,6 +609,7 @@ const (
 	HumanReviewReasonRcaIncomplete             HumanReviewReason = "rca_incomplete"
 	HumanReviewReasonAlignmentCheckFailed      HumanReviewReason = "alignment_check_failed"
 	HumanReviewReasonOperatorEscalation        HumanReviewReason = "operator_escalation"
+	HumanReviewReasonDecisionExpired           HumanReviewReason = "decision_expired"
 )
 
 // AllValues returns all HumanReviewReason values.
@@ -622,6 +625,7 @@ func (HumanReviewReason) AllValues() []HumanReviewReason {
 		HumanReviewReasonRcaIncomplete,
 		HumanReviewReasonAlignmentCheckFailed,
 		HumanReviewReasonOperatorEscalation,
+		HumanReviewReasonDecisionExpired,
 	}
 }
 
@@ -647,6 +651,8 @@ func (s HumanReviewReason) MarshalText() ([]byte, error) {
 	case HumanReviewReasonAlignmentCheckFailed:
 		return []byte(s), nil
 	case HumanReviewReasonOperatorEscalation:
+		return []byte(s), nil
+	case HumanReviewReasonDecisionExpired:
 		return []byte(s), nil
 	default:
 		return nil, errors.Errorf("invalid value: %q", s)
@@ -685,6 +691,9 @@ func (s *HumanReviewReason) UnmarshalText(data []byte) error {
 		return nil
 	case HumanReviewReasonOperatorEscalation:
 		*s = HumanReviewReasonOperatorEscalation
+		return nil
+	case HumanReviewReasonDecisionExpired:
+		*s = HumanReviewReasonDecisionExpired
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)

--- a/pkg/agentclient/oas_validators_gen.go
+++ b/pkg/agentclient/oas_validators_gen.go
@@ -290,6 +290,8 @@ func (s HumanReviewReason) Validate() error {
 		return nil
 	case "operator_escalation":
 		return nil
+	case "decision_expired":
+		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)
 	}

--- a/pkg/aianalysis/handlers/response_processor.go
+++ b/pkg/aianalysis/handlers/response_processor.go
@@ -753,6 +753,7 @@ func (p *ResponseProcessor) mapEnumToSubReason(reason string) string {
 		"investigation_inconclusive":  "InvestigationInconclusive", // BR-HAPI-200
 		"rca_incomplete":              "RcaIncomplete",             // BR-496 v2: root_owner missing from session_state
 		"operator_escalation":         "OperatorEscalation",        // #1449: KA complete_no_action escalation
+		"decision_expired":            "DecisionExpired",           // #2019: presented decision expired via inactivity timeout
 	}
 	if subReason, ok := mapping[reason]; ok {
 		return subReason

--- a/pkg/aianalysis/response_processor_decision_expired_test.go
+++ b/pkg/aianalysis/response_processor_decision_expired_test.go
@@ -1,0 +1,157 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package aianalysis contains unit tests for the decision_expired path
+// in ResponseProcessor.
+//
+// Issue #2019: KA finalizes a discovered-but-unpresented-decision session with
+// has_workflow=false on inactivity timeout, discarding the real recommendation.
+// This test proves that once KA reports human_review_reason=decision_expired
+// AND a selected_workflow, RO's ResponseProcessor preserves both onto the CRD --
+// it must NOT be treated like no_matching_workflows (which has no workflow at all).
+// FedRAMP: AU-2/AU-3 (accurate audit record), AC-6/CM-3 (no silent auto-approval).
+package aianalysis_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-faster/jx"
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	aianalysisv1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis/handlers"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis/metrics"
+	client "github.com/jordigilh/kubernaut/pkg/agentclient"
+)
+
+var _ = Describe("ResponseProcessor decision_expired (#2019)", func() {
+	var (
+		processor *handlers.ResponseProcessor
+		ctx       context.Context
+		m         *metrics.Metrics
+	)
+
+	BeforeEach(func() {
+		m = metrics.NewMetrics()
+		processor = handlers.NewResponseProcessor(logr.Discard(), m, &noopAuditClient{})
+		ctx = context.Background()
+	})
+
+	createAnalysis := func() *aianalysisv1.AIAnalysis {
+		startedAt := metav1.NewTime(time.Now().Add(-5 * time.Second))
+		return &aianalysisv1.AIAnalysis{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-2019",
+				Namespace:  "default",
+				UID:        types.UID("test-uid-2019"),
+				Generation: 1,
+			},
+			Spec: aianalysisv1.AIAnalysisSpec{
+				RemediationID: "test-rr-2019",
+			},
+			Status: aianalysisv1.AIAnalysisStatus{
+				Phase:     aianalysis.PhaseInvestigating,
+				StartedAt: &startedAt,
+			},
+		}
+	}
+
+	buildDecisionExpiredResp := func() *client.IncidentResponse {
+		return &client.IncidentResponse{
+			IncidentID:       "inc-2019-001",
+			Analysis:         "Workflow discovered and presented, but no decision was received before the inactivity timeout.",
+			NeedsHumanReview: client.NewOptBool(true),
+			HumanReviewReason: client.OptNilHumanReviewReason{
+				Value: client.HumanReviewReasonDecisionExpired,
+				Set:   true,
+			},
+			Confidence: 0.9,
+			Timestamp:  "2026-08-08T12:00:00Z",
+			SelectedWorkflow: client.OptNilIncidentResponseSelectedWorkflow{
+				Value: client.IncidentResponseSelectedWorkflow{
+					"workflow_id": jx.Raw(`"wf-recommended-2019"`),
+					"confidence":  jx.Raw(`0.9`),
+					"rationale":   jx.Raw(`"restart the crashlooping pod"`),
+				},
+				Set: true,
+			},
+		}
+	}
+
+	// ═══════════════════════════════════════════════════════════════════════
+	// Issue #2019 / FedRAMP AU-2, AU-3, AC-6, CM-3: A presented-but-unanswered
+	// decision must be recorded accurately, and the discovered workflow must
+	// survive for retroactive human action -- never silently discarded.
+	// ═══════════════════════════════════════════════════════════════════════
+
+	Context("AU-2/AU-3: decision_expired via kubernaut_discover_workflows + inactivity timeout", func() {
+		It("UT-AA-2019-006: sets Phase=Failed, NeedsHumanReview=true, HumanReviewReason=decision_expired", func() {
+			analysis := createAnalysis()
+			resp := buildDecisionExpiredResp()
+
+			_, err := processor.ProcessIncidentResponse(ctx, analysis, resp)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(analysis.Status.Phase).To(Equal(aianalysis.PhaseFailed),
+				"AU-2/AU-3: decision_expired must result in Failed phase to route to human review")
+			Expect(analysis.Status.NeedsHumanReview).To(BeTrue(),
+				"AC-6/CM-3: NeedsHumanReview must be true -- a presented decision with no answer is never auto-approved")
+			Expect(analysis.Status.HumanReviewReason).To(Equal("decision_expired"),
+				"AU-2/AU-3: decision_expired must be persisted as the audit-trail reason")
+		})
+
+		It("UT-AA-2019-007: maps decision_expired to DecisionExpired SubReason", func() {
+			analysis := createAnalysis()
+			resp := buildDecisionExpiredResp()
+
+			_, err := processor.ProcessIncidentResponse(ctx, analysis, resp)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(analysis.Status.SubReason).To(Equal("DecisionExpired"),
+				"AU-2/AU-3: SubReason must map decision_expired enum to structured DecisionExpired value")
+		})
+
+		It("UT-AA-2019-008: preserves the discovered SelectedWorkflow instead of discarding it (the actual #2019 bug)", func() {
+			analysis := createAnalysis()
+			resp := buildDecisionExpiredResp()
+
+			_, err := processor.ProcessIncidentResponse(ctx, analysis, resp)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(analysis.Status.SelectedWorkflow).NotTo(BeNil(),
+				"AU-2/AU-3: the discovered workflow must survive a decision_expired outcome -- "+
+					"this is the false negative #2019 fixes (previously has_workflow:false discarded it)")
+			Expect(analysis.Status.SelectedWorkflow.WorkflowID).To(Equal("wf-recommended-2019"))
+		})
+
+		It("UT-AA-2019-009: never sets ApprovalRequired=true for an unanswered decision", func() {
+			analysis := createAnalysis()
+			resp := buildDecisionExpiredResp()
+
+			_, err := processor.ProcessIncidentResponse(ctx, analysis, resp)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(analysis.Status.ApprovalRequired).To(BeFalse(),
+				"AC-6/CM-3: no human ever approved this workflow -- decision_expired must never imply consent")
+		})
+	})
+})

--- a/pkg/apifrontend/agent/phase_guard.go
+++ b/pkg/apifrontend/agent/phase_guard.go
@@ -160,11 +160,22 @@ func newPhaseGuard(registry *launcher.ActiveContextRegistry) (llmagent.BeforeToo
 			}
 		}
 
+		// #1997: phaseGuardAfter only ever records a side effect (session
+		// state, ActiveContextRegistry) -- it never modifies resp/callErr.
+		// Every exit path below returns (nil, nil), the ADK AfterToolCallback
+		// convention for "pass through unchanged" (google.golang.org/adk,
+		// internal/llminternal/base_flow.go: invokeAfterToolCallbacks treats
+		// a non-nil result as an explicit override that stops the chain,
+		// falling back to the original fResult/fErr only once every
+		// callback has returned nil). Re-returning the original resp/callErr
+		// here looked harmless but silently skipped every AfterToolCallback
+		// registered after this one (afterLog) for any tool call at all,
+		// not just the ones this guard cares about.
 		if !isEntry && !isTerminal && !isDiscoverWorkflows {
-			return resp, callErr
+			return nil, nil
 		}
 		if !isSuccess {
-			return resp, callErr
+			return nil, nil
 		}
 
 		logger := logr.FromContextOrDiscard(ctx)
@@ -178,7 +189,7 @@ func newPhaseGuard(registry *launcher.ActiveContextRegistry) (llmagent.BeforeToo
 					logger.Error(err, "phase-guard failed to persist phase3_blocked state")
 				}
 			}
-			return resp, callErr
+			return nil, nil
 		}
 
 		if isEntry {
@@ -275,7 +286,7 @@ func newPhaseGuard(registry *launcher.ActiveContextRegistry) (llmagent.BeforeToo
 			}
 		}
 
-		return resp, callErr
+		return nil, nil
 	}
 
 	return before, after

--- a/pkg/apifrontend/agent/phase_guard_aftercallback_1997_test.go
+++ b/pkg/apifrontend/agent/phase_guard_aftercallback_1997_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"google.golang.org/adk/tool"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
+)
+
+// phaseGuardAfter AfterToolCallback contract (#1997).
+//
+// ADK's invokeAfterToolCallbacks (google.golang.org/adk, internal/llminternal/
+// base_flow.go) treats a non-nil result returned by ANY AfterToolCallback as
+// an explicit override that stops the chain immediately -- every later
+// callback (afterLog in root.go's registration order: afterMetrics,
+// afterAudit, afterPhase, afterLog) never runs. A callback that only wants
+// to observe/record a side effect (as phaseGuardAfter does -- it never
+// modifies resp) MUST return (nil, nil) to signal "pass through unchanged",
+// exactly as afterAudit/afterMetrics already do correctly in the same file.
+//
+// phaseGuardAfter instead re-returns (resp, callErr) from every exit path,
+// which -- since resp is non-nil for any tool call that produced a
+// structured result -- unconditionally short-circuits the chain and skips
+// afterLog for every tool call, not just the driver-entry/terminal/
+// discover_workflows tools phaseGuardAfter cares about.
+//
+// Business requirement: BR-AUDIT-005 (audit completeness) / FedRAMP AU-3
+// (content of audit records) and AU-12 (audit generation), as implemented
+// by afterLog's "tool call completed" line (root.go, TP-1310 §4.3). This
+// suite proves the logic that was silently dropping that audit signal;
+// IT-AF-1997-009 (phase_guard_afterlog_wiring_1997_test.go) proves the fix
+// closes the gap end-to-end through the real production dispatch path.
+var _ = Describe("phaseGuardAfter AfterToolCallback contract (#1997)", func() {
+	var (
+		state   *mapState
+		toolCtx tool.Context
+		after   func(tool.Context, tool.Tool, map[string]any, map[string]any, error) (map[string]any, error)
+	)
+
+	BeforeEach(func() {
+		state = newMapState()
+		ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+			Username: "alice", Groups: []string{"sre"},
+		})
+		toolCtx = statefulToolContext{
+			fakeToolContext: fakeToolContext{Context: ctx},
+			state:           state,
+		}
+		_, after = NewPhaseGuardForTest()
+	})
+
+	DescribeTable("must return (nil, nil) on success so later AfterToolCallbacks (afterLog) still run",
+		func(toolName string, resp map[string]any) {
+			result, err := after(toolCtx, fakeTool{name: toolName}, nil, resp, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNil(),
+				"%s: phaseGuardAfter must return (nil, nil) on success -- returning the original resp short-circuits ADK's AfterToolCallback chain and silently drops afterLog", toolName)
+		},
+		Entry("UT-AF-1997-001: kubernaut_discover_workflows (phase3 checkpoint path)", "kubernaut_discover_workflows", map[string]any{"workflows": []any{}}),
+		Entry("UT-AF-1997-002: kubernaut_investigate (driver-entry path)", "kubernaut_investigate", map[string]any{"session_id": "sess-1997", "status": "active"}),
+		Entry("UT-AF-1997-003: kubernaut_reconnect (driver-entry path)", "kubernaut_reconnect", map[string]any{"session_id": "sess-1997b", "status": "active"}),
+		Entry("UT-AF-1997-004: kubernaut_complete (session-terminal path)", "kubernaut_complete", map[string]any{"status": "completed"}),
+		Entry("UT-AF-1997-005: kubernaut_cancel (session-terminal path)", "kubernaut_cancel", map[string]any{"status": "cancelled"}),
+		Entry("UT-AF-1997-006: kubernaut_complete_no_action (unmatched-tool fallthrough)", "kubernaut_complete_no_action", map[string]any{"status": "no_action"}),
+		Entry("UT-AF-1997-007: kubernaut_message (unmatched-tool fallthrough, unrelated tool)", "kubernaut_message", map[string]any{"reply": "hi"}),
+	)
+
+	It("UT-AF-1997-008: also returns (nil, nil) on a failed call, instead of re-surfacing callErr itself (no functional regression: ADK falls back to the original fErr when every callback passes through)", func() {
+		result, err := after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, nil, fmt.Errorf("boom"))
+		Expect(result).To(BeNil())
+		Expect(err).NotTo(HaveOccurred(),
+			"phaseGuardAfter must pass through (nil, nil) on failure too, so later AfterToolCallbacks still observe the failed call instead of the chain terminating early on phaseGuardAfter's own re-returned error")
+	})
+})

--- a/pkg/apifrontend/agent/phase_guard_afterlog_wiring_1997_test.go
+++ b/pkg/apifrontend/agent/phase_guard_afterlog_wiring_1997_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent_test
+
+import (
+	"context"
+	"iter"
+	"sync"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/runner"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+	"google.golang.org/genai"
+
+	agentpkg "github.com/jordigilh/kubernaut/pkg/apifrontend/agent"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
+)
+
+// wiringLogSink is a minimal logr.LogSink that records Info() messages, used
+// to prove afterLog actually executes (AU-3/AU-12 audit-trail completeness)
+// when driven through the real production dispatch path.
+type wiringLogSink struct {
+	mu       sync.Mutex
+	messages []string
+}
+
+func (s *wiringLogSink) Init(logr.RuntimeInfo)                  {}
+func (s *wiringLogSink) Enabled(int) bool                       { return true }
+func (s *wiringLogSink) WithValues(...interface{}) logr.LogSink { return s }
+func (s *wiringLogSink) WithName(string) logr.LogSink           { return s }
+func (s *wiringLogSink) Error(error, string, ...interface{})    {}
+func (s *wiringLogSink) Info(_ int, msg string, _ ...interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, msg)
+}
+
+func (s *wiringLogSink) contains(msg string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, m := range s.messages {
+		if m == msg {
+			return true
+		}
+	}
+	return false
+}
+
+// #1997 wiring proof: root.go's NewRootAgent registers
+// AfterToolCallbacks: []llmagent.AfterToolCallback{afterMetrics, afterAudit,
+// afterPhase, afterLog}. This IT test reproduces that exact relative
+// ordering (afterPhase before afterLog) through the real ADK dispatch path
+// (llmagent + runner.Run, not a direct in-process call to `after`), and
+// proves afterLog's "tool call completed" line -- the FedRAMP AU-3/AU-12
+// audit-completeness signal BR-AUDIT-005 requires -- now actually reaches
+// the log for a driver-entry tool call, closing the gap a UT calling
+// phaseGuardAfter in isolation cannot observe.
+var _ = Describe("phaseGuardAfter + afterLog production wiring (#1997, BR-AUDIT-005 AU-3/AU-12)", func() {
+	It("IT-AF-1997-009: afterLog's \"tool call completed\" fires for kubernaut_investigate via runner.Run, in root.go's real AfterToolCallbacks order", func() {
+		type investigateArgs struct {
+			RRID string `json:"rr_id,omitempty"`
+		}
+		type investigateResult struct {
+			SessionID string `json:"session_id"`
+			Status    string `json:"status"`
+		}
+
+		investigateTool, err := functiontool.New(functiontool.Config{
+			Name:        "kubernaut_investigate",
+			Description: "Start an interactive investigation (driver-entry tool)",
+		}, func(_ tool.Context, _ investigateArgs) (investigateResult, error) {
+			return investigateResult{SessionID: "sess-1997-wiring", Status: "active"}, nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		var callCount int
+		genFn := func(_ context.Context, _ *model.LLMRequest, _ bool) iter.Seq2[*model.LLMResponse, error] {
+			return func(yield func(*model.LLMResponse, error) bool) {
+				callCount++
+				if callCount == 1 {
+					yield(&model.LLMResponse{
+						Content: &genai.Content{
+							Role: "model",
+							Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{
+								ID:   "call-1997-1",
+								Name: "kubernaut_investigate",
+								Args: map[string]any{},
+							}}},
+						},
+					}, nil)
+					return
+				}
+				yield(&model.LLMResponse{
+					Content: &genai.Content{
+						Role:  "model",
+						Parts: []*genai.Part{{Text: "Done."}},
+					},
+				}, nil)
+			}
+		}
+		adapter := &llmAdapter{genFn: genFn}
+
+		// Registration order mirrors root.go's NewRootAgent exactly for the
+		// two callbacks under test: afterPhase runs before afterLog.
+		_, afterPhase := agentpkg.NewPhaseGuardForTest()
+		_, afterLog := agentpkg.NewToolLoggingCallbacksForTest()
+
+		a, err := llmagent.New(llmagent.Config{
+			Name:               "phase-guard-afterlog-wiring-it-agent",
+			Description:        "IT agent proving afterPhase does not short-circuit afterLog (#1997)",
+			Model:              adapter,
+			Tools:              []tool.Tool{investigateTool},
+			Instruction:        "You are a test agent. Call kubernaut_investigate when asked.",
+			AfterToolCallbacks: []llmagent.AfterToolCallback{afterPhase, afterLog},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		r, err := runner.New(runner.Config{
+			AppName:           "phase-guard-afterlog-wiring-it",
+			Agent:             a,
+			SessionService:    session.InMemoryService(),
+			AutoCreateSession: true,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		sink := &wiringLogSink{}
+		logger := logr.New(sink)
+		ctx := logr.NewContext(context.Background(), logger)
+		ctx = auth.WithUserIdentity(ctx, &auth.UserIdentity{
+			Username: "sre@example.com", Groups: []string{"sre"},
+		})
+
+		msg := &genai.Content{
+			Role:  "user",
+			Parts: []*genai.Part{{Text: "start an investigation"}},
+		}
+		for event, runErr := range r.Run(ctx, "test-user", "sess-1997-wiring", msg, agent.RunConfig{}) {
+			Expect(runErr).NotTo(HaveOccurred())
+			_ = event
+		}
+
+		Expect(sink.contains("tool call completed")).To(BeTrue(),
+			"IT-AF-1997-009 BR-AUDIT-005/AU-3/AU-12: afterLog's \"tool call completed\" audit log must fire for kubernaut_investigate through the real production AfterToolCallbacks chain -- afterPhase must not short-circuit it")
+	})
+})

--- a/pkg/apifrontend/config/config.go
+++ b/pkg/apifrontend/config/config.go
@@ -142,6 +142,12 @@ type ServerConfig struct {
 	HealthPort        int             `yaml:"healthPort"`
 	TLS               ServerTLSConfig `yaml:"tls"`
 	MaxSSEConnections int             `yaml:"maxSSEConnections,omitempty"`
+	// DisableProfiling gates the /debug/pprof/* endpoints on the health
+	// mux (#1995). Defaults to true (profiling OFF), mirroring
+	// kubernautagent's ServerConfig.DisableProfiling secure-by-default
+	// posture -- an operator must explicitly set this to false to expose
+	// pprof for live diagnostics.
+	DisableProfiling bool `yaml:"disableProfiling"`
 }
 
 // ServerTLSConfig extends the shared TLS config with a Required flag for FedRAMP compliance.
@@ -243,9 +249,10 @@ type RBACConfig struct {
 func DefaultConfig() *Config {
 	return &Config{
 		Server: ServerConfig{
-			Port:        8443,
-			MetricsPort: 9090,
-			HealthPort:  8081,
+			Port:             8443,
+			MetricsPort:      9090,
+			HealthPort:       8081,
+			DisableProfiling: true,
 		},
 		Agent: AgentConfig{
 			KABaseURL:     "http://localhost:8080",

--- a/pkg/apifrontend/config/config_test.go
+++ b/pkg/apifrontend/config/config_test.go
@@ -532,6 +532,34 @@ var _ = Describe("Tier 5b: Configurable Ports (Issue #1339)", func() {
 	})
 })
 
+var _ = Describe("Tier 5c: pprof/debug profiling gate (Issue #1995)", func() {
+	// DisableProfiling defaults to true (profiling OFF), mirroring
+	// kubernautagent's DefaultConfig() secure-by-default posture
+	// (internal/kubernautagent/config/config.go). Unlike gateway/
+	// datastorage (which default profiling ON), AF and KA both sit behind
+	// the same trust boundary consideration and are kept consistent with
+	// each other; an operator must explicitly opt in via
+	// server.disableProfiling: false to expose /debug/pprof/*.
+	It("UT-AF-1995-001 DefaultConfig disables profiling by default (secure-by-default, mirrors KA)", func() {
+		cfg := config.DefaultConfig()
+		Expect(cfg.Server.DisableProfiling).To(BeTrue())
+	})
+
+	It("UT-AF-1995-002 YAML can opt in to profiling by setting disableProfiling: false", func() {
+		data := []byte("server:\n  disableProfiling: false\n")
+		cfg, err := config.Load(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Server.DisableProfiling).To(BeFalse())
+	})
+
+	It("UT-AF-1995-003 omitted disableProfiling in YAML keeps the secure default", func() {
+		data := []byte("server:\n  port: 8443\n")
+		cfg, err := config.Load(data)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cfg.Server.DisableProfiling).To(BeTrue())
+	})
+})
+
 var _ = Describe("Tier 6: Extended Validation (v2)", func() {
 	It("UT-AF-039-036 rejects auth issuerURL without scheme", func() {
 		cfg := validConfig()

--- a/pkg/apifrontend/ka/session_pool.go
+++ b/pkg/apifrontend/ka/session_pool.go
@@ -46,6 +46,45 @@ func extractSessionID(s PoolSession) string {
 	return "unknown"
 }
 
+// closeSessionBoundedTimeout bounds how long closeSessionBounded waits for
+// PoolSession.Close() before abandoning it. A var (not const) so tests can
+// shrink it, mirroring PooledToolCallTimeout's test-override pattern
+// (pkg/apifrontend/tools/ka_tools.go).
+var closeSessionBoundedTimeout = 5 * time.Second
+
+// closeSessionBounded fires session.Close() and its bounding timer entirely
+// in a background goroutine, so this call returns immediately regardless of
+// how long (or whether) Close() ever completes (#1995). go-sdk@v1.7.0's
+// streamableClientConn.Close() sends an HTTP DELETE that can block
+// indefinitely if the server-side session has an in-flight tool handler
+// that never returns (confirmed via a time-boxed spike) -- without this,
+// a single poisoned session wedges EvictIdle's shared ticker (and, via
+// this same helper, DrainAll/Inject/InjectWithCleanup) for every other
+// (rr_id, username) pool entry forever. If Close() never returns, its
+// innermost goroutine is abandoned (leaked until the underlying transport
+// eventually errors out or the process exits); this is a deliberate,
+// bounded trade-off versus an unbounded pool-wide stall.
+func closeSessionBounded(session PoolSession, logger logr.Logger, sessionID string) {
+	if session == nil {
+		return
+	}
+	go func() {
+		done := make(chan error, 1)
+		go func() {
+			done <- session.Close()
+		}()
+		select {
+		case err := <-done:
+			if err != nil {
+				logger.Info("pooled session close returned error", "mcp_session_id", sessionID, "error", err.Error())
+			}
+		case <-time.After(closeSessionBoundedTimeout):
+			logger.Info("pooled session close did not complete within bound, abandoning wait",
+				"mcp_session_id", sessionID, "timeout", closeSessionBoundedTimeout.String())
+		}
+	}()
+}
+
 // PoolConfig configures the KASessionPool.
 type PoolConfig struct {
 	Factory    SessionFactory
@@ -172,7 +211,7 @@ func (p *KASessionPool) Inject(rrID, username string, session PoolSession) {
 	p.mu.Unlock()
 
 	if exists && old.session != nil {
-		_ = old.session.Close()
+		closeSessionBounded(old.session, p.logger, old.sessionID)
 	}
 	p.logger.Info("session injected into pool", "rr_id", rrID, "username", username, "mcp_session_id", sid)
 }
@@ -201,7 +240,7 @@ func (p *KASessionPool) InjectWithCleanup(rrID, username string, session PoolSes
 			old.onRelease()
 		}
 		if old.session != nil {
-			_ = old.session.Close()
+			closeSessionBounded(old.session, p.logger, old.sessionID)
 		}
 	}
 	p.logger.Info("session injected into pool (with cleanup)",
@@ -270,7 +309,7 @@ func (p *KASessionPool) DrainAll(ctx context.Context) error {
 			entry.onRelease()
 		}
 		if entry.session != nil {
-			_ = entry.session.Close()
+			closeSessionBounded(entry.session, p.logger, entry.sessionID)
 		}
 	}
 	return nil
@@ -298,7 +337,7 @@ func (p *KASessionPool) EvictIdle() int {
 			e.onRelease()
 		}
 		if e.session != nil {
-			_ = e.session.Close()
+			closeSessionBounded(e.session, p.logger, e.sessionID)
 		}
 	}
 	return evicted

--- a/pkg/apifrontend/ka/session_pool_test.go
+++ b/pkg/apifrontend/ka/session_pool_test.go
@@ -18,11 +18,12 @@ import (
 
 // mockPoolSession is a test double for ka.PoolSession.
 type mockPoolSession struct {
-	id       int
-	closed   bool
-	mu       sync.Mutex
-	callFn   func(ctx context.Context, params *mcp.CallToolParams) (*mcp.CallToolResult, error)
-	pingFn   func(ctx context.Context, params *mcp.PingParams) error
+	id      int
+	closed  bool
+	mu      sync.Mutex
+	callFn  func(ctx context.Context, params *mcp.CallToolParams) (*mcp.CallToolResult, error)
+	pingFn  func(ctx context.Context, params *mcp.PingParams) error
+	closeFn func() error
 }
 
 func (s *mockPoolSession) CallTool(ctx context.Context, params *mcp.CallToolParams) (*mcp.CallToolResult, error) {
@@ -39,7 +40,17 @@ func (s *mockPoolSession) Ping(ctx context.Context, params *mcp.PingParams) erro
 	return nil
 }
 
+// Close honors closeFn (used by #1995 specs to simulate a Close() that
+// hangs forever) without holding s.mu while it runs, so a hanging closeFn
+// on one instance never blocks IsClosed() calls on that same instance.
 func (s *mockPoolSession) Close() error {
+	if s.closeFn != nil {
+		err := s.closeFn()
+		s.mu.Lock()
+		s.closed = true
+		s.mu.Unlock()
+		return err
+	}
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.closed = true
@@ -473,7 +484,8 @@ var _ = Describe("KASessionPool (G2 + G9: Pool + User Isolation)", func() {
 
 			err := pool.DrainAll(context.Background())
 			Expect(err).NotTo(HaveOccurred())
-			Expect(injected.IsClosed()).To(BeTrue(),
+			// #1995: DrainAll's Close() call is now bounded/async (closeSessionBounded).
+			Eventually(injected.IsClosed).Should(BeTrue(),
 				"DrainAll should close injected sessions")
 		})
 	})
@@ -775,6 +787,61 @@ var _ = Describe("MCP Transport Observability — Audit Logging (#1387)", func()
 		}
 		Expect(found).To(BeTrue(),
 			"SI-4: ping-eviction must log mcp_session_id of dead session alongside error detail for incident correlation")
+	})
+})
+
+// #1995: EvictIdle (and, by the shared closeSessionBounded helper, DrainAll
+// and Inject/InjectWithCleanup's replace-on-collision) must never let one
+// poisoned session's hanging Close() wedge the entire pool. EvictIdle in
+// particular runs on a single shared 2-minute ticker for every (rr_id,
+// username) in the pool (cmd/apifrontend/main.go) -- a synchronous,
+// unbounded Close() call would starve idle cleanup for every other entry
+// forever.
+var _ = Describe("KASessionPool bounded session close (#1995)", func() {
+	It("IT-AF-1995-007: EvictIdle returns promptly and still closes a healthy sibling entry even when another entry's Close() hangs forever", func() {
+		var healthyClosed atomic.Bool
+		hangingSession := &mockPoolSession{
+			id: 1,
+			closeFn: func() error {
+				select {} // simulates go-sdk's Close() blocking on an in-flight server handler that never returns
+			},
+		}
+		healthySession := &mockPoolSession{
+			id: 2,
+			closeFn: func() error {
+				healthyClosed.Store(true)
+				return nil
+			},
+		}
+
+		pool := ka.NewKASessionPool(ka.PoolConfig{
+			Factory:    func(_ context.Context) (ka.PoolSession, error) { return &mockPoolSession{}, nil },
+			MaxEntries: 10,
+			IdleTTL:    1 * time.Millisecond,
+			Logger:     logr.Discard(),
+		})
+		pool.Inject("rr-hang", "alice", hangingSession)
+		pool.Inject("rr-healthy", "bob", healthySession)
+
+		time.Sleep(5 * time.Millisecond)
+
+		var evicted int
+		done := make(chan struct{})
+		go func() {
+			evicted = pool.EvictIdle()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			Fail("IT-AF-1995-007: EvictIdle did not return within the safety bound — a hanging Close() wedged the shared eviction path")
+		}
+
+		Expect(evicted).To(Equal(2), "both idle entries must be reported evicted")
+		Expect(pool.Size()).To(Equal(0), "both entries must be removed from the pool immediately, independent of Close() completion")
+		Eventually(healthyClosed.Load, 2*time.Second).Should(BeTrue(),
+			"the healthy sibling's Close() must still be invoked even though the hanging entry's Close() never returns")
 	})
 })
 

--- a/pkg/apifrontend/ka/shutdown_test.go
+++ b/pkg/apifrontend/ka/shutdown_test.go
@@ -52,7 +52,11 @@ var _ = Describe("Graceful Shutdown (G14)", func() {
 		err = pool.DrainAll(ctx)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(pool.Size()).To(Equal(0))
-		Expect(atomic.LoadInt32(&closeCount)).To(Equal(int32(2)))
+		// #1995: DrainAll's session.Close() calls are now bounded/async
+		// (closeSessionBounded) so a poisoned session can't wedge shutdown
+		// forever -- Close() completion is observed via Eventually rather
+		// than assumed synchronous with DrainAll's return.
+		Eventually(func() int32 { return atomic.LoadInt32(&closeCount) }).Should(Equal(int32(2)))
 	})
 
 	It("UT-AF-1234-141: DrainAll respects context deadline", func() {

--- a/pkg/apifrontend/severity/triage.go
+++ b/pkg/apifrontend/severity/triage.go
@@ -218,19 +218,7 @@ func (t *Triager) runTier1(ctx context.Context, input TriageInput) (TriageResult
 		podNameSet[pn] = struct{}{}
 	}
 
-	// Pass 1: firing alerts (highest priority).
-	if result, ok := t.bestAlertMatch(alerts, input.Labels, podNameSet, input.Namespace, "firing", SourceFiringAlert); ok {
-		return result, true
-	}
-
-	// Pass 2: pending alerts with the same pod correlation (closes the
-	// timing race where an alert condition is met but the `for` duration
-	// has not elapsed yet).
-	if result, ok := t.bestAlertMatch(alerts, input.Labels, podNameSet, input.Namespace, "pending", SourcePendingAlert); ok {
-		return result, true
-	}
-
-	return TriageResult{}, false
+	return t.bestOverallMatch(alerts, input.Labels, podNameSet, input.Namespace)
 }
 
 // matchCandidate tracks the best alert match at a given priority tier.
@@ -256,48 +244,73 @@ func (m *matchCandidate) result(source Source) TriageResult {
 	}
 }
 
-// nsSource maps a resource-level source to its namespace-scoped equivalent.
-func nsSource(base Source) Source {
-	if base == SourcePendingAlert {
-		return SourceNSPendingAlert
-	}
-	return SourceNSFiringAlert
-}
-
-// clusterSource maps a resource-level source to its cluster-scoped equivalent.
-func clusterSource(base Source) Source {
-	if base == SourcePendingAlert {
-		return SourceClusterPendingAlert
-	}
-	return SourceClusterFiringAlert
-}
-
-func (t *Triager) bestAlertMatch(alerts []prom.Alert, targetLabels map[string]string, podNameSet map[string]struct{}, targetNamespace, state string, source Source) (TriageResult, bool) {
-	var resourceBest, nsBest, clusterBest matchCandidate
+// bestOverallMatch scans all firing/pending alerts once and returns the
+// single best match across both specificity (resource > namespace >
+// cluster) and state (firing > pending), with specificity taking strict
+// priority over state (#2018/#2021): a resource- or namespace-scoped alert
+// -- even only "pending" -- must never lose to a cluster-scoped alert
+// merely because the cluster alert happens to be "firing".
+//
+// Before this fix, runTier1 ran two sequential full-fallback passes (firing
+// first, then pending only if firing found nothing at all). A persistently
+// firing, unrelated cluster-scoped alert (no namespace label) would win the
+// firing pass's cluster slot and return immediately -- before ever reaching
+// the pending pass, where the *actual* target's own alert might have been
+// found via resourceBest/nsBest but simply hadn't started firing yet.
+//
+// Within a single tier (resource, namespace, or cluster), firing still
+// beats pending -- only the cross-tier priority changed.
+func (t *Triager) bestOverallMatch(alerts []prom.Alert, targetLabels map[string]string, podNameSet map[string]struct{}, targetNamespace string) (TriageResult, bool) {
+	var resourceFiring, resourcePending, nsFiring, nsPending, clusterFiring, clusterPending matchCandidate
 
 	for _, alert := range alerts {
-		if alert.State != state {
+		var firing bool
+		switch alert.State {
+		case "firing":
+			firing = true
+		case "pending":
+			firing = false
+		default:
 			continue
 		}
 		sev := alert.Labels["severity"]
+		name := alert.Labels["alertname"]
 
-		if labelsOverlap(alert.Labels, targetLabels, podNameSet, targetNamespace) {
-			resourceBest.update(sev, alert.Labels["alertname"])
-		} else if targetNamespace != "" && alert.Labels["namespace"] == targetNamespace {
-			nsBest.update(sev, alert.Labels["alertname"])
-		} else if alert.Labels["namespace"] == "" {
-			clusterBest.update(sev, alert.Labels["alertname"])
+		switch {
+		case labelsOverlap(alert.Labels, targetLabels, podNameSet, targetNamespace):
+			if firing {
+				resourceFiring.update(sev, name)
+			} else {
+				resourcePending.update(sev, name)
+			}
+		case targetNamespace != "" && alert.Labels["namespace"] == targetNamespace:
+			if firing {
+				nsFiring.update(sev, name)
+			} else {
+				nsPending.update(sev, name)
+			}
+		case alert.Labels["namespace"] == "":
+			if firing {
+				clusterFiring.update(sev, name)
+			} else {
+				clusterPending.update(sev, name)
+			}
 		}
 	}
 
-	if resourceBest.found {
-		return resourceBest.result(source), true
-	}
-	if nsBest.found {
-		return nsBest.result(nsSource(source)), true
-	}
-	if clusterBest.found {
-		return clusterBest.result(clusterSource(source)), true
+	switch {
+	case resourceFiring.found:
+		return resourceFiring.result(SourceFiringAlert), true
+	case resourcePending.found:
+		return resourcePending.result(SourcePendingAlert), true
+	case nsFiring.found:
+		return nsFiring.result(SourceNSFiringAlert), true
+	case nsPending.found:
+		return nsPending.result(SourceNSPendingAlert), true
+	case clusterFiring.found:
+		return clusterFiring.result(SourceClusterFiringAlert), true
+	case clusterPending.found:
+		return clusterPending.result(SourceClusterPendingAlert), true
 	}
 	return TriageResult{}, false
 }

--- a/pkg/apifrontend/severity/triage_test.go
+++ b/pkg/apifrontend/severity/triage_test.go
@@ -213,6 +213,56 @@ var _ = Describe("Triage Orchestrator", func() {
 			Expect(result.Severity).To(Equal("info"))
 			Expect(result.Source).To(Equal(severity.SourceFiringAlert))
 		})
+
+		It("UT-AF-2018-001: pending resource-specific alert wins over firing cluster-scoped alert (specificity beats state)", func() {
+			mockProm := &mockPromClient{
+				alerts: []prom.Alert{
+					// Cluster-scoped, continuously firing, unrelated to the target (#2018 repro:
+					// CDIDefaultStorageClassDegraded firing throughout the window).
+					{Labels: map[string]string{"alertname": "CDIDefaultStorageClassDegraded", "severity": "warning"}, State: "firing"},
+					// The target's own alert, correlated by resource labels, but only "pending"
+					// (its `for` duration has not elapsed yet) at triage time.
+					{Labels: map[string]string{"alertname": "KubePodCrashLooping", "namespace": "prod", "kind": "Deployment", "name": "web-api", "severity": "critical"}, State: "pending"},
+				},
+			}
+			triager := severity.NewTriager(mockProm, &mockLLM{}, defaultCfg, logr.Discard())
+			result, err := triager.Triage(context.Background(), defaultInput)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.AlertName).To(Equal("KubePodCrashLooping"),
+				"#2018: resource-specific match must win over cluster-scoped fallback regardless of firing/pending state")
+			Expect(result.Severity).To(Equal("critical"))
+			Expect(result.Source).To(Equal(severity.SourcePendingAlert))
+		})
+
+		It("UT-AF-2018-002: pending namespace-scoped alert wins over firing cluster-scoped alert (specificity beats state)", func() {
+			mockProm := &mockPromClient{
+				alerts: []prom.Alert{
+					{Labels: map[string]string{"alertname": "ClusterWideAlert", "severity": "critical"}, State: "firing"},
+					{Labels: map[string]string{"alertname": "NamespaceAlert", "namespace": "prod", "severity": "warning"}, State: "pending"},
+				},
+			}
+			triager := severity.NewTriager(mockProm, &mockLLM{}, defaultCfg, logr.Discard())
+			result, err := triager.Triage(context.Background(), defaultInput)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.AlertName).To(Equal("NamespaceAlert"),
+				"#2018: namespace-scoped match must win over cluster-scoped fallback regardless of firing/pending state")
+			Expect(result.Source).To(Equal(severity.SourceNSPendingAlert))
+		})
+
+		It("UT-AF-2018-003: cluster-scoped firing still wins over cluster-scoped pending when nothing more specific exists", func() {
+			mockProm := &mockPromClient{
+				alerts: []prom.Alert{
+					{Labels: map[string]string{"alertname": "PendingClusterAlert", "severity": "critical"}, State: "pending"},
+					{Labels: map[string]string{"alertname": "FiringClusterAlert", "severity": "warning"}, State: "firing"},
+				},
+			}
+			triager := severity.NewTriager(mockProm, &mockLLM{}, defaultCfg, logr.Discard())
+			result, err := triager.Triage(context.Background(), defaultInput)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.AlertName).To(Equal("FiringClusterAlert"),
+				"within the same (cluster) tier, firing still beats pending -- only cross-tier priority changed")
+			Expect(result.Source).To(Equal(severity.SourceClusterFiringAlert))
+		})
 	})
 
 	Describe("Tier 1.5: Pending Alert Check", func() {

--- a/pkg/apifrontend/severity/types.go
+++ b/pkg/apifrontend/severity/types.go
@@ -25,6 +25,13 @@ const (
 	// The alert has no namespace label, so it is matched to any investigation target.
 	// This is the broadest correlation tier -- the alert represents a cluster-wide
 	// condition that may or may not be related to the specific workload under triage.
+	//
+	// #2018: cluster-scoped tiers are the LAST fallback, checked only after BOTH
+	// firing and pending resource-scoped and namespace-scoped alerts have been
+	// ruled out (bestOverallMatch in triage.go). Specificity always outranks
+	// state -- a merely "pending" resource-specific alert still beats a
+	// continuously "firing" cluster-scoped alert, since the latter carries no
+	// evidence of actually being related to the target workload.
 	SourceClusterFiringAlert Source = "cluster_firing_alert"
 	// SourceClusterPendingAlert is the pending equivalent of SourceClusterFiringAlert.
 	SourceClusterPendingAlert Source = "cluster_pending_alert"

--- a/pkg/apifrontend/tools/ka_tools.go
+++ b/pkg/apifrontend/tools/ka_tools.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"time"
 
+	"github.com/go-logr/logr"
 	"google.golang.org/adk/tool"
 	"google.golang.org/adk/tool/functiontool"
 
@@ -28,6 +29,17 @@ import (
 // verify real end-to-end timeout enforcement in milliseconds, mirroring
 // AwaitSessionTimeout's test-override pattern (crd_tools.go).
 var PooledToolCallTimeout = 60 * time.Second
+
+// logPooledToolTimeoutFired emits a log line when a pooled KA MCP tool call
+// is aborted by PooledToolCallTimeout (or an inherited parent cancellation)
+// rather than completing normally (#1995) -- without this, an operator
+// investigating a stuck interactive session has no signal distinguishing "the
+// tool call is still legitimately in flight" from "AF already gave up on it
+// N seconds ago and downgraded/errored the response".
+func logPooledToolTimeoutFired(ctx context.Context, toolName, rrID string, start time.Time) {
+	logr.FromContextOrDiscard(ctx).Info("pooled KA tool call timed out or was canceled",
+		"tool", toolName, "rr_id", rrID, "elapsed", time.Since(start).String())
+}
 
 // WorkflowParameter describes a single input parameter for a workflow.
 type WorkflowParameter struct {
@@ -87,6 +99,7 @@ func HandleDiscoverWorkflows(ctx context.Context, mcpClient ka.MCPClient, args D
 
 	toolCtx, cancel := context.WithTimeout(ctx, PooledToolCallTimeout)
 	defer cancel()
+	start := time.Now()
 	kaResult, err := mcpClient.DiscoverWorkflows(toolCtx, ka.DiscoverWorkflowsArgs{
 		RRID:       args.RRID,
 		WorkflowID: args.WorkflowID,
@@ -94,6 +107,7 @@ func HandleDiscoverWorkflows(ctx context.Context, mcpClient ka.MCPClient, args D
 	})
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			logPooledToolTimeoutFired(ctx, "discover_workflows", args.RRID, start)
 			return DiscoverWorkflowsResult{Workflows: []WorkflowDetail{}, Count: 0}, nil
 		}
 		return DiscoverWorkflowsResult{}, fmt.Errorf("discover workflows: %w", err)
@@ -264,6 +278,7 @@ func HandleSelectWorkflow(ctx context.Context, mcpClient ka.MCPClient, args Sele
 	}
 	toolCtx, cancel := context.WithTimeout(ctx, PooledToolCallTimeout)
 	defer cancel()
+	start := time.Now()
 	result, err := mcpClient.SelectWorkflow(toolCtx, ka.SelectWorkflowArgs{
 		RRID:       args.RRID,
 		WorkflowID: args.WorkflowID,
@@ -273,6 +288,9 @@ func HandleSelectWorkflow(ctx context.Context, mcpClient ka.MCPClient, args Sele
 		Parameters: args.Parameters,
 	})
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			logPooledToolTimeoutFired(ctx, "select_workflow", args.RRID, start)
+		}
 		return SelectWorkflowResult{}, fmt.Errorf("selecting workflow: %w", err)
 	}
 
@@ -402,12 +420,18 @@ func HandleCompleteNoAction(ctx context.Context, mcpClient ka.MCPClient, args Co
 		}
 	}
 
-	kaResult, err := mcpClient.CompleteNoAction(ctx, ka.CompleteNoActionArgs{
+	toolCtx, cancel := context.WithTimeout(ctx, PooledToolCallTimeout)
+	defer cancel()
+	start := time.Now()
+	kaResult, err := mcpClient.CompleteNoAction(toolCtx, ka.CompleteNoActionArgs{
 		RRID:             args.RRID,
 		Reason:           args.Reason,
 		EscalationReason: args.EscalationReason,
 	})
 	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			logPooledToolTimeoutFired(ctx, "complete_no_action", args.RRID, start)
+		}
 		return CompleteNoActionResult{}, fmt.Errorf("complete_no_action: %w", err)
 	}
 

--- a/pkg/apifrontend/tools/pooled_tool_timeout_1995_test.go
+++ b/pkg/apifrontend/tools/pooled_tool_timeout_1995_test.go
@@ -1,0 +1,121 @@
+package tools_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+)
+
+// containsMessage reports whether sink captured a log entry with the given message.
+func (s *logCaptureSink) containsMessage(msg string) bool {
+	for _, m := range s.messages {
+		if m == msg {
+			return true
+		}
+	}
+	return false
+}
+
+var _ = Describe("Pooled KA tool-call timeout observability (#1995, BR-INTERACTIVE-010)", func() {
+	var origTimeout time.Duration
+
+	BeforeEach(func() {
+		origTimeout = tools.PooledToolCallTimeout
+		tools.PooledToolCallTimeout = 20 * time.Millisecond
+	})
+
+	AfterEach(func() {
+		tools.PooledToolCallTimeout = origTimeout
+	})
+
+	Describe("HandleDiscoverWorkflows", func() {
+		It("UT-AF-1995-005: logs a warning with rr_id and elapsed time when the pooled call times out", func() {
+			mockMCP := &ka.MockMCPClient{
+				DiscoverWorkflowsFn: func(ctx context.Context, _ ka.DiscoverWorkflowsArgs) (*ka.DiscoverWorkflowsResult, error) {
+					<-ctx.Done()
+					return nil, ctx.Err()
+				},
+			}
+
+			sink := &logCaptureSink{}
+			logger := logr.New(sink)
+			ctx := logr.NewContext(context.Background(), logger)
+
+			var result tools.DiscoverWorkflowsResult
+			var err error
+			awaitWithSafetyBound(2*time.Second, func() {
+				result, err = tools.HandleDiscoverWorkflows(ctx, mockMCP, tools.DiscoverWorkflowsArgs{RRID: "pay/rr-1995-disc"})
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Count).To(Equal(0))
+
+			found := false
+			for i, msg := range sink.messages {
+				if msg == "pooled KA tool call timed out or was canceled" {
+					found = true
+					kv := sink.kvPairs[i]
+					Expect(kv).To(HaveKeyWithValue("rr_id", "pay/rr-1995-disc"))
+					Expect(kv).To(HaveKeyWithValue("tool", "discover_workflows"))
+					Expect(kv).To(HaveKey("elapsed"))
+				}
+			}
+			Expect(found).To(BeTrue(), "expected a timeout-fired log line from HandleDiscoverWorkflows; got messages: %v", sink.messages)
+		})
+	})
+
+	Describe("HandleSelectWorkflow", func() {
+		It("UT-AF-1995-006: logs a warning with rr_id and elapsed time when the pooled call times out", func() {
+			mockMCP := &ka.MockMCPClient{
+				SelectWorkflowFn: func(ctx context.Context, _ ka.SelectWorkflowArgs) (*ka.SelectWorkflowResult, error) {
+					<-ctx.Done()
+					return nil, ctx.Err()
+				},
+			}
+
+			sink := &logCaptureSink{}
+			logger := logr.New(sink)
+			ctx := logr.NewContext(context.Background(), logger)
+
+			var err error
+			awaitWithSafetyBound(2*time.Second, func() {
+				_, err = tools.HandleSelectWorkflow(ctx, mockMCP, tools.SelectWorkflowArgs{
+					RRID:       "pay/rr-1995-sel",
+					WorkflowID: "wf-restart",
+				}, nil)
+			})
+
+			Expect(err).To(HaveOccurred())
+
+			found := sink.containsMessage("pooled KA tool call timed out or was canceled")
+			Expect(found).To(BeTrue(), "expected a timeout-fired log line from HandleSelectWorkflow; got messages: %v", sink.messages)
+		})
+	})
+
+	Describe("HandleCompleteNoAction", func() {
+		It("UT-AF-1995-007: returns instead of hanging when the pooled MCP call never responds", func() {
+			mockMCP := &ka.MockMCPClient{
+				CompleteNoActionFn: func(ctx context.Context, _ ka.CompleteNoActionArgs) (*ka.CompleteNoActionResult, error) {
+					<-ctx.Done()
+					return nil, ctx.Err()
+				},
+			}
+
+			var err error
+			awaitWithSafetyBound(2*time.Second, func() {
+				_, err = tools.HandleCompleteNoAction(context.Background(), mockMCP, tools.CompleteNoActionArgs{
+					RRID: "pay/rr-1995-cna",
+				}, nil)
+			})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("complete_no_action"))
+		})
+	})
+})

--- a/pkg/audit/openapi_spec_data.yaml
+++ b/pkg/audit/openapi_spec_data.yaml
@@ -5839,8 +5839,8 @@ components:
           description: True when AI could not produce reliable result
         humanReviewReason:
           type: string
-          enum: [workflow_not_found, image_mismatch, parameter_validation_failed, no_matching_workflows, low_confidence, llm_parsing_error, investigation_inconclusive, rca_incomplete, alignment_check_failed]
-          description: Structured reason when needsHumanReview=true (BR-HAPI-197, BR-HAPI-200, BR-HAPI-212, BR-AI-601)
+          enum: [workflow_not_found, image_mismatch, parameter_validation_failed, no_matching_workflows, low_confidence, llm_parsing_error, investigation_inconclusive, rca_incomplete, alignment_check_failed, decision_expired]
+          description: Structured reason when needsHumanReview=true (BR-HAPI-197, BR-HAPI-200, BR-HAPI-212, BR-AI-601, #2019)
         warnings:
           type: array
           items:

--- a/pkg/datastorage/ogen-client/oas_json_gen.go
+++ b/pkg/datastorage/ogen-client/oas_json_gen.go
@@ -32183,6 +32183,8 @@ func (s *IncidentResponseDataHumanReviewReason) Decode(d *jx.Decoder) error {
 		*s = IncidentResponseDataHumanReviewReasonRcaIncomplete
 	case IncidentResponseDataHumanReviewReasonAlignmentCheckFailed:
 		*s = IncidentResponseDataHumanReviewReasonAlignmentCheckFailed
+	case IncidentResponseDataHumanReviewReasonDecisionExpired:
+		*s = IncidentResponseDataHumanReviewReasonDecisionExpired
 	default:
 		*s = IncidentResponseDataHumanReviewReason(v)
 	}

--- a/pkg/datastorage/ogen-client/oas_schemas_gen.go
+++ b/pkg/datastorage/ogen-client/oas_schemas_gen.go
@@ -18221,7 +18221,7 @@ type IncidentResponseData struct {
 	Timestamp time.Time `json:"timestamp"`
 	// True when AI could not produce reliable result.
 	NeedsHumanReview OptBool `json:"needsHumanReview"`
-	// Structured reason when needsHumanReview=true (BR-HAPI-197, BR-HAPI-200, BR-HAPI-212, BR-AI-601).
+	// Structured reason when needsHumanReview=true (BR-HAPI-197, BR-HAPI-200, BR-HAPI-212, BR-AI-601,.
 	HumanReviewReason OptIncidentResponseDataHumanReviewReason `json:"humanReviewReason"`
 	// Non-fatal warnings (e.g., OwnerChain validation issues).
 	Warnings []string `json:"warnings"`
@@ -18378,7 +18378,7 @@ func (s *IncidentResponseDataAlternativeWorkflowsItem) SetConfidence(val OptFloa
 	s.Confidence = val
 }
 
-// Structured reason when needsHumanReview=true (BR-HAPI-197, BR-HAPI-200, BR-HAPI-212, BR-AI-601).
+// Structured reason when needsHumanReview=true (BR-HAPI-197, BR-HAPI-200, BR-HAPI-212, BR-AI-601,.
 type IncidentResponseDataHumanReviewReason string
 
 const (
@@ -18391,6 +18391,7 @@ const (
 	IncidentResponseDataHumanReviewReasonInvestigationInconclusive IncidentResponseDataHumanReviewReason = "investigation_inconclusive"
 	IncidentResponseDataHumanReviewReasonRcaIncomplete             IncidentResponseDataHumanReviewReason = "rca_incomplete"
 	IncidentResponseDataHumanReviewReasonAlignmentCheckFailed      IncidentResponseDataHumanReviewReason = "alignment_check_failed"
+	IncidentResponseDataHumanReviewReasonDecisionExpired           IncidentResponseDataHumanReviewReason = "decision_expired"
 )
 
 // AllValues returns all IncidentResponseDataHumanReviewReason values.
@@ -18405,6 +18406,7 @@ func (IncidentResponseDataHumanReviewReason) AllValues() []IncidentResponseDataH
 		IncidentResponseDataHumanReviewReasonInvestigationInconclusive,
 		IncidentResponseDataHumanReviewReasonRcaIncomplete,
 		IncidentResponseDataHumanReviewReasonAlignmentCheckFailed,
+		IncidentResponseDataHumanReviewReasonDecisionExpired,
 	}
 }
 
@@ -18428,6 +18430,8 @@ func (s IncidentResponseDataHumanReviewReason) MarshalText() ([]byte, error) {
 	case IncidentResponseDataHumanReviewReasonRcaIncomplete:
 		return []byte(s), nil
 	case IncidentResponseDataHumanReviewReasonAlignmentCheckFailed:
+		return []byte(s), nil
+	case IncidentResponseDataHumanReviewReasonDecisionExpired:
 		return []byte(s), nil
 	default:
 		return nil, errors.Errorf("invalid value: %q", s)
@@ -18463,6 +18467,9 @@ func (s *IncidentResponseDataHumanReviewReason) UnmarshalText(data []byte) error
 		return nil
 	case IncidentResponseDataHumanReviewReasonAlignmentCheckFailed:
 		*s = IncidentResponseDataHumanReviewReasonAlignmentCheckFailed
+		return nil
+	case IncidentResponseDataHumanReviewReasonDecisionExpired:
+		*s = IncidentResponseDataHumanReviewReasonDecisionExpired
 		return nil
 	default:
 		return errors.Errorf("invalid value: %q", data)

--- a/pkg/datastorage/ogen-client/oas_validators_gen.go
+++ b/pkg/datastorage/ogen-client/oas_validators_gen.go
@@ -5624,6 +5624,8 @@ func (s IncidentResponseDataHumanReviewReason) Validate() error {
 		return nil
 	case "alignment_check_failed":
 		return nil
+	case "decision_expired":
+		return nil
 	default:
 		return errors.Errorf("invalid value: %v", s)
 	}

--- a/pkg/datastorage/server/middleware/openapi_spec_data.yaml
+++ b/pkg/datastorage/server/middleware/openapi_spec_data.yaml
@@ -5839,8 +5839,8 @@ components:
           description: True when AI could not produce reliable result
         humanReviewReason:
           type: string
-          enum: [workflow_not_found, image_mismatch, parameter_validation_failed, no_matching_workflows, low_confidence, llm_parsing_error, investigation_inconclusive, rca_incomplete, alignment_check_failed]
-          description: Structured reason when needsHumanReview=true (BR-HAPI-197, BR-HAPI-200, BR-HAPI-212, BR-AI-601)
+          enum: [workflow_not_found, image_mismatch, parameter_validation_failed, no_matching_workflows, low_confidence, llm_parsing_error, investigation_inconclusive, rca_incomplete, alignment_check_failed, decision_expired]
+          description: Structured reason when needsHumanReview=true (BR-HAPI-197, BR-HAPI-200, BR-HAPI-212, BR-AI-601, #2019)
         warnings:
           type: array
           items:

--- a/pkg/kubernautagent/types/types.go
+++ b/pkg/kubernautagent/types/types.go
@@ -34,6 +34,16 @@ const (
 // that must bypass interactive hold.
 const HumanReviewReasonAlignmentCheckFailed = "alignment_check_failed"
 
+// HumanReviewReasonDecisionExpired is the sentinel value for
+// InvestigationResult.HumanReviewReason when kubernaut_discover_workflows
+// found and presented a real workflow recommendation via
+// kubernaut_present_decision, but no response (select_workflow or
+// complete_no_action) arrived before the interactive session's inactivity
+// timeout tore it down. Distinguishes this outcome from the genuine
+// "no_matching_workflows" case (#2003) so the discovered recommendation is
+// preserved in the audit trail/CRD instead of silently discarded (#2019).
+const HumanReviewReasonDecisionExpired = "decision_expired"
+
 // PhaseToolMap defines which tool names are available in each phase (I4).
 type PhaseToolMap map[Phase][]string
 

--- a/pkg/remediationorchestrator/creator/notification.go
+++ b/pkg/remediationorchestrator/creator/notification.go
@@ -976,7 +976,11 @@ func (c *NotificationCreator) mapManualReviewPriority(ctx *ManualReviewContext) 
 	case "alignment_check_failed":
 		return notificationv1.NotificationPriorityCritical
 	// Workflow resolution failures
-	case "WorkflowNotFound", "ImageMismatch", "ParameterValidationFailed", "LLMParsingError":
+	// #2019: DecisionExpired means a concrete workflow was already discovered and
+	// presented -- unlike NoMatchingWorkflows (nothing found), a recommendation is
+	// sitting unanswered, so it is routed at the same priority as other concrete,
+	// actionable failures rather than the "no candidate" Medium tier.
+	case "WorkflowNotFound", "ImageMismatch", "ParameterValidationFailed", "LLMParsingError", "DecisionExpired":
 		return notificationv1.NotificationPriorityHigh
 	case "NoMatchingWorkflows", "LowConfidence", "InvestigationInconclusive":
 		return notificationv1.NotificationPriorityMedium

--- a/pkg/remediationorchestrator/notification_creator_test.go
+++ b/pkg/remediationorchestrator/notification_creator_test.go
@@ -708,6 +708,10 @@ var _ = Describe("NotificationCreator", func() {
 			Entry("AC-036-30: MaxRetriesExceeded → High", "MaxRetriesExceeded", notificationv1.NotificationPriorityHigh),
 			Entry("AC-036-31: TransientError → High", "TransientError", notificationv1.NotificationPriorityHigh),
 			Entry("AC-036-32: PermanentError → High", "PermanentError", notificationv1.NotificationPriorityHigh),
+			// #2019: A workflow was already discovered and presented -- unlike NoMatchingWorkflows
+			// (nothing found), a concrete recommendation is sitting unanswered. AC-6/CM-3: route as
+			// High so the pending decision isn't lost in a Medium-priority queue.
+			Entry("UT-RO-2019-001: DecisionExpired → High", "DecisionExpired", notificationv1.NotificationPriorityHigh),
 		)
 		})
 

--- a/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
+++ b/pkg/shared/assets/crds/kubernaut.ai_aianalyses.yaml
@@ -694,6 +694,10 @@ spec:
                   Reason why human review needed (when NeedsHumanReview=true)
                   BR-HAPI-197: Maps to KA's human_review_reason enum values
                   BR-AI-601: alignment_check_failed added for shadow agent alignment verdicts
+                  #2019: decision_expired added -- a workflow was found and presented via
+                  kubernaut_present_decision, but no response arrived before the interactive
+                  session's inactivity timeout. Distinguishes this from no_matching_workflows
+                  so the discovered SelectedWorkflow is preserved instead of discarded.
                 enum:
                 - workflow_not_found
                 - image_mismatch
@@ -705,6 +709,7 @@ spec:
                 - rca_incomplete
                 - alignment_check_failed
                 - operator_escalation
+                - decision_expired
                 type: string
               interactiveSession:
                 description: |-
@@ -1142,6 +1147,7 @@ spec:
                   SubReason provides specific failure cause within the Reason category
                   BR-HAPI-197: Maps to needs_human_review triggers from KA
                   BR-HAPI-200: Added InvestigationInconclusive, ProblemResolved for new investigation outcomes
+                  #2019: Added DecisionExpired for a presented-but-unanswered workflow decision
                 enum:
                 - WorkflowNotFound
                 - ImageMismatch
@@ -1160,6 +1166,7 @@ spec:
                 - RcaIncomplete
                 - InvestigationFailed
                 - OperatorEscalation
+                - DecisionExpired
                 type: string
               totalAnalysisTime:
                 description: TotalAnalysisTime is the total duration of the analysis

--- a/test/integration/aianalysis/decision_expired_status_test.go
+++ b/test/integration/aianalysis/decision_expired_status_test.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Issue #2019 / FedRAMP AU-2, AU-3, AC-6, CM-3: Proves decision_expired can be
+// persisted to the CRD status via the Kubernetes API server (envtest with real
+// CRD validation), and that the discovered-but-unconfirmed SelectedWorkflow is
+// preserved alongside it -- without ever setting ApprovalRequired/auto-executing
+// on the human's behalf.
+package aianalysis
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	aianalysisv1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+	sharedtypes "github.com/jordigilh/kubernaut/pkg/shared/types"
+	"github.com/jordigilh/kubernaut/test/shared/helpers"
+)
+
+var _ = Describe("Decision Expired Status Write (#2019)", Label("integration", "decision-expired"), func() {
+	const (
+		timeout  = 30 * time.Second
+		interval = 500 * time.Millisecond
+	)
+
+	Context("IT-AA-2019-001: decision_expired CRD status write preserves the discovered workflow (AU-2, AU-3, AC-6, CM-3)", func() {
+		var analysis *aianalysisv1.AIAnalysis
+
+		BeforeEach(func() {
+			rrName := helpers.UniqueTestName("test-decision-expired-rr")
+			analysis = &aianalysisv1.AIAnalysis{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      helpers.UniqueTestName("decision-expired-test"),
+					Namespace: testNamespace,
+				},
+				Spec: aianalysisv1.AIAnalysisSpec{
+					RemediationRequestRef: corev1.ObjectReference{
+						Name:      rrName,
+						Namespace: testNamespace,
+					},
+					RemediationID: rrName,
+					AnalysisRequest: aianalysisv1.AnalysisRequest{
+						SignalContext: aianalysisv1.SignalContextInput{
+							Fingerprint:      "test-fingerprint-decision-expired",
+							Severity:         "critical",
+							SignalName:       "KubePodCrashLooping",
+							Environment:      "production",
+							BusinessPriority: "P1",
+							TargetResource: aianalysisv1.TargetResource{
+								Kind:      "Deployment",
+								Name:      "worker",
+								Namespace: testNamespace,
+							},
+							EnrichmentResults: sharedtypes.EnrichmentResults{},
+						},
+						AnalysisTypes: []aianalysisv1.AnalysisType{aianalysisv1.AnalysisTypeInvestigation},
+					},
+				},
+			}
+		})
+
+		It("IT-AA-2019-001: persists humanReviewReason=decision_expired and the discovered SelectedWorkflow, without approval", func() {
+			defer func() {
+				_ = k8sClient.Delete(ctx, analysis)
+			}()
+
+			By("Creating AIAnalysis CRD")
+			Expect(k8sClient.Create(ctx, analysis)).To(Succeed())
+
+			By("Writing status with humanReviewReason=decision_expired and a preserved SelectedWorkflow")
+			Eventually(func() error {
+				if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), analysis); err != nil {
+					return err
+				}
+				now := metav1.Now()
+				analysis.Status.Phase = aianalysis.PhaseFailed
+				analysis.Status.NeedsHumanReview = true
+				analysis.Status.HumanReviewReason = katypes.HumanReviewReasonDecisionExpired
+				analysis.Status.Reason = aianalysisv1.ReasonWorkflowResolutionFailed
+				analysis.Status.SubReason = "DecisionExpired"
+				analysis.Status.CompletedAt = &now
+				// #2019: the discovered-but-unconfirmed workflow must be preserved
+				// for audit/retroactive human action -- but ApprovalRequired stays
+				// unset/false, since the human never actually confirmed it (AC-6/CM-3:
+				// no silent auto-approval of an action nobody signed off on).
+				analysis.Status.SelectedWorkflow = &aianalysisv1.SelectedWorkflow{
+					WorkflowID: "wf-recommended-2019",
+					Confidence: 0.9,
+					Rationale:  "restart the crashlooping pod",
+				}
+				return k8sClient.Status().Update(ctx, analysis)
+			}, timeout, interval).Should(Succeed(),
+				"AU-2/AU-3: API server must accept decision_expired in CRD status (proves the CRD/OpenAPI enum widening)")
+
+			By("Verifying the field persisted after re-read")
+			var persisted aianalysisv1.AIAnalysis
+			Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), &persisted)).To(Succeed())
+
+			Expect(persisted.Status.HumanReviewReason).To(Equal(katypes.HumanReviewReasonDecisionExpired),
+				"AU-2/AU-3: decision_expired must be persisted -- this is the #2019 audit-of-record fix")
+			Expect(persisted.Status.NeedsHumanReview).To(BeTrue(),
+				"AC-6/CM-3: NeedsHumanReview must stay true -- a presented-but-unanswered decision is never auto-approved")
+			Expect(string(persisted.Status.Phase)).To(Equal("Failed"),
+				"AU-2/AU-3: Phase=Failed must be persisted for audit trail")
+			Expect(persisted.Status.SubReason).To(Equal("DecisionExpired"),
+				"AU-2/AU-3: SubReason must be persisted for structured audit reporting/metrics")
+			Expect(persisted.Status.SelectedWorkflow).NotTo(BeNil(),
+				"AU-2/AU-3: the discovered workflow recommendation must survive -- this is the actual bug #2019 fixes "+
+					"(previously silently discarded as has_workflow:false)")
+			Expect(persisted.Status.SelectedWorkflow.WorkflowID).To(Equal("wf-recommended-2019"))
+			Expect(persisted.Status.ApprovalRequired).To(BeFalse(),
+				"AC-6/CM-3: a decision_expired outcome must never be marked as approved -- no execution without an explicit human decision")
+		})
+	})
+})

--- a/test/integration/kubernautagent/mcp/discovery_flow_test.go
+++ b/test/integration/kubernautagent/mcp/discovery_flow_test.go
@@ -69,6 +69,7 @@ type discoveryHTTPCompleter struct {
 	mu              sync.Mutex
 	completedID     string
 	completedResult *katypes.InvestigationResult
+	pendingResult   *katypes.InvestigationResult
 }
 
 func (c *discoveryHTTPCompleter) CompleteUserDriving(id string, result *katypes.InvestigationResult) error {
@@ -88,6 +89,12 @@ func (c *discoveryHTTPCompleter) ForceCompleteByRemediationID(_ string, result *
 	defer c.mu.Unlock()
 	c.completedResult = result
 	return nil
+}
+
+func (c *discoveryHTTPCompleter) PersistPendingDecisionResult(_ string, result *katypes.InvestigationResult) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.pendingResult = result
 }
 
 func (c *discoveryHTTPCompleter) getCompletedResult() *katypes.InvestigationResult {

--- a/test/integration/kubernautagent/mcp/golden_path_test.go
+++ b/test/integration/kubernautagent/mcp/golden_path_test.go
@@ -111,6 +111,8 @@ func (m *goldenPathAutoMgr) GetSessionLazySink(_ string) (*session.LazySink, boo
 	return nil, false
 }
 
+func (m *goldenPathAutoMgr) EmitSessionEndedByRR(_, _ string) {}
+
 // sessionIDForwardingAutoMgr tracks whether AF-provided SessionID was used for direct lookup.
 type sessionIDForwardingAutoMgr struct {
 	launchOK           bool
@@ -158,6 +160,8 @@ func (m *sessionIDForwardingAutoMgr) GetLatestRCAResultByRemediationID(_ string)
 func (m *sessionIDForwardingAutoMgr) GetSessionLazySink(_ string) (*session.LazySink, bool) {
 	return nil, false
 }
+
+func (m *sessionIDForwardingAutoMgr) EmitSessionEndedByRR(_, _ string) {}
 
 var _ = Describe("Golden Path Lifecycle — IT-KA-GOLDEN-001 BR-INTERACTIVE-001", func() {
 	var (

--- a/test/integration/kubernautagent/mcp/takeover_test.go
+++ b/test/integration/kubernautagent/mcp/takeover_test.go
@@ -129,6 +129,10 @@ func (m *mockAutoMgrIT) GetSessionLazySink(id string) (*session.LazySink, bool) 
 	return m.mgr.GetSessionLazySink(id)
 }
 
+func (m *mockAutoMgrIT) EmitSessionEndedByRR(rrID, reason string) {
+	m.mgr.EmitSessionEndedByRR(rrID, reason)
+}
+
 type mockWorkflowCatalogIT struct {
 	workflow *tools.CatalogWorkflow
 }


### PR DESCRIPTION
## Summary

Eight fixes, all surfaced during the same #1995 (`workflow_discovery` ~10-minute hang) live-diagnostics investigation and its dev-cluster validation, plus four independent v1.5 bugs found while triaging follow-up issues from that same investigation (two of them — #2018/#2019 — found by QE against this PR's own dev-cluster deployment). Bundled into one PR to minimize review/merge overhead.

### 1. #1995 diagnostic/hardening groundwork

- **`ServerConfig.DisableProfiling`** (default `true`) gates `/debug/pprof/*` on the internal health mux only, mirroring `kubernautagent`'s existing secure-by-default posture — enables capturing a live goroutine dump on the next occurrence without a redeploy. Never exposed on the external API router (`IT-AF-1995-006`).
- **`closeSessionBounded`**: `PoolSession.Close()` now runs in a background goroutine with a 5s bound. go-sdk@v1.7.0's DELETE-based session teardown can block indefinitely when the server-side session has an in-flight handler that never returns (confirmed via a time-boxed spike) — without this, one poisoned session wedges `EvictIdle`'s shared ticker (and, via the same helper, `DrainAll`/`Inject`/`InjectWithCleanup`) for every other `(rr_id, username)` pool entry forever (`IT-AF-1995-007`).
- **Timeout-fired logging**: `HandleDiscoverWorkflows`/`HandleSelectWorkflow`/`HandleCompleteNoAction` now log a warning when `PooledToolCallTimeout` fires, distinguishing "still legitimately in flight" from "AF already gave up and downgraded/errored the response" during live incident triage.
- **`HandleCompleteNoAction`** is now itself bounded by `PooledToolCallTimeout` (previously used the caller's raw `ctx` with no deadline).

This was built and deployed to the dev cluster (`quay.io/jordigilh/apifrontend:1995-pprof`) for QE's live repro runs against #1995, with pprof also enabled on `kubernaut-agent`. QE's RCA (https://github.com/jordigilh/kubernaut/issues/1995#issuecomment-5221146631) pinpointed the actual signal-loss site as AF's `WatchTerminalEvents` (`pkg/apifrontend/tools/ka_investigate_mcp.go`) blocking indefinitely waiting on a `session_ended` event from KA — see fix #3 below.

### 2. #1997: phaseGuardAfter short-circuits the AfterToolCallback chain

Discovered while tracing why "tool call completed"/timeout-fired logs never showed up during the #1995 dev-cluster diagnostics above.

- `phaseGuardAfter` re-returned the original `(resp, callErr)` from every exit path instead of `(nil, nil)`. ADK's `invokeAfterToolCallbacks` (`google.golang.org/adk`, `internal/llminternal/base_flow.go`) treats any non-nil result from a callback as an explicit override and stops the chain immediately — so `afterLog` (registered after `afterPhase` in `root.go`'s `AfterToolCallbacks: []llmagent.AfterToolCallback{afterMetrics, afterAudit, afterPhase, afterLog}`) never ran for **any** tool call, silently dropping the `"tool call completed"` audit line.
- `phaseGuardAfter` only ever records a side effect (session state, the active-context registry) — it never needs to modify `resp`/`callErr` — so `(nil, nil)` is the correct "pass through unchanged" signal, exactly matching how `afterAudit`/`afterMetrics` already behave in the same chain.
- **BR-AUDIT-005** (audit completeness) / **FedRAMP AU-3** (content of audit records), **AU-12** (audit generation).

### 3. #2003: KA doesn't release the interactive session on `no_matching_workflows` — this was the actual #1995 hang mechanism

QE's RCA on #1995, corroborated by independent live pprof/goroutine-dump capture and KA/AF log correlation against this PR's dev deployment, converged on the real root cause: `discover_workflows` never acted on a terminal `HumanReviewReason: "no_matching_workflows"` result. The interactive session lingered until KA's blunt 10-minute inactivity timeout eventually tore it down — the *only* thing that ever emitted the `session_ended` terminal event AF's `WatchTerminalEvents` blocks on (no timer-based safety net, #1438).

- `handleDiscoverWorkflows` now mirrors `select_workflow.go`'s existing auto-close pattern (deferred goroutine, mutex re-acquired to avoid a TOCTOU race), but additionally emits `EmitSessionEndedByRR` **before** completing/releasing — matching the `#1438` ordering precedent from `cmd/kubernautagent/main.go`'s timeout/disconnect handlers. This ordering is required here specifically because, unlike a successful workflow selection, no CRD-phase watch ever takes over to drive the console phase forward for "no match".
- Verified via code trace (not assumed) that `HumanReviewReason == "no_matching_workflows"` is only ever set on paths that leave `WorkflowID`/`AlternativeWorkflows` empty — so unconditionally closing on this specific reason never cuts off a legitimate "browse the alternatives" flow.
- Widened `AutonomousSessionManager` with `EmitSessionEndedByRR` (already implemented by production `*session.Manager`), updating 10 test-mock implementations across `internal/kubernautagent` and `test/integration/kubernautagent`.
- **BR-INTERACTIVE-001**, **AU-3/AU-12** (audit/session-lifecycle traces reflect the actual investigation-conclusion moment, not an unrelated timer).

Full writeup: #2003.

### 4. #2010: reasoning_delta self-duplicates identical Reasoning.Text and Content in the Console ThinkingPanel

Found live in this PR's dev environment while validating the fixes above: the Console's ThinkingPanel showed the same sentence twice (e.g. "Let me now gather the pod logs and events for complete evidence." appearing back-to-back, separated by a blank line).

- Root cause: Claude's extended-thinking + tool-use behavior frequently ends the private thinking block with a short one-line plan, then repeats that identical line as the visible `Content` right before the `tool_use` block. `reasoningDeltaText` concatenated `Reasoning.Text` and `Content` unconditionally, so a single `reasoning_delta` event carried the literal text `"X\n\nX"`.
- Fix: when `Content` and `Reasoning.Text` match after trimming whitespace, only `Reasoning.Text` is surfaced. No information is lost (they're identical modulo whitespace); genuinely distinct reasoning/content pairs are unaffected — this is `release/v1.5`'s own `reasoningDeltaText` helper (#1935), architecturally distinct from `main`'s dual-event `EventTypeReasoningDelta`/`EventTypeReasoningContentDelta` split (#2006), so the fix is local to this one function.
- **BR-AI-086**, **FedRAMP CC7.2** (decision audit trails visible to the operator) / **SI-10** (input validation before display).

Full writeup: #2010.

### 5. #2011: RemediationOrchestrator discards a valid, AutoApproved AIAnalysis result on a same-reconcile timeout-extension race

Found while triaging whether v1.5 had #2011's upstream bug. `checkPhaseTimeouts` recomputes the `DD-INTERACTIVE-002` interactive-session timeout extension fresh on every reconcile. The instant `AIAnalysis` reaches a terminal phase (`Completed`/`Failed`), `InteractiveSession.CompletedAt` is set in that same tick, which revokes the 45m extension and lets the already-elapsed 10m base timeout fire — **before** `AnalyzingHandler.Handle` (which would correctly finalize the result) ever runs in that reconcile. A validated, policy-evaluated `AutoApproved` remediation decision is silently discarded into `TimedOut`.

- `applyInteractiveTimeoutExtension` now also reports whether `AIAnalysis` has already reached a terminal phase; `checkPhaseTimeouts` skips the timeout comparison entirely in that case, letting the *same reconcile* fall through to the `Analyzing` phase handler instead of racing it into `TimedOut`.
- Reproduced with a deterministic fake-client unit test (not envtest/timing-based — no flakiness risk) before applying the fix; the existing 9-test `interactive_timeout_test.go` suite (including `UT-RO-703-003`, a legitimately-stuck scenario left intentionally unaffected) and the full 369-spec `remediationorchestrator` package suite remain green.
- **BR-ORCH-028** (per-phase timeouts) / **DD-INTERACTIVE-002** (dynamic extension), **FedRAMP IR-4** (an incident's remediation decision must survive to the point of use) / **SI-4** (phase-timeout logic must not misclassify a completed analysis as timed out).

Full writeup: #2011.

### 6. #2017: KA's MCP server silently discards go-sdk-internal log/error events

Found while triaging the diagnosability gaps that slowed #1949's/#1995's triage. `NewMCPServer` never set go-sdk's `ServerOptions.Logger`, so `ensureLogger(nil)` defaults to a discard `*slog.Logger` (`go-sdk@v1.7.0/mcp/logging.go:104`), silently dropping `OnInternalError` and all other SDK-internal log paths from KA's log stream.

- Added a variadic `MCPServerOption`/`WithMCPLogger` to `NewMCPServer` and a `Logger logr.Logger` field to `MCPDeps`; `cmd/kubernautagent/main.go`'s existing `BootstrapMCP` call site now passes `logger.WithName("mcp-sdk")`. Zero-value `logr.Logger` remains a safe no-op per go-logr's `sink == nil` guards, so none of the 5 existing `NewMCPServer(0)` call sites in `server_test.go` are affected.
- Honest scope note: the issue's second acceptance criterion (a forced internal-error condition mirroring go-sdk's own `TestProcessResultWriteFailureReportsInternalError`) can't be fully replicated yet — that upstream test ships with the not-yet-merged `go-sdk#1153`. This PR proves the wiring contract itself (`WithMCPLogger` correctly forwards to the underlying `logr.Logger` sink), which is the fully verifiable and in-scope part today.
- **AU-2/AU-3** (Audit Events / Content of Audit Records), **SI-4** (System Monitoring). No existing numbered BR covers this observability enhancement (confirmed absent from `docs/requirements/`); framed against the general FedRAMP controls per the issue's own text.

Full writeup: #2017.

### 7. #2018: cluster-scoped alert wins over a merely-pending target-specific alert, misattributing the RCA

Found by QE against this PR's dev-cluster deployment: a `KubePodCrashLooping` alert on the actual failing workload was investigated as an unrelated, continuously-firing cluster-scoped alert (`CDIDefaultStorageClassDegraded`) instead. `af_investigate_alert.go`/`validateAlertExists` were ruled out by code trace; the real mechanism is `severity.Triager`'s multi-tier correlation.

- `runTier1` ran two separate passes — firing alerts across all three specificity tiers (resource, namespace, cluster), *then* pending alerts across the same three tiers — so a firing cluster-scoped alert always won the first pass even when a resource- or namespace-scoped alert for the actual target was merely pending (e.g. hadn't crossed Prometheus's `for:` duration yet) at correlation time.
- Replaced the two-pass `bestAlertMatch` calls with a single-pass `bestOverallMatch` that ranks specificity (resource > namespace > cluster) strictly ahead of alert state (firing > pending) — matching `SourceClusterFiringAlert`'s documented intent as a last-resort fallback, not a tier that pre-empts more specific matches.
- Confirmed via live dev-cluster logs and audit traces (not assumed) before fixing — QE's claim that CRDs were garbage-collected was refuted by direct cluster inspection; the actual cause was purely this correlation-ordering bug.
- **BR-AI-XXX** (signal-to-target correlation accuracy); **FedRAMP SI-4** (correct event correlation for system monitoring).

Full writeup: #2018.

### 8. #2019: KA silently discards a discovered-and-presented workflow recommendation on decision timeout

Also found by QE against this PR's dev-cluster deployment. When `kubernaut_discover_workflows` finds a workflow and `kubernaut_present_decision` delivers it to the user, but no response arrives before KA's 10-minute interactive-session inactivity timeout, KA finalized the session with a `nil` result — producing `has_workflow: false` and discarding the real recommendation as a false negative, indistinguishable from a genuine "nothing found" outcome.

- Added `Store.SetPendingDecisionResult`/`Manager.PersistPendingDecisionResult` to preserve the discovered-but-unconfirmed result on the session the moment it's presented; the inactivity-timeout path's existing `CompleteUserDriving(nil)` now composes with this (its `if result != nil` guard already skips overwriting a result that's already set), so the preserved recommendation survives instead of being clobbered.
- Added a new `decision_expired` `HumanReviewReason` (distinct from `no_matching_workflows`) threaded end-to-end through the full contract: KA OpenAPI spec + `agentclient` codegen, DataStorage OpenAPI spec + `ogen-client` codegen (incl. embedded spec copies), the `AIAnalysis` CRD's `status.humanReviewReason`/`status.subReason` kubebuilder enums, KA's `mapHumanReviewReason`/`validHumanReviewReasons` audit whitelist, AA's `mapEnumToSubReason`, and RO's `mapManualReviewPriority` (routed `High` — a concrete recommendation is waiting, unlike the `Medium` "nothing found" tier).
- `IT-AA-2019-001` proves the new enum value round-trips through a real (envtest) Kubernetes API server without a CRD-validation rejection, mirroring the established `IT-AA-1449-001` pattern for this exact class of bug (a CRD enum/OpenAPI drift silently breaking `Status().Update()`).
- **BR-HAPI-197**, **BR-ORCH-036**; **FedRAMP AU-2/AU-3** (the audit-of-record must reflect that a decision was presented and timed out, not that nothing was found), **AC-6/CM-3** (a presented-but-unanswered decision must never be treated as, or imply, approval).

Full writeup: #2019.

## Tests (pyramid invariant)

- `UT-AF-1995-001..007`, `IT-AF-1995-006`, `IT-AF-1995-007` (#1995 side)
- `UT-AF-1997-001..008` (RED, `phase_guard_aftercallback_1997_test.go`) + `IT-AF-1997-009` (`phase_guard_afterlog_wiring_1997_test.go`, real `llmagent` + `runner.Run` dispatch path) — #1997 side
- `UT-KA-2003-001/002` + `IT-KA-2003-001` (`discover_workflows_no_match_2003_test.go`, `discover_workflows_no_match_2003_it_test.go`) — #2003 side. The IT drives the real `InvestigateTool.Handle` dispatch path wired to a real `session.Manager` (not a mock) and asserts `session_ended` propagates through the real `EventLogBridge` promptly, proving the fix resolves the actual hang mechanism rather than just satisfying a mock.
- `UT-KA-2010-001` (3 cases: identical text, whitespace-only diff, genuinely different — no false-positive suppression) + `IT-KA-2010-002` (real `Investigator.Investigate` dispatch through the full KA/AF wire contract: KA event → JSON marshal → AF's `ka.InvestigationEvent` → production `FormatEventForUser`, mirroring the existing `IT-KA-1771-001` pattern) — #2010 side.
- `UT-RO-2011-001`/`002` (`interactive_timeout_test.go`, Completed and Failed terminal-phase races) — #2011 side. No new production entry point (modifies logic inside `Reconciler.Reconcile()`'s already-wired `checkPhaseTimeouts`), so per the Pyramid Invariant the existing UT-tier suite already exercises the literal production entry point; regression-verified against the full 369-spec package suite.
- `UT-KA-2017-001`/`002` (`server_test.go`, logger forwarding + zero-value safety) — #2017 side. No new production entry point (`BootstrapMCP`'s existing call site now supplies a real logger instead of an implicit zero value); regression-verified against the full `internal/kubernautagent/mcp/...` suite.
- `UT-AF-2018-001..003` (`triage_test.go`) — #2018 side: pending resource-specific/namespace-scoped alerts must win over a firing cluster-scoped alert; firing cluster-scoped still wins when nothing more specific exists (regression guard).
- `UT-KA-2019-001..010` across `store_test.go`, `discover_workflows_no_match_2003_test.go`, `response_mapper_test.go`, `coverage_668_test.go` — #2019 KA-side: pending-result preservation semantics, `handleDiscoverWorkflows` wiring (and mutual exclusivity with the `no_matching_workflows` auto-close path), `mapHumanReviewReason` enum coverage, and the DataStorage audit whitelist.
- `UT-AA-2019-006..009` (`response_processor_decision_expired_test.go`) + `IT-AA-2019-001` (`decision_expired_status_test.go`, envtest apiserver CRD acceptance) — #2019 AA-side: `HumanReviewReason`/`SubReason` persistence, `SelectedWorkflow` preservation (the actual bug), `ApprovalRequired` never implied, and the CRD schema round-trip proof.
- `UT-RO-2019-001` (`notification_creator_test.go`) — #2019 RO-side: `DecisionExpired` routes to `High` priority, not the default `Medium`.

All confirmed RED before their respective fix and GREEN after.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./pkg/apifrontend/... ./cmd/apifrontend/... ./internal/kubernautagent/... ./pkg/aianalysis/... ./pkg/remediationorchestrator/... ./pkg/apifrontend/severity/... ./internal/controller/remediationorchestrator/... ./test/integration/kubernautagent/...` (unit suites — envtest/podman-dependent integration suites unaffected, pre-existing local env gaps unrelated to this change) — full suite green, zero regressions
- [x] `make lint-openapi-crd-drift` — no new drift introduced by `decision_expired` (one pre-existing, unrelated `operator_escalation` gap from #1449 noted separately, out of scope here)
- [x] `golangci-lint run` on all changed packages — 0 issues
- [ ] `IT-AA-2019-001` (envtest apiserver, `test/integration/aianalysis`) — compiles clean and follows the proven `IT-AA-1449-001` pattern exactly; blocked from a local run by this dev machine's Podman VM being unstable (crashes on start, unrelated to this change) — will confirm green from CI

## Related

- Fixes groundwork + root cause for #1995 (primary v1.5 issue)
- Fixes #1997 (phaseGuardAfter audit-log gap, v1.5)
- Fixes #2003 (KA session auto-close on no_matching_workflows, v1.5)
- Fixes #2010 (reasoningDeltaText self-duplication, v1.5; architecturally distinct sibling of #2006 on `main`)
- Fixes #2011 (RemediationOrchestrator timeout-extension race, v1.5)
- Fixes #2017 (KA MCP server logger wiring, v1.5)
- Fixes #2018 (cluster-scoped alert mis-correlation, v1.5; found by QE against this PR's dev deployment)
- Fixes #2019 (KA finalization gap on decision timeout, v1.5; found by QE against this PR's dev deployment)
- Will be ported to `main` for #1996/#1998/#2013/#2006 (v1.6 clones) — see PR #2001. #2011/#2017's `main` companions (#2012/#2016) and #2018/#2019's `main` companions (#2021/#2020) are deferred follow-ups once this is validated in dev, consistent with the rest of this PR's port sequencing.

Made with [Cursor](https://cursor.com)

