### PR TITLE
fix(e2e/apifrontend): give E2E-AF-1396-001 its own grounding fixture

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -662,7 +662,14 @@ jobs:
             timeout: 30
           - service: apifrontend
             service_name: "API Frontend"
-            timeout: 25
+            # #2060: was 25 (last bumped 2026-06-04); the suite now
+            # routinely runs right at/past 25min and gets cancelled by the
+            # job timeout before Ginkgo can report a result (confirmed on
+            # two separate runs, both cut off within seconds of the
+            # 25-minute mark). 35 gives ~40% headroom, matching the buffer
+            # already given to kubernautagent (30min) for a comparably
+            # long-running suite.
+            timeout: 35
           - service: fullpipeline
             service_name: "Full Pipeline"
             timeout: 20

--- a/deploy/apifrontend/overlays/e2e/mock-llm.yaml
+++ b/deploy/apifrontend/overlays/e2e/mock-llm.yaml
@@ -223,6 +223,35 @@ data:
             name: "structured-decision-target-2"
             kind: "Pod"
 
+      - name: "af_structured_decision_ground_3"
+        # #2057: dedicated grounding call for E2E-AF-1396-001 alone.
+        # af_structured_decision_ground above was WRONGLY assumed safe to
+        # share between E2E-AF-1395-001 and E2E-AF-1396-001 ("fine for
+        # #1395-001 and #1396-001" per the comment on
+        # StructuredDecisionGrounding2/apifrontend_prometheus_e2e.go) --
+        # but those two Its hit the exact same
+        # checkExistingRRByFingerprint-dedup-onto-still-open-session
+        # contention that af_structured_decision_ground_2 was created to
+        # fix for E2E-AF-1396-002: E2E-AF-1396-001's own groundSession call
+        # dedups onto E2E-AF-1395-001's still-open RR/session, KA returns
+        # session_active, and present_decision's grounding guard fails
+        # closed to the empty RCA payload (severity:"", CI run 31341614213,
+        # "AU-3: severity must flow from mock-LLM through AF to SSE"). See
+        # StructuredDecisionGrounding3 (apifrontend_prometheus_e2e.go).
+        #
+        # Keyword deliberately shares no substring with any other keyword in
+        # this file (see af_structured_decision_ground_2's comment above for
+        # why that matters).
+        keywords: ["seed alt fixture context 1396 001"]
+        match_last_only: true
+        tool_call:
+          name: "kubernaut_investigate"
+          arguments:
+            api_version: "v1"
+            namespace: "af-structured-decision-e2e"
+            name: "structured-decision-target-3"
+            kind: "Pod"
+
       - name: "af_structured_decision"
         keywords: ["structured decision", "present structured rca decision"]
         match_last_only: true

--- a/test/e2e/apifrontend/structured_decision_e2e_test.go
+++ b/test/e2e/apifrontend/structured_decision_e2e_test.go
@@ -155,9 +155,47 @@ var _ = Describe("Structured Decision Payload E2E — #1395 #1396", Ordered, Lab
 	// grounded result -- silently starving present_decision of grounding
 	// and emitting no SSE decision event at all (CI run 31320575553,
 	// this test, "not to be empty").
+	//
+	// Used by E2E-AF-1395-001 ALONE. It used to also be shared with
+	// E2E-AF-1396-001 below, on the (wrong -- see groundSessionAlt2, #2057)
+	// assumption that two sequential Its in the same Ordered block never
+	// contend for this fixture the way concurrently-running Describe blocks
+	// do.
 	groundSession := func(ctx context.Context, contextID string) {
 		resp, err := a2aSSEPost(ctx, a2aMessageStreamWithContext(contextID+"-ground", contextID,
 			"seed grounding context for pod structured-decision-target in af-structured-decision-e2e"))
+		Expect(err).NotTo(HaveOccurred(), "grounding kubernaut_investigate call must succeed")
+		defer func() { _ = resp.Body.Close() }()
+		_, _ = scanDecisionEvent(resp) // drain to EOF; no decision event expected here
+	}
+
+	// groundSessionAlt2 is groundSession's twin for E2E-AF-1396-001 alone,
+	// targeting a THIRD dedicated fixture (structured-decision-target-3,
+	// StructuredDecisionGrounding3 in apifrontend_prometheus_e2e.go / the
+	// "seed alt fixture context 1396 001" mock-LLM keyword). #2057: this
+	// Describe block is Ordered and its 3 Its run sequentially;
+	// E2E-AF-1395-001 and E2E-AF-1396-001 used to both call groundSession
+	// against the SAME structured-decision-target fixture on the assumption
+	// that sequential-in-block execution made that safe ("fine for
+	// #1395-001 and #1396-001" -- the comment on groundSessionAlt below,
+	// written when only the 2nd-vs-3rd-It contention had been diagnosed).
+	// That assumption was wrong: af_create_rr.go's
+	// checkExistingRRByFingerprint dedups by target regardless of which It
+	// calls it, so E2E-AF-1396-001's groundSession call dedups onto
+	// E2E-AF-1395-001's still-open RR/session (that session isn't torn down
+	// just because the Ordered container moved on to the next It) and
+	// nondeterministically observes "session_active" instead of a clean
+	// grounded result -- which per investigateHasGroundedContent
+	// (phase_guard.go, UT-AF-2023-004) deterministically fails
+	// present_decision's grounding guard closed, substituting the empty RCA
+	// payload (severity:"") for the mock-LLM's scripted "critical" (CI run
+	// 31341614213, "AU-3: severity must flow from mock-LLM through AF to
+	// SSE"). A fixture E2E-AF-1396-001 alone uses eliminates the contention
+	// outright, matching the fix already applied below for
+	// E2E-AF-1396-002's identical exposure to both of its predecessors.
+	groundSessionAlt2 := func(ctx context.Context, contextID string) {
+		resp, err := a2aSSEPost(ctx, a2aMessageStreamWithContext(contextID+"-ground", contextID,
+			"seed alt fixture context 1396 001 for pod structured-decision-target-3 in af-structured-decision-e2e"))
 		Expect(err).NotTo(HaveOccurred(), "grounding kubernaut_investigate call must succeed")
 		defer func() { _ = resp.Body.Close() }()
 		_, _ = scanDecisionEvent(resp) // drain to EOF; no decision event expected here
@@ -168,17 +206,19 @@ var _ = Describe("Structured Decision Payload E2E — #1395 #1396", Ordered, Lab
 	// StructuredDecisionGrounding2 in apifrontend_prometheus_e2e.go / the
 	// "seed alt fixture context 1396 002" mock-LLM keyword). This Describe
 	// block is Ordered and its 3 Its run sequentially; #1395-001 and
-	// #1396-001 above both call groundSession against the SAME
-	// structured-decision-target fixture, and af_create_rr.go's
-	// checkExistingRRByFingerprint dedups by target, so by this 3rd call
-	// the RR already has a KA interactive session opened by one of the
-	// prior two Its. That nondeterministically surfaces as "session_active"
-	// instead of a clean grounded result, which per
-	// investigateHasGroundedContent (phase_guard.go, UT-AF-2023-004)
-	// deterministically fails present_decision's grounding guard closed --
-	// clearing options to [] (CI run 31335085795, "AC-6: ALL options must
-	// be presented"). A fixture this test alone uses eliminates the
-	// contention outright rather than relying on lease timing.
+	// #1396-001 above used to both call groundSession against the SAME
+	// structured-decision-target fixture -- WRONGLY assumed "fine" at the
+	// time this helper was written (corrected by groundSessionAlt2 above,
+	// #2057) -- and af_create_rr.go's checkExistingRRByFingerprint dedups
+	// by target, so by this 3rd call the RR already has a KA interactive
+	// session opened by one of the prior two Its. That nondeterministically
+	// surfaces as "session_active" instead of a clean grounded result,
+	// which per investigateHasGroundedContent (phase_guard.go,
+	// UT-AF-2023-004) deterministically fails present_decision's grounding
+	// guard closed -- clearing options to [] (CI run 31335085795, "AC-6:
+	// ALL options must be presented"). A fixture this test alone uses
+	// eliminates the contention outright rather than relying on lease
+	// timing.
 	groundSessionAlt := func(ctx context.Context, contextID string) {
 		resp, err := a2aSSEPost(ctx, a2aMessageStreamWithContext(contextID+"-ground", contextID,
 			"seed alt fixture context 1396 002 for pod structured-decision-target-2 in af-structured-decision-e2e"))
@@ -221,7 +261,7 @@ var _ = Describe("Structured Decision Payload E2E — #1395 #1396", Ordered, Lab
 		defer cancel()
 
 		const ctxID = "ctx-e2e-structured-002"
-		groundSession(readCtx, ctxID)
+		groundSessionAlt2(readCtx, ctxID)
 
 		resp, err := a2aSSEPost(readCtx, a2aMessageStreamWithContext("e2e-structured-002-decision", ctxID, "present structured rca decision"))
 		Expect(err).NotTo(HaveOccurred())

--- a/test/infrastructure/apifrontend_prometheus_e2e.go
+++ b/test/infrastructure/apifrontend_prometheus_e2e.go
@@ -243,18 +243,34 @@ func AFInjectOTLPMetrics(ctx context.Context, prometheusURL, metricName string, 
 //     name="structured-decision-target-2"), dedicated to
 //     structured_decision_e2e_test.go's E2E-AF-1396-002 alone. That
 //     Describe block is Ordered, and all three of its Its previously shared
-//     ONE grounding fixture -- fine for #1395-001 and #1396-001, but by the
-//     third call af_create_rr.go's checkExistingRRByFingerprint dedups to
-//     the SAME RR the first two tests already opened a KA interactive
-//     session against, so E2E-AF-1396-002's own groundSession call
-//     nondeterministically observes "session_active" instead of a clean
-//     result -- which per investigateHasGroundedContent (phase_guard.go)
-//     and its own UT-AF-2023-004 deterministically fails present_decision's
-//     grounding guard closed, clearing options to [] (CI run 31335085795,
-//     "AC-6: ALL options must be presented"). A second dedicated target
-//     gives this one test its own RR so it never contends with #1395-001/
-//     #1396-001's still-open sessions, matching the fix already applied
-//     once above for cross-Describe-block contention.
+//     ONE grounding fixture -- WRONGLY assumed "fine for #1395-001 and
+//     #1396-001" (see StructuredDecisionGrounding3 below, #2057, for the
+//     correction), but by the third call af_create_rr.go's
+//     checkExistingRRByFingerprint dedups to the SAME RR the first two
+//     tests already opened a KA interactive session against, so
+//     E2E-AF-1396-002's own groundSession call nondeterministically
+//     observes "session_active" instead of a clean result -- which per
+//     investigateHasGroundedContent (phase_guard.go) and its own
+//     UT-AF-2023-004 deterministically fails present_decision's grounding
+//     guard closed, clearing options to [] (CI run 31335085795, "AC-6: ALL
+//     options must be presented"). A second dedicated target gives this
+//     one test its own RR so it never contends with #1395-001/#1396-001's
+//     still-open sessions, matching the fix already applied once above for
+//     cross-Describe-block contention.
+//   - StructuredDecisionGrounding3: same shape again (namespace=
+//     "af-structured-decision-e2e", kind=Pod,
+//     name="structured-decision-target-3"), dedicated to
+//     structured_decision_e2e_test.go's E2E-AF-1396-001 alone (#2057). The
+//     "fine for #1395-001 and #1396-001" assumption above turned out to be
+//     wrong: those two tests share the SAME fixture as each other, so
+//     E2E-AF-1396-001's own groundSession call hits the exact same
+//     contention StructuredDecisionGrounding2 was created to fix for
+//     E2E-AF-1396-002 -- checkExistingRRByFingerprint dedups onto
+//     E2E-AF-1395-001's still-open RR/session, KA returns "session_active",
+//     and present_decision's grounding guard fails closed to the empty RCA
+//     payload (severity:"", CI run 31341614213, "AU-3: severity must flow
+//     from mock-LLM through AF to SSE"). A third dedicated target
+//     fully isolates all 3 Its in the block from one another.
 //
 // #1839 follow-up (no fixtures in "default"): HighCPU and HighMemory used to
 // target namespace="default" (unlike DiskPressure/NetworkLatency, which
@@ -389,4 +405,15 @@ groups:
           name: structured-decision-target-2
         annotations:
           summary: "Synthetic grounding alert for structured_decision_e2e_test.go's E2E-AF-1396-002 (dedicated target, avoids intra-suite session_active contention with #1395-001/#1396-001)"
+      - alert: StructuredDecisionGrounding3
+        expr: vector(1) > 0
+        for: 0s
+        labels:
+          severity: warning
+          source: prometheus
+          namespace: af-structured-decision-e2e
+          kind: Pod
+          name: structured-decision-target-3
+        annotations:
+          summary: "Synthetic grounding alert for structured_decision_e2e_test.go's E2E-AF-1396-001 (dedicated target, #2057: avoids intra-suite session_active contention with #1395-001)"
 `


### PR DESCRIPTION
## Summary

Fixes #2057. Also fixes #2060 (piled in per project convention: each PR
against this active branch consumes ~30min+ of shared CI resources, so
CI-only fixes discovered while validating this PR are folded in here
rather than opened as separate PRs).

### #2057: E2E-AF-1396-001 grounding contention

`structured_decision_e2e_test.go`'s `Ordered` Describe block
("Structured Decision Payload E2E — #1395 #1396") has 3 sequential `It`s.
`E2E-AF-1395-001` and `E2E-AF-1396-001` shared one synthetic grounding
fixture (`namespace=af-structured-decision-e2e, kind=Pod,
name=structured-decision-target`), and `E2E-AF-1396-001` intermittently
failed on the `release/v1.5` merge commit for #2026:

```
[FAILED] AU-3: severity must flow from mock-LLM through AF to SSE
Expected <string>: <empty>
to equal <string>: critical
```

CI: https://github.com/jordigilh/kubernaut/actions/runs/31341614213/job/93340103744

#### Root cause (test-only — confirmed via must-gather, not a production bug)

From the AF pod log in that run's must-gather artifact:

1. `E2E-AF-1395-001`'s `groundSession()` call creates RR
   `rr-daedd45b27f2-f5b74dc7` for `structured-decision-target` and opens a
   pooled KA interactive session.
2. `E2E-AF-1396-001`'s own `groundSession()` call targets the **same**
   fixture. `af_create_rr.go`'s `checkExistingRRByFingerprint` correctly
   dedups onto that still-open, non-terminal RR — the log shows the
   **same** `rr_id` for both tests.
3. KA's single-driver session enforcement correctly rejects the second
   concurrent investigation attempt: `"session_active from KA: returning
   structured result instead of error"`.
4. AF's grounding-guard (#2023) correctly fails closed:
   `"grounding-guard overriding present_decision content: no groundable
   investigation content available"` — substituting the empty
   `emptyRCAPayload` (`severity: ""`) for the mock-LLM's scripted
   `"critical"`.

All four behaviors are correct and intentional; the defect is purely that
two independent `It`s share one synthetic grounding target that only one
investigation session can occupy at a time. This is the exact same
contention class already diagnosed and fixed once in this file for
`E2E-AF-1396-002` (which got `structured-decision-target-2` after hitting
this identical failure mode in CI run 31335085795) — that fix's own
comment wrongly asserted sharing the original fixture was "fine for
#1395-001 and #1396-001"; this run refutes that assumption.

#### Fix

Give `E2E-AF-1396-001` its own dedicated grounding fixture too, mirroring
the already-proven pattern used for `E2E-AF-1396-002`:
- New `structured-decision-target-3` fixture + `StructuredDecisionGrounding3`
  Prometheus rule (`test/infrastructure/apifrontend_prometheus_e2e.go`)
- New `af_structured_decision_ground_3` mock-LLM scenario with a
  collision-free keyword `"seed alt fixture context 1396 001"`
  (`deploy/apifrontend/overlays/e2e/mock-llm.yaml`)
- New `groundSessionAlt2` test helper, wired into `E2E-AF-1396-001`
  (`test/e2e/apifrontend/structured_decision_e2e_test.go`)

All 3 `It`s in the Describe block are now fully isolated from each other.

`release/v1.5`-only: the grounding-guard machinery (#2023) this test
exercises does not exist on `main` (its copy of
`structured_decision_e2e_test.go` has no `groundSession` at all).

### #2060: E2E (apifrontend) job timeout too tight

Validating #2057's fix hit a second, unrelated, pre-existing problem: the
`E2E (apifrontend)` job got cancelled by its 25-minute job timeout before
Ginkgo could report a result — on **both** the original failing run
(25.30min) and this PR's own first CI attempt (25.02min), each cut off
within seconds of the configured limit. `test/e2e/apifrontend/` has grown
to 29 files since that timeout was last sized (2026-06-04); each blocking
`kubernaut_investigate` round trip alone costs ~25s per the must-gather
evidence. Bumped `timeout: 25` → `35` in `ci-pipeline.yml`'s E2E matrix,
matching the headroom already given to `kubernautagent` (30min) for a
comparably long-running suite.

## Test plan

- [x] `go build ./test/...` — passes
- [x] `go vet ./test/e2e/apifrontend/... ./test/infrastructure/...` — clean
- [x] `gofmt -l` on modified files — clean
- [x] `mock-llm.yaml` parses as valid multi-doc YAML
- [x] `actionlint` on `ci-pipeline.yml` — no new findings
- [ ] CI: `E2E (apifrontend)` job on this PR completes within its new
      35min budget with `E2E-AF-1396-001` passing consistently now that it
      has its own fixture