### PR TITLE
fix(apifrontend): mark severity-triage fallback RCA Provisional so #2023's grounding guard never caches it

### DIFF
--- a/internal/kubernautagent/session/complete_event_rca_1794_test.go
+++ b/internal/kubernautagent/session/complete_event_rca_1794_test.go
@@ -53,11 +53,22 @@ var _ = Describe("Live complete event carries RCA data — #1794", func() {
 
 	Describe("UT-KA-1794-001: live complete event Data is populated from a non-nil result", func() {
 		It("should attach the bounded RCA subset to the live EventTypeComplete event", func() {
+			// ready/proceed gate (same idiom as manager_upgrade_test.go's
+			// UT-KA-1390-008/026/027): without it, this instant, no-I/O closure
+			// can race Store.Update(StatusCompleted) ahead of the Subscribe call
+			// below, which — with no eventChan attached yet — makes Subscribe
+			// return ErrSessionTerminal (manager_query.go) instead of the live
+			// channel this test means to exercise. Observed as a real,
+			// non-hypothetical flake in CI (run 30727355643, job 91441733492).
+			ready := make(chan struct{})
+			proceed := make(chan struct{})
 			investigationDone := make(chan struct{})
 
 			pendingID, err := mgr.StartInteractiveSession(context.Background(),
 				func(_ context.Context) (*katypes.InvestigationResult, error) {
 					defer close(investigationDone)
+					close(ready)
+					<-proceed
 					return &katypes.InvestigationResult{
 						Severity:   "critical",
 						Confidence: 0.92,
@@ -70,9 +81,11 @@ var _ = Describe("Live complete event carries RCA data — #1794", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(mgr.LaunchDeferredInvestigation(pendingID)).To(Succeed())
+			<-ready
 
 			eventCh, subErr := mgr.Subscribe(context.Background(), pendingID)
 			Expect(subErr).NotTo(HaveOccurred())
+			close(proceed)
 
 			Eventually(investigationDone, 5*time.Second).Should(BeClosed())
 
@@ -108,11 +121,17 @@ var _ = Describe("Live complete event carries RCA data — #1794", func() {
 
 	Describe("UT-KA-1794-002: live complete event has empty Data when investigation returns nil result", func() {
 		It("should not populate Data for a nil result (e.g. a failed investigation)", func() {
+			// Same ready/proceed gate as UT-KA-1794-001 above — this closure is
+			// equally instant and would otherwise race Subscribe below.
+			ready := make(chan struct{})
+			proceed := make(chan struct{})
 			investigationDone := make(chan struct{})
 
 			pendingID, err := mgr.StartInteractiveSession(context.Background(),
 				func(_ context.Context) (*katypes.InvestigationResult, error) {
 					defer close(investigationDone)
+					close(ready)
+					<-proceed
 					return nil, nil
 				},
 				map[string]string{"remediation_id": "rr-1794-002"},
@@ -120,9 +139,11 @@ var _ = Describe("Live complete event carries RCA data — #1794", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(mgr.LaunchDeferredInvestigation(pendingID)).To(Succeed())
+			<-ready
 
 			eventCh, subErr := mgr.Subscribe(context.Background(), pendingID)
 			Expect(subErr).NotTo(HaveOccurred())
+			close(proceed)
 
 			Eventually(investigationDone, 5*time.Second).Should(BeClosed())
 

--- a/internal/kubernautagent/session/verdict_escalation_1420_test.go
+++ b/internal/kubernautagent/session/verdict_escalation_1420_test.go
@@ -301,6 +301,11 @@ var _ = Describe("Issue #1420: Shadow Agent Verdict Escalation Fix", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			ch, subErr := mgr.Subscribe(context.Background(), id)
+			if subErr == session.ErrSessionTerminal {
+				// Investigation completed before Subscribe — the security-escalation
+				// forced completion (IR-4.a), so the channel closure is trivially satisfied.
+				return
+			}
 			Expect(subErr).NotTo(HaveOccurred())
 
 			Eventually(func() bool {

--- a/pkg/apifrontend/agent/phase_guard.go
+++ b/pkg/apifrontend/agent/phase_guard.go
@@ -17,6 +17,7 @@ limitations under the License.
 package agent
 
 import (
+	"encoding/json"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -27,6 +28,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/session"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
 )
 
 const (
@@ -202,11 +204,23 @@ func newPhaseGuard(registry *launcher.ActiveContextRegistry) (llmagent.BeforeToo
 				// earlier successful one in the same session (hardening
 				// beyond #2023's original binary gate -- see
 				// enforceGroundingGuard).
-				var rawRCA map[string]any
+				//
+				// #2068: a Provisional rca (AF's own severity-triage guess,
+				// synthesized when KA hasn't genuinely investigated yet --
+				// see ka_investigate_mcp.go's two InvestigateRCA fallback
+				// construction sites) is deliberately excluded here. It is
+				// not "extracted from the KA complete event" the way this
+				// struct's own doc comment describes, so it must not be
+				// cached as an authoritative fact to substitute into
+				// present_decision -- same treatment as "no structured rca
+				// at all" (UT-AF-2023-011).
+				var rca *tools.InvestigateRCA
 				if isSuccess {
-					rawRCA, _ = resp["rca"].(map[string]any)
+					if decoded := decodeInvestigateRCA(resp["rca"]); decoded != nil && !decoded.Provisional {
+						rca = decoded
+					}
 				}
-				if err := state.Set(session.StateKeyGroundedRCA, rawRCA); err != nil {
+				if err := state.Set(session.StateKeyGroundedRCA, rca); err != nil {
 					logr.FromContextOrDiscard(ctx).Error(err, "phase-guard failed to persist grounded_rca state")
 				}
 			}
@@ -461,37 +475,52 @@ func investigateHasGroundedContent(resp map[string]any, isSuccess bool) bool {
 	return false
 }
 
-// rcaFieldRename maps InvestigateRCA's JSON field names (tools.InvestigateRCA)
-// to RCAData's JSON field names (tools.RCAData) where they differ --
-// canonicalGroundedRCA's pass-through target. severity/confidence/
-// causal_chain/target are identical in both and need no rename.
-var rcaFieldRename = map[string]string{
-	"total_tool_calls": "tool_calls_count",
-	"total_llm_turns":  "llm_turns",
-}
-
-// canonicalGroundedRCA converts a raw kubernaut_investigate "rca" payload
-// (tools.InvestigateRCA field names) into present_decision's RCAData shape,
-// renaming the two fields that differ and dropping the free-text
-// rca_summary/is_actionable/has_workflow keys that RCAData has no slot for.
-// Returns nil when raw is empty, so callers can distinguish "nothing to pass
-// through" from "pass through an empty object".
-func canonicalGroundedRCA(raw map[string]any) map[string]any {
-	if len(raw) == 0 {
+// decodeInvestigateRCA converts a kubernaut_investigate response's "rca"
+// value (map[string]any, per the ADK AfterToolCallback's untyped resp
+// contract) into the same tools.InvestigateRCA type ka_investigate_mcp.go
+// constructs it from, so callers work with named, typed fields (Severity,
+// Provisional, ...) instead of probing map keys by hand. Returns nil when v
+// isn't a non-empty map or fails to decode.
+func decodeInvestigateRCA(v any) *tools.InvestigateRCA {
+	raw, ok := v.(map[string]any)
+	if !ok || len(raw) == 0 {
 		return nil
 	}
-	out := make(map[string]any, len(raw))
-	for k, v := range raw {
-		if k == "rca_summary" || k == "is_actionable" || k == "has_workflow" {
-			continue
-		}
-		if renamed, ok := rcaFieldRename[k]; ok {
-			out[renamed] = v
-			continue
-		}
-		out[k] = v
+	b, err := json.Marshal(raw)
+	if err != nil {
+		return nil
 	}
-	return out
+	var rca tools.InvestigateRCA
+	if err := json.Unmarshal(b, &rca); err != nil {
+		return nil
+	}
+	return &rca
+}
+
+// canonicalGroundedRCA converts KA's InvestigateRCA (tools package, KA's own
+// wire-format field names total_tool_calls/total_llm_turns) into
+// present_decision's RCAData shape (tools package, tool_calls_count/
+// llm_turns) -- the two have always used different names for these two
+// fields since InvestigateRCA mirrors KA's EventTypeComplete payload (a
+// contract this package doesn't own) while RCAData is AF's own LLM-facing
+// present_decision schema; renaming them is unavoidable however it's
+// expressed, so this is done via explicit field assignment rather than a
+// generic map copy. rca_summary/is_actionable/has_workflow/provisional have
+// no slot in RCAData and are intentionally dropped. Returns nil when rca is
+// nil or carries no severity at all, so callers can distinguish "nothing to
+// pass through" from "pass through an empty object".
+func canonicalGroundedRCA(rca *tools.InvestigateRCA) *tools.RCAData {
+	if rca == nil || rca.Severity == "" {
+		return nil
+	}
+	return &tools.RCAData{
+		Severity:       rca.Severity,
+		Confidence:     rca.Confidence,
+		CausalChain:    rca.CausalChain,
+		Target:         rca.Target,
+		ToolCallsCount: rca.TotalToolCalls,
+		LLMTurns:       rca.TotalLLMTurns,
+	}
 }
 
 // enforceGroundingGuard implements #2023's harness-side fabrication guard.
@@ -520,7 +549,10 @@ func canonicalGroundedRCA(raw map[string]any) map[string]any {
 // deliberately left model-authored once grounded -- it may legitimately
 // synthesize reasoning the pure structured facts don't capture -- and
 // args["rca"] is left untouched when KA reported no structured rca at all
-// (nothing authoritative to substitute).
+// (nothing authoritative to substitute) -- and, per #2068, when the only
+// "rca" available is AF's own Provisional severity-triage guess rather than
+// a genuine KA finding (session.StateKeyGroundedRCA is never populated with
+// a Provisional rca in the first place; see the after-callback above).
 func enforceGroundingGuard(ctx tool.Context, args map[string]any) {
 	if args == nil {
 		return
@@ -536,8 +568,8 @@ func enforceGroundingGuard(ctx tool.Context, args map[string]any) {
 	}
 	if grounded {
 		if v, err := state.Get(session.StateKeyGroundedRCA); err == nil {
-			if raw, ok := v.(map[string]any); ok {
-				if canonical := canonicalGroundedRCA(raw); canonical != nil {
+			if rca, ok := v.(*tools.InvestigateRCA); ok {
+				if canonical := canonicalGroundedRCA(rca); canonical != nil {
 					args["rca"] = canonical
 				}
 			}

--- a/pkg/apifrontend/agent/phase_guard_test.go
+++ b/pkg/apifrontend/agent/phase_guard_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/auth"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/launcher"
 	"github.com/jordigilh/kubernaut/pkg/apifrontend/session"
+	"github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
 )
 
 // statefulToolContext extends fakeToolContext with a working session.State
@@ -724,14 +725,14 @@ var _ = Describe("Phase Guard — Content Grounding Guard (#2023)", func() {
 		_, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
 		Expect(err).NotTo(HaveOccurred())
 
-		rca, ok := args["rca"].(map[string]any)
-		Expect(ok).To(BeTrue(), "rca must be overwritten with a map, not left as the LLM's own value")
-		Expect(rca["severity"]).To(Equal("warning"), "severity must come from KA's own report, not the LLM's fabricated 'critical'")
-		Expect(rca["confidence"]).To(Equal(0.55))
-		Expect(rca["target"]).To(Equal("pod/real-target"))
-		Expect(rca["causal_chain"]).To(Equal([]any{"MemoryPressure", "Evicted"}))
-		Expect(rca["tool_calls_count"]).To(Equal(7), "total_tool_calls must be renamed to RCAData's tool_calls_count field")
-		Expect(rca["llm_turns"]).To(Equal(3), "total_llm_turns must be renamed to RCAData's llm_turns field")
+		rca, ok := args["rca"].(*tools.RCAData)
+		Expect(ok).To(BeTrue(), "rca must be overwritten with a *tools.RCAData, not left as the LLM's own value")
+		Expect(rca.Severity).To(Equal("warning"), "severity must come from KA's own report, not the LLM's fabricated 'critical'")
+		Expect(rca.Confidence).To(Equal(0.55))
+		Expect(rca.Target).To(Equal("pod/real-target"))
+		Expect(rca.CausalChain).To(Equal([]string{"MemoryPressure", "Evicted"}))
+		Expect(rca.ToolCallsCount).To(Equal(7), "total_tool_calls must be renamed to RCAData's tool_calls_count field")
+		Expect(rca.LLMTurns).To(Equal(3), "total_llm_turns must be renamed to RCAData's llm_turns field")
 	})
 
 	It("UT-AF-2023-011: leaves the rca argument untouched when investigate reported no structured rca payload (summary-only grounding)", func() {
@@ -825,6 +826,70 @@ var _ = Describe("Phase Guard — Content Grounding Guard (#2023)", func() {
 		summary, _ := argsSecond["summary"].(string)
 		Expect(summary).To(ContainSubstring("No investigation content is available"),
 			"stale grounded=true from the FIRST investigate must not leak into the SECOND, failed attempt")
+	})
+
+	It("UT-AF-2068-001: does NOT overwrite present_decision's rca with a Provisional severity-triage fallback (RCA never genuinely investigated by KA)", func() {
+		// #2068 spike: reproduces ka_investigate_mcp.go's severity-triage
+		// fallback shape (Severity/Confidence only, no causal_chain/target/
+		// tool_calls_count/llm_turns -- KA never ran a real investigation).
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+			"session_id": "sess-2068-1", "status": "completed",
+			"summary": "Severity assessed from resource metadata (full investigation pending)",
+			"rca": map[string]any{
+				"severity": "warning", "confidence": 0.6, "provisional": true,
+			},
+		}, nil)
+
+		args := fabricatedArgs()
+		_, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(args["rca"]).To(Equal(fabricatedArgs()["rca"]),
+			"#2068: a Provisional (AF-synthesized severity-triage guess, not a genuine KA finding) rca must "+
+				"not clobber present_decision's own rca -- same treatment as 'no structured rca at all' (UT-AF-2023-011)")
+	})
+
+	It("UT-AF-2068-004: still overwrites present_decision's rca when kubernaut_investigate's rca is genuinely KA-reported (Provisional unset/false)", func() {
+		// Companion to UT-AF-2023-010, restated in #2068 terms: a real,
+		// non-Provisional rca must keep working exactly as before -- #2068
+		// must gate ONLY on Provisional=true, not regress the original
+		// #2023 caching behavior for a genuinely-investigated result.
+		_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+			"session_id": "sess-2068-4", "status": "completed",
+			"summary": "Real investigation summary.",
+			"rca": map[string]any{
+				"severity": "warning", "confidence": 0.55,
+				"causal_chain": []any{"MemoryPressure", "Evicted"},
+			},
+		}, nil)
+
+		args := fabricatedArgs()
+		_, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
+		Expect(err).NotTo(HaveOccurred())
+
+		rca, ok := args["rca"].(*tools.RCAData)
+		Expect(ok).To(BeTrue())
+		Expect(rca.Severity).To(Equal("warning"), "a non-Provisional rca must still overwrite present_decision's rca (#2023's original guarantee)")
+	})
+
+	It("UT-AF-2068-005: treats a malformed (non-object) rca payload the same as no rca at all, without panicking", func() {
+		// decodeInvestigateRCA must fail closed: a type-mismatched "rca"
+		// value (here a bare string instead of an object) must not cache
+		// anything usable, and must never panic the after-callback.
+		Expect(func() {
+			_, _ = after(toolCtx, fakeTool{name: "kubernaut_investigate"}, nil, map[string]any{
+				"session_id": "sess-2068-5", "status": "completed",
+				"summary": "Real investigation summary.",
+				"rca":     "not-an-object",
+			}, nil)
+		}).NotTo(Panic())
+
+		args := fabricatedArgs()
+		_, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(args["rca"]).To(Equal(fabricatedArgs()["rca"]),
+			"a malformed rca payload has nothing authoritative to substitute, same as UT-AF-2023-011")
 	})
 })
 

--- a/pkg/apifrontend/session/consent.go
+++ b/pkg/apifrontend/session/consent.go
@@ -68,7 +68,7 @@ const (
 	// artifact.
 	StateKeyGroundedContentAvailable = "af_grounded_content_available"
 
-	// StateKeyGroundedRCA records the exact "rca" payload (severity,
+	// StateKeyGroundedRCA records a *tools.InvestigateRCA (severity,
 	// confidence, causal_chain, target, total_tool_calls, total_llm_turns)
 	// carried by the most recent kubernaut_investigate response, keyed
 	// unconditionally on every investigate call (present or nil) so a
@@ -85,6 +85,12 @@ const (
 	// stays model-authored once grounded, since it may legitimately
 	// synthesize reasoning across a session that a pure pass-through would
 	// lose.
+	//
+	// #2068: never populated with a Provisional RCA (InvestigateRCA.
+	// Provisional=true -- AF's own severity-triage guess synthesized before
+	// KA has genuinely investigated, not a value "carried by" KA's response
+	// the way this key's name implies). A Provisional-only investigate call
+	// is treated the same as one with no structured RCA at all.
 	StateKeyGroundedRCA = "af_grounded_rca"
 )
 

--- a/pkg/apifrontend/tools/ka_investigate_mcp.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp.go
@@ -171,6 +171,15 @@ type InvestigateRCA struct {
 	// stays distinguishable from a genuine computed false.
 	IsActionable *bool `json:"is_actionable,omitempty"`
 	HasWorkflow  bool  `json:"has_workflow,omitempty"`
+	// Provisional marks an RCA synthesized locally by AF from severity-triage
+	// labels alone (no KA investigation occurred yet), as opposed to one
+	// extracted from KA's own EventTypeComplete payload (#2068). Progressive
+	// UX events (emitEarlyRCA/emitFallbackInvestigationArtifact) still fire
+	// normally for a provisional RCA -- only phase_guard.go's #2023
+	// anti-fabrication cache treats this flag specially, since this struct's
+	// own doc comment ("extracted from the KA complete event") never held
+	// for the fallback construction sites below.
+	Provisional bool `json:"provisional,omitempty"`
 }
 
 // SessionStartedHook is called after a successful StartInvestigation with the
@@ -414,9 +423,10 @@ func HandleInvestigationMCPWithRegistry(ctx context.Context, mcpClient ka.MCPCli
 
 			if rrSeverity != "" {
 				rca := &InvestigateRCA{
-					Severity:   rrSeverity,
-					Confidence: 0.6,
-					RCASummary: fmt.Sprintf("Severity assessed from resource metadata (investigation in progress by %s)", driver),
+					Severity:    rrSeverity,
+					Confidence:  0.6,
+					Provisional: true,
+					RCASummary:  fmt.Sprintf("Severity assessed from resource metadata (investigation in progress by %s)", driver),
 				}
 				emitEarlyRCA(ctx, rca)
 				emitFallbackInvestigationArtifact(ctx, rca, args.RRID)
@@ -526,9 +536,10 @@ func HandleInvestigationMCPWithRegistry(ctx context.Context, mcpClient ka.MCPCli
 		// user gets immediate severity feedback.
 		if rca == nil && rrSeverity != "" {
 			rca = &InvestigateRCA{
-				Severity:   rrSeverity,
-				Confidence: 0.6,
-				RCASummary: "Severity assessed from resource metadata (full investigation pending)",
+				Severity:    rrSeverity,
+				Confidence:  0.6,
+				Provisional: true,
+				RCASummary:  "Severity assessed from resource metadata (full investigation pending)",
 			}
 			emitEarlyRCA(ctx, rca)
 			emitFallbackInvestigationArtifact(ctx, rca, args.RRID)

--- a/pkg/apifrontend/tools/ka_investigate_wiring_test.go
+++ b/pkg/apifrontend/tools/ka_investigate_wiring_test.go
@@ -107,6 +107,77 @@ var _ = Describe("HandleInvestigationMCPWithRegistry — wiring audit (WIRE-C01/
 		})
 	})
 
+	Describe("WIRE-C02 / #2068: blocking-path severity-triage fallback RCA is marked Provisional", func() {
+		It("UT-AF-2068-002: HandleInvestigationMCPWithRegistry's InvestigateMCPResult.RCA carries Provisional=true when the bridge produced no structured RCA", func() {
+			// Same closed-empty-channel setup as WIRE-C01: bridgeEventsCollectSummary
+			// observes zero events, so its own rca return is nil and only the
+			// triager's severity is available -- exactly the "full investigation
+			// pending" fallback at ka_investigate_mcp.go's rca==nil && rrSeverity!=""
+			// site (the one whose Provisional=false value, before #2068, let a
+			// severity-triage guess get cached by phase_guard.go and clobber a
+			// genuinely investigated present_decision RCA -- see UT-AF-2068-001).
+			origTimeout := tools.AwaitSessionTimeout
+			tools.AwaitSessionTimeout = 10 * time.Millisecond
+			defer func() { tools.AwaitSessionTimeout = origTimeout }()
+
+			eventCh := make(chan ka.InvestigationEvent)
+			close(eventCh)
+
+			mockMCP := &ka.MockMCPClient{
+				StartInvestigationFn: func(_ context.Context, args ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+					return &ka.StartInvestigationResult{
+						SessionID: "sess-wire-c02",
+						Status:    "started",
+						Events:    eventCh,
+						Closer:    func() {},
+					}, nil
+				},
+			}
+
+			mockProm := &mockPromClientForWiring{
+				alerts: []prom.Alert{
+					{
+						State: "firing",
+						Labels: map[string]string{
+							"alertname": "KubePodCrashLooping",
+							"severity":  "warning",
+							"namespace": "prod",
+							"kind":      "Deployment",
+							"name":      "web-app-2068",
+						},
+					},
+				},
+			}
+			triager := severity.NewTriager(mockProm, &noopLLMForWiring{}, severity.DefaultConfig(), logr.Discard())
+
+			ctx, cancel := context.WithTimeout(
+				auth.WithUserIdentity(context.Background(), &auth.UserIdentity{
+					Username: "alice",
+					Groups:   []string{"sre"},
+				}),
+				10*time.Second,
+			)
+			defer cancel()
+
+			tc := newTypedClientForInvestigate()
+			result, err := tools.HandleInvestigationMCPWithRegistry(
+				ctx, mockMCP, tc, "kubernaut-system",
+				tools.InvestigateMCPArgs{
+					APIVersion: "apps/v1",
+					Namespace:  "prod",
+					Kind:       "Deployment",
+					Name:       "web-app-2068",
+				},
+				nil, nil, nil, true, nil, "", nil, triager,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.RCA).NotTo(BeNil(), "fallback must populate RCA when the bridge produced no structured result but severity triage succeeded")
+			Expect(result.RCA.Severity).To(Equal("warning"), "fallback RCA must carry the triaged severity")
+			Expect(result.RCA.Provisional).To(BeTrue(),
+				"#2068: a severity-triage-only guess (no genuine KA investigation) must be marked Provisional so phase_guard.go's #2023 anti-fabrication cache never treats it as a verified finding")
+		})
+	})
+
 	Describe("WIRE-C03: triager audit event emission", func() {
 		It("UT-AF-WIRE-C03: triager constructed with WithAuditor emits severity event", func() {
 			spy := &auditSpy{}


### PR DESCRIPTION
## Summary

Fixes #2068.

- `kubernaut_investigate`'s severity-triage-only fallback RCA (synthesized locally by AF *before* KA has produced a real finding) was being cached by `phase_guard.go`'s `#2023` anti-fabrication guard as if it were a verified KA result.
- A later, genuinely-investigated `present_decision` call in the same session then had its correct `rca` silently overwritten by the earlier, stale, low-confidence fallback -- exactly what broke `E2E-AF-1396-001` once #2058's test-isolation fix stopped masking it (`severity: warning` instead of the expected `critical`).
- `InvestigateRCA` now carries a `Provisional` flag, set at both fallback construction sites in `ka_investigate_mcp.go`. `phase_guard.go`'s after-callback decodes the raw `rca` into a typed `*tools.InvestigateRCA` and only caches it into `session.StateKeyGroundedRCA` when NOT Provisional -- a Provisional-only investigate call is now treated the same as "no structured rca at all" (matching `UT-AF-2023-011`'s existing semantics).
- `canonicalGroundedRCA` now converts the typed `*tools.InvestigateRCA` directly into `*tools.RCAData`, replacing the old `map[string]any` plumbing and manual field-copy-by-key.

## Wiring Manifest

| Component | Production Entry Point | Wiring Code Location | Test ID |
|---|---|---|---|
| `InvestigateRCA.Provisional` | `HandleInvestigationMCPWithRegistry` (both fallback sites) | `ka_investigate_mcp.go` | `UT-AF-2068-002` (end-to-end through the real triager + bridge) |
| `decodeInvestigateRCA` | phase_guard after-callback | `phase_guard.go` `newPhaseGuard` | `UT-AF-2068-001`, `UT-AF-2068-005` |
| `canonicalGroundedRCA` (typed) | phase_guard before-callback (`enforceGroundingGuard`) | `phase_guard.go` | `UT-AF-2023-010` (updated), `UT-AF-2068-004` |

## Test plan

- [x] `UT-AF-2068-001`: reproduces the exact failure shape (RED against pre-fix code), confirms fix (GREEN)
- [x] `UT-AF-2068-002`: wiring-level proof the real fallback path sets `Provisional=true` on the actual `InvestigateMCPResult`
- [x] `UT-AF-2068-004`: regression guard -- a genuine (non-Provisional) rca still overwrites present_decision's rca as `#2023` always intended
- [x] `UT-AF-2068-005`: fail-closed behavior for a malformed (non-object) rca payload
- [x] `go build ./...` clean
- [x] `go vet ./pkg/apifrontend/...` clean
- [x] Full `pkg/apifrontend/agent` and `pkg/apifrontend/tools` suites pass
- [ ] `E2E-AF-1396-001` (already asserts `severity: critical`, unchanged) expected to pass once this lands in CI -- not run locally against a live Kind cluster as part of this PR

Made with [Cursor](https://cursor.com)