### PR TITLE
Fix #2073 (present_decision schema failure), #2075 (complete_no_action race), and #2080 (session-lost/adoption race)

### DIFF
--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -1345,6 +1345,13 @@ func buildMCPHandler(
 		},
 	)
 
+	// AutoCloseTombstone: records interactive sessions InvestigateTool's
+	// no_matching_workflows handling auto-closes on its own, so a racing
+	// kubernaut_complete_no_action call resolves as "already_resolved"
+	// instead of erroring (#2075). TTL matches disconnectGracePeriod's order
+	// of magnitude below.
+	autoCloseTombstone := mcpkg.NewAutoCloseTombstone(60 * time.Second)
+
 	// ReconstructionSpawner: rebuilds context and spawns autonomous investigation
 	// after an interactive session ends (INT-06, BR-INTERACTIVE-008).
 	reconRunner := mcpadapters.NewReconRunnerAdapter(inv)
@@ -1455,6 +1462,7 @@ func buildMCPHandler(
 		mcptools.WithAuditStore(auditStore, logger.WithName("mcp-audit")),
 		mcptools.WithSignalContextResolver(signalResolver),
 		mcptools.WithWorkflowCatalog(catalogAdapter),
+		mcptools.WithInvestigateAutoCloseTombstone(autoCloseTombstone),
 	}
 	investigateTool := mcptools.NewInvestigateTool(leaseMgr, investigatorRunner, recon, autoMgr, investigateOpts...)
 
@@ -1484,6 +1492,7 @@ func buildMCPHandler(
 		// wired here, leaving the inactivity timer running past session
 		// completion (same root cause as select_workflow above).
 		mcptools.WithCompleteNoActionTimeoutTracker(timeoutMgr),
+		mcptools.WithCompleteNoActionAutoCloseTombstone(autoCloseTombstone),
 	)
 
 	// Register tools with the MCP SDK server.

--- a/internal/kubernautagent/mcp/auto_close_tombstone.go
+++ b/internal/kubernautagent/mcp/auto_close_tombstone.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp
+
+import (
+	"sync"
+	"time"
+)
+
+// defaultAutoCloseTombstoneTTL matches the order of magnitude of the
+// existing disconnectGracePeriod (#2075) used elsewhere in the interactive
+// session lifecycle.
+const defaultAutoCloseTombstoneTTL = 60 * time.Second
+
+// AutoCloseTombstone is a small, self-expiring record of interactive
+// sessions the backend recently auto-closed on its own (#2075).
+//
+// investigate.go's no_matching_workflows handling releases the MCP
+// interactive lease asynchronously, in a goroutine, after the
+// discover_workflows response has already been sent to the caller. If the
+// console's Dismiss button (kubernaut_complete_no_action) races in after
+// that release completes, IsDriverActive(rrID) has already gone false and
+// complete_no_action would otherwise fail with "no active interactive
+// session" even though the investigation was already correctly concluded.
+//
+// This is deliberately not a general-purpose cache: it is written only at
+// the exact call site that causes the race (the no_matching_workflows
+// auto-close goroutine) and read only at the exact call site affected by
+// it (complete_no_action.Handle) — no changes to the SessionManager or
+// HTTPSessionCompleter interfaces, and no interaction with the #1654/#1949
+// inactivity-timer-correctness code.
+type AutoCloseTombstone struct {
+	mu      sync.Mutex
+	entries map[string]struct{}
+	ttl     time.Duration
+}
+
+// NewAutoCloseTombstone creates a tombstone that forgets a marked rr_id
+// after ttl elapses. A ttl <= 0 falls back to defaultAutoCloseTombstoneTTL.
+func NewAutoCloseTombstone(ttl time.Duration) *AutoCloseTombstone {
+	if ttl <= 0 {
+		ttl = defaultAutoCloseTombstoneTTL
+	}
+	return &AutoCloseTombstone{
+		entries: make(map[string]struct{}),
+		ttl:     ttl,
+	}
+}
+
+// Mark records that rrID's interactive session was just auto-closed by the
+// backend (not by an explicit user action), self-expiring after ttl. A nil
+// receiver is a safe no-op, so callers can treat the tombstone as an
+// optional dependency (matching the WithHTTPCompleter/WithTimeoutTracker
+// nil-safety convention used elsewhere in this package).
+func (a *AutoCloseTombstone) Mark(rrID string) {
+	if a == nil || rrID == "" {
+		return
+	}
+	a.mu.Lock()
+	a.entries[rrID] = struct{}{}
+	a.mu.Unlock()
+
+	time.AfterFunc(a.ttl, func() {
+		a.mu.Lock()
+		delete(a.entries, rrID)
+		a.mu.Unlock()
+	})
+}
+
+// WasRecentlyAutoClosed reports whether rrID's session was auto-closed by
+// the backend within the last ttl. A nil receiver always reports false.
+func (a *AutoCloseTombstone) WasRecentlyAutoClosed(rrID string) bool {
+	if a == nil || rrID == "" {
+		return false
+	}
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	_, ok := a.entries[rrID]
+	return ok
+}

--- a/internal/kubernautagent/mcp/auto_close_tombstone_test.go
+++ b/internal/kubernautagent/mcp/auto_close_tombstone_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp_test
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+)
+
+// UT-KA-2075-001: AutoCloseTombstone is the small, self-expiring record
+// (#2075) that lets kubernaut_complete_no_action recognize a session it
+// raced against investigate.go's no_matching_workflows auto-close, instead
+// of erroring with "no active interactive session".
+var _ = Describe("AutoCloseTombstone — #2075", func() {
+	It("UT-KA-2075-001a: WasRecentlyAutoClosed reports false before Mark is ever called", func() {
+		tomb := mcpinternal.NewAutoCloseTombstone(50 * time.Millisecond)
+		Expect(tomb.WasRecentlyAutoClosed("rr-1")).To(BeFalse())
+	})
+
+	It("UT-KA-2075-001b: WasRecentlyAutoClosed reports true immediately after Mark", func() {
+		tomb := mcpinternal.NewAutoCloseTombstone(1 * time.Second)
+		tomb.Mark("rr-2")
+		Expect(tomb.WasRecentlyAutoClosed("rr-2")).To(BeTrue())
+	})
+
+	It("UT-KA-2075-001c: entry expires after the TTL elapses", func() {
+		tomb := mcpinternal.NewAutoCloseTombstone(30 * time.Millisecond)
+		tomb.Mark("rr-3")
+		Expect(tomb.WasRecentlyAutoClosed("rr-3")).To(BeTrue())
+		Eventually(func() bool {
+			return tomb.WasRecentlyAutoClosed("rr-3")
+		}, 500*time.Millisecond, 5*time.Millisecond).Should(BeFalse(),
+			"a stale tombstone entry must not permanently mask a genuinely new race/miss for the same rr_id")
+	})
+
+	It("UT-KA-2075-001d: Mark and WasRecentlyAutoClosed are concurrent-safe", func() {
+		tomb := mcpinternal.NewAutoCloseTombstone(200 * time.Millisecond)
+		var wg sync.WaitGroup
+		for i := 0; i < 50; i++ {
+			wg.Add(1)
+			go func(n int) {
+				defer wg.Done()
+				id := fmt.Sprintf("rr-concurrent-%d", n)
+				tomb.Mark(id)
+				_ = tomb.WasRecentlyAutoClosed(id)
+			}(i)
+		}
+		Expect(func() { wg.Wait() }).NotTo(Panic())
+	})
+
+	It("UT-KA-2075-001e: entries are isolated per rr_id -- marking one rr_id does not affect another", func() {
+		tomb := mcpinternal.NewAutoCloseTombstone(1 * time.Second)
+		tomb.Mark("rr-a")
+		Expect(tomb.WasRecentlyAutoClosed("rr-a")).To(BeTrue())
+		Expect(tomb.WasRecentlyAutoClosed("rr-b")).To(BeFalse())
+	})
+
+	It("UT-KA-2075-001f: a nil *AutoCloseTombstone is safe to call (optional dependency, matches WithHTTPCompleter/WithTimeoutTracker nil-safety convention)", func() {
+		var tomb *mcpinternal.AutoCloseTombstone
+		Expect(func() { tomb.Mark("rr-nil") }).NotTo(Panic())
+		Expect(tomb.WasRecentlyAutoClosed("rr-nil")).To(BeFalse())
+	})
+})

--- a/internal/kubernautagent/mcp/tools/complete_no_action.go
+++ b/internal/kubernautagent/mcp/tools/complete_no_action.go
@@ -47,11 +47,12 @@ type CompleteNoActionOutput struct {
 // Allows the user to explicitly conclude an investigation without selecting
 // a workflow. No discovery gate — can be called at any point in the session.
 type CompleteNoActionTool struct {
-	sessions       mcpinternal.SessionManager
-	httpCompleter  HTTPSessionCompleter
-	mutexProvider  SessionMutexProvider
-	timeoutTracker TimeoutTracker
-	logger         logr.Logger
+	sessions           mcpinternal.SessionManager
+	httpCompleter      HTTPSessionCompleter
+	mutexProvider      SessionMutexProvider
+	timeoutTracker     TimeoutTracker
+	autoCloseTombstone AutoCloseTombstone
+	logger             logr.Logger
 }
 
 // CompleteNoActionOption configures optional dependencies.
@@ -89,6 +90,18 @@ func WithCompleteNoActionTimeoutTracker(tt TimeoutTracker) CompleteNoActionOptio
 	}
 }
 
+// WithCompleteNoActionAutoCloseTombstone sets the tombstone consulted when
+// no active driver session is found, so a call racing a backend auto-close
+// (e.g. investigate.go's no_matching_workflows) resolves as
+// "already_resolved" instead of erroring (#2075).
+func WithCompleteNoActionAutoCloseTombstone(tombstone AutoCloseTombstone) CompleteNoActionOption {
+	return func(t *CompleteNoActionTool) {
+		if tombstone != nil {
+			t.autoCloseTombstone = tombstone
+		}
+	}
+}
+
 // NewCompleteNoActionTool creates the tool handler with its dependencies.
 func NewCompleteNoActionTool(sessions mcpinternal.SessionManager, opts ...CompleteNoActionOption) *CompleteNoActionTool {
 	t := &CompleteNoActionTool{sessions: sessions, logger: logr.Discard()}
@@ -117,6 +130,18 @@ func (t *CompleteNoActionTool) Handle(_ context.Context, input CompleteNoActionI
 	}
 
 	if !t.sessions.IsDriverActive(input.RRID) {
+		// #2075: the backend may have already auto-closed this session on
+		// its own (e.g. investigate.go's no_matching_workflows) between the
+		// caller learning about the session and this call arriving. That
+		// auto-close already emitted its own terminal audit record and
+		// released the lease exactly once -- re-running any of that here
+		// would duplicate it (AU-3/AU-12). Report a distinct
+		// "already_resolved" status rather than "completed_no_action" or
+		// "escalated", since this call's specific dismiss/escalate reason
+		// was never actually recorded.
+		if t.autoCloseTombstone != nil && t.autoCloseTombstone.WasRecentlyAutoClosed(input.RRID) {
+			return CompleteNoActionOutput{Status: "already_resolved"}, nil
+		}
 		return CompleteNoActionOutput{}, fmt.Errorf("no active interactive session for rr_id")
 	}
 

--- a/internal/kubernautagent/mcp/tools/complete_no_action_test.go
+++ b/internal/kubernautagent/mcp/tools/complete_no_action_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+	mcptools "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+)
+
+// fakeAutoCloseTombstone implements mcptools.AutoCloseTombstone for unit
+// tests, decoupled from the real mcp.AutoCloseTombstone's TTL/goroutine
+// machinery (UT-KA-2075-001 covers that in isolation).
+type fakeAutoCloseTombstone struct {
+	hits map[string]bool
+}
+
+func (f *fakeAutoCloseTombstone) Mark(_ string) {}
+
+func (f *fakeAutoCloseTombstone) WasRecentlyAutoClosed(rrID string) bool {
+	return f.hits[rrID]
+}
+
+// UT-KA-2075-002: complete_no_action.Handle's tombstone fallback (#2075) --
+// isolated from the real no_matching_workflows race (IT-KA-2075-001 proves
+// the two production call sites are actually wired together).
+var _ = Describe("kubernaut_complete_no_action tool — #2075 tombstone fallback", func() {
+	It("UT-KA-2075-002a (AC-6, AU-3): returns already_resolved instead of erroring on a tombstone hit", func() {
+		sessions := &mockSessionManager{isActive: false}
+		completer := &mockHTTPCompleter{}
+		tombstone := &fakeAutoCloseTombstone{hits: map[string]bool{"rr-2075-a": true}}
+
+		tool := mcptools.NewCompleteNoActionTool(sessions,
+			mcptools.WithCompleteNoActionHTTPCompleter(completer),
+			mcptools.WithCompleteNoActionAutoCloseTombstone(tombstone),
+		)
+
+		output, err := tool.Handle(context.Background(), mcptools.CompleteNoActionInput{RRID: "rr-2075-a"},
+			mcpinternal.UserInfo{Username: "alice"})
+		Expect(err).NotTo(HaveOccurred(), "#2075: a tombstone hit must resolve the race, not error")
+		Expect(output.Status).To(Equal("already_resolved"))
+
+		_, completedResult := completer.getCompleted()
+		Expect(completedResult).To(BeNil(),
+			"the original auto-close already completed the HTTP session exactly once -- a tombstone hit must not re-invoke it (no duplicate audit event)")
+
+		releasedID, _ := sessions.getReleased()
+		Expect(releasedID).To(BeEmpty(),
+			"the original auto-close already released the lease exactly once -- a tombstone hit must not re-invoke Release")
+	})
+
+	It("UT-KA-2075-002b: still returns the original error on a genuine miss (no active session, no tombstone hit) -- regression check", func() {
+		sessions := &mockSessionManager{isActive: false}
+		tombstone := &fakeAutoCloseTombstone{hits: map[string]bool{}}
+
+		tool := mcptools.NewCompleteNoActionTool(sessions,
+			mcptools.WithCompleteNoActionAutoCloseTombstone(tombstone),
+		)
+
+		_, err := tool.Handle(context.Background(), mcptools.CompleteNoActionInput{RRID: "rr-2075-b"},
+			mcpinternal.UserInfo{Username: "alice"})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no active interactive session"))
+	})
+
+	It("UT-KA-2075-002c: does not consult the tombstone when a driver session is genuinely active (normal path unaffected)", func() {
+		sessions := &mockSessionManager{
+			isActive:        true,
+			getDriverResult: &mcpinternal.InteractiveSession{SessionID: "sess-2075-c", ActingUser: mcpinternal.UserInfo{Username: "alice"}},
+		}
+		completer := &mockHTTPCompleter{}
+		tombstone := &fakeAutoCloseTombstone{hits: map[string]bool{}}
+
+		tool := mcptools.NewCompleteNoActionTool(sessions,
+			mcptools.WithCompleteNoActionHTTPCompleter(completer),
+			mcptools.WithCompleteNoActionAutoCloseTombstone(tombstone),
+		)
+
+		output, err := tool.Handle(context.Background(), mcptools.CompleteNoActionInput{RRID: "rr-2075-c"},
+			mcpinternal.UserInfo{Username: "alice"})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output.Status).To(Equal("completed_no_action"))
+
+		_, completedResult := completer.getCompleted()
+		Expect(completedResult).NotTo(BeNil(), "the normal, non-raced path must still complete the HTTP session exactly once")
+	})
+
+	It("UT-KA-2075-002d: an inactive session still errors exactly as before when no tombstone is configured (optional dependency, no regression)", func() {
+		sessions := &mockSessionManager{isActive: false}
+		tool := mcptools.NewCompleteNoActionTool(sessions)
+
+		_, err := tool.Handle(context.Background(), mcptools.CompleteNoActionInput{RRID: "rr-2075-d"},
+			mcpinternal.UserInfo{Username: "alice"})
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(ContainSubstring("no active interactive session"))
+	})
+})

--- a/internal/kubernautagent/mcp/tools/investigate.go
+++ b/internal/kubernautagent/mcp/tools/investigate.go
@@ -164,6 +164,16 @@ type TimeoutTracker interface {
 	ClearActiveCancel(sessionID string)
 }
 
+// AutoCloseTombstone tracks interactive sessions the backend recently
+// auto-closed on its own, so a racing kubernaut_complete_no_action call can
+// recognize "already resolved" instead of erroring (#2075). Implemented by
+// *mcp.AutoCloseTombstone; written by InvestigateTool's no_matching_workflows
+// auto-close, read by CompleteNoActionTool.Handle.
+type AutoCloseTombstone interface {
+	Mark(rrID string)
+	WasRecentlyAutoClosed(rrID string) bool
+}
+
 // withInactivityCancel derives a cancellable context from ctx and registers
 // its CancelFunc with the timeout tracker so that, if sessionID's inactivity
 // timer expires while this action is still in flight, the action's context
@@ -220,22 +230,23 @@ func (NopAutonomousManager) EmitSessionEndedByRR(string, string)                
 // start, message, complete, cancel, takeover, discover_workflows.
 // BR-INTERACTIVE-001, BR-INTERACTIVE-004.
 type InvestigateTool struct {
-	sessions       mcpinternal.SessionManager
-	runner         InvestigatorRunner
-	recon          mcpinternal.ContextReconstructor
-	autoMgr        AutonomousSessionManager
-	httpCompleter  HTTPSessionCompleter
-	signalResolver SignalContextResolver
-	rrChecker      RRExistenceChecker
-	catalog        WorkflowCatalog
-	metrics        ToolMetrics
-	rateLimiter    MessageRateLimiter
-	timeoutTracker TimeoutTracker
-	auditStore     audit.AuditStore
-	logger         logr.Logger
-	notifyFn       func(sessionID, msg string) // optional: delivers timeout warnings to client
-	sessionMu      sync.Map                    // rrID -> *sync.Mutex (per-session serialization)
-	reconHistory   sync.Map                    // rrID -> []LLMMessage (reconstructed context for LLM)
+	sessions           mcpinternal.SessionManager
+	runner             InvestigatorRunner
+	recon              mcpinternal.ContextReconstructor
+	autoMgr            AutonomousSessionManager
+	httpCompleter      HTTPSessionCompleter
+	signalResolver     SignalContextResolver
+	rrChecker          RRExistenceChecker
+	catalog            WorkflowCatalog
+	metrics            ToolMetrics
+	rateLimiter        MessageRateLimiter
+	timeoutTracker     TimeoutTracker
+	auditStore         audit.AuditStore
+	autoCloseTombstone AutoCloseTombstone
+	logger             logr.Logger
+	notifyFn           func(sessionID, msg string) // optional: delivers timeout warnings to client
+	sessionMu          sync.Map                    // rrID -> *sync.Mutex (per-session serialization)
+	reconHistory       sync.Map                    // rrID -> []LLMMessage (reconstructed context for LLM)
 }
 
 // InvestigateOption configures optional dependencies for InvestigateTool.
@@ -325,6 +336,18 @@ func WithAuditStore(store audit.AuditStore, logger logr.Logger) InvestigateOptio
 func WithWorkflowCatalog(catalog WorkflowCatalog) InvestigateOption {
 	return func(t *InvestigateTool) {
 		t.catalog = catalog
+	}
+}
+
+// WithInvestigateAutoCloseTombstone sets the tombstone that records
+// sessions this tool auto-closes on its own (#2075), e.g. via
+// no_matching_workflows, so a racing kubernaut_complete_no_action call can
+// recognize the session as already resolved instead of erroring.
+func WithInvestigateAutoCloseTombstone(tombstone AutoCloseTombstone) InvestigateOption {
+	return func(t *InvestigateTool) {
+		if tombstone != nil {
+			t.autoCloseTombstone = tombstone
+		}
 	}
 }
 
@@ -1053,6 +1076,7 @@ func (t *InvestigateTool) handleDiscoverWorkflows(ctx context.Context, input Inv
 			autoMgr := t.autoMgr
 			completer := t.httpCompleter
 			sessions := t.sessions
+			tombstone := t.autoCloseTombstone
 			rrID := input.RRID
 			sessionID := sess.SessionID
 			result := workflowResult
@@ -1069,6 +1093,13 @@ func (t *InvestigateTool) handleDiscoverWorkflows(ctx context.Context, input Inv
 				// closes.
 				autoMgr.EmitSessionEndedByRR(rrID, "no_matching_workflows")
 				CompleteHTTPSession(completer, rrID, result, logger, "no_matching_workflows")
+				// #2075: mark BEFORE releasing the lease, so a
+				// complete_no_action call that observes IsDriverActive==false
+				// can never find a tombstone miss for a release that already
+				// happened by the time it checks.
+				if tombstone != nil {
+					tombstone.Mark(rrID)
+				}
 				if releaseErr := sessions.Release(sessionID, "no_matching_workflows"); releaseErr != nil {
 					if !errors.Is(releaseErr, mcpinternal.ErrSessionNotFound) {
 						logger.Error(releaseErr, "failed to release MCP lease", "session_id", sessionID)

--- a/internal/kubernautagent/mcp/tools/investigate_test.go
+++ b/internal/kubernautagent/mcp/tools/investigate_test.go
@@ -78,6 +78,15 @@ func (m *mockSessionManager) getReleased() (string, string) {
 	return m.releasedID, m.releasedReason
 }
 
+// setActive lets a test simulate a real SessionManager's IsDriverActive
+// transitioning to false after Release runs (#2075 race reproduction) --
+// the mock otherwise reports a static isActive value.
+func (m *mockSessionManager) setActive(active bool) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.isActive = active
+}
+
 type mockInvestigatorRunner struct {
 	response                string
 	err                     error

--- a/internal/kubernautagent/mcp/tools/no_matching_workflows_race_2075_it_test.go
+++ b/internal/kubernautagent/mcp/tools/no_matching_workflows_race_2075_it_test.go
@@ -1,0 +1,151 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools_test
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/audit"
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+	mcptools "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// IT-KA-2075-001 proves the fix through the REAL production dispatch path for
+// BOTH tools involved in the race: InvestigateTool.Handle(action=
+// discover_workflows) drives the real no_matching_workflows auto-close
+// goroutine (investigate.go), which marks the shared AutoCloseTombstone and
+// releases the lease; CompleteNoActionTool.Handle (complete_no_action.go) is
+// then driven through its own real production Handle() and must consult
+// that same tombstone instance instead of erroring. This is what
+// distinguishes it from UT-KA-2075-001 (component logic in isolation) and
+// UT-KA-2075-002 (complete_no_action's fallback logic against a fake
+// tombstone): this IT proves the two production call sites are actually
+// wired to one shared instance, exactly as cmd/kubernautagent/main.go wires
+// it (#2075).
+var _ = Describe("IT #2075 — complete_no_action races the no_matching_workflows auto-close", func() {
+
+	It("IT-KA-2075-001 (AC-6, AU-12): complete_no_action succeeds with already_resolved when it arrives after the real auto-close already released the lease", func() {
+		store := session.NewStore(30 * time.Minute)
+		mgr := session.NewManager(store, logr.Discard(), audit.NopAuditStore{}, nil)
+
+		rrID := "rr-it-2075-001"
+		user := mcpinternal.UserInfo{Username: "alice"}
+
+		By("Start and launch an interactive session so a stored RCA result exists for rrID")
+		readyCh := make(chan struct{})
+		pendingID, err := mgr.StartInteractiveSession(context.Background(),
+			func(ctx context.Context) (*katypes.InvestigationResult, error) {
+				<-readyCh
+				return &katypes.InvestigationResult{
+					InteractiveHold: true,
+					RCASummary:      "OOM crash on payments-api",
+				}, nil
+			},
+			map[string]string{"remediation_id": rrID},
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(mgr.LaunchDeferredInvestigation(pendingID)).To(Succeed())
+
+		By("Subscribe before releasing the goroutine — activates the LazySink, then drain in the background")
+		eventCh, subErr := mgr.Subscribe(context.Background(), pendingID)
+		Expect(subErr).NotTo(HaveOccurred())
+		go func() {
+			for range eventCh {
+			}
+		}()
+
+		close(readyCh)
+
+		By("Wait for the session to reach StatusUserDriving (RCA stored, ready for discover_workflows)")
+		Eventually(func() session.Status {
+			s, _ := mgr.GetSession(pendingID)
+			if s == nil {
+				return ""
+			}
+			return s.Status
+		}, 5*time.Second).Should(Equal(session.StatusUserDriving))
+
+		By("Share one real production lease-session manager stand-in and one AutoCloseTombstone across both tools, exactly as cmd/kubernautagent/main.go wires them")
+		leaseSessions := &mockSessionManager{
+			isActive: true,
+			getDriverResult: &mcpinternal.InteractiveSession{
+				SessionID:     "lease-it-2075-001",
+				CorrelationID: rrID,
+				ActingUser:    user,
+			},
+		}
+		tombstone := mcpinternal.NewAutoCloseTombstone(60 * time.Second)
+
+		runner := &mockInvestigatorRunner{
+			workflowDiscoveryResult: &katypes.InvestigationResult{
+				RCASummary:        "OOM crash on payments-api",
+				HumanReviewNeeded: true,
+				HumanReviewReason: "no_matching_workflows",
+			},
+		}
+		recon := &mockContextReconstructor{}
+
+		investigateTool := mcptools.NewInvestigateTool(leaseSessions, runner, recon, mgr,
+			mcptools.WithHTTPCompleter(mgr),
+			mcptools.WithWorkflowCatalog(&mockWorkflowCatalog{}),
+			mcptools.WithInvestigateAutoCloseTombstone(tombstone),
+		)
+		completeNoActionTool := mcptools.NewCompleteNoActionTool(leaseSessions,
+			mcptools.WithCompleteNoActionHTTPCompleter(mgr),
+			mcptools.WithCompleteNoActionAutoCloseTombstone(tombstone),
+		)
+
+		By("Drive discover_workflows through the real InvestigateTool — triggers the real no_matching_workflows auto-close goroutine")
+		output, err := investigateTool.Handle(context.Background(), mcptools.InvestigateInput{
+			RRID:   rrID,
+			Action: mcptools.ActionDiscoverWorkflows,
+		}, user)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(output.Status).To(Equal("workflows_discovered"))
+
+		By("Simulate the real production race: the async auto-close goroutine releases the lease (a real Release() call recorded on the shared session manager) before the console's Dismiss click arrives")
+		Eventually(func() string {
+			id, _ := leaseSessions.getReleased()
+			return id
+		}, 3*time.Second).Should(Equal("lease-it-2075-001"),
+			"the real no_matching_workflows auto-close goroutine (investigate.go) must have called Release")
+		leaseSessions.setActive(false)
+
+		By("complete_no_action, called after the auto-close already released the lease, must succeed via the tombstone instead of erroring")
+		completeOutput, err := completeNoActionTool.Handle(context.Background(), mcptools.CompleteNoActionInput{
+			RRID: rrID,
+		}, user)
+		Expect(err).NotTo(HaveOccurred(), "#2075: complete_no_action must not error when it races the no_matching_workflows auto-close")
+		Expect(completeOutput.Status).To(Equal("already_resolved"))
+
+		By("Verify the real session actually reached its terminal state via the auto-close, not via this second complete_no_action call")
+		Eventually(func() session.Status {
+			s, _ := mgr.GetSession(pendingID)
+			if s == nil {
+				return ""
+			}
+			return s.Status
+		}, 3*time.Second).Should(Equal(session.StatusCompleted))
+	})
+})

--- a/pkg/aianalysis/handlers/investigating.go
+++ b/pkg/aianalysis/handlers/investigating.go
@@ -974,7 +974,33 @@ func (h *InvestigatingHandler) handleSessionPollError(ctx context.Context, analy
 // handleSessionLost handles session loss (404 on poll) with regeneration logic.
 // BR-AA-HAPI-064.5: Increment generation, clear ID, requeue for re-submit
 // BR-AA-HAPI-064.6: Fail with SessionRegenerationExceeded if cap reached
+//
+// #2080: before declaring the session lost, re-check whether AF has already
+// correlated a different, currently-active KA session onto this RR's
+// InvestigationSession. A rapid, legitimate session hand-off (autonomous->
+// interactive upgrade immediately followed by a takeover, or several hops in
+// quick succession) can produce a 404 for an already-superseded session ID
+// before checkISMismatchAndCancel/checkCorrelatedSessionBeforeFinalizing get
+// another chance to run -- exhausting the regeneration cap even though the
+// real, underlying investigation had already completed. This re-check is
+// symmetric to those two call sites (same tryAdoptCorrelatedSession helper,
+// #2029 Part B) but closes the gap for the session-lost path specifically.
+//
+// Residual (accepted, theoretical) risk: if this re-check races and misses
+// (correlation hasn't landed yet at the exact instant of this 404), the 404
+// below still counts as one regeneration before the backoff gives the race
+// room to settle on the next attempt. No evidence of this occurring in the
+// #2080 incident's log timeline; the backoff below already shrinks this
+// window to well under the ~1-2s cascade duration observed there.
 func (h *InvestigatingHandler) handleSessionLost(ctx context.Context, analysis *aianalysisv1.AIAnalysis) (ctrl.Result, error) {
+	if h.isChecker != nil {
+		if rrName := analysis.Spec.RemediationRequestRef.Name; rrName != "" {
+			if h.tryAdoptCorrelatedSession(ctx, analysis, rrName, "session-lost-recheck") {
+				return ctrl.Result{Requeue: true}, nil
+			}
+		}
+	}
+
 	session := analysis.Status.KASession
 	session.Generation++
 	session.ID = ""
@@ -1033,8 +1059,14 @@ func (h *InvestigatingHandler) handleSessionLost(ctx context.Context, analysis *
 	aianalysis.SetInvestigationSessionReady(analysis, false, aianalysis.ReasonSessionLost,
 		fmt.Sprintf("Session lost, regenerating (generation %d/%d)", session.Generation, MaxSessionRegenerations))
 
-	// Requeue immediately for re-submit
-	return ctrl.Result{Requeue: true}, nil
+	// #2080: back off before resubmitting instead of an immediate tight-loop
+	// requeue -- gives a legitimate multi-hop session hand-off room to settle
+	// (see the re-check above) before the next regeneration is even
+	// attempted. Reuses the same DD-SHARED-001-compliant backoff calculator
+	// as BR-AI-009's transient-error retry (handleError), keyed on
+	// session.Generation instead of ConsecutiveFailures.
+	backoffDuration := h.errorClassifier.GetRetryDelay(int(session.Generation))
+	return ctrl.Result{RequeueAfter: backoffDuration}, nil
 }
 
 // handleSessionGetResultError handles errors when fetching the session result.

--- a/pkg/aianalysis/investigating_handler_recovery_test.go
+++ b/pkg/aianalysis/investigating_handler_recovery_test.go
@@ -158,8 +158,10 @@ var _ = Describe("Fix #1390: AA GetResult 409 Retry Cap — BR-REL-014", func() 
 			Expect(err).NotTo(HaveOccurred())
 			Expect(analysis.Status.KASession.ID).To(BeEmpty(),
 				"session ID must be cleared after 3 consecutive 409 errors")
-			Expect(result.Requeue).To(BeTrue(),
-				"should requeue for re-submit (session regeneration)")
+			// #2080: backs off instead of requeuing immediately (see UT-AA-064-008).
+			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0),
+				"should back off before resubmit, not requeue immediately (session regeneration)")
 		})
 	})
 

--- a/pkg/aianalysis/investigating_handler_session_test.go
+++ b/pkg/aianalysis/investigating_handler_session_test.go
@@ -443,8 +443,14 @@ var _ = Describe("InvestigatingHandler Session-Based Pull (BR-AA-HAPI-064)", fun
 				Expect(string(cond.Status)).To(Equal("False"))
 				Expect(cond.Reason).To(Equal("SessionLost"))
 
-				// Result: immediate resubmit (no delay)
-				Expect(result.RequeueAfter).To(Equal(time.Duration(0)), "Should requeue immediately for resubmit")
+				// #2080: regeneration retry now backs off (RequeueAfter) instead of
+				// an immediate tight-loop requeue, giving a legitimate multi-hop
+				// session hand-off room to settle before the next attempt (reuses
+				// the same DD-SHARED-001 ErrorClassifier.GetRetryDelay as BR-AI-009's
+				// transient-error backoff, keyed on Generation instead of
+				// ConsecutiveFailures).
+				Expect(result.Requeue).To(BeFalse())
+				Expect(result.RequeueAfter).To(BeNumerically(">", 0), "Should back off before resubmit, not requeue immediately")
 
 				// Audit side effect: exactly 1 aiagent.session_lost event
 				Expect(auditSpy.sessionLostEvents).To(HaveLen(1), "Should record exactly 1 session_lost audit event")
@@ -476,7 +482,9 @@ var _ = Describe("InvestigatingHandler Session-Based Pull (BR-AA-HAPI-064)", fun
 				Expect(err).NotTo(HaveOccurred())
 				Expect(analysis.Status.KASession.Generation).To(Equal(int32(4)), "Generation should increment to 4")
 				Expect(analysis.Status.KASession.ID).To(BeEmpty(), "ID should be cleared")
-				Expect(result.RequeueAfter).To(Equal(time.Duration(0)), "Should requeue immediately for resubmit")
+				// #2080: backs off instead of requeuing immediately (see UT-AA-064-008).
+				Expect(result.Requeue).To(BeFalse())
+				Expect(result.RequeueAfter).To(BeNumerically(">", 0), "Should back off before resubmit, not requeue immediately")
 				// Phase should NOT be Failed (still under cap)
 				Expect(analysis.Status.Phase).NotTo(Equal(aianalysis.PhaseFailed), "Should NOT fail while under regeneration cap")
 			})

--- a/pkg/aianalysis/investigating_session_lost_adoption_test.go
+++ b/pkg/aianalysis/investigating_session_lost_adoption_test.go
@@ -1,0 +1,269 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Issue #2080: session-regeneration races with AF-correlated-session
+// adoption, exhausting the regeneration cap and failing investigations that
+// already succeeded.
+//
+// handleSessionLost (reached from a 404 on PollSession/GetSessionResult) is
+// the one remaining call site in the #2029 Part B adoption family that never
+// re-checked whether AF had already correlated a different, currently-active
+// KA session before treating the 404 as loss. A rapid, legitimate sequence
+// of session hand-offs (autonomous->interactive upgrade, one or more
+// AF-correlated takeovers) can each independently 404 on an
+// already-superseded session ID, incrementing Generation and exhausting the
+// 5-regeneration cap before adoption ever gets another chance to run --
+// permanently failing an AIAnalysis whose real investigation had already
+// completed.
+//
+// Business-level framing:
+//   - FedRAMP IR-4 (Incident Handling): a completed investigation must not be
+//     discarded because of a session-lifecycle race -- this is the same
+//     continuity guarantee #2029 Part B established for the poll-completed/
+//     poll-failed paths, now closed for the session-lost path too.
+//   - FedRAMP SI-4/AU-2/AU-3: the adoption remains an observable, durably
+//     audited event (unchanged: adoptCorrelatedSession's existing K8s Event +
+//     RecordAIAgentCall("session_adopted")) -- these tests verify that path
+//     fires instead of the SessionLost path, not a new audit mechanism.
+//   - The added backoff (RequeueAfter, not immediate Requeue) gives a
+//     legitimate multi-hop hand-off room to settle before the next
+//     regeneration attempt is even considered, directly addressing the
+//     incident's sub-2-second cascade window.
+package aianalysis_test
+
+import (
+	"context"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/tools/record"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/jordigilh/kubernaut/internal/controller/aianalysis"
+	"github.com/jordigilh/kubernaut/pkg/agentclient"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis/handlers"
+	"github.com/jordigilh/kubernaut/pkg/aianalysis/metrics"
+	"github.com/jordigilh/kubernaut/test/shared/mocks"
+)
+
+var _ = Describe("InvestigatingHandler Session-Lost Correlation Adoption (#2080)", func() {
+	var (
+		ctx        context.Context
+		mockClient *mocks.MockAgentClient
+		auditSpy   *sessionAuditSpy
+		recorder   *record.FakeRecorder
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		mockClient = mocks.NewMockAgentClient()
+		auditSpy = &sessionAuditSpy{}
+		recorder = record.NewFakeRecorder(20)
+	})
+
+	// Models the incident's exact race: the general mismatch check at the top
+	// of handleSessionBased runs before AF's correlation write lands
+	// (correlatedSequence's first entry), so polling proceeds against the
+	// now-stale session. By the time PollSession 404s, AF's correlation has
+	// landed (second entry) -- handleSessionLost's new re-check must adopt
+	// instead of treating this as loss.
+	Context("UT-AA-2080-001: race-closing adoption in handleSessionPollError (404)", func() {
+		It("adopts the newer correlated session instead of incrementing Generation", func() {
+			isChecker := &mockISChecker{
+				hasSession: true,
+				correlatedSequence: []correlatedSessionStub{
+					{id: "", active: false},                  // general mismatch check: not landed yet
+					{id: "ka-session-new-001", active: true}, // session-lost re-check: landed now
+				},
+			}
+			mockClient.WithSessionPollError(&agentclient.APIError{StatusCode: 404, Message: "Session not found"})
+
+			handler := handlers.NewInvestigatingHandler(
+				mockClient, ctrl.Log.WithName("test-2080-001"), metrics.NewMetrics(), auditSpy,
+				handlers.WithSessionMode(),
+				handlers.WithRecorder(recorder),
+				handlers.WithInvestigationSessionChecker(isChecker),
+			)
+
+			analysis := adoptionTestAnalysis("rr-2080-001", "ka-session-old-001", true)
+
+			result, err := handler.Handle(ctx, analysis)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeTrue(), "must requeue immediately to poll the newly adopted session")
+
+			By("verifying the business protection: a real/still-running session is never counted as a regeneration")
+			Expect(analysis.Status.KASession.ID).To(Equal("ka-session-new-001"))
+			Expect(analysis.Status.KASession.Generation).To(Equal(int32(0)),
+				"adoption on a 404 is not a regeneration -- the session was never actually lost")
+			Expect(analysis.Status.Phase).NotTo(Equal(aianalysis.PhaseFailed))
+
+			By("verifying no SessionLost audit/event fired for what turned out to be an adoption")
+			Expect(auditSpy.sessionLostEvents).To(BeEmpty())
+			Expect(auditSpy.agentCallEvents).To(HaveLen(1))
+			Expect(auditSpy.agentCallEvents[0].endpoint).To(Equal("session_adopted"))
+		})
+	})
+
+	// Symmetric to UT-AA-2080-001: closes the same race for the
+	// GetSessionResult 404 path (handleSessionGetResultError). Requires 3
+	// correlatedSequence entries because handleSessionPollCompleted's own
+	// #2029 Part B re-check (checkCorrelatedSessionBeforeFinalizing) sits
+	// between the general mismatch check and the GetSessionResult call.
+	Context("UT-AA-2080-002: race-closing adoption in handleSessionGetResultError (404)", func() {
+		It("adopts the newer correlated session instead of incrementing Generation", func() {
+			isChecker := &mockISChecker{
+				hasSession: true,
+				correlatedSequence: []correlatedSessionStub{
+					{id: "", active: false}, // general mismatch check: not landed yet
+					{id: "", active: false}, // finalize-recheck in handleSessionPollCompleted: still not landed
+					{id: "ka-session-new-002", active: true}, // session-lost re-check: landed now
+				},
+			}
+			mockClient.WithSessionPollStatus("completed")
+			mockClient.WithSessionResultError(&agentclient.APIError{StatusCode: 404, Message: "Session not found"})
+
+			handler := handlers.NewInvestigatingHandler(
+				mockClient, ctrl.Log.WithName("test-2080-002"), metrics.NewMetrics(), auditSpy,
+				handlers.WithSessionMode(),
+				handlers.WithRecorder(recorder),
+				handlers.WithInvestigationSessionChecker(isChecker),
+			)
+
+			analysis := adoptionTestAnalysis("rr-2080-002", "ka-session-old-002", true)
+
+			result, err := handler.Handle(ctx, analysis)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Requeue).To(BeTrue())
+
+			By("verifying the business protection: a real/still-running session is never counted as a regeneration")
+			Expect(analysis.Status.KASession.ID).To(Equal("ka-session-new-002"))
+			Expect(analysis.Status.KASession.Generation).To(Equal(int32(0)))
+			Expect(analysis.Status.Phase).NotTo(Equal(aianalysis.PhaseFailed))
+			Expect(mockClient.GetResultCallCount).To(Equal(1), "GetSessionResult must have been attempted (and 404'd) before adoption fires")
+
+			Expect(auditSpy.sessionLostEvents).To(BeEmpty())
+			Expect(auditSpy.agentCallEvents).To(HaveLen(1))
+			Expect(auditSpy.agentCallEvents[0].endpoint).To(Equal("session_adopted"))
+		})
+	})
+
+	// Regression guard: an isChecker IS configured (interactive mode), but
+	// genuinely reports no active correlation for this 404 -- the new
+	// re-check must fall through to the existing regeneration behavior
+	// unchanged (this, plus UT-AA-064-008/009/010 which run with no isChecker
+	// configured at all, together prove the #2080 change is fully additive).
+	Context("UT-AA-2080-003: regression -- no correlation available, session genuinely lost", func() {
+		It("still increments Generation and regenerates when nothing can be adopted", func() {
+			isChecker := &mockISChecker{
+				hasSession:       true,
+				correlatedActive: false, // no correlation recorded for this RR
+			}
+			mockClient.WithSessionPollError(&agentclient.APIError{StatusCode: 404, Message: "Session not found"})
+
+			handler := handlers.NewInvestigatingHandler(
+				mockClient, ctrl.Log.WithName("test-2080-003"), metrics.NewMetrics(), auditSpy,
+				handlers.WithSessionMode(),
+				handlers.WithRecorder(recorder),
+				handlers.WithInvestigationSessionChecker(isChecker),
+			)
+
+			analysis := adoptionTestAnalysis("rr-2080-003", "ka-session-003", true)
+
+			result, err := handler.Handle(ctx, analysis)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(analysis.Status.KASession.Generation).To(Equal(int32(1)), "must still regenerate when adoption genuinely finds nothing")
+			Expect(analysis.Status.KASession.ID).To(BeEmpty())
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0), "#2080: regeneration retry now backs off instead of an immediate tight-loop requeue")
+			Expect(auditSpy.sessionLostEvents).To(HaveLen(1))
+		})
+	})
+
+	// #2080 Option 2: the regeneration retry must back off (RequeueAfter)
+	// rather than requeue immediately (Requeue: true) -- gives a legitimate
+	// hand-off cascade room to settle before the next regeneration attempt,
+	// shrinking the exact race window UT-AA-2080-001/002 close structurally.
+	// Reuses the shared, DD-SHARED-001-compliant ErrorClassifier.GetRetryDelay
+	// already used by handleError (BR-AI-009), keyed on session.Generation
+	// instead of ConsecutiveFailures.
+	Context("UT-AA-2080-004: session-lost regeneration backs off instead of tight-looping", func() {
+		It("requeues with a positive, generation-scaled delay, not immediately", func() {
+			analysis := adoptionTestAnalysis("rr-2080-004", "ka-session-004", false)
+			analysis.Status.KASession.Generation = 0
+
+			mockClient.WithSessionPollError(&agentclient.APIError{StatusCode: 404, Message: "Session not found"})
+
+			handler := handlers.NewInvestigatingHandler(
+				mockClient, ctrl.Log.WithName("test-2080-004"), metrics.NewMetrics(), auditSpy,
+				handlers.WithSessionMode(),
+				handlers.WithRecorder(recorder),
+			)
+
+			result, err := handler.Handle(ctx, analysis)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(analysis.Status.KASession.Generation).To(Equal(int32(1)))
+			Expect(result.Requeue).To(BeFalse(), "must use RequeueAfter backoff, not an immediate Requeue")
+			Expect(result.RequeueAfter).To(BeNumerically(">", 500*time.Millisecond),
+				"backoff for the first regeneration must be meaningfully non-zero")
+			Expect(result.RequeueAfter).To(BeNumerically("<", 10*time.Second),
+				"backoff must stay well under the investigation's overall time budget")
+		})
+	})
+
+	// Incident reproduction at unit level: a cascade of 4 rapid, legitimate
+	// hand-off-correlated 404s (one below the 5-regeneration cap) must each
+	// adopt rather than regenerate, so Generation never moves and the
+	// AIAnalysis never fails -- directly modeling the incident's "6 sessions
+	// in 1.1s, cap exhausted 440ms after the real session had already
+	// completed" timeline.
+	Context("UT-AA-2080-005: repeated hand-off cascade never exhausts the regeneration cap", func() {
+		It("adopts on every 404 in the cascade instead of accumulating Generation", func() {
+			handOffs := []string{"ka-session-hop-1", "ka-session-hop-2", "ka-session-hop-3", "ka-session-hop-4"}
+			var sequence []correlatedSessionStub
+			for _, id := range handOffs {
+				sequence = append(sequence,
+					correlatedSessionStub{id: "", active: false}, // general mismatch check: not landed yet
+					correlatedSessionStub{id: id, active: true},  // session-lost re-check: landed
+				)
+			}
+			isChecker := &mockISChecker{hasSession: true, correlatedSequence: sequence}
+			mockClient.WithSessionPollError(&agentclient.APIError{StatusCode: 404, Message: "Session not found"})
+
+			handler := handlers.NewInvestigatingHandler(
+				mockClient, ctrl.Log.WithName("test-2080-005"), metrics.NewMetrics(), auditSpy,
+				handlers.WithSessionMode(),
+				handlers.WithRecorder(recorder),
+				handlers.WithInvestigationSessionChecker(isChecker),
+			)
+
+			analysis := adoptionTestAnalysis("rr-2080-005", "ka-session-old-005", true)
+
+			for i, id := range handOffs {
+				result, err := handler.Handle(ctx, analysis)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(result.Requeue).To(BeTrue(), "hop %d must requeue immediately to poll the newly adopted session", i)
+				Expect(analysis.Status.KASession.ID).To(Equal(id), "hop %d must adopt the correlated session", i)
+			}
+
+			Expect(analysis.Status.KASession.Generation).To(Equal(int32(0)),
+				"none of the 4 hand-offs should have counted as a regeneration")
+			Expect(analysis.Status.Phase).NotTo(Equal(aianalysis.PhaseFailed),
+				"the cap (5) must never be threatened by a cascade of legitimate adoptions")
+			Expect(auditSpy.sessionLostEvents).To(BeEmpty())
+			Expect(auditSpy.agentCallEvents).To(HaveLen(len(handOffs)))
+		})
+	})
+})

--- a/pkg/aianalysis/investigation_timeout_test.go
+++ b/pkg/aianalysis/investigation_timeout_test.go
@@ -221,7 +221,9 @@ var _ = Describe("AA-Side Investigation Timeout — #1078", func() {
 			Expect(analysis.Status.KASession.Generation).To(Equal(int32(1)),
 				"GetSessionResult 404 must trigger handleSessionLost regeneration (AA-HIGH-1)")
 			Expect(analysis.Status.KASession.ID).To(BeEmpty(), "session ID should be cleared for re-submit")
-			Expect(result.Requeue).To(BeTrue(), "should requeue immediately for re-submit")
+			// #2080: backs off instead of requeuing immediately (see UT-AA-064-008).
+			Expect(result.Requeue).To(BeFalse())
+			Expect(result.RequeueAfter).To(BeNumerically(">", 0), "should back off before resubmit, not requeue immediately")
 			Expect(analysis.Status.Phase).To(Equal(aianalysis.PhaseInvestigating),
 				"should not use handleError terminal path on result 404")
 		})

--- a/pkg/apifrontend/agent/phase_guard.go
+++ b/pkg/apifrontend/agent/phase_guard.go
@@ -574,6 +574,24 @@ func enforceGroundingGuard(ctx tool.Context, args map[string]any) {
 				}
 			}
 		}
+		// #2073: when no authoritative InvestigateRCA was available to fully
+		// substitute above (summary-only grounding, a Provisional-severity
+		// triage guess, or a malformed investigate rca payload), args["rca"]
+		// is still whatever the LLM supplied. tool_calls_count/llm_turns are
+		// no longer schema-required (ka_tools.go RCAData omitempty), but the
+		// LLM is still never instructed how to compute them -- backfilling
+		// an honest zero (rather than leaving whatever value the LLM
+		// invented) prevents a fabricated-looking count from reaching the
+		// AU-3 structured artifact. severity/confidence/causal_chain/target
+		// remain LLM-authored here -- unlike the two bookkeeping fields,
+		// there is genuinely nothing authoritative in AF's state to
+		// substitute for them in this branch (see canonicalGroundedRCA doc).
+		if _, isRCAData := args["rca"].(*tools.RCAData); !isRCAData {
+			if rcaMap, ok := args["rca"].(map[string]any); ok {
+				rcaMap["tool_calls_count"] = 0
+				rcaMap["llm_turns"] = 0
+			}
+		}
 		return
 	}
 

--- a/pkg/apifrontend/agent/phase_guard_test.go
+++ b/pkg/apifrontend/agent/phase_guard_test.go
@@ -745,8 +745,16 @@ var _ = Describe("Phase Guard — Content Grounding Guard (#2023)", func() {
 		_, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(args["rca"]).To(Equal(fabricatedArgs()["rca"]),
-			"with no structured rca to pass through, the harness has nothing authoritative to substitute")
+		rca, ok := args["rca"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(rca["severity"]).To(Equal(fabricatedArgs()["rca"].(map[string]any)["severity"]),
+			"with no structured rca to pass through, the harness has nothing authoritative to substitute for severity/confidence/causal_chain")
+		Expect(rca["confidence"]).To(Equal(fabricatedArgs()["rca"].(map[string]any)["confidence"]))
+		Expect(rca["causal_chain"]).To(Equal(fabricatedArgs()["rca"].(map[string]any)["causal_chain"]))
+		Expect(rca["tool_calls_count"]).To(Equal(0),
+			"#2073: backfilled with an honest zero rather than left for the LLM to fabricate a plausible-looking count")
+		Expect(rca["llm_turns"]).To(Equal(0),
+			"#2073: backfilled with an honest zero rather than left for the LLM to fabricate a plausible-looking count")
 	})
 
 	It("UT-AF-2023-012: clears a stale rca pass-through after a later investigate call that reported no rca", func() {
@@ -766,8 +774,14 @@ var _ = Describe("Phase Guard — Content Grounding Guard (#2023)", func() {
 		_, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(args["rca"]).To(Equal(fabricatedArgs()["rca"]),
+		rca, ok := args["rca"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(rca["severity"]).To(Equal(fabricatedArgs()["rca"].(map[string]any)["severity"]),
 			"the first call's rca must not leak into a present_decision grounded by the second, rca-less call")
+		Expect(rca["tool_calls_count"]).To(Equal(0),
+			"#2073: backfilled with an honest zero rather than left for the LLM to fabricate a plausible-looking count")
+		Expect(rca["llm_turns"]).To(Equal(0),
+			"#2073: backfilled with an honest zero rather than left for the LLM to fabricate a plausible-looking count")
 	})
 
 	It("UT-AF-2023-013: overrides present_decision content when kubernaut_investigate's shadow-agent alignment verdict is not aligned, even with summary/rca present", func() {
@@ -844,9 +858,15 @@ var _ = Describe("Phase Guard — Content Grounding Guard (#2023)", func() {
 		_, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(args["rca"]).To(Equal(fabricatedArgs()["rca"]),
+		rca, ok := args["rca"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(rca["severity"]).To(Equal(fabricatedArgs()["rca"].(map[string]any)["severity"]),
 			"#2068: a Provisional (AF-synthesized severity-triage guess, not a genuine KA finding) rca must "+
 				"not clobber present_decision's own rca -- same treatment as 'no structured rca at all' (UT-AF-2023-011)")
+		Expect(rca["tool_calls_count"]).To(Equal(0),
+			"#2073: backfilled with an honest zero rather than left for the LLM to fabricate a plausible-looking count")
+		Expect(rca["llm_turns"]).To(Equal(0),
+			"#2073: backfilled with an honest zero rather than left for the LLM to fabricate a plausible-looking count")
 	})
 
 	It("UT-AF-2068-004: still overwrites present_decision's rca when kubernaut_investigate's rca is genuinely KA-reported (Provisional unset/false)", func() {
@@ -888,8 +908,14 @@ var _ = Describe("Phase Guard — Content Grounding Guard (#2023)", func() {
 		_, err := before(toolCtx, fakeTool{name: "kubernaut_present_decision"}, args)
 		Expect(err).NotTo(HaveOccurred())
 
-		Expect(args["rca"]).To(Equal(fabricatedArgs()["rca"]),
+		rca, ok := args["rca"].(map[string]any)
+		Expect(ok).To(BeTrue())
+		Expect(rca["severity"]).To(Equal(fabricatedArgs()["rca"].(map[string]any)["severity"]),
 			"a malformed rca payload has nothing authoritative to substitute, same as UT-AF-2023-011")
+		Expect(rca["tool_calls_count"]).To(Equal(0),
+			"#2073: backfilled with an honest zero rather than left for the LLM to fabricate a plausible-looking count")
+		Expect(rca["llm_turns"]).To(Equal(0),
+			"#2073: backfilled with an honest zero rather than left for the LLM to fabricate a plausible-looking count")
 	})
 })
 

--- a/pkg/apifrontend/tools/ka_tools.go
+++ b/pkg/apifrontend/tools/ka_tools.go
@@ -328,12 +328,18 @@ func NewSelectWorkflowTool(mcpClient ka.MCPClient, auditor audit.Emitter) (tool.
 // This field is required — ADK schema validation enforces self-correction
 // if omitted by the LLM (#1396).
 type RCAData struct {
-	Severity       string   `json:"severity"`
-	Confidence     float64  `json:"confidence"`
-	CausalChain    []string `json:"causal_chain,omitempty"`
-	Target         string   `json:"target"`
-	ToolCallsCount int      `json:"tool_calls_count"`
-	LLMTurns       int      `json:"llm_turns"`
+	Severity    string   `json:"severity"`
+	Confidence  float64  `json:"confidence"`
+	CausalChain []string `json:"causal_chain,omitempty"`
+	Target      string   `json:"target"`
+	// ToolCallsCount and LLMTurns are omitempty (#2073): prompt.txt never
+	// instructs the LLM to compute these bookkeeping fields, so marking
+	// them required made ADK's schema validation reject every
+	// kubernaut_present_decision call. The harness backfills an
+	// authoritative value where available (canonicalGroundedRCA,
+	// enforceGroundingGuard) rather than relying on the LLM to supply them.
+	ToolCallsCount int `json:"tool_calls_count,omitempty"`
+	LLMTurns       int `json:"llm_turns,omitempty"`
 }
 
 type PresentDecisionArgs struct {

--- a/pkg/apifrontend/tools/present_decision_test.go
+++ b/pkg/apifrontend/tools/present_decision_test.go
@@ -3,6 +3,7 @@ package tools_test
 import (
 	"encoding/json"
 
+	"github.com/google/jsonschema-go/jsonschema"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -100,6 +101,43 @@ var _ = Describe("present_decision", func() {
 		Expect(decoded.CausalChain).To(HaveLen(3))
 		Expect(decoded.ToolCallsCount).To(Equal(19))
 		Expect(decoded.LLMTurns).To(Equal(17))
+	})
+
+	It("UT-AF-2073-001: SI-10 RCAData's ADK-generated JSON schema does not require tool_calls_count/llm_turns", func() {
+		// #2073: prompt.txt never instructs the LLM to compute tool_calls_count
+		// or llm_turns, but the ADK-generated schema (github.com/google/
+		// jsonschema-go) marks every non-omitempty field as required --
+		// causing every kubernaut_present_decision call to fail schema
+		// validation before the handler ever runs.
+		schema, err := jsonschema.For[tools.RCAData](nil)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(schema.Required).NotTo(ContainElement("tool_calls_count"),
+			"the LLM is never told to supply tool_calls_count -- marking it required makes every present_decision call fail schema validation (#2073)")
+		Expect(schema.Required).NotTo(ContainElement("llm_turns"),
+			"the LLM is never told to supply llm_turns -- marking it required makes every present_decision call fail schema validation (#2073)")
+		Expect(schema.Required).To(ContainElement("severity"),
+			"fields the LLM IS expected to supply must remain required")
+	})
+
+	It("UT-AF-2073-002: AU-3 RCAData omits zero-value tool_calls_count/llm_turns from JSON but still round-trips genuine values", func() {
+		rca := tools.RCAData{Severity: "critical", Confidence: 0.9}
+		data, err := json.Marshal(rca)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data)).NotTo(ContainSubstring("tool_calls_count"),
+			"an unset count must not appear in the payload the LLM is never told to populate (#2073)")
+		Expect(string(data)).NotTo(ContainSubstring("llm_turns"))
+
+		rcaWithCounts := tools.RCAData{Severity: "critical", Confidence: 0.9, ToolCallsCount: 5, LLMTurns: 2}
+		data2, err := json.Marshal(rcaWithCounts)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(data2)).To(ContainSubstring(`"tool_calls_count":5`),
+			"a genuinely supplied count must still round-trip correctly (no regression vs UT-AF-1396-001)")
+		Expect(string(data2)).To(ContainSubstring(`"llm_turns":2`))
+
+		var decoded tools.RCAData
+		Expect(json.Unmarshal(data2, &decoded)).To(Succeed())
+		Expect(decoded.ToolCallsCount).To(Equal(5))
+		Expect(decoded.LLMTurns).To(Equal(2))
 	})
 
 	It("UT-AF-1396-002: AU-3 WorkflowOption.Parameters serializes as JSON object", func() {

--- a/test/e2e/apifrontend/structured_decision_e2e_test.go
+++ b/test/e2e/apifrontend/structured_decision_e2e_test.go
@@ -302,8 +302,17 @@ var _ = Describe("Structured Decision Payload E2E — #1395 #1396", Ordered, Lab
 		Expect(payload.RCA.Confidence).To(BeNumerically("~", 0.92, 0.01))
 		Expect(payload.RCA.CausalChain).To(HaveLen(3))
 		Expect(payload.RCA.Target).To(Equal("Deployment/data-processor in production"))
-		Expect(payload.RCA.ToolCallsCount).To(Equal(19))
-		Expect(payload.RCA.LLMTurns).To(Equal(17))
+		// #2073: tool_calls_count/llm_turns are mock-LLM-scripted values in
+		// af_structured_decision's present_decision tool_call (mock-llm.yaml)
+		// -- exactly the LLM-invented bookkeeping enforceGroundingGuard's
+		// backfill now overrides with an honest 0, since groundSessionAlt2's
+		// seed-only investigate call never populates
+		// session.StateKeyGroundedRCA with authoritative total_tool_calls/
+		// total_llm_turns to substitute instead (phase_guard.go
+		// canonicalGroundedRCA). severity/confidence/causal_chain/target
+		// above remain LLM-authored pass-through and are unaffected.
+		Expect(payload.RCA.ToolCallsCount).To(Equal(0))
+		Expect(payload.RCA.LLMTurns).To(Equal(0))
 
 		By("Verifying extended workflow options")
 		Expect(payload.Options).To(HaveLen(3))


### PR DESCRIPTION
## Summary

Consolidated fix for three issues (single PR per runner-capacity constraint):

- **#2073**: `kubernaut_present_decision` failed ADK schema validation on every call because `RCAData.ToolCallsCount`/`LLMTurns` were schema-required even though `prompt.txt` never instructs the LLM to compute them. Fixed by making both fields `omitempty` (matching how `github.com/google/jsonschema-go` derives its `required` list), plus a defense-in-depth backfill in `enforceGroundingGuard` so the two bookkeeping fields are set to an honest `0` instead of trusting the LLM's own transcription when no authoritative KA-reported RCA is available to substitute.
- **#2075**: `kubernaut_complete_no_action` failed with "no active interactive session" when it raced `investigate.go`'s `no_matching_workflows` auto-close (which releases the MCP lease asynchronously after the response is already sent). Fixed with a small, self-expiring `AutoCloseTombstone`, written only at the exact race-causing call site and read only at the exact race-affected call site, returning a new `already_resolved` status on a hit rather than duplicating the audit/completion the original auto-close already performed.
- **#2080**: `AIAnalysis`'s `handleSessionLost` (404 on session poll/result) never re-checked whether AF had already correlated a different, currently-active KA session before treating the 404 as loss -- the one remaining #2029 Part B adoption call site missing this guard. A rapid, legitimate session hand-off cascade (autonomous→interactive upgrade, one or more takeovers) could each independently 404 on an already-superseded session ID, exhausting the 5-regeneration cap before adoption caught up, permanently failing an investigation that had already completed. Fixed by reusing the existing `tryAdoptCorrelatedSession` helper before counting a 404 as a regeneration, plus backing off the regeneration retry (`RequeueAfter` via the existing `ErrorClassifier.GetRetryDelay`) instead of an immediate tight-loop requeue.

All three cycles followed RED → GREEN → CHECKPOINT W → REFACTOR. See the commits for the TDD progression per issue.

## Test plan

- `UT-AF-2073-001`: RCAData's ADK-generated JSON schema no longer requires `tool_calls_count`/`llm_turns`.
- `UT-AF-2073-002`: RCAData still round-trips genuine values, omits zero-value bookkeeping fields.
- `UT-AF-2023-011/012`, `UT-AF-2068-001/005` (updated): summary-only/Provisional/malformed-rca grounding paths backfill the two fields to `0`.
- `UT-KA-2075-001`: `AutoCloseTombstone` Mark/WasRecentlyAutoClosed round-trip, TTL expiry, concurrency- and nil-safety.
- `UT-KA-2075-002`: `complete_no_action.Handle`'s tombstone fallback logic (fake tombstone, isolated).
- `IT-KA-2075-001`: the real `no_matching_workflows` → `complete_no_action` race, through both tools' actual production `Handle()` methods.
- `UT-AA-2080-001/002`: adoption fires on a 404 from `PollSession`/`GetSessionResult` when AF has since correlated a newer active session.
- `UT-AA-2080-003`: regression guard -- adoption unavailable falls through to normal regeneration.
- `UT-AA-2080-004`: regeneration retry backs off (`RequeueAfter`) instead of an immediate tight-loop requeue.
- `UT-AA-2080-005`: a 4-hop hand-off cascade never moves `Generation`.
- `UT-AA-064-008/009`, `UT-AA-1390-022`, `UT-AA-1351-004` (updated): expectations adjusted for the new backoff behavior.
- `go build ./...` and `go test ./... -run=^$` (compile-only) both pass clean across the entire repo.
- `golangci-lint run` reports 0 issues on all touched packages.
- Full `pkg/aianalysis` unit suite (458 specs) green.

## Out of scope (tracked separately)

- Filed #2078 for the ADK model-generation-loop circuit-breaker gap QE flagged in a [follow-up comment](https://github.com/jordigilh/kubernaut/issues/2073#issuecomment-5243422594) -- targeting the `v1.6` milestone on `main`, since it's new cross-cutting functionality (requiring its own DD) rather than a defect fix, and doesn't block this PR.
- #2080's suggested direction 3 (reconsidering whether `Generation` should retroactively "forgive" a regeneration immediately superseded by adoption) is not implemented as a follow-up issue: once this fix lands, adoption bypasses `Generation` entirely, so the residual case direction 3 would address is a narrow, unevidenced timing edge case the backoff above already shrinks well below the incident's observed cascade window. Documented as an accepted residual risk in `handleSessionLost`'s doc comment instead.

Closes #2073, closes #2075, closes #2080.

Made with [Cursor](https://cursor.com)
