### PR TITLE
fix(kubernautagent,apifrontend,aianalysis): workflow_discovery hang from silent gate-retry LLM calls + tool_call_start wire-format mismatch (#2086, #2089)

### DIFF
--- a/internal/kubernautagent/investigator/gate_keepalive_2086_test.go
+++ b/internal/kubernautagent/investigator/gate_keepalive_2086_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/enrichment"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/investigator"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/parser"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/prompt"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+	katypes "github.com/jordigilh/kubernaut/pkg/kubernautagent/types"
+)
+
+// firstToolCallStartToolName scans events for the first EventTypeToolCallStart
+// and returns its "tool_name" field, or ("", false) if none was emitted.
+func firstToolCallStartToolName(events []session.InvestigationEvent) (string, bool) {
+	for i := range events {
+		if events[i].Type != session.EventTypeToolCallStart {
+			continue
+		}
+		var data map[string]interface{}
+		if json.Unmarshal(events[i].Data, &data) != nil {
+			continue
+		}
+		toolName, _ := data["tool_name"].(string)
+		return toolName, true
+	}
+	return "", false
+}
+
+// #2086 (BR-INTERACTIVE-010, FedRAMP SI-4): sameKindValidationGate,
+// apiVersionValidationGate, and RunRCAExtractionFromConversation each issue a
+// second, non-streamed llm.ChatWithParams call that emits zero events to the
+// investigation sink for the duration of that LLM round-trip. Live-cluster
+// forensics on rr-cc99762025f0-5977eb36 showed this silent gap (~87s in the
+// observed incident) exceeds AF's 60s bridge-inactivity timeout
+// (bridgeEventsCollectSummary), causing AF to falsely report the interactive
+// investigation as "completed" with an empty RCA — the driving agent then
+// never calls discover_workflows. These specs drive a real Investigator
+// through its real production event-sink wiring and prove each of the 3
+// silent call sites now emits an EventTypeToolCallStart keepalive (which
+// resets AF's inactivity timer without polluting the RCA summary — see
+// UT-AF-2086-006 for the summary-pollution regression guard) before issuing
+// its retry/extraction LLM call.
+var _ = Describe("#2086: silent gate-retry LLM calls must emit a keepalive to the investigation sink", func() {
+
+	Describe("UT-KA-2086-001: sameKindValidationGate emits a keepalive during its retry LLM call", func() {
+		It("should emit an EventTypeToolCallStart event around the gate-retry LLM call so AF's bridge inactivity timer resets (#2086)", func() {
+			eventCh := make(chan session.InvestigationEvent, 64)
+			ctx := session.WithEventSink(context.Background(), eventCh)
+
+			signal := katypes.SignalContext{
+				ResourceKind: "Pod",
+				ResourceName: "api-server-xyz",
+				Name:         "api-server-xyz",
+				Namespace:    "production",
+				Severity:     "critical",
+				Message:      "Pod OOMKilled repeatedly",
+			}
+
+			mockClient := &gateMockLLMClient{
+				responses: []llm.ChatResponse{
+					// Turn 1: RCA target kind == signal.ResourceKind ("Pod") -> same-kind gate fires.
+					{Message: llm.Message{Role: "assistant", Content: `{
+						"rca_summary":"Pod OOMKilled",
+						"confidence":0.85,
+						"remediation_target":{"kind":"Pod","name":"api-server-xyz","namespace":"production"}
+					}`}},
+					// Gate retry: LLM re-targets the parent Deployment. This is the silent,
+					// non-streamed llm.ChatWithParams call Fix 1 wraps with a keepalive.
+					{Message: llm.Message{Role: "assistant", Content: `{
+						"rca_summary":"Deployment memory limit too low",
+						"confidence":0.85,
+						"remediation_target":{"kind":"Deployment","name":"api-server","namespace":"production","api_version":"apps/v1"}
+					}`}},
+					gateWfToolResp(`{"workflow_id":"increase-memory-limit","confidence":0.9}`),
+				},
+			}
+
+			logger := logr.Discard()
+			store := &gateRecordingAuditStore{}
+			builder, _ := prompt.NewBuilder()
+			enricher := enrichment.NewEnricher(&gateK8sClient{}, &gateDSClient{}, store, logger)
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: parser.NewResultParser(),
+				Enricher: enricher, AuditStore: store, Logger: logger,
+				MaxTurns: 15, PhaseTools: investigator.DefaultPhaseToolMap(),
+			})
+
+			go func() {
+				_, _ = inv.Investigate(ctx, signal)
+				close(eventCh)
+			}()
+
+			events := collectEvents(eventCh)
+			toolName, found := firstToolCallStartToolName(events)
+			Expect(found).To(BeTrue(),
+				"UT-KA-2086-001: sameKindValidationGate's silent retry LLM call must emit a keepalive "+
+					"EventTypeToolCallStart event, or AF's bridge-inactivity timer (60s) can starve during "+
+					"the LLM round-trip and falsely report the investigation as completed (#2086)")
+			Expect(toolName).NotTo(BeEmpty(),
+				"UT-KA-2086-001: keepalive event must carry a non-empty tool_name so AF's "+
+					"FormatEventForUser can render status text once the tool_name/tool key mismatch is "+
+					"fixed (Fix 5)")
+		})
+	})
+
+	Describe("UT-KA-2086-002: apiVersionValidationGate emits a keepalive during its retry LLM call", func() {
+		It("should emit an EventTypeToolCallStart event around the gate-retry LLM call so AF's bridge inactivity timer resets (#2086)", func() {
+			eventCh := make(chan session.InvestigationEvent, 64)
+			ctx := session.WithEventSink(context.Background(), eventCh)
+
+			signal := katypes.SignalContext{
+				ResourceKind: "Pod",
+				ResourceName: "etcd-operator-xyz",
+				Name:         "etcd-operator-xyz",
+				Namespace:    "demo-operator",
+				Severity:     "critical",
+				Message:      "RBAC denial on wrong API group",
+			}
+
+			mockClient := &gateMockLLMClient{
+				responses: []llm.ChatResponse{
+					{Message: llm.Message{Role: "assistant", Content: `{
+						"rca_summary":"Subscription etcd needs restart",
+						"confidence":0.85,
+						"remediation_target":{"kind":"Subscription","name":"etcd","namespace":"demo-operator"}
+					}`}},
+					// Gate retry: LLM provides api_version. Silent, non-streamed
+					// llm.ChatWithParams call Fix 1 wraps with a keepalive.
+					{Message: llm.Message{Role: "assistant", Content: `{
+						"rca_summary":"Subscription etcd needs restart",
+						"confidence":0.85,
+						"remediation_target":{"kind":"Subscription","name":"etcd","namespace":"demo-operator","api_version":"operators.coreos.com/v1alpha1"}
+					}`}},
+					gateWfToolResp(`{"workflow_id":"restart-sub","confidence":0.9}`),
+				},
+			}
+
+			logger := logr.Discard()
+			store := &gateRecordingAuditStore{}
+			builder, _ := prompt.NewBuilder()
+			enricher := enrichment.NewEnricher(&gateK8sClient{}, &gateDSClient{}, store, logger)
+			resolver := investigator.NewMapperScopeResolver(newAmbiguousSubscriptionMapper())
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: parser.NewResultParser(),
+				Enricher: enricher, AuditStore: store, Logger: logger,
+				MaxTurns: 15, PhaseTools: investigator.DefaultPhaseToolMap(), ScopeResolver: resolver,
+			})
+
+			go func() {
+				_, _ = inv.Investigate(ctx, signal)
+				close(eventCh)
+			}()
+
+			events := collectEvents(eventCh)
+			toolName, found := firstToolCallStartToolName(events)
+			Expect(found).To(BeTrue(),
+				"UT-KA-2086-002: apiVersionValidationGate's silent retry LLM call must emit a keepalive "+
+					"EventTypeToolCallStart event, or AF's bridge-inactivity timer (60s) can starve during "+
+					"the LLM round-trip and falsely report the investigation as completed (#2086)")
+			Expect(toolName).NotTo(BeEmpty(),
+				"UT-KA-2086-002: keepalive event must carry a non-empty tool_name so AF's "+
+					"FormatEventForUser can render status text once the tool_name/tool key mismatch is "+
+					"fixed (Fix 5)")
+		})
+	})
+
+	Describe("UT-KA-2086-003: RunRCAExtractionFromConversation emits a keepalive during its extraction LLM call", func() {
+		It("should emit an EventTypeToolCallStart event around the extraction LLM call so AF's bridge inactivity timer resets (#2086)", func() {
+			eventCh := make(chan session.InvestigationEvent, 64)
+			ctx := session.WithEventSink(context.Background(), eventCh)
+
+			mockClient := &gateMockLLMClient{
+				responses: []llm.ChatResponse{
+					// discover_workflows extraction call: silent, non-streamed
+					// llm.ChatWithParams call Fix 1 wraps with a keepalive.
+					{
+						Message: llm.Message{Role: "assistant", Content: ""},
+						ToolCalls: []llm.ToolCall{
+							{ID: "tc_extract", Name: investigator.SubmitResultToolName, Arguments: `{
+								"rca_summary":"OOMKilled",
+								"confidence":0.9,
+								"remediation_target":{"kind":"Deployment","name":"api","namespace":"ns","api_version":"apps/v1"}
+							}`},
+						},
+					},
+				},
+			}
+
+			logger := logr.Discard()
+			store := &gateRecordingAuditStore{}
+			builder, _ := prompt.NewBuilder()
+			enricher := enrichment.NewEnricher(&gateK8sClient{}, &gateDSClient{}, store, logger)
+			inv := investigator.New(investigator.Config{
+				Client: mockClient, Builder: builder, ResultParser: parser.NewResultParser(),
+				Enricher: enricher, AuditStore: store, Logger: logger,
+				MaxTurns: 15, PhaseTools: investigator.DefaultPhaseToolMap(),
+			})
+
+			messages := []llm.Message{
+				{Role: "user", Content: "investigate this pod"},
+				{Role: "assistant", Content: "Looking at the pod, it appears to be OOMKilled."},
+			}
+
+			result, err := inv.RunRCAExtractionFromConversation(ctx, messages, "corr-2086-003")
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result).NotTo(BeNil())
+			close(eventCh)
+
+			events := collectEvents(eventCh)
+			toolName, found := firstToolCallStartToolName(events)
+			Expect(found).To(BeTrue(),
+				"UT-KA-2086-003: RunRCAExtractionFromConversation's silent extraction LLM call must emit "+
+					"a keepalive EventTypeToolCallStart event, or AF's bridge-inactivity timer (60s) can "+
+					"starve during the LLM round-trip while an operator is waiting on kubernaut_discover_workflows (#2086)")
+			Expect(toolName).NotTo(BeEmpty(),
+				"UT-KA-2086-003: keepalive event must carry a non-empty tool_name so AF's "+
+					"FormatEventForUser can render status text once the tool_name/tool key mismatch is "+
+					"fixed (Fix 5)")
+		})
+	})
+})

--- a/internal/kubernautagent/investigator/investigator.go
+++ b/internal/kubernautagent/investigator/investigator.go
@@ -391,6 +391,12 @@ func (inv *Investigator) RunRCAExtractionFromConversation(ctx context.Context, m
 		Tools:    submitOnlyTools,
 	}
 
+	// #2086: this extraction call is non-streamed and emits no sink events
+	// for its duration. discover_workflows callers can wait through this
+	// call while AF's bridge-inactivity timer is running, so a keepalive is
+	// required to prevent AF from falsely reporting completion.
+	emitGateRetryKeepalive(ctx, "extracting_rca_from_conversation")
+
 	resp, err := llm.ChatWithParams(ctx, client, req, runtimeParams)
 	if err != nil {
 		return nil, fmt.Errorf("RCA extraction LLM call: %w", err)
@@ -1695,6 +1701,22 @@ func emitToSink(ctx context.Context, eventType string, turn int, phase string, d
 	default:
 		diagSendDrop.Add(1)
 	}
+}
+
+// emitGateRetryKeepalive emits an EventTypeToolCallStart keepalive around a
+// silent, non-streamed llm.ChatWithParams call (#2086: sameKindValidationGate,
+// apiVersionValidationGate, RunRCAExtractionFromConversation). Turn 0 is a
+// sentinel -- these calls happen outside runLLMLoop's normal turn counting.
+// EventTypeToolCallStart is used (not EventTypeReasoningDelta/TokenDelta)
+// specifically because bridgeEventsCollectSummary only accumulates the
+// latter two into the RCA summary returned to the driving agent; using a
+// text-accumulating event type would splice placeholder status text
+// directly into the summary (spike-discovered regression, see
+// UT-AF-2086-006).
+func emitGateRetryKeepalive(ctx context.Context, toolName string) {
+	emitToSink(ctx, session.EventTypeToolCallStart, 0, string(katypes.PhaseRCA), map[string]interface{}{
+		"tool_name": toolName,
+	})
 }
 
 // emitCancellationAudit emits an investigation-level cancellation event

--- a/internal/kubernautagent/investigator/investigator_gates.go
+++ b/internal/kubernautagent/investigator/investigator_gates.go
@@ -94,6 +94,15 @@ func (inv *Investigator) sameKindValidationGate(
 	gateEvent.Data["target_name"] = result.RemediationTarget.Name
 	audit.StoreBestEffort(ctx, inv.auditStore, gateEvent, inv.auditLog())
 
+	// #2086: this gate-retry LLM call is non-streamed (llm.ChatWithParams),
+	// so it emits zero sink events for the duration of the round-trip. A
+	// slow/retried backend call here can outlast AF's bridge-inactivity
+	// timeout, causing AF to falsely report the investigation as
+	// "completed" while the driving agent never calls discover_workflows.
+	// This keepalive resets that timer without polluting the RCA summary
+	// (EventTypeToolCallStart is never concatenated into summary text).
+	emitGateRetryKeepalive(ctx, "revalidating_remediation_target")
+
 	resp, err := llm.ChatWithParams(ctx, client, llm.ChatRequest{
 		Messages: retryMessages,
 		Tools:    submitOnlyTools,
@@ -247,6 +256,11 @@ func (inv *Investigator) apiVersionValidationGate(
 	gateEvent.Data["ambiguous_kind"] = kind
 	gateEvent.Data["conflicting_groups"] = groupList
 	audit.StoreBestEffort(ctx, inv.auditStore, gateEvent, inv.auditLog())
+
+	// #2086: same silent-gap risk as sameKindValidationGate above — this
+	// retry LLM call is non-streamed and emits no sink events during the
+	// round-trip.
+	emitGateRetryKeepalive(ctx, "resolving_api_version_ambiguity")
 
 	resp, retryErr := llm.ChatWithParams(ctx, client, llm.ChatRequest{
 		Messages: retryMessages,

--- a/internal/kubernautagent/investigator/tool_call_start_wire_contract_2086_test.go
+++ b/internal/kubernautagent/investigator/tool_call_start_wire_contract_2086_test.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package investigator_test
+
+import (
+	"context"
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+	afka "github.com/jordigilh/kubernaut/pkg/apifrontend/ka"
+	aftools "github.com/jordigilh/kubernaut/pkg/apifrontend/tools"
+	"github.com/jordigilh/kubernaut/pkg/kubernautagent/llm"
+)
+
+// IT-AF-2086-030 (FedRAMP SI-4: status text must actually reach the operator):
+// proves the real tool_call_start event KA puts on the wire (via the actual
+// emitToSink call site in runLLMLoop, not a hand-built fixture) is consumable
+// by AF's production FormatEventForUser, closing the loop across the KA/AF
+// package boundary. Regression target: #2086 Fix 5 -- KA emits key
+// "tool_name" (investigator.go) but AF's FormatEventForUser read "tool",
+// so genuine "Calling kubectl_get..." status text never rendered in
+// production; AF's own unit tests passed only because they hand-constructed
+// fixtures with the (wrong) "tool" key, never exercising the real KA
+// emission path.
+var _ = Describe("IT-AF-2086-030: tool_call_start wire contract between KA and AF", func() {
+	It("round-trips a real KA tool_call_start event through AF's FormatEventForUser and produces the display text", func() {
+		eventCh := make(chan session.InvestigationEvent, 64)
+		ctx := session.WithEventSink(context.Background(), eventCh)
+
+		mockClient := &cancelAwareMockClient{
+			responses: []llm.ChatResponse{
+				{
+					Message: llm.Message{Role: "assistant", Content: "investigating..."},
+					ToolCalls: []llm.ToolCall{
+						{ID: "tc_1", Name: "kubectl_describe", Arguments: `{"kind":"Pod","name":"test","namespace":"default"}`},
+					},
+					Usage: llm.TokenUsage{PromptTokens: 100, CompletionTokens: 50, TotalTokens: 150},
+				},
+				{
+					Message: llm.Message{
+						Role:    "assistant",
+						Content: `{"rca_summary":"pod OOM killed","confidence":0.9}`,
+					},
+					Usage: llm.TokenUsage{PromptTokens: 200, CompletionTokens: 100, TotalTokens: 300},
+				},
+			},
+		}
+
+		inv := streamTestInvestigator(mockClient)
+		go func() {
+			_, _ = inv.Investigate(ctx, streamSignal)
+			close(eventCh)
+		}()
+
+		events := collectEvents(eventCh)
+
+		var kaEvent *session.InvestigationEvent
+		for i := range events {
+			if events[i].Type == session.EventTypeToolCallStart {
+				kaEvent = &events[i]
+				break
+			}
+		}
+		Expect(kaEvent).NotTo(BeNil(), "KA must emit a tool_call_start event for the LLM-requested tool call")
+
+		// Simulate the actual wire hop: KA's InvestigationEvent is marshaled to
+		// JSON for the MCP LoggingMessage transport, then AF unmarshals the raw
+		// bytes into its own wire-compatible ka.InvestigationEvent type.
+		wireBytes, err := json.Marshal(kaEvent)
+		Expect(err).NotTo(HaveOccurred())
+
+		var afEvent afka.InvestigationEvent
+		Expect(json.Unmarshal(wireBytes, &afEvent)).To(Succeed())
+
+		displayText := aftools.FormatEventForUser(afEvent)
+		Expect(displayText).To(Equal("Calling kubectl_describe..."),
+			"AF's production FormatEventForUser must extract the tool name KA put on the wire under "+
+				"the \"tool_name\" key; a field-name mismatch here means real tool-call status text "+
+				"never renders in production (#2086 Fix 5)")
+	})
+})

--- a/internal/kubernautagent/mcp/tools/deferred_investigation_log_2086_test.go
+++ b/internal/kubernautagent/mcp/tools/deferred_investigation_log_2086_test.go
@@ -1,0 +1,159 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools_test
+
+import (
+	"context"
+	"errors"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+	mcptools "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+	"github.com/jordigilh/kubernaut/internal/kubernautagent/session"
+)
+
+// levelCaptureSink records every Info/Error call with its level, so tests
+// can assert the exact log level chosen for a given message. Unlike
+// logCaptureSink-style helpers (which discard Error calls entirely), this
+// sink is needed to prove a log entry was downgraded from Error to Info,
+// not merely that some Info entry exists.
+type levelCaptureSink struct {
+	entries []levelLogEntry
+}
+
+type levelLogEntry struct {
+	level string // "info" or "error"
+	msg   string
+}
+
+func (s *levelCaptureSink) Init(logr.RuntimeInfo)                  {}
+func (s *levelCaptureSink) Enabled(int) bool                       { return true }
+func (s *levelCaptureSink) WithValues(...interface{}) logr.LogSink { return s }
+func (s *levelCaptureSink) WithName(string) logr.LogSink           { return s }
+func (s *levelCaptureSink) Error(_ error, msg string, _ ...interface{}) {
+	s.entries = append(s.entries, levelLogEntry{level: "error", msg: msg})
+}
+func (s *levelCaptureSink) Info(_ int, msg string, _ ...interface{}) {
+	s.entries = append(s.entries, levelLogEntry{level: "info", msg: msg})
+}
+
+// levelFor returns the level of the first captured entry whose message
+// contains msg, or ("", false) if none was captured.
+func (s *levelCaptureSink) levelFor(msg string) (string, bool) {
+	for _, e := range s.entries {
+		if e.msg == msg {
+			return e.level, true
+		}
+	}
+	return "", false
+}
+
+// #2086 (BR-INTERACTIVE-010, FedRAMP AU-3): handleStart's launch-deferred
+// log line was previously always logged at Error level, even though
+// session.ErrSessionNotPending is a benign, expected race -- it fires when
+// the driving agent retries kubernaut_investigate action=start after a
+// prior call already launched the deferred session (exactly the kind of
+// retry #2086's false-"completed" report could trigger). An Error-level log
+// for an expected, harmless race pollutes on-call alerting/dashboards with
+// false-positive noise. Genuine failures (e.g. the deferred function itself
+// is missing) must remain at Error.
+var _ = Describe("#2086: LaunchDeferredInvestigation benign-retry log level", func() {
+
+	Describe("UT-KA-2086-006: benign ErrSessionNotPending race logs at Info, not Error", func() {
+		It("should log the launch-deferred failure at Info level when the session was already launched by a concurrent retry", func() {
+			sink := &levelCaptureSink{}
+			logger := logr.New(sink)
+
+			sessionMgr := &mockSessionManager{
+				takeoverSession: &mcpinternal.InteractiveSession{
+					SessionID:     "sess-2086-006",
+					CorrelationID: "rr-2086-006",
+				},
+			}
+			autoMgr := &interactiveAutoMgr{
+				pendingResult: "http-sess-2086-006",
+				pendingOK:     true,
+				launchErr:     session.ErrSessionNotPending,
+			}
+			runner := &mockInvestigatorRunner{}
+			recon := &mockContextReconstructor{turns: []mcpinternal.ConversationTurn{}}
+			auditStore := &recordingAuditStore{}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr,
+				mcptools.WithAuditStore(auditStore, logger),
+			)
+
+			out, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-2086-006",
+				Action: mcptools.ActionStart,
+			}, mcpinternal.UserInfo{Username: "charlie"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out.Status).To(Equal("started"))
+
+			level, found := sink.levelFor("start: failed to launch deferred investigation")
+			Expect(found).To(BeTrue(),
+				"UT-KA-2086-006: expected a launch-deferred log line to be emitted")
+			Expect(level).To(Equal("info"),
+				"UT-KA-2086-006: session.ErrSessionNotPending is a benign, expected retry race (#2086) "+
+					"and must not be logged at Error level, or on-call alerting/dashboards accumulate "+
+					"false-positive noise from routine driving-agent retries")
+		})
+	})
+
+	Describe("UT-KA-2086-006b: genuine launch failures remain at Error level (regression guard)", func() {
+		It("should still log at Error level for a non-benign launch failure", func() {
+			sink := &levelCaptureSink{}
+			logger := logr.New(sink)
+
+			sessionMgr := &mockSessionManager{
+				takeoverSession: &mcpinternal.InteractiveSession{
+					SessionID:     "sess-2086-006b",
+					CorrelationID: "rr-2086-006b",
+				},
+			}
+			autoMgr := &interactiveAutoMgr{
+				pendingResult: "http-sess-2086-006b",
+				pendingOK:     true,
+				launchErr:     errors.New("deferred investigation function unexpectedly nil"),
+			}
+			runner := &mockInvestigatorRunner{}
+			recon := &mockContextReconstructor{turns: []mcpinternal.ConversationTurn{}}
+			auditStore := &recordingAuditStore{}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr,
+				mcptools.WithAuditStore(auditStore, logger),
+			)
+
+			out, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-2086-006b",
+				Action: mcptools.ActionStart,
+			}, mcpinternal.UserInfo{Username: "charlie"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out.Status).To(Equal("started"))
+
+			level, found := sink.levelFor("start: failed to launch deferred investigation")
+			Expect(found).To(BeTrue(),
+				"UT-KA-2086-006b: expected a launch-deferred log line to be emitted")
+			Expect(level).To(Equal("error"),
+				"UT-KA-2086-006b: a genuine, unexpected launch failure must remain at Error level so "+
+					"real incidents are not silently downgraded alongside the benign retry race")
+		})
+	})
+})

--- a/internal/kubernautagent/mcp/tools/investigate.go
+++ b/internal/kubernautagent/mcp/tools/investigate.go
@@ -457,8 +457,20 @@ func (t *InvestigateTool) handleStart(ctx context.Context, input InvestigateInpu
 	}
 	if hasPending {
 		if launchErr := t.autoMgr.LaunchDeferredInvestigation(pendingID); launchErr != nil {
-			t.logger.Error(launchErr, "start: failed to launch deferred investigation",
-				"rr_id", input.RRID, "pending_session_id", pendingID)
+			// #2086: session.ErrSessionNotPending is a benign, expected race
+			// -- it fires when the driving agent retries action=start after
+			// a prior call already launched the deferred session (e.g. the
+			// retry a false-"completed" report from #2086 could trigger).
+			// Logging this at Error level pollutes on-call alerting with
+			// false-positive noise for routine retries; genuine failures
+			// (missing deferred function, unknown session) stay at Error.
+			if errors.Is(launchErr, session.ErrSessionNotPending) {
+				t.logger.Info("start: failed to launch deferred investigation",
+					"rr_id", input.RRID, "pending_session_id", pendingID, "reason", launchErr.Error())
+			} else {
+				t.logger.Error(launchErr, "start: failed to launch deferred investigation",
+					"rr_id", input.RRID, "pending_session_id", pendingID)
+			}
 		} else {
 			launchedPending = true
 			investigationSessionID = pendingID

--- a/pkg/aianalysis/handlers/investigating.go
+++ b/pkg/aianalysis/handlers/investigating.go
@@ -847,7 +847,38 @@ func (h *InvestigatingHandler) handleSessionIncidentResult(ctx context.Context, 
 	if err == nil {
 		h.setRetryCount(analysis, 0)
 	}
+
+	// #2086 Fix 4: KA's own session inactivity timeout (e.g. a 10-minute
+	// interactive-session idle limit) completes with no InvestigationResult
+	// ever produced. KA synthesizes a placeholder for this
+	// (synthesizeNilResult's default branch, internal/kubernautagent/server/handler.go)
+	// with has_workflow=false and human_review_reason="" -- ProcessIncidentResponse
+	// cannot distinguish this from a genuine "investigated and found no
+	// matching workflow" conclusion, so it always classifies both identically
+	// as SubReason=NoMatchingWorkflows. That is misleading: the investigation
+	// never actually reached a conclusion. Correct the classification here
+	// (response_processor.go stays untouched -- this fix's blast radius is
+	// contained to this file, per plan). FedRAMP AU-3 (truthful audit
+	// content) / SI-11 (accurate error handling).
+	if analysis.Status.SubReason == "NoMatchingWorkflows" && isSessionTimedOutWithoutResult(resp) {
+		analysis.Status.SubReason = "InvestigationInconclusive"
+		analysis.Status.HumanReviewReason = "investigation_inconclusive"
+		analysis.Status.Message = "KA session completed without producing a result " +
+			"(likely an inactivity timeout); the investigation did not reach a conclusion"
+	}
+
 	return result, err
+}
+
+// isSessionTimedOutWithoutResult reports whether resp is KA's nil-result
+// synthesis placeholder rather than a genuine investigation outcome. #2086:
+// this is the only signal available on the wire that distinguishes "the
+// session completed without KA ever producing a result" (e.g. an inactivity
+// timeout) from "KA investigated and concluded no workflow matches" --
+// synthesizeNilResult's default branch always sets exactly this Analysis text
+// with Confidence 0 and no other fields populated.
+func isSessionTimedOutWithoutResult(resp *agentclient.IncidentResponse) bool {
+	return resp.Analysis == "Investigation completed without result" && resp.Confidence == 0
 }
 
 // handleSessionPollFailed handles poll results where investigation has failed on KA side.

--- a/pkg/aianalysis/investigating_handler_session_test.go
+++ b/pkg/aianalysis/investigating_handler_session_test.go
@@ -379,6 +379,54 @@ var _ = Describe("InvestigatingHandler Session-Based Pull (BR-AA-HAPI-064)", fun
 			})
 		})
 
+		// IT-AA-2086-020: Poll completed via KA's own inactivity timeout,
+		// which synthesizes a nil result (has_workflow=false,
+		// human_review_reason=""). Must not be misclassified identically to
+		// a genuine "no matching workflows" conclusion. Driven through the
+		// real reconcile entry point (handler.Handle), not a direct call to
+		// handleSessionPollCompleted, so this proves the wiring end-to-end.
+		Context("IT-AA-2086-020: Poll completed via KA inactivity timeout (nil result, no human_review_reason)", func() {
+			It("should classify as InvestigationInconclusive, not NoMatchingWorkflows (#2086 Fix 4)", func() {
+				analysis := createSessionTestAnalysis()
+				analysis.Status.KASession = &aianalysisv1.KASession{
+					ID:         "session-timeout-001",
+					Generation: 0,
+					CreatedAt:  &metav1.Time{Time: time.Now().Add(-600 * time.Second)},
+				}
+
+				mockClient.WithSessionPollStatus("completed")
+				// #2086: mirrors KA's synthesizeNilResult default branch
+				// (internal/kubernautagent/server/handler.go) -- the exact
+				// wire shape produced when a user-driving session's own
+				// 10-minute inactivity timeout fires with no
+				// InvestigationResult ever set: has_workflow=false,
+				// human_review_reason="" (left unset), confidence=0.
+				mockClient.WithResponse(&agentclient.IncidentResponse{
+					IncidentID:       "session-timeout-001",
+					Analysis:         "Investigation completed without result",
+					NeedsHumanReview: agentclient.NewOptBool(false),
+					Confidence:       0,
+					Timestamp:        "2026-04-03T00:00:00Z",
+					Warnings:         []string{},
+				})
+
+				_, err := handler.Handle(ctx, analysis)
+
+				Expect(err).NotTo(HaveOccurred())
+				Expect(analysis.Status.Phase).To(Equal(aianalysis.PhaseFailed))
+				// #2086 Fix 4: must NOT be misclassified as a genuine "no
+				// matching workflows found" conclusion -- KA's investigation
+				// never reached one. FedRAMP AU-3 (truthful audit content) /
+				// SI-11 (accurate error handling).
+				Expect(analysis.Status.SubReason).NotTo(Equal("NoMatchingWorkflows"),
+					"#2086: a session that timed out with no result must not be reported as a genuine no-match conclusion")
+				Expect(analysis.Status.SubReason).To(Equal("InvestigationInconclusive"),
+					"#2086: distinguishable classification for a session that completed without producing any result")
+				Expect(analysis.Status.Message).NotTo(Equal("No workflow selected for remediation"),
+					"#2086: message must reflect the true timeout/no-result cause, not the generic no-match message")
+			})
+		})
+
 		// UT-AA-064-007: Polling interval is constant across all polls
 		// BR-AA-HAPI-064.8: Constant interval -- polling is not error recovery.
 		// Every poll uses the same configured interval regardless of PollCount.

--- a/pkg/apifrontend/tools/ka_investigate_mcp.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp.go
@@ -520,12 +520,28 @@ func HandleInvestigationMCPWithRegistry(ctx context.Context, mcpClient ka.MCPCli
 		logger.Info("bridgeEventsCollectSummary: starting blocking event bridge",
 			"rr_id", args.RRID, "session_id", result.SessionID, "ctx_err", ctx.Err())
 		bridgeCtx := WithRRID(ctx, args.RRID)
-		summary, rca, alignmentVerdict := bridgeEventsCollectSummary(bridgeCtx, result.Events, BridgeInactivityTimeout)
+		summary, rca, alignmentVerdict, bridgeCompleted := bridgeEventsCollectSummary(bridgeCtx, result.Events, BridgeInactivityTimeout)
+		var statusErr string
 		status := "completed"
-		if ctx.Err() != nil {
+		switch {
+		case ctx.Err() != nil:
 			status = "timeout"
 			logger.Info("bridgeEventsCollectSummary: context cancelled",
 				"rr_id", args.RRID, "ctx_err", ctx.Err(), "summary_len", len(summary))
+		case !bridgeCompleted:
+			// #2086: the bridge gave up (inactivity timeout or channel
+			// closed) without ever observing a genuine terminal KA event.
+			// KA's investigation may still be running (e.g. a silent
+			// gate-retry LLM call) -- reporting "completed" here is exactly
+			// the defect that caused #2086: the driving agent believed the
+			// investigation had finished with an empty RCA and never called
+			// discover_workflows. Report a truthful, distinct status with
+			// guidance to poll rather than retry.
+			status = "in_progress"
+			statusErr = "investigation is still in progress on the backend; poll kubernaut_get_remediation " +
+				"for the current status instead of retrying kubernaut_investigate"
+			logger.Info("bridgeEventsCollectSummary: bridge exited without a terminal event",
+				"rr_id", args.RRID, "summary_len", len(summary))
 		}
 		logger.Info("bridgeEventsCollectSummary: finished",
 			"rr_id", args.RRID, "status", status, "summary_len", len(summary))
@@ -583,6 +599,7 @@ func HandleInvestigationMCPWithRegistry(ctx context.Context, mcpClient ka.MCPCli
 			RCA:              rca,
 			Managed:          true,
 			AlignmentVerdict: alignmentVerdict,
+			Error:            statusErr,
 		}, nil
 	}
 
@@ -680,11 +697,18 @@ var NonBlockingBridgeTTL = 15 * time.Minute
 // so investigations of any wall-clock duration succeed as long as KA keeps
 // producing events (token deltas, tool calls, keepalives).
 // Exported so that tests can override it without modifying production code.
-var BridgeInactivityTimeout = 60 * time.Second
+//
+// #2086: set to 90s (was 60s) purely for headroom. DefaultToolCallTimeout
+// (KA's per-tool-call bound, #1949) is also 60s -- an uncoordinated tie with
+// zero margin between two independent timeouts. Fix 1's keepalives are the
+// primary fix for the silent-gate-retry class of bug; this bump is
+// defense-in-depth against any other single tool call that legitimately
+// takes close to the full 60s.
+var BridgeInactivityTimeout = 90 * time.Second
 
 // BridgeEventsCollectSummary is the exported entry point for bridgeEventsCollectSummary.
 // It is used by integration tests and the blocking MCP investigation path.
-func BridgeEventsCollectSummary(ctx context.Context, events <-chan ka.InvestigationEvent, inactivityTimeout time.Duration) (string, *InvestigateRCA, *katypes.AlignmentVerdictResult) {
+func BridgeEventsCollectSummary(ctx context.Context, events <-chan ka.InvestigationEvent, inactivityTimeout time.Duration) (string, *InvestigateRCA, *katypes.AlignmentVerdictResult, bool) {
 	return bridgeEventsCollectSummary(ctx, events, inactivityTimeout)
 }
 
@@ -697,7 +721,16 @@ func BridgeEventsCollectSummary(ctx context.Context, events <-chan ka.Investigat
 // previously this was only used locally to fire the human-facing SSE
 // alignment_check_failed notification and then discarded, leaving the #2023
 // grounding guard with no way to consult it.
-func bridgeEventsCollectSummary(ctx context.Context, events <-chan ka.InvestigationEvent, inactivityTimeout time.Duration) (string, *InvestigateRCA, *katypes.AlignmentVerdictResult) {
+//
+// The returned bool is `completed`: true only when the bridge exited because
+// it observed a genuine terminal KA event (EventTypeComplete, Cancelled, or
+// SessionEnded). Exiting via ctx.Done(), the inactivity timer, or the events
+// channel closing without ever seeing a terminal event all report
+// completed=false -- these are cases where KA's investigation may still be
+// running (#2086: the caller previously could not distinguish a silent
+// bridge-inactivity timeout from a genuine finish, so it told the driving
+// agent the investigation was "completed" with an empty RCA).
+func bridgeEventsCollectSummary(ctx context.Context, events <-chan ka.InvestigationEvent, inactivityTimeout time.Duration) (string, *InvestigateRCA, *katypes.AlignmentVerdictResult, bool) {
 	var summary strings.Builder
 	var rcaResult *InvestigateRCA
 	var verdictResult *katypes.AlignmentVerdictResult
@@ -708,14 +741,14 @@ func bridgeEventsCollectSummary(ctx context.Context, events <-chan ka.Investigat
 	for {
 		select {
 		case <-ctx.Done():
-			return summary.String(), rcaResult, verdictResult
+			return summary.String(), rcaResult, verdictResult, false
 		case <-inactivity.C:
-			return summary.String(), rcaResult, verdictResult
+			return summary.String(), rcaResult, verdictResult, false
 		case <-keepalive.C:
 			_ = launcher.EmitKeepaliveDotSafe(ctx)
 		case evt, ok := <-events:
 			if !ok {
-				return summary.String(), rcaResult, verdictResult
+				return summary.String(), rcaResult, verdictResult, false
 			}
 			inactivity.Reset(inactivityTimeout)
 			// #1438: Handle session_ended before generic emit to avoid double-emit.
@@ -729,7 +762,7 @@ func bridgeEventsCollectSummary(ctx context.Context, events <-chan ka.Investigat
 						"reason":   evt.Phase,
 						"terminal": true,
 					})
-				return summary.String(), rcaResult, verdictResult
+				return summary.String(), rcaResult, verdictResult, true
 			}
 			emitEventToA2A(ctx, evt, FormatEventForUser(evt))
 			switch evt.Type {
@@ -766,9 +799,9 @@ func bridgeEventsCollectSummary(ctx context.Context, events <-chan ka.Investigat
 						emitEarlyRCA(ctx, &rca)
 					}
 				}
-				return summary.String(), rcaResult, verdictResult
+				return summary.String(), rcaResult, verdictResult, true
 			case ka.EventTypeCancelled:
-				return summary.String(), rcaResult, verdictResult
+				return summary.String(), rcaResult, verdictResult, true
 			}
 		}
 	}
@@ -860,7 +893,12 @@ func FormatEventForUser(evt ka.InvestigationEvent) string {
 	case ka.EventTypeTokenDelta:
 		return extractJSONField(evt.Data, "delta")
 	case ka.EventTypeToolCallStart:
-		toolName := extractJSONField(evt.Data, "tool")
+		// #2086 Fix 5: KA's real emission (investigator.go's emitToSink calls,
+		// e.g. runLLMLoop's tool-dispatch block) uses key "tool_name" -- this
+		// previously read "tool", a wire-format mismatch AF's own unit tests
+		// never caught because they hand-constructed fixtures with the wrong
+		// key instead of exercising the real KA emission path.
+		toolName := extractJSONField(evt.Data, "tool_name")
 		if toolName != "" {
 			return "Calling " + toolName + "..."
 		}

--- a/pkg/apifrontend/tools/ka_investigate_mcp_test.go
+++ b/pkg/apifrontend/tools/ka_investigate_mcp_test.go
@@ -250,10 +250,34 @@ var _ = Describe("formatEventForUser — #1326 BR-MCP-008 event filtering", func
 		It("should format tool name with 'Calling ...' prefix", func() {
 			evt := ka.InvestigationEvent{
 				Type: ka.EventTypeToolCallStart,
-				Data: json.RawMessage(`{"tool":"kubectl_get"}`),
+				Data: json.RawMessage(`{"tool_name":"kubectl_get"}`),
 			}
 			result := tools.FormatEventForUser(evt)
 			Expect(result).To(Equal("Calling kubectl_get..."))
+		})
+	})
+
+	Describe("UT-AF-2086-007: tool_call_start key mismatch fix — reads tool_name, not tool", func() {
+		It("should extract the tool name from the real KA wire key \"tool_name\"", func() {
+			evt := ka.InvestigationEvent{
+				Type: ka.EventTypeToolCallStart,
+				Data: json.RawMessage(`{"tool_name":"kubectl_get"}`),
+			}
+			result := tools.FormatEventForUser(evt)
+			Expect(result).To(Equal("Calling kubectl_get..."),
+				"#2086: KA's real emission (investigator.go) uses the \"tool_name\" key -- "+
+					"FormatEventForUser must read it for tool-call status text to ever render")
+		})
+
+		It("should return empty string for the old (wrong) \"tool\" key, proving the mismatch is fixed and not just relocated", func() {
+			evt := ka.InvestigationEvent{
+				Type: ka.EventTypeToolCallStart,
+				Data: json.RawMessage(`{"tool":"kubectl_get"}`),
+			}
+			result := tools.FormatEventForUser(evt)
+			Expect(result).To(BeEmpty(),
+				"#2086: the old \"tool\" key never appears on KA's real wire format; a fixed "+
+					"FormatEventForUser must not silently keep accepting it")
 		})
 	})
 
@@ -393,7 +417,7 @@ var _ = Describe("A2A status channel routing — event type aware emission", fun
 			eventCh := make(chan ka.InvestigationEvent, 5)
 			eventCh <- ka.InvestigationEvent{
 				Type: ka.EventTypeToolCallStart,
-				Data: json.RawMessage(`{"tool":"kubectl_get"}`),
+				Data: json.RawMessage(`{"tool_name":"kubectl_get"}`),
 			}
 			eventCh <- ka.InvestigationEvent{Type: ka.EventTypeComplete}
 			close(eventCh)
@@ -538,7 +562,7 @@ var _ = Describe("A2A status channel routing — event type aware emission", fun
 			eventCh := make(chan ka.InvestigationEvent, 10)
 			eventCh <- ka.InvestigationEvent{
 				Type: ka.EventTypeToolCallStart,
-				Data: json.RawMessage(`{"tool":"kubectl_get"}`),
+				Data: json.RawMessage(`{"tool_name":"kubectl_get"}`),
 			}
 			eventCh <- ka.InvestigationEvent{
 				Type: ka.EventTypeReasoningDelta,
@@ -550,7 +574,7 @@ var _ = Describe("A2A status channel routing — event type aware emission", fun
 			}
 			eventCh <- ka.InvestigationEvent{
 				Type: ka.EventTypeToolCallStart,
-				Data: json.RawMessage(`{"tool":"kubectl_describe"}`),
+				Data: json.RawMessage(`{"tool_name":"kubectl_describe"}`),
 			}
 			eventCh <- ka.InvestigationEvent{Type: ka.EventTypeComplete}
 			close(eventCh)
@@ -1048,7 +1072,7 @@ var _ = Describe("HandleInvestigationMCPWithRegistry — blocking mode (A2A path
 					go func() {
 						eventCh <- ka.InvestigationEvent{
 							Type: ka.EventTypeToolCallStart,
-							Data: json.RawMessage(`{"tool":"kubectl_get"}`),
+							Data: json.RawMessage(`{"tool_name":"kubectl_get"}`),
 						}
 						eventCh <- ka.InvestigationEvent{
 							Type: ka.EventTypeReasoningDelta,
@@ -1078,6 +1102,213 @@ var _ = Describe("HandleInvestigationMCPWithRegistry — blocking mode (A2A path
 			Expect(result.Summary).To(Equal("Root cause: memory limit too low."))
 			Expect(result.Summary).NotTo(ContainSubstring("kubectl_get"))
 		})
+	})
+})
+
+// #2086 (BR-INTERACTIVE-010, FedRAMP AU-3/SI-11): bridgeEventsCollectSummary
+// previously returned identically whether it received a genuine terminal KA
+// event (EventTypeComplete/Cancelled/SessionEnded) or simply gave up after
+// its inactivity timer fired — the caller's status := "completed" only
+// checked the OUTER ctx.Err(), never why the bridge itself returned. Live
+// forensics on rr-cc99762025f0-5977eb36 showed KA's silent gate-retry LLM
+// calls (see gate_keepalive_2086_test.go) blow past the 60s inactivity
+// budget, so AF told the driving agent the investigation was "completed"
+// with an empty RCA — the agent then never called discover_workflows. These
+// specs prove the bridge now distinguishes "silently timed out" from
+// "genuinely finished" and that the distinction reaches InvestigateMCPResult.
+var _ = Describe("#2086: bridgeEventsCollectSummary/InvestigateMCPResult must not report false completion on inactivity timeout", func() {
+
+	Describe("UT-AF-2086-004: BridgeEventsCollectSummary returns completed=false on inactivity timeout without a terminal event", func() {
+		It("should signal completed=false when the bridge exits via its inactivity timer, not a terminal KA event", func() {
+			eventCh := make(chan ka.InvestigationEvent, 5)
+			eventCh <- ka.InvestigationEvent{
+				Type: ka.EventTypeReasoningDelta,
+				Data: json.RawMessage(`{"text":"Partial analysis before silence"}`),
+			}
+			// No further events, no close — simulate a silent gap (KA's
+			// gate-retry LLM call) that outlasts inactivityTimeout without
+			// KA ever actually completing (#2086).
+
+			summary, rca, _, completed := tools.BridgeEventsCollectSummary(context.Background(), eventCh, 100*time.Millisecond)
+			Expect(completed).To(BeFalse(),
+				"UT-AF-2086-004: exiting via the inactivity timer (no EventTypeComplete/Cancelled/SessionEnded "+
+					"seen) must be reported as NOT completed, or callers cannot distinguish a genuine finish "+
+					"from a silent gap (#2086)")
+			Expect(summary).To(Equal("Partial analysis before silence"))
+			Expect(rca).To(BeNil())
+		})
+	})
+
+	Describe("UT-AF-2086-004b: BridgeEventsCollectSummary returns completed=true on a genuine terminal event", func() {
+		It("should signal completed=true when the bridge exits via EventTypeComplete", func() {
+			eventCh := make(chan ka.InvestigationEvent, 5)
+			eventCh <- ka.InvestigationEvent{
+				Type: ka.EventTypeReasoningDelta,
+				Data: json.RawMessage(`{"text":"Full analysis"}`),
+			}
+			eventCh <- ka.InvestigationEvent{Type: ka.EventTypeComplete, Data: json.RawMessage(`{}`)}
+			close(eventCh)
+
+			_, _, _, completed := tools.BridgeEventsCollectSummary(context.Background(), eventCh, 5*time.Second)
+			Expect(completed).To(BeTrue(),
+				"UT-AF-2086-004b: a genuine EventTypeComplete must be reported as completed=true, "+
+					"so this regression guard fails loudly if a future change breaks the true-completion path")
+		})
+	})
+
+	Describe("UT-AF-2086-005: HandleInvestigationMCPWithRegistry does not report status=completed when the bridge times out without a terminal event", func() {
+		It("should return a truthful, non-completed status with guidance to poll instead of retry (#2086)", func() {
+			origInactivity := tools.BridgeInactivityTimeout
+			tools.BridgeInactivityTimeout = 100 * time.Millisecond
+			defer func() { tools.BridgeInactivityTimeout = origInactivity }()
+
+			eventCh := make(chan ka.InvestigationEvent, 5)
+			mockMCP := &ka.MockMCPClient{
+				StartInvestigationFn: func(_ context.Context, _ ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+					go func() {
+						eventCh <- ka.InvestigationEvent{
+							Type: ka.EventTypeReasoningDelta,
+							Data: json.RawMessage(`{"text":"Investigating"}`),
+						}
+						// Simulate KA's silent gate-retry LLM call (#2086 root
+						// cause): no further events arrive within
+						// BridgeInactivityTimeout, and the investigation is
+						// NOT actually complete.
+					}()
+					return &ka.StartInvestigationResult{
+						SessionID: "sess-2086-005",
+						Status:    "autonomous_started",
+						Events:    eventCh,
+						Closer:    func() {},
+					}, nil
+				},
+			}
+
+			// Outer ctx is never cancelled — the ONLY reason the bridge
+			// returns here is BridgeInactivityTimeout, exactly like the live
+			// #2086 incident where AF's outer ctx was healthy the whole time.
+			result, err := tools.HandleInvestigationMCPWithRegistry(
+				context.Background(), mockMCP, nil, "",
+				tools.InvestigateMCPArgs{RRID: "rr-2086-005"},
+				nil, nil, nil, true, nil, "", nil, nil,
+			)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(result.Status).NotTo(Equal("completed"),
+				"UT-AF-2086-005: inactivity timeout without a terminal event must NOT be reported as "+
+					"'completed' — this is the exact defect that caused #2086: the driving agent believed "+
+					"the investigation had finished with an empty RCA and never called discover_workflows")
+			Expect(result.Error).NotTo(BeEmpty(),
+				"UT-AF-2086-005: the result must carry guidance so the driving agent knows to poll "+
+					"kubernaut_get_remediation instead of retrying kubernaut_investigate")
+			Expect(result.Error).NotTo(ContainSubstring("investigation complete"),
+				"UT-AF-2086-005: guidance text must not imply the investigation finished")
+		})
+	})
+
+	Describe("UT-AF-2086-006: bridgeEventsCollectSummary's summary excludes keepalive status text", func() {
+		It("should not splice EventTypeToolCallStart keepalive text into the RCA summary (spike-discovered regression guard)", func() {
+			eventCh := make(chan ka.InvestigationEvent, 5)
+			eventCh <- ka.InvestigationEvent{
+				Type: ka.EventTypeReasoningDelta,
+				Data: json.RawMessage(`{"text":"Root cause: memory limit too low."}`),
+			}
+			// Fix 1's keepalive: emitted around KA's silent gate-retry LLM
+			// call using EventTypeToolCallStart (NOT reasoning_delta/token_delta)
+			// specifically so it cannot be concatenated into the summary below.
+			eventCh <- ka.InvestigationEvent{
+				Type: ka.EventTypeToolCallStart,
+				Data: json.RawMessage(`{"tool_name":"revalidating_remediation_target"}`),
+			}
+			eventCh <- ka.InvestigationEvent{Type: ka.EventTypeComplete, Data: json.RawMessage(`{}`)}
+			close(eventCh)
+
+			summary, _, _, completed := tools.BridgeEventsCollectSummary(context.Background(), eventCh, 5*time.Second)
+			Expect(completed).To(BeTrue())
+			Expect(summary).To(Equal("Root cause: memory limit too low."),
+				"UT-AF-2086-006: a keepalive emitted as EventTypeToolCallStart must NOT be concatenated "+
+					"into the RCA summary returned to the driving agent — using EventTypeReasoningDelta for "+
+					"the keepalive (the original plan) would have spliced placeholder status text directly "+
+					"into the analysis content returned to the agent (spike-discovered content-correctness bug)")
+			Expect(summary).NotTo(ContainSubstring("revalidating_remediation_target"))
+		})
+	})
+})
+
+// IT-AF-2086-010 (Pyramid Invariant: IT proves wiring): drives the FULL
+// production dispatch path (HandleInvestigationMCPWithRegistry -> pool
+// handoff -> bridgeEventsCollectSummary) with a fake KA session that goes
+// silent for longer than BridgeInactivityTimeout before ever sending a
+// terminal event -- the exact live #2086 shape. Proves two things a UT of
+// bridgeEventsCollectSummary alone cannot: (1) the truthful non-completed
+// status reaches the caller through the real handler, and (2) the pooled
+// session handoff (so a later kubernaut_get_remediation/select_workflow can
+// reuse the same MCP connection) still happens even though the investigation
+// was not reported as completed.
+var _ = Describe("IT-AF-2086-010: full dispatch path survives a silent gap without falsely reporting completion or dropping the pooled session", func() {
+	It("should report a non-completed status AND still hand the session off to the pool (#2086)", func() {
+		origInactivity := tools.BridgeInactivityTimeout
+		tools.BridgeInactivityTimeout = 50 * time.Millisecond
+		defer func() { tools.BridgeInactivityTimeout = origInactivity }()
+
+		mockSession := &mockPoolSession{}
+		eventCh := make(chan ka.InvestigationEvent, 5)
+		mockMCP := &ka.MockMCPClient{
+			StartInvestigationFn: func(_ context.Context, _ ka.StartInvestigationArgs) (*ka.StartInvestigationResult, error) {
+				go func() {
+					eventCh <- ka.InvestigationEvent{
+						Type: ka.EventTypeReasoningDelta,
+						Data: json.RawMessage(`{"text":"Investigating before the silent gate-retry gap"}`),
+					}
+					// Silence longer than BridgeInactivityTimeout with no
+					// ctx cancellation -- this is KA's silent gate-retry
+					// LLM call from the live #2086 incident. The bridge
+					// MUST give up here; any later send on eventCh below is
+					// deliberately never read by THIS blocking call (it
+					// already returned), matching the real incident where
+					// KA's genuine completion arrived ~10s after AF had
+					// already told the driving agent "completed".
+					time.Sleep(150 * time.Millisecond)
+					eventCh <- ka.InvestigationEvent{Type: ka.EventTypeComplete, Data: json.RawMessage(`{}`)}
+					close(eventCh)
+				}()
+				return &ka.StartInvestigationResult{
+					SessionID: "sess-it-2086-010",
+					Status:    "autonomous_started",
+					Events:    eventCh,
+					Closer:    func() {},
+					Session:   mockSession,
+				}, nil
+			},
+		}
+
+		registry := tools.NewMonitorRegistry()
+		pool := ka.NewKASessionPool(ka.PoolConfig{
+			Factory: func(_ context.Context) (ka.PoolSession, error) {
+				return &mockPoolSession{}, nil
+			},
+			MaxEntries: 10,
+			Logger:     logr.Discard(),
+		})
+
+		result, err := tools.HandleInvestigationMCPWithRegistry(
+			context.Background(), mockMCP, nil, "",
+			tools.InvestigateMCPArgs{RRID: "rr-it-2086-010"},
+			nil, registry, nil, true, pool, "alice", nil, nil,
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result.Status).NotTo(Equal("completed"),
+			"IT-AF-2086-010: a silent gap that outlasts BridgeInactivityTimeout without a terminal event "+
+				"must not be reported as completed through the real production dispatch path (#2086)")
+
+		acquired, acqErr := pool.Acquire(context.Background(), "rr-it-2086-010", "alice")
+		Expect(acqErr).NotTo(HaveOccurred())
+		Expect(acquired).To(BeIdenticalTo(mockSession),
+			"IT-AF-2086-010: the MCP session must still be handed off to the pool even though the "+
+				"investigation was not reported as completed, so a later kubernaut_get_remediation or "+
+				"select_workflow call can reuse the connection instead of KA's session being orphaned")
+
+		Expect(registry.Active("sess-it-2086-010")).To(BeFalse(),
+			"IT-AF-2086-010: session must be deregistered from MonitorRegistry once handed off to the pool")
 	})
 })
 

--- a/pkg/apifrontend/tools/ka_investigate_rca_test.go
+++ b/pkg/apifrontend/tools/ka_investigate_rca_test.go
@@ -58,7 +58,7 @@ var _ = Describe("bridgeEventsCollectSummary RCA Parsing — TP-1395-1396 (#1396
 			}
 
 			ctx := context.Background()
-			summary, rca, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+			summary, rca, _, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 
 			Expect(summary).To(ContainSubstring("Investigating..."))
 			Expect(rca).NotTo(BeNil(), "RCA should be populated from complete event Data")
@@ -85,7 +85,7 @@ var _ = Describe("bridgeEventsCollectSummary RCA Parsing — TP-1395-1396 (#1396
 			}
 
 			ctx := context.Background()
-			summary, rca, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+			summary, rca, _, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 
 			Expect(summary).To(Equal("Found the issue."))
 			Expect(rca).To(BeNil(), "RCA should be nil when complete event has no Data")
@@ -111,7 +111,7 @@ var _ = Describe("bridgeEventsCollectSummary RCA Parsing — TP-1395-1396 (#1396
 			events <- ka.InvestigationEvent{Type: ka.EventTypeComplete, Data: rcaJSON}
 
 			ctx := context.Background()
-			_, rca, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+			_, rca, _, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 
 			Expect(rca).NotTo(BeNil())
 			Expect(rca.IsActionable).NotTo(BeNil(),
@@ -136,7 +136,7 @@ var _ = Describe("bridgeEventsCollectSummary RCA Parsing — TP-1395-1396 (#1396
 			events <- ka.InvestigationEvent{Type: ka.EventTypeComplete, Data: rcaJSON}
 
 			ctx := context.Background()
-			_, rca, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+			_, rca, _, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 
 			Expect(rca).NotTo(BeNil())
 			Expect(rca.IsActionable).NotTo(BeNil())
@@ -157,7 +157,7 @@ var _ = Describe("bridgeEventsCollectSummary RCA Parsing — TP-1395-1396 (#1396
 			events <- ka.InvestigationEvent{Type: ka.EventTypeComplete, Data: rcaJSON}
 
 			ctx := context.Background()
-			_, rca, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+			_, rca, _, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 
 			Expect(rca).NotTo(BeNil())
 			Expect(rca.IsActionable).To(BeNil(),
@@ -195,7 +195,7 @@ var _ = Describe("Progressive RCA Emission — #1407", func() {
 				Data: rcaJSON,
 			}
 
-			_, rca, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+			_, rca, _, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 			Expect(rca).NotTo(BeNil())
 
 			allEvents := queue.Events()
@@ -242,7 +242,7 @@ var _ = Describe("Progressive RCA Emission — #1407", func() {
 				Type: ka.EventTypeComplete,
 			}
 
-			_, rca, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+			_, rca, _, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 			Expect(rca).To(BeNil())
 
 			allEvents := queue.Events()
@@ -319,7 +319,7 @@ var _ = Describe("Progressive RCA Emission — #1407", func() {
 			}
 
 			ctx := context.Background()
-			summary, rca, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+			summary, rca, _, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 			Expect(rca).NotTo(BeNil())
 			Expect(summary).To(ContainSubstring("Should not panic"))
 		})

--- a/pkg/apifrontend/tools/ka_investigate_verdict_1420_test.go
+++ b/pkg/apifrontend/tools/ka_investigate_verdict_1420_test.go
@@ -62,7 +62,7 @@ var _ = Describe("Issue #1420: AF Bridge Alignment Verdict Handling (SC-7)", fun
 		ctx := launcher.WithEventBridge(context.Background(), q, taskID, "ctx-1420", nil)
 		ctx = tools.WithRRID(ctx, "rr-1420-001")
 
-		summary, _, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+		summary, _, _, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 		_ = summary
 
 		found := false
@@ -163,7 +163,7 @@ var _ = Describe("Issue #1420: AF Bridge Alignment Verdict Handling (SC-7)", fun
 		ctx := launcher.WithEventBridge(context.Background(), q, taskID, "ctx-1420-004", nil)
 		ctx = tools.WithRRID(ctx, "rr-1420-004")
 
-		_, _, verdict := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+		_, _, verdict, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 
 		Expect(verdict).NotTo(BeNil(),
 			"the caller (HandleInvestigationMCPWithRegistry) needs the verdict to populate InvestigateMCPResult.AlignmentVerdict, "+
@@ -178,7 +178,7 @@ var _ = Describe("Issue #1420: AF Bridge Alignment Verdict Handling (SC-7)", fun
 		events <- ka.InvestigationEvent{Type: ka.EventTypeComplete}
 
 		ctx := context.Background()
-		_, _, verdict := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+		_, _, verdict, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 
 		Expect(verdict).To(BeNil(), "no alignment check ran (or is disabled) -- must not fabricate a verdict")
 	})

--- a/pkg/apifrontend/tools/terminal_event_1438_test.go
+++ b/pkg/apifrontend/tools/terminal_event_1438_test.go
@@ -63,7 +63,7 @@ var _ = Describe("Terminal event emission to A2A — #1438", func() {
 				Phase: "inactivity_timeout",
 			}
 
-			summary, _, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
+			summary, _, _, _ := tools.BridgeEventsCollectSummary(ctx, events, 5*time.Second)
 			_ = summary
 
 			queuedEvents := queue.Events()

--- a/test/integration/apifrontend/investigation_event_bridge_test.go
+++ b/test/integration/apifrontend/investigation_event_bridge_test.go
@@ -188,7 +188,7 @@ var _ = Describe("Investigation Event Bridge Wiring (IT-AF-1326)", func() {
 			}
 			eventCh <- ka.InvestigationEvent{
 				Type: ka.EventTypeToolCallStart,
-				Data: json.RawMessage(`{"tool":"kubectl_get"}`),
+				Data: json.RawMessage(`{"tool_name":"kubectl_get"}`),
 			}
 			eventCh <- ka.InvestigationEvent{
 				Type: ka.EventTypeComplete,
@@ -302,7 +302,7 @@ var _ = Describe("Investigation Event Bridge Wiring (IT-AF-1326)", func() {
 					expected: "Analyzing...",
 				},
 				{
-					evt:      ka.InvestigationEvent{Type: ka.EventTypeToolCallStart, Data: json.RawMessage(`{"tool":"kubectl_get"}`)},
+					evt:      ka.InvestigationEvent{Type: ka.EventTypeToolCallStart, Data: json.RawMessage(`{"tool_name":"kubectl_get"}`)},
 					expected: "Calling kubectl_get...",
 				},
 				{


### PR DESCRIPTION
## Summary

Root-caused against the live incident in #2086 (RR `rr-cc99762025f0-5977eb36`, `redhat-internal.com` cluster): after RCA completes with high confidence, KA never transitions into `workflow_discovery`. Live pod logs pinpoint the mechanism: AF's blocking `kubernaut_investigate` tool call uses `bridgeEventsCollectSummary` with a fixed 60s inactivity timeout that resets only on KA sink events. KA's `sameKindValidationGate` (and identically-shaped `apiVersionValidationGate`) issue a second, **non-streamed** `llm.ChatWithParams` call that emits zero events for the duration of the round-trip -- in this incident, ~87s, exceeding the 60s budget. AF then falsely reports the investigation as "completed" with an empty RCA, so the driving agent never calls `discover_workflows`, and the session idles out ~10 minutes later, misreported as `NoMatchingWorkflows`.

This PR closes **two issues** with 4 commits, consolidated into one PR (scarce CI resources):

- **#2086** -- the workflow_discovery hang itself (commits 1, 3, 4 below)
- **#2089** -- an independent, pre-existing `tool_name`/`tool` wire-format mismatch, spike-discovered while triaging #2086 and folded into commit 2 below since it's directly relevant to commit 1's keepalive rendering

### 1. `fix(kubernautagent): emit keepalive events during silent gate-retry LLM calls` (#2086)

`sameKindValidationGate`, `apiVersionValidationGate`, and `RunRCAExtractionFromConversation` each issue a non-streamed `llm.ChatWithParams` call that emits zero sink events for the round-trip duration. Emit an `EventTypeToolCallStart` keepalive immediately before each call -- this event type resets AF's inactivity timer but is excluded from RCA summary accumulation, so it cannot corrupt the analysis text returned to the driving agent (confirmed via spike, `UT-AF-2086-006`).

Test plan: `UT-KA-2086-001`, `UT-KA-2086-002`, `UT-KA-2086-003`

### 2. `fix(apifrontend): truthful bridge status on inactivity timeout + tool_call_start wire-format fix` (#2086, #2089)

`bridgeEventsCollectSummary` now returns a `completed` bool, true only for a genuine terminal KA event (`EventTypeComplete`/`Cancelled`/`SessionEnded`). A silent gap without a terminal event now reports `status="in_progress"` with guidance to poll `kubernaut_get_remediation`, instead of falsely reporting `"completed"` with an empty RCA. Also bumps `BridgeInactivityTimeout` 60s -> 90s for headroom against KA's equally-60s `DefaultToolCallTimeout` (#1949) -- defense-in-depth, not the primary fix.

Separately (**#2089**, spike-discovered while auditing commit 1's keepalive rendering): `FormatEventForUser`'s `EventTypeToolCallStart` case read JSON key `"tool"`, but KA's real emission (and the rest of the codebase) uses `"tool_name"` -- a wire-format mismatch that silenced all real tool-call status text in production. AF's own tests never caught this because they hand-constructed fixtures with the wrong key instead of exercising KA's real emission path; fixed the key, updated the 5 affected fixtures, and added a wire-contract regression test.

Test plan: `UT-AF-2086-004`, `UT-AF-2086-004b`, `UT-AF-2086-005`, `UT-AF-2086-006`, `UT-AF-2086-007`, `IT-AF-2086-010`, `IT-AF-2086-030`

### 3. `fix(kubernautagent): downgrade benign LaunchDeferredInvestigation retry-race log to Info` (#2086)

`session.ErrSessionNotPending` fires on every benign retry against an already-active/launched session -- an expected race, not a failure (it fired 3x in the live #2086 incident, all harmless, and was a red herring during triage). Genuine launch failures remain at Error.

Test plan: `UT-KA-2086-006`, `UT-KA-2086-006b`

### 4. `fix(aianalysis): classify KA session timeout without result as InvestigationInconclusive` (#2086)

When KA's own session inactivity timeout fires with no `InvestigationResult` ever produced, it synthesizes a placeholder (`Analysis="Investigation completed without result"`, `Confidence=0`, `has_workflow=false`, `human_review_reason=""`). AIAnalysis previously classified this identically to a genuine "no matching workflow" conclusion (`NoMatchingWorkflows`) -- misleading, since the investigation never reached a conclusion. Now classified as `InvestigationInconclusive` with a message reflecting the true cause. FedRAMP AU-3 (truthful audit content) / SI-11 (accurate error handling).

Test plan: `IT-AA-2086-020`

## Test plan (Pyramid Invariant)

All test IDs above drive through their real production entry points (`HandleInvestigationMCPWithRegistry`, the AA reconcile loop via `handler.Handle`, the actual `emitToSink` call sites) -- not direct unit calls.

## Backport tracking (v1.6, not closed by this PR)

- #2088 -- v1.6 backport clone of #2086
- #2090 -- v1.6 backport clone of #2089

## Verification

`go build ./...`, `go vet ./...`, and `golangci-lint run` are clean across all touched packages. All test IDs above pass with `-count=1` (no cache). CI: unit tests, builds, lint, integration tests, and E2E tests for every touched package (`apifrontend`, `kubernautagent`, `aianalysis`) are green. One unrelated flake observed (`E2E (gateway)`: Kind cluster-name collision on CI retry, `test/e2e/gateway` -- this PR touches no gateway code); under investigation separately from this PR's own correctness.

## Confidence

95% -- root cause reconstructed from live, timestamped pod logs/CRD status for the actual incident; fixes reuse existing, already-proven wiring patterns.

Closes #2086
Closes #2089