### PR TITLE
fix(kubernautagent): backport UT-KA-1420-013/UT-KA-1794-001/002 session-race stabilization to v1.5

### DIFF
--- a/internal/kubernautagent/session/complete_event_rca_1794_test.go
+++ b/internal/kubernautagent/session/complete_event_rca_1794_test.go
@@ -53,11 +53,22 @@ var _ = Describe("Live complete event carries RCA data — #1794", func() {
 
 	Describe("UT-KA-1794-001: live complete event Data is populated from a non-nil result", func() {
 		It("should attach the bounded RCA subset to the live EventTypeComplete event", func() {
+			// ready/proceed gate (same idiom as manager_upgrade_test.go's
+			// UT-KA-1390-008/026/027): without it, this instant, no-I/O closure
+			// can race Store.Update(StatusCompleted) ahead of the Subscribe call
+			// below, which — with no eventChan attached yet — makes Subscribe
+			// return ErrSessionTerminal (manager_query.go) instead of the live
+			// channel this test means to exercise. Observed as a real,
+			// non-hypothetical flake in CI (run 30727355643, job 91441733492).
+			ready := make(chan struct{})
+			proceed := make(chan struct{})
 			investigationDone := make(chan struct{})
 
 			pendingID, err := mgr.StartInteractiveSession(context.Background(),
 				func(_ context.Context) (*katypes.InvestigationResult, error) {
 					defer close(investigationDone)
+					close(ready)
+					<-proceed
 					return &katypes.InvestigationResult{
 						Severity:   "critical",
 						Confidence: 0.92,
@@ -70,9 +81,11 @@ var _ = Describe("Live complete event carries RCA data — #1794", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(mgr.LaunchDeferredInvestigation(pendingID)).To(Succeed())
+			<-ready
 
 			eventCh, subErr := mgr.Subscribe(context.Background(), pendingID)
 			Expect(subErr).NotTo(HaveOccurred())
+			close(proceed)
 
 			Eventually(investigationDone, 5*time.Second).Should(BeClosed())
 
@@ -108,11 +121,17 @@ var _ = Describe("Live complete event carries RCA data — #1794", func() {
 
 	Describe("UT-KA-1794-002: live complete event has empty Data when investigation returns nil result", func() {
 		It("should not populate Data for a nil result (e.g. a failed investigation)", func() {
+			// Same ready/proceed gate as UT-KA-1794-001 above — this closure is
+			// equally instant and would otherwise race Subscribe below.
+			ready := make(chan struct{})
+			proceed := make(chan struct{})
 			investigationDone := make(chan struct{})
 
 			pendingID, err := mgr.StartInteractiveSession(context.Background(),
 				func(_ context.Context) (*katypes.InvestigationResult, error) {
 					defer close(investigationDone)
+					close(ready)
+					<-proceed
 					return nil, nil
 				},
 				map[string]string{"remediation_id": "rr-1794-002"},
@@ -120,9 +139,11 @@ var _ = Describe("Live complete event carries RCA data — #1794", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			Expect(mgr.LaunchDeferredInvestigation(pendingID)).To(Succeed())
+			<-ready
 
 			eventCh, subErr := mgr.Subscribe(context.Background(), pendingID)
 			Expect(subErr).NotTo(HaveOccurred())
+			close(proceed)
 
 			Eventually(investigationDone, 5*time.Second).Should(BeClosed())
 

--- a/internal/kubernautagent/session/verdict_escalation_1420_test.go
+++ b/internal/kubernautagent/session/verdict_escalation_1420_test.go
@@ -301,6 +301,11 @@ var _ = Describe("Issue #1420: Shadow Agent Verdict Escalation Fix", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			ch, subErr := mgr.Subscribe(context.Background(), id)
+			if subErr == session.ErrSessionTerminal {
+				// Investigation completed before Subscribe — the security-escalation
+				// forced completion (IR-4.a), so the channel closure is trivially satisfied.
+				return
+			}
 			Expect(subErr).NotTo(HaveOccurred())
 
 			Eventually(func() bool {


### PR DESCRIPTION
## Summary

Backports two already-validated flaky-test fixes from `main` (v1.6) to `release/v1.5`, discovered while monitoring CI for PR #2069 (unrelated `apifrontend` change — confirmed via `git diff` that no `internal/kubernautagent/` files were touched there).

Both fixes address the same class of test-synchronization bug previously diagnosed and resolved in #1631: `internal/kubernautagent/session.Manager.launchInvestigation` synchronously sets `StatusRunning` and spawns the investigation goroutine *before* `StartInvestigation`/`StartInteractiveSession` returns. When a test's investigation closure returns instantly with no synchronization, the goroutine can complete (`store.Update(StatusCompleted, ...)`) before the test's next line calls `Subscribe`, which — with no `eventChan` attached yet — returns `ErrSessionTerminal` (`session is in terminal state`) instead of the live channel the test means to exercise. This is a **test-design bug, not a production defect** (mirrors #1631's conclusion for a different pair of tests/functions).

- `db201b9d` (cherry-pick of `main`@`da0b652a2`): `UT-KA-1420-013` — tolerates `ErrSessionTerminal` from `Subscribe` as a valid outcome (the security-escalation forced completion, so the channel-closure assertion is trivially satisfied).
- `b7e21a0b` (cherry-pick of `main`@`6564b5b4b`): `UT-KA-1794-001`/`UT-KA-1794-002` — applies the `ready`/`proceed` channel-gate idiom (same pattern as `manager_upgrade_test.go`'s `UT-KA-1390-008/026/027`) to deterministically sequence `Subscribe` before the closure is allowed to return.

## RCA evidence

- PR #2069 CI run [31394230826](https://github.com/jordigilh/kubernaut/actions/runs/31394230826): `Unit Tests (kubernautagent)` failed on `UT-KA-1420-013` (attempt 1) then `UT-KA-1794-002` (attempt 2, after `gh run rerun --failed`) — both with identical `session is in terminal state` errors, on a PR that touches zero files in `internal/kubernautagent/`.
- Confirmed both fixes exist on `main` already (`da0b652a2`, `6564b5b4b`) but were never backported to `release/v1.5`.
- No production code changed — test-only synchronization hardening, matching the precedent and root-cause pattern documented in #1631.

## Test plan

- [x] `go build ./internal/kubernautagent/...` clean
- [x] `go vet ./internal/kubernautagent/session/...` clean
- [x] `gofmt -l` on both changed files: no *new* issues (pre-existing unrelated formatting drift in `verdict_escalation_1420_test.go` confirmed present before this change too)
- [x] `ginkgo -race -repeat=25 --focus="UT-KA-1420-013|UT-KA-1794-00"`: 26/26 runs green (previously intermittent)
- [x] `ginkgo -race` full `internal/kubernautagent/session` suite: 139/139 specs pass

Made with [Cursor](https://cursor.com)