### PR TITLE
fix(audit): full reconstruction fix for AF-created RRs (Issue #2043)

### DIFF
--- a/api/openapi/data-storage-v1.yaml
+++ b/api/openapi/data-storage-v1.yaml
@@ -6210,7 +6210,7 @@ components:
 
     ApifrontendRRCreatedPayload:
       type: object
-      required: [event_type, session_id, rr_name, rr_namespace, target_kind, target_name, fingerprint]
+      required: [event_type, session_id, rr_name, rr_namespace, target_kind, target_name, fingerprint, signal_name]
       description: RemediationRequest created event payload (apifrontend.rr.created) — AF created an RR (SOC2 CC7.2, Issue #1021)
       properties:
         event_type:
@@ -6235,6 +6235,13 @@ components:
         fingerprint:
           type: string
           description: Dedup fingerprint hash
+        signal_name:
+          type: string
+          description: >-
+            Grounded signal name driving investigation behavior (Prometheus alert/rule name,
+            dominant K8s event reason, or "unknown"); mirrors the RR CRD's own spec.signalName
+            field verbatim (Issue #2043 -- BR-AUDIT-005 v2.0 CC8.1 genesis-event parity with
+            gateway.signal.received's own signal_name, required for RR reconstruction)
         signal_source:
           type: string
           description: How the signal was received (nl_query, alert_forward, etc.)

--- a/docs/architecture/decisions/DD-AUDIT-004-RR-RECONSTRUCTION-FIELD-MAPPING.md
+++ b/docs/architecture/decisions/DD-AUDIT-004-RR-RECONSTRUCTION-FIELD-MAPPING.md
@@ -588,6 +588,80 @@ deleted (DD-WORKFLOW-018's deletion-semantics decision: CRD DELETE never mutates
 
 ---
 
+## Extension: `apifrontend.rr.created` as an Alternate Genesis Event (Issue #2043, 2026-08-09)
+
+> **Scope note**: this extension does not add a new RR field to the mapping matrix above -- the
+> fields it covers (`signal_name`/`signal_type`/`signal_fingerprint`, plus `cluster_id`) were
+> already implicitly assumed to live solely on `gateway.signal.received` (see the Reconstruction
+> Algorithm's STEP 1, which historically hard-failed reconstruction when that event was absent).
+> It is documented here because it changes the mandatory precondition of STEP 1 for a real,
+> shipped ingestion path that never emits a Gateway event at all.
+
+### Problem
+
+`RemediationRequest`s created directly via APIFrontend's `kubernaut_remediate` MCP tool
+(`pkg/apifrontend/tools/af_create_rr.go`) bypass the Gateway service entirely -- there is no
+signal ingestion, webhook, or Prometheus alert involved. These RRs therefore **never** emit a
+`gateway.signal.received` event. Before this fix, `MergeAuditData` unconditionally required
+`gateway.signal.received` to be present (`pkg/datastorage/reconstruction/mapper.go`), which made
+reconstruction of every AF-created RR's genesis data **architecturally impossible** -- not a
+missing-data gap, but a hard `return nil, error` for a real, shipped ingestion path.
+
+### Decision
+
+`apifrontend.rr.created` (`ApifrontendRRCreatedPayload` in `api/openapi/data-storage-v1.yaml`) is
+now a second, equally-valid **genesis event** for RR reconstruction. Exactly one of the two
+genesis event types must be present; either satisfies the requirement:
+
+| RR CRD Field Path | Audit Event Field | Service | Event Type (either satisfies) |
+|---|---|---|---|
+| `.spec.signalName` | `event_data.signal_name` | Gateway **or** APIFrontend | `gateway.signal.received` **or** `apifrontend.rr.created` |
+| `.spec.signalType` | *(Gateway: explicit field; APIFrontend: hardcoded `"alert"`)* | Gateway **or** APIFrontend | `gateway.signal.received` **or** `apifrontend.rr.created` |
+| `.spec.signalFingerprint` | `event_data.fingerprint` | Gateway **or** APIFrontend | `gateway.signal.received` **or** `apifrontend.rr.created` |
+| `.spec.clusterID` | envelope `cluster_id` | Gateway **or** APIFrontend | `gateway.signal.received` **or** `apifrontend.rr.created` |
+
+`signal_type` is not carried as an explicit field on `ApifrontendRRCreatedPayload` because
+AF-created RRs always hardcode it to `"alert"` in production (`buildRRObject`,
+`pkg/apifrontend/tools/af_create_rr.go`); the parser mirrors this constant rather than inferring
+it, so there is nothing ambiguous to reconstruct.
+
+**Implementation**:
+- `pkg/datastorage/reconstruction/query.go`: `apifrontend.rr.created` added to the reconstruction
+  query allowlist, `eventDataDecoders` (via `decodeApifrontendRRCreatedPayload`), and
+  `IsReconstructionRelevant`.
+- `pkg/datastorage/reconstruction/parser.go`: `parseApifrontendRRCreated` dispatch case --
+  extracts `SignalName`/`SignalFingerprint` from the payload, hardcodes `SignalType: "alert"`, and
+  returns an error if `signal_name` is missing (mirrors the Gateway parser's required-field
+  contract).
+- `pkg/datastorage/reconstruction/mapper.go`: `mapApifrontendRRCreatedFields` (mirrors
+  `mapGatewaySignalFields`'s Spec assignments); `genesisEventTypes`/`hasGenesisEvent` replace the
+  single-event-type check in `MergeAuditData`.
+- **Emission-side prerequisite** (same issue, same PR): `pkg/apifrontend/tools/af_create_rr.go`
+  and `pkg/apifrontend/audit/store_adapter.go` were also fixed to actually populate
+  `CorrelationID`, `target_kind`/`target_name`/`rr_name`/`fingerprint`/`signal_name` in the emitted
+  event -- these fields were schema-required since Issue #1021 but silently persisted as `""`
+  because the `Detail` map's key names never matched what `buildRRCreatedPayload` read. Without
+  this emission-side fix, the reconstruction-side dispatch above would successfully parse an event
+  whose `signal_name` was always empty, and immediately fail the "missing signal_name" check.
+
+**Reconstruction Logic** (STEP 1 replacement, mapper.go's `MergeAuditData`):
+```go
+// Previously: unconditionally required gateway.signal.received, hard-failing
+// reconstruction for every AF-created RR.
+if !hasGenesisEvent(events) {  // gateway.signal.received OR apifrontend.rr.created
+    return nil, fmt.Errorf("gateway.signal.received or apifrontend.rr.created event is required for reconstruction")
+}
+```
+
+**Tests**:
+- Unit: `pkg/datastorage/reconstruction/parser_test.go` (`PARSER-AF-01`),
+  `pkg/datastorage/reconstruction/mapper_test.go` (`MAPPER-AF-01`, `MAPPER-MERGE-AF-01`)
+- Integration (real PostgreSQL, full production dispatch path -- query allowlist → decoder →
+  parser dispatch → mapper genesis-event acceptance):
+  `test/integration/datastorage/reconstruction_integration_test.go` (`INTEGRATION-AF-01`)
+
+---
+
 ## Related Decisions
 
 - **ADR-034 v1.3**: [Unified Audit Table Design](./ADR-034-unified-audit-table-design.md) - Parent ADR establishing this as authoritative subdocument

--- a/docs/services/apifrontend/security/AUDIT_EVENT_CATALOG.md
+++ b/docs/services/apifrontend/security/AUDIT_EVENT_CATALOG.md
@@ -82,8 +82,8 @@ type Event struct {
 | `triage.completed` | `EventTriageCompleted` | AU-2, AU-12 | Triage pipeline completes | `session_id`, `triage_outcome`, `triage_duration_ms` |
 | `severity_triage.completed` | `EventSeverityTriageCompleted` | AU-2, AU-12 | Severity triage pipeline determines severity | `tier`, `severity`, `source`, `duration_ms`, `alert_name` (if Tier 1), `rule_name` (if Tier 1.5/2/2.5) |
 | `severity_triage.failed` | `EventSeverityTriageFailed` | AU-2 | All severity triage tiers fail or LLM error | `error` (redacted), `tier` (last attempted), `namespace`, `kind`, `name` |
-| `rr.created` | `EventRRCreated` | AU-2 | RemediationRequest CRD created | `session_id`, `rr_name`, `rr_namespace`, `fingerprint` |
-| `rr.deduplicated` | `EventRRDeduplicated` | AU-2 | Duplicate RemediationRequest detected, creation skipped | `session_id`, `fingerprint`, `existing_rr_name` |
+| `rr.created` | `EventRRCreated` | AU-2, CC8.1 | RemediationRequest CRD created -- sole reconstruction genesis event for AF-created RRs (Issue #2043: AF bypasses Gateway, never emits `gateway.signal.received`) | `session_id`, `rr_name`, `rr_namespace`, `target_kind`, `target_name`, `fingerprint`, `signal_name` |
+| `rr.deduplicated` | `EventRRDeduplicated` | AU-2 | Duplicate RemediationRequest detected, creation skipped | `session_id`, `rr_namespace`, `target_kind`, `target_name`, `fingerprint`, `existing_rr_name` |
 
 **Emitted from:** `pkg/apifrontend/launcher/launcher.go`, `pkg/apifrontend/tools/af_create_rr.go`
 

--- a/pkg/apifrontend/audit/store_adapter.go
+++ b/pkg/apifrontend/audit/store_adapter.go
@@ -481,7 +481,17 @@ func buildRRCreatedPayload(e *Event) ogenclient.AuditEventRequestEventData {
 		SessionID:   detailStr(d, "session_id"),
 		RrName:      detailStr(d, "rr_name"),
 		RrNamespace: detailStr(d, "rr_namespace"),
+		// TargetKind/TargetName/SignalName (Issue #2043): previously never
+		// populated even though the schema has required them since Issue
+		// #1021 -- af_create_rr.go's Detail map used different key names
+		// (kind/name, no signal_name at all), so these always persisted as
+		// "" in event_data. SignalName specifically is what DataStorage's
+		// reconstruction mapper needs for genesis-event parity with
+		// gateway.signal.received.
+		TargetKind:  detailStr(d, "target_kind"),
+		TargetName:  detailStr(d, "target_name"),
 		Fingerprint: detailStr(d, "fingerprint"),
+		SignalName:  detailStr(d, "signal_name"),
 	})
 }
 

--- a/pkg/apifrontend/audit/store_adapter_test.go
+++ b/pkg/apifrontend/audit/store_adapter_test.go
@@ -86,7 +86,7 @@ var _ = Describe("StoreAdapter", func() {
 		{"UT-AF-1156-021", audit.EventSeverityTriageFailed, map[string]string{"error": "llm timeout"}, "apifrontend.severity_triage.failed"},
 		{"UT-AF-1156-022", audit.EventTriageStarted, map[string]string{"session_id": "sess-1", "persona": "sre"}, "apifrontend.triage.started"},
 		{"UT-AF-1156-023", audit.EventTriageCompleted, map[string]string{"session_id": "sess-1", "triage_outcome": "delegated", "triage_duration_ms": "500"}, "apifrontend.triage.completed"},
-		{"UT-AF-1156-024", audit.EventRRCreated, map[string]string{"session_id": "sess-1", "rr_name": "rr-1", "rr_namespace": "default", "fingerprint": "fp1"}, "apifrontend.rr.created"},
+		{"UT-AF-1156-024", audit.EventRRCreated, map[string]string{"session_id": "sess-1", "rr_name": "rr-1", "rr_namespace": "default", "target_kind": "Deployment", "target_name": "web", "fingerprint": "fp1", "signal_name": "HighCPU"}, "apifrontend.rr.created"},
 		{"UT-AF-1156-025", audit.EventRRDeduplicated, map[string]string{"session_id": "sess-1", "fingerprint": "abc123", "existing_rr_name": "rr-1"}, "apifrontend.rr.deduplicated"},
 		{"UT-AF-1156-026", audit.EventKADelegated, map[string]string{"session_id": "sess-1", "ka_correlation_id": "ka-1", "delegation_type": "autonomous"}, "apifrontend.ka.delegated"},
 		{"UT-AF-1156-027", audit.EventKAResultReceived, map[string]string{"session_id": "sess-1", "ka_correlation_id": "ka-1", "result_type": "rca_complete"}, "apifrontend.ka.result_received"},
@@ -321,6 +321,36 @@ var _ = Describe("StoreAdapter", func() {
 			"StoreAdapter must propagate Event.CorrelationID to AuditEventRequest.CorrelationID without modification")
 		Expect(evt.CorrelationID).NotTo(HaveLen(36),
 			"CorrelationID should be the RR name, not a synthetic UUID")
+	})
+
+	Describe("Issue #2043: full field wiring in ApifrontendRRCreatedPayload (RR reconstruction genesis event)", func() {
+		It("UT-AF-2043-001: EventRRCreated populates TargetKind/TargetName/SignalName from Detail", func() {
+			adapter.Emit(context.Background(), &audit.Event{
+				Type: audit.EventRRCreated,
+				Detail: map[string]string{
+					"session_id":   "sess-1",
+					"rr_name":      "rr-oom-web",
+					"rr_namespace": "kubernaut-system",
+					"target_kind":  "Deployment",
+					"target_name":  "web",
+					"fingerprint":  "fp-abc123",
+					"signal_name":  "OOMKilled",
+				},
+			})
+			evt := store.lastEvent()
+			Expect(evt).NotTo(BeNil())
+			payload, ok := evt.EventData.GetApifrontendRRCreatedPayload()
+			Expect(ok).To(BeTrue(), "expected ApifrontendRRCreatedPayload variant")
+			Expect(payload.RrName).To(Equal("rr-oom-web"))
+			Expect(payload.RrNamespace).To(Equal("kubernaut-system"))
+			Expect(payload.TargetKind).To(Equal("Deployment"),
+				"Issue #2043: TargetKind was never populated despite the schema requiring it")
+			Expect(payload.TargetName).To(Equal("web"),
+				"Issue #2043: TargetName was never populated despite the schema requiring it")
+			Expect(payload.Fingerprint).To(Equal("fp-abc123"))
+			Expect(payload.SignalName).To(Equal("OOMKilled"),
+				"Issue #2043: SignalName is required for RR reconstruction parity with gateway.signal.received")
+		})
 	})
 
 	Describe("Issue #1199: rr_name/rr_namespace wiring in A2A task payloads", func() {

--- a/pkg/apifrontend/tools/af_create_rr.go
+++ b/pkg/apifrontend/tools/af_create_rr.go
@@ -73,6 +73,12 @@ type CreateRRResult struct {
 	// branch it is read from the *existing* RR object (not the caller's
 	// args) to avoid misattributing audit provenance under a create race.
 	ClusterID string `json:"cluster_id,omitempty"`
+	// Fingerprint is the dedup fingerprint matched/assigned for this RR
+	// (#2043). Threaded through to emitCreateRRAudit so the
+	// apifrontend.rr.created/rr.deduplicated audit payloads can carry it
+	// without recomputing -- both the create and dedup branches already know
+	// it via req.Fingerprint at construction time.
+	Fingerprint string `json:"-"`
 }
 
 // rrCreateGroup provides singleflight deduplication per fingerprint.
@@ -260,6 +266,7 @@ func createOrReuseRR(ctx context.Context, d *ToolDeps, req createRRRequest) (*Cr
 			AlreadyExists: true,
 			Severity:      existing.Severity,
 			ClusterID:     existing.ClusterID,
+			Fingerprint:   req.Fingerprint,
 		}, nil
 	}
 
@@ -269,10 +276,11 @@ func createOrReuseRR(ctx context.Context, d *ToolDeps, req createRRRequest) (*Cr
 	}
 
 	out := &CreateRRResult{
-		RRID:       rrObj.Name,
-		Message:    fmt.Sprintf("RemediationRequest created for %s/%s by %s", req.Args.Kind, req.Args.Name, req.Username),
-		SignalName: req.SignalName,
-		ClusterID:  req.Args.ClusterID,
+		RRID:        rrObj.Name,
+		Message:     fmt.Sprintf("RemediationRequest created for %s/%s by %s", req.Args.Kind, req.Args.Name, req.Username),
+		SignalName:  req.SignalName,
+		ClusterID:   req.Args.ClusterID,
+		Fingerprint: req.Fingerprint,
 	}
 	if req.TriageResult != nil {
 		out.Severity = req.TriageResult.Severity
@@ -328,36 +336,52 @@ func buildRRObject(controllerNS string, args *CreateRRArgs, fingerprint, signalN
 
 // emitCreateRRAudit emits the RR-created or RR-deduplicated audit event, when
 // an auditor is configured.
+//
+// #2043: CorrelationID is set to the RR's own name (res.RRID) so DataStorage's
+// reconstruction endpoint can look this event up by correlation_id -- an
+// unset CorrelationID previously fell back to a random UUID
+// (store_adapter.go's correlationID() helper), making this event permanently
+// unqueryable by the RR it describes. Detail keys use the
+// ApifrontendRRCreatedPayload/ApifrontendRRDeduplicatedPayload schema's own
+// field names (rr_name/rr_namespace/target_kind/target_name/fingerprint)
+// rather than ad hoc ones, since buildRRCreatedPayload in
+// pkg/apifrontend/audit/store_adapter.go reads Detail by those exact keys.
 func emitCreateRRAudit(ctx context.Context, d *ToolDeps, args *CreateRRArgs, username string, res *CreateRRResult, resolvedSeverity string) {
 	if d.Auditor == nil {
 		return
 	}
 	if res.AlreadyExists {
 		d.Auditor.Emit(ctx, &audit.Event{
-			Type:      audit.EventRRDeduplicated,
-			UserID:    username,
-			ClusterID: args.ClusterID,
+			Type:          audit.EventRRDeduplicated,
+			CorrelationID: res.RRID,
+			UserID:        username,
+			ClusterID:     args.ClusterID,
 			Detail: map[string]string{
-				"namespace":   d.ControllerNS,
-				"kind":        args.Kind,
-				"name":        args.Name,
-				"existing_rr": res.RRID,
-				"cluster_id":  res.ClusterID,
+				"rr_namespace":     d.ControllerNS,
+				"target_kind":      args.Kind,
+				"target_name":      args.Name,
+				"existing_rr":      res.RRID,
+				"existing_rr_name": res.RRID,
+				"cluster_id":       res.ClusterID,
+				"fingerprint":      res.Fingerprint,
 			},
 		})
 		return
 	}
 	d.Auditor.Emit(ctx, &audit.Event{
-		Type:      audit.EventRRCreated,
-		UserID:    username,
-		ClusterID: args.ClusterID,
+		Type:          audit.EventRRCreated,
+		CorrelationID: res.RRID,
+		UserID:        username,
+		ClusterID:     args.ClusterID,
 		Detail: map[string]string{
-			"namespace":  d.ControllerNS,
-			"kind":       args.Kind,
-			"name":       args.Name,
-			"rr_id":      res.RRID,
-			"severity":   resolvedSeverity,
-			"cluster_id": res.ClusterID,
+			"rr_namespace": d.ControllerNS,
+			"target_kind":  args.Kind,
+			"target_name":  args.Name,
+			"rr_name":      res.RRID,
+			"severity":     resolvedSeverity,
+			"cluster_id":   res.ClusterID,
+			"fingerprint":  res.Fingerprint,
+			"signal_name":  res.SignalName,
 		},
 	})
 }

--- a/pkg/apifrontend/tools/af_create_rr_test.go
+++ b/pkg/apifrontend/tools/af_create_rr_test.go
@@ -820,10 +820,26 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 			ev := rec.events[0]
 			Expect(ev.Type).To(Equal(audit.EventRRCreated))
 			Expect(ev.UserID).To(Equal("alice"))
-			Expect(ev.Detail["rr_id"]).To(Equal(extractRRName(result.RRID)))
+			// Issue #2043: CorrelationID must be the RR's own name so DataStorage's
+			// reconstruction endpoint can look up this event by correlation_id --
+			// previously unset, silently falling back to a random UUID
+			// (store_adapter.go's correlationID() helper), making every AF-created
+			// RR's genesis event permanently unqueryable by its own RR name.
+			Expect(ev.CorrelationID).To(Equal(extractRRName(result.RRID)))
+			// Issue #2043: Detail keys renamed to match the already-schema-aligned
+			// ApifrontendRRCreatedPayload contract (rr_name/target_kind/target_name)
+			// that buildRRCreatedPayload has always read -- af_create_rr.go was
+			// supplying the wrong key names (rr_id/kind/name), so every field except
+			// severity/cluster_id/session_id silently persisted as "" in event_data.
+			Expect(ev.Detail["rr_name"]).To(Equal(extractRRName(result.RRID)))
 			Expect(ev.Detail["severity"]).To(Equal("warning"))
-			Expect(ev.Detail["kind"]).To(Equal("Deployment"))
-			Expect(ev.Detail["name"]).To(Equal("web"))
+			Expect(ev.Detail["target_kind"]).To(Equal("Deployment"))
+			Expect(ev.Detail["target_name"]).To(Equal("web"))
+			Expect(ev.Detail["rr_namespace"]).To(Equal(kubernautSystem))
+			Expect(ev.Detail["fingerprint"]).ToNot(BeEmpty(),
+				"BR-AUDIT-005: fingerprint is required in ApifrontendRRCreatedPayload for dedup identity")
+			Expect(ev.Detail["signal_name"]).To(Equal(result.SignalName),
+				"Issue #2043: signal_name must be audited so DataStorage can reconstruct RemediationRequestSpec.SignalName for AF-genesis RRs")
 		})
 
 		It("emits EventRRDeduplicated with existing_rr detail when a non-terminal RR already exists", func() {

--- a/pkg/apifrontend/tools/ka_remediate.go
+++ b/pkg/apifrontend/tools/ka_remediate.go
@@ -41,10 +41,13 @@ type RemediateResult struct {
 	Severity       string `json:"severity,omitempty"`
 	SeveritySource string `json:"severity_source,omitempty"`
 	SignalName     string `json:"signal_name,omitempty"`
-	// ClusterID attributes the RR to its cluster of origin (#1409). Kept as
-	// the trailing field, matching CreateRRResult's field order, so the
-	// RemediateResult(result) conversion below stays valid.
+	// ClusterID attributes the RR to its cluster of origin (#1409).
 	ClusterID string `json:"cluster_id,omitempty"`
+	// Fingerprint (#2043) and ClusterID above must stay the two trailing
+	// fields, matching CreateRRResult's field order/types exactly, so the
+	// RemediateResult(result) conversion below stays valid (Go struct
+	// conversion requires identical field sequences; tags may differ).
+	Fingerprint string `json:"-"`
 }
 
 // HandleRemediate creates a RemediationRequest CRD without creating an

--- a/pkg/audit/openapi_spec_data.yaml
+++ b/pkg/audit/openapi_spec_data.yaml
@@ -6210,7 +6210,7 @@ components:
 
     ApifrontendRRCreatedPayload:
       type: object
-      required: [event_type, session_id, rr_name, rr_namespace, target_kind, target_name, fingerprint]
+      required: [event_type, session_id, rr_name, rr_namespace, target_kind, target_name, fingerprint, signal_name]
       description: RemediationRequest created event payload (apifrontend.rr.created) — AF created an RR (SOC2 CC7.2, Issue #1021)
       properties:
         event_type:
@@ -6235,6 +6235,13 @@ components:
         fingerprint:
           type: string
           description: Dedup fingerprint hash
+        signal_name:
+          type: string
+          description: >-
+            Grounded signal name driving investigation behavior (Prometheus alert/rule name,
+            dominant K8s event reason, or "unknown"); mirrors the RR CRD's own spec.signalName
+            field verbatim (Issue #2043 -- BR-AUDIT-005 v2.0 CC8.1 genesis-event parity with
+            gateway.signal.received's own signal_name, required for RR reconstruction)
         signal_source:
           type: string
           description: How the signal was received (nl_query, alert_forward, etc.)

--- a/pkg/datastorage/ogen-client/oas_json_gen.go
+++ b/pkg/datastorage/ogen-client/oas_json_gen.go
@@ -10827,6 +10827,10 @@ func (s *ApifrontendRRCreatedPayload) encodeFields(e *jx.Encoder) {
 		e.Str(s.Fingerprint)
 	}
 	{
+		e.FieldStart("signal_name")
+		e.Str(s.SignalName)
+	}
+	{
 		if s.SignalSource.Set {
 			e.FieldStart("signal_source")
 			s.SignalSource.Encode(e)
@@ -10834,7 +10838,7 @@ func (s *ApifrontendRRCreatedPayload) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfApifrontendRRCreatedPayload = [8]string{
+var jsonFieldsNameOfApifrontendRRCreatedPayload = [9]string{
 	0: "event_type",
 	1: "session_id",
 	2: "rr_name",
@@ -10842,7 +10846,8 @@ var jsonFieldsNameOfApifrontendRRCreatedPayload = [8]string{
 	4: "target_kind",
 	5: "target_name",
 	6: "fingerprint",
-	7: "signal_source",
+	7: "signal_name",
+	8: "signal_source",
 }
 
 // Decode decodes ApifrontendRRCreatedPayload from json.
@@ -10850,7 +10855,7 @@ func (s *ApifrontendRRCreatedPayload) Decode(d *jx.Decoder) error {
 	if s == nil {
 		return errors.New("invalid: unable to decode ApifrontendRRCreatedPayload to nil")
 	}
-	var requiredBitSet [1]uint8
+	var requiredBitSet [2]uint8
 
 	if err := d.ObjBytes(func(d *jx.Decoder, k []byte) error {
 		switch string(k) {
@@ -10936,6 +10941,18 @@ func (s *ApifrontendRRCreatedPayload) Decode(d *jx.Decoder) error {
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"fingerprint\"")
 			}
+		case "signal_name":
+			requiredBitSet[0] |= 1 << 7
+			if err := func() error {
+				v, err := d.Str()
+				s.SignalName = string(v)
+				if err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"signal_name\"")
+			}
 		case "signal_source":
 			if err := func() error {
 				s.SignalSource.Reset()
@@ -10955,8 +10972,9 @@ func (s *ApifrontendRRCreatedPayload) Decode(d *jx.Decoder) error {
 	}
 	// Validate required fields.
 	var failures []validate.FieldError
-	for i, mask := range [1]uint8{
-		0b01111111,
+	for i, mask := range [2]uint8{
+		0b11111111,
+		0b00000000,
 	} {
 		if result := (requiredBitSet[i] & mask) ^ mask; result != 0 {
 			// Mask only required fields and check equality to mask using XOR.
@@ -17983,6 +18001,10 @@ func (s AuditEventEventData) encodeFields(e *jx.Encoder) {
 				e.Str(s.Fingerprint)
 			}
 			{
+				e.FieldStart("signal_name")
+				e.Str(s.SignalName)
+			}
+			{
 				if s.SignalSource.Set {
 					e.FieldStart("signal_source")
 					s.SignalSource.Encode(e)
@@ -22961,6 +22983,10 @@ func (s AuditEventRequestEventData) encodeFields(e *jx.Encoder) {
 			{
 				e.FieldStart("fingerprint")
 				e.Str(s.Fingerprint)
+			}
+			{
+				e.FieldStart("signal_name")
+				e.Str(s.SignalName)
 			}
 			{
 				if s.SignalSource.Set {

--- a/pkg/datastorage/ogen-client/oas_schemas_gen.go
+++ b/pkg/datastorage/ogen-client/oas_schemas_gen.go
@@ -5621,6 +5621,11 @@ type ApifrontendRRCreatedPayload struct {
 	TargetName string `json:"target_name"`
 	// Dedup fingerprint hash.
 	Fingerprint string `json:"fingerprint"`
+	// Grounded signal name driving investigation behavior (Prometheus alert/rule name, dominant K8s
+	// event reason, or "unknown"); mirrors the RR CRD's own spec.signalName field verbatim (Issue #2043
+	// -- BR-AUDIT-005 v2.0 CC8.1 genesis-event parity with gateway.signal.received's own signal_name,
+	// required for RR reconstruction).
+	SignalName string `json:"signal_name"`
 	// How the signal was received (nl_query, alert_forward, etc.).
 	SignalSource OptString `json:"signal_source"`
 }
@@ -5658,6 +5663,11 @@ func (s *ApifrontendRRCreatedPayload) GetTargetName() string {
 // GetFingerprint returns the value of Fingerprint.
 func (s *ApifrontendRRCreatedPayload) GetFingerprint() string {
 	return s.Fingerprint
+}
+
+// GetSignalName returns the value of SignalName.
+func (s *ApifrontendRRCreatedPayload) GetSignalName() string {
+	return s.SignalName
 }
 
 // GetSignalSource returns the value of SignalSource.
@@ -5698,6 +5708,11 @@ func (s *ApifrontendRRCreatedPayload) SetTargetName(val string) {
 // SetFingerprint sets the value of Fingerprint.
 func (s *ApifrontendRRCreatedPayload) SetFingerprint(val string) {
 	s.Fingerprint = val
+}
+
+// SetSignalName sets the value of SignalName.
+func (s *ApifrontendRRCreatedPayload) SetSignalName(val string) {
+	s.SignalName = val
 }
 
 // SetSignalSource sets the value of SignalSource.

--- a/pkg/datastorage/reconstruction/mapper.go
+++ b/pkg/datastorage/reconstruction/mapper.go
@@ -39,6 +39,7 @@ type ReconstructedRRFields struct {
 // are silently ignored, keeping reconstruction tolerant of irrelevant events.
 var rrFieldMappers = map[string]func(*ParsedAuditData, *ReconstructedRRFields) error{
 	"gateway.signal.received":               mapGatewaySignalFields,
+	"apifrontend.rr.created":                mapApifrontendRRCreatedFields,
 	"orchestrator.lifecycle.created":        mapOrchestratorCreatedFields,
 	"aianalysis.analysis.completed":         mapAIAnalysisCompletedFields,
 	"workflowexecution.selection.completed": mapWorkflowSelectionCompletedFields,
@@ -84,6 +85,27 @@ func mapGatewaySignalFields(parsedData *ParsedAuditData, result *ReconstructedRR
 	if len(parsedData.OriginalPayload) > 0 {
 		result.Spec.OriginalPayload = parsedData.OriginalPayload
 	}
+
+	// DD-AUDIT-003 v2.2: Map cluster_id to Spec.ClusterID for fleet reconstruction (CC8.1)
+	if parsedData.ClusterID != "" {
+		result.Spec.ClusterID = parsedData.ClusterID
+	}
+
+	return nil
+}
+
+// mapApifrontendRRCreatedFields maps AF-genesis audit data to RR Spec (Issue #2043).
+// AF-created RRs (via kubernaut_remediate) bypass Gateway and never emit
+// gateway.signal.received; this is their sole source of Spec.SignalName/
+// SignalType/SignalFingerprint for reconstruction (CC8.1 parity).
+func mapApifrontendRRCreatedFields(parsedData *ParsedAuditData, result *ReconstructedRRFields) error {
+	if parsedData.SignalName == "" {
+		return fmt.Errorf("signal name is required for apifrontend.rr.created event")
+	}
+
+	result.Spec.SignalName = parsedData.SignalName
+	result.Spec.SignalType = parsedData.SignalType
+	result.Spec.SignalFingerprint = parsedData.SignalFingerprint // BR-AUDIT-005: deduplication identity
 
 	// DD-AUDIT-003 v2.2: Map cluster_id to Spec.ClusterID for fleet reconstruction (CC8.1)
 	if parsedData.ClusterID != "" {
@@ -195,24 +217,40 @@ func mapOrchestratorTerminalFields(parsedData *ParsedAuditData, result *Reconstr
 	return nil
 }
 
+// genesisEventTypes are the event types that establish RR.Spec's foundational
+// identity (SignalName/SignalType/SignalFingerprint). Exactly one MUST be
+// present for reconstruction: gateway.signal.received for Gateway-ingested
+// RRs, or apifrontend.rr.created for RRs created directly via AF's
+// kubernaut_remediate tool (Issue #2043 -- these never emit a Gateway event,
+// so requiring gateway.signal.received unconditionally made reconstruction
+// architecturally impossible for a real, shipped ingestion path).
+var genesisEventTypes = map[string]bool{
+	"gateway.signal.received": true,
+	"apifrontend.rr.created":  true,
+}
+
+// hasGenesisEvent reports whether events contains at least one genesis event
+// (see genesisEventTypes) -- the minimum required for MergeAuditData to
+// produce a valid RR.Spec.
+func hasGenesisEvent(events []ParsedAuditData) bool {
+	for _, event := range events {
+		if genesisEventTypes[event.EventType] {
+			return true
+		}
+	}
+	return false
+}
+
 // MergeAuditData merges multiple parsed audit events into a single ReconstructedRRFields.
-// The gateway.signal.received event is required as it contains the foundational RR spec.
+// A genesis event (see genesisEventTypes) is required as it contains the foundational RR spec.
 // TDD GREEN: Minimal implementation to pass current merge tests.
 func MergeAuditData(events []ParsedAuditData) (*ReconstructedRRFields, error) {
 	if len(events) == 0 {
 		return nil, fmt.Errorf("no audit events provided for merging")
 	}
 
-	// Ensure gateway.signal.received event exists (mandatory for reconstruction)
-	hasGatewayEvent := false
-	for _, event := range events {
-		if event.EventType == "gateway.signal.received" {
-			hasGatewayEvent = true
-			break
-		}
-	}
-	if !hasGatewayEvent {
-		return nil, fmt.Errorf("gateway.signal.received event is required for reconstruction")
+	if !hasGenesisEvent(events) {
+		return nil, fmt.Errorf("gateway.signal.received or apifrontend.rr.created event is required for reconstruction")
 	}
 
 	// Initialize result with empty spec and status

--- a/pkg/datastorage/reconstruction/mapper_test.go
+++ b/pkg/datastorage/reconstruction/mapper_test.go
@@ -135,6 +135,117 @@ var _ = Describe("Audit Event Mapper", func() {
 		})
 	})
 
+	// ========================================
+	// MAPPER-AF-01: Map apifrontend.rr.created audit data to RR Spec (Issue #2043)
+	// BR-AUDIT-005 v2.0 CC8.1: AF-genesis event parity with gateway.signal.received
+	// ========================================
+	Context("MAPPER-AF-01: Map apifrontend.rr.created audit data to RR Spec (Issue #2043)", func() {
+		It("should map SignalName, SignalType, and SignalFingerprint to RR spec", func() {
+			parsedData := &reconstructionpkg.ParsedAuditData{
+				EventType:         "apifrontend.rr.created",
+				SignalName:        "OOMKilled",
+				SignalType:        "alert",
+				SignalFingerprint: "fp-abc123def456",
+			}
+
+			rrFields, err := reconstructionpkg.MapToRRFields(parsedData)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rrFields).ToNot(BeNil())
+			Expect(rrFields.Spec.SignalName).To(Equal("OOMKilled"),
+				"Issue #2043: AF-genesis event must map SignalName for RR reconstruction")
+			Expect(rrFields.Spec.SignalType).To(Equal("alert"))
+			Expect(rrFields.Spec.SignalFingerprint).To(Equal("fp-abc123def456"),
+				"BR-AUDIT-005: SignalFingerprint is required for deduplication identity")
+		})
+
+		It("should map ClusterID to Spec.ClusterID for fleet AF-created RRs [CC8.1]", func() {
+			parsedData := &reconstructionpkg.ParsedAuditData{
+				EventType:         "apifrontend.rr.created",
+				SignalName:        "OOMKilled",
+				SignalType:        "alert",
+				SignalFingerprint: "fp-abc123def456",
+				ClusterID:         "remote-cluster",
+			}
+
+			rrFields, err := reconstructionpkg.MapToRRFields(parsedData)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rrFields.Spec.ClusterID).To(Equal("remote-cluster"),
+				"CC8.1: Mapper must set Spec.ClusterID for AF-genesis events too")
+		})
+
+		It("should return error for missing required signal name", func() {
+			parsedData := &reconstructionpkg.ParsedAuditData{
+				EventType:  "apifrontend.rr.created",
+				SignalType: "alert",
+				// SignalName is missing - should error
+			}
+
+			_, err := reconstructionpkg.MapToRRFields(parsedData)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("signal name is required"))
+		})
+	})
+
+	// ========================================
+	// MAPPER-MERGE-AF-01: apifrontend.rr.created satisfies the genesis-event
+	// requirement for MergeAuditData (Issue #2043)
+	// ========================================
+	Context("MAPPER-MERGE-AF-01: apifrontend.rr.created as genesis event (Issue #2043)", func() {
+		It("should successfully merge when only an apifrontend.rr.created genesis event is present", func() {
+			afData := &reconstructionpkg.ParsedAuditData{
+				EventType:         "apifrontend.rr.created",
+				SignalName:        "OOMKilled",
+				SignalType:        "alert",
+				SignalFingerprint: "fp-abc123def456",
+			}
+
+			rrFields, err := reconstructionpkg.MergeAuditData([]reconstructionpkg.ParsedAuditData{*afData})
+
+			Expect(err).ToNot(HaveOccurred(),
+				"Issue #2043: apifrontend.rr.created must satisfy MergeAuditData's genesis-event requirement (AF-created RRs never emit gateway.signal.received)")
+			Expect(rrFields.Spec.SignalName).To(Equal("OOMKilled"))
+		})
+
+		It("should merge apifrontend.rr.created with orchestrator status data", func() {
+			afData := &reconstructionpkg.ParsedAuditData{
+				EventType:         "apifrontend.rr.created",
+				SignalName:        "OOMKilled",
+				SignalType:        "alert",
+				SignalFingerprint: "fp-abc123def456",
+			}
+			orchestratorData := &reconstructionpkg.ParsedAuditData{
+				EventType: "orchestrator.lifecycle.completed",
+				Outcome:   "success",
+			}
+
+			rrFields, err := reconstructionpkg.MergeAuditData(
+				[]reconstructionpkg.ParsedAuditData{*afData, *orchestratorData},
+			)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rrFields.Spec.SignalName).To(Equal("OOMKilled"))
+			Expect(rrFields.Status.Outcome).To(Equal("success"))
+		})
+
+		It("should still return error when neither gateway.signal.received nor apifrontend.rr.created is present", func() {
+			orchestratorData := &reconstructionpkg.ParsedAuditData{
+				EventType: "orchestrator.lifecycle.created",
+				TimeoutConfig: &reconstructionpkg.TimeoutConfigData{
+					Global: "1h0m0s",
+				},
+			}
+
+			_, err := reconstructionpkg.MergeAuditData([]reconstructionpkg.ParsedAuditData{*orchestratorData})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("gateway.signal.received"))
+			Expect(err.Error()).To(ContainSubstring("apifrontend.rr.created"))
+		})
+	})
+
 	Context("MAPPER-MERGE-01: Merge multiple audit events", func() {
 		It("should merge gateway and orchestrator data into single RR", func() {
 			// Validates merging multiple audit events into complete RR
@@ -173,8 +284,12 @@ var _ = Describe("Audit Event Mapper", func() {
 			Expect(rrFields.Status.TimeoutConfig.Global.Duration.String()).To(Equal("2h0m0s"))
 		})
 
-		It("should return error when gateway event is missing", func() {
-			// Validates that gateway event is mandatory for reconstruction
+		It("should return error when no genesis event (gateway or apifrontend) is present", func() {
+			// Validates that a genesis event is mandatory for reconstruction.
+			// Issue #2043: this used to require gateway.signal.received
+			// specifically; apifrontend.rr.created now also satisfies this
+			// requirement (see MAPPER-MERGE-AF-01), so this test only proves
+			// the "neither is present" failure path.
 			orchestratorData := &reconstructionpkg.ParsedAuditData{
 				EventType: "orchestrator.lifecycle.created",
 				TimeoutConfig: &reconstructionpkg.TimeoutConfigData{
@@ -185,7 +300,8 @@ var _ = Describe("Audit Event Mapper", func() {
 			_, err := reconstructionpkg.MergeAuditData([]reconstructionpkg.ParsedAuditData{*orchestratorData})
 
 			Expect(err).To(HaveOccurred())
-			Expect(err.Error()).To(ContainSubstring("gateway.signal.received event is required"))
+			Expect(err.Error()).To(ContainSubstring("gateway.signal.received"))
+			Expect(err.Error()).To(ContainSubstring("apifrontend.rr.created"))
 		})
 	})
 

--- a/pkg/datastorage/reconstruction/parser.go
+++ b/pkg/datastorage/reconstruction/parser.go
@@ -98,6 +98,8 @@ func ParseAuditEvent(event ogenclient.AuditEvent) (*ParsedAuditData, error) {
 	switch event.EventType {
 	case "gateway.signal.received":
 		parsed, err = parseGatewaySignalReceived(event)
+	case "apifrontend.rr.created":
+		parsed, err = parseApifrontendRRCreated(event)
 	case "orchestrator.lifecycle.created":
 		parsed, err = parseOrchestratorLifecycleCreated(event)
 	case "orchestrator.lifecycle.completed":
@@ -241,6 +243,29 @@ func parseOrchestratorLifecycleFailed(event ogenclient.AuditEvent) (*ParsedAudit
 	}
 
 	return data, nil
+}
+
+// parseApifrontendRRCreated extracts genesis fields from an apifrontend.rr.created
+// event (Issue #2043). AF-created RRs (via kubernaut_remediate) bypass Gateway
+// entirely and never emit gateway.signal.received; this is their sole source of
+// Spec.SignalName/SignalType/SignalFingerprint for reconstruction (CC8.1 parity).
+func parseApifrontendRRCreated(event ogenclient.AuditEvent) (*ParsedAuditData, error) {
+	payload := event.EventData.ApifrontendRRCreatedPayload
+
+	if payload.SignalName == "" {
+		return nil, fmt.Errorf("missing signal_name in apifrontend.rr.created event")
+	}
+
+	return &ParsedAuditData{
+		EventType:     event.EventType,
+		CorrelationID: event.CorrelationID,
+		SignalName:    payload.SignalName,
+		// SignalType is not carried by ApifrontendRRCreatedPayload; AF-created
+		// RRs always hardcode it to "alert" (buildRRObject, af_create_rr.go),
+		// so this mirrors production rather than guessing.
+		SignalType:        "alert",
+		SignalFingerprint: payload.Fingerprint,
+	}, nil
 }
 
 // getOptString extracts the value from an OptString, returning empty string if not set.

--- a/pkg/datastorage/reconstruction/parser_test.go
+++ b/pkg/datastorage/reconstruction/parser_test.go
@@ -159,6 +159,48 @@ var _ = Describe("Audit Event Parser", func() {
 	})
 
 	// ========================================
+	// PARSER-AF-01: Parse apifrontend.rr.created events (Issue #2043)
+	// BR-AUDIT-005 v2.0 CC8.1: AF-created RRs (via kubernaut_remediate) bypass
+	// Gateway entirely and never emit gateway.signal.received; this is their
+	// sole genesis event for reconstruction.
+	// ========================================
+	Context("PARSER-AF-01: Parse apifrontend.rr.created events (Issue #2043)", func() {
+		It("should extract signal name, signal type, and fingerprint from the AF genesis event", func() {
+			event := createApifrontendRRCreatedEvent(testTimestamp)
+
+			parsedData, err := reconstructionpkg.ParseAuditEvent(event)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(parsedData.SignalName).To(Equal("OOMKilled"),
+				"Issue #2043: signal_name must be extracted for genesis-event parity with gateway.signal.received")
+			Expect(parsedData.SignalType).To(Equal("alert"),
+				"AF-created RRs always hardcode SignalType=alert (buildRRObject, af_create_rr.go)")
+			Expect(parsedData.SignalFingerprint).To(Equal("fp-abc123def456"),
+				"BR-AUDIT-005: fingerprint is required for RR.Spec.SignalFingerprint deduplication identity")
+		})
+
+		It("should return error for missing signal name", func() {
+			event := createInvalidApifrontendRRCreatedEvent(testTimestamp)
+
+			_, err := reconstructionpkg.ParseAuditEvent(event)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("missing signal_name"))
+		})
+
+		It("should extract ClusterID from event envelope [CC8.1]", func() {
+			event := createApifrontendRRCreatedEvent(testTimestamp)
+			event.ClusterID.SetTo("remote-cluster")
+
+			parsedData, err := reconstructionpkg.ParseAuditEvent(event)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(parsedData.ClusterID).To(Equal("remote-cluster"),
+				"CC8.1: Parser must extract cluster_id from event envelope for AF-genesis events too")
+		})
+	})
+
+	// ========================================
 	// PARSER-CLUSTER-01: ClusterID extraction from event envelope [AU-2, CC8.1]
 	// BR-AUDIT-005 v2.0 / DD-AUDIT-003 v2.2: Fleet cluster-scoped audit
 	// ========================================
@@ -231,6 +273,43 @@ func createInvalidGatewayEvent(timestamp time.Time) ogenclient.AuditEvent {
 			GatewayAuditPayload: ogenclient.GatewayAuditPayload{
 				SignalType: ogenclient.GatewayAuditPayloadSignalTypeAlert,
 				SignalName: "", // Missing - should cause error in our parser
+			},
+		},
+	}
+}
+
+func createApifrontendRRCreatedEvent(timestamp time.Time) ogenclient.AuditEvent {
+	// Minimal: only fields OUR parser logic needs (Issue #2043)
+	return ogenclient.AuditEvent{
+		EventType:      "apifrontend.rr.created",
+		EventTimestamp: timestamp,
+		CorrelationID:  "rr-oom-web",
+		EventData: ogenclient.AuditEventEventData{
+			ApifrontendRRCreatedPayload: ogenclient.ApifrontendRRCreatedPayload{
+				EventType:   ogenclient.ApifrontendRRCreatedPayloadEventTypeApifrontendRrCreated,
+				SessionID:   "sess-1",
+				RrName:      "rr-oom-web",
+				RrNamespace: "kubernaut-system",
+				TargetKind:  "Deployment",
+				TargetName:  "web",
+				Fingerprint: "fp-abc123def456",
+				SignalName:  "OOMKilled",
+			},
+		},
+	}
+}
+
+func createInvalidApifrontendRRCreatedEvent(timestamp time.Time) ogenclient.AuditEvent {
+	// Minimal invalid: missing signal_name to test error handling
+	return ogenclient.AuditEvent{
+		EventType:      "apifrontend.rr.created",
+		EventTimestamp: timestamp,
+		EventData: ogenclient.AuditEventEventData{
+			ApifrontendRRCreatedPayload: ogenclient.ApifrontendRRCreatedPayload{
+				EventType:   ogenclient.ApifrontendRRCreatedPayloadEventTypeApifrontendRrCreated,
+				RrName:      "rr-oom-web",
+				Fingerprint: "fp-abc123def456",
+				SignalName:  "", // Missing - should cause error in our parser
 			},
 		},
 	}

--- a/pkg/datastorage/reconstruction/query.go
+++ b/pkg/datastorage/reconstruction/query.go
@@ -72,6 +72,7 @@ const reconstructionEventsQuery = `
 	WHERE correlation_id = $1
 	  AND event_type IN (
 		  'gateway.signal.received',
+		  'apifrontend.rr.created',
 		  'aianalysis.analysis.completed',
 		  'workflowexecution.selection.completed',
 		  'workflowexecution.execution.started',
@@ -299,6 +300,7 @@ type eventDataDecoder func(eventDataJSON []byte) (ogenclient.AuditEventEventData
 // function's cyclomatic complexity.
 var eventDataDecoders = map[string]eventDataDecoder{
 	"gateway.signal.received": decodeGatewayAuditPayload,
+	"apifrontend.rr.created":  decodeApifrontendRRCreatedPayload,
 	"orchestrator.lifecycle.created": decodeOrchestratorAuditPayload(
 		ogenclient.AuditEventEventDataOrchestratorLifecycleCreatedAuditEventEventData),
 	"orchestrator.lifecycle.completed": decodeOrchestratorAuditPayload(
@@ -319,6 +321,18 @@ func decodeGatewayAuditPayload(eventDataJSON []byte) (ogenclient.AuditEventEvent
 	}
 	var data ogenclient.AuditEventEventData
 	data.SetGatewayAuditPayload(ogenclient.AuditEventEventDataGatewaySignalReceivedAuditEventEventData, payload)
+	return data, nil
+}
+
+// decodeApifrontendRRCreatedPayload decodes the apifrontend.rr.created
+// event_data JSON into its typed discriminated-union variant (Issue #2043).
+func decodeApifrontendRRCreatedPayload(eventDataJSON []byte) (ogenclient.AuditEventEventData, error) {
+	var payload ogenclient.ApifrontendRRCreatedPayload
+	if err := json.Unmarshal(eventDataJSON, &payload); err != nil {
+		return ogenclient.AuditEventEventData{}, err
+	}
+	var data ogenclient.AuditEventEventData
+	data.SetApifrontendRRCreatedPayload(payload)
 	return data, nil
 }
 
@@ -362,6 +376,7 @@ func decodeWorkflowExecutionAuditPayload(discriminator ogenclient.AuditEventEven
 func IsReconstructionRelevant(eventType string) bool {
 	relevantTypes := map[string]bool{
 		"gateway.signal.received":               true, // Gap #1, #3, #4
+		"apifrontend.rr.created":                true, // Issue #2043: AF-genesis event (no gateway.signal.received for AF-created RRs)
 		"aianalysis.analysis.completed":         true, // Gap #2
 		"workflowexecution.selection.completed": true, // Gap #5
 		"workflowexecution.execution.started":   true, // Gap #6

--- a/pkg/datastorage/server/middleware/openapi_spec_data.yaml
+++ b/pkg/datastorage/server/middleware/openapi_spec_data.yaml
@@ -6210,7 +6210,7 @@ components:
 
     ApifrontendRRCreatedPayload:
       type: object
-      required: [event_type, session_id, rr_name, rr_namespace, target_kind, target_name, fingerprint]
+      required: [event_type, session_id, rr_name, rr_namespace, target_kind, target_name, fingerprint, signal_name]
       description: RemediationRequest created event payload (apifrontend.rr.created) — AF created an RR (SOC2 CC7.2, Issue #1021)
       properties:
         event_type:
@@ -6235,6 +6235,13 @@ components:
         fingerprint:
           type: string
           description: Dedup fingerprint hash
+        signal_name:
+          type: string
+          description: >-
+            Grounded signal name driving investigation behavior (Prometheus alert/rule name,
+            dominant K8s event reason, or "unknown"); mirrors the RR CRD's own spec.signalName
+            field verbatim (Issue #2043 -- BR-AUDIT-005 v2.0 CC8.1 genesis-event parity with
+            gateway.signal.received's own signal_name, required for RR reconstruction)
         signal_source:
           type: string
           description: How the signal was received (nl_query, alert_forward, etc.)

--- a/test/e2e/fleet/12_reconstruction_test.go
+++ b/test/e2e/fleet/12_reconstruction_test.go
@@ -19,6 +19,7 @@ package fleet
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -54,39 +55,108 @@ var _ = Describe("E2E-FLEET-CC81-001: Fleet Reconstruction Compliance [CC8.1]", 
 	)
 
 	It("should include cluster_id in reconstruction response for fleet RRs", func() {
-		By("Finding a completed RemediationRequest with ClusterID set")
-		rrList := &remediationv1.RemediationRequestList{}
-		Eventually(func(g Gomega) {
-			g.Expect(k8sClient.List(ctx, rrList, client.InNamespace(namespace))).To(Succeed())
-			var found bool
-			for _, rr := range rrList.Items {
-				if rr.Spec.ClusterID != "" && rr.Status.OverallPhase != "" {
-					rrName = rr.Name
-					correlationID = rr.Name
-					found = true
-					break
-				}
-			}
-			g.Expect(found).To(BeTrue(), "no RemediationRequest with ClusterID found")
-		}, 2*time.Minute, 5*time.Second).Should(Succeed())
-
-		GinkgoWriter.Printf("Found fleet RR: %s (correlationID: %s)\n", rrName, correlationID)
-
-		By("Waiting for audit events to be persisted (async pipeline)")
-		time.Sleep(10 * time.Second)
-
-		By("Calling ReconstructRemediationRequest API")
+		// Issue #2043: this suite has multiple RR-creation paths sharing the
+		// same namespace -- most go through Gateway's normal webhook ingestion
+		// (which emits the mandatory `gateway.signal.received` audit event
+		// reconstruction requires), but E2E-FLEET-018 creates its RR directly
+		// via APIFrontend's kubernaut_remediate A2A/MCP tool
+		// (pkg/apifrontend/tools/af_create_rr.go), bypassing Gateway entirely
+		// and emitting a different (equally valid, but reconstruction-mapper-
+		// unsupported) `apifrontend.rr.created` event instead. Locking onto
+		// the FIRST RR matching the spec-level condition below is a race
+		// against Ginkgo's spec ordering: if that first match happens to be
+		// the APIFrontend-created one, reconstruction is *permanently*
+		// impossible for it (not a timing issue -- confirmed via must-gather
+		// RCA in #2043), and the old single-candidate retry loop had no way
+		// to recover.
+		//
+		// Fixed by trying EVERY currently-listed candidate RR on each poll,
+		// not just the first: this test's actual business intent (BR-AUDIT-005
+		// v2.0 CC8.1: cluster_id survives reconstruction for fleet RRs) only
+		// needs ONE successfully-reconstructable fleet RR to prove the
+		// contract, not a specific one -- so falling through to the next
+		// candidate is correct, not a weaker assertion.
+		//
+		// Follow-up hardening: the candidate filter now requires
+		// PhaseCompleted explicitly (previously `OverallPhase != ""`, which
+		// matched all 10 non-terminal/failure phases too -- e.g. Pending,
+		// Processing, Blocked -- and is exactly how the AF-created RR above,
+		// permanently stuck in Blocked, was being swept into candidacy in
+		// the first place). This keeps the multi-candidate loop as
+		// defense-in-depth for legitimately concurrent completed fleet RRs,
+		// without silently accepting non-terminal ones as proof of anything.
+		// Per-candidate failures are now joined (not just the last one kept)
+		// so a systemic regression across every completed candidate is loud
+		// in the failure output, rather than reporting only the final
+		// candidate's error. This intentionally does NOT special-case the
+		// unrelated, already-tracked #1985 cold-start audit-write race --
+		// that failure mode should keep surfacing on its own merits if it
+		// recurs, not be silently absorbed here.
+		//
+		// Further hardening: "reconstructed" alone was too weak a success
+		// criterion for picking a candidate to `return` on -- a candidate
+		// could get a 200 ReconstructionResponse back with cluster_id still
+		// unset/empty (e.g. a genuine cluster_id-mapping bug affecting only
+		// some RRs), and the loop would still latch onto it, return, and let
+		// the *outer*, non-retried assertions below fail immediately on the
+		// real business check -- with no chance for the loop to move on to
+		// another, possibly-conformant candidate. The cluster_id check is
+		// now part of the loop's own success predicate, so only a candidate
+		// that fully satisfies the business contract can end the retry.
+		//
+		// Review follow-up: the loop used to end with TWO sequential
+		// g.Expect calls -- `candidateCount > 0` then `resp != nil` -- but
+		// the only place `resp` is ever assigned is the `return` above, so
+		// reaching the second check at all already means this tick's loop
+		// ran to completion without returning, i.e. `resp` is unconditionally
+		// nil there regardless of `candidateCount`. The first check couldn't
+		// actually gate anything: whenever it passed (candidateCount > 0),
+		// the second check was guaranteed to fail anyway, making it dead
+		// code wearing a real-looking assertion. Collapsed into one
+		// assertion that always carries both diagnostics (candidateCount and
+		// errs) in its failure message, whether zero candidates existed yet
+		// or some existed and all failed.
+		By("Finding a completed fleet RemediationRequest whose audit trail is actually reconstructable")
 		var resp *ogenclient.ReconstructionResponse
 		Eventually(func(g Gomega) {
-			result, err := dataStorageClient.ReconstructRemediationRequest(ctx, ogenclient.ReconstructRemediationRequestParams{
-				CorrelationID: correlationID,
-			})
-			g.Expect(err).ToNot(HaveOccurred())
+			rrList := &remediationv1.RemediationRequestList{}
+			g.Expect(k8sClient.List(ctx, rrList, client.InNamespace(namespace))).To(Succeed())
 
-			reconResp, ok := result.(*ogenclient.ReconstructionResponse)
-			g.Expect(ok).To(BeTrue(), "expected ReconstructionResponse, got %T", result)
-			resp = reconResp
-		}, 30*time.Second, 2*time.Second).Should(Succeed())
+			var candidateCount int
+			var errs []error
+			for _, rr := range rrList.Items {
+				if rr.Spec.ClusterID == "" || rr.Status.OverallPhase != remediationv1.PhaseCompleted {
+					continue
+				}
+				candidateCount++
+
+				result, err := dataStorageClient.ReconstructRemediationRequest(ctx, ogenclient.ReconstructRemediationRequestParams{
+					CorrelationID: rr.Name,
+				})
+				if err != nil {
+					errs = append(errs, fmt.Errorf("RR %s: %w", rr.Name, err))
+					continue
+				}
+				reconResp, ok := result.(*ogenclient.ReconstructionResponse)
+				if !ok {
+					errs = append(errs, fmt.Errorf("RR %s: expected ReconstructionResponse, got %T", rr.Name, result))
+					continue
+				}
+				if !reconResp.ClusterID.Set || reconResp.ClusterID.Value == "" {
+					errs = append(errs, fmt.Errorf("RR %s: reconstructed but cluster_id not set (CC8.1 violation for this candidate)", rr.Name))
+					continue
+				}
+
+				rrName = rr.Name
+				correlationID = rr.Name
+				resp = reconResp
+				return
+			}
+
+			g.Expect(resp).ToNot(BeNil(),
+				"no completed fleet RemediationRequest reconstructed with cluster_id set yet (%d candidate(s) tried): %v",
+				candidateCount, errors.Join(errs...))
+		}, 2*time.Minute, 5*time.Second).Should(Succeed())
 
 		By("Verifying cluster_id is present in reconstruction response")
 		Expect(resp.ClusterID.Set).To(BeTrue(),
@@ -183,10 +253,15 @@ var _ = Describe("E2E-FLEET-CC81-001: Fleet Reconstruction Compliance [CC8.1]", 
 					"RR must have entered a known reconciliation phase, got %q", rr.Status.OverallPhase)
 			}, timeout, interval).Should(Succeed())
 
-			By("Waiting for audit events to be persisted (async pipeline)")
-			time.Sleep(10 * time.Second)
-
-			By(fmt.Sprintf("Reconstructing hub-only RR: %s", hubRRName))
+			// AGENTS.md testing standard: no fixed time.Sleep() in tests --
+			// poll for the actual condition instead. The async audit
+			// pipeline's persistence delay is absorbed entirely by this
+			// Eventually's own retry loop (it already treats a query error,
+			// e.g. audit events not yet persisted, as a retryable failure),
+			// so a separate blind sleep before it added nothing but wasted
+			// wall-clock time on every run. Budget bumped from 30s to 40s to
+			// preserve the same total wait headroom the sleep+30s poll gave.
+			By(fmt.Sprintf("Reconstructing hub-only RR: %s (polling for async audit-event persistence)", hubRRName))
 			var resp *ogenclient.ReconstructionResponse
 			Eventually(func(g Gomega) {
 				result, err := dataStorageClient.ReconstructRemediationRequest(ctx, ogenclient.ReconstructRemediationRequestParams{
@@ -196,7 +271,7 @@ var _ = Describe("E2E-FLEET-CC81-001: Fleet Reconstruction Compliance [CC8.1]", 
 				reconResp, ok := result.(*ogenclient.ReconstructionResponse)
 				g.Expect(ok).To(BeTrue(), "expected ReconstructionResponse, got %T", result)
 				resp = reconResp
-			}, 30*time.Second, 2*time.Second).Should(Succeed())
+			}, 40*time.Second, 2*time.Second).Should(Succeed())
 
 			Expect(resp.ClusterID.Set).To(BeFalse(),
 				"hub-only RR should not have cluster_id set")

--- a/test/integration/apifrontend/create_rr_wiring_test.go
+++ b/test/integration/apifrontend/create_rr_wiring_test.go
@@ -410,7 +410,21 @@ var _ = Describe("kubernaut_remediate wiring (#1282, #1332)", func() {
 		events := auditRecorder.EventsOfType(audit.EventRRCreated)
 		Expect(events).To(HaveLen(1))
 		Expect(events[0].UserID).To(Equal("audit-user"))
-		Expect(events[0].Detail).To(HaveKeyWithValue("namespace", defaultFixture))
+		// Issue #2043: CorrelationID must be the RR's own name (not a random
+		// UUID) so DataStorage's reconstruction endpoint can look it up by
+		// correlation_id.
+		Expect(events[0].CorrelationID).To(Equal(result.RRID))
+		// Issue #2043: Detail keys renamed from namespace/kind/name to the
+		// schema-aligned rr_namespace/target_kind/target_name that
+		// buildRRCreatedPayload has always read.
+		Expect(events[0].Detail).To(HaveKeyWithValue("rr_namespace", defaultFixture))
+		Expect(events[0].Detail).To(HaveKeyWithValue("target_kind", "Deployment"))
+		Expect(events[0].Detail).To(HaveKeyWithValue("target_name", "web-w06"))
+		Expect(events[0].Detail).To(HaveKeyWithValue("rr_name", result.RRID))
+		Expect(events[0].Detail["fingerprint"]).ToNot(BeEmpty(),
+			"BR-AUDIT-005: fingerprint is required in ApifrontendRRCreatedPayload for dedup identity")
+		Expect(events[0].Detail["signal_name"]).ToNot(BeEmpty(),
+			"Issue #2043: signal_name is required for DataStorage to reconstruct RemediationRequestSpec.SignalName for AF-genesis RRs")
 
 		DeferCleanup(func() {
 			_ = dynamicClient.Resource(rrGVR).Namespace(defaultFixture).Delete(ctx, result.RRID, metav1.DeleteOptions{})

--- a/test/integration/datastorage/audit_test_helpers.go
+++ b/test/integration/datastorage/audit_test_helpers.go
@@ -132,6 +132,56 @@ func CreateOrchestratorLifecycleCreatedEvent(
 	}, nil
 }
 
+// CreateApifrontendRRCreatedEvent creates a typed apifrontend.rr.created audit event.
+//
+// Required fields in payload:
+// - EventType (must be apifrontend.rr.created)
+// - SessionID
+// - RrName
+// - RrNamespace
+// - TargetKind
+// - TargetName
+// - Fingerprint
+// - SignalName
+//
+// Issue #2043: this is the sole genesis event for RRs created directly via
+// AF's kubernaut_remediate tool -- these bypass Gateway entirely and never
+// emit gateway.signal.received.
+func CreateApifrontendRRCreatedEvent(
+	correlationID string,
+	payload ogenclient.ApifrontendRRCreatedPayload,
+) (*repository.AuditEvent, error) {
+	// Validate required discriminator
+	if payload.EventType != ogenclient.ApifrontendRRCreatedPayloadEventTypeApifrontendRrCreated {
+		payload.EventType = ogenclient.ApifrontendRRCreatedPayloadEventTypeApifrontendRrCreated
+	}
+
+	// Use ogen's encoder to properly handle Opt types
+	encoder := &jx.Encoder{}
+	payload.Encode(encoder)
+	payloadJSON := encoder.Bytes()
+
+	// Convert JSON to map for repository layer
+	var eventDataMap map[string]interface{}
+	if err := json.Unmarshal(payloadJSON, &eventDataMap); err != nil {
+		return nil, err
+	}
+
+	return &repository.AuditEvent{
+		EventID:        uuid.New(),
+		Version:        "1.0",
+		EventTimestamp: time.Now().UTC(),
+		EventType:      "apifrontend.rr.created",
+		EventCategory:  "apifrontend",
+		EventAction:    "created",
+		EventOutcome:   "success",
+		CorrelationID:  correlationID,
+		ResourceType:   "RemediationRequest",
+		ResourceID:     payload.RrName,
+		EventData:      eventDataMap,
+	}, nil
+}
+
 // CreateAIAnalysisCompletedEvent creates a typed aianalysis.analysis.completed audit event.
 //
 // Required fields in payload:

--- a/test/integration/datastorage/reconstruction_integration_test.go
+++ b/test/integration/datastorage/reconstruction_integration_test.go
@@ -322,6 +322,158 @@ var _ = Describe("Reconstruction Business Logic Integration Tests (BR-AUDIT-006)
 		})
 	})
 
+	// ========================================
+	// AF-GENESIS EVENT INTEGRATION TESTS (Issue #2043)
+	// ========================================
+	// AF-created RRs (via kubernaut_remediate) bypass Gateway entirely and
+	// never emit gateway.signal.received; apifrontend.rr.created is their
+	// sole genesis event. These tests prove the full production dispatch
+	// path -- query allowlist, decoder registration, parser dispatch, and
+	// mapper genesis-event acceptance -- against a real PostgreSQL database.
+	Context("INTEGRATION-AF-01: Reconstruct RR from apifrontend.rr.created genesis event only", func() {
+		It("should reconstruct RR spec from an AF-created RR's audit trail", func() {
+			// ARRANGE: Seed only an apifrontend.rr.created event (no gateway.signal.received)
+			afPayload := ogenclient.ApifrontendRRCreatedPayload{
+				EventType:   ogenclient.ApifrontendRRCreatedPayloadEventTypeApifrontendRrCreated,
+				SessionID:   "sess-oom-1",
+				RrName:      "rr-oom-web",
+				RrNamespace: "kubernaut-system",
+				TargetKind:  "Deployment",
+				TargetName:  "web",
+				Fingerprint: "fp-af-integration-001",
+				SignalName:  "OOMKilled",
+			}
+			afEvent, err := CreateApifrontendRRCreatedEvent(correlationID, afPayload)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = auditRepo.Create(ctx, afEvent)
+			Expect(err).ToNot(HaveOccurred())
+
+			// ACT: Full reconstruction pipeline via the production dispatch path
+
+			// Step 1: Query events from real database (proves query.go allowlist + decoder)
+			events, err := reconstruction.QueryAuditEventsForReconstruction(ctx, db.DB, logger, correlationID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(events).To(HaveLen(1))
+			Expect(events[0].EventType).To(Equal("apifrontend.rr.created"))
+
+			// Step 2: Parse events (proves parser.go dispatch case)
+			parsedData := make([]reconstruction.ParsedAuditData, 0, len(events))
+			for _, event := range events {
+				parsed, err := reconstruction.ParseAuditEvent(event)
+				Expect(err).ToNot(HaveOccurred())
+				parsedData = append(parsedData, *parsed)
+			}
+			Expect(parsedData).To(HaveLen(1))
+
+			// Step 3: Map + merge (proves mapper.go genesis-event acceptance)
+			rrFields, err := reconstruction.MergeAuditData(parsedData)
+			Expect(err).ToNot(HaveOccurred(),
+				"Issue #2043: apifrontend.rr.created must satisfy MergeAuditData's genesis-event requirement")
+			Expect(rrFields).ToNot(BeNil())
+
+			// Step 4: Build complete RemediationRequest CRD
+			rr, err := reconstruction.BuildRemediationRequest(correlationID, rrFields)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(rr).ToNot(BeNil())
+
+			// ASSERT: Reconstructed fields match seeded AF-genesis data
+			Expect(rr.Spec.SignalName).To(Equal("OOMKilled"))
+			Expect(rr.Spec.SignalType).To(Equal("alert"),
+				"AF-created RRs always hardcode SignalType=alert (buildRRObject, af_create_rr.go)")
+			Expect(rr.Spec.SignalFingerprint).To(Equal("fp-af-integration-001"),
+				"BR-AUDIT-005: SignalFingerprint required for deduplication identity")
+		})
+
+		It("should reconstruct with ClusterID for fleet AF-created RRs [CC8.1]", func() {
+			// ARRANGE: Seed an apifrontend.rr.created event with a fleet ClusterID envelope field
+			afPayload := ogenclient.ApifrontendRRCreatedPayload{
+				EventType:   ogenclient.ApifrontendRRCreatedPayloadEventTypeApifrontendRrCreated,
+				SessionID:   "sess-oom-2",
+				RrName:      "rr-oom-web-fleet",
+				RrNamespace: "kubernaut-system",
+				TargetKind:  "Deployment",
+				TargetName:  "web",
+				Fingerprint: "fp-af-integration-002",
+				SignalName:  "OOMKilled",
+			}
+			afEvent, err := CreateApifrontendRRCreatedEvent(correlationID, afPayload)
+			Expect(err).ToNot(HaveOccurred())
+			afEvent.ClusterID = "remote-cluster"
+			_, err = auditRepo.Create(ctx, afEvent)
+			Expect(err).ToNot(HaveOccurred())
+
+			// ACT
+			events, err := reconstruction.QueryAuditEventsForReconstruction(ctx, db.DB, logger, correlationID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(events).To(HaveLen(1))
+
+			parsedData := make([]reconstruction.ParsedAuditData, 0, len(events))
+			for _, event := range events {
+				parsed, err := reconstruction.ParseAuditEvent(event)
+				Expect(err).ToNot(HaveOccurred())
+				parsedData = append(parsedData, *parsed)
+			}
+
+			rrFields, err := reconstruction.MergeAuditData(parsedData)
+			Expect(err).ToNot(HaveOccurred())
+
+			// ASSERT: CC8.1 -- ClusterID propagated from envelope through parse+map
+			Expect(rrFields.Spec.ClusterID).To(Equal("remote-cluster"))
+		})
+
+		It("should merge apifrontend.rr.created with downstream orchestrator status data", func() {
+			// ARRANGE: AF genesis event + orchestrator completion event (mixed pipeline)
+			afPayload := ogenclient.ApifrontendRRCreatedPayload{
+				EventType:   ogenclient.ApifrontendRRCreatedPayloadEventTypeApifrontendRrCreated,
+				SessionID:   "sess-oom-3",
+				RrName:      "rr-oom-web-mixed",
+				RrNamespace: "kubernaut-system",
+				TargetKind:  "Deployment",
+				TargetName:  "web",
+				Fingerprint: "fp-af-integration-003",
+				SignalName:  "OOMKilled",
+			}
+			afEvent, err := CreateApifrontendRRCreatedEvent(correlationID, afPayload)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = auditRepo.Create(ctx, afEvent)
+			Expect(err).ToNot(HaveOccurred())
+
+			orchestratorPayload := ogenclient.RemediationOrchestratorAuditPayload{
+				EventType: ogenclient.RemediationOrchestratorAuditPayloadEventTypeOrchestratorLifecycleCreated,
+				RrName:    "rr-oom-web-mixed",
+				Namespace: "kubernaut-system",
+				TimeoutConfig: ogenclient.NewOptTimeoutConfig(
+					ogenclient.TimeoutConfig{
+						Global: ogenclient.NewOptString("1h"),
+					},
+				),
+			}
+			orchestratorEvent, err := CreateOrchestratorLifecycleCreatedEvent(correlationID, orchestratorPayload)
+			Expect(err).ToNot(HaveOccurred())
+			_, err = auditRepo.Create(ctx, orchestratorEvent)
+			Expect(err).ToNot(HaveOccurred())
+
+			// ACT
+			events, err := reconstruction.QueryAuditEventsForReconstruction(ctx, db.DB, logger, correlationID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(events).To(HaveLen(2))
+
+			parsedData := make([]reconstruction.ParsedAuditData, 0, len(events))
+			for _, event := range events {
+				parsed, err := reconstruction.ParseAuditEvent(event)
+				Expect(err).ToNot(HaveOccurred())
+				parsedData = append(parsedData, *parsed)
+			}
+
+			rrFields, err := reconstruction.MergeAuditData(parsedData)
+			Expect(err).ToNot(HaveOccurred())
+
+			// ASSERT: AF-genesis spec fields + orchestrator status fields both present
+			Expect(rrFields.Spec.SignalName).To(Equal("OOMKilled"))
+			Expect(rrFields.Status.TimeoutConfig.Global).ToNot(BeNil())
+		})
+	})
+
 	// NOTE: Additional integration tests for database constraints,
 	// concurrent access, and transaction handling can be added here
 })


### PR DESCRIPTION
## Summary

Fixes the root cause behind #2043's `ReconstructRemediationRequest` failures for RemediationRequests created directly via APIFrontend's `kubernaut_remediate` MCP tool (bypassing Gateway entirely).

Two independent, stacked bugs made these RRs' genesis data unreconstructable:

1. **Emission side** (`pkg/apifrontend/tools/af_create_rr.go`): `Event.CorrelationID` was never set (silently falling back to a random UUID), and `Event.Detail` used ad-hoc key names that never matched what `buildRRCreatedPayload` (`pkg/apifrontend/audit/store_adapter.go`) actually reads. Every field except `severity`/`cluster_id`/`session_id` silently persisted as `""` in `event_data`, despite `target_kind`/`target_name`/`fingerprint` being schema-required since Issue #1021.
2. **Reconstruction side** (`pkg/datastorage/reconstruction/mapper.go`): `MergeAuditData` unconditionally required a `gateway.signal.received` event to be present. AF-created RRs never emit one, making reconstruction architecturally impossible for this ingestion path — not a missing-data gap, but a hard failure.

Also extends the schema: `ApifrontendRRCreatedPayload` gained a `signal_name` field (previously absent entirely), required for CC8.1 genesis-event parity with `gateway.signal.received`.

**Consolidated from #2044**: this PR also absorbs #2044's E2E test-resilience fix (`test/e2e/fleet/12_reconstruction_test.go`), since both PRs address Issue #2043 and splitting the test-side workaround from the production-code root-cause fix was unnecessary overhead. #2044 is closed in favor of this PR.

## Changes (5 logical commits)

1. **`feat(datastorage)`** — add `signal_name` to `ApifrontendRRCreatedPayload` OpenAPI schema + regenerate `ogen-client`.
2. **`fix(apifrontend)`** — set `CorrelationID`, rename `Detail` keys to schema-aligned names, thread `Fingerprint`/`SignalName` through `CreateRRResult`/`RemediateResult`.
3. **`fix(datastorage)`** — accept `apifrontend.rr.created` as an alternate RR reconstruction genesis event (query allowlist + decoder + `IsReconstructionRelevant`, parser dispatch case, mapper field mapping + `hasGenesisEvent`).
4. **`docs(audit)`** — `DD-AUDIT-004` extension + `AUDIT_EVENT_CATALOG.md` updates.
5. **`fix(e2e/fleet)`** — (consolidated from #2044) make the CC8.1 reconstruction E2E test resilient to non-Gateway RRs in the candidate pool.

## Test plan

- [x] RED: `parser_test.go` (`PARSER-AF-01`), `mapper_test.go` (`MAPPER-AF-01`, `MAPPER-MERGE-AF-01`) — 10 failing specs before GREEN
- [x] GREEN: all reconstruction unit specs pass (71/71)
- [x] Emission-side unit tests pass (`pkg/apifrontend/tools`, `pkg/apifrontend/audit`)
- [x] IT (CHECKPOINT W): `reconstruction_integration_test.go` `INTEGRATION-AF-01` — 3 new specs against a real PostgreSQL database, proving the full production dispatch path (query → decode → parse → map → merge); 8/8 specs pass with no regressions
- [x] `go build ./...` passes
- [x] `golangci-lint run` — 0 issues on all affected packages
- [x] `go vet` clean on consolidated `test/e2e/fleet` package
- [x] Rebased on latest `main`

Closes #2043