### PR TITLE
fix(apifrontend): stop phaseGuardAfter short-circuiting the AfterToolCallback chain

### DIFF
--- a/pkg/apifrontend/agent/phase_guard.go
+++ b/pkg/apifrontend/agent/phase_guard.go
@@ -160,11 +160,22 @@ func newPhaseGuard(registry *launcher.ActiveContextRegistry) (llmagent.BeforeToo
 			}
 		}
 
+		// #1997: phaseGuardAfter only ever records a side effect (session
+		// state, ActiveContextRegistry) -- it never modifies resp/callErr.
+		// Every exit path below returns (nil, nil), the ADK AfterToolCallback
+		// convention for "pass through unchanged" (google.golang.org/adk,
+		// internal/llminternal/base_flow.go: invokeAfterToolCallbacks treats
+		// a non-nil result as an explicit override that stops the chain,
+		// falling back to the original fResult/fErr only once every
+		// callback has returned nil). Re-returning the original resp/callErr
+		// here looked harmless but silently skipped every AfterToolCallback
+		// registered after this one (afterLog) for any tool call at all,
+		// not just the ones this guard cares about.
 		if !isEntry && !isTerminal && !isDiscoverWorkflows {
-			return resp, callErr
+			return nil, nil
 		}
 		if !isSuccess {
-			return resp, callErr
+			return nil, nil
 		}
 
 		logger := logr.FromContextOrDiscard(ctx)
@@ -178,7 +189,7 @@ func newPhaseGuard(registry *launcher.ActiveContextRegistry) (llmagent.BeforeToo
 					logger.Error(err, "phase-guard failed to persist phase3_blocked state")
 				}
 			}
-			return resp, callErr
+			return nil, nil
 		}
 
 		if isEntry {
@@ -275,7 +286,7 @@ func newPhaseGuard(registry *launcher.ActiveContextRegistry) (llmagent.BeforeToo
 			}
 		}
 
-		return resp, callErr
+		return nil, nil
 	}
 
 	return before, after

--- a/pkg/apifrontend/agent/phase_guard_aftercallback_1997_test.go
+++ b/pkg/apifrontend/agent/phase_guard_aftercallback_1997_test.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"google.golang.org/adk/tool"
+
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
+)
+
+// phaseGuardAfter AfterToolCallback contract (#1997).
+//
+// ADK's invokeAfterToolCallbacks (google.golang.org/adk, internal/llminternal/
+// base_flow.go) treats a non-nil result returned by ANY AfterToolCallback as
+// an explicit override that stops the chain immediately -- every later
+// callback (afterLog in root.go's registration order: afterMetrics,
+// afterAudit, afterPhase, afterLog) never runs. A callback that only wants
+// to observe/record a side effect (as phaseGuardAfter does -- it never
+// modifies resp) MUST return (nil, nil) to signal "pass through unchanged",
+// exactly as afterAudit/afterMetrics already do correctly in the same file.
+//
+// phaseGuardAfter instead re-returns (resp, callErr) from every exit path,
+// which -- since resp is non-nil for any tool call that produced a
+// structured result -- unconditionally short-circuits the chain and skips
+// afterLog for every tool call, not just the driver-entry/terminal/
+// discover_workflows tools phaseGuardAfter cares about.
+//
+// Business requirement: BR-AUDIT-005 (audit completeness) / FedRAMP AU-3
+// (content of audit records) and AU-12 (audit generation), as implemented
+// by afterLog's "tool call completed" line (root.go, TP-1310 §4.3). This
+// suite proves the logic that was silently dropping that audit signal;
+// IT-AF-1997-009 (phase_guard_afterlog_wiring_1997_test.go) proves the fix
+// closes the gap end-to-end through the real production dispatch path.
+var _ = Describe("phaseGuardAfter AfterToolCallback contract (#1997)", func() {
+	var (
+		state   *mapState
+		toolCtx tool.Context
+		after   func(tool.Context, tool.Tool, map[string]any, map[string]any, error) (map[string]any, error)
+	)
+
+	BeforeEach(func() {
+		state = newMapState()
+		ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+			Username: "alice", Groups: []string{"sre"},
+		})
+		toolCtx = statefulToolContext{
+			fakeToolContext: fakeToolContext{Context: ctx},
+			state:           state,
+		}
+		_, after = NewPhaseGuardForTest()
+	})
+
+	DescribeTable("must return (nil, nil) on success so later AfterToolCallbacks (afterLog) still run",
+		func(toolName string, resp map[string]any) {
+			result, err := after(toolCtx, fakeTool{name: toolName}, nil, resp, nil)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).To(BeNil(),
+				"%s: phaseGuardAfter must return (nil, nil) on success -- returning the original resp short-circuits ADK's AfterToolCallback chain and silently drops afterLog", toolName)
+		},
+		Entry("UT-AF-1997-001: kubernaut_discover_workflows (phase3 checkpoint path)", "kubernaut_discover_workflows", map[string]any{"workflows": []any{}}),
+		Entry("UT-AF-1997-002: kubernaut_investigate (driver-entry path)", "kubernaut_investigate", map[string]any{"session_id": "sess-1997", "status": "active"}),
+		Entry("UT-AF-1997-003: kubernaut_reconnect (driver-entry path)", "kubernaut_reconnect", map[string]any{"session_id": "sess-1997b", "status": "active"}),
+		Entry("UT-AF-1997-004: kubernaut_complete (session-terminal path)", "kubernaut_complete", map[string]any{"status": "completed"}),
+		Entry("UT-AF-1997-005: kubernaut_cancel (session-terminal path)", "kubernaut_cancel", map[string]any{"status": "cancelled"}),
+		Entry("UT-AF-1997-006: kubernaut_complete_no_action (unmatched-tool fallthrough)", "kubernaut_complete_no_action", map[string]any{"status": "no_action"}),
+		Entry("UT-AF-1997-007: kubernaut_message (unmatched-tool fallthrough, unrelated tool)", "kubernaut_message", map[string]any{"reply": "hi"}),
+	)
+
+	It("UT-AF-1997-008: also returns (nil, nil) on a failed call, instead of re-surfacing callErr itself (no functional regression: ADK falls back to the original fErr when every callback passes through)", func() {
+		result, err := after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, nil, fmt.Errorf("boom"))
+		Expect(result).To(BeNil())
+		Expect(err).NotTo(HaveOccurred(),
+			"phaseGuardAfter must pass through (nil, nil) on failure too, so later AfterToolCallbacks still observe the failed call instead of the chain terminating early on phaseGuardAfter's own re-returned error")
+	})
+})

--- a/pkg/apifrontend/agent/phase_guard_afterlog_wiring_1997_test.go
+++ b/pkg/apifrontend/agent/phase_guard_afterlog_wiring_1997_test.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package agent_test
+
+import (
+	"context"
+	"iter"
+	"sync"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"google.golang.org/adk/agent"
+	"google.golang.org/adk/agent/llmagent"
+	"google.golang.org/adk/model"
+	"google.golang.org/adk/runner"
+	"google.golang.org/adk/session"
+	"google.golang.org/adk/tool"
+	"google.golang.org/adk/tool/functiontool"
+	"google.golang.org/genai"
+
+	agentpkg "github.com/jordigilh/kubernaut/pkg/apifrontend/agent"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
+)
+
+// wiringLogSink is a minimal logr.LogSink that records Info() messages, used
+// to prove afterLog actually executes (AU-3/AU-12 audit-trail completeness)
+// when driven through the real production dispatch path.
+type wiringLogSink struct {
+	mu       sync.Mutex
+	messages []string
+}
+
+func (s *wiringLogSink) Init(logr.RuntimeInfo)                  {}
+func (s *wiringLogSink) Enabled(int) bool                       { return true }
+func (s *wiringLogSink) WithValues(...interface{}) logr.LogSink { return s }
+func (s *wiringLogSink) WithName(string) logr.LogSink           { return s }
+func (s *wiringLogSink) Error(error, string, ...interface{})    {}
+func (s *wiringLogSink) Info(_ int, msg string, _ ...interface{}) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.messages = append(s.messages, msg)
+}
+
+func (s *wiringLogSink) contains(msg string) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, m := range s.messages {
+		if m == msg {
+			return true
+		}
+	}
+	return false
+}
+
+// #1997 wiring proof: root.go's NewRootAgent registers
+// AfterToolCallbacks: []llmagent.AfterToolCallback{afterMetrics, afterAudit,
+// afterPhase, afterLog}. This IT test reproduces that exact relative
+// ordering (afterPhase before afterLog) through the real ADK dispatch path
+// (llmagent + runner.Run, not a direct in-process call to `after`), and
+// proves afterLog's "tool call completed" line -- the FedRAMP AU-3/AU-12
+// audit-completeness signal BR-AUDIT-005 requires -- now actually reaches
+// the log for a driver-entry tool call, closing the gap a UT calling
+// phaseGuardAfter in isolation cannot observe.
+var _ = Describe("phaseGuardAfter + afterLog production wiring (#1997, BR-AUDIT-005 AU-3/AU-12)", func() {
+	It("IT-AF-1997-009: afterLog's \"tool call completed\" fires for kubernaut_investigate via runner.Run, in root.go's real AfterToolCallbacks order", func() {
+		type investigateArgs struct {
+			RRID string `json:"rr_id,omitempty"`
+		}
+		type investigateResult struct {
+			SessionID string `json:"session_id"`
+			Status    string `json:"status"`
+		}
+
+		investigateTool, err := functiontool.New(functiontool.Config{
+			Name:        "kubernaut_investigate",
+			Description: "Start an interactive investigation (driver-entry tool)",
+		}, func(_ tool.Context, _ investigateArgs) (investigateResult, error) {
+			return investigateResult{SessionID: "sess-1997-wiring", Status: "active"}, nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		var callCount int
+		genFn := func(_ context.Context, _ *model.LLMRequest, _ bool) iter.Seq2[*model.LLMResponse, error] {
+			return func(yield func(*model.LLMResponse, error) bool) {
+				callCount++
+				if callCount == 1 {
+					yield(&model.LLMResponse{
+						Content: &genai.Content{
+							Role: "model",
+							Parts: []*genai.Part{{FunctionCall: &genai.FunctionCall{
+								ID:   "call-1997-1",
+								Name: "kubernaut_investigate",
+								Args: map[string]any{},
+							}}},
+						},
+					}, nil)
+					return
+				}
+				yield(&model.LLMResponse{
+					Content: &genai.Content{
+						Role:  "model",
+						Parts: []*genai.Part{{Text: "Done."}},
+					},
+				}, nil)
+			}
+		}
+		adapter := &llmAdapter{genFn: genFn}
+
+		// Registration order mirrors root.go's NewRootAgent exactly for the
+		// two callbacks under test: afterPhase runs before afterLog.
+		_, afterPhase := agentpkg.NewPhaseGuardForTest()
+		_, afterLog := agentpkg.NewToolLoggingCallbacksForTest()
+
+		a, err := llmagent.New(llmagent.Config{
+			Name:               "phase-guard-afterlog-wiring-it-agent",
+			Description:        "IT agent proving afterPhase does not short-circuit afterLog (#1997)",
+			Model:              adapter,
+			Tools:              []tool.Tool{investigateTool},
+			Instruction:        "You are a test agent. Call kubernaut_investigate when asked.",
+			AfterToolCallbacks: []llmagent.AfterToolCallback{afterPhase, afterLog},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		r, err := runner.New(runner.Config{
+			AppName:           "phase-guard-afterlog-wiring-it",
+			Agent:             a,
+			SessionService:    session.InMemoryService(),
+			AutoCreateSession: true,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		sink := &wiringLogSink{}
+		logger := logr.New(sink)
+		ctx := logr.NewContext(context.Background(), logger)
+		ctx = auth.WithUserIdentity(ctx, &auth.UserIdentity{
+			Username: "sre@example.com", Groups: []string{"sre"},
+		})
+
+		msg := &genai.Content{
+			Role:  "user",
+			Parts: []*genai.Part{{Text: "start an investigation"}},
+		}
+		for event, runErr := range r.Run(ctx, "test-user", "sess-1997-wiring", msg, agent.RunConfig{}) {
+			Expect(runErr).NotTo(HaveOccurred())
+			_ = event
+		}
+
+		Expect(sink.contains("tool call completed")).To(BeTrue(),
+			"IT-AF-1997-009 BR-AUDIT-005/AU-3/AU-12: afterLog's \"tool call completed\" audit log must fire for kubernaut_investigate through the real production AfterToolCallbacks chain -- afterPhase must not short-circuit it")
+	})
+})


### PR DESCRIPTION
## Summary

- `phaseGuardAfter` re-returned the original `(resp, callErr)` from every exit path instead of `(nil, nil)`. ADK's `invokeAfterToolCallbacks` (`google.golang.org/adk`, `internal/llminternal/base_flow.go`) treats any non-nil result from a callback as an explicit override and stops the chain immediately — so `afterLog` (registered after `afterPhase` in `root.go`'s `AfterToolCallbacks: []llmagent.AfterToolCallback{afterMetrics, afterAudit, afterPhase, afterLog}`) never ran for **any** tool call, silently dropping the `"tool call completed"` audit line.
- This explains the missing completion/timeout-fired logs observed while diagnosing #1995: the tool calls *were* completing, but the audit-trail signal proving it was silently discarded.
- `phaseGuardAfter` only ever records a side effect (session state, the active-context registry) — it never needs to modify `resp`/`callErr` — so `(nil, nil)` is the correct "pass through unchanged" signal, exactly matching how `afterAudit`/`afterMetrics` already behave in the same chain.

## Business requirement / compliance mapping

- **BR-AUDIT-005** (audit completeness) / **FedRAMP AU-3** (content of audit records), **AU-12** (audit generation) — implemented by `afterLog`'s `"tool call completed"` line (`root.go`, TP-1310 §4.3), which this bug was silently dropping for every tool call.

## Tests (pyramid invariant)

- **UT-AF-1997-001..008** (`phase_guard_aftercallback_1997_test.go`, RED): prove `phaseGuardAfter` must return `(nil, nil)` on both success and failure across every phase-guard path (discover_workflows checkpoint, driver-entry, session-terminal, unmatched-tool fallthrough).
- **IT-AF-1997-009** (`phase_guard_afterlog_wiring_1997_test.go`): proves the fix end-to-end through the **real** `llmagent` + `runner.Run` dispatch path, using `root.go`'s actual `AfterToolCallbacks` registration order (`afterPhase` then `afterLog`) — closing the wiring gap that a direct unit call to `phaseGuardAfter` alone cannot observe. Verified this IT test (and all 8 UT cases) fail against the pre-fix code and pass after the fix.

Ref #1997

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/apifrontend/...` (full package suite, zero regressions)
- [x] `go test ./cmd/apifrontend/...`
- [x] `golangci-lint run --timeout=5m ./pkg/apifrontend/agent/...` → 0 issues
- [x] Confirmed RED: reverted the fix locally and re-ran the suite — all 8 UT cases + IT-AF-1997-009 fail as expected
- [x] Confirmed GREEN: re-applied the fix — full suite passes

Made with [Cursor](https://cursor.com)