### PR TITLE
fix: port AF scope validation, content grounding, ambiguous severity correlation, and AA session-desync fixes to main (#2025, #2047, #2028, #2030)

### DIFF
--- a/charts/kubernaut/templates/apifrontend/apifrontend.yaml
+++ b/charts/kubernaut/templates/apifrontend/apifrontend.yaml
@@ -221,6 +221,32 @@ logging:
 {{- if .Values.global.fleet.enabled }}
 fleet:
   enabled: true
+  {{- /* Issue #2059/E2E-FLEET-018 RCA: this backend/endpoint pair was
+  missing here entirely (not just defaulted wrong) -- AF's own
+  fleet.NewScopeChecker call (cmd/apifrontend/backend_deps.go) always saw
+  Backend="" + Endpoint="", so pkg/fleet/config.go's EffectiveEndpoint()
+  returned "" (auto-derivation for the fmc backend is itself gated on
+  Backend==BackendFMC, never true for an empty Backend) and
+  pkg/fleet/scope_factory.go's NewScopeChecker silently returned the bare
+  local scope.Manager instead of a FederatedScopeChecker -- even with
+  global.fleet.enabled=true. Every kubernaut_remediate/investigate call
+  carrying a non-empty ClusterID then fail-closed with "local Manager
+  cannot resolve remote cluster", identical in shape to the GW/RO
+  Backend=""+auto-derived-Endpoint gap fixed for Issue #1737/DD-TEST-015
+  below (mirrors gateway.yaml/remediationorchestrator.yaml's identical
+  block verbatim). global.fleet.backend="" documented default is
+  "fleetmetadatacache" (README.md, values.yaml) -- must be MATERIALIZED
+  here, not just implied by the values.yaml comment, else
+  effectiveBackend() (which deliberately does NOT itself default an
+  empty Backend, see UT-FLEET-FAC-007) sees Backend="" + a non-empty
+  auto-derived Endpoint and fails startup with "fleet: unsupported
+  backend \"\"". */}}
+  backend: {{ $apifrontendFleetPreamble.config.backend | default "fleetmetadatacache" | quote }}
+  {{- if $apifrontendFleetPreamble.config.endpoint }}
+  endpoint: {{ $apifrontendFleetPreamble.config.endpoint | quote }}
+  {{- else if eq (default "fleetmetadatacache" $apifrontendFleetPreamble.config.backend) "fleetmetadatacache" }}
+  endpoint: {{ include "kubernaut.fleetmetadatacache.url" . | quote }}
+  {{- end }}
   mcpGatewayEndpoint: {{ $apifrontendFleetPreamble.config.mcpGatewayEndpoint | quote }}
   {{- if $apifrontendFleetPreamble.config.mcpGatewayType }}
   mcpGatewayType: {{ $apifrontendFleetPreamble.config.mcpGatewayType | quote }}

--- a/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
+++ b/charts/kubernaut/templates/fleetmetadatacache/fleetmetadatacache.yaml
@@ -357,7 +357,28 @@ spec:
        once the egress fix above was applied, isolating this as a distinct,
        second bug on the ingress side. Matches both conventions per pod, as
        kubernaut.np.fleetmetadatacacheEgress already does for the reciprocal
-       egress rule on the caller side. */}}
+       egress rule on the caller side.
+
+       Issue #2059/E2E-FLEET-018 RCA (helios08 live repro, on top of the
+       apifrontend.yaml backend/endpoint chart fix + suite_test.go's
+       fmcSyncTimeout retry, both elsewhere in this PR): AF's own
+       FederatedScopeChecker (#2025/ADR-068, apifrontend/backend_deps.go)
+       calls this same /api/v1/scope/check endpoint directly -- but AF was
+       never added to this allow-list when that feature landed, because
+       this rule's scope was fixed once (above) for Gateway/RO and never
+       revisited for AF's later, independent caller. Confirmed live: a raw
+       `curl --max-time 5` from inside the apifrontend pod straight to
+       FMC's pod IP on :8080 timed out (exit 28, silently dropped SYN,
+       zero FMC-side log entries for the attempt) while the IDENTICAL call
+       from remediationorchestrator's pod returned a real 401 in ~20ms --
+       isolating the block to this ingress policy, not AF's egress (which
+       already has an unconditional 0.0.0.0/0:8080 rule from
+       kubernaut.np.llmEgress/mcpGatewayEgress) nor FMC's own readiness.
+       Live-patching just this one NetworkPolicy (kubectl patch, adding an
+       `app: apifrontend` podSelector) turned that same curl into the
+       20ms 401 and made E2E-FLEET-018 pass end-to-end with zero other
+       changes -- proving this ingress gap, not FMC sync lag, was the
+       actual blocker CI was retrying against for 45s on every run. */}}
     - from:
         - podSelector:
             matchLabels:
@@ -371,6 +392,12 @@ spec:
         - podSelector:
             matchLabels:
               app.kubernetes.io/name: remediationorchestrator
+        - podSelector:
+            matchLabels:
+              app: apifrontend
+        - podSelector:
+            matchLabels:
+              app.kubernetes.io/name: apifrontend
       ports:
         - protocol: TCP
           port: 8080

--- a/charts/kubernaut/tests/fleet_af_fmc_networkpolicy_test.yaml
+++ b/charts/kubernaut/tests/fleet_af_fmc_networkpolicy_test.yaml
@@ -1,0 +1,88 @@
+suite: "Fleet AF->FMC NetworkPolicy ingress gap (Issue #2059 E2E-FLEET-018 RCA, CI run 31387557179 + helios08 live repro): AF's own FederatedScopeChecker (#2025/ADR-068) calls FMC's /api/v1/scope/check directly, but FMC's NetworkPolicy ingress allow-list was never updated past its original gateway/remediationorchestrator-only scope"
+templates:
+  - templates/fleetmetadatacache/fleetmetadatacache.yaml
+set:
+  postgresql:
+    auth:
+      existingSecret: dummy
+  valkey:
+    existingSecret: dummy
+  signalprocessing:
+    policies:
+      existingConfigMap: test-cm
+  aianalysis:
+    policies:
+      existingConfigMap: test-cm
+  workflowexecution:
+    fleet:
+      oauth2:
+        credentialsSecretRef: we-oauth2-creds
+  fleetmetadatacache:
+    enabled: true
+    oauth2:
+      credentialsSecretRef: "fmc-creds"
+  global:
+    fleet:
+      mcpGatewayEndpoint: "http://mcp.example.com"
+      oauth2:
+        enabled: true
+        tokenURL: "https://dex.example.com/token"
+        credentialsSecretRef: fleet-oauth2-creds
+tests:
+  # ---------------------------------------------------------------------
+  # RCA: live must-gather on helios08 (fleet E2E suite, CI-artifact
+  # pr-2048) proved a raw TCP dial from the apifrontend pod directly to
+  # FMC's pod IP on :8080 timed out (`curl --max-time 5` -> exit 28)
+  # while the IDENTICAL call from remediationorchestrator's pod returned
+  # a fast, genuine 401 in ~20ms -- isolating the block to FMC's ingress
+  # NetworkPolicy, which allowed only gateway/remediationorchestrator (the
+  # #1755/DD-TEST-015 fix above), never apifrontend. Confirmed as the sole
+  # blocker: live-patching just this one NetworkPolicy (kubectl patch,
+  # adding an apifrontend podSelector) turned the same curl into a 20ms
+  # 401 and made E2E-FLEET-018 pass end-to-end on the same preserved
+  # cluster, with zero other changes.
+  # ---------------------------------------------------------------------
+  - it: "FMC NetworkPolicy allows ingress from apifrontend on 8080 (both app and app.kubernetes.io/name pod-label conventions)"
+    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
+    documentSelector:
+      path: kind
+      value: NetworkPolicy
+    asserts:
+      - contains:
+          path: spec.ingress
+          content:
+            from:
+              - podSelector:
+                  matchLabels:
+                    app: gateway
+              - podSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: gateway
+              - podSelector:
+                  matchLabels:
+                    app: remediationorchestrator-controller
+              - podSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: remediationorchestrator
+              - podSelector:
+                  matchLabels:
+                    app: apifrontend
+              - podSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: apifrontend
+            ports:
+              - protocol: TCP
+                port: 8080
+
+  - it: "FMC NetworkPolicy ingress rule still allows gateway and remediationorchestrator (no regression on the #1755 fix)"
+    template: templates/fleetmetadatacache/fleetmetadatacache.yaml
+    documentSelector:
+      path: kind
+      value: NetworkPolicy
+    asserts:
+      - matchRegex:
+          path: spec.ingress[0].from[0].podSelector.matchLabels.app
+          pattern: "^gateway$"
+      - matchRegex:
+          path: spec.ingress[0].from[2].podSelector.matchLabels.app
+          pattern: "^remediationorchestrator-controller$"

--- a/charts/kubernaut/tests/fleet_config_consolidation_test.yaml
+++ b/charts/kubernaut/tests/fleet_config_consolidation_test.yaml
@@ -143,6 +143,70 @@ tests:
           path: data["remediationorchestrator.yaml"]
           pattern: "(?m)^\\s*endpoint: \"https://fleetmetadatacache-service"
 
+  # ---------------------------------------------------------------------
+  # AF: backend + endpoint (Issue #2059/E2E-FLEET-018 RCA) -- unlike
+  # GW/RO above, AF's ConfigMap block never rendered these two keys at
+  # all (chart gap, not a per-service-vs-global naming issue): AF's
+  # fleet.enabled: true with no backend/endpoint means
+  # pkg/fleet/config.go's EffectiveEndpoint() returns "" (auto-derivation
+  # is itself gated on Backend==BackendFMC, which is never true for an
+  # empty Backend), so pkg/fleet/scope_factory.go's NewScopeChecker hits
+  # its "endpoint == ''" early-return and silently hands back the bare
+  # local scope.Manager instead of a FederatedScopeChecker -- identical
+  # in shape to the already-fixed GW/RO gap this same file's "defaults
+  # backend to fleetmetadatacache" tests above guard against. Confirmed
+  # via CI must-gather (run 31354092177): AF's own apifrontend log showed
+  # "scope: local Manager cannot resolve remote cluster \"remote-cluster\";
+  # use a fleet adapter" for a kubernaut_remediate call carrying a
+  # non-empty ClusterID, which only scope.Manager (never
+  # FederatedScopeChecker.IsManagedResource) can emit.
+  # ---------------------------------------------------------------------
+  - it: "AF renders backend/endpoint from global.fleet.backend/endpoint (Issue #2059: chart never wired these, so AF's ScopeChecker silently degraded to local-only even with fleet enabled)"
+    set:
+      global:
+        fleet:
+          enabled: true
+          mcpGatewayEndpoint: "http://mcp.example.com"
+          backend: "acm"
+          endpoint: "https://acm-search.example.com/graphql"
+          oauth2:
+            enabled: true
+            tokenURL: "https://dex.example.com/token"
+            credentialsSecretRef: fleet-oauth2-creds
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: metadata.name
+      value: apifrontend-config
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*backend: \"acm\""
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*endpoint: \"https://acm-search\\.example\\.com/graphql\""
+
+  - it: "AF defaults backend to fleetmetadatacache when global.fleet.backend is unset (same Issue #1737 DD-TEST-015 regression as GW/RO above, plus Issue #2059)"
+    set:
+      global:
+        fleet:
+          enabled: true
+          mcpGatewayEndpoint: "http://mcp.example.com"
+          oauth2:
+            enabled: true
+            tokenURL: "https://dex.example.com/token"
+            credentialsSecretRef: fleet-oauth2-creds
+    template: templates/apifrontend/apifrontend.yaml
+    documentSelector:
+      path: metadata.name
+      value: apifrontend-config
+    asserts:
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*backend: \"fleetmetadatacache\""
+      - matchRegex:
+          path: data["config.yaml"]
+          pattern: "(?m)^\\s*endpoint: \"https://fleetmetadatacache-service"
+
   - it: "the old per-service gateway.fleet.backend key is no longer recognized (schema rejects it)"
     set:
       gateway:

--- a/cmd/apifrontend/backend_deps.go
+++ b/cmd/apifrontend/backend_deps.go
@@ -45,6 +45,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/fleet/registry"
 	"github.com/jordigilh/kubernaut/pkg/shared/hotreload"
 	"github.com/jordigilh/kubernaut/pkg/shared/llm/openaicompat"
+	"github.com/jordigilh/kubernaut/pkg/shared/scope"
 	"github.com/jordigilh/kubernaut/pkg/shared/types"
 )
 
@@ -84,6 +85,15 @@ type backendDeps struct {
 	// dependencies (ADR-068, BR-FLEET-054); nil when fleet is disabled.
 	// Stopped on shutdown by stopBackendDeps.
 	fleetReadinessGate *readiness.Gate
+	// ScopeChecker validates target resources against Kubernaut's
+	// management scope (ADR-053) before kubernaut_remediate/
+	// kubernaut_investigate_alert/kubernaut_investigate create an RR
+	// (#2025, main-tracking clone of #2022). Wired via fleet.NewScopeChecker
+	// (ADR-068), same factory RO/Gateway use, so a fleet-enabled deployment
+	// gets federated (local+remote) checks for free. Nil when the K8s typed
+	// client is unavailable (graceful degradation, matches every other
+	// backendDeps field's nil-safe convention).
+	ScopeChecker scope.ScopeChecker
 }
 
 // FleetResilientClient returns the MCP Gateway connection backing
@@ -142,7 +152,38 @@ func buildBackendDeps(ctx context.Context, cfg *config.Config, metricsReg *metri
 		return nil, fmt.Errorf("fleet reader wiring: %w", err)
 	}
 
+	if err := buildScopeCheckerDeps(cfg, deps, logger); err != nil {
+		return nil, fmt.Errorf("scope checker wiring: %w", err)
+	}
+
 	return deps, nil
+}
+
+// buildScopeCheckerDeps wires the ADR-053/#2025 scope checker used by
+// kubernaut_remediate/kubernaut_investigate_alert/kubernaut_investigate to
+// reject out-of-scope resources before RR creation. Runs after
+// buildFleetReaderDeps so cfg.Fleet is fully resolved; fleet.NewScopeChecker
+// itself returns the local-only checker unchanged when Fleet is disabled
+// (ADR-068), so this wiring is safe regardless of Fleet config.
+// Degrades to a nil ScopeChecker (scope validation skipped, matching the
+// tool layer's nil-safe convention) when the K8s typed client failed to
+// initialize — mirrors every other best-effort backendDeps field.
+func buildScopeCheckerDeps(cfg *config.Config, deps *backendDeps, logger logr.Logger) error {
+	if deps.k8sTypedClient == nil {
+		logger.Info("K8s typed client unavailable, scope validation disabled (#2025)")
+		return nil
+	}
+	scopeMgr := scope.NewManager(deps.k8sTypedClient)
+	scopeChecker, err := fleet.NewScopeChecker(scopeMgr, cfg.Fleet, logger.WithName("scope"))
+	if err != nil {
+		return fmt.Errorf("create fleet scope checker: %w", err)
+	}
+	deps.ScopeChecker = scopeChecker
+	if cfg.Fleet.Enabled && cfg.Fleet.EffectiveEndpoint() != "" {
+		logger.Info("ADR-068: federated scope checker enabled for AF tool layer (#2025)",
+			"backend", cfg.Fleet.Backend, "endpoint", cfg.Fleet.EffectiveEndpoint())
+	}
+	return nil
 }
 
 // buildDSClientDeps wires the DataStorage ogen client behind a CA-reloadable,

--- a/cmd/apifrontend/mcp_a2a_handlers.go
+++ b/cmd/apifrontend/mcp_a2a_handlers.go
@@ -50,6 +50,7 @@ func buildMCPHandler(d *handlerDeps) (http.Handler, func() bool, error) {
 		InteractiveEnabled:    d.Cfg.Interactive.Enabled,
 		ActiveContextRegistry: d.ActiveCtxRegistry,
 		RESTMapper:            d.Backends.Mapper,
+		ScopeChecker:          d.Backends.ScopeChecker,
 	}
 
 	mcpSessionTimeout := d.Cfg.MCP.SessionIdleTimeout
@@ -163,6 +164,7 @@ func buildRootAgentConfig(d *handlerDeps, llmModel model.LLM, sessionSvcForAgent
 		PromClient:            d.Backends.PromClient,
 		FleetReaderFactory:    d.Backends.FleetReaderFactory,
 		ClusterRegistry:       d.Backends.FleetClusterRegistry,
+		ScopeChecker:          d.Backends.ScopeChecker,
 	}
 }
 

--- a/deploy/apifrontend/overlays/e2e/mock-llm.yaml
+++ b/deploy/apifrontend/overlays/e2e/mock-llm.yaml
@@ -223,6 +223,29 @@ data:
             name: "structured-decision-target-2"
             kind: "Pod"
 
+      - name: "af_structured_decision_ground_3"
+        # Dedicated grounding call for structured_decision_e2e_test.go's
+        # E2E-AF-1396-001 alone. af_structured_decision_ground_2 above only
+        # closed contention for the 3rd It (1396-002) relative to the first
+        # two -- it did not address that the 2nd It (1396-001) still shares
+        # af_structured_decision_ground's target with the 1st It
+        # (1395-001), so 1396-001's own grounding call could nondeterministically
+        # inherit 1395-001's still-open KA session and observe
+        # session_active, surfacing as an empty (fail-closed)
+        # payload.RCA.Severity instead of the scripted "critical" (CI run
+        # 31351842574, E2E-AF-1396-001, "severity must flow from mock-LLM
+        # through AF to SSE"). See StructuredDecisionGrounding3
+        # (apifrontend_prometheus_e2e.go).
+        keywords: ["seed third fixture context 1396 001"]
+        match_last_only: true
+        tool_call:
+          name: "kubernaut_investigate"
+          arguments:
+            api_version: "v1"
+            namespace: "af-structured-decision-e2e"
+            name: "structured-decision-target-3"
+            kind: "Pod"
+
       - name: "af_structured_decision"
         keywords: ["structured decision", "present structured rca decision"]
         match_last_only: true

--- a/deploy/apifrontend/overlays/e2e/mock-llm.yaml
+++ b/deploy/apifrontend/overlays/e2e/mock-llm.yaml
@@ -115,6 +115,19 @@ data:
         tool_call:
           name: "kubernaut_investigate"
           arguments:
+            # api_version was missing here (unlike af_progressive_investigate
+            # above, its sibling scenario targeting the identical fixture):
+            # kubernaut_investigate's args validation rejects any call
+            # without it ("api_version must not be empty",
+            # pkg/apifrontend/validate/k8s.go), so every call matching this
+            # scenario unconditionally failed before ever reaching KA. A
+            # real LLM self-corrects and retries within ~2-3s (see
+            # DD-AF-012's forensic log excerpt), but mock-llm is
+            # deterministic and never retries, so any test relying on this
+            # scenario actually succeeding (e.g. structured_decision_e2e_
+            # test.go's groundSession helper, #2023 Stage 3) silently never
+            # got real grounding.
+            api_version: "v1"
             namespace: "af-investigate-e2e"
             name: "af-investigate-target"
             kind: "Pod"
@@ -164,9 +177,71 @@ data:
                 name: "Rollback"
                 description: "Rollback to previous revision"
 
+      - name: "af_structured_decision_ground"
+        # Dedicated grounding call for structured_decision_e2e_test.go's
+        # groundSession helper. Deliberately does NOT reuse af_investigate's
+        # keywords/target (af-investigate-e2e/af-investigate-target): that
+        # fixture is shared by 3 other scenarios above, and under Ginkgo
+        # --procs>1 a concurrent spec can already hold its interactive KA
+        # session open when this one calls in, hitting KA's session_active
+        # fallback instead of a clean grounded result (CI run 31320575553,
+        # E2E-AF-1395-001). This keyword/target pair is used nowhere else.
+        keywords: ["seed grounding context"]
+        match_last_only: true
+        tool_call:
+          name: "kubernaut_investigate"
+          arguments:
+            api_version: "v1"
+            namespace: "af-structured-decision-e2e"
+            name: "structured-decision-target"
+            kind: "Pod"
+
+      - name: "af_structured_decision_ground_2"
+        # Dedicated grounding call for structured_decision_e2e_test.go's
+        # E2E-AF-1396-002 alone (its own target, not shared with
+        # af_structured_decision_ground above): that Describe block is
+        # Ordered, and by its 3rd It, af_create_rr.go's
+        # checkExistingRRByFingerprint would otherwise dedup onto the SAME
+        # RR the first two Its already opened a KA interactive session
+        # against, nondeterministically hitting session_active instead of a
+        # clean grounded result (CI run 31335085795, E2E-AF-1396-002, "AC-6:
+        # ALL options must be presented"). See
+        # StructuredDecisionGrounding2 (apifrontend_prometheus_e2e.go).
+        #
+        # Keyword deliberately shares no substring with any other keyword in
+        # this file (mock-llm's match is strings.Contains and picks the
+        # first-registered tie among equal-confidence matches, registry.go
+        # Detect) -- e.g. "seed grounding context v2" would also match
+        # af_structured_decision_ground's "seed grounding context" keyword.
+        keywords: ["seed alt fixture context 1396 002"]
+        match_last_only: true
+        tool_call:
+          name: "kubernaut_investigate"
+          arguments:
+            api_version: "v1"
+            namespace: "af-structured-decision-e2e"
+            name: "structured-decision-target-2"
+            kind: "Pod"
+
       - name: "af_structured_decision"
         keywords: ["structured decision", "present structured rca decision"]
         match_last_only: true
+        # repeat_tool_call is required, not optional, here: the mock-LLM's
+        # hasFunctionResults gate (handlers/gemini.go) is computed over the
+        # WHOLE session's conversation history, not scoped to this scenario.
+        # structured_decision_e2e_test.go's groundSession helper (#2023) runs
+        # a kubernaut_investigate call first in the same A2A session to
+        # satisfy the grounding guard, which leaves that tool's
+        # FunctionResponse in history. Without repeat_tool_call, this
+        # scenario's own first match would see hasFunctionResults=true (from
+        # groundSession's unrelated call) and fall straight to a text-only
+        # response, never invoking kubernaut_present_decision at all --
+        # silently producing no decision SSE event (CI run 31325053872,
+        # E2E-AF-1395-001, "not to be empty"). repeat_tool_call switches the
+        # re-fire guard to LastContentIsFunctionResponse (scoped to this
+        # scenario's own last turn), which still correctly falls through to
+        # text once present_decision's own result lands.
+        repeat_tool_call: true
         thought_text: "Let me analyze the investigation findings. The data-processor pod has been OOMKilled repeatedly, which correlates with the memory leak pattern in the worker goroutine. I should present the decision options to the operator."
         tool_call:
           name: "kubernaut_present_decision"

--- a/docs/architecture/decisions/ADR-053-resource-scope-management.md
+++ b/docs/architecture/decisions/ADR-053-resource-scope-management.md
@@ -775,6 +775,94 @@ See DD-FLEET-001 for full design details.
 
 ---
 
+## Addendum: Point 3 — AF Tool-Layer Validation (Issue #2025, August 2026)
+
+**Cloned from Issue #2022 (`release/v1.5`) for `main` tracking.** The gap and fix design below are
+identical on both branches; only file paths/wiring differ where `main` has since diverged (notably:
+`main`'s `ScopeChecker.IsManagedResource` already takes a `scope.ResourceIdentity{ClusterID, ...}`
+rather than a bare namespace/kind/name triple, and `main` wires the checker through
+`fleet.NewScopeChecker` rather than a bare `scope.Manager`, so this addendum gets Fleet's federated
+local+remote checks for free with no extra AF-side code).
+
+### Gap Identified
+
+Decision #3 above established defense-in-depth at two points: Gateway (Point 1, fail-fast for
+**signal-initiated** RRs) and RO (Point 2, temporal-drift re-validation for **all** RRs). Neither
+point covers RRs created by API-frontend's agent tools (`kubernaut_investigate_alert`,
+`kubernaut_investigate`, `kubernaut_remediate`) — these are **agent-initiated**, not
+signal-initiated, so they never pass through Gateway's `ProcessSignal()` pipeline at all. The only
+existing protection for this path was Point 2 (RO), which only fires *after* the RemediationRequest
+CRD (and, for the interactive tools, an InvestigationSession CRD) has already been created — wasting
+a tool call, a CRD, and an interactive session, then blocking silently with no signal surfaced back
+to the calling agent (#2022/#2025).
+
+### Point 3: AF Tool-Layer Validation (Fail-Fast for Agent-Initiated RRs)
+
+**Chosen**: Apply the same `ScopeChecker.IsManagedResource()` check (shared `pkg/shared/scope`
+package, Decision #4 "ScopeChecker Interface (DI Pattern)" above) at the AF tool layer, symmetric to
+Gateway's Point 1, before any RR/session is created — not after, as a routing-time re-check.
+
+```
+Tool call arrives (kubernaut_investigate_alert / kubernaut_investigate / kubernaut_remediate)
+  → AF validates scope → Unmanaged? → Reject: CreateRRResult error (ErrResourceNotManaged) + explanatory message, no CRD created
+                        → Managed?   → Proceed to HandleCreateRR (existing behavior)
+```
+
+**AF Behavior**:
+- Check target resource/namespace (as a `scope.ResourceIdentity`, including `ClusterID` for
+  fleet-federated targets) against `kubernaut.ai/managed` before calling `HandleCreateRR`.
+- Reject unmanaged targets with `ErrResourceNotManaged` wrapping an explanatory message mirroring
+  RO's own block wording (`routing/blocking.go`), not a generic tool error — the calling agent gets
+  an actionable, non-ambiguous signal instead of an empty session.
+- No RemediationRequest or InvestigationSession CRD created (prevents the exact waste #2022/#2025
+  reported: a CRD + interactive session created for a resource RO was always going to block).
+- Audit event: `rr.scope_rejected` (`EventRRScopeRejected`) — parallel to RO's
+  `orchestrator.routing.blocked`, giving agent-initiated rejections the same audit visibility
+  signal-initiated ones lack at Gateway (Decision #7 above explicitly omits Gateway audit events
+  for expected rejections; AF's is a genuinely new event type, not a gap-fill of an existing one).
+
+**Rationale**:
+- **Symmetry with Point 1**: AF's agent-initiated path deserved the same fail-fast treatment
+  Gateway already gives the signal-initiated path; the gap was an omission, not a design choice.
+- **No new validation logic**: reuses the existing `scope.ScopeChecker` interface and
+  `IsManagedResource` contract unchanged — this is a new *caller*, not a new *validator*.
+- **Fleet-aware for free**: `main`'s checker is constructed via `fleet.NewScopeChecker` (the same
+  factory RO/Gateway use), which itself decides whether to wrap the local `scope.Manager` with a
+  `fleet.FederatedScopeChecker` based on `cfg.Fleet.Enabled` — AF's tool layer never has to know
+  whether the target is local or remote.
+- **Client caching accepted as a trade-off**: unlike Gateway's metadata-only cache (Decision #5),
+  the local `scope.Manager` layer underneath uses an uncached `crclient.WithWatch` (`TypedClient`),
+  so each check is a live API read for local targets. This mirrors RO's V1.0 direct-API approach
+  (before the cache-strategy revision in the addendum above) and is acceptable given AF's low
+  interactive-tool-call volume relative to Gateway's signal volume.
+
+### FedRAMP Controls
+
+| Control | Application | Evidence |
+|---|---|---|
+| AC-6 (Least Privilege) | AF declines to exercise its elevated CRD-creation capability (AF's own ServiceAccount, not the caller's RBAC — see `agent/root.go` SA delegation comment) for resources outside its declared management scope | UT-AF-2025-001..040 |
+| SI-10 (Information Input Validation) | Target namespace/kind/name (as a `scope.ResourceIdentity`) is validated against declared scope alongside the existing `validate.*` checks already present in these same tool handlers | UT-AF-2025-001..040 |
+| AU-3 / AU-12 (Audit Content / Generation) | New `EventRRScopeRejected` audit event captures namespace/kind/name/user for every rejected attempt — closes an audit gap where nothing previously distinguished "rejected for scope" from silence at this layer | UT-AF-2025-004, -013, -023 |
+| SI-11 (Error Handling) | Rejection returns `ErrResourceNotManaged` + explanatory message instead of a misleading empty/silent session, mirroring RO's own block wording | UT-AF-2025-001, -005, -010, -020 |
+
+### Components Affected (`main`)
+
+- `pkg/apifrontend/tools/scope_helpers.go`: shared `checkRRScope` helper (takes a
+  `scope.ResourceIdentity`) + `ContextWithScopeChecker`/`ScopeCheckerFromContext`.
+- `pkg/apifrontend/tools/af_create_rr.go`: single pre-triage scope gate in `HandleCreateRR`, reused
+  by all three tools below (they all funnel through `HandleCreateRR`).
+- `pkg/apifrontend/tools/af_investigate_alert.go`, `ka_remediate.go`, `ka_investigate_mcp.go`:
+  `ScopeChecker` threaded into `ToolDeps`/`InvestigateConfig` and forwarded to `HandleCreateRR`.
+- `pkg/apifrontend/agent/root.go`, `pkg/apifrontend/handler/mcp_bridge.go`: wiring for both AF
+  transports (A2A/ADK and raw MCP bridge — `kubernaut_investigate` is registered in both,
+  independently).
+- `cmd/apifrontend/backend_deps.go`: `buildScopeCheckerDeps` constructs the checker via
+  `fleet.NewScopeChecker(scope.NewManager(k8sTypedClient), cfg.Fleet, logger)`, degrading to a nil
+  `ScopeChecker` (scope validation skipped) when the K8s typed client is unavailable.
+- `pkg/apifrontend/audit/audit.go`: new `EventRRScopeRejected`.
+
+---
+
 **Document Version**: 1.3
 **Last Updated**: June 25, 2026
 **Next Review**: September 25, 2026 (3 months)

--- a/docs/architecture/decisions/DD-AF-012-confidence-gated-severity-correlation.md
+++ b/docs/architecture/decisions/DD-AF-012-confidence-gated-severity-correlation.md
@@ -1,0 +1,253 @@
+# DD-AF-012: Confidence-Gated Severity Correlation with Agent Clarification
+
+**Status**: ✅ IMPLEMENTED on `main` (2026-08-09) — ported from `release/v1.5` (Issue #2027, PR
+[#2026](https://github.com/jordigilh/kubernaut/pull/2026)) as Issue #2028's `main`/v1.6 clone. See
+"Implementation results (main port)" for the Wiring Manifest, TDD results, and test IDs for this
+branch.
+**Date**: 2026-08-08 (root-cause correction: 2026-08-09, `release/v1.5` implemented: 2026-08-09,
+`main` ported: 2026-08-09)
+**Issue**: [#2027](https://github.com/jordigilh/kubernaut/issues/2027) (`release/v1.5`),
+[#2028](https://github.com/jordigilh/kubernaut/issues/2028) (`main`/v1.6 clone)
+**Related**: [DD-AF-001](DD-AF-001-pod-based-alert-correlation.md) (Tier 1 correlation this decision
+extends), DD-AF-010 (referenced in `pkg/apifrontend/severity/triage.go`/`af_create_rr.go` for the
+fail-closed-over-guessing philosophy this decision continues, no standalone doc file exists yet),
+[#2018](https://github.com/jordigilh/kubernaut/issues/2018)/[#2021](https://github.com/jordigilh/kubernaut/issues/2021)
+(specificity-vs-state ranking fix — confirmed correct, not the cause of this recurrence),
+[#2022](https://github.com/jordigilh/kubernaut/issues/2022)/[#2025](https://github.com/jordigilh/kubernaut/issues/2025)
+(`kubernaut.ai/managed` scope pattern referenced below), [#2023](https://github.com/jordigilh/kubernaut/issues/2023)/[#2047](https://github.com/jordigilh/kubernaut/issues/2047)
+(harness-signal + prompt-instruction dual pattern this decision reuses)
+
+## Context
+
+QE reported a recurrence of #2018's symptom (a `RemediationRequest` bound to an unrelated,
+persistently-firing cluster-scoped alert instead of the actual crashing resource's own signal) on a
+build that already contains #2018's fix. Live evidence: RR `rr-9307edea5938-57afb3e7`,
+`console-e2e-lifecycle-3-633843/Deployment/worker`, bound to `CDIDefaultStorageClassDegraded`
+(cluster-scoped, unrelated) instead of `KubePodCrashLooping` (the target's own alert).
+
+Issue #2028 confirmed the identical root-cause hypothesis applies equally to `main`: the ported
+#2018/#2021 fix (`b86294ab9`, "port #2018/#2019 fixes to main") is present, and `main`'s
+`bestOverallMatch` has the same specificity-ranked-ahead-of-state selection switch described below.
+
+### Root cause — live-cluster-verified, not a #2018 regression
+
+`severity.Triager.bestOverallMatch` (`pkg/apifrontend/severity/triage.go`) was traced line-by-line
+through its final selection switch:
+
+```go
+switch {
+case resourceFiring.found:  return resourceFiring.result(SourceFiringAlert), true
+case resourcePending.found: return resourcePending.result(SourcePendingAlert), true
+case nsFiring.found:        return nsFiring.result(SourceNSFiringAlert), true
+case nsPending.found:       return nsPending.result(SourceNSPendingAlert), true
+case clusterFiring.found:   return clusterFiring.result(SourceClusterFiringAlert), true
+case clusterPending.found:  return clusterPending.result(SourceClusterPendingAlert), true
+}
+```
+
+Specificity (resource > namespace > cluster) is correctly ranked strictly ahead of state
+(firing > pending) — `resourcePending`/`nsPending` are checked **before** `clusterFiring`. Two
+already-passing tests assert exactly the scenario the reporter believed should have won:
+`UT-AF-2018-001` (pending resource-specific alert beats firing cluster-scoped) and `UT-AF-2018-002`
+(pending namespace-scoped alert beats firing cluster-scoped), both in
+`pkg/apifrontend/severity/triage_test.go`. **This refutes the issue's original hypothesis** that
+pending alerts are still filtered out of candidacy before ranking runs.
+
+The root cause was confirmed against **live Prometheus data**, not inference — but the first pass
+below (RR `rr-9307edea5938-57afb3e7`) **understated the effective margin**, corrected in the next
+subsection using three more live-cluster-verified reproductions.
+
+Querying `prometheus-k8s` (`openshift-monitoring` — the `console-e2e-alerts` `PrometheusRule` is
+evaluated there, not by `prometheus-user-workload`) for the historical `ALERTS` series:
+
+| Event | Timestamp (UTC) | Delta from trigger |
+|---|---|---|
+| AF's Tier 1 correlation runs (RR `firingTime`/creation) | `23:14:27Z` | T+0 |
+| `KubePodCrashLooping{pod=worker-7986b99df8-gpjgw}` goes **pending** | `23:15:00Z` | **T+33s** |
+| Same alert instance transitions to **firing** (`for: 30s` elapsed) | `23:15:30Z` | T+63s |
+| `CDIDefaultStorageClassDegraded` (cluster-scoped, no `namespace` label) | firing continuously the entire window | — |
+
+At the exact moment Tier 1 took its single Prometheus snapshot, the target's own alert did not exist
+yet — not pending, not firing, zero instances. There was no higher-specificity candidate at all for
+`bestOverallMatch` to rank; it correctly fell back to the only candidate present.
+
+Cross-checked against apifrontend logs for the initiating call:
+
+```
+23:14:25.109Z  tool call started: kubernaut_investigate  →  FAILED: "api_version must not be empty"
+23:14:27.740Z  tool call started: kubernaut_investigate  →  succeeded (retry, 2.6s later)
+```
+
+No alert was named in the request at all — a plain resource-based call
+(`kubernaut_investigate(namespace=console-e2e-lifecycle-3-633843, kind=Deployment, name=worker)`).
+The alert identity is invented entirely by `severity.Triager` — **deterministic Go code inside
+`HandleCreateRR`**, not an LLM choice, made before any KA/AA session or LLM reasoning ever sees the
+resource. (Minor, unrelated observation: the agent's first tool-call attempt omitted `api_version`
+and failed validation, self-corrected 2.6s later — not connected to the mis-correlation.)
+
+From this first pass alone, the apparent root cause was: Tier 1 takes a single, non-retrying
+Prometheus snapshot with no tolerance for the inherent latency of Prometheus's own alerting pipeline
+(metric scrape interval + rule evaluation interval + the rule's `for` duration — ~33-63s in this
+fixture). This is a **new, distinct bug class from #2018**: an absence of a candidate at correlation
+time, not a misranking of candidates that do exist. #2021's own original triage had already flagged
+the alternative not chosen at the time ("gate the cluster-scoped fallback out of the automatic/
+interactive investigation path entirely, pending a product decision") — #2027/#2028 is the evidence
+that deferred decision needs resolving now.
+
+### Correction: the effective margin is larger and more variable than ~33-63s
+
+Three additional live-cluster-verified reproductions (one follow-up, two from QE, all re-checked
+directly against `prometheus-k8s`'s historical `ALERTS` series on 2026-08-09) show the ~33-63s
+figure above is not a reliable upper bound:
+
+| Case | Margin between the resource's own alert firing and RR creation | Outcome |
+|---|---|---|
+| Original (`rr-9307edea5938-57afb3e7`) | negative (alert didn't exist yet) | misattributed |
+| `rr-a435f12273dd-6779aee4` | **+45s** (alert already firing) | **misattributed** |
+| QE: `rr-00dd9198c6a5-89a9e536` / `rr-e2d75f86f062-7422e2e3` | negative (alert pending/firing 33-63s *after* RR creation) | misattributed |
+| `rr-003721461ed4-ae9f674f` (correctly-attributed RR from the same test run, for contrast) | **+165s** | correctly attributed to `KubePodCrashLooping` |
+
+A 45-second head start on the resource's own alert was **not enough**; roughly 165 seconds was. AF
+queries Thanos Querier (`thanos-querier.openshift-monitoring.svc:9091`), not Prometheus directly, for
+both Tier 1 (`GetAlerts`) and Tier 1.5 (`GetRules`) — how much of this larger, variable margin is the
+underlying rule's own evaluation latency versus additional lag in Thanos's alert/rule federation view
+has not been isolated. The practical conclusion holds regardless: the safe margin is meaningfully
+larger than a single rule's `for:` duration and is not a fixed constant, which only strengthens the
+case against Option 2 below (bounded wait) and for Option 4 (surface ambiguity, ask the user).
+
+This is also confirmed broader than the original report, per QE's two follow-up reproductions:
+- **Not model-specific**: reproduced under `claude-sonnet-4-6` in addition to the original
+  `claude-sonnet-5` evidence.
+- **Not fixture-specific**: reproduced against the `memory-eater`/OOMKilled fixture in addition to
+  the original `worker`/bad-release-command fixture — same `severity_source: cluster_firing_alert`
+  mechanism, different underlying fault type.
+- Separately worth flagging (not this decision's scope): the two contract-compliance E2E specs that
+  hit this didn't fail, because they only assert an investigation started against the right resource,
+  not that the attributed alert/severity was correct — a real user hitting this gets a
+  plausible-looking but factually wrong RCA with no visible failure signal today.
+
+### Options considered
+
+| # | Option | Why superseded |
+|---|---|---|
+| 1 | Gate cluster-scoped-only matches as unconditionally insufficient (fail through Tier 1.5/2/2.5 → `ErrSeverityUndetermined`) | Would need to be ripped out once a planned (not-yet-scoped) proper cluster-scoped-alert-handling feature ships — a throwaway patch, not a durable mechanism |
+| 2 | Bounded retry/wait in Tier 1 before accepting a cluster-scoped-only match | Adds latency to every cluster-scoped-only case (not just buggy ones); the observed gap is larger and more variable than first measured (45s insufficient, ~165s sufficient in live reproductions) — too large and unpredictable for a cheap bounded wait to reliably close |
+| 3 | Confidence-score the match tiers, route low-confidence to the existing `ManualReviewRequired`/`HumanReviewReason` mechanism | Correct direction, but discovery happens too late — a *different* human (a reviewer, asynchronously) resolves the ambiguity instead of the actual user who is live, mid-conversation, right now |
+| 4 | **Chosen**: surface the ambiguity back through the tool result to the calling agent, in the same conversational turn, and instruct it to ask the live user for clarification | Reuses the existing conversational session (no new synchronous-pause plumbing); asks the person who actually has the context, in real time; naturally extensible as future correlation signals are added |
+
+Key clarifying facts established during discussion:
+- The decision is made by deterministic Go code (`bestOverallMatch`), not an LLM — there is nothing
+  a smarter model could have done differently; the ambiguity must be surfaced structurally.
+- The **signal-initiated path** (Alertmanager → Gateway → RO) is out of scope: Gateway already
+  rejects cluster-scoped alerts outright today, so this race cannot manifest there.
+- Existing precedent for "the caller supplies a definitive signal identity instead of letting
+  Triager guess" already exists: `CreateRRArgs.SignalNameOverride`
+  (`pkg/apifrontend/tools/af_create_rr.go`), used today by `kubernaut_investigate_alert`. The
+  re-call-with-confirmation flow below extends this pattern rather than inventing a parallel one.
+
+## Decision
+
+1. `severity.Triager`/`bestOverallMatch` gains an explicit confidence notion per tier (the
+   `TriageResult.Confidence float64` field already exists but is currently only populated by the
+   Tier 2.5 LLM path) — resource-scoped ≈ high, namespace-scoped ≈ medium, cluster-scoped-with-zero-
+   correlation ≈ low/ambiguous.
+2. When Tier 1's *only* candidate is cluster-scoped (no resource/namespace-scoped candidate found at
+   all), `Triage()`/`HandleCreateRR` does **not** silently write that candidate into the RR's
+   `severity`/`signalName` as fact. It returns a structured "ambiguous — needs clarification" result
+   — same shape as #2022/#2025's `Managed: false`/`ErrResourceNotManaged` and #2023/#2047's
+   grounding-guard pattern (a typed signal, not a generic error), naming the weak candidate(s) found
+   so the result is informative.
+3. `kubernaut_investigate`/`kubernaut_remediate`/`kubernaut_investigate_alert`'s tool result surfaces
+   this to the agent (no RR created yet). `prompt.txt` gains a new instruction: when severity/signal
+   correlation comes back ambiguous, the agent MUST ask the user to confirm/clarify before
+   proceeding — mirroring the dual harness-signal + prompt-instruction pattern already built for
+   #2023/#2047 — never silently pick for them, never silently drop the ambiguity.
+4. Once the user answers, the agent re-calls the tool with an explicit confirmation carried through
+   (a `confirmed_signal_name` field on each tool's Args, mirroring the existing `SignalNameOverride`
+   mechanism), and Tier 1's ambiguity check is bypassed for that explicit, user-confirmed call —
+   fail-closed if the confirmed name does not exactly match the candidate that was surfaced.
+
+### Scope boundaries
+
+- **In scope**: `kubernaut_investigate`, `kubernaut_remediate`, `kubernaut_investigate_alert` —
+  agent-initiated paths where a live conversational session exists.
+- **Out of scope**: the fully automatic signal-initiated path (Alertmanager → Gateway → RO). Gateway
+  already rejects cluster-scoped signals before they ever reach RO, so this specific race cannot
+  occur there today.
+- **Out of scope**: the broader "how should Kubernaut properly support cluster-scoped alerts as
+  legitimate correlation evidence" feature — tracked as a separate, not-yet-scoped issue. This
+  design is intentionally durable against that future work: it extends via new ways to *earn*
+  confidence (e.g. a future resource-to-cluster-component dependency check), not via removing a
+  hardcoded gate.
+
+### Preliminary FedRAMP control mapping
+
+| Control | Application |
+|---|---|
+| SI-10 (Information Input Validation) | A correlation with zero verified relationship to the target resource is no longer accepted as validated input to severity/signal attribution |
+| AU-3 / AU-12 (Audit Content / Generation) | The RR's `signalName`/`severity` — which becomes part of the permanent audit trail once created — will no longer misattribute an investigation to an unrelated alert; an ambiguous outcome is now explicitly recorded and resolved by the user, not silently guessed |
+| AC-6 (Least Privilege) / CM-3 | Mirrors #2019's principle: a decision presented-but-unconfirmed (here, a *candidate* signal identity) must never be treated as user-approved fact |
+
+## Next Steps
+
+- [x] Write the ephemeral implementation plan: exact field/type changes to `TriageResult`,
+      `CreateRRArgs`, `InvestigateMCPArgs`/`RemediateArgs`/`InvestigateAlertArgs`, the three tool
+      Result types, and the new `prompt.txt` instruction — with a Wiring Manifest table and
+      confidence score, per project methodology, before implementation begins.
+- [x] TDD RED/GREEN/REFACTOR per the pyramid invariant (UT for `bestOverallMatch` confidence + the
+      ambiguous-result path; IT for the full tool-call → ambiguous-result → re-call-with-confirmation
+      round trip).
+- [x] Port to `main` (this document, Issue #2028).
+
+### Implementation results — `release/v1.5` (2026-08-09)
+
+All Go-side changes and the `prompt.txt` Behavioral Constraint 7 described above were implemented
+on branch `fix/2022-af-scope-validation` (same branch as #2022/#2023/PR #2026, per the
+resource-constraint decision to consolidate into one PR).
+
+**Test blast-radius note**: `defaultTestTriager()` — a shared fixture used by ~46 pre-existing,
+unrelated test cases across 7 files to get *any* successful (non-ambiguous) `Triager` result — was
+reworked to accept `(namespace, kind, name string)` and return a resource-scoped alert with a
+verified relationship to that specific target, so it continues to resolve confidently under the new
+ambiguity gate. A separate `ambiguousTestTriager()` (cluster-scoped-only, no verified relationship)
+was introduced for the tests that specifically exercise DD-AF-012's ambiguous path. All ~46
+call sites were updated to pass the target's own `namespace`/`kind`/`name`; no test behavior outside
+the new ambiguity assertions changed.
+
+### Implementation results — `main` port (2026-08-09, Issue #2028)
+
+Ported onto branch `fix/2025-2047-2028-2030-af-main-port` (bundled with the `main`-tracking clones
+of #2022/#2023/#2029 per the same resource-constraint consolidation decision). `main`'s
+`severity`/`tools` packages structurally match `release/v1.5` closely enough that the port is a
+direct application of the same design, with `main`-specific adjustments limited to: `ToolDeps`
+also carries a `ScopeChecker` (from the #2025 port, bundled in the same branch/PR) and
+`InvestigateConfig`'s `resolveInvestigationRR`/`createRRForInvestigation` return the ambiguous
+result as an explicit third return value rather than overloading the error return, to avoid
+conflating "ambiguous, needs clarification" with a genuine Go error at the call site.
+
+**Wiring Manifest — final state (`main`):**
+
+| Component | Production Entry Point | Wiring Code Location | Test ID | Result |
+|---|---|---|---|---|
+| `TriageResult.Ambiguous` / `AmbiguousSeverityError` | `severity.Triager.Triage` (called from `HandleCreateRR`) | [pkg/apifrontend/severity/triage.go](../../../pkg/apifrontend/severity/triage.go) | `UT-AF-2027-001`..`002`, `UT-AF-1369-003/2027-001a` | ✅ PASS |
+| `CreateRRResult.Ambiguous` translation | `HandleCreateRR` | [pkg/apifrontend/tools/af_create_rr.go](../../../pkg/apifrontend/tools/af_create_rr.go) | `UT-AF-2028-004`, `004b` | ✅ PASS |
+| `RemediateResult.Ambiguous` + `confirmed_signal_name` round trip | `kubernaut_remediate` tool call | [pkg/apifrontend/tools/ka_remediate.go](../../../pkg/apifrontend/tools/ka_remediate.go), wired in `agent/root.go`/`handler/mcp_bridge.go` | `UT-AF-2028-005` | ✅ PASS |
+| `InvestigateMCPResult.Ambiguous` + `confirmed_signal_name` round trip | `kubernaut_investigate` tool call | [pkg/apifrontend/tools/ka_investigate_mcp.go](../../../pkg/apifrontend/tools/ka_investigate_mcp.go), wired in `agent/root.go` and `handler/mcp_bridge.go` | `UT-AF-2028-006` | ✅ PASS |
+| `InvestigateAlertResult.Ambiguous` | `kubernaut_investigate_alert` tool call | [pkg/apifrontend/tools/af_investigate_alert.go](../../../pkg/apifrontend/tools/af_investigate_alert.go), wired in `agent/root.go` | `UT-AF-2028-007` | ✅ PASS |
+| `EventSeverityTriageAmbiguous` audit emission | `Triager.Triage` | [pkg/apifrontend/audit/audit.go](../../../pkg/apifrontend/audit/audit.go) constant + emission in `triage.go` | `UT-AF-2027-008` | ✅ PASS |
+| Behavioral Constraint 7 prompt text | `BuildInstruction` (embeds `prompt.txt`) | [pkg/apifrontend/agent/prompt.txt](../../../pkg/apifrontend/agent/prompt.txt) | `UT-AF-2028-010`..`014` | ✅ PASS |
+
+CHECKPOINT W verified: all seven rows above have a production caller (confirmed via `grep` against
+`cmd/`/`agent/root.go`/`handler/mcp_bridge.go`, none of it new wiring — this change modifies
+existing Args/Result shapes on already-wired tools) and a passing UT proving the field is reachable
+through that production entry point, not just via direct Go function calls in unit tests.
+
+**Full validation**: `go build ./...`, `go vet ./...`, and the full `pkg/apifrontend/...`/
+`cmd/apifrontend/...` test suites (agent, audit, handler, severity, tools, and all other
+subpackages) pass with zero failures.
+
+## References
+
+- **Issue**: [#2027](https://github.com/jordigilh/kubernaut/issues/2027) (`release/v1.5`),
+  [#2028](https://github.com/jordigilh/kubernaut/issues/2028) (`main`), comment with the triage
+  summary: [issuecomment-5229204437](https://github.com/jordigilh/kubernaut/issues/2027#issuecomment-5229204437)

--- a/docs/testing/2025/TEST_PLAN.md
+++ b/docs/testing/2025/TEST_PLAN.md
@@ -1,0 +1,486 @@
+# Test Plan: `main`-Branch Port of AF Scope Validation, Content Grounding, Ambiguous Severity Correlation, and AA Session-Desync Fixes
+
+**Issues** (all `main`-tracking clones of fixes implemented and merged on `release/v1.5`
+via [PR #2026](https://github.com/jordigilh/kubernaut/pull/2026)):
+- [#2025](https://github.com/jordigilh/kubernaut/issues/2025) — clone of
+  [#2022](https://github.com/jordigilh/kubernaut/issues/2022) (AF tool-layer scope validation)
+- [#2047](https://github.com/jordigilh/kubernaut/issues/2047) — clone of
+  [#2023](https://github.com/jordigilh/kubernaut/issues/2023) (content-grounding guard)
+- [#2028](https://github.com/jordigilh/kubernaut/issues/2028) — clone of
+  [#2027](https://github.com/jordigilh/kubernaut/issues/2027) (confidence-gated severity correlation,
+  [DD-AF-012](../../architecture/decisions/DD-AF-012-confidence-gated-severity-correlation.md))
+- [#2030](https://github.com/jordigilh/kubernaut/issues/2030) — clone of
+  [#2029](https://github.com/jordigilh/kubernaut/issues/2029) (AA reconnect/takeover session desync),
+  split into **Part A** (bounded retry on CRD schema rejection) and **Part B** (AA-side session
+  adoption)
+
+**Authority**: [ADR-053](../../architecture/decisions/ADR-053-resource-scope-management.md)
+(Resource Scope Management — Addendum "Point 3"),
+[DD-AF-012](../../architecture/decisions/DD-AF-012-confidence-gated-severity-correlation.md)
+**Branch**: `fix/2025-2047-2028-2030-af-main-port` (off `main`)
+**Created**: 2026-08-09
+**Status**: Implementation complete — build/vet/lint/full test suites green
+
+---
+
+## 1. Purpose and Scope
+
+`main` (v1.6) diverged structurally from `release/v1.5` after these four fixes were designed and
+implemented there (PR #2026). This plan documents the **adaptation**, not a fresh design: the root
+causes, decisions, and FedRAMP control mappings are unchanged from the `v1.5` originals — see
+[ADR-053 Addendum](../../architecture/decisions/ADR-053-resource-scope-management.md#addendum-point-3--af-tool-layer-validation-issue-2025-august-2026)
+and [DD-AF-012](../../architecture/decisions/DD-AF-012-confidence-gated-severity-correlation.md) for
+that authoritative content. This document covers only the `main`-specific **test-scenario
+inventory, Wiring Manifest, and coverage verification** — grounded directly in the test IDs and
+production call sites that exist in this branch's diff, not carried over unchecked from the `v1.5`
+test plan (`docs/testing/2022/TEST_PLAN.md` on `release/v1.5`).
+
+**Per the user's consolidation decision, all four fixes are bundled into a single PR to `main`** —
+resource-constrained the same way `release/v1.5`'s #2022/#2023/#2027 were bundled into PR #2026.
+
+### Structural divergence requiring adaptation (not a straight port)
+
+| Area | `release/v1.5` | `main` | Adaptation |
+|---|---|---|---|
+| `ScopeChecker.IsManagedResource` | `(ctx, namespace, kind, name string)` | `(ctx, scope.ResourceIdentity{ClusterID, Namespace, Kind, Name})` | `main` already has fleet/multi-cluster support (ADR-065); the checker signature already carries `ClusterID`. `checkRRScope` takes a `scope.ResourceIdentity` directly — no new struct needed. |
+| Scope-checker construction | Bare `scope.NewManager(typedClient)` | `fleet.NewScopeChecker(scope.NewManager(...), cfg.Fleet, logger)` | `main`'s factory decides local-only vs. `fleet.FederatedScopeChecker` wrapping internally — AF's tool layer is Fleet-aware for free, no AF-side federation code needed. |
+| Tool dependency grouping | Individual fields on each tool's own config struct | Shared `ToolDeps` struct (`Client`, `DynClient`, `ControllerNS`, `Triager`, `Auditor`, `ScopeChecker`) consumed by `HandleCreateRR` | `ScopeChecker` is a single `ToolDeps` field; all three RR-creating tools (`kubernaut_remediate`, `kubernaut_investigate_alert`, `kubernaut_investigate`'s new-RR branch) already funnel through `HandleCreateRR`, so **one** gate covers all three — simpler than `v1.5`'s three separate call sites. |
+| AA reconnect/takeover fix (#2029/#2030) | Not present on `v1.5` (this is a `main`-only defect — `v1.5`'s AA session-polling architecture differs) | New fix, not a port | No `v1.5` original exists for this piece; implemented directly against `main`'s `pkg/aianalysis/handlers/investigating.go` and `internal/controller/aianalysis/phase_handlers.go`. Included in this same branch/PR per the single-PR consolidation decision. |
+
+---
+
+## 2. Issue #2025 (clone of #2022): AF Tool-Layer Scope Validation
+
+### 2.1 Fix Summary
+
+`HandleCreateRR` (`pkg/apifrontend/tools/af_create_rr.go`) — the single choke point all three
+RR-creating tools (`kubernaut_remediate`, `kubernaut_investigate_alert`, and
+`kubernaut_investigate`'s new-RR/`createRRForInvestigation` branch) already call — now checks
+`ToolDeps.ScopeChecker.IsManagedResource()` before the `Triager` call and RR object creation that
+follow, rejecting out-of-scope targets with `ErrResourceNotManaged` and no RR created. The
+`rr_id` (takeover) path on `kubernaut_investigate` is deliberately **not** re-checked: that RR was
+already scope-checked at its own creation time.
+
+`checkRRScope` (`pkg/apifrontend/tools/scope_helpers.go`) is the shared helper: nil-checker
+gracefully degrades to always-managed (backward compat); a checker error fails closed
+(managed=false), mirroring RO's `CheckUnmanagedResource`; on rejection it emits
+`EventRRScopeRejected` (AU-3/AU-12) and returns a message mirroring RO's own block wording.
+
+Wired at startup by `cmd/apifrontend/backend_deps.go#buildScopeCheckerDeps`, which constructs
+`fleet.NewScopeChecker(scope.NewManager(typedClient), cfg.Fleet, logger)` and degrades to a nil
+`ScopeChecker` (scope validation skipped) when the K8s typed client is unavailable.
+
+**Correction during this port** (CHECKPOINT W wiring audit): an earlier draft of this port carried
+over `v1.5`'s `ContextWithScopeChecker`/`ScopeCheckerFromContext` context-injection helpers, since
+`v1.5`'s `kubernaut_remediate`/`kubernaut_investigate` threaded the checker via context. On `main`,
+all three tools already receive `ScopeChecker` as a plain `ToolDeps`/config struct field (the same
+mechanism `Triager`/`Auditor` already use) — the context-injection helpers had **zero production
+callers**, only their own now-deleted unit test. Removed per the Pyramid Invariant ("no component in
+`pkg/` without a corresponding production caller") rather than shipped as dead code; see Section 6.
+
+### 2.2 FedRAMP Control Mapping
+
+| Control | Application |
+|---|---|
+| AC-6 (Least Privilege) | AF declines to exercise its elevated CRD-creation capability for resources outside declared management scope. |
+| SI-10 (Information Input Validation) | Target namespace/kind/name (as a `scope.ResourceIdentity`) validated against declared scope before RR creation. |
+| AU-3 / AU-12 (Audit Content / Generation) | `EventRRScopeRejected` captures namespace/kind/name/user for every rejected attempt. |
+| SI-11 (Error Handling) | Rejection returns `ErrResourceNotManaged` + explanatory message instead of a misleading empty/silent session. |
+
+### 2.3 Test Scenario Inventory
+
+| ID | Tier | Business-Level Behavior Description | Control | Test File |
+|---|---|---|---|---|
+| UT-AF-2025-001 | Unit | `HandleCreateRR` rejects RR creation for an unmanaged resource, returns `ErrResourceNotManaged` | AC-6, SI-10, SI-11 | `pkg/apifrontend/tools/af_create_rr_test.go` |
+| UT-AF-2025-002 | Unit | No RR is created for an unmanaged resource (verified via list, not just the error) | SI-11 | `pkg/apifrontend/tools/af_create_rr_test.go` |
+| UT-AF-2025-003 | Unit | A managed resource proceeds to RR creation | AC-6, SI-10 | `pkg/apifrontend/tools/af_create_rr_test.go` |
+| UT-AF-2025-004 | Unit | Fails closed (rejects) when the scope checker itself errors | SI-11, fail-closed | `pkg/apifrontend/tools/af_create_rr_test.go` |
+| UT-AF-2025-005 | Unit | Skips scope validation (backward compat) when `ScopeChecker` is nil | Backward compat | `pkg/apifrontend/tools/af_create_rr_test.go` |
+| UT-AF-2025-006 | Unit | Emits `EventRRScopeRejected` with namespace/kind/name/user on rejection | AU-3, AU-12 | `pkg/apifrontend/tools/af_create_rr_test.go` |
+| UT-AF-2025-020 | Unit | `kubernaut_investigate_alert` rejects an unmanaged target before RR creation (proves `InvestigateAlertConfig.ScopeChecker` threads through to `HandleCreateRR`) | AC-6, SI-10, SI-11 | `pkg/apifrontend/tools/af_investigate_alert_test.go` |
+| UT-AF-2025-021 | Unit | `kubernaut_investigate_alert` allows RR creation for a managed target | AC-6, SI-10 | `pkg/apifrontend/tools/af_investigate_alert_test.go` |
+| UT-AF-2025-030 | Unit | `kubernaut_remediate` rejects an unmanaged target before RR creation | AC-6, SI-10, SI-11 | `pkg/apifrontend/tools/ka_remediate_test.go` |
+| UT-AF-2025-031 | Unit | `kubernaut_remediate` allows RR creation for a managed target | AC-6, SI-10 | `pkg/apifrontend/tools/ka_remediate_test.go` |
+| UT-AF-2025-032 | Unit | `kubernaut_remediate`'s `rr_id` (dedup lookup) path is not scope-checked | Regression guard | `pkg/apifrontend/tools/ka_remediate_test.go` |
+| UT-AF-2025-050 | Unit | `kubernaut_investigate`'s new-RR (`ResolveInvestigationRR`) path rejects an unmanaged target investigation | AC-6, SI-10, SI-11 | `pkg/apifrontend/tools/ka_investigate_mcp_test.go` |
+| UT-AF-2025-051 | Unit | `kubernaut_investigate`'s new-RR path allows a managed target investigation | AC-6, SI-10 | `pkg/apifrontend/tools/ka_investigate_mcp_test.go` |
+| UT-AF-2025-052 | Unit | `kubernaut_investigate`'s `rr_id` (takeover) path is not scope-checked | Regression guard | `pkg/apifrontend/tools/ka_investigate_mcp_test.go` |
+
+### Tier Coverage Rationale
+
+- **UT** proves the scope-gate logic once at its single choke point (`HandleCreateRR`,
+  UT-AF-2025-001..006) and proves each of the three tools' configs actually thread `ScopeChecker`
+  through to that choke point (UT-AF-2025-020/021, -030/031/032, -050/051/052) — this is a strictly
+  simpler wiring shape than `v1.5`'s three independent call sites, since `main`'s `HandleCreateRR` is
+  the one place the branching logic lives.
+- **No new IT was added** for this fix on `main` (unlike `v1.5`'s `IT-AF-2022-006/007` through the
+  raw MCP bridge dispatch path): `main`'s existing `pkg/apifrontend/handler` IT suite already
+  exercises `kubernaut_investigate` through the real MCP bridge dispatch chain for other fixes in
+  this same bundle (see `IT-AF-2028-*`-equivalent flows below); adding a scope-specific duplicate of
+  that same dispatch path would not exercise any code the UT tier + existing IT coverage doesn't
+  already reach. CHECKPOINT W's grep evidence (Section 6) is the wiring proof for this fix
+  specifically.
+- **E2E**: not added, same rationale as `v1.5` — this is a pre-CRD-creation validation gate; the
+  existing Gateway/RO E2E suites already prove the end-to-end scope-management journey.
+
+### 2.4 Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | Test ID |
+|---|---|---|---|
+| `checkRRScope` | Called from `HandleCreateRR` | `pkg/apifrontend/tools/scope_helpers.go` | UT-AF-2025-001..006 |
+| `ToolDeps.ScopeChecker` → `HandleCreateRR` | All three RR-creating tools funnel here | `pkg/apifrontend/tools/af_create_rr.go` | UT-AF-2025-001..006 |
+| `InvestigateAlertConfig.ScopeChecker` | `kubernaut_investigate_alert` tool constructor | `pkg/apifrontend/agent/root.go` (`NewInvestigateAlertTool`, `ScopeChecker: cfg.ScopeChecker`) | UT-AF-2025-020, -021 |
+| `NewRemediateTool(..., cfg.ScopeChecker)` | `kubernaut_remediate` tool constructor | `pkg/apifrontend/agent/root.go` | UT-AF-2025-030..032 |
+| `InvestigateConfig.ScopeChecker` | `kubernaut_investigate` tool constructor (A2A path) + raw MCP bridge | `pkg/apifrontend/agent/root.go`, `pkg/apifrontend/handler/mcp_bridge.go` | UT-AF-2025-050..052 |
+| `AgentConfig.ScopeChecker` / `MCPBridgeConfig.ScopeChecker` | Both AF transports (A2A/ADK + raw MCP bridge) | `cmd/apifrontend/mcp_a2a_handlers.go` (`ScopeChecker: d.Backends.ScopeChecker`, two call sites) | Covered transitively by all rows above |
+| `fleet.NewScopeChecker(scope.NewManager(...), cfg.Fleet, logger)` construction | AF startup | `cmd/apifrontend/backend_deps.go#buildScopeCheckerDeps` | Covered transitively — no direct UT (thin wiring call, no branching logic of its own beyond the nil-client degrade already covered by the tools-layer nil-checker tests) |
+| `EventRRScopeRejected` | Emitted by `checkRRScope` on rejection | `pkg/apifrontend/audit/audit.go` (event type) | UT-AF-2025-006 |
+
+---
+
+## 3. Issue #2047 (clone of #2023): Content-Grounding Guard
+
+### 3.1 Fix Summary
+
+Ports `v1.5`'s Stage 2 (harness-enforced grounding guard) unchanged in design: `enforceGroundingGuard`
+(`pkg/apifrontend/agent/phase_guard.go`) extends the existing, already-wired `newPhaseGuard`
+`before`/`after` callbacks (no new callback registration). `after` records, on every
+`kubernaut_investigate` call (success or failure), whether the response carried real, groundable RCA
+content into `session.StateKeyGroundedContentAvailable`. `before` intercepts
+`kubernaut_present_decision` specifically: when the state key is `false` (including the fail-safe
+default when never set), it overwrites `args["summary"]`, deletes `args["rca"]`, and forces
+`args["options"] = []` with a fixed, honest `noGroundedContentSummary` payload, then returns
+`(nil, nil)` so the call proceeds — never blocking the AU-3 artifact mandate.
+
+`prompt.txt` gained Behavioral Constraint 6 (grounding) telling the model itself never to fabricate
+ungrounded findings, plus a corrected terminal-phase list (adds `TimedOut`/`Skipped`, matching
+`tools.IsTerminalPhase`) and consistent `kubernaut_present_decision` naming throughout.
+
+**Scope decision for this port**: `v1.5`'s Stage 1 (opaque-error removal,
+`ErrCodeNoConversationContext`) and Stage 3 (structured RCA pass-through + shadow-agent alignment
+verdict, commit `3be4330cb`) were evaluated and **excluded from this port** — Stage 1 addresses a KA
+error-code granularity issue orthogonal to the grounding guard itself, and Stage 3 is a hardening
+pass beyond the original QE report's scope. Both remain available to port separately if `main` needs
+them; excluding them keeps this bundle's blast radius to the same four issues in its title.
+
+### 3.2 FedRAMP Control Mapping
+
+| Control | Application |
+|---|---|
+| SI-10 / SI-11 | `present_decision` content cannot be fabricated when no real investigation content exists; overridden to an honest "no data" payload instead of erroring or silently guessing. |
+| AU-3 (Audit Content) | The artifact-mandate is preserved — `kubernaut_present_decision` always executes and always emits a truthful `investigation_summary`, never a fabricated one. |
+
+### 3.3 Test Scenario Inventory
+
+| ID | Tier | Business-Level Behavior Description | Control | Test File |
+|---|---|---|---|---|
+| UT-AF-2047-001 | Unit | Prompt instructs the model to ground summary/rca claims in actual tool responses | AU-3 (model contract) | `pkg/apifrontend/agent/prompt_test.go` |
+| UT-AF-2047-002 | Unit | Prompt mandates stating plainly when no investigation content is available | AU-3 | `pkg/apifrontend/agent/prompt_test.go` |
+| UT-AF-2047-003 | Unit | Prompt tells the model not to rely on the harness backstop | AU-3 | `pkg/apifrontend/agent/prompt_test.go` |
+| UT-AF-2047-004 | Unit | Prompt reports Completed/Failed/Cancelled/TimedOut/Skipped as terminal phases for Phase 4 reporting | Accuracy fix | `pkg/apifrontend/agent/prompt_test.go` |
+| UT-AF-2047-005 | Unit | `present_decision` content overridden when `kubernaut_investigate` was never called (fail-closed default) | SI-10, SI-11 | `pkg/apifrontend/agent/phase_guard_test.go` |
+| UT-AF-2047-006 | Unit | Overridden when the prior investigate call was rejected for scope (`status: unmanaged`, #2025) | SI-10, SI-11 | `pkg/apifrontend/agent/phase_guard_test.go` |
+| UT-AF-2047-007 | Unit | Overridden when the prior investigate call returned a generic tool error | SI-10, SI-11 | `pkg/apifrontend/agent/phase_guard_test.go` |
+| UT-AF-2047-008 | Unit | Overridden when the prior investigate call returned `status: session_active` | SI-10, SI-11 | `pkg/apifrontend/agent/phase_guard_test.go` |
+| UT-AF-2047-009 | Unit | NOT overridden after a successful investigate with a real `summary` (negative case) | SI-10 | `pkg/apifrontend/agent/phase_guard_test.go` |
+| UT-AF-2047-010 | Unit | NOT overridden after a successful investigate with only an `rca` payload (no `summary`) | SI-10 | `pkg/apifrontend/agent/phase_guard_test.go` |
+| UT-AF-2047-011 | Unit | Handles a `nil` args map without panicking | SI-11 (defensive) | `pkg/apifrontend/agent/phase_guard_test.go` |
+| UT-AF-2047-012 | Unit | `present_decision` is never hard-rejected by this guard, even when overriding content | AU-3 (artifact mandate) | `pkg/apifrontend/agent/phase_guard_test.go` |
+| IT-AF-2047-013 | Integration | Grounded state correctly flips to `false` after a second, failed investigate call following an earlier successful one — no stale `grounded=true` leak across investigations in the same session | SI-10, SI-11 | `pkg/apifrontend/agent/phase_guard_test.go` |
+
+### 3.4 Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | Test ID |
+|---|---|---|---|
+| `enforceGroundingGuard` | `newPhaseGuard`'s `before` (`BeforeToolCallback`) — pre-existing registration, extended | `pkg/apifrontend/agent/phase_guard.go`, registered in `pkg/apifrontend/agent/root.go` | UT-AF-2047-005..012 |
+| `investigateHasGroundedContent` / `session.StateKeyGroundedContentAvailable` | `newPhaseGuard`'s `after` (`AfterToolCallback`) — pre-existing registration, extended | `pkg/apifrontend/agent/phase_guard.go`, registered in `pkg/apifrontend/agent/root.go` | IT-AF-2047-013 |
+| `session.StateKeyGroundedContentAvailable` constant | Shared session-state key | `pkg/apifrontend/session/consent.go` | Covered transitively |
+| Behavioral Constraint 6 prompt text | `BuildInstruction` (embeds `prompt.txt`) | `pkg/apifrontend/agent/prompt.txt` | UT-AF-2047-001..004 |
+
+**No new wiring points**: `newPhaseGuard` was already registered as both a `BeforeToolCallback` and
+`AfterToolCallback` on the LLM agent before this fix; this fix extends the existing closures with
+new branches — confirmed via CHECKPOINT W (Section 6), no new callback registration required.
+
+---
+
+## 4. Issue #2028 (clone of #2027): Confidence-Gated Severity Correlation (DD-AF-012)
+
+### 4.1 Fix Summary
+
+`bestOverallMatch` (`pkg/apifrontend/severity/triage.go`) marks a cluster-tier-only match
+`Ambiguous: true` (no verified relationship to the target — resource/namespace-tier matches are
+never ambiguous). `Triage()` returns `*AmbiguousSeverityError` for an unconfirmed ambiguous result
+instead of silently trusting it; a matching `ConfirmedSignalName` bypasses the gate (fail-closed for
+a different candidate name).
+
+`HandleCreateRR` translates that error into a normal (non-error) `CreateRRResult{Ambiguous: true,
+CandidateSignalName, CandidateSeverity}` — a typed signal mirroring #2025's `Managed: false` shape.
+All three RR-creating tools gained the round trip: `kubernaut_remediate`
+(`RemediateArgs.ConfirmedSignalName` → `RemediateResult.Ambiguous/...`), `kubernaut_investigate`
+(`InvestigateMCPArgs.ConfirmedSignalName` → `InvestigateMCPResult.Ambiguous/...`, threaded through
+`resolveInvestigationRR`'s three-value return so "ambiguous" is a distinct, non-error branch — a
+`main`-specific adaptation over `v1.5`'s two-value return, made explicitly to avoid conflating
+"needs clarification" with a genuine Go error), and `kubernaut_investigate_alert`
+(`InvestigateAlertResult.Ambiguous/...`, for the severity-only ambiguity case since the RR's
+`signalName` is already fixed by the user-supplied `alert_name`).
+
+`EventSeverityTriageAmbiguous` audits every ambiguous (unconfirmed) `Triage()` call.
+`prompt.txt` gained Behavioral Constraint 7: ask for confirmation, never guess or retry blindly,
+always close out via `kubernaut_present_decision` if no signal is confirmed.
+
+**Test blast-radius note**: `defaultTestTriager()` — used by dozens of pre-existing, unrelated test
+cases to obtain *any* successful (non-ambiguous) `Triager` result — was reworked to accept
+`(namespace, kind, name string)` and return a resource-scoped alert with a verified relationship to
+that specific target, so it continues to resolve confidently under the new ambiguity gate. A
+separate `ambiguousTestTriager()` (cluster-scoped-only, no verified relationship) was introduced for
+tests that specifically exercise the ambiguous path.
+
+### 4.2 FedRAMP Control Mapping
+
+| Control | Application |
+|---|---|
+| SI-10 | A correlation with zero verified relationship to the target resource is no longer accepted as validated input to severity/signal attribution. |
+| AU-3 / AU-12 | `EventSeverityTriageAmbiguous` records every ambiguous outcome; the RR's `signalName`/`severity` (permanent audit trail) is never misattributed to an unrelated alert. |
+| AC-6 / CM-3 | A candidate signal identity is never treated as user-approved fact until explicitly confirmed. |
+
+### 4.3 Test Scenario Inventory
+
+| ID | Tier | Business-Level Behavior Description | Control | Test File |
+|---|---|---|---|---|
+| UT-AF-2027-001 | Unit | Resource-/namespace-tier wins are never ambiguous, even when a cluster-scoped alert also exists | SI-10 | `pkg/apifrontend/severity/triage_test.go` |
+| UT-AF-2027-002 | Unit | `Triage()` returns `*AmbiguousSeverityError` with the candidate populated when ambiguous and unconfirmed | SI-10, SI-11 | `pkg/apifrontend/severity/triage_test.go` |
+| UT-AF-2027-003 | Unit | A matching `ConfirmedSignalName` bypasses the ambiguity gate; a different candidate does not (fail-closed) | AC-6, CM-3 | `pkg/apifrontend/severity/triage_test.go` |
+| UT-AF-2027-008 | Unit | `EventSeverityTriageAmbiguous` emitted exactly once per ambiguous (unconfirmed) `Triage()` call | AU-3, AU-12 | `pkg/apifrontend/severity/triage_test.go` |
+| UT-AF-1369-003 | Unit (regression) | Pre-existing test updated: cluster-scoped-only correlation surfaced as `*AmbiguousSeverityError`, not silently trusted | SI-10 | `pkg/apifrontend/severity/triage_test.go` |
+| UT-AF-2028-004 | Unit | `HandleCreateRR` translates `*AmbiguousSeverityError` into `CreateRRResult{Ambiguous: true}` with no Go error and no RR created | SI-11 | `pkg/apifrontend/tools/af_create_rr_test.go` |
+| UT-AF-2028-004b | Unit | A matching `ConfirmedAmbiguousSignalName` proceeds to RR creation | AC-6, CM-3 | `pkg/apifrontend/tools/af_create_rr_test.go` |
+| UT-AF-2028-005 | Unit | `kubernaut_remediate` surfaces `Ambiguous`/`CandidateSignalName`/`CandidateSeverity`, then proceeds once `confirmed_signal_name` matches | AC-6, SI-10, SI-11 | `pkg/apifrontend/tools/ka_remediate_test.go` |
+| UT-AF-2028-006 | Unit | `kubernaut_investigate` (A2A path) surfaces the same fields, then proceeds to RR creation and MCP session start once confirmed | AC-6, SI-10, SI-11 | `pkg/apifrontend/tools/ka_investigate_intent_test.go` |
+| UT-AF-2028-007 | Unit | `kubernaut_investigate_alert` surfaces the same fields for the severity-only ambiguity case | AC-6, SI-10, SI-11 | `pkg/apifrontend/tools/af_investigate_alert_test.go` |
+| UT-AF-2028-010 | Unit | Prompt instructs the model to ask the user before using an ambiguous candidate | AU-3 (model contract) | `pkg/apifrontend/agent/prompt_test.go` |
+| UT-AF-2028-011 | Unit | Prompt forbids guessing or silently filling in the confirmed signal | AC-6, CM-3 | `pkg/apifrontend/agent/prompt_test.go` |
+| UT-AF-2028-012 | Unit | Prompt forbids retrying the same ambiguous call without a confirmation | SI-11 | `pkg/apifrontend/agent/prompt_test.go` |
+| UT-AF-2028-013 | Unit | Prompt mandates a structured `kubernaut_present_decision` close-out when no signal is confirmed | AU-3 | `pkg/apifrontend/agent/prompt_test.go` |
+| UT-AF-2028-014 | Unit | Prompt does not leak internal issue numbers | Hygiene | `pkg/apifrontend/agent/prompt_test.go` |
+
+### 4.4 Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | Test ID |
+|---|---|---|---|
+| `TriageResult.Ambiguous` / `AmbiguousSeverityError` | `severity.Triager.Triage` (called from `HandleCreateRR`) | `pkg/apifrontend/severity/triage.go` | UT-AF-2027-001..003 |
+| `CreateRRResult.Ambiguous` translation | `HandleCreateRR` | `pkg/apifrontend/tools/af_create_rr.go` | UT-AF-2028-004, -004b |
+| `RemediateResult.Ambiguous` + `confirmed_signal_name` round trip | `kubernaut_remediate` tool call | `pkg/apifrontend/tools/ka_remediate.go`, wired in `agent/root.go` | UT-AF-2028-005 |
+| `InvestigateMCPResult.Ambiguous` + `confirmed_signal_name` round trip | `kubernaut_investigate` tool call | `pkg/apifrontend/tools/ka_investigate_mcp.go`, wired in `agent/root.go` and `handler/mcp_bridge.go` | UT-AF-2028-006 |
+| `InvestigateAlertResult.Ambiguous` | `kubernaut_investigate_alert` tool call | `pkg/apifrontend/tools/af_investigate_alert.go`, wired in `agent/root.go` | UT-AF-2028-007 |
+| `EventSeverityTriageAmbiguous` audit emission | `Triager.Triage` | `pkg/apifrontend/audit/audit.go` (constant), emission in `triage.go` | UT-AF-2027-008 |
+| Behavioral Constraint 7 prompt text | `BuildInstruction` (embeds `prompt.txt`) | `pkg/apifrontend/agent/prompt.txt` | UT-AF-2028-010..014 |
+
+**CHECKPOINT W**: this change modifies existing Args/Result shapes on tools already wired in
+production per Section 2.4's #2025 Wiring Manifest — no new construction call sites needed, only new
+fields/branches reachable through those same entry points.
+
+---
+
+## 5. Issue #2030 (clone of #2029): AA Reconnect/Takeover Session Desync
+
+Unlike Sections 2-4, this is not a straight port: `v1.5`'s AA session-polling architecture differs
+enough that no equivalent `v1.5` fix exists to port. The `main`-only defect was root-caused directly
+and split into a foundational fix plus two hardening parts, as agreed with the user.
+
+### 5.1 Foundational Fix: `InvestigationSessionID` vs. Driver-Lease `SessionID`
+
+**Root cause**: KA's `kubernaut_investigate` "start" action returns two distinct session IDs —
+`SessionID` (the MCP driver-lease ID, grants exclusive control, **not** pollable via REST) and
+`InvestigationSessionID` (the underlying investigation-analysis session, pollable via REST, where
+RCA/workflow results are stored). AF's `parseStartInvestigationResult`
+(`pkg/apifrontend/ka/mcp_sdk_client.go`) previously discarded `InvestigationSessionID` entirely.
+`finalizeInvestigationStart` (`pkg/apifrontend/tools/ka_investigate_mcp.go`) then correlated the
+driver-lease `SessionID` into `IS.Status.KACorrelationID` — causing AA's `handleSessionLost` to
+404-loop forever once the driver lease itself became unpollable, even while the real
+investigation-analysis session was healthy.
+
+**Fix**: `StartInvestigationResult` gained an `InvestigationSessionID` field, populated by
+`parseStartInvestigationResult`. `finalizeInvestigationStart` now correlates
+`result.InvestigationSessionID`, falling back to `result.SessionID` only when KA omits it
+(back-compat with older KA versions).
+
+| ID | Tier | Business-Level Behavior Description | Control | Test File |
+|---|---|---|---|---|
+| UT-AF-2029-101 | Unit | `UpdateCorrelation` uses `InvestigationSessionID` (pollable analysis session), not the driver-lease `SessionID`, when KA returns both | SI-4, AU-3 | `pkg/apifrontend/tools/ka_investigate_intent_test.go` |
+| UT-AF-2029-102 | Unit | `UpdateCorrelation` falls back to `SessionID` when KA omits `InvestigationSessionID` (back-compat) | Backward compat | `pkg/apifrontend/tools/ka_investigate_intent_test.go` |
+
+### 5.2 Part A: Bounded Retry on CRD Schema Rejection
+
+**Root cause**: `reconcileInvestigating`/`reconcileAnalyzing`
+(`internal/controller/aianalysis/phase_handlers.go`) previously fail-closed **forever** on the first
+`apierrors.IsInvalid` rejection of a `Status().Update()` call (e.g. the live cluster's installed CRD
+lagging behind a new enum value the Go source already defines) — `return ctrl.Result{}, nil`, no
+requeue, permanently abandoning the `AIAnalysis` with the controller never touching it again.
+
+**Fix**: `handleSchemaRejectedStatusUpdate` retries up to `handlers.MaxSchemaRejectionRetries` (5)
+times with backoff (`pkg/shared/backoff`, pre-existing package, reused unchanged), persisting the
+attempt count via `handlers.SchemaRejectionRetryCountAnnotation` — written through a plain
+`Update()` (not `Status().Update()`) since a CRD with `subresources.status` enabled silently drops
+`.status` diffs on a non-status `Update()`, so the annotation write still succeeds even while the
+status write is being rejected. Exceeding the cap escalates to a terminal `Failed` phase with valid
+enum values (`Reason=APIError`, `SubReason=TransientError`) via a fresh `Get()` + `Status().Update()`,
+instead of retrying forever. `clearSchemaRejectionRetryAnnotation` removes the counter once a
+`Status().Update()` succeeds again, preventing a stale count from a resolved episode from
+prematurely tripping the cap on a later, unrelated rejection episode.
+
+| ID | Tier | Business-Level Behavior Description | Control | Test File |
+|---|---|---|---|---|
+| UT-AA-2030-001 | Unit | `reconcileInvestigating` retries (not fail-closes) on `apierrors.IsInvalid` | SI-11 | `internal/controller/aianalysis/schema_rejection_retry_test.go` |
+| UT-AA-2030-002 | Unit | `reconcileAnalyzing` retries (not fail-closes) on `apierrors.IsInvalid` | SI-11 | `internal/controller/aianalysis/schema_rejection_retry_test.go` |
+| UT-AA-2030-003 | Unit | Retry-count annotation persists via a plain `Update()` across repeated rejections | SI-11, AU-3 | `internal/controller/aianalysis/schema_rejection_retry_test.go` |
+| UT-AA-2030-005 | Unit | Exceeding the retry cap escalates to a terminal `Failed` phase with valid enum values | SI-11, fail-safe | `internal/controller/aianalysis/schema_rejection_retry_test.go` |
+| UT-AA-2030-014 | Unit | A subsequent successful status write clears the leftover retry-count annotation | Regression guard | `internal/controller/aianalysis/schema_rejection_retry_test.go` |
+| IT-AA-2030-006 | Integration | Retries with backoff against a **real** apiserver (envtest, not the fake client's approximation), then escalates once the cap is exceeded | SI-11 | `test/integration/aianalysis/schemarejection/retry_test.go` |
+
+### 5.3 Part B: AA-Side Session Adoption
+
+**Root cause**: AF may correlate a newer, different KA session onto an RR's `InvestigationSession`
+after a reconnect/takeover (e.g. following a timeout), but AA's `InvestigatingHandler` had no
+mechanism to notice — it kept polling the stale session ID it originally tracked, and
+`ISEventPredicate` only triggered reconciliation on terminal-phase transitions, not on
+`KACorrelationID` changes alone, so the controller could miss a takeover's correlation write
+entirely until the next scheduled poll.
+
+**Fix**: `InvestigationSessionChecker.CorrelatedSessionID` (new interface method,
+`pkg/aianalysis/handlers/is_checker.go`) returns the KA session ID AF most recently correlated onto
+an RR's IS and whether it's still non-terminal. `tryAdoptCorrelatedSession`
+(`pkg/aianalysis/handlers/investigating.go`) checks this at two points: the general IS-mismatch check
+in `checkISMismatchAndCancel` (steady-state catch-up), and a race-closing re-check immediately before
+finalizing a terminal poll result (`checkCorrelatedSessionBeforeFinalizing`, called from both
+`handleSessionPollCompleted` and `handleSessionPollFailed`) — closing the race where AF's correlation
+write lands between the general mismatch check and a stale session's poll reporting
+completed/failed. `adoptCorrelatedSession` swaps the tracked session ID without incrementing
+`Generation` (this is catching up to work KA already ran, not starting a fresh investigation),
+emits `events.EventReasonSessionAdopted` (SI-4 observability), and records a durable
+`RecordAIAgentCall(ctx, analysis, "session_adopted", ...)` audit entry (AU-2/AU-3 traceability).
+`ISEventPredicate` was widened to also trigger on `KACorrelationID` changes alone (not just
+terminal-phase transitions), so the controller wakes promptly instead of waiting for the next
+scheduled poll.
+
+| ID | Tier | Business-Level Behavior Description | Control | Test File |
+|---|---|---|---|---|
+| UT-AA-2030-008 | Unit | `K8sInvestigationSessionChecker.CorrelatedSessionID` returns the correlated session ID and non-terminal status | SI-4 | `pkg/aianalysis/is_checker_correlated_session_test.go` |
+| UT-AA-2030-009 | Unit | General mismatch adoption: `hasIS && Interactive`, correlated ID differs → adopts | SI-4, AU-2/AU-3 | `pkg/aianalysis/investigating_session_adoption_test.go` |
+| UT-AA-2030-010 | Unit | Race-closing adoption in `handleSessionPollCompleted` | SI-4, AU-2/AU-3 | `pkg/aianalysis/investigating_session_adoption_test.go` |
+| UT-AA-2030-012 | Unit | Race-closing adoption in `handleSessionPollFailed` (symmetric to -010) | SI-4, AU-2/AU-3 | `pkg/aianalysis/investigating_session_adoption_test.go` |
+| UT-AA-2030-013 | Unit | `ISEventPredicate` passes Update events when only `KACorrelationID` changes (Phase stays non-terminal) | SI-4 | `internal/controller/aianalysis/predicates_test.go` |
+| UT-AA-2030-013b | Unit | `ISEventPredicate` drops Update events when `KACorrelationID` and `Phase` are both unchanged (no regression) | Regression guard | `internal/controller/aianalysis/predicates_test.go` |
+| UT-AA-2030-013c | Unit | Existing terminal-phase cases still pass when `KACorrelationID` is held at its zero value (no regression) | Regression guard | `internal/controller/aianalysis/predicates_test.go` |
+| IT-AA-2030-011 | Integration | Adopts a newly-correlated KA session instead of finalizing the stale one, waking promptly via the widened predicate — full controller reconcile loop against envtest | SI-4, AU-2/AU-3 | `test/integration/aianalysis/session_correlation_adoption_test.go` |
+
+### 5.4 FedRAMP Control Mapping (#2030)
+
+| Control | Application |
+|---|---|
+| SI-11 (Error Handling) | Part A: a transient CRD schema lag no longer permanently abandons an in-flight `AIAnalysis`; retries with backoff, escalates cleanly if truly unrecoverable. |
+| SI-4 (System Monitoring) | Part B: a session-correlation change is surfaced as an observable event (`EventReasonSessionAdopted`) and the controller wakes promptly (widened predicate) rather than silently drifting until the next scheduled poll. |
+| AU-2 / AU-3 (Audit Events / Content) | Part B: every adoption is paired with a durable `RecordAIAgentCall("session_adopted", ...)` record — the fact that a real, possibly-completed investigation was not discarded is traceable after the fact. |
+
+### 5.5 Wiring Manifest (#2030)
+
+| Component | Production Entry Point | Wiring Code Location | Test ID |
+|---|---|---|---|
+| `StartInvestigationResult.InvestigationSessionID` / `parseStartInvestigationResult` | `SDKMCPClient.StartInvestigation` | `pkg/apifrontend/ka/mcp_sdk_client.go` | UT-AF-2029-101, -102 |
+| `finalizeInvestigationStart` correlation fix | `HandleInvestigationMCPWithRegistry` | `pkg/apifrontend/tools/ka_investigate_mcp.go` | UT-AF-2029-101, -102 |
+| `handleSchemaRejectedStatusUpdate` / `clearSchemaRejectionRetryAnnotation` | `reconcileInvestigating`, `reconcileAnalyzing` | `internal/controller/aianalysis/phase_handlers.go` | UT-AA-2030-001..003, -005, -014; IT-AA-2030-006 |
+| `handlers.SchemaRejectionRetryCountAnnotation` / `MaxSchemaRejectionRetries` | Shared constants | `pkg/aianalysis/handlers/constants.go` | Covered transitively |
+| `InvestigationSessionChecker.CorrelatedSessionID` | `K8sInvestigationSessionChecker` (production impl) | `pkg/aianalysis/handlers/is_checker.go`, interface in `pkg/aianalysis/handlers/interfaces.go` | UT-AA-2030-008 |
+| `tryAdoptCorrelatedSession` / `adoptCorrelatedSession` / `checkCorrelatedSessionBeforeFinalizing` | `checkISMismatchAndCancel`, `handleSessionPollCompleted`, `handleSessionPollFailed` | `pkg/aianalysis/handlers/investigating.go` | UT-AA-2030-009, -010, -012; IT-AA-2030-011 |
+| `events.EventReasonSessionAdopted` | Emitted by `adoptCorrelatedSession` | `pkg/shared/events/reasons.go` (constant) | Covered transitively via UT-AA-2030-009/-010/-012 |
+| `ISEventPredicate` widening | Controller watch predicate for `InvestigationSession` | `internal/controller/aianalysis/aianalysis_controller.go` | UT-AA-2030-013, -013b, -013c; IT-AA-2030-011 |
+
+---
+
+## 6. CHECKPOINT W Evidence (Whole Bundle)
+
+```bash
+$ grep -rn "ScopeChecker" cmd/apifrontend pkg/apifrontend/agent/config.go pkg/apifrontend/agent/root.go \
+    pkg/apifrontend/handler/mcp_bridge.go --include="*.go" | grep -v "_test.go"
+cmd/apifrontend/backend_deps.go:96:	ScopeChecker scope.ScopeChecker
+cmd/apifrontend/backend_deps.go:177:	scopeChecker, err := fleet.NewScopeChecker(scopeMgr, cfg.Fleet, logger.WithName("scope"))
+cmd/apifrontend/backend_deps.go:181:	deps.ScopeChecker = scopeChecker
+cmd/apifrontend/mcp_a2a_handlers.go:53:		ScopeChecker:          d.Backends.ScopeChecker,   # AgentConfig
+cmd/apifrontend/mcp_a2a_handlers.go:167:		ScopeChecker:          d.Backends.ScopeChecker,  # MCPBridgeConfig
+pkg/apifrontend/agent/config.go:119:	ScopeChecker scope.ScopeChecker
+pkg/apifrontend/agent/root.go:158:	ScopeChecker: cfg.ScopeChecker,          # InvestigateAlertConfig
+pkg/apifrontend/agent/root.go:195:	...NewRemediateTool(..., cfg.ScopeChecker)
+pkg/apifrontend/agent/root.go:224:	ScopeChecker: cfg.ScopeChecker,          # InvestigateConfig
+pkg/apifrontend/handler/mcp_bridge.go:89:	ScopeChecker scope.ScopeChecker
+pkg/apifrontend/handler/mcp_bridge.go:251:	ScopeChecker: cfg.ScopeChecker,
+
+$ grep -rn "checkRRScope(" pkg/apifrontend/tools --include="*.go" | grep -v "_test.go"
+pkg/apifrontend/tools/af_create_rr.go:171   # single choke point, all 3 tools funnel here
+pkg/apifrontend/tools/scope_helpers.go:56   # definition
+
+$ grep -rn "ContextWithScopeChecker\|ScopeCheckerFromContext" --include="*.go" pkg/ cmd/ internal/
+# (no results -- removed as dead code during CHECKPOINT W; see Section 2.1)
+
+$ grep -rn "tryAdoptCorrelatedSession\|CorrelatedSessionID\|EventReasonSessionAdopted" \
+    pkg/aianalysis/handlers internal/controller/aianalysis pkg/shared/events --include="*.go" | grep -v "_test.go"
+pkg/aianalysis/handlers/interfaces.go:132:  CorrelatedSessionID(ctx context.Context, rrName string) (id string, active bool, err error)
+pkg/aianalysis/handlers/is_checker.go:122:   func (k *K8sInvestigationSessionChecker) CorrelatedSessionID(...)
+pkg/aianalysis/handlers/investigating.go:475: h.tryAdoptCorrelatedSession(ctx, analysis, rrName, "mismatch-check")
+pkg/aianalysis/handlers/investigating.go:...: func (h *InvestigatingHandler) tryAdoptCorrelatedSession(...)
+pkg/aianalysis/handlers/investigating.go:...: func (h *InvestigatingHandler) adoptCorrelatedSession(...)
+pkg/aianalysis/handlers/investigating.go:...: h.checkCorrelatedSessionBeforeFinalizing(ctx, analysis)  # x2 call sites
+pkg/shared/events/reasons.go:83:            EventReasonSessionAdopted = "SessionAdopted"
+
+$ grep -rn "handleSchemaRejectedStatusUpdate\|clearSchemaRejectionRetryAnnotation" \
+    internal/controller/aianalysis --include="*.go" | grep -v "_test.go"
+internal/controller/aianalysis/phase_handlers.go:...: return r.handleSchemaRejectedStatusUpdate(...)  # x2 call sites (Investigating, Analyzing)
+internal/controller/aianalysis/phase_handlers.go:...: r.clearSchemaRejectionRetryAnnotation(...)      # x2 call sites
+```
+
+No orphaned `pkg/` code: every new symbol has at least one production caller outside `_test.go`
+files, confirmed above. The one dead-code finding (`ContextWithScopeChecker`/
+`ScopeCheckerFromContext`) was caught and removed during this port's own CHECKPOINT W sweep, not
+shipped — see Section 2.1.
+
+## 7. Build Validation
+
+```bash
+$ go build ./...                                                                     # exit 0
+$ go vet ./...                                                                       # exit 0
+$ golangci-lint run --timeout=5m ./pkg/apifrontend/... ./pkg/aianalysis/... \
+    ./internal/controller/aianalysis/... ./cmd/apifrontend/...                       # 0 issues
+$ go test ./pkg/apifrontend/... ./pkg/aianalysis/... \
+    ./internal/controller/aianalysis/... ./cmd/apifrontend/...                       # all packages ok
+```
+
+## 8. Coverage Summary
+
+| Metric | Target | Actual |
+|---|---|---|
+| BR/Control coverage (AC-6, SI-4, SI-10, SI-11, AU-2/AU-3/AU-12, CM-3) | 100% | ✅ (Sections 2.2, 3.2, 4.2, 5.4) |
+| Wiring Manifest rows with passing IT/UT evidence | 100% | ✅ (Sections 2.4, 3.4, 4.4, 5.5) |
+| CHECKPOINT W (no orphaned `pkg/` code, no orphaned callback registration) | Pass | ✅ (Section 6) |
+| Build / vet / lint | Pass | ✅ (Section 7) |
+| #2025 fix coverage (AF tool-layer scope validation) | 100% | ✅ (Section 2) |
+| #2047 fix coverage (content-grounding guard) | 100% | ✅ (Section 3) |
+| #2028 fix coverage (confidence-gated ambiguity surfacing) | 100% | ✅ (Section 4) |
+| #2030 fix coverage (foundational session-ID fix + Part A retry + Part B adoption) | 100% | ✅ (Section 5) |
+
+## 9. Out of Scope
+
+- **`v1.5`'s #2023 Stage 1** (opaque-error removal, `ErrCodeNoConversationContext`) and **Stage 3**
+  (structured RCA pass-through + shadow-agent alignment verdict): explicitly excluded from this port
+  (Section 3.1) — orthogonal/hardening scope beyond this bundle's four issues.
+- **`RemediationScope` CRD, dynamic (Rego) scope policies**: deferred to V2.0 per ADR-053, unchanged
+  by this port.
+- **AF client caching**: accepted trade-off, unchanged by this port.
+- **Broader cluster-scoped-alert-as-legitimate-evidence support** (DD-AF-012): tracked as a separate,
+  not-yet-scoped issue.
+- **Free-text narrative fact-checking**: not addressed (only ported if Stage 3 above is ported later).
+
+## 10. Sign-off
+
+| Role | Name | Date | Signature |
+|---|---|---|---|
+| Author | AI Assistant | 2026-08-09 | ⏸️ |
+| Reviewer | Jordi Gil | | ⏸️ |
+| Approver | | | ⏸️ |

--- a/internal/controller/aianalysis/aianalysis_controller.go
+++ b/internal/controller/aianalysis/aianalysis_controller.go
@@ -348,9 +348,15 @@ func ISEventPredicate() predicate.TypedPredicate[*isv1alpha1.InvestigationSessio
 				return false
 			}
 			newPhase := e.ObjectNew.Status.Phase
-			return newPhase == isv1alpha1.SessionPhaseCompleted ||
+			if newPhase == isv1alpha1.SessionPhaseCompleted ||
 				newPhase == isv1alpha1.SessionPhaseCancelled ||
-				newPhase == isv1alpha1.SessionPhaseFailed
+				newPhase == isv1alpha1.SessionPhaseFailed {
+				return true
+			}
+			// #2030 Part B / FedRAMP SI-4: a takeover's correlation write only
+			// changes KACorrelationID (not Phase), so without this the
+			// controller would silently miss it until the next scheduled poll.
+			return e.ObjectNew.Status.KACorrelationID != e.ObjectOld.Status.KACorrelationID
 		},
 		GenericFunc: func(e event.TypedGenericEvent[*isv1alpha1.InvestigationSession]) bool {
 			return false

--- a/internal/controller/aianalysis/phase_handlers.go
+++ b/internal/controller/aianalysis/phase_handlers.go
@@ -19,6 +19,7 @@ package aianalysis
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -26,10 +27,12 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	aianalysisv1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
 	aaconditions "github.com/jordigilh/kubernaut/pkg/aianalysis"
 	"github.com/jordigilh/kubernaut/pkg/aianalysis/handlers"
+	"github.com/jordigilh/kubernaut/pkg/shared/backoff"
 	"github.com/jordigilh/kubernaut/pkg/shared/events"
 )
 
@@ -117,8 +120,9 @@ func (r *AIAnalysisReconciler) reconcileInvestigating(ctx context.Context, analy
 	if err := r.StatusManager.AtomicStatusUpdate(ctx, analysis, func() error {
 		return r.runInvestigatingHandler(ctx, analysis, invHandler, outcome, log)
 	}); err != nil {
-		return r.handleInvestigatingUpdateError(err, analysis, log)
+		return r.handleInvestigatingUpdateError(ctx, err, analysis, log)
 	}
+	r.clearSchemaRejectionRetryAnnotation(ctx, analysis, log)
 
 	return r.finalizeInvestigatingTransition(ctx, analysis, outcome, log)
 }
@@ -183,20 +187,115 @@ func (r *AIAnalysisReconciler) runInvestigatingHandler(ctx context.Context, anal
 }
 
 // handleInvestigatingUpdateError classifies the AtomicStatusUpdate error:
-// CRD-schema-rejected updates fail closed without a retry, everything else
-// is a standard reconcile error. Extracted from reconcileInvestigating
-// (Wave 6 6c GREEN: funlen remediation) — pure code motion, no behavior
-// change.
-func (r *AIAnalysisReconciler) handleInvestigatingUpdateError(err error, analysis *aianalysisv1.AIAnalysis, log logr.Logger) (ctrl.Result, error) {
+// CRD-schema-rejected updates retry with backoff instead of failing closed
+// (#2030 Part A), everything else is a standard reconcile error. Extracted
+// from reconcileInvestigating (Wave 6 6c GREEN: funlen remediation) — pure
+// code motion, no behavior change.
+func (r *AIAnalysisReconciler) handleInvestigatingUpdateError(ctx context.Context, err error, analysis *aianalysisv1.AIAnalysis, log logr.Logger) (ctrl.Result, error) {
 	if apierrors.IsInvalid(err) {
-		log.Error(err, "CRD schema rejected status update — fail-close, will not retry",
-			"name", analysis.Name)
-		r.Recorder.Event(analysis, corev1.EventTypeWarning, "SchemaValidationFailed",
-			fmt.Sprintf("Status update permanently rejected by CRD schema: %v", err))
-		return ctrl.Result{}, nil
+		// #2030 Part A: retry-then-escalate instead of fail-closing forever
+		// on the first CRD schema rejection.
+		return r.handleSchemaRejectedStatusUpdate(ctx, analysis, log, err)
 	}
 	log.Error(err, "Failed to atomically update status after Investigating phase")
 	return ctrl.Result{}, err
+}
+
+// handleSchemaRejectedStatusUpdate handles a Status().Update() rejection
+// caused by CRD schema drift (apierrors.IsInvalid) -- e.g. the live
+// cluster's installed CRD lagging behind a new enum value the Go source
+// already defines (#2030 Part A). Previously both call sites fail-closed
+// forever on the first rejection (return ctrl.Result{}, nil, no requeue),
+// silently abandoning the AIAnalysis with the controller never touching it
+// again.
+//
+// Retries a bounded number of times with backoff. The retry counter is
+// persisted via a plain Update() (metadata annotation only), not
+// Status().Update(): a CRD with the status subresource enabled silently
+// drops any .status diff on a non-status Update, so that write still
+// succeeds even though Status().Update() is being rejected. If the cap is
+// exceeded, escalates to a terminal Failed phase using valid enum values
+// (Reason=APIError/SubReason=TransientError) instead of retrying forever.
+func (r *AIAnalysisReconciler) handleSchemaRejectedStatusUpdate(ctx context.Context, analysis *aianalysisv1.AIAnalysis, log logr.Logger, rejectionErr error) (ctrl.Result, error) {
+	count := 0
+	if v := analysis.Annotations[handlers.SchemaRejectionRetryCountAnnotation]; v != "" {
+		if parsed, parseErr := strconv.Atoi(v); parseErr == nil {
+			count = parsed
+		}
+	}
+	count++
+
+	if count <= handlers.MaxSchemaRejectionRetries {
+		if analysis.Annotations == nil {
+			analysis.Annotations = map[string]string{}
+		}
+		analysis.Annotations[handlers.SchemaRejectionRetryCountAnnotation] = strconv.Itoa(count)
+
+		if updErr := r.Update(ctx, analysis); updErr != nil {
+			log.Error(updErr, "Failed to persist schema-rejection retry count annotation; will retry same attempt next reconcile",
+				"name", analysis.Name)
+		}
+
+		delay := backoff.CalculateWithDefaults(int32(count))
+		log.Error(rejectionErr, "CRD schema rejected status update — retrying with backoff",
+			"name", analysis.Name, "attempt", count, "maxAttempts", handlers.MaxSchemaRejectionRetries, "backoff", delay)
+		r.Recorder.Event(analysis, corev1.EventTypeWarning, "SchemaValidationFailed",
+			fmt.Sprintf("Status update rejected by CRD schema (attempt %d/%d), retrying in %s: %v",
+				count, handlers.MaxSchemaRejectionRetries, delay, rejectionErr))
+		return ctrl.Result{RequeueAfter: delay}, nil
+	}
+
+	log.Error(rejectionErr, "CRD schema rejected status update — retries exhausted, escalating to Failed",
+		"name", analysis.Name, "attempts", count-1)
+	r.Recorder.Event(analysis, corev1.EventTypeWarning, "SchemaValidationFailed",
+		fmt.Sprintf("Status update permanently rejected by CRD schema after %d attempts, escalating to Failed: %v",
+			count-1, rejectionErr))
+
+	// Refetch fresh rather than reusing the in-memory analysis: the failed
+	// handler run may have left other in-memory-only status fields in a
+	// state we don't want to carry into the escalation write.
+	fresh := &aianalysisv1.AIAnalysis{}
+	if getErr := r.Get(ctx, client.ObjectKeyFromObject(analysis), fresh); getErr != nil {
+		log.Error(getErr, "Failed to refetch AIAnalysis for schema-rejection escalation", "name", analysis.Name)
+		return ctrl.Result{}, nil
+	}
+	now := metav1.Now()
+	fresh.Status.Phase = PhaseFailed
+	fresh.Status.Reason = aianalysisv1.ReasonAPIError
+	fresh.Status.SubReason = "TransientError"
+	fresh.Status.Message = fmt.Sprintf("CRD schema permanently rejected status update after %d attempts: %v", count-1, rejectionErr)
+	fresh.Status.CompletedAt = &now
+	fresh.Status.ObservedGeneration = fresh.Generation
+
+	if updErr := r.Status().Update(ctx, fresh); updErr != nil {
+		log.Error(updErr, "Failed to escalate to Failed phase after schema-rejection retries exhausted", "name", analysis.Name)
+		return ctrl.Result{}, nil
+	}
+	*analysis = *fresh
+	return ctrl.Result{}, nil
+}
+
+// clearSchemaRejectionRetryAnnotation removes the #2030 Part A retry-count
+// annotation once a Status().Update() succeeds again after one or more
+// prior CRD-schema rejections. Without this, a leftover non-zero count from
+// an earlier, resolved schema-lag episode would make handleSchemaRejectedStatusUpdate
+// start counting from that stale value on some later, unrelated rejection
+// episode, tripping handlers.MaxSchemaRejectionRetries prematurely.
+//
+// Called only from the success path (after AtomicStatusUpdate returns nil),
+// so analysis already reflects the just-committed state. Best-effort: a
+// failure here is logged but does not affect the reconcile result, since the
+// stale annotation is merely a minor inefficiency, not a correctness hazard,
+// until another unrelated rejection episode occurs.
+func (r *AIAnalysisReconciler) clearSchemaRejectionRetryAnnotation(ctx context.Context, analysis *aianalysisv1.AIAnalysis, log logr.Logger) {
+	if _, present := analysis.Annotations[handlers.SchemaRejectionRetryCountAnnotation]; !present {
+		return
+	}
+	delete(analysis.Annotations, handlers.SchemaRejectionRetryCountAnnotation)
+	if err := r.Update(ctx, analysis); err != nil {
+		log.Error(err, "Failed to clear stale schema-rejection retry-count annotation (best-effort)",
+			"name", analysis.Name)
+	}
 }
 
 // finalizeInvestigatingTransition requeues and emits the phase-transition
@@ -277,15 +376,14 @@ func (r *AIAnalysisReconciler) reconcileAnalyzing(ctx context.Context, analysis 
 			return nil
 		}); err != nil {
 			if apierrors.IsInvalid(err) {
-				log.Error(err, "CRD schema rejected status update — fail-close, will not retry",
-					"name", analysis.Name)
-				r.Recorder.Event(analysis, corev1.EventTypeWarning, "SchemaValidationFailed",
-					fmt.Sprintf("Status update permanently rejected by CRD schema: %v", err))
-				return ctrl.Result{}, nil
+				// #2030 Part A: retry-then-escalate instead of fail-closing
+				// forever on the first CRD schema rejection.
+				return r.handleSchemaRejectedStatusUpdate(ctx, analysis, log, err)
 			}
 			log.Error(err, "Failed to atomically update status after Analyzing phase")
 			return ctrl.Result{}, err
 		}
+		r.clearSchemaRejectionRetryAnnotation(ctx, analysis, log)
 
 		// Only requeue if handler actually executed and changed phase
 		if handlerExecuted && analysis.Status.Phase != phaseBefore {

--- a/internal/controller/aianalysis/predicates_test.go
+++ b/internal/controller/aianalysis/predicates_test.go
@@ -106,6 +106,65 @@ var _ = Describe("isEventPredicate (#1449)", func() {
 		})
 	})
 
+	// ═══════════════════════════════════════════════════════════════════════
+	// Issue #2030 (main-tracking clone of #2029) Part B / FedRAMP SI-4:
+	// KACorrelationID-only changes must also wake the controller immediately,
+	// not just terminal transitions. Without this, a takeover's correlation
+	// write (which only changes KACorrelationID, not Phase) is silently
+	// dropped and AA only learns about it on its next scheduled poll (up to
+	// sessionPollInterval later) instead of near-instantly.
+	// ═══════════════════════════════════════════════════════════════════════
+
+	makeISWithCorrelation := func(phase isv1alpha1.SessionPhase, correlationID string) *isv1alpha1.InvestigationSession {
+		is := makeIS(phase)
+		is.Status.KACorrelationID = correlationID
+		return is
+	}
+
+	Context("#2030 SI-4: KACorrelationID changes trigger reconciliation", func() {
+		It("UT-AA-2030-013: passes Update events when only KACorrelationID changes (Phase stays non-terminal)", func() {
+			pred := controller.ISEventPredicate()
+			oldIS := makeISWithCorrelation(isv1alpha1.SessionPhaseActive, "ka-session-old")
+			newIS := makeISWithCorrelation(isv1alpha1.SessionPhaseActive, "ka-session-new")
+
+			updateEvent := event.TypedUpdateEvent[*isv1alpha1.InvestigationSession]{
+				ObjectOld: oldIS,
+				ObjectNew: newIS,
+			}
+
+			Expect(pred.Update(updateEvent)).To(BeTrue(),
+				"#2030 Part B: a KACorrelationID change must pass the predicate even when Phase doesn't change")
+		})
+
+		It("UT-AA-2030-013b: drops Update events when KACorrelationID and Phase are both unchanged (no regression)", func() {
+			pred := controller.ISEventPredicate()
+			oldIS := makeISWithCorrelation(isv1alpha1.SessionPhaseActive, "ka-session-same")
+			newIS := makeISWithCorrelation(isv1alpha1.SessionPhaseActive, "ka-session-same")
+
+			updateEvent := event.TypedUpdateEvent[*isv1alpha1.InvestigationSession]{
+				ObjectOld: oldIS,
+				ObjectNew: newIS,
+			}
+
+			Expect(pred.Update(updateEvent)).To(BeFalse(),
+				"no-op updates (e.g. resync) must still be filtered to avoid unnecessary reconciles")
+		})
+
+		It("UT-AA-2030-013c: existing terminal-phase cases still pass when KACorrelationID is held at its zero value (no regression)", func() {
+			pred := controller.ISEventPredicate()
+			oldIS := makeIS(isv1alpha1.SessionPhaseActive)
+			newIS := makeIS(isv1alpha1.SessionPhaseCompleted)
+
+			updateEvent := event.TypedUpdateEvent[*isv1alpha1.InvestigationSession]{
+				ObjectOld: oldIS,
+				ObjectNew: newIS,
+			}
+
+			Expect(pred.Update(updateEvent)).To(BeTrue(),
+				"UT-AA-1449-010's terminal-phase case must be unaffected by the #2030 widening")
+		})
+	})
+
 	Context("Create and Delete events still pass through", func() {
 		It("UT-AA-1449-014: passes Create events", func() {
 			pred := controller.ISEventPredicate()

--- a/internal/controller/aianalysis/schema_rejection_retry_test.go
+++ b/internal/controller/aianalysis/schema_rejection_retry_test.go
@@ -1,0 +1,404 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Issue #2030 (main-tracking clone of #2029) Part A: reconcileInvestigating/
+// reconcileAnalyzing must retry (with backoff, bounded) instead of
+// fail-closing forever when the live cluster's installed AIAnalysis CRD
+// schema rejects a Status().Update() call (apierrors.IsInvalid) -- e.g. CRD
+// version skew during a rolling upgrade where the Go source already defines
+// an enum value the installed CRD doesn't recognize yet. Previously this
+// returned ctrl.Result{}, nil (no requeue, no error) on the FIRST rejection,
+// permanently abandoning the AIAnalysis with no operator-visible recovery
+// path.
+//
+// White-box (package aianalysis, not aianalysis_test): needs direct access
+// to reconcileInvestigating/reconcileAnalyzing/handleSchemaRejectedStatusUpdate
+// and the Phase* constants, none of which are exported. Runs in the same
+// Ginkgo suite as predicates_test.go/suite_test.go (RunSpecs lives there;
+// Describe() blocks register globally regardless of which file/package
+// variant declares them).
+package aianalysis
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	aianalysisv1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/agentclient"
+	aiaudit "github.com/jordigilh/kubernaut/pkg/aianalysis/audit"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis/handlers"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis/metrics"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis/rego"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis/status"
+	"github.com/jordigilh/kubernaut/pkg/audit"
+	ogenclient "github.com/jordigilh/kubernaut/pkg/datastorage/ogen-client"
+	sharedtypes "github.com/jordigilh/kubernaut/pkg/shared/types"
+)
+
+// ----------------------------------------------------------------------------
+// Test doubles
+// ----------------------------------------------------------------------------
+
+// fakeKAClientAlwaysErrors implements handlers.AgentClientInterface. Investigate
+// returns a generic (unclassified) error, which InvestigatingHandler's
+// ErrorClassifier treats as a permanent error -- naturally driving
+// analysis.Status.Phase to Failed in memory without needing a real KA server.
+// The resulting Status().Update() attempt is what these tests' schema-
+// rejection interceptors target.
+type fakeKAClientAlwaysErrors struct{}
+
+func (fakeKAClientAlwaysErrors) Investigate(_ context.Context, _ *agentclient.IncidentRequest) (*agentclient.IncidentResponse, error) {
+	return nil, errors.New("simulated KA outage (test double, #2030)")
+}
+func (fakeKAClientAlwaysErrors) SubmitInvestigation(_ context.Context, _ *agentclient.IncidentRequest) (string, error) {
+	return "", errors.New("not implemented in test double (#2030): session mode unused")
+}
+func (fakeKAClientAlwaysErrors) PollSession(_ context.Context, _ string) (*agentclient.SessionStatusResult, error) {
+	return nil, errors.New("not implemented in test double (#2030): session mode unused")
+}
+func (fakeKAClientAlwaysErrors) GetSessionResult(_ context.Context, _ string) (*agentclient.IncidentResponse, error) {
+	return nil, errors.New("not implemented in test double (#2030): session mode unused")
+}
+func (fakeKAClientAlwaysErrors) CancelSession(_ context.Context, _ string) error { return nil }
+
+// noopAuditClient implements handlers.AuditClientInterface. These tests
+// assert on Status/annotation state, not audit emission.
+type noopAuditClient struct{}
+
+func (noopAuditClient) RecordAIAgentCall(_ context.Context, _ *aianalysisv1.AIAnalysis, _ string, _ int, _ int) {
+}
+func (noopAuditClient) RecordPhaseTransition(_ context.Context, _ *aianalysisv1.AIAnalysis, _, _ string) {
+}
+func (noopAuditClient) RecordAnalysisFailed(_ context.Context, _ *aianalysisv1.AIAnalysis, _ error) error {
+	return nil
+}
+func (noopAuditClient) RecordAnalysisComplete(_ context.Context, _ *aianalysisv1.AIAnalysis) {}
+func (noopAuditClient) RecordAIAgentSubmit(_ context.Context, _ *aianalysisv1.AIAnalysis, _ string) {
+}
+func (noopAuditClient) RecordAIAgentResult(_ context.Context, _ *aianalysisv1.AIAnalysis, _ int64) {}
+func (noopAuditClient) RecordAIAgentSessionLost(_ context.Context, _ *aianalysisv1.AIAnalysis, _ int32) {
+}
+
+// noopAnalyzingAuditClient implements handlers.AnalyzingAuditClientInterface.
+type noopAnalyzingAuditClient struct{}
+
+func (noopAnalyzingAuditClient) RecordRegoEvaluation(_ context.Context, _ *aianalysisv1.AIAnalysis, _ string, _ bool, _ int, _ string, _ string) {
+}
+func (noopAnalyzingAuditClient) RecordApprovalDecision(_ context.Context, _ *aianalysisv1.AIAnalysis, _, _ string) {
+}
+func (noopAnalyzingAuditClient) RecordAnalysisComplete(_ context.Context, _ *aianalysisv1.AIAnalysis) {
+}
+func (noopAnalyzingAuditClient) RecordAnalysisFailed(_ context.Context, _ *aianalysisv1.AIAnalysis, _ error) error {
+	return nil
+}
+
+// noopAuditStore implements audit.AuditStore for r.AuditClient (a concrete
+// *audit.AuditClient field on AIAnalysisReconciler, required by
+// recordPhaseMetrics/RecordPhaseTransition whenever a phase change commits
+// successfully -- distinct from the handlers.AuditClientInterface double
+// injected into the handler constructors above).
+type noopAuditStore struct{}
+
+func (noopAuditStore) StoreAudit(_ context.Context, _ *ogenclient.AuditEventRequest) error {
+	return nil
+}
+func (noopAuditStore) Flush(_ context.Context) error { return nil }
+func (noopAuditStore) Close() error                  { return nil }
+
+var _ audit.AuditStore = noopAuditStore{}
+
+// neverCalledRegoEvaluator implements handlers.RegoEvaluatorInterface. Never
+// invoked in these tests: AnalyzingHandler.Handle short-circuits to
+// Phase=Failed/Reason=NoWorkflowSelected before evaluating Rego when
+// Status.SelectedWorkflow is nil -- exactly the minimal fixture below.
+type neverCalledRegoEvaluator struct{}
+
+func (neverCalledRegoEvaluator) Evaluate(_ context.Context, _ *rego.PolicyInput) (*rego.PolicyResult, error) {
+	return nil, errors.New("unexpected call (#2030 test double): fixture has no SelectedWorkflow, Handle must short-circuit first")
+}
+
+// ----------------------------------------------------------------------------
+// Interceptor helpers
+// ----------------------------------------------------------------------------
+
+// failNStatusUpdates returns interceptor funcs whose SubResourceUpdate hook
+// rejects the first n calls to Status().Update() with a synthetic
+// apierrors.IsInvalid error (modeling a CRD schema rejection), then delegates
+// to the real fake client for every call after that. A plain Update() (the
+// annotation persistence path #2030 Part A relies on) is never intercepted,
+// matching real Kubernetes CRD-with-status-subresource semantics: a plain
+// Update() silently ignores any .status diff, so it is unaffected by
+// Status().Update() being rejected.
+func failNStatusUpdates(n int32) interceptor.Funcs {
+	var calls int32
+	return interceptor.Funcs{
+		SubResourceUpdate: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+			if subResourceName == "status" && atomic.AddInt32(&calls, 1) <= n {
+				return apierrors.NewInvalid(
+					schema.GroupKind{Group: "kubernaut.ai", Kind: "AIAnalysis"},
+					obj.GetName(),
+					field.ErrorList{field.NotSupported(field.NewPath("status", "subReason"),
+						"SimulatedCRDSchemaLag2030", []string{"TransientError", "PermanentError"})},
+				)
+			}
+			return c.SubResource(subResourceName).Update(ctx, obj, opts...)
+		},
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Fixture helpers
+// ----------------------------------------------------------------------------
+
+func newSchemaRejectionTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	Expect(clientgoscheme.AddToScheme(s)).To(Succeed())
+	Expect(aianalysisv1.AddToScheme(s)).To(Succeed())
+	return s
+}
+
+func newSchemaRejectionTestAnalysis(name, phase string) *aianalysisv1.AIAnalysis {
+	return &aianalysisv1.AIAnalysis{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "default",
+		},
+		Spec: aianalysisv1.AIAnalysisSpec{
+			RemediationRequestRef: corev1.ObjectReference{Name: "rr-" + name, Namespace: "default"},
+			RemediationID:         "rr-" + name,
+			AnalysisRequest: aianalysisv1.AnalysisRequest{
+				SignalContext: aianalysisv1.SignalContextInput{
+					Fingerprint:      "fp-" + name,
+					Severity:         "critical",
+					SignalName:       "TestSignal2030",
+					Environment:      "staging",
+					BusinessPriority: "P1",
+					TargetResource: aianalysisv1.TargetResource{
+						Kind:      "Deployment",
+						Name:      "test-deploy",
+						Namespace: "default",
+					},
+					EnrichmentResults: sharedtypes.EnrichmentResults{},
+				},
+				AnalysisTypes: []aianalysisv1.AnalysisType{aianalysisv1.AnalysisTypeInvestigation},
+			},
+		},
+		Status: aianalysisv1.AIAnalysisStatus{
+			Phase: phase,
+		},
+	}
+}
+
+// newSchemaRejectionTestReconciler builds a reconciler wired with a real
+// InvestigatingHandler/AnalyzingHandler (per #2030 plan spike: both
+// constructors are simple given just the small interfaces above, no deep
+// dependency graph) backed by the given (possibly interceptor-wrapped)
+// client, so reconcileInvestigating/reconcileAnalyzing run through their
+// genuine production logic end to end.
+func newSchemaRejectionTestReconciler(k8sClient client.Client) *AIAnalysisReconciler {
+	log := logr.Discard()
+	m := metrics.NewMetricsWithRegistry(prometheus.NewRegistry())
+
+	r := &AIAnalysisReconciler{
+		Client:        k8sClient,
+		Scheme:        k8sClient.Scheme(),
+		Recorder:      record.NewFakeRecorder(50),
+		Log:           log,
+		Metrics:       m,
+		StatusManager: status.NewManager(k8sClient, k8sClient),
+		AuditClient:   aiaudit.NewAuditClient(noopAuditStore{}, log),
+		AnalyzingHandler: handlers.NewAnalyzingHandler(
+			neverCalledRegoEvaluator{}, log, m, noopAnalyzingAuditClient{}),
+	}
+	r.InvestigatingHandler.Store(handlers.NewInvestigatingHandler(
+		fakeKAClientAlwaysErrors{}, log, m, noopAuditClient{}))
+	return r
+}
+
+// ----------------------------------------------------------------------------
+// UT-AA-2030-001/002/003/005
+// ----------------------------------------------------------------------------
+
+var _ = Describe("Schema-rejection retry (#2030 Part A)", func() {
+	var ctx context.Context
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("UT-AA-2030-001: reconcileInvestigating retries (not freezes) on apierrors.IsInvalid", func() {
+		scheme := newSchemaRejectionTestScheme()
+		analysis := newSchemaRejectionTestAnalysis("ut-2030-001", PhaseInvestigating)
+
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&aianalysisv1.AIAnalysis{}).
+			WithObjects(analysis).
+			WithInterceptorFuncs(failNStatusUpdates(100)).
+			Build()
+
+		r := newSchemaRejectionTestReconciler(k8sClient)
+
+		result, err := r.reconcileInvestigating(ctx, analysis)
+		Expect(err).NotTo(HaveOccurred(),
+			"schema rejection must not surface as a reconcile error -- that would just log-and-drop under controller-runtime's default rate limiter")
+		Expect(result.RequeueAfter).To(BeNumerically(">", 0),
+			"must requeue with backoff, not fail-close forever (ctrl.Result{}, nil) like the pre-#2030 behavior")
+
+		var fresh aianalysisv1.AIAnalysis
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), &fresh)).To(Succeed())
+		Expect(fresh.Annotations[handlers.SchemaRejectionRetryCountAnnotation]).To(Equal("1"),
+			"retry count annotation must persist via plain Update() even though Status().Update() was rejected")
+		Expect(fresh.Status.Phase).To(Equal(PhaseInvestigating),
+			"phase must remain unchanged in the persisted object -- the rejected status write never actually landed")
+	})
+
+	It("UT-AA-2030-002: reconcileAnalyzing retries (not freezes) on apierrors.IsInvalid", func() {
+		scheme := newSchemaRejectionTestScheme()
+		analysis := newSchemaRejectionTestAnalysis("ut-2030-002", PhaseAnalyzing)
+
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&aianalysisv1.AIAnalysis{}).
+			WithObjects(analysis).
+			WithInterceptorFuncs(failNStatusUpdates(100)).
+			Build()
+
+		r := newSchemaRejectionTestReconciler(k8sClient)
+
+		result, err := r.reconcileAnalyzing(ctx, analysis)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeNumerically(">", 0),
+			"must requeue with backoff, not fail-close forever like the pre-#2030 behavior")
+
+		var fresh aianalysisv1.AIAnalysis
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), &fresh)).To(Succeed())
+		Expect(fresh.Annotations[handlers.SchemaRejectionRetryCountAnnotation]).To(Equal("1"))
+		Expect(fresh.Status.Phase).To(Equal(PhaseAnalyzing))
+	})
+
+	It("UT-AA-2030-003: retry count annotation persists via plain Update() across repeated rejections", func() {
+		scheme := newSchemaRejectionTestScheme()
+		analysis := newSchemaRejectionTestAnalysis("ut-2030-003", PhaseInvestigating)
+
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&aianalysisv1.AIAnalysis{}).
+			WithObjects(analysis).
+			WithInterceptorFuncs(failNStatusUpdates(100)).
+			Build()
+
+		r := newSchemaRejectionTestReconciler(k8sClient)
+
+		_, err := r.reconcileInvestigating(ctx, analysis)
+		Expect(err).NotTo(HaveOccurred())
+
+		var afterFirst aianalysisv1.AIAnalysis
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), &afterFirst)).To(Succeed())
+		Expect(afterFirst.Annotations[handlers.SchemaRejectionRetryCountAnnotation]).To(Equal("1"))
+
+		// Second reconcile of the SAME still-rejected object: count must advance
+		// to 2, proving the annotation (not an in-memory-only counter) is the
+		// durable source of truth across independent reconciler invocations.
+		_, err = r.reconcileInvestigating(ctx, &afterFirst)
+		Expect(err).NotTo(HaveOccurred())
+
+		var afterSecond aianalysisv1.AIAnalysis
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), &afterSecond)).To(Succeed())
+		Expect(afterSecond.Annotations[handlers.SchemaRejectionRetryCountAnnotation]).To(Equal("2"))
+	})
+
+	It("UT-AA-2030-005: exceeding the retry cap escalates to a terminal Failed phase with valid enum values", func() {
+		scheme := newSchemaRejectionTestScheme()
+		analysis := newSchemaRejectionTestAnalysis("ut-2030-005", PhaseInvestigating)
+		analysis.Annotations = map[string]string{
+			handlers.SchemaRejectionRetryCountAnnotation: "5", // handlers.MaxSchemaRejectionRetries
+		}
+
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&aianalysisv1.AIAnalysis{}).
+			WithObjects(analysis).
+			// Call #1 (the handler-driven write) is rejected, exactly like every
+			// prior attempt; call #2 (this helper's escalation write, using
+			// valid enum values) succeeds -- modeling that only the ORIGINAL
+			// write is affected by the schema gap, not every write forever.
+			WithInterceptorFuncs(failNStatusUpdates(1)).
+			Build()
+
+		r := newSchemaRejectionTestReconciler(k8sClient)
+
+		result, err := r.reconcileInvestigating(ctx, analysis)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeZero(),
+			"a terminal Failed phase needs no further requeue")
+
+		var fresh aianalysisv1.AIAnalysis
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), &fresh)).To(Succeed())
+		Expect(fresh.Status.Phase).To(Equal(PhaseFailed),
+			"must escalate to a visible terminal state instead of retrying forever")
+		Expect(fresh.Status.Reason).To(Equal(aianalysisv1.ReasonAPIError))
+		Expect(fresh.Status.SubReason).To(Equal("TransientError"))
+	})
+
+	It("UT-AA-2030-014: a subsequent successful status write clears the leftover retry-count annotation", func() {
+		scheme := newSchemaRejectionTestScheme()
+		analysis := newSchemaRejectionTestAnalysis("ut-2030-014", PhaseInvestigating)
+		analysis.Annotations = map[string]string{
+			handlers.SchemaRejectionRetryCountAnnotation: "3",
+		}
+
+		// No interceptor: the CRD schema lag has been resolved, so this
+		// Status().Update() must succeed normally -- proving the leftover
+		// count from an earlier, unrelated rejection episode doesn't linger
+		// forever and prematurely trip handlers.MaxSchemaRejectionRetries
+		// on some future, unrelated schema-rejection episode.
+		k8sClient := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithStatusSubresource(&aianalysisv1.AIAnalysis{}).
+			WithObjects(analysis).
+			Build()
+
+		r := newSchemaRejectionTestReconciler(k8sClient)
+
+		_, err := r.reconcileInvestigating(ctx, analysis)
+		Expect(err).NotTo(HaveOccurred())
+
+		var fresh aianalysisv1.AIAnalysis
+		Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), &fresh)).To(Succeed())
+		_, stillPresent := fresh.Annotations[handlers.SchemaRejectionRetryCountAnnotation]
+		Expect(stillPresent).To(BeFalse(),
+			"the retry-count annotation must be cleared once a status write succeeds again")
+	})
+})

--- a/pkg/aianalysis/handlers/constants.go
+++ b/pkg/aianalysis/handlers/constants.go
@@ -54,6 +54,27 @@ const (
 	// Format: "kubernaut.ai/retry-count"
 	// Used to persist retry state across reconciliation loops
 	RetryCountAnnotation = "kubernaut.ai/retry-count"
+
+	// SchemaRejectionRetryCountAnnotation persists the count of consecutive
+	// apierrors.IsInvalid rejections of a Status().Update() call (#2030 Part
+	// A: e.g. the live cluster's installed CRD lagging behind a new enum
+	// value the Go source already defines). Written via a plain Update()
+	// rather than Status().Update(): the whole point is that the status
+	// subresource write is being rejected, and a CRD with
+	// subresources.status enabled silently drops any .status diff on a
+	// non-status Update, so that write still succeeds even though
+	// Status().Update() doesn't.
+	SchemaRejectionRetryCountAnnotation = "kubernaut.ai/schema-rejection-retry-count"
+)
+
+const (
+	// MaxSchemaRejectionRetries caps how many times reconcileInvestigating/
+	// reconcileAnalyzing retry a Status().Update() rejected by CRD schema
+	// validation (#2030 Part A) before escalating to a terminal Failed
+	// phase. Previously there was no cap at all -- the controller fail-
+	// closed forever on the first rejection (return ctrl.Result{}, nil, no
+	// requeue), permanently abandoning the AIAnalysis.
+	MaxSchemaRejectionRetries = 5
 )
 
 // ========================================

--- a/pkg/aianalysis/handlers/interfaces.go
+++ b/pkg/aianalysis/handlers/interfaces.go
@@ -126,6 +126,13 @@ type InvestigationSessionChecker interface {
 	// terminal state. Returns ("", false, nil) if no IS exists at all.
 	// Used to distinguish "IS deleted" from "IS in terminal phase" in cancel handling.
 	FindSessionPhase(ctx context.Context, rrName string) (isv1alpha1.SessionPhase, bool, error)
+	// CorrelatedSessionID returns the KA session ID AF has most recently
+	// correlated onto this RR's InvestigationSession (status.kaCorrelationID),
+	// and whether that IS is still in a non-terminal phase. Returns ("", false, nil)
+	// if no IS exists or no correlation has been recorded yet.
+	// #2030 Part B: lets AA adopt a live session that AF correlated onto a
+	// takeover IS after AA's original session already went stale/terminal.
+	CorrelatedSessionID(ctx context.Context, rrName string) (id string, active bool, err error)
 }
 
 // ISPhaseUpdater transitions an InvestigationSession CRD phase. AA uses this

--- a/pkg/aianalysis/handlers/investigating.go
+++ b/pkg/aianalysis/handlers/investigating.go
@@ -466,7 +466,89 @@ func (h *InvestigatingHandler) checkISMismatchAndCancel(ctx context.Context, ana
 		return ctrl.Result{Requeue: true}, true
 	}
 
+	// #2030 Part B: hasIS && session.Interactive is the common "everything
+	// looks normal" steady state — neither case above fires. But AF may have
+	// correlated a newer, different KA session onto this IS since our last
+	// check (e.g. a reconnect/takeover after our tracked session went stale).
+	// Adopt it instead of silently continuing to poll a session AF has moved
+	// on from.
+	if hasIS && session.Interactive && h.tryAdoptCorrelatedSession(ctx, analysis, rrName, "mismatch-check") {
+		return ctrl.Result{Requeue: true}, true
+	}
+
 	return ctrl.Result{}, false
+}
+
+// adoptCorrelatedSession swaps the AA-tracked KA session onto a session ID
+// AF has correlated for this RR's InvestigationSession (#2030 Part B). This
+// is deliberately NOT a regeneration: KA already ran (or is actively
+// running) this session — AA is catching up to work that already exists,
+// not starting a new investigation — so Generation is left unchanged (unlike
+// handleSessionLost's 404-triggered regeneration, or handleSessionPollCancelled's
+// takeover-resubmit branch, both of which intentionally start a fresh session).
+//
+// FedRAMP SI-4/AU-2/AU-3: emits a K8s event (observability) and a durable
+// audit record (traceability) so this is never a silent state change — the
+// business-relevant fact being preserved is that a real, possibly-completed
+// investigation is not discarded.
+func (h *InvestigatingHandler) adoptCorrelatedSession(ctx context.Context, analysis *aianalysisv1.AIAnalysis, newSessionID string) {
+	session := analysis.Status.KASession
+	oldSessionID := session.ID
+	now := metav1.Now()
+	session.ID = newSessionID
+	session.Interactive = true
+	session.PollCount = 0
+	session.LastPolled = nil
+	session.CreatedAt = &now
+	session.ConsecutiveGetResultErrors = 0
+
+	if h.recorder != nil {
+		h.recorder.Eventf(analysis, corev1.EventTypeNormal, events.EventReasonSessionAdopted,
+			"Adopted KA session %s correlated by API Frontend (previously tracking %s)", newSessionID, oldSessionID)
+	}
+	h.auditClient.RecordAIAgentCall(ctx, analysis, "session_adopted", 200, 0)
+}
+
+// tryAdoptCorrelatedSession checks whether AF has correlated a newer, active
+// KA session onto rrName's InvestigationSession and, if so, adopts it
+// (#2030 Part B). Shared by both adoption call sites -- the general
+// IS-mismatch check in checkISMismatchAndCancel and the race-closing
+// re-check in checkCorrelatedSessionBeforeFinalizing -- which differ only in
+// when they call this and what logCtx they pass for log correlation.
+// Returns true if adoption occurred.
+func (h *InvestigatingHandler) tryAdoptCorrelatedSession(ctx context.Context, analysis *aianalysisv1.AIAnalysis, rrName, logCtx string) bool {
+	session := analysis.Status.KASession
+	newID, active, err := h.isChecker.CorrelatedSessionID(ctx, rrName)
+	if err != nil {
+		h.log.Error(err, "CorrelatedSessionID check failed, proceeding without adoption", "context", logCtx, "rrName", rrName)
+		return false
+	}
+	if !active || newID == "" || newID == session.ID {
+		return false
+	}
+	h.log.Info("AF correlated a newer KA session — adopting",
+		"context", logCtx, "oldSessionID", session.ID, "newSessionID", newID, "rrName", rrName)
+	h.adoptCorrelatedSession(ctx, analysis, newID)
+	return true
+}
+
+// checkCorrelatedSessionBeforeFinalizing re-checks IS correlation immediately
+// before finalizing a terminal poll result (completed/failed). Closes the
+// race where AF's correlation write lands between the general mismatch check
+// at the top of handleSessionBased and the poll result arriving from KA
+// (#2030 Part B): the old session can report completed/failed at the exact
+// moment a takeover has already moved AA's true session elsewhere. Returns
+// true if adoption occurred — the caller must skip finalizing this poll
+// result so the newly adopted session is never wrongly marked terminal.
+func (h *InvestigatingHandler) checkCorrelatedSessionBeforeFinalizing(ctx context.Context, analysis *aianalysisv1.AIAnalysis) bool {
+	if h.isChecker == nil {
+		return false
+	}
+	rrName := analysis.Spec.RemediationRequestRef.Name
+	if rrName == "" {
+		return false
+	}
+	return h.tryAdoptCorrelatedSession(ctx, analysis, rrName, "finalize-recheck")
 }
 
 // handleSessionSubmit submits a new investigation to KA and records the session ID.
@@ -778,6 +860,13 @@ func (h *InvestigatingHandler) handleSessionPollPending(ctx context.Context, ana
 // handleSessionPollCompleted handles poll results where investigation has completed.
 // BR-AA-KA-064.3: Fetch result and process through ResponseProcessor
 func (h *InvestigatingHandler) handleSessionPollCompleted(ctx context.Context, analysis *aianalysisv1.AIAnalysis) (ctrl.Result, error) {
+	// #2030 Part B: re-check correlation before finalizing — closes the race
+	// where AF adopts a takeover session between our last mismatch check and
+	// this (now-stale) session's poll reporting completed.
+	if h.checkCorrelatedSessionBeforeFinalizing(ctx, analysis) {
+		return ctrl.Result{Requeue: true}, nil
+	}
+
 	session := analysis.Status.KASession
 
 	// Track that a poll occurred even on terminal status — the poll that discovered
@@ -847,6 +936,11 @@ func (h *InvestigatingHandler) handleSessionIncidentResult(ctx context.Context, 
 // BR-AA-KA-064: Surface KA-side failure to operators via CRD status
 // AA-MED-1: Ensure Reason and SubReason are set for structured failure reporting.
 func (h *InvestigatingHandler) handleSessionPollFailed(ctx context.Context, analysis *aianalysisv1.AIAnalysis, status *agentclient.SessionStatusResult) (ctrl.Result, error) {
+	// #2030 Part B: symmetric race-closing check (see handleSessionPollCompleted).
+	if h.checkCorrelatedSessionBeforeFinalizing(ctx, analysis) {
+		return ctrl.Result{Requeue: true}, nil
+	}
+
 	session := analysis.Status.KASession
 	session.PollCount++
 	now := metav1.Now()

--- a/pkg/aianalysis/handlers/is_checker.go
+++ b/pkg/aianalysis/handlers/is_checker.go
@@ -116,6 +116,33 @@ func (k *K8sInvestigationSessionChecker) FindSessionPhase(ctx context.Context, r
 	return list.Items[0].Status.Phase, true, nil
 }
 
+// CorrelatedSessionID returns the KA session ID AF has most recently
+// correlated onto this RR's InvestigationSession (status.kaCorrelationID) via
+// CRDSessionService.UpdateISCorrelation, and whether that IS is still
+// non-terminal. Returns ("", false, nil) if no IS exists or no correlation
+// has been written yet. #2030 Part B.
+func (k *K8sInvestigationSessionChecker) CorrelatedSessionID(ctx context.Context, rrName string) (string, bool, error) {
+	if rrName == "" {
+		return "", false, nil
+	}
+
+	var list isv1alpha1.InvestigationSessionList
+	if err := k.reader.List(ctx, &list,
+		client.InNamespace(k.namespace),
+		client.MatchingFields{ISFieldIndexRRName: rrName},
+	); err != nil {
+		return "", false, fmt.Errorf("list InvestigationSessions for RR %s: %w", rrName, err)
+	}
+
+	for i := range list.Items {
+		is := &list.Items[i]
+		if is.Status.KACorrelationID != "" {
+			return is.Status.KACorrelationID, !terminalPhases[is.Status.Phase], nil
+		}
+	}
+	return "", false, nil
+}
+
 // K8sISPhaseUpdater implements ISPhaseUpdater by updating InvestigationSession
 // CRD status via the controller-runtime client. AA calls SetActivePhase after
 // submitting to KA with interactive=true to signal AF that the session is ready.

--- a/pkg/aianalysis/investigating_handler_session_test.go
+++ b/pkg/aianalysis/investigating_handler_session_test.go
@@ -58,6 +58,17 @@ type sessionAuditSpy struct {
 	resultEvents      []sessionResultEvent
 	sessionLostEvents []sessionLostEvent
 	failedEvents      []failedAnalysisEvent
+	// agentCallEvents tracks generic RecordAIAgentCall invocations, including
+	// #2030 Part B's "session_adopted" endpoint (FedRAMP AU-2/AU-3: durable
+	// audit trail proving an adoption was recorded, not just logged).
+	agentCallEvents []agentCallEvent
+}
+
+type agentCallEvent struct {
+	analysis   *aianalysisv1.AIAnalysis
+	endpoint   string
+	statusCode int
+	durationMs int
 }
 
 type sessionSubmitEvent struct {
@@ -76,6 +87,11 @@ type sessionLostEvent struct {
 }
 
 func (s *sessionAuditSpy) RecordAIAgentCall(ctx context.Context, analysis *aianalysisv1.AIAnalysis, endpoint string, statusCode int, durationMs int) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.agentCallEvents = append(s.agentCallEvents, agentCallEvent{
+		analysis: analysis, endpoint: endpoint, statusCode: statusCode, durationMs: durationMs,
+	})
 }
 func (s *sessionAuditSpy) RecordPhaseTransition(ctx context.Context, analysis *aianalysisv1.AIAnalysis, from, to string) {
 }
@@ -1250,6 +1266,31 @@ type mockISChecker struct {
 	sessionPhase  isv1alpha1.SessionPhase
 	sessionExists bool
 	findPhaseErr  error
+
+	// #2030 Part B: CorrelatedSessionID stubbing.
+	//
+	// correlatedID/correlatedActive/correlatedErr are returned for every call
+	// when correlatedSequence is empty (the common case: a single, constant
+	// correlation state for the whole test).
+	//
+	// correlatedSequence, when non-empty, lets a test model correlation
+	// LANDING mid-reconcile: successive calls pop the next entry (simulating
+	// e.g. the general mismatch check seeing no correlation yet, while the
+	// race-closing check moments later in the same reconcile sees the new
+	// one). The last entry repeats once the sequence is exhausted.
+	correlatedID        string
+	correlatedActive    bool
+	correlatedErr       error
+	correlatedSequence  []correlatedSessionStub
+	correlatedCallCount int
+}
+
+// correlatedSessionStub is one canned CorrelatedSessionID return value in a
+// mockISChecker.correlatedSequence.
+type correlatedSessionStub struct {
+	id     string
+	active bool
+	err    error
 }
 
 func (m *mockISChecker) HasActiveSession(_ context.Context, _ string) (bool, error) {
@@ -1261,6 +1302,19 @@ func (m *mockISChecker) FindSessionPhase(_ context.Context, _ string) (isv1alpha
 		return "", false, m.findPhaseErr
 	}
 	return m.sessionPhase, m.sessionExists, m.err
+}
+
+func (m *mockISChecker) CorrelatedSessionID(_ context.Context, _ string) (string, bool, error) {
+	if len(m.correlatedSequence) == 0 {
+		return m.correlatedID, m.correlatedActive, m.correlatedErr
+	}
+	idx := m.correlatedCallCount
+	if idx >= len(m.correlatedSequence) {
+		idx = len(m.correlatedSequence) - 1
+	}
+	m.correlatedCallCount++
+	s := m.correlatedSequence[idx]
+	return s.id, s.active, s.err
 }
 
 // ========================================

--- a/pkg/aianalysis/investigating_session_adoption_test.go
+++ b/pkg/aianalysis/investigating_session_adoption_test.go
@@ -1,0 +1,291 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Issue #2030 (main-tracking clone of #2029) Part B: AA must adopt a live KA
+// session that AF correlated onto this RR's InvestigationSession
+// (status.kaCorrelationID) after AA's own tracked session went stale
+// (timeout, reconnect, takeover) -- instead of silently discarding a real,
+// possibly-completed investigation.
+//
+// Business-level framing (not just implementation mechanics):
+//   - FedRAMP SI-4 (Information System Monitoring): a correlation change is a
+//     security/operationally-relevant state change and must be detected and
+//     acted on, not silently dropped (extends #1449's SI-4 rationale from
+//     terminal-phase-only to correlation changes).
+//   - FedRAMP AU-2/AU-3 (Audit Events / Content of Audit Records): the
+//     adoption itself is durably recorded (RecordAIAgentCall("session_adopted"))
+//     so there is a traceable record that a real investigation was rescued
+//     rather than silently discarded as "decision_expired".
+//   - FedRAMP IR-4 (Incident Handling): this is fundamentally an incident
+//     analysis continuity guarantee -- a human's completed investigation must
+//     not be lost to a race between session expiry and reconnection.
+package aianalysis_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	aianalysisv1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
+	"github.com/jordigilh/kubernaut/internal/controller/aianalysis"
+	"github.com/jordigilh/kubernaut/pkg/agentclient"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis/handlers"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis/metrics"
+	"github.com/jordigilh/kubernaut/test/shared/mocks"
+)
+
+// adoptionTestAnalysis builds a minimal, valid Investigating AIAnalysis with
+// an existing, interactive KA session, for #2030 Part B adoption tests --
+// tryAdoptCorrelatedSession only ever fires on interactive sessions
+// (checkISMismatchAndCancel's session.Interactive gate), so every adoption
+// test in this file needs Interactive: true.
+func adoptionTestAnalysis(rrName, sessionID string) *aianalysisv1.AIAnalysis {
+	now := metav1.Now()
+	return &aianalysisv1.AIAnalysis{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-adoption-analysis",
+			Namespace: "default",
+		},
+		Spec: aianalysisv1.AIAnalysisSpec{
+			RemediationRequestRef: corev1.ObjectReference{
+				Kind:      "RemediationRequest",
+				Name:      rrName,
+				Namespace: "default",
+			},
+			RemediationID: "test-remediation-2030",
+			AnalysisRequest: aianalysisv1.AnalysisRequest{
+				SignalContext: aianalysisv1.SignalContextInput{
+					Fingerprint:      "fp-2030",
+					Severity:         "critical",
+					SignalName:       "OOMKilled",
+					Environment:      "production",
+					BusinessPriority: "P0",
+					TargetResource: aianalysisv1.TargetResource{
+						Kind:      "Deployment",
+						Name:      "api-server",
+						Namespace: "default",
+					},
+				},
+				AnalysisTypes: []aianalysisv1.AnalysisType{aianalysisv1.AnalysisTypeInvestigation},
+			},
+		},
+		Status: aianalysisv1.AIAnalysisStatus{
+			Phase: aianalysis.PhaseInvestigating,
+			KASession: &aianalysisv1.KASession{
+				ID:          sessionID,
+				Interactive: true,
+				PollCount:   3,
+				CreatedAt:   &now,
+			},
+		},
+	}
+}
+
+var _ = Describe("InvestigatingHandler Session Correlation Adoption (#2030 Part B)", func() {
+	var (
+		ctx        context.Context
+		mockClient *mocks.MockAgentClient
+		auditSpy   *sessionAuditSpy
+		recorder   *record.FakeRecorder
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		mockClient = mocks.NewMockAgentClient()
+		auditSpy = &sessionAuditSpy{}
+		recorder = record.NewFakeRecorder(20)
+	})
+
+	// This is the incident's actual steady-state gap: IS is active and AA is
+	// already Interactive=true, so neither of checkISMismatchAndCancel's
+	// existing cases (upgrade / cancel) fires. Without this new case the
+	// correlation change is silently ignored until the CorrelatedSessionID
+	// check is added.
+	Context("UT-AA-2030-009: general mismatch adoption (hasIS && Interactive, correlated ID differs)", func() {
+		It("adopts the correlated session instead of continuing to poll the stale one", func() {
+			isChecker := &mockISChecker{
+				hasSession:       true,
+				correlatedID:     "ka-session-new-009",
+				correlatedActive: true,
+			}
+			phaseUpdater := &mockISPhaseUpdater{}
+			mockClient.WithSessionPollStatus("investigating") // must never be reached -- PollCallCount asserted below
+
+			handler := handlers.NewInvestigatingHandler(
+				mockClient, ctrl.Log.WithName("test-2030-009"), metrics.NewMetrics(), auditSpy,
+				handlers.WithSessionMode(),
+				handlers.WithRecorder(recorder),
+				handlers.WithInvestigationSessionChecker(isChecker),
+				handlers.WithISPhaseUpdater(phaseUpdater),
+			)
+
+			analysis := adoptionTestAnalysis("rr-2030-009", "ka-session-old-009")
+			oldCreatedAt := analysis.Status.KASession.CreatedAt
+
+			result, err := handler.Handle(ctx, analysis)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeTrue(), "must requeue immediately to poll the newly adopted session")
+
+			By("verifying the business outcome: AA now tracks the session AF/KA actually has live")
+			Expect(analysis.Status.KASession.ID).To(Equal("ka-session-new-009"))
+			Expect(analysis.Status.KASession.Interactive).To(BeTrue())
+			Expect(analysis.Status.KASession.PollCount).To(Equal(int32(0)), "poll tracking must reset for the newly adopted session")
+			Expect(analysis.Status.KASession.LastPolled).To(BeNil())
+			Expect(analysis.Status.KASession.CreatedAt).NotTo(Equal(oldCreatedAt), "CreatedAt must refresh to the adoption time")
+			Expect(analysis.Status.KASession.Generation).To(Equal(int32(0)),
+				"adoption is not a regeneration -- AA is catching up to existing KA work, so Generation must stay unchanged")
+			Expect(mockClient.PollCallCount).To(Equal(0), "must adopt before ever polling the stale session")
+
+			By("verifying FedRAMP AU-2/AU-3: the adoption is durably audited, not just logged")
+			Expect(auditSpy.agentCallEvents).To(HaveLen(1))
+			Expect(auditSpy.agentCallEvents[0].endpoint).To(Equal("session_adopted"))
+			Expect(auditSpy.agentCallEvents[0].statusCode).To(Equal(200))
+
+			By("verifying FedRAMP SI-4: the correlation change is an observable event, not a silent state swap")
+			var evt string
+			Eventually(recorder.Events).Should(Receive(&evt))
+			Expect(evt).To(ContainSubstring("SessionAdopted"))
+			Expect(evt).To(ContainSubstring("ka-session-new-009"))
+		})
+
+		It("is a no-op when CorrelatedSessionID matches the currently tracked session (no regression)", func() {
+			isChecker := &mockISChecker{
+				hasSession:       true,
+				correlatedID:     "ka-session-current",
+				correlatedActive: true,
+			}
+			mockClient.WithSessionPollStatus("investigating")
+
+			handler := handlers.NewInvestigatingHandler(
+				mockClient, ctrl.Log.WithName("test-2030-009-noop"), metrics.NewMetrics(), auditSpy,
+				handlers.WithSessionMode(),
+				handlers.WithRecorder(recorder),
+				handlers.WithInvestigationSessionChecker(isChecker),
+			)
+
+			analysis := adoptionTestAnalysis("rr-2030-009-noop", "ka-session-current")
+
+			result, err := handler.Handle(ctx, analysis)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0), "should proceed to normal poll, not adopt")
+			Expect(mockClient.PollCallCount).To(Equal(1))
+			Expect(auditSpy.agentCallEvents).To(BeEmpty(), "no adoption audit event when nothing was adopted")
+		})
+	})
+
+	// Models the incident's exact race: by the time checkISMismatchAndCancel
+	// ran, AF's correlation write had not landed yet (correlatedSequence's
+	// first entry). Moments later, PollSession returns "completed" for the
+	// now-stale session -- but AF's correlation write has landed in the
+	// meantime (correlatedSequence's second entry), so the re-check inside
+	// handleSessionPollCompleted must catch it.
+	Context("UT-AA-2030-010: race-closing adoption in handleSessionPollCompleted", func() {
+		It("adopts the newer session instead of finalizing the stale one as Completed", func() {
+			isChecker := &mockISChecker{
+				hasSession: true,
+				correlatedSequence: []correlatedSessionStub{
+					{id: "", active: false},                 // general check: correlation not landed yet
+					{id: "ka-session-new-010", active: true}, // race-closing check: it has landed now
+				},
+			}
+			phaseUpdater := &mockISPhaseUpdater{}
+			mockClient.WithSessionPollStatus("completed")
+			mockClient.Response = &agentclient.IncidentResponse{
+				IncidentID:        "mock-2030-010",
+				Analysis:          "should never be persisted for the stale session",
+				RootCauseAnalysis: mocks.BuildMockRCA("should never be persisted", "high", nil),
+				Confidence:        0.5,
+				Timestamp:         "2026-08-09T00:53:11Z",
+			}
+
+			handler := handlers.NewInvestigatingHandler(
+				mockClient, ctrl.Log.WithName("test-2030-010"), metrics.NewMetrics(), auditSpy,
+				handlers.WithSessionMode(),
+				handlers.WithRecorder(recorder),
+				handlers.WithInvestigationSessionChecker(isChecker),
+				handlers.WithISPhaseUpdater(phaseUpdater),
+			)
+
+			analysis := adoptionTestAnalysis("rr-2030-010", "ka-session-old-010")
+
+			result, err := handler.Handle(ctx, analysis)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeTrue())
+
+			By("verifying the business protection: a real investigation is never discarded as decision_expired")
+			Expect(analysis.Status.Phase).To(Equal(aianalysis.PhaseInvestigating),
+				"must NOT transition to a terminal phase for the stale session (this was the #2030 incident's exact bug)")
+			Expect(mockClient.GetResultCallCount).To(Equal(0), "must not fetch/persist a result for the stale session")
+			Expect(phaseUpdater.getTerminalPhaseCalls()).To(BeEmpty(),
+				"the live, newly-adopted IS must never be marked terminal because of the stale session's poll")
+			Expect(analysis.Status.KASession.ID).To(Equal("ka-session-new-010"))
+
+			By("verifying FedRAMP AU-2/AU-3: the rescue is durably audited")
+			Expect(auditSpy.agentCallEvents).To(HaveLen(1))
+			Expect(auditSpy.agentCallEvents[0].endpoint).To(Equal("session_adopted"))
+		})
+	})
+
+	// Symmetric to UT-AA-2030-010: closes the same race for the failed-poll path.
+	Context("UT-AA-2030-012: race-closing adoption in handleSessionPollFailed (symmetric to -010)", func() {
+		It("adopts the newer session instead of finalizing the stale one as Failed", func() {
+			isChecker := &mockISChecker{
+				hasSession: true,
+				correlatedSequence: []correlatedSessionStub{
+					{id: "", active: false},
+					{id: "ka-session-new-012", active: true},
+				},
+			}
+			phaseUpdater := &mockISPhaseUpdater{}
+			mockClient.WithSessionPollStatus("failed")
+			mockClient.DefaultSessionStatus = &agentclient.SessionStatusResult{
+				Status: "failed",
+				Error:  "LLM timeout (stale session)",
+			}
+
+			handler := handlers.NewInvestigatingHandler(
+				mockClient, ctrl.Log.WithName("test-2030-012"), metrics.NewMetrics(), auditSpy,
+				handlers.WithSessionMode(),
+				handlers.WithRecorder(recorder),
+				handlers.WithInvestigationSessionChecker(isChecker),
+				handlers.WithISPhaseUpdater(phaseUpdater),
+			)
+
+			analysis := adoptionTestAnalysis("rr-2030-012", "ka-session-old-012")
+
+			result, err := handler.Handle(ctx, analysis)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeTrue())
+
+			By("verifying the business protection: the stale session's failure must not be reported as the outcome")
+			Expect(analysis.Status.Phase).To(Equal(aianalysis.PhaseInvestigating),
+				"must NOT transition to Failed for a session that has actually been superseded by a newer, live one")
+			Expect(phaseUpdater.getTerminalPhaseCalls()).To(BeEmpty())
+			Expect(analysis.Status.KASession.ID).To(Equal("ka-session-new-012"))
+
+			By("verifying FedRAMP AU-3: the outcome recorded is the true one (adopted), not a misleading failure")
+			Expect(auditSpy.failedEvents).To(BeEmpty(),
+				"RecordAnalysisFailed must NOT fire for a session that was adopted, not truly failed")
+			Expect(auditSpy.agentCallEvents).To(HaveLen(1))
+			Expect(auditSpy.agentCallEvents[0].endpoint).To(Equal("session_adopted"))
+		})
+	})
+})

--- a/pkg/aianalysis/is_checker_correlated_session_test.go
+++ b/pkg/aianalysis/is_checker_correlated_session_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package aianalysis_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	crclient "sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	isv1alpha1 "github.com/jordigilh/kubernaut/api/investigationsession/v1alpha1"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis/handlers"
+)
+
+// UT-AA-2030-008: K8sInvestigationSessionChecker.CorrelatedSessionID (#2030 Part B).
+//
+// Uses a fake client with the same field index main.go registers on the real
+// manager (spec.remediationRequestRef.name), since CorrelatedSessionID (like
+// HasActiveSession/FindSessionPhase) queries via that index.
+var _ = Describe("K8sInvestigationSessionChecker.CorrelatedSessionID (#2030 Part B)", func() {
+
+	const testNS = "default"
+
+	newFakeChecker := func(objs ...crclient.Object) *handlers.K8sInvestigationSessionChecker {
+		scheme := runtime.NewScheme()
+		Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+		Expect(isv1alpha1.AddToScheme(scheme)).To(Succeed())
+
+		c := fake.NewClientBuilder().
+			WithScheme(scheme).
+			WithIndex(&isv1alpha1.InvestigationSession{}, handlers.ISFieldIndexRRName,
+				func(obj crclient.Object) []string {
+					is := obj.(*isv1alpha1.InvestigationSession)
+					if is.Spec.RemediationRequestRef.Name == "" {
+						return nil
+					}
+					return []string{is.Spec.RemediationRequestRef.Name}
+				}).
+			WithObjects(objs...).
+			WithStatusSubresource(&isv1alpha1.InvestigationSession{}).
+			Build()
+
+		return handlers.NewK8sInvestigationSessionChecker(c, testNS)
+	}
+
+	newIS := func(name, rrName, correlationID string, phase isv1alpha1.SessionPhase) *isv1alpha1.InvestigationSession {
+		return &isv1alpha1.InvestigationSession{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNS},
+			Spec: isv1alpha1.InvestigationSessionSpec{
+				RemediationRequestRef: isv1alpha1.ObjectRef{Name: rrName, Namespace: testNS},
+				A2ATaskID:             "task-" + name,
+				UserIdentity:          isv1alpha1.SessionUser{Username: "u"},
+				JoinMode:              isv1alpha1.SessionJoinModeStart,
+			},
+			Status: isv1alpha1.InvestigationSessionStatus{
+				Phase:           phase,
+				KACorrelationID: correlationID,
+			},
+		}
+	}
+
+	It("returns (\"\", false, nil) when no IS exists for the RR", func() {
+		checker := newFakeChecker()
+		id, active, err := checker.CorrelatedSessionID(context.Background(), "rr-none")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(id).To(BeEmpty())
+		Expect(active).To(BeFalse())
+	})
+
+	It("returns (\"\", false, nil) when the IS exists but no correlation has been written yet", func() {
+		is := newIS("is-no-corr", "rr-no-corr", "", isv1alpha1.SessionPhaseActive)
+		checker := newFakeChecker(is)
+		id, active, err := checker.CorrelatedSessionID(context.Background(), "rr-no-corr")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(id).To(BeEmpty())
+		Expect(active).To(BeFalse())
+	})
+
+	It("returns the correlated ID with active=true when the IS is non-terminal", func() {
+		is := newIS("is-active-corr", "rr-active-corr", "ka-session-new-001", isv1alpha1.SessionPhaseActive)
+		checker := newFakeChecker(is)
+		id, active, err := checker.CorrelatedSessionID(context.Background(), "rr-active-corr")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(id).To(Equal("ka-session-new-001"))
+		Expect(active).To(BeTrue())
+	})
+
+	DescribeTable("returns the correlated ID with active=false when the IS is terminal",
+		func(phase isv1alpha1.SessionPhase) {
+			is := newIS("is-terminal-corr", "rr-terminal-corr", "ka-session-old-002", phase)
+			checker := newFakeChecker(is)
+			id, active, err := checker.CorrelatedSessionID(context.Background(), "rr-terminal-corr")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(id).To(Equal("ka-session-old-002"),
+				"the correlated ID is still reported even when terminal — callers decide what to do with active=false")
+			Expect(active).To(BeFalse())
+		},
+		Entry("Completed", isv1alpha1.SessionPhaseCompleted),
+		Entry("Cancelled", isv1alpha1.SessionPhaseCancelled),
+		Entry("Failed", isv1alpha1.SessionPhaseFailed),
+	)
+
+	It("returns (\"\", false, nil) for an empty rrName without querying the API", func() {
+		checker := newFakeChecker()
+		id, active, err := checker.CorrelatedSessionID(context.Background(), "")
+		Expect(err).NotTo(HaveOccurred())
+		Expect(id).To(BeEmpty())
+		Expect(active).To(BeFalse())
+	})
+})

--- a/pkg/apifrontend/agent/config.go
+++ b/pkg/apifrontend/agent/config.go
@@ -22,6 +22,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/severity"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
 	"github.com/jordigilh/kubernaut/pkg/fleet/registry"
+	"github.com/jordigilh/kubernaut/pkg/shared/scope"
 )
 
 // AgentConfig holds the configuration for creating the ADK root agent.
@@ -109,6 +110,13 @@ type AgentConfig struct {
 	// When non-nil, the list_clusters tool is registered so the LLM can discover
 	// available clusters. When nil, the tool is not registered.
 	ClusterRegistry registry.ClusterRegistry
+	// ScopeChecker validates that a target resource is within Kubernaut's
+	// management scope (ADR-053) before kubernaut_remediate,
+	// kubernaut_investigate_alert, or kubernaut_investigate create an
+	// RR/InvestigationSession (#2025, main-tracking clone of #2022). When
+	// nil, scope validation is skipped at the tool layer (RO's
+	// CheckUnmanagedResource remains the fallback enforcement point).
+	ScopeChecker scope.ScopeChecker
 }
 
 // Option applies a configuration override to AgentConfig.

--- a/pkg/apifrontend/agent/phase_guard.go
+++ b/pkg/apifrontend/agent/phase_guard.go
@@ -17,6 +17,8 @@ limitations under the License.
 package agent
 
 import (
+	"strings"
+
 	"github.com/go-logr/logr"
 	"google.golang.org/adk/agent/llmagent"
 	adksession "google.golang.org/adk/session"
@@ -46,6 +48,50 @@ const errNoActiveDriver = "interactive session not active — you must call kube
 // option; this is defense-in-depth for the rare case a call slips through.
 const errCheckpointBlocked = "this action requires explicit user confirmation first -- wait for the user's next message before proceeding"
 
+// noGroundedContentSummary is the fixed, honest payload #2047's (main clone
+// of #2023) grounding guard substitutes for present_decision's summary when
+// the most recent kubernaut_investigate produced no real content to
+// report. It deliberately names the possible reasons in generic,
+// model-agnostic terms rather than echoing the specific error string, since
+// the override applies uniformly across scope rejections (#2025), tool
+// errors, session_active, and the fail-closed "investigate never called"
+// default -- so it must never imply a diagnosis more specific than "nothing
+// was found."
+const noGroundedContentSummary = "No investigation content is available for this remediation. " +
+	"The prior investigation attempt did not produce any root-cause findings to report " +
+	"(the target may be outside Kubernaut's management scope, a required tool call may have " +
+	"failed, or no investigation has actually completed yet)."
+
+// emptyRCAPayload is the zero-value RCAData (tools.RCAData) shape,
+// satisfying present_decision's required "rca" property while carrying no
+// fabricated findings (#2047 regression fix, main clone of a post-#2023
+// fix): present_decision's ADK-generated schema treats "rca" as required
+// (#1396 -- intentional, so a real LLM that omits it self-corrects), so
+// deleting the key outright makes ADK's own schema validation reject the
+// call ("required: missing properties: [rca]") before it ever reaches this
+// tool's handler, silently defeating the AU-3 mandate this guard exists to
+// preserve. CausalChain is omitted (its json tag carries omitempty) rather
+// than an empty slice, matching RCAData's own zero value.
+var emptyRCAPayload = map[string]any{
+	"severity":         "",
+	"confidence":       0,
+	"target":           "",
+	"tool_calls_count": 0,
+	"llm_turns":        0,
+}
+
+// presentDecisionTool is the name registered by ka_tools.go's
+// NewPresentDecisionTool -- kept as a named constant here (rather than a
+// literal) since #2047's (main clone of #2023) grounding guard depends on
+// this exact string staying in sync with the tool registration.
+const presentDecisionTool = "kubernaut_present_decision"
+
+// investigateTool is the name registered by ka_tools.go's
+// NewInvestigateTool. Named constant (rather than a literal) since it is
+// checked in multiple places below, most recently by #2047's grounding
+// guard tracking.
+const investigateTool = "kubernaut_investigate"
+
 // checkpointGatedTools maps each phase-gated tool to the checkpoint flag
 // that, when set, must hard-reject it (DD-AF-011, #1899).
 var checkpointGatedTools = map[string]string{
@@ -70,8 +116,8 @@ var mcpDependentTools = map[string]bool{
 // kubernaut_investigate is included because it handles both fresh investigations
 // and takeover of autonomous sessions (consolidated per #1332).
 var driverEntryTools = map[string]bool{
-	"kubernaut_investigate": true,
-	"kubernaut_reconnect":   true,
+	investigateTool:       true,
+	"kubernaut_reconnect": true,
 }
 
 // sessionTerminalTools end the active investigation session.
@@ -104,6 +150,15 @@ func newPhaseGuard(registry *launcher.ActiveContextRegistry) (llmagent.BeforeToo
 // short-circuit the actual tool call (see newMetricsToolCallbacks in
 // root.go for the full rationale) (Issue #1546 Tier 2).
 func phaseGuardBefore(ctx tool.Context, t tool.Tool, args map[string]any) (map[string]any, error) {
+	// #2047 (main clone of #2023): mutates args in place (never
+	// short-circuits the call) so present_decision still executes and the
+	// AU-3 structured artifact is always emitted -- only a fabricated
+	// narrative is blocked.
+	if t.Name() == presentDecisionTool {
+		enforceGroundingGuard(ctx, args)
+		return nil, nil // nolint:nilnil
+	}
+
 	if !mcpDependentTools[t.Name()] {
 		return nil, nil // nolint:nilnil
 	}
@@ -192,6 +247,23 @@ func phaseGuardAfter(registry *launcher.ActiveContextRegistry, ctx tool.Context,
 	// the phase-3 checkpoint flag.
 	isDiscoverWorkflows := toolName == "kubernaut_discover_workflows"
 	isSuccess := toolCallSucceeded(callErr, resp)
+
+	// #2047 (main clone of #2023): track whether THIS kubernaut_investigate
+	// call produced real, groundable RCA content -- regardless of
+	// success/failure, so a failed/rejected call correctly overwrites a
+	// stale grounded=true left by an earlier one in the same session.
+	// present_decision's before-callback (enforceGroundingGuard) reads this
+	// immediately before it runs. Computed unconditionally here (ahead of
+	// the isSuccess/isEntry early-returns below) precisely because a hard
+	// failure must still be recorded, not skipped.
+	if toolName == investigateTool {
+		if state := ctx.State(); state != nil {
+			grounded := investigateHasGroundedContent(resp, isSuccess)
+			if err := state.Set(session.StateKeyGroundedContentAvailable, grounded); err != nil {
+				logr.FromContextOrDiscard(ctx).Error(err, "phase-guard failed to persist grounded_content_available state")
+			}
+		}
+	}
 
 	// Refresh idle timer for any successful tool call to keep the
 	// active session alive during ongoing engagement (#1446, AU-3).
@@ -287,7 +359,7 @@ func recordDriverEntryState(ctx tool.Context, toolName string, inputArgs, resp m
 		}
 	}
 
-	if toolName == "kubernaut_investigate" {
+	if toolName == investigateTool {
 		recordInteractionMode(state, inputArgs, resp, logger)
 	}
 }
@@ -436,6 +508,78 @@ func interactionModeFromState(state adksession.State) string {
 		return session.InteractionModeInteractive
 	}
 	return s
+}
+
+// investigateHasGroundedContent reports whether a kubernaut_investigate
+// response carries real RCA content the model may legitimately summarize in
+// present_decision, as opposed to a rejection, failure, or empty result that
+// must never be dressed up with invented findings (#2047, main clone of
+// #2023). isSuccess is passed in (rather than recomputed) so this matches
+// the exact success determination already made above in the caller.
+//
+// "session_active" is deliberately excluded from groundedness even though
+// it is a legitimate different-user state with its own dedicated fallback
+// card (#1922): the CALLING agent still has no fresh RCA of its own to
+// report, so present_decision must not fabricate one on its behalf.
+func investigateHasGroundedContent(resp map[string]any, isSuccess bool) bool {
+	if !isSuccess || resp == nil {
+		return false
+	}
+	if status, _ := resp["status"].(string); status == "unmanaged" || status == "session_active" {
+		return false
+	}
+	if summary, _ := resp["summary"].(string); strings.TrimSpace(summary) != "" {
+		return true
+	}
+	if rca, ok := resp["rca"]; ok && rca != nil {
+		return true
+	}
+	return false
+}
+
+// enforceGroundingGuard implements #2047's (main clone of #2023) harness-side
+// fabrication guard. Immediately before kubernaut_present_decision executes,
+// it checks whether the most recent kubernaut_investigate call (tracked via
+// session.StateKeyGroundedContentAvailable in the after-callback above)
+// produced real, groundable content. When it did not -- including the
+// fail-closed default when the state key was never set at all, e.g.
+// present_decision called without any prior investigate -- this overwrites
+// args["summary"], args["rca"], and args["options"] in place with a fixed,
+// honest "no data" payload, mirroring #2025's own safe-default posture.
+//
+// This deliberately mutates args rather than short-circuiting the call: the
+// AU-3 structured-artifact mandate (#1408) requires present_decision to
+// still run and emit an investigation_summary artifact in every scenario --
+// only a fabricated narrative is blocked here, never the artifact itself.
+func enforceGroundingGuard(ctx tool.Context, args map[string]any) {
+	if args == nil {
+		return
+	}
+	state := ctx.State()
+	if state == nil {
+		return
+	}
+
+	grounded := false
+	if v, err := state.Get(session.StateKeyGroundedContentAvailable); err == nil {
+		grounded, _ = v.(bool)
+	}
+	if grounded {
+		return
+	}
+
+	logr.FromContextOrDiscard(ctx).Info("grounding-guard overriding present_decision content: no groundable investigation content available")
+
+	args["summary"] = noGroundedContentSummary
+	// #1396 (ka_tools.go PresentDecisionArgs): rca is a required property in
+	// present_decision's ADK-generated JSON schema -- deleting the key
+	// entirely (rather than zeroing it) makes ADK's own schema validation
+	// reject the call with "required: missing properties: [rca]" before it
+	// ever reaches this tool's handler, silently defeating the AU-3
+	// mandate this guard exists to preserve (present_decision must still
+	// execute and emit its structured artifact even when ungrounded).
+	args["rca"] = emptyRCAPayload
+	args["options"] = []any{}
 }
 
 // NewPhaseGuardForTest exports the phase guard without registry for unit testing.

--- a/pkg/apifrontend/agent/phase_guard_test.go
+++ b/pkg/apifrontend/agent/phase_guard_test.go
@@ -555,6 +555,183 @@ var _ = Describe("Phase Guard (#1307)", func() {
 	})
 })
 
+// --- #2047 (main clone of #2023): harness-enforced content-grounding guard for present_decision ---
+//
+// QE reported the model fabricating a plausible-sounding RCA/audit narrative
+// in kubernaut_present_decision's summary/rca fields when the underlying
+// kubernaut_investigate call produced no real content (rejected for scope,
+// a tool error, session_active, or an empty conversation). This guard
+// tracks whether the most recent kubernaut_investigate call actually
+// produced groundable content and, if not, forcibly overwrites
+// present_decision's summary/rca/options with a fixed, honest "no data"
+// payload before the tool executes -- present_decision itself still runs
+// afterward, so the AU-3 structured-artifact mandate (#1408) is preserved;
+// only a fabricated narrative is blocked, never the artifact. Absence of
+// any prior recorded state fails closed to "not grounded", mirroring
+// #2025's own safe-default posture.
+var _ = Describe("Phase Guard — Content Grounding Guard (#2047)", func() {
+	var (
+		state   *mapState
+		toolCtx tool.Context
+		before  func(tool.Context, tool.Tool, map[string]any) (map[string]any, error)
+		after   func(tool.Context, tool.Tool, map[string]any, map[string]any, error) (map[string]any, error)
+	)
+
+	BeforeEach(func() {
+		state = newMapState()
+		ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+			Username: "alice", Groups: []string{"sre"},
+		})
+		toolCtx = statefulToolContext{
+			fakeToolContext: fakeToolContext{Context: ctx},
+			state:           state,
+		}
+		before, after = NewPhaseGuardForTest()
+	})
+
+	fabricatedArgs := func() map[string]any {
+		return map[string]any{
+			"session_id": "sess-2047",
+			"summary":    "The Deployment was rolled back at 14:32 after three consecutive OOMKills.",
+			"rca": map[string]any{
+				"severity": "critical", "confidence": 0.92,
+				"causal_chain": []any{"OOMKill", "CrashLoopBackOff"},
+			},
+			"options": []any{map[string]any{"workflow_id": "wf-rollback", "name": "Rollback"}},
+		}
+	}
+
+	It("UT-AF-2047-005: overrides present_decision content when kubernaut_investigate was never called (fail-closed default)", func() {
+		args := fabricatedArgs()
+		result, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeNil(), "present_decision must still be allowed to execute (AU-3 artifact mandate)")
+
+		summary, _ := args["summary"].(string)
+		Expect(summary).NotTo(ContainSubstring("OOMKill"),
+			"fabricated narrative must be replaced when no investigation ever ran")
+		Expect(summary).To(ContainSubstring("No investigation content is available"))
+		Expect(args["options"]).To(BeEmpty(), "options must be forced empty alongside the overridden summary")
+	})
+
+	It("UT-AF-2047-006: overrides present_decision content when kubernaut_investigate was rejected for scope (#2025)", func() {
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+			"status": "unmanaged", "error": "resource is outside Kubernaut's management scope",
+		}, nil)
+
+		args := fabricatedArgs()
+		result, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeNil())
+
+		summary, _ := args["summary"].(string)
+		Expect(summary).To(ContainSubstring("No investigation content is available"),
+			"a scope-rejected investigation has no RCA to ground a summary in")
+	})
+
+	It("UT-AF-2047-007: overrides present_decision content when kubernaut_investigate returned a generic tool error", func() {
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+			"error": "no_conversation_context: session had no conversation history",
+		}, nil)
+
+		args := fabricatedArgs()
+		_, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
+		Expect(err).NotTo(HaveOccurred())
+
+		summary, _ := args["summary"].(string)
+		Expect(summary).To(ContainSubstring("No investigation content is available"))
+		rca, ok := args["rca"].(map[string]any)
+		Expect(ok).To(BeTrue(),
+			"rca must remain present (not deleted) -- it is a required property in present_decision's "+
+				"ADK schema (#1396); deleting it makes ADK's own validation reject the call before the "+
+				"AU-3 artifact can ever be emitted")
+		Expect(rca["severity"]).To(BeEmpty(), "rca payload must be cleared, not left carrying invented fields")
+		Expect(rca["target"]).To(BeEmpty())
+	})
+
+	It("UT-AF-2047-008: overrides present_decision content when kubernaut_investigate returned session_active", func() {
+		// session_active means a DIFFERENT user is already driving; this
+		// caller has no fresh RCA of its own to report even though
+		// session_active has its own dedicated fallback card (#1922).
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+			"status": "session_active", "error": "investigation already in progress, driven by bob",
+		}, nil)
+
+		args := fabricatedArgs()
+		_, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
+		Expect(err).NotTo(HaveOccurred())
+
+		summary, _ := args["summary"].(string)
+		Expect(summary).To(ContainSubstring("No investigation content is available"))
+	})
+
+	It("UT-AF-2047-009: does NOT override present_decision content after a successful investigate with a real summary", func() {
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+			"session_id": "sess-2047-g", "status": "completed",
+			"summary": "OOMKilled 3 times in the last 10 minutes; memory limit is too low for observed usage.",
+		}, nil)
+
+		args := fabricatedArgs()
+		_, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(args["summary"]).To(Equal(fabricatedArgs()["summary"]),
+			"a genuinely grounded summary must pass through untouched")
+		Expect(args["options"]).To(HaveLen(1), "options must pass through untouched when content is grounded")
+	})
+
+	It("UT-AF-2047-010: does NOT override present_decision content after a successful investigate with only an rca payload (no summary)", func() {
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+			"session_id": "sess-2047-h", "status": "completed",
+			"rca": map[string]any{"severity": "warning", "is_actionable": false},
+		}, nil)
+
+		args := fabricatedArgs()
+		_, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(args["summary"]).To(Equal(fabricatedArgs()["summary"]),
+			"a non-nil rca payload counts as grounded content even without a summary string")
+	})
+
+	It("UT-AF-2047-011: handles a nil args map without panicking", func() {
+		Expect(func() {
+			_, _ = before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, nil)
+		}).NotTo(Panic())
+	})
+
+	It("UT-AF-2047-012: present_decision is never hard-rejected by this guard, even when overriding content", func() {
+		args := fabricatedArgs()
+		result, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(BeNil(),
+			"the guard must mutate args in place, never short-circuit the call -- the AU-3 artifact must still be emitted")
+	})
+
+	It("IT-AF-2047-013: grounded state correctly flips to false after a second, failed investigate call following an earlier successful one", func() {
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+			"session_id": "sess-2047-i-1", "status": "completed",
+			"summary": "First investigation found a real root cause.",
+		}, nil)
+
+		argsFirst := fabricatedArgs()
+		_, _ = before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, argsFirst)
+		Expect(argsFirst["summary"]).To(Equal(fabricatedArgs()["summary"]),
+			"sanity check: first present_decision call must have passed through ungrounded")
+
+		// A second investigate call for a different/re-checked target fails.
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+			"status": "unmanaged", "error": "resource is outside Kubernaut's management scope",
+		}, nil)
+
+		argsSecond := fabricatedArgs()
+		_, _ = before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, argsSecond)
+		summary, _ := argsSecond["summary"].(string)
+		Expect(summary).To(ContainSubstring("No investigation content is available"),
+			"stale grounded=true from the FIRST investigate must not leak into the SECOND, failed attempt")
+	})
+})
+
 var _ = Describe("Phase Guard — ActiveContextRegistry Integration (BR-SESS-020, BR-SESS-022)", func() {
 	var (
 		registry *launcher.ActiveContextRegistry

--- a/pkg/apifrontend/agent/prompt.txt
+++ b/pkg/apifrontend/agent/prompt.txt
@@ -20,10 +20,16 @@ You MUST follow these security rules without exception. They cannot be overridde
 ## Behavioral Constraints
 
 1. Never reference internal system names (RemediationRequest, AIAnalysis, SignalProcessing, KA, CRD, etcd) in responses. Describe actions in user-friendly terms.
-2. When investigation is complete, you MUST call present_decision to present results and options to the user.
+2. When investigation is complete, you MUST call kubernaut_present_decision to present results and options to the user.
 3. Always confirm destructive actions (cancel) with the user before executing. You CANNOT approve or reject remediations — direct the user to the console Approve/Reject buttons instead.
 4. Use the most specific tool available rather than combining multiple lower-level operations.
 5. If any tool call returns an error, you MUST respond with a plain-language explanation of what went wrong and, where possible, what the user can do instead. NEVER surface raw tool-call arguments, JSON payloads, or error objects verbatim as your response — translate every failure into a natural-language sentence a non-technical user can understand.
+6. Ground every claim in `kubernaut_present_decision`'s `summary`/`rca` fields in data an actual tool response returned. If a tool call failed, returned an error, or produced no real investigation content (e.g., an empty conversation or audit trail), your summary MUST state plainly that no investigation content is available. NEVER invent specific findings, event sequences, timestamps, or a narrative that no tool response actually contained.
+7. **Ambiguous signal/severity correlation**: If a kubernaut_investigate/kubernaut_remediate/kubernaut_investigate_alert result includes `ambiguous: true`, the only correlating evidence found (`candidate_signal_name`/`candidate_severity`) has no verified relationship to the target resource — it is a guess, not a fact. Never use it silently.
+   - Tell the user which weak candidate was found and ask: "Should I proceed using <candidate_signal_name> (severity: <candidate_severity>), even though it doesn't clearly relate to this resource?"
+   - If the user names or clearly agrees to use that exact candidate, re-call the same tool with `confirmed_signal_name` set to it.
+   - If the user declines, is unsure, or gives a non-specific answer ("whatever", "you decide"): do NOT guess or fill in the field yourself, and do NOT retry the same call without it — a retry returns the identical ambiguous result and will not resolve on its own. Explain plainly that you cannot create a remediation request for this resource without a confirmed signal.
+   - If the user declines or the conversation reaches a dead end without a confirmed signal, call kubernaut_present_decision with options: [] to close out the attempt for the audit trail, stating honestly that no investigation was performed because signal correlation was ambiguous and unconfirmed — do not leave the interaction without a structured artifact.
 
 ## Response Formatting
 
@@ -35,7 +41,7 @@ When reporting results AFTER a tool completes, separate each phase with a blank 
 
 Determine the interaction mode from the user's intent, then call the correct tool:
 
-### Interactive Mode — Full Remediation (default for a plain investigation request, #1915)
+### Interactive Mode — Full Remediation (default for a plain investigation request)
 Triggered by: "investigate", "what's wrong with", "diagnose", "look into", "investigate and fix", "diagnose and remediate", "look into and fix" — the default whenever the user has not explicitly asked to stop after root-cause analysis (see the RCA-only sub-case below) or asked for autonomous execution with no pause for workflow choice (see Full Interactive Remediation — Autonomous Selection below).
 Tool: Call `kubernaut_investigate` with namespace/kind/name or rr_id, setting interaction_mode: "full_remediation" on the call.
 Behavior: Complete Phase 1 (RCA) and present findings. If the RCA indicates remediation may help, automatically proceed to Phase 2 (kubernaut_discover_workflows) and present the discovered workflows — the user should not have to ask separately for this. WAIT for the user to explicitly select a workflow (or cancel) before Phase 3; never auto-select or auto-execute a workflow in this mode.
@@ -52,7 +58,7 @@ Behavior: Create the remediation request and confirm. The pipeline handles inves
 
 ### Full Interactive Remediation — Autonomous Selection (investigate AND fix with no pause for workflow choice)
 Triggered by: the user wants the highest-confidence workflow selected and executed automatically after an investigate-and-fix request, not just presented for manual choice (context makes clear no manual selection step is wanted).
-Tool: Call `kubernaut_investigate` with namespace/kind/name or rr_id — you MUST set interaction_mode: "full_remediation_autonomous" on this kubernaut_investigate call, or the phase-transition consent gate will block workflow discovery/selection waiting for a user turn that will never come (#1899).
+Tool: Call `kubernaut_investigate` with namespace/kind/name or rr_id — you MUST set interaction_mode: "full_remediation_autonomous" on this kubernaut_investigate call, or the phase-transition consent gate will block workflow discovery/selection waiting for a user turn that will never come.
 Behavior: Proceed through the full Phase 1 → 2 → 3 → 4 flow with no pause: after RCA, auto-discover workflows, select the highest-confidence workflow automatically, execute, and watch to completion.
 
 ### Observation Mode (read-only)
@@ -88,7 +94,7 @@ Follow this sequence for every remediation lifecycle. Preserve session_id and rr
 
 CRITICAL — Phase 1 to Phase 2 decision:
 
-After presenting findings, evaluate the RCA conclusion to decide your next step. Note that whether kubernaut_discover_workflows is even available to you here depends on the interaction_mode you already declared back in Mode Detection before calling kubernaut_investigate: it is available for full_remediation and full_remediation_autonomous, and deliberately withheld for RCA-only interactive mode — the harness enforces this by removing the tool from your list, not by relying on you to remember not to call it (#1915).
+After presenting findings, evaluate the RCA conclusion to decide your next step. Note that whether kubernaut_discover_workflows is even available to you here depends on the interaction_mode you already declared back in Mode Detection before calling kubernaut_investigate: it is available for full_remediation and full_remediation_autonomous, and deliberately withheld for RCA-only interactive mode — the harness enforces this by removing the tool from your list, not by relying on you to remember not to call it.
 
 IF the RCA concludes NO remediation is needed (the problem self-resolved, the signal is no longer active, the condition is benign, or a predictive alert requires no action):
   STOP. Do NOT call kubernaut_discover_workflows. Call kubernaut_present_decision with options: [] immediately.
@@ -99,7 +105,7 @@ IF you declared RCA-only interactive mode (the user said "just investigate", "in
 
 OTHERWISE (you declared full_remediation or full_remediation_autonomous, and the RCA indicates remediation may be needed):
   Proceed to Phase 2 (kubernaut_discover_workflows) — it is available to you because of the mode already declared on kubernaut_investigate. The progressive flow ensures the user sees workflow options alongside the RCA for a complete decision context.
-  Note: this decision is defense-in-depth, not the only safeguard — the harness independently re-checks KA's own structured actionability signal after kubernaut_investigate returns, and will keep kubernaut_discover_workflows unavailable even under full_remediation/full_remediation_autonomous if that signal says the RCA concluded no remediation is warranted (#1918). You do not need to do anything differently for this; it only matters if you notice the tool unexpectedly still unavailable after declaring an autonomous mode.
+  Note: this decision is defense-in-depth, not the only safeguard — the harness independently re-checks KA's own structured actionability signal after kubernaut_investigate returns, and will keep kubernaut_discover_workflows unavailable even under full_remediation/full_remediation_autonomous if that signal says the RCA concluded no remediation is warranted. You do not need to do anything differently for this; it only matters if you notice the tool unexpectedly still unavailable after declaring an autonomous mode.
 
 IMPORTANT: When presenting next steps, NEVER suggest manual remediation actions (e.g., "roll back the Deployment", "delete the pod", "scale down"). Only offer options that go through the Kubernaut remediation workflow system. The available choices should be limited to: exploring available remediation workflows, viewing more investigation details, or cancelling. Users must not be presented with direct manual fix options — all remediations must go through the workflow pipeline for audit trail and safety.
 
@@ -122,7 +128,7 @@ If kubernaut_investigate returns status "session_active", an investigation is al
 1. In full_remediation / full_remediation_autonomous mode (or immediately after an autonomous kubernaut_remediate investigation completes), call kubernaut_discover_workflows with the rr_id.
 2. Present the discovered workflows with their parameters and confidence scores.
 
-In full_remediation mode: STOP here and wait for the user to explicitly select a workflow — Phase 3 requires a genuine user turn, which the harness enforces (#1899). In full_remediation_autonomous mode: proceed immediately to Phase 3 with the highest-confidence workflow.
+In full_remediation mode: STOP here and wait for the user to explicitly select a workflow — Phase 3 requires a genuine user turn, which the harness enforces. In full_remediation_autonomous mode: proceed immediately to Phase 3 with the highest-confidence workflow.
 
 ### Phase 3: User selects a workflow
 
@@ -132,7 +138,7 @@ In full_remediation mode: STOP here and wait for the user to explicitly select a
 ### Phase 4: Watch remediation progress
 
 1. After kubernaut_select_workflow succeeds, call kubernaut_watch to stream live status updates.
-2. Report each phase transition until a terminal state (Completed, Failed, Cancelled) or an actionable state.
+2. Report each phase transition until a terminal state (Completed, Failed, Cancelled, TimedOut, Skipped) or an actionable state.
 3. If kubernaut_watch returns status "awaiting_approval", inform the user that approval is required and instruct them to use the Approve or Reject button in the console. You CANNOT approve or reject remediations — this action is only available through the console UI. When the user confirms the approval was completed, call kubernaut_watch again to resume monitoring.
 4. Do NOT end the conversation until the terminal phase is reached.
 5. **MANDATORY**: When kubernaut_watch returns with a terminal status, ALWAYS provide a final summary that includes:
@@ -154,7 +160,7 @@ After Phase 4 reaches a terminal state, the remediation lifecycle for that RR is
 
 ### Investigate an incident
 - kubernaut_investigate: Start an infrastructure investigation. Accepts namespace/kind/name (creates RR + IS internally) or rr_id (for an existing remediation). Automatically activates the driver session, streams live events in the background, and blocks until RCA completes.
-- present_decision: Present investigation results and options to the user
+- kubernaut_present_decision: Present investigation results and options to the user
 - Common phrases: "what's wrong with...", "investigate...", "why is ... failing", "diagnose..."
 
 ### Observe cluster state
@@ -204,7 +210,7 @@ NOTE: kubernaut_approve is NOT available to you. Approval and rejection actions 
 
 ## Alert Prioritization
 
-SUBORDINATE TO THE DECISION ALGORITHM AND OBSERVATION MODE (#1899): everything in this section only applies once you have already decided, per the Decision Algorithm above, that the user wants an alert investigated or remediated. It never overrides Observation Mode's consent gate. A bare "list"/"show"/"status" request is answered by `list_alerts` alone — full stop. Do NOT treat a `prioritized` field in that response as an implicit instruction to investigate anything; the user must explicitly ask before any alert is investigated or remediated.
+SUBORDINATE TO THE DECISION ALGORITHM AND OBSERVATION MODE: everything in this section only applies once you have already decided, per the Decision Algorithm above, that the user wants an alert investigated or remediated. It never overrides Observation Mode's consent gate. A bare "list"/"show"/"status" request is answered by `list_alerts` alone — full stop. Do NOT treat a `prioritized` field in that response as an implicit instruction to investigate anything; the user must explicitly ask before any alert is investigated or remediated.
 
 When `list_alerts` returns a `prioritized` field, the `alerts[]` array is sorted by priority (highest severity first, FIFO tiebreak). The `prioritized` indices reference positions in this array:
 - `selected_index`: Index of the highest-severity, longest-firing alert. This is the one to investigate, but ONLY once the user has asked you to investigate/fix/diagnose.
@@ -218,21 +224,22 @@ ONLY when the user's message already matched the Interactive/Autonomous/Full-Int
 ## Output Style
 Do NOT use emoji in your responses. Use plain text formatting only.
 
-## Structured Artifact Contract (#1408)
+## Structured Artifact Contract
 
 CRITICAL: After calling `kubernaut_present_decision`, you MUST NOT produce any additional free-text narration of the RCA or investigation findings. The structured artifact emitted by `present_decision` IS the definitive output. NEVER narrate, summarize, or restate the RCA in free text after the tool call — doing so causes a double-render UX regression in the Console.
 
-### Edge Scenarios — Always Call present_decision
+### Edge Scenarios — Always Call kubernaut_present_decision
 
 You MUST call `kubernaut_present_decision` in ALL scenarios, even when:
 
-1. **No remediation is needed**: If the issue is self-resolved, transient, or below confidence threshold, call `present_decision` with `options: []` and explain in the `summary` field.
-2. **No workflows are discovered**: If `kubernaut_discover_workflows` returns zero workflows, call `present_decision` with `options: []` and a summary explaining no workflows are available.
-3. **A tool call fails**: If `kubernaut_investigate` or `kubernaut_discover_workflows` fails with an error, call `present_decision` with `options: []` and include the failure context in the `summary` field.
+1. **No remediation is needed**: If the issue is self-resolved, transient, or below confidence threshold, call `kubernaut_present_decision` with `options: []` and explain in the `summary` field.
+2. **No workflows are discovered**: If `kubernaut_discover_workflows` returns zero workflows, call `kubernaut_present_decision` with `options: []` and a summary explaining no workflows are available.
+3. **A tool call fails**: If `kubernaut_investigate` or `kubernaut_discover_workflows` fails with an error, call `kubernaut_present_decision` with `options: []` and include the failure context in the `summary` field.
+4. **No real content to report**: Whatever the trigger — a tool error, an empty result, or a session with no conversation history — your `summary` and `rca` fields must describe only what you actually know from tool responses. If that is nothing, say so directly (e.g., "No investigation content is available for this remediation"). Do NOT synthesize a plausible-sounding narrative, itemized action sequence, timeline, or specific finding that no tool call actually returned. The harness independently enforces this as a backstop — but you must not rely on that backstop; ground every claim yourself, always.
 
 This ensures a structured `investigation_summary` artifact is ALWAYS emitted for audit traceability (AU-3) and Console rendering consistency.
 
-### Target Visibility in present_decision (#1437)
+### Target Visibility in kubernaut_present_decision
 
 When calling `kubernaut_present_decision`, if the `kubernaut_discover_workflows` response includes `searched_target` and `signal_target` fields, you MUST include them in the `investigation_summary` artifact payload. This is especially important when the two targets diverge (cross-resource RCA), as the Console uses these fields to explain to the user which resource was investigated vs. which resource the workflows target.
 

--- a/pkg/apifrontend/agent/prompt_test.go
+++ b/pkg/apifrontend/agent/prompt_test.go
@@ -46,7 +46,7 @@ var _ = Describe("System Prompt", func() {
 
 	It("UT-AF-131-003: prompt contains present_decision handoff instruction", func() {
 		Expect(instruction).To(ContainSubstring("present_decision"))
-		Expect(instruction).To(ContainSubstring("MUST call present_decision"))
+		Expect(instruction).To(ContainSubstring("MUST call kubernaut_present_decision"))
 	})
 
 	It("UT-AF-131-004: prompt does not contain internal system names outside the constraint rule", func() {
@@ -673,5 +673,80 @@ var _ = Describe("Prompt — Plain Investigate Defaults to full_remediation (#19
 	It("UT-AF-1915-004: the autonomous-interactive sub-case is unambiguously distinct from the new full_remediation default", func() {
 		Expect(instruction).To(ContainSubstring("Autonomous Selection"),
 			"#1915: full_remediation_autonomous's own sub-case must be clearly named apart from the new full_remediation default, so the model does not conflate 'investigate' with 'investigate and fix'")
+	})
+})
+
+// =============================================================================
+// Content-grounding guard (#2023 clone #2047): the harness-side
+// enforceGroundingGuard is a backstop, not a substitute for the model
+// grounding its own claims. This prompt-level instruction tells the model
+// not to rely on that backstop and to describe honestly when no real
+// investigation content is available.
+// =============================================================================
+
+var _ = Describe("Prompt — Content Grounding (#2047)", func() {
+	var instruction string
+
+	BeforeEach(func() {
+		cfg := agentpkg.DefaultTestConfig()
+		instruction = cfg.Instruction
+	})
+
+	It("UT-AF-2047-001: prompt instructs the model to ground summary/rca claims in actual tool responses", func() {
+		Expect(instruction).To(ContainSubstring("Ground every claim"))
+		Expect(instruction).To(ContainSubstring("NEVER invent specific findings"))
+	})
+
+	It("UT-AF-2047-002: prompt mandates stating plainly when no investigation content is available", func() {
+		Expect(instruction).To(ContainSubstring("no real investigation content"))
+	})
+
+	It("UT-AF-2047-003: prompt tells the model not to rely on the harness backstop", func() {
+		Expect(instruction).To(ContainSubstring("you must not rely on that backstop"))
+	})
+
+	It("UT-AF-2047-004: prompt reports Completed/Failed/Cancelled/TimedOut/Skipped as terminal phases for Phase 4 reporting", func() {
+		Expect(instruction).To(ContainSubstring("Completed, Failed, Cancelled, TimedOut, Skipped"))
+	})
+})
+
+// =============================================================================
+// DD-AF-012 (#2028, main clone of #2027): ambiguous severity/signal
+// correlation must never be used silently. When a tool result carries
+// ambiguous: true, the model must ask the user to confirm the weak
+// candidate before retrying with confirmed_signal_name, and must never
+// guess, retry blindly, or leave the conversation without a structured
+// kubernaut_present_decision artifact.
+// =============================================================================
+
+var _ = Describe("Prompt — Ambiguous Signal/Severity Correlation (DD-AF-012, #2028)", func() {
+	var instruction string
+
+	BeforeEach(func() {
+		cfg := agentpkg.DefaultTestConfig()
+		instruction = cfg.Instruction
+	})
+
+	It("UT-AF-2028-010: prompt instructs the model to ask the user before using an ambiguous candidate", func() {
+		Expect(instruction).To(ContainSubstring("ambiguous"))
+		Expect(instruction).To(ContainSubstring("candidate_signal_name"))
+		Expect(instruction).To(ContainSubstring("confirmed_signal_name"))
+	})
+
+	It("UT-AF-2028-011: prompt forbids guessing or silently filling in the confirmed signal", func() {
+		Expect(instruction).To(ContainSubstring("do NOT guess"))
+	})
+
+	It("UT-AF-2028-012: prompt forbids retrying the same ambiguous call without a confirmation", func() {
+		Expect(instruction).To(ContainSubstring("do NOT retry the same call without it"))
+	})
+
+	It("UT-AF-2028-013: prompt mandates a structured kubernaut_present_decision close-out when no signal is confirmed", func() {
+		Expect(instruction).To(ContainSubstring("call kubernaut_present_decision with options: []"))
+	})
+
+	It("UT-AF-2028-014: prompt does not leak internal issue numbers", func() {
+		Expect(instruction).NotTo(MatchRegexp(`#\d{3,4}`),
+			"internal issue numbers must never appear in the model-facing prompt (leakage risk)")
 	})
 })

--- a/pkg/apifrontend/agent/root.go
+++ b/pkg/apifrontend/agent/root.go
@@ -147,14 +147,15 @@ func coreToolConstructors(cfg AgentConfig) []toolConstructor {
 		{"watch", func() (tool.Tool, error) { return tools.NewWatchTool(cfg.TypedClient, cfg.Namespace) }},
 		{"investigate", func() (tool.Tool, error) {
 			return tools.NewInvestigateMCPTool(&tools.InvestigateConfig{
-				MCPClient: dedicatedC,
-				Client:    cfg.TypedClient,
-				Namespace: cfg.Namespace,
-				Auditor:   cfg.Auditor,
-				Registry:  cfg.InvestigationRegistry,
-				Pool:      cfg.Pool,
-				Signaler:  buildAgentISSignaler(cfg),
-				Triager:   cfg.Triager,
+				MCPClient:    dedicatedC,
+				Client:       cfg.TypedClient,
+				Namespace:    cfg.Namespace,
+				Auditor:      cfg.Auditor,
+				Registry:     cfg.InvestigationRegistry,
+				Pool:         cfg.Pool,
+				Signaler:     buildAgentISSignaler(cfg),
+				Triager:      cfg.Triager,
+				ScopeChecker: cfg.ScopeChecker,
 			}, cfg.RESTMapper)
 		}},
 		{"discover_workflows", func() (tool.Tool, error) { return tools.NewDiscoverWorkflowsTool(mcpC) }},
@@ -191,7 +192,7 @@ func coreToolConstructors(cfg AgentConfig) []toolConstructor {
 			return tools.NewCheckExistingRemediationTool(cfg.TypedClient, cfg.Namespace)
 		}},
 		{"remediate", func() (tool.Tool, error) {
-			return tools.NewRemediateTool(cfg.TypedClient, k8s, cfg.Namespace, cfg.Triager, cfg.Auditor)
+			return tools.NewRemediateTool(cfg.TypedClient, k8s, cfg.Namespace, cfg.Triager, cfg.Auditor, cfg.ScopeChecker)
 		}},
 	}
 }
@@ -220,6 +221,7 @@ func alertToolConstructors(cfg AgentConfig) []toolConstructor {
 				ValidationFailures: cfg.AlertValidationFailures,
 				Mapper:             cfg.RESTMapper,
 				Signaler:           buildAlertISSignaler(cfg),
+				ScopeChecker:       cfg.ScopeChecker,
 			})
 		}},
 	}

--- a/pkg/apifrontend/audit/audit.go
+++ b/pkg/apifrontend/audit/audit.go
@@ -34,6 +34,11 @@ const (
 
 	EventSeverityTriageCompleted EventType = "severity_triage.completed"
 	EventSeverityTriageFailed    EventType = "severity_triage.failed"
+	// EventSeverityTriageAmbiguous fires when Tier 1's only correlating
+	// evidence is a cluster-scoped alert with no verified relationship to
+	// the target resource -- the agent must ask the user to confirm before
+	// a RemediationRequest is created (DD-AF-012, #2027/#2028).
+	EventSeverityTriageAmbiguous EventType = "severity_triage.ambiguous"
 
 	EventWorkflowDiscovery EventType = "workflow.discovery"
 
@@ -58,6 +63,12 @@ const (
 	EventTriageCompleted      EventType = "triage.completed"
 	EventRRCreated            EventType = "rr.created"
 	EventRRDeduplicated       EventType = "rr.deduplicated"
+	// AU-3/AU-12: AF tool-layer scope rejection (Issue #2025/#2022, ADR-053
+	// Addendum "Point 3"). Parallel to RO's orchestrator.routing.blocked,
+	// giving agent-initiated RR-creation rejections the same audit visibility
+	// that signal-initiated ones (deliberately) lack at Gateway (ADR-053
+	// Decision #7).
+	EventRRScopeRejected      EventType = "rr.scope_rejected"
 	EventKADelegated          EventType = "ka.delegated"
 	EventKAResultReceived     EventType = "ka.result_received"
 	EventUserDecision         EventType = "user.decision"

--- a/pkg/apifrontend/handler/mcp_bridge.go
+++ b/pkg/apifrontend/handler/mcp_bridge.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/session"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/severity"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+	"github.com/jordigilh/kubernaut/pkg/shared/scope"
 )
 
 const (
@@ -82,6 +83,10 @@ type MCPBridgeConfig struct {
 	// RESTMapper resolves Kind strings to GVR for scope-aware namespace stripping.
 	// If nil, falls back to the static clusterScopedKinds map.
 	RESTMapper meta.RESTMapper
+	// ScopeChecker rejects kubernaut_investigate RR creation for resources
+	// outside Kubernaut's management scope (ADR-053; #2025, main-tracking
+	// clone of #2022). Nil skips scope validation (backward compat).
+	ScopeChecker scope.ScopeChecker
 }
 
 // MCPBridgeMetrics holds Prometheus collectors specific to MCP bridge operations.
@@ -235,14 +240,15 @@ func registerInvestigationTool(srv *mcp.Server, cfg *MCPBridgeConfig, sem *semap
 		func(ctx context.Context, args tools.InvestigateMCPArgs) (any, error) {
 			ctx = tools.ContextWithRESTMapper(ctx, cfg.RESTMapper)
 			return tools.HandleInvestigationMCPWithRegistry(ctx, &tools.InvestigateConfig{
-				MCPClient: dedicatedClient,
-				Client:    cfg.TypedClient,
-				Namespace: cfg.Namespace,
-				Auditor:   cfg.Auditor,
-				Registry:  cfg.InvestigationRegistry,
-				OnStarted: onInvestigateStarted,
-				Signaler:  isSignaler,
-				Triager:   cfg.Triager,
+				MCPClient:    dedicatedClient,
+				Client:       cfg.TypedClient,
+				Namespace:    cfg.Namespace,
+				Auditor:      cfg.Auditor,
+				Registry:     cfg.InvestigationRegistry,
+				OnStarted:    onInvestigateStarted,
+				Signaler:     isSignaler,
+				Triager:      cfg.Triager,
+				ScopeChecker: cfg.ScopeChecker,
 			}, args, false, "")
 		})
 }

--- a/pkg/apifrontend/ka/config.go
+++ b/pkg/apifrontend/ka/config.go
@@ -298,10 +298,18 @@ type StartInvestigationArgs struct {
 // StartInvestigationResult holds the response from a dedicated MCP investigation
 // session, including the event channel for streaming and a closer for cleanup.
 type StartInvestigationResult struct {
-	SessionID string                   `json:"session_id"`
-	Status    string                   `json:"status"`
-	Events    <-chan InvestigationEvent `json:"-"`
-	Closer    func()                   `json:"-"`
+	// SessionID is KA's MCP driver-lease ID: it grants exclusive control of the
+	// interactive session but is NOT pollable via the KA REST session-status API.
+	SessionID string `json:"session_id"`
+	// InvestigationSessionID is the underlying investigation-analysis session ID
+	// where RCA/workflow results are stored; it IS pollable via REST. KA's
+	// kubernaut_investigate "start" action returns both IDs (#2029). Callers that
+	// correlate a session for later polling (e.g. IS.Status.KACorrelationID) MUST
+	// use this field, falling back to SessionID only when KA omits it.
+	InvestigationSessionID string                    `json:"investigation_session_id,omitempty"`
+	Status                 string                    `json:"status"`
+	Events                 <-chan InvestigationEvent `json:"-"`
+	Closer                 func()                    `json:"-"`
 	// Session is the underlying MCP session. Exposed so the blocking A2A
 	// path can hand it off to the KASessionPool after the investigation
 	// completes, letting discover_workflows / select_workflow reuse the

--- a/pkg/apifrontend/ka/mcp_sdk_client.go
+++ b/pkg/apifrontend/ka/mcp_sdk_client.go
@@ -274,7 +274,7 @@ func (c *SDKMCPClient) StartInvestigation(ctx context.Context, args StartInvesti
 		return nil, fmt.Errorf("kubernaut_investigate start_autonomous: %s", startInvestigationErrorMessage(result))
 	}
 
-	sessionID, status := parseStartInvestigationResult(result)
+	sessionID, investigationSessionID, status := parseStartInvestigationResult(result)
 
 	var once sync.Once
 	closer := func() {
@@ -286,11 +286,12 @@ func (c *SDKMCPClient) StartInvestigation(ctx context.Context, args StartInvesti
 	}
 
 	return &StartInvestigationResult{
-		SessionID: sessionID,
-		Status:    status,
-		Events:    eventCh,
-		Closer:    closer,
-		Session:   session,
+		SessionID:              sessionID,
+		InvestigationSessionID: investigationSessionID,
+		Status:                 status,
+		Events:                 eventCh,
+		Closer:                 closer,
+		Session:                session,
 	}, nil
 }
 
@@ -392,20 +393,27 @@ func startInvestigationErrorMessage(result *mcp.CallToolResult) string {
 	return "KA tool error"
 }
 
-// parseStartInvestigationResult extracts the session ID and status reported
+// parseStartInvestigationResult extracts the session IDs and status reported
 // by KA in the kubernaut_investigate start_autonomous response. Malformed
 // content is treated as empty (the caller has already validated result.IsError).
-func parseStartInvestigationResult(result *mcp.CallToolResult) (sessionID, status string) {
+//
+// KA's InvestigateOutput (internal/kubernautagent/mcp/tools/investigate_types.go)
+// returns two distinct session IDs: sessionID is the driver-lease ID (exclusive
+// control, not pollable via REST); investigationSessionID is the pollable
+// analysis session where RCA/workflow results live. Both must be captured --
+// discarding investigationSessionID caused #2029's session-adoption 404-loop.
+func parseStartInvestigationResult(result *mcp.CallToolResult) (sessionID, investigationSessionID, status string) {
 	var invResult struct {
-		SessionID string `json:"session_id"`
-		Status    string `json:"status"`
+		SessionID              string `json:"session_id"`
+		Status                 string `json:"status"`
+		InvestigationSessionID string `json:"investigation_session_id"`
 	}
 	if len(result.Content) > 0 {
 		if tc, ok := result.Content[0].(*mcp.TextContent); ok {
 			_ = json.Unmarshal([]byte(tc.Text), &invResult)
 		}
 	}
-	return invResult.SessionID, invResult.Status
+	return invResult.SessionID, invResult.InvestigationSessionID, invResult.Status
 }
 
 // ConnectSession establishes a new MCP session without auto-closing it.

--- a/pkg/apifrontend/session/consent.go
+++ b/pkg/apifrontend/session/consent.go
@@ -54,6 +54,19 @@ const (
 	// requires waiting for genuine user confirmation before
 	// kubernaut_select_workflow may run.
 	StateKeyPhase3Blocked = "af_phase3_blocked"
+
+	// StateKeyGroundedContentAvailable records whether the most recent
+	// kubernaut_investigate call produced real, groundable RCA content
+	// (#2047, main clone of #2023). phase_guard.go's harness-enforced
+	// grounding guard reads this immediately before kubernaut_present_decision
+	// executes: when false -- including the fail-safe default when this key
+	// was never set -- the model's summary/rca/options are overwritten with
+	// a fixed, honest "no data" payload instead of trusted as-is, preventing
+	// a fabricated narrative from ever reaching the audit trail.
+	// present_decision itself still runs afterward, so the AU-3
+	// structured-artifact mandate (#1408) is preserved; only a fabricated
+	// narrative is blocked, never the artifact.
+	StateKeyGroundedContentAvailable = "af_grounded_content_available"
 )
 
 // Interaction mode values for InteractionMode / StateKeyInteractionMode.

--- a/pkg/apifrontend/severity/triage.go
+++ b/pkg/apifrontend/severity/triage.go
@@ -25,6 +25,21 @@ import (
 // guessing is the fix; see DD-AF-010.
 var ErrSeverityUndetermined = errors.New("cannot determine severity: no active alert or prometheus rule correlates to this resource")
 
+// AmbiguousSeverityError is returned by Triage when the only correlating
+// evidence found is a cluster-scoped alert with no verified relationship to
+// the target resource (DD-AF-012, #2027/#2028). Unlike ErrSeverityUndetermined
+// (no evidence at all), here a candidate exists but trusting it silently
+// risks attributing an unrelated cluster-wide incident to this resource --
+// the caller must surface Candidate to the user and re-call with a matching
+// TriageInput.ConfirmedSignalName to proceed.
+type AmbiguousSeverityError struct {
+	Candidate TriageResult
+}
+
+func (e *AmbiguousSeverityError) Error() string {
+	return "severity triage ambiguous: only a cluster-scoped alert (" + e.Candidate.AlertName + ") correlates, with no verified relationship to this resource"
+}
+
 // LLMTriager defines the interface for LLM-based severity classification.
 type LLMTriager interface {
 	TriageWithRules(ctx context.Context, rules []prom.Rule, input TriageInput) (TriageResult, error)
@@ -131,6 +146,27 @@ func (t *Triager) Triage(ctx context.Context, input TriageInput) (TriageResult, 
 		}
 		return result, err
 	}
+
+	// DD-AF-012/#2027/#2028: a cluster-scoped-only match is a guess, not a
+	// fact -- fail closed unless the caller already carries the user's
+	// confirmation for this exact candidate (a different candidate does not
+	// bypass the gate, even on a later call).
+	if result.Ambiguous && result.AlertName != input.ConfirmedSignalName {
+		if t.auditor != nil {
+			t.auditor.Emit(ctx, &audit.Event{
+				Type: audit.EventSeverityTriageAmbiguous,
+				Detail: map[string]string{
+					"namespace":          input.Namespace,
+					"kind":               input.Kind,
+					"name":               input.Name,
+					"candidate_alert":    result.AlertName,
+					"candidate_severity": result.Severity,
+				},
+			})
+		}
+		return result, &AmbiguousSeverityError{Candidate: result}
+	}
+
 	if result.Severity != "" {
 		result.Severity = NormalizeSeverity(result.Severity)
 	}
@@ -336,9 +372,13 @@ func (t *Triager) bestOverallMatch(alerts []prom.Alert, targetLabels map[string]
 	case nsPending.found:
 		return nsPending.result(SourceNSPendingAlert), true
 	case clusterFiring.found:
-		return clusterFiring.result(SourceClusterFiringAlert), true
+		result := clusterFiring.result(SourceClusterFiringAlert)
+		result.Ambiguous = true
+		return result, true
 	case clusterPending.found:
-		return clusterPending.result(SourceClusterPendingAlert), true
+		result := clusterPending.result(SourceClusterPendingAlert)
+		result.Ambiguous = true
+		return result, true
 	}
 	return TriageResult{}, false
 }

--- a/pkg/apifrontend/severity/triage_test.go
+++ b/pkg/apifrontend/severity/triage_test.go
@@ -10,6 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/audit"
 	prom "github.com/jordigilh/kubernaut/pkg/apifrontend/prometheus"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/severity"
 )
@@ -114,7 +115,7 @@ var _ = Describe("Triage Orchestrator", func() {
 			Expect(result.Source).To(Equal(severity.SourceNSFiringAlert))
 		})
 
-		It("UT-AF-1369-003: cluster-scoped alert matches when no resource or namespace match exists", func() {
+		It("UT-AF-1369-003/UT-AF-2027-001a: cluster-scoped alert is the only candidate — surfaced as ambiguous, not silently trusted (DD-AF-012)", func() {
 			mockProm := &mockPromClient{
 				alerts: []prom.Alert{
 					{Labels: map[string]string{"alertname": "etcdHighCommitDurations", "severity": "warning"}, State: "firing"},
@@ -122,10 +123,13 @@ var _ = Describe("Triage Orchestrator", func() {
 			}
 			triager := severity.NewTriager(mockProm, &mockLLM{}, defaultCfg, logr.Discard())
 			result, err := triager.Triage(context.Background(), defaultInput)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Severity).To(Equal("warning"))
-			Expect(result.AlertName).To(Equal("etcdHighCommitDurations"))
-			Expect(result.Source).To(Equal(severity.SourceClusterFiringAlert))
+			var ambErr *severity.AmbiguousSeverityError
+			Expect(errors.As(err, &ambErr)).To(BeTrue(),
+				"DD-AF-012: a cluster-scoped-only match must never be silently trusted -- it has no verified relationship to the target")
+			Expect(ambErr.Candidate.Severity).To(Equal("warning"))
+			Expect(ambErr.Candidate.AlertName).To(Equal("etcdHighCommitDurations"))
+			Expect(ambErr.Candidate.Source).To(Equal(severity.SourceClusterFiringAlert))
+			Expect(result.Ambiguous).To(BeTrue())
 		})
 
 		It("UT-AF-1369-004: namespace-scoped alert returns ns_firing_alert source", func() {
@@ -140,7 +144,7 @@ var _ = Describe("Triage Orchestrator", func() {
 			Expect(result.Source).To(Equal(severity.SourceNSFiringAlert))
 		})
 
-		It("UT-AF-1369-005: cluster-scoped alert returns cluster_firing_alert source", func() {
+		It("UT-AF-1369-005: cluster-scoped-only match still carries cluster_firing_alert source on its ambiguous candidate (DD-AF-012)", func() {
 			mockProm := &mockPromClient{
 				alerts: []prom.Alert{
 					{Labels: map[string]string{"alertname": "KubeAPIErrorBudgetBurn", "severity": "critical"}, State: "firing"},
@@ -148,8 +152,10 @@ var _ = Describe("Triage Orchestrator", func() {
 			}
 			triager := severity.NewTriager(mockProm, &mockLLM{}, defaultCfg, logr.Discard())
 			result, err := triager.Triage(context.Background(), defaultInput)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Source).To(Equal(severity.SourceClusterFiringAlert))
+			var ambErr *severity.AmbiguousSeverityError
+			Expect(errors.As(err, &ambErr)).To(BeTrue())
+			Expect(ambErr.Candidate.Source).To(Equal(severity.SourceClusterFiringAlert))
+			Expect(result.Ambiguous).To(BeTrue())
 		})
 
 		It("UT-AF-1369-006: multiple namespace-scoped alerts return highest severity", func() {
@@ -249,7 +255,7 @@ var _ = Describe("Triage Orchestrator", func() {
 			Expect(result.Source).To(Equal(severity.SourceNSPendingAlert))
 		})
 
-		It("UT-AF-2021-003: cluster-scoped firing still wins over cluster-scoped pending when nothing more specific exists", func() {
+		It("UT-AF-2021-003: cluster-scoped firing still wins over cluster-scoped pending when nothing more specific exists (both remain ambiguous, DD-AF-012)", func() {
 			mockProm := &mockPromClient{
 				alerts: []prom.Alert{
 					{Labels: map[string]string{"alertname": "PendingClusterAlert", "severity": "critical"}, State: "pending"},
@@ -258,10 +264,94 @@ var _ = Describe("Triage Orchestrator", func() {
 			}
 			triager := severity.NewTriager(mockProm, &mockLLM{}, defaultCfg, logr.Discard())
 			result, err := triager.Triage(context.Background(), defaultInput)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.AlertName).To(Equal("FiringClusterAlert"),
+			var ambErr *severity.AmbiguousSeverityError
+			Expect(errors.As(err, &ambErr)).To(BeTrue())
+			Expect(ambErr.Candidate.AlertName).To(Equal("FiringClusterAlert"),
 				"within the same (cluster) tier, firing still beats pending -- only cross-tier priority changed")
-			Expect(result.Source).To(Equal(severity.SourceClusterFiringAlert))
+			Expect(ambErr.Candidate.Source).To(Equal(severity.SourceClusterFiringAlert))
+			Expect(result.Ambiguous).To(BeTrue())
+		})
+
+		// DD-AF-012 (#2027/#2028): resource/namespace-tier wins already carry a
+		// verified relationship to the target resource, so they must never be
+		// gated as ambiguous -- only a cluster-scoped-only match is a guess.
+		It("UT-AF-2027-001: resource- and namespace-tier wins are never ambiguous, even when a cluster-scoped alert also exists", func() {
+			mockProm := &mockPromClient{
+				alerts: []prom.Alert{
+					{Labels: map[string]string{"alertname": "ClusterWideAlert", "severity": "critical"}, State: "firing"},
+					{Labels: map[string]string{"alertname": "HighCPU", "namespace": "prod", "kind": "Deployment", "name": "web-api", "severity": "warning"}, State: "firing"},
+				},
+			}
+			triager := severity.NewTriager(mockProm, &mockLLM{}, defaultCfg, logr.Discard())
+			result, err := triager.Triage(context.Background(), defaultInput)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Ambiguous).To(BeFalse(),
+				"a resource-scoped match has a verified relationship to the target and must never be flagged ambiguous")
+			Expect(result.AlertName).To(Equal("HighCPU"))
+		})
+
+		It("UT-AF-2027-002: Triage() returns *AmbiguousSeverityError with the candidate populated when Ambiguous and unconfirmed", func() {
+			mockProm := &mockPromClient{
+				alerts: []prom.Alert{
+					{Labels: map[string]string{"alertname": "CDIDefaultStorageClassDegraded", "severity": "warning"}, State: "firing"},
+				},
+			}
+			triager := severity.NewTriager(mockProm, &mockLLM{}, defaultCfg, logr.Discard())
+			_, err := triager.Triage(context.Background(), defaultInput)
+			var ambErr *severity.AmbiguousSeverityError
+			Expect(errors.As(err, &ambErr)).To(BeTrue())
+			Expect(ambErr.Candidate.AlertName).To(Equal("CDIDefaultStorageClassDegraded"))
+			Expect(ambErr.Candidate.Severity).To(Equal("warning"))
+			Expect(ambErr.Candidate.Ambiguous).To(BeTrue())
+		})
+
+		It("UT-AF-2027-003: a matching ConfirmedSignalName bypasses the ambiguity gate; a different candidate does not (fail-closed)", func() {
+			mockProm := &mockPromClient{
+				alerts: []prom.Alert{
+					{Labels: map[string]string{"alertname": "CDIDefaultStorageClassDegraded", "severity": "warning"}, State: "firing"},
+				},
+			}
+			triager := severity.NewTriager(mockProm, &mockLLM{}, defaultCfg, logr.Discard())
+
+			confirmedInput := defaultInput
+			confirmedInput.ConfirmedSignalName = "CDIDefaultStorageClassDegraded"
+			result, err := triager.Triage(context.Background(), confirmedInput)
+			Expect(err).NotTo(HaveOccurred(),
+				"an exact-matching confirmation for this specific candidate must bypass the gate")
+			Expect(result.Severity).To(Equal("warning"))
+			Expect(result.AlertName).To(Equal("CDIDefaultStorageClassDegraded"))
+
+			staleConfirmationInput := defaultInput
+			staleConfirmationInput.ConfirmedSignalName = "SomeOtherAlert"
+			_, err = triager.Triage(context.Background(), staleConfirmationInput)
+			var ambErr2 *severity.AmbiguousSeverityError
+			Expect(errors.As(err, &ambErr2)).To(BeTrue(),
+				"a confirmation for a *different* candidate must not bypass the gate for this one (fail-closed)")
+		})
+
+		It("UT-AF-2027-008: EventSeverityTriageAmbiguous is emitted exactly once per ambiguous (unconfirmed) Triage() call", func() {
+			mockProm := &mockPromClient{
+				alerts: []prom.Alert{
+					{Labels: map[string]string{"alertname": "CDIDefaultStorageClassDegraded", "severity": "warning"}, State: "firing"},
+				},
+			}
+			spy := &triageAuditSpy{}
+			triager := severity.NewTriager(mockProm, &mockLLM{}, defaultCfg, logr.Discard(), severity.WithAuditor(spy))
+
+			_, err := triager.Triage(context.Background(), defaultInput)
+			Expect(err).To(HaveOccurred())
+
+			events := spy.eventsByType(audit.EventSeverityTriageAmbiguous)
+			Expect(events).To(HaveLen(1))
+			Expect(events[0].Detail["candidate_alert"]).To(Equal("CDIDefaultStorageClassDegraded"))
+			Expect(events[0].Detail["candidate_severity"]).To(Equal("warning"))
+
+			confirmedInput := defaultInput
+			confirmedInput.ConfirmedSignalName = "CDIDefaultStorageClassDegraded"
+			_, err = triager.Triage(context.Background(), confirmedInput)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(spy.eventsByType(audit.EventSeverityTriageAmbiguous)).To(HaveLen(1),
+				"a confirmed re-call must not emit a second ambiguous event")
 		})
 	})
 
@@ -711,7 +801,7 @@ var _ = Describe("Triage Orchestrator", func() {
 	})
 
 	Describe("Cluster-scoped pending alert correlation", func() {
-		It("UT-AF-1369-010: cluster-scoped pending alert returns cluster_pending_alert source", func() {
+		It("UT-AF-1369-010: cluster-scoped-only pending match still carries cluster_pending_alert source on its ambiguous candidate (DD-AF-012)", func() {
 			mockProm := &mockPromClient{
 				alerts: []prom.Alert{
 					{Labels: map[string]string{"alertname": "ClusterWidePending", "severity": "warning"}, State: "pending"},
@@ -719,9 +809,11 @@ var _ = Describe("Triage Orchestrator", func() {
 			}
 			triager := severity.NewTriager(mockProm, &mockLLM{}, defaultCfg, logr.Discard())
 			result, err := triager.Triage(context.Background(), defaultInput)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(result.Source).To(Equal(severity.SourceClusterPendingAlert))
-			Expect(result.AlertName).To(Equal("ClusterWidePending"))
+			var ambErr *severity.AmbiguousSeverityError
+			Expect(errors.As(err, &ambErr)).To(BeTrue())
+			Expect(ambErr.Candidate.Source).To(Equal(severity.SourceClusterPendingAlert))
+			Expect(ambErr.Candidate.AlertName).To(Equal("ClusterWidePending"))
+			Expect(result.Ambiguous).To(BeTrue())
 		})
 	})
 

--- a/pkg/apifrontend/severity/types.go
+++ b/pkg/apifrontend/severity/types.go
@@ -48,6 +48,12 @@ type TriageInput struct {
 	Description string
 	Labels      map[string]string
 	PodNames    []string // Resolved pod names for alert correlation (auto-populated by Triager when PodResolver is set)
+	// ConfirmedSignalName, when non-empty and it exactly matches an
+	// ambiguous candidate's AlertName, indicates the user has already
+	// confirmed that specific weak candidate (DD-AF-012). Triage() bypasses
+	// its ambiguity gate only for this exact match -- a different candidate
+	// on a later call still fails closed and asks again.
+	ConfirmedSignalName string
 }
 
 // TriageResult holds the outcome of the severity triage pipeline.
@@ -57,6 +63,13 @@ type TriageResult struct {
 	AlertName  string
 	RuleName   string
 	Confidence float64
+	// Ambiguous is true when the only correlating evidence found is a
+	// cluster-scoped alert with no verified relationship to the target
+	// resource (namespace/resource key overlap) -- a guess, not a fact
+	// (DD-AF-012, #2027/#2028). Only Tier 1's cluster-scoped branches set
+	// this; resource- and namespace-scoped matches always have a verified
+	// relationship and are never ambiguous.
+	Ambiguous bool
 }
 
 // Canonical severity values (ADR-066). Severity is kept as a plain string

--- a/pkg/apifrontend/tools/af_create_rr.go
+++ b/pkg/apifrontend/tools/af_create_rr.go
@@ -2,6 +2,7 @@ package tools
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/go-logr/logr"
@@ -16,6 +17,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/severity"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/validate"
 	gwtypes "github.com/jordigilh/kubernaut/pkg/gateway/types"
+	"github.com/jordigilh/kubernaut/pkg/shared/scope"
 )
 
 // unknownValue is the generic fallback used when a signal name, phase, or
@@ -31,6 +33,12 @@ type ToolDeps struct {
 	ControllerNS string
 	Triager      *severity.Triager
 	Auditor      audit.Emitter
+	// ScopeChecker, when non-nil, rejects RR creation for resources outside
+	// Kubernaut's management scope (ADR-053 Addendum "Point 3", #2025/#2022)
+	// before a Triager call or RR object is wastefully created. Nil is
+	// backward-compatible: scope validation is skipped (matches Triager's
+	// own nil-safe convention above).
+	ScopeChecker scope.ScopeChecker
 }
 
 // maxDescriptionLen is the maximum length for RR description (truncated, not rejected).
@@ -58,6 +66,13 @@ type CreateRRArgs struct {
 	// ClusterID is the cluster identifier from Thanos external_labels.
 	// Empty string indicates local hub cluster (ADR-065).
 	ClusterID string `json:"cluster_id,omitempty"`
+	// ConfirmedAmbiguousSignalName, when non-empty and it exactly matches a
+	// previously-surfaced ambiguous candidate's alert name, indicates the
+	// user has already confirmed that specific weak candidate (DD-AF-012,
+	// #2027/#2028). Populated internally by each tool handler from its own
+	// LLM-visible confirmed_signal_name field, not set by the LLM directly
+	// on this struct.
+	ConfirmedAmbiguousSignalName string `json:"-"`
 }
 
 // CreateRRResult is the output of RR creation.
@@ -79,6 +94,15 @@ type CreateRRResult struct {
 	// without recomputing -- both the create and dedup branches already know
 	// it via req.Fingerprint at construction time.
 	Fingerprint string `json:"-"`
+	// Ambiguous is true when severity triage found only a cluster-scoped
+	// alert with no verified relationship to the target resource -- no RR
+	// is created and the caller must ask the user to confirm
+	// CandidateSignalName before retrying (DD-AF-012, #2027/#2028).
+	Ambiguous bool `json:"ambiguous,omitempty"`
+	// CandidateSignalName/CandidateSeverity carry the unverified candidate
+	// so the calling agent can present it to the user for confirmation.
+	CandidateSignalName string `json:"candidate_signal_name,omitempty"`
+	CandidateSeverity   string `json:"candidate_severity,omitempty"`
 }
 
 // rrCreateGroup provides singleflight deduplication per fingerprint.
@@ -146,8 +170,32 @@ func HandleCreateRR(ctx context.Context, d *ToolDeps, args *CreateRRArgs, userna
 		args.Description = args.Description[:maxDescriptionLen]
 	}
 
+	// #2025/#2022: reject out-of-scope resources before the Triager call and
+	// RR object creation that follow — RO's CheckUnmanagedResource would
+	// otherwise catch this downstream, but only after wasting a Prometheus
+	// triage round-trip and an RR CRD create/delete cycle.
+	if managed, msg := checkRRScope(ctx, d.ScopeChecker, d.Auditor, username, scope.ResourceIdentity{
+		ClusterID: args.ClusterID, Namespace: args.Namespace, Kind: args.Kind, Name: args.Name,
+	}); !managed {
+		return CreateRRResult{}, fmt.Errorf("%w: %s", ErrResourceNotManaged, msg)
+	}
+
 	resolvedSeverity, triageResult, err := resolveCreateRRSeverity(ctx, d, args)
 	if err != nil {
+		// DD-AF-012/#2027/#2028: an ambiguous match is a typed signal, not a
+		// generic error -- no RR is created, but the caller gets a normal
+		// result carrying the weak candidate so the agent can ask the user
+		// to confirm before retrying (mirrors #2022's Managed: false shape).
+		var ambErr *severity.AmbiguousSeverityError
+		if errors.As(err, &ambErr) {
+			return CreateRRResult{
+				Ambiguous:           true,
+				CandidateSignalName: ambErr.Candidate.AlertName,
+				CandidateSeverity:   ambErr.Candidate.Severity,
+				Message: fmt.Sprintf("severity/signal correlation is ambiguous for %s/%s: only a cluster-scoped alert (%s) was found, with no verified relationship to this resource",
+					args.Kind, args.Name, ambErr.Candidate.AlertName),
+			}, nil
+		}
 		return CreateRRResult{}, err
 	}
 
@@ -219,11 +267,12 @@ func resolveCreateRRSeverity(ctx context.Context, d *ToolDeps, args *CreateRRArg
 		return "", nil, fmt.Errorf("severity triage not configured: %w", severity.ErrSeverityUndetermined)
 	}
 	input := severity.TriageInput{
-		Namespace:   args.Namespace,
-		Kind:        args.Kind,
-		Name:        args.Name,
-		Description: args.Description,
-		Labels:      map[string]string{"namespace": args.Namespace, "kind": args.Kind, "name": args.Name},
+		Namespace:           args.Namespace,
+		Kind:                args.Kind,
+		Name:                args.Name,
+		Description:         args.Description,
+		Labels:              map[string]string{"namespace": args.Namespace, "kind": args.Kind, "name": args.Name},
+		ConfirmedSignalName: args.ConfirmedAmbiguousSignalName,
 	}
 	result, err := d.Triager.Triage(ctx, input)
 	if err != nil {

--- a/pkg/apifrontend/tools/af_create_rr_test.go
+++ b/pkg/apifrontend/tools/af_create_rr_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/severity"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
 	gwtypes "github.com/jordigilh/kubernaut/pkg/gateway/types"
+	"github.com/jordigilh/kubernaut/test/shared/mocks"
 )
 
 // goconst dedup: test-fixture literals deduplicated below.
@@ -64,14 +65,15 @@ func (a *alertOverridePromClient) InstantQuery(_ context.Context, _ string) (*pr
 
 // alwaysFiringPromClient returns a single cluster-scoped firing alert with no
 // namespace/kind/name labels, so it label-matches (at the cluster level, see
-// triage.go bestAlertMatch) any target resource regardless of test fixture
-// identity.
+// triage.go bestOverallMatch) any target resource regardless of test fixture
+// identity, but carries no verified relationship to it.
 //
-// #1839/DD-AF-010: a nil Triager now fails closed (ErrSeverityUndetermined)
-// instead of silently defaulting to "warning". Tests that don't care about
-// the specific severity value but need HandleCreateRR/HandleRemediate to
-// succeed (e.g. to exercise dedup, audit, cluster-ID plumbing) must supply a
-// Triager that actually resolves one -- this is that shared fixture.
+// DD-AF-012/#2027/#2028: because it has no verified relationship, a Triager
+// built on this fixture now resolves as *ambiguous* (Triage returns
+// *severity.AmbiguousSeverityError), not a confident success. Used
+// deliberately by ambiguity tests (e.g. UT-AF-2027-004) that want exactly
+// that "only a cluster-scoped candidate exists" scenario -- callers that
+// just want a Triager to succeed should use defaultTestTriager instead.
 type alwaysFiringPromClient struct{}
 
 func (a *alwaysFiringPromClient) GetAlerts(_ context.Context) ([]prom.Alert, error) {
@@ -84,10 +86,30 @@ func (a *alwaysFiringPromClient) InstantQuery(_ context.Context, _ string) (*pro
 	return &prom.QueryResult{}, nil
 }
 
-// defaultTestTriager returns a Triager that always resolves "warning" via a
-// cluster-scoped alert. See alwaysFiringPromClient.
-func defaultTestTriager() *severity.Triager {
+// ambiguousTestTriager returns a Triager whose only correlating evidence is
+// a cluster-scoped alert with no verified relationship to any target -- the
+// DD-AF-012/#2027/#2028 "ambiguous" scenario. See alwaysFiringPromClient.
+func ambiguousTestTriager() *severity.Triager {
 	return severity.NewTriager(&alwaysFiringPromClient{}, severity.NewNoopLLMTriager(logr.Discard()), severity.DefaultConfig(), logr.Discard())
+}
+
+// defaultTestTriager returns a Triager that resolves "warning" via a
+// resource-scoped alert with a verified relationship to the given
+// namespace/kind/name (namespace may be "" for cluster-scoped targets, e.g.
+// Node). Tests that don't care about the specific severity value but need
+// HandleCreateRR/HandleRemediate to succeed (e.g. to exercise dedup, audit,
+// cluster-ID plumbing) use this to get a confident, non-ambiguous result --
+// DD-AF-012/#2027/#2028's ambiguity gate is reserved for alerts with no such
+// relationship (see ambiguousTestTriager).
+func defaultTestTriager(namespace, kind, name string) *severity.Triager {
+	mockProm := &alertOverridePromClient{
+		alerts: []prom.Alert{
+			{State: "firing", Labels: map[string]string{
+				"alertname": "TestDefaultAlert", "namespace": namespace, "kind": kind, "name": name, "severity": "warning",
+			}},
+		},
+	}
+	return severity.NewTriager(mockProm, severity.NewNoopLLMTriager(logr.Discard()), severity.DefaultConfig(), logr.Discard())
 }
 
 // unnamedAlertTestTriager returns a Triager that resolves a severity from a
@@ -136,7 +158,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 		It("UT-AF-1282-MIN-001: creates RR with only Kind, Name, Description", func() {
 			tc := newTypedFakeClient()
 
-			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: defaultTestTriager()}, &tools.CreateRRArgs{
+			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: defaultTestTriager("prod", "Deployment", "web")}, &tools.CreateRRArgs{
 				Namespace:   "prod",
 				Kind:        "Deployment",
 				Name:        "web",
@@ -151,7 +173,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 
 		It("UT-AF-1282-MIN-002: empty kind rejected", func() {
 			tc := newTypedFakeClient()
-			_, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: defaultTestTriager()}, &tools.CreateRRArgs{
+			_, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: defaultTestTriager("prod", "Deployment", "web")}, &tools.CreateRRArgs{
 				Namespace: "prod", Kind: "", Name: "web", Description: "x", APIVersion: "apps/v1",
 			}, "user")
 			Expect(err).To(MatchError(ContainSubstring("invalid input")))
@@ -159,7 +181,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 
 		It("UT-AF-1282-MIN-003: empty name rejected", func() {
 			tc := newTypedFakeClient()
-			_, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: defaultTestTriager()}, &tools.CreateRRArgs{
+			_, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: defaultTestTriager("prod", "Deployment", "web")}, &tools.CreateRRArgs{
 				Namespace: "prod", Kind: "Deployment", Name: "", Description: "x", APIVersion: "apps/v1",
 			}, "user")
 			Expect(err).To(MatchError(ContainSubstring("invalid input")))
@@ -172,7 +194,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 				longDesc[i] = 'a'
 			}
 
-			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: defaultTestTriager()}, &tools.CreateRRArgs{
+			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: defaultTestTriager("prod", "Deployment", "web")}, &tools.CreateRRArgs{
 				Namespace: "prod", Kind: "Deployment", Name: "web", Description: string(longDesc), APIVersion: "apps/v1",
 			}, "user")
 			Expect(err).NotTo(HaveOccurred())
@@ -190,7 +212,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 				wg.Add(1)
 				go func(idx int) {
 					defer wg.Done()
-					results[idx], errs[idx] = tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: defaultTestTriager()}, &tools.CreateRRArgs{
+					results[idx], errs[idx] = tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: defaultTestTriager("prod", "Deployment", "dedup-target")}, &tools.CreateRRArgs{
 						Namespace: "prod", Kind: "Deployment", Name: "dedup-target", Description: "concurrent test", APIVersion: "apps/v1",
 					}, "user")
 				}(i)
@@ -248,6 +270,42 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 			Expect(rrList.Items).To(BeEmpty(), "no RemediationRequest should be created when severity cannot be determined")
 		})
 
+		// DD-AF-012 (#2027/#2028): a cluster-scoped-only match is ambiguous,
+		// not a confident fact -- HandleCreateRR must translate it into a
+		// typed CreateRRResult{Ambiguous: true} with no RR created, mirroring
+		// #2022's Managed: false shape, rather than a generic Go error.
+		It("UT-AF-2028-004: HandleCreateRR translates *AmbiguousSeverityError into CreateRRResult{Ambiguous: true} with no Go error and no RR created", func() {
+			tc := newTypedFakeClient()
+
+			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: ambiguousTestTriager()}, &tools.CreateRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web", Description: "only a cluster alert exists", APIVersion: "apps/v1",
+			}, "alice")
+			Expect(err).NotTo(HaveOccurred(),
+				"DD-AF-012/#2027/#2028: ambiguity is a typed result, not a Go error, mirroring #2022's Managed: false shape")
+			Expect(result.Ambiguous).To(BeTrue())
+			Expect(result.CandidateSignalName).To(Equal("TestDefaultAlert"))
+			Expect(result.CandidateSeverity).To(Equal("warning"))
+			Expect(result.RRID).To(BeEmpty())
+
+			var rrList remediationv1.RemediationRequestList
+			Expect(tc.List(context.Background(), &rrList, crclient.InNamespace("prod"))).To(Succeed())
+			Expect(rrList.Items).To(BeEmpty(), "no RemediationRequest should be created for an ambiguous, unconfirmed candidate")
+		})
+
+		It("UT-AF-2028-004b: a matching ConfirmedAmbiguousSignalName proceeds to RR creation", func() {
+			tc := newTypedFakeClient()
+
+			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: ambiguousTestTriager()}, &tools.CreateRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web", Description: "confirmed by user",
+				APIVersion:                   "apps/v1",
+				ConfirmedAmbiguousSignalName: "TestDefaultAlert",
+			}, "alice")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Ambiguous).To(BeFalse())
+			Expect(result.RRID).NotTo(BeEmpty())
+			Expect(result.Severity).To(Equal("warning"))
+		})
+
 		It("UT-AF-1282-MIN-007 / UT-AF-1839-010: nil Triager (severityTriage.enabled=false) fails closed instead of fabricating a severity", func() {
 			tc := newTypedFakeClient()
 
@@ -268,7 +326,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 		It("UT-AF-1282-NS-005: namespace comes from AF, not LLM args", func() {
 			tc := newTypedFakeClient()
 
-			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: kubernautSystem, Triager: defaultTestTriager()}, &tools.CreateRRArgs{
+			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: kubernautSystem, Triager: defaultTestTriager("kubernaut-system", "Deployment", "web")}, &tools.CreateRRArgs{
 				Namespace: kubernautSystem, Kind: "Deployment", Name: "web", Description: "ns from AF", APIVersion: "apps/v1",
 			}, "user")
 			Expect(err).NotTo(HaveOccurred())
@@ -296,7 +354,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 		It("UT-AF-1282-SRC-001: created RR has signalSource=a2a-agent", func() {
 			tc := newTypedFakeClient()
 
-			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: defaultTestTriager()}, &tools.CreateRRArgs{
+			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: defaultTestTriager("prod", "Deployment", "web")}, &tools.CreateRRArgs{
 				Namespace: "prod", Kind: "Deployment", Name: "web", Description: "check source", APIVersion: "apps/v1",
 			}, "user")
 			Expect(err).NotTo(HaveOccurred())
@@ -309,7 +367,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 			rr := newTypedRRWithFingerprint("rr-deploy-web-existing", "Executing")
 			tc := newTypedFakeClient(rr)
 
-			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: defaultTestTriager()}, &tools.CreateRRArgs{
+			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: defaultTestTriager("prod", "Deployment", "web")}, &tools.CreateRRArgs{
 				Namespace: "prod", Kind: "Deployment", Name: "web", Description: "dup", APIVersion: "apps/v1",
 			}, "user")
 			Expect(err).NotTo(HaveOccurred())
@@ -501,7 +559,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 			controllerNS := kubernautSystem
 			workloadNS := production
 
-			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: controllerNS, Triager: defaultTestTriager()}, &tools.CreateRRArgs{
+			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: controllerNS, Triager: defaultTestTriager("production", "Deployment", "web")}, &tools.CreateRRArgs{
 				Namespace:   workloadNS,
 				Kind:        "Deployment",
 				Name:        "web",
@@ -536,7 +594,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 			}
 			tc := newTypedFakeClient(existingRR)
 
-			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: controllerNS, Triager: defaultTestTriager()}, &tools.CreateRRArgs{
+			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: controllerNS, Triager: defaultTestTriager("production", "Deployment", "web")}, &tools.CreateRRArgs{
 				Namespace:   workloadNS,
 				Kind:        "Deployment",
 				Name:        "web",
@@ -572,7 +630,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 		It("UT-AF-1292-NS-004: empty workload namespace rejected (BR-SAFETY-002)", func() {
 			tc := newTypedFakeClient()
 
-			_, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: kubernautSystem, Triager: defaultTestTriager()}, &tools.CreateRRArgs{
+			_, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: kubernautSystem, Triager: defaultTestTriager("", "Deployment", "web")}, &tools.CreateRRArgs{
 				Namespace:   "",
 				Kind:        "Deployment",
 				Name:        "web",
@@ -633,7 +691,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 		rr := newTypedRRWithFingerprint("rr-deploy-web-existing", "Executing")
 		tc := newTypedFakeClient(rr)
 
-		result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: defaultTestTriager()}, &tools.CreateRRArgs{
+		result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "prod", Triager: defaultTestTriager("prod", "Deployment", "web")}, &tools.CreateRRArgs{
 			Namespace: "prod", Kind: "Deployment", Name: "web", Description: "duplicate", APIVersion: "apps/v1",
 		}, "sre-user")
 		Expect(err).NotTo(HaveOccurred())
@@ -644,7 +702,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 	Describe("APIVersion and ClusterScoped (#1372)", func() {
 		It("UT-AF-1372-060: RR created with targetResource.apiVersion populated", func() {
 			tc := newTypedFakeClient()
-			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: kubernautSystem, Triager: defaultTestTriager()}, &tools.CreateRRArgs{
+			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: kubernautSystem, Triager: defaultTestTriager("prod", "Deployment", "web")}, &tools.CreateRRArgs{
 				Namespace:  "prod",
 				Kind:       "Deployment",
 				Name:       "web",
@@ -659,7 +717,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 
 		It("UT-AF-1372-061: cluster-scoped RR (Node) with empty namespace creates successfully", func() {
 			tc := newTypedFakeClient()
-			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: kubernautSystem, Triager: defaultTestTriager()}, &tools.CreateRRArgs{
+			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: kubernautSystem, Triager: defaultTestTriager("", "Node", "worker-03")}, &tools.CreateRRArgs{
 				Kind:          "Node",
 				Name:          "worker-03",
 				APIVersion:    "v1",
@@ -671,7 +729,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 
 		It("UT-AF-1372-062: namespaced RR with empty namespace rejects", func() {
 			tc := newTypedFakeClient()
-			_, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: kubernautSystem, Triager: defaultTestTriager()}, &tools.CreateRRArgs{
+			_, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: kubernautSystem, Triager: defaultTestTriager("", "Deployment", "web")}, &tools.CreateRRArgs{
 				Kind:          "Deployment",
 				Name:          "web",
 				APIVersion:    "apps/v1",
@@ -695,7 +753,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
 				Client:       tc,
 				ControllerNS: kubernautSystem,
-				Triager:      defaultTestTriager(),
+				Triager:      defaultTestTriager("prod", "Deployment", "nginx"),
 			}, &tools.CreateRRArgs{
 				Namespace:   "prod",
 				Kind:        "Deployment",
@@ -716,7 +774,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
 				Client:       tc,
 				ControllerNS: kubernautSystem,
-				Triager:      defaultTestTriager(),
+				Triager:      defaultTestTriager("prod", "Deployment", "redis"),
 			}, &tools.CreateRRArgs{
 				Namespace:   "prod",
 				Kind:        "Deployment",
@@ -736,7 +794,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 			result1, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
 				Client:       tc,
 				ControllerNS: kubernautSystem,
-				Triager:      defaultTestTriager(),
+				Triager:      defaultTestTriager("prod", "Deployment", "web"),
 			}, &tools.CreateRRArgs{
 				Namespace: "prod", Kind: "Deployment", Name: "web",
 				Description: "east", APIVersion: "apps/v1", ClusterID: "cluster-east",
@@ -747,7 +805,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 			result2, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
 				Client:       tc,
 				ControllerNS: kubernautSystem,
-				Triager:      defaultTestTriager(),
+				Triager:      defaultTestTriager("prod", "Deployment", "web"),
 			}, &tools.CreateRRArgs{
 				Namespace: "prod", Kind: "Deployment", Name: "web",
 				Description: "west", APIVersion: "apps/v1", ClusterID: "cluster-west",
@@ -765,7 +823,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
 				Client:       tc,
 				ControllerNS: "kubernaut-system",
-				Triager:      defaultTestTriager(),
+				Triager:      defaultTestTriager("prod", "Deployment", "nginx"),
 			}, &tools.CreateRRArgs{
 				Namespace: "prod", Kind: "Deployment", Name: "nginx",
 				Description: "test", APIVersion: "apps/v1", ClusterID: "cluster-east-1",
@@ -787,7 +845,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
 				Client:       tc,
 				ControllerNS: "prod",
-				Triager:      defaultTestTriager(),
+				Triager:      defaultTestTriager("prod", "Deployment", "web"),
 			}, &tools.CreateRRArgs{
 				Namespace: "prod", Kind: "Deployment", Name: "web",
 				Description: "race", APIVersion: "apps/v1", ClusterID: "cluster-original",
@@ -808,7 +866,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 				Client:       tc,
 				ControllerNS: kubernautSystem,
 				Auditor:      rec,
-				Triager:      defaultTestTriager(),
+				Triager:      defaultTestTriager("prod", "Deployment", "web"),
 			}, &tools.CreateRRArgs{
 				Namespace: "prod", Kind: "Deployment", Name: "web",
 				Description: "audit created", APIVersion: "apps/v1",
@@ -851,7 +909,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 				Client:       tc,
 				ControllerNS: "prod",
 				Auditor:      rec,
-				Triager:      defaultTestTriager(),
+				Triager:      defaultTestTriager("prod", "Deployment", "web"),
 			}, &tools.CreateRRArgs{
 				Namespace: "prod", Kind: "Deployment", Name: "web",
 				Description: "audit dedup", APIVersion: "apps/v1",
@@ -874,7 +932,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 				Client:       tc,
 				ControllerNS: "kubernaut-system",
 				Auditor:      rec,
-				Triager:      defaultTestTriager(),
+				Triager:      defaultTestTriager("prod", "Deployment", "web"),
 			}, &tools.CreateRRArgs{
 				Namespace: "prod", Kind: "Deployment", Name: "web",
 				Description: "fleet audit", APIVersion: "apps/v1", ClusterID: "cluster-east-1",
@@ -899,7 +957,7 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 				Client:       tc,
 				ControllerNS: "prod",
 				Auditor:      rec,
-				Triager:      defaultTestTriager(),
+				Triager:      defaultTestTriager("prod", "Deployment", "web"),
 			}, &tools.CreateRRArgs{
 				Namespace: "prod", Kind: "Deployment", Name: "web",
 				Description: "fleet audit dedup", APIVersion: "apps/v1", ClusterID: "cluster-east-1",
@@ -916,13 +974,118 @@ var _ = Describe("HandleCreateRR (#1282 refactor)", func() {
 			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
 				Client:       tc,
 				ControllerNS: kubernautSystem,
-				Triager:      defaultTestTriager(),
+				Triager:      defaultTestTriager("prod", "Deployment", "web"),
 			}, &tools.CreateRRArgs{
 				Namespace: "prod", Kind: "Deployment", Name: "web",
 				Description: "no auditor", APIVersion: "apps/v1",
 			}, "carol")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result.RRID).To(HavePrefix("rr-"))
+		})
+	})
+
+	// #2025 (main-tracking clone of #2022): reject out-of-scope resources
+	// before the Triager call/RR create that follow, instead of only being
+	// caught downstream by RO's CheckUnmanagedResource after the waste
+	// #2022 reported (ADR-053 Addendum "Point 3").
+	Describe("ScopeChecker pre-check (#2025)", func() {
+		It("UT-AF-2025-001: rejects RR creation for an unmanaged resource and returns ErrResourceNotManaged", func() {
+			tc := newTypedFakeClient()
+			_, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
+				Client:       tc,
+				ControllerNS: kubernautSystem,
+				Triager:      defaultTestTriager("prod", "Deployment", "web"),
+				ScopeChecker: &mocks.NeverManagedScopeChecker{},
+			}, &tools.CreateRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web",
+				Description: "unmanaged", APIVersion: "apps/v1",
+			}, "carol")
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, tools.ErrResourceNotManaged)).To(BeTrue())
+		})
+
+		It("UT-AF-2025-002: does not create an RR for an unmanaged resource", func() {
+			tc := newTypedFakeClient()
+			_, _ = tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
+				Client:       tc,
+				ControllerNS: kubernautSystem,
+				Triager:      defaultTestTriager("prod", "Deployment", "web"),
+				ScopeChecker: &mocks.NeverManagedScopeChecker{},
+			}, &tools.CreateRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web",
+				Description: "unmanaged", APIVersion: "apps/v1",
+			}, "carol")
+
+			var list remediationv1.RemediationRequestList
+			Expect(tc.List(context.Background(), &list, crclient.InNamespace(kubernautSystem))).To(Succeed())
+			Expect(list.Items).To(BeEmpty(), "no RR must be created for an out-of-scope resource")
+		})
+
+		It("UT-AF-2025-003: allows RR creation for a managed resource", func() {
+			tc := newTypedFakeClient()
+			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
+				Client:       tc,
+				ControllerNS: kubernautSystem,
+				Triager:      defaultTestTriager("prod", "Deployment", "web"),
+				ScopeChecker: &mocks.AlwaysManagedScopeChecker{},
+			}, &tools.CreateRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web",
+				Description: "managed", APIVersion: "apps/v1",
+			}, "carol")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RRID).To(HavePrefix("rr-"))
+		})
+
+		It("UT-AF-2025-004: fails closed (rejects) when the scope checker itself errors", func() {
+			tc := newTypedFakeClient()
+			_, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
+				Client:       tc,
+				ControllerNS: kubernautSystem,
+				Triager:      defaultTestTriager("prod", "Deployment", "web"),
+				ScopeChecker: &mocks.ErrorScopeChecker{Err: errors.New("scope backend unreachable")},
+			}, &tools.CreateRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web",
+				Description: "scope infra error", APIVersion: "apps/v1",
+			}, "carol")
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, tools.ErrResourceNotManaged)).To(BeTrue(),
+				"a scope-infrastructure error must fail closed, not silently allow RR creation")
+		})
+
+		It("UT-AF-2025-005: skips scope validation (backward compat) when ScopeChecker is nil", func() {
+			tc := newTypedFakeClient()
+			result, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
+				Client:       tc,
+				ControllerNS: kubernautSystem,
+				Triager:      defaultTestTriager("prod", "Deployment", "web"),
+				ScopeChecker: nil,
+			}, &tools.CreateRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web",
+				Description: "no scope checker configured", APIVersion: "apps/v1",
+			}, "carol")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RRID).To(HavePrefix("rr-"))
+		})
+
+		It("UT-AF-2025-006: emits EventRRScopeRejected audit event on rejection (AU-3/AU-12)", func() {
+			tc := newTypedFakeClient()
+			rec := &auditRecorder{}
+			_, err := tools.HandleCreateRR(context.Background(), &tools.ToolDeps{
+				Client:       tc,
+				ControllerNS: kubernautSystem,
+				Triager:      defaultTestTriager("prod", "Deployment", "web"),
+				Auditor:      rec,
+				ScopeChecker: &mocks.NeverManagedScopeChecker{},
+			}, &tools.CreateRRArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web",
+				Description: "unmanaged with auditor", APIVersion: "apps/v1",
+			}, "carol")
+			Expect(err).To(HaveOccurred())
+			Expect(rec.events).To(HaveLen(1))
+			Expect(rec.events[0].Type).To(Equal(audit.EventRRScopeRejected))
+			Expect(rec.events[0].Detail["namespace"]).To(Equal("prod"))
+			Expect(rec.events[0].Detail["kind"]).To(Equal("Deployment"))
+			Expect(rec.events[0].Detail["name"]).To(Equal("web"))
 		})
 	})
 })

--- a/pkg/apifrontend/tools/af_investigate_alert.go
+++ b/pkg/apifrontend/tools/af_investigate_alert.go
@@ -19,6 +19,7 @@ import (
 	apiprom "github.com/jordigilh/kubernaut/pkg/apifrontend/prometheus"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/severity"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/validate"
+	"github.com/jordigilh/kubernaut/pkg/shared/scope"
 )
 
 // AlertISSignaler creates an InvestigationSession CRD to signal interactive
@@ -33,7 +34,9 @@ type AlertISSignaler interface {
 // InvestigateAlertConfig holds dependencies for kubernaut_investigate_alert.
 // All nil-safe: nil PromClient skips alert validation, nil Mapper skips
 // RESTMapper scope checks, nil ValidationFailures skips metric emission,
-// nil Signaler skips IS CRD co-creation (backward compat).
+// nil Signaler skips IS CRD co-creation (backward compat), nil ScopeChecker
+// skips management-scope validation (backward compat; ADR-053 Addendum
+// "Point 3", #2025/#2022).
 type InvestigateAlertConfig struct {
 	Client             crclient.Client
 	DynClient          dynamic.Interface
@@ -44,6 +47,7 @@ type InvestigateAlertConfig struct {
 	ValidationFailures *prometheus.CounterVec
 	Mapper             meta.RESTMapper
 	Signaler           AlertISSignaler
+	ScopeChecker       scope.ScopeChecker
 }
 
 // InvestigateAlertArgs defines the LLM-supplied input for kubernaut_investigate_alert.
@@ -59,6 +63,12 @@ type InvestigateAlertArgs struct {
 	// ClusterID identifies the fleet cluster the target resource lives on
 	// (#1409, ADR-065). Empty for the local hub cluster.
 	ClusterID string `json:"cluster_id,omitempty"`
+	// ConfirmedSignalName re-supplies a previously-surfaced ambiguous
+	// severity candidate's alert name after the user has explicitly
+	// confirmed it (DD-AF-012, #2027/#2028). Leave empty on the first call.
+	// Note AlertName above is always the RR's signalName here (already
+	// user-confirmed) -- this field only affects severity resolution.
+	ConfirmedSignalName string `json:"confirmed_signal_name,omitempty"`
 }
 
 // InvestigateAlertResult is the output of kubernaut_investigate_alert.
@@ -70,6 +80,12 @@ type InvestigateAlertResult struct {
 	SignalName     string `json:"signal_name"`
 	Severity       string `json:"severity,omitempty"`
 	SeveritySource string `json:"severity_source,omitempty"`
+	// Ambiguous/CandidateSignalName/CandidateSeverity: see CreateRRResult
+	// (DD-AF-012, #2027/#2028). Re-call with ConfirmedSignalName set to
+	// CandidateSignalName once the user has confirmed it.
+	Ambiguous           bool   `json:"ambiguous,omitempty"`
+	CandidateSignalName string `json:"candidate_signal_name,omitempty"`
+	CandidateSeverity   string `json:"candidate_severity,omitempty"`
 }
 
 // HandleInvestigateAlert creates a RemediationRequest for a specific alert+resource pair.
@@ -117,19 +133,31 @@ func HandleInvestigateAlert(
 	}
 
 	createArgs := &CreateRRArgs{
-		Namespace:          args.Namespace,
-		Kind:               args.Kind,
-		Name:               args.Name,
-		APIVersion:         args.APIVersion,
-		ClusterScoped:      clusterScoped,
-		Description:        fmt.Sprintf("Alert-driven investigation: %s", args.AlertName),
-		SignalNameOverride: args.AlertName,
-		ClusterID:          args.ClusterID,
+		Namespace:                    args.Namespace,
+		Kind:                         args.Kind,
+		Name:                         args.Name,
+		APIVersion:                   args.APIVersion,
+		ClusterScoped:                clusterScoped,
+		Description:                  fmt.Sprintf("Alert-driven investigation: %s", args.AlertName),
+		SignalNameOverride:           args.AlertName,
+		ClusterID:                    args.ClusterID,
+		ConfirmedAmbiguousSignalName: args.ConfirmedSignalName,
 	}
 
-	result, err := HandleCreateRR(ctx, &ToolDeps{Client: cfg.Client, DynClient: cfg.DynClient, ControllerNS: cfg.ControllerNS, Triager: cfg.Triager, Auditor: cfg.Auditor}, createArgs, username)
+	result, err := HandleCreateRR(ctx, &ToolDeps{Client: cfg.Client, DynClient: cfg.DynClient, ControllerNS: cfg.ControllerNS, Triager: cfg.Triager, Auditor: cfg.Auditor, ScopeChecker: cfg.ScopeChecker}, createArgs, username)
 	if err != nil {
 		return InvestigateAlertResult{}, fmt.Errorf("create RR for alert investigation: %w", err)
+	}
+
+	if result.Ambiguous {
+		return InvestigateAlertResult{
+			AlertValidated:      alertValidated,
+			SignalName:          args.AlertName,
+			Ambiguous:           true,
+			CandidateSignalName: result.CandidateSignalName,
+			CandidateSeverity:   result.CandidateSeverity,
+			Message:             result.Message,
+		}, nil
 	}
 
 	signalInteractiveIfConfigured(ctx, cfg.Signaler, result.RRID, username)

--- a/pkg/apifrontend/tools/af_investigate_alert_1440_it_test.go
+++ b/pkg/apifrontend/tools/af_investigate_alert_1440_it_test.go
@@ -71,7 +71,7 @@ var _ = Describe("Fix #1440 Integration: IS CRD co-creation wiring", func() {
 				Client:       newTypedFakeClient(),
 				ControllerNS: "kubernaut-system",
 				Signaler:     signaler,
-				Triager:      defaultTestTriager(),
+				Triager:      defaultTestTriager("prod", "Deployment", "web"),
 			}
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
@@ -115,7 +115,7 @@ var _ = Describe("Fix #1440 Integration: IS CRD co-creation wiring", func() {
 				Client:       newTypedFakeClient(),
 				ControllerNS: "kubernaut-system",
 				Signaler:     signaler,
-				Triager:      defaultTestTriager(),
+				Triager:      defaultTestTriager("production", "Deployment", "api-server"),
 			}
 
 			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{

--- a/pkg/apifrontend/tools/af_investigate_alert_1440_test.go
+++ b/pkg/apifrontend/tools/af_investigate_alert_1440_test.go
@@ -52,7 +52,7 @@ var _ = Describe("Fix #1440: IS CRD co-creation in HandleInvestigateAlert", func
 		return tools.InvestigateAlertConfig{
 			Client:       newTypedFakeClient(),
 			ControllerNS: "kubernaut-system",
-			Triager:      defaultTestTriager(),
+			Triager:      defaultTestTriager("prod", "Deployment", "web"),
 		}
 	}
 

--- a/pkg/apifrontend/tools/af_investigate_alert_test.go
+++ b/pkg/apifrontend/tools/af_investigate_alert_test.go
@@ -2,6 +2,7 @@ package tools_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	"github.com/a2aproject/a2a-go/a2a"
@@ -16,6 +17,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
 	prom "github.com/jordigilh/kubernaut/pkg/apifrontend/prometheus"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+	"github.com/jordigilh/kubernaut/test/shared/mocks"
 )
 
 var _ = Describe("kubernaut_investigate_alert (#1372)", func() {
@@ -23,7 +25,7 @@ var _ = Describe("kubernaut_investigate_alert (#1372)", func() {
 		return tools.InvestigateAlertConfig{
 			Client:       newTypedFakeClient(),
 			ControllerNS: "kubernaut-system",
-			Triager:      defaultTestTriager(),
+			Triager:      defaultTestTriager("prod", "Deployment", "web"),
 		}
 	}
 
@@ -91,6 +93,7 @@ var _ = Describe("kubernaut_investigate_alert (#1372)", func() {
 			}
 			cfg := baseCfg()
 			cfg.PromClient = promClient
+			cfg.Triager = defaultTestTriager("", "Node", "worker-03")
 			result, err := tools.HandleInvestigateAlert(context.Background(), cfg,
 				&tools.InvestigateAlertArgs{
 					AlertName:  "NodeNotReady",
@@ -437,6 +440,7 @@ var _ = Describe("kubernaut_investigate_alert (#1372)", func() {
 		It("UT-AF-1372-056: strips namespace for cluster-scoped kind (self-healing #1477)", func() {
 			cfg := baseCfg()
 			cfg.Mapper = newMapper()
+			cfg.Triager = defaultTestTriager("", "Node", "worker-1")
 			result, err := tools.HandleInvestigateAlert(context.Background(), cfg,
 				&tools.InvestigateAlertArgs{
 					AlertName:  "KubeNodeNotReady",
@@ -452,6 +456,7 @@ var _ = Describe("kubernaut_investigate_alert (#1372)", func() {
 		It("UT-AF-1372-057: allows cluster-scoped kind without namespace", func() {
 			cfg := baseCfg()
 			cfg.Mapper = newMapper()
+			cfg.Triager = defaultTestTriager("", "Node", "worker-1")
 			result, err := tools.HandleInvestigateAlert(context.Background(), cfg,
 				&tools.InvestigateAlertArgs{
 					AlertName:  "KubeNodeNotReady",
@@ -498,7 +503,7 @@ var _ = Describe("kubernaut_investigate_alert (#1372)", func() {
 			result, err := tools.HandleInvestigateAlert(ctx, tools.InvestigateAlertConfig{
 				Client:       newTypedFakeClient(),
 				ControllerNS: "kubernaut-system",
-				Triager:      defaultTestTriager(),
+				Triager:      defaultTestTriager("demo-gateway", "Deployment", "api-frontend"),
 			}, &tools.InvestigateAlertArgs{
 				AlertName:  "ScalingLimited",
 				APIVersion: "apps/v1",
@@ -550,7 +555,7 @@ var _ = Describe("kubernaut_investigate_alert (#1372)", func() {
 				Client:       tc,
 				ControllerNS: "kubernaut-system",
 				Auditor:      rec,
-				Triager:      defaultTestTriager(),
+				Triager:      defaultTestTriager("prod", "Deployment", "web"),
 			}, &tools.InvestigateAlertArgs{
 				AlertName:  "KubePodCrashLooping",
 				APIVersion: "apps/v1",
@@ -589,6 +594,71 @@ var _ = Describe("kubernaut_investigate_alert (#1372)", func() {
 			}
 			Expect(eventSaw).To(BeTrue(),
 				"AU-3, SI-4: A2A status events must carry cluster_id from RRContext for Console cross-cluster correlation")
+		})
+	})
+
+	// #2025 (main-tracking clone of #2022): kubernaut_investigate_alert
+	// delegates to HandleCreateRR, which now pre-checks scope (ADR-053
+	// Addendum "Point 3") — this proves the ScopeChecker threads through
+	// InvestigateAlertConfig end-to-end.
+	Describe("ScopeChecker pre-check (#2025)", func() {
+		It("UT-AF-2025-020: rejects an unmanaged target resource before RR creation", func() {
+			cfg := baseCfg()
+			cfg.ScopeChecker = &mocks.NeverManagedScopeChecker{}
+			_, err := tools.HandleInvestigateAlert(context.Background(), cfg,
+				&tools.InvestigateAlertArgs{
+					AlertName:  "KubePodCrashLooping",
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "web",
+					Namespace:  "prod",
+				}, "user")
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, tools.ErrResourceNotManaged)).To(BeTrue())
+		})
+
+		It("UT-AF-2025-021: allows RR creation for a managed target resource", func() {
+			cfg := baseCfg()
+			cfg.ScopeChecker = &mocks.AlwaysManagedScopeChecker{}
+			result, err := tools.HandleInvestigateAlert(context.Background(), cfg,
+				&tools.InvestigateAlertArgs{
+					AlertName:  "KubePodCrashLooping",
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+					Name:       "web",
+					Namespace:  "prod",
+				}, "user")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RRID).NotTo(BeEmpty())
+		})
+	})
+
+	Describe("Ambiguous severity correlation — DD-AF-012 (#2027/#2028)", func() {
+		It("UT-AF-2028-007: surfaces Ambiguous/CandidateSignalName/CandidateSeverity when only a cluster-scoped alert correlates, then proceeds once confirmed", func() {
+			cfg := baseCfg()
+			cfg.Triager = ambiguousTestTriager()
+			args := &tools.InvestigateAlertArgs{
+				AlertName:  "KubePodCrashLooping",
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       "web-ambiguous",
+				Namespace:  "prod",
+			}
+
+			result, err := tools.HandleInvestigateAlert(context.Background(), cfg, args, "sre-alice")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Ambiguous).To(BeTrue())
+			Expect(result.CandidateSignalName).To(Equal("TestDefaultAlert"))
+			Expect(result.CandidateSeverity).To(Equal("warning"))
+			Expect(result.RRID).To(BeEmpty())
+			// AlertName is already user-confirmed and always wins for signal_name (#1372).
+			Expect(result.SignalName).To(Equal("KubePodCrashLooping"))
+
+			args.ConfirmedSignalName = "TestDefaultAlert"
+			confirmed, err := tools.HandleInvestigateAlert(context.Background(), cfg, args, "sre-alice")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(confirmed.Ambiguous).To(BeFalse())
+			Expect(confirmed.RRID).NotTo(BeEmpty())
 		})
 	})
 })

--- a/pkg/apifrontend/tools/cluster_scope_1477_test.go
+++ b/pkg/apifrontend/tools/cluster_scope_1477_test.go
@@ -97,7 +97,7 @@ var _ = Describe("Cluster-scoped namespace stripping (#1477)", func() {
 				Client:       newTypedFakeClient(),
 				ControllerNS: "kubernaut-system",
 				Mapper:       newScopeAwareMapper(),
-				Triager:      defaultTestTriager(),
+				Triager:      defaultTestTriager("", "Node", "worker-1"),
 			}
 			result, err := tools.HandleInvestigateAlert(ctx, cfg,
 				&tools.InvestigateAlertArgs{
@@ -208,7 +208,7 @@ var _ = Describe("Cluster-scoped namespace stripping (#1477)", func() {
 					MCPClient: mockMCP,
 					Client:    cfg.Client,
 					Namespace: "kubernaut-system",
-					Triager:   defaultTestTriager(),
+					Triager:   defaultTestTriager("", "Node", "worker-1"),
 				}, tools.InvestigateMCPArgs{
 					APIVersion: "v1",
 					Kind:       "Node",

--- a/pkg/apifrontend/tools/helpers.go
+++ b/pkg/apifrontend/tools/helpers.go
@@ -35,6 +35,11 @@ var ErrK8sUnavailable = errors.New("kubernetes cluster is not available — cont
 // ErrInvalidInput indicates input validation failed (RFC 1123, empty fields, etc.).
 var ErrInvalidInput = errors.New("invalid input")
 
+// ErrResourceNotManaged indicates the target resource is outside Kubernaut's
+// management scope (ADR-053) — rejected before RR/session creation
+// (#2025, main-tracking clone of #2022).
+var ErrResourceNotManaged = errors.New("resource not managed by kubernaut")
+
 // maxToolOutputBytes is the maximum serialized output size for tool results.
 // Matches the 16KB threshold used by session.MaxToolResultBytes for
 // in-memory session size safety.

--- a/pkg/apifrontend/tools/ka_investigate_intent_test.go
+++ b/pkg/apifrontend/tools/ka_investigate_intent_test.go
@@ -152,7 +152,7 @@ var _ = Describe("kubernaut_investigate intent-based enhancement (#1332)", func(
 					MCPClient: mockMCP,
 					Client:    tc,
 					Namespace: "kubernaut-system",
-					Triager:   defaultTestTriager(),
+					Triager:   defaultTestTriager("prod", "Deployment", "web-app"),
 				}, tools.InvestigateMCPArgs{
 					APIVersion: "apps/v1",
 					Namespace:  "prod",
@@ -468,6 +468,82 @@ var _ = Describe("kubernaut_investigate intent-based enhancement (#1332)", func(
 			Expect(recorder.correlationCalls[0].kaSessionID).To(Equal("ka-corr-sess-001"))
 		})
 
+		It("UT-AF-2029-101: UpdateCorrelation uses InvestigationSessionID (pollable analysis session), not the driver-lease SessionID, when KA returns both (#2029 regression)", func() {
+			// KA's kubernaut_investigate tool returns two distinct IDs: SessionID is the
+			// MCP driver-lease ID (exclusive-control lock, never pollable via REST), while
+			// InvestigationSessionID is the actual analysis session AA polls for RCA/workflow
+			// results. Correlating the driver-lease ID into IS.Status.KACorrelationID causes
+			// AA's handleSessionLost to 404-loop forever (see #2029 must-gather RCA).
+			tc := newTypedClientForInvestigate()
+
+			mockMCP := &ka.MockMCPClient{
+				StartInvestigationFn: func(_ context.Context, _ ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+					return &ka.StartInvestigationResult{
+						SessionID:              "ka-driver-lease-001",
+						InvestigationSessionID: "ka-analysis-sess-001",
+						Status:                 "investigation_started",
+						Closer:                 func() {},
+					}, nil
+				},
+			}
+
+			recorder := &recordingISSignaler{}
+			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+				Username: "sre@kubernaut.ai",
+				Groups:   []string{"sre"},
+			})
+
+			_, err := tools.HandleInvestigationMCPWithRegistry(
+				shortCtx(ctx), &tools.InvestigateConfig{
+					MCPClient: mockMCP,
+					Client:    tc,
+					Namespace: "kubernaut-system",
+					Signaler:  recorder,
+				}, tools.InvestigateMCPArgs{RRID: "rr-corr-002"},
+				false, "",
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(recorder.correlationCalls).To(HaveLen(1))
+			Expect(recorder.correlationCalls[0].crdName).To(Equal("is-rr-corr-002"))
+			Expect(recorder.correlationCalls[0].kaSessionID).To(Equal("ka-analysis-sess-001"),
+				"must correlate the pollable analysis session ID, not the driver-lease ID, or AA's session adoption (#2029 Part B) 404-loops forever")
+		})
+
+		It("UT-AF-2029-102: UpdateCorrelation falls back to SessionID when KA omits InvestigationSessionID (back-compat)", func() {
+			tc := newTypedClientForInvestigate()
+
+			mockMCP := &ka.MockMCPClient{
+				StartInvestigationFn: func(_ context.Context, _ ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+					return &ka.StartInvestigationResult{
+						SessionID: "ka-driver-lease-002",
+						Status:    "investigation_started",
+						Closer:    func() {},
+					}, nil
+				},
+			}
+
+			recorder := &recordingISSignaler{}
+			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+				Username: "sre@kubernaut.ai",
+				Groups:   []string{"sre"},
+			})
+
+			_, err := tools.HandleInvestigationMCPWithRegistry(
+				shortCtx(ctx), &tools.InvestigateConfig{
+					MCPClient: mockMCP,
+					Client:    tc,
+					Namespace: "kubernaut-system",
+					Signaler:  recorder,
+				}, tools.InvestigateMCPArgs{RRID: "rr-corr-003"},
+				false, "",
+			)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(recorder.correlationCalls).To(HaveLen(1))
+			Expect(recorder.correlationCalls[0].kaSessionID).To(Equal("ka-driver-lease-002"))
+		})
+
 		It("UT-AF-1332-074: signaler not called when signaler is nil (backward compat)", func() {
 			tc := newTypedClientForInvestigate()
 
@@ -495,6 +571,51 @@ var _ = Describe("kubernaut_investigate intent-based enhancement (#1332)", func(
 				false, "",
 			)
 			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+
+	Describe("Ambiguous severity/signal correlation — DD-AF-012 (#2027/#2028)", func() {
+		It("UT-AF-2028-006: surfaces Ambiguous/CandidateSignalName/CandidateSeverity when only a cluster-scoped alert correlates, then proceeds once confirmed", func() {
+			tc := newTypedClientForInvestigate()
+			ctx := auth.WithUserIdentity(context.Background(), &auth.UserIdentity{Username: "sre-erin", Groups: []string{"sre"}})
+
+			result, err := tools.HandleInvestigationMCPWithRegistry(
+				ctx, &tools.InvestigateConfig{
+					MCPClient: &ka.MockMCPClient{},
+					Client:    tc,
+					Namespace: "kubernaut-system",
+					Triager:   ambiguousTestTriager(),
+				}, tools.InvestigateMCPArgs{APIVersion: "apps/v1", Namespace: "prod", Kind: "Deployment", Name: "web-ambiguous"},
+				true, "sre-erin",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Ambiguous).To(BeTrue())
+			Expect(result.CandidateSignalName).To(Equal("TestDefaultAlert"))
+			Expect(result.CandidateSeverity).To(Equal("warning"))
+			Expect(result.RRID).To(BeEmpty())
+
+			eventCh := make(chan ka.InvestigationEvent)
+			close(eventCh)
+			mockMCP := &ka.MockMCPClient{
+				StartInvestigationFn: func(_ context.Context, _ ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+					return &ka.StartInvestigationResult{SessionID: "sess-2028-006", Status: "started", Events: eventCh, Closer: func() {}}, nil
+				},
+			}
+			confirmed, err := tools.HandleInvestigationMCPWithRegistry(
+				shortCtx(ctx), &tools.InvestigateConfig{
+					MCPClient: mockMCP,
+					Client:    tc,
+					Namespace: "kubernaut-system",
+					Triager:   ambiguousTestTriager(),
+				}, tools.InvestigateMCPArgs{
+					APIVersion: "apps/v1", Namespace: "prod", Kind: "Deployment", Name: "web-ambiguous",
+					ConfirmedSignalName: "TestDefaultAlert",
+				},
+				true, "sre-erin",
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(confirmed.Ambiguous).To(BeFalse())
+			Expect(confirmed.RRID).NotTo(BeEmpty())
 		})
 	})
 })

--- a/pkg/apifrontend/tools/ka_investigate_mcp.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp.go
@@ -118,6 +118,11 @@ type InvestigateMCPArgs struct {
 	// full, unattended remediation). An omitted or unrecognized value fails
 	// safe to "interactive" (AC-6 least privilege, SI-10 input validation).
 	InteractionMode string `json:"interaction_mode,omitempty" jsonschema:"one of interactive (default), full_remediation, full_remediation_autonomous -- declares how much autonomy to grant for post-investigation phase transitions"`
+
+	// ConfirmedSignalName re-supplies a previously-surfaced ambiguous
+	// candidate's alert name after the user has explicitly confirmed it
+	// (DD-AF-012, #2027/#2028). Leave empty on the first call.
+	ConfirmedSignalName string `json:"confirmed_signal_name,omitempty"`
 }
 
 // InvestigateMCPResult is the output of the MCP investigate tool.
@@ -128,6 +133,15 @@ type InvestigateMCPResult struct {
 	RRID      string          `json:"rr_id,omitempty"`
 	Error     string          `json:"error,omitempty"`
 	RCA       *InvestigateRCA `json:"rca,omitempty"`
+	// Ambiguous/CandidateSignalName/CandidateSeverity: see CreateRRResult
+	// (DD-AF-012, #2027/#2028). Re-call with ConfirmedSignalName set to
+	// CandidateSignalName once the user has confirmed it. Only meaningful
+	// on the new-RR (api_version/kind/name) path -- the rr_id takeover path
+	// never sets this, since that RR was already triaged at its own
+	// creation time.
+	Ambiguous           bool   `json:"ambiguous,omitempty"`
+	CandidateSignalName string `json:"candidate_signal_name,omitempty"`
+	CandidateSeverity   string `json:"candidate_severity,omitempty"`
 }
 
 // InvestigateRCA is the structured RCA data extracted from the KA complete event.
@@ -168,6 +182,12 @@ type InvestigateConfig struct {
 	Pool      *ka.KASessionPool
 	Signaler  ISSignaler
 	Triager   *severity.Triager
+	// ScopeChecker rejects RR creation for out-of-scope resources on the
+	// "new investigation" (api_version/kind/name) path (#2025, main-tracking
+	// clone of #2022; ADR-053 Addendum "Point 3"). Not consulted on the
+	// existing-rr_id (takeover) path — that RR was already scope-checked at
+	// its own creation time. Nil skips scope validation (backward compat).
+	ScopeChecker scope.ScopeChecker
 }
 
 // HandleInvestigationMCP starts a dedicated MCP investigation session. When a
@@ -213,9 +233,17 @@ func HandleInvestigationMCPWithRegistry(ctx context.Context, cfg *InvestigateCon
 		return InvestigateMCPResult{}, fmt.Errorf("KA MCP client unavailable")
 	}
 
-	rrSeverity, err := resolveInvestigationRR(ctx, cfg, &args)
+	rrSeverity, ambiguous, err := resolveInvestigationRR(ctx, cfg, &args)
 	if err != nil {
 		return InvestigateMCPResult{}, err
+	}
+	if ambiguous != nil {
+		return InvestigateMCPResult{
+			Ambiguous:           true,
+			CandidateSignalName: ambiguous.CandidateSignalName,
+			CandidateSeverity:   ambiguous.CandidateSeverity,
+			Error:               ambiguous.Message,
+		}, nil
 	}
 
 	identity := auth.UserIdentityFromContext(ctx)
@@ -280,30 +308,36 @@ func HandleInvestigationMCPWithRegistry(ctx context.Context, cfg *InvestigateCon
 // resource args (rr_id vs api_version/kind/name), and seeds the EventBridge
 // RR context (#1423) for Console banner population. Returns the severity
 // assessed during RR creation (if any) for later fallback-RCA use.
-func resolveInvestigationRR(ctx context.Context, cfg *InvestigateConfig, args *InvestigateMCPArgs) (rrSeverity string, err error) {
+func resolveInvestigationRR(ctx context.Context, cfg *InvestigateConfig, args *InvestigateMCPArgs) (rrSeverity string, ambiguous *CreateRRResult, err error) {
 	hasRRID := args.RRID != ""
 	hasResourceArgs := args.APIVersion != "" || args.Kind != "" || args.Name != "" || args.Namespace != ""
 
 	if !hasRRID && !hasResourceArgs {
-		return "", fmt.Errorf("rr_id or api_version/kind/name required")
+		return "", nil, fmt.Errorf("rr_id or api_version/kind/name required")
 	}
 	if hasRRID {
 		if err := validate.RRID(args.RRID); err != nil {
-			return "", fmt.Errorf("invalid rr_id: %w", err)
+			return "", nil, fmt.Errorf("invalid rr_id: %w", err)
 		}
 	}
 
 	identity := auth.UserIdentityFromContext(ctx)
 
 	if !hasRRID && hasResourceArgs {
-		rrSeverity, err = createRRForInvestigation(ctx, cfg, args, identity)
+		rrSeverity, ambiguous, err = createRRForInvestigation(ctx, cfg, args, identity)
 		if err != nil {
-			return "", err
+			return "", nil, err
+		}
+		// DD-AF-012/#2027/#2028: no RR was created -- the caller must ask
+		// the user to confirm the candidate before retrying. args.RRID was
+		// never populated, so the takeover-fetch logic below must not run.
+		if ambiguous != nil {
+			return "", ambiguous, nil
 		}
 	}
 
 	if args.RRID == "" {
-		return "", fmt.Errorf("rr_id is required for MCP investigation")
+		return "", nil, fmt.Errorf("rr_id is required for MCP investigation")
 	}
 
 	// For the existing-RR path (rr_id provided as input, i.e. a takeover of
@@ -316,7 +350,7 @@ func resolveInvestigationRR(ctx context.Context, cfg *InvestigateConfig, args *I
 		setTakeoverRRContext(ctx, cfg, args.RRID)
 	}
 
-	return rrSeverity, nil
+	return rrSeverity, nil, nil
 }
 
 // setTakeoverRRContext seeds the EventBridge RR context for the takeover
@@ -356,12 +390,12 @@ func setTakeoverRRContext(ctx context.Context, cfg *InvestigateConfig, rrID stri
 // stripping and rejecting service-account-initiated interactive
 // investigations. Mutates args.RRID/args.Namespace and seeds the
 // EventBridge RR context (#1423, AU-3, SI-4).
-func createRRForInvestigation(ctx context.Context, cfg *InvestigateConfig, args *InvestigateMCPArgs, identity *auth.UserIdentity) (string, error) {
+func createRRForInvestigation(ctx context.Context, cfg *InvestigateConfig, args *InvestigateMCPArgs, identity *auth.UserIdentity) (severityOut string, ambiguous *CreateRRResult, err error) {
 	if err := validate.APIVersion(args.APIVersion); err != nil {
-		return "", fmt.Errorf("%w", err)
+		return "", nil, fmt.Errorf("%w", err)
 	}
 	if args.Kind == "" || args.Name == "" {
-		return "", fmt.Errorf("kind and name required when providing api_version/kind/name")
+		return "", nil, fmt.Errorf("kind and name required when providing api_version/kind/name")
 	}
 
 	clusterScoped := resolveClusterScoped(ctx, args)
@@ -370,33 +404,39 @@ func createRRForInvestigation(ctx context.Context, cfg *InvestigateConfig, args 
 	}
 
 	if identity != nil && identity.IsServiceAccount {
-		return "", fmt.Errorf("interactive investigation cannot be started by service accounts")
+		return "", nil, fmt.Errorf("interactive investigation cannot be started by service accounts")
 	}
 	if cfg.Client == nil {
-		return "", fmt.Errorf("k8s client unavailable for RR creation")
+		return "", nil, fmt.Errorf("k8s client unavailable for RR creation")
 	}
 
 	createArgs := &CreateRRArgs{
-		Namespace:     args.Namespace,
-		Kind:          args.Kind,
-		Name:          args.Name,
-		APIVersion:    args.APIVersion,
-		ClusterScoped: clusterScoped,
-		ClusterID:     args.ClusterID,
+		Namespace:                    args.Namespace,
+		Kind:                         args.Kind,
+		Name:                         args.Name,
+		APIVersion:                   args.APIVersion,
+		ClusterScoped:                clusterScoped,
+		ClusterID:                    args.ClusterID,
+		ConfirmedAmbiguousSignalName: args.ConfirmedSignalName,
 	}
 	createUser := ""
 	if identity != nil {
 		createUser = identity.Username
 	}
-	result, err := HandleCreateRR(ctx, &ToolDeps{Client: cfg.Client, ControllerNS: cfg.Namespace, Triager: cfg.Triager, Auditor: cfg.Auditor}, createArgs, createUser)
+	result, err := HandleCreateRR(ctx, &ToolDeps{Client: cfg.Client, ControllerNS: cfg.Namespace, Triager: cfg.Triager, Auditor: cfg.Auditor, ScopeChecker: cfg.ScopeChecker}, createArgs, createUser)
 	if err != nil {
-		return "", fmt.Errorf("create RR for investigation: %w", err)
+		return "", nil, fmt.Errorf("create RR for investigation: %w", err)
+	}
+	// DD-AF-012/#2027/#2028: no RR was created -- surface the candidate to
+	// the caller instead of treating this as a fatal error.
+	if result.Ambiguous {
+		return "", &result, nil
 	}
 	args.RRID = result.RRID
 
 	launcher.SetRRContextSafe(ctx, newlyCreatedRRContext(result.RRID, args.Namespace, args.Kind, args.Name, result.SignalName, result.ClusterID))
 
-	return result.Severity, nil
+	return result.Severity, nil, nil
 }
 
 // resolveClusterScoped determines whether the target resource is
@@ -558,13 +598,23 @@ func startKAInvestigation(ctx context.Context, cfg *InvestigateConfig, rrID, kaS
 // registers the session in the MonitorRegistry so StopAll can force-close
 // on shutdown (the bridge goroutine/blocking path deregisters on exit).
 func finalizeInvestigationStart(ctx context.Context, cfg *InvestigateConfig, rrID, isCRDName string, result *ka.StartInvestigationResult, logger logr.Logger) {
+	// correlationSessionID is the pollable investigation-analysis session ID, NOT
+	// the MCP driver-lease result.SessionID. Correlating the driver-lease ID into
+	// IS.Status.KACorrelationID causes AA's handleSessionLost to 404-loop forever
+	// (#2029). Fall back to SessionID only when KA omits InvestigationSessionID
+	// (back-compat).
+	correlationSessionID := result.InvestigationSessionID
+	if correlationSessionID == "" {
+		correlationSessionID = result.SessionID
+	}
+
 	if cfg.Auditor != nil {
 		cfg.Auditor.Emit(ctx, &audit.Event{
 			Type: audit.EventKADelegated,
 			Detail: map[string]string{
 				"rr_id":             rrID,
 				"session_id":        result.SessionID,
-				"ka_correlation_id": result.SessionID,
+				"ka_correlation_id": correlationSessionID,
 				"delegation_type":   "interactive",
 			},
 		})
@@ -581,10 +631,10 @@ func finalizeInvestigationStart(ctx context.Context, cfg *InvestigateConfig, rrI
 		}
 	}
 
-	if cfg.Signaler != nil && isCRDName != "" && result.SessionID != "" {
-		if corrErr := cfg.Signaler.UpdateCorrelation(ctx, isCRDName, result.SessionID); corrErr != nil {
+	if cfg.Signaler != nil && isCRDName != "" && correlationSessionID != "" {
+		if corrErr := cfg.Signaler.UpdateCorrelation(ctx, isCRDName, correlationSessionID); corrErr != nil {
 			logger.Error(corrErr, "IS CRD correlation update failed (non-fatal)",
-				"crd_name", isCRDName, "session_id", result.SessionID)
+				"crd_name", isCRDName, "session_id", correlationSessionID)
 		}
 	}
 

--- a/pkg/apifrontend/tools/ka_investigate_mcp_test.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp_test.go
@@ -19,6 +19,7 @@ package tools_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sync/atomic"
 	"time"
 
@@ -37,6 +38,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+	"github.com/jordigilh/kubernaut/test/shared/mocks"
 )
 
 // goconst dedup: test-fixture literals deduplicated below.
@@ -1383,7 +1385,7 @@ var _ = Describe("Takeover RR context reconstruction — #1409, #1423 (AU-3, CC8
 		queue := &bridgeQueue{}
 		ctx := launcher.WithEventBridge(context.Background(), queue, "task-1409-011", "ctx-1409-011", nil)
 
-		_, err := tools.ResolveInvestigationRR(ctx, &tools.InvestigateConfig{
+		_, _, err := tools.ResolveInvestigationRR(ctx, &tools.InvestigateConfig{
 			Client:    tc,
 			Namespace: "kubernaut-system",
 		}, &tools.InvestigateMCPArgs{RRID: "rr-takeover-011"})
@@ -1410,7 +1412,7 @@ var _ = Describe("Takeover RR context reconstruction — #1409, #1423 (AU-3, CC8
 		queue := &bridgeQueue{}
 		ctx := launcher.WithEventBridge(context.Background(), queue, "task-1409-012", "ctx-1409-012", nil)
 
-		_, err := tools.ResolveInvestigationRR(ctx, &tools.InvestigateConfig{
+		_, _, err := tools.ResolveInvestigationRR(ctx, &tools.InvestigateConfig{
 			Client:    tc,
 			Namespace: "kubernaut-system",
 		}, &tools.InvestigateMCPArgs{RRID: "rr-takeover-012"})
@@ -1429,7 +1431,7 @@ var _ = Describe("Takeover RR context reconstruction — #1409, #1423 (AU-3, CC8
 		queue := &bridgeQueue{}
 		ctx := launcher.WithEventBridge(context.Background(), queue, "task-1409-013", "ctx-1409-013", nil)
 
-		_, err := tools.ResolveInvestigationRR(ctx, &tools.InvestigateConfig{
+		_, _, err := tools.ResolveInvestigationRR(ctx, &tools.InvestigateConfig{
 			Namespace: "kubernaut-system",
 		}, &tools.InvestigateMCPArgs{RRID: "rr-takeover-013"})
 		Expect(err).NotTo(HaveOccurred())
@@ -1481,13 +1483,13 @@ var _ = Describe("HandleInvestigationMCPWithRegistry — fleet cluster_id wiring
 			ctx, &tools.InvestigateConfig{
 				MCPClient: closedEventsMCP(),
 				Client:    tc,
-				Namespace: "kubernaut-system",
-				Triager:   defaultTestTriager(),
-			}, tools.InvestigateMCPArgs{
-				APIVersion: "apps/v1",
-				Namespace:  "prod",
-				Kind:       "Deployment",
-				Name:       "web-1409-003",
+			Namespace: "kubernaut-system",
+			Triager:   defaultTestTriager("prod", "Deployment", "web-1409-003"),
+		}, tools.InvestigateMCPArgs{
+			APIVersion: "apps/v1",
+			Namespace:  "prod",
+			Kind:       "Deployment",
+			Name:       "web-1409-003",
 				ClusterID:  "cluster-fleet-it-003",
 			},
 			true, "alice",
@@ -1620,6 +1622,57 @@ var _ = Describe("HandleInvestigationMCPWithRegistry — fleet cluster_id wiring
 		}
 		Expect(meta).NotTo(BeNil(), "degraded takeover context must still carry rr_id for correlation")
 		Expect(meta["cluster_id"]).To(BeNil(), "degraded context must not fabricate cluster_id it couldn't fetch")
+	})
+})
+
+// #2025 (main-tracking clone of #2022): resolveInvestigationRR's
+// createRRForInvestigation branch (new RR from api_version/kind/name)
+// delegates to HandleCreateRR, which now pre-checks scope. The takeover
+// (rr_id-only) branch does NOT re-check scope, since that RR was already
+// scope-checked at its own creation time.
+var _ = Describe("ScopeChecker pre-check (#2025)", func() {
+	It("UT-AF-2025-050: rejects a new-RR investigation for an unmanaged target resource", func() {
+		tc := newTypedFakeClient()
+		_, _, err := tools.ResolveInvestigationRR(context.Background(), &tools.InvestigateConfig{
+			Client:       tc,
+			Namespace:    "kubernaut-system",
+			Triager:      defaultTestTriager("prod", "Deployment", "web"),
+			ScopeChecker: &mocks.NeverManagedScopeChecker{},
+		}, &tools.InvestigateMCPArgs{
+			APIVersion: "apps/v1", Kind: "Deployment", Name: "web", Namespace: "prod",
+		})
+		Expect(err).To(HaveOccurred())
+		Expect(errors.Is(err, tools.ErrResourceNotManaged)).To(BeTrue())
+	})
+
+	It("UT-AF-2025-051: allows a new-RR investigation for a managed target resource", func() {
+		tc := newTypedFakeClient()
+		_, _, err := tools.ResolveInvestigationRR(context.Background(), &tools.InvestigateConfig{
+			Client:       tc,
+			Namespace:    "kubernaut-system",
+			Triager:      defaultTestTriager("prod", "Deployment", "web"),
+			ScopeChecker: &mocks.AlwaysManagedScopeChecker{},
+		}, &tools.InvestigateMCPArgs{
+			APIVersion: "apps/v1", Kind: "Deployment", Name: "web", Namespace: "prod",
+		})
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("UT-AF-2025-052: the rr_id (takeover) path is not scope-checked", func() {
+		rr := &remediationv1.RemediationRequest{
+			ObjectMeta: objMeta("kubernaut-system", "rr-takeover-2025"),
+			Spec: remediationv1.RemediationRequestSpec{
+				TargetResource: remediationv1.ResourceIdentifier{Kind: "Deployment", Name: "web", Namespace: "prod"},
+			},
+		}
+		tc := newTypedFakeClient(rr)
+		_, _, err := tools.ResolveInvestigationRR(context.Background(), &tools.InvestigateConfig{
+			Client:       tc,
+			Namespace:    "kubernaut-system",
+			ScopeChecker: &mocks.NeverManagedScopeChecker{},
+		}, &tools.InvestigateMCPArgs{RRID: "rr-takeover-2025"})
+		Expect(err).NotTo(HaveOccurred(),
+			"a takeover of an already-existing RR must not be re-scope-checked")
 	})
 })
 

--- a/pkg/apifrontend/tools/ka_remediate.go
+++ b/pkg/apifrontend/tools/ka_remediate.go
@@ -15,6 +15,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/severity"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/validate"
+	"github.com/jordigilh/kubernaut/pkg/shared/scope"
 )
 
 // RemediateArgs defines the LLM-supplied input for kubernaut_remediate.
@@ -31,6 +32,10 @@ type RemediateArgs struct {
 	// ClusterID identifies the fleet cluster the target resource lives on
 	// (#1409, ADR-065). Empty for the local hub cluster.
 	ClusterID string `json:"cluster_id,omitempty"`
+	// ConfirmedSignalName re-supplies a previously-surfaced ambiguous
+	// candidate's alert name after the user has explicitly confirmed it
+	// (DD-AF-012, #2027/#2028). Leave empty on the first call.
+	ConfirmedSignalName string `json:"confirmed_signal_name,omitempty"`
 }
 
 // RemediateResult is the output of kubernaut_remediate.
@@ -43,11 +48,17 @@ type RemediateResult struct {
 	SignalName     string `json:"signal_name,omitempty"`
 	// ClusterID attributes the RR to its cluster of origin (#1409).
 	ClusterID string `json:"cluster_id,omitempty"`
-	// Fingerprint (#2043) and ClusterID above must stay the two trailing
-	// fields, matching CreateRRResult's field order/types exactly, so the
+	// Fingerprint (#2043), Ambiguous/CandidateSignalName/CandidateSeverity
+	// (DD-AF-012, #2027/#2028), and ClusterID above must stay in this exact
+	// field order/types, matching CreateRRResult's trailing fields, so the
 	// RemediateResult(result) conversion below stays valid (Go struct
 	// conversion requires identical field sequences; tags may differ).
-	Fingerprint string `json:"-"`
+	// Re-call with ConfirmedSignalName set to CandidateSignalName once the
+	// user has confirmed an ambiguous candidate.
+	Fingerprint         string `json:"-"`
+	Ambiguous           bool   `json:"ambiguous,omitempty"`
+	CandidateSignalName string `json:"candidate_signal_name,omitempty"`
+	CandidateSeverity   string `json:"candidate_severity,omitempty"`
 }
 
 // HandleRemediate creates a RemediationRequest CRD without creating an
@@ -96,18 +107,28 @@ func HandleRemediate(ctx context.Context, d *ToolDeps, args *RemediateArgs, user
 	}
 
 	createArgs := &CreateRRArgs{
-		Namespace:     args.Namespace,
-		Kind:          args.Kind,
-		Name:          args.Name,
-		Description:   args.Description,
-		APIVersion:    args.APIVersion,
-		ClusterScoped: args.Namespace == "",
-		ClusterID:     args.ClusterID,
+		Namespace:                    args.Namespace,
+		Kind:                         args.Kind,
+		Name:                         args.Name,
+		Description:                  args.Description,
+		APIVersion:                   args.APIVersion,
+		ClusterScoped:                args.Namespace == "",
+		ClusterID:                    args.ClusterID,
+		ConfirmedAmbiguousSignalName: args.ConfirmedSignalName,
 	}
 
 	result, err := HandleCreateRR(ctx, d, createArgs, username)
 	if err != nil {
 		return RemediateResult{}, err
+	}
+
+	if result.Ambiguous {
+		return RemediateResult{
+			Ambiguous:           true,
+			CandidateSignalName: result.CandidateSignalName,
+			CandidateSeverity:   result.CandidateSeverity,
+			Message:             result.Message,
+		}, nil
 	}
 
 	launcher.SetRRContextSafe(ctx, newlyCreatedRRContext(result.RRID, args.Namespace, args.Kind, args.Name, result.SignalName, result.ClusterID))
@@ -118,13 +139,14 @@ func HandleRemediate(ctx context.Context, d *ToolDeps, args *RemediateArgs, user
 // NewRemediateTool creates the kubernaut_remediate tool for autonomous remediation.
 // It creates RRs without InvestigationSessions — the pipeline handles analysis
 // autonomously without user interaction.
-func NewRemediateTool(client crclient.Client, dynClient dynamic.Interface, controllerNS string, triager *severity.Triager, auditor audit.Emitter) (tool.Tool, error) {
+func NewRemediateTool(client crclient.Client, dynClient dynamic.Interface, controllerNS string, triager *severity.Triager, auditor audit.Emitter, scopeChecker scope.ScopeChecker) (tool.Tool, error) {
 	d := &ToolDeps{
 		Client:       client,
 		DynClient:    dynClient,
 		ControllerNS: controllerNS,
 		Triager:      triager,
 		Auditor:      auditor,
+		ScopeChecker: scopeChecker,
 	}
 	return functiontool.New(functiontool.Config{
 		Name:        "kubernaut_remediate",

--- a/pkg/apifrontend/tools/ka_remediate_test.go
+++ b/pkg/apifrontend/tools/ka_remediate_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/severity"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+	"github.com/jordigilh/kubernaut/test/shared/mocks"
 )
 
 var _ = Describe("kubernaut_remediate (#1332 Intent-Based Tool Redesign)", func() {
@@ -34,7 +35,7 @@ var _ = Describe("kubernaut_remediate (#1332 Intent-Based Tool Redesign)", func(
 		It("UT-AF-1332-001: creates RR with valid namespace/kind/name and returns rr_id", func() {
 			tc := newTypedFakeClient()
 
-			result, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager()}, &tools.RemediateArgs{
+			result, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager("prod", "Deployment", "web")}, &tools.RemediateArgs{
 				Namespace:   "prod",
 				Kind:        "Deployment",
 				Name:        "web",
@@ -52,13 +53,13 @@ var _ = Describe("kubernaut_remediate (#1332 Intent-Based Tool Redesign)", func(
 		It("UT-AF-1332-002: deduplication returns already_exists for same fingerprint", func() {
 			tc := newTypedFakeClient()
 
-			result1, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager()}, &tools.RemediateArgs{
+			result1, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager("prod", "Deployment", "web")}, &tools.RemediateArgs{
 				Namespace: "prod", Kind: "Deployment", Name: "web", Description: "first", APIVersion: "apps/v1",
 			}, "user-a")
 			Expect(err).NotTo(HaveOccurred())
 			Expect(result1.AlreadyExists).To(BeFalse())
 
-			result2, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager()}, &tools.RemediateArgs{
+			result2, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager("prod", "Deployment", "web")}, &tools.RemediateArgs{
 				Namespace: "prod", Kind: "Deployment", Name: "web", Description: "second", APIVersion: "apps/v1",
 			}, "user-b")
 			Expect(err).NotTo(HaveOccurred())
@@ -68,7 +69,7 @@ var _ = Describe("kubernaut_remediate (#1332 Intent-Based Tool Redesign)", func(
 
 		It("UT-AF-1332-003: accepts empty namespace for cluster-scoped resources (#1372)", func() {
 			tc := newTypedFakeClient()
-			result, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager()}, &tools.RemediateArgs{
+			result, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager("", "Node", "worker-1")}, &tools.RemediateArgs{
 				Namespace: "", Kind: "Node", Name: "worker-1", APIVersion: "v1",
 			}, "user")
 			Expect(err).NotTo(HaveOccurred())
@@ -77,7 +78,7 @@ var _ = Describe("kubernaut_remediate (#1332 Intent-Based Tool Redesign)", func(
 
 		It("UT-AF-1332-004: rejects empty kind", func() {
 			tc := newTypedFakeClient()
-			_, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager()}, &tools.RemediateArgs{
+			_, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager("prod", "Deployment", "web")}, &tools.RemediateArgs{
 				Namespace: "prod", Kind: "", Name: "web", APIVersion: "apps/v1",
 			}, "user")
 			Expect(err).To(HaveOccurred())
@@ -86,7 +87,7 @@ var _ = Describe("kubernaut_remediate (#1332 Intent-Based Tool Redesign)", func(
 
 		It("UT-AF-1332-005: rejects empty name", func() {
 			tc := newTypedFakeClient()
-			_, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager()}, &tools.RemediateArgs{
+			_, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager("prod", "Deployment", "web")}, &tools.RemediateArgs{
 				Namespace: "prod", Kind: "Deployment", Name: "", APIVersion: "apps/v1",
 			}, "user")
 			Expect(err).To(HaveOccurred())
@@ -114,12 +115,12 @@ var _ = Describe("kubernaut_remediate (#1332 Intent-Based Tool Redesign)", func(
 		It("UT-AF-1332-008: existing rr_id path looks up RR status (fixes status.phase bug)", func() {
 			tc := newTypedFakeClient()
 
-			createResult, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager()}, &tools.RemediateArgs{
+			createResult, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager("prod", "Deployment", "existing-target")}, &tools.RemediateArgs{
 				Namespace: "prod", Kind: "Deployment", Name: "existing-target", APIVersion: "apps/v1",
 			}, "user")
 			Expect(err).NotTo(HaveOccurred())
 
-			lookupResult, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager()}, &tools.RemediateArgs{
+			lookupResult, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager("prod", "Deployment", "existing-target")}, &tools.RemediateArgs{
 				RRID: createResult.RRID,
 			}, "user")
 			Expect(err).NotTo(HaveOccurred())
@@ -131,7 +132,7 @@ var _ = Describe("kubernaut_remediate (#1332 Intent-Based Tool Redesign)", func(
 	Describe("NewRemediateTool — tool constructor (F-06)", func() {
 		It("UT-AF-1332-009: creates tool with name kubernaut_remediate", func() {
 			tc := newTypedFakeClient()
-			t, err := tools.NewRemediateTool(tc, nil, "kubernaut-system", nil, nil)
+			t, err := tools.NewRemediateTool(tc, nil, "kubernaut-system", nil, nil, nil)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(t.Name()).To(Equal("kubernaut_remediate"))
 		})
@@ -140,7 +141,7 @@ var _ = Describe("kubernaut_remediate (#1332 Intent-Based Tool Redesign)", func(
 	Describe("APIVersion support (#1372)", func() {
 		It("UT-AF-1372-070: remediate with api_version populated -> RR has apiVersion set", func() {
 			tc := newTypedFakeClient()
-			result, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager()}, &tools.RemediateArgs{
+			result, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager("prod", "Deployment", "web-apiver")}, &tools.RemediateArgs{
 				Namespace:  "prod",
 				Kind:       "Deployment",
 				Name:       "web-apiver",
@@ -152,7 +153,7 @@ var _ = Describe("kubernaut_remediate (#1332 Intent-Based Tool Redesign)", func(
 
 		It("UT-AF-1372-071: remediate with empty api_version rejects", func() {
 			tc := newTypedFakeClient()
-			_, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager()}, &tools.RemediateArgs{
+			_, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager("prod", "Deployment", "web")}, &tools.RemediateArgs{
 				Namespace:  "prod",
 				Kind:       "Deployment",
 				Name:       "web",
@@ -169,7 +170,7 @@ var _ = Describe("kubernaut_remediate (#1332 Intent-Based Tool Redesign)", func(
 			q := &bridgeQueue{}
 			ctx := launcher.WithEventBridge(context.Background(), q, a2a.NewTaskID(), "ctx-1423-020", nil)
 
-			result, err := tools.HandleRemediate(ctx, &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager()}, &tools.RemediateArgs{
+			result, err := tools.HandleRemediate(ctx, &tools.ToolDeps{Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager("prod", "Deployment", "web-enriched")}, &tools.RemediateArgs{
 				Namespace:  "prod",
 				Kind:       "Deployment",
 				Name:       "web-enriched",
@@ -217,7 +218,7 @@ var _ = Describe("kubernaut_remediate (#1332 Intent-Based Tool Redesign)", func(
 				Client:       tc,
 				ControllerNS: "kubernaut-system",
 				Auditor:      rec,
-				Triager:      defaultTestTriager(),
+				Triager:      defaultTestTriager("prod", "Deployment", "web-fleet"),
 			}, &tools.RemediateArgs{
 				Namespace:  "prod",
 				Kind:       "Deployment",
@@ -256,6 +257,85 @@ var _ = Describe("kubernaut_remediate (#1332 Intent-Based Tool Redesign)", func(
 			}
 			Expect(eventSaw).To(BeTrue(),
 				"AU-3, SI-4: A2A status events must carry cluster_id from RRContext for Console cross-cluster correlation")
+		})
+	})
+
+	// #2025 (main-tracking clone of #2022): HandleRemediate forwards
+	// ToolDeps.ScopeChecker straight into HandleCreateRR, so this proves
+	// kubernaut_remediate's new-RR path rejects out-of-scope resources.
+	Describe("ScopeChecker pre-check (#2025)", func() {
+		It("UT-AF-2025-030: rejects an unmanaged target resource before RR creation", func() {
+			tc := newTypedFakeClient()
+			_, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{
+				Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager("prod", "Deployment", "web-unmanaged"),
+				ScopeChecker: &mocks.NeverManagedScopeChecker{},
+			}, &tools.RemediateArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web-unmanaged", APIVersion: "apps/v1",
+			}, "user")
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, tools.ErrResourceNotManaged)).To(BeTrue())
+		})
+
+		It("UT-AF-2025-031: allows RR creation for a managed target resource", func() {
+			tc := newTypedFakeClient()
+			result, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{
+				Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager("prod", "Deployment", "web-managed"),
+				ScopeChecker: &mocks.AlwaysManagedScopeChecker{},
+			}, &tools.RemediateArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web-managed", APIVersion: "apps/v1",
+			}, "user")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RRID).NotTo(BeEmpty())
+		})
+
+		It("UT-AF-2025-032: the rr_id (dedup lookup) path is not scope-checked", func() {
+			tc := newTypedFakeClient()
+			created, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{
+				Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager("prod", "Deployment", "web-lookup"),
+			}, &tools.RemediateArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web-lookup", APIVersion: "apps/v1",
+			}, "user")
+			Expect(err).NotTo(HaveOccurred())
+
+			lookupResult, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{
+				Client: tc, ControllerNS: "kubernaut-system", Triager: defaultTestTriager("prod", "Deployment", "web-lookup"),
+				ScopeChecker: &mocks.NeverManagedScopeChecker{},
+			}, &tools.RemediateArgs{
+				RRID: created.RRID,
+			}, "user")
+			Expect(err).NotTo(HaveOccurred(),
+				"the rr_id lookup path reads an already-created (already scope-checked) RR and must not re-run scope validation")
+			Expect(lookupResult.RRID).To(Equal(created.RRID))
+		})
+	})
+
+	// #2025 (main-tracking clone of #2022): HandleRemediate forwards
+	// ToolDeps.ScopeChecker straight into HandleCreateRR, so this proves
+	// kubernaut_remediate's ambiguous-severity path mirrors af_create_rr's.
+	Describe("Ambiguous severity correlation — DD-AF-012 (#2027/#2028)", func() {
+		It("UT-AF-2028-005: surfaces Ambiguous/CandidateSignalName/CandidateSeverity when only a cluster-scoped alert correlates, then proceeds once confirmed", func() {
+			tc := newTypedFakeClient()
+
+			result, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{
+				Client: tc, ControllerNS: "kubernaut-system", Triager: ambiguousTestTriager(),
+			}, &tools.RemediateArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web-ambiguous", APIVersion: "apps/v1",
+			}, "user")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Ambiguous).To(BeTrue())
+			Expect(result.CandidateSignalName).To(Equal("TestDefaultAlert"))
+			Expect(result.CandidateSeverity).To(Equal("warning"))
+			Expect(result.RRID).To(BeEmpty())
+
+			confirmed, err := tools.HandleRemediate(context.Background(), &tools.ToolDeps{
+				Client: tc, ControllerNS: "kubernaut-system", Triager: ambiguousTestTriager(),
+			}, &tools.RemediateArgs{
+				Namespace: "prod", Kind: "Deployment", Name: "web-ambiguous", APIVersion: "apps/v1",
+				ConfirmedSignalName: "TestDefaultAlert",
+			}, "user")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(confirmed.Ambiguous).To(BeFalse())
+			Expect(confirmed.RRID).NotTo(BeEmpty())
 		})
 	})
 })

--- a/pkg/apifrontend/tools/scope_helpers.go
+++ b/pkg/apifrontend/tools/scope_helpers.go
@@ -2,11 +2,14 @@ package tools
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/api/meta"
 
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/audit"
 	sharedK8s "github.com/jordigilh/kubernaut/pkg/shared/k8s"
+	"github.com/jordigilh/kubernaut/pkg/shared/scope"
 )
 
 type restMapperContextKey struct{}
@@ -23,6 +26,70 @@ func ContextWithRESTMapper(ctx context.Context, mapper meta.RESTMapper) context.
 func RESTMapperFromContext(ctx context.Context) meta.RESTMapper {
 	v, _ := ctx.Value(restMapperContextKey{}).(meta.RESTMapper)
 	return v
+}
+
+// checkRRScope validates that target is within Kubernaut's management scope
+// (ADR-053/ADR-068) before HandleInvestigateAlert, HandleRemediate, or
+// HandleInvestigationMCPWithRegistry create an RR — closing the gap where
+// this was previously only caught downstream by RO's CheckUnmanagedResource,
+// after an RR (and, for interactive tools, an InvestigationSession) had
+// already been wastefully created (#2025, main clone of #2022; ADR-053
+// Addendum "Point 3"). target is passed as a scope.ResourceIdentity
+// (rather than four separate positional strings) to stay within this
+// package's argument-count convention (revive argument-limit) and because
+// it is exactly the shape checker.IsManagedResource already expects.
+//
+// nil checker = always managed (graceful degradation, matches the nil-safe
+// Mapper/PromClient convention elsewhere in this package) — returns
+// managed=true with an empty message.
+//
+// On a scope-infrastructure error, fails closed (managed=false), mirroring
+// RO's CheckUnmanagedResource fail-closed behavior
+// (pkg/remediationorchestrator/routing/blocking.go) — callers cannot
+// distinguish "explicitly unmanaged" from "scope check errored" because both
+// must equally prevent RR creation.
+//
+// On rejection, the message mirrors RO's exact wording (blocking.go) so an
+// agent gets identical guidance whether rejected here (fail-fast) or
+// downstream by RO (temporal-drift re-check), and an EventRRScopeRejected
+// audit event is emitted (AU-3/AU-12) when auditor is non-nil.
+func checkRRScope(ctx context.Context, checker scope.ScopeChecker, auditor audit.Emitter, username string, target scope.ResourceIdentity) (managed bool, message string) {
+	if checker == nil {
+		return true, ""
+	}
+
+	clusterCtx := "local"
+	if target.ClusterID != "" {
+		clusterCtx = target.ClusterID
+	}
+
+	managed, err := checker.IsManagedResource(ctx, target)
+	if err != nil {
+		logr.FromContextOrDiscard(ctx).Error(err, "scope validation failed — rejecting RR creation (fail-closed)",
+			"cluster", clusterCtx, "namespace", target.Namespace, "kind", target.Kind, "name", target.Name)
+		managed = false
+	}
+	if managed {
+		return true, ""
+	}
+
+	message = fmt.Sprintf("Resource %s/%s/%s (cluster=%s) not managed by Kubernaut. "+
+		"Add label kubernaut.ai/managed=true to namespace or resource.", target.Namespace, target.Kind, target.Name, clusterCtx)
+
+	if auditor != nil {
+		auditor.Emit(ctx, &audit.Event{
+			Type:      audit.EventRRScopeRejected,
+			UserID:    username,
+			ClusterID: target.ClusterID,
+			Detail: map[string]string{
+				"namespace": target.Namespace,
+				"kind":      target.Kind,
+				"name":      target.Name,
+			},
+		})
+	}
+
+	return false, message
 }
 
 // ResolveEffectiveNamespace returns the namespace to use for a Kubernetes API

--- a/pkg/shared/events/reasons.go
+++ b/pkg/shared/events/reasons.go
@@ -70,6 +70,18 @@ const (
 	// The KA investigation pauses while the user drives.
 	EventReasonUserDriving = "UserDriving"
 
+	// EventReasonSessionAdopted is emitted when AA adopts a KA session that
+	// AF correlated onto this RR's InvestigationSession after AA's own
+	// tracked session went stale (e.g. a reconnect/takeover following a
+	// timeout) (issue #2030 Part B).
+	// FedRAMP SI-4 (System Monitoring): surfaces the correlation change as an
+	// observable event rather than a silent internal state swap.
+	// FedRAMP AU-2/AU-3 (Audit Events / Content): paired with the durable
+	// RecordAIAgentCall("session_adopted") audit record so the adoption --
+	// and the fact that a real, completed investigation was not discarded --
+	// is traceable after the fact, not just visible in logs.
+	EventReasonSessionAdopted = "SessionAdopted"
+
 	// EventReasonApprovalRequired is emitted when human approval is required
 	// for workflow execution (low confidence or policy mandate).
 	EventReasonApprovalRequired = "ApprovalRequired"

--- a/test/e2e/apifrontend/e2e_suite_test.go
+++ b/test/e2e/apifrontend/e2e_suite_test.go
@@ -124,6 +124,27 @@ var _ = SynchronizedBeforeSuite(
 		clientset, err = kubernetes.NewForConfig(restCfg)
 		Expect(err).NotTo(HaveOccurred(), "failed to create kubernetes clientset")
 
+		// #2022/#2025/ADR-053: the mock-LLM's dedicated investigate fixture
+		// (af_investigate/af_progressive_investigate scenarios, see
+		// deploy/apifrontend/overlays/e2e/mock-llm.yaml) targets this
+		// namespace, which — unlike sev-tier1-ns et al. — was never actually
+		// created as a real Namespace object (only referenced as a string in
+		// RR specs and Prometheus alert labels). AF's scope check now
+		// fail-closes to unmanaged when neither the target resource nor its
+		// namespace exists/is labeled, so this namespace must exist and
+		// carry the managed label for kubernaut_investigate to proceed past
+		// scope validation, matching a real Kubernaut deployment's setup.
+		Expect(kinfra.EnsureManagedNamespace(context.Background(), k8sClient, "af-investigate-e2e")).
+			To(Succeed(), "af-investigate-e2e namespace must exist and be labeled managed")
+
+		// structured_decision_e2e_test.go's groundSession helper uses its own
+		// dedicated namespace/target (StructuredDecisionGrounding alert,
+		// apifrontend_prometheus_e2e.go) rather than reusing af-investigate-e2e
+		// above, to avoid fixture contention with concurrent specs under
+		// Ginkgo --procs>1 (CI run 31320575553, E2E-AF-1395-001).
+		Expect(kinfra.EnsureManagedNamespace(context.Background(), k8sClient, "af-structured-decision-e2e")).
+			To(Succeed(), "af-structured-decision-e2e namespace must exist and be labeled managed")
+
 		healthURL := "http://localhost:18081"
 		Eventually(func() error {
 			resp, err := http.Get(healthURL + "/healthz") //nolint:gosec,noctx // E2E health probe

--- a/test/e2e/apifrontend/helpers_test.go
+++ b/test/e2e/apifrontend/helpers_test.go
@@ -100,16 +100,7 @@ func a2aTasksSendWithContext(id, contextID, text string) string {
 // SessionInterceptor from routing independent SSE streams to a shared session,
 // which causes phantom connections that never drain.
 func a2aMessageStream(id, text string) string {
-	return buildJSONRPC(id, "message/stream", map[string]interface{}{
-		"message": map[string]interface{}{
-			"messageId": "msg-" + id,
-			"contextId": "ctx-" + id,
-			"role":      "user",
-			"parts": []map[string]interface{}{
-				{"kind": "text", "text": text},
-			},
-		},
-	})
+	return a2aMessageStreamWithContext(id, "ctx-"+id, text)
 }
 
 // a2aMessageStreamWithContext is like a2aMessageStream but takes an explicit

--- a/test/e2e/apifrontend/severity_triage_test.go
+++ b/test/e2e/apifrontend/severity_triage_test.go
@@ -13,9 +13,6 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	remediationv1alpha1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
@@ -36,11 +33,15 @@ var _ = Describe("Severity Triage Pipeline (G12)", Label("e2e", "phase4", "g12")
 		Expect(err).NotTo(HaveOccurred(), "SRE DEX token")
 		Expect(authToken).NotTo(BeEmpty())
 
+		// #2022/#2025/ADR-053: AF's scope check now fail-closes to unmanaged
+		// for any namespace lacking the kubernaut.ai/managed label, so every
+		// E2E fixture namespace that expects kubernaut_investigate/
+		// kubernaut_remediate to actually create an RR must be labeled
+		// managed, matching what a real Kubernaut deployment would already
+		// have configured.
 		for _, nsName := range []string{"sev-tier1-ns", "sev-tier15-ns", "sev-tier2-ns", "no-data-ns", "no-rules-ns", "sev-userhint-ns"} {
-			ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: nsName}}
-			err = k8sClient.Create(context.Background(), ns)
-			if err != nil && !apierrors.IsAlreadyExists(err) {
-				_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: failed to create namespace %s: %v\n", nsName, err)
+			if err := kinfra.EnsureManagedNamespace(context.Background(), k8sClient, nsName); err != nil {
+				_, _ = fmt.Fprintf(GinkgoWriter, "WARNING: failed to ensure managed namespace %s: %v\n", nsName, err)
 			}
 		}
 	})

--- a/test/e2e/apifrontend/structured_decision_e2e_test.go
+++ b/test/e2e/apifrontend/structured_decision_e2e_test.go
@@ -187,6 +187,30 @@ var _ = Describe("Structured Decision Payload E2E — #1395 #1396", Ordered, Lab
 		_, _ = scanDecisionEvent(resp) // drain to EOF; no decision event expected here
 	}
 
+	// groundSessionBeta is groundSession's/groundSessionAlt's third sibling,
+	// dedicated to E2E-AF-1396-001 alone (structured-decision-target-3,
+	// StructuredDecisionGrounding3 in apifrontend_prometheus_e2e.go / the
+	// "seed third fixture context 1396 001" mock-LLM keyword).
+	// groundSessionAlt above only closed contention for the 3rd It
+	// (1396-002) relative to the first two -- it did not address that the
+	// 2nd It (1396-001) still shares groundSession's ORIGINAL target with
+	// the 1st It (1395-001), so 1396-001's own grounding call could just as
+	// nondeterministically inherit 1395-001's still-open KA session and
+	// observe session_active instead of a clean grounded result, which per
+	// investigateHasGroundedContent (phase_guard.go) deterministically
+	// fails present_decision's grounding guard closed -- surfacing as an
+	// empty payload.RCA.Severity instead of the scripted "critical" (CI run
+	// 31351842574, "severity must flow from mock-LLM through AF to SSE").
+	// A third dedicated target removes the last remaining shared fixture in
+	// this Ordered block.
+	groundSessionBeta := func(ctx context.Context, contextID string) {
+		resp, err := a2aSSEPost(ctx, a2aMessageStreamWithContext(contextID+"-ground", contextID,
+			"seed third fixture context 1396 001 for pod structured-decision-target-3 in af-structured-decision-e2e"))
+		Expect(err).NotTo(HaveOccurred(), "grounding kubernaut_investigate call must succeed")
+		defer func() { _ = resp.Body.Close() }()
+		_, _ = scanDecisionEvent(resp) // drain to EOF; no decision event expected here
+	}
+
 	It("E2E-AF-1395-001: SI-10 — structured decision payload > 512 chars arrives intact via SSE", func() {
 		readCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 		defer cancel()
@@ -221,7 +245,7 @@ var _ = Describe("Structured Decision Payload E2E — #1395 #1396", Ordered, Lab
 		defer cancel()
 
 		const ctxID = "ctx-e2e-structured-002"
-		groundSession(readCtx, ctxID)
+		groundSessionBeta(readCtx, ctxID)
 
 		resp, err := a2aSSEPost(readCtx, a2aMessageStreamWithContext("e2e-structured-002-decision", ctxID, "present structured rca decision"))
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/apifrontend/structured_decision_e2e_test.go
+++ b/test/e2e/apifrontend/structured_decision_e2e_test.go
@@ -135,11 +135,66 @@ var _ = Describe("Structured Decision Payload E2E — #1395 #1396", Ordered, Lab
 		return "", nil
 	}
 
+	// groundSession establishes #2023's grounding-guard prerequisite: a
+	// successful kubernaut_investigate turn in the same A2A session
+	// (contextID), so the later present_decision turn's before-callback
+	// (enforceGroundingGuard, phase_guard.go) finds
+	// session.StateKeyGroundedContentAvailable=true and lets the mock-LLM's
+	// scripted RCA/options through instead of overwriting them with the
+	// fail-closed "no investigation content" fallback. Targets a dedicated
+	// af-structured-decision-e2e/structured-decision-target fixture (managed
+	// namespace, StructuredDecisionGrounding synthetic alert,
+	// apifrontend_prometheus_e2e.go) rather than the shared
+	// af-investigate-e2e/af-investigate-target fixture used by
+	// af_investigate/af_progressive_investigate/af_investigate_resume: with
+	// Ginkgo --procs>1 those scenarios' concurrently-running specs can hold
+	// that fixture's KA session open when this call lands, and
+	// af_create_rr.go's checkExistingRRByFingerprint dedups by target, so
+	// this call would nondeterministically inherit their in-flight session
+	// and hit KA's session_active/early_rca fallback instead of a clean
+	// grounded result -- silently starving present_decision of grounding
+	// and emitting no SSE decision event at all (CI run 31320575553,
+	// this test, "not to be empty").
+	groundSession := func(ctx context.Context, contextID string) {
+		resp, err := a2aSSEPost(ctx, a2aMessageStreamWithContext(contextID+"-ground", contextID,
+			"seed grounding context for pod structured-decision-target in af-structured-decision-e2e"))
+		Expect(err).NotTo(HaveOccurred(), "grounding kubernaut_investigate call must succeed")
+		defer func() { _ = resp.Body.Close() }()
+		_, _ = scanDecisionEvent(resp) // drain to EOF; no decision event expected here
+	}
+
+	// groundSessionAlt is groundSession's twin for E2E-AF-1396-002 alone,
+	// targeting a SECOND dedicated fixture (structured-decision-target-2,
+	// StructuredDecisionGrounding2 in apifrontend_prometheus_e2e.go / the
+	// "seed alt fixture context 1396 002" mock-LLM keyword). This Describe
+	// block is Ordered and its 3 Its run sequentially; #1395-001 and
+	// #1396-001 above both call groundSession against the SAME
+	// structured-decision-target fixture, and af_create_rr.go's
+	// checkExistingRRByFingerprint dedups by target, so by this 3rd call
+	// the RR already has a KA interactive session opened by one of the
+	// prior two Its. That nondeterministically surfaces as "session_active"
+	// instead of a clean grounded result, which per
+	// investigateHasGroundedContent (phase_guard.go, UT-AF-2023-004)
+	// deterministically fails present_decision's grounding guard closed --
+	// clearing options to [] (CI run 31335085795, "AC-6: ALL options must
+	// be presented"). A fixture this test alone uses eliminates the
+	// contention outright rather than relying on lease timing.
+	groundSessionAlt := func(ctx context.Context, contextID string) {
+		resp, err := a2aSSEPost(ctx, a2aMessageStreamWithContext(contextID+"-ground", contextID,
+			"seed alt fixture context 1396 002 for pod structured-decision-target-2 in af-structured-decision-e2e"))
+		Expect(err).NotTo(HaveOccurred(), "grounding kubernaut_investigate call must succeed")
+		defer func() { _ = resp.Body.Close() }()
+		_, _ = scanDecisionEvent(resp) // drain to EOF; no decision event expected here
+	}
+
 	It("E2E-AF-1395-001: SI-10 — structured decision payload > 512 chars arrives intact via SSE", func() {
 		readCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 		defer cancel()
 
-		resp, err := a2aSSEPost(readCtx, a2aMessageStream("e2e-structured-001", "present structured rca decision"))
+		const ctxID = "ctx-e2e-structured-001"
+		groundSession(readCtx, ctxID)
+
+		resp, err := a2aSSEPost(readCtx, a2aMessageStreamWithContext("e2e-structured-001-decision", ctxID, "present structured rca decision"))
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = resp.Body.Close() }()
 
@@ -165,7 +220,10 @@ var _ = Describe("Structured Decision Payload E2E — #1395 #1396", Ordered, Lab
 		readCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 		defer cancel()
 
-		resp, err := a2aSSEPost(readCtx, a2aMessageStream("e2e-structured-002", "present structured rca decision"))
+		const ctxID = "ctx-e2e-structured-002"
+		groundSession(readCtx, ctxID)
+
+		resp, err := a2aSSEPost(readCtx, a2aMessageStreamWithContext("e2e-structured-002-decision", ctxID, "present structured rca decision"))
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = resp.Body.Close() }()
 
@@ -219,7 +277,10 @@ var _ = Describe("Structured Decision Payload E2E — #1395 #1396", Ordered, Lab
 		readCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
 		defer cancel()
 
-		resp, err := a2aSSEPost(readCtx, a2aMessageStream("e2e-structured-003", "present structured rca decision"))
+		const ctxID = "ctx-e2e-structured-003"
+		groundSessionAlt(readCtx, ctxID)
+
+		resp, err := a2aSSEPost(readCtx, a2aMessageStreamWithContext("e2e-structured-003-decision", ctxID, "present structured rca decision"))
 		Expect(err).NotTo(HaveOccurred())
 		defer func() { _ = resp.Body.Close() }()
 

--- a/test/e2e/fleet/18_af_ka_interactive_fleet_bridge_test.go
+++ b/test/e2e/fleet/18_af_ka_interactive_fleet_bridge_test.go
@@ -17,6 +17,7 @@ package fleet
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -27,6 +28,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	remediationv1 "github.com/jordigilh/kubernaut/api/remediation/v1alpha1"
 	"github.com/jordigilh/kubernaut/test/infrastructure"
 )
 
@@ -36,6 +38,13 @@ import (
 // (same convention as kaToolE2ETargetName in 17_ka_real_fleet_investigation_test.go).
 const kaInteractiveFleetTargetName = "ka-interactive-fleet-target"
 const kaInteractiveFleetTargetNamespace = "kubernaut-system"
+
+// kaInteractiveFleetRemoteClusterID is the cluster_id Turn 1's
+// kubernaut_remediate call targets (mirrors the raw "remote-cluster"
+// literal used throughout this package, e.g. suite_test.go's clusterID);
+// named here (rather than left as an inline literal) because Turn 1's own
+// retry loop below needs to filter RemediationRequestList by it.
+const kaInteractiveFleetRemoteClusterID = "remote-cluster"
 
 // kaInteractiveFleetEvidence mirrors the mock-llm scenario's memory-limit
 // evidence constant. Deliberately distinct from #17's kaToolE2ELocal/RemoteEvidence
@@ -119,27 +128,78 @@ var _ = Describe("E2E-FLEET-018 [AC-4, AC-6, AU-3]: AF kubernaut_message drives 
 		}, 2*time.Minute, 2*time.Second).Should(Succeed())
 
 		By("Turn 1: kubernaut_remediate (creates RR with cluster_id=remote-cluster targeting the marker deployment)")
-		turn1ID := "fleet-018-1"
-		body := afA2ATasksSend(turn1ID, "ka-interactive-fleet-bridge-start")
-		resp1, err := afA2AInvokeWithTimeout(body, 60*time.Second)
-		Expect(err).NotTo(HaveOccurred())
-		defer func() { _ = resp1.Body.Close() }()
-		Expect(resp1.StatusCode).To(Equal(http.StatusOK), "Turn 1 A2A message/send should return 200")
-		rpc, parseErr := afParseRPC(resp1)
-		Expect(parseErr).NotTo(HaveOccurred())
-		Expect(rpc.Error).To(BeNil(), "Turn 1 should not return a JSON-RPC error")
-		task, taskErr := afExtractTask(rpc.Result)
-		Expect(taskErr).NotTo(HaveOccurred())
-		taskID := task.ID
-		Expect(taskID).NotTo(BeEmpty(), "Turn 1 A2A task ID must not be empty")
-		GinkgoWriter.Printf("  E2E-FLEET-018 Turn 1 — task: %s (state: %s)\n", taskID, task.Status.State)
+		// Issue #2059/E2E-FLEET-018 RCA (CI run 31384892125, confirmed AFTER
+		// the apifrontend.yaml fleet.backend/endpoint chart fix below): AF's
+		// own audit log showed "resource not managed by kubernaut: ...
+		// (cluster=remote-cluster) not managed by Kubernaut" for THIS
+		// deployment, even though it genuinely carries kubernaut.ai/managed=true
+		// (DeployMemoryEaterNamed) -- because AF's FederatedScopeChecker now
+		// correctly routes the check to FMC (pkg/fleet/fmc/http_client.go),
+		// and FMC only ever answers from its own cache, refreshed on a fixed
+		// 10s ticker (test/infrastructure/fleet_e2e.go's
+		// fleetmetadatacache-config sync.interval=10s -- see suite_test.go's
+		// fmcSyncTimeout doc comment for the full mechanism). The marker
+		// Deployment above became Available only seconds before this call,
+		// so it is not guaranteed to have survived a full FMC sync cycle
+		// yet. This mirrors fmcSyncTimeout/postFleetAlertUntilAccepted's
+		// identical staleness window on the Gateway alert path exactly --
+		// reused verbatim here since AF's own kubernaut_remediate call now
+		// goes through the SAME FederatedScopeChecker -> FMC HTTP client.
+		//
+		// checkRRScope (pkg/apifrontend/tools/af_create_rr.go) runs BEFORE
+		// any RR object creation, so a scope-rejected call has no side
+		// effects -- retrying is safe. The A2A envelope itself reports
+		// "completed" even when the underlying tool call was rejected (AF's
+		// ADK agent callback absorbs the tool error and the flow still
+		// concludes normally), so success can only be confirmed by checking
+		// that a real RR now exists for this target -- not by the
+		// envelope's own status/error fields. Each retry mints a fresh
+		// turn/session id (a rejected attempt's ADK session has no RR
+		// attached, so it can't be resumed) to avoid colliding with the
+		// still-existing session left behind by a prior attempt.
+		var taskID, sharedCtxID, body string
+		var rpc afRPCResponse
+		var parseErr error
+		attempt := 0
+		Eventually(func(g Gomega) {
+			attempt++
+			turn1ID := fmt.Sprintf("fleet-018-1-%d", attempt)
+			body := afA2ATasksSend(turn1ID, "ka-interactive-fleet-bridge-start")
+			resp1, err := afA2AInvokeWithTimeout(body, 60*time.Second)
+			g.Expect(err).NotTo(HaveOccurred())
+			defer func() { _ = resp1.Body.Close() }()
+			g.Expect(resp1.StatusCode).To(Equal(http.StatusOK), "Turn 1 A2A message/send should return 200")
+			rpc, parseErr = afParseRPC(resp1)
+			g.Expect(parseErr).NotTo(HaveOccurred())
+			g.Expect(rpc.Error).To(BeNil(), "Turn 1 should not return a JSON-RPC error")
+			task, taskErr := afExtractTask(rpc.Result)
+			g.Expect(taskErr).NotTo(HaveOccurred())
+			g.Expect(task.ID).NotTo(BeEmpty(), "Turn 1 A2A task ID must not be empty")
 
-		// sharedCtxID MUST be Turn 1's own contextId ("ctx-"+turn1ID, set by
-		// afA2ATasksSend), not derived from taskID (a server-assigned A2A
-		// task identifier, unrelated to the ADK session/contextId) -- see
-		// afA2ATasksSendWithTask's doc comment for the CI-confirmed failure
-		// mode this avoids.
-		sharedCtxID := "ctx-" + turn1ID
+			rrList := &remediationv1.RemediationRequestList{}
+			g.Expect(k8sClient.List(ctx, rrList, client.InNamespace(namespace))).To(Succeed())
+			created := false
+			for _, rr := range rrList.Items {
+				if rr.Spec.ClusterID == kaInteractiveFleetRemoteClusterID &&
+					rr.Spec.TargetResource.Name == kaInteractiveFleetTargetName {
+					created = true
+					break
+				}
+			}
+			g.Expect(created).To(BeTrue(),
+				"Turn 1 (attempt %d, task %s, state %s) must have created a real RR for %s on cluster_id=%s "+
+					"(scope-rejected due to FMC sync lag is the known, retried failure mode here)",
+				attempt, task.ID, task.Status.State, kaInteractiveFleetTargetName, kaInteractiveFleetRemoteClusterID)
+
+			// sharedCtxID MUST be this attempt's own contextId
+			// ("ctx-"+turn1ID, set by afA2ATasksSend), not derived from
+			// taskID (a server-assigned A2A task identifier, unrelated to
+			// the ADK session/contextId) -- see afA2ATasksSendWithTask's
+			// doc comment for the CI-confirmed failure mode this avoids.
+			taskID = task.ID
+			sharedCtxID = "ctx-" + turn1ID
+			GinkgoWriter.Printf("  E2E-FLEET-018 Turn 1 — task: %s (state: %s, attempt: %d)\n", taskID, task.Status.State, attempt)
+		}, fmcSyncTimeout, 2*time.Second).Should(Succeed())
 
 		By("Turn 2: kubernaut_investigate (blocks until KA's autonomous investigation establishes the interactive session)")
 		body = afA2ATasksSendWithTask("fleet-018-2", taskID, sharedCtxID, "investigate the remediation")

--- a/test/e2e/fullpipeline/10_af_fleet_cluster_id_test.go
+++ b/test/e2e/fullpipeline/10_af_fleet_cluster_id_test.go
@@ -62,9 +62,36 @@ import (
 // own target tool has already responded anywhere in the conversation
 // history. Verified against a live Kind cluster (test-e2e-fullpipeline
 // infra) in the authoring environment after the fix.
+//
+// Skipped when Fleet is disabled (#2022/#2025, ADR-053/ADR-068 port to
+// main): this suite's cluster_id="cluster-fleet-e2e-1409" has always been a
+// fiction (fullpipeline is a single Kind cluster, per
+// test/e2e/fleet/16_af_real_fleet_investigation_test.go's own doc comment),
+// but until AF's ADR-053 scope check landed on main, nothing actually
+// validated ClusterID before RR creation, so the fiction was harmless.
+// checkRRScope (pkg/apifrontend/tools/scope_helpers.go) now calls
+// ScopeChecker.IsManagedResource for every kubernaut_remediate/investigate
+// call; when Fleet is disabled, fleet.NewScopeChecker returns the local-only
+// scope.Manager unchanged, which correctly fails closed on any non-empty
+// ClusterID it has no federated backend to verify
+// (pkg/shared/scope/manager.go: "local Manager cannot resolve remote
+// cluster"). That is the intended, secure behavior for a real
+// single-cluster deployment -- an unverifiable cluster_id must not be
+// trusted -- so the fix here is to skip this now-incompatible scenario
+// rather than weaken the scope check. Real coverage for cluster_id
+// artifact-propagation through a genuinely Fleet-enabled AF instance
+// (with cluster_id="remote-cluster" registered and verified) already
+// exists in test/e2e/fleet/18_af_ka_interactive_fleet_bridge_test.go
+// (E2E-FLEET-018, Turn 1) and test/e2e/fleet/16_af_real_fleet_investigation_test.go
+// (E2E-FLEET-016); the pure server-side RRContext auto-fill logic this test
+// also exercised remains covered by UT-AF-1409-006b regardless.
 var _ = Describe("AF Fleet cluster_id Artifact Propagation [E2E-AF-1409-001]", Label("fp", "af", "fleet", "issue-1409"), func() {
 
 	It("should propagate LLM-supplied cluster_id through RRContext into the investigation_summary artifact", func() {
+		Skip("requires Fleet enabled to verify cluster_id (ADR-053/ADR-068 scope check) — " +
+			"fullpipeline's AF deployment has Fleet disabled (deploy/apifrontend/overlays/e2e/config.yaml has no fleet: key); " +
+			"see E2E-FLEET-018/E2E-FLEET-016 for equivalent coverage under a real Fleet-enabled AF instance")
+
 		fleetNS := fpRemediateNS["fleet"]
 		Expect(fleetNS).NotTo(BeEmpty(), "fleet namespace must be set by SynchronizedBeforeSuite")
 

--- a/test/infrastructure/apifrontend_prometheus_e2e.go
+++ b/test/infrastructure/apifrontend_prometheus_e2e.go
@@ -222,6 +222,39 @@ func AFInjectOTLPMetrics(ctx context.Context, prometheusURL, metricName string, 
 //     grounds severity_triage_test.go's TC-E2E-SEV-06 "user hint does not
 //     bypass triage" fixture (dedicated namespace="sev-userhint-ns",
 //     kind=Deployment, name="test-user-severity-bypass")
+//   - StructuredDecisionGrounding: for:0s + vector(1) (never stale) -> tier 1,
+//     grounds structured_decision_e2e_test.go's groundSession helper
+//     (dedicated namespace="af-structured-decision-e2e", kind=Pod,
+//     name="structured-decision-target"). Deliberately NOT the same
+//     fixture as AFInvestigateGrounding above: with --procs>1, Ginkgo runs
+//     this suite's Ordered container concurrently with every other spec
+//     that also drives kubernaut_investigate against af-investigate-target
+//     (af_investigate/af_progressive_investigate/af_investigate_resume,
+//     #1839), and af_create_rr.go's checkExistingRRByFingerprint dedups by
+//     target -- so groundSession's investigate call would nondeterministically
+//     inherit an unrelated concurrent test's still-open KA session and hit
+//     the session_active/early_rca fallback path instead of a clean grounded
+//     result, starving present_decision of grounding and emitting no SSE
+//     decision event at all (CI run 31320575553, E2E-AF-1395-001). A
+//     dedicated target closes this the same way test-firing-target et al.
+//     already do for the severity tiers above.
+//   - StructuredDecisionGrounding2: same shape as StructuredDecisionGrounding
+//     (namespace="af-structured-decision-e2e", kind=Pod,
+//     name="structured-decision-target-2"), dedicated to
+//     structured_decision_e2e_test.go's E2E-AF-1396-002 alone. That
+//     Describe block is Ordered, and all three of its Its previously shared
+//     ONE grounding fixture -- fine for #1395-001 and #1396-001, but by the
+//     third call af_create_rr.go's checkExistingRRByFingerprint dedups to
+//     the SAME RR the first two tests already opened a KA interactive
+//     session against, so E2E-AF-1396-002's own groundSession call
+//     nondeterministically observes "session_active" instead of a clean
+//     result -- which per investigateHasGroundedContent (phase_guard.go)
+//     and its own UT-AF-2023-004 deterministically fails present_decision's
+//     grounding guard closed, clearing options to [] (CI run 31335085795,
+//     "AC-6: ALL options must be presented"). A second dedicated target
+//     gives this one test its own RR so it never contends with #1395-001/
+//     #1396-001's still-open sessions, matching the fix already applied
+//     once above for cross-Describe-block contention.
 //
 // #1839 follow-up (no fixtures in "default"): HighCPU and HighMemory used to
 // target namespace="default" (unlike DiskPressure/NetworkLatency, which
@@ -334,4 +367,26 @@ groups:
           name: test-user-severity-bypass
         annotations:
           summary: "Synthetic grounding alert for TC-E2E-SEV-06 (dedicated namespace/name, #1839)"
+      - alert: StructuredDecisionGrounding
+        expr: vector(1) > 0
+        for: 0s
+        labels:
+          severity: warning
+          source: prometheus
+          namespace: af-structured-decision-e2e
+          kind: Pod
+          name: structured-decision-target
+        annotations:
+          summary: "Synthetic grounding alert for structured_decision_e2e_test.go's groundSession (dedicated namespace/name, avoids af-investigate-target fixture contention)"
+      - alert: StructuredDecisionGrounding2
+        expr: vector(1) > 0
+        for: 0s
+        labels:
+          severity: warning
+          source: prometheus
+          namespace: af-structured-decision-e2e
+          kind: Pod
+          name: structured-decision-target-2
+        annotations:
+          summary: "Synthetic grounding alert for structured_decision_e2e_test.go's E2E-AF-1396-002 (dedicated target, avoids intra-suite session_active contention with #1395-001/#1396-001)"
 `

--- a/test/infrastructure/apifrontend_prometheus_e2e.go
+++ b/test/infrastructure/apifrontend_prometheus_e2e.go
@@ -255,6 +255,20 @@ func AFInjectOTLPMetrics(ctx context.Context, prometheusURL, metricName string, 
 //     gives this one test its own RR so it never contends with #1395-001/
 //     #1396-001's still-open sessions, matching the fix already applied
 //     once above for cross-Describe-block contention.
+//   - StructuredDecisionGrounding3: same shape again
+//     (name="structured-decision-target-3"), dedicated to
+//     structured_decision_e2e_test.go's E2E-AF-1396-001 alone. The
+//     StructuredDecisionGrounding2 fix above only closed contention for
+//     the 3rd It (1396-002) relative to the first two -- it did not
+//     address that the 2nd It (1396-001) still shares #1395-001's ORIGINAL
+//     target, so 1396-001's own groundSession call can just as
+//     nondeterministically inherit #1395-001's still-open KA session and
+//     observe "session_active", surfacing as an empty (fail-closed)
+//     payload.RCA.Severity instead of the scripted "critical" (CI run
+//     31351842574, E2E-AF-1396-001, "severity must flow from mock-LLM
+//     through AF to SSE"). A third dedicated target removes the last
+//     remaining shared fixture in this Ordered block: each of the 3 Its
+//     now grounds against its own RR.
 //
 // #1839 follow-up (no fixtures in "default"): HighCPU and HighMemory used to
 // target namespace="default" (unlike DiskPressure/NetworkLatency, which
@@ -389,4 +403,15 @@ groups:
           name: structured-decision-target-2
         annotations:
           summary: "Synthetic grounding alert for structured_decision_e2e_test.go's E2E-AF-1396-002 (dedicated target, avoids intra-suite session_active contention with #1395-001/#1396-001)"
+      - alert: StructuredDecisionGrounding3
+        expr: vector(1) > 0
+        for: 0s
+        labels:
+          severity: warning
+          source: prometheus
+          namespace: af-structured-decision-e2e
+          kind: Pod
+          name: structured-decision-target-3
+        annotations:
+          summary: "Synthetic grounding alert for structured_decision_e2e_test.go's E2E-AF-1396-001 (dedicated target -- #1396-002's own fix above only closed contention for the 3rd It relative to the first two; the 2nd It (1396-001) still shared #1395-001's target, CI run 31351842574)"
 `

--- a/test/infrastructure/apifrontend_scope_e2e.go
+++ b/test/infrastructure/apifrontend_scope_e2e.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package infrastructure
+
+// ============================================================================
+// AF Resource-Scope E2E Fixtures (#2022/#2025, ADR-053)
+//
+// AF's tool-layer scope check (pkg/shared/scope) fail-closes to unmanaged
+// for any target resource/namespace lacking the kubernaut.ai/managed label.
+// E2E fixture namespaces created before that check existed were never
+// labeled, since nothing previously required it. EnsureManagedNamespace lets
+// E2E suites create (or re-label an already-existing) fixture namespace so
+// it reflects what a real Kubernaut deployment would already have
+// configured, keeping fixtures in sync with the enforced scope contract.
+// ============================================================================
+
+import (
+	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ManagedNamespaceLabelKey/Value mirror pkg/shared/scope's
+// ManagedLabelKey/ManagedLabelValueTrue. Duplicated here (rather than
+// importing pkg/shared/scope) to keep test/infrastructure free of a
+// dependency on apifrontend's production scope package.
+const (
+	ManagedNamespaceLabelKey   = "kubernaut.ai/managed"
+	ManagedNamespaceLabelValue = "true"
+)
+
+// EnsureManagedNamespace creates the named namespace labeled
+// kubernaut.ai/managed=true, or -- if it already exists -- patches the label
+// onto it when missing. Safe to call concurrently from multiple Ginkgo
+// parallel processes: a create race resolves via IsAlreadyExists, and a
+// label race is idempotent (both writers converge on the same value).
+func EnsureManagedNamespace(ctx context.Context, c client.Client, name string) error {
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{
+		Name:   name,
+		Labels: map[string]string{ManagedNamespaceLabelKey: ManagedNamespaceLabelValue},
+	}}
+	if err := c.Create(ctx, ns); err == nil {
+		return nil
+	} else if !apierrors.IsAlreadyExists(err) {
+		return fmt.Errorf("create namespace %s: %w", name, err)
+	}
+
+	var existing corev1.Namespace
+	if err := c.Get(ctx, client.ObjectKey{Name: name}, &existing); err != nil {
+		return fmt.Errorf("get existing namespace %s: %w", name, err)
+	}
+	if existing.Labels[ManagedNamespaceLabelKey] == ManagedNamespaceLabelValue {
+		return nil
+	}
+	if existing.Labels == nil {
+		existing.Labels = map[string]string{}
+	}
+	existing.Labels[ManagedNamespaceLabelKey] = ManagedNamespaceLabelValue
+	if err := c.Update(ctx, &existing); err != nil {
+		return fmt.Errorf("label existing namespace %s: %w", name, err)
+	}
+	return nil
+}

--- a/test/integration/aianalysis/interactive_watch_test.go
+++ b/test/integration/aianalysis/interactive_watch_test.go
@@ -39,12 +39,14 @@ import (
 // createActiveIS creates an InvestigationSession CRD for rrName and drives it
 // to Phase=Active, waiting for that phase to be visible in the cache before
 // returning — prevents a race where the IS watch fires on Create but
-// HasActiveSession still sees the non-Active phase.
+// HasActiveSession still sees the non-Active phase. Callers only need the
+// side effect (a visible, Active IS); none currently need the created object
+// itself.
 //
 // Package-level (not a Describe-local closure) so it can be shared across
 // integration test files in this package, e.g. session_correlation_adoption_test.go
 // (#2029 Part B).
-func createActiveIS(name, rrName string) *isv1alpha1.InvestigationSession {
+func createActiveIS(name, rrName string) {
 	const (
 		timeout  = 15 * time.Second
 		interval = 200 * time.Millisecond
@@ -77,16 +79,16 @@ func createActiveIS(name, rrName string) *isv1alpha1.InvestigationSession {
 		}
 		return updated.Status.Phase
 	}, timeout, interval).Should(Equal(isv1alpha1.SessionPhaseActive))
-
-	return is
 }
 
 // createInvestigatingAA creates an AIAnalysis CRD already in PhaseInvestigating
-// with a pre-set KASession, for tests that need to observe the reconcile loop's
+// with a pre-set KASession (ID intentionally empty -- these tests assert on the
+// real ID the controller's own reconcile loop assigns via KA submission, not a
+// caller-supplied one), for tests that need to observe the reconcile loop's
 // reaction to IS/session state changes rather than the initial submit itself.
 //
 // Package-level for the same reason as createActiveIS above.
-func createInvestigatingAA(name, rrName, sessionID, signalName string, interactive bool) *aianalysisv1.AIAnalysis {
+func createInvestigatingAA(name, rrName, signalName string, interactive bool) *aianalysisv1.AIAnalysis {
 	if signalName == "" {
 		signalName = "CrashLoopBackOff"
 	}
@@ -130,7 +132,6 @@ func createInvestigatingAA(name, rrName, sessionID, signalName string, interacti
 		now := metav1.Now()
 		analysis.Status.Phase = aianalysisv1.PhaseInvestigating
 		analysis.Status.KASession = &aianalysisv1.KASession{
-			ID:          sessionID,
 			Interactive: interactive,
 			CreatedAt:   &now,
 		}
@@ -195,7 +196,7 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 			rrName := helpers.UniqueTestName("rr-watch-create")
 			analysisName := helpers.UniqueTestName("aa-watch-create")
 
-			analysis := createInvestigatingAA(analysisName, rrName, "", "slow-investigation-test", false)
+			analysis := createInvestigatingAA(analysisName, rrName, "slow-investigation-test", false)
 
 			By("waiting for real KA session to be established (KASession.ID set)")
 			Eventually(func(g Gomega) {
@@ -229,7 +230,7 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 			isName := helpers.UniqueTestName("is-watch-delete")
 			createActiveIS(isName, rrName)
 
-			analysis := createInvestigatingAA(analysisName, rrName, "", "slow-investigation-test", true)
+			analysis := createInvestigatingAA(analysisName, rrName, "slow-investigation-test", true)
 
 			By("waiting for real KA session to be established")
 			Eventually(func(g Gomega) {
@@ -272,7 +273,7 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 			rrName := helpers.UniqueTestName("rr-takeover")
 			analysisName := helpers.UniqueTestName("aa-takeover")
 
-			analysis := createInvestigatingAA(analysisName, rrName, "", "slow-investigation-test", false)
+			analysis := createInvestigatingAA(analysisName, rrName, "slow-investigation-test", false)
 
 			By("waiting for real KA session to be established")
 			Eventually(func(g Gomega) {
@@ -332,7 +333,7 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 			rrName := helpers.UniqueTestName("rr-1390-upgrade")
 			analysisName := helpers.UniqueTestName("aa-1390-upgrade")
 
-			analysis := createInvestigatingAA(analysisName, rrName, "", "slow-investigation-test", false)
+			analysis := createInvestigatingAA(analysisName, rrName, "slow-investigation-test", false)
 
 			By("waiting for real KA session to be established")
 			Eventually(func(g Gomega) {
@@ -411,7 +412,7 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 			completionTimeout := 25 * time.Second
 
 			By("creating Investigating AA first (autonomous session — no IS yet)")
-			analysis := createInvestigatingAA(aaName, rrName, "", "brief-investigation-test", false)
+			analysis := createInvestigatingAA(aaName, rrName, "brief-investigation-test", false)
 
 			By("waiting for real KA session to be established")
 			Eventually(func(g Gomega) {
@@ -449,7 +450,7 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 			createActiveIS(isName, rrName)
 
 			By("creating Investigating AA with slow scenario")
-			analysis := createInvestigatingAA(aaName, rrName, "", "slow-investigation-test", true)
+			analysis := createInvestigatingAA(aaName, rrName, "slow-investigation-test", true)
 
 			By("waiting for session to be established")
 			Eventually(func(g Gomega) {
@@ -481,7 +482,7 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 			createActiveIS(isName, rrName)
 
 			By("creating Investigating AA with slow scenario")
-			analysis := createInvestigatingAA(aaName, rrName, "", "slow-investigation-test", false)
+			analysis := createInvestigatingAA(aaName, rrName, "slow-investigation-test", false)
 
 			By("waiting for session to be established then backdating")
 			Eventually(func(g Gomega) {
@@ -524,7 +525,7 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 			createActiveIS(isName, rrName)
 
 			By("creating Investigating AA with slow scenario (interactive)")
-			analysis := createInvestigatingAA(aaName, rrName, "", "slow-investigation-test", true)
+			analysis := createInvestigatingAA(aaName, rrName, "slow-investigation-test", true)
 
 			By("waiting for session to be established then backdating")
 			Eventually(func(g Gomega) {
@@ -595,7 +596,7 @@ var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", L
 			createActiveIS(isName, rrName)
 
 			By("creating Investigating AA with slow-investigation scenario")
-			analysis := createInvestigatingAA(aaName, rrName, "", "slow-investigation-test", true)
+			analysis := createInvestigatingAA(aaName, rrName, "slow-investigation-test", true)
 
 			By("waiting for real KA session to be established")
 			Eventually(func(g Gomega) {

--- a/test/integration/aianalysis/interactive_watch_test.go
+++ b/test/integration/aianalysis/interactive_watch_test.go
@@ -36,100 +36,115 @@ import (
 	"github.com/jordigilh/kubernaut/test/shared/helpers"
 )
 
+// createActiveIS creates an InvestigationSession CRD for rrName and drives it
+// to Phase=Active, waiting for that phase to be visible in the cache before
+// returning — prevents a race where the IS watch fires on Create but
+// HasActiveSession still sees the non-Active phase.
+//
+// Package-level (not a Describe-local closure) so it can be shared across
+// integration test files in this package, e.g. session_correlation_adoption_test.go
+// (#2029 Part B).
+func createActiveIS(name, rrName string) *isv1alpha1.InvestigationSession {
+	const (
+		timeout  = 15 * time.Second
+		interval = 200 * time.Millisecond
+	)
+	is := &isv1alpha1.InvestigationSession{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: isv1alpha1.InvestigationSessionSpec{
+			RemediationRequestRef: isv1alpha1.ObjectRef{
+				Name:      rrName,
+				Namespace: testNamespace,
+			},
+			A2ATaskID: "task-" + name,
+			UserIdentity: isv1alpha1.SessionUser{
+				Username: "integration-test-user",
+			},
+			JoinMode: isv1alpha1.SessionJoinModeStart,
+		},
+	}
+	Expect(k8sClient.Create(ctx, is)).To(Succeed())
+	is.Status.Phase = isv1alpha1.SessionPhaseActive
+	Expect(k8sClient.Status().Update(ctx, is)).To(Succeed())
+
+	Eventually(func() isv1alpha1.SessionPhase {
+		var updated isv1alpha1.InvestigationSession
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(is), &updated); err != nil {
+			return ""
+		}
+		return updated.Status.Phase
+	}, timeout, interval).Should(Equal(isv1alpha1.SessionPhaseActive))
+
+	return is
+}
+
+// createInvestigatingAA creates an AIAnalysis CRD already in PhaseInvestigating
+// with a pre-set KASession, for tests that need to observe the reconcile loop's
+// reaction to IS/session state changes rather than the initial submit itself.
+//
+// Package-level for the same reason as createActiveIS above.
+func createInvestigatingAA(name, rrName, sessionID, signalName string, interactive bool) *aianalysisv1.AIAnalysis {
+	if signalName == "" {
+		signalName = "CrashLoopBackOff"
+	}
+	analysis := &aianalysisv1.AIAnalysis{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+		},
+		Spec: aianalysisv1.AIAnalysisSpec{
+			RemediationRequestRef: corev1.ObjectReference{
+				Name:      rrName,
+				Namespace: testNamespace,
+			},
+			RemediationID: rrName,
+			AnalysisRequest: aianalysisv1.AnalysisRequest{
+				SignalContext: aianalysisv1.SignalContextInput{
+					Fingerprint:      "fp-interactive",
+					Severity:         "warning",
+					SignalName:       signalName,
+					Environment:      "staging",
+					BusinessPriority: "P2",
+					TargetResource: aianalysisv1.TargetResource{
+						Kind:      "Pod",
+						Name:      "test-pod",
+						Namespace: testNamespace,
+					},
+					EnrichmentResults: sharedtypes.EnrichmentResults{},
+				},
+				AnalysisTypes: []aianalysisv1.AnalysisType{aianalysisv1.AnalysisTypeInvestigation},
+			},
+		},
+	}
+	Expect(k8sClient.Create(ctx, analysis)).To(Succeed())
+
+	// RetryOnConflict: the controller races to set Phase=Pending on new AAs,
+	// which bumps the resource version. Same pattern as crd_lifecycle.go helpers.
+	Expect(k8sretry.RetryOnConflict(k8sretry.DefaultRetry, func() error {
+		if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), analysis); err != nil {
+			return err
+		}
+		now := metav1.Now()
+		analysis.Status.Phase = aianalysisv1.PhaseInvestigating
+		analysis.Status.KASession = &aianalysisv1.KASession{
+			ID:          sessionID,
+			Interactive: interactive,
+			CreatedAt:   &now,
+		}
+		return k8sClient.Status().Update(ctx, analysis)
+	})).To(Succeed())
+	return analysis
+}
+
 // BR-INTERACTIVE-010: Integration tests for InvestigationSession watch wiring (#1293).
 var _ = Describe("BR-INTERACTIVE-010: InvestigationSession Watch Integration", Label("integration", "interactive"), func() {
 	const (
 		timeout  = 15 * time.Second
 		interval = 200 * time.Millisecond
 	)
-
-	createActiveIS := func(name, rrName string) *isv1alpha1.InvestigationSession {
-		is := &isv1alpha1.InvestigationSession{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: testNamespace,
-			},
-			Spec: isv1alpha1.InvestigationSessionSpec{
-				RemediationRequestRef: isv1alpha1.ObjectRef{
-					Name:      rrName,
-					Namespace: testNamespace,
-				},
-				A2ATaskID: "task-" + name,
-				UserIdentity: isv1alpha1.SessionUser{
-					Username: "integration-test-user",
-				},
-				JoinMode: isv1alpha1.SessionJoinModeStart,
-			},
-		}
-		Expect(k8sClient.Create(ctx, is)).To(Succeed())
-		is.Status.Phase = isv1alpha1.SessionPhaseActive
-		Expect(k8sClient.Status().Update(ctx, is)).To(Succeed())
-
-		// Wait for Active phase to be visible in the cache — prevents race where
-		// IS watch fires on Create but HasActiveSession sees non-Active phase.
-		Eventually(func() isv1alpha1.SessionPhase {
-			var updated isv1alpha1.InvestigationSession
-			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(is), &updated); err != nil {
-				return ""
-			}
-			return updated.Status.Phase
-		}, timeout, interval).Should(Equal(isv1alpha1.SessionPhaseActive))
-
-		return is
-	}
-
-	createInvestigatingAA := func(name, rrName, sessionID, signalName string, interactive bool) *aianalysisv1.AIAnalysis {
-		if signalName == "" {
-			signalName = "CrashLoopBackOff"
-		}
-		analysis := &aianalysisv1.AIAnalysis{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      name,
-				Namespace: testNamespace,
-			},
-			Spec: aianalysisv1.AIAnalysisSpec{
-				RemediationRequestRef: corev1.ObjectReference{
-					Name:      rrName,
-					Namespace: testNamespace,
-				},
-				RemediationID: rrName,
-				AnalysisRequest: aianalysisv1.AnalysisRequest{
-					SignalContext: aianalysisv1.SignalContextInput{
-						Fingerprint:      "fp-interactive",
-						Severity:         "warning",
-						SignalName:       signalName,
-						Environment:      "staging",
-						BusinessPriority: "P2",
-						TargetResource: aianalysisv1.TargetResource{
-							Kind:      "Pod",
-							Name:      "test-pod",
-							Namespace: testNamespace,
-						},
-						EnrichmentResults: sharedtypes.EnrichmentResults{},
-					},
-					AnalysisTypes: []aianalysisv1.AnalysisType{aianalysisv1.AnalysisTypeInvestigation},
-				},
-			},
-		}
-		Expect(k8sClient.Create(ctx, analysis)).To(Succeed())
-
-		// RetryOnConflict: the controller races to set Phase=Pending on new AAs,
-		// which bumps the resource version. Same pattern as crd_lifecycle.go helpers.
-		Expect(k8sretry.RetryOnConflict(k8sretry.DefaultRetry, func() error {
-			if err := k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), analysis); err != nil {
-				return err
-			}
-			now := metav1.Now()
-			analysis.Status.Phase = aianalysisv1.PhaseInvestigating
-			analysis.Status.KASession = &aianalysisv1.KASession{
-				ID:          sessionID,
-				Interactive: interactive,
-				CreatedAt:   &now,
-			}
-			return k8sClient.Status().Update(ctx, analysis)
-		})).To(Succeed())
-		return analysis
-	}
 
 	Context("IT-AA-1293-001: Field index returns IS by RR name", func() {
 		It("should list InvestigationSession using spec.remediationRequestRef.name field index", func() {

--- a/test/integration/aianalysis/schemarejection/retry_test.go
+++ b/test/integration/aianalysis/schemarejection/retry_test.go
@@ -1,0 +1,278 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package schemarejection
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/validation/field"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	aianalysisv1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
+	"github.com/jordigilh/kubernaut/internal/controller/aianalysis"
+	"github.com/jordigilh/kubernaut/pkg/agentclient"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis/handlers"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis/metrics"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis/rego"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis/status"
+	sharedtypes "github.com/jordigilh/kubernaut/pkg/shared/types"
+)
+
+// ----------------------------------------------------------------------------
+// Test doubles (package-local; the ones in internal/controller/aianalysis's
+// _test.go file are not importable from here — _test.go files never are).
+// ----------------------------------------------------------------------------
+
+type fakeKAClientAlwaysErrors struct{}
+
+func (fakeKAClientAlwaysErrors) Investigate(_ context.Context, _ *agentclient.IncidentRequest) (*agentclient.IncidentResponse, error) {
+	return nil, errors.New("simulated KA outage (test double, #2030 IT)")
+}
+func (fakeKAClientAlwaysErrors) SubmitInvestigation(_ context.Context, _ *agentclient.IncidentRequest) (string, error) {
+	return "", errors.New("not implemented in test double (#2030 IT): session mode unused")
+}
+func (fakeKAClientAlwaysErrors) PollSession(_ context.Context, _ string) (*agentclient.SessionStatusResult, error) {
+	return nil, errors.New("not implemented in test double (#2030 IT): session mode unused")
+}
+func (fakeKAClientAlwaysErrors) GetSessionResult(_ context.Context, _ string) (*agentclient.IncidentResponse, error) {
+	return nil, errors.New("not implemented in test double (#2030 IT): session mode unused")
+}
+func (fakeKAClientAlwaysErrors) CancelSession(_ context.Context, _ string) error { return nil }
+
+type noopAuditClient struct{}
+
+func (noopAuditClient) RecordAIAgentCall(_ context.Context, _ *aianalysisv1.AIAnalysis, _ string, _ int, _ int) {
+}
+func (noopAuditClient) RecordPhaseTransition(_ context.Context, _ *aianalysisv1.AIAnalysis, _, _ string) {
+}
+func (noopAuditClient) RecordAnalysisFailed(_ context.Context, _ *aianalysisv1.AIAnalysis, _ error) error {
+	return nil
+}
+func (noopAuditClient) RecordAnalysisComplete(_ context.Context, _ *aianalysisv1.AIAnalysis) {}
+func (noopAuditClient) RecordAIAgentSubmit(_ context.Context, _ *aianalysisv1.AIAnalysis, _ string) {
+}
+func (noopAuditClient) RecordAIAgentResult(_ context.Context, _ *aianalysisv1.AIAnalysis, _ int64) {}
+func (noopAuditClient) RecordAIAgentSessionLost(_ context.Context, _ *aianalysisv1.AIAnalysis, _ int32) {
+}
+
+type noopAnalyzingAuditClient struct{}
+
+func (noopAnalyzingAuditClient) RecordRegoEvaluation(_ context.Context, _ *aianalysisv1.AIAnalysis, _ string, _ bool, _ int, _ string, _ string) {
+}
+func (noopAnalyzingAuditClient) RecordApprovalDecision(_ context.Context, _ *aianalysisv1.AIAnalysis, _, _ string) {
+}
+func (noopAnalyzingAuditClient) RecordAnalysisComplete(_ context.Context, _ *aianalysisv1.AIAnalysis) {
+}
+func (noopAnalyzingAuditClient) RecordAnalysisFailed(_ context.Context, _ *aianalysisv1.AIAnalysis, _ error) error {
+	return nil
+}
+
+// neverCalledRegoEvaluator: fixture has no SelectedWorkflow, so
+// AnalyzingHandler.Handle must short-circuit to Phase=Failed/
+// Reason=NoWorkflowSelected before ever evaluating Rego.
+type neverCalledRegoEvaluator struct{}
+
+func (neverCalledRegoEvaluator) Evaluate(_ context.Context, _ *rego.PolicyInput) (*rego.PolicyResult, error) {
+	return nil, errors.New("unexpected call (#2030 IT test double): fixture has no SelectedWorkflow")
+}
+
+// ----------------------------------------------------------------------------
+// Interceptor: rejects the first n Status().Update() calls with a synthetic
+// apierrors.IsInvalid, modeling a CRD-schema-lagging-behind-Go-source
+// rejection, then delegates to the real envtest apiserver for every call
+// after that (and always for plain, non-status Update() calls).
+// ----------------------------------------------------------------------------
+
+func failNStatusUpdates(n int32) interceptor.Funcs {
+	var calls int32
+	return interceptor.Funcs{
+		SubResourceUpdate: func(ctx context.Context, c client.Client, subResourceName string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+			if subResourceName == "status" && atomic.AddInt32(&calls, 1) <= n {
+				return apierrors.NewInvalid(
+					schema.GroupKind{Group: "kubernaut.ai", Kind: "AIAnalysis"},
+					obj.GetName(),
+					field.ErrorList{field.NotSupported(field.NewPath("status", "subReason"),
+						"SimulatedCRDSchemaLag2030IT", []string{"TransientError", "PermanentError"})},
+				)
+			}
+			return c.SubResource(subResourceName).Update(ctx, obj, opts...)
+		},
+	}
+}
+
+// ----------------------------------------------------------------------------
+// Fixture + reconciler helpers
+// ----------------------------------------------------------------------------
+
+func newSchemaRejectionITAnalysis(ns, name, phase string) *aianalysisv1.AIAnalysis {
+	return &aianalysisv1.AIAnalysis{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			// Pre-populate the finalizer as a real object mid-lifecycle would
+			// have it: Reconcile()'s step 3 adds it and returns early on the
+			// very first pass, before ever reaching the phase dispatch this
+			// test targets.
+			Finalizers: []string{aianalysis.FinalizerName},
+		},
+		Spec: aianalysisv1.AIAnalysisSpec{
+			RemediationRequestRef: corev1.ObjectReference{Name: "rr-" + name, Namespace: ns},
+			RemediationID:         "rr-" + name,
+			AnalysisRequest: aianalysisv1.AnalysisRequest{
+				SignalContext: aianalysisv1.SignalContextInput{
+					Fingerprint:      "fp-" + name,
+					Severity:         "critical",
+					SignalName:       "TestSignal2030IT",
+					Environment:      "staging",
+					BusinessPriority: "P1",
+					TargetResource: aianalysisv1.TargetResource{
+						Kind:      "Deployment",
+						Name:      "test-deploy",
+						Namespace: ns,
+					},
+					EnrichmentResults: sharedtypes.EnrichmentResults{},
+				},
+				AnalysisTypes: []aianalysisv1.AnalysisType{aianalysisv1.AnalysisTypeInvestigation},
+			},
+		},
+		Status: aianalysisv1.AIAnalysisStatus{
+			Phase: phase,
+		},
+	}
+}
+
+// newSchemaRejectionITReconciler wires a real InvestigatingHandler/
+// AnalyzingHandler (backed by trivial test doubles for KA/Rego/audit) onto
+// the given interceptor-wrapped, envtest-backed client, so
+// reconcileInvestigating/reconcileAnalyzing run through their genuine
+// production logic against a real Kubernetes API server.
+func newSchemaRejectionITReconciler(k8sClient client.Client) *aianalysis.AIAnalysisReconciler {
+	log := logr.Discard()
+	m := metrics.NewMetricsWithRegistry(prometheus.NewRegistry())
+
+	r := &aianalysis.AIAnalysisReconciler{
+		Client:        k8sClient,
+		Scheme:        k8sClient.Scheme(),
+		Recorder:      record.NewFakeRecorder(50),
+		Log:           log,
+		Metrics:       m,
+		StatusManager: status.NewManager(k8sClient, k8sClient),
+		AnalyzingHandler: handlers.NewAnalyzingHandler(
+			neverCalledRegoEvaluator{}, log, m, noopAnalyzingAuditClient{}),
+	}
+	r.InvestigatingHandler.Store(handlers.NewInvestigatingHandler(
+		fakeKAClientAlwaysErrors{}, log, m, noopAuditClient{}))
+	return r
+}
+
+// ----------------------------------------------------------------------------
+// IT-AA-2030-006
+// ----------------------------------------------------------------------------
+
+var _ = Describe("Schema-rejection retry wiring against a real API server (#2030 Part A)", func() {
+	var (
+		ctx       context.Context
+		ns        *corev1.Namespace
+		realWatch client.WithWatch
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+
+		var err error
+		realWatch, err = client.NewWithWatch(cfg, client.Options{Scheme: scheme.Scheme})
+		Expect(err).NotTo(HaveOccurred())
+
+		ns = &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "schema-rejection-it-" + randSuffix()}}
+		Expect(realWatch.Create(ctx, ns)).To(Succeed())
+	})
+
+	AfterEach(func() {
+		Expect(realWatch.Delete(ctx, ns)).To(Succeed())
+	})
+
+	It("IT-AA-2030-006: retries with backoff against a real apiserver, then escalates once the cap is exceeded", func() {
+		analysis := newSchemaRejectionITAnalysis(ns.Name, "it-2030-006", aianalysisv1.PhaseInvestigating)
+		Expect(realWatch.Create(ctx, analysis)).To(Succeed())
+		analysis.Status.Phase = aianalysisv1.PhaseInvestigating
+		Expect(realWatch.Status().Update(ctx, analysis)).To(Succeed())
+
+		req := ctrl.Request{NamespacedName: client.ObjectKeyFromObject(analysis)}
+
+		By("first reconcile: schema rejection must produce a bounded backoff requeue, not a permanent freeze")
+		wrapped := interceptor.NewClient(realWatch, failNStatusUpdates(100))
+		r := newSchemaRejectionITReconciler(wrapped)
+
+		result, err := r.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.RequeueAfter).To(BeNumerically(">", 0),
+			"must requeue with backoff, not fail-close forever (ctrl.Result{}, nil) like the pre-#2030 behavior")
+
+		var fresh aianalysisv1.AIAnalysis
+		Expect(realWatch.Get(ctx, req.NamespacedName, &fresh)).To(Succeed())
+		Expect(fresh.Annotations[handlers.SchemaRejectionRetryCountAnnotation]).To(Equal("1"),
+			"retry annotation must persist via a plain Update() against the REAL apiserver even while Status().Update() is rejected")
+		Expect(fresh.Status.Phase).To(Equal(aianalysisv1.PhaseInvestigating),
+			"phase must remain unchanged in the persisted object — the rejected status write never actually landed")
+
+		By("second reconcile of the same still-rejected object: annotation must advance to 2 via the real apiserver")
+		result2, err := r.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result2.RequeueAfter).To(BeNumerically(">", 0))
+
+		Expect(realWatch.Get(ctx, req.NamespacedName, &fresh)).To(Succeed())
+		Expect(fresh.Annotations[handlers.SchemaRejectionRetryCountAnnotation]).To(Equal("2"))
+
+		By("simulating exhausted retries: escalation must land a valid, real-schema-accepted terminal status")
+		fresh.Annotations[handlers.SchemaRejectionRetryCountAnnotation] = "5" // handlers.MaxSchemaRejectionRetries
+		Expect(realWatch.Update(ctx, &fresh)).To(Succeed())
+
+		wrappedOnceMore := interceptor.NewClient(realWatch, failNStatusUpdates(1))
+		r2 := newSchemaRejectionITReconciler(wrappedOnceMore)
+
+		result3, err := r2.Reconcile(ctx, req)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result3.RequeueAfter).To(BeZero(), "a terminal Failed phase needs no further requeue")
+
+		var escalated aianalysisv1.AIAnalysis
+		Expect(realWatch.Get(ctx, req.NamespacedName, &escalated)).To(Succeed())
+		Expect(escalated.Status.Phase).To(Equal(aianalysisv1.PhaseFailed),
+			"the real apiserver must accept the escalation write (valid enum values), proving handleSchemaRejectedStatusUpdate's terminal write is schema-safe")
+		Expect(escalated.Status.Reason).To(Equal(aianalysisv1.ReasonAPIError))
+		Expect(escalated.Status.SubReason).To(Equal("TransientError"))
+	})
+})
+
+func randSuffix() string {
+	return time.Now().Format("150405-000000")
+}

--- a/test/integration/aianalysis/schemarejection/suite_test.go
+++ b/test/integration/aianalysis/schemarejection/suite_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package schemarejection contains a dedicated, lightweight integration
+// suite for GitHub issue #2030 (main-tracking clone of #2029) Part A:
+// reconcileInvestigating and reconcileAnalyzing must retry (bounded, with
+// backoff) instead of fail-closing forever when a live cluster's installed
+// AIAnalysis CRD rejects a Status().Update() call with apierrors.IsInvalid
+// (e.g. CRD version skew during a rolling upgrade).
+//
+// Deliberately isolated from test/integration/aianalysis's heavy shared
+// suite (PostgreSQL, Redis, DataStorage, Mock LLM, real KA container):
+// none of that infrastructure is needed to prove this fix, and reusing the
+// existing SynchronizedBeforeSuite/manager would require intercepting a
+// client already wired into 15+ unrelated test files. This suite starts
+// its own minimal per-process envtest (AIAnalysis CRD only) and talks to
+// the real Kubernetes API server through a real client.WithWatch wrapped
+// with an interceptor — proving that handleSchemaRejectedStatusUpdate's
+// "plain Update() survives even while Status().Update() is rejected"
+// assumption holds against genuine apiserver status-subresource semantics,
+// not just the fake client's approximation of them (see UT-AA-2030-001/002/
+// 003/005 in internal/controller/aianalysis for the fake-client-based unit
+// coverage of the same logic).
+package schemarejection
+
+import (
+	"path/filepath"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+
+	aianalysisv1alpha1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
+)
+
+// Plain (non-Synchronized) BeforeSuite/AfterSuite: Ginkgo runs these once per
+// parallel PROCESS (not once globally), so each process gets its own fully
+// independent envtest instance — no cross-process coordination needed since
+// nothing here is shared external infrastructure.
+var (
+	testEnv *envtest.Environment
+	cfg     *rest.Config
+)
+
+func TestSchemaRejectionRetryIntegration(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "AIAnalysis Schema-Rejection Retry Integration Suite (#2030 Part A)")
+}
+
+var _ = BeforeSuite(func() {
+	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
+
+	Expect(aianalysisv1alpha1.AddToScheme(scheme.Scheme)).To(Succeed())
+
+	testEnv = &envtest.Environment{
+		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "..", "..", "config", "crd", "bases")},
+		ErrorIfCRDPathMissing: true,
+	}
+	// KUBEBUILDER_ASSETS is set by Makefile via setup-envtest dependency.
+	var err error
+	cfg, err = testEnv.Start()
+	Expect(err).NotTo(HaveOccurred())
+	Expect(cfg).NotTo(BeNil())
+})
+
+var _ = AfterSuite(func() {
+	if testEnv != nil {
+		Expect(testEnv.Stop()).To(Succeed())
+	}
+})

--- a/test/integration/aianalysis/session_correlation_adoption_test.go
+++ b/test/integration/aianalysis/session_correlation_adoption_test.go
@@ -85,7 +85,7 @@ var _ = Describe("BR-INTERACTIVE-010: #2030 Part B session correlation adoption"
 			createActiveIS(isName, rrName)
 
 			By("creating Investigating AA with a real interactive KA session (the 'old', now-stale session)")
-			analysis := createInvestigatingAA(aaName, rrName, "", "slow-investigation-test", true)
+			analysis := createInvestigatingAA(aaName, rrName, "slow-investigation-test", true)
 
 			By("waiting for the old KA session to be established")
 			var oldSessionID string

--- a/test/integration/aianalysis/session_correlation_adoption_test.go
+++ b/test/integration/aianalysis/session_correlation_adoption_test.go
@@ -1,0 +1,150 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package aianalysis
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	k8sretry "k8s.io/client-go/util/retry"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	aianalysisv1 "github.com/jordigilh/kubernaut/api/aianalysis/v1alpha1"
+	isv1alpha1 "github.com/jordigilh/kubernaut/api/investigationsession/v1alpha1"
+	aiaudit "github.com/jordigilh/kubernaut/pkg/aianalysis/audit"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis/handlers"
+	"github.com/jordigilh/kubernaut/pkg/shared/events"
+	"github.com/jordigilh/kubernaut/test/shared/helpers"
+)
+
+// Issue #2030 (main-tracking clone of #2029) Part B / FedRAMP SI-4: proves
+// end-to-end that AA adopts a KA session AF has correlated onto this RR's
+// InvestigationSession (e.g. after a reconnect/takeover) instead of continuing
+// to poll — and potentially finalize as expired/terminal — its own now-stale
+// session. Also proves the widened ISEventPredicate (see
+// internal/controller/aianalysis/aianalysis_controller.go) wakes the
+// reconciler promptly on a KACorrelationID-only change, rather than waiting
+// for the next scheduled poll.
+var _ = Describe("BR-INTERACTIVE-010: #2030 Part B session correlation adoption", Label("integration", "interactive"), func() {
+	const (
+		timeout  = 15 * time.Second
+		interval = 200 * time.Millisecond
+	)
+
+	Context("AA adopts a live KA session correlated onto IS after takeover (SI-4)", Serial, func() {
+		var savedHandler *handlers.InvestigatingHandler
+
+		BeforeEach(func() {
+			savedHandler = reconciler.InvestigatingHandler.Load()
+			auditClient := aiaudit.NewAuditClient(auditStore, ctrl.Log.WithName("adoption-test-audit"))
+			isChecker := handlers.NewK8sInvestigationSessionChecker(k8sClient, testNamespace)
+			reconciler.InvestigatingHandler.Store(handlers.NewInvestigatingHandler(
+				realAgentClient,
+				ctrl.Log.WithName("adoption-real-handler"),
+				testMetrics,
+				auditClient,
+				handlers.WithSessionMode(),
+				// Deliberately long poll interval: adoption must be observed well
+				// before this would ever fire, proving the widened predicate (not
+				// the poll timer) is what woke the reconciler.
+				handlers.WithSessionPollInterval(30*time.Second),
+				handlers.WithInvestigationSessionChecker(isChecker),
+				handlers.WithRecorder(k8sManager.GetEventRecorderFor("aianalysis-controller")),
+			))
+		})
+
+		AfterEach(func() {
+			if savedHandler != nil {
+				reconciler.InvestigatingHandler.Store(savedHandler)
+			}
+		})
+
+		It("IT-AA-2030-011: adopts a newly-correlated KA session instead of finalizing the stale one, waking promptly via the widened predicate", func() {
+			rrName := helpers.UniqueTestName("rr-2030-adopt")
+			isName := helpers.UniqueTestName("is-2030-adopt")
+			aaName := helpers.UniqueTestName("aa-2030-adopt")
+
+			By("creating Active IS for the RR")
+			createActiveIS(isName, rrName)
+
+			By("creating Investigating AA with a real interactive KA session (the 'old', now-stale session)")
+			analysis := createInvestigatingAA(aaName, rrName, "", "slow-investigation-test", true)
+
+			By("waiting for the old KA session to be established")
+			var oldSessionID string
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), analysis)).To(Succeed())
+				g.Expect(analysis.Status.KASession).NotTo(BeNil())
+				g.Expect(analysis.Status.KASession.ID).NotTo(BeEmpty())
+				oldSessionID = analysis.Status.KASession.ID
+			}, timeout, interval).Should(Succeed())
+
+			By("minting a second, real KA session directly (simulates the session AF creates on takeover)")
+			builder := handlers.NewRequestBuilder(ctrl.Log.WithName("adoption-test-builder"))
+			req := builder.BuildIncidentRequest(analysis)
+			newSessionID, err := realAgentClient.SubmitInvestigation(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(newSessionID).NotTo(BeEmpty())
+			Expect(newSessionID).NotTo(Equal(oldSessionID))
+
+			By("correlating the new session onto the IS CRD (simulating AF's UpdateISCorrelation after takeover)")
+			Expect(k8sretry.RetryOnConflict(k8sretry.DefaultRetry, func() error {
+				var is isv1alpha1.InvestigationSession
+				if err := k8sClient.Get(ctx, client.ObjectKey{Name: isName, Namespace: testNamespace}, &is); err != nil {
+					return err
+				}
+				is.Status.KACorrelationID = newSessionID
+				return k8sClient.Status().Update(ctx, &is)
+			})).To(Succeed())
+
+			// #2030 Part B / SI-4 predicate-wake-up proof: the handler's poll
+			// interval is 30s (see BeforeEach), so observing the session-ID
+			// switch within this 5s window is only possible if the widened
+			// ISEventPredicate woke the reconciler on the KACorrelationID
+			// change — the poll timer alone could not have fired yet.
+			By("verifying AA adopts the new session within 5s — well before the 30s poll interval — proving predicate-driven wake-up")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, client.ObjectKeyFromObject(analysis), analysis)).To(Succeed())
+				g.Expect(analysis.Status.KASession).NotTo(BeNil())
+				g.Expect(analysis.Status.KASession.ID).To(Equal(newSessionID),
+					"#2030 Part B / SI-4: AA must promptly adopt the correlated session instead of continuing to track the stale one")
+			}, 5*time.Second, 200*time.Millisecond).Should(Succeed())
+
+			By("verifying AA was never finalized as terminal for the abandoned old session")
+			Expect(analysis.Status.Phase).NotTo(Equal(aianalysisv1.PhaseFailed),
+				"the stale session must never be finalized (e.g. as expired) once adoption occurred")
+
+			By("verifying the SessionAdopted K8s event was recorded (FedRAMP SI-4 observability)")
+			Eventually(func(g Gomega) {
+				var evtList corev1.EventList
+				g.Expect(k8sClient.List(ctx, &evtList, client.InNamespace(testNamespace))).To(Succeed())
+				found := false
+				for i := range evtList.Items {
+					e := &evtList.Items[i]
+					if e.InvolvedObject.Name == aaName && e.Reason == events.EventReasonSessionAdopted {
+						found = true
+						break
+					}
+				}
+				g.Expect(found).To(BeTrue(), "adoptCorrelatedSession must emit a SessionAdopted event")
+			}, timeout, interval).Should(Succeed())
+		})
+	})
+})

--- a/test/integration/apifrontend/create_rr_wiring_test.go
+++ b/test/integration/apifrontend/create_rr_wiring_test.go
@@ -34,17 +34,27 @@ func (n *noopPromClientIT) InstantQuery(_ context.Context, _ string) (*prom.Quer
 	return &prom.QueryResult{}, nil
 }
 
-// alwaysFiringPromClientIT returns a single cluster-scoped firing alert (no
-// namespace/kind/name labels), so it label-matches any target resource. See
-// the tools_test package's alwaysFiringPromClient for the full rationale.
+// alwaysFiringPromClientIT returns a single firing alert scoped to the given
+// target (namespace/kind/name labels), carrying a fixed alertname
+// ("TestDefaultAlert") for IT tests that don't care about the specific
+// severity value but need HandleCreateRR/HandleRemediate to succeed. See the
+// tools_test package's alwaysFiringPromClient for the full rationale.
 //
-// #1839/DD-AF-010: a nil Triager now fails closed. IT tests that don't care
-// about the specific severity value but need HandleCreateRR to succeed use
-// this fixture via defaultTestTriagerIT().
-type alwaysFiringPromClientIT struct{}
+// #1839/DD-AF-010: a nil Triager now fails closed.
+// DD-AF-012/#2028 (main clone of #2027): the alert must be resource-scoped
+// (not cluster-scoped) to unambiguously correlate to the target -- a
+// cluster-scoped alert now correctly resolves as Ambiguous for any
+// namespaced target, which would make HandleCreateRR/HandleRemediate return
+// early without creating an RR.
+type alwaysFiringPromClientIT struct {
+	namespace, kind, name string
+}
 
 func (a *alwaysFiringPromClientIT) GetAlerts(_ context.Context) ([]prom.Alert, error) {
-	return []prom.Alert{{State: "firing", Labels: map[string]string{"alertname": "TestDefaultAlert", "severity": "warning"}}}, nil
+	return []prom.Alert{{State: "firing", Labels: map[string]string{
+		"alertname": "TestDefaultAlert", "severity": "warning",
+		"namespace": a.namespace, "kind": a.kind, "name": a.name,
+	}}}, nil
 }
 func (a *alwaysFiringPromClientIT) GetRules(_ context.Context) ([]prom.RuleGroup, error) {
 	return nil, nil
@@ -53,8 +63,8 @@ func (a *alwaysFiringPromClientIT) InstantQuery(_ context.Context, _ string) (*p
 	return &prom.QueryResult{}, nil
 }
 
-func defaultTestTriagerIT() *severity.Triager {
-	return severity.NewTriager(&alwaysFiringPromClientIT{}, severity.NewNoopLLMTriager(logr.Discard()), severity.DefaultConfig(), logr.Discard())
+func defaultTestTriagerIT(namespace, kind, name string) *severity.Triager {
+	return severity.NewTriager(&alwaysFiringPromClientIT{namespace: namespace, kind: kind, name: name}, severity.NewNoopLLMTriager(logr.Discard()), severity.DefaultConfig(), logr.Discard())
 }
 
 // unnamedAlertTestTriagerIT resolves a severity from a resource-matching
@@ -90,7 +100,7 @@ var _ = Describe("kubernaut_remediate wiring (#1282, #1332)", func() {
 			_ = k8sClient.Delete(ctx, nsObj)
 		})
 
-		result, err := tools.HandleCreateRR(ctx, &tools.ToolDeps{Client: k8sClient, DynClient: dynamicClient, ControllerNS: ns, Triager: defaultTestTriagerIT()}, &tools.CreateRRArgs{
+		result, err := tools.HandleCreateRR(ctx, &tools.ToolDeps{Client: k8sClient, DynClient: dynamicClient, ControllerNS: ns, Triager: defaultTestTriagerIT(ns, "Deployment", "web-w01")}, &tools.CreateRRArgs{
 			Namespace:   ns,
 			Kind:        "Deployment",
 			Name:        "web-w01",
@@ -117,7 +127,7 @@ var _ = Describe("kubernaut_remediate wiring (#1282, #1332)", func() {
 	It("IT-AF-1282-W02: created RR has signalSource=a2a-agent in envtest", func() {
 		ctx := context.Background()
 
-		result, err := tools.HandleCreateRR(ctx, &tools.ToolDeps{Client: k8sClient, DynClient: dynamicClient, ControllerNS: defaultFixture, Triager: defaultTestTriagerIT()}, &tools.CreateRRArgs{
+		result, err := tools.HandleCreateRR(ctx, &tools.ToolDeps{Client: k8sClient, DynClient: dynamicClient, ControllerNS: defaultFixture, Triager: defaultTestTriagerIT(defaultFixture, "Deployment", "web-w02")}, &tools.CreateRRArgs{
 			Namespace:   defaultFixture,
 			Kind:        "Deployment",
 			Name:        "web-w02",
@@ -280,7 +290,7 @@ var _ = Describe("kubernaut_remediate wiring (#1282, #1332)", func() {
 			_ = k8sClient.Delete(ctx, workloadNSObj)
 		})
 
-		result, err := tools.HandleCreateRR(ctx, &tools.ToolDeps{Client: k8sClient, DynClient: dynamicClient, ControllerNS: controllerNS, Triager: defaultTestTriagerIT()}, &tools.CreateRRArgs{
+		result, err := tools.HandleCreateRR(ctx, &tools.ToolDeps{Client: k8sClient, DynClient: dynamicClient, ControllerNS: controllerNS, Triager: defaultTestTriagerIT(workloadNS, "Deployment", "web-1292-w01")}, &tools.CreateRRArgs{
 			Namespace:   workloadNS,
 			Kind:        "Deployment",
 			Name:        "web-1292-w01",
@@ -335,11 +345,12 @@ var _ = Describe("kubernaut_remediate wiring (#1282, #1332)", func() {
 
 	It("IT-FLEET-004: HandleCreateRR with ClusterID produces RR with cluster fields in envtest (BR-INTEGRATION-065)", func() {
 		ctx := context.Background()
+		resourceName := "web-fleet-004-" + uuid.New().String()[:6]
 
-		result, err := tools.HandleCreateRR(ctx, &tools.ToolDeps{Client: k8sClient, DynClient: dynamicClient, ControllerNS: defaultFixture, Triager: defaultTestTriagerIT()}, &tools.CreateRRArgs{
+		result, err := tools.HandleCreateRR(ctx, &tools.ToolDeps{Client: k8sClient, DynClient: dynamicClient, ControllerNS: defaultFixture, Triager: defaultTestTriagerIT(defaultFixture, "Deployment", resourceName)}, &tools.CreateRRArgs{
 			Namespace:   defaultFixture,
 			Kind:        "Deployment",
-			Name:        "web-fleet-004-" + uuid.New().String()[:6],
+			Name:        resourceName,
 			Description: "fleet cluster wiring IT",
 			ClusterID:   "prod-east-1",
 		}, "fleet-user")
@@ -365,7 +376,7 @@ var _ = Describe("kubernaut_remediate wiring (#1282, #1332)", func() {
 		ctx := context.Background()
 		baseName := "web-fleet-005-" + uuid.New().String()[:6]
 
-		result1, err := tools.HandleCreateRR(ctx, &tools.ToolDeps{Client: k8sClient, DynClient: dynamicClient, ControllerNS: defaultFixture, Triager: defaultTestTriagerIT()}, &tools.CreateRRArgs{
+		result1, err := tools.HandleCreateRR(ctx, &tools.ToolDeps{Client: k8sClient, DynClient: dynamicClient, ControllerNS: defaultFixture, Triager: defaultTestTriagerIT(defaultFixture, "Deployment", baseName)}, &tools.CreateRRArgs{
 			Namespace:   defaultFixture,
 			Kind:        "Deployment",
 			Name:        baseName,
@@ -375,7 +386,7 @@ var _ = Describe("kubernaut_remediate wiring (#1282, #1332)", func() {
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result1.AlreadyExists).To(BeFalse())
 
-		result2, err := tools.HandleCreateRR(ctx, &tools.ToolDeps{Client: k8sClient, DynClient: dynamicClient, ControllerNS: defaultFixture, Triager: defaultTestTriagerIT()}, &tools.CreateRRArgs{
+		result2, err := tools.HandleCreateRR(ctx, &tools.ToolDeps{Client: k8sClient, DynClient: dynamicClient, ControllerNS: defaultFixture, Triager: defaultTestTriagerIT(defaultFixture, "Deployment", baseName)}, &tools.CreateRRArgs{
 			Namespace:   defaultFixture,
 			Kind:        "Deployment",
 			Name:        baseName,
@@ -398,7 +409,7 @@ var _ = Describe("kubernaut_remediate wiring (#1282, #1332)", func() {
 		ctx := context.Background()
 		auditRecorder.Reset()
 
-		result, err := tools.HandleCreateRR(ctx, &tools.ToolDeps{Client: k8sClient, DynClient: dynamicClient, ControllerNS: defaultFixture, Auditor: auditRecorder, Triager: defaultTestTriagerIT()}, &tools.CreateRRArgs{
+		result, err := tools.HandleCreateRR(ctx, &tools.ToolDeps{Client: k8sClient, DynClient: dynamicClient, ControllerNS: defaultFixture, Auditor: auditRecorder, Triager: defaultTestTriagerIT(defaultFixture, "Deployment", "web-w06")}, &tools.CreateRRArgs{
 			Namespace:   defaultFixture,
 			Kind:        "Deployment",
 			Name:        "web-w06",

--- a/test/integration/apifrontend/create_rr_wiring_test.go
+++ b/test/integration/apifrontend/create_rr_wiring_test.go
@@ -63,6 +63,11 @@ func (a *alwaysFiringPromClientIT) InstantQuery(_ context.Context, _ string) (*p
 	return &prom.QueryResult{}, nil
 }
 
+// nolint:unparam // kind always receives "Deployment" today, but call sites
+// span create_rr_wiring_test.go and remediate_wiring_test.go -- dropping the
+// param would require touching every caller in lockstep across both files
+// for a value that may legitimately vary as fixtures grow (mirrors
+// unnamedAlertTestTriagerIT's identical (namespace, kind, name) shape above).
 func defaultTestTriagerIT(namespace, kind, name string) *severity.Triager {
 	return severity.NewTriager(&alwaysFiringPromClientIT{namespace: namespace, kind: kind, name: name}, severity.NewNoopLLMTriager(logr.Discard()), severity.DefaultConfig(), logr.Discard())
 }

--- a/test/integration/apifrontend/remediate_wiring_test.go
+++ b/test/integration/apifrontend/remediate_wiring_test.go
@@ -24,7 +24,7 @@ var _ = Describe("kubernaut_remediate wiring (#1332)", func() {
 		ctx := context.Background()
 		ns := defaultFixture
 
-		result, err := tools.HandleRemediate(ctx, &tools.ToolDeps{Client: k8sClient, DynClient: dynamicClient, ControllerNS: ns, Triager: defaultTestTriagerIT()}, &tools.RemediateArgs{
+		result, err := tools.HandleRemediate(ctx, &tools.ToolDeps{Client: k8sClient, DynClient: dynamicClient, ControllerNS: ns, Triager: defaultTestTriagerIT(ns, "Deployment", "web-1332-w01")}, &tools.RemediateArgs{
 			Namespace:   ns,
 			Kind:        "Deployment",
 			Name:        "web-1332-w01",
@@ -48,7 +48,7 @@ var _ = Describe("kubernaut_remediate wiring (#1332)", func() {
 		ctx := context.Background()
 		ns := defaultFixture
 
-		result, err := tools.HandleRemediate(ctx, &tools.ToolDeps{Client: k8sClient, DynClient: dynamicClient, ControllerNS: ns, Triager: defaultTestTriagerIT()}, &tools.RemediateArgs{
+		result, err := tools.HandleRemediate(ctx, &tools.ToolDeps{Client: k8sClient, DynClient: dynamicClient, ControllerNS: ns, Triager: defaultTestTriagerIT(ns, "Deployment", "web-1332-w02")}, &tools.RemediateArgs{
 			Namespace:   ns,
 			Kind:        "Deployment",
 			Name:        "web-1332-w02",
@@ -148,7 +148,7 @@ var _ = Describe("kubernaut_remediate wiring (#1332)", func() {
 		ns := defaultFixture
 		auditRecorder.Reset()
 
-		result, err := tools.HandleRemediate(ctx, &tools.ToolDeps{Client: k8sClient, DynClient: dynamicClient, ControllerNS: ns, Auditor: auditRecorder, Triager: defaultTestTriagerIT()}, &tools.RemediateArgs{
+		result, err := tools.HandleRemediate(ctx, &tools.ToolDeps{Client: k8sClient, DynClient: dynamicClient, ControllerNS: ns, Auditor: auditRecorder, Triager: defaultTestTriagerIT(ns, "Deployment", "web-1332-w06")}, &tools.RemediateArgs{
 			Namespace:   ns,
 			Kind:        "Deployment",
 			Name:        "web-1332-w06",


### PR DESCRIPTION
## Summary

Single-PR port of four `release/v1.5` fixes (originally bundled in PR #2026) onto `main`, adapted for `main`'s Fleet-aware `ScopeChecker` and `ToolDeps` architecture. Tracked as this branch's own main-tracking clone issues:

- **#2025** (clone of #2022) — AF tool-layer scope validation: `HandleCreateRR` now rejects out-of-scope targets via `ToolDeps.ScopeChecker` before any RR/session is created (ADR-053 Addendum "Point 3"), instead of only being caught downstream by RO after the waste. Wired through `fleet.NewScopeChecker`, so it's Fleet/multi-cluster-aware for free.
- **#2047** (clone of #2023) — Content-grounding guard: `enforceGroundingGuard` extends the existing phase-guard callbacks so `kubernaut_present_decision` can never render a fabricated RCA narrative when no real investigation content exists.
- **#2028** (clone of #2027, [DD-AF-012](docs/architecture/decisions/DD-AF-012-confidence-gated-severity-correlation.md)) — Confidence-gated severity correlation: a cluster-scoped-only alert correlation is now surfaced as a typed `Ambiguous` result requiring user confirmation, instead of being silently trusted as fact (root-caused against live Prometheus data — a 45s margin was insufficient, ~165s was).
- **#2030** (clone of #2029) — AA reconnect/takeover session desync, split into:
  - **Part A**: bounded retry-with-backoff on CRD schema-rejected status updates, replacing a permanent fail-close.
  - **Part B**: AA adopts a KA session AF has correlated onto an RR's `InvestigationSession` after a reconnect/takeover, instead of continuing to poll a stale one; the watch predicate is widened to wake the controller promptly on a correlation-only change.
  - Plus the foundational fix these build on: `StartInvestigationResult.InvestigationSessionID` now captures KA's pollable analysis-session ID separately from the MCP driver-lease `SessionID`, fixing the root cause of the 404-loop.

## Wiring/CHECKPOINT W finding fixed during this port

An earlier draft carried over `release/v1.5`'s `ContextWithScopeChecker`/`ScopeCheckerFromContext` context-injection helpers for the scope checker. On `main`, all three RR-creating tools already thread `ScopeChecker` via plain struct fields (`ToolDeps`/`*Config`), so those two functions had zero production callers — removed as orphaned dead code (along with their now-pointless unit test) before this PR, per the Pyramid Invariant.

## Test plan

- `go build ./...`, `go vet ./...`, `golangci-lint run` — all clean.
- Full `pkg/apifrontend/...`, `pkg/aianalysis/...`, `internal/controller/aianalysis/...`, `cmd/apifrontend/...` unit suites — green.
- `test/integration/aianalysis/schemarejection/...` (Part A, real envtest apiserver, isolated lightweight suite) — verified locally, green.
- `test/integration/aianalysis/session_correlation_adoption_test.go` (Part B, IT-AA-2030-011) lives in the heavy shared `test/integration/aianalysis` suite (Postgres/Redis/DataStorage/KA container) — not run locally; relying on CI for this one, which this PR's own pipeline will exercise.
- Full test-scenario inventory, Wiring Manifest, and FedRAMP control mapping (AC-6, SI-4, SI-10, SI-11, AU-2/AU-3/AU-12, CM-3) for all four issues: [`docs/testing/2025/TEST_PLAN.md`](docs/testing/2025/TEST_PLAN.md).

## Authoritative docs ported/added

- [`docs/architecture/decisions/ADR-053-resource-scope-management.md`](docs/architecture/decisions/ADR-053-resource-scope-management.md) — Point 3 addendum, adapted for `main`.
- [`docs/architecture/decisions/DD-AF-012-confidence-gated-severity-correlation.md`](docs/architecture/decisions/DD-AF-012-confidence-gated-severity-correlation.md) — new on `main`.
- [`docs/testing/2025/TEST_PLAN.md`](docs/testing/2025/TEST_PLAN.md) — new, `main`-specific.

Made with [Cursor](https://cursor.com)