### PR TITLE
fix(test/aianalysis): stop decision_expired_status_test racing the live controller

### DIFF
--- a/test/integration/aianalysis/decision_expired_status_test.go
+++ b/test/integration/aianalysis/decision_expired_status_test.go
@@ -75,9 +75,17 @@ var _ = Describe("Decision Expired Status Write (#2019/#2020)", Label("integrati
 					RemediationID: rrName,
 					AnalysisRequest: aianalysisv1.AnalysisRequest{
 						SignalContext: aianalysisv1.SignalContextInput{
-							Fingerprint:      "test-fingerprint-decision-expired",
-							Severity:         "critical",
-							SignalName:       "KubePodCrashLooping",
+							Fingerprint: "test-fingerprint-decision-expired",
+							Severity:    "critical",
+							// MOCK_NO_WORKFLOW_FOUND (test/services/mock-llm/scenarios/scenario_mock_keywords.go)
+							// keeps the live envtest AIAnalysis controller's own real reconcile from ever
+							// populating Status.SelectedWorkflow (handleNoMatchingWorkflowsCompleted never
+							// touches it). Without this, the controller races ahead of this test's manual
+							// status write below with its own real KA-driven selection, and the CEL
+							// write-once guard correctly (if confusingly) rejects the test's differing
+							// content as a second writer -- not a CEL bug, a fixture race (Issue #2032).
+							// Precedent: selectedworkflow_immutability_test.go IT-AA-344-001.
+							SignalName:       "MOCK_NO_WORKFLOW_FOUND",
 							Environment:      "production",
 							BusinessPriority: "P1",
 							TargetResource: aianalysisv1.TargetResource{


### PR DESCRIPTION
## Summary

- `IT-AA-2020-001` (`decision_expired_status_test.go`, added by #2001 for #2019/#2020) intermittently fails with a CEL rejection on `status.selectedWorkflow` because the test's own force-write races the live envtest controller's own default auto-approval flow, which populates `SelectedWorkflow`/`SelectedAt` first.
- Not a CEL/production bug — a test-fixture race, exactly like the one already solved in the same suite by `selectedworkflow_immutability_test.go` (`IT-AA-344-001`), which uses `SignalName: "MOCK_NO_WORKFLOW_FOUND"` to keep the live controller's reconcile from ever touching `Status.SelectedWorkflow`.
- Applies that same precedented fixture pattern to `decision_expired_status_test.go`.

Fixes #2032.

## Evidence

- PR #2001's own CI run of this exact test passed ([job 93142915178](https://github.com/jordigilh/kubernaut/actions/runs/31272865839/job/93142915178)) before merge; the identical code failed on the very next `main` run ([job 93148677777](https://github.com/jordigilh/kubernaut/actions/runs/31274932202/job/93148677777)) — consistent with a timing-dependent race, not a deterministic bug.
- `handleNoMatchingWorkflowsCompleted` (`pkg/aianalysis/handlers/response_processor.go`) sets `Phase`/`CompletedAt`/`HumanReviewReason` but never touches `SelectedWorkflow`, and neither field carries a CEL immutability guard — so the fix has no other side effects on this test's assertions.

## Test plan

- [x] `go build ./test/integration/aianalysis/...` and `go vet` clean
- [x] `ginkgo --dry-run` confirms the spec still registers correctly
- [ ] Full `make test-integration-aianalysis` (envtest + Podman mock-llm/KA images) — running locally; CI will also validate on this PR

Made with [Cursor](https://cursor.com)