### PR TITLE
fix(chart): verify console oauth2-proxy's OIDC issuer TLS cert

### DIFF
--- a/charts/kubernaut/templates/console/console.yaml
+++ b/charts/kubernaut/templates/console/console.yaml
@@ -148,7 +148,17 @@ spec:
             - --scope=openid email profile
             - --skip-jwt-bearer-tokens=true
             - --cookie-refresh=25m
-            - --ssl-insecure-skip-verify=true
+            {{- /*
+            Issue #1988: verify the OIDC issuer's TLS cert instead of skipping
+            verification outright. --provider-ca-file alone would replace Go's
+            default trust store, breaking issuers with a publicly-trusted cert,
+            so --use-system-trust-store=true keeps that path working while also
+            trusting the chart's own inter-service CA (kubernaut.tlsCaVolume/
+            VolumeMount below) for genuinely self-signed/dev-only issuers --
+            same pattern already fixed for FMC's OAuth2 client in #1755.
+            */}}
+            - --provider-ca-file={{ include "kubernaut.interServiceTLS.caFile" . }}
+            - --use-system-trust-store=true
             - --ping-path=/oauth2/ping
           env:
             - name: OAUTH2_PROXY_CLIENT_ID
@@ -191,6 +201,8 @@ spec:
             limits:
               cpu: 100m
               memory: 128Mi
+          volumeMounts:
+            {{- include "kubernaut.tlsCaVolumeMount" . | nindent 12 }}
         - name: console
           image: {{ include "kubernaut.image" (dict "service" "kubernaut-console" "root" $ "appVersion" .Chart.AppVersion) }}
           imagePullPolicy: {{ include "kubernaut.imagePullPolicy" $ }}

--- a/charts/kubernaut/tests/console_oauth2proxy_tls_test.yaml
+++ b/charts/kubernaut/tests/console_oauth2proxy_tls_test.yaml
@@ -1,0 +1,101 @@
+suite: "Issue #1988: console oauth2-proxy sidecar must verify the OIDC issuer's TLS certificate, not skip verification"
+templates:
+  - templates/console/console.yaml
+set:
+  postgresql:
+    auth:
+      existingSecret: dummy
+  valkey:
+    existingSecret: dummy
+  global:
+    llmProfiles:
+      primary:
+        provider: openai
+        model: gpt-4
+        credentialsSecretName: llm-credentials-primary
+  kubernautAgent:
+    llmProfileRef: primary
+  signalprocessing:
+    policies:
+      existingConfigMap: test-cm
+  aianalysis:
+    policies:
+      existingConfigMap: test-cm
+  console:
+    enabled: true
+    auth:
+      secretName: console-auth
+    ingress:
+      host: console.apps.example.com
+  apifrontend:
+    config:
+      auth:
+        issuerURL: https://sso.example.com/realms/kubernaut
+tests:
+  - it: "IT-HELM-1988-001: oauth2-proxy args do NOT include --ssl-insecure-skip-verify (regression guard -- SC-8)"
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: "--ssl-insecure-skip-verify=true"
+
+  - it: "IT-HELM-1988-002: oauth2-proxy trusts the shared inter-service CA via --provider-ca-file, defaulting to tls.interService.caFile (/etc/tls-ca/ca.crt)"
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--provider-ca-file=/etc/tls-ca/ca.crt"
+
+  - it: "IT-HELM-1988-003: oauth2-proxy also keeps the system trust store enabled, so genuinely externally-trusted OIDC issuers (public CA) still verify without needing the inter-service CA"
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--use-system-trust-store=true"
+
+  - it: "IT-HELM-1988-004: --provider-ca-file follows a tls.interService.caFile override, same as every other consumer of kubernaut.interServiceTLS.caFile"
+    set:
+      tls:
+        interService:
+          caFile: /custom/tls-ca/bundle.crt
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--provider-ca-file=/custom/tls-ca/bundle.crt"
+
+  - it: "IT-HELM-1988-005: oauth2-proxy container mounts the tls-ca volume at /etc/tls-ca so --provider-ca-file's default path actually exists in the container"
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            name: tls-ca
+            mountPath: /etc/tls-ca
+            readOnly: true
+
+  - it: "IT-HELM-1988-006: the pod still only mounts one tls-ca volume (shared between the oauth2-proxy and console containers, not duplicated)"
+    documentSelector:
+      path: kind
+      value: Deployment
+    asserts:
+      - contains:
+          path: spec.template.spec.volumes
+          content:
+            name: tls-ca
+            configMap:
+              name: inter-service-ca
+              optional: true
+      - lengthEqual:
+          path: spec.template.spec.volumes
+          count: 3


### PR DESCRIPTION
## Summary

- Fixes #1988: the console's `oauth2-proxy` sidecar hardcoded `--ssl-insecure-skip-verify=true` with no opt-out, disabling TLS certificate verification against the OIDC issuer for every chart-based install.
- Replaces it with `--provider-ca-file={{ include "kubernaut.interServiceTLS.caFile" . }}` (defaults to `/etc/tls-ca/ca.crt`, the chart's existing mandatory inter-service CA) plus `--use-system-trust-store=true`, so:
  - genuinely externally-trusted OIDC issuers (public CA) keep verifying via the system trust store, and
  - self-signed/dev-only issuers signed by the chart's own inter-service CA also verify correctly,
  - with TLS verification never skipped outright.
- Mounts the existing `kubernaut.tlsCaVolumeMount` (`/etc/tls-ca`) onto the `oauth2-proxy` container — it already existed on the `console` container for `proxy_ssl_trusted_certificate`, and the pod-level `kubernaut.tlsCaVolume` was already shared, so no new volume was introduced.
- No values.yaml/schema changes needed — reuses plumbing already established for the identical CA-trust problem fixed for FleetMetadataCache's OAuth2 client in #1755.
- Same bug, same origin as jordigilh/kubernaut-operator#309 (this chart's console template was ported from `internal/resources/console.go`); tracked/fixed separately there.

## Test plan

- [x] Added `charts/kubernaut/tests/console_oauth2proxy_tls_test.yaml` (helm-unittest, IT-HELM-1988-001..006): asserts `--ssl-insecure-skip-verify` is absent, `--provider-ca-file`/`--use-system-trust-store=true` are present and follow a `tls.interService.caFile` override, and the `tls-ca` volume/volumeMount are wired without duplication.
- [x] `helm unittest charts/kubernaut/` — full suite: 55/55 suites, 507/507 tests passing (zero regressions).
- [x] `helm lint charts/kubernaut` with `console.enabled=true` — clean.
- [x] Manually rendered `templates/console/console.yaml` with `helm template` to visually confirm the oauth2-proxy container spec.

Made with [Cursor](https://cursor.com)