### PR TITLE
docs: prefer MCP tools (gopls/cocoindex_search) over grep in detection commands

### DIFF
--- a/.cursor/rules/03-testing-strategy.mdc
+++ b/.cursor/rules/03-testing-strategy.mdc
@@ -191,18 +191,33 @@ url = config['data_storage']['url']
 
 ### Validation Sequence
 
+Prefer MCP tools over grep for Steps 1-3 (see
+[AGENTS.md Detection Commands](../../AGENTS.md#detection-commands)): gopls gives a type-safe
+definition + method set directly; cocoindex_search finds mocks by meaning when the exact name
+is unknown.
+
 **Step 1 - Interface Discovery**:
+```
+go_search(query="[InterfaceName]")
+```
 ```bash
+# Fallback only if gopls is unavailable:
 grep -r "type.*[InterfaceName].*interface" pkg/ --include="*.go"
 ```
 
 **Step 2 - Method Signature Validation**:
+
+`go_search`/`gopls definition` returns the full interface body directly. Fallback:
 ```bash
 grep -A 20 "type.*[InterfaceName].*interface" [interface_file.go]
 ```
 
 **Step 3 - Mock Reuse Check**:
+```
+cocoindex_search(query="existing Mock[ComponentName] implementation", limit=10)
+```
 ```bash
+# Fallback only if cocoindex_search is unavailable:
 find pkg/testutil/mocks/ -name "*[ComponentName]*" -type f
 grep -r "Mock[ComponentName]" pkg/testutil/ --include="*.go"
 ```

--- a/.cursor/rules/04-ai-ml.mdc
+++ b/.cursor/rules/04-ai-ml.mdc
@@ -63,9 +63,15 @@ if err != nil {
 
 ### AI Discovery Phase (5-10 min)
 
-Search existing AI interfaces BEFORE creating new.
+Search existing AI interfaces BEFORE creating new. Prefer MCP tools over grep (see
+[AGENTS.md Detection Commands](../../AGENTS.md#detection-commands)):
+
+```
+cocoindex_search(query="existing AI/LLM client interfaces in pkg/ai", limit=10)
+```
 
 ```bash
+# Fallback only if cocoindex_search is unavailable:
 grep -r "Client.*interface" pkg/ai/ --include="*.go"
 grep -r "AI\|LLM\|Holmes" cmd/ --include="*.go"
 ```

--- a/.cursor/rules/14-design-decisions-documentation.mdc
+++ b/.cursor/rules/14-design-decisions-documentation.mdc
@@ -89,9 +89,15 @@ When user requests or AI proposes a significant architectural change, AI MUST:
 #### **Validation Steps**
 
 **Step 1: Discovery (REQUIRED)**
+
+Prefer MCP tools over grep (see [AGENTS.md Detection Commands](../../AGENTS.md#detection-commands)):
+```
+cocoindex_search(query="existing [ArchitecturalPattern] implementations", limit=10)
+```
 ```bash
 # AI must search for existing patterns
 codebase_search "existing [pattern] implementations"
+# Fallback only if cocoindex_search is unavailable:
 grep -r "[ArchitecturalPattern]" docs/architecture/ docs/services/
 ```
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,9 +223,27 @@ REFACTOR: Clean up (name what's being cleaned up; N/A if GREEN left nothing to c
 
 ### Detection Commands
 
-**Preference hierarchy**: gopls MCP > gopls CLI > grep
+**Preference hierarchy**: MCP tools (gopls / cocoindex_search) > gopls CLI > grep
 
-#### gopls (preferred -- type-safe, import-aware)
+Use the right tool for the question:
+
+- **gopls** -- precise, type-safe answers about Go code: symbol references, callers,
+  definitions, "does this have a production caller". Use when you know (or can guess) the
+  exact identifier.
+- **cocoindex_search** -- semantic code search across the whole repo. Use when you don't know
+  the exact symbol name, or are exploring how a feature/subsystem works conceptually (e.g.
+  "how does workflow selection scoring work", "where do we handle rate limiting for LLM
+  calls"). More effective than grep for this because it ranks by meaning, not literal text.
+- **grep/rg** -- fallback only: literal string/regex matching MCP tools can't do (e.g.
+  anti-pattern detection like `grep "ToNot(BeNil())"`), or when the MCP servers above are
+  unavailable/misconfigured for this workspace.
+
+Both MCP servers are unavailable on a Go-symbol-refactor from the CLI (rename, extract,
+inline) -- see [`.cursor/skills/go-refactor-with-gopls/`](.cursor/skills/go-refactor-with-gopls/)
+for that workflow, which legitimately uses `rg` only to locate `line:col` coordinates to feed
+into `gopls`'s CLI mode.
+
+#### gopls (preferred for precise Go lookups -- type-safe, import-aware)
 
 gopls provides precise reference lookups using the Go type system. Results are identical
 regardless of interface; MCP is preferred for AI agents because it avoids shell parsing.
@@ -265,7 +283,23 @@ gopls symbols -query="NewComponent"
 Verify that each new exported function/type has at least one caller in production code
 (`cmd/` or `handler/` paths, excluding `_test.go`).
 
-#### grep (fallback -- when gopls is unavailable)
+#### cocoindex_search (preferred for semantic/conceptual exploration)
+
+cocoindex_search performs semantic code search over the whole repository. Use it instead of
+grep when you don't know the exact symbol name, or want to understand how a subsystem works
+before modifying it, or need to find likely callers/dependents of a function by meaning
+rather than exact text match.
+
+**MCP usage** (AI agents):
+```
+cocoindex_search(query="how does workflow selection scoring work", limit=10)
+cocoindex_search(query="where do we handle rate limiting for LLM calls", limit=10)
+```
+
+Pre-configured in Cursor as `cocoindex-code`. For other MCP-compatible agents, add the same
+server (`~/.hindsight/cocoindex-search.py`) to your MCP configuration.
+
+#### grep (fallback -- when MCP tools are unavailable or don't apply)
 
 ```bash
 # Verify new components have production callers


### PR DESCRIPTION
## Summary
- `AGENTS.md`'s Detection Commands section documented a `gopls MCP > gopls CLI > grep` preference, but never mentioned `cocoindex_search` -- so any search that wasn't an exact-symbol lookup (i.e. semantic/conceptual exploration) had no MCP-preferred path and fell straight to grep.
- Added a `cocoindex_search` subsection alongside the existing `gopls` one, and reframed the preference hierarchy as "MCP tools (gopls/cocoindex_search) > gopls CLI > grep".
- Applied the same MCP-preferred-alternative pattern to the handful of grep-based discovery steps still present in `.cursor/rules/*.mdc` (`03-testing-strategy.mdc`, `04-ai-ml.mdc`, `14-design-decisions-documentation.mdc`). Left literal-pattern/build-log greps alone (e.g. parsing `go build` output, `os.getenv` anti-pattern scan) since there's no MCP equivalent for those.

## Why
This exact correction ("use MCP tools, not grep") has recurred at least twice in agent sessions despite `gopls` guidance already existing in `AGENTS.md`. Root cause: the guidance only covered the Go-symbol-exact case (gopls); the semantic-search case (cocoindex_search) was undocumented, so agents defaulted to grep for that.

## Test plan
- [x] Reviewed rendered `AGENTS.md` Detection Commands section for consistency with existing style
- [x] Confirmed the 3 edited `.mdc` files still parse as valid frontmatter + markdown
- [ ] Next AI agent session in this repo picks `cocoindex_search`/`gopls` over grep for a semantic-search task

Made with [Cursor](https://cursor.com)