### PR TITLE
fix(kubernautagent): centralize aiagent_mcp_interactive_sessions_active decrement in Release()

### DIFF
--- a/cmd/kubernautagent/main.go
+++ b/cmd/kubernautagent/main.go
@@ -1309,9 +1309,19 @@ func buildMCPHandler(
 			autoMgr.EmitSessionEndedByRR(rrID, reason)
 			mcptools.CompleteHTTPSession(autoMgr, rrID, nil, logger, reason)
 			emitDisconnectAudit(sessionID, rrID, reason)
-			agentMetrics.RecordInteractiveSessionEnded()
+			// #2103: aiagent_mcp_interactive_sessions_active decrement moved
+			// into LeaseSessionManager.Release() itself (called by GetDriver
+			// just before this callback fires) -- see WithSessionEndedMetrics
+			// below. An explicit call here would double-decrement.
 		}),
 		mcpkg.WithSessionJanitor(sessionJanitor),
+		// #2103: centralizes the aiagent_mcp_interactive_sessions_active
+		// decrement inside Release() itself, so every Release() caller --
+		// InvestigateTool, SelectWorkflowTool, CompleteNoActionTool, the
+		// SessionJanitor backstop above, and this file's own TTL/inactivity/
+		// disconnect callbacks below -- keeps the gauge accurate without
+		// each needing its own metrics wiring.
+		mcpkg.WithSessionEndedMetrics(agentMetrics),
 	}
 	leaseMgr := mcpkg.NewLeaseSessionManagerConcrete(ctrlCli, namespace, logger, leaseOpts...)
 
@@ -1352,8 +1362,10 @@ func buildMCPHandler(
 			// KA-CRIT-2: Resolve the HTTP session so AA stops polling user_driving.
 			mcptools.CompleteHTTPSession(autoMgr, rrID, nil, logger, "inactivity_timeout")
 			emitDisconnectAudit(sessionID, rrID, "inactivity_timeout")
-			// T1-4: Decrement gauge on timeout expiry to prevent drift.
-			agentMetrics.RecordInteractiveSessionEnded()
+			// #2103: T1-4's gauge decrement moved into LeaseSessionManager.
+			// Release() itself (called by leaseMgr.Release just above) --
+			// see WithSessionEndedMetrics. An explicit call here would
+			// double-decrement.
 		},
 	)
 
@@ -1411,8 +1423,10 @@ func buildMCPHandler(
 
 		emitDisconnectAudit(interactiveSessionID, rrID, "disconnect")
 
-		// T1-4: Decrement gauge on disconnect to prevent drift.
-		agentMetrics.RecordInteractiveSessionEnded()
+		// #2103: T1-4's gauge decrement moved into LeaseSessionManager.
+		// Release() itself (called by leaseMgr.Release just above) -- see
+		// WithSessionEndedMetrics. An explicit call here would
+		// double-decrement.
 
 		// Spawn reconstruction in background (best-effort, BR-INTERACTIVE-008).
 		go func() {

--- a/docs/testing/2103/TEST_PLAN.md
+++ b/docs/testing/2103/TEST_PLAN.md
@@ -1,0 +1,237 @@
+# Test Plan: #2103 — `aiagent_mcp_interactive_sessions_active` Gauge Drift
+
+## 1. Purpose
+
+`aiagent_mcp_interactive_sessions_active` (the Prometheus gauge tracking
+concurrent MCP interactive sessions) only ever decrements for two of the
+ways an interactive session can end — explicit `complete`/`cancel` — plus
+two callback paths owned directly by `cmd/kubernautagent/main.go`
+(disconnect-grace-period expiry, inactivity-timeout expiry via
+`TimeoutManager`). Every other completion path releases the real session
+(Lease + `LeaseSessionManager.activeCount`, both healthy) but never calls
+the matching `RecordInteractiveSessionEnded()`, so the gauge drifts upward
+and never reflects true concurrency. This is **not** a recurrence of
+#2100's capacity leak — the real Lease/activeCount bookkeeping is
+confirmed healthy; this is an observability-only bug.
+
+Discovered live-monitoring QE's #2100 validation run (PR #2102, images
+deployed with `SessionJanitor` wired).
+
+### Root Cause Detail
+
+`RecordInteractiveSessionEnded()` is not called from inside
+`LeaseSessionManager.Release()` itself — it is the *caller's*
+responsibility to call both `sessions.Release(...)` and the metrics
+decrement separately, and most callers of `Release()` don't have
+`agentMetrics` wired at all. Confirmed gaps (all verified directly against
+current code, not just the issue's live evidence):
+
+1. `CompleteNoActionTool.Handle` (`complete_no_action.go:194`, reason
+   `"complete_no_action"`) — struct has no `metrics` field.
+2. `SelectWorkflowTool`'s post-selection release goroutine
+   (`select_workflow.go:372`, reason `"workflow_selected"`) — struct has
+   no `metrics` field.
+3. `InvestigateTool`'s `no_matching_workflows` auto-close goroutine
+   (`investigate.go:1101-1138`, release at line 1133) — `InvestigateTool`
+   *does* have `t.metrics` (used elsewhere at lines 583-584, 850, 1271),
+   but this goroutine's closure doesn't capture or call it.
+4. `SessionJanitor`'s `onExpire` callback, added by #2100's own fix
+   (`session_manager.go:290-294`) — lives inside `LeaseSessionManager`, a
+   package with zero awareness of `agentMetrics`. #2100's new backstop
+   sweep path inherits this same gap.
+
+Correctly-decrementing paths (for contrast): `InvestigateTool.handleComplete`
+(investigate.go:850, `"complete"`), `handleCancel` (investigate.go:1271,
+`"explicit"`), `TimeoutManager`'s inactivity-expiry callback
+(`main.go:1356`, `"inactivity_timeout"`), `GracefulSessionClosedHandler`'s
+disconnect callback (`main.go:1415`, `"disconnect"`), and
+`WithSessionExpiredCallback` (`main.go:1312`, TTL/inactivity via
+`GetDriver`'s lazy check).
+
+## 2. Fix Design
+
+**Rejected alternative**: patch each of the 4 (and growing) gap call sites
+individually with their own `metrics ToolMetrics` field + option, mirroring
+`InvestigateTool`'s existing pattern. Rejected because it reintroduces the
+exact same gap for the *next* new completion path (this issue is itself
+evidence that per-call-site wiring doesn't scale — #2100's new janitor path
+inherited the gap on day one).
+
+**Chosen fix**: centralize the decrement *inside*
+`LeaseSessionManager.Release()` itself, paired with the existing
+`activeCount.Add(-1)`, via a new optional callback wired the same way
+`WithSessionExpiredCallback`/`WithSessionJanitor` already are:
+
+```go
+// SessionEndedMetrics is the minimal metrics surface LeaseSessionManager
+// needs to keep aiagent_mcp_interactive_sessions_active accurate for every
+// Release caller, current and future (#2103). Implemented structurally by
+// *metrics.Metrics (see tools.ToolMetrics for the parallel interface at
+// the tool-handler layer) -- defined locally here, rather than imported,
+// to avoid mcp importing metrics or tools (tools already imports mcp).
+type SessionEndedMetrics interface {
+    RecordInteractiveSessionEnded()
+}
+```
+
+`Release()` calls `m.sessionMetrics.RecordInteractiveSessionEnded()`
+immediately after `m.activeCount.Add(-1)`, guarded by nil-check, and
+**only** on the path that actually reaches that line (i.e. not on
+`ErrSessionNotFound`, not on a hard Lease-delete error) — so a
+double-`Release()` call never double-decrements.
+
+This single change automatically closes gaps #1–#4 above, since all four
+routes call `sessions.Release(...)` against the *same* shared
+`LeaseSessionManager` instance in `buildMCPHandler`. No per-tool `metrics`
+field is added to `CompleteNoActionTool` or `SelectWorkflowTool`, and
+`InvestigateTool`'s `no_matching_workflows` goroutine needs no capture
+change.
+
+**Redundant-call cleanup** (required to avoid double-decrementing once
+`Release()` handles it centrally):
+
+- `investigate.go` `handleComplete` (was line 849-851) and `handleCancel`
+  (was line 1270-1272): remove the explicit
+  `t.metrics.RecordInteractiveSessionEnded()` call — both already call
+  `t.sessions.Release(...)` just above.
+- `main.go`'s `WithSessionExpiredCallback` (was line 1312), `timeoutMgr`'s
+  inactivity callback (was line 1356), `disconnectHandler`'s callback (was
+  line 1415): remove the explicit `agentMetrics.RecordInteractiveSessionEnded()`
+  calls — all three already call `leaseMgr.Release(...)` (directly, or via
+  `GetDriver`'s lazy TTL/inactivity check) just above.
+
+**Started/Ended symmetry fix** (subtlety not called out in the original
+issue): `handleStart`'s fallback-exhausted branch (`#2100`'s own fix,
+`investigate.go:570`) calls `Release(sess.SessionID, "no_investigation_available")`
+on a lease for which `RecordInteractiveSessionStarted()` was **never**
+called (that call happens later, at the end of `handleStart`, only on the
+success path). Once `Release()` centrally decrements, this branch would
+decrement a gauge that was never incremented for that session, pushing it
+negative. Fix: move `t.metrics.RecordInteractiveSessionStarted()` to fire
+immediately after `Takeover()` confirms a genuinely new lease (i.e. after
+the `sess.Reconnected` check, which correctly still returns early without
+touching the gauge — no new lease was acquired for a reconnect), before any
+of the fallback logic that might immediately release it. This keeps
+Started/Ended paired with the lease's own lifecycle (`activeCount`'s own
+`Add(1)`/`Add(-1)` pair), which is more accurate than the previous
+behavior (a lease that lived for a few hundred ms before failing closed was
+never counted as "started" at all).
+
+## 3. FedRAMP Control Mapping
+
+| Control | Title | Relevance |
+|---|---|---|
+| **SI-4** | System Monitoring | The core control: `aiagent_mcp_interactive_sessions_active` is an operational-monitoring signal (BR-KA-OBSERVABILITY-001); a monotonically-drifting gauge produces false-positive capacity alerts and masks the true concurrency the #2100 capacity guarantee depends on. |
+| **SI-11** | Error Handling | The Started/Ended symmetry fix ensures a fail-closed lease release (#2100's `no_investigation_available` path) is still correctly accounted for in the gauge instead of silently under/over-counting. |
+| **SC-5** | Denial of Service Protection | An operator/dashboard relying on this gauge to catch a *future* recurrence of #2100's capacity-exhaustion bug would be blind to it while the gauge is stuck climbing regardless of true load. |
+
+## 4. Pyramid Invariant — Test Scenario Inventory
+
+| ID | Tier | Business-Level Behavior Description | Control | Test File |
+|---|---|---|---|---|
+| UT-KA-2103-001 | Unit | `LeaseSessionManager.Release()` calls the wired `SessionEndedMetrics.RecordInteractiveSessionEnded()` exactly once on a successful release | SI-4 | `internal/kubernautagent/mcp/session_manager_metrics_2103_test.go` |
+| UT-KA-2103-002 (regression guard) | Unit | `Release()` on an unknown/already-released session ID returns `ErrSessionNotFound` and does **not** call the metrics callback (no phantom decrement) | SI-4 | `internal/kubernautagent/mcp/session_manager_metrics_2103_test.go` |
+| UT-KA-2103-003 (regression guard) | Unit | `Release()` with no `WithSessionEndedMetrics` wired (nil) does not panic — safe no-op, matching every pre-#2103 call site | SI-11 | `internal/kubernautagent/mcp/session_manager_metrics_2103_test.go` |
+| UT-KA-2103-004 (regression guard) | Unit | `InvestigateTool.handleComplete` (`action=complete`) no longer calls `metrics.RecordInteractiveSessionEnded()` directly — proves the responsibility fully moved to `LeaseSessionManager.Release()`, preventing double-decrement once combined with the real manager | SI-4 | `internal/kubernautagent/mcp/tools/investigate_metrics_2103_test.go` |
+| UT-KA-2103-005 (regression guard) | Unit | `InvestigateTool.handleCancel` (`action=cancel`) — same as UT-KA-2103-004 | SI-4 | `internal/kubernautagent/mcp/tools/investigate_metrics_2103_test.go` |
+| UT-KA-2103-006 | Unit | `handleStart` records `RecordInteractiveSessionStarted()` immediately after a successful (non-reconnect) `Takeover`, even on the fallback-exhausted branch that immediately releases the lease — proves Started/Ended stay paired now that Ended is centralized (prevents the gauge going negative) | SI-4, SI-11 | `internal/kubernautagent/mcp/tools/investigate_metrics_2103_test.go` |
+| UT-KA-2103-007 (regression guard) | Unit | `handleStart`'s `Reconnected` branch and `Takeover`-failure branches still do **not** call `RecordInteractiveSessionStarted()` — no new lease was actually acquired | SI-4 | `internal/kubernautagent/mcp/tools/investigate_metrics_2103_test.go` |
+| IT-KA-2103-001 | Integration | An explicit `Release()` call (reasons `complete_no_action`, `workflow_selected`, `no_matching_workflows` in sequence) against a real envtest `LeaseSessionManager` wired with `WithSessionEndedMetrics` decrements the metrics recorder exactly once per release — proves gaps #1–#3 all collapse to the same fixed chokepoint, using the exact `NewLeaseSessionManagerConcrete(..., WithSessionEndedMetrics(...))` construction `buildMCPHandler` uses in production | SI-4 | `test/integration/kubernautagent/mcp/session_manager_metrics_2103_it_test.go` |
+| IT-KA-2103-002 | Integration | `SessionJanitor`'s sweep-triggered `onExpire` → `Release(..., reason)` decrements the same wired metrics recorder against a real envtest API server (real `coordination.k8s.io/Lease` reclaimed) — closes gap #4 end-to-end, extending #2100's own `session_janitor_wiring_2100_test.go` IT pattern | SI-4, SC-5 | `test/integration/kubernautagent/mcp/session_manager_metrics_2103_it_test.go` |
+
+### Tier Coverage Rationale
+
+- **UT** covers the centralized decrement's logic in isolation (found/not-found/nil-metrics against a fake K8s client, mirroring #2100's own `session_manager_janitor_2100_test.go` precedent — no real API server needed since this fix touches zero K8s-API-specific behavior), plus the two `investigate.go` regression guards proving the old direct-call pattern is fully retired, plus the Started/Ended symmetry fix.
+- **IT** proves the fix against a real envtest API server using the identical `NewLeaseSessionManagerConcrete(..., WithSessionEndedMetrics(...))` construction path `buildMCPHandler` uses in production, exercising both call shapes that existed pre-fix: an explicit `Release()` call (the shape shared verbatim by `CompleteNoActionTool.Handle`, `SelectWorkflowTool`'s async goroutine, and `InvestigateTool`'s `no_matching_workflows` auto-close — CHECKPOINT W's grep evidence confirms all three call the same `sessions.Release(sessionID, reason)` signature on the one shared `SessionManager` instance `buildMCPHandler` constructs), and the `SessionJanitor`'s real sweep-triggered `onExpire` callback (gap #4), mirroring #2100's own precedent of proving `LeaseSessionManager`-internal wiring directly against envtest rather than requiring a full MCP-protocol round trip per caller. A UT of `Release()` alone (already covered above) cannot prove the `WithSessionEndedMetrics` option is actually threaded through `buildMCPHandler`'s `leaseOpts` to the one shared instance in production — CHECKPOINT W's grep evidence plus this IT together close that gap.
+- **E2E**: not added net-new. This is an observability-only fix (no functional/capacity behavior change); QE's next acceptance run against this branch's images is the confirmation path, not a new E2E suite in this repo.
+
+## 5. Wiring Manifest
+
+| Component | Production Entry Point | Wiring Code Location | Test ID |
+|---|---|---|---|
+| `SessionEndedMetrics` interface + `sessionMetrics` field | `LeaseSessionManager.Release()` | `internal/kubernautagent/mcp/session_manager.go` | UT-KA-2103-001..003 |
+| `WithSessionEndedMetrics` option | `buildMCPHandler`'s `leaseOpts` (`cmd/kubernautagent/main.go`), passed `agentMetrics` | `cmd/kubernautagent/main.go`, `internal/kubernautagent/mcp/session_manager.go` | IT-KA-2103-001, IT-KA-2103-002 |
+| `handleStart`'s relocated `RecordInteractiveSessionStarted()` call | `InvestigateTool.Handle` (`action=start`), dispatched from the `kubernaut_investigate` MCP tool handler registered in `buildMCPHandler` | `internal/kubernautagent/mcp/tools/investigate.go` | UT-KA-2103-006, UT-KA-2103-007 |
+
+## 6. CHECKPOINT W Evidence
+
+```
+=== WithSessionEndedMetrics production callers ===
+cmd/kubernautagent/main.go:1324:		mcpkg.WithSessionEndedMetrics(agentMetrics),
+internal/kubernautagent/mcp/session_manager.go:177:func WithSessionEndedMetrics(m SessionEndedMetrics) LeaseOption {
+
+=== sessionMetrics.RecordInteractiveSessionEnded call site (the ONLY production call site) ===
+internal/kubernautagent/mcp/session_manager.go:374:	if m.sessionMetrics != nil {
+internal/kubernautagent/mcp/session_manager.go:375:		m.sessionMetrics.RecordInteractiveSessionEnded()
+
+=== Confirm no orphaned direct RecordInteractiveSessionEnded calls remain in cmd/ or internal/ ===
+(none outside session_manager.go:375 and metrics.go's own implementation — confirmed via
+ grep -rn "RecordInteractiveSessionEnded" cmd/ internal/ --include="*.go" | grep -v _test.go)
+
+=== All 4 original gap call sites now route through the one centralized Release() ===
+internal/kubernautagent/mcp/tools/select_workflow.go:372:   sessions.Release(sessionID, "workflow_selected")
+internal/kubernautagent/mcp/tools/investigate.go:582:      t.sessions.Release(sess.SessionID, "no_investigation_available")  (#2100 fail-closed path, unrelated reason string)
+internal/kubernautagent/mcp/tools/investigate.go:1147:     sessions.Release(sessionID, "no_matching_workflows")
+internal/kubernautagent/mcp/tools/complete_no_action.go:194: t.sessions.Release(driver.SessionID, "complete_no_action")
+```
+
+CHECKPOINT W: PASSED — `WithSessionEndedMetrics` has exactly one production caller
+(`cmd/kubernautagent/main.go`, wired into the same `leaseOpts` slice that constructs the
+one shared `LeaseSessionManager` instance `buildMCPHandler` hands to every tool), the
+decrement itself has exactly one call site (`Release()` line 375), and all four originally-
+reported gap paths (`complete_no_action`, `workflow_selected`, `no_matching_workflows`,
+`SessionJanitor.onExpire`) call `Release()` on that same shared instance — no orphaned
+`pkg`/`internal` code, no "TODO: wire later" deferred wiring.
+
+## 7. Build Validation
+
+Executed 2026-08-11:
+
+```bash
+$ go build ./...                                                          # PASS
+$ go vet ./...                                                            # PASS (no output)
+$ golangci-lint run --timeout=5m ./internal/kubernautagent/... \
+    ./cmd/kubernautagent/...                                              # 0 issues
+$ make test-unit-kubernautagent
+  # Ran 97 of 97 Specs — SUCCESS! 97 Passed | 0 Failed | 0 Pending | 0 Skipped
+  # (across all 29 KA unit suites; composite coverage 84.8%)
+$ make test-integration-kubernautagent-interactive
+  # Ran 27 of 103 Specs (label: interactive) — SUCCESS! 27 Passed | 0 Failed | 0 Pending
+  # includes both new IT-KA-2103-001 and IT-KA-2103-002
+```
+
+## 8. Coverage Summary
+
+- Unit: 97/97 specs passed across 29 KA unit suites; composite (merged) coverage 84.8%
+  of unit-testable statements in `internal/kubernautagent/...` (per
+  `make test-unit-kubernautagent`'s coverage report).
+- Integration: 27/27 specs passed for the `interactive` label subset (full
+  `test/integration/kubernautagent/mcp` package, envtest + Podman DataStorage + Mock LLM),
+  including the two new #2103 IT tests exercising the real `Release()` chokepoint and the
+  real `SessionJanitor` sweep against a live envtest API server.
+- No regressions introduced in any pre-existing #2100/#2098/#2094/#2092/#2105 test in the
+  same packages (all still passing in the same runs above).
+
+## 9. Out of Scope
+
+- Restructuring the pre-existing, seemingly-overlapping dual inactivity
+  mechanisms (`LeaseSessionManager.inactivityTimeout`'s lazy `GetDriver`
+  check vs. `TimeoutManager`'s proactive timer) — both already correctly
+  route through `Release()` and are unaffected by this centralization;
+  consolidating them is a separate, unrelated architectural question not
+  raised by this issue.
+- The `#1654`-style "transition to user-driving fails, not terminal"
+  branch in `handleTakeover` (investigate.go:656-659) that returns an
+  error without releasing the just-acquired lease — noticed while tracing
+  this issue's call graph, but out of scope: it is a potential *capacity*
+  leak (#2100's concern), not a *metrics* leak (#2103's concern), since
+  `RecordInteractiveSessionStarted()` was never called for it either. Flag
+  for separate triage if confirmed live.
+
+## 10. Sign-off
+
+| Role | Name | Date | Signature |
+|---|---|---|---|
+| Author | AI Assistant | 2026-08-11 | pending |
+| Reviewer | Jordi Gil | | pending |
+| Approver | | | pending |

--- a/internal/kubernautagent/mcp/session_manager.go
+++ b/internal/kubernautagent/mcp/session_manager.go
@@ -86,6 +86,28 @@ type LeaseSessionManager struct {
 	// deployments/tests that don't wire one via WithSessionJanitor --
 	// Track/Untrack calls are no-ops in that case.
 	janitor *SessionJanitor
+
+	// sessionMetrics is the #2103 centralization point for
+	// aiagent_mcp_interactive_sessions_active: every Release caller used to
+	// be individually responsible for calling RecordInteractiveSessionEnded,
+	// and most never wired it (CompleteNoActionTool, SelectWorkflowTool,
+	// InvestigateTool's no_matching_workflows goroutine, and #2100's own new
+	// SessionJanitor onExpire callback all leaked this gauge). Wiring the
+	// decrement here instead, paired with activeCount's own Add(-1), makes
+	// every current and future Release() caller correct automatically. Nil
+	// in deployments/tests that don't wire one via WithSessionEndedMetrics --
+	// the call is a no-op in that case.
+	sessionMetrics SessionEndedMetrics
+}
+
+// SessionEndedMetrics is the minimal metrics surface LeaseSessionManager
+// needs to keep aiagent_mcp_interactive_sessions_active accurate for every
+// Release caller (#2103). Implemented structurally by *metrics.Metrics (see
+// tools.ToolMetrics for the parallel interface at the tool-handler layer) --
+// defined locally here, rather than imported, to avoid mcp importing
+// metrics or tools (tools already imports mcp, so the reverse would cycle).
+type SessionEndedMetrics interface {
+	RecordInteractiveSessionEnded()
 }
 
 type sessionEntry struct {
@@ -143,6 +165,20 @@ func (m *LeaseSessionManager) SetReconnectCallback(fn func(sessionID string)) {
 func WithSessionJanitor(j *SessionJanitor) LeaseOption {
 	return func(m *LeaseSessionManager) {
 		m.janitor = j
+	}
+}
+
+// WithSessionEndedMetrics wires the aiagent_mcp_interactive_sessions_active
+// decrement into Release() itself (#2103), so every current and future
+// Release() caller -- InvestigateTool, SelectWorkflowTool,
+// CompleteNoActionTool, the SessionJanitor backstop, and main.go's own
+// TTL/inactivity/disconnect callbacks -- keeps the gauge accurate without
+// needing its own metrics field.
+func WithSessionEndedMetrics(m SessionEndedMetrics) LeaseOption {
+	return func(mgr *LeaseSessionManager) {
+		if m != nil {
+			mgr.sessionMetrics = m
+		}
 	}
 }
 
@@ -328,6 +364,16 @@ func (m *LeaseSessionManager) Release(sessionID string, reason string) error {
 	m.sessions.Delete(sessionID)
 	m.rrIndex.Delete(entry.rrID)
 	m.activeCount.Add(-1)
+
+	// #2103: centralize the aiagent_mcp_interactive_sessions_active
+	// decrement here, paired with activeCount.Add(-1) above, so every
+	// current and future Release() caller keeps the gauge accurate. Only
+	// reached once the session is confirmed locally found and removed
+	// above -- a double-Release (ErrSessionNotFound) or a hard Lease-delete
+	// error never reaches this line, so this can never double-decrement.
+	if m.sessionMetrics != nil {
+		m.sessionMetrics.RecordInteractiveSessionEnded()
+	}
 
 	if m.janitor != nil {
 		m.janitor.Untrack(sessionID)

--- a/internal/kubernautagent/mcp/session_manager_metrics_2103_test.go
+++ b/internal/kubernautagent/mcp/session_manager_metrics_2103_test.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp_test
+
+import (
+	"context"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	coordinationv1 "k8s.io/api/coordination/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+)
+
+// recordingSessionEndedMetrics captures RecordInteractiveSessionEnded calls
+// for assertion, implementing mcpinternal.SessionEndedMetrics.
+type recordingSessionEndedMetrics struct {
+	endedCount int
+}
+
+func (m *recordingSessionEndedMetrics) RecordInteractiveSessionEnded() {
+	m.endedCount++
+}
+
+// #2103: aiagent_mcp_interactive_sessions_active only ever decremented for
+// two of the ways an interactive session can end (explicit complete/cancel)
+// plus two callback paths owned directly by cmd/kubernautagent/main.go.
+// Every other completion path (complete_no_action, workflow_selected,
+// no_matching_workflows, and #2100's own new SessionJanitor backstop) called
+// LeaseSessionManager.Release() without ever decrementing the gauge, because
+// the decrement was the caller's responsibility and most callers never wired
+// agentMetrics at all. These tests prove the fix: centralizing the decrement
+// inside Release() itself, paired with the existing activeCount.Add(-1), so
+// every current and future Release() caller keeps the gauge accurate without
+// needing its own metrics field.
+var _ = Describe("LeaseSessionManager.Release centralized metrics decrement — #2103", func() {
+	var (
+		ctx       context.Context
+		k8sClient client.Client
+		namespace string
+		logger    logr.Logger
+	)
+
+	BeforeEach(func() {
+		ctx = context.Background()
+		namespace = "kubernaut-system"
+		logger = logr.Discard()
+
+		scheme := runtime.NewScheme()
+		Expect(coordinationv1.AddToScheme(scheme)).To(Succeed())
+		k8sClient = fake.NewClientBuilder().WithScheme(scheme).Build()
+	})
+
+	Describe("UT-KA-2103-001: Release calls the wired metrics callback exactly once on success", func() {
+		It("should decrement the metrics recorder when the session is found and released", func() {
+			metrics := &recordingSessionEndedMetrics{}
+			mgr := mcpinternal.NewLeaseSessionManagerConcrete(k8sClient, namespace, logger,
+				mcpinternal.WithSessionEndedMetrics(metrics))
+
+			user := mcpinternal.UserInfo{Username: "alice@example.com", Groups: []string{"sre"}}
+			sess, err := mgr.Takeover(ctx, "rr-2103-001", user)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(metrics.endedCount).To(Equal(0), "must not decrement before Release is called")
+
+			Expect(mgr.Release(sess.SessionID, "complete_no_action")).To(Succeed())
+			Expect(metrics.endedCount).To(Equal(1),
+				"#2103: Release must call the wired SessionEndedMetrics exactly once, "+
+					"regardless of which caller/reason triggered it")
+		})
+	})
+
+	Describe("UT-KA-2103-002 (regression guard): Release on an unknown session ID never decrements", func() {
+		It("should return ErrSessionNotFound and leave the metrics recorder untouched", func() {
+			metrics := &recordingSessionEndedMetrics{}
+			mgr := mcpinternal.NewLeaseSessionManagerConcrete(k8sClient, namespace, logger,
+				mcpinternal.WithSessionEndedMetrics(metrics))
+
+			err := mgr.Release("nonexistent-session-id", "complete_no_action")
+			Expect(err).To(MatchError(mcpinternal.ErrSessionNotFound))
+			Expect(metrics.endedCount).To(Equal(0),
+				"#2103: a session that was never tracked (or already released) must not phantom-decrement the gauge")
+		})
+	})
+
+	Describe("UT-KA-2103-003 (regression guard): Release with no metrics wired does not panic", func() {
+		It("should complete the release successfully with a nil SessionEndedMetrics (matches every pre-#2103 call site)", func() {
+			mgr := mcpinternal.NewLeaseSessionManagerConcrete(k8sClient, namespace, logger)
+
+			user := mcpinternal.UserInfo{Username: "bob@example.com", Groups: []string{"sre"}}
+			sess, err := mgr.Takeover(ctx, "rr-2103-003", user)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(func() {
+				Expect(mgr.Release(sess.SessionID, "complete_no_action")).To(Succeed())
+			}).NotTo(Panic(), "#2103: WithSessionEndedMetrics is optional -- Release must stay nil-safe")
+		})
+	})
+
+	Describe("UT-KA-2103-004 (regression guard): a double Release only decrements once", func() {
+		It("should decrement exactly once even if Release is called twice for the same session ID", func() {
+			metrics := &recordingSessionEndedMetrics{}
+			mgr := mcpinternal.NewLeaseSessionManagerConcrete(k8sClient, namespace, logger,
+				mcpinternal.WithSessionEndedMetrics(metrics))
+
+			user := mcpinternal.UserInfo{Username: "carol@example.com", Groups: []string{"sre"}}
+			sess, err := mgr.Takeover(ctx, "rr-2103-004", user)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(mgr.Release(sess.SessionID, "complete")).To(Succeed())
+			Expect(metrics.endedCount).To(Equal(1))
+
+			secondErr := mgr.Release(sess.SessionID, "explicit")
+			Expect(secondErr).To(MatchError(mcpinternal.ErrSessionNotFound))
+			Expect(metrics.endedCount).To(Equal(1),
+				"#2103: the second (redundant) Release call must not double-decrement")
+		})
+	})
+})

--- a/internal/kubernautagent/mcp/tools/investigate.go
+++ b/internal/kubernautagent/mcp/tools/investigate.go
@@ -514,6 +514,18 @@ func (t *InvestigateTool) handleStart(ctx context.Context, input InvestigateInpu
 		}
 	}
 
+	// #2103: record Started as soon as Takeover confirms a genuinely new
+	// lease was acquired (activeCount.Add(1)) -- before any fallback logic
+	// below that might immediately Release() it again (the
+	// no_investigation_available branch a few lines down). Now that
+	// Release() centrally decrements aiagent_mcp_interactive_sessions_active
+	// (paired with its own activeCount.Add(-1)), Started/Ended must stay
+	// paired with the lease's own lifecycle -- otherwise that branch would
+	// decrement a gauge that was never incremented, driving it negative.
+	if t.metrics != nil {
+		t.metrics.RecordInteractiveSessionStarted()
+	}
+
 	// #1390: Upgrade running autonomous session in-place (Jump In) instead of
 	// cancelling and recreating. UpgradeToInteractive sets the atomic flag so
 	// the goroutine's next InteractiveHold check sees it, and store.Update's
@@ -580,7 +592,6 @@ func (t *InvestigateTool) handleStart(ctx context.Context, input InvestigateInpu
 	}
 
 	if t.metrics != nil {
-		t.metrics.RecordInteractiveSessionStarted()
 		t.metrics.RecordInteractiveTakeover("start_success")
 	}
 
@@ -846,9 +857,12 @@ func (t *InvestigateTool) handleComplete(input InvestigateInput, user mcpinterna
 
 	CompleteHTTPSession(t.httpCompleter, input.RRID, finalResult, t.logger, "complete")
 
-	if t.metrics != nil {
-		t.metrics.RecordInteractiveSessionEnded()
-	}
+	// #2103: the aiagent_mcp_interactive_sessions_active decrement moved
+	// into LeaseSessionManager.Release() itself (called above), paired
+	// with its own activeCount.Add(-1) -- centralizing it there closes the
+	// same gap for every other Release() caller (complete_no_action,
+	// workflow_selected, no_matching_workflows, the SessionJanitor
+	// backstop) that never had a metrics field to call this explicitly.
 
 	t.sessionMu.Delete(input.RRID)
 	t.reconHistory.Delete(input.RRID)
@@ -1267,9 +1281,8 @@ func (t *InvestigateTool) handleCancel(input InvestigateInput, user mcpinternal.
 
 	CompleteHTTPSession(t.httpCompleter, input.RRID, nil, t.logger, "cancel")
 
-	if t.metrics != nil {
-		t.metrics.RecordInteractiveSessionEnded()
-	}
+	// #2103: see handleComplete's matching comment above -- the gauge
+	// decrement is now centralized in LeaseSessionManager.Release().
 
 	t.sessionMu.Delete(input.RRID)
 	t.reconHistory.Delete(input.RRID)

--- a/internal/kubernautagent/mcp/tools/investigate_metrics_2103_test.go
+++ b/internal/kubernautagent/mcp/tools/investigate_metrics_2103_test.go
@@ -1,0 +1,188 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tools_test
+
+import (
+	"context"
+	"fmt"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+	mcptools "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp/tools"
+)
+
+// #2103: aiagent_mcp_interactive_sessions_active's decrement moved from
+// InvestigateTool's own explicit RecordInteractiveSessionEnded() calls (in
+// handleComplete/handleCancel) into LeaseSessionManager.Release() itself,
+// so every Release() caller -- including complete_no_action, workflow
+// selection, and the no_matching_workflows auto-close, none of which ever
+// called it directly -- decrements the gauge automatically. These tests
+// guard against reintroducing a double-decrement: with the shared mock
+// SessionManager here (which does NOT itself call metrics, unlike the real
+// LeaseSessionManager post-#2103), handleComplete/handleCancel must show
+// ZERO direct RecordInteractiveSessionEnded calls.
+var _ = Describe("InvestigateTool metrics after centralization — #2103", func() {
+
+	Describe("UT-KA-2103-004 (regression guard): handleComplete no longer directly decrements the gauge", func() {
+		It("should not call RecordInteractiveSessionEnded itself -- that responsibility moved to LeaseSessionManager.Release", func() {
+			metrics := &recordingToolMetrics{}
+			sessionMgr := &mockSessionManager{
+				getDriverResult: &mcpinternal.InteractiveSession{
+					SessionID:     "sess-2103-complete",
+					CorrelationID: "rr-2103-complete",
+					ActingUser:    mcpinternal.UserInfo{Username: "alice"},
+				},
+				isActive: true,
+			}
+			runner := &mockInvestigatorRunner{}
+			recon := &mockContextReconstructor{}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, mcptools.NopAutonomousManager{},
+				mcptools.WithToolMetrics(metrics))
+			out, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-2103-complete",
+				Action: mcptools.ActionComplete,
+			}, mcpinternal.UserInfo{Username: "alice"})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out.Status).To(Equal("completed"))
+			Expect(sessionMgr.releasedID).To(Equal("sess-2103-complete"),
+				"Release must still be called -- only the direct metrics call moved")
+			Expect(metrics.sessionEnded).To(Equal(0),
+				"#2103: handleComplete must not call RecordInteractiveSessionEnded directly anymore -- "+
+					"the real LeaseSessionManager.Release() does it centrally now, and this mock does not "+
+					"simulate that, so a nonzero count here would mean a double-decrement in production")
+		})
+	})
+
+	Describe("UT-KA-2103-005 (regression guard): handleCancel no longer directly decrements the gauge", func() {
+		It("should not call RecordInteractiveSessionEnded itself -- same rationale as handleComplete", func() {
+			metrics := &recordingToolMetrics{}
+			sessionMgr := &mockSessionManager{
+				getDriverResult: &mcpinternal.InteractiveSession{
+					SessionID:     "sess-2103-cancel",
+					CorrelationID: "rr-2103-cancel",
+					ActingUser:    mcpinternal.UserInfo{Username: "alice"},
+				},
+				isActive: true,
+			}
+			runner := &mockInvestigatorRunner{}
+			recon := &mockContextReconstructor{}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, mcptools.NopAutonomousManager{},
+				mcptools.WithToolMetrics(metrics))
+			out, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-2103-cancel",
+				Action: mcptools.ActionCancel,
+			}, mcpinternal.UserInfo{Username: "alice"})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(out.Status).To(Equal("cancelled"))
+			Expect(sessionMgr.releasedReason).To(Equal("explicit"))
+			Expect(metrics.sessionEnded).To(Equal(0),
+				"#2103: handleCancel must not call RecordInteractiveSessionEnded directly anymore")
+		})
+	})
+
+	Describe("UT-KA-2103-006: handleStart records Started immediately, even on the fallback-exhausted branch that releases the lease", func() {
+		It("should call RecordInteractiveSessionStarted before the #2100 fail-closed Release, keeping the gauge paired with activeCount", func() {
+			metrics := &recordingToolMetrics{}
+			sessionMgr := &mockSessionManager{
+				takeoverSession: &mcpinternal.InteractiveSession{
+					SessionID:     "lease-sess-2103-006",
+					CorrelationID: "rr-2103-006",
+				},
+			}
+			autoMgr := &fallbackAutoMgr{
+				findOK:   false,
+				startErr: fmt.Errorf("simulated StartInvestigation failure"),
+				forceErr: fmt.Errorf("simulated ForceTransitionToUserDriving failure"),
+			}
+			completer := &reattachHTTPCompleter{found: false}
+			runner := &mockInvestigatorRunner{}
+			recon := &mockContextReconstructor{turns: []mcpinternal.ConversationTurn{}}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, autoMgr,
+				mcptools.WithHTTPCompleter(completer), mcptools.WithToolMetrics(metrics))
+			_, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-2103-006",
+				Action: mcptools.ActionStart,
+			}, mcpinternal.UserInfo{Username: "sre-erin", Groups: []string{"sre-team"}})
+
+			Expect(err).To(HaveOccurred(), "#2100: this branch still fails closed")
+
+			releasedID, releasedReason := sessionMgr.getReleased()
+			Expect(releasedID).To(Equal("lease-sess-2103-006"))
+			Expect(releasedReason).To(Equal("no_investigation_available"))
+
+			Expect(metrics.sessionStarted).To(Equal(1),
+				"#2103: Takeover acquired a genuine new lease (activeCount.Add(1)) before this branch released "+
+					"it again -- RecordInteractiveSessionStarted must fire for that lease's brief lifetime so the "+
+					"now-centralized Release() decrement (which fires unconditionally) has a matching increment "+
+					"to pair with, instead of driving the gauge negative")
+		})
+	})
+
+	Describe("UT-KA-2103-007 (regression guard): Started is still not recorded when no new lease was acquired", func() {
+		It("should not call RecordInteractiveSessionStarted on a reconnect", func() {
+			metrics := &recordingToolMetrics{}
+			sessionMgr := &mockSessionManager{
+				takeoverSession: &mcpinternal.InteractiveSession{
+					SessionID:     "lease-sess-2103-007a",
+					CorrelationID: "rr-2103-007a",
+					Reconnected:   true,
+				},
+			}
+			runner := &mockInvestigatorRunner{}
+			recon := &mockContextReconstructor{turns: []mcpinternal.ConversationTurn{}}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, mcptools.NopAutonomousManager{},
+				mcptools.WithToolMetrics(metrics))
+			_, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-2103-007a",
+				Action: mcptools.ActionStart,
+			}, mcpinternal.UserInfo{Username: "sre-erin", Groups: []string{"sre-team"}})
+
+			Expect(err).To(HaveOccurred(), "a reconnect on action=start returns the session_active error")
+			Expect(metrics.sessionStarted).To(Equal(0),
+				"#2103: a reconnect never acquires a new lease (Takeover returns early, no activeCount.Add(1)), "+
+					"so it must not record a Started that has no matching lease lifetime")
+		})
+
+		It("should not call RecordInteractiveSessionStarted when Takeover itself fails", func() {
+			metrics := &recordingToolMetrics{}
+			sessionMgr := &mockSessionManager{
+				takeoverErr: mcpinternal.ErrMaxSessionsReached,
+			}
+			runner := &mockInvestigatorRunner{}
+			recon := &mockContextReconstructor{turns: []mcpinternal.ConversationTurn{}}
+
+			tool := mcptools.NewInvestigateTool(sessionMgr, runner, recon, mcptools.NopAutonomousManager{},
+				mcptools.WithToolMetrics(metrics))
+			_, err := tool.Handle(context.Background(), mcptools.InvestigateInput{
+				RRID:   "rr-2103-007b",
+				Action: mcptools.ActionStart,
+			}, mcpinternal.UserInfo{Username: "sre-erin", Groups: []string{"sre-team"}})
+
+			Expect(err).To(HaveOccurred())
+			Expect(metrics.sessionStarted).To(Equal(0),
+				"#2103: no lease was ever acquired when Takeover itself fails")
+		})
+	})
+})

--- a/test/integration/kubernautagent/mcp/session_manager_metrics_2103_it_test.go
+++ b/test/integration/kubernautagent/mcp/session_manager_metrics_2103_it_test.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 Jordi Gil.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package mcp_test
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-logr/logr"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	mcpinternal "github.com/jordigilh/kubernaut/internal/kubernautagent/mcp"
+)
+
+// recordingSessionEndedMetricsIT is a concurrency-safe SessionEndedMetrics
+// recorder for IT assertions -- the SessionJanitor's sweep (IT-KA-2103-002)
+// fires the callback from its own background goroutine, so a plain int
+// counter would race with the test's read.
+type recordingSessionEndedMetricsIT struct {
+	endedCount atomic.Int64
+}
+
+func (m *recordingSessionEndedMetricsIT) RecordInteractiveSessionEnded() {
+	m.endedCount.Add(1)
+}
+
+// #2103: aiagent_mcp_interactive_sessions_active drifted upward over time
+// because several production Release() callers -- CompleteNoActionTool,
+// SelectWorkflowTool's async release, InvestigateTool's no_matching_workflows
+// auto-close, and the SessionJanitor's onExpire backstop -- released the
+// underlying Lease correctly but never called RecordInteractiveSessionEnded,
+// so the gauge never came back down even though capacity was reclaimed.
+//
+// The fix centralizes the decrement inside LeaseSessionManager.Release()
+// itself (WithSessionEndedMetrics), so every current and future caller gets
+// it for free. These IT tests exercise that production wiring against a
+// real envtest API server and real coordination.k8s.io/Lease objects -- the
+// same wiring buildMCPHandler (cmd/kubernautagent/main.go) uses -- covering
+// both call shapes that existed pre-fix:
+//   - an explicit Release() call from a tool handler (stands in for
+//     complete_no_action / workflow_selected / no_matching_workflows, which
+//     all bottom out in the same mgr.Release(sessionID, reason) call with
+//     only the reason string differing)
+//   - the SessionJanitor's onExpire callback, which also routes through
+//     Release() (janitor_expired)
+var _ = Describe("LeaseSessionManager + SessionEndedMetrics wiring IT — #2103 SI-4 (metrics integrity)", Label("integration", "interactive"), func() {
+
+	Describe("IT-KA-2103-001: an explicit Release call decrements the wired gauge exactly once (complete_no_action / workflow_selected / no_matching_workflows shape)", func() {
+		It("should call RecordInteractiveSessionEnded exactly once per real Release, regardless of the reason string", func() {
+			nsName := uniqueNamespace("metrics-2103-001")
+			createNamespace(context.Background(), sharedK8sClient, nsName)
+
+			logger := logr.Discard()
+			metrics := &recordingSessionEndedMetricsIT{}
+			mgr := mcpinternal.NewLeaseSessionManagerConcrete(sharedK8sClient, nsName, logger,
+				mcpinternal.WithSessionEndedMetrics(metrics))
+
+			for i, reason := range []string{"complete_no_action", "workflow_selected", "no_matching_workflows"} {
+				user := mcpinternal.UserInfo{Username: "sre-2103-001@example.com", Groups: []string{"sre"}}
+				sess, err := mgr.Takeover(context.Background(), "rr-2103-001", user)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(mgr.Release(sess.SessionID, reason)).To(Succeed())
+				Expect(metrics.endedCount.Load()).To(Equal(int64(i+1)),
+					"#2103: Release(reason=%q) must call the wired SessionEndedMetrics through the real "+
+						"production chokepoint, same as every other Release() caller", reason)
+			}
+		})
+	})
+
+	Describe("IT-KA-2103-002: the SessionJanitor's onExpire sweep decrements the wired gauge too (janitor_expired shape)", func() {
+		It("should have the janitor's backstop Release call the wired SessionEndedMetrics, closing the original SI-4 gap", func() {
+			nsName := uniqueNamespace("metrics-2103-002")
+			createNamespace(context.Background(), sharedK8sClient, nsName)
+
+			logger := logr.Discard()
+			metrics := &recordingSessionEndedMetricsIT{}
+			janitor := mcpinternal.NewSessionJanitor(100*time.Millisecond, logger)
+			janitorCtx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go janitor.Run(janitorCtx)
+
+			mgr := mcpinternal.NewLeaseSessionManagerConcrete(sharedK8sClient, nsName, logger,
+				mcpinternal.WithSessionJanitor(janitor),
+				mcpinternal.WithSessionEndedMetrics(metrics))
+
+			user := mcpinternal.UserInfo{Username: "sre-2103-002@example.com", Groups: []string{"sre"}}
+			_, err := mgr.Takeover(context.Background(), "rr-2103-002", user)
+			Expect(err).NotTo(HaveOccurred())
+
+			Expect(metrics.endedCount.Load()).To(Equal(int64(0)), "must not decrement before the janitor sweeps")
+
+			Eventually(func() *mcpinternal.InteractiveSession {
+				driver, _ := mgr.GetDriver("rr-2103-002")
+				return driver
+			}, 5*time.Second, 50*time.Millisecond).Should(BeNil(),
+				"#2100: the orphaned session must be reclaimed by the janitor's backstop sweep")
+
+			Eventually(func() int64 {
+				return metrics.endedCount.Load()
+			}, 5*time.Second, 50*time.Millisecond).Should(Equal(int64(1)),
+				"#2103: the janitor's onExpire callback routes through the same Release() chokepoint, "+
+					"so it must decrement the gauge too -- pre-fix this path never did, driving the metric-only drift")
+		})
+	})
+})


### PR DESCRIPTION
## Summary

- `aiagent_mcp_interactive_sessions_active` only decremented on explicit `complete`/`cancel` and two `main.go`-owned callbacks (TTL/inactivity via `GetDriver`, disconnect grace-period expiry). Every other completion path — `CompleteNoActionTool`, `SelectWorkflowTool`'s async release, `InvestigateTool`'s `no_matching_workflows` auto-close, and #2100's own new `SessionJanitor` backstop — released the real Lease/`activeCount` correctly but never called the matching metrics decrement, so the gauge drifted upward forever. Real capacity bookkeeping was unaffected; this was observability-only, discovered live-monitoring QE's #2100 validation run on this stack (#2102).
- Centralizes the decrement inside `LeaseSessionManager.Release()` itself via a new `WithSessionEndedMetrics` option, so every current and future `Release()` caller is correct automatically instead of needing its own metrics wiring.
- Removes the now-redundant explicit `RecordInteractiveSessionEnded()` calls from `InvestigateTool.handleComplete`/`handleCancel` and `main.go`'s three callbacks (would otherwise double-decrement).
- Moves `handleStart`'s `RecordInteractiveSessionStarted()` earlier (right after a successful non-reconnect `Takeover`) so Started/Ended stay paired with the lease's own lifecycle now that `Release()` decrements unconditionally — otherwise #2100's fail-closed `no_investigation_available` branch would decrement a gauge that was never incremented for that lease.

Fixes #2103.

Stacked on #2102 (`fix/2092-2094-2098-2100-interactive-session-batch`), which is still under QE validation, so this diff only shows the incremental #2103 change on top of it.

## Test plan

- [x] `docs/testing/2103/TEST_PLAN.md` — Wiring Manifest, FedRAMP mapping (SI-4/SI-11/SC-5), pyramid-invariant test inventory
- [x] UT-KA-2103-001..003 (`internal/kubernautagent/mcp/session_manager_metrics_2103_test.go`) — `Release()` decrement, not-found/nil-metrics regression guards
- [x] UT-KA-2103-004..007 (`internal/kubernautagent/mcp/tools/investigate_metrics_2103_test.go`) — `handleComplete`/`handleCancel` no longer double-decrement; `handleStart` Started/Ended symmetry
- [x] IT-KA-2103-001/002 (`test/integration/kubernautagent/mcp/session_manager_metrics_2103_it_test.go`) — real envtest API server proving explicit `Release()` and the real `SessionJanitor` sweep both decrement the wired gauge
- [x] CHECKPOINT W: grep evidence — `WithSessionEndedMetrics` has exactly one production caller (`cmd/kubernautagent/main.go`), the decrement has exactly one call site (`session_manager.go` `Release()`), all 4 originally-reported gap paths route through it
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` — clean
- [x] `make test-unit-kubernautagent` — 97/97 specs passed (29 suites, 84.8% composite coverage)
- [x] `make test-integration-kubernautagent-interactive` — 27/27 specs passed (label: interactive), including the two new IT tests, no regressions in prior #2092/#2094/#2098/#2100/#2105 tests